### PR TITLE
fix(synth): Go testify bare-name allowlist gated to _test.go files (Refs #115 #103)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -72,9 +72,18 @@ func Synthesize(doc *graph.Document) Stats {
 	// the language-agnostic stop-list — matching pre-#103 behaviour for
 	// every relationship whose FromID isn't a known entity.
 	entityLang := make(map[string]string, len(doc.Entities))
+	// entityFile maps every entity ID to its declared SourceFile so the
+	// classifier can apply file-path-gated bare-name allowlists (issue
+	// #115 — Go testify helpers like Equal/NoError that are receiver-
+	// stripped by the extractor and would collide trivially with user
+	// methods if classified globally). Only test-file callers (paths
+	// ending in `_test.go`) are eligible. Lookups against non-existent
+	// IDs return "" — matching pre-#115 behaviour.
+	entityFile := make(map[string]string, len(doc.Entities))
 	for k := range doc.Entities {
 		known[doc.Entities[k].ID] = true
 		entityLang[doc.Entities[k].ID] = doc.Entities[k].Language
+		entityFile[doc.Entities[k].ID] = doc.Entities[k].SourceFile
 	}
 
 	// First pass — collect every unique external name we want to
@@ -99,7 +108,7 @@ func Synthesize(doc *graph.Document) Stats {
 		if rel.ToID == "" || isHexID(rel.ToID) || strings.HasPrefix(rel.ToID, ExtIDPrefix) {
 			continue
 		}
-		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID])
+		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID], entityFile[rel.FromID])
 		if !ok {
 			continue
 		}
