### PR TITLE
feat(dockerfile): emit IMPORTS for FROM + CONTAINS for stages

### DIFF
--- a/internal/extractors/dockerfile/dockerfile.go
+++ b/internal/extractors/dockerfile/dockerfile.go
@@ -74,6 +74,10 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	lineCount := strings.Count(string(file.Content), "\n") + 1
 	entities, stageCount := walkDockerfile(tree.RootNode(), file)
 
+	// Issue #384 — language tag for resolver dynamic-pattern dispatch on
+	// IMPORTS / CONTAINS / USES edges.
+	extractor.TagRelationshipsLanguage(entities, "dockerfile")
+
 	span.SetAttributes(
 		attribute.Int("file_line_count", lineCount),
 		attribute.Int("entity_count", len(entities)),
@@ -93,6 +97,11 @@ func walkDockerfile(root *sitter.Node, file extractor.FileInput) ([]types.Entity
 	stageCount := 0
 	currentStage := "" // alias of the current FROM stage
 
+	// Track stage image names in order (for the file-level CONTAINS component)
+	// and an alias→imageName map (for COPY --from=<alias> USES edges).
+	var stageImages []string
+	aliasToImage := map[string]string{}
+
 	for i := range root.ChildCount() {
 		node := root.Child(int(i))
 		if node == nil {
@@ -104,6 +113,10 @@ func walkDockerfile(root *sitter.Node, file extractor.FileInput) ([]types.Entity
 			if rec, ok := buildFrom(node, file, &currentStage); ok {
 				entities = append(entities, rec)
 				stageCount++
+				stageImages = append(stageImages, rec.Name)
+				if currentStage != "" {
+					aliasToImage[currentStage] = rec.Name
+				}
 			}
 
 		case "run_instruction":
@@ -113,6 +126,7 @@ func walkDockerfile(root *sitter.Node, file extractor.FileInput) ([]types.Entity
 
 		case "copy_instruction":
 			if rec, ok := buildCopyLike(node, file, currentStage, "COPY"); ok {
+				attachCopyFromUses(node, file, &rec, aliasToImage)
 				entities = append(entities, rec)
 			}
 
@@ -145,6 +159,12 @@ func walkDockerfile(root *sitter.Node, file extractor.FileInput) ([]types.Entity
 				entities = append(entities, rec)
 			}
 		}
+	}
+
+	// Issue #384 — emit a file-level SCOPE.Component carrying CONTAINS edges
+	// to every stage. Skipped when there are no FROM instructions.
+	if len(stageImages) > 0 {
+		entities = append(entities, buildFileComponent(file, stageImages))
 	}
 
 	return entities, stageCount
@@ -230,17 +250,36 @@ func buildFrom(node *sitter.Node, file extractor.FileInput, currentStage *string
 		props["tag"] = tag
 	}
 
+	// Issue #384 — IMPORTS edge file→image (base image as external dependency).
+	importProps := map[string]string{
+		"import_kind":   "from",
+		"source_module": imageName,
+		"imported_name": imageName,
+	}
+	if alias != "" {
+		importProps["local_name"] = alias
+	}
+	rels := []types.RelationshipRecord{
+		{
+			FromID:     file.Path,
+			ToID:       imageName,
+			Kind:       "IMPORTS",
+			Properties: importProps,
+		},
+	}
+
 	return types.EntityRecord{
-		Name:         imageName,
-		Kind:         "SCOPE.Component",
-		Subtype:      "stage",
-		SourceFile:   file.Path,
-		Language:     "dockerfile",
-		StartLine:    int(node.StartPoint().Row) + 1,
-		EndLine:      int(node.EndPoint().Row) + 1,
-		Signature:    "FROM " + imageName,
-		Properties:   props,
-		QualityScore: 0.8,
+		Name:          imageName,
+		Kind:          "SCOPE.Component",
+		Subtype:       "stage",
+		SourceFile:    file.Path,
+		Language:      "dockerfile",
+		StartLine:     int(node.StartPoint().Row) + 1,
+		EndLine:       int(node.EndPoint().Row) + 1,
+		Signature:     "FROM " + imageName,
+		Properties:    props,
+		Relationships: rels,
+		QualityScore:  0.8,
 	}, true
 }
 
@@ -420,4 +459,70 @@ func buildEntrypointOrCmd(node *sitter.Node, file extractor.FileInput, stage, in
 		Properties:   props,
 		QualityScore: 0.8,
 	}, true
+}
+
+// buildFileComponent emits a single file-level SCOPE.Component carrying one
+// CONTAINS edge per stage in stageImages. Issue #384 — multi-stage Dockerfile
+// CONTAINS each stage. The structural-ref shape mirrors every Format A
+// emitter via BuildOperationStructuralRef.
+func buildFileComponent(file extractor.FileInput, stageImages []string) types.EntityRecord {
+	name := file.Path
+	if slash := strings.LastIndexByte(file.Path, '/'); slash >= 0 {
+		name = file.Path[slash+1:]
+	}
+	rels := make([]types.RelationshipRecord, 0, len(stageImages))
+	for _, img := range stageImages {
+		rels = append(rels, types.RelationshipRecord{
+			ToID: extractor.BuildOperationStructuralRef("dockerfile", file.Path, img),
+			Kind: "CONTAINS",
+		})
+	}
+	return types.EntityRecord{
+		Name:          name,
+		Kind:          "SCOPE.Component",
+		Subtype:       "dockerfile",
+		SourceFile:    file.Path,
+		Language:      "dockerfile",
+		Relationships: rels,
+		QualityScore:  0.7,
+	}
+}
+
+// attachCopyFromUses inspects a copy_instruction node for a `--from=<stage>`
+// param and, if found, attaches a USES relationship to rec pointing at the
+// referenced stage's structural-ref. The stage may be referenced by alias
+// (resolved via aliasToImage) or by raw image name (passed through).
+func attachCopyFromUses(node *sitter.Node, file extractor.FileInput, rec *types.EntityRecord, aliasToImage map[string]string) {
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil || ch.Type() != "param" {
+			continue
+		}
+		raw := nodeText(ch, file.Content)
+		// raw is e.g. "--from=builder". Split on '='.
+		eq := strings.IndexByte(raw, '=')
+		if eq < 0 {
+			continue
+		}
+		key := strings.TrimSpace(strings.TrimPrefix(raw[:eq], "--"))
+		if key != "from" {
+			continue
+		}
+		stageRef := strings.TrimSpace(raw[eq+1:])
+		if stageRef == "" {
+			continue
+		}
+		target := stageRef
+		if img, ok := aliasToImage[stageRef]; ok {
+			target = img
+		}
+		rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+			FromID: file.Path,
+			ToID:   extractor.BuildOperationStructuralRef("dockerfile", file.Path, target),
+			Kind:   "USES",
+			Properties: map[string]string{
+				"from_stage": stageRef,
+			},
+		})
+	}
 }

