### PR TITLE
fix(go): bare CALLS ToIDs become structural-refs; Dynamic over bug-resolver

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -906,7 +906,7 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 		// Body-derived var types do NOT include closure-param shadowing — the
 		// per-call walker below maintains its own scope stack to disambiguate.
 		paramTypes = mergeVarTypes(paramTypes, collectBodyVarTypes(bodyOrNode, src))
-		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType, paramTypes)
+		relationships := extractCallRelationships(bodyOrNode, src, nameText, recvVarName, receiverType, paramTypes, filePath)
 		// Rewrite FromID on each CALLS edge to the qualified Name so the
 		// edge source matches the entity ID downstream.
 		//
@@ -992,7 +992,7 @@ func extractFunctions(root *sitter.Node, src []byte, filePath string) ([]types.E
 // entity. Calls on other selector operands (e.g. `other.foo()`, package-
 // qualified calls) are NOT stamped — the heuristic is intentionally
 // conservative to avoid false same-package binds (Refs #94 lesson).
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVarName, recvType string, paramTypes map[string]string) []types.RelationshipRecord {
+func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVarName, recvType string, paramTypes map[string]string, filePath string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -1058,6 +1058,26 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVar
 					if ty := lookup(operand); ty != "" {
 						rec.Properties = map[string]string{"receiver_type": ty}
 					}
+				}
+				// Refs #44 (Refs #476 follow-up) — identifier-form CALLS edges
+				// (bare `foo(...)` with no selector operand) collide on the
+				// ToID side just like top-level `main`/`init` collide on the
+				// FromID side: any multi-binary repo (grpc-go-examples with
+				// 14 `func callUnaryEcho` across examples/*/client/main.go)
+				// folds the bare-name byName entry to "ambiguous" and forces
+				// every such edge into bug-resolver. Rewriting the ToID to a
+				// Format A structural-ref keyed on the CALLER's file pins
+				// same-file callees (the dominant pattern: a function calling
+				// a sibling helper declared in the same .go file) to a unique
+				// byLocation entry. Cross-file/cross-package bare-name calls
+				// that don't resolve still avoid bug-resolver because
+				// isHeuristicScopeStub routes unresolved `scope:operation:`
+				// stubs to Dynamic. Selector-form calls (`pkg.X` /
+				// `recv.method`) keep their bare ToID — they resolve through
+				// byMember / external-package / receiver_type paths that the
+				// structural-ref shape doesn't help with.
+				if operand == "" && !isSelfReceiver && filePath != "" {
+					rec.ToID = extractor.BuildOperationStructuralRef("go", filePath, target)
 				}
 				rels = append(rels, rec)
 			}

