### PR TITLE
feat(yaml): emit IMPORTS + CONTAINS edges (#386)

### DIFF
--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -243,20 +243,25 @@ func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput)
 		}
 	}()
 
+	var entities []types.EntityRecord
 	switch flavor {
 	case flavorGitHubActions:
-		return extractGitHubActions(root, file)
+		entities = extractGitHubActions(root, file)
 	case flavorGitLabCI:
-		return extractGitLabCI(root, file)
+		entities = extractGitLabCI(root, file)
 	case flavorDockerCompose:
-		return extractDockerCompose(root, file)
+		entities = extractDockerCompose(root, file)
 	case flavorKubernetes:
-		return extractKubernetes(root, file)
+		entities = extractKubernetes(root, file)
 	case flavorAnsible:
-		return extractAnsible(root, file)
+		entities = extractAnsible(root, file)
 	default:
-		return extractGeneric(root, file)
+		entities = extractGeneric(root, file)
 	}
+	// Issue #386 / #90: stamp Properties["language"]="yaml" on every embedded
+	// relationship so the resolver dispatches the YAML dynamic-pattern catalog.
+	extractor.TagRelationshipsLanguage(entities, "yaml")
+	return entities
 }
 
 // ---------------------------------------------------------------------------
@@ -540,6 +545,22 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
 
+	// Resolve the workflow ref once (top-level `name:`); fall back to file.Path
+	// when no name is present.
+	workflowRef := ""
+	for _, p := range pairs {
+		if pairKeyText(p, src) == "name" {
+			if v := getPairValueText(p, src); v != "" {
+				workflowRef = "github_actions/workflow/" + v
+			}
+			break
+		}
+	}
+
+	// Track unique `uses:` references so we emit one IMPORTS edge per action
+	// from the workflow file.
+	seenUses := map[string]bool{}
+
 	for _, p := range pairs {
 		key := pairKeyText(p, src)
 		startLine := int(p.StartPoint().Row) + 1
@@ -565,11 +586,20 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 				}
 				jStart := int(jp.StartPoint().Row) + 1
 				jEnd := int(jp.EndPoint().Row) + 1
-				entities = append(entities, entity(
+				jobRef := "github_actions/job/" + jobName
+				jobEnt := entity(
 					"SCOPE.Operation", jobName, "job",
-					"github_actions/job/"+jobName,
+					jobRef,
 					file.Path, "yaml", jStart, jEnd,
-				))
+				)
+				// CONTAINS: workflow (or file) → job.
+				parentRef := workflowRef
+				if parentRef == "" {
+					parentRef = file.Path
+				}
+				jobEnt.Relationships = append(jobEnt.Relationships,
+					containsRel(parentRef, jobRef))
+				entities = append(entities, jobEnt)
 
 				// Extract steps from this job
 				jobValNode := pairValueNode(jp)
@@ -591,21 +621,46 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 					stepName := findPairValueText(stepPairs, "name", src)
 					if stepName != "" {
 						sStart, sEnd := pairsLineRange(stepPairs)
-						entities = append(entities, entity(
+						stepRef := "github_actions/step/" + stepName
+						stepEnt := entity(
 							"SCOPE.Operation", stepName, "step",
-							"github_actions/step/"+stepName,
+							stepRef,
 							file.Path, "yaml", sStart, sEnd,
-						))
+						)
+						stepEnt.Relationships = append(stepEnt.Relationships,
+							containsRel(jobRef, stepRef))
+						entities = append(entities, stepEnt)
 					}
 					// uses action
 					usesVal := findPairValueText(stepPairs, "uses", src)
 					if usesVal != "" {
 						sStart, sEnd := pairsLineRange(stepPairs)
-						entities = append(entities, entity(
+						actionRef := "github_actions/action/" + usesVal
+						actionEnt := entity(
 							"SCOPE.Component", usesVal, "action",
-							"github_actions/action/"+usesVal,
+							actionRef,
 							file.Path, "yaml", sStart, sEnd,
-						))
+						)
+						// CONTAINS: job → action.
+						actionEnt.Relationships = append(actionEnt.Relationships,
+							containsRel(jobRef, actionRef))
+						// IMPORTS: workflow file → unique action reference
+						// (e.g. "actions/checkout@v4"). Attach to the workflow
+						// entity if we have one, otherwise to this entity.
+						if !seenUses[usesVal] {
+							seenUses[usesVal] = true
+							importRel := importsRel(file.Path, usesVal, "github_actions_uses")
+							if workflowRef != "" {
+								if wfIdx := findEntityIndex(entities, workflowRef); wfIdx >= 0 {
+									entities[wfIdx].Relationships = append(entities[wfIdx].Relationships, importRel)
+								} else {
+									actionEnt.Relationships = append(actionEnt.Relationships, importRel)
+								}
+							} else {
+								actionEnt.Relationships = append(actionEnt.Relationships, importRel)
+							}
+						}
+						entities = append(entities, actionEnt)
 					}
 				}
 			}
