### PR TITLE
Bug-resolver categorization (Refs #92)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -362,6 +362,21 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			}
 			dumpBugExtractorSamples(out, doc, *i.resolveIdx, allow, n)
 		}
+		// Issue #92 — temporary bug-resolver diagnostic instrumentation.
+		// Enabled with ARCHIGRAPH_BUG_RESOLVER_SAMPLES=N. Optional
+		// ARCHIGRAPH_BUG_RESOLVER_OUT=/path overrides stderr.
+		if n := bugResolverSampleCount(); n > 0 {
+			out := os.Stderr
+			if p := strings.TrimSpace(os.Getenv("ARCHIGRAPH_BUG_RESOLVER_OUT")); p != "" {
+				if f, ferr := os.Create(p); ferr == nil {
+					defer f.Close()
+					out = f
+				} else {
+					fmt.Fprintf(os.Stderr, "bug-resolver-samples: cannot open %q: %v\n", p, ferr)
+				}
+			}
+			dumpBugResolverSamples(out, doc, *i.resolveIdx, allow, n)
+		}
 	}
 
 	// Pass 4 — graph algorithms. Conceptually this runs "between" pass 3 and
@@ -610,6 +625,96 @@ func dumpBugExtractorSamples(w *os.File, doc *graph.Document, ridx resolve.Index
 
 	// Histogram footer.
 	fmt.Fprintln(w, "#category histogram (all bug-extractor edges):")
+	type kv struct {
+		k string
+		v int
+	}
+	pairs := make([]kv, 0, len(cats))
+	total := 0
+	for k, v := range cats {
+		pairs = append(pairs, kv{k, v})
+		total += v
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].v > pairs[j].v })
+	for _, p := range pairs {
+		pct := 0.0
+		if total > 0 {
+			pct = 100 * float64(p.v) / float64(total)
+		}
+		fmt.Fprintf(w, "#  %-22s %6d (%5.2f%%)\n", p.k, p.v, pct)
+	}
+	fmt.Fprintf(w, "#  %-22s %6d\n", "TOTAL", total)
+}
+
+// bugResolverSampleCount parses ARCHIGRAPH_BUG_RESOLVER_SAMPLES.
+// Issue #92 — temporary diagnostic instrumentation, not a production knob.
+func bugResolverSampleCount() int {
+	v := strings.TrimSpace(os.Getenv("ARCHIGRAPH_BUG_RESOLVER_SAMPLES"))
+	if v == "" {
+		return 0
+	}
+	var n int
+	if _, err := fmt.Sscanf(v, "%d", &n); err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// dumpBugResolverSamples writes up to n bug-resolver sample rows + a
+// category histogram. Issue #92 diagnostic instrumentation. Format is
+// tab-separated lines so it can be piped to awk/sort/uniq.
+//
+// Categories come from resolve.DiagnoseBugResolver — see BugResolverDiag
+// for the canonical list.
+func dumpBugResolverSamples(w *os.File, doc *graph.Document, ridx resolve.Index, allow resolve.ExternalAllowlist, n int) {
+	type ent struct{ file, name, lang string }
+	byID := make(map[string]ent, len(doc.Entities))
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		byID[e.ID] = ent{file: e.SourceFile, name: e.Name, lang: e.Language}
+	}
+
+	cats := make(map[string]int)
+	written := 0
+	fmt.Fprintf(w, "#bug-resolver-samples (issue #92): n=%d\n", n)
+	fmt.Fprintf(w, "#cols: rel_kind\tlang\tcategory\tstub_kind\tname\tkinds_present\trel_hint\tfrom_file\tfrom_name\tto_stub\n")
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		stub := r.ToID
+		if stub == "" {
+			continue
+		}
+		if isHex16(stub) || strings.HasPrefix(stub, "ext:") {
+			continue
+		}
+		lang := r.Properties["language"]
+		if lang == "" {
+			lang = r.Properties["lang"]
+		}
+		d := classifyForDiag(ridx, stub, lang, allow)
+		if d != resolve.DispositionBugResolver {
+			continue
+		}
+		diag := ridx.DiagnoseBugResolver(stub, r.Kind)
+		cats[diag.Category]++
+		if written < n {
+			from := byID[r.FromID]
+			kinds := strings.Join(diag.KindsPresent, ",")
+			if kinds == "" {
+				kinds = "-"
+			}
+			hint := strings.Join(diag.HintFamily, ",")
+			if hint == "" {
+				hint = "-"
+			}
+			fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n",
+				r.Kind, lang, diag.Category, diag.StubKind, diag.Name,
+				kinds, hint, from.file, from.name, stub)
+			written++
+		}
+	}
+
+	fmt.Fprintln(w, "#category histogram (all bug-resolver edges):")
 	type kv struct {
 		k string
 		v int

--- a/docs/verify2/issue-92-bug-resolver-categorization.md
+++ b/docs/verify2/issue-92-bug-resolver-categorization.md
@@ -1,0 +1,87 @@
+# Issue #92 — bug-resolver categorization
+
+**Date:** 2026-05-09
+**Corpus:** post-#96 sample-app refresh (apps that USE frameworks, not framework internals)
+**Method:** added `internal/resolve.Index.DiagnoseBugResolver` + `cmd/archigraph` env-gated dump (`ARCHIGRAPH_BUG_RESOLVER_SAMPLES=80`); ran per-repo `archigraph index --json-stats`; bucketed via histogram + manual sample inspection.
+**Time on harness:** ~3 min for the four repos covered.
+
+forbidden-term grep: clean
+
+## Per-repo baseline
+
+ToID-side bug-resolver edges only (the dump skips FromID — bug-resolver is overwhelmingly a ToID phenomenon, mirroring #91). Histogram TOTAL is therefore lower than `disposition_counts['bug-resolver']`, which counts both endpoints.
+
+| repo | dispositions: bug-resolver | bug-rate% | dump TOTAL | top category |
+| --- | ---: | ---: | ---: | --- |
+| go-gin | 105 | 43.6 | 72 | `ambig-bare-hint-fail` 52.78% |
+| java-spring-petclinic | 84 | 60.1 | 55 | `ambig-bare-no-hint` 52.73% |
+| python-flask-realworld | 122 | 52.9 | 113 | `ambig-bare-no-hint` 69.91% |
+| ruby-rails-realworld | 39 | 25.6 | 39 | `ambig-bare-no-hint` 100.00% |
+
+**Two categories dominate every repo**: `ambig-bare-no-hint` (bare-name lookup ambiguous; relKind has no registered hint family) and `ambig-bare-hint-fail` (relKind hint registered but the hint family still sees >=2 candidates or zero in the family). `kind-mismatch` and `ambig-kind` are <6% combined across the corpus.
+
+## Diagnostic categories (from `BugResolverDiag.Category`)
+
+The classifier in `classifyDispositionLang` declares an endpoint bug-resolver when the leaf name exists *somewhere* in the graph but `LookupStatusHint` returned a non-rewritten status. `DiagnoseBugResolver` re-walks the same indexes to pinpoint *why*:
+
+| category | meaning |
+| --- | --- |
+| `kind-mismatch` | stub had `Kind:Name`; that kind exists in the graph but not for this name; bare-name is also ambiguous or absent. |
+| `ambig-kind` | `Kind:Name` where `(kind, name)` is itself ambiguous (multiple entities at the same kind+name). |
+| `ambig-bare-no-hint` | bare-name lookup ambiguous and the relKind has NO registered hint family in `hintKinds()`. |
+| `ambig-bare-hint-fail` | relKind hint exists but the hint family had zero or >=2 candidates with this name. |
+| `ambig-qualified` | stub matched a `byQualifiedName` entry but with the blank-string sentinel (collision). |
+| `unknown` | none of the above; should be near-zero. |
+
+## Top-3 patterns per repo
+
+### go-gin — bug-resolver=105, dump=72
+
+1. **`DEPENDS_ON RouterGroup` (23 of 72)** — `DEPENDS_ON` has no hint family registered in `hintKinds()`; `RouterGroup` exists multiple times (`Component` + `SCOPE.Component`) so `byName` is ambiguous. Same shape for `SecureJSON`, `PureJSON`, `AsciiJSON` (depended-on response writer types).
+2. **`CALLS validate` (16) / `CALLS Default` (9) / `CALLS ResponseWriter` (7)** — `ambig-bare-hint-fail`. The Operation hint family fires but matches multiple entities (e.g. `validate` exists as both Function and Method on different receivers), so `lookupByKindHint` aborts. Receiver-binding gap — same root cause as the cross-file method patterns identified in #91.
+3. **`IMPORTS maps` (2)** — `IMPORTS` has no hint family. `maps` collides between the Go stdlib `maps` package (synthesised entity) and a project-internal `maps` Component.
+
+### java-spring-petclinic — bug-resolver=84, dump=55
+
+1. **`CALLS name` from PetControllerTests / ValidatorTests (25 of 55)** — `ambig-bare-hint-fail`. The KindsPresent column reveals the bug: `name` exists ONLY as `Schema` and `SCOPE.Schema` entities (SQL column names from the Petclinic schema files). The Operation hint family has no `name` entity, so the hint returns zero matches. **This is a cross-language false bug-resolver**: a Java `.name(...)` method call collides with a SQL column entity. Should arguably be classified as bug-extractor (no method named `name`) but the `nameExists()` check in `classifyDispositionLang` is kind-agnostic.
+2. **`CONTAINS first_name|last_name|name|...` (~12)** — `ambig-bare-no-hint`. SQL schema CONTAINS edges from a `Schema` entity to bare column names. Multiple schemas have a column named `name` / `first_name`. CONTAINS has no hint registered.
+3. **`REFERENCES vets|specialties|pets|owners|types|visits` and `INDEXES visits` (~7)** — same SQL-schema ambiguity. `REFERENCES`/`INDEXES` have no hint family.
+
+### python-flask-realworld — bug-resolver=122, dump=113
+
+1. **Project-local Python IMPORTS (`conduit.database.db`, `conduit.user.models.User`, `conduit.exceptions.InvalidUsage`, `..views`, …)** — `ambig-bare-no-hint`. Dotted import paths probed against `byName` against the full string fail when the project's `__init__.py` re-exports the same name from multiple modules (so `User` is ambiguous; the dotted path lookup also misses because `byQualifiedName` keys on the entity's QualifiedName which doesn't include the importing alias style). IMPORTS has no hint family.
+2. **External library IMPORTS that DO have a project-internal collision (`marshmallow.Schema`, `marshmallow.fields`, `flask_jwt_extended.jwt_required`, …)** — same `ambig-bare-no-hint` shape, but here the bare leaf (`Schema`, `fields`, `jwt_required`) collides between an external-package alias and an in-project Component. The synth pass should have routed these to `ext:marshmallow` / `ext:flask_jwt_extended` but the importing form (`from marshmallow import Schema`) reaches the resolver as a bare leaf without the package prefix.
+3. **CALLS bare-name (8 rows: `Comment`, `Tags`, `User`, `UserProfile`, `_register_user`)** — bare-name calls to constructors and helpers that exist as both `Component` and `Operation` in the graph (model class + factory function with same name); CALLS hint picks Operation family but multiple Operations share the leaf.
+
+### ruby-rails-realworld — bug-resolver=39, dump=39 (100%)
+
+1. **`CONTAINS up|down|change|create|destroy|show|index|update` from controller / migration classes (28 of 39)** — `ambig-bare-no-hint` 100%. The Ruby extractor (`internal/extractors/ruby/ruby.go:95`) emits `ToID: child.Name` — bare leaf — for class→method CONTAINS edges. Every Rails app has dozens of controllers each defining `create`, `destroy`, `index`, etc., so bare-name is always ambiguous. CONTAINS has no hint family. **The fix is at the extractor**: emit a structural-ref `scope:operation:...:<file>:<class>#<method>` instead of the bare method name. (Same pattern applies to ActiveRecord migration `up`/`down`/`change` callbacks — class methods sharing a name across migration files.)
+2. **`CONTAINS find_article!` and similar bang/method-name controller helpers (4)** — same shape, bang methods used as `before_action` filters.
+3. **`IMPORTS test_helper` (4)** — Ruby `require 'test_helper'` resolves to the project's `test/test_helper.rb`, which exists as a Component. The literal `test_helper` is unique within the corpus but is registered under both `Component` and `SCOPE.Component`, making `byName` ambiguous and `IMPORTS` unable to disambiguate (no hint family).
+
+## Cross-cutting observations
+
+1. **`CONTAINS` is the dominant rel kind for `ambig-bare-no-hint`**. Across rails-realworld, spring-petclinic SQL schemas, and partly java-spring-petclinic, CONTAINS edges from a parent (Class / Schema) to a bare child name are the single biggest pattern. The parent's file IS known at resolve time (FromID is hex by Pass 2.5), so a structural-ref / file-scoped lookup would resolve every one. **Highest-leverage fix.**
+2. **No relKind hint for `IMPORTS`, `CONTAINS`, `DEPENDS_ON`, `REFERENCES`, `INDEXES`**. Only `EXTENDS`/`IMPLEMENTS` (Component family) and `CALLS` (Operation family) are wired. Adding hint families for these other kinds would help, but in practice the bare-name pool is too crowded for a kind-only hint to disambiguate (see rails-realworld `create`).
+3. **Cross-language same-name collisions inflate bug-resolver**. The most striking case is java-spring-petclinic `CALLS name`: the Java method call collides with a SQL `Schema:name` column entity, and the kind-agnostic `nameExists()` happily reports "exists", flipping the classifier from bug-extractor to bug-resolver. A KindsPresent-aware classifier (when relKind is CALLS and KindsPresent has zero Operation-family kinds, classify as bug-extractor) would re-bucket these.
+4. **Project-internal IMPORTS in Python and JS** ride on the dotted-name shape; they need a per-language importer that attempts segment-by-segment resolution against `byQualifiedName` rather than treating the whole dotted string as a single byName key.
+
+## Quick wins evaluated
+
+Considered the following and **did not land any in this PR** for the reasons noted:
+
+- **Add `IMPORTS` / `CONTAINS` / `DEPENDS_ON` to `hintKinds()`**: too coarse to disambiguate the dominant patterns. `create` exists as 6+ Operations in rails-realworld; the Operation-family hint still aborts. Would move <10 edges across the four-repo set.
+- **Resolver-side parent-file fallback for CONTAINS**: cleanest fix for the rails-realworld pattern but requires (a) a new `byID → SourceFile` index inside `Index`, (b) a new lookup branch in `LookupStatusHint`, and (c) regression tests. Past the 1–2 hour quick-win envelope and overlaps with the structural-ref work tracked under PORT-2-FIX-2.
+- **Promote false bug-resolver to bug-extractor when KindsPresent has no hint-family overlap**: clean two-line classifier patch but bends the issue #44 metric (would re-allocate ~25 of 84 spring-petclinic bug-resolver rows into bug-extractor). That moves the goalposts without fixing anything; better tracked as a separate scoring proposal.
+
+The right shape of fix is per-extractor: emit structural-refs (`scope:operation:<lang>:<file>:<class>#<method>`) instead of bare leaf names for `CONTAINS` edges. The structural-ref resolver path (`lookupStructural`) already handles these without ambiguity. This is per-extractor work, scoped per language, tracked in the follow-up issues below.
+
+## Follow-up issues filed
+
+| # | language(s) | title |
+| --- | --- | --- |
+| TBD | ruby | Ruby extractor emits bare-name CONTAINS instead of structural-ref (rails-realworld 100% bug-resolver) |
+| TBD | java / sql | SQL schema CONTAINS / REFERENCES / INDEXES emit bare column names; Java CALLS to common method names collide |
+| TBD | python | Project-internal Python IMPORTS with dotted path don't resolve via byQualifiedName segment matching |
+| TBD | go | Go DEPENDS_ON edges to RouterGroup-style framework types ambiguous between Component and SCOPE.Component |
+| TBD | resolver | Cross-language bug-resolver mis-classification: kind-agnostic `nameExists()` flips bug-extractor to bug-resolver |

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -21,6 +21,7 @@ package resolve
 import (
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/types"
@@ -1318,6 +1319,119 @@ func (idx Index) nameExists(name string) bool {
 		return true
 	}
 	return false
+}
+
+// BugResolverDiag is a diagnostic record describing why a stub flagged as
+// bug-resolver failed to bind. Returned by DiagnoseBugResolver. Fields are
+// stable for the lifetime of issue #92; callers should not depend on
+// values being non-empty across releases.
+type BugResolverDiag struct {
+	// Category is a short token suitable for histogram bucketing. One of:
+	//   "kind-mismatch"          — stub had Kind:Name; that kind exists but
+	//                              not for this name; bare-name is also
+	//                              ambiguous or missing.
+	//   "ambig-kind"             — Kind:Name where (kind, name) is ambiguous.
+	//   "ambig-bare-no-hint"     — bare-name lookup ambiguous and no relKind
+	//                              hint was supplied or the hint had no
+	//                              registered family.
+	//   "ambig-bare-hint-fail"   — relKind hint family didn't disambiguate
+	//                              (zero or >=2 candidates in the family).
+	//   "ambig-qualified"        — stub matched a QualifiedName but it
+	//                              collided with another entity.
+	//   "unknown"                — none of the above matched; should be rare.
+	Category string
+	// Name is the bare leaf name probed against byName / nameKinds.
+	Name string
+	// StubKind is the Kind: prefix segment when present (else "").
+	StubKind string
+	// KindsPresent is the sorted list of entity kinds the graph holds for
+	// this Name. A value with multiple entries plus a missing StubKind
+	// match is the "kind-mismatch" pattern; a single entry is an
+	// "ambig-bare-*" pattern (multiple entities share that name+kind).
+	KindsPresent []string
+	// RelKindHint is the relationship-kind hint that was tried (e.g.
+	// CALLS, EXTENDS). Empty when the caller didn't supply one.
+	RelKindHint string
+	// HintFamily lists the entity-kind families the hint biases toward.
+	// Empty when relKind has no registered hint or no hint was passed.
+	HintFamily []string
+}
+
+// DiagnoseBugResolver returns a BugResolverDiag describing the failure
+// mode for a stub that classifyDispositionLang labelled
+// DispositionBugResolver. The classifier's own decision is NOT re-checked
+// here; callers feed only stubs they have already classified as
+// bug-resolver. Issue #92 — diagnostic instrumentation, not a hot path.
+func (idx Index) DiagnoseBugResolver(originalStub, relKind string) BugResolverDiag {
+	diag := BugResolverDiag{Category: "unknown", RelKindHint: relKind}
+	if originalStub == "" {
+		return diag
+	}
+
+	// Direct QualifiedName collision sentinel — byQualifiedName carries a
+	// blank string when two entities share the same QualifiedName.
+	if qid, ok := idx.byQualifiedName[originalStub]; ok && qid == "" {
+		diag.Category = "ambig-qualified"
+		diag.Name = originalStub
+		return diag
+	}
+
+	kind, name := splitStub(originalStub)
+	if strings.HasPrefix(originalStub, stubPrefixScope) {
+		parts := strings.SplitN(originalStub, stubDelim, stubScopeSegments)
+		if len(parts) == stubScopeSegments {
+			tail := parts[stubScopeTailIndex]
+			if hash := strings.IndexByte(tail, stubMemberDelim); hash >= 0 {
+				name = tail[hash+1:]
+			} else {
+				name = tail
+			}
+			kind = ""
+		}
+	}
+	diag.Name = name
+	diag.StubKind = kind
+
+	if bucket, ok := idx.nameKinds[name]; ok {
+		kinds := make([]string, 0, len(bucket))
+		for k := range bucket {
+			kinds = append(kinds, k)
+		}
+		sort.Strings(kinds)
+		diag.KindsPresent = kinds
+	}
+
+	families := hintKinds(relKind)
+	diag.HintFamily = families
+
+	switch {
+	case kind != "":
+		// Kind: prefix path. Kind-bucket missed for this name. Two
+		// shapes: either the (kind, name) tuple is itself ambiguous, or
+		// the name lives under DIFFERENT kinds entirely.
+		if idx.ambigKind[kind] != nil && idx.ambigKind[kind][name] {
+			diag.Category = "ambig-kind"
+			return diag
+		}
+		diag.Category = "kind-mismatch"
+		return diag
+	case idx.ambigName[name]:
+		// Bare-name ambiguous globally.
+		if len(families) == 0 {
+			diag.Category = "ambig-bare-no-hint"
+			return diag
+		}
+		diag.Category = "ambig-bare-hint-fail"
+		return diag
+	case len(diag.KindsPresent) > 0:
+		// nameKinds carries this name (so nameExists returned true) but
+		// neither byName nor ambigName tracks it — a same-(name,kind)
+		// duplicate registered as a blank-string sentinel inside a
+		// nameKinds bucket. Treat as ambig-kind for histogram purposes.
+		diag.Category = "ambig-kind"
+		return diag
+	}
+	return diag
 }
 
 // classifyDisposition returns the Disposition for an endpoint after the

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -921,4 +921,48 @@ func TestDiagnoseBugResolver(t *testing.T) {
 			t.Fatalf("category for empty stub: got %q want unknown", got.Category)
 		}
 	})
