### PR TITLE
[chore] gofmt repo-wide cleanup — unblock CI

### DIFF
--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -15,13 +15,13 @@
 //  2. For each synthetic http_endpoint with a source_handler property:
 //     a. Parses the property into (handlerKind, handlerName).
 //     b. Resolves to a real entity in the same SourceFile (handlers and
-//        their owning routes always live in the same file by construction
-//        of Phase 1).
+//     their owning routes always live in the same file by construction
+//     of Phase 1).
 //     c. If resolved: appends an IMPLEMENTS edge (handler → synthetic)
-//        to the handler's embedded Relationships, then clears the
-//        source_handler property (its job is done).
+//     to the handler's embedded Relationships, then clears the
+//     source_handler property (its job is done).
 //     d. If NOT resolved: marks the synthetic for removal so it never
-//        reaches the resolver as an orphan.
+//     reaches the resolver as an orphan.
 //
 // Returning a NEW slice of EntityRecords (with unresolved synthetics
 // dropped) keeps the data flow obvious and avoids in-place slice
@@ -40,10 +40,10 @@ import (
 // Exposed so cmd/archigraph can log a stats line analogous to the
 // import-aware resolver line.
 type ResolveHTTPEndpointStats struct {
-	Synthetics       int // total http_endpoint records seen
-	HandlerResolved  int // source_handler resolved → IMPLEMENTS edge emitted
-	HandlerDropped   int // synthetics dropped because source_handler unresolved
-	NoHandlerProp    int // synthetics with no source_handler property (kept as-is)
+	Synthetics      int // total http_endpoint records seen
+	HandlerResolved int // source_handler resolved → IMPLEMENTS edge emitted
+	HandlerDropped  int // synthetics dropped because source_handler unresolved
+	NoHandlerProp   int // synthetics with no source_handler property (kept as-is)
 }
 
 // ResolveHTTPEndpointHandlers runs the Phase-2 post-pass over `merged`.

--- a/internal/enrichment/repair_edge_test.go
+++ b/internal/enrichment/repair_edge_test.go
@@ -134,8 +134,8 @@ func TestCollectRepairEdgeCandidates_SchemaShape(t *testing.T) {
 		"from users.models import User",
 		"",
 		"class UserListView:",
-		"    def get(self, request):",         // line 5 — call site
-		"        return JsonResponse({})",     // line 6
+		"    def get(self, request):",     // line 5 — call site
+		"        return JsonResponse({})", // line 6
 	}, "\n")
 	if err := os.MkdirAll(filepath.Join(tmp, filepath.Dir(srcPath)), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)

--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -3127,16 +3127,16 @@ func hasExpoCameraImport(imports map[string]bool) bool {
 }
 
 var jsExpoCameraBareNames = map[string]struct{}{
-	"requestCameraPermissionsAsync":   {},
-	"getCameraPermissionsAsync":       {},
-	"requestMicrophonePermissionsAsync": {},
+	"requestCameraPermissionsAsync":       {},
+	"getCameraPermissionsAsync":           {},
+	"requestMicrophonePermissionsAsync":   {},
 	"requestMediaLibraryPermissionsAsync": {},
-	"launchCameraAsync":              {},
-	"launchImageLibraryAsync":        {},
-	"openCamera":                     {}, // react-native-image-crop-picker
-	"openPicker":                     {},
-	"openCropper":                    {},
-	"clean":                          {}, // ImagePicker.clean()
+	"launchCameraAsync":                   {},
+	"launchImageLibraryAsync":             {},
+	"openCamera":                          {}, // react-native-image-crop-picker
+	"openPicker":                          {},
+	"openCropper":                         {},
+	"clean":                               {}, // ImagePicker.clean()
 }
 
 // hasExpoFileImport reports whether the file imports expo-file-system /
