### PR TITLE
fix(synth): Kotlin Ktor DSL methods classified (Closes #435)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -2125,6 +2125,55 @@ var kotlinBareNames = map[string]struct{}{
 	"lazy":           {},
 	"lazyOf":         {},
 	"TODO":           {},
+
+	// Issue #435: Ktor builder DSL methods + kotlinx.coroutines
+	// builders. The Kotlin extractor receiver-strips DSL calls
+	// (`call.respond(x)` → `respond`, `routing { get(...) }` → `get`
+	// already handled elsewhere; the routing block name itself lands
+	// as `routing`), so the resolver sees only the bare leaf and the
+	// call falls into bug-extractor. Gating to lang="kotlin" keeps a
+	// JS user variable named `request` or a Go `launch` symbol from
+	// being shadowed. Generic accessor verbs (`get`, `set`, `add`,
+	// `remove`, `size`, `isEmpty`) remain in the rejected list per
+	// #106 — only Ktor- / coroutine-specific names are added here.
+	//
+	// Ktor route builder DSL.
+	"routing":   {},
+	"route":     {},
+	"install":   {},
+	"intercept": {},
+	// Ktor ApplicationCall responders / accessors.
+	"respond":         {},
+	"respondText":     {},
+	"respondHtml":     {},
+	"respondRedirect": {},
+	"respondFile":     {},
+	"parameters":      {},
+	"headers":         {},
+	"principal":       {},
+	"authentication":  {},
+	"application":     {},
+	"environment":     {},
+	"request":         {},
+	"pipeline":        {},
+	"attributes":      {},
+	// kotlinx.coroutines builders. `launch` and `async` carry some
+	// collision risk even Kotlin-gated, but the leaf coroutine
+	// builders are the dominant residual in ktor-samples /
+	// ktor-source bug-extractor; the language gate is the safety net.
+	"runBlocking":    {},
+	"withContext":    {},
+	"coroutineScope": {},
+	"launch":         {},
+	"async":          {},
+	"delay":          {},
+	"flow":           {},
+	// Ktor server entry / static content / WebSocket DSL.
+	"embeddedServer":   {},
+	"staticFiles":      {},
+	"static":           {},
+	"webSocket":        {},
+	"webSocketSession": {},
 }
 
 // rubyBareNames is the Ruby-language-gated bare-name stop-list (issue

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1581,6 +1581,107 @@ func TestKotlinBareNames_RejectedNamesNotClassified(t *testing.T) {
 	}
 }
 
