### PR TITLE
fix(go): qualify top-level main/init FromIDs with structural-ref (Refs #44 #472)

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -909,8 +909,30 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType, paramTypes)
 		// Rewrite FromID on each CALLS edge to the qualified Name so the
 		// edge source matches the entity ID downstream.
+		//
+		// Refs #44 #472 — top-level `main` and `init` are unqualified across
+		// every Go package: any multi-binary repo (e.g. grpc-go-examples
+		// with 70 `examples/*/main.go` files) collapses their bare-name
+		// byName entries to "ambiguous", forcing every CALLS edge sourced
+		// from `main`/`init` into the bug-resolver bucket. The Format A
+		// structural-ref form `scope:operation:function:go:<file>:<name>`
+		// pins the edge to the file's entity via byLocation[<file>][<name>]
+		// regardless of how many sibling files repeat the same bare name.
+		// Methods already encode their receiver into Name (issue #66) and
+		// resolve via byMember, so this only fires for top-level functions.
+		fromID := name
+		if receiverType == "" {
+			// All top-level functions get a Format A structural-ref FromID.
+			// Even `Run`, `Setup`, `Handle`, `New`, etc. collide across
+			// packages in any non-trivial multi-binary repo; widening from
+			// the narrow `main`/`init` allowlist to every top-level function
+			// removes the entire FromID-side ambiguity class for Go without
+			// changing the entity Name (so byName lookups for the ToID side
+			// behave exactly as before).
+			fromID = extractor.BuildOperationStructuralRef("go", filePath, nameText)
+		}
 		for i := range relationships {
-			relationships[i].FromID = name
+			relationships[i].FromID = fromID
 		}
 
 		// DEPENDS_ON edge from each method to its receiver type.
@@ -918,7 +940,7 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 		// needing qualified-name joins downstream.
 		if receiverType != "" {
 			relationships = append(relationships, types.RelationshipRecord{
-				FromID: name,
+				FromID: fromID,
 				ToID:   receiverType,
 				Kind:   "DEPENDS_ON",
 			})

--- a/internal/extractors/golang/extractor_test.go
+++ b/internal/extractors/golang/extractor_test.go
@@ -1854,3 +1854,223 @@ func (s *OrderStore) Get(id string) string { return "" }
 		t.Errorf("struct %s: not found in extracted entities", name)
 	}
 }
