### PR TITLE
feat(just): emit IMPORTS + CALLS + CONTAINS edges (#374)

### DIFF
--- a/internal/extractors/just/just.go
+++ b/internal/extractors/just/just.go
@@ -8,6 +8,10 @@
 // Extracted entities:
 //   - recipe_name [deps...]:          → Kind="SCOPE.Operation", Subtype="recipe"
 //   - variable := value                → Kind="SCOPE.Schema",   Subtype="variable"
+//   - import "<path>"                  → Kind="SCOPE.Component", Subtype="import"
+//                                        (carries one IMPORTS edge)
+//   - file-level container            → Kind="SCOPE.Component", Subtype="file"
+//                                        (carries CONTAINS edges)
 //
 // (SCOPE.Schema matches the convention used by the Dockerfile extractor for
 // ENV/ARG — both are configuration-style name/value pairs bound at build
@@ -16,6 +20,23 @@
 // Recipe dependencies (the tokens after the colon on a recipe line) are
 // recorded in the recipe entity's Properties["dependencies"] —
 // they are relationship metadata, not standalone entities.
+//
+// Issue #374 (PORT-RELS-JUST) — emits the same three relationship kinds the
+// other ported extractors emit:
+//
+//   - IMPORTS: every `import "<path>"` directive (including `import?` for
+//     optional imports) becomes a SCOPE.Component import-stub entity carrying
+//     a single IMPORTS edge from the justfile → the imported path. Mirrors
+//     the contract used by the fish / lua extractors.
+//
+//   - CALLS: every recipe dependency token (the names following the
+//     recipe-separating `:`) emits one CALLS edge per unique callee, attached
+//     to the recipe entity. `release: (lint "strict") (vet)` therefore emits
+//     CALLS edges to `lint` and `vet`. Self-recursion is dropped.
+//
+//   - CONTAINS: a file-level SCOPE.Component (subtype="file") emits one
+//     CONTAINS edge per declared recipe via BuildOperationStructuralRef
+//     (Format A, #144).
 //
 // Registers itself via init() and is imported by registry_gen.go.
 package just
@@ -76,6 +97,12 @@ var (
 	variableRE = regexp.MustCompile(
 		`(?m)^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*:=\s*([^\n#]*)`,
 	)
+	// importRE captures: `import "path"`, `import 'path'`, `import? "path"`.
+	// Just's `import` directive must appear at column 0; the path may be
+	// double- or single-quoted.
+	importRE = regexp.MustCompile(
+		`(?m)^import\??\s+(?:"([^"\n]+)"|'([^'\n]+)')`,
+	)
 )
 
 // Extract processes the Justfile source and returns entity records.
@@ -84,10 +111,62 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		return nil, nil
 	}
 	src := string(file.Content)
+	// Strip line comments so commented-out import/recipe lines don't match.
+	stripped := stripLineComments(src)
 
 	var entities []types.EntityRecord
 	seenRecipe := make(map[string]bool)
 	seenVar := make(map[string]bool)
+
+	// File-level container entity (CONTAINS edges appended below).
+	fileEntity := types.EntityRecord{
+		Name:       file.Path,
+		Kind:       "SCOPE.Component",
+		Subtype:    "file",
+		SourceFile: file.Path,
+		Language:   "just",
+	}
+	entities = append(entities, fileEntity)
+	const fileIdx = 0
+
+	// IMPORTS — `import "path"` / `import? "path"` directives become
+	// SCOPE.Component import-stub entities, one per unique imported path.
+	seenImport := make(map[string]bool)
+	for _, m := range importRE.FindAllStringSubmatchIndex(stripped, -1) {
+		var path string
+		// Two alternation groups: double-quoted (g1) and single-quoted (g2).
+		if m[2] >= 0 && m[3] > m[2] {
+			path = stripped[m[2]:m[3]]
+		} else if m[4] >= 0 && m[5] > m[4] {
+			path = stripped[m[4]:m[5]]
+		}
+		if path == "" || seenImport[path] {
+			continue
+		}
+		seenImport[path] = true
+		startLine := strings.Count(stripped[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       path,
+			Kind:       "SCOPE.Component",
+			Subtype:    "import",
+			SourceFile: file.Path,
+			Language:   "just",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: file.Path,
+					ToID:   path,
+					Kind:   "IMPORTS",
+					Properties: map[string]string{
+						"source_module": path,
+						"imported_name": path,
+						"import_kind":   "import",
+					},
+				},
+			},
+		})
+	}
 
 	// Variables first — they don't conflict with recipe names because the
 	// regexes require different terminators (`:=` vs `:`).
@@ -161,12 +240,31 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 		}
 
 		props := map[string]string{}
