### PR TITLE
[daemon Phase B] fsnotify watcher + debounced reindex + algorithm scheduling

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -49,10 +49,103 @@ func runDaemon(argv []string) error {
 		Logger:  logger,
 		Index:   daemonIndexFunc,
 		Rebuild: daemonRebuildFunc,
+
+		// Phase B — wire the watcher + scheduler. The fast reactive
+		// reindex skips Pass 4 (graph algorithms) so a freshly-saved
+		// file becomes queryable as soon as the basic graph lands;
+		// the algorithm pass is run separately on a 30s debounce.
+		ReposToWatch:   daemonReposToWatch,
+		GroupsForRepo:  daemonGroupsForRepo,
+		SchedulerIndex: daemonSchedulerIndex,
+		SchedulerLinks: daemonSchedulerLinks,
+		SchedulerAlgo:  daemonSchedulerAlgo,
 	}
 
 	ctx := context.Background()
 	return daemon.Run(ctx, cfg)
+}
+
+// daemonReposToWatch returns every repo from every registered group
+// (deduped by absolute path). Called once at daemon startup.
+func daemonReposToWatch() []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	seen := map[string]bool{}
+	var out []string
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			abs, err := filepath.Abs(r.Path)
+			if err != nil {
+				abs = r.Path
+			}
+			if seen[abs] {
+				continue
+			}
+			seen[abs] = true
+			out = append(out, abs)
+		}
+	}
+	return out
+}
+
+// daemonGroupsForRepo returns the names of the groups whose config
+// lists repoPath (compared by absolute path).
+func daemonGroupsForRepo(repoPath string) []string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	var out []string
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			rp, err := filepath.Abs(r.Path)
+			if err != nil {
+				rp = r.Path
+			}
+			if rp == abs {
+				out = append(out, g.Name)
+				break
+			}
+		}
+	}
+	return out
+}
+
+// daemonSchedulerIndex is the fast reactive reindex used by the
+// scheduler's worker pool. It skips the graph-algorithm pass so the
+// basic graph is available to queries within seconds of a file save;
+// the algorithm pass runs separately via daemonSchedulerAlgo on a
+// longer debounce.
+func daemonSchedulerIndex(_ context.Context, repoPath string) error {
+	return Index(repoPath, "", "", []string{"graph-algo"}, false, false)
+}
+
+// daemonSchedulerLinks re-runs the cross-repo link passes for a group.
+// Delegates to the same hook the Rebuild RPC uses so behaviour is
+// identical to a force rebuild's link step.
+func daemonSchedulerLinks(_ context.Context, group string) error {
+	return runLinksHook(group)
+}
+
+// daemonSchedulerAlgo runs the full index (including Pass 4 algorithms)
+// against a repo. The scheduler arranges cancel+reschedule on new
+// writes, so this is allowed to be slow.
+func daemonSchedulerAlgo(_ context.Context, repoPath string) error {
+	return Index(repoPath, "", "", nil, false, false)
 }
 
 // daemonIndexFunc is the IndexFunc handed to daemon.Run. It bridges the

--- a/go.mod
+++ b/go.mod
@@ -28,6 +28,7 @@ require (
 	github.com/charmbracelet/x/term v0.2.1 // indirect
 	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f // indirect
+	github.com/fsnotify/fsnotify v1.10.1 // indirect
 	github.com/go-logr/logr v1.4.3 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/google/flatbuffers v25.12.19+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,6 +35,8 @@ github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f h1:Y/CXytFA4m6
 github.com/erikgeiser/coninput v0.0.0-20211004153227-1c3628e74d0f/go.mod h1:vw97MGsxSvLiUE2X8qFplwetxpGLQrlU1Q9AUEIzCaM=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
 github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
+github.com/fsnotify/fsnotify v1.10.1 h1:b0/UzAf9yR5rhf3RPm9gf3ehBPpf0oZKIjtpKrx59Ho=
+github.com/fsnotify/fsnotify v1.10.1/go.mod h1:TLheqan6HD6GBK6PrDWyDPBaEV8LspOxvPSjC+bVfgo=
 github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.4.3 h1:CjnDlHq8ikf6E492q6eKboGOC0T8CDaOvkHCIg8idEI=
 github.com/go-logr/logr v1.4.3/go.mod h1:9T104GzyrTigFIr8wt5mBrctHMim0Nb2HLGrmQ40KvY=

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -46,6 +46,47 @@ func runStatus(w io.Writer, filter string) error {
 				st.PID, uptime, humanBytes(st.RSSBytes), st.InFlight)
 			fmt.Fprintf(w, "  version: %s\n", st.Version)
 			fmt.Fprintf(w, "  socket:  %s\n", st.SocketPath)
+			if st.WatcherRepos > 0 || st.WatcherEvents > 0 {
+				fmt.Fprintf(w, "  watcher: repos=%d dirs=%d events=%d dropped=%d\n",
+					st.WatcherRepos, st.WatcherDirs, st.WatcherEvents, st.WatcherDropped)
+			}
+			if st.QueueLen > 0 || len(st.IndexInFlight) > 0 ||
+				len(st.PendingAlgo) > 0 || len(st.PendingLinks) > 0 {
+				fmt.Fprintf(w, "  scheduler: queue=%d in_flight=%d pending_algo=%d pending_links=%d\n",
+					st.QueueLen, len(st.IndexInFlight), len(st.PendingAlgo), len(st.PendingLinks))
+			}
+			if len(st.IndexedRepos) > 0 {
+				fmt.Fprintln(w, "  indexed repos:")
+				for _, r := range st.IndexedRepos {
+					last := r.LastIndex
+					if last == "" {
+						last = "(never)"
+					}
+					fmt.Fprintf(w, "    %s  last_index=%s  indexes=%d  algos=%d",
+						r.Path, last, r.IndexCount, r.AlgoCount)
+					if r.LastErr != "" {
+						fmt.Fprintf(w, "  err=%s", r.LastErr)
+					}
+					fmt.Fprintln(w)
+				}
+			}
+			if n := len(st.RecentLog); n > 0 {
+				start := n - 5
+				if start < 0 {
+					start = 0
+				}
+				fmt.Fprintln(w, "  recent events:")
+				for _, e := range st.RecentLog[start:] {
+					line := fmt.Sprintf("    %s  %s", e.Time, e.Kind)
+					if e.Repo != "" {
+						line += "  " + e.Repo
+					}
+					if e.Msg != "" {
+						line += "  " + e.Msg
+					}
+					fmt.Fprintln(w, line)
+				}
+			}
 		}
 	case errors.Is(err, client.ErrDaemonNotRunning):
 		fmt.Fprintln(w, "Daemon: not running")

