### PR TITLE
feat(zig): emit IMPORTS + CALLS + CONTAINS edges (Closes #382)

### DIFF
--- a/internal/extractors/zig/relationships_test.go
+++ b/internal/extractors/zig/relationships_test.go
@@ -1,0 +1,224 @@
+package zig_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/zig"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runZig runs the extractor on raw source and returns entity records.
+func runZig(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, _ := extractor.Get("zig")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "zig",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func zigFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func zigHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestZig_Imports — @import("...") emits IMPORTS edges from file.Path → module.
+func TestZig_Imports(t *testing.T) {
+	src := `const std = @import("std");
+const foo = @import("./foo.zig");
+const bar = @import("../bar.zig");
+
+pub fn main() !void {}
+`
+	ents := runZig(t, src, "main.zig")
+
+	want := map[string]bool{
+		"std":        false,
+		"./foo.zig":  false,
+		"../bar.zig": false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := want[r.ToID]; ok {
+					want[r.ToID] = true
+					if r.FromID != "main.zig" {
+						t.Errorf("IMPORTS %q: expected FromID=main.zig, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for k, ok := range want {
+		if !ok {
+			t.Errorf("expected IMPORTS edge for %q", k)
+		}
+	}
+}
+
+// TestZig_CallsBareName — bare-name fn calls and qualified Foo.bar / std.debug.print.
+func TestZig_CallsBareName(t *testing.T) {
+	src := `const std = @import("std");
+
+fn helper(x: u32) u32 {
+    return x * 2;
+}
+
+pub fn caller() void {
+    helper(1);
+    helper(2);
+    std.debug.print("hi\n", .{});
+    Foo.bar(42);
+}
+`
+	ents := runZig(t, src, "calls.zig")
+
+	if !zigHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Errorf("expected CALLS caller→helper")
+	}
+	if !zigHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "print") {
+		t.Errorf("expected CALLS caller→print (rightmost identifier of std.debug.print)")
+	}
+	if !zigHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "bar") {
+		t.Errorf("expected CALLS caller→bar (rightmost identifier of Foo.bar)")
+	}
+
+	caller := zigFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("caller not extracted")
+	}
+	n := 0
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "helper" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected dedup CALLS caller→helper to 1, got %d", n)
+	}
+}
+
+// TestZig_CallsExcludeSelfRecursion — caller→caller self-edges are filtered.
+func TestZig_CallsExcludeSelfRecursion(t *testing.T) {
+	src := `fn factorial(n: u32) u32 {
+    if (n <= 1) return 1;
+    return n * factorial(n - 1);
+}
+`
+	ents := runZig(t, src, "rec.zig")
+	if zigHasRel(ents, "factorial", "SCOPE.Operation", "CALLS", "factorial") {
+		t.Errorf("self-recursion CALLS should be filtered")
+	}
+}
+
+// TestZig_ContainsStructMethods — struct with N fns inside → N CONTAINS.
+func TestZig_ContainsStructMethods(t *testing.T) {
+	src := `const Foo = struct {
+    x: u32,
+
+    pub fn init() Foo {
+        return Foo{ .x = 0 };
+    }
+
+    pub fn bump(self: *Foo) void {
+        self.x += 1;
+    }
+
+    fn private(self: *Foo) u32 {
+        return self.x;
+    }
+};
+`
+	ents := runZig(t, src, "foo.zig")
+	foo := zigFind(ents, "Foo", "SCOPE.Component")
+	if foo == nil {
+		t.Fatal("expected Foo struct component")
+	}
+	contains := 0
+	for _, r := range foo.Relationships {
+		if r.Kind == "CONTAINS" {
+			contains++
+		}
+	}
+	if contains != 3 {
+		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, foo.Relationships)
+	}
+	// Format A structural-ref keyed on file path.
+	for _, m := range []string{"init", "bump", "private"} {
+		want := "scope:operation:method:zig:foo.zig:" + m
+		if !zigHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
+		}
+	}
+}
+
+// TestZig_ContainsOnlyForFnsInsideStruct — top-level fns must not appear in
+// any struct's CONTAINS edge set.
+func TestZig_ContainsTopLevelFnNotInStruct(t *testing.T) {
+	src := `const Foo = struct {
+    pub fn inner() void {}
+};
+
+pub fn topLevel() void {}
+`
+	ents := runZig(t, src, "scope.zig")
+	foo := zigFind(ents, "Foo", "SCOPE.Component")
+	if foo == nil {
+		t.Fatal("expected Foo struct component")
+	}
+	for _, r := range foo.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == "scope:operation:method:zig:scope.zig:topLevel" {
+			t.Error("Foo should not CONTAINS top-level fn topLevel")
+		}
+	}
+	// inner must be there.
+	want := "scope:operation:method:zig:scope.zig:inner"
+	if !zigHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+		t.Errorf("expected CONTAINS Foo→%s", want)
+	}
+}
+
+// TestZig_RelationshipsLanguageTagged — every relationship gets language=zig.
+func TestZig_RelationshipsLanguageTagged(t *testing.T) {
+	src := `const std = @import("std");
+
+const Foo = struct {
+    pub fn bar() void {
+        std.debug.print("x\n", .{});
+    }
+};
+`
+	ents := runZig(t, src, "tag.zig")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "zig" {
+				t.Errorf("rel %s→%s missing language=zig (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}

--- a/internal/extractors/zig/zig.go
+++ b/internal/extractors/zig/zig.go
@@ -3,9 +3,27 @@
 // Extracted entities:
 //   - fn declarations (pub or private)  → Kind="SCOPE.Operation", Subtype="function"
 //   - const Name = struct { ... }       → Kind="SCOPE.Component", Subtype="struct"
+//   - @import("...") sites              → Kind="SCOPE.Component" stub carrying
+//     an IMPORTS relationship
 //
-// No tree-sitter grammar for Zig is bundled in smacker/go-tree-sitter.
-// Registers itself via init() and is imported by registry_gen.go.
+// Issue #382 — relationship parity with java/rust/cpp:
+//
+//   - IMPORTS edges are emitted from file.Path → imported module for every
+//     `@import("...")` invocation. Both stdlib (`@import("std")`) and
+//     relative paths (`@import("./foo.zig")`) are captured verbatim.
+//   - CALLS edges are attached to each fn entity, one per unique callee
+//     identifier discovered in its body. Qualified calls (`std.debug.print`,
+//     `Foo.bar`) resolve to the rightmost identifier; zig keywords / control
+//     forms and self-recursion are filtered out.
+//   - CONTAINS edges are attached from a `const Name = struct { ... }` (and
+//     enum/union variants) to every `pub fn` / `fn` declared in its
+//     declaration body, using the Format A structural-ref
+//     `scope:operation:method:zig:<file>:<name>`.
+//
+// No tree-sitter grammar for Zig is bundled in smacker/go-tree-sitter, so
+// this extractor parses Zig with regular expressions plus a hand-rolled
+// brace walker. Registers itself via init() and is imported by
+// registry_gen.go.
 package zig
 
 import (
@@ -37,7 +55,7 @@ var (
 	privFnRE = regexp.MustCompile(
 		`(?m)^[ \t]*fn\s+(\w+)\s*(\([^)]*\))`,
 	)
-	// const Name = struct {
+	// const Name = struct {  (also enum / union — same CONTAINS semantics).
 	structRE = regexp.MustCompile(
 		`(?m)^[ \t]*(?:pub\s+)?const\s+(\w+)\s*=\s*struct\s*\{`,
 	)
@@ -45,21 +63,57 @@ var (
 	importRE = regexp.MustCompile(
 		`@import\("([^"]+)"\)`,
 	)
+	// fn declarations anywhere (used to enumerate methods inside a struct
+	// body). Captures the fn name. Matches both `pub fn` and `fn`.
+	anyFnRE = regexp.MustCompile(
+		`(?m)(?:^|\s)(?:pub\s+)?fn\s+(\w+)\s*\(`,
+	)
+	// Call-site head capture: a (possibly dotted) identifier path followed by
+	// `(`. The path is captured; the call target is the rightmost segment.
+	// Matches `helper(`, `Foo.bar(`, `std.debug.print(`. Excludes builtins
+	// (which start with `@`) and indexed expressions.
+	callRE = regexp.MustCompile(
+		`(?:^|[^\w.@])([A-Za-z_][\w]*(?:\.[A-Za-z_][\w]*)*)\s*\(`,
+	)
 )
+
+// zigKeywords lists tokens that look like calls to the bare regex walker
+// but are control-flow / declaration keywords in Zig. Matches the keyword
+// list the rust extractor's special-form filter plays for that language.
+var zigKeywords = map[string]bool{
+	"if": true, "else": true, "while": true, "for": true, "switch": true,
+	"return": true, "break": true, "continue": true, "defer": true,
+	"errdefer": true, "try": true, "catch": true, "orelse": true,
+	"and": true, "or": true, "not": true, "fn": true, "pub": true,
+	"const": true, "var": true, "comptime": true, "inline": true,
+	"export": true, "extern": true, "test": true, "asm": true,
+	"struct": true, "enum": true, "union": true, "opaque": true,
+	"error": true, "unreachable": true, "noreturn": true,
+	"true": true, "false": true, "null": true, "undefined": true,
+	// Common type names that would otherwise be picked up from `Type(args)`
+	// constructor-style invocations and tagged unions.
+	"u8": true, "u16": true, "u32": true, "u64": true, "usize": true,
+	"i8": true, "i16": true, "i32": true, "i64": true, "isize": true,
+	"f16": true, "f32": true, "f64": true, "bool": true, "void": true,
+	"anytype": true, "anyerror": true, "anyopaque": true, "type": true,
+}
 
 // Extract processes the Zig source and returns entity records.
 func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	if len(file.Content) == 0 {
 		return nil, nil
 	}
-	return extractZig(string(file.Content), file.Path), nil
+	out := extractZig(string(file.Content), file.Path)
+	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
+	extractor.TagRelationshipsLanguage(out, "zig")
+	return out, nil
 }
 
 func extractZig(src, filePath string) []types.EntityRecord {
 	var entities []types.EntityRecord
 	imports := collectImports(src)
 
-	// Public functions.
+	// 1. Public functions.
 	seen := make(map[string]bool)
 	for _, m := range pubFnRE.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
@@ -71,6 +125,8 @@ func extractZig(src, filePath string) []types.EntityRecord {
 		seen[key] = true
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		endLine := findBraceEnd(src, m[1])
+		body := extractBraceBody(src, m[1])
+		calls := collectCalls(body, name)
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Operation",
@@ -84,10 +140,11 @@ func extractZig(src, filePath string) []types.EntityRecord {
 			Properties: map[string]string{
 				"imports": strings.Join(imports, ","),
 			},
+			Relationships: calls,
 		})
 	}
 
-	// Private functions (no pub prefix).
+	// 2. Private functions (no pub prefix).
 	for _, m := range privFnRE.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		params := src[m[4]:m[5]]
@@ -98,6 +155,8 @@ func extractZig(src, filePath string) []types.EntityRecord {
 		seen[key] = true
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		endLine := findBraceEnd(src, m[1])
+		body := extractBraceBody(src, m[1])
+		calls := collectCalls(body, name)
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Operation",
@@ -111,14 +170,35 @@ func extractZig(src, filePath string) []types.EntityRecord {
 			Properties: map[string]string{
 				"imports": strings.Join(imports, ","),
 			},
+			Relationships: calls,
 		})
 	}
 
-	// Structs.
+	// 3. Structs — emit Components and attach CONTAINS edges to every fn
+	//    declared inside the brace body.
 	for _, m := range structRE.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		endLine := findBraceEnd(src, m[1]-1)
+		body := extractBraceBody(src, m[1]-1)
+
+		var rels []types.RelationshipRecord
+		methodSeen := make(map[string]bool)
+		for _, fm := range anyFnRE.FindAllStringSubmatch(body, -1) {
+			if len(fm) < 2 {
+				continue
+			}
+			methodName := fm[1]
+			if methodSeen[methodName] {
+				continue
+			}
+			methodSeen[methodName] = true
+			ref := extractor.BuildOperationStructuralRef("zig", filePath, methodName)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: ref,
+				Kind: "CONTAINS",
+			})
+		}
 
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
@@ -133,12 +213,21 @@ func extractZig(src, filePath string) []types.EntityRecord {
 			Properties: map[string]string{
 				"imports": strings.Join(imports, ","),
 			},
+			Relationships: rels,
 		})
