### PR TITLE
feat(php): emit CALLS edges with receiver_type stamps (Closes #376)

### DIFF
--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -8,12 +8,19 @@
 //   - namespace_definition       → IMPORTS relationship (file → own namespace)
 //   - namespace_use_declaration  → IMPORTS relationship (file → imported FQN)
 //
+// Method/function bodies emit CALLS relationships (#376) for:
+//   - function_call_expression  bareFunc()
+//   - member_call_expression    $obj->method()
+//   - scoped_call_expression    Foo::m() / self::m() / parent::m()
+//   - object_creation_expression  new Foo()  (CALLS Foo, constructor edge)
+//
 // The extractor registers itself via init() and is auto-imported by the
 // generated registry_gen.go.
 package php
 
 import (
 	"context"
+	"regexp"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -116,14 +123,27 @@ func walk(node *sitter.Node, file extractor.FileInput, parentClass string, out *
 
 	case "method_declaration":
 		if rec, ok := buildOperation(node, file, "method"); ok {
+			bareName := rec.Name
 			if parentClass != "" {
-				rec.Name = parentClass + "." + rec.Name
+				rec.Name = parentClass + "." + bareName
 			}
+			body := node.ChildByFieldName("body")
+			if body == nil {
+				body = findFirstChildOfType(node, "compound_statement")
+			}
+			rec.Relationships = append(rec.Relationships,
+				extractCallRelationships(body, file.Content, bareName, parentClass)...)
 			*out = append(*out, rec)
 		}
 
 	case "function_definition":
 		if rec, ok := buildOperation(node, file, "function"); ok {
+			body := node.ChildByFieldName("body")
+			if body == nil {
+				body = findFirstChildOfType(node, "compound_statement")
+			}
+			rec.Relationships = append(rec.Relationships,
+				extractCallRelationships(body, file.Content, rec.Name, "")...)
 			*out = append(*out, rec)
 		}
 
@@ -446,4 +466,307 @@ func buildClassSignature(node *sitter.Node, src []byte, name string) string {
 		return strings.TrimSpace(raw[:idx])
 	}
 	return name
+}
+
+// findFirstChildOfType returns the first direct child whose Type() == kind.
+// Used as a fallback when ChildByFieldName("body") fails on older grammar
+// revisions that didn't label the body field.
+func findFirstChildOfType(n *sitter.Node, kind string) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := range int(n.ChildCount()) {
+		ch := n.Child(i)
+		if ch.Type() == kind {
+			return ch
+		}
+	}
+	return nil
+}
+
+// findAllNodes returns every descendant of root whose Type() is in kinds.
+func findAllNodes(root *sitter.Node, kinds ...string) []*sitter.Node {
+	if root == nil {
+		return nil
+	}
+	set := make(map[string]bool, len(kinds))
+	for _, k := range kinds {
+		set[k] = true
+	}
+	var out []*sitter.Node
+	stack := []*sitter.Node{root}
+	for len(stack) > 0 {
+		n := stack[len(stack)-1]
+		stack = stack[:len(stack)-1]
+		if set[n.Type()] {
+			out = append(out, n)
+		}
+		for i := 0; i < int(n.ChildCount()); i++ {
+			stack = append(stack, n.Child(i))
+		}
+	}
+	return out
+}
+
+// extractCallRelationships returns one CALLS RelationshipRecord per unique
+// callable invocation descendant of body. Issue #376.
+//
+// Tree-sitter PHP exposes four invocation node types:
+//
+//	function_call_expression    bareFunc()              — `function` field is the leaf name
+//	member_call_expression      $obj->method()          — `object` + `name` fields
+//	scoped_call_expression      Foo::m() / self::m()    — `scope` + `name` fields
+//	object_creation_expression  new Foo()               — constructor edge
+//
+// Receiver-type inference (stamped as Properties["receiver_type"] when known
+// and used by the resolver to bind same-name methods to the right class):
+//
+//	$this->m()                       → "<parentClass>.m"
+//	self::m() / static::m()          → "<parentClass>.m"
+//	Foo::m()                         → "Foo.m" (scope is a `name` node)
+//	$x->m() with `$x = new Foo()`    → "Foo.m"
+//	$x->m() preceded by /** @var Foo $x */
+//	                                 → "Foo.m"
+//	$x->m() otherwise                → bare leaf "m"
+//	bareFunc()                       → bare leaf "bareFunc"
+//	new Foo()                        → "Foo" (constructor)
+//
+// FromID is left empty so buildDocument substitutes the caller's entity ID
+// at emit time. Self-recursion (target leaf == callerName, dotted match
+// against parentClass + "." + callerName included) is dropped.
+func extractCallRelationships(body *sitter.Node, src []byte, callerName, parentClass string) []types.RelationshipRecord {
+	if body == nil || callerName == "" {
+		return nil
+	}
+	locals := collectLocalVarTypes(body, src)
+	selfQualified := callerName
+	if parentClass != "" {
+		selfQualified = parentClass + "." + callerName
+	}
+	calls := findAllNodes(body,
+		"function_call_expression",
+		"member_call_expression",
+		"scoped_call_expression",
+		"object_creation_expression",
+	)
+	if len(calls) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(calls))
+	rels := make([]types.RelationshipRecord, 0, len(calls))
+	for _, call := range calls {
+		target, recvType := phpCallTarget(call, src, parentClass, locals)
+		if target == "" {
+			continue
+		}
+		// Self-recursion check on the bare leaf.
+		leaf := target
+		if dot := strings.LastIndexByte(target, '.'); dot >= 0 {
+			leaf = target[dot+1:]
+		}
+		if leaf == callerName && (target == callerName || target == selfQualified) {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		r := types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		}
+		if recvType != "" {
+			r.Properties = map[string]string{"receiver_type": recvType}
+		}
+		rels = append(rels, r)
+	}
+	return rels
+}
+
+// phpCallTarget resolves the callee target from one of the four PHP
+// invocation nodes. Returns (target, receiverType). receiverType is "" when
+// no static type for the receiver is determinable. Issue #376.
+func phpCallTarget(call *sitter.Node, src []byte, parentClass string, locals map[string]string) (string, string) {
+	switch call.Type() {
+	case "function_call_expression":
+		fn := call.ChildByFieldName("function")
+		if fn == nil {
+			return "", ""
+		}
+		// Only emit for plain `name` callees. Variable-function calls
+		// (`$callable($x)`) and chained call results are too dynamic
+		// for static binding; the resolver would just route them to
+		// bug-resolver, so skip.
+		if fn.Type() != "name" {
+			return "", ""
+		}
+		return string(src[fn.StartByte():fn.EndByte()]), ""
+
+	case "member_call_expression":
+		nameNode := call.ChildByFieldName("name")
+		if nameNode == nil || nameNode.Type() != "name" {
+			return "", ""
+		}
+		method := string(src[nameNode.StartByte():nameNode.EndByte()])
+		obj := call.ChildByFieldName("object")
+		if obj == nil {
+			return method, ""
+		}
+		// $this->m() — receiver is the enclosing class.
+		if obj.Type() == "variable_name" {
+			vname := string(src[obj.StartByte():obj.EndByte()])
+			if vname == "$this" && parentClass != "" {
+				return parentClass + "." + method, parentClass
+			}
+			if t, ok := locals[vname]; ok && t != "" {
+				return t + "." + method, t
+			}
+		}
+		return method, ""
+
+	case "scoped_call_expression":
+		nameNode := call.ChildByFieldName("name")
+		if nameNode == nil || nameNode.Type() != "name" {
+			return "", ""
+		}
+		method := string(src[nameNode.StartByte():nameNode.EndByte()])
+		scope := call.ChildByFieldName("scope")
+		if scope == nil {
+			return method, ""
+		}
+		switch scope.Type() {
+		case "name":
+			// Foo::m() — explicit type name.
+			t := string(src[scope.StartByte():scope.EndByte()])
+			return t + "." + method, t
+		case "qualified_name":
+			// \Foo\Bar::m() — leaf segment is the bound type.
+			raw := strings.TrimSpace(string(src[scope.StartByte():scope.EndByte()]))
+			leaf := raw
+			if i := strings.LastIndex(raw, "\\"); i >= 0 {
+				leaf = raw[i+1:]
+			}
+			if leaf == "" {
+				return method, ""
+			}
+			return leaf + "." + method, leaf
+		case "relative_scope":
+			// self::m() / static::m() / parent::m() — bind to enclosing
+			// class when known. parent:: would ideally bind to the
+			// declared parent class, but the extractor doesn't track
+			// `extends` here; binding to parentClass is a best-effort
+			// shape that keeps the receiver_type stamp accurate for the
+			// caller-side and lets the resolver fall back to the bare
+			// leaf when needed.
+			if parentClass == "" {
+				return method, ""
+			}
+			return parentClass + "." + method, parentClass
+		}
+		return method, ""
+
+	case "object_creation_expression":
+		// new Foo() — emit a CALLS edge to "Foo". The resolver treats
+		// this as a constructor reference so framework classes
+		// (Symfony Request, Doctrine EntityManager, …) appear as
+		// outgoing edges from the calling method.
+		var typeNode *sitter.Node
+		// `type`/`name` fields are not consistently set across grammar
+		// revisions; the type is the first `name` or `qualified_name`
+		// child after the `new` keyword.
+		for i := range int(call.ChildCount()) {
+			ch := call.Child(i)
+			if ch.Type() == "name" || ch.Type() == "qualified_name" {
+				typeNode = ch
+				break
+			}
+		}
+		if typeNode == nil {
+			return "", ""
+		}
+		raw := strings.TrimSpace(string(src[typeNode.StartByte():typeNode.EndByte()]))
+		// Take the leaf segment of a qualified name.
+		if i := strings.LastIndex(raw, "\\"); i >= 0 {
+			raw = raw[i+1:]
+		}
+		if raw == "" {
+			return "", ""
+		}
+		return raw, ""
+	}
+	return "", ""
+}
+
+// docblockVarRE matches `@var Type $name` inside a /** ... */ docblock.
+// PHPDoc allows `@var Foo\Bar $x`, `@var ?Foo $x`, `@var Foo|null $x` —
+// we capture the first type token (up to whitespace, `|`, or `&`) and
+// strip a leading `?` nullable marker. Union/intersection types after the
+// first segment are dropped — receiver-type stamping needs a single class
+// name to bind, and downstream synth handles unions via the resolver.
+var docblockVarRE = regexp.MustCompile(`@var\s+\??([A-Za-z_\\][A-Za-z0-9_\\]*)\s+\$([A-Za-z_][A-Za-z0-9_]*)`)
+
+// collectLocalVarTypes scans the method/function body for two binding
+// patterns and returns a map from `$varname` to bare type leaf.
+//
+//  1. Assignment with constructor:   $x = new Foo();           → x → Foo
+//  2. PHPDoc `@var` immediately before a use:  /** @var Foo $x */
+//
+// Returned keys carry the leading `$` so callers can match them directly
+// against `variable_name` token text.
+func collectLocalVarTypes(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	out := map[string]string{}
+	// Pattern 1: assignment_expression where rhs is object_creation_expression.
+	for _, n := range findAllNodes(body, "assignment_expression") {
+		left := n.ChildByFieldName("left")
+		right := n.ChildByFieldName("right")
+		if left == nil || right == nil {
+			continue
+		}
+		if left.Type() != "variable_name" {
+			continue
+		}
+		if right.Type() != "object_creation_expression" {
+			continue
+		}
+		// Type leaf — first name/qualified_name child of the new-expr.
+		var typeNode *sitter.Node
+		for i := range int(right.ChildCount()) {
+			ch := right.Child(i)
+			if ch.Type() == "name" || ch.Type() == "qualified_name" {
+				typeNode = ch
+				break
+			}
+		}
+		if typeNode == nil {
+			continue
+		}
+		raw := strings.TrimSpace(string(src[typeNode.StartByte():typeNode.EndByte()]))
+		if i := strings.LastIndex(raw, "\\"); i >= 0 {
+			raw = raw[i+1:]
+		}
+		if raw == "" {
+			continue
+		}
+		vname := string(src[left.StartByte():left.EndByte()])
+		out[vname] = raw
+	}
+	// Pattern 2: PHPDoc `@var Type $name` comments. tree-sitter exposes
+	// docblocks as `comment` nodes — scan all and apply the regex.
+	for _, c := range findAllNodes(body, "comment") {
+		text := string(src[c.StartByte():c.EndByte()])
+		if !strings.HasPrefix(text, "/**") {
+			continue
+		}
+		for _, m := range docblockVarRE.FindAllStringSubmatch(text, -1) {
+			typ := m[1]
+			if i := strings.LastIndex(typ, "\\"); i >= 0 {
+				typ = typ[i+1:]
+			}
+			out["$"+m[2]] = typ
+		}
+	}
+	return out
 }

