### PR TITLE
[#509] cross-repo linker: skip ext:bare-name placeholders (100% false-positive cohort)

### DIFF
--- a/internal/links/import_pass.go
+++ b/internal/links/import_pass.go
@@ -1,5 +1,35 @@
 package links
 
+import "strings"
+
+// isBareNameExt reports whether id is a bare-name external placeholder
+// of the form "ext:<name>" with no module qualifier (no second ":" after
+// the prefix). These placeholders are emitted when the extractor sees an
+// unresolved bare identifier (e.g. `[].filter()`, `array.split(...)`) and
+// the external synthesiser has no module path to attach. Two repos that
+// each independently call `[].filter()` therefore both end up pointing
+// edges at the same `ext:filter` placeholder, which is NOT a real
+// cross-repo reference — it is each repo's own use of a built-in.
+//
+// Qualified placeholders of the form "ext:<module>:<name>" carry real
+// module identity (e.g. `ext:react:useState`) and remain eligible for
+// cross-repo linking.
+//
+// Issue #509: bare-name ext:* matches produced 100% false-positive
+// cross-repo links on the upvate group (1,114 of 1,114). Filtering
+// these out is the precision fix.
+func isBareNameExt(id string) bool {
+	const prefix = "ext:"
+	if !strings.HasPrefix(id, prefix) {
+		return false
+	}
+	rest := id[len(prefix):]
+	if rest == "" {
+		return true // pathological "ext:" — also bare/empty.
+	}
+	return !strings.Contains(rest, ":")
+}
+
 // runImportPass implements P1: structural cross-repo imports/calls edges.
 //
 // Idempotent overwrite: every link previously emitted with method=import is
@@ -42,6 +72,15 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 			}
 			if fromRepo == toRepo {
 				// Self-pair: not a cross-repo edge.
+				continue
+			}
+			// Issue #509: bare-name ext:* placeholders (e.g. "ext:filter",
+			// "ext:split") are each repo's own unresolved use of a built-in
+			// or stdlib bare identifier. Two repos pointing at the same
+			// placeholder ID does NOT mean they share a real symbol — only
+			// qualified "ext:<module>:<name>" forms carry that guarantee.
+			// Skip either side being a bare-name ext: placeholder.
+			if isBareNameExt(edge.FromID) || isBareNameExt(edge.ToID) {
 				continue
 			}
 			source := entityKey(fromRepo, edge.FromID)

