### PR TITLE
[cross-repo] HTTP route ↔ fetch end-to-end matching (closes #534 Phase 2 + #533 Phase 1 loop)

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -1,0 +1,499 @@
+package links
+
+// http_pass.go implements the cross-repo HTTP route ↔ fetch matcher.
+//
+// Foundation:
+//   - #534 Phase 1 emits a synthetic `http_endpoint` entity on the
+//     producer side (backend that SERVES the route).
+//   - #534 Phase 2 attaches an IMPLEMENTS edge from the handler to its
+//     synthetic endpoint.
+//   - #533 Phase 1 emits a synthetic `http_endpoint` on the consumer
+//     side (frontend / RN / Node client that CALLS the route) and
+//     records the call-site as a `source_caller` property on the
+//     synthetic.
+//
+// This pass closes the loop. For every synthetic-entity Name shared by
+// ≥ 2 repos in the group, we look for at least one producer-side and
+// one consumer-side appearance and emit a cross-repo CALLS link from
+// the consumer's caller → the producer's handler. The link carries
+//
+//	relation   = "calls"
+//	method     = "http"
+//	channel    = "http"
+//	identifier = "http:<VERB>:<canonical-path>"
+//
+// so dashboards and graph queries can filter for typed-HTTP edges
+// independently of the structural import-pass output.
+//
+// Producer / consumer disambiguation
+// ----------------------------------
+// Each synthetic carries a `pattern_type` property set during emission
+// in #533 / #534:
+//
+//	"http_endpoint_synthesis"         → producer side
+//	"http_endpoint_client_synthesis"  → consumer side
+//
+// When the property is missing or ambiguous, we fall back to the
+// attached edges:
+//
+//	IMPLEMENTS edge from handler → endpoint  → producer
+//	CALLS edge from caller → endpoint        → consumer
+//
+// When neither signal is present we treat the synthetic as
+// producer-side by default — this matches the framework prior (most
+// http_endpoint synthetics in practice come from the producer-side
+// scan).
+//
+// Verb wildcarding
+// ----------------
+// Django emits route synthetics with `verb=ANY` because its URL
+// configuration wires HTTP methods at the View / ViewSet level rather
+// than the URL level. An `ANY`-verb endpoint MUST be matched against
+// any specific verb (`GET`, `POST`, …) from the opposite side; we
+// canonicalise pairs by collapsing `ANY` to the partner's verb when
+// emitting the identifier.
+//
+// Idempotency
+// -----------
+// The pass is method-segregated (MethodHTTP). Re-running it replaces
+// every entry whose method is "http" while leaving links from
+// import_pass, label_pass, and string_pass intact.
+
+import (
+	"sort"
+	"strings"
+)
+
+// MethodHTTP identifies this pass's emissions in links.json.
+const MethodHTTP = "http"
+
+// httpChannel is the channel string used on every emitted link.
+const httpChannel = "http"
+
+// patternTypeProducer / patternTypeConsumer match the values set by
+// the synthesis pass in internal/engine/http_endpoint_synthesis.go.
+const (
+	patternTypeProducer = "http_endpoint_synthesis"
+	patternTypeConsumer = "http_endpoint_client_synthesis"
+)
+
+// httpSide labels a synthetic as producer or consumer.
+type httpSide int
+
+const (
+	sideUnknown httpSide = iota
+	sideProducer
+	sideConsumer
+)
+
+// httpEndpointHit collects everything we need to emit a cross-repo
+// link for one synthetic-entity appearance in one repo.
+type httpEndpointHit struct {
+	repo string
+	// stampedID is the synthetic entity's on-disk ID (sha-hashed by
+	// the indexer; differs across repos for the same logical endpoint).
+	stampedID string
+	// name is the canonical `http:<VERB>:<path>` string.
+	name string
+	// verb is taken from the synthetic's `verb` property (or parsed
+	// from name as a fallback).
+	verb string
+	// canonicalPath is `path` from the synthetic's properties.
+	canonicalPath string
+	// side is producer / consumer / unknown.
+	side httpSide
+	// handlerID is the entity ID of the producer-side handler resolved
+	// via the IMPLEMENTS edge (handler → endpoint). Empty if no edge.
+	handlerID string
+	// callerID is the entity ID of the consumer-side caller resolved
+	// via a CALLS edge OR via the `source_caller` property fallback.
+	// Empty if not resolvable.
+	callerID string
+	// sourceFile is the synthetic's source file (used for SourceLocations).
+	sourceFile string
+	// framework comes from the synthetic's `framework` property.
+	framework string
+}
+
+// runHTTPPass implements the cross-repo HTTP route ↔ fetch matcher.
+// See the file header for the contract.
+func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "http"}
+
+	if len(graphs) < 2 {
+		// Method-segregated overwrite still runs so a previous group of
+		// ≥ 2 repos that shrunk to 1 cleans up its prior HTTP entries.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodHTTP), nil, rejects)
+		return res, err
+	}
+
+	// Pre-compute the per-repo IMPLEMENTS / CALLS edges that target each
+	// http_endpoint synthetic. We key by the local stampedID so we can
+	// look the edges up while iterating entities.
+	type endpointEdges struct {
+		implementsFrom []string // handler entity IDs (producer side)
+		callsFrom      []string // caller entity IDs (consumer side)
+	}
+	// repo → endpointEntityID → endpointEdges
+	edgesByEndpoint := map[string]map[string]*endpointEdges{}
+	for _, g := range graphs {
+		m := map[string]*endpointEdges{}
+		edgesByEndpoint[g.Repo] = m
+		for _, e := range g.Edges {
+			switch strings.ToUpper(e.Kind) {
+			case "IMPLEMENTS":
+				ee := m[e.ToID]
+				if ee == nil {
+					ee = &endpointEdges{}
+					m[e.ToID] = ee
+				}
+				ee.implementsFrom = append(ee.implementsFrom, e.FromID)
+			case "CALLS":
+				ee := m[e.ToID]
+				if ee == nil {
+					ee = &endpointEdges{}
+					m[e.ToID] = ee
+				}
+				ee.callsFrom = append(ee.callsFrom, e.FromID)
+			}
+		}
+	}
+
+	// Index: synthetic name → repo → []hit.
+	hits := map[string]map[string][]*httpEndpointHit{}
+	for _, g := range graphs {
+		edgesForRepo := edgesByEndpoint[g.Repo]
+		// Index entities-by-(kind,name,file) so source_caller refs can
+		// be resolved to stamped entity IDs in the same file.
+		type entKey struct{ kind, name, file string }
+		entIDByKey := map[entKey]string{}
+		for _, e := range g.Entities {
+			if e.Kind == httpEndpointKindLink {
+				continue
+			}
+			k := entKey{e.Kind, e.Name, e.SourceFile}
+			if _, ok := entIDByKey[k]; !ok {
+				entIDByKey[k] = e.ID
+			}
+		}
+		for _, e := range g.Entities {
+			if e.Kind != httpEndpointKindLink {
+				continue
+			}
+			if e.Name == "" {
+				continue
+			}
+			hit := &httpEndpointHit{
+				repo:       g.Repo,
+				stampedID:  e.ID,
+				name:       e.Name,
+				sourceFile: e.SourceFile,
+			}
+			if e.Properties != nil {
+				hit.verb = e.Properties["verb"]
+				hit.canonicalPath = e.Properties["path"]
+				hit.framework = e.Properties["framework"]
+				switch e.Properties["pattern_type"] {
+				case patternTypeProducer:
+					hit.side = sideProducer
+				case patternTypeConsumer:
+					hit.side = sideConsumer
+				}
+				// Resolve source_caller (consumer side) to a stamped
+				// entity ID in the same file. Falls through silently
+				// when missing or unresolvable.
+				if ref := e.Properties["source_caller"]; ref != "" {
+					if kind, name, ok := splitKindNameRef(ref); ok {
+						if id := entIDByKey[entKey{kind, name, e.SourceFile}]; id != "" {
+							hit.callerID = id
+						}
+					}
+				}
+			}
+			// Fallbacks: derive verb / path from the canonical name if
+			// the properties weren't populated for some reason.
+			if hit.verb == "" || hit.canonicalPath == "" {
+				if v, p, ok := parseHTTPName(e.Name); ok {
+					if hit.verb == "" {
+						hit.verb = v
+					}
+					if hit.canonicalPath == "" {
+						hit.canonicalPath = p
+					}
+				}
+			}
+			// Edge-based side resolution.
+			if ee := edgesForRepo[e.ID]; ee != nil {
+				if len(ee.implementsFrom) > 0 {
+					if hit.side == sideUnknown {
+						hit.side = sideProducer
+					}
+					hit.handlerID = ee.implementsFrom[0]
+				}
+				if len(ee.callsFrom) > 0 {
+					if hit.side == sideUnknown {
+						hit.side = sideConsumer
+					}
+					if hit.callerID == "" {
+						hit.callerID = ee.callsFrom[0]
+					}
+				}
+			}
+			// Final default: when no signal at all is available, treat
+			// as producer-side. Most http_endpoint synthetics in
+			// practice come from the producer-side scan.
+			if hit.side == sideUnknown {
+				hit.side = sideProducer
+			}
+			byRepo := hits[e.Name]
+			if byRepo == nil {
+				byRepo = map[string][]*httpEndpointHit{}
+				hits[e.Name] = byRepo
+			}
+			byRepo[g.Repo] = append(byRepo[g.Repo], hit)
+		}
+	}
+
+	// Verb wildcarding: build a parallel index from (path) → []hit so
+	// `ANY`-verb endpoints can be matched against any specific-verb
+	// endpoint with the same path.
+	byPath := map[string][]*httpEndpointHit{}
+	for _, byRepo := range hits {
+		for _, perRepo := range byRepo {
+			for _, h := range perRepo {
+				if h.canonicalPath == "" {
+					continue
+				}
+				byPath[h.canonicalPath] = append(byPath[h.canonicalPath], h)
+			}
+		}
+	}
+
+	now := discoveredAt()
+	emitted := map[string]bool{}
+	var fresh []Link
+
+	// Deterministic iteration order: sort names.
+	names := make([]string, 0, len(hits))
+	for n := range hits {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		byRepo := hits[name]
+		// Producers & consumers for this exact name.
+		producers, consumers := splitSidesAcrossRepos(byRepo)
+
+		// Verb wildcarding: if `name` has verb=ANY, also pull in any
+		// specific-verb hits with the same path; conversely if `name`
+		// has a specific verb, also pull in ANY-verb hits with the same
+		// path. The wildcarded counterpart contributes producer /
+		// consumer hits keyed by ITS own repo set.
+		if verb, p, ok := parseHTTPName(name); ok {
+			for _, h := range byPath[p] {
+				if h.name == name {
+					continue
+				}
+				hVerb, _, _ := parseHTTPName(h.name)
+				if !verbsCompatible(verb, hVerb) {
+					continue
+				}
+				if h.side == sideProducer {
+					producers = appendUnique(producers, h)
+				} else if h.side == sideConsumer {
+					consumers = appendUnique(consumers, h)
+				}
+			}
+		}
+
+		if len(producers) == 0 || len(consumers) == 0 {
+			continue
+		}
+		// Emit one link per (consumer-repo, producer-repo) cross-repo
+		// pair. Within a repo-pair we pick the first hit on each side
+		// (sorted by file then stampedID for determinism).
+		sort.SliceStable(producers, func(i, j int) bool { return less(producers[i], producers[j]) })
+		sort.SliceStable(consumers, func(i, j int) bool { return less(consumers[i], consumers[j]) })
+
+		// Group by repo (first hit per repo, per side).
+		firstByRepo := func(hh []*httpEndpointHit) map[string]*httpEndpointHit {
+			out := map[string]*httpEndpointHit{}
+			for _, h := range hh {
+				if _, ok := out[h.repo]; !ok {
+					out[h.repo] = h
+				}
+			}
+			return out
+		}
+		producerRepos := firstByRepo(producers)
+		consumerRepos := firstByRepo(consumers)
+
+		consumerRepoNames := sortedKeys(consumerRepos)
+		producerRepoNames := sortedKeys(producerRepos)
+
+		for _, cRepo := range consumerRepoNames {
+			for _, pRepo := range producerRepoNames {
+				if cRepo == pRepo {
+					continue // never emit a self-pair as a cross-repo edge
+				}
+				c := consumerRepos[cRepo]
+				p := producerRepos[pRepo]
+
+				// Source / target: consumer's caller → producer's handler.
+				// If either side hasn't resolved to a real entity, fall
+				// back to the synthetic stampedID so the link still
+				// points at something meaningful.
+				srcID := c.callerID
+				if srcID == "" {
+					srcID = c.stampedID
+				}
+				tgtID := p.handlerID
+				if tgtID == "" {
+					tgtID = p.stampedID
+				}
+				source := entityKey(c.repo, srcID)
+				target := entityKey(p.repo, tgtID)
+				id := MakeID(source, target, MethodHTTP)
+				if emitted[id] {
+					continue
+				}
+				emitted[id] = true
+
+				ident := canonicalIdentifier(c, p)
+				ch := httpChannel
+				link := Link{
+					ID:           id,
+					Source:       source,
+					Target:       target,
+					Relation:     RelationCalls,
+					Method:       MethodHTTP,
+					Confidence:   ScoreImport(),
+					Channel:      &ch,
+					Identifier:   &ident,
+					DiscoveredAt: now,
+					SourceLocations: [][]string{
+						{c.sourceFile},
+						{p.sourceFile},
+					},
+				}
+				fresh = append(fresh, link)
+			}
+		}
+	}
+
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodHTTP), fresh, rejects)
+	if err != nil {
+		return res, err
+	}
+	res.LinksAdded = added
+	res.Skipped = skipped
+	return res, nil
+}
+
+// splitSidesAcrossRepos partitions every hit under `byRepo` into
+// producer / consumer slices. Hits with sideUnknown were already
+// re-classified by runHTTPPass before reaching here (default →
+// producer).
+func splitSidesAcrossRepos(byRepo map[string][]*httpEndpointHit) (producers, consumers []*httpEndpointHit) {
+	for _, hh := range byRepo {
+		for _, h := range hh {
+			switch h.side {
+			case sideProducer:
+				producers = append(producers, h)
+			case sideConsumer:
+				consumers = append(consumers, h)
+			}
+		}
+	}
+	return
+}
+
+// less is the deterministic ordering for cross-repo hit selection.
+func less(a, b *httpEndpointHit) bool {
+	if a.repo != b.repo {
+		return a.repo < b.repo
+	}
+	if a.sourceFile != b.sourceFile {
+		return a.sourceFile < b.sourceFile
+	}
+	return a.stampedID < b.stampedID
+}
+
+// appendUnique appends h to hh only if no existing entry has the same
+// stampedID (within the same repo).
+func appendUnique(hh []*httpEndpointHit, h *httpEndpointHit) []*httpEndpointHit {
+	for _, x := range hh {
+		if x.repo == h.repo && x.stampedID == h.stampedID {
+			return hh
+		}
+	}
+	return append(hh, h)
+}
+
+// sortedKeys returns the deterministic sorted key list of m.
+func sortedKeys(m map[string]*httpEndpointHit) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// parseHTTPName parses `http:<VERB>:<path>` into its parts.
+// Returns ok=false when the input doesn't have that shape.
+func parseHTTPName(name string) (verb, path string, ok bool) {
+	const prefix = "http:"
+	if !strings.HasPrefix(name, prefix) {
+		return "", "", false
+	}
+	rest := name[len(prefix):]
+	i := strings.IndexByte(rest, ':')
+	if i <= 0 || i == len(rest)-1 {
+		return "", "", false
+	}
+	return rest[:i], rest[i+1:], true
+}
+
+// verbsCompatible reports whether two verbs may refer to the same
+// logical endpoint. ANY (case-insensitive) matches everything; otherwise
+// the verbs must match case-insensitively.
+func verbsCompatible(a, b string) bool {
+	a = strings.ToUpper(a)
+	b = strings.ToUpper(b)
+	if a == "ANY" || b == "ANY" {
+		return true
+	}
+	return a == b
+}
+
+// canonicalIdentifier picks the most specific verb available across
+// the two sides when emitting the link's `identifier` field. If one
+// side has verb=ANY and the other has GET (etc.), prefer the specific
+// verb. Falls back to the consumer's verb otherwise.
+func canonicalIdentifier(c, p *httpEndpointHit) string {
+	verb := strings.ToUpper(c.verb)
+	pVerb := strings.ToUpper(p.verb)
+	if verb == "ANY" && pVerb != "" {
+		verb = pVerb
+	}
+	if verb == "" {
+		verb = pVerb
+	}
+	path := c.canonicalPath
+	if path == "" {
+		path = p.canonicalPath
+	}
+	return "http:" + verb + ":" + path
+}
+
+// splitKindNameRef parses "<Kind>:<Name>" into (kind, name). The Kind
+// never contains a colon by construction of the synthesis pass.
+func splitKindNameRef(ref string) (kind, name string, ok bool) {
+	i := strings.IndexByte(ref, ':')
+	if i <= 0 || i == len(ref)-1 {
+		return "", "", false
+	}
+	return ref[:i], ref[i+1:], true
+}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -1,0 +1,309 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestHTTPPass_ProducerConsumerMatch verifies the canonical happy path:
+// a Django-style producer synthetic with `pattern_type=http_endpoint_synthesis`
+// plus an IMPLEMENTS edge from a handler entity, and a fetch-style consumer
+// synthetic with `pattern_type=http_endpoint_client_synthesis` plus a
+// resolvable `source_caller` property, produce one cross-repo CALLS link
+// from caller → handler with channel=http and identifier=http:GET:/users/{id}.
+func TestHTTPPass_ProducerConsumerMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id": "h1", "name": "UserView", "kind": "Controller",
+				"source_file": "app/views.py",
+			},
+			{
+				"id": "ep1", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/users/{id}",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id": "fn1", "name": "loadUser", "kind": "Function",
+				"source_file": "src/api.ts",
+			},
+			{
+				"id": "ep2", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/users/{id}",
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadUser",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("ghttp", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "ghttp-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected at least one http-method link, got %+v", doc.Links)
+	}
+	if hit.Source != "frontend::fn1" {
+		t.Errorf("source: want frontend::fn1 (resolved caller), got %s", hit.Source)
+	}
+	if hit.Target != "backend::h1" {
+		t.Errorf("target: want backend::h1 (resolved handler), got %s", hit.Target)
+	}
+	if hit.Relation != RelationCalls {
+		t.Errorf("relation: want calls, got %s", hit.Relation)
+	}
+	if hit.Channel == nil || *hit.Channel != "http" {
+		t.Errorf("channel: want http, got %v", hit.Channel)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "http:GET:/users/{id}" {
+		t.Errorf("identifier: want http:GET:/users/{id}, got %v", hit.Identifier)
+	}
+}
+
+// TestHTTPPass_AnyVerbWildcard verifies Django-style producer endpoints
+// with verb=ANY can match consumer endpoints with a specific verb
+// (GET/POST/...) when their canonical paths agree.
+func TestHTTPPass_AnyVerbWildcard(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "UserView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:ANY:/users/{id}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "ANY",
+					"path":         "/users/{id}",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "loadUser", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/users/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/users/{id}",
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadUser",
+				},
+			},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("ghttp-any", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "ghttp-any-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method != MethodHTTP {
+			continue
+		}
+		if l.Identifier != nil && *l.Identifier == "http:GET:/users/{id}" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ANY ↔ GET wildcard match emitting identifier http:GET:/users/{id}; got %+v", doc.Links)
+	}
+}
+
+// TestHTTPPass_NoMatchWhenOnlyOneSide verifies that two repos that both
+// emit producer-side synthetics for the same endpoint do NOT produce a
+// CALLS link. Cross-repo CALLS requires at least one consumer side.
+func TestHTTPPass_NoMatchWhenOnlyOneSide(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "service-a",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "View", "kind": "Controller", "source_file": "a.py"},
+			{
+				"id": "ep1", "name": "http:GET:/foo", "kind": "http_endpoint",
+				"source_file": "a.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/foo", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "service-b",
+		Entities: []map[string]any{
+			{"id": "h2", "name": "View", "kind": "Controller", "source_file": "b.py"},
+			{
+				"id": "ep2", "name": "http:GET:/foo", "kind": "http_endpoint",
+				"source_file": "b.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/foo", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h2", "to_id": "ep2", "kind": "IMPLEMENTS"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("ghttp-no-consumer", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "ghttp-no-consumer-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			t.Errorf("expected zero http-method links without a consumer side, got %+v", l)
+		}
+	}
+}
+
+// TestHTTPPass_FallbackToSyntheticEntities verifies the graceful fallback:
+// when the producer hasn't resolved an IMPLEMENTS edge (Phase-2 resolver
+// dropped the synthetic? or the handler couldn't be matched), the link
+// still emits with the synthetic stampedIDs as endpoints.
+func TestHTTPPass_FallbackToSyntheticEntities(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			// No handler entity, no IMPLEMENTS edge — just the synthetic.
+			{
+				"id": "ep1", "name": "http:GET:/foo", "kind": "http_endpoint",
+				"source_file": "a.py",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/foo", "framework": "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id": "ep2", "name": "http:GET:/foo", "kind": "http_endpoint",
+				"source_file": "x.ts",
+				"properties": map[string]any{
+					"verb": "GET", "path": "/foo", "framework": "fetch",
+					"pattern_type": "http_endpoint_client_synthesis",
+				},
+			},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("ghttp-fallback", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "ghttp-fallback-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method != MethodHTTP {
+			continue
+		}
+		// Fallback: source = consumer synthetic, target = producer synthetic.
+		if l.Source == "frontend::ep2" && l.Target == "backend::ep1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected fallback http-method link frontend::ep2 → backend::ep1, got %+v", doc.Links)
+	}
+}
+
+// TestHTTPPass_VerbsCompatible verifies the verb compatibility helper.
+func TestHTTPPass_VerbsCompatible(t *testing.T) {
+	cases := []struct {
+		a, b string
+		want bool
+	}{
+		{"GET", "GET", true},
+		{"get", "GET", true},
+		{"GET", "POST", false},
+		{"ANY", "GET", true},
+		{"GET", "ANY", true},
+		{"ANY", "ANY", true},
+		{"", "GET", false},
+	}
+	for _, c := range cases {
+		if got := verbsCompatible(c.a, c.b); got != c.want {
+			t.Errorf("verbsCompatible(%q,%q) = %v, want %v", c.a, c.b, got, c.want)
+		}
+	}
+}
+
+// TestHTTPPass_ParseHTTPName verifies the canonical-name parser.
+func TestHTTPPass_ParseHTTPName(t *testing.T) {
+	cases := []struct {
+		in        string
+		verb      string
+		path      string
+		ok        bool
+	}{
+		{"http:GET:/users/{id}", "GET", "/users/{id}", true},
+		{"http:ANY:/foo", "ANY", "/foo", true},
+		{"http:GET:", "", "", false},
+		{"http:/foo", "", "", false},
+		{"nothttp:GET:/x", "", "", false},
+	}
+	for _, c := range cases {
+		v, p, ok := parseHTTPName(c.in)
+		if ok != c.ok || v != c.verb || p != c.path {
+			t.Errorf("parseHTTPName(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, v, p, ok, c.verb, c.path, c.ok)
+		}
+	}
+}

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -50,6 +50,12 @@ const (
 	MethodStringResolved     = "string+resolved"
 )
 
+// (Re-declared in http_pass.go; this comment is the public anchor.)
+//
+// MethodHTTP identifies cross-repo HTTP route ↔ fetch links emitted by
+// runHTTPPass — see http_pass.go for the contract. Declared in the
+// pass file so the constant lives next to its consumer.
+
 // Link is one cross-repo edge.
 type Link struct {
 	ID              string     `json:"id"`
@@ -215,6 +221,16 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 		return nil, fmt.Errorf("string pass: %w", err)
 	}
 	res.Results = append(res.Results, p3)
+
+	// P4 — cross-repo HTTP route ↔ fetch matcher (this pass). Runs
+	// after the structural / label / string passes so that its
+	// method-segregated entries are rewritten cleanly without
+	// disturbing earlier output.
+	p4, err := runHTTPPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("http pass: %w", err)
+	}
+	res.Results = append(res.Results, p4)
 
 	for _, r := range res.Results {
 		res.TotalLinks += r.LinksAdded


### PR DESCRIPTION
## Summary

Wires the daemon-side linker to match `http_endpoint` synthetic entities
across group members and emit cross-repo CALLS links from consumer-side
fetch / axios call sites to producer-side handlers.

Closes the loop opened by:

- #534 Phase 1: producer-side synthetic emission (JAX-RS, Spring MVC,
  Django, Flask, FastAPI, Express).
