### PR TITLE
fix(synth): Swift Vapor DSL methods classified (Closes #436)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -748,6 +748,11 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 			return "function", true
 		}
 	}
+	if lang == "swift" {
+		if _, ok := swiftBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -2361,6 +2366,199 @@ var jsBareNames = map[string]struct{}{
 	// either too collision-prone (`includes`, `indexOf`) or
 	// insufficiently observed in #104's bug-extractor sample to
 	// justify carrying the false-positive risk.
+}
+
+// swiftBareNames is the Swift-language-gated bare-name stop-list (issue
+// #436). The Swift extractor strips the receiver from a Vapor / Fluent
+// DSL call (`app.get("/x") { req in ... }` → `get`,
+// `User.query(on: db).filter(...).all()` → `query`/`filter`/`all`,
+// `req.parameters.get("id")` → `parameters`), and the resolver can't
+// bind the bare leaf to a local entity, so it lands in bug-extractor.
+//
+// Mirrors the Kotlin Ktor DSL precedent (issue #435 / kotlinBareNames):
+// the language gate (lang == "swift") is the safety net that prevents
+// generic verbs like `get`/`post`/`save`/`update`/`delete`/`map`/`first`
+// from shadowing user-defined methods in Go/JS/Python/Ruby/Kotlin
+// codebases. Vapor- and Fluent-specific names dominate the residual
+// bug-extractor in vapor (27.41%) and vapor-api-template (30.85%).
+//
+// Conservative selection (lessons from #94 / #105 / #106): names already
+// classified by the language-agnostic stdlibBareNames map (`all`,
+// `filter`, `map`, `set`, `range`, `join`, `Response`) are NOT
+// duplicated here — they classify globally before the swift gate fires.
+//
+// Categories:
+//   - Vapor route builder DSL (`get`, `post`, `put`, `patch`, `delete`,
+//     `on`, `group`, `grouped`, `route`, `register`, `boot`, `run`,
+//     `start`, `shutdown`, `respond`, `redirect`, `view`, `render`).
+//   - Vapor middleware DSL (`middleware`, `use`, `authenticate`,
+//     `authorize`, `protect`).
+//   - Fluent ORM builders (`save`, `delete`, `create`, `update`, `find`,
+//     `query`, `sort`, `limit`, `offset`, `with`, `count`, `first`,
+//     `last`, `paginate`, `transform`, `flatMap`).
+//   - HTTP context accessors (`parameters`, `query` — same name reused,
+//     `headers`, `body`, `request`, `response`, `auth`, `session`,
+//     `cookies`).
+//   - Swift Concurrency primitives (`async`, `await`, `Task`,
+//     `withCheckedContinuation`).
+var swiftBareNames = map[string]struct{}{
+	// Vapor route builder DSL.
+	"get":      {},
+	"post":     {},
+	"put":      {},
+	"patch":    {},
+	"delete":   {},
+	"on":       {},
+	"group":    {},
+	"grouped":  {},
+	"route":    {},
+	"register": {},
+	"boot":     {},
+	"run":      {},
+	"start":    {},
+	"shutdown": {},
+	"respond":  {},
+	"redirect": {},
+	"view":     {},
+	"render":   {},
+
+	// Vapor middleware DSL. `use` is a known cross-language collision
+	// (Rust prelude, JS Express); the lang=="swift" gate is the safety
+	// net per the Ktor precedent.
+	"middleware":   {},
+	"use":          {},
+	"authenticate": {},
+	"authorize":    {},
+	"protect":      {},
+
+	// Fluent ORM query / persistence builders. Names like `save`,
+	// `update`, `delete`, `find`, `first`, `last`, `count` collide with
+	// generic ORM verbs in any language — safe only because of the
+	// swift gate.
+	"save":      {},
+	"create":    {},
+	"update":    {},
+	"find":      {},
+	"query":     {},
+	"sort":      {},
+	"limit":     {},
+	"offset":    {},
+	"with":      {},
+	"count":     {},
+	"first":     {},
+	"last":      {},
+	"paginate":  {},
+	"transform": {},
+	"flatMap":   {},
+
+	// HTTP context accessors (Request / Response / ApplicationCall-
+	// equivalent). `parameters`/`headers`/`request` mirror the Ktor
+	// (#435) additions for the Kotlin gate; the swift gate keeps them
+	// from leaking across languages.
+	"parameters": {},
+	"headers":    {},
+	"body":       {},
+	"request":    {},
+	"response":   {},
+	"auth":       {},
+	"session":    {},
+	"cookies":    {},
+
+	// Swift Concurrency. `Task` is a Swift stdlib type; `async`/`await`
+	// are language keywords but show up as bare-name calls when the
+	// extractor receiver-strips a coroutine-style API.
+	"async":                   {},
+	"await":                   {},
+	"Task":                    {},
+	"withCheckedContinuation": {},
+
+	// SwiftNIO EventLoopFuture / EventLoopPromise / NIOLockedValueBox
+	// API. Vapor is built on SwiftNIO, and the dominant residual
+	// bug-extractor in the vapor framework source after the Vapor /
+	// Fluent additions above is the NIO Future API
+	// (`eventLoop.makePromise()`, `future.whenComplete { ... }`,
+	// `box.withLockedValue { ... }`). These names are Swift-only
+	// camelCase idioms with no plausible collision in other ecosystems,
+	// gated by lang=="swift" as defence-in-depth. Generic verbs
+	// (`succeed`, `fail`, `wait`) are deliberately OMITTED — they
+	// collide with user methods even within Swift codebases.
+	"makeSucceededFuture": {},
+	"makeFailedFuture":    {},
+	"makePromise":         {},
+	"makeFutureWithTask":  {},
+	"completeWithTask":    {},
+	"whenComplete":        {},
+	"whenSuccess":         {},
+	"whenFailure":         {},
+	"flatSubmit":          {},
+	"withLockedValue":     {},
+
+	// Swift stdlib types and Sequence/Collection protocol methods.
+	// The Swift extractor receiver-strips collection idioms
+	// (`names.forEach { ... }` → `forEach`, `parts.joined(separator:)` →
+	// `joined`, `bytes.dropFirst(2)` → `dropFirst`) and `init(...)`
+	// constructor calls. These are language-builtin operations with no
+	// plausible collision in non-Swift codebases; the swift gate adds
+	// defence-in-depth. Generic accessors (`get`/`set`/`add`/`remove`/
+	// `count`) are kept out of this group — `count` is already in
+	// swiftBareNames above as a Fluent ORM verb, and the rest are
+	// excluded per the #94 / #106 conservative-selection rule.
+	"String":                  {},
+	"Int":                     {},
+	"Array":                   {},
+	"Date":                    {},
+	"ObjectIdentifier":        {},
+	"forEach":                 {},
+	"joined":                  {},
+	"dropFirst":               {},
+	"prefix":                  {},
+	"numericCast":             {},
+	"singleValueContainer":    {},
+	"preconditionFailure":     {},
+	"preconditionInEventLoop": {},
+	"syncShutdownGracefully":  {},
+
+	// swift-log Logger API. Vapor / SwiftNIO log via swift-log's
+	// `Logger` type, and the extractor receiver-strips
+	// (`req.logger.debug("...")` → `debug`, `logger.notice(...)` →
+	// `notice`). Generic names like `error` would shadow user methods
+	// in other ecosystems, but the swift gate keeps these scoped. Within
+	// Swift codebases these names are dominantly Logger calls.
+	"debug":    {},
+	"info":     {},
+	"trace":    {},
+	"notice":   {},
+	"warning":  {},
+	"critical": {},
+
+	// More Swift stdlib / Foundation idioms (Sequence, String,
+	// Date/Calendar, integer types) and SwiftNIO Future helpers seen at
+	// volume in the vapor framework source. Each is a Swift-specific
+	// camelCase or PascalCase name; the swift gate prevents bleed into
+	// other ecosystems.
+	"hasSuffix":            {},
+	"hasPrefix":            {},
+	"lowercased":           {},
+	"uppercased":           {},
+	"replacingOccurrences": {},
+	"dropLast":             {},
+	"addingTimeInterval":   {},
+	"merging":              {},
+	"flatMapThrowing":      {},
+	"makeCompletedFuture":  {},
+	"precondition":         {},
+	"fatalError":           {},
+	"TimeZone":             {},
+	"Locale":               {},
+	"DateFormatter":        {},
+	"Int64":                {},
+	"UInt8":                {},
+	"UInt16":               {},
+	"UInt32":               {},
+	"UInt64":               {},
+	"Int8":                 {},
+	"Int16":                {},
+	"Int32":                {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1709,6 +1709,169 @@ func TestKotlinBareNames_UnknownKotlinMethodFallsThrough(t *testing.T) {
 	}
 }
 
+// TestSwiftVaporDSLBareNames_ClassifiedWhenLangIsSwift covers issue
+// #436: Vapor route builder DSL methods (`app.get(...)`, `routes.post`,
+// `route.group`, `req.respond`), Fluent ORM query builders
+// (`Model.query(on:)`, `.filter`, `.sort`, `.first`, `.all`), and HTTP
+// context accessors (`req.parameters`, `req.headers`, `req.body`) get
+// receiver-stripped by the Swift extractor and land in bug-extractor.
+// These names must classify as stdlib bare-names — but only when the
+// source entity's language is "swift". Mirrors the Kotlin Ktor DSL
+// precedent (#435).
+func TestSwiftVaporDSLBareNames_ClassifiedWhenLangIsSwift(t *testing.T) {
+	names := []string{
+		// Vapor route builder DSL.
+		"get", "post", "put", "patch", "delete", "on", "group",
+		"grouped", "route", "register", "boot", "run", "start",
+		"shutdown", "respond", "redirect", "view", "render",
+		// Vapor middleware DSL.
+		"middleware", "use", "authenticate", "authorize", "protect",
+		// Fluent ORM builders.
+		"save", "create", "update", "find", "query", "sort",
+		"limit", "offset", "with", "count", "first", "last",
+		"paginate", "transform", "flatMap",
+		// HTTP context accessors.
+		"parameters", "headers", "body", "request", "response",
+		"auth", "session", "cookies",
+		// Swift Concurrency.
+		"async", "await", "Task", "withCheckedContinuation",
+		// SwiftNIO EventLoopFuture / Promise / LockedValueBox.
+		"makeSucceededFuture", "makeFailedFuture", "makePromise",
+		"makeFutureWithTask", "completeWithTask",
+		"whenComplete", "whenSuccess", "whenFailure",
+		"flatSubmit", "withLockedValue",
+		// Swift stdlib types and Sequence/Collection idioms.
+		"String", "Int", "Array", "Date", "ObjectIdentifier",
+		"forEach", "joined", "dropFirst", "prefix",
+		"numericCast", "singleValueContainer",
+		"preconditionFailure", "preconditionInEventLoop",
+		"syncShutdownGracefully",
+		// swift-log Logger API.
+		"debug", "info", "trace", "notice", "warning", "critical",
+		// More Swift stdlib / Foundation / NIO Future idioms.
+		"hasSuffix", "hasPrefix", "lowercased", "uppercased",
+		"replacingOccurrences", "dropLast", "addingTimeInterval",
+		"merging", "flatMapThrowing", "makeCompletedFuture",
+		"precondition", "fatalError",
+		"TimeZone", "Locale", "DateFormatter",
+		"Int64", "UInt8", "UInt16", "UInt32", "UInt64",
+		"Int8", "Int16", "Int32",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "swift", "", nil)
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"swift\", nil) = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"swift\", nil) subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "swift-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "swift",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "swift-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestSwiftVaporDSLBareNames_NotClassifiedForOtherLanguages confirms the
+// Swift language gate holds for the issue #436 additions: Vapor / Fluent
+// DSL names must NOT be rewritten when the source entity's language is
+// anything other than "swift". A JS user method named `request`, a Go
+// method named `save`, a Ruby `find`, a Kotlin `respond`, etc. must not
+// be shadowed by the Swift gate.
+func TestSwiftVaporDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Pick names with the highest cross-language collision potential —
+	// generic verbs/accessors that exist as user methods in every
+	// ecosystem. Selection rule: each name MUST be unique to
+	// swiftBareNames (i.e. not in stdlibBareNames or any other
+	// language map), otherwise the cross-language gate test would
+	// trip on a different language's allowlist firing first.
+	names := []string{
+		"query", "body", "auth", "session", "cookies",
+		"register", "boot", "shutdown", "grouped", "redirect",
+		"render", "middleware", "authorize", "protect",
+		"paginate", "transform", "flatMap", "offset",
+	}
+	otherLangs := []string{"go", "python", "javascript", "ruby", "rust", "java", "kotlin", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
+						"(name is gated to lang=\"swift\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Swift)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestSwiftBareNames_UnknownSwiftMethodFallsThrough confirms that a
+// Swift-source bare-name call that ISN'T in the swiftBareNames allowlist
+// still falls through normally, so genuine missing-resolution bugs
+// continue to surface in bug-extractor.
+func TestSwiftBareNames_UnknownSwiftMethodFallsThrough(t *testing.T) {
+	name := "myCustomBusinessMethod" // Not Vapor/Fluent; user-defined.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "swift-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "swift",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "swift-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user fn)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
+	}
+}
+
 // TestRubyBareNames_ClassifiedWhenLangIsRuby covers issue #107: Ruby
 // Object/Kernel instance methods (post-receiver-strip) classify as
 // stdlib bare-names — but only when the source entity's language is
@@ -2580,16 +2743,16 @@ func TestSynthesize_HostPathMount(t *testing.T) {
 // docker image references.
 func TestDockerImageRepo(t *testing.T) {
 	cases := map[string]string{
-		"":                                 "",
-		"nginx":                            "nginx",
-		"nginx:1.21":                       "nginx",
-		"redis:alpine":                     "redis",
-		"library/postgres:14":              "library/postgres",
-		"ghcr.io/owner/svc:v1.2.3":         "ghcr.io/owner/svc",
-		"myregistry.io:5000/team/api:dev":  "myregistry.io:5000/team/api",
-		"myregistry.io:5000/team/api":      "myregistry.io:5000/team/api",
-		"alpine@sha256:abcdef":             "alpine",
-		"ubuntu:22.04@sha256:abcdef":       "ubuntu",
+		"":                                "",
+		"nginx":                           "nginx",
+		"nginx:1.21":                      "nginx",
+		"redis:alpine":                    "redis",
+		"library/postgres:14":             "library/postgres",
+		"ghcr.io/owner/svc:v1.2.3":        "ghcr.io/owner/svc",
+		"myregistry.io:5000/team/api:dev": "myregistry.io:5000/team/api",
+		"myregistry.io:5000/team/api":     "myregistry.io:5000/team/api",
+		"alpine@sha256:abcdef":            "alpine",
+		"ubuntu:22.04@sha256:abcdef":      "ubuntu",
 	}
 	for in, want := range cases {
 		if got := dockerImageRepo(in); got != want {


### PR DESCRIPTION
## Summary
- Adds `swiftBareNames` map gated to `lang == "swift"` in `internal/external/synth.go`, mirroring the Kotlin Ktor DSL fix (#435).
- Classifies Vapor route builders + Fluent ORM verbs + HTTP context accessors + Swift Concurrency + SwiftNIO Future API + swift-log Logger + Swift stdlib idioms as bare-name externals so they no longer fall into bug-extractor.
- Conservative-selection rule (#94 / #106) holds: generic verbs `succeed`/`fail`/`wait`/`get`(global)/`set`(global) are kept out, and `index`/`write`/`read`/`update`(global) remain in the cross-language collisions stop-list.

## Verify-2 (single-repo, before → after)

| repo | bug_rate before | bug_rate after | target |
| --- | ---: | ---: | ---: |
| vapor | 27.41% | **18.75%** | ≤20% |
| vapor-api-template | 30.85% | **21.28%** | ≤25% |

Both acceptance thresholds met.

## Test plan
- [x] `go test ./...` passes
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/external/` clean
- [x] 247 Swift-gated subtest cases (positive classify when lang=swift, negative reject across go/python/javascript/ruby/rust/java/kotlin/"", fall-through for unknown Swift names)

🤖 Generated with [Claude Code](https://claude.com/claude-code)