### PR TITLE
[django] resolve nested include() URL paths for cross-repo HTTP matching

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -398,6 +398,17 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	i.stats.pass3Rels = countEmbeddedRels(pass3Records)
 
+	// Pass 2.6 — Django nested URLconf composition.
+	// Runs after Pass 3 so the classified slice is still populated with file
+	// content. Emits fully-resolved http_endpoint entities for
+	// path("prefix", include("module.path")) chains where the per-file
+	// passes in Pass 2.5 can only see each file in isolation.
+	// Results are appended to pass3Records for buildDocument to merge.
+	if !i.skipPasses[PassFramework] {
+		nestedEntities := runDjangoNestedURLConf(classified)
+		pass3Records = append(pass3Records, nestedEntities...)
+	}
+
 	// Issue #633 — release per-file AST trees + source bytes now that the
 	// last consumer (Pass 3 cross-language extractors) has finished. The
 	// classified slice is otherwise retained until Run() returns, which on
@@ -1347,6 +1358,30 @@ func (i *Indexer) runPass3CrossLang(ctx context.Context, absRepo string, classif
 	// — this preserves the truly-external (stdlib) signal the report calls
 	// out — but cross-file user calls now resolve to a stable entity ID.
 	return out, nil
+}
+
+// runDjangoNestedURLConf runs the cross-file Django URLconf composition
+// pass over the set of classified files. It builds a content-lookup map
+// from repo-relative path to raw bytes, then delegates to
+// engine.ApplyDjangoNestedURLConf.
+func runDjangoNestedURLConf(classified []classifiedFile) []types.EntityRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	// Build a quick lookup: relPath → content (Python files only).
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte {
+		return contentByPath[relPath]
+	}
+	return engine.ApplyDjangoNestedURLConf(pyPaths, reader)
 }
 
 // stampEntityIDs computes the deterministic graph entity ID for every

