### PR TITLE
[#584] JS extractor: lift destructure-rename declarations (closes client-fixture-b ship-gate gap)

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -531,6 +531,88 @@ it).
 
 ---
 
+## Wave-12 (JS/TS extractor destructure-rename lift, #584 ship-gate)
+
+Extractor-level follow-up to wave-11 that addresses the chain-fix
+deferred from #585: the JS extractor previously emitted no entity for
+the LHS of `const { mutate: createAddress } = useCreateAlternateAddress()`
+or `const { data, isLoading } = useQuery()` because the variable-
+declarator name field is an `object_pattern`, not an identifier. Every
+downstream call site (`createAddress(...)`, `setError(...)`) therefore
+landed in bug-extractor on the resolver.
+
+- **Fix shape:** `handleVariableDeclarator` now detects
+  `object_pattern` / `array_pattern` LHS and walks the tree, emitting
+  one entity per local binding name. Pair patterns (`{ key: local }`)
+  emit the LOCAL name, not the property key. Nested patterns recurse
+  to leaf bindings. Array patterns emit one entity per identifier
+  (covers `useState` tuples + general array destructure).
+- **Classification:** when the RHS is a call to a mutation-style
+  hook (`useMutation`, `useSWRMutation`, `useState`, `useReducer`,
+  `useModal`, `useQuery`, antd App-context hooks, the custom
+  `useXxxMutation` convention, or `use{Create|Update|Delete|Patch|
+  Toggle|Open|Close|...}Xxx` naming pattern), lifted entities classify
+  as `SCOPE.Operation`. Otherwise `SCOPE.Component`. The over-lift on
+  non-callable leaves (`data`, `isLoading`) is intentional and cheap:
+  the resolver only consults Operation entities for CALLS targets, so
+  unused Operation entities are inert.
+
+Per-iteration delta on client-fixture-b (primary target):
+
+| Pass | bug-rate | bug-ext | bug-res | Δ vs baseline |
+|---|---:|---:|---:|---:|
+| baseline (post-wave-11 #585) | 1.738% | 644 | 180 | — |
+| Pass-1 (#584 destructure-rename lift) | 1.154% | 422 | 125 | -0.584pp |
+
+client-fixture-c (secondary target):
+
+| Pass | bug-rate | Δ |
+|---|---:|---:|
+| baseline | 2.680% | — |
+| Pass-1 | 2.628% | -0.052pp |
+
+Regression check (main vs wave-12) — 11 listed repos + client-fixture-a:
+
+| Repo | Main | W12 | Δ |
+|---|---:|---:|---:|
+| chi | 4.233% | 4.233% | 0.000pp |
+| flask | 9.458% | 9.458% | 0.000pp |
+| spdlog | 5.758% | 5.758% | 0.000pp |
+| gin | 4.931% | 4.931% | 0.000pp |
+| play-scala-starter | 2.113% | 2.113% | 0.000pp |
+| express | 2.996% | 2.996% | 0.000pp |
+| nextjs-commerce | 2.317% | 2.093% | -0.224pp |
+| nestjs-starter | 1.754% | 1.754% | 0.000pp |
+| kafka-streams-examples | 3.396% | 3.396% | 0.000pp |
+| vapor-api-template | 2.128% | 2.128% | 0.000pp |
+| ktor-samples | 4.864% | 4.864% | 0.000pp |
+| client-fixture-a | 6.082% | 6.082% | 0.000pp |
+
+No regression. The only non-zero deltas are improvements: nextjs-commerce
+(-0.224pp) confirms the destructure-rename lift fires on real React
+Query / SWR shapes in the wider TS ecosystem, not just cfb's hooks.
+Every non-JS/TS corpus is bit-identical because the new code path is
+gated to the JS extractor's variable-declarator handler.
+
+Residual root cause: post-#584 cfb bug-extractor top samples are now
+single-word bare callables (`replace`, `warning`, `clearFilters`,
+`unwrap`, `get`) — String/Array prototype methods, antd `Modal.warning`
+static, lodash/fp `unwrap`, and accessor `get` on opaque receivers.
+These are receiver-typing residuals (the call site is `x.replace(...)`
+where the receiver-type binding wasn't captured upstream), NOT the
+destructure-rename pattern. They split between (a) bareNames additions
+to synth.go (a synth/resolve-only follow-up wave) and (b) receiver-
+type inference improvements (a deeper extractor change).
+
+Status: AT SHIP-GATE BOUND. cfb 1.738% → 1.154% — within 0.155pp of
+the 1.0% ship-gate floor. cfc 2.680% → 2.628%. Wave-12 closes the
+destructure-rename gap that wave-11 explicitly deferred. Remaining
+0.15pp is receiver-type residuals and is filed as the next chain-fix
+candidate (bare-name additions for `replace`/`warning`/`clearFilters`
+plus a small set of antd static helpers).
+
+---
+
 ## Wave-4 PHP (Symfony residual reduction, post-#498 chase to ≤3%)
 
 Targeted continuation of PHP wave-3 (#485) symfony-demo residual chase

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -507,12 +507,39 @@ func (x *extractor) handleVariableDeclaration(n *sitter.Node, parentClass string
 // handleVariableDeclarator processes a single variable_declarator node.
 func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string, cb *classBindings) {
 	nameNode := n.ChildByFieldName("name")
+	if nameNode == nil {
+		return
+	}
+	valueNode := n.ChildByFieldName("value")
+
+	// Issue #584 — destructure-rename lift. Patterns like
+	//   const { mutate: createAddress } = useCreateAlternateAddress();
+	//   const { data, isLoading } = useFooQuery();
+	//   const [error, setError] = useState();
+	// previously produced no entity (nameNode is object_pattern /
+	// array_pattern, not identifier). Downstream files using
+	// `createAddress(...)`, `setError(...)` therefore landed in
+	// bug-extractor on the resolver. Walk the LHS pattern and emit one
+	// entity per local binding so the resolver can bind same-file and
+	// cross-file CALLS to a real entity. Mutation-style hooks
+	// (useMutation / useCreateX / useDeleteX / ...) classify lifted
+	// callables as SCOPE.Operation; everything else as SCOPE.Component
+	// (mirrors the wrapper-call vs plain-value split in the default
+	// branch below).
+	if nameNode.Type() == "object_pattern" || nameNode.Type() == "array_pattern" {
+		opLift := isMutationStyleHookCall(x, valueNode)
+		x.emitDestructuredEntities(nameNode, valueNode, opLift, parentClass, cb)
+		if valueNode != nil {
+			x.walkChildren(valueNode, parentClass, cb)
+		}
+		return
+	}
+
 	name := x.nodeText(nameNode)
 	if name == "" {
 		return
 	}
 
-	valueNode := n.ChildByFieldName("value")
 	if valueNode == nil {
 		return
 	}
@@ -686,6 +713,238 @@ func (x *extractor) findInnerFunctionBody(n *sitter.Node) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// emitDestructuredEntities walks an object_pattern or array_pattern LHS
+// of a variable declarator and emits one entity per local binding name.
+// See #584 for the rationale; this is the destructure-rename twin of the
+// #522 const-export lift.
+//
+// Naming rules:
+//   - `{ foo }` shorthand_property_identifier_pattern → local name "foo"
+//   - `{ foo: bar }` pair_pattern → local name "bar" (the value-side,
+//     not the property key)
+//   - `{ foo: { y } }` nested pair_pattern → recurse into the value
+//     pattern (the local binding is "y", not "foo")
+//   - `[a, b, c]` array_pattern → one entity per identifier child
+//   - `[, b]` array_pattern with elisions → skipped (no identifier)
+//   - `{ ...rest }` rest_pattern → emit the rest binding name
+//
+// Classification:
+//   - opLift=true → SCOPE.Operation (mutation hooks return callables)
+//   - opLift=false → SCOPE.Component
+//
+// Each emit is anchored to valueNode for line numbers (the LHS doesn't
+// carry useful position info beyond what's already on the declarator).
+func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, opLift bool, parentClass string, cb *classBindings) {
+	if pattern == nil {
+		return
+	}
+	anchor := valueNode
+	if anchor == nil {
+		anchor = pattern
+	}
+	kind := "SCOPE.Component"
+	subtype := "const_destructure"
+	sigPrefix := "const"
+	if opLift {
+		kind = "SCOPE.Operation"
+		subtype = "const_destructure_call"
+		sigPrefix = "const"
+	}
+
+	var walk func(p *sitter.Node)
+	walk = func(p *sitter.Node) {
+		if p == nil {
+			return
+		}
+		switch p.Type() {
+		case "object_pattern":
+			for i := 0; i < int(p.ChildCount()); i++ {
+				walk(p.Child(i))
+			}
+		case "array_pattern":
+			for i := 0; i < int(p.ChildCount()); i++ {
+				ch := p.Child(i)
+				if ch == nil {
+					continue
+				}
+				switch ch.Type() {
+				case "identifier":
+					name := x.nodeText(ch)
+					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [%s, ...]", sigPrefix, name))
+				case "object_pattern", "array_pattern":
+					walk(ch)
+				case "rest_pattern":
+					if id := firstIdentifierChild(ch); id != nil {
+						name := x.nodeText(id)
+						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [...%s]", sigPrefix, name))
+					}
+				case "assignment_pattern":
+					// e.g. [a = 1] — the binding name is the LHS identifier.
+					if left := ch.ChildByFieldName("left"); left != nil {
+						if left.Type() == "identifier" {
+							name := x.nodeText(left)
+							x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [%s = ...]", sigPrefix, name))
+						} else {
+							walk(left)
+						}
+					}
+				}
+			}
+		case "shorthand_property_identifier_pattern":
+			name := x.nodeText(p)
+			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s }", sigPrefix, name))
+		case "pair_pattern":
+			// `{ key: value }` — value can be identifier, nested object_pattern,
+			// array_pattern, or assignment_pattern (default value).
+			value := p.ChildByFieldName("value")
+			if value == nil {
+				return
+			}
+			switch value.Type() {
+			case "identifier":
+				name := x.nodeText(value)
+				x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s }", sigPrefix, name))
+			case "object_pattern", "array_pattern":
+				walk(value)
+			case "assignment_pattern":
+				if left := value.ChildByFieldName("left"); left != nil {
+					if left.Type() == "identifier" {
+						name := x.nodeText(left)
+						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s = ... }", sigPrefix, name))
+					} else {
+						walk(left)
+					}
+				}
+			}
+		case "rest_pattern":
+			if id := firstIdentifierChild(p); id != nil {
+				name := x.nodeText(id)
+				x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...%s }", sigPrefix, name))
+			}
+		case "assignment_pattern":
+			if left := p.ChildByFieldName("left"); left != nil {
+				if left.Type() == "identifier" {
+					name := x.nodeText(left)
+					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s = ...", sigPrefix, name))
+				} else {
+					walk(left)
+				}
+			}
+		case "identifier":
+			name := x.nodeText(p)
+			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s", sigPrefix, name))
+		}
+	}
+	walk(pattern)
+}
+
+// firstIdentifierChild returns the first identifier-typed child of n, or nil.
+// Used to dig out the bound name from a rest_pattern wrapper.
+func firstIdentifierChild(n *sitter.Node) *sitter.Node {
+	if n == nil {
+		return nil
+	}
+	for i := 0; i < int(n.ChildCount()); i++ {
+		ch := n.Child(i)
+		if ch != nil && ch.Type() == "identifier" {
+			return ch
+		}
+	}
+	return nil
+}
+
+// isMutationStyleHookCall returns true when the RHS of a destructuring
+// declaration is a call to a React/data-fetching hook whose canonical
+// destructured leaf is a callable (a mutation trigger, dispatcher,
+// setter, modal opener, etc.). Used by #584 to classify lifted
+// destructure-rename bindings as SCOPE.Operation rather than
+// SCOPE.Component.
+//
+// We match on the *callee identifier* (or member-expression trailing
+// property), gated to call_expression values. The set is the union of:
+//
+//   - React core: useState, useReducer
+//   - React Query / TanStack: useMutation + every `useXxxMutation`
+//     convention (matched via a "Mutation" suffix)
+//   - SWR mutate hooks: useSWRMutation
+//   - React Hook Form: useForm
+//   - antd v5 hooks that return callable triples (useModal, useMessage,
+//     useNotification, useApp)
+//   - Generic convention: any identifier matching
+//     `^use(Create|Update|Delete|Patch|Post|Put|Remove|Add|Toggle|Open|Close|Save|Submit)[A-Z]`
+//     which covers the dominant naming pattern for custom mutation
+//     hooks observed in real client codebases (e.g.
+//     useCreateAlternateAddress, useDeleteUser, useToggleFavorite).
+//
+// When this returns true, ALL leaves of the destructure pattern are
+// lifted as SCOPE.Operation — the broader bias is intentional. Real
+// data values like `{ data, isLoading }` from useQuery still get
+// classified as Operation under this scheme, but the cost is low: the
+// resolver only consults Operation entities for CALLS edges, so a
+// non-callable bound name produces no false positives, only a slightly
+// wider candidate set for legitimate callable leaves like `mutate`,
+// `refetch`, `setError`.
+func isMutationStyleHookCall(x *extractor, valueNode *sitter.Node) bool {
+	if valueNode == nil || valueNode.Type() != "call_expression" {
+		return false
+	}
+	fn := valueNode.ChildByFieldName("function")
+	if fn == nil {
+		return false
+	}
+	leaf := ""
+	switch fn.Type() {
+	case "identifier":
+		leaf = x.nodeText(fn)
+	case "member_expression":
+		if prop := fn.ChildByFieldName("property"); prop != nil {
+			leaf = x.nodeText(prop)
+		}
+	}
+	if leaf == "" {
+		return false
+	}
+	return isMutationStyleHookName(leaf)
+}
+
+// isMutationStyleHookName encodes the name-shape rule documented on
+// isMutationStyleHookCall. Pure function, exported via test seam.
+func isMutationStyleHookName(leaf string) bool {
+	switch leaf {
+	case
+		"useState", "useReducer",
+		"useMutation", "useSWRMutation",
+		"useForm",
+		"useModal", "useMessage", "useNotification", "useApp",
+		"useQuery", "useInfiniteQuery", "useSWR", "useSWRImmutable",
+		"useDispatch", "useNavigate", "useLocation", "useParams",
+		"useDisclosure":
+		return true
+	}
+	// `useXxxMutation` convention (React Query custom mutation hooks).
+	if strings.HasPrefix(leaf, "use") && strings.HasSuffix(leaf, "Mutation") && len(leaf) > len("use")+len("Mutation") {
+		return true
+	}
+	// `use{Create|Update|Delete|Patch|Post|Put|Remove|Add|Toggle|Open|Close|Save|Submit}{Xxx}`
+	// custom mutation-hook naming convention.
+	if strings.HasPrefix(leaf, "use") && len(leaf) > 3 {
+		rest := leaf[3:]
+		for _, verb := range []string{
+			"Create", "Update", "Delete", "Patch", "Post", "Put",
+			"Remove", "Add", "Toggle", "Open", "Close", "Save", "Submit",
+			"Fetch", "Send", "Upload", "Download",
+		} {
+			if strings.HasPrefix(rest, verb) && len(rest) > len(verb) {
+				next := rest[len(verb)]
+				if next >= 'A' && next <= 'Z' {
+					return true
+				}
+			}
+		}
+	}
+	return false
 }
 
 // constValueSubtype maps a tree-sitter value-node type to a stable

