### PR TITLE
[#710][#711][ts] Same-file destructure REFERENCES + define-then-export edges

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -802,6 +802,21 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 		case "shorthand_property_identifier_pattern":
 			name := x.nodeText(p)
 			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s }", sigPrefix, name))
+		case "object_assignment_pattern":
+			// `{ foo = defaultValue }` — tree-sitter wraps the
+			// shorthand identifier in an object_assignment_pattern when
+			// a default value is present. The bound local is the LHS;
+			// we ignore the RHS default-value expression for entity
+			// emission (#710 — destructure-with-defaults).
+			if left := p.ChildByFieldName("left"); left != nil {
+				switch left.Type() {
+				case "shorthand_property_identifier_pattern", "identifier":
+					name := x.nodeText(left)
+					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s = ... }", sigPrefix, name))
+				default:
+					walk(left)
+				}
+			}
 		case "pair_pattern":
 			// `{ key: value }` — value can be identifier, nested object_pattern,
 			// array_pattern, or assignment_pattern (default value).

--- a/internal/extractors/javascript/references.go
+++ b/internal/extractors/javascript/references.go
@@ -109,8 +109,11 @@ type fileSymbol struct {
 // emitReferences is the second-pass entry point invoked from Extract
 // AFTER x.walk() has populated x.entities. It (1) builds the file-scope
 // symbol table from emitted entities, (2) walks every function-like
-// body in the tree, and (3) appends REFERENCES edges to the enclosing
-// function entity. Mutates x.entities in place.
+// body in the tree appending REFERENCES edges to the enclosing
+// function entity, and (3) processes `export { ... }` statements,
+// emitting REFERENCES edges from the file entity to each named const
+// (issue #711 — define-then-export pattern). Mutates x.entities in
+// place.
 //
 // Safe to call with an empty entity slice — degenerates to a no-op. Safe
 // to call when the file has no function bodies — degenerates to a no-op.
@@ -131,12 +134,22 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 	// x.entities. We need it to append REFERENCES edges to the
 	// enclosing function entity below.
 	entIdxByName := make(map[string]int)
+	// fileEntIdx is the index of the file-level SCOPE.Component entity
+	// for this source file (emitted in Extract before walk). Used as
+	// the from-attribution for #711 export-clause REFERENCES so the
+	// const_call entity that backs an `export { X }` clause gets a real
+	// inbound edge from the file. Defaults to -1 (no file entity), in
+	// which case the #711 emission is skipped.
+	fileEntIdx := -1
 	for i := range x.entities {
 		e := &x.entities[i]
 		if e.SourceFile != x.filePath {
 			continue
 		}
 		if e.Subtype == "file" {
+			if fileEntIdx == -1 {
+				fileEntIdx = i
+			}
 			continue
 		}
 		// First emission wins on duplicate names (matches Phase-1
@@ -165,8 +178,9 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 
 	// seen dedupes (fromName, toName) pairs across the entire file so a
 	// function that uses the same identifier N times produces a single
-	// REFERENCES edge.
-	type edgeKey struct{ from, to string }
+	// REFERENCES edge. Shared with Phase 3 (#711 export-clause emission)
+	// so a file-from edge can't accidentally double-emit when the same
+	// const is also referenced inside another function body.
 	seen := make(map[edgeKey]bool)
 
 	// Emit one REFERENCES edge from the enclosing function (top of
@@ -286,9 +300,24 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 				if name != "" {
 					if _, isGlobal := jsGlobals[name]; !isGlobal {
 						if _, isBuiltin := tsBuiltinTypes[name]; !isBuiltin || nt != "type_identifier" {
-							if _, isLocal := symbols[name]; isLocal {
-								if !isDeclarationPosition(n) && !isCallCallee(n) {
-									emit(fstack, name)
+							if sym, isLocal := symbols[name]; isLocal {
+								if !isDeclarationPosition(n) {
+									// #710 — Same-file destructure binding
+									// references in call position. CALLS edges
+									// resolve to Operation-kinded targets only;
+									// a SCOPE.Component target (const_destructure,
+									// const_call, const, const_alias, …) would
+									// never bind via CALLS, so the entity stays
+									// orphaned. Emit REFERENCES from the
+									// enclosing function frame so the binding
+									// gains an inbound edge. CALLS-eligible
+									// (Operation) targets still skip — those
+									// remain owned by the CALLS pathway and an
+									// additive REFERENCES edge would double-count.
+									callee := isCallCallee(n)
+									if !callee || sym.kind == "SCOPE.Component" {
+										emit(fstack, name)
+									}
 								}
 							}
 						}
@@ -316,7 +345,119 @@ func (x *extractor) emitReferences(root *sitter.Node) {
 	}
 
 	walk(root, nil)
+
+	// Phase 3 — #711 define-then-export.
+	// `const X = createIcon(...); export { X };` produces a const_call
+	// entity for X but no incoming edge: the export clause is a separate
+	// AST statement and the const itself has no usage inside the file.
+	// Wire the export by emitting a REFERENCES edge from the file entity
+	// to each export-specifier whose `name` matches a same-file symbol.
+	//
+	// Skipped shapes:
+	//   - Re-exports with a `source` field: `export { X } from './foo'`
+	//     — X here is NOT a same-file declaration (it's a binding being
+	//     forwarded from another module); emitting a same-file
+	//     REFERENCES would attribute the edge to the wrong entity.
+	//   - `export *` (no specifiers): documented gap; the resolver
+	//     handles wildcard re-exports through the IMPORTS path.
+	//
+	// Rename shape: `export { X as Y }` — the local-binding name
+	// is the `name` field (X); the alias (Y) is the externally
+	// visible name. We bind to X because X is the same-file entity;
+	// downstream consumers that import Y resolve via the file-level
+	// barrel index, not via this in-file REFERENCES edge.
+	if fileEntIdx >= 0 {
+		x.emitExportClauseReferences(root, symbols, fileEntIdx, seen)
+	}
 }
+
+// emitExportClauseReferences walks the AST looking for `export_statement`
+// nodes that carry an `export_clause` of named specifiers (and no
+// `source` field — re-exports forwarding from another module are skipped).
+// For each specifier whose local-binding name matches a same-file symbol,
+// it appends a REFERENCES edge from the file entity to the named symbol
+// using the same Format-A structural-ref the regular emit path produces.
+//
+// Issue #711.
+func (x *extractor) emitExportClauseReferences(
+	root *sitter.Node,
+	symbols map[string]fileSymbol,
+	fileEntIdx int,
+	seen map[edgeKey]bool,
+) {
+	if root == nil {
+		return
+	}
+	fromName := x.entities[fileEntIdx].Name
+	var visit func(n *sitter.Node)
+	visit = func(n *sitter.Node) {
+		if n == nil {
+			return
+		}
+		nt := n.Type()
+		if nt == "export_statement" {
+			// Skip re-exports like `export { X } from './baz'` —
+			// the source field signals the binding originates from
+			// another module, so X is not a same-file declaration.
+			if src := n.ChildByFieldName("source"); src == nil {
+				// Find the export_clause child (named specifiers).
+				count := int(n.ChildCount())
+				for i := 0; i < count; i++ {
+					c := n.Child(i)
+					if c == nil {
+						continue
+					}
+					if c.Type() != "export_clause" {
+						continue
+					}
+					// Iterate export_specifier children.
+					sc := int(c.ChildCount())
+					for j := 0; j < sc; j++ {
+						sp := c.Child(j)
+						if sp == nil || sp.Type() != "export_specifier" {
+							continue
+						}
+						// Local binding name is the `name` field;
+						// `alias` (when present) is the external name.
+						nameNode := sp.ChildByFieldName("name")
+						if nameNode == nil {
+							continue
+						}
+						local := x.nodeText(nameNode)
+						if local == "" {
+							continue
+						}
+						sym, ok := symbols[local]
+						if !ok {
+							continue
+						}
+						key := edgeKey{fromName, local}
+						if seen[key] {
+							continue
+						}
+						seen[key] = true
+						toID := buildReferenceTargetID(x.language, x.filePath, local, sym.kind)
+						x.entities[fileEntIdx].Relationships = append(
+							x.entities[fileEntIdx].Relationships,
+							types.RelationshipRecord{
+								ToID: toID,
+								Kind: "REFERENCES",
+							},
+						)
+					}
+				}
+			}
+		}
+		count := int(n.ChildCount())
+		for i := 0; i < count; i++ {
+			visit(n.Child(i))
+		}
+	}
+	visit(root)
+}
+
+// edgeKey is the dedup key for REFERENCES emission (file-scope).
+type edgeKey struct{ from, to string }
 
 // buildReferenceTargetID emits a Format A structural-ref so the resolver
 // routes through `lookupStructural` -> `lookupLocationKind` without any

--- a/internal/extractors/javascript/references_test.go
+++ b/internal/extractors/javascript/references_test.go
@@ -471,3 +471,256 @@ function use() { return A; }
 		t.Errorf("expected 1 REFERENCES from use, got %d", n)
 	}
 }
+
+// =============================================================================
+// Issue #710 — Same-file destructure binding REFERENCES.
+//
+// Destructured bindings (const { foo } = useHook()) emit a const_destructure
+// SCOPE.Component entity per local name. Same-file uses of that name must
+// produce a REFERENCES edge from the enclosing function frame to the
+// destructure entity, including when the use is in call position (CALLS
+// edges target Operation-kinded callees only, so the const_destructure
+// entity stays orphaned without an additive REFERENCES edge).
+// =============================================================================
+
+// anySameFileReferenceTo reports whether any entity in the slice has a
+// REFERENCES edge whose ToID trails with `:targetName`. Used when the
+// emitter attributes the edge to whichever same-file frame (parent
+// component or nested arrow-bound const) wraps the usage — what we care
+// about for orphan reduction is that SOMETHING in the file references
+// the destructure binding entity.
+func anySameFileReferenceTo(ents []types.EntityRecord, targetName string) bool {
+	suffix := ":" + targetName
+	for i := range ents {
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "REFERENCES" && strings.HasSuffix(r.ToID, suffix) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestReferences_DestructureBinding_SimpleObject — `const { foo } = obj`
+// then `foo()` inside the same function emits REFERENCES to foo. The
+// attribution lands on the nearest enclosing function-like frame; nested
+// arrow bound to a const wins over the outer component.
+func TestReferences_DestructureBinding_SimpleObject(t *testing.T) {
+	src := `function ReviewTabContent() {
+  const { onConfirmLeave } = useReviewLeaveGuard();
+  const handleClose = () => onConfirmLeave();
+  return handleClose;
+}
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !anySameFileReferenceTo(ents, "onConfirmLeave") {
+		t.Errorf("expected SOME same-file REFERENCES edge to onConfirmLeave; got from ReviewTabContent=%v, from handleClose=%v",
+			referencesFrom(ents, "ReviewTabContent"),
+			referencesFrom(ents, "handleClose"))
+	}
+}
+
+// TestReferences_DestructureBinding_Renamed — `const { foo: bar } = obj`
+// renames the property; the local binding name is bar. Same-file uses of
+// bar must REFERENCES the bar entity (not foo).
+func TestReferences_DestructureBinding_Renamed(t *testing.T) {
+	src := `function comp() {
+  const { mutate: createAddress } = useCreateAddress();
+  const onSave = () => createAddress();
+  return onSave;
+}
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasReferencesTo(ents, "comp", "createAddress") {
+		t.Errorf("expected REFERENCES comp->createAddress; got %v",
+			referencesFrom(ents, "comp"))
+	}
+	// Negative: should NOT bind to the property key 'mutate'.
+	for _, id := range referencesFrom(ents, "comp") {
+		if strings.HasSuffix(id, ":mutate") {
+			t.Errorf("unexpected REFERENCES to property key 'mutate': %s", id)
+		}
+	}
+}
+
+// TestReferences_DestructureBinding_WithDefault — `const { foo = "x" } = obj`
+// still binds foo; default value should not prevent REFERENCES emission.
+func TestReferences_DestructureBinding_WithDefault(t *testing.T) {
+	src := `function comp() {
+  const { onConfirm = noop } = props;
+  const fire = () => onConfirm();
+  return fire;
+}
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !anySameFileReferenceTo(ents, "onConfirm") {
+		t.Errorf("expected SOME same-file REFERENCES edge to onConfirm; got from comp=%v, from fire=%v",
+			referencesFrom(ents, "comp"), referencesFrom(ents, "fire"))
+	}
+}
+
+// TestReferences_DestructureBinding_ArrayPattern — `const [first, second] = arr`
+// emits one entity per identifier; same-file uses must REFERENCES the
+// binding entity.
+func TestReferences_DestructureBinding_ArrayPattern(t *testing.T) {
+	src := `function comp() {
+  const [first, second] = useState(0);
+  const show = () => first + second;
+  return show;
+}
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasReferencesTo(ents, "comp", "first") {
+		t.Errorf("expected REFERENCES comp->first; got %v",
+			referencesFrom(ents, "comp"))
+	}
+	if !hasReferencesTo(ents, "comp", "second") {
+		t.Errorf("expected REFERENCES comp->second; got %v",
+			referencesFrom(ents, "comp"))
+	}
+}
+
+// TestReferences_DestructureBinding_CallPosition — the destructured
+// binding is invoked as a function. CALLS would target an Operation
+// (which a SCOPE.Component const_destructure is not); REFERENCES must
+// still fire so the binding entity has an inbound edge.
+func TestReferences_DestructureBinding_CallPosition(t *testing.T) {
+	src := `function ReviewTabContent() {
+  const { onConfirmLeave } = useReviewLeaveGuard();
+  return <Foo onConfirm={() => onConfirmLeave(clearChecks)} />;
+}
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJS(t, src, "typescript", tree)
+
+	if !hasReferencesTo(ents, "ReviewTabContent", "onConfirmLeave") {
+		t.Errorf("expected REFERENCES ReviewTabContent->onConfirmLeave (call position); got %v",
+			referencesFrom(ents, "ReviewTabContent"))
+	}
+}
+
+// =============================================================================
+// Issue #711 — Define-then-export icon pattern.
+//
+// `const X = createIcon(...); export { X };` produces a const_call entity
+// for X but no inbound edge (X is never referenced inside the file; the
+// export clause is a separate statement). Emit REFERENCES from the file
+// entity to each named specifier whose binding is a same-file symbol.
+// =============================================================================
+
+// TestReferences_ExportClause_DefineThenExport — define-then-export
+// emits REFERENCES from the file entity to the named const.
+func TestReferences_ExportClause_DefineThenExport(t *testing.T) {
+	src := `const FlamingoIcon = createIcon({ viewBox: "0 0 24 24" });
+const HippoIcon = createIcon({ viewBox: "0 0 24 24" });
+export { FlamingoIcon, HippoIcon };
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJSPath(t, src, "typescript", tree, "icons.tsx")
+
+	// File entity carries the REFERENCES edges for export clauses.
+	file := findByNameRel(ents, "icons.tsx")
+	if file == nil {
+		t.Fatalf("file entity not found")
+	}
+	got := map[string]bool{}
+	for _, r := range file.Relationships {
+		if r.Kind == "REFERENCES" {
+			for _, name := range []string{"FlamingoIcon", "HippoIcon"} {
+				if strings.HasSuffix(r.ToID, ":"+name) {
+					got[name] = true
+				}
+			}
+		}
+	}
+	if !got["FlamingoIcon"] {
+		t.Errorf("expected REFERENCES file->FlamingoIcon; got %+v", file.Relationships)
+	}
+	if !got["HippoIcon"] {
+		t.Errorf("expected REFERENCES file->HippoIcon; got %+v", file.Relationships)
+	}
+}
+
+// TestReferences_ExportClause_RenamedExport — `export { X as Y }` binds
+// to the local name X (the `name` field of export_specifier).
+func TestReferences_ExportClause_RenamedExport(t *testing.T) {
+	src := `const FlamingoIcon = createIcon({});
+export { FlamingoIcon as Flamingo };
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJSPath(t, src, "typescript", tree, "icons.tsx")
+
+	file := findByNameRel(ents, "icons.tsx")
+	if file == nil {
+		t.Fatalf("file entity not found")
+	}
+	found := false
+	for _, r := range file.Relationships {
+		if r.Kind == "REFERENCES" && strings.HasSuffix(r.ToID, ":FlamingoIcon") {
+			found = true
+		}
+		if r.Kind == "REFERENCES" && strings.HasSuffix(r.ToID, ":Flamingo") {
+			t.Errorf("unexpected REFERENCES to alias name Flamingo: %s", r.ToID)
+		}
+	}
+	if !found {
+		t.Errorf("expected REFERENCES file->FlamingoIcon for `export { FlamingoIcon as Flamingo }`; got %+v", file.Relationships)
+	}
+}
+
+// TestReferences_ExportClause_MultipleSpecifiers — a single export
+// statement with N specifiers emits REFERENCES to each named const.
+func TestReferences_ExportClause_MultipleSpecifiers(t *testing.T) {
+	src := `const A = createIcon({});
+const B = createIcon({});
+const C = createIcon({});
+export { A, B, C };
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJSPath(t, src, "typescript", tree, "icons.tsx")
+
+	file := findByNameRel(ents, "icons.tsx")
+	if file == nil {
+		t.Fatalf("file entity not found")
+	}
+	for _, name := range []string{"A", "B", "C"} {
+		found := false
+		for _, r := range file.Relationships {
+			if r.Kind == "REFERENCES" && strings.HasSuffix(r.ToID, ":"+name) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected REFERENCES file->%s; got %+v", name, file.Relationships)
+		}
+	}
+}
+
+// TestReferences_ExportClause_ReExportSkipped — `export { X } from './baz'`
+// is a re-export forwarding from another module; X is NOT a same-file
+// declaration and MUST NOT receive a REFERENCES edge from the file.
+func TestReferences_ExportClause_ReExportSkipped(t *testing.T) {
+	src := `export { Foo } from './baz';
+`
+	tree := parseJSRel(t, []byte(src))
+	ents := runJSPath(t, src, "typescript", tree, "barrel.ts")
+
+	file := findByNameRel(ents, "barrel.ts")
+	if file == nil {
+		t.Fatalf("file entity not found")
+	}
+	for _, r := range file.Relationships {
+		if r.Kind == "REFERENCES" && strings.HasSuffix(r.ToID, ":Foo") {
+			t.Errorf("unexpected REFERENCES edge for re-export `export { Foo } from './baz'`: %s", r.ToID)
+		}
+	}
+}


### PR DESCRIPTION
Closes #710 and #711. Follow-up to #718 (#709).

## Summary

- **#710** — In `emitReferences`, relax the `isCallCallee` skip for `SCOPE.Component` targets. Destructure bindings (`const { onConfirmLeave } = useHook()`) now receive REFERENCES edges from same-file uses, including in call position (CALLS targets Operation-kinded callees only, so additive REFERENCES doesn't double-count).
- **#711** — New third pass walks `export_statement` nodes (without a `source` field), emits REFERENCES from the file entity to each `export_specifier`'s local-binding `name` when it matches a same-file symbol.
- **Beyond minimum** — `object_assignment_pattern` (the `{ foo = defaultValue }` tree-sitter shape) now produces a clean destructure entity. Renamed exports (`export { X as Y }`) bind to X. Re-exports (`export { Foo } from './baz'`) are skipped.

## Measurements

Single re-index per fixture under `ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-710-711`:

| fixture | post-#709 | post-#710+#711 | delta | spec target |
| --- | ---: | ---: | ---: | ---: |
| client-fixture-c | 6.21% | **3.7%** | −2.51pp | ≤3% (close, 0.7pp shy) |
| client-fixture-b | 5.74% | 5.2% | −0.54pp | ≤4% |
| client-fixture-e | 10.30% | 10.1% | −0.20pp | ≤7% |

fixture-c TS-language orphan rate: 6.4% → **3.6%** (−2.8pp).
TS `const_no_references`: 200 → **61** (−139). Destructure cluster (53) and define-then-export icon cluster (~103) fully connected.

fixture-b and fixture-e barely move because their remaining orphans are JS-side `const_no_references` not addressed by these two TS-pattern fixes — those will land on the JS pattern follow-up.

### Quality fixtures (all 100% must-have recall, 0 forbidden hits)

- typescript-react-mini
- go-chi-mini
- java-spring-mini
- python-django-mini
- rust-tokio-mini

Cross-language parity preserved — all edits confined to `internal/extractors/javascript/`.

## Remaining fixture-c const_no_references (61)

Sub-classes left for follow-up issues:
- `export const X = require(...)` in `components/assets/index.ts` (6 entities — const_call with no outbound edge; the `require()` target is an external asset path with no graph entity).
- Genuine dead-code consts (~21 per the fixture-c orphan investigation, 2026-05-20).
- TypeScript namespace exports (`namespace X { export const Y = ... }`) — not encountered in fixture-c sample; documented gap.
- `export *` star re-exports — by design, no specific name to reference; handled via IMPORTS path.

## Tests

New cases in `internal/extractors/javascript/references_test.go`:

- #710 — `DestructureBinding_SimpleObject`, `_Renamed`, `_WithDefault`, `_ArrayPattern`, `_CallPosition`
- #711 — `ExportClause_DefineThenExport`, `_RenamedExport`, `_MultipleSpecifiers`, `_ReExportSkipped`

All 9 pass; existing tests (including `TestReferences_TS_NonTSCorpusParity` from #709) unchanged.

## Test plan

- [x] `go test ./internal/extractors/javascript/...` — pass
- [x] `go test ./...` — pass
- [x] fixture-c, -b, -e re-indexed + audited
- [x] 5 quality fixtures: 100% recall, 0 forbidden hits
- [x] Daemon cleanup: ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-710-711, daemon stopped, PID 9483 confirmed dead

🤖 Generated with [Claude Code](https://claude.com/claude-code)