### PR TITLE
chore(verify2): add ORM/framework consumer apps to corpus (chunk G, #301)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -116,6 +116,15 @@ REPOS=(
   "starter-workflows|https://github.com/actions/starter-workflows.git|main|yaml"                 # Official GitHub Actions starter workflows: ci/, deployments/, automation/, code-scanning/, pages/
   # --- OpenAPI ---
   "openapi-stripe|https://github.com/APIs-guru/openapi-directory.git|main|yaml|APIs/stripe.com"  # OpenAPI directory — Stripe API spec subtree (yaml extractor handles OpenAPI documents)
+  # --- ORMs/Frameworks (chunk G, umbrella #301) ---
+  # Sample apps that USE each ORM/framework, per Refs #96 corpus policy.
+  # django-realworld (#176) and node-express-realworld (#178/Prisma) are already
+  # listed above under Python and JavaScript respectively — not duplicated here.
+  "microblog|https://github.com/miguelgrinberg/microblog.git|main|python"                          # SQLAlchemy sample app (#174)
+  "fastapi-realworld|https://github.com/nsidnev/fastapi-realworld-example-app.git|master|python"   # FastAPI sample app (#175)
+  "sequelize-express-example|https://github.com/sequelize/express-example.git|master|javascript"   # Sequelize sample app (#177)
+  "golang-gin-realworld|https://github.com/gothinkster/golang-gin-realworld-example-app.git|main|go" # GORM sample app (#179)
+  "actix-diesel-realworld|https://github.com/snamiki1212/realworld-v1-rust-actix-web-diesel.git|main|rust" # Diesel sample app (#180)
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
Closes #174
Closes #175
Closes #176
Closes #177
Closes #178
Closes #179
Closes #180
Closes #301

## Summary

Adds the chunk G ORM / framework consumer apps to `scripts/verify2/run.sh`. All entries follow the existing `name|url|branch|language[|sparse-path]` convention and the Refs #96 corpus policy (sample apps that USE a framework, not framework internals).

## Repos added (5)

| Child | Framework / ORM | Repo | Branch | Verified HEAD SHA |
|---|---|---|---|---|
| #174 | SQLAlchemy | miguelgrinberg/microblog | main | a975ef64864354867c88e0ed3a17ba7d17dca752 |
| #175 | FastAPI | nsidnev/fastapi-realworld-example-app | master | 029eb7781c60d5f563ee8990a0cbfb79b244538c |
| #177 | Sequelize | sequelize/express-example | master | 7304dc6ff4b842b06301d962bd0bcb07454042b8 |
| #179 | GORM | gothinkster/golang-gin-realworld-example-app | main | 626c372d259472148d93303f74aa9b9a1cdcef24 |
| #180 | Diesel | snamiki1212/realworld-v1-rust-actix-web-diesel | main | 1b844c094208be54008cd993ef51d87b808eea24 |

Each remote was verified with `git ls-remote --symref <url> HEAD`; the SHA returned matches the umbrella's pinned table value exactly.

## Dedup notes (no entry added)

- **#176 — Django REST Framework — gothinkster/django-realworld-example-app** is already present in `run.sh` line 54 under the Python block (`django-realworld`, same URL, same `master` branch). No second entry added; closing via this PR body.
- **#178 — Prisma — gothinkster/node-express-realworld-example-app** is already present in `run.sh` line 61 under the JavaScript block (`express-realworld`, same URL, same `master` branch). No second entry added; closing via this PR body.

The harness already exercises both repos, so chunk G's coverage of those frameworks is satisfied without duplication.

## Test plan

- [ ] `bash -n scripts/verify2/run.sh` passes (verified locally)
- [ ] Run `scripts/verify2/run.sh` end-to-end and confirm the 5 new repos clone, index, and appear in the per-repo table
- [ ] Confirm the new entries land in the per-language aggregate buckets (python +2, javascript +1, go +1, rust +1)

forbidden-term grep: clean