--- a/internal/daemon/phaseb_test.go
+++ b/internal/daemon/phaseb_test.go
@@ -1,0 +1,206 @@
+package daemon_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+)
+
+// runDaemonWithPhaseBForTest spins up daemon.Run with a synthetic
+// scheduler index hook that records every reindex request. The repo
+// is created in a tempdir and registered via ReposToWatch.
+func runDaemonWithPhaseBForTest(t *testing.T, repos []string, schedIdx daemon.Config) (daemon.Layout, func()) {
+	t.Helper()
+	root := shortTempRoot(t)
+	t.Setenv(daemon.EnvRoot, root)
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+	cfg := schedIdx
+	cfg.Layout = layout
+	cfg.ReposToWatch = func() []string { return repos }
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// Poll for readiness.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		c, err := client.Dial()
+		if err == nil {
+			c.Close()
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+
+	cleanup := func() {
+		cancel()
+		select {
+		case <-done:
+		case <-time.After(3 * time.Second):
+			t.Logf("daemon did not exit within 3s")
+		}
+	}
+	return layout, cleanup
+}
+
+// TestPhaseB_FileWriteTriggersReindex creates a file in a watched
+// repo and verifies the scheduler index hook fires within the
+// debounce window.
+func TestPhaseB_FileWriteTriggersReindex(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var indexCount atomic.Int32
+	indexedCh := make(chan string, 4)
+
+	cfg := daemon.Config{
+		// Bare RPC entrypoints — unused in this test but Service
+		// requires them non-nil to invoke Index/Rebuild RPCs.
+		Index: func(_ proto.IndexArgs) (string, string, error) { return "", "", nil },
+		Rebuild: func(_ proto.RebuildArgs) ([]string, string, error) {
+			return nil, "", nil
+		},
+		SchedulerIndex: func(_ context.Context, p string) error {
+			indexCount.Add(1)
+			indexedCh <- p
+			return nil
+		},
+		SchedulerLinks: func(_ context.Context, _ string) error { return nil },
+		SchedulerAlgo:  func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:  func(_ string) []string { return nil },
+	}
+
+	_, cleanup := runDaemonWithPhaseBForTest(t, []string{repo}, cfg)
+	defer cleanup()
+
+	// Small settle delay so AddRepo finishes before the write.
+	time.Sleep(150 * time.Millisecond)
+	if err := os.WriteFile(filepath.Join(repo, "src", "main.go"),
+		[]byte("package main\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	select {
+	case got := <-indexedCh:
+		abs, _ := filepath.Abs(repo)
+		if got != abs {
+			t.Errorf("scheduler got repo=%q, want %q", got, abs)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatalf("scheduler did not fire within 5s; calls=%d", indexCount.Load())
+	}
+}
+
+// TestPhaseB_RapidWritesCoalesce ensures a tight burst of writes
+// produces a single index call (debounce coalescing).
+func TestPhaseB_RapidWritesCoalesce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	cfg := daemon.Config{
+		Index: func(_ proto.IndexArgs) (string, string, error) { return "", "", nil },
+		Rebuild: func(_ proto.RebuildArgs) ([]string, string, error) {
+			return nil, "", nil
+		},
+		SchedulerIndex: func(_ context.Context, _ string) error {
+			mu.Lock()
+			calls++
+			mu.Unlock()
+			return nil
+		},
+		SchedulerLinks: func(_ context.Context, _ string) error { return nil },
+		SchedulerAlgo:  func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:  func(_ string) []string { return nil },
+	}
+
+	_, cleanup := runDaemonWithPhaseBForTest(t, []string{repo}, cfg)
+	defer cleanup()
+	time.Sleep(150 * time.Millisecond)
+
+	// Burst of 8 writes over ~400ms — debounce is 2s so all should
+	// coalesce.
+	for i := 0; i < 8; i++ {
+		if err := os.WriteFile(filepath.Join(repo, "src", "a.go"),
+			[]byte("package main\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Wait beyond the 2s debounce window.
+	time.Sleep(2500 * time.Millisecond)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 1 {
+		t.Errorf("expected coalesced single index, got %d", got)
+	}
+}
+
+// TestPhaseB_StatusRPCReflectsWatcher dials the daemon and verifies
+// the Status reply includes the watcher count after AddRepo runs.
+func TestPhaseB_StatusRPCReflectsWatcher(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := daemon.Config{
+		Index: func(_ proto.IndexArgs) (string, string, error) { return "", "", nil },
+		Rebuild: func(_ proto.RebuildArgs) ([]string, string, error) {
+			return nil, "", nil
+		},
+		SchedulerIndex: func(_ context.Context, _ string) error { return nil },
+		SchedulerLinks: func(_ context.Context, _ string) error { return nil },
+		SchedulerAlgo:  func(_ context.Context, _ string) error { return nil },
+		GroupsForRepo:  func(_ string) []string { return nil },
+	}
+	_, cleanup := runDaemonWithPhaseBForTest(t, []string{repo}, cfg)
+	defer cleanup()
+
+	c, err := client.Dial()
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer c.Close()
+	st, err := c.Status()
+	if err != nil {
+		t.Fatalf("status: %v", err)
+	}
+	if st.WatcherRepos != 1 {
+		t.Errorf("expected WatcherRepos=1, got %d (Dirs=%d)", st.WatcherRepos, st.WatcherDirs)
+	}
+}

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -35,6 +35,37 @@ type StatusReply struct {
 	Groups     []string `json:"groups,omitempty"`
 	StartedAt  string   `json:"started_at"`
 	SocketPath string   `json:"socket_path"`
+
+	// Phase B additions — watcher + scheduler observability. Fields
+	// are optional; older clients ignore them.
+	WatcherRepos   int                `json:"watcher_repos,omitempty"`
+	WatcherDirs    int                `json:"watcher_dirs,omitempty"`
+	WatcherEvents  uint64             `json:"watcher_events,omitempty"`
+	WatcherDropped uint64             `json:"watcher_dropped,omitempty"`
+	QueueLen       int                `json:"queue_len,omitempty"`
+	IndexInFlight  []string           `json:"index_in_flight,omitempty"`
+	PendingAlgo    []string           `json:"pending_algo,omitempty"`
+	PendingLinks   []string           `json:"pending_links,omitempty"`
+	IndexedRepos   []IndexedRepoState `json:"indexed_repos,omitempty"`
+	RecentLog      []SchedLogEntry    `json:"recent_log,omitempty"`
+}
+
+// IndexedRepoState mirrors sched.RepoSnapshot for the wire.
+type IndexedRepoState struct {
+	Path       string `json:"path"`
+	LastIndex  string `json:"last_index,omitempty"`
+	LastAlgo   string `json:"last_algo,omitempty"`
+	IndexCount int64  `json:"index_count"`
+	AlgoCount  int64  `json:"algo_count"`
+	LastErr    string `json:"last_err,omitempty"`
+}
+
+// SchedLogEntry is the wire form of a scheduler log entry.
+type SchedLogEntry struct {
+	Time string `json:"time"`
+	Kind string `json:"kind"`
+	Repo string `json:"repo,omitempty"`
+	Msg  string `json:"msg"`
 }
 
 // IndexArgs requests a one-shot index of a single repository. Mirrors the

--- a/internal/daemon/sched/scheduler.go
+++ b/internal/daemon/sched/scheduler.go
@@ -1,0 +1,447 @@
+// Package sched is the daemon's reactive scheduler (Phase B). The
+// watcher hands off settled-repo notifications to Enqueue; the
+// scheduler serialises per-repo indexes, runs them on a small worker
+// pool, then schedules:
+//
+//   - a debounced cross-repo link recompute per group (10s),
+//   - a debounced graph-algorithm pass per repo (30s),
+//
+// both of which are cancelled and rescheduled if new write activity
+// arrives during the window. The link recompute and algorithm pass
+// run via caller-supplied callbacks so the scheduler stays free of
+// extractor + graph package dependencies.
+package sched
+
+import (
+	"context"
+	"log"
+	"os"
+	"sync"
+	"time"
+)
+
+// IndexFn re-indexes a single repo. The scheduler invokes it on a
+// worker goroutine; concurrent calls for distinct repos may run in
+// parallel up to the worker-pool size, but each repo path is
+// serialised against itself.
+type IndexFn func(ctx context.Context, repoPath string) error
+
+// LinksFn re-runs the cross-repo link passes for a group.
+type LinksFn func(ctx context.Context, group string) error
+
+// AlgoFn runs the graph-algorithm pass for a repo (community detection,
+// PageRank, articulation points). It is scheduled after a successful
+// index settles and is cancelled+rescheduled on any further write.
+type AlgoFn func(ctx context.Context, repoPath string) error
+
+// GroupsForRepoFn returns the group names a repo participates in.
+// Provided by the caller so the scheduler does not import the registry.
+type GroupsForRepoFn func(repoPath string) []string
+
+// Config wires the scheduler. All function fields are required; nil
+// causes Enqueue to short-circuit with a logged warning.
+type Config struct {
+	Workers       int           // worker pool size; defaults to 2
+	LinkDebounce  time.Duration // group settling window; defaults to 10s
+	AlgoDebounce  time.Duration // per-repo algo delay; defaults to 30s
+	Index         IndexFn
+	Links         LinksFn
+	Algorithms    AlgoFn
+	GroupsForRepo GroupsForRepoFn
+	Logger        *log.Logger
+}
+
+// Scheduler is constructed once per daemon. It owns:
+//   - a bounded job channel (per-repo dedup happens before enqueue),
+//   - a worker pool,
+//   - per-group link debounce timers,
+//   - per-repo algorithm debounce timers.
+type Scheduler struct {
+	cfg    Config
+	logger *log.Logger
+	jobs   chan string // repo paths to index
+	enq    chan string // public enqueue input → dedup → jobs
+	stop   chan struct{}
+	wg     sync.WaitGroup
+
+	mu           sync.Mutex
+	inflight     map[string]bool // repos currently indexing
+	pendingIndex map[string]bool // repos already enqueued but not yet indexing
+	queueLen     int             // length of enq+jobs (approx, for status)
+	linkTimers   map[string]*time.Timer
+	linkPending  map[string]bool
+	algoTimers   map[string]*time.Timer
+	algoPending  map[string]bool
+	algoCancel   map[string]context.CancelFunc
+	indexedRepos map[string]repoStats
+	recentLog    []LogEntry
+}
+
+// repoStats records what we know about each successful index pass.
+type repoStats struct {
+	LastIndex  time.Time
+	LastAlgo   time.Time
+	IndexCount int64
+	AlgoCount  int64
+	LastErr    string
+}
+
+// LogEntry is a single structured event captured for /status. Kept in
+// memory only; the daemon's regular log file remains authoritative.
+type LogEntry struct {
+	Time time.Time `json:"time"`
+	Kind string    `json:"kind"`
+	Repo string    `json:"repo,omitempty"`
+	Msg  string    `json:"msg"`
+}
+
+const maxRecentLog = 32
+
+// New constructs a scheduler. Start must be called before Enqueue.
+func New(cfg Config) *Scheduler {
+	if cfg.Workers <= 0 {
+		cfg.Workers = 2
+	}
+	if cfg.LinkDebounce <= 0 {
+		cfg.LinkDebounce = 10 * time.Second
+	}
+	if cfg.AlgoDebounce <= 0 {
+		cfg.AlgoDebounce = 30 * time.Second
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = log.New(os.Stderr, "sched: ", log.LstdFlags)
+	}
+	return &Scheduler{
+		cfg:          cfg,
+		logger:       cfg.Logger,
+		jobs:         make(chan string, 64),
+		enq:          make(chan string, 64),
+		stop:         make(chan struct{}),
+		inflight:     map[string]bool{},
+		pendingIndex: map[string]bool{},
+		linkTimers:   map[string]*time.Timer{},
+		linkPending:  map[string]bool{},
+		algoTimers:   map[string]*time.Timer{},
+		algoPending:  map[string]bool{},
+		algoCancel:   map[string]context.CancelFunc{},
+		indexedRepos: map[string]repoStats{},
+	}
+}
+
+// Start spins up the dedup goroutine + worker pool. Stop reverses it.
+func (s *Scheduler) Start() {
+	s.wg.Add(1)
+	go s.dedupLoop()
+	for i := 0; i < s.cfg.Workers; i++ {
+		s.wg.Add(1)
+		go s.workerLoop()
+	}
+}
+
+// Stop closes the channels and waits for in-flight work to drain.
+func (s *Scheduler) Stop() {
+	close(s.stop)
+	s.wg.Wait()
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	for _, t := range s.linkTimers {
+		t.Stop()
+	}
+	for _, t := range s.algoTimers {
+		t.Stop()
+	}
+	for _, c := range s.algoCancel {
+		c()
+	}
+}
+
+// Enqueue requests a (debounced+deduped) reindex of repoPath. Safe to
+// call from arbitrary goroutines.
+func (s *Scheduler) Enqueue(repoPath string) {
+	select {
+	case s.enq <- repoPath:
+	case <-s.stop:
+	}
+}
+
+// dedupLoop forwards from enq to jobs, suppressing duplicate enqueues
+// for repos that are already pending or running. This is also where
+// we cancel any scheduled algorithm pass — any new write activity in
+// the repo invalidates the pending algo schedule.
+func (s *Scheduler) dedupLoop() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case p := <-s.enq:
+			s.mu.Lock()
+			// Cancel any pending algorithm pass for this repo; new
+			// writes mean the algo pass would race against the
+			// upcoming index.
+			s.cancelAlgoLocked(p)
+			if s.inflight[p] || s.pendingIndex[p] {
+				s.mu.Unlock()
+				continue
+			}
+			s.pendingIndex[p] = true
+			s.queueLen++
+			s.mu.Unlock()
+			select {
+			case s.jobs <- p:
+			case <-s.stop:
+				return
+			}
+		}
+	}
+}
+
+// workerLoop pulls jobs off the channel and runs them under a per-repo
+// serialisation lock. Two workers means two repos can index in parallel.
+func (s *Scheduler) workerLoop() {
+	defer s.wg.Done()
+	for {
+		select {
+		case <-s.stop:
+			return
+		case p, ok := <-s.jobs:
+			if !ok {
+				return
+			}
+			s.runIndex(p)
+		}
+	}
+}
+
+// runIndex is the per-job wrapper: serialise against same-repo runs,
+// invoke IndexFn, then schedule the downstream link + algo passes.
+func (s *Scheduler) runIndex(repoPath string) {
+	s.mu.Lock()
+	s.pendingIndex[repoPath] = false
+	s.queueLen--
+	if s.inflight[repoPath] {
+		// Already running — push back onto the queue.
+		s.mu.Unlock()
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			s.Enqueue(repoPath)
+		}()
+		return
+	}
+	s.inflight[repoPath] = true
+	s.mu.Unlock()
+
+	t0 := time.Now()
+	s.logEvent("index_start", repoPath, "")
+	var err error
+	if s.cfg.Index != nil {
+		err = s.cfg.Index(context.Background(), repoPath)
+	}
+	s.mu.Lock()
+	stats := s.indexedRepos[repoPath]
+	stats.LastIndex = time.Now()
+	stats.IndexCount++
+	if err != nil {
+		stats.LastErr = err.Error()
+	} else {
+		stats.LastErr = ""
+	}
+	s.indexedRepos[repoPath] = stats
+	s.inflight[repoPath] = false
+	s.mu.Unlock()
+
+	if err != nil {
+		s.logEvent("index_err", repoPath, err.Error())
+		s.logger.Printf("sched: index %s failed: %v (took %s)", repoPath, err, time.Since(t0))
+		return
+	}
+	s.logEvent("index_ok", repoPath, time.Since(t0).Truncate(time.Millisecond).String())
+
+	// Schedule downstream passes.
+	s.scheduleAlgo(repoPath)
+	if s.cfg.GroupsForRepo != nil {
+		for _, g := range s.cfg.GroupsForRepo(repoPath) {
+			s.scheduleLinks(g)
+		}
+	}
+}
+
+// scheduleLinks (re)arms the per-group link debounce timer. The 10s
+// window is meant to coalesce bursts where multiple repos in a group
+// re-index back-to-back.
+func (s *Scheduler) scheduleLinks(group string) {
+	if s.cfg.Links == nil {
+		return
+	}
+	s.mu.Lock()
+	if t, ok := s.linkTimers[group]; ok {
+		t.Stop()
+	}
+	s.linkPending[group] = true
+	s.linkTimers[group] = time.AfterFunc(s.cfg.LinkDebounce, func() {
+		s.mu.Lock()
+		s.linkPending[group] = false
+		delete(s.linkTimers, group)
+		s.mu.Unlock()
+		s.runLinks(group)
+	})
+	s.mu.Unlock()
+}
+
+func (s *Scheduler) runLinks(group string) {
+	s.logEvent("links_start", "", group)
+	t0 := time.Now()
+	err := s.cfg.Links(context.Background(), group)
+	if err != nil {
+		s.logEvent("links_err", "", group+": "+err.Error())
+		s.logger.Printf("sched: links %s failed: %v", group, err)
+		return
+	}
+	s.logEvent("links_ok", "", group+" "+time.Since(t0).Truncate(time.Millisecond).String())
+}
+
+// scheduleAlgo (re)arms the per-repo algorithm pass timer. Any pending
+// pass is cancelled first; a new pass starts the 30s window over.
+func (s *Scheduler) scheduleAlgo(repoPath string) {
+	if s.cfg.Algorithms == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.cancelAlgoLocked(repoPath)
+	s.algoPending[repoPath] = true
+	s.algoTimers[repoPath] = time.AfterFunc(s.cfg.AlgoDebounce, func() {
+		s.mu.Lock()
+		s.algoPending[repoPath] = false
+		delete(s.algoTimers, repoPath)
+		ctx, cancel := context.WithCancel(context.Background())
+		s.algoCancel[repoPath] = cancel
+		s.mu.Unlock()
+
+		s.runAlgo(ctx, repoPath)
+
+		s.mu.Lock()
+		delete(s.algoCancel, repoPath)
+		s.mu.Unlock()
+	})
+}
+
+// cancelAlgoLocked stops any pending timer or cancels an in-flight
+// algorithm pass for the given repo. MUST be called with s.mu held.
+func (s *Scheduler) cancelAlgoLocked(repoPath string) {
+	if t, ok := s.algoTimers[repoPath]; ok {
+		t.Stop()
+		delete(s.algoTimers, repoPath)
+		s.algoPending[repoPath] = false
+	}
+	if c, ok := s.algoCancel[repoPath]; ok {
+		c()
+		delete(s.algoCancel, repoPath)
+	}
+}
+
+func (s *Scheduler) runAlgo(ctx context.Context, repoPath string) {
+	s.logEvent("algo_start", repoPath, "")
+	t0 := time.Now()
+	err := s.cfg.Algorithms(ctx, repoPath)
+	if err != nil {
+		if ctx.Err() != nil {
+			s.logEvent("algo_cancelled", repoPath, "")
+			return
+		}
+		s.logEvent("algo_err", repoPath, err.Error())
+		s.logger.Printf("sched: algo %s failed: %v", repoPath, err)
+		return
+	}
+	s.mu.Lock()
+	stats := s.indexedRepos[repoPath]
+	stats.LastAlgo = time.Now()
+	stats.AlgoCount++
+	s.indexedRepos[repoPath] = stats
+	s.mu.Unlock()
+	s.logEvent("algo_ok", repoPath, time.Since(t0).Truncate(time.Millisecond).String())
+}
+
+// Snapshot reports current scheduler state for the Status RPC.
+type Snapshot struct {
+	QueueLen     int
+	InFlight     []string
+	PendingAlgo  []string
+	PendingLinks []string
+	IndexedRepos []RepoSnapshot
+	RecentLog    []LogEntry
+}
+
+// RepoSnapshot is one repo's slice of Snapshot.
+type RepoSnapshot struct {
+	Path       string    `json:"path"`
+	LastIndex  time.Time `json:"last_index"`
+	LastAlgo   time.Time `json:"last_algo"`
+	IndexCount int64     `json:"index_count"`
+	AlgoCount  int64     `json:"algo_count"`
+	LastErr    string    `json:"last_err,omitempty"`
+}
+
+// Snapshot returns a defensive copy of the scheduler's user-visible
+// state. Safe to call from the RPC handler.
+func (s *Scheduler) Snapshot() Snapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := Snapshot{
+		QueueLen: s.queueLen,
+	}
+	for p := range s.inflight {
+		if s.inflight[p] {
+			out.InFlight = append(out.InFlight, p)
+		}
+	}
+	for p := range s.algoPending {
+		if s.algoPending[p] {
+			out.PendingAlgo = append(out.PendingAlgo, p)
+		}
+	}
+	for g := range s.linkPending {
+		if s.linkPending[g] {
+			out.PendingLinks = append(out.PendingLinks, g)
+		}
+	}
+	for p, st := range s.indexedRepos {
+		out.IndexedRepos = append(out.IndexedRepos, RepoSnapshot{
+			Path: p, LastIndex: st.LastIndex, LastAlgo: st.LastAlgo,
+			IndexCount: st.IndexCount, AlgoCount: st.AlgoCount,
+			LastErr: st.LastErr,
+		})
+	}
+	if n := len(s.recentLog); n > 0 {
+		out.RecentLog = append(out.RecentLog, s.recentLog...)
+	}
+	return out
+}
+
+// MarkIndexed lets the daemon record a non-watcher-driven index (e.g.
+// an explicit `archigraph index` RPC) so Status reflects reality.
+func (s *Scheduler) MarkIndexed(repoPath string, err error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	stats := s.indexedRepos[repoPath]
+	stats.LastIndex = time.Now()
+	stats.IndexCount++
+	if err != nil {
+		stats.LastErr = err.Error()
+	} else {
+		stats.LastErr = ""
+	}
+	s.indexedRepos[repoPath] = stats
+}
+
+// logEvent appends to the in-memory recent-log buffer (capped at
+// maxRecentLog). The daemon log file remains the authoritative store.
+func (s *Scheduler) logEvent(kind, repo, msg string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.recentLog = append(s.recentLog, LogEntry{Time: time.Now(), Kind: kind, Repo: repo, Msg: msg})
+	if len(s.recentLog) > maxRecentLog {
+		s.recentLog = s.recentLog[len(s.recentLog)-maxRecentLog:]
+	}
+}

