### PR TITLE
fix(synth): Python stdlib + typing bare-name allowlist extension (Closes #455)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -3208,6 +3208,212 @@ var pythonBareNames = map[string]struct{}{
 	"search_fields":   {},
 	"readonly_fields": {},
 	"fieldsets":       {},
+
+	// Issue #455 — Python stdlib + typing + framework DSL extension.
+	// Pulled from real bug-extractor samples on click / flask /
+	// flask-realworld (residuals after #420 / #423 / #446 / #447 were
+	// 10–17%). All names below arrive at the resolver as bare
+	// identifiers after the Python extractor strips the receiver from
+	// attribute calls (`typing.cast(...)` → `cast`, `Path(...)` from
+	// `from pathlib import Path` → `Path`, `pytest.raises(...)` →
+	// `raises`, `app.route(...)` → `route`). Gated to lang=="python"
+	// so a same-named user method in JS / Go / Ruby / etc. is not
+	// shadowed (safer-bias rule #94). Names that already classify via
+	// the global stdlibBareNames stop-list are NOT duplicated.
+	//
+	// Conservative selection rule: include names that are clearly
+	// stdlib / well-known-package helpers in Python idiom. Excluded
+	// even though present in samples: `write`, `read`, `close`,
+	// `append`, `pop`, `keys`, `items`, `update`, `extend`, `remove`,
+	// `replace`, `split`, `format`, `match`, `search`, `info`,
+	// `debug`, `warning`, `error`, `warn`, `first`, `commit`, `run`,
+	// `send`, `connect`, `execute`, `cls`, `func`, `f` — they collide
+	// trivially with user-method identifiers, and the safer-bias rule
+	// from #94 makes a missed external strictly better than a
+	// synthesised placeholder shadowing a real user method. Reflection
+	// builtins (`getattr` / `setattr` / `hasattr` / `delattr`) are
+	// likewise excluded — they are dynamic-dispatch primitives, not
+	// external imports, and are tagged DispositionDynamic upstream.
+
+	// typing module — generic / annotation primitives. `Iterator` and
+	// `Any` collide with rustBareNames and goChiRouterNames (which is
+	// fine — the cross-language gate test below excludes them) and
+	// are still included here so Python sources classify correctly.
+	"cast":       {},
+	"Optional":   {},
+	"Union":      {},
+	"Callable":   {},
+	"Iterable":   {},
+	"Iterator":   {},
+	"Generator":  {},
+	"TypeVar":    {},
+	"Generic":    {},
+	"Protocol":   {},
+	"Awaitable":  {},
+	"Sequence":   {},
+	"Mapping":    {},
+	"Annotated":  {},
+	"Literal":    {},
+	"Final":      {},
+	"ClassVar":   {},
+	"NewType":    {},
+	"NamedTuple": {},
+	"TypedDict":  {},
+	"overload":   {},
+	// `List`, `Dict`, `Tuple`, `Type`, `Set` are intentionally NOT
+	// added — they are also the Python builtins (already classified
+	// via stdlibBareNames as `list`/`dict`/`tuple`/`type`/`set`) and
+	// adding the PascalCase typing aliases would conflict with the
+	// `NoDuplicatesWithStdlibBareNames` invariant only if we cased
+	// them identically; we omit them to keep the list narrow.
+
+	// functools / itertools — closure + iteration helpers. `chain`
+	// collides with rustBareNames; cross-lang gate excludes it.
+	"update_wrapper":  {},
+	"partial":         {},
+	"wraps":           {},
+	"lru_cache":       {},
+	"cache":           {},
+	"cached_property": {},
+	"reduce":          {},
+	"chain":           {},
+	"islice":          {},
+	"cycle":           {},
+	"tee":             {},
+	"starmap":         {},
+	"takewhile":       {},
+	"dropwhile":       {},
+	"groupby":         {},
+	"product":         {},
+	"permutations":    {},
+	"combinations":    {},
+
+	// inspect / textwrap — introspection + doc helpers.
+	"cleandoc":   {},
+	"getsource":  {},
+	"signature":  {},
+	"isfunction": {},
+	"isclass":    {},
+	"ismethod":   {},
+	"getmembers": {},
+	"dedent":     {},
+	"indent":     {},
+
+	// pytest test-DSL — `raises`, `fixture`, `mark`, `parametrize`,
+	// `monkeypatch`, `xfail` are Python testing idioms; receiver-
+	// stripped from `pytest.raises(...)` / `@pytest.mark.parametrize`
+	// / `monkeypatch.setattr(...)`. High volume in flask + click test
+	// suites; safer than `skip` (too generic) so `skip` is excluded.
+	"raises":       {},
+	"fixture":      {},
+	"mark":         {},
+	"parametrize":  {},
+	"monkeypatch":  {},
+	"xfail":        {},
+
+	// dataclasses — `dataclass` decorator + accessor helpers.
+	// `replace` excluded as too collision-prone (str.replace,
+	// list.replace, user replace methods).
+	"dataclass":    {},
+	"field":        {},
+	"fields":       {},
+	"asdict":       {},
+	"astuple":      {},
+	"is_dataclass": {},
+
+	// pathlib — `Path` collides with rustBareNames; cross-lang gate
+	// excludes it.
+	"Path":            {},
+	"PurePath":        {},
+	"PurePosixPath":   {},
+	"PureWindowsPath": {},
+
+	// os / os.path / io stdlib helpers. `getcwd` / `listdir` /
+	// `makedirs` already classify via stdlibBareNames and are NOT
+	// duplicated. `path` excluded as too generic.
+	"dirname":               {},
+	"basename":              {},
+	"abspath":               {},
+	"realpath":              {},
+	"expanduser":            {},
+	"expandvars":            {},
+	"splitext":              {},
+	"fspath":                {},
+	"fileno":                {},
+	"mkdir":                 {},
+	"getfilesystemencoding": {},
+
+	// io / pytest capture helpers — `getvalue` is StringIO/BytesIO,
+	// `readouterr` is pytest capsys. Both unambiguous Python idioms.
+	"getvalue":   {},
+	"readouterr": {},
+
+	// logging — conservative pair only. `getLogger` + `basicConfig`
+	// are unambiguous logging-module helpers; `info` / `debug` /
+	// `warning` / `error` / `warn` are deliberately EXCLUDED because
+	// they collide trivially with user field/method names.
+	"getLogger":   {},
+	"basicConfig": {},
+
+	// Flask routing / app / request-context DSL. Receiver-stripped
+	// from `app.route(...)` / `app.register_blueprint(...)` /
+	// `current_app._get_current_object()`. `route` / `redirect` /
+	// `flash` collide with other language maps (rust/swift/php/java/
+	// kotlin); cross-lang gate excludes them. `query` collides with
+	// swiftBareNames; cross-lang gate excludes it (kept for SQLA).
+	"route":                        {},
+	"register_blueprint":           {},
+	"add_url_rule":                 {},
+	"errorhandler":                 {},
+	"as_view":                      {},
+	"app_context":                  {},
+	"test_request_context":         {},
+	"test_client":                  {},
+	"test_cli_runner":              {},
+	"url_for":                      {},
+	"jsonify":                      {},
+	"init_app":                     {},
+	"Markup":                       {},
+	"_get_current_object":          {},
+	"app_template_filter":          {},
+	"app_template_test":            {},
+	"add_template_filter":          {},
+	"add_template_test":            {},
+	"template_global":              {},
+	"template_filter":              {},
+	"template_test":                {},
+	"make_response":                {},
+	"redirect":                     {},
+	"send_file":                    {},
+	"send_from_directory":          {},
+	"abort":                        {},
+	"flash":                        {},
+	"stream_with_context":          {},
+	"copy_current_request_context": {},
+
+	// Click CLI test-runner + DSL. `invoke` dominates the click
+	// bug-extractor sample (~300 hits) from `runner.invoke(cli, ...)`
+	// in click's own test suite. Gating to lang=="python" + the
+	// Python idiom dominance keeps the collision risk acceptable
+	// (the safer-bias trade-off from #94).
+	"invoke":               {},
+	"isolated_filesystem":  {},
+	"get_help_record":      {},
+	"get_help_extra":       {},
+	"make_context":         {},
+	"get_parameter_source": {},
+	"call_on_close":        {},
+	"lookup_default":       {},
+	"get_default":          {},
+
+	// SQLAlchemy ORM — `filter_by` / `create_all` / `drop_all` /
+	// `query` are unambiguous SQLAlchemy idioms receiver-stripped
+	// from `Model.query.filter_by(...)` / `db.create_all()`. `first`
+	// / `commit` / `rollback` / `add` excluded as too generic.
+	"filter_by":  {},
+	"create_all": {},
+	"drop_all":   {},
+	"query":      {},
 }
 
 // isKnownExternalPackage reports whether s matches our small allowlist

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1926,9 +1926,11 @@ func TestSwiftVaporDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 	// trip on a different language's allowlist firing first.
 	// `body` and `register` removed — now also classified by
 	// rustBareNames (Actix-web DSL, #440).
