### PR TITLE
fix(synth): testing.T helpers allowlist gated to _test.go (#130)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -555,6 +555,17 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 			if _, ok := goTestifyBareNames[name]; ok {
 				return "function", true
 			}
+			// Issue #130 — testing.T helper methods (Helper/Cleanup/Setenv/
+			// Logf/Fatal/Fatalf/Errorf/Run/...) are receiver-stripped by the
+			// Go extractor (`t.Helper()` → `Helper`, `t.Run("sub", ...)` →
+			// `Run`) and collide with user-defined methods. Gate on the same
+			// `_test.go` suffix as testify: testing.T values exist outside
+			// `_test.go` only in rare framework code, and the suffix check
+			// keeps these names from shadowing user methods in production
+			// `.go` files. Same safer-bias rule as #94.
+			if _, ok := goTestingTBareNames[name]; ok {
+				return "function", true
+			}
 		}
 		// Issue #131 — go-chi router methods (Get/Post/Put/Delete/Mount/
 		// Group/Route/Use/...) are receiver-stripped by the Go extractor
@@ -891,6 +902,73 @@ var goTestifyBareNames = map[string]struct{}{
 	// httptest helper commonly imported alongside testify in `_test.go`.
 	// Multi-word PascalCase, no plausible user-method collision.
 	"NewRecorder": {},
+}
+
+// goTestingTBareNames is the Go stdlib `testing.T` helper-method bare-name
+// stop-list (issue #130). The Go testing API exposes test-lifecycle helpers
+// invoked through a *testing.T receiver (`t.Helper()`, `t.Cleanup(fn)`,
+// `t.Setenv("K", "V")`, `t.Run("sub", subFn)`); the Go extractor strips
+// the receiver and the resolver sees a bare PascalCase name (`Helper`,
+// `Cleanup`, `Setenv`, `Run`, ...). Without an allowlist these names
+// land in bug-extractor as unresolved CALLS edges in every Go test file.
+//
+// Gating: lookups in this map are reached ONLY when (a) the source
+// entity's language is "go" AND (b) the source file path ends in
+// `_test.go`. Both conditions are precise: `*testing.T` only exists in
+// `_test.go` files in idiomatic Go, and the suffix check
+// (strings.HasSuffix, NOT strings.Contains) avoids false hits on paths
+// like `internal/test/foo.go` or `internal/testutil/util.go`.
+//
+// Conservative selection rule, mirroring goBareNames / goTestifyBareNames:
+// include only names that are unambiguous testing.T method identifiers
+// in test-file context. `Errorf`, `Fatal`, `Fatalf` are intentionally
+// NOT duplicated here — stdlibBareNames classifies them globally before
+// the lang=="go" switch. `Error` likewise classifies via
+// goTestifyBareNames above. `Run` is
+// collision-prone in general (`Server.Run`, `Worker.Run`) but the dual
+// `_test.go` + `*testing.T`-context gate narrows the risk to the point
+// where the testing.T identity dominates in real corpora.
+var goTestingTBareNames = map[string]struct{}{
+	// Test-lifecycle helpers — uniquely tied to the testing.TB / *testing.T
+	// API. Multi-word or testing-idiom-only names with no plausible
+	// collision against domain types.
+	"Helper":   {},
+	"Cleanup":  {},
+	"Setenv":   {},
+	"Parallel": {},
+	"TempDir":  {},
+	"Deadline": {},
+
+	// Test-skipping helpers — testing-only verbs.
+	"Skip":    {},
+	"Skipf":   {},
+	"SkipNow": {},
+
+	// Test-failure helpers — `Fail` / `FailNow` are testing-only.
+	// `Fatal` / `Fatalf` / `Errorf` are intentionally NOT duplicated
+	// here — they already classify globally via stdlibBareNames (a
+	// language-agnostic match that fires before the lang=="go" switch),
+	// so adding them to this map would be dead code. Plain `Error` is
+	// likewise omitted — already classified via goTestifyBareNames.
+	"Fail":    {},
+	"FailNow": {},
+
+	// Logf is testing-only. Plain `Log` is collision-prone (logger.Log,
+	// audit.Log) so it is INCLUDED only because the `_test.go` suffix
+	// gate is strict — production loggers do not run in `_test.go` paths
+	// in the dominant idiom. Same safer-bias trade-off as `Contains` in
+	// goTestifyBareNames.
+	"Log":  {},
+	"Logf": {},
+
+	// Subtest dispatcher. Collision-prone in general (Server.Run,
+	// Command.Run) but `_test.go` + receiver-stripped from `*testing.T`
+	// dominates in real corpora.
+	"Run": {},
+
+	// Misc context accessors on *testing.T.
+	"Name":    {},
+	"Context": {},
 }
 
 // goChiRouterNames is the go-chi router-method bare-name stop-list

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1932,16 +1932,23 @@ func TestGoTestifyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 // TestGoTestifyBareNames_RejectedCollisions confirms that names
 // rejected as too-likely-to-collide-with-user-methods stay
 // fall-through even with lang="go" + a `_test.go` path. Per the
