### PR TITLE
feat(shell): emit IMPORTS + CALLS + CONTAINS edges (Closes #380)

### DIFF
--- a/internal/extractors/shell/relationships_test.go
+++ b/internal/extractors/shell/relationships_test.go
@@ -1,0 +1,311 @@
+package shell_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/shell"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findEntity returns the first entity matching the predicate.
+func findEntity(entities []types.EntityRecord, pred func(types.EntityRecord) bool) (types.EntityRecord, bool) {
+	for _, e := range entities {
+		if pred(e) {
+			return e, true
+		}
+	}
+	return types.EntityRecord{}, false
+}
+
+func collectImports(entities []types.EntityRecord) []string {
+	var paths []string
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				paths = append(paths, r.ToID)
+			}
+		}
+	}
+	return paths
+}
+
+func collectCallsFor(entities []types.EntityRecord, fnName string) []string {
+	var targets []string
+	for _, e := range entities {
+		if e.Name != fnName || e.Kind != "SCOPE.Operation" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" {
+				targets = append(targets, r.ToID)
+			}
+		}
+	}
+	return targets
+}
+
+func TestShell_Imports_SourceCommand(t *testing.T) {
+	src := `#!/bin/bash
+source ./lib.sh
+. /etc/foo.sh
+
+main() {
+    echo hi
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imps := collectImports(entities)
+	want := map[string]bool{"./lib.sh": false, "/etc/foo.sh": false}
+	for _, p := range imps {
+		if _, ok := want[p]; ok {
+			want[p] = true
+		}
+	}
+	for p, seen := range want {
+		if !seen {
+			t.Errorf("missing IMPORTS for %q. got %v", p, imps)
+		}
+	}
+}
+
+func TestShell_Imports_HaveProperties(t *testing.T) {
+	src := `source ./lib.sh
+foo() { :; }
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	stub, ok := findEntity(entities, func(e types.EntityRecord) bool {
+		return e.Name == "./lib.sh"
+	})
+	if !ok {
+		t.Fatalf("expected import stub for ./lib.sh, entities=%+v", entities)
+	}
+	if len(stub.Relationships) == 0 {
+		t.Fatal("import stub has no relationships")
+	}
+	r := stub.Relationships[0]
+	if r.Kind != "IMPORTS" {
+		t.Errorf("expected IMPORTS, got %q", r.Kind)
+	}
+	if r.FromID != "test.sh" {
+		t.Errorf("expected FromID=test.sh, got %q", r.FromID)
+	}
+	if r.ToID != "./lib.sh" {
+		t.Errorf("expected ToID=./lib.sh, got %q", r.ToID)
+	}
+	if r.Properties["import_kind"] != "source" {
+		t.Errorf("expected import_kind=source, got %q", r.Properties["import_kind"])
+	}
+	if r.Properties["language"] != "shell" {
+		t.Errorf("expected language=shell, got %q", r.Properties["language"])
+	}
+}
+
+func TestShell_Calls_BetweenLocalFunctions(t *testing.T) {
+	src := `helper() {
+    echo hi
+}
+
+main() {
+    helper
+    other_thing
+    helper arg1 arg2
+}
+
+other_thing() {
+    :
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	calls := collectCallsFor(entities, "main")
+	want := map[string]bool{"helper": false, "other_thing": false}
+	for _, c := range calls {
+		if _, ok := want[c]; ok {
+			want[c] = true
+		}
+	}
+	for k, v := range want {
+		if !v {
+			t.Errorf("expected CALLS to %q from main, got %v", k, calls)
+		}
+	}
+}
+
+func TestShell_Calls_FilterExternalCommands(t *testing.T) {
+	src := `helper() {
+    :
+}
+
+main() {
+    docker build .
+    rm -rf /tmp
+    helper
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	calls := collectCallsFor(entities, "main")
+	for _, c := range calls {
+		if c == "docker" || c == "rm" {
+			t.Errorf("did not expect external command %q in CALLS, got %v", c, calls)
+		}
+	}
+	found := false
+	for _, c := range calls {
+		if c == "helper" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CALLS to helper from main, got %v", calls)
+	}
+}
+
+func TestShell_Calls_DropSelfRecursion(t *testing.T) {
+	src := `recurse() {
+    recurse
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	calls := collectCallsFor(entities, "recurse")
+	if len(calls) != 0 {
+		t.Errorf("expected self-recursion to be filtered, got %v", calls)
+	}
+}
+
+func TestShell_Calls_Dedup(t *testing.T) {
+	src := `helper() { :; }
+
+main() {
+    helper
+    helper
+    helper
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "test.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	calls := collectCallsFor(entities, "main")
+	count := 0
+	for _, c := range calls {
+		if c == "helper" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected deduped CALLS to helper, got count=%d", count)
+	}
+}
+
+func TestShell_Contains_FileToFunctions(t *testing.T) {
+	src := `helper() { :; }
+main() { :; }
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "scripts/run.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	script, ok := findEntity(entities, func(e types.EntityRecord) bool {
+		return e.Kind == "SCOPE.Component" && e.Subtype == "script"
+	})
+	if !ok {
+		t.Fatalf("expected SCOPE.Component subtype=script entity, got %+v", entities)
+	}
+	wantHelper := extractor.BuildOperationStructuralRef("shell", "scripts/run.sh", "helper")
+	wantMain := extractor.BuildOperationStructuralRef("shell", "scripts/run.sh", "main")
+	got := map[string]bool{}
+	for _, r := range script.Relationships {
+		if r.Kind == "CONTAINS" {
+			got[r.ToID] = true
+		}
+	}
+	if !got[wantHelper] {
+		t.Errorf("missing CONTAINS to %q. got %+v", wantHelper, got)
+	}
+	if !got[wantMain] {
+		t.Errorf("missing CONTAINS to %q. got %+v", wantMain, got)
+	}
+}
+
+func TestShell_Relationships_LanguageTagged(t *testing.T) {
+	src := `source ./lib.sh
+helper() { :; }
+main() { helper; }
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("shell")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:    "x.sh",
+		Content: []byte(src),
+		Tree:    tree,
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "shell" {
+				t.Errorf("relationship %s→%s missing language=shell tag, props=%+v",
+					r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}

--- a/internal/extractors/shell/shell.go
+++ b/internal/extractors/shell/shell.go
@@ -1,10 +1,32 @@
 // Package shell implements the tree-sitter–based extractor for Shell/Bash source files.
 //
 // Extracted entities:
-//   - function_definition → Kind="SCOPE.Operation", Subtype="function"
+//   - function_definition           → Kind="SCOPE.Operation",  Subtype="function"
+//   - script (file-level wrapper)   → Kind="SCOPE.Component",  Subtype="script"
+//   - source/. import stubs         → Kind="SCOPE.Component" carrying IMPORTS edge
 //
-// Uses the bash grammar from smacker/go-tree-sitter.
-// Registers itself via init() and is imported by registry_gen.go.
+// Issue #380 (PORT-RELS-SHELL) — emits the same three relationship kinds the
+// other ported extractors emit:
+//
+//   - IMPORTS: every `source <path>` and `. <path>` command produces a
+//     SCOPE.Component import-stub entity carrying an IMPORTS edge from the
+//     file → the sourced path. Properties carry source_module / local_name /
+//     imported_name / import_kind="source" so the resolver's dynamic dispatch
+//     (issue #90) can target the shell pattern catalog.
+//
+//   - CALLS: each function body is scanned for `command_name` nodes whose
+//     identifier matches a function defined in the same file. External
+//     program executions (docker, rm, echo, etc.) are dropped — bash has no
+//     reliable way to distinguish a function call from an external invocation
+//     without a shell-aware resolver, so we restrict to known same-file
+//     callees per the issue spec. Self-recursion is dropped, callees deduped.
+//
+//   - CONTAINS: a single file-level SCOPE.Component (subtype="script") emits
+//     one CONTAINS edge per declared function via BuildOperationStructuralRef
+//     ("shell", file, name) — Format A structural-ref (issue #144).
+//
+// Uses the bash grammar from smacker/go-tree-sitter. Registers itself via
+// init() and is imported by the generated registry_gen.go.
 package shell
 
 import (
@@ -38,25 +60,66 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		return extractRegex(file), nil
 	}
 
+	root := file.Tree.RootNode()
+	imports := collectSources(root, file.Content)
+
+	// Pass 1: IMPORTS — emit one stub entity per `source`/`.` command.
 	var entities []types.EntityRecord
-	imports := collectSources(file.Tree.RootNode(), file.Content)
-	walkShell(file.Tree.RootNode(), file, imports, &entities)
+	emitImportStubs(root, file, &entities)
+
+	// Pass 2: collect the names of every function defined in this file. The
+	// CALLS pass uses this set to filter out external program invocations
+	// (the issue spec: "only emit for identifiers that match a previously-
+	// defined function in the file").
+	localFns := collectLocalFunctionNames(root, file.Content)
+
+	// Pass 3: walk the CST emitting Operation entities, attaching CALLS edges.
+	var fnEntities []types.EntityRecord
+	walkShell(root, file, imports, localFns, &fnEntities)
+
+	// Pass 4: emit a script-level SCOPE.Component carrying CONTAINS edges to
+	// every function in fnEntities. Skipped when there are no functions.
+	if len(fnEntities) > 0 {
+		entities = append(entities, buildScriptComponent(file, fnEntities))
+	}
+	entities = append(entities, fnEntities...)
+
+	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
+	extractor.TagRelationshipsLanguage(entities, "shell")
 	return entities, nil
 }
 
 // walkShell performs a depth-first traversal collecting function_definition nodes.
-func walkShell(node *sitter.Node, file extractor.FileInput, imports []string, out *[]types.EntityRecord) {
+func walkShell(node *sitter.Node, file extractor.FileInput, imports []string, localFns map[string]bool, out *[]types.EntityRecord) {
 	if node == nil {
 		return
 	}
 	if node.Type() == "function_definition" {
 		if rec, ok := buildFunction(node, file, imports); ok {
+			body := findCompoundStatement(node)
+			rec.Relationships = append(rec.Relationships,
+				extractCallRelationships(body, file.Content, rec.Name, localFns)...)
 			*out = append(*out, rec)
 		}
 	}
 	for i := range node.ChildCount() {
-		walkShell(node.Child(int(i)), file, imports, out)
+		walkShell(node.Child(int(i)), file, imports, localFns, out)
 	}
+}
+
+// findCompoundStatement returns the `compound_statement` body child of a
+// function_definition node, or nil.
+func findCompoundStatement(node *sitter.Node) *sitter.Node {
+	if node == nil {
+		return nil
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch != nil && ch.Type() == "compound_statement" {
+			return ch
+		}
+	}
+	return nil
 }
 
 // buildFunction creates a SCOPE.Operation entity for a function_definition node.
@@ -96,7 +159,9 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, imports []string
 	}, true
 }
 
-// collectSources collects source/. commands as import equivalents.
+// collectSources collects source/. commands as the legacy
+// Properties["imports"] string list (preserved for backwards compatibility
+// with the existing Operation-entity contract).
 func collectSources(root *sitter.Node, src []byte) []string {
 	var imports []string
 	walkForSources(root, src, &imports)
@@ -107,20 +172,247 @@ func walkForSources(node *sitter.Node, src []byte, out *[]string) {
 	if node == nil {
 		return
 	}
-	if node.Type() == "command" && node.ChildCount() > 0 {
-		first := node.Child(0)
-		if first != nil {
-			text := string(src[first.StartByte():first.EndByte()])
-			if (text == "source" || text == ".") && int(node.ChildCount()) > 1 {
-				arg := node.Child(1)
-				if arg != nil {
-					*out = append(*out, string(src[arg.StartByte():arg.EndByte()]))
+	if path := sourceCommandArg(node, src); path != "" {
+		*out = append(*out, path)
+	}
+	for i := range node.ChildCount() {
+		walkForSources(node.Child(int(i)), src, out)
+	}
+}
+
+// sourceCommandArg returns the argument of a `source <arg>` / `. <arg>`
+// command node, or "" if the node isn't a source command.
+//
+// Bash CST shape (smacker/go-tree-sitter):
+//
+//	command
+//	  command_name
+//	    word "source"   (or word ".")
+//	  word "<path>"
+func sourceCommandArg(node *sitter.Node, src []byte) string {
+	if node == nil || node.Type() != "command" || node.ChildCount() < 2 {
+		return ""
+	}
+	head := node.Child(0)
+	if head == nil {
+		return ""
+	}
+	headText := strings.TrimSpace(string(src[head.StartByte():head.EndByte()]))
+	if headText != "source" && headText != "." {
+		return ""
+	}
+	// Find the first non-command_name child as the path argument.
+	for i := 1; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch == nil {
+			continue
+		}
+		t := ch.Type()
+		if t == "word" || t == "string" || t == "raw_string" || t == "concatenation" {
+			raw := string(src[ch.StartByte():ch.EndByte()])
+			return strings.Trim(raw, `'"`)
+		}
+	}
+	return ""
+}
+
+// emitImportStubs walks the CST and emits one SCOPE.Component entity per
+// source/. command, each carrying a single IMPORTS edge file→path. Mirrors
+// the lua/dart/elixir contract: per-import entity records so the resolver
+// can dispatch on Properties["language"] (#90).
+func emitImportStubs(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	walkForImportStubs(root, file, out)
+}
+
+func walkForImportStubs(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
+	if node == nil {
+		return
+	}
+	if path := sourceCommandArg(node, file.Content); path != "" {
+		*out = append(*out, makeImportStub(file, path))
+	}
+	for i := range node.ChildCount() {
+		walkForImportStubs(node.Child(int(i)), file, out)
+	}
+}
+
+// makeImportStub builds a SCOPE.Component import-stub carrying a single
+// IMPORTS edge for a `source <path>` / `. <path>` command.
+//
+//	Properties["local_name"]    — trailing path segment (basename).
+//	Properties["source_module"] — full sourced path (matches ToID).
+//	Properties["imported_name"] — equal to local_name.
+//	Properties["import_kind"]   — always "source" for shell.
+func makeImportStub(file extractor.FileInput, path string) types.EntityRecord {
+	leaf := path
+	if slash := strings.LastIndexByte(path, '/'); slash >= 0 {
+		leaf = path[slash+1:]
+	}
+	return types.EntityRecord{
+		Name:       path,
+		Kind:       "SCOPE.Component",
+		SourceFile: file.Path,
+		Language:   "shell",
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID: file.Path,
+				ToID:   path,
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"local_name":    leaf,
+					"source_module": path,
+					"imported_name": leaf,
+					"import_kind":   "source",
+				},
+			},
+		},
+	}
+}
+
+// collectLocalFunctionNames walks the CST and returns the set of names of
+// every `function_definition` node. Used by extractCallRelationships to
+// restrict CALLS edges to identifiers known to be functions defined in this
+// file (the issue spec — bash can't reliably distinguish function calls from
+// external program invocations otherwise).
+func collectLocalFunctionNames(root *sitter.Node, src []byte) map[string]bool {
+	out := make(map[string]bool)
+	walkForFnNames(root, src, out)
+	return out
+}
+
+func walkForFnNames(node *sitter.Node, src []byte, out map[string]bool) {
+	if node == nil {
+		return
+	}
+	if node.Type() == "function_definition" {
+		nameNode := node.ChildByFieldName("name")
+		if nameNode == nil {
+			for i := range node.ChildCount() {
+				ch := node.Child(int(i))
+				if ch != nil && ch.Type() == "word" {
+					nameNode = ch
+					break
 				}
+			}
+		}
+		if nameNode != nil {
+			name := string(src[nameNode.StartByte():nameNode.EndByte()])
+			if name != "" {
+				out[name] = true
 			}
 		}
 	}
 	for i := range node.ChildCount() {
-		walkForSources(node.Child(int(i)), src, out)
+		walkForFnNames(node.Child(int(i)), src, out)
+	}
+}
+
+// extractCallRelationships returns one CALLS RelationshipRecord per unique
+// command head inside body whose identifier matches a known local function
+// (localFns). External program invocations are dropped. Self-recursion is
+// dropped, results are deduped.
+func extractCallRelationships(body *sitter.Node, src []byte, callerName string, localFns map[string]bool) []types.RelationshipRecord {
+	if body == nil || callerName == "" || len(localFns) == 0 {
+		return nil
+	}
+	commands := findAllNodes(body, "command")
+	if len(commands) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(commands))
+	rels := make([]types.RelationshipRecord, 0, len(commands))
+	for _, cmd := range commands {
+		head := commandHeadName(cmd, src)
+		if head == "" || head == callerName {
+			continue
+		}
+		if !localFns[head] {
+			continue
+		}
+		if seen[head] {
+			continue
+		}
+		seen[head] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID: head,
+			Kind: "CALLS",
+		})
+	}
+	return rels
+}
+
+// commandHeadName returns the identifier text of a command node's
+// command_name child, or "" if not a simple identifier.
+//
+//	command
+//	  command_name
+//	    word "<head>"
+func commandHeadName(cmd *sitter.Node, src []byte) string {
+	if cmd == nil || cmd.ChildCount() == 0 {
+		return ""
+	}
+	head := cmd.Child(0)
+	if head == nil || head.Type() != "command_name" {
+		return ""
+	}
+	// command_name typically has a single word child.
+	for i := 0; i < int(head.ChildCount()); i++ {
+		ch := head.Child(i)
+		if ch != nil && ch.Type() == "word" {
+			return string(src[ch.StartByte():ch.EndByte()])
+		}
+	}
+	// Fall back to the whole command_name text.
+	return strings.TrimSpace(string(src[head.StartByte():head.EndByte()]))
+}
+
+// findAllNodes returns every descendant of root whose Type() is in kinds.
+func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+	if root == nil {
+		return nil
+	}
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	var out []*sitter.Node
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if set[n.Type()] {
+			out = append(out, n)
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return out
+}
+
+// buildScriptComponent emits a single file-level SCOPE.Component carrying
+// one CONTAINS edge per function entity. The structural-ref shape matches
+// every other Format A class→method emitter (#144).
+func buildScriptComponent(file extractor.FileInput, fns []types.EntityRecord) types.EntityRecord {
+	name := file.Path
+	if slash := strings.LastIndexByte(file.Path, '/'); slash >= 0 {
+		name = file.Path[slash+1:]
+	}
+	rels := make([]types.RelationshipRecord, 0, len(fns))
+	for _, fn := range fns {
+		toID := extractor.BuildOperationStructuralRef("shell", file.Path, fn.Name)
+		rels = append(rels, types.RelationshipRecord{
+			ToID: toID,
+			Kind: "CONTAINS",
+		})
+	}
+	return types.EntityRecord{
+		Name:          name,
+		Kind:          "SCOPE.Component",
+		Subtype:       "script",
+		SourceFile:    file.Path,
+		Language:      "shell",
+		Relationships: rels,
 	}
 }
 

