### PR TITLE
feat(css): emit IMPORTS for @import directives (Closes #383)

### DIFF
--- a/internal/extractors/css/css.go
+++ b/internal/extractors/css/css.go
@@ -4,14 +4,22 @@
 //   - rule_set (selectors)     → Kind="SCOPE.Stylesheet", Subtype="selector"
 //   - keyframes_statement      → Kind="SCOPE.Stylesheet", Subtype="keyframe"
 //   - at_rule (@mixin/@function) → Kind="SCOPE.Stylesheet", Subtype="mixin"
+//   - import_statement (@import) → Kind="SCOPE.Component",  Subtype="import"
 //   - CSS custom properties (--var) → Kind="SCOPE.Stylesheet", Subtype="variable"
 //
 // Extracted entities (SCSS/Less via regex —):
 //   - SCSS $variable: value    → Kind="SCOPE.Component", Subtype="variable"
 //   - SCSS @mixin name(params) → Kind="SCOPE.Component", Subtype="mixin"
 //   - SCSS @function name      → Kind="SCOPE.Component", Subtype="function"
+//   - SCSS/Less @import "x"    → Kind="SCOPE.Component", Subtype="import"
 //   - Less @variable: value    → Kind="SCOPE.Component", Subtype="variable"
 //   - Less .mixin(params) {    → Kind="SCOPE.Component", Subtype="mixin"
+//
+// Emitted relationships (per issue #383 PORT-RELS-CSS):
+//
+//	IMPORTS  — one edge per @import directive (plain CSS, SCSS, Less),
+//	           attached to the @import entity. CALLS and CONTAINS are not
+//	           applicable to the CSS family and are pinned out by tests.
 //
 // Uses the css grammar from smacker/go-tree-sitter for plain CSS.
 // SCSS/Less use regex because go-tree-sitter has no dedicated SCSS/Less grammar.
@@ -63,10 +71,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	case ".scss", ".sass":
 		var entities []types.EntityRecord
 		ExtractSCSS(ctx, file, &entities)
+		lang := "scss"
+		if ext == ".sass" {
+			lang = "sass"
+		}
+		extractor.TagRelationshipsLanguage(entities, lang)
 		return entities, nil
 	case ".less":
 		var entities []types.EntityRecord
 		ExtractLess(ctx, file, &entities)
+		extractor.TagRelationshipsLanguage(entities, "less")
 		return entities, nil
 	default:
 		// Plain CSS: tree-sitter parse required.
@@ -76,6 +90,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		var entities []types.EntityRecord
 		root := file.Tree.RootNode()
 		extractCSS(root, file, &entities)
+		extractor.TagRelationshipsLanguage(entities, "css")
 		return entities, nil
 	}
 }
@@ -107,6 +122,10 @@ func walkCSS(node *sitter.Node, file extractor.FileInput, seenVars map[string]bo
 		}
 	case "declaration":
 		if rec, ok := buildVariable(node, file, seenVars); ok {
+			*out = append(*out, rec)
+		}
+	case "import_statement":
+		if rec, ok := buildImport(node, file); ok {
 			*out = append(*out, rec)
 		}
 	}
@@ -207,6 +226,77 @@ func buildAtRule(node *sitter.Node, file extractor.FileInput) (types.EntityRecor
 		Signature:          kw + " " + name,
 		EnrichmentRequired: false,
 	}, true
