### PR TITLE
fix(synth): manifest image refs and file mounts route to ExternalKnown/Unknown (Closes #424)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -280,6 +280,34 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		return "external_api", "external_api", true
 	}
 
+	// Issue #424 — YAML extractor (Docker Compose, Kubernetes) emits image
+	// refs as "docker_image:<image-ref>". The image lives in a container
+	// registry, not the indexed corpus, so it is external by definition.
+	// Canonicalise to "docker:<repo>" (drop the tag/digest) and route the
+	// edge to a single placeholder per repository — matches the package-
+	// per-import collapse used elsewhere. The "docker:" prefix is on the
+	// allowlist so all real image refs land in ExternalKnown.
+	if strings.HasPrefix(stub, "docker_image:") {
+		ref := strings.TrimSpace(stub[len("docker_image:"):])
+		if repo := dockerImageRepo(ref); repo != "" {
+			return "docker:" + repo, "docker_image", true
+		}
+	}
+
+	// Issue #424 — YAML extractor emits Compose host-filesystem mounts as
+	// "host_path:<path>". By definition these reference files outside the
+	// indexed corpus (relative `./src`, absolute `/etc/foo`, env-driven
+	// `${PWD}/data`). Bucket every distinct source path under a single
+	// "external_filesystem" placeholder — the path itself is rarely useful
+	// for graph navigation, and one placeholder keeps the entity count
+	// flat across large compose stacks. Lands in ExternalUnknown.
+	if strings.HasPrefix(stub, "host_path:") {
+		path := strings.TrimSpace(stub[len("host_path:"):])
+		if path != "" {
+			return "external_filesystem", "file_mount", true
+		}
+	}
+
 	// Pass 3 cross-language extractors emit external imports as
 	// "scope:<kind>:import:external:<name>" — short structural-ref
 	// form that the resolver leaves untouched (it expects 6 segments).
@@ -2292,6 +2320,13 @@ var jsBareNames = map[string]struct{}{
 // local name into a placeholder, which is worse than missing one.
 func isKnownExternalPackage(s string) bool {
 	lower := strings.ToLower(s)
+	// Issue #424 — every "docker:<repo>" placeholder corresponds to a real
+	// image in a container registry. Treat the entire docker namespace as
+	// allowlisted; ExternalKnown is the right disposition for image refs
+	// regardless of whether the repo is on the static package allowlist.
+	if strings.HasPrefix(lower, "docker:") {
+		return true
+	}
 	if _, ok := knownExternalPackages[lower]; ok {
 		return true
 	}
@@ -2929,6 +2964,49 @@ func goHostCanonical(segs []string) string {
 		return host + "/" + segs[1] + "/" + segs[2]
 	}
 	return ""
+}
+
+// dockerImageRepo extracts the canonical repository segment from a Docker
+// image reference, dropping the tag (`:<tag>`) or digest (`@sha256:...`).
+// Returns "" for malformed inputs.
+//
+// Examples (Issue #424):
+//
+//	"nginx:1.21"                      → "nginx"
+//	"redis:alpine"                    → "redis"
+//	"library/postgres:14"             → "library/postgres"
+//	"ghcr.io/owner/svc:v1.2.3"        → "ghcr.io/owner/svc"
+//	"myregistry.io:5000/team/api:dev" → "myregistry.io:5000/team/api"
+//	"alpine@sha256:abc..."            → "alpine"
+//	""                                → ""
+func dockerImageRepo(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	// Strip the digest first — it always uses `@` and never contains `:`
+	// inside the digest body for our purposes (the algorithm prefix uses `:`
+	// but lives strictly to the right of the `@`).
+	if at := strings.IndexByte(ref, '@'); at >= 0 {
+		ref = ref[:at]
+	}
+	// Find the last `:` and decide whether it's a tag separator or part of a
+	// registry-port specifier. A tag separator never appears after a `/` of
+	// a path; a registry port is always followed by `/`.
+	lastColon := strings.LastIndexByte(ref, ':')
+	if lastColon < 0 {
+		return ref
+	}
+	// If there's a `/` to the right of the colon, the colon belongs to a
+	// registry-port (e.g. "myregistry.io:5000/team/api") — keep it.
+	if strings.IndexByte(ref[lastColon:], '/') >= 0 {
+		return ref
+	}
+	repo := ref[:lastColon]
+	if repo == "" {
+		return ""
+	}
+	return repo
 }
 
 // isHexID mirrors resolve.isHexID — a 16-char lower-hex string is

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -2389,3 +2389,109 @@ func itoa(i int) string {
 	}
 	return string(buf[pos:])
 }
