### PR TITLE
fix(synth): Go stdlib bare-Pascal method names allowlist (Refs #103)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -64,8 +64,17 @@ func Synthesize(doc *graph.Document) Stats {
 	// external that already exists in the document. Re-runs of this
 	// pass on the same document must be idempotent.
 	known := make(map[string]bool, len(doc.Entities))
+	// entityLang maps every entity ID to its declared language so the
+	// classifier can apply per-language bare-name allowlists (issue #103
+	// — Go stdlib/framework Pascal-case method names that arrive at the
+	// resolver after the extractor strips the receiver). Lookups against
+	// non-existent IDs return "" (the zero value), which falls back to
+	// the language-agnostic stop-list — matching pre-#103 behaviour for
+	// every relationship whose FromID isn't a known entity.
+	entityLang := make(map[string]string, len(doc.Entities))
 	for k := range doc.Entities {
 		known[doc.Entities[k].ID] = true
+		entityLang[doc.Entities[k].ID] = doc.Entities[k].Language
 	}
 
 	// First pass — collect every unique external name we want to
@@ -90,7 +99,7 @@ func Synthesize(doc *graph.Document) Stats {
 		if rel.ToID == "" || isHexID(rel.ToID) || strings.HasPrefix(rel.ToID, ExtIDPrefix) {
 			continue
 		}
-		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind)
+		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID])
 		if !ok {
 			continue
 		}
