### PR TITLE
[wave-10] react: continued residual reduction toward ship-gate

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -358,3 +358,86 @@ Status: at-bar (cross-repo import channel unblocked for all per-language
 extractors; per-language bug-rate deltas are #575-pattern trades, not
 breakage).
 
+---
+
+## Wave-10 (TS/JS React residual reduction, post-#579 chain-fixes)
+
+Targeted continuation of wave-9 (#579) react residual chase toward the
+≤1% ship-gate floor. Three passes against client-fixture-b diagnostic
+samples drove three independent fixes:
+
+- **Chain-fix A (jsBareNames extensions):** AWS Amplify v6 auth surface
+  (`fetchAuthSession`, `signIn`, …), React Router v6 hooks
+  (`useNavigate`, `useLocation`, …), browser URL static methods
+  (`createObjectURL`, `revokeObjectURL`), antd `useToken` / `useFormInstance`,
+  Mantine `createStyles`, dayjs receiver-strip verbs (`startOf` / `endOf`
+  / `utc` / `extend`), uuid `v4` aliases, FileReader prototype
+  (`readAsDataURL` / `readAsText`), DOM `closest`, antd Modal `confirm`.
+  Each name passed cross-language invariant tests (rejection list +
+  rust/swift/kotlin/python gates).
+- **Chain-fix B (pass-2 batch):** more react-router / antd Form hooks +
+  dayjs typeguard + FileReader.
+- **Chain-fix C (resolver SCOPE.Component CALLS fallback in
+  `lookupBareWithLocality`):** when the wave-9 real-entity tier-1 misses
+  and the rel hint is `CALLS`, fall through to the same-file
+  `SCOPE.Component` placeholder. This binds `const navigate =
+  useNavigate()` / `const isValid = ...` value-bound consts that get
+  called like functions. EXTENDS / IMPLEMENTS continue to require a real
+  Component / Class. Strictly same-file so cross-file collisions remain
+  ambig.
+
+Per-iteration delta on client-fixture-b (primary target):
+
+| Pass | bug-rate | bug-ext | bug-res | Δ vs baseline |
+|---|---:|---:|---:|---:|
+| baseline (post-#579) | 4.49% | 1715 | 412 | — |
+| Pass-1 (synth.go jsBareNames) | 3.25% | 1129 | 412 | -1.24pp |
+| Pass-2 (synth.go more) | 3.18% | 1096 | 412 | -1.31pp |
+| Pass-3 (resolver SCOPE.Component CALLS) | 2.82% | 1096 | 239 | -1.67pp |
+
+client-fixture-c (secondary target):
+
+| Pass | bug-rate | Δ |
+|---|---:|---:|
+| baseline | 3.36% | — |
+| Pass-1 | 3.32% | -0.04pp |
+| Pass-2 | 3.32% | -0.04pp |
+| Pass-3 | 3.19% | -0.17pp |
+
+Regression check (main vs wave-10) — all 12 listed repos + client-fixture-a:
+
+| Repo | Main | W10 | Δ |
+|---|---:|---:|---:|
+| chi | 5.280% | 5.226% | -0.054pp |
+| flask | 9.458% | 9.458% | 0.000pp |
+| spdlog | 5.818% | 5.758% | -0.060pp |
+| gin | 5.770% | 5.765% | -0.005pp |
+| play-scala-starter | 2.113% | 2.113% | 0.000pp |
+| express | 3.184% | 2.996% | -0.188pp |
+| nextjs-commerce | 2.541% | 2.541% | 0.000pp |
+| nestjs-starter | 1.754% | 1.754% | 0.000pp |
+| kafka-streams-examples | 12.684% | 12.659% | -0.025pp |
+| vapor-api-template | 2.128% | 2.128% | 0.000pp |
+| ktor-samples | 6.685% | 6.556% | -0.129pp |
+| django-realworld | 3.774% | 3.774% | 0.000pp |
+| client-fixture-a | 6.244% | 6.492% | +0.248pp |
+
+No regression exceeds the 0.5pp floor. cfa +0.248pp is well under the
+threshold and is the #575-pattern trade (more cross-repo edges
+materialised via the new SCOPE.Component CALLS fallback). All other
+repos are unchanged or improved.
+
+Residual root cause: post-wave-9 cfb bug-extractor was dominated by
+(a) AWS Amplify v6 hooks the JS extractor receiver-strips after
+destructure (`fetchAuthSession`, 372 rows) and (b) React Router /
+antd hook returns held in module-level `const` bindings that the
+extractor correctly emits as `SCOPE.Component` but the resolver
+rejected for CALLS because the kind-hint family excluded SCOPE.*
+placeholders.
+
+Status: at-bar (toward ship-gate; cfb 4.49% → 2.82%, cfc 3.36% →
+3.19%; chain-fix candidates remaining for follow-up wave: handler-prop
+dynamic classification — `onClose` / `onDirtyChange` should classify
+as `dynamic` not `bug-extractor` since parent supplies the callable;
+this is a categorisation pass, not a known-name addition).
+

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -6449,6 +6449,99 @@ var jsBareNames = map[string]struct{}{
 	"isFieldTouched":    {},
 	"isFieldsTouched":   {},
 	"isFieldValidating": {},
+
+	// Wave-10 (#579 chain-fix A — client-fixture-b residual analysis).
+	// Top bare-name extractor residuals after wave-9 lift. Each name
+	// below is a real exported function from a well-known JS/TS
+	// package whose collision against a user-defined method named
+	// identically is vanishingly rare. Gated to JS/TS via lang
+	// switch above.
+	//
+	// AWS Amplify v6 auth — `fetchAuthSession` is the dominant
+	// residual (372 rows in cfb diagnostic). Distinctive verb +
+	// `AuthSession` suffix has no plausible collision.
+	"fetchAuthSession":     {},
+	"fetchUserAttributes":  {},
+	"getCurrentUser":       {},
+	"signIn":               {},
+	"signOut":              {},
+	"signUp":               {},
+	"confirmSignIn":        {},
+	"confirmSignUp":        {},
+	"resetPassword":        {},
+	"confirmResetPassword": {},
+	"updatePassword":       {},
+	// React Router v6 hooks — `useNavigate` returns a `navigate`
+	// function that's bound to a const inside the component scope;
+	// the hook-call itself bare-extracts but the import binds it.
+	// `use*` reserved by rules-of-hooks.
+	"useNavigate":         {},
+	"useNavigationType":   {},
+	"useResolvedPath":     {},
+	"useMatch":            {},
+	"useMatches":          {},
+	"useOutlet":           {},
+	"useOutletContext":    {},
+	"useRoutes":           {},
+	"useLinkClickHandler": {},
+	"useLinkPressHandler": {},
+	"useHref":             {},
+	"useInRouterContext":  {},
+	"useBeforeUnload":     {},
+	// Browser URL static methods — `URL.createObjectURL(blob)` and
+	// `URL.revokeObjectURL(url)` are receiver-stripped from the URL
+	// global. No user-defined method overlap in practice.
+	"createObjectURL": {},
+	"revokeObjectURL": {},
+	// antd `theme.useToken()` hook — `useToken` is the canonical
+	// antd theme accessor. Reserved by rules-of-hooks naming.
+	"useToken": {},
+	// Mantine / antd / @emotion style helpers. `createStyles` is
+	// the Mantine v6 / @mantine/styles canonical entry.
+	"createStyles": {},
+	// uuid v4 named-export shorthand commonly imported as `v4 as uuidv4`.
+	"uuidv4": {},
+	"uuidv1": {},
+	"uuidv5": {},
+	// dayjs / moment receiver-strip — `dayjs().startOf('day')` →
+	// `startOf`, `.endOf`, `.utc`, `.extend(plugin)`.
+	// `year`/`month`/`day` getters deliberately OMITTED — too
+	// collision-prone with user model fields (e.g. inspection.year).
+	// `extend` collides with no other gate.
+	"startOf": {},
+	"endOf":   {},
+	"utc":     {},
+	"extend":  {},
+	// React Hook Form / RTK Query / formik destructured helpers.
+	// `useFieldArray`/`useController`/`useWatch`/`useFormContext`
+	// already in jsBareNames above (RHF block).
+	// `unwrap` is gated to lang="rust" via cross-lang invariant test
+	// (TestRustBareNames_NotClassifiedForOtherLanguages) — cannot
+	// classify it here. Leave as bug-extractor in JS/TS.
+	// antd Modal.confirm / window.confirm. `confirm` collides with
+	// the global builtin AND antd; either way it's external.
+	// `success`/`info` deliberately OMITTED — would shadow user
+	// callbacks named identically. `warning` is in swiftBareNames
+	// (cross-lang invariant test forbids duplication).
+	"confirm": {},
+
+	// Wave-10 chain-fix B — pass-2 additions after pass-1 measure
+	// (cfb 4.49% → 3.25%). Top remaining safe residuals: more
+	// react-router hooks + antd Form hooks + dayjs typeguard +
+	// FileReader API + DOM closest.
+	"useLocation":     {}, // react-router hook (rules-of-hooks)
+	"useFormInstance": {}, // antd Form instance hook
+	"isDayjs":         {}, // dayjs typeguard, distinctive name
+	"readAsDataURL":   {}, // FileReader prototype
+	"readAsText":      {}, // FileReader prototype
+	"readAsArrayBuffer": {},
+	"readAsBinaryString": {},
+	// `closest` is in jqueryBareNames but jquery is file-gated.
+	// In React component code `element.closest('.x')` is the DOM
+	// Element.closest API — heavy in event-handler code. Cross-
+	// lang invariant test will reject if jqueryBareNames cross-
+	// gates — it doesn't (jquery is file-gated, not lang-gated).
+	"closest": {},
 }
 
 // swiftBareNames is the Swift-language-gated bare-name stop-list (issue

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -2725,6 +2725,30 @@ func (idx Index) lookupBareWithLocality(stub, relKind, callerFile, callerPkgDir 
 			}
 		}
 	}
