### PR TITLE
[#675][patterns][γ] Lifecycle actions + confidence decay scheduler (ADR-0018)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -90,6 +90,11 @@ func runDaemon(argv []string) error {
 
 		MaxRSSBudgetMB: maxRSSBudget,
 		RSSHistoryPath: filepath.Join(filepath.Dir(layout.PIDPath), "repo-rss-history.json"),
+
+		// Pattern confidence time-decay: runs every 6 hours.
+		// PatternGroupDirs returns the patterns storage directory for each
+		// registered group so the decay scheduler can find patterns.json.
+		PatternGroupDirs: daemonPatternGroupDirs,
 	}
 
 	ctx := context.Background()
@@ -329,3 +334,28 @@ func mustEncodeStatus(w io.Writer, reply proto.StatusReply) error {
 var daemonNotRunningErr = errors.New(
 	"daemon not running; run 'archigraph start' or reinstall via 'archigraph install'",
 )
+
+// daemonPatternGroupDirs returns a map of group-name → patterns storage
+// directory for every registered group. This is injected into daemon.Config
+// so the pattern decay scheduler can find each group's patterns.json.
+//
+// Directory convention mirrors internal/mcp/patterns.go defaultPatternsDir:
+// ~/.archigraph/groups/<group>-patterns/. Groups whose patterns are stored in
+// a custom MemoryDir (MCP registry config) will be found there by the MCP
+// server; the daemon uses the default path which covers production deployments.
+func daemonPatternGroupDirs() map[string]string {
+	groups, err := registry.Groups()
+	if err != nil {
+		return nil
+	}
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return nil
+	}
+	out := make(map[string]string, len(groups))
+	for _, g := range groups {
+		dir := filepath.Join(home, ".archigraph", "groups", g.Name+"-patterns")
+		out[g.Name] = dir
+	}
+	return out
+}

--- a/internal/agentpatterns/patterns.go
+++ b/internal/agentpatterns/patterns.go
@@ -98,6 +98,20 @@ type Pattern struct {
 	// Exemplars holds the entity IDs of canonical examples of this pattern
 	// in use. Required on record (≥1). Written as EXEMPLAR edges to the graph.
 	Exemplars []string `json:"exemplars,omitempty"`
+
+	// Touches holds entity IDs that this pattern touches (produces TOUCHES edges).
+	Touches []string `json:"touches,omitempty"`
+
+	// AntiExemplars holds entity IDs that are counter-examples (ANTI_EXEMPLAR edges).
+	AntiExemplars []string `json:"anti_exemplars,omitempty"`
+
+	// RejectReason is populated by action=reject.
+	RejectReason string `json:"reject_reason,omitempty"`
+	// RejectTimestamp is the unix timestamp of the last reject event.
+	RejectTimestamp int64 `json:"reject_timestamp,omitempty"`
+
+	// ApprovalNote is an optional user-facing note set during action=promote.
+	ApprovalNote string `json:"approval_note,omitempty"`
 }
 
 // PatternID computes the deterministic ID for a pattern given its group and

