### PR TITLE
fix(synth): JS/TS Prisma + array builtins per-language allowlist (Refs #104)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -527,6 +527,11 @@ func stdlibFunction(name, lang string) (string, bool) {
 			return "function", true
 		}
 	}
+	if lang == "javascript" || lang == "typescript" {
+		if _, ok := jsBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -1085,6 +1090,73 @@ var rubyBareNames = map[string]struct{}{
 	"instance_of?": {},
 }
 
+// jsBareNames is the JS/TS-language-gated bare-name stop-list (issue
+// #104). Two families covered:
+//
+//  1. Prisma ORM client method names. The JS extractor strips the
+//     receiver (`prisma.user.findMany(...)` → bare `findMany`), so
+//     the resolver only sees the leaf identifier. These collide with
+//     user methods in OTHER ecosystems (Ruby/Java/Go all have classes
+//     with their own `update`/`delete`/`create` methods) so the
+//     language gate is required.
+//  2. JS/TS array & util builtins (`some`, `every`, `push`, `trim`,
+//     `isArray`) that bare-call after receiver-strip and reach the
+//     resolver as leaf identifiers.
+//
+// Conservative selection rule (lessons from #94 / #105 / #106 / #107):
+// generic collection ops (`map`, `filter`, `forEach`, `reduce`,
+// `find`, `length`, `size`) are deliberately EXCLUDED. They are
+// user-method names on any class in any language and the language
+// gate alone is not strong enough to keep them safe — JS/TS share
+// the `map`/`filter`/`forEach` namespace with hand-rolled domain
+// methods on user classes too readily.
+var jsBareNames = map[string]struct{}{
+	// Prisma ORM client surface (https://www.prisma.io/docs/orm/reference/prisma-client-reference)
+	"findUnique":        {},
+	"findUniqueOrThrow": {},
+	"findFirst":         {},
+	"findFirstOrThrow":  {},
+	"findMany":          {},
+	"createMany":        {},
+	"updateMany":        {},
+	"deleteMany":        {},
+	"upsert":            {},
+	"aggregate":         {},
+	"groupBy":           {},
+	"executeRaw":        {},
+	"executeRawUnsafe":  {},
+	"queryRaw":          {},
+	"queryRawUnsafe":    {},
+	// Prisma `$`-prefixed top-level client methods. `$` is rare in
+	// user-defined identifier names so these are unambiguous.
+	"$connect":     {},
+	"$disconnect":  {},
+	"$transaction": {},
+	"$queryRaw":    {},
+	"$executeRaw":  {},
+	"$on":          {},
+	"$use":         {},
+	// `create`, `update`, `delete`, `count` are intentionally OMITTED.
+	// They overlap heavily with non-Prisma user methods (controllers,
+	// services, factories) and the per-language gate isn't enough.
+	// They land in bug-extractor instead — acceptable trade-off vs
+	// false positives that hide real local entities.
+
+	// JS/TS array & util builtins. Names that bare-call after
+	// receiver-strip (`xs.some(p)` → `some`).
+	"some":    {},
+	"every":   {},
+	"push":    {},
+	"trim":    {},
+	"isArray": {},
+	// `pop` / `shift` / `unshift` / `splice` / `slice` / `concat` /
+	// `join` / `includes` / `indexOf` / `lastIndexOf` / `flat` /
+	// `flatMap` are deliberately OMITTED for this iteration: each is
+	// either too collision-prone (`includes`, `indexOf`) or
+	// insufficiently observed in #104's bug-extractor sample to
+	// justify carrying the false-positive risk.
+}
+
 // isKnownExternalPackage reports whether s matches our small allowlist
 // of well-known third-party packages and stdlib top-level modules. The
 // allowlist is intentionally narrow for v1.0 — false positives turn a
@@ -1220,6 +1292,7 @@ var knownExternalPackages = map[string]struct{}{
 	"@testing-library": {},
 	"@types":           {},
 	"@nestjs":          {},
+	"@prisma":          {},
 	"@apollo":          {},
 	"@mui":             {},
 	"@emotion":         {},

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1637,3 +1637,144 @@ func TestIoKtorKnownExternalPackage(t *testing.T) {
 		t.Fatal("IsKnownExternalPackage(\"IO.KTOR\") = false; want case-folded match")
 	}
 }
+
+// TestJSBareNames_ClassifiedWhenLangIsJSOrTS covers issue #104:
+// Prisma ORM client method names and JS/TS array/util builtins
+// (post-receiver-strip) classify as stdlib bare-names — but only
+// when the source entity's language is "javascript" or "typescript".
+func TestJSBareNames_ClassifiedWhenLangIsJSOrTS(t *testing.T) {
+	names := []string{
+		// Prisma ORM client method surface
+		"findUnique", "findUniqueOrThrow", "findFirst", "findFirstOrThrow",
+		"findMany", "createMany", "updateMany", "deleteMany", "upsert",
+		"aggregate", "groupBy", "executeRaw", "executeRawUnsafe",
+		"queryRaw", "queryRawUnsafe",
+		// `$`-prefixed Prisma client methods
+		"$connect", "$disconnect", "$transaction", "$queryRaw",
+		"$executeRaw", "$on", "$use",
+		// Array / util builtins
+		"some", "every", "push", "trim", "isArray",
+	}
+	for _, name := range names {
+		for _, lang := range []string{"javascript", "typescript"} {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				subtype, ok := stdlibFunction(name, lang)
+				if !ok {
+					t.Fatalf("stdlibFunction(%q, %q) = (_, false); want classified", name, lang)
+				}
+				if subtype != "function" {
+					t.Fatalf("stdlibFunction(%q, %q) subtype=%q, want %q", name, lang, subtype, "function")
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "js-src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "js-src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 1 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 1", name, lang, stats.Synthesized)
+				}
+				want := "ext:" + name
+				if doc.Relationships[0].ToID != want {
+					t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+				}
+			})
+		}
+	}
+}
+
+// TestJSBareNames_NotClassifiedForOtherLanguages confirms the JS/TS
+// language gate: a Ruby user-method named `push`, a Go method named
+// `trim`, etc. must NOT be rewritten when source lang is neither
+// javascript nor typescript.
+func TestJSBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Names that are NOT in language-agnostic stdlibBareNames.
+	names := []string{"findUnique", "findMany", "upsert", "$transaction", "some", "every", "push", "trim", "isArray"}
+	otherLangs := []string{"go", "python", "ruby", "rust", "java", "kotlin", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			// `push` is on the language-specific allowlist for Rust
+			// (rustBareNames covers Vec/String#push). Skip the
+			// Rust-cross-check for that name; the JS/TS gate is what
+			// this test cares about.
+			if name == "push" && lang == "rust" {
+				continue
+			}
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang); ok {
+					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+						"(name is gated to JS/TS only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-JS/TS)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestJSBareNames_RejectedNamesNotClassified locks in the explicit
+// rejection list from issue #104: generic collection ops and overly
+// generic Prisma names collide with user methods on any class and
+// MUST NOT be in the JS/TS allowlist.
+func TestJSBareNames_RejectedNamesNotClassified(t *testing.T) {
+	rejected := []string{
+		// Generic collection ops shared with user methods
+		"map", "filter", "forEach", "reduce", "find", "length", "size",
+		// Generic Prisma names that overlap with non-Prisma domain
+		// methods (services, controllers, factories).
+		"create", "update", "delete", "count",
+	}
+	for _, name := range rejected {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := jsBareNames[name]; ok {
+				t.Fatalf("jsBareNames[%q] present; must be rejected per issue #104 (collision-prone)", name)
+			}
+		})
+	}
+}
+
+// TestPrismaScopedKnownExternalPackage locks in the issue #104
+// addition of "@prisma" (covers @prisma/client, @prisma/extension-*,
+// etc.) to the external-package allowlist so @prisma/* references
+// classify as ExternalKnown rather than ExternalUnknown.
+func TestPrismaScopedKnownExternalPackage(t *testing.T) {
+	if !IsKnownExternalPackage("@prisma/client") {
+		t.Fatal("IsKnownExternalPackage(\"@prisma/client\") = false; want true (Issue #104)")
+	}
+	if !IsKnownExternalPackage("@PRISMA/CLIENT") {
+		t.Fatal("IsKnownExternalPackage(\"@PRISMA/CLIENT\") = false; want case-folded match")
+	}
+	if !IsKnownExternalPackage("prisma") {
+		t.Fatal("IsKnownExternalPackage(\"prisma\") = false; want true (Issue #104)")
+	}
+}


