### PR TITLE
feat(groovy): emit IMPORTS + CALLS + CONTAINS edges (#372)

### DIFF
--- a/internal/extractors/groovy/groovy.go
+++ b/internal/extractors/groovy/groovy.go
@@ -6,6 +6,24 @@
 //   - function_definition  → Kind="SCOPE.Operation", Subtype="function"
 //   - Gradle apply plugin  → Kind="SCOPE.Component", Subtype="plugin_id"
 //   - Gradle task def      → Kind="SCOPE.Operation", Subtype="task"
+//   - groovy_import        → IMPORTS relationships
+//
+// Issue #372 — relationship parity with java/kotlin/scala:
+//
+//   - IMPORTS edges carry the same Properties contract Python emits
+//     (#93): local_name, source_module, imported_name, wildcard. Aliased
+//     imports (`import foo.Bar as Baz`) preserve the original
+//     imported_name while local_name reflects the alias. Static imports
+//     are tagged with import_kind="static".
+//   - CALLS edges are emitted per function_call descendant of every
+//     method/function body. When the call target uses a dotted_identifier
+//     receiver and the receiver's first segment is PascalCase, the target
+//     is emitted as the dotted "<Type>.<method>" form and Properties
+//     carries `receiver_type=<Type>`. Self-recursion is dropped, matching
+//     java/scala/kotlin dedup semantics.
+//   - CONTAINS edges are attached from each class component to every
+//     method declared in its body, using the canonical Format A
+//     structural-ref (`scope:operation:method:groovy:<file>:<name>`).
 //
 // Uses the groovy grammar from smacker/go-tree-sitter.
 // Registers itself via init() and is imported by registry_gen.go.
@@ -37,9 +55,15 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		return nil, nil
 	}
 
-	imports := collectImports(file.Tree.RootNode(), file.Content)
+	root := file.Tree.RootNode()
+	imports := collectImports(root, file.Content)
 	var entities []types.EntityRecord
-	walkGroovy(file.Tree.RootNode(), file, imports, &entities)
+	// Issue #372: emit IMPORTS edges as standalone SCOPE.Component records
+	// matching the scala/elixir extractor pattern.
+	entities = append(entities, buildImportRecords(root, file)...)
+	walkGroovy(root, file, imports, &entities)
+	// Issue #90 — tag every relationship with language="groovy".
+	extractor.TagRelationshipsLanguage(entities, "groovy")
 	return entities, nil
 }
 
@@ -57,26 +81,52 @@ func walkGroovyWithContext(node *sitter.Node, file extractor.FileInput, imports 
 	switch node.Type() {
 	case "class_declaration", "class_definition":
 		// smacker grammar uses class_definition; Python tree-sitter uses class_declaration.
+		classIdx := -1
 		if rec, ok := buildClass(node, file, imports); ok {
+			classIdx = len(*out)
 			*out = append(*out, rec)
 		}
 		// Walk ALL children with inClass=true (all nested definitions are methods).
+		before := len(*out)
 		for i := range node.ChildCount() {
 			walkGroovyWithContext(node.Child(int(i)), file, imports, out, true)
+		}
+		after := len(*out)
+		// Issue #372: attach CONTAINS edges from this class to every
+		// SCOPE.Operation emitted from its body.
+		if classIdx >= 0 {
+			for k := before; k < after; k++ {
+				child := &(*out)[k]
+				if child.Kind != "SCOPE.Operation" {
+					continue
+				}
+				toID := extractor.BuildOperationStructuralRef("groovy", file.Path, child.Name)
+				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
+					types.RelationshipRecord{
+						ToID: toID,
+						Kind: "CONTAINS",
+					})
+			}
 		}
 		return
 	case "method_declaration":
 		if rec, ok := buildMethod(node, file, imports); ok {
+			rec.Relationships = append(rec.Relationships,
+				extractCallRelationships(findFunctionBody(node), file.Content, rec.Name)...)
 			*out = append(*out, rec)
 		}
 	case "function_definition":
 		if inClass {
 			// Inside a class, treat as method (Groovy's `def name()` inside class = method).
 			if rec, ok := buildFunctionAsMethod(node, file, imports); ok {
+				rec.Relationships = append(rec.Relationships,
+					extractCallRelationships(findFunctionBody(node), file.Content, rec.Name)...)
 				*out = append(*out, rec)
 			}
 		} else {
 			if rec, ok := buildFunction(node, file, imports); ok {
+				rec.Relationships = append(rec.Relationships,
+					extractCallRelationships(findFunctionBody(node), file.Content, rec.Name)...)
 				*out = append(*out, rec)
 			}
 		}
@@ -516,4 +566,317 @@ func buildGradleTaskJuxt(node *sitter.Node, file extractor.FileInput, imports []
 		}
 	}
 	return types.EntityRecord{}, false