+
+// ---------------------------------------------------------------------------
+// Issue #424 — Docker image refs and host-path mounts route through synth.
+// ---------------------------------------------------------------------------
+
+// TestSynthesize_DockerImage_Compose covers a Compose-style image stub
+// "docker_image:nginx:1.21". Synth must rewrite the edge to ext:docker:nginx
+// (tag dropped, single placeholder per repository) and place the image on
+// the allowlist so the resolver classifies it as ExternalKnown.
+func TestSynthesize_DockerImage_Compose(t *testing.T) {
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "docker_compose/service/api", ToID: "docker_image:nginx:1.21", Kind: "IMPORTS"},
+			{ID: "r2", FromID: "docker_compose/service/db", ToID: "docker_image:postgres:14", Kind: "IMPORTS"},
+			{ID: "r3", FromID: "docker_compose/service/cache", ToID: "docker_image:redis:alpine", Kind: "IMPORTS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.RelationshipsResolved != 3 {
+		t.Fatalf("resolved=%d, want 3", stats.RelationshipsResolved)
+	}
+	want := map[int]string{
+		0: "ext:docker:nginx",
+		1: "ext:docker:postgres",
+		2: "ext:docker:redis",
+	}
+	for i, w := range want {
+		if got := doc.Relationships[i].ToID; got != w {
+			t.Errorf("rel[%d].ToID=%q, want %q", i, got, w)
+		}
+	}
+	for _, w := range want {
+		if !IsKnownExternalPackage(w[len("ext:"):]) {
+			t.Errorf("IsKnownExternalPackage(%q)=false, want true (ExternalKnown gate)", w)
+		}
+	}
+}
+
+// TestSynthesize_DockerImage_Registry covers a registry-prefixed image with
+// a port (`myregistry.io:5000/team/api:dev`). The leading colon belongs to
+// the port and must NOT be treated as a tag separator.
+func TestSynthesize_DockerImage_Registry(t *testing.T) {
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "k8s/container/app", ToID: "docker_image:ghcr.io/owner/svc:v1.2.3", Kind: "IMPORTS"},
+			{ID: "r2", FromID: "k8s/container/api", ToID: "docker_image:myregistry.io:5000/team/api:dev", Kind: "IMPORTS"},
+			{ID: "r3", FromID: "k8s/container/raw", ToID: "docker_image:alpine@sha256:abc", Kind: "IMPORTS"},
+		},
+	}
+	Synthesize(doc)
+	want := []string{
+		"ext:docker:ghcr.io/owner/svc",
+		"ext:docker:myregistry.io:5000/team/api",
+		"ext:docker:alpine",
+	}
+	for i, w := range want {
+		if got := doc.Relationships[i].ToID; got != w {
+			t.Errorf("rel[%d].ToID=%q, want %q", i, got, w)
+		}
+	}
+}
+
+// TestSynthesize_HostPathMount covers Compose host-filesystem volume mounts.
+// Every distinct path collapses to a single ext:external_filesystem
+// placeholder; the package is NOT on the allowlist, so the resolver lands
+// these in ExternalUnknown.
+func TestSynthesize_HostPathMount(t *testing.T) {
+	doc := &graph.Document{
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "docker_compose/service/api", ToID: "host_path:./src", Kind: "IMPORTS"},
+			{ID: "r2", FromID: "docker_compose/service/api", ToID: "host_path:/etc/myapp", Kind: "IMPORTS"},
+			{ID: "r3", FromID: "docker_compose/service/api", ToID: "host_path:${PWD}/data", Kind: "IMPORTS"},
+		},
+	}
+	Synthesize(doc)
+	for i, r := range doc.Relationships {
+		if r.ToID != "ext:external_filesystem" {
+			t.Errorf("rel[%d].ToID=%q, want ext:external_filesystem", i, r.ToID)
+		}
+	}
+	if IsKnownExternalPackage("external_filesystem") {
+		t.Error("external_filesystem unexpectedly on allowlist; want ExternalUnknown disposition")
+	}
+}
+
+// TestDockerImageRepo unit-tests the repo-extraction helper for canonical
+// docker image references.
+func TestDockerImageRepo(t *testing.T) {
+	cases := map[string]string{
+		"":                                 "",
+		"nginx":                            "nginx",
+		"nginx:1.21":                       "nginx",
+		"redis:alpine":                     "redis",
+		"library/postgres:14":              "library/postgres",
+		"ghcr.io/owner/svc:v1.2.3":         "ghcr.io/owner/svc",
+		"myregistry.io:5000/team/api:dev":  "myregistry.io:5000/team/api",
+		"myregistry.io:5000/team/api":      "myregistry.io:5000/team/api",
+		"alpine@sha256:abcdef":             "alpine",
+		"ubuntu:22.04@sha256:abcdef":       "ubuntu",
+	}
+	for in, want := range cases {
+		if got := dockerImageRepo(in); got != want {
+			t.Errorf("dockerImageRepo(%q)=%q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -827,6 +827,38 @@ func extractDockerCompose(root *sitter.Node, file extractor.FileInput) []types.E
 					svcEnt.Relationships = append(svcEnt.Relationships,
 						importsRel(svcRef, targetRef, "compose_depends_on"))
 				}
+
+				// IMPORTS: service → docker image (issue #424). The image ref is
+				// an external dependency by definition — its source lives in a
+				// container registry, not the indexed corpus. Emit a stub the
+				// external-synth pass can route to ext:docker:<image> (lands in
+				// ExternalKnown via the docker: allowlist branch).
+				if imgVal := findPairValueText(svcPairs, "image", src); imgVal != "" {
+					stub := "docker_image:" + imgVal
+					svcEnt.Relationships = append(svcEnt.Relationships,
+						importsRel(svcRef, stub, "compose_image"))
+				}
+
+				// IMPORTS: service → host filesystem mount (issue #424). Compose
+				// volume entries can take three shapes:
+				//   - "<src>:<dst>[:<mode>]"      (string short syntax)
+				//   - "<named-volume>:<dst>"      (string short syntax, src is a key)
+				//   - { source: ..., target: ... } (long syntax)
+				// We only route source paths that look like a host filesystem
+				// reference (./..., ../..., /abs, ~, ${VAR}, $VAR). Named-volume
+				// sources and target-only entries already resolve via the
+				// top-level volumes block — skip them.
+				volNode := findValueNodeForKey(svcPairs, "volumes", src)
+				for _, vol := range getSequenceItems(volNode, src) {
+					srcPath := composeVolumeSource(vol)
+					if !looksLikeHostPath(srcPath) {
+						continue
+					}
+					stub := "host_path:" + srcPath
+					svcEnt.Relationships = append(svcEnt.Relationships,
+						importsRel(svcRef, stub, "compose_volume_mount"))
+				}
+
 				entities = append(entities, svcEnt)
 
 				portsNode := findValueNodeForKey(svcPairs, "ports", src)
@@ -1020,6 +1052,11 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				icEnt.Relationships = append(icEnt.Relationships,
 					containsRel(resourceRef, icRef))
 			}
+			// IMPORTS: init_container → docker image (issue #424).
+			if imgVal := findPairValueText(icPairs, "image", src); imgVal != "" {
+				icEnt.Relationships = append(icEnt.Relationships,
+					importsRel(icRef, "docker_image:"+imgVal, "k8s_image"))
+			}
 			entities = append(entities, icEnt)
 		}
 
@@ -1041,6 +1078,15 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				cEnt.Relationships = append(cEnt.Relationships,
 					containsRel(resourceRef, cRef))
 			}
