### PR TITLE
chore(verify2): add dart + lua + elixir sample apps to corpus

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -90,6 +90,12 @@ REPOS=(
   "spdlog|https://github.com/gabime/spdlog.git|v1.x|cpp"                                          # header-only logging library; small
   # --- Zig ---
   "http.zig|https://github.com/karlseguin/http.zig.git|master|zig"                                # Zig HTTP server library; small
+  # --- Dart ---
+  "dart-samples|https://github.com/dart-lang/samples.git|main|dart"                               # Dart sample apps
+  # --- Lua ---
+  "kickstart.nvim|https://github.com/nvim-lua/kickstart.nvim.git|master|lua"                      # Neovim config sample
+  # --- Elixir ---
+  "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"          # Phoenix sample app
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary
Adds 3 new entries to `scripts/verify2/run.sh` covering the script + mobile chunk:

- **Dart** — `dart-lang/samples` @ main
- **Lua** — `nvim-lua/kickstart.nvim` @ master
- **Elixir** — `dwyl/phoenix-todo-list-tutorial` @ main

Follows the alphabetical/logical clustering pattern from PR #328 with `# --- <Lang> ---` headers.

## Verification
- `bash -n scripts/verify2/run.sh` — parses clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- forbidden-term grep on diff: clean
- HEAD SHAs verified via `git ls-remote --symref`:
  - dart-lang/samples main → `5ea622ee4a51e030cc4eb89df0e523ff3cbacc74`
  - nvim-lua/kickstart.nvim master → `cfdc17be3ae1607d4427332de0b29d556f9dda13`
  - dwyl/phoenix-todo-list-tutorial main → `ac145a5e88d2b27063763fecfbaaba060bc2c913`

Closes #152
Closes #153
Closes #154
Closes #296