@@ -3209,28 +3209,28 @@ func hasExpoNetworkImport(imports map[string]bool) bool {
 }
 
 var jsExpoPlatformBareNames = map[string]struct{}{
-	"getNetworkStateAsync":              {}, // expo-network
-	"getIpAddressAsync":                 {},
-	"getMacAddressAsync":                {},
-	"startActivityAsync":                {}, // expo-intent-launcher
-	"supportedAuthenticationTypesAsync": {}, // expo-local-authentication
-	"authenticateAsync":                 {},
-	"hasHardwareAsync":                  {},
-	"isEnrolledAsync":                   {},
-	"scheduleNotificationAsync":         {}, // expo-notifications
-	"cancelScheduledNotificationAsync":  {},
+	"getNetworkStateAsync":                 {}, // expo-network
+	"getIpAddressAsync":                    {},
+	"getMacAddressAsync":                   {},
+	"startActivityAsync":                   {}, // expo-intent-launcher
+	"supportedAuthenticationTypesAsync":    {}, // expo-local-authentication
+	"authenticateAsync":                    {},
+	"hasHardwareAsync":                     {},
+	"isEnrolledAsync":                      {},
+	"scheduleNotificationAsync":            {}, // expo-notifications
+	"cancelScheduledNotificationAsync":     {},
 	"cancelAllScheduledNotificationsAsync": {},
-	"setNotificationHandler":            {},
-	"getExpoPushTokenAsync":             {},
-	"getDevicePushTokenAsync":           {},
-	"setStringAsync":                    {}, // expo-clipboard
-	"getStringAsync":                    {},
-	"hasStringAsync":                    {},
-	"lockAsync":                         {}, // expo-screen-orientation
-	"unlockAsync":                       {},
-	"impactAsync":                       {}, // expo-haptics
-	"notificationAsync":                 {},
-	"selectionAsync":                    {},
+	"setNotificationHandler":               {},
+	"getExpoPushTokenAsync":                {},
+	"getDevicePushTokenAsync":              {},
+	"setStringAsync":                       {}, // expo-clipboard
+	"getStringAsync":                       {},
+	"hasStringAsync":                       {},
+	"lockAsync":                            {}, // expo-screen-orientation
+	"unlockAsync":                          {},
+	"impactAsync":                          {}, // expo-haptics
+	"notificationAsync":                    {},
+	"selectionAsync":                       {},
 }
 
 // hasRNAudioRecorderImport reports whether the file imports
@@ -3299,19 +3299,19 @@ func hasRNGestureHandlerImport(imports map[string]bool) bool {
 }
 
 var jsRNGestureHandlerBareNames = map[string]struct{}{
-	"requireExternalGestureToFail": {},
-	"requireExternalGestureToBegin": {},
+	"requireExternalGestureToFail":    {},
+	"requireExternalGestureToBegin":   {},
 	"simultaneousWithExternalGesture": {},
-	"numberOfTaps":                 {},
-	"maxDuration":                  {},
-	"minDuration":                  {},
-	"manualActivation":             {},
-	"shouldCancelWhenOutside":      {},
-	"hitSlop":                      {},
-	"activeOffsetX":                {},
-	"activeOffsetY":                {},
-	"failOffsetX":                  {},
-	"failOffsetY":                  {},
+	"numberOfTaps":                    {},
+	"maxDuration":                     {},
+	"minDuration":                     {},
+	"manualActivation":                {},
+	"shouldCancelWhenOutside":         {},
+	"hitSlop":                         {},
+	"activeOffsetX":                   {},
+	"activeOffsetY":                   {},
+	"failOffsetX":                     {},
+	"failOffsetY":                     {},
 }
 
 // hasReactNavigationImport reports whether the file imports any
