### PR TITLE
chore(resolve): drop dead branches and simplify Lookup index updates

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -855,7 +855,7 @@ func BuildIndex(entities []types.EntityRecord) Index {
 				}
 				if existing, ok := nameKindBucketLoc[kind]; ok && existing != e.ID {
 					nameKindBucketLoc[kind] = "" // ambiguous within (file, name, kind)
-				} else if !ok || existing == e.ID {
+				} else {
 					nameKindBucketLoc[kind] = e.ID
 				}
 			}
@@ -981,10 +981,8 @@ func (idx Index) Lookup(stub string) (string, bool) {
 				return id, true
 			}
 		}
-		if idx.ambigKind[kind] != nil && idx.ambigKind[kind][name] {
-			// Ambiguous within this kind; fall through to kind-agnostic
-			// only if the kind-agnostic name is itself unique.
-		}
+		// Ambiguous within this kind: fall through to the kind-agnostic
+		// path; it succeeds only if the bare name is itself unique.
 	}
 	// Kind-agnostic fallback: bare name (no prefix) OR missed kind lookup.
 	lookupName := name


### PR DESCRIPTION
## Summary
Two trivial cleanups in `internal/resolve/refs.go`:

1. **`Lookup`** (~L984): removed the empty `if idx.ambigKind[kind] != nil && ...` block that did nothing. Replaced with an explanatory comment so the fall-through-to-kind-agnostic intent is preserved. Behavior unchanged.
2. **Per-location index update** (~L856-859): the `else if !ok || existing == e.ID` clause was logically equivalent to a plain `else` (it was the negation of the if's condition). Simplified to `else { nameKindBucketLoc[kind] = e.ID }`.

Closes #55

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/resolve/...` passes
- [x] `go test ./...` all packages pass
- [x] `go vet` and `gofmt -l` clean