### PR TITLE
feat(markdown): emit IMPORTS edges for relative-path links (Closes #388)

### DIFF
--- a/internal/extractors/markdown/markdown.go
+++ b/internal/extractors/markdown/markdown.go
@@ -5,6 +5,8 @@
 //   - SCOPE.Document   — one per file
 //   - SCOPE.Heading    — one per ATX heading (#, ##, ..., ######)
 //   - SCOPE.CodeBlock  — one per fenced code block (``` or ~~~)
+//   - SCOPE.Component  — one stub per unique relative-path link target
+//     (carries the IMPORTS edge below)
 //
 // And the following relationships:
 //
@@ -14,6 +16,10 @@
 //   - Heading  --REFERENCES--> <code-slug>  (one per backtick literal in heading text;
 //     ToID is a bare slug — a later cross-file
 //     pass can resolve it to a real entity ID)
+//   - file.Path --IMPORTS--> <relative-target> (one per unique [text](path) link
+//     whose target is a relative file path — i.e. not http/https/mailto/ftp,
+//     not a bare in-page #fragment. The target is resolved against the file's
+//     directory and any trailing #fragment is stripped.)
 //
 // v1 deliberately ignores: setext headings (=== / ---), inline code, links,
 // lists, tables, images, blockquotes, HTML blocks. Only ATX headings and
@@ -41,6 +47,8 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"path"
+	"regexp"
 	"strings"
 	"unicode"
 
@@ -87,7 +95,7 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		return nil, fmt.Errorf("markdown extractor: %w", err)
 	}
 
-	headings, codeBlocks := scan(lines)
+	headings, codeBlocks, links := scan(lines)
 
 	totalLines := len(lines)
 	docName := basename(file.Path)
@@ -242,15 +250,21 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		}
 	}
 
-	out := make([]types.EntityRecord, 0, 1+len(headingEntities)+len(codeEntities))
+	// Build IMPORTS stub entities — one SCOPE.Component per unique relative-path
+	// link target. Edge: file.Path --IMPORTS--> resolved target.
+	importEntities := buildImportEntities(file.Path, links)
+
+	out := make([]types.EntityRecord, 0, 1+len(headingEntities)+len(codeEntities)+len(importEntities))
 	out = append(out, doc)
 	out = append(out, headingEntities...)
 	out = append(out, codeEntities...)
+	out = append(out, importEntities...)
 
 	span.SetAttributes(
 		attribute.Int("entity_count", len(out)),
 		attribute.Int("heading_count", len(headingEntities)),
 		attribute.Int("codeblock_count", len(codeEntities)),
+		attribute.Int("import_count", len(importEntities)),
 	)
 	return out, nil
 }
@@ -273,15 +287,16 @@ type codeBlock struct {
 	byteCount int
 }
 
-// scan walks lines once and emits headings + code blocks.
+// scan walks lines once and emits headings + code blocks + link references.
 //
-// While inside a fenced block, ATX heading lines are NOT recognised.
-// A code-fence opener determines the closing fence token (``` or ~~~) and
-// the minimum length (>=3, must be matched by a closer of equal-or-greater length
-// using the same character).
-func scan(lines []string) ([]heading, []codeBlock) {
+// While inside a fenced block, ATX heading lines and inline links are NOT
+// recognised. A code-fence opener determines the closing fence token (``` or
+// ~~~) and the minimum length (>=3, must be matched by a closer of
+// equal-or-greater length using the same character).
+func scan(lines []string) ([]heading, []codeBlock, []linkRef) {
 	var headings []heading
 	var codeBlocks []codeBlock
+	var links []linkRef
 
 	inFence := false
 	var fenceChar byte
@@ -325,6 +340,13 @@ func scan(lines []string) ([]heading, []codeBlock) {
 		if h, ok := parseATXHeading(line, lineNo); ok {
 			headings = append(headings, h)
 		}
+
+		// Collect inline link targets on every non-fence line. Heading lines
+		// are intentionally included — a `## See [foo](./foo.md)` heading
+		// should still emit IMPORTS.
+		for _, t := range extractLinkTargets(line) {
+			links = append(links, linkRef{line: lineNo, target: t})
+		}
 	}
 
 	// Unclosed fence: terminate at EOF.
@@ -337,7 +359,140 @@ func scan(lines []string) ([]heading, []codeBlock) {
 		})
 	}
 
