### PR TITLE
chore(verify2): add proto + graphql + hcl corpora

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -102,6 +102,12 @@ REPOS=(
   "tide|https://github.com/IlanCosman/tide.git|main|fish"                                        # Pure-fish prompt theme: 117 .fish files (functions, completions, conf.d)
   # --- Just ---
   "just|https://github.com/casey/just.git|master|just"                                           # Just build runner: dogfooded top-level justfile + tests/ parser fixtures
+  # --- Proto ---
+  "grpc-go-examples|https://github.com/grpc/grpc-go.git|master|proto|examples"                   # gRPC-Go examples/ subtree: dozens of .proto service/message definitions
+  # --- GraphQL ---
+  "apollo-server|https://github.com/apollographql/apollo-server.git|main|graphql"                # Apollo Server: GraphQL schema SDL + resolvers across packages
+  # --- HCL ---
+  "terraform-aws-vpc|https://github.com/terraform-aws-modules/terraform-aws-vpc.git|master|hcl"  # Terraform AWS VPC module: canonical HCL resource/variable/output definitions
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds three IDL/API corpus entries to `scripts/verify2/run.sh` for chunk E (umbrella #299):

- **Proto** (`#157`): `grpc-go-examples` — `grpc/grpc-go@master`, sparse path `examples/`
- **GraphQL** (`#159`): `apollo-server` — `apollographql/apollo-server@main`
- **HCL** (`#162`): `terraform-aws-vpc` — `terraform-aws-modules/terraform-aws-vpc@master`

Default branches verified via `git ls-remote --symref <url> HEAD`. Format follows PR #328-#330 conventions: `# --- <Format> ---` headers, `name|url|branch|language[|sparse-path]`.

## Verification

- `bash -n scripts/verify2/run.sh` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- forbidden-term grep on added lines: clean

Closes #157
Closes #159
Closes #162
Closes #299