### PR TITLE
[#545] ADR-0015 Phase-1 — repair.json reader + apply path with R1-R7 trust model

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -76,6 +76,13 @@ type Indexer struct {
 	// (#545) lands before the writer is flipped on by default in #546.
 	enableRepairCandidates bool
 
+	// enableRepairApply toggles ADR-0015 phase-1 repair.json read+apply
+	// (issue #545). Default false during phase-1 rollout. When true, the
+	// indexer reads <repo>/.archigraph/repair.json BEFORE the final
+	// disposition reclassification pass and rewrites edges per the
+	// trust-model rules in docs/specs/repair-trust-model.md.
+	enableRepairApply bool
+
 	// Statistics — populated as passes run, surfaced in the final summary.
 	stats indexerStats
 
@@ -100,6 +107,16 @@ type IndexOption func(*Indexer)
 // bug-resolver disposition. Default is false.
 func WithRepairCandidates(enabled bool) IndexOption {
 	return func(i *Indexer) { i.enableRepairCandidates = enabled }
+}
+
+// WithRepairApply toggles ADR-0015 phase-1 repair.json apply (issue #545).
+// When true the indexer reads <repo>/.archigraph/repair.json before the
+// final disposition reclassification and applies allowlisted rewrites
+// (bind_to_entity / reclassify_* / abandon) per the trust model. Default
+// is false; pair with --enable-repair-candidates for the full
+// emit → human/agent writes → apply loop.
+func WithRepairApply(enabled bool) IndexOption {
+	return func(i *Indexer) { i.enableRepairApply = enabled }
 }
 
 type indexerStats struct {
@@ -338,6 +355,35 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			extStats.Synthesized, extStats.RelationshipsResolved, extStats.UniqueExternals)
 	}
 	i.stats.extSynth = extStats
+
+	// ADR-0015 phase-1 (#545) — repair.json apply path. Runs BEFORE the
+	// final reclassification so the bug-rate measurement that follows
+	// already reflects agent-supplied repairs. The disposition classifier
+	// core is unchanged — repairs land via the override hook here,
+	// mutating ToID + edge properties; classification then sees the
+	// rewritten edges as ordinary resolved/external/dynamic endpoints.
+	//
+	// Default-off (--enable-repair-apply false) so existing bug-rate
+	// measurements across the 10-corpus regression set stay unchanged.
+	if i.enableRepairApply {
+		archigraphDir := filepath.Join(absRepo, ".archigraph")
+		repairs, rerr := enrichment.ReadRepairs(archigraphDir)
+		if rerr != nil {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: repair.json read error (continuing without): %v\n", rerr)
+		}
+		repairStats := enrichment.ApplyRepairs(doc, repairs,
+			enrichment.ApplyRepairsOptions{RepoRoot: absRepo})
+		if werr := enrichment.WriteRepairStats(archigraphDir, repairStats); werr != nil {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: repair_stats.json write failed: %v\n", werr)
+		}
+		if verbose() {
+			fmt.Fprintf(os.Stderr,
+				"repair-apply: applied=%d rejected=%d stale=%d (ADR-0015 phase-1)\n",
+				repairStats.AppliedCount, repairStats.RejectedCount, repairStats.StaleCount)
+		}
+	}
 
 	// VERIFY-2-PREP / issue #56 — reclassify dispositions over the FINAL
 	// edge state (post-external-synthesis) so "ext:<pkg>" endpoints land in

--- a/cmd/archigraph/main.go
+++ b/cmd/archigraph/main.go
@@ -31,6 +31,7 @@ func runIndex(argv []string) error {
 	pretty := fs.Bool("pretty", false, "emit indented JSON for graph.json and graph-stats.json (default: minified)")
 	jsonStats := fs.Bool("json-stats", false, "emit per-run statistics (entities, relationships, dispositions, bug-rate) to stdout as JSON")
 	enableRepair := fs.Bool("enable-repair-candidates", false, "emit ADR-0015 phase-1 repair_edge entries into enrichment-candidates.json (issue #544; default false during phase-1 rollout)")
+	enableRepairApply := fs.Bool("enable-repair-apply", false, "read <repo>/.archigraph/repair.json and apply allowlisted repairs before disposition classification (issue #545 / ADR-0015 phase-1; default false during phase-1 rollout)")
 	if err := fs.Parse(argv); err != nil {
 		return err
 	}
@@ -44,7 +45,8 @@ func runIndex(argv []string) error {
 		skipPasses = []string{*skip}
 	}
 	return Index(repoPath, *out, *repoTag, skipPasses, *pretty, *jsonStats,
-		WithRepairCandidates(*enableRepair))
+		WithRepairCandidates(*enableRepair),
+		WithRepairApply(*enableRepairApply))
 }
 
 // runLinksHook is wired into cli.Hooks so the watcher can re-run cross-

