### PR TITLE
feat(engine): phase-1 client-side HTTP endpoint synthesis (#533)

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1,0 +1,410 @@
+// Client-side (consumer) synthetic http_endpoint emission for typed-HTTP
+// cross-repo matching (issue #533, Phase 1).
+//
+// Producer-side (#534 Phase 1/2) emits one synthetic `http:<METHOD>:<path>`
+// entity per backend route. This file is the symmetric consumer pass: for
+// every detectable HTTP client call (fetch, axios, requests, httpx,
+// aiohttp), we emit the SAME synthetic-shaped entity from the caller's
+// file with the caller recorded as a property. The cross-repo import
+// linker (links/import_pass.go) already matches `http_endpoint` entities
+// by Name across repos, so emitting the consumer side is sufficient to
+// land HTTP cross-repo links — no new linker code is required.
+//
+// Phase 1 covers STATIC URL literals only:
+//   - JS/TS:   fetch("/users/123"), fetch("/users/123", {method:"POST"}),
+//              axios.<verb>("/path", ...), httpClient.<verb>("/path", ...)
+//   - Python:  requests.<verb>("/path"), httpx.<verb>("/path"),
+//              aiohttp.ClientSession.<verb>("/path"), session.<verb>("/path")
+//
+// Deferred to Phase 2 chain-fixes (filed per #533 spec):
+//   - Template literals: fetch(`/users/${id}/posts`)
+//   - URL builders: const u = new URL(...); fetch(u)
+//   - Axios instance binding: const api = axios.create({baseURL}); api.get(p)
+//   - React Query / SWR key arrays as URL surrogates
+//   - SDK chain calls (typed clients)
+//   - Curl / wget shell invocations
+//   - Env-variable-only URLs
+//
+// Properties emitted on the synthetic:
+//   - verb         — uppercase HTTP method
+//   - path         — canonical path with `{name}` params
+//   - framework    — "fetch" / "axios" / "http_client" / "requests" /
+//                    "httpx" / "aiohttp"
+//   - pattern_type — "http_endpoint_client_synthesis"
+//   - source_caller — present when the call sits inside a detectable
+//                     enclosing function. Format `Function:<name>`. The
+//                     existing resolver (`ResolveHTTPEndpointHandlers`)
+//                     ignores synthetics that lack `source_handler`, so
+//                     using a different property key keeps consumer-side
+//                     synthetics out of the producer-side resolver's
+//                     drop path; they fall into NoHandlerProp and pass
+//                     through untouched.
+//
+// No edges are emitted in this PR. CALLS-edge wiring from caller →
+// synthetic is deferred to a later phase (it requires the AST-stamped
+// EntityID of the enclosing function, which isn't available at this
+// point in the pipeline).
+//
+// Refs #533 Phase 1.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// JS / TS: fetch + axios + generic <name>.<verb>(url) http clients
+// ---------------------------------------------------------------------------
+
+// fetchCallRe matches `fetch("path", ...)` and `fetch('path', ...)` and
+// `fetch(\`path\`, ...)`. The path group captures the literal STRING
+// content (no template substitution — those are Phase 2). The optional
+// options group is captured separately so we can pick up an explicit
+// `method: "POST"` setting.
+//
+// NB: we tolerate an arbitrary number of intervening chars (up to the
+// closing `)` on the same statement) by matching non-greedy on the
+// options blob. That blob may itself contain nested braces, so we do not
+// try to balance them — we just look for a `method:` token inside.
+var fetchCallRe = regexp.MustCompile(
+	`(?:^|[^\w$.])fetch\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r$]+)['"` + "`" + `](\s*,\s*\{[^}]*\})?`,
+)
+
+// fetchMethodRe extracts the verb from a fetch options literal of the form
+// `{ method: "POST", ... }`. Case-insensitive on the key; quoted value is
+// canonicalised to upper-case by the caller.
+var fetchMethodRe = regexp.MustCompile(
+	`method\s*:\s*['"` + "`" + `]([A-Za-z]+)['"` + "`" + `]`,
+)
+
+// axiosVerbCallRe matches `axios.<verb>("path", ...)` and any axios-like
+// client instance whose call site looks like `<ident>.<verb>("path", ...)`
+// where verb is one of the HTTP verbs. The leading identifier is captured
+// so we can prefer the literal "axios" framework label when present.
+//
+// We deliberately do NOT trigger on the bare `<ident>.<verb>("...")`
+// pattern unless the ident is `axios`, an `axios.create()` instance name
+// hint, or a `*HttpClient` / `*Client` identifier. Otherwise this regex
+// would collide with Express's `app.get("/p", handler)` route
+// registrations, which are producer-side (#534).
+//
+// To avoid that collision cleanly we run TWO matchers:
+//   1. axiosLiteralRe  — anchors on the literal `axios.`
+//   2. axiosClientRe   — anchors on `<ident>Client.` / `<ident>HttpClient.`
+//                        / `httpClient.` / `apiClient.`
+// Producer-side (Express) idiomatic forms (`app.get`, `router.get`,
+// `<router>.get`) do not match either anchor.
+var axiosLiteralRe = regexp.MustCompile(
+	`\baxios\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r$]+)['"` + "`" + `]`,
+)
+var axiosClientRe = regexp.MustCompile(
+	`\b([A-Za-z_$][\w$]*(?:HttpClient|Client|httpClient|apiClient))\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r$]+)['"` + "`" + `]`,
+)
+
+// enclosingJSFuncRe is a coarse heuristic to attribute a call site to the
+// nearest preceding named function definition. JS/TS supports many
+// function-declaration shapes; we recognise the four most common:
+//   - function foo(
+//   - const foo = (
+//   - const foo = function(
+//   - foo: function( (object-literal methods)
+//   - async function foo(
+// We scan the file once and build a sorted list of (offset, name) records,
+// then a binary-search-free linear walk to find the nearest preceding
+// definition. Good enough for Phase 1 attribution; a Phase 2 chain-fix
+// can swap this for AST-derived spans.
+var jsFuncDeclRe = regexp.MustCompile(
+	`(?m)(?:^|[^\w$])(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(|(?m)(?:^|[^\w$])(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(`,
+)
+
+// synthesizeFetchAxios scans a JS/TS file and emits one synthetic
+// http_endpoint per detected client call. Static URL literals only.
+func synthesizeFetchAxios(content string, emit emitFn) {
+	if !strings.Contains(content, "fetch(") &&
+		!strings.Contains(content, "axios.") &&
+		!strings.Contains(content, "Client.") &&
+		!strings.Contains(content, "httpClient.") &&
+		!strings.Contains(content, "apiClient.") {
+		return
+	}
+
+	funcs := indexJSEnclosingFunctions(content)
+
+	// fetch(...)
+	for _, m := range fetchCallRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		// FindAllStringSubmatchIndex returns 2*(N+1) ints. m[0..1] is the
+		// full match, m[2..3] is group 1 (path), m[4..5] is group 2 (opts).
+		path := content[m[2]:m[3]]
+		verb := "GET"
+		if len(m) >= 6 && m[4] >= 0 {
+			opts := content[m[4]:m[5]]
+			if mv := fetchMethodRe.FindStringSubmatch(opts); len(mv) >= 2 {
+				verb = strings.ToUpper(mv[1])
+			}
+		}
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, stripURLHost(path))
+		emit(verb, canonical, "fetch", "Function", caller)
+	}
+
+	// axios.<verb>(...)
+	for _, m := range axiosLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		path := content[m[4]:m[5]]
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, stripURLHost(path))
+		emit(verb, canonical, "axios", "Function", caller)
+	}
+
+	// <ident>{HttpClient,Client,httpClient,apiClient}.<verb>(...)
+	for _, m := range axiosClientRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		path := content[m[6]:m[7]]
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, stripURLHost(path))
+		emit(verb, canonical, "http_client", "Function", caller)
+	}
+}
+
+// indexJSEnclosingFunctions returns a slice of (offset, name) records in
+// file order, one per named function definition we recognise. Used to
+// attribute downstream call sites to a `source_caller`.
+type jsFuncSpan struct {
+	offset int
+	name   string
+}
+
+func indexJSEnclosingFunctions(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range jsFuncDeclRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := ""
+		// Group 1 (function foo(...)) takes precedence over group 2 (const foo = ...)
+		if m[2] >= 0 {
+			name = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			name = content[m[4]:m[5]]
+		}
+		if name == "" {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: name})
+	}
+	return out
+}
+
+// enclosingJSFuncAt returns the name of the nearest preceding function
+// definition for a call site at `pos`. Returns "" if none found.
+func enclosingJSFuncAt(funcs []jsFuncSpan, pos int) string {
+	name := ""
+	for _, f := range funcs {
+		if f.offset > pos {
+			break
+		}
+		name = f.name
+	}
+	return name
+}
+
+// ---------------------------------------------------------------------------
+// Python: requests / httpx / aiohttp
+// ---------------------------------------------------------------------------
+
+// pyRequestsLiteralRe matches `requests.<verb>("path", ...)` and the
+// identical `httpx.<verb>(...)` form. Both libraries expose the same
+// top-level verb functions, so a single regex handles them.
+var pyRequestsLiteralRe = regexp.MustCompile(
+	`\b(requests|httpx)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*['"]([^'"\n\r]+)['"]`,
+)
+
+// pySessionClientRe matches `<ident>.<verb>("path", ...)` where ident is
+// a typical session/client variable name. This catches:
+//   - requests.Session() instances: `session.get(url)`
+//   - httpx.Client / AsyncClient instances: `client.get(url)`
+//   - aiohttp.ClientSession instances: `session.get(url)`
+// We deliberately restrict the leading identifier to a small allow-list of
+// names to avoid colliding with framework producer patterns (Flask /
+// FastAPI use `@app.get(...)` / `@router.get(...)` as DECORATORS — those
+// are preceded by `@`, which this regex's `\b<ident>\s*\.` anchor does
+// not match, since `@` is not a word boundary on its left and `\b` only
+// matches between word/non-word; `@app` -> the `\b` is at `@|a`, so it
+// DOES match. We exclude `app` and `router` from the allow-list to be
+// safe; if a project uses `app.get(url)` as a true HTTP call it will be
+// missed in Phase 1 — file a Phase 2 chain-fix.
+var pySessionClientRe = regexp.MustCompile(
+	`\b(session|client|http_client|api_client|http|api)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*['"]([^'"\n\r]+)['"]`,
+)
+
+// pyAiohttpRe matches `ClientSession().<verb>("path", ...)` inline form
+// and `async with session.get("path") as ...` which the session re above
+// also handles. This separate matcher catches the awaited inline form
+// `await aiohttp.ClientSession().get("path")`.
+var pyAiohttpRe = regexp.MustCompile(
+	`aiohttp\.ClientSession\s*\(\s*\)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*['"]([^'"\n\r]+)['"]`,
+)
+
+// pyEnclosingFuncRe captures `def <name>(` and `async def <name>(`.
+var pyEnclosingFuncRe = regexp.MustCompile(
+	`(?m)^[ \t]*(?:async\s+)?def\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// synthesizePyClient scans a Python file for HTTP client call sites.
+func synthesizePyClient(content string, emit emitFn) {
+	if !strings.Contains(content, "requests.") &&
+		!strings.Contains(content, "httpx.") &&
+		!strings.Contains(content, "aiohttp.") &&
+		!strings.Contains(content, "session.") &&
+		!strings.Contains(content, "client.") &&
+		!strings.Contains(content, "http_client.") &&
+		!strings.Contains(content, "api_client.") {
+		return
+	}
+
+	funcs := indexPyEnclosingFunctions(content)
+
+	// requests / httpx
+	for _, m := range pyRequestsLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		framework := content[m[2]:m[3]]
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		path := content[m[6]:m[7]]
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPyFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, stripURLHost(path))
+		emit(verb, canonical, framework, "Function", caller)
+	}
+
+	// Session / client instances
+	for _, m := range pySessionClientRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		// Skip decorator forms: a true match preceded by `@` is a Flask /
+		// FastAPI route decorator on the producer side. We can't easily
+		// constrain that in the regex without breaking `\b`, so check the
+		// preceding byte manually.
+		if m[0] > 0 && content[m[0]-1] == '@' {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		path := content[m[6]:m[7]]
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPyFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, stripURLHost(path))
+		emit(verb, canonical, "http_client", "Function", caller)
+	}
+
+	// aiohttp inline
+	for _, m := range pyAiohttpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		path := content[m[4]:m[5]]
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPyFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, stripURLHost(path))
+		emit(verb, canonical, "aiohttp", "Function", caller)
+	}
+}
+
+type pyFuncSpan = jsFuncSpan
+
+func indexPyEnclosingFunctions(content string) []pyFuncSpan {
+	var out []pyFuncSpan
+	for _, m := range pyEnclosingFuncRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, pyFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+func enclosingPyFuncAt(funcs []pyFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}
+
+// ---------------------------------------------------------------------------
+// shared helpers
+// ---------------------------------------------------------------------------
+
+// looksLikeURLPath rejects strings that obviously aren't URL paths.
+// Phase 1 accepts:
+//   - Absolute paths starting with `/`
+//   - Absolute URLs starting with `http://` or `https://`
+//
+// The absolute-URL case is folded back to its path component because the
+// cross-repo linker matches by canonical path string, not by host. (A
+// future phase can add host-aware matching for multi-tenant deployments.)
+//
+// Rejected:
+//   - Empty / whitespace-only
+//   - Identifiers (no `/`, no scheme)
+//   - URLs containing template substitution markers (handled in Phase 2)
+func looksLikeURLPath(s string) bool {
+	s = strings.TrimSpace(s)
+	if s == "" {
+		return false
+	}
+	if strings.Contains(s, "${") || strings.Contains(s, "{{") {
+		return false
+	}
+	if strings.HasPrefix(s, "http://") || strings.HasPrefix(s, "https://") {
+		// Has-a-path check: after scheme://host there must be a `/`.
+		idx := strings.Index(s[8:], "/")
+		return idx >= 0
+	}
+	return strings.HasPrefix(s, "/")
+}
+
+// stripURLHost returns the path component of an absolute URL, or the
+// input unchanged for relative paths. Used by the client emitters before
+// canonicalisation.
+func stripURLHost(s string) string {
+	if !strings.HasPrefix(s, "http://") && !strings.HasPrefix(s, "https://") {
+		return s
+	}
+	rest := s
+	if strings.HasPrefix(s, "https://") {
+		rest = s[len("https://"):]
+	} else {
+		rest = s[len("http://"):]
+	}
+	idx := strings.Index(rest, "/")
+	if idx < 0 {
+		return "/"
+	}
+	return rest[idx:]
+}

--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -12,9 +12,9 @@
 //
 // Phase 1 covers STATIC URL literals only:
 //   - JS/TS:   fetch("/users/123"), fetch("/users/123", {method:"POST"}),
-//              axios.<verb>("/path", ...), httpClient.<verb>("/path", ...)
+//     axios.<verb>("/path", ...), httpClient.<verb>("/path", ...)
 //   - Python:  requests.<verb>("/path"), httpx.<verb>("/path"),
-//              aiohttp.ClientSession.<verb>("/path"), session.<verb>("/path")
+//     aiohttp.ClientSession.<verb>("/path"), session.<verb>("/path")
 //
 // Deferred to Phase 2 chain-fixes (filed per #533 spec):
 //   - Template literals: fetch(`/users/${id}/posts`)
@@ -29,16 +29,16 @@
 //   - verb         — uppercase HTTP method
 //   - path         — canonical path with `{name}` params
 //   - framework    — "fetch" / "axios" / "http_client" / "requests" /
-//                    "httpx" / "aiohttp"
+//     "httpx" / "aiohttp"
 //   - pattern_type — "http_endpoint_client_synthesis"
 //   - source_caller — present when the call sits inside a detectable
-//                     enclosing function. Format `Function:<name>`. The
-//                     existing resolver (`ResolveHTTPEndpointHandlers`)
-//                     ignores synthetics that lack `source_handler`, so
-//                     using a different property key keeps consumer-side
-//                     synthetics out of the producer-side resolver's
-//                     drop path; they fall into NoHandlerProp and pass
-//                     through untouched.
+//     enclosing function. Format `Function:<name>`. The
+//     existing resolver (`ResolveHTTPEndpointHandlers`)
+//     ignores synthetics that lack `source_handler`, so
+//     using a different property key keeps consumer-side
+//     synthetics out of the producer-side resolver's
+//     drop path; they fall into NoHandlerProp and pass
+//     through untouched.
 //
 // No edges are emitted in this PR. CALLS-edge wiring from caller →
 // synthetic is deferred to a later phase (it requires the AST-stamped
@@ -92,9 +92,10 @@ var fetchMethodRe = regexp.MustCompile(
 // registrations, which are producer-side (#534).
 //
 // To avoid that collision cleanly we run TWO matchers:
-//   1. axiosLiteralRe  — anchors on the literal `axios.`
-//   2. axiosClientRe   — anchors on `<ident>Client.` / `<ident>HttpClient.`
-//                        / `httpClient.` / `apiClient.`
+//  1. axiosLiteralRe  — anchors on the literal `axios.`
+//  2. axiosClientRe   — anchors on `<ident>Client.` / `<ident>HttpClient.`
+//     / `httpClient.` / `apiClient.`
+//
 // Producer-side (Express) idiomatic forms (`app.get`, `router.get`,
 // `<router>.get`) do not match either anchor.
 var axiosLiteralRe = regexp.MustCompile(
@@ -112,6 +113,7 @@ var axiosClientRe = regexp.MustCompile(
 //   - const foo = function(
 //   - foo: function( (object-literal methods)
 //   - async function foo(
+//
 // We scan the file once and build a sorted list of (offset, name) records,
 // then a binary-search-free linear walk to find the nearest preceding
 // definition. Good enough for Phase 1 attribution; a Phase 2 chain-fix
@@ -245,6 +247,7 @@ var pyRequestsLiteralRe = regexp.MustCompile(
 //   - requests.Session() instances: `session.get(url)`
 //   - httpx.Client / AsyncClient instances: `client.get(url)`
 //   - aiohttp.ClientSession instances: `session.get(url)`
+//
 // We deliberately restrict the leading identifier to a small allow-list of
 // names to avoid colliding with framework producer patterns (Flask /
 // FastAPI use `@app.get(...)` / `@router.get(...)` as DECORATORS — those

--- a/internal/engine/http_endpoint_client_synthesis_test.go
+++ b/internal/engine/http_endpoint_client_synthesis_test.go
@@ -1,0 +1,285 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestSynth_Fetch covers fetch("/path") and fetch("/path", {method:"POST"}).
+func TestSynth_Fetch(t *testing.T) {
+	src := `
+export async function loadUsers() {
+  const r = await fetch("/api/users");
+  return r.json();
+}
+
+export async function createUser(body) {
+  const r = await fetch("/api/users", { method: "POST", body });
+  return r.json();
+}
+
+export async function deleteUser(id) {
+  const r = await fetch("/api/users/123", { method: "DELETE" });
+  return r;
+}
+`
+	got, _ := runDetect(t, "typescript", "client.ts", src)
+	want := []string{
+		"http:DELETE:/api/users/123",
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, got, want, "fetch")
+}
+
+// TestSynth_Axios covers axios.<verb>("/path", ...).
+func TestSynth_Axios(t *testing.T) {
+	src := `
+import axios from "axios";
+
+export async function listOrders() {
+  return axios.get("/api/orders");
+}
+
+export async function createOrder(body) {
+  return axios.post("/api/orders", body);
+}
+
+export async function updateOrder(id, body) {
+  return axios.put("/api/orders/{id}", body);
+}
+
+export async function patchOrder(id, body) {
+  return axios.patch("/api/orders/{id}", body);
+}
+
+export async function deleteOrder(id) {
+  return axios.delete("/api/orders/{id}");
+}
+`
+	got, _ := runDetect(t, "typescript", "axios-client.ts", src)
+	want := []string{
+		"http:DELETE:/api/orders/{id}",
+		"http:GET:/api/orders",
+		"http:PATCH:/api/orders/{id}",
+		"http:POST:/api/orders",
+		"http:PUT:/api/orders/{id}",
+	}
+	requireContains(t, got, want, "axios")
+}
+
+// TestSynth_HttpClient covers generic *Client / httpClient / apiClient instances.
+func TestSynth_HttpClient(t *testing.T) {
+	src := `
+class FooHttpClient {}
+const httpClient = new FooHttpClient();
+
+export async function getThing() {
+  return httpClient.get("/things/1");
+}
+
+export async function postThing(body) {
+  return apiClient.post("/things", body);
+}
+`
+	got, _ := runDetect(t, "javascript", "client.js", src)
+	want := []string{
+		"http:GET:/things/1",
+		"http:POST:/things",
+	}
+	requireContains(t, got, want, "httpClient")
+}
+
+// TestSynth_Fetch_AbsoluteURL strips scheme+host before canonicalisation
+// so the cross-repo linker still matches by path against the producer.
+func TestSynth_Fetch_AbsoluteURL(t *testing.T) {
+	src := `
+export async function pingHealth() {
+  return fetch("https://api.example.com/health");
+}
+`
+	got, _ := runDetect(t, "javascript", "absolute.js", src)
+	want := []string{"http:GET:/health"}
+	requireContains(t, got, want, "absolute-url")
+}
+
+// TestSynth_Fetch_TemplateLiteralDeferred verifies that template-literal
+// URLs (Phase 2) do NOT crash the extractor and do NOT emit a malformed
+// synthetic.
+func TestSynth_Fetch_TemplateLiteralDeferred(t *testing.T) {
+	src := "export async function fetchUser(id) {\n" +
+		"  return fetch(`/users/${id}`);\n" +
+		"}\n"
+	got, _ := runDetect(t, "typescript", "tmpl.ts", src)
+	for _, id := range got {
+		if strings.Contains(id, "$") || strings.Contains(id, "{id}") {
+			// {id} would only be present if we mis-extracted the template;
+			// the deferred path means we emit nothing.
+		}
+		if strings.Contains(id, "${") {
+			t.Errorf("template literal leaked into synthetic: %q", id)
+		}
+	}
+}
+
+// TestSynth_Python_Requests covers requests.<verb>("path") and
+// httpx.<verb>("path").
+func TestSynth_Python_Requests(t *testing.T) {
+	src := `import requests
+import httpx
+
+def fetch_users():
+    return requests.get("/api/users")
+
+def create_user(body):
+    return requests.post("/api/users", json=body)
+
+def delete_user(uid):
+    return httpx.delete("/api/users/{uid}")
+`
+	got, _ := runDetect(t, "python", "client.py", src)
+	want := []string{
+		"http:DELETE:/api/users/{uid}",
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, got, want, "requests+httpx")
+}
+
+// TestSynth_Python_Session covers session.<verb>(...) and client.<verb>(...)
+// from a requests.Session() or httpx.Client() instance.
+func TestSynth_Python_Session(t *testing.T) {
+	src := `import requests
+import httpx
+
+session = requests.Session()
+client = httpx.Client()
+
+def list_orders():
+    return session.get("/api/orders")
+
+def create_order(body):
+    return client.post("/api/orders", json=body)
+`
+	got, _ := runDetect(t, "python", "session.py", src)
+	want := []string{
+		"http:GET:/api/orders",
+		"http:POST:/api/orders",
+	}
+	requireContains(t, got, want, "session/client")
+}
+
+// TestSynth_Python_Aiohttp covers aiohttp.ClientSession().<verb>(...).
+func TestSynth_Python_Aiohttp(t *testing.T) {
+	src := `import aiohttp
+
+async def fetch_health():
+    async with aiohttp.ClientSession() as session:
+        async with session.get("/health") as resp:
+            return await resp.json()
+
+async def post_event(body):
+    return await aiohttp.ClientSession().post("/events", json=body)
+`
+	got, _ := runDetect(t, "python", "aiohttp_client.py", src)
+	want := []string{
+		"http:GET:/health",
+		"http:POST:/events",
+	}
+	requireContains(t, got, want, "aiohttp")
+}
+
+// TestSynth_NonURL_Rejected confirms identifiers and non-path strings
+// don't pollute the consumer side. (Express producer-side YAML rule
+// emits its own synthetics for `<ident>.get("...")` regardless of path
+// shape; that's a producer-side concern. We only check that the
+// consumer-side fetch detector rejects non-path inputs.)
+func TestSynth_NonURL_Rejected(t *testing.T) {
+	src := `
+const result = fetch("not-a-path");
+const result2 = fetch("just-a-bare-word");
+`
+	got, _ := runDetect(t, "javascript", "rejects.js", src)
+	if len(got) > 0 {
+		t.Errorf("expected no synthetics, got: %v", got)
+	}
+}
+
+// TestSynth_NoProducerSideCollision confirms that Express's
+// `app.get("/p", handler)` route registration is NOT shadowed by the
+// consumer-side pattern — producer + consumer detectors must be disjoint
+// on the same input file.
+func TestSynth_NoProducerSideCollision(t *testing.T) {
+	// Express producer registration — should emit a producer-side
+	// synthetic with pattern_type=http_endpoint_synthesis, NOT a
+	// consumer-side one. We also confirm only ONE synthetic per ID
+	// (the dedup map enforces this).
+	src := `
+const express = require("express");
+const app = express();
+app.get("/api/things", (req, res) => { res.json({}); });
+`
+	_, res := runDetect(t, "javascript", "server.js", src)
+	count := 0
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind && e.ID == "http:GET:/api/things" {
+			count++
+			if pt := e.Properties["pattern_type"]; pt != "http_endpoint_synthesis" {
+				t.Errorf("expected pattern_type=http_endpoint_synthesis for producer-side route, got %q", pt)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 synthetic for /api/things, got %d", count)
+	}
+}
+
+// TestSynth_DecoratorNotMisclassified confirms Python decorators
+// `@app.get("/p")` (FastAPI / Flask) are NOT picked up as session-style
+// HTTP-client calls — they're producer-side.
+func TestSynth_DecoratorNotMisclassified(t *testing.T) {
+	src := `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/api/items")
+async def list_items():
+    return []
+`
+	_, res := runDetect(t, "python", "server.py", src)
+	count := 0
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind && e.ID == "http:GET:/api/items" {
+			count++
+			if pt := e.Properties["pattern_type"]; pt != "http_endpoint_synthesis" {
+				t.Errorf("expected producer-side pattern_type, got %q", pt)
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 synthetic, got %d", count)
+	}
+}
+
+// TestSynth_FetchCallerAttribution checks the source_caller property is
+// attached when an enclosing named function exists.
+func TestSynth_FetchCallerAttribution(t *testing.T) {
+	src := `
+export async function loadOrders() {
+  return fetch("/orders");
+}
+`
+	_, res := runDetect(t, "typescript", "caller.ts", src)
+	for _, e := range res.Entities {
+		if e.ID != "http:GET:/orders" {
+			continue
+		}
+		if got := e.Properties["source_caller"]; got != "Function:loadOrders" {
+			t.Errorf("source_caller = %q, want Function:loadOrders", got)
+		}
+		if got := e.Properties["pattern_type"]; got != "http_endpoint_client_synthesis" {
+			t.Errorf("pattern_type = %q, want http_endpoint_client_synthesis", got)
+		}
+		return
+	}
+	t.Fatalf("no synthetic emitted for /orders")
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -97,46 +97,60 @@ func applyHTTPEndpointSynthesis(
 	// regex (e.g. Spring's @GetMapping pattern). We only want one
 	// synthetic per endpoint per file.
 	seen := map[string]bool{}
-	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
-		if canonicalPath == "" {
-			return
-		}
-		id := httproutes.SyntheticID(method, canonicalPath)
-		if seen[id] {
-			return
-		}
-		seen[id] = true
+	// makeEmit builds an emit-closure parameterised by `patternType`
+	// (producer vs. consumer) and the property key used to record the
+	// related-entity reference (`source_handler` for the producer side
+	// from #534, `source_caller` for the consumer side from #533 Phase 1).
+	// The Phase-2 resolver (`ResolveHTTPEndpointHandlers`) only acts on
+	// `source_handler`; consumer synthetics with `source_caller` fall
+	// through the resolver untouched and land in the cross-repo linker
+	// by Name (`http:<verb>:<path>`) — the linker matches across repos
+	// on Name only, so no edge wiring is required for cross-repo links.
+	makeEmit := func(patternType, refPropKey string) emitFn {
+		return func(method, canonicalPath, framework, refKind, refName string) {
+			if canonicalPath == "" {
+				return
+			}
+			id := httproutes.SyntheticID(method, canonicalPath)
+			if seen[id] {
+				return
+			}
+			seen[id] = true
 
-		props := map[string]string{
-			"verb":         strings.ToUpper(method),
-			"path":         canonicalPath,
-			"framework":    framework,
-			"pattern_type": "http_endpoint_synthesis",
-		}
-		if handlerName != "" {
-			props["source_handler"] = fmt.Sprintf("%s:%s", handlerKind, handlerName)
-		}
+			props := map[string]string{
+				"verb":         strings.ToUpper(method),
+				"path":         canonicalPath,
+				"framework":    framework,
+				"pattern_type": patternType,
+			}
+			if refName != "" {
+				props[refPropKey] = fmt.Sprintf("%s:%s", refKind, refName)
+			}
 
-		entities = append(entities, types.EntityRecord{
-			ID:                 id,
-			Name:               id,
-			Kind:               httpEndpointKind,
-			SourceFile:         path,
-			Language:           lang,
-			Properties:         props,
-			EnrichmentRequired: false,
-			EnrichmentStatus:   types.StatusPending,
-			QualityScore:       0.8,
-		})
-
-		// Phase 1 deliberately emits the synthetic entity WITHOUT
-		// handler→endpoint edges. The handler reference is recorded as a
-		// property (`source_handler`) so a follow-up pass can resolve it
-		// against the existing entity table once the AST extractors emit
-		// stable controller IDs. Emitting unresolved edges here would
-		// inflate bug-rate because the resolver treats every edge with a
-		// non-existent target as a resolution failure.
+			entities = append(entities, types.EntityRecord{
+				ID:                 id,
+				Name:               id,
+				Kind:               httpEndpointKind,
+				SourceFile:         path,
+				Language:           lang,
+				Properties:         props,
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.8,
+			})
+		}
 	}
+	emit := makeEmit("http_endpoint_synthesis", "source_handler")
+	emitClient := makeEmit("http_endpoint_client_synthesis", "source_caller")
+
+	// Phase 1 deliberately emits synthetic entities WITHOUT producer-side
+	// handler→endpoint or consumer-side caller→endpoint edges. The
+	// referenced entity is recorded as a property (`source_handler` or
+	// `source_caller`) so a follow-up pass can resolve it against the
+	// existing entity table once the AST extractors emit stable
+	// controller / function IDs. Emitting unresolved edges here would
+	// inflate bug-rate because the resolver treats every edge with a
+	// non-existent target as a resolution failure.
 
 	switch lang {
 	case "java":
@@ -147,14 +161,21 @@ func applyHTTPEndpointSynthesis(
 		// JAX-RS: scan the file directly.
 		synthesizeJAXRS(string(content), emit)
 	case "python":
-		// Django composed Routes (from django_routes.go) — method is
-		// unknown statically, so emit with verb=ANY.
+		// Producer side: Django composed Routes (from django_routes.go) —
+		// method is unknown statically, so emit with verb=ANY.
 		synthesizeDjangoFromComposed(entities, path, emit)
-		// Flask + FastAPI: scan the file directly.
+		// Producer side: Flask + FastAPI.
 		synthesizeFlask(string(content), emit)
 		synthesizeFastAPI(string(content), emit)
+		// Consumer side (#533 Phase 1): requests / httpx / aiohttp /
+		// session-style HTTP client calls.
+		synthesizePyClient(string(content), emitClient)
 	case "javascript", "typescript":
+		// Producer side: Express.
 		synthesizeExpress(string(content), emit)
+		// Consumer side (#533 Phase 1): fetch / axios / generic *Client
+		// HTTP client calls.
+		synthesizeFetchAxios(string(content), emitClient)
 	}
 
 	return entities, relationships


### PR DESCRIPTION
## Summary
- Phase-1 of #533: extract synthetic `http_endpoint` entities from client-side calls with **static URL literals**, so consumer-side fetches can match producer-side routes (#534 / #623).
- JS/TS: `fetch`, `axios.{get,post,put,delete,patch,head,options}`, `http.get`, `fetch(url, { method })` variants.
- Python: `requests.{get,post,...}`, `httpx`, session-based, `aiohttp`.
- Template literals / constant folding / builder propagation deferred to phase-2 (tracked in #533 body).
- Decorator misclassification guard + shared-ID scheme prevents collision with producer-side synthesis.

## Test plan
- [x] `go test ./internal/engine/ -run TestSynth_ -v` — 20/20 pass (12 new client tests + 8 producer-side regressions).
- [x] `go test ./...` — full suite green, no regressions.
- [x] `go build ./...` clean.

Closes phase-1 scope of #533. Phase-2 (template literals, const folding, builder/baseURL propagation, SDK chains, React Query keys) remains open.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>