### PR TITLE
feat(resolve): PHP FQN Class::method binding (Closes #422)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1164,6 +1164,14 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d dotted IMPORTS targets\n",
 			importStats.ImportsRewritten, importStats.ImportsConsidered)
 	}
+	// Issue #422 — PHP FQN-method CALLS targets
+	// (`App\Controller\BlogController::list`) emitted by the Symfony
+	// YAML cross-extractor. Surfaced separately so the verify2 harness
+	// can attribute the bug-resolver delta on php-symfony-* corpora.
+	if importStats.PHPFQNMethodConsidered > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d PHP FQN-method CALLS targets\n",
+			importStats.PHPFQNMethodRewritten, importStats.PHPFQNMethodConsidered)
+	}
 
 	idx := resolve.BuildIndex(merged)
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -107,6 +107,14 @@ type ImportTable struct {
 	// entity. Ambiguous tuples are tracked in ambigModuleName.
 	entitiesByModuleName map[string]map[string]string
 	ambigModuleName      map[string]map[string]bool
+	// methodsByFileName[source_file][method_name] = entity_id, populated
+	// only for PHP method entities and only when the (file, name) tuple
+	// resolves to exactly one entity. Ambiguous tuples are tracked in
+	// ambigMethodFileName. Used by ResolvePHPFQNMethodTarget (issue #422)
+	// to bind an FQN-method like `App\Controller\BlogController::list` to
+	// the method declared in the class's source file.
+	methodsByFileName   map[string]map[string]string
+	ambigMethodFileName map[string]map[string]bool
 }
 
 // BuildImportTable scans every embedded IMPORTS relationship in records
@@ -125,6 +133,8 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 		modulesByName:        make(map[string]map[string]bool),
 		entitiesByModuleName: make(map[string]map[string]string),
 		ambigModuleName:      make(map[string]map[string]bool),
+		methodsByFileName:    make(map[string]map[string]string),
+		ambigMethodFileName:  make(map[string]map[string]bool),
 	}
 
 	// Pass 1 — per-file import bindings.
@@ -199,6 +209,36 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 		if e.Kind == "SCOPE.Component" && e.Subtype == "module" {
 			continue
 		}
