### PR TITLE
feat(html): emit IMPORTS for asset references (Closes #373)

### DIFF
--- a/internal/extractors/html/extractor.go
+++ b/internal/extractors/html/extractor.go
@@ -5,12 +5,21 @@
 //	form element         → Kind="SCOPE.Operation",   Subtype="form"         (action attr or "form")
 //	script src include   → Kind="SCOPE.Component",   Subtype="script_include"
 //	link stylesheet      → Kind="SCOPE.Component",   Subtype="style_include"
+//	img src include      → Kind="SCOPE.Component",   Subtype="image_include"
 //	mustache expression  → Kind="SCOPE.Pattern",     Subtype="template_expr"  (dot/filter only)
 //	custom element       → Kind="SCOPE.Component",   Subtype="component"
 //	Vue directive (@/v-) → Kind="SCOPE.Pattern",     Subtype="directive"
 //	Angular ng- attr     → Kind="SCOPE.Pattern",     Subtype="directive"
 //	Jinja2 directive     → Kind="SCOPE.Component",   Subtype="jinja_directive" (block/extends/include/macro/for/if)
 //	form field child     → Kind="SCOPE.UIComponent", Subtype="form_field"   (input/select/textarea/button)
+//
+// Emitted relationships (per issue #373 PORT-RELS-HTML):
+//
+//	IMPORTS  — asset references via <script src>, <link href>, <img src>.
+//	          Edge FromID = file path, ToID = href/src value. Properties:
+//	          local_name (filename basename), source_module (raw href/src),
+//	          imported_name (""). CALLS and CONTAINS are not applicable to
+//	          HTML templates (no functions/classes/methods to model).
 //
 // Registers itself via init() and is imported by registry_gen.go.
 package html
@@ -141,6 +150,12 @@ func walkDocument(root *sitter.Node, file extractor.FileInput) []types.EntityRec
 				entities = append(entities, rec)
 			}
 
+		case "self_closing_tag":
+			// e.g. <img src="..." /> in XHTML-style documents.
+			if rec, ok := visitSelfClosingTag(node, file); ok {
+				entities = append(entities, rec)
+			}
+
 		case "text":
 			recs := visitTextNode(node, file)
 			entities = append(entities, recs...)
@@ -232,8 +247,30 @@ func visitElement(node *sitter.Node, file extractor.FileInput) []types.EntityRec
 					EndLine:      endLine,
 					Signature:    "link rel=stylesheet href=" + href,
 					QualityScore: 0.7,
+					Relationships: []types.RelationshipRecord{
+						buildAssetImportRel(file.Path, href),
+					},
 				})
 			}
+		}
+
+	case "img":
+		src := attrValue(startTag, "src", file.Content)
+		if src != "" {
+			recs = append(recs, types.EntityRecord{
+				Name:         src,
+				Kind:         "SCOPE.Component",
+				Subtype:      "image_include",
+				SourceFile:   file.Path,
+				Language:     "html",
+				StartLine:    startLine,
+				EndLine:      endLine,
+				Signature:    "img src=" + src,
+				QualityScore: 0.65,
+				Relationships: []types.RelationshipRecord{
+					buildAssetImportRel(file.Path, src),
+				},
+			})
 		}
 	}
 
@@ -431,7 +468,133 @@ func visitScriptElement(node *sitter.Node, file extractor.FileInput) (types.Enti
 		EndLine:      endLine,
 		Signature:    "script src=" + src,
 		QualityScore: 0.7,
+		Relationships: []types.RelationshipRecord{
+			buildAssetImportRel(file.Path, src),
+		},
 	}, true
