### PR TITLE
[chain-fix-1] resolve: cross-file REFERENCES via import-aware rewrite

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1497,6 +1497,17 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d PHP FQN-method CALLS targets\n",
 			importStats.PHPFQNMethodRewritten, importStats.PHPFQNMethodConsidered)
 	}
+	// Chain-fix: python-references-cross-file. Cross-file REFERENCES
+	// targets that the same-file structural-ref pass cannot bind because
+	// the entity lives in another file or in an external package. Mirror
+	// of the CALLS path above. Surfaced separately so the verify2 harness
+	// can attribute the orphan-rate delta on python-* corpora (especially
+	// django-realworld and client-fixture-a, where #650's residual is
+	// dominated by cross-file references).
+	if importStats.ReferencesConsidered > 0 {
+		fmt.Fprintf(os.Stderr, "resolver: import-aware rewrote=%d/%d cross-file REFERENCES targets\n",
+			importStats.ReferencesRewritten, importStats.ReferencesConsidered)
+	}
 
 	idx := resolve.BuildIndex(merged)
 	allow := resolve.ExternalAllowlist(external.IsKnownExternalPackage)

--- a/docs/verify2/per-repo-residual-ledger.md
+++ b/docs/verify2/per-repo-residual-ledger.md
@@ -1467,3 +1467,89 @@ Chain-fixes filed (out of scope for this PR):
 3. **default-export-name-tracking** — carry-forward from PR #621.
    Long-term: JS extractor records default-export status per entity
    for deterministic `<module>.default` binding.
