### PR TITLE
chore(verify2): add 7 API/Spec/IDL alt repos (Closes #325)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -279,6 +279,22 @@ REPOS=(
   "kong|https://github.com/Kong/kong.git|master|kong-declarative|spec/fixtures"                                # Kong declarative config services/routes/plugins (#326) SHA 58f2daa56b90
   "envoy|https://github.com/envoyproxy/envoy.git|main|envoy-yaml|configs"                                      # Envoy listener/cluster/route YAML (#326) SHA 3ddecad194fc
   "haproxy|https://github.com/haproxy/haproxy.git|master|haproxy-cfg|examples"                                 # HAProxy frontend/backend/acl config (#326) SHA efb36c0dafd5
+  # --- API/Spec/IDL alts (chunk U, umbrella #325) ---
+  # API spec / IDL alternatives beyond OpenAPI, per Refs #87 corpus policy.
+  # Each entry pinned to the SHA verified in the umbrella body via
+  # git ls-remote --symref against canonical upstream branches.
+  # Sparse-paths are applied to the three large monorepos (smithy, avro,
+  # thrift); the remaining four are small enough to clone in full. Where
+  # the umbrella listed multiple sparse subtrees (or glob patterns not
+  # supported by cone-mode sparse-checkout), one canonical IDL/schema
+  # subtree per repo is selected — broad extractor coverage is preserved.
+  "asyncapi-spec|https://github.com/asyncapi/spec.git|master|asyncapi"                                          # AsyncAPI channels/messages/bindings (#325) SHA 94ff695acb10
+  "smithy|https://github.com/smithy-lang/smithy.git|main|smithy|smithy-model"                                   # Smithy IDL services/operations/shapes (#325) SHA 22a34991defb
+  "avro|https://github.com/apache/avro.git|main|avro|lang"                                                      # Avro schemas (.avsc) and IDL (.avdl) (#325) SHA 892d6997dcb6
+  "thrift|https://github.com/apache/thrift.git|master|thrift|tutorial"                                          # Thrift IDL services/structs (#325) SHA f39cecc4d5b6
+  "json-schema-spec|https://github.com/json-schema-org/json-schema-spec.git|main|json-schema"                   # JSON Schema draft definitions (#325) SHA 5794814cca9e
+  "raml-spec|https://github.com/raml-org/raml-spec.git|master|raml"                                             # RAML 1.0 API definitions (#325) SHA 3ba244ade44c
+  "api-blueprint|https://github.com/apiaryio/api-blueprint.git|master|api-blueprint"                            # API Blueprint markdown specs (#325) SHA 86fc3a128a93
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary
- Adds 7 API spec / IDL alternative fixtures to `scripts/verify2/run.sh` covering AsyncAPI, Smithy, Avro, Thrift, JSON Schema, RAML, and API Blueprint per umbrella #325.
- Each entry pinned to the SHA verified via `git ls-remote --symref` against the canonical upstream branch listed in the umbrella body.
- Sparse-paths applied to the three large monorepos (smithy / avro / thrift); the remaining four clone in full (each <5MB).

## Verified URLs and SHAs
| repo | branch | SHA |
|---|---|---|
| asyncapi/spec | master | 94ff695acb109f3fd1a3cbf3dd33ccbc0802542c |
| smithy-lang/smithy | main | 22a34991defb723b4e8c59ec0c18e7ff0dc811e3 |
| apache/avro | main | 892d6997dcb65627560b04bd76c5a3dd97666cdf |
| apache/thrift | master | f39cecc4d5b67a01c611696507362bdb3daa2cc7 |
| json-schema-org/json-schema-spec | main | 5794814cca9edc379cc578d1d8ba756adc05814f |
| raml-org/raml-spec | master | 3ba244ade44c2757f2038767d88e3647543d535a |
| apiaryio/api-blueprint | master | 86fc3a128a939e3b476ffc2e2819e54e20f3b45b |

## Notes on sparse-path selection
The `git sparse-checkout set "$sparse"` invocation in `run.sh` passes the value as a single quoted argument and uses cone mode, which accepts top-level directory paths only -- it does not accept glob patterns (`*.json`, `*.md`, `*.apib`) and is treated as a single dir. Where the umbrella listed multiple subtrees or globs, one canonical IDL/schema subtree per repo was selected:
- smithy -> `smithy-model` (canonical Smithy IDL)
- avro -> `lang` (per-language schemas + IDL across all language bindings)
- thrift -> `tutorial` (canonical Thrift IDL services/structs)

Small repos (asyncapi-spec, json-schema-spec, raml-spec, api-blueprint) clone in full so glob-style fixtures from the umbrella are still exercised.

## Test plan
- [ ] `bash -n scripts/verify2/run.sh` (already verified locally)
- [ ] Spot-run the indexer on one new fixture to confirm extractor wiring (e.g., `archigraph index --json-stats $CORPORA_DIR/asyncapi-spec`)
- [ ] Full `scripts/verify2/run.sh` on a workstation -- harness exercises every listed extractor without errors (umbrella acceptance)

forbidden-term grep: clean

Closes #325