### PR TITLE
feat: cross-file import-aware resolution (Refs #93)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1033,6 +1033,17 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	//   - standalone Pass 2.5 RelationshipRecords (engine output)
 	// against the merged entity index. Stubs that are ambiguous (≥2 matches)
 	// or unmatched are left in place and counted in the log line below.
+	// Issue #93 — import-aware cross-file resolution. Builds a per-file
+	// import table from IMPORTS edges and rewrites bare-name CALLS targets
+	// to the entity they actually point at. Runs BEFORE BuildIndex so the
+	// disposition classifier sees the rewritten ID as already-resolved.
+	importTbl := resolve.BuildImportTable(merged)
+	importStats := resolve.ResolveImports(merged, importTbl)
+	if importStats.CallsConsidered > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d bare-name CALLS targets\n",
+			importStats.CallsRewritten, importStats.CallsConsidered)
+	}
+
 	idx := resolve.BuildIndex(merged)
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)
 	embStats := resolve.ReferencesEmbeddedWithAllowlist(merged, idx, allow)

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -204,20 +204,20 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 // downstream harnesses (scripts/verify2/run.sh) can aggregate without
 // needing to understand the inner Disposition enum.
 type JSONStats struct {
-	Repo                  string              `json:"repo"`
-	Files                 int                 `json:"files"`
-	Entities              int                 `json:"entities"`
-	Relationships         int                 `json:"relationships"`
-	Pass1Rels             int                 `json:"pass1_rels"`
-	Pass2Rels             int                 `json:"pass2_rels"`
-	Pass3Rels             int                 `json:"pass3_rels"`
-	DispositionCounts     map[string]int      `json:"disposition_counts"`
-	DispositionSamples    map[string][]string `json:"disposition_samples,omitempty"`
-	BugRate               float64             `json:"bug_rate"`
-	ResolutionRate        float64             `json:"resolution_rate"`
-	ExternalSynthesized   int                 `json:"external_synthesized"`
-	ExternalUniqueCount   int                 `json:"external_unique_count"`
-	ExternalRelsResolved  int                 `json:"external_rels_resolved"`
+	Repo                 string              `json:"repo"`
+	Files                int                 `json:"files"`
+	Entities             int                 `json:"entities"`
+	Relationships        int                 `json:"relationships"`
+	Pass1Rels            int                 `json:"pass1_rels"`
+	Pass2Rels            int                 `json:"pass2_rels"`
+	Pass3Rels            int                 `json:"pass3_rels"`
+	DispositionCounts    map[string]int      `json:"disposition_counts"`
+	DispositionSamples   map[string][]string `json:"disposition_samples,omitempty"`
+	BugRate              float64             `json:"bug_rate"`
+	ResolutionRate       float64             `json:"resolution_rate"`
+	ExternalSynthesized  int                 `json:"external_synthesized"`
+	ExternalUniqueCount  int                 `json:"external_unique_count"`
+	ExternalRelsResolved int                 `json:"external_rels_resolved"`
 }
 
 // emitJSONStats writes a JSONStats record (one line, no trailing whitespace)
@@ -1039,9 +1039,17 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	// disposition classifier sees the rewritten ID as already-resolved.
 	importTbl := resolve.BuildImportTable(merged)
 	importStats := resolve.ResolveImports(merged, importTbl)
+	// Always emit the stats line when the pass had work to do, so a
+	// silent-failure regression (considered>0 but rewritten=0 — e.g. the
+	// import table failed to build) surfaces in stderr instead of
+	// disappearing.
 	if importStats.CallsConsidered > 0 {
-		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d bare-name CALLS targets\n",
-			importStats.CallsRewritten, importStats.CallsConsidered)
+		note := ""
+		if importStats.CallsRewritten == 0 {
+			note = " (no candidates resolved — check IMPORTS edges)"
+		}
+		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d bare-name CALLS targets%s\n",
+			importStats.CallsRewritten, importStats.CallsConsidered, note)
 	}
 
 	idx := resolve.BuildIndex(merged)

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -509,6 +509,22 @@ func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
 // `from x import a` creates one entity per imported name with module path
 // "x.a", matching the symbol-level granularity Python uses for cross-module
 // resolution.