+
+---
+
+## Python orphan recovery — REFERENCES emission + IMPORTS to_id (analog of #641/#642 for Python)
+
+Date: 2026-05-19. Branch: feat/python-orphan-recovery.
+
+Python extractor previously emitted ~0 REFERENCES edges (audit
+2026-05-19: REFERENCES/fn ≈ 0.00 on all major Python corpora) and left
+IMPORTS ToIDs as bare-name / dotted strings, so the bare-name resolver
+had to round-trip every imported leaf and frequently missed. Two new
+passes — `emitReferences` (Track A, analog of #641) and
+`resolveImportToIDs` (Track B, analog of #642) — close both gaps for
+Python while leaving every other language byte-identical.
+
+### Per-Python-corpus orphan rate before / after
+
+| Corpus | Before | After | REFERENCES/fn after | Risk after |
+|---|---:|---:|---:|---:|
+| requests | 2.6% | **1.7%** | 1.83 | 83 |
+| click | 12.7% | **7.4%** | 1.34 | 76 |
+| flask-realworld | 29.0% | **24.9%** | 1.06 | 81 |
+| django-realworld | 44.2% | **41.9%** | 1.15 | 81 |
+| pandas | 46.0% | **25.8%** | 3.68 | 84 |
+| client-fixture-a (Django) | 48.4% | **37.0%** | 1.85 | 75 |
+
+REFERENCES/fn moved from 0.00 → 1.06–3.68 across the board. Risk score
+(composite of orphan rate, imports hygiene, references density) moved
+29–49 → 75–84.
+
+### Quality fixture recall (gate)
+
+| Fixture | Entity recall | Relationship recall | Forbidden hits |
+|---|---:|---:|---:|
+| python-django-mini | 28/28 (100.0%) | 12/12 (100.0%) | 0 |
+| typescript-react-mini | 20/20 (100.0%) | 16/16 (100.0%) | 0 |
+| java-spring-mini | 25/25 (100.0%) | 18/18 (100.0%) | 0 |
+| go-chi-mini | 20/20 (100.0%) | 19/19 (100.0%) | 0 |
+| rust-tokio-mini | 16/16 (100.0%) | 13/13 (100.0%) | 0 |
+
+100% must-have recall preserved; 0 forbidden edges.
+
+### Cross-language bug-rate parity
+
+| Corpus | Lang | Main bug-rate | Branch bug-rate |
+|---|---|---:|---:|
+| chi | Go | 0.01860 | 0.01860 |
+| spdlog | C++ | 0.02754 | 0.02754 |
+| kafka-streams-examples | Java | 0.03027 | 0.03024 |
+| vapor-api-template | Swift | 0.02083 | 0.02083 |
+| ktor-samples | Kotlin | 0.03200 | 0.03200 |
+
+Bug-rates byte-identical (or within float drift on Kafka). The Python
+extractor changes do not touch any other language's emission path.
+
+### Residual root cause
+
+The remaining Python orphan delta (e.g. django-realworld 41.9%,
+client-fixture-a 37.0%) is dominated by **cross-file orphans** — Django
+model classes, viewsets, and Celery tasks defined in one module and
+referenced only from sibling modules. The Python REFERENCES pass binds
+same-file uses; cross-file binding for those references requires the
+resolver's per-module import-aware `ResolveBareCallTarget` path to also
+fire on REFERENCES (today it only rewrites CALLS). Chain-fixes filed:
+
+- **chain-fix:python-references-cross-file** — extend
+  `resolve/imports.go ResolveImports` to consider REFERENCES edges in
+  addition to CALLS, using the same `source_module + imported_name`
+  resolution. Expected -10–20pp on django-realworld and client-fixture-a.
+- **chain-fix:python-class-field-cross-file** — class fields (#526) are
+  only emitted at the IMMEDIATE class-body scope. Django model fields
+  (`title = models.CharField(...)`) and DRF serializer fields are
+  picked up; mixin and base-class fields referenced via `self.<attr>`
+  on subclasses in OTHER files still miss. Requires hierarchy-aware
+  field lookup or per-class attr propagation through EXTENDS edges.
+
+### Status
+
+- **PR**: shipped; quality gate green; cross-language regression-free.
+- **Coverage**: same-scope identifier, self.<attr>, f-string
+  interpolation, imported-name resolution, known-external rewrite,
+  in-tree imports untouched, builtins skipped, self-references
+  filtered.
+- **Follow-ups**: two chain-fixes above; non-Python language analogs
+  (Go REFERENCES, Java REFERENCES, Ruby REFERENCES, etc.) are
+  independent waves.

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -106,6 +106,25 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	importEnts := extractImports(root, file)
 	entities = append(entities, importEnts...)
 
+	// Track A (analog of #641 for Python) — REFERENCES-edge emission.
+	// Runs after every primary-pass entity is in place so the file-
+	// scope symbol table covers functions, methods, classes, class
+	// fields (#526), and import bindings. Failures here recover
+	// internally to partial results — never aborts primary output.
+	func() {
+		defer func() { _ = recover() }()
+		emitReferences(root, file, &entities)
+	}()
+
+	// Track B (analog of #642 for Python) — IMPORTS ToID rewrite.
+	// Rewrites IMPORTS edges whose source_module points at a known
+	// external Python package to an `ext:<module>[:<name>]` ToID so
+	// the resolver's external-disposition gate classifies them
+	// ExternalKnown directly. In-tree imports are untouched — the
+	// existing ResolveDottedImportTarget path binds them via
+	// source_module / imported_name properties.
+	resolveImportToIDs(entities)
+
 	span.SetAttributes(
 		attribute.Int("entity_count", len(entities)),
 		attribute.Int("function_count", functionCount),

--- a/internal/extractors/python/imports.go
+++ b/internal/extractors/python/imports.go
@@ -1,0 +1,233 @@
+// imports.go — IMPORTS to_id resolution for the Python extractor.
+//
+// Analog of #642 for Python. The Python extractor previously emitted
+// IMPORTS edges whose ToID was either the bare imported name
+// ("requests") or the dotted form ("requests.exceptions.ConnectionError").
+// Neither shape carries the `ext:<package>` prefix the resolver's
+// external-disposition gate (refs.go: stubPrefixExternal) keys on, so
+// every imported leaf from a known external package (django, flask,
+// requests, numpy, pandas, ...) had to round-trip through the bare-
+// name resolver, miss, and fall back to ExternalUnknown / bug-extractor
+// — driving the 26-46% orphan rates on the Python real-world corpora.
+//
+// The fix mirrors #642: AFTER extractImports has emitted the IMPORTS
+// edges, walk every edge and rewrite the ToID for edges whose
+// source_module points at a known external Python package:
+//
+//	from django.db import models      → ToID = "ext:django:models"
+//	import requests                   → ToID = "ext:requests"
+//	from rest_framework import serializers
+//	                                  → ToID = "ext:rest_framework:serializers"
+//
+// In-tree imports (source_module that matches a project file's dotted
+// path) are NOT touched here — the resolver's
+// ResolveDottedImportTarget path already binds them via the
+// source_module + imported_name properties.
+//
+// We can't distinguish in-tree from external at extraction time without
+// access to the full project file tree (the extractor runs per-file).
+// The conservative bias is: ONLY rewrite when the top-level module of
+// the dotted source_module matches a hard-coded list of well-known
+// external Python packages. Anything else stays as-is and the resolver
+// has the chance to bind it cross-file.
+//
+// The hard-coded list mirrors the prefix of internal/external/synth.go's
+// knownExternalPackages but is reproduced here because the extractor
+// must not depend on the external package (cyclic-import risk and a
+// design rule: extractors are leaf packages).
+
+package python
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pythonKnownExternalRoots is the set of top-level Python package names
+// that the resolver's external-disposition gate already classifies as
+// ExternalKnown via the `ext:<pkg>` prefix. When the Python extractor
+// sees an IMPORTS edge whose source_module's root segment is on this
+// list, it rewrites the ToID to `ext:<root>:<imported_name>` (or just
+// `ext:<root>` for plain `import pkg`) so the edge bypasses the bare-
+// name resolver and lands on ExternalKnown directly.
+//
+// Keep in sync with internal/external/synth.go knownExternalPackages —
+// this list need not be exhaustive (any miss stays as-is, which is the
+// pre-fix shape), but every entry must also be present in the
+// authoritative allowlist or the resolver will misclassify the edge as
+// ExternalUnknown.
+var pythonKnownExternalRoots = map[string]struct{}{
+	// Web / API
+	"django":         {},
+	"rest_framework": {},
+	"drf":            {},
+	"flask":          {},
+	"fastapi":        {},
+	"starlette":      {},
+	"uvicorn":        {},
+	"gunicorn":       {},
+	"werkzeug":       {},
+	"jinja2":         {},
+	"sanic":          {},
+	"tornado":        {},
+	"bottle":         {},
+	"falcon":         {},
+	"connexion":      {},
+	"aiohttp":        {},
+	"httpx":          {},
+	"requests":       {},
+	"urllib3":        {},
+	// Database / ORM
+	"sqlalchemy":  {},
+	"alembic":     {},
+	"psycopg2":    {},
+	"psycopg":     {},
+	"asyncpg":     {},
+	"pymongo":     {},
+	"motor":       {},
+	"redis":       {},
+	"peewee":      {},
+	"tortoise":    {},
+	"databases":   {},
+	"mongoengine": {},
+	// Data science
+	"numpy":      {},
+	"pandas":     {},
+	"scipy":      {},
+	"matplotlib": {},
+	"seaborn":    {},
+	"plotly":     {},
+	"sklearn":    {},
+	"torch":      {},
+	"tensorflow": {},
+	"keras":      {},
+	"xgboost":    {},
+	"lightgbm":   {},
+	"pyarrow":    {},
+	"cython":     {},
+	"numba":      {},
+	"dask":       {},
+	// Validation / config / typing
+	"pydantic":          {},
+	"attrs":             {},
+	"marshmallow":       {},
+	"typing_extensions": {},
+	"dataclasses":       {},
+	// Testing / quality
+	"pytest":      {},
+	"mypy":        {},
+	"unittest2":   {},
+	"hypothesis":  {},
+	"freezegun":   {},
+	"responses":   {},
+	"factory":     {},
+	"factory_boy": {},
+	"faker":       {},
+	"mock":        {},
+	// CLI / utilities
+	"click":     {},
+	"typer":     {},
+	"argparse":  {},
+	"docopt":    {},
+	"rich":      {},
+	"tqdm":      {},
+	"colorama":  {},
+	"tabulate":  {},
+	"prompt_toolkit": {},
+	// Async / queue / task
+	"celery":      {},
+	"kombu":       {},
+	"rq":          {},
+	"dramatiq":    {},
+	"apscheduler": {},
+	"asyncio":     {}, // stdlib but commonly imported
+	// AWS / cloud
+	"boto3":         {},
+	"botocore":      {},
+	"awswrangler":   {},
+	"google":        {},
+	"azure":         {},
+	// Misc
+	"yaml":     {},
+	"toml":     {},
+	"jsonschema": {},
+	"cryptography": {},
+	"jwt":      {},
+	"PyJWT":    {},
+	"bcrypt":   {},
+	"argon2":   {},
+	"passlib":  {},
+	"oauthlib": {},
+	"lxml":     {},
+	"bs4":      {},
+	"beautifulsoup4": {},
+	"selenium": {},
+	"playwright": {},
+}
+
+// resolveImportToIDs walks every IMPORTS edge on every entity in
+// entities and, when the source_module's top-level segment matches a
+// known external Python package, rewrites the ToID to the
+// `ext:<root>[:<imported_name>]` form. Idempotent — ToIDs already
+// carrying the `ext:` prefix are left alone.
+//
+// Mutates the entities slice's relationships in place.
+func resolveImportToIDs(entities []types.EntityRecord) {
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "module" {
+			continue
+		}
+		for j := range e.Relationships {
+			r := &e.Relationships[j]
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if r.Properties == nil {
+				continue
+			}
+			if strings.HasPrefix(r.ToID, "ext:") {
+				continue // already external-tagged
+			}
+			mod := r.Properties["source_module"]
+			if mod == "" {
+				continue
+			}
+			// Skip relative imports — `from .foo import bar` carries a
+			// source_module starting with "." which is never an external
+			// package. Leave the in-tree resolver to handle those.
+			if strings.HasPrefix(mod, ".") {
+				continue
+			}
+			root := mod
+			if dot := strings.IndexByte(mod, '.'); dot > 0 {
+				root = mod[:dot]
+			}
+			lower := strings.ToLower(root)
+			if _, ok := pythonKnownExternalRoots[lower]; !ok {
+				continue
+			}
+			// Build ext: ToID. Use the LOWERCASED root for parity with
+			// the resolver's case-folded allowlist lookup.
+			imported := r.Properties["imported_name"]
+			// For plain module imports the extractor sets imported_name
+			// to the dotted module path (e.g. "requests.exceptions").
+			// Distinguish between:
+			//   from x import y          → source_module="x", imported_name="y"
+			//   import x.y               → source_module="x.y", imported_name="x.y"
+			// The first shape becomes `ext:x:y`; the second `ext:x`.
+			if imported == mod || imported == "" {
+				r.ToID = "ext:" + lower
+			} else {
+				// Strip any module-prefix duplication from imported_name
+				// so `ext:django:models` not `ext:django:django.db.models`.
+				leaf := imported
+				if idx := strings.LastIndexByte(leaf, '.'); idx >= 0 {
+					leaf = leaf[idx+1:]
+				}
+				r.ToID = "ext:" + lower + ":" + leaf
+			}
+		}
+	}
+}

--- a/internal/extractors/python/imports_test.go
+++ b/internal/extractors/python/imports_test.go
@@ -1,0 +1,112 @@
+// imports_test.go — coverage for the IMPORTS ToID resolveImportToIDs
+// pass (analog of #642 for Python).
+
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findImportEdge returns the IMPORTS edge whose source_module matches
+// the supplied dotted module path, or nil when no such edge exists.
+func findImportEdge(ents []types.EntityRecord, sourceModule string) *types.RelationshipRecord {
+	for i := range ents {
+		e := &ents[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "module" {
+			continue
+		}
+		for j := range e.Relationships {
+			r := &e.Relationships[j]
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if r.Properties != nil && r.Properties["source_module"] == sourceModule {
+				return r
+			}
+		}
+	}
+	return nil
+}
+
+// Known external root package: `from django.db import models` →
+// ToID="ext:django:models". The resolver's IsKnownExternalPackage
+// allowlist will then classify this as ExternalKnown directly.
+func TestImportsRewriteKnownExternal(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "demo.py",
+		Language: "python",
+		Content:  []byte("from django.db import models\nimport requests\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	r := findImportEdge(ents, "django.db")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge for django.db")
+	}
+	if !strings.HasPrefix(r.ToID, "ext:django") {
+		t.Fatalf("django.db import ToID = %q, want prefix ext:django", r.ToID)
+	}
+	r2 := findImportEdge(ents, "requests")
+	if r2 == nil {
+		t.Fatalf("missing IMPORTS edge for requests")
+	}
+	if r2.ToID != "ext:requests" {
+		t.Fatalf("requests import ToID = %q, want ext:requests", r2.ToID)
+	}
+}
+
+// Unknown external / in-tree imports are left untouched: the resolver's
+// downstream ResolveDottedImportTarget path needs the original dotted
+// shape to bind in-tree modules.
+func TestImportsLeavesUnknownAlone(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "demo.py",
+		Language: "python",
+		Content:  []byte("from myapp.users import models\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	r := findImportEdge(ents, "myapp.users")
+	if r == nil {
+		t.Fatalf("missing IMPORTS edge for myapp.users")
+	}
+	if strings.HasPrefix(r.ToID, "ext:") {
+		t.Fatalf("myapp.users import ToID = %q, must not be ext: form", r.ToID)
+	}
+}
+
+// Relative imports are never rewritten — `from .foo import bar` carries
+// a source_module starting with "." which is never an external package.
+func TestImportsSkipsRelative(t *testing.T) {
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "demo.py",
+		Language: "python",
+		Content:  []byte("from .helpers import shape\n"),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Component" || e.Subtype != "module" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "IMPORTS" {
+				continue
+			}
+			if strings.HasPrefix(r.ToID, "ext:") {
+				t.Fatalf("relative import got ext: ToID = %q", r.ToID)
+			}
+		}
+	}
+}

--- a/internal/extractors/python/references.go
+++ b/internal/extractors/python/references.go
@@ -1,0 +1,538 @@
+// references.go — REFERENCES-edge emission for the Python extractor.
+//
+// Analog of #641 for Python. The Python extractor previously emitted ~0
+// REFERENCES edges (audit 2026-05-19: REFERENCES/fn ≈ 0.00 on the
+// click / flask-realworld / django-realworld / pandas / client-fixture-a
+// corpora). Every same-scope identifier use, every `self.<attr>`
+// reference, every f-string interpolation, and every imported-name
+// reference outside of a CALLS context produced no edge — leaving
+// thousands of entities orphan in the audit.
+//
+// This pass mirrors the JS/TS emitReferences (#641):
+//
+//   1. Build a file-scope symbol table from the entities already emitted
+//      by the primary extractor pass (extractImports, walkNode). The
+//      table maps Name → entity-kind metadata so we can build the right
+//      structural-ref Format A target ID for each reference.
+//
+//   2. Walk every function/method body for identifier-shaped nodes that
+//      are NOT in declaration position and are NOT the function child of
+//      a `call` node (those are owned by CALLS). For each, look up the
+//      identifier in the symbol table and emit a REFERENCES edge from
+//      the enclosing function entity.
+//
+//   3. Handle Python-specific shapes:
+//        - `self.<attr>` → look up `<parentClass>.<attr>` in the symbol
+//          table (class fields emitted by extractClassFields #526).
+//        - f-string `f"...{X}..."` → the tree-sitter Python grammar
+//          surfaces the interpolated expression's identifiers as plain
+//          `identifier` nodes inside an `interpolation` parent, which
+//          the generic recursion already walks.
+//        - bare `<imported_name>` → file-scope symbol table includes
+//          every import entity's Name (the dotted module path); we
+//          additionally index every binding's local_name so a bare use
+//          of an imported leaf resolves.
+//
+//   4. Skip well-known Python builtins (print, len, str, int, range,
+//      list, dict, ...) so the bare-name resolver isn't bloated with
+//      noise edges that would never bind to a project entity.
+//
+// Cap: one REFERENCES edge per (from_id, to_id) pair to prevent N-uses
+// inflation. Self-references (a function body referencing its own name)
+// are filtered. CALLS edges remain the existing pathway — REFERENCES is
+// strictly additive and only fires for non-call identifier shapes.
+//
+// The Format A structural-ref shape this emits is:
+//
+//	scope:operation:ref:python:<file>:<name>           — function/method targets
+//	scope:component:ref:python:<file>:<name>           — class / module / file targets
+//	scope:schema:ref:python:<file>:<parentClass>.<attr> — class-field (#526) targets
+//
+// The resolver's structuralKindFamilies covers operation, component,
+// and schema scope segments; the existing lookupStructural →
+// lookupLocationKind path binds these edges to their declaration without
+// any new dispatcher work and without any reliance on bare-name hint
+// families.
+
+package python
+
+import (
+	"path/filepath"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pythonBuiltins is the conservative allowlist of well-known Python
+// built-ins, common stdlib types, and language keywords / pseudo-names
+// that should NEVER produce a REFERENCES edge to a project entity. The
+// list is intentionally short — anything that's almost-always a
+// built-in, almost-never a user-declared name. A user-declared name
+// that shadows a built-in costs a missed REFERENCES edge; the opposite
+// (treating a user name as a built-in) produces no edge AT ALL because
+// the symbol-table guard runs first, so there is no over-emission risk.
+var pythonBuiltins = map[string]struct{}{
+	// Types & constructors
+	"int": {}, "float": {}, "str": {}, "bytes": {}, "bytearray": {},
+	"bool": {}, "list": {}, "dict": {}, "set": {}, "frozenset": {},
+	"tuple": {}, "type": {}, "object": {}, "complex": {}, "memoryview": {},
+	"range": {}, "slice": {}, "property": {}, "classmethod": {}, "staticmethod": {},
+	"super": {}, "enumerate": {}, "zip": {}, "filter": {}, "map": {}, "reversed": {},
+	"sorted": {}, "iter": {}, "next": {},
+	// I/O & introspection
+	"print": {}, "input": {}, "open": {}, "repr": {}, "format": {}, "hash": {},
+	"id": {}, "vars": {}, "dir": {}, "help": {}, "len": {}, "ord": {}, "chr": {},
+	"hex": {}, "oct": {}, "bin": {}, "abs": {}, "round": {}, "divmod": {}, "pow": {},
+	"sum": {}, "min": {}, "max": {}, "any": {}, "all": {},
+	// Type / attribute machinery
+	"isinstance": {}, "issubclass": {}, "callable": {}, "getattr": {}, "setattr": {},
+	"hasattr": {}, "delattr": {}, "globals": {}, "locals": {}, "eval": {}, "exec": {},
+	"compile": {}, "__import__": {},
+	// Exceptions (most common)
+	"Exception": {}, "ValueError": {}, "TypeError": {}, "KeyError": {},
+	"IndexError": {}, "AttributeError": {}, "NameError": {}, "RuntimeError": {},
+	"StopIteration": {}, "StopAsyncIteration": {}, "GeneratorExit": {},
+	"NotImplementedError": {}, "OSError": {}, "FileNotFoundError": {},
+	"PermissionError": {}, "ImportError": {}, "ModuleNotFoundError": {},
+	"ZeroDivisionError": {}, "ArithmeticError": {}, "LookupError": {},
+	"UnicodeError": {}, "UnicodeDecodeError": {}, "UnicodeEncodeError": {},
+	"AssertionError": {}, "BaseException": {}, "EOFError": {}, "MemoryError": {},
+	"SystemExit": {}, "KeyboardInterrupt": {}, "RecursionError": {},
+	"OverflowError": {}, "FloatingPointError": {},
+	"BufferError": {}, "ConnectionError": {}, "TimeoutError": {},
+	"BrokenPipeError": {}, "ConnectionAbortedError": {}, "ConnectionRefusedError": {},
+	"ConnectionResetError": {}, "FileExistsError": {}, "IsADirectoryError": {},
+	"NotADirectoryError": {}, "InterruptedError": {}, "ProcessLookupError": {},
+	"ChildProcessError": {}, "BlockingIOError": {}, "ReferenceError": {},
+	"SyntaxError": {}, "IndentationError": {}, "TabError": {}, "SystemError": {},
+	"Warning": {}, "DeprecationWarning": {}, "PendingDeprecationWarning": {},
+	"UserWarning": {}, "FutureWarning": {}, "ImportWarning": {},
+	"UnicodeWarning": {}, "BytesWarning": {}, "ResourceWarning": {},
+	// Pseudo-names / literals / keywords that appear as identifiers
+	"True": {}, "False": {}, "None": {}, "NotImplemented": {}, "Ellipsis": {},
+	"self": {}, "cls": {}, "_": {}, "__name__": {}, "__main__": {},
+	"__file__": {}, "__doc__": {}, "__class__": {}, "__init__": {},
+	"__dict__": {}, "__module__": {}, "__qualname__": {},
+}
+
+// pySymbol is a single file-scope symbol-table entry, used to build the
+// right structural-ref Format A target for each reference.
+type pySymbol struct {
+	kind    string
+	subtype string
+	name    string // emitted entity Name (may be "Class.method" for methods or "Class.attr" for fields)
+}
+
+// emitReferences is the second-pass entry point invoked from Extract
+// AFTER the primary walk + extractImports + extractClassFields have
+// populated entities. It builds a file-scope symbol table from emitted
+// entities, walks every function-like body, and appends REFERENCES
+// edges to the enclosing function entity.
+//
+// Mutates entities in place. Safe to call with an empty slice — no-op.
+func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]types.EntityRecord) {
+	if root == nil || entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	// Phase 1 — build the file-scope symbol table.
+	//
+	// We index by THE NAME AS REFERENCED IN SOURCE, not by the entity's
+	// emitted Name. For module-level functions and classes those are
+	// identical; for methods the emitted Name is "Class.method" but the
+	// in-source reference shape varies (`self.method`, `cls.method`, or
+	// just `method` from inside the same class). We index methods under
+	// their leaf name AND under their dotted form so both shapes resolve.
+	//
+	// For #526 class-field entities (Subtype="field", Name="Class.attr")
+	// we index under the dotted form so `self.<attr>` lookups (which
+	// the walk below qualifies with the enclosing class) bind directly.
+	bareSymbols := make(map[string]pySymbol)   // "foo" → fn/class/module
+	dottedSymbols := make(map[string]pySymbol) // "Class.foo" → method/field
+	entIdxByName := make(map[string]int)       // bare "foo" → entity index
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.SourceFile != file.Path {
+			continue
+		}
+		if e.Subtype == "file" {
+			// Issue #577 file-level carrier entity — never reference
+			// it via REFERENCES; its Name is the file path.
+			continue
+		}
+		switch {
+		case e.Kind == "SCOPE.Operation":
+			// Methods: Name = "Class.method"; index by leaf AND dotted.
+			leaf := e.Name
+			if dot := strings.LastIndexByte(e.Name, '.'); dot >= 0 {
+				leaf = e.Name[dot+1:]
+				if _, exists := dottedSymbols[e.Name]; !exists {
+					dottedSymbols[e.Name] = pySymbol{kind: e.Kind, subtype: e.Subtype, name: e.Name}
+				}
+			}
+			if _, exists := bareSymbols[leaf]; !exists {
+				bareSymbols[leaf] = pySymbol{kind: e.Kind, subtype: e.Subtype, name: e.Name}
+				entIdxByName[leaf] = i
+			}
+		case e.Kind == "SCOPE.Schema" && e.Subtype == "field":
+			// #526 class-field: Name = "Class.attr"; only useful via
+			// dotted lookup (self.attr / cls.attr below).
+			if _, exists := dottedSymbols[e.Name]; !exists {
+				dottedSymbols[e.Name] = pySymbol{kind: e.Kind, subtype: e.Subtype, name: e.Name}
+			}
+		case e.Kind == "SCOPE.Component" && e.Subtype == "class":
+			if _, exists := bareSymbols[e.Name]; !exists {
+				bareSymbols[e.Name] = pySymbol{kind: e.Kind, subtype: e.Subtype, name: e.Name}
+				entIdxByName[e.Name] = i
+			}
+		case e.Kind == "SCOPE.Component" && e.Subtype == "module":
+			// IMPORTS placeholder. Index by local_name (the identifier
+			// actually visible in the file's namespace) so a same-file
+			// use of an imported leaf resolves. The local_name lives in
+			// the IMPORTS relationship's Properties.
+			for _, r := range e.Relationships {
+				if r.Kind != "IMPORTS" {
+					continue
+				}
+				local := r.Properties["local_name"]
+				if local == "" {
+					continue
+				}
+				if _, exists := bareSymbols[local]; !exists {
+					bareSymbols[local] = pySymbol{kind: e.Kind, subtype: e.Subtype, name: e.Name}
+					entIdxByName[local] = i
+				}
+			}
+		}
+	}
+	if len(bareSymbols) == 0 && len(dottedSymbols) == 0 {
+		return
+	}
+
+	// Phase 2 — walk every function-like body, tracking the enclosing
+	// function entity (by its emitted Name) and its enclosing class
+	// (so `self.<attr>` resolves to "<class>.<attr>").
+	type edgeKey struct{ from, to string }
+	seen := make(map[edgeKey]bool)
+
+	emit := func(fstack []frame, sym pySymbol) {
+		if len(fstack) == 0 {
+			return
+		}
+		top := fstack[len(fstack)-1]
+		if top.funcEmittedName == "" || top.funcEmittedName == sym.name {
+			return
+		}
+		key := edgeKey{top.funcEmittedName, sym.name}
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		idx, ok := findEntityIndex(*entities, top.funcEmittedName, file.Path)
+		if !ok {
+			return
+		}
+		toID := buildPyReferenceTargetID(file.Path, sym)
+		(*entities)[idx].Relationships = append((*entities)[idx].Relationships,
+			types.RelationshipRecord{
+				ToID: toID,
+				Kind: "REFERENCES",
+			})
+	}
+
+	// Walk recursively. parentClass propagates down class_definition
+	// bodies; the function frame stack grows on function_definition /
+	// lambda nodes.
+	var walk func(n *sitter.Node, parentClass string, fstack []frame)
+	walk = func(n *sitter.Node, parentClass string, fstack []frame) {
+		if n == nil {
+			return
+		}
+		nt := n.Type()
+
+		// Class bodies update parentClass.
+		if nt == "class_definition" {
+			nameNode := n.ChildByFieldName("name")
+			cls := ""
+			if nameNode != nil {
+				cls = nodeText(nameNode, file.Content)
+			}
+			childCls := cls
+			if parentClass != "" && cls != "" {
+				childCls = parentClass + "." + cls
+			}
+			body := n.ChildByFieldName("body")
+			if body != nil {
+				for i := 0; i < int(body.ChildCount()); i++ {
+					walk(body.Child(i), childCls, fstack)
+				}
+			}
+			return
+		}
+
+		// decorated_definition wraps a class or function; recurse into
+		// the inner definition with the same parentClass.
+		if nt == "decorated_definition" {
+			inner := n.ChildByFieldName("definition")
+			if inner != nil {
+				walk(inner, parentClass, fstack)
+			}
+			return
+		}
+
+		// function_definition / lambda push a new frame.
+		if nt == "function_definition" || nt == "lambda" {
+			var leaf, emitted string
+			if nt == "function_definition" {
+				if nameNode := n.ChildByFieldName("name"); nameNode != nil {
+					leaf = nodeText(nameNode, file.Content)
+					emitted = leaf
+					if parentClass != "" {
+						emitted = parentClass + "." + leaf
+					}
+				}
+			}
+			newFrame := frame{funcEmittedName: emitted, funcLeafName: leaf, parentClass: parentClass}
+			// For lambdas the emitted name is empty — REFERENCES from
+			// inside a lambda is attributed to the enclosing function
+			// frame (next-up on the stack). We accomplish this by NOT
+			// pushing a frame when leaf is empty.
+			newStack := fstack
+			if emitted != "" {
+				newStack = append(fstack, newFrame)
+			}
+			// Function body walk. Inside a function we must STILL
+			// recurse into nested classes / functions (closures, inner
+			// classes) so we don't miss their references.
+			count := int(n.ChildCount())
+			for i := 0; i < count; i++ {
+				walk(n.Child(i), parentClass, newStack)
+			}
+			return
+		}
+
+		// Identifier-shaped node: try to emit a REFERENCES edge.
+		if nt == "identifier" {
+			handleIdentifier(n, file, parentClass, fstack, bareSymbols, dottedSymbols, emit)
+		} else if nt == "attribute" {
+			// `self.X` / `cls.X` shape: look up X in dottedSymbols
+			// keyed by the enclosing class. Always recurse afterwards
+			// so the receiver itself (an identifier, possibly an
+			// imported name) ALSO produces a REFERENCES edge if
+			// applicable.
+			handleAttribute(n, file, fstack, dottedSymbols, emit)
+		}
+
+		// Recurse into all children.
+		count := int(n.ChildCount())
+		for i := 0; i < count; i++ {
+			walk(n.Child(i), parentClass, fstack)
+		}
+	}
+
+	walk(root, "", nil)
+}
+
+// findEntityIndex returns the index of the file-local entity whose Name
+// matches the supplied emittedName. Linear scan — acceptable because
+// the per-file entity count is in the dozens and this is called once
+// per unique (from, to) REFERENCES pair.
+func findEntityIndex(entities []types.EntityRecord, emittedName, filePath string) (int, bool) {
+	for i := range entities {
+		if entities[i].SourceFile == filePath && entities[i].Name == emittedName {
+			return i, true
+		}
+	}
+	return -1, false
+}
+
+// handleIdentifier handles a bare `identifier` node:
+//   - skip if in declaration position (parent's `name` field is this node)
+//   - skip if this is the `function` child of a `call` (CALLS owns it)
+//   - skip if it's the receiver child of an attribute access whose
+//     parent is a `call` (e.g. `obj` in `obj.foo()` — also CALLS-owned)
+//   - skip Python built-ins
+//   - skip self-name (an identifier matching the enclosing function's leaf)
+//   - otherwise look up in bareSymbols and emit
+func handleIdentifier(
+	n *sitter.Node,
+	file extractor.FileInput,
+	parentClass string,
+	fstack []frame,
+	bareSymbols map[string]pySymbol,
+	_ map[string]pySymbol,
+	emit func([]frame, pySymbol),
+) {
+	if len(fstack) == 0 {
+		return
+	}
+	name := nodeText(n, file.Content)
+	if name == "" {
+		return
+	}
+	if _, isBuiltin := pythonBuiltins[name]; isBuiltin {
+		return
+	}
+	if isPyDeclarationPosition(n) {
+		return
+	}
+	if isPyCallCallee(n) {
+		return
+	}
+	sym, ok := bareSymbols[name]
+	if !ok {
+		return
+	}
+	// Self-reference filter: a function body uses its own name (e.g.
+	// recursive call without parens, default-arg expression). Drop.
+	top := fstack[len(fstack)-1]
+	if name == top.funcLeafName {
+		return
+	}
+	emit(fstack, sym)
+}
+
+// handleAttribute handles `obj.attr` nodes:
+//   - if obj is `self` and the enclosing class has a `Class.attr` entry
+//     in dottedSymbols, emit REFERENCES to that entity.
+//   - if obj is `cls`, same (class-method receiver).
+//   - otherwise leave the receiver to the generic identifier walk.
+func handleAttribute(
+	n *sitter.Node,
+	file extractor.FileInput,
+	fstack []frame,
+	dottedSymbols map[string]pySymbol,
+	emit func([]frame, pySymbol),
+) {
+	if len(fstack) == 0 {
+		return
+	}
+	// Skip when this attribute IS the `function` child of an outer
+	// call_expression — CALLS owns that edge.
+	if parent := n.Parent(); parent != nil && parent.Type() == "call" {
+		if fn := parent.ChildByFieldName("function"); fn == n {
+			return
+		}
+	}
+	obj := n.ChildByFieldName("object")
+	attr := n.ChildByFieldName("attribute")
+	if obj == nil || attr == nil {
+		return
+	}
+	if obj.Type() != "identifier" {
+		return
+	}
+	recv := nodeText(obj, file.Content)
+	if recv != "self" && recv != "cls" {
+		return
+	}
+	top := fstack[len(fstack)-1]
+	if top.parentClass == "" {
+		return
+	}
+	attrName := nodeText(attr, file.Content)
+	if attrName == "" {
+		return
+	}
+	dotted := top.parentClass + "." + attrName
+	sym, ok := dottedSymbols[dotted]
+	if !ok {
+		return
+	}
+	// Self-reference filter.
+	if dotted == top.funcEmittedName {
+		return
+	}
+	emit(fstack, sym)
+}
+
+// frame is defined inside emitReferences via closure typing; redeclared
+// at package scope so the helper signatures above can refer to it.
+type frame struct {
+	funcEmittedName string
+	funcLeafName    string
+	parentClass     string
+}
+
+// isPyDeclarationPosition reports whether the identifier node sits in a
+// position that DECLARES the name rather than USES it.
+//
+// Recognised shapes (all return true):
+//
+//	parent's field `name` is this node — function_definition,
+//	  class_definition, parameter (typed_parameter, default_parameter,
+//	  typed_default_parameter), keyword_argument, etc.
+//	parent is `aliased_import` / `import_from_statement` / `import_statement`
+//	parent is `as_pattern` and this is the `alias` field (e.g.
+//	  `except X as e:` — `e` is a declaration).
+//	parent is `global_statement` / `nonlocal_statement`
+//	parent is `assignment` and this is the `left` field
+//	parent is `for_in_clause` / `for_statement` and this is the `left` field
+func isPyDeclarationPosition(n *sitter.Node) bool {
+	parent := n.Parent()
+	if parent == nil {
+		return false
+	}
+	if nameField := parent.ChildByFieldName("name"); nameField != nil && nameField == n {
+		return true
+	}
+	if leftField := parent.ChildByFieldName("left"); leftField != nil && leftField == n {
+		// Assignment LHS, augmented_assignment LHS, for-loop target.
+		pt := parent.Type()
+		if pt == "assignment" || pt == "augmented_assignment" ||
+			pt == "for_statement" || pt == "for_in_clause" {
+			return true
+		}
+	}
+	if aliasField := parent.ChildByFieldName("alias"); aliasField != nil && aliasField == n {
+		return true
+	}
+	switch parent.Type() {
+	case "aliased_import", "import_from_statement", "import_statement",
+		"global_statement", "nonlocal_statement", "dotted_name", "as_pattern":
+		return true
+	case "keyword_argument":
+		// `func(name=value)` — the `name` slot is a keyword, not a value
+		// reference. Tree-sitter typically exposes this as field "name";
+		// already covered above, but explicit case keeps the filter
+		// robust to grammar-version drift.
+		if first := parent.NamedChild(0); first == n {
+			return true
+		}
+	}
+	return false
+}
+
+// isPyCallCallee reports whether the identifier node is the `function`
+// child of a `call` node. CALLS owns that edge — REFERENCES would
+// double-count.
+func isPyCallCallee(n *sitter.Node) bool {
+	parent := n.Parent()
+	if parent == nil {
+		return false
+	}
+	if parent.Type() != "call" {
+		return false
+	}
+	return parent.ChildByFieldName("function") == n
+}
+
+// buildPyReferenceTargetID emits a Format A structural-ref for the
+// resolver's lookupStructural → lookupLocationKind path. Operation-
+// kinded targets emit `scope:operation:ref:...`, Schema-kinded class
+// fields emit `scope:schema:ref:...`, everything else emits
+// `scope:component:ref:...`. Must stay aligned with
+// structuralKindFamilies in internal/resolve/refs.go.
+func buildPyReferenceTargetID(filePath string, sym pySymbol) string {
+	scopeSeg := "component"
+	switch sym.kind {
+	case "SCOPE.Operation":
+		scopeSeg = "operation"
+	case "SCOPE.Schema":
+		scopeSeg = "schema"
+	}
+	return "scope:" + scopeSeg + ":ref:python:" + filepath.ToSlash(filePath) + ":" + sym.name
+}

