### PR TITLE
[#653] Fix express synthesizer false positives: receiver allowlist + path gate

### DIFF
--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -418,18 +418,66 @@ func synthesizeFastAPI(content string, emit emitFn) {
 // Express (JS/TS)
 // ---------------------------------------------------------------------------
 
+// expressAllowedReceiverRe matches receiver names that look like an Express
+// app or router object. The allowlist covers the most common conventions:
+//   - `app`, `router`, `r`, `srv`, `server` (exact matches, word-boundary)
+//   - any identifier ending in `Router`, `App`, `Server`, `Srv`, `Handler`
+//     (e.g. `apiRouter`, `httpServer`, `myApp`)
+//
+// This replaces the open `(?:\w+)` anchor in both expressVerbRe and
+// expressVerbRePathOnly which matched ANY identifier — including FormData,
+// URLSearchParams, Dimensions, Map, etc. (issue #653).
+var expressAllowedReceiverRe = regexp.MustCompile(
+	`(?:^|[^.\w])(app|router|r|srv|server|httpServer|` +
+		`\w+[Rr]outer|\w+[Aa]pp|\w+[Ss]erver|\w+[Ss]rv|\w+[Hh]andler)\b`,
+)
+
+// expressBlocklistRe matches receiver names that are definitively NOT HTTP
+// routers — they are browser/RN/DOM APIs that share the same method names
+// (get, post, delete, put, patch). Even if a future allowlist regex
+// accidentally matches one of these, this blocklist is the final veto.
+var expressBlocklistRe = regexp.MustCompile(
+	`^(?i:formData|formdata|urlSearchParams|urlsearchparams|` +
+		`searchParams|searchparams|headers|dimensions|` +
+		`localStorage|localstorage|sessionStorage|sessionstorage|` +
+		`cache|map|set|params|query|queryParams|queryparams)$`,
+)
+
 // expressVerbRe captures the canonical Express form
-// `<obj>.<verb>("/path", handler)` where verb is one of the HTTP verbs.
-// The handler may be:
-//   - a bare identifier (e.g. `users.list`)
-//   - an inline function (regex captures only identifier-style handlers;
-//     inline handlers don't yield a useful handler name).
-var expressVerbRe = regexp.MustCompile(`(?:\w+)\.(get|post|put|patch|delete|head|options|all)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]\s*(?:,[^,)]*)*?,\s*([\w$.]+)\s*[\),]`)
+// `<receiver>.<verb>("/path", handler)` where verb is one of the HTTP verbs.
+// capture group 1 = receiver, 2 = verb, 3 = path string, 4 = handler name.
+// The receiver is now captured (not discarded) so we can apply the
+// allowlist/blocklist gates before emitting.
+var expressVerbRe = regexp.MustCompile(`(\w+)\.(get|post|put|patch|delete|head|options|all)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]\s*(?:,[^,)]*)*?,\s*([\w$.]+)\s*[\),]`)
 
 // expressVerbRePathOnly captures the path-only variant where the handler
 // is inline (function expression / arrow); we still emit the synthetic
 // entity but without a handler reference.
-var expressVerbRePathOnly = regexp.MustCompile(`(?:\w+)\.(get|post|put|patch|delete|head|options|all)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]`)
+// capture group 1 = receiver, 2 = verb, 3 = path string.
+var expressVerbRePathOnly = regexp.MustCompile(`(\w+)\.(get|post|put|patch|delete|head|options|all)\s*\(\s*['"` + "`" + `]([^'"` + "`" + `\n\r]+)['"` + "`" + `]`)
+
+// isExpressReceiver returns true when the receiver identifier looks like an
+// Express app/router variable (allowlist) and is not on the hard blocklist.
+// This is the central guard that prevents false positives from FormData,
+// URLSearchParams, React Native Dimensions, and similar non-HTTP objects.
+func isExpressReceiver(receiver string) bool {
+	// Hard blocklist — highest priority veto.
+	if expressBlocklistRe.MatchString(receiver) {
+		return false
+	}
+	// Allowlist: must look like an express app or router variable.
+	// We test the receiver in isolation (prefix the string with a space so
+	// the word-boundary anchor in expressAllowedReceiverRe fires correctly).
+	return expressAllowedReceiverRe.MatchString(" " + receiver)
+}
+
+// looksLikeExpressPath returns true when a raw string argument looks like an
+// HTTP path (must start with `/`). This blocks single-word keys like
+// "cronjob_opt_in", "window", "segment" that are valid JS keys but not HTTP
+// paths. Belt-and-suspenders on top of the receiver gate.
+func looksLikeExpressPath(raw string) bool {
+	return len(raw) > 0 && raw[0] == '/'
+}
 
 func synthesizeExpress(content string, emit emitFn) {
 	if !strings.Contains(content, ".get(") && !strings.Contains(content, ".post(") &&
@@ -438,15 +486,24 @@ func synthesizeExpress(content string, emit emitFn) {
 		!strings.Contains(content, ".head(") && !strings.Contains(content, ".options(") {
 		return
 	}
-	// First pass: handler-named form.
+	// First pass: handler-named form (groups: receiver, verb, path, handler).
 	withHandler := map[string]bool{}
 	for _, m := range expressVerbRe.FindAllStringSubmatch(content, -1) {
-		if len(m) < 4 {
+		if len(m) < 5 {
 			continue
 		}
-		verb := strings.ToUpper(m[1])
-		raw := m[2]
-		handler := m[3]
+		receiver := m[1]
+		verb := strings.ToUpper(m[2])
+		raw := m[3]
+		handler := m[4]
+		// Receiver-shape gate (allowlist + blocklist) — primary false-positive guard.
+		if !isExpressReceiver(receiver) {
+			continue
+		}
+		// Path-shape gate — belt-and-suspenders; rejects non-path string literals.
+		if !looksLikeExpressPath(raw) {
+			continue
+		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
 		// Express `.all(...)` registers every verb on the path; emit as ANY.
 		if verb == "ALL" {
@@ -456,14 +513,22 @@ func synthesizeExpress(content string, emit emitFn) {
 		withHandler[key] = true
 		emit(verb, canonical, "express", "Controller", handler)
 	}
-	// Second pass: path-only form, skipping any (verb, path) already
-	// claimed by the handler-named scan.
+	// Second pass: path-only form (groups: receiver, verb, path), skipping any
+	// (verb, path) already claimed by the handler-named scan.
 	for _, m := range expressVerbRePathOnly.FindAllStringSubmatch(content, -1) {
-		if len(m) < 3 {
+		if len(m) < 4 {
 			continue
 		}
-		verb := strings.ToUpper(m[1])
-		raw := m[2]
+		receiver := m[1]
+		verb := strings.ToUpper(m[2])
+		raw := m[3]
+		// Same gates as the handler-named pass.
+		if !isExpressReceiver(receiver) {
+			continue
+		}
+		if !looksLikeExpressPath(raw) {
+			continue
+		}
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
 		if verb == "ALL" {
 			verb = "ANY"

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -142,6 +142,125 @@ func TestSynth_Express(t *testing.T) {
 	requireContains(t, got, want, "Express")
 }
 
+// TestSynth_Express_FalsePositiveBlocklist verifies that non-HTTP API calls
+// that share the same method names as Express routes do NOT produce
+// http_endpoint entities. This covers the confirmed false-positive patterns
+// from audit report 2026-05-19 (issue #653).
+//
+// Blacklisted receivers tested here:
+//   - formData.delete(key)        — FormData API (browser)
+//   - urlSearchParams.get(key)    — URLSearchParams API (browser)
+//   - searchParams.get(key)       — URLSearchParams alias (common)
+//   - headers.delete(key)         — Headers API (browser fetch)
+//   - Dimensions.get('window')    — React Native screen dimensions
+//   - localStorage.getItem(key)   — Web Storage API
+//   - sessionStorage.getItem(key) — Web Storage API
+//   - cache.delete(key)           — Cache API (service-worker)
+//   - map.get(key)                — ES6 Map
+//   - set.delete(key)             — ES6 Set
+func TestSynth_Express_FalsePositiveBlocklist(t *testing.T) {
+	src := "// All of the following look like express verbs but are NOT HTTP routes.\n" +
+		"formData.delete('cronjob_opt_in');\n" +
+		"formData.delete('deficiency_proposal_pricing');\n" +
+		"urlSearchParams.get('segment');\n" +
+		"searchParams.get('session_expired');\n" +
+		"headers.delete('Authorization');\n" +
+		"Dimensions.get('window');\n" +
+		"localStorage.getItem('token');\n" +
+		"sessionStorage.getItem('user');\n" +
+		"cache.delete('my-cache-key');\n" +
+		"map.get('some-key');\n" +
+		"set.delete('some-key');\n" +
+		"params.get('id');\n" +
+		"query.get('filter');\n"
+	got, _ := runDetect(t, "javascript", "components/ui/Form.jsx", src)
+	if len(got) != 0 {
+		t.Errorf("expected zero http_endpoint entities from non-HTTP calls, got %v", got)
+	}
+}
+
+// TestSynth_Express_ReceiverAllowlist verifies that the receiver-shape gate
+// allows known Express receiver names through while blocking unknown or
+// ambiguous names.
+func TestSynth_Express_ReceiverAllowlist(t *testing.T) {
+	// Should match: these look like Express app/router variables.
+	allowed := []struct {
+		receiver string
+		verb     string
+		path     string
+	}{
+		{"app", "get", "/users"},
+		{"router", "post", "/items"},
+		{"r", "delete", "/things/:id"},
+		{"srv", "get", "/health"},
+		{"server", "put", "/profile"},
+		{"apiRouter", "get", "/api/v1/orders"},
+		{"myApp", "post", "/submit"},
+		{"httpServer", "get", "/ping"},
+		{"userRouter", "delete", "/users/:id"},
+	}
+
+	for _, tc := range allowed {
+		line := tc.receiver + "." + tc.verb + "('" + tc.path + "', handler);\n"
+		got, _ := runDetect(t, "javascript", "server.js", line)
+		if len(got) == 0 {
+			t.Errorf("receiver %q with path %q: expected an http_endpoint entity, got none", tc.receiver, tc.path)
+		}
+	}
+}
+
+// TestSynth_Express_ReceiverBlocklistUnknown verifies that arbitrary unknown
+// receiver names without any express-like suffix are NOT emitted as endpoints.
+func TestSynth_Express_ReceiverBlocklistUnknown(t *testing.T) {
+	// These should NOT emit HTTP endpoints even though the method name looks
+	// like an Express verb — the receiver is not Express-shaped.
+	blocked := []struct {
+		receiver string
+		verb     string
+		path     string
+	}{
+		{"myObj", "get", "/users"},
+		{"someService", "post", "/items"},
+		{"helper", "delete", "/things"},
+		{"config", "get", "/settings"},
+	}
+
+	for _, tc := range blocked {
+		line := tc.receiver + "." + tc.verb + "('" + tc.path + "', handler);\n"
+		got, _ := runDetect(t, "javascript", "utils/helper.js", line)
+		if len(got) != 0 {
+			t.Errorf("receiver %q: expected zero http_endpoint entities, got %v", tc.receiver, got)
+		}
+	}
+}
+
+// TestSynth_Express_PathGate verifies the path-shape gate: a receiver that
+// looks Express-shaped but passes a non-path string (no leading `/`) must not
+// emit an endpoint. This is the belt-and-suspenders layer on top of the
+// receiver gate (issue #653 strategy C).
+func TestSynth_Express_PathGate(t *testing.T) {
+	// Even if the receiver were allowlisted, these string args are not HTTP paths.
+	src := "app.get('window', handler);\n" +
+		"app.delete('key', handler);\n" +
+		"router.get('cronjob_opt_in', handler);\n"
+	got, _ := runDetect(t, "javascript", "server.js", src)
+	if len(got) != 0 {
+		t.Errorf("expected zero http_endpoint entities for non-path args, got %v", got)
+	}
+}
+
+// TestSynth_Express_ReactNativeDimensions specifically reproduces the
+// fixture-c false positive: Dimensions.get('window') in React Native files.
+func TestSynth_Express_ReactNativeDimensions(t *testing.T) {
+	src := "import { Dimensions } from 'react-native';\n" +
+		"const { width, height } = Dimensions.get('window');\n" +
+		"const windowWidth = Dimensions.get('window').width;\n"
+	got, _ := runDetect(t, "typescript", "components/ui/drawer/index.tsx", src)
+	if len(got) != 0 {
+		t.Errorf("Dimensions.get('window') should not produce http_endpoint entities, got %v", got)
+	}
+}
+
 // TestSynth_JAXRS exercises a class-level @Path with method-level @GET +
 // @Path and bare @POST without a method-level path.
 func TestSynth_JAXRS(t *testing.T) {


### PR DESCRIPTION
## Problem

The `expressVerbRe` / `expressVerbRePathOnly` regexes used an open `(?:\w+)` anchor that matched ANY identifier followed by `.get(`, `.delete(`, etc. This caused 28 phantom `http_endpoint` entities across fixture-b and fixture-c:

- `formData.delete("cronjob_opt_in")` → emitted `DELETE:/cronjob_opt_in`
- `urlSearchParams.get("segment")` → emitted `GET:/segment`
- `Dimensions.get('window')` (React Native) → emitted `GET:/window` (×4)
- `cache.delete(...)`, `map.get(...)`, JSX prop names, etc.

## Fix: three complementary guards

### A. Receiver allowlist (`isExpressReceiver` + `expressAllowedReceiverRe`)
Only fires when the receiver looks like an Express app or router: exact names `app`, `router`, `r`, `srv`, `server`, `httpServer`, or any identifier ending in `Router`, `App`, `Server`, `Srv`, or `Handler`. All other receivers are rejected at source.

### B. Receiver blocklist (`expressBlocklistRe`)
Hard-veto list for known non-HTTP APIs: `formData`, `urlSearchParams`, `searchParams`, `headers`, `Dimensions`, `localStorage`, `sessionStorage`, `cache`, `map`, `set`, `params`, `query`, `queryParams`. Case-insensitive. Highest-priority gate.

### C. Path-shape gate (`looksLikeExpressPath`)
The first string argument must start with `/`. Blocks `"window"`, `"segment"`, `"cronjob_opt_in"`, `app.get('env')`, and other non-path string literals.

## Measurements

### Primary fixtures

| Fixture | Before | After |
|---|---|---|
| fixture-b (Vite+React) | 25 entities (1 correct, 24 FP) | **1 entity** — `GET:/version.txt` survives |
| fixture-c (RN+Expo) | 4 entities (0 correct, 4 FP) | **0 entities** |

### Quality golden fixtures — 100% must-have recall maintained

All 5 golden fixtures: 100% entity + relationship recall, 0 forbidden hits.

### Broader corpus deltas

| Corpus | Before | After | Delta |
|---|---|---|---|
| `express` | 57 | **9** | -48 false positives removed |
| `express-realworld` | 4 | 4 | 0 |
| `flask` | 225 | 225 | 0 |
| `flask-realworld` | 12 | 12 | 0 |
| `spring-petclinic` | 13 | 13 | 0 |

The 9 remaining express entities are all real routes (e.g. `app.get('/')`, `router.get('/users/:id')` in the express examples and test files).

## New tests

- `TestSynth_Express_FalsePositiveBlocklist` — all 13 blocklisted receivers
- `TestSynth_Express_ReceiverAllowlist` — 9 allowed receiver shapes
- `TestSynth_Express_ReceiverBlocklistUnknown` — arbitrary non-express receivers rejected
- `TestSynth_Express_PathGate` — non-path string args rejected even with allowed receiver
- `TestSynth_Express_ReactNativeDimensions` — specific fixture-c false positive

All 88 `go test ./...` packages pass.

Closes #653

🤖 Generated with [Claude Code](https://claude.com/claude-code)