- #534 Phase 2: IMPLEMENTS edges (handler → endpoint).
- #533 Phase 1: consumer-side fetch / axios / requests static-URL
  detection (with `source_caller` attribution).

The new `runHTTPPass` registers a fourth pass (after P1 import / P2 label /
P3 string) in `RunAllPasses`. It is fully method-segregated under a new
`method=http` bucket, so re-running it rewrites only its own
`links.json` entries.

### Matching algorithm

1. Index every `http_endpoint` entity by canonical name across all repos
   in the group.
2. Partition hits per name into **producer-side** and **consumer-side**
   using:
   - `properties.pattern_type` — `http_endpoint_synthesis` (producer) vs
     `http_endpoint_client_synthesis` (consumer); emitted by the
     synthesis pass in `internal/engine/`.
   - Edge fallback — IMPLEMENTS edge to the endpoint ⇒ producer; CALLS
     edge ⇒ consumer. Hits without any signal default to producer
     (matches the framework prior).
3. For each (consumer-repo, producer-repo) cross-repo pair, emit one
   CALLS link with `channel=http`, `identifier=http:<VERB>:<path>`.
4. **Verb wildcarding:** an endpoint with `verb=ANY` (used by Django,
   which wires methods at the View level) matches any specific verb on
   the same canonical path. The emitted identifier prefers the specific
   verb when only one side knows it.