@@ -672,12 +727,16 @@ func extractGitLabCI(root *sitter.Node, file extractor.FileInput) []types.Entity
 			if gitlabReservedKeys[key] || key == "" {
 				continue
 			}
-			// Treat as a job definition
-			entities = append(entities, entity(
+			// Treat as a job definition. CONTAINS edge: file → job.
+			jobRef := "gitlab_ci/job/" + key
+			jobEnt := entity(
 				"SCOPE.Operation", key, "job",
-				"gitlab_ci/job/"+key,
+				jobRef,
 				file.Path, "yaml", startLine, endLine,
-			))
+			)
+			jobEnt.Relationships = append(jobEnt.Relationships,
+				containsRel(file.Path, jobRef))
+			entities = append(entities, jobEnt)
 
 			// Extract script entries
 			jobVal := pairValueNode(p)
@@ -731,16 +790,21 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 				}
 				sStart := int(sp.StartPoint().Row) + 1
 				sEnd := int(sp.EndPoint().Row) + 1
-				entities = append(entities, entity(
+				svcRef := "docker_compose/service/" + svcName
+				svcEnt := entity(
 					"SCOPE.Component", svcName, "service",
-					"docker_compose/service/"+svcName,
+					svcRef,
 					file.Path, "yaml", sStart, sEnd,
-				))
+				)
+				// CONTAINS: file → service.
+				svcEnt.Relationships = append(svcEnt.Relationships,
+					containsRel(file.Path, svcRef))
 
 				// Ports
 				svcVal := pairValueNode(sp)
 				svcBM := getBlockMapping(svcVal)
 				if svcBM == nil {
+					entities = append(entities, svcEnt)
 					continue
 				}
 				var svcPairs []*sitter.Node
@@ -750,14 +814,34 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 						svcPairs = append(svcPairs, child)
 					}
 				}
+
+				// IMPORTS: depends_on → service. Compose dependency chains
+				// look exactly like an import graph for purposes of resolution
+				// (see issue #386).
+				dependsNode := findValueNodeForKey(svcPairs, "depends_on", src)
+				for _, dep := range getSequenceItems(dependsNode, src) {
+					if dep == "" {
+						continue
+					}
+					targetRef := "docker_compose/service/" + dep
+					svcEnt.Relationships = append(svcEnt.Relationships,
+						importsRel(svcRef, targetRef, "compose_depends_on"))
+				}
+				entities = append(entities, svcEnt)
+
 				portsNode := findValueNodeForKey(svcPairs, "ports", src)
 				ports := getSequenceItems(portsNode, src)
 				for _, port := range ports {
-					entities = append(entities, entity(
+					portRef := "docker_compose/port/" + svcName + "/" + port
+					portEnt := entity(
 						"SCOPE.Pattern", port, "port",
-						"docker_compose/port/"+svcName+"/"+port,
+						portRef,
 						file.Path, "yaml", sStart, sEnd,
-					))
+					)
+					// CONTAINS: service → port.
+					portEnt.Relationships = append(portEnt.Relationships,
+						containsRel(svcRef, portRef))
+					entities = append(entities, portEnt)
 				}
 			}
 
