### PR TITLE
[http-extract] JAX-RS / Spring MVC annotation HTTP endpoint extraction (#657)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -398,6 +398,18 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	}
 	i.stats.pass3Rels = countEmbeddedRels(pass3Records)
 
+	// Pass 2.6 — Java JAX-RS / Spring MVC annotation route composition.
+	// Runs after Pass 3 (while the classified slice is still live with file
+	// content) and emits fully-resolved http_endpoint synthetic entities for
+	// every annotated handler method. The class-level + method-level path
+	// composition cannot be done by the per-file passes in Pass 2.5 because
+	// the Java extractor strips annotation arguments before producing
+	// SCOPE.Component / SCOPE.Operation entities. Refs #657.
+	if !i.skipPasses[PassFramework] {
+		javaEntities := runJavaAnnotationRoutes(classified)
+		pass3Records = append(pass3Records, javaEntities...)
+	}
+
 	// Issue #633 — release per-file AST trees + source bytes now that the
 	// last consumer (Pass 3 cross-language extractors) has finished. The
 	// classified slice is otherwise retained until Run() returns, which on
@@ -1360,6 +1372,32 @@ func (i *Indexer) stampEntityIDs(records []types.EntityRecord) {
 		}
 		r.ID = graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
 	}
+}
+
+// runJavaAnnotationRoutes runs the Java JAX-RS / Spring MVC annotation
+// route composition pass over the set of classified files. Builds a
+// content-lookup map from repo-relative path to raw bytes (Java files
+// only), then delegates to engine.ApplyJavaAnnotationRoutes. Refs #657.
+func runJavaAnnotationRoutes(classified []classifiedFile) []types.EntityRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var javaPaths []string
+	for _, cf := range classified {
+		if cf.language != "java" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		javaPaths = append(javaPaths, cf.relPath)
+	}
+	if len(javaPaths) == 0 {
+		return nil
+	}
+	reader := func(relPath string) []byte {
+		return contentByPath[relPath]
+	}
+	return engine.ApplyJavaAnnotationRoutes(javaPaths, reader)
 }
 
 // buildPatternContainsRels emits one CONTAINS edge per SCOPE.Pattern entity,

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -1,0 +1,417 @@
+// Java JAX-RS / Spring MVC annotation route composition pass.
+//
+// Problem: Java REST controllers compose their full HTTP routes from
+// class-level + method-level annotations:
+//
+//	@Path("/products")              // JAX-RS class-level
+//	public class ProductsController {
+//	    @GET
+//	    @Path("/{id}")              // JAX-RS method-level
+//	    public Product get(...) {}
+//	}
+//
+//	@RequestMapping("/api/users")   // Spring class-level
+//	@RestController
+//	public class UserController {
+//	    @GetMapping("/{id}")        // Spring method-level
+//	    public User get(...) {}
+//	}
+//
+// Today archigraph emits SCOPE.Operation entities for each handler method
+// but the existing JAX-RS regex in http_endpoint_synthesis.go is too strict
+// (requires a tight annotation/class layout) and emits source_handler
+// references pointing at a Kind that doesn't exist in the entity table
+// (`Controller:method`), so all synthetics get dropped by
+// ResolveHTTPEndpointHandlers.
+//
+// This pass runs AFTER Pass 3 with the full classified file set. It:
+//
+//  1. Scans every .java file for the class-level @Path or @RequestMapping.
+//  2. For every method-level HTTP verb annotation, composes the full route.
+//  3. Emits one `http_endpoint` synthetic entity per (verb, path) pair,
+//     with `source_handler` set to `SCOPE.Operation:<Class>.<method>` so
+//     ResolveHTTPEndpointHandlers can resolve it against the real
+//     SCOPE.Operation entity emitted by the Java extractor.
+//
+// JAX-RS verb annotations recognised:
+//
+//	@GET @POST @PUT @DELETE @PATCH @HEAD @OPTIONS
+//
+// Spring verb annotations recognised:
+//
+//	@GetMapping @PostMapping @PutMapping @DeleteMapping @PatchMapping
+//	@RequestMapping(method = RequestMethod.X)
+//
+// Refs #657.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// JavaAnnotationFileReader returns the source bytes for a repo-relative
+// path, or nil if the file is unavailable.
+type JavaAnnotationFileReader func(relPath string) []byte
+
+// javaClassDeclRe matches a Java class declaration and captures the class
+// name. We do not anchor on visibility because the parsed Java sources we
+// emit synthetics for in archigraph use both `public class` and bare
+// `class` declarations.
+var javaClassDeclRe = regexp.MustCompile(`(?m)^\s*(?:public\s+|abstract\s+|final\s+|static\s+)*class\s+(\w+)`)
+
+// javaPathAnnotationRe matches @Path("value") OR @Path(value = "..."). The
+// captured group is the raw path string.
+var javaPathAnnotationRe = regexp.MustCompile(`@Path\s*\(\s*(?:value\s*=\s*)?"([^"]*)"\s*\)`)
+
+// javaRequestMappingRe matches a Spring class-level OR method-level
+// @RequestMapping. Captures the entire argument list so we can extract
+// both the path and (optionally) the method= keyword.
+var javaRequestMappingRe = regexp.MustCompile(`@RequestMapping\s*\(([^)]*)\)`)
+
+// javaSpringVerbMappingRe matches @GetMapping("/x") / @PostMapping(...) etc.
+// Captures the verb keyword (group 1) and the argument list (group 2).
+var javaSpringVerbMappingRe = regexp.MustCompile(`@(Get|Post|Put|Delete|Patch)Mapping\s*(?:\(([^)]*)\))?`)
+
+// javaJAXRSVerbRe matches a bare JAX-RS verb annotation. Captures the verb.
+var javaJAXRSVerbRe = regexp.MustCompile(`@(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)\b`)
+
+// javaStringArgRe extracts the first quoted string from an argument list
+// (covers both `"/foo"` and `value = "/foo"`).
+var javaStringArgRe = regexp.MustCompile(`"([^"]*)"`)
+
+// javaMethodMethodArgRe captures the `method = RequestMethod.X` keyword in
+// a @RequestMapping argument list.
+var javaMethodMethodArgRe = regexp.MustCompile(`method\s*=\s*(?:RequestMethod\s*\.\s*)?(GET|POST|PUT|DELETE|PATCH|HEAD|OPTIONS)`)
+
+// javaConsumesRe / javaProducesRe capture content-type metadata.
+var javaConsumesRe = regexp.MustCompile(`@Consumes\s*\(([^)]+)\)`)
+var javaProducesRe = regexp.MustCompile(`@Produces\s*\(([^)]+)\)`)
+
+// javaMethodDeclRe matches the start of a Java method declaration so we
+// can extract the method name following a block of annotations. We scan
+// line-by-line in the file walker; this regex matches one method-decl line.
+//
+// We accept: modifiers, generic return type, method-name, opening paren.
+var javaMethodDeclRe = regexp.MustCompile(`^\s*(?:public|protected|private|static|final|abstract|synchronized|default|\s)+[\w<>\[\],.\s?]+?\s+(\w+)\s*\(`)
+
+// ApplyJavaAnnotationRoutes scans the supplied Java files for JAX-RS or
+// Spring MVC annotation patterns and returns a slice of synthetic
+// http_endpoint EntityRecords. Caller appends these to the existing
+// entity slice; ResolveHTTPEndpointHandlers wires them to the matching
+// SCOPE.Operation handlers.
+func ApplyJavaAnnotationRoutes(
+	javaFiles []string,
+	fileReader JavaAnnotationFileReader,
+) []types.EntityRecord {
+	var out []types.EntityRecord
+	seen := map[string]bool{}
+
+	for _, relPath := range javaFiles {
+		if !strings.HasSuffix(relPath, ".java") {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+		// Cheap pre-filter: skip files that have no HTTP annotation.
+		if !containsAnyHTTPAnnotation(src) {
+			continue
+		}
+
+		for _, ep := range extractJavaEndpoints(src, relPath) {
+			if seen[ep.ID] {
+				continue
+			}
+			seen[ep.ID] = true
+			out = append(out, ep)
+		}
+	}
+	return out
+}
+
+// containsAnyHTTPAnnotation reports whether the source likely contains
+// JAX-RS or Spring MVC route annotations.
+func containsAnyHTTPAnnotation(src string) bool {
+	switch {
+	case strings.Contains(src, "@Path("):
+		return true
+	case strings.Contains(src, "@RequestMapping"):
+		return true
+	case strings.Contains(src, "@GetMapping"),
+		strings.Contains(src, "@PostMapping"),
+		strings.Contains(src, "@PutMapping"),
+		strings.Contains(src, "@DeleteMapping"),
+		strings.Contains(src, "@PatchMapping"):
+		return true
+	case strings.Contains(src, "@GET"),
+		strings.Contains(src, "@POST"),
+		strings.Contains(src, "@PUT"),
+		strings.Contains(src, "@DELETE"),
+		strings.Contains(src, "@PATCH"):
+		return true
+	}
+	return false
+}
+
+// classFrame holds per-class state during file scan: the class name (for
+// handler-reference composition), the class-level path prefix, and
+// class-level content-type metadata that method-level routes inherit.
+type classFrame struct {
+	name           string
+	prefix         string
+	framework      string // "jaxrs" or "spring" (best-effort)
+	classConsumes  string
+	classProduces  string
+}
+
+// extractJavaEndpoints walks a Java source file and returns the synthetic
+// http_endpoint records for every annotated handler method.
+//
+// Strategy:
+//   - Split file into lines.
+//   - Maintain a per-class frame. When `class X` is encountered, capture
+//     the most recent annotation block above it as the class prefix.
+//   - When a method declaration is found, gather the immediately preceding
+//     annotation block, parse its verb + optional method-level path, and
+//     compose the full route against the current class frame.
+//
+// This deliberately uses a lightweight line-oriented parser rather than
+// the tree-sitter AST because the Java extractor strips annotation
+// arguments before producing entities (so we can't reuse extractor output).
+func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
+	lines := strings.Split(src, "\n")
+
+	var out []types.EntityRecord
+	var cur classFrame
+	// Buffer of consecutive annotation/blank lines immediately above the
+	// current code line. Cleared by any non-annotation, non-blank line.
+	var annoBuf []string
+
+	flushAnnoBuf := func() []string {
+		buf := annoBuf
+		annoBuf = nil
+		return buf
+	}
+
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+
+		// Track annotation lines (and blank lines, which can occur between
+		// annotations in the wild).
+		if strings.HasPrefix(trimmed, "@") || trimmed == "" {
+			annoBuf = append(annoBuf, trimmed)
+			continue
+		}
+		// Comment lines: ignore but do not reset annoBuf (devs sometimes
+		// put a comment between annotations and the declaration).
+		if strings.HasPrefix(trimmed, "//") || strings.HasPrefix(trimmed, "*") || strings.HasPrefix(trimmed, "/*") {
+			continue
+		}
+
+		// Class declaration?
+		if m := javaClassDeclRe.FindStringSubmatch(line); m != nil {
+			classAnnos := flushAnnoBuf()
+			cur = buildClassFrame(m[1], classAnnos)
+			continue
+		}
+
+		// Method declaration?
+		if m := javaMethodDeclRe.FindStringSubmatch(line); m != nil {
+			methodName := m[1]
+			methodAnnos := flushAnnoBuf()
+			if cur.name == "" {
+				// Method declared before any class header (shouldn't happen
+				// in valid Java but harmless to skip).
+				continue
+			}
+			eps := buildMethodEndpoints(cur, methodName, methodAnnos, relPath)
+			out = append(out, eps...)
+			continue
+		}
+
+		// Any other code line resets the annotation buffer.
+		flushAnnoBuf()
+	}
+	return out
+}
+
+// buildClassFrame parses the annotation block immediately above a class
+// declaration and produces the per-class state used when emitting method
+// routes.
+func buildClassFrame(className string, annos []string) classFrame {
+	cf := classFrame{name: className}
+	joined := strings.Join(annos, "\n")
+
+	// JAX-RS class-level @Path.
+	if m := javaPathAnnotationRe.FindStringSubmatch(joined); m != nil {
+		cf.prefix = m[1]
+		cf.framework = "jaxrs"
+	}
+	// Spring class-level @RequestMapping. Path may be the bare quoted
+	// arg or `value = "..."`.
+	if m := javaRequestMappingRe.FindStringSubmatch(joined); m != nil {
+		if sm := javaStringArgRe.FindStringSubmatch(m[1]); sm != nil {
+			cf.prefix = sm[1]
+			cf.framework = "spring"
+		}
+	}
+	// Class-level Consumes/Produces — captured as raw substring so we
+	// can surface as property when emitting method routes.
+	if m := javaConsumesRe.FindStringSubmatch(joined); m != nil {
+		cf.classConsumes = strings.TrimSpace(m[1])
+	}
+	if m := javaProducesRe.FindStringSubmatch(joined); m != nil {
+		cf.classProduces = strings.TrimSpace(m[1])
+	}
+	// Spring @RestController / @Controller signals Spring framework even
+	// when @RequestMapping is absent at the class level (some endpoints
+	// rely on method-level @GetMapping alone).
+	if cf.framework == "" {
+		if strings.Contains(joined, "@RestController") || strings.Contains(joined, "@Controller") {
+			cf.framework = "spring"
+		}
+	}
+	return cf
+}
+
+// buildMethodEndpoints walks the annotation block above a method
+// declaration and produces one or more http_endpoint records.
+func buildMethodEndpoints(cf classFrame, methodName string, annos []string, relPath string) []types.EntityRecord {
+	joined := strings.Join(annos, "\n")
+
+	// Collect method-level paths (may be empty).
+	methodPath := ""
+	if m := javaPathAnnotationRe.FindStringSubmatch(joined); m != nil {
+		methodPath = m[1]
+	}
+
+	// Collect verbs.
+	var verbs []string
+	// JAX-RS bare verbs.
+	for _, m := range javaJAXRSVerbRe.FindAllStringSubmatch(joined, -1) {
+		verbs = append(verbs, strings.ToUpper(m[1]))
+	}
+	// Spring specialised mappings (@GetMapping, etc.).
+	for _, m := range javaSpringVerbMappingRe.FindAllStringSubmatch(joined, -1) {
+		verb := strings.ToUpper(m[1])
+		verbs = append(verbs, verb)
+		// If the specialised mapping carries an inline path arg, use it.
+		if methodPath == "" && len(m) > 2 && m[2] != "" {
+			if sm := javaStringArgRe.FindStringSubmatch(m[2]); sm != nil {
+				methodPath = sm[1]
+			}
+		}
+	}
+	// Method-level @RequestMapping. Captures the verb from the `method=...`
+	// keyword (if any) and the path from the first quoted string.
+	for _, m := range javaRequestMappingRe.FindAllStringSubmatch(joined, -1) {
+		args := m[1]
+		// Path.
+		if methodPath == "" {
+			if sm := javaStringArgRe.FindStringSubmatch(args); sm != nil {
+				methodPath = sm[1]
+			}
+		}
+		// Verb(s). If method= is absent the mapping accepts ANY verb.
+		methodVerbs := parseRequestMappingMethods(args)
+		if len(methodVerbs) == 0 {
+			methodVerbs = []string{"ANY"}
+		}
+		verbs = append(verbs, methodVerbs...)
+	}
+
+	if len(verbs) == 0 {
+		// No verb annotation found — not a route.
+		return nil
+	}
+
+	// Method-level Consumes/Produces (override class-level when present).
+	methodConsumes := cf.classConsumes
+	methodProduces := cf.classProduces
+	if m := javaConsumesRe.FindStringSubmatch(joined); m != nil {
+		methodConsumes = strings.TrimSpace(m[1])
+	}
+	if m := javaProducesRe.FindStringSubmatch(joined); m != nil {
+		methodProduces = strings.TrimSpace(m[1])
+	}
+
+	framework := cf.framework
+	if framework == "" {
+		// Pure method-level Spring annotation with no class hint.
+		framework = "spring"
+	}
+
+	canonFW := httproutes.FrameworkJAXRS
+	if framework == "spring" {
+		canonFW = httproutes.FrameworkSpring
+	}
+
+	composed := joinPathFragments(cf.prefix, methodPath)
+	canonical := httproutes.Canonicalize(canonFW, composed)
+	if canonical == "" {
+		return nil
+	}
+
+	// Deduplicate verbs in case both @GET and a method=GET were present.
+	verbSet := map[string]bool{}
+	var uniqueVerbs []string
+	for _, v := range verbs {
+		if verbSet[v] {
+			continue
+		}
+		verbSet[v] = true
+		uniqueVerbs = append(uniqueVerbs, v)
+	}
+
+	var out []types.EntityRecord
+	for _, verb := range uniqueVerbs {
+		id := httproutes.SyntheticID(verb, canonical)
+		props := map[string]string{
+			"verb":           verb,
+			"path":           canonical,
+			"framework":      framework,
+			"pattern_type":   "java_annotation_routes",
+			"source_handler": "SCOPE.Operation:" + cf.name + "." + methodName,
+		}
+		if methodConsumes != "" {
+			props["consumes"] = methodConsumes
+		}
+		if methodProduces != "" {
+			props["produces"] = methodProduces
+		}
+
+		out = append(out, types.EntityRecord{
+			ID:                 id,
+			Name:               id,
+			Kind:               httpEndpointKind,
+			SourceFile:         relPath,
+			Language:           "java",
+			Properties:         props,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.85,
+		})
+	}
+	return out
+}
+
+// parseRequestMappingMethods extracts every `method = RequestMethod.X` (or
+// `method = {RequestMethod.X, RequestMethod.Y}`) value from a
+// @RequestMapping argument list. Returns empty when no method keyword is
+// present (caller treats this as ANY).
+func parseRequestMappingMethods(args string) []string {
+	var out []string
+	for _, m := range javaMethodMethodArgRe.FindAllStringSubmatch(args, -1) {
+		out = append(out, strings.ToUpper(m[1]))
+	}
+	return out
+}
+
+// joinPathFragments is shared with http_endpoint_synthesis.go (defined
+// there). We do not redefine it here.

