### PR TITLE
chore(verify2): re-add esp-idf for C corpus coverage

### DIFF
--- a/scripts/verify2/run.sh
+++ b/scripts/verify2/run.sh
@@ -100,6 +100,7 @@ REPOS=(
   "sample-food-truck|https://github.com/apple/sample-food-truck.git|main|swift"
   "aspnetcore-realworld|https://github.com/gothinkster/aspnetcore-realworld-example-app.git|master|csharp"
   "spdlog|https://github.com/gabime/spdlog.git|v1.x|cpp"
+  "esp-idf|https://github.com/espressif/esp-idf.git|master|c|examples/get-started"  # pure-C corpus; cpp extractor registers for both "c" and "cpp" languages via tree-sitter-c
   "flutter-samples|https://github.com/flutter/samples.git|main|dart"
   "phoenix-todo-list|https://github.com/dwyl/phoenix-todo-list-tutorial.git|main|elixir"
   # --- Secondary distinctive coverage ---


### PR DESCRIPTION
Curation #463 dropped `esp-idf` on the false premise that archigraph has no C extractor.

It does — `internal/extractors/cpp/extractor.go:52` registers the cpp extractor for **both** `"c"` and `"cpp"` languages and dispatches to tree-sitter-c (`internal/treesitter/parser.go:13`) for .c files. `esp-idf` provides a real pure-C corpus distinct from spdlog (header-only C++).

Refs #44 #87 #463