+}
+
+// groovyKeywordStop lists groovy keywords / special identifiers that the
+// parser surfaces as call_expression heads but are not real call targets.
+// Mirrors the kotlin/scala extractors' drop list (#106, #379).
+var groovyKeywordStop = map[string]bool{
+	"this":  true,
+	"super": true,
+	"new":   true,
+}
+
+// findFunctionBody returns the closure child of a function_definition /
+// method_declaration that holds the call expressions, or nil when the
+// declaration has no body (abstract/interface method).
+func findFunctionBody(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch == nil {
+			continue
+		}
+		// smacker groovy grammar wraps the body in a "closure" node;
+		// some grammars use "block".
+		if ch.Type() == "closure" || ch.Type() == "block" {
+			return ch
+		}
+	}
+	return nil
+}
+
+// findAllNodes returns every descendant of root whose Type() is in kinds.
+func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+	if root == nil {
+		return nil
+	}
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	var out []*sitter.Node
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if n == nil {
+			continue
+		}
+		if set[n.Type()] {
+			out = append(out, n)
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return out
+}
+
+// extractCallRelationships returns one CALLS RelationshipRecord per
+// unique function_call descendant of body. Self-recursion is dropped.
+//
+// In smacker/go-tree-sitter/groovy, function_call has either:
+//
+//   - identifier         → bare-name call (helper())
+//   - dotted_identifier  → obj.method() — the trailing identifier is the
+//     method, the leading identifier is the receiver. When the receiver
+//     is PascalCase, the target is emitted as "<Type>.<method>" with
+//     Properties[receiver_type]=<Type>.
+//   - function_call      → curried call (`f()(x)`); recurse to find the
+//     leaf method name.
+func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+	if body == nil || callerName == "" {
+		return nil
+	}
+	calls := findAllNodes(body, "function_call")
+	if len(calls) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(calls))
+	rels := make([]types.RelationshipRecord, 0, len(calls))
+	for _, call := range calls {
+		target, recv := groovyCallTarget(call, src)
+		if target == "" {
+			continue
+		}
+		if groovyKeywordStop[target] {
+			continue
+		}
+		// Self-recursion check on the bare leaf name.
+		leaf := target
+		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
+			leaf = target[dot+1:]
+		}
+		if leaf == callerName {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		rel := types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		}
+		if recv != "" {
+			rel.Properties = map[string]string{"receiver_type": recv}
+		}
+		rels = append(rels, rel)
+	}
+	return rels
+}
+
+// groovyCallTarget resolves the callee target of a function_call node.
+// Returns (target, receiverType). receiverType is non-empty only when a
+// dotted_identifier receiver looks like a PascalCase type.
+func groovyCallTarget(call *sitter.Node, src []byte) (string, string) {
+	if call == nil || call.ChildCount() == 0 {
+		return "", ""
+	}
+	first := call.Child(0)
+	if first == nil {
+		return "", ""
+	}
+	switch first.Type() {
+	case "identifier":
+		return nodeText(first, src), ""
+	case "dotted_identifier":
+		// dotted_identifier children: identifier "." identifier ...
+		// The trailing identifier is the method, the leading identifier
+		// is the receiver. Nested function_call children (`Service().run`)
+		// indicate chained-call receivers — fall back to bare leaf.
+		var idents []*sitter.Node
+		hasNestedCall := false
+		for i := 0; i < int(first.ChildCount()); i++ {
+			ch := first.Child(i)
+			if ch == nil {
+				continue
+			}
+			switch ch.Type() {
+			case "identifier":
+				idents = append(idents, ch)
+			case "function_call", "dotted_identifier":
+				hasNestedCall = true
+			}
+		}
+		if len(idents) == 0 {
+			return "", ""
+		}
+		methodNode := idents[len(idents)-1]
+		method := nodeText(methodNode, src)
+		if method == "" {
+			return "", ""
+		}
+		if hasNestedCall || len(idents) < 2 {
+			return method, ""
+		}
+		receiver := nodeText(idents[0], src)
+		// PascalCase static-call shape: `Module.method`.
+		if isPascalCase(receiver) {
+			return receiver + "." + method, receiver
+		}
+		return method, ""
+	case "function_call":
+		// Curried call — recurse.
+		return groovyCallTarget(first, src)
+	}
+	return "", ""
+}
+
+// isPascalCase reports whether s starts with an uppercase ASCII letter
+// followed by at least one more character.
+func isPascalCase(s string) bool {
+	if len(s) < 2 {
+		return false
+	}
+	c := s[0]
+	return c >= 'A' && c <= 'Z'
+}
+
+// buildImportRecords walks the source for groovy_import nodes and emits
+// one SCOPE.Component entity per import edge with an embedded IMPORTS
+// relationship. The edge Properties carry the same contract Python (#93),
+// Java (#120), and Scala (#379) emit so the cross-file resolver can
+// build a per-file binding table.
+//
+// Groovy import shapes handled:
+//
+//	import foo.Bar              → ToID=foo.Bar,  local_name=Bar
+//	import foo.Bar as Baz       → ToID=foo.Bar,  local_name=Baz, imported_name=Bar
+//	import foo.something.*      → ToID=foo.something, wildcard=1
+//	import static foo.Util.helper → ToID=foo.Util.helper, import_kind=static
+//	import static foo.Util.*    → ToID=foo.Util,  wildcard=1, import_kind=static
+func buildImportRecords(root *sitter.Node, file extractor.FileInput) []types.EntityRecord {
+	imports := findAllNodes(root, "groovy_import", "import_declaration")
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	for _, imp := range imports {
+		rec, ok := buildImportRecord(imp, file)
+		if !ok {
+			continue
+		}
+		out = append(out, rec)
+	}
+	return out
+}
+
+// buildImportRecord builds a single import edge from a groovy_import node.
+func buildImportRecord(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	var path string
+	var alias string
+	hasWildcard := false
+	isStatic := false
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "qualified_name":
+			path = nodeText(ch, file.Content)
+		case "wildcard_import":
+			hasWildcard = true
+		case "modifier":
+			// `import static ...`
+			if strings.Contains(nodeText(ch, file.Content), "static") {
+				isStatic = true
+			}
+		case "static":
+			isStatic = true
+		case "as":
+			// next identifier is the alias.
+		case "identifier":
+			// Trailing identifier: either the alias (after "as") or the
+			// final segment of a non-wildcard static import (when the
+			// grammar surfaces it separately from qualified_name).
+			alias = nodeText(ch, file.Content)
+		}
+	}
+	if path == "" {
+		// Fallback: parse from raw text for grammars that don't expose
+		// qualified_name directly.
+		raw := strings.TrimSpace(nodeText(node, file.Content))
+		raw = strings.TrimPrefix(raw, "import")
+		raw = strings.TrimSpace(raw)
+		raw = strings.TrimPrefix(raw, "static")
+		raw = strings.TrimSpace(raw)
+		raw = strings.TrimSuffix(raw, ";")
+		if asIdx := strings.Index(raw, " as "); asIdx >= 0 {
+			alias = strings.TrimSpace(raw[asIdx+4:])
+			raw = strings.TrimSpace(raw[:asIdx])
+		}
+		if strings.HasSuffix(raw, ".*") {
+			hasWildcard = true
+			raw = strings.TrimSuffix(raw, ".*")
+		}
+		path = raw
+	}
+	if path == "" {
+		return types.EntityRecord{}, false
+	}
+
+	// Determine ToID and properties.
+	var toID string
+	props := map[string]string{}
+	if isStatic {
+		props["import_kind"] = "static"
+	}
+	if hasWildcard {
+		toID = path
+		props["source_module"] = path
+		props["wildcard"] = "1"
+	} else {
+		// Plain import (with optional alias). Static non-wildcard imports
+		// also have shape `static foo.Util.helper` where the leaf is the
+		// member; we treat path as the full ToID and split off the leaf.
+		toID = path
+		leaf := path
+		mod := path
+		if dot := strings.LastIndexByte(path, '.'); dot > 0 {
+			leaf = path[dot+1:]
+			mod = path[:dot]
+		}
+		importedName := leaf
+		localName := leaf
+		if alias != "" {
+			localName = alias
+		}
+		props["local_name"] = localName
+		props["source_module"] = mod
+		props["imported_name"] = importedName
+	}
+
+	top := toID
+	if idx := strings.Index(toID, "."); idx >= 0 {
+		top = toID[:idx]
+	}
+	return types.EntityRecord{
+		Name:       top,
+		Kind:       "SCOPE.Component",
+		SourceFile: file.Path,
+		Language:   "groovy",
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID:     file.Path,
+				ToID:       toID,
+				Kind:       "IMPORTS",
+				Properties: props,
+			},
+		},
+	}, true
 }