--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -1,0 +1,271 @@
+// Django URLconf nested include() composition pass.
+//
+// Problem: Django's URL routing uses two-level include() composition:
+//
+//   # myproject/urls.py
+//   urlpatterns = [
+//       path("api/v1/", include("api.urls")),
+//   ]
+//   # api/urls.py
+//   urlpatterns = [
+//       path("users/<int:id>/checklists/", ChecklistView.as_view()),
+//   ]
+//
+// The full HTTP route is `/api/v1/users/{id}/checklists`. The per-file
+// YAML + AST passes emit separate Route entities for each file independently
+// — they cannot compose across files.
+//
+// This pass runs AFTER Pass 2.5 has finished, with the complete set of
+// classified Python source files available. It:
+//
+//  1. Scans every Python file for `path("<prefix>", include("<module.path>"))` calls.
+//  2. Resolves `<module.path>` (e.g. "api.urls") to a repo-relative file
+//     path (e.g. "api/urls.py").
+//  3. Parses the included file's source for its `path(...)` route declarations.
+//  4. For each child route: prepends the parent prefix, calls
+//     httproutes.Canonicalize, and emits one `http_endpoint` entity.
+//
+// The emitted entities have kind=http_endpoint and ID/Name of the form
+// `http:ANY:<canonical-path>` — identical to what applyHTTPEndpointSynthesis
+// would emit if it had cross-file context. This lets the cross-repo HTTP
+// linker (#645) match them against consumer-side fetch/axios calls.
+//
+// Refs #645 residual analysis.
+package engine
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// djangoIncludeStringRe matches `path("prefix", include("module.path"))` or
+// the re_path variant. It captures the parent prefix (group 1) and the
+// included module path string (group 2).
+//
+// Accepted forms:
+//   - path('api/v1/', include('api.urls'))
+//   - path("api/v1/", include("api.urls"))
+//   - re_path(r'^api/v1/', include('api.urls'))
+//
+// We do NOT match include(<router>.urls) here (attribute access) — that is
+// handled by the existing applyDjangoRouteComposition pass in django_routes.go.
+var djangoIncludeStringRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*include\s*\(\s*["']([^"'.][^"']*)["']\s*\)`)
+
+// djangoChildPathRe matches a `path(...)` call in a child urls.py and
+// captures the route pattern (group 1) and the view/handler reference
+// (group 2). The handler may be a bare identifier, a dotted name, or a
+// `ClassName.as_view()` call.
+//
+// We intentionally exclude lines where the second argument is itself an
+// include(...) call — recursive nesting is handled by the outer loop below.
+var djangoChildPathRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*([\w.]+(?:\s*\.\s*as_view\s*\(\s*\))?)`)
+
+// djangoChildIncludeStringRe detects whether a child file itself
+// includes further sub-modules (two levels of nesting). We recurse one
+// level only — deeper nesting is uncommon and infinite recursion is
+// avoided by the depth limit in resolveIncludedRoutes.
+var djangoChildIncludeStringRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*include\s*\(\s*["']([^"'.][^"']*)["']\s*\)`)
+
+// djangoRouterRegisterRe matches `router.register(r"prefix", ViewSet)` calls
+// in DRF-style routers files. Captures the route prefix (group 1).
+// This handles the case where a child file (e.g. routers.py) uses DRF
+// DefaultRouter/SimpleRouter registrations rather than plain path() calls.
+var djangoRouterRegisterRe = regexp.MustCompile(
+	`(?:[\w]*[Rr]outer|api_router|v\d+_router|router_v\d+)\.register\s*\(\s*r?["']([^"']*)["']`)
+
+// NestedURLConfFileReader is a function that returns the source bytes for a
+// repo-relative file path, or nil if the file is not available.
+type NestedURLConfFileReader func(relPath string) []byte
+
+// ApplyDjangoNestedURLConf runs the cross-file URLconf composition pass.
+// It returns additional http_endpoint EntityRecords derived from nested
+// include() chains. The caller appends these to the existing entity slice.
+//
+// `fileReader` is a callback used to retrieve file contents by repo-relative
+// path. It returns nil when a path is not available (not in the classified
+// set, or outside the repo).
+//
+// `parentFiles` is the set of Python source file paths (repo-relative) that
+// should be scanned as potential roots. Only files whose base name ends in
+// "urls.py" are scanned — all other Python files are skipped for efficiency.
+func ApplyDjangoNestedURLConf(
+	parentFiles []string,
+	fileReader NestedURLConfFileReader,
+) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+
+	for _, relPath := range parentFiles {
+		if !isDjangoURLFile(relPath) {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+
+		// Find all `path("prefix", include("module.path"))` bindings.
+		for _, m := range djangoIncludeStringRe.FindAllStringSubmatch(src, -1) {
+			parentPrefix := m[1]
+			modulePath := m[2]
+
+			// Resolve the Python module path to a repo-relative file path.
+			childRelPath := modulePathToFilePath(modulePath)
+			if childRelPath == "" {
+				continue
+			}
+
+			childContent := fileReader(childRelPath)
+			if len(childContent) == 0 {
+				// Try common alternative: same directory as parent.
+				childRelPath = modulePathToFilePath_relToParent(modulePath, relPath)
+				if childRelPath != "" {
+					childContent = fileReader(childRelPath)
+				}
+			}
+			if len(childContent) == 0 {
+				continue
+			}
+
+			childRoutes := extractChildRoutes(string(childContent), fileReader, childRelPath, 0)
+
+			for _, childRoute := range childRoutes {
+				composed := joinDjangoRoutePaths(parentPrefix, childRoute)
+				canonical := httproutes.Canonicalize(httproutes.FrameworkDjango, composed)
+				if canonical == "" || canonical == "/" {
+					continue
+				}
+				id := httproutes.SyntheticID("ANY", canonical)
+				if seen[id] {
+					continue
+				}
+				seen[id] = true
+
+				out = append(out, types.EntityRecord{
+					ID:         id,
+					Name:       id,
+					Kind:       httpEndpointKind,
+					SourceFile: relPath,
+					Language:   "python",
+					Properties: map[string]string{
+						"verb":         "ANY",
+						"path":         canonical,
+						"framework":    "django",
+						"pattern_type": "urlconf_nested_include",
+					},
+					EnrichmentRequired: false,
+					EnrichmentStatus:   types.StatusPending,
+					QualityScore:       0.8,
+				})
+			}
+		}
+	}
+	return out
+}
+
+// extractChildRoutes returns all route patterns declared in a child file
+// (urls.py, routers.py, or any Python file referenced by include()). It
+// handles two patterns:
+//
+//  1. Plain `path("pattern", view)` calls → extract pattern directly.
+//  2. DRF `<router>.register("prefix", ViewSet)` calls → extract prefix.
+//
+// It also handles one level of recursive string include() nesting (depth
+// limit prevents infinite loops on circular imports).
+func extractChildRoutes(src string, fileReader NestedURLConfFileReader, filePath string, depth int) []string {
+	const maxDepth = 2
+	var routes []string
+
+	// Direct routes (non-include path() calls).
+	for _, m := range djangoChildPathRe.FindAllStringSubmatch(src, -1) {
+		pattern := m[1]
+		handler := m[2]
+		// Skip calls where the second argument is `include(...)` — those are
+		// recursive includes handled separately below, or DRF
+		// `include(router.urls)` which the DRF-router pass handles.
+		if strings.HasPrefix(strings.TrimSpace(handler), "include") {
+			continue
+		}
+		routes = append(routes, pattern)
+	}
+
+	// DRF router.register() calls — handles routers.py style child files.
+	// e.g. `router.register(r"users", UserViewSet)` → yields "users".
+	for _, m := range djangoRouterRegisterRe.FindAllStringSubmatch(src, -1) {
+		routes = append(routes, m[1])
+	}
+
+	// Recursive nested string include() calls in the child file.
+	if depth < maxDepth {
+		for _, m := range djangoChildIncludeStringRe.FindAllStringSubmatch(src, -1) {
+			subPrefix := m[1]
+			subModule := m[2]
+
+			subRelPath := modulePathToFilePath(subModule)
+			if subRelPath == "" {
+				subRelPath = modulePathToFilePath_relToParent(subModule, filePath)
+			}
+			if subRelPath == "" || fileReader == nil {
+				continue
+			}
+			subContent := fileReader(subRelPath)
+			if len(subContent) == 0 {
+				continue
+			}
+			subRoutes := extractChildRoutes(string(subContent), fileReader, subRelPath, depth+1)
+			for _, sr := range subRoutes {
+				routes = append(routes, joinDjangoRoutePaths(subPrefix, sr))
+			}
+		}
+	}
+
+	return routes
+}
+
+// modulePathToFilePath converts a Python module path (e.g. "api.urls" or
+// "apps.users.urls") to a repo-relative file path (e.g. "api/urls.py").
+// Returns "" when the module path is not convertible (e.g. it references a
+// third-party package without a recognisable path component).
+func modulePathToFilePath(modulePath string) string {
+	if modulePath == "" {
+		return ""
+	}
+	// Replace dots with path separators and append .py.
+	// "api.urls"       → "api/urls.py"
+	// "apps.users.urls" → "apps/users/urls.py"
+	parts := strings.Split(modulePath, ".")
+	return filepath.Join(parts...) + ".py"
+}
+
+// modulePathToFilePath_relToParent tries to resolve a Python module path
+// relative to the parent file's directory. This handles the common pattern
+// where include("urls") is used within the same app directory.
+func modulePathToFilePath_relToParent(modulePath, parentPath string) string {
+	if modulePath == "" || parentPath == "" {
+		return ""
+	}
+	parentDir := filepath.Dir(parentPath)
+	if parentDir == "." {
+		return ""
+	}
+	parts := strings.Split(modulePath, ".")
+	return filepath.Join(append([]string{parentDir}, parts...)...) + ".py"
+}
+
+// isDjangoURLFile reports whether the repo-relative path looks like a Django
+// URLconf file. We only scan files whose base name ends in "urls.py" to
+// avoid false positives from other Python files that might incidentally
+// contain the word "path" or "include".
+func isDjangoURLFile(relPath string) bool {
+	base := filepath.Base(relPath)
+	// Matches: urls.py, myapp_urls.py, api_urls.py, etc.
+	return strings.HasSuffix(base, "urls.py")
+}

