### PR TITLE
fix(resolve): Python project-internal dotted-path IMPORTS resolve via per-module index (Closes #142)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1156,6 +1156,14 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d bare-name CALLS targets%s\n",
 			importStats.CallsRewritten, importStats.CallsConsidered, note)
 	}
+	// Issue #142 — IMPORTS edges with dotted-path ToIDs
+	// (`conduit.database.db`) are rewritten via the same per-module
+	// reverse index. Surfaced separately so the verify2 harness can
+	// attribute the bug-resolver delta on python-flask-realworld.
+	if importStats.ImportsConsidered > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d dotted IMPORTS targets\n",
+			importStats.ImportsRewritten, importStats.ImportsConsidered)
+	}
 
 	idx := resolve.BuildIndex(merged)
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -376,6 +376,41 @@ type ImportResolveStats struct {
 	// CallsRewritten counts the subset of CallsConsidered that resolved
 	// to a 16-char entity ID via the import table.
 	CallsRewritten int
+	// ImportsConsidered counts every embedded IMPORTS edge whose ToID
+	// was a non-empty, non-hex dotted module path (issue #142).
+	ImportsConsidered int
+	// ImportsRewritten counts the subset of ImportsConsidered that
+	// resolved to a 16-char entity ID via the per-module reverse index.
+	ImportsRewritten int
+}
+
+// ResolveDottedImportTarget looks up a project-internal IMPORTS ToID of
+// the form "<module>.<leaf>" against the per-module reverse index built
+// in BuildImportTable. The dotted path is split on the LAST dot; the
+// left segment is the module path, the right segment is the leaf
+// symbol. Returns (id, true) when (module, leaf) maps to exactly one
+// entity; ("", false) otherwise (external package, plain module import
+// with no leaf, ambiguous tuple, or unknown module).
+//
+// Issue #142 — flask-realworld emits IMPORTS edges with ToIDs like
+// "conduit.database.db". Pre-fix these flowed through the Index
+// resolver as bare-name stubs, missed every (kind, name, qualified)
+// index, and landed on bug-resolver. The dotted-path → entity mapping
+// is the same data BuildImportTable already builds for CALLS rewrite;
+// this function simply exposes it for the IMPORTS-edge code path.
+func (t ImportTable) ResolveDottedImportTarget(dotted string) (string, bool) {
+	if dotted == "" {
+		return "", false
+	}
+	dot := strings.LastIndexByte(dotted, '.')
+	if dot <= 0 || dot == len(dotted)-1 {
+		// No leaf separator — this is a plain module import like
+		// `import conduit.database`. There is no per-symbol entity to
+		// bind to; leave the edge alone.
+		return "", false
+	}
+	module, leaf := dotted[:dot], dotted[dot+1:]
+	return t.lookupModuleEntity(module, leaf)
 }
 
 // ResolveImports rewrites embedded CALLS edges in records using the
@@ -394,26 +429,45 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 		}
 		for j := range e.Relationships {
 			rel := &e.Relationships[j]
-			if rel.Kind != "CALLS" {
-				continue
-			}
 			to := rel.ToID
 			if to == "" || isHexID(to) {
 				continue
 			}
-			// Skip stubs that already encode a kind ("Kind:Name") or a
-			// receiver-typed dotted target ("Class.method"). The base
-			// resolver handles those via byKind / byMember.
-			if strings.ContainsAny(to, ":.#") {
-				continue
+			switch rel.Kind {
+			case "CALLS":
+				// Skip stubs that already encode a kind ("Kind:Name") or
+				// a receiver-typed dotted target ("Class.method"). The
+				// base resolver handles those via byKind / byMember.
+				if strings.ContainsAny(to, ":.#") {
+					continue
+				}
+				stats.CallsConsidered++
+				id, ok := tbl.ResolveBareCallTarget(callerFile, to)
+				if !ok {
+					continue
+				}
+				rel.ToID = id
+				stats.CallsRewritten++
+			case importRelKind:
+				// IMPORTS ToID is a dotted module path like
+				// "conduit.database.db" (issue #142). Project-internal
+				// targets resolve via the per-module reverse index;
+				// external packages ("marshmallow.Schema") miss the
+				// lookup and are left for the external-synthesis pass.
+				if !strings.ContainsRune(to, '.') {
+					continue
+				}
+				if strings.ContainsAny(to, ":#") {
+					continue
+				}
+				stats.ImportsConsidered++
+				id, ok := tbl.ResolveDottedImportTarget(to)
+				if !ok {
+					continue
+				}
+				rel.ToID = id
+				stats.ImportsRewritten++
 			}
-			stats.CallsConsidered++
-			id, ok := tbl.ResolveBareCallTarget(callerFile, to)
-			if !ok {
-				continue
-			}
-			rel.ToID = id
-			stats.CallsRewritten++
 		}
 	}
 	return stats

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -364,6 +364,112 @@ func TestResolveImports_PlainImportAmbiguous(t *testing.T) {
 	}
 }
 