--- a/internal/extractors/groovy/relationships_test.go
+++ b/internal/extractors/groovy/relationships_test.go
@@ -1,0 +1,293 @@
+package groovy_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/groovy"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runGroovy parses src with the real groovy grammar and returns extracted entities.
+func runGroovy(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("groovy")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Test.groovy",
+		Content:  []byte(src),
+		Language: "groovy",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func gFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func gHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	e := gFind(ents, name, kind)
+	if e == nil {
+		return false
+	}
+	for _, r := range e.Relationships {
+		if r.Kind == edgeKind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// TestGroovy_ContainsClassMethods (#372): class with N methods → N
+// CONTAINS edges keyed on the canonical Format A structural-ref.
+func TestGroovy_ContainsClassMethods(t *testing.T) {
+	src := `class Foo {
+    def a() {}
+    def b(int x) {}
+    def c() {}
+}
+`
+	ents := runGroovy(t, src)
+	foo := gFind(ents, "Foo", "SCOPE.Component")
+	if foo == nil {
+		t.Fatal("expected Foo component")
+	}
+	contains := 0
+	for _, r := range foo.Relationships {
+		if r.Kind == "CONTAINS" {
+			contains++
+		}
+	}
+	if contains != 3 {
+		t.Errorf("expected 3 CONTAINS edges, got %d (rels=%+v)", contains, foo.Relationships)
+	}
+	for _, m := range []string{"a", "b", "c"} {
+		want := "scope:operation:method:groovy:Test.groovy:" + m
+		if !gHasRel(ents, "Foo", "SCOPE.Component", "CONTAINS", want) {
+			t.Errorf("expected CONTAINS Foo→%s", want)
+		}
+	}
+}
+
+// TestGroovy_CallsBareName (#372): bare-name method invocation in a
+// function body emits a CALLS edge with the bare callee name. Dedup
+// is applied per (target).
+func TestGroovy_CallsBareName(t *testing.T) {
+	src := `class A {
+    def caller() {
+        helper()
+        helper()
+        println("x")
+    }
+    def helper() {}
+}
+`
+	ents := runGroovy(t, src)
+	if !gHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Errorf("expected CALLS caller→helper")
+	}
+	if !gHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "println") {
+		t.Errorf("expected CALLS caller→println")
+	}
+	caller := gFind(ents, "caller", "SCOPE.Operation")
+	n := 0
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "helper" {
+			n++
+		}
+	}
+	if n != 1 {
+		t.Errorf("expected dedup CALLS caller→helper to 1, got %d", n)
+	}
+}
+
+// TestGroovy_CallsDottedReceiver (#372): method invocation through a
+// dotted receiver `obj.method()` emits the bare leaf method name. When
+// the receiver looks like a PascalCase type (`Module.method`), the
+// target is emitted as the dotted "<Type>.<method>" form.
+func TestGroovy_CallsDottedReceiver(t *testing.T) {
+	src := `class C {
+    def f() {
+        repo.find()
+        Service.run()
+    }
+}
+`
+	ents := runGroovy(t, src)
+	caller := gFind(ents, "f", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected operation f")
+	}
+	wantDotted := "Service.run"
+	wantBare := "find"
+	gotDotted := false
+	gotBare := false
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if r.ToID == wantDotted {
+			gotDotted = true
+			if r.Properties["receiver_type"] != "Service" {
+				t.Errorf("Service.run receiver_type=%q want Service", r.Properties["receiver_type"])
+			}
+		}
+		if r.ToID == wantBare {
+			gotBare = true
+		}
+	}
+	if !gotDotted {
+		t.Errorf("expected CALLS f→Service.run")
+	}
+	if !gotBare {
+		t.Errorf("expected CALLS f→find")
+	}
+}
+
+// TestGroovy_CallsKeywordsFiltered (#372): groovy keywords / special
+// identifiers must NOT be emitted as CALLS targets.
+func TestGroovy_CallsKeywordsFiltered(t *testing.T) {
+	src := `class A {
+    def caller() {
+        helper()
+    }
+    def helper() {}
+}
+`
+	ents := runGroovy(t, src)
+	caller := gFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller operation")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		switch r.ToID {
+		case "this", "super", "new":
+			t.Errorf("groovy keyword %q must not be emitted as CALLS target", r.ToID)
+		}
+	}
+}
+
+// TestGroovy_CallsSelfRecursionDropped (#372): a function calling itself
+// must not emit a CALLS edge to itself (matches java/scala semantics).
+func TestGroovy_CallsSelfRecursionDropped(t *testing.T) {
+	src := `class A {
+    def loop() {
+        loop()
+    }
+}
+`
+	ents := runGroovy(t, src)
+	loop := gFind(ents, "loop", "SCOPE.Operation")
+	if loop == nil {
+		t.Fatal("expected operation loop")
+	}
+	for _, r := range loop.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "loop" {
+			t.Errorf("self-recursion CALLS loop→loop must be dropped")
+		}
+	}
+}
+
+// TestGroovy_ImportsCarryProperties (#372): IMPORTS edges carry the
+// metadata the cross-file resolver consumes (mirroring Python #93,
+// Java #120, Scala #379): local_name, source_module, imported_name,
+// wildcard.
+func TestGroovy_ImportsCarryProperties(t *testing.T) {
+	src := `import foo.Bar
+import foo.Baz as Renamed
+import foo.helpers.*
+import static foo.Util.helper
+
+class A {}
+`
+	ents := runGroovy(t, src)
+
+	want := map[string]map[string]string{
+		"foo.Bar": {
+			"local_name":    "Bar",
+			"source_module": "foo",
+			"imported_name": "Bar",
+		},
+		"foo.Baz": {
+			"local_name":    "Renamed",
+			"source_module": "foo",
+			"imported_name": "Baz",
+		},
+		"foo.Util.helper": {
+			"local_name":    "helper",
+			"source_module": "foo.Util",
+			"imported_name": "helper",
+		},
+	}
+
+	got := map[string]map[string]string{}
+	wildcardSeen := false
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			got[r.ToID] = r.Properties
+			if r.Properties["wildcard"] == "1" && r.ToID == "foo.helpers" {
+				wildcardSeen = true
+			}
+		}
+	}
+	for to, wantProps := range want {
+		gotProps, ok := got[to]
+		if !ok {
+			t.Errorf("expected IMPORTS edge to=%q (got=%v)", to, got)
+			continue
+		}
+		for k, v := range wantProps {
+			if gotProps[k] != v {
+				t.Errorf("IMPORTS to=%q prop %q: got=%q want=%q (all=%v)",
+					to, k, gotProps[k], v, gotProps)
+			}
+		}
+	}
+	if !wildcardSeen {
+		t.Errorf("expected wildcard IMPORTS edge for foo.helpers.*")
+	}
+}
+
+// TestGroovy_RelationshipsLanguageTagged (#372): every emitted
+// relationship must carry Properties["language"]="groovy" so the
+// cross-file resolver dispatches the correct dynamic patterns.
+func TestGroovy_RelationshipsLanguageTagged(t *testing.T) {
+	src := `import foo.Bar
+
+class A {
+    def f() {
+        helper()
+    }
+    def helper() {}
+}
+`
+	ents := runGroovy(t, src)
+	relCount := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			relCount++
+			if r.Properties["language"] != "groovy" {
+				t.Errorf("rel %s→%s missing language=groovy (got=%q)", r.Kind, r.ToID, r.Properties["language"])
+			}
+		}
+	}
+	if relCount == 0 {
+		t.Errorf("expected at least one relationship; entities=%+v", ents)
+	}
+}