+//
+// Issue #93 — every IMPORTS relationship now carries the metadata the
+// cross-file resolver needs to bind a bare CALLS target back to its real
+// entity:
+//
+//	Properties["local_name"]    — the identifier as referenced inside the
+//	                              importing file (alias when present, else
+//	                              the imported leaf name; for `import a.b`
+//	                              this is the top-level package "a").
+//	Properties["source_module"] — the dotted module path the symbol was
+//	                              imported from. For `import x.y` this is
+//	                              "x.y"; for `from x import y` this is "x".
+//	Properties["imported_name"] — the original (pre-alias) leaf identifier
+//	                              inside the source module. Equal to
+//	                              local_name when no alias is present.
+//	Properties["wildcard"]      — "1" when the import is `from x import *`.
 func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
 	if root == nil {
 		return nil
@@ -517,11 +533,24 @@ func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityR
 	for _, n := range findAll(root, "import_statement") {
 		for i := 0; i < int(n.NamedChildCount()); i++ {
 			ch := n.NamedChild(i)
-			path := dottedNamePath(ch, file.Content)
+			path, alias := dottedNameAndAlias(ch, file.Content)
 			if path == "" {
 				continue
 			}
-			out = append(out, importRecord(path, file))
+			localName := alias
+			if localName == "" {
+				if dot := strings.IndexByte(path, '.'); dot > 0 {
+					localName = path[:dot]
+				} else {
+					localName = path
+				}
+			}
+			props := map[string]string{
+				"local_name":    localName,
+				"source_module": path,
+				"imported_name": path,
+			}
+			out = append(out, importRecord(path, file, props))
 		}
 	}
 	for _, n := range findAll(root, "import_from_statement") {
@@ -539,18 +568,61 @@ func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityR
 			if ch == modNode {
 				continue
 			}
-			name := dottedNamePath(ch, file.Content)
-			if name == "" || name == "*" {
+			name, alias := dottedNameAndAlias(ch, file.Content)
+			if name == "" {
 				continue
 			}
-			out = append(out, importRecord(modPath+"."+name, file))
+			if name == "*" {
+				out = append(out, importRecord(modPath, file, map[string]string{
+					"source_module": modPath,
+					"wildcard":      "1",
+				}))
+				emittedAny = true
+				continue
+			}
+			localName := alias
+			if localName == "" {
+				localName = name
+			}
+			props := map[string]string{
+				"local_name":    localName,
+				"source_module": modPath,
+				"imported_name": name,
+			}
+			out = append(out, importRecord(modPath+"."+name, file, props))
 			emittedAny = true
 		}
 		if !emittedAny {
-			out = append(out, importRecord(modPath, file))
+			out = append(out, importRecord(modPath, file, map[string]string{
+				"source_module": modPath,
+			}))
 		}
 	}
 	return out
+}
+
+// dottedNameAndAlias returns (path, alias) for an import-list child node.
+// path is the dotted import path stripped of any "as <alias>" suffix; alias
+// is the binding identifier introduced by `as` (or "" when not present).
+// Wildcards return ("*", ""). Unrecognised shapes return ("", "").
+func dottedNameAndAlias(node *sitter.Node, src []byte) (string, string) {
+	if node == nil {
+		return "", ""
+	}
+	if node.Type() != "aliased_import" {
+		return dottedNamePath(node, src), ""
+	}
+	var path, alias string
+	if name := node.ChildByFieldName("name"); name != nil {
+		path = dottedNamePath(name, src)
+	}
+	if a := node.ChildByFieldName("alias"); a != nil {
+		alias = strings.TrimSpace(nodeText(a, src))
+	}
+	if path == "" && node.NamedChildCount() > 0 {
+		path = dottedNamePath(node.NamedChild(0), src)
+	}
+	return path, alias
 }
 
 // dottedNamePath flattens a dotted_name / identifier / aliased_import node into
@@ -580,8 +652,10 @@ func dottedNamePath(node *sitter.Node, src []byte) string {
 }
 
 // importRecord builds a single SCOPE.Component entity for the given module
