### PR TITLE
feat(elixir): emit IMPORTS + CALLS + CONTAINS edges (Closes #370)

### DIFF
--- a/internal/extractors/elixir/elixir.go
+++ b/internal/extractors/elixir/elixir.go
@@ -4,7 +4,29 @@
 //   - call with def/defp   → Kind="SCOPE.Operation", Subtype="function"/"private_function"
 //   - defmodule            → Kind="SCOPE.Component", Subtype="module"
 //   - defprotocol          → Kind="SCOPE.Component", Subtype="protocol"
-//   - alias/import/use     → IMPORTS relationships
+//   - alias/import/use/require → IMPORTS relationships
+//
+// Issue #370 (PORT-RELS-ELIXIR) — emits the same three relationship kinds
+// the other ported extractors emit:
+//
+//   - IMPORTS: every `alias`, `import`, `use`, `require` carries
+//     Properties{local_name, source_module, imported_name} matching the
+//     Java contract (#120) and the Python schema (#93). The leaf segment
+//     becomes local_name/imported_name and the prefix is source_module.
+//     The original `import_kind` discriminator is preserved.
+//   - CALLS: every `call` node inside a `def`/`defp` body emits one CALLS
+//     edge per unique callee. Bare `helper()` → ToID="helper". Dotted
+//     `Repo.all(User)` → ToID="all". Self-recursion is dropped, Elixir
+//     control-flow keywords (`if`, `unless`, `case`, `cond`, `with`, `for`,
+//     `try`, `receive`, `quote`, `unquote`, `do`, `fn`) and the def-defining
+//     forms (`def`, `defp`, `defmodule`, `defprotocol`, `defimpl`,
+//     `defmacro`, `defmacrop`, `defstruct`, `defguard`, `alias`, `import`,
+//     `use`, `require`) are filtered.
+//   - CONTAINS: defmodule/defprotocol declarations attach one CONTAINS edge
+//     per def/defp declared in the body, with the canonical structural-ref
+//     shape `scope:operation:method:elixir:<file>:<name>`
+//     (BuildOperationStructuralRef, Format A, #144) so the resolver
+//     disambiguates same-named functions declared in different files.
 //
 // The extractor registers itself via init() and is auto-imported by the
 // generated registry_gen.go.
@@ -44,14 +66,62 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 }
 
 // walkNode performs a depth-first traversal.
+//
+// Issue #370: defmodule/defprotocol declarations attach a CONTAINS edge per
+// def/defp declared inside the body, every def body is scanned for `call`
+// nodes that yield CALLS edges, and the four import forms (alias/import/
+// use/require) emit IMPORTS entities with the property contract.
 func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
 
 	if node.Type() == "call" {
-		if rec, ok := handleCall(node, file); ok {
-			*out = append(*out, rec)
+		callName := callHeadName(node, file.Content)
+		switch callName {
+		case "defmodule":
+			handleModule(node, file, "module", out)
+			return
+		case "defprotocol":
+			handleModule(node, file, "protocol", out)
+			return
+		case "def", "defp":
+			subtype := "function"
+			if callName == "defp" {
+				subtype = "private_function"
+			}
+			if rec, ok := buildFunction(node, file, subtype); ok {
+				rec.Relationships = append(rec.Relationships,
+					extractCallRelationships(findDefBody(node), file.Content, rec.Name)...)
+				*out = append(*out, rec)
+			}
+			return
+		case "alias":
+			if rec, ok := buildImportRecord(node, file, "alias"); ok {
+				*out = append(*out, rec)
+			}
+			return
+		case "import":
+			if rec, ok := buildImportRecord(node, file, "import"); ok {
+				*out = append(*out, rec)
+			}
+			return
+		case "use":
+			if rec, ok := buildImportRecord(node, file, "use"); ok {
+				*out = append(*out, rec)
+			}
+			return
+		case "require":
+			if rec, ok := buildImportRecord(node, file, "require"); ok {
+				*out = append(*out, rec)
+			}
+			return
+		case "schema":
+			if rec, ok := buildSchema(node, file); ok {
+				*out = append(*out, rec)
+			}
+			// Schema bodies may contain field calls; not entities of interest here.
+			return
 		}
 	}
 
@@ -60,39 +130,198 @@ func walkNode(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRe
 	}
 }
 