@@ -770,11 +854,16 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 				}
 				vStart := int(vp.StartPoint().Row) + 1
 				vEnd := int(vp.EndPoint().Row) + 1
-				entities = append(entities, entity(
+				volRef := "docker_compose/volume/" + volName
+				volEnt := entity(
 					"SCOPE.Schema", volName, "volume",
-					"docker_compose/volume/"+volName,
+					volRef,
 					file.Path, "yaml", vStart, vEnd,
-				))
+				)
+				// CONTAINS: file → volume.
+				volEnt.Relationships = append(volEnt.Relationships,
+					containsRel(file.Path, volRef))
+				entities = append(entities, volEnt)
 			}
 
 		default:
@@ -839,17 +928,23 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 		endLine = int(doc.EndPoint().Row) + 1
 	}
 
+	resourceRef := ""
 	if metadataName != "" {
 		// Deployment/Service/StatefulSet/DaemonSet → SCOPE.Service; others → SCOPE.Component.
 		topKind := "SCOPE.Component"
 		if kindVal == "Service" || kindVal == "Deployment" || kindVal == "StatefulSet" || kindVal == "DaemonSet" {
 			topKind = "SCOPE.Service"
 		}
-		entities = append(entities, entity(
+		resourceRef = "k8s/resource/" + metadataName
+		resEnt := entity(
 			topKind, metadataName, "k8s_resource",
 			kindVal,
 			file.Path, "yaml", startLine, endLine,
-		))
+		)
+		// CONTAINS: file → resource.
+		resEnt.Relationships = append(resEnt.Relationships,
+			containsRel(file.Path, resourceRef))
+		entities = append(entities, resEnt)
 	}
 
 	specPairs := getMappingPairsForKey(pairs, "spec", src)
@@ -915,11 +1010,17 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				continue
 			}
 			icStart, icEnd := pairsLineRange(icPairs)
-			entities = append(entities, entity(
+			icRef := "k8s/init-container/" + name
+			icEnt := entity(
 				"SCOPE.Component", name, "init_container",
-				"k8s/init-container/"+name,
+				icRef,
 				file.Path, "yaml", icStart, icEnd,
-			))
+			)
+			if resourceRef != "" {
+				icEnt.Relationships = append(icEnt.Relationships,
+					containsRel(resourceRef, icRef))
+			}
+			entities = append(entities, icEnt)
 		}
 
 		// Main containers
@@ -930,11 +1031,17 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				continue
 			}
 			cStart, cEnd := pairsLineRange(cPairs)
-			entities = append(entities, entity(
+			cRef := "k8s/container/" + name
+			cEnt := entity(
 				"SCOPE.Component", name, "container",
-				"k8s/container/"+name,
+				cRef,
 				file.Path, "yaml", cStart, cEnd,
-			))
+			)
+			if resourceRef != "" {
+				cEnt.Relationships = append(cEnt.Relationships,
+					containsRel(resourceRef, cRef))
+			}
+			entities = append(entities, cEnt)
 
 			// containerPort values
 			portsNode := findValueNodeForKey(cPairs, "ports", src)
@@ -1147,9 +1254,10 @@ func extractAnsible(root *sitter.Node, file extractor.FileInput) []types.EntityR
 		if isDocSequence(doc) {
 			entities = append(entities, extractAnsiblePlaybookDoc(doc, file)...)
 		} else {
-			// Flat format: top-level tasks/handlers/roles keys.
+			// Flat format: top-level tasks/handlers/roles keys. No enclosing
+			// play, so CONTAINS edges (when emitted) are rooted at the file.
 			for _, p := range documentMappings(doc) {
-				entities = append(entities, extractAnsibleSectionPairs(p, file, src)...)
+				entities = append(entities, extractAnsibleSectionPairs(p, file, src, "")...)
 			}
 		}
 	}