+
+			// IMPORTS: container → docker image (issue #424). Same routing as
+			// compose `image:` — the registry is outside the indexed corpus,
+			// so external-synth lifts it to ext:docker:<image>.
+			if imgVal := findPairValueText(cPairs, "image", src); imgVal != "" {
+				cEnt.Relationships = append(cEnt.Relationships,
+					importsRel(cRef, "docker_image:"+imgVal, "k8s_image"))
+			}
+
 			entities = append(entities, cEnt)
 
 			// containerPort values

--- a/internal/extractors/yaml/relationships.go
+++ b/internal/extractors/yaml/relationships.go
@@ -24,8 +24,101 @@ package yaml
 // extractor.TagRelationshipsLanguage in extractByFlavor.
 
 import (
+	"strings"
+
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// composeVolumeSource extracts the source segment from a compose volume
+// short-syntax entry. Compose volumes accept:
+//
+//	"<src>:<dst>"            → returns "<src>"
+//	"<src>:<dst>:<mode>"     → returns "<src>"
+//	"<dst>"                  → returns "" (no source — volume targets only)
+//
+// Long-syntax map entries (`{ source: ..., target: ... }`) come through
+// getSequenceItems as the empty string today (we don't unpack inline maps in
+// short-syntax helpers); this helper returns "" for those — caller skips.
+//
+// Issue #424.
+func composeVolumeSource(entry string) string {
+	entry = strings.TrimSpace(entry)
+	if entry == "" {
+		return ""
+	}
+	// Strip surrounding quotes if the YAML scalar was quoted (the parser
+	// returns the raw text including the quote characters). Single and
+	// double quotes are both valid YAML; no escape unwrapping is needed
+	// because the path content is round-tripped verbatim.
+	if len(entry) >= 2 {
+		first, last := entry[0], entry[len(entry)-1]
+		if (first == '"' && last == '"') || (first == '\'' && last == '\'') {
+			entry = entry[1 : len(entry)-1]
+		}
+	}
+	// Long-syntax inline maps (`{ source: ..., target: ... }`) start with
+	// `{` and never look like a host path source. Reject only the inline-
+	// map shape; bare `${VAR}` env-substitutions inside a scalar are valid
+	// host-path sources.
+	if strings.HasPrefix(entry, "{") {
+		return ""
+	}
+	idx := strings.IndexByte(entry, ':')
+	if idx < 0 {
+		// Single-element entry — by spec this is a target (anonymous volume),
+		// no source to route.
+		return ""
+	}
+	// Windows-style absolute paths ("C:\\..." or "C:/...") share the colon
+	// with compose's separator. Detect: a single drive letter followed by `:`
+	// followed by a path separator means the colon is part of the source.
+	if idx == 1 {
+		c := entry[0]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			if len(entry) > 2 && (entry[2] == '/' || entry[2] == '\\') {
+				// Find the next colon (separator before the destination).
+				if next := strings.IndexByte(entry[2:], ':'); next >= 0 {
+					return entry[:2+next]
+				}
+				return entry
+			}
+		}
+	}
+	return entry[:idx]
+}
+
+// looksLikeHostPath returns true when src is a compose-style host filesystem
+// reference: relative path (`./...`, `../...`), absolute Unix path (`/...`),
+// home-anchored path (`~`, `~/...`), Windows drive path (`C:\` / `C:/`), or
+// an env-substitution form (`${VAR}`, `$VAR`). Bare-word sources (e.g.
+// `postgres_data`) are NOT host paths — they reference a top-level named
+// volume key and are already routed by the existing CONTAINS edge.
+//
+// Issue #424.
+func looksLikeHostPath(src string) bool {
+	if src == "" {
+		return false
+	}
+	switch {
+	case strings.HasPrefix(src, "./"), strings.HasPrefix(src, "../"):
+		return true
+	case strings.HasPrefix(src, "/"):
+		return true
+	case src == "~" || strings.HasPrefix(src, "~/"):
+		return true
+	case strings.HasPrefix(src, "${"), strings.HasPrefix(src, "$"):
+		// `$VAR` — must look like a shell var reference, not a literal `$tag`.
+		return true
+	}
+	// Windows drive letter: `C:\` or `C:/`.
+	if len(src) >= 3 && src[1] == ':' && (src[2] == '/' || src[2] == '\\') {
+		c := src[0]
+		if (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') {
+			return true
+		}
+	}
+	return false
+}
 
 // containsRel builds a CONTAINS RelationshipRecord (Properties left nil; the
 // resolver-tag pass fills language).

