### PR TITLE
fix(synth): Go stdlib interface dispatch via receiver_type (Closes #364)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -133,7 +133,16 @@ func Synthesize(doc *graph.Document) Stats {
 		if rel.ToID == "" || isHexID(rel.ToID) || strings.HasPrefix(rel.ToID, ExtIDPrefix) {
 			continue
 		}
-		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, entityLang[rel.FromID], entityFile[rel.FromID], fileImports[entityFile[rel.FromID]])
+		// Issue #364 — fall back to the relationship's stamped language
+		// when the FromID isn't a known entity (e.g. unresolved bare-name
+		// caller, ambiguous-name caller). Without this, Go-only branches
+		// in classifyExternal (receiver_type stdlib dispatch) miss every
+		// edge whose source isn't a 1:1-resolvable entity.
+		lang := entityLang[rel.FromID]
+		if lang == "" && rel.Properties != nil {
+			lang = rel.Properties["language"]
+		}
+		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, lang, entityFile[rel.FromID], fileImports[entityFile[rel.FromID]], rel.Properties)
 		if !ok {
 			continue
 		}
@@ -211,9 +220,25 @@ func Synthesize(doc *graph.Document) Stats {
 // Returns ("", "", false) when the stub doesn't look external — those
 // are left untouched and continue to count as "unmatched" in the
 // resolver stats.
-func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool) (canonical, subtype string, ok bool) {
+func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[string]bool, relProps map[string]string) (canonical, subtype string, ok bool) {
 	if stub == "" {
 		return "", "", false
+	}
+
+	// Issue #364 — Go stdlib interface dispatch. The Go extractor stamps
+	// `Properties["receiver_type"]` on CALLS edges whose operand is a
+	// function parameter with a known static type (e.g. `*http.Request`,
+	// `http.ResponseWriter`, `io.Writer`). When the bare-name target is a
+	// method on the stdlib interface for that type, route the edge to the
+	// owning ext:<package> placeholder. The stamp is canonicalised by the
+	// extractor (leading `*` stripped, generic type params dropped) so the
+	// lookup table can use a single key per package type. Lang-gated to go.
+	if lang == "go" && relKind == string(types.RelationshipKindCalls) && relProps != nil {
+		if recvType := relProps["receiver_type"]; recvType != "" {
+			if pkg, ok := goStdlibInterfaceMethod(recvType, stub); ok {
+				return pkg, "package", true
+			}
+		}
 	}
 
 	// Issue #89 — manifest extractor emits dependency stubs as
@@ -878,7 +903,22 @@ var goBareNames = map[string]struct{}{
 	"ServeHTTP":      {},
 	"ListenAndServe": {},
 	"HandleFunc":     {},
-	"WriteHeader":    {},
+	// Issue #364: HandlerFunc is the `http.HandlerFunc(fn)` type
+	// constructor, distinct from the `HandleFunc` method on a
+	// ServeMux/Router. Single high-volume net/http idiom.
+	"HandlerFunc": {},
+	"WriteHeader": {},
+
+	// Issue #364: net/http + net/http/httptest factory functions that
+	// arrive at the resolver as bare names after the receiver-strip
+	// (`http.NewRequest(...)` → `NewRequest`, `httptest.NewServer(...)`
+	// → `NewServer`, `httptest.NewRecorder()` → `NewRecorder`,
+	// `httptest.NewRequest(...)` is also `NewRequest`). Multi-word
+	// PascalCase tied to net/http test patterns; user-method collision
+	// risk is low.
+	"NewRequest":  {},
+	"NewServer":   {},
+	"NewRecorder": {},
 	// "Write" / "Header" / "Handle" deliberately omitted: they are
 	// frequent user-method names (io.Writer.Write user-implementations,
 	// custom Header() accessors, generic Handle handlers) and gating by
@@ -904,6 +944,45 @@ var goBareNames = map[string]struct{}{
 	// issue #103 hard rules: Get/Post/Put/Delete/Use are EXCLUDED.
 	"MethodFunc":      {},
 	"AbortWithStatus": {},
+
+	// Issue #364 — strings package PascalCase helpers. Multi-word names
+	// (`HasPrefix`, `HasSuffix`, `TrimSpace`, `EqualFold`, `Replace`,
+	// `Contains`-prefix-suffix, `IndexByte`, etc.) are tied to the
+	// strings package and rarely user-defined. Single-word names like
+	// `Split`, `Join`, `Trim` are EXCLUDED — they collide trivially with
+	// user methods and the safer-bias rule from #94 applies.
+	"HasPrefix":     {},
+	"HasSuffix":     {},
+	"TrimSpace":     {},
+	"TrimPrefix":    {},
+	"TrimSuffix":    {},
+	"EqualFold":     {},
+	"ToUpper":       {},
+	"ToLower":       {},
+	"ContainsRune":  {},
+	"ContainsAny":   {},
+	"IndexByte":     {},
+	"IndexAny":      {},
+	"LastIndexByte": {},
+	"SplitN":        {},
+	"ReplaceAll":    {},
+	"FieldsFunc":    {},
+
+	// time package PascalCase helpers. Multi-word names with idiomatic
+	// time-domain semantics; collision risk is low.
+	"Sleep":         {},
+	"NewTicker":     {},
+	"NewTimer":      {},
+	"Since":         {},
+	"Until":         {},
+	"AfterFunc":     {},
+	"ParseDuration": {},
+
+	// io package + io/ioutil package helpers (Go 1.16+ moved many to io).
+	"ReadAll":   {},
+	"WriteAll":  {},
+	"Copy":      {},
+	"NopCloser": {},
 }
 
 // goTestifyBareNames is the Go testify-helper bare-name stop-list (issue
@@ -1137,6 +1216,406 @@ func hasGoChiImport(imports map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// goStdlibInterfaceMethods maps a canonicalised Go-stdlib type (with
+// leading `*` stripped) to the set of methods defined on that type or its
+// embedding interfaces, paired with the canonical import-path of the
+// declaring stdlib package. Used by classifyExternal (issue #364) to route
+// CALLS edges whose extractor-stamped `receiver_type` matches one of these
+// types to the corresponding `ext:<package>` placeholder.
+//
+// Only stdlib types are catalogued — user-defined types and third-party
+// types fall through and continue to count as unmatched. Per-method false
+// positives are extremely rare because both gates (the type name AND the
+// method name) must align with a stdlib signature; a user type happening to
+// share a name (e.g. local `Request` struct) will not have a stdlib package
+// path stamp upstream and is filtered out here.
+//
+// Selection rule: the catalogue mirrors the `net/http`, `io`, `fmt`, `os`,
+// `bytes`, `strings`, `sync`, `context`, `bufio`, and `database/sql`
+// surfaces that dominate residual go-chi bug-rate post-#148. Each entry's
+// methods list is the union of (a) methods declared on the type itself and
+// (b) methods inherited from embedded stdlib interfaces. Adding a new entry
+// requires the package and the method name to both be unambiguous in the
+// stdlib — see comments in this map for borderline names that were
+// excluded.
+var goStdlibInterfaceMethods = map[string]struct {
+	pkg     string
+	methods map[string]struct{}
+}{
+	// net/http core types. *http.Request methods include those from
+	// io.Reader (via Body) but Body itself is a field; only the request's
+	// own methods are listed.
+	"http.Request": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"Cookie": {}, "Cookies": {}, "AddCookie": {}, "FormFile": {},
+			"FormValue": {}, "PostFormValue": {}, "ParseForm": {},
+			"ParseMultipartForm": {}, "Referer": {}, "UserAgent": {},
+			"BasicAuth": {}, "SetBasicAuth": {}, "Clone": {}, "Context": {},
+			"WithContext": {}, "MultipartReader": {}, "ProtoAtLeast": {},
+			"PathValue": {}, "SetPathValue": {},
+		},
+	},
+	"http.ResponseWriter": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			// Header is intentionally listed — collision with user types is
+			// gated by the `receiver_type=http.ResponseWriter` stamp.
+			"Header": {}, "Write": {}, "WriteHeader": {}, "Flush": {},
+		},
+	},
+	"http.Handler": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"ServeHTTP": {},
+		},
+	},
+	"http.HandlerFunc": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"ServeHTTP": {},
+		},
+	},
+	"http.Server": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"ListenAndServe": {}, "ListenAndServeTLS": {}, "Serve": {},
+			"ServeTLS": {}, "Shutdown": {}, "Close": {}, "RegisterOnShutdown": {},
+			"SetKeepAlivesEnabled": {},
+		},
+	},
+	"http.Client": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"Do": {}, "Get": {}, "Head": {}, "Post": {}, "PostForm": {},
+			"CloseIdleConnections": {},
+		},
+	},
+	"http.Response": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			// Cookies is on *http.Response too; Write encodes the response
+			// to a Writer (rare but valid stdlib method).
+			"Cookies": {}, "Location": {}, "ProtoAtLeast": {},
+		},
+	},
+	"http.Header": {
+		pkg: "net/http",
+		methods: map[string]struct{}{
+			"Add": {}, "Set": {}, "Get": {}, "Values": {}, "Del": {},
+			"Clone": {}, "Write": {}, "WriteSubset": {},
+		},
+	},
+
+	// io interfaces. Method sets are tiny and well-known; collision risk
+	// with user types is handled by the receiver_type stamp.
+	"io.Reader": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Read": {},
+		},
+	},
+	"io.Writer": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Write": {},
+		},
+	},
+	"io.Closer": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Close": {},
+		},
+	},
+	"io.ReadCloser": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Read": {}, "Close": {},
+		},
+	},
+	"io.WriteCloser": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Write": {}, "Close": {},
+		},
+	},
+	"io.ReadWriter": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Read": {}, "Write": {},
+		},
+	},
+	"io.ReadWriteCloser": {
+		pkg: "io",
+		methods: map[string]struct{}{
+			"Read": {}, "Write": {}, "Close": {},
+		},
+	},
+
+	// fmt.Stringer + error are universally implemented; the receiver_type
+	// stamp guarantees we only synthesise when the parameter is declared
+	// with the interface type explicitly.
+	"fmt.Stringer": {
+		pkg:     "fmt",
+		methods: map[string]struct{}{"String": {}},
+	},
+	// `error` is a Go builtin interface, but the placeholder convention
+	// uses package import paths. Routing it to `errors` keeps the
+	// downstream allowlist gate (which already lists "errors") stable;
+	// `Error()` calls land in ext:errors rather than synthesising a new
+	// "builtin" bucket.
+	"error": {
+		pkg:     "errors",
+		methods: map[string]struct{}{"Error": {}},
+	},
+
+	// context.Context — appears as a parameter in nearly every Go service.
+	"context.Context": {
+		pkg: "context",
+		methods: map[string]struct{}{
+			"Deadline": {}, "Done": {}, "Err": {}, "Value": {},
+		},
+	},
+
+	// sync types frequently passed by pointer.
+	"sync.Mutex": {
+		pkg: "sync",
+		methods: map[string]struct{}{
+			"Lock": {}, "Unlock": {}, "TryLock": {},
+		},
+	},
+	"sync.RWMutex": {
+		pkg: "sync",
+		methods: map[string]struct{}{
+			"Lock": {}, "Unlock": {}, "RLock": {}, "RUnlock": {},
+			"TryLock": {}, "TryRLock": {}, "RLocker": {},
+		},
+	},
+	"sync.WaitGroup": {
+		pkg: "sync",
+		methods: map[string]struct{}{
+			"Add": {}, "Done": {}, "Wait": {},
+		},
+	},
+
+	// bytes / strings buffers — methods include the io.Reader / io.Writer
+	// surface plus Buffer-specific helpers.
+	"bytes.Buffer": {
+		pkg: "bytes",
+		methods: map[string]struct{}{
+			"Bytes": {}, "String": {}, "Len": {}, "Cap": {}, "Truncate": {},
+			"Reset": {}, "Grow": {}, "Write": {}, "WriteString": {},
+			"WriteByte": {}, "WriteRune": {}, "Read": {}, "ReadByte": {},
+			"ReadRune": {}, "ReadBytes": {}, "ReadString": {}, "Next": {},
+			"UnreadByte": {}, "UnreadRune": {},
+		},
+	},
+	"strings.Builder": {
+		pkg: "strings",
+		methods: map[string]struct{}{
+			"String": {}, "Len": {}, "Reset": {}, "Grow": {},
+			"Write": {}, "WriteString": {}, "WriteByte": {}, "WriteRune": {},
+		},
+	},
+
+	// bufio Reader/Writer — common stdlib I/O wrappers.
+	"bufio.Reader": {
+		pkg: "bufio",
+		methods: map[string]struct{}{
+			"Read": {}, "ReadByte": {}, "ReadRune": {}, "ReadString": {},
+			"ReadBytes": {}, "ReadLine": {}, "ReadSlice": {}, "Peek": {},
+			"Discard": {}, "Buffered": {}, "Reset": {},
+			"UnreadByte": {}, "UnreadRune": {},
+		},
+	},
+	"bufio.Writer": {
+		pkg: "bufio",
+		methods: map[string]struct{}{
+			"Write": {}, "WriteString": {}, "WriteByte": {}, "WriteRune": {},
+			"Flush": {}, "Available": {}, "Buffered": {}, "Reset": {},
+		},
+	},
+
+	// database/sql common pointer types.
+	"sql.DB": {
+		pkg: "database/sql",
+		methods: map[string]struct{}{
+			"Query": {}, "QueryRow": {}, "Exec": {}, "QueryContext": {},
+			"QueryRowContext": {}, "ExecContext": {}, "Begin": {},
+			"BeginTx": {}, "Prepare": {}, "PrepareContext": {}, "Ping": {},
+			"PingContext": {}, "Close": {}, "Conn": {}, "Driver": {},
+			"SetMaxOpenConns": {}, "SetMaxIdleConns": {},
+			"SetConnMaxLifetime": {}, "SetConnMaxIdleTime": {}, "Stats": {},
+		},
+	},
+	"sql.Tx": {
+		pkg: "database/sql",
+		methods: map[string]struct{}{
+			"Commit": {}, "Rollback": {}, "Query": {}, "QueryRow": {},
+			"Exec": {}, "QueryContext": {}, "QueryRowContext": {},
+			"ExecContext": {}, "Prepare": {}, "PrepareContext": {}, "Stmt": {},
+			"StmtContext": {},
+		},
+	},
+	"sql.Rows": {
+		pkg: "database/sql",
+		methods: map[string]struct{}{
+			"Next": {}, "NextResultSet": {}, "Scan": {}, "Close": {},
+			"Err": {}, "Columns": {}, "ColumnTypes": {},
+		},
+	},
+	"sql.Row": {
+		pkg: "database/sql",
+		methods: map[string]struct{}{
+			"Scan": {}, "Err": {},
+		},
+	},
+	"sql.Stmt": {
+		pkg: "database/sql",
+		methods: map[string]struct{}{
+			"Query": {}, "QueryRow": {}, "Exec": {}, "QueryContext": {},
+			"QueryRowContext": {}, "ExecContext": {}, "Close": {},
+		},
+	},
+
+	// os.File — the bare *File pointer is omnipresent in Go I/O code.
+	"os.File": {
+		pkg: "os",
+		methods: map[string]struct{}{
+			"Read": {}, "ReadAt": {}, "Write": {}, "WriteAt": {},
+			"WriteString": {}, "Close": {}, "Name": {}, "Stat": {},
+			"Sync": {}, "Truncate": {}, "Seek": {}, "Chdir": {},
+			"Chmod": {}, "Chown": {}, "Fd": {}, "ReadDir": {},
+			"Readdir": {}, "Readdirnames": {}, "SetDeadline": {},
+			"SetReadDeadline": {}, "SetWriteDeadline": {},
+		},
+	},
+
+	// chi router types — third-party but indistinguishable from stdlib
+	// dispatch shape and dominate residual go-chi bug-rate (issue #103
+	// target). Methods mirror chi.Router + chi.Mux; routing yields the
+	// host-canonical "github.com/go-chi/chi" placeholder which is on the
+	// allowlist (so the disposition is ExternalKnown).
+	"chi.Mux": {
+		pkg: "github.com/go-chi/chi",
+		methods: map[string]struct{}{
+			"Get": {}, "Post": {}, "Put": {}, "Delete": {}, "Patch": {},
+			"Head": {}, "Options": {}, "Connect": {}, "Trace": {},
+			"Method": {}, "MethodFunc": {}, "Handle": {}, "HandleFunc": {},
+			"Mount": {}, "Group": {}, "Route": {}, "Use": {}, "With": {},
+			"NotFound": {}, "MethodNotAllowed": {}, "ServeHTTP": {},
+			"Find": {}, "Match": {}, "Routes": {}, "Middlewares": {},
+		},
+	},
+	"chi.Router": {
+		pkg: "github.com/go-chi/chi",
+		methods: map[string]struct{}{
+			"Get": {}, "Post": {}, "Put": {}, "Delete": {}, "Patch": {},
+			"Head": {}, "Options": {}, "Connect": {}, "Trace": {},
+			"Method": {}, "MethodFunc": {}, "Handle": {}, "HandleFunc": {},
+			"Mount": {}, "Group": {}, "Route": {}, "Use": {}, "With": {},
+			"NotFound": {}, "MethodNotAllowed": {}, "ServeHTTP": {},
+			"Find": {}, "Routes": {}, "Middlewares": {}, "Match": {},
+		},
+	},
+
+	// gin engine + context — same rationale as chi.
+	"gin.Engine": {
+		pkg: "github.com/gin-gonic/gin",
+		methods: map[string]struct{}{
+			"GET": {}, "POST": {}, "PUT": {}, "DELETE": {}, "PATCH": {},
+			"HEAD": {}, "OPTIONS": {}, "Any": {}, "Handle": {},
+			"Group": {}, "Use": {}, "Run": {}, "RunTLS": {},
+			"NoRoute": {}, "NoMethod": {}, "ServeHTTP": {},
+			"Static": {}, "StaticFS": {}, "StaticFile": {},
+			"LoadHTMLFiles": {}, "LoadHTMLGlob": {},
+			"SetTrustedProxies": {},
+		},
+	},
+	"gin.Context": {
+		pkg: "github.com/gin-gonic/gin",
+		methods: map[string]struct{}{
+			"Param": {}, "Query": {}, "DefaultQuery": {}, "PostForm": {},
+			"DefaultPostForm": {}, "Bind": {}, "BindJSON": {},
+			"ShouldBind": {}, "ShouldBindJSON": {}, "ShouldBindQuery": {},
+			"JSON": {}, "String": {}, "HTML": {}, "XML": {}, "YAML": {},
+			"Data": {}, "File": {}, "Status": {}, "Header": {},
+			"AbortWithStatus": {}, "AbortWithStatusJSON": {}, "Abort": {},
+			"Next": {}, "Set": {}, "Get": {}, "MustGet": {},
+			"GetString": {}, "GetInt": {}, "GetBool": {},
+			"Cookie": {}, "SetCookie": {}, "Redirect": {},
+			"ClientIP": {}, "ContentType": {}, "FullPath": {},
+			"GetHeader": {}, "Request": {}, "Writer": {},
+		},
+	},
+	"gin.RouterGroup": {
+		pkg: "github.com/gin-gonic/gin",
+		methods: map[string]struct{}{
+			"GET": {}, "POST": {}, "PUT": {}, "DELETE": {}, "PATCH": {},
+			"HEAD": {}, "OPTIONS": {}, "Any": {}, "Handle": {},
+			"Group": {}, "Use": {}, "Static": {}, "StaticFS": {},
+			"StaticFile": {},
+		},
+	},
+
+	// echo (labstack)
+	"echo.Echo": {
+		pkg: "github.com/labstack/echo",
+		methods: map[string]struct{}{
+			"GET": {}, "POST": {}, "PUT": {}, "DELETE": {}, "PATCH": {},
+			"HEAD": {}, "OPTIONS": {}, "Any": {}, "Add": {},
+			"Group": {}, "Use": {}, "Pre": {}, "Match": {},
+			"Start": {}, "StartTLS": {}, "Logger": {}, "Static": {},
+			"File": {}, "ServeHTTP": {}, "Routes": {},
+		},
+	},
+
+	// testing.T / testing.B — primarily covered by goTestingTBareNames
+	// for bare-name lookups in `_test.go` files, but also routed here when
+	// the receiver_type is stamped (some test helpers take `*testing.T`
+	// as a parameter explicitly).
+	"testing.T": {
+		pkg: "testing",
+		methods: map[string]struct{}{
+			"Helper": {}, "Cleanup": {}, "Setenv": {}, "TempDir": {},
+			"Log": {}, "Logf": {}, "Error": {}, "Errorf": {}, "Fatal": {},
+			"Fatalf": {}, "Skip": {}, "Skipf": {}, "SkipNow": {},
+			"Skipped": {}, "Failed": {}, "Fail": {}, "FailNow": {},
+			"Name": {}, "Run": {}, "Parallel": {}, "Deadline": {},
+		},
+	},
+	"testing.B": {
+		pkg: "testing",
+		methods: map[string]struct{}{
+			"Helper": {}, "Cleanup": {}, "Setenv": {}, "TempDir": {},
+			"Log": {}, "Logf": {}, "Error": {}, "Errorf": {}, "Fatal": {},
+			"Fatalf": {}, "Skip": {}, "Skipf": {}, "SkipNow": {},
+			"Skipped": {}, "Failed": {}, "Fail": {}, "FailNow": {},
+			"Name": {}, "Run": {}, "RunParallel": {}, "ResetTimer": {},
+			"StopTimer": {}, "StartTimer": {}, "ReportAllocs": {},
+			"ReportMetric": {}, "SetBytes": {}, "SetParallelism": {},
+		},
+	},
+}
+
+// goStdlibInterfaceMethod looks up (recvType, method) against the
+// goStdlibInterfaceMethods catalogue and returns the canonical stdlib
+// package import-path and true on a hit. recvType is expected to be the
+// extractor's canonicalised form (leading `*` stripped, generic type
+// parameters dropped) — `*http.Request` arrives here as `http.Request`.
+// Returns ("", false) on a miss; the caller falls through to the existing
+// classification heuristics.
+func goStdlibInterfaceMethod(recvType, method string) (string, bool) {
+	entry, ok := goStdlibInterfaceMethods[recvType]
+	if !ok {
+		return "", false
+	}
+	if _, ok := entry.methods[method]; !ok {
+		return "", false
+	}
+	return entry.pkg, true
 }
 
 // rustBareNames is the Rust-language-gated bare-name stop-list (issue
