### PR TITLE
fix(synth): Python Flask extensions + Marshmallow DSL classified (Closes #446)

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -355,6 +355,89 @@ var (
 		regexp.MustCompile(`^launch$`),
 		regexp.MustCompile(`^edit$`),
 		regexp.MustCompile(`^get_app_dir$`),
+
+		// Flask extensions + Marshmallow + Flask-SQLAlchemy DSL (issue
+		// #446). Residual after #420 was Flask-SQLAlchemy column / type
+		// / relationship constructors on `db = SQLAlchemy()`, Flask-Login
+		// proxies (`current_user`, `@login_required`), Flask-WTF form
+		// methods (`form.validate_on_submit()`), Marshmallow schema field
+		// constructors (`fields.Str`, `fields.Nested`) and (de)serialization
+		// hooks (`@pre_load`, `Schema.dump`, `Schema.load`), and Flask's
+		// common response helpers (`jsonify`, `abort`, `send_file`). The
+		// Python extractor strips receivers like `db.`, `fields.`,
+		// `Schema.`, `form.`, `app.` and only the bare leaf identifier
+		// arrives at the resolver. Pre-fix this drove flask 41.32% and
+		// flask-realworld 43.47%. Per-language gate (Python only) keeps
+		// generic leaves (`add`, `delete`, `commit`, `session`, `query`,
+		// `dump`, `load`, `fields`, `String`, `Integer`) from shadowing
+		// user methods/types in other ecosystems. Within Python the
+		// collision trade is accepted: same precedent as Rails
+		// `render`/`session`/`params` (#107) and Flask `route`/`command`
+		// (#420) — Dynamic is the appropriate bucket for framework
+		// dispatch the resolver can't statically bind.
+		// Flask-SQLAlchemy
+		regexp.MustCompile(`^Column$`),
+		regexp.MustCompile(`^ForeignKey$`),
+		regexp.MustCompile(`^relationship$`),
+		regexp.MustCompile(`^backref$`),
+		regexp.MustCompile(`^Integer$`),
+		regexp.MustCompile(`^String$`),
+		regexp.MustCompile(`^Text$`),
+		regexp.MustCompile(`^Boolean$`),
+		regexp.MustCompile(`^DateTime$`),
+		regexp.MustCompile(`^Date$`),
+		regexp.MustCompile(`^Float$`),
+		regexp.MustCompile(`^Numeric$`),
+		regexp.MustCompile(`^init_app$`),
+		regexp.MustCompile(`^query$`),
+		regexp.MustCompile(`^query_property$`),
+		regexp.MustCompile(`^create_all$`),
+		regexp.MustCompile(`^drop_all$`),
+		regexp.MustCompile(`^session$`),
+		regexp.MustCompile(`^commit$`),
+		regexp.MustCompile(`^rollback$`),
+		regexp.MustCompile(`^flush$`),
+		regexp.MustCompile(`^add$`),
+		regexp.MustCompile(`^delete$`),
+		regexp.MustCompile(`^merge$`),
+		regexp.MustCompile(`^refresh$`),
+		// Flask-Login
+		regexp.MustCompile(`^current_user$`),
+		regexp.MustCompile(`^login_required$`),
+		regexp.MustCompile(`^login_user$`),
+		regexp.MustCompile(`^logout_user$`),
+		regexp.MustCompile(`^confirm_login$`),
+		// Flask-WTF
+		regexp.MustCompile(`^validate_on_submit$`),
+		regexp.MustCompile(`^populate_obj$`),
+		regexp.MustCompile(`^render_kw$`),
+		// Marshmallow — `Boolean` and `DateTime` overlap with the
+		// SQLAlchemy types above and are already covered.
+		regexp.MustCompile(`^fields$`),
+		regexp.MustCompile(`^Schema$`),
+		regexp.MustCompile(`^Str$`),
+		regexp.MustCompile(`^Int$`),
+		regexp.MustCompile(`^List$`),
+		regexp.MustCompile(`^Nested$`),
+		regexp.MustCompile(`^Method$`),
+		regexp.MustCompile(`^Function$`),
+		regexp.MustCompile(`^pre_load$`),
+		regexp.MustCompile(`^post_load$`),
+		regexp.MustCompile(`^pre_dump$`),
+		regexp.MustCompile(`^post_dump$`),
+		regexp.MustCompile(`^validates$`),
+		regexp.MustCompile(`^validates_schema$`),
+		regexp.MustCompile(`^dump$`),
+		regexp.MustCompile(`^load$`),
+		regexp.MustCompile(`^dumps$`),
+		regexp.MustCompile(`^loads$`),
+		// Flask common response helpers
+		regexp.MustCompile(`^jsonify$`),
+		regexp.MustCompile(`^make_response$`),
+		regexp.MustCompile(`^abort$`),
+		regexp.MustCompile(`^send_file$`),
+		regexp.MustCompile(`^send_from_directory$`),
+		regexp.MustCompile(`^stream_with_context$`),
 	}
 
 	goDynamicPatterns = []*regexp.Regexp{

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -843,12 +843,16 @@ func TestRubyRailsDSL_GatedToRuby(t *testing.T) {
 	t.Parallel()
 	stubs := []string{
 		"where", "order", "params", "request", "response", "limit",
-		"render", "validates",
+		"render",
 		// NOTE: `group` was removed from this gate list (issue #423) —
 		// click's `@click.group()` decorator legitimately makes `group`
 		// a Python DSL bare-name too, so it is intentionally NOT
 		// ruby-only any more. Per-language scoping still holds for the
 		// remaining names.
+		// NOTE: `validates` was removed from this gate list (issue
+		// #446) — Marshmallow's `@validates(...)` decorator
+		// legitimately makes `validates` a Python DSL bare-name too,
+		// so it is intentionally NOT ruby-only any more.
 		// Migration DSL gating (issue #124) — collision-prone for
 		// other languages (`string`, `integer`, `boolean`, `text`,
 		// `references`, `execute`, `add_column`...).
@@ -953,6 +957,88 @@ func TestPythonFlaskDSL_GatedToPython(t *testing.T) {
 				if isDynamicPatternLang(stub, lang) {
 					t.Fatalf("stub %q matched dynamic for lang=%q; "+
 						"must be gated to python only (issue #420)", stub, lang)
+				}
+			})
+		}
+	}
+}
+
+// TestPythonFlaskExtensionsDSL_RecognisedAsDynamic locks in issue #446:
+// Flask extension + Marshmallow + Flask-SQLAlchemy DSL bindings. Pre-fix
+// the residual on python/flask (41.32%) and python/flask-realworld
+// (43.47%) was dominated by these bare-name leaves emitted after the
+// Python extractor strips receivers like `db.`, `current_user.`,
+// `fields.`, `Schema.`, `form.`, `app.`. Mirrors the Flask (#420) and
+// click (#423) DSL precedent. Per-language gate (Python only) keeps
+// generic names like `add`, `delete`, `commit`, `dump`, `load` from
+// shadowing user methods in other ecosystems — within Python the
+// trade is accepted (same precedent as Rails `render`/`session` etc.
+// in #107) because Dynamic is the appropriate bucket for framework
+// dispatch we can't statically resolve.
+func TestPythonFlaskExtensionsDSL_RecognisedAsDynamic(t *testing.T) {
+	t.Parallel()
+	dynamic := []string{
+		// Flask-SQLAlchemy: column / type / relationship constructors and
+		// session/query methods on `db` (SQLAlchemy()) instances.
+		"Column", "ForeignKey", "relationship", "backref",
+		"Integer", "String", "Text", "Boolean", "DateTime",
+		"Date", "Float", "Numeric",
+		"init_app", "query", "query_property", "create_all", "drop_all",
+		"session", "commit", "rollback", "flush",
+		"add", "delete", "merge", "refresh",
+		// Flask-Login
+		"current_user", "login_required", "login_user", "logout_user", "confirm_login",
+		// Flask-WTF
+		"validate_on_submit", "populate_obj", "render_kw",
+		// Marshmallow — schema field constructors and (de)serialization hooks.
+		// `Boolean`/`DateTime` are deliberately not re-listed (already above).
+		"fields", "Schema", "Str", "Int", "List", "Nested", "Method", "Function",
+		"pre_load", "post_load", "pre_dump", "post_dump",
+		"validates", "validates_schema",
+		"dump", "load", "dumps", "loads",
+		// Flask common response helpers
+		"jsonify", "make_response", "abort", "send_file",
+		"send_from_directory", "stream_with_context",
+	}
+	for _, stub := range dynamic {
+		stub := stub
+		t.Run("python/"+stub, func(t *testing.T) {
+			t.Parallel()
+			if !isDynamicPatternLang(stub, "python") {
+				t.Fatalf("Flask extension DSL stub %q not recognised as Dynamic for lang=python", stub)
+			}
+		})
+	}
+}
+
+// TestPythonFlaskExtensionsDSL_GatedToPython confirms the Flask
+// extension / Marshmallow / Flask-SQLAlchemy bare-name patterns only
+// match when lang="python" — otherwise generic names like `add`,
+// `delete`, `commit`, `session`, `query`, `dump`, `load`, `fields`,
+// `String`, `Integer` would shadow user methods/types in other
+// ecosystems trivially.
+func TestPythonFlaskExtensionsDSL_GatedToPython(t *testing.T) {
+	t.Parallel()
+	// NOTE: `session` is intentionally NOT in this list — the Ruby
+	// DSL block (#107) also claims `session` for Rails, so the
+	// per-language assertion against ruby would fail. The Python
+	// gate still applies to `session` for non-ruby languages, but
+	// asserting only the non-overlap cases keeps the test honest.
+	stubs := []string{
+		"add", "delete", "commit", "query",
+		"dump", "load", "fields", "Schema", "Column",
+		"String", "Integer", "current_user", "login_required",
+		"jsonify", "abort",
+	}
+	otherLangs := []string{"go", "ruby", "javascript", "typescript", "java", "kotlin"}
+	for _, stub := range stubs {
+		for _, lang := range otherLangs {
+			stub, lang := stub, lang
+			t.Run(stub+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if isDynamicPatternLang(stub, lang) {
+					t.Fatalf("stub %q matched dynamic for lang=%q; "+
+						"must be gated to python only (issue #446)", stub, lang)
 				}
 			})
 		}


### PR DESCRIPTION
## Summary

Adds bare-name Dynamic anchors (Python-gated) for the residual Flask extension surface after #420:

- **Flask-SQLAlchemy**: `Column`, `ForeignKey`, `relationship`, `backref`, `Integer`, `String`, `Text`, `Boolean`, `DateTime`, `Date`, `Float`, `Numeric`, `init_app`, `query`, `query_property`, `create_all`, `drop_all`, `session`, `commit`, `rollback`, `flush`, `add`, `delete`, `merge`, `refresh`
- **Flask-Login**: `current_user`, `login_required`, `login_user`, `logout_user`, `confirm_login`
- **Flask-WTF**: `validate_on_submit`, `populate_obj`, `render_kw`
- **Marshmallow**: `fields`, `Schema`, `Str`, `Int`, `List`, `Nested`, `Method`, `Function`, `pre_load`, `post_load`, `pre_dump`, `post_dump`, `validates`, `validates_schema`, `dump`, `load`, `dumps`, `loads`
- **Flask common**: `jsonify`, `make_response`, `abort`, `send_file`, `send_from_directory`, `stream_with_context`

The Python extractor strips receivers like `db.`, `fields.`, `Schema.`, `form.`, `app.` so only bare leaf identifiers reach the resolver. The per-language gate (Python only) keeps generic leaves from shadowing user methods/types in other ecosystems. Mirrors Rails (#107), Flask (#420), click (#423), Vapor (#436), Kotlin Ktor (#435), PHP (#439), C# (#441), Rust (#440) precedents.

Also relaxes the Ruby-only gate on `validates` (Marshmallow uses `@validates(...)` as a Python decorator) — same precedent as `group` in #423.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] New tests: `TestPythonFlaskExtensionsDSL_RecognisedAsDynamic`, `TestPythonFlaskExtensionsDSL_GatedToPython`
- [x] VERIFY-2 single-repo:
  - flask: bug_rate 18.89% to 18.78% (bug-extractor 1977 to 1972, bug-resolver 208 to 200, dynamic 2821 to 2834)
  - flask-realworld: bug_rate 20.18% to 19.16% (bug-extractor 286 to 267, bug-resolver 91 to 91, dynamic 452 to 471)

Closes #446.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>