@@ -1211,13 +1319,19 @@ func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []typ
 
 			// Emit play name (- name: ...) as SCOPE.Service
 			playName := findPairValueText(playPairs, "name", src)
+			playRef := ""
 			if playName != "" {
 				pStart, pEnd := pairsLineRange(playPairs)
-				entities = append(entities, entity(
+				playRef = "ansible/play/" + playName
+				playEnt := entity(
 					"SCOPE.Service", playName, "play",
-					"ansible/play/"+playName,
+					playRef,
 					file.Path, "yaml", pStart, pEnd,
-				))
+				)
+				// CONTAINS: file → play.
+				playEnt.Relationships = append(playEnt.Relationships,
+					containsRel(file.Path, playRef))
+				entities = append(entities, playEnt)
 			}
 
 			// Emit hosts target as SCOPE.Component
@@ -1231,9 +1345,10 @@ func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []typ
 				))
 			}
 
-			// Extract tasks, pre_tasks, post_tasks, handlers, roles
+			// Extract tasks, pre_tasks, post_tasks, handlers, roles. The play
+			// is the enclosing parent for the CONTAINS edges these emit.
 			for _, pp := range playPairs {
-				entities = append(entities, extractAnsibleSectionPairs(pp, file, src)...)
+				entities = append(entities, extractAnsibleSectionPairs(pp, file, src, playRef)...)
 			}
 		}
 	}
@@ -1243,10 +1358,21 @@ func extractAnsiblePlaybookDoc(doc *sitter.Node, file extractor.FileInput) []typ
 
 // extractAnsibleSectionPairs extracts entities from a single block_mapping_pair
 // that represents a section (tasks, pre_tasks, post_tasks, handlers, roles).
-func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []byte) []types.EntityRecord {
+// parentRef is the canonical ref of the enclosing play (e.g. "ansible/play/X")
+// or "" when there's no enclosing play (flat task file). When non-empty, every
+// emitted child carries a CONTAINS edge from parentRef.
+func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []byte, parentRef string) []types.EntityRecord {
 	key := pairKeyText(p, src)
 	valNode := pairValueNode(p)
 	var entities []types.EntityRecord
+
+	addContains := func(ent *types.EntityRecord, childRef string) {
+		if parentRef == "" {
+			return
+		}
+		ent.Relationships = append(ent.Relationships,
+			containsRel(parentRef, childRef))
+	}
 
 	switch key {
 	case "tasks", "pre_tasks", "post_tasks":
@@ -1257,11 +1383,14 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 				continue
 			}
 			tStart, tEnd := pairsLineRange(taskPairs)
-			entities = append(entities, entity(
+			ref := "ansible/task/" + name
+			ent := entity(
 				"SCOPE.Operation", name, "task",
-				"ansible/task/"+name,
+				ref,
 				file.Path, "yaml", tStart, tEnd,
-			))
+			)
+			addContains(&ent, ref)
+			entities = append(entities, ent)
 		}
 
 	case "handlers":
@@ -1272,11 +1401,14 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 				continue
 			}
 			hStart, hEnd := pairsLineRange(hPairs)
-			entities = append(entities, entity(
+			ref := "ansible/handler/" + name
+			ent := entity(
 				"SCOPE.Operation", name, "handler",
-				"ansible/handler/"+name,
+				ref,
 				file.Path, "yaml", hStart, hEnd,
-			))
+			)
+			addContains(&ent, ref)
+			entities = append(entities, ent)
 		}
 
 	case "roles":
@@ -1296,11 +1428,14 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 			if roleName == "" {
 				continue
 			}
-			entities = append(entities, entity(
+			ref := "ansible/role/" + roleName
+			ent := entity(
 				"SCOPE.Component", roleName, "role",
-				"ansible/role/"+roleName,
+				ref,
 				file.Path, "yaml", startLine, endLine,
-			))
+			)
+			addContains(&ent, ref)
+			entities = append(entities, ent)
 		}
 
 		// Also handle roles as mappings with role: key.
