### PR TITLE
fix(synth): Ktor server DSL HTTP-verb classification via import gate

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -1304,6 +1304,27 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 				return "function", true
 			}
 		}
+		// Ktor server DSL HTTP-verb routing — `get("/x") { ... }`,
+		// `post(...)`, `put(...)`, `delete(...)`, `patch(...)`,
+		// `head(...)`, `options(...)` are extension functions on
+		// `Route` / `Routing` declared in `io.ktor.server.routing.*`.
+		// The Kotlin extractor receiver-strips them and the lowercase
+		// HTTP-verb names collide trivially with generic property
+		// accessors / Java-style getters (`Repository.get`,
+		// `Cache.put`), so #106's safer-bias rule rejected them from
+		// kotlinBareNames. We gate them on the source file having a
+		// genuine `io.ktor.server.*` import — same precision model as
+		// the Go chi-router gate (#131): the routing-DSL extension
+		// functions can only originate from a Ktor server import, and
+		// files that don't import Ktor keep the safer-bias miss.
+		//
+		// In the ktor-samples corpus these verbs are the single largest
+		// bug-resolver cohort (~310 of 647 unresolved CALLS).
+		if hasKtorServerImport(fromImports) {
+			if _, ok := kotlinKtorRoutingVerbs[name]; ok {
+				return "function", true
+			}
+		}
 	}
 	if lang == "scala" {
 		if _, ok := scalaBareNames[name]; ok {
@@ -1964,6 +1985,54 @@ func hasGoChiImport(imports map[string]bool) bool {
 	}
 	for p := range goChiImportPaths {
 		if imports[p] {
+			return true
+		}
+	}
+	return false
+}
+
+// kotlinKtorRoutingVerbs is the Kotlin-language-gated + Ktor-server-import-
+// gated bare-name allowlist for the HTTP-verb routing-DSL functions.
+// Ktor exposes them as extension functions on `io.ktor.server.routing.Route`
+// (and through the `routing { ... }` builder on `Application`); the
+// kotlin extractor receiver-strips them (`get("/x") { ... }` → bare
+// `get`), and the lowercase verb names collide trivially with generic
+// property accessors / Java-style getters (`Repository.get`, `Cache.put`),
+// so #106's safer-bias rule rejected them from kotlinBareNames.
+//
+// Used by stdlibFunction (kotlin branch) gated on BOTH lang=="kotlin"
+// AND hasKtorServerImport(fromImports). On the ktor-samples corpus
+// these verbs are the single largest bug-resolver cohort (~310 of 647
+// unresolved CALLS at the PR #471 baseline).
+//
+// Refs #44 #435 #456.
+var kotlinKtorRoutingVerbs = map[string]struct{}{
+	"get":     {},
+	"post":    {},
+	"put":     {},
+	"delete":  {},
+	"patch":   {},
+	"head":    {},
+	"options": {},
+}
+
+// hasKtorServerImport reports whether the source file's import set
+// contains any `io.ktor.server.*` path — the precise signal that the
+// file is using the Ktor server DSL. Same precision model as the Go
+// chi-router gate (#131): the routing-DSL extension functions
+// (`get`/`post`/`put`/`delete`/`patch`/`head`/`options` on `Route`)
+// can only originate from a Ktor server import, and a file that doesn't
+// import Ktor keeps the safer-bias miss.
+//
+// The Kotlin extractor stamps IMPORTS edges with the full dotted
+// module path (`io.ktor.server.routing`, `io.ktor.server.application`,
+// `io.ktor.server.netty`, ...), so a simple prefix match is precise.
+func hasKtorServerImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		if p == "io.ktor.server" || strings.HasPrefix(p, "io.ktor.server.") {
 			return true
 		}
 	}

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1802,6 +1802,165 @@ func TestKotlinKtorDSLBareNames_NotClassifiedForOtherLanguages(t *testing.T) {
 	}
 }
 