+		normDeps := ""
 		if deps != "" {
 			// Dependency list is extracted as relationship metadata per JIRA.
-			props["dependencies"] = normalizeDeps(deps)
+			normDeps = normalizeDeps(deps)
+			props["dependencies"] = normDeps
 		}
 		if params != "" {
 			props["parameters"] = params
+		}
+
+		// CALLS edges — one per unique dependency name (filter self-recursion).
+		var callRels []types.RelationshipRecord
+		if normDeps != "" {
+			seenCall := make(map[string]bool)
+			for _, dep := range strings.Split(normDeps, ",") {
+				dep = strings.TrimSpace(dep)
+				if dep == "" || dep == name || seenCall[dep] {
+					continue
+				}
+				seenCall[dep] = true
+				callRels = append(callRels, types.RelationshipRecord{
+					ToID: dep,
+					Kind: "CALLS",
+				})
+			}
 		}
 
 		entities = append(entities, types.EntityRecord{
@@ -180,10 +278,45 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 			Signature:          sig,
 			EnrichmentRequired: false,
 			Properties:         props,
+			Relationships:      callRels,
+		})
+
+		// CONTAINS edge: file → recipe (Format A structural-ref).
+		toID := extractor.BuildOperationStructuralRef("just", file.Path, name)
+		entities[fileIdx].Relationships = append(entities[fileIdx].Relationships, types.RelationshipRecord{
+			ToID: toID,
+			Kind: "CONTAINS",
 		})
 	}
 
+	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
+	extractor.TagRelationshipsLanguage(entities, "just")
 	return entities, nil
+}
+
+// stripLineComments removes the portion of each line starting at `#` to
+// end-of-line. Justfile comments are line-terminated; quote handling is
+// minimal but adequate for structural extraction.
+func stripLineComments(src string) string {
+	var b strings.Builder
+	b.Grow(len(src))
+	for _, line := range strings.SplitAfter(src, "\n") {
+		if strings.HasPrefix(line, "#!") {
+			b.WriteString(line)
+			continue
+		}
+		if idx := strings.Index(line, "#"); idx >= 0 {
+			nl := ""
+			if strings.HasSuffix(line, "\n") {
+				nl = "\n"
+			}
+			b.WriteString(line[:idx])
+			b.WriteString(nl)
+			continue
+		}
+		b.WriteString(line)
+	}
+	return b.String()
 }
 
 // findRecipeEnd returns the line number of the last line in a recipe body.