@@ -168,7 +177,7 @@ func Synthesize(doc *graph.Document) Stats {
 // Returns ("", "", false) when the stub doesn't look external — those
 // are left untouched and continue to count as "unmatched" in the
 // resolver stats.
-func classifyExternal(stub, relKind string) (canonical, subtype string, ok bool) {
+func classifyExternal(stub, relKind, lang string) (canonical, subtype string, ok bool) {
 	if stub == "" {
 		return "", "", false
 	}
@@ -351,7 +360,7 @@ func classifyExternal(stub, relKind string) (canonical, subtype string, ok bool)
 	}
 
 	// Stdlib function stop-list — bare names like "Println", "print".
-	if subtype, ok := stdlibFunction(name); ok {
+	if subtype, ok := stdlibFunction(name, lang); ok {
 		return name, subtype, true
 	}
 
@@ -443,9 +452,19 @@ func isNpmSegment(s string) bool {
 // the small per-language stop-list. Kept deliberately small — v1.0
 // catches the highest-volume bare-name calls without ballooning into
 // a full stdlib catalogue.
-func stdlibFunction(name string) (string, bool) {
+func stdlibFunction(name, lang string) (string, bool) {
 	if _, ok := stdlibBareNames[name]; ok {
 		return "function", true
+	}
+	// Per-language allowlists — gated so a Go-only Pascal-case name like
+	// "ServeHTTP" or "EncodeToString" doesn't shadow user-defined methods
+	// in other ecosystems. Fall through to ("", false) when lang is empty
+	// (relationships whose FromID isn't a known entity); the result
+	// matches the pre-gating behaviour for those edges.
+	if lang == "go" {
+		if _, ok := goBareNames[name]; ok {
+			return "function", true
+		}
 	}
 	return "", false
 }
@@ -603,6 +622,59 @@ var stdlibBareNames = map[string]struct{}{
 	// Per-language Rust prelude allowlist filed as follow-up.
 	"assert_eq": {},
 	"assert_ne": {},
+}
+
+// goBareNames is the Go-language-gated bare-Pascal stop-list (issue
+// #103). After the Go extractor strips the receiver from a method call
+// (`w.Write(buf)` → `Write`, `r.Header().Set(...)` → `Header`), the
+// resolver sees a bare PascalCase name that can't be matched to a local
+// entity and lands in bug-extractor. These names are stdlib method
+// identifiers from net/http, encoding/base64, encoding/hex, crypto/
+// subtle, fmt, and strconv — high-volume in Go web codebases (gin/chi/
+// echo) and extremely unlikely to be user-defined receiver methods on
+// a Go type (PascalCase + multi-word + tied to specific stdlib APIs).
+//
+// Conservative selection rule: include only names that are unambiguous
+// stdlib method identifiers OR have a strong stdlib idiom signature.
+// Single-word framework verbs (Get, Post, Put, Delete, Use) are
+// deliberately EXCLUDED — they collide trivially with user methods on
+// any domain type (Repository.Get, Service.Use, etc.). When doubt
+// exists about user-method collision, omit; a missed external is
+// strictly better than a synthesised placeholder shadowing a real
+// missing-resolution bug (lesson from #94).
+var goBareNames = map[string]struct{}{
+	// net/http server-side method receivers (ResponseWriter, Request,
+	// Handler, Server). Multi-word PascalCase, deeply tied to net/http
+	// — no plausible collision with user types.
+	"ServeHTTP":      {},
+	"ListenAndServe": {},
+	"HandleFunc":     {},
+	"WriteHeader":    {},
+	// "Write" / "Header" / "Handle" deliberately omitted: they are
+	// frequent user-method names (io.Writer.Write user-implementations,
+	// custom Header() accessors, generic Handle handlers) and gating by
+	// language alone is not enough to keep them safe.
+
+	// encoding/base64, encoding/hex — package-level helpers commonly
+	// invoked through a package-qualified call that the receiver-strip
+	// reduces to a bare name.
+	"EncodeToString": {},
+	"DecodeString":   {},
+
+	// crypto/subtle — single high-volume name, no plausible collision.
+	"ConstantTimeCompare": {},
+
+	// strconv — Pascal-case stdlib helpers. "Quote" is a common chi/gin
+	// router-helper-adjacent call; Atoi/Itoa are stdlib-only idioms.
+	"Atoi":  {},
+	"Itoa":  {},
+	"Quote": {},
+
+	// Web-framework method names that are unlikely-as-user-methods
+	// (multi-word PascalCase tied to gin/chi/echo handler types). Per
+	// issue #103 hard rules: Get/Post/Put/Delete/Use are EXCLUDED.
+	"MethodFunc":      {},
+	"AbortWithStatus": {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -453,7 +453,7 @@ func TestStdlibBareNames_NoCollisionNames(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := stdlibFunction(name); ok {
+			if _, ok := stdlibFunction(name, ""); ok {
 				t.Fatalf("stdlibFunction(%q) classified as stdlib bare-name; "+
 					"this name commonly collides with user-defined methods "+
 					"and must not synthesise a placeholder", name)
@@ -488,7 +488,7 @@ func TestStdlibBareNames_RustAssertMacros(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name)
+			subtype, ok := stdlibFunction(name, "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q) = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -692,5 +692,178 @@ func TestSynthesize_PhpAppNamespaceLeftAlone(t *testing.T) {
 		if doc.Relationships[k].ToID != s {
 			t.Fatalf("case %q: ToID was rewritten to %q, expected unchanged", s, doc.Relationships[k].ToID)
 		}
+	}
+}
+
+// TestGoBareNames_ClassifiedWhenLangIsGo locks in issue #103: bare
+// PascalCase Go stdlib/framework method names that arrive at the
+// resolver after the extractor strips the receiver (e.g. `w.Write(buf)`
+// → `Write`, `r.ServeHTTP(...)` → `ServeHTTP`) must classify as
+// stdlib bare-names — but only when the source entity's language is
+// "go". The same name in another language must fall through to the
+// language-agnostic path so user-defined methods aren't shadowed.
+func TestGoBareNames_ClassifiedWhenLangIsGo(t *testing.T) {
+	names := []string{
+		"ServeHTTP",
+		"ListenAndServe",
+		"HandleFunc",
+		"WriteHeader",
+		"EncodeToString",
+		"DecodeString",
+		"ConstantTimeCompare",
+		"Atoi",
+		"Itoa",
+		"Quote",
+		"MethodFunc",
+		"AbortWithStatus",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Direct stdlibFunction probe with lang="go" must classify.
+			subtype, ok := stdlibFunction(name, "go")
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"go\") = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"go\") subtype=%q, want %q", name, subtype, "function")
+			}
+			// End-to-end: Synthesize on a document whose FromID entity
+			// is tagged language="go" rewrites the edge to ext:<name>.
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "go-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "go",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "go-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestGoBareNames_NotClassifiedForOtherLanguages confirms the
+// language gate: the same Go-only Pascal-case names must NOT be
+// rewritten when the source entity's language is anything other than
+// "go". Without the gate, a user-defined `WriteHeader` method on a
+// Python or JS class would be shadowed by a synthesised placeholder.
+func TestGoBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	names := []string{"ServeHTTP", "EncodeToString", "AbortWithStatus", "Atoi"}
+	otherLangs := []string{"python", "javascript", "rust", "java", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang); ok {
+					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+						"(name is gated to lang=\"go\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Go)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestGoBareNames_UserMethodCollisionExclusions confirms that names
+// rejected as too-likely-to-collide-with-user-methods stay
+// fall-through even with lang="go". Per issue #103 hard rules:
+// Get/Post/Put/Delete/Use must NOT be in the allowlist; per the
+// internal review Write/Header/Handle were also excluded as too
+// collision-prone (io.Writer.Write user-implementations, Header()
+// accessors, generic Handle handlers).
+func TestGoBareNames_UserMethodCollisionExclusions(t *testing.T) {
+	excluded := []string{
+		// Hard-rule exclusions from issue #103.
+		"Get", "Post", "Put", "Delete", "Use",
+		// Internal-review exclusions (collision-prone PascalCase).
+		"Write", "Header", "Handle",
+	}
+	for _, name := range excluded {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := stdlibFunction(name, "go"); ok {
+				t.Fatalf("stdlibFunction(%q, \"go\") classified; want fall-through "+
+					"(name is too-likely to be a user-defined method)", name)
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "go-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "go",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "go-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 0 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (excluded)", name, stats.Synthesized)
+			}
+			if doc.Relationships[0].ToID != name {
+				t.Fatalf("ToID=%q, want %q (excluded name must not be rewritten)",
+					doc.Relationships[0].ToID, name)
+			}
+		})
+	}
+}
+
+// TestGoBareNames_UnknownGoMethodFallsThrough confirms that a
+// PascalCase Go-source method name that ISN'T in the goBareNames
+// allowlist still falls through normally, so genuine missing-
+// resolution bugs continue to surface in bug-extractor.
+func TestGoBareNames_UnknownGoMethodFallsThrough(t *testing.T) {
+	name := "MyHandler" // Not stdlib; user-defined method.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "go-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "go",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "go-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user method)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
 	}
 }


### PR DESCRIPTION
## Summary

After the Go extractor strips the receiver from method calls
(`w.Write(buf)` → `Write`, `r.ServeHTTP(...)` → `ServeHTTP`), bare
PascalCase stdlib method identifiers reach the resolver and land in
bug-extractor. This is the highest-volume Go bug-extractor pattern.

Add a Go-language-gated `goBareNames` allowlist for the names whose
shape is unambiguously stdlib/framework and unlikely to be user-defined
methods on a Go type. Per-language gating is threaded through
`classifyExternal(stub, kind, lang)` and `stdlibFunction(name, lang)`,
with `lang` looked up from the FromID entity. Non-Go sources are
unaffected.

## Names added

- `net/http` (multi-word PascalCase, no plausible user collision):
  `ServeHTTP`, `ListenAndServe`, `HandleFunc`, `WriteHeader`
- `encoding/base64` + `encoding/hex`: `EncodeToString`, `DecodeString`
- `crypto/subtle`: `ConstantTimeCompare`
- `strconv`: `Atoi`, `Itoa`, `Quote`
- Framework (unambiguously gin/chi/echo handler API):
  `MethodFunc`, `AbortWithStatus`

## Names considered but rejected

Per the #103 hard rules: `Get`, `Post`, `Put`, `Delete`, `Use` —
trivially collide with `Repository.Get`, `Service.Use`, etc.

Internal review additions to the rejection list: `Write`, `Header`,
`Handle` — io.Writer.Write user-implementations, custom `Header()`
accessors, and generic `Handle` handlers all collide. Language gating
alone is not sufficient protection.

## Measured impact (single-repo VERIFY-2)

| repo | baseline bug_rate | new bug_rate | delta |
|------|-------------------|--------------|-------|
| gin  | 50.93%            | 50.57%       | -0.36pp (79 edges reclassified) |
| chi  | 51.82%            | 50.36%       | -1.46pp (106 edges reclassified) |

The targeted bare-name pattern is hit cleanly — every reclassified edge
moves from `bug-extractor` into `external-known` / `external-unknown`.

The #103 acceptance target of ≤35% is **not** met by this change alone.
Remaining bug volume in gin/chi is dominated by:
- testify helpers (`Equal`, `NoError`, `NewRecorder`, `Contains`,
  `Empty`, `True`, `False`) — these collide with common user
  identifiers across languages, would need a separate Go-only gate plus
  more nuanced collision analysis.
- Full import-path stubs like `net/http` and
  `github.com/stretchr/testify/assert` — these hit the existing
  `strings.ContainsAny(name, "/\\\\")` rejection in `classifyExternal`
  before reaching the allowlist. Out of scope for #103.

Both gaps should be filed as follow-ups if further bug-rate reduction
on the Go corpus is desired.

## Tests

- `TestGoBareNames_ClassifiedWhenLangIsGo` — every new name classifies
  end-to-end when the FromID entity has language="go".
- `TestGoBareNames_NotClassifiedForOtherLanguages` — same names fall
  through for python/javascript/rust/java/empty.
- `TestGoBareNames_UserMethodCollisionExclusions` — locks in the
  rejection list so future drift adding `Get`/`Post`/etc. fails the
  build.
- `TestGoBareNames_UnknownGoMethodFallsThrough` — a PascalCase name
  not on the allowlist still surfaces as a missing-resolution bug.

## Test plan

- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/external/` clean
- [x] Single-repo VERIFY-2 on go-gin and go-chi compared to main

forbidden-term grep: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)