### PR TITLE
[fix #544] emit repair candidates for non-hex FromID edges

### DIFF
--- a/internal/enrichment/repair_edge.go
+++ b/internal/enrichment/repair_edge.go
@@ -143,24 +143,34 @@ func CollectRepairEdgeCandidates(doc *graph.Document, opts RepairEdgeCandidateOp
 		}
 
 		from := byID[r.FromID]
-		if from == nil {
-			// Without a from-entity we can't build the context window;
-			// skip. This is rare — happens only for synthetic edges that
-			// reference an ID not in doc.Entities.
-			continue
+		// Non-hex / un-stamped FromID fall-through: if the resolver hasn't
+		// stamped the from-side yet (qualified-name stub like
+		// "scope:component:file:src/manage.py", "Model:View", "Route:User"),
+		// `byID` won't contain it. We still want a repair_edge candidate —
+		// the #545 reader keys off (from_id, relation, original_stub) and
+		// computes edge_ids from the live relationships regardless of
+		// hex-stamping, so the emitter must match. Synthesize a minimal
+		// from_entity from the raw FromID so the candidate still carries
+		// enough context for the agent + downstream apply path.
+		fromEntity := from
+		if fromEntity == nil {
+			if r.FromID == "" {
+				continue
+			}
+			fromEntity = syntheticFromEntity(r.FromID)
 		}
 
-		edgeID := repairEdgeID(from.ID, r.Kind, stub)
+		edgeID := repairEdgeID(fromEntity.ID, r.Kind, stub)
 		if seen[edgeID] {
 			continue
 		}
 		seen[edgeID] = true
 
-		ctx := buildRepairEdgeContext(from, r, stub, d, opts.Resolver, fileCache)
+		ctx := buildRepairEdgeContext(fromEntity, r, stub, d, opts.Resolver, fileCache)
 		out = append(out, Candidate{
 			ID:           repairCandidateID(edgeID),
 			Kind:         KindRepairEdge,
-			SubjectID:    from.ID,
+			SubjectID:    fromEntity.ID,
 			Context:      ctx,
 			DiscoveredAt: nowRFC3339(),
 		})
@@ -294,6 +304,46 @@ func nullableString(s string) any {
 		return nil
 	}
 	return s
+}
+
+// syntheticFromEntity builds a minimal graph.Entity from a raw FromID when
+// the resolver hasn't stamped the from-side into doc.Entities yet. The
+// shape mirrors the cmd-side qualified-name stub families
+// ("scope:component:file:...", "Model:Name", "Route:Name", "View:Name", …)
+// so the agent can still reason about the call site without a stamped ID.
+// SourceFile / StartLine are left empty: the context-window block becomes
+// empty arrays, matching the schema's optional-emptiness contract.
+func syntheticFromEntity(rawFromID string) *graph.Entity {
+	kind := ""
+	name := rawFromID
+	file := ""
+	// Pull out a kind + name from the common stub shapes. This is a hint
+	// for the agent, not a binding — best-effort parsing only.
+	switch {
+	case strings.HasPrefix(rawFromID, "scope:component:file:"):
+		kind = "file"
+		file = strings.TrimPrefix(rawFromID, "scope:component:file:")
+		name = file
+	case strings.HasPrefix(rawFromID, "scope:component:class:"):
+		kind = "class"
+		// shape: scope:component:class:<lang>:<file>:<name>
+		parts := strings.SplitN(strings.TrimPrefix(rawFromID, "scope:component:class:"), ":", 3)
+		if len(parts) == 3 {
+			file = parts[1]
+			name = parts[2]
+		}
+	default:
+		if i := strings.Index(rawFromID, ":"); i > 0 {
+			kind = strings.ToLower(rawFromID[:i])
+			name = rawFromID[i+1:]
+		}
+	}
+	return &graph.Entity{
+		ID:         rawFromID,
+		Name:       name,
+		Kind:       kind,
+		SourceFile: file,
+	}
 }
 
 // isHexID is a local copy of the cmd-side helper. Inline to avoid a circular

--- a/internal/enrichment/repair_edge_test.go
+++ b/internal/enrichment/repair_edge_test.go
@@ -282,6 +282,116 @@ func TestCollectRepairEdgeCandidates_SkipsResolvedAndExternal(t *testing.T) {
 	}
 }
 