--- a/internal/extractors/just/just_test.go
+++ b/internal/extractors/just/just_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/extractor"
 	_ "github.com/cajasmota/archigraph/internal/extractors/just"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 func TestJustExtractor_Registered(t *testing.T) {
@@ -117,9 +118,18 @@ func TestJustExtractor_DependenciesWithArguments(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(entities))
+	// Filter to recipe entities — the extractor also emits a file-level
+	// SCOPE.Component container that carries CONTAINS edges (issue #374).
+	var recipes []types.EntityRecord
+	for _, e := range entities {
+		if e.Subtype == "recipe" {
+			recipes = append(recipes, e)
+		}
 	}
+	if len(recipes) != 1 {
+		t.Fatalf("expected 1 recipe entity, got %d", len(recipes))
+	}
+	entities = recipes
 	deps := entities[0].Properties["dependencies"]
 	if deps != "test" {
 		t.Errorf("expected deps='test' (args stripped), got %q", deps)
@@ -139,9 +149,18 @@ func TestJustExtractor_MultipleDependencies(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(entities))
+	// Filter to recipe entities — the extractor also emits a file-level
+	// SCOPE.Component container that carries CONTAINS edges (issue #374).
+	var recipes []types.EntityRecord
+	for _, e := range entities {
+		if e.Subtype == "recipe" {
+			recipes = append(recipes, e)
+		}
 	}
+	if len(recipes) != 1 {
+		t.Fatalf("expected 1 recipe entity, got %d", len(recipes))
+	}
+	entities = recipes
 	deps := entities[0].Properties["dependencies"]
 	if deps != "build,test,lint,vet" {
 		t.Errorf("expected deps=build,test,lint,vet got %q", deps)
@@ -161,9 +180,18 @@ func TestJustExtractor_RecipeParameters(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(entities) != 1 {
-		t.Fatalf("expected 1 entity, got %d", len(entities))
+	// Filter to recipe entities — the extractor also emits a file-level
+	// SCOPE.Component container that carries CONTAINS edges (issue #374).
+	var recipes []types.EntityRecord
+	for _, e := range entities {
+		if e.Subtype == "recipe" {
+			recipes = append(recipes, e)
+		}
 	}
+	if len(recipes) != 1 {
+		t.Fatalf("expected 1 recipe entity, got %d", len(recipes))
+	}
+	entities = recipes
 	e := entities[0]
 	if e.Name != "deploy" {
 		t.Errorf("expected name=deploy, got %q", e.Name)
@@ -187,8 +215,14 @@ func TestJustExtractor_UnderscoreRecipe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if len(entities) != 1 || entities[0].Name != "_internal" {
-		t.Errorf("expected _internal recipe, got %+v", entities)
+	var recipes []types.EntityRecord
+	for _, e := range entities {
+		if e.Subtype == "recipe" {
+			recipes = append(recipes, e)
+		}
+	}
+	if len(recipes) != 1 || recipes[0].Name != "_internal" {
+		t.Errorf("expected _internal recipe, got %+v", recipes)
 	}
 }
 

--- a/internal/extractors/just/relationships_test.go
+++ b/internal/extractors/just/relationships_test.go
@@ -1,0 +1,345 @@
+package just_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/just"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func extractJust(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("just")
+	if !ok {
+		t.Fatal("just extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "just",
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	return got
+}
+
+func justRelsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+func findJustByName(entities []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range entities {
+		if entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+func hasJustRel(entities []types.EntityRecord, kind, toContains string) bool {
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind && strings.Contains(r.ToID, toContains) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---- IMPORTS ---------------------------------------------------------------
+
+func TestJustRelationships_Imports_QuotedDouble(t *testing.T) {
+	src := `import "path/to/other.justfile"
+
+build:
+    echo hi
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "path/to/other.justfile" {
+		t.Errorf("IMPORTS ToID = %q, want path/to/other.justfile", rels[0].ToID)
+	}
+	if rels[0].FromID != "justfile" {
+		t.Errorf("IMPORTS FromID = %q, want justfile", rels[0].FromID)
+	}
+	if rels[0].Properties["import_kind"] != "import" {
+		t.Errorf("import_kind = %q, want import", rels[0].Properties["import_kind"])
+	}
+	if rels[0].Properties["language"] != "just" {
+		t.Errorf("language = %q, want just", rels[0].Properties["language"])
+	}
+}
+
+func TestJustRelationships_Imports_QuotedSingle(t *testing.T) {
+	src := `import 'helpers.just'
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "helpers.just" {
+		t.Errorf("ToID = %q, want helpers.just", rels[0].ToID)
+	}
+}
+
+func TestJustRelationships_Imports_Optional(t *testing.T) {
+	src := `import? "optional.just"
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "optional.just" {
+		t.Errorf("ToID = %q, want optional.just", rels[0].ToID)
+	}
+}
+
+func TestJustRelationships_Imports_DedupesIdentical(t *testing.T) {
+	src := `import "dup.just"
+import "dup.just"
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Errorf("IMPORTS dedup count = %d, want 1", len(rels))
+	}
+}
+
+func TestJustRelationships_Imports_NoneWhenAbsent(t *testing.T) {
+	src := `build:
+    echo hi
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 0 {
+		t.Errorf("IMPORTS count = %d, want 0", len(rels))
+	}
+}
+
+func TestJustRelationships_Imports_SkipsCommented(t *testing.T) {
+	src := `# import "commented.just"
+import "real.just"
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "IMPORTS")
+	if len(rels) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(rels))
+	}
+	if rels[0].ToID != "real.just" {
+		t.Errorf("ToID = %q, want real.just", rels[0].ToID)
+	}
+}
+
+// ---- CALLS -----------------------------------------------------------------
+
+func TestJustRelationships_Calls_FromDependencies(t *testing.T) {
+	src := `build:
+    go build
+
+test: build
+    go test
+`
+	entities := extractJust(t, "justfile", src)
+	test := findJustByName(entities, "test")
+	if test == nil {
+		t.Fatal("test recipe not found")
+	}
+	var callees []string
+	for _, r := range test.Relationships {
+		if r.Kind == "CALLS" {
+			callees = append(callees, r.ToID)
+		}
+	}
+	found := false
+	for _, c := range callees {
+		if c == "build" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected CALLS to build from test (got %v)", callees)
+	}
+}
+
+func TestJustRelationships_Calls_MultipleDependencies(t *testing.T) {
+	src := `build:
+    echo build
+
+test:
+    echo test
+
+lint:
+    echo lint
+
+ci: build test lint
+    echo done
+`
+	entities := extractJust(t, "justfile", src)
+	ci := findJustByName(entities, "ci")
+	if ci == nil {
+		t.Fatal("ci recipe not found")
+	}
+	wants := map[string]bool{"build": false, "test": false, "lint": false}
+	for _, r := range ci.Relationships {
+		if r.Kind == "CALLS" {
+			if _, ok := wants[r.ToID]; ok {
+				wants[r.ToID] = true
+			}
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing CALLS to %q", k)
+		}
+	}
+}
+
+func TestJustRelationships_Calls_StripsParenthesisedArgs(t *testing.T) {
+	// Parenthesised dep groups carry recipe arguments; the existing
+	// normalizeDeps drops them, so CALLS edges are emitted only for the
+	// top-level dep names.
+	src := `test:
+    echo test
+
+release: test (lint "strict")
+    echo ok
+`
+	entities := extractJust(t, "justfile", src)
+	rel := findJustByName(entities, "release")
+	if rel == nil {
+		t.Fatal("release recipe not found")
+	}
+	var callees []string
+	for _, r := range rel.Relationships {
+		if r.Kind == "CALLS" {
+			callees = append(callees, r.ToID)
+		}
+	}
+	if len(callees) != 1 || callees[0] != "test" {
+		t.Errorf("CALLS = %v, want [test]", callees)
+	}
+}
+
+func TestJustRelationships_Calls_DedupedPerRecipe(t *testing.T) {
+	src := `build:
+    echo build
+
+ci: build build build
+    echo done
+`
+	entities := extractJust(t, "justfile", src)
+	ci := findJustByName(entities, "ci")
+	if ci == nil {
+		t.Fatal("ci not found")
+	}
+	count := 0
+	for _, r := range ci.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "build" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("CALLS to build count = %d, want 1 (deduped)", count)
+	}
+}
+
+func TestJustRelationships_Calls_NoneWithoutDeps(t *testing.T) {
+	src := `build:
+    echo build
+`
+	entities := extractJust(t, "justfile", src)
+	rels := justRelsByKind(entities, "CALLS")
+	if len(rels) != 0 {
+		t.Errorf("CALLS count = %d, want 0", len(rels))
+	}
+}
+
+// ---- CONTAINS --------------------------------------------------------------
+
+func TestJustRelationships_Contains_FileToRecipe(t *testing.T) {
+	src := `build:
+    echo hi
+`
+	entities := extractJust(t, "justfile", src)
+	wantRef := extractor.BuildOperationStructuralRef("just", "justfile", "build")
+	if !hasJustRel(entities, "CONTAINS", wantRef) {
+		t.Errorf("expected CONTAINS to %q", wantRef)
+	}
+}
+
+func TestJustRelationships_Contains_MultipleRecipes(t *testing.T) {
+	src := `a:
+    echo a
+
+b:
+    echo b
+
+c:
+    echo c
+`
+	entities := extractJust(t, "justfile", src)
+	count := 0
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CONTAINS" {
+				count++
+			}
+		}
+	}
+	if count < 3 {
+		t.Errorf("CONTAINS count = %d, want >= 3", count)
+	}
+}
+
+func TestJustRelationships_Contains_UsesStructuralRef(t *testing.T) {
+	src := `deploy:
+    echo deploy
+`
+	entities := extractJust(t, "ops/justfile", src)
+	if !hasJustRel(entities, "CONTAINS", "scope:operation:method:just:ops/justfile:deploy") {
+		t.Errorf("expected CONTAINS structural-ref")
+	}
+}
+
+// ---- Combined --------------------------------------------------------------
+
+func TestJustRelationships_Combined_AllThreeKinds(t *testing.T) {
+	src := `import "shared.just"
+
+build:
+    echo build
+
+test: build
+    echo test
+`
+	entities := extractJust(t, "justfile", src)
+	if len(justRelsByKind(entities, "IMPORTS")) < 1 {
+		t.Errorf("expected >= 1 IMPORTS")
+	}
+	if len(justRelsByKind(entities, "CALLS")) < 1 {
+		t.Errorf("expected >= 1 CALLS")
+	}
+	if len(justRelsByKind(entities, "CONTAINS")) < 1 {
+		t.Errorf("expected >= 1 CONTAINS")
+	}
+}


### PR DESCRIPTION
## Summary
- IMPORTS: `import "<path>"` / `import? "<path>"` directives become SCOPE.Component import-stub entities carrying a single IMPORTS edge from the justfile to the imported path.
- CALLS: each recipe emits one CALLS edge per unique top-level dependency name from the `recipe: dep1 dep2` form. Self-recursion dropped; parenthesised dep-arg groups stripped (consistent with the existing `dependencies` property).
- CONTAINS: a file-level SCOPE.Component (subtype="file") emits one CONTAINS edge per declared recipe via `BuildOperationStructuralRef` (Format A, #144).

Closes #374.

## Test plan
- [x] `go test ./internal/extractors/just/...` — 26 tests pass (11 existing + 15 new relationship tests)
- [x] `go test ./...` — full repo suite green
- [x] `go vet ./internal/extractors/just/...`
- [x] Real-world fixture (`fixtures/real-world/just/Justfile`) extracts 12 recipes + 4 variables and emits CONTAINS / CALLS edges.

Mirrors the IMPORTS/CALLS/CONTAINS contract used by the fish (#371), shell, and lua extractors.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>