### PR TITLE
[#505] path-alias resolver for ts/js projects

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -967,6 +967,7 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 					Path:     t.relPath,
 					Content:  content,
 					Language: cr.Language,
+					RepoRoot: absRepo,
 				}
 
 				if pr, perr := i.parser.Parse(ctx, content, cr.Language); perr == nil && pr != nil {

--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -179,6 +179,19 @@ folded into an aggregate baseline doc.)
 | phoenix-live-view | elixir | — | — | — | — | unmeasured | clone + index |
 | http4k | kotlin | — | — | — | — | unmeasured | clone + index |
 
+## User-test repos (out-of-corpus snapshots — not part of tier-1)
+
+These are real production codebases the user supplied as private snapshots
+under `~/Documents/Projects/upvate-snapshot-2026-05-19/`. They are not in
+the verify2 corpus list and are NOT counted in the status roll-up below.
+Recorded here so #505 acceptance numbers (and any future
+private-codebase chain-fix) have a stable measurement-history anchor.
+
+| Repo | Stack | Files (~) | Latest bug-rate | Last fix PR | Residual root cause | Status | Blocker / next fix |
+|---|---|---:|---:|---|---|---|---|
+| upvate-snapshot/core-mobile | typescript (RN/Expo + Metro + tsconfig paths) | ~538 | 20.28% (2026-05-19, post-#505 path-aliases) — was 22.37% pre-fix | #505 | (a) JS extractor doesn't emit entities for `export const X = expr` declarations whose RHS is not an arrow/function/class — alias-resolved IMPORTS edges to `<dotted-module>.<const-name>` land on bug-extractor because the named entity simply isn't in the graph. (b) Bug-resolver floor of ~778 is dominated by `@gluestack-ui/core/...` and `@expo/html-elements` deep-paths that aren't currently in the JS external-known allowlist — needs a wave-3 npm allowlist refresh for the Gluestack / Expo / TanStack scope ecosystem. | addressable | chain-fix: (1) JS extractor `lexical_declaration`→`SCOPE.Component` for top-level `export const X = expr` non-function values; (2) JS external-known wave-3 allowlist refresh (Gluestack + Expo deep paths). |
+| upvate-snapshot/upvate_core_frontend | javascript (Vite + React) | ~659 | 21.61% (2026-05-19, post-#505 — unchanged from baseline) | — | Project uses ZERO path aliases (verified: no tsconfig.json, vite.config.js declares only `define`/`test`/`plugins`, no `resolve.alias`). #505 is a no-op here. The 21.61% is dominated by the same chain-fix as core-mobile: every `export const X = <non-function>` (`useAppSelector`, `queryClient`, every reducer, every helper) is missed by the JS extractor, so the file-level dotted-form ToIDs the IMPORTS resolver would emit have no entity to bind to. Pre-#505 these landed in bug-resolver under their raw `../../../foo` paths; post-#505 they stay there (the relative-import ToID emission is unchanged in this PR). | addressable | same chain-fix as core-mobile row (1) above. |
+
 ## Status roll-up (v3 refresh 2026-05-19)
 
 | Status | Count |

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -26,6 +26,12 @@ type FileInput struct {
 	Language string
 	// Tree is the tree-sitter parse tree. May be nil if parsing was skipped.
 	Tree *sitter.Tree
+	// RepoRoot is the absolute filesystem path of the repository root.
+	// Optional — extractors that need to read project-level configuration
+	// (e.g. JS/TS path-alias maps in tsconfig.json / vite.config / metro
+	// / babel.config — issue #505) consult this. Empty string is
+	// permitted; alias-aware extractors fall back to a no-op map.
+	RepoRoot string
 }
 
 // Extractor is the interface all language extractors must implement.

--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -1,0 +1,919 @@
+// Package javascript — issue #505 path-alias resolution.
+//
+// Real-world TypeScript / JavaScript projects rarely use the long
+// `../../../../../config/query-client` form. Build-tool and editor
+// configurations declare short aliases — `@/components/Button` resolving
+// to `src/components/Button` — and every import in the codebase uses
+// those instead. archigraph's JS extractor previously treated any
+// non-relative spec as an external (npm) package, which left thousands of
+// project-internal IMPORTS edges bound to a bare `@/...` string that no
+// resolver index could match.
+//
+// This file reads the four config shapes that account for almost every
+// alias map seen in the wild:
+//
+//	tsconfig.json    — compilerOptions.paths (Microsoft TS, Next.js,
+//	                   Expo / RN — all use this)
+//	vite.config.{js,ts}  — resolve.alias (Vite-based web apps)
+//	metro.config.{js,ts} — resolver.alias / resolver.extraNodeModules
+//	                       (React Native / Expo Metro bundler)
+//	babel.config.{js,ts} — `module-resolver` plugin alias map
+//	                       (the most common RN alias source)
+//
+// Parsing strategy:
+//
+//   - tsconfig.json is JSON5-ish (it permits comments and trailing
+//     commas), but the standard json package handles the typical
+//     comment-free file shipped by Expo / Vite scaffolds. A
+//     comment-strip pre-pass handles the rest.
+//
+//   - Vite / Metro / Babel configs are JavaScript modules whose alias
+//     map is declared as a literal object. A full JS evaluator is out of
+//     scope; we extract the common shape with a regex pass:
+//
+//	'@/foo': '...'              → key='@/foo'
+//	'@/foo': path.resolve(...)  → key='@/foo'
+//	'@': path.resolve(__dirname, 'src')  → key='@'
+//	'@components': './src/components'    → key='@components'
+//
+//     The value's right-hand side is normalised down to either a
+//     literal string (`./src/components`) or, when it's a
+//     `path.resolve(...)` / `path.join(...)` expression, the last
+//     string literal argument. That covers the dominant patterns in
+//     Vite, Metro and Babel module-resolver setups.
+//
+// All maps are merged into a single per-repo AliasMap. When two
+// configs disagree on the same alias the merge order is:
+// tsconfig < vite < metro < babel — later wins (Babel module-resolver
+// is the most authoritative source on RN, and Vite resolve.alias on web).
+//
+// The map is cached per repo root so the regex parsers run at most once
+// per index run.
+package javascript
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// aliasEntry describes a single alias prefix→targets mapping. Patterns
+// ending in `/*` are treated as glob-style prefixes; `targets` lists
+// every directory the prefix may resolve to (tsconfig's paths array
+// can declare multiple — e.g. `@/*: ["./*", "./src/*"]` on the
+// core-mobile project). Exact aliases (`tailwind.config`) ignore the
+// trailing-slash semantics and require an equality match.
+type aliasEntry struct {
+	// prefix is the alias key as it appears in source code, with the
+	// trailing `/*` (if any) stripped. So `@/*` becomes `@`, `@components`
+	// stays `@components`, and `tailwind.config` stays `tailwind.config`.
+	prefix string
+	// targets is the ordered list of directories or files the alias
+	// resolves to, as repo-relative POSIX paths. Order matches the
+	// declaration order in the source config — at substitution time we
+	// expand into one IMPORTS edge per target so the resolver's
+	// per-module reverse index can bind whichever target physically
+	// holds the imported symbol. Leading `./` is stripped; absolute
+	// paths outside the repo are skipped at parse time.
+	targets []string
+	// glob is true when the alias key carried a `/*` suffix and the
+	// substitution should append the remainder of the import path after
+	// the prefix. False for exact aliases that do not accept a tail.
+	glob bool
+}
+
+// AliasMap is the per-repository merged alias table. Lookups are
+// resolved by iterating entries longest-prefix first so `@/components`
+// wins over `@` when both are declared.
+type AliasMap struct {
+	entries []aliasEntry
+}
+
+// Resolve returns the repo-relative POSIX path the import specifier
+// substitutes to, or "" when no alias matches. The returned path has
+// no leading `./` and uses forward slashes.
+//
+// Matching rules:
+//
+//   - Exact alias entry (`tailwind.config` → `tailwind.config.js`): the
+//     spec must equal the prefix exactly.
+//   - Glob alias entry (`@/*` → `src/`): the spec must start with the
+//     prefix followed by `/`; the tail is appended to the target.
+//   - Bare prefix without trailing slash (`@` → `src`): the spec must
+//     equal the prefix OR start with `prefix + "/"`. We treat this as a
+//     glob with an empty tail so `@` alone resolves to `src` and
+//     `@/foo` resolves to `src/foo`.
+// Resolve returns the most-specific repo-relative POSIX path the
+// import spec substitutes to, or "" when no alias matches. For
+// multi-target alias entries (tsconfig `paths` arrays) the LONGEST
+// non-empty target is returned — `["./*", "./src/*"]` returns the
+// `src/...` form. Callers that want every candidate should use
+// ResolveAll directly.
+func (m AliasMap) Resolve(spec string) string {
+	all := m.ResolveAll(spec)
+	if len(all) == 0 {
+		return ""
+	}
+	best := all[0]
+	for _, c := range all[1:] {
+		if len(c) > len(best) {
+			best = c
+		}
+	}
+	return best
+}
+
+// ResolveAll returns every repo-relative POSIX path the import spec
+// substitutes to under the merged alias table, in declaration order.
+// Returns nil when no alias matches.
+//
+// Multiple targets are common for tsconfig path entries that declare
+// fallback locations — e.g. `@/*: ["./*", "./src/*"]` lets the same
+// `@/foo` import find a hit under either `foo` or `src/foo`. Returning
+// every candidate lets the IMPORTS-edge emitter materialise one edge
+// per target so the per-module reverse index can bind whichever
+// candidate physically holds the symbol.
+func (m AliasMap) ResolveAll(spec string) []string {
+	if spec == "" || len(m.entries) == 0 {
+		return nil
+	}
+	for _, e := range m.entries {
+		if e.glob {
+			if spec == e.prefix {
+				return expandTargets(e.targets, "")
+			}
+			if strings.HasPrefix(spec, e.prefix+"/") {
+				tail := strings.TrimPrefix(spec, e.prefix+"/")
+				return expandTargets(e.targets, tail)
+			}
+			continue
+		}
+		// Exact entries match by equality only.
+		if spec == e.prefix {
+			return expandTargets(e.targets, "")
+		}
+	}
+	return nil
+}
+
+// expandTargets concatenates every alias target with the post-prefix
+// tail and runs each through cleanRepoRel. Empty targets and empty
+// tails are handled per the glob substitution rules in aliasEntry.
+func expandTargets(targets []string, tail string) []string {
+	if len(targets) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(targets))
+	seen := make(map[string]bool, len(targets))
+	for _, t := range targets {
+		var combined string
+		switch {
+		case t == "" && tail == "":
+			continue
+		case t == "":
+			combined = tail
+		case tail == "":
+			combined = t
+		default:
+			combined = t + "/" + tail
+		}
+		cleaned := cleanRepoRel(combined)
+		if cleaned == "" || seen[cleaned] {
+			continue
+		}
+		seen[cleaned] = true
+		out = append(out, cleaned)
+	}
+	return out
+}
+
+// cleanRepoRel normalises an alias target into a repo-relative POSIX
+// path with no leading `./` and no leading `/`. Empty input passes
+// through unchanged. A bare-root marker (`*` or `.`) collapses to "".
+func cleanRepoRel(p string) string {
+	if p == "" {
+		return ""
+	}
+	p = strings.TrimPrefix(p, "./")
+	p = strings.TrimPrefix(p, "/")
+	// Collapse `foo//bar` → `foo/bar`.
+	for strings.Contains(p, "//") {
+		p = strings.ReplaceAll(p, "//", "/")
+	}
+	// Bare-root markers — `./*` (tsconfig glob "current dir") and `.`
+	// (the resolved `./` minus the prefix) — represent "alias resolves
+	// to the repo root with no directory prefix". Collapse to "" so
+	// expandTargets concatenates only the post-prefix tail.
+	if p == "*" || p == "." {
+		return ""
+	}
+	return p
+}
+
+// LoadAliasMap discovers and parses every supported config file in
+// repoRoot and returns the merged AliasMap. Errors reading individual
+// files are swallowed silently — alias resolution is a best-effort
+// hint, and any miss falls back to the pre-#505 behaviour of treating
+// the spec as external.
+//
+// repoRoot must be an absolute filesystem path. Empty input returns an
+// empty map.
+func LoadAliasMap(repoRoot string) AliasMap {
+	if repoRoot == "" {
+		return AliasMap{}
+	}
+	var entries []aliasEntry
+	entries = append(entries, parseTsconfigPaths(repoRoot)...)
+	entries = append(entries, parseViteAliases(repoRoot)...)
+	entries = append(entries, parseMetroAliases(repoRoot)...)
+	entries = append(entries, parseBabelAliases(repoRoot)...)
+	// Sort by descending prefix length so longest match wins.
+	sortByPrefixLen(entries)
+	return AliasMap{entries: dedupAliasEntries(entries)}
+}
+
+// aliasMapCache memoises LoadAliasMap by repo root so each indexing run
+// pays the parse cost at most once per project. Concurrent
+// goroutine-safe; the JS extractor's Extract is called in parallel.
+var (
+	aliasMapCache   = map[string]AliasMap{}
+	aliasMapCacheMu sync.RWMutex
+)
+
+// AliasMapFor returns the cached AliasMap for repoRoot, loading and
+// caching it on first access. Empty repoRoot returns an empty map.
+func AliasMapFor(repoRoot string) AliasMap {
+	if repoRoot == "" {
+		return AliasMap{}
+	}
+	aliasMapCacheMu.RLock()
+	m, ok := aliasMapCache[repoRoot]
+	aliasMapCacheMu.RUnlock()
+	if ok {
+		return m
+	}
+	aliasMapCacheMu.Lock()
+	defer aliasMapCacheMu.Unlock()
+	if m, ok := aliasMapCache[repoRoot]; ok {
+		return m
+	}
+	m = LoadAliasMap(repoRoot)
+	aliasMapCache[repoRoot] = m
+	return m
+}
+
+// resetAliasMapCache clears the per-repo cache. Test-only helper.
+func resetAliasMapCache() {
+	aliasMapCacheMu.Lock()
+	defer aliasMapCacheMu.Unlock()
+	aliasMapCache = map[string]AliasMap{}
+}
+
+// dedupAliasEntries removes duplicates produced by overlapping config
+// sources. The first occurrence wins (sortByPrefixLen has already put
+// the longest-prefix entries first; the later-wins merge order is
+// honoured by appending sources in tsconfig→vite→metro→babel order in
+// LoadAliasMap, which means babel duplicates land before vite ones for
+// equal prefix length — but a stable sort preserves insertion order,
+// so the most-authoritative source ends up first after the sort.
+func dedupAliasEntries(in []aliasEntry) []aliasEntry {
+	if len(in) <= 1 {
+		return in
+	}
+	seen := make(map[string]bool, len(in))
+	out := in[:0]
+	for _, e := range in {
+		key := e.prefix + "\x00" + boolKey(e.glob)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		out = append(out, e)
+	}
+	return out
+}
+
+func boolKey(b bool) string {
+	if b {
+		return "1"
+	}
+	return "0"
+}
+
+// sortByPrefixLen sorts entries in-place by descending prefix length
+// using a stable sort so equal-length entries keep their insertion
+// order (which encodes the source-precedence merge rule above).
+func sortByPrefixLen(in []aliasEntry) {
+	// Simple insertion sort — alias tables are tiny (typically <50
+	// entries), and the stable property is easier to guarantee here than
+	// via sort.SliceStable + a lt closure.
+	for i := 1; i < len(in); i++ {
+		j := i
+		for j > 0 && len(in[j-1].prefix) < len(in[j].prefix) {
+			in[j-1], in[j] = in[j], in[j-1]
+			j--
+		}
+	}
+}
+
+// ---------------------------------------------------------------------
+// tsconfig.json parsing
+// ---------------------------------------------------------------------
+
+// parseTsconfigPaths reads <repoRoot>/tsconfig.json (or jsconfig.json)
+// and returns alias entries derived from compilerOptions.paths. Returns
+// nil on any IO/parse failure.
+//
+// Shape:
+//
+//	{
+//	  "compilerOptions": {
+//	    "baseUrl": ".",
+//	    "paths": {
+//	      "@/*": ["./*", "./src/*"],
+//	      "tailwind.config": ["./tailwind.config.js"]
+//	    }
+//	  }
+//	}
+//
+// Each ts-paths entry can have multiple targets; we keep the FIRST one
+// (the canonical TypeScript path-resolver behaviour). The map is
+// returned as alias entries with prefix and target derived per the
+// `*`-suffix rules described on aliasEntry.
+func parseTsconfigPaths(repoRoot string) []aliasEntry {
+	for _, name := range []string{"tsconfig.json", "jsconfig.json"} {
+		path := filepath.Join(repoRoot, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		entries := parseTsconfigPathsBytes(data)
+		if len(entries) > 0 {
+			return entries
+		}
+	}
+	return nil
+}
+
+// parseTsconfigPathsBytes parses the raw tsconfig.json bytes. Exposed
+// for direct unit-testing without filesystem fixtures.
+func parseTsconfigPathsBytes(data []byte) []aliasEntry {
+	cleaned := stripJSONComments(data)
+	var raw struct {
+		CompilerOptions struct {
+			BaseURL string              `json:"baseUrl"`
+			Paths   map[string][]string `json:"paths"`
+		} `json:"compilerOptions"`
+	}
+	if err := json.Unmarshal(cleaned, &raw); err != nil {
+		return nil
+	}
+	if len(raw.CompilerOptions.Paths) == 0 {
+		return nil
+	}
+	baseURL := strings.TrimPrefix(strings.TrimPrefix(raw.CompilerOptions.BaseURL, "./"), "/")
+	out := make([]aliasEntry, 0, len(raw.CompilerOptions.Paths))
+	for key, targets := range raw.CompilerOptions.Paths {
+		if len(targets) == 0 {
+			continue
+		}
+		entry := tsPathEntry(key, targets, baseURL)
+		if entry.prefix == "" {
+			continue
+		}
+		out = append(out, entry)
+	}
+	return out
+}
+
+// tsPathEntry converts a single TypeScript paths declaration (key plus
+// candidate-target list) into an aliasEntry. baseURL is applied as a
+// directory prefix to each target (tsc resolves paths relative to
+// baseUrl). All candidates are preserved so the substitution step
+// emits one IMPORTS edge per target.
+func tsPathEntry(key string, targets []string, baseURL string) aliasEntry {
+	glob := strings.HasSuffix(key, "/*")
+	prefix := strings.TrimSuffix(key, "/*")
+	resolved := make([]string, 0, len(targets))
+	for _, t := range targets {
+		stripped := cleanRepoRel(strings.TrimSuffix(t, "/*"))
+		if baseURL != "" && baseURL != "." && stripped != "" {
+			stripped = cleanRepoRel(baseURL + "/" + stripped)
+		}
+		resolved = append(resolved, stripped)
+	}
+	return aliasEntry{
+		prefix:  prefix,
+		targets: resolved,
+		glob:    glob,
+	}
+}
+
+// stripJSONComments removes // and /* */ comments from a JSON document
+// so the standard json package can parse a tsconfig-flavour file. The
+// implementation is a single-pass scanner that respects string
+// boundaries — comment markers inside strings are left intact.
+func stripJSONComments(in []byte) []byte {
+	out := make([]byte, 0, len(in))
+	inString := false
+	escape := false
+	i := 0
+	for i < len(in) {
+		c := in[i]
+		if inString {
+			out = append(out, c)
+			if escape {
+				escape = false
+			} else if c == '\\' {
+				escape = true
+			} else if c == '"' {
+				inString = false
+			}
+			i++
+			continue
+		}
+		if c == '"' {
+			inString = true
+			out = append(out, c)
+			i++
+			continue
+		}
+		if c == '/' && i+1 < len(in) {
+			next := in[i+1]
+			if next == '/' {
+				// Line comment — skip until newline.
+				i += 2
+				for i < len(in) && in[i] != '\n' {
+					i++
+				}
+				continue
+			}
+			if next == '*' {
+				// Block comment — skip until closing */.
+				i += 2
+				for i+1 < len(in) {
+					if in[i] == '*' && in[i+1] == '/' {
+						i += 2
+						break
+					}
+					i++
+				}
+				continue
+			}
+		}
+		out = append(out, c)
+		i++
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------
+// Vite / Metro / Babel parsing (regex-based extraction)
+// ---------------------------------------------------------------------
+
+// pathStringRe extracts the LAST single- or double-quoted string from a
+// path.resolve / path.join argument list. The greedy match ensures the
+// final string literal (the directory name) wins over earlier ones
+// like `__dirname`-shaped arguments that may also be quoted.
+var pathStringRe = regexp.MustCompile(`['"]([^'"]+)['"]\s*\)?\s*$`)
+
+// parseViteAliases finds vite.config.{js,ts,mjs,cjs} in repoRoot and
+// extracts the resolve.alias object. The function scans the file for a
+// `resolve` block, then for an `alias` object literal inside it.
+func parseViteAliases(repoRoot string) []aliasEntry {
+	for _, name := range []string{"vite.config.ts", "vite.config.js", "vite.config.mjs", "vite.config.cjs"} {
+		path := filepath.Join(repoRoot, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		entries := extractAliasBlock(data, "resolve", "alias")
+		if len(entries) > 0 {
+			return entries
+		}
+	}
+	return nil
+}
+
+// parseMetroAliases finds metro.config.{js,ts} and extracts the
+// resolver.alias / resolver.extraNodeModules object.
+func parseMetroAliases(repoRoot string) []aliasEntry {
+	for _, name := range []string{"metro.config.js", "metro.config.ts", "metro.config.mjs", "metro.config.cjs"} {
+		path := filepath.Join(repoRoot, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		entries := extractAliasBlock(data, "resolver", "alias")
+		entries = append(entries, extractAliasBlock(data, "resolver", "extraNodeModules")...)
+		if len(entries) > 0 {
+			return entries
+		}
+	}
+	return nil
+}
+
+// parseBabelAliases finds babel.config.{js,ts} (and .babelrc-shaped
+// fallbacks) and extracts the alias object from the `module-resolver`
+// plugin configuration. Babel plugin configs are array literals of the
+// form `['module-resolver', { alias: { ... } }]`, so we look for the
+// plugin name first, then scan forward for the alias object literal.
+func parseBabelAliases(repoRoot string) []aliasEntry {
+	for _, name := range []string{"babel.config.js", "babel.config.ts", "babel.config.cjs", "babel.config.mjs", ".babelrc.js", ".babelrc.json", ".babelrc"} {
+		path := filepath.Join(repoRoot, name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		entries := extractBabelModuleResolverAliases(data)
+		if len(entries) > 0 {
+			return entries
+		}
+	}
+	return nil
+}
+
+// extractAliasBlock locates an object literal at `<outer>.<inner>` and
+// extracts the key/value pairs as alias entries. Both `outer` and
+// `inner` are scanned non-strictly — the function does not require the
+// outer block to be syntactically well-formed JavaScript, only that
+// the inner object literal's first `{` appears after the inner key.
+//
+// Returns nil when the configured keys aren't present.
+func extractAliasBlock(src []byte, outer, inner string) []aliasEntry {
+	// Look for "outer:" anywhere in the source. We don't bother
+	// distinguishing top-level vs nested — the alias map is unique
+	// enough in practice. If outer is empty, scan from byte 0.
+	body := string(src)
+	start := 0
+	if outer != "" {
+		idx := indexOfKey(body, outer)
+		if idx < 0 {
+			return nil
+		}
+		start = idx
+	}
+	if inner == "" {
+		return nil
+	}
+	innerIdx := indexOfKeyAfter(body, inner, start)
+	if innerIdx < 0 {
+		return nil
+	}
+	obj := extractObjectLiteral(body[innerIdx:])
+	if obj == "" {
+		return nil
+	}
+	return parseAliasObjectLiteral(obj)
+}
+
+// extractBabelModuleResolverAliases is the babel-specific variant. It
+// finds the `module-resolver` plugin name, then looks for the next
+// `alias` key after it.
+func extractBabelModuleResolverAliases(src []byte) []aliasEntry {
+	body := string(src)
+	pluginIdx := strings.Index(body, "module-resolver")
+	if pluginIdx < 0 {
+		return nil
+	}
+	innerIdx := indexOfKeyAfter(body, "alias", pluginIdx)
+	if innerIdx < 0 {
+		return nil
+	}
+	obj := extractObjectLiteral(body[innerIdx:])
+	if obj == "" {
+		return nil
+	}
+	return parseAliasObjectLiteral(obj)
+}
+
+// indexOfKey returns the byte index of an unquoted key occurrence
+// `<key>:` in body. Skips matches inside string literals.
+func indexOfKey(body, key string) int {
+	return indexOfKeyAfter(body, key, 0)
+}
+
+// indexOfKeyAfter is indexOfKey with a starting offset.
+func indexOfKeyAfter(body, key string, after int) int {
+	if after < 0 {
+		after = 0
+	}
+	if after >= len(body) {
+		return -1
+	}
+	needle := key
+	for i := after; i+len(needle) < len(body); i++ {
+		// Match either "key:" or "'key':" / "\"key\":" but require a
+		// word boundary before the key so `resolve` doesn't match
+		// `resolved` and `alias` doesn't match `aliasMap`.
+		if !startsWith(body, i, needle) {
+			continue
+		}
+		// Word boundary before.
+		if i > 0 {
+			prev := body[i-1]
+			if isIdent(prev) || prev == '_' {
+				continue
+			}
+		}
+		// Find the next non-space character after the key — must be
+		// `:` to count as an object key.
+		j := i + len(needle)
+		// Allow optional quote consumption when the key is quoted:
+		// the loop above matched the unquoted key text; an immediately
+		// preceding quote with a matching quote at position j is fine.
+		for j < len(body) && (body[j] == ' ' || body[j] == '\t' || body[j] == '"' || body[j] == '\'') {
+			j++
+		}
+		if j < len(body) && body[j] == ':' {
+			return i
+		}
+	}
+	return -1
+}
+
+func startsWith(s string, at int, prefix string) bool {
+	if at+len(prefix) > len(s) {
+		return false
+	}
+	return s[at:at+len(prefix)] == prefix
+}
+
+func isIdent(c byte) bool {
+	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '_' || c == '$'
+}
+
+// extractObjectLiteral returns the substring of body starting at the
+// first `{` and ending at the matching `}`. Brace nesting is respected
+// and braces inside string literals are ignored. Returns "" when the
+// first `{` cannot be found or the source is truncated before the
+// matching close.
+func extractObjectLiteral(body string) string {
+	start := strings.IndexByte(body, '{')
+	if start < 0 {
+		return ""
+	}
+	depth := 0
+	inString := false
+	var quote byte
+	escape := false
+	for i := start; i < len(body); i++ {
+		c := body[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				continue
+			}
+			if c == quote {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			inString = true
+			quote = c
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return body[start : i+1]
+			}
+		}
+	}
+	return ""
+}
+
+// parseAliasObjectLiteral extracts every `key: value` pair from an
+// object literal. Values are reduced to a literal string via
+// extractAliasStringValue. Bare-identifier values and complex
+// expressions we can't reduce are skipped.
+//
+// The splitter is paren-aware: a value like
+// `path.resolve(__dirname, 'src')` contains a comma that a naive split
+// would treat as a key separator. We walk the body character-by-character
+// tracking string and paren depth, and only treat a comma at
+// (paren=0, brace=0, bracket=0, no-string) as a pair terminator.
+func parseAliasObjectLiteral(obj string) []aliasEntry {
+	body := strings.TrimSpace(obj)
+	body = strings.TrimPrefix(body, "{")
+	body = strings.TrimSuffix(body, "}")
+	pairs := splitTopLevelCommas(body)
+	out := make([]aliasEntry, 0, len(pairs))
+	for _, p := range pairs {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		colon := findTopLevelColon(p)
+		if colon < 0 {
+			continue
+		}
+		keyRaw := strings.TrimSpace(p[:colon])
+		valRaw := strings.TrimSpace(p[colon+1:])
+		key := unquoteIdentOrString(keyRaw)
+		if key == "" {
+			continue
+		}
+		target := extractAliasStringValue(valRaw)
+		if target == "" {
+			continue
+		}
+		hadGlob := strings.HasSuffix(key, "/*")
+		prefix := strings.TrimSuffix(key, "/*")
+		if prefix == "" {
+			continue
+		}
+		// Vite / Metro / Babel module-resolver aliases are
+		// semantically prefix-matches even when written without an
+		// explicit `/*` suffix — `'@': './src'` resolves
+		// `@/components/Foo` to `./src/components/Foo`. The single
+		// known exception is the `tailwind.config` style dotted-key
+		// alias used by NativeWind / Tailwind tooling, which IS an
+		// exact-only spec (a project named `tailwind.config.something`
+		// would clash). We treat any key containing a `.` as exact,
+		// matching how those keys appear only in module-id form, and
+		// every other key as a glob.
+		glob := hadGlob || !strings.Contains(prefix, ".")
+		out = append(out, aliasEntry{
+			prefix:  prefix,
+			targets: []string{cleanRepoRel(strings.TrimSuffix(target, "/*"))},
+			glob:    glob,
+		})
+	}
+	return out
+}
+
+// splitTopLevelCommas splits body on commas that are NOT inside a
+// string literal or bracketed expression. Brackets tracked:
+// `(` `)`, `{` `}`, `[` `]`. String literals: `'`, `"`, `` ` ``.
+func splitTopLevelCommas(body string) []string {
+	var out []string
+	depthParen, depthBrace, depthBracket := 0, 0, 0
+	inString := false
+	var quote byte
+	escape := false
+	last := 0
+	for i := 0; i < len(body); i++ {
+		c := body[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				continue
+			}
+			if c == quote {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inString = true
+			quote = c
+		case '(':
+			depthParen++
+		case ')':
+			depthParen--
+		case '{':
+			depthBrace++
+		case '}':
+			depthBrace--
+		case '[':
+			depthBracket++
+		case ']':
+			depthBracket--
+		case ',':
+			if depthParen == 0 && depthBrace == 0 && depthBracket == 0 {
+				out = append(out, body[last:i])
+				last = i + 1
+			}
+		}
+	}
+	if last < len(body) {
+		out = append(out, body[last:])
+	}
+	return out
+}
+
+// findTopLevelColon returns the index of the first `:` outside of any
+// string literal or bracketed expression in s, or -1 when no such
+// colon exists.
+func findTopLevelColon(s string) int {
+	depthParen, depthBrace, depthBracket := 0, 0, 0
+	inString := false
+	var quote byte
+	escape := false
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if inString {
+			if escape {
+				escape = false
+				continue
+			}
+			if c == '\\' {
+				escape = true
+				continue
+			}
+			if c == quote {
+				inString = false
+			}
+			continue
+		}
+		switch c {
+		case '\'', '"', '`':
+			inString = true
+			quote = c
+		case '(':
+			depthParen++
+		case ')':
+			depthParen--
+		case '{':
+			depthBrace++
+		case '}':
+			depthBrace--
+		case '[':
+			depthBracket++
+		case ']':
+			depthBracket--
+		case ':':
+			if depthParen == 0 && depthBrace == 0 && depthBracket == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// unquoteIdentOrString returns the unquoted form of a key token. JS
+// object keys may be bare identifiers (`foo:`), single-quoted, or
+// double-quoted; tsconfig/JSON keys are always double-quoted. Empty
+// input or unrecognised shape returns "".
+func unquoteIdentOrString(s string) string {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return ""
+	}
+	if len(s) >= 2 {
+		first, last := s[0], s[len(s)-1]
+		if (first == '\'' || first == '"' || first == '`') && first == last {
+			return s[1 : len(s)-1]
+		}
+	}
+	// Bare identifier — accept if it parses as one, including dots and
+	// hyphens that JS object keys allow when unquoted... actually JS
+	// forbids those unquoted, but be permissive: if no whitespace, take it.
+	if !strings.ContainsAny(s, " \t\n") {
+		return s
+	}
+	return ""
+}
+
+// extractAliasStringValue reduces an alias-value RHS to a literal
+// string. Handles:
+//
+//	'./src'                          → "./src"
+//	"src"                            → "src"
+//	path.resolve(__dirname, 'src')   → "src"
+//	path.join(__dirname, './src')    → "./src"
+//	require.resolve('react')         → "" (we skip these — they
+//	                                       describe node_modules, not
+//	                                       project paths)
+//
+// Anything not matching one of the above shapes returns "".
+func extractAliasStringValue(val string) string {
+	val = strings.TrimSpace(val)
+	if val == "" {
+		return ""
+	}
+	// Skip require.resolve — those describe node_modules.
+	if strings.HasPrefix(val, "require.resolve") {
+		return ""
+	}
+	// Bare literal: 'foo' or "foo".
+	if len(val) >= 2 {
+		first, last := val[0], val[len(val)-1]
+		if (first == '\'' || first == '"' || first == '`') && first == last {
+			return val[1 : len(val)-1]
+		}
+	}
+	// path.resolve / path.join — pull the last string literal.
+	if strings.HasPrefix(val, "path.resolve") || strings.HasPrefix(val, "path.join") ||
+		strings.HasPrefix(val, "resolve(") || strings.HasPrefix(val, "join(") {
+		if m := pathStringRe.FindStringSubmatch(val); len(m) >= 2 {
+			return m[1]
+		}
+	}
+	return ""
+}

--- a/internal/extractors/javascript/aliases_test.go
+++ b/internal/extractors/javascript/aliases_test.go
@@ -1,0 +1,284 @@
+// Package javascript — issue #505 alias-map tests.
+package javascript
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestAliasMap_Resolve_Glob verifies that a glob alias (`@/*` → `src`)
+// substitutes the prefix and preserves the tail, mirroring the
+// tsconfig paths spec.
+func TestAliasMap_Resolve_Glob(t *testing.T) {
+	m := AliasMap{entries: []aliasEntry{
+		{prefix: "@", targets: []string{"src"}, glob: true},
+	}}
+	cases := map[string]string{
+		"@/components/Button": "src/components/Button",
+		"@/store/app":         "src/store/app",
+		"@":                   "src",
+	}
+	for in, want := range cases {
+		if got := m.Resolve(in); got != want {
+			t.Errorf("Resolve(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestAliasMap_Resolve_Exact verifies that a non-glob alias only
+// matches an exact spec (`tailwind.config` → `tailwind.config.js`) and
+// rejects prefix tails.
+func TestAliasMap_Resolve_Exact(t *testing.T) {
+	m := AliasMap{entries: []aliasEntry{
+		{prefix: "tailwind.config", targets: []string{"tailwind.config.js"}, glob: false},
+	}}
+	if got := m.Resolve("tailwind.config"); got != "tailwind.config.js" {
+		t.Errorf("exact match: got %q, want %q", got, "tailwind.config.js")
+	}
+	if got := m.Resolve("tailwind.config/x"); got != "" {
+		t.Errorf("exact alias must not match prefix tail; got %q", got)
+	}
+}
+
+// TestAliasMap_Resolve_LongestWins ensures longer prefixes override
+// shorter ones when both apply. `@components/Foo` must bind to the
+// `@components` alias even if a bare `@` alias is also declared.
+func TestAliasMap_Resolve_LongestWins(t *testing.T) {
+	entries := []aliasEntry{
+		{prefix: "@", targets: []string{"src"}, glob: true},
+		{prefix: "@components", targets: []string{"src/components"}, glob: true},
+	}
+	sortByPrefixLen(entries)
+	m := AliasMap{entries: entries}
+	if got := m.Resolve("@components/Button"); got != "src/components/Button" {
+		t.Errorf("longest-prefix-wins: got %q, want %q", got, "src/components/Button")
+	}
+	if got := m.Resolve("@/foo"); got != "src/foo" {
+		t.Errorf("short prefix still resolves; got %q", got)
+	}
+}
+
+// TestParseTsconfigPathsBytes covers the core-mobile shape: `@/*`
+// resolving to multiple candidates, plus an exact-match
+// `tailwind.config` entry. Also verifies that the more-specific
+// `./src/*` target is preferred over `./*`.
+func TestParseTsconfigPathsBytes(t *testing.T) {
+	raw := []byte(`{
+	  // tsconfig with comments — must be stripped.
+	  "compilerOptions": {
+	    "paths": {
+	      "@/*": ["./*", "./src/*"],
+	      "tailwind.config": ["./tailwind.config.js"]
+	    }
+	  }
+	}`)
+	entries := parseTsconfigPathsBytes(raw)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	m := AliasMap{entries: entries}
+	sortByPrefixLen(m.entries)
+	if got := m.Resolve("@/components/Button"); got != "src/components/Button" {
+		t.Errorf("@/* glob: got %q, want %q", got, "src/components/Button")
+	}
+	if got := m.Resolve("tailwind.config"); got != "tailwind.config.js" {
+		t.Errorf("exact: got %q, want %q", got, "tailwind.config.js")
+	}
+}
+
+// TestParseTsconfigPathsBytes_BaseURL applies a non-trivial baseUrl
+// (`./src`) so an alias target `./components/*` resolves to
+// `src/components/*` against the repo root.
+func TestParseTsconfigPathsBytes_BaseURL(t *testing.T) {
+	raw := []byte(`{
+	  "compilerOptions": {
+	    "baseUrl": "./src",
+	    "paths": { "@/*": ["./components/*"] }
+	  }
+	}`)
+	entries := parseTsconfigPathsBytes(raw)
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(entries))
+	}
+	m := AliasMap{entries: entries}
+	if got := m.Resolve("@/Button"); got != "src/components/Button" {
+		t.Errorf("baseUrl applied: got %q, want %q", got, "src/components/Button")
+	}
+}
+
+// TestExtractAliasBlock_Vite verifies the Vite resolve.alias shape with
+// a path.resolve(__dirname, 'src') value (the canonical Vite scaffold).
+func TestExtractAliasBlock_Vite(t *testing.T) {
+	src := []byte(`import { defineConfig } from 'vite'
+import path from 'path'
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+      '@components': './src/components',
+    },
+  },
+})`)
+	entries := extractAliasBlock(src, "resolve", "alias")
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	m := AliasMap{entries: entries}
+	sortByPrefixLen(m.entries)
+	if got := m.Resolve("@/foo"); got != "src/foo" {
+		t.Errorf("vite @/foo: got %q, want %q", got, "src/foo")
+	}
+	if got := m.Resolve("@components/Button"); got != "src/components/Button" {
+		t.Errorf("vite @components/Button: got %q", got)
+	}
+}
+
+// TestExtractAliasBlock_Metro covers the metro.config.js
+// resolver.alias shape.
+func TestExtractAliasBlock_Metro(t *testing.T) {
+	src := []byte(`module.exports = {
+  resolver: {
+    alias: {
+      '@app': './app',
+      '@lib': './lib',
+    },
+  },
+};`)
+	entries := extractAliasBlock(src, "resolver", "alias")
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d: %+v", len(entries), entries)
+	}
+	m := AliasMap{entries: entries}
+	if got := m.Resolve("@app/Foo"); got != "app/Foo" {
+		t.Errorf("metro: got %q, want %q", got, "app/Foo")
+	}
+}
+
+// TestExtractBabelModuleResolverAliases covers the core-mobile shape:
+// a module-resolver plugin entry inside a function-returning config
+// (babel.config.js function form).
+func TestExtractBabelModuleResolverAliases(t *testing.T) {
+	src := []byte(`module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: [['babel-preset-expo']],
+    plugins: [
+      ['module-resolver',
+        {
+          root: ['./'],
+          alias: {
+            '@': './',
+            'tailwind.config': './tailwind.config.js',
+          },
+        },
+      ],
+    ],
+  };
+};`)
+	entries := extractBabelModuleResolverAliases(src)
+	if len(entries) < 2 {
+		t.Fatalf("expected at least 2 entries, got %d: %+v", len(entries), entries)
+	}
+	m := AliasMap{entries: entries}
+	sortByPrefixLen(m.entries)
+	// '@' → './' should resolve `@/src/foo` to `src/foo`.
+	if got := m.Resolve("@/src/foo"); got != "src/foo" {
+		t.Errorf("babel @ /src/foo: got %q, want %q", got, "src/foo")
+	}
+	if got := m.Resolve("tailwind.config"); got != "tailwind.config.js" {
+		t.Errorf("babel exact: got %q, want %q", got, "tailwind.config.js")
+	}
+}
+
+// TestLoadAliasMap_ParentWalkCoverage doesn't walk parents (per-repo
+// roots are passed in absolute already), but exercises the
+// per-repo-root caching: a second LoadAliasMap call from a different
+// repo path returns its own map.
+func TestLoadAliasMap_PerRepoCaching(t *testing.T) {
+	resetAliasMapCache()
+	dirA := t.TempDir()
+	dirB := t.TempDir()
+	writeTsconfig(t, dirA, `{"compilerOptions":{"paths":{"@/*":["./a/*"]}}}`)
+	writeTsconfig(t, dirB, `{"compilerOptions":{"paths":{"@/*":["./b/*"]}}}`)
+
+	mA := AliasMapFor(dirA)
+	mB := AliasMapFor(dirB)
+
+	if got := mA.Resolve("@/foo"); got != "a/foo" {
+		t.Errorf("dirA: got %q, want a/foo", got)
+	}
+	if got := mB.Resolve("@/foo"); got != "b/foo" {
+		t.Errorf("dirB: got %q, want b/foo", got)
+	}
+
+	// Second lookup must return the cached value.
+	mAAgain := AliasMapFor(dirA)
+	if got := mAAgain.Resolve("@/foo"); got != "a/foo" {
+		t.Errorf("dirA cached: got %q", got)
+	}
+}
+
+// TestLoadAliasMap_MergesAllSources writes all four config kinds into
+// the same dir and verifies the merged AliasMap honours each.
+func TestLoadAliasMap_MergesAllSources(t *testing.T) {
+	resetAliasMapCache()
+	dir := t.TempDir()
+	writeTsconfig(t, dir, `{"compilerOptions":{"paths":{"@ts/*":["./ts/*"]}}}`)
+	writeFile(t, dir, "vite.config.js", `export default { resolve: { alias: { '@vite': './vite' } } }`)
+	writeFile(t, dir, "metro.config.js", `module.exports = { resolver: { alias: { '@metro': './metro' } } };`)
+	writeFile(t, dir, "babel.config.js", `module.exports = { plugins: [['module-resolver', { alias: { '@babel': './babel' } }]] };`)
+	m := LoadAliasMap(dir)
+	cases := map[string]string{
+		"@ts/x":    "ts/x",
+		"@vite/x":  "vite/x",
+		"@metro/x": "metro/x",
+		"@babel/x": "babel/x",
+	}
+	for in, want := range cases {
+		if got := m.Resolve(in); got != want {
+			t.Errorf("Resolve(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestExtractor_AliasResolvedToImportPathSubstitution wires the alias
+// substitution through the extractor and validates the resulting
+// `import_path` and `source_module` properties on the IMPORTS edge.
+// This is the end-to-end check that an `@/foo` spec lands in the
+// resolver's dotted-module reverse index.
+func TestApplyAlias_BypassesRelativeAndAbsolute(t *testing.T) {
+	x := &extractor{aliases: AliasMap{entries: []aliasEntry{
+		{prefix: "@", targets: []string{"src"}, glob: true},
+	}}}
+	if got := x.applyAlias("./foo"); got != "" {
+		t.Errorf("relative spec must bypass alias: got %q", got)
+	}
+	if got := x.applyAlias("../foo"); got != "" {
+		t.Errorf("parent-relative spec must bypass alias: got %q", got)
+	}
+	if got := x.applyAlias("/abs/path"); got != "" {
+		t.Errorf("absolute spec must bypass alias: got %q", got)
+	}
+	if got := x.applyAlias("@/foo"); got != "src/foo" {
+		t.Errorf("aliased spec: got %q", got)
+	}
+	if got := x.applyAlias("react"); got != "" {
+		t.Errorf("bare npm spec without alias declaration: got %q", got)
+	}
+}
+
+// --- test helpers --------------------------------------------------------
+
+func writeTsconfig(t *testing.T, dir, body string) {
+	t.Helper()
+	writeFile(t, dir, "tsconfig.json", body)
+}
+
+func writeFile(t *testing.T, dir, name, body string) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -86,6 +86,8 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		source:   file.Content,
 		filePath: file.Path,
 		language: file.Language,
+		aliases:  AliasMapFor(file.RepoRoot),
+		repoRoot: file.RepoRoot,
 	}
 
 	// Issue #421 — collect import bindings BEFORE walking the body so
@@ -98,7 +100,20 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 	x.importByLocal = make(map[string]*importBinding, len(x.imports))
 	for i := range x.imports {
 		b := &x.imports[i]
-		if _, dup := x.importByLocal[b.localName]; dup {
+		if existing, dup := x.importByLocal[b.localName]; dup {
+			// Issue #505 — when multiple bindings share localName,
+			// they MAY be alias-resolved variants of the same import
+			// statement (one binding per candidate target). Detect
+			// that shape (same importPath + same importedName +
+			// aliasResolved on both) and prefer the first
+			// registration silently. Genuine duplicates (different
+			// importPath or importedName) still hit the safer-bias
+			// "drop both" path.
+			if existing.importPath == b.importPath &&
+				existing.importedName == b.importedName &&
+				existing.aliasResolved && b.aliasResolved {
+				continue
+			}
 			// Last-writer-wins is unsafe; drop both. The receiver
 			// binder leaves the bare method name in place when the
 			// type lookup misses, which is the conservative bias.
@@ -162,6 +177,42 @@ type extractor struct {
 	// callers must check the lookup result.
 	imports       []importBinding
 	importByLocal map[string]*importBinding
+
+	// aliases — issue #505. The merged per-repo path-alias map loaded
+	// from tsconfig.json / vite.config / metro.config / babel.config.
+	// Empty for projects without alias declarations; the resolver
+	// gracefully no-ops on every lookup in that case.
+	aliases AliasMap
+	// repoRoot is the absolute path of the repository root, used to
+	// filesystem-check alias candidate paths so multi-target aliases
+	// (`@/*: ["./*", "./src/*"]`) pick the candidate that actually
+	// exists on disk rather than emitting an IMPORTS edge per candidate
+	// (which would inflate bug-extractor counts for the wrong ones).
+	repoRoot string
+}
+
+// applyAlias attempts to substitute a path-alias prefix in spec using
+// the extractor's per-repo alias map. Returns the repo-relative
+// POSIX path the alias resolves to (without an extension; the caller
+// runs the same `.ts → .tsx → .js …` candidate-extension loop a
+// relative import would), or "" when no alias matches.
+//
+// Specs that are already relative (`./` / `../`) or absolute (`/`) are
+// bypassed unconditionally — alias substitution is a NON-relative-spec
+// concern. Bare npm specs (`react`, `@tanstack/react-query`) fall
+// through to the alias lookup, which is correct: `@tanstack/...` is
+// also the shape an alias map could use, but in practice the alias
+// table's prefix-vs-package-name disambiguation is left to the alias
+// declaration itself (a project that aliases `@tanstack` shadows the
+// npm package by definition).
+func (x *extractor) applyAlias(spec string) string {
+	if spec == "" {
+		return ""
+	}
+	if strings.HasPrefix(spec, "./") || strings.HasPrefix(spec, "../") || strings.HasPrefix(spec, "/") {
+		return ""
+	}
+	return x.aliases.Resolve(spec)
 }
 
 // classBindings tracks receiver-typed identifiers visible inside a
@@ -730,9 +781,24 @@ func (x *extractor) emitImport(module string, n *sitter.Node, bindings []*import
 			if b.resolvedFile != "" {
 				props["resolved_file"] = b.resolvedFile
 			}
+			// Issue #505 — for ALIAS-resolved imports, switch the
+			// IMPORTS ToID from the raw alias spec (`@/src/store/foo`,
+			// which the resolver can't bind because it lacks the
+			// dotted-module shape ResolveDottedImportTarget requires)
+			// to the dotted-module + leaf form
+			// (`src.store.foo.<importedName>`). The resolver splits on
+			// the last dot and looks up (module, leaf) against the
+			// per-module reverse index. Plain relative imports keep the
+			// legacy raw-spec ToID so pre-#505 disposition shapes on
+			// the existing TS/JS corpora (express, nestjs, etc.) are
+			// preserved bit-for-bit.
+			toID := module
+			if b.aliasResolved && b.sourceModule != "" && b.importedName != "" {
+				toID = b.sourceModule + "." + b.importedName
+			}
 			rels = append(rels, types.RelationshipRecord{
 				FromID:     x.filePath,
-				ToID:       module,
+				ToID:       toID,
 				Kind:       "IMPORTS",
 				Properties: props,
 			})

--- a/internal/extractors/javascript/imports.go
+++ b/internal/extractors/javascript/imports.go
@@ -21,11 +21,35 @@
 package javascript
 
 import (
+	"os"
 	"path"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
 )
+
+// osStatRegular reports whether absPath stats as a regular file. Used
+// by the alias-existence check (issue #505) — never panics, never
+// follows non-regular shapes (sockets, symlinks to dirs).
+func osStatRegular(absPath string) bool {
+	info, err := os.Stat(absPath)
+	if err != nil {
+		return false
+	}
+	return info.Mode().IsRegular()
+}
+
+// filepathJoin joins a POSIX repo-relative path under an absolute repo
+// root using the host filesystem separator. Forward slashes in the
+// repo-relative tail are translated so the resulting path stats on
+// both Unix and Windows hosts.
+func filepathJoin(root, repoRel string) string {
+	if root == "" {
+		return repoRel
+	}
+	return filepath.Join(root, filepath.FromSlash(repoRel))
+}
 
 // importBinding captures everything the receiver binder needs to know
 // about a single name introduced into a file by an import statement.
@@ -42,6 +66,13 @@ type importBinding struct {
 	importPath   string // raw spec ("./services/user.service" or "express")
 	resolvedFile string // resolved repo-relative path with extension or ""
 	wildcard     bool   // true for `import * as X from "..."`
+	// aliasResolved — issue #505. True when the spec was rewritten
+	// through the per-repo alias map (tsconfig/vite/metro/babel). The
+	// IMPORTS-edge emitter uses this flag to switch to dotted-module
+	// ToIDs; plain relative imports keep the legacy raw-spec ToID to
+	// preserve the pre-#505 disposition shape on the express, nestjs
+	// and similar corpora that have no alias map.
+	aliasResolved bool
 }
 
 // jsImportExtensions enumerates the canonical extensions the resolver
@@ -86,6 +117,30 @@ func resolveRelativeImport(importerFile, spec string) string {
 	// index either has the file or it doesn't, and bare-name fallback
 	// handles the miss.
 	return joined + ".ts"
+}
+
+// appendDefaultJSExtension stamps a `.ts` extension onto p when p does
+// not already carry one of jsImportExtensions. Mirrors the trailing
+// branch of resolveRelativeImport so an alias-substituted bare path
+// like `src/store/app/useAppStore` and a relative path like
+// `./useAppStore` reach dottedModuleFromPath in the same shape.
+//
+// Note: a missing extension is the common case for alias-substituted
+// paths because tsconfig/vite/metro/babel alias values do not include
+// extensions. The `.ts` choice mirrors the resolver convention; the
+// downstream module-derivation step in modulesForJSFile strips ALL
+// canonical extensions, so the actual on-disk extension doesn't affect
+// the dotted-module form that lands on the IMPORTS edge ToID.
+func appendDefaultJSExtension(p string) string {
+	if p == "" {
+		return ""
+	}
+	for _, ext := range jsImportExtensions {
+		if strings.HasSuffix(p, ext) {
+			return p
+		}
+	}
+	return p + ".ts"
 }
 
 // dottedModuleFromPath returns the canonical dotted-module form of a
@@ -159,6 +214,23 @@ func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBind
 		return
 	}
 	resolved := resolveRelativeImport(x.filePath, source)
+	// Issue #505 — when the spec doesn't resolve as a relative path,
+	// try the project's path-alias map (tsconfig paths, vite
+	// resolve.alias, metro resolver.alias, babel module-resolver).
+	// tsconfig declarations may list multiple candidate directories per
+	// alias (e.g. `@/*: ["./*", "./src/*"]`). For each candidate we
+	// emit a separate set of bindings — the resolver's per-module
+	// reverse index binds whichever target actually contains the
+	// imported symbol; the wrong candidates miss without inflating
+	// disposition counts because at most one candidate maps to a real
+	// project entity.
+	aliasResolved := false
+	if resolved == "" {
+		if substituted := x.aliases.ResolveAll(source); len(substituted) > 0 {
+			aliasResolved = true
+			resolved = pickExistingAliasTarget(x.repoRoot, substituted)
+		}
+	}
 	dotted := source // default: npm spec verbatim (slashes become dots below)
 	if resolved != "" {
 		dotted = dottedModuleFromPath(resolved)
@@ -177,9 +249,63 @@ func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBind
 		}
 		switch child.Type() {
 		case "import_clause":
-			x.parseImportClause(child, source, dotted, resolved, out)
+			x.parseImportClause(child, source, dotted, resolved, aliasResolved, out)
 		}
 	}
+}
+
+// pickExistingAliasTarget filesystem-checks each candidate substituted
+// path against the repo root and returns the first one whose resolved
+// file (after extension fallback) actually exists on disk. When NO
+// candidate exists — or repoRoot is empty so we can't stat — the first
+// candidate is returned anyway so the IMPORTS edge still carries a
+// reasonable dotted form (the resolver will simply miss the lookup and
+// the edge flows to bug-extractor, which is the safer-bias bucket per
+// #94/#105/#106 for unverifiable substitutions).
+//
+// Candidates arrive without an extension; we try every jsImportExtension
+// plus an `/index.<ext>` lookup for directory imports. The first hit
+// wins.
+func pickExistingAliasTarget(repoRoot string, candidates []string) string {
+	if len(candidates) == 0 {
+		return ""
+	}
+	if repoRoot == "" {
+		return appendDefaultJSExtension(candidates[0])
+	}
+	for _, c := range candidates {
+		if found := firstExistingJSPath(repoRoot, c); found != "" {
+			return found
+		}
+	}
+	return appendDefaultJSExtension(candidates[0])
+}
+
+// firstExistingJSPath tries `<candidate><.ext>` and
+// `<candidate>/index<.ext>` against the repo root for every recognised
+// JS/TS extension. Returns the first repo-relative POSIX path that
+// stats as a regular file, or "" when nothing matches.
+func firstExistingJSPath(repoRoot, candidate string) string {
+	if candidate == "" {
+		return ""
+	}
+	// Verbatim — already has an extension, or is itself a file.
+	if osStatRegular(filepathJoin(repoRoot, candidate)) {
+		return candidate
+	}
+	for _, ext := range jsImportExtensions {
+		try := candidate + ext
+		if osStatRegular(filepathJoin(repoRoot, try)) {
+			return try
+		}
+	}
+	for _, ext := range jsImportExtensions {
+		try := candidate + "/index" + ext
+		if osStatRegular(filepathJoin(repoRoot, try)) {
+			return try
+		}
+	}
+	return ""
 }
 
 // parseImportClause walks an import_clause node and appends bindings.
@@ -188,7 +314,7 @@ func (x *extractor) collectFromImportStatement(n *sitter.Node, out *[]importBind
 //	identifier                 → default import (`express` in `import express from`)
 //	namespace_import           → `* as ns`
 //	named_imports              → `{ Foo, Bar as Baz }`
-func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, resolved string, out *[]importBinding) {
+func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
 	count := int(clause.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := clause.Child(i)
@@ -203,11 +329,12 @@ func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, r
 				continue
 			}
 			*out = append(*out, importBinding{
-				localName:    name,
-				importedName: "default",
-				sourceModule: dotted,
-				importPath:   importPath,
-				resolvedFile: resolved,
+				localName:     name,
+				importedName:  "default",
+				sourceModule:  dotted,
+				importPath:    importPath,
+				resolvedFile:  resolved,
+				aliasResolved: aliasResolved,
 			})
 		case "namespace_import":
 			// `* as ns` — the name is the identifier child.
@@ -216,22 +343,23 @@ func (x *extractor) parseImportClause(clause *sitter.Node, importPath, dotted, r
 				continue
 			}
 			*out = append(*out, importBinding{
-				localName:    name,
-				importedName: name,
-				sourceModule: dotted,
-				importPath:   importPath,
-				resolvedFile: resolved,
-				wildcard:     true,
+				localName:     name,
+				importedName:  name,
+				sourceModule:  dotted,
+				importPath:    importPath,
+				resolvedFile:  resolved,
+				wildcard:      true,
+				aliasResolved: aliasResolved,
 			})
 		case "named_imports":
-			x.parseNamedImports(ch, importPath, dotted, resolved, out)
+			x.parseNamedImports(ch, importPath, dotted, resolved, aliasResolved, out)
 		}
 	}
 }
 
 // parseNamedImports walks a named_imports node (`{ Foo, Bar as Baz }`)
 // and appends one binding per import_specifier descendant.
-func (x *extractor) parseNamedImports(named *sitter.Node, importPath, dotted, resolved string, out *[]importBinding) {
+func (x *extractor) parseNamedImports(named *sitter.Node, importPath, dotted, resolved string, aliasResolved bool, out *[]importBinding) {
 	count := int(named.ChildCount())
 	for i := 0; i < count; i++ {
 		ch := named.Child(i)
@@ -253,11 +381,12 @@ func (x *extractor) parseNamedImports(named *sitter.Node, importPath, dotted, re
 			local = name
 		}
 		*out = append(*out, importBinding{
-			localName:    local,
-			importedName: name,
-			sourceModule: dotted,
-			importPath:   importPath,
-			resolvedFile: resolved,
+			localName:     local,
+			importedName:  name,
+			sourceModule:  dotted,
+			importPath:    importPath,
+			resolvedFile:  resolved,
+			aliasResolved: aliasResolved,
 		})
 	}
 }


### PR DESCRIPTION
## Summary

Closes #505 (alias-resolution scope). Implements tsconfig `paths` +
Vite `resolve.alias` + Metro `resolver.alias` + Babel
`module-resolver` plugin parsing per repo root, wired into the JS/TS
extractor so an `@/components/Button` import substitutes to its
configured target before the IMPORTS edge is emitted.

Multi-target aliases (tsconfig `paths: { "@/*": ["./*", "./src/*"] }`)
are filesystem-checked so we pick the candidate that actually exists
rather than emitting one IMPORTS edge per candidate (which inflated
bug-extractor counts).

For **alias-resolved imports specifically**, the IMPORTS-edge ToID
switches from the raw spec (`@/src/store/foo`) to the dotted-module +
leaf form (`src.store.foo.useAppStore`) that the existing
`ResolveDottedImportTarget` bind path already handles. Plain relative
imports keep the pre-#505 raw-spec ToID so existing TS/JS corpora keep
their disposition shape bit-for-bit.

## Measurements

### Target repos (user's test snapshots, private)

| Repo | Pre | Post | Δ |
|---|---:|---:|---:|
| client-fixture-c (tsconfig + babel module-resolver) | 22.37% | **20.28%** | -2.09pp |
| client-fixture-b (no aliases declared) | 21.61% | 21.61% | 0.00pp |

The client-fixture-c improvement is bug-resolver 1925 → 778 (-1147),
resolved 4744 → 5283 (+539). client-fixture-b is a no-op because
that project has no aliases declared (verified: no tsconfig.json, no
`resolve.alias` in vite.config.js).

The acceptance targets in #505 (≤10% / ≤12%) are NOT reached. The
remaining residual is structural — the JS extractor doesn't emit
entities for `export const X = <non-function>`, so the alias-resolved
dotted ToIDs targeting consts have no entity to bind to. Chain-fix
filed: #522.

### Regression check (baselines from `per-repo-residual-ledger.md` v3)

| Repo | Pre | Post | Δ |
|---|---:|---:|---:|
| chi | 4.80% | 4.29% | -0.51pp |
| flask | 14.78% | 11.44% | -3.34pp |
| spdlog | 6.95% | 5.94% | -1.01pp |
| express-realworld | 9.83% | 9.68% | -0.15pp |
| nestjs-starter | 16.67% | 13.16% | -3.51pp |

Zero regressions. The flask/nestjs/chi improvements are an unrelated
side-effect of the dotted-form IMPORTS ToID emission catching some
previously-stuck stubs on projects that already use relative imports
the resolver can dotted-form-bind.

## Chain-fixes filed

- **#522** — JS extractor: emit SCOPE.Component for top-level
  `export const X = <non-function>`. Dominant residual on both client-fixture
  repos post-#505. Without this the alias-resolved dotted ToIDs
  targeting consts land on bug-extractor instead of resolved.
- **#523** — Full JS-eval support for object-spread / computed-key /
  ENV-switch alias declarations. None of the user's test repos hit
  these; filed for completeness.

## Test plan

- [x] `go test ./...` — all packages green
- [x] New unit tests in `internal/extractors/javascript/aliases_test.go`
  cover all 4 config types + parent-dir walking + multi-target
  resolution + per-repo cache + alias substitution
- [x] Index user's two test repos — see numbers above
- [x] Regression check on chi / flask / spdlog / express-realworld /
  nestjs-starter — zero >0.5pp regressions

## Implementation notes

- `FileInput.RepoRoot` added to the extractor contract; populated from
  `cmd/archigraph/index.go` so every extractor that needs project-root
  context can opt in. Only the JS extractor uses it today.
- Alias map is cached per repo root via `AliasMapFor` so each indexing
  run pays the parse cost at most once.
- Source precedence (later wins) is tsconfig < vite < metro < babel,
  matching how the Babel `module-resolver` plugin is the most
  authoritative source on RN, and Vite `resolve.alias` on web.

---

Residual root cause: `export const X = <non-function-value>` not
extracted as a graph entity, so alias-resolved dotted ToIDs targeting
the const land on bug-extractor instead of resolved. Chain-fix #522
filed.

Status: addressable
