### PR TITLE
[js/ts] template-literal URL extraction for HTTP cross-repo matching

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -1,5 +1,5 @@
 // Client-side (consumer) synthetic http_endpoint emission for typed-HTTP
-// cross-repo matching (issue #533, Phase 1).
+// cross-repo matching (issue #533, Phase 1 + template-literal Phase 2).
 //
 // Producer-side (#534 Phase 1/2) emits one synthetic `http:<METHOD>:<path>`
 // entity per backend route. This file is the symmetric consumer pass: for
@@ -10,14 +10,20 @@
 // by Name across repos, so emitting the consumer side is sufficient to
 // land HTTP cross-repo links — no new linker code is required.
 //
-// Phase 1 covers STATIC URL literals only:
+// Phase 1 covers STATIC URL literals:
 //   - JS/TS:   fetch("/users/123"), fetch("/users/123", {method:"POST"}),
 //     axios.<verb>("/path", ...), httpClient.<verb>("/path", ...)
 //   - Python:  requests.<verb>("/path"), httpx.<verb>("/path"),
 //     aiohttp.ClientSession.<verb>("/path"), session.<verb>("/path")
 //
-// Deferred to Phase 2 chain-fixes (filed per #533 spec):
-//   - Template literals: fetch(`/users/${id}/posts`)
+// Phase 2 (this file) adds TEMPLATE-LITERAL URL extraction for JS/TS:
+//   - fetch(`/users/${id}/checklists`) → http:GET:/users/{param}/checklists
+//   - axios.post(`/api/v1/users/${userId}`, body) → http:POST:/api/v1/users/{param}
+//   - Simple constant folding: const API_BASE = "/api/v1"; fetch(`${API_BASE}/users`)
+//     → resolves API_BASE to "/api/v1" → http:GET:/api/v1/users
+//   - Unknown substitutions emit {param} as a placeholder.
+//
+// Still deferred to later chain-fixes:
 //   - URL builders: const u = new URL(...); fetch(u)
 //   - Axios instance binding: const api = axios.create({baseURL}); api.get(p)
 //   - React Query / SWR key arrays as URL surrogates
@@ -122,8 +128,140 @@ var jsFuncDeclRe = regexp.MustCompile(
 	`(?m)(?:^|[^\w$])(?:async\s+)?function\s+([A-Za-z_$][\w$]*)\s*\(|(?m)(?:^|[^\w$])(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*(?:async\s*)?\(`,
 )
 
