### PR TITLE
[#673][patterns][α] Pattern entity kind + per-group storage (ADR-0018 foundation)

### DIFF
--- a/internal/agentpatterns/confidence.go
+++ b/internal/agentpatterns/confidence.go
@@ -1,0 +1,133 @@
+package agentpatterns
+
+import (
+	"context"
+	"math"
+	"time"
+)
+
+// Confidence bounds and starting values per ADR-0018.
+const (
+	InitialConfidence  = 0.4
+	ConfidenceFloor    = 0.2
+	ConfidenceCeiling  = 1.0
+	DecayDeltaPer30Day = 0.05 // −0.05 per 30 days since last_applied
+)
+
+// ConfidenceEvent enumerates the lifecycle events that affect pattern confidence.
+type ConfidenceEvent int
+
+const (
+	// EventApplySuccess is emitted when a pattern was applied and the result
+	// was confirmed correct. Confidence += 0.10.
+	EventApplySuccess ConfidenceEvent = iota
+	// EventApplyFailure is emitted when a pattern was applied and the result
+	// was wrong. Confidence −= 0.15.
+	EventApplyFailure
+	// EventReject is emitted when a user explicitly rejects a pattern as
+	// stale or incorrect. Confidence −= 0.30.
+	EventReject
+	// EventRefine is emitted when a pattern's text is updated without a
+	// success/failure signal. Confidence delta == 0.
+	EventRefine
+)
+
+// NewPatternConfidence returns the initial confidence for a newly created
+// pattern: 0.4 (per ADR-0018, Table "Confidence model").
+func NewPatternConfidence() float64 {
+	return InitialConfidence
+}
+
+// ApplyConfidenceDelta applies the event-driven delta to current and returns
+// the updated value, clamped to [ConfidenceFloor, ConfidenceCeiling].
+//
+// Deltas per ADR-0018:
+//
+//	EventApplySuccess  → +0.10
+//	EventApplyFailure  → −0.15
+//	EventReject        → −0.30
+//	EventRefine        → 0 (neutral)
+func ApplyConfidenceDelta(current float64, event ConfidenceEvent) float64 {
+	var delta float64
+	switch event {
+	case EventApplySuccess:
+		delta = +0.10
+	case EventApplyFailure:
+		delta = -0.15
+	case EventReject:
+		delta = -0.30
+	case EventRefine:
+		delta = 0
+	}
+	return clampConfidence(current + delta)
+}
+
+// ApplyTimeDecay applies the time-decay rule: −0.05 per 30 days since the
+// pattern was last applied (floor: ConfidenceFloor).
+//
+// daysSinceLastApplied must be ≥ 0. If the pattern has never been applied
+// (lastAppliedUnix == 0) the caller may pass 0 to skip decay.
+func ApplyTimeDecay(current float64, daysSinceLastApplied float64) float64 {
+	if daysSinceLastApplied <= 0 {
+		return current
+	}
+	periods := daysSinceLastApplied / 30.0
+	decay := DecayDeltaPer30Day * periods
+	return clampConfidence(current - decay)
+}
+
+// ApplyTimeDecayFromUnix is a convenience wrapper around ApplyTimeDecay that
+// computes the elapsed days between lastAppliedUnix and nowUnix.
+// If lastAppliedUnix is 0 (never applied), no decay is applied.
+func ApplyTimeDecayFromUnix(current float64, lastAppliedUnix, nowUnix int64) float64 {
+	if lastAppliedUnix == 0 {
+		return current
+	}
+	elapsed := nowUnix - lastAppliedUnix
+	if elapsed <= 0 {
+		return current
+	}
+	days := float64(elapsed) / 86400.0
+	return ApplyTimeDecay(current, days)
+}
+
+func clampConfidence(v float64) float64 {
+	return math.Max(ConfidenceFloor, math.Min(ConfidenceCeiling, v))
+}
+
+// ---------------------------------------------------------------------------
+// Background decay scheduler skeleton
+// ---------------------------------------------------------------------------
+// The full integration with the daemon loop is PR β's territory. This skeleton
+// provides the timer and decay-job hook so the wiring can be dropped in.
+
+// DecayJob is a function that the scheduler calls on each tick. It receives
+// the current time so implementations can compute elapsed days per pattern.
+type DecayJob func(nowUnix int64)
+
+// DecayScheduler drives periodic confidence decay passes.
+type DecayScheduler struct {
+	interval time.Duration
+	job      DecayJob
+}
+
+// NewDecayScheduler creates a DecayScheduler that calls job every interval.
+// Typical interval: 24 hours. The scheduler does not start until Run is called.
+func NewDecayScheduler(interval time.Duration, job DecayJob) *DecayScheduler {
+	return &DecayScheduler{interval: interval, job: job}
+}
+
+// Run starts the scheduler loop. It blocks until ctx is cancelled, then
+// returns. The first tick fires after interval (no immediate run).
+func (s *DecayScheduler) Run(ctx context.Context) {
+	ticker := time.NewTicker(s.interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case t := <-ticker.C:
+			s.job(t.Unix())
+		}
+	}
+}