-// path with one embedded IMPORTS relationship.
-func importRecord(modulePath string, file extractor.FileInput) types.EntityRecord {
+// path with one embedded IMPORTS relationship. Properties on the IMPORTS
+// edge carry the import-binding metadata the cross-file resolver consumes
+// (issue #93): local_name, source_module, imported_name, and wildcard.
+func importRecord(modulePath string, file extractor.FileInput, props map[string]string) types.EntityRecord {
 	return types.EntityRecord{
 		Name:       modulePath,
 		Kind:       "SCOPE.Component",
@@ -590,9 +664,10 @@ func importRecord(modulePath string, file extractor.FileInput) types.EntityRecor
 		Language:   "python",
 		Relationships: []types.RelationshipRecord{
 			{
-				FromID: file.Path,
-				ToID:   modulePath,
-				Kind:   "IMPORTS",
+				FromID:     file.Path,
+				ToID:       modulePath,
+				Kind:       "IMPORTS",
+				Properties: props,
 			},
 		},
 	}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -1,0 +1,393 @@
+// Package resolve — import-aware cross-file CALLS resolution (issue #93).
+//
+// The base resolver (refs.go) maps a stub like "get" to the unique entity
+// named "get" via byName. When two or more entities in the merged graph
+// share a name (e.g. requests/api.py defines `get`, and a dozen tests also
+// define `get`), the base resolver flips the name to ambiguous and the
+// CALLS edge is left as a bug-* disposition.
+//
+// In real Python codebases the dominant share of post-#94 bug-extractor /
+// bug-resolver dispositions are precisely this shape: a function imports
+// a symbol from another module and then calls it bare. The extractor sees
+// the CALLS site (`get(...)`), emits a bare-name target ("get"), but the
+// resolver has no way to know which `get` was meant.
+//
+// This file adds an import-aware resolution pass:
+//
+//  1. BuildImportTable walks the merged EntityRecord slice and, from
+//     IMPORTS relationships emitted by the per-language extractor (Python
+//     is the first language plumbed through; others can opt in by
+//     emitting the same Properties), builds a per-file map:
+//
+//     file_path → local_name → (source_module, imported_name)
+//
+//  2. ResolveImports walks every EntityRecord and rewrites embedded CALLS
+//     edges whose ToID is a bare local name imported in the parent's
+//     SourceFile. The rewrite picks an entity whose Name == imported_name
+//     and whose SourceFile lives in the source_module's file set.
+//
+// The pass runs BEFORE BuildIndex / References so all subsequent stages
+// (disposition classification, external synthesis, downstream traversal)
+// see the rewritten ID.
+package resolve
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ImportRelKind is the relationship kind emitted by the Python (and any
+// future) extractor for import statements. ImportTable consumes only
+// relationships whose Kind matches this constant.
+const ImportRelKind = "IMPORTS"
+
+// Property keys read off an IMPORTS relationship. See
+// internal/extractors/python/extractor.go:extractImports for the producer
+// side. Languages other than Python can opt into import-aware resolution
+// by emitting these same keys on their IMPORTS edges.
+const (
+	importPropLocalName    = "local_name"
+	importPropSourceModule = "source_module"
+	importPropImportedName = "imported_name"
+	importPropWildcard     = "wildcard"
+)
+
+// ImportBinding describes a single name introduced into a file by an
+// import statement.
+type ImportBinding struct {
+	// LocalName is the identifier as referenced inside the importing
+	// file. For `import x.y` this is "x"; for `import x.y as z` this is
+	// "z"; for `from a.b import c` this is "c"; for
+	// `from a.b import c as d` this is "d".
+	LocalName string
+	// SourceModule is the dotted module path the symbol was imported
+	// from. For `import x.y[.z]` this is the full path; for
+	// `from a.b import c` this is "a.b".
+	SourceModule string
+	// ImportedName is the original (pre-alias) leaf identifier inside
+	// the source module. Equal to LocalName when no alias is present.
+	// For `from a import b as c` this is "b". For module imports
+	// (`import x.y`) this is the full module path.
+	ImportedName string
+	// Wildcard is true for `from x import *`. The resolver treats these
+	// best-effort: a bare CALLS target N is rewritten to <module>.N if
+	// such an entity exists.
+	Wildcard bool
+}
+
+// ImportTable maps file path → local-name → ImportBinding, plus the
+// list of wildcard source modules per file. Local names that collide
+// inside a single file are dropped (last-writer-wins is unsafe — Python
+// rebinds, but we'd rather miss than misresolve).
+type ImportTable struct {
+	// byFile[file_path][local_name] = binding. Files with no imports
+	// don't appear; local names that collide inside a single file are
+	// removed (the resolver leaves the original CALLS stub alone).
+	byFile map[string]map[string]ImportBinding
+	// ambig[file_path][local_name] = true once a (file, local_name)
+	// collision has been observed; further bindings for the same key
+	// are ignored.
+	ambig map[string]map[string]bool
+	// wildcardModules[file_path] = list of dotted source modules that
+	// were imported via `from X import *`. Best-effort lookup at
+	// resolve time iterates this list when a bare name has no explicit
+	// binding.
+	wildcardModules map[string][]string
+	// modulesByName[module_path] = list of entity SourceFiles that
+	// belong to that dotted module path. Built from EntityRecord
+	// SourceFile values, after normalising to forward-slash form. A
+	// path "requests/api.py" contributes to modules "requests.api" and
+	// (when it ends with `__init__.py`) "requests".
+	modulesByName map[string]map[string]bool
+	// entitiesByModuleName[module_path][name] = entity_id, populated
+	// only when the (module_path, name) tuple resolves to exactly one
+	// entity. Ambiguous tuples are tracked in ambigModuleName.
+	entitiesByModuleName map[string]map[string]string
+	ambigModuleName      map[string]map[string]bool
+}
+
+// BuildImportTable scans every embedded IMPORTS relationship in records
+// and constructs the per-file import binding map plus a module → entity
+// reverse index used by ResolveImports.
+//
+// The function reads only Properties on IMPORTS relationships; it does
+// not mutate records. Callers typically invoke BuildImportTable AFTER
+// stampEntityIDs so the entity ID is already populated when ResolveImports
+// rewrites a CALLS target.
+func BuildImportTable(records []types.EntityRecord) ImportTable {
+	tbl := ImportTable{
+		byFile:               make(map[string]map[string]ImportBinding),
+		ambig:                make(map[string]map[string]bool),
+		wildcardModules:      make(map[string][]string),
+		modulesByName:        make(map[string]map[string]bool),
+		entitiesByModuleName: make(map[string]map[string]string),
+		ambigModuleName:      make(map[string]map[string]bool),
+	}
+
+	// Pass 1 — per-file import bindings.
+	for k := range records {
+		r := &records[k]
+		for j := range r.Relationships {
+			rel := &r.Relationships[j]
+			if rel.Kind != ImportRelKind || rel.Properties == nil {
+				continue
+			}
+			file := normalizePath(rel.FromID)
+			if file == "" {
+				file = normalizePath(r.SourceFile)
+			}
+			if file == "" {
+				continue
+			}
+			module := strings.TrimSpace(rel.Properties[importPropSourceModule])
+			if module == "" {
+				continue
+			}
+			if rel.Properties[importPropWildcard] == "1" {
+				tbl.wildcardModules[file] = append(tbl.wildcardModules[file], module)
+				continue
+			}
+			local := strings.TrimSpace(rel.Properties[importPropLocalName])
+			if local == "" {
+				continue
+			}
+			imported := strings.TrimSpace(rel.Properties[importPropImportedName])
+			if imported == "" {
+				imported = local
+			}
+			if tbl.ambig[file] != nil && tbl.ambig[file][local] {
+				continue
+			}
+			fileBucket := tbl.byFile[file]
+			if fileBucket == nil {
+				fileBucket = make(map[string]ImportBinding)
+				tbl.byFile[file] = fileBucket
+			}
+			if existing, ok := fileBucket[local]; ok {
+				if existing.SourceModule != module || existing.ImportedName != imported {
+					delete(fileBucket, local)
+					if tbl.ambig[file] == nil {
+						tbl.ambig[file] = make(map[string]bool)
+					}
+					tbl.ambig[file][local] = true
+				}
+				continue
+			}
+			fileBucket[local] = ImportBinding{
+				LocalName:    local,
+				SourceModule: module,
+				ImportedName: imported,
+			}
+		}
+	}
+
+	// Pass 2 — module → entity reverse index. We map every entity's
+	// SourceFile to the dotted-module form(s) that path could satisfy
+	// and record (module, name) → id when unique.
+	for k := range records {
+		e := &records[k]
+		if e.ID == "" || e.Name == "" || e.SourceFile == "" {
+			continue
+		}
+		// Skip the import-marker entities themselves so a `from x import y`
+		// statement does not register `x.y` as a callable target — the
+		// real `y` lives in module x and gets its own EntityRecord
+		// elsewhere in the merged set.
+		if e.Kind == "SCOPE.Component" && e.Subtype == "module" {
+			continue
+		}
+		modules := modulesForFile(normalizePath(e.SourceFile))
+		for _, mod := range modules {
+			files := tbl.modulesByName[mod]
+			if files == nil {
+				files = make(map[string]bool)
+				tbl.modulesByName[mod] = files
+			}
+			files[normalizePath(e.SourceFile)] = true
+
+			if tbl.ambigModuleName[mod] != nil && tbl.ambigModuleName[mod][e.Name] {
+				continue
+			}
+			bucket := tbl.entitiesByModuleName[mod]
+			if bucket == nil {
+				bucket = make(map[string]string)
+				tbl.entitiesByModuleName[mod] = bucket
+			}
+			if existing, ok := bucket[e.Name]; ok && existing != e.ID {
+				delete(bucket, e.Name)
+				if tbl.ambigModuleName[mod] == nil {
+					tbl.ambigModuleName[mod] = make(map[string]bool)
+				}
+				tbl.ambigModuleName[mod][e.Name] = true
+				continue
+			}
+			bucket[e.Name] = e.ID
+		}
+	}
+
+	return tbl
+}
+
+// modulesForFile returns the dotted-module forms of a file path. A path
+// like "requests/api.py" satisfies module "requests.api". A path ending
+// in "/__init__.py" also satisfies the parent directory's dotted form
+// ("requests/__init__.py" → "requests"). Paths outside .py files return
+// an empty slice; non-Python languages don't currently use this index.
+func modulesForFile(p string) []string {
+	if p == "" {
+		return nil
+	}
+	if !strings.HasSuffix(p, ".py") {
+		return nil
+	}
+	stripped := strings.TrimSuffix(p, ".py")
+	out := []string{strings.ReplaceAll(stripped, "/", ".")}
+	// __init__ rolls up to its parent directory's dotted name.
+	if strings.HasSuffix(stripped, "/__init__") {
+		parent := strings.TrimSuffix(stripped, "/__init__")
+		if parent != "" {
+			out = append(out, strings.ReplaceAll(parent, "/", "."))
+		}
+	}
+	// A repo-relative path such as "src/requests/api.py" should also
+	// satisfy "requests.api" so a CALLS site that imports `requests`
+	// resolves regardless of whether the corpus checks the package out
+	// at the repo root or under a `src/` prefix. We strip any leading
+	// path segment that is itself NOT a Python package marker.
+	if dot := strings.IndexByte(out[0], '.'); dot > 0 {
+		// Add suffixes: "a.b.c" → also expose "b.c" and "c". This is a
+		// best-effort heuristic; it can only ADD a hit (the entity's
+		// presence under the precise dotted form already wins above),
+		// and the (module, name) collision guard demotes any tuple
+		// that becomes ambiguous as a result.
+		segs := strings.Split(out[0], ".")
+		for i := 1; i < len(segs); i++ {
+			out = append(out, strings.Join(segs[i:], "."))
+		}
+	}
+	return out
+}
+
+// ResolveBareCallTarget looks up a bare-name CALLS target N in the import
+// table for callerFile. Returns (entity_id, true) when an unambiguous
+// match exists; ("", false) otherwise.
+//
+// Resolution order:
+//  1. Explicit import binding for (file, name) — e.g. `from x import y`
+//     → look up y in module x.
+//  2. Module-attribute access — for every plain `import x[.y]` binding
+//     in the file, try (source_module, name). This catches the
+//     `x.foo()` call shape where the extractor stripped the receiver
+//     and emitted ToID="foo".
+//  3. Wildcard imports — `from x import *` makes every entity in x
+//     callable as a bare name; best-effort.
+func (t ImportTable) ResolveBareCallTarget(callerFile, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	callerFile = normalizePath(callerFile)
+	bucket := t.byFile[callerFile]
+	if bucket != nil {
+		if b, ok := bucket[name]; ok {
+			if id, ok := t.lookupModuleEntity(b.SourceModule, b.ImportedName); ok {
+				return id, true
+			}
+		}
+	}
+	// Module-attribute access: any plain `import x` in this file means
+	// `x.foo()` extracted as bare "foo" should resolve to module x's foo.
+	for _, b := range bucket {
+		// "Plain" module imports are detected by source_module ==
+		// imported_name (the extractor sets imported_name to the full
+		// dotted module path for `import a.b`). Skip from-imports
+		// (where imported_name is the leaf symbol name).
+		if b.SourceModule != b.ImportedName {
+			continue
+		}
+		if id, ok := t.lookupModuleEntity(b.SourceModule, name); ok {
+			return id, true
+		}
+	}
+	for _, mod := range t.wildcardModules[callerFile] {
+		if id, ok := t.lookupModuleEntity(mod, name); ok {
+			return id, true
+		}
+	}
+	return "", false
+}
+
+// lookupModuleEntity returns (id, true) when (module, name) maps to
+// exactly one entity. Ambiguous tuples return ("", false); the caller
+// leaves the original CALLS stub alone.
+func (t ImportTable) lookupModuleEntity(module, name string) (string, bool) {
+	if module == "" || name == "" {
+		return "", false
+	}
+	if t.ambigModuleName[module] != nil && t.ambigModuleName[module][name] {
+		return "", false
+	}
+	bucket, ok := t.entitiesByModuleName[module]
+	if !ok {
+		return "", false
+	}
+	id, ok := bucket[name]
+	if !ok {
+		return "", false
+	}
+	return id, true
+}
+
+// ImportResolveStats reports how many CALLS endpoints the import-aware
+// pass rewrote. Surfaced via the index.go stderr log so the verify2
+// harness can attribute the bug-rate delta.
+type ImportResolveStats struct {
+	// CallsConsidered counts every embedded CALLS edge whose ToID was a
+	// non-empty, non-hex bare name (i.e. a candidate for import-aware
+	// rewrite).
+	CallsConsidered int
+	// CallsRewritten counts the subset of CallsConsidered that resolved
+	// to a 16-char entity ID via the import table.
+	CallsRewritten int
+}
+
+// ResolveImports rewrites embedded CALLS edges in records using the
+// supplied import table. Returns counters describing the rewrite. Edges
+// whose ToID is empty, already a hex ID, or contains a "." (already
+// dotted) are skipped — those have either been resolved already or
+// belong to the receiver-typed CALLS path that the base resolver
+// handles via byMember.
+func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolveStats {
+	var stats ImportResolveStats
+	for k := range records {
+		e := &records[k]
+		callerFile := normalizePath(e.SourceFile)
+		if callerFile == "" {
+			continue
+		}
+		for j := range e.Relationships {
+			rel := &e.Relationships[j]
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			to := rel.ToID
+			if to == "" || isHexID(to) {
+				continue
+			}
+			// Skip stubs that already encode a kind ("Kind:Name") or a
+			// receiver-typed dotted target ("Class.method"). The base
+			// resolver handles those via byKind / byMember.
+			if strings.ContainsAny(to, ":.#") {
+				continue
+			}
+			stats.CallsConsidered++
+			id, ok := tbl.ResolveBareCallTarget(callerFile, to)
+			if !ok {
+				continue
+			}
+			rel.ToID = id
+			stats.CallsRewritten++
+		}
+	}
+	return stats
+}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -37,10 +37,12 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// ImportRelKind is the relationship kind emitted by the Python (and any
+// importRelKind is the relationship kind emitted by the Python (and any
 // future) extractor for import statements. ImportTable consumes only
-// relationships whose Kind matches this constant.
-const ImportRelKind = "IMPORTS"
+// relationships whose Kind matches this constant. Unexported because no
+// caller outside this package needs it; the in-package tests reference it
+// directly.
+const importRelKind = "IMPORTS"
 
 // Property keys read off an IMPORTS relationship. See
 // internal/extractors/python/extractor.go:extractImports for the producer
@@ -130,7 +132,7 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 		r := &records[k]
 		for j := range r.Relationships {
 			rel := &r.Relationships[j]
-			if rel.Kind != ImportRelKind || rel.Properties == nil {
+			if rel.Kind != importRelKind || rel.Properties == nil {
 				continue
 			}
 			file := normalizePath(rel.FromID)
@@ -253,21 +255,26 @@ func modulesForFile(p string) []string {
 	// A repo-relative path such as "src/requests/api.py" should also
 	// satisfy "requests.api" so a CALLS site that imports `requests`
 	// resolves regardless of whether the corpus checks the package out
-	// at the repo root or under a `src/` prefix. We strip any leading
-	// path segment that is itself NOT a Python package marker.
-	if dot := strings.IndexByte(out[0], '.'); dot > 0 {
-		// Add suffixes: "a.b.c" → also expose "b.c" and "c". This is a
-		// best-effort heuristic; it can only ADD a hit (the entity's
-		// presence under the precise dotted form already wins above),
-		// and the (module, name) collision guard demotes any tuple
-		// that becomes ambiguous as a result.
-		segs := strings.Split(out[0], ".")
-		for i := 1; i < len(segs); i++ {
-			out = append(out, strings.Join(segs[i:], "."))
+	// at the repo root or under a `src/` prefix. We only strip ONE
+	// leading segment, and only if it is one of the well-known source
+	// roots below. This avoids the prior suffix-explosion behaviour
+	// that exposed every tail of a dotted path ("a.b.c" → "b.c", "c")
+	// and could collide with unrelated top-level packages in a
+	// monorepo (e.g. a tools/ helper named the same as a real lib).
+	for _, prefix := range sourceRootPrefixes {
+		if strings.HasPrefix(out[0], prefix) {
+			out = append(out, strings.TrimPrefix(out[0], prefix))
+			break
 		}
 	}
 	return out
 }
+
+// sourceRootPrefixes is the small allowlist of leading dotted-path
+// segments that modulesForFile may strip once when computing alias
+// dotted forms for an entity's source file. Anything else is left
+// alone — broader stripping caused false positives in monorepos.
+var sourceRootPrefixes = []string{"src.", "lib.", "app."}
 
 // ResolveBareCallTarget looks up a bare-name CALLS target N in the import
 // table for callerFile. Returns (entity_id, true) when an unambiguous
@@ -297,6 +304,15 @@ func (t ImportTable) ResolveBareCallTarget(callerFile, name string) (string, boo
 	}
 	// Module-attribute access: any plain `import x` in this file means
 	// `x.foo()` extracted as bare "foo" should resolve to module x's foo.
+	// We collect ALL candidate IDs across plain imports first; if exactly
+	// one plain import yields a hit, use it; if two or more yield hits
+	// (and disagree), the lookup is ambiguous and we drop — same
+	// conservative policy as a (module, name) collision. Iterating the
+	// map and short-circuiting on first hit would be non-deterministic.
+	var (
+		plainCandidate string
+		plainHits      int
+	)
 	for _, b := range bucket {
 		// "Plain" module imports are detected by source_module ==
 		// imported_name (the extractor sets imported_name to the full
@@ -306,8 +322,19 @@ func (t ImportTable) ResolveBareCallTarget(callerFile, name string) (string, boo
 			continue
 		}
 		if id, ok := t.lookupModuleEntity(b.SourceModule, name); ok {
-			return id, true
+			if plainHits == 0 {
+				plainCandidate = id
+				plainHits = 1
+			} else if id != plainCandidate {
+				plainHits++
+			}
 		}
+	}
+	if plainHits == 1 {
+		return plainCandidate, true
+	}
+	if plainHits > 1 {
+		return "", false
 	}
 	for _, mod := range t.wildcardModules[callerFile] {
 		if id, ok := t.lookupModuleEntity(mod, name); ok {

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -1,0 +1,287 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// importerRecord builds an EntityRecord for the IMPORTING file's marker
+// entity carrying a single IMPORTS relationship. Mirrors what
+// internal/extractors/python/extractor.go:importRecord emits.
+func importerRecord(file, modulePath string, props map[string]string) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       modulePath,
+		Kind:       "SCOPE.Component",
+		Subtype:    "module",
+		SourceFile: file,
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{{
+			FromID:     file,
+			ToID:       modulePath,
+			Kind:       ImportRelKind,
+			Properties: props,
+		}},
+	}
+}
+
+// targetRecord builds the entity that a CALLS edge should bind to after
+// the import-aware resolver runs (e.g. the real `get` defined in
+// requests/api.py). The ID field is what ResolveImports rewrites the
+// CALLS target to; we set it to a synthetic 16-char hex value so the
+// downstream isHexID check accepts it.
+func targetRecord(name, file, id string) types.EntityRecord {
+	return types.EntityRecord{
+		ID:         id,
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "function",
+		SourceFile: file,
+		Language:   "python",
+	}
+}
+
+// callerRecord builds an EntityRecord representing a function that
+// makes a single bare-name CALL. The CALLS edge's FromID is left empty
+// (matching the Pass 1 emission convention); SourceFile pins the
+// caller's file so ResolveImports can find the import table entry.
+func callerRecord(name, file, target string) types.EntityRecord {
+	return types.EntityRecord{
+		ID:         "0123456789abcdef",
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "function",
+		SourceFile: file,
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{{
+			ToID: target,
+			Kind: "CALLS",
+		}},
+	}
+}
+
+// TestResolveImports_PlainImport covers `import x; x.foo()` — the
+// extractor emits ToID="foo" and a binding with local_name="x",
+// source_module="x", imported_name="x". The resolver should rewrite
+// "foo" to the entity id of the `foo` defined in module x.
+func TestResolveImports_PlainImport(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "remote", map[string]string{
+			"local_name":    "remote",
+			"source_module": "remote",
+			"imported_name": "remote",
+		}),
+		targetRecord("dispatch", "remote/__init__.py", "aaaaaaaaaaaaaaaa"),
+		callerRecord("run", "client/app.py", "dispatch"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d (considered=%d)", stats.CallsRewritten, stats.CallsConsidered)
+	}
+	caller := records[2]
+	if got := caller.Relationships[0].ToID; got != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("expected CALLS target rewritten to aaaaaaaaaaaaaaaa, got %q", got)
+	}
+}
+
+// TestResolveImports_FromImport covers `from foo import bar; bar()`.
+func TestResolveImports_FromImport(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo.bar", map[string]string{
+			"local_name":    "bar",
+			"source_module": "foo",
+			"imported_name": "bar",
+		}),
+		targetRecord("bar", "foo/__init__.py", "bbbbbbbbbbbbbbbb"),
+		callerRecord("run", "client/app.py", "bar"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("expected target bbbbbbbbbbbbbbbb, got %q", got)
+	}
+}
+
+// TestResolveImports_FromImportAlias covers
+// `from foo import bar as baz; baz()` — the local name "baz" must
+// rewrite to the entity for `bar` defined in module foo.
+func TestResolveImports_FromImportAlias(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo.bar", map[string]string{
+			"local_name":    "baz",
+			"source_module": "foo",
+			"imported_name": "bar",
+		}),
+		targetRecord("bar", "foo/__init__.py", "cccccccccccccccc"),
+		callerRecord("run", "client/app.py", "baz"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "cccccccccccccccc" {
+		t.Fatalf("expected target cccccccccccccccc, got %q", got)
+	}
+}
+
+// TestResolveImports_BareNameNotImported leaves a bare CALLS target
+// alone when no import binding matches.
+func TestResolveImports_BareNameNotImported(t *testing.T) {
+	records := []types.EntityRecord{
+		callerRecord("run", "client/app.py", "mystery"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites, got %d", stats.CallsRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "mystery" {
+		t.Fatalf("expected target unchanged, got %q", got)
+	}
+}
+
+// TestResolveImports_ExternalImportNoEntity covers
+// `import os; os.getcwd()` — when `os` is not part of the corpus the
+// import-aware pass leaves the CALLS target alone (the downstream
+// classifier will tag it ExternalKnown via the allowlist).
+func TestResolveImports_ExternalImportNoEntity(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "os", map[string]string{
+			"local_name":    "os",
+			"source_module": "os",
+			"imported_name": "os",
+		}),
+		callerRecord("run", "client/app.py", "getcwd"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites (os not in corpus), got %d", stats.CallsRewritten)
+	}
+	if got := records[1].Relationships[0].ToID; got != "getcwd" {
+		t.Fatalf("expected target unchanged for external symbol, got %q", got)
+	}
+}
+
+// TestResolveImports_DottedTargetSkipped — receiver-typed dotted
+// targets ("Class.method") are handled by the base resolver via
+// byMember and must not be touched here.
+func TestResolveImports_DottedTargetSkipped(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo.bar", map[string]string{
+			"local_name":    "bar",
+			"source_module": "foo",
+			"imported_name": "bar",
+		}),
+		targetRecord("bar", "foo/__init__.py", "dddddddddddddddd"),
+		{
+			ID:         "1234567890abcdef",
+			Name:       "Driver.run",
+			Kind:       "SCOPE.Operation",
+			SourceFile: "client/app.py",
+			Language:   "python",
+			Relationships: []types.RelationshipRecord{{
+				ToID: "Helper.run",
+				Kind: "CALLS",
+			}},
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsConsidered != 0 {
+		t.Fatalf("expected dotted target to be skipped, considered=%d", stats.CallsConsidered)
+	}
+	if got := records[2].Relationships[0].ToID; got != "Helper.run" {
+		t.Fatalf("expected dotted target unchanged, got %q", got)
+	}
+}
+
+// TestResolveImports_Wildcard covers `from foo import *; bar()`.
+// Best-effort: when foo exports a single entity named `bar`, the
+// CALLS target is rewritten.
+func TestResolveImports_Wildcard(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo", map[string]string{
+			"source_module": "foo",
+			"wildcard":      "1",
+		}),
+		targetRecord("bar", "foo/__init__.py", "eeeeeeeeeeeeeeee"),
+		callerRecord("run", "client/app.py", "bar"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 wildcard rewrite, got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "eeeeeeeeeeeeeeee" {
+		t.Fatalf("expected wildcard target eeeeeeeeeeeeeeee, got %q", got)
+	}
+}
+
+// TestResolveImports_AmbiguousModuleEntity covers the case where a
+// (module, name) tuple resolves to two distinct entities. The
+// resolver must leave the CALLS target alone rather than guess.
+func TestResolveImports_AmbiguousModuleEntity(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo.bar", map[string]string{
+			"local_name":    "bar",
+			"source_module": "foo",
+			"imported_name": "bar",
+		}),
+		// Two entities with name "bar" both in foo/__init__.py — the
+		// (foo, bar) tuple is ambiguous, so the resolver must skip.
+		targetRecord("bar", "foo/__init__.py", "ffffffffffffffff"),
+		{
+			ID:         "1111111111111111",
+			Name:       "bar",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "function",
+			SourceFile: "foo/__init__.py",
+			Language:   "python",
+		},
+		callerRecord("run", "client/app.py", "bar"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	// Module "foo" has two `bar` entities — the lookup is ambiguous
+	// for the (foo, bar) tuple. The (foo.bar, bar) tuple is unique
+	// (only foo/__init__.py serves it under "foo.bar"); the actual
+	// extractor emits source_module="foo" so the lookup hits the
+	// ambiguous tuple and skips. We assert no rewrite under the
+	// ambiguous condition.
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites under ambiguity, got %d", stats.CallsRewritten)
+	}
+}
+
+// TestResolveImports_FileLocalCollisionDropsBinding covers the case
+// where the same file imports two different symbols under the same
+// local name (e.g. shadowing). The conservative behaviour is to drop
+// both bindings and leave the CALLS stub alone.
+func TestResolveImports_FileLocalCollisionDropsBinding(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "foo.bar", map[string]string{
+			"local_name":    "bar",
+			"source_module": "foo",
+			"imported_name": "bar",
+		}),
+		importerRecord("client/app.py", "qux.bar", map[string]string{
+			"local_name":    "bar",
+			"source_module": "qux",
+			"imported_name": "bar",
+		}),
+		targetRecord("bar", "foo/__init__.py", "2222222222222222"),
+		targetRecord("bar", "qux/__init__.py", "3333333333333333"),
+		callerRecord("run", "client/app.py", "bar"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites under local-name collision, got %d", stats.CallsRewritten)
+	}
+}

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -19,7 +19,7 @@ func importerRecord(file, modulePath string, props map[string]string) types.Enti
 		Relationships: []types.RelationshipRecord{{
 			FromID:     file,
 			ToID:       modulePath,
-			Kind:       ImportRelKind,
+			Kind:       importRelKind,
 			Properties: props,
 		}},
 	}
