### PR TITLE
[#613] Go chi/gorilla/gin: ROUTES_TO binds to handler method, not receiver variable

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -1290,3 +1290,67 @@ type primitive) — chain-fix already filed in click PR #601.
    signal (could be: presence of a `with open(...)` block in the
    function, or a `bytes`/`str` literal-typed receiver inference).
 
+
+## #613 — Go chi/gin/echo/fiber/gorilla_mux ROUTES_TO method binding (2026-05-19)
+
+The YAML rules for the five supported Go HTTP routers capture the handler
+argument with `(\w+)`, which cannot span `.` — so `r.Get("/users", h.List)`
+emits a ROUTES_TO edge to `Controller:h` (the receiver variable) instead of
+`Controller:UsersHandler.List` (the actual method entity). Every Go web
+service in the corpus + downstream user stacks is affected.
+
+**Fix (Option A):** new AST-driven post-pass `applyGoRouteComposition` in
+`internal/engine/go_routes.go`. The pass parses Go source with the stdlib
+`go/parser`, builds a same-file `varName -> typeName` map covering the three
+declaration shapes that dominate handler-registration code:
+
+1. `var h *UsersHandler` / `var h UsersHandler` — typed var decl.
+2. `h := &UsersHandler{...}` / `h := UsersHandler{...}` — composite literal.
+3. `h := NewUsersHandler(...)` / `h := handlers.NewUsersHandler(...)` —
+   Go `NewT` constructor idiom, which by convention returns `*T`.
+
+It then walks every `<recv>.<HTTPVerb>("<path>", <recv>.<Method>)` call,
+resolves `<recv>` via the var-type map, and rewrites the matching
+`Controller:<recv>` ROUTES_TO ToID to `Controller:<TypeName>.<Method>`. The
+pass edits ToID only — no entities created, no relationships added or
+removed — so it cannot regress non-Go pipelines or introduce
+false-positive Routes. When a receiver cannot be confidently resolved the
+edge is left untouched (safer-bias).
+
+**Quality bench delta (go-chi-mini fixture):**
+
+- Pre-fix recall: relationships 15/16 (93.8%); `nice_to_have` 1/2 (the
+  /users → UsersHandler.List edge was nice-to-have because the must_exist
+  asserted the broken `Controller:h` target).
+- Post-fix recall: relationships 17/17 (100.0%); `must_exist`
+  flipped to the correct method target, plus a second must_exist for
+  /users/{id} → UsersHandler.Get to assert multiple bindings off one
+  receiver var.
+- Forbidden hits: 0 (unchanged).
+
+**Regression check (mandatory):**
+
+| Fixture | Pre | Post | Δ |
+|---|---:|---:|---:|
+| go-chi-mini | 93.8% | 100.0% | +6.2pp |
+| java-spring-mini | 100.0% | 100.0% | 0.000pp |
+| python-django-mini | 100.0% | 100.0% | 0.000pp |
+| rust-tokio-mini | 100.0% | 100.0% | 0.000pp |
+| typescript-react-mini | 100.0% | 100.0% | 0.000pp |
+
+Zero regressions outside go (language-gated). All five quality fixtures at
+100% recall post-fix.
+
+**Residual root cause:** receiver-type tracking is intentionally bounded to
+the three Go-idiomatic shapes above; uncommon patterns (factories that
+don't follow `NewT`, struct fields holding handlers, generic-typed
+receivers, embedded-struct method promotion) still fall through to
+"unresolved → leave edge alone". A future #494 receiver-type primitive
+would cover those cases.
+
+**Status:** shipped. New edges land at `pattern_type=ast_driven` +
+`go_route_binding=method_receiver_resolved` for downstream telemetry.
+
+**Chain-fixes filed:** none — implementation is self-contained and the
+remaining unresolved cases are tracked under the existing #494 receiver-
+type primitive umbrella.

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -225,6 +225,16 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		ctx, file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Go HTTP route binding pass: rewrites YAML-emitted
+	// `Route:<path> -ROUTES_TO-> Controller:<receiverVar>` edges to point at
+	// the qualified handler method (`Controller:<Type>.<Method>`). Covers
+	// chi, gin, echo, fiber, gorilla_mux — every framework whose YAML rule
+	// captures only the bare receiver identifier with `(\w+)`. Edits ToID
+	// only; never adds/removes entities. No-op for non-Go files. Refs #613.
+	entities, relationships = applyGoRouteComposition(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// Synthetic http_endpoint emission for typed-HTTP cross-repo matching.
 	// Runs AFTER the Spring + Django composition passes so it can re-use
 	// the composed Route entities they emit. Appends new entities/edges

--- a/internal/engine/go_routes.go
+++ b/internal/engine/go_routes.go
@@ -1,0 +1,378 @@
+// AST-driven Go HTTP route -> handler-method binding pass.
+//
+// The YAML framework rules for chi/gin/echo/fiber/gorilla_mux emit ROUTES_TO
+// edges from `Route:<path>` to `Controller:<bareName>`, where `<bareName>` is
+// the second-argument identifier captured by a `(\w+)` group. For idiomatic Go
+// HTTP code, the handler is almost always a struct-method expression:
+//
+//	h := handlers.NewUsersHandler(s)
+//	r := chi.NewRouter()
+//	r.Get("/users", h.List)
+//	r.Get("/users/{id}", h.Get)
+//
+// Because `(\w+)` cannot span `.`, the regex captures only `h` (the receiver
+// variable), so the YAML pass emits `Controller:h` — an edge that doesn't
+// resolve to the real handler entity (`UsersHandler.List`,
+// `UsersHandler.Get`). Every Go HTTP service using one of the supported
+// routers is affected.
+//
+// This pass walks the Go AST, finds router-style calls of the form
+// `<receiver>.<HTTPVerb>("<path>", <recv>.<Method>, ...)`, resolves `<recv>`
+// to its declared type using a same-file local-variable map, and rewrites the
+// orphan `Controller:<recv>` ROUTES_TO edge to point at
+// `Controller:<TypeName>.<Method>` — the qualified-method form used by the
+// Go extractor for methods on a struct receiver.
+//
+// Type resolution is intentionally conservative:
+//
+//  1. `var h *UsersHandler` / `var h UsersHandler` (typed decl)
+//  2. `h := &UsersHandler{...}` / `h := UsersHandler{...}` (composite literal)
+//  3. `h := NewUsersHandler(...)` (Go `NewT` constructor idiom — returns `*T`)
+//
+// If a receiver cannot be confidently resolved we leave the edge untouched
+// (safer-bias). The pass only rewrites edges; it never creates new entities,
+// so it cannot regress non-Go pipelines or add false-positive Routes.
+//
+// Refs #613.
+package engine
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// goHTTPVerbs is the union of method names used by the supported Go HTTP
+// routers to register a single-path handler. Title-case (chi, fiber,
+// gorilla_mux), upper-case (gin, echo), and the "Any/All/Handle" catch-alls
+// are all included so the same pass covers every framework whose YAML rule
+// emits `Controller:<receiverVar>`.
+var goHTTPVerbs = map[string]bool{
+	// Title-case (chi, fiber, gorilla_mux)
+	"Get": true, "Post": true, "Put": true, "Patch": true, "Delete": true,
+	"Head": true, "Options": true, "Connect": true, "Trace": true,
+	// Upper-case (gin, echo)
+	"GET": true, "POST": true, "PUT": true, "PATCH": true, "DELETE": true,
+	"HEAD": true, "OPTIONS": true, "CONNECT": true, "TRACE": true,
+	// Catch-alls
+	"Any": true, "All": true, "Handle": true, "HandleFunc": true,
+}
+
+// applyGoRouteComposition rewrites YAML-emitted ROUTES_TO edges whose target
+// is a bare receiver variable (e.g. `Controller:h`) into edges that target
+// the qualified handler method (e.g. `Controller:UsersHandler.List`).
+//
+// Non-Go files are returned unchanged. The pass never adds or removes
+// entities and never adds new relationships — it only edits the `ToID` of
+// existing ROUTES_TO records, so it cannot regress the surrounding pipeline.
+func applyGoRouteComposition(
+	lang string,
+	path string,
+	content []byte,
+	rawEntities []types.EntityRecord,
+	rawRels []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if lang != "go" || len(content) == 0 {
+		return rawEntities, rawRels
+	}
+	// Cheap pre-filter: skip files that obviously don't register HTTP routes.
+	if !bytesContainsAny(content,
+		".Get(", ".Post(", ".Put(", ".Patch(", ".Delete(",
+		".GET(", ".POST(", ".PUT(", ".PATCH(", ".DELETE(",
+		".Handle(", ".HandleFunc(", ".Any(", ".All(",
+	) {
+		return rawEntities, rawRels
+	}
+
+	bindings := extractGoHandlerBindings(path, content)
+	if len(bindings) == 0 {
+		return rawEntities, rawRels
+	}
+
+	// Build a lookup keyed by `(path, receiverVar)` -> qualified method name.
+	// The YAML rule emits exactly one ROUTES_TO per `.Verb("/path", h.X)`
+	// call site, and we keyed the binding the same way to make the rewrite
+	// unambiguous.
+	type key struct {
+		routePath string
+		recvVar   string
+	}
+	rewrite := map[key]string{}
+	for _, b := range bindings {
+		rewrite[key{b.routePath, b.recvVar}] = b.qualified
+	}
+
+	for i, r := range rawRels {
+		if r.Kind != "ROUTES_TO" {
+			continue
+		}
+		if !strings.HasPrefix(r.FromID, "Route:") {
+			continue
+		}
+		if !strings.HasPrefix(r.ToID, "Controller:") {
+			continue
+		}
+		routePath := strings.TrimPrefix(r.FromID, "Route:")
+		recvVar := strings.TrimPrefix(r.ToID, "Controller:")
+		// Only rewrite if the current target is a bare receiver-variable
+		// name. If `recvVar` already contains a `.` it's a qualified method
+		// reference (or a package call) and we leave it alone.
+		if strings.Contains(recvVar, ".") {
+			continue
+		}
+		qualified, ok := rewrite[key{routePath, recvVar}]
+		if !ok {
+			continue
+		}
+		newRel := r
+		newRel.ToID = "Controller:" + qualified
+		if newRel.Properties == nil {
+			newRel.Properties = map[string]string{}
+		} else {
+			// Clone to avoid mutating the original map shared with other
+			// relationship slices.
+			cloned := make(map[string]string, len(newRel.Properties)+1)
+			for k, v := range newRel.Properties {
+				cloned[k] = v
+			}
+			newRel.Properties = cloned
+		}
+		newRel.Properties["pattern_type"] = "ast_driven"
+		newRel.Properties["go_route_binding"] = "method_receiver_resolved"
+		rawRels[i] = newRel
+	}
+
+	return rawEntities, rawRels
+}
+
+// goHandlerBinding pairs a router call site with the qualified method name
+// it targets after receiver-type resolution.
+type goHandlerBinding struct {
+	routePath string // e.g. "/users/{id}"
+	recvVar   string // e.g. "h"
+	qualified string // e.g. "UsersHandler.List"
+}
+
+// extractGoHandlerBindings parses the Go file, builds a same-file variable
+// type map, and returns one binding per recognised `.Verb("/path", recv.M)`
+// call where `recv` resolves to a known struct type. Calls that don't fit
+// the shape (string-literal first arg, selector-expr second arg, supported
+// verb) are skipped silently.
+func extractGoHandlerBindings(path string, content []byte) []goHandlerBinding {
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, content, parser.SkipObjectResolution)
+	if err != nil || file == nil {
+		return nil
+	}
+
+	varTypes := buildGoVarTypeMap(file)
+
+	var out []goHandlerBinding
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok {
+			return true
+		}
+		sel, ok := call.Fun.(*ast.SelectorExpr)
+		if !ok {
+			return true
+		}
+		if !goHTTPVerbs[sel.Sel.Name] {
+			return true
+		}
+		if len(call.Args) < 2 {
+			return true
+		}
+		// First arg must be a string literal path.
+		lit, ok := call.Args[0].(*ast.BasicLit)
+		if !ok || lit.Kind != token.STRING {
+			return true
+		}
+		routePath := strings.Trim(lit.Value, "\"`")
+		// Find the handler arg. For .Handle("/p", handler) it's args[1];
+		// for chains with middleware (e.g. fiber `.Get("/p", mw1, mw2, h)`)
+		// the handler is conventionally the last arg. We scan from the end
+		// for the first SelectorExpr whose base is an Ident — that's the
+		// receiver-method handler we care about.
+		var handlerSel *ast.SelectorExpr
+		for i := len(call.Args) - 1; i >= 1; i-- {
+			if hs, ok := call.Args[i].(*ast.SelectorExpr); ok {
+				if _, ok := hs.X.(*ast.Ident); ok {
+					handlerSel = hs
+					break
+				}
+			}
+		}
+		if handlerSel == nil {
+			return true
+		}
+		recvIdent, _ := handlerSel.X.(*ast.Ident)
+		recvVar := recvIdent.Name
+		method := handlerSel.Sel.Name
+		typeName, ok := varTypes[recvVar]
+		if !ok || typeName == "" {
+			return true
+		}
+		out = append(out, goHandlerBinding{
+			routePath: routePath,
+			recvVar:   recvVar,
+			qualified: typeName + "." + method,
+		})
+		return true
+	})
+	return out
+}
+
+// buildGoVarTypeMap walks the file's top-level + function-level declarations
+// and returns a `varName -> typeName` map, where `typeName` is the bare
+// struct type the variable holds (pointer-ness is intentionally stripped:
+// downstream entities key on the type name, not `*Type`).
+//
+// Supported declaration shapes:
+//
+//	var h *T
+//	var h T
+//	h := &T{...}
+//	h := T{...}
+//	h := NewT(...)         // Go constructor idiom → *T
+//	h := pkg.NewT(...)     // cross-package constructor → *T
+func buildGoVarTypeMap(file *ast.File) map[string]string {
+	out := map[string]string{}
+
+	record := func(name, typ string) {
+		if name == "" || typ == "" || name == "_" {
+			return
+		}
+		// First-write-wins keeps the earliest binding stable. Local
+		// shadowing inside nested blocks is rare in route-registration
+		// code and we'd rather under-rewrite than mis-rewrite.
+		if _, exists := out[name]; !exists {
+			out[name] = typ
+		}
+	}
+
+	visit := func(decl ast.Node) {
+		ast.Inspect(decl, func(n ast.Node) bool {
+			switch x := n.(type) {
+			case *ast.AssignStmt:
+				if x.Tok != token.DEFINE && x.Tok != token.ASSIGN {
+					return true
+				}
+				// Pair each LHS Ident with the corresponding RHS.
+				for i, lhs := range x.Lhs {
+					id, ok := lhs.(*ast.Ident)
+					if !ok {
+						continue
+					}
+					if i >= len(x.Rhs) {
+						break
+					}
+					if typ := inferGoExprType(x.Rhs[i]); typ != "" {
+						record(id.Name, typ)
+					}
+				}
+			case *ast.DeclStmt:
+				gen, ok := x.Decl.(*ast.GenDecl)
+				if !ok || gen.Tok != token.VAR {
+					return true
+				}
+				for _, spec := range gen.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					typ := typeNameFromExpr(vs.Type)
+					for i, name := range vs.Names {
+						if typ != "" {
+							record(name.Name, typ)
+							continue
+						}
+						if i < len(vs.Values) {
+							if inferred := inferGoExprType(vs.Values[i]); inferred != "" {
+								record(name.Name, inferred)
+							}
+						}
+					}
+				}
+			case *ast.GenDecl:
+				if x.Tok != token.VAR {
+					return true
+				}
+				for _, spec := range x.Specs {
+					vs, ok := spec.(*ast.ValueSpec)
+					if !ok {
+						continue
+					}
+					typ := typeNameFromExpr(vs.Type)
+					for i, name := range vs.Names {
+						if typ != "" {
+							record(name.Name, typ)
+							continue
+						}
+						if i < len(vs.Values) {
+							if inferred := inferGoExprType(vs.Values[i]); inferred != "" {
+								record(name.Name, inferred)
+							}
+						}
+					}
+				}
+			}
+			return true
+		})
+	}
+
+	for _, decl := range file.Decls {
+		visit(decl)
+	}
+	return out
+}
+
+// inferGoExprType returns the bare struct type name an expression evaluates
+// to, for the limited set of shapes used by route-registration code.
+// Returns "" when no confident inference can be made.
+func inferGoExprType(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case *ast.UnaryExpr:
+		// &T{...} -> T
+		if v.Op == token.AND {
+			return inferGoExprType(v.X)
+		}
+	case *ast.CompositeLit:
+		// T{...} or pkg.T{...} -> T
+		return typeNameFromExpr(v.Type)
+	case *ast.CallExpr:
+		// NewT(...) or pkg.NewT(...) -> T (Go constructor idiom).
+		switch fn := v.Fun.(type) {
+		case *ast.Ident:
+			if strings.HasPrefix(fn.Name, "New") && len(fn.Name) > 3 {
+				return fn.Name[3:]
+			}
+		case *ast.SelectorExpr:
+			if strings.HasPrefix(fn.Sel.Name, "New") && len(fn.Sel.Name) > 3 {
+				return fn.Sel.Name[3:]
+			}
+		}
+	}
+	return ""
+}
+
+// typeNameFromExpr returns the bare type name from a type expression, peeling
+// off pointer- and package-qualifier wrappers. Returns "" for unsupported
+// shapes (slices, maps, interfaces, etc.).
+func typeNameFromExpr(expr ast.Expr) string {
+	switch v := expr.(type) {
+	case nil:
+		return ""
+	case *ast.Ident:
+		return v.Name
+	case *ast.StarExpr:
+		return typeNameFromExpr(v.X)
+	case *ast.SelectorExpr:
+		// pkg.T -> T (entity names in the index are unqualified).
+		return v.Sel.Name
+	}
+	return ""
+}

