### PR TITLE
fix(kotlin): keyword filter + stdlib bare-name allowlist (Refs #106)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -517,6 +517,11 @@ func stdlibFunction(name, lang string) (string, bool) {
 			return "function", true
 		}
 	}
+	if lang == "kotlin" {
+		if _, ok := kotlinBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -933,6 +938,94 @@ var javaBareNames = map[string]struct{}{
 	"hasPrevious":      {},
 }
 
+// kotlinBareNames is the Kotlin-language-gated bare-name stop-list
+// (issue #106). The Kotlin extractor strips the receiver from a call
+// (`flow.collect { ... }` → `collect`, `Channel(capacity)` →
+// `Channel`), and the resolver can't bind the bare name to a local
+// entity, so it lands in bug-extractor. The names below are
+// kotlinx.coroutines / io.ktor stdlib types, kotlin.collections /
+// kotlin builtins, scope functions, and contract / lazy helpers that
+// have a low collision rate with user-defined identifiers in real
+// Kotlin codebases.
+//
+// Conservative selection rule (lessons from #94 / #105): generic
+// getters/setters/collection ops (`get`, `set`, `add`, `remove`,
+// `size`, `isEmpty`) are deliberately EXCLUDED — every Kotlin
+// codebase has user methods with those names and the language gate
+// alone is not strong enough to prevent shadowing real
+// missing-resolution bugs.
+//
+// Categories (curated, not exhaustive):
+//   - kotlinx.coroutines / io.ktor common Pascal-case stdlib types.
+//   - kotlin.collections / kotlin builtins (factory functions).
+//   - scope functions (`let`, `also`, `apply`, `run`, `with`) — KEPT
+//     Kotlin-gated because `let` could plausibly shadow a JS
+//     user-variable name.
+//   - kotlin.contract / lazy / require helpers.
+var kotlinBareNames = map[string]struct{}{
+	// kotlinx.coroutines / io.ktor stdlib types (Pascal).
+	"Frame":                {},
+	"CloseReason":          {},
+	"CopyOnWriteArrayList": {},
+	"ConcurrentHashMap":    {},
+	"AtomicInteger":        {},
+	"AtomicLong":           {},
+	"AtomicBoolean":        {},
+	"AtomicReference":      {},
+	"Job":                  {},
+	"Deferred":             {},
+	"Channel":              {},
+	"CoroutineScope":       {},
+	"MutableStateFlow":     {},
+	"StateFlow":            {},
+	"MutableSharedFlow":    {},
+	"SharedFlow":           {},
+	"Flow":                 {},
+	"ApplicationCall":      {},
+	"Application":          {},
+	"Route":                {},
+	"Routing":              {},
+	"WebSocketSession":     {},
+
+	// kotlin.collections / kotlin builtins (factory functions).
+	"listOf":        {},
+	"mapOf":         {},
+	"setOf":         {},
+	"mutableListOf": {},
+	"mutableMapOf":  {},
+	"mutableSetOf":  {},
+	"arrayOf":       {},
+	"arrayListOf":   {},
+	"hashMapOf":     {},
+	"hashSetOf":     {},
+	"linkedSetOf":   {},
+	"sortedSetOf":   {},
+	"emptyList":     {},
+	"emptyMap":      {},
+	"emptySet":      {},
+	"listOfNotNull": {},
+	"mapNotNull":    {},
+
+	// Scope functions — Kotlin-gated. `let` in particular would
+	// shadow JS user-variable names if added to the language-agnostic
+	// list.
+	"let":   {},
+	"also":  {},
+	"apply": {},
+	"run":   {},
+	"with":  {},
+
+	// Contracts / lazy / require helpers.
+	"requireNotNull": {},
+	"checkNotNull":   {},
+	"require":        {},
+	"check":          {},
+	"error":          {},
+	"lazy":           {},
+	"lazyOf":         {},
+	"TODO":           {},
+}
+
 // isKnownExternalPackage reports whether s matches our small allowlist
 // of well-known third-party packages and stdlib top-level modules. The
 // allowlist is intentionally narrow for v1.0 — false positives turn a
@@ -1190,6 +1283,7 @@ var knownExternalPackages = map[string]struct{}{
 	"javax":                 {},
 	"kotlin":                {},
 	"kotlinx":               {},
+	"io.ktor":               {}, // io.ktor.* server / client / websockets (Issue #106)
 	"org.springframework":   {},
 	"com.fasterxml.jackson": {},
 	"com.google.guava":      {},

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1370,3 +1370,164 @@ func TestJavaBareNames_UnknownJavaMethodFallsThrough(t *testing.T) {
 			doc.Relationships[0].ToID, name)
 	}
 }