+		// PHP method index for FQN-method resolution (issue #422). Index
+		// every PHP SCOPE.Operation by (file, name). Methods declared
+		// inside a class (the dominant case) have Name == method name —
+		// the extractor doesn't pre-qualify with the class. We reuse the
+		// SourceFile <-> class file 1:1 mapping (PSR-4 convention) at
+		// lookup time: resolve the class FQN to its file, then probe
+		// (file, method_name) here.
+		if e.Language == "php" && e.Kind == "SCOPE.Operation" {
+			file := normalizePath(e.SourceFile)
+			if file != "" && e.Name != "" {
+				if tbl.ambigMethodFileName[file] == nil ||
+					!tbl.ambigMethodFileName[file][e.Name] {
+					bucket := tbl.methodsByFileName[file]
+					if bucket == nil {
+						bucket = make(map[string]string)
+						tbl.methodsByFileName[file] = bucket
+					}
+					if existing, ok := bucket[e.Name]; ok && existing != e.ID {
+						delete(bucket, e.Name)
+						if tbl.ambigMethodFileName[file] == nil {
+							tbl.ambigMethodFileName[file] = make(map[string]bool)
+						}
+						tbl.ambigMethodFileName[file][e.Name] = true
+					} else {
+						bucket[e.Name] = e.ID
+					}
+				}
+			}
+		}
+
 		modules := modulesForFile(normalizePath(e.SourceFile))
 		for _, mod := range modules {
 			files := tbl.modulesByName[mod]
@@ -521,6 +561,14 @@ type ImportResolveStats struct {
 	// ImportsRewritten counts the subset of ImportsConsidered that
 	// resolved to a 16-char entity ID via the per-module reverse index.
 	ImportsRewritten int
+	// PHPFQNMethodConsidered counts every embedded CALLS edge whose
+	// ToID matched the PHP FQN-method shape `<namespace>::<method>`
+	// (issue #422 — Symfony YAML routes emit these via _controller).
+	PHPFQNMethodConsidered int
+	// PHPFQNMethodRewritten counts the subset of PHPFQNMethodConsidered
+	// that resolved to a 16-char entity ID via the class-file method
+	// lookup.
+	PHPFQNMethodRewritten int
 }
 
 // ResolveDottedImportTarget looks up a project-internal IMPORTS ToID of
@@ -552,6 +600,126 @@ func (t ImportTable) ResolveDottedImportTarget(dotted string) (string, bool) {
 	return t.lookupModuleEntity(module, leaf)
 }
 
+// isPHPFQNMethodShape reports whether s looks like a PHP FQN-method
+// reference (`App\Controller\BlogController::list` or its dotted
+// equivalent). The shape is: a `::` infix with non-empty halves, where
+// the left half contains either a backslash or a dot (i.e. a real
+// namespace, not a single identifier — `Foo::bar` is the receiver-typed
+// form already handled by the base resolver via byMember).
+func isPHPFQNMethodShape(s string) bool {
+	sep := strings.Index(s, "::")
+	if sep <= 0 || sep+2 >= len(s) {
+		return false
+	}
+	left := s[:sep]
+	right := s[sep+2:]
+	if right == "" {
+		return false
+	}
+	// Reject CONTAINS-style file references (`doc.md::heading`) — the
+	// left half there is a path with a slash. Issue #100 owns those.
+	if strings.ContainsRune(left, '/') {
+		return false
+	}
+	return strings.ContainsAny(left, "\\.")
+}
+
+// ResolvePHPFQNMethodTarget binds a PHP FQN-method ToID of the form
+// `App\Controller\BlogController::list` (or its dotted equivalent
+// `App.Controller.BlogController::list`) to the entity ID of the
+// method declared in the resolved class's source file.
+//
+// Issue #422 — Symfony YAML routes carry `_controller: <FQN>::<method>`
+// strings that the YAML cross-extractor stamps verbatim onto CALLS /
+// IMPORTS edges. Pre-fix these flowed through the base resolver as
+// opaque names, missed every (kind, name, qualified) index, and landed
+// on bug-resolver. The resolution is two-step:
+//
+//  1. Split the input on `::`. The left side is a class FQN; normalise
+//     backslashes to dots, then split on the LAST dot to obtain
+//     (module, class). Pass to lookupModuleEntity to find the class
+//     entity ID.
+//  2. From the class ID, recover the class entity's SourceFile (via the
+//     methodsByFileName index built at BuildImportTable time we already
+//     have a file → method-name → method-id map; we use the class file
+//     directly via the same modulesByName mapping).
+//
+// Returns ("", false) for: malformed shapes (no `::`, empty halves),
+// classes that resolve into external namespaces (Symfony, Doctrine, …),
+// ambiguous (file, method) tuples, and methods not present in the
+// class's file.
+func (t ImportTable) ResolvePHPFQNMethodTarget(toID string) (string, bool) {
+	if toID == "" {
+		return "", false
+	}
+	sep := strings.Index(toID, "::")
+	if sep <= 0 || sep+2 >= len(toID) {
+		return "", false
+	}
+	classFQN := toID[:sep]
+	method := toID[sep+2:]
+	if method == "" {
+		return "", false
+	}
+	// Normalise backslash to dot (PHP namespace separator). Either form
+	// flows through the same dotted lookup.
+	if strings.ContainsRune(classFQN, '\\') {
+		classFQN = strings.ReplaceAll(classFQN, "\\", ".")
+	}
+	dot := strings.LastIndexByte(classFQN, '.')
+	if dot <= 0 || dot == len(classFQN)-1 {
+		return "", false
+	}
+	module, className := classFQN[:dot], classFQN[dot+1:]
+	// Resolve the class entity. lookupModuleEntity returns the unique
+	// entity ID for (module, name); ambiguous or unknown → ("", false).
+	classID, ok := t.lookupModuleEntity(module, className)
+	if !ok {
+		return "", false
+	}
+	// Recover the class's SourceFile via modulesByName: the file that
+	// satisfies `module` and contains the class. PHP PSR-4 maps a
+	// namespace to exactly one file, so the (module, file) intersection
+	// converges. We pick the file whose method index contains `method`.
+	files := t.modulesByName[module]
+	if len(files) == 0 {
+		return "", false
+	}
+	_ = classID // class ID is not needed for the method lookup; presence
+	// in the per-module reverse index is the project-internal gate. The
+	// method is bound by (class_file, method_name). When two project
+	// files declare the same module (rare but possible — duplicate
+	// namespace fragments split across roots), we accept the first
+	// unambiguous (file, method) hit.
+	var (
+		hitID string
+		hits  int
+	)
+	for file := range files {
+		if t.ambigMethodFileName[file] != nil && t.ambigMethodFileName[file][method] {
+			continue
+		}
+		bucket := t.methodsByFileName[file]
+		if bucket == nil {
+			continue
+		}
+		id, ok := bucket[method]
+		if !ok {
+			continue
+		}
+		if hits == 0 {
+			hitID = id
+			hits = 1
+		} else if id != hitID {
+			hits++
+		}
+	}
+	if hits != 1 {
+		return "", false
+	}
+	return hitID, true
+}
+
 // ResolveImports rewrites embedded CALLS edges in records using the
 // supplied import table. Returns counters describing the rewrite. Edges
 // whose ToID is empty, already a hex ID, or contains a "." (already
@@ -574,6 +742,22 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 			}
 			switch rel.Kind {
 			case "CALLS":
+				// Issue #422 — PHP FQN-method shape `<NS>::<method>`
+				// (Symfony YAML _controller). Detect before the generic
+				// `ContainsAny(":.#")` skip below, which would otherwise
+				// drop these on the floor. The shape is unambiguous: a
+				// `::` infix with non-empty halves and either backslash
+				// or dot separators in the namespace.
+				if strings.Contains(to, "::") {
+					if isPHPFQNMethodShape(to) {
+						stats.PHPFQNMethodConsidered++
+						if id, ok := tbl.ResolvePHPFQNMethodTarget(to); ok {
+							rel.ToID = id
+							stats.PHPFQNMethodRewritten++
+						}
+					}
+					continue
+				}
 				// Skip stubs that already encode a kind ("Kind:Name") or
 				// a receiver-typed dotted target ("Class.method"). The
 				// base resolver handles those via byKind / byMember.

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -786,6 +786,195 @@ func TestResolveImports_PHPExternalNamespaceLeftAlone(t *testing.T) {
 	}
 }
 
