### PR TITLE
feat(sql): emit READS_FROM/WRITES_TO for views and functions (Closes #389)

### DIFF
--- a/internal/extractors/sql/sql.go
+++ b/internal/extractors/sql/sql.go
@@ -10,9 +10,12 @@
 //   - dbt {{ config(...) }}     → Kind="SCOPE.Component",  Subtype="dbt_config"
 //
 // Relationships emitted:
-//   - Table  → Column        : CONTAINS
-//   - Column → ReferencedTable : REFERENCES (foreign key)
-//   - Index  → Table         : INDEXES
+//   - Table    → Column          : CONTAINS
+//   - Column   → ReferencedTable  : REFERENCES (foreign key)
+//   - Index    → Table            : INDEXES
+//   - View     → Table            : READS_FROM   (Issue #389)
+//   - Function → Table            : READS_FROM   (Issue #389; SELECT in body)
+//   - Function → Table            : WRITES_TO    (Issue #389; INSERT/UPDATE/DELETE in body)
 //
 // dbt model files are SQL files containing Jinja templating. They are classified
 // as "sql" by the file classifier and receive enhanced entity extraction here.
@@ -277,6 +280,38 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		seen[key] = true
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		endLine := findStmtEnd(src, m[0])
+
+		// Issue #389: capture the view body (text from end of header up to
+		// the next ';') and emit READS_FROM edges to every table referenced
+		// in FROM / JOIN clauses. Writes are not expected in a CREATE VIEW
+		// body but we run the full detector for symmetry — INSERT/UPDATE/
+		// DELETE inside a view body would still surface a real dependency.
+		body := sliceStmtBody(src, m[1])
+		reads, writes := extractDMLTargets(body)
+		var rels []types.RelationshipRecord
+		for _, t := range reads {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "READS_FROM",
+				Properties: map[string]string{"dml": "select"},
+			})
+		}
+		for _, t := range writes {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "WRITES_TO",
+				Properties: map[string]string{"dml": "write"},
+			})
+		}
+
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Datastore",
@@ -287,6 +322,7 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 			EndLine:            endLine,
 			Signature:          fmt.Sprintf("CREATE VIEW %s", name),
 			EnrichmentRequired: false,
+			Relationships:      rels,
 		})
 	}
 
@@ -334,6 +370,45 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		seen[key] = true
 		startLine := strings.Count(src[:m[0]], "\n") + 1
 		endLine := findBlockEnd(src, m[1]-1)
+
+		// Issue #389: scan the function/procedure body for DML targets.
+		// PostgreSQL functions are dollar-quoted ($$ ... $$); other dialects
+		// (MySQL, MSSQL) use BEGIN ... END or just a SELECT after AS. We
+		// scan from the open-paren of the function header down to the end
+		// of the statement, which is permissive enough for all three.
+		body := sliceFuncBody(src, m[1])
+		reads, writes := extractDMLTargets(body)
+		var rels []types.RelationshipRecord
+		dmlKindFor := func(table string, isWrite bool) string {
+			if isWrite {
+				return "write"
+			}
+			_ = table
+			return "select"
+		}
+		for _, t := range reads {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "READS_FROM",
+				Properties: map[string]string{"dml": dmlKindFor(t, false)},
+			})
+		}
+		for _, t := range writes {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "WRITES_TO",
+				Properties: map[string]string{"dml": dmlKindFor(t, true)},
+			})
+		}
+
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Datastore",
@@ -344,6 +419,7 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 			EndLine:            endLine,
 			Signature:          fmt.Sprintf("CREATE FUNCTION %s", name),
 			EnrichmentRequired: false,
+			Relationships:      rels,
 		})
 	}
 
