### PR TITLE
[#506] suppress HTML email-template + URL noise in TS/JS extractors

### DIFF
--- a/internal/extractors/html/extractor.go
+++ b/internal/extractors/html/extractor.go
@@ -48,6 +48,62 @@ type Extractor struct{}
 // Language returns the canonical language key.
 func (e *Extractor) Language() string { return "html" }
 
+// reEmailTemplate matches filenames that are conventionally transactional
+// email templates rather than browseable HTML pages — emails are server-side
+// rendered, are never imported by a JS/TS bundle, and have no graph identity
+// in a Vite/Webpack/Next.js project (issue #506).
+//
+// Patterns matched (case-insensitive):
+//
+//	templates/*_email.html        — Django/Flask style transactional emails
+//	templates/*_template.html     — generic template files under templates/
+//	*_email.html, *.email.html    — explicit email-template suffix anywhere
+//	emails/*.html, email/*.html   — Rails/MJML convention
+var reEmailTemplate = regexp.MustCompile(`(?i)(^|/)(templates|emails?)/.*\.html$|(^|/)[^/]*[._]email\.html$|(^|/)[^/]*[._]template\.html$`)
+
+// isExternalURL reports whether a <link>/<script>/<img> src or href value
+// points at an external resource (issue #506). External URLs are not graph
+// entities — the cross-file resolver has no file to bind them to, so they
+// land as bug-extractor `to_id` noise. Skip them at extract time.
+//
+// Matches: http://, https://, protocol-relative //, mailto:, tel:, data:,
+// javascript:, about:, blob:, file://. Returns false for the empty string
+// and for in-document fragment refs (#anchor).
+func isExternalURL(s string) bool {
+	if s == "" {
+		return false
+	}
+	if strings.HasPrefix(s, "//") {
+		return true
+	}
+	lower := strings.ToLower(s)
+	for _, p := range externalURLPrefixes {
+		if strings.HasPrefix(lower, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// externalURLPrefixes is the catalog of URI-scheme prefixes treated as
+// external (non-extractable) by isExternalURL. Kept narrow on purpose:
+// every entry here is a scheme that cannot resolve to a local repo file.
+var externalURLPrefixes = []string{
+	"http://", "https://",
+	"mailto:", "tel:", "sms:",
+	"data:", "blob:", "javascript:",
+	"about:", "file://", "ftp://", "ftps://",
+	"ws://", "wss://",
+}
+
+// isEmailTemplateFile reports whether the file path looks like a
+// transactional email template that should NOT have entities extracted
+// (issue #506). The heuristic is conservative — it matches well-known
+// directory conventions and explicit suffixes, but not arbitrary HTML.
+func isEmailTemplateFile(path string) bool {
+	return reEmailTemplate.MatchString(path)
+}
+
 // reCustomElement matches Web Component / custom element tag names.
 // Per spec: tag name matching [A-Z][a-zA-Z]+-[a-zA-Z]+ OR containing a hyphen
 // (both uppercase-starting like CustomWidget-v2 and lowercase like my-component).
@@ -84,6 +140,19 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	if len(file.Content) == 0 {
 		span.SetAttributes(
 			attribute.Int("file_line_count", 0),
+			attribute.Int("entity_count", 0),
+		)
+		return nil, nil
+	}
+
+	// Issue #506: email-template HTML files (templates/*_email.html etc.)
+	// are server-side rendered, never imported by a JS/TS bundle, and have
+	// no graph identity in a Vite/Webpack/Next.js project. Extracting them
+	// produces nothing but bug-extractor noise (the file path as FromID,
+	// any inline external URLs as ToID). Skip the file wholesale.
+	if isEmailTemplateFile(file.Path) {
+		span.SetAttributes(
+			attribute.Bool("skipped_email_template", true),
 			attribute.Int("entity_count", 0),
 		)
 		return nil, nil
@@ -236,7 +305,9 @@ func visitElement(node *sitter.Node, file extractor.FileInput) []types.EntityRec
 		rel := attrValue(startTag, "rel", file.Content)
 		if strings.ToLower(rel) == "stylesheet" {
 			href := attrValue(startTag, "href", file.Content)
-			if href != "" {
+			// Issue #506: external URLs (https://cdn..., //cdn...) cannot
+			// resolve to a local repo file. Skip to avoid bug-extractor noise.
+			if href != "" && !isExternalURL(href) {
 				recs = append(recs, types.EntityRecord{
 					Name:         href,
 					Kind:         "SCOPE.Component",
@@ -256,7 +327,9 @@ func visitElement(node *sitter.Node, file extractor.FileInput) []types.EntityRec
 
 	case "img":
 		src := attrValue(startTag, "src", file.Content)
-		if src != "" {
+		// Issue #506: external URLs (https://cdn..., data:..., etc.) are not
+		// graph entities. Skip them at extract time.
+		if src != "" && !isExternalURL(src) {
 			recs = append(recs, types.EntityRecord{
 				Name:         src,
 				Kind:         "SCOPE.Component",
@@ -451,7 +524,9 @@ func visitScriptElement(node *sitter.Node, file extractor.FileInput) (types.Enti
 	}
 
 	src := attrValue(startTag, "src", file.Content)
-	if src == "" {
+	// Issue #506: external scripts (https://cdn..., //cdn...) are not graph
+	// entities — they live on a CDN, not in the repo.
+	if src == "" || isExternalURL(src) {
 		return types.EntityRecord{}, false
 	}
 
@@ -492,7 +567,8 @@ func visitSelfClosingTag(node *sitter.Node, file extractor.FileInput) (types.Ent
 	switch tagName {
 	case "img":
 		src := attrValue(node, "src", file.Content)
-		if src == "" {
+		// Issue #506: external image URLs are not graph entities.
+		if src == "" || isExternalURL(src) {
 			return types.EntityRecord{}, false
 		}
 		return types.EntityRecord{
@@ -512,7 +588,8 @@ func visitSelfClosingTag(node *sitter.Node, file extractor.FileInput) (types.Ent
 
 	case "script":
 		src := attrValue(node, "src", file.Content)
-		if src == "" {
+		// Issue #506: external script URLs (CDN scripts) are not graph entities.
+		if src == "" || isExternalURL(src) {
 			return types.EntityRecord{}, false
 		}
 		return types.EntityRecord{
@@ -536,7 +613,8 @@ func visitSelfClosingTag(node *sitter.Node, file extractor.FileInput) (types.Ent
 			return types.EntityRecord{}, false
 		}
 		href := attrValue(node, "href", file.Content)
-		if href == "" {
+		// Issue #506: external stylesheet URLs cannot resolve to a local file.
+		if href == "" || isExternalURL(href) {
 			return types.EntityRecord{}, false
 		}
 		return types.EntityRecord{

--- a/internal/extractors/html/extractor_test.go
+++ b/internal/extractors/html/extractor_test.go
@@ -875,3 +875,125 @@ func TestHTMLExtractor_FlaskJinja2Register_AllKindsAllowlistCompliant(t *testing
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #506 — HTML email-template + external-URL noise suppression
+// ---------------------------------------------------------------------------
+
+func TestHTMLExtractor_SkipsEmailTemplateFiles(t *testing.T) {
+	src := `<!DOCTYPE html><html><body>
+<img src="https://controller.upvate.com/img/controller-logo-400px.png">
+<a href="https://example.com/reset">Click here</a>
+</body></html>`
+
+	cases := []string{
+		"src/templates/new_user_login_email.html",
+		"src/templates/reset_password_email.html",
+		"app/templates/welcome_email.html",
+		"emails/order_confirmation.html",
+		"email/notification.html",
+		"src/templates/account_template.html",
+		"some/path/footer_template.html",
+		"my.email.html",
+	}
+
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			tree := parseHTML(t, src)
+			entities := extractEntities(t, path, src, tree)
+			if len(entities) != 0 {
+				t.Fatalf("expected 0 entities for email-template path %q, got %d", path, len(entities))
+			}
+		})
+	}
+}
+
+func TestHTMLExtractor_ExtractsNonEmailTemplateHTML(t *testing.T) {
+	// Negative control: index.html and pages/*.html must still be extracted.
+	src := `<!DOCTYPE html><html><body>
+<script src="/src/main.jsx" type="module"></script>
+<img src="/logo.png">
+</body></html>`
+
+	cases := []string{
+		"index.html",
+		"public/index.html",
+		"src/pages/about.html",
+		"docs/contact.html",
+	}
+
+	for _, path := range cases {
+		t.Run(path, func(t *testing.T) {
+			tree := parseHTML(t, src)
+			entities := extractEntities(t, path, src, tree)
+			if len(entities) == 0 {
+				t.Fatalf("expected entities for non-email path %q, got 0", path)
+			}
+		})
+	}
+}
+
+func TestHTMLExtractor_SkipsExternalURLsInImgScriptLink(t *testing.T) {
+	// External URLs (CDN scripts, hotlinked images, external stylesheets)
+	// must not produce entities. They cannot resolve to a local repo file
+	// and only create bug-extractor `to_id` noise.
+	src := `<!DOCTYPE html><html>
+<head>
+  <link rel="stylesheet" href="https://cdn.example.com/style.css">
+  <link rel="stylesheet" href="//cdn.example.com/proto.css">
+  <script src="https://cdn.example.com/lib.js"></script>
+  <script src="//cdn.example.com/proto.js"></script>
+</head>
+<body>
+  <img src="https://controller.upvate.com/img/logo.png">
+  <img src="data:image/png;base64,AAAA">
+</body>
+</html>`
+
+	tree := parseHTML(t, src)
+	entities := extractEntities(t, "index.html", src, tree)
+
+	for _, e := range entities {
+		if strings.HasPrefix(e.Name, "http://") ||
+			strings.HasPrefix(e.Name, "https://") ||
+			strings.HasPrefix(e.Name, "//") ||
+			strings.HasPrefix(e.Name, "data:") {
+			t.Errorf("external URL leaked into entity: name=%q kind=%q subtype=%q",
+				e.Name, e.Kind, e.Subtype)
+		}
+	}
+}
+
+func TestHTMLExtractor_KeepsLocalImgScriptLink(t *testing.T) {
+	// Positive control: local refs (relative + root-absolute) must still
+	// produce entities.
+	src := `<!DOCTYPE html><html>
+<head>
+  <link rel="stylesheet" href="/css/site.css">
+  <link rel="stylesheet" href="./styles/app.css">
+  <script src="/src/main.jsx" type="module"></script>
+  <script src="js/app.js"></script>
+</head>
+<body>
+  <img src="/logo.png">
+  <img src="../assets/banner.svg">
+</body>
+</html>`
+
+	tree := parseHTML(t, src)
+	entities := extractEntities(t, "index.html", src, tree)
+
+	subtypes := map[string]int{}
+	for _, e := range entities {
+		subtypes[e.Subtype]++
+	}
+	if subtypes["style_include"] < 2 {
+		t.Errorf("expected >=2 style_include entities, got %d", subtypes["style_include"])
+	}
+	if subtypes["script_include"] < 2 {
+		t.Errorf("expected >=2 script_include entities, got %d", subtypes["script_include"])
+	}
+	if subtypes["image_include"] < 2 {
+		t.Errorf("expected >=2 image_include entities, got %d", subtypes["image_include"])
+	}
+}

--- a/internal/extractors/html/relationships_test.go
+++ b/internal/extractors/html/relationships_test.go
@@ -115,6 +115,9 @@ func TestRelationships_Imports_ImgSrc(t *testing.T) {
 // ---- IMPORTS — multiple mixed asset references -----------------------------
 
 func TestRelationships_Imports_Multiple(t *testing.T) {
+	// Issue #506: external URLs (https://cdn..., //cdn...) are intentionally
+	// dropped at extract time — they are not graph entities and previously
+	// landed as bug-extractor `to_id` noise. Only local refs are emitted.
 	src := `<html>
 <head>
   <link rel="stylesheet" href="/css/main.css">
@@ -128,15 +131,19 @@ func TestRelationships_Imports_Multiple(t *testing.T) {
 </html>`
 	entities := extractRels(t, "page.html", src)
 	rels := relsByKind(entities, "IMPORTS")
-	if len(rels) != 5 {
-		t.Fatalf("IMPORTS count = %d, want 5", len(rels))
+	if len(rels) != 4 {
+		t.Fatalf("IMPORTS count = %d, want 4 (external CDN URL skipped per #506)", len(rels))
 	}
 	wantTargets := map[string]bool{
-		"/css/main.css":                    false,
-		"https://cdn.example.com/lib.css":  false,
-		"/js/app.js":                       false,
-		"/img/a.png":                       false,
-		"b.svg":                            false,
+		"/css/main.css": false,
+		"/js/app.js":    false,
+		"/img/a.png":    false,
+		"b.svg":         false,
+	}
+	for _, r := range rels {
+		if r.ToID == "https://cdn.example.com/lib.css" {
+			t.Errorf("external CDN URL leaked into IMPORTS: %q (issue #506)", r.ToID)
+		}
 	}
 	for _, r := range rels {
 		if _, ok := wantTargets[r.ToID]; ok {

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2268,6 +2268,11 @@ var sourceFileExtensions = []string{
 	// HCL / Terraform — issue #44. The HCL extractor emits file-level
 	// CONTAINS / IMPORTS edges with FromID set to the .tf file path.
 	".tf", ".tfvars", ".hcl",
+	// HTML — issue #506. The HTML extractor emits IMPORTS edges with
+	// FromID set to the .html file path (e.g. index.html → /src/main.jsx).
+	// Without this entry the .html path itself lands in bug-extractor even
+	// when the target resolved successfully.
+	".html", ".htm",
 }
 
 // isHeuristicScopeStub reports whether s is a short-form structural-ref

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -1581,6 +1581,10 @@ func TestLooksLikeSourceFilePath_BasenameOnly(t *testing.T) {
 		{"Package.swift", true},
 		{"main.go", true},
 		{"index.ts", true},
+		// HTML files — must be accepted so that HTML-extractor IMPORTS edge
+		// FromIDs do not land in bug-extractor (#506).
+		{"index.html", true},
+		{"public/index.htm", true},
 		// Sub-path source files — must still be accepted.
 		{"a/b/Package.swift", true},
 		{"src/main.go", true},


### PR DESCRIPTION
## Summary

Fixes #506. The HTML extractor was emitting bug-extractor ghost edges for non-source HTML files in Vite/Webpack/Next.js projects:

- Email templates (`templates/*_email.html`, `emails/*.html`, `*_template.html`) are server-side rendered, never imported by a JS/TS bundle. Skip the file wholesale.
- External URLs in `<img>`, `<script>`, `<link>` (`https://`, `//`, `data:`, `mailto:`, etc.) cannot resolve to a local repo file. Skip them at extract time.
- Resolver: add `.html` / `.htm` to `sourceFileExtensions` so HTML extractor IMPORTS edge FromIDs land in `dynamic` (matching the #120 pattern for source-file FromIDs).

## Before / after on client-fixture-b (Vite + React, snapshot 2026-05-19)

| Metric | Before | After | Δ |
|---|---|---|---|
| bug_rate | 21.615% | 21.603% | -0.012pp |
| bug-extractor count | 7220 | 7214 | -6 |
| `bug-extractor` samples | `index.html`, `src/templates/new_user_login_email.html`, `https://example.com/img/controller-logo-400px.png`, `src/templates/reset_password_email.html`, `setSearchValue` | `setSearchValue`, `setTableFilters`, `then`, `setSelectedRecord`, `requestTurnNotifications` | **html+url cohort fully eliminated from samples** |

Issue #506 acceptance criterion ("client-fixture-b bug-extractor count drops by the html+url cohort visible in disposition_samples") — met.

## Regression check (tier-1 corpora, ≤0.5pp threshold)

| Repo | Before | After | Δ |
|---|---|---|---|
| argocd-example-apps (yaml) | 0.000% | 0.000% | flat |
| starter-workflows (yaml) | 0.548% | 0.548% | flat |
| nestjs-starter (ts) | 13.158% | 13.158% | flat |
| express (js) | 13.764% | 13.670% | -0.094pp (improvement) |
| spdlog (cpp) | 5.938% | 5.938% | flat |

No regression.

## Residual root cause:
JSX bare-name member-call noise on Vite/React projects — receiver-stripped calls like `form.setFieldsValue(...)` → `setFieldsValue`, `useState` destructured setters (`setX`), Promise `.then`/`.catch`, React Query / Redux / antd Form DSL methods. The JS extractor receiver-strips `a.b(...)` to bare `b` and these names can't go in `jsBareNames` globally (collide with user-defined methods). Needs framework-gated Dynamic patterns parallel to #514 (express DSL) and #508 (RN DSL).

## Status:
at-bar pending chain-fix #519 (`js-jsx-setter-prop bare-name residue: setState/setFieldsValue/setSearchValue on Vite/React`). This PR addresses the issue scope (HTML+URL cohort); client-fixture-b ship-gate work continues in #519.

## Chain-fixes filed:
- #519 — js-jsx-setter-prop bare-name residue on Vite/React (React Query / Redux / antd Form / useState-setter / Promise-then gates)

## Test plan
- [x] `go build -o build/archigraph ./cmd/archigraph`
- [x] `go test ./...` (all green)
- [x] New unit tests: `TestHTMLExtractor_SkipsEmailTemplateFiles` (8 path patterns), `TestHTMLExtractor_ExtractsNonEmailTemplateHTML` (negative controls), `TestHTMLExtractor_SkipsExternalURLsInImgScriptLink`, `TestHTMLExtractor_KeepsLocalImgScriptLink`
- [x] Updated `TestRelationships_Imports_Multiple` to reflect external-URL drop
- [x] Updated `TestLooksLikeSourceFilePath_BasenameOnly` with `.html` / `.htm` cases
- [x] Verified client-fixture-b html+url cohort eliminated from disposition_samples
- [x] Verified no regression on argocd / starter-workflows / nestjs-starter / express / spdlog

Closes #506

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
