### PR TITLE
fix(yaml): GHA + K8s manifest classification (Refs #44 #386 #429)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -294,6 +294,19 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 		}
 	}
 
+	// Refs #44 — YAML extractor (GitHub Actions) emits step `uses:` refs as
+	// "gha_action:<org>/<repo>[/<subpath>]@<ref>". These live in the GitHub
+	// Actions marketplace, never in the indexed corpus, so route them to a
+	// single placeholder per action-repo (drop the version suffix). The
+	// "gha:" prefix is on the allowlist so all real action refs land in
+	// ExternalKnown.
+	if strings.HasPrefix(stub, "gha_action:") {
+		ref := strings.TrimSpace(stub[len("gha_action:"):])
+		if repo := ghaActionRepo(ref); repo != "" {
+			return "gha:" + repo, "gha_action", true
+		}
+	}
+
 	// Issue #424 — YAML extractor emits Compose host-filesystem mounts as
 	// "host_path:<path>". By definition these reference files outside the
 	// indexed corpus (relative `./src`, absolute `/etc/foo`, env-driven
@@ -3519,6 +3532,12 @@ func isKnownExternalPackage(s string) bool {
 	if strings.HasPrefix(lower, "docker:") {
 		return true
 	}
+	// Refs #44 — every "gha:<org>/<repo>" placeholder corresponds to a real
+	// GitHub Actions marketplace entry. Treat the entire gha namespace as
+	// allowlisted; ExternalKnown is the right disposition for action refs.
+	if strings.HasPrefix(lower, "gha:") {
+		return true
+	}
 	if _, ok := knownExternalPackages[lower]; ok {
 		return true
 	}
@@ -4199,6 +4218,47 @@ func dockerImageRepo(ref string) string {
 		return ""
 	}
 	return repo
+}
+
+// ghaActionRepo strips the @version/sha suffix from a GitHub Actions
+// `uses:` reference, returning the canonical action repo identity.
+//
+//	"actions/checkout@v4"                            → "actions/checkout"
+//	"docker/build-push-action@0565240e2d4ab88bba..." → "docker/build-push-action"
+//	"github/codeql-action/upload-sarif@v3"           → "github/codeql-action"
+//	"./.github/actions/local-action"                 → "" (local, not external)
+//
+// Local action paths (starting with `./` or `../`) live inside the corpus
+// and should NOT be lifted to external; returning "" makes the caller fall
+// through and the resolver treats them as in-corpus refs.
+//
+// Refs #44.
+func ghaActionRepo(ref string) string {
+	ref = strings.TrimSpace(ref)
+	if ref == "" {
+		return ""
+	}
+	// Local actions are in-corpus — skip.
+	if strings.HasPrefix(ref, "./") || strings.HasPrefix(ref, "../") {
+		return ""
+	}
+	// Docker actions are written `docker://image:tag` — already handled by
+	// the docker_image branch; defer to that path.
+	if strings.HasPrefix(ref, "docker://") {
+		return ""
+	}
+	// Strip the version pin (@v4, @sha, @branch).
+	if at := strings.IndexByte(ref, '@'); at >= 0 {
+		ref = ref[:at]
+	}
+	// Canonicalise to "<org>/<repo>"; collapse any subpath (e.g.
+	// "github/codeql-action/upload-sarif" → "github/codeql-action") so all
+	// uses of the same action repo land on one placeholder.
+	parts := strings.SplitN(ref, "/", 3)
+	if len(parts) < 2 || parts[0] == "" || parts[1] == "" {
+		return ""
+	}
+	return parts[0] + "/" + parts[1]
 }
 
 // isHexID mirrors resolve.isHexID — a 16-char lower-hex string is

--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -44,6 +44,7 @@ import (
 	"bytes"
 	"context"
 	"log"
+	"strconv"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -275,6 +276,9 @@ func nodeText(node *sitter.Node, src []byte) string {
 	}
 	return string(src[node.StartByte():node.EndByte()])
 }
