### PR TITLE
fix(synth): C# ASP.NET Core MVC + EF Core DSL classified (Closes #441)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -753,6 +753,11 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 			return "function", true
 		}
 	}
+	if lang == "csharp" {
+		if _, ok := csharpBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -2559,6 +2564,166 @@ var swiftBareNames = map[string]struct{}{
 	"Int8":                 {},
 	"Int16":                {},
 	"Int32":                {},
+}
+
+// csharpBareNames is the C#-language-gated bare-name stop-list (issue
+// #441). The C# extractor strips the receiver from an ASP.NET Core MVC
+// or EF Core call (`return Ok(model)` from a Controller base class →
+// `Ok`, `db.Users.Where(...).FirstOrDefaultAsync()` → `Where` /
+// `FirstOrDefaultAsync`, `HttpContext.User.IsAuthenticated` → `User` /
+// `IsAuthenticated`), and the resolver can't bind the bare leaf to a
+// local entity, so it lands in bug-extractor.
+//
+// Mirrors the Swift Vapor / Kotlin Ktor DSL precedents (issues #436 /
+// #435): the language gate (lang == "csharp") is the safety net that
+// prevents generic verbs like `Add`/`Update`/`Remove`/`Find`/`Where`/
+// `Select`/`First` from shadowing user-defined methods in Go/JS/Java/
+// Kotlin codebases. ASP.NET Core MVC and EF Core method names dominate
+// the residual bug-extractor in real ASP.NET sample apps.
+//
+// Conservative selection (lessons from #94 / #105 / #106): names already
+// classified by the language-agnostic stdlibBareNames map (`Response`,
+// `NotFound`) are NOT duplicated here — they classify globally before
+// the csharp gate fires.
+//
+// Categories:
+//   - ASP.NET Core MVC ControllerBase action helpers (`Ok`, `BadRequest`,
+//     `Unauthorized`, `Forbid`, `Conflict`, `UnprocessableEntity`,
+//     `RedirectToAction`, `RedirectToRoute`, `RedirectToPage`,
+//     `Redirect`, `View`, `PartialView`, `Json`, `Content`, `File`,
+//     `PhysicalFile`, `Created`, `CreatedAtAction`, `CreatedAtRoute`,
+//     `Accepted`, `NoContent`, `StatusCode`, `Problem`,
+//     `ValidationProblem`).
+//   - EF Core / LINQ-to-Entities query and persistence builders
+//     (`FirstOrDefault`, `FirstOrDefaultAsync`, `SingleOrDefault`,
+//     `SingleOrDefaultAsync`, `First`, `FirstAsync`, `Single`,
+//     `SingleAsync`, `ToList`, `ToListAsync`, `ToArray`, `ToArrayAsync`,
+//     `Include`, `ThenInclude`, `Where`, `Select`, `SelectMany`,
+//     `OrderBy`, `OrderByDescending`, `ThenBy`, `GroupBy`, `Skip`,
+//     `Take`, `Count`, `CountAsync`, `Sum`, `SumAsync`, `Average`,
+//     `Max`, `Min`, `Any`, `All`, `Find`, `FindAsync`, `AsNoTracking`,
+//     `AsQueryable`, `SaveChanges`, `SaveChangesAsync`, `Add`,
+//     `AddAsync`, `AddRange`, `Update`, `Remove`, `RemoveRange`,
+//     `Attach`, `Entry`).
+//   - HttpContext / IActionResult accessors (`User`, `Request`,
+//     `Response`, `Session`, `Items`, `Headers`, `Cookies`, `Form`,
+//     `Query`).
+//   - ASP.NET Core authentication helpers (`SignIn`, `SignOut`,
+//     `Authenticate`, `Challenge`, `IsAuthenticated`, `HasClaim`).
+//   - Microsoft.Extensions.DependencyInjection helpers
+//     (`GetRequiredService`, `GetService`, `GetServices`,
+//     `BuildServiceProvider`).
+//
+// Generic accessors `Get`/`Set` are deliberately NOT included — the
+// #94 / #106 conservative-selection rule treats them as collision-prone
+// even within a single ecosystem. EF Core's canonical `Add`, `Update`,
+// `Remove`, `Find` ARE included because the lang=="csharp" gate scopes
+// them to C# sources, and they dominate EF Core call-sites.
+var csharpBareNames = map[string]struct{}{
+	// ASP.NET Core MVC ControllerBase action helpers. `Response` and
+	// `NotFound` are intentionally omitted — they're already in
+	// stdlibBareNames and classify globally.
+	"Ok":                  {},
+	"BadRequest":          {},
+	"Unauthorized":        {},
+	"Forbid":              {},
+	"Conflict":            {},
+	"UnprocessableEntity": {},
+	"RedirectToAction":    {},
+	"RedirectToRoute":     {},
+	"RedirectToPage":      {},
+	"Redirect":            {},
+	"View":                {},
+	"PartialView":         {},
+	"Json":                {},
+	"Content":             {},
+	"File":                {},
+	"PhysicalFile":        {},
+	"Created":             {},
+	"CreatedAtAction":     {},
+	"CreatedAtRoute":      {},
+	"Accepted":            {},
+	"NoContent":           {},
+	"StatusCode":          {},
+	"Problem":             {},
+	"ValidationProblem":   {},
+
+	// EF Core / LINQ-to-Entities query and persistence builders.
+	// Names like `Where`, `Select`, `First`, `Add`, `Update`, `Remove`,
+	// `Find` collide with generic ORM/collection verbs in any language;
+	// safe only because of the csharp gate.
+	"FirstOrDefault":       {},
+	"FirstOrDefaultAsync":  {},
+	"SingleOrDefault":      {},
+	"SingleOrDefaultAsync": {},
+	"First":                {},
+	"FirstAsync":           {},
+	"Single":               {},
+	"SingleAsync":          {},
+	"ToList":               {},
+	"ToListAsync":          {},
+	"ToArray":              {},
+	"ToArrayAsync":         {},
+	"Include":              {},
+	"ThenInclude":          {},
+	"Where":                {},
+	"Select":               {},
+	"SelectMany":           {},
+	"OrderBy":              {},
+	"OrderByDescending":    {},
+	"ThenBy":               {},
+	"GroupBy":              {},
+	"Skip":                 {},
+	"Take":                 {},
+	"Count":                {},
+	"CountAsync":           {},
+	"Sum":                  {},
+	"SumAsync":             {},
+	"Average":              {},
+	"Max":                  {},
+	"Min":                  {},
+	"Any":                  {},
+	"All":                  {},
+	"Find":                 {},
+	"FindAsync":            {},
+	"AsNoTracking":         {},
+	"AsQueryable":          {},
+	"SaveChanges":          {},
+	"SaveChangesAsync":     {},
+	"Add":                  {},
+	"AddAsync":             {},
+	"AddRange":             {},
+	"Update":               {},
+	"Remove":               {},
+	"RemoveRange":          {},
+	"Attach":               {},
+	"Entry":                {},
+
+	// HttpContext / IActionResult accessors. `Response` already
+	// classifies globally via stdlibBareNames and is intentionally
+	// omitted here.
+	"User":    {},
+	"Request": {},
+	"Session": {},
+	"Items":   {},
+	"Headers": {},
+	"Cookies": {},
+	"Form":    {},
+	"Query":   {},
+
+	// ASP.NET Core authentication helpers.
+	"SignIn":          {},
+	"SignOut":         {},
+	"Authenticate":    {},
+	"Challenge":       {},
+	"IsAuthenticated": {},
+	"HasClaim":        {},
+
+	// Microsoft.Extensions.DependencyInjection helpers.
+	"GetRequiredService":   {},
+	"GetService":           {},
+	"GetServices":          {},
+	"BuildServiceProvider": {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1872,6 +1872,166 @@ func TestSwiftBareNames_UnknownSwiftMethodFallsThrough(t *testing.T) {
 	}
 }
 
+// TestCSharpAspNetCoreDSLBareNames_ClassifiedWhenLangIsCSharp covers
+// issue #441: ASP.NET Core MVC ControllerBase action helpers
+// (`return Ok(model)`, `BadRequest()`, `RedirectToAction(...)`), EF Core
+// LINQ query builders (`db.Users.Where(...).FirstOrDefaultAsync()`,
+// `Include(...)`, `ThenInclude(...)`), HttpContext / auth accessors
+// (`User`, `IsAuthenticated`, `HasClaim`), and DI helpers
+// (`GetRequiredService`) get receiver-stripped by the C# extractor and
+// land in bug-extractor. These names must classify as stdlib bare-names
+// — but only when the source entity's language is "csharp". Mirrors the
+// Swift Vapor DSL precedent (#436).
+func TestCSharpAspNetCoreDSLBareNames_ClassifiedWhenLangIsCSharp(t *testing.T) {
+	names := []string{
+		// ASP.NET Core MVC ControllerBase action helpers.
+		"Ok", "BadRequest", "Unauthorized", "Forbid", "Conflict",
+		"UnprocessableEntity", "RedirectToAction", "RedirectToRoute",
+		"RedirectToPage", "Redirect", "View", "PartialView", "Json",
+		"Content", "File", "PhysicalFile", "Created", "CreatedAtAction",
+		"CreatedAtRoute", "Accepted", "NoContent", "StatusCode",
+		"Problem", "ValidationProblem",
+		// EF Core / LINQ-to-Entities query and persistence builders.
+		"FirstOrDefault", "FirstOrDefaultAsync", "SingleOrDefault",
+		"SingleOrDefaultAsync", "First", "FirstAsync", "Single",
+		"SingleAsync", "ToList", "ToListAsync", "ToArray", "ToArrayAsync",
+		"Include", "ThenInclude", "Where", "Select", "SelectMany",
+		"OrderBy", "OrderByDescending", "ThenBy", "GroupBy", "Skip",
+		"Take", "Count", "CountAsync", "Sum", "SumAsync", "Average",
+		"Max", "Min", "Any", "All", "Find", "FindAsync", "AsNoTracking",
+		"AsQueryable", "SaveChanges", "SaveChangesAsync", "Add",
+		"AddAsync", "AddRange", "Update", "Remove", "RemoveRange",
+		"Attach", "Entry",
+		// HttpContext / IActionResult accessors.
+		"User", "Request", "Session", "Items", "Headers", "Cookies",
+		"Form", "Query",
+		// ASP.NET Core authentication helpers.
+		"SignIn", "SignOut", "Authenticate", "Challenge",
+		"IsAuthenticated", "HasClaim",
+		// Microsoft.Extensions.DependencyInjection helpers.
+		"GetRequiredService", "GetService", "GetServices",
+		"BuildServiceProvider",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "csharp", "", nil)
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"csharp\", nil) = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"csharp\", nil) subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "csharp-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "csharp",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "csharp-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestCSharpAspNetCoreDSLBareNames_NotClassifiedForOtherLanguages
+// confirms the C# language gate holds for the issue #441 additions:
+// ASP.NET Core / EF Core DSL names must NOT be rewritten when the source
+// entity's language is anything other than "csharp". A JS user method
+// named `Where`, a Go method named `Add`, a Ruby `Find`, a Kotlin
+// `Update`, etc. must not be shadowed by the csharp gate.
+func TestCSharpAspNetCoreDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Pick names with the highest cross-language collision potential —
+	// generic verbs/accessors that exist as user methods in every
+	// ecosystem. Selection rule: each name MUST be unique to
+	// csharpBareNames (i.e. not in stdlibBareNames or any other
+	// language map), otherwise the cross-language gate test would
+	// trip on a different language's allowlist firing first.
+	names := []string{
+		"BadRequest", "Unauthorized", "Forbid", "Conflict",
+		"UnprocessableEntity", "RedirectToAction", "RedirectToRoute",
+		"RedirectToPage", "PartialView", "PhysicalFile",
+		"CreatedAtAction", "CreatedAtRoute", "ValidationProblem",
+		"FirstOrDefaultAsync", "SingleOrDefaultAsync", "ToListAsync",
+		"ToArrayAsync", "ThenInclude", "AsNoTracking", "AsQueryable",
+		"SaveChangesAsync", "AddRange", "RemoveRange", "FindAsync",
+		"GetRequiredService", "BuildServiceProvider", "HasClaim",
+		"IsAuthenticated",
+	}
+	otherLangs := []string{"go", "python", "javascript", "ruby", "rust", "java", "kotlin", "swift", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
+						"(name is gated to lang=\"csharp\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-C#)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestCSharpBareNames_UnknownCSharpMethodFallsThrough confirms that a
+// C#-source bare-name call that ISN'T in the csharpBareNames allowlist
+// still falls through normally, so genuine missing-resolution bugs
+// continue to surface in bug-extractor.
+func TestCSharpBareNames_UnknownCSharpMethodFallsThrough(t *testing.T) {
+	name := "MyCustomBusinessMethod" // Not ASP.NET/EF Core; user-defined.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "csharp-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "csharp",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "csharp-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user fn)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
+	}
+}
+
 // TestRubyBareNames_ClassifiedWhenLangIsRuby covers issue #107: Ruby
 // Object/Kernel instance methods (post-receiver-strip) classify as
 // stdlib bare-names — but only when the source entity's language is


### PR DESCRIPTION
## Summary

Adds `csharpBareNames` stop-list gated to `lang=="csharp"`, mirroring the Swift Vapor (#436) and Kotlin Ktor (#435) precedents. Closes #441.

Covers:
- **ASP.NET Core MVC ControllerBase** action helpers: `Ok`, `BadRequest`, `Unauthorized`, `Forbid`, `Conflict`, `UnprocessableEntity`, `RedirectToAction`, `RedirectToRoute`, `RedirectToPage`, `Redirect`, `View`, `PartialView`, `Json`, `Content`, `File`, `PhysicalFile`, `Created`, `CreatedAtAction`, `CreatedAtRoute`, `Accepted`, `NoContent`, `StatusCode`, `Problem`, `ValidationProblem`.
- **EF Core / LINQ-to-Entities** query and persistence builders: `Where`, `Select`, `SelectMany`, `Include`, `ThenInclude`, `OrderBy`, `OrderByDescending`, `ThenBy`, `GroupBy`, `Skip`, `Take`, `First`, `FirstAsync`, `FirstOrDefault`, `FirstOrDefaultAsync`, `Single`, `SingleAsync`, `SingleOrDefault`, `SingleOrDefaultAsync`, `ToList`, `ToListAsync`, `ToArray`, `ToArrayAsync`, `Count`, `CountAsync`, `Sum`, `SumAsync`, `Average`, `Max`, `Min`, `Any`, `All`, `Find`, `FindAsync`, `AsNoTracking`, `AsQueryable`, `SaveChanges`, `SaveChangesAsync`, `Add`, `AddAsync`, `AddRange`, `Update`, `Remove`, `RemoveRange`, `Attach`, `Entry`.
- **HttpContext / IActionResult** accessors: `User`, `Request`, `Session`, `Items`, `Headers`, `Cookies`, `Form`, `Query`.
- **Authentication** helpers: `SignIn`, `SignOut`, `Authenticate`, `Challenge`, `IsAuthenticated`, `HasClaim`.
- **Microsoft.Extensions.DependencyInjection** helpers: `GetRequiredService`, `GetService`, `GetServices`, `BuildServiceProvider`.

Generic accessors `Get`/`Set` are excluded per the #94 / #106 conservative-selection rule. EF Core's canonical `Add`/`Update`/`Remove`/`Find` ARE included because the `lang=="csharp"` gate scopes them to C# sources, and they dominate EF Core call-sites. Names already classified by `stdlibBareNames` (`Response`, `NotFound`) are not duplicated.

## VERIFY-2 single-repo (csharp/aspnetcore-realworld)

| metric | main | branch | delta |
| --- | ---: | ---: | ---: |
| bug-extractor | 464 | 370 | **-94 (-20.3%)** |
| bug_rate | 0.2174 | 0.1793 | **-17.5%** |
| external_synthesized | 11 | 36 | +25 |

Names like `AsNoTracking`, `Include`, `FirstOrDefaultAsync`, `SaveChangesAsync`, `Remove` move from `bug-extractor` -> `external-unknown` (correctly synthesized as `ext:<Name>`).

## Test plan

- [x] `go test ./...` (all packages green)
- [x] `go vet ./...` clean
- [x] `gofmt -l internal/external/` clean
- [x] Positive test: every name classifies under `lang=="csharp"`
- [x] Cross-language gate test: collision-prone names (`BadRequest`, `FirstOrDefaultAsync`, `ThenInclude`, `AsNoTracking`, etc.) do NOT classify under go/python/js/ruby/rust/java/kotlin/swift/""
- [x] Unknown-name fall-through test: user-defined `MyCustomBusinessMethod` still surfaces in bug-extractor

NOTE: parallel siblings #439 / #440 also touch `synth.go`. Rebase if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)