@@ -3337,17 +3337,17 @@ func hasReactNavigationImport(imports map[string]bool) bool {
 }
 
 var jsReactNavigationBareNames = map[string]struct{}{
-	"goBack":        {}, // navigation.goBack
-	"jumpTo":        {}, // navigation.jumpTo
-	"toggleDrawer":  {}, // drawer navigation
-	"openDrawer":    {},
-	"closeDrawer":   {},
-	"setParams":     {},
-	"isFocused":     {},
-	"canGoBack":     {},
-	"addListener":   {}, // navigation.addListener (also EventEmitter)
+	"goBack":         {}, // navigation.goBack
+	"jumpTo":         {}, // navigation.jumpTo
+	"toggleDrawer":   {}, // drawer navigation
+	"openDrawer":     {},
+	"closeDrawer":    {},
+	"setParams":      {},
+	"isFocused":      {},
+	"canGoBack":      {},
+	"addListener":    {}, // navigation.addListener (also EventEmitter)
 	"removeListener": {},
-	"dispatch":      {}, // navigation.dispatch (Redux dispatch already
+	"dispatch":       {}, // navigation.dispatch (Redux dispatch already
 	// handled by useDispatch hook; navigation.dispatch is the bare
 	// receiver-stripped name).
 }

--- a/internal/links/import_pass.go
+++ b/internal/links/import_pass.go
@@ -280,7 +280,6 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	return res, nil
 }
 
-
 // normalizedRelation maps a graph relationship Kind to one of the
 // canonical relation values used in links.json. Accepts upper- or
 // lowercase forms (extractors emit either).

