### PR TITLE
fix(synth): click decorator DSL classified on Python files (Closes #423)

### DIFF
--- a/internal/resolve/dynamic_patterns_test.go
+++ b/internal/resolve/dynamic_patterns_test.go
@@ -133,6 +133,41 @@ func TestDynamicPatterns_Catalog(t *testing.T) {
 		{"jvm_bare_getDeclaredConstructors", "java", `getDeclaredConstructors`, true},
 		// Per-language gate: bare `invoke` from a JS file MUST NOT
 		// classify as JVM dynamic — those names are JVM-only.
+		// ---- click decorator + helper DSL (issue #423) -------------
+		// Python click extractor strips the `click.` receiver so the
+		// resolver sees bare leaf identifiers. Per-language gate keeps
+		// these names from polluting other ecosystems.
+		{"py_click_command", "python", `command`, true},
+		{"py_click_group", "python", `group`, true},
+		{"py_click_option", "python", `option`, true},
+		{"py_click_argument", "python", `argument`, true},
+		{"py_click_pass_context", "python", `pass_context`, true},
+		{"py_click_pass_obj", "python", `pass_obj`, true},
+		{"py_click_pass_meta_key", "python", `pass_meta_key`, true},
+		{"py_click_echo", "python", `echo`, true},
+		{"py_click_secho", "python", `secho`, true},
+		{"py_click_prompt", "python", `prompt`, true},
+		{"py_click_confirm", "python", `confirm`, true},
+		{"py_click_progressbar", "python", `progressbar`, true},
+		{"py_click_getchar", "python", `getchar`, true},
+		{"py_click_pause", "python", `pause`, true},
+		{"py_click_clear", "python", `clear`, true},
+		{"py_click_style", "python", `style`, true},
+		{"py_click_unstyle", "python", `unstyle`, true},
+		{"py_click_format_filename", "python", `format_filename`, true},
+		{"py_click_get_terminal_size", "python", `get_terminal_size`, true},
+		{"py_click_launch", "python", `launch`, true},
+		{"py_click_edit", "python", `edit`, true},
+		{"py_click_get_app_dir", "python", `get_app_dir`, true},
+		// Per-language gate: click DSL names from non-Python files MUST
+		// NOT classify as Python dynamic — these names are Python/click
+		// scoped here and would collide trivially with user methods in
+		// other ecosystems (`group`, `option`, `echo`, `command`).
+		{"click_command_js_negative", "javascript", `command`, false},
+		{"click_option_ruby_negative", "ruby", `option`, false},
+		{"click_echo_go_negative", "go", `echo`, false},
+		{"click_group_java_negative", "java", `group`, false},
+
 		{"jvm_bare_invoke_js_negative", "javascript", `invoke`, false},
 		{"jvm_bare_getMethod_python_negative", "python", `getMethod`, false},
 		{"jvm_bare_newInstance_go_negative", "go", `newInstance`, false},

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -299,6 +299,48 @@ var (
 		// Flask CLI / click AppGroup decorator: `@bp.cli.command(...)` and
 		// `@app.cli.command(...)`. Extractor leaf is "command".
 		regexp.MustCompile(`^command$`),
+
+		// click decorator + helper DSL (issue #423). click is the
+		// dominant Python CLI framework and its decorators (`@click.command()`,
+		// `@click.group()`, `@click.option('--foo')`, `@click.argument('name')`,
+		// `@click.pass_context`) plus helper functions (`click.echo`,
+		// `click.prompt`, `click.confirm`, `click.style`, ...) arrive at
+		// the resolver as bare leaf identifiers after the Python extractor
+		// strips the `click.` receiver. Without anchors here every
+		// decorator/helper call site inflates bug-extractor (python/click
+		// 32.60% pre-fix). Names follow the Rails (#107) and Flask (#420)
+		// precedent: collision with user methods is accepted because the
+		// per-language gate (Python only) keeps them safely scoped, and
+		// Dynamic is the appropriate "we know it's framework dispatch we
+		// can't statically resolve" bucket. click constants (`STRING`,
+		// `INT`, `FLOAT`, `BOOL`, `UUID`) and class types (`Path`,
+		// `Choice`, `IntRange`, `FloatRange`, `Tuple`, `File`,
+		// `make_pass_decorator`) are deliberately EXCLUDED here — they
+		// arrive as `ext:click.<name>` stubs and the external allowlist
+		// (click is allowlisted) classifies them ExternalKnown without
+		// help from the dynamic catalog.
+		// NOTE: ^command$ already declared above by the Flask block (#420).
+		regexp.MustCompile(`^group$`),
+		regexp.MustCompile(`^option$`),
+		regexp.MustCompile(`^argument$`),
+		regexp.MustCompile(`^pass_context$`),
+		regexp.MustCompile(`^pass_obj$`),
+		regexp.MustCompile(`^pass_meta_key$`),
+		regexp.MustCompile(`^echo$`),
+		regexp.MustCompile(`^secho$`),
+		regexp.MustCompile(`^prompt$`),
+		regexp.MustCompile(`^confirm$`),
+		regexp.MustCompile(`^progressbar$`),
+		regexp.MustCompile(`^getchar$`),
+		regexp.MustCompile(`^pause$`),
+		regexp.MustCompile(`^clear$`),
+		regexp.MustCompile(`^style$`),
+		regexp.MustCompile(`^unstyle$`),
+		regexp.MustCompile(`^format_filename$`),
+		regexp.MustCompile(`^get_terminal_size$`),
+		regexp.MustCompile(`^launch$`),
+		regexp.MustCompile(`^edit$`),
+		regexp.MustCompile(`^get_app_dir$`),
 	}
 
 	goDynamicPatterns = []*regexp.Regexp{

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -843,7 +843,12 @@ func TestRubyRailsDSL_GatedToRuby(t *testing.T) {
 	t.Parallel()
 	stubs := []string{
 		"where", "order", "params", "request", "response", "limit",
-		"group", "render", "validates",
+		"render", "validates",
+		// NOTE: `group` was removed from this gate list (issue #423) —
+		// click's `@click.group()` decorator legitimately makes `group`
+		// a Python DSL bare-name too, so it is intentionally NOT
+		// ruby-only any more. Per-language scoping still holds for the
+		// remaining names.
 		// Migration DSL gating (issue #124) — collision-prone for
 		// other languages (`string`, `integer`, `boolean`, `text`,
 		// `references`, `execute`, `add_column`...).


### PR DESCRIPTION
## Summary

- Add click decorator + helper DSL bare-name patterns to `pythonDynamicPatterns` in `internal/resolve/refs.go` so leaf-stripped click identifiers (`command`, `group`, `option`, `argument`, `pass_context`, `echo`, `secho`, `prompt`, `confirm`, `style`, `launch`, `edit`, ...) classify as Dynamic instead of bug-extractor/bug-resolver.
- Mirrors the Rails (#107) and Flask (#420) precedent: Python-gated bare-name allowlist for `method_missing`-style framework DSL. click constants/types (`STRING`, `INT`, `Path`, `Choice`, ...) are deliberately excluded — they arrive as `ext:click.<name>` and the existing `click` allowlist entry already classifies them ExternalKnown.
- Drops `group` from the Ruby-only gate test in `refs_test.go` since `@click.group()` legitimately makes `group` a Python DSL bare-name too. Per-language scoping holds for the rest.

## VERIFY-2 single-repo (python/click)

| metric          | baseline | fixed   | delta    |
| --------------- | -------- | ------- | -------- |
| bug-extractor   | 4624     | 4622    | -2       |
| bug-resolver    | 249      | 197     | -52      |
| dynamic         | 973      | 1027    | +54      |
| bug_rate        | 32.60%   | 32.24%  | -0.36 pp |
| resolution_rate | 52.35%   | 52.35%  | -        |

Remaining residue is click-internal parameter/attribute names (`paramtype`, `ctx`, `flag_value`, `is_flag_true`) and leading-dot relative imports (`.utils.echo`, `.types.ParamType`) — distinct extractor/resolver issues outside the scope of this DSL gating.

## Test plan

- [x] `go test ./...` clean (resolve, all extractors, verify, etc.).
- [x] `TestDynamicPatterns_Catalog` extended with 22 positive click rows + 4 cross-language negative rows (`command` in JS / `option` in Ruby / `echo` in Go / `group` in Java).
- [x] `TestRubyRailsDSL_GatedToRuby` updated for the `group` overlap; remaining names still gated to Ruby.
- [x] VERIFY-2 indexer run on `pallets/click` — bug-rate drops, no regression in resolution-rate.

Closes #423

🤖 Generated with [Claude Code](https://claude.com/claude-code)