### PR TITLE
fix(ruby): emit structural-ref for class CONTAINS method (Closes #140)

### DIFF
--- a/internal/extractors/ruby/relationships_test.go
+++ b/internal/extractors/ruby/relationships_test.go
@@ -69,9 +69,13 @@ end
 	if contains != 3 {
 		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, foo.Relationships)
 	}
+	// Issue #140 — CONTAINS edges target structural-ref stubs so the
+	// resolver can disambiguate same-name methods across different
+	// Rails controllers (Format A: scope:operation:method:ruby:<file>:<name>).
 	for _, m := range []string{"a", "b", "c"} {
-		if !rbHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", m) {
-			t.Errorf("expected CONTAINS Foo→%s", m)
+		want := "scope:operation:method:ruby:test.rb:" + m
+		if !rbHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
 	}
 }

--- a/internal/extractors/ruby/relationships_test.go
+++ b/internal/extractors/ruby/relationships_test.go
@@ -2,6 +2,7 @@ package ruby_test
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
@@ -77,6 +78,37 @@ end
 		if !rbHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
 			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
+	}
+}
+
+// TestRuby_ContainsClassMethods_OSNativePath (#140): structural-ref ToID
+// must be normalized via filepath.ToSlash so OS-native separators (e.g.
+// Windows backslashes) produce forward-slash refs that match the
+// resolver's convention (internal/resolve/refs.go:93,785). On POSIX the
+// separator is already "/" so this test exercises the no-op branch;
+// constructing the input via filepath.FromSlash makes the assertion
+// meaningful on every host (backslashes on Windows, slashes elsewhere).
+func TestRuby_ContainsClassMethods_OSNativePath(t *testing.T) {
+	src := `class Foo
+  def a; end
+end
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("ruby")
+	nativePath := filepath.FromSlash("app/controllers/foo.rb")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     nativePath,
+		Content:  []byte(src),
+		Language: "ruby",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	want := "scope:operation:method:ruby:app/controllers/foo.rb:a"
+	if !rbHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+		foo := rbFind(ents, "Foo", "SCOPE.Component")
+		t.Errorf("expected CONTAINS Foo→%s; got rels=%+v", want, foo.Relationships)
 	}
 }
 

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -90,9 +90,17 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #140 — bare-name CONTAINS targets are 100%
+				// ambiguous in Rails apps where dozens of controllers
+				// share the same `create`/`destroy`/`index` methods.
+				// Emit a structural-ref (Format A) keyed on the source
+				// file so the resolver disambiguates by location;
+				// each Rails class is its own file by convention so
+				// the file-local method name is unique.
+				toID := "scope:operation:method:ruby:" + file.Path + ":" + child.Name
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -12,6 +12,7 @@ package ruby
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -97,7 +98,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// file so the resolver disambiguates by location;
 				// each Rails class is its own file by convention so
 				// the file-local method name is unique.
-				toID := "scope:operation:method:ruby:" + file.Path + ":" + child.Name
+				toID := "scope:operation:method:ruby:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -966,3 +966,42 @@ func TestDiagnoseBugResolver(t *testing.T) {
 		}
 	})
 }
+
+// Issue #140 — Ruby class CONTAINS edges must use a structural-ref so that
+// same-named methods (e.g. Rails `create` in many controllers) resolve to
+// the file-local method rather than landing in the bug-resolver bucket.
+//
+// Two Ruby files each define a `create` method inside a class. The CONTAINS
+// edges from each class must rewrite to the matching file-local method ID,
+// not to the other file's `create`.
+func TestReferences_RubyClassContainsStructuralRef(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Component", "UsersController", "app/controllers/users_controller.rb"),
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Operation", "create", "app/controllers/users_controller.rb"),
+		entAt("cccccccccccccccc", "SCOPE.Component", "PostsController", "app/controllers/posts_controller.rb"),
+		entAt("dddddddddddddddd", "SCOPE.Operation", "create", "app/controllers/posts_controller.rb"),
+	}
+	rels := []types.RelationshipRecord{
+		{
+			FromID: "aaaaaaaaaaaaaaaa",
+			ToID:   "scope:operation:method:ruby:app/controllers/users_controller.rb:create",
+			Kind:   "CONTAINS",
+		},
+		{
+			FromID: "cccccccccccccccc",
+			ToID:   "scope:operation:method:ruby:app/controllers/posts_controller.rb:create",
+			Kind:   "CONTAINS",
+		},
+	}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("users#create: ToID=%s, want bbbbbbbbbbbbbbbb", rels[0].ToID)
+	}
+	if rels[1].ToID != "dddddddddddddddd" {
+		t.Fatalf("posts#create: ToID=%s, want dddddddddddddddd", rels[1].ToID)
+	}
+	if stats.Rewritten != 2 {
+		t.Fatalf("expected 2 rewrites, got %+v", stats)
+	}
+}


### PR DESCRIPTION
## Summary
- Ruby class→method CONTAINS edges emitted bare leaf names (e.g. `create`) as ToID. In Rails apps where every controller defines `create`/`destroy`/`index`, this is always ambiguous → 100% bug-resolver.
- Now emits a Format A structural-ref `scope:operation:method:ruby:<file>:<method>` so the resolver disambiguates by source-file location. Each Rails class lives in its own file, so file-keyed lookup is unique.
- New TDD test in `internal/resolve/refs_test.go` proves two Ruby files each containing a `create` method resolve to distinct entity IDs via the structural-ref.

## VERIFY-2 measurements (rails-realworld + sidekiq)

| repo            | metric           | baseline | current |
| --------------- | ---------------- | -------- | ------- |
| rails-realworld | bug-resolver %   | 7.44%    | 0.76%   |
| rails-realworld | aggregate bug-rate | 25.57% | 18.89%  |
| sidekiq         | bug-resolver %   | 10.67%   | 4.23%   |
| sidekiq         | aggregate bug-rate | 23.31% | 16.88%  |

## Test plan
- [x] `go test ./internal/extractors/ruby/... ./internal/resolve/...` green
- [x] `go test ./...` green
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] VERIFY-2 single-repo runs on rails-realworld and sidekiq compared baseline (origin/main) vs HEAD

Closes #140
Refs #92