@@ -512,7 +588,66 @@ var (
 	// Identifier-then-rest: column lines start with an identifier (or quoted ident)
 	// at the top level — used to filter constraint clauses.
 	columnIdentRE = regexp.MustCompile(`^\s*([A-Za-z_][A-Za-z0-9_]*)\b`)
+
+	// Issue #389 (PORT-RELS-SQL): DML target detection inside view / function
+	// bodies. We attach READS_FROM / WRITES_TO edges from the surrounding
+	// scope entity (view or function) to each referenced table.
+	//
+	// Patterns are intentionally permissive — schema-qualified names are
+	// allowed; quoted identifiers fall through (rare in views/functions and
+	// covered by sibling extractors).
+	dmlFromRE   = regexp.MustCompile(`(?is)\b(?:FROM|JOIN)\s+(?:\w+\.)?(\w+)`)
+	dmlInsertRE = regexp.MustCompile(`(?is)\bINSERT\s+INTO\s+(?:\w+\.)?(\w+)`)
+	dmlUpdateRE = regexp.MustCompile(`(?is)\bUPDATE\s+(?:ONLY\s+)?(?:\w+\.)?(\w+)`)
+	dmlDeleteRE = regexp.MustCompile(`(?is)\bDELETE\s+FROM\s+(?:ONLY\s+)?(?:\w+\.)?(\w+)`)
 )
+
+// dmlReservedWord matches identifiers that the FROM/JOIN regex can pick up
+// when SQL syntax follows the keyword with another keyword instead of a
+// table name (e.g. "DELETE FROM ONLY table"). Filter these out.
+var dmlReservedWords = map[string]bool{
+	"ONLY":   true,
+	"SELECT": true,
+	"WHERE":  true,
+	"WITH":   true,
+	"AS":     true,
+}
+
+// extractDMLTargets scans a SQL body (view body or function body) for table
+// references and returns deduplicated read and write target lists. Each
+// returned slice preserves first-seen order so emitted edges are stable.
+func extractDMLTargets(body string) (reads, writes []string) {
+	seenR := map[string]bool{}
+	seenW := map[string]bool{}
+	add := func(target string, m map[string]bool, out *[]string) {
+		t := strings.TrimSpace(target)
+		if t == "" {
+			return
+		}
+		upper := strings.ToUpper(t)
+		if dmlReservedWords[upper] {
+			return
+		}
+		if m[t] {
+			return
+		}
+		m[t] = true
+		*out = append(*out, t)
+	}
+	for _, m := range dmlFromRE.FindAllStringSubmatch(body, -1) {
+		add(m[1], seenR, &reads)
+	}
+	for _, m := range dmlInsertRE.FindAllStringSubmatch(body, -1) {
+		add(m[1], seenW, &writes)
+	}
+	for _, m := range dmlUpdateRE.FindAllStringSubmatch(body, -1) {
+		add(m[1], seenW, &writes)
+	}
+	for _, m := range dmlDeleteRE.FindAllStringSubmatch(body, -1) {
+		add(m[1], seenW, &writes)
+	}
+	return reads, writes
+}
 
 // parseTableBody parses a CREATE TABLE body (text between '(' and ')') into
 // column entities and a list of foreign-key relationships. Columns named
@@ -682,6 +817,47 @@ func isReservedColumnKeyword(upper string) bool {
 		return true
 	}
 	return false
+}
+
+// sliceStmtBody returns the substring of src from headerEnd up to the next
+// top-level ';' (or end of file). Used by the VIEW emitter to capture the
+// SELECT body that follows "CREATE VIEW name AS".
+func sliceStmtBody(src string, headerEnd int) string {
+	if headerEnd < 0 || headerEnd >= len(src) {
+		return ""
+	}
+	idx := strings.Index(src[headerEnd:], ";")
+	if idx < 0 {
+		return src[headerEnd:]
+	}
+	return src[headerEnd : headerEnd+idx]
+}
+
+// sliceFuncBody returns the body of a function/procedure declaration. The
+// body region runs from the parameter list onward to the end of the next
+// trailing-statement terminator. For dollar-quoted bodies ($$ ... $$) we
+// take the content between the two $$ markers; otherwise we fall back to
+// sliceStmtBody.
+func sliceFuncBody(src string, headerEnd int) string {
+	if headerEnd < 0 || headerEnd >= len(src) {
+		return ""
+	}
+	// Skip past the parameter list of the function header so DML scanning
+	// does not pick up "FROM" inside e.g. parameter defaults or column types.
+	paramEnd := findBlockEndOffset(src, headerEnd-1)
+	scanFrom := headerEnd
+	if paramEnd > 0 && paramEnd < len(src) {
+		scanFrom = paramEnd + 1
+	}
+	rest := src[scanFrom:]
+	// Dollar-quoted body: content between the first two "$$" markers.
+	if i := strings.Index(rest, "$$"); i >= 0 {
+		j := strings.Index(rest[i+2:], "$$")
+		if j >= 0 {
+			return rest[i+2 : i+2+j]
+		}
+	}
+	return sliceStmtBody(src, scanFrom)
 }
 
 // findStmtEnd returns the line number of the next semicolon after startPos.

