### PR TITLE
[react-native] platform symbols + reanimated 3.x + file-scoped gates — drive fixture-c to ship-gate

### DIFF
--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -1290,6 +1290,7 @@ type primitive) — chain-fix already filed in click PR #601.
    signal (could be: presence of a `with open(...)` block in the
    function, or a `bytes`/`str` literal-typed receiver inference).
 
+---
 
 ## #613 — Go chi/gin/echo/fiber/gorilla_mux ROUTES_TO method binding (2026-05-19)
 
@@ -1354,3 +1355,115 @@ would cover those cases.
 **Chain-fixes filed:** none — implementation is self-contained and the
 remaining unresolved cases are tracked under the existing #494 receiver-
 type primitive umbrella.
+
+---
+
+## Wave: rn-platform-symbols (PR follow-up to #621, 2026-05-19)
+
+Driver: client-fixture-c (RN+Expo) post-#621 sat at 1.43% — above the
+1% ship-gate. PR #621 chain-fixes 1 + 2 (RN platform symbols, Reanimated
+receiver-strip) are this wave. Diagnosis raised `maxDispositionSamples`
+locally to 5000 (reverted before commit) to aggregate true bug-extractor
+frequencies. Top residual stubs (count):
+
+- `useStyleContext` (43) — `@gluestack-ui/utils/nativewind-utils`
+- `indicator` (12), `delete` (12), `show` (10) — domain-generic
+- `Value` (4), `timing` (3), `sequence` (2), `parallel` (1),
+  `createAnimatedComponent` (2) — `react-native` `Animated.*`
+- `startPlayer` / `stopPlayer` / `pausePlayer` / `seekToPlayer` /
+  `startRecorder` / `stopRecorder` / `addPlayBackListener` /
+  `removePlayBackListener` / `addRecordBackListener` /
+  `removeRecordBackListener` / `addPlaybackEndListener` /
+  `removePlaybackEndListener` — `react-native-nitro-sound`
+- `getNetworkStateAsync` (3), `requestCameraPermissionsAsync`,
+  `pickDirectoryAsync`, `getDocumentAsync`, `startActivityAsync`,
+  `shareAsync`, `downloadFileAsync`, `supportedAuthenticationTypesAsync`,
+  `isAvailableAsync` — expo-* platform modules
+- `openCamera`, `openCropper`, `openPicker` —
+  `react-native-image-crop-picker`
+- `goBack`, `addListener`, `toggleDrawer`, `back`, `isFocused`,
+  `requestCancel` — `@react-navigation/*` / `expo-router`
+- `snapToIndex` — `@gorhom/bottom-sheet`
+- `requireExternalGestureToFail`, `numberOfTaps`, `manualActivation` —
+  `react-native-gesture-handler`
+- `useBreakpointValue`, `useDrawerStatus` — gluestack-ui
+
+Eight new file-scoped gates, all in `synth.go` and TS/JS-language-gated
+above the call site. Each gate matches on the canonical npm spec
+(`spec == "react-native-reanimated"` etc., with prefix match for
+sub-paths). The Reanimated gate also fires on `react-native` itself
+because `Animated.<name>(...)` is the dominant caller of `timing` /
+`Value` / `sequence` / `createAnimatedComponent` and the names ride
+on the core `react-native` `Animated` namespace, not the standalone
+`react-native-reanimated` package.
+
+Per-iteration delta on client-fixture-c (target):
+
+| pass | change | bug-rate | delta |
+|---|---|---|---|
+| baseline (#621 merged) | — | 1.433% | — |
+| 1 | reanimated/gluestack/expo-camera/expo-file/expo-network/audio-recorder/gesture-handler/react-navigation gates (initial) | 1.043% | -0.39pp |
+| 2 | reanimated gate widened to include `react-native` core; audio-recorder gate widened to include `react-native-nitro-sound` | 0.882% | -0.16pp |
+| 3 | `@gorhom/bottom-sheet` gate + `useBreakpointValue` / `useDrawerStatus` / `useToken` added to gluestack | 0.873% | -0.01pp |
+
+Cumulative **-0.560pp** on client-fixture-c — **ship-gate (≤1%)
+reached at 0.873%**. bug-extractor 317 → 185 (-132). Resolved count
+unchanged (13,156) — every win is reclassification from bug-extractor
+to external-known/unknown, not new extraction.
+
+Regression sweep (14 repos, ≥0.5pp = STOP):
+
+| repo | main | branch | delta_pp |
+|---|---|---|---|
+| chi (go) | 0.02025 | 0.02025 | 0.0000 |
+| flask (python) | 0.05249 | 0.05192 | -0.057 |
+| spdlog (cpp) | 0.02856 | 0.02856 | 0.0000 |
+| gin (go) | 0.03383 | 0.03383 | 0.0000 |
+| play-scala-starter (scala) | 0.00704 | 0.00704 | 0.0000 |
+| express (js) | 0.02856 | 0.02856 | 0.0000 |
+| nextjs-commerce (ts) | 0.02241 | 0.02241 | 0.0000 |
+| nestjs-starter (ts) | 0.01754 | 0.01754 | 0.0000 |
+| kafka-streams-examples (java) | 0.03329 | 0.03329 | 0.0000 |
+| vapor-api-template (swift) | 0.02128 | 0.02128 | 0.0000 |
+| ktor-samples (kotlin) | 0.04735 | 0.04735 | 0.0000 |
+| client-fixture-a (python) | 0.03410 | 0.03427 | +0.017 |
+| client-fixture-b (ts) | 0.00572 | 0.00572 | 0.0000 |
+| **client-fixture-c (ts/tsx)** | **0.01433** | **0.00873** | **-0.560** |
+
+Zero ≥0.5pp regressions. The +0.017pp on client-fixture-a (python) is
+unrelated to this PR (no python code touched); within run-to-run
+noise. The -0.057pp on flask is similarly orthogonal — likely an
+artifact of the post-#621 merge ordering on shared infra. All TS/JS
+allowlists are inside `if lang == "javascript" || lang == "typescript"`,
+no cross-language leakage possible.
+
+Residual root cause (client-fixture-c, post-fix at 0.87%):
+- Bug-extractor top: `indicator` (12), `delete` (12), `show` (10),
+  `has` (6), `create` (5), `close` (4), `copy` (4), `back` (3) — all
+  domain-generic verbs / nouns too collision-prone for a global
+  allowlist. Resolving requires receiver-type inference (cross #494
+  equivalent for JS/TS).
+- Bug-resolver top (21 total): `detail` (7), `deficiencies` (5),
+  `showInlineAlert` (3) — user-defined cross-module bare names that
+  failed to bind because the extractor receiver-stripped them.
+  Resolver-side fix is out of scope for the external-synth allowlist.
+
+Status: **ship-gate (≤1%) cleared at 0.87%**. Track A (RN platform
+symbols, PR #621 chain-fix #1) complete. Track B (Reanimated
+receiver-strip via file-scoped gate, PR #621 chain-fix #2) complete.
+Chain-fixes #3 (react_props followups) and #4 (default-export name
+tracking) remain queued.
+
+Chain-fixes filed (out of scope for this PR):
+1. **js-receiver-type-inference** — domain-generic bare names
+   (`indicator`, `delete`, `show`, `has`, `create`, `close`, `copy`)
+   are receiver-stripped at extraction time and lose the class context.
+   Same blocker as Python #494; a TS-side receiver-type primitive
+   would lift these without a global allowlist.
+2. **js-resolver-shortform-followups** — bug-resolver residue
+   (`detail`, `deficiencies`, `showInlineAlert`) suggests other
+   cross-file extraction shapes that fail to bind via `byLocation`
+   short-form. Audit needed.
+3. **default-export-name-tracking** — carry-forward from PR #621.
+   Long-term: JS extractor records default-export status per entity
+   for deterministic `<module>.default` binding.

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -2065,6 +2065,61 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 				return "function", true
 			}
 		}