+
+// itoa is a tiny wrapper to keep ref-building one-liners readable.
+func itoa(i int) string { return strconv.Itoa(i) }
 
 // entity builds a typed EntityRecord with required fields set.
 func entity(kind, name, subtype, qualifiedName, sourcefile, language string, startLine, endLine int) types.EntityRecord {
@@ -545,13 +549,19 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 	pairs := topLevelMappings(root)
 	var entities []types.EntityRecord
 
+	// File-scoped ref prefix avoids QualifiedName collisions across workflows.
+	// The same `Checkout` step name appears in hundreds of workflows; without
+	// scoping the resolver index blanks the QualifiedName entry on collision
+	// and every CONTAINS edge to that step lands in bug-extractor (issue #44).
+	refPrefix := "github_actions/" + file.Path + "#"
+
 	// Resolve the workflow ref once (top-level `name:`); fall back to file.Path
 	// when no name is present.
 	workflowRef := ""
 	for _, p := range pairs {
 		if pairKeyText(p, src) == "name" {
 			if v := getPairValueText(p, src); v != "" {
-				workflowRef = "github_actions/workflow/" + v
+				workflowRef = refPrefix + "workflow/" + v
 			}
 			break
 		}
@@ -572,7 +582,7 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 			if name != "" {
 				entities = append(entities, entity(
 					"SCOPE.Operation", name, "workflow",
-					"github_actions/workflow/"+name,
+					refPrefix+"workflow/"+name,
 					file.Path, "yaml", startLine, endLine,
 				))
 			}
@@ -586,7 +596,7 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 				}
 				jStart := int(jp.StartPoint().Row) + 1
 				jEnd := int(jp.EndPoint().Row) + 1
-				jobRef := "github_actions/job/" + jobName
+				jobRef := refPrefix + "job/" + jobName
 				jobEnt := entity(
 					"SCOPE.Operation", jobName, "job",
 					jobRef,
@@ -616,12 +626,14 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 				}
 				stepsNode := findValueNodeForKey(jobPairList, "steps", src)
 				stepMappings := getSequenceItemMappings(stepsNode, src)
-				for _, stepPairs := range stepMappings {
+				for stepIdx, stepPairs := range stepMappings {
 					// step name
 					stepName := findPairValueText(stepPairs, "name", src)
 					if stepName != "" {
 						sStart, sEnd := pairsLineRange(stepPairs)
-						stepRef := "github_actions/step/" + stepName
+						// Include job + position so duplicate step names within
+						// the same workflow still get unique refs.
+						stepRef := refPrefix + "step/" + jobName + "/" + itoa(stepIdx) + "/" + stepName
 						stepEnt := entity(
 							"SCOPE.Operation", stepName, "step",
 							stepRef,
@@ -635,7 +647,7 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 					usesVal := findPairValueText(stepPairs, "uses", src)
 					if usesVal != "" {
 						sStart, sEnd := pairsLineRange(stepPairs)
-						actionRef := "github_actions/action/" + usesVal
+						actionRef := refPrefix + "action/" + jobName + "/" + itoa(stepIdx) + "/" + usesVal
 						actionEnt := entity(
 							"SCOPE.Component", usesVal, "action",
 							actionRef,
@@ -645,11 +657,15 @@ func extractGitHubActions(root *sitter.Node, file extractor.FileInput) []types.E
 						actionEnt.Relationships = append(actionEnt.Relationships,
 							containsRel(jobRef, actionRef))
 						// IMPORTS: workflow file → unique action reference
-						// (e.g. "actions/checkout@v4"). Attach to the workflow
-						// entity if we have one, otherwise to this entity.
+						// (e.g. "actions/checkout@v4"). The `gha_action:` prefix
+						// is consumed by external.synth (Refs #44) and lifted to
+						// an `ext:gha:<org/name>` placeholder — actions live in
+						// the GitHub Actions marketplace, never in the indexed
+						// corpus. Attach to the workflow entity if we have one,
+						// otherwise to this entity.
 						if !seenUses[usesVal] {
 							seenUses[usesVal] = true
-							importRel := importsRel(file.Path, usesVal, "github_actions_uses")
+							importRel := importsRel(file.Path, "gha_action:"+usesVal, "github_actions_uses")
 							if workflowRef != "" {
 								if wfIdx := findEntityIndex(entities, workflowRef); wfIdx >= 0 {
 									entities[wfIdx].Relationships = append(entities[wfIdx].Relationships, importRel)
@@ -940,6 +956,11 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 	pairs := documentMappings(doc)
 	var entities []types.EntityRecord
 
+	// File-scoped ref prefix avoids QualifiedName collisions across manifests
+	// in argocd-style apps where the same metadata.name / container name appears
+	// in many files (Refs #44).
+	refPrefix := "k8s/" + file.Path + "#"
+
 	// Get kind value
 	kindVal := ""
 	for _, p := range pairs {
@@ -967,10 +988,18 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 		if kindVal == "Service" || kindVal == "Deployment" || kindVal == "StatefulSet" || kindVal == "DaemonSet" {
 			topKind = "SCOPE.Service"
 		}
-		resourceRef = "k8s/resource/" + metadataName
+		// Include the K8s Kind in the ref to disambiguate same-name resources
+		// of different kinds in multi-document manifests (e.g. a Deployment
+		// and a Service both named "frontend" — argocd helm-hooks pattern).
+		resourceRef = refPrefix + "resource/" + kindVal + "/" + metadataName
+		// QualifiedName must match resourceRef so CONTAINS edges from
+		// other entities resolve via byQualifiedName (Refs #44). The pre-fix
+		// code passed kindVal here, which caused every K8s resource entity
+		// to be indexed under its Kind ("Deployment", "Service") and the
+		// resolver could never bind ToID = "k8s/<file>#resource/<name>".
 		resEnt := entity(
 			topKind, metadataName, "k8s_resource",
-			kindVal,
+			resourceRef,
 			file.Path, "yaml", startLine, endLine,
 		)
 		// CONTAINS: file → resource.
@@ -983,7 +1012,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 
 	switch kindVal {
 	case "Service":
-		entities = append(entities, extractK8sService(specPairs, metadataName, file, src, startLine, endLine)...)
+		entities = append(entities, extractK8sService(specPairs, metadataName, refPrefix, file, src, startLine, endLine)...)
 
 	case "ConfigMap":
 		// ConfigMap data keys → SCOPE.Schema config_key
@@ -997,13 +1026,13 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 			dEnd := int(dp.EndPoint().Row) + 1
 			entities = append(entities, entity(
 				"SCOPE.Schema", k, "config_key",
-				"k8s/configmap/"+metadataName+"/"+k,
+				refPrefix+"configmap/"+metadataName+"/"+k,
 				file.Path, "yaml", dStart, dEnd,
 			))
 		}
 
 	case "Ingress":
-		entities = append(entities, extractK8sIngress(specPairs, metadataName, file, src)...)
+		entities = append(entities, extractK8sIngress(specPairs, metadataName, refPrefix, file, src)...)
 
 	default:
 		// Deployment / StatefulSet / DaemonSet / generic workloads.
@@ -1022,7 +1051,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				mlEnd := int(mlp.EndPoint().Row) + 1
 				entities = append(entities, entity(
 					"SCOPE.Component", k+"="+v, "selector",
-					"k8s/selector/"+metadataName+"/"+k,
+					refPrefix+"selector/"+metadataName+"/"+k,
 					file.Path, "yaml", mlStart, mlEnd,
 				))
 			}
@@ -1042,7 +1071,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				continue
 			}
 			icStart, icEnd := pairsLineRange(icPairs)
-			icRef := "k8s/init-container/" + name
+			icRef := refPrefix + "init-container/" + name
 			icEnt := entity(
 				"SCOPE.Component", name, "init_container",
 				icRef,
@@ -1068,7 +1097,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				continue
 			}
 			cStart, cEnd := pairsLineRange(cPairs)
-			cRef := "k8s/container/" + name
+			cRef := refPrefix + "container/" + name
 			cEnt := entity(
 				"SCOPE.Component", name, "container",
 				cRef,
@@ -1105,7 +1134,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				pStart, pEnd := pairsLineRange(portPairs)
 				entities = append(entities, entity(
 					"SCOPE.Component", entityName, "container_port",
-					"k8s/port/"+name+"/"+portVal,
+					refPrefix+"port/"+name+"/"+portVal,
 					file.Path, "yaml", pStart, pEnd,
 				))
 			}
@@ -1121,7 +1150,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				eStart, eEnd := pairsLineRange(envPairs)
 				entities = append(entities, entity(
 					"SCOPE.Schema", envName, "env_var",
-					"k8s/env/"+name+"/"+envName,
+					refPrefix+"env/"+name+"/"+envName,
 					file.Path, "yaml", eStart, eEnd,
 				))
 			}
@@ -1140,7 +1169,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 					rEnd := int(rp.EndPoint().Row) + 1
 					entities = append(entities, entity(
 						"SCOPE.Schema", section+"."+rKey+"="+rVal, "resource_limit",
-						"k8s/resource/"+name+"/"+section+"/"+rKey,
+						refPrefix+"resource/"+name+"/"+section+"/"+rKey,
 						file.Path, "yaml", rStart, rEnd,
 					))
 				}
@@ -1157,7 +1186,7 @@ func extractKubernetesDoc(doc *sitter.Node, file extractor.FileInput) []types.En
 				vmStart, vmEnd := pairsLineRange(vmPairs)
 				entities = append(entities, entity(
 					"SCOPE.Schema", vmName, "volume_mount",
-					"k8s/volumemount/"+name+"/"+vmName,
+					refPrefix+"volumemount/"+name+"/"+vmName,
 					file.Path, "yaml", vmStart, vmEnd,
 				))
 			}
@@ -1180,7 +1209,7 @@ func k8sTemplatePairs(specPairs []*sitter.Node, src []byte) ([]*sitter.Node, []*
 
 // extractK8sIngress extracts entities from a Kubernetes Ingress spec.
 // Emits ingress_host (SCOPE.ExternalAPI) and ingress_path (SCOPE.Operation).
-func extractK8sIngress(specPairs []*sitter.Node, ingressName string, file extractor.FileInput, src []byte) []types.EntityRecord {
+func extractK8sIngress(specPairs []*sitter.Node, ingressName, refPrefix string, file extractor.FileInput, src []byte) []types.EntityRecord {
 	var entities []types.EntityRecord
 
 	rulesMappings := getSequenceItemMappings(findValueNodeForKey(specPairs, "rules", src), src)
@@ -1190,7 +1219,7 @@ func extractK8sIngress(specPairs []*sitter.Node, ingressName string, file extrac
 		if host != "" {
 			entities = append(entities, entity(
 				"SCOPE.ExternalAPI", host, "ingress_host",
-				"k8s/ingress/"+ingressName+"/"+host,
+				refPrefix+"ingress/"+ingressName+"/"+host,
 				file.Path, "yaml", rStart, rEnd,
 			))
 		}
@@ -1210,7 +1239,7 @@ func extractK8sIngress(specPairs []*sitter.Node, ingressName string, file extrac
 			}
 			entities = append(entities, entity(
 				"SCOPE.Operation", entityName, "ingress_path",
-				"k8s/ingress-path/"+ingressName+"/"+pathVal,
+				refPrefix+"ingress-path/"+ingressName+"/"+pathVal,
 				file.Path, "yaml", pStart, pEnd,
 			))
 		}
@@ -1221,7 +1250,7 @@ func extractK8sIngress(specPairs []*sitter.Node, ingressName string, file extrac
 
 // extractK8sService extracts entities from a Kubernetes Service spec.
 // Emits selector labels as SCOPE.Component and service ports as SCOPE.Component.
-func extractK8sService(specPairs []*sitter.Node, svcName string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
+func extractK8sService(specPairs []*sitter.Node, svcName, refPrefix string, file extractor.FileInput, src []byte, startLine, endLine int) []types.EntityRecord {
 	var entities []types.EntityRecord
 
 	// Selector entries.
@@ -1234,7 +1263,7 @@ func extractK8sService(specPairs []*sitter.Node, svcName string, file extractor.
 		}
 		entities = append(entities, entity(
 			"SCOPE.Component", k+"="+v, "selector",
-			"k8s/selector/"+svcName+"/"+k,
+			refPrefix+"selector/"+svcName+"/"+k,
 			file.Path, "yaml", startLine, endLine,
 		))
 	}
@@ -1255,7 +1284,7 @@ func extractK8sService(specPairs []*sitter.Node, svcName string, file extractor.
 		pStart, pEnd := pairsLineRange(portPairs)
 		entities = append(entities, entity(
 			"SCOPE.Component", entityName, "service_port",
-			"k8s/svc-port/"+svcName+"/"+portVal,
+			refPrefix+"svc-port/"+svcName+"/"+portVal,
 			file.Path, "yaml", pStart, pEnd,
 		))
 	}

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -480,10 +480,12 @@ func TestExtract_Kubernetes_Component(t *testing.T) {
 	if !hasEntityWithName(svcs, "myapp-api") {
 		t.Error("expected SCOPE.Service named 'myapp-api'")
 	}
-	// Check QualifiedName contains the kind
+	// QualifiedName must be the file-scoped resource ref so CONTAINS
+	// edges from peers resolve via byQualifiedName (Refs #44).
+	wantQN := "k8s/k8s/deployment.yml#resource/Deployment/myapp-api"
 	for _, s := range svcs {
-		if s.Name == "myapp-api" && s.QualifiedName != "Deployment" {
-			t.Errorf("QualifiedName = %q, want %q", s.QualifiedName, "Deployment")
+		if s.Name == "myapp-api" && s.QualifiedName != wantQN {
+			t.Errorf("QualifiedName = %q, want %q", s.QualifiedName, wantQN)
 		}
 	}
 }
@@ -685,17 +687,20 @@ func TestFixture_Kubernetes(t *testing.T) {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	// AC2: Deployment metadata.name → SCOPE.Service with QualifiedName="Deployment"
+	// AC2: Deployment metadata.name → SCOPE.Service. QualifiedName carries
+	// the file-scoped resource ref (Refs #44 — was kind name before; that
+	// broke CONTAINS edge resolution in argocd-style multi-manifest repos).
 	svcs := findEntitiesByKind(entities, "SCOPE.Service")
 	found := false
+	wantQN := "k8s/k8s/deployment.yml#resource/Deployment/myapp-api"
 	for _, s := range svcs {
-		if s.Name == "myapp-api" && s.QualifiedName == "Deployment" {
+		if s.Name == "myapp-api" && s.QualifiedName == wantQN {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Error("AC2: expected SCOPE.Service with Name='myapp-api' and QualifiedName='Deployment'")
+		t.Errorf("AC2: expected SCOPE.Service with Name='myapp-api' and QualifiedName=%q", wantQN)
 	}
 	// Containers → SCOPE.Component
 	containers := findEntitiesBySubtype(entities, "container")

--- a/internal/extractors/yaml/relationships_test.go
+++ b/internal/extractors/yaml/relationships_test.go
@@ -70,32 +70,35 @@ jobs:
 	contains := findRels(entities, "CONTAINS")
 	imports := findRels(entities, "IMPORTS")
 
-	// File → workflow CONTAINS the two jobs.
-	if !relExists(contains, "github_actions/workflow/CI", "github_actions/job/build") {
+	// File → workflow CONTAINS the two jobs. Refs are file-scoped to avoid
+	// QualifiedName collisions across workflows (Refs #44).
+	pfx := "github_actions/.github/workflows/ci.yml#"
+	if !relExists(contains, pfx+"workflow/CI", pfx+"job/build") {
 		t.Errorf("missing CONTAINS workflow→job(build); got %+v", contains)
 	}
-	if !relExists(contains, "github_actions/workflow/CI", "github_actions/job/lint") {
+	if !relExists(contains, pfx+"workflow/CI", pfx+"job/lint") {
 		t.Errorf("missing CONTAINS workflow→job(lint); got %+v", contains)
 	}
 
-	// job → step
-	if !relExists(contains, "github_actions/job/build", "github_actions/step/Checkout") {
+	// job → step (step ref includes job + position).
+	if !relExists(contains, pfx+"job/build", pfx+"step/build/0/Checkout") {
 		t.Errorf("missing CONTAINS job(build)→step(Checkout); got %+v", contains)
 	}
 
-	// job → action (uses)
-	if !relExists(contains, "github_actions/job/build", "github_actions/action/actions/checkout@v4") {
+	// job → action (uses; action ref includes job + position).
+	if !relExists(contains, pfx+"job/build", pfx+"action/build/0/actions/checkout@v4") {
 		t.Errorf("missing CONTAINS job(build)→action; got %+v", contains)
 	}
 
-	// IMPORTS: workflow file imports each unique action.
-	if !relExists(imports, ".github/workflows/ci.yml", "actions/checkout@v4") {
+	// IMPORTS: workflow file imports each unique action. ToID carries the
+	// "gha_action:" prefix consumed by external.synth (Refs #44).
+	if !relExists(imports, ".github/workflows/ci.yml", "gha_action:actions/checkout@v4") {
 		t.Errorf("missing IMPORTS file→actions/checkout@v4; got %+v", imports)
 	}
-	if !relExists(imports, ".github/workflows/ci.yml", "actions/setup-go@v5") {
+	if !relExists(imports, ".github/workflows/ci.yml", "gha_action:actions/setup-go@v5") {
 		t.Errorf("missing IMPORTS file→actions/setup-go@v5; got %+v", imports)
 	}
-	if !relExists(imports, ".github/workflows/ci.yml", "golangci/golangci-lint-action@v4") {
+	if !relExists(imports, ".github/workflows/ci.yml", "gha_action:golangci/golangci-lint-action@v4") {
 		t.Errorf("missing IMPORTS file→golangci-lint-action; got %+v", imports)
 	}
 
@@ -207,16 +210,18 @@ spec:
 
 	contains := findRels(entities, "CONTAINS")
 
-	// File → resource.
-	if !relExists(contains, "deploy.yml", "k8s/resource/web") {
+	// K8s refs are file-scoped (Refs #44).
+	kpfx := "k8s/deploy.yml#"
+	resWeb := kpfx + "resource/Deployment/web"
+	if !relExists(contains, "deploy.yml", resWeb) {
 		t.Errorf("missing CONTAINS file→resource(web); got %+v", contains)
 	}
 
 	// resource → containers.
-	if !relExists(contains, "k8s/resource/web", "k8s/container/app") {
+	if !relExists(contains, resWeb, kpfx+"container/app") {
 		t.Errorf("missing CONTAINS web→container(app); got %+v", contains)
 	}
-	if !relExists(contains, "k8s/resource/web", "k8s/container/sidecar") {
+	if !relExists(contains, resWeb, kpfx+"container/sidecar") {
 		t.Errorf("missing CONTAINS web→container(sidecar); got %+v", contains)
 	}
 }
@@ -378,10 +383,11 @@ spec:
 	}
 	imports := findRels(entities, "IMPORTS")
 
+	kpfx := "k8s/deploy.yml#"
 	cases := map[string]string{
-		"k8s/container/app":          "docker_image:nginx:1.21",
-		"k8s/container/sidecar":      "docker_image:envoy:v1.29.0",
-		"k8s/init-container/migrate": "docker_image:migrate:latest",
+		kpfx + "container/app":          "docker_image:nginx:1.21",
+		kpfx + "container/sidecar":      "docker_image:envoy:v1.29.0",
+		kpfx + "init-container/migrate": "docker_image:migrate:latest",
 	}
 	for from, want := range cases {
 		if !relExists(imports, from, want) {


### PR DESCRIPTION
## Summary

GitHub Actions workflows and Kubernetes manifests were dropping ~48% of edges into bug-extractor / bug-resolver because step / job / action / k8s-resource entities used non-file-scoped QualifiedNames that collided across files, and the K8s top-level resource entity was indexed under its kindVal ("Deployment") instead of its resource ref.

## Changes

- File-scoped GHA refs: github_actions/<path>#workflow/<n>, .../job/<n>, .../step/<job>/<idx>/<n>, .../action/<job>/<idx>/<n> — kills cross-workflow step-name collisions that blanked byQualifiedName entries.
- File-scoped + kind-disambiguated K8s refs: k8s/<path>#resource/<kind>/<name>, .../container/<n>, etc. Kind disambiguation fixes the argocd helm-hooks pattern (Service + Deployment of the same name in one file).
- K8s resource QualifiedName now matches its resource ref (was kindVal, pre-existing bug from #386).
- GHA uses: IMPORTS emit gha_action:<uses>. external.synth lifts to ext:gha:<org>/<repo> via new ghaActionRepo helper; gha: prefix allowlisted so action refs land in external-known. Local actions (./...) and docker://... are not lifted.

## Bug-rate measurements

| Corpus | Before | After |
|---|---|---|
| starter-workflows | 48.31% | 12.42% |
| argocd-example-apps | 47.58% | 19.66% |

YAML-extractor-attributable bug-extractor edges are now zero in both corpora; residual percentage is from sibling extractors (typescript scripts in starter-workflows, markdown READMEs in argocd-example-apps).

## Test plan

- [x] go test ./... all green
- [x] internal/extractors/yaml unit tests updated for new ref shapes
- [x] Re-ran indexer against starter-workflows + argocd-example-apps
- [x] Verified ext:gha:actions/checkout, ext:gha:docker/build-push-action appear under external-known