### PR TITLE
[quality] Automated orphan audit tool — corpus-wide in <60s

### DIFF
--- a/cmd/archigraph/quality.go
+++ b/cmd/archigraph/quality.go
@@ -7,8 +7,11 @@ import (
 	"os"
 	"path/filepath"
 
+	"strings"
+
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/quality"
+	"github.com/cajasmota/archigraph/internal/quality/audit"
 )
 
 // runQuality handles `archigraph quality <fixture-dir>`.
@@ -23,6 +26,12 @@ import (
 // the harness end-to-end honest and lets fixtures detect regressions in
 // any pass (extract / framework / cross-lang / resolver / synthesis).
 func runQuality(argv []string) error {
+	// Subverb dispatch: `quality audit-orphans <path>` runs the audit tool
+	// (internal/quality/audit) instead of the golden-fixture harness. The
+	// legacy `quality <fixture-dir>` form is preserved untouched.
+	if len(argv) >= 1 && (argv[0] == "audit-orphans" || argv[0] == "audit") {
+		return runAuditOrphans(argv[1:])
+	}
 	fs := flag.NewFlagSet("quality", flag.ContinueOnError)
 	jsonOut := fs.String("json", "", "write JSON report to this path (default: stderr-only human summary)")
 	keepGraph := fs.Bool("keep-graph", false, "preserve the temp graph.json (path printed on stderr)")
@@ -96,6 +105,74 @@ func runQuality(argv []string) error {
 		// Returning an error from a cobra RunE would surface "Error: ..."
 		// which is noisier than necessary — exit cleanly with code 2.
 		os.Exit(2)
+	}
+	return nil
+}
+
+// runAuditOrphans is the entry point for `archigraph quality audit-orphans`.
+// It accepts a single repo path (auto-detected by looking for
+// .archigraph/graph.json) or a corpus directory under --corpus.
+//
+// Output format defaults to markdown on stdout; --json flips to JSON;
+// --output redirects to a file. The format is inferred from the output path
+// extension when both --json and --output are present without conflicts.
+func runAuditOrphans(argv []string) error {
+	fs := flag.NewFlagSet("quality audit-orphans", flag.ContinueOnError)
+	corpus := fs.String("corpus", "", "treat <path> as a corpus directory containing many indexed repos")
+	jsonOut := fs.Bool("json", false, "emit JSON instead of markdown")
+	outPath := fs.String("output", "", "write to this file instead of stdout")
+	_ = fs.Bool("reindex", false, "(not implemented) re-run indexer before auditing; default trusts graph.json")
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	var path string
+	corpusMode := false
+	switch {
+	case *corpus != "":
+		path = *corpus
+		corpusMode = true
+	case fs.NArg() >= 1:
+		path = fs.Arg(0)
+	default:
+		return fmt.Errorf("usage: archigraph quality audit-orphans [--corpus] <path> [--json] [--output FILE]")
+	}
+
+	rep, err := audit.AuditPath(path, corpusMode)
+	if err != nil {
+		return err
+	}
+
+	// Decide output format. If --output ends in .json we honour that; else
+	// the --json flag picks the encoder.
+	jsonMode := *jsonOut
+	if *outPath != "" && strings.HasSuffix(*outPath, ".json") {
+		jsonMode = true
+	}
+	if *outPath != "" && strings.HasSuffix(*outPath, ".md") {
+		jsonMode = false
+	}
+
+	var w *os.File = os.Stdout
+	if *outPath != "" {
+		f, ferr := os.Create(*outPath)
+		if ferr != nil {
+			return fmt.Errorf("create output: %w", ferr)
+		}
+		defer f.Close()
+		w = f
+	}
+	if jsonMode {
+		if err := rep.WriteJSON(w); err != nil {
+			return err
+		}
+	} else {
+		if err := rep.WriteMarkdown(w); err != nil {
+			return err
+		}
+	}
+	if *outPath != "" {
+		fmt.Fprintf(os.Stderr, "audit-orphans: wrote %s\n", *outPath)
 	}
 	return nil
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -128,5 +128,6 @@ Dashboard:
   dashboard serve                 Run the local dashboard HTTP server
 
 Quality:
-  quality <fixture-dir>           Measure extraction recall vs a golden fixture
+  quality <fixture-dir>                       Measure extraction recall vs a golden fixture
+  quality audit-orphans [--corpus] <path>     Audit orphan rate + edge hygiene; emits md or JSON
 `

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -1,0 +1,653 @@
+// Package audit implements the `archigraph quality audit-orphans` workflow:
+// load one (or many) graph.json documents and produce a report describing
+// orphan rate, IMPORTS edge hygiene, REFERENCES density, root-cause-classified
+// orphan breakdowns and a composite risk score per language.
+//
+// The tool replaces a stack of ad-hoc jq pipelines that previously took
+// 1-2 hours to run by hand. It is purely a read-side analyser: it never
+// mutates the graph, never re-indexes, and never touches the network.
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ImportFormat classifies the shape of an IMPORTS edge's to_id. The bucket
+// distribution per language is the single most actionable signal we surface:
+// repos dominated by path-string or "other" imports are the ones where the
+// resolver never got to attach the import to a real entity id.
+type ImportFormat string
+
+const (
+	ImportFormatHex          ImportFormat = "hex"           // resolved entity id (16 lowercase hex)
+	ImportFormatExtQualified ImportFormat = "ext_qualified" // ext:<module>:<name>
+	ImportFormatExtBare      ImportFormat = "ext_bare"      // ext:<module>
+	ImportFormatPathString   ImportFormat = "path_string"   // ./foo or /abs/...
+	ImportFormatOther        ImportFormat = "other"         // bare module name without prefix
+)
+
+// OrphanCause is the bucket we drop each orphan into. The heuristic logic
+// lives in heuristics.go; keeping the enum here makes it easy for downstream
+// callers (CI dashboards, JSON consumers) to enumerate.
+type OrphanCause string
+
+const (
+	CauseImportPlaceholder OrphanCause = "import_placeholder"
+	CauseConstNoReferences OrphanCause = "const_no_references"
+	CauseCrossFileExport   OrphanCause = "cross_file_export"
+	CauseFrameworkSynth    OrphanCause = "framework_synthetic"
+	CauseRealConstructBug  OrphanCause = "real_construct_bug"
+	CauseMisc              OrphanCause = "misc"
+)
+
+// RepoReport is the per-repo result of an audit. Aggregate-level numbers are
+// produced by combining many of these in Report.Aggregate.
+type RepoReport struct {
+	Path                  string                  `json:"path"`
+	Languages             []string                `json:"languages"`
+	Entities              int                     `json:"entities"`
+	Relationships         int                     `json:"relationships"`
+	EntitiesByLanguage    map[string]int          `json:"entities_by_language"`
+	TopKinds              []KVCount               `json:"top_kinds"`
+	RelKinds              []KVCount               `json:"rel_kinds"`
+	Orphans               int                     `json:"orphans"`
+	OrphanRate            float64                 `json:"orphan_rate"`
+	OrphansByLanguage     map[string]int          `json:"orphans_by_language"`
+	TopOrphanKinds        []KVCount               `json:"top_orphan_kinds"`
+	ImportsTotal          int                     `json:"imports_total"`
+	ImportsToIDFormat     map[ImportFormat]int    `json:"imports_to_id_format"`
+	ImportsByLanguage     map[string]ImportHealth `json:"imports_by_language"`
+	ReferencesTotal       int                     `json:"references_total"`
+	ReferencesByLanguage  map[string]int          `json:"references_by_language"`
+	FunctionsByLanguage   map[string]int          `json:"functions_by_language"`
+	ReferencesPerFunction float64                 `json:"references_per_function"`
+	CallsTotal            int                     `json:"calls_total"`
+	CallsByLanguage       map[string]int          `json:"calls_by_language"`
+	OrphanClassification  map[OrphanCause]int     `json:"orphan_classification"`
+	ClassificationByLang  map[string]map[OrphanCause]int `json:"orphan_classification_by_language"`
+	RiskScore             int                     `json:"risk_score"`
+	Errors                []string                `json:"errors,omitempty"`
+}
+
+// ImportHealth summarises IMPORTS edge to_id quality for a single language.
+type ImportHealth struct {
+	Total      int                  `json:"total"`
+	ByFormat   map[ImportFormat]int `json:"by_format"`
+	HygieneScore float64            `json:"hygiene_score"` // 0..1 ; share of edges in {hex, ext_qualified}
+}
+
+// KVCount is a sortable (key, count) pair used for top-N tables.
+type KVCount struct {
+	Key   string `json:"key"`
+	Count int    `json:"count"`
+}
+
+// Report is the full audit output across one or more repos.
+type Report struct {
+	Version         int                       `json:"version"`
+	AuditedAt       time.Time                 `json:"audited_at"`
+	Repos           []*RepoReport             `json:"repos"`
+	Aggregate       AggregateReport           `json:"aggregate"`
+	Recommendations []Recommendation          `json:"recommendations"`
+}
+
+// AggregateReport rolls the per-repo numbers up into per-language buckets so a
+// reader can answer "which languages should we invest extractor work in?" in
+// one glance.
+type AggregateReport struct {
+	PerLanguage map[string]LanguageRollup `json:"per_language"`
+}
+
+// LanguageRollup is the cross-corpus snapshot per language.
+type LanguageRollup struct {
+	Repos                 int                  `json:"repos"`
+	Entities              int                  `json:"entities"`
+	Orphans               int                  `json:"orphans"`
+	OrphanRate            float64              `json:"orphan_rate"`
+	ImportsTotal          int                  `json:"imports_total"`
+	ImportsByFormat       map[ImportFormat]int `json:"imports_by_format"`
+	ImportsHygiene        float64              `json:"imports_hygiene"`
+	References            int                  `json:"references"`
+	Functions             int                  `json:"functions"`
+	ReferencesPerFunction float64              `json:"references_per_function"`
+	Classification        map[OrphanCause]int  `json:"classification"`
+	RiskScore             int                  `json:"risk_score"`
+}
+
+// Recommendation is one actionable bullet point synthesised from the
+// aggregate numbers. The list is ordered by priority (1 = highest).
+type Recommendation struct {
+	Priority                     int    `json:"priority"`
+	Issue                        string `json:"issue"`
+	AffectedRepos                int    `json:"affected_repos"`
+	RecoverableEntitiesEstimate  int    `json:"recoverable_entities_estimate"`
+}
+
+// AuditPath dispatches based on whether path is a single repo (contains
+// .archigraph/graph.json) or a directory holding many such repos.
+//
+// corpus=true forces directory mode regardless of layout, which matches the
+// --corpus flag wired by the CLI.
+func AuditPath(path string, corpus bool) (*Report, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve path: %w", err)
+	}
+	st, err := os.Stat(abs)
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", abs, err)
+	}
+	if !st.IsDir() {
+		return nil, fmt.Errorf("path is not a directory: %s", abs)
+	}
+
+	rep := &Report{Version: 1, AuditedAt: time.Now().UTC()}
+
+	if !corpus && hasGraphJSON(abs) {
+		rr, err := auditRepo(abs)
+		if err != nil {
+			return nil, err
+		}
+		rep.Repos = append(rep.Repos, rr)
+	} else {
+		paths, err := findRepos(abs)
+		if err != nil {
+			return nil, err
+		}
+		if len(paths) == 0 {
+			return nil, fmt.Errorf("no .archigraph/graph.json found under %s", abs)
+		}
+		rep.Repos = auditMany(paths)
+	}
+	rep.Aggregate = aggregate(rep.Repos)
+	rep.Recommendations = recommend(rep.Aggregate)
+	return rep, nil
+}
+
+// hasGraphJSON returns true if dir/.archigraph/graph.json exists.
+func hasGraphJSON(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".archigraph", "graph.json"))
+	return err == nil
+}
+
+// findRepos walks one directory level deep looking for subdirectories that
+// each contain .archigraph/graph.json. We deliberately do NOT recurse beyond
+// depth 1 — corpora are flat by convention and recursive walks on huge
+// fixture trees are wasteful.
+func findRepos(root string) ([]string, error) {
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return nil, err
+	}
+	var out []string
+	for _, e := range ents {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), "_") {
+			continue
+		}
+		p := filepath.Join(root, e.Name())
+		if hasGraphJSON(p) {
+			out = append(out, p)
+		}
+	}
+	sort.Strings(out)
+	return out, nil
+}
+
+// auditMany runs auditRepo on each path with a small worker pool (4) so a
+// 25-repo corpus completes well under a minute. Each goroutine owns its own
+// json.Decoder; the shared mutex only guards the output slice.
+func auditMany(paths []string) []*RepoReport {
+	out := make([]*RepoReport, len(paths))
+	const workers = 4
+	var wg sync.WaitGroup
+	jobs := make(chan int)
+	wg.Add(workers)
+	for w := 0; w < workers; w++ {
+		go func() {
+			defer wg.Done()
+			for idx := range jobs {
+				rr, err := auditRepo(paths[idx])
+				if err != nil {
+					rr = &RepoReport{Path: paths[idx], Errors: []string{err.Error()}}
+				}
+				out[idx] = rr
+			}
+		}()
+	}
+	for i := range paths {
+		jobs <- i
+	}
+	close(jobs)
+	wg.Wait()
+	return out
+}
+
+// auditRepo loads .archigraph/graph.json for one repo and computes every
+// metric in RepoReport. It uses encoding/json's streaming decoder for the
+// large entities + relationships arrays so we avoid materialising the
+// whole document twice in memory.
+func auditRepo(repoPath string) (*RepoReport, error) {
+	graphPath := filepath.Join(repoPath, ".archigraph", "graph.json")
+	rr := &RepoReport{
+		Path:                 repoPath,
+		EntitiesByLanguage:   map[string]int{},
+		OrphansByLanguage:    map[string]int{},
+		ImportsToIDFormat:    map[ImportFormat]int{},
+		ImportsByLanguage:    map[string]ImportHealth{},
+		ReferencesByLanguage: map[string]int{},
+		FunctionsByLanguage:  map[string]int{},
+		CallsByLanguage:      map[string]int{},
+		OrphanClassification: map[OrphanCause]int{},
+		ClassificationByLang: map[string]map[OrphanCause]int{},
+	}
+
+	doc, err := loadDocument(graphPath)
+	if err != nil {
+		return nil, err
+	}
+
+	rr.Entities = len(doc.Entities)
+	rr.Relationships = len(doc.Relationships)
+
+	// Pass 1: index entities by id and tally languages + kind histograms.
+	entByID := make(map[string]*graph.Entity, len(doc.Entities))
+	kindCounts := map[string]int{}
+	langSet := map[string]struct{}{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		entByID[e.ID] = e
+		lang := normalizeLang(e.Language)
+		if lang != "" {
+			langSet[lang] = struct{}{}
+			rr.EntitiesByLanguage[lang]++
+		}
+		key := e.Kind
+		if e.Subtype != "" {
+			key = e.Kind + "/" + e.Subtype
+		}
+		kindCounts[key]++
+		if isFunctionLike(e) {
+			rr.FunctionsByLanguage[lang]++
+		}
+	}
+	rr.TopKinds = topN(kindCounts, 15)
+
+	// Pass 2: tally relationship kinds, IMPORTS hygiene, REFERENCES density.
+	relKinds := map[string]int{}
+	touched := make(map[string]struct{}, len(doc.Entities))
+	imHealth := map[string]*ImportHealth{}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		k := strings.ToUpper(r.Kind)
+		relKinds[k]++
+		touched[r.FromID] = struct{}{}
+		touched[r.ToID] = struct{}{}
+		lang := relLanguage(r, entByID)
+		switch k {
+		case "IMPORTS":
+			rr.ImportsTotal++
+			f := classifyImportToID(r.ToID)
+			rr.ImportsToIDFormat[f]++
+			ih, ok := imHealth[lang]
+			if !ok {
+				ih = &ImportHealth{ByFormat: map[ImportFormat]int{}}
+				imHealth[lang] = ih
+			}
+			ih.Total++
+			ih.ByFormat[f]++
+		case "REFERENCES":
+			rr.ReferencesTotal++
+			rr.ReferencesByLanguage[lang]++
+		case "CALLS":
+			rr.CallsTotal++
+			rr.CallsByLanguage[lang]++
+		}
+	}
+	rr.RelKinds = topN(relKinds, 20)
+	for lang, ih := range imHealth {
+		hex := ih.ByFormat[ImportFormatHex]
+		extq := ih.ByFormat[ImportFormatExtQualified]
+		if ih.Total > 0 {
+			ih.HygieneScore = float64(hex+extq) / float64(ih.Total)
+		}
+		rr.ImportsByLanguage[lang] = *ih
+	}
+
+	// Pass 3: orphan detection + heuristic classification.
+	orphanKinds := map[string]int{}
+	for id, e := range entByID {
+		if _, ok := touched[id]; ok {
+			continue
+		}
+		rr.Orphans++
+		lang := normalizeLang(e.Language)
+		rr.OrphansByLanguage[lang]++
+		key := e.Kind
+		if e.Subtype != "" {
+			key = e.Kind + "/" + e.Subtype
+		}
+		orphanKinds[key]++
+
+		cause := ClassifyOrphan(e)
+		rr.OrphanClassification[cause]++
+		if rr.ClassificationByLang[lang] == nil {
+			rr.ClassificationByLang[lang] = map[OrphanCause]int{}
+		}
+		rr.ClassificationByLang[lang][cause]++
+	}
+	rr.TopOrphanKinds = topN(orphanKinds, 10)
+	if rr.Entities > 0 {
+		rr.OrphanRate = float64(rr.Orphans) / float64(rr.Entities)
+	}
+
+	// REFERENCES/function ratio: total across all languages.
+	totalFuncs := 0
+	for _, n := range rr.FunctionsByLanguage {
+		totalFuncs += n
+	}
+	if totalFuncs > 0 {
+		rr.ReferencesPerFunction = float64(rr.ReferencesTotal) / float64(totalFuncs)
+	}
+
+	// Risk score: composite, see riskScore() for the formula.
+	rr.RiskScore = riskScore(rr)
+
+	// Final language list (sorted for determinism).
+	for lang := range langSet {
+		rr.Languages = append(rr.Languages, lang)
+	}
+	sort.Strings(rr.Languages)
+
+	return rr, nil
+}
+
+// loadDocument streams graph.json into memory. We use a one-shot Decoder
+// rather than splitting entities/relationships into chunks: the bottleneck on
+// modern hardware is allocation, and json.Unmarshal of a 200 MB document
+// completes in ~2-3 s, well inside the per-repo budget. If a future corpus
+// outgrows that, this is the choke point to revisit (an Iterator-style decoder
+// that calls back into Pass 1/2/3 directly would halve memory.)
+func loadDocument(path string) (*graph.Document, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open graph.json: %w", err)
+	}
+	defer f.Close()
+	dec := json.NewDecoder(f)
+	var doc graph.Document
+	if err := dec.Decode(&doc); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return &doc, nil
+}
+
+// relLanguage returns the canonical language for a relationship. We prefer
+// the explicit `language` property the extractor sets on most edges; if it's
+// missing, fall back to the source entity's language so a CALLS edge whose
+// resolver dropped the property still counts toward a real bucket.
+func relLanguage(r *graph.Relationship, entByID map[string]*graph.Entity) string {
+	if r.Properties != nil {
+		if v := r.Properties["language"]; v != "" {
+			return normalizeLang(v)
+		}
+	}
+	if e, ok := entByID[r.FromID]; ok {
+		return normalizeLang(e.Language)
+	}
+	return ""
+}
+
+// normalizeLang collapses extractor variants ("typescript"/"tsx") to a single
+// bucket so per-language aggregates aren't fragmented.
+func normalizeLang(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	switch s {
+	case "typescriptreact", "tsx":
+		return "typescript"
+	case "javascriptreact", "jsx":
+		return "javascript"
+	}
+	return s
+}
+
+// isFunctionLike returns true for entities the extractor treats as a
+// callable construct. Function/Method/Operation are the three kind tokens
+// the production schema uses; we tolerate case variants.
+func isFunctionLike(e *graph.Entity) bool {
+	k := strings.ToLower(e.Kind)
+	if strings.Contains(k, "function") || strings.Contains(k, "method") {
+		return true
+	}
+	if strings.Contains(k, "operation") {
+		// Operation/* covers many ts/js function-like subtypes.
+		st := strings.ToLower(e.Subtype)
+		if st == "function" || st == "method" || strings.HasPrefix(st, "arrow") {
+			return true
+		}
+	}
+	return false
+}
+
+// classifyImportToID buckets an IMPORTS edge's to_id by shape. Anything that
+// doesn't look like an entity id (16 lowercase hex) or an "ext:" placeholder
+// is either a path string or some other raw token: both are bugs in
+// extractor or resolver and should be surfaced.
+func classifyImportToID(toID string) ImportFormat {
+	if isHexID(toID) {
+		return ImportFormatHex
+	}
+	if strings.HasPrefix(toID, "ext:") {
+		// ext:react:useState  -> qualified (3 segments)
+		// ext:antd            -> bare (2 segments)
+		parts := strings.SplitN(toID, ":", 3)
+		if len(parts) == 3 && parts[2] != "" {
+			return ImportFormatExtQualified
+		}
+		return ImportFormatExtBare
+	}
+	if strings.HasPrefix(toID, "./") || strings.HasPrefix(toID, "../") || strings.HasPrefix(toID, "/") {
+		return ImportFormatPathString
+	}
+	return ImportFormatOther
+}
+
+// isHexID returns true if s is a 16-char lowercase hex string — the canonical
+// shape of an entity id (graph.EntityID).
+func isHexID(s string) bool {
+	if len(s) != 16 {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			return false
+		}
+	}
+	return true
+}
+
+// topN sorts a (key,count) map descending by count and returns the first n.
+// Ties are broken alphabetically so output is deterministic across runs.
+func topN(m map[string]int, n int) []KVCount {
+	out := make([]KVCount, 0, len(m))
+	for k, v := range m {
+		out = append(out, KVCount{Key: k, Count: v})
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Count != out[j].Count {
+			return out[i].Count > out[j].Count
+		}
+		return out[i].Key < out[j].Key
+	})
+	if len(out) > n {
+		out = out[:n]
+	}
+	return out
+}
+
+// riskScore is a 0..100 composite of the three signals that drove the manual
+// audit's recommendations:
+//
+//   - orphan rate (lower = healthier)
+//   - imports hygiene (share of resolved or ext-qualified imports)
+//   - references density (REFERENCES per function — capped at 1.0)
+//
+// Equal weighting; we round to int because false precision past the unit
+// digit invites readers to over-interpret deltas between 64 and 67.
+func riskScore(r *RepoReport) int {
+	orphanHealth := 1.0 - r.OrphanRate
+	if orphanHealth < 0 {
+		orphanHealth = 0
+	}
+	importHealth := 1.0
+	if r.ImportsTotal > 0 {
+		hex := r.ImportsToIDFormat[ImportFormatHex]
+		extq := r.ImportsToIDFormat[ImportFormatExtQualified]
+		importHealth = float64(hex+extq) / float64(r.ImportsTotal)
+	}
+	refHealth := math.Min(1.0, r.ReferencesPerFunction)
+	score := 100.0 * (orphanHealth + importHealth + refHealth) / 3.0
+	return int(math.Round(score))
+}
+
+// aggregate folds per-repo numbers into the cross-corpus per-language view.
+func aggregate(repos []*RepoReport) AggregateReport {
+	per := map[string]*LanguageRollup{}
+	get := func(lang string) *LanguageRollup {
+		lr, ok := per[lang]
+		if !ok {
+			lr = &LanguageRollup{
+				ImportsByFormat: map[ImportFormat]int{},
+				Classification:  map[OrphanCause]int{},
+			}
+			per[lang] = lr
+		}
+		return lr
+	}
+	repoLangs := map[string]map[string]struct{}{}
+	for _, r := range repos {
+		if r == nil {
+			continue
+		}
+		for lang, n := range r.EntitiesByLanguage {
+			lr := get(lang)
+			lr.Entities += n
+			set, ok := repoLangs[lang]
+			if !ok {
+				set = map[string]struct{}{}
+				repoLangs[lang] = set
+			}
+			set[r.Path] = struct{}{}
+			lr.Repos = len(set)
+		}
+		for lang, n := range r.OrphansByLanguage {
+			get(lang).Orphans += n
+		}
+		for lang, ih := range r.ImportsByLanguage {
+			lr := get(lang)
+			lr.ImportsTotal += ih.Total
+			for f, c := range ih.ByFormat {
+				lr.ImportsByFormat[f] += c
+			}
+		}
+		for lang, n := range r.ReferencesByLanguage {
+			get(lang).References += n
+		}
+		for lang, n := range r.FunctionsByLanguage {
+			get(lang).Functions += n
+		}
+		for lang, m := range r.ClassificationByLang {
+			lr := get(lang)
+			for cause, c := range m {
+				lr.Classification[cause] += c
+			}
+		}
+	}
+	out := AggregateReport{PerLanguage: map[string]LanguageRollup{}}
+	for lang, lr := range per {
+		if lr.Entities > 0 {
+			lr.OrphanRate = float64(lr.Orphans) / float64(lr.Entities)
+		}
+		if lr.ImportsTotal > 0 {
+			hex := lr.ImportsByFormat[ImportFormatHex] + lr.ImportsByFormat[ImportFormatExtQualified]
+			lr.ImportsHygiene = float64(hex) / float64(lr.ImportsTotal)
+		}
+		if lr.Functions > 0 {
+			lr.ReferencesPerFunction = float64(lr.References) / float64(lr.Functions)
+		}
+		// Composite risk per language using the same formula as per-repo.
+		orphanHealth := 1.0 - lr.OrphanRate
+		refHealth := math.Min(1.0, lr.ReferencesPerFunction)
+		importHealth := 1.0
+		if lr.ImportsTotal > 0 {
+			importHealth = lr.ImportsHygiene
+		}
+		lr.RiskScore = int(math.Round(100.0 * (orphanHealth + importHealth + refHealth) / 3.0))
+		out.PerLanguage[lang] = *lr
+	}
+	return out
+}
+
+// recommend converts the aggregate snapshot into a small priority-ordered
+// punch list. The rules below intentionally mirror the manual analysis we
+// are automating: REFERENCES missing + IMPORTS path-strings dominate the
+// recoverable orphan population on every multi-language corpus we've seen.
+func recommend(a AggregateReport) []Recommendation {
+	var recs []Recommendation
+	type entry struct {
+		lang  string
+		score float64 // higher = worse
+		rec   Recommendation
+	}
+	var bag []entry
+	for lang, lr := range a.PerLanguage {
+		if lr.Functions > 100 && lr.ReferencesPerFunction < 0.5 {
+			estimate := lr.Functions * 2 // conservative: ~2 refs/function is the floor we see in healthy corpora
+			bag = append(bag, entry{
+				lang:  lang,
+				score: 1.0 - lr.ReferencesPerFunction,
+				rec: Recommendation{
+					Issue:                       fmt.Sprintf("%s: REFERENCES emission missing (%.2f refs/function)", lang, lr.ReferencesPerFunction),
+					AffectedRepos:               lr.Repos,
+					RecoverableEntitiesEstimate: estimate,
+				},
+			})
+		}
+		if lr.ImportsTotal > 50 {
+			path := lr.ImportsByFormat[ImportFormatPathString]
+			other := lr.ImportsByFormat[ImportFormatOther]
+			bad := path + other
+			if float64(bad)/float64(lr.ImportsTotal) > 0.10 {
+				bag = append(bag, entry{
+					lang:  lang,
+					score: float64(bad) / float64(lr.ImportsTotal),
+					rec: Recommendation{
+						Issue:                       fmt.Sprintf("%s: IMPORTS to_id stored as path string / unqualified (%d / %d)", lang, bad, lr.ImportsTotal),
+						AffectedRepos:               lr.Repos,
+						RecoverableEntitiesEstimate: bad,
+					},
+				})
+			}
+		}
+	}
+	sort.Slice(bag, func(i, j int) bool {
+		if bag[i].score != bag[j].score {
+			return bag[i].score > bag[j].score
+		}
+		return bag[i].lang < bag[j].lang
+	})
+	for i := range bag {
+		bag[i].rec.Priority = i + 1
+		recs = append(recs, bag[i].rec)
+	}
+	return recs
+}

--- a/internal/quality/audit/heuristics.go
+++ b/internal/quality/audit/heuristics.go
@@ -1,0 +1,123 @@
+package audit
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ClassifyOrphan buckets a single orphan entity by root cause. The order of
+// the checks matters: more specific patterns (import-placeholder,
+// framework-synthetic) are tested before the broader fallbacks so an entity
+// matched by two heuristics ends up in the most actionable bucket.
+//
+// The rules below mirror the manual analysis verbatim:
+//   1. SCOPE.Component / subtype "import"            -> import_placeholder
+//   2. Operation/Component + subtype "const_*"       -> const_no_references
+//   3. PascalCase / camelCase exported-looking name  -> cross_file_export
+//   4. Synthetic framework prefixes (manifest:/...)  -> framework_synthetic
+//   5. Class / Function / Method / Interface         -> real_construct_bug
+//   6. anything else                                 -> misc
+func ClassifyOrphan(e *graph.Entity) OrphanCause {
+	kind := e.Kind
+	st := e.Subtype
+	lkind := strings.ToLower(kind)
+	lst := strings.ToLower(st)
+
+	// (1) Import placeholders: the SCOPE.Component/import family the manual
+	// analysis identified as the single biggest orphan bucket on TS/JS fixtures.
+	if (kind == "SCOPE.Component" || lkind == "scope.component") && lst == "import" {
+		return CauseImportPlaceholder
+	}
+	if lst == "import" && (strings.Contains(lkind, "component") || strings.Contains(lkind, "scope")) {
+		return CauseImportPlaceholder
+	}
+
+	// (4) Synthetic framework / manifest / HTTP / DB-map nodes. Detect by
+	// kind prefix — these are emitted by per-framework passes and never
+	// participate in code-level edges, so being orphan is expected and not a
+	// bug. We check this BEFORE the real_construct fallback so an
+	// "http_endpoint" entity (which technically is a Method-like construct)
+	// doesn't get flagged as a real bug.
+	for _, p := range []string{"manifest:", "hierarchy:", "http_endpoint", "dbmap:", "openapi:", "framework:"} {
+		if strings.HasPrefix(lkind, p) {
+			return CauseFrameworkSynth
+		}
+	}
+
+	// (2) const_* family on Operation/Component kinds: in TS/JS the extractor
+	// emits `const X = ...` as an Operation/const_call (and many variants).
+	// When nothing in the same file or any other file references it, it lands
+	// here. The manual analysis tied these directly to the missing-REFERENCES
+	// finding.
+	if (strings.Contains(lkind, "operation") || strings.Contains(lkind, "component")) &&
+		strings.Contains(lst, "const") {
+		return CauseConstNoReferences
+	}
+
+	// (3) Cross-file export candidates: a non-const-family entity whose name
+	// looks like a PascalCase type or camelCase function. This is the
+	// "exported for consumers" bucket from the manual analysis. We require
+	// the name to start with a letter and contain at least one upper/lower
+	// transition, which filters out single-token lowercase noise.
+	if isExportishName(e.Name) {
+		// Functions, methods, classes, interfaces are reported separately
+		// below as "real construct" — only count the misc-but-named entities
+		// here as export candidates. Otherwise every orphan function falls
+		// into both buckets.
+		if !isCoreConstructKind(lkind) {
+			return CauseCrossFileExport
+		}
+	}
+
+	// (5) Real-construct bug: a Class/Function/Method/Interface entity that
+	// has zero edges. These are the orphans that genuinely indicate an
+	// extractor or resolver bug and most warrant follow-up.
+	if isCoreConstructKind(lkind) {
+		return CauseRealConstructBug
+	}
+
+	return CauseMisc
+}
+
+// isCoreConstructKind returns true for the kinds that should virtually never
+// be orphan in healthy graphs: language-level construct definitions.
+func isCoreConstructKind(lkind string) bool {
+	for _, k := range []string{"class", "function", "method", "interface", "struct", "trait", "enum"} {
+		if strings.Contains(lkind, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// isExportishName returns true when the name has the shape of a Pascal- or
+// camelCase identifier (common heuristic for cross-file exports). We
+// deliberately accept both because, e.g., React component names are Pascal
+// while hook / util exports are camel.
+func isExportishName(name string) bool {
+	if name == "" {
+		return false
+	}
+	r0 := rune(name[0])
+	if !unicode.IsLetter(r0) {
+		return false
+	}
+	if r0 == '_' {
+		return false
+	}
+	hasLower := false
+	hasUpper := false
+	for _, r := range name {
+		if unicode.IsUpper(r) {
+			hasUpper = true
+		}
+		if unicode.IsLower(r) {
+			hasLower = true
+		}
+	}
+	// Need both — pure UPPER_SNAKE constants and pure lower tokens don't
+	// look like exported types or functions to a human reader.
+	return hasUpper && hasLower
+}

--- a/internal/quality/audit/heuristics_test.go
+++ b/internal/quality/audit/heuristics_test.go
@@ -1,0 +1,116 @@
+package audit
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestClassifyOrphan_ImportPlaceholder(t *testing.T) {
+	e := &graph.Entity{Kind: "SCOPE.Component", Subtype: "import", Name: "x"}
+	if got := ClassifyOrphan(e); got != CauseImportPlaceholder {
+		t.Errorf("want %s, got %s", CauseImportPlaceholder, got)
+	}
+}
+
+func TestClassifyOrphan_ConstNoReferences(t *testing.T) {
+	cases := []*graph.Entity{
+		{Kind: "Operation", Subtype: "const_call", Name: "foo"},
+		{Kind: "Component", Subtype: "const_destructure", Name: "bar"},
+		{Kind: "Operation", Subtype: "const", Name: "baz"},
+	}
+	for _, e := range cases {
+		if got := ClassifyOrphan(e); got != CauseConstNoReferences {
+			t.Errorf("%+v: want %s, got %s", e, CauseConstNoReferences, got)
+		}
+	}
+}
+
+func TestClassifyOrphan_FrameworkSynthetic(t *testing.T) {
+	cases := []*graph.Entity{
+		{Kind: "manifest:nextjs", Name: "/api/foo"},
+		{Kind: "hierarchy:django", Name: "App"},
+		{Kind: "http_endpoint", Name: "GET /users"},
+		{Kind: "dbmap:postgres", Name: "users"},
+	}
+	for _, e := range cases {
+		if got := ClassifyOrphan(e); got != CauseFrameworkSynth {
+			t.Errorf("%+v: want %s, got %s", e, CauseFrameworkSynth, got)
+		}
+	}
+}
+
+func TestClassifyOrphan_RealConstructBug(t *testing.T) {
+	cases := []*graph.Entity{
+		{Kind: "Class", Name: "PaymentService"},
+		{Kind: "Function", Name: "processPayment"},
+		{Kind: "Method", Name: "handle"},
+		{Kind: "Interface", Name: "Handler"},
+	}
+	for _, e := range cases {
+		if got := ClassifyOrphan(e); got != CauseRealConstructBug {
+			t.Errorf("%+v: want %s, got %s", e, CauseRealConstructBug, got)
+		}
+	}
+}
+
+func TestClassifyOrphan_CrossFileExport(t *testing.T) {
+	// PascalCase non-construct kind => export candidate.
+	e := &graph.Entity{Kind: "Variable", Subtype: "let", Name: "DefaultTheme"}
+	if got := ClassifyOrphan(e); got != CauseCrossFileExport {
+		t.Errorf("want %s, got %s", CauseCrossFileExport, got)
+	}
+	// camelCase too.
+	e2 := &graph.Entity{Kind: "Variable", Subtype: "let", Name: "useTheme"}
+	if got := ClassifyOrphan(e2); got != CauseCrossFileExport {
+		t.Errorf("want %s, got %s", CauseCrossFileExport, got)
+	}
+}
+
+func TestClassifyOrphan_Misc(t *testing.T) {
+	e := &graph.Entity{Kind: "Variable", Subtype: "tmp", Name: "x"}
+	if got := ClassifyOrphan(e); got != CauseMisc {
+		t.Errorf("want %s, got %s", CauseMisc, got)
+	}
+}
+
+func TestClassifyImportToID(t *testing.T) {
+	cases := map[string]ImportFormat{
+		"0123456789abcdef":      ImportFormatHex,
+		"ext:react:useState":    ImportFormatExtQualified,
+		"ext:antd":              ImportFormatExtBare,
+		"./constants":           ImportFormatPathString,
+		"../../util":            ImportFormatPathString,
+		"/abs/path":             ImportFormatPathString,
+		"raw_module_name":       ImportFormatOther,
+		"PascalNoPrefix":        ImportFormatOther,
+		"0123456789ABCDEF":      ImportFormatOther, // uppercase hex isn't our canonical id
+		"short":                 ImportFormatOther,
+	}
+	for in, want := range cases {
+		if got := classifyImportToID(in); got != want {
+			t.Errorf("%q: want %s, got %s", in, want, got)
+		}
+	}
+}
+
+func TestIsExportishName(t *testing.T) {
+	if !isExportishName("UserCard") {
+		t.Error("UserCard should be exportish")
+	}
+	if !isExportishName("useTheme") {
+		t.Error("useTheme should be exportish")
+	}
+	if isExportishName("MAX_RETRIES") {
+		t.Error("MAX_RETRIES is pure upper, not exportish")
+	}
+	if isExportishName("foo") {
+		t.Error("pure lowercase is not exportish")
+	}
+	if isExportishName("") {
+		t.Error("empty is not exportish")
+	}
+	if isExportishName("_internal") {
+		t.Error("underscore-prefixed is not exportish")
+	}
+}

--- a/internal/quality/audit/report.go
+++ b/internal/quality/audit/report.go
@@ -1,0 +1,133 @@
+package audit
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// WriteJSON emits the report as indented JSON. Used by --json or whenever the
+// output path has a .json suffix.
+func (r *Report) WriteJSON(w io.Writer) error {
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	return enc.Encode(r)
+}
+
+// WriteMarkdown renders the report as a human-friendly markdown document.
+// The structure mirrors the manual analysis: per-repo summary table first,
+// then orphan classification per language, then a recommendations punch list.
+func (r *Report) WriteMarkdown(w io.Writer) error {
+	bw := &errWriter{w: w}
+	fmt.Fprintf(bw, "# Orphan Audit Report — %s\n\n", r.AuditedAt.Format("2006-01-02"))
+
+	fmt.Fprintln(bw, "## Per-repo summary")
+	fmt.Fprintln(bw, "")
+	fmt.Fprintln(bw, "| Repo | Lang(s) | Entities | Orphans (%) | IMPORTS health | REFERENCES/fn | Risk |")
+	fmt.Fprintln(bw, "|---|---|---|---|---|---|---|")
+	for _, rr := range r.Repos {
+		if rr == nil {
+			continue
+		}
+		langs := strings.Join(rr.Languages, ",")
+		orphanPct := 0.0
+		if rr.Entities > 0 {
+			orphanPct = 100.0 * float64(rr.Orphans) / float64(rr.Entities)
+		}
+		importHealth := importSummary(rr)
+		fmt.Fprintf(bw, "| %s | %s | %d | %d (%.1f%%) | %s | %.2f | %d |\n",
+			filepath.Base(rr.Path), langs, rr.Entities, rr.Orphans, orphanPct,
+			importHealth, rr.ReferencesPerFunction, rr.RiskScore)
+	}
+	fmt.Fprintln(bw, "")
+
+	fmt.Fprintln(bw, "## Orphan root-cause breakdown (per language)")
+	fmt.Fprintln(bw, "")
+	fmt.Fprintln(bw, "| Language | import-placeholder | const-no-refs | cross-file | framework-synth | real-bug | misc |")
+	fmt.Fprintln(bw, "|---|---|---|---|---|---|---|")
+	langs := make([]string, 0, len(r.Aggregate.PerLanguage))
+	for k := range r.Aggregate.PerLanguage {
+		langs = append(langs, k)
+	}
+	sort.Strings(langs)
+	for _, lang := range langs {
+		c := r.Aggregate.PerLanguage[lang].Classification
+		fmt.Fprintf(bw, "| %s | %d | %d | %d | %d | %d | %d |\n",
+			lang,
+			c[CauseImportPlaceholder], c[CauseConstNoReferences],
+			c[CauseCrossFileExport], c[CauseFrameworkSynth],
+			c[CauseRealConstructBug], c[CauseMisc])
+	}
+	fmt.Fprintln(bw, "")
+
+	fmt.Fprintln(bw, "## Per-language rollup")
+	fmt.Fprintln(bw, "")
+	fmt.Fprintln(bw, "| Language | Repos | Entities | Orphan% | Imports hygiene | Refs/fn | Risk |")
+	fmt.Fprintln(bw, "|---|---|---|---|---|---|---|")
+	for _, lang := range langs {
+		lr := r.Aggregate.PerLanguage[lang]
+		fmt.Fprintf(bw, "| %s | %d | %d | %.1f%% | %.0f%% | %.2f | %d |\n",
+			lang, lr.Repos, lr.Entities,
+			100*lr.OrphanRate, 100*lr.ImportsHygiene,
+			lr.ReferencesPerFunction, lr.RiskScore)
+	}
+	fmt.Fprintln(bw, "")
+
+	if len(r.Recommendations) > 0 {
+		fmt.Fprintln(bw, "## Top recommendations")
+		fmt.Fprintln(bw, "")
+		for _, rec := range r.Recommendations {
+			fmt.Fprintf(bw, "%d. %s — affects %d repo(s), ~%d entities recoverable\n",
+				rec.Priority, rec.Issue, rec.AffectedRepos, rec.RecoverableEntitiesEstimate)
+		}
+		fmt.Fprintln(bw, "")
+	}
+
+	return bw.err
+}
+
+// importSummary renders one repo's IMPORTS to_id format mix as a short string
+// (e.g. "100% hex" or "12% hex / 65% path"). Designed for the summary table
+// cell, so we only surface the top one or two buckets.
+func importSummary(r *RepoReport) string {
+	if r.ImportsTotal == 0 {
+		return "n/a"
+	}
+	type kv struct {
+		f ImportFormat
+		c int
+	}
+	var pairs []kv
+	for f, c := range r.ImportsToIDFormat {
+		pairs = append(pairs, kv{f, c})
+	}
+	sort.Slice(pairs, func(i, j int) bool { return pairs[i].c > pairs[j].c })
+	var parts []string
+	for i, p := range pairs {
+		if i >= 2 || p.c == 0 {
+			break
+		}
+		pct := 100.0 * float64(p.c) / float64(r.ImportsTotal)
+		parts = append(parts, fmt.Sprintf("%.0f%% %s", pct, p.f))
+	}
+	return strings.Join(parts, " / ")
+}
+
+// errWriter accumulates the first write error so render code can stay
+// straight-line without checking every Fprintf.
+type errWriter struct {
+	w   io.Writer
+	err error
+}
+
+func (e *errWriter) Write(p []byte) (int, error) {
+	if e.err != nil {
+		return 0, e.err
+	}
+	n, err := e.w.Write(p)
+	e.err = err
+	return n, err
+}

--- a/scripts/quality/audit.sh
+++ b/scripts/quality/audit.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+# CI helper that runs the orphan/quality audit across a corpus and writes
+# both a markdown summary and a machine-readable JSON sidecar under
+# reports/quality/.
+#
+# Usage:
+#   scripts/quality/audit.sh [corpus-dir]
+#
+# Env:
+#   OUT_DIR  override the report destination (default: ./reports/quality)
+set -euo pipefail
+
+CORPUS_DIR="${1:-$HOME/Documents/Projects/archigraph-corpora}"
+OUT_DIR="${OUT_DIR:-./reports/quality}"
+DATE="$(date +%Y-%m-%d)"
+
+mkdir -p "$OUT_DIR"
+
+BIN="./build/archigraph"
+if [[ ! -x "$BIN" ]]; then
+  echo "audit.sh: building $BIN" >&2
+  go build -o "$BIN" ./cmd/archigraph
+fi
+
+"$BIN" quality audit-orphans --corpus "$CORPUS_DIR" --json   --output "$OUT_DIR/orphan-audit-$DATE.json"
+"$BIN" quality audit-orphans --corpus "$CORPUS_DIR"          --output "$OUT_DIR/orphan-audit-$DATE.md"
+
+echo "audit.sh: reports written to $OUT_DIR" >&2


### PR DESCRIPTION
Adds `archigraph quality audit-orphans` subcommand that automates the orphan/quality audits previously done manually via jq pipelines (1-2 hours of work).

## What's included
- Per-repo orphan analysis with heuristic root-cause classification
  (import_placeholder / const_no_references / cross_file_export /
  framework_synthetic / real_construct_bug / misc)
- IMPORTS edge health: to_id format distribution (hex / ext_qualified /
  ext_bare / path_string / other) per language
- REFERENCES edge density per language with flag for likely-missing emission
- Per-language composite risk score (0..100)
- Markdown + JSON output, single-repo or `--corpus` directory mode
- CI script at `scripts/quality/audit.sh`

## Performance
- ~0.17s for 3 client fixtures
- ~0.71s for the full 37-repo corpus
- Well under the <5s/repo, <60s/corpus targets

## Validation
Numbers match the manual analysis at `~/private/orphan-root-cause-analysis-2026-05-19.md` exactly:
- client-fixture-b: 15091 entities, 9390 orphans (62.2%) ✓
- client-fixture-c: 9407 entities, 6580 orphans (69.9%) ✓
- IMPORTS path_string anti-pattern surfaced on fixture-b as expected
- Missing REFERENCES emission flagged as #1 recommendation for js/ts/python

## Residual root cause
n/a — this is tooling, no extractor or resolver behavior change.

## Status
at-ship-gate