### PR TITLE
fix(synth): add ActiveRecord persistence methods to Ruby allowlist (Closes #124)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1398,6 +1398,72 @@ var rubyBareNames = map[string]struct{}{
 	"is_a?":        {},
 	"kind_of?":     {},
 	"instance_of?": {},
+	// ActiveRecord persistence and validation methods (issue #124).
+	// After #107 + #143, residual rails-realworld bug-extractor was
+	// dominated by AR persistence calls (`record.save`, `user.update!`,
+	// `model.valid_password?`). These names ARE generated/inherited from
+	// ActiveRecord::Base, not user-defined — extractor strips the
+	// receiver and the resolver sees only the bare leaf. The Ruby
+	// language gate keeps them from polluting other ecosystems. Generic
+	// collection ops (`find`, `count`) remain EXCLUDED per #107 lock-in.
+	// `new` and `where` are intentionally omitted: `new` is already
+	// covered above; `where` is classified by the resolver-side
+	// rubyDynamicPatterns catalog as Dynamic.
+	"save":               {},
+	"save!":              {},
+	"update":             {},
+	"update!":            {},
+	"destroy":            {},
+	"destroy!":           {},
+	"valid?":             {},
+	"valid_password?":    {},
+	"errors":             {},
+	"persisted?":         {},
+	"new_record?":        {},
+	"attributes":         {},
+	"reload":             {},
+	"create":             {},
+	"create!":            {},
+	"find_or_create_by":  {},
+	"build":              {},
+	"exists?":            {},
+	"first":              {},
+	"last":               {},
+	"all":                {},
+	// Additional AR persistence/query methods observed in
+	// rails-realworld bug-extractor after the initial #124 batch. All
+	// are stable AR::Base / AR::Relation methods (not method_missing).
+	"find_by":         {},
+	"find_each":       {},
+	"find_in_batches": {},
+	"destroy_all":     {},
+	"delete_all":      {},
+	"update_all":      {},
+	"update_attribute":      {},
+	"update_attributes":     {},
+	"update_attributes!":    {},
+	"toggle":          {},
+	"toggle!":         {},
+	"increment":       {},
+	"increment!":      {},
+	"decrement":       {},
+	"decrement!":      {},
+	"touch":           {},
+	"reset_counters":  {},
+	"reset_column_information": {},
+	// Numeric / time helpers added by ActiveSupport to Numeric
+	// (`3.days`, `1.hour.ago`, `5.minutes.from_now`). Ruby-only by
+	// virtue of ActiveSupport's monkey-patches; the language gate
+	// keeps them from polluting non-Ruby ecosystems.
+	"days":     {},
+	"hours":    {},
+	"minutes":  {},
+	"seconds":  {},
+	"weeks":    {},
+	"months":   {},
+	"years":    {},
+	"ago":      {},
+	"from_now": {},
 }
 
 // jsBareNames is the JS/TS-language-gated bare-name stop-list (issue

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1534,6 +1534,20 @@ func TestRubyBareNames_ClassifiedWhenLangIsRuby(t *testing.T) {
 		"to_s", "to_str", "to_i", "to_f", "to_a", "to_h", "to_sym",
 		// Inspection / type checks
 		"inspect", "is_a?", "kind_of?", "instance_of?",
+		// ActiveRecord persistence and validation (issue #124)
+		"save", "save!", "update", "update!", "destroy", "destroy!",
+		"valid?", "valid_password?", "errors", "persisted?",
+		"new_record?", "attributes", "reload", "create", "create!",
+		"find_or_create_by", "build", "exists?", "first", "last", "all",
+		"find_by", "find_each", "find_in_batches",
+		"destroy_all", "delete_all", "update_all",
+		"update_attribute", "update_attributes", "update_attributes!",
+		"toggle", "toggle!", "increment", "increment!",
+		"decrement", "decrement!", "touch",
+		"reset_counters", "reset_column_information",
+		// ActiveSupport Numeric/Time helpers
+		"days", "hours", "minutes", "seconds", "weeks", "months",
+		"years", "ago", "from_now",
 	}
 	for _, name := range names {
 		name := name
@@ -1574,7 +1588,19 @@ func TestRubyBareNames_ClassifiedWhenLangIsRuby(t *testing.T) {
 // `clone`, etc. must NOT be rewritten when source lang != "ruby".
 func TestRubyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 	// Names that are NOT in the language-agnostic stdlibBareNames map.
-	names := []string{"new", "tap", "then", "dup", "freeze", "to_s", "to_h", "is_a?", "respond_to?"}
+	names := []string{
+		"new", "tap", "then", "dup", "freeze", "to_s", "to_h", "is_a?", "respond_to?",
+		// ActiveRecord persistence names (issue #124) must not leak to
+		// other languages. `save`/`errors`/`all` are intentionally
+		// EXCLUDED from this negative list — they are independently
+		// classified by other-language allowlists (Spring Data `save`
+		// in Java, Go `errors` package, Python `all` builtin) and the
+		// non-leak guarantee for Ruby-only AR names is asserted by the
+		// remaining names below.
+		"update", "destroy", "valid?", "create", "build", "first", "last",
+		"reload", "attributes", "exists?", "persisted?", "new_record?",
+		"find_or_create_by", "valid_password?",
+	}
 	otherLangs := []string{"go", "python", "javascript", "rust", "java", "kotlin", ""}
 	for _, name := range names {
 		for _, lang := range otherLangs {

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -350,6 +350,43 @@ var (
 		regexp.MustCompile(`^after_create$`),
 		regexp.MustCompile(`^before_destroy$`),
 		regexp.MustCompile(`^after_destroy$`),
+
+		// ActiveRecord migration DSL (issue #124). Rails migrations are
+		// method_missing-driven schema DSL — `t.string :name`,
+		// `create_table :users do |t|`, `add_index :users, :email`,
+		// `references :user`. The Ruby extractor strips the receiver and
+		// the resolver sees only the bare leaf identifier. These names
+		// are the dominant residue in rails-realworld bug-extractor
+		// after #143. Per-language gate (Ruby) keeps the column-type
+		// names (`string`, `integer`, `boolean`, `text`) safely scoped
+		// — they would collide trivially with user-method names in any
+		// other ecosystem.
+		regexp.MustCompile(`^create_table$`),
+		regexp.MustCompile(`^drop_table$`),
+		regexp.MustCompile(`^change_table$`),
+		regexp.MustCompile(`^rename_table$`),
+		regexp.MustCompile(`^add_column$`),
+		regexp.MustCompile(`^remove_column$`),
+		regexp.MustCompile(`^rename_column$`),
+		regexp.MustCompile(`^change_column$`),
+		regexp.MustCompile(`^add_index$`),
+		regexp.MustCompile(`^remove_index$`),
+		regexp.MustCompile(`^add_reference$`),
+		regexp.MustCompile(`^remove_reference$`),
+		regexp.MustCompile(`^add_foreign_key$`),
+		regexp.MustCompile(`^remove_foreign_key$`),
+		regexp.MustCompile(`^references$`),
+		regexp.MustCompile(`^timestamps$`),
+		regexp.MustCompile(`^string$`),
+		regexp.MustCompile(`^integer$`),
+		regexp.MustCompile(`^boolean$`),
+		regexp.MustCompile(`^text$`),
+		regexp.MustCompile(`^datetime$`),
+		regexp.MustCompile(`^date$`),
+		regexp.MustCompile(`^float$`),
+		regexp.MustCompile(`^decimal$`),
+		regexp.MustCompile(`^binary$`),
+		regexp.MustCompile(`^execute$`),
 	}
 
 	jvmDynamicPatterns = []*regexp.Regexp{

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -788,6 +788,14 @@ func TestRubyRailsDSL_RecognisedAsDynamic(t *testing.T) {
 		"has_and_belongs_to_many", "validates", "validate",
 		"before_save", "after_save", "before_create", "after_create",
 		"before_destroy", "after_destroy",
+		// ActiveRecord migration DSL (issue #124)
+		"create_table", "drop_table", "change_table", "rename_table",
+		"add_column", "remove_column", "rename_column", "change_column",
+		"add_index", "remove_index", "add_reference", "remove_reference",
+		"add_foreign_key", "remove_foreign_key",
+		"references", "timestamps",
+		"string", "integer", "boolean", "text", "datetime", "date",
+		"float", "decimal", "binary", "execute",
 	}
 	for _, stub := range dynamic {
 		stub := stub
@@ -809,6 +817,11 @@ func TestRubyRailsDSL_GatedToRuby(t *testing.T) {
 	stubs := []string{
 		"where", "order", "params", "request", "response", "limit",
 		"group", "render", "validates",
+		// Migration DSL gating (issue #124) — collision-prone for
+		// other languages (`string`, `integer`, `boolean`, `text`,
+		// `references`, `execute`, `add_column`...).
+		"string", "integer", "boolean", "text", "references",
+		"execute", "create_table", "add_index", "timestamps",
 	}
 	otherLangs := []string{"go", "python", "javascript", "rust", "java", "kotlin"}
 	for _, stub := range stubs {


### PR DESCRIPTION
## Summary
- After #107 + #143, residual rails-realworld bug-extractor (~19%) was dominated by AR persistence calls (`save`, `update!`, `valid_password?`), AR query helpers (`find_by`, `find_each`), ActiveSupport Numeric/Time helpers (`3.days`, `1.hour.from_now`), and Rails migration DSL (`create_table`, `add_index`, `t.string`).
- Two-pronged fix: (1) stable AR/ActiveSupport methods → `rubyBareNames` in `synth.go` (promoted to ExternalKnown); (2) method_missing-driven migration DSL → resolver-side `rubyDynamicPatterns` (classified as Dynamic, same pattern as the existing AR query builder DSL).
- Ruby language gate keeps every name scoped — no leakage to other ecosystems. Generic collection ops (`find`, `count`, `map`, `each`, `select`) remain EXCLUDED per the issue #107 lock-in test.

## VERIFY-2 results (single-repo)
| repo | before (main) | after (this PR) | delta |
| --- | ---: | ---: | ---: |
| rails-realworld | 18.89% | **8.40%** | -10.5pp |
| sidekiq | 16.88% | 16.60% | -0.28pp |

Acceptance target was rails-realworld ≤15% — comfortably met. sidekiq residue is gem-specific middleware code (not AR persistence) and out of scope for #124.

## Test plan
- [x] `go test ./...` (all green; 28s on `internal/verify`)
- [x] `go vet ./...` (clean)
- [x] `TestRubyBareNames_ClassifiedWhenLangIsRuby` covers all new persistence + ActiveSupport names
- [x] `TestRubyBareNames_NotClassifiedForOtherLanguages` confirms Ruby gate (excludes overlap names: `save` in Spring Data, `errors` in Go, `all` in Python)
- [x] `TestRubyRailsDSL_RecognisedAsDynamic` + `TestRubyRailsDSL_GatedToRuby` cover migration DSL additions
- [x] `TestRubyBareNames_RejectedNamesNotClassified` and `TestRubyRailsDSL_RejectedGenericCollectionOps` lock-in tests still hold
- [x] VERIFY-2 single-repo on rails-realworld + sidekiq

🤖 Generated with [Claude Code](https://claude.com/claude-code)