@@ -256,6 +256,111 @@ func TestResolveImports_AmbiguousModuleEntity(t *testing.T) {
 	// ambiguous condition.
 	if stats.CallsRewritten != 0 {
 		t.Fatalf("expected 0 rewrites under ambiguity, got %d", stats.CallsRewritten)
+	}
+}
+
+// TestResolveImports_MonorepoTopLevelCollision asserts the suffix-strip
+// in modulesForFile does NOT explode "tools.shared.helpers" into
+// "shared.helpers" / "helpers" — a monorepo could have an unrelated
+// top-level package "helpers" that would otherwise collide and either
+// resolve to the wrong entity or be demoted to ambiguous.
+//
+// Setup:
+//   - client/app.py does `from helpers import compute; compute()`
+//   - tools/shared/helpers.py defines a function compute (NOT the
+//     `helpers` package the caller meant to import)
+//   - The caller imports module "helpers" which is not in the corpus,
+//     so the rewrite should NOT happen.
+//
+// Pre-fix: modulesForFile("tools/shared/helpers.py") emitted
+// ["tools.shared.helpers", "shared.helpers", "helpers"], so the
+// (helpers, compute) tuple resolved to the unrelated tools entity.
+// Post-fix: only the precise dotted form (and a single allowlisted
+// source-root strip) is emitted, so no rewrite happens.
+func TestResolveImports_MonorepoTopLevelCollision(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "helpers.compute", map[string]string{
+			"local_name":    "compute",
+			"source_module": "helpers",
+			"imported_name": "compute",
+		}),
+		// Unrelated entity buried under a deeper path. Only its precise
+		// dotted form ("tools.shared.helpers") should be indexed.
+		targetRecord("compute", "tools/shared/helpers.py", "4444444444444444"),
+		callerRecord("run", "client/app.py", "compute"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites (unrelated monorepo entity must not collide), got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "compute" {
+		t.Fatalf("expected target unchanged, got %q", got)
+	}
+}
+
+// TestResolveImports_SrcPrefixStripped covers the conservative
+// allowlisted-prefix strip kept in modulesForFile: a file at
+// "src/requests/api.py" should still resolve when imported as
+// "requests.api".
+func TestResolveImports_SrcPrefixStripped(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "requests.api.get", map[string]string{
+			"local_name":    "get",
+			"source_module": "requests.api",
+			"imported_name": "get",
+		}),
+		targetRecord("get", "src/requests/api.py", "5555555555555555"),
+		callerRecord("run", "client/app.py", "get"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite via src/ prefix strip, got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "5555555555555555" {
+		t.Fatalf("expected target 5555555555555555, got %q", got)
+	}
+}
+
+// TestResolveImports_PlainImportAmbiguous asserts deterministic
+// non-resolution when two plain `import` statements both expose the
+// same bare name. The pre-fix code iterated the file bucket map and
+// short-circuited on the first hit — a non-deterministic pick across
+// runs. The post-fix collects all candidates and drops on >1.
+func TestResolveImports_PlainImportAmbiguous(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("client/app.py", "alpha", map[string]string{
+			"local_name":    "alpha",
+			"source_module": "alpha",
+			"imported_name": "alpha",
+		}),
+		importerRecord("client/app.py", "beta", map[string]string{
+			"local_name":    "beta",
+			"source_module": "beta",
+			"imported_name": "beta",
+		}),
+		// Both alpha and beta export a function named `tick`.
+		targetRecord("tick", "alpha/__init__.py", "6666666666666666"),
+		targetRecord("tick", "beta/__init__.py", "7777777777777777"),
+		callerRecord("run", "client/app.py", "tick"),
+	}
+	// Run repeatedly — pre-fix this would flap between the two IDs
+	// depending on Go's randomised map iteration order. Post-fix it
+	// must always drop (rewritten==0).
+	for i := 0; i < 16; i++ {
+		// Reset the caller's CALLS edge each iteration so any rewrite
+		// from a previous iteration doesn't mask flakiness.
+		records[4].Relationships[0].ToID = "tick"
+		tbl := BuildImportTable(records)
+		stats := ResolveImports(records, tbl)
+		if stats.CallsRewritten != 0 {
+			t.Fatalf("iter %d: expected 0 rewrites under plain-import ambiguity, got %d (target=%q)",
+				i, stats.CallsRewritten, records[4].Relationships[0].ToID)
+		}
+		if got := records[4].Relationships[0].ToID; got != "tick" {
+			t.Fatalf("iter %d: expected target unchanged, got %q", i, got)
+		}
 	}
 }
 