+// TestKotlinKtorRoutingVerbs_ClassifiedWithKtorImport covers the
+// Ktor-verb fix: HTTP-verb routing-DSL functions (`get("/x") { ... }`,
+// `post(...)`, `put(...)`, `delete(...)`, `patch(...)`, `head(...)`,
+// `options(...)`) on `io.ktor.server.routing.Route` get receiver-
+// stripped by the Kotlin extractor. The lowercase verb names collide
+// trivially with generic property accessors (`Repository.get`,
+// `Cache.put`), so #106's safer-bias rule rejected them from
+// kotlinBareNames. They must classify as stdlib bare-names ONLY when
+// the source file imports `io.ktor.server.*` — same precision model as
+// the Go chi-router gate (#131).
+//
+// Refs #44 #435 #456.
+func TestKotlinKtorRoutingVerbs_ClassifiedWithKtorImport(t *testing.T) {
+	verbs := []string{"get", "post", "put", "delete", "patch", "head", "options"}
+	importSets := []map[string]bool{
+		{"io.ktor.server.routing": true},
+		{"io.ktor.server.application": true, "io.ktor.server.netty": true},
+		{"io.ktor.server.routing.get": true}, // non-wildcard leaf still matches the prefix.
+		{"io.ktor.server": true},
+	}
+	for _, name := range verbs {
+		for i, imps := range importSets {
+			name, imps := name, imps
+			t.Run(name+"/set"+itoaTest(i), func(t *testing.T) {
+				t.Parallel()
+				subtype, ok := stdlibFunction(name, "kotlin", "Routes.kt", imps)
+				if !ok {
+					t.Fatalf("stdlibFunction(%q, \"kotlin\", Ktor imports) not classified; want stdlib bare-name", name)
+				}
+				if subtype != "function" {
+					t.Fatalf("subtype=%q, want \"function\"", subtype)
+				}
+			})
+		}
+	}
+}
+
+// TestKotlinKtorRoutingVerbs_NotClassifiedWithoutKtorImport locks the
+// import-gate precision: without a `io.ktor.server.*` import the
+// HTTP-verb names must NOT be rewritten. A Kotlin `Repository.get` /
+// `Cache.put` user method that lands at the resolver as a bare leaf
+// (the resolver couldn't bind the receiver, common with field chains)
+// must stay unresolved rather than synthesise an `ext:get` placeholder.
+//
+// `head` and `options` are EXCLUDED from this assertion: `head` is in
+// the unconditional kotlinBareNames allowlist as a kotlinx.html DSL
+// leaf builder (#470 — `<head>` HTML element block), and `options`
+// would otherwise be added by an HTML-DSL cohort; both classify
+// regardless of the Ktor-import gate. This test covers the verbs whose
+// CLASSIFICATION depends on the Ktor gate.
+//
+// Refs #44 #435 #456.
+func TestKotlinKtorRoutingVerbs_NotClassifiedWithoutKtorImport(t *testing.T) {
+	verbs := []string{"get", "post", "put", "delete", "patch"}
+	importSets := []map[string]bool{
+		nil,
+		{},
+		{"kotlin.io.println": true},
+		{"org.springframework.web.bind.annotation.RestController": true},
+		{"io.ktor.client.HttpClient": true}, // client-side, not server DSL
+	}
+	for _, name := range verbs {
+		for i, imps := range importSets {
+			name, imps := name, imps
+			t.Run(name+"/set"+itoaTest(i), func(t *testing.T) {
+				t.Parallel()
+				if _, ok := stdlibFunction(name, "kotlin", "App.kt", imps); ok {
+					t.Fatalf("stdlibFunction(%q, \"kotlin\", non-Ktor imports=%v) classified; "+
+						"must require io.ktor.server.* import", name, imps)
+				}
+			})
+		}
+	}
+}
+
+// TestKotlinKtorRoutingVerbs_NotClassifiedForOtherLanguages confirms
+// the Kotlin language gate holds for the Ktor-verb addition: with a
+// non-kotlin language, the Kotlin Ktor-import branch must be skipped
+// even when the (synthetic) import set contains `io.ktor.server.*`.
+//
+// Test strategy: compare each verb/lang pair WITH and WITHOUT the
+// Ktor imports. If the result is the same, the Kotlin Ktor branch is
+// correctly NOT firing for the non-kotlin language (other-lang
+// allowlists may classify the verb on their own — that is orthogonal
+// to this gate and intentional). If a verb classifies only when Ktor
+// imports are present for a non-kotlin language, the gate is broken.
+//
+// Refs #44 #435 #456.
+func TestKotlinKtorRoutingVerbs_NotClassifiedForOtherLanguages(t *testing.T) {
+	verbs := []string{"get", "post", "put", "delete", "patch", "head", "options"}
+	otherLangs := []string{"go", "python", "javascript", "rust", "java", "csharp", ""}
+	ktorImps := map[string]bool{"io.ktor.server.routing": true}
+	for _, name := range verbs {
+		for _, lang := range otherLangs {
+			name, lang := name, lang
+			t.Run(name+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				_, okWithout := stdlibFunction(name, lang, "Routes.kt", nil)
+				_, okWith := stdlibFunction(name, lang, "Routes.kt", ktorImps)
+				if okWith != okWithout {
+					t.Fatalf("stdlibFunction(%q, %q): classify diverges based on Ktor imports "+
+						"(with=%v, without=%v); Kotlin Ktor branch must not fire for non-kotlin",
+						name, lang, okWith, okWithout)
+				}
+			})
+		}
+	}
+}
+
+// TestHasKtorServerImport covers the import-gate helper directly:
+// matches any `io.ktor.server` or `io.ktor.server.*` path, rejects
+// empty / nil sets and non-Ktor / Ktor-client imports.
+//
+// Refs #44 #435 #456.
+func TestHasKtorServerImport(t *testing.T) {
+	cases := []struct {
+		name    string
+		imports map[string]bool
+		want    bool
+	}{
+		{"nil", nil, false},
+		{"empty", map[string]bool{}, false},
+		{"root", map[string]bool{"io.ktor.server": true}, true},
+		{"routing", map[string]bool{"io.ktor.server.routing": true}, true},
+		{"application", map[string]bool{"io.ktor.server.application": true}, true},
+		{"netty", map[string]bool{"io.ktor.server.netty": true}, true},
+		{"leaf import", map[string]bool{"io.ktor.server.routing.get": true}, true},
+		{"client only", map[string]bool{"io.ktor.client.HttpClient": true}, false},
+		{"unrelated", map[string]bool{"kotlin.io.println": true, "java.util.UUID": true}, false},
+		{"io.ktor (no server)", map[string]bool{"io.ktor.http.HttpStatusCode": true}, false},
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			if got := hasKtorServerImport(c.imports); got != c.want {
+				t.Errorf("hasKtorServerImport(%v) = %v, want %v", c.imports, got, c.want)
+			}
+		})
+	}
+}
+
+// itoaTest is a tiny int-to-string helper to keep test subtest names
+// deterministic without pulling in strconv (already used elsewhere in
+// the file via helper functions, but this avoids touching imports).
+func itoaTest(i int) string {
+	if i == 0 {
+		return "0"
+	}
+	var buf [16]byte
+	pos := len(buf)
+	for i > 0 {
+		pos--
+		buf[pos] = byte('0' + i%10)
+		i /= 10
+	}
+	return string(buf[pos:])
+}
+
 // TestKotlinResidualBareNames_ClassifiedWhenLangIsKotlin covers issue
 // #456: residual ktor-samples bug-extractor cohorts after #122 + #106 +
 // #435. The Kotlin extractor receiver-strips kotlinx.serialization

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -4,17 +4,25 @@
 //   - class_declaration    → Kind="SCOPE.Component", Subtype="class"
 //   - object_declaration   → Kind="SCOPE.Component", Subtype="object"
 //   - function_declaration → Kind="SCOPE.Operation", Subtype="function"
