### PR TITLE
chore(verify2): add build-tool manifest fixtures (chunk H umbrella #309)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -125,6 +125,13 @@ REPOS=(
   "sequelize-express-example|https://github.com/sequelize/express-example.git|master|javascript"   # Sequelize sample app (#177)
   "golang-gin-realworld|https://github.com/gothinkster/golang-gin-realworld-example-app.git|main|go" # GORM sample app (#179)
   "actix-diesel-realworld|https://github.com/snamiki1212/realworld-v1-rust-actix-web-diesel.git|main|rust" # Diesel sample app (#180)
+  # --- Build tools (chunk H, umbrella #309) ---
+  # Manifest fixtures: each repo's root Cargo.toml / pom.xml / package.json /
+  # tsconfig is the canonical artifact for the cross/manifest extractor.
+  "tokio|https://github.com/tokio-rs/tokio.git|master|rust"                                          # Cargo.toml workspace manifest (#168)
+  "maven|https://github.com/apache/maven.git|master|java"                                            # pom.xml multi-module manifest (#170)
+  "pnpm|https://github.com/pnpm/pnpm.git|main|javascript"                                            # package.json workspace manifest (#172)
+  "nx|https://github.com/nrwl/nx.git|master|typescript"                                              # tsconfig + nx.json manifests (#173)
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds 4 build-tool manifest fixture entries to `scripts/verify2/run.sh` per chunk H umbrella #309.

| Child | Manifest | Repo | Branch | Verified HEAD SHA |
|---|---|---|---|---|
| #168 | Cargo.toml | tokio-rs/tokio | master | `ee0dc9092665a1f13df573dc5e5124999d8e9035` |
| #170 | pom.xml | apache/maven | master | `9cedc78f3491085f2786c314298e375b05c04624` |
| #172 | package.json | pnpm/pnpm | main | `f2b28f85ff09280de6895875a2e8a5f449a99101` |
| #173 | tsconfig | nrwl/nx | master | `305cd56960d8bfb32a044b486bceade82445e553` |

All four URLs verified via `git ls-remote --symref <url> HEAD`; SHAs match the umbrella table exactly.

## Dedup notes

- `tokio-rs/tokio` (this PR) is distinct from the existing `tokio-rs/mini-redis` corpus entry — different URLs, both retained per umbrella guidance (tokio is the runtime library; mini-redis is a consumer sample app).
- No other URL collisions detected.

## Validation

- `bash -n scripts/verify2/run.sh` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- forbidden-term grep: clean

## Closes

Closes #168
Closes #170
Closes #172
Closes #173
Closes #309