### PR TITLE
feat(fish): emit IMPORTS + CALLS + CONTAINS edges (Closes #371)

### DIFF
--- a/fixtures/real-world/fish/config.fish
+++ b/fixtures/real-world/fish/config.fish
@@ -8,6 +8,10 @@ set -gx EDITOR nvim
 set -gx PAGER less
 set -gx PATH $HOME/.local/bin $PATH
 
+# Source helper modules — exercises IMPORTS edges (#371).
+source $HOME/.config/fish/conf.d/aliases.fish
+. $HOME/.config/fish/conf.d/path.fish
+
 # ---------------------------------------------------------------------------
 # Prompt
 # ---------------------------------------------------------------------------

--- a/internal/extractors/fish/fish.go
+++ b/internal/extractors/fish/fish.go
@@ -6,6 +6,28 @@
 // Extracted entities:
 //   - function <name>                 → Kind="SCOPE.Operation", Subtype="function"
 //   - complete --command <name> …     → Kind="SCOPE.Operation", Subtype="completion"
+//   - source / . <path>               → Kind="SCOPE.Component",  Subtype="import"
+//                                       (carries one IMPORTS edge)
+//
+// Issue #371 (PORT-RELS-FISH) — emits the same three relationship kinds the
+// other ported extractors emit:
+//
+//   - IMPORTS: every `source <path>` and `. <path>` (dot-source) directive
+//     becomes a SCOPE.Component import-stub entity carrying a single IMPORTS
+//     edge from the source file → the imported path. Properties carry
+//     {source_module, import_kind="source"} matching the contract used by
+//     the lua / razor extractors.
+//
+//   - CALLS: every command invocation (first word of a non-blank, non-keyword
+//     line) inside a function body emits one CALLS edge per unique callee.
+//     Self-recursion is dropped, fish keywords (if/while/for/switch/begin/
+//     case/return/break/continue/and/or/not/end/else/function) are filtered.
+//
+//   - CONTAINS: the file itself acts as the structural container — a single
+//     SCOPE.Component "file" entity is emitted per .fish source carrying one
+//     CONTAINS edge per declared function with the canonical structural-ref
+//     shape `scope:operation:method:fish:<file>:<name>`
+//     (BuildOperationStructuralRef, Format A, #144).
 //
 // Registers itself via init() and is imported by registry_gen.go.
 package fish
@@ -44,7 +66,30 @@ var (
 	completionShortRE = regexp.MustCompile(
 		`(?m)^[ \t]*complete\s+(?:[^\n]*?)\-c\s+([A-Za-z_][A-Za-z0-9_\-]*)`,
 	)
+	// source <path>  or  . <path>   — fish import directives. The path may
+	// be quoted with single or double quotes. We capture everything up to
+	// end-of-line / first whitespace after the path token.
+	sourceLongRE = regexp.MustCompile(
+		`(?m)^[ \t]*source\s+(?:"([^"\n]+)"|'([^'\n]+)'|(\S+))`,
+	)
+	sourceDotRE = regexp.MustCompile(
+		`(?m)^[ \t]*\.\s+(?:"([^"\n]+)"|'([^'\n]+)'|(\S+))`,
+	)
+	// First-word command head on a line (used for CALLS extraction inside
+	// function bodies). Captures the leading identifier of an invocation.
+	commandHeadRE = regexp.MustCompile(
+		`(?m)^[ \t]*([A-Za-z_][A-Za-z0-9_\-]*)`,
+	)
 )
+
+// fishKeywords are tokens that begin a line but are NOT command invocations
+// (control flow + structural keywords). Filtered out of CALLS edges.
+var fishKeywords = map[string]bool{
+	"if": true, "else": true, "end": true, "while": true, "for": true,
+	"switch": true, "case": true, "begin": true, "function": true,
+	"return": true, "break": true, "continue": true,
+	"and": true, "or": true, "not": true,
+}
 
 // Extract processes the Fish source and returns entity records.
 // Never raises: on parse failure the extractor returns an empty list and
@@ -62,6 +107,43 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	var entities []types.EntityRecord
 	seen := make(map[string]bool)
 
+	// Pass 1: file-level container entity. We populate its CONTAINS edges
+	// as we discover functions below. Inserted at index 0 so subsequent
+	// CONTAINS appends mutate entities[0].
+	fileEntity := types.EntityRecord{
+		Name:       file.Path,
+		Kind:       "SCOPE.Component",
+		Subtype:    "file",
+		SourceFile: file.Path,
+		Language:   "fish",
+	}
+	entities = append(entities, fileEntity)
+
+	// Pass 2: IMPORTS — `source` and `.` (dot-source) directives become
+	// SCOPE.Component import-stub entities, one per unique imported path.
+	seenImport := make(map[string]bool)
+	for _, m := range sourceLongRE.FindAllStringSubmatchIndex(stripped, -1) {
+		path := importPathFromMatch(stripped, m)
+		if path == "" || seenImport[path] {
+			continue
+		}
+		seenImport[path] = true
+		startLine := strings.Count(stripped[:m[0]], "\n") + 1
+		entities = append(entities, makeImportEntity(file.Path, path, startLine))
+	}
+	for _, m := range sourceDotRE.FindAllStringSubmatchIndex(stripped, -1) {
+		path := importPathFromMatch(stripped, m)
+		if path == "" || seenImport[path] {
+			continue
+		}
+		seenImport[path] = true
+		startLine := strings.Count(stripped[:m[0]], "\n") + 1
+		entities = append(entities, makeImportEntity(file.Path, path, startLine))
+	}
+
+	// Pass 3: function declarations. For each function we capture its body
+	// substring so CALLS can be scanned. CONTAINS edges are appended to the
+	// file entity (index 0).
 	for _, m := range functionRE.FindAllStringSubmatchIndex(stripped, -1) {
 		name := stripped[m[2]:m[3]]
 		key := "fn:" + name
@@ -70,7 +152,12 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		}
 		seen[key] = true
 		startLine := strings.Count(stripped[:m[0]], "\n") + 1
-		endLine := findBlockEnd(stripped, m[1], startLine)
+		endLine, bodyStart, bodyEnd := findBlockBounds(stripped, m[1], startLine)
+		body := ""
+		if bodyStart >= 0 && bodyEnd >= bodyStart && bodyEnd <= len(stripped) {
+			body = stripped[bodyStart:bodyEnd]
+		}
+		calls := collectCalls(body, name)
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Operation",
@@ -81,10 +168,17 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 			EndLine:            endLine,
 			Signature:          "function " + name,
 			EnrichmentRequired: false,
+			Relationships:      calls,
+		})
+		// CONTAINS edge: file → function (Format A structural-ref).
+		toID := extractor.BuildOperationStructuralRef("fish", file.Path, name)
+		entities[0].Relationships = append(entities[0].Relationships, types.RelationshipRecord{
+			ToID: toID,
+			Kind: "CONTAINS",
 		})
 	}
 
