### PR TITLE
[wave-3] vapor swift-gated bare-name stop-list

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -112,7 +112,7 @@ folded into an aggregate baseline doc.)
 | symfony-demo | php | 241 | 23.02% (2026-05-19, v3) | — | php extractor untouched in wave-1+2 | structural | file php-fix-wave issue |
 | mini-redis | rust | 33 | 14.85% (2026-05-19, v3) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
 | actix-examples | rust | 460 | 18.75% (2026-05-19, v3) | — | rust extractor not targeted in wave-1+2 | structural | file rust-fix-wave issue |
-| vapor-api-template | swift | 21 | 21.28% (2026-05-19, v3) | — | swift extractor untouched | structural | file swift-extractor issue |
+| vapor-api-template | swift | 21 | 3.19% (2026-05-19, wave-3 vapor PR) | wave-3 vapor (this PR — swift-gated bare-name stop-list + Swift ecosystem package allowlist) | residual = 1 bug-extractor (root-level `Package.swift` IMPORTS edge, no `/` in FromID so `looksLikeSourceFilePath` misses) + 2 bug-resolver (`App` SwiftPM target-dependency name collides with local SCOPE.Component created by import-extractor) | at-bar | (a) extend `looksLikeSourceFilePath` to accept basename-only swift paths; (b) swift extractor: stop emitting SCOPE.Component per import (the same name leaks into the local entity table and causes bug-resolver ambiguity) — file swift-import-extractor issue |
 | sample-food-truck | swift | — | — | — | — | unmeasured | clone + index |
 | aspnetcore-realworld | csharp | 97 | 9.82% (2026-05-19, v3) | #473 | razor/csharp fix improved but residual cs-specific identifier resolution remains | addressable | next csharp wave |
 | spdlog | cpp | 175 | 6.95% (2026-05-19, v3) | #468 | clean | at-bar | next cpp wave for ship-gate gap |

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -5060,6 +5060,58 @@ var swiftBareNames = map[string]struct{}{
 	"Int8":                 {},
 	"Int16":                {},
 	"Int32":                {},
+
+	// Vapor 3 / Fluent 3 service-graph types, factory/builder verbs, and
+	// XCTest assertion DSL (Wave 3, vapor-api-template residuals — issue
+	// #436 follow-up). The Swift extractor strips the receiver from
+	// constructor calls (`MiddlewareConfig()` → `MiddlewareConfig`,
+	// `SQLiteDatabase(storage: .memory)` → `SQLiteDatabase`) and from
+	// static factory calls (`Config.default()` → `default`,
+	// `Services.default()` → `default`). The receiver-less bare CALL
+	// lands in bug-extractor with no plausible local candidate.
+	//
+	// Two name classes:
+	//   1. PascalCase Vapor framework types (Application, MigrationConfig,
+	//      DatabasesConfig, SQLiteDatabase, MiddlewareConfig, EngineRouter,
+	//      ErrorMiddleware, FileMiddleware) — high specificity, very low
+	//      collision risk even in the Vapor framework source repo.
+	//   2. Lowercase Fluent/service-graph verbs (`add`, `default`) —
+	//      generic on their own, but the synthesizer ONLY runs against
+	//      UNRESOLVED endpoints (`Synthesize` skips hex-resolved IDs at
+	//      synth.go:133). When `add`/`default` bind to a local Swift
+	//      entity they keep their hex ID and never reach
+	//      `swiftBareNames`. The stop-list only catches the receiver-
+	//      stripped-and-unresolved residue — which IS the Fluent
+	//      collection mutator (`databases.add(database:as:)`,
+	//      `migrations.add(model:database:)`) or static factory
+	//      (`Config.default()`, `Services.default()`) by construction.
+	//      `register` is already covered by the upstream Swift stdlib
+	//      stop-list. Swift gate prevents cross-language leakage.
+	//
+	// XCTest assertion macros (`XCTAssert*`, `XCTFail`) are Apple stdlib
+	// with the `XCT` prefix; the Swift gate is defence-in-depth.
+	"Application":          {},
+	"MigrationConfig":      {},
+	"DatabasesConfig":      {},
+	"SQLiteDatabase":       {},
+	"MiddlewareConfig":     {},
+	"EngineRouter":         {},
+	"ErrorMiddleware":      {},
+	"FileMiddleware":       {},
+	"add":                  {},
+	"default":              {},
+	"XCTAssert":            {},
+	"XCTAssertEqual":       {},
+	"XCTAssertNotEqual":    {},
+	"XCTAssertTrue":        {},
+	"XCTAssertFalse":       {},
+	"XCTAssertNil":         {},
+	"XCTAssertNotNil":      {},
+	"XCTAssertThrowsError": {},
+	"XCTAssertNoThrow":     {},
+	"XCTAssertGreaterThan": {},
+	"XCTAssertLessThan":    {},
+	"XCTFail":              {},
 }
 
 // csharpBareNames is the C#-language-gated bare-name stop-list (issue