+// ---------------------------------------------------------------------------
+// JS / TS: template-literal URL extraction (Phase 2)
+// ---------------------------------------------------------------------------
+
+// fetchTemplateLiteralRe matches fetch(`...`) where the argument is a
+// template literal containing at least one ${...} substitution.
+//
+// Capture groups:
+//   1. the raw template body (content between the outermost backticks,
+//      excluding the backticks themselves). We do a single-line scan and
+//      stop at the first newline-free closing backtick after the opening
+//      one. Multiline template literals whose path spans multiple lines are
+//      uncommon in URL context and are left for a later phase.
+//   2. optional options object (`,{...}`) to extract the HTTP method.
+//
+// The [^`\n\r]*\$\{[^`\n\r]* pattern requires at least one ${…} sequence so
+// we only match actual template strings, not plain backtick strings (those
+// are covered by fetchCallRe already).
+var fetchTemplateLiteralRe = regexp.MustCompile(
+	"(?:^|[^\\w$.])fetch\\s*\\(\\s*`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`(\\s*,\\s*\\{[^}]*\\})?",
+)
+
+// axiosLiteralTemplateLiteralRe matches axios.<verb>(`...${...}...`, ...).
+var axiosLiteralTemplateLiteralRe = regexp.MustCompile(
+	"\\baxios\\s*\\.\\s*(get|post|put|patch|delete|head|options)\\s*\\(\\s*`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`",
+)
+
+// axiosClientTemplateLiteralRe matches <ident>Client.<verb>(`...${...}...`).
+var axiosClientTemplateLiteralRe = regexp.MustCompile(
+	"\\b([A-Za-z_$][\\w$]*(?:HttpClient|Client|httpClient|apiClient))\\s*\\.\\s*(get|post|put|patch|delete|head|options)\\s*\\(\\s*`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`",
+)
+
+// jsConstStringRe matches simple string-literal const / let / var
+// declarations: `const NAME = "/value"` or `const NAME = '/value'`.
+// Used to build a lightweight constant-folding symbol table.
+//
+// Capture groups: 1=name, 2=value (without quotes).
+var jsConstStringRe = regexp.MustCompile(
+	`(?m)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*['"]([^'"]{1,256})['"]`,
+)
+
+// buildJSConstantSymbolTable returns a map from identifier name → string
+// value for every simple string-literal const declaration in the file.
+// Used by canonicalizeTemplateLiteral for constant folding.
+// Only single-line string assignments are captured; complex expressions
+// and computed values are ignored (unknown variables fold to {param}).
+func buildJSConstantSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range jsConstStringRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		value := content[m[4]:m[5]]
+		if _, dup := syms[name]; !dup {
+			syms[name] = value
+		}
+	}
+	return syms
+}
+
+// templateSubstRe matches ${<identifier>} inside a template literal.
+// We capture the identifier inside. Supports plain identifiers and simple
+// member expressions like `${obj.prop}`, `${obj.prop.sub}` — all map to
+// the leading identifier for constant-folding purposes.
+var templateSubstRe = regexp.MustCompile(`\$\{([^}]+)\}`)
+
+// canonicalizeTemplateLiteral converts a raw template-literal body (the
+// content between backticks) into a canonical URL path suitable for
+// cross-repo matching. Each `${expr}` substitution is either:
+//   - Resolved to its constant string value from syms (constant folding), or
+//   - Replaced with the `{param}` placeholder.
+//
+// The resulting string is stripped of any host prefix (via stripURLHost) and
+// validated by looksLikeURLPathOrParam before being returned. Returns ("", false)
+// when the template does not look like a URL path.
+func canonicalizeTemplateLiteral(tmpl string, syms map[string]string) (string, bool) {
+	// Replace each ${expr} with its constant value or {param}.
+	result := templateSubstRe.ReplaceAllStringFunc(tmpl, func(match string) string {
+		// Extract the expression inside ${...}.
+		inner := match[2 : len(match)-1]
+		// Trim whitespace.
+		inner = strings.TrimSpace(inner)
+		// For simple identifiers: look up in the constant symbol table.
+		// For member expressions (e.g. `obj.field`), try the full expr
+		// first, then the leading identifier.
+		if val, ok := syms[inner]; ok {
+			return val
+		}
+		// Try just the leading identifier of a dotted expression.
+		if dot := strings.IndexByte(inner, '.'); dot > 0 {
+			if val, ok := syms[inner[:dot]]; ok {
+				return val
+			}
+		}
+		return "{param}"
+	})
+
+	// Strip host prefix for absolute URLs.
+	result = stripURLHost(result)
+
+	// Validate that this looks like a URL path (absolute) or a
+	// template-parameter-prefixed path (starts with {param}).
+	if !looksLikeURLPathOrParam(result) {
+		return "", false
+	}
+
+	return result, true
+}
+
+// looksLikeURLPathOrParam extends looksLikeURLPath to also accept paths
+// that start with a {param} placeholder. These arise when the first segment
+// of the template literal is a substitution whose value is unknown, e.g.:
+//
+//	fetch(`${BASE}/users/${id}`)  →  {param}/users/{param}
+//
+// The resulting path starts with `{param}` rather than `/` because the
+// constant BASE was not resolvable. We still emit these so cross-repo
+// matching has something to work with; the linker normalises leading slashes.
+func looksLikeURLPathOrParam(s string) bool {
+	if looksLikeURLPath(s) {
+		return true
+	}
+	s = strings.TrimSpace(s)
+	// Accept {param}/... or {param} alone.
+	if strings.HasPrefix(s, "{") {
+		return true
+	}
+	return false
+}
+
 // synthesizeFetchAxios scans a JS/TS file and emits one synthetic