--- a/internal/links/import_pass_test.go
+++ b/internal/links/import_pass_test.go
@@ -1,0 +1,115 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestImportPass_SkipsBareNameExt verifies the issue #509 fix:
+// two repos that each independently reference `ext:filter` (a bare-name
+// external placeholder for a built-in like `[].filter()`) must NOT
+// produce a cross-repo link. Bare-name ext:* placeholders are each
+// repo's own unresolved use of a built-in, not a shared symbol.
+func TestImportPass_SkipsBareNameExt(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "doStuff", "kind": "function", "source_file": "src/a.js"},
+			{"id": "ext:filter", "name": "filter", "kind": "External", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "a_local", "to_id": "ext:filter", "kind": "calls"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "doMore", "kind": "function", "source_file": "src/b.js"},
+			{"id": "ext:filter", "name": "filter", "kind": "External", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "b_local", "to_id": "ext:filter", "kind": "calls"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g509", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g509-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			t.Errorf("expected zero import-method links for bare-name ext:filter, got %+v", l)
+		}
+	}
+}
+
+// TestImportPass_EmitsQualifiedExt verifies the converse: qualified
+// "ext:<module>:<name>" placeholders (e.g. `ext:react:useState`) DO
+// carry real module identity and remain eligible for cross-repo
+// linking when two repos point at the same qualified ID.
+func TestImportPass_EmitsQualifiedExt(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_comp", "name": "Component", "kind": "function", "source_file": "src/a.tsx"},
+			{"id": "ext:react:useState", "name": "useState", "kind": "External", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "a_comp", "to_id": "ext:react:useState", "kind": "calls"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_comp", "name": "Other", "kind": "function", "source_file": "src/b.tsx"},
+			{"id": "ext:react:useState", "name": "useState", "kind": "External", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "b_comp", "to_id": "ext:react:useState", "kind": "calls"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g509q", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g509q-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var count int
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly 1 import-method link for ext:react:useState, got %d (%+v)", count, doc.Links)
+	}
+}
+
+func TestIsBareNameExt(t *testing.T) {
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"ext:filter", true},
+		{"ext:split", true},
+		{"ext:", true}, // pathological — treat as bare
+		{"ext:react:useState", false},
+		{"ext:django:models.Model", false},
+		{"ext:click.command", true}, // dot-qualified but no second colon — still bare per spec
+		{"a_local", false},
+		{"", false},
+		{"react:useState", false}, // no ext: prefix
+	}
+	for _, c := range cases {
+		if got := isBareNameExt(c.in); got != c.want {
+			t.Errorf("isBareNameExt(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

The cross-repo import pass (P1) was matching bare-name external placeholders (e.g. `ext:filter`, `ext:split`) across repos and emitting them as `calls`/`import` cross-repo links. These placeholders are each repo's own unresolved use of a built-in or stdlib bare identifier (`[].filter()`, `array.split(...)`), not shared symbols.

On the client-fixture group this generated 1,114 of 1,114 false positives. Top offenders: filter (378), split (85), set (80), join (75), all (61), map (50), next (44), values (36), push (28), max (25).

## Fix

- New predicate `isBareNameExt(id)` returns true for `ext:<name>` placeholders with no second colon.
- In `runImportPass`, skip any edge whose FromID or ToID is a bare-name `ext:*` placeholder.
- Qualified `ext:<module>:<name>` placeholders (e.g. `ext:react:useState`, `ext:django:models.Model`) still link normally — they carry real module identity.

## Verification (client-fixture group)

Before:
- 1452 total links
- 1114 import (all false positives)
- 338 label_match

After:
- 338 total links
- 0 import
- 338 label_match

Top remaining identifiers (label_match only — all `error_handling:try_catch:N` shared_label artifacts):
- `error_handling:try_catch:NNN` dominates the surviving set
- a handful of legit name matches (`uuid`, `usenotetypesmap`, etc.)

## Tests

- `TestImportPass_SkipsBareNameExt` — two repos each calling `ext:filter` → 0 import links
- `TestImportPass_EmitsQualifiedExt` — two repos each calling `ext:react:useState` → 1 import link
- `TestIsBareNameExt` — unit coverage for `ext:`, `ext:foo`, `ext:foo:bar`, etc.
- `TestImportPass_EmitsCrossRepoEdges` (existing, regression check) — non-ext IDs (`a1 → b1`) still produce real cross-repo links. Passes.

Full `go test ./...` is green.

## Residual root cause

The 338 surviving links are all `label_match` method — 337 of them are `error_handling:try_catch:N` shared_label noise tracked by **#511** (separate label-pass stop-list issue, out of scope here per spec). The bare-name ext:* false-positive cohort — which is what #509 covers — is fully eliminated.

## Status

`at-ship-gate` for the bare-name ext:* false-positive cohort. The import-pass precision fix lands a 100% → 0% reduction on that cohort with no regression on legitimate cross-repo structural edges.

## Test plan

- [x] `go build -o build/archigraph ./cmd/archigraph`
- [x] `go test ./...` — all green
- [x] `build/archigraph rebuild client-fixture` — `import links=0 candidates=0`
- [x] `jq '.links | length' ~/.archigraph/groups/client-fixture-links.json` — 338 (was 1452)
- [x] Existing `TestImportPass_EmitsCrossRepoEdges` regression test still passes

Closes #509