+// TestCollectRepairEdgeCandidates_NonHexFromID asserts the emitter does NOT
+// drop edges whose FromID isn't a stamped hex ID — un-stamped qualified-name
+// FromIDs (e.g. "Model:View", "scope:component:file:src/foo.py") still
+// produce a repair_edge candidate. This is the #544 follow-up fix: the
+// pre-fix emitter silently skipped these because `byID[r.FromID]` was nil,
+// which meant 0 candidates emitted on inputs where the #545 reader saw
+// residual bug-disposition edges.
+func TestCollectRepairEdgeCandidates_NonHexFromID(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// Note: NO entity for "Model:View" — it's an un-stamped from.
+			{ID: "aaaaaaaaaaaaaaaa", Name: "X", Kind: "Function", SourceFile: "a.py", StartLine: 1, Language: "python"},
+		},
+		Relationships: []graph.Relationship{
+			// hex FromID — covered by existing tests, here to assert
+			// the two paths produce stable, distinct edge_ids.
+			{FromID: "aaaaaaaaaaaaaaaa", ToID: "Foo:Bar", Kind: "CALLS", Properties: map[string]string{"language": "python"}},
+			// non-hex FromID — the regression case.
+			{FromID: "Model:View", ToID: "View:View", Kind: "DEPENDS_ON", Properties: map[string]string{"language": "python"}},
+			// scope-prefix from — common in early-pass scope edges.
+			{FromID: "scope:component:file:src/manage.py", ToID: "execute_from_command_line", Kind: "CALLS", Properties: map[string]string{"language": "python"}},
+		},
+	}
+	ridx := resolve.BuildIndex(nil)
+	got := CollectRepairEdgeCandidates(doc, RepairEdgeCandidateOptions{
+		RepoRoot: "",
+		Allow:    func(string) bool { return false },
+		Resolver: &ridx,
+	})
+	if len(got) != 3 {
+		t.Fatalf("got %d candidates, want 3 (1 hex-from + 2 non-hex-from)", len(got))
+	}
+	// Each candidate's subject_id matches the relationship's FromID — for
+	// non-hex froms, the raw stub flows through unchanged.
+	subjects := map[string]bool{}
+	for _, c := range got {
+		subjects[c.SubjectID] = true
+	}
+	for _, want := range []string{"aaaaaaaaaaaaaaaa", "Model:View", "scope:component:file:src/manage.py"} {
+		if !subjects[want] {
+			t.Fatalf("missing subject_id %q in %v", want, subjects)
+		}
+	}
+	// edge_id is stable across re-runs on the same input — the reader
+	// (#545) keys on this.
+	run := func() map[string]string {
+		out := map[string]string{}
+		for _, c := range CollectRepairEdgeCandidates(doc, RepairEdgeCandidateOptions{
+			RepoRoot: "",
+			Allow:    func(string) bool { return false },
+			Resolver: &ridx,
+		}) {
+			ctx := c.Context
+			out[c.SubjectID] = ctx["edge_id"].(string)
+		}
+		return out
+	}
+	a, b := run(), run()
+	for k, va := range a {
+		if vb := b[k]; va != vb {
+			t.Fatalf("edge_id for %q not stable: %q vs %q", k, va, vb)
+		}
+		if !strings.HasPrefix(va, "er:") || len(va) != len("er:")+16 {
+			t.Fatalf("edge_id shape wrong for %q: %q", k, va)
+		}
+	}
+	// Hex-from and non-hex-from must produce DISTINCT edge_ids — the
+	// FromID participates in the hash and changing it must flip the output.
+	seen := map[string]bool{}
+	for _, eid := range a {
+		if seen[eid] {
+			t.Fatalf("duplicate edge_id %q across distinct subjects", eid)
+		}
+		seen[eid] = true
+	}
+}
+
+// TestSyntheticFromEntity_KindHints exercises the raw-FromID → synthetic
+// graph.Entity parser. The Kind / SourceFile fields are best-effort hints
+// for the agent and shouldn't crash on unusual stub shapes.
+func TestSyntheticFromEntity_KindHints(t *testing.T) {
+	cases := []struct {
+		raw      string
+		wantKind string
+		wantName string
+		wantFile string
+	}{
+		{"scope:component:file:src/manage.py", "file", "src/manage.py", "src/manage.py"},
+		{"scope:component:class:python:src/users/views.py:UserView", "class", "UserView", "src/users/views.py"},
+		{"Model:View", "model", "View", ""},
+		{"Route:User", "route", "User", ""},
+		{"bare_name_no_colon", "", "bare_name_no_colon", ""},
+	}
+	for _, tc := range cases {
+		got := syntheticFromEntity(tc.raw)
+		if got.ID != tc.raw {
+			t.Errorf("%s: ID = %q, want %q", tc.raw, got.ID, tc.raw)
+		}
+		if got.Kind != tc.wantKind {
+			t.Errorf("%s: Kind = %q, want %q", tc.raw, got.Kind, tc.wantKind)
+		}
+		if got.Name != tc.wantName {
+			t.Errorf("%s: Name = %q, want %q", tc.raw, got.Name, tc.wantName)
+		}
+		if got.SourceFile != tc.wantFile {
+			t.Errorf("%s: SourceFile = %q, want %q", tc.raw, got.SourceFile, tc.wantFile)
+		}
+	}
+}
+
 // TestCollectRepairEdgeCandidates_DeterministicOrdering ensures repeated
 // calls on the same doc produce candidates in the same order — readers and
 // diff tools depend on byte-stable output.