+//   - import_header        → Kind="SCOPE.Component", Subtype="import"
+//     (one entity per import; Name is the FULL dotted path, NOT the
+//     leading segment — the historical "ghost org / com / java" hazard
+//     came from splitting on '.', which we do NOT do here; mirrors the
+//     Python extractor's importRecord shape.)
 //
 // When a class carries a Spring stereotype annotation (@RestController,
 // @Controller, @Service, @Component, @Repository) we additionally emit a
 // Kind="SCOPE.Service" entity whose Name is the class name, matching the
 // Python indexer's output.
 //
-// Import headers are intentionally NOT emitted as entities or
-// IMPORTS relationships. The Python kotlin extractor does not emit them,
-// and the Go extractor previously produced ghost "org" / "com" / "java"
-// SCOPE.Component entities by splitting import paths on '.', which broke
-// parity verdict classification.
+// Import headers carry one IMPORTS relationship (FromID=file path,
+// ToID=full dotted module path, with `.*` wildcard suffix stripped).
+// This unlocks file-import-aware allowlist gating in
+// internal/external/synth.go — Ktor server DSL HTTP-verb routing
+// (`get("/x") { ... }`, `post(...)`, ...) is the leading residual
+// bug-resolver cohort in ktor-samples (#456 / #470), and the synth
+// classifier needs the file's import set to gate these collision-prone
+// verb names on a genuine Ktor import.
 //
 // The extractor registers itself via init() and is auto-imported by the
 // generated registry_gen.go.