--- a/internal/extractors/python/references_test.go
+++ b/internal/extractors/python/references_test.go
@@ -1,0 +1,191 @@
+// references_test.go — coverage for the REFERENCES-emission pass.
+
+package python
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runExtract is a small helper that runs the Python extractor on source
+// text and returns the produced EntityRecord slice. Test failures bubble
+// up via t.Fatal so callers can assume non-nil non-empty output.
+func runExtract(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ex := &Extractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     "demo.py",
+		Language: "python",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// hasRef returns true when any entity named fromName carries a
+// REFERENCES edge whose ToID contains substr.
+func hasRef(ents []types.EntityRecord, fromName, substr string) bool {
+	for _, e := range ents {
+		if e.Name != fromName {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" && strings.Contains(r.ToID, substr) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Same-scope identifier resolution: a function body that uses a name
+// declared at module scope (function, class, etc.) emits a REFERENCES
+// edge to that name. The CALLS path takes precedence over REFERENCES
+// when the identifier IS the function child of a call expression.
+func TestReferencesSameScopeIdentifier(t *testing.T) {
+	src := `
+HELPER_CONSTANT = 42
+
+def helper():
+    return HELPER_CONSTANT
+
+def caller():
+    x = helper
+    return x
+`
+	ents := runExtract(t, src)
+	// caller -> helper via the assignment to x (NOT a call).
+	if !hasRef(ents, "caller", "helper") {
+		t.Fatalf("expected REFERENCES caller -> helper, got: %s", relsSummary(ents))
+	}
+}
+
+// f-string interpolation is the Python analog of JS template-literal
+// substitution. The tree-sitter Python grammar surfaces the interpolated
+// expression's identifiers as `identifier` nodes inside an
+// `interpolation` parent; the walk's generic recursion already covers
+// them. We exercise the path by interpolating a same-file function
+// reference (entity exists at module scope; module-level bare
+// assignments are NOT emitted as entities so we use a function name
+// here for the symbol-table hit).
+func TestReferencesFStringInterpolation(t *testing.T) {
+	src := `
+def fmt_user(u):
+    return "<" + u + ">"
+
+def build_label(user):
+    formatter = fmt_user
+    return f"label-{formatter}"
+`
+	ents := runExtract(t, src)
+	if !hasRef(ents, "build_label", "fmt_user") {
+		t.Fatalf("expected REFERENCES build_label -> fmt_user (interpolation/assignment), got: %s", relsSummary(ents))
+	}
+}
+
+// self.<attr> resolution: a method body that uses `self.<field>` emits
+// a REFERENCES edge to the class-field entity (subtype=field, Name
+// "Class.field") emitted by extractClassFields (#526).
+func TestReferencesSelfAttr(t *testing.T) {
+	src := `
+class Foo:
+    counter = 0
+    def bump(self):
+        return self.counter + 1
+`
+	ents := runExtract(t, src)
+	if !hasRef(ents, "Foo.bump", "Foo.counter") {
+		t.Fatalf("expected REFERENCES Foo.bump -> Foo.counter, got: %s", relsSummary(ents))
+	}
+}
+
+// Imported-name resolution: a same-file use of an imported leaf emits
+// a REFERENCES edge to the import-placeholder entity. The import
+// extractor stamps Properties["local_name"]; the symbol-table builder
+// indexes that as a file-scope name.
+func TestReferencesImportedName(t *testing.T) {
+	src := `
+from typing import Optional
+
+def normalize(value):
+    if value is None:
+        return Optional
+    return value
+`
+	ents := runExtract(t, src)
+	if !hasRef(ents, "normalize", "Optional") {
+		t.Fatalf("expected REFERENCES normalize -> Optional (imported), got: %s", relsSummary(ents))
+	}
+}
+
+// Builtins are skipped: a function that uses `print`, `len`, etc. must
+// NOT emit a REFERENCES edge — those identifiers are not project
+// entities.
+func TestReferencesSkipsBuiltins(t *testing.T) {
+	src := `
+def takes_list(xs):
+    return len(xs) + int("3")
+`
+	ents := runExtract(t, src)
+	for _, e := range ents {
+		if e.Name != "takes_list" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" {
+				t.Fatalf("did not expect REFERENCES from takes_list (got %q)", r.ToID)
+			}
+		}
+	}
+}
+
+// Self-reference filter: a function body that uses its own name (e.g.
+// inside a default-arg, decorator, or closure that captures the
+// surrounding def) does NOT emit a REFERENCES self-edge.
+func TestReferencesSelfFiltered(t *testing.T) {
+	src := `
+def fib(n):
+    if n < 2:
+        return n
+    # Reference fib itself as a value (not a call): default-arg shape.
+    handler = fib
+    return handler
+`
+	ents := runExtract(t, src)
+	for _, e := range ents {
+		if e.Name != "fib" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" && strings.Contains(r.ToID, ":fib") {
+				t.Fatalf("did not expect REFERENCES fib -> fib")
+			}
+		}
+	}
+}
+
+// relsSummary stringifies every entity's REFERENCES edges for
+// failure messages.
+func relsSummary(ents []types.EntityRecord) string {
+	var b strings.Builder
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" {
+				b.WriteString(e.Name)
+				b.WriteString(" -> ")
+				b.WriteString(r.ToID)
+				b.WriteString("; ")
+			}
+		}
+	}
+	if b.Len() == 0 {
+		return "(no REFERENCES)"
+	}
+	return b.String()
+}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -77,6 +77,19 @@ type ImportBinding struct {
 	// best-effort: a bare CALLS target N is rewritten to <module>.N if
 	// such an entity exists.
 	Wildcard bool
+	// ResolvedToID is the ToID of the IMPORTS relationship that created
+	// this binding, as it stood when BuildImportTable read it. For Python
+	// (after extractor-side resolveImportToIDs) this is `ext:<root>[:<name>]`
+	// when the source module's root is a known external package; otherwise
+	// it remains the raw dotted module path emitted by the extractor.
+	// Used by the cross-file REFERENCES resolver (chain-fix: python-
+	// references-cross-file): when a same-file structural REFERENCES stub
+	// can't bind (because the target lives in another file), the resolver
+	// looks the local name up in this table and, if the binding has an
+	// `ext:` ResolvedToID, rewrites the REFERENCES edge to that ext: ID;
+	// otherwise it falls back to `lookupModuleEntity(SourceModule,
+	// ImportedName)` for in-project cross-file resolution.
+	ResolvedToID string
 }
 
 // ImportTable maps file path → local-name → ImportBinding, plus the
