### PR TITLE
chore: fix stale comment referencing nonexistent slice

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -183,16 +183,15 @@ var AllDispositions = []Disposition{
 //
 // The fix groups patterns by the language that owns the runtime-dispatch
 // idiom. Patterns that are intrinsically reflective regardless of language
-// (template-built names) live in crossLangDynamicPatterns. Receiver-anchored
-// reflection APIs that have a unique fully-qualified shape (Go's
-// `plugin.Lookup`, JVM `Method.invoke` / `Class.forName().newInstance()`)
-// stay tight enough to be safe even when language is unknown — they go in
-// the per-language slice plus a small "safe-anchored" cross-language slice.
+// (template-built names like `${x}`) live in crossLangDynamicPatterns.
+// Receiver-anchored reflection APIs that have a unique fully-qualified
+// shape (Go's `plugin.Lookup`, JVM `Method.invoke` /
+// `Class.forName().newInstance()`) stay in their per-language slice.
 //
 // Language identifiers follow the structural-ref `<lang>:` segment
 // convention: "python", "go", "javascript" (also "typescript"), "ruby",
 // "java" (also "kotlin", "scala", "jvm"). Unknown / empty languages fall
-// back to crossLangDynamicPatterns + safeAnchoredDynamicPatterns only.
+// back to crossLangDynamicPatterns only.
 var (
 	pythonDynamicPatterns = []*regexp.Regexp{
 		// Bare-identifier forms: per-language extractors emit only the


### PR DESCRIPTION
## Summary
Closes #73.

The comment block above the per-language dynamic-dispatch pattern catalogs in `internal/resolve/refs.go` referenced a `safeAnchoredDynamicPatterns` slice that does not exist in the code (only `crossLangDynamicPatterns` and the per-language slices exist).

Rewrote the comment to accurately describe the current grouping: receiver-anchored reflection APIs live in their per-language slice, and the unknown-language fallback is `crossLangDynamicPatterns` only.

## Test plan
- [x] `go build ./...`
- [x] `go test ./internal/resolve/...`