+}
+
+// visitSelfClosingTag handles XHTML-style void elements like
+// <img src="..." />, <link href="..." />, <script src="..." />.
+// The HTML grammar parses these as self_closing_tag nodes rather than as
+// element/script_element wrappers, so we cover them separately here to
+// keep IMPORTS coverage symmetric with the start_tag form.
+func visitSelfClosingTag(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	tagNameNode := childByType(node, "tag_name")
+	if tagNameNode == nil {
+		return types.EntityRecord{}, false
+	}
+	tagName := strings.ToLower(nodeText(tagNameNode, file.Content))
+
+	startLine := int(node.StartPoint().Row) + 1
+	endLine := int(node.EndPoint().Row) + 1
+
+	switch tagName {
+	case "img":
+		src := attrValue(node, "src", file.Content)
+		if src == "" {
+			return types.EntityRecord{}, false
+		}
+		return types.EntityRecord{
+			Name:         src,
+			Kind:         "SCOPE.Component",
+			Subtype:      "image_include",
+			SourceFile:   file.Path,
+			Language:     "html",
+			StartLine:    startLine,
+			EndLine:      endLine,
+			Signature:    "img src=" + src,
+			QualityScore: 0.65,
+			Relationships: []types.RelationshipRecord{
+				buildAssetImportRel(file.Path, src),
+			},
+		}, true
+
+	case "script":
+		src := attrValue(node, "src", file.Content)
+		if src == "" {
+			return types.EntityRecord{}, false
+		}
+		return types.EntityRecord{
+			Name:         src,
+			Kind:         "SCOPE.Component",
+			Subtype:      "script_include",
+			SourceFile:   file.Path,
+			Language:     "html",
+			StartLine:    startLine,
+			EndLine:      endLine,
+			Signature:    "script src=" + src,
+			QualityScore: 0.7,
+			Relationships: []types.RelationshipRecord{
+				buildAssetImportRel(file.Path, src),
+			},
+		}, true
+
+	case "link":
+		rel := attrValue(node, "rel", file.Content)
+		if strings.ToLower(rel) != "stylesheet" {
+			return types.EntityRecord{}, false
+		}
+		href := attrValue(node, "href", file.Content)
+		if href == "" {
+			return types.EntityRecord{}, false
+		}
+		return types.EntityRecord{
+			Name:         href,
+			Kind:         "SCOPE.Component",
+			Subtype:      "style_include",
+			SourceFile:   file.Path,
+			Language:     "html",
+			StartLine:    startLine,
+			EndLine:      endLine,
+			Signature:    "link rel=stylesheet href=" + href,
+			QualityScore: 0.7,
+			Relationships: []types.RelationshipRecord{
+				buildAssetImportRel(file.Path, href),
+			},
+		}, true
+	}
+	return types.EntityRecord{}, false
+}
+
+// buildAssetImportRel constructs the IMPORTS relationship contract used by
+// HTML asset references (issue #373). The cross-file resolver consumes:
+//
+//	local_name    — the filename basename of the asset (e.g. "app.js" from
+//	                "/static/app.js"). Best-effort identifier for the
+//	                imported binding inside this file.
+//	source_module — the raw href/src value as written in source.
+//	imported_name — empty: HTML asset includes do not introduce named
+//	                bindings the way `import { x } from "y"` does.
+func buildAssetImportRel(fromPath, ref string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: fromPath,
+		ToID:   ref,
+		Kind:   "IMPORTS",
+		Properties: map[string]string{
+			"local_name":    assetBasename(ref),
+			"source_module": ref,
+			"imported_name": "",
+		},
+	}
+}
+
+// assetBasename returns the trailing path segment of a URL or file ref,
+// stripped of any query string or fragment. Used for the local_name
+// property on HTML IMPORTS edges. Falls back to the full ref if no
+// path segment can be extracted.
+func assetBasename(ref string) string {
+	s := ref
+	if i := strings.IndexAny(s, "?#"); i >= 0 {
+		s = s[:i]
+	}
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
+	}
+	if s == "" {
+		return ref
+	}
+	return s
 }
 
 // visitTextNode scans text content for {{ }} mustache template expressions.

