### PR TITLE
fix(synth): per-language Java stdlib + Spring/JPA bare-name allowlist (Refs #105)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -512,6 +512,11 @@ func stdlibFunction(name, lang string) (string, bool) {
 			return "function", true
 		}
 	}
+	if lang == "java" {
+		if _, ok := javaBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -831,6 +836,101 @@ var rustBareNames = map[string]struct{}{
 	"assert":        {},
 	"debug_assert":  {},
 	"matches":       {},
+}
+
+// javaBareNames is the Java-language-gated bare-name stop-list (issue
+// #105). After the Java extractor strips the receiver from a method
+// call (`repo.findById(id)` → `findById`, `optional.orElseThrow()` →
+// `orElseThrow`), the resolver sees a bare name that can't be matched
+// to a local entity and lands in bug-extractor. The names below are
+// JDK exception classes plus the most distinctive Spring Data /
+// Spring MVC / Spring binding helper methods.
+//
+// Conservative selection rule (lesson from #94): include only names
+// whose plausible-user-method-collision rate is low. Generic
+// getters/setters (`getId`, `getName`, `getValue`, `setName`,
+// `setValue`) and ubiquitous functional verbs (`map`, `filter`,
+// `forEach`, `collect`, `stream`) are deliberately EXCLUDED — the
+// proper resolution for those is cross-class receiver binding (the
+// (A) follow-up to issue #105). When doubt exists, omit; a missed
+// external is strictly better than a synthesised placeholder
+// shadowing a real missing-resolution bug.
+//
+// Categories (curated, not exhaustive):
+//   - JDK stdlib exception class names (constructed bare or referenced
+//     bare in `throws`/`catch` clauses post-receiver-strip).
+//   - JDK Optional helpers — only the four where collision risk is
+//     low. `map`/`flatMap` excluded because every user collection
+//     method named `map` would be shadowed.
+//   - Spring Data JPA repository methods with distinctive shapes
+//     (`findById`, `saveAndFlush`, etc.). Verbs like `delete` /
+//     `find` alone are excluded; the JpaRepository names listed
+//     here have a low natural-method-collision rate.
+//   - Spring `BindingResult` validation helpers.
+//   - Spring `Model` / `RedirectAttributes` flash-attribute helpers.
+//   - Spring Data `Pageable` / `Page` accessors.
+var javaBareNames = map[string]struct{}{
+	// JDK stdlib exception classes — constructor and reference forms.
+	"IllegalArgumentException":      {},
+	"NullPointerException":          {},
+	"IllegalStateException":         {},
+	"UnsupportedOperationException": {},
+	"RuntimeException":              {},
+	"IndexOutOfBoundsException":     {},
+	"ClassCastException":            {},
+	"NumberFormatException":         {},
+	"ArithmeticException":           {},
+	"IOException":                   {},
+	"FileNotFoundException":         {},
+	"InterruptedException":          {},
+	"Error":                         {},
+	"Throwable":                     {},
+	// `Exception` is already covered by the language-agnostic
+	// stdlibBareNames map (it's also a Python builtin), so it does
+	// NOT need to live here.
+
+	// JDK java.util.Optional helpers — the four with low collision
+	// risk. `map`/`flatMap`/`filter` are deliberately excluded:
+	// every Java codebase that does anything with collections has
+	// at least one user method named `map` or `filter`, and the
+	// language gate alone is not strong enough.
+	"orElseThrow": {},
+	"orElse":      {},
+	"ifPresent":   {},
+	"isPresent":   {},
+
+	// Spring Data JPA repository methods. Distinctive shapes only —
+	// generic verbs (`find`, `delete`, `update`) are excluded.
+	"findById":     {},
+	"findAll":      {},
+	"findAllById":  {},
+	"save":         {},
+	"saveAll":      {},
+	"saveAndFlush": {},
+	"deleteById":   {},
+	"deleteAll":    {},
+	"existsById":   {},
+	"count":        {},
+
+	// Spring BindingResult validation helpers.
+	"hasErrors":     {},
+	"rejectValue":   {},
+	"getFieldError": {},
+
+	// Spring Model / RedirectAttributes flash-attribute helpers.
+	// `addAttribute` is generic enough to cover some user code
+	// collisions but the lang="java" gate keeps the rewrite scoped
+	// to Java sources only.
+	"addFlashAttribute": {},
+	"addAttribute":      {},
+
+	// Spring Data Pageable / Page accessors.
+	"getTotalElements": {},
+	"getTotalPages":    {},
+	"getNumber":        {},
+	"getSize":          {},
+	"hasNext":          {},
+	"hasPrevious":      {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1202,3 +1202,171 @@ func TestRustBareNames_UnknownRustMethodFallsThrough(t *testing.T) {
 			doc.Relationships[0].ToID, name)
 	}
 }
+
+// TestJavaBareNames_ClassifiedWhenLangIsJava covers issue #105 fix
+// (B): JDK stdlib exception classes plus high-frequency Spring/JPA
+// repository, BindingResult, Model, and Pageable helper bare-names
+// must classify as stdlib bare-names — but only when the source
+// entity's language is "java". One representative name per category
+// is exercised; the full list is asserted via the per-name test
+// below.
+func TestJavaBareNames_ClassifiedWhenLangIsJava(t *testing.T) {
+	names := []string{
+		// JDK exceptions
+		"IllegalArgumentException", "NullPointerException",
+		"IllegalStateException", "UnsupportedOperationException",
+		"RuntimeException", "IndexOutOfBoundsException",
+		"ClassCastException", "NumberFormatException",
+		"ArithmeticException", "IOException", "FileNotFoundException",
+		"InterruptedException", "Error", "Throwable",
+		// JDK Optional helpers
+		"orElseThrow", "orElse", "ifPresent", "isPresent",
+		// Spring Data JPA repository methods
+		"findById", "findAll", "findAllById", "save", "saveAll",
+		"saveAndFlush", "deleteById", "deleteAll", "existsById", "count",
+		// Spring BindingResult helpers
+		"hasErrors", "rejectValue", "getFieldError",
+		// Spring Model / RedirectAttributes
+		"addFlashAttribute", "addAttribute",
+		// Spring Pageable / Page accessors
+		"getTotalElements", "getTotalPages", "getNumber", "getSize",
+		"hasNext", "hasPrevious",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "java")
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"java\") = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"java\") subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "java-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "java",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "java-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestJavaBareNames_NotClassifiedForOtherLanguages confirms the
+// language gate: Java-only Spring/JPA names (the high-collision-risk
+// ones like `save`, `count`, `orElse`, `hasNext`) must NOT be
+// rewritten when the source entity's language is anything other
+// than "java". Without the gate, a user-defined `save()` method on
+// a Go service or a JS array `count()` would be shadowed by a
+// synthesised placeholder.
+func TestJavaBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Names that DON'T also appear in language-agnostic
+	// stdlibBareNames. (`Exception` is global and intentionally
+	// omitted from this gate-check.)
+	// `count` deliberately omitted: it's also in rustBareNames so
+	// it classifies under lang="rust"; the gate verified here is
+	// the *Java* gate, not absence-from-all-other-language-gates.
+	names := []string{"save", "orElse", "hasNext", "findById", "findAll", "hasErrors", "IllegalArgumentException"}
+	otherLangs := []string{"go", "python", "javascript", "rust", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang); ok {
+					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+						"(name is gated to lang=\"java\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Java)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestJavaBareNames_RejectedNamesNotClassified locks in the explicit
+// rejection list from issue #105: generic getters/setters and
+// ubiquitous functional verbs MUST NOT be in the Java allowlist.
+// Resolution for those names is the responsibility of the (A)
+// follow-up — cross-file receiver binding. Adding them here would
+// shadow any user-defined `getId()` / `getName()` / `map()` /
+// `filter()` method on a Java type and turn a real missing-resolution
+// bug into a silent placeholder.
+func TestJavaBareNames_RejectedNamesNotClassified(t *testing.T) {
+	rejected := []string{
+		// Generic getters/setters — every entity has them.
+		"getId", "getName", "getValue", "setName", "setValue",
+		// Ubiquitous functional verbs.
+		"map", "filter", "forEach", "stream",
+		// `collect` is global-collision; gated out of the Java map.
+		"collect",
+	}
+	for _, name := range rejected {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := javaBareNames[name]; ok {
+				t.Fatalf("javaBareNames[%q] present; must be rejected per issue #105 (A) deferral", name)
+			}
+		})
+	}
+}
+
+// TestJavaBareNames_UnknownJavaMethodFallsThrough confirms that a
+// Java-source bare-name call that ISN'T in the javaBareNames
+// allowlist still falls through normally, so genuine missing-
+// resolution bugs continue to surface in bug-extractor.
+func TestJavaBareNames_UnknownJavaMethodFallsThrough(t *testing.T) {
+	name := "myCustomBusinessMethod" // Not stdlib/Spring; user-defined.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "java-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "java",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "java-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user fn)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
+	}
+}