--- a/internal/quality/diff.go
+++ b/internal/quality/diff.go
@@ -37,10 +37,10 @@ type Report struct {
 	FixtureName string
 
 	// Entity scoring.
-	EntityResults     []EntityResult
-	EntityExpected    int // total must_exist
-	EntityFound       int // must_exist AND found
-	EntityExtractedN  int // |doc.Entities| — extra context, not in recall
+	EntityResults    []EntityResult
+	EntityExpected   int // total must_exist
+	EntityFound      int // must_exist AND found
+	EntityExtractedN int // |doc.Entities| — extra context, not in recall
 
 	// Relationship scoring.
 	RelResults    []RelationshipResult

--- a/internal/quality/expected.go
+++ b/internal/quality/expected.go
@@ -33,12 +33,12 @@ import (
 // over-specify. Recall is therefore "did the must_exist things show up",
 // not "is the extracted set exactly this".
 type Fixture struct {
-	Name                    string                  `json:"fixture_name"`
-	Language                string                  `json:"language"`
-	Description             string                  `json:"description,omitempty"`
-	ExpectedEntities        []ExpectedEntity        `json:"expected_entities"`
-	ExpectedRelationships   []ExpectedRelationship  `json:"expected_relationships"`
-	ForbiddenRelationships  []ExpectedRelationship  `json:"forbidden_relationships,omitempty"`
+	Name                   string                 `json:"fixture_name"`
+	Language               string                 `json:"language"`
+	Description            string                 `json:"description,omitempty"`
+	ExpectedEntities       []ExpectedEntity       `json:"expected_entities"`
+	ExpectedRelationships  []ExpectedRelationship `json:"expected_relationships"`
+	ForbiddenRelationships []ExpectedRelationship `json:"forbidden_relationships,omitempty"`
 }
 
 // ExpectedEntity is a hand-curated assertion about what the indexer SHOULD
@@ -87,17 +87,17 @@ type ExpectedEntity struct {
 // django.db.models.Model.objects.filter), the harness also accepts an
 // edge whose ToID matches ToBareName directly (no entity lookup required).
 type ExpectedRelationship struct {
-	FromName     string `json:"from_name"`
-	FromKind     string `json:"from_kind,omitempty"`
-	FromFile     string `json:"from_file,omitempty"`
-	Kind         string `json:"kind"`
-	ToName       string `json:"to_name,omitempty"`
-	ToKind       string `json:"to_kind,omitempty"`
-	ToFile       string `json:"to_file,omitempty"`
-	ToBareName   string `json:"to_bare_name,omitempty"`
-	MustExist    bool   `json:"must_exist"`
-	NiceToHave   bool   `json:"nice_to_have,omitempty"`
-	Note         string `json:"note,omitempty"`
+	FromName   string `json:"from_name"`
+	FromKind   string `json:"from_kind,omitempty"`
+	FromFile   string `json:"from_file,omitempty"`
+	Kind       string `json:"kind"`
+	ToName     string `json:"to_name,omitempty"`
+	ToKind     string `json:"to_kind,omitempty"`
+	ToFile     string `json:"to_file,omitempty"`
+	ToBareName string `json:"to_bare_name,omitempty"`
+	MustExist  bool   `json:"must_exist"`
+	NiceToHave bool   `json:"nice_to_have,omitempty"`
+	Note       string `json:"note,omitempty"`
 }
 
 // LoadFixture reads expected.json from the given fixture directory.

--- a/internal/quality/report.go
+++ b/internal/quality/report.go
@@ -10,23 +10,23 @@ import (
 // --json`. It is intentionally flat so CI dashboards / regression diff
 // scripts can aggregate without depending on the in-process Report type.
 type JSONReport struct {
-	Fixture                  string  `json:"fixture"`
-	EntityExpected           int     `json:"entity_expected"`
-	EntityFound              int     `json:"entity_found"`
-	EntityRecall             float64 `json:"entity_recall"`
-	EntityExtractedTotal     int     `json:"entity_extracted_total"`
-	RelationshipExpected     int     `json:"relationship_expected"`
-	RelationshipFound        int     `json:"relationship_found"`
-	RelationshipRecall       float64 `json:"relationship_recall"`
-	RelationshipExtractedTotal int   `json:"relationship_extracted_total"`
-	ForbiddenHits            int     `json:"forbidden_hits"`
-	NiceEntityFound          int     `json:"nice_entity_found"`
-	NiceEntityTotal          int     `json:"nice_entity_total"`
-	NiceRelFound             int     `json:"nice_relationship_found"`
-	NiceRelTotal             int     `json:"nice_relationship_total"`
+	Fixture                    string  `json:"fixture"`
+	EntityExpected             int     `json:"entity_expected"`
+	EntityFound                int     `json:"entity_found"`
+	EntityRecall               float64 `json:"entity_recall"`
+	EntityExtractedTotal       int     `json:"entity_extracted_total"`
+	RelationshipExpected       int     `json:"relationship_expected"`
+	RelationshipFound          int     `json:"relationship_found"`
+	RelationshipRecall         float64 `json:"relationship_recall"`
+	RelationshipExtractedTotal int     `json:"relationship_extracted_total"`
+	ForbiddenHits              int     `json:"forbidden_hits"`
+	NiceEntityFound            int     `json:"nice_entity_found"`
+	NiceEntityTotal            int     `json:"nice_entity_total"`
+	NiceRelFound               int     `json:"nice_relationship_found"`
+	NiceRelTotal               int     `json:"nice_relationship_total"`
 
 	// Per-item details so a human can see WHICH expectations missed.
-	MissingEntities      []missingEntity      `json:"missing_entities,omitempty"`
+	MissingEntities      []missingEntity       `json:"missing_entities,omitempty"`
 	MissingRelationships []missingRelationship `json:"missing_relationships,omitempty"`
 	Forbidden            []missingRelationship `json:"forbidden,omitempty"`
 }

--- a/internal/treesitter/parser.go
+++ b/internal/treesitter/parser.go
@@ -106,7 +106,7 @@ func init() {
 		// component default-exported entities (BrandLogo, LoadingEllipsis,
 		// etc.) never make it into the graph — landing every importing
 		// IMPORTS edge in bug-extractor.
-		"tsx": tsx.GetLanguage(),
+		"tsx":  tsx.GetLanguage(),
 		"yaml": yaml.GetLanguage(),
 	}
 }


### PR DESCRIPTION
Fixes gofmt drift in 8 files that's been failing CI on every PR since #623. Pure whitespace/formatting changes — `git diff -w` is empty (one stray blank line removed). `go test ./...` passes.

## Files fixed
- internal/engine/http_endpoint_resolve.go
- internal/enrichment/repair_edge_test.go
- internal/external/synth.go
- internal/links/import_pass.go
- internal/quality/diff.go
- internal/quality/expected.go
- internal/quality/report.go
- internal/treesitter/parser.go

## Residual root cause
Multiple parallel PRs landed without running gofmt; original drift introduced by quality-fixtures PRs.

## Status
at-ship-gate (CI green after this lands)