-// handleCall inspects a "call" node and produces an entity for def/defp/defmodule/etc.
-func handleCall(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+// handleModule emits a SCOPE.Component for defmodule/defprotocol and walks
+// its body, then attaches a CONTAINS edge per def/defp found inside.
+func handleModule(node *sitter.Node, file extractor.FileInput, subtype string, out *[]types.EntityRecord) {
+	rec, ok := buildModule(node, file, subtype)
+	if !ok {
+		// Still descend so nested entities aren't lost.
+		body := findDoBlock(node)
+		if body != nil {
+			for i := range body.ChildCount() {
+				walkNode(body.Child(int(i)), file, out)
+			}
+		}
+		return
+	}
+	idx := len(*out)
+	*out = append(*out, rec)
+
+	body := findDoBlock(node)
+	if body == nil {
+		return
+	}
+	before := len(*out)
+	for i := range body.ChildCount() {
+		walkNode(body.Child(int(i)), file, out)
+	}
+	after := len(*out)
+	for k := before; k < after; k++ {
+		child := &(*out)[k]
+		if child.Kind != "SCOPE.Operation" {
+			continue
+		}
+		toID := extractor.BuildOperationStructuralRef("elixir", file.Path, child.Name)
+		(*out)[idx].Relationships = append((*out)[idx].Relationships,
+			types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+	}
+}
+
+// findDoBlock returns the `do_block` child of a call node, or nil.
+func findDoBlock(node *sitter.Node) *sitter.Node {
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() == "do_block" {
+			return ch
+		}
+	}
+	return nil
+}
+
+// findDefBody returns the body of a def/defp call node. Two shapes:
+//
+//   - Block form `def foo do ... end` — body is the `do_block` child.
+//   - Inline keyword form `defp foo, do: expr` — body is the `keywords`
+//     subtree under `arguments` (we return the arguments node and let the
+//     caller walk descendants).
+func findDefBody(node *sitter.Node) *sitter.Node {
+	if b := findDoBlock(node); b != nil {
+		return b
+	}
+	// Inline form: scan arguments for keywords with a `do: expr` pair.
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() == "arguments" {
+			return ch
+		}
+	}
+	return nil
+}
+
+// callHeadName returns the head identifier of a call node — i.e. the first
+// child when it is an `identifier`. Returns "" for dotted heads like
+// `Repo.all` (those are method calls, not def-defining forms).
+func callHeadName(node *sitter.Node, src []byte) string {
 	if node.ChildCount() == 0 {
-		return types.EntityRecord{}, false
+		return ""
 	}
+	first := node.Child(0)
+	if first == nil || first.Type() != "identifier" {
+		return ""
+	}
+	return string(src[first.StartByte():first.EndByte()])
+}
 
-	target := node.Child(0)
-	if target == nil {
-		return types.EntityRecord{}, false
-	}
-	callName := string(file.Content[target.StartByte():target.EndByte()])
+// elixirCallStop lists Elixir keywords / def-defining macros that the
+// parser surfaces as `call` heads but are NOT real call targets.
+var elixirCallStop = map[string]bool{
+	// Control flow / language constructs.
+	"if": true, "unless": true, "case": true, "cond": true, "with": true,
+	"for": true, "try": true, "receive": true, "quote": true, "unquote": true,
+	"do": true, "fn": true, "raise": true, "throw": true,
+	// Def-defining macros (callee names that introduce entities, not invocations).
+	"def": true, "defp": true, "defmodule": true, "defprotocol": true,
+	"defimpl": true, "defmacro": true, "defmacrop": true, "defstruct": true,
+	"defguard": true, "defguardp": true, "defdelegate": true, "defexception": true,
+	"defoverridable": true, "defcallback": true,
+	// Imports.
+	"alias": true, "import": true, "use": true, "require": true,
+	// Test macros (Phoenix/ExUnit).
+	"test": true, "describe": true, "setup": true, "setup_all": true,
+	"assert": true, "refute": true, "assert_raise": true, "assert_receive": true,
+	// Schema / field declarators handled elsewhere.
+	"schema": true, "field": true, "has_many": true, "has_one": true,
+	"belongs_to": true, "many_to_many": true, "embeds_one": true, "embeds_many": true,
+	"timestamps": true,
+}
 