@@ -1311,11 +1446,14 @@ func extractAnsibleSectionPairs(p *sitter.Node, file extractor.FileInput, src []
 				continue
 			}
 			rStart, rEnd := pairsLineRange(rPairs)
-			entities = append(entities, entity(
+			ref := "ansible/role/" + roleName
+			ent := entity(
 				"SCOPE.Component", roleName, "role",
-				"ansible/role/"+roleName,
+				ref,
 				file.Path, "yaml", rStart, rEnd,
-			))
+			)
+			addContains(&ent, ref)
+			entities = append(entities, ent)
 		}
 	}
 

--- a/internal/extractors/yaml/relationships.go
+++ b/internal/extractors/yaml/relationships.go
@@ -1,0 +1,59 @@
+package yaml
+
+// Relationship helpers for the YAML extractor (Issue #386).
+//
+// The YAML extractor emits two relationship kinds:
+//
+//   - CONTAINS: structural parent → child edges. Each flavor knows its
+//     own structural hierarchy:
+//       GitHub Actions  workflow → job → step | action
+//       GitLab CI       file → job
+//       Docker Compose  file → service → port; file → volume
+//       Kubernetes      file → resource → container | init_container
+//       Ansible         play → task | role
+//     File-rooted edges use file.Path as FromID; nested edges use the
+//     parent's canonical ref (matching the child's QualifiedName scheme).
+//
+//   - IMPORTS: cross-references that look like dependencies in the
+//     container model:
+//       GitHub Actions  workflow file → `uses:` action ref (e.g.
+//                       actions/checkout@v4) — one IMPORTS per unique action.
+//       Docker Compose  service → service named in `depends_on:`.
+//
+// Every relationship is later tagged Properties["language"]="yaml" via
+// extractor.TagRelationshipsLanguage in extractByFlavor.
+
+import (
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// containsRel builds a CONTAINS RelationshipRecord (Properties left nil; the
+// resolver-tag pass fills language).
+func containsRel(fromID, toID string) types.RelationshipRecord {
+	return types.RelationshipRecord{FromID: fromID, ToID: toID, Kind: "CONTAINS"}
+}
+
+// importsRel builds an IMPORTS RelationshipRecord with the given importKind
+// recorded under Properties["import_kind"] for downstream resolver dispatch.
+func importsRel(fromID, toID, importKind string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: fromID,
+		ToID:   toID,
+		Kind:   "IMPORTS",
+		Properties: map[string]string{
+			"import_kind":   importKind,
+			"source_module": toID,
+		},
+	}
+}
+
+// findEntityIndex returns the index of the first entity whose QualifiedName
+// matches ref, or -1.
+func findEntityIndex(entities []types.EntityRecord, qualifiedName string) int {
+	for i := range entities {
+		if entities[i].QualifiedName == qualifiedName {
+			return i
+		}
+	}
+	return -1
+}