+}
+
+// buildImport handles tree-sitter import_statement nodes for plain CSS.
+// Both forms are supported:
+//
+//	@import "foo.css";        — module ref is the string_value child
+//	@import url("foo.css");   — module ref is the string_value inside the
+//	                            call_expression's arguments
+//
+// Media queries trailing the directive (e.g. `screen`, `print`) are
+// ignored — they don't change the import target.
+func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	module := importModuleRef(node, file.Content)
+	if module == "" {
+		return types.EntityRecord{}, false
+	}
+	startLine := int(node.StartPoint().Row) + 1
+	endLine := int(node.EndPoint().Row) + 1
+	return types.EntityRecord{
+		Name:       module,
+		Kind:       "SCOPE.Component",
+		Subtype:    "import",
+		SourceFile: file.Path,
+		Language:   "css",
+		StartLine:  startLine,
+		EndLine:    endLine,
+		Signature:  "@import " + module,
+		Relationships: []types.RelationshipRecord{
+			buildImportRel(file.Path, module),
+		},
+		EnrichmentRequired: false,
+	}, true
+}
+
+// importModuleRef extracts the imported module path from an import_statement
+// node, handling both bare-string and url(...) forms. Returns "" if no
+// module ref can be located.
+func importModuleRef(node *sitter.Node, src []byte) string {
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "string_value":
+			return unquoteStringValue(ch, src)
+		case "call_expression":
+			args := childByType(ch, "arguments")
+			if args == nil {
+				continue
+			}
+			if str := childByType(args, "string_value"); str != nil {
+				return unquoteStringValue(str, src)
+			}
+		}
+	}
+	return ""
+}
+
+// unquoteStringValue strips the surrounding "" or '' quote tokens from a
+// tree-sitter string_value node and returns the inner text.
+func unquoteStringValue(node *sitter.Node, src []byte) string {
+	raw := nodeText(node, src)
+	raw = strings.TrimSpace(raw)
+	if len(raw) >= 2 {
+		first, last := raw[0], raw[len(raw)-1]
+		if (first == '"' || first == '\'') && first == last {
+			return raw[1 : len(raw)-1]
+		}
+	}
+	return raw
 }
 
 func buildVariable(node *sitter.Node, file extractor.FileInput, seen map[string]bool) (types.EntityRecord, bool) {

--- a/internal/extractors/css/less.go
+++ b/internal/extractors/css/less.go
@@ -32,6 +32,16 @@ import (
 // Captures: 1=name, 2=value.
 var lessVarRE = regexp.MustCompile(`^\s*@([a-zA-Z_-][a-zA-Z0-9_-]*)\s*:\s*(.+?)\s*;`)
 
+// lessImportLineRE matches Less @import directives, optionally with a
+// parenthesised options list (e.g. `@import (reference) "foo.less";`).
+// Captures: 1=tail (everything after `@import` up to the optional ;).
+var lessImportLineRE = regexp.MustCompile(`^\s*@import\b\s*(.+?)\s*;?\s*$`)
+
+// lessImportModuleRE captures the quoted module ref inside a Less @import
+// directive. The optional url(...) wrapper is allowed for parity with CSS.
+// Captures: 1=double-quoted body, 2=single-quoted body.
+var lessImportModuleRE = regexp.MustCompile(`(?:url\(\s*)?(?:"([^"]*)"|'([^']*)')`)
+
 // lessMixinRE matches Less class-style mixin definitions:
 //
 //	.name() { or .name(@param) { or .name(@p1; @p2) {
@@ -41,7 +51,7 @@ var lessMixinRE = regexp.MustCompile(`^\s*\.([a-zA-Z_-][a-zA-Z0-9_-]*)\s*\(([^)]
 
 // ExtractLess extracts Less entities from raw source and appends them to out.
 // It is exported (uppercase) so tests in the same package can call it directly.
-func ExtractLess(ctx context.Context, file extractor.FileInput, out *[]types.EntityRecord) (varCount, mixinCount int) {
+func ExtractLess(ctx context.Context, file extractor.FileInput, out *[]types.EntityRecord) (varCount, mixinCount, importCount int) {
 	tracer := otel.Tracer("extractor.less")
 
 	var span trace.Span
@@ -55,6 +65,7 @@ func ExtractLess(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 		span.SetAttributes(
 			attribute.Int("less_variable_count", varCount),
 			attribute.Int("less_mixin_count", mixinCount),
+			attribute.Int("less_import_count", importCount),
 		)
 		span.End()
 	}()
@@ -86,6 +97,39 @@ func ExtractLess(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 		// Skip comment lines.
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			continue
+		}
+
+		// Less @import (handled before lessVarRE because @import would
+		// otherwise look like a variable to lessVarRE — though the
+		// at-rule-keywords map already filters it, keep the explicit
+		// branch so we can also emit the IMPORTS entity).
+		if m := lessImportLineRE.FindStringSubmatch(line); m != nil {
+			matches := lessImportModuleRE.FindAllStringSubmatch(m[1], -1)
+			for _, mm := range matches {
+				module := mm[1]
+				if module == "" {
+					module = mm[2]
+				}
+				if module == "" {
+					continue
+				}
+				*out = append(*out, types.EntityRecord{
+					Name:       module,
+					Kind:       "SCOPE.Component",
+					Subtype:    "import",
+					SourceFile: file.Path,
+					Language:   "less",
+					StartLine:  lineNum,
+					EndLine:    lineNum,
+					Signature:  "@import " + module,
+					Relationships: []types.RelationshipRecord{
+						buildImportRel(file.Path, module),
+					},
+					EnrichmentRequired: false,
+				})
+				importCount++
+			}
 			continue
 		}
 
@@ -140,7 +184,7 @@ func ExtractLess(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 		}
 	}
 
-	return varCount, mixinCount
+	return varCount, mixinCount, importCount
 }
 
 // parseLessParams splits a raw Less params string (e.g. "@bg: red; @color: #fff")

--- a/internal/extractors/css/less_test.go
+++ b/internal/extractors/css/less_test.go
@@ -106,7 +106,7 @@ func TestExtractLess_AllEntityCounts(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount := css.ExtractLess(context.Background(), file, &ents)
+	varCount, mixinCount, _ := css.ExtractLess(context.Background(), file, &ents)
 
 	if varCount < 5 {
 		t.Errorf("expected >= 5 variables, got %d", varCount)
@@ -192,7 +192,7 @@ func TestExtractLess_SkipsComments(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, _ := css.ExtractLess(context.Background(), file, &ents)
+	varCount, _, _ := css.ExtractLess(context.Background(), file, &ents)
 
 	if varCount != 1 {
 		t.Errorf("expected 1 variable (skipping commented), got %d", varCount)
@@ -211,14 +211,23 @@ func TestExtractLess_SkipsAtRuleKeywords(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, _ := css.ExtractLess(context.Background(), file, &ents)
+	varCount, _, _ := css.ExtractLess(context.Background(), file, &ents)
 
-	// Only @primary-color should be extracted, not @import
+	// Only @primary-color should be extracted as a variable, not @import.
+	// @import is now emitted as a separate "import" entity (issue #383),
+	// so we check varCount and find the variable entity by Subtype.
 	if varCount != 1 {
 		t.Errorf("expected 1 variable (skipping @import), got %d", varCount)
 	}
-	if len(ents) > 0 && ents[0].Name != "@primary-color" {
-		t.Errorf("expected @primary-color, got %q", ents[0].Name)
+	var got string
+	for _, e := range ents {
+		if e.Subtype == "variable" {
+			got = e.Name
+			break
+		}
+	}
+	if got != "@primary-color" {
+		t.Errorf("expected @primary-color variable, got %q", got)
 	}
 }
 
@@ -229,7 +238,7 @@ func TestExtractLess_EmptyContent(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount := css.ExtractLess(context.Background(), file, &ents)
+	varCount, mixinCount, _ := css.ExtractLess(context.Background(), file, &ents)
 
 	if varCount != 0 || mixinCount != 0 {
 		t.Errorf("expected all counts=0 for empty content, got %d/%d", varCount, mixinCount)
@@ -265,7 +274,7 @@ func TestExtractLess_NoParamsMixin(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	_, mixinCount := css.ExtractLess(context.Background(), file, &ents)
+	_, mixinCount, _ := css.ExtractLess(context.Background(), file, &ents)
 
 	if mixinCount != 1 {
 		t.Errorf("expected 1 mixin, got %d", mixinCount)
@@ -287,7 +296,7 @@ func TestExtractLess_FixtureFile(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount := css.ExtractLess(context.Background(), file, &ents)
+	varCount, mixinCount, _ := css.ExtractLess(context.Background(), file, &ents)
 
 	if varCount < 5 {
 		t.Errorf("expected >= 5 variables from fixture, got %d", varCount)

--- a/internal/extractors/css/relationships.go
+++ b/internal/extractors/css/relationships.go
@@ -1,0 +1,77 @@
+// relationships.go — IMPORTS edge emission for the CSS / SCSS / Less
+// extractor (issue #383 PORT-RELS-CSS).
+//
+// The CSS family's only meaningful relationship surface is the @import
+// directive, which links one stylesheet to another. We emit one
+// SCOPE.Component "import" entity per @import directive, with an embedded
+// IMPORTS edge attached to it, so the cross-file resolver can wire the
+// importing file to the imported module.
+//
+// Forms covered:
+//
+//	plain CSS (tree-sitter)   @import url("foo.css");
+//	                          @import "foo.css";
+//	                          @import url('foo.css') screen;
+//	                          @import "foo.css" print;
+//	SCSS (regex)              @import "foo";
+//	                          @import "foo", "bar";
+//	                          @use   "foo" as f;
+//	                          @forward "foo";
+//	Less (regex)              @import "foo.less";
+//	                          @import (reference) "foo.less";
+//	                          @import (less) "foo";
+//
+// Property contract on every IMPORTS edge (matches issue #383 spec):
+//
+//	local_name    — basename of the imported module (filename without
+//	                directory; not stripped of extension because CSS refs
+//	                are typically already bare names).
+//	source_module — the raw module path as written in source (the value
+//	                between the quotes / inside url()).
+//	imported_name — "" — CSS @import does not introduce a named binding.
+//
+// CALLS: not modelled. CSS has no function calls in the architectural
+// sense. var(--x) is a value reference inside a declaration — not an
+// edge worth wiring at the entity layer. Pinned with a regression test.
+//
+// CONTAINS: not modelled. Stylesheets nominally contain rule_sets, but
+// rule_sets are themselves the SCOPE.Stylesheet/selector entities and
+// there is no parent stylesheet entity to hang them from. Pinned with a
+// regression test.
+
+package css
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// buildImportRel constructs the IMPORTS RelationshipRecord attached to an
+// @import entity. fromPath is the source file (used as FromID); module is
+// the imported module ref as written in source.
+func buildImportRel(fromPath, module string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: fromPath,
+		ToID:   module,
+		Kind:   "IMPORTS",
+		Properties: map[string]string{
+			"local_name":    importBasename(module),
+			"source_module": module,
+			"imported_name": "",
+		},
+	}
+}
+
+// importBasename returns the trailing path segment of an @import target.
+// Falls back to the full ref if there is no directory separator.
+func importBasename(ref string) string {
+	s := ref
+	if i := strings.LastIndex(s, "/"); i >= 0 {
+		s = s[i+1:]
+	}
+	if s == "" {
+		return ref
+	}
+	return s
+}

--- a/internal/extractors/css/relationships_test.go
+++ b/internal/extractors/css/relationships_test.go
@@ -1,0 +1,220 @@
+package css_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/css"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findImportRel returns the IMPORTS RelationshipRecord whose ToID matches
+// module, or nil. Searches all entities' embedded Relationships.
+func findImportRel(entities []types.EntityRecord, module string) *types.RelationshipRecord {
+	for i := range entities {
+		for j := range entities[i].Relationships {
+			r := &entities[i].Relationships[j]
+			if r.Kind == "IMPORTS" && r.ToID == module {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+func assertImportContract(t *testing.T, r *types.RelationshipRecord, fromPath, module, wantLocal, wantLang string) {
+	t.Helper()
+	if r == nil {
+		t.Fatalf("expected IMPORTS edge for module %q, found none", module)
+	}
+	if r.FromID != fromPath {
+		t.Errorf("FromID: want %q, got %q", fromPath, r.FromID)
+	}
+	if r.ToID != module {
+		t.Errorf("ToID: want %q, got %q", module, r.ToID)
+	}
+	if got := r.Properties["local_name"]; got != wantLocal {
+		t.Errorf("Properties[local_name]: want %q, got %q", wantLocal, got)
+	}
+	if got := r.Properties["source_module"]; got != module {
+		t.Errorf("Properties[source_module]: want %q, got %q", module, got)
+	}
+	if got, ok := r.Properties["imported_name"]; !ok || got != "" {
+		t.Errorf("Properties[imported_name]: want \"\" present, got %q (present=%v)", got, ok)
+	}
+	if got := r.Properties["language"]; got != wantLang {
+		t.Errorf("Properties[language]: want %q, got %q", wantLang, got)
+	}
+}
+
+// --- plain CSS (tree-sitter) ---
+
+func TestCSSExtractor_Imports_Plain(t *testing.T) {
+	src := `@import url("foo.css");
+@import "bar.css";
+@import url('sub/baz.css') screen;
+@import "qux.css" print;
+body { color: red; }
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("css")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "main.css",
+		Content:  []byte(src),
+		Language: "css",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		module    string
+		wantLocal string
+	}{
+		{"foo.css", "foo.css"},
+		{"bar.css", "bar.css"},
+		{"sub/baz.css", "baz.css"},
+		{"qux.css", "qux.css"},
+	}
+	for _, c := range cases {
+		r := findImportRel(entities, c.module)
+		assertImportContract(t, r, "main.css", c.module, c.wantLocal, "css")
+	}
+
+	// Each @import should also have produced an import entity.
+	importCount := 0
+	for _, e := range entities {
+		if e.Subtype == "import" {
+			importCount++
+			if e.Kind != "SCOPE.Component" {
+				t.Errorf("import entity %q: Kind=%q, want SCOPE.Component", e.Name, e.Kind)
+			}
+		}
+	}
+	if importCount != 4 {
+		t.Errorf("expected 4 import entities, got %d", importCount)
+	}
+}
+
+// --- SCSS (regex) ---
+
+func TestCSSExtractor_Imports_SCSS(t *testing.T) {
+	src := `@import "foundation/reset";
+@import "vars", "mixins/buttons";
+@use "sass:math";
+@forward "components/card";
+$primary: #007bff;
+`
+	ext, _ := extractor.Get("css")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "app.scss",
+		Content:  []byte(src),
+		Language: "scss",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		module    string
+		wantLocal string
+	}{
+		{"foundation/reset", "reset"},
+		{"vars", "vars"},
+		{"mixins/buttons", "buttons"},
+		{"sass:math", "sass:math"},
+		{"components/card", "card"},
+	}
+	for _, c := range cases {
+		r := findImportRel(entities, c.module)
+		assertImportContract(t, r, "app.scss", c.module, c.wantLocal, "scss")
+	}
+}
+
+// --- Less (regex) ---
+
+func TestCSSExtractor_Imports_Less(t *testing.T) {
+	src := `@import "foundation/reset.less";
+@import (reference) "mixins.less";
+@import (less) "legacy";
+@brand: #f00;
+`
+	ext, _ := extractor.Get("css")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "app.less",
+		Content:  []byte(src),
+		Language: "less",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	cases := []struct {
+		module    string
+		wantLocal string
+	}{
+		{"foundation/reset.less", "reset.less"},
+		{"mixins.less", "mixins.less"},
+		{"legacy", "legacy"},
+	}
+	for _, c := range cases {
+		r := findImportRel(entities, c.module)
+		assertImportContract(t, r, "app.less", c.module, c.wantLocal, "less")
+	}
+}
+
+// --- pinned non-emissions ---
+
+// CSS has no function-call surface to model, so no CALLS edges should be
+// emitted by any flavor of the CSS extractor.
+func TestCSSExtractor_NoCalls(t *testing.T) {
+	cssSrc := `:root { --x: 12px; }
+.btn { padding: var(--x); transform: translate(10px, 20px); color: rgb(255, 0, 0); }
+`
+	tree := parseForTest(t, cssSrc)
+	ext, _ := extractor.Get("css")
+	entities, _ := ext.Extract(context.Background(), extractor.FileInput{
+		Path: "x.css", Content: []byte(cssSrc), Language: "css", Tree: tree,
+	})
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" {
+				t.Errorf("unexpected CALLS edge: %+v", r)
+			}
+		}
+	}
+}
+
+// CSS has no parent stylesheet entity to attach selectors to, so no
+// CONTAINS edges should be emitted by any flavor of the CSS extractor.
+func TestCSSExtractor_NoContains(t *testing.T) {
+	srcs := map[string][]byte{
+		"a.css": []byte(`@import "x.css"; body { color: red; } .a { color: blue; }`),
+		"a.scss": []byte(`@import "vars";
+$x: 1;
+@mixin button($bg) { background: $bg; }
+`),
+		"a.less": []byte(`@import "vars.less";
+@x: 1;
+.button(@bg) { background: @bg; }
+`),
+	}
+	ext, _ := extractor.Get("css")
+	for path, src := range srcs {
+		var input extractor.FileInput
+		input = extractor.FileInput{Path: path, Content: src, Language: "css"}
+		if path == "a.css" {
+			input.Tree = parseForTest(t, string(src))
+		}
+		entities, _ := ext.Extract(context.Background(), input)
+		for _, e := range entities {
+			for _, r := range e.Relationships {
+				if r.Kind == "CONTAINS" {
+					t.Errorf("[%s] unexpected CONTAINS edge: %+v", path, r)
+				}
+			}
+		}
+	}
+}

