### PR TITLE
[PLT] Phase E: CLI thin-client — quality audit-orphans via daemon RPC (ADR-0017)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -12,9 +12,11 @@ import (
 	"os"
 	"path/filepath"
 	"strconv"
+	"strings"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/quality/audit"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -70,10 +72,11 @@ func runDaemon(argv []string) error {
 		log.LstdFlags|log.Lmicroseconds)
 
 	cfg := daemon.Config{
-		Layout:  layout,
-		Logger:  logger,
-		Index:   daemonIndexFunc,
-		Rebuild: daemonRebuildFunc,
+		Layout:       layout,
+		Logger:       logger,
+		Index:        daemonIndexFunc,
+		Rebuild:      daemonRebuildFunc,
+		QualityAudit: daemonQualityAuditFunc,
 
 		// Phase B — wire the watcher + scheduler. The fast reactive
 		// reindex skips Pass 4 (graph algorithms) so a freshly-saved
@@ -260,6 +263,56 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 		warning = fmt.Sprintf("link passes failed: %v", err)
 	}
 	return rebuilt, warning, nil
+}
+
+// daemonQualityAuditFunc is the QualityAuditFunc handed to daemon.Run.
+// It calls audit.AuditPath (in this process — the daemon process) and
+// serialises the result into the wire reply.
+func daemonQualityAuditFunc(args proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+	rep, err := audit.AuditPath(args.RepoPath, args.Corpus)
+	if err != nil {
+		return proto.QualityAuditReply{}, err
+	}
+
+	// Build the scalar summary by folding per-repo numbers.
+	var totalEntities, totalOrphans int
+	orphansByKind := make(map[string]int)
+	for _, rr := range rep.Repos {
+		if rr == nil {
+			continue
+		}
+		totalEntities += rr.Entities
+		totalOrphans += rr.Orphans
+		for cause, n := range rr.OrphanClassification {
+			orphansByKind[string(cause)] += n
+		}
+	}
+	orphanRate := 0.0
+	if totalEntities > 0 {
+		orphanRate = 100.0 * float64(totalOrphans) / float64(totalEntities)
+	}
+
+	// Serialise the report according to the requested format.
+	var sb strings.Builder
+	if args.JSON {
+		enc := json.NewEncoder(&sb)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(rep); err != nil {
+			return proto.QualityAuditReply{}, fmt.Errorf("encode audit report: %w", err)
+		}
+	} else {
+		if err := rep.WriteMarkdown(&sb); err != nil {
+			return proto.QualityAuditReply{}, fmt.Errorf("format audit report: %w", err)
+		}
+	}
+
+	return proto.QualityAuditReply{
+		OrphansByKind:     orphansByKind,
+		TotalEntities:     totalEntities,
+		TotalOrphans:      totalOrphans,
+		OrphanRatePercent: orphanRate,
+		Markdown:          sb.String(),
+	}, nil
 }
 
 // mustEncodeStatus is a small helper for the `status` command when it

--- a/cmd/archigraph/quality.go
+++ b/cmd/archigraph/quality.go
@@ -2,16 +2,17 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
 	"path/filepath"
-
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/quality"
-	"github.com/cajasmota/archigraph/internal/quality/audit"
 )
 
 // runQuality handles `archigraph quality <fixture-dir>`.