@@ -177,7 +186,7 @@ func Synthesize(doc *graph.Document) Stats {
 // Returns ("", "", false) when the stub doesn't look external — those
 // are left untouched and continue to count as "unmatched" in the
 // resolver stats.
-func classifyExternal(stub, relKind, lang string) (canonical, subtype string, ok bool) {
+func classifyExternal(stub, relKind, lang, fromFile string) (canonical, subtype string, ok bool) {
 	if stub == "" {
 		return "", "", false
 	}
@@ -401,7 +410,7 @@ func classifyExternal(stub, relKind, lang string) (canonical, subtype string, ok
 	}
 
 	// Stdlib function stop-list — bare names like "Println", "print".
-	if subtype, ok := stdlibFunction(name, lang); ok {
+	if subtype, ok := stdlibFunction(name, lang, fromFile); ok {
 		return name, subtype, true
 	}
 
@@ -493,7 +502,7 @@ func isNpmSegment(s string) bool {
 // the small per-language stop-list. Kept deliberately small — v1.0
 // catches the highest-volume bare-name calls without ballooning into
 // a full stdlib catalogue.
-func stdlibFunction(name, lang string) (string, bool) {
+func stdlibFunction(name, lang, fromFile string) (string, bool) {
 	if _, ok := stdlibBareNames[name]; ok {
 		return "function", true
 	}
@@ -505,6 +514,22 @@ func stdlibFunction(name, lang string) (string, bool) {
 	if lang == "go" {
 		if _, ok := goBareNames[name]; ok {
 			return "function", true
+		}
+		// Issue #115 — testify helpers (Equal/NoError/Contains/Empty/...)
+		// are receiver-stripped by the Go extractor (`assert.Equal(t, ...)`
+		// → `Equal`) and collide trivially with user-defined methods on
+		// any domain type. Gate the testify allowlist on BOTH lang=="go"
+		// AND a `_test.go` file-path suffix on the caller — the suffix
+		// rule is precise (not just "contains test"), and Go's build tool
+		// already enforces that testify usage outside `_test.go` is rare
+		// or wrong. A non-test caller named `Equal` falls through to the
+		// generic allowlist and is left unresolved (the safer bias from
+		// lesson #94 — a missed external is strictly better than a
+		// synthesised placeholder shadowing a real user method).
+		if strings.HasSuffix(fromFile, "_test.go") {
+			if _, ok := goTestifyBareNames[name]; ok {
+				return "function", true
+			}
 		}
 	}
 	if lang == "rust" {
@@ -741,6 +766,90 @@ var goBareNames = map[string]struct{}{
 	// issue #103 hard rules: Get/Post/Put/Delete/Use are EXCLUDED.
 	"MethodFunc":      {},
 	"AbortWithStatus": {},
+}
+
+// goTestifyBareNames is the Go testify-helper bare-name stop-list (issue
+// #115). The testify package (`github.com/stretchr/testify/assert` and
+// `.../require`) exposes assertion helpers that are invoked through a
+// receiver (`assert.Equal(t, ...)`, `require.NoError(t, err)`); the Go
+// extractor strips that receiver, leaving the resolver with bare Pascal-
+// case names like `Equal`, `NoError`, `Contains`. Many of these names
+// (Equal in particular) collide trivially with user-defined methods on
+// domain types in non-test code, so a language-only gate is not enough.
+//
+// Gating: lookups in this map are reached ONLY when (a) the source
+// entity's language is "go" AND (b) the source entity's file path ends
+// in `_test.go`. Both conditions are precise: the build tool restricts
+// testify usage to `*_test.go` files in practice, and the suffix check
+// (strings.HasSuffix, NOT strings.Contains) avoids false hits on paths
+// like `internal/test/foo.go`.
+//
+// Conservative selection rule, mirroring the goBareNames spec: include
+// only assertion helpers whose name is a strong testify idiom. EXCLUDED
+// per the issue's hard rules: `Run` (subtest helper, but `t.Run` is the
+// standard testing API and aliases trivially to user code), `New`,
+// `Add`, `Set` (constructor / mutator names that collide with anything).
+// `Contains` is included despite being slightly collision-prone because
+// in `_test.go` context the testify identity dominates by orders of
+// magnitude in real corpora.
+var goTestifyBareNames = map[string]struct{}{
+	// Equality and identity assertions.
+	"Equal":       {},
+	"NotEqual":    {},
+	"EqualValues": {},
+	"Same":        {},
+	"NotSame":     {},
+
+	// Error / nil assertions.
+	"NoError": {},
+	"Error":   {},
+	"Nil":     {},
+	"NotNil":  {},
+
+	// Boolean assertions.
+	"True":  {},
+	"False": {},
+
+	// Container assertions.
+	"Empty":         {},
+	"NotEmpty":      {},
+	"Contains":      {},
+	"NotContains":   {},
+	"Len":           {},
+	"Subset":        {},
+	"ElementsMatch": {},
+
+	// Ordering assertions.
+	"Greater":        {},
+	"Less":           {},
+	"GreaterOrEqual": {},
+	"LessOrEqual":    {},
+
+	// Panic assertions.
+	"Panics":          {},
+	"NotPanics":       {},
+	"PanicsWithError": {},
+
+	// Type / interface assertions.
+	"Implements": {},
+	"IsType":     {},
+
+	// Eventual / temporal assertions.
+	"Eventually":     {},
+	"Never":          {},
+	"WithinDuration": {},
+
+	// Encoding assertions.
+	"JSONEq": {},
+	"YAMLEq": {},
+
+	// Filesystem assertions.
+	"FileExists": {},
+	"DirExists":  {},
+
+	// httptest helper commonly imported alongside testify in `_test.go`.
+	// Multi-word PascalCase, no plausible user-method collision.
+	"NewRecorder": {},
 }
 
 // rustBareNames is the Rust-language-gated bare-name stop-list (issue

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -453,7 +453,7 @@ func TestStdlibBareNames_NoCollisionNames(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := stdlibFunction(name, ""); ok {
+			if _, ok := stdlibFunction(name, "", ""); ok {
 				t.Fatalf("stdlibFunction(%q) classified as stdlib bare-name; "+
 					"this name commonly collides with user-defined methods "+
 					"and must not synthesise a placeholder", name)
@@ -488,7 +488,7 @@ func TestStdlibBareNames_RustAssertMacros(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "")
+			subtype, ok := stdlibFunction(name, "", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q) = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -722,7 +722,7 @@ func TestGoBareNames_ClassifiedWhenLangIsGo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			// Direct stdlibFunction probe with lang="go" must classify.
-			subtype, ok := stdlibFunction(name, "go")
+			subtype, ok := stdlibFunction(name, "go", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q, \"go\") = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -767,7 +767,7 @@ func TestGoBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to lang=\"go\" only)", name, lang)
 				}
@@ -814,7 +814,7 @@ func TestGoBareNames_UserMethodCollisionExclusions(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := stdlibFunction(name, "go"); ok {
+			if _, ok := stdlibFunction(name, "go", ""); ok {
 				t.Fatalf("stdlibFunction(%q, \"go\") classified; want fall-through "+
 					"(name is too-likely to be a user-defined method)", name)
 			}
@@ -1100,7 +1100,7 @@ func TestRustBareNames_ClassifiedWhenLangIsRust(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "rust")
+			subtype, ok := stdlibFunction(name, "rust", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q, \"rust\") = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -1147,7 +1147,7 @@ func TestRustBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to lang=\"rust\" only)", name, lang)
 				}
@@ -1236,7 +1236,7 @@ func TestJavaBareNames_ClassifiedWhenLangIsJava(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "java")
+			subtype, ok := stdlibFunction(name, "java", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q, \"java\") = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -1287,7 +1287,7 @@ func TestJavaBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to lang=\"java\" only)", name, lang)
 				}
@@ -1400,7 +1400,7 @@ func TestKotlinBareNames_ClassifiedWhenLangIsKotlin(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "kotlin")
+			subtype, ok := stdlibFunction(name, "kotlin", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q, \"kotlin\") = (_, false); want classified as stdlib bare-name", name)
 			}
@@ -1445,7 +1445,7 @@ func TestKotlinBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to lang=\"kotlin\" only)", name, lang)
 				}
@@ -1539,7 +1539,7 @@ func TestRubyBareNames_ClassifiedWhenLangIsRuby(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "ruby")
+			subtype, ok := stdlibFunction(name, "ruby", "")
 			if !ok {
 				t.Fatalf("stdlibFunction(%q, \"ruby\") = (_, false); want classified", name)
 			}
@@ -1581,7 +1581,7 @@ func TestRubyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to lang=\"ruby\" only)", name, lang)
 				}
@@ -1660,7 +1660,7 @@ func TestJSBareNames_ClassifiedWhenLangIsJSOrTS(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				subtype, ok := stdlibFunction(name, lang)
+				subtype, ok := stdlibFunction(name, lang, "")
 				if !ok {
 					t.Fatalf("stdlibFunction(%q, %q) = (_, false); want classified", name, lang)
 				}
@@ -1711,7 +1711,7 @@ func TestJSBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang); ok {
+				if _, ok := stdlibFunction(name, lang, ""); ok {
 					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
 						"(name is gated to JS/TS only)", name, lang)
 				}
@@ -1793,5 +1793,171 @@ func TestSynthesize_FakerAllowlist(t *testing.T) {
 	}
 	if !IsKnownExternalPackage("faker") {
 		t.Fatal("IsKnownExternalPackage(\"faker\") = false; want true (Issue #127)")
+	}
+}
+
+// TestGoTestifyBareNames_ClassifiedInTestFiles locks in issue #115:
+// testify-helper bare names (Equal/NoError/Contains/...) that arrive at
+// the resolver after the Go extractor strips the receiver
+// (`assert.Equal(t, ...)` → `Equal`) must classify as stdlib bare-names
+// — but only when (a) the source entity's language is "go" AND (b) the
+// source file path ends with `_test.go`. The dual gate keeps these
+// collision-prone names from shadowing user methods in non-test code.
+func TestGoTestifyBareNames_ClassifiedInTestFiles(t *testing.T) {
+	names := []string{
+		"Equal", "NotEqual", "EqualValues", "Same", "NotSame",
+		"NoError", "Error", "Nil", "NotNil",
+		"True", "False",
+		"Empty", "NotEmpty", "Contains", "NotContains", "Len",
+		"Subset", "ElementsMatch",
+		"Greater", "Less", "GreaterOrEqual", "LessOrEqual",
+		"Panics", "NotPanics", "PanicsWithError",
+		"Implements", "IsType",
+		"Eventually", "Never", "WithinDuration",
+		"JSONEq", "YAMLEq",
+		"FileExists", "DirExists",
+		"NewRecorder",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			// Direct stdlibFunction probe with lang="go" + _test.go path
+			// must classify.
+			subtype, ok := stdlibFunction(name, "go", "internal/foo/foo_test.go")
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) = (_, false); want classified", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) subtype=%q, want %q", name, subtype, "function")
+			}
+			// End-to-end: Synthesize on a doc whose source entity is a Go
+			// _test.go file rewrites the edge to ext:<name>.
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:         "go-test-src",
+					Name:       "TestFoo",
+					Kind:       "function",
+					Language:   "go",
+					SourceFile: "internal/foo/foo_test.go",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "go-test-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestGoTestifyBareNames_NotClassifiedInNonTestGoFiles locks in the
+// file-path gate: the same testify-helper names must NOT classify when
+// the Go source file is a regular `.go` file (not `_test.go`). Without
+// the gate, a user-defined `Equal` method on a domain type would be
+// shadowed by a synthesised testify placeholder.
+func TestGoTestifyBareNames_NotClassifiedInNonTestGoFiles(t *testing.T) {
+	names := []string{"Equal", "NoError", "Contains", "Empty", "Len"}
+	nonTestPaths := []string{
+		"internal/foo/foo.go",
+		"cmd/main.go",
+		// Adversarial: contains "test" but not as a `_test.go` suffix.
+		"internal/test/helpers.go",
+		"internal/testutil/util.go",
+		"",
+	}
+	for _, name := range names {
+		for _, path := range nonTestPaths {
+			name, path := name, path
+			t.Run(name+"|"+path, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, "go", path); ok {
+					t.Fatalf("stdlibFunction(%q, \"go\", %q) classified; want fall-through "+
+						"(file is not a _test.go file)", name, path)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:         "go-src",
+						Name:       "Foo",
+						Kind:       "function",
+						Language:   "go",
+						SourceFile: path,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "go-src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, file=%q): synthesized=%d, want 0",
+						name, path, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten outside _test.go)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestGoTestifyBareNames_NotClassifiedForOtherLanguages confirms the
+// language gate: even for a `_test.go` path, the same testify names
+// must not classify when the source language isn't "go". Defensive in
+// depth; the file-suffix is the dominant gate but a stray non-Go
+// entity with a `.go`-shaped path must not slip through.
+func TestGoTestifyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	names := []string{"Equal", "NoError", "Contains"}
+	otherLangs := []string{"python", "javascript", "rust", "java", "ruby", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "foo_test.go"); ok {
+					t.Fatalf("stdlibFunction(%q, %q, _test.go) classified; want fall-through "+
+						"(testify map is gated to lang=\"go\")", name, lang)
+				}
+			})
+		}
+	}
+}
+
+// TestGoTestifyBareNames_RejectedCollisions confirms that names
+// rejected as too-likely-to-collide-with-user-methods stay
+// fall-through even with lang="go" + a `_test.go` path. Per the
+// issue #115 hard rules: Run/New/Add/Set are EXCLUDED.
+func TestGoTestifyBareNames_RejectedCollisions(t *testing.T) {
+	excluded := []string{"Run", "New", "Add", "Set"}
+	for _, name := range excluded {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if _, ok := goTestifyBareNames[name]; ok {
+				t.Fatalf("goTestifyBareNames[%q] present; must be rejected per issue #115 "+
+					"(collision-prone with user-defined Run/New/Add/Set methods)", name)
+			}
+			if _, ok := stdlibFunction(name, "go", "foo_test.go"); ok {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) classified; want fall-through "+
+					"(name is too-likely to be a user-defined method)", name)
+			}
+		})
+	}
+}
+
+// TestGoTestifyBareNames_TestifyPackageAllowlisted confirms #117's
+// addition of `github.com/stretchr/testify` as a host-prefixed known
+// external package — synthesised testify CALLS edges should resolve
+// to the testify package node when the full import path arrives.
+func TestGoTestifyBareNames_TestifyPackageAllowlisted(t *testing.T) {
+	if !IsKnownExternalPackage("github.com/stretchr/testify") {
+		t.Fatal("IsKnownExternalPackage(\"github.com/stretchr/testify\") = false; " +
+			"want true (Issue #115/#117)")
 	}
 }


