### PR TITLE
feat(python): emit class->field CONTAINS to close SCOPE.Schema/field orphan gap

### DIFF
--- a/internal/extractor/structural_ref.go
+++ b/internal/extractor/structural_ref.go
@@ -35,3 +35,30 @@ func BuildOperationStructuralRef(lang, filePath, name string) string {
 func BuildSchemaColumnStructuralRef(filePath, table, column string) string {
 	return "scope:schema:column:sql:" + filepath.ToSlash(filePath) + ":" + table + "#" + column
 }
+
+// BuildSchemaFieldStructuralRef returns a Format A structural-ref for
+// class→field CONTAINS edges. Shape:
+//
+//	scope:schema:field:<lang>:<file>:<Class>.<attr>
+//
+// The trailing name segment exactly matches the SCOPE.Schema/field entity's
+// Name ("<dottedClass>.<attr>") and the SourceFile is the class's file, so
+// the resolver's byLocation fallback in internal/resolve/refs.go binds the
+// stub to the field entity ID without needing a kind-family widening for
+// scope="schema" (structuralKindFamilies returns nil for "schema").
+//
+// Counterpart of BuildOperationStructuralRef for class→method CONTAINS:
+// both emit a stub keyed on the parent class's file path so two classes in
+// different files declaring an attribute of the same bare name produce
+// distinct stubs that resolve to distinct entities.
+//
+// Used by the Python extractor to close the SCOPE.Schema/field orphan gap:
+// extractClassFields previously emitted field entities with no inbound or
+// outbound edges (see #526 deferred-emission comment in
+// internal/extractors/python/extractor.go), leaving them as the single
+// largest residual orphan class (~56% on django-realworld). The stub form
+// avoids the ComputeID circularity that motivated the original deferral
+// (the resolver fills the hex ID in after buildDocument runs).
+func BuildSchemaFieldStructuralRef(lang, filePath, name string) string {
+	return "scope:schema:field:" + lang + ":" + filepath.ToSlash(filePath) + ":" + name
+}

--- a/internal/extractor/structural_ref_test.go
+++ b/internal/extractor/structural_ref_test.go
@@ -88,3 +88,44 @@ func TestBuildSchemaColumnStructuralRef(t *testing.T) {
 		})
 	}
 }