+		// Wave-RN-platform-symbols (PR follow-up to #621). File-scoped
+		// gates for React Native ecosystem packages. The names are too
+		// generic for the global jsBareNames stop-list (`timing`,
+		// `Value`, `sequence`, `parallel`, `useStyleContext`,
+		// `goBack`, `addListener`, `*Async` verbs) — they would shadow
+		// user methods on hand-rolled classes — but inside files that
+		// import the canonical RN platform package these are
+		// overwhelmingly the library form. Same precedent as the
+		// wave-9 `hasJSCollectionLibImport` gate and the python
+		// wave-10 per-import gates.
+		if hasReanimatedImport(fromImports) {
+			if _, ok := jsReanimatedBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasGluestackImport(fromImports) {
+			if _, ok := jsGluestackBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasExpoCameraImport(fromImports) {
+			if _, ok := jsExpoCameraBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasExpoFileImport(fromImports) {
+			if _, ok := jsExpoFileBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasExpoNetworkImport(fromImports) {
+			if _, ok := jsExpoPlatformBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasRNAudioRecorderImport(fromImports) {
+			if _, ok := jsRNAudioRecorderBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasRNGestureHandlerImport(fromImports) {
+			if _, ok := jsRNGestureHandlerBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasReactNavigationImport(fromImports) {
+			if _, ok := jsReactNavigationBareNames[name]; ok {
+				return "function", true
+			}
+		}
+		if hasGorhomBottomSheetImport(fromImports) {
+			if _, ok := jsGorhomBottomSheetBareNames[name]; ok {
+				return "function", true
+			}
+		}
 	}
 	if lang == "swift" {
 		if _, ok := swiftBareNames[name]; ok {
@@ -2908,6 +2963,393 @@ func hasJSCollectionLibImport(imports map[string]bool) bool {
 		}
 	}
 	return false
+}
+
+// hasReanimatedImport reports whether the source JS/TS file imports
+// `react-native-reanimated`. Gates the Reanimated 3.x bare-name
+// allowlist (`withTiming` etc. already in jsBareNames; the gate
+// brings in the generic `timing` / `Value` / `sequence` / `parallel`
+// / `Easing` / `interpolate` / `Extrapolate` shapes that ride on
+// `Animated.<name>` receiver-strip and would shadow user methods if
+// classified globally).
+func hasReanimatedImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		// `react-native-reanimated` is the canonical source for the
+		// Reanimated API. `react-native` itself re-exports `Animated`
+		// (with `.timing`/`.sequence`/`.parallel`/`.Value`/
+		// `.createAnimatedComponent` as members) — files calling
+		// `Animated.<name>(...)` in a `react-native` import context
+		// produce the same bare leaves. Treat both as activating the
+		// Animated allowlist.
+		if spec == "react-native-reanimated" ||
+			strings.HasPrefix(spec, "react-native-reanimated/") ||
+			spec == "react-native" ||
+			strings.HasPrefix(spec, "react-native/") {
+			return true
+		}
+	}
+	return false
+}
+
+// jsReanimatedBareNames is the file-scoped Reanimated 3.x surface
+// gated by hasReanimatedImport. These names ride on
+// `Animated.<name>(...)` receiver-strip and on the
+// `react-native-reanimated` factory + helper exports. Curated from
+// client-fixture-c bug-extractor residual: `timing`, `Value`,
+// `sequence`, `parallel`, `createAnimatedComponent` appear on the
+// Reanimated `Animated` namespace and standalone re-exports.
+//
+// `withTiming`/`withSpring`/`withDecay`/`withDelay`/`withRepeat`/
+// `withSequence`/`interpolate`/`interpolateColor` and the Reanimated
+// hooks (`useSharedValue` etc.) are already in jsBareNames
+// (unconditional) — not duplicated here.
+var jsReanimatedBareNames = map[string]struct{}{
+	"timing":                  {}, // Animated.timing
+	"spring":                  {}, // Animated.spring
+	"decay":                   {}, // Animated.decay
+	"sequence":                {}, // Animated.sequence (also array-shape)
+	"parallel":                {}, // Animated.parallel
+	"stagger":                 {}, // Animated.stagger
+	"delay":                   {}, // Animated.delay
+	"loop":                    {}, // Animated.loop
+	"event":                   {}, // Animated.event
+	"diffClamp":               {}, // Animated.diffClamp
+	"Value":                   {}, // Animated.Value
+	"ValueXY":                 {}, // Animated.ValueXY
+	"createAnimatedComponent": {}, // Animated.createAnimatedComponent
+	"cancelAnimation":         {}, // reanimated
+	"useFrameCallback":        {},
+	"useAnimatedSensor":       {},
+	"measure":                 {}, // reanimated measure() worklet
+	"scrollTo":                {}, // reanimated scrollTo worklet
+	"defineAnimation":         {},
+}
+
+// hasGluestackImport reports whether the source JS/TS file imports
+// any `@gluestack-ui/*` or `@gluestack-style/*` package. Gates the
+// gluestack-ui bare-name allowlist (`useStyleContext`,
+// `withStyleContext`, `tva`, ...). The package surface is distinctive
+// enough that the gate is mostly belt-and-braces against rare user
+// methods of the same name elsewhere in the codebase.
+func hasGluestackImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if strings.HasPrefix(spec, "@gluestack-ui/") ||
+			strings.HasPrefix(spec, "@gluestack-style/") {
+			return true
+		}
+	}
+	return false
+}
+
+// jsGluestackBareNames is the gluestack-ui surface gated by
+// hasGluestackImport. Top-residual on client-fixture-c (`useStyleContext`
+// = 43 hits — single largest leaf) plus the related style-context
+// helpers.
+var jsGluestackBareNames = map[string]struct{}{
+	"useStyleContext":           {},
+	"withStyleContext":          {},
+	"withStyleContextAndStates": {},
+	"useStyleContextAndStates":  {},
+	"tva":                       {}, // gluestack tva() variant authoring
+	"createStyle":               {},
+	"styled":                    {},
+	"createConfig":              {},
+	"createComponents":          {},
+	"createGenericComponent":    {},
+	"useBreakpointValue":        {}, // gluestack responsive helper
+	"useDrawerStatus":           {}, // gluestack drawer
+	"useToken":                  {}, // gluestack token reader
+}
+
+// hasGorhomBottomSheetImport reports whether the file imports
+// `@gorhom/bottom-sheet`. Activates the bottom-sheet handle method
+// surface (`snapToIndex`, `expand`, `collapse`, `close`, ...).
+func hasGorhomBottomSheetImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if spec == "@gorhom/bottom-sheet" ||
+			strings.HasPrefix(spec, "@gorhom/bottom-sheet/") {
+			return true
+		}
+	}
+	return false
+}
+
+var jsGorhomBottomSheetBareNames = map[string]struct{}{
+	"snapToIndex":    {},
+	"snapToPosition": {},
+	"expand":         {},
+	"collapse":       {},
+	"forceClose":     {},
+	"present":        {},
+	"dismiss":        {},
+	"dismissAll":     {},
+}
+
+// hasExpoCameraImport reports whether the file imports expo-camera /
+// expo-image-picker. Activates the camera/permission surface.
+func hasExpoCameraImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if spec == "expo-camera" || strings.HasPrefix(spec, "expo-camera/") ||
+			spec == "expo-image-picker" || strings.HasPrefix(spec, "expo-image-picker/") ||
+			spec == "react-native-image-crop-picker" {
+			return true
+		}
+	}
+	return false
+}
+
+var jsExpoCameraBareNames = map[string]struct{}{
+	"requestCameraPermissionsAsync":   {},
+	"getCameraPermissionsAsync":       {},
+	"requestMicrophonePermissionsAsync": {},
+	"requestMediaLibraryPermissionsAsync": {},
+	"launchCameraAsync":              {},
+	"launchImageLibraryAsync":        {},
+	"openCamera":                     {}, // react-native-image-crop-picker
+	"openPicker":                     {},
+	"openCropper":                    {},
+	"clean":                          {}, // ImagePicker.clean()
+}
+
+// hasExpoFileImport reports whether the file imports expo-file-system /
+// expo-document-picker / expo-media-library / expo-sharing.
+func hasExpoFileImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if spec == "expo-file-system" || strings.HasPrefix(spec, "expo-file-system/") ||
+			spec == "expo-document-picker" || strings.HasPrefix(spec, "expo-document-picker/") ||
+			spec == "expo-media-library" || strings.HasPrefix(spec, "expo-media-library/") ||
+			spec == "expo-sharing" {
+			return true
+		}
+	}
+	return false
+}
+
+var jsExpoFileBareNames = map[string]struct{}{
+	"downloadFileAsync":         {}, // expo-file-system
+	"uploadAsync":               {},
+	"readAsStringAsync":         {},
+	"writeAsStringAsync":        {},
+	"deleteAsync":               {},
+	"moveAsync":                 {},
+	"copyAsync":                 {},
+	"makeDirectoryAsync":        {},
+	"readDirectoryAsync":        {},
+	"getInfoAsync":              {},
+	"getContentUriAsync":        {},
+	"getFreeDiskStorageAsync":   {},
+	"getTotalDiskCapacityAsync": {},
+	"pickDirectoryAsync":        {}, // expo-document-picker
+	"getDocumentAsync":          {},
+	"shareAsync":                {}, // expo-sharing
+	"isAvailableAsync":          {}, // expo-sharing / expo-haptics / ...
+	"createAssetAsync":          {}, // expo-media-library
+	"createAlbumAsync":          {},
+	"addAssetsToAlbumAsync":     {},
+	"saveToLibraryAsync":        {},
+}
+
+// hasExpoNetworkImport reports whether the file imports expo-network /
+// expo-intent-launcher / expo-linking / expo-local-authentication /
+// expo-notifications — the smaller expo platform modules whose
+// distinctive `*Async` surface needs gating.
+func hasExpoNetworkImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		switch spec {
+		case "expo-network", "expo-intent-launcher", "expo-linking",
+			"expo-local-authentication", "expo-notifications",
+			"expo-application", "expo-device", "expo-haptics",
+			"expo-clipboard", "expo-screen-orientation", "expo-status-bar":
+			return true
+		}
+	}
+	return false
+}
+
+var jsExpoPlatformBareNames = map[string]struct{}{
+	"getNetworkStateAsync":              {}, // expo-network
+	"getIpAddressAsync":                 {},
+	"getMacAddressAsync":                {},
+	"startActivityAsync":                {}, // expo-intent-launcher
+	"supportedAuthenticationTypesAsync": {}, // expo-local-authentication
+	"authenticateAsync":                 {},
+	"hasHardwareAsync":                  {},
+	"isEnrolledAsync":                   {},
+	"scheduleNotificationAsync":         {}, // expo-notifications
+	"cancelScheduledNotificationAsync":  {},
+	"cancelAllScheduledNotificationsAsync": {},
+	"setNotificationHandler":            {},
+	"getExpoPushTokenAsync":             {},
+	"getDevicePushTokenAsync":           {},
+	"setStringAsync":                    {}, // expo-clipboard
+	"getStringAsync":                    {},
+	"hasStringAsync":                    {},
+	"lockAsync":                         {}, // expo-screen-orientation
+	"unlockAsync":                       {},
+	"impactAsync":                       {}, // expo-haptics
+	"notificationAsync":                 {},
+	"selectionAsync":                    {},
+}
+
+// hasRNAudioRecorderImport reports whether the file imports
+// `react-native-audio-recorder-player`. Activates the recorder/player
+// bare-name allowlist — every method on the singleton instance leaks
+// as a receiver-stripped bare name.
+func hasRNAudioRecorderImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if spec == "react-native-audio-recorder-player" ||
+			strings.HasPrefix(spec, "react-native-audio-recorder-player/") ||
+			spec == "react-native-nitro-sound" ||
+			strings.HasPrefix(spec, "react-native-nitro-sound/") {
+			return true
+		}
+	}
+	return false
+}
+
+var jsRNAudioRecorderBareNames = map[string]struct{}{
+	"startPlayer":               {},
+	"stopPlayer":                {},
+	"pausePlayer":               {},
+	"resumePlayer":              {},
+	"seekToPlayer":              {},
+	"setVolume":                 {},
+	"setSubscriptionDuration":   {},
+	"addPlayBackListener":       {},
+	"removePlayBackListener":    {},
+	"addPlaybackEndListener":    {},
+	"removePlaybackEndListener": {},
+	"startRecorder":             {},
+	"stopRecorder":              {},
+	"pauseRecorder":             {},
+	"resumeRecorder":            {},
+	"addRecordBackListener":     {},
+	"removeRecordBackListener":  {},
+	"mmssss":                    {},
+	"mmss":                      {},
+}
+
+// hasRNGestureHandlerImport reports whether the file imports
+// `react-native-gesture-handler`. Activates the gesture-builder
+// chain-method surface.
+func hasRNGestureHandlerImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if spec == "react-native-gesture-handler" ||
+			strings.HasPrefix(spec, "react-native-gesture-handler/") {
+			return true
+		}
+	}
+	return false
+}
+
+var jsRNGestureHandlerBareNames = map[string]struct{}{
+	"requireExternalGestureToFail": {},
+	"requireExternalGestureToBegin": {},
+	"simultaneousWithExternalGesture": {},
+	"numberOfTaps":                 {},
+	"maxDuration":                  {},
+	"minDuration":                  {},
+	"manualActivation":             {},
+	"shouldCancelWhenOutside":      {},
+	"hitSlop":                      {},
+	"activeOffsetX":                {},
+	"activeOffsetY":                {},
+	"failOffsetX":                  {},
+	"failOffsetY":                  {},
+}
+
+// hasReactNavigationImport reports whether the file imports any
+// `@react-navigation/*` package, or `expo-router` (which wraps it).
+// Activates a focused navigation-handle surface
+// (`goBack`/`jumpTo`/`reset`/...). `setOptions` and several other
+// names are already in jsBareNames (unconditional) — not duplicated.
+func hasReactNavigationImport(imports map[string]bool) bool {
+	if len(imports) == 0 {
+		return false
+	}
+	for p := range imports {
+		spec := p
+		if strings.HasPrefix(spec, "ext:") {
+			spec = spec[len("ext:"):]
+		}
+		if strings.HasPrefix(spec, "@react-navigation/") ||
+			spec == "expo-router" || strings.HasPrefix(spec, "expo-router/") {
+			return true
+		}
+	}
+	return false
+}
+
+var jsReactNavigationBareNames = map[string]struct{}{
+	"goBack":        {}, // navigation.goBack
+	"jumpTo":        {}, // navigation.jumpTo
+	"toggleDrawer":  {}, // drawer navigation
+	"openDrawer":    {},
+	"closeDrawer":   {},
+	"setParams":     {},
+	"isFocused":     {},
+	"canGoBack":     {},
+	"addListener":   {}, // navigation.addListener (also EventEmitter)
+	"removeListener": {},
+	"dispatch":      {}, // navigation.dispatch (Redux dispatch already
+	// handled by useDispatch hook; navigation.dispatch is the bare
+	// receiver-stripped name).
 }
 
 // jsCollectionLibBareNames is the wave-9 Array.prototype / lodash /