### PR DESCRIPTION
## Summary

Closes a chunk of the receiver-stripped bare-name gap that's keeping the Go bug-rate above the #103 ≤35% target. Adds `goTestifyBareNames` (Equal / NoError / Contains / Empty / Len / Greater / Panics / IsType / Eventually / JSONEq / FileExists / NewRecorder / ...) gated by **both** `lang == "go"` AND `strings.HasSuffix(SourceFile, "_test.go")`.

## Approach

**Approach (ii)** from the issue — file-path gate via `_test.go` suffix.

Investigation of the Go extractor confirmed it strips the receiver in `callExpressionTarget` (`assert.Equal(t, ...)` → `Equal`), so receiver-context gating (approach i) isn't available without an architectural extension. The file-path gate is precise (suffix, not contains), and Go's build tool already constrains testify usage to `*_test.go` files. Threads `SourceFile` through `Synthesize → classifyExternal → stdlibFunction` by building an `entityFile` map alongside the existing `entityLang` map.

Names in / names rejected:

- IN (35): `Equal`, `NotEqual`, `EqualValues`, `Same`, `NotSame`, `NoError`, `Error`, `Nil`, `NotNil`, `True`, `False`, `Empty`, `NotEmpty`, `Contains`, `NotContains`, `Len`, `Subset`, `ElementsMatch`, `Greater`, `Less`, `GreaterOrEqual`, `LessOrEqual`, `Panics`, `NotPanics`, `PanicsWithError`, `Implements`, `IsType`, `Eventually`, `Never`, `WithinDuration`, `JSONEq`, `YAMLEq`, `FileExists`, `DirExists`, `NewRecorder`.
- REJECTED per #115 hard rules: `Run` (aliases `t.Run`), `New`, `Add`, `Set` (collision-prone constructor/mutator names).

