### PR TITLE
[P0] JS/TS IMPORTS: emit file-level entity so resolver rewrites from_id (unblocks cross-repo linker)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -90,6 +90,39 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		repoRoot: file.RepoRoot,
 	}
 
+	// Issue #570 — emit a file-level SCOPE.Component (subtype="file")
+	// entity per source file so the cross-repo import linker (#566)
+	// can map IMPORTS edges back to the originating repo via the
+	// resolver's byName index. Before this change every JS/TS IMPORTS
+	// edge carried FromID=<file path string>; the linker's
+	// `entRepo[edge.FromID]` lookup missed because no entity had that
+	// path as its ID, collapsing the candidate cross-repo
+	// `method=import` link count to ~0 across the client-fixture
+	// group despite #566/#569 making the rest of the pipeline work
+	// end-to-end. With the file-level entity present, the resolver's
+	// ReferencesEmbeddedWithAllowlist pass rewrites the IMPORTS
+	// FromID from the path string to the file entity's stamped hex ID
+	// (graph.EntityID(repoTag, "SCOPE.Component", path, path)) via
+	// byName, and the linker then matches it back to the source repo.
+	// We do NOT pre-stamp the ID here — the extractor doesn't know
+	// the indexer's repoTag seed, so any hex we wrote would be
+	// short-circuited as already-hex by isHexID in the resolver and
+	// the rewrite would never happen.
+	fileEntity := types.EntityRecord{
+		Name:       file.Path,
+		Kind:       "SCOPE.Component",
+		SourceFile: file.Path,
+		Language:   file.Language,
+		Subtype:    "file",
+		Properties: map[string]string{
+			"kind":    "SCOPE.Component",
+			"subtype": "file",
+		},
+		EnrichmentStatus: types.StatusPending,
+		QualityScore:     1.0,
+	}
+	x.entities = append(x.entities, fileEntity)
+
 	// Issue #421 — collect import bindings BEFORE walking the body so
 	// receiver-typed CALLS edges materialised inside class methods can
 	// look up the imported source file at emission time. Bindings is
@@ -904,10 +937,17 @@ func (x *extractor) collectImportsNode(n *sitter.Node, seen map[string]bool, bin
 func (x *extractor) emitImport(module string, n *sitter.Node, bindings []*importBinding) {
 	// Use the full module path as the entity name for parity with Python indexer.
 	start, end := lines(n)
+	// Issue #570 — FromID is the importing file's path. The extractor
+	// also emits a file-level SCOPE.Component (subtype="file") entity
+	// with Name == file path at the top of Extract; the resolver's
+	// byName index then rewrites this path-shaped FromID to the file
+	// entity's stamped hex ID, and the cross-repo import linker
+	// (#566) can map the edge back to its originating repo.
+	fromID := x.filePath
 	rels := make([]types.RelationshipRecord, 0, max1(len(bindings)))
 	if len(bindings) == 0 {
 		rels = append(rels, types.RelationshipRecord{
-			FromID: x.filePath,
+			FromID: fromID,
 			ToID:   module,
 			Kind:   "IMPORTS",
 		})
@@ -941,7 +981,7 @@ func (x *extractor) emitImport(module string, n *sitter.Node, bindings []*import
 				toID = b.sourceModule + "." + b.importedName
 			}
 			rels = append(rels, types.RelationshipRecord{
-				FromID:     x.filePath,
+				FromID:     fromID,
 				ToID:       toID,
 				Kind:       "IMPORTS",
 				Properties: props,

--- a/internal/extractors/javascript/relationships_test.go
+++ b/internal/extractors/javascript/relationships_test.go
@@ -430,3 +430,80 @@ function run(repo: Repository) {
 			caller.Relationships)
 	}
 }
+
+// TestExtract_FileLevelEntityEnablesImportsFromIDRewrite (#570) —
+// the cross-repo import linker (#566) consults a per-entity-id →
+// repo index; a file-path-shaped from_id isn't in that index, so the
+// linker silently skipped every JS/TS import edge — collapsing the
+// candidate `method=import` link count to near-zero on shared
+// packages like react / axios / react-native between sibling repos.
+//
+// The fix has two parts that this test pins:
+//
+//  1. The extractor emits a file-level SCOPE.Component (subtype="file")
+//     entity whose Name == the file path. The indexer stamps it with
+//     graph.EntityID(repoTag, ...), and the resolver's byName index
+//     then maps the file-path string to the file-entity's hex ID.
+//
+//  2. Every IMPORTS edge keeps FromID == the file path string at
+//     extract time. The path is the file-entity's Name, so the
+//     resolver's ReferencesEmbeddedWithAllowlist pass rewrites the
+//     FromID to the file-entity's stamped hex ID before the link
+//     pipeline reads the graph. We do NOT pre-stamp a hex in the
+//     extractor because the extractor doesn't know the indexer's
+//     repoTag seed — a pre-stamped hex would short-circuit isHexID
+//     in ReferencesEmbedded and prevent the rewrite.
+//
+// This test asserts the extractor-side contract (file entity exists,
+// IMPORTS FromID matches its Name). The end-to-end hex-rewrite is
+// verified by re-indexing client-fixture-{a,b,c} and inspecting the
+// saved graph.json — see PR description.
+func TestExtract_FileLevelEntityEnablesImportsFromIDRewrite(t *testing.T) {
+	src := `import { UserService } from "./user/user.service";
+import express from "express";
+import * as fs from "fs";
+import "./side-effect";
+const lodash = require("lodash");
+`
+	tree := parseTSRel(t, []byte(src))
+	const path = "src/app/app.module.ts"
+	ents := runJSPath(t, src, "typescript", tree, path)
+
+	// 1. A file-level SCOPE.Component subtype="file" must exist for
+	//    the source path, so the indexer's byName index can map the
+	//    path-shaped FromID to the file entity's stamped hex ID.
+	var fileEntFound bool
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" && e.Name == path {
+			fileEntFound = true
+			break
+		}
+	}
+	if !fileEntFound {
+		t.Fatalf("expected file-level SCOPE.Component subtype=file entity for %s; ents=%+v", path, ents)
+	}
+
+	// 2. Every IMPORTS edge across every import-entity must carry
+	//    FromID == path (the file entity's Name). The resolver
+	//    rewrites this to the stamped hex ID at index-time.
+	var importEdges int
+	for _, e := range ents {
+		if e.Subtype != "import" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			importEdges++
+			if r.FromID != path {
+				t.Errorf("IMPORTS edge on %q has FromID=%q; want file path %q",
+					e.Name, r.FromID, path)
+			}
+		}
+	}
+	// Five distinct import shapes: named, default, namespace, side-effect, require.
+	if importEdges < 5 {
+		t.Errorf("expected at least 5 IMPORTS edges across shapes, got %d", importEdges)
+	}
+}


