### PR TITLE
fix(kotlin): only emit CALLS for parenthesized method calls (Closes #122)

### DIFF
--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -245,10 +245,27 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 }
 
 // kotlinCallTarget resolves the callee name from a call_expression node.
-// Tree-sitter-kotlin shapes a call as `<expression> <call_suffix>`. When the
-// expression is a simple_identifier or navigation_expression we pull the
-// rightmost simple_identifier; otherwise we return "".
+//
+// Tree-sitter-kotlin shapes a call as `<expression> <call_suffix>` where
+// `<call_suffix>` carries the parenthesized argument list (or trailing
+// lambda) that distinguishes a real method invocation from a plain
+// property/field reference. We require a `call_suffix` sibling before
+// emitting any CALLS edge — without it, the node is not a true call
+// site and the resolver cannot bind it. Issue #122.
+//
+// When the receiver expression is a `simple_identifier` (`foo()`) we
+// return that identifier. When it is a `navigation_expression`
+// (`a.b.c()`) the actual callee name is the rightmost `simple_identifier`
+// of the trailing `navigation_suffix`, NOT the leftmost descendant — the
+// previous implementation walked descendants via the stack-based
+// findAllNodes (LIFO) which returned the receiver's root identifier
+// (e.g. `chat` for `chat.lastMessages.add()`), producing the
+// false-positive same-class field-access CALLS that dominated the
+// ktor-samples bug-extractor rate. Issue #122.
 func kotlinCallTarget(call *sitter.Node, src []byte) string {
+	if !hasCallSuffix(call) {
+		return ""
+	}
 	if call.ChildCount() == 0 {
 		return ""
 	}
@@ -257,14 +274,39 @@ func kotlinCallTarget(call *sitter.Node, src []byte) string {
 	case "simple_identifier":
 		return string(src[first.StartByte():first.EndByte()])
 	case "navigation_expression":
-		// Walk to the last simple_identifier descendant.
-		ids := findAllNodes(first, "simple_identifier")
-		if len(ids) > 0 {
-			n := ids[len(ids)-1]
-			return string(src[n.StartByte():n.EndByte()])
+		// The callee name is the last `simple_identifier` of the
+		// trailing navigation_suffix (`.method`).
+		var lastSuffix *sitter.Node
+		for i := 0; i < int(first.ChildCount()); i++ {
+			ch := first.Child(i)
+			if ch.Type() == "navigation_suffix" {
+				lastSuffix = ch
+			}
+		}
+		if lastSuffix == nil {
+			return ""
+		}
+		for i := int(lastSuffix.ChildCount()) - 1; i >= 0; i-- {
+			ch := lastSuffix.Child(i)
+			if ch.Type() == "simple_identifier" {
+				return string(src[ch.StartByte():ch.EndByte()])
+			}
 		}
 	}
 	return ""
+}
+
+// hasCallSuffix reports whether a call_expression node has a `call_suffix`
+// child. Tree-sitter-kotlin requires this child for a real invocation —
+// its presence (parentheses or trailing lambda) is what distinguishes a
+// method call from a bare identifier or property reference. Issue #122.
+func hasCallSuffix(call *sitter.Node) bool {
+	for i := 0; i < int(call.ChildCount()); i++ {
+		if call.Child(i).Type() == "call_suffix" {
+			return true
+		}
+	}
+	return false
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.

--- a/internal/extractors/kotlin/relationships_test.go
+++ b/internal/extractors/kotlin/relationships_test.go
@@ -137,6 +137,99 @@ func TestKotlin_CallsKeywordsFiltered(t *testing.T) {
 	}
 }
 
+// TestKotlin_NoCallsForBareFieldAccess (#122): tree-sitter-kotlin shapes
+// `chat.lastMessages` as a `navigation_expression`, NOT a `call_expression`
+// — there's no parenthesized call_suffix. The extractor must not emit any
+// CALLS edge for these bare property references; doing so creates
+// resolver-unbindable stubs that land in bug-extractor and dominate the
+// ktor-samples error rate.
+func TestKotlin_NoCallsForBareFieldAccess(t *testing.T) {
+	src := `class ChatService {
+    val members = mutableListOf<String>()
+    val lastMessages = mutableListOf<String>()
+    fun caller() {
+        members
+        lastMessages
+        chat.lastMessages
+        chat.members.size
+        helper()
+    }
+    fun helper() {}
+}
+`
+	ents := runKotlin(t, src)
+	caller := ktFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller operation")
+	}
+	forbidden := map[string]bool{
+		"members":      true,
+		"lastMessages": true,
+		"chat":         true,
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if forbidden[r.ToID] {
+			t.Errorf("bare field/property reference %q must not be emitted as CALLS target", r.ToID)
+		}
+	}
+	if !ktHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("real method call helper() must still produce CALLS caller→helper")
+	}
+}
+
+// TestKotlin_NavigationCallTrailingIdentifier (#122): for a navigation
+// call like `usersCounter.incrementAndGet()` the CALLS target must be
+// the trailing method identifier, not the receiver. The previous
+// implementation walked descendants via stack-based DFS (LIFO) which
+// returned the leftmost simple_identifier of the receiver chain (e.g.
+// `usersCounter`, `chat`, `members`), producing same-class field-access
+// false positives.
+func TestKotlin_NavigationCallTrailingIdentifier(t *testing.T) {
+	src := `class S {
+    val usersCounter = AtomicInteger()
+    fun caller() {
+        usersCounter.incrementAndGet()
+        chat.lastMessages.add("x")
+        a.b.c.d()
+    }
+}
+`
+	ents := runKotlin(t, src)
+	caller := ktFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller operation")
+	}
+	want := map[string]bool{
+		"incrementAndGet": false,
+		"add":             false,
+		"d":               false,
+	}
+	forbidden := map[string]bool{
+		"usersCounter": true,
+		"chat":         true,
+		"a":            true,
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if forbidden[r.ToID] {
+			t.Errorf("receiver root %q must not be emitted as CALLS target", r.ToID)
+		}
+		if _, ok := want[r.ToID]; ok {
+			want[r.ToID] = true
+		}
+	}
+	for k, v := range want {
+		if !v {
+			t.Errorf("expected CALLS caller→%s", k)
+		}
+	}
+}
+
 // TestKotlin_NoImports (#41): kotlin extractor intentionally does
 // NOT emit IMPORTS edges (Python parity). Guard against future regressions
 // that re-introduce ghost "org" / "com" / "java" entities.


