### PR TITLE
fix(yaml): CONTAINS FromID uses canonical entity ID, not raw file path

### DIFF
--- a/internal/extractors/yaml/extractor.go
+++ b/internal/extractors/yaml/extractor.go
@@ -259,10 +259,55 @@ func extractByFlavor(flavor string, root *sitter.Node, file extractor.FileInput)
 	default:
 		entities = extractGeneric(root, file)
 	}
+	// Issue #474 chain-fix — file-rooted CONTAINS edges across every YAML
+	// flavor use `file.Path` as FromID (see relationships.go). Pre-fix the
+	// file had no corresponding entity, so the resolver could not bind the
+	// FromID and every such edge landed in bug-extractor (57 on
+	// argocd-example-apps alone). Mirror the markdown extractor and emit
+	// one SCOPE.Document per YAML file with QualifiedName=file.Path so
+	// the byQualifiedName index resolves file.Path → the Document entity
+	// ID. The Document is the canonical parent entity for the file, per
+	// ADR-0009.
+	if len(entities) > 0 {
+		docEntity := buildYAMLDocument(flavor, root, file)
+		// Prepend so the Document appears first in the file's entity list
+		// (matches the markdown extractor's ordering convention).
+		entities = append([]types.EntityRecord{docEntity}, entities...)
+	}
 	// Issue #386 / #90: stamp Properties["language"]="yaml" on every embedded
 	// relationship so the resolver dispatches the YAML dynamic-pattern catalog.
 	extractor.TagRelationshipsLanguage(entities, "yaml")
 	return entities
