### PR TITLE
chore: gofmt drift cleanup (Closes #136)

### DIFF
--- a/internal/engine/drf_router_routes_test.go
+++ b/internal/engine/drf_router_routes_test.go
@@ -61,11 +61,11 @@ func TestDetect_DRFRouterRoutes(t *testing.T) {
 
 	type rel struct{ from, to string }
 	expected := map[rel]bool{
-		{"Route:/api/users", "View:UserViewSet"}:           false,
-		{"Route:/api/orders", "View:OrderViewSet"}:         false,
-		{"Route:/api/products", "View:ProductViewSet"}:     false,
-		{"Route:/api/categories", "View:CategoryViewSet"}:  false,
-		{"Route:/api/v2/reviews", "View:ReviewViewSet"}:    false,
+		{"Route:/api/users", "View:UserViewSet"}:          false,
+		{"Route:/api/orders", "View:OrderViewSet"}:        false,
+		{"Route:/api/products", "View:ProductViewSet"}:    false,
+		{"Route:/api/categories", "View:CategoryViewSet"}: false,
+		{"Route:/api/v2/reviews", "View:ReviewViewSet"}:   false,
 	}
 
 	var routesToCount int

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -772,11 +772,11 @@ func TestExtract_NestedClassesFromFixture(t *testing.T) {
 	}
 
 	wantMethods := map[string]bool{
-		"Outer.Inner.foo":         false,
-		"Outer.Inner.Deep.bar":    false,
-		"Outer.Sibling.foo":       false,
-		"Outer.Sibling.Deep.bar":  false,
-		"Standalone.foo":          false,
+		"Outer.Inner.foo":        false,
+		"Outer.Inner.Deep.bar":   false,
+		"Outer.Sibling.foo":      false,
+		"Outer.Sibling.Deep.bar": false,
+		"Standalone.foo":         false,
 	}
 	for _, e := range entities {
 		if e.Kind != "SCOPE.Operation" || e.Subtype != "method" {

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -240,7 +240,7 @@ func TestCompactFormatStripsScope(t *testing.T) {
 		Nodes: []nodeWithRepo{{
 			Repo: "x", Score: 1, Entity: &graph.Entity{Name: "Foo", Kind: "SCOPE.Component", SourceFile: "f.go", StartLine: 1},
 		}},
-		Edges:   []renderEdge{{From: "Foo", To: "Bar", Kind: "SCOPE.IMPORTS"}, {From: "A", To: "B", Kind: "calls"}},
+		Edges: []renderEdge{{From: "Foo", To: "Bar", Kind: "SCOPE.IMPORTS"}, {From: "A", To: "B", Kind: "calls"}},
 		// Note: "SCOPE.IMPORTS" left intact as input to verify the renderer
 		// still strips the historical-bug prefix form (Issue #77 reconciliation).
 		OneRepo: true,


### PR DESCRIPTION
## Summary
- Pure mechanical `gofmt -w` on 3 test files with pre-existing drift on trunk
- No behavioral edits

## Files
- `internal/engine/drf_router_routes_test.go`
- `internal/extractors/python/extractor_test.go`
- `internal/mcp/server_test.go`

## Verification
- `gofmt -l .` clean
- `go build ./...` clean
- `go vet ./...` clean
- `go test ./...` all pass

Closes #136