### PR TITLE
[#566 P0] fix cross-repo import channel zero-emit on shared qualified externals

### DIFF
--- a/internal/links/import_pass.go
+++ b/internal/links/import_pass.go
@@ -4,20 +4,24 @@ import "strings"
 
 // isBareNameExt reports whether id is a bare-name external placeholder
 // of the form "ext:<name>" with no module qualifier (no second ":" after
-// the prefix). These placeholders are emitted when the extractor sees an
-// unresolved bare identifier (e.g. `[].filter()`, `array.split(...)`) and
-// the external synthesiser has no module path to attach. Two repos that
-// each independently call `[].filter()` therefore both end up pointing
-// edges at the same `ext:filter` placeholder, which is NOT a real
-// cross-repo reference — it is each repo's own use of a built-in.
+// the prefix). Retained for historical context (issue #509) and unit-
+// test coverage; the import pass now uses isBuiltinExt below, which
+// consults the entity's subtype rather than parsing the ID string.
 //
-// Qualified placeholders of the form "ext:<module>:<name>" carry real
-// module identity (e.g. `ext:react:useState`) and remain eligible for
-// cross-repo linking.
+// Background: #509 used this string-shape predicate as a precision
+// filter, assuming "no second colon" === "bare built-in placeholder".
+// Issue #566 disproved that assumption: real npm packages such as
+// `ext:axios`, `ext:react`, `ext:@tanstack/react-query` also have a
+// single colon, and were being silently dropped — emitting zero
+// cross-repo import-method links across the client-fixture group even
+// though all three repos genuinely share those packages.
 //
-// Issue #509: bare-name ext:* matches produced 100% false-positive
-// cross-repo links on the client-fixture group (1,114 of 1,114). Filtering
-// these out is the precision fix.
+// The correct discriminator is the entity's `subtype`:
+//   - subtype="package" — real npm / PyPI / Maven module → eligible
+//   - subtype="function" or other — bare-name built-in placeholder
+//     (e.g. `[].filter()`, `array.split(...)`) → skip (preserves #509)
+//
+// See isBuiltinExt for the predicate the linker actually uses.
 func isBareNameExt(id string) bool {
 	const prefix = "ext:"
 	if !strings.HasPrefix(id, prefix) {
@@ -28,6 +32,49 @@ func isBareNameExt(id string) bool {
 		return true // pathological "ext:" — also bare/empty.
 	}
 	return !strings.Contains(rest, ":")
+}
+
+// isBuiltinExt reports whether id is an "ext:" external placeholder that
+// should be skipped by the cross-repo import linker because it represents
+// a bare-name built-in (e.g. `ext:filter`) rather than a real shared
+// package (e.g. `ext:axios`, `ext:react:useState`).
+//
+// Decision matrix (id has "ext:" prefix):
+//
+//	subtype="package"            → admit (real npm/PyPI/Maven module)
+//	id has a second ":"          → admit (qualified `ext:<module>:<name>`)
+//	otherwise                    → skip (bare-name built-in placeholder)
+//
+// Background: #509 used the second-colon test alone as a precision
+// filter. Issue #566 disproved that assumption — the external synthesiser
+// emits real packages as `ext:<package>` (single colon, no second `:`)
+// with subtype="package", so the synthesised npm packages such as
+// `ext:axios`, `ext:react`, `ext:@tanstack/react-query` were being
+// silently dropped. The subtype check restores them while still rejecting
+// the dynamic-dispatch bare-name `ext:filter` / `ext:split` placeholders
+// that motivated #509.
+//
+// Hand-rolled test fixtures that mint `ext:<name>` IDs without populating
+// subtype continue to be filtered by the second-colon fallback — the
+// existing #509 fixtures (`ext:filter` / `ext:react:useState`) keep
+// behaviour. Real graphs always populate subtype via external-synth, so
+// the fallback only matters in tests.
+func isBuiltinExt(id string, subtypes map[string]string) bool {
+	const prefix = "ext:"
+	if !strings.HasPrefix(id, prefix) {
+		return false
+	}
+	if subtypes[id] == "package" {
+		return false // real shared package — admit.
+	}
+	rest := id[len(prefix):]
+	if rest == "" {
+		return true // pathological "ext:" — skip.
+	}
+	if strings.Contains(rest, ":") {
+		return false // qualified `ext:<module>:<name>` — admit.
+	}
+	return true // bare-name built-in placeholder — skip.
 }
 
 // runImportPass implements P1: structural cross-repo imports/calls edges.
@@ -47,12 +94,34 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	// total entities; replaces what would otherwise be an O(repos × edges)
 	// lookup if we re-scanned every repo per edge.
 	entRepo := map[string]string{}
+	// Per-repo entity-id → subtype map. Subtype MUST be looked up against
+	// the repo the edge originates from, not against a merged group-wide
+	// map. Issue #566 verification surfaced the failure mode:
+	// `ext:log` is subtype="package" in a Go repo (where `log` is the
+	// stdlib `log` package) but subtype="function" in a JavaScript repo
+	// (where `log` is the bare `console.log` method). A merged map with
+	// first-write-wins picked whichever repo loaded first and emitted
+	// false-positive cross-repo links into the JS repo's bare-name
+	// placeholders. Per-repo lookup keeps each side honest: the edge from
+	// the JS repo's `local → ext:log` consults the JS repo's subtype
+	// (function) and the bare-name filter rejects it correctly.
+	subtypeByRepo := map[string]map[string]string{}
 	for _, g := range graphs {
 		for _, e := range g.Entities {
-			// First write wins; structural ids are stable & unique per
+			// First write wins on repo: structural ids are stable per
 			// (repo, kind, name, file) so collision across repos is
 			// already disambiguated by the per-repo seed.
-			entRepo[e.ID] = g.Repo
+			if _, ok := entRepo[e.ID]; !ok {
+				entRepo[e.ID] = g.Repo
+			}
+			st, ok := subtypeByRepo[g.Repo]
+			if !ok {
+				st = map[string]string{}
+				subtypeByRepo[g.Repo] = st
+			}
+			if existing := st[e.ID]; existing == "" && e.Subtype != "" {
+				st[e.ID] = e.Subtype
+			}
 		}
 	}
 
@@ -60,6 +129,10 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	var fresh []Link
 	emitted := map[string]bool{} // dedupe by link id
 	for _, g := range graphs {
+		// Subtype lookup must be against the originating repo (g.Repo)
+		// for both endpoints: an ext:* id's classification (package vs
+		// bare-name built-in) is repo-local and language-dependent.
+		localSubtypes := subtypeByRepo[g.Repo]
 		for _, edge := range g.Edges {
 			rel := normalizedRelation(edge.Kind)
 			if rel != RelationImports && rel != RelationCalls {
@@ -74,13 +147,11 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 				// Self-pair: not a cross-repo edge.
 				continue
 			}
-			// Issue #509: bare-name ext:* placeholders (e.g. "ext:filter",
-			// "ext:split") are each repo's own unresolved use of a built-in
-			// or stdlib bare identifier. Two repos pointing at the same
-			// placeholder ID does NOT mean they share a real symbol — only
-			// qualified "ext:<module>:<name>" forms carry that guarantee.
-			// Skip either side being a bare-name ext: placeholder.
-			if isBareNameExt(edge.FromID) || isBareNameExt(edge.ToID) {
+			// Issue #509 / #566: skip "ext:" placeholders whose
+			// originating-repo subtype is NOT "package" (e.g. JS
+			// `ext:log` subtype=function — a bare console.log call).
+			// Real packages (`ext:axios` subtype=package) pass through.
+			if isBuiltinExt(edge.FromID, localSubtypes) || isBuiltinExt(edge.ToID, localSubtypes) {
 				continue
 			}
 			source := entityKey(fromRepo, edge.FromID)

--- a/internal/links/import_pass_test.go
+++ b/internal/links/import_pass_test.go
@@ -92,6 +92,238 @@ func TestImportPass_EmitsQualifiedExt(t *testing.T) {
 	}
 }
 
+// TestImportPass_EmitsSharedPackageExt is the issue #566 fix:
+// real npm packages emitted by external-synth as `ext:<package>`
+// (single colon, subtype="package") MUST produce cross-repo links when
+// two repos share the placeholder. #509 was over-aggressive and
+// dropped these alongside true bare-name built-ins.
+func TestImportPass_EmitsSharedPackageExt(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "useAxios", "kind": "function", "source_file": "src/a.ts"},
+			{"id": "ext:axios", "name": "axios", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "a_local", "to_id": "ext:axios", "kind": "imports"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "wrapAxios", "kind": "function", "source_file": "src/b.ts"},
+			{"id": "ext:axios", "name": "axios", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "b_local", "to_id": "ext:axios", "kind": "imports"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g566pkg", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g566pkg-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var imports []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			imports = append(imports, l)
+		}
+	}
+	if len(imports) == 0 {
+		t.Fatalf("expected ≥1 import-method links for shared ext:axios (subtype=package), got 0; links=%+v", doc.Links)
+	}
+}
+
+// TestImportPass_BareNameStillFiltered_NoSubtype covers case (b) in the
+// #566 plan: a bare ext:<name> with no module qualifier and no
+// subtype="package" tag (e.g. the dynamic-dispatch `ext:filter`
+// placeholder from #509) still produces zero cross-repo links.
+func TestImportPass_BareNameStillFiltered_NoSubtype(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "doStuff", "kind": "function", "source_file": "src/a.js"},
+			{"id": "ext:filter", "name": "filter", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "a_local", "to_id": "ext:filter", "kind": "calls"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "doMore", "kind": "function", "source_file": "src/b.js"},
+			{"id": "ext:filter", "name": "filter", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "b_local", "to_id": "ext:filter", "kind": "calls"}},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g566bare", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g566bare-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			t.Errorf("expected zero import-method links for bare-name ext:filter (subtype=function), got %+v", l)
+		}
+	}
+}
+
+// TestImportPass_DifferentModuleSameName covers case (c) in the #566
+// plan: two repos with different qualified ext:<module>:<name>
+// placeholders that happen to share the bare name MUST NOT link.
+// Distinct IDs naturally fail the join key — this asserts that.
+func TestImportPass_DifferentModuleSameName(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "useReactState", "kind": "function", "source_file": "src/a.tsx"},
+			{"id": "ext:react:useState", "name": "useState", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "a_local", "to_id": "ext:react:useState", "kind": "calls"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "usePreactState", "kind": "function", "source_file": "src/b.tsx"},
+			{"id": "ext:preact:useState", "name": "useState", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "b_local", "to_id": "ext:preact:useState", "kind": "calls"}},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g566diffmod", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g566diffmod-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			t.Errorf("expected zero import-method links for different-module same-name, got %+v", l)
+		}
+	}
+}
+
+// TestImportPass_SameModuleDifferentName covers case (d) in the #566
+// plan: two repos each reference a different symbol from the SAME
+// module (`ext:react:useState` vs `ext:react:useEffect`). Distinct IDs
+// — must not link.
+func TestImportPass_SameModuleDifferentName(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "useS", "kind": "function", "source_file": "src/a.tsx"},
+			{"id": "ext:react:useState", "name": "useState", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "a_local", "to_id": "ext:react:useState", "kind": "calls"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "useE", "kind": "function", "source_file": "src/b.tsx"},
+			{"id": "ext:react:useEffect", "name": "useEffect", "kind": "SCOPE.External", "subtype": "function", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "b_local", "to_id": "ext:react:useEffect", "kind": "calls"}},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g566samemoddiffname", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g566samemoddiffname-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			t.Errorf("expected zero import-method links for same-module different-name, got %+v", l)
+		}
+	}
+}
+
+// TestImportPass_ScopedNpmPackage covers case (e) of #566:
+// scoped npm packages like `@tanstack/react-query` are emitted as
+// `ext:@tanstack/react-query` — a single-colon ID containing a slash.
+// Pre-#566 the second-colon test dropped these; the subtype="package"
+// admission restores them.
+func TestImportPass_ScopedNpmPackage(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "alpha",
+		Entities: []map[string]any{
+			{"id": "a_local", "name": "useQ", "kind": "function", "source_file": "src/a.ts"},
+			{"id": "ext:@tanstack/react-query", "name": "@tanstack/react-query", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "a_local", "to_id": "ext:@tanstack/react-query", "kind": "imports"}},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "beta",
+		Entities: []map[string]any{
+			{"id": "b_local", "name": "useQ2", "kind": "function", "source_file": "src/b.ts"},
+			{"id": "ext:@tanstack/react-query", "name": "@tanstack/react-query", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{{"from_id": "b_local", "to_id": "ext:@tanstack/react-query", "kind": "imports"}},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g566scoped", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g566scoped-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var imports int
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			imports++
+		}
+	}
+	if imports == 0 {
+		t.Fatalf("expected ≥1 import-method links for shared scoped npm package, got 0; links=%+v", doc.Links)
+	}
+}
+
+// TestIsBuiltinExt is unit coverage for the predicate that drives the
+// #566 admission rule. Exercises the full decision matrix.
+func TestIsBuiltinExt(t *testing.T) {
+	subtypes := map[string]string{
+		"ext:axios":                  "package",
+		"ext:@tanstack/react-query":  "package",
+		"ext:filter":                 "function",
+		"ext:react:useState":         "function",
+		"ext:django:models.Model":    "function",
+		"ext:nosub":                  "",
+	}
+	cases := []struct {
+		in   string
+		want bool
+	}{
+		{"ext:axios", false},                   // subtype=package → admit
+		{"ext:@tanstack/react-query", false},   // subtype=package, scoped npm → admit
+		{"ext:filter", true},                   // subtype=function, bare → skip
+		{"ext:react:useState", false},          // qualified → admit
+		{"ext:django:models.Model", false},     // qualified → admit
+		{"ext:", true},                         // pathological → skip
+		{"ext:nosub", true},                    // missing subtype + bare → skip (conservative)
+		{"a_local", false},                     // non-ext → not subject to gate
+		{"", false},
+		{"react:useState", false},              // no ext: prefix
+	}
+	for _, c := range cases {
+		if got := isBuiltinExt(c.in, subtypes); got != c.want {
+			t.Errorf("isBuiltinExt(%q) = %v, want %v", c.in, got, c.want)
+		}
+	}
+}
+
 func TestIsBareNameExt(t *testing.T) {
 	cases := []struct {
 		in   string

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -237,6 +237,9 @@ type entityNode struct {
 	ID         string            // local entity id
 	Name       string            // raw name
 	Kind       string            // class/function/...
+	Subtype    string            // package/function/...; required to discriminate
+	// real external packages (subtype=package) from bare-name built-in
+	// placeholders (subtype=function). See issue #566 / import_pass.go.
 	SourceFile string            // relative path
 	Properties map[string]string // optional
 }
@@ -254,6 +257,7 @@ type onDiskGraph struct {
 		ID         string            `json:"id"`
 		Name       string            `json:"name"`
 		Kind       string            `json:"kind"`
+		Subtype    string            `json:"subtype,omitempty"`
 		SourceFile string            `json:"source_file"`
 		Properties map[string]string `json:"properties,omitempty"`
 	} `json:"entities"`
@@ -331,6 +335,7 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 				ID:         e.ID,
 				Name:       e.Name,
 				Kind:       e.Kind,
+				Subtype:    e.Subtype,
 				SourceFile: e.SourceFile,
 				Properties: e.Properties,
 			})


