### PR TITLE
chore(verify2): chunk N declarative IaC corpus (#308)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -152,6 +152,19 @@ REPOS=(
   "react-native|https://github.com/facebook/react-native.git|main|javascript|template"                 # React Native: template/ subtree per umbrella body (#212)
   "ionic-conference-app|https://github.com/ionic-team/ionic-conference-app.git|main|typescript"        # Ionic / Capacitor sample app (#215)
   "maui-samples|https://github.com/dotnet/maui-samples.git|main|csharp"                                # .NET MAUI sample apps (#217)
+  # --- Declarative IaC (chunk N, umbrella #308) ---
+  # Sample/canonical fixtures for declarative IaC + container orchestration
+  # languages, per Refs #96 corpus policy. Each entry pinned to the SHA
+  # recorded in its child issue. ArgoCD (#211) is intentionally NOT re-listed
+  # here: argocd-example-apps is already present above under K8s YAML
+  # (chunk F) and #211 closes via that single fixture.
+  "aws-cloudformation-samples|https://github.com/aws-cloudformation/aws-cloudformation-samples.git|main|yaml"  # CloudFormation sample templates (#185)
+  "kustomize|https://github.com/kubernetes-sigs/kustomize.git|master|yaml|examples"                            # Kustomize examples/ subtree (#189)
+  "ansible-for-devops|https://github.com/geerlingguy/ansible-for-devops.git|master|yaml"                       # Ansible playbooks/roles sample (#192)
+  "chef-runit|https://github.com/chef-cookbooks/runit.git|main|ruby"                                           # Chef cookbook (Ruby DSL) (#195)
+  "puppet-control-repo|https://github.com/puppetlabs/control-repo.git|production|ruby"                         # Puppet control repo (Ruby DSL) (#199)
+  "awesome-compose|https://github.com/docker/awesome-compose.git|master|yaml"                                  # Docker Compose canonical samples (#204)
+  "nomad-pack|https://github.com/hashicorp/nomad-pack.git|main|hcl|registry"                                   # Nomad Pack registry/ subtree (#208)
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds 7 new declarative IaC + container orchestration sample repos to `scripts/verify2/run.sh` under a new `# --- Declarative IaC (chunk N, umbrella #308) ---` block. ArgoCD (#211) is intentionally not re-added: `argocd-example-apps` is already pinned in the K8s YAML block (chunk F) and #211 closes via that single fixture.

All SHAs match the umbrella table in #308 exactly (verified live via `git ls-remote --symref HEAD <branch>`):

| # | Repo | Branch | SHA |
|---|------|--------|-----|
| #185 | aws-cloudformation/aws-cloudformation-samples | main | c63b9a1e9769 |
| #189 | kubernetes-sigs/kustomize (sparse: examples) | master | 313aacedd3ad |
| #192 | geerlingguy/ansible-for-devops | master | 86e1bf800982 |
| #195 | chef-cookbooks/runit | main | d6d2d36ef747 |
| #199 | puppetlabs/control-repo | production | 565607dc6b2c |
| #204 | docker/awesome-compose | master | 18f59bdb09ec |
| #208 | hashicorp/nomad-pack (sparse: registry) | main | 35e0ef36b5ff |
| #211 | argoproj/argocd-example-apps | master | 723b86e01bea (already in chunk F K8s YAML — not duplicated) |

## Verification

- `bash -n scripts/verify2/run.sh` — clean
- `gofmt -l .` — clean
- `go vet ./...` — clean
- forbidden-term grep — clean

Closes #185
Closes #189
Closes #192
Closes #195
Closes #199
Closes #204
Closes #208
Closes #211
Closes #308

Refs #87 #96