### PR TITLE
fix(synth): add @faker-js/faker to package allowlist (Refs #127)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1284,6 +1284,7 @@ var knownExternalPackages = map[string]struct{}{
 	"jsonwebtoken": {},
 	"helmet":       {},
 	"multer":       {},
+	"faker":        {},
 	// JS / TS scoped packages (kept lowercase per case-folded lookup;
 	// only the leading "@scope" segment is matched).
 	"@radix-ui":        {},
@@ -1293,6 +1294,7 @@ var knownExternalPackages = map[string]struct{}{
 	"@types":           {},
 	"@nestjs":          {},
 	"@prisma":          {},
+	"@faker-js":        {},
 	"@apollo":          {},
 	"@mui":             {},
 	"@emotion":         {},

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1778,3 +1778,20 @@ func TestPrismaScopedKnownExternalPackage(t *testing.T) {
 		t.Fatal("IsKnownExternalPackage(\"prisma\") = false; want true (Issue #104)")
 	}
 }
+
+// TestSynthesize_FakerAllowlist locks in the issue #127 addition of
+// "@faker-js" (covers @faker-js/faker and any future @faker-js/*
+// subpackages) plus the legacy unscoped "faker" bare name so faker
+// references in JS/TS fixtures classify as ExternalKnown rather than
+// ExternalUnknown.
+func TestSynthesize_FakerAllowlist(t *testing.T) {
+	if !IsKnownExternalPackage("@faker-js/faker") {
+		t.Fatal("IsKnownExternalPackage(\"@faker-js/faker\") = false; want true (Issue #127)")
+	}
+	if !IsKnownExternalPackage("@FAKER-JS/FAKER") {
+		t.Fatal("IsKnownExternalPackage(\"@FAKER-JS/FAKER\") = false; want case-folded match")
+	}
+	if !IsKnownExternalPackage("faker") {
+		t.Fatal("IsKnownExternalPackage(\"faker\") = false; want true (Issue #127)")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `@faker-js` (scoped root, matches `@faker-js/faker` and any `@faker-js/*` subpackage via the existing scoped-root match path) and the legacy unscoped `faker` bare name to `knownExternalPackages`.
- New `TestSynthesize_FakerAllowlist` locks in case-folded scope match + bare `faker` + full `@faker-js/faker` key.

## Test plan
- [x] `go test ./internal/external/ -run Faker -v` — PASS
- [x] `go test ./...` — all packages green
- [x] `gofmt -l` clean for the two changed files
- [x] forbidden-term grep: clean
- [x] VERIFY-2 single-repo measurement on `express-realworld` — see comment

Refs #127

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>