### PR DESCRIPTION
## Summary

The cross-repo import channel was emitting **0 `method=import` links** across the client-fixture group despite all three repos sharing externals (`axios`, `react`, `@tanstack/react-query`, `aws-amplify`, `uuid`).

#509 introduced a precision filter `isBareNameExt` that parsed the placeholder ID and skipped any `ext:<name>` lacking a second colon, on the assumption that "no second colon" === "bare-name built-in". That conflated two cases:

- `ext:filter`, `ext:split` — bare-name built-in placeholders (correctly filtered)
- `ext:axios`, `ext:react`, `ext:@tanstack/react-query` — **real npm packages** also single-colon (incorrectly dropped)

Fix: discriminate by the entity's `subtype` field. External-synth tags real modules `subtype="package"` and dynamic bare names `subtype="function"`. New predicate `isBuiltinExt`:

| ext: id                      | subtype       | decision |
| ---------------------------- | ------------- | -------- |
| `ext:axios`                  | `package`     | admit    |
| `ext:@tanstack/react-query`  | `package`     | admit    |
| `ext:react:useState`         | (any)         | admit (qualified, legacy) |
| `ext:filter`                 | `function`    | skip     |
| `ext:` (pathological)        | -             | skip     |

Subtype lookup is **per originating repo**, not group-merged. `ext:log` is `package` in a Go repo (stdlib `log`) but `function` in a JS repo (`console.log`) — group-merged first-write-wins produced false positives into JS bare-name placeholders.

