### PR TITLE
chore(verify2): add 11 validation/lint config repos (Closes #324)

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -308,6 +308,24 @@ REPOS=(
   "prometheus-client-golang|https://github.com/prometheus/client_golang.git|main|go|prometheus"                  # Prometheus Go client metrics (#322) SHA 0ac87e14c303
   "sentry-javascript|https://github.com/getsentry/sentry-javascript.git|develop|typescript|packages"             # Sentry SDK init + capture (#322) SHA 298807727c81
   "dd-trace-js|https://github.com/DataDog/dd-trace-js.git|master|javascript|packages"                            # Datadog APM tracer instrumentations (#322) SHA 807fceb14d1a
+  # --- Validation + Lint configs (chunk T, umbrella #324) ---
+  # Validation libraries (Zod, Joi, Yup, Pydantic, class-validator) and lint
+  # configurations (ESLint, Prettier, Ruff, RuboCop, golangci-lint, Clippy)
+  # per Refs #87. Each entry pinned to the SHA recorded in the umbrella body.
+  # Sparse paths from the umbrella are documented in comments; the harness
+  # entry uses a full clone because the parser supports a single sparse path
+  # only and these fixtures list multiple paths each.
+  "zod|https://github.com/colinhacks/zod.git|main|typescript"                                                  # Zod schema definitions, refinements (#324) SHA b6071fc0ad2b paths src/ tests/
+  "joi|https://github.com/hapijs/joi.git|master|javascript"                                                    # Joi schema + extensions (#324) SHA 048fe05b8235 paths lib/ test/
+  "yup|https://github.com/jquense/yup.git|master|typescript"                                                   # Yup object/array validation (#324) SHA ff31eee8a2b1 paths src/ test/
+  "pydantic|https://github.com/pydantic/pydantic.git|main|python"                                              # pydantic v2 BaseModel + validators (#324) SHA 7a369fb502a4 paths pydantic/ tests/
+  "class-validator|https://github.com/typestack/class-validator.git|develop|typescript"                        # class-validator decorators (#324) SHA 2e1a5c27dbd6 paths src/ test/
+  "eslint|https://github.com/eslint/eslint.git|main|javascript"                                                # ESLint flat + legacy config (#324) SHA a4297918d264 paths lib/ conf/ eslint.config.js
+  "prettier|https://github.com/prettier/prettier.git|main|javascript"                                          # Prettier config + plugin discovery (#324) SHA f3db616d8389 paths .prettierrc* src/config/
+  "ruff|https://github.com/astral-sh/ruff.git|main|python"                                                     # ruff config + rule selectors (#324) SHA 8091ad11d15f paths ruff.toml pyproject.toml crates/
+  "rubocop|https://github.com/rubocop/rubocop.git|master|ruby"                                                 # RuboCop cop config + inheritance (#324) SHA 11262e1cdb45 paths .rubocop.yml config/
+  "golangci-lint|https://github.com/golangci/golangci-lint.git|main|go"                                        # golangci-lint linters + presets (#324) SHA ef3710ea5470 paths .golangci.yml pkg/config/
+  "rust-clippy|https://github.com/rust-lang/rust-clippy.git|master|rust"                                       # Clippy lint config + categories (#324) SHA f763854b8bd3 paths clippy.toml clippy_lints/
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir


### PR DESCRIPTION
## Summary

Adds chunk T fixtures to `scripts/verify2/run.sh` (umbrella #324). Net 11 new entries: validation libraries (Zod, Joi, Yup, Pydantic, class-validator) and lint configurations (ESLint, Prettier, Ruff, RuboCop, golangci-lint, Clippy).

Each entry pinned to the SHA in the umbrella body and verified via `git ls-remote --symref`. Sparse paths from the umbrella are documented in trailing comments; the harness entry uses a full clone because the parser supports a single sparse path only and these fixtures list multiple paths each.

## Verified URLs / SHAs

| repo | branch | umbrella SHA | remote HEAD on branch |
|---|---|---|---|
| colinhacks/zod | main | b6071fc0ad2b... | match |
| hapijs/joi | master | 048fe05b8235... | match |
| jquense/yup | master | ff31eee8a2b1... | match |
| pydantic/pydantic | main | 7a369fb502a4... | match |
| typestack/class-validator | develop | 2e1a5c27dbd6... | match |
| eslint/eslint | main | a4297918d264... | match |
| prettier/prettier | main | f3db616d8389... | match |
| astral-sh/ruff | main | 8091ad11d15f... | drifted to 893bfde6fc9b (umbrella SHA retained per pinning policy) |
| rubocop/rubocop | master | 11262e1cdb45... | match |
| golangci/golangci-lint | main | ef3710ea5470... | match |
| rust-lang/rust-clippy | master | f763854b8bd3... | match |

## Notes

- forbidden-term grep: clean
- `bash -n scripts/verify2/run.sh` passes
- Parallel siblings S/U/V touch the same file — rebase onto origin/main if remote moves.

## Test plan

- [ ] `bash -n scripts/verify2/run.sh` (syntax check — passed locally)
- [ ] Manual harness run: `scripts/verify2/run.sh` exercises every new extractor without errors
- [ ] Confirm no per-repo `ERROR` rows in the generated report for the 11 new fixtures

Closes #324