@@ -26,9 +27,10 @@ import (
 // the harness end-to-end honest and lets fixtures detect regressions in
 // any pass (extract / framework / cross-lang / resolver / synthesis).
 func runQuality(argv []string) error {
-	// Subverb dispatch: `quality audit-orphans <path>` runs the audit tool
-	// (internal/quality/audit) instead of the golden-fixture harness. The
-	// legacy `quality <fixture-dir>` form is preserved untouched.
+	// Subverb dispatch: `quality audit-orphans <path>` routes via the
+	// daemon's QualityAudit RPC (ADR-0017 Phase E). The legacy
+	// `quality <fixture-dir>` form runs the in-process indexer for
+	// golden-fixture CI gating and is preserved untouched.
 	if len(argv) >= 1 && (argv[0] == "audit-orphans" || argv[0] == "audit") {
 		return runAuditOrphans(argv[1:])
 	}
@@ -110,12 +112,13 @@ func runQuality(argv []string) error {
 }
 
 // runAuditOrphans is the entry point for `archigraph quality audit-orphans`.
-// It accepts a single repo path (auto-detected by looking for
-// .archigraph/graph.json) or a corpus directory under --corpus.
 //
-// Output format defaults to markdown on stdout; --json flips to JSON;
-// --output redirects to a file. The format is inferred from the output path
-// extension when both --json and --output are present without conflicts.
+// Per ADR-0017 Phase E this is a thin daemon RPC — the audit logic lives
+// in the daemon (which imports internal/quality/audit). If the daemon is
+// not running the command prints the canonical hint and exits non-zero.
+//
+// Flag surface is unchanged from the previous in-process implementation so
+// existing scripts and aliases keep working.
 func runAuditOrphans(argv []string) error {
 	fs := flag.NewFlagSet("quality audit-orphans", flag.ContinueOnError)
 	corpus := fs.String("corpus", "", "treat <path> as a corpus directory containing many indexed repos")
@@ -138,13 +141,14 @@ func runAuditOrphans(argv []string) error {
 		return fmt.Errorf("usage: archigraph quality audit-orphans [--corpus] <path> [--json] [--output FILE]")
 	}
 
-	rep, err := audit.AuditPath(path, corpusMode)
+	// Resolve to absolute so the daemon (which may have a different cwd)
+	// can open the path without ambiguity.
+	absPath, err := filepath.Abs(path)
 	if err != nil {
-		return err
+		return fmt.Errorf("resolve path: %w", err)
 	}
 
-	// Decide output format. If --output ends in .json we honour that; else
-	// the --json flag picks the encoder.
+	// Decide output format up front (mirrors the old in-process logic).
 	jsonMode := *jsonOut
 	if *outPath != "" && strings.HasSuffix(*outPath, ".json") {
 		jsonMode = true
@@ -153,6 +157,27 @@ func runAuditOrphans(argv []string) error {
 		jsonMode = false
 	}
 
+	// Dial the daemon. Fail fast with the canonical install hint.
+	c, err := client.Dial()
+	if err != nil {
+		if errors.Is(err, client.ErrDaemonNotRunning) {
+			return daemonNotRunningErr
+		}
+		return err
+	}
+	defer c.Close()
+
+	reply, err := c.QualityAudit(proto.QualityAuditRequest{
+		RepoPath: absPath,
+		Kind:     "orphans",
+		Corpus:   corpusMode,
+		JSON:     jsonMode,
+	})
+	if err != nil {
+		return fmt.Errorf("quality audit RPC: %w", err)
+	}
+
+	// Write the report.
 	var w *os.File = os.Stdout
 	if *outPath != "" {
 		f, ferr := os.Create(*outPath)
@@ -162,14 +187,8 @@ func runAuditOrphans(argv []string) error {
 		defer f.Close()
 		w = f
 	}
-	if jsonMode {
-		if err := rep.WriteJSON(w); err != nil {
-			return err
-		}
-	} else {
-		if err := rep.WriteMarkdown(w); err != nil {
-			return err
-		}
+	if _, err := fmt.Fprint(w, reply.Markdown); err != nil {
+		return err
 	}
 	if *outPath != "" {
 		fmt.Fprintf(os.Stderr, "audit-orphans: wrote %s\n", *outPath)

--- a/internal/daemon/client/client.go
+++ b/internal/daemon/client/client.go
@@ -123,3 +123,15 @@ func (c *Client) Stop() error {
 	var reply proto.StopReply
 	return c.rpc.Call(proto.ServiceName+".Stop", proto.StopArgs{}, &reply)
 }
+
+// QualityAudit forwards an audit-orphans request to the daemon. The
+// daemon runs internal/quality/audit and returns a pre-formatted report
+// alongside the scalar summary fields so the CLI can write output
+// without importing the audit package.
+func (c *Client) QualityAudit(args proto.QualityAuditRequest) (proto.QualityAuditReply, error) {
+	var reply proto.QualityAuditReply
+	if err := c.rpc.Call(proto.ServiceName+".QualityAudit", args, &reply); err != nil {
+		return proto.QualityAuditReply{}, err
+	}
+	return reply, nil
+}

--- a/internal/daemon/proto/quality.go
+++ b/internal/daemon/proto/quality.go
@@ -1,0 +1,53 @@
+// Package proto — quality audit wire types.
+//
+// QualityAuditRequest / QualityAuditReply carry the `archigraph quality
+// audit-orphans` request over the daemon socket. The daemon handles the
+// request by calling into internal/quality/audit so the CLI process has
+// no dependency on the graph or audit packages.
+package proto
+
+// QualityAuditRequest asks the daemon to audit a single repo (or a
+// corpus directory when Corpus=true).
+type QualityAuditRequest struct {
+	// RepoPath is the absolute path to audit. For a single repo it must
+	// contain .archigraph/graph.json; set Corpus=true to treat it as a
+	// flat directory of repos.
+	RepoPath string `json:"repo_path"`
+
+	// Kind selects the audit variant. The only defined value today is
+	// "orphans". Room is left for "imports", "references", etc.
+	Kind string `json:"kind"`
+
+	// Corpus mirrors the --corpus flag: treat RepoPath as a directory
+	// containing many indexed repos rather than a single repo root.
+	Corpus bool `json:"corpus,omitempty"`
+
+	// JSON requests the reply's Markdown field to be replaced with a
+	// JSON-encoded report rather than the markdown one. When false the
+	// daemon fills Markdown with the human-readable report; when true it
+	// fills Markdown with the JSON encoding of audit.Report.
+	JSON bool `json:"json,omitempty"`
+}
+
+// QualityAuditReply carries the audit summary back to the CLI.
+type QualityAuditReply struct {
+	// OrphansByKind maps each orphan cause label to its count across all
+	// repos in the request. Populated even when JSON=true.
+	OrphansByKind map[string]int `json:"orphans_by_kind"`
+
+	// TotalEntities is the sum of entities across all audited repos.
+	TotalEntities int `json:"total_entities"`
+
+	// TotalOrphans is the sum of orphans across all audited repos.
+	TotalOrphans int `json:"total_orphans"`
+
+	// OrphanRatePercent = 100 * TotalOrphans / TotalEntities. Zero when
+	// TotalEntities is zero.
+	OrphanRatePercent float64 `json:"orphan_rate_percent"`
+
+	// Markdown contains the formatted report. The format is markdown by
+	// default or JSON when QualityAuditRequest.JSON=true. The CLI writes
+	// this directly to stdout so it does not need to reconstruct the
+	// report from the scalar fields above.
+	Markdown string `json:"markdown"`
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -22,10 +22,11 @@ import (
 
 // Config configures Run. Fields are required unless documented otherwise.
 type Config struct {
-	Layout  Layout      // on-disk paths (see DefaultLayout)
-	Index   IndexFunc   // injected from cmd/archigraph
-	Rebuild RebuildFunc // injected from cmd/archigraph
-	Logger  *log.Logger // optional; defaults to stderr
+	Layout       Layout           // on-disk paths (see DefaultLayout)
+	Index        IndexFunc        // injected from cmd/archigraph
+	Rebuild      RebuildFunc      // injected from cmd/archigraph
+	QualityAudit QualityAuditFunc // injected from cmd/archigraph (Phase E)
+	Logger       *log.Logger      // optional; defaults to stderr
 
 	// Phase B optional wiring. When all four are non-nil the daemon
 	// starts the fsnotify watcher + scheduler and registers every
@@ -92,7 +93,7 @@ func Run(ctx context.Context, cfg Config) error {
 	}()
 
 	stopReq := make(chan struct{})
-	svc := newService(cfg.Index, cfg.Rebuild, cfg.Layout.SocketPath, stopReq)
+	svc := newService(cfg.Index, cfg.Rebuild, cfg.QualityAudit, cfg.Layout.SocketPath, stopReq)
 
 	// Phase B — bring up the scheduler + watcher when the caller
 	// supplied the four hooks. They are optional so tests can exercise

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -25,6 +25,12 @@ type IndexFunc func(args proto.IndexArgs) (graphPath string, statsJSON string, e
 // injected from cmd/archigraph at construction.
 type RebuildFunc func(args proto.RebuildArgs) (repos []string, warning string, err error)
 
+// QualityAuditFunc runs the audit-orphans analysis for a repo (or
+// corpus directory). Returns the pre-formatted markdown (or JSON) report
+// and the scalar summary. Like IndexFunc, the heavy audit package lives
+// in cmd/archigraph and is injected here at construction time.
+type QualityAuditFunc func(args proto.QualityAuditRequest) (reply proto.QualityAuditReply, err error)
+
 // Service is the RPC handler registered under proto.ServiceName. All
 // public methods follow the net/rpc signature so jsonrpc can invoke
 // them: func (s *Service) Method(args *T1, reply *T2) error.
@@ -33,13 +39,14 @@ type RebuildFunc func(args proto.RebuildArgs) (repos []string, warning string, e
 // in-flight tracking, and (b) the underlying IndexFunc/RebuildFunc
 // being responsible for their own concurrency.
 type Service struct {
-	startedAt  time.Time
-	socketPath string
-	index      IndexFunc
-	rebuild    RebuildFunc
-	stopReq    chan<- struct{}
-	stopped    int32 // atomic; 1 once stopReq has been closed
-	inFlight   int64
+	startedAt    time.Time
+	socketPath   string
+	index        IndexFunc
+	rebuild      RebuildFunc
+	qualityAudit QualityAuditFunc
+	stopReq      chan<- struct{}
+	stopped      int32 // atomic; 1 once stopReq has been closed
+	inFlight     int64
 
 	// Phase B — populated only when the daemon is run with a watcher
 	// + scheduler attached. Both may be nil in test wiring that
@@ -51,13 +58,14 @@ type Service struct {
 // newService wires the injected entrypoints onto a fresh Service. The
 // stopReq channel is closed by Stop to signal the server loop; the
 // service itself never re-closes it (a stopped atomic guards the close).
-func newService(idx IndexFunc, rb RebuildFunc, socketPath string, stopReq chan<- struct{}) *Service {
+func newService(idx IndexFunc, rb RebuildFunc, qa QualityAuditFunc, socketPath string, stopReq chan<- struct{}) *Service {
 	return &Service{
-		startedAt:  time.Now(),
-		socketPath: socketPath,
-		index:      idx,
-		rebuild:    rb,
-		stopReq:    stopReq,
+		startedAt:    time.Now(),
+		socketPath:   socketPath,
+		index:        idx,
+		rebuild:      rb,
+		qualityAudit: qa,
+		stopReq:      stopReq,
 	}
 }
 
@@ -188,5 +196,25 @@ func (s *Service) Stop(_ *proto.StopArgs, _ *proto.StopReply) error {
 	if atomic.CompareAndSwapInt32(&s.stopped, 0, 1) {
 		close(s.stopReq)
 	}
+	return nil
+}
+
+// QualityAudit runs the audit-orphans analysis for a repo or corpus
+// directory and returns the pre-formatted report. The heavy audit
+// package lives in cmd/archigraph; it is injected via QualityAuditFunc.
+func (s *Service) QualityAudit(args *proto.QualityAuditRequest, reply *proto.QualityAuditReply) error {
+	if s.qualityAudit == nil {
+		return errors.New("quality audit entrypoint not configured")
+	}
+	if args == nil || args.RepoPath == "" {
+		return errors.New("repo_path is required")
+	}
+	atomic.AddInt64(&s.inFlight, 1)
+	defer atomic.AddInt64(&s.inFlight, -1)
+	r, err := s.qualityAudit(*args)
+	if err != nil {
+		return err
+	}
+	*reply = r
 	return nil
 }


### PR DESCRIPTION
## Summary

- **New RPC method**: `Daemon.QualityAudit` handles `archigraph quality audit-orphans` requests. Audit logic (internal/quality/audit) runs in the daemon process — zero logic change, new transport only.
- **CLI is now a thin client**: `runAuditOrphans` dials the daemon socket and writes `reply.Markdown` to stdout. No in-process fallback. If daemon is unreachable: `daemon not running; run 'archigraph start' or reinstall via 'archigraph install'`.
- **Golden fixtures unaffected**: `archigraph quality <fixture-dir>` still runs the in-process indexer (CI/dev harness, not a user-facing daemon command).

## Files changed

| File | Change |
|---|---|
| `internal/daemon/proto/quality.go` | New — `QualityAuditRequest` / `QualityAuditReply` wire types |
| `internal/daemon/service.go` | `QualityAuditFunc` type + `Service.QualityAudit` RPC handler; `newService` signature updated |
| `internal/daemon/server.go` | `Config.QualityAudit` field threaded to `newService` |
| `internal/daemon/client/client.go` | `Client.QualityAudit()` wrapper |
| `cmd/archigraph/daemon.go` | `daemonQualityAuditFunc` injected into `daemon.Config`; adds `audit` + `strings` imports |
| `cmd/archigraph/quality.go` | `runAuditOrphans` replaced with thin RPC client; removes direct `audit` import |

## Acceptance evidence

**`go test ./...`**: all packages pass.

**`archigraph index client-fixture-d` (daemon running)**:
```
indexed /Users/jorgecajas/private/archigraph-fixtures/client-fixture-d -> .../.archigraph/graph.json
```

**`archigraph quality audit-orphans client-fixture-d` (daemon running)**:
```
# Orphan Audit Report — 2026-05-19

## Per-repo summary
| Repo | Lang(s) | Entities | Orphans (%) | IMPORTS health | REFERENCES/fn | Risk |
|---|---|---|---|---|---|---|
| client-fixture-d | java,markdown,sql | 2010 | 1232 (61.3%) | 59% ext_bare / 26% hex | 0.01 | 22 |
```

**Both commands when daemon is NOT running**:
```
daemon not running; run 'archigraph start' or reinstall via 'archigraph install'
exit: 1
```

**Bug-rate parity**: fixtures a/b/c indexed via daemon; entity/relationship counts identical to main (same `internal/engine` code path, zero changes to indexer or graph format).

**No `--standalone` / `--no-daemon` flag**: confirmed — only inline code comments, no flags.

## Test plan

- [ ] `go build ./...` — clean build
- [ ] `go test ./...` — all packages pass
- [ ] Start daemon, run `archigraph index <fixture>`, confirm output
- [ ] `archigraph quality audit-orphans <fixture>` with daemon running — markdown report on stdout
- [ ] Kill daemon, confirm both commands print the install/start hint and exit 1
- [ ] `archigraph quality <golden-fixture-dir>` still works (in-process path unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)