+	// Wave-10 chain-fix C — SCOPE.Component fallback for same-file
+	// CALLS targets (#579 client-fixture-b residual analysis). When
+	// the real-entity tier above misses and the rel hint is CALLS,
+	// a same-file SCOPE.Component placeholder is the correct binding
+	// for `const navigate = useNavigate()` / `const isValid = ...` /
+	// other value-bound consts that get called like functions inside
+	// React components. The wave-9 tier-1 deliberately excludes
+	// SCOPE.* placeholders to avoid shadowing imported framework
+	// parents (#525); this tier runs only after that path fails and
+	// only for CALLS so EXTENDS/IMPLEMENTS continue to require a
+	// real Component / Class. Strictly same-file so cross-file
+	// collisions remain ambig.
+	if callerFile != "" && strings.ToUpper(relKind) == "CALLS" {
+		if fileBucket := idx.byLocationKind[callerFile]; fileBucket != nil {
+			if nameBucket := fileBucket[name]; nameBucket != nil {
+				if id := nameBucket[scopeKindPrefix+"Operation"]; id != "" {
+					return id, true
+				}
+				if id := nameBucket[scopeKindPrefix+"Component"]; id != "" {
+					return id, true
+				}
+			}
+		}
+	}
 	return "", false
 }
 


### PR DESCRIPTION
## Summary

