### PR TITLE
feat(razor): emit IMPORTS + CALLS + CONTAINS (Closes #378)

### DIFF
--- a/internal/extractors/razor/extractor.go
+++ b/internal/extractors/razor/extractor.go
@@ -55,6 +55,10 @@ var (
 	// @inject ServiceType Name
 	reInject = regexp.MustCompile(`(?m)^@inject\s+(\S+)\s+(\S+)`)
 
+	// @using Foo.Bar(.Baz)*
+	// Captures: dotted module path (the imported namespace).
+	reUsing = regexp.MustCompile(`(?m)^@using\s+([\w\.]+)`)
+
 	// @code followed by optional whitespace then {
 	reCodeBlock = regexp.MustCompile(`@code\s*\{`)
 
@@ -68,7 +72,28 @@ var (
 	// event handler: void or async / Task returning method that looks like an event handler
 	// Captures: return_type, method_name
 	reEventHandler = regexp.MustCompile(`(?:private|public|protected|internal)?\s*(?:async\s+)?(?:void|Task)\s+(\w+)\s*\(`)
+
+	// Method/function call head: identifier followed by `(`. Captures the
+	// identifier. Used to harvest CALLS edges from method bodies.
+	reCallHead = regexp.MustCompile(`\b([A-Za-z_][A-Za-z0-9_]*)\s*\(`)
 )
+
+// csKeywords are C# / Razor reserved words that appear before "(" but are NOT
+// method calls (control flow, declarations, etc.). Filtered out of CALLS.
+var csKeywords = map[string]bool{
+	"if": true, "else": true, "while": true, "for": true, "foreach": true,
+	"switch": true, "case": true, "return": true, "throw": true, "try": true,
+	"catch": true, "finally": true, "using": true, "lock": true, "do": true,
+	"new": true, "typeof": true, "sizeof": true, "nameof": true, "default": true,
+	"checked": true, "unchecked": true, "in": true, "out": true, "ref": true,
+	"is": true, "as": true, "void": true, "Task": true, "var": true,
+	"true": true, "false": true, "null": true, "this": true, "base": true,
+	"await": true, "async": true, "yield": true, "break": true, "continue": true,
+	"goto": true, "fixed": true, "stackalloc": true, "delegate": true,
+	"public": true, "private": true, "protected": true, "internal": true,
+	"static": true, "readonly": true, "const": true, "virtual": true,
+	"override": true, "abstract": true, "sealed": true, "partial": true,
+}
 
 // Extract processes a .razor file and returns entity records.
 func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (entities []types.EntityRecord, retErr error) {
@@ -124,6 +149,8 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 		EnrichmentStatus:   types.StatusPending,
 		EnrichmentRequired: false,
 	}
+	// Component entity is the first record; we mutate index 0 below to attach
+	// CONTAINS edges to event-handler operations (Issue #378).
 	entities = append(entities, componentEntity)
 
 	// --- 2. @inject directives -----------------------------------------------
@@ -154,6 +181,13 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 	// Re-scan inject positions individually for accurate line numbers.
 	entities = rebuildInjectEntities(entities, src, file.Path, componentName)
 
+	// --- 3a. @using directives → IMPORTS edges -------------------------------
+	// Each @using emits a SCOPE.Component import-stub entity carrying a single
+	// IMPORTS edge from the source file → the imported namespace. Mirrors the
+	// contract used by the Clojure (#118) and Java (#120) extractors. Inserted
+	// after rebuildInjectEntities, which retains only entities[:1].
+	entities = append(entities, buildImportEntities(file.Path, src)...)
+
 	// --- 4. @code block ------------------------------------------------------
 	codeSrc, codeOffset, ok := extractCodeBlock(src)
 	if !ok {
@@ -169,7 +203,141 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (enti
 	}
 	entities = append(entities, codeEntities...)
 
+	// --- 6. CONTAINS edges: component → each event_handler (Format A
+	// structural-ref keyed on file path so the resolver disambiguates
+	// across components that share method names).
+	for i := range entities {
+		if entities[i].Subtype != "event_handler" {
+			continue
+		}
+		toID := extractor.BuildOperationStructuralRef("razor", file.Path, entities[i].Name)
+		entities[0].Relationships = append(entities[0].Relationships, types.RelationshipRecord{
+			ToID: toID,
+			Kind: "CONTAINS",
+		})
+	}
+
 	return entities, nil
+}
+
+// buildImportEntities scans @using directives and emits one SCOPE.Component
+// stub per unique namespace, each carrying a single IMPORTS edge from the
+// source file → namespace. Matches the contract used by Clojure / Java
+// extractors (Issue #378).
+func buildImportEntities(filePath, src string) []types.EntityRecord {
+	matches := reUsing.FindAllStringSubmatchIndex(src, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.EntityRecord, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 4 {
+			continue
+		}
+		ns := src[m[2]:m[3]]
+		if ns == "" || seen[ns] {
+			continue
+		}
+		seen[ns] = true
+		lineNum := lineOf(src, m[0])
+		out = append(out, types.EntityRecord{
+			Name:             topSegment(ns),
+			QualifiedName:    ns,
+			Kind:             "SCOPE.Component",
+			Subtype:          "import",
+			SourceFile:       filePath,
+			Language:         "razor",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			QualityScore:     0.85,
+			EnrichmentStatus: types.StatusPending,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   ns,
+					Kind:   "IMPORTS",
+					Properties: map[string]string{
+						"source_module": parentNamespace(ns),
+					},
+				},
+			},
+		})
+	}
+	return out
+}
+
+// parentNamespace returns the dotted-parent of a namespace ("A.B.C" → "A.B").
+func parentNamespace(dotted string) string {
+	if dot := strings.LastIndexByte(dotted, '.'); dot > 0 {
+		return dotted[:dot]
+	}
+	return dotted
+}
+
+// topSegment returns the first dotted segment ("A.B.C" → "A").
+func topSegment(dotted string) string {
+	if dot := strings.IndexByte(dotted, '.'); dot > 0 {
+		return dotted[:dot]
+	}
+	return dotted
+}
+
+// collectCalls scans body for identifier-followed-by-paren patterns and
+// returns deduped CALLS edges, dropping C# reserved words and the caller's
+// own name (self-recursion).
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	matches := reCallHead.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		head := m[1]
+		if head == "" || csKeywords[head] {
+			continue
+		}
+		if head == callerName {
+			continue
+		}
+		if seen[head] {
+			continue
+		}
+		seen[head] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: head,
+			Kind: "CALLS",
+		})
+	}
+	return out
+}
+
+// extractMethodBody returns the substring inside the matching {} that follows
+// the method signature beginning at sigStart (offset within codeSrc). Returns
+// "" if no balanced body is found.
+func extractMethodBody(codeSrc string, sigStart int) string {
+	openIdx := strings.IndexByte(codeSrc[sigStart:], '{')
+	if openIdx < 0 {
+		return ""
+	}
+	abs := sigStart + openIdx
+	depth := 0
+	for i := abs; i < len(codeSrc); i++ {
+		switch codeSrc[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return codeSrc[abs+1 : i]
+			}
+		}
+	}
+	return ""
 }
 
 // componentNameFromPath derives the PascalCase component name from the file path.