--- a/internal/daemon/pattern_decay_test.go
+++ b/internal/daemon/pattern_decay_test.go
@@ -1,0 +1,240 @@
+package daemon
+
+// pattern_decay_test.go — unit tests for buildPatternDecayJob (γ).
+//
+// These tests call buildPatternDecayJob directly so they exercise the decay
+// logic without waiting 6 hours for the scheduler to tick.
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/agentpatterns"
+)
+
+// makePatternDecayDir creates a temp dir and saves a set of patterns into it.
+// Returns the directory path.
+func makePatternDecayDir(t *testing.T, patterns []agentpatterns.Pattern) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := agentpatterns.Save(dir, patterns); err != nil {
+		t.Fatalf("save patterns: %v", err)
+	}
+	return dir
+}
+
+// patternWithLastApplied returns a pattern with the given ID, confidence, and
+// last_applied unix timestamp.
+func patternWithLastApplied(id string, confidence float64, lastApplied int64) agentpatterns.Pattern {
+	return agentpatterns.Pattern{
+		ID:          id,
+		Kind:        "AgentPattern",
+		Trigger:     agentpatterns.Trigger{NaturalLanguage: id + " trigger"},
+		Steps:       []string{"step one"},
+		Category:    agentpatterns.CategoryCode,
+		Confidence:  confidence,
+		LastApplied: lastApplied,
+		IsCandidate: false,
+		Exemplars:   []string{"repo::e1"},
+	}
+}
+
+// nowSec is a fixed "now" for tests: 2026-05-20 00:00:00 UTC.
+const nowSec = int64(1747699200)
+
+// TestPatternDecayJob_OldPatternDecays verifies that a pattern with
+// last_applied > 30 days ago loses confidence by 0.05 on each decay cycle,
+// with 3 cycles totalling 0.15 decrease and eventually flooring at 0.2.
+func TestPatternDecayJob_OldPatternDecays(t *testing.T) {
+	// last_applied = 90 days ago — well past the 30-day threshold.
+	lastApplied := nowSec - 90*86400
+	p := patternWithLastApplied("decay-test", 0.6, lastApplied)
+	dir := makePatternDecayDir(t, []agentpatterns.Pattern{p})
+
+	groupDirs := map[string]string{"g": dir}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	// Each cycle decrements by DecayDeltaPer30Day = 0.05.
+	// Cycle 1: 0.6 → 0.55
+	// Cycle 2: 0.55 → 0.50
+	// Cycle 3: 0.50 → 0.45
+	expected := []float64{0.55, 0.50, 0.45}
+
+	for cycle, want := range expected {
+		job(nowSec)
+		pts, err := agentpatterns.Load(dir)
+		if err != nil {
+			t.Fatalf("load after cycle %d: %v", cycle+1, err)
+		}
+		pN := agentpatterns.ByID(pts, "decay-test")
+		if pN == nil {
+			t.Fatalf("pattern not found after cycle %d", cycle+1)
+		}
+		if abs64(pN.Confidence-want) > 1e-9 {
+			t.Errorf("cycle %d: expected confidence=%.4f, got %.4f", cycle+1, want, pN.Confidence)
+		}
+	}
+}
+
+// TestPatternDecayJob_Floor verifies that repeated decay cycles do not push
+// confidence below 0.2 (ConfidenceFloor).
+//
+// Starting at 0.5 and decrementing 0.05 per cycle: (0.5-0.2)/0.05 = 6 cycles
+// to hit the floor. We run 10 cycles to ensure no further decrease.
+func TestPatternDecayJob_Floor(t *testing.T) {
+	lastApplied := nowSec - 365*86400 // > 30 days ago
+	p := patternWithLastApplied("floor-test", 0.5, lastApplied)
+	dir := makePatternDecayDir(t, []agentpatterns.Pattern{p})
+
+	groupDirs := map[string]string{"g": dir}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	// Run 10 cycles — more than enough to hit the floor (needs 6).
+	for i := 0; i < 10; i++ {
+		job(nowSec)
+	}
+
+	patterns, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	result := agentpatterns.ByID(patterns, "floor-test")
+	if result == nil {
+		t.Fatal("pattern not found")
+	}
+	if result.Confidence < agentpatterns.ConfidenceFloor {
+		t.Errorf("floor breached: got %.4f, want >= %.4f", result.Confidence, agentpatterns.ConfidenceFloor)
+	}
+	if result.Confidence != agentpatterns.ConfidenceFloor {
+		t.Errorf("expected confidence at floor %.4f after 10 cycles, got %.4f", agentpatterns.ConfidenceFloor, result.Confidence)
+	}
+}
+
+// TestPatternDecayJob_RecentPatternNotDecayed verifies that a pattern applied
+// within the last 30 days is untouched.
+func TestPatternDecayJob_RecentPatternNotDecayed(t *testing.T) {
+	lastApplied := nowSec - 10*86400 // 10 days ago — within grace window
+	p := patternWithLastApplied("recent-test", 0.8, lastApplied)
+	dir := makePatternDecayDir(t, []agentpatterns.Pattern{p})
+
+	groupDirs := map[string]string{"g": dir}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	job(nowSec)
+	patterns, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	result := agentpatterns.ByID(patterns, "recent-test")
+	if result == nil {
+		t.Fatal("pattern not found")
+	}
+	if result.Confidence != 0.8 {
+		t.Errorf("recently-applied pattern should not decay: got %.4f, want 0.8", result.Confidence)
+	}
+}
+
+// TestPatternDecayJob_NeverAppliedPatternNotDecayed verifies patterns that
+// have never been applied (last_applied == 0) are skipped.
+func TestPatternDecayJob_NeverAppliedPatternNotDecayed(t *testing.T) {
+	p := patternWithLastApplied("never-applied", 0.4, 0) // last_applied = 0
+	dir := makePatternDecayDir(t, []agentpatterns.Pattern{p})
+
+	groupDirs := map[string]string{"g": dir}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	job(nowSec)
+	patterns, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	result := agentpatterns.ByID(patterns, "never-applied")
+	if result == nil {
+		t.Fatal("pattern not found")
+	}
+	if result.Confidence != 0.4 {
+		t.Errorf("never-applied pattern should not decay: got %.4f", result.Confidence)
+	}
+}
+
+// TestPatternDecayJob_AlreadyAtFloor verifies that a pattern already at
+// confidence floor is skipped (no file write needed).
+func TestPatternDecayJob_AlreadyAtFloor(t *testing.T) {
+	lastApplied := nowSec - 365*86400
+	p := patternWithLastApplied("at-floor", agentpatterns.ConfidenceFloor, lastApplied)
+	dir := makePatternDecayDir(t, []agentpatterns.Pattern{p})
+
+	// Record file mtime before.
+	statBefore, _ := os.Stat(filepath.Join(dir, "patterns.json"))
+	mtimeBefore := statBefore.ModTime()
+
+	groupDirs := map[string]string{"g": dir}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	job(nowSec)
+
+	statAfter, _ := os.Stat(filepath.Join(dir, "patterns.json"))
+	if statAfter.ModTime().After(mtimeBefore) {
+		// File was rewritten; verify content unchanged.
+		patterns, _ := agentpatterns.Load(dir)
+		result := agentpatterns.ByID(patterns, "at-floor")
+		if result.Confidence < agentpatterns.ConfidenceFloor {
+			t.Errorf("floor breached: got %.4f", result.Confidence)
+		}
+	}
+	// Either way, confidence must still be at floor.
+	patterns, err := agentpatterns.Load(dir)
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	result := agentpatterns.ByID(patterns, "at-floor")
+	if result.Confidence < agentpatterns.ConfidenceFloor {
+		t.Errorf("floor breached: %.4f", result.Confidence)
+	}
+}
+
+// TestPatternDecayJob_MultiGroup verifies that multiple groups are all processed.
+func TestPatternDecayJob_MultiGroup(t *testing.T) {
+	lastApplied := nowSec - 60*86400 // 2 periods
+	p1 := patternWithLastApplied("grp1-p", 0.7, lastApplied)
+	p2 := patternWithLastApplied("grp2-p", 0.8, lastApplied)
+
+	dir1 := makePatternDecayDir(t, []agentpatterns.Pattern{p1})
+	dir2 := makePatternDecayDir(t, []agentpatterns.Pattern{p2})
+
+	groupDirs := map[string]string{"g1": dir1, "g2": dir2}
+	job := buildPatternDecayJob(func() map[string]string { return groupDirs }, nil)
+
+	job(nowSec)
+
+	// One cycle = one tick: each pattern loses exactly DecayDeltaPer30Day.
+	for _, tc := range []struct {
+		dir, id string
+		start   float64
+	}{
+		{dir1, "grp1-p", 0.7},
+		{dir2, "grp2-p", 0.8},
+	} {
+		pts, err := agentpatterns.Load(tc.dir)
+		if err != nil {
+			t.Fatalf("load %s: %v", tc.dir, err)
+		}
+		result := agentpatterns.ByID(pts, tc.id)
+		if result == nil {
+			t.Errorf("pattern %s not found", tc.id)
+			continue
+		}
+		expected := tc.start - agentpatterns.DecayDeltaPer30Day
+		if abs64(result.Confidence-expected) > 1e-9 {
+			t.Errorf("%s: expected %.4f, got %.4f", tc.id, expected, result.Confidence)
+		}
+	}
+}
+
+func abs64(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/agentpatterns"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
@@ -48,6 +49,16 @@ type Config struct {
 	// RSSHistoryPath is where the scheduler persists per-repo observed
 	// peak RSS for predictor calibration. Empty disables history.
 	RSSHistoryPath string
+
+	// PatternDecayInterval controls how often the confidence time-decay
+	// pass runs. Default (zero value) → 6 hours. Set to a shorter interval
+	// for testing.
+	PatternDecayInterval time.Duration
+
+	// PatternGroupDirs is a function that returns a map of group-name →
+	// patterns directory (the dir that contains patterns.json). When nil,
+	// the decay scheduler is not started. Populated by cmd/archigraph.
+	PatternGroupDirs func() map[string]string
 }
 
 // Run starts the daemon. It blocks until either:
@@ -136,6 +147,22 @@ func Run(ctx context.Context, cfg Config) error {
 		}
 	}
 