--- a/internal/extractors/dockerfile/dockerfile_test.go
+++ b/internal/extractors/dockerfile/dockerfile_test.go
@@ -389,13 +389,21 @@ func TestDockerfileExtractor_FromScratch(t *testing.T) {
 	tree := parseForTest(t, src)
 	entities := extractEntities(t, "Dockerfile", src, tree)
 
-	if len(entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(entities))
+	// Issue #384: in addition to the FROM stage entity, the extractor emits a
+	// file-level SCOPE.Component carrying CONTAINS edges. Filter to the stage.
+	var stages []types.EntityRecord
+	for _, e := range entities {
+		if e.Subtype == "stage" {
+			stages = append(stages, e)
+		}
 	}
-	if entities[0].Name != "scratch" {
-		t.Errorf("expected Name='scratch', got %q", entities[0].Name)
+	if len(stages) != 1 {
+		t.Fatalf("expected 1 stage entity, got %d (all=%d)", len(stages), len(entities))
 	}
-	if entities[0].Subtype != "stage" {
-		t.Errorf("expected Subtype='stage', got %q", entities[0].Subtype)
+	if stages[0].Name != "scratch" {
+		t.Errorf("expected Name='scratch', got %q", stages[0].Name)
+	}
+	if stages[0].Subtype != "stage" {
+		t.Errorf("expected Subtype='stage', got %q", stages[0].Subtype)
 	}
 }

--- a/internal/extractors/dockerfile/relationships_test.go
+++ b/internal/extractors/dockerfile/relationships_test.go
@@ -1,0 +1,151 @@
+package dockerfile_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/dockerfile"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// collectRels returns all relationships across entities matching the kind.
+func collectRels(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// TestDockerfile_Imports_FromInstruction asserts every FROM yields an IMPORTS
+// edge file→image (treating the base image as an external dependency).
+func TestDockerfile_Imports_FromInstruction(t *testing.T) {
+	src := `FROM golang:1.22 AS builder
+RUN go build ./...
+
+FROM ubuntu:22.04 AS runtime
+EXPOSE 8080
+`
+	tree := parseForTest(t, src)
+	entities := extractEntities(t, "Dockerfile", src, tree)
+
+	imports := collectRels(entities, "IMPORTS")
+	wantImages := map[string]bool{"golang:1.22": false, "ubuntu:22.04": false}
+	for _, r := range imports {
+		if r.FromID != "Dockerfile" {
+			t.Errorf("IMPORTS FromID: want Dockerfile, got %q", r.FromID)
+		}
+		if _, ok := wantImages[r.ToID]; ok {
+			wantImages[r.ToID] = true
+		}
+		if r.Properties["language"] != "dockerfile" {
+			t.Errorf("IMPORTS missing language=dockerfile, got %q", r.Properties["language"])
+		}
+		if r.Properties["import_kind"] != "from" {
+			t.Errorf("IMPORTS import_kind: want 'from', got %q", r.Properties["import_kind"])
+		}
+	}
+	for img, seen := range wantImages {
+		if !seen {
+			t.Errorf("missing IMPORTS for image %q. got %+v", img, imports)
+		}
+	}
+}
+
+// TestDockerfile_Contains_Stages asserts a file-level SCOPE.Component is
+// emitted carrying one CONTAINS edge per FROM stage.
+func TestDockerfile_Contains_Stages(t *testing.T) {
+	src := `FROM golang:1.22 AS builder
+RUN go build ./...
+
+FROM ubuntu:22.04 AS runtime
+EXPOSE 8080
+`
+	tree := parseForTest(t, src)
+	entities := extractEntities(t, "Dockerfile", src, tree)
+
+	contains := collectRels(entities, "CONTAINS")
+	if len(contains) != 2 {
+		t.Fatalf("expected 2 CONTAINS edges, got %d: %+v", len(contains), contains)
+	}
+
+	wantToIDs := map[string]bool{
+		extractor.BuildOperationStructuralRef("dockerfile", "Dockerfile", "golang:1.22"):  false,
+		extractor.BuildOperationStructuralRef("dockerfile", "Dockerfile", "ubuntu:22.04"): false,
+	}
+	for _, r := range contains {
+		if _, ok := wantToIDs[r.ToID]; ok {
+			wantToIDs[r.ToID] = true
+		}
+	}
+	for to, seen := range wantToIDs {
+		if !seen {
+			t.Errorf("missing CONTAINS to %q. got %+v", to, contains)
+		}
+	}
+}
+
+// TestDockerfile_Contains_NoStagesNoComponent asserts no file-level component
+// is emitted when there are no FROM instructions (degenerate input).
+func TestDockerfile_Contains_NoStagesNoComponent(t *testing.T) {
+	src := `# only a comment
+`
+	tree := parseForTest(t, src)
+	entities := extractEntities(t, "Dockerfile", src, tree)
+
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" {
+				t.Errorf("unexpected CONTAINS edge: %+v", r)
+			}
+		}
+	}
+}
+
+// TestDockerfile_Uses_CopyFromStage asserts COPY --from=<stage> emits a USES
+// edge to the referenced stage structural-ref.
+func TestDockerfile_Uses_CopyFromStage(t *testing.T) {
+	src := `FROM golang:1.22 AS builder
+RUN go build -o /app/bin ./...
+
+FROM ubuntu:22.04 AS runtime
+COPY --from=builder /app/bin /usr/local/bin
+`
+	tree := parseForTest(t, src)
+	entities := extractEntities(t, "Dockerfile", src, tree)
+
+	uses := collectRels(entities, "USES")
+	if len(uses) != 1 {
+		t.Fatalf("expected 1 USES edge, got %d: %+v", len(uses), uses)
+	}
+	wantTo := extractor.BuildOperationStructuralRef("dockerfile", "Dockerfile", "golang:1.22")
+	if uses[0].ToID != wantTo {
+		t.Errorf("USES ToID: want %q, got %q", wantTo, uses[0].ToID)
+	}
+	if uses[0].Properties["language"] != "dockerfile" {
+		t.Errorf("USES missing language=dockerfile, got %q", uses[0].Properties["language"])
+	}
+	if uses[0].Properties["from_stage"] != "builder" {
+		t.Errorf("USES from_stage: want 'builder', got %q", uses[0].Properties["from_stage"])
+	}
+}
+
+// TestDockerfile_Imports_SingleStageNoAlias asserts FROM without AS still
+// emits an IMPORTS edge.
+func TestDockerfile_Imports_SingleStageNoAlias(t *testing.T) {
+	src := "FROM alpine:3.18\n"
+	tree := parseForTest(t, src)
+	entities := extractEntities(t, "Dockerfile", src, tree)
+
+	imports := collectRels(entities, "IMPORTS")
+	if len(imports) != 1 {
+		t.Fatalf("expected 1 IMPORTS edge, got %d: %+v", len(imports), imports)
+	}
+	if imports[0].ToID != "alpine:3.18" {
+		t.Errorf("IMPORTS ToID: want alpine:3.18, got %q", imports[0].ToID)
+	}
+}