--- a/internal/extractors/css/scss.go
+++ b/internal/extractors/css/scss.go
@@ -39,9 +39,19 @@ var scssMixinRE = regexp.MustCompile(`^\s*@mixin\s+([a-zA-Z_-][a-zA-Z0-9_-]*)(?:
 // Captures: 1=name, 2=params string (may be empty).
 var scssFunctionRE = regexp.MustCompile(`^\s*@function\s+([a-zA-Z_-][a-zA-Z0-9_-]*)(?:\s*\(([^)]*)\))?`)
 
+// scssImportLineRE matches the start of an SCSS-flavour @import / @use /
+// @forward directive. Captures: 1=keyword (import|use|forward), 2=tail
+// (everything after the keyword up to ; or EOL — parsed for module refs).
+var scssImportLineRE = regexp.MustCompile(`^\s*@(import|use|forward)\s+(.+?)\s*;?\s*$`)
+
+// scssImportModuleRE matches a single quoted module ref inside an @import /
+// @use / @forward tail, including url("...") wrappers. Captures: 1=double-
+// quoted body, 2=single-quoted body (one will be empty per match).
+var scssImportModuleRE = regexp.MustCompile(`(?:url\(\s*)?(?:"([^"]*)"|'([^']*)')`)
+
 // ExtractSCSS extracts SCSS entities from raw source and appends them to out.
 // It is exported (uppercase) so tests in the same package can call it directly.
