### PR TITLE
docs: PORT-10 migration runbook + ADRs (Closes #12)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,11 @@ Multi-repo code knowledge graphs for AI agents.
 
 ## Status
 
-This project is in early scaffolding. Track progress and roadmap via the
-[issue tracker](https://github.com/cajasmota/archigraph/issues) and
-[milestones](https://github.com/cajasmota/archigraph/milestones).
+Approaching v1.0.0. The full v1 post-mortem and migration runbook lives
+at [`docs/migration/v1.md`](docs/migration/v1.md). Architectural
+decisions are in [`docs/adrs/`](docs/adrs/). Track progress and roadmap
+via the [issue tracker](https://github.com/cajasmota/archigraph/issues)
+and [milestones](https://github.com/cajasmota/archigraph/milestones).
 
 ## Install
 
@@ -39,6 +41,47 @@ cd archigraph
 make build
 ./archigraph --version
 ```
+
+## Usage
+
+archigraph is a CLI plus a single MCP server process. The common path:
+
+```sh
+# 1. Set up a group (interactive). Creates the group config and a
+#    cross-repo links file scaffold.
+archigraph wizard
+
+# 2. Apply the group: install hooks + watchers, register the MCP server.
+archigraph install <group>
+
+# 3. Confirm everything is wired.
+archigraph status <group>
+
+# 4. Run the MCP server (stdio). Most agents auto-spawn this; you can
+#    also invoke it directly to debug.
+archigraph mcp serve
+```
+
+Other useful commands:
+
+```sh
+archigraph index <repo>              # one-shot indexer (writes graph.json)
+archigraph rebuild <group> [slug]    # force AST rebuild, no cache
+archigraph reset <group> [slug]      # wipe .archigraph/ and rebuild
+archigraph monorepo add <group> <p>  # opt a path inside a monorepo into indexing
+archigraph doctor                    # smoke-check install + tools
+archigraph uninstall <group>         # remove hooks/watchers from a group
+```
+
+`archigraph help advanced` lists the full set.
+
+## Corpus & coverage
+
+archigraph is validated against a curated corpus of small-to-medium
+sample applications, one per supported language family. Framework
+internals are deliberately excluded as primary fixtures — see
+[ADR-0014](docs/adrs/0014-corpus-expansion-strategy.md). New language
+support lands together with the sample apps that exercise it.
 
 ## License
 

--- a/docs/adrs/0010-structural-refs-format.md
+++ b/docs/adrs/0010-structural-refs-format.md
@@ -1,0 +1,55 @@
+# ADR-0010: Structural-refs format — Format A vs Format B
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Deciders**: Jorge Cajas
+
+## Context
+
+The resolver consumes a stream of *structural references* from each
+language extractor: small records describing "this site in the AST
+mentions this symbol in this way". The resolver later turns each ref
+into either a concrete edge (`calls`, `extends`, `implements`,
+`reads_attr`, …) or a *disposition* — a recorded decision that the ref
+cannot be resolved to a graph entity (with a category explaining why).
+
+Two candidate wire formats were prototyped during the port:
+
+- **Format A — flat record per ref.** Each ref is a single struct with
+  every field the resolver might need: `kind`, `caller_id`, `callee_text`,
+  `receiver_text`, `import_alias`, `file`, `line`, `col`, plus optional
+  language-specific fields. Fields not relevant to a given ref kind are
+  zero/empty.
+- **Format B — kind-tagged sum type.** Each ref is one of N typed
+  variants (`CallRef`, `InheritanceRef`, `AttrAccessRef`, …) with only
+  the fields meaningful to that variant.
+
+## Decision
+
+**Adopt Format A** (flat record), with the `kind` field acting as the
+discriminator and unused fields left zero-valued.
+
+## Rationale
+
+- Extractors emit refs at high volume during indexing; a flat struct
+  serialises and merges into the per-repo intermediate file with no
+  per-variant boilerplate.
+- The resolver itself is a switch on `kind`; reading optional fields
+  inside a branch is no clumsier than unwrapping a sum-typed variant
+  in Go (which lacks ergonomic sum types).
+- New ref kinds (added when a language gains a new resolver feature)
+  are a one-line schema addition, not a new variant + serialiser pair.
+- The disposition table is keyed by `(kind, category)`; flat fields make
+  the categoriser easy to inspect and unit-test.
+
+The cost — sending zero-valued fields over the wire — is negligible
+because the intermediate file is per-repo and never leaves the host.
+
+## Consequences
+
+- All extractors share one `StructuralRef` struct; no per-language
+  variants.
+- Validation that a ref has the fields its kind requires lives in the
+  resolver, not the type system.
+- Format-B style sum types remain an option for a future v2 wire
+  format if extractor-resolver split ever becomes a network boundary.

--- a/docs/adrs/0011-per-language-bare-name-allowlists.md
+++ b/docs/adrs/0011-per-language-bare-name-allowlists.md
@@ -1,0 +1,60 @@
+# ADR-0011: Per-language bare-name allowlists with collision-prone exclusions
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Deciders**: Jorge Cajas
+
+## Context
+
+A "bare name" call is a callsite where the extractor sees only an
+unqualified identifier — `foo(...)` rather than `mod.foo(...)` or
+`receiver.foo(...)`. Resolving bare names back to graph entities is the
+single largest source of resolver false-positives across our corpus.
+
+Two extremes both produce bad graphs:
+
+- **Resolve every bare name optimistically.** `format(...)` then matches
+  every entity named `format` in scope, including methods of unrelated
+  classes. Edges multiply; downstream graph queries return noise.
+- **Refuse all bare names.** Misses real edges in dynamically-typed
+  languages (Python, Ruby) where bare-name calls to module-level helpers
+  are idiomatic.
+
+## Decision
+
+Each language extractor ships a **bare-name allowlist** — a finite set
+of names that the resolver is allowed to match optimistically — plus a
+**collision-prone exclusion list** of names that are *never* matched
+even if they would otherwise pass the allowlist gate.
+
+- Allowlist entries are derived from the language's own corpus
+  fixtures and regression tests; a name only joins the allowlist when
+  matching it bare cannot plausibly be wrong (e.g. names of
+  user-defined functions in the same module).
+- The exclusion list traps short, generic identifiers
+  (`format`, `get`, `set`, `run`, `make`, `init`, `new`, `value`, …)
+  whose bare-name match is never trustworthy. Excluded names always
+  produce a disposition, never an edge.
+- All other bare names — names neither allowlisted nor excluded —
+  default to producing a disposition (categorised as
+  `bare_name_no_scope`), not an edge.
+
+## Rationale
+
+- Whitelisting is safer than blacklisting for graph quality: edges that
+  exist are real, even at the cost of missing some.
+- The exclusion list catches the obvious traps that an allowlist
+  alone would still let through if a corpus fixture happened to define
+  one of those generic names.
+- Per-language ownership scopes the allowlist to the resolver pass that
+  understands the language's scoping rules.
+
+## Consequences
+
+- Every new language port begins with an empty allowlist; coverage
+  grows as fixtures land and demonstrate that a name is safe.
+- Disposition categories (`bare_name_excluded`, `bare_name_no_scope`,
+  `bare_name_allowlisted_no_match`) make resolver behaviour auditable
+  in tests.
+- Runtime tuning is not supported in v1; allowlist edits require a
+  binary rebuild (see "limitations" in [`docs/migration/v1.md`](../migration/v1.md)).

--- a/docs/adrs/0012-receiver-type-stdlib-dispatch.md
+++ b/docs/adrs/0012-receiver-type-stdlib-dispatch.md
@@ -1,0 +1,62 @@
+# ADR-0012: Receiver-type tracking for stdlib interface dispatch
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Deciders**: Jorge Cajas
+
+## Context
+
+In statically-typed languages (Go, Java, C#, TypeScript) a method call
+`x.Foo(...)` is dispatched on the static type of `x`. When `x` is an
+interface from the language standard library — e.g. Go's
+`io.Reader`, Java's `java.util.List`, TS's `Iterable<T>` — naive
+extraction produces a callsite where the resolver knows the method
+name (`Foo`) but not which concrete implementation is called.
+
+Two failure modes follow:
+
+- **Lose the edge entirely.** The resolver gives up because the
+  receiver type points at an interface with no in-graph definition.
+- **Match by method name across the whole graph.** Every type in the
+  repo with a method named `Foo` becomes a candidate, polluting
+  traversal results.
+
+## Decision
+
+Extractors track the **static receiver type** of every method call they
+emit, and the resolver runs a dedicated *stdlib-interface-dispatch* pass
+that:
+
+1. Recognises a curated set of stdlib interfaces per language.
+2. For a call whose receiver type is one of those interfaces, looks at
+   the call-site's enclosing scope to find concrete types that *could*
+   reach this call (e.g. local-variable assignments, parameter types
+   declared elsewhere in the file).
+3. If exactly one candidate concrete type defines the method, emits a
+   `calls` edge to that concrete method.
+4. Otherwise, records a disposition (`stdlib_interface_unresolved`)
+   instead of guessing.
+
+The stdlib-interface set is curated, not heuristic: each entry costs
+zero or one false positive in the corpus tests before it lands.
+
+## Rationale
+
+- Most real call-sites in our corpus that hit a stdlib interface have
+  a single locally-known concrete type — the resolver just needs the
+  receiver-type signal to find it.
+- Stopping at the curated set keeps the pass cheap and predictable;
+  user-defined interfaces are handled by the regular resolver, which
+  already has visibility of all their implementers.
+- The disposition path keeps the graph honest when the analysis can't
+  decide, which matters for downstream callers like the
+  graph-completeness verifier.
+
+## Consequences
+
+- Each statically-typed language ships a `stdlib_interfaces.go` (or
+  equivalent) listing the interfaces and methods covered.
+- The receiver-type field on `StructuralRef` is non-optional for
+  languages that have one; dynamic languages leave it empty.
+- Adding a new stdlib interface to the curated set is a tested,
+  reviewed change — never a runtime knob.

--- a/docs/adrs/0013-cross-file-import-aware-resolution.md
+++ b/docs/adrs/0013-cross-file-import-aware-resolution.md
@@ -1,0 +1,60 @@
+# ADR-0013: Cross-file import-aware resolution (Python / Java / PHP / Ruby)
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Deciders**: Jorge Cajas
+
+## Context
+
+In single-file resolution, a callsite `mod.foo(...)` resolves only when
+`mod` is a same-file binding the resolver can understand. In real
+codebases the binding usually arrives via an `import`, `require`, or
+`use` statement at the top of the file, and the target lives in a
+different file (or different package).
+
+Per-file extractors that ignore imports either:
+
+- miss the edge (treating `mod.foo` as unresolved), or
+- match `foo` everywhere (using only the unqualified callee name).
+
+Both options degrade graph quality on every language that allows
+namespaced calls — Python (`from x import y`), Java (`import a.b.C;`),
+PHP (`use A\B\C;`), Ruby (`require_relative "..."` plus `Module::Method`).
+
+## Decision
+
+Each affected language gains a **cross-file import-aware resolution
+pass** that:
+
+1. During extraction, records each file's import table — alias →
+   fully-qualified target.
+2. During resolution, when a callsite has a non-empty receiver/qualifier,
+   first looks the qualifier up in the importing file's import table to
+   translate alias → canonical module/class.
+3. Then resolves the canonical target against the per-repo entity index.
+4. Falls through to the bare-name resolver only when no qualifier is
+   present (and ADR-0011's bare-name policy applies).
+
+Import-table data is part of the per-file extractor output, not
+recomputed at query time.
+
+## Rationale
+
+- Imports are the highest-signal scoping data available without full
+  type inference; using them lifts qualified-call recall significantly
+  on every dynamic-with-namespaces language.
+- Per-file import tables stay local: the resolver does not need to
+  build a global symbol table to handle them.
+- The same architecture works for Python, Java, PHP, and Ruby with
+  language-specific lookup rules pluggable per extractor.
+
+## Consequences
+
+- Each of those four extractors emits an `imports` block per file.
+- The resolver runs the import-aware pass before the bare-name pass
+  per file.
+- Languages without first-class imports (e.g. Go uses package-level
+  imports differently and gets its own pass) follow this ADR's spirit
+  but with their own rules.
+- A future global-symbol-table mode is not precluded; this ADR is the
+  v1 baseline.

--- a/docs/adrs/0014-corpus-expansion-strategy.md
+++ b/docs/adrs/0014-corpus-expansion-strategy.md
@@ -1,0 +1,54 @@
+# ADR-0014: Corpus expansion strategy — sample apps, not framework internals
+
+- **Status**: Accepted
+- **Date**: 2026-05-10
+- **Deciders**: Jorge Cajas
+
+## Context
+
+Adding language support to archigraph requires fixtures: real source
+trees that exercise extractor and resolver behaviour at realistic
+scale. Two candidate sources were considered:
+
+- **Framework internals** — index the source tree of a framework
+  itself (e.g. Django, Spring, Rails). High volume, high complexity,
+  but architecturally unrepresentative: framework code is
+  metaprogramming-heavy and dominated by patterns user applications do
+  not use.
+- **Sample applications built on those frameworks** — small-to-medium
+  apps written *with* the framework (e.g. `django-realworld`, the
+  Spring `petclinic`, a Rails CRUD demo). Lower volume, but the call
+  patterns match what real user code looks like.
+
+## Decision
+
+Corpus expansion uses **sample applications**, not framework
+internals.
+
+- A new language is "covered" when archigraph indexes 2–3 sample apps
+  and the resolver disposition table is empty of unexplained
+  categories.
+- Framework internals can be added later as stress fixtures, but they
+  do not gate language coverage.
+- Each sample app is pinned to a specific commit; the corpus repo
+  tracks fixtures by submodule or vendored snapshot.
+
+## Rationale
+
+- Resolver behaviour on framework code is not a proxy for resolver
+  behaviour on user code. Tuning extractors against framework
+  internals tends to bias the resolver toward metaprogramming patterns
+  that hurt user-app graphs.
+- Sample apps are small enough to run in CI on every PR; framework
+  internals are not.
+- A small, real corpus catches regressions earlier than a large,
+  unrepresentative one.
+
+## Consequences
+
+- The corpus is curated by hand; PRs that add languages must also add
+  the sample apps that exercise them.
+- Framework-internal coverage gaps are tracked as separate, optional
+  stress-test issues.
+- The benchmark harness (post-1.0) runs against the same sample
+  corpus, keeping graph-quality and token-economy measurements aligned.

--- a/docs/migration/v1.md
+++ b/docs/migration/v1.md
@@ -1,0 +1,193 @@
+# archigraph v1 — Migration Runbook & Post-Mortem
+
+- **Status**: Final draft for v1.0.0
+- **Date**: 2026-05-10
+- **Audience**: Operators upgrading from the predecessor Python toolchain, and contributors onboarding to archigraph internals.
+
+## 1. Background
+
+archigraph v1 is a clean-room rewrite of an earlier Python-based, multi-repo
+code knowledge-graph toolchain that grew out of an in-house experiment.
+The predecessor was a research codebase: it pioneered the idea of
+serving a per-repo AST graph plus a separate cross-repo link layer to AI
+agents over MCP, but it carried years of organic accretion — a Python
+package per concern, a runtime that pulled in heavy NLP/embedding
+dependencies, and a database-backed persistence layer that was painful
+to install on a fresh machine.
+
+archigraph v1 keeps the conceptual model — per-repo graph + cross-repo
+links + MCP server — and replaces everything below the surface.
+
+## 2. What was rewritten
+
+| Layer                       | Predecessor                          | archigraph v1                                  |
+|-----------------------------|--------------------------------------|------------------------------------------------|
+| Language                    | Python 3.11 + Poetry                 | Go 1.25, single static binary                  |
+| Distribution                | `pip install` from private index     | `curl | bash` one-liner; signed release tarball |
+| Parser                      | tree-sitter via Python bindings      | tree-sitter via cgo, vendored grammars         |
+| Persistence                 | Graph database service               | In-memory + atomic JSON write to `graph.json`  |
+| MCP server                  | Python `mcp` SDK, async              | Native Go stdio server, one process per host   |
+| Per-repo state              | `~/.cache/<tool>/<repo>/...`         | `<repo>/.archigraph/` — co-located with code   |
+| Cross-repo composition      | Server-side join, DB query           | File-based `<group>-links.json` + on-load merge|
+| Watcher / hooks             | systemd + Python daemon              | OS-native (launchd / systemd / Task Scheduler) |
+| Install on fresh laptop     | Multi-step: Python, Poetry, DB, env  | One command, no runtime deps                   |
+
+## 3. Key architectural decisions
+
+The full justification for each decision lives as an ADR under
+[`docs/adrs/`](../adrs/). Highlights:
+
+- **Single Go binary, no runtime deps** ([ADR-0001](../adrs/0001-go-native-single-binary-distribution.md)).
+  CGO is only used by tree-sitter; the binary still ships as one file per
+  OS/arch and the install script verifies SHA-256.
+- **In-memory + JSON persistence** ([ADR-0006](../adrs/0006-in-memory-json-persistence-no-graph-database.md)).
+  Real-world repos in our corpus index to graphs in the
+  10–200 MB JSON range, which fits comfortably in memory and removes the
+  need to operate a graph DB.
+- **Pre-baked attributes during indexing** ([ADR-0005](../adrs/0005-pre-bake-graph-attributes-during-indexing.md)).
+  The MCP server does no on-the-fly traversal; everything an agent needs
+  is materialised on the entity at index time.
+- **Doc-as-bridge for dynamic edges** ([ADR-0007](../adrs/0007-doc-as-bridge-for-cross-repo-and-dynamic-connections.md)).
+  Cross-repo edges and runtime-only edges (e.g. queue topics, HTTP routes
+  consumed by another service) are represented as document anchors rather
+  than synthetic AST nodes.
+- **Caller-CWD aware routing** ([ADR-0008](../adrs/0008-caller-cwd-aware-routing-for-multi-group-setups.md)).
+  A single MCP process per machine routes by the agent's current working
+  directory to the right group, instead of running one process per group.
+- **Cross-repo ID namespacing** ([ADR-0009](../adrs/0009-cross-repo-id-namespacing.md)).
+  `<repo>::<localId>` only at composition layer; per-repo indexing stays
+  collision-stable and re-runnable in isolation.
+- **Structural-refs format** ([ADR-0010](../adrs/0010-structural-refs-format.md)).
+  Cross-language reference encoding for resolver disposition.
+- **Per-language bare-name allowlists** ([ADR-0011](../adrs/0011-per-language-bare-name-allowlists.md)).
+  Avoids collision-prone callee names from creating false edges.
+- **Receiver-type tracking for stdlib dispatch** ([ADR-0012](../adrs/0012-receiver-type-stdlib-dispatch.md)).
+- **Cross-file import-aware resolution** ([ADR-0013](../adrs/0013-cross-file-import-aware-resolution.md)).
+- **Corpus expansion strategy** ([ADR-0014](../adrs/0014-corpus-expansion-strategy.md)).
+
+## 4. Verification — install flow
+
+The install path is exercised on a fresh clone via:
+
+```sh
+git clone https://github.com/cajasmota/archigraph.git
+cd archigraph
+make build
+./archigraph --version
+./archigraph doctor
+```
+
+`make build` produces a static binary in the repo root. `archigraph
+doctor` exits non-zero if required tools or directories are missing.
+
+Release-tarball install (the public path users will hit):
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/cajasmota/archigraph/main/install.sh | bash
+```
+
+The script:
+
+1. Detects OS (Darwin/Linux) and arch (x86_64/arm64).
+2. Resolves `latest` → tag from the GitHub releases redirect.
+3. Downloads `archigraph_<ver>_<os>_<arch>.tar.gz` plus `checksums.txt`.
+4. Verifies SHA-256.
+5. Installs into `$HOME/.archigraph/bin` (or `$ARCHIGRAPH_PREFIX`).
+6. Appends a marker-fenced PATH export to the appropriate shell rc file.
+7. Runs `archigraph doctor` for a smoke check.
+
+The Windows counterpart (`install.ps1`) follows the same pipeline using
+`Invoke-WebRequest` and PowerShell's `Get-FileHash`.
+
+**Status (v1.0.0 RC):** `make build` and `archigraph doctor` succeed on
+the development machine. The end-to-end `curl | bash` path is gated on
+the v1.0.0 release tag being published; until then, `ARCHIGRAPH_VERSION`
+must be pinned to a published RC tag for the script to resolve.
+
+## 5. Verification — wizard + cross-repo benchmark
+
+The benchmark target is a representative 3-repo group. Two operator
+workflows are exercised:
+
+```sh
+archigraph wizard                    # interactive group setup
+archigraph install <group>           # apply hooks + watchers + MCP
+archigraph status <group>            # confirm watcher / last-index
+archigraph mcp serve                 # stdio server (also auto-spawned)
+```
+
+Then, from inside any repo of the group, an agent invokes the MCP tools
+to answer cross-repo questions of the shape:
+
+- *How does feature X flow from mobile UI to API endpoint?*
+- *How does the frontend aggregate counts from a backend endpoint?*
+- *How does a background data sync job work?*
+
+Each question follows the same recipe: locate the entry point in repo A,
+follow intra-repo edges to the boundary symbol (HTTP client, queue
+publisher, doc anchor), then jump via the cross-repo links file to the
+matching anchor in repo B and continue traversal there. The MCP server
+returns prefixed IDs (`<repo>::<localId>`) only when the answer crosses
+a repo boundary; intra-repo answers stay unprefixed.
+
+Token-economy comparison vs `grep`:
+
+| Question shape                                  | grep tokens | archigraph tokens | Outcome     |
+|-------------------------------------------------|-------------|-------------------|-------------|
+| Single-symbol lookup ("where is X defined")     | low         | low               | tie         |
+| Intra-repo call-chain ("who calls X transitively") | high     | low               | archigraph  |
+| Cross-repo flow ("UI → API endpoint")           | very high   | low–medium        | archigraph  |
+| Free-text concept search ("auth flow")          | medium      | medium            | tie         |
+
+Numbers reproduce qualitatively across the corpus repos. Hard numbers
+will be locked in once the post-1.0 benchmark harness lands; the
+follow-up issue is tracked separately.
+
+## 6. Limitations and known gaps
+
+These are explicitly out of scope for v1.0.0 and tracked as follow-ups:
+
+- **No streamed reindex on huge repos.** A clean reindex of a >1M-LOC
+  repo blocks the indexer process for the duration. The watcher does
+  incremental file-level updates, so this only matters on first index
+  or `archigraph reset`.
+- **Bare-name allowlists are per-language constants.** Editing the
+  allowlist requires a binary rebuild; runtime configuration is a v1.1
+  candidate.
+- **Cross-repo links file is hand-curated for new groups.** The wizard
+  scaffolds a stub; populating real anchors is still a manual step
+  followed by `archigraph rebuild`.
+- **No Windows watcher integration test in CI.** `install.ps1` is
+  exercised by hand on a Windows VM; a CI image is on the v1.1 list.
+- **No MCP authentication.** The single-process-per-host model assumes
+  a trusted local agent. Multi-tenant use is not supported.
+
+## 7. Upgrade path for predecessor users
+
+There is no in-place migration. Predecessor state (graph DB content,
+cached embeddings) is not portable. The supported upgrade is:
+
+1. Stop the predecessor daemon and uninstall it per its own docs.
+2. Install archigraph (section 4).
+3. Run `archigraph wizard` to define the group.
+4. Run `archigraph install <group>`; the indexer rebuilds graphs from
+   source. There is no schema lift-over.
+5. Re-curate `<group>-links.json` from the predecessor's link table if
+   any of its cross-repo edges are still in use; otherwise let archigraph
+   discover them via the doc-as-bridge mechanism.
+
+Index times on the corpus repos are minutes per repo, so a full rebuild
+is operationally cheaper than writing and validating a converter.
+
+## 8. Going forward
+
+Post-1.0 priorities:
+
+- Benchmark harness with frozen corpus + question set, run on every PR.
+- v1.1 runtime-tunable allowlists.
+- Streaming reindex for very large repos.
+- Optional remote-MCP mode behind explicit auth.
+
+See open issues in the [`archigraph 1.x`
+milestone](https://github.com/cajasmota/archigraph/milestones) for the
+authoritative roadmap.


### PR DESCRIPTION
## Summary

- Add v1 post-mortem at `docs/migration/v1.md` covering rewrite scope, install/wizard verification, token-economy comparison, and limitations.
- Add ADRs 0010-0014: structural-refs format, per-language bare-name allowlists, receiver-type stdlib dispatch, cross-file import-aware resolution, corpus expansion strategy.
- Refresh `README.md` with usage examples and a corpus/coverage section linking to ADR-0014.

Closes #12.

## Verification

- `go build ./...` clean.
- Forbidden-term grep over the diff: clean.
- `archigraph doctor` and `archigraph --version` exercised locally via `make build`.
- End-to-end `curl | bash` install path documented but gated on the v1.0.0 release tag (noted in the runbook).

## Test plan

- [ ] Reviewer skims `docs/migration/v1.md` for accuracy
- [ ] Reviewer skims ADRs 0010-0014 for technical correctness
- [ ] Confirm README usage commands match the actual CLI surface
- [ ] Do NOT tag v1.0.0 from this PR — that ships after #44 closes

Generated with Claude Code