--- a/internal/engine/go_routes_test.go
+++ b/internal/engine/go_routes_test.go
@@ -1,0 +1,235 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// makeRoutesToRel builds a ROUTES_TO edge in the shape the YAML rule emits.
+func makeRoutesToRel(path, recv string) types.RelationshipRecord {
+	return types.RelationshipRecord{
+		FromID: "Route:" + path,
+		ToID:   "Controller:" + recv,
+		Kind:   "ROUTES_TO",
+		Properties: map[string]string{
+			"framework":    "go",
+			"pattern_type": "yaml_driven",
+		},
+	}
+}
+
+func TestApplyGoRouteComposition_ChiCompositeLiteral(t *testing.T) {
+	src := []byte(`package main
+
+import "github.com/go-chi/chi/v5"
+
+func main() {
+	h := &UsersHandler{}
+	r := chi.NewRouter()
+	r.Get("/users", h.List)
+	r.Get("/users/{id}", h.Get)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+		makeRoutesToRel("/users/{id}", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+
+	if got[0].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ToID[0] = %q, want Controller:UsersHandler.List", got[0].ToID)
+	}
+	if got[1].ToID != "Controller:UsersHandler.Get" {
+		t.Errorf("ToID[1] = %q, want Controller:UsersHandler.Get", got[1].ToID)
+	}
+	if got[0].Properties["pattern_type"] != "ast_driven" {
+		t.Errorf("pattern_type[0] = %q, want ast_driven", got[0].Properties["pattern_type"])
+	}
+}
+
+func TestApplyGoRouteComposition_ConstructorIdiom(t *testing.T) {
+	// `h := handlers.NewUsersHandler(s)` — cross-package NewT() returns *T.
+	src := []byte(`package main
+
+import (
+	"github.com/go-chi/chi/v5"
+	"example.com/demo/handlers"
+)
+
+func main() {
+	h := handlers.NewUsersHandler(nil)
+	r := chi.NewRouter()
+	r.Get("/users", h.List)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ToID = %q, want Controller:UsersHandler.List", got[0].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_GinUppercaseVerb(t *testing.T) {
+	src := []byte(`package main
+
+func main() {
+	h := &UserAPI{}
+	r := newRouter()
+	r.GET("/users", h.List)
+	r.POST("/teams", h.CreateTeam)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+		makeRoutesToRel("/teams", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:UserAPI.List" {
+		t.Errorf("ToID[0] = %q, want Controller:UserAPI.List", got[0].ToID)
+	}
+	if got[1].ToID != "Controller:UserAPI.CreateTeam" {
+		t.Errorf("ToID[1] = %q, want Controller:UserAPI.CreateTeam", got[1].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_PointerVarDecl(t *testing.T) {
+	src := []byte(`package main
+
+func main() {
+	var h *UsersHandler
+	r := newRouter()
+	r.Get("/users", h.List)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ToID = %q, want Controller:UsersHandler.List", got[0].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_UnresolvedReceiverLeftAlone(t *testing.T) {
+	// `h` is never declared in-file → can't resolve type → leave edge alone.
+	src := []byte(`package main
+
+func register() {
+	r := newRouter()
+	r.Get("/users", h.List)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:h" {
+		t.Errorf("ToID = %q, want unchanged Controller:h", got[0].ToID)
+	}
+	if got[0].Properties["pattern_type"] != "yaml_driven" {
+		t.Errorf("pattern_type should stay yaml_driven, got %q",
+			got[0].Properties["pattern_type"])
+	}
+}
+
+func TestApplyGoRouteComposition_BareFuncHandlerUnchanged(t *testing.T) {
+	// `r.Get("/users", listUsers)` — bare function, not a method call.
+	// The YAML rule already emits Controller:listUsers, which DOES resolve.
+	// Pass must leave it alone.
+	src := []byte(`package main
+
+func listUsers() {}
+
+func main() {
+	r := newRouter()
+	r.Get("/users", listUsers)
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "listUsers"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:listUsers" {
+		t.Errorf("ToID = %q, want unchanged Controller:listUsers", got[0].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_NonGoNoop(t *testing.T) {
+	src := []byte(`r.Get("/users", h.List)`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("python", "main.py", src, nil, rels)
+	if got[0].ToID != "Controller:h" {
+		t.Errorf("python file mutated: %q", got[0].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_NonRoutesToRelationshipsUnchanged(t *testing.T) {
+	src := []byte(`package main
+
+func main() {
+	h := &UsersHandler{}
+	r := newRouter()
+	r.Get("/users", h.List)
+}
+`)
+	rels := []types.RelationshipRecord{
+		{
+			FromID: "Route:/users",
+			ToID:   "Controller:h",
+			Kind:   "CALLS", // not ROUTES_TO
+		},
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:h" {
+		t.Errorf("non-ROUTES_TO edge mutated: %q", got[0].ToID)
+	}
+	if got[1].ToID != "Controller:UsersHandler.List" {
+		t.Errorf("ROUTES_TO edge not rewritten: %q", got[1].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_AlreadyQualifiedToIDUnchanged(t *testing.T) {
+	src := []byte(`package main
+
+func main() {
+	h := &UsersHandler{}
+	r := newRouter()
+	r.Get("/users", h.List)
+}
+`)
+	rels := []types.RelationshipRecord{
+		{
+			FromID:     "Route:/users",
+			ToID:       "Controller:Existing.Qualified",
+			Kind:       "ROUTES_TO",
+			Properties: map[string]string{"pattern_type": "yaml_driven"},
+		},
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:Existing.Qualified" {
+		t.Errorf("already-qualified ToID mutated: %q", got[0].ToID)
+	}
+}
+
+func TestApplyGoRouteComposition_PreFilterSkipsIrrelevantFiles(t *testing.T) {
+	// File has no router-call substrings → pre-filter exits early.
+	src := []byte(`package main
+
+func main() {
+	println("no routes here")
+}
+`)
+	rels := []types.RelationshipRecord{
+		makeRoutesToRel("/users", "h"),
+	}
+	_, got := applyGoRouteComposition("go", "main.go", src, nil, rels)
+	if got[0].ToID != "Controller:h" {
+		t.Errorf("ToID = %q, want unchanged Controller:h", got[0].ToID)
+	}
+}

--- a/internal/quality/golden/go-chi-mini/expected.json
+++ b/internal/quality/golden/go-chi-mini/expected.json
@@ -81,8 +81,9 @@
       "must_exist": true },
 
     { "from_name": "/users", "from_kind": "Route", "from_file": "main.go",
-      "kind": "ROUTES_TO", "to_bare_name": "Controller:h", "must_exist": true,
-      "note": "Chi route -> handler binding; today the to_bare_name is the receiver variable, not the method (capability gap)." },
+      "kind": "ROUTES_TO", "to_name": "UsersHandler.List", "to_kind": "SCOPE.Operation", "to_file": "handlers/users.go",
+      "must_exist": true,
+      "note": "Chi route -> handler method binding. Fixed by #613: the Go AST receiver-resolution post-pass rewrites Controller:<recv> to Controller:<Type>.<Method>." },
 
     { "from_name": "UsersHandler.Get", "from_kind": "SCOPE.Operation", "from_file": "handlers/users.go",
       "kind": "CALLS", "to_name": "writeJSON", "to_kind": "SCOPE.Operation", "to_file": "handlers/users.go",
@@ -94,9 +95,9 @@
       "must_exist": false, "nice_to_have": true,
       "note": "Cross-package method call through interface field (h.Store.List). Today bare-name h.Store.List is not resolved to the implementing struct." },
 
-    { "from_name": "/users", "from_kind": "Route", "from_file": "main.go",
-      "kind": "ROUTES_TO", "to_name": "UsersHandler.List", "to_kind": "SCOPE.Operation", "to_file": "handlers/users.go",
-      "must_exist": false, "nice_to_have": true,
-      "note": "Route should bind to the handler method, not the receiver variable. Filed as a chi-extractor gap." }
+    { "from_name": "/users/{id}", "from_kind": "Route", "from_file": "main.go",
+      "kind": "ROUTES_TO", "to_name": "UsersHandler.Get", "to_kind": "SCOPE.Operation", "to_file": "handlers/users.go",
+      "must_exist": true,
+      "note": "Second chi route emitted from the same `h := handlers.NewUsersHandler(s)` receiver. Asserts the post-pass handles multiple bindings off one receiver var. Refs #613." }
   ]
 }


### PR DESCRIPTION
## Summary

YAML rules for chi/gin/echo/fiber/gorilla_mux capture the second argument
of `r.Verb("/path", handler)` with `(\w+)`, which cannot span `.`. For the
idiomatic Go form `r.Get("/users", h.List)` the regex captures only `h`
(the receiver variable), so the ROUTES_TO edge lands on `Controller:h`
instead of `Controller:UsersHandler.List`. Every Go HTTP service using one
of the supported routers is affected.

## Option chosen: A (AST-driven receiver resolution)

New post-pass `applyGoRouteComposition` in `internal/engine/go_routes.go`:

- Parses Go source with stdlib `go/parser` (no tree-sitter needed for Go).
- Builds a same-file `varName -> typeName` map covering the three
  declaration shapes that dominate route-registration code:
  1. `var h *UsersHandler` / `var h UsersHandler`
  2. `h := &UsersHandler{...}` / `h := UsersHandler{...}`
  3. `h := NewUsersHandler(...)` / `h := pkg.NewUsersHandler(...)` —
     the Go `NewT` constructor idiom returns `*T` by convention.
- Walks every `<recv>.<HTTPVerb>("<path>", <recv>.<Method>)` call and
  rewrites the matching `Controller:<recv>` ROUTES_TO ToID to
  `Controller:<TypeName>.<Method>`.
- Cheap substring pre-filter exits early for files with no router calls.
- Edits ToID only — never adds/removes entities or relationships, so the
  pass cannot regress non-Go pipelines or introduce false-positive Routes.
- Safer-bias: when a receiver cannot be confidently resolved the edge is
  left untouched (no fake edges).
- New properties: `pattern_type=ast_driven`,
  `go_route_binding=method_receiver_resolved` for downstream telemetry.

## Quality bench delta (go-chi-mini)

| Metric | Pre | Post | Δ |
|---|---:|---:|---:|
| relationships recall | 15/16 (93.8%) | 17/17 (100.0%) | +6.2pp |
| `must_exist` ROUTES_TO target | `Controller:h` (broken) | `UsersHandler.List` + `UsersHandler.Get` | resolved |
| forbidden hits | 0 | 0 | 0 |

`expected.json` updated: the previous `must_exist` edge asserting
`Controller:h` (which documented the broken behavior as a known capability
gap) is replaced with two `must_exist` edges hitting `UsersHandler.List`
and `UsersHandler.Get` — the second exercises multiple bindings off one
receiver var declared via `h := handlers.NewUsersHandler(s)`.

## Regression check (cross-corpus, mandatory)

| Fixture | Pre | Post | Δ |
|---|---:|---:|---:|
| go-chi-mini | 93.8% | 100.0% | +6.2pp |
| java-spring-mini | 100.0% | 100.0% | 0.000pp |
| python-django-mini | 100.0% | 100.0% | 0.000pp |
| rust-tokio-mini | 100.0% | 100.0% | 0.000pp |
| typescript-react-mini | 100.0% | 100.0% | 0.000pp |

Zero deltas outside Go (language-gated pass). All five golden fixtures at
100% relationship recall post-fix.

## Test plan

- [x] `go test ./internal/engine/ -run TestApplyGoRouteComposition` — 10/10 pass
- [x] `go test ./...` — full suite pass, no regressions
- [x] `go vet ./...` clean
- [x] Quality bench on all 5 golden fixtures — 100% recall, zero forbidden hits
- [x] `build/archigraph quality internal/quality/golden/go-chi-mini` confirms
      both /users → UsersHandler.List and /users/{id} → UsersHandler.Get
      now resolve to method entities

## Residual root cause

Receiver-type tracking is intentionally bounded to the three Go-idiomatic
shapes above. Uncommon patterns — struct fields holding handlers, embedded-
struct method promotion, generic-typed receivers, factories that don't
follow the `NewT` naming convention — still fall through to
"unresolved → leave edge alone" (safer-bias). A future #494 receiver-type
primitive would cover those cases.

## Status

Shipped. Implementation is self-contained; the remaining unresolved
shapes are tracked under the existing #494 receiver-type primitive
umbrella. No new chain-fixes filed.

Refs #613.

🤖 Generated with [Claude Code](https://claude.com/claude-code)