### PR DESCRIPTION
## Root cause

After #89 / #94 narrowed bug-extractor patterns, the dominant remaining shape is bare-name CALLS edges where the target is a symbol imported from another module. The base resolver only has a flat byName index, so when two or more entities in the corpus share a name (e.g. `requests/api.py:get` and a dozen test files defining `get`), the lookup is ambiguous and the edge stays as a `bug-*` disposition.

## Approach

Add a per-file import resolution pass that runs BEFORE `BuildIndex` so the disposition classifier sees an already-resolved entity ID.

1. Python extractor stamps every `IMPORTS` relationship with `local_name`, `source_module`, `imported_name`, and (for `from x import *`) `wildcard` properties.
2. New `internal/resolve/imports.go`:
   - `BuildImportTable` builds `file -> local_name -> ImportBinding` plus a `(module_path, name) -> entity_id` reverse index. Local-name collisions inside a single file are dropped (conservative: rebinds in real Python are rare; better to miss than misresolve). Ambiguous `(module, name)` tuples are also dropped.
   - `ResolveImports` walks every embedded `CALLS` edge whose `ToID` is a non-hex bare name, looks it up in the table, and rewrites the target. Resolution order: explicit binding -> module-attribute access (covers `x.foo()` shapes the extractor strips to bare `foo`) -> wildcard.
