### PR TITLE
[#739] /archigraph-quality-check skill — pre-docgen MCP quality benchmark

### DIFF
--- a/skills/archigraph-quality-check/SKILL.md
+++ b/skills/archigraph-quality-check/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: archigraph-quality-check
+description: Pre-`/generate-docs` MCP quality benchmark. Runs a head-to-head between archigraph MCP and grep+read across ~10-15 representative questions on the registered group, judges quality against ground truth read from source, and emits a shareable markdown report with token / speed / quality tables, findings, and tuning recommendations. Use BEFORE generating documentation to confirm the MCP foundation is healthy.
+when-to-use: User asks to "benchmark archigraph", "check MCP quality", "is archigraph helping", "validate MCP before docgen", or invokes `/archigraph-quality-check` explicitly. Run this BEFORE `/generate-docs` on a new group, after major archigraph changes, or to produce a comparison snapshot for tuning.
+---
+
+# archigraph-quality-check
+
+Pre-docgen MCP quality benchmark. The skill answers a single question with data: **does archigraph MCP deliver value over grep+read on this group?** It produces a shareable markdown report the user passes back to the archigraph coordinator for tuning.
+
+## When to use this skill
+
+Invoke when the user asks for any of:
+
+- "Benchmark archigraph on this group."
+- "Is the MCP actually saving tokens here?"
+- "Quality-check before we run /generate-docs."
+- "Run a regression against the last benchmark."
+- "/archigraph-quality-check" (slash command).
+
+Do **not** invoke for one-off lookups, ad-hoc grep substitution, or to "test the daemon" - the daemon health-check is a separate concern.
+
+## Why this skill exists
+
+A predecessor MCP tool ("Tool A") was empirically found to consume **3-6× more tokens than grep+read** on representative questions, while not improving answer quality. This skill is the gate that confirms archigraph does not have the same failure mode. It is the formal step between "we built archigraph" and "we have evidence archigraph helps."
+
+It runs **before** `/generate-docs` because docgen amplifies whatever bias the MCP has - if the MCP is slower and less accurate than grep on this group, docgen will burn tokens producing worse documentation than a grep-only pipeline would.
+
+## Inputs the skill expects
+
+- A resolved archigraph group (the skill calls `archigraph_whoami` first to confirm).
+- A running archigraph daemon (per the user's `archigraph install` setup). **The skill never spawns a daemon.** If `archigraph_whoami` fails, stop and tell the user to start their daemon.
+- Optional flags:
+  - `--output <path>` - report destination. Default: `~/private/benchmarks/mcp-quality-bench-<YYYY-MM-DD>.md`.
+  - `--iterations N` - run each question N times for noise reduction. Default 1. Reports median + stddev when N > 1.
+  - `--focus <category>` - only generate questions from one of the nine categories (see Phase 1). Useful for stress-testing a known weak area.
+  - `--question-set <path>` - JSON file with a user-curated question set instead of auto-generated. Schema documented in Phase 1.
+  - `--baseline <path>` - prior report markdown to diff against. Surfaces deltas in token/quality/speed.
+
+## Daemon discipline
+
+This skill **runs against the user's existing daemon**. It does not start, restart, or touch the daemon. The user's `archigraph install` setup determines which daemon is in use.
+
+- The agent never sets `ARCHIGRAPH_DAEMON_ROOT` or spawns `archigraph daemon`.
+- The agent never kills any `archigraph` process.
+- If MCP tool calls fail with "no daemon" errors, the skill stops and asks the user to run their own start command.
+
+## Pass numbering (Phase 1 through Phase 5)
+
+The skill is a strict pipeline. Each phase has a dedicated prompt under `prompts/`. A subagent reads the prompt and follows it; the orchestrator (this skill) tracks progress and gates each phase on the previous one's output.
+
+| Phase | Prompt | Purpose |
+|------|--------|---------|
+| 1 | `prompts/01-question-generation.md` | Call `archigraph_whoami`, learn the group's real entities, generate ~10-15 questions across nine categories. Persist as `questions.json`. |
+| 2 | `prompts/02-with-mcp-run.md` | Answer every question using archigraph MCP tools. Record tokens / time / tool calls / confidence per question. Persist as `with-mcp.json`. |
+| 3 | `prompts/03-without-mcp-run.md` | Answer the **same** questions using only `rg` / `grep` / `Read` / `Bash`. No archigraph MCP. Same metrics. Persist as `without-mcp.json`. |
+| 4 | `prompts/04-quality-judgment.md` | Determine ground truth by reading source code directly. Judge both runs against ground truth: full / partial / wrong / unknown plus per-question misses. Persist as `judgment.json`. |
+| 5 | `prompts/05-report.md` | Render the markdown report at `--output`. Tables, findings, issues, recommendations, raw-data appendix. |
+
+Each phase reads its predecessor's output from the run directory:
+
+```
+~/.archigraph/quality-check/<YYYY-MM-DD-HHMMSS>/
+  questions.json       # Phase 1
+  with-mcp.json        # Phase 2
+  without-mcp.json     # Phase 3
+  judgment.json        # Phase 4
+  report.md            # Phase 5 (also copied to --output)
+```
+
+## Question categories
+
+Phase 1 generates questions across nine categories. Each question is adapted to the registered group's actual entities (e.g., "what is UserService?" only if a `UserService`-like entity exists; otherwise substitute a real entity discovered via `archigraph_search`).
+
+1. **Entity lookup** - "what is `<ClassName>`?"
+2. **Reference finding** - "what calls `<Class>.<method>`?"
+3. **Cross-stack tracing** - "how does the frontend `<feature>` flow reach the backend?"
+4. **Pattern discovery** - "what's the convention for adding a new `<thing>`?"
+5. **Architecture overview** - "what are the main subsystems in this group?"
+6. **Subsystem deep-dive** - "describe the `<subsystem>`."
+7. **Specific traces** - "trace from `<ui-entity>` to the DB row written."
+8. **Data access** - "where does `<Entity>.<field>` get read or written?"
+9. **HTTP cross-repo** - "what endpoints does the `<client-repo>` app actually call?"
+
+## Token tracking
+
+The host (Claude Code or compatible) provides `usage_info` per message: `{ input_tokens, output_tokens, cache_read_input_tokens, cache_creation_input_tokens }`. The skill's per-question records must capture these directly from the host's reported usage for each agent message inside that question's scope, not estimate them.
+
+- A question's `input_tokens` = sum of `input_tokens + cache_creation_input_tokens` across all agent messages emitted while answering that question.
+- A question's `output_tokens` = sum of `output_tokens`.
+- A question's `cache_read_tokens` = sum of `cache_read_input_tokens` (reported separately - cached reads are effectively free, so the report shows total-with-cache and total-without-cache).
+- If the host does not surface usage info, the skill **falls back** to char-count / 4 as a rough estimate and clearly labels the report as "estimated tokens, host did not provide usage info".
+
+## Ground truth methodology
+
+Phase 4 reads source files **directly** to determine ground truth, independent of either Phase 2 or Phase 3. The judge does not see the with-MCP or without-MCP answer until ground truth is committed. Specifically:
+
+1. Read the question.
+2. Identify the files involved using a fresh `rg`/`Read` pass (no MCP) - the judge uses grep too, to avoid favoring either side.
+3. Write the canonical answer.
+4. **Then** open `with-mcp.json` and `without-mcp.json` and score each answer:
+   - **full** - mentions every expected fact, no fabrications.
+   - **partial** - mentions some expected facts, no fabrications.
+   - **wrong** - contradicts the ground truth, or fabricates entities that don't exist.
+   - **unknown** - the agent said "I don't know" or refused.
+5. Record `misses` (expected facts not mentioned) and `extras` (fabrications or off-topic claims) per side.
+
+This methodology is honest about MCP losses. If MCP confidently returned a wrong answer, the judge marks it wrong even if it sounded authoritative.
+
+## Privacy
+
+The skill **never logs file content** in the report or in any intermediate JSON. It logs:
+
+- Entity kinds and counts.
+- File **paths** (relative to repo root).
+- Line numbers and span lengths.
+- Tool names and call counts.
+
+Source snippets are referenced by path+line, not embedded. The raw-data appendix in the report includes the agent's **answer text** (which the user wrote, and which the user is sharing voluntarily), but not source content.
+
+## Beyond the minimum (flags)
+
+- `--iterations N` - re-runs Phases 2-4 N times per question, reports median + stddev.
+- `--focus <category>` - restricts Phase 1 to one category from the nine above. Useful when the user wants to stress-test, e.g., pattern discovery.
+- `--question-set <path>` - skip Phase 1's generation, load the user's curated questions.
+- `--baseline <path>` - load a prior report, surface per-question deltas: token saved or lost, quality changes, new failure modes.
+- Cost projection - the report always extrapolates: "at this token rate, a 1000-query session would cost X with-MCP vs Y without-MCP."
+
+## Acceptance criteria
+
+- The skill's five prompt files exist and reference each other in the order documented above.
+- The skill calls `archigraph_whoami` before generating any question, and questions reference only entities actually present in the group.
+- Token counts come from the host's `usage_info`, with a labeled estimation fallback.
+- Ground truth is established by an independent grep+read pass before scoring either answer.
+- The report is written to `--output` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`).
+- The skill never spawns a daemon and never names real competitor tools in any artifact.
+
+## Outputs
+
+- `~/.archigraph/quality-check/<timestamp>/questions.json` - input set.
+- `~/.archigraph/quality-check/<timestamp>/with-mcp.json` - Phase 2 results.
+- `~/.archigraph/quality-check/<timestamp>/without-mcp.json` - Phase 3 results.
+- `~/.archigraph/quality-check/<timestamp>/judgment.json` - Phase 4 scoring.
+- `<--output>` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`) - final shareable report.
+
+## Related
+
+- `/generate-docs` - the docgen skill this benchmark gates.
+- ADR-0018 - pattern-discovery design; pattern questions in the test set verify it.
+- ADR-0015 - repair passes; repair questions verify Pass 1a/1b/3a.

--- a/skills/archigraph-quality-check/prompts/01-question-generation.md
+++ b/skills/archigraph-quality-check/prompts/01-question-generation.md
@@ -1,0 +1,75 @@
+# Phase 1 - Question generation
+
+You are generating the test set for an archigraph MCP quality benchmark. Your output is a JSON file of ~10-15 questions adapted to the registered group's actual entities. Subsequent phases will answer these questions twice (with MCP, without MCP) and compare results.
+
+## Setup
+
+1. Confirm the run directory: `~/.archigraph/quality-check/<YYYY-MM-DD-HHMMSS>/` (the orchestrator passes the exact path). Create it if missing.
+2. Call `archigraph_whoami` to resolve the group, repos, and entity stats. If this fails, **stop** and report "no daemon running" - do not start one.
+3. Capture the group's entity-kind distribution and top entities by degree using `archigraph_graph_stats` and `archigraph_list_clusters`.
+
+## Nine question categories
+
+Generate at least one question per category, totaling 10-15 questions:
+
+1. **Entity lookup** - "what is `<EntityName>`?" - pick a real high-degree entity from the group.
+2. **Reference finding** - "what calls `<Class>.<method>` (or `<function>`)?" - pick a method with ≥3 callers per graph stats.
+3. **Cross-stack tracing** - "how does `<frontend-feature>` reach the backend?" - only include if the group has more than one repo AND `archigraph_list_link_candidates` shows cross-repo edges.
+4. **Pattern discovery** - "what's the convention for adding a new `<thing>` (endpoint / handler / migration / etc.)?" - pick a kind with ≥3 promoted patterns from `archigraph_patterns(action=list)`. If none exist, replace with a structural-recurrence question.
+5. **Architecture overview** - "what are the main subsystems in this group?" - always include.
+6. **Subsystem deep-dive** - "describe `<cluster-label>`." - pick a Louvain cluster from `archigraph_list_clusters` with ≥10 members.
+7. **Specific trace** - "trace from `<entry-entity>` to the data write." - pick a real entry-point entity (HTTP route, button handler, etc.).
+8. **Data access** - "where does `<Entity>.<field>` get read or written?" - pick a domain field with ≥2 readers and ≥1 writer.
+9. **HTTP cross-repo** - "what endpoints does `<client-repo>` actually call?" - only if the group has a client + server pair.
+
+## Adaptation rules
+
+- Never invent entity names. Every entity in every question MUST exist in the group (verified via `archigraph_search` or `archigraph_describe`).
+- If a category cannot be filled (e.g., single-repo group has no cross-stack trace), record `"skipped": true` for that category with a reason string. The final report flags skipped categories.
+- If `--focus <category>` is set, only generate questions from that category (4-8 of them) and skip the others entirely.
+- If `--question-set <path>` is set, **skip auto-generation** - load that file, validate the schema below, and pass through. Each question's entities must still be verified to exist; flag any that don't.
+
+## Output schema (`questions.json`)
+
+```json
+{
+  "version": 1,
+  "group": "<group-name>",
+  "repos": ["<repo-1>", "<repo-2>"],
+  "generated_at": "<RFC3339>",
+  "focus": "<category-or-null>",
+  "questions": [
+    {
+      "id": "q01",
+      "category": "entity-lookup",
+      "question": "What is OrderService?",
+      "anchors": [
+        {"kind": "entity_name", "value": "OrderService"},
+        {"kind": "repo", "value": "shop-backend"}
+      ],
+      "expected_signals": [
+        "definition location (file + line)",
+        "kind (class/struct/module)",
+        "key methods",
+        "callers or referencers"
+      ]
+    }
+  ],
+  "skipped_categories": [
+    {"category": "cross-stack-tracing", "reason": "single-repo group"}
+  ]
+}
+```
+
+- `anchors` are the real entities the question references. The judge in Phase 4 uses them to seed ground-truth discovery.
+- `expected_signals` is a free-form list of facts the judge expects in a "full" answer. Used for scoring coverage.
+
+## Privacy and naming
+
+- Never include source-code content in the question or anchors.
+- Never use the name of any competitor tool ("predecessor MCP tool" / "Tool A" if needed).
+- File paths in anchors are relative to repo root.
+
+## Output
+
+Write `questions.json` to the run directory and print a short summary table: `id | category | question`. Do not call any tool again after the write - return control to the orchestrator.

--- a/skills/archigraph-quality-check/prompts/02-with-mcp-run.md
+++ b/skills/archigraph-quality-check/prompts/02-with-mcp-run.md
@@ -1,0 +1,79 @@
+# Phase 2 - With-MCP run
+
+Answer every question from `questions.json` using **only archigraph MCP tools**. Record full per-question metrics. Your output is `with-mcp.json` in the run directory.
+
+## Allowed tools
+
+You may call any archigraph MCP tool: `archigraph_whoami`, `archigraph_search`, `archigraph_describe`, `archigraph_related`, `archigraph_trace`, `archigraph_list_clusters`, `archigraph_get_source`, `archigraph_recent_activity`, `archigraph_list_link_candidates`, `archigraph_list_enrichment_candidates`, `archigraph_graph_stats`, `archigraph_patterns`, `archigraph_get_telemetry`, etc.
+
+You may **not** call `rg`, `grep`, `Read` on source files, or any other non-MCP file-inspection tool. If a question is unanswerable through MCP alone, record `confidence: 0.0` and mark `unknown: true` - that is a valid result.
+
+## Per-question protocol
+
+For each question in `questions.json`:
+
+1. Note the host's `usage_info` snapshot at question start (input/output/cache tokens emitted so far in this session).
+2. Note `wall_clock_start` (monotonic time, RFC3339 nanos).
+3. Answer the question using archigraph MCP tools. Take as many tool calls as needed but stop when you reach a defensible answer.
+4. Note `wall_clock_end`.
+5. Note the host's `usage_info` at question end.
+6. Compute the delta and record the metrics below.
+
+## Output schema (`with-mcp.json`)
+
+```json
+{
+  "version": 1,
+  "method": "with-mcp",
+  "iteration": 1,
+  "started_at": "<RFC3339>",
+  "ended_at": "<RFC3339>",
+  "results": [
+    {
+      "id": "q01",
+      "answer": "<the agent's prose answer>",
+      "confidence": 0.85,
+      "unknown": false,
+      "tool_calls": [
+        {"tool": "archigraph_search", "args_digest": "sha256:...", "ok": true, "ms": 142}
+      ],
+      "tool_call_count": 4,
+      "tools_used": ["archigraph_search", "archigraph_describe", "archigraph_related"],
+      "metrics": {
+        "input_tokens": 12345,
+        "output_tokens": 678,
+        "cache_read_tokens": 5000,
+        "cache_creation_tokens": 0,
+        "wall_clock_ms": 8421
+      },
+      "notes": "Mentioned archigraph_search returned 0 hits initially; widened query."
+    }
+  ]
+}
+```
+
+## Token accounting
+
+The host (Claude Code) provides `usage_info` per message. The total tokens for a question are the sums **across all agent messages emitted while answering it**:
+
+- `input_tokens` += `usage_info.input_tokens + usage_info.cache_creation_input_tokens`
+- `output_tokens` += `usage_info.output_tokens`
+- `cache_read_tokens` += `usage_info.cache_read_input_tokens`
+
+If the host does not surface `usage_info`, fall back to `len(text) / 4` for input and output respectively, and set `"estimated": true` on each result. Phase 5 will label the report accordingly.
+
+## Honesty rules
+
+- Do not retry indefinitely to "win" a question. Stop when you have a defensible answer or after a reasonable effort.
+- Record tool failures verbatim in `tool_calls[].ok = false` with the error string in `notes`. This data is used to surface MCP failure modes in the report.
+- If a tool returned partial/malformed data, note that in `notes`. Phase 5's "Issues encountered" section depends on this.
+- Confidence should reflect honest uncertainty, not match the user's expected outcome.
+
+## Privacy
+
+- The `answer` field may include entity names, file paths, line numbers, kinds, and structural facts. It must **not** include source-code content. Reference snippets by `path:line`, not by embedded code.
+- `tool_calls[].args_digest` is a SHA-256 of the arguments, not the raw arguments. This protects entity strings the user may consider private.
+
+## Output
+
+Write `with-mcp.json` to the run directory and print a one-line summary: `<n> questions answered, <unknown> unknown, total <tokens> tokens, total <wall_ms>ms`. Return control to the orchestrator.

--- a/skills/archigraph-quality-check/prompts/03-without-mcp-run.md
+++ b/skills/archigraph-quality-check/prompts/03-without-mcp-run.md
@@ -1,0 +1,89 @@
+# Phase 3 - Without-MCP run
+
+Answer the **same** questions from `questions.json` using **only** `rg` / `ripgrep` / `grep` / `Read` / `Bash` (no archigraph MCP). Use the best non-MCP approach for each question - give grep+read a fair shot. Your output is `without-mcp.json`.
+
+## Forbidden tools
+
+- Any `archigraph_*` MCP tool.
+- Any reference to a prior MCP answer in `with-mcp.json` (do not open that file in this phase).
+- Any external code-search service.
+
+If you accidentally see archigraph state on disk (e.g., `.archigraph/graph.json`), do not read it - it would leak MCP results into a grep-only run.
+
+## Allowed approach per category
+
+These are reasonable best-effort strategies. Use whichever you would honestly use in a real grep-only session:
+
+- **Entity lookup** - `rg -n 'class EntityName|struct EntityName|def EntityName'` then `Read` the definition file.
+- **Reference finding** - `rg -n 'EntityName\.methodName\('` recursively, count results.
+- **Cross-stack tracing** - `rg -n` for the entry-point keyword in the client repo, then `rg` the response shape in the server repo. Multi-pass.
+- **Pattern discovery** - sample 3-5 instances of the kind via `rg`, read each, summarize the recurrence.
+- **Architecture overview** - read top-level directory structure of each repo + each README + each `cmd/` or `apps/` subdir.
+- **Subsystem deep-dive** - `rg` the subsystem keyword, follow imports, summarize.
+- **Specific trace** - read the entry file, follow imports manually, multi-hop.
+- **Data access** - `rg -n '\.fieldName'` then filter to read vs write contexts.
+- **HTTP cross-repo** - `rg -n 'fetch\(|axios\.|http\.' client-repo`, then for each URL `rg -n` the matching route in server-repo.
+
+## Per-question protocol
+
+Identical to Phase 2 but using grep tools instead of MCP:
+
+1. Snapshot `usage_info` at question start.
+2. Note `wall_clock_start`.
+3. Answer using `rg` / `Read` / `Bash`. Keep tool calls bounded but fair - if a grep takes 3 passes, take the 3 passes.
+4. Note `wall_clock_end`.
+5. Snapshot `usage_info` at question end.
+6. Record metrics.
+
+## Output schema (`without-mcp.json`)
+
+```json
+{
+  "version": 1,
+  "method": "without-mcp",
+  "iteration": 1,
+  "started_at": "<RFC3339>",
+  "ended_at": "<RFC3339>",
+  "results": [
+    {
+      "id": "q01",
+      "answer": "<the agent's prose answer>",
+      "confidence": 0.7,
+      "unknown": false,
+      "tool_calls": [
+        {"tool": "rg", "args_digest": "sha256:...", "ok": true, "ms": 88},
+        {"tool": "Read", "args_digest": "sha256:...", "ok": true, "ms": 12}
+      ],
+      "tool_call_count": 6,
+      "tools_used": ["rg", "Read"],
+      "metrics": {
+        "input_tokens": 8200,
+        "output_tokens": 612,
+        "cache_read_tokens": 4100,
+        "cache_creation_tokens": 0,
+        "wall_clock_ms": 5104
+      },
+      "notes": "Initial rg returned 200+ hits; narrowed pattern to method signature."
+    }
+  ]
+}
+```
+
+## Fairness rules
+
+- Use the best grep query you can think of, not a deliberately weak one. The benchmark is meaningless if the grep run is straw-manned.
+- If the grep+read approach genuinely cannot answer a question (e.g., "what are the main subsystems" - hard without graph data), record `unknown: true` and a `notes` field explaining what stopped you. This is signal, not failure.
+- Do not consult any cached or memorized prior knowledge about archigraph or the codebase that would not be available to a grep-only agent.
+
+## Token accounting
+
+Same protocol as Phase 2. Use the host's `usage_info`; fall back to char/4 with `"estimated": true` if unavailable.
+
+## Privacy
+
+- Same constraints as Phase 2: no source content in answer text; reference by `path:line`.
+- `args_digest` not raw args.
+
+## Output
+
+Write `without-mcp.json`. Print a one-line summary mirroring Phase 2's. Return to orchestrator.

--- a/skills/archigraph-quality-check/prompts/04-quality-judgment.md
+++ b/skills/archigraph-quality-check/prompts/04-quality-judgment.md
@@ -1,0 +1,77 @@
+# Phase 4 - Quality judgment
+
+Judge both runs against an **independently established ground truth**. Your output is `judgment.json`. You must establish ground truth **before** opening either run's answers, to avoid anchoring on whichever side sounded more confident.
+
+## Protocol
+
+For each question in `questions.json`:
+
+### Step A - Establish ground truth (independent)
+
+1. Read the question and its `anchors` + `expected_signals`.
+2. Use `rg` / `Read` / `Bash` only (no archigraph MCP - the judge uses grep so it does not favor MCP). Read the actual source code.
+3. Write the canonical answer: definition locations, callers, kinds, fields, line numbers - whatever the `expected_signals` call for.
+4. Commit the ground truth to memory (write it into your scratch) **before** you open `with-mcp.json` or `without-mcp.json`.
+
+### Step B - Score with-MCP
+
+5. Open `with-mcp.json`, read the `answer` for this question.
+6. Score against ground truth:
+   - **full** - mentions every expected fact, no fabrications.
+   - **partial** - mentions some expected facts, no fabrications.
+   - **wrong** - contradicts ground truth, OR fabricates entities / paths / lines that do not exist.
+   - **unknown** - the agent said "I don't know" or set `unknown: true`.
+7. Record `misses` (expected facts not mentioned) and `extras` (fabrications or off-topic claims).
+
+### Step C - Score without-MCP
+
+8. Open `without-mcp.json`, read the `answer` for the same question.
+9. Score with the same rubric.
+10. Record `misses` and `extras` for this side too.
+
+### Honesty rule
+
+If MCP confidently returned a wrong answer, mark it `wrong`. Do not soften scoring for either side. The whole point of the skill is honest measurement.
+
+## Output schema (`judgment.json`)
+
+```json
+{
+  "version": 1,
+  "judged_at": "<RFC3339>",
+  "judgments": [
+    {
+      "id": "q01",
+      "ground_truth_summary": "OrderService is a Go struct in shop-backend/internal/order/service.go:18, with 4 methods (Create, Get, Update, Cancel). Called from 12 sites across 3 packages.",
+      "ground_truth_anchors": [
+        {"path": "shop-backend/internal/order/service.go", "line": 18, "kind": "struct"}
+      ],
+      "with_mcp": {
+        "score": "full",
+        "misses": [],
+        "extras": [],
+        "rationale": "Mentioned definition, all 4 methods, and caller count. Matches ground truth."
+      },
+      "without_mcp": {
+        "score": "partial",
+        "misses": ["caller count (rg returned too many false positives to count cleanly)"],
+        "extras": [],
+        "rationale": "Found definition and methods but stopped on caller enumeration."
+      }
+    }
+  ],
+  "aggregate": {
+    "with_mcp": {"full": 8, "partial": 4, "wrong": 1, "unknown": 1},
+    "without_mcp": {"full": 5, "partial": 6, "wrong": 1, "unknown": 2}
+  }
+}
+```
+
+## Privacy
+
+- Ground-truth content in `ground_truth_summary` should be a description of the structural facts (kinds, paths, line numbers, counts) and **not** include source-code snippets.
+- `ground_truth_anchors` carries `path`, `line`, `kind` - no source content.
+
+## Output
+
+Write `judgment.json` and print the aggregate scoreboard. Return to orchestrator.

--- a/skills/archigraph-quality-check/prompts/05-report.md
+++ b/skills/archigraph-quality-check/prompts/05-report.md
@@ -1,0 +1,150 @@
+# Phase 5 - Report generation
+
+Render the final shareable markdown report from the four JSON artifacts in the run directory. Write it to `--output` (default `~/private/benchmarks/mcp-quality-bench-<YYYY-MM-DD>.md`) and also copy it to `<run-dir>/report.md`.
+
+## Inputs
+
+- `questions.json`
+- `with-mcp.json` (or `with-mcp-iter-<N>.json` files if `--iterations > 1`)
+- `without-mcp.json` (same)
+- `judgment.json`
+- Optional `--baseline <path>` - prior report markdown for regression diffing.
+
+## Report structure
+
+```markdown
+# Archigraph MCP Quality Benchmark - <YYYY-MM-DD>
+
+**Group:** `<group>`
+**Repos:** `<repo-1>`, `<repo-2>`
+**Run directory:** `~/.archigraph/quality-check/<timestamp>/`
+**Iterations:** `<N>` (median/stddev reported when N > 1)
+**Token source:** `host usage_info` (or `estimated (host did not surface usage)`)
+**Focus:** `<category or "all">`
+
+## Test set
+`<N>` questions across categories: entity-lookup (x), reference-finding (x), cross-stack-tracing (x), pattern-discovery (x), architecture-overview (x), subsystem-deep-dive (x), specific-trace (x), data-access (x), http-cross-repo (x).
+
+Skipped categories: `<list with reasons>`.
+
+## Token economy
+
+| Method | Input tokens | Cache-read tokens | Output tokens | Total (input+output) | Per-question median |
+|---|---:|---:|---:|---:|---:|
+| With MCP | ... | ... | ... | ... | ... |
+| Without MCP (grep+read) | ... | ... | ... | ... | ... |
+| **Ratio MCP / grep (lower=MCP wins)** | ... | | ... | ... | ... |
+
+Lower-is-better ratios highlighted: **bold** if MCP wins, *italic* if grep wins, plain if tie.
+
+### Cost projection
+At this token rate, a 1000-query session would cost roughly:
+- With MCP: ~`<X>` tokens
+- Without MCP: ~`<Y>` tokens
+- Delta: `<Z>` tokens saved (or burned) by using the MCP
+
+## Speed
+
+| Method | Median per-question (ms) | P95 (ms) | Total wall-clock (ms) | Median tool calls per question |
+|---|---:|---:|---:|---:|
+| With MCP | ... | ... | ... | ... |
+| Without MCP | ... | ... | ... | ... |
+
+## Quality
+
+| Method | Full | Partial | Wrong | Unknown | Avg confidence | Net quality (full=1, partial=0.5, wrong=-0.5, unknown=0) |
+|---|---:|---:|---:|---:|---:|---:|
+| With MCP | ... | ... | ... | ... | ... | ... |
+| Without MCP | ... | ... | ... | ... | ... | ... |
+
+## Per-question breakdown
+
+| # | Category | Question | With-MCP tokens | Without-MCP tokens | Token ratio | With-MCP quality | Without-MCP quality |
+|---|---|---|---:|---:|---:|---|---|
+
+Token ratio formatted as `0.42×` (MCP saved 58%) or `2.10×` (MCP burned 110% more).
+
+## Findings
+
+### Where MCP wins
+- `<question id + concrete example>` - bullet describing the win with the cite to the per-question row.
+
+### Where MCP loses
+- `<question id + concrete example>` - what MCP missed or burned tokens on, plus the visible root cause if any (e.g., "archigraph_search returned 0 hits because the entity name uses a non-ASCII suffix").
+
+### Surprising patterns
+- Anything that does not fit the above two buckets.
+
+## Issues encountered
+
+For each `tool_calls[].ok = false` in `with-mcp.json` or notes about malformed data:
+
+- **Tool errors** - `<tool>` returned `<error>` on `<question id>`.
+- **Malformed responses** - `<tool>` returned data missing field `<x>` on `<question id>`.
+- **Tool description quality** - questions where the agent picked the wrong tool first; suggests the description is unclear.
+- **Cost-model mismatches** - queries that took >2× the median time. Hint at a slow tool path.
+
+## Recommendations
+
+Concrete tuning ideas for the archigraph coordinator. Each recommendation cites the question(s) that motivated it.
+
+- **Tool description for `archigraph_<X>`** - rewrite to clarify `<Y>` (cites: q03, q07).
+- **Add cache for `<call pattern>`** - the agent ran the same call N times on q05; consider memoization.
+- **Pattern discovery weak on `<kind>`** - q08 missed obvious recurrence; suggests Phase 4 of ADR-0018 needs `<X>`.
+- **Doc-gen flow should leverage `<MCP capability>`** - q02 showed a 6× token saving for reference finding; docgen should call this tool directly instead of round-tripping through `archigraph_search`.
+
+### Anti-patterns to avoid
+- `<X>` - observed in q04, costs N tokens per occurrence.
+
+## Regression diff (if --baseline provided)
+
+| Question | Prior with-MCP tokens | Current | Δ | Prior quality | Current | Δ |
+
+Summary deltas: total token change, quality change, new failure modes.
+
+## Raw data appendix
+
+Full per-question dump for verification:
+
+### q01 - `<question>`
+- **Category:** `<>`
+- **Anchors:** `<>`
+- **Expected signals:** `<>`
+- **With-MCP answer:** `<verbatim answer text>`
+- **With-MCP tool calls:** `<list>` (`<count>` total)
+- **With-MCP metrics:** input=`<>`, output=`<>`, cache=`<>`, wall=`<>`ms, conf=`<>`
+- **Without-MCP answer:** `<verbatim answer text>`
+- **Without-MCP tool calls:** `<list>` (`<count>` total)
+- **Without-MCP metrics:** input=`<>`, output=`<>`, cache=`<>`, wall=`<>`ms, conf=`<>`
+- **Ground truth:** `<summary>`
+- **Judgment - with-MCP:** `<score>` - rationale: `<>` - misses: `<>` - extras: `<>`
+- **Judgment - without-MCP:** `<score>` - rationale: `<>` - misses: `<>` - extras: `<>`
+
+(repeat for each question)
+
+## Methodology notes
+
+- Token counts sourced from the host's `usage_info` per message. When the host did not surface usage, char/4 estimation was used and the table header reads "(estimated)".
+- Ground truth established by an independent grep+read pass before either run's answer was opened.
+- The judge used `rg` / `Read` (not the MCP) so it does not favor either side.
+- No source-code content was logged in any intermediate JSON or in this report - only paths, kinds, line numbers, and the agent's prose answer.
+- The skill ran against the user's existing archigraph daemon; no daemon was spawned by the skill.
+```
+
+## Generation rules
+
+- **Always compute the cost projection**, even when only one iteration ran.
+- **Always render the per-question breakdown** - this is the table the user copies to the coordinator.
+- For `--iterations N > 1`, report median ± stddev in the token / speed tables, and use the median in the per-question breakdown.
+- When `--baseline` is provided, render the regression diff section; otherwise omit it (do not show empty placeholders).
+- Find the run dir's `iter-*.json` files if `--iterations > 1` and aggregate before rendering.
+
+## Privacy
+
+- Quote the agent's answers verbatim in the appendix (the user wrote them and is sharing voluntarily).
+- Do not include source-code snippets - paths, lines, kinds only.
+- Do not name competitor tools anywhere - use "predecessor MCP tool" or "Tool A" if you must reference the earlier benchmark context.
+
+## Output
+
+Write the report to `--output` (default `~/private/benchmarks/mcp-quality-bench-<YYYY-MM-DD>.md`, creating parent directories if missing) and copy it to `<run-dir>/report.md`. Print the absolute output path and a one-line scoreboard: `with-MCP: <full/partial/wrong/unknown>, without-MCP: <full/partial/wrong/unknown>, token ratio: <X>×`. Return control to the orchestrator.


### PR DESCRIPTION
## Summary

New `/archigraph-quality-check` skill that runs **before** `/generate-docs` to validate the MCP foundation. Head-to-head benchmark between archigraph MCP and grep+read across 10-15 questions adapted to the registered group's real entities, with an independent grep-based ground-truth pass and a shareable markdown report.

Addresses the concern from earlier benchmarks of a predecessor MCP tool (3-6× more tokens than grep+read without quality gains). This skill is the gate that confirms archigraph does not have the same failure mode on the user's group.

## Structure

```
skills/archigraph-quality-check/
  SKILL.md                                # frontmatter + 5-phase pipeline doc
  prompts/
    01-question-generation.md             # archigraph_whoami → 9 categories
    02-with-mcp-run.md                    # MCP-only answer + host usage_info
    03-without-mcp-run.md                 # rg/Read/Bash only; same metrics
    04-quality-judgment.md                # independent ground truth, then score
    05-report.md                          # tables + findings + appendix
```

## Highlights

- 9 question categories (entity lookup, reference finding, cross-stack tracing, pattern discovery, architecture overview, subsystem deep-dive, specific trace, data access, HTTP cross-repo) - adapted to the group's actual entities, never invented.
- Token counts come from the host's `usage_info` per message (input + cache_creation + output + cache_read), with a labeled `len/4` fallback.
- Ground truth established **before** opening either run's answer, using grep+read (judge does not favor MCP).
- Daemon discipline: runs against the user's existing daemon, never spawns one.
- Privacy: logs only paths, kinds, line numbers, counts - never source content. `args_digest` SHA-256 instead of raw tool arguments.
- Beyond the minimum: `--iterations` (median+stddev), `--focus <category>`, `--question-set <path>`, `--baseline <path>` regression diff, 1000-query cost projection.

## Test plan

- [ ] `ls skills/archigraph-quality-check/prompts/0[1-5]-*.md` shows all 5 phase prompts.
- [ ] `grep prompts/0 skills/archigraph-quality-check/SKILL.md` confirms SKILL.md references every phase.
- [ ] SKILL.md frontmatter has `name`, `description`, `when-to-use` - matches the harness's skill-loading contract.
- [ ] No competitor tool names appear anywhere: `grep -riE '(gitnexus|graphify|gfleet)' skills/archigraph-quality-check/` returns nothing.
- [ ] Manual smoke: invoke `/archigraph-quality-check` on a small registered group, verify the report renders with all sections.

Closes #739