+
+// TestKotlinBareNames_ClassifiedWhenLangIsKotlin covers issue #106 fix
+// (B): kotlinx.coroutines / io.ktor stdlib types, kotlin.collections
+// builtins, scope functions, and contract / lazy helpers must
+// classify as stdlib bare-names — but only when the source entity's
+// language is "kotlin".
+func TestKotlinBareNames_ClassifiedWhenLangIsKotlin(t *testing.T) {
+	names := []string{
+		// kotlinx.coroutines / io.ktor types
+		"Frame", "CloseReason", "CopyOnWriteArrayList",
+		"ConcurrentHashMap", "AtomicInteger", "AtomicLong",
+		"AtomicBoolean", "AtomicReference", "Job", "Deferred",
+		"Channel", "CoroutineScope", "MutableStateFlow", "StateFlow",
+		"MutableSharedFlow", "SharedFlow", "Flow", "ApplicationCall",
+		"Application", "Route", "Routing", "WebSocketSession",
+		// kotlin.collections / builtins
+		"listOf", "mapOf", "setOf", "mutableListOf", "mutableMapOf",
+		"mutableSetOf", "arrayOf", "arrayListOf", "hashMapOf",
+		"hashSetOf", "linkedSetOf", "sortedSetOf", "emptyList",
+		"emptyMap", "emptySet", "listOfNotNull", "mapNotNull",
+		// scope functions
+		"let", "also", "apply", "run", "with",
+		// contracts / lazy helpers
+		"requireNotNull", "checkNotNull", "require", "check", "error",
+		"lazy", "lazyOf", "TODO",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "kotlin")
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"kotlin\") = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"kotlin\") subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "kt-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "kotlin",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "kt-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestKotlinBareNames_NotClassifiedForOtherLanguages confirms the
+// language gate: Kotlin-only names (`let`, `apply`, `Frame`, `Job`,
+// ...) must NOT be rewritten when the source entity's language is
+// anything other than "kotlin". Without the gate, a JS user variable
+// named `let` or a Go `Job` struct would be shadowed by a synthesised
+// placeholder.
+func TestKotlinBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Names that DON'T also appear in language-agnostic stdlibBareNames.
+	names := []string{"let", "apply", "Frame", "Job", "Channel", "listOf", "lazy", "TODO", "Flow", "checkNotNull"}
+	otherLangs := []string{"go", "python", "javascript", "rust", "java", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang); ok {
+					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+						"(name is gated to lang=\"kotlin\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Kotlin)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestKotlinBareNames_RejectedNamesNotClassified locks in the explicit
+// rejection list from issue #106: generic accessors / collection ops
+// MUST NOT be in the Kotlin allowlist. These names have a high
+// collision rate with user-defined methods on any class.
+func TestKotlinBareNames_RejectedNamesNotClassified(t *testing.T) {
+	rejected := []string{
+		"get", "set", "add", "remove", "size", "isEmpty",
+	}
+	for _, name := range rejected {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := kotlinBareNames[name]; ok {
+				t.Fatalf("kotlinBareNames[%q] present; must be rejected per issue #106 (collision-prone)", name)
+			}
+		})
+	}
+}
+
+// TestKotlinBareNames_UnknownKotlinMethodFallsThrough confirms that a
+// Kotlin-source bare-name call that ISN'T in the kotlinBareNames
+// allowlist still falls through normally, so genuine missing-
+// resolution bugs continue to surface in bug-extractor.
+func TestKotlinBareNames_UnknownKotlinMethodFallsThrough(t *testing.T) {
+	name := "myCustomBusinessMethod" // Not stdlib/kotlinx; user-defined.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "kt-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "kotlin",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "kt-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user fn)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
+	}
+}
+
+// TestIoKtorKnownExternalPackage locks in the issue #106 addition of
+// "io.ktor" to the external-package allowlist so io.ktor.* references
+// classify as ExternalKnown rather than ExternalUnknown.
+func TestIoKtorKnownExternalPackage(t *testing.T) {
+	if !IsKnownExternalPackage("io.ktor") {
+		t.Fatal("IsKnownExternalPackage(\"io.ktor\") = false; want true (Issue #106)")
+	}
+	if !IsKnownExternalPackage("IO.KTOR") {
+		t.Fatal("IsKnownExternalPackage(\"IO.KTOR\") = false; want case-folded match")
+	}
+}

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -179,6 +179,22 @@ func findFunctionBody(node *sitter.Node) *sitter.Node {
 	return nil
 }
 