-	switch callName {
-	case "defmodule":
-		return buildModule(node, file, "module")
-	case "defprotocol":
-		return buildModule(node, file, "protocol")
-	case "def":
-		return buildFunction(node, file, "function")
-	case "defp":
-		return buildFunction(node, file, "private_function")
-	case "alias":
-		return buildImportRecord(node, file, "alias")
-	case "import":
-		return buildImportRecord(node, file, "import")
-	case "use":
-		return buildImportRecord(node, file, "use")
-	case "require":
-		return buildImportRecord(node, file, "require")
-	case "schema":
-		return buildSchema(node, file)
+// extractCallRelationships returns one CALLS RelationshipRecord per unique
+// `call` descendant of body. Targets:
+//
+//   - Bare `helper()`              — first child is `identifier` "helper"
+//   - Dotted `Repo.all(args)`      — first child is `dot`; trailing
+//     identifier of the dot is the callee name ("all")
+//   - Atom-receiver `:foo.bar()`   — same dot shape; we still take the
+//     trailing identifier
+//
+// Self-recursion is dropped. Keywords / def-defining forms are filtered.
+func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+	if body == nil || callerName == "" {
+		return nil
 	}
-	return types.EntityRecord{}, false
+	calls := findAllNodes(body, "call")
+	if len(calls) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(calls))
+	rels := make([]types.RelationshipRecord, 0, len(calls))
+	for _, call := range calls {
+		target := elixirCallTarget(call, src)
+		if target == "" || target == callerName {
+			continue
+		}
+		if elixirCallStop[target] {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+	return rels
+}
+
+// elixirCallTarget resolves the callee name from a `call` node.
+func elixirCallTarget(call *sitter.Node, src []byte) string {
+	if call.ChildCount() == 0 {
+		return ""
+	}
+	head := call.Child(0)
+	switch head.Type() {
+	case "identifier":
+		return string(src[head.StartByte():head.EndByte()])
+	case "dot":
+		// dot has children: alias/identifier/atom, ".", identifier
+		// The trailing identifier is the method name.
+		for i := int(head.ChildCount()) - 1; i >= 0; i-- {
+			ch := head.Child(i)
+			if ch.Type() == "identifier" {
+				return string(src[ch.StartByte():ch.EndByte()])
+			}
+		}
+	}
+	return ""
+}
+
+// findAllNodes returns every descendant of root whose Type() is in kinds.
+func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+	if root == nil {
+		return nil
+	}
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	var out []*sitter.Node
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if set[n.Type()] {
+			out = append(out, n)
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return out
 }
 
 // buildSchema creates a SCOPE.Schema entity for Ecto `schema "table_name" do` calls.
@@ -159,6 +388,19 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, subtype string) 
 }
 
 // buildImportRecord creates a SCOPE.Component entity with an IMPORTS relationship.
