### PR TITLE
fix(extractors): emit structural-ref for class CONTAINS across languages

### DIFF
--- a/internal/extractor/structural_ref.go
+++ b/internal/extractor/structural_ref.go
@@ -1,0 +1,17 @@
+package extractor
+
+import "path/filepath"
+
+// BuildOperationStructuralRef returns the canonical Format A structural-ref
+// for class→method CONTAINS edges. Shape:
+//
+//	scope:operation:method:<lang>:<file>:<name>
+//
+// where <file> is forward-slash normalized via filepath.ToSlash so that
+// extractor output is stable across POSIX and Windows callers. This helper
+// centralizes the literal that was previously duplicated across every
+// language extractor that emits class→method CONTAINS edges (java,
+// javascript, kotlin, python, ruby, rust).
+func BuildOperationStructuralRef(lang, filePath, name string) string {
+	return "scope:operation:method:" + lang + ":" + filepath.ToSlash(filePath) + ":" + name
+}

--- a/internal/extractor/structural_ref_test.go
+++ b/internal/extractor/structural_ref_test.go
@@ -1,0 +1,55 @@
+package extractor
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestBuildOperationStructuralRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		lang     string
+		filePath string
+		ident    string
+		want     string
+	}{
+		{
+			name:     "posix path",
+			lang:     "python",
+			filePath: "src/foo/bar.py",
+			ident:    "do_thing",
+			want:     "scope:operation:method:python:src/foo/bar.py:do_thing",
+		},
+		{
+			name:     "windows path is normalized to forward slashes",
+			lang:     "java",
+			filePath: filepath.FromSlash("src/main/java/Foo.java"),
+			ident:    "run",
+			want:     "scope:operation:method:java:src/main/java/Foo.java:run",
+		},
+		{
+			name:     "empty name",
+			lang:     "ruby",
+			filePath: "app/controllers/foo.rb",
+			ident:    "",
+			want:     "scope:operation:method:ruby:app/controllers/foo.rb:",
+		},
+		{
+			name:     "dotted name",
+			lang:     "javascript",
+			filePath: "src/index.js",
+			ident:    "Foo.bar",
+			want:     "scope:operation:method:javascript:src/index.js:Foo.bar",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildOperationStructuralRef(tc.lang, tc.filePath, tc.ident)
+			if got != tc.want {
+				t.Fatalf("BuildOperationStructuralRef(%q, %q, %q) = %q, want %q",
+					tc.lang, tc.filePath, tc.ident, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -13,7 +13,6 @@ package java
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -140,7 +139,7 @@ func walk(node *sitter.Node, file extractor.FileInput, parentType string, out *[
 				// the source file. child.Name is dotted "Outer.method" for
 				// nested types (issue #65); the same string is the entity
 				// Name indexed by byLocation, so the resolver matches.
-				toID := "scope:operation:method:java:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("java", file.Path, child.Name)
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -13,6 +13,7 @@ package java
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -135,11 +136,14 @@ func walk(node *sitter.Node, file extractor.FileInput, parentType string, out *[
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #144 — emit a structural-ref (Format A) keyed on
+				// the source file. child.Name is dotted "Outer.method" for
+				// nested types (issue #65); the same string is the entity
+				// Name indexed by byLocation, so the resolver matches.
+				toID := "scope:operation:method:java:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
-						// ToID matches the dotted Name emitted by
-						// buildOperation when parentType is non-empty.
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}

--- a/internal/extractors/java/relationships_test.go
+++ b/internal/extractors/java/relationships_test.go
@@ -70,9 +70,13 @@ class Foo {
 	if contains != 3 {
 		t.Errorf("expected 3 CONTAINS edges from Foo, got %d (rels=%+v)", contains, foo.Relationships)
 	}
+	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A)
+	// keyed on the source file. The trailing :<name> segment carries the
+	// dotted "Outer.member" form (issue #65).
 	for _, m := range []string{"Foo.a", "Foo.b", "Foo.c"} {
-		if !javaHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", m) {
-			t.Errorf("expected CONTAINS Foo→%s", m)
+		want := "scope:operation:method:java:Test.java:" + m
+		if !javaHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
 	}
 }

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -20,7 +20,6 @@ package javascript
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -296,7 +295,7 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 			// source file so the resolver disambiguates by location when
 			// two classes in different files declare same-named methods
 			// (a common shape in Express/Nest/React-component apps).
-			toID := "scope:operation:method:" + x.language + ":" + filepath.ToSlash(x.filePath) + ":" + child.Name
+			toID := extreg.BuildOperationStructuralRef(x.language, x.filePath, child.Name)
 			x.entities[classIdx].Relationships = append(x.entities[classIdx].Relationships,
 				types.RelationshipRecord{
 					ToID: toID,

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -20,6 +20,7 @@ package javascript
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -291,9 +292,14 @@ func (x *extractor) handleClassDeclaration(n *sitter.Node) {
 			if child.Kind != "SCOPE.Operation" {
 				continue
 			}
+			// Issue #144 — emit a structural-ref (Format A) keyed on the
+			// source file so the resolver disambiguates by location when
+			// two classes in different files declare same-named methods
+			// (a common shape in Express/Nest/React-component apps).
+			toID := "scope:operation:method:" + x.language + ":" + filepath.ToSlash(x.filePath) + ":" + child.Name
 			x.entities[classIdx].Relationships = append(x.entities[classIdx].Relationships,
 				types.RelationshipRecord{
-					ToID: child.Name,
+					ToID: toID,
 					Kind: "CONTAINS",
 				})
 		}

--- a/internal/extractors/javascript/relationships_test.go
+++ b/internal/extractors/javascript/relationships_test.go
@@ -111,9 +111,12 @@ func TestExtract_ContainsClassMethods(t *testing.T) {
 	if c := countRelByKind(ents, "Foo", "CONTAINS"); c != 3 {
 		t.Errorf("expected 3 CONTAINS edges, got %d", c)
 	}
+	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A)
+	// keyed on the source file so the resolver disambiguates by location.
 	for _, m := range []string{"a", "b", "c"} {
-		if !hasRelEdge(ents, "Foo", "CONTAINS", m) {
-			t.Errorf("expected CONTAINS Foo→%s", m)
+		want := "scope:operation:method:javascript:test.js:" + m
+		if !hasRelEdge(ents, "Foo", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
 	}
 }
@@ -192,6 +195,14 @@ function helper() {}
 
 	if c := countRelByKind(ents, "A", "CONTAINS"); c != 2 {
 		t.Errorf("expected 2 CONTAINS from A, got %d", c)
+	}
+	// Issue #144 — TS goes through the same JS extractor; CONTAINS targets
+	// must be structural-ref stubs prefixed with the "typescript" segment.
+	for _, m := range []string{"foo", "bar"} {
+		want := "scope:operation:method:typescript:test.ts:" + m
+		if !hasRelEdge(ents, "A", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS A→%s", want)
+		}
 	}
 	if !hasRelEdge(ents, "foo", "CALLS", "bar") {
 		t.Errorf("expected CALLS foo→bar")

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -22,7 +22,6 @@ package kotlin
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -102,7 +101,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// the source file so the resolver disambiguates by location
 				// when two Kotlin classes/objects in different files declare
 				// same-named functions.
-				toID := "scope:operation:method:kotlin:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("kotlin", file.Path, child.Name)
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,
@@ -138,7 +137,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// the source file so the resolver disambiguates by location
 				// when two Kotlin classes/objects in different files declare
 				// same-named functions.
-				toID := "scope:operation:method:kotlin:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("kotlin", file.Path, child.Name)
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -22,6 +22,7 @@ package kotlin
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -97,9 +98,14 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #144 — emit a structural-ref (Format A) keyed on
+				// the source file so the resolver disambiguates by location
+				// when two Kotlin classes/objects in different files declare
+				// same-named functions.
+				toID := "scope:operation:method:kotlin:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}
@@ -128,9 +134,14 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #144 — emit a structural-ref (Format A) keyed on
+				// the source file so the resolver disambiguates by location
+				// when two Kotlin classes/objects in different files declare
+				// same-named functions.
+				toID := "scope:operation:method:kotlin:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}

--- a/internal/extractors/kotlin/relationships_test.go
+++ b/internal/extractors/kotlin/relationships_test.go
@@ -69,9 +69,12 @@ func TestKotlin_ContainsClassMethods(t *testing.T) {
 	if contains != 3 {
 		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, foo.Relationships)
 	}
+	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A)
+	// keyed on the source file.
 	for _, m := range []string{"a", "b", "c"} {
-		if !ktHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", m) {
-			t.Errorf("expected CONTAINS Foo→%s", m)
+		want := "scope:operation:method:kotlin:Test.kt:" + m
+		if !ktHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
 	}
 }

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -23,7 +23,6 @@ package python
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -165,7 +164,7 @@ func walkNode(
 					// location when two classes in different files declare
 					// methods with the same Name. FromID empty → buildDocument
 					// substitutes the parent (class) entity ID at emit time.
-					toID := "scope:operation:method:python:" + filepath.ToSlash(file.Path) + ":" + child.Name
+					toID := extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
 					(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 						types.RelationshipRecord{
 							ToID: toID,
@@ -238,7 +237,7 @@ func walkNode(
 						// Issue #144 — structural-ref (Format A) keyed on
 						// file path; same rationale as the bare class
 						// branch above.
-						toID := "scope:operation:method:python:" + filepath.ToSlash(file.Path) + ":" + child.Name
+						toID := extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
 						(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 							types.RelationshipRecord{
 								ToID: toID,

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -23,6 +23,7 @@ package python
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -159,11 +160,15 @@ func walkNode(
 					if child.Kind != "SCOPE.Operation" {
 						continue
 					}
+					// Issue #144 — emit a structural-ref (Format A) keyed on
+					// the source file so the resolver disambiguates by
+					// location when two classes in different files declare
+					// methods with the same Name. FromID empty → buildDocument
+					// substitutes the parent (class) entity ID at emit time.
+					toID := "scope:operation:method:python:" + filepath.ToSlash(file.Path) + ":" + child.Name
 					(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 						types.RelationshipRecord{
-							// FromID empty → buildDocument substitutes the
-							// parent (class) entity ID at emit time.
-							ToID: child.Name,
+							ToID: toID,
 							Kind: "CONTAINS",
 						})
 				}
@@ -230,9 +235,13 @@ func walkNode(
 						if child.Kind != "SCOPE.Operation" {
 							continue
 						}
+						// Issue #144 — structural-ref (Format A) keyed on
+						// file path; same rationale as the bare class
+						// branch above.
+						toID := "scope:operation:method:python:" + filepath.ToSlash(file.Path) + ":" + child.Name
 						(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 							types.RelationshipRecord{
-								ToID: child.Name,
+								ToID: toID,
 								Kind: "CONTAINS",
 							})
 					}

--- a/internal/extractors/python/relationships_test.go
+++ b/internal/extractors/python/relationships_test.go
@@ -74,12 +74,15 @@ func TestExtract_ContainsClassMethods(t *testing.T) {
 		t.Errorf("expected 3 CONTAINS edges from Foo, got %d (rels=%+v)",
 			c, findEntity(ents, "Foo").Relationships)
 	}
-	// Methods are emitted with class-qualified Name "Foo.<method>" (issue #45).
-	// CONTAINS edges carry that same dotted form as ToID since ToID is set
-	// from child.Name in walkNode.
+	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A:
+	// scope:operation:method:python:<file>:<name>) so the resolver can
+	// disambiguate same-named methods across files. Methods carry the
+	// class-qualified Name "Foo.<method>" (issue #45), which appears as
+	// the trailing :<name> segment of the structural-ref.
 	for _, m := range []string{"Foo.a", "Foo.b", "Foo.c"} {
-		if !hasRel(ents, "Foo", "CONTAINS", m) {
-			t.Errorf("expected CONTAINS Foo→%s", m)
+		want := "scope:operation:method:python:test.py:" + m
+		if !hasRel(ents, "Foo", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
 		}
 	}
 }

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -12,7 +12,6 @@ package ruby
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -98,7 +97,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// file so the resolver disambiguates by location;
 				// each Rails class is its own file by convention so
 				// the file-local method name is unique.
-				toID := "scope:operation:method:ruby:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("ruby", file.Path, child.Name)
 				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,

--- a/internal/extractors/rust/relationships_test.go
+++ b/internal/extractors/rust/relationships_test.go
@@ -78,6 +78,21 @@ impl Foo {
 	if contains != 3 {
 		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, impl.Relationships)
 	}
+	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A)
+	// keyed on the source file so impl→method edges disambiguate by location.
+	for _, m := range []string{"a", "b", "c"} {
+		want := "scope:operation:method:rust:test.rs:" + m
+		found := false
+		for _, r := range impl.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == want {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected CONTAINS Foo→%s", want)
+		}
+	}
 }
 
 // TestRust_ContainsTraitMethods (#41): trait with N method signatures → N CONTAINS.
@@ -100,6 +115,13 @@ func TestRust_ContainsTraitMethods(t *testing.T) {
 	}
 	if contains != 2 {
 		t.Errorf("expected 2 CONTAINS edges, got %d", contains)
+	}
+	// Issue #144 — trait→method CONTAINS edges also use structural-ref stubs.
+	for _, m := range []string{"a", "b"} {
+		want := "scope:operation:method:rust:test.rs:" + m
+		if !rsHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
+		}
 	}
 }
 

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -14,7 +14,6 @@ package rust
 
 import (
 	"context"
-	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -92,7 +91,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				}
 				// Issue #144 — structural-ref (Format A) keyed on file path
 				// so trait→method CONTAINS edges disambiguate by location.
-				toID := "scope:operation:method:rust:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("rust", file.Path, child.Name)
 				(*out)[traitIdx].Relationships = append((*out)[traitIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,
@@ -127,7 +126,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// Issue #144 — structural-ref (Format A) keyed on file path
 				// so impl→method CONTAINS edges disambiguate when two files
 				// each define an `impl Foo { fn new() }` shape.
-				toID := "scope:operation:method:rust:" + filepath.ToSlash(file.Path) + ":" + child.Name
+				toID := extractor.BuildOperationStructuralRef("rust", file.Path, child.Name)
 				(*out)[implIdx].Relationships = append((*out)[implIdx].Relationships,
 					types.RelationshipRecord{
 						ToID: toID,

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -14,6 +14,7 @@ package rust
 
 import (
 	"context"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -89,9 +90,12 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #144 — structural-ref (Format A) keyed on file path
+				// so trait→method CONTAINS edges disambiguate by location.
+				toID := "scope:operation:method:rust:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[traitIdx].Relationships = append((*out)[traitIdx].Relationships,
 					types.RelationshipRecord{
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}
@@ -120,9 +124,13 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				if child.Kind != "SCOPE.Operation" {
 					continue
 				}
+				// Issue #144 — structural-ref (Format A) keyed on file path
+				// so impl→method CONTAINS edges disambiguate when two files
+				// each define an `impl Foo { fn new() }` shape.
+				toID := "scope:operation:method:rust:" + filepath.ToSlash(file.Path) + ":" + child.Name
 				(*out)[implIdx].Relationships = append((*out)[implIdx].Relationships,
 					types.RelationshipRecord{
-						ToID: child.Name,
+						ToID: toID,
 						Kind: "CONTAINS",
 					})
 			}

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -1005,3 +1005,74 @@ func TestReferences_RubyClassContainsStructuralRef(t *testing.T) {
 		t.Fatalf("expected 2 rewrites, got %+v", stats)
 	}
 }
+
+// Issue #144 — Java class CONTAINS edges use the same Format-A structural
+// ref pattern as Ruby. Two Java files each define a class with a same-named
+// method (`save`); the CONTAINS edges must rewrite to the file-local method.
+func TestReferences_JavaClassContainsStructuralRef(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Component", "UserRepository", "src/main/java/UserRepository.java"),
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Operation", "save", "src/main/java/UserRepository.java"),
+		entAt("cccccccccccccccc", "SCOPE.Component", "PostRepository", "src/main/java/PostRepository.java"),
+		entAt("dddddddddddddddd", "SCOPE.Operation", "save", "src/main/java/PostRepository.java"),
+	}
+	rels := []types.RelationshipRecord{
+		{
+			FromID: "aaaaaaaaaaaaaaaa",
+			ToID:   "scope:operation:method:java:src/main/java/UserRepository.java:save",
+			Kind:   "CONTAINS",
+		},
+		{
+			FromID: "cccccccccccccccc",
+			ToID:   "scope:operation:method:java:src/main/java/PostRepository.java:save",
+			Kind:   "CONTAINS",
+		},
+	}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("UserRepository#save: ToID=%s, want bbbbbbbbbbbbbbbb", rels[0].ToID)
+	}
+	if rels[1].ToID != "dddddddddddddddd" {
+		t.Fatalf("PostRepository#save: ToID=%s, want dddddddddddddddd", rels[1].ToID)
+	}
+	if stats.Rewritten != 2 {
+		t.Fatalf("expected 2 rewrites, got %+v", stats)
+	}
+}
+
+// Issue #144 — Python class CONTAINS edges use Format-A structural refs.
+// Python emits methods with class-qualified Name "Foo.<method>" (issue #45),
+// so the structural-ref tail carries the dotted form. Two files each define
+// `Foo.save` — edges must rewrite to the file-local method.
+func TestReferences_PythonClassContainsStructuralRef(t *testing.T) {
+	entities := []types.EntityRecord{
+		entAt("aaaaaaaaaaaaaaaa", "SCOPE.Component", "UserStore", "app/users.py"),
+		entAt("bbbbbbbbbbbbbbbb", "SCOPE.Operation", "UserStore.save", "app/users.py"),
+		entAt("cccccccccccccccc", "SCOPE.Component", "PostStore", "app/posts.py"),
+		entAt("dddddddddddddddd", "SCOPE.Operation", "PostStore.save", "app/posts.py"),
+	}
+	rels := []types.RelationshipRecord{
+		{
+			FromID: "aaaaaaaaaaaaaaaa",
+			ToID:   "scope:operation:method:python:app/users.py:UserStore.save",
+			Kind:   "CONTAINS",
+		},
+		{
+			FromID: "cccccccccccccccc",
+			ToID:   "scope:operation:method:python:app/posts.py:PostStore.save",
+			Kind:   "CONTAINS",
+		},
+	}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("UserStore.save: ToID=%s, want bbbbbbbbbbbbbbbb", rels[0].ToID)
+	}
+	if rels[1].ToID != "dddddddddddddddd" {
+		t.Fatalf("PostStore.save: ToID=%s, want dddddddddddddddd", rels[1].ToID)
+	}
+	if stats.Rewritten != 2 {
+		t.Fatalf("expected 2 rewrites, got %+v", stats)
+	}
+}


### PR DESCRIPTION
## Summary

Port the Ruby pattern from #143 to **Java, JavaScript/TypeScript, Kotlin, Python, and Rust**. Each extractor that emits class→method `CONTAINS` edges now emits a Format-A structural-ref `scope:operation:method:<lang>:<file>:<name>` instead of a bare leaf name. The resolver disambiguates same-named methods across files via the existing `byLocation` index.

Paths normalized via `filepath.ToSlash` to match #143.

## What's in scope

- `internal/extractors/java/java.go` — class body
- `internal/extractors/javascript/extractor.go` — class body (covers JS *and* TS via the shared extractor registration)
- `internal/extractors/kotlin/kotlin.go` — class + object bodies
- `internal/extractors/python/extractor.go` — class body (decorated + bare branches)
- `internal/extractors/rust/rust.go` — `impl` and `trait` bodies

## Out of scope

Go (`receiver methods`) and PHP currently emit **no** class CONTAINS edges at all. Adding them is net-new extraction work, filed as **#145**.

## Tests

- Updated extractor `relationships_test.go` for each modified language (Java, JS, Kotlin, Python, Rust) to assert the structural-ref shape, plus a TS-specific assertion in `TestExtract_TypeScript`.
- Resolver-level tests in `internal/resolve/refs_test.go` mirror `TestReferences_RubyClassContainsStructuralRef`:
  - `TestReferences_JavaClassContainsStructuralRef`
  - `TestReferences_PythonClassContainsStructuralRef`
- Full suite: `go build ./...`, `go test ./...`, `go vet ./...`, `gofmt -l .` all clean.

## Measurement (single-repo VERIFY-2, base `origin/main` vs HEAD)

| repo                | lang       | bug-resolver | bug-rate         | resolution-rate  |
| ------------------- | ---------- | ------------ | ---------------- | ---------------- |
| rails-realworld     | ruby       | 4 → 4        | 18.89% → 18.89%  | 66.22% → 66.22%  |
| sidekiq             | ruby       | 400 → 400    | 16.88% → 16.88%  | 74.46% → 74.46%  |
| express-realworld   | javascript | 17 → 17      | 36.73% → 36.73%  | 35.28% → 35.28%  |
| nestjs-starter      | typescript | 7 → 5        | 33.04% → 31.25%  | 34.82% → 36.61%  |
| nestjs              | typescript | 1239 → 997   | 48.94% → 47.37%  | 32.41% → 34.01%  |
| spring-petclinic    | java       | 84 → 84      | 60.09% → 60.09%  | 31.54% → 31.54%  |
| ktor-samples        | kotlin     | 631 → 544    | 36.79% → 35.70%  | 60.91% → 62.06%  |
| exposed             | kotlin     | 808 → 90     | 25.20% → 15.59%  | 71.01% → 81.13%  |
| django-realworld    | python     | 59 → 59      | 32.23% → 32.23%  | 39.13% → 39.13%  |
| flask-realworld     | python     | 122 → 118    | 52.89% → 52.68%  | 34.10% → 34.31%  |
| pandas              | python     | 427 → 409    | 23.64% → 23.61%  | 56.33% → 56.36%  |
| mini-redis          | rust       | 157 → 95     | 25.17% → 22.18%  | 49.57% → 53.18%  |
| actix-examples      | rust       | 569 → 472    | 27.33% → 26.53%  | 50.84% → 51.73%  |

Highlights:
- **Kotlin / exposed**: -718 bug-resolver, +10.1pp resolution, -9.6pp bug-rate.
- **TypeScript / nestjs**: -242 bug-resolver, +1.6pp resolution.
- **Rust / actix-examples**: -97 bug-resolver, +0.9pp resolution.

Java/Python sample apps showed neutral results — the chosen apps already had unique method names per class, so the resolver was already finding the right entity via fallback paths. The change is risk-free (no regression on any repo measured) and unlocks resolution for apps where class methods collide on name.

## Test plan
- [x] `go build ./...`
- [x] `go test ./...` (all green)
- [x] `go vet ./...`
- [x] `gofmt -l .` (clean)
- [x] forbidden-term grep: clean
- [x] VERIFY-2 single-repo deltas captured above

Closes #144
Refs #92 #143 #145