+	// Pattern confidence time-decay scheduler — runs every 6 hours (or a
+	// caller-supplied interval for tests). Requires PatternGroupDirs to be
+	// non-nil; skipped gracefully when the caller has not provided it.
+	if cfg.PatternGroupDirs != nil {
+		decayInterval := cfg.PatternDecayInterval
+		if decayInterval <= 0 {
+			decayInterval = 6 * time.Hour
+		}
+		decayJob := buildPatternDecayJob(cfg.PatternGroupDirs, logger)
+		decaySched := agentpatterns.NewDecayScheduler(decayInterval, decayJob)
+		decayCtx, decayCancel := context.WithCancel(ctx)
+		go decaySched.Run(decayCtx)
+		defer decayCancel()
+		logger.Printf("pattern decay scheduler started interval=%s", decayInterval)
+	}
+
 	server := rpc.NewServer()
 	if err := server.RegisterName(proto.ServiceName, svc); err != nil {
 		return fmt.Errorf("register %s: %w", proto.ServiceName, err)
@@ -220,4 +247,63 @@ func (c *loggingConn) Read(p []byte) (int, error) {
 		c.log.Printf("conn read: %v", err)
 	}
 	return n, err
+}
+
+// buildPatternDecayJob constructs the DecayJob that the pattern decay scheduler
+// calls on each tick (every 6 hours by default).
+//
+// Decay rule (per ADR-0018 and γ spec):
+//
+//	For each pattern: if last_applied > 30 days ago AND confidence > 0.2,
+//	decrement by DecayDeltaPer30Day (0.05) on each scheduler tick, floored at
+//	ConfidenceFloor (0.2). Each tick is one decay step; the 30-day window is
+//	the eligibility threshold, not the delta size.
+func buildPatternDecayJob(groupDirs func() map[string]string, logger *log.Logger) agentpatterns.DecayJob {
+	return func(nowUnix int64) {
+		dirs := groupDirs()
+		for group, dir := range dirs {
+			if dir == "" {
+				continue
+			}
+			patterns, err := agentpatterns.Load(dir)
+			if err != nil {
+				if logger != nil {
+					logger.Printf("pattern decay: load %s: %v", group, err)
+				}
+				continue
+			}
+			changed := false
+			for i := range patterns {
+				p := &patterns[i]
+				if p.LastApplied == 0 {
+					continue // never applied — skip decay
+				}
+				daysSince := float64(nowUnix-p.LastApplied) / 86400.0
+				if daysSince <= 30 {
+					continue // within the 30-day grace window
+				}
+				if p.Confidence <= agentpatterns.ConfidenceFloor {
+					continue // already at floor
+				}
+				// Flat decrement per scheduler tick (not proportional to days).
+				before := p.Confidence
+				newConf := p.Confidence - agentpatterns.DecayDeltaPer30Day
+				if newConf < agentpatterns.ConfidenceFloor {
+					newConf = agentpatterns.ConfidenceFloor
+				}
+				p.Confidence = newConf
+				if p.Confidence != before {
+					changed = true
+				}
+			}
+			if !changed {
+				continue
+			}
+			if err := agentpatterns.Save(dir, patterns); err != nil {
+				if logger != nil {
+					logger.Printf("pattern decay: save %s: %v", group, err)
+				}
+			}
+		}
+	}
 }

--- a/internal/mcp/patterns.go
+++ b/internal/mcp/patterns.go
@@ -1,9 +1,9 @@
 package mcp
 
-// patterns.go — MCP handler for archigraph_patterns (ADR-0018, PR β).
+// patterns.go — MCP handler for archigraph_patterns (ADR-0018, PR γ).
 //
-// Implements action=query and action=record. Actions refine|apply|reject|promote
-// are reserved for PR γ and return a "not implemented yet — γ" error.
+// Implements action=query, action=record (PR β), and the γ lifecycle actions:
+// refine, apply, reject, promote.
 //
 // Storage delegates entirely to internal/agentpatterns/. No duplicate logic.
 
@@ -64,13 +64,19 @@ func (s *Server) handlePatterns(ctx context.Context, req mcpapi.CallToolRequest)
 		return s.handlePatternsQuery(ctx, req)
 	case "record":
 		return s.handlePatternsRecord(ctx, req)
-	case "refine", "apply", "reject", "promote":
-		return mcpapi.NewToolResultError(fmt.Sprintf(
-			"action=%q not implemented yet — γ", action,
-		)), nil
+	case "refine":
+		return s.handlePatternsRefine(ctx, req)
+	case "apply":
+		return s.handlePatternsApply(ctx, req)
+	case "reject":
+		return s.handlePatternsReject(ctx, req)
+	case "promote":
+		return s.handlePatternsPromote(ctx, req)
+	case "get":
+		return s.handlePatternsGet(ctx, req)
 	default:
 		return mcpapi.NewToolResultError(fmt.Sprintf(
-			"unknown action %q (allowed in β: query, record)", action,
+			"unknown action %q (allowed: query, record, refine, apply, reject, promote, get)", action,
 		)), nil
 	}
 }
@@ -977,6 +983,7 @@ func patternToMap(p agentpatterns.Pattern, includePrivate bool) map[string]any {
 		"confidence":        p.Confidence,
 		"observations":      p.Observations,
 		"last_applied":      p.LastApplied,
+		"last_validated":    p.LastValidated,
 		"is_candidate":      p.IsCandidate,
 		"convergence_count": p.ConvergenceCount,
 		"exemplars":         p.Exemplars,
@@ -984,6 +991,19 @@ func patternToMap(p agentpatterns.Pattern, includePrivate bool) map[string]any {
 	}
 	if len(p.ProposerSubagents) > 0 {
 		out["proposer_subagents"] = p.ProposerSubagents
+	}
+	if len(p.Touches) > 0 {
+		out["touches"] = p.Touches
+	}
+	if len(p.AntiExemplars) > 0 {
+		out["anti_exemplars"] = p.AntiExemplars
+	}
+	if p.RejectReason != "" {
+		out["reject_reason"] = p.RejectReason
+		out["reject_timestamp"] = p.RejectTimestamp
+	}
+	if p.ApprovalNote != "" {
+		out["approval_note"] = p.ApprovalNote
 	}
 	return out
 }
@@ -1003,4 +1023,405 @@ func formatTimestamp(ts int64) string {
 		return ""
 	}
 	return time.Unix(ts, 0).UTC().Format(time.RFC3339)
