### PR TITLE
[#734] MCP surfaces doc-state nudge — archigraph_whoami enriched with documentation_state + suggested_action

### DIFF
--- a/internal/mcp/docstate.go
+++ b/internal/mcp/docstate.go
@@ -1,0 +1,207 @@
+package mcp
+
+// docstate.go — documentation-state tracking for archigraph_whoami (issue #734).
+//
+// Reads <group>/.archigraph/docgen-state.json (written by /generate-docs skill)
+// and computes:
+//
+//	documentation_state  "never_generated" | "stale" | "fresh"
+//	stale_count          count of source files modified after last_docgen_at
+//	suggested_action     human-readable next step for the agent to surface
+//
+// The file is also read by the MCP server to enrich the archigraph_whoami
+// response, enabling agents to proactively suggest documentation generation.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// DocgenState is the on-disk shape of docgen-state.json.
+// Written by the /generate-docs skill after a successful run;
+// read here by the MCP server and daemon helpers.
+type DocgenState struct {
+	// LastDocgenAt is the RFC3339 timestamp of the last /generate-docs run.
+	// Null / zero time means documentation has never been generated.
+	LastDocgenAt *time.Time `json:"last_docgen_at"`
+
+	// LastDocgenCommit is the git HEAD at the time of the last run (optional).
+	// Useful for staleness reasoning beyond mtime.
+	LastDocgenCommit string `json:"last_docgen_commit,omitempty"`
+
+	// GeneratedPaths is the list of doc files produced in the last run.
+	GeneratedPaths []string `json:"generated_paths,omitempty"`
+
+	// PerRepo holds per-repo timestamps (populated when partial regeneration
+	// was performed). Keys are repo names matching the registry entry.
+	PerRepo map[string]*time.Time `json:"per_repo,omitempty"`
+}
+
+// DocStateResult is the computed documentation state for one group.
+type DocStateResult struct {
+	// DocumentationState is "never_generated", "stale", or "fresh".
+	DocumentationState string `json:"documentation_state"`
+	// LastDocgenAt is the timestamp of the last doc-gen run, or nil.
+	LastDocgenAt *time.Time `json:"last_docgen_at"`
+	// StaleCount is the number of source files changed since the last run.
+	StaleCount int `json:"stale_count"`
+	// SuggestedAction is the human-readable next step.
+	SuggestedAction string `json:"suggested_action"`
+	// PerRepoStale maps repo name → stale file count for detailed reporting.
+	PerRepoStale map[string]int `json:"per_repo_stale,omitempty"`
+}
+
+// defaultDocstateDir returns ~/.archigraph/groups/<group>/ — the group-level
+// archigraph directory where docgen-state.json lives.
+func defaultDocstateDir(group string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", "groups", group)
+}
+
+// docstateFilePath returns the full path to docgen-state.json for a group.
+func docstateFilePath(group string) string {
+	return filepath.Join(defaultDocstateDir(group), "docgen-state.json")
+}
+
+// LoadDocgenState reads docgen-state.json for a group.
+// Returns nil (not error) when the file does not exist (never_generated).
+func LoadDocgenState(group string) (*DocgenState, error) {
+	path := docstateFilePath(group)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("docstate: read %s: %w", path, err)
+	}
+	var st DocgenState
+	if err := json.Unmarshal(data, &st); err != nil {
+		return nil, fmt.Errorf("docstate: parse %s: %w", path, err)
+	}
+	return &st, nil
+}
+
+// SaveDocgenState writes docgen-state.json atomically (tmp + rename).
+// This is called by the /generate-docs skill completion path.
+func SaveDocgenState(group string, st DocgenState) error {
+	dir := defaultDocstateDir(group)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("docstate: mkdir %s: %w", dir, err)
+	}
+	data, err := json.MarshalIndent(st, "", "  ")
+	if err != nil {
+		return fmt.Errorf("docstate: marshal: %w", err)
+	}
+	path := filepath.Join(dir, "docgen-state.json")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return fmt.Errorf("docstate: write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("docstate: rename: %w", err)
+	}
+	return nil
+}
+
+// ComputeDocState computes the documentation state for a loaded group.
+// - Reads docgen-state.json for the group.
+// - Walks every source file in every loaded repo to count stale files
+//   (mtime > last_docgen_at, per-repo and group-wide).
+// - Counts per-repo per-repo stale files separately for detailed surfacing.
+func ComputeDocState(groupName string, lg *LoadedGroup) DocStateResult {
+	state, err := LoadDocgenState(groupName)
+	if err != nil || state == nil || state.LastDocgenAt == nil {
+		return DocStateResult{
+			DocumentationState: "never_generated",
+			LastDocgenAt:       nil,
+			StaleCount:         0,
+			SuggestedAction:    "run /generate-docs",
+		}
+	}
+
+	lastDocgen := *state.LastDocgenAt
+	perRepoStale := map[string]int{}
+	totalStale := 0
+
+	for repoName, repo := range lg.Repos {
+		if repo == nil || repo.Doc == nil || repo.Path == "" {
+			continue
+		}
+
+		// Use per-repo timestamp when available (partial regeneration).
+		repoDocgen := lastDocgen
+		if state.PerRepo != nil {
+			if rt, ok := state.PerRepo[repoName]; ok && rt != nil {
+				repoDocgen = *rt
+			}
+		}
+
+		// Walk source files for this repo.
+		seen := map[string]bool{}
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+			abs := e.SourceFile
+			if !filepath.IsAbs(abs) && repo.Path != "" {
+				abs = filepath.Join(repo.Path, e.SourceFile)
+			}
+			if seen[abs] {
+				continue
+			}
+			seen[abs] = true
+
+			info, err := os.Stat(abs)
+			if err != nil {
+				continue
+			}
+			if info.ModTime().After(repoDocgen) {
+				perRepoStale[repoName]++
+				totalStale++
+			}
+		}
+	}
+
+	result := DocStateResult{
+		LastDocgenAt: state.LastDocgenAt,
+		StaleCount:   totalStale,
+	}
+	if len(perRepoStale) > 0 {
+		result.PerRepoStale = perRepoStale
+	}
+
+	if totalStale > 0 {
+		result.DocumentationState = "stale"
+		result.SuggestedAction = fmt.Sprintf("refresh docs — %d file(s) changed since last generation", totalStale)
+	} else {
+		result.DocumentationState = "fresh"
+		result.SuggestedAction = "none — graph is healthy"
+	}
+	return result
+}
+
+// composeSuggestedAction selects the highest-priority suggested_action given the
+// full state picture. Priority: stale docs > pattern candidates > residuals > healthy.
+func composeSuggestedAction(docState DocStateResult, candidateCount, residualCount int) string {
+	// Docs-first: if never generated or stale, that dominates.
+	if docState.DocumentationState == "never_generated" {
+		return "run /generate-docs"
+	}
+	if docState.DocumentationState == "stale" {
+		return fmt.Sprintf("refresh docs — %d file(s) changed since last generation", docState.StaleCount)
+	}
+	// Secondary: pattern candidates.
+	if candidateCount > 0 {
+		return fmt.Sprintf("review %d pending pattern candidate(s)", candidateCount)
+	}
+	// Tertiary: residual repairs.
+	if residualCount > 0 {
+		return fmt.Sprintf("review %d pending repair candidate(s)", residualCount)
+	}
+	return "none — graph is healthy"
+}