--- a/internal/extractors/php/relationships_test.go
+++ b/internal/extractors/php/relationships_test.go
@@ -1,0 +1,314 @@
+package php_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/php"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runPHP parses the PHP source and runs the registered extractor, returning
+// every emitted entity record.
+func runPHP(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("php")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "php",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func phpFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func phpCallsRels(e *types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func phpHasCallTo(e *types.EntityRecord, toID string) bool {
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+func phpReceiverFor(e *types.EntityRecord, toID string) string {
+	for _, r := range e.Relationships {
+		if r.Kind == "CALLS" && r.ToID == toID {
+			if r.Properties == nil {
+				return ""
+			}
+			return r.Properties["receiver_type"]
+		}
+	}
+	return ""
+}
+
+// TestPHP_Calls_BareFunction (#376): calls to a top-level PHP function emit a
+// bare-name CALLS edge with no receiver_type stamp.
+func TestPHP_Calls_BareFunction(t *testing.T) {
+	src := `<?php
+function helper(int $x): int { return $x + 1; }
+
+function caller(): int {
+    return helper(5);
+}
+`
+	ents := runPHP(t, src, "f.php")
+	caller := phpFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller function entity")
+	}
+	if !phpHasCallTo(caller, "helper") {
+		t.Errorf("expected CALLS caller→helper, got %+v", caller.Relationships)
+	}
+	if rt := phpReceiverFor(caller, "helper"); rt != "" {
+		t.Errorf("expected no receiver_type for bare call, got %q", rt)
+	}
+}
+
+// TestPHP_Calls_ThisMethod (#376): `$this->m()` inside class Foo emits a
+// CALLS edge to "Foo.m" with receiver_type=Foo so the resolver binds it
+// to the same-class method instead of an arbitrary same-named method
+// elsewhere in the codebase.
+func TestPHP_Calls_ThisMethod(t *testing.T) {
+	src := `<?php
+class Greeter {
+    public function greet(): string {
+        return $this->build();
+    }
+    public function build(): string { return "hi"; }
+}
+`
+	ents := runPHP(t, src, "greeter.php")
+	greet := phpFind(ents, "Greeter.greet", "SCOPE.Operation")
+	if greet == nil {
+		t.Fatal("expected Greeter.greet method entity")
+	}
+	if !phpHasCallTo(greet, "Greeter.build") {
+		t.Errorf("expected CALLS Greeter.greet→Greeter.build, got %+v", greet.Relationships)
+	}
+	if rt := phpReceiverFor(greet, "Greeter.build"); rt != "Greeter" {
+		t.Errorf("expected receiver_type=Greeter, got %q", rt)
+	}
+}
+
+// TestPHP_Calls_StaticScoped (#376): `Foo::m()` and `self::m()` both produce
+// dotted "<Class>.m" targets. The Foo:: scope binds to the literal name;
+// self:: binds to the enclosing class.
+func TestPHP_Calls_StaticScoped(t *testing.T) {
+	src := `<?php
+class Util {
+    public static function fmt(string $s): string { return $s; }
+    public function run(): string {
+        $a = Util::fmt("a");
+        $b = self::fmt("b");
+        return $a . $b;
+    }
+}
+`
+	ents := runPHP(t, src, "util.php")
+	run := phpFind(ents, "Util.run", "SCOPE.Operation")
+	if run == nil {
+		t.Fatal("expected Util.run method entity")
+	}
+	// Util::fmt and self::fmt both resolve to "Util.fmt" — dedup expected.
+	calls := phpCallsRels(run)
+	if len(calls) != 1 {
+		t.Errorf("expected 1 CALLS edge after dedup, got %d (%+v)", len(calls), calls)
+	}
+	if !phpHasCallTo(run, "Util.fmt") {
+		t.Errorf("expected CALLS Util.run→Util.fmt, got %+v", run.Relationships)
+	}
+	if rt := phpReceiverFor(run, "Util.fmt"); rt != "Util" {
+		t.Errorf("expected receiver_type=Util, got %q", rt)
+	}
+}
+
+// TestPHP_Calls_LocalNewBinding (#376): local-var type inference from
+// `$x = new Foo()` lets a follow-up `$x->m()` resolve to "Foo.m" with
+// receiver_type=Foo.
+func TestPHP_Calls_LocalNewBinding(t *testing.T) {
+	src := `<?php
+class Mailer { public function send(): void {} }
+function notify(): void {
+    $m = new Mailer();
+    $m->send();
+}
+`
+	ents := runPHP(t, src, "n.php")
+	notify := phpFind(ents, "notify", "SCOPE.Operation")
+	if notify == nil {
+		t.Fatal("expected notify function entity")
+	}
+	if !phpHasCallTo(notify, "Mailer.send") {
+		t.Errorf("expected CALLS notify→Mailer.send, got %+v", notify.Relationships)
+	}
+	if rt := phpReceiverFor(notify, "Mailer.send"); rt != "Mailer" {
+		t.Errorf("expected receiver_type=Mailer, got %q", rt)
+	}
+	// Constructor edge `new Mailer()` is also emitted.
+	if !phpHasCallTo(notify, "Mailer") {
+		t.Errorf("expected CALLS notify→Mailer (constructor), got %+v", notify.Relationships)
+	}
+}
+
+// TestPHP_Calls_DocblockVar (#376): a /** @var Foo $x */ docblock binds
+// `$x` so a subsequent `$x->m()` resolves with receiver_type=Foo even
+// when the variable was assigned from a non-constructor expression.
+func TestPHP_Calls_DocblockVar(t *testing.T) {
+	src := `<?php
+function persist($repo): void {
+    /** @var UserRepo $repo */
+    $repo->save();
+}
+`
+	ents := runPHP(t, src, "p.php")
+	persist := phpFind(ents, "persist", "SCOPE.Operation")
+	if persist == nil {
+		t.Fatal("expected persist function entity")
+	}
+	if !phpHasCallTo(persist, "UserRepo.save") {
+		t.Errorf("expected CALLS persist→UserRepo.save, got %+v", persist.Relationships)
+	}
+	if rt := phpReceiverFor(persist, "UserRepo.save"); rt != "UserRepo" {
+		t.Errorf("expected receiver_type=UserRepo, got %q", rt)
+	}
+}
+
+// TestPHP_Calls_UntypedVar (#376): `$x->m()` with no resolvable type for
+// `$x` falls back to a bare-leaf CALLS edge with no receiver_type stamp,
+// so the resolver routes it to bug-resolver as ambiguous-method.
+func TestPHP_Calls_UntypedVar(t *testing.T) {
+	src := `<?php
+function f($obj): void {
+    $obj->doWork();
+}
+`
+	ents := runPHP(t, src, "u.php")
+	f := phpFind(ents, "f", "SCOPE.Operation")
+	if f == nil {
+		t.Fatal("expected f function entity")
+	}
+	if !phpHasCallTo(f, "doWork") {
+		t.Errorf("expected bare CALLS f→doWork, got %+v", f.Relationships)
+	}
+	if rt := phpReceiverFor(f, "doWork"); rt != "" {
+		t.Errorf("expected no receiver_type for untyped receiver, got %q", rt)
+	}
+}
+
+// TestPHP_Calls_ConstructorEdge (#376): `new Foo()` emits a CALLS edge
+// whose ToID is the type leaf (qualified names are stripped to leaf so
+// the edge merges with framework class entities).
+func TestPHP_Calls_ConstructorEdge(t *testing.T) {
+	src := `<?php
+namespace App;
+function build(): void {
+    $r = new \Symfony\Component\HttpFoundation\Request();
+}
+`
+	ents := runPHP(t, src, "b.php")
+	build := phpFind(ents, "build", "SCOPE.Operation")
+	if build == nil {
+		t.Fatal("expected build function entity")
+	}
+	if !phpHasCallTo(build, "Request") {
+		t.Errorf("expected CALLS build→Request (constructor leaf), got %+v", build.Relationships)
+	}
+}
+
+// TestPHP_Calls_NoSelfRecursion (#376): a method calling itself with the
+// same dotted name must not emit a self-loop.
+func TestPHP_Calls_NoSelfRecursion(t *testing.T) {
+	src := `<?php
+class Counter {
+    public function tick(int $n): int {
+        if ($n <= 0) { return 0; }
+        return $this->tick($n - 1);
+    }
+}
+`
+	ents := runPHP(t, src, "c.php")
+	tick := phpFind(ents, "Counter.tick", "SCOPE.Operation")
+	if tick == nil {
+		t.Fatal("expected Counter.tick method entity")
+	}
+	for _, r := range tick.Relationships {
+		if r.Kind == "CALLS" && (r.ToID == "tick" || r.ToID == "Counter.tick") {
+			t.Errorf("self-recursion CALLS edge should be dropped, got %+v", r)
+		}
+	}
+}
+
+// TestPHP_Calls_DedupSameTarget (#376): repeated invocations of the same
+// callee within a single body collapse to one CALLS edge.
+func TestPHP_Calls_DedupSameTarget(t *testing.T) {
+	src := `<?php
+function logger(string $m): void {}
+function caller(): void {
+    logger("a");
+    logger("b");
+    logger("c");
+}
+`
+	ents := runPHP(t, src, "d.php")
+	caller := phpFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller function entity")
+	}
+	count := 0
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "logger" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 deduped CALLS logger edge, got %d", count)
+	}
+}
+
+// TestPHP_Calls_LanguageTag (#376/#90): every CALLS edge carries
+// Properties["language"]="php" so the resolver routes it through the PHP
+// dynamic-pattern catalog.
+func TestPHP_Calls_LanguageTag(t *testing.T) {
+	src := `<?php
+function caller(): void { other(); }
+`
+	ents := runPHP(t, src, "lt.php")
+	caller := phpFind(ents, "caller", "SCOPE.Operation")
+	if caller == nil {
+		t.Fatal("expected caller function entity")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if r.Properties["language"] != "php" {
+			t.Errorf("expected Properties[language]=php on CALLS edge, got %v", r.Properties)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

PORT-RELS-PHP gap closer. The PHP extractor already emits IMPORTS (#102) and CONTAINS (#145); this PR closes the remaining CALLS gap so the relationship contract matches Java/Ruby/Python.

Methods and functions now emit CALLS edges inside their bodies covering all four tree-sitter PHP invocation shapes:

- `function_call_expression` — `bareFunc()`
- `member_call_expression` — `$obj->method()`
- `scoped_call_expression` — `Foo::m()` / `self::m()` / `parent::m()`
- `object_creation_expression` — `new Foo()` (constructor edge)

Receiver-type inference (stamped as `Properties["receiver_type"]`):

- `$this->m()` → `"<parentClass>.m"`
- `Foo::m()` / `self::m()` → `"Foo.m"` or `"<parentClass>.m"`
- `$x->m()` with `$x = new Foo()` in scope → `"Foo.m"`
- `$x->m()` preceded by `/** @var Foo $x */` → `"Foo.m"`
- Otherwise → bare leaf, no `receiver_type`

Self-recursion is dropped (both bare and dotted forms), and repeated calls to the same target within a body collapse to one edge.

## VERIFY-2 single-repo on symfony-demo

| metric | baseline (origin/main) | with #376 |
| --- | ---: | ---: |
| relationships | 856 | 1499 |
| pass1_rels | 591 | 1234 |
| resolved | 540 (63%) | 1263 (84%) |

PHP CALLS edges added: ~643. Resolution rate climbs ~21 pts on the same fixture.

## Test plan

- [x] `go test ./...` (full suite green)
- [x] `go test ./internal/extractors/php/...` (existing IMPORTS/CONTAINS tests + 10 new TDD CALLS tests)
- [x] VERIFY-2 manual run on `php/symfony-demo` (baseline vs #376 comparison above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)