### PR TITLE
[#722] Response shape extraction for HTTP endpoints (multi-framework)

### DIFF
--- a/internal/engine/detector_test.go
+++ b/internal/engine/detector_test.go
@@ -281,6 +281,13 @@ func TestDetect_GinEntityProperties(t *testing.T) {
 		if e.Language != "go" {
 			t.Errorf("entity %q: Language = %q, want go", e.Name, e.Language)
 		}
+		// Synthetic http_endpoint entities emitted by the response-shape
+		// pass (#722) intentionally carry framework=gin / pattern_type=
+		// http_endpoint_synthesis — those are not subject to the YAML
+		// invariants below.
+		if e.Kind == httpEndpointKind {
+			continue
+		}
 		if e.Properties["framework"] != "go" {
 			t.Errorf("entity %q: framework property = %q, want go", e.Name, e.Properties["framework"])
 		}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -67,7 +67,7 @@ const implementsEdgeKind = "IMPLEMENTS"
 // are compiled for its language.
 func synthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "java", "python", "javascript", "typescript":
+	case "java", "python", "javascript", "typescript", "go":
 		return true
 	default:
 		return false
@@ -176,7 +176,15 @@ func applyHTTPEndpointSynthesis(
 		// Consumer side (#533 Phase 1): fetch / axios / generic *Client
 		// HTTP client calls.
 		synthesizeFetchAxios(string(content), emitClient)
+	case "go":
+		// Producer side: Gin / Echo / Chi route registrations. #722.
+		synthesizeGoRouters(string(content), emit)
 	}
+
+	// #722 — response/request shape extraction. Mutates Properties on
+	// the synthetic entities emitted above; never adds or removes
+	// entities, so it cannot regress the bug-rate of upstream passes.
+	applyResponseShapes(lang, content, entities)
 
 	return entities, relationships
 }

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -25,6 +25,13 @@ const (
 	FrameworkSpring  = "spring"
 	FrameworkJAXRS   = "jaxrs"
 	FrameworkExpress = "express"
+	// FrameworkGin, FrameworkEcho, FrameworkChi (#722) share Express's
+	// `:name` parameter convention; their canonicalisation reuses the
+	// colon-param walker. They are listed as distinct constants so call
+	// sites in per-language extractors read naturally.
+	FrameworkGin  = "gin"
+	FrameworkEcho = "echo"
+	FrameworkChi  = "chi"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -47,7 +54,7 @@ func Canonicalize(framework, raw string) string {
 		out = canonicalizeAngleBrackets(raw)
 	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS:
 		out = canonicalizeCurlyBraces(raw)
-	case FrameworkExpress:
+	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi:
 		out = canonicalizeColonParams(raw)
 	default:
 		// Unknown framework: pass through but still normalise slashes.

--- a/internal/engine/response_shape.go
+++ b/internal/engine/response_shape.go
@@ -1,0 +1,372 @@
+// Response-shape extraction for synthetic http_endpoint entities (#722).
+//
+// For every http_endpoint that the synthesis pass emits, this module walks
+// the same file looking for the named handler function body, parses the
+// return statements, and records:
+//
+//   - response_keys      top-level keys of literal-object responses
+//   - response_schema    {key: type} JSON map when type info is statically
+//                        recoverable (Spring DTO, JAX-RS @Schema, Pydantic
+//                        BaseModel, Go struct, NestJS DTO class)
+//   - error_keys         keys observed in 4xx/5xx returns
+//   - status_codes       sorted comma-separated list of emitted HTTP codes
+//   - request_keys       request-body shape (FastAPI Pydantic param,
+//                        NestJS @Body() Dto, Spring @RequestBody Dto)
+//   - request_schema     same shape as response_schema for the request body
+//   - response_keys_known=false when the return value is a free variable
+//     that we cannot statically resolve to a literal/typed shape.
+//
+// All properties are stored on the http_endpoint entity (Properties is
+// map[string]string) — list values are joined with `,` for grep-friendly
+// queries, schema maps are stored as a stable JSON-serialised string
+// sorted by key for deterministic output.
+//
+// The pass is deliberately additive: when extraction fails it sets
+// response_keys_known=false and leaves the rest unset. It never removes
+// an existing property.
+package engine
+
+import (
+	"encoding/json"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// shape collects everything we learn about one endpoint's request/response
+// shape from scanning a single handler. Empty fields are not written to
+// the entity properties.
+type shape struct {
+	responseKeys    []string
+	responseSchema  map[string]string
+	errorKeys       []string
+	statusCodes     []int
+	requestKeys     []string
+	requestSchema   map[string]string
+	knownResponse   bool // true when at least one return was statically parsed
+	dynamicResponse bool // true when we saw a non-literal return value
+}
+
+// applyResponseShapes scans the freshly-emitted http_endpoint entities and
+// attaches response/request shape properties extracted from the same file.
+// It is safe to call with content==nil (no-op) and with frameworks that
+// have no response-shape support (the per-framework dispatch falls through).
+//
+// The `entities` slice is the post-synthesis list returned by
+// applyHTTPEndpointSynthesis. We mutate Properties in place.
+func applyResponseShapes(lang string, content []byte, entities []types.EntityRecord) {
+	if len(content) == 0 || len(entities) == 0 {
+		return
+	}
+	src := string(content)
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		if e.Properties == nil {
+			continue
+		}
+		framework := e.Properties["framework"]
+		handler := e.Properties["source_handler"]
+		// source_handler is stored as "<Kind>:<Name>" (see emit closure
+		// in http_endpoint_synthesis.go). Strip both common prefixes so
+		// per-framework body scanners can use the bare handler name.
+		if idx := strings.Index(handler, ":"); idx >= 0 {
+			handler = handler[idx+1:]
+		}
+		var sh shape
+		switch framework {
+		case "django", "flask", "fastapi":
+			// Always try the FastAPI walks (response_model decorator,
+			// Pydantic request-body annotation) regardless of which
+			// Python synth fired — the framework label is set by
+			// whichever regex matches first, but the extraction logic
+			// is additive and FastAPI projects often share decorator
+			// shapes with Flask blueprints (#722).
+			sh = extractPythonShape(src, handler, "fastapi")
+		case "express":
+			sh = extractJSShape(src, handler, "express")
+		case "nestjs":
+			sh = extractJSShape(src, handler, "nestjs")
+		case "spring_mvc":
+			sh = extractJavaShape(src, handler, "spring_mvc")
+		case "jaxrs":
+			sh = extractJavaShape(src, handler, "jaxrs")
+		case "gin", "echo", "chi":
+			sh = extractGoShape(src, handler, framework)
+		default:
+			continue
+		}
+		if !sh.knownResponse && !sh.dynamicResponse {
+			continue
+		}
+		writeShapeProps(e.Properties, sh)
+	}
+}
+
+// writeShapeProps serialises a shape struct onto an entity's Properties
+// map. Lists go in as comma-joined values; schemas go in as a stable JSON
+// string sorted by key for deterministic output.
+func writeShapeProps(props map[string]string, sh shape) {
+	if props == nil {
+		return
+	}
+	if sh.dynamicResponse && !sh.knownResponse {
+		props["response_keys_known"] = "false"
+		return
+	}
+	if sh.knownResponse {
+		props["response_keys_known"] = "true"
+	}
+	if len(sh.responseKeys) > 0 {
+		props["response_keys"] = joinUniqueSorted(sh.responseKeys)
+	}
+	if len(sh.errorKeys) > 0 {
+		props["error_keys"] = joinUniqueSorted(sh.errorKeys)
+	}
+	if len(sh.statusCodes) > 0 {
+		props["status_codes"] = joinIntsSorted(sh.statusCodes)
+	}
+	if len(sh.requestKeys) > 0 {
+		props["request_keys"] = joinUniqueSorted(sh.requestKeys)
+	}
+	if len(sh.responseSchema) > 0 {
+		if s := marshalSchema(sh.responseSchema); s != "" {
+			props["response_schema"] = s
+		}
+	}
+	if len(sh.requestSchema) > 0 {
+		if s := marshalSchema(sh.requestSchema); s != "" {
+			props["request_schema"] = s
+		}
+	}
+}
+
+func joinUniqueSorted(in []string) string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		s = strings.TrimSpace(s)
+		if s == "" || seen[s] {
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	sort.Strings(out)
+	return strings.Join(out, ",")
+}
+
+func joinIntsSorted(in []int) string {
+	seen := map[int]bool{}
+	out := make([]int, 0, len(in))
+	for _, n := range in {
+		if seen[n] {
+			continue
+		}
+		seen[n] = true
+		out = append(out, n)
+	}
+	sort.Ints(out)
+	parts := make([]string, len(out))
+	for i, n := range out {
+		parts[i] = strconv.Itoa(n)
+	}
+	return strings.Join(parts, ",")
+}
+
+func marshalSchema(m map[string]string) string {
+	if len(m) == 0 {
+		return ""
+	}
+	// json.Marshal of map[string]string emits keys in alphabetical
+	// order, so the resulting string is deterministic.
+	b, err := json.Marshal(m)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// ---------------------------------------------------------------------------
+// Common helpers
+// ---------------------------------------------------------------------------
+
+// dictKeyRe matches `"key":` / `'key':` style key declarations.
+var dictKeyRe = regexp.MustCompile(`["']([A-Za-z_][\w-]*)["']\s*:`)
+
+// bareKeyRe matches JS-shorthand `key:` declarations (no quotes).
+var bareKeyRe = regexp.MustCompile(`(?:^|[{,]\s*)([A-Za-z_]\w*)\s*:`)
+
+// extractDictKeys returns the top-level keys of a Python/JS dict/object
+// literal expressed as a string. Only literal `"key":` / `'key':` or
+// bare-word `key:` pairs are extracted; nested objects are skipped via
+// brace-depth tracking. Returns nil when the body is not a literal object
+// (e.g. a variable name).
+func extractDictKeys(body string) []string {
+	body = strings.TrimSpace(body)
+	if !(strings.HasPrefix(body, "{") && strings.HasSuffix(body, "}")) {
+		return nil
+	}
+	inner := body[1 : len(body)-1]
+	// Walk top-level only — track brace/paren/bracket depth so we don't
+	// pick up keys nested inside arrays or sub-objects.
+	var topLevel strings.Builder
+	depth := 0
+	inStr := byte(0)
+	esc := false
+	for i := 0; i < len(inner); i++ {
+		c := inner[i]
+		if esc {
+			esc = false
+			topLevel.WriteByte(c)
+			continue
+		}
+		if inStr != 0 {
+			if c == '\\' {
+				esc = true
+			} else if c == inStr {
+				inStr = 0
+			}
+			topLevel.WriteByte(c)
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			inStr = c
+			topLevel.WriteByte(c)
+		case '{', '(', '[':
+			depth++
+			topLevel.WriteByte(c)
+		case '}', ')', ']':
+			depth--
+			topLevel.WriteByte(c)
+		default:
+			if depth == 0 {
+				topLevel.WriteByte(c)
+			} else {
+				topLevel.WriteByte(' ') // preserve offsets
+			}
+		}
+	}
+	flat := topLevel.String()
+	var keys []string
+	for _, m := range dictKeyRe.FindAllStringSubmatch(flat, -1) {
+		keys = append(keys, m[1])
+	}
+	if len(keys) == 0 {
+		for _, m := range bareKeyRe.FindAllStringSubmatch(flat, -1) {
+			keys = append(keys, m[1])
+		}
+	}
+	return keys
+}
+
+// findMatchingBracket returns the index of the closing `}`/`)`/`]` that
+// matches the opening bracket at position `start` (which MUST point at
+// one of `{([`). Returns -1 on overrun. Tracks string literals (single,
+// double, backtick) so braces inside strings are ignored.
+func findMatchingBracket(s string, start int) int {
+	if start >= len(s) {
+		return -1
+	}
+	open := s[start]
+	var closeCh byte
+	switch open {
+	case '{':
+		closeCh = '}'
+	case '(':
+		closeCh = ')'
+	case '[':
+		closeCh = ']'
+	default:
+		return -1
+	}
+	depth := 0
+	inStr := byte(0)
+	esc := false
+	for i := start; i < len(s); i++ {
+		c := s[i]
+		if esc {
+			esc = false
+			continue
+		}
+		if inStr != 0 {
+			if c == '\\' {
+				esc = true
+				continue
+			}
+			if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			inStr = c
+		case open:
+			depth++
+		case closeCh:
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// extractArgList returns the comma-separated top-level arguments of a
+// function call starting at `(` at index `start`. Useful for parsing
+// `Response({...}, status=400)` and `c.JSON(http.StatusOK, gin.H{...})`.
+func extractArgList(s string, start int) []string {
+	if start >= len(s) || s[start] != '(' {
+		return nil
+	}
+	end := findMatchingBracket(s, start)
+	if end < 0 {
+		return nil
+	}
+	inner := s[start+1 : end]
+	var args []string
+	depth := 0
+	inStr := byte(0)
+	esc := false
+	last := 0
+	for i := 0; i < len(inner); i++ {
+		c := inner[i]
+		if esc {
+			esc = false
+			continue
+		}
+		if inStr != 0 {
+			if c == '\\' {
+				esc = true
+			} else if c == inStr {
+				inStr = 0
+			}
+			continue
+		}
+		switch c {
+		case '"', '\'', '`':
+			inStr = c
+		case '{', '(', '[':
+			depth++
+		case '}', ')', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				args = append(args, strings.TrimSpace(inner[last:i]))
+				last = i + 1
+			}
+		}
+	}
+	if last < len(inner) {
+		args = append(args, strings.TrimSpace(inner[last:]))
+	}
+	return args
+}

--- a/internal/engine/response_shape_go.go
+++ b/internal/engine/response_shape_go.go
@@ -1,0 +1,314 @@
+// Go response-shape extraction for Gin / Echo / Chi handlers.
+//
+// Patterns recognized inside a handler body:
+//
+//   - c.JSON(http.StatusOK, gin.H{"a": 1, "b": "x"})    Gin map literal
+//   - c.JSON(200, &MyDto{A: 1, B: "x"})                 typed struct
+//   - c.JSON(http.StatusBadRequest, gin.H{"error":...}) error path
+//   - c.JSON(200, structInstance)                        free variable
+//   - render.JSON(w, r, payload)                         Chi via go-chi/render
+//   - json.NewEncoder(w).Encode(payload)                 Chi stdlib
+//   - return ctx.JSON(http.StatusOK, dto)                Echo
+//
+// For typed responses (`&MyDto{...}` or a named identifier whose type
+// resolves to a struct in this file), the struct's exported fields are
+// walked into response_schema.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// goRouteRe matches the canonical Gin / Echo / Chi route registration:
+//
+//	r.GET("/path", handlerFunc)
+//	router.POST("/users/:id", h.Create)
+//	app.DELETE("/users/:id", deleteUser)
+//
+// Group 1 is the verb, group 2 is the path, group 3 is the handler
+// identifier (may be qualified, e.g. `h.Create`). The handler is the
+// bare or last-component name so the shape extractor can locate its
+// definition in the same file.
+var goRouteRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*(GET|POST|PUT|PATCH|DELETE|HEAD|OPTIONS)\s*\(\s*` +
+		"`" + `?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]` + "`" + `?\s*,\s*([\w.]+)`,
+)
+
+// goFrameworkFromImports returns the framework name based on package
+// imports observable in the source. Falls back to "gin" when none of
+// the three explicit markers match (Gin is the most common, and the
+// response-shape extractor treats gin/echo/chi identically).
+func goFrameworkFromImports(content string) string {
+	switch {
+	case strings.Contains(content, "github.com/labstack/echo"):
+		return "echo"
+	case strings.Contains(content, "github.com/go-chi/chi"):
+		return "chi"
+	case strings.Contains(content, "github.com/gin-gonic/gin"):
+		return "gin"
+	}
+	return "gin"
+}
+
+// synthesizeGoRouters scans a Go file for HTTP route registrations
+// against a Gin, Echo, or Chi router and emits one http_endpoint per
+// (verb, path) pair. The handler identifier is recorded so the response
+// shape extractor can walk back to the handler body.
+func synthesizeGoRouters(content string, emit emitFn) {
+	if !strings.Contains(content, ".GET(") && !strings.Contains(content, ".POST(") &&
+		!strings.Contains(content, ".PUT(") && !strings.Contains(content, ".PATCH(") &&
+		!strings.Contains(content, ".DELETE(") && !strings.Contains(content, ".HEAD(") &&
+		!strings.Contains(content, ".OPTIONS(") {
+		return
+	}
+	framework := goFrameworkFromImports(content)
+	for _, m := range goRouteRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		verb := m[1]
+		raw := m[2]
+		handler := m[3]
+		// Use the last `.`-separated component so a `h.Create` style
+		// handler resolves to `Create` in the same file's func decls.
+		if i := strings.LastIndex(handler, "."); i >= 0 {
+			handler = handler[i+1:]
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkGin, raw)
+		emit(verb, canonical, framework, "Controller", handler)
+	}
+}
+
+// goFuncOpenRe locates the brace that opens a Go function or method
+// named `handler`. We support both top-level `func name(` and receiver
+// methods `func (r *T) name(`.
+func goFuncOpenRe(handler string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?m)^func\s*(?:\(\s*\w+\s+\*?\w+\s*\)\s*)?` + regexp.QuoteMeta(handler) + `\s*\(`,
+	)
+}
+
+// goJSONCallRe matches the standard Gin/Echo response idiom:
+//
+//	c.JSON(<status>, <payload>)
+//
+// where `<status>` is either an int literal or http.StatusXxx and
+// `<payload>` is what we want to inspect.
+var goJSONCallRe = regexp.MustCompile(`\b\w+\s*\.\s*JSON\s*\(`)
+
+// goStatusLiteralRe captures both `200` and `http.StatusOK` arguments.
+var goStatusLiteralRe = regexp.MustCompile(`^(?:(\d{3})|http\.Status([A-Z][A-Za-z]+))$`)
+
+func extractGoShape(src, handler, framework string) shape {
+	var sh shape
+	if handler == "" {
+		return sh
+	}
+	body := findGoHandlerBody(src, handler)
+	if body == "" {
+		return sh
+	}
+	// Walk every c.JSON(...) call in the body.
+	for _, idx := range goJSONCallRe.FindAllStringIndex(body, -1) {
+		paren := idx[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) < 2 {
+			continue
+		}
+		status := parseGoStatusArg(args[0])
+		payload := strings.TrimSpace(args[1])
+		applyGoPayload(src, payload, status, &sh)
+	}
+	// render.JSON(w, r, payload).
+	for _, m := range regexp.MustCompile(`\brender\s*\.\s*JSON\s*\(`).FindAllStringIndex(body, -1) {
+		paren := m[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) < 3 {
+			continue
+		}
+		applyGoPayload(src, strings.TrimSpace(args[2]), 200, &sh)
+	}
+	// json.NewEncoder(w).Encode(payload).
+	for _, m := range regexp.MustCompile(`json\.NewEncoder\([^)]*\)\.Encode\s*\(`).FindAllStringIndex(body, -1) {
+		paren := m[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) < 1 {
+			continue
+		}
+		applyGoPayload(src, strings.TrimSpace(args[0]), 200, &sh)
+	}
+	return sh
+}
+
+func findGoHandlerBody(src, handler string) string {
+	re := goFuncOpenRe(handler)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return ""
+	}
+	// Find the `{` after the closing `)` of the signature.
+	open := strings.Index(src[loc[1]:], "{")
+	if open < 0 {
+		return ""
+	}
+	braceIdx := loc[1] + open
+	end := findMatchingBracket(src, braceIdx)
+	if end < 0 {
+		return ""
+	}
+	return src[braceIdx+1 : end]
+}
+
+func parseGoStatusArg(arg string) int {
+	arg = strings.TrimSpace(arg)
+	m := goStatusLiteralRe.FindStringSubmatch(arg)
+	if m == nil {
+		return 0
+	}
+	if m[1] != "" {
+		if n, err := atoi(m[1]); err == nil {
+			return n
+		}
+	}
+	if m[2] != "" {
+		return goHTTPStatusFromName(m[2])
+	}
+	return 0
+}
+
+// goHTTPStatusFromName maps the http package's constant suffix
+// ("OK", "BadRequest", "NotFound", …) to its numeric code. Only the
+// common subset is needed for status code emission.
+func goHTTPStatusFromName(name string) int {
+	switch name {
+	case "OK":
+		return 200
+	case "Created":
+		return 201
+	case "Accepted":
+		return 202
+	case "NoContent":
+		return 204
+	case "BadRequest":
+		return 400
+	case "Unauthorized":
+		return 401
+	case "Forbidden":
+		return 403
+	case "NotFound":
+		return 404
+	case "Conflict":
+		return 409
+	case "UnprocessableEntity":
+		return 422
+	case "InternalServerError":
+		return 500
+	}
+	return 0
+}
+
+// applyGoPayload classifies a payload expression as a literal map, a
+// typed struct literal, or a free variable, and updates `sh`.
+func applyGoPayload(src, payload string, status int, sh *shape) {
+	// gin.H{...} / map[string]interface{}{...} / map[string]any{...}.
+	if strings.HasPrefix(payload, "gin.H{") ||
+		strings.HasPrefix(payload, "map[string]interface{}") ||
+		strings.HasPrefix(payload, "map[string]any") ||
+		strings.HasPrefix(payload, "echo.Map{") ||
+		strings.HasPrefix(payload, "fiber.Map{") {
+		brace := strings.Index(payload, "{")
+		if brace < 0 {
+			sh.dynamicResponse = true
+			return
+		}
+		end := findMatchingBracket(payload, brace)
+		if end < 0 {
+			sh.dynamicResponse = true
+			return
+		}
+		// Wrap in dict-form for extractDictKeys (it expects `{...}`).
+		keys := extractDictKeys(payload[brace : end+1])
+		if len(keys) > 0 {
+			sh.knownResponse = true
+			if status >= 400 || looksLikeError(payload) {
+				sh.errorKeys = append(sh.errorKeys, keys...)
+			} else {
+				sh.responseKeys = append(sh.responseKeys, keys...)
+			}
+			recordStatus(sh, status, false)
+			return
+		}
+	}
+	// `&MyDto{A: 1, ...}` or `MyDto{A: 1, ...}` typed literal.
+	if m := regexp.MustCompile(`^&?([A-Z]\w*)\s*\{`).FindStringSubmatch(payload); len(m) >= 2 {
+		dto := m[1]
+		schema := walkGoStructFields(src, dto)
+		if len(schema) > 0 {
+			if sh.responseSchema == nil {
+				sh.responseSchema = schema
+			}
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+			recordStatus(sh, status, false)
+			return
+		}
+	}
+	// Bare identifier — try to resolve as a same-file struct or fall through.
+	if id := regexp.MustCompile(`^[A-Z]\w*$`).FindString(payload); id != "" {
+		schema := walkGoStructFields(src, id)
+		if len(schema) > 0 {
+			sh.responseSchema = schema
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+			recordStatus(sh, status, false)
+			return
+		}
+	}
+	sh.dynamicResponse = true
+	recordStatus(sh, status, looksLikeError(payload))
+}
+
+// walkGoStructFields locates `type X struct { ... }` and returns
+// {fieldName -> typeToken} for every exported field. The fieldName uses
+// the json tag when present (so the externally-visible key matches the
+// JSON shape).
+var goStructFieldRe = regexp.MustCompile(`(?m)^[ \t]+([A-Z]\w*)\s+([\w*\.\[\]]+)(?:\s+` + "`" + `([^` + "`" + `]*)` + "`" + `)?`)
+var goJSONTagRe = regexp.MustCompile(`json:"([^",]+)`)
+
+func walkGoStructFields(src, name string) map[string]string {
+	re := regexp.MustCompile(`(?m)^type\s+` + regexp.QuoteMeta(name) + `\s+struct\s*\{`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return nil
+	}
+	braceIdx := loc[1] - 1
+	end := findMatchingBracket(src, braceIdx)
+	if end < 0 {
+		return nil
+	}
+	body := src[braceIdx+1 : end]
+	out := map[string]string{}
+	for _, m := range goStructFieldRe.FindAllStringSubmatch(body, -1) {
+		fname := m[1]
+		ftype := m[2]
+		tag := ""
+		if len(m) >= 4 {
+			tag = m[3]
+		}
+		// Prefer the json tag when it names the wire field explicitly.
+		if tag != "" {
+			if jt := goJSONTagRe.FindStringSubmatch(tag); len(jt) >= 2 && jt[1] != "-" {
+				fname = jt[1]
+			}
+		}
+		out[fname] = ftype
+	}
+	return out
+}

--- a/internal/engine/response_shape_java.go
+++ b/internal/engine/response_shape_java.go
@@ -1,0 +1,347 @@
+// Java response-shape extraction for Spring MVC and JAX-RS / Quarkus.
+//
+// Spring MVC patterns recognized:
+//
+//   - public DtoClass handler(...)               return type → response_schema
+//   - public ResponseEntity<DtoClass> handler()  ditto
+//   - return ResponseEntity.ok(new Dto(...))     literal new-instance
+//   - return ResponseEntity.status(404).body(...)
+//
+// JAX-RS / Quarkus patterns:
+//
+//   - public Response handler() with `@Schema` annotations on the
+//     declared return wrapper class
+//   - public DtoClass handler()                  return type used directly
+//   - return Response.ok(new Dto(...)).build()
+//
+// For request bodies we honour `@RequestBody Dto body` (Spring) and the
+// JAX-RS implicit body parameter (the un-annotated method argument).
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// javaMethodSigRe matches the signature line of a Java method named `handler`.
+// We capture the return type so it can be walked when it names a DTO class.
+func javaMethodSigRe(handler string) *regexp.Regexp {
+	return regexp.MustCompile(
+		`(?m)^(?:\s*(?:public|protected|private|static|final|abstract|synchronized)\s+)+` +
+			`([A-Za-z_][\w<>,.\s\[\]]*?)\s+` + regexp.QuoteMeta(handler) + `\s*\(([^)]*)\)`,
+	)
+}
+
+// javaReturnStatusRe captures the explicit status code in
+// ResponseEntity.status(404) chains.
+var javaReturnStatusRe = regexp.MustCompile(`ResponseEntity\s*\.\s*status\s*\(\s*(?:HttpStatus\.\w+\s*\(?\s*)?(\d{3})`)
+
+// javaResponseStatusConstRe captures HttpStatus.NOT_FOUND-style references.
+var javaResponseStatusConstRe = regexp.MustCompile(`HttpStatus\.([A-Z_]+)`)
+
+// extractJavaShape resolves response/request shapes for a single Java
+// handler in `src`. `framework` is "spring_mvc" or "jaxrs".
+func extractJavaShape(src, handler, framework string) shape {
+	var sh shape
+	if handler == "" {
+		return sh
+	}
+	// When the Spring composed-route pass emits a Route entity whose
+	// name is a path (e.g. "/users/{id}") rather than a method name,
+	// resolve the path back to the annotated handler method by
+	// scanning the file for the matching @*Mapping annotation. This
+	// keeps the shape extractor useful for YAML-only Spring extracts
+	// where the AST pass isn't running (#722).
+	if strings.HasPrefix(handler, "/") {
+		if resolved := resolveSpringHandlerByPath(src, handler); resolved != "" {
+			handler = resolved
+		} else {
+			return sh
+		}
+	}
+	sig := javaMethodSigRe(handler)
+	m := sig.FindStringSubmatch(src)
+	if m == nil {
+		return sh
+	}
+	retType := strings.TrimSpace(m[1])
+	params := m[2]
+
+	// Resolve the return type to a DTO class name, unwrapping common
+	// JAX-RS / Spring containers: ResponseEntity<X>, Response, X[], List<X>.
+	dto := unwrapJavaReturnType(retType)
+	if dto != "" {
+		schema := walkJavaClassFields(src, dto)
+		if len(schema) > 0 {
+			sh.responseSchema = schema
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+		}
+	}
+
+	// Walk the method body for explicit status codes.
+	body := findJavaMethodBody(src, handler)
+	if body != "" {
+		for _, sm := range javaReturnStatusRe.FindAllStringSubmatch(body, -1) {
+			if n, err := atoi(sm[1]); err == nil {
+				sh.statusCodes = append(sh.statusCodes, n)
+			}
+		}
+		for _, sm := range javaResponseStatusConstRe.FindAllStringSubmatch(body, -1) {
+			if code := javaHTTPStatusFromConst(sm[1]); code > 0 {
+				sh.statusCodes = append(sh.statusCodes, code)
+			}
+		}
+		// If the body contains `new Dto(...)` inside ResponseEntity.ok(...) or
+		// Response.ok(...) and we don't yet have a schema, try that DTO.
+		if sh.responseSchema == nil {
+			if nm := regexp.MustCompile(`(?:ResponseEntity|Response)\s*\.\s*(?:ok|status\s*\(\s*\d+\s*\))\s*\(\s*new\s+([A-Z]\w*)\s*\(`).FindStringSubmatch(body); len(nm) >= 2 {
+				schema := walkJavaClassFields(src, nm[1])
+				if len(schema) > 0 {
+					sh.responseSchema = schema
+					for k := range schema {
+						sh.responseKeys = append(sh.responseKeys, k)
+					}
+					sh.knownResponse = true
+				}
+			}
+		}
+	}
+	// Default status when body has none.
+	if sh.knownResponse && len(sh.statusCodes) == 0 {
+		sh.statusCodes = append(sh.statusCodes, 200)
+	}
+
+	// Request body via @RequestBody (Spring) or bare body argument (JAX-RS).
+	if reqDto := extractJavaRequestDTO(params, framework); reqDto != "" {
+		schema := walkJavaClassFields(src, reqDto)
+		if len(schema) > 0 {
+			sh.requestSchema = schema
+			for k := range schema {
+				sh.requestKeys = append(sh.requestKeys, k)
+			}
+		}
+	}
+	return sh
+}
+
+// findJavaMethodBody returns the text of the method body for `handler`.
+// We rely on the fact that the signature ends with `)` immediately
+// followed by (possibly through `throws ...`) an opening `{`.
+func findJavaMethodBody(src, handler string) string {
+	// Locate the signature.
+	sig := javaMethodSigRe(handler)
+	loc := sig.FindStringIndex(src)
+	if loc == nil {
+		return ""
+	}
+	// Find the `{` after the signature.
+	open := strings.Index(src[loc[1]:], "{")
+	if open < 0 {
+		return ""
+	}
+	braceIdx := loc[1] + open
+	end := findMatchingBracket(src, braceIdx)
+	if end < 0 {
+		return ""
+	}
+	return src[braceIdx+1 : end]
+}
+
+// unwrapJavaReturnType strips common containers (ResponseEntity<>, Response,
+// List<>, [], CompletableFuture<>) to recover the inner DTO class name, or
+// returns "" when the type is a primitive / void.
+func unwrapJavaReturnType(t string) string {
+	t = strings.TrimSpace(t)
+	for _, wrap := range []string{"ResponseEntity<", "CompletableFuture<", "Mono<", "Flux<", "Optional<", "List<", "Set<", "Collection<", "Iterable<"} {
+		if strings.HasPrefix(t, wrap) {
+			t = strings.TrimSuffix(strings.TrimPrefix(t, wrap), ">")
+			t = strings.TrimSpace(t)
+		}
+	}
+	t = strings.TrimSuffix(t, "[]")
+	// Strip generic params on the inner type itself.
+	if i := strings.Index(t, "<"); i >= 0 {
+		t = t[:i]
+	}
+	// Skip primitives + JAX-RS Response (we'll look at its body instead).
+	switch t {
+	case "void", "Void", "String", "int", "Integer", "long", "Long", "boolean", "Boolean", "double", "Double", "float", "Float", "Object", "Response":
+		return ""
+	}
+	// Keep only identifier characters.
+	if id := regexp.MustCompile(`^([A-Z][A-Za-z0-9_]*)`).FindStringSubmatch(t); len(id) >= 2 {
+		return id[1]
+	}
+	return ""
+}
+
+// extractJavaRequestDTO locates a @RequestBody-annotated argument (Spring)
+// or the first un-annotated body argument (JAX-RS) and returns the DTO
+// type name, or "" when none was found.
+func extractJavaRequestDTO(params, framework string) string {
+	params = strings.TrimSpace(params)
+	if params == "" {
+		return ""
+	}
+	if framework == "spring_mvc" {
+		re := regexp.MustCompile(`@RequestBody\s+(?:final\s+)?(?:@\w+(?:\([^)]*\))?\s+)*([A-Z][\w<>,.\s\[\]]*?)\s+\w+`)
+		if m := re.FindStringSubmatch(params); len(m) >= 2 {
+			return unwrapJavaReturnType(m[1])
+		}
+		return ""
+	}
+	// JAX-RS: any argument with no @PathParam/@QueryParam/@HeaderParam/@Context
+	// annotation is the request body (one per method).
+	for _, p := range splitJavaParams(params) {
+		p = strings.TrimSpace(p)
+		if p == "" {
+			continue
+		}
+		hasParamAnno := false
+		for _, anno := range []string{"@PathParam", "@QueryParam", "@HeaderParam", "@MatrixParam", "@CookieParam", "@FormParam", "@BeanParam", "@Context"} {
+			if strings.Contains(p, anno) {
+				hasParamAnno = true
+				break
+			}
+		}
+		if hasParamAnno {
+			continue
+		}
+		// Strip leading annotations.
+		stripped := regexp.MustCompile(`^(?:@\w+(?:\([^)]*\))?\s+)*`).ReplaceAllString(p, "")
+		parts := strings.Fields(stripped)
+		if len(parts) < 2 {
+			continue
+		}
+		return unwrapJavaReturnType(parts[0])
+	}
+	return ""
+}
+
+// splitJavaParams splits a parameter list on top-level commas (i.e.
+// commas not inside generic <...> or annotation (...) brackets).
+func splitJavaParams(params string) []string {
+	depth := 0
+	var out []string
+	last := 0
+	for i := 0; i < len(params); i++ {
+		c := params[i]
+		switch c {
+		case '<', '(', '[':
+			depth++
+		case '>', ')', ']':
+			depth--
+		case ',':
+			if depth == 0 {
+				out = append(out, params[last:i])
+				last = i + 1
+			}
+		}
+	}
+	if last < len(params) {
+		out = append(out, params[last:])
+	}
+	return out
+}
+
+// walkJavaClassFields locates `class X` or `record X(...)` in the source
+// and returns a map of field name -> type. Records have a different
+// shape — their components are declared in the parentheses.
+var javaFieldRe = regexp.MustCompile(`(?m)^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:public|private|protected|static|final|\s)+\s*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
+
+func walkJavaClassFields(src, name string) map[string]string {
+	// Record form first: `record X(Type a, Type b)`.
+	rec := regexp.MustCompile(`(?m)^(?:public\s+|private\s+|protected\s+)?record\s+` + regexp.QuoteMeta(name) + `\s*\(([^)]*)\)`)
+	if m := rec.FindStringSubmatch(src); len(m) >= 2 {
+		out := map[string]string{}
+		for _, p := range splitJavaParams(m[1]) {
+			parts := strings.Fields(strings.TrimSpace(p))
+			if len(parts) >= 2 {
+				out[parts[len(parts)-1]] = parts[len(parts)-2]
+			}
+		}
+		if len(out) > 0 {
+			return out
+		}
+	}
+	// Class / interface form.
+	re := regexp.MustCompile(`(?m)^(?:public\s+|private\s+|protected\s+|abstract\s+|final\s+|static\s+|\s)*(?:class|interface)\s+` + regexp.QuoteMeta(name) + `\b[^{]*\{`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return nil
+	}
+	braceIdx := loc[1] - 1
+	end := findMatchingBracket(src, braceIdx)
+	if end < 0 {
+		return nil
+	}
+	body := src[braceIdx+1 : end]
+	out := map[string]string{}
+	for _, m := range javaFieldRe.FindAllStringSubmatch(body, -1) {
+		fname := m[2]
+		ftype := m[1]
+		// Skip obvious non-field declarations: method bodies start with `(`.
+		// Also skip if the "type" looks like a method-return that wasn't
+		// followed by `;` or `=` — defensive.
+		if strings.Contains(ftype, "(") {
+			continue
+		}
+		out[fname] = strings.TrimSpace(ftype)
+	}
+	return out
+}
+
+// resolveSpringHandlerByPath finds a Spring controller method annotated
+// with @GetMapping / @PostMapping / @RequestMapping(path=...) matching
+// the given path string, and returns the method name. Empty when no
+// matching annotation is present.
+func resolveSpringHandlerByPath(src, path string) string {
+	// Try each verb-mapping annotation (and the generic @RequestMapping).
+	// The annotation may use a bare string ("/users/{id}") or a
+	// path/value kwarg ({"/users/{id}"}). We only require the path
+	// string to appear inside the annotation parentheses.
+	patterns := []string{
+		`@(?:Get|Post|Put|Patch|Delete|Request)Mapping\s*\(\s*[^)]*` + regexp.QuoteMeta(`"`+path+`"`) + `[^)]*\)[\s\S]*?\b(?:public|protected|private)\s+[^;{]+?\s+([a-zA-Z_]\w*)\s*\(`,
+	}
+	for _, p := range patterns {
+		re := regexp.MustCompile(p)
+		if m := re.FindStringSubmatch(src); len(m) >= 2 {
+			return m[1]
+		}
+	}
+	return ""
+}
+
+// javaHTTPStatusFromConst maps a small set of HttpStatus enum names to
+// their numeric codes. Only the common ones are covered; anything else
+// returns 0 (no status recorded).
+func javaHTTPStatusFromConst(name string) int {
+	switch name {
+	case "OK":
+		return 200
+	case "CREATED":
+		return 201
+	case "ACCEPTED":
+		return 202
+	case "NO_CONTENT":
+		return 204
+	case "BAD_REQUEST":
+		return 400
+	case "UNAUTHORIZED":
+		return 401
+	case "FORBIDDEN":
+		return 403
+	case "NOT_FOUND":
+		return 404
+	case "CONFLICT":
+		return 409
+	case "UNPROCESSABLE_ENTITY":
+		return 422
+	case "INTERNAL_SERVER_ERROR":
+		return 500
+	}
+	return 0
+}

--- a/internal/engine/response_shape_jsts.go
+++ b/internal/engine/response_shape_jsts.go
@@ -1,0 +1,308 @@
+// JavaScript / TypeScript response-shape extraction for Express and NestJS.
+//
+// Express handler bodies are scanned for:
+//
+//   - res.json({...})              top-level keys
+//   - res.json({key: typed.Type})  type info via the value position
+//   - res.status(404).json({...})  status code + error_keys
+//   - res.send(JSON.stringify({})) same shape as res.json
+//   - return res.json(...)         alias form
+//
+// NestJS handlers additionally honour:
+//
+//   - @ApiResponse({ type: DtoClass })
+//   - return-type annotation `: Promise<DtoClass>` or `: DtoClass`
+//   - @Body() body: DtoClass parameter for request_schema
+//
+// In both cases, when the value is a class/interface declared in the
+// same file, we walk the declaration to populate response_schema /
+// request_schema with {field: type}.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// jsFuncBodyOpenRe locates the opening brace of a JS function or method
+// body keyed by name. We support:
+//   - function name(...)
+//   - const name = (...) =>
+//   - name(...) { (object method)
+//   - async name(...) {
+var jsFuncBodyOpenRes = []*regexp.Regexp{
+	regexp.MustCompile(`function\s+%s\s*\([^)]*\)\s*\{`),
+	regexp.MustCompile(`\b(?:const|let|var)\s+%s\s*=\s*(?:async\s*)?\([^)]*\)\s*=>\s*\{`),
+	regexp.MustCompile(`\b(?:const|let|var)\s+%s\s*=\s*(?:async\s+)?function\s*\([^)]*\)\s*\{`),
+	regexp.MustCompile(`(?m)^(?:\s*(?:public|private|protected|static|async)\s+)*%s\s*\([^)]*\)(?::\s*[A-Za-z_][\w<>,.\s\[\]|]+)?\s*\{`),
+}
+
+// findJSHandlerBody locates the body of a JS function/method named `name`
+// and returns the text between (but not including) the opening `{` and
+// its matching `}`. Returns "" when no body can be found.
+func findJSHandlerBody(src, name string) string {
+	if name == "" {
+		return ""
+	}
+	q := regexp.QuoteMeta(name)
+	for _, tmpl := range jsFuncBodyOpenRes {
+		// Substitute the name into the pattern. Each template uses %s
+		// exactly once; the unrelated `%` in regex syntax is escaped
+		// via printf-friendly placeholder substitution.
+		patStr := strings.Replace(tmpl.String(), "%s", q, 1)
+		re := regexp.MustCompile(patStr)
+		loc := re.FindStringIndex(src)
+		if loc == nil {
+			continue
+		}
+		// Find the brace that opens at loc[1]-1.
+		braceIdx := loc[1] - 1
+		if braceIdx >= len(src) || src[braceIdx] != '{' {
+			continue
+		}
+		end := findMatchingBracket(src, braceIdx)
+		if end < 0 {
+			continue
+		}
+		return src[braceIdx+1 : end]
+	}
+	return ""
+}
+
+// jsResJsonRe and jsResStatusJsonRe locate Express response calls inside
+// a handler body. The chained `.status(code).json(...)` form gets its own
+// regex so we can record the explicit code.
+var jsResJsonRe = regexp.MustCompile(`\bres\s*\.\s*json\s*\(`)
+var jsResStatusJsonRe = regexp.MustCompile(`\bres\s*\.\s*status\s*\(\s*(\d{3})\s*\)\s*\.\s*(?:json|send)\s*\(`)
+var jsResSendRe = regexp.MustCompile(`\bres\s*\.\s*send\s*\(`)
+
+func extractJSShape(src, handler, framework string) shape {
+	var sh shape
+	if handler == "" {
+		return sh
+	}
+	body := findJSHandlerBody(src, handler)
+	if body == "" {
+		return sh
+	}
+	// First pass: chained status().json() — explicit error code.
+	for _, m := range jsResStatusJsonRe.FindAllStringSubmatchIndex(body, -1) {
+		// m[0]:m[1] = full match, m[2]:m[3] = status digits.
+		status := mustAtoi(body[m[2]:m[3]])
+		// The opening paren is at m[1]-1.
+		paren := m[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) == 0 {
+			recordStatus(&sh, status, false)
+			continue
+		}
+		applyJSReturnArg(src, args[0], status, &sh)
+		recordStatus(&sh, status, false)
+	}
+	// Second pass: bare res.json(...).
+	for _, m := range jsResJsonRe.FindAllStringIndex(body, -1) {
+		// The previous chained pass already covers res.status().json(...);
+		// skip when this match is the .json piece of a chain.
+		// Heuristic: look 30 chars back for `res.status(`.
+		back := m[0] - 30
+		if back < 0 {
+			back = 0
+		}
+		if strings.Contains(body[back:m[0]], ".status(") {
+			continue
+		}
+		paren := m[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) == 0 {
+			continue
+		}
+		applyJSReturnArg(src, args[0], 200, &sh)
+		recordStatus(&sh, 200, false)
+	}
+	// Third pass: res.send(JSON.stringify({...})).
+	for _, m := range jsResSendRe.FindAllStringIndex(body, -1) {
+		paren := m[1] - 1
+		args := extractArgList(body, paren)
+		if len(args) == 0 {
+			continue
+		}
+		// Strip JSON.stringify wrapper if present.
+		arg := args[0]
+		if strings.HasPrefix(arg, "JSON.stringify(") {
+			inner := extractArgList(arg, len("JSON.stringify"))
+			if len(inner) > 0 {
+				arg = inner[0]
+			}
+		}
+		applyJSReturnArg(src, arg, 200, &sh)
+		recordStatus(&sh, 200, false)
+	}
+	// NestJS: walk @ApiResponse({type: Dto}) decorators above the method
+	// and @Body() / return-type annotations on the signature.
+	if framework == "nestjs" {
+		if dto := lookupNestApiResponseType(src, handler); dto != "" {
+			schema := walkJSClassFields(src, dto)
+			if len(schema) > 0 {
+				sh.responseSchema = schema
+				for k := range schema {
+					sh.responseKeys = append(sh.responseKeys, k)
+				}
+				sh.knownResponse = true
+			}
+		}
+		if dto := lookupNestReturnType(src, handler); dto != "" && sh.responseSchema == nil {
+			schema := walkJSClassFields(src, dto)
+			if len(schema) > 0 {
+				sh.responseSchema = schema
+				for k := range schema {
+					sh.responseKeys = append(sh.responseKeys, k)
+				}
+				sh.knownResponse = true
+			}
+		}
+		if dto := lookupNestBodyType(src, handler); dto != "" {
+			schema := walkJSClassFields(src, dto)
+			if len(schema) > 0 {
+				sh.requestSchema = schema
+				for k := range schema {
+					sh.requestKeys = append(sh.requestKeys, k)
+				}
+			}
+		}
+	}
+	return sh
+}
+
+// applyJSReturnArg merges a single argument (the object passed to
+// res.json / res.send) into `sh`.
+func applyJSReturnArg(src, arg string, status int, sh *shape) {
+	arg = strings.TrimSpace(arg)
+	keys := extractDictKeys(arg)
+	if len(keys) > 0 {
+		sh.knownResponse = true
+		if status >= 400 || looksLikeError(arg) {
+			sh.errorKeys = append(sh.errorKeys, keys...)
+		} else {
+			sh.responseKeys = append(sh.responseKeys, keys...)
+		}
+		return
+	}
+	// `new DtoClass(...)` or bare `DtoClass(...)`.
+	if m := regexp.MustCompile(`^(?:new\s+)?([A-Z][A-Za-z0-9_]*)\s*\(`).FindStringSubmatch(arg); len(m) >= 2 {
+		schema := walkJSClassFields(src, m[1])
+		if len(schema) > 0 {
+			if sh.responseSchema == nil {
+				sh.responseSchema = schema
+			}
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+			return
+		}
+	}
+	sh.dynamicResponse = true
+}
+
+// walkJSClassFields locates `class X { ... }` or `interface X { ... }`
+// in the source and returns a map of field name -> type token.
+// Class-body declarations of the form `name: Type;` and `name: Type =`
+// are both supported; method declarations are skipped.
+var jsClassFieldRe = regexp.MustCompile(`(?m)^[ \t]+(?:public|private|protected|readonly|\s)*\s*([a-zA-Z_]\w*)(\??):\s*([^;=\n{]+?)(?:;|=|\n)`)
+
+func walkJSClassFields(src, name string) map[string]string {
+	// class or interface declaration.
+	re := regexp.MustCompile(`(?m)^(?:export\s+)?(?:abstract\s+)?(?:class|interface)\s+` + regexp.QuoteMeta(name) + `\b[^{]*\{`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return nil
+	}
+	braceIdx := loc[1] - 1
+	if braceIdx >= len(src) || src[braceIdx] != '{' {
+		return nil
+	}
+	end := findMatchingBracket(src, braceIdx)
+	if end < 0 {
+		return nil
+	}
+	body := src[braceIdx+1 : end]
+	out := map[string]string{}
+	for _, m := range jsClassFieldRe.FindAllStringSubmatch(body, -1) {
+		fname := m[1]
+		opt := m[2]
+		ftype := strings.TrimSpace(m[3])
+		// Skip constructor params / methods (heuristic: opening paren in type).
+		if strings.Contains(ftype, "(") {
+			continue
+		}
+		if opt == "?" {
+			ftype = ftype + "|null"
+		}
+		out[fname] = ftype
+	}
+	return out
+}
+
+// lookupNestApiResponseType extracts the `type: Dto` token from an
+// @ApiResponse({...}) decorator immediately above the handler.
+func lookupNestApiResponseType(src, handler string) string {
+	re := regexp.MustCompile(`@ApiResponse\s*\(\s*\{[^}]*\btype\s*:\s*([A-Za-z_][\w.]*)[^}]*\}\s*\)[\s\S]*?\b` + regexp.QuoteMeta(handler) + `\s*\(`)
+	if m := re.FindStringSubmatch(src); len(m) >= 2 {
+		return stripGeneric(m[1])
+	}
+	return ""
+}
+
+// lookupNestReturnType reads the return-type annotation on a method
+// declaration, e.g. `findOne(id): Promise<UserDto>`.
+func lookupNestReturnType(src, handler string) string {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(handler) + `\s*\([^)]*\)\s*:\s*([^\{;\n]+)`)
+	m := re.FindStringSubmatch(src)
+	if len(m) < 2 {
+		return ""
+	}
+	t := strings.TrimSpace(m[1])
+	// Strip leading `async` markers and Promise<>/Observable<> wrappers.
+	for _, wrap := range []string{"Promise<", "Observable<", "Awaited<"} {
+		if strings.HasPrefix(t, wrap) {
+			t = strings.TrimSuffix(strings.TrimPrefix(t, wrap), ">")
+		}
+	}
+	// Strip array suffix.
+	t = strings.TrimSuffix(t, "[]")
+	if id := regexp.MustCompile(`^([A-Z][A-Za-z0-9_]*)`).FindStringSubmatch(t); len(id) >= 2 {
+		return id[1]
+	}
+	return ""
+}
+
+// lookupNestBodyType extracts the type of an @Body() parameter on the
+// handler signature.
+func lookupNestBodyType(src, handler string) string {
+	re := regexp.MustCompile(`\b` + regexp.QuoteMeta(handler) + `\s*\(([^)]*)\)`)
+	m := re.FindStringSubmatch(src)
+	if len(m) < 2 {
+		return ""
+	}
+	// Find @Body() name: Type
+	body := regexp.MustCompile(`@Body\s*\(\s*\)\s+\w+\s*:\s*([A-Z][A-Za-z0-9_]*)`).FindStringSubmatch(m[1])
+	if len(body) >= 2 {
+		return body[1]
+	}
+	return ""
+}
+
+func stripGeneric(s string) string {
+	if i := strings.Index(s, "<"); i >= 0 {
+		return s[:i]
+	}
+	return s
+}
+
+func mustAtoi(s string) int {
+	n, err := atoi(s)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/engine/response_shape_python.go
+++ b/internal/engine/response_shape_python.go
@@ -1,0 +1,433 @@
+// Python response-shape extraction for Django, DRF, Flask, FastAPI.
+//
+// All four frameworks share enough surface that we use a single body
+// scanner: find the `def <handler>(...)` block, walk every `return`
+// statement, and classify by call shape:
+//
+//   - Response({...})                   Django REST Framework / DRF
+//   - Response({...}, status=400)       error-status variant
+//   - JsonResponse({...})               Django stdlib
+//   - jsonify({...})                    Flask
+//   - {...}                             dict literal (Flask, FastAPI)
+//   - SomeModel(...)                    Pydantic / dataclass return; the
+//                                       caller-side type is taken from a
+//                                       FastAPI response_model decorator
+//                                       (when present) or the function
+//                                       return-type annotation.
+//
+// Request-body extraction (request_keys/request_schema) parses FastAPI
+// parameter annotations: `body: SomeModel` → walk SomeModel's class body
+// for `field: type` declarations.
+package engine
+
+import (
+	"regexp"
+	"strings"
+)
+
+// pyDefRe locates the start of a Python function definition by name.
+var pyDefRe = regexp.MustCompile(`(?m)^(\s*)(?:async\s+)?def\s+(%s)\s*\(`)
+
+// fastapiResponseModelRe captures the response_model=ClassName kwarg
+// off a FastAPI decorator above the handler. Multiple decorators are
+// supported; we only need the response_model token.
+var fastapiResponseModelRe = regexp.MustCompile(`response_model\s*=\s*([A-Za-z_][\w.]*)`)
+
+// pyClassFieldRe pulls `name: type` declarations out of a Pydantic /
+// dataclass body. Group 1 is the field name, group 2 is the type token
+// (everything up to `=` or end-of-line).
+var pyClassFieldRe = regexp.MustCompile(`(?m)^[ \t]+([a-zA-Z_]\w*)\s*:\s*([^=\n#]+?)\s*(?:=|$)`)
+
+// pyReturnRe matches `return <expr>` indented under a handler body.
+// We anchor on word-boundary to skip yields/returns-in-comments.
+var pyReturnRe = regexp.MustCompile(`(?m)^[ \t]+return\b\s*(.*)$`)
+
+// pyStatusKwargRe captures `status=<int>` inside a Response(...) call.
+var pyStatusKwargRe = regexp.MustCompile(`\bstatus(?:_code)?\s*=\s*(\d{3})`)
+
+// pyStatusHTTPConstRe handles `status=status.HTTP_404_NOT_FOUND` symbolic forms.
+var pyStatusHTTPConstRe = regexp.MustCompile(`\bstatus(?:_code)?\s*=\s*status\.HTTP_(\d{3})_`)
+
+// findHandlerBody returns the source slice that contains the body of the
+// named Python function, or "" if not found. We use indentation to
+// determine where the function ends — the body is every line whose
+// indent strictly exceeds the indent of the `def` line, up to the first
+// line that breaks that condition.
+func findHandlerBody(src, name string) string {
+	if name == "" {
+		return ""
+	}
+	re := regexp.MustCompile(`(?m)^([ \t]*)(?:async\s+)?def\s+` + regexp.QuoteMeta(name) + `\s*\(`)
+	loc := re.FindStringSubmatchIndex(src)
+	if loc == nil {
+		return ""
+	}
+	defIndent := loc[3] - loc[2] // length of capture group 1
+	// Start from the end of the def line. Find next newline.
+	startLine := loc[0]
+	headEnd := strings.Index(src[startLine:], "\n")
+	if headEnd < 0 {
+		return ""
+	}
+	bodyStart := startLine + headEnd + 1
+	// The signature might span multiple lines (Python allows wrapped
+	// argument lists); skip until we reach a line ending with `:`.
+	for {
+		// Find end of current line.
+		nl := strings.Index(src[bodyStart-1:], "\n")
+		if nl < 0 {
+			break
+		}
+		prev := src[startLine : bodyStart-1+nl]
+		if strings.Contains(prev, "):") || strings.HasSuffix(strings.TrimRight(prev, " \t\r"), ":") {
+			break
+		}
+		bodyStart = bodyStart - 1 + nl + 1
+		if bodyStart >= len(src) {
+			return ""
+		}
+	}
+	// Walk subsequent lines: include them while their indent > defIndent
+	// (or while they're blank). Stop at the first non-blank, indent <= defIndent.
+	i := bodyStart
+	bodyEnd := bodyStart
+	for i < len(src) {
+		lineEnd := strings.Index(src[i:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(src) - i
+		}
+		line := src[i : i+lineEnd]
+		stripped := strings.TrimLeft(line, " \t")
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			// blank/comment line; keep going.
+			i += lineEnd + 1
+			bodyEnd = i
+			continue
+		}
+		indent := len(line) - len(stripped)
+		if indent <= defIndent {
+			break
+		}
+		i += lineEnd + 1
+		bodyEnd = i
+	}
+	return src[bodyStart:bodyEnd]
+}
+
+// extractPythonShape implements the shape extractor for all four Python
+// frameworks. The `framework` argument tunes a few small per-framework
+// behaviours (e.g. FastAPI response_model lookup uses decorators above
+// the def line, which the others don't have in the same form).
+func extractPythonShape(src, handler, framework string) shape {
+	var sh shape
+	if handler == "" {
+		return sh
+	}
+	body := findHandlerBody(src, handler)
+	if body == "" {
+		return sh
+	}
+	// FastAPI response_model — look at the decorator block immediately
+	// above the def line.
+	if framework == "fastapi" {
+		if m := lookupFastAPIResponseModel(src, handler); m != "" {
+			schema := walkPyClassFields(src, m)
+			if len(schema) > 0 {
+				sh.responseSchema = schema
+				keys := make([]string, 0, len(schema))
+				for k := range schema {
+					keys = append(keys, k)
+				}
+				sh.responseKeys = append(sh.responseKeys, keys...)
+				sh.knownResponse = true
+			}
+		}
+		// Request body: scan the def signature for `name: Model` annotations
+		// where Model is a Pydantic class in the same file.
+		if reqSchema := extractFastAPIRequestSchema(src, handler); len(reqSchema) > 0 {
+			sh.requestSchema = reqSchema
+			for k := range reqSchema {
+				sh.requestKeys = append(sh.requestKeys, k)
+			}
+		}
+	}
+	// Scan returns.
+	for _, m := range pyReturnRe.FindAllStringSubmatch(body, -1) {
+		expr := strings.TrimSpace(m[1])
+		if expr == "" || expr == "None" {
+			continue
+		}
+		parsePyReturn(src, expr, &sh)
+	}
+	return sh
+}
+
+// parsePyReturn inspects a single `return <expr>` and updates `sh` in place.
+func parsePyReturn(src, expr string, sh *shape) {
+	// Strip a trailing comment.
+	if i := strings.Index(expr, " #"); i >= 0 {
+		expr = strings.TrimSpace(expr[:i])
+	}
+	// Detect status code on the expression first (works for Response/JsonResponse).
+	status := 0
+	if m := pyStatusKwargRe.FindStringSubmatch(expr); len(m) >= 2 {
+		if n, err := atoi(m[1]); err == nil {
+			status = n
+		}
+	}
+	if status == 0 {
+		if m := pyStatusHTTPConstRe.FindStringSubmatch(expr); len(m) >= 2 {
+			if n, err := atoi(m[1]); err == nil {
+				status = n
+			}
+		}
+	}
+	// Common wrappers: Response(...), JsonResponse(...), jsonify(...).
+	for _, wrapper := range []string{"Response", "JsonResponse", "jsonify"} {
+		if idx := strings.Index(expr, wrapper+"("); idx == 0 || (idx > 0 && !isIdentChar(expr[idx-1])) {
+			parenIdx := strings.Index(expr[idx:], "(")
+			if parenIdx >= 0 {
+				args := extractArgList(expr, idx+parenIdx)
+				if len(args) > 0 {
+					applyPyReturnArg(src, args[0], status, sh)
+					recordStatus(sh, status, looksLikeError(args[0]))
+					return
+				}
+			}
+		}
+	}
+	// Bare dict literal (Flask / FastAPI implicit jsonify).
+	if strings.HasPrefix(expr, "{") {
+		// Could be `{...}` or `{...}, 200`.
+		end := findMatchingBracket(expr, 0)
+		if end > 0 {
+			dict := expr[:end+1]
+			rest := strings.TrimSpace(expr[end+1:])
+			if strings.HasPrefix(rest, ",") {
+				tail := strings.TrimSpace(strings.TrimPrefix(rest, ","))
+				if n, err := atoi(strings.TrimRight(tail, " \r\n")); err == nil {
+					status = n
+				}
+			}
+			applyPyReturnArg(src, dict, status, sh)
+			recordStatus(sh, status, false)
+			return
+		}
+	}
+	// `return SomeModel(...)` — walk the class fields if SomeModel is in this file.
+	if m := regexp.MustCompile(`^([A-Z][A-Za-z0-9_]*)\s*\(`).FindStringSubmatch(expr); len(m) >= 2 {
+		schema := walkPyClassFields(src, m[1])
+		if len(schema) > 0 {
+			if sh.responseSchema == nil {
+				sh.responseSchema = schema
+			}
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+			recordStatus(sh, status, false)
+			return
+		}
+	}
+	// `return serializer.data` — known DRF idiom; we cannot resolve the
+	// serializer from the local return alone, but mark known-dynamic.
+	if strings.Contains(expr, ".data") || strings.Contains(expr, ".to_dict()") {
+		sh.dynamicResponse = true
+		return
+	}
+	// Free variable — mark dynamic.
+	sh.dynamicResponse = true
+}
+
+// applyPyReturnArg merges a single argument (typically the body literal
+// passed to Response(...)) into `sh`.
+func applyPyReturnArg(src, arg string, status int, sh *shape) {
+	keys := extractDictKeys(arg)
+	if len(keys) > 0 {
+		sh.knownResponse = true
+		if status >= 400 {
+			sh.errorKeys = append(sh.errorKeys, keys...)
+		} else {
+			sh.responseKeys = append(sh.responseKeys, keys...)
+		}
+		return
+	}
+	// `return SomeModel(...)` inside a wrapper, e.g. Response(SomeModel(...)).
+	if m := regexp.MustCompile(`^([A-Z][A-Za-z0-9_]*)\s*\(`).FindStringSubmatch(strings.TrimSpace(arg)); len(m) >= 2 {
+		schema := walkPyClassFields(src, m[1])
+		if len(schema) > 0 {
+			if sh.responseSchema == nil {
+				sh.responseSchema = schema
+			}
+			for k := range schema {
+				sh.responseKeys = append(sh.responseKeys, k)
+			}
+			sh.knownResponse = true
+			return
+		}
+	}
+	// Unknown — flag dynamic.
+	sh.dynamicResponse = true
+}
+
+// lookupFastAPIResponseModel scans the source for a FastAPI decorator
+// immediately above the def line and returns the response_model class
+// name, or "" when none was found.
+func lookupFastAPIResponseModel(src, handler string) string {
+	re := regexp.MustCompile(`@[\w.]+\([^)]*\)\s*[\r\n]+(?:\s*@[^\r\n]*[\r\n]+)*\s*(?:async\s+)?def\s+` + regexp.QuoteMeta(handler) + `\s*\(`)
+	loc := re.FindStringIndex(src)
+	if loc == nil {
+		return ""
+	}
+	region := src[loc[0]:loc[1]]
+	if m := fastapiResponseModelRe.FindStringSubmatch(region); len(m) >= 2 {
+		return m[1]
+	}
+	return ""
+}
+
+// extractFastAPIRequestSchema walks the def signature looking for a
+// parameter annotated with a Pydantic-class type from the same file.
+// Returns the class's field map, or nil when nothing was found.
+func extractFastAPIRequestSchema(src, handler string) map[string]string {
+	re := regexp.MustCompile(`(?:async\s+)?def\s+` + regexp.QuoteMeta(handler) + `\s*\(([^)]*)\)`)
+	m := re.FindStringSubmatch(src)
+	if len(m) < 2 {
+		return nil
+	}
+	args := m[1]
+	for _, arg := range strings.Split(args, ",") {
+		arg = strings.TrimSpace(arg)
+		// Match `name: TypeName` with TypeName starting capital.
+		parts := strings.SplitN(arg, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		typ := strings.TrimSpace(parts[1])
+		// Strip default value.
+		if eq := strings.Index(typ, "="); eq >= 0 {
+			typ = strings.TrimSpace(typ[:eq])
+		}
+		// Take leading identifier.
+		idMatch := regexp.MustCompile(`^([A-Z][A-Za-z0-9_]*)`).FindStringSubmatch(typ)
+		if len(idMatch) < 2 {
+			continue
+		}
+		// FastAPI special types we should skip.
+		switch idMatch[1] {
+		case "Request", "Response", "BackgroundTasks", "Depends", "Path", "Query", "Header", "Cookie", "Body", "Form", "File", "UploadFile":
+			continue
+		}
+		schema := walkPyClassFields(src, idMatch[1])
+		if len(schema) > 0 {
+			return schema
+		}
+	}
+	return nil
+}
+
+// walkPyClassFields locates `class <name>(...):` in the source and returns
+// a map of `field -> type` for every `name: type` declaration in the
+// class body. Returns nil when the class is not found.
+func walkPyClassFields(src, name string) map[string]string {
+	re := regexp.MustCompile(`(?m)^([ \t]*)class\s+` + regexp.QuoteMeta(name) + `\b[^\n]*:`)
+	loc := re.FindStringSubmatchIndex(src)
+	if loc == nil {
+		return nil
+	}
+	classIndent := loc[3] - loc[2]
+	// Find the class body bounds the same way we did for handlers.
+	headEnd := strings.Index(src[loc[0]:], "\n")
+	if headEnd < 0 {
+		return nil
+	}
+	bodyStart := loc[0] + headEnd + 1
+	i := bodyStart
+	bodyEnd := bodyStart
+	for i < len(src) {
+		lineEnd := strings.Index(src[i:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(src) - i
+		}
+		line := src[i : i+lineEnd]
+		stripped := strings.TrimLeft(line, " \t")
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			i += lineEnd + 1
+			bodyEnd = i
+			continue
+		}
+		indent := len(line) - len(stripped)
+		if indent <= classIndent {
+			break
+		}
+		i += lineEnd + 1
+		bodyEnd = i
+	}
+	body := src[bodyStart:bodyEnd]
+	out := map[string]string{}
+	for _, m := range pyClassFieldRe.FindAllStringSubmatch(body, -1) {
+		fname := m[1]
+		ftype := strings.TrimSpace(m[2])
+		// Skip dunder fields and obvious non-field declarations.
+		if strings.HasPrefix(fname, "_") {
+			continue
+		}
+		out[fname] = ftype
+	}
+	return out
+}
+
+// recordStatus appends an observed status code; defaults to 200 when none
+// was observed. `isError` is used as a hint when we couldn't read a
+// status kwarg but the literal contained an "error"-ish key.
+func recordStatus(sh *shape, status int, isError bool) {
+	if status > 0 {
+		sh.statusCodes = append(sh.statusCodes, status)
+		return
+	}
+	if isError {
+		sh.statusCodes = append(sh.statusCodes, 400)
+		return
+	}
+	sh.statusCodes = append(sh.statusCodes, 200)
+}
+
+// looksLikeError returns true for argument strings that contain an
+// `"error":` / `'error':` / `error:` key — a heuristic to classify
+// returns missing an explicit status kwarg.
+func looksLikeError(arg string) bool {
+	lower := strings.ToLower(arg)
+	return strings.Contains(lower, "\"error\"") ||
+		strings.Contains(lower, "'error'") ||
+		strings.Contains(lower, "error:") ||
+		strings.Contains(lower, "\"detail\"") ||
+		strings.Contains(lower, "'detail'")
+}
+
+func isIdentChar(b byte) bool {
+	return (b >= 'a' && b <= 'z') || (b >= 'A' && b <= 'Z') || (b >= '0' && b <= '9') || b == '_'
+}
+
+// atoi is strconv.Atoi with a returning err. We re-export here so the
+// per-language extractors don't all need to import strconv directly.
+func atoi(s string) (int, error) {
+	n := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		if c < '0' || c > '9' {
+			return 0, errParseInt
+		}
+		n = n*10 + int(c-'0')
+	}
+	if len(s) == 0 {
+		return 0, errParseInt
+	}
+	return n, nil
+}
+
+// errParseInt is the sentinel returned by atoi when parsing fails.
+var errParseInt = parseIntErr{}
+
+type parseIntErr struct{}
+
+func (parseIntErr) Error() string { return "parse int" }

--- a/internal/engine/response_shape_test.go
+++ b/internal/engine/response_shape_test.go
@@ -1,0 +1,351 @@
+// Tests for response shape extraction (#722).
+//
+// Each test exercises one framework's response_keys / response_schema /
+// error_keys / status_codes / request_keys path. The cross-language
+// parity test at the end verifies that frameworks NOT targeted by a
+// given fixture do not pick up false-positive shape extraction.
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// shapeOf returns the http_endpoint synthetic with the given verb+path
+// from a runDetect result. Failing the lookup is a test error.
+func shapeOf(t *testing.T, res *DetectResult, id string) map[string]string {
+	t.Helper()
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind && e.ID == id {
+			return e.Properties
+		}
+	}
+	t.Fatalf("expected http_endpoint %q in entities; got: %s", id, dumpEndpointIDs(res))
+	return nil
+}
+
+func dumpEndpointIDs(res *DetectResult) string {
+	var out []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind {
+			out = append(out, e.ID)
+		}
+	}
+	return strings.Join(out, ", ")
+}
+
+func assertProp(t *testing.T, props map[string]string, key, want string) {
+	t.Helper()
+	if got := props[key]; got != want {
+		t.Errorf("property %q: got %q, want %q (all props: %v)", key, got, want, props)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Flask
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_Flask_LiteralDict(t *testing.T) {
+	src := `from flask import Flask, jsonify
+app = Flask(__name__)
+
+@app.route("/users/<int:id>", methods=["GET"])
+def get_user(id):
+    return jsonify({"id": id, "name": "alice", "active": True})
+
+@app.route("/users", methods=["POST"])
+def create_user():
+    return {"id": 1, "name": "bob"}, 201
+
+@app.route("/users/<int:id>", methods=["DELETE"])
+def delete_user(id):
+    return {"error": "not found"}, 404
+`
+	_, res := runDetect(t, "python", "app.py", src)
+	props := shapeOf(t, res, "http:GET:/users/{id}")
+	assertProp(t, props, "response_keys", "active,id,name")
+	assertProp(t, props, "status_codes", "200")
+	assertProp(t, props, "response_keys_known", "true")
+
+	createProps := shapeOf(t, res, "http:POST:/users")
+	assertProp(t, createProps, "response_keys", "id,name")
+	assertProp(t, createProps, "status_codes", "201")
+
+	delProps := shapeOf(t, res, "http:DELETE:/users/{id}")
+	assertProp(t, delProps, "error_keys", "error")
+	assertProp(t, delProps, "status_codes", "404")
+}
+
+// ---------------------------------------------------------------------------
+// Django / DRF
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_Django_Response(t *testing.T) {
+	// Django views typically register through urls.py; we exercise the
+	// per-file synth that walks `def handler` defs. The Flask-like test
+	// covers the DRF Response(...) shape; the route is emitted by the
+	// Django composed-route synth so the handler property names match.
+	src := `from rest_framework.response import Response
+from rest_framework.decorators import api_view
+
+# A urls.py-like route registration that the Django composed-route synth
+# would have picked up. We register through the Flask shape (which
+# emits a Route entity into the file) so the test does not need urls.py.
+@app.route("/api/users/<int:id>")
+def detail(id):
+    return Response({"id": id, "name": "alice", "email": "a@b"})
+
+@app.route("/api/users")
+def list_users():
+    return Response({"items": [], "count": 0})
+
+@app.route("/api/users/error")
+def bad():
+    return Response({"detail": "not found"}, status=404)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/users/{id}")
+	assertProp(t, props, "response_keys", "email,id,name")
+	assertProp(t, props, "response_keys_known", "true")
+
+	listProps := shapeOf(t, res, "http:GET:/api/users")
+	assertProp(t, listProps, "response_keys", "count,items")
+
+	badProps := shapeOf(t, res, "http:GET:/api/users/error")
+	assertProp(t, badProps, "error_keys", "detail")
+	assertProp(t, badProps, "status_codes", "404")
+}
+
+// ---------------------------------------------------------------------------
+// FastAPI
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_FastAPI_PydanticResponseModel(t *testing.T) {
+	src := `from fastapi import FastAPI, APIRouter
+from pydantic import BaseModel
+
+router = APIRouter()
+
+class UserOut(BaseModel):
+    id: int
+    name: str
+    email: str
+
+class UserIn(BaseModel):
+    name: str
+    email: str
+
+@router.get("/users/{id}", response_model=UserOut)
+async def get_user(id: int):
+    return {"id": id, "name": "x", "email": "y"}
+
+@router.post("/users")
+def create_user(body: UserIn):
+    return {"id": 1, "name": body.name, "email": body.email}
+`
+	_, res := runDetect(t, "python", "main.py", src)
+	props := shapeOf(t, res, "http:GET:/users/{id}")
+	assertProp(t, props, "response_keys", "email,id,name")
+	// response_schema is a stable JSON map sorted by key.
+	if got := props["response_schema"]; !strings.Contains(got, "\"id\":\"int\"") {
+		t.Errorf("response_schema missing typed id field: %q", got)
+	}
+	createProps := shapeOf(t, res, "http:POST:/users")
+	assertProp(t, createProps, "request_keys", "email,name")
+	if got := createProps["request_schema"]; !strings.Contains(got, "\"email\":\"str\"") {
+		t.Errorf("request_schema missing email field: %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Express
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_Express_ResJson(t *testing.T) {
+	src := `const express = require('express');
+const app = express();
+
+function getUser(req, res) {
+    res.json({id: 1, name: "alice", active: true});
+}
+
+function createUser(req, res) {
+    res.status(201).json({id: 1, name: "bob"});
+}
+
+function bad(req, res) {
+    res.status(404).json({error: "not found"});
+}
+
+app.get('/users/:id', getUser);
+app.post('/users', createUser);
+app.get('/users/:id/missing', bad);
+`
+	_, res := runDetect(t, "javascript", "app.js", src)
+	props := shapeOf(t, res, "http:GET:/users/{id}")
+	assertProp(t, props, "response_keys", "active,id,name")
+	assertProp(t, props, "response_keys_known", "true")
+	createProps := shapeOf(t, res, "http:POST:/users")
+	assertProp(t, createProps, "response_keys", "id,name")
+	// status_codes set includes the 201 from the chained status() call.
+	if got := createProps["status_codes"]; !strings.Contains(got, "201") {
+		t.Errorf("expected status_codes to include 201; got %q", got)
+	}
+	badProps := shapeOf(t, res, "http:GET:/users/{id}/missing")
+	assertProp(t, badProps, "error_keys", "error")
+	assertProp(t, badProps, "status_codes", "404")
+}
+
+// ---------------------------------------------------------------------------
+// Spring MVC
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_Spring_ResponseEntity(t *testing.T) {
+	src := `package com.example;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+class UserDto {
+    public Long id;
+    public String name;
+    public String email;
+}
+
+class CreateUserDto {
+    public String name;
+    public String email;
+}
+
+@RestController
+public class UserController {
+    @GetMapping("/users/{id}")
+    public ResponseEntity<UserDto> get(@PathVariable Long id) {
+        return ResponseEntity.ok(new UserDto());
+    }
+
+    @PostMapping("/users")
+    public UserDto create(@RequestBody CreateUserDto body) {
+        return new UserDto();
+    }
+}
+`
+	_, res := runDetect(t, "java", "UserController.java", src)
+	// The single-file test uses the YAML composed-route path which emits
+	// verb=ANY (the verb comes from the Spring AST pass in real builds).
+	getProps := shapeOf(t, res, "http:ANY:/users/{id}")
+	if rk := getProps["response_keys"]; !strings.Contains(rk, "id") || !strings.Contains(rk, "name") || !strings.Contains(rk, "email") {
+		t.Errorf("expected response_keys with id,name,email; got %q (all: %v)", rk, getProps)
+	}
+	if s := getProps["response_schema"]; !strings.Contains(s, "\"id\":\"Long\"") {
+		t.Errorf("expected response_schema with id:Long; got %q", s)
+	}
+	createProps := shapeOf(t, res, "http:ANY:/users")
+	if rk := createProps["request_keys"]; !strings.Contains(rk, "name") || !strings.Contains(rk, "email") {
+		t.Errorf("expected request_keys with name,email; got %q (all: %v)", rk, createProps)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// JAX-RS
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_JAXRS_TypedReturn(t *testing.T) {
+	src := `package com.example;
+import javax.ws.rs.*;
+import javax.ws.rs.core.Response;
+
+class ProductDto {
+    public Long id;
+    public String sku;
+    public Double price;
+}
+
+@Path("/products")
+public class ProductResource {
+    @GET
+    @Path("/{id}")
+    public ProductDto get(@PathParam("id") long id) {
+        return new ProductDto();
+    }
+}
+`
+	_, res := runDetect(t, "java", "ProductResource.java", src)
+	props := shapeOf(t, res, "http:GET:/products/{id}")
+	if rk := props["response_keys"]; !strings.Contains(rk, "id") || !strings.Contains(rk, "sku") || !strings.Contains(rk, "price") {
+		t.Errorf("expected response_keys with id,sku,price; got %q (all props: %v)", rk, props)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Go (Gin)
+// ---------------------------------------------------------------------------
+
+func TestResponseShape_Gin_JSONMap(t *testing.T) {
+	src := "package main\n" +
+		"\n" +
+		"import (\n" +
+		"\t\"github.com/gin-gonic/gin\"\n" +
+		"\t\"net/http\"\n" +
+		")\n" +
+		"\n" +
+		"type User struct {\n" +
+		"\tID    int    `json:\"id\"`\n" +
+		"\tName  string `json:\"name\"`\n" +
+		"\tEmail string `json:\"email\"`\n" +
+		"}\n" +
+		"\n" +
+		"func getUser(c *gin.Context) {\n" +
+		"\tc.JSON(http.StatusOK, gin.H{\"id\": 1, \"name\": \"alice\"})\n" +
+		"}\n" +
+		"\n" +
+		"func getUserTyped(c *gin.Context) {\n" +
+		"\tc.JSON(http.StatusOK, &User{})\n" +
+		"}\n" +
+		"\n" +
+		"func notFound(c *gin.Context) {\n" +
+		"\tc.JSON(http.StatusNotFound, gin.H{\"error\": \"missing\"})\n" +
+		"}\n" +
+		"\n" +
+		"func main() {\n" +
+		"\tr := gin.Default()\n" +
+		"\tr.GET(\"/users/:id\", getUser)\n" +
+		"\tr.GET(\"/users/:id/typed\", getUserTyped)\n" +
+		"\tr.GET(\"/users/:id/missing\", notFound)\n" +
+		"}\n"
+	_, res := runDetect(t, "go", "main.go", src)
+	props := shapeOf(t, res, "http:GET:/users/{id}")
+	assertProp(t, props, "response_keys", "id,name")
+	assertProp(t, props, "status_codes", "200")
+
+	typedProps := shapeOf(t, res, "http:GET:/users/{id}/typed")
+	if rk := typedProps["response_keys"]; !strings.Contains(rk, "id") || !strings.Contains(rk, "name") || !strings.Contains(rk, "email") {
+		t.Errorf("expected response_keys with id,name,email from struct; got %q", rk)
+	}
+	if s := typedProps["response_schema"]; !strings.Contains(s, "\"id\":") {
+		t.Errorf("expected response_schema with id field; got %q", s)
+	}
+	errProps := shapeOf(t, res, "http:GET:/users/{id}/missing")
+	assertProp(t, errProps, "error_keys", "error")
+	assertProp(t, errProps, "status_codes", "404")
+}
+
+// ---------------------------------------------------------------------------
+// Cross-language false-positive guard
+// ---------------------------------------------------------------------------
+
+// TestResponseShape_NoFalsePositive_GoFile verifies that scanning a Go
+// file with Express-shaped code in a string literal does not produce
+// shape extraction (the synth pass restricts JS extraction to JS files).
+func TestResponseShape_NoFalsePositive_GoFile(t *testing.T) {
+	// A Go file with a string literal that contains an Express-looking
+	// substring. The Python/JS shape extractors must NOT fire.
+	src := "package main\n\nconst sample = \"app.get('/users/:id', (req,res) => res.json({id:1}))\"\n"
+	_, res := runDetect(t, "go", "main.go", src)
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind {
+			if rk := e.Properties["response_keys"]; rk != "" {
+				t.Errorf("unexpected response_keys on go entity %s: %q", e.ID, rk)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Closes #722.

## Summary
- Adds `response_keys`, `response_schema`, `error_keys`, `status_codes`, `request_keys`, `request_schema`, `response_keys_known` properties to every synthetic `http_endpoint` entity emitted by `applyHTTPEndpointSynthesis`.
- New post-synthesis pass `applyResponseShapes` walks each emitted endpoint's handler body in the same file and extracts the shape additively (never adds/removes entities, only attaches properties).
- Schema values are JSON-serialised `map[string]string` sorted by key for deterministic output; list values are comma-joined and sorted.

## Framework coverage
- Django views (`return Response({...})` / `JsonResponse({...})`)
- DRF (`Response(...)` with `status=` kwarg + error keys)
- Flask (`jsonify({...})`, `{...}, 200`)
- FastAPI (`response_model=Dto` decorator + walks Pydantic class fields; `body: Dto` parameter for `request_schema`)
- Express (`res.json({...})`, `res.status(404).json({...})`)
- NestJS (`@ApiResponse({type: Dto})` + `Promise<Dto>` return type + `@Body() body: Dto`)
- Spring MVC (`ResponseEntity<Dto>`, `@ResponseBody Dto`, `ResponseEntity.status(404)`, `@RequestBody Dto`; path-shaped Route names fall back to scanning `@*Mapping` annotations)
- JAX-RS / Quarkus (typed return + walks DTO / record fields; implicit body parameter)
- Gin / Echo / Chi (Go) — adds Go to `synthesisSupportsLanguage` and a new `synthesizeGoRouters` scanner; handles `c.JSON(http.StatusOK, gin.H{...})` literals AND typed-struct returns with `json:"…"` tag respect

## Test plan
- [x] `go test ./internal/engine/... -run TestResponseShape` — 8 new tests covering Flask literal, Django Response, FastAPI Pydantic + request body, Express `res.status().json()`, Spring `ResponseEntity<>`, JAX-RS typed return, Gin JSON map + typed struct + error path, plus a cross-language false-positive guard (Go file with Express-shaped string literal)
- [x] `go test ./internal/engine/...` — full engine suite passes (one assertion in `TestDetect_GinEntityProperties` updated to skip http_endpoint entities, since their framework/pattern_type properties intentionally differ from YAML-driven ones)
- [x] `go test ./...` — full repo test suite green
- [ ] Verify on fixture-a / fixture-d / spring-petclinic that `response_keys` are populated on real corpora

## Behaviour for unresolvable returns
When the return value is a free variable (e.g. `return some_dict_var`, `return serializer.data`), the pass sets `response_keys_known=false` and skips the rest — distinguishing dynamic responses from genuinely keyless endpoints.

## File-disjoint with in-flight work
All new code lives in new files: `internal/engine/response_shape{,_python,_jsts,_java,_go,_test}.go`. The two modified files are `http_endpoint_synthesis.go` (one append + one switch-case addition + Go added to `synthesisSupportsLanguage`), `httproutes/canonicalize.go` (3 new framework constants reusing the colon-param walker), and `detector_test.go` (one skip-http_endpoint clause).