### PR TITLE
feat(resolve): PHP project-local namespace-aware resolution (Closes #113)

### DIFF
--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -333,6 +333,27 @@ func useClauseFQN(clause *sitter.Node, src []byte) string {
 // namespace segment (Symfony, Doctrine, App, ...) — same convention as
 // buildNamespace — so emitting the same `use` from multiple files
 // idempotently merges to one Component per top-level namespace.
+//
+// Issue #113 — IMPORTS edges carry the same Properties contract as
+// Python (#93) and Java (#120) so the cross-file resolver can build a
+// per-file binding table:
+//
+//	Properties["local_name"]    — bare leaf identifier introduced into
+//	                              the importing file. For `use Foo\Bar`
+//	                              this is "Bar"; aliases are intentionally
+//	                              dropped at FQN-extraction time so the
+//	                              alias is not visible here.
+//	Properties["source_module"] — dotted-namespace path with the leaf
+//	                              stripped, slashes normalized to dots
+//	                              ("Foo\\Bar" → source_module="Foo").
+//	                              This matches the form modulesForPHPFile
+//	                              produces in the resolver.
+//	Properties["imported_name"] — equal to local_name. The shape `use
+//	                              function Foo\helper;` and `use const
+//	                              Foo\PI;` are treated identically — the
+//	                              leaf identifier is the importable
+//	                              symbol name regardless of the
+//	                              function/const sub-form.
 func useImportRecord(fqn, srcPath string) types.EntityRecord {
 	// Strip leading '\' (PHP allows fully-qualified `use \Foo\Bar`).
 	fqn = strings.TrimPrefix(fqn, "\\")
@@ -340,6 +361,25 @@ func useImportRecord(fqn, srcPath string) types.EntityRecord {
 	if idx := strings.Index(fqn, "\\"); idx >= 0 {
 		top = fqn[:idx]
 	}
+
+	// Derive (source_module, local_name) pair. local_name is the leaf
+	// (last backslash-separated segment); source_module is the prefix
+	// with slashes converted to dots so it matches the resolver's
+	// modulesByName index. A FQN without a backslash separator (rare
+	// — `use Foo;`) sets source_module = the FQN itself and leaf =
+	// the FQN; the resolver will skip it (no leaf separator).
+	leaf := fqn
+	mod := fqn
+	if idx := strings.LastIndex(fqn, "\\"); idx >= 0 {
+		leaf = fqn[idx+1:]
+		mod = strings.ReplaceAll(fqn[:idx], "\\", ".")
+	}
+	props := map[string]string{
+		"local_name":    leaf,
+		"source_module": mod,
+		"imported_name": leaf,
+	}
+
 	return types.EntityRecord{
 		Name:       top,
 		Kind:       "SCOPE.Component",
@@ -347,9 +387,10 @@ func useImportRecord(fqn, srcPath string) types.EntityRecord {
 		Language:   "php",
 		Relationships: []types.RelationshipRecord{
 			{
-				FromID: srcPath,
-				ToID:   fqn,
-				Kind:   "IMPORTS",
+				FromID:     srcPath,
+				ToID:       fqn,
+				Kind:       "IMPORTS",
+				Properties: props,
 			},
 		},
 	}

--- a/internal/extractors/php/php_test.go
+++ b/internal/extractors/php/php_test.go
@@ -351,6 +351,83 @@ class PostType extends AbstractType {}
 	}
 }
 
+// TestPHPExtractor_UseImportsCarryProperties (#113): PHP IMPORTS edges
+// must carry the same Properties contract Python (#93) and Java (#120)
+// emit so the cross-file resolver's per-file binding table can be
+// built. For `use App\Entity\Post;` local_name="Post",
+// source_module="App.Entity" (slashes normalized to dots),
+// imported_name="Post". Aliased forms drop the alias at FQN extraction;
+// the leaf identifier of the canonical FQN is still what local_name
+// records.
+func TestPHPExtractor_UseImportsCarryProperties(t *testing.T) {
+	src := `<?php
+
+namespace App\Form;
+
+use App\Entity\Post;
+use Symfony\Component\Form\AbstractType;
+use Symfony\Component\HttpFoundation\{Request, Response};
+
+class PostType extends AbstractType {}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("php")
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "src/Form/PostType.php",
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := map[string]map[string]string{
+		"App\\Entity\\Post": {
+			"local_name":    "Post",
+			"source_module": "App.Entity",
+			"imported_name": "Post",
+		},
+		"Symfony\\Component\\Form\\AbstractType": {
+			"local_name":    "AbstractType",
+			"source_module": "Symfony.Component.Form",
+			"imported_name": "AbstractType",
+		},
+		"Symfony\\Component\\HttpFoundation\\Request": {
+			"local_name":    "Request",
+			"source_module": "Symfony.Component.HttpFoundation",
+			"imported_name": "Request",
+		},
+		"Symfony\\Component\\HttpFoundation\\Response": {
+			"local_name":    "Response",
+			"source_module": "Symfony.Component.HttpFoundation",
+			"imported_name": "Response",
+		},
+	}
+	gotProps := map[string]map[string]string{}
+	for _, e := range got {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			gotProps[r.ToID] = r.Properties
+		}
+	}
+	for to, wantP := range want {
+		gp, ok := gotProps[to]
+		if !ok {
+			t.Errorf("expected IMPORTS edge to=%q, got=%v", to, gotProps)
+			continue
+		}
+		for k, v := range wantP {
+			if gp[k] != v {
+				t.Errorf("IMPORTS to=%q prop %q: got=%q want=%q (all=%v)",
+					to, k, gp[k], v, gp)
+			}
+		}
+	}
+}
+
 func TestPHPExtractor_LineNumbers(t *testing.T) {
 	src := `<?php
 class Alpha {

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -245,6 +245,8 @@ func modulesForFile(p string) []string {
 		return modulesForPythonFile(p)
 	case strings.HasSuffix(p, ".java"):
 		return modulesForJavaFile(p)
+	case strings.HasSuffix(p, ".php"):
+		return modulesForPHPFile(p)
 	}
 	return nil
 }
@@ -323,6 +325,75 @@ func modulesForJavaFile(p string) []string {
 		}
 	}
 	return out
+}
+
+// modulesForPHPFile derives the dotted-namespace forms of a PHP source
+// file (issue #113). PHP uses PSR-4 to map a top-level namespace to a
+// source root directory; Symfony's `composer.json` ships the canonical
+// `App\` → `src/` map, and Laravel ships `App\` → `app/`. Every
+// project-internal class lives in a file whose path-after-the-source-root
+// equals its sub-namespace (e.g. `src/Entity/Post.php` ↔
+// `App\Entity\Post`).
+//
+// The returned slice always contains the dotted form derived from the
+// raw path (slash → dot, `.php` stripped, parent directory only).
+// When the path begins with one of the well-known PSR-4 source roots
+// the function additionally emits the canonical `App.` form so an
+// IMPORTS edge whose ToID was emitted as `App\Entity\Post`
+// (source_module = `App.Entity`) binds against the file's
+// `src/Entity/Post.php` location regardless of whether the corpus was
+// indexed under the PSR-4 root or as a generic repo.
+//
+// Files at the repo root (no parent directory) return nil — the caller's
+// nil-guards treat that as "no module".
+func modulesForPHPFile(p string) []string {
+	stripped := strings.TrimSuffix(p, ".php")
+	dir := stripped
+	if slash := strings.LastIndexByte(stripped, '/'); slash >= 0 {
+		dir = stripped[:slash]
+	} else {
+		// File at repo root — no namespace.
+		return nil
+	}
+	dotted := strings.ReplaceAll(dir, "/", ".")
+	out := []string{dotted}
+	// PSR-4: src/Foo/Bar.php → App\Foo\Bar (Symfony default);
+	//        app/Foo/Bar.php → App\Foo\Bar (Laravel default).
+	// Strip the leading source root once and re-prefix with the
+	// canonical "App" segment so an import whose source_module is
+	// "App.Foo" binds regardless of whether the corpus was rooted at
+	// the package root or the repo root.
+	for _, prefix := range phpPSR4SourceRootPrefixes {
+		if strings.HasPrefix(dotted, prefix) {
+			tail := strings.TrimPrefix(dotted, prefix)
+			if tail == "" {
+				out = append(out, "App")
+			} else {
+				out = append(out, "App."+tail)
+			}
+			break
+		}
+	}
+	// Also try the generic source-root strip (src./lib./app.) so a
+	// non-PSR-4 layout still resolves under its repo-relative dotted
+	// form. Same conservative single-strip policy as Python/Java.
+	for _, prefix := range sourceRootPrefixes {
+		if strings.HasPrefix(out[0], prefix) {
+			out = append(out, strings.TrimPrefix(out[0], prefix))
+			break
+		}
+	}
+	return out
+}
+
+// phpPSR4SourceRootPrefixes lists the canonical PSR-4 source-root
+// directories that map to the conventional `App\` top-level namespace.
+// Matched against the dotted form of the parent directory (slashes
+// already replaced with dots), so entries end with a dot. "src." covers
+// Symfony's composer.json default; "app." covers Laravel's.
+var phpPSR4SourceRootPrefixes = []string{
+	"src.",
+	"app.",
 }
 
 // javaSourceRootPrefixes lists the canonical Maven/Gradle layout
@@ -518,18 +589,26 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 				stats.CallsRewritten++
 			case importRelKind:
 				// IMPORTS ToID is a dotted module path like
-				// "conduit.database.db" (issue #142). Project-internal
-				// targets resolve via the per-module reverse index;
-				// external packages ("marshmallow.Schema") miss the
-				// lookup and are left for the external-synthesis pass.
-				if !strings.ContainsRune(to, '.') {
+				// "conduit.database.db" (issue #142) or — for PHP
+				// (issue #113) — a backslash-separated FQN like
+				// `App\Entity\Post`. Both shapes are normalized to
+				// dotted form here and then looked up against the
+				// per-module reverse index. External packages
+				// ("marshmallow.Schema", "Symfony\\...") miss the
+				// lookup and are left for the external-synthesis
+				// pass.
+				normalized := to
+				if strings.ContainsRune(normalized, '\\') {
+					normalized = strings.ReplaceAll(normalized, "\\", ".")
+				}
+				if !strings.ContainsRune(normalized, '.') {
 					continue
 				}
-				if strings.ContainsAny(to, ":#") {
+				if strings.ContainsAny(normalized, ":#") {
 					continue
 				}
 				stats.ImportsConsidered++
-				id, ok := tbl.ResolveDottedImportTarget(to)
+				id, ok := tbl.ResolveDottedImportTarget(normalized)
 				if !ok {
 					continue
 				}

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -609,6 +609,183 @@ func TestResolveImports_JavaSrcMainJavaStripped(t *testing.T) {
 	}
 }
 
+// TestModulesForFile_PHP covers the PHP dispatch added in #113 —
+// `src/Entity/Post.php` is the canonical Symfony PSR-4 layout for a
+// class living at the namespace `App\Entity\Post`. The module-derivation
+// must yield `App.Entity` (PSR-4 strip + `App` re-prefix) so an IMPORTS
+// edge whose ToID is `App\Entity\Post` (normalized to `App.Entity.Post`)
+// resolves via the per-module reverse index. The pre-strip
+// `src.Entity` form is also retained so a corpus indexed without PSR-4
+// awareness still binds.
+func TestModulesForFile_PHP(t *testing.T) {
+	got := modulesForFile("src/Entity/Post.php")
+	want := "App.Entity"
+	found := false
+	for _, m := range got {
+		if m == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("modulesForFile PHP: expected %q in %v", want, got)
+	}
+	// Laravel default: app/ → App
+	got = modulesForFile("app/Models/User.php")
+	wantLaravel := "App.Models"
+	found = false
+	for _, m := range got {
+		if m == wantLaravel {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("modulesForFile PHP Laravel: expected %q in %v", wantLaravel, got)
+	}
+	// File at repo root should return nil.
+	if got := modulesForFile("Index.php"); got != nil {
+		t.Fatalf("modulesForFile root-level php: expected nil, got %v", got)
+	}
+}
+
+// TestResolveImports_PHPProjectLocalNamespace covers the PHP analogue
+// of #93/#142 (issue #113). An IMPORTS edge whose ToID is
+// `App\Entity\Post` should rewrite to the entity ID of class Post
+// declared in `src/Entity/Post.php`. The backslash separator is
+// normalized to dotted form before the per-module lookup.
+func TestResolveImports_PHPProjectLocalNamespace(t *testing.T) {
+	records := []types.EntityRecord{
+		// PHP `use App\Entity\Post;` in a Form file.
+		{
+			Name:       "App",
+			Kind:       "SCOPE.Component",
+			SourceFile: "src/Form/PostType.php",
+			Language:   "php",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "src/Form/PostType.php",
+				ToID:   "App\\Entity\\Post",
+				Kind:   importRelKind,
+				Properties: map[string]string{
+					"local_name":    "Post",
+					"source_module": "App.Entity",
+					"imported_name": "Post",
+				},
+			}},
+		},
+		// Class Post declared in src/Entity/Post.php.
+		{
+			ID:         "aaaa1111aaaa1111",
+			Name:       "Post",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Entity/Post.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 PHP IMPORTS rewrite, got %d (considered=%d)",
+			stats.ImportsRewritten, stats.ImportsConsidered)
+	}
+	if got := records[0].Relationships[0].ToID; got != "aaaa1111aaaa1111" {
+		t.Fatalf("expected target aaaa1111aaaa1111, got %q", got)
+	}
+}
+
+// TestResolveImports_PHPSameLeafTwoNamespaces covers the disambiguation
+// case: two classes both named `User` live in different project-internal
+// namespaces (`App\Entity\User` vs `App\Security\User`). An importer of
+// `App\Entity\User` must resolve to the Entity, not Security, version.
+func TestResolveImports_PHPSameLeafTwoNamespaces(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			Name:       "App",
+			Kind:       "SCOPE.Component",
+			SourceFile: "src/Controller/UserController.php",
+			Language:   "php",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "src/Controller/UserController.php",
+				ToID:   "App\\Entity\\User",
+				Kind:   importRelKind,
+				Properties: map[string]string{
+					"local_name":    "User",
+					"source_module": "App.Entity",
+					"imported_name": "User",
+				},
+			}},
+		},
+		{
+			ID:         "1111aaaa1111aaaa",
+			Name:       "User",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Entity/User.php",
+			Language:   "php",
+		},
+		{
+			ID:         "2222bbbb2222bbbb",
+			Name:       "User",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Security/User.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 1 {
+		t.Fatalf("expected 1 PHP rewrite, got %d", stats.ImportsRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "1111aaaa1111aaaa" {
+		t.Fatalf("expected Entity\\User (1111aaaa1111aaaa), got %q", got)
+	}
+}
+
+// TestResolveImports_PHPExternalNamespaceLeftAlone confirms that an
+// IMPORTS edge to a non-project namespace (`Symfony\Component\...`)
+// misses the per-module index and is left for the external-synthesis
+// pass — the resolver must not fabricate a binding to a coincidentally
+// same-named project entity.
+func TestResolveImports_PHPExternalNamespaceLeftAlone(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			Name:       "Symfony",
+			Kind:       "SCOPE.Component",
+			SourceFile: "src/Form/PostType.php",
+			Language:   "php",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "src/Form/PostType.php",
+				ToID:   "Symfony\\Component\\Form\\AbstractType",
+				Kind:   importRelKind,
+				Properties: map[string]string{
+					"local_name":    "AbstractType",
+					"source_module": "Symfony.Component.Form",
+					"imported_name": "AbstractType",
+				},
+			}},
+		},
+		// A coincidentally-named project class — must NOT bind.
+		{
+			ID:         "ccccddddccccdddd",
+			Name:       "AbstractType",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Form/AbstractType.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ImportsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites for external namespace, got %d", stats.ImportsRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "Symfony\\Component\\Form\\AbstractType" {
+		t.Fatalf("expected ToID preserved, got %q", got)
+	}
+}
+
 // TestResolveImports_FileLocalCollisionDropsBinding covers the case
 // where the same file imports two different symbols under the same
 // local name (e.g. shadowing). The conservative behaviour is to drop