--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -1,0 +1,418 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// docstate unit tests
+// ---------------------------------------------------------------------------
+
+func TestLoadDocgenState_absent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	st, err := LoadDocgenState("mygroup")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if st != nil {
+		t.Fatalf("expected nil state for absent file, got %+v", st)
+	}
+}
+
+func TestLoadDocgenState_present(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	now := time.Now().UTC().Truncate(time.Second)
+	st := DocgenState{
+		LastDocgenAt:     &now,
+		LastDocgenCommit: "abc123",
+		GeneratedPaths:   []string{"docs/index.md"},
+	}
+	if err := SaveDocgenState("mygroup", st); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+
+	loaded, err := LoadDocgenState("mygroup")
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil state")
+	}
+	if !loaded.LastDocgenAt.Equal(now) {
+		t.Errorf("last_docgen_at: got %v want %v", loaded.LastDocgenAt, now)
+	}
+	if loaded.LastDocgenCommit != "abc123" {
+		t.Errorf("commit: got %q", loaded.LastDocgenCommit)
+	}
+}
+
+func TestComputeDocState_neverGenerated(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	lg := &LoadedGroup{Name: "g", Repos: map[string]*LoadedRepo{}}
+	res := ComputeDocState("g", lg)
+
+	if res.DocumentationState != "never_generated" {
+		t.Errorf("state: got %q want never_generated", res.DocumentationState)
+	}
+	if res.SuggestedAction != "run /generate-docs" {
+		t.Errorf("action: got %q", res.SuggestedAction)
+	}
+	if res.LastDocgenAt != nil {
+		t.Errorf("last_docgen_at: expected nil")
+	}
+}
+
+func TestComputeDocState_fresh(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// Create a repo with one source file.
+	repoDir := filepath.Join(tmp, "repo-a")
+	srcFile := filepath.Join(repoDir, "src", "app.go")
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Docgen happened *after* the file was written.
+	time.Sleep(5 * time.Millisecond) // ensure strict after
+	futureDocgen := time.Now().UTC()
+
+	st := DocgenState{LastDocgenAt: &futureDocgen}
+	if err := SaveDocgenState("g", st); err != nil {
+		t.Fatal(err)
+	}
+
+	lg := makeLoadedGroupWithFile(t, "g", "repo-a", repoDir, "src/app.go")
+	res := ComputeDocState("g", lg)
+
+	if res.DocumentationState != "fresh" {
+		t.Errorf("state: got %q want fresh", res.DocumentationState)
+	}
+	if res.StaleCount != 0 {
+		t.Errorf("stale_count: got %d want 0", res.StaleCount)
+	}
+	if res.SuggestedAction != "none — graph is healthy" {
+		t.Errorf("action: got %q", res.SuggestedAction)
+	}
+}
+
+func TestComputeDocState_stale(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	// Docgen happened *before* the file was written.
+	pastDocgen := time.Now().UTC().Add(-1 * time.Hour)
+	st := DocgenState{LastDocgenAt: &pastDocgen}
+	if err := SaveDocgenState("g", st); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create source file (mtime = now, after pastDocgen).
+	repoDir := filepath.Join(tmp, "repo-b")
+	srcFile := filepath.Join(repoDir, "src", "handler.go")
+	if err := os.MkdirAll(filepath.Dir(srcFile), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcFile, []byte("package main"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	lg := makeLoadedGroupWithFile(t, "g", "repo-b", repoDir, "src/handler.go")
+	res := ComputeDocState("g", lg)
+
+	if res.DocumentationState != "stale" {
+		t.Errorf("state: got %q want stale", res.DocumentationState)
+	}
+	if res.StaleCount != 1 {
+		t.Errorf("stale_count: got %d want 1", res.StaleCount)
+	}
+}
+
+func TestComposeSuggestedAction_transitions(t *testing.T) {
+	cases := []struct {
+		name           string
+		docState       DocStateResult
+		candidates     int
+		residuals      int
+		wantSubstring  string
+	}{
+		{
+			name:          "never_generated",
+			docState:      DocStateResult{DocumentationState: "never_generated"},
+			wantSubstring: "run /generate-docs",
+		},
+		{
+			name:          "stale",
+			docState:      DocStateResult{DocumentationState: "stale", StaleCount: 3},
+			wantSubstring: "refresh docs",
+		},
+		{
+			name:          "fresh_with_candidates",
+			docState:      DocStateResult{DocumentationState: "fresh"},
+			candidates:    2,
+			wantSubstring: "pattern candidate",
+		},
+		{
+			name:          "fresh_with_residuals",
+			docState:      DocStateResult{DocumentationState: "fresh"},
+			residuals:     5,
+			wantSubstring: "repair candidate",
+		},
+		{
+			name:          "all_fresh",
+			docState:      DocStateResult{DocumentationState: "fresh"},
+			wantSubstring: "graph is healthy",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := composeSuggestedAction(tc.docState, tc.candidates, tc.residuals)
+			if got == "" {
+				t.Fatal("empty suggested_action")
+			}
+			// Contains check.
+			if len(tc.wantSubstring) > 0 {
+				found := false
+				for i := 0; i <= len(got)-len(tc.wantSubstring); i++ {
+					if got[i:i+len(tc.wantSubstring)] == tc.wantSubstring {
+						found = true
+						break
+					}
+				}
+				if !found {
+					t.Errorf("suggested_action %q does not contain %q", got, tc.wantSubstring)
+				}
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Integration: archigraph_whoami returns enriched response
+// ---------------------------------------------------------------------------
+
+func TestHandleWhoami_enrichedResponse_neverGenerated(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "") // ensure nudge enabled
+
+	repoDir := filepath.Join(tmp, "repo-a")
+	doc := fixtureDoc("repo-a")
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(mcpapi.TextContent).Text), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	checkField(t, out, "documentation_state", "never_generated")
+	checkField(t, out, "suggested_action", "run /generate-docs")
+}
+
+func TestHandleWhoami_enrichedResponse_afterDocgen_fresh(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "")
+
+	repoDir := filepath.Join(tmp, "repo-a")
+	doc := fixtureDoc("repo-a")
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+
+	// Write docgen state in the future so no files appear stale.
+	futureTime := time.Now().UTC().Add(1 * time.Hour)
+	st := DocgenState{LastDocgenAt: &futureTime}
+	if err := SaveDocgenState("g", st); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(mcpapi.TextContent).Text), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	checkField(t, out, "documentation_state", "fresh")
+	checkField(t, out, "suggested_action", "none — graph is healthy")
+}
+
+func TestHandleWhoami_enrichedResponse_stale(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "")
+
+	// Write a source file to the repo dir.
+	repoDir := filepath.Join(tmp, "repo-a")
+	srcPath := filepath.Join(repoDir, "src", "DashboardScreen.tsx")
+	if err := os.MkdirAll(filepath.Dir(srcPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(srcPath, []byte("// code"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc := &graph.Document{
+		Repo: "repo-a",
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "DashboardScreen", SourceFile: "src/DashboardScreen.tsx", StartLine: 1, EndLine: 5},
+		},
+	}
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+
+	// Docgen happened before the source file was written.
+	pastDocgen := time.Now().UTC().Add(-2 * time.Hour)
+	st := DocgenState{LastDocgenAt: &pastDocgen}
+	if err := SaveDocgenState("g", st); err != nil {
+		t.Fatal(err)
+	}
+
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(mcpapi.TextContent).Text), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	checkField(t, out, "documentation_state", "stale")
+	sc, _ := out["stale_count"].(float64)
+	if sc < 1 {
+		t.Errorf("stale_count: got %v want >= 1", out["stale_count"])
+	}
+}
+
+func TestHandleWhoami_quietMode(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+	t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", "quiet")
+
+	repoDir := filepath.Join(tmp, "repo-a")
+	doc := fixtureDoc("repo-a")
+	writeGraph(t, repoDir, doc)
+
+	regPath := makeRegistry(t, tmp, map[string]map[string]string{
+		"g": {"repo-a": repoDir},
+	})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "g"}
+	res, err := srv.handleWhoami(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handleWhoami: %v", err)
+	}
+
+	var out map[string]any
+	if err := json.Unmarshal([]byte(res.Content[0].(mcpapi.TextContent).Text), &out); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// In quiet mode, documentation_state must NOT be present.
+	if _, found := out["documentation_state"]; found {
+		t.Error("documentation_state should be absent in quiet mode")
+	}
+	if _, found := out["suggested_action"]; found {
+		t.Error("suggested_action should be absent in quiet mode")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func checkField(t *testing.T, m map[string]any, key, want string) {
+	t.Helper()
+	got, ok := m[key].(string)
+	if !ok {
+		t.Errorf("field %q: missing or not string (got %T: %v)", key, m[key], m[key])
+		return
+	}
+	if got != want {
+		t.Errorf("field %q: got %q want %q", key, got, want)
+	}
+}
+
+// makeLoadedGroupWithFile builds a minimal LoadedGroup with one repo whose
+// entity graph has the given source file path relative to repoDir.
+func makeLoadedGroupWithFile(t *testing.T, groupName, repoName, repoDir, relFile string) *LoadedGroup {
+	t.Helper()
+	doc := &graph.Document{
+		Repo: repoName,
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "Foo", SourceFile: relFile, StartLine: 1, EndLine: 5},
+		},
+	}
+	lr := &LoadedRepo{
+		Repo: repoName,
+		Path: repoDir,
+		Doc:  doc,
+	}
+	return &LoadedGroup{
+		Name:  groupName,
+		Repos: map[string]*LoadedRepo{repoName: lr},
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -10,6 +10,31 @@ import (
 	mcpsrv "github.com/mark3labs/mcp-go/server"
 )
 
+// mcpInstructions is the handshake text returned to MCP clients on initialize.
+// It tells agents to call archigraph_whoami first and act on suggested_action.
+// The doc-gen flow (pattern discovery, repair sweep, ORM query extraction,
+// response shape extraction) must run before substantive graph queries are
+// reliable — this nudge ensures agents prompt the user when it hasn't run yet.
+const mcpInstructions = `archigraph — code graph MCP server
+
+On first connect in a session:
+  1. Call archigraph_whoami (with cwd= set to the caller's working directory).
+  2. Check the suggested_action field in the response.
+  3. If suggested_action is "run /generate-docs": proactively suggest to the
+     user that they trigger documentation generation before substantive queries.
+     Say something like: "I noticed archigraph is connected but documentation
+     hasn't been generated yet — want me to run /generate-docs now? It enables
+     pattern discovery, repair sweep, ORM query mapping, and response shape
+     extraction, which makes subsequent graph queries much more accurate."
+  4. If suggested_action starts with "refresh docs": surface that N files have
+     changed and offer to refresh. Example: "N files have changed since docs
+     were last generated — want me to refresh them?"
+  5. If suggested_action mentions "pattern candidates" or "repair candidates":
+     offer to review them after the user's immediate task is addressed.
+  6. If suggested_action is "none — graph is healthy": proceed normally.
+
+Set ARCHIGRAPH_WHOAMI_NUDGE=quiet to suppress doc-state fields (e.g. in CI).`
+
 // Config controls server construction.
 type Config struct {
 	RegistryPath string
@@ -43,7 +68,8 @@ func NewServer(cfg Config) (*Server, error) {
 	tel := NewTelemetry(cfg.DebugLevel)
 
 	srv := mcpsrv.NewMCPServer("archigraph", version.String(),
-		mcpsrv.WithToolCapabilities(true))
+		mcpsrv.WithToolCapabilities(true),
+		mcpsrv.WithInstructions(mcpInstructions))
 
 	s := &Server{State: st, Tel: tel, MCP: srv, cfg: cfg}
 	s.registerTools()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -163,12 +163,111 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 		}), nil
 	}
 	repo := repoFromCWD(cwd)
-	return jsonResult(map[string]any{
+
+	// Base response.
+	resp := map[string]any{
 		"group":         group,
 		"repo":          repo,
 		"source":        source,
 		"registry_path": s.State.registry.Path,
-	}), nil
+	}
+
+	// Nudge suppression: ARCHIGRAPH_WHOAMI_NUDGE=quiet disables doc-state fields.
+	if os.Getenv("ARCHIGRAPH_WHOAMI_NUDGE") == "quiet" {
+		return jsonResult(resp), nil
+	}
+
+	// Enrich with documentation state + action counts.
+	lg := s.State.Group(group)
+	if lg == nil {
+		return jsonResult(resp), nil
+	}
+
+	docState := ComputeDocState(group, lg)
+
+	// Count pattern candidates and residuals for suggested_action priority.
+	candidateCount := countPatternCandidates(group, lg)
+	residualCount := countResiduals(lg)
+
+	suggestedAction := composeSuggestedAction(docState, candidateCount, residualCount)
+
+	resp["documentation_state"] = docState.DocumentationState
+	resp["last_docgen_at"] = docState.LastDocgenAt
+	resp["stale_count"] = docState.StaleCount
+	resp["patterns_count"] = countPatterns(group, lg)
+	resp["candidate_count"] = candidateCount
+	resp["residual_count"] = residualCount
+	resp["suggested_action"] = suggestedAction
+	if len(docState.PerRepoStale) > 0 {
+		resp["per_repo_stale"] = docState.PerRepoStale
+	}
+
+	return jsonResult(resp), nil
+}
+
+// countPatterns returns the total number of patterns (candidate + approved) for a group.
+func countPatterns(groupName string, lg *LoadedGroup) int {
+	dir := patternsDir(groupName, lg)
+	patterns, err := loadPatternsQuiet(dir)
+	if err != nil {
+		return 0
+	}
+	return len(patterns)
+}
+
+// countPatternCandidates returns the number of is_candidate=true patterns.
+func countPatternCandidates(groupName string, lg *LoadedGroup) int {
+	dir := patternsDir(groupName, lg)
+	patterns, err := loadPatternsQuiet(dir)
+	if err != nil {
+		return 0
+	}
+	count := 0
+	for _, p := range patterns {
+		if p.IsCandidate {
+			count++
+		}
+	}
+	return count
+}
+
+// countResiduals returns the total repair_edge candidate count across all repos.
+func countResiduals(lg *LoadedGroup) int {
+	total := 0
+	for _, r := range lg.Repos {
+		if r == nil || r.Path == "" {
+			continue
+		}
+		total += len(readRepairEdgeCandidates(r.Path))
+	}
+	return total
+}
+
+// loadPatternsQuiet loads patterns without propagating errors (whoami must not fail).
+func loadPatternsQuiet(dir string) ([]patternForCount, error) {
+	if dir == "" {
+		return nil, nil
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "patterns.json"))
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	var env struct {
+		Patterns []patternForCount `json:"patterns"`
+	}
+	if err := json.Unmarshal(data, &env); err != nil {
+		return nil, err
+	}
+	return env.Patterns, nil
+}
+
+// patternForCount is a minimal pattern shape for counting — avoids importing
+// agentpatterns here (already imported in patterns.go; this avoids the cycle).
+type patternForCount struct {
+	IsCandidate bool `json:"is_candidate"`
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **New file `internal/mcp/docstate.go`** — doc-state tracking layer: `DocgenState` struct (mirrors `docgen-state.json` written by `/generate-docs`), `LoadDocgenState` / `SaveDocgenState` (atomic tmp+rename), `ComputeDocState` (walks every repo's source files for mtime-based staleness, per-repo granularity), `composeSuggestedAction` (priority: stale docs › pattern candidates › residuals › healthy).
- **`handleWhoami` enriched** (`internal/mcp/tools.go`) — response now includes `documentation_state`, `last_docgen_at`, `stale_count`, `patterns_count`, `candidate_count`, `residual_count`, `suggested_action`, and `per_repo_stale` (when any repo has stale files). Suppressed via `ARCHIGRAPH_WHOAMI_NUDGE=quiet` env var (CI / power-user opt-out).
- **MCP `instructions` handshake** (`internal/mcp/server.go`) — `mcpInstructions` constant wired into `mcpsrv.WithInstructions(...)` so agents receive the nudge text on every session initialize.
- **10 new tests** (`internal/mcp/docstate_test.go`) — unit + integration, all passing.

## Sample `archigraph_whoami` responses

**Fresh group (never generated):**
```json
{
  "group": "client-fixture",
  "documentation_state": "never_generated",
  "last_docgen_at": null,
  "stale_count": 0,
  "patterns_count": 0,
  "candidate_count": 0,
  "residual_count": 0,
  "suggested_action": "run /generate-docs"
}
```

**Stale (4 files changed since last docgen):**
```json
{
  "group": "client-fixture",
  "documentation_state": "stale",
  "last_docgen_at": "2026-05-18T10:00:00Z",
  "stale_count": 4,
  "per_repo_stale": { "client-fixture-a": 3, "client-fixture-b": 1 },
  "suggested_action": "refresh docs — 4 file(s) changed since last generation"
}
```

**Fresh with pending pattern candidates:**
```json
{
  "group": "client-fixture",
  "documentation_state": "fresh",
  "last_docgen_at": "2026-05-20T08:00:00Z",
  "stale_count": 0,
  "candidate_count": 2,
  "suggested_action": "review 2 pending pattern candidate(s)"
}
```

## Files changed

- `internal/mcp/docstate.go` — new
- `internal/mcp/docstate_test.go` — new (10 tests)
- `internal/mcp/server.go` — `WithInstructions` wired + `mcpInstructions` constant
- `internal/mcp/tools.go` — `handleWhoami` enriched + helper counts

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/mcp/ -count=1` — all pass (existing + 10 new)
- [x] `never_generated` on a fresh group (no docgen-state.json)
- [x] `fresh` after writing a stub docgen-state.json with future timestamp
- [x] `stale` with correct `stale_count` after mutating a source file
- [x] All `suggested_action` branches
- [x] Quiet mode suppresses doc-state fields
- [x] No regressions in existing mcp package tests

Closes #734