--- a/internal/extractors/golang/extractor_test.go
+++ b/internal/extractors/golang/extractor_test.go
@@ -900,8 +900,12 @@ func main() {
 	if main == nil {
 		t.Fatal("main function not found")
 	}
-	if !hasRelationship(main, "CALLS", "helper") {
-		t.Errorf("expected CALLS → helper on main, got %+v", main.Relationships)
+	// Refs #44 follow-up: identifier-form CALLS edges (no selector) emit a
+	// Format A structural-ref ToID so bare names like `helper` don't collide
+	// across packages in multi-binary repos. Same-file callees resolve via
+	// byLocation in the resolver.
+	if !hasRelationship(main, "CALLS", "scope:operation:method:go:main.go:helper") {
+		t.Errorf("expected CALLS → structural-ref(helper) on main, got %+v", main.Relationships)
 	}
 }
 
@@ -972,8 +976,10 @@ func fact(n int) int {
 }
 
 func TestCallsRelationship_UnknownExternalCall(t *testing.T) {
-	// rule #6: unknown/external callees are emitted with the bare
-	// function name rather than being dropped.
+	// rule #6: unknown/external callees are emitted rather than being
+	// dropped. Refs #44 follow-up — identifier-form (bare) calls get a
+	// Format A structural-ref ToID so unresolved targets land in
+	// Dynamic via isHeuristicScopeStub rather than bug-resolver.
 	src := `package main
 
 func caller() {
@@ -985,8 +991,8 @@ func caller() {
 	if caller == nil {
 		t.Fatal("caller function not found")
 	}
-	if !hasRelationship(caller, "CALLS", "mystery") {
-		t.Errorf("expected CALLS → mystery (unknown target), got %+v", caller.Relationships)
+	if !hasRelationship(caller, "CALLS", "scope:operation:method:go:main.go:mystery") {
+		t.Errorf("expected CALLS → structural-ref(mystery), got %+v", caller.Relationships)
 	}
 }
 
@@ -2073,4 +2079,135 @@ func (s *S) Save() {
 		return
 	}
 	t.Fatalf("S.Save entity not found")
+}
+
+// TestBareCallToIDEmitsStructuralRef verifies Refs #44 / Refs #476 follow-up:
+// CALLS edges whose target is a bare identifier (a same-file/same-package
+// function call like `valid(md)` or `callUnaryEcho(rgc, "x")`) emit a Format A
+// structural-ref ToID that pins the edge to the caller's file. Without this
+// the bare name collides with same-named functions in sibling packages
+// (e.g. 14 `func callUnaryEcho` across grpc-go-examples/examples/*) and
+// every such CALLS edge lands in the bug-resolver bucket. The structural-ref
+// resolves via byLocation[<file>][<name>] when the callee lives in the same
+// file (the dominant case), and falls through to Dynamic via
+// isHeuristicScopeStub otherwise — never to bug-resolver.
+func TestBareCallToIDEmitsStructuralRef(t *testing.T) {
+	src := `package main
+
+func valid(s string) bool { return s != "" }
+
+func ensureValidToken(s string) bool {
+	if !valid(s) {
+		return false
+	}
+	return true
+}
+`
+	results, err := extractFromPath(src, "examples/features/authentication/server/main.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	wantTo := "scope:operation:method:go:examples/features/authentication/server/main.go:valid"
+	for _, r := range results {
+		e := r.(types.EntityRecord)
+		if e.Kind != "SCOPE.Operation" || e.Name != "ensureValidToken" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			if rel.ToID == wantTo {
+				return
+			}
+		}
+		t.Fatalf("ensureValidToken: no CALLS edge with ToID=%q; got rels=%+v", wantTo, e.Relationships)
+	}
+	t.Fatalf("ensureValidToken entity not found")
+}
+
+// TestBareCallToIDsDistinctAcrossFiles verifies that two files in distinct
+// packages declaring `callUnaryEcho` and calling it from `main` no longer
+// emit colliding bare-name ToIDs. Each file's CALLS edge points at its own
+// structural-ref so the resolver binds to the file-local function via
+// byLocation rather than tripping the bare-name ambiguity guard.
+func TestBareCallToIDsDistinctAcrossFiles(t *testing.T) {
+	src := `package main
+
+func callUnaryEcho() {}
+
+func main() {
+	callUnaryEcho()
+}
+`
+	a, err := extractFromPath(src, "examples/features/authentication/client/main.go")
+	if err != nil {
+		t.Fatalf("extract a: %v", err)
+	}
+	b, err := extractFromPath(src, "examples/features/encryption/TLS/client/main.go")
+	if err != nil {
+		t.Fatalf("extract b: %v", err)
+	}
+	pick := func(rs []interface{}) string {
+		for _, r := range rs {
+			e := r.(types.EntityRecord)
+			if e.Kind != "SCOPE.Operation" || e.Name != "main" {
+				continue
+			}
+			for _, rel := range e.Relationships {
+				if rel.Kind == "CALLS" && rel.ToID != "" {
+					return rel.ToID
+				}
+			}
+		}
+		return ""
+	}
+	ta, tb := pick(a), pick(b)
+	if ta == "" || tb == "" {
+		t.Fatalf("missing ToID: a=%q b=%q", ta, tb)
+	}
+	if ta == tb {
+		t.Errorf("bare ToIDs collided across files: %q", ta)
+	}
+	const wantPrefix = "scope:operation:method:go:"
+	if !strings.HasPrefix(ta, wantPrefix) || !strings.HasPrefix(tb, wantPrefix) {
+		t.Errorf("expected structural-ref ToIDs; got a=%q b=%q", ta, tb)
+	}
+}
+
+// TestQualifiedCallToIDStaysBare verifies that selector-form calls (e.g.
+// `pkg.Func()` or `recv.Method()`) keep their bare member-name ToID. Only
+// the identifier-form (no selector) needs the structural-ref rewrite —
+// selector-form calls already resolve via byMember / package-member /
+// external-package lookups.
+func TestQualifiedCallToIDStaysBare(t *testing.T) {
+	src := `package widgets
+
+import "fmt"
+
+func Run() {
+	fmt.Println("ok")
+}
+`
+	results, err := extractFromPath(src, "widgets/run.go")
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	for _, r := range results {
+		e := r.(types.EntityRecord)
+		if e.Kind != "SCOPE.Operation" || e.Name != "Run" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			// Selector-form Println keeps its bare ToID for the external/byName path.
+			if rel.ToID != "Println" {
+				t.Errorf("fmt.Println CALLS ToID = %q, want bare %q", rel.ToID, "Println")
+			}
+		}
+		return
+	}
+	t.Fatalf("Run entity not found")
 }

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1262,6 +1262,20 @@ type Index struct {
 	// member) collisions so the resolver leaves the stub alone instead of
 	// silently picking a wrong overload.
 	byPackageMember map[string]map[string]map[string]string
+
+	// byPackageOperation[pkg_dir][name] = entity_id. Used by the
+	// Refs #44 Go bare-call structural-ref path: the extractor rewrites
+	// identifier-form CALLS edges (e.g. `helper()` from `main`) to
+	// `scope:operation:method:go:<file>:<name>` so the resolver binds the
+	// callee via byLocation when the callee lives in the SAME file. The
+	// dominant Go pattern, however, is cross-file same-package: `Greet` in
+	// `b.go` calling `Hello` defined in `a.go`. byLocation[b.go][Hello]
+	// misses but byPackageOperation[pkgDirOf(b.go)][Hello] hits. Indexed
+	// only when an entity has no dot in its Name (top-level function /
+	// non-method operation) AND a non-empty SourceFile. A blank-string
+	// sentinel marks (pkg, name) collisions so the resolver leaves the
+	// stub alone instead of silently binding to the wrong overload.
+	byPackageOperation map[string]map[string]string
 }
 
 // LocationIndex maps file_path -> name -> entity_id, retaining only entries
@@ -1461,7 +1475,8 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		ambigLocation:   make(map[string]map[string]bool),
 		byLocationKind:  make(LocationKindIndex),
 		byMember:        make(map[string]map[string]map[string]string),
-		byPackageMember: make(map[string]map[string]map[string]string),
+		byPackageMember:    make(map[string]map[string]map[string]string),
+		byPackageOperation: make(map[string]map[string]string),
 		byQualifiedName: make(map[string]string),
 	}
 	for k := range entities {
@@ -1642,6 +1657,31 @@ func BuildIndex(entities []types.EntityRecord) Index {
 			}
 		}
 
+		// Package-scoped top-level-operation index (Refs #44). Mirrors
+		// byPackageMember but for operations whose Name has no dot — i.e.
+		// non-method functions. The Go extractor rewrites identifier-form
+		// CALLS edges to `scope:operation:method:go:<file>:<name>` so a
+		// same-file callee binds via byLocation. Cross-file same-package
+		// callees (the dominant Go pattern) fall back to this index in
+		// lookupStructural. Indexed only when SourceFile is non-empty
+		// and Name carries no dot (top-level Operation).
+		if sourceFile != "" && strings.IndexByte(e.Name, dottedNameSep) < 0 &&
+			isOperationKind(e.Kind) {
+			pkgDir := pkgDirOf(sourceFile)
+			if pkgDir != "" {
+				pkgBucket := idx.byPackageOperation[pkgDir]
+				if pkgBucket == nil {
+					pkgBucket = make(map[string]string)
+					idx.byPackageOperation[pkgDir] = pkgBucket
+				}
+				if existing, ok := pkgBucket[e.Name]; ok && existing != e.ID {
+					pkgBucket[e.Name] = "" // blank sentinel → ambiguous
+				} else if _, taken := pkgBucket[e.Name]; !taken {
+					pkgBucket[e.Name] = e.ID
+				}
+			}
+		}
+
 		// Kind-agnostic name index. Two different entities sharing a name
 		// (even across kinds) flips the name to ambiguous.
 		if idx.ambigName[e.Name] {
@@ -1655,6 +1695,13 @@ func BuildIndex(entities []types.EntityRecord) Index {
 		idx.byName[e.Name] = e.ID
 	}
 	return idx
+}
+
+// isOperationKind reports whether the kind string is one of the Operation
+// family kinds (SCOPE.Operation, etc.) that should be indexed in
+// byPackageOperation.
+func isOperationKind(k string) bool {
+	return k == "SCOPE.Operation" || k == "Operation"
 }
 
 // BuildLocationIndex returns a (file_path, name) -> entity_id map built from
@@ -2002,6 +2049,28 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	if bucket, ok := idx.byLocation[filePath]; ok {
 		if id, ok := bucket[tail]; ok {
 			return id, statusRewritten, true
+		}
+	}
+	// Refs #44 — Go cross-file same-package fallback. The Go extractor
+	// rewrites bare CALLS targets to scope:operation:method:go:<file>:<name>
+	// using the CALLER's file path; same-file callees bind via byLocation
+	// above. Cross-file same-package callees (`Greet` in b.go calling
+	// `Hello` defined in a.go) hit here: probe byPackageOperation under
+	// pkgDirOf(filePath). A blank-sentinel hit means ambiguous within the
+	// package — leave the stub alone rather than picking an arbitrary
+	// overload, matching the byPackageMember (issue #148) policy. Only
+	// fires for the "operation" scope-kind so other Format A scopes
+	// (component, schema) aren't affected.
+	if strings.EqualFold(scopeKind, "operation") {
+		if pkgDir := pkgDirOf(filePath); pkgDir != "" {
+			if pkgBucket, ok := idx.byPackageOperation[pkgDir]; ok {
+				if id, ok := pkgBucket[tail]; ok {
+					if id == "" {
+						return "", statusAmbiguous, true
+					}
+					return id, statusRewritten, true
+				}
+			}
 		}
 	}
 	return "", statusUnmatched, true


### PR DESCRIPTION
## Summary
- Identifier-form CALLS edges (bare `foo()`) had bare-name ToIDs that collided across packages (e.g. 14 `func callUnaryEcho` across grpc-go-examples/examples/*/client/main.go), forcing every such edge into bug-resolver. Mirrors the #476 FromID fix on the ToID side.
- Extractor rewrites bare ToIDs to Format A `scope:operation:method:go:<file>:<name>` keyed on the **caller's** file. Same-file callees resolve via byLocation; cross-file same-package callees fall back to a new `byPackageOperation[pkg_dir][name]` index (mirroring `byPackageMember` from #148 but for non-method operations). Unresolved structural-refs land in Dynamic via `isHeuristicScopeStub`.
- Selector-form calls (`pkg.X` / `recv.method`) are untouched.

## Bug-rate impact (VERIFY-2, before -> after)
| Repo | Before | After | Δ |
|---|---|---|---|
| grpc-go-examples | 8.76% | 7.11% | -1.65pp |
| chi | 7.04% | 4.81% | -2.22pp |
| gin | 8.57% | 6.20% | -2.37pp |
| etcd | 12.05% | 8.88% | -3.17pp |

All 47 `ambig-bare-hint-fail` CALLS edges on grpc-go-examples are eliminated. Residual 144 bug-resolver edges are all `DEPENDS_ON` receiver-type lookups (cross-file same-package struct names like `s`, `Server`) — separate issue out of scope here.

## Test plan
- [x] `go test ./...` clean across all packages
- [x] New tests: `TestBareCallToIDEmitsStructuralRef`, `TestBareCallToIDsDistinctAcrossFiles`, `TestQualifiedCallToIDStaysBare`
- [x] Updated tests: `TestCallsRelationship_LocalFunctionCall`, `TestCallsRelationship_UnknownExternalCall` (expect structural-ref ToID)
- [x] Regression check on 3 Go repos (chi, gin, etcd) — every repo IMPROVED, none regressed
- [x] grpc-go-examples bug-rate ≤8% target (7.11%)

Refs #44 #476

🤖 Generated with [Claude Code](https://claude.com/claude-code)