+	// `query` and `redirect` removed — now also classified by
+	// pythonBareNames (SQLAlchemy / Flask DSL, #455).
 	names := []string{
-		"query", "auth", "session", "cookies",
-		"boot", "shutdown", "grouped", "redirect",
+		"auth", "session", "cookies",
+		"boot", "shutdown", "grouped",
 		"render", "middleware", "authorize", "protect",
 		"paginate", "transform", "flatMap", "offset",
 	}
@@ -3404,6 +3406,49 @@ func TestPythonDjangoDRFDSLBareNames_ClassifiedWhenLangIsPython(t *testing.T) {
 		// Django admin DSL.
 		"register", "unregister", "site", "list_display", "list_filter",
 		"search_fields", "readonly_fields", "fieldsets",
+		// Issue #455 additions — typing.
+		"cast", "Optional", "Union", "Callable", "Iterable", "Iterator",
+		"Generator", "TypeVar", "Generic", "Protocol", "Awaitable",
+		"Sequence", "Mapping", "Annotated", "Literal", "Final",
+		"ClassVar", "NewType", "NamedTuple", "TypedDict", "overload",
+		// functools / itertools.
+		"update_wrapper", "partial", "wraps", "lru_cache", "cache",
+		"cached_property", "reduce", "chain", "islice", "cycle", "tee",
+		"starmap", "takewhile", "dropwhile", "groupby", "product",
+		"permutations", "combinations",
+		// inspect / textwrap.
+		"cleandoc", "getsource", "signature", "isfunction", "isclass",
+		"ismethod", "getmembers", "dedent", "indent",
+		// pytest.
+		"raises", "fixture", "mark", "parametrize", "monkeypatch",
+		"xfail",
+		// dataclasses.
+		"dataclass", "field", "fields", "asdict", "astuple",
+		"is_dataclass",
+		// pathlib.
+		"Path", "PurePath", "PurePosixPath", "PureWindowsPath",
+		// os / os.path / io.
+		"dirname", "basename", "abspath", "realpath", "expanduser",
+		"expandvars", "splitext", "fspath", "fileno", "mkdir",
+		"getfilesystemencoding",
+		"getvalue", "readouterr",
+		// logging.
+		"getLogger", "basicConfig",
+		// Flask DSL.
+		"route", "register_blueprint", "add_url_rule", "errorhandler",
+		"as_view", "app_context", "test_request_context", "test_client",
+		"test_cli_runner", "url_for", "jsonify", "init_app", "Markup",
+		"_get_current_object", "app_template_filter", "app_template_test",
+		"add_template_filter", "add_template_test", "template_global",
+		"template_filter", "template_test", "make_response", "redirect",
+		"send_file", "send_from_directory", "abort", "flash",
+		"stream_with_context", "copy_current_request_context",
+		// Click DSL.
+		"invoke", "isolated_filesystem", "get_help_record",
+		"get_help_extra", "make_context", "get_parameter_source",
+		"call_on_close", "lookup_default", "get_default",
+		// SQLAlchemy.
+		"filter_by", "create_all", "drop_all", "query",
 	}
 	for _, name := range names {
 		name := name
@@ -3475,6 +3520,52 @@ func TestPythonDjangoDRFDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T
 		// Django admin attributes.
 		"list_display", "list_filter", "search_fields",
 		"readonly_fields", "fieldsets",
+		// Issue #455 — Python-only typing primitives (collision-free
+		// across other-language maps). `Iterator`, `Any` are in
+		// pythonBareNames but ALSO in rustBareNames /
+		// goChiRouterNames respectively and are intentionally
+		// excluded from this cross-lang gate (they classify under the
+		// other language's allowlist, which is correct for that
+		// language's source).
+		"Optional", "Union", "Callable", "Iterable", "Generator",
+		"TypeVar", "Awaitable", "Sequence", "Mapping", "Annotated",
+		"Literal", "ClassVar", "NewType", "NamedTuple", "TypedDict",
+		"overload",
+		// functools / itertools — `chain` excluded (rust collision).
+		"update_wrapper", "wraps", "lru_cache", "cached_property",
+		"islice", "starmap", "takewhile", "dropwhile", "groupby",
+		"permutations", "combinations",
+		// inspect / textwrap.
+		"cleandoc", "getsource", "isfunction", "isclass", "ismethod",
+		"getmembers", "dedent",
+		// pytest.
+		"raises", "parametrize", "monkeypatch", "xfail",
+		// dataclasses.
+		"dataclass", "asdict", "astuple", "is_dataclass",
+		// pathlib — `Path` excluded (rust collision).
+		"PurePath", "PurePosixPath", "PureWindowsPath",
+		// os / os.path / io.
+		"dirname", "basename", "abspath", "realpath", "expanduser",
+		"expandvars", "splitext", "fspath", "fileno", "mkdir",
+		"getfilesystemencoding", "getvalue", "readouterr",
+		// logging.
+		"getLogger", "basicConfig",
+		// Flask DSL — `route`, `redirect`, `flash` excluded
+		// (rust/swift/php/java/kotlin collisions).
+		"register_blueprint", "add_url_rule", "errorhandler", "as_view",
+		"app_context", "test_request_context", "test_client",
+		"test_cli_runner", "url_for", "jsonify", "init_app", "Markup",
+		"_get_current_object", "app_template_filter", "app_template_test",
+		"add_template_filter", "add_template_test", "template_global",
+		"template_filter", "template_test", "make_response", "send_file",
+		"send_from_directory", "stream_with_context",
+		"copy_current_request_context",
+		// Click DSL.
+		"isolated_filesystem", "get_help_record", "get_help_extra",
+		"make_context", "get_parameter_source", "call_on_close",
+		"lookup_default", "get_default",
+		// SQLAlchemy — `query` excluded (swift collision).
+		"filter_by", "create_all", "drop_all",
 	}
 	otherLangs := []string{"go", "php", "javascript", "ruby", "rust", "java", "kotlin", "swift", "csharp", ""}
 	for _, name := range names {


### PR DESCRIPTION
## Summary
- Extends \`pythonBareNames\` (lang=\"python\" gated, #94 safer-bias) with Python stdlib + typing + functools/itertools + inspect + pytest + dataclasses + pathlib + os.path + logging + Flask DSL + Click DSL + SQLAlchemy bare names pulled from real bug-extractor samples on click / flask / flask-realworld.
- Drops residual bug-extractor on the three target repos by 1.6–3.3 percentage points (see deltas below).
- Excludes generic/collision-prone names (\`write\`, \`read\`, \`append\`, \`pop\`, \`keys\`, \`items\`, \`update\`, \`first\`, \`commit\`, \`run\`, \`send\`, \`info\`, \`debug\`, \`warning\`, ...) and reflection builtins (\`getattr\`/\`setattr\`/\`hasattr\`/\`delattr\`, which are tagged DispositionDynamic upstream).
- Adjusts \`TestSwiftVaporDSLBareNames_NotClassifiedForOtherLanguages\` to drop \`query\` and \`redirect\` from its cross-lang gate sample (now also classified by pythonBareNames).

## VERIFY-2 single-repo deltas (bug_rate)
| repo | before | after | delta |
| --- | ---: | ---: | ---: |
| click | 10.3813% | 7.1101% | -3.27 pp |
| flask | 16.8800% | 14.1906% | -2.69 pp |
| flask-realworld | 16.7024% | 15.0964% | -1.61 pp |

Resolution rate unchanged on all three (newly-classified endpoints move from bug-extractor to external-unknown / external-known, as designed for stop-list additions).

## Test plan
- [x] \`go test ./...\` — full suite green
- [x] \`TestPythonDjangoDRFDSLBareNames_ClassifiedWhenLangIsPython\` covers every new entry
- [x] \`TestPythonDjangoDRFDSLBareNames_NotClassifiedForOtherLanguages\` covers collision-free additions across go/php/js/ruby/rust/java/kotlin/swift/csharp/\"\"; cross-collision names (\`Iterator\`, \`Any\`, \`chain\`, \`Path\`, \`route\`, \`redirect\`, \`flash\`, \`query\`) are intentionally excluded from this cross-lang sample because they classify under another language's allowlist
- [x] \`TestPythonBareNames_NoDuplicatesWithStdlibBareNames\` invariant holds
- [x] \`TestSwiftVaporDSLBareNames_NotClassifiedForOtherLanguages\` updated for \`query\`/\`redirect\` overlap
- [x] VERIFY-2 single-repo on click / flask / flask-realworld measured before/after

Closes #455.
Parallel sibling: #456 (no expected conflict — different language gate).