### PR TITLE
[#560] flatten phantom relationship entities in cross-extractors

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -44,6 +44,43 @@ miss these lines should be sent back to the agent before merge.
 | `upstream` | > 8%, blocked on an extractor/resolver primitive being landed elsewhere |
 | `unmeasured` | in `scripts/verify2/run.sh` tier-1 manifest but not yet indexed (not on disk) |
 
+## Post-#560 honest baseline (2026-05-19)
+
+#560 flattened the synthetic `kind: "relationship"` container EntityRecords
+emitted by the 4 cross-extractors (imports, httpclient, hierarchy, manifest)
+into edges embedded on the existing SCOPE.Component / SCOPE.ExternalAPI
+entities. **Bug-rate is unchanged on every repo** because the resolver
+disposition logic walks `EntityRecord.Relationships` (which still contains
+the same edges) — phantom container entities never contributed to bug
+counts. **Entity counts drop** on every repo that uses these extractors,
+which is the structural correction (the data-model lie is removed):
+
+| Repo | Pre-#560 ent | Post-#560 ent | Delta | Rel delta |
+|---|---:|---:|---:|---:|
+| chi | 2,359 | 2,039 | -320 | 0 |
+| gin | 6,354 | 5,835 | -519 | 0 |
+| express | 2,017 | 1,633 | -384 | 0 |
+| spdlog | 1,772 | 1,770 | -2 | 0 |
+| nextjs-commerce | 879 | 713 | -166 | 0 |
+| nestjs-starter | 71 | 52 | -19 | 0 |
+| play-scala-starter | 256 | 251 | -5 | 0 |
+| kafka-streams-examples | 2,884 | 2,522 | -362 | 0 |
+| vapor-api-template | 60 | 60 | 0 | 0 |
+| http.zig | 889 | 889 | 0 | 0 |
+| terraform-aws-vpc | 2,403 | 2,403 | 0 | 0 |
+| django-realworld | 690 | 563 | -127 | 0 |
+| flask-realworld | 917 | 815 | -102 | 0 |
+| click | 5,019 | 4,597 | -422 | 0 |
+| requests | 22,218 | 21,902 | -316 | 0 |
+| client-fixture-a | 10,565 | 9,118 | -1,447 | 0 |
+| client-fixture-b | 15,884 | 12,647 | -3,237 | 0 |
+| client-fixture-c | 8,980 | 7,361 | -1,619 | 0 |
+
+Zero edges lost on any repo (rel delta = 0 everywhere). The
+`Latest bug-rate` columns in the ledger below are valid as-is post-#560
+and need no row-by-row rewrite; they are the post-#560 honest baseline
+going forward.
+
 ## Sources of truth
 
 - Latest aggregate measurement: `docs/verify2/quick-tier1-baseline-refresh-2026-05-19-v3.md` (40 repos, post-determinism #486, includes #474-#483 chain-fixes — **reliable single-shot**)

--- a/internal/extractors/cross/hierarchy/extractor.go
+++ b/internal/extractors/cross/hierarchy/extractor.go
@@ -121,7 +121,27 @@ func (r *result) addEntity(e types.EntityRecord) {
 }
 
 func (r *result) addRel(from, to, kind string, props map[string]string) {
-	// Attach relationship to a sentinel entity so it flows through the pipeline.
+	// #560: embed the edge on the most recently emitted entity (the child
+	// class or the implementing interface) instead of a synthetic
+	// "relationship"-kind container entity. The downstream pipeline walks
+	// EntityRecord.Relationships across every record, so this still flows.
+	//
+	// All in-tree callers add the parent/iface entity immediately before
+	// calling addRel, so there will be at least one entity to attach to. As a
+	// defensive fallback (and to preserve the previous behaviour of "the edge
+	// is never silently dropped"), we keep the sentinel container if no
+	// entity exists yet — but assert via a panic-free no-op equivalent: a
+	// freshly-created class entity that owns the edge.
+	if n := len(r.entities); n > 0 {
+		r.entities[n-1].Relationships = append(r.entities[n-1].Relationships, types.RelationshipRecord{
+			FromID:     from,
+			ToID:       to,
+			Kind:       kind,
+			Properties: props,
+		})
+		return
+	}
+	// Fallback: should be unreachable given current callers.
 	r.entities = append(r.entities, types.EntityRecord{
 		Name:       kind + ":" + from + "->" + to,
 		Kind:       "relationship",

--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -304,13 +304,17 @@ func apiRef(url string) string {
 func buildEntitiesAndRels(filePath string, calls []call, importedModules map[string]bool) []types.EntityRecord {
 	var out []types.EntityRecord
 	cRef := callerRef(filePath)
-	seenURLs := map[string]bool{}
+	// indexOf maps url -> position in `out` of the SCOPE.ExternalAPI for that
+	// URL, so the CALLS edge can be embedded on the real entity instead of a
+	// synthetic "relationship"-kind container (#560). Multiple call sites with
+	// distinct HTTP methods to the same URL each contribute an embedded edge.
+	indexOf := map[string]int{}
 
 	for _, c := range calls {
 		aRef := apiRef(c.url)
 
-		if !seenURLs[c.url] {
-			seenURLs[c.url] = true
+		idx, seen := indexOf[c.url]
+		if !seen {
 			out = append(out, types.EntityRecord{
 				Name:       c.url,
 				Kind:       "SCOPE.ExternalAPI",
@@ -322,6 +326,8 @@ func buildEntitiesAndRels(filePath string, calls []call, importedModules map[str
 				},
 				QualityScore: 0.8,
 			})
+			idx = len(out) - 1
+			indexOf[c.url] = idx
 		}
 
 		protocol := detectProtocol(c.url, importedModules)
@@ -334,24 +340,11 @@ func buildEntitiesAndRels(filePath string, calls []call, importedModules map[str
 			relProps["http_method"] = c.method
 		}
 
-		relName := "CALLS:" + cRef + "->" + aRef
-		if c.method != "" {
-			relName += ":" + c.method
-		}
-		out = append(out, types.EntityRecord{
-			Name:       relName,
-			Kind:       "relationship",
-			Subtype:    "calls",
-			SourceFile: filePath,
-			Relationships: []types.RelationshipRecord{
-				{
-					FromID:     cRef,
-					ToID:       aRef,
-					Kind:       "CALLS",
-					Properties: relProps,
-				},
-			},
-			QualityScore: 0.8,
+		out[idx].Relationships = append(out[idx].Relationships, types.RelationshipRecord{
+			FromID:     cRef,
+			ToID:       aRef,
+			Kind:       "CALLS",
+			Properties: relProps,
 		})
 	}
 

--- a/internal/extractors/cross/httpclient/extractor_test.go
+++ b/internal/extractors/cross/httpclient/extractor_test.go
@@ -33,10 +33,16 @@ func apiEntities(records []types.EntityRecord) []types.EntityRecord {
 }
 
 func callRels(records []types.EntityRecord) []types.RelationshipRecord {
+	// #560: post-flatten, CALLS edges are embedded directly on the
+	// SCOPE.ExternalAPI entity rather than on a synthetic
+	// "relationship"-kind container. Scan every record's Relationships and
+	// filter by Kind to keep the helper precise.
 	var out []types.RelationshipRecord
 	for _, r := range records {
-		if r.Kind == "relationship" {
-			out = append(out, r.Relationships...)
+		for _, rel := range r.Relationships {
+			if rel.Kind == "CALLS" {
+				out = append(out, rel)
+			}
 		}
 	}
 	return out

--- a/internal/extractors/cross/imports/extractor.go
+++ b/internal/extractors/cross/imports/extractor.go
@@ -372,13 +372,16 @@ var langExtractors = map[string]extractFn{
 func buildEntitiesAndRels(filePath string, imports []importRecord) []types.EntityRecord {
 	var out []types.EntityRecord
 	fRef := fileRef(filePath)
-	seenRefs := map[string]bool{}
+	// indexOf maps modRef -> position in `out` of the SCOPE.Component carrying
+	// that module, so the DEPENDS_ON edge can be embedded directly on the real
+	// entity instead of a synthetic "relationship"-kind container (#560).
+	indexOf := map[string]int{}
 
 	for _, imp := range imports {
 		modRef := moduleRef(imp.module, imp.isLocal)
 
-		if !seenRefs[modRef] {
-			seenRefs[modRef] = true
+		idx, seen := indexOf[modRef]
+		if !seen {
 			extDep := "true"
 			if imp.isLocal {
 				extDep = "false"
@@ -396,28 +399,24 @@ func buildEntitiesAndRels(filePath string, imports []importRecord) []types.Entit
 				},
 				QualityScore: 0.8,
 			})
+			idx = len(out) - 1
+			indexOf[modRef] = idx
 		}
 
-		// Relationship entity
-		out = append(out, types.EntityRecord{
-			Name:       "DEPENDS_ON:" + fRef + "->" + modRef,
-			Kind:       "relationship",
-			Subtype:    "depends_on",
-			SourceFile: filePath,
-			Relationships: []types.RelationshipRecord{
-				{
-					FromID: fRef,
-					ToID:   modRef,
-					Kind:   "DEPENDS_ON",
-					Properties: map[string]string{
-						"kind":       "import",
-						"module":     imp.module,
-						"is_local":   boolStr(imp.isLocal),
-						"raw_import": imp.raw,
-					},
-				},
+		// Embed the DEPENDS_ON relationship on the SCOPE.Component for this
+		// module rather than emitting a synthetic relationship-kind entity.
+		// The downstream pipeline (cmd/archigraph/index.go) walks every
+		// EntityRecord.Relationships, so the edge still reaches the document.
+		out[idx].Relationships = append(out[idx].Relationships, types.RelationshipRecord{
+			FromID: fRef,
+			ToID:   modRef,
+			Kind:   "DEPENDS_ON",
+			Properties: map[string]string{
+				"kind":       "import",
+				"module":     imp.module,
+				"is_local":   boolStr(imp.isLocal),
+				"raw_import": imp.raw,
 			},
-			QualityScore: 0.8,
 		})
 	}
 	return out

--- a/internal/extractors/cross/manifest/extractor.go
+++ b/internal/extractors/cross/manifest/extractor.go
@@ -420,6 +420,10 @@ func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.E
 			isDev = "true"
 		}
 
+		// #560: emit a single SCOPE.Component carrying the DEPENDS_ON edge
+		// embedded in its Relationships, rather than a real entity plus a
+		// synthetic "relationship"-kind container entity that the downstream
+		// pipeline would otherwise count as a phantom entity.
 		out = append(out, types.EntityRecord{
 			Name:       d.name,
 			Kind:       "SCOPE.Component",
@@ -434,14 +438,6 @@ func buildEntitiesAndRels(filePath, packageManager string, deps []dep) []types.E
 				"ref":                 pRef,
 				"provenance":          "INFERRED_FROM_PACKAGE_MANIFEST",
 			},
-			QualityScore: 0.8,
-		})
-
-		out = append(out, types.EntityRecord{
-			Name:       "DEPENDS_ON:" + projRef + "->" + pRef,
-			Kind:       "relationship",
-			Subtype:    "depends_on",
-			SourceFile: filePath,
 			Relationships: []types.RelationshipRecord{
 				{
 					FromID: projRef,

--- a/internal/extractors/cross/manifest/extractor_test.go
+++ b/internal/extractors/cross/manifest/extractor_test.go
@@ -31,11 +31,16 @@ func depEntities(records []types.EntityRecord) []types.EntityRecord {
 	return out
 }
 
-func relEntities(records []types.EntityRecord) []types.EntityRecord {
-	var out []types.EntityRecord
+// dependsOnRels returns every DEPENDS_ON edge embedded across all records.
+// #560: edges are now embedded on the SCOPE.Component for each dep rather
+// than on a synthetic "relationship"-kind container entity.
+func dependsOnRels(records []types.EntityRecord) []types.RelationshipRecord {
+	var out []types.RelationshipRecord
 	for _, r := range records {
-		if r.Kind == "relationship" {
-			out = append(out, r)
+		for _, rel := range r.Relationships {
+			if rel.Kind == "DEPENDS_ON" {
+				out = append(out, rel)
+			}
 		}
 	}
 	return out
@@ -312,11 +317,11 @@ func TestNonManifest_ReturnsEmpty(t *testing.T) {
 func TestRelationshipsEmitted(t *testing.T) {
 	src := `{"dependencies":{"lodash":"4.17.21"}}`
 	records := runExtract(t, "package.json", src)
-	rels := relEntities(records)
+	rels := dependsOnRels(records)
 	if len(rels) != 1 {
-		t.Fatalf("expected 1 relationship entity, got %d", len(rels))
+		t.Fatalf("expected 1 DEPENDS_ON edge, got %d", len(rels))
 	}
-	r := rels[0].Relationships[0]
+	r := rels[0]
 	if r.Kind != "DEPENDS_ON" {
 		t.Errorf("rel kind=%q want DEPENDS_ON", r.Kind)
 	}


### PR DESCRIPTION
## Summary

The 4 cross-extractors (`imports`, `httpclient`, `hierarchy`, `manifest`) were emitting synthetic `EntityRecord{Kind: "relationship"}` containers whose only job was to carry one `RelationshipRecord` through the pipeline. The downstream code in `cmd/archigraph/index.go` walks `r.Relationships` on every record regardless of kind, so the container itself was pure phantom entity inventory — 1,619 phantoms on client-fixture-c (~18% inflation) and similar across every TS/JS/import-heavy corpus.

This PR drops the container and embeds the edge directly on the real entity emitted in the same iteration:

- `imports/extractor.go` — DEPENDS_ON embedded on the `SCOPE.Component` for the imported module (indexed-by-modRef to handle repeat imports)
- `httpclient/extractor.go` — CALLS embedded on the `SCOPE.ExternalAPI` for the URL (indexed-by-URL; multiple methods per URL still emit multiple edges on the same entity)
- `hierarchy/extractor.go` — `addRel` now appends to the most recently emitted entity's Relationships (the child class or implementing interface). Defensive sentinel fallback retained for any future caller that doesn't precede `addRel` with `addEntity`
- `manifest/extractor.go` — DEPENDS_ON embedded on the `SCOPE.Component` for the package dep

Test helpers in `httpclient/extractor_test.go` and `manifest/extractor_test.go` that filtered records by `Kind == "relationship"` updated to walk every record's `Relationships` and filter by `RelationshipRecord.Kind`.

## Regression — tier-1 corpus + private fixtures (18 repos)

Built `/tmp/archigraph-pre` from origin/main pre-fix, ran the same `index --json-stats` against every repo with both binaries:

| Repo | Pre ent | Post ent | Ent delta | Pre rel | Post rel | Rel delta | Pre bug-rate | Post bug-rate |
|---|---:|---:|---:|---:|---:|---:|---:|---:|
| chi | 2,359 | 2,039 | -320 | 3,826 | 3,826 | 0 | 0.04286 | 0.04286 |
| gin | 6,354 | 5,835 | -519 | 11,335 | 11,335 | 0 | 0.04945 | 0.04945 |
| express | 2,017 | 1,633 | -384 | 1,068 | 1,068 | 0 | 0.03277 | 0.03277 |
| spdlog | 1,772 | 1,770 | -2 | 3,326 | 3,326 | 0 | 0.05938 | 0.05938 |
| nextjs-commerce | 879 | 713 | -166 | 669 | 669 | 0 | 0.03662 | 0.03662 |
| nestjs-starter | 71 | 52 | -19 | 57 | 57 | 0 | 0.01754 | 0.01754 |
| play-scala-starter | 256 | 251 | -5 | 71 | 71 | 0 | 0.02113 | 0.02113 |
| kafka-streams-examples | 2,884 | 2,522 | -362 | 8,156 | 8,156 | 0 | 0.03807 | 0.03807 |
| vapor-api-template | 60 | 60 | 0 | 47 | 47 | 0 | 0.02128 | 0.02128 |
| http.zig | 889 | 889 | 0 | 1,874 | 1,874 | 0 | 0.10005 | 0.10005 |
| terraform-aws-vpc | 2,403 | 2,403 | 0 | 3,650 | 3,650 | 0 | 0.00000 | 0.00000 |
| django-realworld | 690 | 563 | -127 | 530 | 530 | 0 | 0.04906 | 0.04906 |
| flask-realworld | 917 | 815 | -102 | 934 | 934 | 0 | 0.07388 | 0.07388 |
| click | 5,019 | 4,597 | -422 | 7,841 | 7,841 | 0 | 0.06434 | 0.06434 |
| requests | 22,218 | 21,902 | -316 | 23,584 | 23,584 | 0 | 0.01509 | 0.01509 |
| client-fixture-a | 10,565 | 9,118 | **-1,447** | 15,496 | 15,496 | **0** | 0.11997 | 0.11997 |
| client-fixture-b | 15,884 | 12,647 | **-3,237** | 22,322 | 22,322 | **0** | 0.12096 | 0.12096 |
| client-fixture-c | 8,980 | 7,361 | **-1,619** | 8,654 | 8,654 | **0** | 0.03987 | 0.03987 |

**No relationships were lost on any repo** — every `Rel delta` column is exactly 0. Total relationship count is identical pre- and post-fix on all 18 measured repos.

vapor-api-template, http.zig and terraform-aws-vpc are unchanged because they do not exercise these 4 cross-extractors in any meaningful volume.

Bug-rate is unchanged on every repo because resolver dispositions key off the `RelationshipRecord` (which still exists, just embedded on a real entity instead of a phantom container), not the carrier `EntityRecord`. The structural correctness win — phantom entities removed from the graph — does not move the bug-rate needle here, but the underlying data-model lie is gone.

## Test plan

- [x] `go build -o build/archigraph ./cmd/archigraph` — succeeds
- [x] `go test ./...` — passes (`internal/extractors/cross/...`, `internal/resolve/...`, all extractor packages, indexer)
- [x] Regression across 15 tier-1 corpora + 3 private fixtures — entities drop, relationships stable, bug-rate unchanged
- [x] No edges lost on any repo

## Notes

- `docs/verify2/per-repo-residual-ledger.md` updated with a "Post-#560 honest baseline" section. Per-row `Latest bug-rate` columns are unchanged because the underlying number didn't move; they are valid as the post-#560 baseline going forward.
- Scope is strictly the 4 cross-extractor files + their tests + the ledger note. Untouched: JS const extraction (#562), bug-rate formula (#561), any other extractor.

Residual root cause: the original data-model anti-pattern — relationships were represented as entities-that-carry-edges, double-counting in any metric whose denominator was entity count.
Status: at-ship-gate for the flattening itself.

Refs #560