### PR TITLE
[ADR-0015] residual repair: agent-side enrichment for v1.0 ship-gate

### DIFF
--- a/docs/adrs/0015-residual-repair-agent-enrichment.md
+++ b/docs/adrs/0015-residual-repair-agent-enrichment.md
@@ -1,4 +1,4 @@
-# ADR-0016: Residual repair via agent-side enrichment
+# ADR-0015: Residual repair via agent-side enrichment
 
 - **Status**: Proposed
 - **Date**: 2026-05-19
@@ -11,13 +11,13 @@ archigraph's resolver classifies every cross-symbol reference into one of seven 
 
 - synthetic ship-gate corpus: 12% bug-rate
 - `django-realworld`: 7.83%
-- `client-fixture-a` group: 11.34% across three repos (per current ship-gate state)
+- `client-fixture` group: 11.34% across three repos (per current ship-gate state)
 
-The strategy used through sprints 14-18 was per-language allowlist expansion: every wave (#494 receiver-type primitive, #533 dynamic URL match, #535 React npm allowlist, #525/#526/#527 in flight) pushed the bug-rate down by chipping at one framework's idioms inside `internal/external/synth.go` (currently 11,333 lines) and `internal/resolve/refs.go` (3,196 lines). Each wave costs multi-day engineering and only buys a fixed-stack improvement.
+The strategy used through sprints 14-18 was per-language allowlist expansion: every wave (#494 receiver-type primitive, #533 dynamic URL match, #535 React npm allowlist, #525/#526/#527 in flight) pushed the bug-rate down by chipping at one framework's idioms inside `internal/external/synth.go` (currently 11,333 lines) and `internal/resolve/refs.go` (3,196 lines). That work is genuinely effective for popular, stable stacks (React, Django, Flask, SwiftNIO, etc.) — it is cheap, deterministic, free, offline, and reduces the workload of any downstream pass. It will continue. What it does not cover is the long tail: novel/obscure frameworks the indexer hasn't been taught, dynamic URL construction, runtime/distributed edges, and ambiguities that need 50 lines of semantic context to resolve.
 
-Meanwhile, since #15 we have already run an agent-driven loop for *subjective* enrichment (entity descriptions, domain classification, role descriptions). The mechanics — emit a candidate JSON, let an LLM-equipped agent reason over it, merge back on the next index — are proven in `internal/enrichment/candidates.go`. We have an MCP server (`internal/mcp/server.go`, `internal/mcp/tools.go`) the agent already speaks to. The architectural ingredients to push the *residual* through the same loop are all in place; they have not been wired up because the bug-rate work has been treated as an indexer problem.
+Since #15 we have already run an agent-driven loop for *subjective* enrichment (entity descriptions, domain classification, role descriptions). The mechanics — emit a candidate JSON, let an LLM-equipped agent reason over it, merge back on the next index — are proven in `internal/enrichment/candidates.go`. We have an MCP server (`internal/mcp/server.go`, `internal/mcp/tools.go`) the agent already speaks to. The architectural ingredients to push the residual through the same loop are all in place; they have not been wired up yet.
 
-This ADR makes the pivot: bug-extractor + bug-resolver residuals become a first-class enrichment surface, the agent does the per-call-site reasoning the indexer cannot, and the indexer becomes responsible for *applying* and *verifying* — not *guessing*.
+This ADR adds residual repair as a **first-class indexer phase that complements deterministic static analysis**, not a replacement for it. Indexer continues to be the deterministic default for everything statically visible (and per-language waves continue to land for popular stable stacks); repair is the long-tail closure path for what static analysis structurally cannot reach. Both ship in v1.0.
 
 ADR-0007 already established the doc-as-bridge precedent for dynamic edges; this ADR generalizes that pattern to the structural residual.
 
@@ -44,14 +44,16 @@ The architectural rule: **the indexer is the source of truth for structure that 
 
 ### Positive
 
-- v1.0 ships with a bug-rate floor independent of how exotic the user's stack is. New frameworks no longer require a release.
-- The multi-day per-language allowlist work (#494, #535, #494, future waves) becomes optional optimization rather than ship-gate-blocking.
+- v1.0 ships with a bug-rate floor independent of how exotic the user's stack is. Novel/obscure frameworks no longer block a release on a per-language wave.
+- Per-language allowlist work for popular stable frameworks continues to land and continues to pay — it always reduces the work the agent has to do for the typical case, keeping the deterministic path fast/free/offline. Repair is additive, not substitutive.
 - Cross-repo dynamic edges (#510, #533, #534) and runtime edges (#515) get a viable resolution path that was previously stuck on "we cannot see this from source."
 - Source-attribution turns the graph from "trust the binary" to "audit the binary"; every controversial edge has a `reasoning` string the user can read.
 - Generalizes ADR-0007: docs were the bridge for dynamic content, the agent loop is the bridge for ambiguous structural content. Same architecture, different surface.
 
 ### Negative
 
+- Increases schema surface area: `enrichment-candidates.json` gets a new `kind`, a new sibling file (`repair.json`) appears, and a new stats file (`repair_stats.json`) is emitted. Two new MCP tools (`list_residuals`, `submit_repair`) join the existing surface and must be kept compatible across releases.
+- Introduces an LLM-cost line item for the user during the repair pass. The deterministic indexer remains free/offline; the repair pass spends one round-trip per residual edge to the user's chosen agent.
 - Adds a new failure mode: a misbehaving agent (or hostile `repair.json`) can degrade the graph. Mitigation: strict allowlisted resolutions, verification step rejects invalid targets, `source: agent-repair` makes every edge auditable, `rm .archigraph/repair.json && archigraph index` reverts to pure-static.
 - Bug-rate is no longer a property of "what archigraph the binary knows"; it now depends on whether the user has run an agent loop. We must update README + verify2 docs so users do not see 12% on a fresh index and think the tool is broken.
 - Adds a second sibling-file pair to `.archigraph/` — `repair.json` and `repair_stats.json`. Inventory of `.archigraph/` is starting to grow; we should produce a `.archigraph/README.md` describing each file's purpose.
@@ -110,7 +112,7 @@ Source-attribution: every endpoint touched by `repair.Apply` gets a `properties[
 1. **Hostile or buggy agent corrupting the graph.** Mitigation: allowlisted resolutions, verification step rejects (a) `bind_to_entity` targets that do not exist in the current document, (b) repairs that introduce self-loops, (c) repairs that contradict an existing `CONTAINS` hierarchy, (d) repairs whose `module` is not a syntactically valid identifier (no path traversal). Every rejection is logged with a stable reason code.
 2. **Repair staleness when code outruns the agent.** Mitigation: `edge_id` is content-hash-bound; when source moves, `edge_id` changes; stale repairs fall off naturally and are listed in `repair_stats.json` so the agent knows to redo them.
 3. **Agent throughput on large repos.** A 5k-residual graph is several thousand LLM round-trips. Mitigation lives in Phase 3 (centrality ordering, batch submit). Phase 1 ships the synchronous loop and accepts the latency.
-4. **Two competing residual closures.** The per-language allowlist work in `internal/external/synth.go` keeps closing things over time. If both lanes run, the indexer wins (it runs first); the repair lane just sees a smaller residual. Not a correctness risk but an opportunity to retire allowlist waves whose bug-rate the agent already covers.
+4. **Two complementary residual closures.** The per-language allowlist work in `internal/external/synth.go` keeps closing things over time for popular stable stacks. If both lanes run, the indexer wins (it runs first, deterministically); the repair lane just sees a smaller residual. This is the intended both-and steady state, not a competition — the indexer keeps owning the typical case and the repair lane handles what static analysis structurally can't reach.
 5. **`repair.json` grows unboundedly.** On long-lived repos with churn, stale records accumulate. Mitigation: `repair_stats.json` reports stale count; a future `archigraph repair gc` command (out of scope for Phase 1) prunes by configurable retention. **OPEN QUESTION:** should stale repairs be auto-pruned on apply, or kept as audit history?
 6. **Conflicting repairs for the same `edge_id`.** Two agents writing concurrently. Mitigation: `submit_repair` writes atomically (write-temp-then-rename) and is last-writer-wins by `resolved_at` timestamp. **OPEN QUESTION:** is last-writer-wins acceptable, or do we want optimistic concurrency via a `previous_resolved_at` parameter?
 
@@ -125,22 +127,34 @@ Source-attribution: every endpoint touched by `repair.Apply` gets a `properties[
 
 ## Issue impact
 
-### Becomes OBSOLETE if this lands
+This ADR is **both-and**, not a replacement for per-language work. The split below mirrors the corrected #543 umbrella.
 
-- **#494** — receiver-variable-type-tracking primitive in `internal/external/synth.go`. Multi-day work; agent covers it via 50-line context-read.
-- **#535** — React npm allowlist (~50 packages). Agent recognizes any npm package by name string with no allowlist.
-- **All future per-language `synth.go` allowlist waves** for frameworks the user can name. (Existing waves can finish if already in flight.)
+### STAY indexer-side (continue normally)
 
-### Becomes UNBLOCKED if this lands
+- **#525** — EXTENDS kind-disambiguator: pure resolver fix, cheap, deterministic, halves Python residual.
+- **#526** — DRF ViewSet class-attribute extraction: structural, no semantic context needed.
+- **#527** — Django URLConf module binder: structural cross-language extractor enhancement.
+- **#535** — React npm allowlist (~50 packages): stable popular libs, 100-line PR saves thousands of LLM calls per index.
+- **#537** — barrel re-export resolution: pure AST work.
+- **#494 for statically-typed languages** (Go, Java, Kotlin, Swift): type info is in the AST, no LLM needed.
+- All Phase-1 work and any future per-language wave for **popular stable frameworks** continues on the indexer side.
 
-- **#510** — cross-repo HTTP route matching. Agent can match dynamic URLs the static resolver gives up on.
-- **#515** — runtime-edge discovery (Celery task strings, queue names). Agent can read context and decide.
-- **#533** — dynamic URL pattern matching. Generalized by repair loop.
-- **#534** — same family as #533.
+### BECOME REPAIR-FIRST (indexer emits candidates; agent matches/resolves)
 
-### Remain ORTHOGONAL (in flight, will land)
+- **#494 for dynamic languages** (Python, Ruby, JS): receiver-type inference needs semantic context; the agent does it better.
+- **#510 / #533 / #534** — HTTP route ↔ fetch matching, dynamic URL pattern matching: dynamic URLs are intractable statically, trivial for an LLM.
+- **#515** — runtime/distributed edges (Celery task strings, queue names, pub/sub topics): string-based cross-file matching is what LLMs do well.
 
-- **#525, #526, #527** — in-flight allowlist waves. They land; the repair loop sees a smaller residual.
+### UNBLOCKS
+
+- **Novel-framework-of-the-month** problem — agent recognizes any framework by reading code; v1.0 no longer requires a release for new stacks.
+- **Cross-repo for stacks without shared imports** (e.g. Django + React + RN over HTTP) — agent provides the cross-repo edges via route/contract reading.
+
+### Remain ORTHOGONAL
+
+- **#486** (determinism) and **#489** (PageRank float drift) — apply equally to both paths.
+- **DASH-2 #27** and **DASH-5 #30** — UI/dashboard work, separate channel.
+- Embedding/semantic-search v1.1 plan (**#460, #461, #462**) — separate channel from repair.
 
 ## Alternatives considered
 

--- a/docs/adrs/0016-residual-repair-agent-enrichment.md
+++ b/docs/adrs/0016-residual-repair-agent-enrichment.md
@@ -1,0 +1,158 @@
+# ADR-0016: Residual repair via agent-side enrichment
+
+- **Status**: Proposed
+- **Date**: 2026-05-19
+- **Deciders**: Jorge Cajas
+- **Related**: ADR-0007 (doc-as-bridge), ADR-0011 (per-language bare-name allowlists), ADR-0013 (cross-file import-aware resolution), issue #543, issue #486 (determinism), issue #15 (enrichment loop)
+
+## Context
+
+archigraph's resolver classifies every cross-symbol reference into one of seven `Disposition` buckets (see `internal/resolve/refs.go:127-194`). Two of those buckets — `DispositionBugExtractor` and `DispositionBugResolver` — are the residual: edges the static analyzer knew enough to *emit* but not enough to *bind*. On the v1.0 ship-gate corpus the residual currently sits at:
+
+- synthetic ship-gate corpus: 12% bug-rate
+- `django-realworld`: 7.83%
+- `client-fixture-a` group: 11.34% across three repos (per current ship-gate state)
+
+The strategy used through sprints 14-18 was per-language allowlist expansion: every wave (#494 receiver-type primitive, #533 dynamic URL match, #535 React npm allowlist, #525/#526/#527 in flight) pushed the bug-rate down by chipping at one framework's idioms inside `internal/external/synth.go` (currently 11,333 lines) and `internal/resolve/refs.go` (3,196 lines). Each wave costs multi-day engineering and only buys a fixed-stack improvement.
+
+Meanwhile, since #15 we have already run an agent-driven loop for *subjective* enrichment (entity descriptions, domain classification, role descriptions). The mechanics — emit a candidate JSON, let an LLM-equipped agent reason over it, merge back on the next index — are proven in `internal/enrichment/candidates.go`. We have an MCP server (`internal/mcp/server.go`, `internal/mcp/tools.go`) the agent already speaks to. The architectural ingredients to push the *residual* through the same loop are all in place; they have not been wired up because the bug-rate work has been treated as an indexer problem.
+
+This ADR makes the pivot: bug-extractor + bug-resolver residuals become a first-class enrichment surface, the agent does the per-call-site reasoning the indexer cannot, and the indexer becomes responsible for *applying* and *verifying* — not *guessing*.
+
+ADR-0007 already established the doc-as-bridge precedent for dynamic edges; this ADR generalizes that pattern to the structural residual.
+
+## Decision
+
+Residual repair becomes a first-class indexer phase. The system has three new artefacts and one new flow:
+
+1. **`enrichment-candidates.json` v2** — extended with `kind: "repair_edge"` records, one per residual edge. Carries enough context (`from_entity`, `relation`, `original_stub`, `disposition_reason`, `candidates`, `context_window`, `extracted_metadata`) for an off-line agent to make a binding decision without re-reading the repo.
+2. **`repair.json` v1** — written by the agent (directly or via MCP). One record per repaired `edge_id`, with `resolution` (bind / reclassify / abandon), `confidence`, `reasoning`, `source: "agent-repair"`.
+3. **Repair-apply phase** — runs *before* disposition classification in `cmd/archigraph/index.go` (see the disposition-reclassification pass around lines 321-411). Repairs are validated, applied as overrides, attribution is stamped onto the edge property bag, and a `repair_stats.json` is emitted.
+4. **MCP surface** — `list_residuals(repo, limit, cursor)` paginates the v2 candidates filtered to `kind == "repair_edge"`. `submit_repair(...)` validates and appends to `repair.json` atomically.
+
+The architectural rule: **the indexer is the source of truth for structure that is statically visible; the agent is the source of truth for structure that requires per-call-site context.** Repairs are merged in, not blended — every edge carries a `source` property naming who decided it.
+
+### Key data-contract decisions
+
+- **`edge_id` = `sha256(from_id || relation || original_stub)[:16]`** — stable across runs as long as the source line stays put. The `from_id` is itself a content hash (per `internal/graph/`), so renaming a file moves the edge_id; that is the intended staleness signal.
+- **Repairs do not mutate `graph.json` directly.** They mutate the resolver's internal endpoint table before disposition classification runs. This keeps the existing graph-emit codepath the single writer of `graph.json` and preserves ADR-0005's pre-bake invariants.
+- **`repair.json` lives at `<repo>/.archigraph/repair.json`.** Same directory as `enrichment-candidates.json` / `enrichment-resolutions.json`. Sibling files, sibling schemas.
+- **Trust model is allowlist, not blocklist.** The indexer enumerates *which* resolutions are accepted (bind_to_entity, reclassify_as_external, reclassify_as_dynamic, reclassify_as_resolved, abandon) and rejects anything else with a recorded reason. New resolution kinds require an ADR amendment.
+- **Determinism extension (issue #486).** The repair-apply phase iterates `repair.json` records in `edge_id` sort order, applies them deterministically, and emits `repair_stats.json` in stable sort order. Same source + same `repair.json` → byte-identical `graph.json`.
+
+## Consequences
+
+### Positive
+
+- v1.0 ships with a bug-rate floor independent of how exotic the user's stack is. New frameworks no longer require a release.
+- The multi-day per-language allowlist work (#494, #535, #494, future waves) becomes optional optimization rather than ship-gate-blocking.
+- Cross-repo dynamic edges (#510, #533, #534) and runtime edges (#515) get a viable resolution path that was previously stuck on "we cannot see this from source."
+- Source-attribution turns the graph from "trust the binary" to "audit the binary"; every controversial edge has a `reasoning` string the user can read.
+- Generalizes ADR-0007: docs were the bridge for dynamic content, the agent loop is the bridge for ambiguous structural content. Same architecture, different surface.
+
+### Negative
+
+- Adds a new failure mode: a misbehaving agent (or hostile `repair.json`) can degrade the graph. Mitigation: strict allowlisted resolutions, verification step rejects invalid targets, `source: agent-repair` makes every edge auditable, `rm .archigraph/repair.json && archigraph index` reverts to pure-static.
+- Bug-rate is no longer a property of "what archigraph the binary knows"; it now depends on whether the user has run an agent loop. We must update README + verify2 docs so users do not see 12% on a fresh index and think the tool is broken.
+- Adds a second sibling-file pair to `.archigraph/` — `repair.json` and `repair_stats.json`. Inventory of `.archigraph/` is starting to grow; we should produce a `.archigraph/README.md` describing each file's purpose.
+- The agent loop has a latency floor (LLM round-trip per residual). On a 5,000-residual graph this is not interactive. Mitigation lives in Phase 3: centrality-ordered prioritization, batch submit, parallel `list_residuals` cursors.
+
+### Neutral
+
+- Reuses the existing `internal/enrichment/` machinery and its file conventions. No new directory, no new package boundary, no new persistence story.
+- The repair-apply phase is structurally identical to the existing `enrichment.ApplyResolutions` flow (`internal/enrichment/candidates.go:463`) — same shape, different payload.
+
+## Data-contract summary
+
+Full schemas live alongside this ADR:
+
+- `docs/specs/enrichment-candidates-v2.schema.json`
+- `docs/specs/repair-v1.schema.json`
+- `docs/specs/mcp-residual-repair-tools.md`
+- `docs/specs/repair-trust-model.md`
+
+### enrichment-candidates v2 — change summary
+
+- Schema version bumps from `1` to `2` (`internal/enrichment/candidates.go:41` — `CandidatesSchemaVersion`).
+- New candidate kind: `repair_edge`. Carries `edge_id`, `from_entity`, `relation`, `original_stub`, `disposition_reason`, `candidates[]`, `context_window`, `extracted_metadata`.
+- All v1 kinds (`describe_entity`, `classify_domain`, `describe_role`, ...) retain identical on-disk shape. v1 readers see `repair_edge` records and skip-by-kind — backward compatible.
+
+### repair.json v1
+
+- Sibling file to `enrichment-resolutions.json`.
+- One record per `edge_id`. Resolutions are an enum of five values: `bind_to_entity`, `reclassify_as_external`, `reclassify_as_dynamic`, `reclassify_as_resolved`, `abandon`.
+- `source` is fixed at `"agent-repair"`. Future sources (e.g. `"manual-yaml"`, `"ci-rule"`) would land in a v2 of this schema with its own ADR.
+
+### Indexer integration point
+
+Repair-apply runs *between* the resolver's first pass (`internal/resolve/refs.go`) and the disposition-reclassification pass that lives around `cmd/archigraph/index.go:321`. Pseudocode:
+
+```
+endpoints := resolver.FirstPass(doc)
+repairs   := repair.Read(absRepo + "/.archigraph/repair.json")
+applied,
+rejected,
+stale     := repair.Apply(endpoints, repairs, doc)   // mutates endpoints
+final     := resolve.Reclassify(endpoints, doc)       // unchanged
+repair.WriteStats(absRepo, applied, rejected, stale)
+```
+
+Source-attribution: every endpoint touched by `repair.Apply` gets a `properties["resolved_by"] = "agent-repair"` and `properties["repair_reasoning"] = <one-sentence>` so the graph emit step preserves them on the final edge.
+
+### MCP surface
+
+- `list_residuals(repo, limit, cursor)` — reads `<repo>/.archigraph/enrichment-candidates.json`, filters `kind == "repair_edge"`, slices by cursor, returns the batch plus a `next_cursor`. Cursor is the last `edge_id` in the batch — stateless, deterministic.
+- `submit_repair(edge_id, resolution, target?, module?, confidence, reasoning)` — verifies the proposed repair against `repair-trust-model.md` rules, appends to `repair.json` (or replaces an existing record with the same `edge_id`), returns `{ok, written, rejected_reason?}`.
+- `reindex(repo)` — optional, lets the agent verify bug-rate dropped post-batch. Out of scope for Phase 1; reuses the existing index path under the hood.
+
+## Risks
+
+1. **Hostile or buggy agent corrupting the graph.** Mitigation: allowlisted resolutions, verification step rejects (a) `bind_to_entity` targets that do not exist in the current document, (b) repairs that introduce self-loops, (c) repairs that contradict an existing `CONTAINS` hierarchy, (d) repairs whose `module` is not a syntactically valid identifier (no path traversal). Every rejection is logged with a stable reason code.
+2. **Repair staleness when code outruns the agent.** Mitigation: `edge_id` is content-hash-bound; when source moves, `edge_id` changes; stale repairs fall off naturally and are listed in `repair_stats.json` so the agent knows to redo them.
+3. **Agent throughput on large repos.** A 5k-residual graph is several thousand LLM round-trips. Mitigation lives in Phase 3 (centrality ordering, batch submit). Phase 1 ships the synchronous loop and accepts the latency.
+4. **Two competing residual closures.** The per-language allowlist work in `internal/external/synth.go` keeps closing things over time. If both lanes run, the indexer wins (it runs first); the repair lane just sees a smaller residual. Not a correctness risk but an opportunity to retire allowlist waves whose bug-rate the agent already covers.
+5. **`repair.json` grows unboundedly.** On long-lived repos with churn, stale records accumulate. Mitigation: `repair_stats.json` reports stale count; a future `archigraph repair gc` command (out of scope for Phase 1) prunes by configurable retention. **OPEN QUESTION:** should stale repairs be auto-pruned on apply, or kept as audit history?
+6. **Conflicting repairs for the same `edge_id`.** Two agents writing concurrently. Mitigation: `submit_repair` writes atomically (write-temp-then-rename) and is last-writer-wins by `resolved_at` timestamp. **OPEN QUESTION:** is last-writer-wins acceptable, or do we want optimistic concurrency via a `previous_resolved_at` parameter?
+
+## Migration
+
+- **New repos:** no migration. First `archigraph index` emits v2 candidates; users opt in to repair by running the agent loop.
+- **Existing repos with v1 `enrichment-candidates.json`:** v2 reader is backward compatible (v1 has no `repair_edge` kind, just nothing to apply). On next index the file is rewritten in v2 shape; v1 consumers reading the rewritten file see `repair_edge` rows and skip-by-kind.
+- **Existing `.archigraph/` contents:** unchanged. `repair.json` is a new file; absence means "no repairs," which is the pre-ADR behaviour.
+- **Reverting:** `rm .archigraph/repair.json && archigraph index` returns the graph to pure-static. No data loss outside the repair layer itself.
+- **CI / determinism:** the indexer must read `repair.json` at a deterministic point. CI runs that don't want agent influence simply omit the file (or set `ARCHIGRAPH_DISABLE_REPAIR=1` — **OPEN QUESTION:** do we need an env-var kill switch, or is file-presence enough?).
+- **Schema upgrades:** version field in both files is required. Indexer rejects unknown schema-version values with a clear error pointing to the relevant ADR.
+
+## Issue impact
+
+### Becomes OBSOLETE if this lands
+
+- **#494** — receiver-variable-type-tracking primitive in `internal/external/synth.go`. Multi-day work; agent covers it via 50-line context-read.
+- **#535** — React npm allowlist (~50 packages). Agent recognizes any npm package by name string with no allowlist.
+- **All future per-language `synth.go` allowlist waves** for frameworks the user can name. (Existing waves can finish if already in flight.)
+
+### Becomes UNBLOCKED if this lands
+
+- **#510** — cross-repo HTTP route matching. Agent can match dynamic URLs the static resolver gives up on.
+- **#515** — runtime-edge discovery (Celery task strings, queue names). Agent can read context and decide.
+- **#533** — dynamic URL pattern matching. Generalized by repair loop.
+- **#534** — same family as #533.
+
+### Remain ORTHOGONAL (in flight, will land)
+
+- **#525, #526, #527** — in-flight allowlist waves. They land; the repair loop sees a smaller residual.
+
+## Alternatives considered
+
+1. **Continue per-language allowlist waves (status quo).** Rejected: linear cost per framework, never reaches 0% on novel stacks, positions archigraph as a static tool needing constant patches.
+2. **Ship a YAML edge-injection file users write by hand.** Rejected for the same reason ADR-0007 rejected manual edge YAML: worse author experience than the agent loop, and we already need the MCP surface for other enrichment.
+3. **Embed an LLM in the indexer binary.** Rejected: violates the single-binary-distribution promise (ADR-0001), couples shipping to a model provider, removes user choice of agent.
+4. **Defer to v1.1.** Rejected: every released version with a 7-12% bug-rate teaches users the tool is incomplete. The architectural pivot is small enough to land for v1.0 and large enough to redefine the product story.
+
+## Open questions
+
+1. Auto-prune stale repairs on apply, or retain as audit history? (default proposed: retain, emit count, leave GC to a separate command).
+2. `submit_repair` concurrency: last-writer-wins, or optimistic concurrency via `previous_resolved_at`? (default proposed: last-writer-wins for Phase 1, revisit if real-world conflicts appear).
+3. Env-var kill switch (`ARCHIGRAPH_DISABLE_REPAIR=1`) for CI, or rely on file-presence only? (default proposed: file-presence only — fewer knobs, clearer semantics).
+4. Does `reclassify_as_resolved` need to specify the resolver pass it should re-run, or always treat the new target as authoritative? (default proposed: authoritative, no re-run).
+5. Should `repair_edge` candidates be emitted for `DispositionExternalUnknown` as well, or only the two bug- dispositions? (default proposed: only bug- dispositions for Phase 1; `external-unknown` is "we know it's external, just not which package" and is a softer failure).

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -20,15 +20,15 @@ decision itself, and the consequences we accepted.
 | [0012](0012-receiver-type-stdlib-dispatch.md) | Accepted | Receiver-type stdlib dispatch |
 | [0013](0013-cross-file-import-aware-resolution.md) | Accepted | Cross-file import-aware resolution |
 | [0014](0014-corpus-expansion-strategy.md) | Accepted | Corpus expansion strategy — sample apps, not framework internals |
-| [0016](0016-residual-repair-agent-enrichment.md) | Proposed | Residual repair via agent-side enrichment |
+| [0015](0015-residual-repair-agent-enrichment.md) | Proposed | Residual repair via agent-side enrichment |
 
-Numbers are append-only; gaps (e.g. 0015) indicate a reserved number whose ADR has not yet landed.
+Numbers are append-only.
 
 ## Spec sidecars
 
 ADRs that introduce on-disk or wire-format contracts publish the schemas as sibling files under [`../specs/`](../specs/):
 
-- [`enrichment-candidates-v2.schema.json`](../specs/enrichment-candidates-v2.schema.json) — ADR-0016
-- [`repair-v1.schema.json`](../specs/repair-v1.schema.json) — ADR-0016
-- [`mcp-residual-repair-tools.md`](../specs/mcp-residual-repair-tools.md) — ADR-0016
-- [`repair-trust-model.md`](../specs/repair-trust-model.md) — ADR-0016
+- [`enrichment-candidates-v2.schema.json`](../specs/enrichment-candidates-v2.schema.json) — ADR-0015
+- [`repair-v1.schema.json`](../specs/repair-v1.schema.json) — ADR-0015
+- [`mcp-residual-repair-tools.md`](../specs/mcp-residual-repair-tools.md) — ADR-0015
+- [`repair-trust-model.md`](../specs/repair-trust-model.md) — ADR-0015

--- a/docs/adrs/README.md
+++ b/docs/adrs/README.md
@@ -1,0 +1,34 @@
+# Architecture Decision Records
+
+This directory holds archigraph's ADRs. Each record captures a single
+architecturally-significant decision: the context that produced it, the
+decision itself, and the consequences we accepted.
+
+| ID | Status | Title |
+|---|---|---|
+| [0001](0001-go-native-single-binary-distribution.md) | Accepted | Go-native single-binary distribution |
+| [0002](0002-clean-room-mcp-server-in-go.md) | Accepted | Clean-room MCP server in Go |
+| [0003](0003-scope-entity-taxonomy.md) | Accepted | SCOPE entity taxonomy |
+| [0004](0004-single-mcp-process-per-machine.md) | Accepted | Single MCP process per machine |
+| [0005](0005-pre-bake-graph-attributes-during-indexing.md) | Accepted | Pre-bake graph attributes during indexing |
+| [0006](0006-in-memory-json-persistence-no-graph-database.md) | Accepted | In-memory JSON persistence, no graph database |
+| [0007](0007-doc-as-bridge-for-cross-repo-and-dynamic-connections.md) | Accepted | Doc-as-bridge for cross-repo and dynamic connections |
+| [0008](0008-caller-cwd-aware-routing-for-multi-group-setups.md) | Accepted | Caller-CWD-aware routing for multi-group setups |
+| [0009](0009-cross-repo-id-namespacing.md) | Accepted | Cross-repo ID namespacing |
+| [0010](0010-structural-refs-format.md) | Accepted | Structural refs format |
+| [0011](0011-per-language-bare-name-allowlists.md) | Accepted | Per-language bare-name allowlists |
+| [0012](0012-receiver-type-stdlib-dispatch.md) | Accepted | Receiver-type stdlib dispatch |
+| [0013](0013-cross-file-import-aware-resolution.md) | Accepted | Cross-file import-aware resolution |
+| [0014](0014-corpus-expansion-strategy.md) | Accepted | Corpus expansion strategy — sample apps, not framework internals |
+| [0016](0016-residual-repair-agent-enrichment.md) | Proposed | Residual repair via agent-side enrichment |
+
+Numbers are append-only; gaps (e.g. 0015) indicate a reserved number whose ADR has not yet landed.
+
+## Spec sidecars
+
+ADRs that introduce on-disk or wire-format contracts publish the schemas as sibling files under [`../specs/`](../specs/):
+
+- [`enrichment-candidates-v2.schema.json`](../specs/enrichment-candidates-v2.schema.json) — ADR-0016
+- [`repair-v1.schema.json`](../specs/repair-v1.schema.json) — ADR-0016
+- [`mcp-residual-repair-tools.md`](../specs/mcp-residual-repair-tools.md) — ADR-0016
+- [`repair-trust-model.md`](../specs/repair-trust-model.md) — ADR-0016

--- a/docs/specs/enrichment-candidates-v2.schema.json
+++ b/docs/specs/enrichment-candidates-v2.schema.json
@@ -1,0 +1,160 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://archigraph.dev/schemas/enrichment-candidates-v2.json",
+  "title": "enrichment-candidates.json (v2)",
+  "description": "On-disk format for <repo>/.archigraph/enrichment-candidates.json. Extends v1 (internal/enrichment/candidates.go) with the repair_edge kind required by ADR-0016. v1 readers may safely skip-by-kind on unknown kinds.",
+  "type": "object",
+  "required": ["schema_version", "candidates"],
+  "additionalProperties": true,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 2,
+      "description": "Bumped from 1 -> 2 by ADR-0016. The constant matches CandidatesSchemaVersion in internal/enrichment/candidates.go."
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "RFC3339 UTC timestamp of the index run that produced this file."
+    },
+    "repo_id": {
+      "type": "string",
+      "description": "Stable repo identifier used by the indexer (e.g. cross-repo namespace from ADR-0009)."
+    },
+    "candidates": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Candidate" }
+    }
+  },
+  "definitions": {
+    "Candidate": {
+      "type": "object",
+      "required": ["id", "kind", "subject_id"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^ec:[0-9a-f]{16}$",
+          "description": "Deterministic candidate ID. For repair_edge candidates the ID is derived from edge_id; see context.edge_id."
+        },
+        "kind": {
+          "type": "string",
+          "enum": [
+            "describe_entity",
+            "classify_domain",
+            "infer_xlang_call",
+            "summarize_api",
+            "flag_dead_code",
+            "describe_role",
+            "repair_edge"
+          ]
+        },
+        "subject_id": {
+          "type": "string",
+          "description": "Local entity id (NOT prefixed with repo). For repair_edge candidates this is the from_entity id."
+        },
+        "context": {
+          "type": "object",
+          "description": "Kind-specific payload. For kind=repair_edge see RepairEdgeContext.",
+          "additionalProperties": true
+        },
+        "prompt_template": { "type": "string" },
+        "confidence_floor": { "type": "number", "minimum": 0, "maximum": 1 },
+        "discovered_at": { "type": "string", "format": "date-time" }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "kind": { "const": "repair_edge" } } },
+          "then": {
+            "properties": {
+              "context": { "$ref": "#/definitions/RepairEdgeContext" }
+            },
+            "required": ["context"]
+          }
+        }
+      ]
+    },
+    "RepairEdgeContext": {
+      "type": "object",
+      "required": [
+        "edge_id",
+        "from_entity",
+        "relation",
+        "original_stub",
+        "disposition_reason"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "edge_id": {
+          "type": "string",
+          "pattern": "^er:[0-9a-f]{16}$",
+          "description": "sha256(from_id || relation || original_stub)[:16] prefixed with 'er:'. Stable across runs while the source line stays put; mutates when from_entity's content hash changes (this is the staleness signal)."
+        },
+        "from_entity": {
+          "type": "object",
+          "required": ["id", "kind", "name", "file"],
+          "properties": {
+            "id": { "type": "string" },
+            "kind": { "type": "string", "description": "SCOPE entity kind per ADR-0003." },
+            "name": { "type": "string" },
+            "file": { "type": "string", "description": "Repo-relative POSIX path." },
+            "line": { "type": "integer", "minimum": 1 }
+          }
+        },
+        "relation": {
+          "type": "string",
+          "enum": ["CALLS", "EXTENDS", "IMPLEMENTS", "IMPORTS", "READS", "WRITES", "REFERENCES"]
+        },
+        "original_stub": {
+          "type": "string",
+          "description": "The unbound target string the resolver produced (e.g. 'Kind:Name', 'pkg.func', bare name)."
+        },
+        "disposition_reason": {
+          "type": "string",
+          "description": "Stable enum tag indicating *why* the resolver couldn't bind. Values produced by internal/resolve/refs.go classification.",
+          "examples": [
+            "ambig-bare-hint-fail",
+            "ambig-bare-no-hint",
+            "dotted-other",
+            "bare-other",
+            "receiver-type-unknown",
+            "dynamic-url-other"
+          ]
+        },
+        "candidates": {
+          "type": "array",
+          "description": "Plausible local binding targets the agent can choose from. Present for bug-resolver dispositions, empty for bug-extractor.",
+          "items": {
+            "type": "object",
+            "required": ["entity_id", "hint"],
+            "properties": {
+              "entity_id": { "type": "string" },
+              "hint": { "type": "string", "description": "One-line label: kind + qualified name + file:line." },
+              "score": { "type": "number", "minimum": 0, "maximum": 1, "description": "Heuristic match strength produced by the resolver." }
+            }
+          }
+        },
+        "context_window": {
+          "type": "object",
+          "description": "Source excerpt for agent reasoning. Window is centered on from_entity.line.",
+          "required": ["before", "line", "after"],
+          "properties": {
+            "before": { "type": "array", "items": { "type": "string" }, "description": "Lines preceding the call site (default: 25)." },
+            "line":   { "type": "string", "description": "The call-site line itself." },
+            "after":  { "type": "array", "items": { "type": "string" }, "description": "Lines following the call site (default: 25)." }
+          }
+        },
+        "extracted_metadata": {
+          "type": "object",
+          "description": "Resolver-extracted context the agent should consider.",
+          "additionalProperties": true,
+          "properties": {
+            "receiver_type": { "type": ["string", "null"] },
+            "file_imports": { "type": "array", "items": { "type": "string" } },
+            "surrounding_scope": { "type": ["string", "null"] },
+            "language": { "type": "string" }
+          }
+        }
+      }
+    }
+  }
+}

--- a/docs/specs/enrichment-candidates-v2.schema.json
+++ b/docs/specs/enrichment-candidates-v2.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://archigraph.dev/schemas/enrichment-candidates-v2.json",
   "title": "enrichment-candidates.json (v2)",
-  "description": "On-disk format for <repo>/.archigraph/enrichment-candidates.json. Extends v1 (internal/enrichment/candidates.go) with the repair_edge kind required by ADR-0016. v1 readers may safely skip-by-kind on unknown kinds.",
+  "description": "On-disk format for <repo>/.archigraph/enrichment-candidates.json. Extends v1 (internal/enrichment/candidates.go) with the repair_edge kind required by ADR-0015. v1 readers may safely skip-by-kind on unknown kinds.",
   "type": "object",
   "required": ["schema_version", "candidates"],
   "additionalProperties": true,
@@ -10,7 +10,7 @@
     "schema_version": {
       "type": "integer",
       "const": 2,
-      "description": "Bumped from 1 -> 2 by ADR-0016. The constant matches CandidatesSchemaVersion in internal/enrichment/candidates.go."
+      "description": "Bumped from 1 -> 2 by ADR-0015. The constant matches CandidatesSchemaVersion in internal/enrichment/candidates.go."
     },
     "generated_at": {
       "type": "string",

--- a/docs/specs/mcp-residual-repair-tools.md
+++ b/docs/specs/mcp-residual-repair-tools.md
@@ -1,0 +1,199 @@
+# MCP tool surface — residual repair
+
+This document specifies the MCP tools introduced by ADR-0016. Tools are registered alongside the existing surface in `internal/mcp/tools.go` and the registration table in `internal/mcp/server.go` (compare the `query_graph` / `get_node` / `submit_resolution` family — these new tools follow the same conventions).
+
+All tool input/output schemas are JSON Schema Draft-07.
+
+---
+
+## `list_residuals`
+
+Paginates `repair_edge` candidates from `<repo>/.archigraph/enrichment-candidates.json`. The cursor is stateless and deterministic (it's the last `edge_id` returned), so an agent can resume between sessions without server-side state.
+
+### Input
+
+```json
+{
+  "type": "object",
+  "required": ["repo"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": {
+      "type": "string",
+      "description": "Repo identifier or absolute path. Resolved against the caller-CWD routing rules from ADR-0008."
+    },
+    "limit": {
+      "type": "integer",
+      "minimum": 1,
+      "maximum": 200,
+      "default": 50
+    },
+    "cursor": {
+      "type": ["string", "null"],
+      "description": "edge_id from the last item of the previous page. Null/absent for first page."
+    },
+    "disposition_filter": {
+      "type": "array",
+      "items": { "type": "string", "enum": ["bug-extractor", "bug-resolver"] },
+      "description": "Optional. Restrict to a subset of bug dispositions. Default = both."
+    },
+    "priority": {
+      "type": "string",
+      "enum": ["centrality_desc", "edge_id_asc"],
+      "default": "edge_id_asc",
+      "description": "Stable ordering of returned items. centrality_desc requires Pass-4 graph attributes; falls back to edge_id_asc if unavailable."
+    }
+  }
+}
+```
+
+### Output
+
+```json
+{
+  "type": "object",
+  "required": ["items", "next_cursor", "remaining"],
+  "properties": {
+    "items": {
+      "type": "array",
+      "items": { "$ref": "enrichment-candidates-v2.schema.json#/definitions/Candidate" }
+    },
+    "next_cursor": {
+      "type": ["string", "null"],
+      "description": "Pass back as `cursor` to fetch the next page. Null when the list is exhausted."
+    },
+    "remaining": {
+      "type": "integer",
+      "minimum": 0,
+      "description": "Number of repair_edge candidates left after this page."
+    }
+  }
+}
+```
+
+### Errors
+
+- `repo_not_indexed` — `.archigraph/enrichment-candidates.json` missing. Suggest the user run `archigraph index <repo>` first.
+- `schema_version_unsupported` — file present but `schema_version != 2`.
+- `invalid_cursor` — cursor does not refer to a known `edge_id`.
+
+---
+
+## `submit_repair`
+
+Validates a proposed repair against the trust model (see `repair-trust-model.md`) and appends or replaces a record in `<repo>/.archigraph/repair.json`. Writes are atomic (temp file + rename). Last-writer-wins by `resolved_at` if two calls race on the same `edge_id`.
+
+### Input
+
+```json
+{
+  "type": "object",
+  "required": ["repo", "edge_id", "resolution", "confidence", "reasoning"],
+  "additionalProperties": false,
+  "properties": {
+    "repo": { "type": "string" },
+    "edge_id": { "type": "string", "pattern": "^er:[0-9a-f]{16}$" },
+    "resolution": {
+      "type": "string",
+      "enum": ["bind_to_entity", "reclassify_as_external", "reclassify_as_dynamic", "reclassify_as_resolved", "abandon"]
+    },
+    "target_entity_id": { "type": "string" },
+    "module":           { "type": "string" },
+    "new_target":       { "type": "string" },
+    "dynamic_reason":   { "type": "string" },
+    "abandon_reason":   { "type": "string" },
+    "confidence":       { "type": "number", "minimum": 0, "maximum": 1 },
+    "reasoning":        { "type": "string", "minLength": 1, "maxLength": 500 }
+  }
+}
+```
+
+(Conditional `required` fields by `resolution` mirror `repair-v1.schema.json`.)
+
+### Output
+
+```json
+{
+  "type": "object",
+  "required": ["ok"],
+  "properties": {
+    "ok": { "type": "boolean" },
+    "written": {
+      "type": "object",
+      "description": "Present iff ok == true. The exact record persisted to repair.json (timestamped server-side).",
+      "$ref": "repair-v1.schema.json#/definitions/Repair"
+    },
+    "rejected_reason": {
+      "type": "string",
+      "description": "Present iff ok == false. Stable error code from the trust-model reject list.",
+      "enum": [
+        "edge_id_unknown",
+        "target_entity_not_found",
+        "self_loop_disallowed",
+        "contradicts_contains_hierarchy",
+        "invalid_module_identifier",
+        "missing_required_field",
+        "resolution_kind_unsupported",
+        "reasoning_too_short"
+      ]
+    }
+  }
+}
+```
+
+### Errors (transport-level, distinct from `rejected_reason`)
+
+- `repo_not_indexed` — same as above.
+- `repair_file_corrupt` — existing `repair.json` cannot be parsed. Agent should surface to the user.
+- `io_error` — write failed (disk full, permission denied, etc.).
+
+---
+
+## `reindex` (optional, Phase 1 stretch)
+
+Reuses the indexer entry point used by `cmd/archigraph/index.go` to let the agent verify bug-rate movement after a batch of `submit_repair` calls.
+
+### Input
+
+```json
+{
+  "type": "object",
+  "required": ["repo"],
+  "properties": { "repo": { "type": "string" } }
+}
+```
+
+### Output
+
+```json
+{
+  "type": "object",
+  "required": ["bug_rate_before", "bug_rate_after", "applied", "rejected", "stale"],
+  "properties": {
+    "bug_rate_before": { "type": "number" },
+    "bug_rate_after":  { "type": "number" },
+    "applied":         { "type": "integer" },
+    "rejected":        { "type": "integer" },
+    "stale":           { "type": "integer" }
+  }
+}
+```
+
+`bug_rate_before` is read from the previous run's `disposition_breakdown` (`cmd/archigraph/index.go:220`); `bug_rate_after` is the freshly-indexed value.
+
+---
+
+## Agent loop (reference)
+
+```text
+loop:
+  page = list_residuals(repo, limit=50, cursor=last_cursor)
+  for c in page.items:
+    decision = reason_over(c.context_window, c.candidates, c.extracted_metadata)
+    submit_repair(repo, edge_id=c.context.edge_id, **decision)
+  if page.next_cursor is None: break
+  last_cursor = page.next_cursor
+reindex(repo)   # optional: confirm bug_rate dropped
+```
+
+This loop is the centerpiece of the v1.0 demo (ADR-0016 Phase 2).

--- a/docs/specs/mcp-residual-repair-tools.md
+++ b/docs/specs/mcp-residual-repair-tools.md
@@ -1,6 +1,6 @@
 # MCP tool surface — residual repair
 
-This document specifies the MCP tools introduced by ADR-0016. Tools are registered alongside the existing surface in `internal/mcp/tools.go` and the registration table in `internal/mcp/server.go` (compare the `query_graph` / `get_node` / `submit_resolution` family — these new tools follow the same conventions).
+This document specifies the MCP tools introduced by ADR-0015. Tools are registered alongside the existing surface in `internal/mcp/tools.go` and the registration table in `internal/mcp/server.go` (compare the `query_graph` / `get_node` / `submit_resolution` family — these new tools follow the same conventions).
 
 All tool input/output schemas are JSON Schema Draft-07.
 
@@ -196,4 +196,4 @@ loop:
 reindex(repo)   # optional: confirm bug_rate dropped
 ```
 
-This loop is the centerpiece of the v1.0 demo (ADR-0016 Phase 2).
+This loop is the centerpiece of the v1.0 demo (ADR-0015 Phase 2).

--- a/docs/specs/repair-trust-model.md
+++ b/docs/specs/repair-trust-model.md
@@ -1,0 +1,81 @@
+# Repair trust model
+
+Companion to ADR-0016. Defines what the indexer accepts, rejects, and flags as suspicious when applying `repair.json`. The model is allowlist-only: the set of acceptable resolutions is closed, and adding new ones requires an ADR amendment.
+
+## Allowlisted resolutions
+
+Only the five `resolution` values from `repair-v1.schema.json` are accepted:
+
+| Resolution | Required fields | Effect on endpoint |
+|---|---|---|
+| `bind_to_entity` | `target_entity_id` | Endpoint is rewritten to the named entity; disposition becomes `Resolved`. |
+| `reclassify_as_external` | `module` | Endpoint becomes `ext:<module>`; disposition becomes `ExternalKnown`. |
+| `reclassify_as_dynamic` | `dynamic_reason` | Endpoint is left as-is; disposition becomes `Dynamic`. The reason is stored on the edge. |
+| `reclassify_as_resolved` | `new_target` | Endpoint is rewritten to `new_target`; resolver does NOT re-resolve. Use for cross-repo or runtime-known targets. |
+| `abandon` | `abandon_reason` | Endpoint is dropped from the graph; counted in `repair_stats.json` under `abandoned`. |
+
+Any other `resolution` value: **rejected** with `resolution_kind_unsupported`.
+
+## Verification rules (run before apply)
+
+A repair is **rejected** if any check fails. Rejection records the `edge_id` and reason code in `repair_stats.json` so the agent can re-attempt.
+
+### R1 — `edge_id_unknown`
+The `edge_id` does not match any current `repair_edge` candidate. Common cause: source moved between index runs (stale repair). The indexer does not auto-fix; the agent must reread `list_residuals` and submit a fresh repair.
+
+### R2 — `target_entity_not_found`
+Applies to `bind_to_entity`. The `target_entity_id` must exist in the current `graph.Document`. Lookup is exact; no fuzzy match.
+
+### R3 — `self_loop_disallowed`
+Applies to `bind_to_entity`. `target_entity_id == from_entity.id` is rejected. Even if the source genuinely calls itself, that loop is the responsibility of the static resolver, not the repair layer.
+
+### R4 — `contradicts_contains_hierarchy`
+Applies to `bind_to_entity`. The proposed target cannot be a `CONTAINS` ancestor of `from_entity` (a method cannot CALL/EXTENDS its own enclosing class via repair; static resolution handles that). This preserves the structural invariants emitted by Pass-3.
+
+### R5 — `invalid_module_identifier`
+Applies to `reclassify_as_external`. `module` must match `^[A-Za-z_][A-Za-z0-9_\-./]*$`. No leading `..`, no absolute paths, no shell metacharacters. This prevents path-traversal-style attacks via `ext:` prefixes that downstream tools might join with filesystem paths.
+
+### R6 — `missing_required_field`
+The `resolution` was named but its conditional required field was omitted.
+
+### R7 — `reasoning_too_short`
+`reasoning` is empty or whitespace-only. The reasoning string is preserved on the edge as `repair_reasoning` and shown to users in MCP query output, so it must be substantive (minimum 1 non-whitespace char enforced; reviewers should treat <10 chars as suspicious).
+
+## Suspicious-but-accepted (flagged, not rejected)
+
+These cases are accepted but emitted into `repair_stats.json` under `suspicious` so a human can audit:
+
+- `confidence < 0.5` — accepted; agents are encouraged to abandon rather than low-confidence bind.
+- `bind_to_entity` to an entity of a `kind` that does not normally receive the proposed `relation` (e.g. `CALLS` targeting a `SCOPE.Module` instead of a callable). The indexer doesn't reject because per-language kind/relation matrices are not fully canonical, but it flags.
+- Multiple repairs converging on the same `target_entity_id` from a large fan-in (>50 distinct `from_entity` ids) — possible god-node mis-binding.
+
+## Stale-repair detection
+
+A repair becomes stale when its `edge_id` no longer matches any current `repair_edge` candidate. The indexer detects staleness by computing the set difference between repair `edge_id`s and current candidate `edge_id`s. Stale repairs:
+
+- are **not** applied
+- are **not** auto-deleted from `repair.json` (audit history; see open question 1 in ADR-0016)
+- are listed in `repair_stats.json` under `stale_repairs[]` with their `edge_id`, `resolution`, and `resolved_at`
+
+A subsequent `list_residuals` call returns the new candidate for that edge so the agent can re-submit.
+
+## Source attribution (audit trail)
+
+Every endpoint that the repair layer touches receives two properties before disposition classification:
+
+- `resolved_by = "agent-repair"` — distinguishes from `"static"` (default) and any future sources.
+- `repair_reasoning = "<the one-sentence string>"` — the verbatim `reasoning` from `repair.json`.
+
+These properties survive into `graph.json` and are queryable through the existing MCP graph tools, so users can ask "which edges did the agent decide?" and see the reasoning per edge.
+
+## Auditing requirements
+
+- `repair_stats.json` MUST be emitted on every index run that read a `repair.json`, even if no repairs applied.
+- The stats file MUST list, at minimum: `applied_count`, `rejected[]` (with reason codes), `stale[]`, `suspicious[]`, `total_residuals_before`, `total_residuals_after`, `bug_rate_before`, `bug_rate_after`.
+- Sort order: `applied[]` and `stale[]` ordered by `edge_id` ascending; `rejected[]` and `suspicious[]` ordered by `edge_id` ascending. This preserves byte-identical-output determinism (ADR-0016, issue #486).
+
+## Operator controls
+
+- **Disable repair layer entirely:** `rm <repo>/.archigraph/repair.json`. Next index returns to pure-static behaviour.
+- **Reject a specific repair manually:** delete its record from `repair.json` (or rewrite by hand) before reindex.
+- **CI-only no-repair mode:** OPEN QUESTION in ADR-0016 — likely just file-absence; an `ARCHIGRAPH_DISABLE_REPAIR` env var is on the table if the file-absence convention proves insufficient.

--- a/docs/specs/repair-trust-model.md
+++ b/docs/specs/repair-trust-model.md
@@ -1,6 +1,6 @@
 # Repair trust model
 
-Companion to ADR-0016. Defines what the indexer accepts, rejects, and flags as suspicious when applying `repair.json`. The model is allowlist-only: the set of acceptable resolutions is closed, and adding new ones requires an ADR amendment.
+Companion to ADR-0015. Defines what the indexer accepts, rejects, and flags as suspicious when applying `repair.json`. The model is allowlist-only: the set of acceptable resolutions is closed, and adding new ones requires an ADR amendment.
 
 ## Allowlisted resolutions
 
@@ -54,7 +54,7 @@ These cases are accepted but emitted into `repair_stats.json` under `suspicious`
 A repair becomes stale when its `edge_id` no longer matches any current `repair_edge` candidate. The indexer detects staleness by computing the set difference between repair `edge_id`s and current candidate `edge_id`s. Stale repairs:
 
 - are **not** applied
-- are **not** auto-deleted from `repair.json` (audit history; see open question 1 in ADR-0016)
+- are **not** auto-deleted from `repair.json` (audit history; see open question 1 in ADR-0015)
 - are listed in `repair_stats.json` under `stale_repairs[]` with their `edge_id`, `resolution`, and `resolved_at`
 
 A subsequent `list_residuals` call returns the new candidate for that edge so the agent can re-submit.
@@ -72,10 +72,10 @@ These properties survive into `graph.json` and are queryable through the existin
 
 - `repair_stats.json` MUST be emitted on every index run that read a `repair.json`, even if no repairs applied.
 - The stats file MUST list, at minimum: `applied_count`, `rejected[]` (with reason codes), `stale[]`, `suspicious[]`, `total_residuals_before`, `total_residuals_after`, `bug_rate_before`, `bug_rate_after`.
-- Sort order: `applied[]` and `stale[]` ordered by `edge_id` ascending; `rejected[]` and `suspicious[]` ordered by `edge_id` ascending. This preserves byte-identical-output determinism (ADR-0016, issue #486).
+- Sort order: `applied[]` and `stale[]` ordered by `edge_id` ascending; `rejected[]` and `suspicious[]` ordered by `edge_id` ascending. This preserves byte-identical-output determinism (ADR-0015, issue #486).
 
 ## Operator controls
 
 - **Disable repair layer entirely:** `rm <repo>/.archigraph/repair.json`. Next index returns to pure-static behaviour.
 - **Reject a specific repair manually:** delete its record from `repair.json` (or rewrite by hand) before reindex.
-- **CI-only no-repair mode:** OPEN QUESTION in ADR-0016 — likely just file-absence; an `ARCHIGRAPH_DISABLE_REPAIR` env var is on the table if the file-absence convention proves insufficient.
+- **CI-only no-repair mode:** OPEN QUESTION in ADR-0015 — likely just file-absence; an `ARCHIGRAPH_DISABLE_REPAIR` env var is on the table if the file-absence convention proves insufficient.

--- a/docs/specs/repair-v1.schema.json
+++ b/docs/specs/repair-v1.schema.json
@@ -1,0 +1,112 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://archigraph.dev/schemas/repair-v1.json",
+  "title": "repair.json (v1)",
+  "description": "On-disk format for <repo>/.archigraph/repair.json. Written by an LLM-equipped agent via the MCP submit_repair tool (or hand-edited). Loaded by the indexer before disposition classification per ADR-0016. Sibling file to enrichment-resolutions.json.",
+  "type": "object",
+  "required": ["schema_version", "repairs"],
+  "additionalProperties": false,
+  "properties": {
+    "schema_version": {
+      "type": "integer",
+      "const": 1
+    },
+    "generated_at": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Last write timestamp. Atomically updated by submit_repair."
+    },
+    "repairs": {
+      "type": "array",
+      "items": { "$ref": "#/definitions/Repair" }
+    }
+  },
+  "definitions": {
+    "Repair": {
+      "type": "object",
+      "required": ["edge_id", "resolution", "confidence", "reasoning", "source", "resolved_at"],
+      "additionalProperties": false,
+      "properties": {
+        "edge_id": {
+          "type": "string",
+          "pattern": "^er:[0-9a-f]{16}$",
+          "description": "Must match the edge_id from the corresponding repair_edge candidate. If the underlying source changes, edge_id changes, and this repair becomes stale (see repair_stats.json)."
+        },
+        "resolution": {
+          "type": "string",
+          "enum": [
+            "bind_to_entity",
+            "reclassify_as_external",
+            "reclassify_as_dynamic",
+            "reclassify_as_resolved",
+            "abandon"
+          ],
+          "description": "Allowlisted resolution kinds per ADR-0016. New kinds require an ADR amendment."
+        },
+        "target_entity_id": {
+          "type": "string",
+          "description": "Required iff resolution == bind_to_entity. Must exist in the current graph document; otherwise the repair is rejected."
+        },
+        "module": {
+          "type": "string",
+          "pattern": "^[A-Za-z_][A-Za-z0-9_\\-./]*$",
+          "description": "Required iff resolution == reclassify_as_external. Becomes the 'ext:<module>' endpoint suffix. No path traversal characters."
+        },
+        "new_target": {
+          "type": "string",
+          "description": "Required iff resolution == reclassify_as_resolved. The agent-supplied authoritative target string; the indexer treats it as already-resolved and skips re-resolution for this edge."
+        },
+        "dynamic_reason": {
+          "type": "string",
+          "description": "Required iff resolution == reclassify_as_dynamic. Short tag (e.g. 'env-var-route', 'celery-task-name')."
+        },
+        "abandon_reason": {
+          "type": "string",
+          "description": "Required iff resolution == abandon. Short tag for why no useful binding exists."
+        },
+        "confidence": {
+          "type": "number",
+          "minimum": 0,
+          "maximum": 1
+        },
+        "reasoning": {
+          "type": "string",
+          "minLength": 1,
+          "maxLength": 500,
+          "description": "One-sentence explanation. Stored verbatim on the resulting edge as the 'repair_reasoning' property."
+        },
+        "source": {
+          "type": "string",
+          "const": "agent-repair",
+          "description": "Always 'agent-repair' in v1. Future sources (manual-yaml, ci-rule) would land in v2 with their own ADR."
+        },
+        "resolved_at": {
+          "type": "string",
+          "format": "date-time"
+        }
+      },
+      "allOf": [
+        {
+          "if": { "properties": { "resolution": { "const": "bind_to_entity" } } },
+          "then": { "required": ["target_entity_id"] }
+        },
+        {
+          "if": { "properties": { "resolution": { "const": "reclassify_as_external" } } },
+          "then": { "required": ["module"] }
+        },
+        {
+          "if": { "properties": { "resolution": { "const": "reclassify_as_resolved" } } },
+          "then": { "required": ["new_target"] }
+        },
+        {
+          "if": { "properties": { "resolution": { "const": "reclassify_as_dynamic" } } },
+          "then": { "required": ["dynamic_reason"] }
+        },
+        {
+          "if": { "properties": { "resolution": { "const": "abandon" } } },
+          "then": { "required": ["abandon_reason"] }
+        }
+      ]
+    }
+  }
+}

--- a/docs/specs/repair-v1.schema.json
+++ b/docs/specs/repair-v1.schema.json
@@ -2,7 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "https://archigraph.dev/schemas/repair-v1.json",
   "title": "repair.json (v1)",
-  "description": "On-disk format for <repo>/.archigraph/repair.json. Written by an LLM-equipped agent via the MCP submit_repair tool (or hand-edited). Loaded by the indexer before disposition classification per ADR-0016. Sibling file to enrichment-resolutions.json.",
+  "description": "On-disk format for <repo>/.archigraph/repair.json. Written by an LLM-equipped agent via the MCP submit_repair tool (or hand-edited). Loaded by the indexer before disposition classification per ADR-0015. Sibling file to enrichment-resolutions.json.",
   "type": "object",
   "required": ["schema_version", "repairs"],
   "additionalProperties": false,
@@ -41,7 +41,7 @@
             "reclassify_as_resolved",
             "abandon"
           ],
-          "description": "Allowlisted resolution kinds per ADR-0016. New kinds require an ADR amendment."
+          "description": "Allowlisted resolution kinds per ADR-0015. New kinds require an ADR amendment."
         },
         "target_entity_id": {
           "type": "string",


### PR DESCRIPTION
Spec-only PR. Drafts ADR-0015 + the four sidecar specs that freeze the data contracts. **No code changes.** Implementation lands as a coordinated wave (#544 - #551) once this ADR is reviewed.

Closes the spec deliverable from #543.

## ADR summary

Adds residual repair (bug-extractor + bug-resolver dispositions in `internal/resolve/refs.go`) as a **first-class indexer phase that complements deterministic static analysis** — it does not replace per-language work. The Go binary stays the deterministic default for everything statically visible; per-language allowlist waves continue to land for popular stable stacks (React, Django, Flask, SwiftNIO, etc.). The LLM-equipped agent (via MCP) handles the long tail: novel/obscure frameworks, dynamic URLs, runtime/distributed edges, and ambiguities that need 50 lines of semantic context. Both ship in v1.0.

Repairs land via a new `<repo>/.archigraph/repair.json`, validated against an allowlisted trust model, applied between the resolver's first pass and disposition reclassification. Every repaired edge carries `resolved_by = "agent-repair"` + a one-sentence `repair_reasoning` for audit.

## Files

- `docs/adrs/0015-residual-repair-agent-enrichment.md` — full ADR
- `docs/specs/enrichment-candidates-v2.schema.json` — extends the existing v1 file with `kind: "repair_edge"`; v1 readers safely skip
- `docs/specs/repair-v1.schema.json` — agent-written `repair.json` contract; five allowlisted resolutions
- `docs/specs/mcp-residual-repair-tools.md` — `list_residuals` (paginated, stateless cursor) + `submit_repair` (atomic, trust-validated) + optional `reindex`
- `docs/specs/repair-trust-model.md` — R1-R7 verification rules, suspicious-but-accepted flags, stale detection, audit requirements
- `docs/adrs/README.md` — ADR index updated with 0015

## Issue impact (aligned with corrected #543)

This is a **both-and** architecture, not a replacement for per-language work.

### STAY indexer-side (continue normally)
- #525 EXTENDS kind-disambiguator
- #526 DRF ViewSet class-attribute extraction
- #527 Django URLConf module binder
- #535 React npm allowlist
- #537 barrel re-export resolution
- #494 receiver-type for statically-typed languages (Go, Java, Kotlin, Swift)
- All Phase-1 work + future per-language waves for popular stable frameworks

### BECOME REPAIR-FIRST (indexer emits candidates; agent resolves)
- #494 for dynamic languages (Python, Ruby, JS)
- #510 / #533 / #534 HTTP route ↔ fetch + dynamic URL matching
- #515 runtime/distributed edges (Celery, queues, pub/sub)

### UNBLOCKS
- Novel-framework-of-the-month problem
- Cross-repo for stacks without shared imports (Django + React + RN over HTTP)

### REMAIN ORTHOGONAL
- #486 (determinism), #489 (PageRank float drift)
- DASH-2 #27, DASH-5 #30
- Embedding/semantic-search v1.1 plan (#460, #461, #462)

## Open questions (need owner input before implementation wave starts)

1. **Stale repair retention** — auto-prune on apply, or retain as audit history? (default proposed: retain; GC via a future command)
2. **`submit_repair` concurrency** — last-writer-wins, or optimistic concurrency via `previous_resolved_at`? (default: LWW for Phase 1)
3. **CI kill switch** — file-absence only, or env-var `ARCHIGRAPH_DISABLE_REPAIR`? (default: file-absence only)
4. **`reclassify_as_resolved`** — re-run resolver pass on the new target, or treat as authoritative? (default: authoritative)
5. **Candidate scope** — emit `repair_edge` for `DispositionExternalUnknown` too, or bug- dispositions only? (default: bug- only in Phase 1)

## Phase 1 implementation tickets (filed)

- #544 — extended enrichment-candidates v2 emission
- #545 — repair.json reader + indexer integration point
- #546 — verification + trust-model enforcement (R1-R7)
- #547 — source-attribution on graph edges
- #548 — stale-repair detection
- #549 — MCP tool: list_residuals
- #550 — MCP tool: submit_repair
- #551 — test corpus + integration test

Dependency order: #544 → (#545, #549) → (#546, #547, #548, #550) → #551.

## Test plan

- [ ] ADR + specs reviewed by owner
- [ ] Open questions resolved (5 items above)
- [ ] Dispatch the 8-ticket wave (#544 - #551)
- [ ] Synthetic corpus bug-rate 12% → 0% via reference repair.json (#551 acceptance)
- [ ] django-realworld bug-rate 7.83% → ≤1% via agent loop
- [ ] client-fixture group bug-rate ≤1% after agent pass
- [ ] Determinism: same source + same repair.json → byte-identical graph.json (extends #486)