## Measurements (single-repo VERIFY-2)

| repo | files | testify files | bug_rate before | bug_rate after | delta |
| --- | ---: | ---: | ---: | ---: | ---: |
| gin | 121 | 41 | 49.30% | 43.61% | -5.69 pts |
| chi | 93 | 0 | 48.29% | 47.79% | -0.50 pts |

chi doesn't import testify (uses stdlib `testing` only) so the move there is incidental. gin shows the expected drop. Neither hits the ≤35% acceptance bar from #103 yet — testify is one of several remaining receiver-stripped categories.

## Tests

4 new tables in `synth_test.go`:
- `TestGoTestifyBareNames_ClassifiedInTestFiles` — 35 names × `_test.go` path classify
- `TestGoTestifyBareNames_NotClassifiedInNonTestGoFiles` — 5 names × 5 non-test paths (incl. adversarial `internal/test/foo.go`, `internal/testutil/util.go`) fall through
- `TestGoTestifyBareNames_NotClassifiedForOtherLanguages` — 3 names × 6 non-Go languages fall through
- `TestGoTestifyBareNames_RejectedCollisions` — Run/New/Add/Set must NOT be in the map

Existing `stdlibFunction(name, lang)` test call sites (15) updated to the new `(name, lang, fromFile)` signature with empty `fromFile`.

Last 5 lines of `go test ./...`:

```
ok  	github.com/cajasmota/archigraph/internal/resolve	(cached)
ok  	github.com/cajasmota/archigraph/internal/treesitter	(cached)
ok  	github.com/cajasmota/archigraph/internal/types	(cached)
ok  	github.com/cajasmota/archigraph/internal/verify	(cached)
ok  	github.com/cajasmota/archigraph/internal/version	(cached)
```

`go vet ./...` clean. `gofmt -l internal/external/` clean.

## State of #103 acceptance

Bar: bug-rate ≤35% on gin and chi. Current after this PR: gin 43.61%, chi 47.79%. Still over. Receiver-stripped allowlists landed so far (#103/#114/#115/#117/#118/#121/#123/#125): Go stdlib PascalCase, Java, Kotlin, Ruby, JS/TS, Rust, Go testify. Remaining work for the chi side likely involves stdlib `testing.T` methods (`Run`, `Fatal`, `Errorf` already in stdlib map but `Helper`, `Cleanup`, `Skip`, `Logf`, `Setenv` may still leak) and chi router method names — none of which are addressed by testify gating. Tracked under follow-up #103 sub-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)