--- a/internal/engine/django_urlconf_nested_test.go
+++ b/internal/engine/django_urlconf_nested_test.go
@@ -1,0 +1,369 @@
+package engine
+
+import (
+	"testing"
+)
+
+// fileMap is a small in-memory file reader for unit tests.
+type fileMap map[string]string
+
+func (m fileMap) reader(relPath string) []byte {
+	s, ok := m[relPath]
+	if !ok {
+		return nil
+	}
+	return []byte(s)
+}
+
+// TestApplyDjangoNestedURLConf_BasicInclude verifies that a simple
+// path("prefix/", include("module.urls")) composition produces a fully
+// resolved http_endpoint entity.
+func TestApplyDjangoNestedURLConf_BasicInclude(t *testing.T) {
+	files := fileMap{
+		"myproject/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/v1/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path
+from api import views
+
+urlpatterns = [
+    path("users/", views.UserListView.as_view(), name="user-list"),
+    path("users/<int:id>/", views.UserDetailView.as_view(), name="user-detail"),
+]
+`,
+	}
+
+	pyPaths := []string{"myproject/urls.py", "api/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	wantIDs := map[string]bool{
+		"http:ANY:/api/v1/users":        false,
+		"http:ANY:/api/v1/users/{id}":   false,
+	}
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if _, ok := wantIDs[e.ID]; ok {
+			wantIDs[e.ID] = true
+		}
+	}
+	for id, found := range wantIDs {
+		if !found {
+			t.Errorf("missing expected http_endpoint %q", id)
+		}
+	}
+}
+
+// TestApplyDjangoNestedURLConf_PathParameters verifies that Django-style
+// angle-bracket path parameters are canonicalized to {name} form.
+func TestApplyDjangoNestedURLConf_PathParameters(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/v1/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path
+from api import views
+
+urlpatterns = [
+    path("users/<int:id>/checklists/", views.ChecklistView.as_view()),
+    path("items/<str:slug>/", views.ItemView.as_view()),
+]
+`,
+	}
+
+	pyPaths := []string{"urls.py", "api/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	wantIDs := map[string]bool{
+		"http:ANY:/api/v1/users/{id}/checklists": false,
+		"http:ANY:/api/v1/items/{slug}":          false,
+	}
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if _, ok := wantIDs[e.ID]; ok {
+			wantIDs[e.ID] = true
+		}
+	}
+	for id, found := range wantIDs {
+		if !found {
+			t.Errorf("missing expected http_endpoint %q", id)
+		}
+	}
+}
+
+// TestApplyDjangoNestedURLConf_TwoLevelNesting verifies recursive include()
+// composition (parent → child → grandchild). Max depth is 2 levels; this test
+// exercises the first recursive step.
+func TestApplyDjangoNestedURLConf_TwoLevelNesting(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("v1/", include("api.v1.urls")),
+]
+`,
+		"api/v1/urls.py": `
+from django.urls import path
+from api.v1 import views
+
+urlpatterns = [
+    path("users/", views.UserListView.as_view()),
+]
+`,
+	}
+
+	pyPaths := []string{"urls.py", "api/urls.py", "api/v1/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	// Two-level compose: api/ + v1/ + users/ → /api/v1/users
+	wantID := "http:ANY:/api/v1/users"
+	found := false
+	for _, e := range got {
+		if e.ID == wantID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		ids := make([]string, 0, len(got))
+		for _, e := range got {
+			ids = append(ids, e.ID)
+		}
+		t.Errorf("missing %q; got: %v", wantID, ids)
+	}
+}
+
+// TestApplyDjangoNestedURLConf_NonURLFileSkipped verifies that Python files
+// whose base name does not end in "urls.py" are not scanned.
+func TestApplyDjangoNestedURLConf_NonURLFileSkipped(t *testing.T) {
+	files := fileMap{
+		// This has the right syntax but the file is not named urls.py
+		"views.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path
+
+urlpatterns = [
+    path("users/", None),
+]
+`,
+	}
+
+	pyPaths := []string{"views.py", "api/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	for _, e := range got {
+		if e.ID == "http:ANY:/api/users" {
+			t.Errorf("should NOT have scanned views.py for urlpatterns: got %q", e.ID)
+		}
+	}
+}
+
+// TestApplyDjangoNestedURLConf_MissingChildFile verifies that a missing
+// included file is silently skipped (no panic, no spurious entities).
+func TestApplyDjangoNestedURLConf_MissingChildFile(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("nonexistent.urls")),
+]
+`,
+	}
+
+	pyPaths := []string{"urls.py"}
+	// Should not panic.
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+	if len(got) != 0 {
+		t.Errorf("expected no entities for missing child; got %d", len(got))
+	}
+}
+
+// TestApplyDjangoNestedURLConf_Dedup verifies that the same path is not
+// emitted twice when multiple parents include the same child module.
+func TestApplyDjangoNestedURLConf_Dedup(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("api.urls")),
+    path("api/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path
+
+urlpatterns = [
+    path("users/", None),
+]
+`,
+	}
+
+	pyPaths := []string{"urls.py", "api/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	count := 0
+	for _, e := range got {
+		if e.ID == "http:ANY:/api/users" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 entity for /api/users, got %d", count)
+	}
+}
+
+// TestApplyDjangoNestedURLConf_DjangoMiniFixture verifies the golden fixture
+// from internal/quality/golden/python-django-mini: path("users/", include("users.urls"))
+// in myproject/urls.py should produce /users, /users/{pk}, /users/health.
+func TestApplyDjangoNestedURLConf_DjangoMiniFixture(t *testing.T) {
+	files := fileMap{
+		"myproject/urls.py": `
+from django.contrib import admin
+from django.urls import include, path
+
+urlpatterns = [
+    path("admin/", admin.site.urls),
+    path("users/", include("users.urls")),
+]
+`,
+		"users/urls.py": `
+from django.urls import path
+from users import views
+
+urlpatterns = [
+    path("", views.UserListView.as_view(), name="user-list"),
+    path("<int:pk>/", views.UserDetailView.as_view(), name="user-detail"),
+    path("health/", views.health_check, name="user-health"),
+]
+`,
+	}
+
+	pyPaths := []string{"myproject/urls.py", "users/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	wantIDs := map[string]bool{
+		"http:ANY:/users/{pk}": false,
+		"http:ANY:/users/health": false,
+		// path("", ...) with empty pattern composes to /users
+		"http:ANY:/users": false,
+	}
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if _, ok := wantIDs[e.ID]; ok {
+			wantIDs[e.ID] = true
+		}
+	}
+	for id, found := range wantIDs {
+		if !found {
+			ids := make([]string, 0, len(got))
+			for _, e := range got {
+				ids = append(ids, e.ID)
+			}
+			t.Errorf("missing expected http_endpoint %q; got: %v", id, ids)
+		}
+	}
+}
+
+// TestApplyDjangoNestedURLConf_DRFRouterChild verifies that a child file using
+// DRF router.register() (e.g. core/routers.py) is handled correctly when
+// the parent urls.py uses include("core.routers").
+func TestApplyDjangoNestedURLConf_DRFRouterChild(t *testing.T) {
+	files := fileMap{
+		"myproject/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/v1/", include("core.routers")),
+]
+`,
+		"core/routers.py": `
+from django.urls import path, include
+from rest_framework import routers
+from core import views
+
+router = routers.DefaultRouter()
+router.register(r"health", views.HealthCheckViewSet, basename="health")
+router.register(r"users", views.UserViewSet, basename="users")
+router.register(r"checklists", views.ChecklistViewSet, basename="checklists")
+
+urlpatterns = [
+    path("", include(router.urls)),
+]
+`,
+	}
+
+	pyPaths := []string{"myproject/urls.py", "core/routers.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	wantIDs := map[string]bool{
+		"http:ANY:/api/v1/health":     false,
+		"http:ANY:/api/v1/users":      false,
+		"http:ANY:/api/v1/checklists": false,
+	}
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if _, ok := wantIDs[e.ID]; ok {
+			wantIDs[e.ID] = true
+		}
+	}
+	for id, found := range wantIDs {
+		if !found {
+			ids := make([]string, 0, len(got))
+			for _, e := range got {
+				ids = append(ids, e.ID)
+			}
+			t.Errorf("missing expected http_endpoint %q; got: %v", id, ids)
+		}
+	}
+}
+
+// TestModulePathToFilePath verifies the module-path to file-path conversion.
+func TestModulePathToFilePath(t *testing.T) {
+	tests := []struct {
+		modulePath string
+		want       string
+	}{
+		{"api.urls", "api/urls.py"},
+		{"apps.users.urls", "apps/users/urls.py"},
+		{"urls", "urls.py"},
+	}
+	for _, tt := range tests {
+		got := modulePathToFilePath(tt.modulePath)
+		if got != tt.want {
+			t.Errorf("modulePathToFilePath(%q) = %q, want %q", tt.modulePath, got, tt.want)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

Django's URL routing uses two-level `include()` composition:

```python
# myproject/urls.py
path("api/v1/", include("api.urls"))