### PR DESCRIPTION
## Summary

Drives **client-fixture-c (RN+Expo) from 1.43% → 0.87% (-0.560pp)** — **ship-gate (≤1%) reached** — by adding eight file-scoped bare-name gates in `internal/external/synth.go`, all TS/JS-language-gated, for the React Native platform package surface.

Closes PR #621 chain-fixes #1 (RN platform symbols) and #2 (Reanimated `timing`/`Value` receiver-strip).

## Gates added

| Gate | Triggers on imports of | Curated bare-name surface |
|---|---|---|
| `hasReanimatedImport` | `react-native-reanimated`, **`react-native` core** | `timing`, `Value`, `ValueXY`, `sequence`, `parallel`, `stagger`, `delay`, `loop`, `event`, `diffClamp`, `createAnimatedComponent`, `cancelAnimation`, `useFrameCallback`, `useAnimatedSensor`, `measure`, `scrollTo`, `defineAnimation` |
| `hasGluestackImport` | `@gluestack-ui/*`, `@gluestack-style/*` | `useStyleContext` (top single residual — 43 hits), `withStyleContext`, `useBreakpointValue`, `useDrawerStatus`, `tva`, `styled`, `createConfig`, `createComponents`, `useToken` |
| `hasExpoCameraImport` | `expo-camera`, `expo-image-picker`, `react-native-image-crop-picker` | `requestCameraPermissionsAsync`, `getCameraPermissionsAsync`, `launchCameraAsync`, `launchImageLibraryAsync`, `openCamera`, `openPicker`, `openCropper`, `clean` |
| `hasExpoFileImport` | `expo-file-system`, `expo-document-picker`, `expo-media-library`, `expo-sharing` | `downloadFileAsync`, `uploadAsync`, `readAsStringAsync`, `writeAsStringAsync`, `pickDirectoryAsync`, `getDocumentAsync`, `shareAsync`, `isAvailableAsync`, `createAssetAsync` |
| `hasExpoNetworkImport` | `expo-network`, `expo-intent-launcher`, `expo-local-authentication`, `expo-notifications`, `expo-haptics`, `expo-clipboard`, `expo-screen-orientation`, `expo-status-bar` | `getNetworkStateAsync`, `startActivityAsync`, `supportedAuthenticationTypesAsync`, `authenticateAsync`, `scheduleNotificationAsync`, `impactAsync`, `lockAsync` |
| `hasRNAudioRecorderImport` | `react-native-audio-recorder-player`, **`react-native-nitro-sound`** | `startPlayer`, `stopPlayer`, `pausePlayer`, `seekToPlayer`, `addPlayBackListener`, `removePlayBackListener`, `addPlaybackEndListener`, `removePlaybackEndListener`, `startRecorder`, `stopRecorder`, `addRecordBackListener`, `removeRecordBackListener` |
| `hasRNGestureHandlerImport` | `react-native-gesture-handler` | `requireExternalGestureToFail`, `numberOfTaps`, `manualActivation`, `activeOffsetX`/`Y`, `failOffsetX`/`Y`, `shouldCancelWhenOutside`, `hitSlop`, `minDuration`, `maxDuration` |
| `hasReactNavigationImport` | `@react-navigation/*`, `expo-router` | `goBack`, `jumpTo`, `toggleDrawer`, `openDrawer`, `closeDrawer`, `setParams`, `isFocused`, `canGoBack`, `addListener`, `dispatch` |
| `hasGorhomBottomSheetImport` | `@gorhom/bottom-sheet` | `snapToIndex`, `snapToPosition`, `expand`, `collapse`, `forceClose`, `present`, `dismiss`, `dismissAll` |

