### PR TITLE
fix(synth): split PHP backslash namespace paths in classifyExternal

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -287,6 +287,27 @@ func classifyExternal(stub, relKind string) (canonical, subtype string, ok bool)
 		}
 	}
 
+	// Issue #102 — PHP `use Foo\Bar\Baz` style FQNs use `\` as the
+	// namespace separator. Without this branch the path-separator
+	// rejection below drops every `Symfony\Component\HttpFoundation\
+	// Response`, `Doctrine\ORM\EntityManager`, etc. into bug-extractor.
+	//
+	// Detect `\` early: take the first segment as the root namespace,
+	// gate it on the PHP-namespace ident shape (PascalCase ASCII), and
+	// look up against the allowlist. Project-internal roots like
+	// `App\*` are not on the allowlist and correctly fall through to
+	// remain unresolved (project-aware resolution is out of scope).
+	if idx := strings.IndexByte(stub, '\\'); idx > 0 {
+		root := stub[:idx]
+		if isPhpNamespaceIdent(root) && isKnownExternalPackage(root) {
+			// Canonicalise to lowercase — the placeholder convention is
+			// "ext:<lowercase>" across ecosystems (django, tokio, ...);
+			// PHP namespace roots are the only ones that arrive
+			// PascalCase, so we fold here rather than at the lookup site.
+			return strings.ToLower(root), "package", true
+		}
+	}
+
 	// Strip a leading "Kind:" prefix if present — e.g. "Module:django"
 	// or "Function:Println". The remainder is what we classify.
 	name := stub
@@ -851,12 +872,19 @@ var knownExternalPackages = map[string]struct{}{
 	"tokio_stream":         {},
 	"tokio_util":           {},
 	"derive_more":          {},
-	// NOTE (Issue #91): PHP namespace roots (Symfony\, Doctrine\, App\)
-	// and Rust `::`-delimited use statements (tokio::net::TcpListener)
-	// are NOT catalogued here because the synth segment-extractor only
-	// splits on '.' and rejects '\'. Filed as follow-up to add separator
-	// support. Adding lowercase keys without resolver support would do
-	// nothing — and risks future false positives once support lands.
+	// PHP ecosystem (Issue #102 — symfony-demo bug-rate reduction).
+	// PHP namespace roots reach this allowlist via the `\`-separator
+	// branch in classifyExternal, gated on isPhpNamespaceIdent. Keys
+	// are lowercase here because isKnownExternalPackage case-folds the
+	// lookup; the on-disk root is "Symfony", "Doctrine", etc. App\* is
+	// intentionally absent — it's the project-local convention in
+	// Symfony/Laravel layouts and must not be promoted to a placeholder.
+	"symfony":    {},
+	"doctrine":   {},
+	"twig":       {},
+	"laravel":    {},
+	"illuminate": {},
+	"psr":        {},
 }
 
 // isKindLikePrefix reports whether s is a short, alphabetic kind name
@@ -937,6 +965,34 @@ func isRustCrateIdent(s string) bool {
 			if i == 0 {
 				return false
 			}
+		default:
+			return false
+		}
+	}
+	return true
+}
+
+// isPhpNamespaceIdent reports whether s has the shape of a PHP
+// top-level namespace segment — ASCII letters, digits, and '_',
+// non-empty, not starting with a digit, and starting with an
+// uppercase letter (PHP convention for vendor/namespace roots:
+// Symfony, Doctrine, Twig, Psr, App, ...). Issue #102: gates the
+// `\` separator branch so we only trust the leading segment of a
+// use-statement when it looks like a namespace root, not a stray
+// fragment with backslashes that slipped in from elsewhere.
+func isPhpNamespaceIdent(s string) bool {
+	if s == "" {
+		return false
+	}
+	if c := s[0]; !(c >= 'A' && c <= 'Z') {
+		return false
+	}
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c == '_':
+		case c >= '0' && c <= '9':
 		default:
 			return false
 		}

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -617,3 +617,80 @@ func TestSynthesize_ExpandedAllowlist(t *testing.T) {
 		}
 	}
 }