-	// Completions — dedupe on name across both long and short flag forms.
+	// Pass 4: completions — dedupe on name across both long and short flag forms.
 	for _, m := range completionLongRE.FindAllStringSubmatchIndex(stripped, -1) {
 		name := stripped[m[2]:m[3]]
 		appendCompletion(&entities, seen, stripped, name, m[0], file.Path)
@@ -94,7 +188,87 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		appendCompletion(&entities, seen, stripped, name, m[0], file.Path)
 	}
 
+	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
+	extractor.TagRelationshipsLanguage(entities, "fish")
 	return entities, nil
+}
+
+// importPathFromMatch returns the captured path from a source/dot-source
+// regex match. The pattern has three alternation groups (double-quoted,
+// single-quoted, bare); pick whichever captured.
+func importPathFromMatch(src string, m []int) string {
+	// Groups 1, 2, 3 → indices 2..7 in the submatch index slice.
+	for g := 1; g <= 3; g++ {
+		s, e := m[2*g], m[2*g+1]
+		if s >= 0 && e > s {
+			return src[s:e]
+		}
+	}
+	return ""
+}
+
+// makeImportEntity builds the SCOPE.Component entity carrying a single
+// IMPORTS edge for a `source` / `.` directive.
+func makeImportEntity(filePath, importPath string, line int) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       importPath,
+		Kind:       "SCOPE.Component",
+		Subtype:    "import",
+		SourceFile: filePath,
+		Language:   "fish",
+		StartLine:  line,
+		EndLine:    line,
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID: filePath,
+				ToID:   importPath,
+				Kind:   "IMPORTS",
+				Properties: map[string]string{
+					"source_module": importPath,
+					"imported_name": importPath,
+					"import_kind":   "source",
+				},
+			},
+		},
+	}
+}
+
+// collectCalls scans a function body line-by-line for command invocations
+// and returns deduped CALLS edges. Skips fish keywords, `source`/`.`
+// (those produce IMPORTS), and self-recursion.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+	for _, line := range strings.Split(body, "\n") {
+		m := commandHeadRE.FindStringSubmatch(line)
+		if m == nil {
+			continue
+		}
+		head := m[1]
+		if head == "" || fishKeywords[head] {
+			continue
+		}
+		if head == callerName {
+			continue
+		}
+		if head == "source" {
+			// Dot-source `.` is not captured by commandHeadRE (it isn't
+			// an identifier), so we only need to filter `source`.
+			continue
+		}
+		if seen[head] {
+			continue
+		}
+		seen[head] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: head,
+			Kind: "CALLS",
+		})
+	}
+	return out
 }
 
 // appendCompletion builds a completion entity if one hasn't been seen already