@@ -7418,6 +7470,41 @@ var knownExternalPackages = map[string]struct{}{
 	"openssl":   {},
 	"zlib":      {},
 	"curl":      {},
+	// Swift ecosystem (Wave 3 — vapor-api-template, follow-up to #436).
+	// Vapor + Fluent are the dominant server-side Swift stack; SwiftNIO
+	// is the networking primitive Vapor builds on; Foundation/Combine/
+	// SwiftUI/UIKit/AppKit are Apple stdlib top-levels; PackageDescription
+	// is the Swift Package Manager DSL imported by `Package.swift`
+	// manifests. Without these, Swift `import Vapor` lands in
+	// bug-resolver (the extractor creates a SCOPE.Component named
+	// "Vapor" per import — see internal/extractors/swift/swift.go
+	// buildImport — and the resolver finds it, so it's flagged as a
+	// bug-resolver ambiguous match rather than an external package).
+	// XCTest is the test-runner stdlib (used by the XCTAssert* macros
+	// already in swiftBareNames).
+	"vapor":              {},
+	"fluent":             {},
+	"fluentsqlite":       {},
+	"fluentpostgresql":   {},
+	"fluentmysql":        {},
+	"fluentmongo":        {},
+	"swiftnio":           {},
+	"nio":                {},
+	"niocore":            {},
+	"niohttp1":           {},
+	"niohttp2":           {},
+	"niofoundationcompat": {},
+	"foundation":         {},
+	"combine":            {},
+	"swiftui":            {},
+	"uikit":              {},
+	"appkit":             {},
+	"xctest":             {},
+	"packagedescription": {},
+	"console":            {},
+	"jwt":                {},
+	"leaf":               {},
+	// `redis` already on the allowlist via the Python ecosystem block.
 }
 
 // googleBenchmarkBareNames is the cpp-gated Google Benchmark public-


### PR DESCRIPTION
## Summary

vapor-api-template bug-rate **21.28% -> 3.19%** (-18.09pp, **at-bar**).

Two changes in `internal/external/synth.go`:

1. **`swiftBareNames` stop-list extended** with Vapor 3 / Fluent 3 service-graph types (`Application`, `MigrationConfig`, `DatabasesConfig`, `SQLiteDatabase`, `MiddlewareConfig`, `EngineRouter`, `ErrorMiddleware`, `FileMiddleware`), two Fluent collection/factory verbs (`add`, `default`), and the XCTest assertion macros (`XCTAssert*`, `XCTFail`). All gated on `lang == "swift"`.

   The two lowercase verbs (`add`, `default`) are safe because `Synthesize` (synth.go:133) skips hex-resolved IDs — locally-defined `add`/`default` keep their hex ID and never reach the stop-list. The stop-list only catches the receiver-stripped-and-unresolved residue (Fluent's `databases.add(database:as:)`, `Config.default()`).

2. **`knownExternalPackages` extended with the Swift ecosystem** (`vapor`, `fluent`, `fluentsqlite`, `fluentpostgresql`, `fluentmysql`, `fluentmongo`, `swiftnio` + nio submodules, `foundation`, `combine`, `swiftui`, `uikit`, `appkit`, `xctest`, `packagedescription`, `console`, `jwt`, `leaf`). Fixes the `bug-resolver` bucket where the Swift import-extractor creates a `SCOPE.Component` per `import Vapor` and the resolver matches the IMPORTS edge ToID against it, flagging it as an ambiguous local resolution. The package allowlist routes the same edge through ext-synthesis to `ext:vapor` (ExternalKnown).

## Before / after (vapor-api-template)

| Disposition | Before | After |
|---|---|---|
| bug-extractor | 10 | 1 |
| bug-resolver | 10 | 2 |
| external-known | 0 | 9 |
| external-unknown | 0 | 20 |
| resolved | 50 | 50 |
| dynamic | 12 | 12 |
| **bug-rate** | **21.28%** | **3.19%** |

## Regression check (sibling repos, no-WIP baseline vs with-WIP)

| repo | lang | baseline | with WIP | delta |
|---|---|---|---|---|
| chi | go | 4.80% | 4.80% | 0.00 (gate works) |
| express | js | 13.81% | 13.81% | 0.00 (gate works) |
| flask | python | 11.44% | 11.44% | 0.00 (gate works) |
| gin | go | 6.17% | 6.17% | 0.00 (gate works) |
| vapor (framework) | swift | 18.38% | 14.07% | **-4.31pp improvement** |

No regressions. The Swift gate isolates the new entries from non-Swift repos by construction; the Swift framework source repo benefits from the same package allowlist additions.

## Residual root cause

1 bug-extractor (root-level `Package.swift` IMPORTS PackageDescription edge — `looksLikeSourceFilePath` requires `/` in the FromID and rejects basename-only paths) + 2 bug-resolver (`App` SwiftPM target-dependency name collides with the SCOPE.Component the Swift import-extractor creates per `import App`).

**Residual root cause:** Swift import-extractor emits `SCOPE.Component` entities named after the imported module, which causes ambiguous local resolution for any SwiftPM target dependency that shares its name with an imported module.
**Status:** at-bar

## Chain-fixes surfaced

1. `internal/resolve/refs.go::looksLikeSourceFilePath` — accept basename-only paths ending in known source extensions (would convert the `Package.swift` IMPORTS edge from bug-extractor to dynamic). Cross-repo win for any repo with root-level source files emitting IMPORTS edges.
2. `internal/extractors/swift/swift.go::buildImport` — stop emitting a `SCOPE.Component` per import; the import target should remain a raw bare name and let ext-synthesis canonicalise it to `ext:<lowercase>`. Would eliminate the `App` bug-resolver class entirely.

## Test plan

- [x] `go test ./...` — all packages pass
- [x] `go test ./internal/external/...` — swiftBareNames tests pass with new entries
- [x] `go test ./internal/resolve/...` — disposition tests pass
- [x] vapor-api-template re-indexed — bug-rate 3.19% confirmed
- [x] 4 non-Swift sibling repos (chi/express/flask/gin) re-indexed — zero delta confirmed
- [x] vapor framework source re-indexed — -4.31pp improvement confirmed (cross-Swift gain, not regression)
- [x] ledger row updated in `docs/verify2/per-repo-residual-ledger.md`