--- a/internal/agentpatterns/confidence_test.go
+++ b/internal/agentpatterns/confidence_test.go
@@ -1,0 +1,201 @@
+package agentpatterns_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/agentpatterns"
+)
+
+// ---------------------------------------------------------------------------
+// NewPatternConfidence
+// ---------------------------------------------------------------------------
+
+func TestNewPatternConfidence(t *testing.T) {
+	c := agentpatterns.NewPatternConfidence()
+	if c != 0.4 {
+		t.Errorf("initial confidence = %v, want 0.4", c)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ApplyConfidenceDelta — each event type
+// ---------------------------------------------------------------------------
+
+func TestApplyConfidenceDelta_ApplySuccess(t *testing.T) {
+	got := agentpatterns.ApplyConfidenceDelta(0.5, agentpatterns.EventApplySuccess)
+	want := 0.6
+	if abs(got-want) > 1e-9 {
+		t.Errorf("ApplySuccess: got %v want %v", got, want)
+	}
+}
+
+func TestApplyConfidenceDelta_ApplyFailure(t *testing.T) {
+	got := agentpatterns.ApplyConfidenceDelta(0.5, agentpatterns.EventApplyFailure)
+	want := 0.35
+	if abs(got-want) > 1e-9 {
+		t.Errorf("ApplyFailure: got %v want %v", got, want)
+	}
+}
+
+func TestApplyConfidenceDelta_Reject(t *testing.T) {
+	got := agentpatterns.ApplyConfidenceDelta(0.5, agentpatterns.EventReject)
+	want := 0.2
+	if abs(got-want) > 1e-9 {
+		t.Errorf("Reject: got %v want %v", got, want)
+	}
+}
+
+func TestApplyConfidenceDelta_Refine(t *testing.T) {
+	got := agentpatterns.ApplyConfidenceDelta(0.5, agentpatterns.EventRefine)
+	if abs(got-0.5) > 1e-9 {
+		t.Errorf("Refine should be neutral: got %v want 0.5", got)
+	}
+}
+
+func TestApplyConfidenceDelta_CeilingClamped(t *testing.T) {
+	got := agentpatterns.ApplyConfidenceDelta(0.95, agentpatterns.EventApplySuccess)
+	if got > agentpatterns.ConfidenceCeiling {
+		t.Errorf("ceiling not enforced: got %v", got)
+	}
+	if got != agentpatterns.ConfidenceCeiling {
+		t.Errorf("expected %v, got %v", agentpatterns.ConfidenceCeiling, got)
+	}
+}
+
+func TestApplyConfidenceDelta_FloorClamped_Reject(t *testing.T) {
+	// Start at 0.4 and reject — floor must be 0.2.
+	got := agentpatterns.ApplyConfidenceDelta(0.4, agentpatterns.EventReject)
+	if got < agentpatterns.ConfidenceFloor {
+		t.Errorf("floor not enforced: got %v", got)
+	}
+	if got != agentpatterns.ConfidenceFloor {
+		t.Errorf("expected floor %v, got %v", agentpatterns.ConfidenceFloor, got)
+	}
+}
+
+func TestApplyConfidenceDelta_FloorClamped_MultipleFailures(t *testing.T) {
+	c := agentpatterns.InitialConfidence
+	for i := 0; i < 20; i++ {
+		c = agentpatterns.ApplyConfidenceDelta(c, agentpatterns.EventApplyFailure)
+	}
+	if c < agentpatterns.ConfidenceFloor {
+		t.Errorf("floor breached: got %v", c)
+	}
+	if c != agentpatterns.ConfidenceFloor {
+		t.Errorf("expected floor %v after repeated failures, got %v", agentpatterns.ConfidenceFloor, c)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Time decay
+// ---------------------------------------------------------------------------
+
+func TestApplyTimeDecay_ZeroDays(t *testing.T) {
+	got := agentpatterns.ApplyTimeDecay(0.8, 0)
+	if got != 0.8 {
+		t.Errorf("0 days decay should not change confidence: got %v", got)
+	}
+}
+
+func TestApplyTimeDecay_30Days(t *testing.T) {
+	got := agentpatterns.ApplyTimeDecay(0.8, 30)
+	want := 0.75
+	if abs(got-want) > 1e-9 {
+		t.Errorf("30-day decay: got %v want %v", got, want)
+	}
+}
+
+func TestApplyTimeDecay_60Days(t *testing.T) {
+	got := agentpatterns.ApplyTimeDecay(0.8, 60)
+	want := 0.7
+	if abs(got-want) > 1e-9 {
+		t.Errorf("60-day decay: got %v want %v", got, want)
+	}
+}
+
+func TestApplyTimeDecay_FloorAt02(t *testing.T) {
+	// Simulate 3 years of decay from floor+small nudge above — must clamp at 0.2.
+	got := agentpatterns.ApplyTimeDecay(0.4, 1095) // 3 years = 36.5 periods × 0.05 = 1.825 delta
+	if got < agentpatterns.ConfidenceFloor {
+		t.Errorf("time decay floor breached: got %v, want >= %v", got, agentpatterns.ConfidenceFloor)
+	}
+	if got != agentpatterns.ConfidenceFloor {
+		t.Errorf("expected floor %v after large decay, got %v", agentpatterns.ConfidenceFloor, got)
+	}
+}
+
+func TestApplyTimeDecayFromUnix_NeverApplied(t *testing.T) {
+	now := int64(1716200000)
+	got := agentpatterns.ApplyTimeDecayFromUnix(0.8, 0, now)
+	if got != 0.8 {
+		t.Errorf("never-applied should not decay: got %v", got)
+	}
+}
+
+func TestApplyTimeDecayFromUnix_30DaysAgo(t *testing.T) {
+	now := int64(1716200000)
+	last := now - 30*86400
+	got := agentpatterns.ApplyTimeDecayFromUnix(0.8, last, now)
+	want := 0.75
+	if abs(got-want) > 1e-9 {
+		t.Errorf("30-day decay via unix: got %v want %v", got, want)
+	}
+}
+
+func TestApplyTimeDecayFromUnix_FloorAt02(t *testing.T) {
+	now := int64(1716200000)
+	last := now - 365*86400*3 // 3 years ago
+	got := agentpatterns.ApplyTimeDecayFromUnix(0.5, last, now)
+	if got < agentpatterns.ConfidenceFloor {
+		t.Errorf("floor breached: got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Decay scheduler skeleton — smoke test
+// ---------------------------------------------------------------------------
+
+func TestDecayScheduler_RunAndCancel(t *testing.T) {
+	calls := 0
+	job := func(nowUnix int64) {
+		calls++
+	}
+	sched := agentpatterns.NewDecayScheduler(10*time.Millisecond, job)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	sched.Run(ctx)
+	// After ~50 ms with 10 ms interval, we expect ≥ 3 ticks (conservative).
+	if calls < 3 {
+		t.Errorf("expected >= 3 scheduler ticks, got %d", calls)
+	}
+}
+
+func TestDecayScheduler_StopsOnCancel(t *testing.T) {
+	calls := 0
+	job := func(int64) { calls++ }
+	sched := agentpatterns.NewDecayScheduler(5*time.Millisecond, job)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+
+	sched.Run(ctx)
+	// After an immediate cancel, the scheduler should exit without ticking.
+	if calls != 0 {
+		t.Errorf("cancelled scheduler should not tick, got %d calls", calls)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func abs(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/agentpatterns/patterns.go
+++ b/internal/agentpatterns/patterns.go
@@ -1,0 +1,228 @@
+// Package agentpatterns implements the storage layer for agent-learned patterns
+// as described in ADR-0018. Patterns are first-class graph entities that store
+// codebase-specific recipes, link to real code exemplars, and improve as agents
+// apply and correct them.
+//
+// Storage is per-group JSON at <group>/.archigraph/patterns.json (matching the
+// convention of enrichment-resolutions.json and repair.json). FlatBuffers
+// migration is deferred to v1.1.
+package agentpatterns
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"time"
+)
+
+// SchemaVersion is the integer version of the on-disk patterns.json schema.
+const SchemaVersion = 1
+
+// Category classifies the nature of a Pattern.
+type Category string
+
+const (
+	CategoryCode         Category = "code"
+	CategoryProcess      Category = "process"
+	CategoryTeam         Category = "team"
+	CategoryTooling      Category = "tooling"
+	CategoryArchitecture Category = "architecture"
+)
+
+// Trigger describes when a pattern should be applied.
+type Trigger struct {
+	NaturalLanguage   string   `json:"natural_language"`
+	Keywords          []string `json:"keywords,omitempty"`
+	TargetEntityKinds []string `json:"target_entity_kinds,omitempty"`
+}
+
+// AntiPattern describes something that must NOT be done when applying a pattern.
+type AntiPattern struct {
+	DoNot   string `json:"do_not"`
+	Reason  string `json:"reason"`
+	Private bool   `json:"private"` // if true, excluded from CLAUDE.md export and doc-gen
+}
+
+// Scope constrains which repositories, paths, languages, stacks, and entity
+// kinds a pattern applies to. An absent (empty) slice is a wildcard.
+type Scope struct {
+	Repos       []string `json:"repos,omitempty"`
+	ModulePaths []string `json:"module_paths,omitempty"`
+	Languages   []string `json:"languages,omitempty"`
+	Stacks      []string `json:"stacks,omitempty"` // e.g. "go/chi", "python/django"
+	EntityKinds []string `json:"entity_kinds,omitempty"`
+}
+
+// Pattern is the in-memory representation of one agent-learned pattern. It
+// maps 1:1 to an entity in the graph with kind "AgentPattern" (see
+// internal/types/kinds.go, EntityKindAgentPattern).
+type Pattern struct {
+	// ID is sha256(group + trigger.natural_language)[:16].
+	ID   string `json:"id"`
+	Kind string `json:"kind"` // always "AgentPattern"
+
+	Trigger      Trigger       `json:"trigger"`
+	Steps        []string      `json:"steps"`
+	AntiPatterns []AntiPattern `json:"anti_patterns,omitempty"`
+	Scope        Scope         `json:"scope"`
+
+	Category Category `json:"category"`
+
+	// Confidence is [0.0, 1.0]. New patterns start at 0.4.
+	Confidence float64 `json:"confidence"`
+	// Observations is the cumulative number of times this pattern has been
+	// referenced (applied, rejected, refined).
+	Observations int `json:"observations"`
+
+	// LastValidated is the unix timestamp of the last validation event.
+	LastValidated int64 `json:"last_validated,omitempty"`
+	// LastApplied is the unix timestamp of the last apply event.
+	LastApplied int64 `json:"last_applied,omitempty"`
+
+	// IsCandidate is true until convergence + user-approval.
+	IsCandidate bool `json:"is_candidate"`
+	// ConvergenceCount is the number of independent subagents that proposed
+	// this candidate.
+	ConvergenceCount int `json:"convergence_count,omitempty"`
+	// ProposerSubagents holds identifiers of subagents that contributed
+	// observations (for audit).
+	ProposerSubagents []string `json:"proposer_subagents,omitempty"`
+
+	// DocumentationURL is populated by Phase 6 doc-gen integration.
+	DocumentationURL string `json:"documentation_url,omitempty"`
+}
+
+// PatternID computes the deterministic ID for a pattern given its group and
+// the trigger's natural_language text.
+//
+// The ID is stable: same (group, naturalLanguage) input → same 16-char hex
+// output, matching the convention used by graph.EntityID and enrichment.
+func PatternID(group, naturalLanguage string) string {
+	h := sha256.New()
+	h.Write([]byte(group))
+	h.Write([]byte{0})
+	h.Write([]byte(naturalLanguage))
+	return hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// New returns a new Pattern initialised with sensible defaults. The caller
+// should populate Trigger, Steps, etc. before saving.
+func New(group string, trigger Trigger, category Category) *Pattern {
+	return &Pattern{
+		ID:          PatternID(group, trigger.NaturalLanguage),
+		Kind:        "AgentPattern",
+		Trigger:     trigger,
+		Category:    category,
+		Confidence:  InitialConfidence,
+		IsCandidate: true,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Storage envelope
+// ---------------------------------------------------------------------------
+
+// patternsEnvelope is the on-disk shape of patterns.json.
+type patternsEnvelope struct {
+	Version  int       `json:"version"`
+	Patterns []Pattern `json:"patterns"`
+}
+
+// patternsPath returns the canonical path for the group's patterns.json file.
+// groupArchigraphDir is the <group>/.archigraph/ directory, matching the
+// convention used by enrichment-resolutions.json.
+func patternsPath(groupArchigraphDir string) string {
+	return filepath.Join(groupArchigraphDir, "patterns.json")
+}
+
+// Save atomically writes the pattern slice to <groupArchigraphDir>/patterns.json.
+// Patterns are sorted by ID before writing to ensure stable, diffable output.
+func Save(groupArchigraphDir string, patterns []Pattern) error {
+	if err := os.MkdirAll(groupArchigraphDir, 0o755); err != nil {
+		return fmt.Errorf("agentpatterns: mkdir %s: %w", groupArchigraphDir, err)
+	}
+
+	// Stable sort by ID so consecutive saves are byte-identical when no data
+	// changed (required by the determinism invariant, issue #481).
+	sorted := make([]Pattern, len(patterns))
+	copy(sorted, patterns)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].ID < sorted[j].ID
+	})
+
+	env := patternsEnvelope{
+		Version:  SchemaVersion,
+		Patterns: sorted,
+	}
+	data, err := json.MarshalIndent(env, "", "  ")
+	if err != nil {
+		return fmt.Errorf("agentpatterns: marshal: %w", err)
+	}
+
+	path := patternsPath(groupArchigraphDir)
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("agentpatterns: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("agentpatterns: rename: %w", err)
+	}
+	return nil
+}
+
+// Load reads <groupArchigraphDir>/patterns.json and returns the pattern slice.
+// Returns an empty slice (not nil) if the file does not exist, matching the
+// convention of enrichment.ReadResolutions.
+func Load(groupArchigraphDir string) ([]Pattern, error) {
+	data, err := os.ReadFile(patternsPath(groupArchigraphDir))
+	if os.IsNotExist(err) {
+		return []Pattern{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("agentpatterns: read: %w", err)
+	}
+
+	var env patternsEnvelope
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, fmt.Errorf("agentpatterns: unmarshal: %w", err)
+	}
+	if env.Patterns == nil {
+		return []Pattern{}, nil
+	}
+	return env.Patterns, nil
+}
+
+// Upsert inserts or replaces a single pattern in the patterns slice (matched by
+// ID). Returns the updated slice. Does not persist — callers must call Save.
+func Upsert(patterns []Pattern, p Pattern) []Pattern {
+	for i, existing := range patterns {
+		if existing.ID == p.ID {
+			patterns[i] = p
+			return patterns
+		}
+	}
+	return append(patterns, p)
+}
+
+// ByID returns the pattern with the given ID from the slice, or nil.
+func ByID(patterns []Pattern, id string) *Pattern {
+	for i := range patterns {
+		if patterns[i].ID == id {
+			return &patterns[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Time helpers exposed for the scheduler skeleton
+// ---------------------------------------------------------------------------
+
+// NowUnix returns the current Unix timestamp. Indirected through a var so
+// tests can freeze time without a global clock.
+var NowUnix = func() int64 { return time.Now().Unix() }

--- a/internal/agentpatterns/patterns_test.go
+++ b/internal/agentpatterns/patterns_test.go
@@ -1,0 +1,409 @@
+package agentpatterns_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/agentpatterns"
+)
+
+// ---------------------------------------------------------------------------
+// PatternID determinism
+// ---------------------------------------------------------------------------
+
+func TestPatternID_Deterministic(t *testing.T) {
+	group := "my-group"
+	nl := "Always register a health-check endpoint at /healthz"
+
+	id1 := agentpatterns.PatternID(group, nl)
+	id2 := agentpatterns.PatternID(group, nl)
+	if id1 != id2 {
+		t.Fatalf("PatternID not deterministic: %q vs %q", id1, id2)
+	}
+	if len(id1) != 16 {
+		t.Fatalf("PatternID length = %d, want 16", len(id1))
+	}
+}
+
+func TestPatternID_DifferentGroupsDifferentIDs(t *testing.T) {
+	nl := "Always use atomic file writes"
+	id1 := agentpatterns.PatternID("group-a", nl)
+	id2 := agentpatterns.PatternID("group-b", nl)
+	if id1 == id2 {
+		t.Fatalf("different groups should produce different IDs, both got %q", id1)
+	}
+}
+
+func TestPatternID_DifferentTriggersDifferentIDs(t *testing.T) {
+	group := "my-group"
+	id1 := agentpatterns.PatternID(group, "use chi router")
+	id2 := agentpatterns.PatternID(group, "use gorilla/mux router")
+	if id1 == id2 {
+		t.Fatalf("different triggers should produce different IDs, both got %q", id1)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Round-trip serialize / deserialize (all fields populated)
+// ---------------------------------------------------------------------------
+
+func fullPattern(group string) agentpatterns.Pattern {
+	nl := "Add a new HTTP endpoint following the chi handler pattern"
+	return agentpatterns.Pattern{
+		ID:   agentpatterns.PatternID(group, nl),
+		Kind: "AgentPattern",
+		Trigger: agentpatterns.Trigger{
+			NaturalLanguage:   nl,
+			Keywords:          []string{"endpoint", "chi", "handler", "http"},
+			TargetEntityKinds: []string{"SCOPE.Endpoint", "SCOPE.Function"},
+		},
+		Steps: []string{
+			"Create handler function in internal/handlers/",
+			"Register route in cmd/server/routes.go",
+			"Add OpenAPI operation annotation",
+			"Write integration test in internal/handlers/*_test.go",
+		},
+		AntiPatterns: []agentpatterns.AntiPattern{
+			{DoNot: "Inline business logic in the handler", Reason: "Violates separation of concerns", Private: false},
+			{DoNot: "Skip the integration test", Reason: "CI will catch a missing test", Private: true},
+		},
+		Scope: agentpatterns.Scope{
+			Repos:       []string{"my-service"},
+			ModulePaths: []string{"internal/handlers"},
+			Languages:   []string{"go"},
+			Stacks:      []string{"go/chi"},
+			EntityKinds: []string{"SCOPE.Endpoint"},
+		},
+		Category:          agentpatterns.CategoryCode,
+		Confidence:        0.75,
+		Observations:      5,
+		LastValidated:     1716100000,
+		LastApplied:       1716200000,
+		IsCandidate:       false,
+		ConvergenceCount:  3,
+		ProposerSubagents: []string{"subagent-a", "subagent-b", "subagent-c"},
+		DocumentationURL:  "docs/patterns/code/chi-handler.md",
+	}
+}
+
+func TestRoundTrip_AllFields(t *testing.T) {
+	dir := t.TempDir()
+	group := "test-group"
+
+	original := fullPattern(group)
+	if err := agentpatterns.Save(dir, []agentpatterns.Pattern{original}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	loaded, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("got %d patterns, want 1", len(loaded))
+	}
+
+	got := loaded[0]
+	if got.ID != original.ID {
+		t.Errorf("ID: got %q want %q", got.ID, original.ID)
+	}
+	if got.Kind != "AgentPattern" {
+		t.Errorf("Kind: got %q want AgentPattern", got.Kind)
+	}
+	if got.Trigger.NaturalLanguage != original.Trigger.NaturalLanguage {
+		t.Errorf("Trigger.NaturalLanguage mismatch")
+	}
+	if len(got.Trigger.Keywords) != len(original.Trigger.Keywords) {
+		t.Errorf("Keywords len: got %d want %d", len(got.Trigger.Keywords), len(original.Trigger.Keywords))
+	}
+	if len(got.Trigger.TargetEntityKinds) != len(original.Trigger.TargetEntityKinds) {
+		t.Errorf("TargetEntityKinds len mismatch")
+	}
+	if len(got.Steps) != len(original.Steps) {
+		t.Errorf("Steps len: got %d want %d", len(got.Steps), len(original.Steps))
+	}
+	if len(got.AntiPatterns) != len(original.AntiPatterns) {
+		t.Fatalf("AntiPatterns len: got %d want %d", len(got.AntiPatterns), len(original.AntiPatterns))
+	}
+	if got.Scope.Languages[0] != "go" {
+		t.Errorf("Scope.Languages[0]: got %q want go", got.Scope.Languages[0])
+	}
+	if got.Category != agentpatterns.CategoryCode {
+		t.Errorf("Category: got %q want code", got.Category)
+	}
+	if got.Confidence != original.Confidence {
+		t.Errorf("Confidence: got %v want %v", got.Confidence, original.Confidence)
+	}
+	if got.Observations != original.Observations {
+		t.Errorf("Observations: got %d want %d", got.Observations, original.Observations)
+	}
+	if got.LastValidated != original.LastValidated {
+		t.Errorf("LastValidated mismatch")
+	}
+	if got.LastApplied != original.LastApplied {
+		t.Errorf("LastApplied mismatch")
+	}
+	if got.IsCandidate != original.IsCandidate {
+		t.Errorf("IsCandidate: got %v want %v", got.IsCandidate, original.IsCandidate)
+	}
+	if got.ConvergenceCount != original.ConvergenceCount {
+		t.Errorf("ConvergenceCount: got %d want %d", got.ConvergenceCount, original.ConvergenceCount)
+	}
+	if len(got.ProposerSubagents) != len(original.ProposerSubagents) {
+		t.Errorf("ProposerSubagents len mismatch")
+	}
+	if got.DocumentationURL != original.DocumentationURL {
+		t.Errorf("DocumentationURL: got %q want %q", got.DocumentationURL, original.DocumentationURL)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Anti-pattern with private=true serializes correctly
+// ---------------------------------------------------------------------------
+
+func TestAntiPattern_PrivateFlag(t *testing.T) {
+	dir := t.TempDir()
+	p := agentpatterns.Pattern{
+		ID:   agentpatterns.PatternID("g", "test trigger"),
+		Kind: "AgentPattern",
+		Trigger: agentpatterns.Trigger{
+			NaturalLanguage: "test trigger",
+		},
+		AntiPatterns: []agentpatterns.AntiPattern{
+			{DoNot: "skip linting", Reason: "CI requires it", Private: false},
+			{DoNot: "hardcode secrets", Reason: "security risk", Private: true},
+		},
+		Category:   agentpatterns.CategoryTooling,
+		Confidence: agentpatterns.InitialConfidence,
+	}
+
+	if err := agentpatterns.Save(dir, []agentpatterns.Pattern{p}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+
+	// Read raw bytes to confirm the private field is present in JSON.
+	raw, _ := os.ReadFile(filepath.Join(dir, "patterns.json"))
+	var envelope struct {
+		Patterns []struct {
+			AntiPatterns []struct {
+				DoNot   string `json:"do_not"`
+				Private bool   `json:"private"`
+			} `json:"anti_patterns"`
+		} `json:"patterns"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		t.Fatalf("unmarshal raw: %v", err)
+	}
+	if len(envelope.Patterns) != 1 {
+		t.Fatalf("expected 1 pattern in raw JSON")
+	}
+	aps := envelope.Patterns[0].AntiPatterns
+	if len(aps) != 2 {
+		t.Fatalf("expected 2 anti-patterns in raw JSON, got %d", len(aps))
+	}
+	// The private one should have private: true in the output.
+	if !aps[1].Private {
+		t.Errorf("second anti-pattern private flag not preserved: got false, want true")
+	}
+	// The public one should have private: false (or omitted and thus false).
+	if aps[0].Private {
+		t.Errorf("first anti-pattern should not be private")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scope validation: empty constraint = wildcard
+// ---------------------------------------------------------------------------
+
+func TestScope_EmptyIsWildcard(t *testing.T) {
+	empty := agentpatterns.Scope{}
+	if len(empty.Repos) != 0 {
+		t.Error("empty scope repos should be zero-length")
+	}
+	if len(empty.Languages) != 0 {
+		t.Error("empty scope languages should be zero-length")
+	}
+	if len(empty.Stacks) != 0 {
+		t.Error("empty scope stacks should be zero-length")
+	}
+	if len(empty.EntityKinds) != 0 {
+		t.Error("empty scope entity_kinds should be zero-length")
+	}
+}
+
+func TestScope_PartialConstraint(t *testing.T) {
+	dir := t.TempDir()
+	// A pattern scoped only by language (all repos, paths, stacks).
+	p := agentpatterns.Pattern{
+		ID:   agentpatterns.PatternID("g", "python pattern"),
+		Kind: "AgentPattern",
+		Trigger: agentpatterns.Trigger{
+			NaturalLanguage: "python pattern",
+		},
+		Scope: agentpatterns.Scope{
+			Languages: []string{"python"},
+			// Repos, ModulePaths, Stacks, EntityKinds are all empty → wildcard
+		},
+		Category:   agentpatterns.CategoryCode,
+		Confidence: agentpatterns.InitialConfidence,
+	}
+	if err := agentpatterns.Save(dir, []agentpatterns.Pattern{p}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	loaded, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if len(loaded) != 1 {
+		t.Fatalf("got %d patterns, want 1", len(loaded))
+	}
+	if len(loaded[0].Scope.Languages) != 1 || loaded[0].Scope.Languages[0] != "python" {
+		t.Errorf("scope.languages not preserved")
+	}
+	if len(loaded[0].Scope.Repos) != 0 {
+		t.Errorf("scope.repos should remain empty (wildcard), got %v", loaded[0].Scope.Repos)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Load returns empty slice for missing file (not an error)
+// ---------------------------------------------------------------------------
+
+func TestLoad_MissingFile_ReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	patterns, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("expected no error for missing file, got %v", err)
+	}
+	if patterns == nil {
+		t.Error("Load should return non-nil slice for missing file")
+	}
+	if len(patterns) != 0 {
+		t.Errorf("expected 0 patterns, got %d", len(patterns))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Save atomicity: tmp+rename approach
+// ---------------------------------------------------------------------------
+
+func TestSave_AtomicWrite(t *testing.T) {
+	dir := t.TempDir()
+	p := agentpatterns.Pattern{
+		ID:   agentpatterns.PatternID("g", "atomic test"),
+		Kind: "AgentPattern",
+		Trigger: agentpatterns.Trigger{
+			NaturalLanguage: "atomic test",
+		},
+		Category:   agentpatterns.CategoryProcess,
+		Confidence: agentpatterns.InitialConfidence,
+	}
+	if err := agentpatterns.Save(dir, []agentpatterns.Pattern{p}); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	// Confirm no stray .tmp file remains.
+	tmpPath := filepath.Join(dir, "patterns.json.tmp")
+	if _, err := os.Stat(tmpPath); !os.IsNotExist(err) {
+		t.Error("stray .tmp file found after Save; atomic rename failed")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Upsert and ByID helpers
+// ---------------------------------------------------------------------------
+
+func TestUpsert_Insert(t *testing.T) {
+	var patterns []agentpatterns.Pattern
+	p := agentpatterns.Pattern{ID: "aabbccddeeff0011", Kind: "AgentPattern"}
+	patterns = agentpatterns.Upsert(patterns, p)
+	if len(patterns) != 1 {
+		t.Fatalf("expected 1, got %d", len(patterns))
+	}
+}
+
+func TestUpsert_Replace(t *testing.T) {
+	p1 := agentpatterns.Pattern{ID: "aabbccddeeff0011", Kind: "AgentPattern", Confidence: 0.4}
+	p2 := agentpatterns.Pattern{ID: "aabbccddeeff0011", Kind: "AgentPattern", Confidence: 0.7}
+	patterns := []agentpatterns.Pattern{p1}
+	patterns = agentpatterns.Upsert(patterns, p2)
+	if len(patterns) != 1 {
+		t.Fatalf("expected 1 after replace, got %d", len(patterns))
+	}
+	if patterns[0].Confidence != 0.7 {
+		t.Errorf("confidence not updated: got %v want 0.7", patterns[0].Confidence)
+	}
+}
+
+func TestByID_Found(t *testing.T) {
+	p := agentpatterns.Pattern{ID: "deadbeef00001234", Kind: "AgentPattern"}
+	patterns := []agentpatterns.Pattern{p}
+	found := agentpatterns.ByID(patterns, "deadbeef00001234")
+	if found == nil {
+		t.Error("ByID returned nil for existing pattern")
+	}
+}
+
+func TestByID_NotFound(t *testing.T) {
+	p := agentpatterns.Pattern{ID: "deadbeef00001234", Kind: "AgentPattern"}
+	patterns := []agentpatterns.Pattern{p}
+	found := agentpatterns.ByID(patterns, "0000000000000000")
+	if found != nil {
+		t.Error("ByID should return nil for unknown ID")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Sort stability: Save produces stable output across multiple calls
+// ---------------------------------------------------------------------------
+
+func TestSave_StableSort(t *testing.T) {
+	dir := t.TempDir()
+	patterns := []agentpatterns.Pattern{
+		{ID: "zzzzzzzzzzzzzzzz", Kind: "AgentPattern", Trigger: agentpatterns.Trigger{NaturalLanguage: "z"}},
+		{ID: "aaaaaaaaaaaaaaaa", Kind: "AgentPattern", Trigger: agentpatterns.Trigger{NaturalLanguage: "a"}},
+		{ID: "mmmmmmmmmmmmmmmm", Kind: "AgentPattern", Trigger: agentpatterns.Trigger{NaturalLanguage: "m"}},
+	}
+
+	if err := agentpatterns.Save(dir, patterns); err != nil {
+		t.Fatalf("Save: %v", err)
+	}
+	raw1, _ := os.ReadFile(filepath.Join(dir, "patterns.json"))
+
+	// Save again in different order — output should be identical.
+	patterns2 := []agentpatterns.Pattern{patterns[2], patterns[0], patterns[1]}
+	if err := agentpatterns.Save(dir, patterns2); err != nil {
+		t.Fatalf("Save2: %v", err)
+	}
+	raw2, _ := os.ReadFile(filepath.Join(dir, "patterns.json"))
+
+	if string(raw1) != string(raw2) {
+		t.Error("Save produced different output for the same patterns in different insertion order (sort not stable)")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// New() helper
+// ---------------------------------------------------------------------------
+
+func TestNew_DefaultValues(t *testing.T) {
+	trigger := agentpatterns.Trigger{
+		NaturalLanguage: "register chi middleware",
+		Keywords:        []string{"chi", "middleware"},
+	}
+	p := agentpatterns.New("group-x", trigger, agentpatterns.CategoryCode)
+	if p.Confidence != agentpatterns.InitialConfidence {
+		t.Errorf("confidence = %v, want %v", p.Confidence, agentpatterns.InitialConfidence)
+	}
+	if !p.IsCandidate {
+		t.Error("new pattern should be a candidate by default")
+	}
+	if p.Kind != "AgentPattern" {
+		t.Errorf("kind = %q, want AgentPattern", p.Kind)
+	}
+	expectedID := agentpatterns.PatternID("group-x", "register chi middleware")
+	if p.ID != expectedID {
+		t.Errorf("id = %q, want %q", p.ID, expectedID)
+	}
+}

--- a/internal/graph/fbreader/reader_test.go
+++ b/internal/graph/fbreader/reader_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/graph/fbreader"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 func writeAndOpen(t *testing.T, doc *graph.Document) *fbreader.Reader {
@@ -69,5 +70,115 @@ func TestPhaseDReaderMethods(t *testing.T) {
 	}
 	if meta.ComputedAt == "" {
 		t.Errorf("expected non-empty computed_at")
+	}
+}
+
+// TestAgentPatternKindRoundTrip verifies that the new "AgentPattern" entity kind
+// and the ADR-0018 pattern edge kinds (EXEMPLAR, TOUCHES, ANTI_EXEMPLAR,
+// SUPERSEDES, CONFLICTS_WITH, CO_APPLIES_WITH, PREREQUISITE, CREATED_BY) survive
+// a write → read round-trip through the FlatBuffers format.
+//
+// The FB schema stores kind as a free-form string, so no schema change is
+// required — this test confirms the strings are preserved exactly.
+func TestAgentPatternKindRoundTrip(t *testing.T) {
+	patternID := "adr0018pattern001"
+	entityID := "someentity0000001"
+	pattern2ID := "adr0018pattern002"
+
+	doc := &graph.Document{
+		Repo:        "patterns-test",
+		GeneratedAt: time.Date(2026, 5, 20, 0, 0, 0, 0, time.UTC),
+		Entities: []graph.Entity{
+			{
+				ID:   patternID,
+				Kind: string(types.EntityKindAgentPattern),
+				Name: "chi-handler-pattern",
+				Properties: map[string]string{
+					"category":   "code",
+					"confidence": "0.75",
+				},
+			},
+			{
+				ID:   entityID,
+				Kind: string(types.EntityKindFunction),
+				Name: "RegisterRoutes",
+			},
+			{
+				ID:   pattern2ID,
+				Kind: string(types.EntityKindAgentPattern),
+				Name: "old-handler-pattern",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r01", FromID: patternID, ToID: entityID, Kind: string(types.RelationshipKindExemplar)},
+			{ID: "r02", FromID: patternID, ToID: entityID, Kind: string(types.RelationshipKindTouches)},
+			{ID: "r03", FromID: patternID, ToID: entityID, Kind: string(types.RelationshipKindAntiExemplar)},
+			{ID: "r04", FromID: patternID, ToID: pattern2ID, Kind: string(types.RelationshipKindSupersedes)},
+			{ID: "r05", FromID: patternID, ToID: pattern2ID, Kind: string(types.RelationshipKindConflictsWith)},
+			{ID: "r06", FromID: patternID, ToID: pattern2ID, Kind: string(types.RelationshipKindCoAppliesWith)},
+			{ID: "r07", FromID: patternID, ToID: pattern2ID, Kind: string(types.RelationshipKindPrerequisite)},
+			{ID: "r08", FromID: entityID, ToID: patternID, Kind: string(types.RelationshipKindCreatedBy)},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+
+	r := writeAndOpen(t, doc)
+
+	// Verify AgentPattern entity kind survives.
+	agentPatternEntity := r.LookupEntityByID(patternID)
+	if agentPatternEntity == nil {
+		t.Fatal("AgentPattern entity not found after round-trip")
+	}
+	if got := string(agentPatternEntity.Kind()); got != string(types.EntityKindAgentPattern) {
+		t.Errorf("kind: got %q want %q", got, types.EntityKindAgentPattern)
+	}
+	if got := string(agentPatternEntity.Name()); got != "chi-handler-pattern" {
+		t.Errorf("name: got %q want chi-handler-pattern", got)
+	}
+
+	// Verify all 8 pattern edge kinds survive via IterateRelationshipsFromID /
+	// IterateRelationshipsToID.
+	fromPattern := r.IterateRelationshipsFromID(patternID)
+	if len(fromPattern) != 7 {
+		t.Errorf("relationships from pattern: got %d want 7", len(fromPattern))
+	}
+
+	// Collect actual kinds from the round-tripped relationships.
+	kindSet := map[string]bool{}
+	for _, rel := range fromPattern {
+		kindSet[string(rel.Kind())] = true
+	}
+
+	wantKinds := []types.RelationshipKind{
+		types.RelationshipKindExemplar,
+		types.RelationshipKindTouches,
+		types.RelationshipKindAntiExemplar,
+		types.RelationshipKindSupersedes,
+		types.RelationshipKindConflictsWith,
+		types.RelationshipKindCoAppliesWith,
+		types.RelationshipKindPrerequisite,
+	}
+	for _, k := range wantKinds {
+		if !kindSet[string(k)] {
+			t.Errorf("edge kind %q not found after round-trip", k)
+		}
+	}
+
+	// Verify CREATED_BY (incoming to pattern, from entity).
+	toPattern := r.IterateRelationshipsToID(patternID)
+	if len(toPattern) != 1 {
+		t.Errorf("relationships to pattern: got %d want 1", len(toPattern))
+	}
+	if len(toPattern) == 1 {
+		if got := string(toPattern[0].Kind()); got != string(types.RelationshipKindCreatedBy) {
+			t.Errorf("CREATED_BY kind: got %q want %q", got, types.RelationshipKindCreatedBy)
+		}
+	}
+
+	// Confirm the count of AgentPattern entities.
+	agentPatterns := r.FilterEntitiesByKind(string(types.EntityKindAgentPattern))
+	if len(agentPatterns) != 2 {
+		t.Errorf("FilterEntitiesByKind(AgentPattern): got %d want 2", len(agentPatterns))
 	}
 }

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -41,6 +41,10 @@ const (
 	EntityKindProject  EntityKind = "SCOPE.Project"
 	EntityKindConfig   EntityKind = "SCOPE.Config"
 	EntityKindModel    EntityKind = "SCOPE.Model"
+	// AgentPattern is the kind for agent-learned Pattern entities introduced
+	// in ADR-0018. Stored as "AgentPattern" (no SCOPE. prefix) to distinguish
+	// from the structural SCOPE.Pattern kind used by static-analysis extractors.
+	EntityKindAgentPattern EntityKind = "AgentPattern"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -78,6 +82,7 @@ func AllEntityKinds() []EntityKind {
 		EntityKindProject,
 		EntityKindConfig,
 		EntityKindModel,
+		EntityKindAgentPattern,
 	}
 }
 
@@ -122,6 +127,18 @@ const (
 	// by the OpenAPI pattern extractor to associate operations with their
 	// tag entities.
 	RelationshipKindTaggedAs RelationshipKind = "TAGGED_AS"
+
+	// ADR-0018: Agent-learned pattern edge kinds (append-only additions).
+	// Outgoing from Pattern entities:
+	RelationshipKindExemplar      RelationshipKind = "EXEMPLAR"       // Pattern → Entity: real code example of this pattern in use
+	RelationshipKindTouches       RelationshipKind = "TOUCHES"        // Pattern → Entity: entity the pattern's steps read or modify
+	RelationshipKindAntiExemplar  RelationshipKind = "ANTI_EXEMPLAR"  // Pattern → Entity: real code example of the anti-pattern
+	RelationshipKindSupersedes    RelationshipKind = "SUPERSEDES"     // Pattern → Pattern: this pattern replaces an older one
+	RelationshipKindConflictsWith RelationshipKind = "CONFLICTS_WITH" // Pattern → Pattern: these two patterns cannot both apply
+	RelationshipKindCoAppliesWith RelationshipKind = "CO_APPLIES_WITH" // Pattern → Pattern: typically applied together
+	RelationshipKindPrerequisite  RelationshipKind = "PREREQUISITE"   // Pattern → Pattern: must be satisfied before this one
+	// Incoming to Pattern:
+	RelationshipKindCreatedBy RelationshipKind = "CREATED_BY" // Entity → Pattern: entity produced using the linked pattern
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -148,6 +165,15 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindRenders,
 		RelationshipKindReturns,
 		RelationshipKindTaggedAs,
+		// ADR-0018 pattern edge kinds:
+		RelationshipKindExemplar,
+		RelationshipKindTouches,
+		RelationshipKindAntiExemplar,
+		RelationshipKindSupersedes,
+		RelationshipKindConflictsWith,
+		RelationshipKindCoAppliesWith,
+		RelationshipKindPrerequisite,
+		RelationshipKindCreatedBy,
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `EntityKindAgentPattern = "AgentPattern"` to `internal/types/kinds.go` (append-only, distinct from the structural `SCOPE.Pattern` kind)
- Adds 8 new `RelationshipKind` constants (append-only): `EXEMPLAR`, `TOUCHES`, `ANTI_EXEMPLAR`, `SUPERSEDES`, `CONFLICTS_WITH`, `CO_APPLIES_WITH`, `PREREQUISITE`, `CREATED_BY`
- New package `internal/agentpatterns/` with:
  - `patterns.go` — `Pattern` struct + `PatternID` + `New` + atomic `Load`/`Save` + `Upsert`/`ByID` helpers
  - `confidence.go` — `NewPatternConfidence`, `ApplyConfidenceDelta` (all 4 events), `ApplyTimeDecay`, `ApplyTimeDecayFromUnix`, `DecayScheduler` skeleton
- `internal/graph/fbreader/reader_test.go` — new `TestAgentPatternKindRoundTrip` covering all 8 edge kinds + `FilterEntitiesByKind("AgentPattern")`

## No-scope confirmation

- No changes to `internal/mcp/server.go` — MCP wiring is PR β
- No CLI subcommand — PR δ
- No skills changes — PR δ
- No extractor or resolver code touched
- FB schema `graph.fbs` unchanged (kind is a free-form string; no new FB tables needed)

## Storage layout

`<group>/.archigraph/patterns.json` — JSON envelope `{"version":1,"patterns":[...]}`, atomic tmp+rename, sorted by ID for deterministic diffs. Matches the convention of `enrichment-resolutions.json` and `repair.json`.

## Test plan

- [x] `go test ./internal/agentpatterns/...` — 32 tests (round-trip all fields, private anti-pattern flag, scope wildcard, ID determinism, confidence math all 4 events, floor/ceiling clamps, time decay 30/60/1095 days, floor at 0.2, scheduler run+cancel)
- [x] `go test ./internal/graph/fbreader/...` — `TestAgentPatternKindRoundTrip` (all 8 edge kinds + entity kind)
- [x] `go test ./internal/types/...` — existing tests still pass; `AllRelationshipKinds` length check passes (now 29)
- [x] `go test ./...` — 0 FAIL across all 90 packages

## Daemon cleanup

No daemon was spawned by this PR (pure storage, no daemon integration). 0 PIDs killed.

Closes #673

🤖 Generated with [Claude Code](https://claude.com/claude-code)