### PR TITLE
fix: reflection builtins as dynamic (Refs #95)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -426,20 +426,23 @@ var stdlibBareNames = map[string]struct{}{
 	"Panicf":  {},
 	// Python builtins (PEP 3102 / builtins module). Keep
 	// alphabetical for review.
-	"abs":        {},
-	"all":        {},
-	"any":        {},
-	"bool":       {},
-	"callable":   {},
-	"chr":        {},
-	"dict":       {},
-	"enumerate":  {},
-	"filter":     {},
-	"float":      {},
-	"format":     {},
-	"frozenset":  {},
-	"getattr":    {},
-	"hasattr":    {},
+	"abs":       {},
+	"all":       {},
+	"any":       {},
+	"bool":      {},
+	"callable":  {},
+	"chr":       {},
+	"dict":      {},
+	"enumerate": {},
+	"filter":    {},
+	"float":     {},
+	"format":    {},
+	"frozenset": {},
+	// Reflection builtins (getattr/setattr/hasattr/delattr/eval/exec/
+	// compile/__import__) deliberately excluded — they are dynamic-
+	// dispatch primitives, not external imports. The resolver classifier
+	// matches them against the per-language dynamic-pattern catalog and
+	// tags them DispositionDynamic (Refs #95).
 	"hash":       {},
 	"id":         {},
 	"int":        {},
@@ -462,7 +465,6 @@ var stdlibBareNames = map[string]struct{}{
 	"reversed":   {},
 	"round":      {},
 	"set":        {},
-	"setattr":    {},
 	"slice":      {},
 	"sorted":     {},
 	"str":        {},
@@ -539,7 +541,6 @@ var stdlibBareNames = map[string]struct{}{
 	"getcwd":          {},
 	"listdir":         {},
 	"makedirs":        {},
-	"__import__":      {},
 	"deepcopy":        {},
 	"deque":           {},
 	"defaultdict":     {},

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -121,6 +121,38 @@ func TestSynthesize_StdlibBareName(t *testing.T) {
 	}
 }
 
+// TestSynthesize_ReflectionBuiltinsLeftAlone is the issue #95 regression
+// guard at the synthesiser layer. Python reflection builtins (getattr /
+// setattr / hasattr / delattr / eval / exec / compile / __import__) used
+// to live in stdlibBareNames and got rewritten to "ext:builtins" before
+// the resolver's dynamic-pattern catalog could see them. The fix removes
+// them from the stop-list — the synthesiser must now leave the stub
+// untouched so the resolver classifies it as DispositionDynamic.
+func TestSynthesize_ReflectionBuiltinsLeftAlone(t *testing.T) {
+	reflectionBuiltins := []string{
+		"getattr", "setattr", "hasattr", "delattr",
+		"eval", "exec", "compile", "__import__",
+	}
+	for _, name := range reflectionBuiltins {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			doc := &graph.Document{
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "app.py", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 0 {
+				t.Fatalf("%s: synthesized=%d, want 0", name, stats.Synthesized)
+			}
+			if doc.Relationships[0].ToID != name {
+				t.Fatalf("%s: ToID rewritten to %q (want %q preserved)",
+					name, doc.Relationships[0].ToID, name)
+			}
+		})
+	}
+}
+
 // TestSynthesize_UnknownLeftAlone confirms truly-unknown stubs are
 // neither rewritten nor synthesised — they continue to count as
 // "unmatched" upstream.

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -201,22 +201,28 @@ var (
 		// requiring patterns below ever match real stubs (issue #90).
 		regexp.MustCompile(`^getattr$`),
 		regexp.MustCompile(`^setattr$`),
+		regexp.MustCompile(`^hasattr$`),
+		regexp.MustCompile(`^delattr$`),
 		regexp.MustCompile(`^eval$`),
 		regexp.MustCompile(`^exec$`),
+		regexp.MustCompile(`^compile$`),
 		regexp.MustCompile(`^__import__$`),
-		regexp.MustCompile(`^getattr\(`),                  // getattr(obj, name)(...)
-		regexp.MustCompile(`^__getattr__$`),               // __getattr__ magic name
-		regexp.MustCompile(`^.*\.__getattr__\(`),          // obj.__getattr__("name")
-		regexp.MustCompile(`^.*\.__getattribute__\(`),     // obj.__getattribute__(...)
-		regexp.MustCompile(`^setattr\(`),                  // setattr-driven dispatch
-		regexp.MustCompile(`^globals\(\)\[`),              // globals()[name](...)
-		regexp.MustCompile(`^locals\(\)\[`),               // locals()[name](...)
-		regexp.MustCompile(`^vars\(\)\[`),                 // vars()[name](...)
-		regexp.MustCompile(`^eval\(`),                     // eval(...)
-		regexp.MustCompile(`^exec\(`),                     // exec(...)
-		regexp.MustCompile(`^__import__\(`),               // __import__("modname")
-		regexp.MustCompile(`^importlib\.`),                // importlib.import_module / etc
-		regexp.MustCompile(`^functools\.partial\(`),       // functools.partial(...)
+		regexp.MustCompile(`^hasattr\(`),              // hasattr(obj, name)
+		regexp.MustCompile(`^delattr\(`),              // delattr(obj, name)
+		regexp.MustCompile(`^compile\(`),              // compile(src, ...)
+		regexp.MustCompile(`^getattr\(`),              // getattr(obj, name)(...)
+		regexp.MustCompile(`^__getattr__$`),           // __getattr__ magic name
+		regexp.MustCompile(`^.*\.__getattr__\(`),      // obj.__getattr__("name")
+		regexp.MustCompile(`^.*\.__getattribute__\(`), // obj.__getattribute__(...)
+		regexp.MustCompile(`^setattr\(`),              // setattr-driven dispatch
+		regexp.MustCompile(`^globals\(\)\[`),          // globals()[name](...)
+		regexp.MustCompile(`^locals\(\)\[`),           // locals()[name](...)
+		regexp.MustCompile(`^vars\(\)\[`),             // vars()[name](...)
+		regexp.MustCompile(`^eval\(`),                 // eval(...)
+		regexp.MustCompile(`^exec\(`),                 // exec(...)
+		regexp.MustCompile(`^__import__\(`),           // __import__("modname")
+		regexp.MustCompile(`^importlib\.`),            // importlib.import_module / etc
+		regexp.MustCompile(`^functools\.partial\(`),   // functools.partial(...)
 		regexp.MustCompile(`^functools\.partialmethod\(`),
 		regexp.MustCompile(`^functools\.reduce\(`),
 		regexp.MustCompile(`^operator\.methodcaller\(`), // operator.methodcaller("name")
@@ -240,8 +246,11 @@ var (
 	}
 
 	jsDynamicPatterns = []*regexp.Regexp{
-		regexp.MustCompile(`^Reflect\.`),     // Reflect.apply / Reflect.construct / Reflect.get
-		regexp.MustCompile(`^Function\(`),    // Function(src)
+		regexp.MustCompile(`^Reflect\.`),      // Reflect.apply / Reflect.construct / Reflect.get
+		regexp.MustCompile(`^eval$`),          // bare eval (issue #95)
+		regexp.MustCompile(`^eval\(`),         // eval(src)
+		regexp.MustCompile(`^Function$`),      // bare Function constructor reference
+		regexp.MustCompile(`^Function\(`),     // Function(src)
 		regexp.MustCompile(`^new Function\(`), // new Function(src)
 		// Dynamic import / require: must NOT be a literal-string first arg —
 		// `require("fs")` and `import("./mod")` are statically resolvable.
@@ -272,10 +281,10 @@ var (
 		regexp.MustCompile(`^send\(`),            // bare send(:name)
 		regexp.MustCompile(`^.*\.public_send\(`), // obj.public_send(:name)
 		regexp.MustCompile(`^public_send\(`),
-		regexp.MustCompile(`^.*\.__send__\(`),    // obj.__send__(:name)
-		regexp.MustCompile(`^method_missing$`),   // ruby method_missing hook
+		regexp.MustCompile(`^.*\.__send__\(`),  // obj.__send__(:name)
+		regexp.MustCompile(`^method_missing$`), // ruby method_missing hook
 		regexp.MustCompile(`^.*\.method_missing\(`),
-		regexp.MustCompile(`^define_method\(`),   // metaprogramming
+		regexp.MustCompile(`^define_method\(`), // metaprogramming
 		regexp.MustCompile(`^.*\.define_method\(`),
 		regexp.MustCompile(`^.*\.instance_eval\(`),
 		regexp.MustCompile(`^.*\.class_eval\(`),
@@ -1199,14 +1208,33 @@ func (idx Index) classifyDisposition(resolvedID, originalStub string, allow Exte
 //
 // Order of checks matters:
 //  1. Already a 16-char hex → Resolved.
-//  2. "ext:<pkg>" prefix → ExternalKnown / ExternalUnknown depending on allow.
-//  3. Dynamic-pattern match on the original stub (gated by language) → Dynamic.
+//  2. Dynamic-pattern match on the ORIGINAL stub (gated by language) →
+//     Dynamic. Runs BEFORE the external-prefix check so reflection
+//     builtins that the external synthesiser also tags as `ext:<pkg>`
+//     (Python `getattr` / `setattr` / `eval` / `exec`, JS `Function`,
+//     etc.) land in the dynamic bucket — they are intrinsically
+//     reflective dispatch, not real external imports (Refs #95).
+//  3. "ext:<pkg>" prefix → ExternalKnown / ExternalUnknown depending on allow.
 //  4. Stub of form "Kind:Name" or bare "Name" → BugExtractor when the name
 //     has zero entities in the graph; BugResolver when it does.
 //  5. Anything else → Unclassified.
 func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, allow ExternalAllowlist) Disposition {
 	if isHexID(resolvedID) {
 		return DispositionResolved
+	}
+	// Dynamic-pattern check runs BEFORE the external-prefix check (Refs
+	// #95). The external synthesiser stamps reflection builtins like
+	// `getattr` / `setattr` / `eval` with an `ext:` prefix because they
+	// happen to live in the stdlib stop-list, but they are dynamic
+	// dispatch by nature — not real external imports. Matching the
+	// original (pre-synth) stub against the per-language dynamic catalog
+	// here promotes them out of `external-unknown` and into `dynamic`.
+	effLang := lang
+	if effLang == "" {
+		effLang = inferLangFromStub(originalStub)
+	}
+	if isDynamicPatternLang(originalStub, effLang) {
+		return DispositionDynamic
 	}
 	if strings.HasPrefix(resolvedID, stubPrefixExternal) {
 		pkg := strings.TrimPrefix(resolvedID, stubPrefixExternal)
@@ -1226,13 +1254,6 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	// then structural-ref `<lang>:` segment as fallback. Non-structural
 	// stubs without a caller-supplied language run only the cross-language
 	// catalog — see isDynamicPatternLang.
-	effLang := lang
-	if effLang == "" {
-		effLang = inferLangFromStub(originalStub)
-	}
-	if isDynamicPatternLang(originalStub, effLang) {
-		return DispositionDynamic
-	}
 	// Issue #89 — short structural-ref stubs emitted by cross-language
 	// extractors that the resolver intentionally leaves untouched (they
 	// don't have the 6-segment scope:<kind>:<subtype>:<lang>:<file>:<tail>

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -656,14 +656,15 @@ func TestDisposition_ReflectionBuiltinsBeatExternal(t *testing.T) {
 	}
 }
 
-// TestStdlibBareNames_ExcludesReflectionBuiltins guards the synthesiser's
-// stop-list against regressions: reflection builtins must NOT appear in
-// stdlibBareNames, otherwise the synthesiser would re-acquire a foothold
-// for stamping them as "ext:<pkg>" before the resolver sees them. The
-// resolver's classifier still does the right thing thanks to the dynamic-
-// before-external ordering, but keeping these names out of the stop-list
-// preserves the original stub for downstream reporting (Refs #95).
-func TestStdlibBareNames_ExcludesReflectionBuiltins(t *testing.T) {
+// TestReflectionBuiltins_RecognisedAsDynamic asserts the resolver-side
+// invariant for issue #95: every reflection builtin we care about is
+// recognised as a dynamic pattern by isDynamicPatternLang for its
+// language. The companion synthesiser-side guard
+// (TestSynthesize_ReflectionBuiltinsLeftAlone in internal/external)
+// covers the stdlibBareNames stop-list directly; this test does not
+// inspect that map (it lives in another package and is unexported) —
+// it only checks the per-language dynamic catalog (Refs #95).
+func TestReflectionBuiltins_RecognisedAsDynamic(t *testing.T) {
 	t.Parallel()
 	// We import nothing from the external package here — that's a
 	// separate test in internal/external. This test verifies the

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -596,6 +596,101 @@ func TestDisposition_Unclassified(t *testing.T) {
 	}
 }
 
+// TestDisposition_ReflectionBuiltinsBeatExternal is the regression test for
+// issue #95. The external synthesiser used to add Python reflection
+// builtins (getattr / setattr / hasattr / delattr / eval / exec / compile /
+// __import__) and the JS Function constructor to its stdlib stop-list,
+// which caused unresolved CALLS pointing at them to be rewritten to
+// "ext:builtins" / "ext:globalThis" and then classified as
+// ExternalUnknown — burying the dynamic-dispatch signal under
+// external-import noise. After the fix, classifyDispositionLang runs the
+// per-language dynamic-pattern catalog BEFORE the "ext:" prefix check, so
+// the original reflection-builtin stub wins regardless of how synthesis
+// rewrote the resolved ID.
+func TestDisposition_ReflectionBuiltinsBeatExternal(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name         string
+		lang         string
+		originalStub string
+		// resolvedID simulates the post-synthesis state where the
+		// synthesiser would (incorrectly) have stamped these builtins
+		// with an "ext:<pkg>" prefix.
+		resolvedID string
+	}{
+		{"py_getattr", "python", "getattr", "ext:builtins"},
+		{"py_setattr", "python", "setattr", "ext:builtins"},
+		{"py_hasattr", "python", "hasattr", "ext:builtins"},
+		{"py_delattr", "python", "delattr", "ext:builtins"},
+		{"py_eval", "python", "eval", "ext:builtins"},
+		{"py_exec", "python", "exec", "ext:builtins"},
+		{"py_compile", "python", "compile", "ext:builtins"},
+		{"py_dunder_import", "python", "__import__", "ext:builtins"},
+		{"py_getattr_call", "python", "getattr(self, name)", "ext:builtins"},
+		{"py_eval_call", "python", "eval(src)", "ext:builtins"},
+		{"js_eval", "javascript", "eval", "ext:globalThis"},
+		{"js_function_ctor", "javascript", "Function", "ext:globalThis"},
+		{"js_new_function", "javascript", "new Function(src)", "ext:globalThis"},
+	}
+	idx := BuildIndex(nil)
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			endpoints := []EndpointPair{{
+				FromID:     "0000000000000000",
+				ToID:       tc.resolvedID,
+				ToOriginal: tc.originalStub,
+				Language:   tc.lang,
+			}}
+			stats := idx.ClassifyEndpoints(endpoints, allowDjango)
+			if got := stats.DispositionCounts[DispositionDynamic]; got != 1 {
+				t.Fatalf("%s: expected 1 dynamic, got counts=%+v",
+					tc.originalStub, stats.DispositionCounts)
+			}
+			if got := stats.DispositionCounts[DispositionExternalUnknown]; got != 0 {
+				t.Fatalf("%s: leaked into external-unknown (counts=%+v)",
+					tc.originalStub, stats.DispositionCounts)
+			}
+		})
+	}
+}
+
+// TestStdlibBareNames_ExcludesReflectionBuiltins guards the synthesiser's
+// stop-list against regressions: reflection builtins must NOT appear in
+// stdlibBareNames, otherwise the synthesiser would re-acquire a foothold
+// for stamping them as "ext:<pkg>" before the resolver sees them. The
+// resolver's classifier still does the right thing thanks to the dynamic-
+// before-external ordering, but keeping these names out of the stop-list
+// preserves the original stub for downstream reporting (Refs #95).
+func TestStdlibBareNames_ExcludesReflectionBuiltins(t *testing.T) {
+	t.Parallel()
+	// We import nothing from the external package here — that's a
+	// separate test in internal/external. This test verifies the
+	// resolver-side invariant that the per-language catalog catches
+	// every reflection builtin on its own.
+	reflectionBuiltins := []struct {
+		stub string
+		lang string
+	}{
+		{"getattr", "python"},
+		{"setattr", "python"},
+		{"hasattr", "python"},
+		{"delattr", "python"},
+		{"eval", "python"},
+		{"exec", "python"},
+		{"compile", "python"},
+		{"__import__", "python"},
+		{"eval", "javascript"},
+		{"Function", "javascript"},
+	}
+	for _, b := range reflectionBuiltins {
+		if !isDynamicPatternLang(b.stub, b.lang) {
+			t.Fatalf("reflection builtin %q (%s) not recognised as dynamic", b.stub, b.lang)
+		}
+	}
+}
+
 func TestBuildLocationIndex(t *testing.T) {
 	entities := []types.EntityRecord{
 		entAt("aaaaaaaaaaaaaaaa", "Component", "Foo", "a.py"),


### PR DESCRIPTION
## Root cause

`classifyDispositionLang` checked the `ext:<pkg>` prefix BEFORE running the per-language dynamic-pattern catalog. Python reflection builtins (`getattr`, `setattr`, `hasattr`, `delattr`, `eval`, `exec`, `compile`, `__import__`) and the JS `Function` constructor lived in the external synthesiser's `stdlibBareNames` stop-list, so unresolved CALLS pointing at them were rewritten to `ext:builtins` / `ext:globalThis` and ended up classified as `DispositionExternalUnknown` — silently masking real dynamic-dispatch signal.

## Fix

1. **`internal/resolve/refs.go`** — move the dynamic-pattern check above the `ext:` prefix check in `classifyDispositionLang`. The original (pre-synth) stub gets matched against `isDynamicPatternLang` first, so reflection builtins land in `DispositionDynamic` regardless of how synthesis rewrote the resolved ID.
2. **`internal/external/synth.go`** — remove `getattr`, `setattr`, `__import__` from `stdlibBareNames` (and document the broader exclusion in a comment) so the synthesiser stops stamping them with an `ext:` prefix in the first place.
3. **`internal/resolve/refs.go`** — extend the catalog: add Python `hasattr`, `delattr`, `compile` (bare + call forms) and JS `eval` (bare + call) and bare `Function` reference.

## Tests added (2 new test functions in resolve, 1 in external)

- `TestDisposition_ReflectionBuiltinsBeatExternal` (13 sub-cases) — drives the classifier end-to-end with simulated post-synth `ext:builtins` / `ext:globalThis` resolved IDs and asserts each lands in Dynamic, none in ExternalUnknown.
- `TestStdlibBareNames_ExcludesReflectionBuiltins` (10 builtins) — guards that the per-language dynamic catalog covers every reflection builtin on its own.
- `TestSynthesize_ReflectionBuiltinsLeftAlone` (8 sub-tests) — guards the synthesiser stop-list: every Python reflection builtin must pass through unrewritten.

## Verification

- `go build ./...` clean
- `go test ./...` all packages pass
- `gofmt -l` clean for touched files
- `go vet ./...` clean

VERIFY-2 corpus run skipped — it requires cloning OSS corpora and runs >2 min.

Closes #95
Refs #90