### PR TITLE
chore(verify2): add scala + groovy + clojure sample apps to corpus

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -67,6 +67,12 @@ REPOS=(
   # --- Kotlin ---
   "exposed|https://github.com/JetBrains/Exposed.git|main|kotlin"                                   # ORM source; small
   "ktor-samples|https://github.com/ktorio/ktor-samples.git|main|kotlin"                            # Ktor sample apps
+  # --- Scala ---
+  "play-scala-starter|https://github.com/playframework/play-scala-starter-example.git|2.7.x|scala" # Play Framework sample app
+  # --- Groovy ---
+  "ratpack-example-books|https://github.com/ratpack/example-books.git|master|groovy"               # Ratpack sample app
+  # --- Clojure ---
+  "usermanager-example|https://github.com/seancorfield/usermanager-example.git|develop|clojure"    # Ring/Compojure sample app
   # --- Ruby ---
   "rails-realworld|https://github.com/gothinkster/rails-realworld-example-app.git|master|ruby"     # Rails sample app
   "sidekiq|https://github.com/sidekiq/sidekiq.git|main|ruby"                                       # library; small


### PR DESCRIPTION
## Summary

Adds 3 JVM-niche language sample apps to the VERIFY-2 corpus to broaden language coverage:

- **Scala**: `playframework/play-scala-starter-example` @ `2.7.x` — Play Framework sample app
- **Groovy**: `ratpack/example-books` @ `master` — Ratpack sample app
- **Clojure**: `seancorfield/usermanager-example` @ `develop` — Ring/Compojure sample app

Follows the same pattern as the recently-merged cpp+zig PR (#327): pure additions to `REPOS=()` in `scripts/verify2/run.sh`, with logical language-grouped headers placed adjacent to Kotlin (JVM cluster).

Verified each upstream URL + ref via `git ls-remote --symref`:
- play-scala-starter-example 2.7.x -> `387913eb5e02f016fdbfbdee8017ec2e52df5a1c`
- ratpack/example-books master -> `58975e35fa196fdebd0720030067d1a5991b0d9f`
- seancorfield/usermanager-example develop -> `2ccb1ee1c19036881a6815d5b6bd211d66fe98e5`

## Test plan

- [x] `bash -n scripts/verify2/run.sh` clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [ ] VERIFY-2 run picks up the 3 new repos and produces a per-language aggregate row for scala/groovy/clojure

Closes #158
Closes #161
Closes #164
Closes #294