# api/urls.py
path("users/<int:id>/checklists/", ChecklistView.as_view())
```

The full HTTP route is `/api/v1/users/{id}/checklists`. The per-file YAML + AST passes in Pass 2.5 process each file independently, so they can only emit disconnected fragment entities — they cannot compose across files. The cross-repo HTTP linker (#645) cannot match against fragments.

## Fix

Add **Pass 2.6** — a post-classification, cross-file Django URLconf composition pass in `internal/engine/django_urlconf_nested.go`.

The pass:
1. Scans every `urls.py` for `path("prefix", include("module.path"))` bindings.
2. Resolves the Python module path (`api.urls` → `api/urls.py`) to a repo-relative file path.
3. Extracts child route patterns from the included file (plain `path()` calls **and** DRF `router.register()` calls).
4. Composes full paths (`prefix + child`), canonicalizes Django angle-bracket params to `{name}` form via `httproutes.Canonicalize`, and emits one `http_endpoint` entity per composed route.

Handles:
- Plain `path()` routes in child `urls.py` files
- DRF `DefaultRouter`/`SimpleRouter` `router.register()` patterns in `routers.py` child files
- 2-level recursive string `include()` nesting (depth-limited to avoid infinite loops)
- Deduplication (`seen` map keyed on synthetic ID)
- Missing child files (silently skipped — no panic)
- Non-`urls.py` files skipped for efficiency

## Before / After — client-fixture-a

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| `http_endpoint` entities | 75 | 143 | **+68** |
| Fully-resolved `/api/v1/*` routes | 0 | 68 | **+68** |
| Handler-resolved synthetics | 74 | 74 | 0 |
| Handler-dropped | 0 | 0 | 0 |
| No-handler-prop (new entities) | 1 | 69 | +68 |

Sample new endpoint IDs emitted:
- `http:ANY:/api/v1/checklists`
- `http:ANY:/api/v1/users`
- `http:ANY:/api/v1/users/{pk}`
- `http:ANY:/api/v1/health`
- `http:ANY:/api/v1/deficiency_proposal_pricing`

## Cross-repo link delta

Pre-fix: 0 cross-repo HTTP links  
Post-fix: 0 cross-repo HTTP links

The producer side now emits correct `/api/v1/*` routes. The consumer side (Node.js client-fixture-b) uses short paths (e.g. `/deficiency_proposal_pricing`) that don't include the `/api/v1` prefix — the mismatch is a consumer-side issue separate from this PR.

## Residual root cause

Consumer fetch calls use bare paths without the API version prefix; the producer emits versioned paths. Cross-repo matching requires both sides to canonicalize to the same path string. This PR is purely the producer-side fix — the consumer-side prefix alignment is a separate follow-on.

## Quality fixtures

All 5 quality fixtures maintain 100% recall post-fix. No regressions.

Unit tests: 8 new tests in `internal/engine/django_urlconf_nested_test.go`:
- `TestApplyDjangoNestedURLConf_BasicInclude`
- `TestApplyDjangoNestedURLConf_PathParameters`
- `TestApplyDjangoNestedURLConf_TwoLevelNesting`
- `TestApplyDjangoNestedURLConf_NonURLFileSkipped`
- `TestApplyDjangoNestedURLConf_MissingChildFile`
- `TestApplyDjangoNestedURLConf_Dedup`
- `TestApplyDjangoNestedURLConf_DjangoMiniFixture`
- `TestApplyDjangoNestedURLConf_DRFRouterChild`

## Status

Producer-side fix complete. Closes the extraction gap for Django nested `include()` chains. Cross-repo link count remains 0 pending consumer-side prefix alignment (separate issue).

Refs #645