### PR TITLE
chore(verify2): curate corpus to 114 ship-gate + 168 extended tier

### DIFF
--- a/docs/verify2/README.md
+++ b/docs/verify2/README.md
@@ -1,0 +1,89 @@
+# VERIFY-2 corpus harness
+
+Two sibling scripts run the bug-rate / resolution-rate measurement
+harness against a curated corpus of public OSS repositories.
+
+| script | entries | when to run | purpose |
+| --- | ---: | --- | --- |
+| `scripts/verify2/run.sh` | 114 | every change, CI ship-gate, nightly baseline | tier-1 — fast, covers the full 32-language extractor matrix without intra-family redundancy |
+| `scripts/verify2/run-extended.sh` | 168 | pre-release, weekly cron | tier-2 — exhaustive, picks up framework-specific surfaces (Quarkus annotations, NgRx dispatchers, Liquibase XML changelogs, etc.) |
+
+Both scripts share identical harness logic — clone-or-update,
+sparse-checkout for monorepos, per-repo wall-clock cap, JSON-stats
+aggregation, per-language bucketing, ship-gate check. They differ
+only in the `REPOS` array.
+
+## Rationale (2026-05-19 curation)
+
+The previous combined manifest contained 283 entries (282 unique;
+one duplicate name). Curation against `internal/extractors/`
+demonstrated that the majority of entries were intra-family
+redundancies — e.g. eight TypeScript state-management libraries
+all exercising the same decorator + store-creation surface already
+covered by `nestjs`, `nextjs-commerce`, `angular-realworld`, and
+`sveltekit`.
+
+The split applied here:
+
+- **Single-source MUST-KEEP** — 22 entries that are the only corpus
+  exercising their extractor or DSL (razor, fish, just, zig, lua,
+  proto, graphql, notebook, sql_dbt, bicep, starlark, java_bpmn,
+  smithy, avro, thrift, json-schema, asyncapi, raml, api-blueprint,
+  nginx-conf, apache-httpd-conf, caddyfile, traefik-dynamic,
+  kong-declarative, envoy-yaml, haproxy-cfg, selenium multi).
+- **Language primary realworld apps** — one canonical realworld app
+  per language extractor. These cover the framework + ORM + manifest
+  + CI surface for their stack.
+- **Secondary distinctive coverage** — one entry per ORM / message
+  broker / IaC family / NoSQL ecosystem / IDL alternative not
+  already covered by a primary.
+
+Entries dropped from tier-1 fall into one of three categories:
+
+1. **Framework alternates** (29 → 6 web frameworks): `axum` / `rocket`
+   / `warp` / `tide` (rust) all exercise the same router-macro
+   surface, so one Actix + one Axum suffice. Same collapse for
+   Go alternates (`echox`, `gofiber`, `beego`) and Python
+   alternates (`tornado`, `starlette`, `pyramid`, `bottle`).
+2. **State management** (8 → 1): redux/mobx/zustand/pinia/ngrx/
+   recoil/effector all single-language TS libraries; covered
+   incidentally by realworld apps. Keep `xstate` for the
+   distinctive statechart DSL.
+3. **CDK/Pulumi multi-flavor sprawl** (9 → 2): per-language CDK
+   variants test the per-language extractor, which is *already*
+   exercised by a realworld app in that language. Keep one CDK
+   (TypeScript) + one Pulumi (Go).
+
+Plus the `esp-idf` entry (a pure-C corpus) was dropped from both
+tiers — archigraph has no `c` extractor (only `cpp`, already
+covered by `spdlog`). It would index zero files.
+
+See `corpus-curation-2026-05-19.md` in this directory for the full
+per-entry decision log (283 entries, each tagged KEEP-primary,
+KEEP-secondary, or DROP with rationale).
+
+## Per-run scratch dir behaviour
+
+Per-repo JSON stats are written under
+`$ARCHIGRAPH_CORPORA_DIR/_reports/<timestamp>-partial/` rather than
+into `mktemp -d`. The `EXIT` trap only deletes that directory if
+a `.complete` sentinel file exists, which the final aggregation
+step writes on success. Aborts (SIGKILL, timeout, etc.) therefore
+preserve the per-repo JSON so a partial run can be inspected or
+resumed by hand. Operators should `rm -rf` stale `*-partial/`
+directories during regular housekeeping.
+
+## Hard rules
+
+- Neither script writes inside the archigraph repo. Corpora and
+  reports live under `$ARCHIGRAPH_CORPORA_DIR` (default:
+  `$HOME/Documents/Projects/archigraph-corpora`).
+- The on-disk corpora directory is not pruned by these scripts.
+  Entries removed from a `REPOS` array are simply ignored at run
+  time; their clone remains on disk for reference until an operator
+  cleans it up.
+- The harness logic is intentionally duplicated across the two
+  scripts (rather than extracted to a shared library) because the
+  duplication is small, the call site is one per script, and a
+  shared library would force both scripts to track the same
+  version of the harness in lockstep.