+
+// TestSynthesize_PhpBackslashNamespace covers issue #102: PHP `use
+// Foo\Bar\Baz` FQNs use `\` as the namespace separator. Without the
+// dedicated branch in classifyExternal these stubs hit the
+// path-separator rejection and land in bug-extractor.
+func TestSynthesize_PhpBackslashNamespace(t *testing.T) {
+	cases := []struct {
+		stub string
+		want string
+	}{
+		// Symfony — top import root in symfony-demo.
+		{"Symfony\\Component\\HttpFoundation\\Response", "ext:symfony"},
+		{"Symfony\\Component\\HttpKernel\\Exception\\NotFoundHttpException", "ext:symfony"},
+		{"Symfony\\Bundle\\FrameworkBundle\\Controller\\AbstractController", "ext:symfony"},
+		// Doctrine ORM/DBAL.
+		{"Doctrine\\ORM\\EntityManager", "ext:doctrine"},
+		{"Doctrine\\DBAL\\Connection", "ext:doctrine"},
+		// Twig templating.
+		{"Twig\\Environment", "ext:twig"},
+		{"Twig\\Extension\\AbstractExtension", "ext:twig"},
+		// PSR interfaces (logger, container, http-message).
+		{"Psr\\Log\\LoggerInterface", "ext:psr"},
+		{"Psr\\Container\\ContainerInterface", "ext:psr"},
+		// Laravel / Illuminate roots.
+		{"Illuminate\\Support\\Facades\\DB", "ext:illuminate"},
+		{"Laravel\\Sanctum\\HasApiTokens", "ext:laravel"},
+	}
+	doc := &graph.Document{}
+	for _, c := range cases {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     "rel-" + c.stub,
+			FromID: "src",
+			ToID:   c.stub,
+			Kind:   "IMPORTS",
+		})
+	}
+	stats := Synthesize(doc)
+	if stats.RelationshipsResolved != len(cases) {
+		t.Fatalf("resolved=%d, want %d", stats.RelationshipsResolved, len(cases))
+	}
+	for k, c := range cases {
+		if doc.Relationships[k].ToID != c.want {
+			t.Fatalf("case %q: ToID=%q, want %q", c.stub, doc.Relationships[k].ToID, c.want)
+		}
+	}
+}
+
+// TestSynthesize_PhpAppNamespaceLeftAlone confirms that the PHP
+// project-local convention `App\*` (used in Symfony / Laravel) is
+// NOT promoted to an ext: placeholder. App is project-internal and
+// proper resolution is out of scope for #102 — the placeholder
+// pathway must skip it cleanly.
+func TestSynthesize_PhpAppNamespaceLeftAlone(t *testing.T) {
+	stubs := []string{
+		"App\\Entity\\User",
+		"App\\Controller\\BlogController",
+		"App\\Repository\\PostRepository",
+	}
+	doc := &graph.Document{}
+	for _, s := range stubs {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     "rel-" + s,
+			FromID: "src",
+			ToID:   s,
+			Kind:   "IMPORTS",
+		})
+	}
+	stats := Synthesize(doc)
+	if stats.RelationshipsResolved != 0 {
+		t.Fatalf("resolved=%d, want 0 (App\\* is project-local)", stats.RelationshipsResolved)
+	}
+	for k, s := range stubs {
+		if doc.Relationships[k].ToID != s {
+			t.Fatalf("case %q: ToID was rewritten to %q, expected unchanged", s, doc.Relationships[k].ToID)
+		}
+	}
+}

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -197,7 +197,7 @@ func buildUseImports(node *sitter.Node, file extractor.FileInput) []types.Entity
 	// by a `namespace_name` prefix. Tree-sitter PHP exposes the prefix
 	// directly as a sibling child of the declaration node.
 	var prefix string
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i := range int(node.ChildCount()) {
 		ch := node.Child(i)
 		switch ch.Type() {
 		case "namespace_name":
@@ -211,7 +211,7 @@ func buildUseImports(node *sitter.Node, file extractor.FileInput) []types.Entity
 	// `namespace_use_clause` children. (PHP allows comma-separated
 	// clauses like `use Foo, Bar;` though it's rare.)
 	var out []types.EntityRecord
-	for i := 0; i < int(node.ChildCount()); i++ {
+	for i := range int(node.ChildCount()) {
 		ch := node.Child(i)
 		if ch.Type() != "namespace_use_clause" {
 			continue
@@ -232,7 +232,7 @@ func buildUseGroup(group *sitter.Node, file extractor.FileInput, prefix string) 
 		return nil
 	}
 	var out []types.EntityRecord
-	for i := 0; i < int(group.ChildCount()); i++ {
+	for i := range int(group.ChildCount()) {
 		ch := group.Child(i)
 		// Tree-sitter PHP uses `namespace_use_group_clause` for grouped
 		// imports and `namespace_use_clause` for non-grouped — accept
@@ -254,7 +254,7 @@ func buildUseGroup(group *sitter.Node, file extractor.FileInput, prefix string) 
 // stripping any trailing `as Alias` segment. Returns "" when the clause
 // has no qualified_name child (defensive — malformed input).
 func useClauseFQN(clause *sitter.Node, src []byte) string {
-	for i := 0; i < int(clause.ChildCount()); i++ {
+	for i := range int(clause.ChildCount()) {
 		ch := clause.Child(i)
 		// `qualified_name` / `name` cover plain `use` clauses;
 		// `namespace_name` covers `namespace_use_group_clause` children

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -5,7 +5,8 @@
 //   - interface_declaration → Kind="SCOPE.Component", Subtype="interface"
 //   - method_declaration    → Kind="SCOPE.Operation", Subtype="method"
 //   - function_definition   → Kind="SCOPE.Operation", Subtype="function"
-//   - namespace_definition  → IMPORTS relationship
+//   - namespace_definition       → IMPORTS relationship (file → own namespace)
+//   - namespace_use_declaration  → IMPORTS relationship (file → imported FQN)
 //
 // The extractor registers itself via init() and is auto-imported by the
 // generated registry_gen.go.
@@ -73,6 +74,17 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 
 	case "namespace_definition":
 		if rec, ok := buildNamespace(node, file); ok {
+			*out = append(*out, rec)
+		}
+
+	case "namespace_use_declaration":
+		// Issue #102: emit one IMPORTS edge per `use` statement so the
+		// synth allowlist (Symfony\, Doctrine\, Twig\, Psr\, ...) can
+		// classify the FQN as ExternalKnown via the `\`-separator
+		// branch in classifyExternal. Without this every `use Foo\Bar;`
+		// would be invisible to the resolver and the bug-rate stays
+		// pinned to whatever extractor emitted before #102.
+		for _, rec := range buildUseImports(node, file) {
 			*out = append(*out, rec)
 		}
 	}
@@ -161,6 +173,131 @@ func buildNamespace(node *sitter.Node, file extractor.FileInput) (types.EntityRe
 			},
 		},
 	}, true
+}
+
+// buildUseImports emits one IMPORTS edge per imported symbol on a
+// `namespace_use_declaration` node. Issue #102.
+//
+// PHP `use` shapes handled:
+//   - simple:    use Foo\Bar;                 → IMPORTS Foo\Bar
+//   - aliased:   use Foo\Bar as B;            → IMPORTS Foo\Bar (alias dropped)
+//   - function:  use function Foo\helper;     → IMPORTS Foo\helper
+//   - const:     use const Foo\PI;            → IMPORTS Foo\PI
+//   - grouped:   use Foo\Bar\{A, B as C};     → IMPORTS Foo\Bar\A, Foo\Bar\B
+//
+// Aliases are intentionally stripped: the synth allowlist matches on the
+// root namespace segment (Symfony, Doctrine, Twig, ...), so emitting the
+// canonical FQN gives the synth `\`-branch a clean root to classify.
+func buildUseImports(node *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+	if node == nil {
+		return nil
+	}
+
+	// Detect grouped use: a child of type "namespace_use_group" preceded
+	// by a `namespace_name` prefix. Tree-sitter PHP exposes the prefix
+	// directly as a sibling child of the declaration node.
+	var prefix string
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		switch ch.Type() {
+		case "namespace_name":
+			prefix = strings.TrimSpace(string(file.Content[ch.StartByte():ch.EndByte()]))
+		case "namespace_use_group":
+			return buildUseGroup(ch, file, prefix)
+		}
+	}
+
+	// Simple/aliased/function/const forms — one or more
+	// `namespace_use_clause` children. (PHP allows comma-separated
+	// clauses like `use Foo, Bar;` though it's rare.)
+	var out []types.EntityRecord
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() != "namespace_use_clause" {
+			continue
+		}
+		fqn := useClauseFQN(ch, file.Content)
+		if fqn == "" {
+			continue
+		}
+		out = append(out, useImportRecord(fqn, file.Path))
+	}
+	return out
+}
+
+// buildUseGroup expands a `namespace_use_group` node by joining each
+// clause's name onto the shared prefix. Issue #102.
+func buildUseGroup(group *sitter.Node, file extractor.FileInput, prefix string) []types.EntityRecord {
+	if group == nil || prefix == "" {
+		return nil
+	}
+	var out []types.EntityRecord
+	for i := 0; i < int(group.ChildCount()); i++ {
+		ch := group.Child(i)
+		// Tree-sitter PHP uses `namespace_use_group_clause` for grouped
+		// imports and `namespace_use_clause` for non-grouped — accept
+		// both so the code is robust to grammar revisions.
+		if ch.Type() != "namespace_use_group_clause" && ch.Type() != "namespace_use_clause" {
+			continue
+		}
+		tail := useClauseFQN(ch, file.Content)
+		if tail == "" {
+			continue
+		}
+		fqn := prefix + "\\" + strings.TrimPrefix(tail, "\\")
+		out = append(out, useImportRecord(fqn, file.Path))
+	}
+	return out
+}
+
+// useClauseFQN returns the qualified-name text of a namespace_use_clause,
+// stripping any trailing `as Alias` segment. Returns "" when the clause
+// has no qualified_name child (defensive — malformed input).
+func useClauseFQN(clause *sitter.Node, src []byte) string {
+	for i := 0; i < int(clause.ChildCount()); i++ {
+		ch := clause.Child(i)
+		// `qualified_name` / `name` cover plain `use` clauses;
+		// `namespace_name` covers `namespace_use_group_clause` children
+		// (group imports), which wrap the trailing segment in a
+		// namespace_name even when it's a single name.
+		switch ch.Type() {
+		case "qualified_name", "name", "namespace_name":
+			return strings.TrimSpace(string(src[ch.StartByte():ch.EndByte()]))
+		}
+	}
+	// Fallback: take clause text up to " as ".
+	raw := strings.TrimSpace(string(src[clause.StartByte():clause.EndByte()]))
+	if idx := strings.Index(raw, " as "); idx > 0 {
+		raw = raw[:idx]
+	}
+	return strings.TrimSpace(raw)
+}
+
+// useImportRecord builds a SCOPE.Component placeholder + IMPORTS edge
+// for a single PHP use-statement target. The component Name is the top
+// namespace segment (Symfony, Doctrine, App, ...) — same convention as
+// buildNamespace — so emitting the same `use` from multiple files
+// idempotently merges to one Component per top-level namespace.
+func useImportRecord(fqn, srcPath string) types.EntityRecord {
+	// Strip leading '\' (PHP allows fully-qualified `use \Foo\Bar`).
+	fqn = strings.TrimPrefix(fqn, "\\")
+	top := fqn
+	if idx := strings.Index(fqn, "\\"); idx >= 0 {
+		top = fqn[:idx]
+	}
+	return types.EntityRecord{
+		Name:       top,
+		Kind:       "SCOPE.Component",
+		SourceFile: srcPath,
+		Language:   "php",
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID: srcPath,
+				ToID:   fqn,
+				Kind:   "IMPORTS",
+			},
+		},
+	}
 }
 
 // childFieldText extracts the text of a named child field.

--- a/internal/extractors/php/php_test.go
+++ b/internal/extractors/php/php_test.go
@@ -292,6 +292,62 @@ func TestPHPExtractor_UnregisteredLanguage(t *testing.T) {
 	}
 }
 