+// TestKotlinKtorDSLBareNames_ClassifiedWhenLangIsKotlin covers issue
+// #435: Ktor builder DSL methods (`routing { get(...); post(...) }`,
+// `install(plugin)`, `intercept(phase)`, `call.respond(...)`, etc.) and
+// kotlinx.coroutines builders (`runBlocking`, `withContext`, `launch`,
+// `async`, `delay`, `flow`) get receiver-stripped by the Kotlin
+// extractor and land in bug-extractor. These names must classify as
+// stdlib bare-names — but only when the source entity's language is
+// "kotlin".
+func TestKotlinKtorDSLBareNames_ClassifiedWhenLangIsKotlin(t *testing.T) {
+	names := []string{
+		// Ktor route builder DSL.
+		"routing", "route", "install", "intercept",
+		// Ktor ApplicationCall responders / accessors.
+		"respond", "respondText", "respondHtml", "respondRedirect",
+		"respondFile", "parameters", "headers", "principal",
+		"authentication", "application", "environment", "request",
+		"pipeline", "attributes",
+		// kotlinx.coroutines builders.
+		"runBlocking", "withContext", "coroutineScope", "launch",
+		"async", "delay", "flow",
+		// Ktor server entry / static / WebSocket.
+		"embeddedServer", "staticFiles", "static", "webSocket",
+		"webSocketSession",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "kotlin", "", nil)
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"kotlin\", nil) = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"kotlin\", nil) subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "kt-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "kotlin",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "kt-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestKotlinKtorDSLBareNames_NotClassifiedForOtherLanguages confirms
+// the Kotlin language gate holds for the issue #435 additions: Ktor
+// DSL / coroutine builder names must NOT be rewritten when the source
+// entity's language is anything other than "kotlin". A JS user method
+// named `request` or a Go `launch` symbol must not be shadowed.
+func TestKotlinKtorDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Pick names with the highest cross-language collision potential.
+	names := []string{"request", "respond", "route", "install", "launch", "async", "static", "headers", "parameters"}
+	otherLangs := []string{"go", "python", "javascript", "rust", "java", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
+						"(name is gated to lang=\"kotlin\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Kotlin)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
 // TestKotlinBareNames_UnknownKotlinMethodFallsThrough confirms that a
 // Kotlin-source bare-name call that ISN'T in the kotlinBareNames
 // allowlist still falls through normally, so genuine missing-
@@ -1679,14 +1780,15 @@ func TestRubyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 	names := []string{
 		"new", "tap", "then", "dup", "freeze", "to_s", "to_h", "is_a?", "respond_to?",
 		// ActiveRecord persistence names (issue #124) must not leak to
-		// other languages. `save`/`errors`/`all` are intentionally
-		// EXCLUDED from this negative list — they are independently
-		// classified by other-language allowlists (Spring Data `save`
-		// in Java, Go `errors` package, Python `all` builtin) and the
-		// non-leak guarantee for Ruby-only AR names is asserted by the
-		// remaining names below.
+		// other languages. `save`/`errors`/`all`/`attributes` are
+		// intentionally EXCLUDED from this negative list — they are
+		// independently classified by other-language allowlists
+		// (Spring Data `save` in Java, Go `errors` package, Python
+		// `all` builtin, Ktor `attributes` accessor in Kotlin per
+		// #435) and the non-leak guarantee for Ruby-only AR names is
+		// asserted by the remaining names below.
 		"update", "destroy", "valid?", "create", "build", "first", "last",
-		"reload", "attributes", "exists?", "persisted?", "new_record?",
+		"reload", "exists?", "persisted?", "new_record?",
 		"find_or_create_by", "valid_password?",
 	}
 	otherLangs := []string{"go", "python", "javascript", "rust", "java", "kotlin", ""}


### PR DESCRIPTION
## Summary

Extend `kotlinBareNames` in `internal/external/synth.go` with Ktor builder DSL methods + kotlinx.coroutines builders so they classify as stdlib bare-names instead of falling into bug-extractor after receiver-strip.

Names added (all Kotlin-gated per #106):
- Ktor route builder: `routing`, `route`, `install`, `intercept`
- Ktor `ApplicationCall` responders / accessors: `respond`, `respondText`, `respondHtml`, `respondRedirect`, `respondFile`, `parameters`, `headers`, `principal`, `authentication`, `application`, `environment`, `request`, `pipeline`, `attributes`
- kotlinx.coroutines builders: `runBlocking`, `withContext`, `coroutineScope`, `launch`, `async`, `delay`, `flow`
- Ktor server entry / static / WebSocket: `embeddedServer`, `staticFiles`, `static`, `webSocket`, `webSocketSession`

Per-language gate keeps a JS user variable named `request` or a Go `launch` symbol from being shadowed. Generic accessors (`get`/`set`/`add`/`remove`/`size`/`isEmpty`) remain in the rejected list. `attributes` is explicitly noted as both Ruby- and Kotlin-classified in the negative test for the Ruby gate.

## VERIFY-2 (single-repo)

| repo | bug_rate before | bug_rate after | delta | target |
| --- | ---: | ---: | ---: | ---: |
| ktor-samples | 34.68% | **31.66%** | -3.02pp | <=25% |
| ktor | 23.07% | **21.33%** | -1.74pp | <=25% (met) |

279 ktor-samples calls reclassified bug-extractor -> external-unknown. The residual ktor-samples gap is dominated by HTML/markdown file paths (`chat/.../index.html`), test infra (`testApplication`, `assertEquals`, `readText`), and iOS Swift sample paths — all out of scope for the Ktor DSL catalog and tracked separately.

forbidden-term grep: clean

Refs #44 #106
Closes #435

## Test plan

- [x] `go test ./...` green
- [x] new tests added: `TestKotlinKtorDSLBareNames_ClassifiedWhenLangIsKotlin`, `TestKotlinKtorDSLBareNames_NotClassifiedForOtherLanguages`
- [x] VERIFY-2 single-repo on `kotlin/ktor-samples` and `kotlin/ktor`
- [ ] AP-5 / IG-11 / K-2SO / TX-20 review on PR