--- a/docs/verify2/corpus-curation-2026-05-19.md
+++ b/docs/verify2/corpus-curation-2026-05-19.md
@@ -1,0 +1,822 @@
+# VERIFY-2 corpus curation proposal
+
+**Date:** 2026-05-19
+**Source manifest:** `scripts/verify2/run.sh` (REPOS array lines 46–520)
+**Source entries:** 283 (manifest header says ~289 — close enough; 6 entries
+were dropped/dedup-noted in line comments)
+**Target:** smallest set that preserves full extractor + framework + ORM +
+manifest + CI/CD + IaC surface coverage measured against `internal/extractors/`.
+
+---
+
+## 1. Summary
+
+| | count |
+| --- | ---: |
+| Current REPOS array entries | 283 |
+| Proposed KEEP-primary | 47 |
+| Proposed KEEP-secondary | 25 |
+| **Proposed total** | **72** |
+| Dropped (redundant) | 211 |
+| Reduction | **−74.6%** |
+
+The proposed 72-entry corpus preserves coverage of every language extractor
+in `internal/extractors/` (32 directories), every ORM/framework family
+currently exercised, every CI/CD format, every IaC family, every NoSQL
+client ecosystem, and every API/IDL alternative. The only material thinning
+is in *intra-family redundancy* (e.g. 8 state-management libs collapsed to
+2; 12 web-framework alternates per language collapsed to 2 per language; 5
+CDK flavors collapsed to 2).
+
+### Top 3 most-redundant categories eliminated
+
+1. **Web-framework alts (chunk J, 29 entries → 6 kept)** — `axum`/`rocket`/
+   `warp`/`tide` all exercise the same Rust extractor + macro-attribute
+   patterns; one representative suffices once `actix-examples` is in. Same
+   for the 4 Go alternates (echox/fiber/beego in addition to gin/chi),
+   the 4 Python alternates (tornado/starlette/pyramid/bottle on top of
+   flask/django/fastapi), and the PHP/Ruby trios.
+2. **State management (chunk AA, 8 entries → 1 kept)** — redux/mobx/
+   zustand/pinia/ngrx/recoil/xstate/effector are all single-language
+   TypeScript libraries exercising decorator + store-creation patterns
+   already covered by `nestjs`, `angular-realworld`, `nextjs-commerce`,
+   and `sveltekit`. Keep one (xstate, distinctive statechart DSL).
+3. **CDK / Pulumi multi-flavor sprawl (chunk M, 9 entries → 2 kept)** —
+   CDK TS/Py/Java/.NET/Go and Pulumi TS/Py/.NET/Go cover the same
+   programmatic-IaC pattern. Per-language extractor logic is what's being
+   tested, and the per-language extractor is *already* exercised by a
+   realworld app in that language. Keep one CDK (TypeScript, the canonical
+   author audience) + one Pulumi (Go, distinct from CDK's flavor).
+
+### Single-source coverage — MUST keep (no alternative)
+
+These are the only repo in the corpus exercising their respective extractor
+or DSL. Dropping any of them creates a coverage gap.
+
+| extractor / DSL | only-source entry | why no alternative |
+| --- | --- | --- |
+| `extractors/razor` | `aspnetcore-docs-samples` | only `.cshtml`/`.razor` corpus |
+| `extractors/fish` | `tide` (IlanCosman/tide) | only `.fish` corpus |
+| `extractors/just` | `just` (casey/just) | only justfile corpus |
+| `extractors/zig` | `http.zig` | only `.zig` corpus |
+| `extractors/lua` | `kickstart.nvim` | only `.lua` corpus |
+| `extractors/proto` | `grpc-go-examples` | only `.proto` corpus |
+| `extractors/graphql` | `apollo-server` | only `.graphql` SDL corpus |
+| `extractors/dockerfile` | (incidental — covered by many) | n/a |
+| `notebook` extractor | `jupyter-notebook` | only `.ipynb` corpus |
+| `sql_dbt` | `jaffle_shop` | only dbt corpus |
+| `bicep` | `azure-quickstart-templates` | only Bicep corpus |
+| `starlark` | `tilt` | only Starlark corpus (also `bazel` BUILD) |
+| `java_bpmn` | `camunda-bpm-examples` | only BPMN corpus |
+| `smithy` / `avro` / `thrift` / `raml` / `json-schema` / `asyncapi` / `api-blueprint` | one repo each | each IDL is single-source |
+| nginx-conf / apache-httpd-conf / caddyfile / traefik-dynamic / kong-declarative / envoy-yaml / haproxy-cfg | one repo each | each proxy format is single-source |
+| `multi` (Selenium polyglot) | `seleniumhq-examples` | only multi-lang fixture |
+
+That's **22 single-source MUST-KEEP** entries before the language matrix
+even starts.
+
+---
+
+## 2. Coverage matrix — proof of no gaps
+
+### 2a. Language-extractor matrix (32 dirs in `internal/extractors/`)
+
+| extractor dir | covered by (primary) | also incidentally |
+| --- | --- | --- |
+| clojure | usermanager-example | leiningen (sec) |
+| cpp | spdlog | UnrealEnginePython, cmake |
+| csharp | aspnetcore-realworld | EntityComponentSystemSamples, maui-samples |
+| css | nextjs-commerce, sveltekit | every frontend |
+| dart | flutter-samples | dart-samples (drop) |
+| dockerfile | spring-petclinic + many | every realworld app |
+| elixir | phoenix-todo-list | phoenix-live-view (sec), elixir |
+| fish | tide (IlanCosman) | — |
+| golang | gin, etcd | every Go realworld |
+| graphql | apollo-server | — |
+| groovy | jenkins | ratpack-example-books (drop), gradle |
+| hcl | terraform-aws-vpc | nomad-pack (sec) |
+| html | every frontend | — |
+| java | spring-petclinic, kafka-streams-examples | quarkus, maven, gradle |
+| javascript | express-realworld, react-redux-realworld | mongoose, jest etc |
+| just | just | — |
+| kotlin | ktor-samples, exposed | compose-samples, http4k (sec) |
+| lua | kickstart.nvim | — |
+| markdown | every README, hugoDocs | docusaurus |
+| php | symfony-demo, laravel-quickstart | composer |
+| proto | grpc-go-examples | — |
+| python | django-realworld, flask-realworld, requests, pandas | many |
+| razor | aspnetcore-docs-samples | — |
+| ruby | rails-realworld, sidekiq | jekyll (sec) |
+| rust | actix-examples, tokio | axum (sec), bevy (sec) |
+| scala | play-scala-starter, spark | http4s (drop), akka-http (drop) |
+| shell | every repo | — |
+| sql | django-realworld, alembic | jaffle_shop |
+| swift | vapor-api-template, sample-food-truck (SwiftUI) | ios-oss |
+| yaml | starter-workflows, argocd-example-apps | every CI repo |
+| zig | http.zig | — |
+| **complexity / cross / references / registry** | exercised by all | n/a (analyzers, not extractors) |
+
+**Result: 32/32 extractor dirs covered.**
+
+### 2b. ORM / query-builder matrix
+
+| ORM | covered by | bucket |
+| --- | --- | --- |
+| Django ORM | django-realworld | KEEP-primary |
+| SQLAlchemy | microblog OR flask-realworld | KEEP-primary (microblog) |
+| ActiveRecord | rails-realworld | KEEP-primary |
+| Eloquent | laravel-quickstart | KEEP-primary |
+| Hibernate / JPA | spring-petclinic (incl Spring Data) | KEEP-primary |
+| jOOQ | joal | KEEP-secondary |
+| MyBatis | jpetstore-6 | KEEP-secondary |
+| Prisma | nestjs-realworld-typeorm covers TS-decorator ORMs | dropped (Prisma not in corpus today either) |
+| TypeORM | nestjs-realworld-typeorm | KEEP-primary |
+| Sequelize | sequelize-express-example | DROP (TypeORM repo covers same TS pattern; if kept → secondary) |
+| Knex | express-bookshelf-realworld | DROP (covered incidentally by knex migration entry) |
+| Bookshelf | express-bookshelf-realworld | DROP |
+| MikroORM | nestjs-realworld-mikroorm | DROP (TypeORM covers decorator pattern) |
+| Ent (Go) | ent | KEEP-secondary |
+| GORM | golang-gin-realworld | KEEP-primary |
+| sqlx | fabric-ca | DROP (GORM covers Go ORM surface) |
+| sqlc | sqlc-examples | KEEP-secondary (codegen pattern is unique) |
+| Diesel (Rust) | actix-diesel-realworld | KEEP-secondary |
+| SeaORM | sea-orm-examples | DROP (Diesel covers Rust ORM) |
+| Exposed (Kotlin) | exposed | KEEP-primary |
+| Dapper | netcore-boilerplate | KEEP-secondary |
+| Sequel (Ruby) | sequel | DROP (Rails covers Ruby SQL; sequel as migration tool only) |
+
+### 2c. Web framework matrix
+
+| stack | kept | notes |
+| --- | --- | --- |
+| Python: Flask, Django, FastAPI | flask-realworld, django-realworld, fastapi-realworld | drop Tornado/Starlette/Pyramid/Bottle (same extractor + decorator surface) |
+| Go: Gin, Chi | gin, chi | drop echox/gofiber/beego/golang-gin-realworld kept for GORM (sec) |
+| JS: Express, NestJS | express-realworld, nestjs-starter, nextjs-commerce | drop fastify/koa/hapi/sails/adonis |
+| TS frameworks | angular-realworld, sveltekit, nextjs-commerce | drop vue/svelte realworld (covered by Pinia + sveltekit), drop solid/preact/ember/qwik/lit/htmx/alpine/gatsby/remix/nuxt/vite/astro |
+| Java: Spring, Kafka | spring-petclinic, kafka-streams-examples | drop quarkus/micronaut/helidon/vertx/dropwizard/play-java/spark-java (all Java framework variants) |
+| Kotlin: Ktor | ktor-samples | drop javalin/http4k (sec — keep http4k for distinctive functional DSL) |
+| Scala: Play, Spark | play-scala-starter, spark | drop akka-http/http4s |
+| PHP: Laravel, Symfony | laravel-quickstart, symfony-demo | drop slim/codeigniter/yii2/lean |
+| Ruby: Rails, Sidekiq | rails-realworld, sidekiq | drop sinatra/hanami/grape |
+| Rust: Actix, Tokio | actix-examples, tokio, mini-redis | drop axum/rocket/warp/tide (Rust router macros same shape) — keep axum (sec) for tower middleware ecosystem |
+| Elixir: Phoenix | phoenix-todo-list, phoenix-live-view | drop plug (covered by phoenix) |
+| C#: ASP.NET | aspnetcore-realworld | drop maui (mobile sec) |
+| Clojure: Ring | usermanager-example | drop compojure/pedestal |
+
+### 2d. CI/CD matrix
+
+| format | kept |
+| --- | --- |
+| GitHub Actions | starter-workflows (PRIMARY) |
+| GitLab CI | gitlab-runner |
+| CircleCI | circleci-demo-python-django |
+| Jenkins (Groovy) | jenkins |
+| Tekton | tektoncd-pipeline |
+| Drone | DROP (yaml step format ≈ argocd already) |
+| Buildkite | DROP (yaml step format ≈ circleci) |
+| Skaffold | DROP (covered by k8s yaml) |
+| Tilt (Starlark) | tilt — MUST keep (only Starlark sample) |
+
+### 2e. IaC matrix
+
+| family | kept | dropped |
+| --- | --- | --- |
+| Terraform | terraform-aws-vpc | — |
+| Nomad/HCL | nomad-pack (sec) | — |
+| K8s YAML | argocd-example-apps | kustomize, awesome-compose (redundant yaml) |
+| Helm | prometheus-helm | — |
+| Ansible | ansible-for-devops | — |
+| Chef / Puppet (Ruby DSL) | DROP both (Ruby DSL covered by rails) | chef-runit, puppet-control-repo |
+| CDK | aws-cdk-examples-typescript | other 4 flavors |
+| Pulumi | pulumi-examples-go | other 3 flavors |
+| Bicep | azure-quickstart-templates | — |
+| CloudFormation | aws-cloudformation-samples | — |
+| SAM | aws-sam-cli-app-templates | — |
+| Serverless Framework | serverless-examples | — |
+| Crossplane | crossplane | — |
+
+### 2f. NoSQL / cache / streaming / message-broker
+
+| ecosystem | kept | dropped |
+| --- | --- | --- |
+| MongoDB | mongoose (Node ODM) + mongo-go-driver (Go) | pymongo, motor, mongo-java-driver |
+| Redis | redis-py (Python sync) + go-redis | ioredis, lettuce |
+| Cassandra | cassandra-java-driver | — |
+| Couchbase | DROP (DynamoDB SDK covers AWS pattern) | couchbase-gocb |
+| DynamoDB / AWS SDK | aws-sdk-go-v2 | aws-sdk-js-v3 (drop) |
+| RabbitMQ | rabbitmq-tutorials | — |
+| NATS | DROP (Kafka covers streaming) | nats.go |
+| Kafka | kafka-streams-examples | — |
+| WebSocket / Socket.IO | socket.io | pusher-js, ably-js, MQTT.js, mdn-dom-examples |
+| WebRTC | DROP | pion-webrtc |
+| MQTT | DROP (socket.io covers pub/sub) | MQTT.js |
+
+### 2g. Manifest / build-tool formats
+
+Real apps' manifests cover the formats; explicit manifest-only entries DROP.
+
+| format | kept (via) |
+| --- | --- |
+| pyproject.toml / setup.py | django-realworld, pandas |
+| package.json (npm/yarn) | express-realworld, nestjs-starter |
+| pnpm-workspace.yaml | pnpm (KEEP-secondary, single source) |
+| tsconfig + nx | DROP nx (covered by nestjs/sveltekit tsconfigs) |
+| Cargo.toml | tokio (KEEP — workspace manifest unique) |
+| pom.xml | spring-petclinic + kafka-streams-examples |
+| build.gradle | spring-petclinic (Gradle build) — DROP gradle/gradle |
+| BUILD (Bazel/Starlark) | bazel (KEEP-secondary, only Starlark BUILD corpus other than Tilt) |
+| Makefile | DROP gnu-make (Makefiles in every Go repo) |
+| CMakeLists | cmake (KEEP-secondary, only CMake corpus) |
+| composer.json | symfony-demo + laravel-quickstart — DROP composer/composer |
+| Gemfile | rails-realworld + sidekiq — DROP bundler |
+| mix.exs | phoenix-todo-list — DROP elixir/elixir |
+| build.sbt | play-scala-starter, spark — DROP sbt |
+| project.clj | usermanager-example — DROP leiningen |
+| lerna.json / turbo.json | DROP both (workspace package.json covered by pnpm) |
+
+### 2h. Validation / lint / auth / observability
+
+| category | kept | dropped |
+| --- | --- | --- |
+| Validation (Zod/Joi/Yup/Pydantic/class-validator) | pydantic + zod | joi, yup, class-validator (TS decorator surface covered by nestjs) |
+| Lint configs | DROP all 6 | eslint, prettier, ruff, rubocop, golangci-lint, rust-clippy (configs covered by every realworld app having `.eslintrc`/`.golangci.yml` etc) |
+| Auth (OAuth/JWT/Keycloak/Auth0/Vault) | DROP all | covered by aspnetcore-realworld + django-realworld (auth flows) |
+| Observability (OTel/Prom/Sentry/DD) | DROP all | covered by spring-petclinic, etcd (metrics) |
+
+### 2i. Mobile / game / embedded
+
+| stack | kept | dropped |
+| --- | --- | --- |
+| iOS UIKit | ios-oss (sec) | — |
+| iOS SwiftUI | sample-food-truck | — |
+| Android Java | android-architecture (sec) | — |
+| Android Kotlin Compose | compose-samples (sec) | — |
+| Flutter | flutter-samples | dart-samples (covered) |
+| React Native | DROP | react-native (template covered by express-realworld JS) |
+| Ionic | DROP | ionic-conference-app |
+| MAUI | DROP | maui-samples (csharp covered by aspnetcore) |
+| Unity ECS | EntityComponentSystemSamples (sec) | — |
+| Unreal C++ | DROP | UnrealEnginePython (cpp covered by spdlog) |
+| Bevy Rust | DROP | bevy (rust covered by tokio/actix) |
+| Arduino | DROP | arduino-examples (cpp covered) |
+| ESP-IDF | esp-idf (sec) | — only C corpus |
+| MicroPython | DROP | (python covered) |
+| Cortex-M Rust | DROP | (rust covered) |
+
+### 2j. Data / ML / notebook / workflow
+
+| repo | kept | rationale |
+| --- | --- | --- |
+| scikit-learn | DROP | python covered by pandas (NumPy + scipy import) |
+| pytorch-examples | DROP | python covered |
+| keras-io | DROP | python covered |
+| transformers | DROP | python covered |
+| jupyter-notebook | **KEEP-primary** | only `.ipynb` corpus |
+| polars | DROP | python covered |
+| spark | KEEP-secondary | only Scala data corpus |
+| jaffle_shop | **KEEP-primary** | only dbt corpus |
+| airflow | KEEP-secondary | unique @dag/@task decorator pattern |
+| prefect, dagster, cadence, temporal | DROP | airflow covers decorator workflow surface |
+| camunda-bpm-examples | **KEEP-primary** | only `java_bpmn` corpus |
+
+### 2k. SSGs / Testing / Migration / Realtime
+
+| family | kept | dropped |
+| --- | --- | --- |
+| SSGs | hugoDocs + sphinx (RST + plugin) | jekyll, hexo, mkdocs, vitepress, docusaurus, nextra, eleventy |
+| Test runners | pytest (sec) | jest, mocha, cypress, playwright, junit5, rspec, karate, cucumber-js |
+| Selenium polyglot | seleniumhq-examples | — (only multi-lang fixture) |
+| Migration tools | alembic | flyway, liquibase, knex, goose, migrate-mongo, sequel |
+| Realtime | socket.io | pusher, ably, MQTT, pion-webrtc, mdn-dom-examples |
+| Frontend SPAs | sveltekit + angular-realworld | vue/svelte/solid/preact/ember/astro/remix/nuxt/lit/htmx/alpine/qwik/gatsby/vite |
+| Serverless | aws-lambda-python-runtime-interface-client + cloudflare-workers-sdk | all other lambda runtimes (handler shape is per-language and already covered by realworld apps) |
+
+---
+
+## 3. Per-entry decisions (283 entries)
+
+Legend: **P** = KEEP-primary, **S** = KEEP-secondary, **D** = DROP.
+
+### Headline / framework realworld apps
+| # | bucket | entry | rationale |
+| --- | --- | --- | --- |
+| 1 | P | requests | Python stdlib library; smallest test for resolver baseline (1.72% bug-rate is the reference low-watermark) |
+| 2 | P | flask-realworld | Flask + SQLAlchemy + Jinja sample |
+| 3 | P | click | Python CLI tool; resolver low-watermark (6.95%) |
+| 4 | P | django-realworld | Django + DRF + ORM + Jinja in one |
+| 5 | P | pandas | Large Python codebase (heavy import surface, complex modules) |
+| 6 | P | gin | Go HTTP routing source |
+| 7 | P | chi | Go middleware-chain source (distinct from gin) |
+| 8 | P | etcd | Large Go microservice + gRPC + protobuf |
+| 9 | P | express-realworld | Node Express + Mongoose |
+| 10 | P | nestjs-starter | TS decorator framework + tsconfig |
+| 11 | P | nextjs-commerce | Next.js SSR + commerce app |
+| 12 | P | spring-petclinic | Spring Boot + JPA + Maven |
+| 13 | P | kafka-streams-examples | Java Kafka streaming |
+| 14 | P | exposed | Kotlin SQL DSL |
+| 15 | P | ktor-samples | Kotlin Ktor framework sample |
+| 16 | P | play-scala-starter | Scala Play (only Scala web sample) |
+| 17 | D | ratpack-example-books | groovy covered by jenkins (which has more groovy surface) |
+| 18 | P | usermanager-example | Clojure Ring/Compojure |
+| 19 | P | rails-realworld | Rails MVC + ActiveRecord |
+| 20 | P | sidekiq | Ruby library |
+| 21 | P | laravel-quickstart | Laravel + Eloquent |
+| 22 | P | symfony-demo | Symfony + Doctrine |
+| 23 | P | mini-redis | Tokio sample |
+| 24 | P | actix-examples | Actix routing |
+| 25 | P | vapor-api-template | Vapor (Swift web) |
+| 26 | P | aspnetcore-realworld | ASP.NET Core MVC |
+| 27 | P | spdlog | C++ header-only |
+| 28 | P | http.zig | only Zig |
+| 29 | D | dart-samples | flutter-samples covers dart |
+| 30 | P | kickstart.nvim | only Lua |
+| 31 | P | phoenix-todo-list | Elixir Phoenix |
+| 32 | P | aspnetcore-docs-samples | only Razor |
+| 33 | P | tide (fish) | only fish |
+| 34 | P | just | only justfile |
+| 35 | P | grpc-go-examples | only proto |
+| 36 | P | apollo-server | only graphql SDL |
+| 37 | P | terraform-aws-vpc | canonical HCL |
+| 38 | P | argocd-example-apps | canonical k8s yaml |
+| 39 | P | prometheus-helm | canonical Helm |
+| 40 | P | starter-workflows | canonical GHA |
+| 41 | S | openapi-stripe | OpenAPI yaml (unique IDL) |
+
+### Chunk G (ORM samples)
+| 42 | S | microblog | SQLAlchemy detailed sample (distinct from flask-realworld) |
+| 43 | S | fastapi-realworld | FastAPI Pydantic + SQLAlchemy async |
+| 44 | D | sequelize-express-example | TypeORM/Prisma decorator patterns cover this |
+| 45 | P | golang-gin-realworld | GORM sample (only Go ORM) |
+| 46 | S | actix-diesel-realworld | Diesel (Rust ORM) |
+
+### Chunk H (build tools)
+| 47 | S | tokio | Cargo workspace (canonical) |
+| 48 | D | maven | pom.xml covered by spring-petclinic + kafka-streams-examples |
+| 49 | S | pnpm | pnpm-workspace.yaml (only source) |
+| 50 | D | nx | tsconfig covered by nestjs/sveltekit/angular |
+
+### Chunk I (Java enterprise) — ALL DROP except primary
+| 51 | D | quarkus-quickstarts | Java covered |
+| 52 | D | micronaut-examples | Java covered |
+| 53 | D | helidon-examples | Java covered |
+| 54 | D | vertx-examples | Java covered |
+| 55 | D | dropwizard-example | Java covered |
+| 56 | D | play-java-starter | Java covered (Play covered by play-scala) |
+| 57 | D | spark-examples | Java covered |
+
+### Chunk L (Mobile native)
+| 58 | S | ios-oss | iOS UIKit (distinct from SwiftUI) |
+| 59 | P | sample-food-truck | iOS SwiftUI (canonical Apple sample) |
+| 60 | S | android-architecture | Android Java (distinct extractor patterns from server Java) |
+| 61 | S | compose-samples | Android Kotlin Compose |
+| 62 | P | flutter-samples | only Dart sample |
+| 63 | D | react-native | JS covered |
+| 64 | D | ionic-conference-app | TS covered |
+| 65 | D | maui-samples | C# covered |
+
+### Chunk N (Declarative IaC)
+| 66 | S | aws-cloudformation-samples | CFN yaml templates |
+| 67 | D | kustomize | k8s yaml redundant w/ argocd |
+| 68 | S | ansible-for-devops | Ansible-specific yaml |
+| 69 | D | chef-runit | Ruby DSL covered by rails |
+| 70 | D | puppet-control-repo | Ruby DSL covered |
+| 71 | D | awesome-compose | docker-compose covered by every realworld app |
+| 72 | S | nomad-pack | HCL+Nomad (distinct from terraform) |
+
+### Chunk O (ORMs missing) — keep distinctive only
+| 73 | D | spring-framework-petclinic | Spring already covered |
+| 74 | S | joal | jOOQ (unique Java ORM idiom) |
+| 75 | S | jpetstore-6 | MyBatis (unique XML-mapper) |
+| 76 | P | nestjs-realworld-typeorm | TypeORM (canonical TS decorator ORM) |
+| 77 | D | express-bookshelf-realworld | knex covered by alembic migration entry |
+| 78 | D | nestjs-realworld-mikroorm | TypeORM covers TS ORM |
+| 79 | S | ent | Go codegen-ORM (distinct from GORM) |
+| 80 | S | sqlc-examples | SQL→Go codegen (unique pattern) |
+| 81 | D | fabric-ca | Go covered |
+| 82 | D | lean | Eloquent covered by laravel-quickstart |
+| 83 | D | sea-orm-examples | Diesel covers Rust ORM |
+| 84 | S | netcore-boilerplate | Dapper (micro-ORM, distinct from EF) |
+
+### Chunk P (NoSQL / streaming)
+| 85 | P | mongoose | canonical Node ODM |
+| 86 | D | pymongo | mongoose covers MongoDB |
+| 87 | D | motor | redundant w/ pymongo (already dropped) |
+| 88 | S | mongo-go-driver | Go MongoDB (distinct from JS) |
+| 89 | D | mongo-java-driver | Java client patterns covered by kafka |
+| 90 | S | redis-py | canonical Redis client |
+| 91 | D | ioredis | redis-py covers |
+| 92 | D | go-redis | mongo-go-driver covers Go nosql |
+| 93 | D | lettuce | java covered |
+| 94 | S | cassandra-java-driver | distinct from Redis (CQL DSL) |
+| 95 | S | aws-sdk-go-v2 | AWS SDK pattern (DynamoDB) |
+| 96 | D | couchbase-gocb | covered |
+| 97 | S | rabbitmq-tutorials | AMQP (distinct from Kafka) |
+| 98 | D | nats.go | Kafka + RabbitMQ cover streaming |
+| 99 | D | aws-sdk-js-v3 | aws-sdk-go-v2 covers SDK shape |
+
+### Chunk M (Programmatic IaC) — collapse multi-flavor
+| 100 | P | aws-cdk-examples-typescript | canonical CDK |
+| 101 | D | aws-cdk-examples-python | python covered |
+| 102 | D | aws-cdk-examples-java | java covered |
+| 103 | D | aws-cdk-examples-csharp | csharp covered |
+| 104 | D | aws-cdk-examples-go | go covered |
+| 105 | D | pulumi-examples-typescript | CDK TS covers |
+| 106 | D | pulumi-examples-python | covered |
+| 107 | S | pulumi-examples-go | distinct Pulumi-Go API |
+| 108 | D | pulumi-examples-csharp | covered |
+| 109 | P | azure-quickstart-templates | only Bicep |
+| 110 | S | aws-sam-cli-app-templates | SAM template.yaml (unique extension) |
+| 111 | S | serverless-examples | serverless.yml (distinct from SAM) |
+| 112 | S | crossplane | XR composition yaml (distinct) |
+
+### Chunk Y (DB migrations) — collapse to one
+| 113 | D | flyway | covered by alembic for migration concept |
+| 114 | D | liquibase | covered |
+| 115 | P | alembic | canonical migration tool (Python + SQL) |
+| 116 | D | knex | covered |
+| 117 | D | goose | covered |
+| 118 | D | migrate-mongo | covered |
+| 119 | D | sequel | covered |
+
+### Chunk Q (CI/CD)
+| 120 | S | gitlab-runner | GitLab CI |
+| 121 | S | circleci-demo-python-django | CircleCI yaml |
+| 122 | P | jenkins | only Groovy DSL (and best Groovy sample) |
+| 123 | S | tektoncd-pipeline | Tekton CRD yaml |
+| 124 | D | drone | yaml step format redundant |
+| 125 | D | buildkite-agent | yaml step format redundant |
+| 126 | D | skaffold | yaml covered |
+| 127 | P | tilt | only Starlark sample |
+
+### Chunk R (Build tools missing)
+| 128 | D | gradle | Gradle covered by spring-petclinic |
+| 129 | S | bazel | BUILD/Starlark targets (distinct from Tilt — BUILD files) |
+| 130 | D | gnu-make | Makefile covered by every Go repo |
+| 131 | S | cmake | only CMake corpus |
+| 132 | D | poetry | pyproject covered |
+| 133 | D | composer | composer.json covered by symfony/laravel |
+| 134 | D | bundler | Gemfile covered by rails |
+| 135 | D | elixir (mix) | mix.exs covered by phoenix-todo-list |
+| 136 | D | sbt | build.sbt covered by play-scala-starter |
+| 137 | D | leiningen | project.clj covered by usermanager-example |
+| 138 | D | lerna | workspaces covered by pnpm |
+| 139 | D | turborepo | turbo.json niche; covered by pnpm |
+
+### Chunk V (reverse proxies) — each format is single-source MUST KEEP
+| 140 | P | nginx (nginx-conf) |
+| 141 | P | apache-httpd (apache-httpd-conf) |
+| 142 | P | caddy (caddyfile) |
+| 143 | P | traefik (traefik-dynamic) |
+| 144 | P | kong (kong-declarative) |
+| 145 | P | envoy (envoy-yaml) |
+| 146 | P | haproxy (haproxy-cfg) |
+
+### Chunk U (API/IDL alts) — each format single-source MUST KEEP
+| 147 | P | asyncapi-spec |
+| 148 | P | smithy |
+| 149 | P | avro |
+| 150 | P | thrift |
+| 151 | P | json-schema-spec |
+| 152 | P | raml-spec |
+| 153 | P | api-blueprint |
+
+### Chunk S (auth/security/observability) — ALL DROP
+| 154-162 | D | node-openid-client, node-jsonwebtoken, keycloak, auth0-spa-js, vault, opentelemetry-js, prometheus-client-golang, sentry-javascript, dd-trace-js | All library consumer code already covered by realworld apps' auth + tracing imports |
+
+### Chunk T (validation + lint)
+| 163 | S | zod | TS schema-builder pattern |
+| 164 | D | joi | covered |
+| 165 | D | yup | covered |
+| 166 | S | pydantic | unique Python decorator-validator surface |
+| 167 | D | class-validator | nestjs covers |
+| 168 | D | eslint | config covered by every realworld |
+| 169 | D | prettier | covered |
+| 170 | D | ruff | covered |
+| 171 | D | rubocop | covered |
+| 172 | D | golangci-lint | covered |
+| 173 | D | rust-clippy | covered |
+
+### Chunk Z (serverless)
+| 174 | D | aws-lambda-developer-guide | Lambda JS handler covered by express |
+| 175 | S | aws-lambda-python-runtime-interface-client | Python Lambda handler bootstrap (distinct) |
+| 176 | D | aws-lambda-java-libs | covered |
+| 177 | D | aws-lambda-go | covered |
+| 178 | D | aws-lambda-rust-runtime | covered |
+| 179 | D | vercel-examples | covered by nextjs-commerce |
+| 180 | D | netlify-functions | covered |
+| 181 | S | cloudflare-workers-sdk | wrangler.toml + Workers fetch (distinct edge handler) |
+| 182 | D | functions-framework-nodejs | covered |
+
+### Chunk AA (state mgmt) — collapse to one
+| 183 | D | redux | covered by nextjs-commerce (toolkit slices common) |
+| 184 | D | mobx | covered |
+| 185 | D | zustand | covered |
+| 186 | D | pinia | covered by vue surface — actually all vue dropped; if Vue must stay → keep pinia. Recommend D. |
+| 187 | D | ngrx-platform | angular-realworld covers |
+| 188 | D | recoil | covered |
+| 189 | S | xstate | distinctive statechart createMachine DSL (unique extractor surface) |
+| 190 | D | effector | covered |
+
+### Chunk W (SSGs)
+| 191 | S | hugoDocs | Go templates + shortcodes + TOML/YAML front-matter |
+| 192 | D | jekyll | Liquid covered |
+| 193 | D | hexo-site | covered |
+| 194 | D | mkdocs | sphinx covers Python SSG |
+| 195 | S | sphinx | RST extractor + plugin system (distinct) |
+| 196 | D | vitepress | covered |
+| 197 | D | docusaurus | MDX covered by nextjs |
+| 198 | D | nextra | covered |
+| 199 | D | eleventy | covered |
+
+### Chunk X (testing)
+| 200 | D | jest | covered |
+| 201 | D | mocha | covered |
+| 202 | D | cypress-realworld-app | covered |
+| 203 | D | playwright | covered |
+| 204 | P | seleniumhq-examples | only `multi`-language fixture |
+| 205 | D | junit5-samples | covered |
+| 206 | D | rspec-rails | covered |
+| 207 | S | pytest | canonical Python test framework (conftest/fixtures distinctive) |
+| 208 | D | karate | covered |
+| 209 | D | cucumber-js | covered |
+
+### Chunk BB (realtime)
+| 210 | S | socket.io | canonical realtime |
+| 211 | D | pusher-js | covered |
+| 212 | D | ably-js | covered |
+| 213 | D | MQTT.js | covered |
+| 214 | D | pion-webrtc | covered |
+| 215 | D | mdn-dom-examples | covered |
+
+### Chunk CC (game/embedded)
+| 216 | S | EntityComponentSystemSamples | Unity ECS C# attributes (distinct) |
+| 217 | D | UnrealEnginePython | covered by spdlog |
+| 218 | D | bevy | rust covered |
+| 219 | D | arduino-examples | covered |
+| 220 | S | esp-idf | only pure-C corpus (distinct from C++) |
+| 221 | D | micropython | python covered |
+| 222 | D | cortex-m-quickstart | rust covered |
+
+### Chunk EE (workflow/orchestration)
+| 223 | D | temporalio-samples-go | airflow covers decorator workflows |
+| 224 | D | cadence-client | covered |
+| 225 | S | airflow | canonical @dag/@task decorator workflow |
+| 226 | D | prefect | covered |
+| 227 | P | camunda-bpm-examples | only `java_bpmn` corpus |
+| 228 | D | dagster | covered |
+
+### Chunk DD (data/ML/notebook)
+| 229 | D | scikit-learn | python covered by pandas |
+| 230 | D | pytorch-examples | covered |
+| 231 | D | keras-io | covered |
+| 232 | D | transformers | covered |
+| 233 | P | jupyter-notebook | only notebook corpus |
+| 234 | D | polars | covered |
+| 235 | S | spark | only Scala data corpus |
+| 236 | P | jaffle_shop | only sql_dbt corpus |
+
+### Chunk K (frontend SPAs) — collapse aggressively
+| 237 | S | angular-realworld | Angular decorators + DI (distinct extractor surface) |
+| 238 | D | react-redux-realworld | covered by nextjs-commerce + nestjs |
+| 239 | D | vite | TS bundler covered by sveltekit |
+| 240 | D | vue-realworld | covered by pinia → wait, pinia dropped. Vue 3 SFC is distinct — RECONSIDER → upgrade to S |
+| 241 | D | svelte-realworld | sveltekit covers |
+| 242 | S | sveltekit | distinct Svelte syntax extractor surface |
+| 243 | D | solid-templates | TS covered |
+| 244 | D | preact-cli | covered |
+| 245 | D | ember-super-rentals | covered |
+| 246 | D | astro | covered |
+| 247 | D | remix-indie-stack | covered |
+| 248 | D | nuxt-starter | covered |
+| 249 | D | lit-element-starter | covered |
+| 250 | D | htmx | small JS covered |
+| 251 | D | alpine | covered |
+| 252 | D | qwik | covered |
+| 253 | D | gatsby-starter-blog | covered |
+
+> NOTE on Vue SFC: if the JS extractor's Vue-SFC handling is a separate
+> code path, promote `vue-realworld` to **S**. Marked as conditional-S
+> below in the proposed run.sh (commented out).
+
+### Chunk J (web framework alts) — ALL DROP except http4k
+| 254 | D | echox | gin/chi cover Go HTTP |
+| 255 | D | gofiber-recipes | covered |
+| 256 | D | beego-example | covered |
+| 257 | D | fastify-demo | express covers |
+| 258 | D | koa-examples | covered |
+| 259 | D | hapi | covered |
+| 260 | D | sails-examples | covered |
+| 261 | D | adonis-blog-demo | covered |
+| 262 | D | tornado | flask/django cover |
+| 263 | D | starlette | covered |
+| 264 | D | pyramid-shootout | covered |
+| 265 | D | bottle | covered |
+| 266 | D | slim-skeleton | symfony covers |
+| 267 | D | codeigniter-shield | covered |
+| 268 | D | yii2-app-basic | covered |
+| 269 | D | sinatra-recipes | rails covers |
+| 270 | D | hanami | covered |
+| 271 | D | grape-on-rack | covered |
+| 272 | S | axum | tower middleware ecosystem (distinct from actix) |
+| 273 | D | rocket | covered |
+| 274 | D | warp | covered |
+| 275 | D | tide (rust) | covered |
+| 276 | D | akka-http | covered |
+| 277 | D | http4s | covered |
+| 278 | D | compojure | covered |
+| 279 | D | pedestal | covered |
+| 280 | D | elixir-plug | phoenix covers |
+| 281 | S | phoenix-live-view | LiveView mount/handle_event (distinct from phoenix-todo) |
+| 282 | D | javalin-samples | ktor covers |
+| 283 | S | http4k | functional HttpHandler composition (distinct DSL) |
+
+---
+
+## 4. Proposed slim run.sh REPOS array
+
+```bash
+REPOS=(
+  # --- Single-source MUST KEEP (extractor or DSL only-source) ---
+  "aspnetcore-docs-samples|https://github.com/dotnet/AspNetCore.Docs.Samples.git|main|razor"
+  "tide|https://github.com/IlanCosman/tide.git|main|fish"
+  "just|https://github.com/casey/just.git|master|just"
+  "http.zig|https://github.com/karlseguin/http.zig.git|master|zig"
+  "kickstart.nvim|https://github.com/nvim-lua/kickstart.nvim.git|master|lua"
+  "grpc-go-examples|https://github.com/grpc/grpc-go.git|master|proto|examples"
+  "apollo-server|https://github.com/apollographql/apollo-server.git|main|graphql"
+  "jupyter-notebook|https://github.com/jupyter/notebook.git|main|notebook|docs/source"
+  "jaffle_shop|https://github.com/dbt-labs/jaffle_shop.git|main|sql_dbt|models"
+  "azure-quickstart-templates|https://github.com/Azure/azure-quickstart-templates.git|master|bicep|quickstarts/microsoft.storage"
+  "tilt|https://github.com/tilt-dev/tilt.git|master|starlark|integration"
+  "camunda-bpm-examples|https://github.com/camunda/camunda-bpm-examples.git|master|java_bpmn|servicetask"
+  "asyncapi-spec|https://github.com/asyncapi/spec.git|master|asyncapi"
+  "smithy|https://github.com/smithy-lang/smithy.git|main|smithy|smithy-model"
+  "avro|https://github.com/apache/avro.git|main|avro|lang"
+  "thrift|https://github.com/apache/thrift.git|master|thrift|tutorial"
+  "json-schema-spec|https://github.com/json-schema-org/json-schema-spec.git|main|json-schema"
+  "raml-spec|https://github.com/raml-org/raml-spec.git|master|raml"
+  "api-blueprint|https://github.com/apiaryio/api-blueprint.git|master|api-blueprint"
+  "nginx|https://github.com/nginx/nginx.git|master|nginx-conf|conf"
+  "apache-httpd|https://github.com/apache/httpd.git|trunk|apache-httpd-conf|docs/conf"
+  "caddy|https://github.com/caddyserver/caddy.git|master|caddyfile|caddyconfig"
+  "traefik|https://github.com/traefik/traefik.git|master|traefik-dynamic|integration/fixtures"
+  "kong|https://github.com/Kong/kong.git|master|kong-declarative|spec/fixtures"
+  "envoy|https://github.com/envoyproxy/envoy.git|main|envoy-yaml|configs"
+  "haproxy|https://github.com/haproxy/haproxy.git|master|haproxy-cfg|examples"
+  "seleniumhq-examples|https://github.com/SeleniumHQ/seleniumhq.github.io.git|trunk|multi|examples"
+  # --- Language primary realworld apps ---
+  "requests|https://github.com/psf/requests.git|main|python"
+  "flask-realworld|https://github.com/gothinkster/flask-realworld-example-app.git|master|python"
+  "click|https://github.com/pallets/click.git|main|python"
+  "django-realworld|https://github.com/gothinkster/django-realworld-example-app.git|master|python"
+  "pandas|https://github.com/pandas-dev/pandas.git|main|python|pandas/core"
+  "gin|https://github.com/gin-gonic/gin.git|master|go"
+  "chi|https://github.com/go-chi/chi.git|master|go"
+  "etcd|https://github.com/etcd-io/etcd.git|main|go|server/etcdserver"
+  "express-realworld|https://github.com/gothinkster/node-express-realworld-example-app.git|master|javascript"
+  "nestjs-starter|https://github.com/nestjs/typescript-starter.git|master|typescript"
+  "nextjs-commerce|https://github.com/vercel/commerce.git|main|typescript"
+  "spring-petclinic|https://github.com/spring-projects/spring-petclinic.git|main|java"
+  "kafka-streams-examples|https://github.com/confluentinc/kafka-streams-examples.git|master|java"
+  "exposed|https://github.com/JetBrains/Exposed.git|main|kotlin"
+  "ktor-samples|https://github.com/ktorio/ktor-samples.git|main|kotlin"
+  "play-scala-starter|https://github.com/playframework/play-scala-starter-example.git|2.7.x|scala"
+  "usermanager-example|https://github.com/seancorfield/usermanager-example.git|develop|clojure"
+  "rails-realworld|https://github.com/gothinkster/rails-realworld-example-app.git|master|ruby"
+  "sidekiq|https://github.com/sidekiq/sidekiq.git|main|ruby"
+  "laravel-quickstart|https://github.com/laravel/quickstart-basic.git|master|php"
+  "symfony-demo|https://github.com/symfony/demo.git|main|php"
+  "mini-redis|https://github.com/tokio-rs/mini-redis.git|master|rust"
+  "actix-examples|https://github.com/actix/examples.git|main|rust"
+  "vapor-api-template|https://github.com/vapor/api-template.git|master|swift"
+  "sample-food-truck|https://github.com/apple/sample-food-truck.git|main|swift"
+  "aspnetcore-realworld|https://github.com/gothinkster/aspnetcore-realworld-example-app.git|master|csharp"
+  "spdlog|https://github.com/gabime/spdlog.git|v1.x|cpp"
+  "flutter-samples|https://github.com/flutter/samples.git|main|dart"
+  "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"
+  "esp-idf|https://github.com/espressif/esp-idf.git|master|c|examples/get-started"
+  # --- Secondary distinctive coverage ---
+  "microblog|https://github.com/miguelgrinberg/microblog.git|main|python"                       # SQLAlchemy + Flask-Login (deeper than flask-realworld)
+  "fastapi-realworld|https://github.com/nsidnev/fastapi-realworld-example-app.git|master|python" # FastAPI + Pydantic + async SQLAlchemy
+  "golang-gin-realworld|https://github.com/gothinkster/golang-gin-realworld-example-app.git|main|go" # GORM
+  "actix-diesel-realworld|https://github.com/snamiki1212/realworld-v1-rust-actix-web-diesel.git|main|rust" # Diesel
+  "nestjs-realworld-typeorm|https://github.com/lujakob/nestjs-realworld-example-app.git|master|typescript" # TypeORM
+  "joal|https://github.com/anthonyraymond/joal.git|master|java"                                 # jOOQ
+  "jpetstore-6|https://github.com/mybatis/jpetstore-6.git|master|java"                          # MyBatis
+  "ent|https://github.com/ent/ent.git|master|go|entc/integration/ent"                           # Ent codegen
+  "sqlc-examples|https://github.com/sqlc-dev/sqlc.git|main|go|examples"                         # sqlc codegen
+  "netcore-boilerplate|https://github.com/lkurzyniec/netcore-boilerplate.git|master|csharp"     # Dapper micro-ORM
+  "tokio|https://github.com/tokio-rs/tokio.git|master|rust"                                     # Cargo workspace manifest
+  "pnpm|https://github.com/pnpm/pnpm.git|main|javascript"                                       # pnpm-workspace.yaml
+  "bazel|https://github.com/bazelbuild/bazel.git|master|java"                                   # BUILD Starlark targets
+  "cmake|https://github.com/Kitware/CMake.git|master|cpp"                                       # CMake lists
+  "mongoose|https://github.com/Automattic/mongoose.git|master|javascript"                       # Mongo Node ODM
+  "mongo-go-driver|https://github.com/mongodb/mongo-go-driver.git|master|go"                    # Mongo Go
+  "redis-py|https://github.com/redis/redis-py.git|master|python"                                # Redis Python
+  "cassandra-java-driver|https://github.com/datastax/java-driver.git|4.x|java"                  # Cassandra CQL
+  "aws-sdk-go-v2|https://github.com/aws/aws-sdk-go-v2.git|main|go"                              # DynamoDB / AWS SDK
+  "rabbitmq-tutorials|https://github.com/rabbitmq/rabbitmq-tutorials.git|main|python"           # AMQP
+  "aws-cdk-examples-typescript|https://github.com/aws-samples/aws-cdk-examples.git|main|typescript|typescript"
+  "pulumi-examples-go|https://github.com/pulumi/examples.git|master|go|aws-go-webserver"
+  "aws-cloudformation-samples|https://github.com/aws-cloudformation/aws-cloudformation-samples.git|main|yaml"
+  "aws-sam-cli-app-templates|https://github.com/aws/aws-sam-cli-app-templates.git|master|yaml|python3.12"
+  "serverless-examples|https://github.com/serverless/examples.git|v4|yaml|aws-node-http-api"
+  "crossplane|https://github.com/crossplane/crossplane.git|main|yaml|cluster/meta"
+  "ansible-for-devops|https://github.com/geerlingguy/ansible-for-devops.git|master|yaml"
+  "nomad-pack|https://github.com/hashicorp/nomad-pack.git|main|hcl|registry"
+  "terraform-aws-vpc|https://github.com/terraform-aws-modules/terraform-aws-vpc.git|master|hcl"
+  "argocd-example-apps|https://github.com/argoproj/argocd-example-apps.git|master|yaml"
+  "prometheus-helm|https://github.com/prometheus-community/helm-charts.git|main|yaml|charts/prometheus"
+  "starter-workflows|https://github.com/actions/starter-workflows.git|main|yaml"
+  "openapi-stripe|https://github.com/APIs-guru/openapi-directory.git|main|yaml|APIs/stripe.com"
+  "gitlab-runner|https://gitlab.com/gitlab-org/gitlab-runner.git|main|yaml|ci"
+  "circleci-demo-python-django|https://github.com/CircleCI-Public/circleci-demo-python-django.git|master|yaml|.circleci"
+  "jenkins|https://github.com/jenkinsci/jenkins.git|master|groovy"
+  "tektoncd-pipeline|https://github.com/tektoncd/pipeline.git|main|yaml|examples"
+  "alembic|https://github.com/sqlalchemy/alembic.git|main|python"
+  "ios-oss|https://github.com/kickstarter/ios-oss.git|main|swift"
+  "android-architecture|https://github.com/googlesamples/android-architecture.git|main|java"
+  "compose-samples|https://github.com/android/compose-samples.git|main|kotlin"
+  "EntityComponentSystemSamples|https://github.com/Unity-Technologies/EntityComponentSystemSamples.git|master|csharp|EntityComponentSystemSamples/ECSSamples"
+  "zod|https://github.com/colinhacks/zod.git|main|typescript"
+  "pydantic|https://github.com/pydantic/pydantic.git|main|python"
+  "aws-lambda-python-runtime-interface-client|https://github.com/aws/aws-lambda-python-runtime-interface-client.git|main|python|awslambdaric"
+  "cloudflare-workers-sdk|https://github.com/cloudflare/workers-sdk.git|main|typescript|packages/wrangler"
+  "xstate|https://github.com/statelyai/xstate.git|main|typescript|packages/core"
+  "hugoDocs|https://github.com/gohugoio/hugoDocs.git|master|go|content"
+  "sphinx|https://github.com/sphinx-doc/sphinx.git|master|python|sphinx"
+  "pytest|https://github.com/pytest-dev/pytest.git|main|python"
+  "socket.io|https://github.com/socketio/socket.io.git|main|typescript|packages/socket.io"
+  "airflow|https://github.com/apache/airflow.git|main|python|airflow/example_dags"
+  "spark|https://github.com/apache/spark.git|master|scala|examples/src/main/scala"
+  "angular-realworld|https://github.com/gothinkster/angular-realworld-example-app.git|main|typescript"
+  "sveltekit|https://github.com/sveltejs/kit.git|main|typescript"
+  "axum|https://github.com/tokio-rs/axum.git|main|rust"
+  "phoenix-live-view|https://github.com/phoenixframework/phoenix_live_view.git|main|elixir"
+  "http4k|https://github.com/http4k/http4k.git|master|kotlin"
+  # CONDITIONAL: uncomment if Vue SFC extractor is a separate code path
+  # "vue-realworld|https://github.com/gothinkster/vue-realworld-example-app.git|master|javascript"
+)
+```
+
+Final count: **72 entries** (47 P + 25 S), comfortably within the 60–90
+target.
+
+---
+
+## 5. Risks and mitigations
+
+### Coverage that becomes thinner
+
+1. **Java framework breadth** — Quarkus / Micronaut / Helidon / Vert.x /
+   Dropwizard are dropped. Spring + Kafka cover the major Java extractor
+   surface, but framework-specific annotations (e.g. `@QuarkusTest`,
+   `@MicronautTest`) won't be exercised. **Mitigation:** if extractor
+   regression hits a Quarkus user, re-add `quarkus-quickstarts` as
+   secondary.
+2. **State management decorators** — Only xstate retained. If a Redux
+   Toolkit / NgRx-specific dispatcher pattern regresses it won't be
+   caught. **Mitigation:** angular-realworld covers NgRx incidentally via
+   Angular DI; sveltekit covers Svelte stores.
+3. **Lint configs as standalone fixtures** — No dedicated `.eslintrc` /
+   `.golangci.yml` consumer. Most realworld apps ship one, so coverage
+   is preserved incidentally — but a synthetic lint-only test corpus
+   would be lost. **Mitigation:** none needed; lint config parsing isn't
+   in `internal/extractors/`.
+4. **Polyglot mobile** — React Native, Ionic, MAUI dropped. Mobile-app
+   path coverage is now thinner: only iOS (UIKit + SwiftUI), Android
+   (Java + Kotlin Compose), Flutter. **Mitigation:** acceptable —
+   underlying extractors (csharp/typescript/javascript) are covered by
+   web counterparts.
+5. **Migration-tool DSL variety** — Only Alembic retained. Flyway's
+   `V__.sql` naming, Liquibase's XML changelog, and Knex's
+   schema-builder are not exercised. **Mitigation:** propose a Tier-2
+   "extended migrations" corpus file.
+
+### Suggested Tier-2 extended-coverage file
+
+Create `scripts/verify2/run-extended.sh` containing the 211 dropped
+entries, runnable on-demand for full-coverage smoke runs (e.g. before
+a major release or after touching `internal/extractors/cross/`). This
+preserves the current investment without paying the cost on every
+baseline refresh.
+
+Suggested run cadence:
+- `run.sh` (72 repos) — every PR + nightly baseline
+- `run-extended.sh` (211 repos) — weekly + pre-release
+
+---
+
+## 6. Report
+
+- **Proposal file:** `/tmp/corpus-curation-proposal.md`
+- **Target N:** **72** (47 primary + 25 secondary)
+- **Top-3 redundancy categories eliminated:**
+  1. Web-framework alternates (chunk J, 29 → 6)
+  2. State-management single-language libs (chunk AA, 8 → 1)
+  3. CDK/Pulumi multi-flavor sprawl (chunk M, 9 → 2)
+- **MUST-KEEP single-source entries flagged:** 22
+  (razor / fish / just / zig / lua / proto / graphql / notebook / sql_dbt /
+  bicep / starlark / java_bpmn / smithy / avro / thrift / json-schema /
+  asyncapi / raml / api-blueprint / nginx / httpd / caddyfile / traefik /
+  kong / envoy / haproxy / multi)

--- a/scripts/verify2/run-extended.sh
+++ b/scripts/verify2/run-extended.sh
@@ -1,0 +1,702 @@
+#!/usr/bin/env bash
+# scripts/verify2/run-extended.sh
+#
+# VERIFY-2 EXTENDED corpus harness (Refs #44, #87, #96).
+#
+# This is the TIER-2 / extended-coverage sibling of scripts/verify2/run.sh.
+# It re-runs the 168 corpus entries that the 2026-05-19 curation moved out
+# of the per-change ship-gate. Use it pre-release or on a weekly cron — the
+# primary scripts/verify2/run.sh ship-gate corpus is the fast 114-entry
+# tier-1 set and is the one that gates every change.
+#
+# Why two tiers:
+#   - Most dropped entries are intra-family redundancies (e.g. 8 state-mgmt
+#     libs, 12 web-framework alternates per language, 5 CDK flavors). They
+#     do not exercise new extractor code paths; running them every change
+#     burned wall-clock without changing the bug-rate signal.
+#   - But they DO catch framework-specific annotation surfaces (Quarkus
+#     `@QuarkusTest`, NgRx dispatchers, Liquibase changelog XML, etc.) so
+#     we keep them around for pre-release safety.
+#
+# See docs/verify2/corpus-curation-2026-05-19.md for the full per-entry
+# decision log. Hard rule: this script reuses the run.sh harness verbatim
+# except for the REPOS array.
+#
+# Usage:
+#   scripts/verify2/run-extended.sh
+#
+# Env vars: same as run.sh (ARCHIGRAPH_CORPORA_DIR, ARCHIGRAPH_BIN,
+# ARCHIGRAPH_VERIFY2_TIMEOUT, ARCHIGRAPH_VERBOSE).
+set -euo pipefail
+
+CORPORA_DIR="${ARCHIGRAPH_CORPORA_DIR:-$HOME/Documents/Projects/archigraph-corpora}"
+REPORTS_DIR="$CORPORA_DIR/_reports"
+mkdir -p "$CORPORA_DIR" "$REPORTS_DIR"
+
+# Repo list. Same entry format as run.sh:
+#   <name>|<git-url>|<ref>|<primary-language>[|<sparse-path>]
+# These are the 168 entries dropped from the tier-1 ship-gate by the
+# 2026-05-19 curation (see docs/verify2/corpus-curation-2026-05-19.md).
+REPOS=(
+  # Corpus policy (Refs #96): prefer SAMPLE APPLICATIONS that USE a framework
+  # over the framework's own source tree. We measure how the indexer handles
+  # framework-using user code, not how it handles framework internals.
+  # --- Python ---
+  # --- Go ---
+  # --- JavaScript / TypeScript ---
+  # --- Java ---
+  # --- Kotlin ---
+  # --- Scala ---
+  # --- Groovy ---
+  "ratpack-example-books|https://github.com/ratpack/example-books.git|master|groovy"               # Ratpack sample app
+  # --- Clojure ---
+  # --- Ruby ---
+  # --- PHP ---
+  # --- Rust ---
+  # --- Swift ---
+  # --- C# ---
+  # --- C++ ---
+  # --- Zig ---
+  # --- Dart ---
+  "dart-samples|https://github.com/dart-lang/samples.git|main|dart"                               # Dart sample apps
+  # --- Lua ---
+  # --- Elixir ---
+  # --- Razor ---
+  # --- Fish ---
+  # --- Just ---
+  # --- Proto ---
+  # --- GraphQL ---
+  # --- HCL ---
+  # --- K8s YAML ---
+  # --- Helm ---
+  # --- GHA ---
+  # --- OpenAPI ---
+  # --- ORMs/Frameworks (chunk G, umbrella #301) ---
+  # Sample apps that USE each ORM/framework, per Refs #96 corpus policy.
+  # django-realworld (#176) and node-express-realworld (#178/Prisma) are already
+  # listed above under Python and JavaScript respectively — not duplicated here.
+  "sequelize-express-example|https://github.com/sequelize/express-example.git|master|javascript"   # Sequelize sample app (#177)
+  # --- Build tools (chunk H, umbrella #309) ---
+  # Manifest fixtures: each repo's root Cargo.toml / pom.xml / package.json /
+  # tsconfig is the canonical artifact for the cross/manifest extractor.
+  "maven|https://github.com/apache/maven.git|master|java"                                            # pom.xml multi-module manifest (#170)
+  "nx|https://github.com/nrwl/nx.git|master|typescript"                                              # tsconfig + nx.json manifests (#173)
+  # --- Java enterprise (chunk I, umbrella #302) ---
+  # Sample apps that USE each Java enterprise framework, per Refs #96 corpus policy.
+  "quarkus-quickstarts|https://github.com/quarkusio/quarkus-quickstarts.git|main|java"                # Quarkus sample apps (#181)
+  "micronaut-examples|https://github.com/micronaut-projects/micronaut-examples.git|master|java"       # Micronaut sample apps (#183)
+  "helidon-examples|https://github.com/helidon-io/helidon-examples.git|helidon-4.x|java"              # Helidon sample apps (#186)
+  "vertx-examples|https://github.com/vert-x3/vertx-examples.git|5.x|java"                             # Vert.x sample apps (#190)
+  "dropwizard-example|https://github.com/dropwizard/dropwizard.git|release/5.0.x|java|dropwizard-example" # Dropwizard sample app subtree (#193)
+  "play-java-starter|https://github.com/playframework/play-java-starter-example.git|2.7.x|java"       # Play Framework Java sample app (#197)
+  "spark-examples|https://github.com/perwendel/spark.git|master|java|examples"                        # Spark Java examples subtree (#203)
+  # --- Mobile native (chunk L, umbrella #313) ---
+  # Sample applications across the major mobile native stacks, per Refs #96
+  # corpus policy. Each entry pinned to the SHA recorded in its child issue.
+  "react-native|https://github.com/facebook/react-native.git|main|javascript|template"                 # React Native: template/ subtree per umbrella body (#212)
+  "ionic-conference-app|https://github.com/ionic-team/ionic-conference-app.git|main|typescript"        # Ionic / Capacitor sample app (#215)
+  "maui-samples|https://github.com/dotnet/maui-samples.git|main|csharp"                                # .NET MAUI sample apps (#217)
+  # --- Declarative IaC (chunk N, umbrella #308) ---
+  # Sample/canonical fixtures for declarative IaC + container orchestration
+  # languages, per Refs #96 corpus policy. Each entry pinned to the SHA
+  # recorded in its child issue. ArgoCD (#211) is intentionally NOT re-listed
+  # here: argocd-example-apps is already present above under K8s YAML
+  # (chunk F) and #211 closes via that single fixture.
+  "kustomize|https://github.com/kubernetes-sigs/kustomize.git|master|yaml|examples"                            # Kustomize examples/ subtree (#189)
+  "chef-runit|https://github.com/chef-cookbooks/runit.git|main|ruby"                                           # Chef cookbook (Ruby DSL) (#195)
+  "puppet-control-repo|https://github.com/puppetlabs/control-repo.git|production|ruby"                         # Puppet control repo (Ruby DSL) (#199)
+  "awesome-compose|https://github.com/docker/awesome-compose.git|master|yaml"                                  # Docker Compose canonical samples (#204)
+  # --- Relational ORMs missing (chunk O, umbrella #315) ---
+  # Sample apps that USE each relational ORM / query builder, per Refs #96
+  # corpus policy. Each entry pinned to the SHA recorded in its child issue.
+  "spring-framework-petclinic|https://github.com/spring-petclinic/spring-framework-petclinic.git|main|java"            # Hibernate-only sample app (#251)
+  "express-bookshelf-realworld|https://github.com/tanem/express-bookshelf-realworld-example-app.git|master|javascript" # Knex sample app (#269)
+  "nestjs-realworld-mikroorm|https://github.com/mikro-orm/nestjs-realworld-example-app.git|master|typescript"          # MikroORM sample app (#274)
+  "fabric-ca|https://github.com/hyperledger/fabric-ca.git|main|go"                                                     # sqlx (Go) sample app (#287)
+  "lean|https://github.com/jenssegers/lean.git|master|php"                                                             # Eloquent (standalone) sample app (#288)
+  "sea-orm-examples|https://github.com/SeaQL/sea-orm.git|master|rust|examples"                                         # SeaORM examples/ subtree (#289)
+  # --- NoSQL/cache/streaming (chunk P, umbrella #316) ---
+  # Canonical client/driver fixtures for the major NoSQL, cache, and streaming
+  # ecosystems, per Refs #96 corpus policy. Each entry pinned to the SHA
+  # recorded in its child issue.
+  "pymongo|https://github.com/mongodb/mongo-python-driver.git|master|python"                                  # MongoDB Python driver (#216)
+  "motor|https://github.com/mongodb/motor.git|master|python"                                                  # MongoDB async Python driver (#219)
+  "mongo-java-driver|https://github.com/mongodb/mongo-java-driver.git|main|java"                              # MongoDB Java driver (#221)
+  "ioredis|https://github.com/redis/ioredis.git|main|typescript"                                              # Redis Node.js TypeScript client (#223)
+  "go-redis|https://github.com/redis/go-redis.git|master|go"                                                  # Redis Go client (#225)
+  "lettuce|https://github.com/redis/lettuce.git|main|java"                                                    # Redis Java client (#226)
+  "couchbase-gocb|https://github.com/couchbase/gocb.git|master|go"                                            # Couchbase Go SDK (#232)
+  "nats.go|https://github.com/nats-io/nats.go.git|main|go"                                                    # NATS Go client (#236)
+  "aws-sdk-js-v3|https://github.com/aws/aws-sdk-js-v3.git|main|typescript"                                    # AWS SQS / AWS JS SDK v3 (#237)
+  # --- Programmatic IaC (chunk M, umbrella #314) ---
+  # Programmatic IaC samples across CDK / Pulumi / Bicep / SAM / Serverless
+  # Framework / Crossplane, per Refs #96 corpus policy. Each entry pinned to
+  # the SHA recorded in its child issue. Multi-flavor monorepos
+  # (aws-cdk-examples, pulumi/examples) get one entry per language flavor with
+  # a unique name and a flavor-scoped sparse-path so cone-mode sparse-checkout
+  # keeps each working tree small.
+  "aws-cdk-examples-python|https://github.com/aws-samples/aws-cdk-examples.git|main|python|python"             # AWS CDK Python (#184) SHA f4143ebe9746
+  "aws-cdk-examples-java|https://github.com/aws-samples/aws-cdk-examples.git|main|java|java"                   # AWS CDK Java (#187) SHA f4143ebe9746
+  "aws-cdk-examples-csharp|https://github.com/aws-samples/aws-cdk-examples.git|main|csharp|csharp"             # AWS CDK .NET (#188) SHA f4143ebe9746
+  "aws-cdk-examples-go|https://github.com/aws-samples/aws-cdk-examples.git|main|go|go"                         # AWS CDK Go (#191) SHA f4143ebe9746
+  "pulumi-examples-typescript|https://github.com/pulumi/examples.git|master|typescript|aws-ts-webserver"       # Pulumi TypeScript (#194) SHA d9173c2ed496
+  "pulumi-examples-python|https://github.com/pulumi/examples.git|master|python|aws-py-webserver"               # Pulumi Python (#196) SHA d9173c2ed496
+  "pulumi-examples-csharp|https://github.com/pulumi/examples.git|master|csharp|aws-cs-webserver"               # Pulumi .NET (#202) SHA d9173c2ed496
+  # --- DB migration tools (chunk Y, umbrella #317) ---
+  # Versioned-SQL migration tooling across major ecosystems, per Refs #87
+  # corpus policy. Each entry pinned to the SHA recorded in the umbrella body.
+  # Sparse-paths are applied to the two large monorepos (flyway, liquibase);
+  # the remaining repos are small enough to clone in full.
+  "flyway|https://github.com/flyway/flyway.git|main|java|flyway-core"                                          # Flyway versioned/repeatable SQL migrations (#317) SHA ce65ee118f01
+  "liquibase|https://github.com/liquibase/liquibase.git|main|java|liquibase-standard"                          # Liquibase changelog formats + changesets (#317) SHA e9c06031abc8
+  "knex|https://github.com/knex/knex.git|master|javascript"                                                    # Knex schema-builder migrations + query builder (#317) SHA af57d1ec662a
+  "goose|https://github.com/pressly/goose.git|main|go"                                                         # Goose -- +goose Up/Down SQL annotations + Go migrations (#317) SHA e3235f7041e1
+  "migrate-mongo|https://github.com/seppevs/migrate-mongo.git|master|javascript"                               # MongoDB migration scripts up/down handler (#317) SHA 1f5e5f953491
+  "sequel|https://github.com/jeremyevans/sequel.git|master|ruby"                                               # Sequel.migration { up/down } blocks (#317) SHA 694ea7798374
+  # --- CI/CD pipelines (chunk Q, umbrella #318) ---
+  # Canonical fixtures for CI/CD pipeline formats not yet exercised by the
+  # corpus, per Refs #87. Each entry pinned to the SHA recorded in umbrella
+  # #318. Sparse-paths keep working trees small for the larger monorepos
+  # (gitlab-runner, jenkins, tektoncd/pipeline, skaffold, tilt).
+  "drone|https://github.com/drone/drone.git|main|yaml"                                                          # Drone pipeline steps + plugins (#318) SHA 9f37938bc913
+  "buildkite-agent|https://github.com/buildkite/agent.git|main|yaml|.buildkite"                                 # Buildkite pipeline.yml + plugins (#318) SHA 561444c7fc59
+  "skaffold|https://github.com/GoogleContainerTools/skaffold.git|main|yaml|examples"                            # Skaffold build/deploy/test profiles (#318) SHA 95531aa9b308
+  # --- Build tools missing (chunk R, umbrella #320) ---
+  # Build-tool manifest fixtures not yet exercised: Gradle, Bazel, Make, CMake,
+  # Poetry, Composer, Bundler, Mix, sbt, Leiningen, Lerna (npm workspaces),
+  # Turborepo. Each entry pinned to the SHA recorded in the umbrella body.
+  # Dedup notes: pnpm/pnpm is already present above under chunk H (#172) — the
+  # same clone exercises both package.json and pnpm-workspace.yaml extractors,
+  # so we do NOT re-list it here. Gradle/spring-petclinic overlap is partial:
+  # spring-petclinic is a Gradle-using sample, gradle/gradle is the canonical
+  # multi-project Groovy + Kotlin DSL build source — kept as separate fixture.
+  "gradle|https://github.com/gradle/gradle.git|master|java|subprojects"                                        # Gradle multi-project Groovy + Kotlin DSL (#320) SHA 62000451ad7b
+  "gnu-make|https://git.savannah.gnu.org/git/make.git|master|c"                                                # GNU Make rules, vars, includes (#320) SHA b3802782de3e
+  "poetry|https://github.com/python-poetry/poetry.git|main|python"                                             # Poetry pyproject + lock semantics (#320) SHA 811a12dae0fe
+  "composer|https://github.com/composer/composer.git|main|php"                                                 # PHP Composer manifest + lock (#320) SHA 37825e985129
+  "bundler|https://github.com/rubygems/bundler.git|master|ruby"                                                # Ruby Bundler Gemfile + gemspec (#320) SHA 35be6d9a6030
+  "elixir|https://github.com/elixir-lang/elixir.git|main|elixir"                                               # Elixir Mix project + deps (#320) SHA b8723fea1ec5
+  "sbt|https://github.com/sbt/sbt.git|develop|scala"                                                           # Scala sbt build definition (#320) SHA 76992ed3f62f
+  "leiningen|https://github.com/technomancy/leiningen.git|main|clojure"                                        # Clojure Leiningen project.clj (#320) SHA 40227328d4a9
+  "lerna|https://github.com/lerna/lerna.git|main|javascript"                                                   # npm/yarn workspaces canonical (#320) SHA f4387d673bfd
+  "turborepo|https://github.com/vercel/turborepo.git|main|typescript"                                          # Turborepo pipeline config (#320) SHA c1f923a4abe5
+  # NOTE: pnpm-workspace coverage is satisfied by the existing pnpm entry under
+  # chunk H above (same repo @ same branch).
+  # --- Reverse-proxy/gateway (chunk V, umbrella #326) ---
+  # Canonical fixtures for reverse-proxy and API-gateway configuration formats
+  # not yet exercised by the corpus, per Refs #87. Each entry pinned to the SHA
+  # recorded in umbrella #326. Sparse-paths keep working trees small for the
+  # larger monorepos (nginx, httpd, envoy, kong, traefik).
+  # --- API/Spec/IDL alts (chunk U, umbrella #325) ---
+  # API spec / IDL alternatives beyond OpenAPI, per Refs #87 corpus policy.
+  # Each entry pinned to the SHA verified in the umbrella body via
+  # git ls-remote --symref against canonical upstream branches.
+  # Sparse-paths are applied to the three large monorepos (smithy, avro,
+  # thrift); the remaining four are small enough to clone in full. Where
+  # the umbrella listed multiple sparse subtrees (or glob patterns not
+  # supported by cone-mode sparse-checkout), one canonical IDL/schema
+  # subtree per repo is selected — broad extractor coverage is preserved.
+  # --- Auth/security/observability (chunk S, umbrella #322) ---
+  # Auth (OAuth2/OIDC/JWT/Keycloak/Auth0), security (Vault), and observability
+  # (OpenTelemetry, Prometheus, Sentry, Datadog) client-library consumer apps.
+  # Each entry pinned to the SHA recorded in the umbrella body.
+  "node-openid-client|https://github.com/panva/node-openid-client.git|main|typescript|lib"                       # OAuth2/OIDC client flows, discovery (#322) SHA d3721c2cab93
+  "node-jsonwebtoken|https://github.com/auth0/node-jsonwebtoken.git|master|javascript"                           # JWT sign/verify consumer patterns (#322) SHA 02688b982132
+  "keycloak|https://github.com/keycloak/keycloak.git|main|java|core"                                             # Keycloak Java SDK adapters (#322) SHA 8938558fa5c7
+  "auth0-spa-js|https://github.com/auth0/auth0-spa-js.git|main|typescript|src"                                   # Auth0 SPA SDK login/logout/token (#322) SHA c66e8b7400f2
+  "vault|https://github.com/hashicorp/vault.git|main|go|api"                                                     # HashiCorp Vault Go client (#322) SHA 54a22347c3fa
+  "opentelemetry-js|https://github.com/open-telemetry/opentelemetry-js.git|main|typescript|packages"             # OpenTelemetry tracing/metrics SDK (#322) SHA 95e48e7afcc4
+  "prometheus-client-golang|https://github.com/prometheus/client_golang.git|main|go|prometheus"                  # Prometheus Go client metrics (#322) SHA 0ac87e14c303
+  "sentry-javascript|https://github.com/getsentry/sentry-javascript.git|develop|typescript|packages"             # Sentry SDK init + capture (#322) SHA 298807727c81
+  "dd-trace-js|https://github.com/DataDog/dd-trace-js.git|master|javascript|packages"                            # Datadog APM tracer instrumentations (#322) SHA 807fceb14d1a
+  # --- Validation + Lint configs (chunk T, umbrella #324) ---
+  # Validation libraries (Zod, Joi, Yup, Pydantic, class-validator) and lint
+  # configurations (ESLint, Prettier, Ruff, RuboCop, golangci-lint, Clippy)
+  # per Refs #87. Each entry pinned to the SHA recorded in the umbrella body.
+  # Sparse paths from the umbrella are documented in comments; the harness
+  # entry uses a full clone because the parser supports a single sparse path
+  # only and these fixtures list multiple paths each.
+  "joi|https://github.com/hapijs/joi.git|master|javascript"                                                    # Joi schema + extensions (#324) SHA 048fe05b8235 paths lib/ test/
+  "yup|https://github.com/jquense/yup.git|master|typescript"                                                   # Yup object/array validation (#324) SHA ff31eee8a2b1 paths src/ test/
+  "class-validator|https://github.com/typestack/class-validator.git|develop|typescript"                        # class-validator decorators (#324) SHA 2e1a5c27dbd6 paths src/ test/
+  "eslint|https://github.com/eslint/eslint.git|main|javascript"                                                # ESLint flat + legacy config (#324) SHA a4297918d264 paths lib/ conf/ eslint.config.js
+  "prettier|https://github.com/prettier/prettier.git|main|javascript"                                          # Prettier config + plugin discovery (#324) SHA f3db616d8389 paths .prettierrc* src/config/
+  "ruff|https://github.com/astral-sh/ruff.git|main|python"                                                     # ruff config + rule selectors (#324) SHA 8091ad11d15f paths ruff.toml pyproject.toml crates/
+  "rubocop|https://github.com/rubocop/rubocop.git|master|ruby"                                                 # RuboCop cop config + inheritance (#324) SHA 11262e1cdb45 paths .rubocop.yml config/
+  "golangci-lint|https://github.com/golangci/golangci-lint.git|main|go"                                        # golangci-lint linters + presets (#324) SHA ef3710ea5470 paths .golangci.yml pkg/config/
+  "rust-clippy|https://github.com/rust-lang/rust-clippy.git|master|rust"                                       # Clippy lint config + categories (#324) SHA f763854b8bd3 paths clippy.toml clippy_lints/
+  # --- Serverless (chunk Z, umbrella #319) ---
+  # Function-only repos covering all major serverless platforms and Lambda
+  # runtimes. Exercises handler detection, function-config parsing
+  # (SAM/serverless/wrangler/netlify/vercel), and per-runtime entry points.
+  # Each entry pinned to the SHA recorded in umbrella #319.
+  "aws-lambda-developer-guide|https://github.com/awsdocs/aws-lambda-developer-guide.git|main|javascript|sample-apps"  # Lambda Node handler shape, SAM template.yaml (#319) SHA 8a681ab924e4
+  "aws-lambda-java-libs|https://github.com/aws/aws-lambda-java-libs.git|main|java|aws-lambda-java-core"               # Java Lambda handler interfaces, event POJOs (#319) SHA c4dcbab4ffed
+  "aws-lambda-go|https://github.com/aws/aws-lambda-go.git|main|go|lambda"                                              # Go Lambda handler signatures, event types (#319) SHA 815d21f41769
+  "aws-lambda-rust-runtime|https://github.com/awslabs/aws-lambda-rust-runtime.git|main|rust|lambda-runtime"            # Rust Lambda runtime crate, handler macros (#319) SHA 01237499db5f
+  "vercel-examples|https://github.com/vercel/examples.git|main|typescript|edge-functions"                              # Vercel Edge/Serverless function shape, vercel.json (#319) SHA 72aaac1ba427
+  "netlify-functions|https://github.com/netlify/functions.git|main|typescript|src"                                     # Netlify Functions handler types, netlify.toml (#319) SHA c3f47247079e
+  "functions-framework-nodejs|https://github.com/GoogleCloudPlatform/functions-framework-nodejs.git|main|typescript|src"  # GCF Functions Framework HTTP/CloudEvent handlers (#319) SHA 243202d5e133
+  # --- State management (chunk AA, umbrella #321) ---
+  # Frontend state-management libraries exercising store/atom/machine detection
+  # across Redux, MobX, Zustand, Pinia, NgRx, Recoil, XState, Effector per
+  # Refs #87. Each entry pinned to the SHA recorded in the umbrella body.
+  "redux|https://github.com/reduxjs/redux.git|master|typescript|packages/toolkit"                              # Redux reducers/actions, Toolkit slices (#321) SHA 38faff513dc2
+  "mobx|https://github.com/mobxjs/mobx.git|main|typescript|packages/mobx"                                     # MobX observables, computed, reactions (#321) SHA 03f420ac4a29
+  "zustand|https://github.com/pmndrs/zustand.git|main|typescript|src"                                         # Zustand `create` stores, middleware (#321) SHA 3fca84617984
+  "pinia|https://github.com/vuejs/pinia.git|v4|typescript|packages/pinia"                                     # Pinia `defineStore`, Vue 3 stores (#321) SHA e329b3805486 (Vue SFC + TS dual extraction)
+  "ngrx-platform|https://github.com/ngrx/platform.git|main|typescript|modules/store"                          # NgRx actions/reducers/effects (#321) SHA a469cbf01562
+  "recoil|https://github.com/facebookexperimental/Recoil.git|main|typescript|packages/recoil"                 # Recoil atoms/selectors (#321) SHA c1b97f3a0117
+  "effector|https://github.com/effector/effector.git|master|typescript|src"                                   # Effector stores/events/effects (#321) SHA 29553bb13dc3
+  # --- Static-site generators (chunk W, umbrella #298) ---
+  # Static-site generator fixtures across the major SSG ecosystems
+  # (Hugo, Jekyll, Hexo, MkDocs, Sphinx, VitePress, Docusaurus, Nextra,
+  # Eleventy), per Refs #87 corpus policy. Each entry pinned to the SHA
+  # recorded in umbrella #298. Where the umbrella listed multiple sparse
+  # subtrees, one canonical content/template subtree per repo is selected
+  # (cone-mode sparse-checkout supports a single path); the harness language
+  # tag is the dominant code-extractor for the repo, with Markdown / front-
+  # matter / template-engine extractors exercised via the sparse subtree.
+  # Dedup notes: Gatsby is intentionally excluded here per the umbrella body
+  # (already covered by chunk K, per the master plan).
+  "jekyll|https://github.com/jekyll/jekyll.git|master|ruby|lib"                                               # Liquid templating, Jekyll plugin model (#298) SHA 202df571314b
+  "hexo-site|https://github.com/hexojs/site.git|master|javascript|source"                                     # Hexo theming + Markdown content tree (#298) SHA fcf644467039
+  "mkdocs|https://github.com/mkdocs/mkdocs.git|master|python|mkdocs"                                          # MkDocs plugin/theme system, mkdocs.yml config (#298) SHA 2862536793b3
+  "vitepress|https://github.com/vuejs/vitepress.git|main|typescript|src"                                      # VitePress theme, Vue SFC + Markdown blend (#298) SHA 6ee01bf30534
+  "docusaurus|https://github.com/facebook/docusaurus.git|main|typescript|packages/docusaurus"                 # MDX extractor, Docusaurus plugin packages (#298) SHA 5f60ae9c872d
+  "nextra|https://github.com/shuding/nextra.git|main|typescript|packages/nextra"                              # Nextra theme + MDX content trees (#298) SHA e604c7fe937e
+  "eleventy|https://github.com/11ty/eleventy.git|main|javascript|src"                                         # Eleventy template engines, .eleventy.js config (#298) SHA 4a6b85f64eef
+  # --- Testing frameworks (chunk X, umbrella #312) ---
+  # Testing-framework-dominated repos so the harness exercises test-file
+  # detection, fixture parsing, and framework-specific patterns (Jest, Mocha,
+  # Cypress, Playwright, Selenium, JUnit 5, RSpec, pytest, Karate, Cucumber).
+  # Each entry pinned to the SHA recorded in the umbrella body and verified
+  # via git ls-remote --symref. Sparse paths from the umbrella are documented
+  # in trailing comments; entries use a full clone where the umbrella lists
+  # multiple sparse paths because the parser supports a single sparse path
+  # only. seleniumhq.github.io uses its single /examples sparse-path.
+  "jest|https://github.com/jestjs/jest.git|main|typescript"                                                   # Jest config, snapshot tests, mock factories (#312) SHA 746b14333fbd paths packages/ e2e/
+  "mocha|https://github.com/mochajs/mocha.git|main|javascript"                                                # Mocha BDD/TDD interfaces, hooks, reporters (#312) SHA 441c32aa076f paths lib/ test/
+  "cypress-realworld-app|https://github.com/cypress-io/cypress-realworld-app.git|develop|typescript"          # Cypress E2E specs, custom commands, fixtures (#312) SHA 84008795de05 paths cypress/ src/
+  "playwright|https://github.com/microsoft/playwright.git|main|typescript"                                    # Playwright test runner, fixtures, projects (#312) SHA c17e0b45c12f paths packages/playwright/ tests/
+  "junit5-samples|https://github.com/junit-team/junit5-samples.git|main|java"                                 # JUnit 5 Jupiter API, parameterized tests (#312) SHA c8828652e601 paths junit5-jupiter-starter-gradle/ junit5-jupiter-starter-maven/
+  "rspec-rails|https://github.com/rspec/rspec-rails.git|main|ruby"                                            # RSpec describe/it/expect, Rails matchers (#312) SHA 810f2a48950c paths lib/ spec/
+  "karate|https://github.com/karatelabs/karate.git|main|java"                                                 # Karate .feature files, API/UI test DSL (#312) SHA 38db45133982 paths karate-core/ examples/
+  "cucumber-js|https://github.com/cucumber/cucumber-js.git|main|typescript"                                   # Cucumber.js step defs, Gherkin .feature parsing (#312) SHA 1c9e7022eae1 paths src/ features/
+  # --- Realtime/WebSocket/messaging (chunk BB, umbrella #323) ---
+  # Consumer apps and libraries showcasing realtime/messaging protocols so the
+  # harness exercises socket-handler detection and event-driven patterns. Each
+  # entry pinned to the SHA recorded in the umbrella body and verified via
+  # git ls-remote --symref. Sparse paths from the umbrella are documented in
+  # trailing comments; entries use a full clone or a single canonical sparse
+  # subtree because cone-mode sparse-checkout supports a single path. The
+  # mdn/dom-examples substitution (no canonical SSE-only repo exists) is
+  # scoped to its WebSocket subtree as the dominant realtime surface; the
+  # /server-sent-events sibling is exercised via separate JS/HTML extractors
+  # when the WS/SSE patterns coincide in scope.
+  "pusher-js|https://github.com/pusher/pusher-js.git|master|typescript|src"                                    # Pusher channel subscribe/bind, presence channels (#323) SHA e58a5d22e063 paths src/ spec/
+  "ably-js|https://github.com/ably/ably-js.git|main|typescript|src"                                            # Ably Realtime channels, message envelopes (#323) SHA 498d26dfb16b paths src/ test/
+  "MQTT.js|https://github.com/mqttjs/MQTT.js.git|main|typescript|src"                                          # MQTT publish/subscribe, topic filters, QoS (#323) SHA a4e9a92c8710 paths src/ test/
+  "pion-webrtc|https://github.com/pion/webrtc.git|main|go"                                                     # WebRTC peer connection, data channels in Go (#323) SHA 9654161f9b69 paths /. examples/
+  "mdn-dom-examples|https://github.com/mdn/dom-examples.git|main|javascript|web-sockets"                       # Native WebSocket usage examples (#323) SHA f8aa45c93985 paths server-sent-events/ web-sockets/
+  # --- Game/embedded (chunk CC, umbrella #291) ---
+  # Game-engine and embedded-systems sample fixtures, per Refs #87 corpus
+  # policy. Each entry pinned to the SHA recorded in umbrella #291 and
+  # verified via git ls-remote --symref against canonical upstream branches.
+  # Sparse-paths keep working trees small for the larger monorepos
+  # (EntityComponentSystemSamples, esp-idf); the remaining repos are small
+  # enough to clone in full. EpicGames/UnrealEngine is private; substituted
+  # 20tab/UnrealEnginePython (public C++ Unreal bindings) for `.h`/`.cpp`
+  # coverage per the umbrella body.
+  "UnrealEnginePython|https://github.com/20tab/UnrealEnginePython.git|master|cpp|Source/UnrealEnginePython/Public"                                            # C++17 Unreal-style headers — UCLASS/UPROPERTY macros, .h/.cpp split, namespaced bindings (#291) SHA 4b5da5bf4ca5
+  "bevy|https://github.com/bevyengine/bevy.git|main|rust|crates/bevy_ecs/src"                                                                                  # Rust ECS with heavy trait-bound generics, derive macros, workspace crates (#291) SHA 7dda2bc7fcd2
+  "arduino-examples|https://github.com/arduino/arduino-examples.git|main|cpp|examples"                                                                         # Arduino sketches — .ino (C++ flavour) global setup()/loop(), embedded idioms (#291) SHA 4c5fa7a66b42
+  "micropython|https://github.com/micropython/micropython.git|master|python|examples"                                                                          # MicroPython firmware-side scripts — top-level imports, no-stdlib subset (#291) SHA a595bbba6727
+  "cortex-m-quickstart|https://github.com/rust-embedded/cortex-m-quickstart.git|master|rust|src"                                                                # Embedded no_std Rust — #![no_main], #[entry] attributes, panic handlers (#291) SHA 7a6a7c2c8b94
+
+  # --- Workflow/orchestration (chunk EE, umbrella #293) ---
+  # Workflow- and orchestration-engine repos so the harness exercises
+  # workflow/activity definitions, DAG schedulers, decorators, and BPMN
+  # process XML alongside Java service-task implementations. Each entry is
+  # pinned to the SHA recorded in the umbrella body and verified via
+  # git ls-remote --symref. Sparse paths from the umbrella are documented
+  # in trailing comments; entries use a full clone where the umbrella lists
+  # multiple sparse paths because the parser supports a single sparse path
+  # only.
+  "temporalio-samples-go|https://github.com/temporalio/samples-go.git|main|go"                                 # Temporal Go workflow.ExecuteActivity, signal/query handlers (#293) SHA c5c710404fbf paths helloworld/ child_workflow/ mutex/
+  "cadence-client|https://github.com/uber-go/cadence-client.git|master|go|internal"                            # Cadence Go client workflow registration, activity options (#293) SHA df799e0e8164
+  "prefect|https://github.com/PrefectHQ/prefect.git|main|python"                                               # Prefect @flow/@task decorators, deployment specs (#293) SHA fe44ad330730 paths src/prefect/flows.py examples/
+  "dagster|https://github.com/dagster-io/dagster.git|master|python|examples/quickstart_etl"                    # Dagster @asset/@op/@job decorators, IO managers (#293) SHA 50915f9cab16
+
+  # --- Data/ML/notebook (chunk DD, umbrella #292) ---
+  # Data, ML, and notebook ecosystems exercising scikit-learn / PyTorch / Keras
+  # / Transformers consumer idioms, the .ipynb extractor, Polars/Spark big-data
+  # APIs, and dbt SQL+Jinja models. Each entry pinned to the SHA recorded in
+  # umbrella #292 and verified via git ls-remote --symref on 2026-05-09.
+  "scikit-learn|https://github.com/scikit-learn/scikit-learn.git|main|python|examples"                        # scikit-learn Pipeline/fit/transform consumer idioms (#292) SHA a421648c9d5b
+  "pytorch-examples|https://github.com/pytorch/examples.git|main|python|mnist"                                # PyTorch nn.Module/forward/DataLoader patterns (#292) SHA acc295dc7b90
+  "keras-io|https://github.com/keras-team/keras-io.git|master|python|examples"                                # TF/Keras functional API, Model.fit, custom layers (#292) SHA 524c0d7ae593
+  "transformers|https://github.com/huggingface/transformers.git|main|python|examples/pytorch"                 # HF Transformers AutoModel/tokenizer/Trainer (#292) SHA c9de1097eed9
+  "polars|https://github.com/pola-rs/polars.git|main|python|py-polars/tests/unit"                             # Polars lazy frames, pl.col expressions, chained transforms (#292) SHA a84168f0a4f1
+  # --- Frontend SPA frameworks (chunk K, umbrella #303) ---
+  # Sample applications across the major frontend SPA / meta-framework stacks,
+  # per Refs #96 corpus policy. Each entry pinned to the SHA recorded in its
+  # child issue and verified via git ls-remote --symref on 2026-05-10. Gatsby
+  # is intentionally NOT in chunk W (#298) — it is owned by chunk K via #279.
+  "react-redux-realworld|https://github.com/gothinkster/react-redux-realworld-example-app.git|master|javascript"   # React (CRA) sample app (#227) SHA ee72eba40563
+  "vite|https://github.com/vitejs/vite.git|main|typescript"                                                        # Vite (React+TS bundler) (#229) SHA cf0ff4154b26
+  "vue-realworld|https://github.com/gothinkster/vue-realworld-example-app.git|master|javascript"                   # Vue sample app (#231) SHA 3df3773b6be7
+  "svelte-realworld|https://github.com/sveltejs/realworld.git|master|javascript"                                   # Svelte sample app (#233) SHA e80873cac4e6
+  "solid-templates|https://github.com/solidjs/templates.git|main|typescript"                                       # SolidJS templates (#238) SHA a48da0c79ecf
+  "preact-cli|https://github.com/developit/preact-cli.git|master|javascript"                                       # Preact CLI scaffold (#239) SHA e826f7caab0d
+  "ember-super-rentals|https://github.com/ember-learn/super-rentals.git|main|javascript"                           # Ember sample app (#243) SHA 5d11a767bdc1
+  "astro|https://github.com/withastro/astro.git|main|typescript"                                                   # Astro framework (#247) SHA d365c975ba2d
+  "remix-indie-stack|https://github.com/remix-run/indie-stack.git|main|typescript"                                 # Remix indie-stack sample (#252) SHA 56abb93bf81f
+  "nuxt-starter|https://github.com/nuxt/starter.git|templates|typescript"                                          # Nuxt starter templates (#256) SHA cc96964ee7a1
+  "lit-element-starter|https://github.com/lit/lit-element-starter-ts.git|main|typescript"                          # Lit / Web Components starter (#261) SHA 6bf882733abd
+  "htmx|https://github.com/bigskysoftware/htmx.git|master|javascript"                                              # HTMX library (#266) SHA dbf77dd5207d
+  "alpine|https://github.com/alpinejs/alpine.git|main|javascript"                                                  # Alpine.js library (#271) SHA 3b125f96058a
+  "qwik|https://github.com/QwikDev/qwik.git|main|typescript"                                                       # Qwik framework (#276) SHA 38620076e10e
+  "gatsby-starter-blog|https://github.com/gatsbyjs/gatsby-starter-blog.git|master|javascript"                      # Gatsby starter blog (#279) SHA 04ec3e642112
+
+  # --- Web framework alts (chunk J, umbrella #311) ---
+  # Alternate web framework sample apps spanning Go (Echo/Fiber/Beego),
+  # Node (Fastify/Koa/Hapi/Sails/AdonisJS), Python (Tornado/Starlette/
+  # Pyramid/Bottle), PHP (Slim/CodeIgniter/Yii), Ruby (Sinatra/Hanami/
+  # Grape), Rust (Axum/Rocket/Warp/Tide), Scala (Akka HTTP/http4s),
+  # Clojure (Compojure/Pedestal), Elixir (Plug/Phoenix LiveView), and
+  # Kotlin (Javalin/http4k). Each entry pinned to the SHA recorded in
+  # the umbrella body and verified via git ls-remote --symref on
+  # 2026-05-10. Sparse paths are not used for these entries — the
+  # repos are sample apps or single-framework sources at HEAD size.
+  "echox|https://github.com/labstack/echox.git|master|go"                                                     # Echo v4 sample app: e.Group, middleware, route handlers (#240) SHA f938a8c5e04e
+  "gofiber-recipes|https://github.com/gofiber/recipes.git|master|go"                                          # Fiber app.Get/Post, middleware chains, sub-routers (#241) SHA 041c1976144d
+  "beego-example|https://github.com/beego/beego-example.git|master|go"                                        # Beego controllers, web.Router, ORM models (#242) SHA 7b8dfaf49040
+  "fastify-demo|https://github.com/fastify/demo.git|main|javascript"                                          # Fastify fastify.register, schema-validated routes (#244) SHA 5fa922df34d0
+  "koa-examples|https://github.com/koajs/examples.git|master|javascript"                                      # Koa app.use middleware, ctx.body, koa-router (#245) SHA 40c77dbecec6
+  "hapi|https://github.com/hapijs/hapi.git|master|javascript"                                                 # Hapi server.route, Joi validation, plugins (#246) SHA d4f93d80e6ac
+  "sails-examples|https://github.com/balderdashy/sails-examples.git|master|javascript"                        # Sails MVC controllers, blueprints, Waterline models (#248) SHA c8e7c8c41640
+  "adonis-blog-demo|https://github.com/adonisjs-community/adonis-blog-demo.git|master|javascript"             # AdonisJS Route.get, Controllers, Lucid ORM (#249) SHA 2262706c39a6
+  "tornado|https://github.com/tornadoweb/tornado.git|master|python"                                           # Tornado RequestHandler subclasses, async get/post (#250) SHA 87508512caab
+  "starlette|https://github.com/encode/starlette.git|main|python"                                             # Starlette Route()/Mount(), ASGI middleware (#253) SHA 7793b925a88e
+  "pyramid-shootout|https://github.com/Pylons/shootout.git|master|python"                                     # Pyramid config.add_route, view_config decorators (#254) SHA e5691d6f5ac0
+  "bottle|https://github.com/bottlepy/bottle.git|master|python"                                               # Bottle @route/@get/@post decorators, Bottle() apps (#255) SHA 2a743a302a71
+  "slim-skeleton|https://github.com/slimphp/Slim-Skeleton.git|main|php"                                       # Slim 4 $app->get/post, PSR-15 middleware, DI container (#258) SHA 0ef01549870b
+  "codeigniter-shield|https://github.com/codeigniter4/shield.git|develop|php"                                 # CodeIgniter 4 Controllers, $routes->group, filters (#260) SHA 34be62ba858d
+  "yii2-app-basic|https://github.com/yiisoft/yii2-app-basic.git|master|php"                                   # Yii2 Controllers, ActiveRecord models, URL rules (#262) SHA 660f9bd23cba
+  "sinatra-recipes|https://github.com/sinatra/sinatra-recipes.git|main|ruby"                                  # Sinatra get/post DSL, modular Sinatra::Base apps (#263) SHA 5430c1a5b613
+  "hanami|https://github.com/hanami/hanami.git|main|ruby"                                                     # Hanami actions, Hanami::Router, slice architecture (#265) SHA 116847bfdf9f
+  "grape-on-rack|https://github.com/ruby-grape/grape-on-rack.git|master|ruby"                                 # Grape API DSL: resource/get/post, params validation (#267) SHA 27b711871229
+  "rocket|https://github.com/rwf2/Rocket.git|master|rust"                                                     # Rocket #[get]/#[post] attribute macros, Form/Json (#270) SHA 3a54d079aef0
+  "warp|https://github.com/seanmonstar/warp.git|master|rust"                                                  # Warp Filter combinators: warp::path, .and(), .map() (#272) SHA 707866ca367d
+  "tide|https://github.com/http-rs/tide.git|main|rust"                                                        # Tide app.at()/get()/post(), async middleware (#273) SHA b32f680d5bd1
+  "akka-http|https://github.com/akka/akka-http.git|main|scala"                                                # Akka HTTP Route DSL: path/get/post directives (#275) SHA d3ef24b4d0a3
+  "http4s|https://github.com/http4s/http4s.git|series/0.23|scala"                                             # http4s HttpRoutes.of partial functions, cats-effect (#277) SHA 134ca10c55c3
+  "compojure|https://github.com/weavejester/compojure.git|master|clojure"                                     # Compojure defroutes, GET/POST macros, ring middleware (#278) SHA 8a4758d28e8f
+  "pedestal|https://github.com/pedestal/pedestal.git|master|clojure"                                          # Pedestal interceptor chains, table-routes, service map (#281) SHA 4bda462b501c
+  "elixir-plug|https://github.com/elixir-plug/plug.git|main|elixir"                                           # Plug.Router, plug pipelines, Plug.Conn transformations (#282) SHA a447199b337d
+  "javalin-samples|https://github.com/javalin/javalin-samples.git|main|kotlin"                                # Javalin app.get/post lambdas, route handlers, Jackson DTOs (#285) SHA 3064bf479c58
+)
+
+# Locate or build the archigraph binary. We build into the corpora dir
+# (outside the repo) so this script is safe to run from any worktree.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+
+if [[ -n "${ARCHIGRAPH_BIN:-}" ]]; then
+  BIN="$ARCHIGRAPH_BIN"
+else
+  BIN="$CORPORA_DIR/_bin/archigraph"
+  mkdir -p "$(dirname "$BIN")"
+  echo "==> building archigraph -> $BIN" >&2
+  ( cd "$REPO_ROOT" && go build -o "$BIN" ./cmd/archigraph )
+fi
+
+if [[ ! -x "$BIN" ]]; then
+  echo "archigraph binary not executable: $BIN" >&2
+  exit 1
+fi
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
+REPORT="$REPORTS_DIR/$TIMESTAMP.md"
+# Per-run scratch dir lives under _reports/ (NOT mktemp) so partial state
+# survives abort/SIGKILL/timeout — earlier behavior wiped per-repo JSON on
+# EXIT, making partial runs unsalvageable. The dir is only deleted at the
+# end of a successful run, gated by a `.complete` sentinel written by the
+# final aggregation step. Anything without a sentinel is preserved for
+# post-mortem; operators can `rm -rf` stale `*-partial/` dirs by hand.
+TMPDIR_AGG="$REPORTS_DIR/${TIMESTAMP}-partial"
+mkdir -p "$TMPDIR_AGG"
+trap '[[ -f "$TMPDIR_AGG/.complete" ]] && rm -rf "$TMPDIR_AGG"' EXIT
+
+# Optional per-repo wall-clock cap (seconds). Set ARCHIGRAPH_VERIFY2_TIMEOUT=0
+# to disable. Uses gtimeout (coreutils) if available, then timeout, then
+# silently skips capping on systems with neither.
+PER_REPO_TIMEOUT="${ARCHIGRAPH_VERIFY2_TIMEOUT:-600}"
+TIMEOUT_BIN=""
+if command -v gtimeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="gtimeout"
+elif command -v timeout >/dev/null 2>&1; then
+  TIMEOUT_BIN="timeout"
+fi
+
+# Write the language manifest used by the per-language aggregation step.
+LANG_MANIFEST="$TMPDIR_AGG/_languages.tsv"
+: >"$LANG_MANIFEST"
+for entry in "${REPOS[@]}"; do
+  IFS='|' read -r name url ref lang sparse <<<"$entry"
+  printf '%s\t%s\n' "$name" "$lang" >>"$LANG_MANIFEST"
+done
+
+# Markdown report header.
+{
+  echo "# VERIFY-2 bug-rate report"
+  echo
+  echo "- generated_at: \`$TIMESTAMP\`"
+  echo "- corpora_dir: \`$CORPORA_DIR\`"
+  echo "- archigraph_bin: \`$BIN\`"
+  echo
+  echo "## Per-repo results"
+  echo
+  echo "| repo | files | entities | relationships | bug_rate | resolution_rate |"
+  echo "| --- | ---: | ---: | ---: | ---: | ---: |"
+} >"$REPORT"
+
+clone_or_update() {
+  local name="$1" url="$2" ref="$3" sparse="${4:-}"
+  local dest="$CORPORA_DIR/$name"
+  if [[ -d "$dest/.git" ]]; then
+    echo "==> updating $name" >&2
+    ( cd "$dest" && git fetch --depth 1 origin "$ref" >/dev/null 2>&1 && git checkout -q FETCH_HEAD ) || true
+    return 0
+  fi
+  if [[ -n "$sparse" ]]; then
+    echo "==> sparse-cloning $name @ $ref (subset: $sparse)" >&2
+    # Blob-less partial clone + cone-mode sparse checkout. We deliberately
+    # do not pass --depth here because partial clones with --depth+--branch
+    # are flaky on older git versions; the blob filter alone keeps the
+    # working set small.
+    if ! git clone --filter=blob:none --no-checkout --branch "$ref" "$url" "$dest" >/dev/null 2>&1; then
+      git clone --filter=blob:none --no-checkout "$url" "$dest" >/dev/null 2>&1
+    fi
+    ( cd "$dest" \
+      && git sparse-checkout init --cone >/dev/null 2>&1 \
+      && git sparse-checkout set "$sparse" >/dev/null 2>&1 \
+      && git checkout -q "$ref" 2>/dev/null \
+        || git checkout -q FETCH_HEAD 2>/dev/null \
+        || git checkout -q ) || true
+  else
+    echo "==> cloning $name @ $ref" >&2
+    git clone --depth 1 --branch "$ref" "$url" "$dest" >/dev/null 2>&1 || \
+      git clone --depth 1 "$url" "$dest" >/dev/null 2>&1
+  fi
+}
+
+run_one() {
+  local name="$1"
+  local dest="$CORPORA_DIR/$name"
+  local out="$TMPDIR_AGG/$name.json"
+  local stderr_log="$TMPDIR_AGG/$name.stderr"
+  echo "==> indexing $name" >&2
+  local rc=0
+  if [[ -n "$TIMEOUT_BIN" && "$PER_REPO_TIMEOUT" != "0" ]]; then
+    "$TIMEOUT_BIN" --foreground "${PER_REPO_TIMEOUT}s" \
+      "$BIN" index --json-stats "$dest" >"$out" 2>"$stderr_log" || rc=$?
+  else
+    "$BIN" index --json-stats "$dest" >"$out" 2>"$stderr_log" || rc=$?
+  fi
+  if [[ $rc -ne 0 ]]; then
+    if [[ -n "$TIMEOUT_BIN" && $rc -eq 124 ]]; then
+      echo "  ! indexer timed out after ${PER_REPO_TIMEOUT}s for $name" >&2
+    else
+      echo "  ! indexer failed (rc=$rc); see $stderr_log" >&2
+    fi
+    return 1
+  fi
+  # Extract numbers via a small inline python (jq not assumed present).
+  python3 - "$out" "$REPORT" "$name" <<'PY'
+import json, sys
+path, report, name = sys.argv[1], sys.argv[2], sys.argv[3]
+with open(path) as fh:
+    d = json.load(fh)
+row = "| {name} | {files} | {ent} | {rel} | {br:.2%} | {rr:.2%} |\n".format(
+    name=name,
+    files=d.get("files", 0),
+    ent=d.get("entities", 0),
+    rel=d.get("relationships", 0),
+    br=d.get("bug_rate", 0.0),
+    rr=d.get("resolution_rate", 0.0),
+)
+with open(report, "a") as fh:
+    fh.write(row)
+PY
+}
+
+for entry in "${REPOS[@]}"; do
+  IFS='|' read -r name url ref lang sparse <<<"$entry"
+  clone_or_update "$name" "$url" "$ref" "${sparse:-}"
+  if ! run_one "$name"; then
+    echo "| $name | ERROR | - | - | - | - |" >>"$REPORT"
+    continue
+  fi
+done
+
+# Fail-fast: if no per-repo JSON files were produced, or every produced
+# JSON had files=0, exit 1 instead of writing an empty report. This guards
+# against silent corpus drift (e.g., clone failures, every clone empty).
+python3 - "$TMPDIR_AGG" <<'PY' || { echo "VERIFY-2: empty corpus — no repos indexed or all repos had files=0" >&2; exit 1; }
+import json, os, sys, glob
+tmp = sys.argv[1]
+paths = sorted(glob.glob(os.path.join(tmp, "*.json")))
+if not paths:
+    sys.exit(1)
+total_files = 0
+for p in paths:
+    with open(p) as fh:
+        d = json.load(fh)
+    total_files += d.get("files", 0)
+if total_files == 0:
+    sys.exit(1)
+sys.exit(0)
+PY
+
+# Aggregate dispositions across every per-repo JSON file. Adds:
+#   - aggregate row inside the per-repo table
+#   - per-repo disposition table for each repo
+#   - corpus-wide aggregate metric table
+#   - corpus-wide disposition breakdown
+#   - per-language aggregate (using the LANG_MANIFEST written above)
+#   - ship-gate check
+python3 - "$TMPDIR_AGG" "$REPORT" "$LANG_MANIFEST" <<'PY'
+import json, os, sys, glob
+tmp, report, manifest = sys.argv[1], sys.argv[2], sys.argv[3]
+
+DISPOSITIONS = [
+    "resolved",
+    "external-known",
+    "external-unknown",
+    "dynamic",
+    "bug-extractor",
+    "bug-resolver",
+    "unclassified",
+]
+
+# Load language manifest: name -> language.
+lang_of = {}
+with open(manifest) as fh:
+    for line in fh:
+        line = line.rstrip("\n")
+        if not line:
+            continue
+        parts = line.split("\t")
+        if len(parts) != 2:
+            continue
+        lang_of[parts[0]] = parts[1]
+
+per_repo = {}
+for p in sorted(glob.glob(os.path.join(tmp, "*.json"))):
+    with open(p) as fh:
+        d = json.load(fh)
+    name = os.path.splitext(os.path.basename(p))[0]
+    per_repo[name] = d
+
+# Aggregate row in the per-repo table (still inside ## Per-repo results).
+totals = {"files": 0, "entities": 0, "relationships": 0}
+endpoints_total = 0
+endpoints_resolved = 0
+endpoints_bug = 0
+agg_dispo = {k: 0 for k in DISPOSITIONS}
+for name, d in per_repo.items():
+    totals["files"] += d.get("files", 0)
+    totals["entities"] += d.get("entities", 0)
+    totals["relationships"] += d.get("relationships", 0)
+    for k, v in d.get("disposition_counts", {}).items():
+        agg_dispo[k] = agg_dispo.get(k, 0) + v
+        endpoints_total += v
+        if k == "resolved":
+            endpoints_resolved += v
+        if k in ("bug-extractor", "bug-resolver"):
+            endpoints_bug += v
+agg_br = (endpoints_bug / endpoints_total) if endpoints_total else 0.0
+agg_rr = (endpoints_resolved / endpoints_total) if endpoints_total else 0.0
+
+with open(report, "a") as fh:
+    # Aggregate row at the bottom of the per-repo table.
+    fh.write("| **AGGREGATE** | **{f}** | **{e}** | **{r}** | **{br:.2%}** | **{rr:.2%}** |\n".format(
+        f=totals["files"], e=totals["entities"], r=totals["relationships"],
+        br=agg_br, rr=agg_rr))
+
+    # Per-repo disposition tables.
+    fh.write("\n## Per-repo disposition breakdown\n")
+    for name in sorted(per_repo):
+        d = per_repo[name]
+        counts = d.get("disposition_counts", {})
+        repo_total = sum(counts.get(k, 0) for k in DISPOSITIONS)
+        fh.write(f"\n### {name}\n\n")
+        fh.write("| disposition | count | pct |\n| --- | ---: | ---: |\n")
+        for k in DISPOSITIONS:
+            v = counts.get(k, 0)
+            pct = (v / repo_total) if repo_total else 0.0
+            fh.write(f"| {k} | {v} | {pct:.2%} |\n")
+        fh.write(f"| **total** | **{repo_total}** | **100.00%** |\n")
+
+    # Corpus-wide aggregate metric table.
+    fh.write("\n## Aggregate\n\n")
+    fh.write("| metric | value |\n| --- | ---: |\n")
+    fh.write(f"| total_files | {totals['files']} |\n")
+    fh.write(f"| total_entities | {totals['entities']} |\n")
+    fh.write(f"| total_relationships | {totals['relationships']} |\n")
+    fh.write(f"| endpoints_classified | {endpoints_total} |\n")
+    fh.write(f"| bug_rate | {agg_br:.4%} |\n")
+    fh.write(f"| resolution_rate | {agg_rr:.4%} |\n")
+
+    # Corpus-wide disposition breakdown.
+    fh.write("\n## Aggregate disposition breakdown\n\n")
+    fh.write("| disposition | count | pct |\n| --- | ---: | ---: |\n")
+    for k in DISPOSITIONS:
+        v = agg_dispo.get(k, 0)
+        pct = (v / endpoints_total) if endpoints_total else 0.0
+        fh.write(f"| {k} | {v} | {pct:.2%} |\n")
+    fh.write(f"| **total** | **{endpoints_total}** | **100.00%** |\n")
+
+    # Per-language aggregate.
+    fh.write("\n## Per-language aggregate\n\n")
+    fh.write("| language | repos | files | entities | relationships | endpoints | bug_rate | resolution_rate |\n")
+    fh.write("| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |\n")
+    by_lang = {}
+    for name, d in per_repo.items():
+        lang = lang_of.get(name, "unknown")
+        bucket = by_lang.setdefault(lang, {
+            "repos": 0, "files": 0, "entities": 0, "relationships": 0,
+            "endpoints": 0, "resolved": 0, "bug": 0,
+        })
+        bucket["repos"] += 1
+        bucket["files"] += d.get("files", 0)
+        bucket["entities"] += d.get("entities", 0)
+        bucket["relationships"] += d.get("relationships", 0)
+        for k, v in d.get("disposition_counts", {}).items():
+            bucket["endpoints"] += v
+            if k == "resolved":
+                bucket["resolved"] += v
+            if k in ("bug-extractor", "bug-resolver"):
+                bucket["bug"] += v
+    for lang in sorted(by_lang):
+        b = by_lang[lang]
+        br = (b["bug"] / b["endpoints"]) if b["endpoints"] else 0.0
+        rr = (b["resolved"] / b["endpoints"]) if b["endpoints"] else 0.0
+        fh.write(f"| {lang} | {b['repos']} | {b['files']} | {b['entities']} | "
+                 f"{b['relationships']} | {b['endpoints']} | {br:.4%} | {rr:.4%} |\n")
+
+    # Ship-gate check.
+    fh.write("\n## Ship-gate check (target bug_rate <= 1%)\n\n")
+    status = "PASS" if agg_br <= 0.01 else "FAIL"
+    fh.write(f"- status: **{status}** (bug_rate={agg_br:.4%})\n")
+PY
+
+# Mark this run complete — the EXIT trap will now garbage-collect
+# $TMPDIR_AGG. Without this sentinel the per-repo JSON survives so a
+# partial/aborted run can be inspected or resumed by hand.
+: >"$TMPDIR_AGG/.complete"
+
+echo "==> wrote report: $REPORT"
+echo "$REPORT"

--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -44,479 +44,125 @@ mkdir -p "$CORPORA_DIR" "$REPORTS_DIR"
 #   - CLI tool              click
 #   - config-heavy          pandas (mixed), spring-petclinic, nestjs-starter
 REPOS=(
-  # Corpus policy (Refs #96): prefer SAMPLE APPLICATIONS that USE a framework
-  # over the framework's own source tree. We measure how the indexer handles
-  # framework-using user code, not how it handles framework internals.
-  # --- Python ---
-  "requests|https://github.com/psf/requests.git|main|python"                                       # library; small enough to keep
-  "flask-realworld|https://github.com/gothinkster/flask-realworld-example-app.git|master|python"   # Flask sample app
-  "click|https://github.com/pallets/click.git|main|python"                                         # CLI tool source; small
-  "django-realworld|https://github.com/gothinkster/django-realworld-example-app.git|master|python" # Django sample app
-  "pandas|https://github.com/pandas-dev/pandas.git|main|python|pandas/core"                        # full ~400 MB; sparse subset
-  # --- Go ---
-  "gin|https://github.com/gin-gonic/gin.git|master|go"                                             # framework src; small
-  "chi|https://github.com/go-chi/chi.git|master|go"                                                # framework src; small
-  "etcd|https://github.com/etcd-io/etcd.git|main|go|server/etcdserver"                             # full ~250 MB; sparse subset
-  # --- JavaScript / TypeScript ---
-  "express-realworld|https://github.com/gothinkster/node-express-realworld-example-app.git|master|javascript" # Express sample app
-  "nestjs-starter|https://github.com/nestjs/typescript-starter.git|master|typescript"              # NestJS sample app
-  "nextjs-commerce|https://github.com/vercel/commerce.git|main|typescript"                         # Next.js sample app
-  # --- Java ---
-  "spring-petclinic|https://github.com/spring-projects/spring-petclinic.git|main|java"             # Spring Boot sample app
-  "kafka-streams-examples|https://github.com/confluentinc/kafka-streams-examples.git|master|java"  # Kafka sample app
-  # --- Kotlin ---
-  "exposed|https://github.com/JetBrains/Exposed.git|main|kotlin"                                   # ORM source; small
-  "ktor-samples|https://github.com/ktorio/ktor-samples.git|main|kotlin"                            # Ktor sample apps
-  # --- Scala ---
-  "play-scala-starter|https://github.com/playframework/play-scala-starter-example.git|2.7.x|scala" # Play Framework sample app
-  # --- Groovy ---
-  "ratpack-example-books|https://github.com/ratpack/example-books.git|master|groovy"               # Ratpack sample app
-  # --- Clojure ---
-  "usermanager-example|https://github.com/seancorfield/usermanager-example.git|develop|clojure"    # Ring/Compojure sample app
-  # --- Ruby ---
-  "rails-realworld|https://github.com/gothinkster/rails-realworld-example-app.git|master|ruby"     # Rails sample app
-  "sidekiq|https://github.com/sidekiq/sidekiq.git|main|ruby"                                       # library; small
-  # --- PHP ---
-  "laravel-quickstart|https://github.com/laravel/quickstart-basic.git|master|php"                  # Laravel sample app
-  "symfony-demo|https://github.com/symfony/demo.git|main|php"                                      # Symfony sample app
-  # --- Rust ---
-  "mini-redis|https://github.com/tokio-rs/mini-redis.git|master|rust"                              # Tokio sample app
-  "actix-examples|https://github.com/actix/examples.git|main|rust"                                 # Actix sample apps
-  # --- Swift ---
-  "vapor-api-template|https://github.com/vapor/api-template.git|master|swift"                      # Vapor sample app (Controllers/Routes/Migrations)
-  # --- C# ---
-  "aspnetcore-realworld|https://github.com/gothinkster/aspnetcore-realworld-example-app.git|master|csharp" # ASP.NET Core MVC sample app
-  # --- C++ ---
-  "spdlog|https://github.com/gabime/spdlog.git|v1.x|cpp"                                          # header-only logging library; small
-  # --- Zig ---
-  "http.zig|https://github.com/karlseguin/http.zig.git|master|zig"                                # Zig HTTP server library; small
-  # --- Dart ---
-  "dart-samples|https://github.com/dart-lang/samples.git|main|dart"                               # Dart sample apps
-  # --- Lua ---
-  "kickstart.nvim|https://github.com/nvim-lua/kickstart.nvim.git|master|lua"                      # Neovim config sample
-  # --- Elixir ---
-  "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"          # Phoenix sample app
-  # --- Razor ---
-  "aspnetcore-docs-samples|https://github.com/dotnet/AspNetCore.Docs.Samples.git|main|razor"     # ASP.NET Core docs companion: 737 .cshtml/.razor view templates
-  # --- Fish ---
-  "tide|https://github.com/IlanCosman/tide.git|main|fish"                                        # Pure-fish prompt theme: 117 .fish files (functions, completions, conf.d)
-  # --- Just ---
-  "just|https://github.com/casey/just.git|master|just"                                           # Just build runner: dogfooded top-level justfile + tests/ parser fixtures
-  # --- Proto ---
-  "grpc-go-examples|https://github.com/grpc/grpc-go.git|master|proto|examples"                   # gRPC-Go examples/ subtree: dozens of .proto service/message definitions
-  # --- GraphQL ---
-  "apollo-server|https://github.com/apollographql/apollo-server.git|main|graphql"                # Apollo Server: GraphQL schema SDL + resolvers across packages
-  # --- HCL ---
-  "terraform-aws-vpc|https://github.com/terraform-aws-modules/terraform-aws-vpc.git|master|hcl"  # Terraform AWS VPC module: canonical HCL resource/variable/output definitions
-  # --- K8s YAML ---
-  "argocd-example-apps|https://github.com/argoproj/argocd-example-apps.git|master|yaml"          # Argo CD example apps: canonical Deployment/Service/Ingress/ConfigMap manifests
-  # --- Helm ---
-  "prometheus-helm|https://github.com/prometheus-community/helm-charts.git|main|yaml|charts/prometheus" # Prometheus Helm chart: templates/, values.yaml, Chart.yaml — sparse subtree
-  # --- GHA ---
-  "starter-workflows|https://github.com/actions/starter-workflows.git|main|yaml"                 # Official GitHub Actions starter workflows: ci/, deployments/, automation/, code-scanning/, pages/
-  # --- OpenAPI ---
-  "openapi-stripe|https://github.com/APIs-guru/openapi-directory.git|main|yaml|APIs/stripe.com"  # OpenAPI directory — Stripe API spec subtree (yaml extractor handles OpenAPI documents)
-  # --- ORMs/Frameworks (chunk G, umbrella #301) ---
-  # Sample apps that USE each ORM/framework, per Refs #96 corpus policy.
-  # django-realworld (#176) and node-express-realworld (#178/Prisma) are already
-  # listed above under Python and JavaScript respectively — not duplicated here.
-  "microblog|https://github.com/miguelgrinberg/microblog.git|main|python"                          # SQLAlchemy sample app (#174)
-  "fastapi-realworld|https://github.com/nsidnev/fastapi-realworld-example-app.git|master|python"   # FastAPI sample app (#175)
-  "sequelize-express-example|https://github.com/sequelize/express-example.git|master|javascript"   # Sequelize sample app (#177)
-  "golang-gin-realworld|https://github.com/gothinkster/golang-gin-realworld-example-app.git|main|go" # GORM sample app (#179)
-  "actix-diesel-realworld|https://github.com/snamiki1212/realworld-v1-rust-actix-web-diesel.git|main|rust" # Diesel sample app (#180)
-  # --- Build tools (chunk H, umbrella #309) ---
-  # Manifest fixtures: each repo's root Cargo.toml / pom.xml / package.json /
-  # tsconfig is the canonical artifact for the cross/manifest extractor.
-  "tokio|https://github.com/tokio-rs/tokio.git|master|rust"                                          # Cargo.toml workspace manifest (#168)
-  "maven|https://github.com/apache/maven.git|master|java"                                            # pom.xml multi-module manifest (#170)
-  "pnpm|https://github.com/pnpm/pnpm.git|main|javascript"                                            # package.json workspace manifest (#172)
-  "nx|https://github.com/nrwl/nx.git|master|typescript"                                              # tsconfig + nx.json manifests (#173)
-  # --- Java enterprise (chunk I, umbrella #302) ---
-  # Sample apps that USE each Java enterprise framework, per Refs #96 corpus policy.
-  "quarkus-quickstarts|https://github.com/quarkusio/quarkus-quickstarts.git|main|java"                # Quarkus sample apps (#181)
-  "micronaut-examples|https://github.com/micronaut-projects/micronaut-examples.git|master|java"       # Micronaut sample apps (#183)
-  "helidon-examples|https://github.com/helidon-io/helidon-examples.git|helidon-4.x|java"              # Helidon sample apps (#186)
-  "vertx-examples|https://github.com/vert-x3/vertx-examples.git|5.x|java"                             # Vert.x sample apps (#190)
-  "dropwizard-example|https://github.com/dropwizard/dropwizard.git|release/5.0.x|java|dropwizard-example" # Dropwizard sample app subtree (#193)
-  "play-java-starter|https://github.com/playframework/play-java-starter-example.git|2.7.x|java"       # Play Framework Java sample app (#197)
-  "spark-examples|https://github.com/perwendel/spark.git|master|java|examples"                        # Spark Java examples subtree (#203)
-  # --- Mobile native (chunk L, umbrella #313) ---
-  # Sample applications across the major mobile native stacks, per Refs #96
-  # corpus policy. Each entry pinned to the SHA recorded in its child issue.
-  "ios-oss|https://github.com/kickstarter/ios-oss.git|main|swift"                                      # iOS UIKit sample app (#198)
-  "sample-food-truck|https://github.com/apple/sample-food-truck.git|main|swift"                        # iOS SwiftUI sample app (#201)
-  "android-architecture|https://github.com/googlesamples/android-architecture.git|main|java"           # Android Java sample app (#205)
-  "compose-samples|https://github.com/android/compose-samples.git|main|kotlin"                         # Android Kotlin Compose sample apps (#207)
-  "flutter-samples|https://github.com/flutter/samples.git|main|dart"                                   # Flutter (Dart) sample apps (#209)
-  "react-native|https://github.com/facebook/react-native.git|main|javascript|template"                 # React Native: template/ subtree per umbrella body (#212)
-  "ionic-conference-app|https://github.com/ionic-team/ionic-conference-app.git|main|typescript"        # Ionic / Capacitor sample app (#215)
-  "maui-samples|https://github.com/dotnet/maui-samples.git|main|csharp"                                # .NET MAUI sample apps (#217)
-  # --- Declarative IaC (chunk N, umbrella #308) ---
-  # Sample/canonical fixtures for declarative IaC + container orchestration
-  # languages, per Refs #96 corpus policy. Each entry pinned to the SHA
-  # recorded in its child issue. ArgoCD (#211) is intentionally NOT re-listed
-  # here: argocd-example-apps is already present above under K8s YAML
-  # (chunk F) and #211 closes via that single fixture.
-  "aws-cloudformation-samples|https://github.com/aws-cloudformation/aws-cloudformation-samples.git|main|yaml"  # CloudFormation sample templates (#185)
-  "kustomize|https://github.com/kubernetes-sigs/kustomize.git|master|yaml|examples"                            # Kustomize examples/ subtree (#189)
-  "ansible-for-devops|https://github.com/geerlingguy/ansible-for-devops.git|master|yaml"                       # Ansible playbooks/roles sample (#192)
-  "chef-runit|https://github.com/chef-cookbooks/runit.git|main|ruby"                                           # Chef cookbook (Ruby DSL) (#195)
-  "puppet-control-repo|https://github.com/puppetlabs/control-repo.git|production|ruby"                         # Puppet control repo (Ruby DSL) (#199)
-  "awesome-compose|https://github.com/docker/awesome-compose.git|master|yaml"                                  # Docker Compose canonical samples (#204)
-  "nomad-pack|https://github.com/hashicorp/nomad-pack.git|main|hcl|registry"                                   # Nomad Pack registry/ subtree (#208)
-  # --- Relational ORMs missing (chunk O, umbrella #315) ---
-  # Sample apps that USE each relational ORM / query builder, per Refs #96
-  # corpus policy. Each entry pinned to the SHA recorded in its child issue.
-  "spring-framework-petclinic|https://github.com/spring-petclinic/spring-framework-petclinic.git|main|java"            # Hibernate-only sample app (#251)
-  "joal|https://github.com/anthonyraymond/joal.git|master|java"                                                        # jOOQ sample app (#257)
-  "jpetstore-6|https://github.com/mybatis/jpetstore-6.git|master|java"                                                 # MyBatis sample app (#259)
-  "nestjs-realworld-typeorm|https://github.com/lujakob/nestjs-realworld-example-app.git|master|typescript"             # TypeORM sample app (#264)
-  "express-bookshelf-realworld|https://github.com/tanem/express-bookshelf-realworld-example-app.git|master|javascript" # Knex sample app (#269)
-  "nestjs-realworld-mikroorm|https://github.com/mikro-orm/nestjs-realworld-example-app.git|master|typescript"          # MikroORM sample app (#274)
-  "ent|https://github.com/ent/ent.git|master|go|entc/integration/ent"                                                  # Ent sample (entc/integration/ent subtree) (#280)
-  "sqlc-examples|https://github.com/sqlc-dev/sqlc.git|main|go|examples"                                                # sqlc examples/ subtree (#284)
-  "fabric-ca|https://github.com/hyperledger/fabric-ca.git|main|go"                                                     # sqlx (Go) sample app (#287)
-  "lean|https://github.com/jenssegers/lean.git|master|php"                                                             # Eloquent (standalone) sample app (#288)
-  "sea-orm-examples|https://github.com/SeaQL/sea-orm.git|master|rust|examples"                                         # SeaORM examples/ subtree (#289)
-  "netcore-boilerplate|https://github.com/lkurzyniec/netcore-boilerplate.git|master|csharp"                            # Dapper sample app (#290)
-  # --- NoSQL/cache/streaming (chunk P, umbrella #316) ---
-  # Canonical client/driver fixtures for the major NoSQL, cache, and streaming
-  # ecosystems, per Refs #96 corpus policy. Each entry pinned to the SHA
-  # recorded in its child issue.
-  "mongoose|https://github.com/Automattic/mongoose.git|master|javascript"                                     # MongoDB Node.js ODM (#213)
-  "pymongo|https://github.com/mongodb/mongo-python-driver.git|master|python"                                  # MongoDB Python driver (#216)
-  "motor|https://github.com/mongodb/motor.git|master|python"                                                  # MongoDB async Python driver (#219)
-  "mongo-go-driver|https://github.com/mongodb/mongo-go-driver.git|master|go"                                  # MongoDB Go driver (#220)
-  "mongo-java-driver|https://github.com/mongodb/mongo-java-driver.git|main|java"                              # MongoDB Java driver (#221)
-  "redis-py|https://github.com/redis/redis-py.git|master|python"                                              # Redis Python client (#222)
-  "ioredis|https://github.com/redis/ioredis.git|main|typescript"                                              # Redis Node.js TypeScript client (#223)
-  "go-redis|https://github.com/redis/go-redis.git|master|go"                                                  # Redis Go client (#225)
-  "lettuce|https://github.com/redis/lettuce.git|main|java"                                                    # Redis Java client (#226)
-  "cassandra-java-driver|https://github.com/datastax/java-driver.git|4.x|java"                                # Cassandra DataStax Java driver (#228)
-  "aws-sdk-go-v2|https://github.com/aws/aws-sdk-go-v2.git|main|go"                                            # DynamoDB / AWS Go SDK v2 (#230)
-  "couchbase-gocb|https://github.com/couchbase/gocb.git|master|go"                                            # Couchbase Go SDK (#232)
-  "rabbitmq-tutorials|https://github.com/rabbitmq/rabbitmq-tutorials.git|main|python"                         # RabbitMQ amqp client tutorials (#234)
-  "nats.go|https://github.com/nats-io/nats.go.git|main|go"                                                    # NATS Go client (#236)
-  "aws-sdk-js-v3|https://github.com/aws/aws-sdk-js-v3.git|main|typescript"                                    # AWS SQS / AWS JS SDK v3 (#237)
-  # --- Programmatic IaC (chunk M, umbrella #314) ---
-  # Programmatic IaC samples across CDK / Pulumi / Bicep / SAM / Serverless
-  # Framework / Crossplane, per Refs #96 corpus policy. Each entry pinned to
-  # the SHA recorded in its child issue. Multi-flavor monorepos
-  # (aws-cdk-examples, pulumi/examples) get one entry per language flavor with
-  # a unique name and a flavor-scoped sparse-path so cone-mode sparse-checkout
-  # keeps each working tree small.
-  "aws-cdk-examples-typescript|https://github.com/aws-samples/aws-cdk-examples.git|main|typescript|typescript" # AWS CDK TypeScript (#182) SHA f4143ebe9746
-  "aws-cdk-examples-python|https://github.com/aws-samples/aws-cdk-examples.git|main|python|python"             # AWS CDK Python (#184) SHA f4143ebe9746
-  "aws-cdk-examples-java|https://github.com/aws-samples/aws-cdk-examples.git|main|java|java"                   # AWS CDK Java (#187) SHA f4143ebe9746
-  "aws-cdk-examples-csharp|https://github.com/aws-samples/aws-cdk-examples.git|main|csharp|csharp"             # AWS CDK .NET (#188) SHA f4143ebe9746
-  "aws-cdk-examples-go|https://github.com/aws-samples/aws-cdk-examples.git|main|go|go"                         # AWS CDK Go (#191) SHA f4143ebe9746
-  "pulumi-examples-typescript|https://github.com/pulumi/examples.git|master|typescript|aws-ts-webserver"       # Pulumi TypeScript (#194) SHA d9173c2ed496
-  "pulumi-examples-python|https://github.com/pulumi/examples.git|master|python|aws-py-webserver"               # Pulumi Python (#196) SHA d9173c2ed496
-  "pulumi-examples-go|https://github.com/pulumi/examples.git|master|go|aws-go-webserver"                       # Pulumi Go (#200) SHA d9173c2ed496
-  "pulumi-examples-csharp|https://github.com/pulumi/examples.git|master|csharp|aws-cs-webserver"               # Pulumi .NET (#202) SHA d9173c2ed496
-  "azure-quickstart-templates|https://github.com/Azure/azure-quickstart-templates.git|master|bicep|quickstarts/microsoft.storage" # Azure Bicep (#206) SHA d4267860bf57
-  "aws-sam-cli-app-templates|https://github.com/aws/aws-sam-cli-app-templates.git|master|yaml|python3.12"      # AWS SAM (#210) SHA c7285973a74a
-  "serverless-examples|https://github.com/serverless/examples.git|v4|yaml|aws-node-http-api"                   # Serverless Framework (#214) SHA 631c0739a793
-  "crossplane|https://github.com/crossplane/crossplane.git|main|yaml|cluster/meta"                             # Crossplane (#218) SHA 2ddc36457725
-  # --- DB migration tools (chunk Y, umbrella #317) ---
-  # Versioned-SQL migration tooling across major ecosystems, per Refs #87
-  # corpus policy. Each entry pinned to the SHA recorded in the umbrella body.
-  # Sparse-paths are applied to the two large monorepos (flyway, liquibase);
-  # the remaining repos are small enough to clone in full.
-  "flyway|https://github.com/flyway/flyway.git|main|java|flyway-core"                                          # Flyway versioned/repeatable SQL migrations (#317) SHA ce65ee118f01
-  "liquibase|https://github.com/liquibase/liquibase.git|main|java|liquibase-standard"                          # Liquibase changelog formats + changesets (#317) SHA e9c06031abc8
-  "alembic|https://github.com/sqlalchemy/alembic.git|main|python"                                              # Alembic env.py + revision graph + op.* DSL (#317) SHA 4d1e38cac108
-  "knex|https://github.com/knex/knex.git|master|javascript"                                                    # Knex schema-builder migrations + query builder (#317) SHA af57d1ec662a
-  "goose|https://github.com/pressly/goose.git|main|go"                                                         # Goose -- +goose Up/Down SQL annotations + Go migrations (#317) SHA e3235f7041e1
-  "migrate-mongo|https://github.com/seppevs/migrate-mongo.git|master|javascript"                               # MongoDB migration scripts up/down handler (#317) SHA 1f5e5f953491
-  "sequel|https://github.com/jeremyevans/sequel.git|master|ruby"                                               # Sequel.migration { up/down } blocks (#317) SHA 694ea7798374
-  # --- CI/CD pipelines (chunk Q, umbrella #318) ---
-  # Canonical fixtures for CI/CD pipeline formats not yet exercised by the
-  # corpus, per Refs #87. Each entry pinned to the SHA recorded in umbrella
-  # #318. Sparse-paths keep working trees small for the larger monorepos
-  # (gitlab-runner, jenkins, tektoncd/pipeline, skaffold, tilt).
-  "gitlab-runner|https://gitlab.com/gitlab-org/gitlab-runner.git|main|yaml|ci"                                  # GitLab CI pipeline (#318) SHA d098a819531c
-  "circleci-demo-python-django|https://github.com/CircleCI-Public/circleci-demo-python-django.git|master|yaml|.circleci" # CircleCI orbs/workflows (#318) SHA 2bbf84b270e6
-  "jenkins|https://github.com/jenkinsci/jenkins.git|master|groovy"                                              # Jenkins declarative + scripted Groovy (#318) SHA 8fef7afff3e6
-  "tektoncd-pipeline|https://github.com/tektoncd/pipeline.git|main|yaml|examples"                               # Tekton Task/Pipeline/PipelineRun CRDs (#318) SHA bdd46842b047
-  "drone|https://github.com/drone/drone.git|main|yaml"                                                          # Drone pipeline steps + plugins (#318) SHA 9f37938bc913
-  "buildkite-agent|https://github.com/buildkite/agent.git|main|yaml|.buildkite"                                 # Buildkite pipeline.yml + plugins (#318) SHA 561444c7fc59
-  "skaffold|https://github.com/GoogleContainerTools/skaffold.git|main|yaml|examples"                            # Skaffold build/deploy/test profiles (#318) SHA 95531aa9b308
-  "tilt|https://github.com/tilt-dev/tilt.git|master|starlark|integration"                                       # Tilt Starlark Tiltfile resources (#318) SHA 98108ca6664b
-  # --- Build tools missing (chunk R, umbrella #320) ---
-  # Build-tool manifest fixtures not yet exercised: Gradle, Bazel, Make, CMake,
-  # Poetry, Composer, Bundler, Mix, sbt, Leiningen, Lerna (npm workspaces),
-  # Turborepo. Each entry pinned to the SHA recorded in the umbrella body.
-  # Dedup notes: pnpm/pnpm is already present above under chunk H (#172) — the
-  # same clone exercises both package.json and pnpm-workspace.yaml extractors,
-  # so we do NOT re-list it here. Gradle/spring-petclinic overlap is partial:
-  # spring-petclinic is a Gradle-using sample, gradle/gradle is the canonical
-  # multi-project Groovy + Kotlin DSL build source — kept as separate fixture.
-  "gradle|https://github.com/gradle/gradle.git|master|java|subprojects"                                        # Gradle multi-project Groovy + Kotlin DSL (#320) SHA 62000451ad7b
-  "bazel|https://github.com/bazelbuild/bazel.git|master|java"                                                  # Bazel BUILD/Starlark targets, deps (#320) SHA bca007ec74f2
-  "gnu-make|https://git.savannah.gnu.org/git/make.git|master|c"                                                # GNU Make rules, vars, includes (#320) SHA b3802782de3e
-  "cmake|https://github.com/Kitware/CMake.git|master|cpp"                                                      # CMake list files, modules, find-packages (#320) SHA 7e1b633a8978
-  "poetry|https://github.com/python-poetry/poetry.git|main|python"                                             # Poetry pyproject + lock semantics (#320) SHA 811a12dae0fe
-  "composer|https://github.com/composer/composer.git|main|php"                                                 # PHP Composer manifest + lock (#320) SHA 37825e985129
-  "bundler|https://github.com/rubygems/bundler.git|master|ruby"                                                # Ruby Bundler Gemfile + gemspec (#320) SHA 35be6d9a6030
-  "elixir|https://github.com/elixir-lang/elixir.git|main|elixir"                                               # Elixir Mix project + deps (#320) SHA b8723fea1ec5
-  "sbt|https://github.com/sbt/sbt.git|develop|scala"                                                           # Scala sbt build definition (#320) SHA 76992ed3f62f
-  "leiningen|https://github.com/technomancy/leiningen.git|main|clojure"                                        # Clojure Leiningen project.clj (#320) SHA 40227328d4a9
-  "lerna|https://github.com/lerna/lerna.git|main|javascript"                                                   # npm/yarn workspaces canonical (#320) SHA f4387d673bfd
-  "turborepo|https://github.com/vercel/turborepo.git|main|typescript"                                          # Turborepo pipeline config (#320) SHA c1f923a4abe5
-  # NOTE: pnpm-workspace coverage is satisfied by the existing pnpm entry under
-  # chunk H above (same repo @ same branch).
-  # --- Reverse-proxy/gateway (chunk V, umbrella #326) ---
-  # Canonical fixtures for reverse-proxy and API-gateway configuration formats
-  # not yet exercised by the corpus, per Refs #87. Each entry pinned to the SHA
-  # recorded in umbrella #326. Sparse-paths keep working trees small for the
-  # larger monorepos (nginx, httpd, envoy, kong, traefik).
-  "nginx|https://github.com/nginx/nginx.git|master|nginx-conf|conf"                                            # Nginx server/location/upstream blocks (#326) SHA 631bfa194d5a
-  "apache-httpd|https://github.com/apache/httpd.git|trunk|apache-httpd-conf|docs/conf"                         # Apache HTTPD VirtualHost/Directory directives (#326) SHA c11a7f9994f6
-  "caddy|https://github.com/caddyserver/caddy.git|master|caddyfile|caddyconfig"                                # Caddyfile + JSON config (#326) SHA 9c78b97f9e79
-  "traefik|https://github.com/traefik/traefik.git|master|traefik-dynamic|integration/fixtures"                 # Traefik static + dynamic YAML config (#326) SHA edd7d2eb333c
-  "kong|https://github.com/Kong/kong.git|master|kong-declarative|spec/fixtures"                                # Kong declarative config services/routes/plugins (#326) SHA 58f2daa56b90
-  "envoy|https://github.com/envoyproxy/envoy.git|main|envoy-yaml|configs"                                      # Envoy listener/cluster/route YAML (#326) SHA 3ddecad194fc
-  "haproxy|https://github.com/haproxy/haproxy.git|master|haproxy-cfg|examples"                                 # HAProxy frontend/backend/acl config (#326) SHA efb36c0dafd5
-  # --- API/Spec/IDL alts (chunk U, umbrella #325) ---
-  # API spec / IDL alternatives beyond OpenAPI, per Refs #87 corpus policy.
-  # Each entry pinned to the SHA verified in the umbrella body via
-  # git ls-remote --symref against canonical upstream branches.
-  # Sparse-paths are applied to the three large monorepos (smithy, avro,
-  # thrift); the remaining four are small enough to clone in full. Where
-  # the umbrella listed multiple sparse subtrees (or glob patterns not
-  # supported by cone-mode sparse-checkout), one canonical IDL/schema
-  # subtree per repo is selected — broad extractor coverage is preserved.
-  "asyncapi-spec|https://github.com/asyncapi/spec.git|master|asyncapi"                                          # AsyncAPI channels/messages/bindings (#325) SHA 94ff695acb10
-  "smithy|https://github.com/smithy-lang/smithy.git|main|smithy|smithy-model"                                   # Smithy IDL services/operations/shapes (#325) SHA 22a34991defb
-  "avro|https://github.com/apache/avro.git|main|avro|lang"                                                      # Avro schemas (.avsc) and IDL (.avdl) (#325) SHA 892d6997dcb6
-  "thrift|https://github.com/apache/thrift.git|master|thrift|tutorial"                                          # Thrift IDL services/structs (#325) SHA f39cecc4d5b6
-  "json-schema-spec|https://github.com/json-schema-org/json-schema-spec.git|main|json-schema"                   # JSON Schema draft definitions (#325) SHA 5794814cca9e
-  "raml-spec|https://github.com/raml-org/raml-spec.git|master|raml"                                             # RAML 1.0 API definitions (#325) SHA 3ba244ade44c
-  "api-blueprint|https://github.com/apiaryio/api-blueprint.git|master|api-blueprint"                            # API Blueprint markdown specs (#325) SHA 86fc3a128a93
-  # --- Auth/security/observability (chunk S, umbrella #322) ---
-  # Auth (OAuth2/OIDC/JWT/Keycloak/Auth0), security (Vault), and observability
-  # (OpenTelemetry, Prometheus, Sentry, Datadog) client-library consumer apps.
-  # Each entry pinned to the SHA recorded in the umbrella body.
-  "node-openid-client|https://github.com/panva/node-openid-client.git|main|typescript|lib"                       # OAuth2/OIDC client flows, discovery (#322) SHA d3721c2cab93
-  "node-jsonwebtoken|https://github.com/auth0/node-jsonwebtoken.git|master|javascript"                           # JWT sign/verify consumer patterns (#322) SHA 02688b982132
-  "keycloak|https://github.com/keycloak/keycloak.git|main|java|core"                                             # Keycloak Java SDK adapters (#322) SHA 8938558fa5c7
-  "auth0-spa-js|https://github.com/auth0/auth0-spa-js.git|main|typescript|src"                                   # Auth0 SPA SDK login/logout/token (#322) SHA c66e8b7400f2
-  "vault|https://github.com/hashicorp/vault.git|main|go|api"                                                     # HashiCorp Vault Go client (#322) SHA 54a22347c3fa
-  "opentelemetry-js|https://github.com/open-telemetry/opentelemetry-js.git|main|typescript|packages"             # OpenTelemetry tracing/metrics SDK (#322) SHA 95e48e7afcc4
-  "prometheus-client-golang|https://github.com/prometheus/client_golang.git|main|go|prometheus"                  # Prometheus Go client metrics (#322) SHA 0ac87e14c303
-  "sentry-javascript|https://github.com/getsentry/sentry-javascript.git|develop|typescript|packages"             # Sentry SDK init + capture (#322) SHA 298807727c81
-  "dd-trace-js|https://github.com/DataDog/dd-trace-js.git|master|javascript|packages"                            # Datadog APM tracer instrumentations (#322) SHA 807fceb14d1a
-  # --- Validation + Lint configs (chunk T, umbrella #324) ---
-  # Validation libraries (Zod, Joi, Yup, Pydantic, class-validator) and lint
-  # configurations (ESLint, Prettier, Ruff, RuboCop, golangci-lint, Clippy)
-  # per Refs #87. Each entry pinned to the SHA recorded in the umbrella body.
-  # Sparse paths from the umbrella are documented in comments; the harness
-  # entry uses a full clone because the parser supports a single sparse path
-  # only and these fixtures list multiple paths each.
-  "zod|https://github.com/colinhacks/zod.git|main|typescript"                                                  # Zod schema definitions, refinements (#324) SHA b6071fc0ad2b paths src/ tests/
-  "joi|https://github.com/hapijs/joi.git|master|javascript"                                                    # Joi schema + extensions (#324) SHA 048fe05b8235 paths lib/ test/
-  "yup|https://github.com/jquense/yup.git|master|typescript"                                                   # Yup object/array validation (#324) SHA ff31eee8a2b1 paths src/ test/
-  "pydantic|https://github.com/pydantic/pydantic.git|main|python"                                              # pydantic v2 BaseModel + validators (#324) SHA 7a369fb502a4 paths pydantic/ tests/
-  "class-validator|https://github.com/typestack/class-validator.git|develop|typescript"                        # class-validator decorators (#324) SHA 2e1a5c27dbd6 paths src/ test/
-  "eslint|https://github.com/eslint/eslint.git|main|javascript"                                                # ESLint flat + legacy config (#324) SHA a4297918d264 paths lib/ conf/ eslint.config.js
-  "prettier|https://github.com/prettier/prettier.git|main|javascript"                                          # Prettier config + plugin discovery (#324) SHA f3db616d8389 paths .prettierrc* src/config/
-  "ruff|https://github.com/astral-sh/ruff.git|main|python"                                                     # ruff config + rule selectors (#324) SHA 8091ad11d15f paths ruff.toml pyproject.toml crates/
-  "rubocop|https://github.com/rubocop/rubocop.git|master|ruby"                                                 # RuboCop cop config + inheritance (#324) SHA 11262e1cdb45 paths .rubocop.yml config/
-  "golangci-lint|https://github.com/golangci/golangci-lint.git|main|go"                                        # golangci-lint linters + presets (#324) SHA ef3710ea5470 paths .golangci.yml pkg/config/
-  "rust-clippy|https://github.com/rust-lang/rust-clippy.git|master|rust"                                       # Clippy lint config + categories (#324) SHA f763854b8bd3 paths clippy.toml clippy_lints/
-  # --- Serverless (chunk Z, umbrella #319) ---
-  # Function-only repos covering all major serverless platforms and Lambda
-  # runtimes. Exercises handler detection, function-config parsing
-  # (SAM/serverless/wrangler/netlify/vercel), and per-runtime entry points.
-  # Each entry pinned to the SHA recorded in umbrella #319.
-  "aws-lambda-developer-guide|https://github.com/awsdocs/aws-lambda-developer-guide.git|main|javascript|sample-apps"  # Lambda Node handler shape, SAM template.yaml (#319) SHA 8a681ab924e4
-  "aws-lambda-python-runtime-interface-client|https://github.com/aws/aws-lambda-python-runtime-interface-client.git|main|python|awslambdaric"  # Python Lambda runtime interface, handler bootstrap (#319) SHA f11e7c5c5cc7
-  "aws-lambda-java-libs|https://github.com/aws/aws-lambda-java-libs.git|main|java|aws-lambda-java-core"               # Java Lambda handler interfaces, event POJOs (#319) SHA c4dcbab4ffed
-  "aws-lambda-go|https://github.com/aws/aws-lambda-go.git|main|go|lambda"                                              # Go Lambda handler signatures, event types (#319) SHA 815d21f41769
-  "aws-lambda-rust-runtime|https://github.com/awslabs/aws-lambda-rust-runtime.git|main|rust|lambda-runtime"            # Rust Lambda runtime crate, handler macros (#319) SHA 01237499db5f
-  "vercel-examples|https://github.com/vercel/examples.git|main|typescript|edge-functions"                              # Vercel Edge/Serverless function shape, vercel.json (#319) SHA 72aaac1ba427
-  "netlify-functions|https://github.com/netlify/functions.git|main|typescript|src"                                     # Netlify Functions handler types, netlify.toml (#319) SHA c3f47247079e
-  "cloudflare-workers-sdk|https://github.com/cloudflare/workers-sdk.git|main|typescript|packages/wrangler"             # Cloudflare Workers fetch handler, wrangler.toml (#319) SHA dba84c225f41
-  "functions-framework-nodejs|https://github.com/GoogleCloudPlatform/functions-framework-nodejs.git|main|typescript|src"  # GCF Functions Framework HTTP/CloudEvent handlers (#319) SHA 243202d5e133
-  # --- State management (chunk AA, umbrella #321) ---
-  # Frontend state-management libraries exercising store/atom/machine detection
-  # across Redux, MobX, Zustand, Pinia, NgRx, Recoil, XState, Effector per
-  # Refs #87. Each entry pinned to the SHA recorded in the umbrella body.
-  "redux|https://github.com/reduxjs/redux.git|master|typescript|packages/toolkit"                              # Redux reducers/actions, Toolkit slices (#321) SHA 38faff513dc2
-  "mobx|https://github.com/mobxjs/mobx.git|main|typescript|packages/mobx"                                     # MobX observables, computed, reactions (#321) SHA 03f420ac4a29
-  "zustand|https://github.com/pmndrs/zustand.git|main|typescript|src"                                         # Zustand `create` stores, middleware (#321) SHA 3fca84617984
-  "pinia|https://github.com/vuejs/pinia.git|v4|typescript|packages/pinia"                                     # Pinia `defineStore`, Vue 3 stores (#321) SHA e329b3805486 (Vue SFC + TS dual extraction)
-  "ngrx-platform|https://github.com/ngrx/platform.git|main|typescript|modules/store"                          # NgRx actions/reducers/effects (#321) SHA a469cbf01562
-  "recoil|https://github.com/facebookexperimental/Recoil.git|main|typescript|packages/recoil"                 # Recoil atoms/selectors (#321) SHA c1b97f3a0117
-  "xstate|https://github.com/statelyai/xstate.git|main|typescript|packages/core"                              # XState `createMachine`, statecharts (#321) SHA f79ea13febe4
-  "effector|https://github.com/effector/effector.git|master|typescript|src"                                   # Effector stores/events/effects (#321) SHA 29553bb13dc3
-  # --- Static-site generators (chunk W, umbrella #298) ---
-  # Static-site generator fixtures across the major SSG ecosystems
-  # (Hugo, Jekyll, Hexo, MkDocs, Sphinx, VitePress, Docusaurus, Nextra,
-  # Eleventy), per Refs #87 corpus policy. Each entry pinned to the SHA
-  # recorded in umbrella #298. Where the umbrella listed multiple sparse
-  # subtrees, one canonical content/template subtree per repo is selected
-  # (cone-mode sparse-checkout supports a single path); the harness language
-  # tag is the dominant code-extractor for the repo, with Markdown / front-
-  # matter / template-engine extractors exercised via the sparse subtree.
-  # Dedup notes: Gatsby is intentionally excluded here per the umbrella body
-  # (already covered by chunk K, per the master plan).
-  "hugoDocs|https://github.com/gohugoio/hugoDocs.git|master|go|content"                                       # Hugo templates, shortcodes, TOML/YAML front-matter (#298) SHA e6abf5644f3f
-  "jekyll|https://github.com/jekyll/jekyll.git|master|ruby|lib"                                               # Liquid templating, Jekyll plugin model (#298) SHA 202df571314b
-  "hexo-site|https://github.com/hexojs/site.git|master|javascript|source"                                     # Hexo theming + Markdown content tree (#298) SHA fcf644467039
-  "mkdocs|https://github.com/mkdocs/mkdocs.git|master|python|mkdocs"                                          # MkDocs plugin/theme system, mkdocs.yml config (#298) SHA 2862536793b3
-  "sphinx|https://github.com/sphinx-doc/sphinx.git|master|python|sphinx"                                      # RST extractor, Sphinx directives, conf.py (#298) SHA cc7c6f435ad3
-  "vitepress|https://github.com/vuejs/vitepress.git|main|typescript|src"                                      # VitePress theme, Vue SFC + Markdown blend (#298) SHA 6ee01bf30534
-  "docusaurus|https://github.com/facebook/docusaurus.git|main|typescript|packages/docusaurus"                 # MDX extractor, Docusaurus plugin packages (#298) SHA 5f60ae9c872d
-  "nextra|https://github.com/shuding/nextra.git|main|typescript|packages/nextra"                              # Nextra theme + MDX content trees (#298) SHA e604c7fe937e
-  "eleventy|https://github.com/11ty/eleventy.git|main|javascript|src"                                         # Eleventy template engines, .eleventy.js config (#298) SHA 4a6b85f64eef
-  # --- Testing frameworks (chunk X, umbrella #312) ---
-  # Testing-framework-dominated repos so the harness exercises test-file
-  # detection, fixture parsing, and framework-specific patterns (Jest, Mocha,
-  # Cypress, Playwright, Selenium, JUnit 5, RSpec, pytest, Karate, Cucumber).
-  # Each entry pinned to the SHA recorded in the umbrella body and verified
-  # via git ls-remote --symref. Sparse paths from the umbrella are documented
-  # in trailing comments; entries use a full clone where the umbrella lists
-  # multiple sparse paths because the parser supports a single sparse path
-  # only. seleniumhq.github.io uses its single /examples sparse-path.
-  "jest|https://github.com/jestjs/jest.git|main|typescript"                                                   # Jest config, snapshot tests, mock factories (#312) SHA 746b14333fbd paths packages/ e2e/
-  "mocha|https://github.com/mochajs/mocha.git|main|javascript"                                                # Mocha BDD/TDD interfaces, hooks, reporters (#312) SHA 441c32aa076f paths lib/ test/
-  "cypress-realworld-app|https://github.com/cypress-io/cypress-realworld-app.git|develop|typescript"          # Cypress E2E specs, custom commands, fixtures (#312) SHA 84008795de05 paths cypress/ src/
-  "playwright|https://github.com/microsoft/playwright.git|main|typescript"                                    # Playwright test runner, fixtures, projects (#312) SHA c17e0b45c12f paths packages/playwright/ tests/
-  "seleniumhq-examples|https://github.com/SeleniumHQ/seleniumhq.github.io.git|trunk|multi|examples"           # Selenium WebDriver examples across languages (#312) SHA 203cffca2951
-  "junit5-samples|https://github.com/junit-team/junit5-samples.git|main|java"                                 # JUnit 5 Jupiter API, parameterized tests (#312) SHA c8828652e601 paths junit5-jupiter-starter-gradle/ junit5-jupiter-starter-maven/
-  "rspec-rails|https://github.com/rspec/rspec-rails.git|main|ruby"                                            # RSpec describe/it/expect, Rails matchers (#312) SHA 810f2a48950c paths lib/ spec/
-  "pytest|https://github.com/pytest-dev/pytest.git|main|python"                                               # pytest fixtures, parametrize, conftest, plugins (#312) SHA b10612810dc6 paths src/ testing/
-  "karate|https://github.com/karatelabs/karate.git|main|java"                                                 # Karate .feature files, API/UI test DSL (#312) SHA 38db45133982 paths karate-core/ examples/
-  "cucumber-js|https://github.com/cucumber/cucumber-js.git|main|typescript"                                   # Cucumber.js step defs, Gherkin .feature parsing (#312) SHA 1c9e7022eae1 paths src/ features/
-  # --- Realtime/WebSocket/messaging (chunk BB, umbrella #323) ---
-  # Consumer apps and libraries showcasing realtime/messaging protocols so the
-  # harness exercises socket-handler detection and event-driven patterns. Each
-  # entry pinned to the SHA recorded in the umbrella body and verified via
-  # git ls-remote --symref. Sparse paths from the umbrella are documented in
-  # trailing comments; entries use a full clone or a single canonical sparse
-  # subtree because cone-mode sparse-checkout supports a single path. The
-  # mdn/dom-examples substitution (no canonical SSE-only repo exists) is
-  # scoped to its WebSocket subtree as the dominant realtime surface; the
-  # /server-sent-events sibling is exercised via separate JS/HTML extractors
-  # when the WS/SSE patterns coincide in scope.
-  "socket.io|https://github.com/socketio/socket.io.git|main|typescript|packages/socket.io"                    # Socket.IO server/client emit/on, namespaces (#323) SHA 439a8f669c67 paths packages/socket.io/ examples/
-  "pusher-js|https://github.com/pusher/pusher-js.git|master|typescript|src"                                    # Pusher channel subscribe/bind, presence channels (#323) SHA e58a5d22e063 paths src/ spec/
-  "ably-js|https://github.com/ably/ably-js.git|main|typescript|src"                                            # Ably Realtime channels, message envelopes (#323) SHA 498d26dfb16b paths src/ test/
-  "MQTT.js|https://github.com/mqttjs/MQTT.js.git|main|typescript|src"                                          # MQTT publish/subscribe, topic filters, QoS (#323) SHA a4e9a92c8710 paths src/ test/
-  "pion-webrtc|https://github.com/pion/webrtc.git|main|go"                                                     # WebRTC peer connection, data channels in Go (#323) SHA 9654161f9b69 paths /. examples/
-  "mdn-dom-examples|https://github.com/mdn/dom-examples.git|main|javascript|web-sockets"                       # Native WebSocket usage examples (#323) SHA f8aa45c93985 paths server-sent-events/ web-sockets/
-  # --- Game/embedded (chunk CC, umbrella #291) ---
-  # Game-engine and embedded-systems sample fixtures, per Refs #87 corpus
-  # policy. Each entry pinned to the SHA recorded in umbrella #291 and
-  # verified via git ls-remote --symref against canonical upstream branches.
-  # Sparse-paths keep working trees small for the larger monorepos
-  # (EntityComponentSystemSamples, esp-idf); the remaining repos are small
-  # enough to clone in full. EpicGames/UnrealEngine is private; substituted
-  # 20tab/UnrealEnginePython (public C++ Unreal bindings) for `.h`/`.cpp`
-  # coverage per the umbrella body.
-  "EntityComponentSystemSamples|https://github.com/Unity-Technologies/EntityComponentSystemSamples.git|master|csharp|EntityComponentSystemSamples/ECSSamples"  # C# Unity ECS samples — [Serializable] MonoBehaviours, partial system structs, attribute-driven jobs (#291) SHA 6786a741ee1f
-  "UnrealEnginePython|https://github.com/20tab/UnrealEnginePython.git|master|cpp|Source/UnrealEnginePython/Public"                                            # C++17 Unreal-style headers — UCLASS/UPROPERTY macros, .h/.cpp split, namespaced bindings (#291) SHA 4b5da5bf4ca5
-  "bevy|https://github.com/bevyengine/bevy.git|main|rust|crates/bevy_ecs/src"                                                                                  # Rust ECS with heavy trait-bound generics, derive macros, workspace crates (#291) SHA 7dda2bc7fcd2
-  "arduino-examples|https://github.com/arduino/arduino-examples.git|main|cpp|examples"                                                                         # Arduino sketches — .ino (C++ flavour) global setup()/loop(), embedded idioms (#291) SHA 4c5fa7a66b42
-  "esp-idf|https://github.com/espressif/esp-idf.git|master|c|examples/get-started"                                                                             # ESP-IDF C — static linkage, IRAM_ATTR macros, FreeRTOS task entry points (#291) SHA 726f71499970
-  "micropython|https://github.com/micropython/micropython.git|master|python|examples"                                                                          # MicroPython firmware-side scripts — top-level imports, no-stdlib subset (#291) SHA a595bbba6727
-  "cortex-m-quickstart|https://github.com/rust-embedded/cortex-m-quickstart.git|master|rust|src"                                                                # Embedded no_std Rust — #![no_main], #[entry] attributes, panic handlers (#291) SHA 7a6a7c2c8b94
-
-  # --- Workflow/orchestration (chunk EE, umbrella #293) ---
-  # Workflow- and orchestration-engine repos so the harness exercises
-  # workflow/activity definitions, DAG schedulers, decorators, and BPMN
-  # process XML alongside Java service-task implementations. Each entry is
-  # pinned to the SHA recorded in the umbrella body and verified via
-  # git ls-remote --symref. Sparse paths from the umbrella are documented
-  # in trailing comments; entries use a full clone where the umbrella lists
-  # multiple sparse paths because the parser supports a single sparse path
-  # only.
-  "temporalio-samples-go|https://github.com/temporalio/samples-go.git|main|go"                                 # Temporal Go workflow.ExecuteActivity, signal/query handlers (#293) SHA c5c710404fbf paths helloworld/ child_workflow/ mutex/
-  "cadence-client|https://github.com/uber-go/cadence-client.git|master|go|internal"                            # Cadence Go client workflow registration, activity options (#293) SHA df799e0e8164
-  "airflow|https://github.com/apache/airflow.git|main|python|airflow/example_dags"                             # Airflow @dag/@task decorators, PythonOperator, schedules (#293) SHA c51127ef4357
-  "prefect|https://github.com/PrefectHQ/prefect.git|main|python"                                               # Prefect @flow/@task decorators, deployment specs (#293) SHA fe44ad330730 paths src/prefect/flows.py examples/
-  "camunda-bpm-examples|https://github.com/camunda/camunda-bpm-examples.git|master|java_bpmn|servicetask"      # Camunda .bpmn XML processes + Java JavaDelegate (#293) SHA 8b86bcf8c329
-  "dagster|https://github.com/dagster-io/dagster.git|master|python|examples/quickstart_etl"                    # Dagster @asset/@op/@job decorators, IO managers (#293) SHA 50915f9cab16
-
-  # --- Data/ML/notebook (chunk DD, umbrella #292) ---
-  # Data, ML, and notebook ecosystems exercising scikit-learn / PyTorch / Keras
-  # / Transformers consumer idioms, the .ipynb extractor, Polars/Spark big-data
-  # APIs, and dbt SQL+Jinja models. Each entry pinned to the SHA recorded in
-  # umbrella #292 and verified via git ls-remote --symref on 2026-05-09.
-  "scikit-learn|https://github.com/scikit-learn/scikit-learn.git|main|python|examples"                        # scikit-learn Pipeline/fit/transform consumer idioms (#292) SHA a421648c9d5b
-  "pytorch-examples|https://github.com/pytorch/examples.git|main|python|mnist"                                # PyTorch nn.Module/forward/DataLoader patterns (#292) SHA acc295dc7b90
-  "keras-io|https://github.com/keras-team/keras-io.git|master|python|examples"                                # TF/Keras functional API, Model.fit, custom layers (#292) SHA 524c0d7ae593
-  "transformers|https://github.com/huggingface/transformers.git|main|python|examples/pytorch"                 # HF Transformers AutoModel/tokenizer/Trainer (#292) SHA c9de1097eed9
-  "jupyter-notebook|https://github.com/jupyter/notebook.git|main|notebook|docs/source"                        # .ipynb extractor: JSON cells, code+md, output stripping (#292) SHA 685709e0f199
-  "polars|https://github.com/pola-rs/polars.git|main|python|py-polars/tests/unit"                             # Polars lazy frames, pl.col expressions, chained transforms (#292) SHA a84168f0a4f1
-  "spark|https://github.com/apache/spark.git|master|scala|examples/src/main/scala"                            # Spark Scala RDD/Dataset, implicit conversions, object entry points (#292) SHA 6650e3f911f4
-  "jaffle_shop|https://github.com/dbt-labs/jaffle_shop.git|main|sql_dbt|models"                               # dbt models {{ ref() }}/{{ source() }}, schema.yml (#292) SHA fd7bfacae4f4
-  # --- Frontend SPA frameworks (chunk K, umbrella #303) ---
-  # Sample applications across the major frontend SPA / meta-framework stacks,
-  # per Refs #96 corpus policy. Each entry pinned to the SHA recorded in its
-  # child issue and verified via git ls-remote --symref on 2026-05-10. Gatsby
-  # is intentionally NOT in chunk W (#298) — it is owned by chunk K via #279.
-  "angular-realworld|https://github.com/gothinkster/angular-realworld-example-app.git|main|typescript"             # Angular sample app (#224) SHA f39866e52414
-  "react-redux-realworld|https://github.com/gothinkster/react-redux-realworld-example-app.git|master|javascript"   # React (CRA) sample app (#227) SHA ee72eba40563
-  "vite|https://github.com/vitejs/vite.git|main|typescript"                                                        # Vite (React+TS bundler) (#229) SHA cf0ff4154b26
-  "vue-realworld|https://github.com/gothinkster/vue-realworld-example-app.git|master|javascript"                   # Vue sample app (#231) SHA 3df3773b6be7
-  "svelte-realworld|https://github.com/sveltejs/realworld.git|master|javascript"                                   # Svelte sample app (#233) SHA e80873cac4e6
-  "sveltekit|https://github.com/sveltejs/kit.git|main|typescript"                                                  # SvelteKit framework (#235) SHA 785cdd3fe958
-  "solid-templates|https://github.com/solidjs/templates.git|main|typescript"                                       # SolidJS templates (#238) SHA a48da0c79ecf
-  "preact-cli|https://github.com/developit/preact-cli.git|master|javascript"                                       # Preact CLI scaffold (#239) SHA e826f7caab0d
-  "ember-super-rentals|https://github.com/ember-learn/super-rentals.git|main|javascript"                           # Ember sample app (#243) SHA 5d11a767bdc1
-  "astro|https://github.com/withastro/astro.git|main|typescript"                                                   # Astro framework (#247) SHA d365c975ba2d
-  "remix-indie-stack|https://github.com/remix-run/indie-stack.git|main|typescript"                                 # Remix indie-stack sample (#252) SHA 56abb93bf81f
-  "nuxt-starter|https://github.com/nuxt/starter.git|templates|typescript"                                          # Nuxt starter templates (#256) SHA cc96964ee7a1
-  "lit-element-starter|https://github.com/lit/lit-element-starter-ts.git|main|typescript"                          # Lit / Web Components starter (#261) SHA 6bf882733abd
-  "htmx|https://github.com/bigskysoftware/htmx.git|master|javascript"                                              # HTMX library (#266) SHA dbf77dd5207d
-  "alpine|https://github.com/alpinejs/alpine.git|main|javascript"                                                  # Alpine.js library (#271) SHA 3b125f96058a
-  "qwik|https://github.com/QwikDev/qwik.git|main|typescript"                                                       # Qwik framework (#276) SHA 38620076e10e
-  "gatsby-starter-blog|https://github.com/gatsbyjs/gatsby-starter-blog.git|master|javascript"                      # Gatsby starter blog (#279) SHA 04ec3e642112
-
-  # --- Web framework alts (chunk J, umbrella #311) ---
-  # Alternate web framework sample apps spanning Go (Echo/Fiber/Beego),
-  # Node (Fastify/Koa/Hapi/Sails/AdonisJS), Python (Tornado/Starlette/
-  # Pyramid/Bottle), PHP (Slim/CodeIgniter/Yii), Ruby (Sinatra/Hanami/
-  # Grape), Rust (Axum/Rocket/Warp/Tide), Scala (Akka HTTP/http4s),
-  # Clojure (Compojure/Pedestal), Elixir (Plug/Phoenix LiveView), and
-  # Kotlin (Javalin/http4k). Each entry pinned to the SHA recorded in
-  # the umbrella body and verified via git ls-remote --symref on
-  # 2026-05-10. Sparse paths are not used for these entries — the
-  # repos are sample apps or single-framework sources at HEAD size.
-  "echox|https://github.com/labstack/echox.git|master|go"                                                     # Echo v4 sample app: e.Group, middleware, route handlers (#240) SHA f938a8c5e04e
-  "gofiber-recipes|https://github.com/gofiber/recipes.git|master|go"                                          # Fiber app.Get/Post, middleware chains, sub-routers (#241) SHA 041c1976144d
-  "beego-example|https://github.com/beego/beego-example.git|master|go"                                        # Beego controllers, web.Router, ORM models (#242) SHA 7b8dfaf49040
-  "fastify-demo|https://github.com/fastify/demo.git|main|javascript"                                          # Fastify fastify.register, schema-validated routes (#244) SHA 5fa922df34d0
-  "koa-examples|https://github.com/koajs/examples.git|master|javascript"                                      # Koa app.use middleware, ctx.body, koa-router (#245) SHA 40c77dbecec6
-  "hapi|https://github.com/hapijs/hapi.git|master|javascript"                                                 # Hapi server.route, Joi validation, plugins (#246) SHA d4f93d80e6ac
-  "sails-examples|https://github.com/balderdashy/sails-examples.git|master|javascript"                        # Sails MVC controllers, blueprints, Waterline models (#248) SHA c8e7c8c41640
-  "adonis-blog-demo|https://github.com/adonisjs-community/adonis-blog-demo.git|master|javascript"             # AdonisJS Route.get, Controllers, Lucid ORM (#249) SHA 2262706c39a6
-  "tornado|https://github.com/tornadoweb/tornado.git|master|python"                                           # Tornado RequestHandler subclasses, async get/post (#250) SHA 87508512caab
-  "starlette|https://github.com/encode/starlette.git|main|python"                                             # Starlette Route()/Mount(), ASGI middleware (#253) SHA 7793b925a88e
-  "pyramid-shootout|https://github.com/Pylons/shootout.git|master|python"                                     # Pyramid config.add_route, view_config decorators (#254) SHA e5691d6f5ac0
-  "bottle|https://github.com/bottlepy/bottle.git|master|python"                                               # Bottle @route/@get/@post decorators, Bottle() apps (#255) SHA 2a743a302a71
-  "slim-skeleton|https://github.com/slimphp/Slim-Skeleton.git|main|php"                                       # Slim 4 $app->get/post, PSR-15 middleware, DI container (#258) SHA 0ef01549870b
-  "codeigniter-shield|https://github.com/codeigniter4/shield.git|develop|php"                                 # CodeIgniter 4 Controllers, $routes->group, filters (#260) SHA 34be62ba858d
-  "yii2-app-basic|https://github.com/yiisoft/yii2-app-basic.git|master|php"                                   # Yii2 Controllers, ActiveRecord models, URL rules (#262) SHA 660f9bd23cba
-  "sinatra-recipes|https://github.com/sinatra/sinatra-recipes.git|main|ruby"                                  # Sinatra get/post DSL, modular Sinatra::Base apps (#263) SHA 5430c1a5b613
-  "hanami|https://github.com/hanami/hanami.git|main|ruby"                                                     # Hanami actions, Hanami::Router, slice architecture (#265) SHA 116847bfdf9f
-  "grape-on-rack|https://github.com/ruby-grape/grape-on-rack.git|master|ruby"                                 # Grape API DSL: resource/get/post, params validation (#267) SHA 27b711871229
-  "axum|https://github.com/tokio-rs/axum.git|main|rust"                                                       # Axum Router::new().route, extractors, tower middleware (#268) SHA c853e44ffce7
-  "rocket|https://github.com/rwf2/Rocket.git|master|rust"                                                     # Rocket #[get]/#[post] attribute macros, Form/Json (#270) SHA 3a54d079aef0
-  "warp|https://github.com/seanmonstar/warp.git|master|rust"                                                  # Warp Filter combinators: warp::path, .and(), .map() (#272) SHA 707866ca367d
-  "tide|https://github.com/http-rs/tide.git|main|rust"                                                        # Tide app.at()/get()/post(), async middleware (#273) SHA b32f680d5bd1
-  "akka-http|https://github.com/akka/akka-http.git|main|scala"                                                # Akka HTTP Route DSL: path/get/post directives (#275) SHA d3ef24b4d0a3
-  "http4s|https://github.com/http4s/http4s.git|series/0.23|scala"                                             # http4s HttpRoutes.of partial functions, cats-effect (#277) SHA 134ca10c55c3
-  "compojure|https://github.com/weavejester/compojure.git|master|clojure"                                     # Compojure defroutes, GET/POST macros, ring middleware (#278) SHA 8a4758d28e8f
-  "pedestal|https://github.com/pedestal/pedestal.git|master|clojure"                                          # Pedestal interceptor chains, table-routes, service map (#281) SHA 4bda462b501c
-  "elixir-plug|https://github.com/elixir-plug/plug.git|main|elixir"                                           # Plug.Router, plug pipelines, Plug.Conn transformations (#282) SHA a447199b337d
-  "phoenix-live-view|https://github.com/phoenixframework/phoenix_live_view.git|main|elixir"                   # Phoenix LiveView mount/handle_event/render callbacks (#283) SHA 1b7b26e7d1e4
-  "javalin-samples|https://github.com/javalin/javalin-samples.git|main|kotlin"                                # Javalin app.get/post lambdas, route handlers, Jackson DTOs (#285) SHA 3064bf479c58
-  "http4k|https://github.com/http4k/http4k.git|master|kotlin"                                                 # http4k HttpHandler functions, routes() composition, filters (#286) SHA 9638dc45d7af
+  # --- Single-source MUST KEEP (extractor or DSL only-source) ---
+  "aspnetcore-docs-samples|https://github.com/dotnet/AspNetCore.Docs.Samples.git|main|razor"
+  "tide|https://github.com/IlanCosman/tide.git|main|fish"
+  "just|https://github.com/casey/just.git|master|just"
+  "http.zig|https://github.com/karlseguin/http.zig.git|master|zig"
+  "kickstart.nvim|https://github.com/nvim-lua/kickstart.nvim.git|master|lua"
+  "grpc-go-examples|https://github.com/grpc/grpc-go.git|master|proto|examples"
+  "apollo-server|https://github.com/apollographql/apollo-server.git|main|graphql"
+  "jupyter-notebook|https://github.com/jupyter/notebook.git|main|notebook|docs/source"
+  "jaffle_shop|https://github.com/dbt-labs/jaffle_shop.git|main|sql_dbt|models"
+  "azure-quickstart-templates|https://github.com/Azure/azure-quickstart-templates.git|master|bicep|quickstarts/microsoft.storage"
+  "tilt|https://github.com/tilt-dev/tilt.git|master|starlark|integration"
+  "camunda-bpm-examples|https://github.com/camunda/camunda-bpm-examples.git|master|java_bpmn|servicetask"
+  "asyncapi-spec|https://github.com/asyncapi/spec.git|master|asyncapi"
+  "smithy|https://github.com/smithy-lang/smithy.git|main|smithy|smithy-model"
+  "avro|https://github.com/apache/avro.git|main|avro|lang"
+  "thrift|https://github.com/apache/thrift.git|master|thrift|tutorial"
+  "json-schema-spec|https://github.com/json-schema-org/json-schema-spec.git|main|json-schema"
+  "raml-spec|https://github.com/raml-org/raml-spec.git|master|raml"
+  "api-blueprint|https://github.com/apiaryio/api-blueprint.git|master|api-blueprint"
+  "nginx|https://github.com/nginx/nginx.git|master|nginx-conf|conf"
+  "apache-httpd|https://github.com/apache/httpd.git|trunk|apache-httpd-conf|docs/conf"
+  "caddy|https://github.com/caddyserver/caddy.git|master|caddyfile|caddyconfig"
+  "traefik|https://github.com/traefik/traefik.git|master|traefik-dynamic|integration/fixtures"
+  "kong|https://github.com/Kong/kong.git|master|kong-declarative|spec/fixtures"
+  "envoy|https://github.com/envoyproxy/envoy.git|main|envoy-yaml|configs"
+  "haproxy|https://github.com/haproxy/haproxy.git|master|haproxy-cfg|examples"
+  "seleniumhq-examples|https://github.com/SeleniumHQ/seleniumhq.github.io.git|trunk|multi|examples"
+  # --- Language primary realworld apps ---
+  "requests|https://github.com/psf/requests.git|main|python"
+  "flask-realworld|https://github.com/gothinkster/flask-realworld-example-app.git|master|python"
+  "click|https://github.com/pallets/click.git|main|python"
+  "django-realworld|https://github.com/gothinkster/django-realworld-example-app.git|master|python"
+  "pandas|https://github.com/pandas-dev/pandas.git|main|python|pandas/core"
+  "gin|https://github.com/gin-gonic/gin.git|master|go"
+  "chi|https://github.com/go-chi/chi.git|master|go"
+  "etcd|https://github.com/etcd-io/etcd.git|main|go|server/etcdserver"
+  "express-realworld|https://github.com/gothinkster/node-express-realworld-example-app.git|master|javascript"
+  "nestjs-starter|https://github.com/nestjs/typescript-starter.git|master|typescript"
+  "nextjs-commerce|https://github.com/vercel/commerce.git|main|typescript"
+  "spring-petclinic|https://github.com/spring-projects/spring-petclinic.git|main|java"
+  "kafka-streams-examples|https://github.com/confluentinc/kafka-streams-examples.git|master|java"
+  "exposed|https://github.com/JetBrains/Exposed.git|main|kotlin"
+  "ktor-samples|https://github.com/ktorio/ktor-samples.git|main|kotlin"
+  "play-scala-starter|https://github.com/playframework/play-scala-starter-example.git|2.7.x|scala"
+  "usermanager-example|https://github.com/seancorfield/usermanager-example.git|develop|clojure"
+  "rails-realworld|https://github.com/gothinkster/rails-realworld-example-app.git|master|ruby"
+  "sidekiq|https://github.com/sidekiq/sidekiq.git|main|ruby"
+  "laravel-quickstart|https://github.com/laravel/quickstart-basic.git|master|php"
+  "symfony-demo|https://github.com/symfony/demo.git|main|php"
+  "mini-redis|https://github.com/tokio-rs/mini-redis.git|master|rust"
+  "actix-examples|https://github.com/actix/examples.git|main|rust"
+  "vapor-api-template|https://github.com/vapor/api-template.git|master|swift"
+  "sample-food-truck|https://github.com/apple/sample-food-truck.git|main|swift"
+  "aspnetcore-realworld|https://github.com/gothinkster/aspnetcore-realworld-example-app.git|master|csharp"
+  "spdlog|https://github.com/gabime/spdlog.git|v1.x|cpp"
+  "flutter-samples|https://github.com/flutter/samples.git|main|dart"
+  "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"
+  # --- Secondary distinctive coverage ---
+  "microblog|https://github.com/miguelgrinberg/microblog.git|main|python"                       # SQLAlchemy + Flask-Login (deeper than flask-realworld)
+  "fastapi-realworld|https://github.com/nsidnev/fastapi-realworld-example-app.git|master|python" # FastAPI + Pydantic + async SQLAlchemy
+  "golang-gin-realworld|https://github.com/gothinkster/golang-gin-realworld-example-app.git|main|go" # GORM
+  "actix-diesel-realworld|https://github.com/snamiki1212/realworld-v1-rust-actix-web-diesel.git|main|rust" # Diesel
+  "nestjs-realworld-typeorm|https://github.com/lujakob/nestjs-realworld-example-app.git|master|typescript" # TypeORM
+  "joal|https://github.com/anthonyraymond/joal.git|master|java"                                 # jOOQ
+  "jpetstore-6|https://github.com/mybatis/jpetstore-6.git|master|java"                          # MyBatis
+  "ent|https://github.com/ent/ent.git|master|go|entc/integration/ent"                           # Ent codegen
+  "sqlc-examples|https://github.com/sqlc-dev/sqlc.git|main|go|examples"                         # sqlc codegen
+  "netcore-boilerplate|https://github.com/lkurzyniec/netcore-boilerplate.git|master|csharp"     # Dapper micro-ORM
+  "tokio|https://github.com/tokio-rs/tokio.git|master|rust"                                     # Cargo workspace manifest
+  "pnpm|https://github.com/pnpm/pnpm.git|main|javascript"                                       # pnpm-workspace.yaml
+  "bazel|https://github.com/bazelbuild/bazel.git|master|java"                                   # BUILD Starlark targets
+  "cmake|https://github.com/Kitware/CMake.git|master|cpp"                                       # CMake lists
+  "mongoose|https://github.com/Automattic/mongoose.git|master|javascript"                       # Mongo Node ODM
+  "mongo-go-driver|https://github.com/mongodb/mongo-go-driver.git|master|go"                    # Mongo Go
+  "redis-py|https://github.com/redis/redis-py.git|master|python"                                # Redis Python
+  "cassandra-java-driver|https://github.com/datastax/java-driver.git|4.x|java"                  # Cassandra CQL
+  "aws-sdk-go-v2|https://github.com/aws/aws-sdk-go-v2.git|main|go"                              # DynamoDB / AWS SDK
+  "rabbitmq-tutorials|https://github.com/rabbitmq/rabbitmq-tutorials.git|main|python"           # AMQP
+  "aws-cdk-examples-typescript|https://github.com/aws-samples/aws-cdk-examples.git|main|typescript|typescript"
+  "pulumi-examples-go|https://github.com/pulumi/examples.git|master|go|aws-go-webserver"
+  "aws-cloudformation-samples|https://github.com/aws-cloudformation/aws-cloudformation-samples.git|main|yaml"
+  "aws-sam-cli-app-templates|https://github.com/aws/aws-sam-cli-app-templates.git|master|yaml|python3.12"
+  "serverless-examples|https://github.com/serverless/examples.git|v4|yaml|aws-node-http-api"
+  "crossplane|https://github.com/crossplane/crossplane.git|main|yaml|cluster/meta"
+  "ansible-for-devops|https://github.com/geerlingguy/ansible-for-devops.git|master|yaml"
+  "nomad-pack|https://github.com/hashicorp/nomad-pack.git|main|hcl|registry"
+  "terraform-aws-vpc|https://github.com/terraform-aws-modules/terraform-aws-vpc.git|master|hcl"
+  "argocd-example-apps|https://github.com/argoproj/argocd-example-apps.git|master|yaml"
+  "prometheus-helm|https://github.com/prometheus-community/helm-charts.git|main|yaml|charts/prometheus"
+  "starter-workflows|https://github.com/actions/starter-workflows.git|main|yaml"
+  "openapi-stripe|https://github.com/APIs-guru/openapi-directory.git|main|yaml|APIs/stripe.com"
+  "gitlab-runner|https://gitlab.com/gitlab-org/gitlab-runner.git|main|yaml|ci"
+  "circleci-demo-python-django|https://github.com/CircleCI-Public/circleci-demo-python-django.git|master|yaml|.circleci"
+  "jenkins|https://github.com/jenkinsci/jenkins.git|master|groovy"
+  "tektoncd-pipeline|https://github.com/tektoncd/pipeline.git|main|yaml|examples"
+  "alembic|https://github.com/sqlalchemy/alembic.git|main|python"
+  "ios-oss|https://github.com/kickstarter/ios-oss.git|main|swift"
+  "android-architecture|https://github.com/googlesamples/android-architecture.git|main|java"
+  "compose-samples|https://github.com/android/compose-samples.git|main|kotlin"
+  "EntityComponentSystemSamples|https://github.com/Unity-Technologies/EntityComponentSystemSamples.git|master|csharp|EntityComponentSystemSamples/ECSSamples"
+  "zod|https://github.com/colinhacks/zod.git|main|typescript"
+  "pydantic|https://github.com/pydantic/pydantic.git|main|python"
+  "aws-lambda-python-runtime-interface-client|https://github.com/aws/aws-lambda-python-runtime-interface-client.git|main|python|awslambdaric"
+  "cloudflare-workers-sdk|https://github.com/cloudflare/workers-sdk.git|main|typescript|packages/wrangler"
+  "xstate|https://github.com/statelyai/xstate.git|main|typescript|packages/core"
+  "hugoDocs|https://github.com/gohugoio/hugoDocs.git|master|go|content"
+  "sphinx|https://github.com/sphinx-doc/sphinx.git|master|python|sphinx"
+  "pytest|https://github.com/pytest-dev/pytest.git|main|python"
+  "socket.io|https://github.com/socketio/socket.io.git|main|typescript|packages/socket.io"
+  "airflow|https://github.com/apache/airflow.git|main|python|airflow/example_dags"
+  "spark|https://github.com/apache/spark.git|master|scala|examples/src/main/scala"
+  "angular-realworld|https://github.com/gothinkster/angular-realworld-example-app.git|main|typescript"
+  "sveltekit|https://github.com/sveltejs/kit.git|main|typescript"
+  "axum|https://github.com/tokio-rs/axum.git|main|rust"
+  "phoenix-live-view|https://github.com/phoenixframework/phoenix_live_view.git|main|elixir"
+  "http4k|https://github.com/http4k/http4k.git|master|kotlin"
+  # CONDITIONAL: uncomment if Vue SFC extractor is a separate code path
+  # "vue-realworld|https://github.com/gothinkster/vue-realworld-example-app.git|master|javascript"
 )
 
 # Locate or build the archigraph binary. We build into the corpora dir
@@ -540,8 +186,15 @@ fi
 
 TIMESTAMP="$(date -u +%Y-%m-%dT%H-%M-%SZ)"
 REPORT="$REPORTS_DIR/$TIMESTAMP.md"
-TMPDIR_AGG="$(mktemp -d)"
-trap 'rm -rf "$TMPDIR_AGG"' EXIT
+# Per-run scratch dir lives under _reports/ (NOT mktemp) so partial state
+# survives abort/SIGKILL/timeout — earlier behavior wiped per-repo JSON on
+# EXIT, making partial runs unsalvageable. The dir is only deleted at the
+# end of a successful run, gated by a `.complete` sentinel written by the
+# final aggregation step. Anything without a sentinel is preserved for
+# post-mortem; operators can `rm -rf` stale `*-partial/` dirs by hand.
+TMPDIR_AGG="$REPORTS_DIR/${TIMESTAMP}-partial"
+mkdir -p "$TMPDIR_AGG"
+trap '[[ -f "$TMPDIR_AGG/.complete" ]] && rm -rf "$TMPDIR_AGG"' EXIT
 
 # Optional per-repo wall-clock cap (seconds). Set ARCHIGRAPH_VERIFY2_TIMEOUT=0
 # to disable. Uses gtimeout (coreutils) if available, then timeout, then
@@ -806,6 +459,11 @@ with open(report, "a") as fh:
     status = "PASS" if agg_br <= 0.01 else "FAIL"
     fh.write(f"- status: **{status}** (bug_rate={agg_br:.4%})\n")
 PY
+
+# Mark this run complete — the EXIT trap will now garbage-collect
+# $TMPDIR_AGG. Without this sentinel the per-repo JSON survives so a
+# partial/aborted run can be inspected or resumed by hand.
+: >"$TMPDIR_AGG/.complete"
 
 echo "==> wrote report: $REPORT"
 echo "$REPORT"


### PR DESCRIPTION
## Summary

Splits the verify2 manifest into two tiers, fixes the trap-on-EXIT
bug that wiped partial state, and lands the per-entry decision log
in-repo.

## Before / after

| | before | after |
| --- | ---: | ---: |
| `scripts/verify2/run.sh` REPOS entries | 283 | **114** |
| `scripts/verify2/run-extended.sh` REPOS entries | — | **168** |
| Total entries tracked | 283 | 282 (dropped 1: `esp-idf`) |

`esp-idf` is the only entry removed from both tiers — archigraph
has no `c` extractor (only `cpp`, already covered by `spdlog`),
so the corpus would index zero files.

## Top-3 redundancies eliminated from the ship-gate

1. **Web-framework alternates** (29 → 6) — `axum`/`rocket`/`warp`/
   `tide` (rust) all exercise the same router-macro surface; one
   `actix-examples` + `axum` covers the lot. Same collapse for Go
   alternates (`echox`/`gofiber`/`beego`) and Python alternates
   (`tornado`/`starlette`/`pyramid`/`bottle`).
2. **State-management libraries** (8 → 1) — redux/mobx/zustand/
   pinia/ngrx/recoil/effector all covered incidentally by realworld
   apps. Keep `xstate` for the distinctive statechart DSL.
3. **CDK / Pulumi multi-flavor sprawl** (9 → 2) — per-language CDK
   variants exercise the per-language extractor, already covered
   by a realworld app in that language. Keep one CDK (TypeScript)
   + one Pulumi (Go).

## Trap-on-EXIT fix

Per-repo JSON now lives under `$REPORTS_DIR/<timestamp>-partial/`
instead of `mktemp -d`. The `EXIT` trap only deletes that dir when
a `.complete` sentinel file is written by the final aggregation
step. Aborts (SIGKILL, timeout, etc.) therefore preserve partial
state for inspection / resume.

## Coverage guarantee

All 32 dirs under `internal/extractors/` remain covered by tier-1
(verified against the per-entry matrix in `docs/verify2/corpus-curation-2026-05-19.md`).
The 22 single-source MUST-KEEP entries (razor, fish, just, zig,
lua, proto, graphql, notebook, sql_dbt, bicep, starlark,
java_bpmn, smithy, avro, thrift, json-schema, asyncapi, raml,
api-blueprint, nginx-conf, apache-httpd-conf, caddyfile,
traefik-dynamic, kong-declarative, envoy-yaml, haproxy-cfg,
selenium multi) all land in `run.sh`.

## Test plan

- [x] `bash -n scripts/verify2/run.sh` — clean
- [x] `bash -n scripts/verify2/run-extended.sh` — clean
- [x] Forbidden-term grep — clean
- [ ] Operator runs `scripts/verify2/run.sh` once on a clean
      workstation and confirms it produces the expected
      `_reports/<ts>.md` plus a `.complete` sentinel under
      `_reports/<ts>-partial/`
- [ ] Operator kills the harness mid-run and confirms the
      `*-partial/` dir survives for inspection

## Refs

#44 #87 #96

Per-entry decision log: `docs/verify2/corpus-curation-2026-05-19.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)