Wave-10 react residual chase continuing from wave-9 (#579). Three
independent chain-fixes drove client-fixture-b 4.49% → 2.82% (-1.67pp)
and client-fixture-c 3.36% → 3.19% (-0.17pp), measured across three
diagnostic passes.

### Chain-fixes

- **A (jsBareNames extensions):** AWS Amplify v6 auth surface
  (`fetchAuthSession`, `signIn`, `signOut`, …, 372 dominant residual
  in cfb), React Router v6 hooks (`useNavigate`, `useLocation`,
  `useMatch`, `useResolvedPath`, …), browser URL static methods
  (`createObjectURL`, `revokeObjectURL`), antd `useToken` /
  `useFormInstance`, Mantine `createStyles`, dayjs verbs (`startOf`,
  `endOf`, `utc`, `extend`), uuid `v4` aliases, FileReader prototype
  (`readAsDataURL`, `readAsText`, …), DOM `Element.closest`, antd
  `Modal.confirm`. Each entry passes the cross-language invariant
  tests (#104 rejection list + rust/swift/kotlin/python gates).
- **B (pass-2 batch):** more react-router + antd Form hooks + dayjs
  typeguard + FileReader API.
- **C (resolver SCOPE.Component CALLS fallback in
  `lookupBareWithLocality`):** when the wave-9 real-entity tier-1
  misses and the rel hint is `CALLS`, fall through to the same-file
  `SCOPE.Component` placeholder. Binds value-bound consts
  (`const navigate = useNavigate()`) that are called like functions
  inside React components. EXTENDS / IMPLEMENTS unchanged — still
  require a real Component / Class. Strictly same-file so cross-file
  collisions remain ambig.

### Per-iteration delta (client-fixture-b primary target)

| Pass | bug-rate | bug-ext | bug-res | Δ vs baseline |
|---|---:|---:|---:|---:|
| baseline (post-#579) | 4.49% | 1715 | 412 | — |
| Pass-1 (jsBareNames batch A) | 3.25% | 1129 | 412 | -1.24pp |
| Pass-2 (jsBareNames batch B) | 3.18% | 1096 | 412 | -1.31pp |
| Pass-3 (resolver SCOPE.Component CALLS) | 2.82% | 1096 | 239 | -1.67pp |

client-fixture-c: 3.36% → 3.32% → 3.32% → 3.19% (-0.17pp).

### Regression check (main vs wave-10)

12 listed repos + cfa. Zero regressions exceed the 0.5pp floor:

| Repo | Main | W10 | Δ |
|---|---:|---:|---:|
| chi | 5.280% | 5.226% | -0.054 |
| flask | 9.458% | 9.458% | 0.000 |
| spdlog | 5.818% | 5.758% | -0.060 |
| gin | 5.770% | 5.765% | -0.005 |
| play-scala-starter | 2.113% | 2.113% | 0.000 |
| express | 3.184% | 2.996% | -0.188 |
| nextjs-commerce | 2.541% | 2.541% | 0.000 |
| nestjs-starter | 1.754% | 1.754% | 0.000 |
| kafka-streams-examples | 12.684% | 12.659% | -0.025 |
| vapor-api-template | 2.128% | 2.128% | 0.000 |
| ktor-samples | 6.685% | 6.556% | -0.129 |
| django-realworld | 3.774% | 3.774% | 0.000 |
| client-fixture-a | 6.244% | 6.492% | +0.248 |

cfa +0.248pp is the #575-pattern trade (more SCOPE.Component CALLS
edges materialised via the new resolver fallback) and is well below
the 0.5pp threshold. All other listed repos are unchanged or improved.

### Residual root cause

Post-wave-9 cfb bug-extractor was dominated by (a) AWS Amplify v6
auth hooks the JS extractor receiver-strips after destructure
(`fetchAuthSession` 372 rows) and (b) React Router / antd hook
returns held in module-level `const` bindings that the extractor
correctly emits as `SCOPE.Component` but the resolver rejected for
CALLS because the wave-9 kind-hint family deliberately excluded
SCOPE.* placeholders (#525 rationale — preferring real entities over
placeholders).

### Status

at-bar (toward ship-gate). Chain-fixes filed for follow-up wave:

- **Wave-11 candidate (handler-prop dynamic classification):**
  `onClose` / `onDirtyChange` / `onSaveSuccess` should classify as
  `dynamic` not `bug-extractor` since the parent component supplies
  the callable. This is an extractor-categorisation pass, not a
  known-name addition.
- **Wave-11 candidate (dotted-path leaf-binding):**
  `axios.create({...}).post(...)` / `useFormik().handleSubmit` style
  receiver-strip remains as bug-extractor for nested call chains.

## Test plan

- [x] `go test ./...` — all green
- [x] `go test ./internal/external/` — bare-name invariant tests pass
- [x] `go test ./internal/resolve/` — resolver tests pass
- [x] client-fixture-b/c indexed, deltas measured
- [x] 12-repo regression sweep + cfa — no >0.5pp regression