+// TestResolveImports_PHPFQNMethodTarget covers issue #422 — Symfony
+// YAML routing strings of the form `App\Controller\BlogController::list`
+// arrive on CALLS/IMPORTS edges and must rewrite to the entity ID of
+// the `list` method declared in `src/Controller/BlogController.php`.
+//
+// The fix mirrors the dotted-import handling for #113 and #142: split
+// the FQN-method shape on `::`, normalise the namespace (backslash →
+// dot), resolve the class via the per-module reverse index, then bind
+// the trailing method name to a method entity that lives in the class's
+// SourceFile.
+func TestResolveImports_PHPFQNMethodTarget(t *testing.T) {
+	records := []types.EntityRecord{
+		// YAML route entity (cross-extractor) carrying a CALLS edge to
+		// the FQN-method shape Symfony's _controller field uses.
+		{
+			Name:       "blog_list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "route",
+			SourceFile: "config/routes.yaml",
+			Language:   "yaml",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "config/routes.yaml",
+				ToID:   "App\\Controller\\BlogController::list",
+				Kind:   "CALLS",
+			}},
+		},
+		// Class BlogController declared in src/Controller/BlogController.php.
+		{
+			ID:         "aaaa1111aaaa1111",
+			Name:       "BlogController",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+		// Method `list` declared in the same file.
+		{
+			ID:         "bbbb2222bbbb2222",
+			Name:       "list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.PHPFQNMethodRewritten != 1 {
+		t.Fatalf("expected 1 PHP FQN-method rewrite, got %d (considered=%d)",
+			stats.PHPFQNMethodRewritten, stats.PHPFQNMethodConsidered)
+	}
+	if got := records[0].Relationships[0].ToID; got != "bbbb2222bbbb2222" {
+		t.Fatalf("expected target bbbb2222bbbb2222, got %q", got)
+	}
+}
+
+// TestResolveImports_PHPFQNMethodAlreadyDotted covers the same shape
+// expressed with dot separators — `App.Controller.BlogController::list`
+// — which the YAML cross-extractor may emit if it normalises FQNs
+// before stamping ToID.
+func TestResolveImports_PHPFQNMethodAlreadyDotted(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			Name:       "blog_list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "route",
+			SourceFile: "config/routes.yaml",
+			Language:   "yaml",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "config/routes.yaml",
+				ToID:   "App.Controller.BlogController::list",
+				Kind:   "CALLS",
+			}},
+		},
+		{
+			ID:         "aaaa1111aaaa1111",
+			Name:       "BlogController",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+		{
+			ID:         "bbbb2222bbbb2222",
+			Name:       "list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.PHPFQNMethodRewritten != 1 {
+		t.Fatalf("expected 1 PHP FQN-method rewrite (dotted), got %d", stats.PHPFQNMethodRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "bbbb2222bbbb2222" {
+		t.Fatalf("expected target bbbb2222bbbb2222, got %q", got)
+	}
+}
+
+// TestResolveImports_PHPFQNMethodExternalClassLeftAlone confirms that an
+// FQN-method whose class lives in an external namespace (Symfony,
+// Doctrine, …) misses the per-module index and is left for the
+// external-synthesis pass.
+func TestResolveImports_PHPFQNMethodExternalClassLeftAlone(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			Name:       "evt",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "route",
+			SourceFile: "config/services.yaml",
+			Language:   "yaml",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "config/services.yaml",
+				ToID:   "Symfony\\Component\\HttpKernel\\HttpKernel::handle",
+				Kind:   "CALLS",
+			}},
+		},
+		// A coincidentally-named project method — must NOT bind.
+		{
+			ID:         "deaddeaddeaddead",
+			Name:       "handle",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/Other/Thing.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.PHPFQNMethodRewritten != 0 {
+		t.Fatalf("expected 0 rewrites for external class, got %d", stats.PHPFQNMethodRewritten)
+	}
+	if got := records[0].Relationships[0].ToID; got != "Symfony\\Component\\HttpKernel\\HttpKernel::handle" {
+		t.Fatalf("expected ToID preserved, got %q", got)
+	}
+}
+
+// TestResolveImports_PHPFQNMethodAmbiguousMethodLeftAlone covers the
+// case where the resolved class file contains two methods with the same
+// name (overloaded? unlikely in PHP but defensively handled). Conservative
+// policy: drop the binding rather than guess.
+func TestResolveImports_PHPFQNMethodAmbiguousMethodLeftAlone(t *testing.T) {
+	records := []types.EntityRecord{
+		{
+			Name:       "blog_list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "route",
+			SourceFile: "config/routes.yaml",
+			Language:   "yaml",
+			Relationships: []types.RelationshipRecord{{
+				FromID: "config/routes.yaml",
+				ToID:   "App\\Controller\\BlogController::list",
+				Kind:   "CALLS",
+			}},
+		},
+		{
+			ID:         "aaaa1111aaaa1111",
+			Name:       "BlogController",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+		{
+			ID:         "bbbb2222bbbb2222",
+			Name:       "list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+		{
+			ID:         "cccc3333cccc3333",
+			Name:       "list",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/Controller/BlogController.php",
+			Language:   "php",
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.PHPFQNMethodRewritten != 0 {
+		t.Fatalf("expected 0 rewrites for ambiguous method, got %d", stats.PHPFQNMethodRewritten)
+	}
+}
+
 // TestResolveImports_FileLocalCollisionDropsBinding covers the case
 // where the same file imports two different symbols under the same
 // local name (e.g. shadowing). The conservative behaviour is to drop


### PR DESCRIPTION
## Summary

Bind PHP FQN-method CALLS targets like `App\Controller\BlogController::list` to the project-internal method entity. Pre-fix the import-aware resolver skipped any ToID containing `:` and these landed on bug-resolver, contributing to symfony-demo at 37.19% and symfony-routing at 48.92% bug rate post-#113.

- BuildImportTable now indexes PHP method entities by `(file, method_name)` with an ambiguity tracker.
- New `ResolvePHPFQNMethodTarget` splits on `::`, normalises backslash to dot, splits the namespace on the LAST dot to `(module, class)`, resolves the class via the existing per-module reverse index (#113), and binds the method via the file -> method index. Mirrors the dotted-import handling for #142.
- `ResolveImports` detects the FQN-method shape before the generic `:.#` skip on CALLS edges and tracks `PHPFQNMethodConsidered`/`Rewritten` separately so verify2 can attribute the delta.
- External namespaces (`Symfony\\...`, `Doctrine\\...`) miss the per-module index and are left for the external-synthesis pass.

Closes #422.

## Test plan

- [x] `go test ./internal/resolve/...` — all pass including 4 new tests:
  - `TestResolveImports_PHPFQNMethodTarget` (backslash form)
  - `TestResolveImports_PHPFQNMethodAlreadyDotted` (dotted form)
  - `TestResolveImports_PHPFQNMethodExternalClassLeftAlone` (external skip)
  - `TestResolveImports_PHPFQNMethodAmbiguousMethodLeftAlone` (overload skip)
- [x] `go test ./...` — all green.
- [x] `go vet ./...` clean, `gofmt -l` clean.
- [x] VERIFY-2 single-repo on `php/symfony-demo` and `php/symfony-routing` — indexes cleanly; bug-rate stable. The current corpora exercise PHP-attribute routes rather than YAML `_controller`, so the new pass logs zero considered events on these specific repos. The fix is the resolver-side half of #422; once a YAML cross-extractor lands that emits `_controller: <FQN>::<method>` edges, those edges will now bind correctly through this code path.

## Notes

- Numbers post-fix (single-repo run with `/tmp/archigraph-422 index --json-stats`):
  - symfony-demo: bug_rate=0.3719, resolution_rate=0.4213 (matches baseline; no FQN-method shape escapes the PHP extractor today, which already normalises `Foo::m()` to `Foo.m`).
  - symfony-routing: bug_rate=0.4892, resolution_rate=0.4423.
- The PHP CALLS extractor already normalises receiver-typed `Foo::m()` invocations to dotted form (`Foo.m`), so the residual shape this PR addresses is specifically FQN strings that bypass the extractor (cross-extractor stamps, future YAML route layer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)