### PR DESCRIPTION
Closes #384.

## Summary
- Emit `IMPORTS` edge `file -> base image` for every `FROM` instruction, treating the base image as an external dependency. Properties: `import_kind=from`, `source_module`, `imported_name`, `local_name` (when `AS <alias>`), and the standard `language=dockerfile` tag.
- Emit a file-level `SCOPE.Component` (subtype=`dockerfile`) carrying one `CONTAINS` edge per stage via `BuildOperationStructuralRef("dockerfile", file, imageName)` — same Format A shape used by shell, java, python, et al.
- Emit a `USES` edge for `COPY --from=<stage>`, resolving the alias back to the stage's image name so the ToID points at the canonical stage entity. Tags `from_stage` in properties.
- `TagRelationshipsLanguage` stamps `language=dockerfile` on every new edge for resolver dynamic-pattern dispatch.

## Test plan
- [x] `go test ./internal/extractors/dockerfile/...` — 19 tests pass (5 new in `relationships_test.go`, 14 existing).
- [x] `go test ./...` — full suite green.
- [x] Existing `TestDockerfileExtractor_FromScratch` updated to filter to stage entities (file-level component is now also emitted).

## New tests
- `TestDockerfile_Imports_FromInstruction` — multi-stage Dockerfile yields IMPORTS for each base image.
- `TestDockerfile_Imports_SingleStageNoAlias` — `FROM alpine:3.18` (no `AS`) yields a single IMPORTS edge.
- `TestDockerfile_Contains_Stages` — file-level component CONTAINS each stage via Format A structural-ref.
- `TestDockerfile_Contains_NoStagesNoComponent` — degenerate input (comments only) emits no CONTAINS.
- `TestDockerfile_Uses_CopyFromStage` — `COPY --from=builder` emits USES pointing at the resolved stage.