--- a/internal/daemon/sched/scheduler_test.go
+++ b/internal/daemon/sched/scheduler_test.go
@@ -1,0 +1,166 @@
+package sched
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// TestEnqueueDedups verifies that two enqueues for the same repo while
+// the first is still pending result in a single index call.
+func TestEnqueueDedups(t *testing.T) {
+	var calls atomic.Int32
+	started := make(chan struct{})
+	gate := make(chan struct{})
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, _ string) error {
+			if calls.Add(1) == 1 {
+				close(started)
+			}
+			<-gate
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/a")
+	// Block until the first index actually entered runIndex, so the
+	// inflight flag is set before the duplicate enqueues arrive.
+	<-started
+	// Small sleep to ensure dedupLoop has drained any in-channel
+	// enqueue before we add more.
+	time.Sleep(50 * time.Millisecond)
+	s.Enqueue("/a")
+	s.Enqueue("/a")
+	// Let dedupLoop process the duplicates while the first is held.
+	time.Sleep(100 * time.Millisecond)
+	close(gate)
+	time.Sleep(200 * time.Millisecond)
+	// The duplicates either dropped (because inflight=true at the
+	// moment they arrived) or queued as pendingIndex=true. The
+	// dedupLoop allows a single pending slot per repo: so the worst
+	// case is 2 total runs (the original + one dedup'd re-run that
+	// the worker found via the pendingIndex slot). Anything above 2
+	// indicates a real dedup leak.
+	if got := calls.Load(); got > 2 {
+		t.Errorf("dedup leaked: got %d calls, want ≤ 2", got)
+	}
+}
+
+// TestAlgoDebounceCancelOnWrite verifies that a new Enqueue during the
+// algo debounce window cancels the pending algo pass.
+func TestAlgoDebounceCancelOnWrite(t *testing.T) {
+	var indexCalls atomic.Int32
+	var algoCalls atomic.Int32
+	s := New(Config{
+		Workers:      1,
+		AlgoDebounce: 500 * time.Millisecond,
+		Index: func(_ context.Context, _ string) error {
+			indexCalls.Add(1)
+			return nil
+		},
+		Algorithms: func(_ context.Context, _ string) error {
+			algoCalls.Add(1)
+			return nil
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/repo")
+	// Wait for the first index to complete and schedule the algo pass.
+	time.Sleep(50 * time.Millisecond)
+	if got := indexCalls.Load(); got < 1 {
+		t.Fatalf("expected first index by now, got %d", got)
+	}
+	// Trigger another write 200ms into the 500ms algo window.
+	time.Sleep(200 * time.Millisecond)
+	s.Enqueue("/repo")
+	// The original algo timer would have fired at ~500ms — make sure
+	// it does NOT, because the second Enqueue cancelled it.
+	time.Sleep(400 * time.Millisecond) // now ~650ms past first index
+	if got := algoCalls.Load(); got != 0 {
+		t.Errorf("algo should be cancelled by mid-window write, got %d calls", got)
+	}
+	// Wait for the rescheduled algo to fire (500ms after 2nd index;
+	// 2nd index ran instantly after 2nd Enqueue at ~250ms mark, so
+	// the rescheduled algo fires at ~750ms after first index).
+	time.Sleep(500 * time.Millisecond)
+	if got := algoCalls.Load(); got != 1 {
+		t.Errorf("expected rescheduled algo to fire exactly once, got %d", got)
+	}
+}
+
+// TestLinksDebouncePerGroup verifies that two repos in the same group
+// trigger a single link recompute (one per group, debounced).
+func TestLinksDebouncePerGroup(t *testing.T) {
+	var (
+		mu        sync.Mutex
+		linkCalls []string
+	)
+	groupsFor := func(p string) []string {
+		switch p {
+		case "/a", "/b":
+			return []string{"shared"}
+		default:
+			return nil
+		}
+	}
+	s := New(Config{
+		Workers:      2,
+		LinkDebounce: 100 * time.Millisecond,
+		Index: func(_ context.Context, _ string) error {
+			return nil
+		},
+		Links: func(_ context.Context, g string) error {
+			mu.Lock()
+			linkCalls = append(linkCalls, g)
+			mu.Unlock()
+			return nil
+		},
+		GroupsForRepo: groupsFor,
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/a")
+	s.Enqueue("/b")
+	time.Sleep(400 * time.Millisecond)
+	mu.Lock()
+	got := append([]string(nil), linkCalls...)
+	mu.Unlock()
+	if len(got) != 1 || got[0] != "shared" {
+		t.Errorf("expected single coalesced links call for 'shared', got %v", got)
+	}
+}
+
+// TestIndexErrorRecorded verifies an index error is captured into the
+// snapshot for /status reporting.
+func TestIndexErrorRecorded(t *testing.T) {
+	s := New(Config{
+		Workers: 1,
+		Index: func(_ context.Context, _ string) error {
+			return errors.New("boom")
+		},
+	})
+	s.Start()
+	defer s.Stop()
+
+	s.Enqueue("/x")
+	time.Sleep(150 * time.Millisecond)
+	snap := s.Snapshot()
+	found := false
+	for _, r := range snap.IndexedRepos {
+		if r.Path == "/x" && r.LastErr == "boom" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected snapshot to record error for /x, got %+v", snap.IndexedRepos)
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -13,8 +13,11 @@ import (
 	"os/signal"
 	"sync"
 	"syscall"
+	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/sched"
+	"github.com/cajasmota/archigraph/internal/daemon/watch"
 )
 
 // Config configures Run. Fields are required unless documented otherwise.
@@ -23,6 +26,17 @@ type Config struct {
 	Index   IndexFunc   // injected from cmd/archigraph
 	Rebuild RebuildFunc // injected from cmd/archigraph
 	Logger  *log.Logger // optional; defaults to stderr
+
+	// Phase B optional wiring. When all four are non-nil the daemon
+	// starts the fsnotify watcher + scheduler and registers every
+	// repo returned by ReposToWatch. The Index field above remains
+	// the synchronous RPC entrypoint; the scheduler uses
+	// SchedulerIndex for fast (algo-skipped) reactive reindexes.
+	ReposToWatch   func() []string                              // repos to subscribe at startup
+	GroupsForRepo  func(repoPath string) []string               // for cross-repo link debounce
+	SchedulerIndex func(ctx context.Context, repo string) error // fast reindex (skip algo pass)
+	SchedulerLinks func(ctx context.Context, group string) error
+	SchedulerAlgo  func(ctx context.Context, repo string) error
 }
 
 // Run starts the daemon. It blocks until either:
@@ -69,6 +83,39 @@ func Run(ctx context.Context, cfg Config) error {
 
 	stopReq := make(chan struct{})
 	svc := newService(cfg.Index, cfg.Rebuild, cfg.Layout.SocketPath, stopReq)
+
+	// Phase B — bring up the scheduler + watcher when the caller
+	// supplied the four hooks. They are optional so tests can exercise
+	// the bare RPC surface without dragging the extractor into scope.
+	if cfg.SchedulerIndex != nil {
+		scheduler := sched.New(sched.Config{
+			Index:         cfg.SchedulerIndex,
+			Links:         cfg.SchedulerLinks,
+			Algorithms:    cfg.SchedulerAlgo,
+			GroupsForRepo: cfg.GroupsForRepo,
+			Logger:        logger,
+		})
+		scheduler.Start()
+		svc.scheduler = scheduler
+		defer scheduler.Stop()
+
+		watcher, werr := watch.NewWatcher(2*time.Second, func(repo string) {
+			scheduler.Enqueue(repo)
+		}, logger)
+		if werr != nil {
+			logger.Printf("watcher: disabled (%v)", werr)
+		} else {
+			svc.watcher = watcher
+			defer watcher.Stop()
+			if cfg.ReposToWatch != nil {
+				for _, r := range cfg.ReposToWatch() {
+					if _, err := watcher.AddRepo(r); err != nil {
+						logger.Printf("watcher: add repo %s: %v", r, err)
+					}
+				}
+			}
+		}
+	}
 
 	server := rpc.NewServer()
 	if err := server.RegisterName(proto.ServiceName, svc); err != nil {

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -8,6 +8,8 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/sched"
+	"github.com/cajasmota/archigraph/internal/daemon/watch"
 	"github.com/cajasmota/archigraph/internal/version"
 )
 
@@ -38,6 +40,12 @@ type Service struct {
 	stopReq    chan<- struct{}
 	stopped    int32 // atomic; 1 once stopReq has been closed
 	inFlight   int64
+
+	// Phase B — populated only when the daemon is run with a watcher
+	// + scheduler attached. Both may be nil in test wiring that
+	// exercises just the RPC surface.
+	watcher   *watch.Watcher
+	scheduler *sched.Scheduler
 }
 
 // newService wires the injected entrypoints onto a fresh Service. The
@@ -62,8 +70,8 @@ func (s *Service) Ping(_ *proto.PingArgs, reply *proto.PingReply) error {
 
 // Status reports a snapshot of daemon state. RSS is read via the Go
 // runtime memstats (Sys); this is approximate but does not require
-// platform-specific code. A more accurate /proc/self/status read can
-// land in Phase B.
+// platform-specific code. Phase B fields (watcher + scheduler) are
+// populated when the daemon was started with both attached.
 func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	var ms runtime.MemStats
 	runtime.ReadMemStats(&ms)
@@ -74,13 +82,50 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	reply.InFlight = int(atomic.LoadInt64(&s.inFlight))
 	reply.StartedAt = s.startedAt.UTC().Format(time.RFC3339)
 	reply.SocketPath = s.socketPath
+
+	if s.watcher != nil {
+		repos, dirs, events, dropped := s.watcher.Stats()
+		reply.WatcherRepos = repos
+		reply.WatcherDirs = dirs
+		reply.WatcherEvents = events
+		reply.WatcherDropped = dropped
+	}
+	if s.scheduler != nil {
+		snap := s.scheduler.Snapshot()
+		reply.QueueLen = snap.QueueLen
+		reply.IndexInFlight = snap.InFlight
+		reply.PendingAlgo = snap.PendingAlgo
+		reply.PendingLinks = snap.PendingLinks
+		for _, r := range snap.IndexedRepos {
+			ir := proto.IndexedRepoState{
+				Path:       r.Path,
+				IndexCount: r.IndexCount,
+				AlgoCount:  r.AlgoCount,
+				LastErr:    r.LastErr,
+			}
+			if !r.LastIndex.IsZero() {
+				ir.LastIndex = r.LastIndex.UTC().Format(time.RFC3339)
+			}
+			if !r.LastAlgo.IsZero() {
+				ir.LastAlgo = r.LastAlgo.UTC().Format(time.RFC3339)
+			}
+			reply.IndexedRepos = append(reply.IndexedRepos, ir)
+		}
+		for _, e := range snap.RecentLog {
+			reply.RecentLog = append(reply.RecentLog, proto.SchedLogEntry{
+				Time: e.Time.UTC().Format(time.RFC3339),
+				Kind: e.Kind,
+				Repo: e.Repo,
+				Msg:  e.Msg,
+			})
+		}
+	}
 	return nil
 }
 
-// Index runs a single-repo index synchronously. The daemon serialises
-// indexes today (Phase A) — Phase B will add a per-repo job queue and
-// debouncing. Returning the stats JSON lets the client print the same
-// `--json-stats` output the old standalone subcommand printed.
+// Index runs a single-repo index synchronously. Phase B adds the
+// MarkIndexed bookkeeping so an explicit RPC index updates the same
+// in-memory state that the watcher-driven path uses.
 func (s *Service) Index(args *proto.IndexArgs, reply *proto.IndexReply) error {
 	if s.index == nil {
 		return errors.New("index entrypoint not configured")
@@ -91,6 +136,9 @@ func (s *Service) Index(args *proto.IndexArgs, reply *proto.IndexReply) error {
 	atomic.AddInt64(&s.inFlight, 1)
 	defer atomic.AddInt64(&s.inFlight, -1)
 	graphPath, stats, err := s.index(*args)
+	if s.scheduler != nil {
+		s.scheduler.MarkIndexed(args.RepoPath, err)
+	}
 	if err != nil {
 		return err
 	}

--- a/internal/daemon/watch/skip.go
+++ b/internal/daemon/watch/skip.go
@@ -1,0 +1,91 @@
+// Package watch implements the daemon's reactive fsnotify-driven file
+// watcher (Phase B). For each registered repo the watcher subscribes
+// recursively to the working tree, applies a coarse skip list to keep
+// the watch count bounded, and emits a single coalesced event after a
+// per-repo debounce window has elapsed.
+//
+// The package is intentionally agnostic to what happens when a repo
+// settles — it just calls back into a caller-supplied function. The
+// scheduler in internal/daemon/sched is the natural consumer.
+package watch
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// SkipDirs is the static list of directory basenames the watcher never
+// recurses into. Source trees pin most of their churn behind these
+// names; recursing into them would balloon the inotify watch count
+// without producing any signal we care about.
+//
+// We honour these by basename so any depth matches (e.g. nested
+// node_modules under a monorepo).
+var SkipDirs = map[string]struct{}{
+	".archigraph":  {},
+	".git":         {},
+	".next":        {},
+	".expo":        {},
+	".venv":        {},
+	"venv":         {},
+	"node_modules": {},
+	"target":       {},
+	"build":        {},
+	"dist":         {},
+	"__pycache__":  {},
+	".idea":        {},
+	".vscode":      {},
+}
+
+// SkipExts is the suffix list for files we never re-index for. Lock
+// files, IDE cache files and the daemon's own outputs would otherwise
+// trigger debounce loops.
+var SkipExts = map[string]struct{}{
+	".lock":  {},
+	".tmp":   {},
+	".swp":   {},
+	".swo":   {},
+	".bak":   {},
+	".orig":  {},
+	".log":   {},
+	".pyc":   {},
+	".class": {},
+	".o":     {},
+	".a":     {},
+	".so":    {},
+	".dylib": {},
+	".dll":   {},
+	".exe":   {},
+}
+
+// ShouldSkipDir reports whether a directory basename is on the skip
+// list. It is the watcher's only mechanism for excluding directories —
+// we deliberately avoid parsing every .gitignore in the tree (correct
+// .gitignore semantics need a full implementation we do not want to
+// reproduce here).
+func ShouldSkipDir(base string) bool {
+	_, ok := SkipDirs[base]
+	return ok
+}
+
+// ShouldSkipPath reports whether a path event should be dropped before
+// it ever reaches the debouncer. We drop:
+//   - paths that traverse any SkipDirs basename, and
+//   - file extensions on SkipExts (with a special case for vim swap
+//     files which look like .foo.swp).
+func ShouldSkipPath(p string) bool {
+	parts := strings.Split(filepath.ToSlash(p), "/")
+	for _, part := range parts {
+		if _, ok := SkipDirs[part]; ok {
+			return true
+		}
+	}
+	ext := strings.ToLower(filepath.Ext(p))
+	if _, ok := SkipExts[ext]; ok {
+		return true
+	}
+	// Vim creates `4913` test files and `.foo.swp` style swap files;
+	// the latter is caught by .swp above, the former is rare enough to
+	// ignore (it lives at most for a few ms).
+	return false
+}

--- a/internal/daemon/watch/watcher.go
+++ b/internal/daemon/watch/watcher.go
@@ -1,0 +1,316 @@
+package watch
+
+import (
+	"errors"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+// EventSink is the per-repo callback invoked once a repo settles
+// (i.e. no new fs events for the debounce window).
+type EventSink func(repoPath string)
+
+// Watcher is a single fsnotify-backed instance that watches one or
+// more registered repos. Each repo has its own debounce timer; when
+// the timer fires, the EventSink is called with the repo path.
+//
+// The watcher is goroutine-safe: AddRepo, RemoveRepo, and Stop may be
+// called concurrently. Internal state is guarded by a single mutex
+// because the volume of mutations is low (handful of repos, lifecycle
+// is registration/deregistration, not per-event).
+type Watcher struct {
+	logger       *log.Logger
+	debounce     time.Duration
+	sink         EventSink
+	fs           *fsnotify.Watcher
+	mu           sync.Mutex
+	repos        map[string]*repoState // key: absolute repo path
+	dirToRepo    map[string]string     // key: absolute dir path → repo path
+	stopOnce     sync.Once
+	stoppedCh    chan struct{}
+	totalEvents  uint64
+	droppedSkips uint64
+}
+
+// repoState tracks per-repo bookkeeping. The timer is recreated on
+// every event after the previous one fires; while it is non-nil and
+// pending, additional events extend the window via Reset.
+type repoState struct {
+	path    string
+	timer   *time.Timer
+	pending bool
+}
+
+// NewWatcher constructs a watcher with the given debounce window. The
+// sink is called once per repo per debounced burst. logger may be nil.
+func NewWatcher(debounce time.Duration, sink EventSink, logger *log.Logger) (*Watcher, error) {
+	if sink == nil {
+		return nil, errors.New("watch: sink is required")
+	}
+	if logger == nil {
+		logger = log.New(os.Stderr, "watch: ", log.LstdFlags)
+	}
+	fw, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("fsnotify: %w", err)
+	}
+	w := &Watcher{
+		logger:    logger,
+		debounce:  debounce,
+		sink:      sink,
+		fs:        fw,
+		repos:     map[string]*repoState{},
+		dirToRepo: map[string]string{},
+		stoppedCh: make(chan struct{}),
+	}
+	go w.loop()
+	return w, nil
+}
+
+// AddRepo subscribes to every directory under repoPath that survives
+// the skip list. Returns the number of directories added. Idempotent:
+// re-adding a registered repo is a no-op.
+func (w *Watcher) AddRepo(repoPath string) (int, error) {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return 0, err
+	}
+	w.mu.Lock()
+	if _, ok := w.repos[abs]; ok {
+		w.mu.Unlock()
+		return 0, nil
+	}
+	w.repos[abs] = &repoState{path: abs}
+	w.mu.Unlock()
+
+	added := 0
+	walkErr := filepath.WalkDir(abs, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			// Permission errors etc. — skip silently rather than abort
+			// the whole subscribe.
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(p)
+		if p != abs && ShouldSkipDir(base) {
+			return filepath.SkipDir
+		}
+		if err := w.fs.Add(p); err != nil {
+			// inotify watch limit hit etc. — log and move on so the
+			// rest of the tree is still watched.
+			w.logger.Printf("watcher: add %s: %v", p, err)
+			return nil
+		}
+		w.mu.Lock()
+		w.dirToRepo[p] = abs
+		w.mu.Unlock()
+		added++
+		return nil
+	})
+	if walkErr != nil {
+		return added, walkErr
+	}
+	w.logger.Printf("watcher: registered repo=%s dirs=%d debounce=%s", abs, added, w.debounce)
+	return added, nil
+}
+
+// RemoveRepo unsubscribes every directory associated with a repo. Any
+// pending debounced event is cancelled.
+func (w *Watcher) RemoveRepo(repoPath string) {
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		return
+	}
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	if rs, ok := w.repos[abs]; ok {
+		if rs.timer != nil {
+			rs.timer.Stop()
+		}
+		delete(w.repos, abs)
+	}
+	for d, owner := range w.dirToRepo {
+		if owner == abs {
+			_ = w.fs.Remove(d)
+			delete(w.dirToRepo, d)
+		}
+	}
+}
+
+// Repos returns a snapshot of the currently watched repos.
+func (w *Watcher) Repos() []string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([]string, 0, len(w.repos))
+	for p := range w.repos {
+		out = append(out, p)
+	}
+	return out
+}
+
+// Stats returns coarse counters for /status output.
+func (w *Watcher) Stats() (repos int, dirs int, events uint64, dropped uint64) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	return len(w.repos), len(w.dirToRepo), w.totalEvents, w.droppedSkips
+}
+
+// Stop halts the watcher and frees the fsnotify handles. Safe to call
+// multiple times.
+func (w *Watcher) Stop() {
+	w.stopOnce.Do(func() {
+		_ = w.fs.Close()
+		<-w.stoppedCh
+		w.mu.Lock()
+		for _, rs := range w.repos {
+			if rs.timer != nil {
+				rs.timer.Stop()
+			}
+		}
+		w.mu.Unlock()
+	})
+}
+
+// loop drains the fsnotify channels until the watcher is closed. We
+// route every event through the per-repo debounce timer; the timer's
+// callback runs the sink on its own goroutine.
+func (w *Watcher) loop() {
+	defer close(w.stoppedCh)
+	for {
+		select {
+		case ev, ok := <-w.fs.Events:
+			if !ok {
+				return
+			}
+			w.handleEvent(ev)
+		case err, ok := <-w.fs.Errors:
+			if !ok {
+				return
+			}
+			if err != nil {
+				w.logger.Printf("watcher: error: %v", err)
+			}
+		}
+	}
+}
+
+// handleEvent classifies an fsnotify event. We do not act on Chmod-only
+// events (they happen during indexing and would self-trigger). New
+// directories are watched recursively so freshly-checked-out commits
+// pick up nested subtrees without an explicit re-register.
+func (w *Watcher) handleEvent(ev fsnotify.Event) {
+	w.mu.Lock()
+	w.totalEvents++
+	w.mu.Unlock()
+
+	if ev.Op == fsnotify.Chmod {
+		return
+	}
+	if ShouldSkipPath(ev.Name) {
+		w.mu.Lock()
+		w.droppedSkips++
+		w.mu.Unlock()
+		return
+	}
+
+	// Track newly-created directories so events under them surface.
+	if ev.Op.Has(fsnotify.Create) {
+		if fi, err := os.Stat(ev.Name); err == nil && fi.IsDir() {
+			base := filepath.Base(ev.Name)
+			if !ShouldSkipDir(base) {
+				w.subscribeDirRecursive(ev.Name)
+			}
+		}
+	}
+
+	repo := w.repoFor(ev.Name)
+	if repo == "" {
+		return
+	}
+	w.armDebounce(repo)
+}
+
+// repoFor finds which registered repo a path belongs to. We walk up
+// the path components and look it up in dirToRepo; if no parent dir is
+// watched we treat the event as orphaned and drop it.
+func (w *Watcher) repoFor(p string) string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	dir := filepath.Dir(p)
+	for {
+		if repo, ok := w.dirToRepo[dir]; ok {
+			return repo
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return ""
+		}
+		dir = parent
+	}
+}
+
+// subscribeDirRecursive adds a newly-created directory (and its
+// contents) to the fsnotify subscription. Used so a `git checkout`
+// that creates new subtrees does not require a daemon restart.
+func (w *Watcher) subscribeDirRecursive(root string) {
+	repo := w.repoFor(filepath.Join(root, "_"))
+	if repo == "" {
+		return
+	}
+	_ = filepath.WalkDir(root, func(p string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+		base := filepath.Base(p)
+		if p != root && ShouldSkipDir(base) {
+			return filepath.SkipDir
+		}
+		if err := w.fs.Add(p); err != nil {
+			return nil
+		}
+		w.mu.Lock()
+		w.dirToRepo[p] = repo
+		w.mu.Unlock()
+		return nil
+	})
+}
+
+// armDebounce (re)starts the per-repo timer. The timer's callback
+// hands off to the sink on its own goroutine so a slow sink does not
+// block the fsnotify loop.
+func (w *Watcher) armDebounce(repo string) {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	rs, ok := w.repos[repo]
+	if !ok {
+		return
+	}
+	if rs.timer != nil {
+		// Reset is safe because the timer is single-fire; if it
+		// already fired the AfterFunc closure cleared rs.pending.
+		rs.timer.Reset(w.debounce)
+		rs.pending = true
+		return
+	}
+	rs.pending = true
+	rs.timer = time.AfterFunc(w.debounce, func() {
+		w.mu.Lock()
+		rs := w.repos[repo]
+		if rs != nil {
+			rs.pending = false
+		}
+		w.mu.Unlock()
+		w.sink(repo)
+	})
+}

--- a/internal/daemon/watch/watcher_test.go
+++ b/internal/daemon/watch/watcher_test.go
@@ -1,0 +1,189 @@
+package watch
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestShouldSkipDir(t *testing.T) {
+	cases := map[string]bool{
+		"node_modules": true,
+		".git":         true,
+		"target":       true,
+		"src":          false,
+		"internal":     false,
+		".archigraph":  true,
+		"dist":         true,
+	}
+	for in, want := range cases {
+		if got := ShouldSkipDir(in); got != want {
+			t.Errorf("ShouldSkipDir(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+func TestShouldSkipPath(t *testing.T) {
+	cases := map[string]bool{
+		"/repo/src/main.go":                false,
+		"/repo/node_modules/foo/bar.js":    true,
+		"/repo/.git/HEAD":                  true,
+		"/repo/target/build.out":           true,
+		"/repo/src/.archigraph/graph.json": true,
+		"/repo/a.log":                      true,
+		"/repo/a.swp":                      true,
+		"/repo/cmd/foo/main_test.go":       false,
+	}
+	for in, want := range cases {
+		if got := ShouldSkipPath(in); got != want {
+			t.Errorf("ShouldSkipPath(%q) = %v, want %v", in, got, want)
+		}
+	}
+}
+
+// TestDebounce verifies that a burst of writes within the debounce
+// window collapses to a single sink invocation.
+func TestDebounce(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	src := filepath.Join(repo, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	doneCh := make(chan string, 4)
+	w, err := NewWatcher(150*time.Millisecond, func(repoPath string) {
+		calls.Add(1)
+		doneCh <- repoPath
+	}, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Burst of 5 writes within ~50ms — fsnotify will surface each as
+	// a Write event but the debouncer should coalesce them.
+	for i := 0; i < 5; i++ {
+		f := filepath.Join(src, "main.go")
+		if err := os.WriteFile(f, []byte("package main // burst"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	select {
+	case <-doneCh:
+	case <-time.After(2 * time.Second):
+		t.Fatalf("debounce did not fire within 2s; calls=%d", calls.Load())
+	}
+
+	// Wait long enough that any leftover timer would have fired.
+	time.Sleep(400 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected single debounced fire, got %d", got)
+	}
+}
+
+// TestDebounceTwoBursts verifies that two separate bursts (separated
+// by more than the debounce window) each trigger one sink call.
+func TestDebounceTwoBursts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(repo, "src"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var (
+		mu    sync.Mutex
+		calls int
+	)
+	w, err := NewWatcher(100*time.Millisecond, func(string) {
+		mu.Lock()
+		calls++
+		mu.Unlock()
+	}, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	touch := func(name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(repo, "src", name),
+			[]byte("x"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	touch("a.go")
+	time.Sleep(300 * time.Millisecond) // exceed debounce window
+	touch("b.go")
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	got := calls
+	mu.Unlock()
+	if got != 2 {
+		t.Errorf("two bursts should yield two sink calls, got %d", got)
+	}
+}
+
+// TestSkipDirRespected verifies that creating files inside a skipped
+// directory does NOT trigger the sink.
+func TestSkipDirRespected(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping in short mode")
+	}
+	repo := t.TempDir()
+	nm := filepath.Join(repo, "node_modules", "foo")
+	if err := os.MkdirAll(nm, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(repo, "src")
+	if err := os.MkdirAll(src, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	var calls atomic.Int32
+	w, err := NewWatcher(100*time.Millisecond, func(string) {
+		calls.Add(1)
+	}, nil)
+	if err != nil {
+		t.Fatalf("new: %v", err)
+	}
+	defer w.Stop()
+	if _, err := w.AddRepo(repo); err != nil {
+		t.Fatalf("add: %v", err)
+	}
+
+	// Write inside node_modules — should be ignored.
+	if err := os.WriteFile(filepath.Join(nm, "ignored.js"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := calls.Load(); got != 0 {
+		t.Errorf("expected 0 sink calls for node_modules write, got %d", got)
+	}
+
+	// Sanity check: write to src — should trigger.
+	if err := os.WriteFile(filepath.Join(src, "main.go"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	time.Sleep(300 * time.Millisecond)
+	if got := calls.Load(); got != 1 {
+		t.Errorf("expected 1 sink call for src write, got %d", got)
+	}
+}

--- a/scripts/phase-b-bench.sh
+++ b/scripts/phase-b-bench.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# Phase B daemon benchmark — measures RSS at 3 lifecycle points:
+#   1) idle daemon (no repos)
+#   2) idle daemon with N repos registered
+#   3) peak RSS during one reactive reindex
+#   4) peak RSS during concurrent reindex of all repos
+#
+# Uses ARCHIGRAPH_DAEMON_ROOT + ARCHIGRAPH_HOME to point at a tempdir
+# so the real ~/.archigraph state is never touched.
+set -euo pipefail
+
+BIN="${BIN:-./build/archigraph}"
+ROOT="$(mktemp -d /tmp/archi-pb-XXXX)"
+trap 'pkill -f "archigraph daemon" 2>/dev/null || true; rm -rf "$ROOT"' EXIT
+
+export ARCHIGRAPH_DAEMON_ROOT="$ROOT/daemon"
+export ARCHIGRAPH_HOME="$ROOT/home"
+mkdir -p "$ARCHIGRAPH_HOME"
+
+# Make 3 small repos from existing fixtures.
+mkdir -p "$ROOT/repos"
+cp -R fixtures/real-world/go "$ROOT/repos/repo-a"
+cp -R fixtures/real-world/javascript "$ROOT/repos/repo-b"
+cp -R fixtures/real-world/python "$ROOT/repos/repo-c"
+
+REPO_A="$ROOT/repos/repo-a"
+REPO_B="$ROOT/repos/repo-b"
+REPO_C="$ROOT/repos/repo-c"
+
+# Write registry + per-group config so daemonReposToWatch() picks them up.
+mkdir -p "$ARCHIGRAPH_HOME/groups/bench"
+cat > "$ARCHIGRAPH_HOME/groups/bench/group.json" <<EOF
+{
+  "name": "bench",
+  "repos": [
+    {"slug": "repo-a", "path": "$REPO_A"},
+    {"slug": "repo-b", "path": "$REPO_B"},
+    {"slug": "repo-c", "path": "$REPO_C"}
+  ],
+  "features": {"watchers": true, "git_hooks": false}
+}
+EOF
+cat > "$ARCHIGRAPH_HOME/registry.json" <<EOF
+{"version":1,"groups":[{"name":"bench","config_path":"$ARCHIGRAPH_HOME/groups/bench/group.json"}]}
+EOF
+
+echo "=== Starting daemon (root=$ROOT) ==="
+"$BIN" daemon &
+DAEMON_PID=$!
+sleep 2
+
+rss() {
+  # ps reports RSS in KB on macOS/Linux.
+  ps -o rss= -p "$DAEMON_PID" 2>/dev/null | tr -d ' ' || echo "0"
+}
+
+human() {
+  local kb=$1
+  awk -v k="$kb" 'BEGIN { printf "%.1f MB", k/1024 }'
+}
+
+echo "--- (1) idle daemon, 3 repos registered & watched, 5s settle ---"
+sleep 5
+RSS_IDLE=$(rss)
+echo "idle RSS: $(human "$RSS_IDLE") (kb=$RSS_IDLE)"
+
+echo "--- (2) trigger reindex on repo-a (touch one file) ---"
+# Background sampler.
+( for _ in $(seq 1 40); do rss; sleep 0.25; done ) > "$ROOT/peak-single.txt" &
+SAMPLER=$!
+echo "// bench tick $(date +%s)" >> "$REPO_A/main.go"
+wait $SAMPLER
+PEAK_SINGLE=$(sort -n "$ROOT/peak-single.txt" | tail -1)
+echo "single-reindex peak RSS: $(human "$PEAK_SINGLE") (kb=$PEAK_SINGLE)"
+
+echo "--- (3) concurrent: trigger reindex on all 3 repos ---"
+sleep 8 # let scheduler settle
+( for _ in $(seq 1 60); do rss; sleep 0.25; done ) > "$ROOT/peak-concurrent.txt" &
+SAMPLER=$!
+echo "// bench tick $(date +%s)" >> "$REPO_A/main.go"
+echo "// bench tick $(date +%s)" >> "$REPO_B/index.js"
+echo "# bench tick $(date +%s)" >> "$REPO_C/main.py"
+wait $SAMPLER
+PEAK_CONCURRENT=$(sort -n "$ROOT/peak-concurrent.txt" | tail -1)
+echo "concurrent-reindex peak RSS: $(human "$PEAK_CONCURRENT") (kb=$PEAK_CONCURRENT)"
+
+echo "--- daemon status snapshot ---"
+"$BIN" status || true
+
+echo "--- shutting down ---"
+"$BIN" stop || kill "$DAEMON_PID" 2>/dev/null || true
+wait "$DAEMON_PID" 2>/dev/null || true
+
+echo
+echo "================ Summary ================"
+echo "Idle (3 repos watched):  $(human "$RSS_IDLE")"
+echo "Single reindex peak:     $(human "$PEAK_SINGLE")"
+echo "Concurrent reindex peak: $(human "$PEAK_CONCURRENT")"
+echo "========================================="


### PR DESCRIPTION
## Summary

Phase B of the install-and-forget daemon ([ADR-0017](docs/adrs/0017-single-binary-daemon-architecture.md)). Builds on PR #638 (Phase A daemon core + RPC).

The daemon now reactively re-indexes registered repos when their files change and schedules graph algorithms separately so the basic graph remains queryable while the algo pass runs.

## Event → action behavior table

| Event | Action |
| --- | --- |
| File write inside a watched repo (non-skip path) | Per-repo 2s debounce timer (re)armed |
| Debounce window expires with no new writes | Repo enqueued for reactive reindex (fast: `SkipPasses=[graph-algo]`) |
| Reactive reindex completes successfully | Algorithm-pass 30s timer armed for that repo; group link recompute 10s timer (re)armed for every group containing the repo |
| New file write arrives during the 30s algo window | Pending algo pass cancelled; new fast-reindex queued; algo timer rescheduled after that reindex |
| 10s link debounce expires | `RunLinksForGroup(group)` invoked once per group, regardless of how many member repos fired |
| File created in `.git/`, `node_modules/`, `target/`, `build/`, `dist/`, `.archigraph/`, `.venv/`, `__pycache__/`, `.idea/`, `.vscode/`, `.next/`, `.expo/`, or any path with a `.log/.swp/.tmp/.bak/.lock/.pyc/.class/.so/.dylib/.dll/.exe` suffix | Dropped (counted in `watcher_dropped`) |
| New directory created in a watched subtree | Recursively subscribed (subject to skip rules) so a `git checkout` of new subtrees works without daemon restart |
| Chmod-only event | Ignored (otherwise indexing self-triggers) |
| Two repos in same group write back-to-back | Each repo reindexes individually; group's link recompute fires once after the second reindex's 10s window elapses |
| `archigraph index` RPC | Still synchronous; updates the scheduler's `indexed_repos` snapshot via `MarkIndexed` |

## Benchmark numbers

Captured via `scripts/phase-b-bench.sh` against three small real-world fixtures (`fixtures/real-world/{go,javascript,python}`):

| Scenario | RSS (ps -o rss=) |
| --- | --- |
| Idle daemon, 3 repos watched, 5s settle | **32.1 MB** |
| Single reindex (touch one file in repo-a) peak | **41.6 MB** |
| Concurrent reindex (touch all 3 repos) peak | **55.6 MB** |

Cross-repo link debounce was observed firing once per group at the 10s mark (`recent_log: links_ok bench 52ms`). Watcher counters reported `repos=3 dirs=3 events=7 dropped=3` after the burst.

**Honesty note on the numbers:** the prompt's target numbers (~80–100 MB idle, ~300–400 MB during fixture-b reindex) assumed the "client-fixture-a/b/c" repos referenced in the dispatch brief; those repos do not exist in this worktree. The benchmark above uses tiny real-world fixtures (24 KB – 100 KB each), so the absolute numbers are lower than the prompt's targets. The *shape* of the measurement is what matters here: idle stays well under 100 MB, single-repo peak rises with extractor work, and concurrent peak grows roughly with the number of in-flight repos. Re-running against larger corpora is a follow-up.

## Design choices

- **Reactive index skips Pass 4.** Reactive reindex passes `SkipPasses=[graph-algo]` so a freshly-saved file becomes queryable as soon as the basic graph lands. The algorithm pass runs separately via the scheduler's debounced algo callback. Cancel-on-write semantics mean a chatty editor doesn't trigger CPU storms.
- **No backwards-compat shim for the old `archigraph watch` polling loop.** The `cli/watch.go` poll loop still exists for now (it predates Phase A and was kept by #638), but the daemon owns watching going forward; we don't fall back to polling if fsnotify fails — we log and continue with the rest of the daemon running.
- **fsnotify, not .gitignore parsing.** A correct `.gitignore` implementation is a non-trivial dependency; the prompt explicitly allowed "best-effort". The static skip list covers the dominant churn paths (`node_modules`, `target`, `build`, etc.) — anything more bespoke is a follow-up.
- **Worker pool of 2.** Matches the brief. Per-repo serialisation is enforced by the `inflight` map under `s.mu`; cross-repo parallelism scales with `Workers`.
- **mtime + content hash dedup deferred.** fsnotify already coalesces by the debounce window; in practice the editor's atomic-write pattern (rename + chmod) produces 1–3 events per save, all absorbed by the 2s debounce. The hash check would only catch IDE "touch but don't modify" cases — fine to defer.

## Status

Builds clean. `gofmt -l .` clean. `go vet ./...` clean. Race-tested via `go test -race -count=1 ./...`; the new packages pass under `-count=3`. The full repo test suite passes (extractors, daemon, scheduler, watcher, CLI).

Residual root cause: none — Phase B closes the reactive-watcher gap noted in Phase A's TODOs (the comment in `internal/daemon/service.go` Phase-A version said "Phase B will add a per-repo job queue and debouncing").

Chain-fixes filed: none.

## Test plan

- [ ] CI green (gofmt + vet + `go test -race -count=1 ./...`)
- [ ] `go test -race ./internal/daemon/watch/... ./internal/daemon/sched/...` passes locally on Linux (macOS already verified)
- [ ] Run `scripts/phase-b-bench.sh` against larger corpora as a follow-up
- [ ] `archigraph status` shows `watcher: repos=N dirs=M events=…` after touching a file in a registered repo

🤖 Generated with [Claude Code](https://claude.com/claude-code)