### PR TITLE
[wave-11] react: handler-prop dynamic + antd app-hook bare-names (toward ship-gate)

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -453,3 +453,79 @@ dynamic classification — `onClose` / `onDirtyChange` should classify
 as `dynamic` not `bug-extractor` since parent supplies the callable;
 this is a categorisation pass, not a known-name addition).
 
+---
+
+## Wave-11 (TS/JS React ship-gate push, post-#582 chain-fixes)
+
+Continuation of wave-10 (#582) ship-gate push targeting the two
+chain-fixes called out in the #582 PR body residual analysis.
+
+- **Chain-fix A (jsDynamicPatterns: React handler-prop convention):**
+  added `^on[A-Z][A-Za-z0-9]*$` to the JS/TS dynamic-pattern set so
+  React handler-prop call sites (`onClose`, `onClick`, `onChange`,
+  `onSubmit`, `onCancel`, `onConfirm`, `onSuccess`, `onError`,
+  `onValueChange`, `onSelect`, `onFocus`, `onBlur`, `onClearAll`,
+  `onDirtyChange`, …) classify as `dynamic` rather than
+  `bug-extractor`. These are callable props bound by the parent at
+  invocation time — statically unresolvable by design. The per-language
+  gate (js/ts only) prevents collision with non-React ecosystems.
+- **Chain-fix B (jsBareNames: antd App-context hook returners,
+  bounded version):** added `useMessage` / `useNotification` / `useApp`
+  to jsBareNames for antd v5 App-context hooks. The fuller
+  dotted-path leaf-binding fix for destructure-rename mutation
+  callables (`const { mutate: createAddress } =
+  useCreateAlternateAddress()` → bare `createAddress(...)`) is
+  deferred as a chain-fix issue because it requires JS/TS
+  extractor work to emit SCOPE.Operation entities for
+  destructure-rename bindings — out of scope for a synth/resolve-only
+  wave.
+
+Per-iteration delta on client-fixture-b (primary target):
+
+| Pass | bug-rate | bug-ext | bug-res | Δ vs baseline |
+|---|---:|---:|---:|---:|
+| baseline (post-#582) | 2.367% | 883 | 239 | — |
+| Pass-1 (Chain-fix A: handler-prop dynamic) | 1.740% | 645 | 180 | -0.626pp |
+| Pass-2 (Chain-fix B: antd hooks) | 1.738% | 644 | 180 | -0.629pp |
+
+client-fixture-c (secondary target):
+
+| Pass | bug-rate | Δ |
+|---|---:|---:|
+| baseline | 2.942% | — |
+| Pass-1 | 2.680% | -0.261pp |
+| Pass-2 | 2.680% | -0.261pp |
+
+Regression check (main vs wave-11) — 11 listed repos + client-fixture-a:
+
+| Repo | Main | W11 | Δ |
+|---|---:|---:|---:|
+| chi | 4.233% | 4.233% | 0.000pp |
+| flask | 9.458% | 9.458% | 0.000pp |
+| spdlog | 5.758% | 5.758% | 0.000pp |
+| gin | 4.931% | 4.931% | 0.000pp |
+| play-scala-starter | 2.113% | 2.113% | 0.000pp |
+| express | 2.996% | 2.996% | 0.000pp |
+| nextjs-commerce | 2.317% | 2.317% | 0.000pp |
+| nestjs-starter | 1.754% | 1.754% | 0.000pp |
+| kafka-streams-examples | 3.396% | 3.396% | 0.000pp |
+| vapor-api-template | 2.128% | 2.128% | 0.000pp |
+| ktor-samples | 4.874% | 4.864% | -0.010pp |
+| client-fixture-a | 6.082% | 6.082% | 0.000pp |
+
+No regression — all repos identical except ktor-samples slight
+improvement.
+
+Residual root cause: post-wave-10 cfb bug-extractor was dominated by
+React handler-prop callables (`onClose`, `onCancel`, `onChange`, …)
+that the parent component supplies — Chain-fix A categorises these
+as Dynamic. Remaining residual is React Query mutation destructure-
+renamed callables (`const { mutate: createAddress } = useFooMutation()`)
+which need extractor-level entity lift; filed as a chain-fix issue
+for follow-up wave.
+
+Status: at-bar (toward ship-gate; cfb 2.37% → 1.74%, cfc 2.94% →
+2.68%; cfb is now within 0.74pp of the 1% ship-gate floor — one more
+extractor-level wave on the destructure-rename pattern should close
+it).
+

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -6655,6 +6655,22 @@ var jsBareNames = map[string]struct{}{
 	// lang invariant test will reject if jqueryBareNames cross-
 	// gates — it doesn't (jquery is file-gated, not lang-gated).
 	"closest": {},
+
+	// Wave-11 (ship-gate, chain-fix B partial) — antd notification +
+	// message + Modal hook returners. The antd App-context API
+	// (`const [api, contextHolder] = message.useMessage()` /
+	// `notification.useNotification()` / `Modal.useModal()`) returns
+	// a callable + a contextHolder. The hook itself bare-extracts
+	// from the receiver-strip (`message.useMessage` → `useMessage`).
+	// `useMessage` / `useNotification` are rules-of-hooks reserved
+	// (must start with `use`) and antd-distinctive enough to be
+	// safe. `useApp` is the antd v5 App component hook returning
+	// `{message, notification, modal}` accessors. The per-language
+	// gate (js/ts only) prevents shadowing in non-JS codebases.
+	// `useModal` already in jsBareNames above (antd).
+	"useMessage":      {}, // antd message.useMessage hook
+	"useNotification": {}, // antd notification.useNotification hook
+	"useApp":          {}, // antd App.useApp hook
 }
 
 // swiftBareNames is the Swift-language-gated bare-name stop-list (issue

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -528,6 +528,19 @@ var (
 		regexp.MustCompile(`^then$`),
 		regexp.MustCompile(`^catch$`),
 		regexp.MustCompile(`^finally$`),
+		// Wave-11 (TS/JS React frontend, ship-gate) — React handler-prop
+		// convention `onClose`, `onClick`, `onChange`, `onSubmit`,
+		// `onCancel`, `onConfirm`, `onSuccess`, `onError`, `onValueChange`,
+		// `onSelect`, `onFocus`, `onBlur`, etc. These are callable props
+		// passed from a parent component; the actual handler implementation
+		// lives in the parent and is bound at component-invocation time, so
+		// the call site (inside the child component) cannot statically bind
+		// it. Standard React convention (React docs + RFC). The per-language
+		// gate (js/ts only) keeps it from biting Python/Go/etc. where the
+		// `onX` callable-prop convention does not exist. client-fixture-b
+		// top bug-extractor sample after wave-10 was `onClearAll` /
+		// `onClose` confirming this is the dominant residual shape.
+		regexp.MustCompile(`^on[A-Z][A-Za-z0-9]*$`),
 	}
 
 	rubyDynamicPatterns = []*regexp.Regexp{


### PR DESCRIPTION
## Summary

Continuation of wave-10 (#582) react ship-gate push targeting the two chain-fixes called out in the #582 PR body residual analysis.

- **Chain-fix A (jsDynamicPatterns):** added `^on[A-Z][A-Za-z0-9]*$` so React handler-prop call sites (`onClose`, `onClick`, `onChange`, `onSubmit`, `onCancel`, etc.) classify as `dynamic` rather than `bug-extractor`. These are callable props bound by the parent at invocation time — statically unresolvable by design. Per-language gate (js/ts only).
- **Chain-fix B (jsBareNames):** added antd App-context hook returners `useMessage` / `useNotification` / `useApp`. The fuller dotted-path leaf-binding fix for destructure-rename mutation callables (`const { mutate: createAddress } = useFooMutation()`) requires extractor work and is deferred as **#584**.

## Per-iteration delta — client-fixture-b (primary target)

| Pass | bug-rate | bug-ext | bug-res | Δ |
|---|---:|---:|---:|---:|
| baseline (post-#582) | 2.367% | 883 | 239 | — |
| Pass-1 (handler-prop dynamic) | 1.740% | 645 | 180 | -0.626pp |
| Pass-2 (antd app hooks) | 1.738% | 644 | 180 | -0.629pp |

## client-fixture-c (secondary)

| Pass | bug-rate | Δ |
|---|---:|---:|
| baseline | 2.942% | — |
| Pass-1 | 2.680% | -0.261pp |
| Pass-2 | 2.680% | -0.261pp |

## Regression check (main vs wave-11)

| Repo | Main | W11 | Δ |
|---|---:|---:|---:|
| chi | 4.233% | 4.233% | 0.000pp |
| flask | 9.458% | 9.458% | 0.000pp |
| spdlog | 5.758% | 5.758% | 0.000pp |
| gin | 4.931% | 4.931% | 0.000pp |
| play-scala-starter | 2.113% | 2.113% | 0.000pp |
| express | 2.996% | 2.996% | 0.000pp |
| nextjs-commerce | 2.317% | 2.317% | 0.000pp |
| nestjs-starter | 1.754% | 1.754% | 0.000pp |
| kafka-streams-examples | 3.396% | 3.396% | 0.000pp |
| vapor-api-template | 2.128% | 2.128% | 0.000pp |
| ktor-samples | 4.874% | 4.864% | -0.010pp |
| client-fixture-a | 6.082% | 6.082% | 0.000pp |

Zero regression — all repos identical except ktor-samples slight improvement.

## Chain-fixes filed

- **#584** ts/js extractor: lift destructure-rename mutation callable to SCOPE.Operation — needed to bind `const { mutate: createAddress } = useFooMutation()` patterns that dominate the remaining cfb bug-extractor residual.

## Residual root cause

post-wave-10 cfb bug-extractor was dominated by React handler-prop callables (`onClose`, `onCancel`, `onChange`, etc.) that the parent component supplies — Chain-fix A categorises these as Dynamic. Remaining residual is React Query mutation destructure-renamed callables (`createAddress` / `patchAddress` / `deleteAddress`) which need extractor-level entity lift (chain-fix #584).

## Status

at-bar (toward ship-gate; cfb 2.37% → 1.74%, cfc 2.94% → 2.68%; cfb is now within 0.74pp of the 1% ship-gate floor — one more extractor-level wave on the destructure-rename pattern should close it).

## Test plan

- [x] Per-iteration delta on cfb / cfc
- [x] Regression check against 11 listed repos + cfa (zero regression)
- [x] `go test ./internal/external/... ./internal/resolve/...`
- [x] Chain-fix issue filed (#584)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>