### PR TITLE
chore(verify2): add 12 build-tool sample apps (Closes #320)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -244,6 +244,29 @@ REPOS=(
   "buildkite-agent|https://github.com/buildkite/agent.git|main|yaml|.buildkite"                                 # Buildkite pipeline.yml + plugins (#318) SHA 561444c7fc59
   "skaffold|https://github.com/GoogleContainerTools/skaffold.git|main|yaml|examples"                            # Skaffold build/deploy/test profiles (#318) SHA 95531aa9b308
   "tilt|https://github.com/tilt-dev/tilt.git|master|starlark|integration"                                       # Tilt Starlark Tiltfile resources (#318) SHA 98108ca6664b
+  # --- Build tools missing (chunk R, umbrella #320) ---
+  # Build-tool manifest fixtures not yet exercised: Gradle, Bazel, Make, CMake,
+  # Poetry, Composer, Bundler, Mix, sbt, Leiningen, Lerna (npm workspaces),
+  # Turborepo. Each entry pinned to the SHA recorded in the umbrella body.
+  # Dedup notes: pnpm/pnpm is already present above under chunk H (#172) — the
+  # same clone exercises both package.json and pnpm-workspace.yaml extractors,
+  # so we do NOT re-list it here. Gradle/spring-petclinic overlap is partial:
+  # spring-petclinic is a Gradle-using sample, gradle/gradle is the canonical
+  # multi-project Groovy + Kotlin DSL build source — kept as separate fixture.
+  "gradle|https://github.com/gradle/gradle.git|master|java|subprojects"                                        # Gradle multi-project Groovy + Kotlin DSL (#320) SHA 62000451ad7b
+  "bazel|https://github.com/bazelbuild/bazel.git|master|java"                                                  # Bazel BUILD/Starlark targets, deps (#320) SHA bca007ec74f2
+  "gnu-make|https://git.savannah.gnu.org/git/make.git|master|c"                                                # GNU Make rules, vars, includes (#320) SHA b3802782de3e
+  "cmake|https://github.com/Kitware/CMake.git|master|cpp"                                                      # CMake list files, modules, find-packages (#320) SHA 7e1b633a8978
+  "poetry|https://github.com/python-poetry/poetry.git|main|python"                                             # Poetry pyproject + lock semantics (#320) SHA 811a12dae0fe
+  "composer|https://github.com/composer/composer.git|main|php"                                                 # PHP Composer manifest + lock (#320) SHA 37825e985129
+  "bundler|https://github.com/rubygems/bundler.git|master|ruby"                                                # Ruby Bundler Gemfile + gemspec (#320) SHA 35be6d9a6030
+  "elixir|https://github.com/elixir-lang/elixir.git|main|elixir"                                               # Elixir Mix project + deps (#320) SHA b8723fea1ec5
+  "sbt|https://github.com/sbt/sbt.git|develop|scala"                                                           # Scala sbt build definition (#320) SHA 76992ed3f62f
+  "leiningen|https://github.com/technomancy/leiningen.git|main|clojure"                                        # Clojure Leiningen project.clj (#320) SHA 40227328d4a9
+  "lerna|https://github.com/lerna/lerna.git|main|javascript"                                                   # npm/yarn workspaces canonical (#320) SHA f4387d673bfd
+  "turborepo|https://github.com/vercel/turborepo.git|main|typescript"                                          # Turborepo pipeline config (#320) SHA c1f923a4abe5
+  # NOTE: pnpm-workspace coverage is satisfied by the existing pnpm entry under
+  # chunk H above (same repo @ same branch).
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds build-tool manifest fixtures to `scripts/verify2/run.sh` for chunk R (umbrella #320). Net 12 new entries covering Gradle, Bazel, GNU Make, CMake, Poetry, Composer, Bundler, Mix, sbt, Leiningen, Lerna, Turborepo.

Each entry pinned to the SHA in the umbrella body, verified via `git ls-remote --symref`. Every URL's HEAD on its listed branch matched the umbrella SHA exactly.

## Dedup notes

- **pnpm/pnpm**: already present from chunk H (#172). Same clone exercises both `package.json` and `pnpm-workspace.yaml`. Skipped to avoid duplicate. Net new rows: 12 (umbrella listed 13).
- **gradle/gradle vs spring-petclinic**: kept gradle/gradle as a separate fixture. petclinic is a Gradle-using sample but does not exercise the canonical multi-project Groovy + Kotlin DSL surface that gradle/gradle does.

## Verified URLs / SHAs

| repo | branch | SHA |
|---|---|---|
| gradle/gradle | master | 62000451ad7b25de53fa89a155ef8ecb401621bb |
| bazelbuild/bazel | master | bca007ec74f21464115b9175fa217698302ace74 |
| git.savannah.gnu.org/git/make.git | master | b3802782de3eff2c0f1eda9e7c0befd8cd142162 |
| Kitware/CMake | master | 7e1b633a897813032d8c088c7da58931498f48c6 |
| python-poetry/poetry | main | 811a12dae0fe81f199e3f1b88b8b8be9eed543c2 |
| composer/composer | main | 37825e9851291b969be52cf98894af17505f2766 |
| rubygems/bundler | master | 35be6d9a603084f719fec4f4028c18860def07f6 |
| elixir-lang/elixir | main | b8723fea1ec5e3d6cd32533df2d946ee3ea77f61 |
| sbt/sbt | develop | 76992ed3f62f735a62566eaa2aefc5243f7aeb00 |
| technomancy/leiningen | main | 40227328d4a9c8945362d6d626d19c2449175df6 |
| lerna/lerna | main | f4387d673bfdf4923ab62cd52d3498dec6dc7f2c |
| vercel/turborepo | main | c1f923a4abe524a462571bb917a9d23f9aa913a5 |

## Test plan

- [ ] `bash -n scripts/verify2/run.sh` (syntax check — passed locally)
- [ ] forbidden-term grep: clean (passed locally)
- [ ] Manual harness run: `scripts/verify2/run.sh` exercises every new extractor without errors
- [ ] Confirm no per-repo `ERROR` rows in the generated report for the 12 new fixtures

Closes #320