+// kotlinKeywordStop lists Kotlin keywords and special identifiers that
+// tree-sitter surfaces inside call_expression nodes but are NOT real
+// call targets. Emitting CALLS edges for them sends meaningless
+// bare-name stubs to the resolver, where they land in bug-extractor
+// because no entity matches. Mirrors the Python extractor's
+// `self`/`cls` drop. Issue #106.
+var kotlinKeywordStop = map[string]bool{
+	"synchronized": true,
+	"it":           true,
+	"this":         true,
+	"super":        true,
+	"lateinit":     true,
+	"by":           true,
+	"where":        true,
+}
+
 // extractCallRelationships returns one CALLS RelationshipRecord per unique
 // call_expression descendant of body. The target name is the trailing
 // simple_identifier of the call's expression. FromID is left empty so
@@ -197,6 +213,13 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 	for _, call := range calls {
 		target := kotlinCallTarget(call, src)
 		if target == "" || target == callerName {
+			continue
+		}
+		if kotlinKeywordStop[target] {
+			// Kotlin keywords / special identifiers that the parser
+			// surfaces as call_expression heads but are not real call
+			// targets. Mirrors how the Python extractor drops `self` /
+			// `cls`. Issue #106.
 			continue
 		}
 		if seen[target] {

--- a/internal/extractors/kotlin/relationships_test.go
+++ b/internal/extractors/kotlin/relationships_test.go
@@ -103,6 +103,37 @@ func TestKotlin_CallsBareName(t *testing.T) {
 	}
 }
 
+// TestKotlin_CallsKeywordsFiltered (#106): Kotlin keywords / special
+// identifiers (`synchronized`, `it`, `this`, `super`, `lateinit`,
+// `by`, `where`) must NOT be emitted as CALLS targets — they are not
+// real call sites and the resolver can't bind them to an entity.
+func TestKotlin_CallsKeywordsFiltered(t *testing.T) {
+	src := `class A {
+    fun caller() {
+        synchronized(lock) { work() }
+        list.forEach { println(it) }
+        this.helper()
+        super.toString()
+    }
+    fun helper() {}
+}
+`
+	ents := runKotlin(t, src)
+	caller := ktFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller operation")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		switch r.ToID {
+		case "synchronized", "it", "this", "super", "lateinit", "by", "where":
+			t.Errorf("kotlin keyword %q must not be emitted as CALLS target", r.ToID)
+		}
+	}
+}
+
 // TestKotlin_NoImports (#41): kotlin extractor intentionally does
 // NOT emit IMPORTS edges (Python parity). Guard against future regressions
 // that re-introduce ghost "org" / "com" / "java" entities.


### PR DESCRIPTION
## Summary
- Kotlin extractor drops `synchronized`/`it`/`this`/`super`/`lateinit`/`by`/`where` from CALLS targets — tree-sitter surfaces them as `call_expression` heads but they are not real call sites (mirrors Python `self`/`cls`).
- synth.go: new `kotlinBareNames` allowlist (lang=`kotlin` gated) covering kotlinx.coroutines / io.ktor stdlib types, kotlin.collections builtins, scope functions, and contract/lazy helpers.
- `io.ktor` added to `knownExternalPackages` so dotted import paths classify as ExternalKnown.
- Conservative selection: `get`/`set`/`add`/`remove`/`size`/`isEmpty` deliberately rejected (collision-prone).

## VERIFY-2 ktor-samples
- before: 41.56% bug_rate (baseline from `docs/verify2/issue-91-per-language-bug-extractors.md`)
- after: 36.96% bug_rate (-4.6pp), 60.91% resolution_rate
- 130 placeholders moved out of bug-extractor → external-unknown (Frame, listOf, CloseReason, etc.)
- Remaining delta to 25% target is dominated by field-access stubs (`lastMessages`, `members`, `connections`) — out of scope for the call-target fix in this issue.

## Test plan
- [x] `go test ./internal/external/... ./internal/extractors/kotlin/...` green
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] forbidden-term grep: clean
- [x] VERIFY-2 single-repo on ktor-samples — bug_rate down 4.6pp

Refs #106