--- a/internal/extractors/yaml/relationships_test.go
+++ b/internal/extractors/yaml/relationships_test.go
@@ -283,3 +283,109 @@ func TestYAML_Ansible_Contains(t *testing.T) {
 		t.Errorf("missing CONTAINS play→task(start nginx); got %+v", contains)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #424 — manifest IMPORTS for image refs and host-path volume mounts.
+// ---------------------------------------------------------------------------
+
+func TestYAML_Compose_ImageImports(t *testing.T) {
+	src := []byte(`version: "3.9"
+services:
+  api:
+    image: myapp:latest
+  db:
+    image: postgres:15
+  cache:
+    image: redis:alpine
+`)
+	entities, err := extractYAML(src, "docker-compose.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imports := findRels(entities, "IMPORTS")
+
+	cases := map[string]string{
+		"api":   "docker_image:myapp:latest",
+		"db":    "docker_image:postgres:15",
+		"cache": "docker_image:redis:alpine",
+	}
+	for svc, want := range cases {
+		from := "docker_compose/service/" + svc
+		if !relExists(imports, from, want) {
+			t.Errorf("missing IMPORTS %s→%s; got %+v", from, want, imports)
+		}
+	}
+}
+
+func TestYAML_Compose_HostPathMountImports(t *testing.T) {
+	src := []byte(`version: "3.9"
+services:
+  api:
+    image: myapp:latest
+    volumes:
+      - ./src:/app/src
+      - ../shared:/app/shared
+      - /etc/myapp:/etc/myapp:ro
+      - ${PWD}/data:/data
+      - data_volume:/var/lib/data
+volumes:
+  data_volume:
+`)
+	entities, err := extractYAML(src, "docker-compose.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imports := findRels(entities, "IMPORTS")
+	from := "docker_compose/service/api"
+	for _, want := range []string{
+		"host_path:./src",
+		"host_path:../shared",
+		"host_path:/etc/myapp",
+		"host_path:${PWD}/data",
+	} {
+		if !relExists(imports, from, want) {
+			t.Errorf("missing IMPORTS %s→%s; got %+v", from, want, imports)
+		}
+	}
+	// Named-volume sources MUST NOT be classified as host paths.
+	for _, r := range imports {
+		if r.FromID == from && r.ToID == "host_path:data_volume" {
+			t.Errorf("named-volume source emitted as host_path: %+v", r)
+		}
+	}
+}
+
+func TestYAML_K8s_ContainerImageImports(t *testing.T) {
+	src := []byte(`apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: web
+spec:
+  template:
+    spec:
+      initContainers:
+        - name: migrate
+          image: migrate:latest
+      containers:
+        - name: app
+          image: nginx:1.21
+        - name: sidecar
+          image: envoy:v1.29.0
+`)
+	entities, err := extractYAML(src, "deploy.yml")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	imports := findRels(entities, "IMPORTS")
+
+	cases := map[string]string{
+		"k8s/container/app":          "docker_image:nginx:1.21",
+		"k8s/container/sidecar":      "docker_image:envoy:v1.29.0",
+		"k8s/init-container/migrate": "docker_image:migrate:latest",
+	}
+	for from, want := range cases {
+		if !relExists(imports, from, want) {
+			t.Errorf("missing IMPORTS %s→%s; got %+v", from, want, imports)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #424. Across docker-compose, K8s, and Helm, image refs (`nginx:1.21`, `redis:alpine`, `postgres:14`) and host-path volume mounts (`./src`, `${PWD}/data`) currently land in bug-extractor.

## Changes

- **YAML extractor (compose)**: service → `docker_image:<ref>` IMPORTS for `image:`; service → `host_path:<path>` IMPORTS for volume short-syntax entries whose source looks like a host filesystem reference (`./`, `../`, absolute path, `~`, `${VAR}`, `$VAR`, Windows drive letter). Bare-word sources (named volumes) are intentionally skipped — already routed by the top-level volumes block.
- **YAML extractor (K8s)**: container and init_container → `docker_image:<ref>` IMPORTS for every `image:` field.
- **external/synth**:
  - `docker_image:<ref>` → canonicalised to `docker:<repo>` (tag/digest dropped, registry-port preserved). One placeholder per repository.
  - `host_path:<path>` → collapsed into a single `ext:external_filesystem` placeholder.
  - `isKnownExternalPackage` allowlists the `docker:` prefix so docker images land as ExternalKnown; `external_filesystem` stays off the allowlist → ExternalUnknown for mounts.

## Verification

VERIFY-2 deltas (issue424 vs main):

| Repo                   | Δ rels | Δ ext-known | Δ ext-unk | Δ bug-x | bug-rate |
|------------------------|-------:|------------:|----------:|--------:|---------:|
| argocd-example-apps    |   +22  |        +22  |        +0 |     +6  | 0.54 → 0.47 |
| awesome-compose        |   +58  |        +32  |       +22 |    +29  | 0.244 → 0.244 |

The +6 / +29 in bug-extractor is on the FromID side of the new edges — `k8s/container/<name>` ids that share names with their parent resource and trip an existing resolver disambiguation issue (out of scope here). The intended IMPORTS-target routing (image refs → ExternalKnown, host-paths → ExternalUnknown) is working in both corpora.

## Test plan

- [x] `go test ./...` (full suite green)
- [x] New unit tests:
  - `internal/extractors/yaml/relationships_test.go`: image and host-path IMPORTS for compose + K8s
  - `internal/external/synth_test.go`: docker image canonicalisation, host-path bucketing, registry-port handling, sha digest stripping
- [x] VERIFY-2 on argocd-example-apps + awesome-compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)