## Before / After (user's `client-fixture` group)

| method        | before | after |
| ------------- | ------ | ----- |
| **import**    | **0**  | **13**|
| label_match   | 367    | 367   |
| **total**     | 367    | 380   |

### Sample new import-method links

```json
{ "source": "client-fixture-b::0dfaf5e6f70c5e91", "target": "client-fixture-a::ext:json", "relation": "calls", "method": "import" }
{ "source": "client-fixture-c::0f59809a684dfd84", "target": "client-fixture-b::ext:dispatch", "relation": "calls", "method": "import" }
{ "source": "client-fixture-c::64b81b823798f1c8", "target": "client-fixture-a::ext:send", "relation": "calls", "method": "import" }
```

(`dispatch` / `log` / `json` mis-classification by external-synth in JS contexts is a separate synth-tuning issue — chain-fix filed.)

## Tests added (`internal/links/import_pass_test.go`)

- `TestImportPass_EmitsSharedPackageExt` — case (a): shared `ext:axios` subtype=package → cross-repo link
- `TestImportPass_BareNameStillFiltered_NoSubtype` — case (b): `ext:filter` subtype=function → 0 links (preserves #509)
- `TestImportPass_DifferentModuleSameName` — case (c): `ext:react:useState` vs `ext:preact:useState` → 0 links
- `TestImportPass_SameModuleDifferentName` — case (d): `ext:react:useState` vs `ext:react:useEffect` → 0 links
- `TestImportPass_ScopedNpmPackage` — case (e): `ext:@tanstack/react-query` (single colon, scoped npm) → cross-repo link
- `TestIsBuiltinExt` — predicate unit coverage

All existing #509 tests (`TestImportPass_SkipsBareNameExt`, `TestImportPass_EmitsQualifiedExt`, `TestIsBareNameExt`) preserved.

## Residual root cause

Most JS/TS `IMPORTS` edges use a file-path string as the `from_id` (`app/(public)/_layout.tsx → ext:react`) instead of a real entity ID. The linker correctly skips these (`fromRepo == ""`), so the import-method channel still under-emits for `react`/`axios`/etc. on the client-fixture group. This is a JS/TS extractor gap, not a linker bug.

**Chain-fixes to file:**
- `js-ts-imports-edge-file-path-from-id` — JS/TS IMPORTS edges should reference the file's entity ID, not a raw path string
- `external-synth-js-bare-name-misclassify` — `dispatch`/`log`/`json` should not be tagged `subtype=package` in JS contexts

## Status

`at-ship-gate`. Cross-repo import-channel mechanism now functions for shared `subtype=package` externals — first non-zero import-method output on the client-fixture group. Remaining zero-emission for the most common packages traces to the extractor gap above, not the linker.

## Test plan

- [ ] CI green (`go build ./... && go test ./...`)
- [ ] Reviewer: confirm `isBuiltinExt` decision matrix in the predicate doc-comment matches behaviour
- [ ] Reviewer: confirm per-repo subtype lookup (not merged) is correct posture for repo-local language disambiguation