### PR TITLE
fix(markdown): resolve heading QualifiedName for CONTAINS edges (Refs #100)

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -451,6 +451,13 @@ type Index struct {
 	// A blank string sentinel marks (file, name, kind) collisions.
 	byLocationKind LocationKindIndex
 
+	// byQualifiedName[qualified_name] = entity_id. Direct lookup for
+	// stubs whose ToID is an entity QualifiedName verbatim (e.g. markdown
+	// CONTAINS edges where ToID = "<file>::<heading-slug>"). Issue #100.
+	// First writer wins; a blank-string sentinel marks collisions so we
+	// never resolve an ambiguous QualifiedName.
+	byQualifiedName map[string]string
+
 	// byMember[file_path][scope_name][member_name] = entity_id. Used by
 	// structural-ref Format B resolution. A blank string sentinel marks
 	// (scope, member) collisions inside the same file. Entities are
@@ -648,21 +655,37 @@ func MergeDispositions(dst, src *Stats) {
 //     so a stub like "View:User" matches an entity of kind "SCOPE.View".
 func BuildIndex(entities []types.EntityRecord) Index {
 	idx := Index{
-		byKind:         make(map[string]map[string]string),
-		ambigKind:      make(map[string]map[string]bool),
-		byName:         make(map[string]string),
-		ambigName:      make(map[string]bool),
-		nameKinds:      make(map[string]map[string]string),
-		byLocation:     make(LocationIndex),
-		ambigLocation:  make(map[string]map[string]bool),
-		byLocationKind: make(LocationKindIndex),
-		byMember:       make(map[string]map[string]map[string]string),
+		byKind:          make(map[string]map[string]string),
+		ambigKind:       make(map[string]map[string]bool),
+		byName:          make(map[string]string),
+		ambigName:       make(map[string]bool),
+		nameKinds:       make(map[string]map[string]string),
+		byLocation:      make(LocationIndex),
+		ambigLocation:   make(map[string]map[string]bool),
+		byLocationKind:  make(LocationKindIndex),
+		byMember:        make(map[string]map[string]map[string]string),
+		byQualifiedName: make(map[string]string),
 	}
 	for k := range entities {
 		e := &entities[k]
 		if e.ID == "" || e.Name == "" {
 			continue
 		}
+		// QualifiedName index — direct lookup for stubs that arrive as a
+		// verbatim QualifiedName (issue #100). The markdown extractor
+		// emits CONTAINS edges with ToID="<file>::<heading-slug>" which
+		// matches the heading entity's QualifiedName exactly, but neither
+		// the byKind nor byName paths see it (splitStub on the first ':'
+		// produces a non-existent "kind" segment). First writer wins;
+		// collisions blank the entry so the resolver leaves the stub.
+		if e.QualifiedName != "" {
+			if existing, ok := idx.byQualifiedName[e.QualifiedName]; ok && existing != e.ID {
+				idx.byQualifiedName[e.QualifiedName] = ""
+			} else {
+				idx.byQualifiedName[e.QualifiedName] = e.ID
+			}
+		}
+
 		// Index under both the plain kind and the trimmed kind ("SCOPE.View"
 		// → "View"), so stubs can match either form.
 		kinds := []string{e.Kind}
@@ -854,6 +877,14 @@ func (idx Index) Lookup(stub string) (string, bool) {
 	if stub == "" {
 		return "", false
 	}
+	// Direct QualifiedName hit short-circuits the kind/name paths
+	// (issue #100). Blank-string sentinel = ambiguous → treat as miss.
+	if qid, ok := idx.byQualifiedName[stub]; ok {
+		if qid == "" {
+			return "", false
+		}
+		return qid, true
+	}
 	kind, name := splitStub(stub)
 	if kind != "" {
 		if bucket, ok := idx.byKind[kind]; ok {
@@ -894,6 +925,19 @@ func (idx Index) LookupStatus(stub string) (id string, status int) {
 func (idx Index) LookupStatusHint(stub, relKind string) (id string, status int) {
 	if stub == "" {
 		return "", statusUnmatched
+	}
+
+	// Direct QualifiedName match (issue #100). Some extractors — markdown
+	// CONTAINS edges, code-block-relative references — emit ToIDs that are
+	// the target entity's QualifiedName verbatim. Probing the QualifiedName
+	// index first short-circuits the structural / kind / name paths for
+	// these unambiguous exact hits. A blank-string sentinel means the
+	// QualifiedName collided across entities; treat as ambiguous.
+	if qid, ok := idx.byQualifiedName[stub]; ok {
+		if qid == "" {
+			return "", statusAmbiguous
+		}
+		return qid, statusRewritten
 	}
 
 	// Structural-ref forms (Format A / B). Recognised by the "scope:"

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -692,6 +692,56 @@ func TestReflectionBuiltins_RecognisedAsDynamic(t *testing.T) {
 	}
 }
 
+// TestReferences_QualifiedNameMatch covers issue #100: a stub equal to an
+// entity's QualifiedName (verbatim) must resolve directly. The markdown
+// extractor emits Document --CONTAINS--> "<file>::<heading-slug>" edges
+// where the ToID is exactly the heading entity's QualifiedName; before the
+// fix splitStub split on the first ':' and the lookup landed in the
+// bug-extractor bucket.
+func TestReferences_QualifiedNameMatch(t *testing.T) {
+	heading := types.EntityRecord{
+		ID:            "abcdef0123456789",
+		Kind:          "SCOPE.Heading",
+		Name:          "Installation",
+		QualifiedName: "README.md::installation",
+		SourceFile:    "README.md",
+	}
+	rels := []types.RelationshipRecord{
+		{FromID: "0000000000000000", ToID: "README.md::installation", Kind: "CONTAINS"},
+	}
+	idx := BuildIndex([]types.EntityRecord{heading})
+	stats := References(rels, idx)
+	if rels[0].ToID != "abcdef0123456789" {
+		t.Fatalf("QName resolution: ToID=%q, want abcdef0123456789", rels[0].ToID)
+	}
+	if stats.Rewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d", stats.Rewritten)
+	}
+}
+
+// TestReferences_QualifiedNameAmbiguous: two entities sharing a
+// QualifiedName should leave the stub unresolved (ambiguous), never silently
+// pick one.
+func TestReferences_QualifiedNameAmbiguous(t *testing.T) {
+	entities := []types.EntityRecord{
+		{ID: "1111111111111111", Kind: "SCOPE.Heading", Name: "Foo",
+			QualifiedName: "doc.md::foo", SourceFile: "doc.md"},
+		{ID: "2222222222222222", Kind: "SCOPE.Heading", Name: "Foo",
+			QualifiedName: "doc.md::foo", SourceFile: "doc.md"},
+	}
+	rels := []types.RelationshipRecord{
+		{FromID: "0000000000000000", ToID: "doc.md::foo", Kind: "CONTAINS"},
+	}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "doc.md::foo" {
+		t.Fatalf("ambiguous QName should preserve stub, got %q", rels[0].ToID)
+	}
+	if stats.Ambiguous != 1 {
+		t.Fatalf("expected 1 ambiguous, got %d", stats.Ambiguous)
+	}
+}
+
 func TestBuildLocationIndex(t *testing.T) {
 	entities := []types.EntityRecord{
 		entAt("aaaaaaaaaaaaaaaa", "Component", "Foo", "a.py"),


### PR DESCRIPTION
## Summary
- Adds a `byQualifiedName` index to `resolve.Index` and probes it first in `Lookup` / `LookupStatusHint`.
- Fixes markdown `Document --CONTAINS--> "<file>::<heading-slug>"` edges that were misclassified as `bug-extractor` because `splitStub` split the stub on the first `:` and the kind/name path could never see the heading entity.
- Heading entities already store their slug-form QualifiedName, so this is a one-place resolver fix; no changes to the markdown extractor or its emitted shape.

## Measurement (single-repo verify2)

Built the new binary alongside the main-tip baseline and indexed the two repos in the issue:

| repo | bug_rate before | bug_rate after | delta | extra resolved |
| --- | ---: | ---: | ---: | ---: |
| gin | 54.37% | 50.95% | **-3.42pp** | +749 |
| aspnetcore-realworld | 52.91% | 51.31% | **-1.60pp** | +22 |

Below the acceptance bar in #100 (`>=15pp` / `>=10pp`). The projected 3395-bug baseline cited in the issue (45% of go-gin bugs) was higher than the actual current markdown contribution to the bug-extractor bucket on the corpus we have today. The fix is still correct — every markdown CONTAINS edge that previously dead-ended now resolves to a real heading entity, and the bug-extractor samples in the post-fix output no longer contain any `<path>::<slug>` strings. The remaining bug-extractors in these corpora are non-markdown (bare-name Go calls, etc.) and need to be addressed in a separate ticket.

`Refs #100` rather than `Closes #100` — leaving the issue open so it can either (a) be re-targeted at the higher bug categories that show up in the post-fix samples, or (b) be closed once owners agree the markdown class is empty.

## Test plan
- [x] `go test ./internal/extractors/markdown/... ./internal/resolve/...` green
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/resolve/refs.go` clean (other pre-existing files in the repo unchanged)
- [x] Two new tests exercise the QualifiedName path:
  - `TestReferences_QualifiedNameMatch` — verbatim QName resolves
  - `TestReferences_QualifiedNameAmbiguous` — colliding QName leaves stub