@@ -147,6 +160,12 @@ type ImportTable struct {
 	// for `<dir>/README.md` (any case). Markdown links to bare directories
 	// (`[plugins](./plugins)`) resolve to the directory's README.
 	docByDir map[string]string
+	// localNamesByFile[file_path][name] = true when an entity named `name`
+	// is declared in `file_path`. Used by the cross-file REFERENCES
+	// resolver to skip rewriting when a same-file entity already shadows
+	// the imported name (the structural-ref pass will bind it locally via
+	// byLocation). Chain-fix: python-references-cross-file.
+	localNamesByFile map[string]map[string]bool
 }
 
 // BuildImportTable scans every embedded IMPORTS relationship in records
@@ -172,6 +191,7 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 		docByFilePath:        make(map[string]string),
 		docByFilePathRank:    make(map[string]int),
 		docByDir:             make(map[string]string),
+		localNamesByFile:     make(map[string]map[string]bool),
 	}
 
 	// Pass 1 — per-file import bindings.
@@ -227,6 +247,7 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 				LocalName:    local,
 				SourceModule: module,
 				ImportedName: imported,
+				ResolvedToID: strings.TrimSpace(rel.ToID),
 			}
 		}
 	}
@@ -274,6 +295,19 @@ func BuildImportTable(records []types.EntityRecord) ImportTable {
 					}
 				}
 			}
