### PR TITLE
[ci] fix go vet failure on go-chi-mini quality fixture

### DIFF
--- a/internal/quality/golden/go-chi-mini/src/go.mod
+++ b/internal/quality/golden/go-chi-mini/src/go.mod
@@ -1,0 +1,10 @@
+// This go.mod isolates the go-chi-mini quality fixture from the parent
+// archigraph module so `go vet ./...` and `go build ./...` at the repo root
+// do not try to resolve the fixture's intentionally-vendored example imports
+// (github.com/go-chi/chi/v5, example.com/demo/*). The fixture is consumed
+// by the quality benchmark as source files on disk — it is never compiled
+// or executed as a real Go program.
+
+module example.com/go-chi-mini-fixture
+
+go 1.25.5


### PR DESCRIPTION
PR #617 added a Go fixture under `internal/quality/golden/go-chi-mini/src/` which gets walked by `go vet ./...`. The fixture uses chi router + example.com/demo/* imports that aren't (and shouldn't be) in the parent `go.mod`, so vet fails on main.

## Fix (Option A — canonical Go pattern)

Added a standalone `go.mod` inside the fixture directory declaring it as a separate module (`example.com/go-chi-mini-fixture`). Go's `./...` traversal stops at nested module boundaries, so `go vet ./...` and `go build ./...` at the repo root no longer descend into the fixture. The fixture is consumed by the quality bench as raw source files on disk — never compiled.

Least invasive: no fixture source changes, no build tags, no directory renames.

## Verification

- `go vet ./...` passes (clean output)
- `go test ./...` all packages green
- `archigraph quality internal/quality/golden/go-chi-mini` still reports 100% must-have recall (entities 20/20, relationships 16/16, forbidden 0)

## Residual root cause

n/a — pre-existing CI issue from quality fixture vendoring landed by PR #617.

## Status
at-ship-gate