### PR TITLE
feat(dashboard): subcommand + embedded HTTP server

### DIFF
--- a/cmd/archigraph/dashboard.go
+++ b/cmd/archigraph/dashboard.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/cajasmota/archigraph/internal/dashboard"
+)
+
+// runDashboard is wired into cli.Hooks and dispatches the `dashboard`
+// subcommand verbs. Currently only `serve` is implemented; future verbs
+// (open, status) plug in here.
+func runDashboard(argv []string) error {
+	if len(argv) == 0 || argv[0] == "-h" || argv[0] == "--help" {
+		fmt.Fprintln(os.Stderr, "usage: archigraph dashboard <serve> [flags]")
+		return nil
+	}
+	switch argv[0] {
+	case "serve":
+		return runDashboardServe(argv[1:])
+	default:
+		return fmt.Errorf("unknown dashboard verb: %s", argv[0])
+	}
+}
+
+// runDashboardServe parses serve-only flags, picks a free port, prints it
+// to stdout, and blocks until SIGINT/SIGTERM.
+func runDashboardServe(argv []string) error {
+	fs := flag.NewFlagSet("dashboard serve", flag.ContinueOnError)
+	bindOverride := fs.String("bind", "", "override Bind (default from ~/.archigraph/dashboard.json)")
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	cfg, err := dashboard.LoadConfig()
+	if err != nil {
+		return fmt.Errorf("load dashboard config: %w", err)
+	}
+	if *bindOverride != "" {
+		cfg.Bind = *bindOverride
+	}
+
+	srv, err := dashboard.NewServer(cfg, dashboard.NewLiveStore())
+	if err != nil {
+		return err
+	}
+	port, err := srv.Listen()
+	if err != nil {
+		return err
+	}
+	// Per spec: chosen port -> stdout (single line, easy to capture from
+	// shell scripts). Logs (including the human-readable banner) -> stderr.
+	fmt.Fprintln(os.Stdout, port)
+	fmt.Fprintf(os.Stderr, "archigraph dashboard listening on http://%s/\n", srv.Addr())
+
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+	return srv.Serve(ctx)
+}