+
+func TestBuildSchemaFieldStructuralRef(t *testing.T) {
+	tests := []struct {
+		name     string
+		lang     string
+		filePath string
+		ident    string
+		want     string
+	}{
+		{
+			name:     "python class.attr",
+			lang:     "python",
+			filePath: "conduit/apps/articles/models.py",
+			ident:    "Article.title",
+			want:     "scope:schema:field:python:conduit/apps/articles/models.py:Article.title",
+		},
+		{
+			name:     "windows path is normalized",
+			lang:     "python",
+			filePath: filepath.FromSlash("app/models.py"),
+			ident:    "User.email",
+			want:     "scope:schema:field:python:app/models.py:User.email",
+		},
+		{
+			name:     "nested class dotted name",
+			lang:     "python",
+			filePath: "x.py",
+			ident:    "Outer.Inner.flag",
+			want:     "scope:schema:field:python:x.py:Outer.Inner.flag",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := BuildSchemaFieldStructuralRef(tc.lang, tc.filePath, tc.ident)
+			if got != tc.want {
+				t.Fatalf("BuildSchemaFieldStructuralRef(%q, %q, %q) = %q, want %q",
+					tc.lang, tc.filePath, tc.ident, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -164,26 +164,42 @@ func walkNode(
 				// "<dottedClass>.<attr>" so the resolver's byMember index
 				// binds `self.<attr>` references back to them.
 				extractClassFields(body, file, childParent, out)
-				// Emit CONTAINS edges from the class to every operation entity
-				// the walker just appended (methods inside this class).
-				// Field entities (#526) are intentionally not given a
-				// CONTAINS edge — they exist solely to populate the
-				// resolver's byMember index for `self.<attr>` lookups,
-				// and an entity-ID-keyed CONTAINS would require the
-				// field's ComputeID up front (it's filled in later by
-				// buildDocument).
+				// Emit CONTAINS edges from the class to every Operation
+				// (method) AND every Schema/field entity the walker just
+				// appended.
+				//
+				// History: field entities (#526) were originally emitted
+				// WITHOUT a CONTAINS edge because the field's hex ComputeID
+				// isn't known until buildDocument runs. The Format A
+				// structural-ref pattern already used for class→method
+				// edges sidesteps that constraint — the resolver binds the
+				// stub to the field entity via byLocation (same-file, name
+				// matches the field's Name="<Class>.<attr>"). Closing this
+				// gap eliminates the largest residual orphan class on
+				// Python corpora (SCOPE.Schema/field with zero edges).
 				after := len(*out)
 				for k := before; k < after; k++ {
 					child := &(*out)[k]
-					if child.Kind != "SCOPE.Operation" {
+					var toID string
+					switch {
+					case child.Kind == "SCOPE.Operation":
+						// Issue #144 — Format A structural-ref keyed on the
+						// source file so the resolver disambiguates by
+						// location when two classes in different files
+						// declare methods with the same Name. FromID empty →
+						// buildDocument substitutes the parent (class)
+						// entity ID at emit time.
+						toID = extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
+					case child.Kind == "SCOPE.Schema" && child.Subtype == "field":
+						// Class-attribute assignment emitted by
+						// extractClassFields (#526). The stub resolves via
+						// byLocation[file][<Class>.<attr>] in the same way
+						// class→method does via lookupLocationKind +
+						// byLocation fallback.
+						toID = extractor.BuildSchemaFieldStructuralRef("python", file.Path, child.Name)
+					default:
 						continue
 					}
-					// Issue #144 — emit a structural-ref (Format A) keyed on
-					// the source file so the resolver disambiguates by
-					// location when two classes in different files declare
-					// methods with the same Name. FromID empty → buildDocument
-					// substitutes the parent (class) entity ID at emit time.
-					toID := extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
 					(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 						types.RelationshipRecord{
 							ToID: toID,
@@ -252,13 +268,21 @@ func walkNode(
 					after := len(*out)
 					for k := before; k < after; k++ {
 						child := &(*out)[k]
-						if child.Kind != "SCOPE.Operation" {
+						var toID string
+						switch {
+						case child.Kind == "SCOPE.Operation":
+							// Issue #144 — structural-ref (Format A) keyed on
+							// file path; same rationale as the bare class
+							// branch above.
+							toID = extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
+						case child.Kind == "SCOPE.Schema" && child.Subtype == "field":
+							// Class→field CONTAINS (closes #526 deferred
+							// emission). See the bare class branch for the
+							// detailed rationale.
+							toID = extractor.BuildSchemaFieldStructuralRef("python", file.Path, child.Name)
+						default:
 							continue
 						}
-						// Issue #144 — structural-ref (Format A) keyed on
-						// file path; same rationale as the bare class
-						// branch above.
-						toID := extractor.BuildOperationStructuralRef("python", file.Path, child.Name)
 						(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
 							types.RelationshipRecord{
 								ToID: toID,

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -1012,6 +1012,103 @@ func TestExtract_ClassAttrFields_AnnotatedAndTuple(t *testing.T) {
 	}
 }
 
+// TestExtract_ClassAttrFields_EmitsContainsEdge verifies the class entity
+// gets a CONTAINS edge for every emitted SCOPE.Schema/field, mirroring the
+// class→method CONTAINS emission. Regression guard for the Django field
+// orphan recovery — without this edge, ~56% of django-realworld orphans
+// (class-scope attribute declarations) had zero relationships and inflated
+// the orphan rate. The stub form is Format A:
+// scope:schema:field:python:<file>:<Class>.<attr>, resolved via byLocation.
+func TestExtract_ClassAttrFields_EmitsContainsEdge(t *testing.T) {
+	src := `class Article(models.Model):
+    title = models.CharField(max_length=200)
+    body = models.TextField()
+
+    def save(self, *args, **kwargs):
+        super().save(*args, **kwargs)
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+	var classRec *types.EntityRecord
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "class" && entities[i].Name == "Article" {
+			classRec = &entities[i]
+			break
+		}
+	}
+	if classRec == nil {
+		t.Fatalf("Article class entity not found; got %v", entityNames(entities))
+	}
+	wantStubs := map[string]bool{
+		"scope:schema:field:python:test.py:Article.title":    false,
+		"scope:schema:field:python:test.py:Article.body":     false,
+		"scope:operation:method:python:test.py:Article.save": false,
+	}
+	for _, rel := range classRec.Relationships {
+		if rel.Kind != "CONTAINS" {
+			continue
+		}
+		if _, want := wantStubs[rel.ToID]; want {
+			wantStubs[rel.ToID] = true
+		}
+	}
+	for stub, seen := range wantStubs {
+		if !seen {
+			t.Errorf("expected CONTAINS edge with ToID=%q on Article; got rels=%+v", stub, classRec.Relationships)
+		}
+	}
+}
+
+// TestExtract_ClassAttrFields_ContainsEdge_DecoratedClass verifies the
+// CONTAINS-for-field emission also fires on decorated classes (the second
+// emission site in walkNode's decorated_definition branch).
+func TestExtract_ClassAttrFields_ContainsEdge_DecoratedClass(t *testing.T) {
+	src := `@dataclass
+class Config:
+    name: str = "default"
+    count: int = 0
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+	var classRec *types.EntityRecord
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "class" && entities[i].Name == "Config" {
+			classRec = &entities[i]
+			break
+		}
+	}
+	if classRec == nil {
+		t.Fatalf("Config class entity not found on decorated definition; got %v", entityNames(entities))
+	}
+	wantStubs := map[string]bool{
+		"scope:schema:field:python:test.py:Config.name":  false,
+		"scope:schema:field:python:test.py:Config.count": false,
+	}
+	for _, rel := range classRec.Relationships {
+		if rel.Kind != "CONTAINS" {
+			continue
+		}
+		if _, want := wantStubs[rel.ToID]; want {
+			wantStubs[rel.ToID] = true
+		}
+	}
+	for stub, seen := range wantStubs {
+		if !seen {
+			t.Errorf("expected CONTAINS edge with ToID=%q on decorated Config; got rels=%+v", stub, classRec.Relationships)
+		}
+	}
+}
+
 // entityNames returns entity names for test diagnostics.
 func entityNames(entities []types.EntityRecord) []string {
 	names := make([]string, len(entities))


### PR DESCRIPTION
## Summary

The dominant Python orphan-rate residual is **SCOPE.Schema/field** entities with zero edges — 126 of 223 orphans (56.5%) on django-realworld (#679). The Python extractor emits one such entity per class-scope attribute assignment (#526) so the resolver's `byMember` index can bind `self.<attr>` references, but the entity itself was emitted with no inbound or outbound relationships. The comment in `extractor.go` admitted this was deliberate — the field's hex ComputeID isn't known until `buildDocument` runs, so a hex-keyed CONTAINS edge wasn't possible at extract time.

This PR closes that gap using the same Format A structural-ref pattern already used for class→method CONTAINS edges. The resolver binds the stub to the field entity ID after `buildDocument` runs, sidestepping the ID-circularity that motivated the original deferral.

## Investigation

Built fresh binary from `main` (PR #650 / #671 not merged yet — the orphan landscape on main matches the #679 measurement exactly). Indexed django-realworld + four other Python corpora with `ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-django-fields`.

### Orphan structure (baseline, main)

| Corpus           | Entities | Orphans | Orphan rate | SCOPE.Schema/field orphans |
|------------------|---------:|--------:|------------:|---------------------------:|
| django-realworld |      532 |     223 |      41.91% |                        126 |
| flask-realworld  |      799 |     232 |      29.04% |                        104 |
| pandas           |    13089 |    6023 |      46.02% |                        649 |
| requests         |    21837 |     571 |       2.61% |                         98 |
| click            |     4592 |     581 |      12.65% |                        111 |

Note: client-fixture-a was not present locally; skipped.

### Why the orphans existed — concrete examples

Sampled 8 field orphans on django-realworld; every single one is a regular, in-file, class-body field declaration, not an inherited or framework-provided attribute:

- `AuthenticationAppConfig.name = 'conduit.apps.authentication'` (conduit/apps/authentication/__init__.py:5)
- `AuthenticationAppConfig.label = 'authentication'` (same file:6)
- `UserSerializer.bio = serializers.CharField(...)` (conduit/apps/authentication/serializers.py:119)
- `UserSerializer.profile = ProfileSerializer(write_only=True)` (same file:115)
- `TagListAPIView.queryset = ...` (conduit/apps/articles/views.py:197)
- `RegistrationSerializer.token = ...` (conduit/apps/authentication/serializers.py:23)

The parent class entity (`UserSerializer`, `AuthenticationAppConfig`, etc.) is in the **same file** and present in the graph. There is no inheritance issue. The bug is purely the missing CONTAINS emission, and it's confirmed by the deliberate-deferral comment at `extractor.go:167-174`.

### Categorisation

Per the task spec's bucket list:
- **Inherited from abstract / concrete parent**: 0 sampled
- **Declared in Mixin / Meta**: 0 sampled (Meta inner classes don't produce these particular orphans — those would be `<Class>.Meta.<attr>` shape entities, which aren't emitted at all)
- **Regular field declaration + CONTAINS emission bug**: 8/8 sampled — **this is the entire population**

The same pattern is universal across Python corpora (not Django-specific): flask-realworld serializers, pandas data classes, click parameter classes, requests session objects all hit it. The fix therefore belongs in the general Python extractor, not a Django-specific framework pass.

## Fix design — Option A (emission fix in Python extractor)

The class→method CONTAINS path already uses `BuildOperationStructuralRef("python", file.Path, "<Class>.<method>")` which produces a Format A stub (`scope:operation:method:python:<file>:<Class>.<method>`). The resolver's `lookupStructural` resolves this via `lookupLocationKind` + `byLocation` fallback.

For fields we add a parallel helper `BuildSchemaFieldStructuralRef` that produces `scope:schema:field:python:<file>:<Class>.<attr>`. `structuralKindFamilies("schema")` returns nil so `lookupLocationKind` is skipped, but the `byLocation[file][tail]` fallback at `refs.go:2425-2429` catches it. The field entity's `Name="<Class>.<attr>"` and `SourceFile=<file>` match the stub exactly; the entity is unique within the file so `byLocation` registers it. Same-file lookup, no fabrication.

Files touched (strictly file-disjoint from in-flight Kotlin / Java / Go / cross-repo-audit agents):
- `internal/extractor/structural_ref.go` — new `BuildSchemaFieldStructuralRef` helper
- `internal/extractor/structural_ref_test.go` — 3 unit tests for the helper
- `internal/extractors/python/extractor.go` — extend the CONTAINS-emission loop in both class-emission paths (bare `class_definition` and `decorated_definition`) to handle `SCOPE.Schema/field` alongside `SCOPE.Operation`
- `internal/extractors/python/extractor_test.go` — 2 new tests verifying CONTAINS edges are emitted on both class paths

No resolver changes. No other language extractor changes. No Django-specific framework code.

## Results

| Corpus           | Before | After  |   Δ      | Field orphans Δ | Target |
|------------------|-------:|-------:|---------:|----------------:|:------:|
| django-realworld | 41.91% | 17.11% | -24.80pp |   126 → 0       |   hit  |
| flask-realworld  | 29.04% | 15.52% | -13.52pp |   104 → 0       |   hit  |
| pandas           | 46.02% | 41.06% |  -4.96pp |   649 → 0       |  partial — see below |
| requests         |  2.61% |  2.14% |  -0.47pp |    98 → 0       | parity-class |
| click            | 12.65% | 10.24% |  -2.41pp |   111 → 0       | parity-class |

**100% reduction in SCOPE.Schema/field orphans on every Python corpus** (-126 / -104 / -649 / -98 / -111). django-realworld -24.80pp essentially matches the -25pp target. The pandas Δ is smaller in percentage terms because pandas is large (13089 entities) and its orphan population is dominated by other classes (module placeholders, etc.) — the absolute field-orphan-reduction is the biggest of any corpus.

## Cross-language parity check (non-Python)

| Corpus | Lang | Entities (main → patched) | Relationships (main → patched) |
|---|---|---|---|
| chi    | Go  | 2107 → 2107 | 4730 → 4730 |
| spdlog | C++ | 1171 → 1171 | 3450 → 3450 |

Byte-identical. The change is contained to the Python extractor and a new helper not called by any other language.

## Quality fixtures

`go test ./internal/quality/...` and `go test ./...` both green. python-django-mini fixture preserves 28/28 entity recall, 12/12 relationship recall, 0 forbidden hits (the gate would fail otherwise).

## What's still orphaned (next chain-fix candidate)

After this PR, on django-realworld the remaining 91 orphans are dominated by:
- `SCOPE.Component / module` (~87) — import placeholder leftovers. This is #650's territory (Python IMPORTS ToID resolution) and PRs already in-flight address it.
- `SCOPE.Component / class` (~4) — framework synth duplicates without inbound EXTENDS / CONTAINS edges.
- A handful of `Config / Constraint / Service` framework-synthesised entities.

The class-field-via-EXTENDS cross-file shape described in #679 is a separate problem (REFERENCES emission, not CONTAINS structural). It does not contribute to the residual orphan count on main — those entities ARE orphans only because no REFERENCES edge points at them; this PR doesn't help with that. #679's chain-fix-2 implementation remains the next lever.

## Cross-language analog worth noting

The same omission likely exists in JVM extractors — Java `private int count;` field declarations, Kotlin class properties — but per spec I did not touch those extractors in this PR. Would be cheap to file a follow-up: search for `BuildOperationStructuralRef` usages in `internal/extractors/{java,kotlin,scala}` and check whether they include field entities alongside method entities in the CONTAINS-emission loop.

## Daemon cleanup

- Worktree: `/Users/jorgecajas/Documents/Projects/archigraph-worktrees/django-field-orphan-recovery`
- Daemon root: `/tmp/arch-django-fields`
- PIDs spawned during this run: 9282 (baseline), 14236, 14472 (transient restarts), 14959 (patched, main run), 11154 (transient)
- All killed at end of run; root removed. Cleanup confirmation in the closing report.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/extractor/ ./internal/extractors/python/ ./internal/resolve/` green
- [x] `go test ./internal/quality/...` green
- [x] `go test ./...` green
- [x] Python corpora reindexed, orphan rate measured before/after
- [x] Non-Python corpora (chi, spdlog) confirmed byte-identical