--- a/internal/extractors/sql/sql_dml_test.go
+++ b/internal/extractors/sql/sql_dml_test.go
@@ -1,0 +1,104 @@
+package sql_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// Issue #389 (PORT-RELS-SQL): DML emission.
+//
+// Coverage matrix gap: SELECT → READS_FROM, INSERT/UPDATE/DELETE → WRITES_TO.
+//
+// In SQL files, raw DML statements are not standalone identity-bearing
+// entities. We attach READS_FROM / WRITES_TO edges to the surrounding
+// scope entity:
+//
+//   - CREATE VIEW v AS SELECT ... FROM t          → v READS_FROM t
+//   - CREATE FUNCTION f ... BEGIN SELECT ... END  → f READS_FROM t
+//   - CREATE FUNCTION f ... BEGIN INSERT ... END  → f WRITES_TO t
+//   - CREATE FUNCTION f ... BEGIN UPDATE ... END  → f WRITES_TO t
+//   - CREATE FUNCTION f ... BEGIN DELETE ... END  → f WRITES_TO t
+
+func collectEdges(rels []types.RelationshipRecord, kind string) map[string]bool {
+	out := map[string]bool{}
+	for _, r := range rels {
+		if r.Kind == kind {
+			out[r.ToID] = true
+		}
+	}
+	return out
+}
+
+func TestSQLExtractor_ViewReadsFromTables(t *testing.T) {
+	src := loadFixture(t, "migration_005_dml.sql")
+	entities := extractSQLBytes(t, src, "migrations/005_dml.sql")
+
+	view := findEntity(entities, "SCOPE.Datastore", "active_sessions")
+	if view == nil {
+		t.Fatal("expected CREATE VIEW active_sessions to be emitted")
+	}
+	reads := collectEdges(view.Relationships, "READS_FROM")
+	for _, want := range []string{"accounts", "sessions"} {
+		if !reads[want] {
+			t.Errorf("expected active_sessions READS_FROM %q (got %v)", want, reads)
+		}
+	}
+}
+
+func TestSQLExtractor_FunctionReadsAndWrites(t *testing.T) {
+	src := loadFixture(t, "migration_005_dml.sql")
+	entities := extractSQLBytes(t, src, "migrations/005_dml.sql")
+
+	fn := findEntity(entities, "SCOPE.Datastore", "record_event")
+	if fn == nil {
+		t.Fatal("expected CREATE FUNCTION record_event to be emitted")
+	}
+
+	reads := collectEdges(fn.Relationships, "READS_FROM")
+	writes := collectEdges(fn.Relationships, "WRITES_TO")
+
+	if !reads["accounts"] {
+		t.Errorf("expected record_event READS_FROM accounts (got %v)", reads)
+	}
+	if !writes["audit_log"] {
+		t.Errorf("expected record_event WRITES_TO audit_log (got %v)", writes)
+	}
+	if !writes["sessions"] {
+		t.Errorf("expected record_event WRITES_TO sessions (got %v)", writes)
+	}
+
+	// Dedupe: UPDATE sessions and DELETE FROM sessions should produce ONE
+	// WRITES_TO edge, not two.
+	count := 0
+	for _, r := range fn.Relationships {
+		if r.Kind == "WRITES_TO" && r.ToID == "sessions" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 WRITES_TO sessions edge (deduped), got %d", count)
+	}
+}
+
+func TestSQLExtractor_DMLProperties(t *testing.T) {
+	src := loadFixture(t, "migration_005_dml.sql")
+	entities := extractSQLBytes(t, src, "migrations/005_dml.sql")
+
+	fn := findEntity(entities, "SCOPE.Datastore", "record_event")
+	if fn == nil {
+		t.Fatal("function record_event not found")
+	}
+	for _, r := range fn.Relationships {
+		switch r.Kind {
+		case "READS_FROM":
+			if r.Properties["dml"] == "" {
+				t.Errorf("READS_FROM edge to %q missing Properties[dml]", r.ToID)
+			}
+		case "WRITES_TO":
+			if r.Properties["dml"] == "" {
+				t.Errorf("WRITES_TO edge to %q missing Properties[dml]", r.ToID)
+			}
+		}
+	}
+}