+// TestResolveImports_DottedImportEdgeRewrite (issue #142) covers the
+// dominant python-flask-realworld bug-resolver pattern: a project-internal
+// IMPORTS edge whose ToID is the full dotted module path
+// (`conduit.database.db`). The Python extractor emits ToID as the full
+// dotted path, but the entity for `db` lives at conduit/database.py with
+// QualifiedName="" (Python entities don't carry QualifiedName), so the
+// downstream Index resolver misses byQualifiedName / byName / byKind and
+// the edge ends up classified as bug-resolver.
+//
+// ResolveImports must rewrite the IMPORTS ToID to the underlying entity
+// ID by splitting the dotted path tail-first into (module, leaf) and
+// probing the per-module reverse index built in BuildImportTable.
+func TestResolveImports_DottedImportEdgeRewrite(t *testing.T) {
+	records := []types.EntityRecord{
+		// Importing file: `from conduit.database import db`. The Python
+		// extractor emits ToID = "conduit.database.db" (modPath + "." + name).
+		importerRecord("app/views.py", "conduit.database.db", map[string]string{
+			"local_name":    "db",
+			"source_module": "conduit.database",
+			"imported_name": "db",
+		}),
+		// Real entity for `db` lives at conduit/database.py with name "db".
+		targetRecord("db", "conduit/database.py", "8888888888888888"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 IMPORTS rewrite, got %d (considered=%d)", stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	// The IMPORTS edge on the importer marker entity should now point at
+	// the real entity ID, not the dotted-path stub.
+	if got := records[0].Relationships[0].ToID; got != "8888888888888888" {
+		t.Fatalf("expected IMPORTS ToID rewritten to 8888888888888888, got %q", got)
+	}
+}
+
+// TestResolveImports_DottedImportEdgePackageInit covers `from conduit.models
+// import db` where `db` is exported from conduit/models/__init__.py.
+// modulesForFile already maps __init__.py to the parent package's dotted
+// form, so the (conduit.models, db) tuple resolves.
+func TestResolveImports_DottedImportEdgePackageInit(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("app/views.py", "conduit.models.db", map[string]string{
+			"local_name":    "db",
+			"source_module": "conduit.models",
+			"imported_name": "db",
+		}),
+		targetRecord("db", "conduit/models/__init__.py", "9999999999999999"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 IMPORTS rewrite, got %d (considered=%d)", stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	if got := records[0].Relationships[0].ToID; got != "9999999999999999" {
+		t.Fatalf("expected IMPORTS ToID rewritten to 9999999999999999, got %q", got)
+	}
+}
+
+// TestResolveImports_DottedImportEdgeExternalLeftAlone covers
+// `from marshmallow import Schema` where marshmallow is NOT in the
+// corpus. The dotted ToID "marshmallow.Schema" must be left alone so
+// the external-synthesis pass can route it to ext:marshmallow.
+func TestResolveImports_DottedImportEdgeExternalLeftAlone(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("app/views.py", "marshmallow.Schema", map[string]string{
+			"local_name":    "Schema",
+			"source_module": "marshmallow",
+			"imported_name": "Schema",
+		}),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 0 {
+		t.Fatalf("expected 0 IMPORTS rewrites for external package, got %d", stats.ImportsRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "marshmallow.Schema" {
+		t.Fatalf("expected IMPORTS ToID unchanged, got %q", got)
+	}
+}
+
+// TestResolveImports_DottedImportPlainModule covers `import conduit.database`
+// — the IMPORTS ToID is just the module path "conduit.database", with NO
+// leaf symbol. The resolver should not attempt to rewrite the edge in
+// this shape (there is no project-internal entity that uniquely is
+// "the module" for a plain import — the marker entity itself is what
+// the IMPORTS edge points at by convention).
+func TestResolveImports_DottedImportPlainModule(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("app/views.py", "conduit.database", map[string]string{
+			"local_name":    "conduit",
+			"source_module": "conduit.database",
+			"imported_name": "conduit.database",
+		}),
+		targetRecord("db", "conduit/database.py", "aaaa1111aaaa1111"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 0 {
+		t.Fatalf("expected 0 IMPORTS rewrites for plain module import, got %d", stats.ImportsRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "conduit.database" {
+		t.Fatalf("expected IMPORTS ToID unchanged for plain module, got %q", got)
+	}
+}
+
 // TestResolveImports_FileLocalCollisionDropsBinding covers the case
 // where the same file imports two different symbols under the same
 // local name (e.g. shadowing). The conservative behaviour is to drop


### PR DESCRIPTION
## Summary

Closes #142. Python IMPORTS edges emit dotted-path ToIDs like `conduit.database.db`. Pre-fix these flowed through `Index.Lookup` as bare-name stubs, missed every (kind, name, qualified) index (Python entities carry empty QualifiedName), and landed on bug-resolver. Per #92 categorization this was 113/113 of the flask-realworld bug-resolver samples.

`ResolveImports` now also rewrites IMPORTS edges. The dotted ToID is split on the last dot into `(module, leaf)` and resolved against the per-module reverse index `BuildImportTable` already builds for the CALLS rewrite path. Plain `import x.y` (no leaf) and external packages (e.g. `marshmallow.Schema`) are left alone for the external-synthesis pass.

## VERIFY-2 deltas

| Repo              | bug-resolver | resolved | bug_rate          | Imports rewritten |
|-------------------|-------------:|---------:|------------------:|------------------:|
| flask-realworld   | 118 -> 96    | 641 -> 663 | 0.527 -> 0.515  | 27 / 140          |
| django-realworld  | 59 -> 54     | 414 -> 419 | 0.322 -> 0.318  | 7 / 128           |

## Test plan
- [x] `go test ./internal/resolve/` (4 new tests pass: `DottedImportEdgeRewrite`, `DottedImportEdgePackageInit`, `DottedImportEdgeExternalLeftAlone`, `DottedImportPlainModule`)
- [x] `go test ./...` (full suite green)
- [x] VERIFY-2 on python/flask-realworld and python/django-realworld confirms bug-resolver decrease and resolved increase
- [x] External-package IMPORTS (`marshmallow.Schema`) left untouched so synth pass routes them to `ext:marshmallow`

🤖 Generated with [Claude Code](https://claude.com/claude-code)