### PR DESCRIPTION
## Summary
- Wires the groovy extractor into the cross-file relationship resolver, matching the IMPORTS/CALLS/CONTAINS contract Python (#93), Java (#120), and Scala (#379) already provide.
- IMPORTS: parsed from `groovy_import` nodes; carries `local_name`, `source_module`, `imported_name`, `wildcard`, and `import_kind=static` for `import static`. `import foo.Bar as Baz` preserves `imported_name=Bar` while `local_name` reflects the alias.
- CALLS: emitted per `function_call` descendant of every method/function body. Receivers via `dotted_identifier` resolve to `<Type>.<method>` when PascalCase; `this`/`super`/`new` and self-recursion are dropped.
- CONTAINS: attached from each class component to every method, using the canonical Format A structural-ref `scope:operation:method:groovy:<file>:<name>`.
- Every emitted edge is tagged `language=groovy` via `TagRelationshipsLanguage`.

Closes #372.

## Test plan
- [x] `go test ./internal/extractors/groovy/...` — 7 new relationship tests + all existing tests pass
- [x] `go test ./...` — full repo green
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/extractors/groovy/` clean
- [x] Smoke run on `fixtures/real-world/groovy/*.groovy` emits non-zero IMPORTS/CALLS/CONTAINS counts (e.g., `grails_controller.groovy` → 3 IMPORTS, 13 CALLS, 7 CONTAINS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)