### PR TITLE
[#511] cross-repo linker: filter line-number-keyed shared_label noise

### DIFF
--- a/internal/links/label_pass.go
+++ b/internal/links/label_pass.go
@@ -2,9 +2,16 @@ package links
 
 import (
 	"math"
+	"regexp"
 	"sort"
 	"strings"
 )
+
+// lineNumberSuffix matches labels ending in `:<digits>` (e.g.
+// `error_handling:try_catch:110`). Line numbers are pure positional
+// coincidence across repos and produce noise-only matches in the
+// cross-repo label channel — see issue #511.
+var lineNumberSuffix = regexp.MustCompile(`:\d+$`)
 
 // labelStopList is the set of generic names that should never produce
 // a shared-label match — they are too common across codebases to carry
@@ -42,6 +49,13 @@ const (
 func normalizeLabel(name string) string {
 	s := strings.TrimSpace(name)
 	if s == "" {
+		return ""
+	}
+	// Drop line-number-keyed labels (see #511). Any label whose final
+	// segment is a bare integer (`foo:bar:110`, `route:42`) is a
+	// positional artefact, not a structural identifier, and cross-repo
+	// matches on it are pure coincidence.
+	if lineNumberSuffix.MatchString(s) {
 		return ""
 	}
 	// Strip suffixes (case-sensitive for the CamelCase variants;

--- a/internal/links/links_test.go
+++ b/internal/links/links_test.go
@@ -167,6 +167,87 @@ func TestLabelPass_HighConfidenceForRareLabel(t *testing.T) {
 	}
 }
 
+func TestLabelPass_LineNumberKeyedLabelsDropped(t *testing.T) {
+	// Regression for #511. Labels whose final segment is a bare integer
+	// (e.g. `error_handling:try_catch:110`) are line-number-keyed and
+	// must not produce cross-repo links — line-number coincidence is not
+	// signal.
+	root := fixtureRoot(t)
+	mkNoise := func(prefix string, n int) []map[string]any {
+		out := []map[string]any{}
+		for i := 0; i < n; i++ {
+			out = append(out, map[string]any{
+				"id":          prefix + "n" + itoa(i),
+				"name":        prefix + "_unique_" + itoa(i),
+				"kind":        "function",
+				"source_file": "f.py",
+			})
+		}
+		return out
+	}
+	a := append(mkNoise("a_", 30),
+		map[string]any{"id": "a1", "name": "error_handling:try_catch:110", "kind": "block", "source_file": "src/a.go"},
+		map[string]any{"id": "a2", "name": "AGENTS.md", "kind": "file", "source_file": "AGENTS.md"},
+		map[string]any{"id": "a3", "name": "route:/users/{id}", "kind": "route", "source_file": "src/r.go"},
+	)
+	b := append(mkNoise("b_", 30),
+		map[string]any{"id": "b1", "name": "error_handling:try_catch:110", "kind": "block", "source_file": "lib/b.py"},
+		map[string]any{"id": "b2", "name": "AGENTS.md", "kind": "file", "source_file": "AGENTS.md"},
+		map[string]any{"id": "b3", "name": "route:/users/{id}", "kind": "route", "source_file": "lib/r.py"},
+	)
+	writeFixture(t, root, fixtureGraph{Repo: "alpha", Entities: a})
+	writeFixture(t, root, fixtureGraph{Repo: "beta", Entities: b})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g511", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g511-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var keptFile, keptRoute bool
+	for _, l := range doc.Links {
+		if l.Method != MethodLabelMatch || l.Identifier == nil {
+			continue
+		}
+		id := *l.Identifier
+		if strings.HasPrefix(id, "error_handling:try_catch:") {
+			t.Errorf("line-number-keyed label produced a link: %+v", l)
+		}
+		if id == "agents.md" {
+			keptFile = true
+		}
+		if id == "route:/users/{id}" {
+			keptRoute = true
+		}
+	}
+	if !keptFile {
+		t.Errorf("expected filename label `agents.md` to still produce a link, got %+v", doc.Links)
+	}
+	if !keptRoute {
+		t.Errorf("expected structural label `route:/users/{id}` to still produce a link, got %+v", doc.Links)
+	}
+}
+
+func TestNormalizeLabel_DropsLineNumberSuffix(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"error_handling:try_catch:110", ""},
+		{"error_handling:try_catch:1", ""},
+		{"route:42", ""},
+		{"agents.md", "agents.md"},
+		{"route:/users/{id}", "route:/users/{id}"},
+		{"OrderBook", "orderbook"},
+	}
+	for _, tc := range cases {
+		if got := normalizeLabel(tc.in); got != tc.want {
+			t.Errorf("normalizeLabel(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestKindCompat_ClassInterface(t *testing.T) {
 	if got := kindCompat("class", "interface"); got != 0.85 {
 		t.Errorf("class↔interface: want 0.85, got %v", got)


### PR DESCRIPTION
## Summary

Fixes #511. Cross-repo `shared_label` channel was emitting noise from labels keyed by line number (e.g. `error_handling:try_catch:110`). Two unrelated try/catch blocks starting on the same line in different repos were getting linked — pure positional coincidence, zero signal.

Filter in `normalizeLabel`: any label whose final segment matches `:\d+$` is dropped before TF-IDF scoring. Filename labels (`agents.md`, `claude.md`) and structural labels (`route:/users/{id}`) are preserved.

## Verification (client-fixture group, 3 repos)

**Before:** 375 shared_label links
**After:**  171 shared_label links (-54%)

All 204 line-number-keyed labels eliminated. Surviving labels are filename matches, package names, and bare identifiers (a separate noise cohort tracked elsewhere).

```
Surviving labels sample:
  @tanstack/react-query, addeventlistener, addnoteattachments, agents.md, all,
  aws-amplify, aws-amplify/auth, axios, bitbucket-pipelines.yml, buildingdetails,
  catch, claude.md, cleartimeout, createinspectiondeficiency, decodeuricomponent,
  deleteinspectiondeficiency, deleteinspectionsfromgroup, deletenote, dispatch,
  endswith
```

## Tests

- `TestLabelPass_LineNumberKeyedLabelsDropped` — regression for #511: confirms `error_handling:try_catch:110` ↔ `error_handling:try_catch:110` produces zero links while `agents.md` and `route:/users/{id}` are preserved.
- `TestNormalizeLabel_DropsLineNumberSuffix` — unit coverage of the regex filter against representative inputs.
- Full suite green (`go test ./...`).

## Residual root cause

Line-number-keyed label cohort is eliminated. Remaining noise in the channel comes from a different cohort: bare common identifiers (`catch`, `all`, `dispatch`, `addeventlistener`, …) and package-name labels (`axios`, `aws-amplify`). The stop-list in `label_pass.go` is partial and predates per-language extractors emitting language stdlib names. Tracked separately.

## Status

at-ship-gate for the line-number-keyed cohort (#511 closed). Broader bare-name / stdlib-name shared_label noise remains and should get its own follow-up ticket.

## Test plan

- [x] `go build -o build/archigraph ./cmd/archigraph`
- [x] `go test ./...` — all green
- [x] `build/archigraph rebuild client-fixture` — link count drops 375 → 171
- [x] No `error_handling:try_catch:NNN` labels in surviving links