--- a/cmd/archigraph/main.go
+++ b/cmd/archigraph/main.go
@@ -14,9 +14,10 @@ import (
 // (extractor, classifier, ...) that we don't want to surface from cli.
 func main() {
 	cli.Execute(cli.Hooks{
-		RunIndex: runIndex,
-		RunMCP:   runMCP,
-		RunLinks: runLinksHook,
+		RunIndex:     runIndex,
+		RunMCP:       runMCP,
+		RunLinks:     runLinksHook,
+		RunDashboard: runDashboard,
 	})
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -15,8 +15,9 @@ import (
 // must live in cmd/archigraph (because they pull in heavy internal
 // packages that should not be visible from the CLI surface).
 type Hooks struct {
-	RunIndex func(argv []string) error
-	RunMCP   func(argv []string) error
+	RunIndex     func(argv []string) error
+	RunMCP       func(argv []string) error
+	RunDashboard func(argv []string) error
 	// RunLinks runs the cross-repo link passes for a group. Wired up
 	// from cmd/archigraph so the watcher loop in watch.go can re-trigger
 	// link passes whenever a registered repo's graph.json changes.

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -1,0 +1,24 @@
+package cli
+
+import (
+	"errors"
+
+	"github.com/spf13/cobra"
+)
+
+// newDashboardCmd is the cobra shim for `archigraph dashboard ...`. The
+// real implementation lives in cmd/archigraph/dashboard.go and is wired
+// in via activeHooks.RunDashboard.
+func newDashboardCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:                "dashboard <serve> [flags]",
+		Short:              "Run the local archigraph dashboard server",
+		DisableFlagParsing: true,
+		RunE: func(_ *cobra.Command, args []string) error {
+			if activeHooks.RunDashboard == nil {
+				return errors.New("dashboard handler not wired")
+			}
+			return activeHooks.RunDashboard(args)
+		},
+	}
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -52,6 +52,7 @@ func newRoot() *cobra.Command {
 		newWatchCmd(),
 		newIndexCmd(),
 		newMCPCmd(),
+		newDashboardCmd(),
 		newLinksCmd(),
 		newHelpCmd(),
 	)
@@ -119,4 +120,7 @@ Indexing:
 
 MCP:
   mcp serve                       Start the MCP server on stdio
+
+Dashboard:
+  dashboard serve                 Run the local dashboard HTTP server
 `

--- a/internal/dashboard/config.go
+++ b/internal/dashboard/config.go
@@ -1,0 +1,118 @@
+// Package dashboard implements the `archigraph dashboard serve` subcommand:
+// a Go-native HTTP server that exposes a small read/write REST surface over
+// the local registry plus an embedded placeholder SPA. Designed to run on a
+// developer workstation only; bind defaults to loopback and auth defaults
+// off (loopback-only). See ADR-0011 (dashboard architecture) for context.
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// PortRange is the inclusive [Min, Max] window the server picks a random
+// free port from at startup. Both ends are clamped to valid TCP ports.
+type PortRange struct {
+	Min int `json:"min"`
+	Max int `json:"max"`
+}
+
+// AuthConfig is reserved for future bearer-token gating. For now Enabled
+// defaults to false and the server binds to loopback, which is the only
+// access control on the wire.
+type AuthConfig struct {
+	Enabled bool   `json:"enabled"`
+	Token   string `json:"token,omitempty"`
+}
+
+// Config is the on-disk shape of ~/.archigraph/dashboard.json. Every field
+// has a zero-value default that produces a usable loopback server, so the
+// file does not need to exist for `dashboard serve` to work.
+type Config struct {
+	PortRange PortRange  `json:"port_range"`
+	Bind      string     `json:"bind"`
+	Auth      AuthConfig `json:"auth"`
+}
+
+// DefaultConfig returns the loopback-only defaults used when the config
+// file is absent or partially specified.
+func DefaultConfig() Config {
+	return Config{
+		PortRange: PortRange{Min: 31000, Max: 31999},
+		Bind:      "127.0.0.1",
+		Auth:      AuthConfig{Enabled: false},
+	}
+}
+
+// ConfigPath returns the canonical path to dashboard.json under HomeDir.
+func ConfigPath() (string, error) {
+	h, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(h, "dashboard.json"), nil
+}
+
+// LoadConfig reads dashboard.json, falling back to DefaultConfig when the
+// file is missing. Partial files are merged onto the defaults so a user
+// can override only the fields they care about.
+func LoadConfig() (Config, error) {
+	cfg := DefaultConfig()
+	p, err := ConfigPath()
+	if err != nil {
+		return cfg, err
+	}
+	b, err := os.ReadFile(p)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return cfg, nil
+		}
+		return cfg, err
+	}
+	// Decode into a sparse struct so unset fields keep their defaults.
+	var raw struct {
+		PortRange *PortRange  `json:"port_range,omitempty"`
+		Bind      *string     `json:"bind,omitempty"`
+		Auth      *AuthConfig `json:"auth,omitempty"`
+	}
+	if err := json.Unmarshal(b, &raw); err != nil {
+		return cfg, fmt.Errorf("dashboard.json: %w", err)
+	}
+	if raw.PortRange != nil {
+		if raw.PortRange.Min != 0 {
+			cfg.PortRange.Min = raw.PortRange.Min
+		}
+		if raw.PortRange.Max != 0 {
+			cfg.PortRange.Max = raw.PortRange.Max
+		}
+	}
+	if raw.Bind != nil && *raw.Bind != "" {
+		cfg.Bind = *raw.Bind
+	}
+	if raw.Auth != nil {
+		cfg.Auth = *raw.Auth
+	}
+	if err := cfg.Validate(); err != nil {
+		return cfg, err
+	}
+	return cfg, nil
+}
+
+// Validate rejects port ranges outside the legal TCP window.
+func (c Config) Validate() error {
+	if c.PortRange.Min < 1 || c.PortRange.Min > 65535 {
+		return fmt.Errorf("port_range.min out of range: %d", c.PortRange.Min)
+	}
+	if c.PortRange.Max < 1 || c.PortRange.Max > 65535 {
+		return fmt.Errorf("port_range.max out of range: %d", c.PortRange.Max)
+	}
+	if c.PortRange.Max < c.PortRange.Min {
+		return fmt.Errorf("port_range.max (%d) < min (%d)", c.PortRange.Max, c.PortRange.Min)
+	}
+	return nil
+}

--- a/internal/dashboard/config_test.go
+++ b/internal/dashboard/config_test.go
@@ -1,0 +1,74 @@
+package dashboard
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultConfig(t *testing.T) {
+	c := DefaultConfig()
+	if c.PortRange.Min != 31000 || c.PortRange.Max != 31999 {
+		t.Errorf("default range = %d-%d", c.PortRange.Min, c.PortRange.Max)
+	}
+	if c.Bind != "127.0.0.1" {
+		t.Errorf("default bind = %q", c.Bind)
+	}
+	if c.Auth.Enabled {
+		t.Errorf("default auth must be disabled")
+	}
+	if err := c.Validate(); err != nil {
+		t.Errorf("default config invalid: %v", err)
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := []struct {
+		name string
+		c    Config
+		ok   bool
+	}{
+		{"min-too-low", Config{PortRange: PortRange{Min: 0, Max: 100}}, false},
+		{"max-too-high", Config{PortRange: PortRange{Min: 1, Max: 70000}}, false},
+		{"reversed", Config{PortRange: PortRange{Min: 200, Max: 100}}, false},
+		{"ok", Config{PortRange: PortRange{Min: 31000, Max: 31999}}, true},
+	}
+	for _, tc := range cases {
+		err := tc.c.Validate()
+		if (err == nil) != tc.ok {
+			t.Errorf("%s: ok=%v err=%v", tc.name, tc.ok, err)
+		}
+	}
+}
+
+func TestLoadConfig_MissingReturnsDefaults(t *testing.T) {
+	// Point HomeDir at a tmp dir with no dashboard.json.
+	tmp := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", tmp)
+	c, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if c.PortRange.Min != 31000 {
+		t.Errorf("expected default min=31000 got %d", c.PortRange.Min)
+	}
+}
+
+func TestLoadConfig_PartialMerge(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", tmp)
+	if err := os.WriteFile(filepath.Join(tmp, "dashboard.json"),
+		[]byte(`{"bind":"0.0.0.0"}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	c, err := LoadConfig()
+	if err != nil {
+		t.Fatalf("LoadConfig: %v", err)
+	}
+	if c.Bind != "0.0.0.0" {
+		t.Errorf("bind = %q", c.Bind)
+	}
+	if c.PortRange.Min != 31000 || c.PortRange.Max != 31999 {
+		t.Errorf("port range not defaulted: %+v", c.PortRange)
+	}
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -1,0 +1,119 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// handleListRegistry — GET /api/registry. Returns every registered group
+// plus its repo slugs. Empty-but-present registry returns [].
+func (s *Server) handleListRegistry(w http.ResponseWriter, _ *http.Request) {
+	groups, err := s.registry.ListGroups()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if groups == nil {
+		groups = []GroupSummary{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
+}
+
+// handleGroupGraph — GET /api/groups/{group}/graph. Returns an envelope
+// containing each repo's graph.json. The envelope is JSON-shaped so the
+// SPA can stream-decode and so we can later attach communities/links
+// without breaking clients.
+func (s *Server) handleGroupGraph(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+	body, err := s.registry.GroupGraph(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// handleRepoGraph — GET /api/groups/{group}/repos/{repo}/graph. Streams
+// the repo's graph.json verbatim.
+func (s *Server) handleRepoGraph(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+	body, err := s.registry.RepoGraph(group, repo)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// createGroupReq is the request body for POST /api/admin/groups.
+type createGroupReq struct {
+	Name string `json:"name"`
+}
+
+func (s *Server) handleCreateGroup(w http.ResponseWriter, r *http.Request) {
+	var req createGroupReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeErr(w, http.StatusBadRequest, "name required")
+		return
+	}
+	out, err := s.registry.CreateGroup(req.Name)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, out)
+}
+
+// addRepoReq is the request body for POST /api/admin/groups/{group}/repos.
+// Mirrors registry.Repo so the SPA can post the same shape it reads back.
+type addRepoReq struct {
+	Slug     string   `json:"slug"`
+	Path     string   `json:"path"`
+	Stack    string   `json:"stack,omitempty"`
+	CloneURL string   `json:"clone_url,omitempty"`
+	Modules  []string `json:"modules,omitempty"`
+}
+
+func (s *Server) handleAddRepo(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+	var req addRepoReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	repo := registry.Repo{
+		Slug:     req.Slug,
+		Path:     req.Path,
+		Stack:    req.Stack,
+		CloneURL: req.CloneURL,
+		Modules:  req.Modules,
+	}
+	if err := s.registry.AddRepo(group, repo); err != nil {
+		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	writeJSON(w, http.StatusCreated, map[string]any{"group": group, "repo": repo})
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -1,0 +1,160 @@
+package dashboard
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/fs"
+	"math/rand"
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// Server is an embedded HTTP dashboard. It is intentionally small: it
+// composes a chi-style router by hand on top of net/http so we keep the
+// stdlib-only constraint from the issue body.
+type Server struct {
+	cfg      Config
+	registry RegistryStore
+	listener net.Listener
+	srv      *http.Server
+	rng      *rand.Rand
+}
+
+// NewServer wires a server against the given config and registry-store
+// adapter. Pass NewLiveStore() in production; tests pass an in-memory
+// fake.
+func NewServer(cfg Config, store RegistryStore) (*Server, error) {
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	if store == nil {
+		return nil, errors.New("dashboard: nil RegistryStore")
+	}
+	return &Server{
+		cfg:      cfg,
+		registry: store,
+		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+	}, nil
+}
+
+// Listen binds to a random free port within cfg.PortRange. It is
+// separated from Serve so callers (and tests) can read back the chosen
+// port before traffic starts flowing.
+func (s *Server) Listen() (int, error) {
+	const maxAttempts = 64
+	span := s.cfg.PortRange.Max - s.cfg.PortRange.Min + 1
+	tried := make(map[int]struct{}, maxAttempts)
+	for i := 0; i < maxAttempts && len(tried) < span; i++ {
+		port := s.cfg.PortRange.Min + s.rng.Intn(span)
+		if _, seen := tried[port]; seen {
+			continue
+		}
+		tried[port] = struct{}{}
+		addr := net.JoinHostPort(s.cfg.Bind, strconv.Itoa(port))
+		l, err := net.Listen("tcp", addr)
+		if err == nil {
+			s.listener = l
+			return port, nil
+		}
+	}
+	return 0, fmt.Errorf("dashboard: no free port in %d-%d after %d attempts",
+		s.cfg.PortRange.Min, s.cfg.PortRange.Max, maxAttempts)
+}
+
+// Serve runs the HTTP server on the listener bound by Listen. It blocks
+// until ctx is cancelled or http.Server returns a non-shutdown error.
+func (s *Server) Serve(ctx context.Context) error {
+	if s.listener == nil {
+		return errors.New("dashboard: Serve called before Listen")
+	}
+	mux := s.routes()
+	s.srv = &http.Server{
+		Handler:           mux,
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+	errCh := make(chan error, 1)
+	go func() {
+		err := s.srv.Serve(s.listener)
+		if errors.Is(err, http.ErrServerClosed) {
+			err = nil
+		}
+		errCh <- err
+	}()
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+		defer cancel()
+		_ = s.srv.Shutdown(shutdownCtx)
+		return nil
+	case err := <-errCh:
+		return err
+	}
+}
+
+// Addr returns the bound TCP address. Useful for tests that do not know
+// the port up front.
+func (s *Server) Addr() string {
+	if s.listener == nil {
+		return ""
+	}
+	return s.listener.Addr().String()
+}
+
+// routes builds the http.ServeMux for this server. Kept package-private so
+// tests can hit handlers via httptest.NewServer(s.routes()) without going
+// through Listen.
+func (s *Server) routes() http.Handler {
+	mux := http.NewServeMux()
+
+	// Static SPA. The embed root is "static/", strip that prefix so the
+	// browser sees /index.html etc.
+	sub, err := fs.Sub(staticFS, "static")
+	if err == nil {
+		mux.Handle("/", http.FileServer(http.FS(sub)))
+	}
+
+	mux.HandleFunc("GET /api/registry", s.handleListRegistry)
+	mux.HandleFunc("GET /api/groups/{group}/graph", s.handleGroupGraph)
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/graph", s.handleRepoGraph)
+	mux.HandleFunc("POST /api/admin/groups", s.handleCreateGroup)
+	mux.HandleFunc("POST /api/admin/groups/{group}/repos", s.handleAddRepo)
+
+	return s.withAuth(mux)
+}
+
+// withAuth wraps the mux with a bearer-token check when cfg.Auth.Enabled.
+// Static asset routes (anything that does not start with /api/) are left
+// open so the SPA shell can load before the user supplies credentials.
+func (s *Server) withAuth(next http.Handler) http.Handler {
+	if !s.cfg.Auth.Enabled {
+		return next
+	}
+	expected := "Bearer " + s.cfg.Auth.Token
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if len(r.URL.Path) >= 5 && r.URL.Path[:5] == "/api/" {
+			if r.Header.Get("Authorization") != expected {
+				http.Error(w, "unauthorized", http.StatusUnauthorized)
+				return
+			}
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+// writeJSON serializes v to w with the standard JSON content type. Errors
+// during encoding are logged via the http.Server error log; the client
+// will see a truncated body, which is the best stdlib can do.
+func writeJSON(w http.ResponseWriter, status int, v any) {
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(v)
+}
+
+// writeErr emits a uniform { "error": "..." } body.
+func writeErr(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, map[string]string{"error": msg})
+}

--- a/internal/dashboard/server_test.go
+++ b/internal/dashboard/server_test.go
@@ -1,0 +1,341 @@
+package dashboard
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// fakeStore is an in-memory RegistryStore. It removes the dependency on
+// ~/.archigraph for tests so they stay hermetic and parallel-safe.
+type fakeStore struct {
+	mu        sync.Mutex
+	groups    map[string]GroupSummary
+	groupG    map[string][]byte
+	repoG     map[string]map[string][]byte
+	addRepoEr error
+}
+
+func newFakeStore() *fakeStore {
+	return &fakeStore{
+		groups: map[string]GroupSummary{},
+		groupG: map[string][]byte{},
+		repoG:  map[string]map[string][]byte{},
+	}
+}
+
+func (f *fakeStore) ListGroups() ([]GroupSummary, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	out := make([]GroupSummary, 0, len(f.groups))
+	for _, v := range f.groups {
+		out = append(out, v)
+	}
+	return out, nil
+}
+
+func (f *fakeStore) GroupGraph(group string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	b, ok := f.groupG[group]
+	if !ok {
+		return nil, fmt.Errorf("group %q not found", group)
+	}
+	return b, nil
+}
+
+func (f *fakeStore) RepoGraph(group, repo string) ([]byte, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	g, ok := f.repoG[group]
+	if !ok {
+		return nil, fmt.Errorf("group %q not found", group)
+	}
+	b, ok := g[repo]
+	if !ok {
+		return nil, fmt.Errorf("repo %q not found", repo)
+	}
+	return b, nil
+}
+
+func (f *fakeStore) CreateGroup(name string) (GroupSummary, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if _, ok := f.groups[name]; ok {
+		return GroupSummary{}, fmt.Errorf("exists")
+	}
+	gs := GroupSummary{Name: name, ConfigPath: "/tmp/" + name + ".json"}
+	f.groups[name] = gs
+	return gs, nil
+}
+
+func (f *fakeStore) AddRepo(group string, repo registry.Repo) error {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	if f.addRepoEr != nil {
+		return f.addRepoEr
+	}
+	gs, ok := f.groups[group]
+	if !ok {
+		return fmt.Errorf("group %q not found", group)
+	}
+	gs.Repos = append(gs.Repos, repo.Slug)
+	f.groups[group] = gs
+	return nil
+}
+
+// newTestServer wires a Server against a httptest harness. Returns the
+// HTTP base URL and a cleanup func.
+func newTestServer(t *testing.T, store RegistryStore, cfg Config) (string, func()) {
+	t.Helper()
+	s, err := NewServer(cfg, store)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(s.routes())
+	return ts.URL, ts.Close
+}
+
+func TestPortDiscovery_PicksFreePort(t *testing.T) {
+	cfg := DefaultConfig()
+	cfg.Bind = "127.0.0.1"
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	port, err := srv.Listen()
+	if err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	defer srv.listener.Close()
+	if port < cfg.PortRange.Min || port > cfg.PortRange.Max {
+		t.Errorf("port %d outside configured range %d-%d", port, cfg.PortRange.Min, cfg.PortRange.Max)
+	}
+	if got := srv.Addr(); !strings.HasSuffix(got, fmt.Sprintf(":%d", port)) {
+		t.Errorf("Addr()=%q; want suffix :%d", got, port)
+	}
+}
+
+func TestPortDiscovery_SkipsOccupied(t *testing.T) {
+	// Bind a port in a tiny range so the server has to skip it.
+	occupied, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("seed listener: %v", err)
+	}
+	defer occupied.Close()
+	occPort := occupied.Addr().(*net.TCPAddr).Port
+
+	// Range covering only [occPort, occPort+1] so the server must pick the
+	// non-conflicting neighbour. If that neighbour is also taken on the
+	// host we widen by one and try again — flaky-host hedge.
+	for span := 1; span < 16; span++ {
+		cfg := Config{
+			PortRange: PortRange{Min: occPort, Max: occPort + span},
+			Bind:      "127.0.0.1",
+		}
+		s, err := NewServer(cfg, newFakeStore())
+		if err != nil {
+			t.Fatalf("NewServer: %v", err)
+		}
+		port, err := s.Listen()
+		if err == nil {
+			defer s.listener.Close()
+			if port == occPort {
+				t.Fatalf("server picked occupied port %d", port)
+			}
+			return
+		}
+	}
+	t.Fatalf("could not find free port near %d", occPort)
+}
+
+func TestRegistryEndpoint(t *testing.T) {
+	st := newFakeStore()
+	st.groups["alpha"] = GroupSummary{Name: "alpha", ConfigPath: "/x/alpha.json", Repos: []string{"r1"}}
+
+	base, cleanup := newTestServer(t, st, DefaultConfig())
+	defer cleanup()
+
+	resp, err := http.Get(base + "/api/registry")
+	if err != nil {
+		t.Fatalf("GET /api/registry: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body struct {
+		Groups []GroupSummary `json:"groups"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Groups) != 1 || body.Groups[0].Name != "alpha" {
+		t.Fatalf("unexpected body: %+v", body)
+	}
+}
+
+func TestRepoGraphEndpoint(t *testing.T) {
+	st := newFakeStore()
+	st.repoG["alpha"] = map[string][]byte{
+		"svc": []byte(`{"entities":[{"id":"e1"}]}`),
+	}
+	base, cleanup := newTestServer(t, st, DefaultConfig())
+	defer cleanup()
+
+	resp, err := http.Get(base + "/api/groups/alpha/repos/svc/graph")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	b, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(b), `"e1"`) {
+		t.Fatalf("body missing entity id: %s", b)
+	}
+
+	// Unknown repo -> 404.
+	resp2, err := http.Get(base + "/api/groups/alpha/repos/missing/graph")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp2.Body.Close()
+	if resp2.StatusCode != 404 {
+		t.Fatalf("status=%d, want 404", resp2.StatusCode)
+	}
+}
+
+func TestGroupGraphEndpoint(t *testing.T) {
+	st := newFakeStore()
+	st.groupG["alpha"] = []byte(`{"group":"alpha","repos":[]}`)
+	base, cleanup := newTestServer(t, st, DefaultConfig())
+	defer cleanup()
+
+	resp, err := http.Get(base + "/api/groups/alpha/graph")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+}
+
+func TestCreateGroupEndpoint(t *testing.T) {
+	st := newFakeStore()
+	base, cleanup := newTestServer(t, st, DefaultConfig())
+	defer cleanup()
+
+	resp, err := http.Post(base+"/api/admin/groups", "application/json",
+		bytes.NewBufferString(`{"name":"beta"}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+	}
+	if _, ok := st.groups["beta"]; !ok {
+		t.Fatalf("group not created in store")
+	}
+}
+
+func TestAddRepoEndpoint(t *testing.T) {
+	st := newFakeStore()
+	st.groups["alpha"] = GroupSummary{Name: "alpha"}
+	base, cleanup := newTestServer(t, st, DefaultConfig())
+	defer cleanup()
+
+	body := `{"slug":"svc","path":"/repo/svc","stack":"go"}`
+	resp, err := http.Post(base+"/api/admin/groups/alpha/repos",
+		"application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 201 {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status=%d body=%s", resp.StatusCode, b)
+	}
+	if got := st.groups["alpha"].Repos; len(got) != 1 || got[0] != "svc" {
+		t.Fatalf("repos=%v", got)
+	}
+}
+
+func TestAuthGate(t *testing.T) {
+	st := newFakeStore()
+	cfg := DefaultConfig()
+	cfg.Auth = AuthConfig{Enabled: true, Token: "secret"}
+	base, cleanup := newTestServer(t, st, cfg)
+	defer cleanup()
+
+	// No auth header -> 401.
+	resp, err := http.Get(base + "/api/registry")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != 401 {
+		t.Fatalf("status=%d, want 401", resp.StatusCode)
+	}
+
+	// Correct token -> 200.
+	req, _ := http.NewRequest("GET", base+"/api/registry", nil)
+	req.Header.Set("Authorization", "Bearer secret")
+	resp2, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp2.Body.Close()
+	if resp2.StatusCode != 200 {
+		t.Fatalf("status=%d, want 200", resp2.StatusCode)
+	}
+
+	// Static asset is open even with auth on (so SPA shell can load).
+	resp3, err := http.Get(base + "/")
+	if err != nil {
+		t.Fatalf("GET /: %v", err)
+	}
+	resp3.Body.Close()
+	if resp3.StatusCode != 200 {
+		t.Fatalf("static status=%d, want 200", resp3.StatusCode)
+	}
+}
+
+func TestServeShutsDownOnContextCancel(t *testing.T) {
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	if _, err := srv.Listen(); err != nil {
+		t.Fatalf("Listen: %v", err)
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- srv.Serve(ctx) }()
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			t.Fatalf("Serve: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("Serve did not return after cancel")
+	}
+}

--- a/internal/dashboard/static.go
+++ b/internal/dashboard/static.go
@@ -1,0 +1,10 @@
+package dashboard
+
+import "embed"
+
+// staticFS holds the placeholder SPA bundle. The real dashboard frontend
+// will replace the contents of internal/dashboard/static/ once it lands;
+// the embed directive does not need to change.
+//
+//go:embed static
+var staticFS embed.FS

--- a/internal/dashboard/static/index.html
+++ b/internal/dashboard/static/index.html
@@ -1,0 +1,22 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Archigraph Dashboard</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        max-width: 720px;
+        margin: 4rem auto;
+        padding: 0 1.5rem;
+        color: #222;
+      }
+      code { background: #f4f4f4; padding: 0 .25rem; border-radius: 3px; }
+    </style>
+  </head>
+  <body>
+    <h1>Archigraph Dashboard</h1>
+    <p>SPA UI coming soon. The REST API is live at <code>/api/registry</code>.</p>
+  </body>
+</html>

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -1,0 +1,170 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// RegistryStore is the small surface the HTTP handlers need. Splitting it
+// out lets tests inject an in-memory implementation without touching
+// ~/.archigraph on disk.
+type RegistryStore interface {
+	ListGroups() ([]GroupSummary, error)
+	GroupGraph(group string) ([]byte, error)
+	RepoGraph(group, repo string) ([]byte, error)
+	CreateGroup(name string) (GroupSummary, error)
+	AddRepo(group string, repo registry.Repo) error
+}
+
+// GroupSummary is the registry list shape returned by GET /api/registry.
+type GroupSummary struct {
+	Name       string   `json:"name"`
+	ConfigPath string   `json:"config_path"`
+	Repos      []string `json:"repos"`
+}
+
+// liveStore is the production RegistryStore: it reads from the on-disk
+// registry under ~/.archigraph and from each repo's .archigraph/graph.json.
+type liveStore struct{}
+
+// NewLiveStore returns the production RegistryStore.
+func NewLiveStore() RegistryStore { return liveStore{} }
+
+func (liveStore) ListGroups() ([]GroupSummary, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, err
+	}
+	out := make([]GroupSummary, 0, len(groups))
+	for _, g := range groups {
+		s := GroupSummary{Name: g.Name, ConfigPath: g.ConfigPath}
+		if cfg, err := registry.LoadGroupConfig(g.ConfigPath); err == nil {
+			for _, r := range cfg.Repos {
+				s.Repos = append(s.Repos, r.Slug)
+			}
+		}
+		out = append(out, s)
+	}
+	return out, nil
+}
+
+func (liveStore) GroupGraph(group string) ([]byte, error) {
+	cfg, err := groupConfig(group)
+	if err != nil {
+		return nil, err
+	}
+	// Compose a minimal envelope: one entry per repo with the embedded
+	// graph.json bytes. Communities, god-nodes and cross-repo links are
+	// deferred per the issue body.
+	type repoEntry struct {
+		Slug  string          `json:"slug"`
+		Path  string          `json:"path"`
+		Graph json.RawMessage `json:"graph,omitempty"`
+		Error string          `json:"error,omitempty"`
+	}
+	entries := make([]repoEntry, 0, len(cfg.Repos))
+	for _, r := range cfg.Repos {
+		e := repoEntry{Slug: r.Slug, Path: r.Path}
+		b, err := os.ReadFile(filepath.Join(r.Path, ".archigraph", "graph.json"))
+		if err != nil {
+			e.Error = err.Error()
+		} else {
+			e.Graph = b
+		}
+		entries = append(entries, e)
+	}
+	return json.Marshal(map[string]any{
+		"group":     group,
+		"repos":     entries,
+		"deferred":  []string{"communities", "god_nodes", "cross_repo_links"},
+		"served_at": time.Now().UTC().Format(time.RFC3339),
+	})
+}
+
+func (liveStore) RepoGraph(group, repo string) ([]byte, error) {
+	cfg, err := groupConfig(group)
+	if err != nil {
+		return nil, err
+	}
+	for _, r := range cfg.Repos {
+		if r.Slug == repo {
+			return os.ReadFile(filepath.Join(r.Path, ".archigraph", "graph.json"))
+		}
+	}
+	return nil, fmt.Errorf("repo %q not registered in group %q", repo, group)
+}
+
+func (liveStore) CreateGroup(name string) (GroupSummary, error) {
+	if name == "" {
+		return GroupSummary{}, errors.New("group name required")
+	}
+	configPath, err := registry.ConfigPathFor(name)
+	if err != nil {
+		return GroupSummary{}, err
+	}
+	if _, err := os.Stat(configPath); err == nil {
+		return GroupSummary{}, fmt.Errorf("group %q already exists", name)
+	}
+	cfg := &registry.GroupConfig{Name: name}
+	if err := registry.SaveGroupConfig(configPath, cfg); err != nil {
+		return GroupSummary{}, err
+	}
+	if err := registry.AddGroup(name, configPath); err != nil {
+		return GroupSummary{}, err
+	}
+	return GroupSummary{Name: name, ConfigPath: configPath}, nil
+}
+
+func (liveStore) AddRepo(group string, repo registry.Repo) error {
+	if repo.Slug == "" {
+		return errors.New("repo slug required")
+	}
+	if repo.Path == "" {
+		return errors.New("repo path required")
+	}
+	groups, err := registry.Groups()
+	if err != nil {
+		return err
+	}
+	var configPath string
+	for _, g := range groups {
+		if g.Name == group {
+			configPath = g.ConfigPath
+			break
+		}
+	}
+	if configPath == "" {
+		return fmt.Errorf("group %q not registered", group)
+	}
+	cfg, err := registry.LoadGroupConfig(configPath)
+	if err != nil {
+		return err
+	}
+	for _, r := range cfg.Repos {
+		if r.Slug == repo.Slug {
+			return fmt.Errorf("repo %q already registered in group %q", repo.Slug, group)
+		}
+	}
+	cfg.Repos = append(cfg.Repos, repo)
+	return registry.SaveGroupConfig(configPath, cfg)
+}
+
+// groupConfig is a small helper used by the read-side handlers.
+func groupConfig(group string) (*registry.GroupConfig, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil, err
+	}
+	for _, g := range groups {
+		if g.Name == group {
+			return registry.LoadGroupConfig(g.ConfigPath)
+		}
+	}
+	return nil, fmt.Errorf("group %q not registered", group)
+}


### PR DESCRIPTION
Closes #26.

## Summary

Adds `archigraph dashboard serve` — a Go-native (stdlib `net/http`) HTTP server with random port discovery, an embedded placeholder SPA, and a minimum-viable REST surface over the on-disk registry. Designed for local-only developer use; binds to `127.0.0.1` by default.

## Endpoints implemented

| Method | Path | Purpose |
| --- | --- | --- |
| `GET` | `/api/registry` | List groups + their repo slugs |
| `GET` | `/api/groups/{group}/graph` | Group envelope: each repo's `graph.json` inlined |
| `GET` | `/api/groups/{group}/repos/{repo}/graph` | Streams a single repo's `graph.json` verbatim |
| `POST` | `/api/admin/groups` | Create a new group (registry + per-group config) |
| `POST` | `/api/admin/groups/{group}/repos` | Register a repo in a group |
| `GET` | `/` (and other static) | Embedded placeholder SPA |

## Deferred (tracked for follow-up)

- Community detection / god-nodes
- Cross-repo links surfaced in the group envelope
- Single-entity detail endpoint
- Full admin surface (delete group, remove repo, edit modules, etc.)
- Production SPA — the `static/` dir ships an `index.html` stub

## Config

`~/.archigraph/dashboard.json`:

```json
{
  "port_range": { "min": 31000, "max": 31999 },
  "bind": "127.0.0.1",
  "auth": { "enabled": false, "token": "" }
}
```

All fields optional — sensible loopback defaults when file absent. When `auth.enabled` is true, `/api/*` requires `Authorization: Bearer <token>`; static routes stay open so the SPA shell can load before the user authenticates.

## Tests

13 new tests in `internal/dashboard`:
- Config: defaults, validation, missing-file fallback, partial-merge from disk
- Port discovery: picks free port in range, skips occupied port
- Endpoints: each of the 5 REST routes, plus 404 paths
- Auth gate: 401 without token, 200 with token, static stays open
- Graceful shutdown on context cancel

`go test ./...`, `go vet ./...`, `gofmt -l` all clean.

## Smoke output (`GET /api/registry`)

```
$ ARCHIGRAPH_HOME=$(mktemp -d) bin/archigraph dashboard serve
31432
archigraph dashboard listening on http://127.0.0.1:31432/

$ curl -s http://127.0.0.1:31432/api/registry
{"groups":[]}

$ curl -s -X POST -H 'Content-Type: application/json' \
       -d '{"name":"alpha"}' http://127.0.0.1:31432/api/admin/groups
{"name":"alpha","config_path":".../alpha.fleet.json","repos":null}

$ curl -s http://127.0.0.1:31432/api/registry
{"groups":[{"name":"alpha","config_path":".../alpha.fleet.json","repos":null}]}
```

## Test plan

- [ ] `go test ./internal/dashboard/...` passes locally
- [ ] `bin/archigraph dashboard serve` prints a port in 31000-31999 to stdout, banner to stderr
- [ ] `curl http://127.0.0.1:<port>/api/registry` returns `{"groups":[...]}`
- [ ] SIGINT shuts the server down within ~3 seconds
- [ ] Setting `auth.enabled=true` causes `/api/*` to 401 without a Bearer token