-// http_endpoint per detected client call. Static URL literals only.
+// http_endpoint per detected client call. Handles both static string literals
+// (Phase 1) and template literals with ${...} substitutions (Phase 2).
 func synthesizeFetchAxios(content string, emit emitFn) {
 	if !strings.Contains(content, "fetch(") &&
 		!strings.Contains(content, "axios.") &&
@@ -134,8 +272,11 @@ func synthesizeFetchAxios(content string, emit emitFn) {
 	}
 
 	funcs := indexJSEnclosingFunctions(content)
+	// Build constant symbol table once for the whole file (used by template
+	// literal folding below).
+	syms := buildJSConstantSymbolTable(content)
 
-	// fetch(...)
+	// fetch(...) — static string literals
 	for _, m := range fetchCallRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 4 {
 			continue
@@ -158,7 +299,29 @@ func synthesizeFetchAxios(content string, emit emitFn) {
 		emit(verb, canonical, "fetch", "Function", caller)
 	}
 
-	// axios.<verb>(...)
+	// fetch(`...${...}...`, ...) — template literal URLs
+	for _, m := range fetchTemplateLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		tmpl := content[m[2]:m[3]]
+		verb := "GET"
+		if len(m) >= 6 && m[4] >= 0 {
+			opts := content[m[4]:m[5]]
+			if mv := fetchMethodRe.FindStringSubmatch(opts); len(mv) >= 2 {
+				verb = strings.ToUpper(mv[1])
+			}
+		}
+		path, ok := canonicalizeTemplateLiteral(tmpl, syms)
+		if !ok {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "fetch", "Function", caller)
+	}
+
+	// axios.<verb>(...) — static string literals
 	for _, m := range axiosLiteralRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 6 {
 			continue
@@ -173,7 +336,23 @@ func synthesizeFetchAxios(content string, emit emitFn) {
 		emit(verb, canonical, "axios", "Function", caller)
 	}
 
-	// <ident>{HttpClient,Client,httpClient,apiClient}.<verb>(...)
+	// axios.<verb>(`...${...}...`) — template literal URLs
+	for _, m := range axiosLiteralTemplateLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		tmpl := content[m[4]:m[5]]
+		path, ok := canonicalizeTemplateLiteral(tmpl, syms)
+		if !ok {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "axios", "Function", caller)
+	}
+
+	// <ident>{HttpClient,Client,httpClient,apiClient}.<verb>(...) — static string literals
 	for _, m := range axiosClientRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 8 {
 			continue
@@ -185,6 +364,22 @@ func synthesizeFetchAxios(content string, emit emitFn) {
 		}
 		caller := enclosingJSFuncAt(funcs, m[0])
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, stripURLHost(path))
+		emit(verb, canonical, "http_client", "Function", caller)
+	}
+
+	// <ident>{HttpClient,Client,httpClient,apiClient}.<verb>(`...${...}...`) — template literal URLs
+	for _, m := range axiosClientTemplateLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		tmpl := content[m[6]:m[7]]
+		path, ok := canonicalizeTemplateLiteral(tmpl, syms)
+		if !ok {
+			continue
+		}
+		caller := enclosingJSFuncAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
 		emit(verb, canonical, "http_client", "Function", caller)
 	}
 }

--- a/internal/engine/http_endpoint_client_synthesis_test.go
+++ b/internal/engine/http_endpoint_client_synthesis_test.go
@@ -103,21 +103,117 @@ export async function pingHealth() {
 	requireContains(t, got, want, "absolute-url")
 }
 