-	return headings, codeBlocks
+	return headings, codeBlocks, links
+}
+
+// linkRef is one inline-link target captured on a non-fence line.
+type linkRef struct {
+	line   int
+	target string // raw target text from `[text](target)` — pre-resolution
+}
+
+// linkRE matches an inline markdown link [text](target). The target capture
+// is intentionally lazy and forbids whitespace/parens so the regex stays
+// well-defined for nested-paren-free targets (sufficient for v1).
+var linkRE = regexp.MustCompile(`\[[^\]]*\]\(([^)\s]+)(?:\s+"[^"]*")?\)`)
+
+// extractLinkTargets returns the raw target text of every inline `[text](target)`
+// link on a single line. Targets are returned in source order. No URL/path
+// classification happens here — that's done at IMPORTS-emission time.
+func extractLinkTargets(line string) []string {
+	if !strings.Contains(line, "](") {
+		return nil
+	}
+	ms := linkRE.FindAllStringSubmatch(line, -1)
+	if len(ms) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(ms))
+	for _, m := range ms {
+		if len(m) >= 2 && m[1] != "" {
+			out = append(out, m[1])
+		}
+	}
+	return out
+}
+
+// buildImportEntities turns each unique relative-path link target into a
+// SCOPE.Component import-stub entity carrying a single IMPORTS edge from
+// file.Path → resolved target. Targets that are absolute URLs (http:, https:,
+// mailto:, ftp:, etc.), bare in-page fragments (#section), or empty after
+// fragment-stripping are skipped. Trailing `#fragment` and `?query` parts are
+// stripped before resolution.
+//
+// Path resolution is forward-slash only and uses path.Clean against the
+// markdown file's directory. Absolute targets ("/foo.md") are kept verbatim
+// (without the leading slash) — they're treated as repo-root-relative.
+func buildImportEntities(filePath string, links []linkRef) []types.EntityRecord {
+	if len(links) == 0 {
+		return nil
+	}
+	dir := path.Dir(filePath)
+	if dir == "." {
+		dir = ""
+	}
+	seen := make(map[string]bool, len(links))
+	out := make([]types.EntityRecord, 0, len(links))
+	for _, lr := range links {
+		resolved, ok := resolveImportTarget(dir, lr.target)
+		if !ok {
+			continue
+		}
+		if seen[resolved] {
+			continue
+		}
+		seen[resolved] = true
+
+		out = append(out, types.EntityRecord{
+			Name:       path.Base(resolved),
+			Kind:       "SCOPE.Component",
+			Subtype:    "import",
+			SourceFile: filePath,
+			Language:   langName,
+			StartLine:  lr.line,
+			EndLine:    lr.line,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   resolved,
+					Kind:   "IMPORTS",
+					Properties: map[string]string{
+						"source_module": resolved,
+						"imported_name": path.Base(resolved),
+						"import_kind":   "link",
+					},
+				},
+			},
+		})
+	}
+	return out
+}
+
+// urlSchemeRE matches a leading URL scheme like "http:", "https:", "mailto:",
+// "ftp:", "tel:", "ssh:", "git:", "irc:", "file:" — i.e. any RFC 3986 scheme.
+// We use this to reject external links from the IMPORTS set.
+var urlSchemeRE = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9+.\-]*:`)
+
+// resolveImportTarget classifies a raw link target and (if it's a relative
+// file path) resolves it against dir. Returns ("", false) for targets that
+// must not produce an IMPORTS edge.
+func resolveImportTarget(dir, raw string) (string, bool) {
+	t := strings.TrimSpace(raw)
+	if t == "" {
+		return "", false
+	}
+	// Bare in-page fragment.
+	if strings.HasPrefix(t, "#") {
+		return "", false
+	}
+	// Strip trailing #fragment and ?query.
+	if i := strings.IndexByte(t, '#'); i >= 0 {
+		t = t[:i]
+	}
+	if i := strings.IndexByte(t, '?'); i >= 0 {
+		t = t[:i]
+	}
+	if t == "" {
+		return "", false
+	}
+	// Protocol-relative URL.
+	if strings.HasPrefix(t, "//") {
+		return "", false
+	}
+	// Any URL with a scheme (http:, https:, mailto:, etc.).
+	if urlSchemeRE.MatchString(t) {
+		return "", false
+	}
+	// Repo-root-absolute: drop leading slash.
+	if strings.HasPrefix(t, "/") {
+		t = strings.TrimLeft(t, "/")
+		return path.Clean(t), t != ""
+	}
+	// Relative to file's directory.
+	if dir == "" {
+		return path.Clean(t), true
+	}
+	return path.Clean(dir + "/" + t), true
 }
 
 // parseATXHeading recognises lines like "# text", "## text", up to "######".

--- a/internal/extractors/markdown/markdown_test.go
+++ b/internal/extractors/markdown/markdown_test.go
@@ -279,6 +279,109 @@ func TestEmptyContent(t *testing.T) {
 	}
 }
 
+// hasImports checks whether ents contains a SCOPE.Component import-stub
+// entity carrying an IMPORTS edge from filePath → toID.
+func hasImports(ents []types.EntityRecord, filePath, toID string) bool {
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Component" || e.Subtype != "import" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" && r.FromID == filePath && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func countImports(ents []types.EntityRecord) int {
+	n := 0
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func TestImports_RelativeLinksEmitImports(t *testing.T) {
+	ents := extract(t, "links.md")
+
+	// Expected: sibling.md, ../parent.md, root.md, after.md
+	// Link in fenced code block should be skipped.
+	// External (https), mailto, and in-page (#) links should NOT emit IMPORTS.
+	wantTargets := []string{"sibling.md", "../parent.md", "root.md", "after.md"}
+	for _, tgt := range wantTargets {
+		if !hasImports(ents, "links.md", tgt) {
+			t.Errorf("missing IMPORTS edge to %q", tgt)
+		}
+	}
+
+	// Negative: links inside fenced code blocks must not emit.
+	if hasImports(ents, "links.md", "should-be-ignored.md") {
+		t.Errorf("link inside fenced code block must not emit IMPORTS")
+	}
+
+	// Negative: external / mailto / in-page must not emit.
+	for _, bad := range []string{"https://example.com", "mailto:foo@bar.com", "#links-doc", "links.md"} {
+		if hasImports(ents, "links.md", bad) {
+			t.Errorf("unexpected IMPORTS edge to %q", bad)
+		}
+	}
+
+	// Dedup: duplicate `./sibling.md` only counted once. Total = 4.
+	if got := countImports(ents); got != 4 {
+		t.Errorf("IMPORTS count = %d, want 4", got)
+	}
+}
+
+func TestImports_ResolveTargetClassification(t *testing.T) {
+	cases := []struct {
+		name    string
+		dir     string
+		raw     string
+		wantOK  bool
+		wantOut string
+	}{
+		{"relative dot-slash", "docs", "./foo.md", true, "docs/foo.md"},
+		{"relative bare", "docs", "foo.md", true, "docs/foo.md"},
+		{"relative parent", "docs", "../README.md", true, "README.md"},
+		{"absolute path", "docs", "/root.md", true, "root.md"},
+		{"strip fragment", "docs", "./foo.md#sec", true, "docs/foo.md"},
+		{"strip query", "docs", "./foo.md?x=1", true, "docs/foo.md"},
+		{"empty dir bare", "", "foo.md", true, "foo.md"},
+		{"http", "docs", "https://example.com", false, ""},
+		{"http no slashes", "docs", "http://example.com", false, ""},
+		{"mailto", "docs", "mailto:a@b.com", false, ""},
+		{"in-page anchor", "docs", "#section", false, ""},
+		{"protocol-relative", "docs", "//cdn/x.js", false, ""},
+		{"empty", "docs", "", false, ""},
+		{"only fragment after strip", "docs", "#", false, ""},
+	}
+	for _, tc := range cases {
+		got, ok := resolveImportTarget(tc.dir, tc.raw)
+		if ok != tc.wantOK {
+			t.Errorf("%s: ok = %v, want %v", tc.name, ok, tc.wantOK)
+			continue
+		}
+		if ok && got != tc.wantOut {
+			t.Errorf("%s: got %q, want %q", tc.name, got, tc.wantOut)
+		}
+	}
+}
+
+func TestImports_NoLinksProducesNoStubs(t *testing.T) {
+	ents := extract(t, "simple.md")
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "import" {
+			t.Errorf("simple.md should produce no import stubs; got %+v", e)
+		}
+	}
+}
+
 func TestRegistration(t *testing.T) {
 	if e, ok := extractor.Get("markdown"); !ok {
 		t.Errorf("markdown extractor not registered")

--- a/internal/extractors/markdown/testdata/links.md
+++ b/internal/extractors/markdown/testdata/links.md
@@ -1,0 +1,16 @@
+# Links Doc
+
+This page links to [a sibling](./sibling.md) and a [parent](../parent.md).
+
+It also references [an absolute](/root.md) page and an [external site](https://example.com)
+plus a [mail link](mailto:foo@bar.com) and an [in-page anchor](#links-doc).
+
+## Section with [inline link](./sibling.md#anchor)
+
+Duplicate link to [sibling again](./sibling.md) should dedupe.
+
+```markdown
+[link in code block](./should-be-ignored.md)
+```
+
+After the fence, [post-fence](./after.md) is real.


### PR DESCRIPTION
## Summary
- Audit found `internal/extractors/markdown` already emits CONTAINS (Document->Heading, Heading->Heading, Heading->CodeBlock) and REFERENCES (backtick literals in headings), but inline `[text](path)` links were ignored entirely.
- Adds an inline-link scanner that runs alongside the existing heading/fence walker and skips content inside fenced code blocks.
- Each unique relative-path link target produces one `SCOPE.Component` import-stub entity carrying `file.Path --IMPORTS--> resolved_target`. Pattern mirrors the zig/proto/graphql siblings.

## Filtering rules
- Reject any URL scheme (`http:`, `https:`, `mailto:`, `ftp:`, ...)
- Reject protocol-relative (`//cdn/x`)
- Reject bare in-page fragments (`#section`)
- Strip trailing `#fragment` and `?query` from otherwise-valid targets
- Resolve relative targets against `path.Dir(file.Path)` via `path.Clean`
- Leading `/` is treated as repo-root-relative (slash stripped)
- Dedup by resolved target

## Test plan
- [x] `go test ./internal/extractors/markdown/...` (new fixture `links.md` covers positive, negative, dedup, code-block exclusion)
- [x] `go test ./...` (full repo green)
- [x] `resolveImportTarget` table-driven test covers schemes, fragment/query stripping, parent-dir, absolute paths

Closes #388

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>