--- a/internal/extractors/shell/shell_test.go
+++ b/internal/extractors/shell/shell_test.go
@@ -65,10 +65,12 @@ build_image() {
 
 	names := make(map[string]bool)
 	for _, e := range entities {
-		names[e.Name] = true
 		if e.Kind != "SCOPE.Operation" {
-			t.Errorf("entity %q: expected Kind=SCOPE.Operation, got %q", e.Name, e.Kind)
+			// Issue #380 also emits SCOPE.Component (script + import stubs);
+			// this test only validates Operation entities.
+			continue
 		}
+		names[e.Name] = true
 		if e.Language != "shell" {
 			t.Errorf("entity %q: expected Language=shell, got %q", e.Name, e.Language)
 		}
@@ -114,7 +116,13 @@ func TestShellExtractor_Signatures(t *testing.T) {
 	if len(entities) == 0 {
 		t.Fatal("expected at least 1 entity")
 	}
-	e := entities[0]
+	var e = entities[0]
+	for _, ent := range entities {
+		if ent.Kind == "SCOPE.Operation" {
+			e = ent
+			break
+		}
+	}
 	if e.Name != "deploy" {
 		t.Errorf("expected name=deploy, got %q", e.Name)
 	}


### PR DESCRIPTION
## Summary

Port relationship extraction to the shell/bash extractor (PORT-RELS-SHELL, #380). Matches the contract the other ported extractors emit:

- **IMPORTS** — every `source <path>` and `. <path>` command emits a `SCOPE.Component` import-stub entity carrying an `IMPORTS` edge from file → sourced path. Properties: `local_name`, `source_module`, `imported_name`, `import_kind="source"`.
- **CALLS** — function bodies are scanned for `command_name` nodes whose identifier matches a function defined in the same file. External commands (docker, rm, echo) are filtered — bash has no reliable static way to distinguish function calls from external invocations, so per the issue spec we restrict to known same-file callees. Self-recursion dropped, deduped.
- **CONTAINS** — a single file-level `SCOPE.Component` (subtype=`script`) carries one CONTAINS edge per declared function via `BuildOperationStructuralRef("shell", file, name)` (Format A, #144).

Every relationship carries `Properties["language"]="shell"` via `TagRelationshipsLanguage` (#90).

## Test plan

- [x] 8 new test cases in `relationships_test.go` (imports basic + properties, calls intra-file, external-command filter, self-recursion drop, dedup, CONTAINS via structural-ref, language tag)
- [x] Existing 5 entity tests adjusted to ignore the new SCOPE.Component records — all still pass
- [x] `go test ./...` — all packages green
- [x] `go vet ./internal/extractors/shell/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)