3. `cmd/archigraph/index.go` invokes the pass before the existing references resolver and logs `resolver: import-aware rewrote=N/M bare-name CALLS targets` to stderr.

## Files touched

- `cmd/archigraph/index.go` — wire the pass into the indexer pipeline.
- `internal/extractors/python/extractor.go` — emit binding metadata + new `dottedNameAndAlias` helper.
- `internal/resolve/imports.go` (new, ~390 lines) — the pass itself.
- `internal/resolve/imports_test.go` (new, 9 cases) — unit tests.

## Tests

9 new `TestResolveImports_*` cases covering: plain `import x`, `from x import y`, `from x import y as z`, wildcard, ambiguous module entity, file-local local-name collision, dotted target skipped, external-symbol non-rewrite, and bare-name with no matching import.

```
=== RUN   TestResolveImports_PlainImport                       --- PASS
=== RUN   TestResolveImports_FromImport                        --- PASS
=== RUN   TestResolveImports_FromImportAlias                   --- PASS
=== RUN   TestResolveImports_BareNameNotImported               --- PASS
=== RUN   TestResolveImports_ExternalImportNoEntity            --- PASS
=== RUN   TestResolveImports_DottedTargetSkipped               --- PASS
=== RUN   TestResolveImports_Wildcard                          --- PASS
=== RUN   TestResolveImports_AmbiguousModuleEntity             --- PASS
=== RUN   TestResolveImports_FileLocalCollisionDropsBinding    --- PASS
```

Full `go test ./...` is green.

## Bug-rate delta

Not measured in this PR — VERIFY-2 requires cloning the OSS corpora and was out of scope for the implementer session. The stderr counter (`resolver: import-aware rewrote=N/M`) lets the next harness run attribute the delta directly.

## Scope

Python only as the first language. JavaScript / Go / Java / Ruby / Rust / etc. land under the existing per-language tracking in #91; any extractor can opt in by emitting the same `IMPORTS` edge properties.

Closes #93