+}
+
+// buildYAMLDocument constructs the SCOPE.Document entity for a YAML file.
+// QualifiedName equals file.Path so that file-rooted CONTAINS edges (whose
+// FromID is set to file.Path by the flavor extractors) resolve via the
+// resolver's byQualifiedName index. The Subtype carries the detected YAML
+// flavor so downstream tooling can distinguish e.g. a Kubernetes manifest
+// Document from an Ansible playbook Document.
+//
+// Issue #474 chain-fix.
+func buildYAMLDocument(flavor string, root *sitter.Node, file extractor.FileInput) types.EntityRecord {
+	endLine := bytes.Count(file.Content, []byte("\n")) + 1
+	if root != nil {
+		endLine = int(root.EndPoint().Row) + 1
+	}
+	name := file.Path
+	if idx := strings.LastIndexByte(name, '/'); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return types.EntityRecord{
+		Kind:          "SCOPE.Document",
+		Name:          name,
+		Subtype:       flavor,
+		QualifiedName: file.Path,
+		SourceFile:    file.Path,
+		Language:      "yaml",
+		StartLine:     1,
+		EndLine:       endLine,
+		QualityScore:  0.7,
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/extractors/yaml/extractor_test.go
+++ b/internal/extractors/yaml/extractor_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -631,6 +632,12 @@ func TestExtract_Generic_TopLevelKeys(t *testing.T) {
 		t.Error("expected entity 'server'")
 	}
 	for _, e := range entities {
+		// Issue #474 chain-fix — the per-file SCOPE.Document anchor entity
+		// is emitted alongside the flavor-specific entities and is not a
+		// generic top-level key.
+		if e.Kind == "SCOPE.Document" {
+			continue
+		}
 		if e.Kind != "SCOPE.Schema" {
 			t.Errorf("generic entity %q kind = %q, want SCOPE.Schema", e.Name, e.Kind)
 		}
@@ -643,6 +650,9 @@ func TestExtract_Generic_Subtype(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	for _, e := range entities {
+		if e.Kind == "SCOPE.Document" {
+			continue
+		}
 		if e.Subtype != "key" {
 			t.Errorf("generic entity %q subtype = %q, want key", e.Name, e.Subtype)
 		}
@@ -791,6 +801,9 @@ baz: qux
 		t.Error("expected entities from generic YAML fallback")
 	}
 	for _, e := range entities {
+		if e.Kind == "SCOPE.Document" {
+			continue
+		}
 		if e.Kind != "SCOPE.Schema" {
 			t.Errorf("fallback entity %q kind=%q, want SCOPE.Schema", e.Name, e.Kind)
 		}
@@ -816,6 +829,11 @@ var allowedKinds = map[string]bool{
 	"SCOPE.Stylesheet":    true,
 	"SCOPE.UIComponent":   true,
 	"SCOPE.InfraResource": true,
+	// Issue #474 chain-fix — per-file SCOPE.Document anchor entity so
+	// file-rooted CONTAINS edges (FromID=file.Path) resolve via the
+	// resolver's byQualifiedName index instead of landing in
+	// bug-extractor.
+	"SCOPE.Document": true,
 }
 
 func TestExtract_AllKindsAreAllowlisted(t *testing.T) {
@@ -1585,5 +1603,80 @@ func TestMX1104_AllNewEntitiesAreAllowlisted(t *testing.T) {
 				t.Errorf("entity %q has non-allowlisted kind %q (file: %s)", e.Name, e.Kind, f.path)
 			}
 		}
+	}
+}
+
+// TestIssue474_ContainsFromIDResolvesToDocumentEntity asserts the chain-fix
+// invariant from issue #474: every file-rooted CONTAINS edge emitted by the
+// YAML extractor (i.e. every FromID that looks like a raw file path rather
+// than a structural ref) must correspond to a SCOPE.Document entity whose
+// QualifiedName equals that FromID. Pre-fix the Document entity was missing
+// and every such FromID landed in the resolver's bug-extractor bucket — 57
+// on argocd-example-apps alone, 538 on starter-workflows.
+func TestIssue474_ContainsFromIDResolvesToDocumentEntity(t *testing.T) {
+	fixtures := []struct {
+		src  []byte
+		path string
+		name string
+	}{
+		{githubActionsFixture, ".github/workflows/ci.yml", "github_actions"},
+		{dockerComposeFixture, "docker-compose.yml", "docker_compose"},
+		{k8sDeploymentFixture, "k8s/deployment.yml", "kubernetes"},
+		{ansibleFixture, "playbook.yml", "ansible"},
+		{gitlabCIFixture, ".gitlab-ci.yml", "gitlab_ci"},
+	}
+	for _, f := range fixtures {
+		t.Run(f.name, func(t *testing.T) {
+			entities, err := extractYAML(f.src, f.path)
+			if err != nil {
+				t.Fatalf("extract %s: %v", f.path, err)
+			}
+
+			var doc *types.EntityRecord
+			for i := range entities {
+				if entities[i].Kind == "SCOPE.Document" {
+					doc = &entities[i]
+					break
+				}
+			}
+			if doc == nil {
+				t.Fatalf("%s: expected one SCOPE.Document entity, found none", f.path)
+			}
+			if doc.QualifiedName != f.path {
+				t.Errorf("%s: SCOPE.Document QualifiedName=%q, want %q (must equal file.Path so file-rooted CONTAINS FromIDs resolve via byQualifiedName)",
+					f.path, doc.QualifiedName, f.path)
+			}
+			if doc.Language != "yaml" {
+				t.Errorf("%s: SCOPE.Document Language=%q, want yaml", f.path, doc.Language)
+			}
+
+			var fileRooted int
+			for _, e := range entities {
+				for _, r := range e.Relationships {
+					if r.Kind != "CONTAINS" {
+						continue
+					}
+					from := r.FromID
+					if strings.ContainsAny(from, ":#") {
+						continue
+					}
+					if !strings.HasSuffix(from, ".yml") && !strings.HasSuffix(from, ".yaml") {
+						continue
+					}
+					fileRooted++
+					if from != doc.QualifiedName {
+						t.Errorf("%s: file-rooted CONTAINS FromID=%q does not equal Document QualifiedName=%q",
+							f.path, from, doc.QualifiedName)
+					}
+				}
+			}
+			// Docker Compose and Kubernetes always emit file-rooted
+			// CONTAINS (file → service / file → resource). GHA only roots
+			// at file.Path when the workflow has no top-level `name:` —
+			// the fixture has one, so it produces no file-rooted edges.
+			if fileRooted == 0 && (f.name == "docker_compose" || f.name == "kubernetes") {
+				t.Errorf("%s: expected at least one file-rooted CONTAINS edge, found none", f.path)
+			}
+		})
 	}
 }


### PR DESCRIPTION
Chain-fix surfaced by #474 (markdown). The YAML extractor emitted file-rooted CONTAINS edges with FromID set to the raw file path (e.g. `applicationset/matrix.yaml`) but never produced a matching entity. The resolver's byQualifiedName index found no anchor and every such FromID landed in bug-extractor.

## Root cause

`internal/extractors/yaml/relationships.go` documents that file-rooted CONTAINS uses `file.Path` as FromID. All six flavor extractors do this. Pre-fix no SCOPE.Document anchor existed for the file, so the FromID was orphaned at resolve time.

## Fix

Mirror the markdown extractor: emit one `SCOPE.Document` per YAML file with `QualifiedName = file.Path`. Existing FromIDs now resolve via byQualifiedName. No resolver changes, no churn across the six flavor extractors. Subtype carries the detected flavor.

A new TDD test `TestIssue474_ContainsFromIDResolvesToDocumentEntity` covers GitHub Actions, Docker Compose, Kubernetes, Ansible, and GitLab CI fixtures and asserts: every file-rooted CONTAINS FromID (path-shaped, no `:` or `#`) must equal the Document's QualifiedName.

## Measurements

| Repo | bug-extractor (before → after) | bug_rate | resolution |
|---|---|---|---|
| argocd-example-apps | 57 → 0 | 16.19% → 0% | 75.57% → 91.76% |
| starter-workflows | 538 → 19* | 11.89% → 0.55%* | 78.31% → 89.46% |
| prometheus-helm | 0 → 0 | 0% (unchanged) | 99.16% (unchanged) |
| openapi-stripe | 0 → 0 | 0% (unchanged) | 100% (unchanged) |

*starter-workflows post-fix numbers include sibling fixes that landed on main during this work (TS Node-stdlib #475, Go main-qualify #476).

## Test plan

- [x] `go test ./internal/extractors/yaml/...` passes
- [x] `go test ./...` clean
- [x] VERIFY-2 on argocd-example-apps: bug-extractor 57 → 0
- [x] VERIFY-2 on starter-workflows: bug-extractor 538 → 19 (no regression)
- [x] Spot-check prometheus-helm, openapi-stripe: unchanged

Refs #44 #386. Closes the YAML branch of the chain surfaced by #474.

🤖 Generated with [Claude Code](https://claude.com/claude-code)