### PR DESCRIPTION
## Summary
- Gate Kotlin `CALLS` emission on a `call_suffix` child so bare field/property references no longer produce edges.
- Fix `kotlinCallTarget` for `navigation_expression`: return the trailing `navigation_suffix`'s last `simple_identifier` (the actual method) instead of the leftmost descendant (the receiver root).

Closes #122.

## Root cause
`a.b.c()` parses as `call_expression(navigation_expression(a.b.c), call_suffix())`. The previous code resolved the callee by walking descendants of the navigation_expression with the stack-based DFS helper (`findAllNodes`), which visits children LIFO. `ids[len-1]` was therefore the LEFTMOST simple_identifier — the receiver root — not the trailing method name. Result: ktor-samples emitted CALLS targeting same-class field names (`chat`, `usersCounter`, `members`, `memberNames`, `lastMessages`, `connections`), producing resolver-unbindable stubs that dominated bug-extractor.

## VERIFY-2 single-repo (before vs after)

**ktor-samples**
- bug-extractor top-5 samples: `[lastMessages, members, usersCounter, memberNames, connections]` (false-positive field shapes) → `[testApplication, assertEquals, readText, webSocket, config]` (real calls; resolver work for separate issue).
- resolved 4944 → 5586 (+642), bug_rate 35.70% → 35.30%.

**exposed**
- bug_rate 15.59% → 13.07%, bug-extractor 1075 → 768 (-307), resolved 6062 → 6884 (+822).

## Test plan
- [x] `go test ./internal/extractors/kotlin/...` (18 tests, including 2 new regression tests).
- [x] `go test -race -count=1 ./...` (full suite, exit 0).
- [x] `go vet ./...` clean.
- [x] `gofmt -l ./internal/extractors/kotlin/` clean.
- [x] VERIFY-2 single-repo on `ktor-samples` and `exposed` confirms field-name pollution removed.

## New tests
- `TestKotlin_NoCallsForBareFieldAccess` — bare property references and chained navigation without parens emit zero CALLS.
- `TestKotlin_NavigationCallTrailingIdentifier` — `x.y.z()` yields CALLS→z, never CALLS→x.

🤖 Generated with [Claude Code](https://claude.com/claude-code)