--- a/internal/extractors/sql/testdata/migration_005_dml.sql
+++ b/internal/extractors/sql/testdata/migration_005_dml.sql
@@ -1,0 +1,40 @@
+-- Fixture for Issue #389: DML emission (READS_FROM / WRITES_TO).
+
+CREATE TABLE accounts (
+    id SERIAL PRIMARY KEY,
+    email VARCHAR(255)
+);
+
+CREATE TABLE sessions (
+    id SERIAL PRIMARY KEY,
+    account_id INTEGER
+);
+
+CREATE TABLE audit_log (
+    id BIGSERIAL PRIMARY KEY,
+    account_id INTEGER,
+    event_kind VARCHAR(64)
+);
+
+-- View pulling from accounts and sessions: should emit
+--   active_sessions READS_FROM accounts
+--   active_sessions READS_FROM sessions
+CREATE VIEW active_sessions AS
+SELECT a.id, a.email, s.id AS session_id
+FROM accounts a
+JOIN sessions s ON s.account_id = a.id
+WHERE s.account_id IS NOT NULL;
+
+-- Function with SELECT + INSERT + UPDATE + DELETE in body: should emit
+--   record_event READS_FROM accounts
+--   record_event WRITES_TO audit_log
+--   record_event WRITES_TO sessions   (UPDATE)
+--   record_event WRITES_TO sessions   (DELETE — dedupe to one edge)
+CREATE FUNCTION record_event(p_account_id INTEGER, p_kind VARCHAR) RETURNS VOID AS $$
+BEGIN
+    PERFORM id FROM accounts WHERE id = p_account_id;
+    INSERT INTO audit_log (account_id, event_kind) VALUES (p_account_id, p_kind);
+    UPDATE sessions SET account_id = p_account_id WHERE id = 1;
+    DELETE FROM sessions WHERE account_id IS NULL;
+END;
+$$ LANGUAGE plpgsql;


### PR DESCRIPTION
## Summary

Closes #389 (PORT-RELS-SQL).

Audit found that SQL extractor already emits CONTAINS (table → column), REFERENCES (column → table FK, both inline and ALTER TABLE FK from #141/#362), and INDEXES (index → table). Coverage matrix gap was DML edges: SELECT → READS_FROM and INSERT/UPDATE/DELETE → WRITES_TO.

Raw DML statements are not identity-bearing entities in SQL files, so edges are attached to the surrounding scope entity:

- `CREATE VIEW v AS SELECT ... FROM t` → `v READS_FROM t`
- `CREATE FUNCTION f ... SELECT ... END` → `f READS_FROM t`
- `CREATE FUNCTION f ... INSERT/UPDATE/DELETE ... END` → `f WRITES_TO t`

Implementation:
- `extractDMLTargets()` — regex-based scanner for FROM/JOIN/INSERT INTO/UPDATE/DELETE FROM. Schema-qualified-name aware. Deduplicated and stable-ordered.
- `sliceStmtBody()` — captures view body (post-`AS` to next `;`).
- `sliceFuncBody()` — captures function body, handling PostgreSQL dollar-quoted `\$\$ ... \$\$` blocks plus fallback to plain statement body.
- Each emitted edge carries `Properties[dml]` with `select` (read) or `write` (write) tag.

Untouched: existing CONTAINS / REFERENCES / INDEXES emission paths.

## Test plan

- [x] `go test ./internal/extractors/sql/...` — green (new `sql_dml_test.go` plus all pre-existing tests including `sql_relationships_test.go`, `sql_alter_fk_test.go`, `sql_issue141_test.go`)
- [x] `go test ./...` — green across the full repo
- [x] `gofmt -l` clean, `go vet ./internal/extractors/sql/...` clean
- [x] Petclinic corpus (`spring-petclinic` schema.sql files) has no views/functions — new code path is inert there, so no risk of regression on the canonical Java fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)