### PR TITLE
fix(synth): Python Django ORM + DRF DSL classified (Closes #447)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -763,6 +763,11 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 			return "function", true
 		}
 	}
+	if lang == "python" {
+		if _, ok := pythonBareNames[name]; ok {
+			return "function", true
+		}
+	}
 	return "", false
 }
 
@@ -2967,6 +2972,130 @@ var phpBareNames = map[string]struct{}{
 	"validator":  {},
 	"optional":   {},
 	"tap":        {},
+}
+
+// pythonBareNames is the Python-language-gated bare-name stop-list
+// (issue #447). After the Python extractor strips the receiver from
+// attribute calls (`User.objects.filter(...)` → `filter`,
+// `self.save()` → `save`, `serializer.is_valid()` → `is_valid`), the
+// resolver sees a bare identifier that can't be matched to a local
+// entity and lands in bug-extractor. These names are Django ORM /
+// QuerySet / Meta verbs, Django REST Framework view / serializer /
+// permission class names, and Django admin DSL helpers — high-volume
+// in django-realworld-style codebases (and django/DRF web apps
+// generally) and gated to lang=="python" so a same-named user method
+// in JS / Go / Ruby / etc. is not shadowed (#94 safer-bias rule).
+//
+// Names that already classify via stdlibBareNames (`filter`,
+// `Response`) are NOT duplicated here — the global stop-list fires
+// first regardless of language gate.
+var pythonBareNames = map[string]struct{}{
+	// Django ORM model field types (class names used in `models.Model`
+	// subclass bodies; receiver-stripped from `models.CharField(...)`).
+	"CharField":       {},
+	"IntegerField":    {},
+	"BooleanField":    {},
+	"DateTimeField":   {},
+	"DateField":       {},
+	"TextField":       {},
+	"ForeignKey":      {},
+	"OneToOneField":   {},
+	"ManyToManyField": {},
+	"URLField":        {},
+	"EmailField":      {},
+	"SlugField":       {},
+	"DecimalField":    {},
+	"FloatField":      {},
+	"BinaryField":     {},
+	"JSONField":       {},
+	"FileField":       {},
+	"ImageField":      {},
+
+	// Django ORM manager / QuerySet API. `objects` arrives bare from
+	// `User.objects.filter(...)` after the receiver-strip; the verb
+	// chain (`filter`, `exclude`, `get`, `annotate`, ...) likewise.
+	// `filter` is already in stdlibBareNames (global) and is not
+	// duplicated here.
+	"objects":          {},
+	"exclude":          {},
+	"get":              {},
+	"get_or_create":    {},
+	"update_or_create": {},
+	"create":           {},
+	"save":             {},
+	"delete":           {},
+	"update":           {},
+	"select_related":   {},
+	"prefetch_related": {},
+	"values":           {},
+	"values_list":      {},
+	"annotate":         {},
+	"aggregate":        {},
+	"count":            {},
+	"exists":           {},
+	"bulk_create":      {},
+	"bulk_update":      {},
+	"latest":           {},
+	"earliest":         {},
+
+	// Django Meta options — inner-class attribute names. They land at
+	// the resolver as bare names when assignment-style declarations
+	// `verbose_name = "..."` are reified by the extractor as USES
+	// edges, and when `class Meta:` is referenced as a bare class.
+	"Meta":                {},
+	"verbose_name":        {},
+	"verbose_name_plural": {},
+	"ordering":            {},
+	"unique_together":     {},
+	"index_together":      {},
+	"validators":          {},
+
+	// Django REST Framework — serializer base classes and generic
+	// view / viewset classes. `Response` is in stdlibBareNames
+	// (global) and is not duplicated here.
+	"ModelSerializer":              {},
+	"Serializer":                   {},
+	"ListAPIView":                  {},
+	"RetrieveAPIView":              {},
+	"CreateAPIView":                {},
+	"UpdateAPIView":                {},
+	"DestroyAPIView":               {},
+	"ListCreateAPIView":            {},
+	"RetrieveUpdateDestroyAPIView": {},
+	"ModelViewSet":                 {},
+	"ReadOnlyModelViewSet":         {},
+
+	// DRF view / viewset attribute names + decorator + status module
+	// leaf. `status` is the `rest_framework.status` module reference
+	// (receiver-stripped from `status.HTTP_200_OK`) and `action` is
+	// the `@action` decorator imported from `rest_framework.decorators`.
+	"status":                 {},
+	"action":                 {},
+	"permission_classes":     {},
+	"authentication_classes": {},
+	"serializer_class":       {},
+	"queryset":               {},
+
+	// DRF permission classes (used as bare class refs in
+	// `permission_classes = [IsAuthenticated, ...]`).
+	"IsAuthenticated":           {},
+	"IsAdminUser":               {},
+	"AllowAny":                  {},
+	"IsAuthenticatedOrReadOnly": {},
+
+	// Django admin DSL. `register` / `unregister` are the
+	// `admin.site.register(Model, Admin)` helpers receiver-stripped
+	// to bare names; `site` is the bare `admin.site` reference.
+	// The remaining names are `ModelAdmin` subclass attribute
+	// declarations (`list_display = (...)`).
+	"register":        {},
+	"unregister":      {},
+	"site":            {},
+	"list_display":    {},
+	"list_filter":     {},
+	"search_fields":   {},
+	"readonly_fields": {},
+	"fieldsets":       {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1484,7 +1484,10 @@ func TestJavaBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 	// `count` deliberately omitted: it's also in rustBareNames so
 	// it classifies under lang="rust"; the gate verified here is
 	// the *Java* gate, not absence-from-all-other-language-gates.
-	names := []string{"save", "orElse", "hasNext", "findById", "findAll", "hasErrors", "IllegalArgumentException"}
+	// `save` deliberately omitted post-#447: it's also in
+	// pythonBareNames (Django ORM `save()`) and classifies under
+	// lang="python".
+	names := []string{"orElse", "hasNext", "findById", "findAll", "hasErrors", "IllegalArgumentException"}
 	otherLangs := []string{"go", "python", "javascript", "rust", ""}
 	for _, name := range names {
 		for _, lang := range otherLangs {
@@ -2087,7 +2090,9 @@ func TestCSharpAspNetCoreDSLBareNames_NotClassifiedForOtherLanguages(t *testing.
 		"ToArrayAsync", "ThenInclude", "AsNoTracking", "AsQueryable",
 		"SaveChangesAsync", "AddRange", "RemoveRange", "FindAsync",
 		"GetRequiredService", "BuildServiceProvider", "HasClaim",
-		"IsAuthenticated",
+		// `IsAuthenticated` deliberately omitted post-#447: it's also
+		// in pythonBareNames (DRF permission class) and classifies
+		// under lang="python".
 	}
 	otherLangs := []string{"go", "python", "javascript", "ruby", "rust", "java", "kotlin", "swift", ""}
 	for _, name := range names {
@@ -2229,7 +2234,11 @@ func TestRubyBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 		// `all` builtin, Ktor `attributes` accessor in Kotlin per
 		// #435) and the non-leak guarantee for Ruby-only AR names is
 		// asserted by the remaining names below.
-		"update", "destroy", "valid?", "create", "build", "first", "last",
+		// `update`/`create` deliberately omitted post-#447: both are
+		// in pythonBareNames (Django ORM verbs) and classify under
+		// lang="python"; the Ruby-only-leak property is asserted by
+		// the remaining AR names below.
+		"destroy", "valid?", "build", "first", "last",
 		"reload", "exists?", "persisted?", "new_record?",
 		"find_or_create_by", "valid_password?",
 	}
@@ -3213,6 +3222,196 @@ func TestPHPBareNames_UnknownPHPMethodFallsThrough(t *testing.T) {
 		}},
 		Relationships: []graph.Relationship{
 			{ID: "rel-1", FromID: "php-src", ToID: name, Kind: "CALLS"},
+		},
+	}
+	stats := Synthesize(doc)
+	if stats.Synthesized != 0 {
+		t.Fatalf("Synthesize(%q): synthesized=%d, want 0 (unknown user fn)", name, stats.Synthesized)
+	}
+	if doc.Relationships[0].ToID != name {
+		t.Fatalf("ToID=%q, want %q (unknown name must not be rewritten)",
+			doc.Relationships[0].ToID, name)
+	}
+}
+
+// TestPythonDjangoDRFDSLBareNames_ClassifiedWhenLangIsPython covers
+// issue #447: Django ORM model fields (`CharField`, `ForeignKey`,
+// `ManyToManyField`, ...), QuerySet / manager verbs (`objects`,
+// `get_or_create`, `select_related`, `bulk_create`, ...), Meta
+// options (`verbose_name`, `unique_together`, ...), Django REST
+// Framework view / serializer / permission classes
+// (`ModelSerializer`, `ListAPIView`, `ModelViewSet`,
+// `IsAuthenticated`, ...) and Django admin DSL helpers (`register`,
+// `list_display`, ...) get receiver-stripped (or arrive bare) and
+// land in bug-extractor. These names must classify as stdlib
+// bare-names — but only when the source entity's language is
+// "python". Mirrors the PHP Laravel/Symfony (#439) precedent.
+func TestPythonDjangoDRFDSLBareNames_ClassifiedWhenLangIsPython(t *testing.T) {
+	names := []string{
+		// Django ORM field types.
+		"CharField", "IntegerField", "BooleanField", "DateTimeField",
+		"DateField", "TextField", "ForeignKey", "OneToOneField",
+		"ManyToManyField", "URLField", "EmailField", "SlugField",
+		"DecimalField", "FloatField", "BinaryField", "JSONField",
+		"FileField", "ImageField",
+		// Django ORM manager / QuerySet API.
+		"objects", "exclude", "get", "get_or_create", "update_or_create",
+		"create", "save", "delete", "update", "select_related",
+		"prefetch_related", "values", "values_list", "annotate",
+		"aggregate", "count", "exists", "bulk_create", "bulk_update",
+		"latest", "earliest",
+		// Django Meta options.
+		"Meta", "verbose_name", "verbose_name_plural", "ordering",
+		"unique_together", "index_together", "validators",
+		// DRF serializer / view / viewset classes.
+		"ModelSerializer", "Serializer", "ListAPIView", "RetrieveAPIView",
+		"CreateAPIView", "UpdateAPIView", "DestroyAPIView",
+		"ListCreateAPIView", "RetrieveUpdateDestroyAPIView",
+		"ModelViewSet", "ReadOnlyModelViewSet",
+		// DRF view attributes + decorator + status module leaf.
+		"status", "action", "permission_classes",
+		"authentication_classes", "serializer_class", "queryset",
+		// DRF permission classes.
+		"IsAuthenticated", "IsAdminUser", "AllowAny",
+		"IsAuthenticatedOrReadOnly",
+		// Django admin DSL.
+		"register", "unregister", "site", "list_display", "list_filter",
+		"search_fields", "readonly_fields", "fieldsets",
+	}
+	for _, name := range names {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			subtype, ok := stdlibFunction(name, "python", "", nil)
+			if !ok {
+				t.Fatalf("stdlibFunction(%q, \"python\", nil) = (_, false); want classified as stdlib bare-name", name)
+			}
+			if subtype != "function" {
+				t.Fatalf("stdlibFunction(%q, \"python\", nil) subtype=%q, want %q", name, subtype, "function")
+			}
+			doc := &graph.Document{
+				Entities: []graph.Entity{{
+					ID:       "py-src",
+					Name:     "caller",
+					Kind:     "function",
+					Language: "python",
+				}},
+				Relationships: []graph.Relationship{
+					{ID: "rel-1", FromID: "py-src", ToID: name, Kind: "CALLS"},
+				},
+			}
+			stats := Synthesize(doc)
+			if stats.Synthesized != 1 {
+				t.Fatalf("Synthesize(%q): synthesized=%d, want 1", name, stats.Synthesized)
+			}
+			want := "ext:" + name
+			if doc.Relationships[0].ToID != want {
+				t.Fatalf("ToID=%q, want %q", doc.Relationships[0].ToID, want)
+			}
+		})
+	}
+}
+
+// TestPythonDjangoDRFDSLBareNames_NotClassifiedForOtherLanguages
+// confirms the Python language gate holds for the issue #447
+// additions: Django / DRF / admin DSL names must NOT be rewritten
+// when the source entity's language is anything other than "python".
+// A Go method named `save`, a JS method named `update`, a Ruby
+// `register`, etc. must not be shadowed by the Python gate.
+func TestPythonDjangoDRFDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
+	// Selection rule: each name MUST be unique to pythonBareNames
+	// (not in stdlibBareNames, phpBareNames or any other language
+	// map), otherwise the cross-language gate test would trip on a
+	// different language's allowlist firing first. Picks span
+	// Django ORM, Meta, DRF, and admin.
+	names := []string{
+		// Django ORM field types (Pascal-case, no collisions).
+		"CharField", "ForeignKey", "ManyToManyField", "OneToOneField",
+		"DateTimeField", "JSONField", "ImageField",
+		// QuerySet verbs unique to Python (snake_case).
+		"get_or_create", "update_or_create", "select_related",
+		"prefetch_related", "values_list", "bulk_create", "bulk_update",
+		// Meta options.
+		"verbose_name", "verbose_name_plural", "unique_together",
+		"index_together",
+		// DRF view / serializer classes.
+		"ModelSerializer", "ListAPIView", "RetrieveAPIView",
+		"CreateAPIView", "ModelViewSet", "ReadOnlyModelViewSet",
+		"RetrieveUpdateDestroyAPIView",
+		// DRF view attributes (snake_case, Python-only).
+		"permission_classes", "authentication_classes",
+		"serializer_class",
+		// DRF permission classes. `IsAuthenticated` collides with
+		// csharpBareNames (ASP.NET Core) and would trip the cross-
+		// lang gate via the C# allowlist, so it is excluded here.
+		"IsAdminUser", "IsAuthenticatedOrReadOnly",
+		// Django admin attributes.
+		"list_display", "list_filter", "search_fields",
+		"readonly_fields", "fieldsets",
+	}
+	otherLangs := []string{"go", "php", "javascript", "ruby", "rust", "java", "kotlin", "swift", "csharp", ""}
+	for _, name := range names {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, lang, "", nil); ok {
+					t.Fatalf("stdlibFunction(%q, %q, nil) classified; want fall-through "+
+						"(name is gated to lang=\"python\" only)", name, lang)
+				}
+				doc := &graph.Document{
+					Entities: []graph.Entity{{
+						ID:       "src",
+						Name:     "caller",
+						Kind:     "function",
+						Language: lang,
+					}},
+					Relationships: []graph.Relationship{
+						{ID: "rel-1", FromID: "src", ToID: name, Kind: "CALLS"},
+					},
+				}
+				stats := Synthesize(doc)
+				if stats.Synthesized != 0 {
+					t.Fatalf("Synthesize(%q, lang=%q): synthesized=%d, want 0",
+						name, lang, stats.Synthesized)
+				}
+				if doc.Relationships[0].ToID != name {
+					t.Fatalf("ToID=%q, want %q (must not be rewritten for non-Python)",
+						doc.Relationships[0].ToID, name)
+				}
+			})
+		}
+	}
+}
+
+// TestPythonBareNames_NoDuplicatesWithStdlibBareNames confirms that
+// names already classified by the global stdlibBareNames stop-list
+// (`filter`, `Response`) are NOT duplicated in pythonBareNames. The
+// global list fires regardless of language gate, so duplicates are
+// dead entries and a maintenance hazard.
+func TestPythonBareNames_NoDuplicatesWithStdlibBareNames(t *testing.T) {
+	for name := range pythonBareNames {
+		if _, ok := stdlibBareNames[name]; ok {
+			t.Errorf("pythonBareNames[%q] duplicates stdlibBareNames entry; remove from pythonBareNames", name)
+		}
+	}
+}
+
+// TestPythonBareNames_UnknownPythonMethodFallsThrough confirms that a
+// Python-source bare-name call that ISN'T in the pythonBareNames
+// allowlist still falls through normally, so genuine
+// missing-resolution bugs continue to surface in bug-extractor.
+func TestPythonBareNames_UnknownPythonMethodFallsThrough(t *testing.T) {
+	name := "my_custom_business_method" // Not Django/DRF/admin; user-defined.
+	doc := &graph.Document{
+		Entities: []graph.Entity{{
+			ID:       "py-src",
+			Name:     "caller",
+			Kind:     "function",
+			Language: "python",
+		}},
+		Relationships: []graph.Relationship{
+			{ID: "rel-1", FromID: "py-src", ToID: name, Kind: "CALLS"},
 		},
 	}
 	stats := Synthesize(doc)


### PR DESCRIPTION
## Summary
- Adds `pythonBareNames` map (Python-language-gated stop-list) and wires it into `stdlibFunction` alongside the existing per-language gates.
- Covers the issue #447 residual surface in `python/django-realworld`: Django ORM model fields + manager/QuerySet API + Meta options, Django REST Framework view/serializer/viewset/permission classes + view attributes, and Django admin DSL helpers.
- Excludes `filter` and `Response` (already in global `stdlibBareNames`) to avoid duplicate dead entries.
- Same safer-bias rule as the PHP (#439), Kotlin Ktor (#435), and Swift Vapor (#436) precedents: names gated to `lang=="python"` only, so a Go `save`, a JS `update`, a Ruby `register`, etc. are not shadowed.
- Updates the cross-language gate tests for Java (#107/#120), C# (#441), and Ruby (#124) to exclude `save` / `IsAuthenticated` / `create`+`update` respectively — those names now also classify under `lang="python"`, mirroring the existing precedent comments (e.g. Java already excluded `count` because Rust classifies it).

## VERIFY-2 result — `python/django-realworld`
- Before: `bug_rate = 19.06%`, `resolution_rate = 39.72%`, 34 external synth.
- After:  `bug_rate = 14.34%`, `resolution_rate = 39.72%`, 41 external synth.
- Delta: `bug_rate -4.72 pp` (drops below the 15% bar from the spec), `resolution_rate unchanged` (expected — the rewrite moves endpoints from `bug-extractor` to `external-known`, not to `resolved`).

## Test plan
- [x] `go test ./internal/external/ -count=1` (passes, includes 4 new tests: positive classification, cross-language gate negative, no-duplicates-with-stdlib invariant, unknown-Python-fall-through)
- [x] `go test ./... -count=1` (full suite green after updating the Java / C# / Ruby cross-language gate tests)
- [x] VERIFY-2 on `python/django-realworld` (before/after numbers above)

🤖 Generated with [Claude Code](https://claude.com/claude-code)