### PR TITLE
fix(refs): bare-name JVM reflection methods classify as dynamic (Closes #72)

### DIFF
--- a/internal/resolve/dynamic_patterns_test.go
+++ b/internal/resolve/dynamic_patterns_test.go
@@ -109,6 +109,33 @@ func TestDynamicPatterns_Catalog(t *testing.T) {
 		{"rb_bare_instance_eval_id", "ruby", `instance_eval`, true},
 		{"rb_bare_class_eval_id", "ruby", `class_eval`, true},
 		{"jvm_bare_forName", "java", `forName`, true},
+		// Issue #72 — Java/Kotlin extractors emit only the leaf callee
+		// identifier, so `m.invoke(target, args)` arrives as bare
+		// `invoke`. The receiver-typed `Method.invoke(` regex never
+		// fires on those stubs. The bare-name anchors below promote
+		// the real-world reflection shape (`Method m = clazz.getMethod(name); m.invoke(...)`)
+		// into Dynamic instead of bug-extractor.
+		{"jvm_bare_invoke_java", "java", `invoke`, true},
+		{"jvm_bare_invoke_kotlin", "kotlin", `invoke`, true},
+		{"jvm_bare_newInstance", "java", `newInstance`, true},
+		{"jvm_bare_getClass", "java", `getClass`, true},
+		{"jvm_bare_getMethod", "java", `getMethod`, true},
+		{"jvm_bare_getMethods", "java", `getMethods`, true},
+		{"jvm_bare_getDeclaredMethod", "java", `getDeclaredMethod`, true},
+		{"jvm_bare_getDeclaredMethods", "java", `getDeclaredMethods`, true},
+		{"jvm_bare_getField", "java", `getField`, true},
+		{"jvm_bare_getFields", "java", `getFields`, true},
+		{"jvm_bare_getDeclaredField", "java", `getDeclaredField`, true},
+		{"jvm_bare_getDeclaredFields", "java", `getDeclaredFields`, true},
+		{"jvm_bare_getConstructor", "java", `getConstructor`, true},
+		{"jvm_bare_getConstructors", "java", `getConstructors`, true},
+		{"jvm_bare_getDeclaredConstructor", "java", `getDeclaredConstructor`, true},
+		{"jvm_bare_getDeclaredConstructors", "java", `getDeclaredConstructors`, true},
+		// Per-language gate: bare `invoke` from a JS file MUST NOT
+		// classify as JVM dynamic — those names are JVM-only.
+		{"jvm_bare_invoke_js_negative", "javascript", `invoke`, false},
+		{"jvm_bare_getMethod_python_negative", "python", `getMethod`, false},
+		{"jvm_bare_newInstance_go_negative", "go", `newInstance`, false},
 
 		// ---- Negative cases (must NOT be dynamic) ------------------
 		{"plain_kindname", "", `Function:Hello`, false},

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -352,15 +352,43 @@ var (
 	}
 
 	jvmDynamicPatterns = []*regexp.Regexp{
-		// Bare-identifier forms: extractors emit just the leaf method
-		// name. `forName` (Class.forName) is reflection-unique enough to
-		// be safe as a bare anchor; `newInstance` and `invoke` are NOT
-		// (collide with domain methods) so we leave those parens-anchored
-		// only (issue #90).
-		regexp.MustCompile(`^forName$`),
+		// Bare-identifier forms: Java/Kotlin extractors emit only the
+		// leaf callee identifier (e.g. `m.invoke(target, args)` →
+		// ToID="invoke"). Real reflection in the wild stores the
+		// reflective handle in a local var (`Method m = clazz.getMethod(name); m.invoke(...)`),
+		// so the receiver-typed pattern `Method.invoke(` never sees the
+		// type and the call lands in BugExtractor instead of Dynamic
+		// (issue #72). The bare-name anchors below promote those leaf
+		// callees into the Dynamic disposition.
+		//
+		// Collisions with non-reflective user methods (`cli.invoke(...)`,
+		// `factory.newInstance()`) are accepted: Dynamic is the
+		// appropriate "we know it's dispatch we can't statically resolve"
+		// bucket — these stubs are equally unresolvable either way, and
+		// classifying them as Dynamic keeps them out of bug-extractor.
+		// The per-language gate (Java/Kotlin/Scala/JVM only) keeps these
+		// names from polluting other languages.
+		regexp.MustCompile(`^forName$`),                 // Class.forName
+		regexp.MustCompile(`^invoke$`),                  // Method.invoke / Constructor handle
+		regexp.MustCompile(`^newInstance$`),             // Class.newInstance / Constructor.newInstance
+		regexp.MustCompile(`^getClass$`),                // Object.getClass — reflection entry point
+		regexp.MustCompile(`^getMethod$`),               // Class.getMethod
+		regexp.MustCompile(`^getMethods$`),              // Class.getMethods
+		regexp.MustCompile(`^getDeclaredMethod$`),       // Class.getDeclaredMethod
+		regexp.MustCompile(`^getDeclaredMethods$`),      // Class.getDeclaredMethods
+		regexp.MustCompile(`^getField$`),                // Class.getField
+		regexp.MustCompile(`^getFields$`),               // Class.getFields
+		regexp.MustCompile(`^getDeclaredField$`),        // Class.getDeclaredField
+		regexp.MustCompile(`^getDeclaredFields$`),       // Class.getDeclaredFields
+		regexp.MustCompile(`^getConstructor$`),          // Class.getConstructor
+		regexp.MustCompile(`^getConstructors$`),         // Class.getConstructors
+		regexp.MustCompile(`^getDeclaredConstructor$`),  // Class.getDeclaredConstructor
+		regexp.MustCompile(`^getDeclaredConstructors$`), // Class.getDeclaredConstructors
 		// JVM reflection invoke is `Method.invoke(...)` or
-		// `Constructor.invoke(...)`. Anchored to those receivers so a
-		// user-defined `cli.invoke(...)` / `cmd.invoke(...)` does NOT match.
+		// `Constructor.invoke(...)`. Anchored to those receivers when
+		// the full call expression is present (extractor pre-strip
+		// stubs) so a user-defined `cli.invoke(...)` / `cmd.invoke(...)`
+		// does NOT match.
 		regexp.MustCompile(`\b(?:Method|Constructor)\.invoke\(`),
 		regexp.MustCompile(`^Class\.forName\(`), // Class.forName("...")
 		// Anchored to the reflective `Class.forName(...).newInstance()` /


### PR DESCRIPTION
## Summary

JVM extractors emit only the leaf callee identifier, so a real-world reflection call like `Method m = clazz.getMethod(name); m.invoke(target, args);` arrives at the resolver as bare `invoke` — never as `Method.invoke(`. The existing receiver-typed pattern (`\b(?:Method|Constructor)\.invoke\(`) only matched when the call site literally spelled out the type name on the receiver, so common real-world reflection landed in bug-extractor instead of Dynamic.

This is the resolver-side fix from issue #72's option (ii) — the smaller landable change. The extractor-side type-tracking option (i) remains future work if the false-positive rate proves problematic in practice.

## Names added (jvmDynamicPatterns, bare `^name$` anchors)

- `invoke` — Method.invoke (the issue #72 case)
- `newInstance` — Class.newInstance / Constructor.newInstance
- `getClass` — Object.getClass (reflection entry point)
- `getMethod`, `getMethods`, `getDeclaredMethod`, `getDeclaredMethods`
- `getField`, `getFields`, `getDeclaredField`, `getDeclaredFields`
- `getConstructor`, `getConstructors`, `getDeclaredConstructor`, `getDeclaredConstructors`

All anchored `^name$` and gated to `java`/`kotlin`/`scala`/`jvm` via `dynamicPatternsByLang`, so a JS/Python/Go callee with the same name is unaffected.

## Trade-off

Collisions with non-reflective user methods (`cli.invoke(...)`, `factory.newInstance()`) are accepted. Dynamic is the right "dispatch we can't statically resolve" disposition — these bare stubs are equally unresolvable either way, and classifying them as Dynamic keeps them out of bug-extractor. The pre-existing receiver-typed patterns (`\b(?:Method|Constructor)\.invoke\(`, `\.class\.newInstance\(`, etc.) are kept for the rarer pre-strip stub shape.

## Verification

VERIFY-2 single-repo runs against the JVM corpora:

| repo | bug-rate before | bug-rate after | delta |
| --- | --- | --- | --- |
| kafka-streams-examples | 38.81% | 38.63% | -0.18 pp |
| exposed | 25.25% | 25.20% | -0.05 pp |
| ktor-samples | unchanged | unchanged | 0 |
| spring-petclinic | unchanged | unchanged | 0 |

Per-disposition counts on kafka-streams-examples confirm the migration: `dynamic` 760 -> 861 (+101), `bug-extractor` 19499 -> 19398 (-101). spring-petclinic and ktor-samples are too small / too CRUD-shaped to exercise reflection. Test count delta: +19 cases in `TestDynamicPatterns_Catalog` (16 new positives + 3 per-language-gate negatives).

`go test ./...`, `go vet ./...`, `gofmt -l` all clean.

## Test plan

- [x] `go test ./internal/resolve/...` passes (full catalog, including new bare-name positives and per-language-gate negatives)
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/resolve/refs.go` clean
- [x] VERIFY-2 single-repo run on kafka-streams-examples shows bug-extractor -> dynamic migration
- [x] Existing negative tests still pass (`neg_cli_invoke`, `neg_factory_newinstance` — full pre-strip strings don't match the new bare anchors)

forbidden-term grep: clean