+	}
+
+	// 4. Import stubs — one SCOPE.Component per unique @import target,
+	//    carrying the IMPORTS edge from file.Path → module.
+	importEntities := buildImportEntities(filePath, imports)
+	if len(importEntities) > 0 {
+		entities = append(importEntities, entities...)
 	}
 
 	return entities
 }
 
+// collectImports returns the textual targets of every @import("...") call.
 func collectImports(src string) []string {
 	var imports []string
 	for _, m := range importRE.FindAllStringSubmatch(src, -1) {
@@ -147,6 +236,194 @@ func collectImports(src string) []string {
 		}
 	}
 	return imports
+}
+
+// buildImportEntities turns each @import target into a SCOPE.Component
+// stub carrying an IMPORTS edge from file.Path → module.
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		out = append(out, types.EntityRecord{
+			Name:       importTopSegment(mod),
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "zig",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+// importTopSegment derives a display name for an @import target. For
+// stdlib-style references like "std" it returns the bare token; for
+// relative paths it returns the basename without extension so the entity
+// name remains a sensible identifier.
+func importTopSegment(mod string) string {
+	// Strip leading "./" / "../" segments.
+	trimmed := mod
+	for strings.HasPrefix(trimmed, "./") || strings.HasPrefix(trimmed, "../") {
+		if strings.HasPrefix(trimmed, "./") {
+			trimmed = trimmed[2:]
+		} else {
+			trimmed = trimmed[3:]
+		}
+	}
+	if trimmed == "" {
+		trimmed = mod
+	}
+	if slash := strings.LastIndexByte(trimmed, '/'); slash >= 0 {
+		trimmed = trimmed[slash+1:]
+	}
+	if dot := strings.LastIndexByte(trimmed, '.'); dot > 0 {
+		trimmed = trimmed[:dot]
+	}
+	if trimmed == "" {
+		return mod
+	}
+	return trimmed
+}
+
+// extractBraceBody returns the textual content between the first '{' at or
+// after pos and its matching '}'. Returns "" when no balanced pair is
+// found.
+func extractBraceBody(src string, pos int) string {
+	bracePos := strings.Index(src[pos:], "{")
+	if bracePos < 0 {
+		return ""
+	}
+	abs := pos + bracePos
+	depth := 0
+	for i := abs; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[abs+1 : i]
+			}
+		}
+	}
+	return src[abs+1:]
+}
+
+// collectCalls walks body, extracts every callee identifier, drops Zig
+// keywords / self-recursion, dedupes, and returns CALLS edges.
+//
+// Qualified calls (`std.debug.print`, `Foo.bar`) resolve to the rightmost
+// identifier so cross-language resolution can match a free-standing
+// function or method by its bare name.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+	matches := callRE.FindAllStringSubmatch(scrubbed, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		path := m[1]
+		// Rightmost segment is the callee.
+		target := path
+		if dot := strings.LastIndexByte(path, '.'); dot >= 0 {
+			target = path[dot+1:]
+		}
+		if target == "" {
+			continue
+		}
+		if zigKeywords[target] {
+			continue
+		}
+		if target == callerName {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+	return out
+}
+
+// stripStringsAndComments replaces string literals and //-line-comments
+// with spaces so the call-head scanner doesn't pick up tokens inside them.
+// Zig multi-line strings (`\\` line prefix) start with `\\` and run to
+// EOL — handled here as a comment-like pass.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := false
+	for i < len(src) {
+		ch := src[i]
+		if inStr {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == '"' {
+				inStr = false
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '"':
+			inStr = true
+			out[i] = ' '
+			i++
+		case '/':
+			if i+1 < len(src) && src[i+1] == '/' {
+				for i < len(src) && src[i] != '\n' {
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			out[i] = ch
+			i++
+		case '\\':
+			// Zig multi-line string lines start with `\\`.
+			if i+1 < len(src) && src[i+1] == '\\' {
+				for i < len(src) && src[i] != '\n' {
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			out[i] = ch
+			i++
+		default:
+			out[i] = ch
+			i++
+		}
+	}
+	return string(out)
 }
 
 // findBraceEnd returns the line of the closing } starting from pos.


### PR DESCRIPTION
## Summary

PORT-RELS-ZIG (#382): brings the regex-based Zig extractor to relationship parity with java/rust/cpp.

- **IMPORTS** — `file.Path → module` for every `@import(\"...\")` (stdlib + relative paths).
- **CALLS** — one edge per unique callee identifier per fn body. Qualified calls (`std.debug.print`, `Foo.bar`) resolve to the rightmost identifier; zig keywords / control forms / self-recursion filtered.
- **CONTAINS** — `const Name = struct { ... }` → each `pub fn` / `fn` in the body via Format A structural-ref `scope:operation:method:zig:<file>:<name>` (using `extractor.BuildOperationStructuralRef`).

All relationships tagged with `language=zig` via `extractor.TagRelationshipsLanguage`.

## Before / After

| Edge kind | Before | After |
| --- | --- | --- |
| IMPORTS   | none | one per `@import` target |
| CALLS     | none | one per unique callee per fn |
| CONTAINS  | none | one per fn declared inside each struct body |

## Test plan

- [x] `go test ./internal/extractors/zig/...` — 11 tests pass (5 pre-existing entity tests + 6 new relationship tests in `relationships_test.go`).
- [x] `go test ./...` — full repo green.
- [x] `go vet ./internal/extractors/zig/...` clean, `gofmt -l` clean.

New tests:
- `TestZig_Imports` — IMPORTS edges for stdlib + relative paths
- `TestZig_CallsBareName` — bare + qualified calls, dedup
- `TestZig_CallsExcludeSelfRecursion` — self-edges filtered
- `TestZig_ContainsStructMethods` — struct → 3 method CONTAINS via Format A
- `TestZig_ContainsTopLevelFnNotInStruct` — top-level fns scoped out
- `TestZig_RelationshipsLanguageTagged` — every rel carries `language=zig`