-// TestSynth_Fetch_TemplateLiteralDeferred verifies that template-literal
-// URLs (Phase 2) do NOT crash the extractor and do NOT emit a malformed
-// synthetic.
-func TestSynth_Fetch_TemplateLiteralDeferred(t *testing.T) {
+// TestSynth_Fetch_TemplateLiteralSimple verifies that a fetch call with a
+// simple template-literal URL emits a canonical synthetic with {param}
+// substitution. This was deferred in Phase 1; Phase 2 (this PR) enables it.
+func TestSynth_Fetch_TemplateLiteralSimple(t *testing.T) {
 	src := "export async function fetchUser(id) {\n" +
 		"  return fetch(`/users/${id}`);\n" +
 		"}\n"
 	got, _ := runDetect(t, "typescript", "tmpl.ts", src)
+	// Must not contain raw ${...} syntax.
 	for _, id := range got {
-		if strings.Contains(id, "$") || strings.Contains(id, "{id}") {
-			// {id} would only be present if we mis-extracted the template;
-			// the deferred path means we emit nothing.
-		}
 		if strings.Contains(id, "${") {
 			t.Errorf("template literal leaked into synthetic: %q", id)
+		}
+	}
+	want := []string{"http:GET:/users/{param}"}
+	requireContains(t, got, want, "template-literal fetch")
+}
+
+// TestSynth_TemplateLiteral_MultiSegment verifies multiple ${...} substitutions
+// in the same URL template.
+func TestSynth_TemplateLiteral_MultiSegment(t *testing.T) {
+	src := "export async function fetchChecklist(userId, listId) {\n" +
+		"  return fetch(`/api/users/${userId}/checklists/${listId}`);\n" +
+		"}\n"
+	got, _ := runDetect(t, "typescript", "tmpl2.ts", src)
+	want := []string{"http:GET:/api/users/{param}/checklists/{param}"}
+	requireContains(t, got, want, "template-literal multi-segment")
+}
+
+// TestSynth_TemplateLiteral_ConstantFolding verifies that a known const
+// string is resolved before {param} substitution.
+func TestSynth_TemplateLiteral_ConstantFolding(t *testing.T) {
+	src := `const API_BASE = "/api/v1";
+
+export async function getUsers() {
+  return fetch(` + "`" + `${API_BASE}/users` + "`" + `);
+}
+
+export async function getUser(id) {
+  return fetch(` + "`" + `${API_BASE}/users/${id}` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "const-fold.ts", src)
+	want := []string{
+		"http:GET:/api/v1/users",
+		"http:GET:/api/v1/users/{param}",
+	}
+	requireContains(t, got, want, "constant-folding fetch")
+}
+
+// TestSynth_TemplateLiteral_AxiosPost verifies axios.post with a template URL.
+func TestSynth_TemplateLiteral_AxiosPost(t *testing.T) {
+	src := `import axios from "axios";
+
+export async function updateUser(userId, body) {
+  return axios.post(` + "`" + `/api/v1/users/${userId}` + "`" + `, body);
+}
+
+export async function deleteUser(userId) {
+  return axios.delete(` + "`" + `/api/v1/users/${userId}` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "axios-tmpl.ts", src)
+	want := []string{
+		"http:POST:/api/v1/users/{param}",
+		"http:DELETE:/api/v1/users/{param}",
+	}
+	requireContains(t, got, want, "axios template literal")
+}
+
+// TestSynth_TemplateLiteral_AxiosConstantFolding verifies axios with a
+// const base URL folded into the canonical path.
+func TestSynth_TemplateLiteral_AxiosConstantFolding(t *testing.T) {
+	src := `import axios from "axios";
+const BASE = "/api/v1";
+
+export async function listOrders(userId) {
+  return axios.get(` + "`" + `${BASE}/users/${userId}/orders` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "axios-const-fold.ts", src)
+	want := []string{"http:GET:/api/v1/users/{param}/orders"}
+	requireContains(t, got, want, "axios constant-folding")
+}
+
+// TestSynth_TemplateLiteral_UnknownBase verifies that when the first
+// segment is an unknown variable, we emit {param}/... as a fallback.
+func TestSynth_TemplateLiteral_UnknownBase(t *testing.T) {
+	src := `export async function fetchUser(userId) {
+  return fetch(` + "`" + `${UNKNOWN_BASE}/users/${userId}` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "unknown-base.ts", src)
+	// {param}/users/{param} — first segment is unknown
+	want := []string{"http:GET:/{param}/users/{param}"}
+	requireContains(t, got, want, "unknown base constant")
+}
+
+// TestSynth_TemplateLiteral_NonURLRejected verifies that template literals
+// that don't look like URL paths are not emitted as synthetics.
+func TestSynth_TemplateLiteral_NonURLRejected(t *testing.T) {
+	src := `export function buildMsg(name) {
+  const msg = ` + "`" + `Hello ${name}!` + "`" + `;
+  console.log(` + "`" + `greeting: ${msg}` + "`" + `);
+  fetch(` + "`" + `not-a-path-${name}` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "non-url-tmpl.ts", src)
+	for _, id := range got {
+		if strings.Contains(id, "Hello") || strings.Contains(id, "greeting") || strings.Contains(id, "not-a-path") {
+			t.Errorf("non-URL template literal produced synthetic: %q", id)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Extends the JS/TS consumer-side HTTP extractor (`internal/engine/http_endpoint_client_synthesis.go`) to capture template-literal URL arguments to `fetch()`, `axios.<verb>()`, and `*Client.<verb>()` calls
- Each `${expr}` substitution is either constant-folded (when `expr` resolves to a simple `const X = "/..."` declaration in the same file) or replaced with the `{param}` placeholder
- Adds `looksLikeURLPathOrParam` helper to accept `{param}/...` paths when the first segment is an unknown variable

**Residual root cause (PR #645 residual analysis):** Phase-1 consumer extractor used regexes that explicitly excluded `$` from the URL character class, so `fetch(\`${BASE}/users/${id}\`)` produced zero `http_endpoint` synthetics. Cross-repo matching had nothing to match against the backend routes.

## Before / After — `http_endpoint` count on JS/TS fixtures

| Fixture | Before | After | Delta |
|---------|--------|-------|-------|
| client-fixture-b (Vite+React) | 25 (all producer-side) | 32 | **+7 consumer-side** |
| client-fixture-c (RN+Expo) | 4 | 4 | 0 (no template-literal HTTP calls) |

New consumer-side synthetics from client-fixture-b:
- `http:GET:/{param}/buildings`
- `http:GET:/{param}/schedule/confirm/{param}` (with constant folding of `SCHEDULE_CONFIRM_ENDPOINT = "schedule/confirm/"`)
- `http:POST:/{param}/schedule/confirm/{param}`
- `http:POST:/{param}/schedule/import`
- `http:GET:/{param}/devices/?{param}`
- `http:GET:/{param}/devices/contract_devices/?{param}`
- `http:POST:/{param}/login`

## Bug-rate parity

- All 5 quality fixtures: 100% must-have recall (`TestHarness_FixturesCorpus` passes)
- Full `./...` test suite: 0 failures across all 40+ packages
- 27/27 synthesis unit tests pass (7 new template-literal tests added)

## Residual root cause

Phase-1 consumer extractor `fetchCallRe` / `axiosLiteralRe` excluded `$` from the URL character class, making template literals invisible. Phase-2 (this PR) adds dedicated `fetchTemplateLiteralRe`, `axiosLiteralTemplateLiteralRe`, `axiosClientTemplateLiteralRe`, and a `canonicalizeTemplateLiteral` function with constant folding.

## Status

COMPLETE. Unblocks HTTP cross-repo matching from PR #645 residual once the parallel Django nested-routes agent lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)