-func ExtractSCSS(ctx context.Context, file extractor.FileInput, out *[]types.EntityRecord) (varCount, mixinCount, fnCount int) {
+func ExtractSCSS(ctx context.Context, file extractor.FileInput, out *[]types.EntityRecord) (varCount, mixinCount, fnCount, importCount int) {
 	tracer := otel.Tracer("extractor.scss")
 
 	var span trace.Span
@@ -56,6 +66,7 @@ func ExtractSCSS(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 			attribute.Int("scss_variable_count", varCount),
 			attribute.Int("scss_mixin_count", mixinCount),
 			attribute.Int("scss_function_count", fnCount),
+			attribute.Int("scss_import_count", importCount),
 		)
 		span.End()
 	}()
@@ -70,6 +81,40 @@ func ExtractSCSS(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 		// Skip comment lines.
 		trimmed := strings.TrimSpace(line)
 		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "/*") {
+			continue
+		}
+
+		// SCSS @import / @use / @forward — module refs are quoted strings,
+		// possibly comma-separated (`@import "a", "b";`). Each ref becomes
+		// its own SCOPE.Component "import" entity with an embedded IMPORTS
+		// edge. @use / @forward use the same dependency-resolution model as
+		// @import in modern SCSS, so we treat them identically here.
+		if m := scssImportLineRE.FindStringSubmatch(line); m != nil {
+			matches := scssImportModuleRE.FindAllStringSubmatch(m[2], -1)
+			for _, mm := range matches {
+				module := mm[1]
+				if module == "" {
+					module = mm[2]
+				}
+				if module == "" {
+					continue
+				}
+				*out = append(*out, types.EntityRecord{
+					Name:       module,
+					Kind:       "SCOPE.Component",
+					Subtype:    "import",
+					SourceFile: file.Path,
+					Language:   "scss",
+					StartLine:  lineNum,
+					EndLine:    lineNum,
+					Signature:  "@" + m[1] + " " + module,
+					Relationships: []types.RelationshipRecord{
+						buildImportRel(file.Path, module),
+					},
+					EnrichmentRequired: false,
+				})
+				importCount++
+			}
 			continue
 		}
 
@@ -143,7 +188,7 @@ func ExtractSCSS(ctx context.Context, file extractor.FileInput, out *[]types.Ent
 		}
 	}
 