+
+// TestMainAndInitEmitStructuralFromID verifies Refs #44 #472: top-level `main`
+// and `init` functions emit CALLS edges with a Format A structural-ref
+// FromID instead of the bare name. Two files declaring `func main` would
+// otherwise both emit FromID="main", colliding in the resolver's byName
+// index and forcing every such edge into bug-resolver.
+func TestMainAndInitEmitStructuralFromID(t *testing.T) {
+	cases := []struct {
+		path    string
+		src     string
+		fnName  string
+		wantSub string // substring expected in the structural-ref FromID
+	}{
+		{
+			path: "examples/helloworld/greeter_server/main.go",
+			src: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("a")
+}
+`,
+			fnName:  "main",
+			wantSub: "scope:operation:method:go:examples/helloworld/greeter_server/main.go:main",
+		},
+		{
+			path: "examples/route_guide/server/main.go",
+			src: `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("b")
+}
+
+func init() {
+	fmt.Println("c")
+}
+`,
+			fnName:  "main",
+			wantSub: "scope:operation:method:go:examples/route_guide/server/main.go:main",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			results, err := extractFromPath(tc.src, tc.path)
+			if err != nil {
+				t.Fatalf("extract: %v", err)
+			}
+			found := false
+			for _, r := range results {
+				e := r.(types.EntityRecord)
+				if e.Kind != "SCOPE.Operation" || e.Name != tc.fnName {
+					continue
+				}
+				found = true
+				if len(e.Relationships) == 0 {
+					t.Fatalf("entity %q: expected at least one CALLS edge, got 0", tc.fnName)
+				}
+				for _, rel := range e.Relationships {
+					if rel.Kind != "CALLS" {
+						continue
+					}
+					if rel.FromID != tc.wantSub {
+						t.Errorf("CALLS FromID = %q, want %q", rel.FromID, tc.wantSub)
+					}
+				}
+			}
+			if !found {
+				t.Fatalf("did not find entity %q in extracted records", tc.fnName)
+			}
+		})
+	}
+}
+
+// TestMainFromIDsDistinctAcrossFiles verifies that the structural-ref form
+// produced for `func main` in two different files differs, so a resolver
+// indexing CALLS edges keyed by (FromID) sees two distinct sources rather
+// than one ambiguous bucket.
+func TestMainFromIDsDistinctAcrossFiles(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("x")
+}
+`
+	a, err := extractFromPath(src, "cmd/server-a/main.go")
+	if err != nil {
+		t.Fatalf("extract a: %v", err)
+	}
+	b, err := extractFromPath(src, "cmd/server-b/main.go")
+	if err != nil {
+		t.Fatalf("extract b: %v", err)
+	}
+	pick := func(rs []interface{}) string {
+		for _, r := range rs {
+			e := r.(types.EntityRecord)
+			if e.Kind != "SCOPE.Operation" || e.Name != "main" {
+				continue
+			}
+			for _, rel := range e.Relationships {
+				if rel.Kind == "CALLS" {
+					return rel.FromID
+				}
+			}
+		}
+		return ""
+	}
+	fa, fb := pick(a), pick(b)
+	if fa == "" || fb == "" {
+		t.Fatalf("missing FromID: a=%q b=%q", fa, fb)
+	}
+	if fa == fb {
+		t.Errorf("FromIDs collided across files: %q", fa)
+	}
+}
+
+// TestInitTopLevelStructuralFromID verifies that a top-level init() function
+// receives the same structural-ref FromID treatment as main().
+func TestInitTopLevelStructuralFromID(t *testing.T) {
+	src := `package widgets
+
+import "fmt"
+
+func init() {
+	fmt.Println("setup")
+}
+`
+	results, err := extractFromPath(src, "internal/widgets/setup.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	wantFrom := "scope:operation:method:go:internal/widgets/setup.go:init"
+	for _, r := range results {
+		e := r.(types.EntityRecord)
+		if e.Kind != "SCOPE.Operation" || e.Name != "init" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if rel.Kind == "CALLS" && rel.FromID != wantFrom {
+				t.Errorf("init CALLS FromID = %q, want %q", rel.FromID, wantFrom)
+			}
+		}
+		return
+	}
+	t.Fatalf("init entity not found")
+}
+
+// TestTopLevelFunctionsAllGetStructuralFromID verifies that the widened
+// fix (Refs #44 #472) emits Format A structural-ref FromIDs for every
+// top-level function, not just `main`/`init`. Common names like `Run`,
+// `Setup`, `Handle`, `New` collide just as often across packages in
+// multi-binary repos.
+func TestTopLevelFunctionsAllGetStructuralFromID(t *testing.T) {
+	src := `package svc
+
+import "fmt"
+
+func Run() {
+	fmt.Println("ok")
+}
+`
+	results, err := extractFromPath(src, "svc/run.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	wantFrom := "scope:operation:method:go:svc/run.go:Run"
+	for _, r := range results {
+		e := r.(types.EntityRecord)
+		if e.Kind != "SCOPE.Operation" || e.Name != "Run" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if rel.Kind == "CALLS" && rel.FromID != wantFrom {
+				t.Errorf("Run CALLS FromID = %q, want %q", rel.FromID, wantFrom)
+			}
+		}
+		return
+	}
+	t.Fatalf("Run entity not found")
+}
+
+// TestMethodFromIDStillBare verifies that methods (entities with a
+// receiver) keep their dotted `<Receiver>.<method>` Name as the FromID.
+// The receiver-qualified Name already disambiguates across files via the
+// byMember index (issue #66), so methods don't need the structural-ref
+// FromID treatment that top-level functions do.
+func TestMethodFromIDStillBare(t *testing.T) {
+	src := `package svc
+
+import "fmt"
+
+type S struct{}
+
+func (s *S) Save() {
+	fmt.Println("ok")
+}
+`
+	results, err := extractFromPath(src, "svc/store.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, r := range results {
+		e := r.(types.EntityRecord)
+		if e.Kind != "SCOPE.Operation" || e.Name != "S.Save" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if rel.Kind == "CALLS" && rel.FromID != "S.Save" {
+				t.Errorf("S.Save CALLS FromID = %q, want %q", rel.FromID, "S.Save")
+			}
+		}
+		return
+	}
+	t.Fatalf("S.Save entity not found")
+}


### PR DESCRIPTION
## Summary

Top-level Go functions (especially `main` and `init`) emitted bare-name CALLS FromIDs. In multi-binary repos (grpc-go-examples has 70 `examples/*/main.go` files), the resolver's `byName` index flips these to ambiguous, sending every CALLS edge sourced from `main` / `init` to the bug-resolver bucket.

This rewrites the FromID on every CALLS / DEPENDS_ON edge from a top-level Go function (no receiver) to a Format A structural-ref:

```
scope:operation:method:go:<file>:<name>
```

The resolver binds these via `byLocation[<file>][<name>]`, which is unambiguous per file. Methods already encode their receiver in Name (issue #66) and resolve via `byMember`, so they keep their dotted form.

## Results

VERIFY-2 on grpc-go-examples:

| | bug-extractor | bug-resolver | bug-rate |
|--|--|--|--|
| Before (post #472) | 1106 | 506 | **10.74%** |
| After (narrow main/init only) | 1109 | 374 | 9.35% |
| After (all top-level funcs) | 1121 | 286 | **8.76%** |

bug-resolver count dropped 506 → 286 (-43%). Did not quite hit the ≤8% target; residual bug-resolver samples (`s`, `valid`, `ecServer`, `callUnaryEcho`) point to single-letter local-var call sites and same-file method bindings — separate problem classes that need their own targeted PRs.

## Test plan

- [x] `go test ./internal/extractors/golang/...` — pass
- [x] `go test ./...` — all green
- [x] `go vet ./...` — clean
- [x] VERIFY-2 grpc-go-examples remeasured
- [x] 5 new TDD tests added (see commit body)

🤖 Generated with [Claude Code](https://claude.com/claude-code)