### PR TITLE
feat(proto): emit IMPORTS + CONTAINS edges (Closes #377)

### DIFF
--- a/internal/extractors/proto/proto.go
+++ b/internal/extractors/proto/proto.go
@@ -1,10 +1,25 @@
 // Package proto implements the tree-sitter–based extractor for Protocol Buffer source files.
 //
 // Extracted entities:
-//   - service  → Kind="SCOPE.Schema", Subtype="service"
-//   - rpc      → Kind="SCOPE.Schema", Subtype="rpc"
-//   - message  → Kind="SCOPE.Schema", Subtype="message"
-//   - enum     → Kind="SCOPE.Schema", Subtype="enum"
+//   - service  → Kind="SCOPE.Service",   Subtype="service"
+//   - rpc      → Kind="SCOPE.Operation", Subtype="endpoint" (Properties["type"]="rpc")
+//   - message  → Kind="SCOPE.Schema",    Subtype="message"
+//   - enum     → Kind="SCOPE.Schema",    Subtype="enum"
+//
+// Issue #377 — relationship parity:
+//
+//   - IMPORTS edges are emitted from file.Path → import target for every
+//     `import "x.proto";` and `import public "x.proto";` directive.
+//     `import public` carries Properties["public"]="true".
+//   - CONTAINS edges:
+//   - file → service / message / enum (top-level definitions),
+//   - service → rpc,
+//   - message → field,
+//   - enum → enum value.
+//     ToIDs use BuildOperationStructuralRef("proto", file, name) for entity
+//     children (service/message/enum/rpc) and the table#column-style ref
+//     `scope:schema:column:proto:<file>:<parent>#<member>` for fields and
+//     enum values, mirroring SQL Format B.
 //
 // Uses the protobuf grammar from smacker/go-tree-sitter.
 // Registers itself via init() and is imported by registry_gen.go.
@@ -39,6 +54,13 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 
 	var entities []types.EntityRecord
 	walkProto(file.Tree.RootNode(), file, &entities)
+
+	// Append IMPORTS stub entities, one per `import "..."` directive.
+	importEntities := buildImportEntities(file)
+	if len(importEntities) > 0 {
+		entities = append(entities, importEntities...)
+	}
+
 	return entities, nil
 }
 
@@ -61,6 +83,22 @@ func childByType(node *sitter.Node, types_ ...string) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// fieldMemberRef returns the Format B structural-ref for a parent#member edge
+// inside a proto file (message field, enum value). Mirrors
+// BuildSchemaColumnStructuralRef but tagged with the "proto" language.
+func fieldMemberRef(filePath, parent, member string) string {
+	return "scope:schema:column:proto:" + filePath + ":" + parent + "#" + member
+}
+
+// fileContainsRel builds a CONTAINS edge from file.Path → top-level entity.
+func fileContainsRel(filePath, name string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: filePath,
+		ToID:   extractor.BuildOperationStructuralRef("proto", filePath, name),
+		Kind:   "CONTAINS",
+	}
 }
 
 func walkProto(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) {
@@ -111,6 +149,32 @@ func buildService(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
+
+	// CONTAINS edges: service → each rpc child + file → service.
+	var rels []types.RelationshipRecord
+	rels = append(rels, fileContainsRel(file.Path, name))
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil || ch.Type() != "rpc" {
+			continue
+		}
+		rpcNameNode := childByType(ch, "rpc_name")
+		if rpcNameNode == nil {
+			continue
+		}
+		rpcName := strings.TrimSpace(nodeText(rpcNameNode, file.Content))
+		if ident := childByType(rpcNameNode, "identifier"); ident != nil {
+			rpcName = nodeText(ident, file.Content)
+		}
+		if rpcName == "" {
+			continue
+		}
+		rels = append(rels, types.RelationshipRecord{
+			ToID: extractor.BuildOperationStructuralRef("proto", file.Path, rpcName),
+			Kind: "CONTAINS",
+		})
+	}
+
 	return types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Service",
@@ -121,6 +185,7 @@ func buildService(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          "service " + name,
 		EnrichmentRequired: false,
+		Relationships:      rels,
 	}, true
 }
 