+
+	t.Run("ambig-qualified", func(t *testing.T) {
+		// Two entities sharing the same QualifiedName cause BuildIndex to
+		// blank the byQualifiedName entry. A stub equal to that QualifiedName
+		// is then diagnosed as ambig-qualified — the diagnoser short-circuits
+		// before kind/name splitting.
+		entities := []types.EntityRecord{
+			{ID: "1111111111111111", Kind: "SCOPE.Heading", Name: "Foo",
+				QualifiedName: "doc.md::foo", SourceFile: "doc.md"},
+			{ID: "2222222222222222", Kind: "SCOPE.Heading", Name: "Foo",
+				QualifiedName: "doc.md::foo", SourceFile: "doc.md"},
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("doc.md::foo", "CONTAINS")
+		if got.Category != "ambig-qualified" {
+			t.Fatalf("category: got %q, want ambig-qualified (diag=%+v)", got.Category, got)
+		}
+		if got.Name != "doc.md::foo" {
+			t.Fatalf("name: got %q want doc.md::foo", got.Name)
+		}
+	})
+
+	t.Run("kindsPresent-fallback", func(t *testing.T) {
+		// Bare-name stub for a name that appears in nameKinds but is NOT in
+		// ambigName and has no Kind: prefix. A single entity registers its
+		// name under nameKinds while leaving ambigName false, so the
+		// diagnoser falls through the kind-prefix and ambig-bare branches
+		// and lands on the kindsPresent-fallback case (returns ambig-kind
+		// per the histogram bucketing comment in DiagnoseBugResolver).
+		entities := []types.EntityRecord{
+			ent("aaaaaaaaaaaaaaaa", "Function", "loneFn"),
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("loneFn", "")
+		if got.Category != "ambig-kind" {
+			t.Fatalf("category: got %q, want ambig-kind via kindsPresent fallback (diag=%+v)", got.Category, got)
+		}
+		if len(got.KindsPresent) == 0 {
+			t.Fatalf("KindsPresent should be populated from nameKinds bucket; diag=%+v", got)
+		}
+		if got.StubKind != "" {
+			t.Fatalf("StubKind should be empty for bare-name stub; got %q", got.StubKind)
+		}
+	})
 }

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -844,3 +844,81 @@ func TestRubyRailsDSL_RejectedGenericCollectionOps(t *testing.T) {
 		})
 	}
 }