### PR DESCRIPTION
## Summary

Closes the JS/TS gap in the per-language bare-name allowlist (issue #104). Same pattern as #105 / #106 / #107 — gate stdlib/ORM bare-name calls by source language so they don't shadow user methods in other ecosystems.

### Changes

- **New `jsBareNames` map** in `internal/external/synth.go`, gated to `lang == "javascript" || "typescript"` in `stdlibFunction`. Contents:
  - **Prisma ORM client methods** (post-receiver-strip): `findUnique`, `findUniqueOrThrow`, `findFirst`, `findFirstOrThrow`, `findMany`, `createMany`, `updateMany`, `deleteMany`, `upsert`, `aggregate`, `groupBy`, `executeRaw`, `executeRawUnsafe`, `queryRaw`, `queryRawUnsafe`.
  - **`$`-prefixed Prisma client methods** (unambiguous — `$` is rare in user identifiers): `$connect`, `$disconnect`, `$transaction`, `$queryRaw`, `$executeRaw`, `$on`, `$use`.
  - **JS/TS array & util builtins**: `some`, `every`, `push`, `trim`, `isArray`.
- **Added `@prisma`** to scoped `knownExternalPackages` so `@prisma/client` (and any future `@prisma/*` extensions) classify as ExternalKnown via the existing scope-fallback branch.
- **`prisma`** (the unscoped npm name) was already on the allowlist — left as is.

### Conservative rejections (per #94 / #105 / #106 / #107 lessons)

These are explicitly NOT added — collision-prone with user methods even with a language gate:
- Generic Prisma names: `create`, `update`, `delete`, `count` (overlap with controller/service/factory methods on any user class).
- Generic collection ops: `map`, `filter`, `forEach`, `reduce`, `find`, `length`, `size`.

Locked in by `TestJSBareNames_RejectedNamesNotClassified`.

### VERIFY-2 results

Single-repo runs against the JS/TS corpus repos:

| repo | metric | baseline (origin/main) | this PR | delta |
| --- | --- | ---: | ---: | ---: |
| express-realworld | bug-extractor pct | 41.57% | 37.71% | -3.86 pts |
| express-realworld | bug_rate | 44.34% | 40.06% | -4.28 pts |
| nestjs-starter | bug-extractor pct | 26.79% | 26.79% | 0.00 pts |
| nestjs-starter | bug_rate | 33.04% | 33.04% | 0.00 pts |

`nestjs-starter` doesn't use Prisma so the array-builtin family is the only relevant change there, and there's no observed bare-name traffic that hits the new entries in this corpus snapshot.

Remaining bug-extractor on `express-realworld` is dominated by:
- Hash-named local entity IDs (e.g. `4cc6a9c6fb65f12f`) — extractor-side bug, separate from the synth allowlist gap.
- Faker helpers (`randParagraph`) — best handled by adding `@faker-js/faker` to the package allowlist in a follow-up.
- Conservatively-rejected generic names (`create`/`update`/`delete`/`count`).

Acceptance ceiling for synth-only changes is therefore lower than the spec's aspirational ≤25%, but the direction is monotonically right.

## Test plan

- [x] `go test ./...` — all green
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean on touched files
- [x] New tests:
  - `TestJSBareNames_ClassifiedWhenLangIsJSOrTS` — positive (both langs)
  - `TestJSBareNames_NotClassifiedForOtherLanguages` — negative cross-language gate
  - `TestJSBareNames_RejectedNamesNotClassified` — locks in rejection list
  - `TestPrismaScopedKnownExternalPackage` — `@prisma/client` allowlist
- [x] Single-repo VERIFY-2 on `express-realworld` and `nestjs-starter` (numbers above)
- [x] forbidden-term grep: clean

Refs #104.