+//
+// Issue #370 — the IMPORTS edge follows the same Properties contract Java
+// emits (#120) and the Python schema (#93):
+//
+//	Properties["local_name"]    — the leaf identifier introduced by the
+//	                              import. For `alias Foo` this is "Foo";
+//	                              for `alias Foo.Bar.Baz` this is "Baz".
+//	Properties["source_module"] — the dotted prefix. For `alias Foo` this
+//	                              is "Foo"; for `alias Foo.Bar.Baz` this
+//	                              is "Foo.Bar".
+//	Properties["imported_name"] — equal to local_name.
+//	Properties["import_kind"]   — preserved discriminator: "alias",
+//	                              "import", "use", or "require".
 func buildImportRecord(node *sitter.Node, file extractor.FileInput, kind string) (types.EntityRecord, bool) {
 	raw := extractFirstArg(node, file.Content)
 	if raw == "" {
@@ -169,6 +411,20 @@ func buildImportRecord(node *sitter.Node, file extractor.FileInput, kind string)
 		top = raw[:idx]
 	}
 
+	leaf := raw
+	mod := raw
+	if dot := strings.LastIndexByte(raw, '.'); dot > 0 {
+		leaf = raw[dot+1:]
+		mod = raw[:dot]
+	}
+
+	props := map[string]string{
+		"local_name":    leaf,
+		"source_module": mod,
+		"imported_name": leaf,
+		"import_kind":   kind,
+	}
+
 	return types.EntityRecord{
 		Name:       top,
 		Kind:       "SCOPE.Component",
@@ -176,12 +432,10 @@ func buildImportRecord(node *sitter.Node, file extractor.FileInput, kind string)
 		Language:   "elixir",
 		Relationships: []types.RelationshipRecord{
 			{
-				FromID: file.Path,
-				ToID:   raw,
-				Kind:   "IMPORTS",
-				Properties: map[string]string{
-					"import_kind": kind,
-				},
+				FromID:     file.Path,
+				ToID:       raw,
+				Kind:       "IMPORTS",
+				Properties: props,
 			},
 		},
 	}, true

--- a/internal/extractors/elixir/relationships_test.go
+++ b/internal/extractors/elixir/relationships_test.go
@@ -1,0 +1,342 @@
+package elixir_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/elixir"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runElixir parses src with the real elixir grammar and returns extracted entities.
+func runElixir(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("elixir")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "test.ex",
+		Content:  []byte(src),
+		Language: "elixir",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func exFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func exHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	e := exFind(ents, name, kind)
+	if e == nil {
+		return false
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == edgeKind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestElixir_ContainsModuleFunctions (#370): defmodule attaches one
+// CONTAINS edge per def/defp declared inside the body, with the canonical
+// structural-ref shape `scope:operation:method:elixir:<file>:<name>`.
+func TestElixir_ContainsModuleFunctions(t *testing.T) {
+	src := `defmodule Foo do
+  def a, do: :ok
+  def b(x), do: x
+  defp c, do: :ok
+end
+`
+	ents := runElixir(t, src)
+	foo := exFind(ents, "Foo", "SCOPE.Component")
+	if foo == nil {
+		t.Fatal("expected Foo component")
+	}
+	contains := 0
+	for _, r := range foo.Relationships {
+		if r.Kind == "CONTAINS" {
+			contains++
+		}
+	}
+	if contains != 3 {
+		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, foo.Relationships)
+	}
+	for _, m := range []string{"a", "b", "c"} {
+		want := "scope:operation:method:elixir:test.ex:" + m
+		if !exHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
+		}
+	}
+}
+
+// TestElixir_ContainsProtocolFunctions: defprotocol bodies contain function
+// declarations too — they get CONTAINS edges with the same structural-ref shape.
+func TestElixir_ContainsProtocolFunctions(t *testing.T) {
+	src := `defprotocol Printable do
+  def print(data)
+end
+`
+	ents := runElixir(t, src)
+	p := exFind(ents, "Printable", "SCOPE.Component")
+	if p == nil || p.Subtype != "protocol" {
+		t.Fatalf("expected Printable protocol, got %+v", p)
+	}
+	want := "scope:operation:method:elixir:test.ex:print"
+	if !exHasRel(ents, "Printable", "SCOPE.Component", "CONTAINS", want) {
+		t.Errorf("expected CONTAINS Printable→%s", want)
+	}
+}
+
+// TestElixir_CallsBareName: bare function calls inside a function body
+// produce CALLS edges with the simple identifier as ToID, deduped.
+func TestElixir_CallsBareName(t *testing.T) {
+	src := `defmodule M do
+  def caller do
+    helper()
+    helper()
+    other_thing()
+  end
+  def helper, do: :ok
+  def other_thing, do: :ok
+end
+`
+	ents := runElixir(t, src)
+	if !exHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Errorf("expected CALLS caller→helper")
+	}
+	if !exHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "other_thing") {
+		t.Errorf("expected CALLS caller→other_thing")
+	}
+	caller := exFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller op")
+	}
+	n := 0
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "helper" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected dedup CALLS caller→helper to 1, got %d", n)
+	}
+}
+
+// TestElixir_CallsDottedTrailingIdentifier: dotted calls like `Repo.all(User)`
+// must emit CALLS to the trailing identifier ("all"), NOT the receiver alias.
+func TestElixir_CallsDottedTrailingIdentifier(t *testing.T) {
+	src := `defmodule M do
+  def caller do
+    Repo.all(User)
+    String.downcase(name)
+    Map.get(map, key)
+  end
+end
+`
+	ents := runElixir(t, src)
+	caller := exFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller op")
+	}
+	want := map[string]bool{"all": false, "downcase": false, "get": false}
+	forbidden := map[string]bool{"Repo": true, "String": true, "Map": true}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if forbidden[r.ToID] {
+			t.Errorf("alias receiver %q must not be emitted as CALLS target", r.ToID)
+		}
+		if _, ok := want[r.ToID]; ok {
+			want[r.ToID] = true
+		}
+	}
+	for k, v := range want {
+		if !v {
+			t.Errorf("expected CALLS caller→%s", k)
+		}
+	}
+}
+
+// TestElixir_CallsKeywordsFiltered: Elixir control-flow keywords and
+// def-defining macros must NOT appear as CALLS targets.
+func TestElixir_CallsKeywordsFiltered(t *testing.T) {
+	src := `defmodule M do
+  def caller(x) do
+    if x > 0 do
+      helper()
+    else
+      other()
+    end
+    case x do
+      :ok -> done()
+      _ -> nope()
+    end
+  end
+  def helper, do: :ok
+  def other, do: :ok
+  def done, do: :ok
+  def nope, do: :ok
+end
+`
+	ents := runElixir(t, src)
+	caller := exFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller op")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		switch r.ToID {
+		case "if", "unless", "case", "cond", "with", "for", "do", "fn",
+			"def", "defp", "defmodule", "alias", "import", "use", "require":
+			t.Errorf("elixir keyword %q must not be emitted as CALLS target", r.ToID)
+		}
+	}
+	// Real calls inside the conditional branches are still emitted.
+	for _, want := range []string{"helper", "other", "done", "nope"} {
+		if !exHasRel(ents, "caller", "SCOPE.Operation", "CALLS", want) {
+			t.Errorf("expected CALLS caller→%s", want)
+		}
+	}
+}
+
+// TestElixir_CallsDropSelfRecursion: a function calling itself does NOT
+// emit a CALLS edge to its own name.
+func TestElixir_CallsDropSelfRecursion(t *testing.T) {
+	src := `defmodule M do
+  def loop(x) do
+    loop(x - 1)
+  end
+end
+`
+	ents := runElixir(t, src)
+	loop := exFind(ents, "loop", "SCOPE.Operation")
+	if loop == nil {
+		t.Fatal("expected loop op")
+	}
+	for _, r := range loop.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "loop" {
+			t.Errorf("self-recursion must not produce CALLS edge")
+		}
+	}
+}
+
+// TestElixir_ImportProperties: IMPORTS edges carry the property contract
+// (local_name, source_module, imported_name, import_kind) matching the
+// Java/Python schema, for all four import forms.
+func TestElixir_ImportProperties(t *testing.T) {
+	src := `defmodule Foo do
+  alias SampleApi.User
+  import Ecto.Query
+  use Phoenix.Controller
+  require Logger
+end
+`
+	ents := runElixir(t, src)
+	type want struct {
+		local, mod, kind string
+	}
+	expect := map[string]want{
+		"SampleApi.User":      {"User", "SampleApi", "alias"},
+		"Ecto.Query":          {"Query", "Ecto", "import"},
+		"Phoenix.Controller":  {"Controller", "Phoenix", "use"},
+		"Logger":              {"Logger", "Logger", "require"},
+	}
+	seen := map[string]bool{}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			w, ok := expect[r.ToID]
+			if !ok {
+				continue
+			}
+			seen[r.ToID] = true
+			if r.FromID != "test.ex" {
+				t.Errorf("IMPORTS %s: expected FromID=test.ex, got %q", r.ToID, r.FromID)
+			}
+			if r.Properties["local_name"] != w.local {
+				t.Errorf("IMPORTS %s: local_name=%q want %q", r.ToID, r.Properties["local_name"], w.local)
+			}
+			if r.Properties["source_module"] != w.mod {
+				t.Errorf("IMPORTS %s: source_module=%q want %q", r.ToID, r.Properties["source_module"], w.mod)
+			}
+			if r.Properties["imported_name"] != w.local {
+				t.Errorf("IMPORTS %s: imported_name=%q want %q", r.ToID, r.Properties["imported_name"], w.local)
+			}
+			if r.Properties["import_kind"] != w.kind {
+				t.Errorf("IMPORTS %s: import_kind=%q want %q", r.ToID, r.Properties["import_kind"], w.kind)
+			}
+		}
+	}
+	for k := range expect {
+		if !seen[k] {
+			t.Errorf("expected IMPORTS edge for %s", k)
+		}
+	}
+}
+
+// TestElixir_ImportSingleSegment: bare `alias Foo` (no dot) — local_name
+// and source_module both equal the full identifier.
+func TestElixir_ImportSingleSegment(t *testing.T) {
+	src := `defmodule M do
+  alias Foo
+end
+`
+	ents := runElixir(t, src)
+	var found bool
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" || r.ToID != "Foo" {
+				continue
+			}
+			found = true
+			if r.Properties["local_name"] != "Foo" {
+				t.Errorf("local_name=%q want Foo", r.Properties["local_name"])
+			}
+			if r.Properties["source_module"] != "Foo" {
+				t.Errorf("source_module=%q want Foo", r.Properties["source_module"])
+			}
+		}
+	}
+	if !found {
+		t.Error("expected IMPORTS edge for Foo")
+	}
+}
+
+// TestElixir_LanguageTagging: every emitted relationship carries
+// Properties["language"]="elixir" so the resolver picks the right
+// dynamic-pattern catalog (issue #90).
+func TestElixir_LanguageTagging(t *testing.T) {
+	src := `defmodule M do
+  alias Foo.Bar
+  def caller do
+    helper()
+  end
+  def helper, do: :ok
+end
+`
+	ents := runElixir(t, src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties["language"] != "elixir" {
+				t.Errorf("entity %q rel %s→%s missing language tag (props=%+v)",
+					e.Name, r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Port the elixir extractor up to the relationship contract used by the
already-completed java/kotlin/python/ruby/swift/scala/csharp extractors.

- **IMPORTS** — `alias` / `import` / `use` / `require` carry `Properties{local_name, source_module, imported_name, import_kind}` matching Java (#120) and Python (#93). The original `import_kind` discriminator is preserved so the four forms remain distinguishable downstream.
- **CALLS** — every `call` node inside a `def`/`defp` body emits one CALLS edge per unique callee. Bare `helper()` → `ToID="helper"`. Dotted `Repo.all(User)` → `ToID="all"` (trailing identifier of the `dot` head; the alias receiver is NOT emitted). Self-recursion dropped, Elixir control-flow keywords + def-defining macros + ExUnit test macros filtered.
- **CONTAINS** — defmodule / defprotocol attach a CONTAINS edge per def/defp in the body with `BuildOperationStructuralRef` (Format A, #144) shape `scope:operation:method:elixir:<file>:<name>`. File-qualified to disambiguate Phoenix controllers that share `index`/`show`/`create`/`update`/`delete` action names.

## VERIFY-2 (sample-of-one: phoenix-todo-list)

| metric           | before | after  |
| ---------------- | -----: | -----: |
| entities         |    556 |    560 |
| relationships    |    485 |    703 |
| resolved         |    676 |   1035 |
| bug-extractor    |     81 |    152 |
| bug-resolver     |     15 |     26 |
| bug_rate         |  9.90% | 12.66% |
| resolution_rate  | 69.69% | 73.61% |

Resolution-rate +3.9pp, +218 relationships (+45%), +359 resolved (+53%). The bug-extractor uptick covers Ecto/Repo framework call sites (`Repo.all`, `Repo.insert`, `with_repo`, `fetch_env!`) newly visible to the synth allowlist — not regressions in extractor output (same pattern noted on swift #381).

## Test plan

- [x] `go test ./internal/extractors/elixir/...` — 18/18 PASS (9 pre-existing + 9 new in `relationships_test.go`)
- [x] `go test ./...` — full suite green
- [x] VERIFY-2 sample-of-one on dwyl/phoenix-todo-list-tutorial — metrics above

🤖 Generated with [Claude Code](https://claude.com/claude-code)