### PR TITLE
chore(verify2): add 13 programmatic IaC repos (chunk M, umbrella #314)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -199,6 +199,26 @@ REPOS=(
   "rabbitmq-tutorials|https://github.com/rabbitmq/rabbitmq-tutorials.git|main|python"                         # RabbitMQ amqp client tutorials (#234)
   "nats.go|https://github.com/nats-io/nats.go.git|main|go"                                                    # NATS Go client (#236)
   "aws-sdk-js-v3|https://github.com/aws/aws-sdk-js-v3.git|main|typescript"                                    # AWS SQS / AWS JS SDK v3 (#237)
+  # --- Programmatic IaC (chunk M, umbrella #314) ---
+  # Programmatic IaC samples across CDK / Pulumi / Bicep / SAM / Serverless
+  # Framework / Crossplane, per Refs #96 corpus policy. Each entry pinned to
+  # the SHA recorded in its child issue. Multi-flavor monorepos
+  # (aws-cdk-examples, pulumi/examples) get one entry per language flavor with
+  # a unique name and a flavor-scoped sparse-path so cone-mode sparse-checkout
+  # keeps each working tree small.
+  "aws-cdk-examples-typescript|https://github.com/aws-samples/aws-cdk-examples.git|main|typescript|typescript" # AWS CDK TypeScript (#182) SHA f4143ebe9746
+  "aws-cdk-examples-python|https://github.com/aws-samples/aws-cdk-examples.git|main|python|python"             # AWS CDK Python (#184) SHA f4143ebe9746
+  "aws-cdk-examples-java|https://github.com/aws-samples/aws-cdk-examples.git|main|java|java"                   # AWS CDK Java (#187) SHA f4143ebe9746
+  "aws-cdk-examples-csharp|https://github.com/aws-samples/aws-cdk-examples.git|main|csharp|csharp"             # AWS CDK .NET (#188) SHA f4143ebe9746
+  "aws-cdk-examples-go|https://github.com/aws-samples/aws-cdk-examples.git|main|go|go"                         # AWS CDK Go (#191) SHA f4143ebe9746
+  "pulumi-examples-typescript|https://github.com/pulumi/examples.git|master|typescript|aws-ts-webserver"       # Pulumi TypeScript (#194) SHA d9173c2ed496
+  "pulumi-examples-python|https://github.com/pulumi/examples.git|master|python|aws-py-webserver"               # Pulumi Python (#196) SHA d9173c2ed496
+  "pulumi-examples-go|https://github.com/pulumi/examples.git|master|go|aws-go-webserver"                       # Pulumi Go (#200) SHA d9173c2ed496
+  "pulumi-examples-csharp|https://github.com/pulumi/examples.git|master|csharp|aws-cs-webserver"               # Pulumi .NET (#202) SHA d9173c2ed496
+  "azure-quickstart-templates|https://github.com/Azure/azure-quickstart-templates.git|master|bicep|quickstarts/microsoft.storage" # Azure Bicep (#206) SHA d4267860bf57
+  "aws-sam-cli-app-templates|https://github.com/aws/aws-sam-cli-app-templates.git|master|yaml|python3.12"      # AWS SAM (#210) SHA c7285973a74a
+  "serverless-examples|https://github.com/serverless/examples.git|v4|yaml|aws-node-http-api"                   # Serverless Framework (#214) SHA 631c0739a793
+  "crossplane|https://github.com/crossplane/crossplane.git|main|yaml|cluster/meta"                             # Crossplane (#218) SHA 2ddc36457725
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds 13 programmatic IaC sample repos to `scripts/verify2/run.sh` per chunk M umbrella #314:

- **AWS CDK** (5 flavors of `aws-samples/aws-cdk-examples` @ `f4143ebe9746`): typescript, python, java, csharp, go — each scoped via cone-mode sparse-checkout to its top-level flavor directory.
- **Pulumi** (4 flavors of `pulumi/examples` @ `d9173c2ed496`): typescript, python, go, csharp — each scoped to a representative `aws-{ts,py,go,cs}-webserver` flavor directory.
- **Azure Bicep** (`Azure/azure-quickstart-templates` @ `d4267860bf57`, sparse `quickstarts/microsoft.storage`).
- **AWS SAM** (`aws/aws-sam-cli-app-templates` @ `c7285973a74a`, sparse `python3.12`).
- **Serverless Framework** (`serverless/examples` @ `631c0739a793`, sparse `aws-node-http-api`).
- **Crossplane** (`crossplane/crossplane` @ `2ddc36457725`, sparse `cluster/meta`).

All 6 distinct URLs verified with `git ls-remote --symref`; remote HEAD/v4 SHAs match the umbrella table exactly.

Closes #182 #184 #187 #188 #191 #194 #196 #200 #202 #206 #210 #214 #218 #314

Refs #87

## Test plan

- [x] `bash -n scripts/verify2/run.sh` parses clean
- [x] `gofmt -l .` clean
- [x] `go vet ./...` clean
- [x] forbidden-term grep: clean
- [ ] Harness completes without errors across newly added repos (run `scripts/verify2/run.sh` locally / in CI)