### PR TITLE
[#131] chi router method allowlist gated to files importing go-chi

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -948,8 +948,10 @@ var goChiRouterNames = map[string]struct{}{
 
 // goChiImportPaths is the set of canonical import paths that signal a
 // source file is using go-chi. The v5 path is the current default; the
-// unversioned + v1/v2/v3/v4 paths cover legacy codebases. Used by
-// hasGoChiImport to gate goChiRouterNames lookups (issue #131).
+// unversioned (chi v1/v2) + v3/v4/v5 paths cover legacy codebases. Note
+// that chi v1.x and v2.x did not use module-path versioning, so they are
+// covered transitively by the unversioned "github.com/go-chi/chi" path.
+// Used by hasGoChiImport to gate goChiRouterNames lookups (issue #131).
 var goChiImportPaths = map[string]bool{
 	"github.com/go-chi/chi":    true,
 	"github.com/go-chi/chi/v3": true,

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -86,6 +86,31 @@ func Synthesize(doc *graph.Document) Stats {
 		entityFile[doc.Entities[k].ID] = doc.Entities[k].SourceFile
 	}
 
+	// fileImports maps every source file path to the set of import paths
+	// that file declares, walking IMPORTS edges (FromID = filePath, ToID
+	// = imported package). Used by the classifier to file-path-gate
+	// import-aware bare-name allowlists (issue #131 — chi router methods
+	// like Get/Post/Put/Delete that collide with HTTP-verb generic getter
+	// names and must only classify when the source file actually imports
+	// `github.com/go-chi/chi`). Lookups against non-existent paths return
+	// nil — matching pre-#131 behaviour for files that import nothing.
+	fileImports := make(map[string]map[string]bool)
+	for k := range doc.Relationships {
+		rel := &doc.Relationships[k]
+		if rel.Kind != string(types.RelationshipKindImports) {
+			continue
+		}
+		if rel.FromID == "" || rel.ToID == "" {
+			continue
+		}
+		set, ok := fileImports[rel.FromID]
+		if !ok {
+			set = make(map[string]bool)
+			fileImports[rel.FromID] = set
+		}
+		set[rel.ToID] = true
+	}
+
 	// First pass — collect every unique external name we want to
 	// synthesise. The placeholder carries a subtype hint
 	// ("package"/"function") but the language field is left empty:
@@ -108,7 +133,7 @@ func Synthesize(doc *graph.Document) Stats {
 		if rel.ToID == "" || isHexID(rel.ToID) || strings.HasPrefix(rel.ToID, ExtIDPrefix) {
 			continue
 		}
-		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID], entityFile[rel.FromID])
+		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID], entityFile[rel.FromID], fileImports[entityFile[rel.FromID]])
 		if !ok {
 			continue
 		}
