### PR TITLE
chore(verify2): chunk I — Java enterprise framework sample apps (umbrella #302)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -132,6 +132,15 @@ REPOS=(
   "maven|https://github.com/apache/maven.git|master|java"                                            # pom.xml multi-module manifest (#170)
   "pnpm|https://github.com/pnpm/pnpm.git|main|javascript"                                            # package.json workspace manifest (#172)
   "nx|https://github.com/nrwl/nx.git|master|typescript"                                              # tsconfig + nx.json manifests (#173)
+  # --- Java enterprise (chunk I, umbrella #302) ---
+  # Sample apps that USE each Java enterprise framework, per Refs #96 corpus policy.
+  "quarkus-quickstarts|https://github.com/quarkusio/quarkus-quickstarts.git|main|java"                # Quarkus sample apps (#181)
+  "micronaut-examples|https://github.com/micronaut-projects/micronaut-examples.git|master|java"       # Micronaut sample apps (#183)
+  "helidon-examples|https://github.com/helidon-io/helidon-examples.git|helidon-4.x|java"              # Helidon sample apps (#186)
+  "vertx-examples|https://github.com/vert-x3/vertx-examples.git|5.x|java"                             # Vert.x sample apps (#190)
+  "dropwizard-example|https://github.com/dropwizard/dropwizard.git|release/5.0.x|java|dropwizard-example" # Dropwizard sample app subtree (#193)
+  "play-java-starter|https://github.com/playframework/play-java-starter-example.git|2.7.x|java"       # Play Framework Java sample app (#197)
+  "spark-examples|https://github.com/perwendel/spark.git|master|java|examples"                        # Spark Java examples subtree (#203)
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds 7 Java enterprise framework sample-app fixtures to `scripts/verify2/run.sh` per chunk I umbrella #302.

| # | repo | branch | sparse |
|---|------|--------|--------|
| #181 | quarkusio/quarkus-quickstarts | main | — |
| #183 | micronaut-projects/micronaut-examples | master | — |
| #186 | helidon-io/helidon-examples | helidon-4.x | — |
| #190 | vert-x3/vertx-examples | 5.x | — |
| #193 | dropwizard/dropwizard | release/5.0.x | dropwizard-example/ |
| #197 | playframework/play-java-starter-example | 2.7.x | — |
| #203 | perwendel/spark | master | examples/ |

All branch HEAD SHAs verified via `git ls-remote --symref` and match the umbrella table exactly.

## Test plan

- [x] `bash -n scripts/verify2/run.sh` passes
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] forbidden-term grep on diff: clean
- [ ] harness run across the 7 new repos completes without errors

Closes #181
Closes #183
Closes #186
Closes #190
Closes #193
Closes #197
Closes #203
Closes #302