### PR TITLE
[#732][docs-skill] Wire archigraph_repairs into /generate-docs (Pass 1a + 1b + 3a)

### DIFF
--- a/skills/archigraph-repair/SKILL.md
+++ b/skills/archigraph-repair/SKILL.md
@@ -1,0 +1,124 @@
+# archigraph-repair
+
+Stand-alone repair flow for ADR-0015 residual edges. Lists pending repair candidates surfaced by `archigraph index`, walks the user through resolutions, and submits each via the `archigraph_repairs` MCP tool. Companion to `/generate-docs`, but can be invoked independently when the user just wants to clean up residuals without regenerating docs.
+
+## When to use this skill
+
+Invoke it when the user asks for any of:
+
+- "Show me archigraph's residuals."
+- "Help me annotate the runtime-resolved edges."
+- "Run the repair flow but don't regenerate docs."
+- "I have N minutes — let me chip at the bug-rate."
+
+Do **not** invoke it inside `/generate-docs`; that flow has its own integrated repair passes (Pass 1a, 1b, 3a). Use this skill for ad-hoc cleanup outside the doc-gen pipeline.
+
+## Inputs
+
+- A resolved archigraph group (the skill calls `archigraph_whoami` first).
+- Per-repo `<repo>/.archigraph/enrichment-candidates.json` with `kind: "repair_edge"` records (emitted by `archigraph index` per ADR-0015).
+- Optional: `~/.archigraph/groups/<group>/repair-history.json` (prior answers).
+- Optional: `~/.archigraph/groups/<group>/repair-templates.json` (saved templates).
+
+If `archigraph_repairs(action=list, limit=1)` returns `total == 0` for every repo, the skill exits with "No residuals to repair." after a one-line summary.
+
+## Procedure
+
+### Step 0 — Confirm scope
+
+`archigraph_whoami` → confirm group + repo set with the user. If the user wants a single repo, capture the slug; otherwise iterate the full group.
+
+### Step 1 — List residuals
+
+For each repo `<r>`:
+
+```
+archigraph_repairs(action=list, repo_filter=["<r>"], limit=50, offset=0)
+```
+
+Continue paging while `len(residuals) == limit`. Display per-repo counts to the user up front:
+
+> archigraph has **N** residuals across this group:
+> - `<repo-a>` — 47 (mostly CALLS to dynamic URLs).
+> - `<repo-b>` — 12 (third-party SaaS).
+> - `<repo-c>` —  3 (cross-repo HTTP).
+>
+> Want me to walk through all of them, just the top 10 by centrality, or a specific repo?
+
+### Step 2 — Apply templates and history (silent)
+
+Before prompting the user, auto-resolve anything that:
+
+- Matches a template in `repair-templates.json` with `confidence >= 0.8`, OR
+- Has a prior successful resolution in `repair-history.json` keyed by `residual_id`.
+
+Submit those via `archigraph_repairs(action=submit, source="archigraph-repair/auto")` and tell the user how many were auto-applied:
+
+> Auto-applied 14 from templates / 6 from prior history. 42 left to walk.
+
+### Step 3 — Walk remaining residuals
+
+Same Q-shape as `/generate-docs` Pass 1b — one residual at a time:
+
+> **<repo>** · <from_entity.kind> `<from_entity.name>` <relation> `<original_stub>`
+>
+> Likely resolutions:
+> - **A.** Bind to `<candidate-id>` (suggested target from the local subgraph).
+> - **B.** Reclassify as dynamic (runtime URL / dispatch).
+> - **C.** Reclassify as external (third-party).
+> - **D.** Abandon.
+> - **S.** Skip for now.
+
+Translate the answer to `archigraph_repairs(action=submit, ..., source="archigraph-repair")` using the same translation table as Pass 1b.
+
+### Step 4 — Handle rejections
+
+Same retry loop as Pass 1b. Rejection reason codes (`target_entity_not_found`, `self_loop_disallowed`, `contradicts_contains_hierarchy`, `invalid_module_identifier`, `missing_required_field`, `reasoning_too_short`) are surfaced to the user in plain language and re-asked.
+
+### Step 5 — Promote templates
+
+When the user answers ≥3 residuals with the same `resolution` + matching shape (same `relation` + similar `original_stub`), prompt:
+
+> You've classified 3 calls to `/${tenantId}/<path>` as `reclassify_as_dynamic`. Want me to save this as a template so I auto-apply on the rest?
+
+If yes, append to `repair-templates.json` (schema in Pass 1a). The template applies on the next sweep and on the remaining residuals in this run.
+
+### Step 6 — Update history
+
+After every submit, append the Q/A pair to `repair-history.json`. Same schema as Pass 1b Step 6.
+
+### Step 7 — Summary
+
+End with:
+
+> Submitted **K** repairs (`A` auto from templates, `H` auto from history, `U` from your answers). Run `archigraph index <repo>` to apply them.
+
+Optionally offer to invoke `archigraph index` for the affected repos. The skill does **not** invoke it automatically — re-indexing has side effects the user should consent to.
+
+## Outputs
+
+- Side effects: zero or more `archigraph_repairs(action=submit)` calls.
+- `~/.archigraph/groups/<group>/repair-history.json` — appended.
+- `~/.archigraph/groups/<group>/repair-templates.json` — possibly extended with new templates.
+- `~/.archigraph/groups/<group>/repair-session-<rfc3339>.md` — human-readable transcript of this session (count, applied list, deferred list).
+
+## archigraph MCP tool surface
+
+- `archigraph_whoami` — group/repo resolution.
+- `archigraph_repairs(action=list|submit)` — primary tool.
+- `archigraph_describe`, `archigraph_related`, `archigraph_search` — for inspecting candidate targets when the user asks "what would that bind to?".
+
+## Quality gates
+
+Before exit, the skill verifies:
+
+- Every `submit` returned without a `rejected_reason`, OR the rejection was surfaced and either re-resolved or recorded as deferred.
+- `repair-history.json` writes are atomic (write-temp-then-rename) so a Ctrl-C mid-session does not corrupt prior history.
+- No template was promoted with `applied_count < 3` (guards against single-example over-generalisation).
+
+## Related
+
+- `skills/generate-docs/SKILL.md` — for the integrated repair flow inside doc generation (Pass 1a, 1b, 3a).
+- ADR-0015 (`docs/adrs/0015-residual-repair-agent-enrichment.md`) — design rationale.
+- `docs/specs/repair-trust-model.md` — allowlist + verification rules enforced by the MCP tool.
+- `internal/mcp/SCHEMA.md` §`archigraph_repairs` — tool reference.

--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -31,8 +31,11 @@ The skill is a strict pipeline. Each pass has a dedicated prompt file under `pro
 |------|--------|---------|
 | 0 | `prompts/00-domain-qa.md` | First-run domain interview: what is this group, who owns it, what are the deployment boundaries. |
 | 1 | `prompts/01-inventory.md` | Discover repos and entities via `archigraph_search` / `archigraph_graph_stats` / `archigraph_list_clusters`. |
+| 1a | `prompts/01a-residual-repair-sweep.md` | Pre-Q&A repair sweep (ADR-0015): list residuals via `archigraph_repairs(action=list)`, auto-resolve unambiguous ones, surface the rest as questions for Pass 1b. |
+| 1b | `prompts/01b-repair-aware-qa.md` | Repair-aware Q&A: walk the user through residuals Pass 1a could not auto-resolve; each answer becomes an `archigraph_repairs(action=submit)` call. |
 | 2 | `prompts/02-plan.md` | Produce a per-module documentation plan with token estimates. |
 | 3 | `prompts/03-overview.md` | Repo-level `overview.md` for every repo. |
+| 3a | `prompts/03a-generation-time-repair.md` | Hook (not a standalone pass): every writer in Passes 3-6 + 12 inspects outbound residuals of the entity it is about to describe, repairs in-place when possible, documents as runtime-resolved otherwise. |
 | 4 | `prompts/04-cluster.md` | Per-module deep-dive (parallel writer subagents, one per cluster). |
 | 5 | `prompts/05-reference.md` | Reference docs: API, config, deployment, scripts, dependencies. |
 | 6 | `prompts/06-cross-cutting.md` | Cross-cutting concerns: auth, logging, error handling, observability. |
@@ -44,6 +47,8 @@ The skill is a strict pipeline. Each pass has a dedicated prompt file under `pro
 | 12 | `prompts/12-pattern-prose.md` | Emit `docs/patterns/<category>/<id>.md` per approved pattern (ADR-0018 Phase 6). |
 
 During Pass 4 (per-module writers), each subagent additionally emits `PatternCandidate` entities via `archigraph_patterns(action=record, as_candidate=true)` whenever it observes ≥ `per_subagent_threshold` (default 2) instances of a structural recurrence in its slice. The candidates aggregate in Pass 10, cross-link in Pass 11, and produce dedicated markdown in Pass 12. The full design is in [ADR-0018](../../docs/adrs/0018-agent-learned-patterns.md).
+
+Passes 1a and 1b integrate the ADR-0015 residual-repair flow into doc generation, closing the gap between the static-analysis recall ceiling and full cross-repo coverage. Pass 3a is a hook (not a numbered pass): every writer in Passes 3–6 and 12 runs it before describing an entity, so any residual that escaped the sweep gets one more chance to repair or, failing that, gets surfaced in prose as a documented runtime-resolved edge per ADR-0007. The standalone `/archigraph-repair` skill (`skills/archigraph-repair/SKILL.md`) exposes the same flow outside doc generation for ad-hoc cleanup.
 
 ## archigraph MCP tool surface
 
@@ -60,6 +65,7 @@ The skill is built around the archigraph MCP server. The agent should call these
 - `archigraph_save_finding` - persist a question/answer pair into the group memory directory.
 - `archigraph_list_link_candidates` / `archigraph_resolve_link_candidate` - cross-repo link review (Pass 8).
 - `archigraph_list_enrichment_candidates` / `archigraph_submit_enrichment` / `archigraph_reject_enrichment` - close enrichment loops.
+- `archigraph_repairs` - residual-edge repair queue (`action=list|submit`). Used by Passes 1a, 1b, and the Pass 3a hook to annotate runtime-resolved edges per ADR-0015.
 - `archigraph_graph_stats` - corpus-level metrics (used in Pass 1 inventory).
 - `archigraph_get_telemetry` - server uptime and per-tool counters (debugging only).
 
@@ -115,5 +121,8 @@ Before any pass commits its output, the writer subagent runs the checks in `snip
 ## Related
 
 - `skills/extend-convention/SKILL.md` - companion skill for adding a new stack convention.
+- `skills/archigraph-repair/SKILL.md` - standalone repair flow for ad-hoc residual cleanup outside doc generation.
+- ADR-0015 (`docs/adrs/0015-residual-repair-agent-enrichment.md`) - residual repair foundation; powers Passes 1a, 1b, and 3a.
+- `docs/specs/repair-trust-model.md` - allowlist + verification rules enforced by `archigraph_repairs(action=submit)`.
 - ADR-0007 (`docs/adrs/0007-doc-as-bridge-for-cross-repo-and-dynamic-connections.md`) - why backticked code identifiers in headings matter.
 - ADR-0008 - caller-CWD-aware routing, which is why `repo_filter` defaults work without the agent passing `cwd` explicitly.

--- a/skills/generate-docs/prompts/01a-residual-repair-sweep.md
+++ b/skills/generate-docs/prompts/01a-residual-repair-sweep.md
@@ -1,0 +1,183 @@
+# Pass 1a — Residual repair sweep (pre-Q&A)
+
+Runs **after Pass 1 (inventory)** and **before any deeper writer passes**. Closes the gap between the static-analysis recall ceiling (~85% on cross-repo b→a) and full coverage by annotating runtime-resolved edges that the resolver structurally cannot bind.
+
+This pass is the doc skill's integration with the ADR-0015 residual-repair mechanism. The MCP tool `archigraph_repairs` is the only surface used; do **not** read or write `repair.json` directly. See `docs/specs/repair-trust-model.md` for the allowlist of resolutions and verification rules.
+
+## When to skip
+
+- If `archigraph_repairs(action=list, limit=1)` returns `total == 0` for every repo in the group, write a single line into `~/.archigraph/groups/<group>/repair-sweep.md` ("No residuals at sweep time.") and hand back to the orchestrator.
+- If a previous run of this pass already produced `repair-sweep.md` for the current commit (track via `git rev-parse HEAD` of each repo recorded inside the file's frontmatter), do **not** re-ask the user about the same residuals. Only surface deltas. This implements the "repair history" bonus from #732.
+
+## Inputs
+
+- `~/.archigraph/groups/<group>/domain.md` — Pass 0 output.
+- `~/.archigraph/groups/<group>/inventory.json` — Pass 1 output.
+- Optional: `~/.archigraph/groups/<group>/repair-templates.json` — saved repair templates from prior runs (see "Repair templates" below). Absent on first run.
+- An archigraph MCP session.
+
+## Outputs
+
+- `~/.archigraph/groups/<group>/repair-sweep.md` — human-readable summary (counts per repo, auto-resolved sample, pending-for-user list).
+- `~/.archigraph/groups/<group>/repair-questions.json` — machine-readable list of residuals that need user input, consumed by Pass 1b (repair-aware Q&A).
+- Side effects: zero or more `archigraph_repairs(action=submit)` calls per auto-resolved residual.
+
+## Procedure
+
+### Step 1 — List residuals per repo
+
+For each repo `<r>` in the group, page through:
+
+```
+archigraph_repairs(action=list, repo_filter=["<r>"], limit=50, offset=0)
+```
+
+Continue paging while the returned `residuals[]` length equals `limit`. Cap total per-repo scan at 1,000 residuals for Phase 1 — if a repo has more, record the truncation in `repair-sweep.md` and surface the count to the user; the deferred residuals will roll forward to the next run.
+
+### Step 2 — Classify each residual
+
+For each residual returned, decide one of:
+
+1. **Auto-resolve** — apply a repair without asking the user. Allowed only when:
+   - The resolution is unambiguous from the discovery output in `inventory.json` (e.g., a single entity in scope matches `original_stub` and `relation` exactly), OR
+   - A repair template (Step 4) matches the residual's shape with `confidence >= 0.8`, OR
+   - The residual is a recognised third-party API call (e.g., `original_stub` starts with `https://api.<vendor>/`) and the relation is `CALLS` → `reclassify_as_external` with `module=<vendor>`.
+2. **Ask user** — surface to Pass 1b. Use this when more than one binding target is plausible, or when the residual is a dynamic baseURL / tenant-prefixed route / runtime-resolved edge.
+3. **Defer** — skip for this run (record reason). Defer is only legal when residual carries no actionable context window (extremely rare; should not happen on real corpora).
+
+Every auto-resolve decision must have a one-sentence `reasoning` string and a `confidence` value. The trust model (`R7`) requires non-empty reasoning. Aim for `confidence >= 0.7` on auto-resolves; lower confidence belongs in the user-question bucket.
+
+### Step 3 — Submit auto-resolutions
+
+For each residual classified as auto-resolve, call:
+
+```
+archigraph_repairs(
+  action=submit,
+  residual_id="er:...",
+  resolution=<bind_to_entity | reclassify_as_external | reclassify_as_dynamic | reclassify_as_resolved | abandon>,
+  target_entity_id=...,      # if bind_to_entity
+  module=...,                # if reclassify_as_external
+  new_target=...,            # if reclassify_as_resolved
+  dynamic_reason=...,        # if reclassify_as_dynamic
+  abandon_reason=...,        # if abandon
+  confidence=<0..1>,
+  reasoning="<one sentence>",
+  source="generate-docs/pass-1a"
+)
+```
+
+Inspect the response. If `rejected_reason` is present (e.g., `target_entity_not_found`, `self_loop_disallowed`), demote the residual to the user-question bucket and record the rejection reason. The trust model rejections are non-recoverable from inside this pass — the agent must hand to the user.
+
+### Step 4 — Repair templates (bonus from #732)
+
+A **repair template** captures the *shape* of a residual + the *kind* of resolution that fits it, so future runs can auto-resolve similar residuals without asking the user.
+
+Templates live in `~/.archigraph/groups/<group>/repair-templates.json`:
+
+```json
+{
+  "version": 1,
+  "templates": [
+    {
+      "id": "tmpl-dyn-tenant-prefix",
+      "matches": {
+        "relation": "CALLS",
+        "original_stub_regex": "^/\\$\\{tenantId\\}/.*",
+        "from_kind": "Component"
+      },
+      "resolution": "reclassify_as_dynamic",
+      "dynamic_reason": "Tenant-prefixed runtime URL; resolves per-tenant at request time.",
+      "confidence": 0.85,
+      "applied_count": 11,
+      "promoted_at": "2026-04-18T..."
+    }
+  ]
+}
+```
+
+A template is **promoted** automatically when the same shape (same `relation` + same `original_stub` regex bucket + same `from_kind`) is auto-resolved successfully `>= 3` times in one sweep, OR when the user answers `>= 3` Pass 1b questions with the same resolution + reasoning. This is the "repair confidence model" bonus — after N successful applies of the same resolution shape, the agent applies it silently on subsequent matches.
+
+Templates are advisory; the indexer's trust-model rules in `docs/specs/repair-trust-model.md` still gate every submit.
+
+### Step 5 — Hand-off to Pass 1b
+
+Anything classified as **ask user** is written to `repair-questions.json`:
+
+```json
+{
+  "group": "<group>",
+  "generated_at": "<rfc3339>",
+  "questions": [
+    {
+      "residual_id": "er:deadbeef00000001",
+      "repo": "mobile-app",
+      "relation": "CALLS",
+      "original_stub": "/${tenantId}/contracts",
+      "from_entity": { "id": "...", "name": "DashboardScreen", "kind": "Component" },
+      "summary": "Frontend Component DashboardScreen calls /${tenantId}/contracts at runtime.",
+      "candidate_resolutions": [
+        { "resolution": "reclassify_as_dynamic", "hint": "tenant-prefixed route" },
+        { "resolution": "bind_to_entity", "hint": "<api-backend>::ContractsViewSet" }
+      ]
+    }
+  ]
+}
+```
+
+Pass 1b reads this file directly. Do **not** include auto-resolved residuals in `questions[]` (those are already done).
+
+## Output — repair-sweep.md
+
+```markdown
+---
+group: <group>
+generated_at: <rfc3339>
+heads:
+  <repo-a>: <commit sha>
+  <repo-b>: <commit sha>
+---
+
+# Residual repair sweep
+
+archigraph surfaced **N** residual edges across the group. Of those:
+
+- **M** auto-resolved by this pass (see `repair-sweep-applied.json` for the full list).
+- **K** will be asked of you in Pass 1b (Q&A).
+- **D** deferred to a future run (reason recorded).
+
+## Per-repo breakdown
+| repo | total | auto | ask | defer |
+|------|------:|-----:|----:|------:|
+| <r>  | ...   | ...  | ... | ...   |
+
+## Templates active this run
+- `tmpl-dyn-tenant-prefix` — applied 11 ×.
+- `tmpl-react-npm-allowlist` — applied 5 ×.
+
+## Sample auto-resolutions
+- `er:abc...` `Component DashboardScreen` `CALLS` `/${tenantId}/contracts` → reclassify_as_dynamic ("tenant-prefixed runtime URL").
+- `er:def...` `Component CheckoutForm` `CALLS` `stripe.charges.create` → reclassify_as_external (`module=stripe`).
+
+## Next step
+Run Pass 1b to answer the K residual questions in `repair-questions.json`.
+```
+
+## Reporting back to the orchestrator
+
+Return a single line in the form:
+
+> `repair sweep: <total> residuals — auto-resolved <M>, asking user <K>, deferred <D>.`
+
+If any repo could not be scanned (MCP error, missing `.archigraph/enrichment-candidates.json`), record it in `repair-sweep.md` under a "Scan errors" section and continue with the repos that succeeded. Do **not** abort the doc-gen pipeline; repair is additive.
+
+## Cross-link to patterns (bonus from #732)
+
+Before recording a `PatternCandidate` in Pass 4 / aggregating in Pass 10, the agent checks whether the exemplar entity has any unresolved outbound edges via `archigraph_repairs(action=list, repo_filter=[<r>])`. If so, the pattern record flow attempts a repair (Step 3 procedure) before storing the exemplar. This keeps pattern exemplars from referencing dangling targets.
+
+## Invariants
+
+- Never write to `repair.json` directly. The MCP tool is the only surface.
+- Never invent a `target_entity_id` that doesn't appear in `inventory.json`. Trust-model rule `R2` rejects unknown targets; the rejection becomes a user question.
+- Never submit `reasoning` shorter than ~10 characters. Trust-model rule `R7` flags it; we treat <10 as effectively rejected and demote to user question.
+- Auto-resolution must be reproducible — the same `repair-templates.json` + same `inventory.json` + same residuals must produce the same submits (no time-based or random decisions). This preserves ADR-0015's determinism guarantee.

--- a/skills/generate-docs/prompts/01b-repair-aware-qa.md
+++ b/skills/generate-docs/prompts/01b-repair-aware-qa.md
@@ -1,0 +1,123 @@
+# Pass 1b — Repair-aware Q&A
+
+Surfaces the residuals Pass 1a could not auto-resolve. The user answers in plain language; the agent translates each answer into an `archigraph_repairs(action=submit)` call.
+
+This pass is **skipped** when `~/.archigraph/groups/<group>/repair-questions.json` is missing, empty, or contains only entries already answered in a prior run (see "Repair history" below).
+
+## Inputs
+
+- `~/.archigraph/groups/<group>/repair-questions.json` (from Pass 1a).
+- `~/.archigraph/groups/<group>/repair-history.json` (optional; written by this pass to remember prior answers across runs).
+- An archigraph MCP session.
+
+## Outputs
+
+- Side effects: one `archigraph_repairs(action=submit)` call per answered question.
+- `~/.archigraph/groups/<group>/repair-history.json` — appended with this run's Q/A pairs (per-residual). Keyed by `residual_id`. On the next run, Pass 1a consults this file before re-asking.
+- `~/.archigraph/groups/<group>/repair-sweep.md` — appended with a "User-answered" section.
+
+## Procedure
+
+### Step 1 — Group questions
+
+Group questions by `repo`, then within each repo by `from_entity.kind`. This keeps the user's attention on one slice of the system at a time and reduces context switching.
+
+### Step 2 — Open the conversation
+
+Surface the global frame **once** at the top of the pass:
+
+> archigraph found **N** runtime-resolved edges that static analysis cannot bind from source alone. They fall into three buckets:
+>
+> 1. Dynamic URLs (template-literal or env-derived) — usually `reclassify_as_dynamic`.
+> 2. Cross-repo HTTP calls — usually `bind_to_entity` to the matching backend route.
+> 3. Third-party library/SaaS calls — usually `reclassify_as_external`.
+>
+> I'll ask you about each. Your answers become repair annotations the graph remembers across re-indexes.
+
+### Step 3 — Ask each question
+
+For each question in `repair-questions.json`, present it in this shape:
+
+> **<repo>** · <from_entity.kind> `<from_entity.name>` <relation> `<original_stub>`
+>
+> _<summary line from Pass 1a>_
+>
+> Likely resolutions:
+> - **A.** Bind to a known backend route (e.g., `<api-backend>::ContractsViewSet`).
+> - **B.** Reclassify as dynamic (tenant-prefixed runtime URL).
+> - **C.** Reclassify as external (third-party API).
+> - **D.** Abandon (this edge is noise; drop it).
+>
+> Which fits, and (if A) what's the target id? Anything that helps me write a good repair `reasoning` is welcome.
+
+### Step 4 — Translate answer → submit
+
+Translate the user's natural-language answer into the corresponding `archigraph_repairs(action=submit, ...)` call. Required fields per `docs/specs/repair-trust-model.md`:
+
+| Answer | resolution | Required extra fields |
+|---|---|---|
+| "Routes to `<X>`" with an entity id from `inventory.json` | `bind_to_entity` | `target_entity_id` |
+| "It's a third-party API" | `reclassify_as_external` | `module` (e.g., `stripe`, `aws-sdk`) |
+| "It's resolved at runtime" | `reclassify_as_dynamic` | `dynamic_reason` (verbatim user phrase, trimmed) |
+| "Resolved cross-repo; new target is `<id>`" | `reclassify_as_resolved` | `new_target` |
+| "Drop it" / "Noise" | `abandon` | `abandon_reason` |
+
+Always set:
+- `confidence` — the agent's read of how confident the user was (1.0 for explicit, 0.7 for hedged, 0.5 for "best guess"). The trust model accepts <0.5 but flags it under `suspicious`.
+- `reasoning` — a single sentence that paraphrases the user's answer. This is what later readers see when they query the graph. Avoid quoting verbatim if the user was terse; expand into a self-contained sentence. Never empty (R7).
+- `source` — `"generate-docs/pass-1b"`.
+
+### Step 5 — Handle rejections
+
+If `archigraph_repairs(action=submit)` returns `rejected_reason`, do not silently retry. Surface the reason to the user in their own terms:
+
+- `target_entity_not_found` → "That id doesn't exist in the graph for this group. Did you mean one of: <top-3 fuzzy matches from `inventory.json`>?"
+- `self_loop_disallowed` → "That would point the edge back at itself. Was this a typo, or should we abandon the edge?"
+- `contradicts_contains_hierarchy` → "That target is the enclosing scope of `<from>`. Static analysis already owns that relationship. Pick a sibling target or abandon."
+- `invalid_module_identifier` → "Module names can't contain path separators or shell characters. What's the package name on its own?"
+
+Re-ask, then re-submit.
+
+### Step 6 — Record history
+
+After every successful submit, append to `repair-history.json`:
+
+```json
+{
+  "residual_id": "er:...",
+  "answered_at": "<rfc3339>",
+  "user_phrasing": "<verbatim>",
+  "resolution": "...",
+  "submitted_payload": { ... },
+  "submit_response": { ... }
+}
+```
+
+This is what makes "don't re-ask the user about the same residual" work: Pass 1a reads this file before classifying. If a residual's `residual_id` (or its template-shape match) appears here with a successful resolution, Pass 1a auto-applies the prior resolution.
+
+### Step 7 — Append to repair-sweep.md
+
+Add a section to the file Pass 1a started:
+
+```markdown
+## User-answered (Pass 1b)
+- `er:abc...` `<from> CALLS <stub>` → reclassify_as_dynamic (\"tenant-prefixed runtime URL\").
+- `er:def...` `<from> CALLS <stub>` → bind_to_entity `<api-backend>::ContractsViewSet`.
+
+K of K answered. 0 left for next run.
+```
+
+## Reporting back to the orchestrator
+
+Return a single line:
+
+> `repair Q&A: <K> asked, <answered> applied, <skipped> skipped, <rejected> rejected.`
+
+Continue to Pass 2 regardless of skip/reject counts; the doc-gen pipeline is robust to partial repair.
+
+## Invariants
+
+- One submit per question. Never bundle multiple residuals into one submit call.
+- Never invent `target_entity_id` values the user did not provide. If the user gestures at a target without an exact id, search `inventory.json` with `archigraph_search` and present the candidates back to the user; only submit once they pick one.
+- The pass is **interactive** — never silently fall through unanswered questions. If the user requests "skip the rest," record the remaining questions back into `repair-questions.json` for the next run.
+- Don't re-ask answered residuals. The history file is authoritative.

--- a/skills/generate-docs/prompts/03-overview.md
+++ b/skills/generate-docs/prompts/03-overview.md
@@ -2,6 +2,8 @@
 
 Write `<repo>/docs/overview.md` for every repo in the group. The overview is the entry point a new engineer reads first; it is also the page Pass 7 quotes when synthesizing the group-level page.
 
+> **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
+
 ## Inputs
 
 - `~/.archigraph/groups/<group>/domain.md`

--- a/skills/generate-docs/prompts/03a-generation-time-repair.md
+++ b/skills/generate-docs/prompts/03a-generation-time-repair.md
@@ -1,0 +1,69 @@
+# Pass 3a — Generation-time repair (in-prose hook)
+
+A **hook**, not a standalone pass. Every writer subagent in Passes 3, 4, 5, 6, and 12 runs this check immediately before emitting prose that describes an entity. The hook closes residuals discovered late (after Pass 1a) or that the agent missed in the sweep.
+
+## When the hook fires
+
+Every time a writer is about to write a paragraph about an entity `E`, run:
+
+```
+archigraph_repairs(action=list, repo_filter=[<repo of E>], limit=20)
+```
+
+Filter the result client-side to residuals whose `from_entity.id == E.id`. If the filtered set is empty, write the prose as planned and continue.
+
+## When the hook acts
+
+For each residual where `from_entity.id == E.id`:
+
+1. Inspect the residual's `original_stub`, `relation`, and the entity's neighborhood (`archigraph_related(entity_id=E.id, depth=1)` or `archigraph_describe`).
+2. Decide whether you can submit a repair **without asking the user**. The same auto-resolve criteria from Pass 1a apply:
+   - Unambiguous binding target visible in the local subgraph, OR
+   - Matches an active template in `repair-templates.json`, OR
+   - Recognised third-party module.
+3. If auto-resolve is possible: `archigraph_repairs(action=submit, ...)` with `source="generate-docs/pass-3a"`, then write the prose **as if the edge were resolved** — describe the target the repair points at, not the original stub.
+4. If auto-resolve is not possible: write the prose with an explicit "runtime-resolved" callout (see template below). Do **not** silently drop the edge.
+
+## Prose template for unresolved residuals
+
+When an outbound edge cannot be repaired in-pass, the writer surfaces it as a documented dynamic edge so readers see what static analysis could not:
+
+```markdown
+> **Runtime-resolved edge.** `<E.name>` calls `<original_stub>` via <relation>. Static analysis cannot bind this target because <one of: the URL is built from a template literal | the target depends on tenant context | the dispatch is via a string registry | the callee is a third-party API archigraph has not catalogued>. If you know the binding, run `/archigraph-repair` to annotate it; the graph will remember on subsequent re-indexes.
+```
+
+The phrasing must match this shape so downstream readers (and ADR-0007's doc-as-bridge resolver) can recognise it as an annotated dynamic edge.
+
+## What NOT to do
+
+- Do **not** invent a target entity to make the prose flow nicely. If the static graph doesn't have it and the agent can't repair it, the callout is the right output.
+- Do **not** call `archigraph_repairs(action=submit)` with `reasoning` that's just the entity name. Reasoning must be a sentence (R7 in the trust model treats short reasoning as suspicious).
+- Do **not** spam the user with questions mid-prose-generation. The user-interactive surface for residuals is Pass 1b. If a residual escaped Pass 1b, this hook either repairs it silently or documents it as runtime-resolved — never breaks out to ask.
+- Do **not** modify the writer's existing output template structure. The "Runtime-resolved edge" callout is inserted as an admonition inside whatever section was already going to describe the entity's outbound calls.
+
+## Throughput considerations
+
+Phase 1 of #732 ships the synchronous in-prose hook. On a 5k-residual graph this adds one `archigraph_repairs(action=list)` per entity. Mitigations:
+
+- Cache the per-repo residual list at the start of each writer subagent's run; refresh only if a submit was made.
+- Skip the hook for entities whose `from_entity.id` does not appear in the cached residual set — most entities will have zero residuals.
+- Batch-submit is out of scope for Phase 1 (see ADR-0015 risks §3).
+
+## Reporting
+
+Writer subagents append a line to their existing pass report:
+
+> `pass-3a hook: <N> entities scanned, <M> residuals seen, <A> auto-repaired, <D> documented as runtime-resolved.`
+
+The orchestrator aggregates these into the final `repair-sweep.md` under a "Generation-time repairs" section.
+
+## Cross-link to patterns
+
+When a pattern's recipe references an entity with unresolved outbound edges, the pattern-record flow (`archigraph_patterns(action=record)`) must run this hook against the exemplar before storing. This prevents pattern exemplars from being authoritative references to dangling targets. See ADR-0018 §"Exemplar integrity" for the broader rationale.
+
+## Invariants
+
+- The hook runs at every "describe-this-entity" boundary. Never skip for performance — the cache makes it cheap.
+- Writes go through `archigraph_repairs(action=submit)` only. No direct file writes.
+- The hook is idempotent: running it twice on the same entity produces zero new submits because the second pass sees `total == 0` for that `from_entity.id`.
+- Source attribution: every submit from this pass uses `source="generate-docs/pass-3a"` so the audit trail distinguishes sweep-time from generation-time repairs.

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -2,6 +2,8 @@
 
 For every entry under `plan.passes.4_cluster.modules`, produce a self-contained module page (or set of pages). This pass runs writer subagents **in parallel** — one subagent per module — bounded by a configured concurrency limit.
 
+> **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
+
 ## Inputs (per writer subagent)
 
 - The single module entry from `plan.json` you are responsible for.

--- a/skills/generate-docs/prompts/05-reference.md
+++ b/skills/generate-docs/prompts/05-reference.md
@@ -2,6 +2,8 @@
 
 Reference docs are the dry, exhaustive, alphabetized pages. They live under `<repo>/docs/reference/` and are produced one section at a time, sequentially, by a single writer subagent per repo.
 
+> **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
+
 Sections (each is a separate file, each has a template):
 
 - `api.md` — public API surface (`output-templates/api.md`)

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -2,6 +2,8 @@
 
 Some topics span every module: authentication, authorization, logging, error handling, observability, feature flags, rate limiting. They deserve their own pages so readers don't have to reconstruct them from per-module docs.
 
+> **Pass 3a hook active.** Before writing any paragraph that describes an entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. Auto-repair residuals where unambiguous; otherwise emit the documented "Runtime-resolved edge" callout from that prompt. Do not silently drop unresolved outbound edges.
+
 Default topics (override per group via `plan.passes.6_cross_cutting.topics`):
 
 - `auth.md` — authentication and authorization

--- a/skills/generate-docs/prompts/12-pattern-prose.md
+++ b/skills/generate-docs/prompts/12-pattern-prose.md
@@ -2,6 +2,8 @@
 
 Emit one markdown file per approved pattern under `docs/patterns/<category>/<pattern-id>.md`. Re-runs of `/generate-docs` overwrite these files from the current pattern store, so refinements and new applies propagate automatically.
 
+> **Pass 3a hook active.** Before writing the section that names an exemplar entity, run the generation-time repair hook from `prompts/03a-generation-time-repair.md`. This prevents pattern exemplars from referencing dangling targets and implements the "patterns → repair" cross-link from #732.
+
 This pass uses the `internal/agentpatterns/docs.go` renderer (`RenderMarkdown`, `WriteMarkdown`) — call it via the daemon's pattern surface rather than reimplementing the markdown construction.
 
 ## Output structure


### PR DESCRIPTION
## Summary

Integrates the ADR-0015 residual-repair mechanism into the `/generate-docs` skill so the doc agent can push past the static-analysis recall ceiling (~85% on cross-repo b→a) by annotating runtime-resolved edges static analysis structurally cannot bind.

Skill-only change. No edits to `internal/mcp/repair.go`, extractors, or resolver. The `archigraph_repairs` MCP tool (action=`list`|`submit`) is the only repair surface used.

## What lands

### New prompts under `skills/generate-docs/prompts/`

- **`01a-residual-repair-sweep.md`** — pre-Q&A sweep. Lists residuals per repo via `archigraph_repairs(action=list)`, auto-resolves unambiguous ones, surfaces the rest as questions. Includes repair-template promotion (≥3 same-shape applies auto-promote) and repair-history reuse (don't re-ask answered residuals).
- **`01b-repair-aware-qa.md`** — interactive Q&A. Walks the user through unresolved residuals one at a time, translates plain-language answers to the right `submit` payload, handles trust-model rejection codes (R1–R7) gracefully, appends to `repair-history.json`.
- **`03a-generation-time-repair.md`** — hook. Every writer in Passes 3, 4, 5, 6, 12 runs it before describing an entity; auto-repairs visible residuals on the entity, or emits a documented "Runtime-resolved edge" callout per ADR-0007 so the dynamic edge is never silently dropped.

### New skill

- **`skills/archigraph-repair/SKILL.md`** — standalone repair flow for ad-hoc cleanup outside doc generation. Reuses the Pass 1a/1b mechanics, templates, and history.

### Wiring

- `skills/generate-docs/SKILL.md` — pass index extended with rows 1a, 1b, 3a; MCP tool surface lists `archigraph_repairs`; related-skills section adds `archigraph-repair`.
- Passes 3, 4, 5, 6, 12 prompts each get a one-line "Pass 3a hook active" directive pointing at the hook prompt so writers invoke it consistently.

## Beyond the minimum (per #732 bonus list)

- **Repair confidence model** — repair templates auto-promote after ≥3 successful applies of the same `(relation, original_stub regex, from_kind)` shape; subsequent matches apply silently with `confidence >= 0.8`.
- **Repair history** — `repair-history.json` persists Q/A pairs across runs; Pass 1a consults it before classifying so the user is never re-asked about an answered residual.
- **Repair templates** — `repair-templates.json` schema defined in Pass 1a; applies in both Pass 1a and `/archigraph-repair`.
- **Patterns ↔ repair cross-link** — Pass 12 (pattern prose) runs the Pass 3a hook on exemplar entities; record-time integrity check noted in 01a so pattern exemplars never point at dangling targets.

## Sample Pass 1a transcript shape

```
repair sweep: 73 residuals — auto-resolved 28, asking user 42, deferred 3.
Per-repo: mobile-app 47 (auto 18, ask 27, defer 2), api-backend 26 (auto 10, ask 15, defer 1).
Templates active: tmpl-dyn-tenant-prefix (11×), tmpl-react-npm-allowlist (5×).
```

## How Pass 1b surfaces residuals to the user

```
archigraph found 42 runtime-resolved edges that need annotation. They fall into three buckets:
  1. Dynamic URLs                   — usually reclassify_as_dynamic
  2. Cross-repo HTTP calls          — usually bind_to_entity to the matching backend route
  3. Third-party library/SaaS calls — usually reclassify_as_external

mobile-app · Component DashboardScreen CALLS /${tenantId}/contracts
Frontend Component DashboardScreen calls /${tenantId}/contracts at runtime.

Likely resolutions:
  A. Bind to api-backend::ContractsViewSet
  B. Reclassify as dynamic (tenant-prefixed runtime URL)
  C. Reclassify as external (third-party)
  D. Abandon

Which fits?
```

## Invariants enforced

- `archigraph_repairs` is the only write surface — no direct `repair.json` writes.
- `target_entity_id` must come from `inventory.json` (or the trust model's R2 rejection routes to user Q).
- Reasoning ≥ a sentence (R7).
- Determinism preserved (ADR-0015 §"Determinism extension") — auto-resolves are reproducible given the same templates + inventory + residuals.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./...` — full suite passes (no Go code touched; skill-only change)
- [x] Markdown of new prompts is syntactically valid; all `prompts/NN-*.md` references in `SKILL.md` resolve to existing files
- [ ] (manual) End-to-end smoke on the client-fixture group: Pass 1a sweep produces `repair-sweep.md` and `repair-questions.json`; Pass 1b applies repairs; re-index drops bug-rate

## Constraints honoured

- File-disjoint from in-flight worktrees (#690, #712+#713, #721, #722).
- Skill files only; no extractor/resolver/MCP server changes.
- No predecessor-tool name used in code or PR.

Closes #732.

🤖 Generated with [Claude Code](https://claude.com/claude-code)