@@ -186,7 +211,7 @@ func Synthesize(doc *graph.Document) Stats {
 // Returns ("", "", false) when the stub doesn't look external — those
 // are left untouched and continue to count as "unmatched" in the
 // resolver stats.
-func classifyExternal(stub, relKind, lang, fromFile string) (canonical, subtype string, ok bool) {
+func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool) (canonical, subtype string, ok bool) {
 	if stub == "" {
 		return "", "", false
 	}
@@ -410,7 +435,7 @@ func classifyExternal(stub, relKind, lang, fromFile string) (canonical, subtype 
 	}
 
 	// Stdlib function stop-list — bare names like "Println", "print".
-	if subtype, ok := stdlibFunction(name, lang, fromFile); ok {
+	if subtype, ok := stdlibFunction(name, lang, fromFile, fromImports); ok {
 		return name, subtype, true
 	}
 
@@ -502,7 +527,7 @@ func isNpmSegment(s string) bool {
 // the small per-language stop-list. Kept deliberately small — v1.0
 // catches the highest-volume bare-name calls without ballooning into
 // a full stdlib catalogue.
-func stdlibFunction(name, lang, fromFile string) (string, bool) {
+func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (string, bool) {
 	if _, ok := stdlibBareNames[name]; ok {
 		return "function", true
 	}
@@ -528,6 +553,22 @@ func stdlibFunction(name, lang, fromFile string) (string, bool) {
 		// synthesised placeholder shadowing a real user method).
 		if strings.HasSuffix(fromFile, "_test.go") {
 			if _, ok := goTestifyBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		// Issue #131 — go-chi router methods (Get/Post/Put/Delete/Mount/
+		// Group/Route/Use/...) are receiver-stripped by the Go extractor
+		// (`r.Get("/x", h)` → `Get`) and collide trivially with HTTP-verb
+		// generic getters (`Repository.Get`, `Cache.Get`) that exist in
+		// virtually every Go web codebase. Gate the chi-router allowlist
+		// on BOTH lang=="go" AND a chi-package import edge from the source
+		// file — the import gate is precise (the router type can only come
+		// from the chi package) and falls through to the generic allowlist
+		// for non-chi callers, matching the safer-bias rule from #94 (a
+		// missed external is strictly better than a synthesised placeholder
+		// shadowing a real user method).
+		if hasGoChiImport(fromImports) {
+			if _, ok := goChiRouterNames[name]; ok {
 				return "function", true
 			}
 		}
@@ -850,6 +891,86 @@ var goTestifyBareNames = map[string]struct{}{
 	// httptest helper commonly imported alongside testify in `_test.go`.
 	// Multi-word PascalCase, no plausible user-method collision.
 	"NewRecorder": {},
+}
+
+// goChiRouterNames is the go-chi router-method bare-name stop-list
+// (issue #131). The chi router (`*chi.Mux` / `chi.Router`) exposes
+// HTTP-verb registration methods (Get/Post/Put/Delete/...) plus
+// router-composition methods (Mount/Group/Route/Use/With) that arrive
+// at the resolver as bare names after the Go extractor strips the
+// receiver (`r.Get("/x", h)` → `Get`). These names collide trivially
+// with user-defined methods on domain types (Repository.Get,
+// Service.Use, Cache.Delete) so a language-only gate is not enough.
+//
+// Gating: lookups in this map are reached ONLY when (a) the source
+// entity's language is "go" AND (b) the source file imports the chi
+// package (any of the four canonical import paths emitted by
+// `hasGoChiImport`). Both conditions are precise: chi router values
+// can only originate from a chi package import, and the post-#117
+// allowlist already canonicalises chi imports to a known package node.
+//
+// The list mirrors chi's `Router` interface plus the small set of
+// `Mux`-only methods (HandleFunc/Handle/NotFound/MethodNotAllowed)
+// commonly invoked in routing setup. Excluded: `Method` and `MethodFunc`
+// — `MethodFunc` is already covered by goBareNames as a multi-word
+// PascalCase stdlib idiom (net/http via mux.HandleFunc family) and we
+// don't want to widen the chi gate beyond chi-distinctive names.
+var goChiRouterNames = map[string]struct{}{
+	// HTTP verb registration on chi.Router. Single-word PascalCase that
+	// shadows generic getters/setters in non-chi code — gated by import.
+	"Get":     {},
+	"Post":    {},
+	"Put":     {},
+	"Delete":  {},
+	"Patch":   {},
+	"Head":    {},
+	"Options": {},
+	"Connect": {},
+	"Trace":   {},
+
+	// Router composition / middleware. `Use` is especially collision-prone
+	// (any plugin / middleware framework names this) so the import gate
+	// is essential.
+	"Mount": {},
+	"Group": {},
+	"Route": {},
+	"Use":   {},
+	"With":  {},
+
+	// chi.Mux-specific dispatch helpers. These are less collision-prone
+	// (HandleFunc is also in goBareNames as a net/http idiom) but kept
+	// here so the chi gate covers the full Router-interface surface.
+	"HandleFunc":       {},
+	"Handle":           {},
+	"NotFound":         {},
+	"MethodNotAllowed": {},
+}
+
+// goChiImportPaths is the set of canonical import paths that signal a
+// source file is using go-chi. The v5 path is the current default; the
+// unversioned + v1/v2/v3/v4 paths cover legacy codebases. Used by
+// hasGoChiImport to gate goChiRouterNames lookups (issue #131).
+var goChiImportPaths = map[string]bool{
+	"github.com/go-chi/chi":    true,
+	"github.com/go-chi/chi/v3": true,
+	"github.com/go-chi/chi/v4": true,
+	"github.com/go-chi/chi/v5": true,
+}
+
+// hasGoChiImport reports whether the source file's import set contains
+// any of the canonical go-chi import paths. Returns false for a nil or
+// empty set — falling through to the generic allowlist, which matches
+// pre-#131 behaviour for files that don't use chi.
+func hasGoChiImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range goChiImportPaths {
+		if imports[p] {
+			return true
+		}
+	}
+	return false
 }
 
 // rustBareNames is the Rust-language-gated bare-name stop-list (issue

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -453,8 +453,8 @@ func TestStdlibBareNames_NoCollisionNames(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := stdlibFunction(name, "", ""); ok {
-				t.Fatalf("stdlibFunction(%q) classified as stdlib bare-name; "+
+			if _, ok := stdlibFunction(name, "", "", nil); ok {
+				t.Fatalf("stdlibFunction(%q, nil) classified as stdlib bare-name; "+
 					"this name commonly collides with user-defined methods "+
 					"and must not synthesise a placeholder", name)
 			}
@@ -488,12 +488,12 @@ func TestStdlibBareNames_RustAssertMacros(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "", "")
+			subtype, ok := stdlibFunction(name, "", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q) = (_, false); want classified as stdlib bare-name", name)
+				t.Fatalf("stdlibFunction(%q, nil) = (_, false); want classified as stdlib bare-name", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q) subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			doc := &graph.Document{
 				Relationships: []graph.Relationship{
@@ -722,12 +722,12 @@ func TestGoBareNames_ClassifiedWhenLangIsGo(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			// Direct stdlibFunction probe with lang="go" must classify.
-			subtype, ok := stdlibFunction(name, "go", "")
+			subtype, ok := stdlibFunction(name, "go", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"go\") = (_, false); want classified as stdlib bare-name", name)
+				t.Fatalf("stdlibFunction(%q, \"go\", nil) = (_, false); want classified as stdlib bare-name", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"go\") subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"go\", nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			// End-to-end: Synthesize on a document whose FromID entity
 			// is tagged language="go" rewrites the edge to ext:<name>.
@@ -767,8 +767,8 @@ func TestGoBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to lang=\"go\" only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -814,8 +814,8 @@ func TestGoBareNames_UserMethodCollisionExclusions(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			if _, ok := stdlibFunction(name, "go", ""); ok {
-				t.Fatalf("stdlibFunction(%q, \"go\") classified; want fall-through "+
+			if _, ok := stdlibFunction(name, "go", "", nil); ok {
+				t.Fatalf("stdlibFunction(%q, \"go\", nil) classified; want fall-through "+
 					"(name is too-likely to be a user-defined method)", name)
 			}
 			doc := &graph.Document{
@@ -1100,12 +1100,12 @@ func TestRustBareNames_ClassifiedWhenLangIsRust(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "rust", "")
+			subtype, ok := stdlibFunction(name, "rust", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"rust\") = (_, false); want classified as stdlib bare-name", name)
+				t.Fatalf("stdlibFunction(%q, \"rust\", nil) = (_, false); want classified as stdlib bare-name", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"rust\") subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"rust\", nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			doc := &graph.Document{
 				Entities: []graph.Entity{{
@@ -1147,8 +1147,8 @@ func TestRustBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to lang=\"rust\" only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -1236,12 +1236,12 @@ func TestJavaBareNames_ClassifiedWhenLangIsJava(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "java", "")
+			subtype, ok := stdlibFunction(name, "java", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"java\") = (_, false); want classified as stdlib bare-name", name)
+				t.Fatalf("stdlibFunction(%q, \"java\", nil) = (_, false); want classified as stdlib bare-name", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"java\") subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"java\", nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			doc := &graph.Document{
 				Entities: []graph.Entity{{
@@ -1287,8 +1287,8 @@ func TestJavaBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to lang=\"java\" only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -1400,12 +1400,12 @@ func TestKotlinBareNames_ClassifiedWhenLangIsKotlin(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "kotlin", "")
+			subtype, ok := stdlibFunction(name, "kotlin", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"kotlin\") = (_, false); want classified as stdlib bare-name", name)
+				t.Fatalf("stdlibFunction(%q, \"kotlin\", nil) = (_, false); want classified as stdlib bare-name", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"kotlin\") subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"kotlin\", nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			doc := &graph.Document{
 				Entities: []graph.Entity{{
@@ -1445,8 +1445,8 @@ func TestKotlinBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to lang=\"kotlin\" only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -1539,12 +1539,12 @@ func TestRubyBareNames_ClassifiedWhenLangIsRuby(t *testing.T) {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
-			subtype, ok := stdlibFunction(name, "ruby", "")
+			subtype, ok := stdlibFunction(name, "ruby", "", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"ruby\") = (_, false); want classified", name)
+				t.Fatalf("stdlibFunction(%q, \"ruby\", nil) = (_, false); want classified", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"ruby\") subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"ruby\", nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			doc := &graph.Document{
 				Entities: []graph.Entity{{
@@ -1581,8 +1581,8 @@ func TestRubyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to lang=\"ruby\" only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -1660,12 +1660,12 @@ func TestJSBareNames_ClassifiedWhenLangIsJSOrTS(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				subtype, ok := stdlibFunction(name, lang, "")
+				subtype, ok := stdlibFunction(name, lang, "", nil)
 				if !ok {
-					t.Fatalf("stdlibFunction(%q, %q) = (_, false); want classified", name, lang)
+					t.Fatalf("stdlibFunction(%q, %q, nil) = (_, false); want classified", name, lang)
 				}
 				if subtype != "function" {
-					t.Fatalf("stdlibFunction(%q, %q) subtype=%q, want %q", name, lang, subtype, "function")
+					t.Fatalf("stdlibFunction(%q, %q, nil) subtype=%q, want %q", name, lang, subtype, "function")
 				}
 				doc := &graph.Document{
 					Entities: []graph.Entity{{
@@ -1711,8 +1711,8 @@ func TestJSBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, ""); ok {
-					t.Fatalf("stdlibFunction(%q, %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
 						"(name is gated to JS/TS only)", name, lang)
 				}
 				doc := &graph.Document{
@@ -1824,12 +1824,12 @@ func TestGoTestifyBareNames_ClassifiedInTestFiles(t *testing.T) {
 			t.Parallel()
 			// Direct stdlibFunction probe with lang="go" + _test.go path
 			// must classify.
-			subtype, ok := stdlibFunction(name, "go", "internal/foo/foo_test.go")
+			subtype, ok := stdlibFunction(name, "go", "internal/foo/foo_test.go", nil)
 			if !ok {
-				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) = (_, false); want classified", name)
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) = (_, false); want classified", name)
 			}
 			if subtype != "function" {
-				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) subtype=%q, want %q", name, subtype, "function")
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) subtype=%q, want %q", name, subtype, "function")
 			}
 			// End-to-end: Synthesize on a doc whose source entity is a Go
 			// _test.go file rewrites the edge to ext:<name>.
@@ -1877,8 +1877,8 @@ func TestGoTestifyBareNames_NotClassifiedInNonTestGoFiles(t *testing.T) {
 			name, path := name, path
 			t.Run(name+"|"+path, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, "go", path); ok {
-					t.Fatalf("stdlibFunction(%q, \"go\", %q) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, "go", path, nil); ok {
+					t.Fatalf("stdlibFunction(%q, \"go\", %q, nil) classified; want fall-through "+
 						"(file is not a _test.go file)", name, path)
 				}
 				doc := &graph.Document{
@@ -1920,8 +1920,8 @@ func TestGoTestifyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 			name, lang := name, lang
 			t.Run(name+"/"+lang, func(t *testing.T) {
 				t.Parallel()
-				if _, ok := stdlibFunction(name, lang, "foo_test.go"); ok {
-					t.Fatalf("stdlibFunction(%q, %q, _test.go) classified; want fall-through "+
+				if _, ok := stdlibFunction(name, lang, "foo_test.go", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, _test.go, nil) classified; want fall-through "+
 						"(testify map is gated to lang=\"go\")", name, lang)
 				}
 			})
@@ -1943,8 +1943,8 @@ func TestGoTestifyBareNames_RejectedCollisions(t *testing.T) {
 				t.Fatalf("goTestifyBareNames[%q] present; must be rejected per issue #115 "+
 					"(collision-prone with user-defined Run/New/Add/Set methods)", name)
 			}
-			if _, ok := stdlibFunction(name, "go", "foo_test.go"); ok {
-				t.Fatalf("stdlibFunction(%q, \"go\", _test.go) classified; want fall-through "+
+			if _, ok := stdlibFunction(name, "go", "foo_test.go", nil); ok {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) classified; want fall-through "+
 					"(name is too-likely to be a user-defined method)", name)
 			}
 		})
@@ -1960,4 +1960,158 @@ func TestGoTestifyBareNames_TestifyPackageAllowlisted(t *testing.T) {
 		t.Fatal("IsKnownExternalPackage(\"github.com/stretchr/testify\") = false; " +
 			"want true (Issue #115/#117)")
 	}
+}
+
+// TestGoChiRouterNames_ClassifiedWithChiImport locks in issue #131:
+// go-chi router-method bare names (Get/Post/Put/Delete/Mount/Group/...)
+// that arrive at the resolver after the Go extractor strips the
+// receiver (`r.Get("/x", h)` → `Get`) must classify as stdlib bare-names
+// — but only when (a) the source entity's language is "go" AND (b) the
+// source file's IMPORTS edges include any canonical go-chi import path.
+// The dual gate keeps these collision-prone names from shadowing user
+// methods like `Repository.Get` in non-chi code.
+func TestGoChiRouterNames_ClassifiedWithChiImport(t *testing.T) {
+	names := []string{
+		"Get", "Post", "Put", "Delete", "Patch",
+		"Head", "Options", "Connect", "Trace",
+		"Mount", "Group", "Route", "Use", "With",
+		"HandleFunc", "Handle", "NotFound", "MethodNotAllowed",
+	}
+	chiPaths := []string{
+		"github.com/go-chi/chi",
+		"github.com/go-chi/chi/v5",
+		"github.com/go-chi/chi/v4",
+		"github.com/go-chi/chi/v3",
+	}
+	for _, name := range names {
+		for _, chiPath := range chiPaths {
+			name, chiPath := name, chiPath
+			t.Run(name+"|"+chiPath, func(t *testing.T) {
+				t.Parallel()
+				// Direct stdlibFunction probe with lang="go" + chi import
+				// in the imports set must classify.
+				imports := map[string]bool{chiPath: true}
+				subtype, ok := stdlibFunction(name, "go", "internal/api/router.go", imports)
+				if !ok {
+					t.Fatalf("stdlibFunction(%q, \"go\", chi=%q) = (_, false); want classified",
+						name, chiPath)
+				}
+				if subtype != "function" {
+					t.Fatalf("stdlibFunction(%q, \"go\", chi=%q) subtype=%q, want %q",
+						name, chiPath, subtype, "function")
+				}
+				// End-to-end: a Go entity in a file that emits an IMPORTS
+				// edge to the chi package must rewrite a CALLS edge with a
+				// chi-router method name to ext:<name>.
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:         "go-chi-src",
+						Name:       "RegisterRoutes",
+						Kind:       "function",
+						Language:   "go",
+						SourceFile: "internal/api/router.go",
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-import", FromID: "internal/api/router.go", ToID: chiPath, Kind: "IMPORTS"},
+						{ID: "rel-call", FromID: "go-chi-src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				Synthesize(doc)
+				want := "ext:" + name
+				// Find the CALLS edge and check it was rewritten.
+				var got string
+				for _, r := range doc.Relationships {
+					if r.ID == "rel-call" {
+						got = r.ToID
+						break
+					}
+				}
+				if got != want {
+					t.Fatalf("CALLS edge ToID=%q, want %q "+
+						"(name=%q, chi import=%q)", got, want, name, chiPath)
+				}
+			})
+		}
+	}
+}
+
+// TestGoChiRouterNames_NotClassifiedWithoutChiImport locks in the
+// import-set gate: the same chi-router names must NOT classify when the
+// source file's IMPORTS edges don't include any go-chi path. Without
+// this gate, a user-defined `Repository.Get` would be shadowed by a
+// synthesised chi placeholder.
+func TestGoChiRouterNames_NotClassifiedWithoutChiImport(t *testing.T) {
+	names := []string{"Get", "Post", "Put", "Delete", "Mount", "Group", "Use"}
+	importSets := []map[string]bool{
+		nil,
+		{},
+		// Adversarial: imports unrelated packages, but no chi.
+		{"github.com/gin-gonic/gin": true},
+		{"github.com/labstack/echo": true},
+		{"net/http": true, "encoding/json": true},
+		// Adversarial: a non-chi path that contains "chi" as a substring.
+		{"github.com/example/chi-fork": true},
+		{"github.com/anything/notchi": true},
+	}
+	for _, name := range names {
+		for i, imports := range importSets {
+			name, imports, i := name, imports, i
+			t.Run(name+"/case"+itoa(i), func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, "go", "internal/foo/foo.go", imports); ok {
+					t.Fatalf("stdlibFunction(%q, \"go\", imports=%v) classified; "+
+						"want fall-through (no chi import in set)", name, imports)
+				}
+			})
+		}
+	}
+}
+
+// TestGoChiRouterNames_NotClassifiedForOtherLanguages confirms the
+// language gate: even with a chi import path in the set, the chi names
+// must not classify when the source language isn't "go". Defensive in
+// depth.
+func TestGoChiRouterNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	names := []string{"Get", "Post", "Mount"}
+	imports := map[string]bool{"github.com/go-chi/chi/v5": true}
+	otherLangs := []string{"python", "javascript", "rust", "java", "ruby", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "foo.go", imports); ok {
+					t.Fatalf("stdlibFunction(%q, %q, chi imports) classified; "+
+						"want fall-through (chi map is gated to lang=\"go\")", name, lang)
+				}
+			})
+		}
+	}
+}
+
+// TestGoChiRouterNames_ChiPackageAllowlisted confirms #131 relies on
+// the existing #117 host-prefixed known-external entry for the chi
+// package — synthesised chi router CALLS edges should resolve to a chi
+// package node when the full import path arrives at the resolver.
+func TestGoChiRouterNames_ChiPackageAllowlisted(t *testing.T) {
+	if !IsKnownExternalPackage("github.com/go-chi/chi") {
+		t.Fatal("IsKnownExternalPackage(\"github.com/go-chi/chi\") = false; " +
+			"want true (Issue #117/#131)")
+	}
+}
+
+// itoa formats a small non-negative int as decimal. Local helper to
+// keep test sub-names deterministic without pulling in strconv.
+func itoa(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [8]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
 }


### PR DESCRIPTION
## Summary

Adds a chi-specific bare-name stop-list (Get/Post/Put/Delete/Patch/Mount/Group/Route/Use/With/HandleFunc/Handle/NotFound/MethodNotAllowed/...) that classifies as ExternalKnown only when **both**:
- the source entity's language is `go`, AND
- the source file emits an `IMPORTS` edge to a go-chi package (`github.com/go-chi/chi[/v3|v4|v5]`).

Closes #131. Refs #103.

## Why a two-gate design

Chi router method names (`Get`, `Use`, `Mount`) collide trivially with user-defined methods on domain types (`Repository.Get`, `Service.Use`, `Cache.Delete`). The language gate alone is not enough — a Go method named `Get` on a domain type must NOT be shadowed by a chi placeholder. The import-set gate is precise: chi router values can only originate from a chi package import, so absence of that import is a strong local-method signal (#94 lesson: bias to misses over false-positive synthesis).

Mirrors the testify file-suffix gate from #129, but with import-set membership instead of file-path suffix.

## Implementation

- `Synthesize()` pre-walks `IMPORTS` edges once to build `fileImports map[filePath]map[importPath]bool`.
- New `fromImports map[string]bool` argument threaded through `classifyExternal` and `stdlibFunction`.
- `goChiRouterNames` stop-list + `hasGoChiImport` helper.
- `goChiImportPaths` covers the unversioned + v3/v4/v5 canonical paths.
- The #117 host-prefixed allowlist already includes `github.com/go-chi/chi`, so synthesised `ext:Get` / `ext:Post` nodes resolve cleanly to a chi package node when the full import path arrives.

## VERIFY-2 single-repo (chi + gin)

| repo | bug_rate before | bug_rate after | delta |
| --- | ---: | ---: | ---: |
| chi  | 47.79% | 46.80% | -0.99% (72 endpoints reclassified, all in `chi/middleware/*` files that import chi) |
| gin  | 43.61% | 43.61% | 0 (no chi imports — gate correctly silent) |

The chi framework's own core files (mux.go, tree.go) don't `import chi` (they ARE chi), so router-method calls inside the framework root don't hit the gate — those should resolve as local methods on `*Mux` and surface as resolver-side issues if they don't (out of scope for #131). Effect on a chi-*using* application would be larger.

## Test plan

- [x] `go test ./...` — all packages pass (last 5 lines: `internal/{resolve,treesitter,types,verify,version}` ok)
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] New tests (40+ subtests):
  - `TestGoChiRouterNames_ClassifiedWithChiImport` — every chi name × every chi import path
  - `TestGoChiRouterNames_NotClassifiedWithoutChiImport` — nil set, empty set, gin import, echo import, net/http only, adversarial chi-substring paths
  - `TestGoChiRouterNames_NotClassifiedForOtherLanguages` — chi imports + python/js/rust/java/ruby/empty
  - `TestGoChiRouterNames_ChiPackageAllowlisted` — sanity check on #117 allowlist
- [x] Existing testify / goBareNames / classifyExternal tests still pass (regression suite)

forbidden-term grep: clean