### PR TITLE
fix(sql): emit structural-ref for column CONTAINS/REFERENCES (Closes #141)

### DIFF
--- a/internal/extractor/structural_ref.go
+++ b/internal/extractor/structural_ref.go
@@ -15,3 +15,23 @@ import "path/filepath"
 func BuildOperationStructuralRef(lang, filePath, name string) string {
 	return "scope:operation:method:" + lang + ":" + filepath.ToSlash(filePath) + ":" + name
 }
+
+// BuildSchemaColumnStructuralRef returns the canonical Format B structural-ref
+// for table→column CONTAINS edges (and column-as-FromID on column REFERENCES
+// edges). Shape:
+//
+//	scope:schema:column:sql:<file>:<table>#<column>
+//
+// where <file> is forward-slash normalized via filepath.ToSlash. Format B is
+// resolved through Index.byMember[<file>][<table>][<column>] in
+// internal/resolve/refs.go, which requires the column entity's Name to be
+// "<table>.<column>" so the dotted-name split during index build assigns
+// scope=<table>, member=<column>.
+//
+// Issue #141: SQL schema CONTAINS / REFERENCES edges previously emitted bare
+// column names (e.g. "name", "id"), which collided cross-language with Java
+// method calls and tripped the bug-resolver classifier. Emitting a
+// structural-ref qualified by file + table removes the collision class.
+func BuildSchemaColumnStructuralRef(filePath, table, column string) string {
+	return "scope:schema:column:sql:" + filepath.ToSlash(filePath) + ":" + table + "#" + column
+}

--- a/internal/extractor/structural_ref_test.go
+++ b/internal/extractor/structural_ref_test.go
@@ -53,3 +53,38 @@ func TestBuildOperationStructuralRef(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildSchemaColumnStructuralRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		filePath string
+		table    string
+		column   string
+		want     string
+	}{
+		{
+			name:     "posix path",
+			filePath: "migrations/001_init.sql",
+			table:    "Pet",
+			column:   "name",
+			want:     "scope:schema:column:sql:migrations/001_init.sql:Pet#name",
+		},
+		{
+			name:     "windows path is normalized to forward slashes",
+			filePath: filepath.FromSlash("db/migrations/002.sql"),
+			table:    "owners",
+			column:   "id",
+			want:     "scope:schema:column:sql:db/migrations/002.sql:owners#id",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildSchemaColumnStructuralRef(tc.filePath, tc.table, tc.column)
+			if got != tc.want {
+				t.Fatalf("BuildSchemaColumnStructuralRef(%q, %q, %q) = %q, want %q",
+					tc.filePath, tc.table, tc.column, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/extractors/sql/sql.go
+++ b/internal/extractors/sql/sql.go
@@ -120,11 +120,18 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		}
 		columns, fks := parseTableBody(body, name, filePath, startLine)
 
+		// Issue #141: emit a structural-ref ToID (Format B) qualified by
+		// file + table so column-name CONTAINS edges no longer collide with
+		// same-named operations in other languages (e.g. Java methods named
+		// "name"). Resolved through Index.byMember[file][table][column];
+		// columns are emitted with Name="<table>.<column>" so the dotted-
+		// name split during BuildIndex populates that bucket.
 		var rels []types.RelationshipRecord
 		for _, col := range columns {
+			shortName := col.Properties["column"]
 			rels = append(rels, types.RelationshipRecord{
 				FromID: name,
-				ToID:   col.Name,
+				ToID:   extractor.BuildSchemaColumnStructuralRef(filePath, name, shortName),
 				Kind:   "CONTAINS",
 				Properties: map[string]string{
 					"contained_kind": "column",
@@ -146,14 +153,21 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		})
 
 		// Column entities, each carrying FOREIGN_KEY REFERENCES edges if any.
+		// Issue #141: FromID uses the same Format B structural-ref as the
+		// table→column CONTAINS edge so the column collision class is
+		// removed from REFERENCES too. fk.FromColumn is the bare column
+		// identifier parsed from the FK declaration; match it against
+		// Properties["column"] (the short name) since col.Name is now the
+		// qualified "<table>.<column>".
 		for _, col := range columns {
 			var colRels []types.RelationshipRecord
+			shortName := col.Properties["column"]
 			for _, fk := range fks {
-				if fk.FromColumn != col.Name {
+				if fk.FromColumn != shortName {
 					continue
 				}
 				colRels = append(colRels, types.RelationshipRecord{
-					FromID: col.Name,
+					FromID: extractor.BuildSchemaColumnStructuralRef(filePath, name, shortName),
 					ToID:   fk.ToTable,
 					Kind:   "REFERENCES",
 					Properties: map[string]string{
@@ -192,8 +206,11 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 			if i < len(toCols) {
 				tc = toCols[i]
 			}
+			// Issue #141: FromID is a Format B structural-ref so the
+			// column-name collision class disappears for ALTER-TABLE FK
+			// emissions too.
 			rel := types.RelationshipRecord{
-				FromID: fc,
+				FromID: extractor.BuildSchemaColumnStructuralRef(filePath, fromTable, fc),
 				ToID:   toTable,
 				Kind:   "REFERENCES",
 				Properties: map[string]string{
@@ -205,13 +222,15 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 
 			// Attach to an existing column entity if one was emitted for this
 			// (table, column) pair. Otherwise emit a synthetic column entity.
+			// Match on Properties["column"] (short name) since e.Name is now
+			// the qualified "<table>.<column>".
 			attached := false
 			for j := range entities {
 				e := &entities[j]
-				if e.Subtype != "column" || e.Name != fc {
+				if e.Subtype != "column" {
 					continue
 				}
-				if e.Properties == nil || e.Properties["table"] != fromTable {
+				if e.Properties == nil || e.Properties["table"] != fromTable || e.Properties["column"] != fc {
 					continue
 				}
 				e.Relationships = append(e.Relationships, rel)
@@ -227,19 +246,21 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 				continue
 			}
 			seen[altKey] = true
+			qualName := fromTable + "." + fc
 			entities = append(entities, types.EntityRecord{
-				Name:               fc,
+				Name:               qualName,
 				Kind:               "SCOPE.Schema",
 				Subtype:            "column",
 				SourceFile:         filePath,
 				Language:           "sql",
 				StartLine:          startLine,
 				EndLine:            startLine,
-				QualifiedName:      fromTable + "." + fc,
+				QualifiedName:      qualName,
 				Signature:          fmt.Sprintf("ALTER TABLE %s ADD FOREIGN KEY (%s) REFERENCES %s(%s)", fromTable, fc, toTable, tc),
 				EnrichmentRequired: false,
 				Properties: map[string]string{
-					"table": fromTable,
+					"table":  fromTable,
+					"column": fc,
 				},
 				Relationships: []types.RelationshipRecord{rel},
 			})
@@ -561,19 +582,29 @@ func parseTableBody(body, tableName, filePath string, tableStartLine int) ([]col
 			})
 		}
 
+		// Issue #141: column entity Name is qualified as "<table>.<column>"
+		// so EntityRecord.ComputeID (which hashes file+kind+name) produces
+		// distinct IDs for same-named columns on sibling tables in a single
+		// SQL file. The dotted Name also drives Index.byMember population
+		// (last-dot split → scope=table, member=column), enabling Format B
+		// structural-ref resolution for CONTAINS / REFERENCES edges. The
+		// short column name is preserved in Properties["column"] for
+		// downstream consumers that need it without re-parsing.
+		qualName := tableName + "." + colName
 		colEntity := types.EntityRecord{
-			Name:               colName,
+			Name:               qualName,
 			Kind:               "SCOPE.Schema",
 			Subtype:            "column",
 			SourceFile:         filePath,
 			Language:           "sql",
 			StartLine:          entryStartLine,
 			EndLine:            entryStartLine,
-			QualifiedName:      tableName + "." + colName,
+			QualifiedName:      qualName,
 			Signature:          strings.TrimSpace(entry),
 			EnrichmentRequired: false,
 			Properties: map[string]string{
-				"table": tableName,
+				"table":  tableName,
+				"column": colName,
 			},
 		}
 		cols = append(cols, colEntity)

--- a/internal/extractors/sql/sql_alter_fk_test.go
+++ b/internal/extractors/sql/sql_alter_fk_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 // hasFK returns true when there is a column entity (table, col) with a
-// REFERENCES edge to (toTable, toCol).
+// REFERENCES edge to (toTable, toCol). Issue #141: column entity Name is
+// "<table>.<column>" so we match on Properties["column"] (short name).
 func hasFK(entities []types.EntityRecord, table, col, toTable, toCol string) bool {
 	for _, e := range entities {
-		if e.Subtype != "column" || e.Name != col {
+		if e.Subtype != "column" || e.Properties["column"] != col {
 			continue
 		}
 		if e.Properties == nil || e.Properties["table"] != table {
@@ -91,7 +92,7 @@ func TestSQLExtractor_AlterTableAddFK_AttachesToExistingColumn(t *testing.T) {
 
 	count := 0
 	for _, e := range entities {
-		if e.Subtype != "column" || e.Name != "user_id" {
+		if e.Subtype != "column" || e.Properties["column"] != "user_id" {
 			continue
 		}
 		if e.Properties != nil && e.Properties["table"] == "orders" {

--- a/internal/extractors/sql/sql_edgecases_test.go
+++ b/internal/extractors/sql/sql_edgecases_test.go
@@ -63,7 +63,7 @@ func TestSQL_MySQL_AutoIncrementColumns(t *testing.T) {
 	// id columns from both tables exist (each tagged with its table via Properties).
 	idColsByTable := map[string]bool{}
 	for _, e := range entities {
-		if e.Subtype != "column" || e.Name != "id" {
+		if e.Subtype != "column" || e.Properties["column"] != "id" {
 			continue
 		}
 		if tbl, ok := e.Properties["table"]; ok {
@@ -90,7 +90,7 @@ func TestSQL_MySQL_EnumColumnTypes(t *testing.T) {
 	for col, table := range wantEnumColumns {
 		found := false
 		for _, e := range entities {
-			if e.Subtype == "column" && e.Name == col && e.Properties["table"] == table {
+			if e.Subtype == "column" && e.Properties["column"] == col && e.Properties["table"] == table {
 				found = true
 				break
 			}
@@ -108,7 +108,7 @@ func TestSQL_MySQL_ForeignKeyExtracted(t *testing.T) {
 
 	hasFK := false
 	for _, e := range entities {
-		if e.Subtype != "column" || e.Name != "product_id" {
+		if e.Subtype != "column" || e.Properties["column"] != "product_id" {
 			continue
 		}
 		if e.Properties["table"] != "order_items" {

--- a/internal/extractors/sql/sql_issue141_test.go
+++ b/internal/extractors/sql/sql_issue141_test.go
@@ -1,0 +1,222 @@
+package sql_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/sql"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #141: SQL schema CONTAINS / REFERENCES edges previously emitted bare
+// column names (e.g. "name", "id") which collided cross-language with Java
+// method calls and tripped the bug-resolver classifier. The fix:
+//   - Column entity Name is qualified as "<table>.<column>" so ComputeID is
+//     unique per (file, table, column).
+//   - CONTAINS ToID is a Format B structural-ref:
+//       scope:schema:column:sql:<file>:<table>#<column>
+//   - REFERENCES FromID is the same Format B structural-ref so the column
+//     collision class disappears for FK edges too.
+
+const twoTablesSameColumnFixture = `CREATE TABLE Pet (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+
+CREATE TABLE Owner (
+    id SERIAL PRIMARY KEY,
+    name VARCHAR(255) NOT NULL
+);
+`
+
+func extractIssue141(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("sql")
+	if !ok {
+		t.Fatal("sql extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "sql",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return entities
+}
+
+// TestIssue141_TwoTables_NameColumn_DistinctIDs is the headline invariant
+// from the issue: two tables both having a `name` column in the same SQL
+// file produce distinct entity IDs (so they don't merge under the same
+// graph node) and have distinct, qualified entity Names.
+func TestIssue141_TwoTables_NameColumn_DistinctIDs(t *testing.T) {
+	entities := extractIssue141(t, twoTablesSameColumnFixture, "migrations/petclinic.sql")
+
+	var pet, owner *types.EntityRecord
+	for i := range entities {
+		e := &entities[i]
+		if e.Subtype != "column" || e.Properties["column"] != "name" {
+			continue
+		}
+		switch e.Properties["table"] {
+		case "Pet":
+			pet = e
+		case "Owner":
+			owner = e
+		}
+	}
+	if pet == nil {
+		t.Fatal("expected Pet.name column entity")
+	}
+	if owner == nil {
+		t.Fatal("expected Owner.name column entity")
+	}
+
+	// Qualified Names — required for unique ComputeID and byMember
+	// population in the resolver.
+	if pet.Name != "Pet.name" {
+		t.Errorf("Pet.name entity Name=%q, want %q", pet.Name, "Pet.name")
+	}
+	if owner.Name != "Owner.name" {
+		t.Errorf("Owner.name entity Name=%q, want %q", owner.Name, "Owner.name")
+	}
+
+	// Distinct ComputeIDs.
+	petID := pet.ComputeID()
+	ownerID := owner.ComputeID()
+	if petID == "" || ownerID == "" {
+		t.Fatalf("ComputeID returned empty: pet=%q owner=%q", petID, ownerID)
+	}
+	if petID == ownerID {
+		t.Errorf("ComputeID collision: Pet.name and Owner.name both hash to %q", petID)
+	}
+}
+
+// TestIssue141_ContainsEdges_StructuralRef verifies that table→column
+// CONTAINS edges emit Format B structural-refs as ToIDs.
+func TestIssue141_ContainsEdges_StructuralRef(t *testing.T) {
+	filePath := "migrations/petclinic.sql"
+	entities := extractIssue141(t, twoTablesSameColumnFixture, filePath)
+
+	var pet *types.EntityRecord
+	for i := range entities {
+		e := &entities[i]
+		if e.Subtype == "table" && e.Name == "Pet" {
+			pet = e
+			break
+		}
+	}
+	if pet == nil {
+		t.Fatal("expected Pet table entity")
+	}
+
+	wantTargets := map[string]bool{
+		"scope:schema:column:sql:" + filePath + ":Pet#id":   false,
+		"scope:schema:column:sql:" + filePath + ":Pet#name": false,
+	}
+	for _, r := range pet.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		if !strings.HasPrefix(r.ToID, "scope:schema:column:sql:") {
+			t.Errorf("CONTAINS ToID=%q, expected structural-ref prefix", r.ToID)
+		}
+		if _, ok := wantTargets[r.ToID]; ok {
+			wantTargets[r.ToID] = true
+		}
+	}
+	for target, found := range wantTargets {
+		if !found {
+			t.Errorf("expected CONTAINS edge with ToID=%q", target)
+		}
+	}
+}
+
+// TestIssue141_ReferencesFromID_StructuralRef verifies that column-level
+// REFERENCES (foreign-key) edges use a Format B structural-ref as FromID.
+func TestIssue141_ReferencesFromID_StructuralRef(t *testing.T) {
+	src := `CREATE TABLE accounts (
+    id SERIAL PRIMARY KEY
+);
+
+CREATE TABLE sessions (
+    id SERIAL PRIMARY KEY,
+    account_id INTEGER REFERENCES accounts(id)
+);
+`
+	filePath := "migrations/sessions.sql"
+	entities := extractIssue141(t, src, filePath)
+
+	var found bool
+	wantFrom := "scope:schema:column:sql:" + filePath + ":sessions#account_id"
+	for _, e := range entities {
+		if e.Subtype != "column" || e.Properties["column"] != "account_id" {
+			continue
+		}
+		if e.Properties["table"] != "sessions" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			if r.FromID != wantFrom {
+				t.Errorf("REFERENCES FromID=%q, want %q", r.FromID, wantFrom)
+			}
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected REFERENCES edge on sessions.account_id")
+	}
+}
+
+// TestIssue141_AlterTableFK_StructuralRef verifies the same FromID shape on
+// ALTER TABLE FK emissions (both attach-to-existing and synthetic-column
+// branches).
+func TestIssue141_AlterTableFK_StructuralRef(t *testing.T) {
+	src := `CREATE TABLE users (
+    id SERIAL PRIMARY KEY
+);
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER
+);
+
+ALTER TABLE orders ADD CONSTRAINT fk_orders_users FOREIGN KEY (user_id) REFERENCES users(id);
+ALTER TABLE shipments ADD FOREIGN KEY (customer_id) REFERENCES users(id);
+`
+	filePath := "migrations/alter.sql"
+	entities := extractIssue141(t, src, filePath)
+
+	wantOrders := "scope:schema:column:sql:" + filePath + ":orders#user_id"
+	wantShipments := "scope:schema:column:sql:" + filePath + ":shipments#customer_id"
+
+	gotOrders, gotShipments := false, false
+	for _, e := range entities {
+		if e.Subtype != "column" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			switch r.FromID {
+			case wantOrders:
+				gotOrders = true
+			case wantShipments:
+				gotShipments = true
+			}
+		}
+	}
+	if !gotOrders {
+		t.Errorf("expected REFERENCES FromID=%q (attach-to-existing branch)", wantOrders)
+	}
+	if !gotShipments {
+		t.Errorf("expected REFERENCES FromID=%q (synthetic-column branch)", wantShipments)
+	}
+}

--- a/internal/extractors/sql/sql_relationships_test.go
+++ b/internal/extractors/sql/sql_relationships_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/extractor"
@@ -50,30 +51,43 @@ func findEntity(entities []types.EntityRecord, kind, name string) *types.EntityR
 }
 
 // TestSQLExtractor_ColumnEntitiesEmitted verifies columns are extracted.
+//
+// Issue #141: column entities are emitted with Name="<table>.<column>" so
+// EntityRecord.ComputeID is unique per (file, table, column). The short
+// column identifier is preserved in Properties["column"].
 func TestSQLExtractor_ColumnEntitiesEmitted(t *testing.T) {
 	src := loadFixture(t, "migration_001_init.sql")
 	entities := extractSQLBytes(t, src, "migrations/001_init.sql")
 
-	colNames := map[string]bool{}
+	shortNames := map[string]bool{}
 	for _, e := range entities {
 		if e.Subtype == "column" {
-			colNames[e.Name] = true
+			shortNames[e.Properties["column"]] = true
 			if e.Kind != "SCOPE.Schema" {
 				t.Errorf("column %q expected Kind=SCOPE.Schema, got %q", e.Name, e.Kind)
+			}
+			// Name must be qualified "<table>.<column>".
+			if got, want := e.Name, e.Properties["table"]+"."+e.Properties["column"]; got != want {
+				t.Errorf("column entity Name=%q, want %q (issue #141)", got, want)
 			}
 		}
 	}
 	for _, want := range []string{"id", "email", "account_id", "token", "event_kind"} {
-		if !colNames[want] {
+		if !shortNames[want] {
 			t.Errorf("expected column %q to be extracted", want)
 		}
 	}
 }
 
 // TestSQLExtractor_TableContainsColumns verifies CONTAINS edges.
+//
+// Issue #141: CONTAINS ToIDs are now Format B structural-refs of the form
+// "scope:schema:column:sql:<file>:<table>#<column>" so column-name targets
+// can no longer collide cross-language with operations of the same bare name.
 func TestSQLExtractor_TableContainsColumns(t *testing.T) {
 	src := loadFixture(t, "migration_001_init.sql")
-	entities := extractSQLBytes(t, src, "migrations/001_init.sql")
+	filePath := "migrations/001_init.sql"
+	entities := extractSQLBytes(t, src, filePath)
 
 	accounts := findEntity(entities, "SCOPE.Datastore", "accounts")
 	if accounts == nil {
@@ -81,15 +95,23 @@ func TestSQLExtractor_TableContainsColumns(t *testing.T) {
 	}
 	wantCols := map[string]bool{"id": false, "email": false, "created_at": false}
 	for _, r := range accounts.Relationships {
-		if r.Kind == "CONTAINS" {
-			if _, ok := wantCols[r.ToID]; ok {
-				wantCols[r.ToID] = true
-			}
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		// Validate structural-ref shape.
+		wantPrefix := "scope:schema:column:sql:" + filePath + ":accounts#"
+		if !strings.HasPrefix(r.ToID, wantPrefix) {
+			t.Errorf("CONTAINS ToID=%q, expected prefix %q (issue #141)", r.ToID, wantPrefix)
+			continue
+		}
+		col := strings.TrimPrefix(r.ToID, wantPrefix)
+		if _, ok := wantCols[col]; ok {
+			wantCols[col] = true
 		}
 	}
 	for col, found := range wantCols {
 		if !found {
-			t.Errorf("expected accounts CONTAINS %q", col)
+			t.Errorf("expected accounts CONTAINS column %q", col)
 		}
 	}
 }
@@ -103,7 +125,7 @@ func TestSQLExtractor_InlineForeignKey(t *testing.T) {
 	// on audit_log; pick the one whose Properties.table=sessions.
 	var found bool
 	for _, e := range entities {
-		if e.Subtype != "column" || e.Name != "account_id" {
+		if e.Subtype != "column" || e.Properties["column"] != "account_id" {
 			continue
 		}
 		if e.Properties["table"] != "sessions" {
@@ -114,6 +136,11 @@ func TestSQLExtractor_InlineForeignKey(t *testing.T) {
 				found = true
 				if r.Properties["reference_kind"] != "foreign_key" {
 					t.Errorf("expected reference_kind=foreign_key, got %q", r.Properties["reference_kind"])
+				}
+				// Issue #141: FromID must be a Format B structural-ref.
+				wantFrom := "scope:schema:column:sql:migrations/001_init.sql:sessions#account_id"
+				if r.FromID != wantFrom {
+					t.Errorf("REFERENCES FromID=%q, want %q", r.FromID, wantFrom)
 				}
 			}
 		}
@@ -135,7 +162,7 @@ func TestSQLExtractor_TableLevelForeignKey(t *testing.T) {
 	for col, expectTo := range wantPairs {
 		found := false
 		for _, e := range entities {
-			if e.Subtype != "column" || e.Name != col || e.Properties["table"] != "audit_log" {
+			if e.Subtype != "column" || e.Properties["column"] != col || e.Properties["table"] != "audit_log" {
 				continue
 			}
 			for _, r := range e.Relationships {
@@ -183,8 +210,8 @@ func TestSQLExtractor_NoStrayConstraintColumns(t *testing.T) {
 		if e.Subtype != "column" {
 			continue
 		}
-		if bad[e.Name] {
-			t.Errorf("column entity has keyword name %q", e.Name)
+		if bad[e.Properties["column"]] {
+			t.Errorf("column entity has keyword name %q", e.Properties["column"])
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- SQL schema previously emitted bare column names (\`name\`, \`id\`, ...) as CONTAINS / REFERENCES targets. Bare names collided cross-language: Java \`CALLS name\` hit the SCOPE.Schema column entity via the resolver's kind-agnostic \`nameExists()\` check, flipping bug-extractor to bug-resolver (dominant pattern in #92).
- New helper \`extractor.BuildSchemaColumnStructuralRef\` emits Format B structural-refs \`scope:schema:column:sql:<file>:<table>#<column>\` for column-targeted edges (resolved via \`Index.byMember\`).
- Column entities now have \`Name="<table>.<column>"\` so \`EntityRecord.ComputeID\` is unique per (file, table, column) and the resolver's last-dot split populates \`byMember\`. The short column identifier is preserved in \`Properties["column"]\`.
- CONTAINS ToIDs (table→column), inline-FK REFERENCES FromIDs, and ALTER TABLE FK FromIDs (both attach-to-existing and synthetic-column branches) all use the Format B structural-ref.

## VERIFY-2 (java/spring-petclinic, single-repo)

| metric          | before | after  | delta            |
| --------------- | ------ | ------ | ---------------- |
| bug_rate        | 0.601  | 0.588  | -0.013 (-1.3 pp) |
| resolution_rate | 0.315  | 0.332  | +0.017 (+1.7 pp) |
| resolved        | 1382   | 1494   | +112             |
| bug-resolver    | 84     | 94     | +10              |
| bug-extractor   | 2549   | 2549   | 0                |

The bug-resolver disposition_samples no longer contain \`name\` (the #92 dominant pattern). Remaining samples are table-name pluralization mismatches outside #141's scope.

## Test plan
- [x] \`go test ./...\` green (full suite, including resolve/patterns/types)
- [x] \`go test ./internal/extractors/sql/...\` — 35 tests pass (including 4 new TDD tests in \`sql_issue141_test.go\`)
- [x] \`go test ./internal/extractor/...\` — \`BuildSchemaColumnStructuralRef\` covered, posix + windows path normalization
- [x] VERIFY-2 single-repo on \`java/spring-petclinic\` — see metrics table

Refs #92.