### PR DESCRIPTION
Closes #570.

## Before
JS/TS extractors emitted IMPORTS edges with file-path strings as `from_id` (e.g. `app/(public)/_layout.tsx → ext:react`). The cross-repo import linker (#566) consults a per-entity-id → repo index and correctly skipped these — file paths weren't entity IDs, so `entRepo[edge.FromID]` returned empty and the edge was dropped.

## After
The JS/TS extractor now emits a file-level `SCOPE.Component` (subtype="file") entity per source file whose `Name` is the file path. The indexer stamps it with `graph.EntityID(repoTag, ...)`, the resolver's `byName` index maps the path-shaped `IMPORTS` FromID to the stamped hex ID via `ReferencesEmbeddedWithAllowlist`, and the cross-repo linker can finally map the edge back to its originating repo.

**Design note:** the extractor deliberately keeps `FromID = file path` (not a pre-stamped hex). The extractor doesn't know the indexer's `repoTag` seed, so any hex it wrote would mismatch the stamped entity ID and `isHexID` in `ReferencesEmbedded` would short-circuit the rewrite. By leaving the path in place, we let the resolver do the rewrite using the stamped seed.

## Cross-repo link impact (client-fixture group)

| | before | after |
|---|---:|---:|
| `method=import` links total | 13 | **328** |
| `react` cross-repo links | 0 | 282 |
| `@tanstack/react-query` | 0 | 18 |
| `aws-amplify` | 0 | 5 |

Target from #570 acceptance: 50+. Achieved: **328**.

Sample new import-channel cross-repo links:
- `client-fixture-b::<file-id> → client-fixture-a::ext:react`
- `client-fixture-b::<file-id> → client-fixture-a::ext:@tanstack/react-query`
- `client-fixture-b::<file-id> → client-fixture-a::ext:aws-amplify`
- `client-fixture-b::<file-id> → client-fixture-c::ext:uuid`
- `client-fixture-c::<file-id> → client-fixture-b::ext:react`

The remaining false-positive bare-name links (`ext:json`, `ext:uuid`, `ext:dispatch`, `ext:send`) are the exact misclassifications captured by chain-fix #571.

## Tests
- New `TestExtract_FileLevelEntityEnablesImportsFromIDRewrite` in `internal/extractors/javascript/relationships_test.go` pins the extractor-side contract: file entity exists with `Name == file path`, and every IMPORTS edge has `FromID == file path`. The end-to-end hex-rewrite is verified by re-indexing the client fixtures.
- Full `go test ./...` passes.

## Bug-rate impact

| repo | main | this PR | delta |
|---|---:|---:|---:|
| client-fixture-a | 0.0832 | 0.0832 | 0.00pp |
| client-fixture-b | 0.1240 | 0.1210 | -0.30pp |
| client-fixture-c | 0.0399 | 0.0399 | 0.00pp |
| express | 0.0328 | 0.0328 | 0.00pp |
| nestjs-starter | 0.0175 | 0.0175 | 0.00pp |
| chi (go) | 0.0429 | 0.0429 | 0.00pp |
| flask (py) | 0.0957 | 0.0957 | 0.00pp |
| gin (go) | 0.0494 | 0.0494 | 0.00pp |
| spdlog (cpp) | 0.0594 | 0.0594 | 0.00pp |
| play-scala-starter | 0.0211 | 0.0211 | 0.00pp |
| kafka-streams-examples (java) | 0.0380 | 0.0380 | 0.00pp |
| nextjs-commerce (ts) | 0.0254 | 0.0366 | **+1.12pp** |

The single regression is `nextjs-commerce` (TS): +15 bug-extractor endpoints. But the same repo's resolution-rate jumped from 30.9% to 46.6% (+15.7pp), and 210 IMPORTS endpoints flipped from `dynamic` to `resolved`. Net signal-quality gain dominates the small bug-extractor uptick. Flagging for human review.

## Residual root cause
Other languages (Python, Go, Java, etc.) still emit IMPORTS FromIDs as raw file paths and don't emit file-level entities — they're routed to `DispositionDynamic` via `looksLikeSourceFilePath` so their bug-rate isn't affected, but their cross-repo import links are similarly invisible. Same pattern applies; tracking as chain-fix follow-up after this lands.

## Status
at-ship-gate / at-bar (with flagged nextjs-commerce regression)