### PR TITLE
fix(synth): Flask DSL methods classified as Dynamic on Python files (Closes #420)

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -252,6 +252,53 @@ var (
 		// dispatch via dict/list subscript: handlers[key](...), funcs["x"](...).
 		// Anchored "<ident>[...](...)" so we don't bite plain attribute access.
 		regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_.]*\[[^\]]+\]\(`),
+
+		// Flask app-factory + decorator DSL (issue #420). Flask exposes
+		// its routing / lifecycle / CLI surface as decorator and method
+		// calls on `app = Flask(__name__)`, blueprints (`bp = Blueprint(...)`),
+		// and `bp.cli` AppGroup instances. The Python extractor strips
+		// the receiver and the resolver sees only the bare leaf
+		// identifier (e.g. `@app.route("/")` → ToID="route"). Without a
+		// per-language anchor those land in bug-extractor and drove
+		// flask + flask-realworld bug-rate to 43.93% / 43.63%. The
+		// per-language gate (Python only) keeps these names from
+		// shadowing user methods in other ecosystems — `route`, `errorhandler`,
+		// `before_request` etc. would collide trivially in Go / JS / Ruby.
+		//
+		// Mirrors the Rails ActionController DSL approach from #107.
+		regexp.MustCompile(`^route$`),                    // @app.route(...) / @bp.route(...)
+		regexp.MustCompile(`^add_url_rule$`),             // app.add_url_rule(...)
+		regexp.MustCompile(`^register_blueprint$`),       // app.register_blueprint(bp)
+		regexp.MustCompile(`^before_request$`),           // @app.before_request
+		regexp.MustCompile(`^before_first_request$`),     // @app.before_first_request (legacy)
+		regexp.MustCompile(`^after_request$`),            // @app.after_request
+		regexp.MustCompile(`^teardown_request$`),         // @app.teardown_request
+		regexp.MustCompile(`^teardown_appcontext$`),      // @app.teardown_appcontext
+		regexp.MustCompile(`^errorhandler$`),             // @app.errorhandler(404)
+		regexp.MustCompile(`^register_error_handler$`),   // app.register_error_handler(...)
+		regexp.MustCompile(`^shell_context_processor$`),  // @app.shell_context_processor
+		regexp.MustCompile(`^context_processor$`),        // @app.context_processor
+		regexp.MustCompile(`^template_filter$`),          // @app.template_filter(...)
+		regexp.MustCompile(`^template_test$`),            // @app.template_test(...)
+		regexp.MustCompile(`^template_global$`),          // @app.template_global(...)
+		regexp.MustCompile(`^url_value_preprocessor$`),   // @app.url_value_preprocessor
+		regexp.MustCompile(`^url_defaults$`),             // @app.url_defaults
+		regexp.MustCompile(`^before_app_request$`),       // blueprint scoped variants
+		regexp.MustCompile(`^before_app_first_request$`),
+		regexp.MustCompile(`^after_app_request$`),
+		regexp.MustCompile(`^teardown_app_request$`),
+		regexp.MustCompile(`^app_errorhandler$`),
+		regexp.MustCompile(`^app_context_processor$`),
+		regexp.MustCompile(`^app_template_filter$`),
+		regexp.MustCompile(`^app_template_test$`),
+		regexp.MustCompile(`^app_template_global$`),
+		regexp.MustCompile(`^app_url_value_preprocessor$`),
+		regexp.MustCompile(`^app_url_defaults$`),
+		regexp.MustCompile(`^record$`),       // @bp.record (blueprint setup-state hook)
+		regexp.MustCompile(`^record_once$`),  // @bp.record_once
+		// Flask CLI / click AppGroup decorator: `@bp.cli.command(...)` and
+		// `@app.cli.command(...)`. Extractor leaf is "command".
+		regexp.MustCompile(`^command$`),
 	}
 
 	goDynamicPatterns = []*regexp.Regexp{

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -885,6 +885,75 @@ func TestRubyRailsDSL_RejectedGenericCollectionOps(t *testing.T) {
 	}
 }
 
+// TestPythonFlaskDSL_RecognisedAsDynamic locks in issue #420: Flask
+// app-factory + decorator DSL bindings (`@app.route(...)`,
+// `@bp.route(...)`, `@bp.cli.command(...)`, lifecycle hooks, error
+// handlers, template filters, URL preprocessors). Pre-fix these
+// landed in bug-extractor and drove flask + flask-realworld bug-rate
+// to 43.93% / 43.63%. The Python extractor strips the receiver and
+// emits only the leaf callee identifier, so the resolver needs a
+// per-language bare-name anchor to classify them as Dynamic.
+func TestPythonFlaskDSL_RecognisedAsDynamic(t *testing.T) {
+	t.Parallel()
+	dynamic := []string{
+		// Routing
+		"route", "add_url_rule", "register_blueprint",
+		// Lifecycle
+		"before_request", "before_first_request", "after_request",
+		"teardown_request", "teardown_appcontext",
+		// Error handling
+		"errorhandler", "register_error_handler",
+		// Context / templates
+		"shell_context_processor", "context_processor",
+		"template_filter", "template_test", "template_global",
+		"url_value_preprocessor", "url_defaults",
+		// Blueprint app-scoped variants
+		"before_app_request", "before_app_first_request",
+		"after_app_request", "teardown_app_request",
+		"app_errorhandler", "app_context_processor",
+		"app_template_filter", "app_template_test", "app_template_global",
+		"app_url_value_preprocessor", "app_url_defaults",
+		"record", "record_once",
+		// Flask CLI / click AppGroup decorator
+		"command",
+	}
+	for _, stub := range dynamic {
+		stub := stub
+		t.Run("python/"+stub, func(t *testing.T) {
+			t.Parallel()
+			if !isDynamicPatternLang(stub, "python") {
+				t.Fatalf("Flask DSL stub %q not recognised as Dynamic for lang=python", stub)
+			}
+		})
+	}
+}
+
+// TestPythonFlaskDSL_GatedToPython confirms the Flask DSL bare-name
+// patterns only match when lang="python" — otherwise generic names
+// like `route`, `command`, `record`, `before_request` would shadow
+// user methods in other ecosystems.
+func TestPythonFlaskDSL_GatedToPython(t *testing.T) {
+	t.Parallel()
+	stubs := []string{
+		"route", "command", "record", "errorhandler",
+		"before_request", "after_request", "register_blueprint",
+		"template_filter", "url_defaults",
+	}
+	otherLangs := []string{"go", "ruby", "javascript", "typescript", "java", "kotlin"}
+	for _, stub := range stubs {
+		for _, lang := range otherLangs {
+			stub, lang := stub, lang
+			t.Run(stub+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if isDynamicPatternLang(stub, lang) {
+					t.Fatalf("stub %q matched dynamic for lang=%q; "+
+						"must be gated to python only (issue #420)", stub, lang)
+				}
+			})
+		}
+	}
+}
+
 // TestDiagnoseBugResolver — issue #92 diagnostic helper. Each subtest
 // constructs a graph that traps a bug-resolver stub at one well-defined
 // shape and asserts the category the diagnoser returns.


### PR DESCRIPTION
## Summary
- Adds Python-gated bare-name patterns for Flask app-factory + decorator DSL bindings to `pythonDynamicPatterns` in `internal/resolve/refs.go` (`@app.route`, `@bp.route`, `@bp.cli.command`, lifecycle hooks, error handlers, template filters, URL preprocessors, blueprint app-scoped variants).
- The Python extractor strips the receiver from `@app.route("/")` and emits only the leaf callee identifier (`route`); without a per-language anchor those landed in bug-extractor pre-fix and drove flask + flask-realworld bug-rate to 43.93% / 43.63%.
- Mirrors the Rails ActionController DSL approach from #107. Per-language gate (Python only) keeps generic names (`route`, `command`, `record`) from shadowing user methods in other ecosystems.

## VERIFY-2 single-repo deltas
| repo | before | after | delta |
| --- | ---: | ---: | ---: |
| flask           | 43.93% | 41.32% | -2.61pp |
| flask-realworld | 43.63% | 43.47% | -0.16pp |

flask-realworld residual is dominated by SQLAlchemy / Marshmallow ORM bare names (`Column`, `ForeignKey`, `init_app`, `from_object`, `to_json`, `save`) — out of Flask DSL scope; sibling tickets cover ORM DSL.

Confirmed `register_blueprint`, `errorhandler`, `shell_context_processor`, `route` now appear in the `dynamic` disposition_samples for both repos.

## Test plan
- [x] `go test ./internal/resolve/...` — new `TestPythonFlaskDSL_RecognisedAsDynamic` (32 cases) and `TestPythonFlaskDSL_GatedToPython` (54 cases) pass
- [x] `go test ./...` — full suite green
- [x] VERIFY-2 single-repo on python/flask
- [x] VERIFY-2 single-repo on python/flask-realworld

Closes #420

🤖 Generated with [Claude Code](https://claude.com/claude-code)