### PR TITLE
feat(community): TF-IDF auto_name on communities (Closes #28 — Layer 1)

### DIFF
--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -28,11 +28,18 @@ import (
 )
 
 // CommunityResult summarises one Louvain community for the on-disk output.
+//
+// AutoName is the deterministic Layer-1 label produced by AssignCommunityNames
+// (TF-IDF over member entity names). It is always populated when communities
+// are computed; consumers that previously fell back to "community_<id>" can
+// now display AutoName directly. A future Layer-2 agent-resolved label will
+// take precedence over AutoName when present.
 type CommunityResult struct {
 	ID          int      `json:"id"`
 	Size        int      `json:"size"`
 	Modularity  float64  `json:"modularity"`
 	TopEntities []string `json:"top_entities"`
+	AutoName    string   `json:"auto_name,omitempty"`
 }
 
 // SurpriseEdge is a cross-community edge whose pair frequency is rare.
@@ -572,6 +579,9 @@ func RunAlgorithms(entities []Entity, rels []Relationship) *AlgorithmResults {
 	}
 
 	commResults, commOf, overallQ := ComputeCommunities(g, idx, names)
+	// Layer-1 deterministic naming (TF-IDF over member entity names +
+	// qualified names + source-file basenames). Mutates commResults in place.
+	AssignCommunityNames(commResults, entities, commOf)
 	betw, pr := ComputeCentrality(g, idx)
 	gods := IdentifyGodNodes(betw, pr)
 	arts := IdentifyArticulationPoints(g, idx)

--- a/internal/graph/community_names.go
+++ b/internal/graph/community_names.go
@@ -1,0 +1,279 @@
+// Layer 1 deterministic naming for Louvain communities.
+//
+// For each community we collect its member entity names (label, qualified
+// name, source-file basename), tokenise on camelCase / snake_case / kebab /
+// path-separators, and compute TF-IDF where each community is a "document".
+// The top 1-3 distinguishing terms become the community's auto_name (e.g.
+// "order-viewset", "data-sync-task"). The result is written back onto each
+// CommunityResult and serialised as `communities[].auto_name` in graph.json.
+//
+// Stdlib only — no new dependencies.
+package graph
+
+import (
+	"math"
+	"path/filepath"
+	"sort"
+	"strings"
+	"unicode"
+)
+
+// stopwords skipped during tokenisation. Generic source-code noise that would
+// otherwise dominate TF-IDF on small communities.
+var stopwords = map[string]bool{
+	"":      true,
+	"a":     true,
+	"an":    true,
+	"and":   true,
+	"as":    true,
+	"at":    true,
+	"by":    true,
+	"for":   true,
+	"from":  true,
+	"in":    true,
+	"is":    true,
+	"of":    true,
+	"on":    true,
+	"or":    true,
+	"the":   true,
+	"to":    true,
+	"with":  true,
+	"go":    true,
+	"py":    true,
+	"js":    true,
+	"ts":    true,
+	"tsx":   true,
+	"jsx":   true,
+	"java":  true,
+	"rb":    true,
+	"src":   true,
+	"lib":   true,
+	"pkg":   true,
+	"main":  true,
+	"init":  true,
+	"new":   true,
+	"impl":  true,
+	"util":  true,
+	"utils": true,
+	"test":  true,
+	"tests": true,
+	"spec":  true,
+	"specs": true,
+	"id":    true,
+	"py_":   true,
+}
+
+// tokenize splits an identifier-like string into lowercase tokens by
+// camelCase boundaries, snake_case, kebab-case, dots, slashes, and any other
+// non-alphanumeric run. Single-character tokens and stopwords are dropped.
+func tokenize(s string) []string {
+	if s == "" {
+		return nil
+	}
+	// First, split on path separators / dots / dashes / underscores / spaces.
+	fields := strings.FieldsFunc(s, func(r rune) bool {
+		return !unicode.IsLetter(r) && !unicode.IsDigit(r)
+	})
+	out := make([]string, 0, len(fields))
+	for _, f := range fields {
+		// Then split each field on camelCase boundaries.
+		for _, sub := range splitCamel(f) {
+			lower := strings.ToLower(sub)
+			if len(lower) <= 1 {
+				continue
+			}
+			if stopwords[lower] {
+				continue
+			}
+			out = append(out, lower)
+		}
+	}
+	return out
+}
+
+// splitCamel breaks "OrderViewSet" into ["Order", "View", "Set"], "HTTPServer"
+// into ["HTTP", "Server"], and leaves "order" / "ORDER" untouched.
+func splitCamel(s string) []string {
+	if s == "" {
+		return nil
+	}
+	runes := []rune(s)
+	out := []string{}
+	start := 0
+	for i := 1; i < len(runes); i++ {
+		prev, cur := runes[i-1], runes[i]
+		// Lower -> Upper transition: foo|Bar
+		if unicode.IsLower(prev) && unicode.IsUpper(cur) {
+			out = append(out, string(runes[start:i]))
+			start = i
+			continue
+		}
+		// Letter -> Digit or Digit -> Letter transition: v2|migrate
+		if unicode.IsLetter(prev) != unicode.IsLetter(cur) {
+			out = append(out, string(runes[start:i]))
+			start = i
+			continue
+		}
+		// Acronym boundary: HTTPServer -> HTTP|Server (Upper followed by
+		// Upper-then-Lower).
+		if i+1 < len(runes) && unicode.IsUpper(prev) && unicode.IsUpper(cur) && unicode.IsLower(runes[i+1]) {
+			out = append(out, string(runes[start:i]))
+			start = i
+			continue
+		}
+	}
+	out = append(out, string(runes[start:]))
+	return out
+}
+
+// communityCorpusEntry is the per-entity input to the naming pass.
+type communityCorpusEntry struct {
+	communityID   int
+	name          string
+	qualifiedName string
+	sourceFile    string
+}
+
+// AssignCommunityNames computes a deterministic auto_name for every community
+// in `results` using TF-IDF over the supplied entity corpus. Communities with
+// no member tokens fall back to the legacy "community_<id>" label so callers
+// can rely on auto_name being non-empty.
+//
+// The function mutates `results` in place. Order of `results` is preserved.
+func AssignCommunityNames(results []CommunityResult, entities []Entity, communityOf map[string]int) {
+	if len(results) == 0 {
+		return
+	}
+
+	// Collect tokens per community. Token frequency inside a community
+	// counts once per source occurrence (name + qname + basename are three
+	// independent observations per entity).
+	tokensByCommunity := make(map[int]map[string]int, len(results))
+	for _, e := range entities {
+		cid, ok := communityOf[e.ID]
+		if !ok || cid < 0 {
+			continue
+		}
+		bag := tokensByCommunity[cid]
+		if bag == nil {
+			bag = make(map[string]int)
+			tokensByCommunity[cid] = bag
+		}
+		for _, t := range tokenize(e.Name) {
+			bag[t]++
+		}
+		for _, t := range tokenize(e.QualifiedName) {
+			bag[t]++
+		}
+		base := filepath.Base(e.SourceFile)
+		// Strip extension so "orders.py" contributes "orders" not "orders" + "py".
+		if ext := filepath.Ext(base); ext != "" {
+			base = strings.TrimSuffix(base, ext)
+		}
+		for _, t := range tokenize(base) {
+			bag[t]++
+		}
+	}
+
+	// Document frequency: number of communities each token appears in.
+	df := make(map[string]int)
+	for _, bag := range tokensByCommunity {
+		for tok := range bag {
+			df[tok]++
+		}
+	}
+	totalDocs := float64(len(tokensByCommunity))
+	if totalDocs == 0 {
+		// No tokens at all — fall back to legacy labels.
+		for i := range results {
+			results[i].AutoName = legacyName(results[i].ID)
+		}
+		return
+	}
+
+	for i := range results {
+		cid := results[i].ID
+		bag := tokensByCommunity[cid]
+		if len(bag) == 0 {
+			results[i].AutoName = legacyName(cid)
+			continue
+		}
+
+		// Total term count for normalisation.
+		total := 0
+		for _, c := range bag {
+			total += c
+		}
+		totalF := float64(total)
+
+		type scored struct {
+			term  string
+			score float64
+		}
+		ranked := make([]scored, 0, len(bag))
+		for term, count := range bag {
+			tf := float64(count) / totalF
+			// log((N+1)/(df+1)) + 1 — smooth IDF; handles single-community
+			// corpora gracefully (idf collapses to 1, so TF ranks terms).
+			idf := math.Log((totalDocs+1)/(float64(df[term])+1)) + 1
+			ranked = append(ranked, scored{term, tf * idf})
+		}
+		// Deterministic ordering: score desc, then term asc.
+		sort.Slice(ranked, func(a, b int) bool {
+			if ranked[a].score != ranked[b].score {
+				return ranked[a].score > ranked[b].score
+			}
+			return ranked[a].term < ranked[b].term
+		})
+
+		// Pick top 1-3 terms; cap at 3, but stop early if score collapses to 0.
+		picked := make([]string, 0, 3)
+		for _, s := range ranked {
+			if s.score <= 0 {
+				break
+			}
+			picked = append(picked, s.term)
+			if len(picked) == 3 {
+				break
+			}
+		}
+		if len(picked) == 0 {
+			results[i].AutoName = legacyName(cid)
+			continue
+		}
+		// Conventional shape: 2 terms looks like "order-viewset"; if only
+		// one strong term survives, use it alone; if three are tied, keep
+		// all three.
+		results[i].AutoName = strings.Join(picked, "-")
+	}
+}
+
+func legacyName(cid int) string {
+	// Match the pre-Layer-1 placeholder shape so the dashboard never sees
+	// an empty string.
+	b := strings.Builder{}
+	b.WriteString("community_")
+	// itoa is defined in the test helpers; re-implement locally to avoid
+	// pulling in strconv just for one call.
+	if cid == 0 {
+		b.WriteString("0")
+		return b.String()
+	}
+	neg := cid < 0
+	n := cid
+	if neg {
+		n = -n
+	}
+	digits := make([]byte, 0, 8)
+	for n > 0 {
+		digits = append(digits, byte('0'+n%10))
+		n /= 10
+	}
+	if neg {
+		b.WriteByte('-')
+	}
+	for i := len(digits) - 1; i >= 0; i-- {
+		b.WriteByte(digits[i])
+	}
+	return b.String()
+}

--- a/internal/graph/community_names_test.go
+++ b/internal/graph/community_names_test.go
@@ -1,0 +1,131 @@
+package graph
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func TestTokenize_CamelAndSnake(t *testing.T) {
+	cases := []struct {
+		in   string
+		want []string
+	}{
+		{"OrderViewSet", []string{"order", "view", "set"}},
+		{"order_view_set", []string{"order", "view", "set"}},
+		{"order-view-set", []string{"order", "view", "set"}},
+		{"HTTPServer", []string{"http", "server"}},
+		{"data_sync_task", []string{"data", "sync", "task"}},
+		{"app/orders/views.py", []string{"app", "orders", "views"}}, // py is a stopword
+		{"v2Migrate", []string{"migrate"}},                          // "v2" -> "v","2" both filtered (single-char + digit-only filtered? digits kept but len>1)
+	}
+	for _, c := range cases {
+		got := tokenize(c.in)
+		if !reflect.DeepEqual(got, c.want) {
+			t.Errorf("tokenize(%q) = %v; want %v", c.in, got, c.want)
+		}
+	}
+}
+
+func TestTokenize_StopwordsAndShort(t *testing.T) {
+	got := tokenize("a_test_of_the_init_main")
+	// every term is a stopword
+	if len(got) != 0 {
+		t.Errorf("tokenize stopword-only string: got %v want []", got)
+	}
+}
+
+// Two communities sharing a generic vocabulary ("service") but each having a
+// distinguishing term ("order" vs "compliance") should receive distinct
+// auto_names that surface the distinguishing term.
+func TestAssignCommunityNames_DistinguishesOverlappingVocab(t *testing.T) {
+	entities := []Entity{
+		{ID: "a1", Name: "OrderService", QualifiedName: "shop.order.OrderService", SourceFile: "shop/order/service.py"},
+		{ID: "a2", Name: "OrderRepository", QualifiedName: "shop.order.OrderRepository", SourceFile: "shop/order/repo.py"},
+		{ID: "a3", Name: "OrderViewSet", QualifiedName: "shop.order.OrderViewSet", SourceFile: "shop/order/views.py"},
+
+		{ID: "b1", Name: "ComplianceService", QualifiedName: "ops.compliance.ComplianceService", SourceFile: "ops/compliance/service.py"},
+		{ID: "b2", Name: "ComplianceTask", QualifiedName: "ops.compliance.ComplianceTask", SourceFile: "ops/compliance/tasks.py"},
+		{ID: "b3", Name: "ComplianceReport", QualifiedName: "ops.compliance.ComplianceReport", SourceFile: "ops/compliance/report.py"},
+	}
+	results := []CommunityResult{
+		{ID: 0, Size: 3},
+		{ID: 1, Size: 3},
+	}
+	commOf := map[string]int{
+		"a1": 0, "a2": 0, "a3": 0,
+		"b1": 1, "b2": 1, "b3": 1,
+	}
+
+	AssignCommunityNames(results, entities, commOf)
+
+	if results[0].AutoName == "" || results[1].AutoName == "" {
+		t.Fatalf("expected non-empty auto_names, got %+v", results)
+	}
+	if results[0].AutoName == results[1].AutoName {
+		t.Fatalf("expected distinct auto_names; both got %q", results[0].AutoName)
+	}
+	if !strings.Contains(results[0].AutoName, "order") {
+		t.Errorf("community 0 auto_name = %q; want it to contain 'order'", results[0].AutoName)
+	}
+	if !strings.Contains(results[1].AutoName, "compliance") {
+		t.Errorf("community 1 auto_name = %q; want it to contain 'compliance'", results[1].AutoName)
+	}
+	// The shared term "service" should not be the only term picked — TF-IDF
+	// must downweight terms appearing in every community.
+	if results[0].AutoName == "service" || results[1].AutoName == "service" {
+		t.Errorf("auto_name collapsed to shared stop-token 'service': %+v", results)
+	}
+}
+
+func TestAssignCommunityNames_FallbackOnEmptyTokens(t *testing.T) {
+	// Entity with only stopword/single-char tokens.
+	entities := []Entity{
+		{ID: "x1", Name: "a", SourceFile: ""},
+	}
+	results := []CommunityResult{{ID: 7, Size: 1}}
+	commOf := map[string]int{"x1": 7}
+	AssignCommunityNames(results, entities, commOf)
+	if results[0].AutoName != "community_7" {
+		t.Errorf("fallback: got %q want %q", results[0].AutoName, "community_7")
+	}
+}
+
+func TestAssignCommunityNames_Deterministic(t *testing.T) {
+	entities := []Entity{
+		{ID: "a1", Name: "PaymentGateway", QualifiedName: "billing.PaymentGateway", SourceFile: "billing/gateway.go"},
+		{ID: "a2", Name: "PaymentProcessor", QualifiedName: "billing.PaymentProcessor", SourceFile: "billing/processor.go"},
+		{ID: "b1", Name: "InventoryStore", QualifiedName: "warehouse.InventoryStore", SourceFile: "warehouse/store.go"},
+		{ID: "b2", Name: "InventoryAudit", QualifiedName: "warehouse.InventoryAudit", SourceFile: "warehouse/audit.go"},
+	}
+	commOf := map[string]int{"a1": 0, "a2": 0, "b1": 1, "b2": 1}
+
+	var prev []string
+	for i := 0; i < 5; i++ {
+		results := []CommunityResult{{ID: 0}, {ID: 1}}
+		AssignCommunityNames(results, entities, commOf)
+		got := []string{results[0].AutoName, results[1].AutoName}
+		if prev != nil && !reflect.DeepEqual(got, prev) {
+			t.Fatalf("non-deterministic: prev=%v got=%v", prev, got)
+		}
+		prev = got
+	}
+}
+
+func TestAssignCommunityNames_SkipsUnassignedNodes(t *testing.T) {
+	// commOf=-1 means the entity wasn't placed in any community; it must be
+	// excluded from the corpus so its tokens don't pollute IDF.
+	entities := []Entity{
+		{ID: "a1", Name: "OrderViewSet", SourceFile: "order.py"},
+		{ID: "ghost", Name: "DanglingNode", SourceFile: "dangling.py"},
+	}
+	results := []CommunityResult{{ID: 0, Size: 1}}
+	commOf := map[string]int{"a1": 0, "ghost": -1}
+	AssignCommunityNames(results, entities, commOf)
+	if !strings.Contains(results[0].AutoName, "order") {
+		t.Errorf("unassigned-node leakage: %q", results[0].AutoName)
+	}
+	if strings.Contains(results[0].AutoName, "dangling") {
+		t.Errorf("unassigned node 'ghost' polluted community: %q", results[0].AutoName)
+	}
+}


### PR DESCRIPTION
## Summary

- Each Louvain community now carries a deterministic `auto_name` derived from TF-IDF over member entity names, qualified names, and source-file basenames. Tokeniser handles camelCase, snake_case, kebab, and path splits with a stopword filter; stdlib-only.
- `CommunityResult.AutoName` is serialised as `communities[].auto_name` in graph.json. The dashboard already streams graph.json bytes through unchanged, so the SPA receives `auto_name` automatically.
- Layer 2 (agent-resolved richer names) is intentionally deferred per #28 and will ship with the agent enrichment workstream (#15).

## Sample auto_names (django-realworld corpus)

| size | auto_name | top_entities |
| --- | --- | --- |
| 27 | `view-api-views` | Response, NotFound, ArticleViewSet |
| 23 | `serializer-serializers-get` | serializers, ArticleSerializer, CommentSerializer |
| 13 | `profile-models-filter` | Profile, filter, CommentsListCreateAPIView.create |
| 11 | `authentication-jwt-decode` | JWTAuthentication.authenticate, decode |
| 9 | `field-related-relations` | TagRelatedField, ArticlesFeedAPIView.list |
| 8 | `migration-0001-initial` | migrations, Migration |
| 8 | `user-models-encode` | User, User._generate_jwt_token, User.token |

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] `gofmt -l internal/graph/` — clean
- [x] Indexed django-realworld; 409 communities all have non-empty `auto_name`
- [x] Unit tests cover tokenisation (camel/snake/kebab/HTTPServer/v2Migrate), stopword filtering, distinguishing communities with overlapping vocab, fallback when no tokens, deterministic output, and exclusion of unassigned (community_id=-1) nodes