### PR DESCRIPTION
## Summary

PHP analogue of #93 (Python) / #120 (Java) / #142 (project-internal IMPORTS). PHP IMPORTS edges from `use App\Foo\Bar;` now resolve to project-local entities via the cross-file resolver, removing project-internal `App\*` edges from the bug-resolver bucket.

- **Extractor (`internal/extractors/php/php.go`)** — `useImportRecord` stamps the same Properties contract Python (#93) and Java (#120) emit: `local_name` (leaf), `source_module` (dotted prefix, slashes normalized), `imported_name` (leaf). Aliases are still dropped at FQN extraction so the canonical FQN drives both the synth allowlist and the per-file binding table.
- **Resolver (`internal/resolve/imports.go`)** — `modulesForFile` learns `.php` dispatch via new `modulesForPHPFile`, which strips the canonical PSR-4 source roots (`src/` for Symfony, `app/` for Laravel) and emits the canonical `App.*` dotted form so a file at `src/Entity/Post.php` is indexed under module `App.Entity` for entity `Post`. The IMPORTS-rewrite branch in `ResolveImports` normalizes backslash separators to dots before the per-module lookup, so the existing #142 ResolveDottedImportTarget covers PHP without a dedicated branch.
- **External namespaces** (Symfony, Doctrine, Twig) miss the project-local index and continue through the external-synthesis allowlist — verified by `TestResolveImports_PHPExternalNamespaceLeftAlone`.

## Test plan

- [x] `go test ./...` (full module green)
- [x] New unit tests: `TestModulesForFile_PHP`, `TestResolveImports_PHPProjectLocalNamespace`, `TestResolveImports_PHPSameLeafTwoNamespaces`, `TestResolveImports_PHPExternalNamespaceLeftAlone`, `TestPHPExtractor_UseImportsCarryProperties`
- [x] `go vet ./...` clean
- [x] `gofmt -l` clean
- [x] VERIFY-2 single-repo `symfony-demo`: bug-rate 34.65% → 34.35%, resolved 529 → 534 (+5 project-local IMPORTS rewrites). Acceptance bar (≤40%) met.
- [x] VERIFY-2 single-repo `laravel-quickstart`: unchanged (corpus has no `use App\*;` project-local shapes; PSR-4 dispatch verified by unit test on `app/Models/User.php`).

Refs #93, #102, #120, #142.