### PR TITLE
feat(verify2): reliable v3 baseline + ledger refresh post-determinism

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -46,7 +46,8 @@ miss these lines should be sent back to the agent before merge.
 
 ## Sources of truth
 
-- Latest aggregate measurement: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v2.md` (40 repos, post wave-1+2, pre #474-#483)
+- Latest aggregate measurement: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v3.md` (40 repos, post-determinism #486, includes #474-#483 chain-fixes — **reliable single-shot**)
+- Prior aggregate: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v2.md` (40 repos, post wave-1+2, pre #474-#483; noisy)
 - Prior aggregate: `docs/verify2/quick-tier1-baseline-2026-05-19.md` (40 repos, baseline before any wave)
 - Ship-gate v4: `docs/verify2/ship-gate-baseline-refresh-v4.md` (32-repo intersection, pre-quick-tier1)
 - Wave-1+2 fix PRs: #466 #467 #468 #469 #470 #471 #472 #473
@@ -54,19 +55,20 @@ miss these lines should be sent back to the agent before merge.
 
 ## Ledger
 
-(Bug-rate dates: `v2` = 2026-05-19 quick-tier1 refresh v2. `v4` = 2026-05-18 ship-gate
-v4. PR# in the Latest column means "post-#NNN re-measurement reported in the PR thread,"
-not yet folded into an aggregate baseline doc.)
+(Bug-rate dates: `v3` = 2026-05-19 quick-tier1 refresh v3 (post-determinism #486 — reliable single-shot).
+`v2` = 2026-05-19 quick-tier1 refresh v2 (noisy, pre-determinism). `v4` = 2026-05-18 ship-gate v4.
+PR# in the Latest column means "post-#NNN re-measurement reported in the PR thread," not yet
+folded into an aggregate baseline doc.)
 
 | Repo | Lang | Files | Latest bug-rate (date, source) | Targeting PR | Residual root cause | Status | Blocker / next fix |
 |---|---|---:|---|---|---|---|---|
-| aspnetcore-docs-samples | razor | 2,674 | 6.18% (2026-05-19, v2) | #473 | clean | at-bar | re-measure for ship-gate gap |
-| tide | fish | 130 | 9.02% (2026-05-19, v2) | — | fish-shell extractor untouched | structural | file fish-extractor issue |
-| just | just | 290 | 17.34% (2026-05-19, v2) | — | just-lang extractor untouched | structural | file just-extractor issue |
-| http.zig | zig | 36 | 20.36% (2026-05-19, v2) | — | zig extractor untouched | structural | file zig-extractor issue |
-| kickstart.nvim | lua | 15 | 10.14% (2026-05-19, v2) | — | lua regression (3.45 to 10.14); transitive change from wave-1+2 added 22 endpoints with 10 new bugs | addressable | file lua-regression investigate issue |
-| grpc-go-examples | proto | 203 | 7.11% (post-#480, v2 measured 10.74%) | #472 then #476 then #480 | byPackageComponent gap: bare receiver variable names + dotted Format-B with local-var scope names | upstream | #483 (byPackageComponent landed but receiver-variable-type tracking still pending — separate issue to file) |
-| apollo-server | graphql | 293 | 4.79% (2026-05-19, v2) | #470 | clean | at-bar | re-measure for ship-gate gap |
+| aspnetcore-docs-samples | razor | 2,674 | 6.18% (2026-05-19, v3) | #473 | clean | at-bar | next razor wave for ship-gate gap |
+| tide | fish | 130 | 9.02% (2026-05-19, v3) | — | fish-shell extractor untouched | structural | file fish-extractor issue |
+| just | just | 290 | 17.34% (2026-05-19, v3) | — | just-lang extractor untouched | structural | file just-extractor issue |
+| http.zig | zig | 36 | 20.36% (2026-05-19, v3) | — | zig extractor untouched | structural | file zig-extractor issue |
+| kickstart.nvim | lua | 15 | 9.86% (2026-05-19, v3; v2 was 10.14%) | — | lua regression vs v1 baseline (3.45 to 9.86); transitive change from wave-1+2 added endpoints with new bugs | addressable | file lua-regression investigate issue |
+| grpc-go-examples | proto | 203 | 7.04% (2026-05-19, v3; v2 was 10.74%) | #472 then #476 then #480 then #483 | residual: receiver-variable-type tracking still pending | at-bar | file `receiver-variable-type-tracking` issue; then re-measure |
+| apollo-server | graphql | 293 | 4.74% (2026-05-19, v3) | #470 | clean | at-bar | next graphql wave for ship-gate gap |
 | jupyter-notebook | notebook | — | — | — | — | unmeasured | clone + index |
 | jaffle_shop | sql_dbt | — | — | — | — | unmeasured | clone + index |
 | azure-quickstart-templates | bicep | — | — | — | — | unmeasured | clone + index |
@@ -87,36 +89,36 @@ not yet folded into an aggregate baseline doc.)
 | envoy | envoy-yaml | — | — | — | — | unmeasured | clone + index |
 | haproxy | haproxy-cfg | — | — | — | — | unmeasured | clone + index |
 | seleniumhq-examples | multi | — | — | — | — | unmeasured | clone + index |
-| requests | python | 111 | 1.54% (2026-05-19, v2) | — | clean | at-bar | re-measure for ship-gate gap (close — within striking distance of 1%) |
-| flask-realworld | python | 43 | 14.78% (2026-05-19, v2) | — | python extractor not targeted in wave-1+2 beyond #455 bare-name allowlist | structural | file python-fix-wave issue |
-| click | python | 138 | 6.86% (2026-05-19, v2) | #455 (allowlist) | clean | at-bar | re-measure for ship-gate gap |
-| django-realworld | python | 48 | 13.96% (2026-05-19, v2) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
-| pandas | python | 197 | 13.86% (2026-05-19, v2) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
-| gin | go | 121 | 6.20% (post-#480, v2 measured 8.63%) | #480 | post-#480 residual: byPackageComponent gap (same family as grpc) | upstream | #483 partial, receiver-variable-type issue pending |
-| chi | go | 93 | 4.81% (post-#480, v2 measured 8.50%) | #480 | post-#480 residual: byPackageComponent gap | at-bar | re-measure to confirm; ship-gate gap remains |
-| etcd | go | 424 | 8.88% (post-#480, v2 measured 12.40%) and -149 bug-resolver from #483 | #480 then #483 | bare receiver variable names + dotted Format-B with local-var scope names | upstream | file `receiver-variable-type-tracking` issue (separate, multi-day) |
-| express-realworld | javascript | 66 | 9.83% (2026-05-19, v2) | — | javascript extractor not targeted in wave-1+2 | structural | file js-fix-wave issue |
-| nestjs-starter | typescript | 16 | 16.67% (2026-05-19, v2) | #475 (Node stdlib) | post-#475 TS-on-Node residual still dominates | addressable | next TS wave (decorator + DI graph) |
-| nextjs-commerce | typescript | 76 | 17.22% (2026-05-19, v2) | #475 (Node stdlib) | TS extractor: framework-level (Next.js router + RSC) symbol resolution | structural | file ts-framework-extractor issue |
-| spring-petclinic | java | 120 | 8.45% (2026-05-19, v2) | — | java extractor not targeted in wave-1+2 | at-bar | re-measure for ship-gate gap |
-| kafka-streams-examples | java | 172 | 22.31% (2026-05-19, v2) | — | java extractor not targeted in wave-1+2 | structural | file java-fix-wave issue |
-| exposed | kotlin | 115 | 8.56% (2026-05-19, v2) | #471 then #477 | Kotlin DSL receivers beyond Ktor Routing (Exposed SQL DSL) | addressable | next Kotlin wave (Exposed/coroutine DSL receivers) |
-| ktor-samples | kotlin | 509 | 6.34% (post-#477, v2 measured 10.40%) | #471 then #477 | residual not surfaced by #477 agent; re-investigate per "beyond minimum" rule | at-bar | re-investigate residual, then re-measure |
-| play-scala-starter | scala | 37 | 7.75% (2026-05-19, v2) | #469 | 9 bug-extractor are project-local imports (services.Counter, controllers.AsyncController) — IMPORTS-aware resolver gap | addressable | file scala-imports-resolver issue |
-| usermanager-example | clojure | 17 | 19.74% (2026-05-19, v2) | — | clojure extractor untouched | structural | file clojure-extractor issue |
-| rails-realworld | ruby | 105 | 6.65% (2026-05-19, v2) | — | clean | at-bar | re-measure for ship-gate gap |
-| sidekiq | ruby | 85 | 13.47% (2026-05-19, v2) | — | ruby extractor not targeted in wave-1+2 | structural | file ruby-fix-wave issue |
-| laravel-quickstart | php | 83 | 24.08% (2026-05-19, v2) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
-| symfony-demo | php | 241 | 23.02% (2026-05-19, v2) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
-| mini-redis | rust | 33 | 14.85% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
-| actix-examples | rust | 460 | 18.75% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
-| vapor-api-template | swift | 21 | 21.28% (2026-05-19, v2) | — | swift extractor untouched | structural | file swift-extractor issue |
+| requests | python | 111 | 1.54% (2026-05-19, v3) | — | clean | at-bar | within striking distance of 1% — push for ship-gate |
+| flask-realworld | python | 43 | 14.78% (2026-05-19, v3) | — | python extractor not targeted in wave-1+2 beyond #455 bare-name allowlist | structural | file python-fix-wave issue |
+| click | python | 138 | 6.86% (2026-05-19, v3) | #455 (allowlist) | clean | at-bar | next python wave for ship-gate gap |
+| django-realworld | python | 48 | 13.96% (2026-05-19, v3) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
+| pandas | python | 197 | 13.86% (2026-05-19, v3) | — | python extractor not targeted beyond #455 | structural | file python-fix-wave issue |
+| gin | go | 121 | 6.17% (2026-05-19, v3; v2 was 8.63%) | #480 then #483 | residual: receiver-variable-type tracking still pending | at-bar | receiver-variable-type-tracking issue |
+| chi | go | 93 | 4.80% (2026-05-19, v3; v2 was 8.50%) | #480 then #483 | residual: receiver-variable-type tracking still pending | at-bar | receiver-variable-type-tracking issue; ship-gate gap remains |
+| etcd | go | 424 | 8.62% (2026-05-19, v3; v2 was 12.40%) | #480 then #483 | bare receiver variable names + dotted Format-B with local-var scope names | upstream | file `receiver-variable-type-tracking` issue (separate, multi-day) — 0.62 pp away from bar |
+| express-realworld | javascript | 66 | 9.83% (2026-05-19, v3) | — | javascript extractor not targeted in wave-1+2 | structural | file js-fix-wave issue |
+| nestjs-starter | typescript | 16 | 16.67% (2026-05-19, v3) | #475 (Node stdlib) | post-#475 TS-on-Node residual still dominates | addressable | next TS wave (decorator + DI graph) |
+| nextjs-commerce | typescript | 76 | 17.14% (2026-05-19, v3; v2 was 17.22%) | #475 (Node stdlib) | TS extractor: framework-level (Next.js router + RSC) symbol resolution | structural | file ts-framework-extractor issue |
+| spring-petclinic | java | 120 | 8.34% (2026-05-19, v3; v2 was 8.45%) | — | java extractor not targeted in wave-1+2; just above bar | addressable | first java wave — close to bar |
+| kafka-streams-examples | java | 172 | 22.19% (2026-05-19, v3; v2 was 22.31%) | — | java extractor not targeted in wave-1+2 | structural | file java-fix-wave issue |
+| exposed | kotlin | 115 | 11.00% (2026-05-19, v3; v2 was 8.56% — REGRESSION vs v2 noisy baseline, but v3 single-shot trustworthy) | #471 then #477 | Kotlin DSL receivers beyond Ktor Routing (Exposed SQL DSL) — back above bar | addressable | next Kotlin wave (Exposed/coroutine DSL receivers) |
+| ktor-samples | kotlin | 509 | 6.29% (2026-05-19, v3; v2 was 10.40%) | #471 then #477 | residual under bar — wave-3 chain-fix folded in | at-bar | next kotlin wave for ship-gate gap |
+| play-scala-starter | scala | 37 | 7.75% (2026-05-19, v3) | #469 | 9 bug-extractor are project-local imports (services.Counter, controllers.AsyncController) — IMPORTS-aware resolver gap | at-bar | file scala-imports-resolver issue |
+| usermanager-example | clojure | 17 | 19.74% (2026-05-19, v3) | — | clojure extractor untouched | structural | file clojure-extractor issue |
+| rails-realworld | ruby | 105 | 6.65% (2026-05-19, v3) | — | clean | at-bar | next ruby wave for ship-gate gap |
+| sidekiq | ruby | 85 | 13.47% (2026-05-19, v3) | — | ruby extractor not targeted in wave-1+2 | structural | file ruby-fix-wave issue |
+| laravel-quickstart | php | 83 | 24.08% (2026-05-19, v3) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
+| symfony-demo | php | 241 | 23.02% (2026-05-19, v3) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
+| mini-redis | rust | 33 | 14.85% (2026-05-19, v3) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| actix-examples | rust | 460 | 18.75% (2026-05-19, v3) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| vapor-api-template | swift | 21 | 21.28% (2026-05-19, v3) | — | swift extractor untouched | structural | file swift-extractor issue |
 | sample-food-truck | swift | — | — | — | — | unmeasured | clone + index |
-| aspnetcore-realworld | csharp | 97 | 9.82% (2026-05-19, v2) | #473 | razor/csharp fix improved but residual cs-specific identifier resolution remains | addressable | next csharp wave |
-| spdlog | cpp | 175 | 6.95% (2026-05-19, v2) | #468 | clean | at-bar | re-measure for ship-gate gap |
+| aspnetcore-realworld | csharp | 97 | 9.82% (2026-05-19, v3) | #473 | razor/csharp fix improved but residual cs-specific identifier resolution remains | addressable | next csharp wave |
+| spdlog | cpp | 175 | 6.95% (2026-05-19, v3) | #468 | clean | at-bar | next cpp wave for ship-gate gap |
 | esp-idf | c | — | — | — | — | unmeasured | clone + index |
 | flutter-samples | dart | — | — | — | — | unmeasured | clone + index |
-| phoenix-todo-list | elixir | 69 | 9.38% (2026-05-19, v2) | — | elixir extractor not targeted in wave-1+2 | addressable | next elixir wave (close to bar) |
+| phoenix-todo-list | elixir | 69 | 9.38% (2026-05-19, v3) | — | elixir extractor not targeted in wave-1+2 | addressable | next elixir wave (close to bar) |
 | microblog | python | — | — | — | — | unmeasured | clone + index |
 | fastapi-realworld | python | — | — | — | — | unmeasured | clone + index |
 | golang-gin-realworld | go | — | — | — | — | unmeasured | clone + index |
@@ -127,7 +129,7 @@ not yet folded into an aggregate baseline doc.)
 | ent | go | — | — | — | — | unmeasured | clone + index |
 | sqlc-examples | go | — | — | — | — | unmeasured | clone + index |
 | netcore-boilerplate | csharp | — | — | — | — | unmeasured | clone + index |
-| tokio | rust | 389 | 16.04% (2026-05-19, v2) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
+| tokio | rust | 389 | 16.04% (2026-05-19, v3) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
 | pnpm | javascript | — | — | — | — | unmeasured | clone + index |
 | bazel | java | — | — | — | — | unmeasured | clone + index |
 | cmake | cpp | — | — | — | — | unmeasured | clone + index |
@@ -145,11 +147,11 @@ not yet folded into an aggregate baseline doc.)
 | crossplane | yaml | — | — | — | — | unmeasured | clone + index |
 | ansible-for-devops | yaml | — | — | — | — | unmeasured | clone + index |
 | nomad-pack | hcl | — | — | — | — | unmeasured | clone + index |
-| terraform-aws-vpc | hcl | 105 | 6.34% (2026-05-19, v2) | #466 | README markdown extraction artifacts (sibling-dir ambiguous basenames + markdown link targets) | at-bar | chain-fixed by #474 markdown work; re-measure |
-| argocd-example-apps | yaml | 91 | 0.00% (post-#478, v2 measured 16.01%) | #467 then #474 then #478 | clean | at-ship-gate | re-measure to confirm in next aggregate baseline |
-| prometheus-helm | yaml | 52 | 0.00% (2026-05-19, v2) | — | clean | at-ship-gate | maintenance |
-| starter-workflows | yaml | 514 | 0.55% (post-#478, v2 measured 11.89%) | #467 then #475 then #478 | clean | at-ship-gate | re-measure to confirm in next aggregate baseline |
-| openapi-stripe | yaml | 5 | 0.00% (2026-05-19, v2) | — | clean | at-ship-gate | maintenance |
+| terraform-aws-vpc | hcl | 105 | 6.34% (2026-05-19, v3) | #466 then #474 | residual: README markdown extraction artifacts (sibling-dir ambiguous basenames) | at-bar | next hcl/markdown wave for ship-gate gap |
+| argocd-example-apps | yaml | 91 | 0.00% (2026-05-19, v3; v2 was 16.01%) | #467 then #474 then #478 | clean | at-ship-gate | maintenance |
+| prometheus-helm | yaml | 52 | 0.00% (2026-05-19, v3) | — | clean | at-ship-gate | maintenance |
+| starter-workflows | yaml | 514 | 0.55% (2026-05-19, v3; v2 was 11.89%) | #467 then #475 then #478 | clean | at-ship-gate | maintenance |
+| openapi-stripe | yaml | 5 | 0.00% (2026-05-19, v3) | — | clean | at-ship-gate | maintenance |
 | gitlab-runner | yaml | — | — | — | — | unmeasured | clone + index |
 | circleci-demo-python-django | yaml | — | — | — | — | unmeasured | clone + index |
 | jenkins | groovy | — | — | — | — | unmeasured | clone + index |
@@ -176,33 +178,36 @@ not yet folded into an aggregate baseline doc.)
 | phoenix-live-view | elixir | — | — | — | — | unmeasured | clone + index |
 | http4k | kotlin | — | — | — | — | unmeasured | clone + index |
 
-## Status roll-up (seed snapshot 2026-05-19)
+## Status roll-up (v3 refresh 2026-05-19)
 
 | Status | Count |
 |---|---:|
 | at-ship-gate | 4 |
-| at-bar | 10 |
+| at-bar | 16 |
 | addressable | 6 |
-| structural | 14 |
-| upstream | 3 |
-| unmeasured | 78 |
+| structural | 13 |
+| upstream | 1 |
+| unmeasured | 75 |
 | **total tier-1 repos** | **115** |
 
-Note: counts of measured rows (37 = 115 - 78) differ slightly from the 40 in the
-v2 doc because #483 / #480 split-measurements (etcd, gin, chi, grpc-go-examples)
-are folded into a single row each in this ledger. The v2 doc remains the
-authoritative aggregate measurement until the next baseline run.
+Notes:
+- 4 ship-gate (argocd-example-apps, starter-workflows, prometheus-helm, openapi-stripe) — argocd + starter-workflows now folded into the aggregate baseline.
+- 16 at-bar (was 10 at v2): added chi, gin, grpc-go-examples, ktor-samples, terraform-aws-vpc (chain-fixed and folded), play-scala-starter (promoted from addressable).
+- 1 upstream (etcd): 0.62 pp from bar but waiting on receiver-variable-type-tracking primitive.
+- exposed moved addressable -> addressable but BACK ABOVE bar (8.56 -> 11.00) — v2 number was a noisy underestimate; v3 single-shot trustworthy. Treat as not-yet-at-bar.
 
-## Next-wave candidates (filter: status in {at-bar, addressable}, sorted by bug-rate desc)
+## Next-wave candidates (filter: status in {at-bar, addressable}, sorted by bug-rate desc, v3 numbers)
 
 | Rank | Repo | Lang | Bug-rate | Why |
 |---:|---|---|---:|---|
-| 1 | nestjs-starter | typescript | 16.67% | post-#475 TS-on-Node residual still dominates |
-| 2 | nextjs-commerce | typescript | 17.22% | TS framework-level resolution (could overlap with above) |
-| 3 | kickstart.nvim | lua | 10.14% | regression — quick win if root cause is transitive |
-| 4 | aspnetcore-realworld | csharp | 9.82% | next csharp wave (one-step from at-bar) |
-| 5 | phoenix-todo-list | elixir | 9.38% | first elixir wave, very close to bar |
-| 6 | exposed | kotlin | 8.56% | extend Kotlin DSL receivers beyond Ktor Routing |
+| 1 | nextjs-commerce | typescript | 17.14% | TS framework-level resolution (Next.js router + RSC) |
+| 2 | nestjs-starter | typescript | 16.67% | post-#475 TS-on-Node residual still dominates |
+| 3 | exposed | kotlin | 11.00% | Kotlin DSL receivers beyond Ktor Routing (v3 reveals v2 was noisy under-read) |
+| 4 | kickstart.nvim | lua | 9.86% | lua regression vs v1 — investigate transitive cause |
+| 5 | aspnetcore-realworld | csharp | 9.82% | next csharp wave (one-step from bar) |
+| 6 | phoenix-todo-list | elixir | 9.38% | first elixir wave, very close to bar |
+| 7 | spring-petclinic | java | 8.34% | first java wave — within striking distance of bar |
+| 8 | etcd | go | 8.62% | upstream — receiver-variable-type primitive will unblock |
 
 `structural` rows (rust, php, java, ruby, python, swift, zig, just, fish, clojure)
 are higher-bug-rate but each requires a dedicated multi-day extractor wave —

--- a/docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v3.md
+++ b/docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v3.md
@@ -1,0 +1,159 @@
+# VERIFY-2 Quick Tier-1 Refresh v3 (2026-05-19, post-determinism)
+
+_Re-measurement after #486 made indexer output byte-identical across runs. First **reliable single-shot** measurement; prior runs carried ~±5pp noise on small repos._
+
+_Binary built from `investigate/remeasure-v3` head (`2e2ec02` merge of #486). `SOURCE_DATE_EPOCH=1700000000`, serial, 300s per-repo timeout. 40/40 OK, 0 timeouts, 0 crashes._
+
+**Headline:** aggregate bug-rate **10.34%** across **40** tier-1 repos (same 40-repo intersection as v2).
+
+**Delta vs v2:** **11.34% to 10.34% (-1.00 pp).** Smaller absolute swing than v1->v2 because v2 had already captured wave-1+2 lands; v3 captures wave-3 chain-fixes (#474 #475 #476 #477 #478 #480 #483) plus the determinism normalisation.
+
+## Determinism sanity check
+
+3 back-to-back runs of `kickstart.nvim` with `SOURCE_DATE_EPOCH=1700000000`:
+
+```
+516976825187bdec8d79215c9d2e9cfb81bb7c748e4da22e64ae33ed642ee09a  run-1
+516976825187bdec8d79215c9d2e9cfb81bb7c748e4da22e64ae33ed642ee09a  run-2
+516976825187bdec8d79215c9d2e9cfb81bb7c748e4da22e64ae33ed642ee09a  run-3
+```
+
+Byte-identical SHA256. #486 holds.
+
+## Comparison vs prior baselines
+
+| Run | Repos | Aggregate bug-rate | At-bar (<=8%) | At ship-gate (<=1%) | Reliability |
+|---|---:|---:|---:|---:|---|
+| v4 baseline | 32 | 15.63% | n/a | n/a | noisy |
+| quick tier-1 v1 (2026-05-19) | 40 | 17.55% | 6 | 2 | noisy |
+| quick tier-1 v2 (2026-05-19) | 40 | 11.34% | 10 | 2 | noisy |
+| **quick tier-1 v3 (this run)** | **40** | **10.34%** | **16** | **4** | **reliable single-shot** |
+
+**Net since v2:** +6 at-bar, +2 at-ship-gate, aggregate -1.00 pp.
+
+## Aggregate disposition counts
+
+| Disposition | v3 | v2 | delta |
+|---|---:|---:|---:|
+| resolved | 252,431 | 249,510 | +2,921 |
+| external-known | 31,448 | 30,495 | +953 |
+| external-unknown | 31,983 | 34,339 | -2,356 |
+| dynamic | 91,869 | 83,971 | +7,898 |
+| bug-extractor | 32,372 | 35,467 | -3,095 |
+| bug-resolver | 14,641 | 15,488 | -847 |
+| unclassified | 2 | 0 | +2 |
+| **total endpoints** | **454,746** | **449,270** | **+5,476** |
+| **bugs (extractor+resolver+unclassified)** | **47,015** | **50,955** | **-3,940** |
+
+Bug-extractor drops by ~3.1k, bug-resolver by ~0.8k; resolved gains ~2.9k. The wave-3 chain-fixes (markdown, YAML chain, byPackageComponent) moved extractor-bugs to either `resolved` (for the markdown/yaml link work) or `external-known/dynamic` (correctly classified).
+
+## Per-repo before/after (sorted by new bug-rate, worst first; bar = 8.0%)
+
+| Repo | Lang | Files | Rels | Endpoints | Bugs | v3 bug-rate | v2 bug-rate | Delta | vs Bar |
+|---|---|---:|---:|---:|---:|---:|---:|---:|:---:|
+| laravel-quickstart | php | 83 | 191 | 382 | 92 | 24.08% | 24.08% | +0.00 | FAIL |
+| symfony-demo | php | 241 | 1,499 | 2,998 | 690 | 23.02% | 23.02% | -0.00 | FAIL |
+| kafka-streams-examples | java | 172 | 8,156 | 16,312 | 3,619 | 22.19% | 22.31% | -0.12 | FAIL |
+| vapor-api-template | swift | 21 | 47 | 94 | 20 | 21.28% | 21.28% | -0.00 | FAIL |
+| http.zig | zig | 36 | 1,874 | 3,748 | 763 | 20.36% | 20.36% | -0.00 | FAIL |
+| usermanager-example | clojure | 17 | 76 | 152 | 30 | 19.74% | 19.74% | -0.00 | FAIL |
+| actix-examples | rust | 460 | 6,100 | 12,200 | 2,288 | 18.75% | 18.75% | +0.00 | FAIL |
+| just | just | 290 | 19,731 | 39,462 | 6,842 | 17.34% | 17.34% | -0.00 | FAIL |
+| nextjs-commerce | typescript | 76 | 668 | 1,336 | 229 | 17.14% | 17.22% | -0.08 | FAIL |
+| nestjs-starter | typescript | 16 | 57 | 114 | 19 | 16.67% | 16.67% | -0.00 | FAIL |
+| tokio | rust | 389 | 18,370 | 36,740 | 5,893 | 16.04% | 16.04% | -0.00 | FAIL |
+| mini-redis | rust | 33 | 1,047 | 2,094 | 311 | 14.85% | 14.85% | +0.00 | FAIL |
+| flask-realworld | python | 43 | 934 | 1,868 | 276 | 14.78% | 14.78% | -0.00 | FAIL |
+| django-realworld | python | 48 | 530 | 1,060 | 148 | 13.96% | 13.96% | +0.00 | FAIL |
+| pandas | python | 197 | 30,385 | 60,770 | 8,424 | 13.86% | 13.86% | +0.00 | FAIL |
+| sidekiq | ruby | 85 | 4,733 | 9,466 | 1,275 | 13.47% | 13.47% | -0.00 | FAIL |
+| exposed | kotlin | 115 | 4,785 | 9,570 | 1,053 | 11.00% | 8.56% | **+2.44** | FAIL |
+| kickstart.nvim | lua | 15 | 71 | 142 | 14 | 9.86% | 10.14% | -0.28 | FAIL |
+| express-realworld | javascript | 66 | 346 | 692 | 68 | 9.83% | 9.83% | -0.00 | FAIL |
+| aspnetcore-realworld | csharp | 97 | 1,288 | 2,576 | 253 | 9.82% | 9.82% | +0.00 | FAIL |
+| phoenix-todo-list | elixir | 69 | 714 | 1,428 | 134 | 9.38% | 9.38% | +0.00 | FAIL |
+| tide | fish | 130 | 754 | 1,508 | 136 | 9.02% | 9.02% | -0.00 | FAIL |
+| etcd | go | 424 | 29,069 | 58,138 | 5,010 | 8.62% | 12.40% | **-3.78** | FAIL |
+| spring-petclinic | java | 120 | 2,291 | 4,582 | 382 | 8.34% | 8.45% | -0.11 | FAIL |
+| play-scala-starter | scala | 37 | 71 | 142 | 11 | 7.75% | 7.75% | -0.00 | ok |
+| grpc-go-examples | proto | 203 | 8,087 | 16,174 | 1,139 | 7.04% | 10.74% | **-3.70** | ok |
+| spdlog | cpp | 175 | 3,326 | 6,652 | 462 | 6.95% | 6.95% | -0.00 | ok |
+| click | python | 138 | 7,841 | 15,682 | 1,076 | 6.86% | 6.86% | +0.00 | ok |
+| rails-realworld | ruby | 105 | 263 | 526 | 35 | 6.65% | 6.65% | +0.00 | ok |
+| terraform-aws-vpc | hcl | 105 | 3,650 | 7,300 | 463 | 6.34% | 6.34% | +0.00 | ok |
+| ktor-samples | kotlin | 509 | 5,854 | 11,708 | 737 | 6.29% | 10.40% | **-4.11** | ok |
+| aspnetcore-docs-samples | razor | 2,674 | 14,459 | 28,918 | 1,787 | 6.18% | 6.18% | -0.00 | ok |
+| gin | go | 121 | 11,335 | 22,670 | 1,399 | 6.17% | 8.63% | **-2.46** | ok |
+| chi | go | 93 | 3,826 | 7,652 | 367 | 4.80% | 8.50% | **-3.70** | ok |
+| apollo-server | graphql | 293 | 8,646 | 17,292 | 820 | 4.74% | 4.79% | -0.05 | ok |
+| requests | python | 111 | 23,584 | 47,168 | 725 | 1.54% | 1.54% | -0.00 | ok |
+| starter-workflows | yaml | 514 | 2,281 | 4,562 | 25 | 0.55% | 11.89% | **-11.34** | ok |
+| argocd-example-apps | yaml | 91 | 176 | 352 | 0 | 0.00% | 16.01% | **-16.01** | ok |
+| openapi-stripe | yaml | 5 | 19 | 38 | 0 | 0.00% | 0.00% | +0.00 | ok |
+| prometheus-helm | yaml | 52 | 239 | 478 | 0 | 0.00% | 0.00% | +0.00 | ok |
+
+## Newly at ship-gate (<=1%) since v2
+
+| Repo | Lang | v2 | v3 | Driving chain |
+|---|---|---:|---:|---|
+| argocd-example-apps | yaml | 16.01% | 0.00% | #467 then #474 then #478 (now folded into aggregate) |
+| starter-workflows | yaml | 11.89% | 0.55% | #467 then #475 then #478 (now folded into aggregate) |
+
+These were already noted as post-PR clean in the ledger; v3 folds them into the aggregate measurement.
+
+## Newly at-bar since v2 (>1% but <=8%)
+
+| Repo | Lang | v2 | v3 | Driving chain |
+|---|---|---:|---:|---|
+| chi | go | 8.50% | 4.80% | #480 then #483 (byPackageComponent) |
+| gin | go | 8.63% | 6.17% | #480 then #483 |
+| ktor-samples | kotlin | 10.40% | 6.29% | #471 then #477 |
+| grpc-go-examples | proto | 10.74% | 7.04% | #472 then #476 then #480 |
+
+## Wave-3 queue — still above 8% bar (24)
+
+Sorted by v3 bug-rate desc:
+
+| Rank | Repo | Lang | v3 | Status hint |
+|---:|---|---|---:|---|
+| 1 | laravel-quickstart | php | 24.08% | see ledger |
+| 2 | symfony-demo | php | 23.02% | see ledger |
+| 3 | kafka-streams-examples | java | 22.19% | see ledger |
+| 4 | vapor-api-template | swift | 21.28% | see ledger |
+| 5 | http.zig | zig | 20.36% | see ledger |
+| 6 | usermanager-example | clojure | 19.74% | see ledger |
+| 7 | actix-examples | rust | 18.75% | see ledger |
+| 8 | just | just | 17.34% | see ledger |
+| 9 | nextjs-commerce | typescript | 17.14% | see ledger |
+| 10 | nestjs-starter | typescript | 16.67% | see ledger |
+| 11 | tokio | rust | 16.04% | see ledger |
+| 12 | mini-redis | rust | 14.85% | see ledger |
+| 13 | flask-realworld | python | 14.78% | see ledger |
+| 14 | django-realworld | python | 13.96% | see ledger |
+| 15 | pandas | python | 13.86% | see ledger |
+| 16 | sidekiq | ruby | 13.47% | see ledger |
+| 17 | exposed | kotlin | 11.00% | see ledger |
+| 18 | kickstart.nvim | lua | 9.86% | see ledger |
+| 19 | express-realworld | javascript | 9.83% | see ledger |
+| 20 | aspnetcore-realworld | csharp | 9.82% | see ledger |
+| 21 | phoenix-todo-list | elixir | 9.38% | see ledger |
+| 22 | tide | fish | 9.02% | see ledger |
+| 23 | etcd | go | 8.62% | see ledger |
+| 24 | spring-petclinic | java | 8.34% | see ledger |
+
+## Findings
+
+1. **Determinism holds.** 3-run SHA256 identical on kickstart.nvim. Single-shot measurement is now trustworthy.
+2. **Aggregate improved -1.00 pp** vs v2 (11.34% to 10.34%) from wave-3 chain-fixes (#478 #480 #483) folding in.
+3. **6 repos crossed the 8% bar** since v2 (incl. 2 to ship-gate). At-bar count went 10 to 16.
+4. **Exposed regressed +2.44 pp** (8.56% to 11.00%). Was at-bar in v2; now above the bar. Likely a v2 noise artifact (v2 was measured pre-determinism); v3 single-shot is the trustworthy number. Investigate as wave-N candidate (Kotlin DSL receivers beyond Ktor Routing — same residual class flagged in the ledger).
+5. **etcd** dropped -3.78 pp (12.40% to 8.62%) but still misses bar by 0.62 pp — the receiver-variable-type chain is the gating issue.
+6. **No false-regression resolution noted from v2->v3 within the 'at-bar' bucket** other than exposed in the other direction; v2 numbers for at-bar repos were within ~0.5 pp of v3, suggesting v2 noise was dominated by repos with large numerators rather than small ones.
+
+## Wall time and reliability
+
+- Index pass wall: 476s (~8 min) serial.
+- All 40 repos OK, no timeouts, no crashes.
+- Sanity check: 3x kickstart.nvim runs SHA256-identical.
+
+forbidden-term grep: clean


### PR DESCRIPTION
## Summary

First **reliable single-shot** tier-1 baseline measurement after #486 made indexer output byte-identical across runs. Also refreshes the per-repo residual ledger to fold in wave-3 chain-fixes (#474 #475 #476 #477 #478 #480 #483) plus the noise-elimination.

**Refs:** #44 #481 #484

## Headline

- Aggregate bug-rate: **11.34% v2 -> 10.34% v3** (-1.00 pp, but now trustworthy)
- At ship-gate (<=1%): **2 -> 4** (argocd-example-apps and starter-workflows now folded in)
- At-bar (<=8%): **10 -> 16** (chi, gin, grpc-go-examples, ktor-samples join; play-scala-starter promoted)
- Still above bar (wave-3 queue): 24

## Determinism sanity check

3x `kickstart.nvim` runs with `SOURCE_DATE_EPOCH=1700000000` produced byte-identical `graph.json` (SHA256 `5169768...4ee09a`). #486 holds.

## Notable findings

- **exposed regressed +2.44 pp** (8.56% v2 -> 11.00% v3). v2 was noisy under-read; v3 single-shot is trustworthy. Now back above bar.
- **etcd** dropped -3.78 pp (12.40 -> 8.62) but misses bar by 0.62 pp. Receiver-variable-type primitive will unblock.
- argocd-example-apps and starter-workflows confirmed at ship-gate post #478.
- 40/40 repos indexed OK, 0 timeouts, 0 crashes. Serial wall: 476s (~8 min).

## Test plan

- [x] 3-run determinism sanity check on kickstart.nvim (SHA256 identical)
- [x] 40/40 repo intersection indexed without timeout/crash
- [x] `forbidden-term grep: clean` on both docs
- [x] Status enum transitions follow ledger rules

## Docs

- New: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v3.md`
- Updated: `docs/verify2/per-repo-residual-ledger.md`

forbidden-term grep: clean