@@ -119,21 +293,24 @@ func appendCompletion(out *[]types.EntityRecord, seen map[string]bool, src, name
 	})
 }
 
-// findBlockEnd returns the line number of the matching `end` keyword for a
-// `function` block starting at byte pos. If no matching `end` is found, the
-// function's start line is returned (graceful degradation on malformed input).
+// findBlockBounds returns the line number of the matching `end` keyword for
+// a `function` block starting at byte pos, plus the byte offsets [bodyStart,
+// bodyEnd) of the function body (everything strictly between the header line
+// and the closing `end`). On malformed input bodyStart=-1 and the start line
+// is returned.
 //
 // Fish uses function … end with other block constructs (if/while/for/switch/begin)
 // that also close with `end`. We track depth by scanning for recognised opening
 // keywords and the terminating `end`.
-func findBlockEnd(src string, pos int, startLine int) int {
+func findBlockBounds(src string, pos, startLine int) (endLine, bodyStart, bodyEnd int) {
 	// Advance past the remainder of the header line (everything between pos
 	// and the next newline is part of the function-signature line).
 	if nl := strings.IndexByte(src[pos:], '\n'); nl >= 0 {
 		pos += nl + 1
 	} else {
-		return startLine
+		return startLine, -1, -1
 	}
+	bodyStart = pos
 
 	depth := 1
 	line := startLine // the next full line we read is startLine+1.
@@ -143,6 +320,7 @@ func findBlockEnd(src string, pos int, startLine int) int {
 		line++
 		nl := strings.IndexByte(src[i:], '\n')
 		var segment string
+		var segStart = i
 		if nl < 0 {
 			segment = src[i:]
 			i = n
@@ -159,11 +337,18 @@ func findBlockEnd(src string, pos int, startLine int) int {
 		if trimmed == "end" || strings.HasPrefix(trimmed, "end ") || strings.HasPrefix(trimmed, "end;") {
 			depth--
 			if depth == 0 {
-				return line
+				return line, bodyStart, segStart
 			}
 		}
 	}
-	return startLine
+	return startLine, -1, -1
+}
+
+// findBlockEnd is the legacy line-only wrapper retained for callers that
+// don't need body bounds.
+func findBlockEnd(src string, pos int, startLine int) int {
+	endLine, _, _ := findBlockBounds(src, pos, startLine)
+	return endLine
 }
 
 // isOpener reports whether the trimmed line starts a fish block that must be

--- a/internal/extractors/fish/fish_test.go
+++ b/internal/extractors/fish/fish_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/extractor"
 	_ "github.com/cajasmota/archigraph/internal/extractors/fish"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 func TestFishExtractor_Registered(t *testing.T) {
@@ -176,9 +177,17 @@ end
 	if len(entities) < 1 {
 		t.Fatal("expected at least one entity")
 	}
-	e := entities[0]
-	if e.Name != "outer" {
-		t.Fatalf("expected outer, got %q", e.Name)
+	// Locate the function entity (the file-stub entity is also emitted as
+	// the CONTAINS container — skip it).
+	var e *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "function" && entities[i].Name == "outer" {
+			e = &entities[i]
+			break
+		}
+	}
+	if e == nil {
+		t.Fatalf("expected outer function, got %+v", entities)
 	}
 	// The function spans lines 1..7; the matching `end` is line 7.
 	if e.EndLine != 7 {
@@ -243,11 +252,20 @@ func TestFishExtractor_MalformedInput_NoPanic(t *testing.T) {
 		t.Fatalf("unexpected error on malformed input: %v", err)
 	}
 	// We still extract the function name; EndLine falls back to StartLine.
-	if len(entities) != 1 {
-		t.Fatalf("expected 1 entity on malformed input, got %d", len(entities))
+	// (The file-stub container entity is also emitted, so we look up the
+	// function entity explicitly rather than asserting on the slice length.)
+	var fn *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "function" {
+			fn = &entities[i]
+			break
+		}
 	}
-	if entities[0].EndLine < entities[0].StartLine {
-		t.Errorf("EndLine %d < StartLine %d", entities[0].EndLine, entities[0].StartLine)
+	if fn == nil {
+		t.Fatalf("expected function entity on malformed input, got %+v", entities)
+	}
+	if fn.EndLine < fn.StartLine {
+		t.Errorf("EndLine %d < StartLine %d", fn.EndLine, fn.StartLine)
 	}
 }
 

--- a/internal/extractors/fish/relationships_test.go
+++ b/internal/extractors/fish/relationships_test.go
@@ -1,0 +1,366 @@
+package fish_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/fish"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func extractFish(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("fish")
+	if !ok {
+		t.Fatal("fish extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "fish",
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	return got
+}
+
+func relsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func findFishByName(entities []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range entities {
+		if entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+func hasFishRel(entities []types.EntityRecord, kind, toContains string) bool {
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind && strings.Contains(r.ToID, toContains) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---- IMPORTS ---------------------------------------------------------------
+
+func TestRelationships_Imports_SourceLong(t *testing.T) {
+	src := `source path/to/lib.fish
+
+function hello
+    echo hi
+end
+`
+	entities := extractFish(t, "config.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "path/to/lib.fish" {
+		t.Errorf("IMPORTS ToID = %q, want path/to/lib.fish", rels[0].ToID)
+	}
+	if rels[0].FromID != "config.fish" {
+		t.Errorf("IMPORTS FromID = %q, want config.fish", rels[0].FromID)
+	}
+	if rels[0].Properties["import_kind"] != "source" {
+		t.Errorf("import_kind = %q, want source", rels[0].Properties["import_kind"])
+	}
+	if rels[0].Properties["language"] != "fish" {
+		t.Errorf("language = %q, want fish", rels[0].Properties["language"])
+	}
+}
+
+func TestRelationships_Imports_DotSource(t *testing.T) {
+	src := `. helpers.fish
+. another/file.fish
+`
+	entities := extractFish(t, "config.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 2 {
+		t.Fatalf("IMPORTS count = %d, want 2", len(rels))
+	}
+	wants := map[string]bool{"helpers.fish": false, "another/file.fish": false}
+	for _, r := range rels {
+		if _, ok := wants[r.ToID]; ok {
+			wants[r.ToID] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing IMPORTS to %q", k)
+		}
+	}
+}
+
+func TestRelationships_Imports_NoneWhenAbsent(t *testing.T) {
+	src := `function hello
+    echo hi
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Errorf("IMPORTS count = %d, want 0", len(rels))
+	}
+}
+
+func TestRelationships_Imports_DedupesIdentical(t *testing.T) {
+	src := `source dup.fish
+source dup.fish
+`
+	entities := extractFish(t, "x.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Errorf("IMPORTS dedup count = %d, want 1", len(rels))
+	}
+}
+
+func TestRelationships_Imports_QuotedPath(t *testing.T) {
+	src := `source "quoted/path.fish"
+source 'single/quoted.fish'
+`
+	entities := extractFish(t, "x.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 2 {
+		t.Fatalf("IMPORTS count = %d, want 2", len(rels))
+	}
+	wants := map[string]bool{"quoted/path.fish": false, "single/quoted.fish": false}
+	for _, r := range rels {
+		if _, ok := wants[r.ToID]; ok {
+			wants[r.ToID] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing IMPORTS to %q", k)
+		}
+	}
+}
+
+func TestRelationships_Imports_SkipsCommented(t *testing.T) {
+	src := `# source commented.fish
+source real.fish
+`
+	entities := extractFish(t, "x.fish", src)
+	rels := relsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "real.fish" {
+		t.Errorf("ToID = %q, want real.fish", rels[0].ToID)
+	}
+}
+
+// ---- CALLS -----------------------------------------------------------------
+
+func TestRelationships_Calls_FromFunctionBody(t *testing.T) {
+	src := `function ll
+    ls -lAh $argv
+    grep foo
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	h := findFishByName(entities, "ll")
+	if h == nil {
+		t.Fatal("ll function not found")
+	}
+	var calls []string
+	for _, r := range h.Relationships {
+		if r.Kind == "CALLS" {
+			calls = append(calls, r.ToID)
+		}
+	}
+	wants := map[string]bool{"ls": false, "grep": false}
+	for _, c := range calls {
+		if _, ok := wants[c]; ok {
+			wants[c] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing CALLS to %q (got %v)", k, calls)
+		}
+	}
+}
+
+func TestRelationships_Calls_DedupedPerFunction(t *testing.T) {
+	src := `function runner
+    foo
+    foo
+    foo
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	h := findFishByName(entities, "runner")
+	if h == nil {
+		t.Fatal("runner not found")
+	}
+	count := 0
+	for _, r := range h.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "foo" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("CALLS to foo count = %d, want 1 (deduped)", count)
+	}
+}
+
+func TestRelationships_Calls_SkipsKeywords(t *testing.T) {
+	src := `function r
+    if test -n "$x"
+        echo hi
+    else
+        echo bye
+    end
+    for i in 1 2 3
+        echo $i
+    end
+    while true
+        break
+    end
+    switch $argv[1]
+        case foo
+            echo foo
+    end
+    return 0
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	h := findFishByName(entities, "r")
+	if h == nil {
+		t.Fatal("r not found")
+	}
+	for _, rel := range h.Relationships {
+		if rel.Kind != "CALLS" {
+			continue
+		}
+		switch rel.ToID {
+		case "if", "else", "end", "for", "while", "switch", "case", "return",
+			"break", "continue", "and", "or", "not", "begin", "function":
+			t.Errorf("CALLS to keyword %q should not be emitted", rel.ToID)
+		}
+	}
+}
+
+func TestRelationships_Calls_SkipsSelfRecursion(t *testing.T) {
+	src := `function fact
+    fact $argv
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	h := findFishByName(entities, "fact")
+	if h == nil {
+		t.Fatal("fact not found")
+	}
+	for _, r := range h.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "fact" {
+			t.Error("self-recursion CALLS should be filtered")
+		}
+	}
+}
+
+func TestRelationships_Calls_NoneOutsideFunction(t *testing.T) {
+	// Top-level commands are not extracted as functions; CALLS only emit
+	// from within function bodies.
+	src := `set -gx EDITOR nvim
+echo "hi"
+`
+	entities := extractFish(t, "x.fish", src)
+	rels := relsByKind(entities, "CALLS")
+	if len(rels) != 0 {
+		t.Errorf("CALLS count = %d, want 0 (no functions)", len(rels))
+	}
+}
+
+// ---- CONTAINS --------------------------------------------------------------
+
+func TestRelationships_Contains_FileToFunction(t *testing.T) {
+	src := `function hello
+    echo hi
+end
+`
+	entities := extractFish(t, "config.fish", src)
+	wantRef := extractor.BuildOperationStructuralRef("fish", "config.fish", "hello")
+	if !hasFishRel(entities, "CONTAINS", wantRef) {
+		t.Errorf("expected CONTAINS to %q\ngot: %+v", wantRef, entities)
+	}
+}
+
+func TestRelationships_Contains_MultipleFunctions(t *testing.T) {
+	src := `function a
+    echo a
+end
+
+function b
+    echo b
+end
+
+function c
+    echo c
+end
+`
+	entities := extractFish(t, "x.fish", src)
+	count := 0
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" {
+				count++
+			}
+		}
+	}
+	if count < 3 {
+		t.Errorf("CONTAINS count = %d, want >= 3", count)
+	}
+}
+
+func TestRelationships_Contains_UsesStructuralRef(t *testing.T) {
+	src := `function onClick
+end
+`
+	entities := extractFish(t, "pages/foo.fish", src)
+	if !hasFishRel(entities, "CONTAINS", "scope:operation:method:fish:pages/foo.fish:onClick") {
+		t.Errorf("expected CONTAINS structural-ref")
+	}
+}
+
+// ---- Combined --------------------------------------------------------------
+
+func TestRelationships_Combined_AllThreeKinds(t *testing.T) {
+	src := `source helpers.fish
+
+function greet
+    echo "hi"
+    helper
+end
+`
+	entities := extractFish(t, "config.fish", src)
+	if len(relsByKind(entities, "IMPORTS")) < 1 {
+		t.Errorf("expected >= 1 IMPORTS")
+	}
+	if len(relsByKind(entities, "CALLS")) < 1 {
+		t.Errorf("expected >= 1 CALLS")
+	}
+	if len(relsByKind(entities, "CONTAINS")) < 1 {
+		t.Errorf("expected >= 1 CONTAINS")
+	}
+}


### PR DESCRIPTION
## Summary

Adds relationship emission to the fish-shell extractor (Issue #371, PORT-RELS-FISH).

- **IMPORTS**: `source <path>` and `. <path>` (dot-source) directives become SCOPE.Component import-stub entities, one per unique imported path. Each carries an IMPORTS edge with `Properties{source_module, imported_name, import_kind="source"}` matching the lua/razor contract.
- **CALLS**: every command invocation (first identifier on a non-keyword line) inside a function body emits one CALLS edge per unique callee. Self-recursion is dropped, fish keywords (`if/else/end/while/for/switch/case/begin/function/return/break/continue/and/or/not`) are filtered, `source` is excluded (handled by IMPORTS).
- **CONTAINS**: a file-stub SCOPE.Component entity (subtype="file") carries one CONTAINS edge per declared function using the canonical Format A structural-ref `scope:operation:method:fish:<file>:<name>` via `BuildOperationStructuralRef`.
- All embedded relationships are tagged with `Properties[language]="fish"` via `TagRelationshipsLanguage` for the resolver's dynamic-pattern dispatch (#90).

## Test plan

- [x] 14 new tests in `internal/extractors/fish/relationships_test.go` covering IMPORTS (long source, dot-source, dedupe, quoted, commented, absent), CALLS (function body, dedupe, keywords, self-recursion, none-outside-function), CONTAINS (file→function, multiple, structural-ref shape), and a combined fixture.
- [x] Existing fish tests updated where they previously asserted on `entities[0]` — they now look up the function entity by subtype since a file-stub container entity is also emitted.
- [x] Real-world fixture `fixtures/real-world/fish/config.fish` extended with `source` and `.` directives so the fixture exercises IMPORTS.
- [x] `go test ./internal/extractors/fish/...` — 25 tests pass (11 existing + 14 new).
- [x] `go test ./...` — full repo passes, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)