@@ -155,7 +163,11 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 		}
 		return
 
-		// import_header intentionally NOT handled — see package doc.
+	case "import_header":
+		if rec, ok := buildImport(node, file); ok {
+			*out = append(*out, rec)
+		}
+		return
 	}
 
 	for i := range node.ChildCount() {
@@ -354,6 +366,67 @@ func buildComponent(node *sitter.Node, file extractor.FileInput, subtype string)
 		EndLine:            int(node.EndPoint().Row) + 1,
 		Signature:          buildClassSignature(node, file.Content, name),
 		EnrichmentRequired: false,
+	}, true
+}
+
+// buildImport creates a SCOPE.Component entity for an import_header node.
+//
+// The entity Name is the FULL dotted module path (e.g.
+// "io.ktor.server.routing"), with the optional trailing `.*` wildcard
+// suffix stripped. We intentionally do NOT split on '.' or use the first
+// segment as the Name — the historical Kotlin ghost-entity hazard
+// (`org`, `com`, `java` ghosts that broke parity verdict classification)
+// came from splitting; mirroring the Python extractor's importRecord
+// shape avoids it.
+//
+// One IMPORTS relationship is embedded on the entity:
+//
+//	FromID = file path  (the importing source file)
+//	ToID   = full dotted module path (wildcard suffix stripped)
+//	Kind   = "IMPORTS"
+//
+// The cross-file resolver and the external-synthesis pass both consume
+// these edges to gate language-specific allowlists on a real import
+// (e.g. Ktor server DSL HTTP-verb routing — `get("/x") { ... }`,
+// `post(...)` — must only classify as external when the source file
+// imports an `io.ktor.server.*` package, per the same precision model
+// the Go chi-router gate uses, #131).
+func buildImport(node *sitter.Node, file extractor.FileInput) (types.EntityRecord, bool) {
+	// import_header text shape: `import io.ktor.server.routing.*`
+	// or `import io.ktor.server.routing.get`. Strip the leading
+	// `import` keyword + trailing wildcard, comments, and the optional
+	// `as <alias>` rename — we keep only the dotted module path so the
+	// resolver can do prefix matches against allowlists.
+	raw := strings.TrimSpace(string(file.Content[node.StartByte():node.EndByte()]))
+	raw = strings.TrimPrefix(raw, "import ")
+	raw = strings.TrimSpace(raw)
+	// Drop trailing line comment (`import x.y // foo`).
+	if i := strings.Index(raw, "//"); i >= 0 {
+		raw = strings.TrimSpace(raw[:i])
+	}
+	// Drop `as <alias>` rename.
+	if i := strings.Index(raw, " as "); i >= 0 {
+		raw = strings.TrimSpace(raw[:i])
+	}
+	// Strip wildcard suffix.
+	raw = strings.TrimSuffix(raw, ".*")
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return types.EntityRecord{}, false
+	}
+	return types.EntityRecord{
+		Name:       raw,
+		Kind:       "SCOPE.Component",
+		Subtype:    "import",
+		SourceFile: file.Path,
+		Language:   "kotlin",
+		Relationships: []types.RelationshipRecord{
+			{
+				FromID: file.Path,
+				ToID:   raw,
+				Kind:   "IMPORTS",
+			},
+		},
 	}, true
 }
 