--- a/internal/extractors/yaml/relationships_test.go
+++ b/internal/extractors/yaml/relationships_test.go
@@ -1,0 +1,285 @@
+package yaml_test
+
+// Issue #386 — port relationships extraction to the YAML extractor.
+//
+// Contract:
+//   - CONTAINS: file → top-level structural entities, and parent → child
+//     for nested structures (job → step, service → port, etc.).
+//   - IMPORTS: cross-references to external resources where simple to detect:
+//        * GitHub Actions `uses: actions/checkout@v4`
+//        * Docker Compose `depends_on:` lists
+//
+// Every relationship is tagged Properties["language"]="yaml" via
+// extractor.TagRelationshipsLanguage so the resolver dispatches the YAML
+// dynamic-pattern catalog (#90).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findRels returns every embedded relationship across the given entity slice
+// matching the given Kind.
+func findRels(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func relExists(rels []types.RelationshipRecord, fromID, toID string) bool {
+	for _, r := range rels {
+		if r.FromID == fromID && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// GitHub Actions
+// ---------------------------------------------------------------------------
+
+func TestYAML_GHA_ContainsAndImports(t *testing.T) {
+	src := []byte(`name: CI
+on: [push]
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup
+        uses: actions/setup-go@v5
+  lint:
+    steps:
+      - name: Lint step
+        uses: golangci/golangci-lint-action@v4
+`)
+	entities, err := extractYAML(src, ".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	contains := findRels(entities, "CONTAINS")
+	imports := findRels(entities, "IMPORTS")
+
+	// File → workflow CONTAINS the two jobs.
+	if !relExists(contains, "github_actions/workflow/CI", "github_actions/job/build") {
+		t.Errorf("missing CONTAINS workflow→job(build); got %+v", contains)
+	}
+	if !relExists(contains, "github_actions/workflow/CI", "github_actions/job/lint") {
+		t.Errorf("missing CONTAINS workflow→job(lint); got %+v", contains)
+	}
+
+	// job → step
+	if !relExists(contains, "github_actions/job/build", "github_actions/step/Checkout") {
+		t.Errorf("missing CONTAINS job(build)→step(Checkout); got %+v", contains)
+	}
+
+	// job → action (uses)
+	if !relExists(contains, "github_actions/job/build", "github_actions/action/actions/checkout@v4") {
+		t.Errorf("missing CONTAINS job(build)→action; got %+v", contains)
+	}
+
+	// IMPORTS: workflow file imports each unique action.
+	if !relExists(imports, ".github/workflows/ci.yml", "actions/checkout@v4") {
+		t.Errorf("missing IMPORTS file→actions/checkout@v4; got %+v", imports)
+	}
+	if !relExists(imports, ".github/workflows/ci.yml", "actions/setup-go@v5") {
+		t.Errorf("missing IMPORTS file→actions/setup-go@v5; got %+v", imports)
+	}
+	if !relExists(imports, ".github/workflows/ci.yml", "golangci/golangci-lint-action@v4") {
+		t.Errorf("missing IMPORTS file→golangci-lint-action; got %+v", imports)
+	}
+
+	// Language tagging.
+	for _, r := range append(contains, imports...) {
+		if r.Properties["language"] != "yaml" {
+			t.Errorf("relationship %+v missing language=yaml tag", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Docker Compose
+// ---------------------------------------------------------------------------
+
+func TestYAML_Compose_ContainsAndDependsOn(t *testing.T) {
+	src := []byte(`version: "3.9"
+services:
+  api:
+    image: myapp:latest
+    ports:
+      - "8080:8080"
+    depends_on:
+      - db
+      - redis
+  db:
+    image: postgres:15
+  redis:
+    image: redis:7
+volumes:
+  data:
+`)
+	entities, err := extractYAML(src, "docker-compose.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	contains := findRels(entities, "CONTAINS")
+	imports := findRels(entities, "IMPORTS")
+
+	// File → service CONTAINS edges.
+	for _, svc := range []string{"api", "db", "redis"} {
+		if !relExists(contains, "docker-compose.yml", "docker_compose/service/"+svc) {
+			t.Errorf("missing CONTAINS file→service(%s); got %+v", svc, contains)
+		}
+	}
+
+	// File → volume CONTAINS edge.
+	if !relExists(contains, "docker-compose.yml", "docker_compose/volume/data") {
+		t.Errorf("missing CONTAINS file→volume(data); got %+v", contains)
+	}
+
+	// service → port (api → 8080).
+	if !relExists(contains, "docker_compose/service/api", "docker_compose/port/api/\"8080:8080\"") {
+		// Ports values may carry quotes — be lenient and just check prefix-match.
+		found := false
+		for _, r := range contains {
+			if r.FromID == "docker_compose/service/api" &&
+				r.Kind == "CONTAINS" &&
+				len(r.ToID) > len("docker_compose/port/api/") &&
+				r.ToID[:len("docker_compose/port/api/")] == "docker_compose/port/api/" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing CONTAINS api→port; got %+v", contains)
+		}
+	}
+
+	// IMPORTS: api depends_on db and redis.
+	if !relExists(imports, "docker_compose/service/api", "docker_compose/service/db") {
+		t.Errorf("missing IMPORTS api→db; got %+v", imports)
+	}
+	if !relExists(imports, "docker_compose/service/api", "docker_compose/service/redis") {
+		t.Errorf("missing IMPORTS api→redis; got %+v", imports)
+	}
+
+	// Language tagging.
+	for _, r := range append(contains, imports...) {
+		if r.Properties["language"] != "yaml" {
+			t.Errorf("relationship %+v missing language=yaml tag", r)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Kubernetes
+// ---------------------------------------------------------------------------
+
+func TestYAML_K8s_Contains(t *testing.T) {
+	src := []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      containers:
+        - name: app
+          image: nginx
+        - name: sidecar
+          image: envoy
+`)
+	entities, err := extractYAML(src, "deploy.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	contains := findRels(entities, "CONTAINS")
+
+	// File → resource.
+	if !relExists(contains, "deploy.yml", "k8s/resource/web") {
+		t.Errorf("missing CONTAINS file→resource(web); got %+v", contains)
+	}
+
+	// resource → containers.
+	if !relExists(contains, "k8s/resource/web", "k8s/container/app") {
+		t.Errorf("missing CONTAINS web→container(app); got %+v", contains)
+	}
+	if !relExists(contains, "k8s/resource/web", "k8s/container/sidecar") {
+		t.Errorf("missing CONTAINS web→container(sidecar); got %+v", contains)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// GitLab CI
+// ---------------------------------------------------------------------------
+
+func TestYAML_GitLabCI_Contains(t *testing.T) {
+	src := []byte(`stages:
+  - build
+  - test
+
+build_job:
+  stage: build
+  script:
+    - echo building
+
+test_job:
+  stage: test
+  script:
+    - echo testing
+`)
+	entities, err := extractYAML(src, ".gitlab-ci.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	contains := findRels(entities, "CONTAINS")
+
+	if !relExists(contains, ".gitlab-ci.yml", "gitlab_ci/job/build_job") {
+		t.Errorf("missing CONTAINS file→job(build_job); got %+v", contains)
+	}
+	if !relExists(contains, ".gitlab-ci.yml", "gitlab_ci/job/test_job") {
+		t.Errorf("missing CONTAINS file→job(test_job); got %+v", contains)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Ansible
+// ---------------------------------------------------------------------------
+
+func TestYAML_Ansible_Contains(t *testing.T) {
+	src := []byte(`---
+- name: Configure web
+  hosts: webservers
+  tasks:
+    - name: install nginx
+      apt: name=nginx
+    - name: start nginx
+      service: name=nginx state=started
+`)
+	entities, err := extractYAML(src, "playbook.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	contains := findRels(entities, "CONTAINS")
+
+	if !relExists(contains, "ansible/play/Configure web", "ansible/task/install nginx") {
+		t.Errorf("missing CONTAINS play→task(install nginx); got %+v", contains)
+	}
+	if !relExists(contains, "ansible/play/Configure web", "ansible/task/start nginx") {
+		t.Errorf("missing CONTAINS play→task(start nginx); got %+v", contains)
+	}
+}


### PR DESCRIPTION
## Summary

Port relationship extraction to the yaml extractor (Closes #386).

YAML structural shape varies per flavor, so each flavor wires its own
parent → child hierarchy:

- **CONTAINS**
  - GitHub Actions: workflow → job → {step, action}
  - GitLab CI: file → job
  - Docker Compose: file → service → port; file → volume
  - Kubernetes: file → resource → {container, init_container}
  - Ansible: file → play → {task, handler, role}
- **IMPORTS**
  - GitHub Actions `uses:` → unique action ref per workflow file
  - Docker Compose `depends_on:` → service → service edges

Every relationship is tagged `Properties["language"]="yaml"` via
`extractor.TagRelationshipsLanguage` so the resolver dispatches the
right dynamic-pattern catalog (#90).

## Test plan

- [x] `go test ./internal/extractors/yaml/...` (existing + 5 new flavor-specific relationship tests)
- [x] `go test ./...` (full suite, all green)
- [x] `go vet ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)