+}
+
+// ---------------------------------------------------------------------------
+// action=get — single-id lookup (bypass BM25 ranking)
+// ---------------------------------------------------------------------------
+
+func (s *Server) handlePatternsGet(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	patternID, err := req.RequireString("pattern_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	includePrivate := argBool(req, "include_private", false)
+
+	groupName, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	dir := patternsDir(groupName, lg)
+	patterns, loadErr := agentpatterns.Load(dir)
+	if loadErr != nil {
+		return mcpapi.NewToolResultError("load patterns: " + loadErr.Error()), nil
+	}
+	p := agentpatterns.ByID(patterns, patternID)
+	if p == nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("pattern %q not found", patternID)), nil
+	}
+	return jsonResult(patternToMap(*p, includePrivate)), nil
+}
+
+// ---------------------------------------------------------------------------
+// action=refine
+// ---------------------------------------------------------------------------
+
+// handlePatternsRefine applies structural edits to an existing pattern.
+// Confidence is unchanged (refinement is neutral per ADR-0018).
+func (s *Server) handlePatternsRefine(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	patternID, err := req.RequireString("pattern_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	changes := argObject(req, "changes")
+	if changes == nil {
+		return mcpapi.NewToolResultError("changes is required for action=refine"), nil
+	}
+
+	groupName, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	dir := patternsDir(groupName, lg)
+
+	patternsMu.Lock()
+	defer patternsMu.Unlock()
+
+	patterns, loadErr := agentpatterns.Load(dir)
+	if loadErr != nil {
+		return mcpapi.NewToolResultError("load patterns: " + loadErr.Error()), nil
+	}
+	p := agentpatterns.ByID(patterns, patternID)
+	if p == nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("pattern %q not found", patternID)), nil
+	}
+
+	// Apply each change, collecting edge change descriptions.
+	var edgeChanges []map[string]any
+	now := agentpatterns.NowUnix()
+
+	// --- add_step ---
+	if v, ok := changes["add_step"].(string); ok && v != "" {
+		p.Steps = append(p.Steps, v)
+	}
+
+	// --- remove_step_index ---
+	if raw, ok := changes["remove_step_index"]; ok {
+		idx := toInt(raw)
+		if idx >= 0 && idx < len(p.Steps) {
+			p.Steps = append(p.Steps[:idx], p.Steps[idx+1:]...)
+		}
+	}
+
+	// --- edit_step: {index, new_text} ---
+	if m, ok := changes["edit_step"].(map[string]any); ok {
+		idx := toInt(m["index"])
+		newText, _ := m["new_text"].(string)
+		if idx >= 0 && idx < len(p.Steps) && newText != "" {
+			p.Steps[idx] = newText
+		}
+	}
+
+	// --- add_anti_pattern: {do_not, reason, private} ---
+	if m, ok := changes["add_anti_pattern"].(map[string]any); ok {
+		ap := agentpatterns.AntiPattern{}
+		if v, ok2 := m["do_not"].(string); ok2 {
+			ap.DoNot = v
+		}
+		if v, ok2 := m["reason"].(string); ok2 {
+			ap.Reason = v
+		}
+		if v, ok2 := m["private"].(bool); ok2 {
+			ap.Private = v
+		}
+		p.AntiPatterns = append(p.AntiPatterns, ap)
+	}
+
+	// --- remove_anti_pattern_index ---
+	if raw, ok := changes["remove_anti_pattern_index"]; ok {
+		idx := toInt(raw)
+		if idx >= 0 && idx < len(p.AntiPatterns) {
+			p.AntiPatterns = append(p.AntiPatterns[:idx], p.AntiPatterns[idx+1:]...)
+		}
+	}
+
+	// --- add_exemplar ---
+	if v, ok := changes["add_exemplar"].(string); ok && v != "" {
+		if !containsString(p.Exemplars, v) {
+			p.Exemplars = append(p.Exemplars, v)
+			edgeChanges = append(edgeChanges, map[string]any{
+				"op":        "add",
+				"from":      p.ID,
+				"to":        v,
+				"edge_kind": "EXEMPLAR",
+			})
+		}
+	}
+
+	// --- remove_exemplar ---
+	if v, ok := changes["remove_exemplar"].(string); ok && v != "" {
+		if containsString(p.Exemplars, v) {
+			p.Exemplars = removeString(p.Exemplars, v)
+			edgeChanges = append(edgeChanges, map[string]any{
+				"op":        "remove",
+				"from":      p.ID,
+				"to":        v,
+				"edge_kind": "EXEMPLAR",
+			})
+		}
+	}
+
+	// --- change_scope: partial — only non-nil fields overwrite existing ---
+	if m, ok := changes["change_scope"].(map[string]any); ok {
+		if v := stringSliceFromAny(m["repos"]); v != nil {
+			p.Scope.Repos = v
+		}
+		if v := stringSliceFromAny(m["module_paths"]); v != nil {
+			p.Scope.ModulePaths = v
+		}
+		if v := stringSliceFromAny(m["languages"]); v != nil {
+			p.Scope.Languages = v
+		}
+		if v := stringSliceFromAny(m["stacks"]); v != nil {
+			p.Scope.Stacks = v
+		}
+		if v := stringSliceFromAny(m["entity_kinds"]); v != nil {
+			p.Scope.EntityKinds = v
+		}
+	}
+
+	// --- change_category ---
+	if v, ok := changes["change_category"].(string); ok && v != "" {
+		cat := agentpatterns.Category(v)
+		if validCategories[cat] {
+			p.Category = cat
+		}
+	}
+
+	// --- set_documentation_url ---
+	if v, ok := changes["set_documentation_url"].(string); ok {
+		p.DocumentationURL = v
+	}
+
+	// Refinement is neutral — confidence unchanged. Update last_validated.
+	p.LastValidated = now
+	// Increment observations (refinement is an interaction).
+	p.Observations++
+
+	patterns = agentpatterns.Upsert(patterns, *p)
+	if saveErr := agentpatterns.Save(dir, patterns); saveErr != nil {
+		return mcpapi.NewToolResultError("save patterns: " + saveErr.Error()), nil
+	}
+
+	return jsonResult(map[string]any{
+		"pattern":      patternToMap(*p, true),
+		"edge_changes": edgeChanges,
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// action=apply
+// ---------------------------------------------------------------------------
+
+// handlePatternsApply records a use outcome and adjusts confidence.
+func (s *Server) handlePatternsApply(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	patternID, err := req.RequireString("pattern_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	args := req.GetArguments()
+	successRaw, ok := args["success"]
+	if !ok {
+		return mcpapi.NewToolResultError("success is required for action=apply"), nil
+	}
+	success, _ := successRaw.(bool)
+	createdEntities := argStringSliceFromAny(req, "created_entities")
+
+	groupName, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	dir := patternsDir(groupName, lg)
+
+	patternsMu.Lock()
+	defer patternsMu.Unlock()
+
+	patterns, loadErr := agentpatterns.Load(dir)
+	if loadErr != nil {
+		return mcpapi.NewToolResultError("load patterns: " + loadErr.Error()), nil
+	}
+	p := agentpatterns.ByID(patterns, patternID)
+	if p == nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("pattern %q not found", patternID)), nil
+	}
+
+	now := agentpatterns.NowUnix()
+
+	// Confidence adjustment.
+	if success {
+		p.Confidence = agentpatterns.ApplyConfidenceDelta(p.Confidence, agentpatterns.EventApplySuccess)
+		p.LastApplied = now
+	} else {
+		p.Confidence = agentpatterns.ApplyConfidenceDelta(p.Confidence, agentpatterns.EventApplyFailure)
+	}
+	p.Observations++
+	p.LastValidated = now
+
+	// Build CREATED_BY edges with apply-call provenance.
+	applyCallID := fmt.Sprintf("apply:%s:%d", patternID[:8], now)
+	var createdByEdges []map[string]any
+	for _, eid := range createdEntities {
+		createdByEdges = append(createdByEdges, map[string]any{
+			"from":          eid,
+			"to":            p.ID,
+			"edge_kind":     "CREATED_BY",
+			"apply_call_id": applyCallID,
+			"success":       success,
+			"timestamp":     now,
+		})
+	}
+
+	patterns = agentpatterns.Upsert(patterns, *p)
+	if saveErr := agentpatterns.Save(dir, patterns); saveErr != nil {
+		return mcpapi.NewToolResultError("save patterns: " + saveErr.Error()), nil
+	}
+
+	return jsonResult(map[string]any{
+		"pattern":           patternToMap(*p, true),
+		"created_by_edges":  createdByEdges,
+		"created_by_count":  len(createdByEdges),
+		"apply_call_id":     applyCallID,
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// action=reject
+// ---------------------------------------------------------------------------
+
+// handlePatternsReject marks a pattern as rejected, adjusting confidence.
+func (s *Server) handlePatternsReject(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	patternID, err := req.RequireString("pattern_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	reason, err := req.RequireString("reason")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	setToZero := argBool(req, "set_to_zero", false)
+
+	groupName, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	dir := patternsDir(groupName, lg)
+
+	patternsMu.Lock()
+	defer patternsMu.Unlock()
+
+	patterns, loadErr := agentpatterns.Load(dir)
+	if loadErr != nil {
+		return mcpapi.NewToolResultError("load patterns: " + loadErr.Error()), nil
+	}
+	p := agentpatterns.ByID(patterns, patternID)
+	if p == nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("pattern %q not found", patternID)), nil
+	}
+
+	now := agentpatterns.NowUnix()
+
+	if setToZero {
+		// Hard-set to 0 (bypasses floor — intentional hard rejection).
+		// Note: normal floor is 0.2; set_to_zero explicitly overrides it.
+		p.Confidence = 0
+	} else {
+		p.Confidence = agentpatterns.ApplyConfidenceDelta(p.Confidence, agentpatterns.EventReject)
+	}
+	p.Observations++
+	p.LastValidated = now
+	p.RejectReason = reason
+	p.RejectTimestamp = now
+
+	patterns = agentpatterns.Upsert(patterns, *p)
+	if saveErr := agentpatterns.Save(dir, patterns); saveErr != nil {
+		return mcpapi.NewToolResultError("save patterns: " + saveErr.Error()), nil
+	}
+
+	return jsonResult(map[string]any{
+		"pattern":       patternToMap(*p, true),
+		"reject_reason": reason,
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// action=promote
+// ---------------------------------------------------------------------------
+
+// handlePatternsPromote promotes a candidate pattern to approved.
+func (s *Server) handlePatternsPromote(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	candidateID, err := req.RequireString("candidate_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	approvalNote := argString(req, "approval_note", "")
+
+	groupName, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	dir := patternsDir(groupName, lg)
+
+	patternsMu.Lock()
+	defer patternsMu.Unlock()
+
+	patterns, loadErr := agentpatterns.Load(dir)
+	if loadErr != nil {
+		return mcpapi.NewToolResultError("load patterns: " + loadErr.Error()), nil
+	}
+	p := agentpatterns.ByID(patterns, candidateID)
+	if p == nil {
+		return mcpapi.NewToolResultError(fmt.Sprintf("pattern %q not found", candidateID)), nil
+	}
+	if !p.IsCandidate {
+		return mcpapi.NewToolResultError(fmt.Sprintf(
+			"pattern %q is already approved (is_candidate=false); cannot promote again", candidateID,
+		)), nil
+	}
+
+	now := agentpatterns.NowUnix()
+	p.IsCandidate = false
+	p.LastValidated = now
+	if approvalNote != "" {
+		p.ApprovalNote = approvalNote
+	}
+
+	patterns = agentpatterns.Upsert(patterns, *p)
+	if saveErr := agentpatterns.Save(dir, patterns); saveErr != nil {
+		return mcpapi.NewToolResultError("save patterns: " + saveErr.Error()), nil
+	}
+
+	return jsonResult(patternToMap(*p, true)), nil
+}
+
+// ---------------------------------------------------------------------------
+// Helpers: slice utilities used by refine
+// ---------------------------------------------------------------------------
+
+// removeString removes the first occurrence of s from slice.
+func removeString(slice []string, s string) []string {
+	out := make([]string, 0, len(slice))
+	removed := false
+	for _, x := range slice {
+		if !removed && x == s {
+			removed = true
+			continue
+		}
+		out = append(out, x)
+	}
+	return out
+}
+
+// toInt converts an interface{} numeric to int. Returns -1 on failure.
+func toInt(v any) int {
+	switch t := v.(type) {
+	case int:
+		return t
+	case int64:
+		return int(t)
+	case float64:
+		return int(t)
+	case float32:
+		return int(t)
+	}
+	return -1
 }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1173,20 +1174,25 @@ func TestPatterns_RecordErrorCases(t *testing.T) {
 	}
 }
 
-// TestPatterns_GammaActionsNotImplemented verifies that γ actions return
-// "not implemented yet" errors.
-func TestPatterns_GammaActionsNotImplemented(t *testing.T) {
+// TestPatterns_GammaActionsImplemented verifies that γ lifecycle actions are
+// now implemented (no longer stubs) and return errors only for missing required
+// args, not for "not implemented" reasons.
+func TestPatterns_GammaActionsImplemented(t *testing.T) {
 	srv, _ := makePatternsServer(t)
 
+	// Each γ action should now return a real error (missing required arg) —
+	// NOT the "not implemented yet — γ" message.
 	for _, action := range []string{"refine", "apply", "reject", "promote"} {
 		res := callTool(t, srv, "archigraph_patterns", map[string]any{
 			"action": action,
+			// Intentionally missing required args to trigger validation errors.
 		})
 		if !res.IsError {
-			t.Errorf("expected error for γ action %q, got: %s", action, resultText(res))
+			t.Errorf("expected validation error for %q with missing args, got success", action)
 		}
-		if !strings.Contains(resultText(res), "γ") {
-			t.Errorf("expected γ mention in error for action=%q, got: %s", action, resultText(res))
+		txt := resultText(res)
+		if strings.Contains(txt, "not implemented yet") {
+			t.Errorf("action %q still returns stub error: %s", action, txt)
 		}
 	}
 }
@@ -1263,5 +1269,567 @@ func TestPatterns_EdgeEmission(t *testing.T) {
 		if e["edge_kind"] != "EXEMPLAR" {
 			t.Errorf("expected edge_kind=EXEMPLAR, got: %v", e["edge_kind"])
 		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// γ lifecycle action tests
+// ---------------------------------------------------------------------------
+
+// absF returns absolute value of a float64 (local helper for γ tests).
+func absF(x float64) float64 {
+	if x < 0 {
+		return -x
+	}
+	return x
+}
+
+// recordPattern is a helper that records a pattern and returns its id.
+func recordPattern(t *testing.T, srv *Server, nl string) string {
+	t.Helper()
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":   "record",
+		"trigger":  map[string]any{"natural_language": nl, "keywords": []any{"test"}},
+		"steps":    []any{"step A", "step B"},
+		"exemplars": []any{"myrepo::a1"},
+		"category": "code",
+	})
+	if res.IsError {
+		t.Fatalf("record error: %s", resultText(res))
+	}
+	var out struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+	return out.ID
+}
+
+// TestPatterns_RefineAddRemoveStep verifies that refine add/remove step works and persists.
+func TestPatterns_RefineAddRemoveStep(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "refine step test pattern")
+
+	// Add a step.
+	refRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes":    map[string]any{"add_step": "step C — added by refine"},
+	})
+	if refRes.IsError {
+		t.Fatalf("refine add_step error: %s", resultText(refRes))
+	}
+	var refOut struct {
+		Pattern map[string]any   `json:"pattern"`
+		EdgeChanges []map[string]any `json:"edge_changes"`
+	}
+	if err := json.Unmarshal([]byte(resultText(refRes)), &refOut); err != nil {
+		t.Fatalf("unmarshal refine: %v: %s", err, resultText(refRes))
+	}
+	steps, _ := refOut.Pattern["steps"].([]any)
+	if len(steps) != 3 {
+		t.Errorf("expected 3 steps after add_step, got %d: %v", len(steps), steps)
+	}
+	if steps[2] != "step C — added by refine" {
+		t.Errorf("unexpected step[2]: %v", steps[2])
+	}
+
+	// Remove step at index 0.
+	rem := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes":    map[string]any{"remove_step_index": float64(0)},
+	})
+	if rem.IsError {
+		t.Fatalf("refine remove_step_index error: %s", resultText(rem))
+	}
+	var remOut struct {
+		Pattern map[string]any `json:"pattern"`
+	}
+	if err := json.Unmarshal([]byte(resultText(rem)), &remOut); err != nil {
+		t.Fatalf("unmarshal refine remove: %v", err)
+	}
+	stepsAfter, _ := remOut.Pattern["steps"].([]any)
+	if len(stepsAfter) != 2 {
+		t.Errorf("expected 2 steps after remove, got %d: %v", len(stepsAfter), stepsAfter)
+	}
+	// step A was removed; remaining: step B and the added step C.
+	if stepsAfter[0] != "step B" {
+		t.Errorf("expected step B at [0] after remove, got: %v", stepsAfter[0])
+	}
+
+	// Verify confidence unchanged (neutral).
+	if conf, ok := remOut.Pattern["confidence"].(float64); ok {
+		if conf != 0.4 { // initial confidence from New()
+			t.Errorf("refine should not change confidence: got %v", conf)
+		}
+	}
+}
+
+// TestPatterns_RefineAddRemoveExemplar verifies add/remove exemplar produces correct edge change records.
+func TestPatterns_RefineAddRemoveExemplar(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "refine exemplar test pattern")
+
+	// Add exemplar.
+	addRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes":    map[string]any{"add_exemplar": "myrepo::a2"},
+	})
+	if addRes.IsError {
+		t.Fatalf("refine add_exemplar error: %s", resultText(addRes))
+	}
+	var addOut struct {
+		Pattern     map[string]any   `json:"pattern"`
+		EdgeChanges []map[string]any `json:"edge_changes"`
+	}
+	if err := json.Unmarshal([]byte(resultText(addRes)), &addOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(addOut.EdgeChanges) != 1 {
+		t.Errorf("expected 1 edge change for add_exemplar, got %d", len(addOut.EdgeChanges))
+	}
+	if addOut.EdgeChanges[0]["op"] != "add" || addOut.EdgeChanges[0]["edge_kind"] != "EXEMPLAR" {
+		t.Errorf("unexpected edge change: %v", addOut.EdgeChanges[0])
+	}
+	exemplars, _ := addOut.Pattern["exemplars"].([]any)
+	if len(exemplars) != 2 {
+		t.Errorf("expected 2 exemplars, got %d", len(exemplars))
+	}
+
+	// Remove exemplar.
+	remRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes":    map[string]any{"remove_exemplar": "myrepo::a2"},
+	})
+	if remRes.IsError {
+		t.Fatalf("refine remove_exemplar error: %s", resultText(remRes))
+	}
+	var remOut struct {
+		EdgeChanges []map[string]any `json:"edge_changes"`
+	}
+	if err := json.Unmarshal([]byte(resultText(remRes)), &remOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if len(remOut.EdgeChanges) != 1 || remOut.EdgeChanges[0]["op"] != "remove" {
+		t.Errorf("expected 1 remove edge change, got: %v", remOut.EdgeChanges)
+	}
+}
+
+// TestPatterns_RefineChangeScope verifies partial scope update (fields not provided preserved).
+func TestPatterns_RefineChangeScope(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "refine scope test pattern")
+
+	// Start by setting a scope.
+	callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes": map[string]any{
+			"change_scope": map[string]any{
+				"repos":     []any{"myrepo"},
+				"languages": []any{"go"},
+			},
+		},
+	})
+
+	// Now change only languages; repos must be preserved.
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "refine",
+		"pattern_id": id,
+		"changes": map[string]any{
+			"change_scope": map[string]any{
+				"languages": []any{"typescript"},
+			},
+		},
+	})
+	if res.IsError {
+		t.Fatalf("refine scope error: %s", resultText(res))
+	}
+	var out struct {
+		Pattern map[string]any `json:"pattern"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	scope, _ := out.Pattern["scope"].(map[string]any)
+	langs, _ := scope["languages"].([]any)
+	repos, _ := scope["repos"].([]any)
+	if len(langs) != 1 || langs[0] != "typescript" {
+		t.Errorf("expected languages=[typescript], got %v", langs)
+	}
+	if len(repos) != 1 || repos[0] != "myrepo" {
+		t.Errorf("expected repos=[myrepo] preserved, got %v", repos)
+	}
+}
+
+// TestPatterns_ApplySuccess verifies confidence += 0.1, observations++, CREATED_BY edges.
+func TestPatterns_ApplySuccess(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "apply success test pattern")
+
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":           "apply",
+		"pattern_id":       id,
+		"success":          true,
+		"created_entities": []any{"myrepo::new-entity-1", "myrepo::new-entity-2"},
+	})
+	if res.IsError {
+		t.Fatalf("apply error: %s", resultText(res))
+	}
+	var out struct {
+		Pattern        map[string]any   `json:"pattern"`
+		CreatedByEdges []map[string]any `json:"created_by_edges"`
+		CreatedByCount int              `json:"created_by_count"`
+		ApplyCallID    string           `json:"apply_call_id"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, resultText(res))
+	}
+
+	// confidence 0.4 + 0.1 = 0.5
+	conf, _ := out.Pattern["confidence"].(float64)
+	if absF(conf-0.5) > 1e-9 {
+		t.Errorf("expected confidence=0.5, got %v", conf)
+	}
+	// observations == 1
+	obs, _ := out.Pattern["observations"].(float64)
+	if int(obs) != 1 {
+		t.Errorf("expected observations=1, got %v", obs)
+	}
+	// CREATED_BY edges
+	if out.CreatedByCount != 2 {
+		t.Errorf("expected 2 created_by edges, got %d", out.CreatedByCount)
+	}
+	if len(out.CreatedByEdges) != 2 {
+		t.Errorf("expected 2 edges in created_by_edges, got %d", len(out.CreatedByEdges))
+	}
+	for _, e := range out.CreatedByEdges {
+		if e["edge_kind"] != "CREATED_BY" {
+			t.Errorf("expected edge_kind=CREATED_BY, got %v", e["edge_kind"])
+		}
+		if e["success"] != true {
+			t.Errorf("expected success=true on edge, got %v", e["success"])
+		}
+		if e["apply_call_id"] == "" {
+			t.Errorf("expected non-empty apply_call_id")
+		}
+	}
+	if out.ApplyCallID == "" {
+		t.Errorf("expected non-empty apply_call_id in response")
+	}
+	// last_applied must be set
+	if la, ok := out.Pattern["last_applied"].(float64); !ok || la == 0 {
+		t.Errorf("expected last_applied to be set, got %v", out.Pattern["last_applied"])
+	}
+}
+
+// TestPatterns_ApplyFailure verifies confidence -= 0.15 (floor at 0.2).
+func TestPatterns_ApplyFailure(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "apply failure test pattern")
+
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "apply",
+		"pattern_id": id,
+		"success":    false,
+	})
+	if res.IsError {
+		t.Fatalf("apply error: %s", resultText(res))
+	}
+	var out struct {
+		Pattern map[string]any `json:"pattern"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	// confidence 0.4 - 0.15 = 0.25
+	conf, _ := out.Pattern["confidence"].(float64)
+	if absF(conf-0.25) > 1e-9 {
+		t.Errorf("expected confidence=0.25, got %v", conf)
+	}
+	// last_applied should NOT be set on failure
+	if la, _ := out.Pattern["last_applied"].(float64); la != 0 {
+		t.Errorf("last_applied should not be set on failure, got %v", la)
+	}
+}
+
+// TestPatterns_ApplyFloorNotBroken verifies repeated failures floor at 0.2.
+func TestPatterns_ApplyFloorNotBroken(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "apply floor test pattern")
+
+	for i := 0; i < 10; i++ {
+		res := callTool(t, srv, "archigraph_patterns", map[string]any{
+			"action":     "apply",
+			"pattern_id": id,
+			"success":    false,
+		})
+		if res.IsError {
+			t.Fatalf("apply iteration %d error: %s", i, resultText(res))
+		}
+	}
+	getRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "get",
+		"pattern_id": id,
+	})
+	if getRes.IsError {
+		t.Fatalf("get error: %s", resultText(getRes))
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(resultText(getRes)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	conf, _ := out["confidence"].(float64)
+	if conf < 0.2 {
+		t.Errorf("confidence floor breached: got %v", conf)
+	}
+	if conf != 0.2 {
+		t.Errorf("expected confidence=0.2 (floor), got %v", conf)
+	}
+}
+
+// TestPatterns_RejectDelta verifies confidence -= 0.3 with set_to_zero=false.
+func TestPatterns_RejectDelta(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "reject delta test pattern")
+
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "reject",
+		"pattern_id": id,
+		"reason":     "outdated approach",
+	})
+	if res.IsError {
+		t.Fatalf("reject error: %s", resultText(res))
+	}
+	var out struct {
+		Pattern      map[string]any `json:"pattern"`
+		RejectReason string         `json:"reject_reason"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, resultText(res))
+	}
+	// confidence 0.4 - 0.3 = 0.2 (exactly at floor)
+	conf, _ := out.Pattern["confidence"].(float64)
+	if absF(conf-0.2) > 1e-9 {
+		t.Errorf("expected confidence=0.2, got %v", conf)
+	}
+	if out.RejectReason != "outdated approach" {
+		t.Errorf("expected reject_reason='outdated approach', got %q", out.RejectReason)
+	}
+	// reject_reason must persist on pattern too
+	if rr, _ := out.Pattern["reject_reason"].(string); rr != "outdated approach" {
+		t.Errorf("expected pattern.reject_reason to be set, got %q", rr)
+	}
+	if ts, _ := out.Pattern["reject_timestamp"].(float64); ts == 0 {
+		t.Errorf("expected reject_timestamp to be set")
+	}
+}
+
+// TestPatterns_RejectSetToZero verifies confidence is hard-set to 0 with set_to_zero=true.
+func TestPatterns_RejectSetToZero(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "reject zero test pattern")
+
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":       "reject",
+		"pattern_id":   id,
+		"reason":       "completely wrong",
+		"set_to_zero":  true,
+	})
+	if res.IsError {
+		t.Fatalf("reject error: %s", resultText(res))
+	}
+	var out struct {
+		Pattern map[string]any `json:"pattern"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	conf, _ := out.Pattern["confidence"].(float64)
+	if conf != 0.0 {
+		t.Errorf("expected confidence=0 with set_to_zero=true, got %v", conf)
+	}
+}
+
+// TestPatterns_PromoteCandidate verifies is_candidate flips to false on promote.
+func TestPatterns_PromoteCandidate(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+
+	// Record as candidate.
+	recRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":       "record",
+		"trigger":      map[string]any{"natural_language": "promote test pattern"},
+		"steps":        []any{"do the thing"},
+		"exemplars":    []any{"myrepo::a1"},
+		"category":     "code",
+		"as_candidate": true,
+	})
+	if recRes.IsError {
+		t.Fatalf("record error: %s", resultText(recRes))
+	}
+	var recOut struct{ ID string `json:"id"` }
+	if err := json.Unmarshal([]byte(resultText(recRes)), &recOut); err != nil {
+		t.Fatalf("unmarshal record: %v", err)
+	}
+
+	// Promote.
+	promRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":        "promote",
+		"candidate_id":  recOut.ID,
+		"approval_note": "reviewed and approved in sprint S19",
+	})
+	if promRes.IsError {
+		t.Fatalf("promote error: %s", resultText(promRes))
+	}
+	var promOut map[string]any
+	if err := json.Unmarshal([]byte(resultText(promRes)), &promOut); err != nil {
+		t.Fatalf("unmarshal promote: %v: %s", err, resultText(promRes))
+	}
+	if isCand, _ := promOut["is_candidate"].(bool); isCand {
+		t.Errorf("expected is_candidate=false after promote, got true")
+	}
+	if note, _ := promOut["approval_note"].(string); note != "reviewed and approved in sprint S19" {
+		t.Errorf("expected approval_note to be set, got %q", note)
+	}
+	if lv, _ := promOut["last_validated"].(float64); lv == 0 {
+		t.Errorf("expected last_validated to be set after promote")
+	}
+}
+
+// TestPatterns_PromoteAlreadyApproved verifies error when promoting a non-candidate.
+func TestPatterns_PromoteAlreadyApproved(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+
+	// Record as candidate so we can promote.
+	recRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":       "record",
+		"trigger":      map[string]any{"natural_language": "promote twice test pattern"},
+		"steps":        []any{"do the thing"},
+		"exemplars":    []any{"myrepo::a1"},
+		"category":     "code",
+		"as_candidate": true,
+	})
+	if recRes.IsError {
+		t.Fatalf("record error: %s", resultText(recRes))
+	}
+	var recOut struct{ ID string `json:"id"` }
+	if err := json.Unmarshal([]byte(resultText(recRes)), &recOut); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// First promote: should succeed.
+	promRes1 := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":       "promote",
+		"candidate_id": recOut.ID,
+	})
+	if promRes1.IsError {
+		t.Fatalf("first promote should succeed: %s", resultText(promRes1))
+	}
+
+	// Second promote on already-approved pattern → error.
+	promRes2 := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":       "promote",
+		"candidate_id": recOut.ID,
+	})
+	if !promRes2.IsError {
+		t.Errorf("expected error promoting already-approved pattern, got: %s", resultText(promRes2))
+	}
+}
+
+// TestPatterns_GetByID verifies get action returns a pattern directly by id.
+func TestPatterns_GetByID(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "get by id test pattern")
+
+	getRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "get",
+		"pattern_id": id,
+	})
+	if getRes.IsError {
+		t.Fatalf("get error: %s", resultText(getRes))
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(resultText(getRes)), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if out["id"] != id {
+		t.Errorf("expected id=%q, got %v", id, out["id"])
+	}
+	if steps, _ := out["steps"].([]any); len(steps) != 2 {
+		t.Errorf("expected 2 steps, got %v", steps)
+	}
+}
+
+// TestPatterns_GetNotFound verifies get returns error for unknown id.
+func TestPatterns_GetNotFound(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	res := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "get",
+		"pattern_id": "nonexistentdeadbeef",
+	})
+	if !res.IsError {
+		t.Errorf("expected error for unknown pattern id, got: %s", resultText(res))
+	}
+}
+
+// TestPatterns_ConcurrentRefineApply verifies no torn writes with concurrent refine+apply.
+func TestPatterns_ConcurrentRefineApply(t *testing.T) {
+	srv, _ := makePatternsServer(t)
+	id := recordPattern(t, srv, "concurrent access test pattern")
+
+	const goroutines = 8
+	errs := make(chan string, goroutines*2)
+	done := make(chan struct{})
+
+	// Half goroutines refine, half apply; all race on the same pattern id.
+	for i := 0; i < goroutines; i++ {
+		i := i
+		go func() {
+			defer func() { done <- struct{}{} }()
+			var res *mcpapi.CallToolResult
+			if i%2 == 0 {
+				res = callTool(t, srv, "archigraph_patterns", map[string]any{
+					"action":     "refine",
+					"pattern_id": id,
+					"changes":    map[string]any{"add_step": fmt.Sprintf("concurrent step %d", i)},
+				})
+			} else {
+				res = callTool(t, srv, "archigraph_patterns", map[string]any{
+					"action":     "apply",
+					"pattern_id": id,
+					"success":    i%4 == 1,
+				})
+			}
+			if res.IsError {
+				errs <- resultText(res)
+			}
+		}()
+	}
+	for i := 0; i < goroutines; i++ {
+		<-done
+	}
+	close(errs)
+	for e := range errs {
+		t.Errorf("concurrent op error: %s", e)
+	}
+	// After all goroutines, pattern must still be loadable and valid.
+	getRes := callTool(t, srv, "archigraph_patterns", map[string]any{
+		"action":     "get",
+		"pattern_id": id,
+	})
+	if getRes.IsError {
+		t.Errorf("get after concurrent ops failed: %s", resultText(getRes))
+	}
+	var out map[string]any
+	if err := json.Unmarshal([]byte(resultText(getRes)), &out); err != nil {
+		t.Errorf("unmarshal after concurrent ops: %v", err)
+	}
+	// Confidence must be within valid bounds.
+	if conf, _ := out["confidence"].(float64); conf < 0.0 || conf > 1.0 {
+		t.Errorf("confidence out of bounds after concurrent ops: %v", conf)
 	}
 }


### PR DESCRIPTION
## Summary

Implements PR γ of ADR-0018: the four lifecycle actions (\`refine\`, \`apply\`, \`reject\`, \`promote\`) that complete the pattern flow, plus a \`get\` convenience action and the time-decay background job wired into the daemon.

Built on top of PR α (#707, merged) and PR β (#716, merged).

### What ships

#### Four new \`archigraph_patterns\` actions

**\`action=refine\`**
- Atomic structural edits: \`add_step\`, \`remove_step_index\`, \`edit_step\`, \`add_anti_pattern\`, \`remove_anti_pattern_index\`, \`add_exemplar\`, \`remove_exemplar\`, \`change_scope\` (partial — unset fields preserved), \`change_category\`, \`set_documentation_url\`
- Confidence unchanged (neutral per ADR-0018); \`last_validated\` updated
- Returns \`edge_changes\` list (add/remove EXEMPLAR edges)

**\`action=apply\`**
- \`success=true\` → confidence += 0.10 (cap 1.0), \`last_applied\` set
- \`success=false\` → confidence -= 0.15 (floor 0.2)
- \`created_entities\` → CREATED_BY edges with \`apply_call_id\` provenance (audit-clean)

**\`action=reject\`**
- \`set_to_zero=false\` (default) → confidence -= 0.30 (floor 0.2)
- \`set_to_zero=true\` → hard confidence = 0 (explicit override of floor)
- Persists \`reject_reason\` + \`reject_timestamp\` on pattern

**\`action=promote\`**
- Asserts \`is_candidate=true\`; flips to \`false\`; updates \`last_validated\`
- Optional \`approval_note\` persisted; error on double-promote

#### Bonus: \`action=get\`
Single-id lookup bypassing BM25 ranking — trivial but overkill-free.

#### Pattern struct additions (\`internal/agentpatterns/patterns.go\`)
- \`Touches []string\`, \`AntiExemplars []string\` (edge-type arrays)
- \`RejectReason\`, \`RejectTimestamp\`, \`ApprovalNote\` fields

#### Time-decay background job
- \`buildPatternDecayJob\`: flat -0.05 per 6-hour tick when \`last_applied > 30 days\` AND \`confidence > 0.2\`
- Wired in \`daemon.Run\` via \`agentpatterns.NewDecayScheduler\` + context-cancelled goroutine
- \`daemon.Config\` gains \`PatternDecayInterval\` (test override) + \`PatternGroupDirs\`
- \`daemonPatternGroupDirs()\` in \`cmd/archigraph/daemon.go\`

## Files changed

| File | Change |
|------|--------|
| \`internal/mcp/patterns.go\` | Add refine/apply/reject/promote/get handlers + edge helpers |
| \`internal/agentpatterns/patterns.go\` | Add Touches, AntiExemplars, RejectReason, RejectTimestamp, ApprovalNote |
| \`internal/daemon/server.go\` | Wire DecayScheduler + buildPatternDecayJob + Config fields |
| \`cmd/archigraph/daemon.go\` | Wire PatternGroupDirs + daemonPatternGroupDirs() |
| \`internal/mcp/server_test.go\` | 14 new γ tests |
| \`internal/daemon/pattern_decay_test.go\` | 6 new decay tests |

## Test count: 19 new tests (0 FAIL)

### γ MCP tests (14):
1. \`TestPatterns_GammaActionsImplemented\` — stubs gone
2. \`TestPatterns_RefineAddRemoveStep\` — add + remove step + confidence neutral
3. \`TestPatterns_RefineAddRemoveExemplar\` — EXEMPLAR edge_changes
4. \`TestPatterns_RefineChangeScope\` — partial scope update
5. \`TestPatterns_ApplySuccess\` — +0.1, last_applied, CREATED_BY edges
6. \`TestPatterns_ApplyFailure\` — -0.15, last_applied NOT set
7. \`TestPatterns_ApplyFloorNotBroken\` — 10 failures → floor 0.2
8. \`TestPatterns_RejectDelta\` — -0.3 delta, reject_reason persisted
9. \`TestPatterns_RejectSetToZero\` — confidence=0
10. \`TestPatterns_PromoteCandidate\` — is_candidate→false, approval_note
11. \`TestPatterns_PromoteAlreadyApproved\` — error on double-promote
12. \`TestPatterns_GetByID\` — direct id lookup
13. \`TestPatterns_GetNotFound\` — error for unknown id
14. \`TestPatterns_ConcurrentRefineApply\` — 8 goroutines, no torn writes

### Decay job tests (6):
1. \`TestPatternDecayJob_OldPatternDecays\` — 3 cycles × -0.05 from 0.6 → 0.45
2. \`TestPatternDecayJob_Floor\` — 10 cycles floors at 0.2
3. \`TestPatternDecayJob_RecentPatternNotDecayed\` — 10-day-old untouched
4. \`TestPatternDecayJob_NeverAppliedPatternNotDecayed\` — last_applied=0 skipped
5. \`TestPatternDecayJob_AlreadyAtFloor\` — no-op at floor
6. \`TestPatternDecayJob_MultiGroup\` — two groups both decayed

\`go test ./... -count=1\` — **0 FAIL** across all packages.

## Decay scheduler integration point

\`daemon.Run\` (\`internal/daemon/server.go\`, after watcher init):
```go
if cfg.PatternGroupDirs != nil {
    decaySched := agentpatterns.NewDecayScheduler(decayInterval, buildPatternDecayJob(...))
    go decaySched.Run(decayCtx)
}
```

## Daemon cleanup

No daemon spawned during γ tests (pure \`t.TempDir()\` unit tests). **0 PIDs killed.**

Closes #675

🤖 Generated with [Claude Code](https://claude.com/claude-code)