### PR DESCRIPTION
## Summary

Follow-up to #544 (PR #625) — surfaced by the #545 reader demo (PR #628).

The `CollectRepairEdgeCandidates` emitter silently dropped any edge whose `FromID` wasn't already stamped into `doc.Entities`. Un-stamped qualified-name `FromID`s (`Model:View`, `scope:component:file:...`, `Route:User`) are common during early classification passes — for those edges, `byID[r.FromID]` returned `nil` and the candidate was skipped.

The #545 reader computes edge_ids from live relationships directly and does NOT require pre-stamped hex IDs, so the emitter's filter was strictly more restrictive than the reader's contract.

## Residual root cause

`internal/enrichment/repair_edge.go` line ~145 (pre-fix): `from := byID[r.FromID]; if from == nil { continue }` — skipped before the candidate could be emitted. Now: synthesize a minimal `graph.Entity` from the raw `FromID` so the candidate still emits with a stable edge_id. The synthetic entity carries best-effort kind/file hints parsed from common stub shapes; the agent's repair path is unchanged.

## Status

Foundation tooling fix. Flag-gated by `--enable-repair-candidates` (purely additive). Flag-off behaviour unchanged (verified: 0 candidates, 74 relationships on python-django-mini, identical to main baseline).

## Before / after on `internal/quality/golden/python-django-mini`

| | repair_edge candidates |
|---|---|
| main (PR #628 demo) | 5 |
| this PR | 6 |

New candidate surfaced: `Model:View -DEPENDS_ON-> View:View` (bug-extractor disposition). The other 3 orphan non-hex edges in the fixture (`Model:AppConfig`, `Model:JsonResponse`, `Route:users.urls`) are classified as non-bug by the resolver and correctly do NOT emit — the fix routes them through the classifier instead of pre-skipping.

## Tests

- `TestCollectRepairEdgeCandidates_NonHexFromID`: hex + non-hex + scope-prefix FromIDs all emit, with stable + distinct edge_ids
- `TestSyntheticFromEntity_KindHints`: stub-shape parser coverage for `scope:component:file:*`, `scope:component:class:*`, `Kind:Name`, bare-name
- Full `go test ./...` green

## Test plan

- [x] `go test ./internal/enrichment/...` passes
- [x] `go test ./...` passes
- [x] `archigraph index --enable-repair-candidates internal/quality/golden/python-django-mini` → 6 repair_edge candidates (was 5)
- [x] `archigraph index internal/quality/golden/python-django-mini` (flag off) → 0 repair_edge candidates, 74 relationships (unchanged)
- [x] Idempotency: re-index twice with no source changes → identical edge_ids

## Related

- Follows: #544 (PR #625) — repair_edge emission
- Discovered by: #545 (PR #628) — repair.json reader + apply path