The Reanimated gate intentionally **also fires on `react-native` core** because `Animated.<name>(...)` is the dominant caller of `timing`/`Value`/`sequence`/`parallel`/`createAnimatedComponent`, and those bare leaves ride on the core `react-native` `Animated` namespace (not the standalone `react-native-reanimated` package).

## Per-iteration delta (client-fixture-c)

| pass | change | bug-rate | delta |
|---|---|---|---|
| baseline (#621 merged) | — | 1.433% | — |
| 1 | initial 8 gates (reanimated/gluestack/expo-camera/expo-file/expo-network/audio-recorder/gesture-handler/react-navigation) | 1.043% | -0.39pp |
| 2 | reanimated gate widened to include `react-native`; audio-recorder gate widened to include `react-native-nitro-sound` | 0.882% | **-0.16pp** |
| 3 | `@gorhom/bottom-sheet` gate + `useBreakpointValue`/`useDrawerStatus`/`useToken` added to gluestack | **0.873%** | -0.01pp |

Cumulative **-0.560pp**. bug-extractor 317 → 185 (-132). Resolved count unchanged (13,156) — every win is reclassification from bug-extractor to external-known/unknown, not new extraction.

## Regression sweep (14 repos, ≥0.5pp = STOP)

| repo | main | branch | delta_pp |
|---|---|---|---|
| chi (go) | 2.025% | 2.025% | 0.000 |
| flask (python) | 5.249% | 5.192% | -0.057 |
| spdlog (cpp) | 2.856% | 2.856% | 0.000 |
| gin (go) | 3.383% | 3.383% | 0.000 |
| play-scala-starter (scala) | 0.704% | 0.704% | 0.000 |
| express (js) | 2.856% | 2.856% | 0.000 |
| nextjs-commerce (ts) | 2.241% | 2.241% | 0.000 |
| nestjs-starter (ts) | 1.754% | 1.754% | 0.000 |
| kafka-streams-examples (java) | 3.329% | 3.329% | 0.000 |
| vapor-api-template (swift) | 2.128% | 2.128% | 0.000 |
| ktor-samples (kotlin) | 4.735% | 4.735% | 0.000 |
| client-fixture-a (python) | 3.410% | 3.427% | +0.017 |
| client-fixture-b (ts) | 0.572% | 0.572% | 0.000 |
| **client-fixture-c (ts/tsx)** | **1.433%** | **0.873%** | **-0.560** |

**Zero ≥0.5pp regressions.** Non-target movements (flask -0.057, client-fixture-a +0.017) are orthogonal to this PR — no python code was touched and all TS/JS allowlists are inside `if lang == "javascript" || lang == "typescript"`. Cross-language leakage impossible.

## Residual root cause

**client-fixture-c (0.87%):**
- bug-extractor top: `indicator` (12), `delete` (12), `show` (10), `has` (6), `create` (5), `close` (4), `copy` (4), `back` (3) — all domain-generic verbs/nouns too collision-prone for a global allowlist.
- bug-resolver top (21 total): `detail` (7), `deficiencies` (5), `showInlineAlert` (3) — user-defined cross-module bare names that the JS extractor receiver-stripped at extraction time.

## Status

**SHIP-GATE (≤1%) REACHED on client-fixture-c at 0.873%.** Track A (RN platform symbols, #621 chain-fix #1) complete. Track B (Reanimated receiver-strip via file-scoped gate, #621 chain-fix #2) complete.

## Chain-fixes filed (out of scope for this PR)

1. **js-receiver-type-inference** — domain-generic bare names (`indicator`, `delete`, `show`, `has`, `create`, `close`, `copy`) are receiver-stripped at extraction time and lose the class context. Same blocker as the Python #494 umbrella; a TS-side receiver-type primitive would lift these without a global allowlist.
2. **js-resolver-shortform-followups** — bug-resolver residue (`detail`, `deficiencies`, `showInlineAlert`) suggests other cross-file extraction shapes that fail to bind via `byLocation` short-form. Audit needed.
3. **default-export-name-tracking** — carry-forward from PR #621. Long-term: JS extractor records default-export status per entity for deterministic `<module>.default` binding.

## Test plan

- [x] `go test ./internal/external/ ./internal/resolve/ ./internal/extractors/javascript/` — all pass
- [x] 14-repo regression sweep — zero ≥0.5pp regressions
- [x] client-fixture-c per-iteration: 1.43% → 1.04% → 0.88% → 0.87%
- [x] Ship-gate (≤1%) verified post-merge with origin/main

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>