--- a/internal/enrichment/repair_apply.go
+++ b/internal/enrichment/repair_apply.go
@@ -1,0 +1,469 @@
+package enrichment
+
+// repair_apply implements the reader + apply path for ADR-0015 phase-1
+// repair.json (issue #545). Sibling to repair_edge.go, which is the writer
+// side (#544).
+//
+// Lifecycle:
+//   1. ReadRepairs(<repo>/.archigraph/repair.json) → []Repair
+//   2. ApplyRepairs(doc, repairs, opts) BEFORE the indexer's final
+//      ClassifyEndpoints reclassify pass. Mutates doc.Relationships in
+//      place: rewrites ToID for binds/reclassifies, drops abandons,
+//      tags affected edges with resolved_by="agent-repair" and
+//      repair_reasoning=<verbatim text>.
+//   3. WriteRepairStats(<repo>/.archigraph/repair_stats.json, stats) so the
+//      operator can audit which repairs landed and which were dropped.
+//
+// Trust model (R1-R7) matches docs/specs/repair-trust-model.md. Every
+// rejection records the edge_id and a reason code; the agent re-fetches
+// candidates and re-submits.
+//
+// This module is purely additive. With --enable-repair-apply OFF the
+// indexer never calls ApplyRepairs, so the default bug-rate measurements
+// are unchanged.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// RepairResolutionKind is the on-disk allowlist. Adding to this set requires
+// an ADR amendment per ADR-0015.
+const (
+	RepairBindToEntity         = "bind_to_entity"
+	RepairReclassifyAsExternal = "reclassify_as_external"
+	RepairReclassifyAsDynamic  = "reclassify_as_dynamic"
+	RepairReclassifyAsResolved = "reclassify_as_resolved"
+	RepairAbandon              = "abandon"
+)
+
+// allowedResolutionKinds is the closed set enforced by R2 / "resolution
+// allowlist". Keep in sync with docs/specs/repair-v1.schema.json.
+var allowedResolutionKinds = map[string]bool{
+	RepairBindToEntity:         true,
+	RepairReclassifyAsExternal: true,
+	RepairReclassifyAsDynamic:  true,
+	RepairReclassifyAsResolved: true,
+	RepairAbandon:              true,
+}
+
+// moduleIdentRe is the R5 (invalid_module_identifier) regex. Matches the
+// JSON-schema pattern from repair-v1.schema.json: leading letter/underscore,
+// then letters/digits/_/-/./. — but disallows ".." traversal and leading
+// dots so an attacker cannot smuggle "ext:../etc/passwd" into the graph.
+var moduleIdentRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_\-./]*$`)
+
+// Repair is one row in repair.json. Mirrors the JSON-schema in
+// docs/specs/repair-v1.schema.json. Field tags use the exact on-disk names.
+type Repair struct {
+	EdgeID         string  `json:"edge_id"`
+	Resolution     string  `json:"resolution"`
+	TargetEntityID string  `json:"target_entity_id,omitempty"`
+	Module         string  `json:"module,omitempty"`
+	NewTarget      string  `json:"new_target,omitempty"`
+	DynamicReason  string  `json:"dynamic_reason,omitempty"`
+	AbandonReason  string  `json:"abandon_reason,omitempty"`
+	Confidence     float64 `json:"confidence"`
+	Reasoning      string  `json:"reasoning"`
+	Source         string  `json:"source"`
+	ResolvedAt     string  `json:"resolved_at"`
+}
+
+// repairFile is the top-level on-disk shape.
+type repairFile struct {
+	SchemaVersion int      `json:"schema_version"`
+	GeneratedAt   string   `json:"generated_at,omitempty"`
+	Repairs       []Repair `json:"repairs"`
+}
+
+// RepairRejection records one (edge_id, reason) pair for the stats sidecar.
+// Reason codes match docs/specs/repair-trust-model.md.
+type RepairRejection struct {
+	EdgeID     string `json:"edge_id"`
+	Resolution string `json:"resolution,omitempty"`
+	Reason     string `json:"reason"`
+}
+
+// RepairAppliedRecord records one successfully-applied repair for the
+// stats sidecar. Order in the file is by edge_id ascending for
+// byte-identical determinism.
+type RepairAppliedRecord struct {
+	EdgeID     string `json:"edge_id"`
+	Resolution string `json:"resolution"`
+}
+
+// RepairStaleRecord records a repair whose edge_id no longer matches any
+// current candidate (R-stale).
+type RepairStaleRecord struct {
+	EdgeID     string `json:"edge_id"`
+	Resolution string `json:"resolution"`
+	ResolvedAt string `json:"resolved_at,omitempty"`
+}
+
+// RepairStats is the on-disk stats sidecar shape. Emitted to
+// <repo>/.archigraph/repair_stats.json on every index run that read a
+// repair.json — even if no repairs applied.
+type RepairStats struct {
+	SchemaVersion int                   `json:"schema_version"`
+	Applied       []RepairAppliedRecord `json:"applied"`
+	Rejected      []RepairRejection     `json:"rejected"`
+	Stale         []RepairStaleRecord   `json:"stale"`
+	AppliedCount  int                   `json:"applied_count"`
+	RejectedCount int                   `json:"rejected_count"`
+	StaleCount    int                   `json:"stale_count"`
+}
+
+// repairPath returns the on-disk path for repair.json.
+func repairPath(archigraphDir string) string {
+	return filepath.Join(archigraphDir, "repair.json")
+}
+
+// repairStatsPath returns the on-disk path for repair_stats.json.
+func repairStatsPath(archigraphDir string) string {
+	return filepath.Join(archigraphDir, "repair_stats.json")
+}
+
+// ReadRepairs reads repair.json from the archigraph dir. Returns nil if
+// the file is absent. Tolerates an empty/whitespace file. Unmarshalling
+// errors are returned so the caller can surface them; the indexer logs
+// and continues with zero repairs.
+func ReadRepairs(archigraphDir string) ([]Repair, error) {
+	data, err := os.ReadFile(repairPath(archigraphDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if len(strings.TrimSpace(string(data))) == 0 {
+		return nil, nil
+	}
+	var rf repairFile
+	if err := json.Unmarshal(data, &rf); err != nil {
+		return nil, fmt.Errorf("parse repair.json: %w", err)
+	}
+	return rf.Repairs, nil
+}
+
+// ApplyRepairsOptions are the knobs the indexer threads through.
+type ApplyRepairsOptions struct {
+	// RepoRoot is the absolute path to the repo being indexed. Reserved
+	// for future repairs that need source-content access; unused today.
+	RepoRoot string
+}
+
+// ApplyRepairs walks doc.Relationships, recomputes each edge's edge_id,
+// looks it up in the repair map, validates the repair per R1-R7, and
+// applies it in place. Abandoned edges are removed from doc.Relationships.
+//
+// Returns RepairStats describing what landed and what was rejected.
+// The stats slices are sorted by edge_id ascending so on-disk output is
+// byte-identical across runs of the same inputs.
+//
+// Invariants:
+//   - doc.Relationships order is preserved for non-abandoned edges.
+//   - doc.Entities is untouched (entity-level repairs are out of scope).
+//   - Repairs without a matching current edge_id are recorded as stale
+//     and never applied (R-stale).
+//   - A repair that fails validation is recorded as rejected; the edge
+//     is left as-is so the static resolver still has a shot at it.
+func ApplyRepairs(doc *graph.Document, repairs []Repair, opts ApplyRepairsOptions) RepairStats {
+	stats := RepairStats{
+		SchemaVersion: 1,
+		Applied:       []RepairAppliedRecord{},
+		Rejected:      []RepairRejection{},
+		Stale:         []RepairStaleRecord{},
+	}
+	if doc == nil {
+		return stats
+	}
+
+	// Build (edge_id → *Repair) and remember the *original* repair for
+	// stale-detection. The same edge_id may appear multiple times in
+	// repair.json (operator hand-edited duplicate); the last wins, but we
+	// still record the dup as rejected with reason "duplicate_edge_id".
+	repairByEdge := make(map[string]*Repair, len(repairs))
+	for ri := range repairs {
+		r := &repairs[ri]
+		if _, exists := repairByEdge[r.EdgeID]; exists {
+			stats.Rejected = append(stats.Rejected, RepairRejection{
+				EdgeID:     r.EdgeID,
+				Resolution: r.Resolution,
+				Reason:     "duplicate_edge_id",
+			})
+			continue
+		}
+		repairByEdge[r.EdgeID] = r
+	}
+
+	// Build (entity_id → kind) lookup for R2 (target_entity_not_found)
+	// and the CONTAINS-hierarchy lookup for R4 (contradicts_contains).
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	containsParents := buildContainsParents(doc)
+
+	// Walk relationships, recompute edge_ids, mark matches as "seen" so
+	// we can detect stale repairs afterwards.
+	seenEdgeIDs := make(map[string]bool, len(doc.Relationships))
+	kept := doc.Relationships[:0]
+
+	for ri := range doc.Relationships {
+		r := &doc.Relationships[ri]
+		// Same emission rules as CollectRepairEdgeCandidates — skip
+		// already-resolved (16-char hex) and ext: stubs so the edge_id
+		// space matches #544's writer exactly.
+		stub := r.ToID
+		if stub == "" || isHexID(stub) || strings.HasPrefix(stub, "ext:") {
+			kept = append(kept, *r)
+			continue
+		}
+		edgeID := repairEdgeID(r.FromID, r.Kind, stub)
+		seenEdgeIDs[edgeID] = true
+
+		rep, ok := repairByEdge[edgeID]
+		if !ok {
+			kept = append(kept, *r)
+			continue
+		}
+
+		// Validate per R1-R7. R1 (edge_id_unknown) is the seen-set check
+		// done later; here the edge_id is known by construction.
+		if reason := validateRepair(rep, r, byID, containsParents); reason != "" {
+			stats.Rejected = append(stats.Rejected, RepairRejection{
+				EdgeID:     edgeID,
+				Resolution: rep.Resolution,
+				Reason:     reason,
+			})
+			kept = append(kept, *r)
+			continue
+		}
+
+		// Apply.
+		newR, drop := applyOneRepair(*r, rep)
+		if !drop {
+			kept = append(kept, newR)
+		}
+		stats.Applied = append(stats.Applied, RepairAppliedRecord{
+			EdgeID:     edgeID,
+			Resolution: rep.Resolution,
+		})
+	}
+	doc.Relationships = kept
+
+	// Stale detection — any repair whose edge_id was never seen in the
+	// current relationship walk is stale. R-stale per the trust model.
+	for edgeID, rep := range repairByEdge {
+		if seenEdgeIDs[edgeID] {
+			continue
+		}
+		// If the repair was already rejected (e.g. duplicate), don't
+		// double-count it as stale.
+		alreadyRejected := false
+		for _, rj := range stats.Rejected {
+			if rj.EdgeID == edgeID && rj.Reason == "duplicate_edge_id" {
+				alreadyRejected = true
+				break
+			}
+		}
+		if alreadyRejected {
+			continue
+		}
+		stats.Stale = append(stats.Stale, RepairStaleRecord{
+			EdgeID:     edgeID,
+			Resolution: rep.Resolution,
+			ResolvedAt: rep.ResolvedAt,
+		})
+	}
+
+	// Sort for deterministic output (ADR-0015 references #486).
+	sort.SliceStable(stats.Applied, func(i, j int) bool {
+		return stats.Applied[i].EdgeID < stats.Applied[j].EdgeID
+	})
+	sort.SliceStable(stats.Rejected, func(i, j int) bool {
+		return stats.Rejected[i].EdgeID < stats.Rejected[j].EdgeID
+	})
+	sort.SliceStable(stats.Stale, func(i, j int) bool {
+		return stats.Stale[i].EdgeID < stats.Stale[j].EdgeID
+	})
+	stats.AppliedCount = len(stats.Applied)
+	stats.RejectedCount = len(stats.Rejected)
+	stats.StaleCount = len(stats.Stale)
+	return stats
+}
+
+// validateRepair runs R2-R7 trust-model checks. Returns a non-empty reason
+// code on rejection; "" means the repair is safe to apply.
+//
+// R1 (edge_id_unknown) is not handled here — that's the caller's
+// "not in current edge set" check. R-stale is the inverse of R1 and is
+// also handled by the caller.
+func validateRepair(
+	rep *Repair,
+	edge *graph.Relationship,
+	byID map[string]*graph.Entity,
+	containsParents map[string]map[string]bool,
+) string {
+	// R-allowlist (closed set of resolution kinds).
+	if !allowedResolutionKinds[rep.Resolution] {
+		return "resolution_kind_unsupported"
+	}
+	// R7 — reasoning must be substantive.
+	if strings.TrimSpace(rep.Reasoning) == "" {
+		return "reasoning_too_short"
+	}
+	// R6 — conditional required fields per resolution kind.
+	switch rep.Resolution {
+	case RepairBindToEntity:
+		if rep.TargetEntityID == "" {
+			return "missing_required_field"
+		}
+		// R2 — target entity must exist.
+		target, ok := byID[rep.TargetEntityID]
+		if !ok || target == nil {
+			return "target_entity_not_found"
+		}
+		// R3 — no self-loop.
+		if rep.TargetEntityID == edge.FromID {
+			return "self_loop_disallowed"
+		}
+		// R4 — target cannot be a CONTAINS ancestor of from.
+		if ancestors, ok := containsParents[edge.FromID]; ok {
+			if ancestors[rep.TargetEntityID] {
+				return "contradicts_contains_hierarchy"
+			}
+		}
+	case RepairReclassifyAsExternal:
+		if rep.Module == "" {
+			return "missing_required_field"
+		}
+		if !moduleIdentRe.MatchString(rep.Module) ||
+			strings.Contains(rep.Module, "..") ||
+			strings.HasPrefix(rep.Module, "/") {
+			return "invalid_module_identifier"
+		}
+	case RepairReclassifyAsDynamic:
+		if strings.TrimSpace(rep.DynamicReason) == "" {
+			return "missing_required_field"
+		}
+	case RepairReclassifyAsResolved:
+		if strings.TrimSpace(rep.NewTarget) == "" {
+			return "missing_required_field"
+		}
+	case RepairAbandon:
+		if strings.TrimSpace(rep.AbandonReason) == "" {
+			return "missing_required_field"
+		}
+	}
+	return ""
+}
+
+// applyOneRepair returns the rewritten relationship and a drop=true flag
+// for abandon. The original is copied — the slice element is replaced
+// wholesale so callers don't have to worry about aliasing.
+func applyOneRepair(r graph.Relationship, rep *Repair) (graph.Relationship, bool) {
+	if rep.Resolution == RepairAbandon {
+		return r, true
+	}
+	if r.Properties == nil {
+		r.Properties = make(map[string]string, 4)
+	}
+	// R6 (audit) — every applied edge carries resolved_by + reasoning.
+	r.Properties["resolved_by"] = "agent-repair"
+	r.Properties["repair_reasoning"] = rep.Reasoning
+
+	switch rep.Resolution {
+	case RepairBindToEntity:
+		r.ToID = rep.TargetEntityID
+		// disposition becomes Resolved on the next ClassifyEndpoints
+		// pass because ToID is now a hex entity id.
+	case RepairReclassifyAsExternal:
+		r.ToID = "ext:" + rep.Module
+		// disposition becomes ExternalKnown (assuming the allowlist
+		// contains the module; otherwise ExternalUnknown — that's
+		// acceptable, the agent told us it's external).
+	case RepairReclassifyAsResolved:
+		r.ToID = rep.NewTarget
+		// Mark resolved-by-agent so the static resolver's
+		// re-resolution pass skips this edge.
+		r.Properties["repair_kind"] = "reclassify_as_resolved"
+	case RepairReclassifyAsDynamic:
+		// ToID stays — but tag the edge so the resolver's dynamic
+		// classifier treats it as dynamic on the next pass.
+		r.Properties["repair_kind"] = "reclassify_as_dynamic"
+		r.Properties["dynamic_reason"] = rep.DynamicReason
+	}
+	return r, false
+}
+
+// buildContainsParents returns (entity_id → set of ancestor entity_ids
+// via CONTAINS edges) for R4. The walk is bounded to a single depth-first
+// traversal; cycles are guarded by a visited set so a pathological
+// hand-built graph doesn't loop forever.
+func buildContainsParents(doc *graph.Document) map[string]map[string]bool {
+	// children[c] = set of parents linked via "CONTAINS"
+	directParents := make(map[string]map[string]bool, len(doc.Entities))
+	for ri := range doc.Relationships {
+		r := &doc.Relationships[ri]
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		if directParents[r.ToID] == nil {
+			directParents[r.ToID] = map[string]bool{}
+		}
+		directParents[r.ToID][r.FromID] = true
+	}
+	// Walk transitively. For each entity, accumulate the closure of its
+	// direct parents.
+	out := make(map[string]map[string]bool, len(directParents))
+	var walk func(id string, acc map[string]bool, seen map[string]bool)
+	walk = func(id string, acc map[string]bool, seen map[string]bool) {
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		for p := range directParents[id] {
+			acc[p] = true
+			walk(p, acc, seen)
+		}
+	}
+	for id := range directParents {
+		acc := map[string]bool{}
+		walk(id, acc, map[string]bool{})
+		out[id] = acc
+	}
+	return out
+}
+
+// WriteRepairStats writes repair_stats.json to the archigraph dir.
+// Always-emit-on-read so audit history is preserved even when no repairs
+// applied. The on-disk bytes are stable across runs of the same input
+// (see sort.SliceStable above + the schema_version pin).
+func WriteRepairStats(archigraphDir string, stats RepairStats) error {
+	if err := os.MkdirAll(archigraphDir, 0o755); err != nil {
+		return err
+	}
+	data, err := json.MarshalIndent(stats, "", "  ")
+	if err != nil {
+		return err
+	}
+	data = append(data, '\n')
+	return os.WriteFile(repairStatsPath(archigraphDir), data, 0o644)
+}
+
+// RepairEdgeID exposes the writer-side hash for callers that need to
+// reproduce edge_ids outside this package (the indexer's apply hook
+// computes one per relationship). Keeping the name capitalised here while
+// the unexported helper stays for #544's internal use means a future
+// refactor can move the implementation without breaking either side.
+func RepairEdgeID(fromID, relation, originalStub string) string {
+	return repairEdgeID(fromID, relation, originalStub)
+}

--- a/internal/enrichment/repair_apply_test.go
+++ b/internal/enrichment/repair_apply_test.go
@@ -1,0 +1,407 @@
+package enrichment
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// mkDoc builds a minimal Document for apply-path tests. Entities a/b/c
+// are real (hex ids); rels start as bare stubs so they're candidates for
+// repair.
+func mkRepairDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Kind: "Function", Name: "caller", SourceFile: "a.py", StartLine: 1, Language: "python"},
+			{ID: "bbbbbbbbbbbbbbbb", Kind: "Function", Name: "target", SourceFile: "b.py", StartLine: 1, Language: "python"},
+			{ID: "cccccccccccccccc", Kind: "Class", Name: "Wrapper", SourceFile: "a.py", StartLine: 1, Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			// Bug-style stub edge.
+			{ID: "r1", FromID: "aaaaaaaaaaaaaaaa", ToID: "Function:target", Kind: "CALLS"},
+			// CONTAINS edge: Wrapper contains caller. Used in R4.
+			{ID: "r2", FromID: "cccccccccccccccc", ToID: "aaaaaaaaaaaaaaaa", Kind: "CONTAINS"},
+		},
+	}
+}
+
+func edgeIDFor(t *testing.T, doc *graph.Document, idx int) string {
+	t.Helper()
+	r := doc.Relationships[idx]
+	return repairEdgeID(r.FromID, r.Kind, r.ToID)
+}
+
+// TestApplyRepairs_BindToEntity_Success — happy path. Bind a bare stub to
+// the real "bbbbbbbbbbbbbbbb" function. After apply, the ToID is rewritten
+// and the edge carries resolved_by + repair_reasoning.
+func TestApplyRepairs_BindToEntity_Success(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         eid,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "bbbbbbbbbbbbbbbb",
+		Confidence:     0.9,
+		Reasoning:      "imported from b.py per import line",
+		Source:         "agent-repair",
+		ResolvedAt:     "2026-05-19T07:00:00Z",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d, want 1; rejected=%+v", stats.AppliedCount, stats.Rejected)
+	}
+	r := doc.Relationships[0]
+	if r.ToID != "bbbbbbbbbbbbbbbb" {
+		t.Fatalf("ToID = %q, want hex target", r.ToID)
+	}
+	if r.Properties["resolved_by"] != "agent-repair" {
+		t.Fatalf("resolved_by = %q, want agent-repair", r.Properties["resolved_by"])
+	}
+	if !strings.Contains(r.Properties["repair_reasoning"], "imported from b.py") {
+		t.Fatalf("repair_reasoning = %q", r.Properties["repair_reasoning"])
+	}
+}
+
+// R2 — bind_to_entity target must exist. Unknown id → rejected with
+// target_entity_not_found; edge is left alone.
+func TestApplyRepairs_R2_TargetEntityNotFound(t *testing.T) {
+	doc := mkRepairDoc()
+	original := doc.Relationships[0].ToID
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         eid,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "deadbeefdeadbeef",
+		Reasoning:      "guessing",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 0 || len(stats.Rejected) != 1 {
+		t.Fatalf("applied=%d rejected=%d, want 0/1", stats.AppliedCount, len(stats.Rejected))
+	}
+	if stats.Rejected[0].Reason != "target_entity_not_found" {
+		t.Fatalf("reason = %q", stats.Rejected[0].Reason)
+	}
+	if doc.Relationships[0].ToID != original {
+		t.Fatalf("edge mutated despite rejection: %q", doc.Relationships[0].ToID)
+	}
+}
+
+// R3 — bind_to_entity must not be a self-loop.
+func TestApplyRepairs_R3_SelfLoopDisallowed(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         eid,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "aaaaaaaaaaaaaaaa", // == FromID
+		Reasoning:      "loop",
+	}}, ApplyRepairsOptions{})
+	if len(stats.Rejected) != 1 || stats.Rejected[0].Reason != "self_loop_disallowed" {
+		t.Fatalf("rejected=%+v", stats.Rejected)
+	}
+}
+
+// R4 — bind_to_entity cannot contradict CONTAINS hierarchy. doc has
+// Wrapper CONTAINS caller; binding caller's CALLS edge to Wrapper would
+// create a method→containing-class edge via repair.
+func TestApplyRepairs_R4_ContradictsContainsHierarchy(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         eid,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "cccccccccccccccc", // CONTAINS-ancestor of FromID
+		Reasoning:      "wrong",
+	}}, ApplyRepairsOptions{})
+	if len(stats.Rejected) != 1 || stats.Rejected[0].Reason != "contradicts_contains_hierarchy" {
+		t.Fatalf("rejected=%+v", stats.Rejected)
+	}
+}
+
+// R5 — repair becomes stale when no current edge matches its edge_id.
+// Source moved → edge_id changed → repair is dropped (not applied),
+// listed in stats.Stale.
+func TestApplyRepairs_R5_StaleRepairDetected(t *testing.T) {
+	doc := mkRepairDoc()
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         "er:0000000000000000",
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "bbbbbbbbbbbbbbbb",
+		Reasoning:      "x",
+		ResolvedAt:     "2026-05-19T07:00:00Z",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 0 {
+		t.Fatalf("stale repair was applied")
+	}
+	if len(stats.Stale) != 1 || stats.Stale[0].EdgeID != "er:0000000000000000" {
+		t.Fatalf("stale = %+v", stats.Stale)
+	}
+}
+
+// R6 — applied edges carry resolved_by=agent-repair tag.
+func TestApplyRepairs_R6_ResolvedByTag(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	ApplyRepairs(doc, []Repair{{
+		EdgeID:         eid,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "bbbbbbbbbbbbbbbb",
+		Reasoning:      "ok",
+	}}, ApplyRepairsOptions{})
+	if doc.Relationships[0].Properties["resolved_by"] != "agent-repair" {
+		t.Fatalf("R6 violated")
+	}
+}
+
+// R7 — reasoning text is persisted on the edge as repair_reasoning.
+// (Trust-model R7 is also about empty reasoning being rejected.)
+func TestApplyRepairs_R7_ReasoningPersistedAndRejectedIfEmpty(t *testing.T) {
+	t.Run("persisted", func(t *testing.T) {
+		doc := mkRepairDoc()
+		eid := edgeIDFor(t, doc, 0)
+		ApplyRepairs(doc, []Repair{{
+			EdgeID:         eid,
+			Resolution:     RepairBindToEntity,
+			TargetEntityID: "bbbbbbbbbbbbbbbb",
+			Reasoning:      "verbatim reasoning text",
+		}}, ApplyRepairsOptions{})
+		if doc.Relationships[0].Properties["repair_reasoning"] != "verbatim reasoning text" {
+			t.Fatalf("reasoning lost: %q", doc.Relationships[0].Properties["repair_reasoning"])
+		}
+	})
+	t.Run("rejected_if_empty", func(t *testing.T) {
+		doc := mkRepairDoc()
+		eid := edgeIDFor(t, doc, 0)
+		stats := ApplyRepairs(doc, []Repair{{
+			EdgeID:         eid,
+			Resolution:     RepairBindToEntity,
+			TargetEntityID: "bbbbbbbbbbbbbbbb",
+			Reasoning:      "   ",
+		}}, ApplyRepairsOptions{})
+		if len(stats.Rejected) != 1 || stats.Rejected[0].Reason != "reasoning_too_short" {
+			t.Fatalf("rejected=%+v", stats.Rejected)
+		}
+	})
+}
+
+// R-allowlist — unknown resolution kinds are rejected.
+func TestApplyRepairs_ResolutionKindUnsupported(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:     eid,
+		Resolution: "vibes_based",
+		Reasoning:  "trust me",
+	}}, ApplyRepairsOptions{})
+	if len(stats.Rejected) != 1 || stats.Rejected[0].Reason != "resolution_kind_unsupported" {
+		t.Fatalf("rejected=%+v", stats.Rejected)
+	}
+}
+
+// reclassify_as_external happy path: ToID becomes ext:<module>.
+func TestApplyRepairs_ReclassifyAsExternal_Success(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:     eid,
+		Resolution: RepairReclassifyAsExternal,
+		Module:     "django.db.models",
+		Reasoning:  "imported from django",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d rejected=%+v", stats.AppliedCount, stats.Rejected)
+	}
+	if doc.Relationships[0].ToID != "ext:django.db.models" {
+		t.Fatalf("ToID = %q", doc.Relationships[0].ToID)
+	}
+}
+
+// R5-module-form — reclassify_as_external rejects path-traversal modules.
+func TestApplyRepairs_InvalidModuleIdentifier(t *testing.T) {
+	for _, bad := range []string{"../etc/passwd", "/absolute", "has spaces", ""} {
+		t.Run(bad, func(t *testing.T) {
+			doc := mkRepairDoc()
+			eid := edgeIDFor(t, doc, 0)
+			stats := ApplyRepairs(doc, []Repair{{
+				EdgeID:     eid,
+				Resolution: RepairReclassifyAsExternal,
+				Module:     bad,
+				Reasoning:  "x",
+			}}, ApplyRepairsOptions{})
+			if len(stats.Rejected) != 1 {
+				t.Fatalf("rejected=%+v for module=%q", stats.Rejected, bad)
+			}
+			// Empty module is missing_required_field; others are invalid_module_identifier.
+			want := "invalid_module_identifier"
+			if bad == "" {
+				want = "missing_required_field"
+			}
+			if stats.Rejected[0].Reason != want {
+				t.Fatalf("reason=%q want=%q for module=%q", stats.Rejected[0].Reason, want, bad)
+			}
+		})
+	}
+}
+
+// abandon: edge is dropped from doc.Relationships entirely.
+func TestApplyRepairs_Abandon_DropsEdge(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	before := len(doc.Relationships)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:        eid,
+		Resolution:    RepairAbandon,
+		AbandonReason: "no useful binding exists",
+		Reasoning:     "abandon",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d", stats.AppliedCount)
+	}
+	if len(doc.Relationships) != before-1 {
+		t.Fatalf("rel count = %d, want %d", len(doc.Relationships), before-1)
+	}
+}
+
+// reclassify_as_dynamic — ToID unchanged, dynamic_reason persisted.
+func TestApplyRepairs_ReclassifyAsDynamic(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	originalToID := doc.Relationships[0].ToID
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:        eid,
+		Resolution:    RepairReclassifyAsDynamic,
+		DynamicReason: "env-var-route",
+		Reasoning:     "name comes from $ROUTE",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d rejected=%+v", stats.AppliedCount, stats.Rejected)
+	}
+	if doc.Relationships[0].ToID != originalToID {
+		t.Fatalf("dynamic reclassify changed ToID")
+	}
+	if doc.Relationships[0].Properties["dynamic_reason"] != "env-var-route" {
+		t.Fatalf("dynamic_reason lost")
+	}
+}
+
+// reclassify_as_resolved — ToID becomes new_target verbatim.
+func TestApplyRepairs_ReclassifyAsResolved(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:     eid,
+		Resolution: RepairReclassifyAsResolved,
+		NewTarget:  "xrepo:other-svc::Handler.run",
+		Reasoning:  "cross-repo target",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d rejected=%+v", stats.AppliedCount, stats.Rejected)
+	}
+	if doc.Relationships[0].ToID != "xrepo:other-svc::Handler.run" {
+		t.Fatalf("ToID = %q", doc.Relationships[0].ToID)
+	}
+}
+
+// missing_required_field — bind_to_entity without target_entity_id is rejected.
+func TestApplyRepairs_MissingRequiredField(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:     eid,
+		Resolution: RepairBindToEntity,
+		Reasoning:  "no target",
+	}}, ApplyRepairsOptions{})
+	if len(stats.Rejected) != 1 || stats.Rejected[0].Reason != "missing_required_field" {
+		t.Fatalf("rejected=%+v", stats.Rejected)
+	}
+}
+
+// duplicate edge_id — last wins, dup recorded as rejected.
+func TestApplyRepairs_DuplicateEdgeID(t *testing.T) {
+	doc := mkRepairDoc()
+	eid := edgeIDFor(t, doc, 0)
+	stats := ApplyRepairs(doc, []Repair{
+		{EdgeID: eid, Resolution: RepairBindToEntity, TargetEntityID: "bbbbbbbbbbbbbbbb", Reasoning: "first"},
+		{EdgeID: eid, Resolution: RepairBindToEntity, TargetEntityID: "bbbbbbbbbbbbbbbb", Reasoning: "second"},
+	}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 1 {
+		t.Fatalf("applied=%d", stats.AppliedCount)
+	}
+	gotDup := false
+	for _, rj := range stats.Rejected {
+		if rj.Reason == "duplicate_edge_id" {
+			gotDup = true
+		}
+	}
+	if !gotDup {
+		t.Fatalf("expected duplicate_edge_id rejection, got %+v", stats.Rejected)
+	}
+}
+
+// ReadRepairs round-trip from disk.
+func TestReadRepairs_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	rf := repairFile{
+		SchemaVersion: 1,
+		Repairs: []Repair{{
+			EdgeID: "er:abcdefabcdefabcd", Resolution: RepairBindToEntity,
+			TargetEntityID: "1111111111111111", Confidence: 1,
+			Reasoning: "x", Source: "agent-repair", ResolvedAt: "2026-05-19T00:00:00Z",
+		}},
+	}
+	data, _ := json.MarshalIndent(rf, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmp, "repair.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadRepairs(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != 1 || got[0].EdgeID != "er:abcdefabcdefabcd" {
+		t.Fatalf("got = %+v", got)
+	}
+}
+
+// ReadRepairs returns (nil, nil) when the file is absent.
+func TestReadRepairs_Absent(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := ReadRepairs(tmp)
+	if err != nil || got != nil {
+		t.Fatalf("got=%v err=%v, want nil/nil", got, err)
+	}
+}
+
+// WriteRepairStats writes a valid JSON document with sorted slices.
+func TestWriteRepairStats_Deterministic(t *testing.T) {
+	tmp := t.TempDir()
+	stats := RepairStats{
+		SchemaVersion: 1,
+		Applied:       []RepairAppliedRecord{{EdgeID: "er:b", Resolution: "bind_to_entity"}, {EdgeID: "er:a", Resolution: "abandon"}},
+	}
+	// Caller is expected to pre-sort; the writer doesn't re-sort.
+	if err := WriteRepairStats(tmp, stats); err != nil {
+		t.Fatal(err)
+	}
+	data, _ := os.ReadFile(filepath.Join(tmp, "repair_stats.json"))
+	if !strings.Contains(string(data), `"applied_count"`) {
+		t.Fatalf("stats file = %s", data)
+	}
+}
+
+// Integration check — when --enable-repair-apply is OFF (i.e. ApplyRepairs
+// is never called), the document is byte-identical to baseline. We
+// simulate this by checking that the function is a pure no-op when
+// repairs is empty.
+func TestApplyRepairs_NoRepairs_NoOp(t *testing.T) {
+	doc := mkRepairDoc()
+	beforeRels := len(doc.Relationships)
+	stats := ApplyRepairs(doc, nil, ApplyRepairsOptions{})
+	if stats.AppliedCount != 0 || stats.RejectedCount != 0 || stats.StaleCount != 0 {
+		t.Fatalf("non-empty stats on empty repairs: %+v", stats)
+	}
+	if len(doc.Relationships) != beforeRels {
+		t.Fatalf("relationships changed on empty repairs")
+	}
+}


### PR DESCRIPTION
## Summary

Reads `<repo>/.archigraph/repair.json` before the final disposition classification pass and applies allowlisted repairs per the trust model in `docs/specs/repair-trust-model.md`. Default-off (`--enable-repair-apply`) — pair with #544's `--enable-repair-candidates` for the full emit → agent writes → apply cycle.

## Trust-rule coverage (R1-R7)

Every rule has a dedicated unit test:

| Rule | Reason code | Test |
|---|---|---|
| R1 / R-stale | `(stale)` | `TestApplyRepairs_R5_StaleRepairDetected` |
| R2 — target_entity_not_found | `target_entity_not_found` | `TestApplyRepairs_R2_TargetEntityNotFound` |
| R3 — self-loop disallowed | `self_loop_disallowed` | `TestApplyRepairs_R3_SelfLoopDisallowed` |
| R4 — contradicts CONTAINS hierarchy | `contradicts_contains_hierarchy` | `TestApplyRepairs_R4_ContradictsContainsHierarchy` |
| R5 — invalid module identifier | `invalid_module_identifier` | `TestApplyRepairs_InvalidModuleIdentifier` |
| R6 — missing required field | `missing_required_field` | `TestApplyRepairs_MissingRequiredField` |
| R7 — reasoning persisted / empty | `reasoning_too_short` | `TestApplyRepairs_R7_ReasoningPersistedAndRejectedIfEmpty` |
| Allowlist | `resolution_kind_unsupported` | `TestApplyRepairs_ResolutionKindUnsupported` |

Plus happy-path tests for each of the five resolution kinds (`bind_to_entity`, `reclassify_as_external`, `reclassify_as_dynamic`, `reclassify_as_resolved`, `abandon`), `ReadRepairs` round-trip, `WriteRepairStats` schema, duplicate-edge_id handling, and an explicit no-op-on-empty assertion. 18 tests total, all passing.

## End-to-end demo (python-django-mini)

Hand-crafted `repair.json` with three repairs:
- `bind_to_entity` — SERVES edge → `health_check` operation
- `reclassify_as_external` — `EXTENDS View` → `django.views.generic.View`
- `abandon` — `EXTENDS AppConfig` (no useful binding)

Result:
```
repair-apply: applied=3 rejected=0 stale=0 (ADR-0015 phase-1)
bug-rate: 4.7% → 4.1%
```

The two non-abandoned edges carry `resolved_by=agent-repair` and the verbatim `repair_reasoning` text. Stale detection verified by mangling one `edge_id` post-write: `applied=2 stale=1`.

## Regression confirmation

With `--enable-repair-apply` OFF (or ON but no `repair.json` present), all five mini corpora produce byte-identical entity + relationship ID sets vs baseline:

| Corpus | ent (base/flag) | rel (base/flag) | Equal? |
|---|---|---|---|
| go-chi-mini | 61 / 61 | 78 / 78 | OK |
| java-spring-mini | 61 / 61 | 77 / 77 | OK |
| python-django-mini | 94 / 94 | 74 / 74 | OK |
| rust-tokio-mini | 27 / 27 | 25 / 25 | OK |
| typescript-react-mini | 81 / 81 | 70 / 70 | OK |

Full `go test ./...` green.

## Residual root cause

`#544`'s `CollectRepairEdgeCandidates` filters edges whose `FromID` is a non-hex stub (`from := byID[r.FromID]; if from == nil { continue }`). On python-django-mini this skips all 7 bug-disposition edges → zero repair_edge candidates emitted despite a 4.7% bug-rate. The reader (#545) is unaffected — it computes edge_ids straight from the current relationship slice — but the agent loop won't be useful end-to-end until that filter is loosened or the diagnostics surface synthetic-from candidates. File a follow-up against #544 for the FromID-stub passthrough.

## Status

ADR-0015 Phase-1 reader landed. Next in the dependency chain: #546 (default-on rollout of both flags after corpus-wide bug-rate validation) → #547-#551 per the ADR.

## Chain-fixes filed

- `#544` follow-up — repair_edge writer skips non-hex-FromID bug edges (suppresses candidate emission for SERVES / synthetic endpoints). To be filed.
- `#546` — flip `--enable-repair-apply` default to true after #545 ships + corpus validation.

## Test plan

- [x] `go test ./internal/enrichment/` — all 18 new tests + existing repair_edge tests pass
- [x] `go test ./...` — full suite green
- [x] End-to-end on python-django-mini with hand-crafted repair.json — bug-rate drops, `resolved_by` + `repair_reasoning` properties present
- [x] Stale detection verified (mangled edge_id → stats.Stale lists it)
- [x] Regression: 5 mini corpora byte-identical with flags OFF
- [x] Regression: 5 mini corpora byte-identical with `--enable-repair-apply` ON but no repair.json present

🤖 Generated with [Claude Code](https://claude.com/claude-code)