--- a/internal/engine/java_annotation_routes_test.go
+++ b/internal/engine/java_annotation_routes_test.go
@@ -1,0 +1,255 @@
+package engine
+
+import (
+	"sort"
+	"strings"
+	"testing"
+)
+
+// helper: build a reader from a path->src map.
+func mapReader(m map[string]string) JavaAnnotationFileReader {
+	return func(p string) []byte {
+		s, ok := m[p]
+		if !ok {
+			return nil
+		}
+		return []byte(s)
+	}
+}
+
+func endpointIDs(records []recordLike) []string {
+	out := make([]string, 0, len(records))
+	for _, r := range records {
+		out = append(out, r.ID)
+	}
+	sort.Strings(out)
+	return out
+}
+
+type recordLike struct {
+	ID         string
+	Props      map[string]string
+	SourceFile string
+}
+
+func collect(t *testing.T, files map[string]string) []recordLike {
+	t.Helper()
+	paths := make([]string, 0, len(files))
+	for p := range files {
+		paths = append(paths, p)
+	}
+	sort.Strings(paths)
+	got := ApplyJavaAnnotationRoutes(paths, mapReader(files))
+	out := make([]recordLike, 0, len(got))
+	for _, e := range got {
+		out = append(out, recordLike{ID: e.ID, Props: e.Properties, SourceFile: e.SourceFile})
+	}
+	return out
+}
+
+func TestApplyJavaAnnotationRoutes_JAXRSClassPlusMethodPath(t *testing.T) {
+	src := `package com.example;
+import jakarta.ws.rs.*;
+
+@Path("/products")
+public class ProductsController {
+    @GET
+    public Object list() { return null; }
+
+    @GET
+    @Path("/{id}")
+    public Object get() { return null; }
+
+    @POST
+    @Path("/upload")
+    public Object upload() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Products.java": src})
+	ids := endpointIDs(got)
+	want := []string{
+		"http:GET:/products",
+		"http:GET:/products/{id}",
+		"http:POST:/products/upload",
+	}
+	sort.Strings(want)
+	if strings.Join(ids, "|") != strings.Join(want, "|") {
+		t.Fatalf("ids = %v\nwant %v", ids, want)
+	}
+	for _, r := range got {
+		if r.Props["framework"] != "jaxrs" {
+			t.Errorf("expected framework=jaxrs, got %q for %s", r.Props["framework"], r.ID)
+		}
+		if !strings.HasPrefix(r.Props["source_handler"], "SCOPE.Operation:ProductsController.") {
+			t.Errorf("bad source_handler %q on %s", r.Props["source_handler"], r.ID)
+		}
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_JAXRSMethodOnlyNoClassPrefix(t *testing.T) {
+	src := `package com.example;
+import jakarta.ws.rs.*;
+
+public class StatusResource {
+    @GET
+    @Path("/status")
+    public Object status() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Status.java": src})
+	ids := endpointIDs(got)
+	if len(ids) != 1 || ids[0] != "http:GET:/status" {
+		t.Fatalf("ids = %v, want [http:GET:/status]", ids)
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_SpringRequestMappingClassGetMappingMethod(t *testing.T) {
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/users")
+@RestController
+public class UserController {
+    @GetMapping("/{id}")
+    public Object get() { return null; }
+
+    @PostMapping
+    public Object create() { return null; }
+}
+`
+	got := collect(t, map[string]string{"User.java": src})
+	ids := endpointIDs(got)
+	want := []string{
+		"http:GET:/api/users/{id}",
+		"http:POST:/api/users",
+	}
+	sort.Strings(want)
+	if strings.Join(ids, "|") != strings.Join(want, "|") {
+		t.Fatalf("ids = %v\nwant %v", ids, want)
+	}
+	for _, r := range got {
+		if r.Props["framework"] != "spring" {
+			t.Errorf("expected framework=spring, got %q for %s", r.Props["framework"], r.ID)
+		}
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_SpringRequestMappingWithMethodKeyword(t *testing.T) {
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+
+@RequestMapping("/api/items")
+@RestController
+public class ItemController {
+    @RequestMapping(value = "/{id}", method = RequestMethod.POST)
+    public Object update() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Item.java": src})
+	ids := endpointIDs(got)
+	if len(ids) != 1 || ids[0] != "http:POST:/api/items/{id}" {
+		t.Fatalf("ids = %v, want [http:POST:/api/items/{id}]", ids)
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_PathParamRegexStripped(t *testing.T) {
+	// Spring + JAX-RS both allow regex constraints inside {name:regex}.
+	// The canonicalizer should drop the constraint.
+	src := `package com.example;
+import jakarta.ws.rs.*;
+
+@Path("/things")
+public class ThingsResource {
+    @GET
+    @Path("/{name:[a-z]+}")
+    public Object byName() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Things.java": src})
+	ids := endpointIDs(got)
+	if len(ids) != 1 || ids[0] != "http:GET:/things/{name}" {
+		t.Fatalf("ids = %v, want [http:GET:/things/{name}]", ids)
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_MultipleVerbsOnSamePath(t *testing.T) {
+	src := `package com.example;
+import jakarta.ws.rs.*;
+
+@Path("/widgets")
+public class WidgetController {
+    @GET
+    @Path("/{id}")
+    public Object get() { return null; }
+
+    @DELETE
+    @Path("/{id}")
+    public Object remove() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Widget.java": src})
+	ids := endpointIDs(got)
+	want := []string{"http:DELETE:/widgets/{id}", "http:GET:/widgets/{id}"}
+	if strings.Join(ids, "|") != strings.Join(want, "|") {
+		t.Fatalf("ids = %v\nwant %v", ids, want)
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_ConsumesProducesSurfaced(t *testing.T) {
+	src := `package com.example;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.MediaType;
+
+@Path("/files")
+@Consumes(MediaType.APPLICATION_JSON)
+@Produces(MediaType.APPLICATION_JSON)
+public class FilesController {
+    @POST
+    @Path("/upload")
+    @Consumes(MediaType.MULTIPART_FORM_DATA)
+    public Object upload() { return null; }
+}
+`
+	got := collect(t, map[string]string{"Files.java": src})
+	if len(got) != 1 {
+		t.Fatalf("expected 1 endpoint, got %d", len(got))
+	}
+	r := got[0]
+	if !strings.Contains(r.Props["consumes"], "MULTIPART_FORM_DATA") {
+		t.Errorf("expected method-level consumes override, got %q", r.Props["consumes"])
+	}
+	if !strings.Contains(r.Props["produces"], "APPLICATION_JSON") {
+		t.Errorf("expected class-level produces inherited, got %q", r.Props["produces"])
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_NonRouteFileSkipped(t *testing.T) {
+	src := `package com.example;
+public class PojoBag {
+    private int x;
+    public int getX() { return x; }
+}
+`
+	got := collect(t, map[string]string{"Pojo.java": src})
+	if len(got) != 0 {
+		t.Fatalf("expected 0 endpoints for non-route file, got %d", len(got))
+	}
+}
+
+func TestApplyJavaAnnotationRoutes_SpringSpecialisedMappingInlinePath(t *testing.T) {
+	// No class-level @RequestMapping — only specialised method mappings.
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+public class PingController {
+    @GetMapping("/ping")
+    public String ping() { return "pong"; }
+}
+`
+	got := collect(t, map[string]string{"Ping.java": src})
+	ids := endpointIDs(got)
+	if len(ids) != 1 || ids[0] != "http:GET:/ping" {
+		t.Fatalf("ids = %v, want [http:GET:/ping]", ids)
+	}
+}


### PR DESCRIPTION
## Problem

archigraph emits 0 http_endpoint entities for Java backends using JAX-RS (Quarkus, Resteasy) or Spring MVC annotations. On fixture-d the baseline shows:

```
http-endpoint-resolve: synthetics=60 handler_resolved=0 handler_dropped=60
```

60 synthetic candidates were generated by the existing `synthesizeJAXRS` regex in `http_endpoint_synthesis.go` — but every one carried `source_handler=Controller:<method>`, a Kind that does not exist in the entity table (the Java extractor emits `SCOPE.Operation`). All 60 were dropped by `ResolveHTTPEndpointHandlers`. The producer side was completely empty for fixture-d, structurally blocking cross-repo HTTP linking against fixture-e.

## Fix

Add a new cross-file Java annotation route composition pass (`internal/engine/java_annotation_routes.go`) that runs after Pass 3 with the full classified file set:

1. Scans every `.java` file for class-level + method-level annotations.
2. Composes class-level `@Path` / `@RequestMapping` prefix with method-level `@Path` / `@RequestMapping` / `@GetMapping`/`@PostMapping`/`@PutMapping`/`@DeleteMapping`/`@PatchMapping` into a full route.
3. Canonicalizes path-param regex constraints (`{name:[a-z]+}` -> `{name}`) via `httproutes.Canonicalize`.
4. Emits one `http_endpoint` synthetic per `(verb, path)` pair with `source_handler="SCOPE.Operation:<Class>.<method>"` so the resolver wires an IMPLEMENTS edge to the real Java method entity.

Recognises:
- **JAX-RS**: `@Path`, `@GET`/`@POST`/`@PUT`/`@DELETE`/`@PATCH`/`@HEAD`/`@OPTIONS`, `@Consumes`/`@Produces` (surfaced as properties)
- **Spring**: `@RequestMapping(value=, method=RequestMethod.X)`, `@GetMapping`/`@PostMapping`/`@PutMapping`/`@DeleteMapping`/`@PatchMapping`, `@RestController`/`@Controller`

Mirrors the shape of #649 (Django nested URLconf) — compose annotation prefix + leaf route into a single emitted endpoint.

## Before / After

| Fixture | Before | After | Delta |
|---|---|---|---|
| client-fixture-d (Quarkus) | 0 | 62 | +62 |
| spring-petclinic | 0 | 25 | +25 (12 new pass + 13 existing) |
| client-fixture-a (Python/Django) | 75 | 75 | 0 |
| client-fixture-b (Node/Express) | 25 | 25 | 0 |
| client-fixture-c | 4 | 4 | 0 |

Resolver stats on fixture-d after the fix: `handler_resolved=60+, handler_dropped=0, source_handler property cleared on every emitted synthetic` (verified `0 entities still carry source_handler`). 69 IMPLEMENTS edges wired from `SCOPE.Operation` -> `http_endpoint`.

## Quality fixtures

All 5 quality fixtures maintain 100% must-have recall:

| Fixture | Recall | Forbidden |
|---|---|---|
| go-chi-mini | 100% / 100% | 0 |
| java-spring-mini | 100% / 100% | 0 |
| python-django-mini | 100% / 100% | 0 |
| rust-tokio-mini | 100% / 100% | 0 |
| typescript-react-mini | 100% / 100% | 0 |

## Tests

9 new unit tests in `internal/engine/java_annotation_routes_test.go`:
- `TestApplyJavaAnnotationRoutes_JAXRSClassPlusMethodPath` — class + method `@Path` composition
- `TestApplyJavaAnnotationRoutes_JAXRSMethodOnlyNoClassPrefix` — standalone method `@GET @Path`
- `TestApplyJavaAnnotationRoutes_SpringRequestMappingClassGetMappingMethod` — Spring class + `@GetMapping`
- `TestApplyJavaAnnotationRoutes_SpringRequestMappingWithMethodKeyword` — `method=RequestMethod.POST`
- `TestApplyJavaAnnotationRoutes_PathParamRegexStripped` — `{name:[a-z]+}` -> `{name}`
- `TestApplyJavaAnnotationRoutes_MultipleVerbsOnSamePath` — GET + DELETE same path
- `TestApplyJavaAnnotationRoutes_ConsumesProducesSurfaced` — method-level Consumes overrides class
- `TestApplyJavaAnnotationRoutes_NonRouteFileSkipped` — POJO file emits 0
- `TestApplyJavaAnnotationRoutes_SpringSpecialisedMappingInlinePath` — `@GetMapping("/ping")` with no class prefix

Full `go test ./...` passes.

## Constraints honoured

- Does NOT touch the Express verb regex in `http_endpoint_synthesis.go` (#653's territory)
- Does NOT touch `http_endpoint_client_synthesis.go` (#651's territory)
- File-disjoint from in-flight server-synth work
- Real measurements only — fixture-d emits 62 endpoints, target was 60+

## Residual

- spring-petclinic now emits 25 endpoints (12 from this pass, 13 from the existing `synthesizeSpringFromComposed` pass that reads composed Route entities). Some overlap may exist if both paths resolve the same route — dedup is by synthetic ID (`http:<verb>:<path>`), so a duplicate would collapse to one entity.
- fixture-e <-> fixture-d cross-repo linking is now structurally unblocked but the actual link count depends on the consumer-side fetch extractor in #651/#653.

Refs #657.

## Test plan
- [x] `go test ./...` passes
- [x] fixture-d emits 60+ http_endpoint entities (62)
- [x] spring-petclinic emits significant endpoints (25)
- [x] 5 quality fixtures maintain 100% recall
- [x] Non-Java fixtures unchanged
- [ ] Cross-repo link delta fixture-d <-> fixture-e (depends on consumer-side work)

Daemon cleanup confirmed.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>