### PR TITLE
[v1.0 daemon] Phase C: zero-config service install (ADR-0017)

### DIFF
--- a/internal/cli/install.go
+++ b/internal/cli/install.go
@@ -1,78 +1,95 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 	"os"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cajasmota/archigraph/internal/install"
-	"github.com/cajasmota/archigraph/internal/registry"
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/service"
 )
 
+// newInstallCmd returns the `archigraph install` subcommand.
+//
+// Per ADR-0017 Phase C the old "apply a group config" semantic is
+// REMOVED. `archigraph install` is now the canonical one-liner that
+// registers the daemon as a user-level OS service (launchd on macOS,
+// systemd on Linux) and starts it.
+//
+// The --foreground flag skips service registration and just starts the
+// daemon in the foreground — useful when launchd/systemd isn't
+// cooperating and you need debug output directly in the terminal.
 func newInstallCmd() *cobra.Command {
-	var groupFlag string
+	var foreground bool
 	cmd := &cobra.Command{
-		Use:   "install [config] | --group <name>",
-		Short: "Apply a group config (hooks, watchers, MCP)",
-		RunE: func(cmd *cobra.Command, args []string) error {
+		Use:   "install",
+		Short: "Register archigraph daemon as a system service and start it",
+		Long: `Install registers the archigraph daemon as a user-level OS service
+and starts it immediately.
+
+On macOS: writes ~/Library/LaunchAgents/com.archigraph.daemon.plist and
+calls 'launchctl bootstrap'. The daemon auto-starts at every login.
+
+On Linux: writes ~/.config/systemd/user/archigraph-daemon.service and
+calls 'systemctl --user enable --now'.
+
+No sudo or root is required.
+
+Re-running install when the service is already active prints the current
+status and exits successfully (idempotent).
+
+Use --foreground to skip service registration and run the daemon directly
+in this terminal — useful for debugging launchd/systemd issues.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			out := cmd.OutOrStdout()
-			var (
-				cfgPath string
-				group   string
-			)
-			switch {
-			case groupFlag != "":
-				groups, err := registry.Groups()
-				if err != nil {
-					return err
+
+			if foreground {
+				// --foreground: skip service registration, just run the daemon
+				// in this process. Useful when launchd/systemd is misbehaving.
+				fmt.Fprintln(out, "starting archigraph daemon in foreground (Ctrl-C to stop)…")
+				if activeHooks.RunDaemon == nil {
+					return fmt.Errorf("daemon entrypoint not wired")
 				}
-				for _, g := range groups {
-					if g.Name == groupFlag {
-						cfgPath = g.ConfigPath
-						group = g.Name
-						break
-					}
-				}
-				if cfgPath == "" {
-					return fmt.Errorf("group not registered: %s", groupFlag)
-				}
-			case len(args) == 1:
-				cfgPath = args[0]
-			default:
-				return errors.New("supply a config path or --group <name>")
+				return activeHooks.RunDaemon(nil)
 			}
-			cfg, err := registry.LoadGroupConfig(cfgPath)
+
+			bin, err := os.Executable()
 			if err != nil {
+				return fmt.Errorf("resolve binary path: %w", err)
+			}
+
+			layout, err := daemon.DefaultLayout()
+			if err != nil {
+				return fmt.Errorf("resolve daemon layout: %w", err)
+			}
+
+			opts := service.Options{
+				BinPath:    bin,
+				SocketPath: layout.SocketPath,
+				LogDir:     layout.LogDir,
+			}
+
+			st, err := service.Install(opts)
+			if err != nil {
+				fmt.Fprintf(out, "✗ install failed: %v\n", err)
+				fmt.Fprintln(out, "")
+				fmt.Fprintln(out, "Try 'archigraph install --foreground' to run the daemon directly")
+				fmt.Fprintln(out, "and see error output.")
 				return err
 			}
-			if group == "" {
-				group = cfg.Name
+
+			pidStr := ""
+			if st.PID > 0 {
+				pidStr = fmt.Sprintf(" pid=%d", st.PID)
 			}
-			bin, _ := os.Executable()
-			res, err := install.Apply(install.Options{
-				Group:   group,
-				Config:  cfg,
-				BinPath: bin,
-			})
-			if err != nil {
-				return err
-			}
-			fmt.Fprintf(out, "installed group %q\n", group)
-			fmt.Fprintf(out, "  config:    %s\n", res.GroupConfigPath)
-			for _, p := range res.HooksInstalled {
-				fmt.Fprintf(out, "  hooks:     %s\n", p)
-			}
-			for _, p := range res.WatcherUnits {
-				fmt.Fprintf(out, "  watcher:   %s\n", p)
-			}
-			for _, p := range res.MCPSettings {
-				fmt.Fprintf(out, "  mcp:       %s\n", p)
-			}
+			fmt.Fprintf(out, "✓ archigraph daemon installed and running%s\n", pidStr)
+			fmt.Fprintf(out, "  socket:  %s\n", opts.SocketPath)
+			fmt.Fprintf(out, "  service: %s\n", st.UnitFile)
 			return nil
 		},
 	}
-	cmd.Flags().StringVar(&groupFlag, "group", "", "install a previously-registered group by name")
+	cmd.Flags().BoolVar(&foreground, "foreground", false,
+		"skip service registration; run the daemon directly in this terminal (debug mode)")
 	return cmd
 }

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -69,15 +69,18 @@ const primaryHelpTemplate = `archigraph — multi-repo code knowledge graphs for
 Usage:
   archigraph <command> [flags]
 
-Setup:
+First-time setup:
+  install       Register the daemon as a system service and start it
+                (replaces wizard + onboard for most users)
+
+Setup (advanced):
   wizard        Interactive setup for a new group
   onboard       Join a teammate's existing group
-  install       Apply a group config (hooks, watchers, MCP)
 
 Operate:
-  update        Update archigraph and reapply hooks
+  update        Update archigraph
   doctor        Run health checks across all groups
-  status        Show watcher + index status
+  status        Show daemon + index status
   list          List registered groups (alias: ls)
 
 Help:
@@ -91,26 +94,27 @@ Run 'archigraph help advanced' to see uninstall, rebuild, monorepo, etc.
 
 const advancedHelpText = `archigraph — full command surface
 
-Setup:
+First-time setup:
+  install [--foreground]          Register daemon as OS service + start it
+  uninstall                       Stop and remove the daemon service
+
+Setup (advanced):
   wizard                          Interactive setup for a new group
   onboard [path]                  Join a teammate's existing group
-  install <config>|--group <n>    Apply a group config
 
 Operate:
-  update [--refresh-rules-lite]   Update archigraph; reapply hooks
+  update [--refresh-rules-lite]   Update archigraph
   doctor                          Run health checks
-  status [group]                  Show watcher + last-index status
+  status [group]                  Show daemon health + per-repo state
   list                            List registered groups (alias: ls)
 
 Repair:
   rebuild [group] [slug]          Force AST rebuild (no cache, daemon RPC)
   reset [group] [slug]            Wipe .archigraph/ and rebuild via daemon
-  uninstall [group] [--purge]     Remove archigraph from a group
 
-Daemon:
+Daemon (manual):
   start | stop | restart          Daemon lifecycle (ADR-0017)
   logs [-f] [-n N]                Print or follow the daemon log
-  status                          Show daemon health + per-repo state
   watch <repo>                    Long-lived watcher (legacy; daemon owns watching)
 
 Monorepo:

--- a/internal/cli/uninstall.go
+++ b/internal/cli/uninstall.go
@@ -1,35 +1,36 @@
 package cli
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/spf13/cobra"
 
-	"github.com/cajasmota/archigraph/internal/install"
-	"github.com/cajasmota/archigraph/internal/install/mcpreg"
+	"github.com/cajasmota/archigraph/internal/daemon/service"
 )
 
+// newUninstallCmd returns the `archigraph uninstall` subcommand.
+//
+// Per ADR-0017 Phase C the old "remove from a group" semantic is
+// REMOVED. `archigraph uninstall` now stops and deregisters the
+// daemon OS service (launchd plist / systemd unit). Idempotent: if
+// the service is not installed the command succeeds silently.
 func newUninstallCmd() *cobra.Command {
-	var purge bool
 	cmd := &cobra.Command{
-		Use:   "uninstall [group]",
-		Short: "Remove archigraph from a group",
-		RunE: func(cmd *cobra.Command, args []string) error {
-			if len(args) != 1 {
-				return errors.New("uninstall expects exactly one group name")
-			}
-			group := args[0]
-			if err := install.Uninstall(group, purge); err != nil {
+		Use:   "uninstall",
+		Short: "Stop and remove the archigraph daemon service",
+		Long: `Uninstall stops the archigraph daemon and removes its OS service
+registration (launchd plist on macOS, systemd unit on Linux).
+
+Idempotent: if the service is not installed the command exits 0 without
+printing an error.`,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out := cmd.OutOrStdout()
+			if err := service.Uninstall(service.Options{}); err != nil {
 				return err
 			}
-			// Best-effort: drop the MCP entry too if no other groups remain.
-			_ = mcpreg.Unregister(mcpreg.ClaudeCode)
-			_ = mcpreg.Unregister(mcpreg.Windsurf)
-			fmt.Fprintf(cmd.OutOrStdout(), "uninstalled group %q (purge=%v)\n", group, purge)
+			fmt.Fprintln(out, "✓ archigraph daemon removed")
 			return nil
 		},
 	}
-	cmd.Flags().BoolVar(&purge, "purge", false, "also delete per-group state and config")
 	return cmd
 }

--- a/internal/daemon/service/helpers_darwin_test.go
+++ b/internal/daemon/service/helpers_darwin_test.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package service_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/service"
+)
+
+// renderPlist renders a LaunchAgent plist using test-fixture options
+// and returns it as a string. It does NOT install anything.
+func renderPlist(t *testing.T) string {
+	t.Helper()
+	data, err := service.GeneratePlist(resolvedOpts())
+	if err != nil {
+		t.Fatalf("GeneratePlist: %v", err)
+	}
+	return string(data)
+}
+
+// renderUnit is a no-op stub on macOS: systemd unit tests only run on
+// Linux. Returning a non-empty string lets the shared test file
+// compile, but the tests are skipped at runtime.
+func renderUnit(t *testing.T) string {
+	t.Skip("systemd unit tests only run on linux")
+	return ""
+}

--- a/internal/daemon/service/helpers_linux_test.go
+++ b/internal/daemon/service/helpers_linux_test.go
@@ -1,0 +1,28 @@
+//go:build linux
+
+package service_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/service"
+)
+
+// renderUnit renders a systemd user unit using test-fixture options
+// and returns it as a string. It does NOT install anything.
+func renderUnit(t *testing.T) string {
+	t.Helper()
+	data, err := service.GenerateUnit(resolvedOpts())
+	if err != nil {
+		t.Fatalf("GenerateUnit: %v", err)
+	}
+	return string(data)
+}
+
+// renderPlist is a no-op stub on Linux: launchd plist tests only run
+// on macOS. Returning a non-empty string lets the shared test file
+// compile, but the tests are skipped at runtime.
+func renderPlist(t *testing.T) string {
+	t.Skip("launchd plist tests only run on darwin")
+	return ""
+}

--- a/internal/daemon/service/install_test.go
+++ b/internal/daemon/service/install_test.go
@@ -1,0 +1,159 @@
+package service_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/service"
+)
+
+// resolvedOpts returns an Options struct with all fields filled in so
+// that template rendering does not depend on os.Executable or the real
+// user home directory.
+func resolvedOpts() service.Options {
+	return service.Options{
+		BinPath:    "/usr/local/bin/archigraph",
+		SocketPath: "/home/testuser/.archigraph/sockets/daemon.sock",
+		LogDir:     "/home/testuser/.archigraph/logs",
+	}
+}
+
+// --- macOS plist tests ---------------------------------------------------
+
+// TestGeneratePlist_ContainsLabel verifies that the rendered plist
+// contains the canonical launchd label.
+func TestGeneratePlist_ContainsLabel(t *testing.T) {
+	t.Helper()
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "com.archigraph.daemon") {
+		t.Errorf("plist missing label com.archigraph.daemon:\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_BinPath verifies that the resolved binary path
+// appears in the ProgramArguments array.
+func TestGeneratePlist_BinPath(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "/usr/local/bin/archigraph") {
+		t.Errorf("plist missing BinPath:\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_DaemonSubcmd verifies the plist invokes
+// `archigraph daemon` — the hidden long-running mode. launchd owns
+// the process lifecycle, so no `start` sub-subcommand is needed.
+func TestGeneratePlist_DaemonSubcmd(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "<string>daemon</string>") {
+		t.Errorf("plist missing daemon subcommand:\n%s", plist)
+	}
+	// Plist must NOT contain a 'start' argument — the old
+	// watcher_ctl start command forks the binary with its own
+	// already-running check that would exit 0 under launchd.
+	if strings.Contains(plist, "<string>start</string>") {
+		t.Errorf("plist must not contain 'start' argument (use 'archigraph daemon' directly):\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_KeepAlive verifies the KeepAlive key is set to
+// true so launchd restarts the daemon on crash.
+func TestGeneratePlist_KeepAlive(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "<key>KeepAlive</key>") {
+		t.Errorf("plist missing KeepAlive:\n%s", plist)
+	}
+	// The true element must follow KeepAlive — just check <true/> appears
+	// after the key (simplistic but reliable for well-formed output).
+	keepIdx := strings.Index(plist, "<key>KeepAlive</key>")
+	trueIdx := strings.Index(plist[keepIdx:], "<true/>")
+	if trueIdx < 0 {
+		t.Errorf("plist KeepAlive not set to true:\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_RunAtLoad verifies RunAtLoad=true so the daemon
+// starts automatically when the user logs in.
+func TestGeneratePlist_RunAtLoad(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "<key>RunAtLoad</key>") {
+		t.Errorf("plist missing RunAtLoad:\n%s", plist)
+	}
+	runIdx := strings.Index(plist, "<key>RunAtLoad</key>")
+	trueIdx := strings.Index(plist[runIdx:], "<true/>")
+	if trueIdx < 0 {
+		t.Errorf("plist RunAtLoad not set to true:\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_LogPaths verifies that stdout and stderr are
+// redirected to the configured log directory.
+func TestGeneratePlist_LogPaths(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.Contains(plist, "/home/testuser/.archigraph/logs/daemon.log") {
+		t.Errorf("plist missing stdout log path:\n%s", plist)
+	}
+	if !strings.Contains(plist, "/home/testuser/.archigraph/logs/daemon.err") {
+		t.Errorf("plist missing stderr log path:\n%s", plist)
+	}
+}
+
+// TestGeneratePlist_ValidXML does a minimal sanity check that the
+// output looks like well-formed plist XML.
+func TestGeneratePlist_ValidXML(t *testing.T) {
+	plist := renderPlist(t)
+	if !strings.HasPrefix(strings.TrimSpace(plist), "<?xml") {
+		t.Errorf("plist does not start with XML declaration:\n%s", plist)
+	}
+	if !strings.Contains(plist, "</plist>") {
+		t.Errorf("plist missing closing </plist> tag:\n%s", plist)
+	}
+}
+
+// --- Linux systemd unit tests --------------------------------------------
+
+// TestGenerateUnit_ExecStart verifies the ExecStart line invokes
+// `archigraph daemon` — the hidden long-running mode. systemd owns
+// the process lifecycle; no sub-subcommand is required.
+func TestGenerateUnit_ExecStart(t *testing.T) {
+	unit := renderUnit(t)
+	if !strings.Contains(unit, "ExecStart=/usr/local/bin/archigraph daemon") {
+		t.Errorf("unit missing ExecStart:\n%s", unit)
+	}
+}
+
+// TestGenerateUnit_RestartPolicy verifies Restart=on-failure is set.
+func TestGenerateUnit_RestartPolicy(t *testing.T) {
+	unit := renderUnit(t)
+	if !strings.Contains(unit, "Restart=on-failure") {
+		t.Errorf("unit missing Restart=on-failure:\n%s", unit)
+	}
+}
+
+// TestGenerateUnit_WantedBy verifies WantedBy=default.target so the
+// service is enabled for normal user login sessions.
+func TestGenerateUnit_WantedBy(t *testing.T) {
+	unit := renderUnit(t)
+	if !strings.Contains(unit, "WantedBy=default.target") {
+		t.Errorf("unit missing WantedBy=default.target:\n%s", unit)
+	}
+}
+
+// TestGenerateUnit_TypeSimple verifies Type=simple (the daemon does not
+// fork; launchd / systemd owns the process lifecycle).
+func TestGenerateUnit_TypeSimple(t *testing.T) {
+	unit := renderUnit(t)
+	if !strings.Contains(unit, "Type=simple") {
+		t.Errorf("unit missing Type=simple:\n%s", unit)
+	}
+}
+
+// TestGenerateUnit_Sections verifies the three required ini-style
+// section headers are present.
+func TestGenerateUnit_Sections(t *testing.T) {
+	unit := renderUnit(t)
+	for _, section := range []string{"[Unit]", "[Service]", "[Install]"} {
+		if !strings.Contains(unit, section) {
+			t.Errorf("unit missing section %s:\n%s", section, unit)
+		}
+	}
+}

--- a/internal/daemon/service/launchd_darwin.go
+++ b/internal/daemon/service/launchd_darwin.go
@@ -1,0 +1,215 @@
+//go:build darwin
+
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const (
+	// launchLabel is the launchd service label / plist basename.
+	launchLabel = "com.archigraph.daemon"
+
+	// socketWaitTimeout is the maximum time Install will block waiting
+	// for the daemon socket to become connectable after launchctl loads
+	// the agent.
+	socketWaitTimeout = 5 * time.Second
+)
+
+// plistTemplate is the LaunchAgent property list. The daemon runs as
+// the current user (no UserName key needed in the user launchd domain).
+// KeepAlive + RunAtLoad provide auto-start + crash-restart semantics.
+const plistTemplate = `<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+    "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>{{.Label}}</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{.BinPath}}</string>
+        <string>daemon</string>
+    </array>
+
+    <key>RunAtLoad</key>
+    <true/>
+
+    <key>KeepAlive</key>
+    <true/>
+
+    <key>StandardOutPath</key>
+    <string>{{.LogDir}}/daemon.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{.LogDir}}/daemon.err</string>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>HOME</key>
+        <string>{{.Home}}</string>
+    </dict>
+</dict>
+</plist>
+`
+
+type plistVars struct {
+	Label   string
+	BinPath string
+	LogDir  string
+	Home    string
+}
+
+// plistPath returns ~/Library/LaunchAgents/com.archigraph.daemon.plist.
+func plistPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, "Library", "LaunchAgents", launchLabel+".plist"), nil
+}
+
+// GeneratePlist renders the LaunchAgent plist for the given options.
+// Exported for testing; production code calls install() which calls
+// this internally.
+func GeneratePlist(opts Options) ([]byte, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New("plist").Parse(plistTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, plistVars{
+		Label:   launchLabel,
+		BinPath: opts.BinPath,
+		LogDir:  opts.LogDir,
+		Home:    home,
+	}); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// install is the macOS implementation of Install.
+func install(opts Options) (StatusInfo, error) {
+	path, err := plistPath()
+	if err != nil {
+		return StatusInfo{}, err
+	}
+
+	// Idempotency: if plist already exists and the service is running,
+	// just return the current status.
+	if _, err := os.Stat(path); err == nil {
+		st, sterr := status(opts)
+		if sterr == nil && st.Running {
+			return st, nil
+		}
+	}
+
+	// Ensure log directory exists before launchd writes to the log file.
+	if err := os.MkdirAll(opts.LogDir, 0o700); err != nil {
+		return StatusInfo{}, fmt.Errorf("create log dir %s: %w", opts.LogDir, err)
+	}
+
+	plist, err := GeneratePlist(opts)
+	if err != nil {
+		return StatusInfo{}, fmt.Errorf("generate plist: %w", err)
+	}
+
+	// Ensure ~/Library/LaunchAgents exists (it normally does, but may
+	// be missing on headless / CI machines).
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return StatusInfo{}, fmt.Errorf("create LaunchAgents dir: %w", err)
+	}
+
+	if err := os.WriteFile(path, plist, 0o644); err != nil {
+		return StatusInfo{}, fmt.Errorf("write plist %s: %w", path, err)
+	}
+
+	// Stop any running daemon before bootstrapping. A leftover daemon
+	// from a previous binary (or a manual 'archigraph start') holds the
+	// PID file; if it's still running the new launchd-managed process
+	// will exit immediately with "daemon already running".
+	stopRunningDaemon(opts.SocketPath)
+
+	// If a stale service entry exists (e.g. from a previous crash that
+	// left the plist without unloading), bootout first so bootstrap can
+	// succeed cleanly.
+	uid := strconv.Itoa(os.Getuid())
+	_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchLabel).Run()
+
+	// Bootstrap loads the plist and starts the service.
+	out, err := exec.Command("launchctl", "bootstrap", "gui/"+uid, path).CombinedOutput()
+	if err != nil {
+		return StatusInfo{}, fmt.Errorf("launchctl bootstrap: %w\n%s", err, out)
+	}
+
+	// Wait for the socket so callers know the daemon is ready.
+	if werr := waitForSocket(opts.SocketPath, socketWaitTimeout); werr != nil {
+		return StatusInfo{UnitFile: path, Installed: true},
+			fmt.Errorf("service loaded but socket not ready: %w", werr)
+	}
+
+	return status(opts)
+}
+
+// uninstall is the macOS implementation of Uninstall.
+func uninstall(opts Options) error {
+	path, err := plistPath()
+	if err != nil {
+		return err
+	}
+
+	uid := strconv.Itoa(os.Getuid())
+	// bootout stops + unloads. Ignore errors (service may not be loaded).
+	_ = exec.Command("launchctl", "bootout", "gui/"+uid+"/"+launchLabel).Run()
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove plist %s: %w", path, err)
+	}
+	return nil
+}
+
+// status is the macOS implementation of Status.
+func status(opts Options) (StatusInfo, error) {
+	path, err := plistPath()
+	if err != nil {
+		return StatusInfo{}, err
+	}
+
+	info := StatusInfo{UnitFile: path}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return info, nil
+	}
+	info.Installed = true
+
+	// launchctl list com.archigraph.daemon prints a tab-separated line:
+	// <pid | -> <last-exit-status> <label>
+	out, err := exec.Command("launchctl", "list", launchLabel).Output()
+	if err != nil {
+		// Exit 113 means the service isn't loaded; that's a valid "not running" state.
+		return info, nil
+	}
+	line := strings.TrimSpace(string(out))
+	fields := strings.Fields(line)
+	if len(fields) >= 1 && fields[0] != "-" {
+		info.Running = true
+		if pid, perr := strconv.Atoi(fields[0]); perr == nil {
+			info.PID = pid
+		}
+	}
+	return info, nil
+}

--- a/internal/daemon/service/service.go
+++ b/internal/daemon/service/service.go
@@ -1,0 +1,157 @@
+// Package service handles registration and removal of the archigraph
+// daemon as an OS-level user service (launchd on macOS, systemd on
+// Linux). It is the implementation layer for the `archigraph install`
+// and `archigraph uninstall` commands introduced in ADR-0017 Phase C.
+//
+// The package is platform-agnostic at this level; build-tag'd files
+// supply the platform implementations:
+//
+//   - launchd_darwin.go  — macOS LaunchAgents plist + launchctl
+//   - systemd_linux.go   — ~/.config/systemd/user unit + systemctl
+//
+// No root / sudo is required: both backends use the per-user service
+// facilities (launchd gui/$UID domain, systemd --user).
+package service
+
+import (
+	"fmt"
+	"net"
+	"net/rpc"
+	"net/rpc/jsonrpc"
+	"os"
+	"time"
+)
+
+// Options carries install-time parameters. All fields that are empty
+// strings are resolved to defaults by Install.
+type Options struct {
+	// BinPath is the absolute path to the archigraph binary. When
+	// empty, Install resolves it via os.Executable().
+	BinPath string
+
+	// SocketPath is the Unix-domain socket the daemon listens on.
+	// When empty it defaults to ~/.archigraph/sockets/daemon.sock
+	// (matches daemon.DefaultLayout).
+	SocketPath string
+
+	// LogDir is the directory for stdout/stderr logs. When empty it
+	// defaults to ~/.archigraph/logs.
+	LogDir string
+}
+
+// StatusInfo is returned by Status to describe the current state of the
+// installed service.
+type StatusInfo struct {
+	Installed bool
+	Running   bool
+	PID       int    // 0 when not running or unknown
+	UnitFile  string // path of the plist / unit file
+}
+
+// Install registers the archigraph daemon as a user-level OS service
+// and starts it. Idempotent: if the service is already installed it
+// returns the current status without modifying anything.
+//
+// On macOS it writes ~/Library/LaunchAgents/com.archigraph.daemon.plist
+// and calls `launchctl bootstrap gui/$UID`.
+//
+// On Linux it writes ~/.config/systemd/user/archigraph-daemon.service
+// and calls `systemctl --user enable --now`.
+//
+// After loading, Install waits up to 5 s for the daemon socket to
+// appear, then returns the populated StatusInfo.
+func Install(opts Options) (StatusInfo, error) {
+	if err := resolveOptions(&opts); err != nil {
+		return StatusInfo{}, fmt.Errorf("resolve options: %w", err)
+	}
+	return install(opts)
+}
+
+// Uninstall stops and removes the OS service registration. Idempotent:
+// if the service is not installed it returns immediately without error.
+func Uninstall(opts Options) error {
+	if err := resolveOptions(&opts); err != nil {
+		return fmt.Errorf("resolve options: %w", err)
+	}
+	return uninstall(opts)
+}
+
+// Status reports whether the service is installed and/or running.
+// It does not modify any state.
+func Status(opts Options) (StatusInfo, error) {
+	if err := resolveOptions(&opts); err != nil {
+		return StatusInfo{}, fmt.Errorf("resolve options: %w", err)
+	}
+	return status(opts)
+}
+
+// resolveOptions fills in empty Options fields from OS defaults. This
+// runs before any platform call so platform code can assume opts is
+// complete.
+func resolveOptions(opts *Options) error {
+	if opts.BinPath == "" {
+		bin, err := os.Executable()
+		if err != nil {
+			return fmt.Errorf("os.Executable: %w", err)
+		}
+		opts.BinPath = bin
+	}
+	if opts.SocketPath == "" || opts.LogDir == "" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return fmt.Errorf("os.UserHomeDir: %w", err)
+		}
+		if opts.SocketPath == "" {
+			opts.SocketPath = home + "/.archigraph/sockets/daemon.sock"
+		}
+		if opts.LogDir == "" {
+			opts.LogDir = home + "/.archigraph/logs"
+		}
+	}
+	return nil
+}
+
+// stopRunningDaemon sends a Stop RPC to any daemon currently listening
+// on socketPath and waits up to 3 s for the socket to disappear. It is
+// called by install before bootstrapping the new service so a leftover
+// daemon from a previous session (or a different binary) doesn't hold
+// the PID file and block the new one from starting.
+//
+// Errors are intentionally ignored: if no daemon is running, the RPC
+// dial fails silently; if the socket never disappears we proceed anyway
+// and let the OS service manager restart the daemon after it crashes.
+func stopRunningDaemon(socketPath string) {
+	conn, err := net.DialTimeout("unix", socketPath, time.Second)
+	if err != nil {
+		return // nothing listening — nothing to stop
+	}
+	client := rpc.NewClientWithCodec(jsonrpc.NewClientCodec(conn))
+	// Fire-and-forget Stop RPC. We don't care about the reply.
+	_ = client.Call("Daemon.Stop", struct{}{}, &struct{}{})
+	_ = client.Close()
+
+	// Wait up to 3 s for the socket to disappear (daemon shut down).
+	end := time.Now().Add(3 * time.Second)
+	for time.Now().Before(end) {
+		if _, err := os.Stat(socketPath); os.IsNotExist(err) {
+			return
+		}
+		time.Sleep(150 * time.Millisecond)
+	}
+}
+
+// waitForSocket polls socketPath until the file appears and is
+// connectable, or deadline is exceeded. Returns nil on success.
+func waitForSocket(socketPath string, deadline time.Duration) error {
+	const pollInterval = 200 * time.Millisecond
+	end := time.Now().Add(deadline)
+	for time.Now().Before(end) {
+		conn, err := net.DialTimeout("unix", socketPath, 200*time.Millisecond)
+		if err == nil {
+			conn.Close()
+			return nil
+		}
+		time.Sleep(pollInterval)
+	}
+	return fmt.Errorf("socket %s did not appear within %s", socketPath, deadline)
+}

--- a/internal/daemon/service/systemd_linux.go
+++ b/internal/daemon/service/systemd_linux.go
@@ -1,0 +1,187 @@
+//go:build linux
+
+package service
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+	"time"
+)
+
+const (
+	unitName          = "archigraph-daemon"
+	socketWaitTimeout = 5 * time.Second
+)
+
+// unitTemplate is the systemd user unit file. Type=simple is correct
+// because the daemon does not fork. Restart=on-failure covers crashes;
+// WantedBy=default.target ensures the service starts at user login when
+// lingering is enabled (or when a user session starts on standard
+// desktop systems).
+const unitTemplate = `[Unit]
+Description=archigraph knowledge-graph daemon
+Documentation=https://github.com/cajasmota/archigraph
+After=network.target
+
+[Service]
+Type=simple
+ExecStart={{.BinPath}} daemon
+Restart=on-failure
+RestartSec=3s
+Environment=HOME={{.Home}}
+
+[Install]
+WantedBy=default.target
+`
+
+type unitVars struct {
+	BinPath string
+	Home    string
+}
+
+// unitPath returns ~/.config/systemd/user/archigraph-daemon.service.
+func unitPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".config", "systemd", "user", unitName+".service"), nil
+}
+
+// GenerateUnit renders the systemd unit for the given options.
+// Exported for testing.
+func GenerateUnit(opts Options) ([]byte, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, err
+	}
+	tmpl, err := template.New("unit").Parse(unitTemplate)
+	if err != nil {
+		return nil, err
+	}
+	var buf bytes.Buffer
+	if err := tmpl.Execute(&buf, unitVars{
+		BinPath: opts.BinPath,
+		Home:    home,
+	}); err != nil {
+		return nil, err
+	}
+	return buf.Bytes(), nil
+}
+
+// install is the Linux implementation of Install.
+func install(opts Options) (StatusInfo, error) {
+	path, err := unitPath()
+	if err != nil {
+		return StatusInfo{}, err
+	}
+
+	// Idempotency check.
+	if _, err := os.Stat(path); err == nil {
+		st, sterr := status(opts)
+		if sterr == nil && st.Running {
+			return st, nil
+		}
+	}
+
+	// Ensure log dir exists even though systemd handles stdout/stderr
+	// via the journal; downstream code may write there directly.
+	if err := os.MkdirAll(opts.LogDir, 0o700); err != nil {
+		return StatusInfo{}, fmt.Errorf("create log dir %s: %w", opts.LogDir, err)
+	}
+
+	unit, err := GenerateUnit(opts)
+	if err != nil {
+		return StatusInfo{}, fmt.Errorf("generate unit: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return StatusInfo{}, fmt.Errorf("create systemd user dir: %w", err)
+	}
+
+	if err := os.WriteFile(path, unit, 0o644); err != nil {
+		return StatusInfo{}, fmt.Errorf("write unit %s: %w", path, err)
+	}
+
+	// Stop any running daemon before enabling+starting the systemd unit.
+	stopRunningDaemon(opts.SocketPath)
+
+	// Reload unit files so systemd picks up the new file.
+	if out, err := exec.Command("systemctl", "--user", "daemon-reload").CombinedOutput(); err != nil {
+		return StatusInfo{}, fmt.Errorf("systemctl daemon-reload: %w\n%s", err, out)
+	}
+
+	// Enable + start in one shot.
+	if out, err := exec.Command("systemctl", "--user", "enable", "--now", unitName+".service").CombinedOutput(); err != nil {
+		return StatusInfo{}, fmt.Errorf("systemctl enable --now: %w\n%s", err, out)
+	}
+
+	if werr := waitForSocket(opts.SocketPath, socketWaitTimeout); werr != nil {
+		return StatusInfo{UnitFile: path, Installed: true},
+			fmt.Errorf("service loaded but socket not ready: %w", werr)
+	}
+
+	return status(opts)
+}
+
+// uninstall is the Linux implementation of Uninstall.
+func uninstall(opts Options) error {
+	path, err := unitPath()
+	if err != nil {
+		return err
+	}
+
+	// stop + disable; ignore errors (service may not be loaded).
+	_ = exec.Command("systemctl", "--user", "disable", "--now", unitName+".service").Run()
+	_ = exec.Command("systemctl", "--user", "daemon-reload").Run()
+
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("remove unit %s: %w", path, err)
+	}
+	return nil
+}
+
+// status is the Linux implementation of Status.
+func status(opts Options) (StatusInfo, error) {
+	path, err := unitPath()
+	if err != nil {
+		return StatusInfo{}, err
+	}
+
+	info := StatusInfo{UnitFile: path}
+
+	if _, err := os.Stat(path); os.IsNotExist(err) {
+		return info, nil
+	}
+	info.Installed = true
+
+	// systemctl --user show outputs KEY=VALUE pairs.
+	out, err := exec.Command("systemctl", "--user", "show",
+		"--property=ActiveState,MainPID", unitName+".service").Output()
+	if err != nil {
+		return info, nil
+	}
+	for _, line := range strings.Split(string(out), "\n") {
+		kv := strings.SplitN(line, "=", 2)
+		if len(kv) != 2 {
+			continue
+		}
+		switch kv[0] {
+		case "ActiveState":
+			if kv[1] == "active" {
+				info.Running = true
+			}
+		case "MainPID":
+			if pid, perr := strconv.Atoi(kv[1]); perr == nil && pid > 0 {
+				info.PID = pid
+			}
+		}
+	}
+	return info, nil
+}

--- a/internal/daemon/service/unsupported.go
+++ b/internal/daemon/service/unsupported.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux
+
+package service
+
+import "errors"
+
+var errUnsupported = errors.New("archigraph service install is not supported on this platform; use 'archigraph daemon start --foreground'")
+
+func install(_ Options) (StatusInfo, error)  { return StatusInfo{}, errUnsupported }
+func uninstall(_ Options) error              { return errUnsupported }
+func status(_ Options) (StatusInfo, error)   { return StatusInfo{}, errUnsupported }


### PR DESCRIPTION
## Summary

Implements ADR-0017 Phase C: \`archigraph install\` as the canonical one-liner that registers the daemon as a user-level OS service and starts it. No root / sudo required.

### What changed

- **\`internal/daemon/service/\`** — new package with platform-agnostic \`Install\` / \`Uninstall\` / \`Status\` interface
  - \`launchd_darwin.go\` — writes \`~/Library/LaunchAgents/com.archigraph.daemon.plist\`, calls \`launchctl bootstrap gui/\$UID\`; \`KeepAlive=true\` + \`RunAtLoad=true\`; stops any running daemon before bootstrapping to prevent PID-file contention
  - \`systemd_linux.go\` — writes \`~/.config/systemd/user/archigraph-daemon.service\`, calls \`systemctl --user enable --now\`; \`Restart=on-failure\`, \`WantedBy=default.target\`
  - \`unsupported.go\` — returns a clear error on non-darwin/linux platforms
  - \`install_test.go\` + \`helpers_{darwin,linux}_test.go\` — golden round-trip tests for plist and unit generation (no actual OS install in CI; Linux tests skip on darwin, darwin tests skip on linux)

- **\`internal/cli/install.go\`** — rewritten per ADR-0017; old "apply group config" semantic removed; \`service.Install()\` wired in; \`--foreground\` flag skips registration and runs daemon in-process for debugging

- **\`internal/cli/uninstall.go\`** — rewritten; calls \`service.Uninstall()\`; idempotent (missing service is not an error)

- **\`internal/cli/root.go\`** — updated help text to surface \`archigraph install\` as the canonical first-time setup command

### ADR-0017 deletions in this PR

- Old \`archigraph install <config>\` / \`--group\` apply-group-config semantic — removed
- Old \`archigraph uninstall [group] [--purge]\` remove-from-group semantic — removed

### No-backwards-compat principle

Per ADR-0017: users on prior binaries reinstall via \`archigraph install\`. No compat shim.

## Test plan

- [x] \`go test ./...\` — all pass (886 lines of new code + tests, 0 FAIL)
- [x] \`go build ./...\` — darwin + linux build tags both compile
- [x] \`archigraph install\` on macOS: plist written, launchctl bootstrap succeeds, daemon socket appears within 5s
- [x] \`launchctl list | grep archigraph\` shows running PID with exit status 0
- [x] Plist contains \`RunAtLoad=true\` and \`KeepAlive=true\` (reboot survival without actual reboot)
- [x] \`archigraph install\` (second run) — idempotent, returns same status
- [x] \`archigraph uninstall\` — stops service, removes plist
- [x] \`archigraph install\` after uninstall — fresh state, same outcome
- [x] Existing \`archigraph daemon start/stop/status\` commands unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)