### PR TITLE
[perf #633 phase-2] profile-driven memory cuts

### DIFF
--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -21,7 +21,6 @@ import (
 	"sort"
 	"time"
 
-	gonumgraph "gonum.org/v1/gonum/graph"
 	"gonum.org/v1/gonum/graph/community"
 	"gonum.org/v1/gonum/graph/network"
 	"gonum.org/v1/gonum/graph/path"
@@ -254,7 +253,97 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 	reduced := community.Modularize(und, 1.0, src)
 
 	groups := reduced.Communities()
-	overallQ := roundForDeterminism(sanitizeFloat(community.Q(und, groups, 1.0)))
+
+	// Issue #633 phase-2 — pprof showed `community.Q` accounted for ~90% of
+	// indexing allocations (21.6 GB on client-fixture-b: 9,549 communities ×
+	// per-call O(|V|+|E|) iteration over the undirected graph). Each Q call
+	// re-builds the weighted-degree table `k[]` and scans every node. We
+	// replace ALL gonum Q calls with a single pre-computed pass:
+	//
+	//   1. Compute k[uid] (weighted degree) and m2 = Σ k[u] in one sweep.
+	//   2. For each community, accumulate internal edge weight and ΣK in
+	//      O(|E_C|) using a node→community map (built below).
+	//   3. Per-community contribution: q_c = (2*internal_w - K_C^2/m2) / m2
+	//      (BuildGraph drops self-loops, so the diagonal term collapses to 0
+	//      and gonum's "2*w_uv for u<v" off-diagonal sum becomes 2*internal_w).
+	//   4. Overall Q = Σ q_c — matches gonum's `community.Q(und, groups, 1)`
+	//      to the rounding tolerance enforced by roundForDeterminism().
+	const resolution = 1.0
+	type nodeStat struct {
+		k      float64
+		cidIdx int // index into groups
+		degree int
+	}
+	nodeStats := make(map[int64]*nodeStat, idx.next)
+	// First, mark community membership so the edge sweep can classify edges
+	// in O(1) without consulting `groups` repeatedly.
+	for cid, gg := range groups {
+		for _, n := range gg {
+			nid := n.ID()
+			if _, ok := nodeStats[nid]; !ok {
+				nodeStats[nid] = &nodeStat{cidIdx: cid}
+			} else {
+				nodeStats[nid].cidIdx = cid
+			}
+		}
+	}
+	// Walk every undirected edge once: contribute weight to each endpoint's
+	// `k` (weighted degree) and, when both endpoints share a community, to
+	// that community's internal-weight accumulator.
+	internalW := make([]float64, len(groups))
+	var m2 float64
+	wedges := und.WeightedEdges()
+	for wedges.Next() {
+		e := wedges.WeightedEdge()
+		w := e.Weight()
+		fid, tid := e.From().ID(), e.To().ID()
+		nf, ok := nodeStats[fid]
+		if !ok {
+			// Isolated-from-Modularize node: gonum's Communities() still
+			// covers every node from the original graph, but defensively
+			// guard so the loop is total.
+			nf = &nodeStat{cidIdx: -1}
+			nodeStats[fid] = nf
+		}
+		nt, ok := nodeStats[tid]
+		if !ok {
+			nt = &nodeStat{cidIdx: -1}
+			nodeStats[tid] = nt
+		}
+		nf.k += w
+		nt.k += w
+		nf.degree++
+		nt.degree++
+		m2 += 2 * w // undirected: each edge contributes 2 to Σ k.
+		if nf.cidIdx >= 0 && nf.cidIdx == nt.cidIdx {
+			internalW[nf.cidIdx] += w
+		}
+	}
+
+	// Per-community K_C = Σ k[u] for u in c.
+	K := make([]float64, len(groups))
+	for cid, gg := range groups {
+		var k float64
+		for _, n := range gg {
+			if ns, ok := nodeStats[n.ID()]; ok {
+				k += ns.k
+			}
+		}
+		K[cid] = k
+	}
+
+	// Compute per-community q_c and overall Q analytically.
+	var overallQRaw float64
+	communityQ := make([]float64, len(groups))
+	if m2 > 0 {
+		for cid := range groups {
+			// q_c = (2*internal_w_c - resolution * K_c^2 / m2) / m2
+			q := (2*internalW[cid] - resolution*K[cid]*K[cid]/m2) / m2
+			communityQ[cid] = q
+			overallQRaw += q
+		}
+	}
+	overallQ := roundForDeterminism(sanitizeFloat(overallQRaw))
 
 	communityOf := make(map[string]int, idx.next)
 	// Default every node into community -1; Modularize's Communities() lists
@@ -274,13 +363,13 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 		}
 		members := make([]member, 0, len(g))
 		for _, n := range g {
-			communityOf[idx.fromInt[n.ID()]] = cid
+			nid := n.ID()
+			communityOf[idx.fromInt[nid]] = cid
 			deg := 0
-			it := und.From(n.ID())
-			for it.Next() {
-				deg++
+			if ns, ok := nodeStats[nid]; ok {
+				deg = ns.degree
 			}
-			members = append(members, member{n.ID(), deg})
+			members = append(members, member{nid, deg})
 		}
 		// Issue #481 — degree ties were resolved by map-iteration order
 		// (g.Nodes / und.From); tiebreak on the gonum int64 node id so
@@ -306,11 +395,7 @@ func ComputeCommunities(g *simple.WeightedDirectedGraph, idx *nodeIndex, entityN
 			top = append(top, name)
 		}
 
-		// Per-community modularity contribution: Q of the singleton partition
-		// containing only this group is meaningless; instead we expose this
-		// community's own size-weighted contribution to overall Q.
-		cQ := community.Q(und, [][]gonumgraph.Node{g}, 1.0)
-		cQ = roundForDeterminism(sanitizeFloat(cQ))
+		cQ := roundForDeterminism(sanitizeFloat(communityQ[cid]))
 
 		results = append(results, CommunityResult{
 			ID:          cid,
@@ -368,7 +453,16 @@ func ComputeCentrality(g *simple.WeightedDirectedGraph, idx *nodeIndex) (map[str
 
 	// PageRank requires a directed graph — use g directly. damping=0.85,
 	// tolerance=1e-6 per spec.
-	prRaw := network.PageRank(g, 0.85, 1e-6)
+	//
+	// Issue #633 phase-2 — pprof showed `network.PageRank` allocates a dense
+	// N×N transition matrix via `mat.NewDense` (~1.74 GB live for 15k nodes
+	// on client-fixture-b). `network.PageRankSparse` solves the SAME fixed
+	// point with identical damping/tolerance using a sparse row-compressed
+	// matrix proportional to |E|. Both gonum variants use the same un-seeded
+	// init vector and converge to the same scores; roundForDeterminism()
+	// rounds to 1e-5 (well above the 1e-6 solver tolerance) so the on-disk
+	// bytes stay stable. Always use sparse — code graphs are sparse by nature.
+	prRaw := network.PageRankSparse(g, 0.85, 1e-6)
 	for nid, v := range prRaw {
 		pr[idx.fromInt[nid]] = roundForDeterminism(sanitizeFloat(v))
 	}


### PR DESCRIPTION
Phase-1 (#635) hit -5.9% on client-fixture-b because the original hypotheses (JSON streaming, per-file AST retention) were partly already done upstream. Phase-2 captured pprof first.

## Top alloc_space sites (fixture-b, 23.96 GB total)

| Func | File:Line | Alloc-space MB | % |
|---|---|---:|---:|
| `gonum/.../community.qUndirected` | louvain_undirected.go:28 | 5431 | 22.7% |
| `gonum/.../iterator.newMapIterByWeightedEdges` | iterator | 6542 | 27.3% |
| `gonum/.../iterator.(*mapIter).next` | iterator | 4925 | 20.6% |
| `gonum/.../iterator.NewNodesByWeightedEdge` | iterator | 2435 | 10.2% |
| `gonum/.../iterator.(*Nodes).NodeSlice` | iterator | 2278 | 9.5% |
| `gonum/v1/gonum/mat.NewDense` (PageRank) | dense.go:60 | 1738 | 7.2% |

All 5 gonum/community entries trace back to `community.Q` calls inside `ComputeCommunities`. The dense `NewDense` traces to `edgeWeightedPageRank`. **Phase-1's predicted sites (Properties maps, gonum graph builder copy, path interning) were NOT in the top ten.**

## Fixes applied

1. **Analytical per-community modularity** in `internal/graph/algorithms.go`. The old code called `community.Q(und, [][]Node{g}, 1.0)` once per community (9,549 calls on fixture-b). Each call internally rebuilds the weighted-degree table and walks every node. Replaced with a single edge-sweep that computes m2 and per-community internal edge weight, then derives q_c analytically:

   `q_c = (2 * internal_w_c - resolution * K_c^2 / m2) / m2`

   Overall Q is just the sum of q_c. Matches gonum within roundForDeterminism()'s 1e-5 tolerance (well above the solver's 1e-6 convergence).

2. **Switch `network.PageRank` → `network.PageRankSparse`** in `ComputeCentrality`. The dense variant allocates `mat.NewDense(N, N, nil)` = N²·8 bytes (~1.74 GB live for fixture-b's 15k nodes) for the whole computation. The sparse variant solves the same fixed-point with O(|E|) storage. Both gonum variants use the same un-seeded init vector and same damping/tolerance, so results are mathematically identical (run-to-run variance from un-seeded rand is the same pre-existing Issue #481).

## Measurements

| Repo | Main MB | Phase-2 MB | vs Main | Bug-rate parity |
|---|---:|---:|---:|---|
| client-fixture-a | 988.3 | 293.2 | -70.3% | byte-identical |
| client-fixture-b | 2060.6 | 384.5 | **-81.3%** | byte-identical |
| client-fixture-c | 895.0 | 221.4 | -75.3% | byte-identical |
| chi | 348.1 | 332.4 | -4.5% | byte-identical |
| exposed | 562.5 | 510.7 | -9.2% | byte-identical |
| flask-realworld | 91.7 | 84.9 | -7.4% | byte-identical |
| kafka-streams-examples | 580.5 | 482.3 | -16.9% | byte-identical |
| pandas | 1667.3 | 420.3 | -74.8% | byte-identical |
| spdlog | 296.7 | 263.5 | -11.2% | byte-identical |

**Target on fixture-b was -30%, achieved -81.3%.** All 9 bug-rates byte-identical to main. Full `go test ./...` passes.

Total allocations on fixture-b: 23.96 GB → 638 MB (-97.3%).

## Residual root cause

The remaining ~400 MB on fixture-b is now dominated by:
- tree-sitter cached AST nodes (~157 MB transient during Pass 1)
- `(*Indexer).classifyAndRead` byte slices (~268 MB cum)
- resolve.BuildIndex / BuildImportTable (~37 MB)
- JSON marshaling (~42 MB)

These are linear in repo size and proportionate to what's being indexed. No single dominant hotspot remains.

## Honest assessment

The -30% target was set assuming further structural fixes (properties/metadata flat layout, path interning). Those fixes were NOT needed — once the algorithmic hotspots in Pass 4 were eliminated, the remaining memory is genuinely needed for indexing work. The disk-backed-graph option (Option B) is no longer urgent; the current memory ceiling on big graphs is now driven by Pass 1 extraction not Pass 4 analytics.

## Status

at-bar / at-ship-gate