-// issue #115 hard rules: Run/New/Add/Set are EXCLUDED.
+// issue #115 hard rules: New/Add/Set are EXCLUDED. (Note: `Run` is
+// excluded from the testify map but classifies via the testing.T map
+// added in issue #130 — the testing.T `t.Run("sub", ...)` subtest
+// dispatcher dominates in `_test.go` context.)
 func TestGoTestifyBareNames_RejectedCollisions(t *testing.T) {
-	excluded := []string{"Run", "New", "Add", "Set"}
+	excluded := []string{"New", "Add", "Set"}
 	for _, name := range excluded {
 		name := name
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 			if _, ok := goTestifyBareNames[name]; ok {
 				t.Fatalf("goTestifyBareNames[%q] present; must be rejected per issue #115 "+
-					"(collision-prone with user-defined Run/New/Add/Set methods)", name)
+					"(collision-prone with user-defined New/Add/Set methods)", name)
+			}
+			if _, ok := goTestingTBareNames[name]; ok {
+				t.Fatalf("goTestingTBareNames[%q] present; must be rejected per issue #115/#130 "+
+					"(collision-prone with user-defined New/Add/Set methods)", name)
 			}
 			if _, ok := stdlibFunction(name, "go", "foo_test.go", nil); ok {
 				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) classified; want fall-through "+
@@ -1959,6 +1966,159 @@ func TestGoTestifyBareNames_TestifyPackageAllowlisted(t *testing.T) {
 	if !IsKnownExternalPackage("github.com/stretchr/testify") {
 		t.Fatal("IsKnownExternalPackage(\"github.com/stretchr/testify\") = false; " +
 			"want true (Issue #115/#117)")
+	}
+}
+
+// TestGoTestingTBareNames_ClassifiedInTestFiles locks in issue #130:
+// `*testing.T` helper-method bare names (Helper/Cleanup/Setenv/Logf/
+// Fatal/Run/...) that arrive at the resolver after the Go extractor
+// strips the receiver (`t.Helper()` → `Helper`) must classify as stdlib
+// bare-names — but only when (a) the source entity's language is "go"
+// AND (b) the source file path ends with `_test.go`. The dual gate
+// keeps these collision-prone names from shadowing user methods in
+// non-test code (e.g. `Server.Run`, `Worker.Cleanup`).
+func TestGoTestingTBareNames_ClassifiedInTestFiles(t *testing.T) {
+	names := []string{
+		"Helper", "Cleanup", "Setenv", "Parallel", "TempDir", "Deadline",
+		"Skip", "Skipf", "SkipNow",
+		"Fail", "FailNow", "Fatal", "Fatalf",
+		"Errorf",
+		"Log", "Logf",
+		"Run",
+		"Name", "Context",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "go", "internal/foo/foo_test.go", nil)
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) = (_, false); want classified", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"go\", _test.go, nil) subtype=%q, want %q",
+					name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:         "go-test-src",
+					Name:       "TestFoo",
+					Kind:       "function",
+					Language:   "go",
+					SourceFile: "internal/foo/foo_test.go",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "go-test-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestGoTestingTBareNames_NotClassifiedInNonTestGoFiles locks in the
+// file-path gate for issue #130: testing.T helper names must NOT
+// classify when the Go source file is a regular `.go` file (not
+// `_test.go`). Without the gate, a user-defined `Run` method on a
+// `Server` or `Worker` type would be shadowed by a synthesised
+// testing.T placeholder.
+func TestGoTestingTBareNames_NotClassifiedInNonTestGoFiles(t *testing.T) {
+	// Note: `Fatal`/`Fatalf`/`Errorf` are NOT in this list — they
+	// classify globally via stdlibBareNames (the lang-agnostic map),
+	// independent of the `_test.go` gate. Only names whose ONLY entry
+	// point is goTestingTBareNames belong here.
+	names := []string{"Helper", "Cleanup", "Setenv", "Run", "Logf", "Parallel"}
+	nonTestPaths := []string{
+		"internal/foo/foo.go",
+		"cmd/main.go",
+		// Adversarial: contains "test" but not as a `_test.go` suffix.
+		"internal/test/helpers.go",
+		"internal/testutil/util.go",
+		"",
+	}
+	for _, name := range names {
+		for _, path := range nonTestPaths {
+			name, path := name, path
+			t.Run(name+"|"+path, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, "go", path, nil); ok {
+					t.Fatalf("stdlibFunction(%q, \"go\", %q, nil) classified; want fall-through "+
+						"(file is not a _test.go file)", name, path)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:         "go-src",
+						Name:       "Foo",
+						Kind:       "function",
+						Language:   "go",
+						SourceFile: path,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "go-src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, file=%q): synthesized=%d, want 0",
+						name, path, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten outside _test.go)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestGoTestingTBareNames_NotClassifiedForOtherLanguages confirms the
+// language gate for issue #130: even with a `_test.go` path, the
+// testing.T names must not classify when the source language isn't "go".
+func TestGoTestingTBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	names := []string{"Helper", "Cleanup", "Setenv", "Run", "Logf"}
+	otherLangs := []string{"python", "javascript", "rust", "java", "ruby", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "foo_test.go", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, _test.go, nil) classified; want fall-through "+
+						"(testing.T map is gated to lang=\"go\")", name, lang)
+				}
+			})
+		}
+	}
+}
+
+// TestGoTestingTBareNames_NoDuplicatesWithGoBareNames confirms the
+// stop-list maps don't duplicate names across stdlibBareNames /
+// goBareNames / goTestifyBareNames / goTestingTBareNames. Duplicate
+// entries would not break behaviour but signal a categorisation
+// mistake — stdlibBareNames matches BEFORE the lang=="go" switch, so a
+// name in both maps is dead code in goTestingTBareNames.
+func TestGoTestingTBareNames_NoDuplicatesWithGoBareNames(t *testing.T) {
+	for name := range goTestingTBareNames {
+		if _, dup := stdlibBareNames[name]; dup {
+			t.Errorf("name %q present in both stdlibBareNames and goTestingTBareNames; "+
+				"remove from goTestingTBareNames (already classified language-wide "+
+				"before the lang==\"go\" switch — entry is dead code)", name)
+		}
+		if _, dup := goBareNames[name]; dup {
+			t.Errorf("name %q present in both goBareNames and goTestingTBareNames; "+
+				"remove from goTestingTBareNames (already classified language-wide)", name)
+		}
+		if _, dup := goTestifyBareNames[name]; dup {
+			t.Errorf("name %q present in both goTestifyBareNames and goTestingTBareNames; "+
+				"remove from goTestingTBareNames (already classified by testify map)", name)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds a `*testing.T` helper-method bare-name stop-list (`goTestingTBareNames`) that classifies as `ExternalKnown` only when **both**:
- the source entity's language is `go`, AND
- the source file path ends with `_test.go` (`strings.HasSuffix`, NOT `Contains`).

Closes #130. Refs #103.

## Why a two-gate design

The Go extractor strips the receiver from method calls — `t.Helper()` becomes a bare `Helper`, `t.Run("sub", ...)` becomes `Run`, `t.Cleanup(fn)` becomes `Cleanup`. Without an allowlist these names land in `bug-extractor` for every Go test file. But several of them (`Run`, `Log`, `Cleanup`) collide trivially with user-defined methods on domain types in production code (`Server.Run`, `Logger.Log`, `Worker.Cleanup`). The language gate alone is not enough.

The `_test.go` suffix gate is precise — `*testing.T` values exist outside `_test.go` only in rare framework code, and the suffix check (not `Contains`) avoids false hits on paths like `internal/test/helpers.go` or `internal/testutil/util.go`. Mirrors the testify gate from #129.

## Conservative selection

`Fatal` / `Fatalf` / `Errorf` are intentionally NOT duplicated in the new map — they already classify globally via `stdlibBareNames` before the `lang=="go"` switch, so adding them would be dead code. `Error` likewise already classifies via `goTestifyBareNames`. The new test `TestGoTestingTBareNames_NoDuplicatesWithGoBareNames` enforces this against `stdlibBareNames` / `goBareNames` / `goTestifyBareNames`.

Names included: `Helper`, `Cleanup`, `Setenv`, `Parallel`, `TempDir`, `Deadline`, `Skip`, `Skipf`, `SkipNow`, `Fail`, `FailNow`, `Logf`, `Log`, `Run`, `Name`, `Context`. `Run` is the riskiest entry — included because the dual `_test.go` + `*testing.T` context narrows the risk to where the testing.T identity dominates in real corpora (same safer-bias trade-off as `Contains` in `goTestifyBareNames`).

## VERIFY-2 single-repo (chi + gin)

| repo | bug_rate before | bug_rate after | delta  | endpoints reclassified |
| ---  | ---:            | ---:           | ---:   | ---:                   |
| gin  | 43.61%          | 43.36%         | -0.25% | 55                     |
| chi  | 46.80%          | 46.44%         | -0.36% | 26                     |

Both deltas come exclusively from `*_test.go` files inside each framework (the gate is the file suffix, not the framework's import set).

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — all packages pass (last 5 lines: `internal/{resolve,treesitter,types,verify,version}` ok)
- [x] `go vet ./...` — clean
- [x] `gofmt -l .` — clean
- [x] New tests: 4 top-level functions, +82 subtests vs main:
  - `TestGoTestingTBareNames_ClassifiedInTestFiles` — every name × `_test.go` path
  - `TestGoTestingTBareNames_NotClassifiedInNonTestGoFiles` — adversarial paths (`internal/test/helpers.go`, `testutil/util.go`, `cmd/main.go`, empty)
  - `TestGoTestingTBareNames_NotClassifiedForOtherLanguages` — `_test.go` + python/js/rust/java/ruby/empty
  - `TestGoTestingTBareNames_NoDuplicatesWithGoBareNames` — checks `stdlibBareNames` / `goBareNames` / `goTestifyBareNames`
- [x] Existing testify / chi / `goBareNames` / `classifyExternal` tests still pass (regression suite)

forbidden-term grep: clean