5. **Source / target resolution:** prefer the producer's IMPLEMENTS-edge
   handler and the consumer's `source_caller` (resolved against same-file
   entity by `(kind, name, file)`). Falls back to synthetic stampedIDs
   when neither has resolved.

### Files

- `internal/links/http_pass.go` — new pass (482 LOC).
- `internal/links/http_pass_test.go` — 6 unit tests (producer/consumer
  happy path, ANY-verb wildcard, no-match-when-only-one-side, fallback
  to synthetic entities, verb compatibility, name parser).
- `internal/links/links.go` — wire `runHTTPPass` into `RunAllPasses` as
  P4 plus the `MethodHTTP` constant anchor comment.

## Validation on user's client-fixture group

```
Total links: 606
By method:
  import       471
  label_match  135
HTTP route matches (cross-repo): 0
```

The existing 471 import-channel links + 135 label_match links remain
**byte-identical** to the baseline; the new pass does not affect the
other passes' output.

### Why 0 cross-repo HTTP matches today

The linker is correct. Per-repo `http_endpoint` synthetics:

| repo | count | shape |
|---|---|---|
| client-fixture-a (Django) | 75 | URL-prefix only: `/api/v1`, `/checklists`, `/auth/login`, … (verb=ANY) |
| client-fixture-b (React, fetch/axios) | 25 | literal-string fragments: `/segment`, `/id`, `/note`, `/version.txt` |
| client-fixture-c (React Native) | 4 | `/window` × 4 (false positives from Express regex matching `Dimensions.get('window')`) |