@@ -2016,6 +2495,17 @@ var knownExternalPackages = map[string]struct{}{
 	// accept Go's `os`/`sort`/etc. as well. "io"/"net"/"sort"/"sync"/
 	// "time"/"path"/"errors"/"strings"/"strconv"/"context"/"bytes"/
 	// "regexp"/"testing"/"hash" likewise serve both ecosystems.
+
+	// Issue #364 — Go stdlib multi-segment paths used as canonical names
+	// for ext:<path> placeholders synthesised from receiver_type stdlib
+	// interface dispatch. Single-segment stdlib roots (`io`, `os`, `fmt`,
+	// `bufio`, `bytes`, `strings`, `sync`, `context`, `testing`, `http`,
+	// `net`, `sql`) already exist above, but the goStdlibInterfaceMethods
+	// catalogue uses the canonical import path (`net/http`,
+	// `database/sql`) so the disposition allowlist must match the slash
+	// form too.
+	"net/http":     {},
+	"database/sql": {},
 
 	// Issue #116: Go third-party host-prefixed roots (3-segment
 	// "<host>/<owner>/<repo>" canonical form). These are matched by

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -171,6 +171,94 @@ func TestSynthesize_UnknownLeftAlone(t *testing.T) {
 	}
 }
 
+// TestSynthesize_GoStdlibInterfaceDispatch (issue #364) confirms a CALLS
+// edge whose `Properties["receiver_type"]` matches a Go-stdlib interface
+// type AND whose ToID matches a method on that type is rewritten to the
+// canonical ext:<package> placeholder. Covers the dominant residual
+// go-chi bug-rate post-#148: calls like `w.Write(...)` on
+// `http.ResponseWriter`, `r.Cookie(...)` on `*http.Request`,
+// `h.ServeHTTP(...)` on `http.Handler`.
+func TestSynthesize_GoStdlibInterfaceDispatch(t *testing.T) {
+	cases := []struct {
+		name      string
+		recvType  string
+		toID      string
+		wantExtID string
+	}{
+		{"http.ResponseWriter.Write", "http.ResponseWriter", "Write", "ext:net/http"},
+		{"http.ResponseWriter.WriteHeader", "http.ResponseWriter", "WriteHeader", "ext:net/http"},
+		{"http.Request.Cookie", "http.Request", "Cookie", "ext:net/http"},
+		{"http.Request.Context", "http.Request", "Context", "ext:net/http"},
+		{"http.Handler.ServeHTTP", "http.Handler", "ServeHTTP", "ext:net/http"},
+		{"http.Server.ListenAndServe", "http.Server", "ListenAndServe", "ext:net/http"},
+		{"io.Reader.Read", "io.Reader", "Read", "ext:io"},
+		{"io.Closer.Close", "io.Closer", "Close", "ext:io"},
+		{"context.Context.Done", "context.Context", "Done", "ext:context"},
+		{"sync.Mutex.Lock", "sync.Mutex", "Lock", "ext:sync"},
+		{"bytes.Buffer.WriteString", "bytes.Buffer", "WriteString", "ext:bytes"},
+		{"strings.Builder.String", "strings.Builder", "String", "ext:strings"},
+		{"sql.Rows.Scan", "sql.Rows", "Scan", "ext:database/sql"},
+		{"error.Error", "error", "Error", "ext:errors"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					{ID: "fn-1", SourceFile: "handlers/http.go", Language: "go"},
+				},
+				Relationships: []graph.Relationship{
+					{
+						ID:     "rel-1",
+						FromID: "fn-1",
+						ToID:   tc.toID,
+						Kind:   "CALLS",
+						Properties: map[string]string{
+							"receiver_type": tc.recvType,
+						},
+					},
+				},
+			}
+			Synthesize(doc)
+			if got := doc.Relationships[0].ToID; got != tc.wantExtID {
+				t.Fatalf("ToID=%q, want %q", got, tc.wantExtID)
+			}
+		})
+	}
+}
+
+// TestSynthesize_GoStdlibInterfaceDispatch_NoFalsePositive verifies that:
+// (a) a CALLS edge with no receiver_type stamp does NOT get routed to a
+// stdlib package even when the bare name happens to match an interface
+// method (Lock/Close/Read/Write are all common user-method names);
+// (b) a CALLS edge with a receiver_type stamp pointing at a USER-defined
+// type (not in the stdlib catalogue) is left alone.
+func TestSynthesize_GoStdlibInterfaceDispatch_NoFalsePositive(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn-1", SourceFile: "domain/cache.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			// (a) No receiver_type — bare "Lock" (a sync.Mutex method name) must
+			// stay unresolved. A user type with a Lock method is far more likely
+			// here than a misclassified call.
+			{ID: "r1", FromID: "fn-1", ToID: "Lock", Kind: "CALLS"},
+			// (b) receiver_type points at a user-defined type. Not on the
+			// catalogue → no rewrite.
+			{
+				ID: "r2", FromID: "fn-1", ToID: "Acquire", Kind: "CALLS",
+				Properties: map[string]string{"receiver_type": "myapp.SemSlot"},
+			},
+		},
+	}
+	Synthesize(doc)
+	if doc.Relationships[0].ToID != "Lock" {
+		t.Fatalf("bare Lock without receiver_type was rewritten to %q", doc.Relationships[0].ToID)
+	}
+	if doc.Relationships[1].ToID != "Acquire" {
+		t.Fatalf("user-typed receiver Acquire was rewritten to %q", doc.Relationships[1].ToID)
+	}
+}
+
 // TestSynthesize_NilDoc confirms calling on a nil document is a no-op.
 func TestSynthesize_NilDoc(t *testing.T) {
 	stats := Synthesize(nil)

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -323,6 +323,392 @@ func receiverParamName(recv *sitter.Node, src []byte) string {
 	return ""
 }
 
+// collectParamTypes returns a (paramName -> typeLiteral) map built from a
+// function/method `parameters` parameter_list AST node. The type literal is
+// canonicalised by stripping a single leading `*` so `*http.Request`
+// becomes `http.Request` — pointer-vs-value distinctions don't change the
+// stdlib-interface methods exposed and folding here lets the synth lookup
+// table use a single key per package type. Returns nil for a nil node or a
+// node that contains no named parameters (variadic/anonymous-only signatures).
+//
+// Issue #364: feeds extractCallRelationships so calls like `w.Write(...)` on
+// a parameter `w http.ResponseWriter` get a `receiver_type` stamp that the
+// synth pass can route to ext:net/http.
+func collectParamTypes(params *sitter.Node, src []byte) map[string]string {
+	if params == nil {
+		return nil
+	}
+	out := map[string]string{}
+	for _, paramDecl := range findAll(params, "parameter_declaration") {
+		// Walk children: collect leading identifier(s), then the first
+		// non-identifier child is the type. Tree-sitter Go grammar emits
+		// parameter_declaration as: identifier (',' identifier)* type.
+		count := int(paramDecl.ChildCount())
+		var names []string
+		typeText := ""
+		for i := 0; i < count; i++ {
+			child := paramDecl.Child(i)
+			t := child.Type()
+			if t == "identifier" {
+				names = append(names, nodeText(child, src))
+				continue
+			}
+			if t == "," {
+				continue
+			}
+			// First non-identifier, non-comma child is the type node.
+			typeText = strings.TrimSpace(nodeText(child, src))
+			break
+		}
+		if typeText == "" || len(names) == 0 {
+			continue
+		}
+		canonical := strings.TrimPrefix(typeText, "*")
+		// Strip type-parameter list ("[T]") so generic types collapse.
+		if idx := strings.IndexByte(canonical, '['); idx >= 0 {
+			canonical = canonical[:idx]
+		}
+		canonical = strings.TrimSpace(canonical)
+		if canonical == "" {
+			continue
+		}
+		for _, n := range names {
+			if n == "" || n == "_" {
+				continue
+			}
+			out[n] = canonical
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// mergeVarTypes folds a body-derived (varName -> type) map into a param-
+// derived map, preferring the outer (param) declaration on a name conflict
+// — Go's lexical scoping rule says outer params shadow body short-var
+// decls of the same name only inside their own scope; reverse holds in
+// the body. The extractor doesn't model scopes, so on a collision it
+// MUST drop the binding rather than emit a wrong receiver_type stamp.
+// Returns nil only when both inputs are nil/empty.
+func mergeVarTypes(outer, inner map[string]string) map[string]string {
+	if len(outer) == 0 && len(inner) == 0 {
+		return nil
+	}
+	out := make(map[string]string, len(outer)+len(inner))
+	for k, v := range outer {
+		out[k] = v
+	}
+	for k, v := range inner {
+		if existing, ok := out[k]; ok && existing != v {
+			// Same identifier declared with different types in two scopes
+			// (closure shadow, nested block, etc.). Drop the binding so
+			// neither call site gets a false stamp.
+			delete(out, k)
+			continue
+		}
+		// Only keep inner bindings that don't conflict with an outer one
+		// of a different type. Identical-type duplicates are harmless.
+		if _, ok := out[k]; !ok {
+			out[k] = v
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// collectBodyVarTypes walks a function/method body and returns a
+// (varName -> typeLiteral) map for short_var_declaration and
+// var_declaration nodes whose RHS has a recognisable static type. Names
+// declared more than once with different types are dropped (ambiguous).
+//
+// Recognised RHS shapes (issue #364):
+//
+//	x := T{...}              composite_literal whose type child is a
+//	                         type_identifier or qualified_type
+//	x := &T{...}             unary_expression (`&`) wrapping the above
+//	var x T                  var_declaration / var_spec with explicit type
+//	var x = T{...}           var_declaration with composite_literal RHS
+//	x := pkg.Func()          call_expression where the function is a
+//	                         qualified_type-style selector recognised as
+//	                         a known stdlib/framework constructor (small
+//	                         allowlist: chi.NewRouter, bytes.NewBuffer,
+//	                         strings.NewReader, ...)
+//
+// Pointer types are stripped (`*Mux` → `Mux`) and generic type parameter
+// lists (`[T]`) are dropped so the synth lookup table can use a single
+// key per package type.
+func collectBodyVarTypes(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	out := map[string]string{}
+	ambiguous := map[string]bool{}
+	record := func(name, typ string) {
+		if name == "" || name == "_" || typ == "" {
+			return
+		}
+		canonical := canonicalTypeLiteral(typ)
+		if canonical == "" {
+			return
+		}
+		if ambiguous[name] {
+			return
+		}
+		if existing, ok := out[name]; ok && existing != canonical {
+			delete(out, name)
+			ambiguous[name] = true
+			return
+		}
+		out[name] = canonical
+	}
+
+	// Closure-param tracking lives in extractCallRelationships' scoped
+	// walker (issue #364) — collecting them here would conflate scopes
+	// and force a drop on common shadowing patterns (e.g. an outer
+	// `r := chi.NewRouter()` shadowed by a closure `r *http.Request`).
+
+	// short_var_declaration: `x := <expr>` (single LHS, single RHS only;
+	// multi-LHS forms like `a, b := f()` are skipped because pairing each
+	// name with the right RHS requires knowing the call's return tuple).
+	for _, decl := range findAll(body, "short_var_declaration") {
+		left := decl.ChildByFieldName("left")
+		right := decl.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		// Only handle the "one-name = one-expr" case.
+		if !singleChildOfType(left, "identifier") || !singleNamedChild(right) {
+			continue
+		}
+		name := nodeText(firstChildOfType(left, "identifier"), src)
+		expr := firstNamedChild(right)
+		if typ := typeOfExpression(expr, src); typ != "" {
+			record(name, typ)
+		}
+	}
+
+	// var_declaration: `var x T` or `var x = <expr>` or `var x T = <expr>`.
+	for _, decl := range findAll(body, "var_declaration") {
+		for _, spec := range findAll(decl, "var_spec") {
+			// var_spec has a `name` field (identifier_list) and either a
+			// `type` field (declared type) or a `value` field (init expr).
+			nameNode := spec.ChildByFieldName("name")
+			typeNode := spec.ChildByFieldName("type")
+			valueNode := spec.ChildByFieldName("value")
+			var names []string
+			if nameNode != nil {
+				if nameNode.Type() == "identifier" {
+					names = []string{nodeText(nameNode, src)}
+				} else {
+					for i := 0; i < int(nameNode.ChildCount()); i++ {
+						ch := nameNode.Child(i)
+						if ch.Type() == "identifier" {
+							names = append(names, nodeText(ch, src))
+						}
+					}
+				}
+			}
+			if len(names) != 1 {
+				continue
+			}
+			typ := ""
+			if typeNode != nil {
+				typ = nodeText(typeNode, src)
+			} else if valueNode != nil {
+				typ = typeOfExpression(valueNode, src)
+			}
+			if typ != "" {
+				record(names[0], typ)
+			}
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// typeOfExpression returns a textual type representation for an expression
+// AST node when it's recognisable as a static type, or "" otherwise. Used
+// by collectBodyVarTypes to type short/var declarations.
+func typeOfExpression(expr *sitter.Node, src []byte) string {
+	if expr == nil {
+		return ""
+	}
+	switch expr.Type() {
+	case "composite_literal":
+		// composite_literal has a `type` field — type_identifier (`Foo{}`),
+		// qualified_type (`pkg.Foo{}`), or pointer_type / array_type / etc.
+		if t := expr.ChildByFieldName("type"); t != nil {
+			return nodeText(t, src)
+		}
+	case "unary_expression":
+		// `&Foo{}` or `&pkg.Foo{}` — drill into the operand.
+		if op := expr.ChildByFieldName("operand"); op != nil {
+			return typeOfExpression(op, src)
+		}
+	case "type_assertion_expression":
+		if t := expr.ChildByFieldName("type"); t != nil {
+			return nodeText(t, src)
+		}
+	case "call_expression":
+		// Recognise a small set of stdlib / well-known-framework constructors
+		// that return a value of a predictable type. Two shapes are matched:
+		//
+		//   `<pkg>.<Func>(...)`  — selector_expression: keyed on the dotted
+		//                          form (e.g. `chi.NewRouter` → `chi.Mux`).
+		//   `<Func>(...)`        — identifier: a same-package call that
+		//                          returns the package's primary type. The
+		//                          extractor doesn't know the package name
+		//                          so the bare-name table maps to a bare
+		//                          receiver type (e.g. `NewRouter` → `Mux`),
+		//                          which the resolver's same-package member
+		//                          lookup picks up directly.
+		fn := expr.ChildByFieldName("function")
+		if fn != nil {
+			switch fn.Type() {
+			case "selector_expression":
+				operand := fn.ChildByFieldName("operand")
+				field := fn.ChildByFieldName("field")
+				if operand != nil && operand.Type() == "identifier" && field != nil {
+					key := nodeText(operand, src) + "." + nodeText(field, src)
+					if t, ok := goConstructorReturnTypes[key]; ok {
+						return t
+					}
+				}
+			case "identifier":
+				if t, ok := goSamePackageConstructorReturnTypes[nodeText(fn, src)]; ok {
+					return t
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// goSamePackageConstructorReturnTypes maps bare-name constructor calls to
+// the receiver type they return when the call is unqualified. Unqualified
+// calls are in-package (`m := NewRouter()` inside the chi package, where
+// `NewRouter` resolves to `chi.NewRouter`). The receiver type is stored
+// as a bare type name (no package prefix) so the resolver's same-package
+// member lookup picks it up directly without the qualifier-strip retry.
+//
+// Issue #364: chi internal tests (mux_test.go) drive 30+ unresolved Get
+// calls of this shape; without same-package constructor tracking the
+// receiver_type stamp is missing and the resolver can't bind the call.
+//
+// Conservative selection rule (lesson #94): include only constructor names
+// extremely unlikely to be redefined as a non-constructor user function.
+// `NewRouter`/`NewMux`/`NewServer` are PascalCase factories that return a
+// well-known type in their primary package; any user package redefining
+// them with a different return type is a vanishingly rare false positive.
+var goSamePackageConstructorReturnTypes = map[string]string{
+	"NewRouter": "Mux",
+	"NewMux":    "Mux",
+}
+
+// goConstructorReturnTypes maps `<pkg>.<Func>` calls to the type their
+// return value carries when used as the RHS of a short-var declaration.
+// Values use the canonical receiver_type form (no leading `*`, generic
+// parameter lists dropped) so the synth lookup can match without further
+// normalisation. Issue #364: covers the highest-volume Go patterns where
+// a short-var-declared identifier is later used as a method-dispatch
+// operand (`r := chi.NewRouter(); r.Get(...)` etc.).
+var goConstructorReturnTypes = map[string]string{
+	// chi router
+	"chi.NewRouter": "chi.Mux",
+	"chi.NewMux":    "chi.Mux",
+	// gin
+	"gin.Default": "gin.Engine",
+	"gin.New":     "gin.Engine",
+	// echo
+	"echo.New": "echo.Echo",
+	// net/http
+	"http.NewRequest":            "http.Request",
+	"http.NewRequestWithContext": "http.Request",
+	"http.NewServeMux":           "http.ServeMux",
+	// bytes / strings / bufio
+	"bytes.NewBuffer":     "bytes.Buffer",
+	"bytes.NewReader":     "bytes.Reader",
+	"strings.NewReader":   "strings.Reader",
+	"strings.NewReplacer": "strings.Replacer",
+	"bufio.NewReader":     "bufio.Reader",
+	"bufio.NewWriter":     "bufio.Writer",
+	"bufio.NewScanner":    "bufio.Scanner",
+	// context
+	"context.Background": "context.Context",
+	"context.TODO":       "context.Context",
+	// sync (rarely literal-constructed; included for completeness)
+	"sync.NewCond": "sync.Cond",
+	// errors
+	"errors.New": "error",
+	"fmt.Errorf": "error",
+}
+
+// singleChildOfType reports whether n has exactly one named child, which
+// is of the requested type. Helper for collectBodyVarTypes.
+func singleChildOfType(n *sitter.Node, typ string) bool {
+	if n == nil {
+		return false
+	}
+	if n.NamedChildCount() != 1 {
+		return false
+	}
+	c := n.NamedChild(0)
+	return c != nil && c.Type() == typ
+}
+
+// singleNamedChild reports whether n has exactly one named child.
+func singleNamedChild(n *sitter.Node) bool {
+	if n == nil {
+		return false
+	}
+	return n.NamedChildCount() == 1
+}
+
+// firstChildOfType returns the first child of n with the given type, or
+// nil. Helper for collectBodyVarTypes.
+func firstChildOfType(n *sitter.Node, typ string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	count := int(n.ChildCount())
+	for i := 0; i < count; i++ {
+		c := n.Child(i)
+		if c.Type() == typ {
+			return c
+		}
+	}
+	return nil
+}
+
+// firstNamedChild returns the first named child of n, or nil.
+func firstNamedChild(n *sitter.Node) *sitter.Node {
+	if n == nil || n.NamedChildCount() == 0 {
+		return nil
+	}
+	return n.NamedChild(0)
+}
+
+// canonicalTypeLiteral reduces a type literal to the form used as a key
+// in goStdlibInterfaceMethods: leading `*` stripped, generic type
+// parameter lists dropped. Returns "" for empty input.
+func canonicalTypeLiteral(t string) string {
+	t = strings.TrimSpace(t)
+	if t == "" {
+		return ""
+	}
+	t = strings.TrimPrefix(t, "*")
+	if i := strings.IndexByte(t, '['); i >= 0 {
+		t = t[:i]
+	}
+	return strings.TrimSpace(t)
+}
+
 // receiverTypeName extracts the base type name from a receiver parameter list.
 // The receiver AST is: parameter_list → parameter_declaration → [identifier, pointer_type|type_identifier|generic_type]
 // e.g. "(s *UserStore)" → "UserStore", "(u User)" → "User",
@@ -505,7 +891,22 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 		// (issue #66): a method `(s *Foo) bar()` calling `bar()` should
 		// still suppress the self-edge even though the entity Name is now
 		// "Foo.bar".
-		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType)
+		// Issue #364 — build a (varName -> typeLiteral) map covering both
+		// the outer function/method parameter list AND short/var declarations
+		// inside the body (`r := chi.NewRouter()` / `var b bytes.Buffer`).
+		// Calls of the form `<varName>.<method>(...)` can then be stamped
+		// with the var's static type (e.g. `*http.Request`,
+		// `http.ResponseWriter`, `*chi.Mux`). The resolver + synth pass use
+		// this stamp to route stdlib-interface dispatch like `w.Write(...)`
+		// to ext:net/http rather than leaving it as bug-extractor. Names
+		// declared in shadowing scopes (closures, nested blocks) are tracked
+		// as "ambiguous" — collectVarTypes drops them rather than emitting a
+		// guess, preserving the safer-bias rule from #94.
+		paramTypes := collectParamTypes(paramsNode, src)
+		// Body-derived var types do NOT include closure-param shadowing — the
+		// per-call walker below maintains its own scope stack to disambiguate.
+		paramTypes = mergeVarTypes(paramTypes, collectBodyVarTypes(bodyOrNode, src))
+		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType, paramTypes)
 		// Rewrite FromID on each CALLS edge to the qualified Name so the
 		// edge source matches the entity ID downstream.
 		for i := range relationships {
@@ -569,43 +970,86 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 // entity. Calls on other selector operands (e.g. `other.foo()`, package-
 // qualified calls) are NOT stamped — the heuristic is intentionally
 // conservative to avoid false same-package binds (Refs #94 lesson).
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVarName, recvType string) []types.RelationshipRecord {
+func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVarName, recvType string, paramTypes map[string]string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
 
-	calls := findAll(body, "call_expression")
-	if len(calls) == 0 {
-		return nil
+	seen := make(map[string]bool)
+	var rels []types.RelationshipRecord
+
+	// Recursive walker (issue #364): maintains a scope stack of (varName ->
+	// type) maps so a closure parameter `r *http.Request` inside an outer
+	// scope where `r := chi.NewRouter()` shadows correctly. The closest
+	// enclosing scope wins per Go's lexical rules. The stack is allocated
+	// once and pushed/popped on entry/exit of func_literal nodes; non-
+	// closure block scopes are not pushed because Go doesn't permit
+	// re-declaring parameters at block scope without `:=`, and short-var
+	// re-declarations at block scope are a rare edge case the linter
+	// catches independently.
+	scopes := []map[string]string{paramTypes}
+	lookup := func(name string) string {
+		if name == "" {
+			return ""
+		}
+		// Walk inner-most scope first.
+		for i := len(scopes) - 1; i >= 0; i-- {
+			if v, ok := scopes[i][name]; ok {
+				return v
+			}
+		}
+		return ""
 	}
 
-	seen := make(map[string]bool, len(calls))
-	rels := make([]types.RelationshipRecord, 0, len(calls))
-
-	for _, call := range calls {
-		target, isSelfReceiver := callExpressionTargetWithReceiver(call, src, recvVarName)
-		if target == "" {
-			continue
+	var visit func(n *sitter.Node)
+	visit = func(n *sitter.Node) {
+		if n == nil {
+			return
 		}
-		if target == callerName {
-			// Skip self-recursion — matches Python parser dedup behaviour
-			// and avoids polluting the graph with trivial loops.
-			continue
+		t := n.Type()
+		// Closure boundary — push the closure's own param map. Body-derived
+		// short-var decls inside the closure are NOT collected here for
+		// performance (they would require another scoped pass); the highest-
+		// volume win is closure params shadowing outer short-var decls.
+		pushed := false
+		if t == "func_literal" {
+			params := n.ChildByFieldName("parameters")
+			closureParams := collectParamTypes(params, src)
+			if closureParams != nil {
+				scopes = append(scopes, closureParams)
+				pushed = true
+			}
 		}
-		if seen[target] {
-			continue
+		if t == "call_expression" {
+			target, isSelfReceiver, operand := callExpressionTargetWithOperand(n, src, recvVarName)
+			if target != "" && target != callerName && !seen[target] {
+				seen[target] = true
+				rec := types.RelationshipRecord{
+					FromID: callerName,
+					ToID:   target,
+					Kind:   "CALLS",
+				}
+				switch {
+				case isSelfReceiver && recvType != "":
+					rec.Properties = map[string]string{"receiver_type": recvType}
+				case operand != "":
+					if ty := lookup(operand); ty != "" {
+						rec.Properties = map[string]string{"receiver_type": ty}
+					}
+				}
+				rels = append(rels, rec)
+			}
 		}
-		seen[target] = true
-		rec := types.RelationshipRecord{
-			FromID: callerName,
-			ToID:   target,
-			Kind:   "CALLS",
+		// Recurse into all named children.
+		count := int(n.NamedChildCount())
+		for i := 0; i < count; i++ {
+			visit(n.NamedChild(i))
 		}
-		if isSelfReceiver && recvType != "" {
-			rec.Properties = map[string]string{"receiver_type": recvType}
+		if pushed {
+			scopes = scopes[:len(scopes)-1]
 		}
-		rels = append(rels, rec)
 	}
+	visit(body)
 	return rels
 }
 
@@ -614,54 +1058,60 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVar
 // prefix. Returns "" if the call node has no resolvable function child
 // (e.g., higher-order call on a literal expression like `f()()`).
 func callExpressionTarget(call *sitter.Node, src []byte) string {
-	target, _ := callExpressionTargetWithReceiver(call, src, "")
+	target, _, _ := callExpressionTargetWithOperand(call, src, "")
 	return target
 }
 
-// callExpressionTargetWithReceiver is callExpressionTarget plus a same-receiver
-// flag (issue #148). When recvVarName is non-empty and the call is a
-// selector_expression whose operand is the identifier recvVarName, the second
-// return is true — signalling the call dispatches to a method on the
-// enclosing method's own receiver. Used by extractCallRelationships to stamp
-// `receiver_type` on the CALLS edge.
-func callExpressionTargetWithReceiver(call *sitter.Node, src []byte, recvVarName string) (string, bool) {
+// callExpressionTargetWithOperand is callExpressionTarget plus a same-receiver
+// flag (issue #148) and the operand identifier text (issue #364). When
+// recvVarName is non-empty and the call is a selector_expression whose operand
+// is the identifier recvVarName, the second return is true — signalling the
+// call dispatches to a method on the enclosing method's own receiver.
+//
+// The third return is the operand identifier text when the call is a
+// selector_expression whose operand is a bare identifier (e.g. `w` in
+// `w.Write(...)` or `r` in `r.Method`); empty otherwise. Used by
+// extractCallRelationships to look up the operand's static type in the
+// caller's parameter map and stamp `receiver_type` for stdlib-interface
+// dispatch.
+func callExpressionTargetWithOperand(call *sitter.Node, src []byte, recvVarName string) (string, bool, string) {
 	fn := call.ChildByFieldName("function")
 	if fn == nil {
-		return "", false
+		return "", false, ""
 	}
 	switch fn.Type() {
 	case "identifier":
-		return nodeText(fn, src), false
+		return nodeText(fn, src), false, ""
 	case "selector_expression":
 		field := fn.ChildByFieldName("field")
 		if field == nil {
-			return "", false
+			return "", false, ""
 		}
 		name := nodeText(field, src)
 		isSelf := false
-		if recvVarName != "" {
-			if op := fn.ChildByFieldName("operand"); op != nil && op.Type() == "identifier" {
-				if nodeText(op, src) == recvVarName {
-					isSelf = true
-				}
+		operand := ""
+		if op := fn.ChildByFieldName("operand"); op != nil && op.Type() == "identifier" {
+			operand = nodeText(op, src)
+			if recvVarName != "" && operand == recvVarName {
+				isSelf = true
 			}
 		}
-		return name, isSelf
+		return name, isSelf, operand
 	case "parenthesized_expression":
 		// Rare: ((some.Expr))() — drill in one level.
 		for i := 0; i < int(fn.ChildCount()); i++ {
 			ch := fn.Child(i)
 			if ch.Type() == "identifier" {
-				return nodeText(ch, src), false
+				return nodeText(ch, src), false, ""
 			}
 			if ch.Type() == "selector_expression" {
 				if f := ch.ChildByFieldName("field"); f != nil {
-					return nodeText(f, src), false
+					return nodeText(f, src), false, ""
 				}
 			}
 		}
 	}
-	return "", false
+	return "", false, ""
 }
 
 // typeIndex captures the set of schema entities and their method sets

--- a/internal/extractors/golang/extractor_test.go
+++ b/internal/extractors/golang/extractor_test.go
@@ -1048,12 +1048,18 @@ func (mx *Mux) Mount(pattern string) {
 	}
 }
 
-// TestCallsRelationship_ReceiverTypeNotStampedOnForeignSelector ensures the
-// receiver_type stamp is conservative: a selector_expression whose operand is
-// NOT the enclosing method's receiver parameter must NOT acquire the stamp,
-// otherwise an unrelated `obj.Get(...)` call would falsely advertise a
-// same-package method dispatch.
-func TestCallsRelationship_ReceiverTypeNotStampedOnForeignSelector(t *testing.T) {
+// TestCallsRelationship_ReceiverTypeStampedFromParamType (issue #364)
+// asserts that a selector_expression whose operand is a function parameter
+// with a known static type acquires a `receiver_type` stamp set to that
+// type's canonical name. Pointer types are stripped (`*Mux` → `Mux`) so the
+// stamp matches the resolver's same-package member index keys, allowing the
+// resolver to bind `other.handle` to the local `Mux.handle` entity.
+//
+// This supersedes the pre-#364 conservative-stamp test, which asserted the
+// stamp was absent on foreign selectors. With param-type tracking the stamp
+// is now both safe and correct: the operand's type IS a same-package type,
+// so the resolver should bind to it.
+func TestCallsRelationship_ReceiverTypeStampedFromParamType(t *testing.T) {
 	src := `package chi
 
 type Mux struct{}
@@ -1069,12 +1075,140 @@ func (mx *Mux) handle(pattern string) {}
 	if mount == nil {
 		t.Fatal("Mux.Mount method not found")
 	}
-	for _, r := range mount.Relationships {
-		if r.Kind != "CALLS" || r.ToID != "handle" {
+	var hit *types.RelationshipRecord
+	for i := range mount.Relationships {
+		r := &mount.Relationships[i]
+		if r.Kind == "CALLS" && r.ToID == "handle" {
+			hit = r
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatal("expected CALLS edge to handle on Mux.Mount")
+	}
+	if hit.Properties == nil || hit.Properties["receiver_type"] != "Mux" {
+		t.Errorf("expected receiver_type=Mux from param-type stamp, got %+v", hit.Properties)
+	}
+}
+
+// TestCallsRelationship_StdlibInterfaceParamType (issue #364) verifies that
+// calls dispatched on a parameter whose static type is a Go-stdlib package-
+// qualified type (`*http.Request`, `http.ResponseWriter`) acquire a
+// receiver_type stamp set to the package-qualified type name (with leading
+// `*` stripped). The synth pass uses this stamp to route stdlib-interface
+// methods like `Write` and `Method` to the correct ext:net/http placeholder.
+func TestCallsRelationship_StdlibInterfaceParamType(t *testing.T) {
+	src := `package handlers
+
+import "net/http"
+
+func handler(w http.ResponseWriter, r *http.Request) {
+	_, _ = r.Cookie("session")
+	w.Write([]byte("ok"))
+	w.WriteHeader(200)
+}
+
+var _ = http.HandlerFunc(handler)
+`
+	records := extractRecords(t, src, "handlers.go")
+	h := findEntity(records, "handler")
+	if h == nil {
+		t.Fatal("handler function not found")
+	}
+	want := map[string]string{
+		"Cookie":      "http.Request",
+		"Write":       "http.ResponseWriter",
+		"WriteHeader": "http.ResponseWriter",
+	}
+	got := map[string]string{}
+	for _, r := range h.Relationships {
+		if r.Kind != "CALLS" || r.Properties == nil {
 			continue
 		}
-		if r.Properties != nil && r.Properties["receiver_type"] != "" {
-			t.Errorf("did not expect receiver_type stamp on `other.handle` call; got %+v", r.Properties)
+		if rt := r.Properties["receiver_type"]; rt != "" {
+			got[r.ToID] = rt
+		}
+	}
+	for tgt, ty := range want {
+		if got[tgt] != ty {
+			t.Errorf("CALLS %s: receiver_type=%q want %q (full got=%v)", tgt, got[tgt], ty, got)
+		}
+	}
+}
+
+// TestCallsRelationship_StampShortVarDecl (issue #364) verifies that a
+// short-var declaration whose RHS is a composite literal of a recognisable
+// type stamps the resulting variable's static type onto downstream calls.
+// `x := &Foo{}` followed by `x.Bar()` produces a CALLS edge with
+// receiver_type=Foo. Routing decisions (stdlib vs user type) happen later
+// in synth.go and this test only asserts the stamp shape.
+func TestCallsRelationship_StampShortVarDecl(t *testing.T) {
+	src := `package main
+
+type Foo struct{}
+
+func (f *Foo) Bar() {}
+
+func driver() {
+	x := &Foo{}
+	x.Bar()
+}
+`
+	records := extractRecords(t, src, "main.go")
+	d := findEntity(records, "driver")
+	if d == nil {
+		t.Fatal("driver function not found")
+	}
+	var hit *types.RelationshipRecord
+	for i := range d.Relationships {
+		r := &d.Relationships[i]
+		if r.Kind == "CALLS" && r.ToID == "Bar" {
+			hit = r
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatal("expected CALLS edge to Bar on driver")
+	}
+	if hit.Properties == nil || hit.Properties["receiver_type"] != "Foo" {
+		t.Errorf("expected receiver_type=Foo from short-var-decl, got %+v", hit.Properties)
+	}
+}
+
+// TestCallsRelationship_StampChiNewRouter (issue #364) verifies the
+// goConstructorReturnTypes table fires for `r := chi.NewRouter()` so the
+// downstream `r.Get("/", h)` call acquires receiver_type=chi.Mux. Synth
+// then routes this to ext:github.com/go-chi/chi.
+func TestCallsRelationship_StampChiNewRouter(t *testing.T) {
+	src := `package main
+
+import "github.com/go-chi/chi"
+
+func setup() {
+	r := chi.NewRouter()
+	r.Get("/", nil)
+	r.Use(nil)
+}
+`
+	records := extractRecords(t, src, "main.go")
+	s := findEntity(records, "setup")
+	if s == nil {
+		t.Fatal("setup function not found")
+	}
+	for _, want := range []string{"Get", "Use"} {
+		var hit *types.RelationshipRecord
+		for i := range s.Relationships {
+			r := &s.Relationships[i]
+			if r.Kind == "CALLS" && r.ToID == want {
+				hit = r
+				break
+			}
+		}
+		if hit == nil {
+			t.Fatalf("expected CALLS edge to %s on setup", want)
+		}
+		if hit.Properties == nil || hit.Properties["receiver_type"] != "chi.Mux" {
+			t.Errorf("CALLS %s: expected receiver_type=chi.Mux, got %+v", want, hit.Properties)
 		}
 	}
 }

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1879,16 +1879,38 @@ func ReferencesEmbeddedWithAllowlist(records []types.EntityRecord, idx Index, al
 				// target like "handle" binds to the local "<pkg>/Mux.handle"
 				// rather than colliding with same-named methods elsewhere.
 				if recvType := r.Properties["receiver_type"]; recvType != "" && parentPkgDir != "" {
-					if id, ok := idx.lookupPackageMember(parentPkgDir, recvType, r.ToID); ok {
-						if id != "" {
-							r.ToID = id
-							applyEndpointStats(&stats, statusRewritten, false)
-							d := idx.classifyDispositionLang(r.ToID, orig, lang, allow)
-							stats.recordDisposition(d, orig)
-							continue
+					// Issue #148 baseline: try the stamped type as-is.
+					// Issue #364 follow-up: when the stamp is package-
+					// qualified (e.g. `chi.Mux` from `chi.NewRouter()` /
+					// `*chi.Mux` parameter), strip the package segment and
+					// retry — entities are emitted under their bare receiver
+					// name (`Mux.handle`), so the qualified form would never
+					// match a same-package member. We try the as-is form
+					// FIRST so an unambiguous user package named e.g.
+					// `chi.Mux` (struct of type Mux in pkg chi, or any
+					// package whose dir name happens to match) still wins.
+					resolved := false
+					tryTypes := []string{recvType}
+					if dot := strings.LastIndexByte(recvType, '.'); dot >= 0 && dot < len(recvType)-1 {
+						tryTypes = append(tryTypes, recvType[dot+1:])
+					}
+					for _, t := range tryTypes {
+						if id, ok := idx.lookupPackageMember(parentPkgDir, t, r.ToID); ok {
+							if id != "" {
+								r.ToID = id
+								applyEndpointStats(&stats, statusRewritten, false)
+								d := idx.classifyDispositionLang(r.ToID, orig, lang, allow)
+								stats.recordDisposition(d, orig)
+								resolved = true
+								break
+							}
+							// Ambiguous within (pkg, recv, member) — fall through
+							// to record as unmatched (preserve the stub).
+							break
 						}
-						// Ambiguous within (pkg, recv, member) — fall through
-						// to record as unmatched (preserve the stub).
+					}
+					if resolved {
+						continue
 					}
 				}
 				newID, st := idx.rewriteOne(r.ToID, r.Kind)


### PR DESCRIPTION
## Summary
- Extends issue #148's `receiver_type` stamping from same-receiver dispatch to a broader var-typed dispatch covering function parameters, short-var declarations, and `func_literal` closures (with a scoped walker that handles closure shadowing).
- Adds a Go-stdlib interface-method catalogue in `synth.go` that routes CALLS edges with matching `(receiver_type, method)` pairs to the canonical `ext:<package>` placeholder. Covers `net/http`, `io`, `context`, `sync`, `bytes`, `strings`, `bufio`, `database/sql`, `os`, `testing`, plus high-volume third-party frameworks (`chi`, `gin`, `echo`).
- Resolver now retries same-package member lookup with the trailing segment of a package-qualified receiver_type so internal package code (`chi/mux_test.go`) binds correctly.

## VERIFY-2 (single-repo)
| repo | baseline (main) | this PR | delta |
| --- | ---: | ---: | ---: |
| go-chi/chi | 40.95% | **34.82%** | -6.13pp |
| gin-gonic/gin | 40.25% | 38.49% | -1.76pp |

Meets the issue #103 <=35% gate for go-chi.

## Test plan
- [x] `go test ./...` (77 packages clean)
- [x] `go vet ./...` clean
- [x] `gofmt -l .` clean
- [x] VERIFY-2 single-repo on go-chi + go-gin (above)
- New tests:
  - `TestCallsRelationship_StdlibInterfaceParamType` (positive)
  - `TestCallsRelationship_StampShortVarDecl` (positive)
  - `TestCallsRelationship_StampChiNewRouter` (positive)
  - `TestCallsRelationship_ReceiverTypeStampedFromParamType` (supersedes pre-#364 conservative-stamp test)
  - `TestSynthesize_GoStdlibInterfaceDispatch` (14 stdlib type/method subtests)
  - `TestSynthesize_GoStdlibInterfaceDispatch_NoFalsePositive`

🤖 Generated with [Claude Code](https://claude.com/claude-code)