@@ -168,6 +233,9 @@ func buildRPC(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, 
 		// Set type=rpc explicitly so buildOutputDoc doesn't override with "endpoint".
 		// Python golden uses type=rpc, subtype=endpoint for RPC entities.
 		Properties: map[string]string{"type": "rpc"},
+		// rpc carries the request/response IMPORTS edges historically emitted
+		// here. File-level `import "..."` edges are emitted separately as stub
+		// entities by buildImportEntities.
 		Relationships: []types.RelationshipRecord{
 			{FromID: file.Path, ToID: reqType, Kind: "IMPORTS"},
 			{FromID: file.Path, ToID: respType, Kind: "IMPORTS"},
@@ -187,6 +255,29 @@ func buildMessage(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
+
+	// CONTAINS edges: file → message + message → each field.
+	var rels []types.RelationshipRecord
+	rels = append(rels, fileContainsRel(file.Path, name))
+	if body := childByType(node, "message_body"); body != nil {
+		seen := make(map[string]bool)
+		for i := range body.ChildCount() {
+			ch := body.Child(int(i))
+			if ch == nil || ch.Type() != "field" {
+				continue
+			}
+			fname := fieldName(ch, file.Content)
+			if fname == "" || seen[fname] {
+				continue
+			}
+			seen[fname] = true
+			rels = append(rels, types.RelationshipRecord{
+				ToID: fieldMemberRef(file.Path, name, fname),
+				Kind: "CONTAINS",
+			})
+		}
+	}
+
 	return types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Schema",
@@ -197,6 +288,7 @@ func buildMessage(node *sitter.Node, file extractor.FileInput) (types.EntityReco
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          "message " + name,
 		EnrichmentRequired: false,
+		Relationships:      rels,
 	}, true
 }
 
@@ -212,6 +304,29 @@ func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord,
 	if name == "" {
 		return types.EntityRecord{}, false
 	}
+
+	// CONTAINS edges: file → enum + enum → each enum value.
+	var rels []types.RelationshipRecord
+	rels = append(rels, fileContainsRel(file.Path, name))
+	if body := childByType(node, "enum_body"); body != nil {
+		seen := make(map[string]bool)
+		for i := range body.ChildCount() {
+			ch := body.Child(int(i))
+			if ch == nil || ch.Type() != "enum_field" {
+				continue
+			}
+			vname := enumValueName(ch, file.Content)
+			if vname == "" || seen[vname] {
+				continue
+			}
+			seen[vname] = true
+			rels = append(rels, types.RelationshipRecord{
+				ToID: fieldMemberRef(file.Path, name, vname),
+				Kind: "CONTAINS",
+			})
+		}
+	}
+
 	return types.EntityRecord{
 		Name:               name,
 		Kind:               "SCOPE.Schema",
@@ -222,5 +337,107 @@ func buildEnum(node *sitter.Node, file extractor.FileInput) (types.EntityRecord,
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          "enum " + name,
 		EnrichmentRequired: false,
+		Relationships:      rels,
 	}, true
+}
+
+// fieldName returns the message-field's identifier (the second `identifier`
+// child after the `type` node — the first `identifier` under `type` is the
+// type name, not the field name). The grammar lays a `field` node out as:
+//
+//	field
+//	  type
+//	    (string|identifier|message_or_enum_type ...)
+//	  identifier   ← field name
+//	  =
+//	  field_number
+func fieldName(node *sitter.Node, src []byte) string {
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil {
+			continue
+		}
+		if ch.Type() == "identifier" {
+			return nodeText(ch, src)
+		}
+	}
+	return ""
+}
+
+// enumValueName returns the first identifier child of an `enum_field` node.
+//
+//	enum_field
+//	  identifier   ← value name (e.g. UNKNOWN)
+//	  =
+//	  int_lit
+func enumValueName(node *sitter.Node, src []byte) string {
+	if id := childByType(node, "identifier"); id != nil {
+		return nodeText(id, src)
+	}
+	return ""
+}
+
+// buildImportEntities scans top-level `import "..."` and `import public "..."`
+// directives and returns one stub SCOPE.Component entity per import target,
+// each carrying an IMPORTS edge from file.Path → target. `import public`
+// imports carry Properties["public"]="true" on the relationship.
+func buildImportEntities(file extractor.FileInput) []types.EntityRecord {
+	root := file.Tree.RootNode()
+	var entities []types.EntityRecord
+	for i := range root.ChildCount() {
+		ch := root.Child(int(i))
+		if ch == nil || ch.Type() != "import" {
+			continue
+		}
+		path, public := parseImport(ch, file.Content)
+		if path == "" {
+			continue
+		}
+		rel := types.RelationshipRecord{
+			FromID: file.Path,
+			ToID:   path,
+			Kind:   "IMPORTS",
+		}
+		if public {
+			rel.Properties = map[string]string{"public": "true"}
+		}
+		entities = append(entities, types.EntityRecord{
+			Name:               path,
+			Kind:               "SCOPE.Component",
+			Subtype:            "import",
+			SourceFile:         file.Path,
+			Language:           "protobuf",
+			StartLine:          int(ch.StartPoint().Row) + 1,
+			EndLine:            int(ch.EndPoint().Row) + 1,
+			Signature:          nodeText(ch, file.Content),
+			EnrichmentRequired: false,
+			Relationships:      []types.RelationshipRecord{rel},
+		})
+	}
+	return entities
+}
+
+// parseImport extracts the quoted path and the `public` modifier from an
+// `import` node. The grammar shape is:
+//
+//	import
+//	  import          (keyword)
+//	  [public|weak]   (optional modifier)
+//	  string          ("path/to.proto")
+//	  ;
+func parseImport(node *sitter.Node, src []byte) (path string, public bool) {
+	for i := range node.ChildCount() {
+		ch := node.Child(int(i))
+		if ch == nil {
+			continue
+		}
+		switch ch.Type() {
+		case "public":
+			public = true
+		case "string":
+			raw := nodeText(ch, src)
+			path = strings.Trim(raw, "\"'")
+		}
+	}
+	return path, public
 }

--- a/internal/extractors/proto/relationships_test.go
+++ b/internal/extractors/proto/relationships_test.go
@@ -1,0 +1,272 @@
+package proto_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/proto"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extract is a small helper that parses src and runs the proto extractor.
+func extract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("proto")
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "proto",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	return entities
+}
+
+func relsByKind(entities []types.EntityRecord, kind string) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == kind {
+				out = append(out, r)
+			}
+		}
+	}
+	return out
+}
+
+// ---- IMPORTS ---------------------------------------------------------------
+
+func TestRelationships_Imports_Single(t *testing.T) {
+	src := `syntax = "proto3";
+import "google/protobuf/empty.proto";
+
+message Foo { string id = 1; }
+`
+	entities := extract(t, "foo.proto", src)
+	imports := relsByKind(entities, "IMPORTS")
+	// buildRPC also emits IMPORTS; this fixture has no rpc, so all IMPORTS are file-level.
+	if len(imports) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1; got %+v", len(imports), imports)
+	}
+	if imports[0].FromID != "foo.proto" {
+		t.Errorf("IMPORTS FromID = %q, want foo.proto", imports[0].FromID)
+	}
+	if imports[0].ToID != "google/protobuf/empty.proto" {
+		t.Errorf("IMPORTS ToID = %q, want google/protobuf/empty.proto", imports[0].ToID)
+	}
+}
+
+func TestRelationships_Imports_Public(t *testing.T) {
+	src := `syntax = "proto3";
+import public "common.proto";
+
+message Foo { string id = 1; }
+`
+	entities := extract(t, "foo.proto", src)
+	imports := relsByKind(entities, "IMPORTS")
+	if len(imports) != 1 {
+		t.Fatalf("IMPORTS count = %d, want 1", len(imports))
+	}
+	if imports[0].ToID != "common.proto" {
+		t.Errorf("IMPORTS ToID = %q, want common.proto", imports[0].ToID)
+	}
+	if imports[0].Properties["public"] != "true" {
+		t.Errorf("IMPORTS Properties[public] = %q, want true", imports[0].Properties["public"])
+	}
+}
+
+func TestRelationships_Imports_Multiple(t *testing.T) {
+	src := `syntax = "proto3";
+import "a.proto";
+import public "b.proto";
+import "c.proto";
+
+message Foo { string id = 1; }
+`
+	entities := extract(t, "foo.proto", src)
+	imports := relsByKind(entities, "IMPORTS")
+	if len(imports) != 3 {
+		t.Fatalf("IMPORTS count = %d, want 3", len(imports))
+	}
+	wants := map[string]bool{"a.proto": false, "b.proto": false, "c.proto": false}
+	for _, r := range imports {
+		if _, ok := wants[r.ToID]; ok {
+			wants[r.ToID] = true
+		}
+	}
+	for k, seen := range wants {
+		if !seen {
+			t.Errorf("missing IMPORTS edge to %q", k)
+		}
+	}
+}
+
+// ---- CONTAINS: file → top-level ------------------------------------------
+
+func TestRelationships_FileContains_ServiceMessageEnum(t *testing.T) {
+	src := `syntax = "proto3";
+
+service S { rpc R(M) returns (M); }
+message M { string id = 1; }
+enum E { Z = 0; }
+`
+	entities := extract(t, "x.proto", src)
+	contains := relsByKind(entities, "CONTAINS")
+
+	wantFileEdges := map[string]bool{
+		"scope:operation:method:proto:x.proto:S": false,
+		"scope:operation:method:proto:x.proto:M": false,
+		"scope:operation:method:proto:x.proto:E": false,
+	}
+	for _, r := range contains {
+		if r.FromID == "x.proto" {
+			if _, ok := wantFileEdges[r.ToID]; ok {
+				wantFileEdges[r.ToID] = true
+			}
+		}
+	}
+	for ref, seen := range wantFileEdges {
+		if !seen {
+			t.Errorf("missing file CONTAINS edge to %q", ref)
+		}
+	}
+}
+
+// ---- CONTAINS: service → rpc ---------------------------------------------
+
+func TestRelationships_ServiceContainsRPC(t *testing.T) {
+	src := `syntax = "proto3";
+
+service UserService {
+  rpc GetUser(Req) returns (Resp);
+  rpc CreateUser(Req) returns (Resp);
+}
+`
+	entities := extract(t, "u.proto", src)
+	var serviceRec *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "service" {
+			serviceRec = &entities[i]
+		}
+	}
+	if serviceRec == nil {
+		t.Fatal("service entity not found")
+	}
+	wantRefs := map[string]bool{
+		"scope:operation:method:proto:u.proto:GetUser":    false,
+		"scope:operation:method:proto:u.proto:CreateUser": false,
+	}
+	for _, r := range serviceRec.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		if _, ok := wantRefs[r.ToID]; ok {
+			wantRefs[r.ToID] = true
+		}
+	}
+	for ref, seen := range wantRefs {
+		if !seen {
+			t.Errorf("service missing CONTAINS edge to %q", ref)
+		}
+	}
+}
+
+// ---- CONTAINS: message → field -------------------------------------------
+
+func TestRelationships_MessageContainsFields(t *testing.T) {
+	src := `syntax = "proto3";
+
+message User {
+  string id = 1;
+  repeated string tags = 2;
+  Status status = 3;
+}
+`
+	entities := extract(t, "u.proto", src)
+	var msgRec *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "message" && entities[i].Name == "User" {
+			msgRec = &entities[i]
+		}
+	}
+	if msgRec == nil {
+		t.Fatal("message entity not found")
+	}
+	wantFields := map[string]bool{"id": false, "tags": false, "status": false}
+	for _, r := range msgRec.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		// ToID is a structural-ref ending with the field name
+		for f := range wantFields {
+			if strings.HasSuffix(r.ToID, ":User#"+f) {
+				wantFields[f] = true
+			}
+		}
+	}
+	for f, seen := range wantFields {
+		if !seen {
+			t.Errorf("message User missing CONTAINS edge for field %q", f)
+		}
+	}
+}
+
+// ---- CONTAINS: enum → value -----------------------------------------------
+
+func TestRelationships_EnumContainsValues(t *testing.T) {
+	src := `syntax = "proto3";
+
+enum Status {
+  UNKNOWN = 0;
+  ACTIVE = 1;
+  INACTIVE = 2;
+}
+`
+	entities := extract(t, "s.proto", src)
+	var enumRec *types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == "enum" && entities[i].Name == "Status" {
+			enumRec = &entities[i]
+		}
+	}
+	if enumRec == nil {
+		t.Fatal("enum entity not found")
+	}
+	wantValues := map[string]bool{"UNKNOWN": false, "ACTIVE": false, "INACTIVE": false}
+	for _, r := range enumRec.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		for v := range wantValues {
+			if strings.HasSuffix(r.ToID, ":Status#"+v) {
+				wantValues[v] = true
+			}
+		}
+	}
+	for v, seen := range wantValues {
+		if !seen {
+			t.Errorf("enum Status missing CONTAINS edge for value %q", v)
+		}
+	}
+}
+
+// ---- Empty / no relationships -------------------------------------------
+
+func TestRelationships_NoImports_NoEdges(t *testing.T) {
+	src := `syntax = "proto3";
+message Foo { string id = 1; }
+`
+	entities := extract(t, "foo.proto", src)
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				t.Errorf("unexpected IMPORTS edge: %+v", r)
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Wires up relationship parity for the Protocol Buffers extractor (issue #377):

- **IMPORTS** edges from `file.Path` → import target for every `import "x.proto";` and `import public "x.proto";` directive. `import public` carries `Properties["public"]="true"`.
- **CONTAINS** edges:
  - file → top-level `service` / `message` / `enum`
  - `service` → each `rpc`
  - `message` → each field
  - `enum` → each enum value

Entity-child CONTAINS targets use `BuildOperationStructuralRef("proto", ...)`. Field / enum-value CONTAINS targets use the Format B table#column-style ref `scope:schema:column:proto:<file>:<parent>#<member>`.

## Test plan
- [x] `go test ./internal/extractors/proto/` — 13 tests pass (5 existing + 8 new in `relationships_test.go`)
- [x] `go test ./...` — full suite green
- [x] `go vet ./internal/extractors/proto/`
- [ ] Run against `proto/grpc-go-examples` corpus (#157)

Closes #377