+
+// TestDiagnoseBugResolver — issue #92 diagnostic helper. Each subtest
+// constructs a graph that traps a bug-resolver stub at one well-defined
+// shape and asserts the category the diagnoser returns.
+func TestDiagnoseBugResolver(t *testing.T) {
+	t.Run("ambig-bare-no-hint", func(t *testing.T) {
+		// Two Functions named "create" → bare "create" call with relKind=CONTAINS
+		// (no hint family registered) is ambig-bare-no-hint.
+		entities := []types.EntityRecord{
+			ent("aaaaaaaaaaaaaaaa", "Function", "create"),
+			ent("bbbbbbbbbbbbbbbb", "Function", "create"),
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("create", "CONTAINS")
+		if got.Category != "ambig-bare-no-hint" {
+			t.Fatalf("category: got %q, want ambig-bare-no-hint (diag=%+v)", got.Category, got)
+		}
+		if got.Name != "create" {
+			t.Fatalf("name: got %q want create", got.Name)
+		}
+	})
+
+	t.Run("ambig-bare-hint-fail", func(t *testing.T) {
+		// Two Operations named "validate" → bare call with relKind=CALLS:
+		// hint family is operation, but multiple Operation matches → fail.
+		entities := []types.EntityRecord{
+			ent("aaaaaaaaaaaaaaaa", "Operation", "validate"),
+			ent("bbbbbbbbbbbbbbbb", "Operation", "validate"),
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("validate", "CALLS")
+		if got.Category != "ambig-bare-hint-fail" {
+			t.Fatalf("category: got %q, want ambig-bare-hint-fail (diag=%+v)", got.Category, got)
+		}
+		if len(got.HintFamily) == 0 {
+			t.Fatalf("HintFamily empty for CALLS")
+		}
+	})
+
+	t.Run("kind-mismatch", func(t *testing.T) {
+		// Stub is "Operation:foo" but graph has Schema:foo only. Kind
+		// bucket misses, kind-bucket has no entity, name lives under a
+		// different kind family entirely.
+		entities := []types.EntityRecord{
+			ent("aaaaaaaaaaaaaaaa", "Schema", "foo"),
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("Operation:foo", "CALLS")
+		if got.Category != "kind-mismatch" {
+			t.Fatalf("category: got %q, want kind-mismatch (diag=%+v)", got.Category, got)
+		}
+		if got.StubKind != "Operation" {
+			t.Fatalf("StubKind: got %q want Operation", got.StubKind)
+		}
+	})
+
+	t.Run("ambig-kind", func(t *testing.T) {
+		// Two Functions named "Bar" → "Function:Bar" stub is ambiguous
+		// within its kind.
+		entities := []types.EntityRecord{
+			ent("aaaaaaaaaaaaaaaa", "Function", "Bar"),
+			ent("bbbbbbbbbbbbbbbb", "Function", "Bar"),
+		}
+		idx := BuildIndex(entities)
+		got := idx.DiagnoseBugResolver("Function:Bar", "CALLS")
+		if got.Category != "ambig-kind" {
+			t.Fatalf("category: got %q, want ambig-kind (diag=%+v)", got.Category, got)
+		}
+	})
+
+	t.Run("empty-stub", func(t *testing.T) {
+		idx := BuildIndex(nil)
+		got := idx.DiagnoseBugResolver("", "CALLS")
+		if got.Category != "unknown" {
+			t.Fatalf("category for empty stub: got %q want unknown", got.Category)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- Adds `Index.DiagnoseBugResolver` and an env-gated dump (`ARCHIGRAPH_BUG_RESOLVER_SAMPLES`, `ARCHIGRAPH_BUG_RESOLVER_OUT`) mirroring the issue #89 bug-extractor instrumentation.
- Five-bucket category scheme: `kind-mismatch`, `ambig-kind`, `ambig-bare-no-hint`, `ambig-bare-hint-fail`, `ambig-qualified`.
- Report at `docs/verify2/issue-92-bug-resolver-categorization.md` covers go-gin, java-spring-petclinic, python-flask-realworld, ruby-rails-realworld.

## Findings

`ambig-bare-no-hint` + `ambig-bare-hint-fail` together account for >94% of every repo's bug-resolver edges. The single highest-leverage shape is bare-name `CONTAINS` edges from a parent class/schema to a child member name (rails-realworld is 100% this pattern). Fix is per-extractor: emit structural-refs (`scope:operation:<lang>:<file>:<class>#<method>`) instead of bare leaves.

No quick-win landed in this PR — every candidate fix either bends the metric (promote false bug-resolver to bug-extractor on cross-language collisions) or exceeds the 1–2h envelope (resolver-side parent-file fallback for CONTAINS). Filed as follow-ups in the report.

forbidden-term grep: clean

## Test plan

- [x] `go test ./...` — all packages pass.
- [x] `go test ./internal/resolve/ -run TestDiagnoseBugResolver -v` — five new subtests pass.
- [x] Harness re-run against four repos confirms category histograms render and totals line up with `disposition_counts['bug-resolver']` (off by FromID-side endpoints, which the dump intentionally skips).