There is **zero overlap** between any pair of repos because:

- Django's `django_routes` AST pass emits only the URL prefix
  (`path("aoc", include(...))` → `/aoc`), not the full nested route
  (`/aoc/...`). So Django paths sit at the URL-tree root.
- The Express regex in `synthesizeExpress` is greedy enough to match
  React's `apiClient.get("/segment")` as if it were Express's
  `app.get("/segment", handler)`, and only captures the literal-string
  body — so consumer fetches look like single-segment paths.

Both are extractor-side gaps, not linker gaps. Canonicalization
(`internal/engine/httproutes/canonicalize.go`) is applied symmetrically
on both sides — verified by re-reading `applyHTTPEndpointSynthesis`,
which routes producer and consumer paths through `Canonicalize` with
the same framework key.

### Sample test fixtures (synthetic, in unit tests)

Producer side:
```json
{
  "id": "ep1",
  "name": "http:GET:/users/{id}",
  "kind": "http_endpoint",
  "properties": {"verb":"GET","path":"/users/{id}","framework":"django","pattern_type":"http_endpoint_synthesis"}
}
```
+ `IMPLEMENTS` edge `h1 → ep1`.

Consumer side:
```json
{
  "id": "ep2",
  "name": "http:GET:/users/{id}",
  "kind": "http_endpoint",
  "properties": {"verb":"GET","path":"/users/{id}","framework":"fetch","pattern_type":"http_endpoint_client_synthesis","source_caller":"Function:loadUser"}
}
```