-	return varCount, mixinCount, fnCount
+	return varCount, mixinCount, fnCount, importCount
 }
 
 // parseParams splits a raw params string (e.g. "$bg: red, $color: #fff") into

--- a/internal/extractors/css/scss_test.go
+++ b/internal/extractors/css/scss_test.go
@@ -143,7 +143,7 @@ $spacing-sm: 8px;
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount, fnCount := css.ExtractSCSS(context.Background(), file, &ents)
+	varCount, mixinCount, fnCount, _ := css.ExtractSCSS(context.Background(), file, &ents)
 
 	if varCount < 5 {
 		t.Errorf("expected >= 5 variables, got %d", varCount)
@@ -232,7 +232,7 @@ func TestExtractSCSS_SkipsComments(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, _, _ := css.ExtractSCSS(context.Background(), file, &ents)
+	varCount, _, _, _ := css.ExtractSCSS(context.Background(), file, &ents)
 
 	if varCount != 1 {
 		t.Errorf("expected 1 variable (skipping commented), got %d", varCount)
@@ -249,7 +249,7 @@ func TestExtractSCSS_EmptyContent(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount, fnCount := css.ExtractSCSS(context.Background(), file, &ents)
+	varCount, mixinCount, fnCount, _ := css.ExtractSCSS(context.Background(), file, &ents)
 
 	if varCount != 0 || mixinCount != 0 || fnCount != 0 {
 		t.Errorf("expected all counts=0 for empty content, got %d/%d/%d", varCount, mixinCount, fnCount)
@@ -285,7 +285,7 @@ func TestExtractSCSS_NoParamsMixin(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	_, mixinCount, _ := css.ExtractSCSS(context.Background(), file, &ents)
+	_, mixinCount, _, _ := css.ExtractSCSS(context.Background(), file, &ents)
 
 	if mixinCount != 1 {
 		t.Errorf("expected 1 mixin, got %d", mixinCount)
@@ -307,7 +307,7 @@ func TestExtractSCSS_FixtureFile(t *testing.T) {
 	}
 
 	var ents []types.EntityRecord
-	varCount, mixinCount, fnCount := css.ExtractSCSS(context.Background(), file, &ents)
+	varCount, mixinCount, fnCount, _ := css.ExtractSCSS(context.Background(), file, &ents)
 
 	if varCount < 5 {
 		t.Errorf("expected >= 5 variables from fixture, got %d", varCount)


### PR DESCRIPTION
## Summary
- Port relationship extraction to the CSS / SCSS / Less extractor (issue #383 PORT-RELS-CSS).
- Emit IMPORTS edges for `@import` directives across all three flavors. SCSS additionally covers `@use` / `@forward`, and Less covers the `(reference) / (less)` option syntax.
- Every edge carries the standard property contract: `local_name` (basename), `source_module` (raw ref), `imported_name` (""), plus `language` set by `TagRelationshipsLanguage`.
- CALLS and CONTAINS are intentionally not modelled and are pinned out by regression tests.

## What's emitted vs deferred
- IMPORTS — emitted for plain CSS (`@import "x.css"`, `@import url("x.css")`), SCSS (`@import`, `@use`, `@forward`, comma-separated lists), and Less (`@import`, `@import (reference) "x.less"`).
- CALLS — deferred. CSS has no function-call architectural surface (`var(--x)`, `translate(...)`, `rgb(...)` are value-level). Pinned by `TestCSSExtractor_NoCalls`.
- CONTAINS — deferred. Selectors *are* the SCOPE.Stylesheet entities; there is no parent stylesheet to attach them to. Pinned by `TestCSSExtractor_NoContains`.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./...` all green (CSS package and full repo)
- [x] New relationships_test.go covers plain CSS, SCSS, and Less import forms plus pinned non-emissions for CALLS / CONTAINS