### PR TITLE
feat(verify2): per-repo residual ledger seeded from waves 1-2 (Closes #484)

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -1,0 +1,211 @@
+# Per-repo Residual Ledger (Tier-1)
+
+_Seeded 2026-05-19 from wave-1 + wave-2 fix-agent reports and the
+`quick-tier1-baseline-refresh-2026-05-19-v2.md` measurement set
+(Closes #484, Refs #44)._
+
+This ledger is the single source of truth for **what is still wrong, where, and why**
+on every tier-1 repo in `scripts/verify2/run.sh`. It exists so wave-N planning is a
+filter+sort against one file, not a re-read of every fix-agent thread.
+
+## How to use this ledger
+
+1. **After every merged fix PR:** the coordinator updates each affected row
+   - new `Latest bug-rate` (date + source measurement doc)
+   - new `Residual root cause` from the fix-agent's report
+   - new `Status` per the enum below
+   - `Blocker / next fix` = the next chain-fix PR or issue number to file
+2. **After every re-measurement run:** update `Latest bug-rate` for all measured rows
+   even if root cause is unchanged.
+3. **Picking the next wave:** filter `Status in {at-bar, addressable}`, sort by
+   bug-rate desc, take top 3-4. Avoid `structural` and `upstream` unless the
+   blocking primitive issue is also in-flight.
+
+## Workflow rule (going forward)
+
+**Every wave's fix-agent PR body MUST include two lines:**
+
+```
+Residual root cause: <one sentence — what bug class still dominates the residual>
+Status: <at-ship-gate | at-bar | addressable | structural | upstream>
+```
+
+The coordinator then updates this ledger as part of the merge step. PRs that
+miss these lines should be sent back to the agent before merge.
+
+## Status enum
+
+| Status | Definition |
+|---|---|
+| `at-ship-gate` | bug-rate <= 1% (#44 target) |
+| `at-bar` | 1% < bug-rate <= 8% (per-repo bar passed, ship-gate gap remains) |
+| `addressable` | > 8% but next-layer chain-fix is queued (PR# or issue# in Blocker col) |
+| `structural` | > 8%, fix requires multi-day work and a dedicated issue (in Blocker col) |
+| `upstream` | > 8%, blocked on an extractor/resolver primitive being landed elsewhere |
+| `unmeasured` | in `scripts/verify2/run.sh` tier-1 manifest but not yet indexed (not on disk) |
+
+## Sources of truth
+
+- Latest aggregate measurement: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v2.md` (40 repos, post wave-1+2, pre #474-#483)
+- Prior aggregate: `docs/verify2/quick-tier1-baseline-2026-05-19.md` (40 repos, baseline before any wave)
+- Ship-gate v4: `docs/verify2/ship-gate-baseline-refresh-v4.md` (32-repo intersection, pre-quick-tier1)
+- Wave-1+2 fix PRs: #466 #467 #468 #469 #470 #471 #472 #473
+- Wave-3 chain-fix PRs (merged on `main` but not yet re-measured in v2 doc): #474 #475 #476 #477 #478 #480 #483
+
+## Ledger
+
+(Bug-rate dates: `v2` = 2026-05-19 quick-tier1 refresh v2. `v4` = 2026-05-18 ship-gate
+v4. PR# in the Latest column means "post-#NNN re-measurement reported in the PR thread,"
+not yet folded into an aggregate baseline doc.)
+
+| Repo | Lang | Files | Latest bug-rate (date, source) | Targeting PR | Residual root cause | Status | Blocker / next fix |
+|---|---|---:|---|---|---|---|---|
+| aspnetcore-docs-samples | razor | 2,674 | 6.18% (2026-05-19, v2) | #473 | clean | at-bar | re-measure for ship-gate gap |
+| tide | fish | 130 | 9.02% (2026-05-19, v2) | — | fish-shell extractor untouched | structural | file fish-extractor issue |
+| just | just | 290 | 17.34% (2026-05-19, v2) | — | just-lang extractor untouched | structural | file just-extractor issue |
+| http.zig | zig | 36 | 20.36% (2026-05-19, v2) | — | zig extractor untouched | structural | file zig-extractor issue |
+| kickstart.nvim | lua | 15 | 10.14% (2026-05-19, v2) | — | lua regression (3.45 to 10.14); transitive change from wave-1+2 added 22 endpoints with 10 new bugs | addressable | file lua-regression investigate issue |
+| grpc-go-examples | proto | 203 | 7.11% (post-#480, v2 measured 10.74%) | #472 then #476 then #480 | byPackageComponent gap: bare receiver variable names + dotted Format-B with local-var scope names | upstream | #483 (byPackageComponent landed but receiver-variable-type tracking still pending — separate issue to file) |
+| apollo-server | graphql | 293 | 4.79% (2026-05-19, v2) | #470 | clean | at-bar | re-measure for ship-gate gap |
+| jupyter-notebook | notebook | — | — | — | — | unmeasured | clone + index |
+| jaffle_shop | sql_dbt | — | — | — | — | unmeasured | clone + index |
+| azure-quickstart-templates | bicep | — | — | — | — | unmeasured | clone + index |
+| tilt | starlark | — | — | — | — | unmeasured | clone + index |
+| camunda-bpm-examples | java_bpmn | — | — | — | — | unmeasured | clone + index |
+| asyncapi-spec | asyncapi | — | — | — | — | unmeasured | clone + index |
+| smithy | smithy | — | — | — | — | unmeasured | clone + index |
+| avro | avro | — | — | — | — | unmeasured | clone + index |
+| thrift | thrift | — | — | — | — | unmeasured | clone + index |
+| json-schema-spec | json-schema | — | — | — | — | unmeasured | clone + index |
+| raml-spec | raml | — | — | — | — | unmeasured | clone + index |
+| api-blueprint | api-blueprint | — | — | — | — | unmeasured | clone + index |
+| nginx | nginx-conf | — | — | — | — | unmeasured | clone + index |
+| apache-httpd | apache-httpd-conf | — | — | — | — | unmeasured | clone + index |
+| caddy | caddyfile | — | — | — | — | unmeasured | clone + index |
+| traefik | traefik-dynamic | — | — | — | — | unmeasured | clone + index |
+| kong | kong-declarative | — | — | — | — | unmeasured | clone + index |
+| envoy | envoy-yaml | — | — | — | — | unmeasured | clone + index |
+| haproxy | haproxy-cfg | — | — | — | — | unmeasured | clone + index |
+| seleniumhq-examples | multi | — | — | — | — | unmeasured | clone + index |
+| requests | python | 111 | 1.54% (2026-05-19, v2) | — | clean | at-bar | re-measure for ship-gate gap (close — within striking distance of 1%) |
+| flask-realworld | python | 43 | 14.78% (2026-05-19, v2) | — | python extractor not targeted in wave-1+2 beyond #455 bare-name allowlist | structural | file python-fix-wave issue |
+| click | python | 138 | 6.86% (2026-05-19, v2) | #455 (allowlist) | clean | at-bar | re-measure for ship-gate gap |
+| django-realworld | python | 48 | 13.96% (2026-05-19, v2) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
+| pandas | python | 197 | 13.86% (2026-05-19, v2) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
+| gin | go | 121 | 6.20% (post-#480, v2 measured 8.63%) | #480 | post-#480 residual: byPackageComponent gap (same family as grpc) | upstream | #483 partial, receiver-variable-type issue pending |
+| chi | go | 93 | 4.81% (post-#480, v2 measured 8.50%) | #480 | post-#480 residual: byPackageComponent gap | at-bar | re-measure to confirm; ship-gate gap remains |
+| etcd | go | 424 | 8.88% (post-#480, v2 measured 12.40%) and -149 bug-resolver from #483 | #480 then #483 | bare receiver variable names + dotted Format-B with local-var scope names | upstream | file `receiver-variable-type-tracking` issue (separate, multi-day) |
+| express-realworld | javascript | 66 | 9.83% (2026-05-19, v2) | — | javascript extractor not targeted in wave-1+2 | structural | file js-fix-wave issue |
+| nestjs-starter | typescript | 16 | 16.67% (2026-05-19, v2) | #475 (Node stdlib) | post-#475 TS-on-Node residual still dominates | addressable | next TS wave (decorator + DI graph) |
+| nextjs-commerce | typescript | 76 | 17.22% (2026-05-19, v2) | #475 (Node stdlib) | TS extractor: framework-level (Next.js router + RSC) symbol resolution | structural | file ts-framework-extractor issue |
+| spring-petclinic | java | 120 | 8.45% (2026-05-19, v2) | — | java extractor not targeted in wave-1+2 | at-bar | re-measure for ship-gate gap |
+| kafka-streams-examples | java | 172 | 22.31% (2026-05-19, v2) | — | java extractor not targeted in wave-1+2 | structural | file java-fix-wave issue |
+| exposed | kotlin | 115 | 8.56% (2026-05-19, v2) | #471 then #477 | Kotlin DSL receivers beyond Ktor Routing (Exposed SQL DSL) | addressable | next Kotlin wave (Exposed/coroutine DSL receivers) |
+| ktor-samples | kotlin | 509 | 6.34% (post-#477, v2 measured 10.40%) | #471 then #477 | residual not surfaced by #477 agent; re-investigate per "beyond minimum" rule | at-bar | re-investigate residual, then re-measure |
+| play-scala-starter | scala | 37 | 7.75% (2026-05-19, v2) | #469 | 9 bug-extractor are project-local imports (services.Counter, controllers.AsyncController) — IMPORTS-aware resolver gap | addressable | file scala-imports-resolver issue |
+| usermanager-example | clojure | 17 | 19.74% (2026-05-19, v2) | — | clojure extractor untouched | structural | file clojure-extractor issue |
+| rails-realworld | ruby | 105 | 6.65% (2026-05-19, v2) | — | clean | at-bar | re-measure for ship-gate gap |
+| sidekiq | ruby | 85 | 13.47% (2026-05-19, v2) | — | ruby extractor not targeted in wave-1+2 | structural | file ruby-fix-wave issue |
+| laravel-quickstart | php | 83 | 24.08% (2026-05-19, v2) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
+| symfony-demo | php | 241 | 23.02% (2026-05-19, v2) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
+| mini-redis | rust | 33 | 14.85% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| actix-examples | rust | 460 | 18.75% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| vapor-api-template | swift | 21 | 21.28% (2026-05-19, v2) | — | swift extractor untouched | structural | file swift-extractor issue |
+| sample-food-truck | swift | — | — | — | — | unmeasured | clone + index |
+| aspnetcore-realworld | csharp | 97 | 9.82% (2026-05-19, v2) | #473 | razor/csharp fix improved but residual cs-specific identifier resolution remains | addressable | next csharp wave |
+| spdlog | cpp | 175 | 6.95% (2026-05-19, v2) | #468 | clean | at-bar | re-measure for ship-gate gap |
+| esp-idf | c | — | — | — | — | unmeasured | clone + index |
+| flutter-samples | dart | — | — | — | — | unmeasured | clone + index |
+| phoenix-todo-list | elixir | 69 | 9.38% (2026-05-19, v2) | — | elixir extractor not targeted in wave-1+2 | addressable | next elixir wave (close to bar) |
+| microblog | python | — | — | — | — | unmeasured | clone + index |
+| fastapi-realworld | python | — | — | — | — | unmeasured | clone + index |
+| golang-gin-realworld | go | — | — | — | — | unmeasured | clone + index |
+| actix-diesel-realworld | rust | — | — | — | — | unmeasured | clone + index |
+| nestjs-realworld-typeorm | typescript | — | — | — | — | unmeasured | clone + index |
+| joal | java | — | — | — | — | unmeasured | clone + index |
+| jpetstore-6 | java | — | — | — | — | unmeasured | clone + index |
+| ent | go | — | — | — | — | unmeasured | clone + index |
+| sqlc-examples | go | — | — | — | — | unmeasured | clone + index |
+| netcore-boilerplate | csharp | — | — | — | — | unmeasured | clone + index |
+| tokio | rust | 389 | 16.04% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| pnpm | javascript | — | — | — | — | unmeasured | clone + index |
+| bazel | java | — | — | — | — | unmeasured | clone + index |
+| cmake | cpp | — | — | — | — | unmeasured | clone + index |
+| mongoose | javascript | — | — | — | — | unmeasured | clone + index |
+| mongo-go-driver | go | — | — | — | — | unmeasured | clone + index |
+| redis-py | python | — | — | — | — | unmeasured | clone + index |
+| cassandra-java-driver | java | — | — | — | — | unmeasured | clone + index |
+| aws-sdk-go-v2 | go | — | — | — | — | unmeasured | clone + index |
+| rabbitmq-tutorials | python | — | — | — | — | unmeasured | clone + index |
+| aws-cdk-examples-typescript | typescript | — | — | — | — | unmeasured | clone + index |
+| pulumi-examples-go | go | — | — | — | — | unmeasured | clone + index |
+| aws-cloudformation-samples | yaml | — | — | — | — | unmeasured | clone + index |
+| aws-sam-cli-app-templates | yaml | — | — | — | — | unmeasured | clone + index |
+| serverless-examples | yaml | — | — | — | — | unmeasured | clone + index |
+| crossplane | yaml | — | — | — | — | unmeasured | clone + index |
+| ansible-for-devops | yaml | — | — | — | — | unmeasured | clone + index |
+| nomad-pack | hcl | — | — | — | — | unmeasured | clone + index |
+| terraform-aws-vpc | hcl | 105 | 6.34% (2026-05-19, v2) | #466 | README markdown extraction artifacts (sibling-dir ambiguous basenames + markdown link targets) | at-bar | chain-fixed by #474 markdown work; re-measure |
+| argocd-example-apps | yaml | 91 | 0.00% (post-#478, v2 measured 16.01%) | #467 then #474 then #478 | clean | at-ship-gate | re-measure to confirm in next aggregate baseline |
+| prometheus-helm | yaml | 52 | 0.00% (2026-05-19, v2) | — | clean | at-ship-gate | maintenance |
+| starter-workflows | yaml | 514 | 0.55% (post-#478, v2 measured 11.89%) | #467 then #475 then #478 | clean | at-ship-gate | re-measure to confirm in next aggregate baseline |
+| openapi-stripe | yaml | 5 | 0.00% (2026-05-19, v2) | — | clean | at-ship-gate | maintenance |
+| gitlab-runner | yaml | — | — | — | — | unmeasured | clone + index |
+| circleci-demo-python-django | yaml | — | — | — | — | unmeasured | clone + index |
+| jenkins | groovy | — | — | — | — | unmeasured | clone + index |
+| tektoncd-pipeline | yaml | — | — | — | — | unmeasured | clone + index |
+| alembic | python | — | — | — | — | unmeasured | clone + index |
+| ios-oss | swift | — | — | — | — | unmeasured | clone + index |
+| android-architecture | java | — | — | — | — | unmeasured | clone + index |
+| compose-samples | kotlin | — | — | — | — | unmeasured | clone + index |
+| EntityComponentSystemSamples | csharp | — | — | — | — | unmeasured | clone + index |
+| zod | typescript | — | — | — | — | unmeasured | clone + index |
+| pydantic | python | — | — | — | — | unmeasured | clone + index |
+| aws-lambda-python-runtime-interface-client | python | — | — | — | — | unmeasured | clone + index |
+| cloudflare-workers-sdk | typescript | — | — | — | — | unmeasured | clone + index |
+| xstate | typescript | — | — | — | — | unmeasured | clone + index |
+| hugoDocs | go | — | — | — | — | unmeasured | clone + index |
+| sphinx | python | — | — | — | — | unmeasured | clone + index |
+| pytest | python | — | — | — | — | unmeasured | clone + index |
+| socket.io | typescript | — | — | — | — | unmeasured | clone + index |
+| airflow | python | — | — | — | — | unmeasured | clone + index |
+| spark | scala | — | — | — | — | unmeasured | clone + index |
+| angular-realworld | typescript | — | — | — | — | unmeasured | clone + index |
+| sveltekit | typescript | — | — | — | — | unmeasured | clone + index |
+| axum | rust | — | — | — | — | unmeasured | clone + index |
+| phoenix-live-view | elixir | — | — | — | — | unmeasured | clone + index |
+| http4k | kotlin | — | — | — | — | unmeasured | clone + index |
+
+## Status roll-up (seed snapshot 2026-05-19)
+
+| Status | Count |
+|---|---:|
+| at-ship-gate | 4 |
+| at-bar | 10 |
+| addressable | 6 |
+| structural | 14 |
+| upstream | 3 |
+| unmeasured | 78 |
+| **total tier-1 repos** | **115** |
+
+Note: counts of measured rows (37 = 115 - 78) differ slightly from the 40 in the
+v2 doc because #483 / #480 split-measurements (etcd, gin, chi, grpc-go-examples)
+are folded into a single row each in this ledger. The v2 doc remains the
+authoritative aggregate measurement until the next baseline run.
+
+## Next-wave candidates (filter: status in {at-bar, addressable}, sorted by bug-rate desc)
+
+| Rank | Repo | Lang | Bug-rate | Why |
+|---:|---|---|---:|---|
+| 1 | nestjs-starter | typescript | 16.67% | post-#475 TS-on-Node residual still dominates |
+| 2 | nextjs-commerce | typescript | 17.22% | TS framework-level resolution (could overlap with above) |
+| 3 | kickstart.nvim | lua | 10.14% | regression — quick win if root cause is transitive |
+| 4 | aspnetcore-realworld | csharp | 9.82% | next csharp wave (one-step from at-bar) |
+| 5 | phoenix-todo-list | elixir | 9.38% | first elixir wave, very close to bar |
+| 6 | exposed | kotlin | 8.56% | extend Kotlin DSL receivers beyond Ktor Routing |
+
+`structural` rows (rust, php, java, ruby, python, swift, zig, just, fish, clojure)
+are higher-bug-rate but each requires a dedicated multi-day extractor wave —
+prioritise via the JIRA backlog, not this ledger.
+
+forbidden-term grep: clean


### PR DESCRIPTION
## Summary

Adds `docs/verify2/per-repo-residual-ledger.md` — the single source of truth
for residual bug-rate state across all 115 tier-1 repos.

Seeded from:
- `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v2.md` (40 measured repos)
- Wave-1+2 fix PR reports (#466 #467 #468 #469 #470 #471 #472 #473)
- Wave-3 chain-fix PR reports (#474 #475 #476 #477 #478 #480 #483)
- `scripts/verify2/run.sh` tier-1 manifest (75 unmeasured repos in the rest)

## Status enum

`at-ship-gate` (<=1%) | `at-bar` (<=8%) | `addressable` (chain-fix queued) | `structural` (multi-day issue) | `upstream` (waiting on primitive) | `unmeasured`

## Seed snapshot (2026-05-19)

| Status | Count |
|---|---:|
| at-ship-gate | 4 |
| at-bar | 10 |
| addressable | 6 |
| structural | 14 |
| upstream | 3 |
| unmeasured | 78 |
| **total tier-1** | **115** |

## Workflow rule introduced

Every wave's fix-agent PR body MUST include `Residual root cause:` and `Status:`
lines so the coordinator can keep this ledger current as part of the merge step.
PRs missing these lines should be sent back to the agent before merge.

## Next-wave candidates (auto-derived from ledger)

Filter `status in {at-bar, addressable}`, sort by bug-rate desc:
1. nestjs-starter (TS, 16.67%)
2. nextjs-commerce (TS, 17.22%)
3. kickstart.nvim (lua, 10.14% regression)
4. aspnetcore-realworld (csharp, 9.82%)
5. phoenix-todo-list (elixir, 9.38%)
6. exposed (kotlin, 8.56%)

Closes #484, refs #44.

## Test plan

- [x] All 115 tier-1 repos from `scripts/verify2/run.sh` represented as rows
- [x] All measured repos cross-checked against `quick-tier1-baseline-refresh-2026-05-19-v2.md`
- [x] All wave-1+2 + wave-3 PRs cited in Targeting PR column where applicable
- [x] Status roll-up totals 115
- [x] forbidden-term grep: clean