Emitted link (verified by `TestHTTPPass_ProducerConsumerMatch`):
```
source     : frontend::fn1          (resolved caller)
target     : backend::h1            (resolved handler via IMPLEMENTS)
relation   : calls
method     : http
channel    : http
identifier : http:GET:/users/{id}
```

## Residual root cause

The remaining gap to "10–30 cross-repo HTTP links on the user's group"
is **producer- and consumer-side extractor coverage**, not the linker:

1. Producer-side: Django's `django_routes` AST pass needs to recurse
   through `include(...)` to emit fully-qualified routes (the path the
   client actually calls), not just the URL prefix. Same applies to
   nested Express routers and Flask blueprints.
2. Consumer-side: the `synthesizeFetchAxios` / `synthesizePyClient`
   regexes need to interpolate template prefixes (`${apiUrl}/...`,
   `axios.defaults.baseURL + path`) so the canonical path includes the
   full producer-visible path.
3. Express false-positives (the `/window` and `/segment` family) need a
   stronger negative filter — currently `synthesizeExpress` claims any
   `<obj>.get("...")` call, even when `<obj>` is a React fetch client.

These are out of scope for the linker change but are the next steps to
turn this PR's zero into the targeted 10–30 matches.

## Status

- Cross-repo HTTP linker: implemented + unit-tested + integration-tested
  against the client-fixture group.
- Existing passes (import, label, string): byte-identical output.
- Bug-rate: unchanged (cross-repo work doesn't touch per-repo extraction).
- Next: producer- and consumer-side extractor coverage (#534 Phase-3
  candidates).

## Test plan

- [x] `go test ./internal/links/...` — all green (6 new tests).
- [x] `go test ./...` — full suite green, no regressions.
- [x] `archigraph rebuild client-fixture` — 606 links emitted, baseline
      preserved (471 import + 135 label_match).
- [x] Manually inspected `~/.archigraph/groups/client-fixture-links.json`
      for HTTP-method entries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)