--- a/internal/extractors/kotlin/kotlin_test.go
+++ b/internal/extractors/kotlin/kotlin_test.go
@@ -2,6 +2,7 @@ package kotlin_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -170,15 +171,19 @@ object MySingleton {
 	}
 }
 
-// TestKotlinExtractor_NoImportGhostComponents is the regression guard for
-// AC #2. The Go kotlin extractor previously emitted a SCOPE.Component
-// entity named after the top-level segment of every import path (e.g. "org",
-// "com", "java") plus an IMPORTS relationship. The Python indexer emits
-// neither, so those entities were Go-only ghosts polluting parity output.
+// TestKotlinExtractor_NoImportGhostComponents is the ghost-entity
+// regression guard for AC #2. The Go kotlin extractor previously
+// emitted a SCOPE.Component entity named after the top-level segment
+// of every import path (e.g. "org", "com", "java"). That ghost shape
+// broke parity verdict classification.
 //
-// This test locks the current behaviour: given a file with org./com./java.
-// imports, the extractor must not emit any entity whose name is one of those
-// segments, and must not emit any IMPORTS relationship at all.
+// IMPORTS edges ARE now emitted (Ktor-verb fix — the synth classifier
+// needs the per-file import set to gate Ktor server DSL HTTP verbs),
+// but every import entity carries Name=FULL dotted path. This test
+// locks the current behaviour: given a file with org./com./java.
+// imports, the extractor must not emit any entity whose name is the
+// short leading segment, and every IMPORTS edge must carry the full
+// dotted path as its ToID.
 func TestKotlinExtractor_NoImportGhostComponents(t *testing.T) {
 	src := `
 package com.example.demo
@@ -203,16 +208,25 @@ class Foo {}
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	ghostNames := map[string]bool{"org": true, "com": true, "java": true}
+	ghostNames := map[string]bool{"org": true, "com": true, "java": true, "io": true, "kotlin": true}
 	for _, e := range got {
 		if ghostNames[e.Name] {
 			t.Errorf("ghost entity %q (kind=%s) emitted from package/import parsing",
 				e.Name, e.Kind)
 		}
 		for _, rel := range e.Relationships {
-			if rel.Kind == "IMPORTS" {
-				t.Errorf("unexpected IMPORTS relationship %s → %s — kotlin extractor must not emit imports",
-					rel.FromID, rel.ToID)
+			if rel.Kind != "IMPORTS" {
+				continue
+			}
+			// Every IMPORTS edge must carry a fully-qualified
+			// dotted path — never a short leading segment.
+			if ghostNames[rel.ToID] {
+				t.Errorf("IMPORTS ToID=%q is a ghost segment; want full dotted path",
+					rel.ToID)
+			}
+			if !strings.Contains(rel.ToID, ".") {
+				t.Errorf("IMPORTS ToID=%q has no '.' — expected fully-qualified import path",
+					rel.ToID)
 			}
 		}
 	}

--- a/internal/extractors/kotlin/relationships_test.go
+++ b/internal/extractors/kotlin/relationships_test.go
@@ -230,20 +230,81 @@ func TestKotlin_NavigationCallTrailingIdentifier(t *testing.T) {
 	}
 }
 
-// TestKotlin_NoImports (#41): kotlin extractor intentionally does
-// NOT emit IMPORTS edges (Python parity). Guard against future regressions
-// that re-introduce ghost "org" / "com" / "java" entities.
-func TestKotlin_NoImports(t *testing.T) {
+// TestKotlin_ImportsEmittedFullPath locks in the Ktor-verb fix:
+// the kotlin extractor emits one SCOPE.Component (Subtype="import")
+// per import_header, with Name set to the FULL dotted module path
+// (NOT split on '.', so no resurrected `org`/`com`/`java` ghost
+// entities that broke parity verdict classification in the original
+// #41 reject). Each entity carries one IMPORTS relationship
+// FromID=file path, ToID=full dotted module path with the optional
+// `.*` wildcard suffix stripped — consumed by the cross-file resolver
+// and the external-synthesis pass to gate language-specific allowlists
+// (Ktor server DSL HTTP verbs `get/post/put/delete/...` need a real
+// `io.ktor.server.*` import to classify, per the chi-router gate
+// precision model #131).
+func TestKotlin_ImportsEmittedFullPath(t *testing.T) {
 	src := `package x
+import io.ktor.server.routing.get
+import io.ktor.server.routing.*
 import kotlin.io.println
 class A
 `
 	ents := runKotlin(t, src)
+
+	// Helper: collect (Name, ToID) tuples for every IMPORTS edge.
+	type impEdge struct {
+		entName string
+		entKind string
+		entSub  string
+		toID    string
+	}
+	var imps []impEdge
 	for _, e := range ents {
 		for _, r := range e.Relationships {
 			if r.Kind == "IMPORTS" {
-				t.Errorf("kotlin extractor should not emit IMPORTS, got %+v on %s", r, e.Name)
+				imps = append(imps, impEdge{
+					entName: e.Name, entKind: e.Kind, entSub: e.Subtype, toID: r.ToID,
+				})
 			}
+		}
+	}
+	want := map[string]string{
+		"io.ktor.server.routing.get": "io.ktor.server.routing.get",
+		"io.ktor.server.routing":     "io.ktor.server.routing",
+		"kotlin.io.println":          "kotlin.io.println",
+	}
+	if len(imps) != len(want) {
+		t.Fatalf("expected %d IMPORTS edges, got %d: %+v", len(want), len(imps), imps)
+	}
+	for _, e := range imps {
+		if e.entKind != "SCOPE.Component" {
+			t.Errorf("import entity %q kind=%q, want SCOPE.Component", e.entName, e.entKind)
+		}
+		if e.entSub != "import" {
+			t.Errorf("import entity %q subtype=%q, want \"import\"", e.entName, e.entSub)
+		}
+		wantTo, ok := want[e.entName]
+		if !ok {
+			t.Errorf("unexpected import entity name %q", e.entName)
+			continue
+		}
+		if e.toID != wantTo {
+			t.Errorf("import %q: ToID=%q, want %q", e.entName, e.toID, wantTo)
+		}
+	}
+
+	// Ghost-entity guard: no `org` / `com` / `java` / `io` / `kotlin`
+	// short-segment SCOPE.Component entities — the original #41 hazard
+	// was a split-on-'.' implementation that produced these.
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Component" {
+			continue
+		}
+		switch e.Name {
+		case "org", "com", "java", "io", "kotlin":
+			t.Errorf("ghost import entity %q (Kind=%q, Subtype=%q) — "+
+				"import Name must be the FULL dotted path, never the first segment",
+				e.Name, e.Kind, e.Subtype)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Ktor server routing-DSL HTTP verbs (`get/post/put/delete/patch/head/options`) on `Route` get receiver-stripped by the Kotlin extractor and collide with generic property accessors (`Repository.get`). Per #106 they were rejected from `kotlinBareNames`. On ktor-samples they are the largest bug-resolver cohort (~310 of 647 unresolved CALLS).
- Adds an import-gated classification path mirroring the Go chi-router gate (#131): kotlin extractor now emits IMPORTS edges with full dotted module paths (no ghost segment entities); synth classifier routes the verb names to `ext:<name>` only when lang=="kotlin" AND the source file imports `io.ktor.server.*`.

## Measurement

VERIFY-2, ktor-samples corpus (single-repo run, local binary):

| metric | before (main @ #471) | after |
| --- | ---: | ---: |
| bug_rate | 10.40% | **6.34%** |
| bug-resolver | 647 | 423 |
| resolved | 5727 | 6010 |
| external-known | 262 | 1152 |

Target was bug_rate <= 8% — achieved.

Cross-repo regression check (chi, etcd, spring-petclinic, kafka-streams-examples, exposed): all unchanged or improved relative to PR #471 baseline. The new gate fires only on the `lang=="kotlin"` branch.

## Test plan

- [x] `go test ./internal/extractors/kotlin/...` — passes (including rewritten ghost guard + new full-path IMPORTS test).
- [x] `go test ./internal/external/...` — passes (4 new tests covering positive/negative/lang-gate/helper).
- [x] `go test ./...` — full suite green.
- [x] VERIFY-2 single-repo measurement on ktor-samples re-run with fix applied.
- [x] Spot-check 4 non-Kotlin corpora for regression.

Refs #44 #435 #456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)