+// TestPHPExtractor_UseStatementImports covers issue #102: every PHP
+// `use` statement should emit an IMPORTS edge whose ToID is the FQN
+// of the imported symbol. Without this the synth allowlist never sees
+// the Symfony / Doctrine roots and they all land in bug-extractor.
+func TestPHPExtractor_UseStatementImports(t *testing.T) {
+	src := `<?php
+
+namespace App\Form;
+
+use App\Entity\Post;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\FormBuilderInterface as FBI;
+use function Symfony\Component\String\u;
+use const Symfony\Component\HttpFoundation\Cookie\SAMESITE_LAX;
+use Symfony\Component\HttpFoundation\{Request, Response};
+
+class PostType extends AbstractType {}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("php")
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "src/Form/PostType.php",
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantImports := map[string]bool{
+		"App\\Entity\\Post":                                        false,
+		"Symfony\\Component\\Form\\AbstractType":                   false,
+		"Symfony\\Component\\Form\\FormBuilderInterface":           false,
+		"Symfony\\Component\\String\\u":                            false,
+		"Symfony\\Component\\HttpFoundation\\Cookie\\SAMESITE_LAX": false,
+		"Symfony\\Component\\HttpFoundation\\Request":              false,
+		"Symfony\\Component\\HttpFoundation\\Response":             false,
+	}
+	for _, e := range got {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if _, ok := wantImports[r.ToID]; ok {
+				wantImports[r.ToID] = true
+			}
+		}
+	}
+	for fqn, seen := range wantImports {
+		if !seen {
+			t.Errorf("expected IMPORTS edge to %q, not found", fqn)
+		}
+	}
+}
+
 func TestPHPExtractor_LineNumbers(t *testing.T) {
 	src := `<?php
 class Alpha {


### PR DESCRIPTION
Closes part of #102 — PHP `use Foo\Bar\Baz` namespace separator is `\`, which `classifyExternal` rejected as a path-separator and dropped every PHP `use`-statement into bug-extractor. Mirrors the Rust `::` fix from #101.

## Summary

- `internal/external/synth.go`: new `\`-separator branch in `classifyExternal` (gated on `isPhpNamespaceIdent` — PascalCase ASCII root); add `symfony`, `doctrine`, `twig`, `laravel`, `illuminate`, `psr` to `knownExternalPackages`; lowercase placeholder root for "ext:<lowercase>" convention parity.
- `internal/extractors/php/php.go`: new `namespace_use_declaration` handler emitting one IMPORTS edge per imported FQN. Handles simple, aliased (`as B`), function/const, and grouped (`use Foo\{A, B}`) forms. Without this PHP only emitted the file's own `namespace App\...` declaration — Symfony/Doctrine/Twig imports were invisible to the resolver.
- `App\*` is intentionally absent from the allowlist — project-local resolution is out of scope.

## Measured on symfony-demo

| metric | before | after |
| --- | ---: | ---: |
| bug_rate | 80.31% | **73.30%** |
| external-known | 1 | 197 |
| endpoints | 716 | 1262 |

Issue acceptance target is `≤40%`. Reaching it requires resolving `App\*` (project-local) namespace references against local entities — that work is **out of scope for #102** (cross-file PHP namespace-aware resolution, parallel to #93's Python work). Synth-side fix alone caps at ~73% while ~350 `App\*` edges remain unresolvable from this layer.

## Test plan

- [x] `go test ./...` all green (added `TestSynthesize_PhpBackslashNamespace`, `TestSynthesize_PhpAppNamespaceLeftAlone`, `TestPHPExtractor_UseStatementImports`)
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] VERIFY-2 measured against `symfony-demo` (single-repo)