### PR TITLE
[perf #633] drop ASTs per-file + release per-pass slices + release resolver tables

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -341,8 +342,30 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	i.stats.pass3Rels = countEmbeddedRels(pass3Records)
 
+	// Issue #633 — release per-file AST trees + source bytes now that the
+	// last consumer (Pass 3 cross-language extractors) has finished. The
+	// classified slice is otherwise retained until Run() returns, which on
+	// TS-heavy fixtures pinned hundreds of MB of tree-sitter AST nodes
+	// across the entire downstream pipeline (resolver, build-document,
+	// external-synthesis, Pass 4). tree-sitter trees are CGo-allocated so
+	// runtime.GC alone can't reclaim them — Close() is required.
+	releaseClassifiedASTs(classified)
+	classified = nil
+	runtime.GC()
+
 	// Pass 5 — build document (deduped).
 	doc := i.buildDocument(pass1Records, pass2Records, pass2Rels, pass3Records)
+	// Drop the per-pass record slices now that buildDocument has produced
+	// the merged + deduped graph.Entity / graph.Relationship slices. These
+	// pass-level slices hold a copy of every entity's Properties /
+	// Metadata maps and embedded Relationship slices; releasing them
+	// before the resolver-classification + Pass 4 algorithms cuts the
+	// peak by roughly the merged-set size on entity-dense repos.
+	pass1Records = nil
+	pass2Records = nil
+	pass2Rels = nil
+	pass3Records = nil
+	runtime.GC()
 
 	// Pass 4.5 — external entity synthesis. Runs BEFORE Pass 4 so the
 	// synthesised "ext:<name>" placeholders participate in the graph
@@ -449,6 +472,20 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				}
 			}
 			dumpBugResolverSamples(out, doc, *i.resolveIdx, allow, n)
+		}
+		// Issue #633 — release the resolver's lookup tables now that the
+		// final classification + optional sample dumps have consumed them.
+		// The Index struct holds 10+ string-keyed nested maps sized for the
+		// full merged entity set (byKind, byName, nameKinds, nameKindsReal,
+		// byLocation, byLocationKind, byLocationKindReal, byMember,
+		// byPackageMember, byPackageOperation, byPackageComponent, …) —
+		// none of them are needed past this point. Pass 6 enrichment uses
+		// resolveIdx only via the optional ADR-0015 repair-edge path; that
+		// path is gated behind --enable-repair-candidates and falls back
+		// gracefully when resolveIdx is nil.
+		if !i.enableRepairCandidates {
+			i.resolveIdx = nil
+			runtime.GC()
 		}
 	}
 
@@ -1456,6 +1493,24 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		},
 		Entities:      entities,
 		Relationships: relationships,
+	}
+}
+
+// releaseClassifiedASTs explicitly drops the tree-sitter parse trees + source
+// bytes attached to each classifiedFile entry. Called after the last
+// extractor pass (Pass 3 cross-language) finishes. The tree-sitter Tree.Close
+// path releases the C-side tree allocation that runtime.GC cannot reclaim
+// because the goroutine handle is reference-counted via CGo, not via the Go
+// allocator. Setting .content to nil drops the per-file source-byte buffer
+// the resolver no longer needs. Issue #633.
+func releaseClassifiedASTs(classified []classifiedFile) {
+	for k := range classified {
+		cf := &classified[k]
+		if cf.tree != nil {
+			cf.tree.Close()
+			cf.tree = nil
+		}
+		cf.content = nil
 	}
 }
 


### PR DESCRIPTION
Closes the lazy-grammar misdiagnosis flagged on #633 (see [update comment](https://github.com/cajasmota/archigraph/issues/633#issuecomment-4485993081)). Implements the three high-leverage retained-allocation fixes.

## Track A: drop tree-sitter ASTs per-file after Pass 3

`classifiedFile.tree` and `classifiedFile.content` were retained across Pass 2.5 + Pass 3 + resolver + buildDocument + external.Synthesize + Pass 4. The classified slice lived in `Run()`'s scope until the function returned, so on TS-heavy fixtures hundreds of MB of tree-sitter AST nodes were pinned the entire downstream pipeline. Fixed by walking the classified slice, calling `tree.Close()` (required — CGo-allocated, the Go GC can't reclaim it), nil-ing `cf.content`, and `runtime.GC()`ing immediately after Pass 3.

## Track B: release per-pass record slices after buildDocument

`pass1Records / pass2Records / pass2Rels / pass3Records` are nil-ed in `Run()` after `buildDocument` returns. The graph.Entity / graph.Relationship slices it produced are the only thing the downstream passes need.

(graph.WriteAtomic already streams via `json.NewEncoder` — the original "switch from Marshal to Encoder" plan in #633 was already solved upstream.)

## Track C: release resolver lookup tables after final ClassifyEndpoints

`i.resolveIdx` holds 10+ string-keyed nested maps sized for the full merged entity set: byKind, byName, nameKinds, nameKindsReal, byLocation, byLocationKind, byLocationKindReal, byMember, byPackageMember, byPackageOperation, byPackageComponent. Released to nil after the post-synthesis classification + optional sample dumps. Gated on `!enableRepairCandidates` since Pass 6's ADR-0015 repair-edge collector consumes it; that path is opt-in.

## Measurements

| Repo | Main RSS | After RSS | Delta |
|---|---|---|---|
| client-fixture-a (Django) | 1011 MB | 792 MB | -21.7% |
| client-fixture-b (Vite+React) | 1868 MB | 1758 MB | -5.9% |
| client-fixture-c (RN+Expo) | 863 MB | 789 MB | -8.6% |
| chi | 355 MB | 338 MB | -4.8% |
| exposed | 568 MB | 502 MB | -11.6% |
| flask-realworld | 93 MB | 88 MB | -5.4% |
| kafka-streams-examples | 522 MB | 509 MB | -2.5% |
| pandas | 1507 MB | 1485 MB | -1.5% |
| spdlog | 275 MB | 251 MB | -8.7% |

All 9 bug_rates byte-identical (regression-check confirmed). Verified via `jq -r '.bug_rate'` across both runs.

## Honest assessment

The original #633 plan called out a 30-50% RSS target. **We did not hit that on the entity-dense fixtures** — client-fixture-b still peaks at 1.76 GB. The win is biggest on the lowest-entity-density fixtures (Django -21.7%, exposed -11.6%) and modest on TS-heavy / pandas-scale corpora. The remaining residency lives in:

- graph.Entity Properties/Metadata maps (one allocation per entity, retained for the whole pipeline)
- gonum Pass 4 graph allocations (community detection, betweenness, articulation points)
- JSON encode write buffer + final entity/relationship slices held during write

A phase-2 follow-up should target string interning of file paths + qualified-name prefixes, and audit the gonum builder for unneeded copies. File when ready.

## Status

below-target / partial-win — lands honest measured deltas, lowers fixture-a peak below 800 MB, but does not unblock 50+ MB source-tree indexing on 16 GB laptops.