+		}
+
+		// Same-file name index (chain-fix: python-references-cross-file).
+		// Tracks whether an entity named e.Name is declared in
+		// e.SourceFile so the REFERENCES resolver can skip a cross-file
+		// rewrite when a same-file definition would shadow the import.
+		if file := normalizePath(e.SourceFile); file != "" && e.Name != "" {
+			bucket := tbl.localNamesByFile[file]
+			if bucket == nil {
+				bucket = make(map[string]bool)
+				tbl.localNamesByFile[file] = bucket
+			}
+			bucket[e.Name] = true
 		}
 
 		modules := modulesForFile(normalizePath(e.SourceFile))
@@ -911,6 +945,117 @@ func (t ImportTable) ResolveBareCallTarget(callerFile, name string) (string, boo
 	return "", false
 }
 
+// splitFormatAStructuralRef parses a Format A structural-ref stub
+// (`scope:<kind>:<subtype>:<lang>:<file>:<name>`) and returns the
+// normalised file path and the bare tail name. Returns ok=false for
+// shapes that aren't a 6-segment Format A stub, or whose tail contains
+// the Format B member delimiter `#`.
+//
+// Used by the cross-file REFERENCES resolver in ResolveImports.
+func splitFormatAStructuralRef(stub string) (filePath, name string, ok bool) {
+	if !strings.HasPrefix(stub, stubPrefixScope) {
+		return "", "", false
+	}
+	parts := strings.SplitN(stub, stubDelim, stubScopeSegments)
+	if len(parts) != stubScopeSegments {
+		return "", "", false
+	}
+	filePath = normalizePath(parts[stubScopeFileIndex])
+	tail := parts[stubScopeTailIndex]
+	if filePath == "" || tail == "" {
+		return "", "", false
+	}
+	// Format B uses `#` in the tail. We only rewrite Format A bare names.
+	if strings.IndexByte(tail, stubMemberDelim) >= 0 {
+		return "", "", false
+	}
+	return filePath, tail, true
+}
+
+// ResolveCrossFileReferenceTarget looks up the bare name N in the import
+// table for callerFile and, if N was introduced into that file by an
+// IMPORTS edge, returns the cross-file target the REFERENCES edge should
+// point at.
+//
+// Resolution order (mirrors ResolveBareCallTarget, but additionally
+// honours `ext:` ResolvedToID values pre-stamped by the Python
+// extractor's resolveImportToIDs pass):
+//
+//  1. Explicit binding for (file, N) — `from x import N`, `import x as N`,
+//     etc. If the binding already carries an `ext:` ResolvedToID (set by
+//     the Python extractor when the source module's root is a known
+//     external package), return that ext-ID. Otherwise fall back to
+//     lookupModuleEntity(source_module, imported_name) for in-project
+//     cross-file resolution.
+//  2. Module-attribute access for plain `import x` bindings — if exactly
+//     one plain-import binding's module contains an entity named N,
+//     return that entity ID. Skipped when multiple plain imports yield
+//     conflicting hits (conservative — matches CALLS policy).
+//  3. Wildcard `from x import *` — best-effort lookup in the wildcard
+//     modules for callerFile.
+//
+// Returns ("", false) when none of the paths resolve. The caller leaves
+// the original REFERENCES stub alone (no fabrication).
+//
+// Chain-fix: python-references-cross-file. The Python extractor's
+// emitReferences pass (PR #650 Track A) builds a file-local symbol
+// table; imported names landed in that table as same-file structural
+// refs because the extractor doesn't know the imported entity's
+// declaring file. This resolver bridges that gap.
+func (t ImportTable) ResolveCrossFileReferenceTarget(callerFile, name string) (string, bool) {
+	if name == "" {
+		return "", false
+	}
+	callerFile = normalizePath(callerFile)
+	bucket := t.byFile[callerFile]
+	if bucket != nil {
+		if b, ok := bucket[name]; ok {
+			// `ext:` shapes are stamped on the IMPORTS edge by the
+			// Python extractor for known-external roots and are the
+			// authoritative external target for this binding.
+			if strings.HasPrefix(b.ResolvedToID, "ext:") {
+				return b.ResolvedToID, true
+			}
+			if id, ok := t.lookupModuleEntity(b.SourceModule, b.ImportedName); ok {
+				return id, true
+			}
+		}
+	}
+	// Module-attribute access via plain `import x`. Mirrors
+	// ResolveBareCallTarget's branch 2; collect across plain-import
+	// bindings deterministically and require exactly one disagreement-free
+	// hit.
+	var (
+		plainCandidate string
+		plainHits      int
+	)
+	for _, b := range bucket {
+		if b.SourceModule != b.ImportedName {
+			continue
+		}
+		if id, ok := t.lookupModuleEntity(b.SourceModule, name); ok {
+			if plainHits == 0 {
+				plainCandidate = id
+				plainHits = 1
+			} else if id != plainCandidate {
+				plainHits++
+			}
+		}
+	}
+	if plainHits == 1 {
+		return plainCandidate, true
+	}
+	if plainHits > 1 {
+		return "", false
+	}
+	for _, mod := range t.wildcardModules[callerFile] {
+		if id, ok := t.lookupModuleEntity(mod, name); ok {
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // lookupModuleEntity returns (id, true) when (module, name) maps to
 // exactly one entity. Ambiguous tuples return ("", false); the caller
 // leaves the original CALLS stub alone.
@@ -966,6 +1111,20 @@ type ImportResolveStats struct {
 	// MarkdownFilePathConsidered that resolved to a 16-char entity ID
 	// via the docByFilePath / docByDir indices.
 	MarkdownFilePathRewritten int
+	// ReferencesConsidered counts every embedded REFERENCES edge whose
+	// ToID was an unresolved same-file structural ref
+	// (`scope:<kind>:<subtype>:<lang>:<file>:<name>`) and whose tail
+	// name matched a local import in the source file (i.e. a candidate
+	// for cross-file rewrite). Chain-fix: python-references-cross-file.
+	ReferencesConsidered int
+	// ReferencesRewritten counts the subset of ReferencesConsidered
+	// that resolved either to a 16-char in-project entity ID (via
+	// lookupModuleEntity over the binding's (source_module,
+	// imported_name)) or to an `ext:<root>[:<name>]` placeholder (when
+	// the IMPORTS edge that introduced the local name already carried
+	// an `ext:` ResolvedToID from the Python extractor's
+	// resolveImportToIDs pass).
+	ReferencesRewritten int
 }
 
 // ResolveDottedImportTarget looks up a project-internal IMPORTS ToID of
@@ -1479,6 +1638,52 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 				}
 				rel.ToID = id
 				stats.CallsRewritten++
+			case "REFERENCES":
+				// Chain-fix: python-references-cross-file. The Python
+				// extractor's emitReferences pass (PR #650 Track A) emits
+				// REFERENCES ToIDs as same-file structural refs
+				// (`scope:<kind>:ref:<lang>:<file>:<name>`). When the
+				// referenced symbol is an imported name, the actual entity
+				// lives in another file, so the structural lookup
+				// (byLocation[callerFile][name]) misses and the edge lands
+				// orphan. Mirror the CALLS path: parse the structural ref,
+				// confirm the tail name maps to an IMPORTS binding in the
+				// caller's file, and rewrite the ToID to either the
+				// in-project entity ID or the binding's `ext:` placeholder.
+				//
+				// Conservative gating:
+				//   - skip non-structural-ref ToIDs (already resolved, or
+				//     not a candidate)
+				//   - skip Format B (`tail#member`) — only Format A bare
+				//     names participate in import-aware rewrite
+				//   - skip when the caller file declares a same-file entity
+				//     by the same name (the local definition shadows the
+				//     import; lookupStructural will bind it).
+				if !strings.HasPrefix(to, stubPrefixScope) {
+					continue
+				}
+				stubFile, stubName, ok := splitFormatAStructuralRef(to)
+				if !ok {
+					continue
+				}
+				if stubFile != callerFile {
+					// Defensive: the stub embeds the caller file, but if a
+					// future emitter ever stamps a different file in the
+					// stub we shouldn't rewrite against the wrong file's
+					// imports.
+					continue
+				}
+				if tbl.localNamesByFile[stubFile] != nil &&
+					tbl.localNamesByFile[stubFile][stubName] {
+					continue
+				}
+				stats.ReferencesConsidered++
+				id, ok := tbl.ResolveCrossFileReferenceTarget(stubFile, stubName)
+				if !ok {
+					continue
+				}
+				rel.ToID = id
+				stats.ReferencesRewritten++
 			case importRelKind:
 				// Markdown cross-file file-path shape (issue #44 follow-up):
 				// `[text](path)` emits ToID="<resolved-path>", which is a

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -1495,3 +1495,217 @@ func TestResolveRelativeImportTarget_TriesAllJSExtensions(t *testing.T) {
 		t.Error("resolveRelativeImportTarget should refuse non-relative specifiers")
 	}
 }
+
+// referencerRecord builds an EntityRecord representing a function whose
+// body REFERENCES a same-file structural ref stub. Mirrors what
+// internal/extractors/python/references.go:buildPyReferenceTargetID
+// emits.
+//
+// stubFile is the file path embedded in the stub (the caller's file
+// path); name is the bare tail. The stub shape is
+// `scope:<kind>:ref:python:<stubFile>:<name>`.
+func referencerRecord(callerName, callerFile string, stubKind, stubFile, stubName string) types.EntityRecord {
+	return types.EntityRecord{
+		ID:         "0123456789abcdef",
+		Name:       callerName,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "function",
+		SourceFile: callerFile,
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{{
+			ToID: "scope:" + stubKind + ":ref:python:" + stubFile + ":" + stubName,
+			Kind: "REFERENCES",
+		}},
+	}
+}
+
+// importerWithToID is like importerRecord but lets the test specify the
+// IMPORTS edge's ToID, mirroring what
+// internal/extractors/python/imports.go:resolveImportToIDs stamps
+// (`ext:<root>[:<name>]` for known external roots; the dotted module
+// path otherwise).
+func importerWithToID(file, modulePath, toID string, props map[string]string) types.EntityRecord {
+	rec := importerRecord(file, modulePath, props)
+	rec.Relationships[0].ToID = toID
+	return rec
+}
+
+// TestResolveImports_ReferencesCrossFileExternal covers the chain-fix
+// path for an imported name whose source module is a known external
+// package. The Python extractor's resolveImportToIDs has already
+// rewritten the IMPORTS edge's ToID to `ext:django:Model`; the
+// REFERENCES edge in the caller body is a same-file structural ref. The
+// resolver must rewrite the REFERENCES ToID to the binding's `ext:` ID.
+func TestResolveImports_ReferencesCrossFileExternal(t *testing.T) {
+	records := []types.EntityRecord{
+		importerWithToID("api/views.py", "django.db.models", "ext:django:Model", map[string]string{
+			"local_name":    "Model",
+			"source_module": "django.db.models",
+			"imported_name": "Model",
+		}),
+		referencerRecord("UserView.get", "api/views.py", "component", "api/views.py", "Model"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesConsidered != 1 {
+		t.Fatalf("expected 1 considered, got %d", stats.ReferencesConsidered)
+	}
+	if stats.ReferencesRewritten != 1 {
+		t.Fatalf("expected 1 rewritten, got %d", stats.ReferencesRewritten)
+	}
+	if got := records[1].Relationships[0].ToID; got != "ext:django:Model" {
+		t.Fatalf("expected REFERENCES rewritten to ext:django:Model, got %q", got)
+	}
+}
+
+// TestResolveImports_ReferencesCrossFileInternal covers the in-project
+// cross-file case: `from app.models import Post` in views.py, with
+// `Post` defined in app/models.py. The IMPORTS edge's ToID is the raw
+// dotted module path (no `ext:` prefix because the root is not in the
+// extractor's known-external list). The resolver must look up the
+// (source_module, imported_name) tuple in the per-module reverse index
+// and rewrite the REFERENCES ToID to the hex entity ID of Post.
+func TestResolveImports_ReferencesCrossFileInternal(t *testing.T) {
+	records := []types.EntityRecord{
+		importerWithToID("app/views.py", "app.models.Post", "app.models.Post", map[string]string{
+			"local_name":    "Post",
+			"source_module": "app.models",
+			"imported_name": "Post",
+		}),
+		targetRecord("Post", "app/models.py", "dddddddddddddddd"),
+		referencerRecord("list_posts", "app/views.py", "component", "app/views.py", "Post"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesRewritten != 1 {
+		t.Fatalf("expected 1 rewritten, got %d (considered=%d)", stats.ReferencesRewritten, stats.ReferencesConsidered)
+	}
+	if got := records[2].Relationships[0].ToID; got != "dddddddddddddddd" {
+		t.Fatalf("expected REFERENCES rewritten to dddddddddddddddd, got %q", got)
+	}
+}
+
+// TestResolveImports_ReferencesFileLocalUntouched asserts that a
+// structural-ref REFERENCES edge whose tail name corresponds to a
+// same-file entity is left alone — the local definition shadows any
+// potential import, and the same-file structural-ref pass will bind it
+// via byLocation downstream. Rewriting here would skip that path.
+func TestResolveImports_ReferencesFileLocalUntouched(t *testing.T) {
+	original := "scope:component:ref:python:app/views.py:helper"
+	records := []types.EntityRecord{
+		// Same file ALSO imports a name `helper` from elsewhere — the
+		// local definition still shadows the import in Python semantics.
+		importerWithToID("app/views.py", "app.utils.helper", "app.utils.helper", map[string]string{
+			"local_name":    "helper",
+			"source_module": "app.utils",
+			"imported_name": "helper",
+		}),
+		// File-local definition of `helper` in the same file.
+		targetRecord("helper", "app/views.py", "eeeeeeeeeeeeeeee"),
+		referencerRecord("entry", "app/views.py", "component", "app/views.py", "helper"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesConsidered != 0 {
+		t.Fatalf("expected 0 considered (shadowed by local), got %d", stats.ReferencesConsidered)
+	}
+	if got := records[2].Relationships[0].ToID; got != original {
+		t.Fatalf("expected REFERENCES ToID untouched, got %q", got)
+	}
+}
+
+// TestResolveImports_ReferencesUnresolvedNameUntouched asserts that a
+// REFERENCES edge whose tail name does NOT correspond to any IMPORTS
+// binding in the source file is left alone — we must never fabricate a
+// binding. The same-file structural-ref pass will mark this edge as
+// unmatched (orphan) downstream; that's the correct disposition.
+func TestResolveImports_ReferencesUnresolvedNameUntouched(t *testing.T) {
+	original := "scope:component:ref:python:api/views.py:Unknown"
+	records := []types.EntityRecord{
+		// Caller's file has an import, but for a DIFFERENT name.
+		importerWithToID("api/views.py", "django.db.models", "ext:django:Model", map[string]string{
+			"local_name":    "Model",
+			"source_module": "django.db.models",
+			"imported_name": "Model",
+		}),
+		referencerRecord("entry", "api/views.py", "component", "api/views.py", "Unknown"),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesRewritten != 0 {
+		t.Fatalf("expected 0 rewritten (no import for `Unknown`), got %d", stats.ReferencesRewritten)
+	}
+	if got := records[1].Relationships[0].ToID; got != original {
+		t.Fatalf("expected REFERENCES ToID untouched, got %q", got)
+	}
+}
+
+// TestResolveImports_ReferencesFormatBSkipped asserts that a Format B
+// structural-ref REFERENCES edge (`...:<file>:<scope>#<member>`) is
+// skipped — only Format A bare names participate in import-aware
+// rewrite. Format B edges encode a member access that the local
+// byMember path handles.
+func TestResolveImports_ReferencesFormatBSkipped(t *testing.T) {
+	original := "scope:component:ref:python:api/views.py:UserView#Model"
+	records := []types.EntityRecord{
+		importerWithToID("api/views.py", "django.db.models", "ext:django:Model", map[string]string{
+			"local_name":    "Model",
+			"source_module": "django.db.models",
+			"imported_name": "Model",
+		}),
+		{
+			ID:         "0123456789abcdef",
+			Name:       "entry",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "function",
+			SourceFile: "api/views.py",
+			Language:   "python",
+			Relationships: []types.RelationshipRecord{{
+				ToID: original,
+				Kind: "REFERENCES",
+			}},
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesConsidered != 0 {
+		t.Fatalf("expected 0 considered (Format B skipped), got %d", stats.ReferencesConsidered)
+	}
+	if got := records[1].Relationships[0].ToID; got != original {
+		t.Fatalf("expected Format B REFERENCES ToID untouched, got %q", got)
+	}
+}
+
+// TestResolveImports_ReferencesHexToIDUntouched asserts that a
+// REFERENCES edge already pointing at a hex entity ID (e.g. resolved by
+// an earlier pass or emitted directly by a cross-extractor) is left
+// alone.
+func TestResolveImports_ReferencesHexToIDUntouched(t *testing.T) {
+	records := []types.EntityRecord{
+		importerWithToID("api/views.py", "django.db.models", "ext:django:Model", map[string]string{
+			"local_name":    "Model",
+			"source_module": "django.db.models",
+			"imported_name": "Model",
+		}),
+		{
+			ID:         "0123456789abcdef",
+			Name:       "entry",
+			Kind:       "SCOPE.Operation",
+			Subtype:    "function",
+			SourceFile: "api/views.py",
+			Language:   "python",
+			Relationships: []types.RelationshipRecord{{
+				ToID: "ffffffffffffffff",
+				Kind: "REFERENCES",
+			}},
+		},
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.ReferencesConsidered != 0 {
+		t.Fatalf("expected 0 considered (hex skipped at outer guard), got %d", stats.ReferencesConsidered)
+	}
+	if got := records[1].Relationships[0].ToID; got != "ffffffffffffffff" {
+		t.Fatalf("expected hex REFERENCES ToID untouched, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Extends `ResolveImports` to rewrite REFERENCES edges symmetric to the CALLS path. When a same-file structural-ref REFERENCES stub (`scope:<kind>:ref:<lang>:<file>:<name>`) has a tail name that was introduced into the source file by an IMPORTS binding, rewrite the ToID to either the in-project entity ID (via `lookupModuleEntity` over the binding's `source_module + imported_name`) or the binding's `ext:` placeholder (pre-stamped by the Python extractor's `resolveImportToIDs`).

This is chain-fix-1 from PR #650's residual ledger. Chain-fix-2 (class-field cross-file via EXTENDS) is filed separately.

## What changed

- `internal/resolve/imports.go`:
  - `ImportBinding` gains `ResolvedToID` (carries the IMPORTS edge's ToID at build time, so we can reuse the extractor's `ext:` tagging without duplicating the known-external-roots allowlist in the resolver layer).
  - `ImportTable` gains `localNamesByFile` (same-file name index used to short-circuit when a local definition shadows an import).
  - New helper `splitFormatAStructuralRef` (parses 6-segment Format A stubs).
  - New method `ImportTable.ResolveCrossFileReferenceTarget` (mirror of `ResolveBareCallTarget`: explicit binding → plain-module attribute → wildcard, with `ext:` preferred when stamped).
  - `ResolveImports` gains a `case "REFERENCES":` branch, with conservative gating (skip non-structural, Format B, hex-already-resolved, local-shadowed, no-import-binding cases — no fabrication).
  - `ImportResolveStats` gains `ReferencesConsidered` / `ReferencesRewritten`.
- `cmd/archigraph/index.go`: surface the new counters in the stderr resolver log.
- `internal/resolve/imports_test.go`: 6 new tests covering ext rewrite, internal cross-file rewrite, local shadowing, unresolved name pass-through, Format B skip, hex pass-through.

## Quality fixtures (gate)

All 5 mini fixtures: 100% entity recall, 100% relationship recall, 0 forbidden hits.

| Fixture | Entity recall | Relationship recall | Forbidden |
|---|---:|---:|---:|
| python-django-mini | 28/28 (100.0%) | 12/12 (100.0%) | 0 |
| typescript-react-mini | 20/20 (100.0%) | 16/16 (100.0%) | 0 |
| java-spring-mini | 25/25 (100.0%) | 18/18 (100.0%) | 0 |
| go-chi-mini | 20/20 (100.0%) | 19/19 (100.0%) | 0 |
| rust-tokio-mini | 16/16 (100.0%) | 13/13 (100.0%) | 0 |

## Non-Python bug-rate parity

Resolver dispositions byte-identical to a baseline binary built from `feat/python-orphan-recovery` (the PR #650 head this change branches from):

| Corpus | Lang | rewrote / ambiguous / unmatched |
|---|---|---|
| chi | Go | 4415 / 590 / 3177 — identical |
| spdlog | C++ | 1712 / 885 / 1776 — identical |
| kafka-streams-examples | Java | 4402 / 51 / 10626 — identical |

## Python orphan-rate measurements

Honest reporting: chain-fix-1 rewrites happen but the measurable orphan-rate movement on the gap corpora is below the spec's `-10 to -20pp` hope. The mechanism is correct (bare-name imports referenced cross-file now resolve), but the residual after PR #650 is dominated by class-field cross-file references through `self.<attr>` on subclasses, which is chain-fix-2 territory.

| Corpus | Before #650 | After #650 (baseline) | After chain-fix-1 | #650 target | Met? |
|---|---:|---:|---:|---:|:---:|
| pandas | 46.0% | 25.8% | 25.9% | ≤15% | no |
| django-realworld | 44.2% | 41.9% | 41.9% | ≤8% | no |
| flask-realworld | 29.0% | 24.9% | 25.0% | ≤10% | no |
| client-fixture-a | 48.4% | 37.0% | 37.0% | ≤10% | no |
| click | 12.7% | 7.4% | 7.4% | ≤10% | already met, no regression |
| requests | 2.6% | 1.7% | 1.7% | already at-target | already met, no regression |

Per-corpus chain-fix-1 rewrite counts (from `resolver: import-aware rewrote=X/Y cross-file REFERENCES targets`):

| Corpus | rewrote / considered |
|---|---|
| pandas | 23 / 7803 |
| django-realworld | low (single-digit) |
| flask-realworld | 0 / ~2k |
| click | small |
| requests | 1 / 368 |
| client-fixture-a | 0 / 2194 |
| kafka-streams-examples | 0 / 4 |

The 0% rewrite rate on client-fixture-a and flask-realworld confirms the diagnosis: those corpora have many same-file structural REFERENCES stubs that the extractor emitted, but the tail names are NOT bare imports — they are class-field accesses (`self.<attr>` on a subclass whose parent defines the field in another file). Those go through chain-fix-2, not chain-fix-1.

## Targets still requiring chain-fix-2

All four gap corpora (pandas, django-realworld, flask-realworld, client-fixture-a) remain above their #650 targets and will need the class-field-cross-file fix to land.

## Test plan

- [x] `go build ./...` clean.
- [x] `go test ./internal/resolve/` passes (including 6 new tests).
- [x] `go test ./...` passes.
- [x] Quality fixtures 100% recall on all 5 mini fixtures.
- [x] Non-Python resolver dispositions byte-identical to PR #650 baseline (chi, spdlog, kafka-streams-examples).
- [x] Daemon cleanup confirmed (isolated `ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-py-cross-ref`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)