--- a/internal/extractors/html/relationships_test.go
+++ b/internal/extractors/html/relationships_test.go
@@ -1,0 +1,216 @@
+package html_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/html"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractRels runs the registered html extractor against src and returns the
+// resulting entity records (which carry embedded RelationshipRecords).
+func extractRels(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("html")
+	if !ok {
+		t.Fatal("html extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "html",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return entities
+}
+
+func relsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// ---- IMPORTS — script src --------------------------------------------------
+
+func TestRelationships_Imports_ScriptSrc(t *testing.T) {
+	src := `<html><head><script src="/static/app.js"></script></head><body></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	r := rels[0]
+	if r.FromID != "page.html" {
+		t.Errorf("FromID = %q, want page.html", r.FromID)
+	}
+	if r.ToID != "/static/app.js" {
+		t.Errorf("ToID = %q, want /static/app.js", r.ToID)
+	}
+	if got := r.Properties["local_name"]; got != "app.js" {
+		t.Errorf("local_name = %q, want app.js", got)
+	}
+	if got := r.Properties["source_module"]; got != "/static/app.js" {
+		t.Errorf("source_module = %q, want /static/app.js", got)
+	}
+	if got, ok := r.Properties["imported_name"]; !ok || got != "" {
+		t.Errorf("imported_name = %q (present=%v), want empty present", got, ok)
+	}
+}
+
+// ---- IMPORTS — link stylesheet href ---------------------------------------
+
+func TestRelationships_Imports_LinkStylesheet(t *testing.T) {
+	src := `<html><head><link rel="stylesheet" href="/css/main.css"></head><body></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "/css/main.css" {
+		t.Errorf("ToID = %q", rels[0].ToID)
+	}
+	if rels[0].Properties["local_name"] != "main.css" {
+		t.Errorf("local_name = %q, want main.css", rels[0].Properties["local_name"])
+	}
+}
+
+// Non-stylesheet <link> (e.g. rel="icon") should not produce IMPORTS — the
+// extractor only models stylesheet includes today.
+func TestRelationships_Imports_LinkIconNotEmitted(t *testing.T) {
+	src := `<html><head><link rel="icon" href="/favicon.ico"></head><body></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Fatalf("IMPORTS count = %d, want 0 (non-stylesheet link must not import)", len(rels))
+	}
+}
+
+// ---- IMPORTS — img src -----------------------------------------------------
+
+func TestRelationships_Imports_ImgSrc(t *testing.T) {
+	src := `<html><body><img src="/img/hero.png" alt="hero"></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "/img/hero.png" {
+		t.Errorf("ToID = %q", rels[0].ToID)
+	}
+	if rels[0].Properties["local_name"] != "hero.png" {
+		t.Errorf("local_name = %q, want hero.png", rels[0].Properties["local_name"])
+	}
+}
+
+// ---- IMPORTS — multiple mixed asset references -----------------------------
+
+func TestRelationships_Imports_Multiple(t *testing.T) {
+	src := `<html>
+<head>
+  <link rel="stylesheet" href="/css/main.css">
+  <link rel="stylesheet" href="https://cdn.example.com/lib.css">
+  <script src="/js/app.js"></script>
+</head>
+<body>
+  <img src="/img/a.png">
+  <img src="b.svg">
+</body>
+</html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 5 {
+		t.Fatalf("IMPORTS count = %d, want 5", len(rels))
+	}
+	wantTargets := map[string]bool{
+		"/css/main.css":                    false,
+		"https://cdn.example.com/lib.css":  false,
+		"/js/app.js":                       false,
+		"/img/a.png":                       false,
+		"b.svg":                            false,
+	}
+	for _, r := range rels {
+		if _, ok := wantTargets[r.ToID]; ok {
+			wantTargets[r.ToID] = true
+		}
+		if r.FromID != "page.html" {
+			t.Errorf("FromID = %q, want page.html", r.FromID)
+		}
+	}
+	for k, seen := range wantTargets {
+		if !seen {
+			t.Errorf("missing IMPORTS edge to %q", k)
+		}
+	}
+}
+
+// ---- IMPORTS — query string and fragment in local_name --------------------
+
+func TestRelationships_Imports_StripsQueryAndFragment(t *testing.T) {
+	src := `<html><head><script src="/js/app.js?v=42#hash"></script></head><body></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if got := rels[0].Properties["local_name"]; got != "app.js" {
+		t.Errorf("local_name = %q, want app.js (query/fragment stripped)", got)
+	}
+	// source_module preserves the raw value.
+	if got := rels[0].Properties["source_module"]; got != "/js/app.js?v=42#hash" {
+		t.Errorf("source_module = %q, want raw value preserved", got)
+	}
+}
+
+// ---- IMPORTS — script with no src is not an import ------------------------
+
+func TestRelationships_Imports_InlineScriptNotEmitted(t *testing.T) {
+	src := `<html><head><script>console.log("hi")</script></head><body></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Fatalf("IMPORTS count = %d, want 0 for inline script", len(rels))
+	}
+}
+
+// ---- IMPORTS — empty href/src is not an import ----------------------------
+
+func TestRelationships_Imports_EmptyAttrNotEmitted(t *testing.T) {
+	src := `<html><body><img src="" alt="broken"></body></html>`
+	entities := extractRels(t, "page.html", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Fatalf("IMPORTS count = %d, want 0 for empty src", len(rels))
+	}
+}
+
+// ---- CALLS / CONTAINS — not applicable to HTML ----------------------------
+//
+// HTML templates do not model functions, methods, or class containment, so
+// the html extractor intentionally does not emit CALLS or CONTAINS edges.
+// These tests pin that behaviour so accidental additions trip a regression.
+
+func TestRelationships_Calls_NotEmitted(t *testing.T) {
+	src := `<html><body><button onclick="handleClick()">Go</button></body></html>`
+	entities := extractRels(t, "page.html", src)
+	if rels := relsByKind(entities, "CALLS"); len(rels) != 0 {
+		t.Fatalf("CALLS count = %d, want 0 (not applicable to HTML)", len(rels))
+	}
+}
+
+func TestRelationships_Contains_NotEmitted(t *testing.T) {
+	src := `<html><body><form action="/submit"><input name="email"></form></body></html>`
+	entities := extractRels(t, "page.html", src)
+	if rels := relsByKind(entities, "CONTAINS"); len(rels) != 0 {
+		t.Fatalf("CONTAINS count = %d, want 0 (not applicable to HTML)", len(rels))
+	}
+}


### PR DESCRIPTION
## Summary

Closes #373 (PORT-RELS-HTML).

Attaches `IMPORTS` relationships to HTML asset-include entities so the cross-file resolver can hop from a template into the JS/CSS/image assets it references:

- `<script src=...>` — already an entity (`script_include`); now carries an IMPORTS edge.
- `<link rel="stylesheet" href=...>` — already an entity (`style_include`); now carries an IMPORTS edge.
- `<img src=...>` — newly modelled as `SCOPE.Component` / `image_include`, with an IMPORTS edge.
- All three are also handled in the `self_closing_tag` shape (`<img />`, `<script />`, `<link />`) for XHTML-style templates.

Each IMPORTS edge follows the standard property contract:
- `local_name` — asset basename with query string and fragment stripped (e.g. `app.js` from `/js/app.js?v=42#hash`).
- `source_module` — raw `href`/`src` value as written in source.
- `imported_name` — empty: HTML asset includes do not introduce named bindings.

## Deferred (not applicable)

- **CALLS** — HTML templates do not model function call sites. Inline `onclick="foo()"` handler text is JS-grammar territory and would belong to a JS sub-extractor pass, not this PR.
- **CONTAINS** — HTML templates do not model class/method containment. Form/field structural nesting is already captured as separate `SCOPE.UIComponent` entities; promoting that into CONTAINS edges is a separate design call.

Both are pinned with regression tests so future changes that accidentally start emitting them trip a fail.

## Test plan

- [x] `go test ./internal/extractors/html/...` — new `relationships_test.go` covers IMPORTS for script/link/img, query+fragment stripping, empty/inline-script negative cases, and CALLS/CONTAINS not-emitted regressions.
- [x] `go test ./...` — full module green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)