### PR TITLE
[#577] all extractors: file-level entities to unblock cross-repo IMPORTS linker

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -305,3 +305,54 @@ are higher-bug-rate but each requires a dedicated multi-day extractor wave —
 prioritise via the JIRA backlog, not this ledger.
 
 forbidden-term grep: clean
+
+## #577 — file-level SCOPE.Component for all per-language extractors (2026-05-19)
+
+Generalised the JS/TS file-entity pattern from #570/#575 to every
+per-language extractor (Python, Go, Java, Ruby, PHP, Scala, Kotlin,
+Swift, C++, Rust, C#, Elixir). Each Extract now emits a per-source-file
+`SCOPE.Component` (subtype="file") record at the top of the entity
+slice so the cross-repo import linker (#566) can map IMPORTS edges
+back to the originating repo via the resolver's byName index.
+
+Cross-repo link delta on client-fixture group:
+
+| Channel | Pre-#577 | Post-#577 | Δ |
+|---|---:|---:|---:|
+| import | 328 | 332 | +4 |
+| label  | 80  | 80  | 0  |
+
+Per-language bug-rate deltas (main → fix/file-entity-all-langs-577):
+
+| Repo | Lang | Main | Worktree | bug-rate Δ | resolution Δ | resolved Δ |
+|---|---|---:|---:|---:|---:|---:|
+| django-realworld | python | 3.77% | 3.77% | 0.00pp | — | — |
+| gin | go | 4.94% | 5.78% | +0.84pp | +2.26pp | +512 |
+| chi | go | 4.29% | 5.28% | +0.99pp | +4.00pp | +306 |
+| kafka-streams-examples | java | 3.80% | 12.68% | +8.88pp | +13.60pp | +2218 |
+| rails-realworld | ruby | 6.65% | 6.65% | 0.00pp | — | — |
+| laravel-quickstart | php | 1.57% | 1.57% | 0.00pp | — | — |
+| play-scala-starter | scala | 2.11% | 2.11% | 0.00pp | — | — |
+| ktor-samples | kotlin | 6.93% | 8.69% | +1.76pp | +6.17pp | +1247 |
+| vapor-api-template | swift | 2.13% | 2.13% | 0.00pp | — | — |
+| spdlog | cpp | 5.94% | 5.94% | 0.00pp | — | — |
+| mini-redis | rust | 14.85% | 14.85% | 0.00pp | — | — |
+| actix-examples | rust | 18.15% | 18.15% | 0.00pp | — | — |
+
+Regressions on gin/chi/kafka/ktor exceed the 0.5pp floor but follow
+the exact #575 pattern: previously-hidden IMPORTS edges now appear in
+the categoriser, so bug-extractor counts go up — but resolution-rate
+goes up much more (e.g. kafka +13.60pp vs +8.88pp, ktor +6.17pp vs
++1.76pp). The net signal — more cross-repo edges materialised + more
+resolved — is the goal of #577 and matches the #575 precedent the
+task explicitly accepts.
+
+Residual root cause: pre-#577 the cross-repo linker silently skipped
+file-path-shaped IMPORTS FromIDs for every non-JS extractor; the linker
+only had byName-indexed entities for code constructs, not for file
+nodes.
+
+Status: at-bar (cross-repo import channel unblocked for all per-language
+extractors; per-language bug-rate deltas are #575-pattern trades, not
+breakage).
+

--- a/internal/extractor/extractor.go
+++ b/internal/extractor/extractor.go
@@ -97,6 +97,40 @@ func TagRelationshipsLanguage(records []types.EntityRecord, lang string) {
 	}
 }
 
+// FileEntity returns a per-source-file SCOPE.Component (subtype="file")
+// entity that all per-language extractors emit at the top of Extract so
+// the cross-repo import linker (#566) can map IMPORTS edges back to the
+// originating repo via the resolver's byName index.
+//
+// Issue #577 — generalises the JS/TS pattern from #570/#575 to every
+// per-language extractor. Without this entity, IMPORTS edges whose
+// FromID is the importing file path don't appear in the resolver's
+// entity-id → repo index, so the cross-repo linker silently skips
+// them. With it, ReferencesEmbeddedWithAllowlist rewrites the IMPORTS
+// FromID from the path string to the file entity's stamped hex ID
+// (graph.EntityID(repoTag, "SCOPE.Component", path, path)) via byName,
+// and the linker then matches the edge back to the source repo.
+//
+// The extractor deliberately keeps FromID = file path on the IMPORTS
+// edges themselves (not a pre-stamped hex): it doesn't know the
+// indexer's repoTag seed, so any hex it wrote would be short-circuited
+// by isHexID in the resolver and the rewrite would never happen.
+func FileEntity(file FileInput) types.EntityRecord {
+	return types.EntityRecord{
+		Name:       file.Path,
+		Kind:       "SCOPE.Component",
+		SourceFile: file.Path,
+		Language:   file.Language,
+		Subtype:    "file",
+		Properties: map[string]string{
+			"kind":    "SCOPE.Component",
+			"subtype": "file",
+		},
+		EnrichmentStatus: types.StatusPending,
+		QualityScore:     1.0,
+	}
+}
+
 // TagStandaloneRelationshipsLanguage is TagRelationshipsLanguage for a slice
 // of standalone (pass-2) relationships rather than entity-embedded ones.
 func TagStandaloneRelationshipsLanguage(rels []types.RelationshipRecord, lang string) {

--- a/internal/extractors/cpp/extractor.go
+++ b/internal/extractors/cpp/extractor.go
@@ -112,6 +112,12 @@ func (e *CppExtractor) Extract(ctx context.Context, file extractor.FileInput) ([
 
 	var records []types.EntityRecord
 
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	records = append(records, extractor.FileEntity(file))
+
 	// Structural walk: container nodes (class/struct/union/namespace) are
 	// handled specially so we can emit CONTAINS edges for their direct
 	// method/function children; everything else is collected via flat

--- a/internal/extractors/csharp/csharp.go
+++ b/internal/extractors/csharp/csharp.go
@@ -61,6 +61,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	root := file.Tree.RootNode()
 	imports := collectImportNames(root, file.Content)
 	walk(root, file, "", nil, imports, &entities)

--- a/internal/extractors/elixir/elixir.go
+++ b/internal/extractors/elixir/elixir.go
@@ -59,6 +59,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walkNode(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "elixir")

--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -93,6 +93,12 @@ func (g *GoExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]
 		structs int
 	)
 
+	// Issue #577 — emit a file-level SCOPE.Component (subtype="file")
+	// entity per source file so the cross-repo import linker (#566) can
+	// map IMPORTS edges back to the originating repo via the resolver's
+	// byName index. Generalises the JS/TS fix from #570/#575.
+	records = append(records, extractor.FileEntity(file))
+
 	// ----------------------------------------------------------------
 	// 1. Functions and methods
 	// ----------------------------------------------------------------

--- a/internal/extractors/golang/extractor_test.go
+++ b/internal/extractors/golang/extractor_test.go
@@ -46,11 +46,27 @@ func extractFromPath(src, path string) ([]interface{}, error) {
 	if err != nil {
 		return nil, err
 	}
+	records = stripFileEntity(records)
 	out := make([]interface{}, len(records))
 	for i, r := range records {
 		out[i] = r
 	}
 	return out, nil
+}
+
+// stripFileEntity drops the file-level SCOPE.Component (subtype="file")
+// entity that the extractor emits for every source file (#577) so legacy
+// tests that count semantic entities (functions, structs, …) remain
+// stable. Only the file-level entity is filtered.
+func stripFileEntity(records []types.EntityRecord) []types.EntityRecord {
+	out := records[:0:0]
+	for _, e := range records {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
 }
 
 // ---- happy path tests -------------------------------------------------------
@@ -94,6 +110,7 @@ func Compute(x int) int {
 		Language: "go",
 		Tree:     parseGo([]byte(src)),
 	})
+	results = stripFileEntity(results)
 
 	r := results[0]
 	if r.Kind != "SCOPE.Operation" {
@@ -127,6 +144,7 @@ func (s *Store) Save(item string) error {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
+	results = stripFileEntity(results)
 	// Should have struct + method
 	if len(results) != 2 {
 		t.Fatalf("expected 2 entities (struct + method), got %d", len(results))
@@ -234,6 +252,7 @@ type User struct {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	results = stripFileEntity(results)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(results))
 	}
@@ -266,6 +285,7 @@ type Reader interface {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	results = stripFileEntity(results)
 	if len(results) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(results))
 	}
@@ -303,6 +323,7 @@ func NewConfig(host string, port int) *Config {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	results = stripFileEntity(results)
 	if len(results) != 2 {
 		t.Fatalf("expected 2 entities (struct + function), got %d", len(results))
 	}
@@ -347,6 +368,7 @@ func TestExtractPackageDeclarationOnly(t *testing.T) {
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
+	results = stripFileEntity(results)
 	if len(results) != 0 {
 		t.Errorf("expected 0 entities for package-only file, got %d", len(results))
 	}
@@ -857,7 +879,7 @@ func extractRecords(t *testing.T, src, path string) []types.EntityRecord {
 	if err != nil {
 		t.Fatalf("extract: %v", err)
 	}
-	return records
+	return stripFileEntity(records)
 }
 
 // findEntity returns the first EntityRecord matching name, or nil.

--- a/internal/extractors/java/java.go
+++ b/internal/extractors/java/java.go
@@ -71,6 +71,11 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	root := file.Tree.RootNode()
 	imports := collectImportNames(root, file.Content)
 	walk(root, file, "", nil, imports, &entities)

--- a/internal/extractors/kotlin/kotlin.go
+++ b/internal/extractors/kotlin/kotlin.go
@@ -55,6 +55,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walk(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "kotlin")

--- a/internal/extractors/php/php.go
+++ b/internal/extractors/php/php.go
@@ -46,6 +46,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walk(file.Tree.RootNode(), file, "", &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "php")

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -84,6 +84,12 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		classCount    int
 	)
 
+	// Issue #577 — emit a file-level SCOPE.Component (subtype="file")
+	// entity per source file so the cross-repo import linker (#566)
+	// can map IMPORTS edges back to the originating repo via the
+	// resolver's byName index. Generalises the JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
+
 	// Walk top-level children.
 	walkNode(root, file, "", &entities, &functionCount, &classCount)
 

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -39,6 +39,22 @@ func makeFile(src string, tree *sitter.Tree) extractor.FileInput {
 	}
 }
 
+// stripFileEntity drops the file-level SCOPE.Component (subtype="file")
+// entity that the extractor emits for every source file (#577) so legacy
+// tests that count semantic entities (functions, classes, …) remain
+// stable. Only the file-level entity is filtered — everything else is
+// returned as-is.
+func stripFileEntity(entities []types.EntityRecord) []types.EntityRecord {
+	out := entities[:0:0]
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "file" {
+			continue
+		}
+		out = append(out, e)
+	}
+	return out
+}
+
 // TestExtract_TwoFunctions verifies that two top-level functions are extracted
 // with correct names, kinds, and line numbers.
 func TestExtract_TwoFunctions(t *testing.T) {
@@ -58,6 +74,7 @@ def bar(x, y):
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 2 {
 		t.Fatalf("expected 2 entities, got %d", len(entities))
 	}
@@ -103,6 +120,7 @@ def greet(name):
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(entities))
 	}
@@ -133,6 +151,7 @@ func TestExtract_ClassWithMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	// Expect: MyService (Component) + __init__ (Operation/method) + process (Operation/method)
 	if len(entities) != 3 {
 		t.Fatalf("expected 3 entities, got %d: %v", len(entities), entityNames(entities))
@@ -194,6 +213,7 @@ async def health_check():
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(entities))
 	}
@@ -284,6 +304,7 @@ func TestExtract_NilTree(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract with nil tree: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(entities))
 	}
@@ -347,6 +368,7 @@ func TestExtract_ClassNoMethods(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 1 {
 		t.Fatalf("expected 1 entity, got %d", len(entities))
 	}
@@ -373,6 +395,7 @@ def standalone():
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	for _, e := range entities {
 		if e.QualifiedName != "" {
 			t.Errorf("entity %q: expected empty QualifiedName (null in JSON), got %q", e.Name, e.QualifiedName)
@@ -395,6 +418,7 @@ def add(a: int, b: int) -> int:
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	if len(entities) != 2 {
 		t.Fatalf("expected 2 entities, got %d", len(entities))
 	}
@@ -477,6 +501,7 @@ class OrderSerializer:
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 
 	// Expected method-entity Names — class-qualified (issue #45).
 	wantMethods := map[string]bool{
@@ -558,6 +583,7 @@ func TestExtract_DuplicateMethodsFromFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 
 	methodCount := 0
 	for _, e := range entities {
@@ -614,6 +640,7 @@ func TestExtract_ControlFlowMethodsInheritClassQualifier(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 
 	// Every method declared in the fixture lives inside an if/try/with block
 	// nested in a class body. None of them must appear as bare names.
@@ -700,6 +727,7 @@ func TestExtract_ClassSubtypeLabels(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 
 	wantClasses := map[string]bool{
 		"UserSerializer": false, // (1) extends external base
@@ -770,6 +798,7 @@ func TestExtract_NestedClassesFromFixture(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 
 	wantMethods := map[string]bool{
 		"Outer.Inner.foo":        false,
@@ -829,6 +858,7 @@ func TestExtract_ClassAttrFields_DRFViewSet(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	wantFields := map[string]bool{
 		"ArticleViewSet.serializer_class":   false,
 		"ArticleViewSet.queryset":           false,
@@ -883,6 +913,7 @@ class CommentForm(ModelForm):
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	want := map[string]bool{
 		"Article.title":      false,
 		"Article.body":       false,
@@ -933,6 +964,7 @@ class Foo:
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	var fieldNames []string
 	for _, e := range entities {
 		if e.Kind == "SCOPE.Schema" && e.Subtype == "field" {
@@ -959,6 +991,7 @@ func TestExtract_ClassAttrFields_AnnotatedAndTuple(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Extract: %v", err)
 	}
+	entities = stripFileEntity(entities)
 	want := map[string]bool{
 		"Config.name":  false,
 		"Config.count": false,

--- a/internal/extractors/ruby/ruby.go
+++ b/internal/extractors/ruby/ruby.go
@@ -37,6 +37,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walk(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — tag every embedded relationship with the source language
 	// so the resolver picks the Ruby dynamic-pattern catalog.

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -39,6 +39,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walk(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "rust")

--- a/internal/extractors/scala/scala.go
+++ b/internal/extractors/scala/scala.go
@@ -56,6 +56,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walkNode(file.Tree.RootNode(), file, nil, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "scala")

--- a/internal/extractors/swift/swift.go
+++ b/internal/extractors/swift/swift.go
@@ -58,6 +58,11 @@ func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]type
 	}
 
 	var entities []types.EntityRecord
+	// Issue #577 — emit file-level SCOPE.Component (subtype="file") so the
+	// cross-repo import linker (#566) can map IMPORTS edges back to the
+	// originating repo via the resolver's byName index. Generalises the
+	// JS/TS fix from #570/#575.
+	entities = append(entities, extractor.FileEntity(file))
 	walkNode(file.Tree.RootNode(), file, &entities)
 	// Issue #90 — language tag for resolver dynamic-pattern dispatch.
 	extractor.TagRelationshipsLanguage(entities, "swift")


### PR DESCRIPTION
## Summary

Generalises the JS/TS file-entity pattern from #570/#575 to every per-language extractor (Python, Go, Java, Ruby, PHP, Scala, Kotlin, Swift, C++, Rust, C#, Elixir). Each Extract now emits a per-source-file `SCOPE.Component` (subtype="file") record so the cross-repo import linker (#566) can map IMPORTS edges back to the originating repo via the resolver's byName index. File-disjoint from in-flight work on synth.go, label channel, and import channel.

Closes #577.

## What changed

- Added `extractor.FileEntity(file)` helper in `internal/extractor/extractor.go` — single source for the file-level SCOPE.Component shape so every extractor stays in lockstep.
- Wired the helper into the entry of `Extract` for: python, golang, java, ruby, php, scala, kotlin, swift, cpp, rust, csharp, elixir.
- Updated python + golang test helpers (`stripFileEntity`) so legacy count-based assertions stay stable now that every Extract emits one extra entity.
- JS/TS extractor is unchanged — it already shipped this pattern in #570/#575.

## Cross-repo verification (client-fixture group)

| Channel | Pre-#577 | Post-#577 | Delta |
|---|---:|---:|---:|
| import | 328 | 332 | +4 |
| label  | 80  | 80  | 0  |

Confirms the linker now maps non-JS IMPORTS edges back to the source repo. Synthetic 2-Python-repo test produced 0 candidates because the cross-repo path also requires a shared external package between the two repos (out of scope for this PR — covered by #566).

## Per-language bug-rate delta (main → fix/file-entity-all-langs-577)

| Repo | Lang | Main | Worktree | bug-rate Delta | resolution Delta | resolved Delta |
|---|---|---:|---:|---:|---:|---:|
| django-realworld | python | 3.77% | 3.77% | 0.00pp | - | - |
| gin | go | 4.94% | 5.78% | +0.84pp | +2.26pp | +512 |
| chi | go | 4.29% | 5.28% | +0.99pp | +4.00pp | +306 |
| kafka-streams-examples | java | 3.80% | 12.68% | +8.88pp | +13.60pp | +2218 |
| rails-realworld | ruby | 6.65% | 6.65% | 0.00pp | - | - |
| laravel-quickstart | php | 1.57% | 1.57% | 0.00pp | - | - |
| play-scala-starter | scala | 2.11% | 2.11% | 0.00pp | - | - |
| ktor-samples | kotlin | 6.93% | 8.69% | +1.76pp | +6.17pp | +1247 |
| vapor-api-template | swift | 2.13% | 2.13% | 0.00pp | - | - |
| spdlog | cpp | 5.94% | 5.94% | 0.00pp | - | - |
| mini-redis | rust | 14.85% | 14.85% | 0.00pp | - | - |
| actix-examples | rust | 18.15% | 18.15% | 0.00pp | - | - |

## Regression analysis

Four repos regress above the 0.5pp budget (gin, chi, kafka, ktor). All four follow the exact #575 pattern the task explicitly accepts: previously-hidden IMPORTS edges now appear in the categoriser, so `bug-extractor` goes up — but `resolution-rate` goes up much more (kafka +13.60pp vs +8.88pp; ktor +6.17pp vs +1.76pp; gin +2.26pp vs +0.84pp; chi +4.00pp vs +0.99pp). Net resolved-edges count rose on every regression repo. The remaining 8 repos are flat.

Acceptance per task brief: "if it's the same pattern as #575 (resolution-rate up more than bug-rate up), accept the trade."

## Chain-fixes to file

None required by this PR. The +bug-extractor edges are the IMPORTS edges that were previously invisible to the categoriser; they will be folded into the per-language `external-known` allowlists by the next per-language wave (existing backlog issues for kafka / ktor / gin / chi).

## Test plan

- [x] `go test ./internal/extractors/... ./internal/extractor/...` — all 32 extractor packages green
- [x] `go test ./...` — full suite green (resolver, indexer, links, cross-repo)
- [x] `./build/archigraph rebuild client-fixture` — import-channel link count 328 -> 332
- [x] Per-language bug-rate measured on representative corpus repo for each touched language

Residual root cause: pre-#577 the cross-repo import linker silently skipped file-path-shaped IMPORTS FromIDs on every non-JS extractor; the byName index had no entity carrying that path as its ID.

Status: at-bar (cross-repo import channel unblocked across all per-language extractors; per-language deltas are #575-pattern trades, not breakage).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>