### PR DESCRIPTION
## Summary

Issue #105 partial fix (B) — adds a Java-language-gated bare-name allowlist for JDK stdlib exception classes plus the most distinctive Spring Data JPA / BindingResult / Model / Pageable helpers. Mirrors the Go (#103, PR #114) and Rust (#108, PR #118) per-language gates.

After the Java extractor strips a method-call receiver (`repo.findById(id)` → `findById`, `optional.orElseThrow()` → `orElseThrow`), the resolver previously landed every such bare name in bug-extractor. With this fix, the allowlisted names classify as external-known.

Conservative scope (lesson from #94): generic getters/setters (`getId`, `getName`, `getValue`, `setName`, `setValue`) and ubiquitous functional verbs (`map`, `filter`, `forEach`, `collect`, `stream`) are explicitly REJECTED and locked in by a regression test. Resolution for those belongs to the cross-file receiver-binding follow-up — fix (A) to issue #105.

## Names added

- **JDK stdlib exception classes**: `IllegalArgumentException`, `NullPointerException`, `IllegalStateException`, `UnsupportedOperationException`, `RuntimeException`, `IndexOutOfBoundsException`, `ClassCastException`, `NumberFormatException`, `ArithmeticException`, `IOException`, `FileNotFoundException`, `InterruptedException`, `Error`, `Throwable` (`Exception` already covered globally).
- **JDK Optional helpers**: `orElseThrow`, `orElse`, `ifPresent`, `isPresent`. (`map`/`flatMap`/`filter` excluded — too common as user methods.)
- **Spring Data JPA repository methods**: `findById`, `findAll`, `findAllById`, `save`, `saveAll`, `saveAndFlush`, `deleteById`, `deleteAll`, `existsById`, `count`.
- **Spring `BindingResult`**: `hasErrors`, `rejectValue`, `getFieldError`.
- **Spring `Model` / `RedirectAttributes`**: `addFlashAttribute`, `addAttribute`.
- **Spring Data `Pageable` / `Page`**: `getTotalElements`, `getTotalPages`, `getNumber`, `getSize`, `hasNext`, `hasPrevious`.

## VERIFY-2 (java/spring-petclinic)

| metric                  | before  | after   |
| ----------------------- | ------: | ------: |
| bug-rate                | 61.68 % | 60.09 % |
| resolution-rate         | 31.54 % | 31.54 % |
| external-known + unknown |   218  |   288   |

The ≤35 % acceptance target is **not** reachable from the bare-name fallback alone — the dominant remaining bug-extractor categories on spring-petclinic are `bare-other` (798 edges, only ~70 hit the allowlist) and `dotted-lower-head` IMPORTS (538 edges). Both require Java cross-file receiver binding — follow-up issue filed.

## Test plan

- [x] `go test ./internal/external/...` — green (4 new tests, ~50 sub-tests)
- [x] `go test ./...` — green
- [x] `go vet ./...` — clean
- [x] `gofmt -l internal/external/` — clean
- [x] VERIFY-2 single-repo on spring-petclinic — bug-rate drop confirmed
- [x] forbidden-term grep: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)