### PR TITLE
chore(verify2): add k8s + helm + gha + openapi corpora

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -108,6 +108,14 @@ REPOS=(
   "apollo-server|https://github.com/apollographql/apollo-server.git|main|graphql"                # Apollo Server: GraphQL schema SDL + resolvers across packages
   # --- HCL ---
   "terraform-aws-vpc|https://github.com/terraform-aws-modules/terraform-aws-vpc.git|master|hcl"  # Terraform AWS VPC module: canonical HCL resource/variable/output definitions
+  # --- K8s YAML ---
+  "argocd-example-apps|https://github.com/argoproj/argocd-example-apps.git|master|yaml"          # Argo CD example apps: canonical Deployment/Service/Ingress/ConfigMap manifests
+  # --- Helm ---
+  "prometheus-helm|https://github.com/prometheus-community/helm-charts.git|main|yaml|charts/prometheus" # Prometheus Helm chart: templates/, values.yaml, Chart.yaml — sparse subtree
+  # --- GHA ---
+  "starter-workflows|https://github.com/actions/starter-workflows.git|main|yaml"                 # Official GitHub Actions starter workflows: ci/, deployments/, automation/, code-scanning/, pages/
+  # --- OpenAPI ---
+  "openapi-stripe|https://github.com/APIs-guru/openapi-directory.git|main|yaml|APIs/stripe.com"  # OpenAPI directory — Stripe API spec subtree (yaml extractor handles OpenAPI documents)
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
Closes #160, #163, #165, #166, #300 (Chunk F umbrella — manifest/infra formats).

## Summary

Adds 4 entries to `scripts/verify2/run.sh` REPOS array under new section headers (`# --- K8s YAML ---`, `# --- Helm ---`, `# --- GHA ---`, `# --- OpenAPI ---`), following the established `name|url|branch|language|optional-sparse-path` format from PR #331.

| # | Format | Repo | Branch | Pinned SHA | Sparse |
|---|---|---|---|---|---|
| #160 | K8s YAML | argoproj/argocd-example-apps | master | 723b86e01bea11dcf72316cb172868fcbf05d69e | full |
| #163 | Helm | prometheus-community/helm-charts | main | 0b19a11353af3b4cd9d7f7000c5f03c93cb5ceea | charts/prometheus |
| #165 | GHA | actions/starter-workflows | main | 53d347c66d8b0618d2e4616e1b841b649349c6d7 | full |
| #166 | OpenAPI | APIs-guru/openapi-directory | main | f04b8d0bcd39c52e1cf3ad7a5fe744709832ae49 | APIs/stripe.com |

All four use `language=yaml` because the YAML extractor (`internal/extractors/yaml/`) is the registered extractor for K8s manifests, Helm chart templates, GitHub Actions workflows, and OpenAPI documents — there is no dedicated `openapi` / `k8s` / `helm` / `gha` extractor in `internal/extractors/`.

## Verification

- `bash -n scripts/verify2/run.sh` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- `git ls-remote --symref` — all 4 HEAD refs match the SHAs above
- forbidden-term grep: clean

## Test plan

- [ ] Reviewer confirms YAML extractor handles all 4 flavors (existing fixtures cover k8s_resource; OpenAPI/Helm/GHA exercise the generic YAML path)
- [ ] On merge, harness picks up the 4 new corpora on next `scripts/verify2/run.sh` invocation