### PR TITLE
[wave-10] python: django.yaml IMPORTS suffix rewrite Chain-fix A

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -643,3 +643,97 @@ extractor csrf_protection_controller helper bareness (cross-language
 leak observed in 5 edges); CSS extractor file-skip for SCSS bootswatch
 imports (2 edges).
 
+---
+
+## #-w10 — python wave-10 django.yaml IMPORTS suffix rewrite (Chain-fix A) (2026-05-19)
+
+Targets PR #580 wave-9 residual analysis: 60 `kind-mismatch`
+bug-resolver edges where `django.yaml:119` + `sqlalchemy.yaml:85`
+relationship rules emit `Model:<name>` for any
+`from X.models import Y` / `from X import <PascalCase>` capture,
+but Y is regularly a DRF Serializer or CBV/ViewSet class re-exported
+through a sibling `models` module.
+
+Implementation: `internal/engine/django_imports_rewrite.go` Go post-pass
+runs after `applyDjangoRouteComposition` (Python-gated in detector.go).
+Rewrites `Model:<X>Serializer` → `Component:<X>Serializer` and
+`Model:<X>(View|ViewSet|Viewset|ListView|DetailView|...|APIView)` →
+`View:<X>...`. Genuine Django ORM model names (no suffix match) keep
+the original `Model:` prefix. Other languages unaffected.
+
+Per-iteration delta (client-fixture-a, 1 pass):
+
+| Pass | bug_rate | bug-resolver | kind-mismatch | Δ | Mechanism |
+|------|----------|---|---|---|-----------|
+| baseline (main) | 6.08% | 259 | 60 | — | post-#582 main |
+| pass-1 | 5.93% | 211 | 3 | -0.15pp | Chain-fix A suffix rewrite |
+
+Residual after pass-1: 84 `ambig-bare-hint-fail` (file-scoped helpers
+— requires receiver-variable-type primitive #494), 9 new `ambig-kind`
+on `Component:<X>Serializer` (DRF custom extractor + base Python class
+extractor BOTH emit `SCOPE.Component:UserSerializer` in the same file
+→ Component kind bucket flips ambiguous — structural duplicate-entity
+problem, separate fix), 3 `kind-mismatch` `Model:User` (no suffix to
+detect, genuinely unresolvable from a regex pass).
+
+Regression check (14 corpora vs current main / post-#582):
+
+| Repo | Lang | main | w10 | Δ |
+|---|---|---:|---:|---:|
+| chi | go | 4.23% | 4.23% | 0.000pp |
+| express | js | 3.00% | 3.00% | 0.000pp |
+| spdlog | cpp | 5.76% | 5.76% | 0.000pp |
+| gin | go | 4.93% | 4.93% | 0.000pp |
+| play-scala-starter | scala | 2.11% | 2.11% | 0.000pp |
+| nextjs-commerce | ts | 2.32% | 2.32% | 0.000pp |
+| nestjs-starter | ts | 1.75% | 1.75% | 0.000pp |
+| django-realworld | python | 3.77% | 3.68% | -0.094pp |
+| flask-realworld | python | 6.58% | 6.58% | 0.000pp |
+| click | python | 5.99% | 5.99% | 0.000pp |
+| requests | python | 1.43% | 1.43% | 0.000pp |
+| pandas | python | 9.80% | 9.80% | 0.000pp |
+| kafka-streams-examples | java | 3.40% | 3.40% | 0.000pp |
+| vapor-api-template | swift | 2.13% | 2.13% | 0.000pp |
+
+Zero non-python deltas (Python-gated). django-realworld improves
+spillover -0.094pp. No regression >0.5pp on any corpus.
+
+Tests: `go test ./internal/engine/...` pass; new
+`django_imports_rewrite_test.go` covers all suffix cases + non-Model
+prefix passthrough + non-IMPORTS/DEPENDS_ON kind passthrough.
+
+Residual root cause: kind-mismatch dropped 60 → 3 (only `User`-shaped
+bare-name imports remain, which have no suffix discriminator). The
+larger remaining bug-resolver bucket (84 `ambig-bare-hint-fail`) is
+file-scoped helper functions defined in multiple modules — requires
+file-scoped resolution (#494 receiver-variable-type primitive).
+Bug-extractor (1676) dominated by generic Python verbs blocked per
+safer-bias rule (#94).
+
+Status: at-bar (5.93%, well below 8% floor; ship-gate target ≤3% —
+gap 2.93pp remains).
+
+Chain-fixes filed (for next wave):
+1. **Python module-constant entity lift at extractor level** —
+   wave-9 already routes `Model:<SCREAMING_SNAKE>` to Dynamic
+   (resolver-level); the structural alternative emits SCOPE.Component
+   entities for `^[A-Z][A-Z0-9_]*$` module-level assignments so they
+   become queryable in the graph (no bug-rate movement, completeness
+   win).
+2. **DRF @action structural binding** — wave-9 routes `Action:<x>` to
+   Dynamic; structural alternative looks up `<x>` as a method in any
+   class in the same module that inherits from a viewset base. No
+   bug-rate change (Dynamic isn't a bug bucket).
+3. **Per-import file-scoped Python allowlists** — pandas `query`/`head`,
+   numpy `array`/`zeros`, requests `get`/`post`, boto3 `client`,
+   redis `set`/`incr`. Mirrors the wave-9 React Track B precedent
+   (jsCollectionLibBareNames gated on lodash/ramda imports). On
+   client-fixture-a the candidate volume is small (~50 edges, ~-0.16pp)
+   so it ships as a separate followup PR with the broader python
+   ecosystem corpora (pandas, requests).
+4. **Serializer duplicate-extraction dedup** — both DRF custom
+   extractor (`internal/custom/python/django.go:153`) AND the base
+   Python class extractor emit `SCOPE.Component:UserSerializer` in
+   `*/serializers.py` files, populating `ambigKind[Component][Name]`.
+   Same-file same-name same-kind dedup at extractor merge time would
+   eliminate the 9 residual `ambig-kind` exposed by Chain-fix A.

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -220,6 +220,18 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		ctx, file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Django models-import suffix rewrite (PR #580 wave-10 Chain-fix A):
+	// The YAML rule `from \S+\.models import (\w+)` emits Model:<name>
+	// for every captured identifier. In Django/DRF projects, a sibling
+	// `models` module routinely re-exports Serializer / ViewSet / View
+	// classes. The naive Model: prefix surfaces as kind-mismatch
+	// bug-resolver edges (60 instances on client-fixture-a). Rewrite the
+	// ToID prefix in-place on suffix heuristics so the IMPORTS edge
+	// matches the actual entity kind. Python-only.
+	if file.Language == "python" {
+		relationships = rewritePythonModelImports(relationships)
+	}
+
 	span.SetAttributes(
 		attribute.Int("entity_count", len(entities)),
 		attribute.Int("relationship_count", len(relationships)),

--- a/internal/engine/django_imports_rewrite.go
+++ b/internal/engine/django_imports_rewrite.go
@@ -1,0 +1,97 @@
+// Django models-import suffix rewrite.
+//
+// The YAML rule
+//   from \S+\.models import (\w+)
+// in `internal/engine/rules/python/frameworks/django.yaml` emits an
+// IMPORTS edge with `ToID = Model:<captured-name>`. Django + DRF
+// codebases routinely re-export Serializer / ViewSet / View classes
+// through a sibling `models` module (or via barrel-style
+// `from app.models import UserSerializer`), so the naive Model: prefix
+// surfaces as kind-mismatch bug-resolver edges at resolve time (60
+// instances on client-fixture-a per PR #580 wave-9 residual analysis).
+//
+// This pass rewrites the ToID prefix in-place on suffix heuristics:
+//   Model:<X>Serializer        → Component:<X>Serializer
+//   Model:<X>(View|ViewSet|...) → View:<X>...
+//
+// Other Model: edges (genuine Django ORM model imports) are left
+// untouched. Python-only — gated by detector.go before invocation.
+//
+// Refs PR #580 wave-10 Chain-fix A.
+
+package engine
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// viewSuffixes lists the Django CBV / DRF ViewSet base-class name
+// suffixes the YAML `source_patterns` register as `entity_type: View`.
+// Kept in sync with the View regex in django.yaml (lines 80-82).
+var viewSuffixes = []string{
+	"ViewSet",
+	"Viewset", // tolerate the lowercase-`set` typo common in older codebases
+	"ListView",
+	"DetailView",
+	"CreateView",
+	"UpdateView",
+	"DeleteView",
+	"TemplateView",
+	"FormView",
+	"APIView",
+	// Plain "View" comes last so "ListView" etc. match first via
+	// length-ordering in classifyName below.
+	"View",
+}
+
+// rewritePythonModelImports rewrites Model:<name> IMPORTS edge targets
+// to Component:<name> when the captured name ends in "Serializer", or
+// View:<name> when it ends in any viewSuffixes entry. The slice is
+// modified in place (no allocation). Returns the same slice for
+// composability with the surrounding pipeline.
+func rewritePythonModelImports(rels []types.RelationshipRecord) []types.RelationshipRecord {
+	for i := range rels {
+		r := &rels[i]
+		// Both IMPORTS (from django.yaml `from X.models import Y`) and
+		// DEPENDS_ON (from sqlalchemy.yaml `from X import <PascalCase>`,
+		// which fires on every Python file regardless of framework
+		// detection) emit `Model:<name>` ToIDs that mismatch when the
+		// captured name is actually a DRF Serializer or a CBV/ViewSet
+		// class re-exported through a sibling `models` module.
+		if r.Kind != "IMPORTS" && r.Kind != "DEPENDS_ON" {
+			continue
+		}
+		const prefix = "Model:"
+		if !strings.HasPrefix(r.ToID, prefix) {
+			continue
+		}
+		name := r.ToID[len(prefix):]
+		if name == "" {
+			continue
+		}
+		switch classifyDjangoModelImportName(name) {
+		case "Component":
+			r.ToID = "Component:" + name
+		case "View":
+			r.ToID = "View:" + name
+		}
+	}
+	return rels
+}
+
+// classifyDjangoModelImportName returns "Component" for names ending in
+// "Serializer", "View" for names ending in any Django/DRF view-class
+// suffix, and "" otherwise (meaning: keep the original Model: prefix).
+func classifyDjangoModelImportName(name string) string {
+	if strings.HasSuffix(name, "Serializer") {
+		return "Component"
+	}
+	for _, suf := range viewSuffixes {
+		if strings.HasSuffix(name, suf) {
+			return "View"
+		}
+	}
+	return ""
+}

--- a/internal/engine/django_imports_rewrite_test.go
+++ b/internal/engine/django_imports_rewrite_test.go
@@ -1,0 +1,103 @@
+// Tests for the Django models-import suffix rewrite pass.
+//
+// Refs PR #580 wave-10 Chain-fix A.
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestRewritePythonModelImports(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   types.RelationshipRecord
+		want string
+	}{
+		{
+			name: "Serializer suffix → Component",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Model:UserSerializer"},
+			want: "Component:UserSerializer",
+		},
+		{
+			name: "ViewSet suffix → View (IMPORTS)",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Model:UserViewSet"},
+			want: "View:UserViewSet",
+		},
+		{
+			name: "ViewSet suffix → View (DEPENDS_ON)",
+			in:   types.RelationshipRecord{Kind: "DEPENDS_ON", ToID: "Model:OrderViewSet"},
+			want: "View:OrderViewSet",
+		},
+		{
+			name: "ListView suffix → View",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Model:UserListView"},
+			want: "View:UserListView",
+		},
+		{
+			name: "Plain View suffix → View",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Model:DashboardView"},
+			want: "View:DashboardView",
+		},
+		{
+			name: "lowercase Viewset typo → View",
+			in:   types.RelationshipRecord{Kind: "DEPENDS_ON", ToID: "Model:ScheduleViewset"},
+			want: "View:ScheduleViewset",
+		},
+		{
+			name: "Genuine Model name preserved",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Model:User"},
+			want: "Model:User",
+		},
+		{
+			name: "Non-Model prefix untouched",
+			in:   types.RelationshipRecord{Kind: "IMPORTS", ToID: "Component:UserSerializer"},
+			want: "Component:UserSerializer",
+		},
+		{
+			name: "Non-IMPORTS/DEPENDS_ON edge untouched",
+			in:   types.RelationshipRecord{Kind: "CALLS", ToID: "Model:UserSerializer"},
+			want: "Model:UserSerializer",
+		},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := rewritePythonModelImports([]types.RelationshipRecord{tc.in})
+			if got := out[0].ToID; got != tc.want {
+				t.Errorf("ToID: got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassifyDjangoModelImportName(t *testing.T) {
+	t.Parallel()
+	cases := map[string]string{
+		"UserSerializer":          "Component",
+		"OrderViewSet":            "View",
+		"OrderViewset":            "View",
+		"DetailView":              "View",
+		"BlogListView":            "View",
+		"DashboardView":           "View",
+		"APIView":                 "View",
+		"User":                    "",
+		"Article":                 "",
+		"DocumentTemplate":        "",
+		"ChecklistItem":           "",
+		"PermissionPagesEnum":     "",
+		"MA_JURISDICTION_NAME":    "",
+	}
+	for name, want := range cases {
+		name, want := name, want
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := classifyDjangoModelImportName(name); got != want {
+				t.Errorf("got %q, want %q", got, want)
+			}
+		})
+	}
+}

--- a/internal/engine/rules/python/frameworks/django.yaml
+++ b/internal/engine/rules/python/frameworks/django.yaml
@@ -116,6 +116,13 @@ source_patterns:
 # relationship_rules: regex patterns that produce edges between entities.
 relationship_rules:
   # Model used in view: from app.models import MyModel
+  # NOTE: emits target_type: Model for every captured name. A Go-side
+  # post-pass (rewritePythonModelImports in detector.go) reclassifies
+  # `Model:<X>Serializer` → `Component:<X>Serializer` and
+  # `Model:<X>(View|ViewSet|...)` → `View:<X>...` so DRF / CBV re-exports
+  # through a sibling `models` module don't surface as kind-mismatch
+  # bug-resolver edges. Refs PR #580 residual analysis (60 kind-mismatch
+  # edges on client-fixture-a).
   - pattern: "from\\s+\\S+\\.models\\s+import\\s+(\\w+)"
     source_type: View
     target_type: Model


### PR DESCRIPTION
## Summary

Wave-10 client-fixture-a Chain-fix A from PR #580 residual analysis: **6.08% → 5.93% (-0.15pp)** via Python-gated Go post-pass that rewrites the kind-prefix of YAML-emitted `Model:<name>` IMPORTS/DEPENDS_ON edges on suffix heuristics. Targets the 60 `kind-mismatch` bug-resolver edges the #580 PR identified as the highest-impact remaining cohort.

## Per-iteration delta (client-fixture-a)

| Pass | bug_rate | bug-resolver | kind-mismatch | Δ | Mechanism |
|------|----------|---|---|---|-----------|
| baseline (post-#582 main) | 6.08% | 259 | 60 | — | post-#582 |
| pass-1 | 5.93% | 211 | 3 | -0.15pp | Chain-fix A suffix rewrite |

bug-resolver dropped 259 → 211 (-48 resolved). kind-mismatch dropped 60 → 3 (-57; the surviving 3 are `Model:User` which has no discriminating suffix). 47 IMPORTS/DEPENDS_ON edges now bind to View/Component entities instead of the kind-mismatched `Model:` prefix.

Diagnostic confirmation pre-fix:
- bug-resolver kind-mismatch: 60 (all `Model:<X>Serializer` or `Model:<X>ViewSet`)

Diagnostic confirmation post-fix:
- bug-resolver kind-mismatch: 3 (only `Model:User` — bare name, no suffix)
- bug-resolver ambig-kind: 9 (new — `Component:<X>Serializer` exposes existing duplicate-extraction problem; see Chain-fix 4 below)

## Implementation

`internal/engine/django_imports_rewrite.go` introduces `rewritePythonModelImports` which runs as a post-pass in `detector.go` after `applyDjangoRouteComposition`, gated on `file.Language == "python"`. Rewrites in-place on `IMPORTS` and `DEPENDS_ON` edges:

- `Model:<X>Serializer` → `Component:<X>Serializer`
- `Model:<X>(ViewSet|Viewset|ListView|DetailView|CreateView|UpdateView|DeleteView|TemplateView|FormView|APIView|View)` → `View:<X>...`
- everything else → unchanged

The `Viewset` (lowercase `set`) variant is included to tolerate the typo common in older Django codebases. `View` is matched last so the longer-suffix view types are caught first.

The single-rule YAML in `django.yaml:119` is preserved (single capture group + single target_type, the engine's contract); the Go post-pass does the suffix-based dispatch a RE2 regex can't express via lookahead.

Tests: `internal/engine/django_imports_rewrite_test.go` covers all suffix mappings, both edge kinds, the lowercase Viewset variant, the non-Model prefix passthrough, and the non-IMPORTS/DEPENDS_ON edge passthrough.

## Regression check (14 corpora vs current main)

| Repo | Lang | main | w10 | Δ |
|---|---|---:|---:|---:|
| chi | go | 4.23% | 4.23% | 0.000pp |
| express | js | 3.00% | 3.00% | 0.000pp |
| spdlog | cpp | 5.76% | 5.76% | 0.000pp |
| gin | go | 4.93% | 4.93% | 0.000pp |
| play-scala-starter | scala | 2.11% | 2.11% | 0.000pp |
| nextjs-commerce | ts | 2.32% | 2.32% | 0.000pp |
| nestjs-starter | ts | 1.75% | 1.75% | 0.000pp |
| django-realworld | python | 3.77% | 3.68% | -0.094pp |
| flask-realworld | python | 6.58% | 6.58% | 0.000pp |
| click | python | 5.99% | 5.99% | 0.000pp |
| requests | python | 1.43% | 1.43% | 0.000pp |
| pandas | python | 9.80% | 9.80% | 0.000pp |
| kafka-streams-examples | java | 3.40% | 3.40% | 0.000pp |
| vapor-api-template | swift | 2.13% | 2.13% | 0.000pp |

Zero non-python deltas (Python-gated). django-realworld improves -0.094pp from Chain-fix A spillover. No regression >0.5pp on any corpus.

## Tests

`go test ./internal/engine/... ./internal/resolve/...` — pass.

## Residual root cause

Kind-mismatch dropped 60 → 3; the 3 residual are `Model:User` shaped — bare-name imports with no discriminating suffix. The remaining bug-resolver cohort is dominated by:
- `ambig-bare-hint-fail` (84): file-scoped helper functions (`client`, `make_jurisdiction`, `make_checklist`, etc.) declared in multiple files with no hint family that narrows them — requires file-scoped resolution / receiver-variable-type primitive (#494).
- `ambig-kind` (9, new): `Component:<X>Serializer` exposed by Chain-fix A — both DRF custom extractor (`internal/custom/python/django.go:153`) AND the base Python class extractor emit `SCOPE.Component:UserSerializer` in `*/serializers.py` files, so the Component kind bucket flips to ambiguous. Structural duplicate-extraction problem, separate fix.

Bug-extractor (1676) dominated by generic Python verbs (`first`/`append`/`write`/`items`/`pop`/`cursor`/`execute`/...) explicitly excluded per safer-bias rule (#94).

## Status

at-bar (5.93%, well below 8% floor; ship-gate target ≤3% — gap 2.93pp remains).

## Chain-fixes filed (for next wave)

1. **Python module-constant entity lift at extractor level** — wave-9 already routes `Model:<SCREAMING_SNAKE>` to Dynamic at resolver level; the structural alternative emits SCOPE.Component entities for `^[A-Z][A-Z0-9_]*$` module-level assignments so they become queryable in the graph (no bug-rate movement, graph completeness win).
2. **DRF `@action` structural binding** — wave-9 routes `Action:<x>` to Dynamic; structural alternative binds to the locally-defined viewset method via the decorator-wrapped class scan. No bug-rate change (Dynamic isn't a bug bucket).
3. **Per-import file-scoped Python allowlists** — pandas `query`/`head`, numpy `array`/`zeros`, requests `get`/`post`, boto3 `client`, redis `set`/`incr`. Mirrors the wave-9 React Track B precedent. On client-fixture-a the candidate volume is small (~50 edges, ≤-0.16pp), so it ships as a separate followup PR with broader python ecosystem corpora (pandas, requests).
4. **Serializer duplicate-extraction dedup** — both DRF custom extractor and base Python class extractor emit `SCOPE.Component:UserSerializer` in `*/serializers.py` files. Same-file same-name same-kind dedup at extractor merge time would eliminate the 9 residual `ambig-kind` exposed by Chain-fix A.

## Test plan

- [x] `go test ./internal/engine/...` passes (existing + new tests)
- [x] `go test ./internal/resolve/...` passes
- [x] client-fixture-a bug-rate measured: 6.08% → 5.93%
- [x] Regression check on 14 corpora: 0 non-python deltas, 1 python improvement
- [x] Determinism verified (2x run identical disposition counts)

Generated with [Claude Code](https://claude.com/claude-code)