@@ -269,6 +437,17 @@ func extractFromCodeBlock(codeSrc string, codeOffset int, fullSrc, filePath, com
 			if m != nil {
 				methodName := m[1]
 				lineNum := lineOf(fullSrc, codeOffset) + i
+
+				// Locate this signature within codeSrc to capture the body
+				// for CALLS scanning. We compute the byte offset of `line`
+				// within codeSrc by re-walking lines (cheap; codeSrc is small).
+				var lineByteOffset int
+				for k := 0; k < i; k++ {
+					lineByteOffset += len(lines[k]) + 1 // +1 for the \n consumed by Split
+				}
+				body := extractMethodBody(codeSrc, lineByteOffset)
+				calls := collectCalls(body, methodName)
+
 				entities = append(entities, types.EntityRecord{
 					Name:             methodName,
 					QualifiedName:    fmt.Sprintf("%s.%s", componentName, methodName),
@@ -284,6 +463,7 @@ func extractFromCodeBlock(codeSrc string, codeOffset int, fullSrc, filePath, com
 						"method_name": methodName,
 						"component":   componentName,
 					},
+					Relationships: calls,
 				})
 			}
 		}

--- a/internal/extractors/razor/relationships_test.go
+++ b/internal/extractors/razor/relationships_test.go
@@ -1,0 +1,277 @@
+package razor_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/razor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func relsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func hasRel(entities []types.EntityRecord, kind, toContains string) bool {
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind && strings.Contains(r.ToID, toContains) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---- IMPORTS ---------------------------------------------------------------
+
+func TestRelationships_Imports_SingleUsing(t *testing.T) {
+	src := `@using Microsoft.AspNetCore.Components
+
+<h1>Hello</h1>`
+	entities := extract(t, "Foo.razor", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "Microsoft.AspNetCore.Components" {
+		t.Errorf("IMPORTS ToID = %q, want %q", rels[0].ToID, "Microsoft.AspNetCore.Components")
+	}
+	if rels[0].FromID != "Foo.razor" {
+		t.Errorf("IMPORTS FromID = %q, want Foo.razor", rels[0].FromID)
+	}
+}
+
+func TestRelationships_Imports_Multiple(t *testing.T) {
+	src := `@using System
+@using System.Linq
+@using Microsoft.AspNetCore.Components.Web
+
+<h1>Hi</h1>`
+	entities := extract(t, "Multi.razor", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 3 {
+		t.Fatalf("IMPORTS count = %d, want 3", len(rels))
+	}
+	wants := map[string]bool{
+		"System":                                 false,
+		"System.Linq":                            false,
+		"Microsoft.AspNetCore.Components.Web":    false,
+	}
+	for _, r := range rels {
+		if _, ok := wants[r.ToID]; ok {
+			wants[r.ToID] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing IMPORTS edge to %q", k)
+		}
+	}
+}
+
+func TestRelationships_Imports_NoneWhenAbsent(t *testing.T) {
+	src := `<h1>Hi</h1>`
+	entities := extract(t, "Plain.razor", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Errorf("IMPORTS count = %d, want 0", len(rels))
+	}
+}
+
+func TestRelationships_Imports_DedupesIdentical(t *testing.T) {
+	src := `@using System
+@using System
+
+<h1>Hi</h1>`
+	entities := extract(t, "Dup.razor", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Errorf("IMPORTS dedup count = %d, want 1", len(rels))
+	}
+}
+
+// ---- CALLS -----------------------------------------------------------------
+
+func TestRelationships_Calls_FromEventHandler(t *testing.T) {
+	src := `@code {
+    private void IncrementCount()
+    {
+        DoSomething();
+        StateHasChanged();
+    }
+}`
+	entities := extract(t, "Counter.razor", src)
+	h := findByName(entities, "IncrementCount")
+	if h == nil {
+		t.Fatal("IncrementCount handler not found")
+	}
+	var callTargets []string
+	for _, r := range h.Relationships {
+		if r.Kind == "CALLS" {
+			callTargets = append(callTargets, r.ToID)
+		}
+	}
+	if len(callTargets) < 2 {
+		t.Fatalf("CALLS count on IncrementCount = %d, want >= 2 (got %v)", len(callTargets), callTargets)
+	}
+	wants := map[string]bool{"DoSomething": false, "StateHasChanged": false}
+	for _, c := range callTargets {
+		if _, ok := wants[c]; ok {
+			wants[c] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing CALLS edge to %q (got %v)", k, callTargets)
+		}
+	}
+}
+
+func TestRelationships_Calls_DedupedPerHandler(t *testing.T) {
+	src := `@code {
+    private void Runner()
+    {
+        Foo();
+        Foo();
+        Foo();
+    }
+}`
+	entities := extract(t, "Dedup.razor", src)
+	h := findByName(entities, "Runner")
+	if h == nil {
+		t.Fatal("Runner not found")
+	}
+	count := 0
+	for _, r := range h.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "Foo" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("CALLS to Foo count = %d, want 1 (deduped)", count)
+	}
+}
+
+func TestRelationships_Calls_SkipsKeywords(t *testing.T) {
+	src := `@code {
+    private void Run()
+    {
+        if (true) { return; }
+        while (false) { }
+        for (int i = 0; i < 1; i++) { }
+    }
+}`
+	entities := extract(t, "Kw.razor", src)
+	h := findByName(entities, "Run")
+	if h == nil {
+		t.Fatal("Run not found")
+	}
+	for _, r := range h.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		switch r.ToID {
+		case "if", "while", "for", "switch", "return", "foreach":
+			t.Errorf("CALLS edge to keyword %q should not exist", r.ToID)
+		}
+	}
+}
+
+// ---- CONTAINS --------------------------------------------------------------
+
+func TestRelationships_Contains_ComponentToEventHandler(t *testing.T) {
+	src := `@code {
+    private void OnClick() { }
+}`
+	entities := extract(t, "Btn.razor", src)
+	if len(entities) == 0 {
+		t.Fatal("no entities")
+	}
+	comp := entities[0]
+	if comp.Name != "Btn" {
+		t.Fatalf("first entity = %q, want Btn", comp.Name)
+	}
+	wantRef := extractor.BuildOperationStructuralRef("razor", "Btn.razor", "OnClick")
+	found := false
+	for _, r := range comp.Relationships {
+		if r.Kind == "CONTAINS" && r.ToID == wantRef {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CONTAINS edge from component → %q\ngot rels: %+v", wantRef, comp.Relationships)
+	}
+}
+
+func TestRelationships_Contains_MultipleHandlers(t *testing.T) {
+	src := `@code {
+    private void OnA() { }
+    private void OnB() { }
+    private async Task OnC() { }
+}`
+	entities := extract(t, "Multi.razor", src)
+	comp := entities[0]
+	count := 0
+	for _, r := range comp.Relationships {
+		if r.Kind == "CONTAINS" {
+			count++
+		}
+	}
+	if count < 3 {
+		t.Errorf("CONTAINS count = %d, want >= 3", count)
+	}
+}
+
+func TestRelationships_Contains_UsesStructuralRef(t *testing.T) {
+	src := `@code {
+    private void OnClick() { }
+}`
+	entities := extract(t, "Pages/Foo.razor", src)
+	comp := entities[0]
+	if !hasRel(entities, "CONTAINS", "scope:operation:method:razor:Pages/Foo.razor:OnClick") {
+		t.Errorf("expected CONTAINS structural-ref to scope:operation:method:razor:Pages/Foo.razor:OnClick\ngot: %+v", comp.Relationships)
+	}
+}
+
+// ---- Combined fixture ------------------------------------------------------
+
+func TestRelationships_Combined_AllThreeKinds(t *testing.T) {
+	src := `@using System
+@using Microsoft.AspNetCore.Components
+
+<h1>Hello</h1>
+
+@code {
+    [Parameter]
+    public int Count { get; set; }
+
+    private void IncrementCount()
+    {
+        Count++;
+        StateHasChanged();
+    }
+}`
+	entities := extract(t, "Counter.razor", src)
+	if len(relsByKind(entities, "IMPORTS")) < 2 {
+		t.Errorf("expected >= 2 IMPORTS")
+	}
+	if len(relsByKind(entities, "CALLS")) < 1 {
+		t.Errorf("expected >= 1 CALLS")
+	}
+	if len(relsByKind(entities, "CONTAINS")) < 1 {
+		t.Errorf("expected >= 1 CONTAINS")
+	}
+}


### PR DESCRIPTION
## Summary
- Razor extractor now emits IMPORTS edges for each `@using` directive (file → namespace), CALLS edges from event-handler bodies (deduped, C# keywords filtered, self-recursion dropped), and CONTAINS edges from the component entity to each event-handler operation using `extractor.BuildOperationStructuralRef("razor", file, name)`.
- Mirrors the Clojure (#118) and Java (#120) contracts; uses Format A structural-refs so the resolver disambiguates handlers across components that share method names.
- 9 new test cases in `relationships_test.go`; full razor package now has 41 test cases. Full repo `go test ./...` is green.

## What was added vs deferred
- Added: IMPORTS (`@using`), CALLS (within event-handler bodies), CONTAINS (component → event_handler).
- Deferred: CALLS from `@functions { }` blocks (existing extractor only knows the `@code { }` block — same Razor semantics, but a separate parsing pass would be needed); CALLS from inline `@Expr` interpolations in markup; CONTAINS for parameters (parameter Kind is `SCOPE.Component`, no Format A ref defined for non-operations).

## Test plan
- [x] `go test ./internal/extractors/razor/...` — 41/41 pass
- [x] `go test ./...` — full suite green
- [x] Fixtures unchanged (Counter / EmptyComponent / WithInject still parse)

Closes #378

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>

Generated with [Claude Code](https://claude.com/claude-code)