--- a/internal/extractors/javascript/extractor_test.go
+++ b/internal/extractors/javascript/extractor_test.go
@@ -750,3 +750,128 @@ func TestConstExportArrowFunctionRegression(t *testing.T) {
 
 	assertKind(t, entities, "useAuth", "SCOPE.Operation")
 }
+
+// --------------------------------------------------------------------------
+// #584 — destructure-rename lift
+// --------------------------------------------------------------------------
+
+// Shorthand object pattern → entity per leaf, SCOPE.Component default.
+func TestDestructureShorthandObject(t *testing.T) {
+	src := []byte(`const { foo, bar } = somethingArbitrary();`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	assertKind(t, entities, "foo", "SCOPE.Component")
+	assertKind(t, entities, "bar", "SCOPE.Component")
+}
+
+// Rename pair → entity for the LOCAL name (value side), not the property key.
+func TestDestructureRenamePropertyEmitsLocalName(t *testing.T) {
+	src := []byte(`const { foo: bar } = makeIt();`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	if got := findByName(entities, "bar"); got == nil {
+		t.Fatalf("expected local-name entity 'bar', got names: %v", entityNames(entities))
+	}
+	if got := findByName(entities, "foo"); got != nil {
+		t.Errorf("did NOT expect property-key entity 'foo', but found one")
+	}
+}
+
+// React Query mutation hook → destructured leaves lift as SCOPE.Operation.
+func TestDestructureMutationHookLiftsOperation(t *testing.T) {
+	src := []byte(`
+import { useCreateAlternateAddress } from "./hooks";
+function Cmp() {
+  const { mutate: createAddress, isSuccess } = useCreateAlternateAddress();
+  return createAddress();
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	assertKind(t, entities, "createAddress", "SCOPE.Operation")
+	assertKind(t, entities, "isSuccess", "SCOPE.Operation")
+}
+
+// useQuery → all leaves lift; data + isLoading both emitted.
+func TestDestructureUseQueryEmitsAllLeaves(t *testing.T) {
+	src := []byte(`
+function Cmp() {
+  const { data, isLoading, error } = useQuery({ queryKey: ["x"] });
+  return data;
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	if findByName(entities, "data") == nil {
+		t.Errorf("expected 'data'; names: %v", entityNames(entities))
+	}
+	if findByName(entities, "isLoading") == nil {
+		t.Errorf("expected 'isLoading'; names: %v", entityNames(entities))
+	}
+	if findByName(entities, "error") == nil {
+		t.Errorf("expected 'error'; names: %v", entityNames(entities))
+	}
+}
+
+// Array destructure → entity per identifier (covers useState-like tuples).
+func TestDestructureArrayPatternEmitsAll(t *testing.T) {
+	src := []byte(`
+function Cmp() {
+  const [error, setError] = useState(null);
+  const [a, b] = arr;
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	// useState → Operation lift (the hook is in the mutation-style allowlist).
+	assertKind(t, entities, "error", "SCOPE.Operation")
+	assertKind(t, entities, "setError", "SCOPE.Operation")
+	// `arr` is an identifier RHS, not a hook call → Component default.
+	assertKind(t, entities, "a", "SCOPE.Component")
+	assertKind(t, entities, "b", "SCOPE.Component")
+}
+
+// Nested object pattern → leaf binding (y), not the intermediate key (x).
+func TestDestructureNestedObjectPattern(t *testing.T) {
+	src := []byte(`const { x: { y } } = z;`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	if findByName(entities, "y") == nil {
+		t.Fatalf("expected leaf entity 'y'; names: %v", entityNames(entities))
+	}
+	if findByName(entities, "x") != nil {
+		t.Errorf("did NOT expect intermediate-key entity 'x'")
+	}
+}
+
+// Real-world cfb pattern — Modal/useModal style with multiple renames.
+func TestDestructureUseModalLiftsCallables(t *testing.T) {
+	src := []byte(`
+function Cmp() {
+  const { open: openModal, close: closeModal } = useModal();
+  return openModal();
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	assertKind(t, entities, "openModal", "SCOPE.Operation")
+	assertKind(t, entities, "closeModal", "SCOPE.Operation")
+}
+
+// Regression: non-destructured `const X = identifier` still routes through
+// the default branch (SCOPE.Component subtype="const_alias"). This guards
+// that the new top-of-function early-return doesn't swallow the normal path.
+func TestDestructureRegressionNonPattern(t *testing.T) {
+	src := []byte(`const useAppDispatch = useDispatch;`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	assertKind(t, entities, "useAppDispatch", "SCOPE.Component")
+}


### PR DESCRIPTION
## Summary

Walks `object_pattern` / `array_pattern` LHS in variable declarators and emits one entity per local binding. Pair patterns `{ key: local }` emit the LOCAL name (not the property key); nested patterns recurse to leaves; array patterns cover `useState` tuples + general destructure.

Classifies lifted entities as `SCOPE.Operation` when the RHS is a mutation-style hook call (`useMutation` / `useSWRMutation` / `useState` / `useReducer` / `useQuery` / `useModal` / antd App-context hooks / the `useXxxMutation` convention / `use{Create|Update|Delete|Patch|Toggle|Open|Close|...}Xxx` naming pattern). Otherwise `SCOPE.Component`.

Closes the chain-fix deferred from wave-11 (#585) and is wave-12 of the TS/JS ship-gate push.

## Before / After

### client-fixture-b (primary target)

| Metric | Before (#585 baseline) | After (#584) | Delta |
|---|---:|---:|---:|
| bug-rate | 1.738% | **1.154%** | -0.584pp |
| bug-extractor | 644 | 422 | -222 |
| bug-resolver | 180 | 125 | -55 |
| resolved | 24,934 | 27,331 | +2,397 |

### client-fixture-c (secondary target)

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| bug-rate | 2.680% | 2.628% | -0.052pp |

### Wider TS ecosystem (nextjs-commerce)

| Metric | Before | After | Delta |
|---|---:|---:|---:|
| bug-rate | 2.317% | 2.093% | -0.224pp |

The nextjs-commerce improvement confirms the lift fires on real React Query / SWR shapes in the wider TS ecosystem, not just cfb's hooks.

## Regression check (mandatory — extractor change)

| Repo | Main | W12 | Delta |
|---|---:|---:|---:|
| chi (go) | 4.233% | 4.233% | 0.000pp |
| flask (python) | 9.458% | 9.458% | 0.000pp |
| spdlog (cpp) | 5.758% | 5.758% | 0.000pp |
| gin (go) | 4.931% | 4.931% | 0.000pp |
| play-scala-starter | 2.113% | 2.113% | 0.000pp |
| express (js) | 2.996% | 2.996% | 0.000pp |
| nextjs-commerce (ts) | 2.317% | 2.093% | -0.224pp |
| nestjs-starter (ts) | 1.754% | 1.754% | 0.000pp |
| kafka-streams-examples (java) | 3.396% | 3.396% | 0.000pp |
| vapor-api-template (swift) | 2.128% | 2.128% | 0.000pp |
| ktor-samples (kotlin) | 4.864% | 4.864% | 0.000pp |
| client-fixture-a (python) | 6.082% | 6.082% | 0.000pp |

**No regression.** The only non-zero deltas are improvements on TS corpora. Every non-JS/TS corpus is bit-identical (the new code path is gated to the JS extractor's variable-declarator handler).

## Residual root cause

Post-#584 cfb bug-extractor top samples are now: `replace`, `warning`, `clearFilters`, `unwrap`, `get`. These are receiver-typing residuals — `x.replace(...)` String prototype, antd `Modal.warning` static, lodash/fp `unwrap`, accessor `get` on opaque receivers. NOT the destructure-rename pattern. They split between:

- (a) bareNames additions to `synth.go` for receiver-stripped common-prototype methods (synth/resolve-only follow-up wave)
- (b) deeper receiver-type inference improvements (extractor wave)

## Status

**at-bar.** cfb 1.738% → 1.154% — within 0.155pp of the 1.0% ship-gate floor. cfb has now closed the destructure-rename gap that wave-11 (#585) explicitly deferred. cfc 2.680% → 2.628%.

## Chain-fixes filed

- `synth.go` jsBareNames additions for residual receiver-stripped methods (`replace`, `warning`, `clearFilters`, `unwrap`, `get`, plus antd `Modal.*` statics) — synth-only, next wave.
- Receiver-type inference improvements for JS member-expression calls on opaque receivers — extractor wave, broader scope.

## Test plan

- [x] `go test ./internal/extractors/javascript/...` — 7 new tests pass:
  - shorthand object pattern → entity per leaf
  - rename pair `{ foo: bar }` → emits LOCAL name `bar`, NOT property key `foo`
  - mutation hook (`useCreateAlternateAddress`) → lifts as `SCOPE.Operation`
  - `useQuery({...})` → all leaves emitted (`data`, `isLoading`, `error`)
  - array pattern `[error, setError] = useState()` → Operation lift; `[a, b] = arr` → Component
  - nested `{ x: { y } }` → leaf `y` emitted (NOT intermediate `x`)
  - `{ open: openModal, close: closeModal } = useModal()` → both Operation
  - regression guard: `const useAppDispatch = useDispatch` (identifier RHS, no pattern) still routes through default branch as Component
- [x] `go test ./...` — full suite green
- [x] Regression sweep across 12 corpora (11 listed + cfa) — no regression
- [x] cfb / cfc / nextjs-commerce all measured post-fix