### PR TITLE
chore(verify2): add razor + fish + just sample apps to corpus

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -96,6 +96,12 @@ REPOS=(
   "kickstart.nvim|https://github.com/nvim-lua/kickstart.nvim.git|master|lua"                      # Neovim config sample
   # --- Elixir ---
   "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"          # Phoenix sample app
+  # --- Razor ---
+  "aspnetcore-docs-samples|https://github.com/dotnet/AspNetCore.Docs.Samples.git|main|razor"     # ASP.NET Core docs companion: 737 .cshtml/.razor view templates
+  # --- Fish ---
+  "tide|https://github.com/IlanCosman/tide.git|main|fish"                                        # Pure-fish prompt theme: 117 .fish files (functions, completions, conf.d)
+  # --- Just ---
+  "just|https://github.com/casey/just.git|master|just"                                           # Just build runner: dogfooded top-level justfile + tests/ parser fixtures
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary
Adds 3 new entries to `scripts/verify2/run.sh` covering Chunk D — .NET / CLI extras:

- **Razor** — `dotnet/AspNetCore.Docs.Samples` @ main
- **Fish** — `IlanCosman/tide` @ main
- **Just** — `casey/just` @ master

Follows the alphabetical/logical clustering pattern from PR #328/#329 with `# --- <Lang> ---` headers.

## Verification
- `bash -n scripts/verify2/run.sh` — parses clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- forbidden-term grep on diff: clean
- HEAD SHAs verified via `git ls-remote --symref`:
  - dotnet/AspNetCore.Docs.Samples main -> `14ecc20154ca5f77d1abd33e033fb311eb225b36`
  - IlanCosman/tide main -> `fcda500d2c2996e25456fb46cd1a5532b3157b16`
  - casey/just master -> `9bfa95b3e54d01b5df2e3e7d4cc4e925528dcc8d`

Closes #167
Closes #169
Closes #171
Closes #297