### PR TITLE
[#724] Process-flow BFS — language-agnostic call-chain traces from entry points

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -42,11 +42,12 @@ const (
 	PassGraphAlgo     = "graph-algo"     // Pass 4: placeholder for PORT-4
 	PassBuildDocument = "build-document" // Pass 5: assemble graph.Document
 	PassEnrichment    = "enrichment"     // Pass 6: emit enrichment candidates
+	PassProcessFlow   = "process-flow"   // Pass 7: process-flow BFS over CALLS (#724)
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassEnrichment,
+	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassEnrichment, PassProcessFlow,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -655,6 +656,28 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			return ra.Kind < rb.Kind
 		})
 		i.runPass4Algorithms(doc)
+	}
+
+	// Pass 7 — process-flow BFS (#724). Runs AFTER all CALLS edges are
+	// finalised (resolver + external synthesis + Pass 4) so the trace
+	// algorithm sees the same graph as downstream consumers. Emits
+	// SCOPE.Process entities + STEP_IN_PROCESS / ENTRY_POINT_OF edges.
+	// Skippable via --skip-pass=process-flow (default on).
+	if !i.skipPasses[PassProcessFlow] {
+		pfStats := engine.RunProcessFlow(doc, engine.DefaultProcessFlowConfig())
+		if verbose() || pfStats.Processes > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: process-flow entry_candidates=%d entries_used=%d "+
+					"processes=%d cross_stack=%d step_edges=%d entry_edges=%d\n",
+				pfStats.EntryCandidates, pfStats.EntriesUsed,
+				pfStats.Processes, pfStats.CrossStack,
+				pfStats.StepEdges, pfStats.EntryEdges)
+		}
+		// Re-sync Stats so the downstream sidecar + emission see the new
+		// entity/edge counts. The final sort below in Index() will fold the
+		// process entities into the canonical id ordering.
+		doc.Stats.Entities = len(doc.Entities)
+		doc.Stats.Relationships = len(doc.Relationships)
 	}
 
 	// Pass 6 — enrichment candidate emission (PORT-LLM / issue #15). Runs

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -1,0 +1,555 @@
+// Process-flow BFS pass (#724).
+//
+// Walks the CALLS graph forward from heuristically-detected entry points
+// and emits Process entities + STEP_IN_PROCESS / ENTRY_POINT_OF edges.
+// Each Process is a linearized call chain. The pass is language-agnostic —
+// it consumes the CALLS edges that the per-language extractors already
+// produce and never inspects source code directly.
+//
+// Algorithm (per ADR-0018 / issue #724):
+//   1. Score every Function/Method/Operation/Component candidate by
+//      fan-out, name pattern, exported flag, framework signal, and HTTP
+//      boundary signal.
+//   2. Keep the top entry points (capped at MaxEntryPoints).
+//   3. For each entry point, run forward BFS over CALLS edges with depth
+//      bounded by MaxDepth (≤10) and branching bounded by BranchingFactor
+//      (≤4). Each traversal stops on a leaf (no outgoing CALLS) or when
+//      bounds are hit.
+//   4. Dedupe traces by (entry_id, terminal_id) — keep the longest chain
+//      and drop strict prefixes of longer chains.
+//   5. Emit one Process entity per surviving trace plus STEP_IN_PROCESS
+//      edges (step_index ordered) and ENTRY_POINT_OF edges from the
+//      entry function to the Process.
+//
+// Cross-stack detection: a Process is marked cross_stack=true when its
+// chain traverses an HTTP boundary — i.e. one of its steps is an HTTP
+// endpoint / route entity, or any edge target switches to a "SCOPE.Endpoint",
+// "SCOPE.Route", or "http_endpoint" kind. Once #726 (FETCHES) lands the
+// detection here will also include that edge kind.
+//
+// The pass is deterministic: entries are sorted by descending score then
+// by canonical ID; outgoing edges at each BFS step are sorted by callee ID
+// for stable top-k selection.
+package engine
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ProcessFlowConfig controls the BFS pass.
+type ProcessFlowConfig struct {
+	// MaxDepth caps the chain length (number of hops past the entry). ≤10.
+	MaxDepth int
+	// BranchingFactor caps the number of outgoing CALLS expanded at each
+	// step. ≤4 keeps the trace count tractable.
+	BranchingFactor int
+	// MaxEntryPoints is the global cap on entry candidates considered.
+	MaxEntryPoints int
+	// MaxProcesses is the global cap on Process entities emitted.
+	MaxProcesses int
+	// MinSteps is the minimum chain length for a Process to be emitted.
+	// Trivial 1-hop processes are discarded.
+	MinSteps int
+}
+
+// DefaultProcessFlowConfig returns the v1.0 tuning per #724.
+func DefaultProcessFlowConfig() ProcessFlowConfig {
+	return ProcessFlowConfig{
+		MaxDepth:        10,
+		BranchingFactor: 4,
+		MaxEntryPoints:  200,
+		MaxProcesses:    300,
+		MinSteps:        3,
+	}
+}
+
+// processStats summarises the outcome of one pass for stderr / tests.
+type processStats struct {
+	EntryCandidates int
+	EntriesUsed     int
+	Processes       int
+	StepEdges       int
+	EntryEdges      int
+	CrossStack      int
+	TruncatedDepth  int
+	TruncatedFanout int
+}
+
+// RunProcessFlow executes the BFS pass against doc and appends the
+// emitted Process entities + STEP_IN_PROCESS / ENTRY_POINT_OF edges to
+// the document in place. Returns a stats summary. Safe to call on a
+// document with no CALLS edges (returns an empty stats record).
+func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
+	if doc == nil {
+		return processStats{}
+	}
+	cfg = clampConfig(cfg)
+
+	// Index entities by ID for fast lookup of kind / source-file metadata.
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		byID[e.ID] = e
+	}
+
+	// Build the same HTTP-boundary set used by entry ranking. Any chain
+	// whose entry or step is on this set traverses an HTTP handler — that
+	// makes the resulting Process cross-stack relevant even when the
+	// http_endpoint entity itself sits at the end of an IMPLEMENTS edge
+	// rather than the CALLS chain.
+	httpBoundary := buildHTTPBoundarySet(doc)
+
+	// Build CALLS adjacency. Edges with explicit `confidence < 0.5` are
+	// excluded so fuzzy global-fallback matches don't dominate traces.
+	adj := buildCallsAdjacency(doc)
+
+	// Score candidate entry points.
+	candidates := rankEntryPoints(doc, byID, adj, cfg)
+	stats := processStats{EntryCandidates: len(candidates)}
+	if len(candidates) == 0 {
+		return stats
+	}
+	if len(candidates) > cfg.MaxEntryPoints {
+		candidates = candidates[:cfg.MaxEntryPoints]
+	}
+	// Drop entries that are reachable from a higher-ranked entry — those
+	// are mid-chain functions, not true entry points. This collapses the
+	// "every node with fan-out claims to be an entry" problem on linear
+	// chains while preserving genuinely-independent entries in DAGs.
+	candidates = pruneReachableEntries(candidates, adj, cfg.MaxDepth)
+	stats.EntriesUsed = len(candidates)
+
+	// BFS from each entry point.
+	best := make(map[traceKey][]string) // key -> longest chain
+	for _, c := range candidates {
+		traces, depthTrunc, fanTrunc := bfsTraces(c.id, adj, cfg)
+		stats.TruncatedDepth += depthTrunc
+		stats.TruncatedFanout += fanTrunc
+		for _, t := range traces {
+			if len(t) < cfg.MinSteps {
+				continue
+			}
+			term := t[len(t)-1]
+			k := traceKey{c.id, term}
+			if prev, ok := best[k]; !ok || len(t) > len(prev) {
+				best[k] = t
+			}
+		}
+	}
+
+	// Stable, scored ordering of the surviving traces.
+	type emit struct {
+		chain     []string
+		entryName string
+		entryFile string
+	}
+	keys := make([]traceKey, 0, len(best))
+	for k := range best {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		// Longest chains first, then by entry id, then terminal id for
+		// determinism.
+		li := len(best[keys[i]])
+		lj := len(best[keys[j]])
+		if li != lj {
+			return li > lj
+		}
+		if keys[i].entry != keys[j].entry {
+			return keys[i].entry < keys[j].entry
+		}
+		return keys[i].terminal < keys[j].terminal
+	})
+	if len(keys) > cfg.MaxProcesses {
+		keys = keys[:cfg.MaxProcesses]
+	}
+
+	// Drop chains that are a strict prefix of a longer chain emitted from
+	// the same entry. This collapses sub-trace redundancy without losing
+	// the longest representation of any branch.
+	keys = dropPrefixSubtraces(keys, best)
+
+	// Emit Process entities + edges.
+	for _, k := range keys {
+		chain := best[k]
+		entry := byID[chain[0]]
+		terminal := byID[chain[len(chain)-1]]
+		if entry == nil || terminal == nil {
+			continue
+		}
+		crossStack := chainCrossesStack(chain, byID) || chainTouchesHTTP(chain, httpBoundary)
+		processID := computeProcessID(doc.Repo, chain)
+		label := fmt.Sprintf("%s → %s", entry.Name, terminal.Name)
+
+		props := map[string]string{
+			"entry_id":     entry.ID,
+			"entry_name":   entry.Name,
+			"terminal_id":  terminal.ID,
+			"step_count":   strconv.Itoa(len(chain)),
+			"cross_stack":  strconv.FormatBool(crossStack),
+			"chain":        strings.Join(chain, ","),
+			"chain_labels": strings.Join(chainLabels(chain, byID), " → "),
+		}
+
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         processID,
+			Name:       label,
+			Kind:       string(EntityKindProcess),
+			SourceFile: entry.SourceFile,
+			StartLine:  entry.StartLine,
+			EndLine:    entry.EndLine,
+			Language:   entry.Language,
+			Properties: props,
+		})
+		stats.Processes++
+		if crossStack {
+			stats.CrossStack++
+		}
+
+		// ENTRY_POINT_OF: entry function → Process.
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(entry.ID, processID, string(RelationshipKindEntryPointOf)),
+			FromID: entry.ID,
+			ToID:   processID,
+			Kind:   string(RelationshipKindEntryPointOf),
+		})
+		stats.EntryEdges++
+
+		// STEP_IN_PROCESS edges: Process → step entity, step_index 0-based.
+		for i, stepID := range chain {
+			rel := graph.Relationship{
+				ID:     graph.RelationshipID(processID, stepID, string(RelationshipKindStepInProcess)+":"+strconv.Itoa(i)),
+				FromID: processID,
+				ToID:   stepID,
+				Kind:   string(RelationshipKindStepInProcess),
+				Properties: map[string]string{
+					"step_index": strconv.Itoa(i),
+				},
+			}
+			doc.Relationships = append(doc.Relationships, rel)
+			stats.StepEdges++
+		}
+	}
+	return stats
+}
+
+// clampConfig enforces the algorithmic bounds in #724.
+func clampConfig(cfg ProcessFlowConfig) ProcessFlowConfig {
+	if cfg.MaxDepth <= 0 || cfg.MaxDepth > 10 {
+		cfg.MaxDepth = 10
+	}
+	if cfg.BranchingFactor <= 0 || cfg.BranchingFactor > 4 {
+		cfg.BranchingFactor = 4
+	}
+	if cfg.MaxEntryPoints <= 0 {
+		cfg.MaxEntryPoints = 200
+	}
+	if cfg.MaxProcesses <= 0 {
+		cfg.MaxProcesses = 300
+	}
+	if cfg.MinSteps < 2 {
+		cfg.MinSteps = 3
+	}
+	return cfg
+}
+
+// callsAdjacency stores out / in degree per node id over CALLS edges.
+type callsAdjacency struct {
+	out map[string][]string
+	in  map[string]int
+}
+
+// buildCallsAdjacency filters the document's edges down to CALLS only and
+// produces a deterministic adjacency list. Edges with confidence < 0.5
+// (as set by the resolver) are excluded — they're typically global-fallback
+// matches and inflate trace counts with false branches.
+func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
+	a := &callsAdjacency{
+		out: make(map[string][]string),
+		in:  make(map[string]int),
+	}
+	seen := make(map[string]map[string]bool)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != string(RelationshipKindCalls) {
+			continue
+		}
+		if !confidenceOK(r) {
+			continue
+		}
+		if r.FromID == r.ToID {
+			continue // skip self-loops
+		}
+		if seen[r.FromID] == nil {
+			seen[r.FromID] = make(map[string]bool)
+		}
+		if seen[r.FromID][r.ToID] {
+			continue
+		}
+		seen[r.FromID][r.ToID] = true
+		a.out[r.FromID] = append(a.out[r.FromID], r.ToID)
+		a.in[r.ToID]++
+	}
+	for k := range a.out {
+		sort.Strings(a.out[k])
+	}
+	return a
+}
+
+// confidenceOK returns true when the relationship has either no
+// confidence property or a parseable confidence ≥ 0.5.
+func confidenceOK(r *graph.Relationship) bool {
+	if r.Properties == nil {
+		return true
+	}
+	v, ok := r.Properties["confidence"]
+	if !ok {
+		return true
+	}
+	f, err := strconv.ParseFloat(v, 64)
+	if err != nil {
+		return true
+	}
+	return f >= 0.5
+}
+
+// bfsTraces runs forward BFS from entry, emitting one chain per reachable
+// terminal node within the configured depth + branching bounds. A "terminal"
+// is any node with no outgoing CALLS or the node at MaxDepth.
+//
+// Returns the slice of chains plus the count of depth- and fanout-truncated
+// branches (useful for stats).
+func bfsTraces(entry string, adj *callsAdjacency, cfg ProcessFlowConfig) ([][]string, int, int) {
+	type frame struct {
+		chain []string
+		seen  map[string]bool
+	}
+	initSeen := map[string]bool{entry: true}
+	work := []frame{{chain: []string{entry}, seen: initSeen}}
+	var out [][]string
+	depthTrunc, fanTrunc := 0, 0
+
+	for len(work) > 0 {
+		// Pop last (DFS-ish iterative — order doesn't matter for the
+		// emitted set since we dedupe by (entry,terminal)).
+		f := work[len(work)-1]
+		work = work[:len(work)-1]
+
+		current := f.chain[len(f.chain)-1]
+		neighbors := adj.out[current]
+		if len(neighbors) == 0 || len(f.chain) > cfg.MaxDepth {
+			if len(f.chain) > cfg.MaxDepth {
+				depthTrunc++
+			}
+			// Emit a copy — f.chain may alias slices we will mutate later.
+			out = append(out, append([]string(nil), f.chain...))
+			continue
+		}
+		// Sort + cap to branching factor for determinism.
+		sortedN := append([]string(nil), neighbors...)
+		sort.Strings(sortedN)
+		if len(sortedN) > cfg.BranchingFactor {
+			fanTrunc += len(sortedN) - cfg.BranchingFactor
+			sortedN = sortedN[:cfg.BranchingFactor]
+		}
+		extended := false
+		for _, n := range sortedN {
+			if f.seen[n] {
+				continue
+			}
+			extended = true
+			newSeen := make(map[string]bool, len(f.seen)+1)
+			for k := range f.seen {
+				newSeen[k] = true
+			}
+			newSeen[n] = true
+			newChain := append(append([]string(nil), f.chain...), n)
+			work = append(work, frame{chain: newChain, seen: newSeen})
+		}
+		if !extended {
+			// All neighbors already visited → terminal cycle stop.
+			out = append(out, append([]string(nil), f.chain...))
+		}
+	}
+	return out, depthTrunc, fanTrunc
+}
+
+// dropPrefixSubtraces removes chains that are strict prefixes of another
+// chain emitted from the same entry id. The longer chain is kept.
+func dropPrefixSubtraces(keys []traceKey, best map[traceKey][]string) []traceKey {
+	// Bucket by entry id.
+	byEntry := make(map[string][]traceKey)
+	for _, k := range keys {
+		byEntry[k.entry] = append(byEntry[k.entry], k)
+	}
+	keep := make(map[traceKey]bool, len(keys))
+	for _, ks := range byEntry {
+		// Longest first so we can short-circuit prefix checks.
+		sort.Slice(ks, func(i, j int) bool {
+			return len(best[ks[i]]) > len(best[ks[j]])
+		})
+		for i, k := range ks {
+			isPrefix := false
+			for j := 0; j < i; j++ {
+				if isStrictPrefix(best[k], best[ks[j]]) {
+					isPrefix = true
+					break
+				}
+			}
+			if !isPrefix {
+				keep[k] = true
+			}
+		}
+	}
+	out := make([]traceKey, 0, len(keep))
+	for _, k := range keys {
+		if keep[k] {
+			out = append(out, k)
+		}
+	}
+	return out
+}
+
+func isStrictPrefix(short, long []string) bool {
+	if len(short) >= len(long) {
+		return false
+	}
+	for i := range short {
+		if short[i] != long[i] {
+			return false
+		}
+	}
+	return true
+}
+
+// chainLabels returns the human-readable names of each step (or its ID
+// when the entity is missing).
+func chainLabels(chain []string, byID map[string]*graph.Entity) []string {
+	out := make([]string, len(chain))
+	for i, id := range chain {
+		if e, ok := byID[id]; ok && e.Name != "" {
+			out[i] = e.Name
+		} else {
+			out[i] = id
+		}
+	}
+	return out
+}
+
+// buildHTTPBoundarySet returns the set of entity ids on either side of
+// an IMPLEMENTS / ROUTES_TO / SERVES edge — i.e. functions/methods that
+// implement an HTTP endpoint, plus the endpoint entities themselves.
+// Used by both rankEntryPoints (boost candidate score) and the cross-
+// stack detector (mark Process as cross_stack=true).
+func buildHTTPBoundarySet(doc *graph.Document) map[string]bool {
+	out := make(map[string]bool)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		switch r.Kind {
+		case "IMPLEMENTS", "ROUTES_TO", "SERVES":
+			out[r.FromID] = true
+			out[r.ToID] = true
+		}
+	}
+	return out
+}
+
+// chainTouchesHTTP returns true when any step in the chain is on the
+// HTTP-boundary set (i.e. is the source or target of an IMPLEMENTS /
+// ROUTES_TO / SERVES edge).
+func chainTouchesHTTP(chain []string, boundary map[string]bool) bool {
+	for _, id := range chain {
+		if boundary[id] {
+			return true
+		}
+	}
+	return false
+}
+
+// chainCrossesStack reports whether any step in the chain points at an
+// entity whose kind represents an HTTP / service boundary. Once the
+// FETCHES edge kind lands (#726) the detection is extended in
+// buildCallsAdjacency to flag the transition there.
+func chainCrossesStack(chain []string, byID map[string]*graph.Entity) bool {
+	for _, id := range chain {
+		e, ok := byID[id]
+		if !ok {
+			continue
+		}
+		switch strings.ToLower(e.Kind) {
+		case "http_endpoint",
+			strings.ToLower(string(EntityKindEndpoint)),
+			strings.ToLower(string(EntityKindRoute)),
+			strings.ToLower(string(EntityKindExternalAPI)):
+			return true
+		}
+	}
+	return false
+}
+
+// computeProcessID derives a stable Process entity ID from the repo tag
+// and the full chain. The hash is collision-resistant: two chains with
+// the same entry + terminal but distinct intermediates get distinct IDs.
+func computeProcessID(repo string, chain []string) string {
+	h := sha256.New()
+	h.Write([]byte(repo))
+	h.Write([]byte{0})
+	h.Write([]byte("Process"))
+	h.Write([]byte{0})
+	for _, c := range chain {
+		h.Write([]byte(c))
+		h.Write([]byte{0})
+	}
+	return "proc:" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// traceKey is a chain identity (defined here at file scope so the
+// dropPrefixSubtraces helper can take it as a parameter).
+type traceKey struct {
+	entry    string
+	terminal string
+}
+
+// pruneReachableEntries removes candidates that are reachable from any
+// higher-ranked candidate. Candidates is consumed in score order so we
+// only need to track which IDs have been "claimed" by an earlier entry's
+// forward-reachable set. Reachability is bounded by maxDepth to mirror the
+// later BFS — a candidate that only becomes reachable past the BFS depth
+// limit is still a valid independent entry.
+func pruneReachableEntries(candidates []entryCandidate, adj *callsAdjacency, maxDepth int) []entryCandidate {
+	claimed := make(map[string]bool)
+	out := make([]entryCandidate, 0, len(candidates))
+	for _, c := range candidates {
+		if claimed[c.id] {
+			continue
+		}
+		out = append(out, c)
+		// Mark everything reachable from c (within maxDepth) as claimed.
+		// We don't need separate frame state here — a simple level-BFS is
+		// enough since we only care about set membership.
+		frontier := []string{c.id}
+		seen := map[string]bool{c.id: true}
+		for depth := 0; depth < maxDepth && len(frontier) > 0; depth++ {
+			var next []string
+			for _, n := range frontier {
+				for _, nb := range adj.out[n] {
+					if seen[nb] {
+						continue
+					}
+					seen[nb] = true
+					claimed[nb] = true
+					next = append(next, nb)
+				}
+			}
+			frontier = next
+		}
+	}
+	return out
+}

--- a/internal/engine/process_flow_entry.go
+++ b/internal/engine/process_flow_entry.go
@@ -1,0 +1,176 @@
+// Entry-point ranking for the process-flow BFS pass (#724).
+//
+// Each candidate function/method/operation is scored by a small set of
+// language-agnostic heuristics. The scoring is intentionally additive
+// and capped so that no single signal dominates — empirically this gives
+// reasonable distributions across Python (decorator-heavy handlers), Go
+// (main + ExportedTitleCase functions), Java/Kotlin (annotated controller
+// methods), and JS/TS (default-exported handlers, useEffect bodies).
+//
+// Signals (additive):
+//
+//   - Fan-out / fan-in ratio: high callees, low callers → entry-like.
+//   - Name pattern: handle*, *Handler, *Controller, *Service, main, run,
+//     bootstrap, start, init, on*, useEffect, componentDidMount, …
+//   - HTTP boundary: entity with inbound IMPLEMENTS / ROUTES_TO / SERVES
+//     from a Route or http_endpoint is almost certainly an entry.
+//   - Exported flag: pythonic dunder-init or capitalised Go identifier,
+//     or signature substring " export " — boosted.
+//   - Utility penalty: get*, set*, format*, parse*, validate*, *Helper,
+//     *Util, *_test — demoted (they are leaves, not entries).
+//
+// The final list is sorted by descending score, then by canonical ID for
+// deterministic output.
+package engine
+
+import (
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// entryCandidate carries the scoring breakdown alongside the entity id.
+type entryCandidate struct {
+	id    string
+	name  string
+	kind  string
+	score float64
+}
+
+// rankEntryPoints scores every Function/Method/Operation/Component entity
+// and returns the candidates in descending score order. Candidates with
+// score ≤ 0 (heavy utility penalty, no fan-out) are dropped.
+func rankEntryPoints(doc *graph.Document, byID map[string]*graph.Entity, adj *callsAdjacency, cfg ProcessFlowConfig) []entryCandidate {
+	// HTTP-boundary signal: any entity on either side of an IMPLEMENTS /
+	// ROUTES_TO / SERVES edge is almost certainly an entry point (or the
+	// endpoint it serves).
+	httpBoundary := buildHTTPBoundarySet(doc)
+
+	out := make([]entryCandidate, 0, 64)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if !isEntryCandidate(e) {
+			continue
+		}
+		outDeg := len(adj.out[e.ID])
+		if outDeg == 0 {
+			// Pure leaves are never entries.
+			continue
+		}
+		inDeg := adj.in[e.ID]
+		score := float64(outDeg) / float64(inDeg+1)
+
+		// Name pattern boosts. Match the un-prefixed local name only —
+		// extractors sometimes pack package paths into Name.
+		local := localName(e.Name)
+		if entryNameRE.MatchString(local) {
+			score += 4.0
+		}
+		if utilityNameRE.MatchString(local) {
+			score -= 3.0
+		}
+
+		// HTTP boundary signal — biggest boost. An IMPLEMENTS edge from a
+		// route handler to this entity (or vice versa) makes it the
+		// canonical entry for that route.
+		if httpBoundary[e.ID] {
+			score += 6.0
+		}
+
+		// Exported / public boost.
+		if isExportedName(local, e.Language) {
+			score += 1.5
+		}
+
+		// Per-kind tweak: SCOPE.Operation is the framework-extractor kind
+		// used for annotated route handler methods (Java, Spring) and
+		// scores higher than a bare Function.
+		switch e.Kind {
+		case "SCOPE.Operation":
+			score += 1.0
+		case "SCOPE.Component":
+			score += 0.5
+		}
+
+		if score <= 0 {
+			continue
+		}
+		out = append(out, entryCandidate{id: e.ID, name: e.Name, kind: e.Kind, score: score})
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].score != out[j].score {
+			return out[i].score > out[j].score
+		}
+		return out[i].id < out[j].id
+	})
+	return out
+}
+
+// isEntryCandidate filters to entity kinds that can host a CALLS chain.
+// Routes and Endpoints themselves are targets of IMPLEMENTS edges, not
+// origins of CALLS; the handler entity (Function/Method/Operation) is what
+// actually emits the CALLS chain.
+func isEntryCandidate(e *graph.Entity) bool {
+	switch e.Kind {
+	case "SCOPE.Function", "SCOPE.Operation", "SCOPE.Component", "SCOPE.Class":
+		return true
+	}
+	return false
+}
+
+// localName strips package qualifications from an entity name. Extractors
+// emit names like "module.path.handleSubmit" or "ClassName.method" — for
+// the regex match we only care about the trailing identifier.
+func localName(n string) string {
+	if i := strings.LastIndex(n, "."); i >= 0 && i+1 < len(n) {
+		return n[i+1:]
+	}
+	if i := strings.LastIndex(n, "::"); i >= 0 && i+2 < len(n) {
+		return n[i+2:]
+	}
+	return n
+}
+
+// entryNameRE matches identifiers that strongly suggest an entry point.
+// The list is intentionally broad to span Python (snake_case), JS/TS
+// (camelCase), Go (CamelCase), and Java/Kotlin annotated handler styles.
+var entryNameRE = regexp.MustCompile(
+	`^(?i)(main|run|start|bootstrap|init|setup|launch|serve|` +
+		`on[A-Z]\w*|handle[A-Z_]\w*|process[A-Z]\w*|dispatch[A-Z]?\w*|` +
+		`useEffect|componentDidMount|componentWillMount|render|module|` +
+		`application|app_factory|create_app|app|getServerSideProps|getStaticProps|` +
+		`__main__|__init__|run_server|run_app|listen)$` +
+		`|.*(Handler|Controller|Service|Endpoint|Resource|Action|Job|Task|Worker|Listener|Consumer|Subscriber|Producer|Resolver|Mutation|Query|Command|Middleware|Filter|Interceptor|Pipeline|Saga|Reducer|Module|Page|View|Screen|Route|Hook|Cron|Schedule)$`,
+)
+
+// utilityNameRE matches identifiers that strongly suggest a leaf utility.
+var utilityNameRE = regexp.MustCompile(
+	`^(?i)(get|set|is|has|to|from|as|of)[A-Z_]?\w*$|` +
+		`^(?i)(format|parse|validate|sanitize|normalize|encode|decode|escape|unescape|hash|sign|verify|serialize|deserialize|stringify|clone|copy|merge|equal|equals|compare|cmp|len|length|size|count|sum|min|max)\w*$|` +
+		`.*(Helper|Util|Utils|Helpers|Constants?)$`,
+)
+
+// isExportedName approximates "is this symbol publicly visible". Per-
+// language conventions:
+//   - Go: leading uppercase
+//   - Python/Ruby: not starting with underscore
+//   - JS/TS/Java/Kotlin: leading uppercase OR camelCase (most code is
+//     exported), so we conservatively treat ALL non-underscore identifiers
+//     as exported for those languages.
+func isExportedName(name, language string) bool {
+	if name == "" {
+		return false
+	}
+	first := name[0]
+	switch strings.ToLower(language) {
+	case "go":
+		return first >= 'A' && first <= 'Z'
+	case "python", "py", "ruby", "rb":
+		return first != '_'
+	default:
+		return first != '_'
+	}
+}

--- a/internal/engine/process_flow_kinds.go
+++ b/internal/engine/process_flow_kinds.go
@@ -1,0 +1,34 @@
+// Process-flow entity + edge kind constants (#724).
+//
+// These constants are intentionally kept in their own file so the typed-
+// kind allowlist in internal/types/kinds.go is not perturbed while the
+// process-flow feature is rolled out append-only. They live in package
+// engine because that is the package that emits them; downstream
+// consumers (MCP, doc-gen) reference the string values directly.
+package engine
+
+// EntityKindProcess identifies a Process entity — a linearized call chain
+// emitted by RunProcessFlow. Name: "<entry> → <terminal>".
+const EntityKindProcess = "SCOPE.Process"
+
+// RelationshipKindStepInProcess identifies a Process → step edge.
+// The step_index property (0-based) records position in the chain.
+const RelationshipKindStepInProcess = "STEP_IN_PROCESS"
+
+// RelationshipKindEntryPointOf identifies the entry-function → Process
+// edge that marks a function as the entry for a Process.
+const RelationshipKindEntryPointOf = "ENTRY_POINT_OF"
+
+// RelationshipKindCalls re-exports the canonical CALLS string for use in
+// this package without an internal/types import cycle.
+const RelationshipKindCalls = "CALLS"
+
+// EntityKindEndpoint, EntityKindRoute, EntityKindExternalAPI are referenced
+// by chainCrossesStack and match the canonical SCOPE.* names produced by
+// the per-language extractors. Duplicated here as raw strings to avoid an
+// internal/types import for a single-use lookup.
+const (
+	EntityKindEndpoint    = "SCOPE.Endpoint"
+	EntityKindRoute       = "SCOPE.Route"
+	EntityKindExternalAPI = "SCOPE.ExternalAPI"
+)

--- a/internal/engine/process_flow_test.go
+++ b/internal/engine/process_flow_test.go
@@ -1,0 +1,278 @@
+package engine
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// buildChainDoc constructs a synthetic graph: one entry function calls
+// step1, which calls step2, …, up to depth+1 nodes total.
+func buildChainDoc(repo string, depth int) *graph.Document {
+	doc := &graph.Document{Repo: repo}
+	prev := ""
+	for i := 0; i <= depth; i++ {
+		name := "handleSubmit"
+		if i > 0 {
+			name = "step" + strconv.Itoa(i)
+		}
+		id := "n" + strconv.Itoa(i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         id,
+			Name:       name,
+			Kind:       "SCOPE.Function",
+			Language:   "go",
+			SourceFile: "main.go",
+		})
+		if prev != "" {
+			doc.Relationships = append(doc.Relationships, graph.Relationship{
+				ID:     "r" + strconv.Itoa(i),
+				FromID: prev,
+				ToID:   id,
+				Kind:   "CALLS",
+			})
+		}
+		prev = id
+	}
+	return doc
+}
+
+func countProcesses(doc *graph.Document) int {
+	n := 0
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			n++
+		}
+	}
+	return n
+}
+
+func TestProcessFlow_EmitsLinearChain(t *testing.T) {
+	doc := buildChainDoc("r", 4) // 5 nodes
+	stats := RunProcessFlow(doc, DefaultProcessFlowConfig())
+	if stats.Processes != 1 {
+		t.Fatalf("want 1 process, got %d", stats.Processes)
+	}
+	if got := countProcesses(doc); got != 1 {
+		t.Fatalf("emitted entity count = %d, want 1", got)
+	}
+	var stepEdges, entryEdges int
+	for _, r := range doc.Relationships {
+		switch r.Kind {
+		case RelationshipKindStepInProcess:
+			stepEdges++
+		case RelationshipKindEntryPointOf:
+			entryEdges++
+		}
+	}
+	if stepEdges != 5 {
+		t.Errorf("step edges = %d, want 5", stepEdges)
+	}
+	if entryEdges != 1 {
+		t.Errorf("entry edges = %d, want 1", entryEdges)
+	}
+}
+
+func TestProcessFlow_DepthCap(t *testing.T) {
+	// 20-deep chain, MaxDepth=10 → emitted chain length ≤ 11 (entry + 10).
+	doc := buildChainDoc("r", 20)
+	cfg := DefaultProcessFlowConfig()
+	cfg.MaxDepth = 10
+	RunProcessFlow(doc, cfg)
+	var procChain string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			procChain = e.Properties["chain"]
+			break
+		}
+	}
+	if procChain == "" {
+		t.Fatal("no Process emitted")
+	}
+	steps := strings.Split(procChain, ",")
+	if len(steps) > 11 {
+		t.Errorf("depth-capped chain has %d steps, want ≤ 11", len(steps))
+	}
+}
+
+func TestProcessFlow_BranchingCap(t *testing.T) {
+	// Entry node with 10 outgoing CALLS, each to a leaf. BranchingFactor=4
+	// should result in only 4 surviving leaf chains.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = append(doc.Entities, graph.Entity{
+		ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go",
+	})
+	for i := 0; i < 10; i++ {
+		id := "leaf" + strconv.Itoa(i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: id, Name: "leaf", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go",
+		})
+		// Add a second hop so MinSteps (=3) is satisfied.
+		mid := "mid" + strconv.Itoa(i)
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: mid, Name: "mid", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go",
+		})
+		doc.Relationships = append(doc.Relationships,
+			graph.Relationship{ID: "e1_" + strconv.Itoa(i), FromID: "entry", ToID: mid, Kind: "CALLS"},
+			graph.Relationship{ID: "e2_" + strconv.Itoa(i), FromID: mid, ToID: id, Kind: "CALLS"},
+		)
+	}
+	cfg := DefaultProcessFlowConfig()
+	cfg.BranchingFactor = 4
+	stats := RunProcessFlow(doc, cfg)
+	if stats.Processes > 4 {
+		t.Errorf("branching-capped processes = %d, want ≤ 4", stats.Processes)
+	}
+	if stats.TruncatedFanout == 0 {
+		t.Errorf("expected fanout truncation to be reported")
+	}
+}
+
+func TestProcessFlow_DedupByEntryTerminal(t *testing.T) {
+	// Diamond: entry → A → terminal, entry → B → terminal.
+	// Both paths share (entry, terminal). Expect 1 Process per unique
+	// (entry, terminal) pair regardless of intermediate branches.
+	doc := &graph.Document{Repo: "r"}
+	for _, n := range []string{"entry", "A", "B", "terminal"} {
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID: n, Name: n, Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go",
+		})
+	}
+	for _, e := range [][3]string{
+		{"entry", "A", "1"},
+		{"entry", "B", "2"},
+		{"A", "terminal", "3"},
+		{"B", "terminal", "4"},
+	} {
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID: "e" + e[2], FromID: e[0], ToID: e[1], Kind: "CALLS",
+		})
+	}
+	// Rename so name match prefers `entry` not utility.
+	doc.Entities[0].Name = "handleSubmit"
+	stats := RunProcessFlow(doc, DefaultProcessFlowConfig())
+	if stats.Processes != 1 {
+		t.Errorf("dedupe: got %d processes, want 1", stats.Processes)
+	}
+}
+
+func TestProcessFlow_CrossStack(t *testing.T) {
+	// entry → call → http_endpoint. Should mark cross_stack=true.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
+		{ID: "svc", Name: "callService", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
+		{ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "ts", SourceFile: "api.ts"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "svc", Kind: "CALLS"},
+		{ID: "2", FromID: "svc", ToID: "ep", Kind: "CALLS"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	var got string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			got = e.Properties["cross_stack"]
+			break
+		}
+	}
+	if got != "true" {
+		t.Errorf("cross_stack = %q, want true", got)
+	}
+}
+
+func TestProcessFlow_CrossStackViaImplements(t *testing.T) {
+	// Handler function implements an http_endpoint via an IMPLEMENTS edge
+	// (not by appearing on the CALLS chain). The Process should still
+	// be marked cross_stack=true because the entry is on the HTTP boundary.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "h", Name: "handleOrders", Kind: "SCOPE.Function", Language: "py", SourceFile: "api.py"},
+		{ID: "svc", Name: "callService", Kind: "SCOPE.Function", Language: "py", SourceFile: "api.py"},
+		{ID: "db", Name: "writeRecord", Kind: "SCOPE.Function", Language: "py", SourceFile: "db.py"},
+		{ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "py", SourceFile: "api.py"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "h", ToID: "svc", Kind: "CALLS"},
+		{ID: "2", FromID: "svc", ToID: "db", Kind: "CALLS"},
+		{ID: "3", FromID: "h", ToID: "ep", Kind: "IMPLEMENTS"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	var got string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			got = e.Properties["cross_stack"]
+			break
+		}
+	}
+	if got != "true" {
+		t.Errorf("expected cross_stack=true via IMPLEMENTS, got %q", got)
+	}
+}
+
+func TestProcessFlow_MinStepsDropsTrivial(t *testing.T) {
+	// Two-node chain: entry → leaf. Below MinSteps=3 → no Process.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "leaf", Name: "leaf", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "leaf", Kind: "CALLS"},
+	}
+	stats := RunProcessFlow(doc, DefaultProcessFlowConfig())
+	if stats.Processes != 0 {
+		t.Errorf("trivial chain emitted %d processes, want 0", stats.Processes)
+	}
+}
+
+func TestProcessFlow_LowConfidenceCallsSkipped(t *testing.T) {
+	// CALLS edge with confidence=0.3 should not be traversed.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "a", Name: "a", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "b", Name: "b", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+		{ID: "c", Name: "c", Kind: "SCOPE.Function", Language: "go", SourceFile: "x.go"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "a", Kind: "CALLS"},
+		{ID: "2", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "3", FromID: "b", ToID: "c", Kind: "CALLS", Properties: map[string]string{"confidence": "0.3"}},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	var chain string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			chain = e.Properties["chain"]
+			break
+		}
+	}
+	if chain == "" {
+		t.Fatal("expected one Process")
+	}
+	if strings.Contains(chain, "c") {
+		t.Errorf("low-confidence edge was traversed; chain=%q", chain)
+	}
+}
+
+func TestProcessFlow_NilDocumentIsSafe(t *testing.T) {
+	RunProcessFlow(nil, DefaultProcessFlowConfig())
+}
+
+func TestProcessFlow_DeterministicAcrossRuns(t *testing.T) {
+	doc1 := buildChainDoc("r", 5)
+	doc2 := buildChainDoc("r", 5)
+	RunProcessFlow(doc1, DefaultProcessFlowConfig())
+	RunProcessFlow(doc2, DefaultProcessFlowConfig())
+	if len(doc1.Entities) != len(doc2.Entities) {
+		t.Fatalf("non-deterministic entity count: %d vs %d", len(doc1.Entities), len(doc2.Entities))
+	}
+	for i := range doc1.Entities {
+		if doc1.Entities[i].ID != doc2.Entities[i].ID {
+			t.Errorf("entity[%d] id mismatch: %q vs %q", i, doc1.Entities[i].ID, doc2.Entities[i].ID)
+		}
+	}
+}

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -72,6 +72,7 @@ below; per-tool tables omit them unless the semantics differ.
 | [`archigraph_inspect`](#archigraph_inspect) | Look up an entity by id, qualified name, or label. |
 | [`archigraph_expand`](#archigraph_expand) | Return neighbors of a node out to a given depth. |
 | [`archigraph_trace`](#archigraph_trace) | Confidence-weighted shortest path between two nodes. |
+| [`archigraph_traces`](#archigraph_traces) | Process-flow traces (action: list\|get\|follow). |
 | [`archigraph_clusters`](#archigraph_clusters) | List Louvain communities across the loaded graphs. |
 | [`archigraph_stats`](#archigraph_stats) | Corpus-level metrics for the resolved group. |
 | [`archigraph_enrichments`](#archigraph_enrichments) | Manage enrichment candidates (action: list\|submit\|reject). |
@@ -288,6 +289,65 @@ use the link's recorded confidence (default `0.7` if unset). Returns
 
 The response also carries a `findings` array — every saved finding whose
 `nodes` list references any node along the resolved `path`. (Refs #59.)
+
+---
+
+### `archigraph_traces`
+
+Process-flow query surface (#724). Surfaces the `SCOPE.Process` entities
+emitted by the indexer's Pass 7 BFS over the CALLS graph from
+heuristically-detected entry points (route handlers, `main`, framework
+lifecycle hooks). Each Process is a linearized call chain with
+`STEP_IN_PROCESS` edges (step_index ordered) and an `ENTRY_POINT_OF`
+edge from the entry function.
+
+Three sub-actions selected via the required `action` argument:
+
+- `list` — return top-ranked Processes for the resolved group, sorted
+  cross-stack first then by step count. Optional `cross_stack_only=true`
+  filters to chains that traverse an HTTP boundary.
+- `get` — return the full step chain for one `process_id` (bare or
+  `repo::local` prefixed). Steps include node id, name, kind,
+  source_file, and start_line.
+- `follow` — ad-hoc forward BFS from any `entry_point_id`. Useful for
+  probing entities that weren't selected as pre-computed entry points.
+  Honours `max_depth` (≤10) and `branching_factor` (≤4) caps.
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `action` | string | yes | — | `list` \| `get` \| `follow` |
+| `process_id` | string | conditional | — | (`get`) Process entity id. |
+| `entry_point_id` | string | conditional | — | (`follow`) Entity id of the entry function. |
+| `max_depth` | number | no | `8` | (`follow`) BFS depth cap. Clamped to ≤10. |
+| `branching_factor` | number | no | `3` | (`follow`) Per-step branch cap. Clamped to ≤4. |
+| `cross_stack_only` | bool | no | `false` | (`list`) Only return cross-stack Processes. |
+| `limit` | number | no | `25` | (`list`) Max processes returned. |
+| `repo_filter` | string[] | no | `[]` | Common arg. |
+| `group`, `cwd` | string | no | — | Common args. |
+
+**Output** (action=list) — JSON object:
+
+```json
+{
+  "count": 2,
+  "processes": [
+    {
+      "process_id": "cf-d::proc:df0cd633e7f8f7f4",
+      "repo": "cf-d",
+      "label": "OrdersPublicController.processOrder → Correlative",
+      "entry_id": "b95e636c1955e82f",
+      "entry_name": "OrdersPublicController.processOrder",
+      "terminal_id": "d358909b92891554",
+      "step_count": 7,
+      "cross_stack": true,
+      "chain_labels": ["OrdersPublicController.processOrder", "OrdersService.processOrderByEcwidNumber", "..."],
+      "source_file": "src/main/java/.../OrdersPublicController.java"
+    }
+  ]
+}
+```
 
 ---
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -201,6 +201,24 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_trace", s.handleShortestPath))
 
+	// archigraph_traces — process-flow query surface (#724).
+	// action=list  → ranked Process entities loaded for the group
+	// action=get   → full step chain for one Process
+	// action=follow→ ad-hoc forward BFS from any entry_point_id
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_traces",
+		mcpapi.WithDescription("Process-flow traces. action=list: ranked Processes; action=get: full step chain; action=follow: ad-hoc BFS from an entry point."),
+		mcpapi.WithString("action", mcpapi.Required(), mcpapi.Description("list|get|follow")),
+		mcpapi.WithString("process_id", mcpapi.Description("(get) Process entity id; bare or repo-prefixed.")),
+		mcpapi.WithString("entry_point_id", mcpapi.Description("(follow) Entity id of the entry function.")),
+		mcpapi.WithNumber("max_depth", mcpapi.DefaultNumber(8), mcpapi.Description("(follow) BFS depth cap (≤10).")),
+		mcpapi.WithNumber("branching_factor", mcpapi.DefaultNumber(3), mcpapi.Description("(follow) Per-step branch cap (≤4).")),
+		mcpapi.WithBoolean("cross_stack_only", mcpapi.DefaultBool(false), mcpapi.Description("(list) Only return Processes that traverse an HTTP boundary.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(25), mcpapi.Description("(list) Max processes returned.")),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_traces", s.handleTraces))
+
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_clusters",
 		mcpapi.WithDescription("List Louvain communities across the loaded graphs."),
 		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -454,6 +454,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_get_source", "archigraph_get_telemetry",
 		// ADR-0018 β
 		"archigraph_patterns",
+		// #724 process-flow BFS query surface
+		"archigraph_traces",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -481,11 +483,12 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 16 (15 pre-β + 1 new archigraph_patterns).
+	// Total count must be exactly 17 (16 pre-#724 + archigraph_traces).
 	// Bundles: enrichments (3→1, saves 2), cross_links (2→1, saves 1),
-	// repairs (2→1, saves 1). Plus archigraph_patterns (ADR-0018 β).
-	if got := len(srv.MCP.ListTools()); got != 16 {
-		t.Errorf("expected 16 registered tools, got %d", got)
+	// repairs (2→1, saves 1). Plus archigraph_patterns (ADR-0018 β) and
+	// archigraph_traces (#724 process-flow BFS query surface).
+	if got := len(srv.MCP.ListTools()); got != 17 {
+		t.Errorf("expected 17 registered tools, got %d", got)
 	}
 }
 

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -1,0 +1,405 @@
+// archigraph_traces tool — process-flow query surface (#724).
+//
+// Sub-actions:
+//
+//	list   — return ranked Process entities loaded for the resolved group
+//	get    — return the full step chain for a specific process_id
+//	follow — ad-hoc forward BFS from an entry_point_id over the live CALLS
+//	         edges (does not require a pre-computed Process)
+//
+// The list/get paths consume the SCOPE.Process entities + STEP_IN_PROCESS
+// edges emitted by Pass 7 (engine.RunProcessFlow). The follow path runs
+// a depth-bounded BFS at query time so agents can probe entry points that
+// weren't pre-emitted (e.g. ones below the per-fixture ranking threshold).
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// processEntityKind is the entity kind written by engine.RunProcessFlow.
+// Duplicated here as a literal to avoid an internal/engine import.
+const (
+	processEntityKind = "SCOPE.Process"
+	stepInProcessEdge = "STEP_IN_PROCESS"
+	entryPointOfEdge  = "ENTRY_POINT_OF"
+)
+
+// handleTraces dispatches archigraph_traces to one of its sub-actions.
+func (s *Server) handleTraces(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	action, err := req.RequireString("action")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	switch strings.ToLower(action) {
+	case "list":
+		return s.handleTracesList(ctx, req)
+	case "get":
+		return s.handleTracesGet(ctx, req)
+	case "follow":
+		return s.handleTracesFollow(ctx, req)
+	default:
+		return mcpapi.NewToolResultError("action must be one of: list|get|follow"), nil
+	}
+}
+
+// handleTracesList returns the top-ranked Process entities in the group,
+// optionally filtered to cross_stack=true and capped to limit.
+func (s *Server) handleTracesList(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	limit := argInt(req, "limit", 25)
+	if limit <= 0 {
+		limit = 25
+	}
+	crossOnly := argBool(req, "cross_stack_only", false)
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type listItem struct {
+		ProcessID   string   `json:"process_id"`
+		Repo        string   `json:"repo"`
+		Label       string   `json:"label"`
+		EntryID     string   `json:"entry_id"`
+		EntryName   string   `json:"entry_name"`
+		TerminalID  string   `json:"terminal_id"`
+		StepCount   int      `json:"step_count"`
+		CrossStack  bool     `json:"cross_stack"`
+		ChainLabels []string `json:"chain_labels"`
+		SourceFile  string   `json:"source_file,omitempty"`
+	}
+
+	var items []listItem
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind {
+				continue
+			}
+			cs := e.Properties["cross_stack"] == "true"
+			if crossOnly && !cs {
+				continue
+			}
+			sc, _ := strconv.Atoi(e.Properties["step_count"])
+			items = append(items, listItem{
+				ProcessID:   prefixedID(r.Repo, e.ID),
+				Repo:        r.Repo,
+				Label:       e.Name,
+				EntryID:     e.Properties["entry_id"],
+				EntryName:   e.Properties["entry_name"],
+				TerminalID:  e.Properties["terminal_id"],
+				StepCount:   sc,
+				CrossStack:  cs,
+				ChainLabels: splitChainLabels(e.Properties["chain_labels"]),
+				SourceFile:  e.SourceFile,
+			})
+		}
+	}
+
+	// Sort: cross-stack first, then by step_count desc, then by label.
+	sort.Slice(items, func(i, j int) bool {
+		if items[i].CrossStack != items[j].CrossStack {
+			return items[i].CrossStack
+		}
+		if items[i].StepCount != items[j].StepCount {
+			return items[i].StepCount > items[j].StepCount
+		}
+		return items[i].Label < items[j].Label
+	})
+	if len(items) > limit {
+		items = items[:limit]
+	}
+	return jsonResult(map[string]any{
+		"processes": items,
+		"count":     len(items),
+	}), nil
+}
+
+// handleTracesGet returns the full step chain for one Process entity.
+func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	pid, err := req.RequireString("process_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	// process_id may be either prefixed ("repo::local") or bare local id.
+	repoHint, local := splitPrefixed(pid)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = pid
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind || e.ID != target {
+				continue
+			}
+			steps := buildProcessSteps(r.Doc, e)
+			return jsonResult(map[string]any{
+				"process_id":  prefixedID(r.Repo, e.ID),
+				"repo":        r.Repo,
+				"label":       e.Name,
+				"entry_id":    e.Properties["entry_id"],
+				"entry_name":  e.Properties["entry_name"],
+				"terminal_id": e.Properties["terminal_id"],
+				"cross_stack": e.Properties["cross_stack"] == "true",
+				"steps":       steps,
+				"found":       true,
+			}), nil
+		}
+	}
+	return jsonResult(map[string]any{"found": false, "process_id": pid}), nil
+}
+
+// handleTracesFollow runs an ad-hoc forward BFS over the loaded CALLS
+// graph from the given entry_point_id. Used when an agent wants a trace
+// from an entity that wasn't selected as an entry candidate.
+func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entry, err := req.RequireString("entry_point_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	maxDepth := argInt(req, "max_depth", 8)
+	if maxDepth <= 0 || maxDepth > 10 {
+		maxDepth = 8
+	}
+	branch := argInt(req, "branching_factor", 3)
+	if branch <= 0 || branch > 4 {
+		branch = 3
+	}
+
+	repoHint, local := splitPrefixed(entry)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+	// Find which repo owns the entity. We follow CALLS edges within that
+	// single repo — cross-repo overlay walks are tracked but not expanded
+	// (those belong to the cross-stack detection on Process entities).
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entry
+		}
+		var entryEnt *graph.Entity
+		for i := range r.Doc.Entities {
+			if r.Doc.Entities[i].ID == target {
+				entryEnt = &r.Doc.Entities[i]
+				break
+			}
+		}
+		if entryEnt == nil {
+			continue
+		}
+		chains := followCallsBFS(r.Doc, target, maxDepth, branch)
+		// Materialise the chains into step lists with labels.
+		out := make([]map[string]any, 0, len(chains))
+		byID := indexByID(r.Doc)
+		for _, c := range chains {
+			steps := make([]map[string]any, 0, len(c))
+			for i, id := range c {
+				step := map[string]any{
+					"step_index": i,
+					"node_id":    prefixedID(r.Repo, id),
+				}
+				if e, ok := byID[id]; ok {
+					step["name"] = e.Name
+					step["kind"] = e.Kind
+					step["source_file"] = e.SourceFile
+					if e.StartLine > 0 {
+						step["start_line"] = e.StartLine
+					}
+				}
+				steps = append(steps, step)
+			}
+			out = append(out, map[string]any{
+				"step_count":  len(c),
+				"terminal_id": prefixedID(r.Repo, c[len(c)-1]),
+				"steps":       steps,
+			})
+		}
+		return jsonResult(map[string]any{
+			"entry_point_id": prefixedID(r.Repo, entryEnt.ID),
+			"repo":           r.Repo,
+			"max_depth":      maxDepth,
+			"branching":      branch,
+			"chains":         out,
+			"count":          len(out),
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entry_point_id not found in any loaded repo"), nil
+}
+
+// buildProcessSteps reconstructs the ordered step list for one Process
+// from its STEP_IN_PROCESS edges, falling back to the `chain` property
+// when the edges are missing.
+func buildProcessSteps(doc *graph.Document, proc *graph.Entity) []map[string]any {
+	byID := indexByID(doc)
+	type indexed struct {
+		idx int
+		id  string
+	}
+	var ordered []indexed
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != stepInProcessEdge || r.FromID != proc.ID {
+			continue
+		}
+		idxStr := ""
+		if r.Properties != nil {
+			idxStr = r.Properties["step_index"]
+		}
+		n, _ := strconv.Atoi(idxStr)
+		ordered = append(ordered, indexed{n, r.ToID})
+	}
+	if len(ordered) == 0 {
+		// Fallback to the chain property if the edges weren't emitted.
+		ids := strings.Split(proc.Properties["chain"], ",")
+		for i, id := range ids {
+			if id != "" {
+				ordered = append(ordered, indexed{i, id})
+			}
+		}
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].idx < ordered[j].idx })
+	out := make([]map[string]any, 0, len(ordered))
+	for _, o := range ordered {
+		step := map[string]any{"step_index": o.idx, "node_id": o.id}
+		if e, ok := byID[o.id]; ok {
+			step["name"] = e.Name
+			step["kind"] = e.Kind
+			step["source_file"] = e.SourceFile
+			if e.StartLine > 0 {
+				step["start_line"] = e.StartLine
+			}
+		}
+		out = append(out, step)
+	}
+	return out
+}
+
+// followCallsBFS is the query-time equivalent of engine.bfsTraces — it
+// walks forward CALLS edges from entry, bounded by maxDepth and
+// branching, and returns each terminal chain.
+func followCallsBFS(doc *graph.Document, entry string, maxDepth, branch int) [][]string {
+	out := make(map[string][]string)
+	type fr struct {
+		chain []string
+		seen  map[string]bool
+	}
+	// Build single-repo CALLS adjacency on the fly. The MCP path doesn't
+	// import internal/engine so it can ship to consumers without taking
+	// the indexer's transitive deps.
+	adj := make(map[string][]string)
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "CALLS" {
+			continue
+		}
+		adj[r.FromID] = append(adj[r.FromID], r.ToID)
+	}
+	for k := range adj {
+		sort.Strings(adj[k])
+	}
+	work := []fr{{chain: []string{entry}, seen: map[string]bool{entry: true}}}
+	for len(work) > 0 {
+		f := work[len(work)-1]
+		work = work[:len(work)-1]
+		cur := f.chain[len(f.chain)-1]
+		ns := adj[cur]
+		if len(ns) == 0 || len(f.chain) > maxDepth {
+			term := f.chain[len(f.chain)-1]
+			if prev, ok := out[term]; !ok || len(prev) < len(f.chain) {
+				out[term] = append([]string(nil), f.chain...)
+			}
+			continue
+		}
+		capped := ns
+		if len(capped) > branch {
+			capped = capped[:branch]
+		}
+		extended := false
+		for _, n := range capped {
+			if f.seen[n] {
+				continue
+			}
+			extended = true
+			newSeen := make(map[string]bool, len(f.seen)+1)
+			for k := range f.seen {
+				newSeen[k] = true
+			}
+			newSeen[n] = true
+			work = append(work, fr{chain: append(append([]string(nil), f.chain...), n), seen: newSeen})
+		}
+		if !extended {
+			term := f.chain[len(f.chain)-1]
+			if prev, ok := out[term]; !ok || len(prev) < len(f.chain) {
+				out[term] = append([]string(nil), f.chain...)
+			}
+		}
+	}
+	chains := make([][]string, 0, len(out))
+	for _, c := range out {
+		chains = append(chains, c)
+	}
+	sort.Slice(chains, func(i, j int) bool {
+		if len(chains[i]) != len(chains[j]) {
+			return len(chains[i]) > len(chains[j])
+		}
+		return strings.Join(chains[i], ",") < strings.Join(chains[j], ",")
+	})
+	return chains
+}
+
+func indexByID(doc *graph.Document) map[string]*graph.Entity {
+	out := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		out[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	return out
+}
+
+func splitChainLabels(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, " → ")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		if t := strings.TrimSpace(p); t != "" {
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/mcp/traces_test.go
+++ b/internal/mcp/traces_test.go
@@ -1,0 +1,152 @@
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// processFixtureDoc builds a graph with two pre-computed Process entities
+// plus their STEP_IN_PROCESS / ENTRY_POINT_OF edges — mirroring what
+// engine.RunProcessFlow emits at index time.
+func processFixtureDoc(repo string) *graph.Document {
+	doc := &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Repo:        repo,
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "handleSubmit", Kind: "SCOPE.Function", SourceFile: "src/form.ts", StartLine: 10, EndLine: 30, Language: "ts"},
+			{ID: "f2", Name: "validateForm", Kind: "SCOPE.Function", SourceFile: "src/form.ts", StartLine: 40, EndLine: 55, Language: "ts"},
+			{ID: "f3", Name: "submitOrder", Kind: "SCOPE.Function", SourceFile: "src/api.ts", StartLine: 5, EndLine: 25, Language: "ts"},
+			{ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", SourceFile: "src/api.ts", StartLine: 30, EndLine: 60, Language: "ts"},
+			// Process entity 1: ordinary 3-step chain.
+			{ID: "p1", Name: "handleSubmit → validateForm", Kind: "SCOPE.Process", SourceFile: "src/form.ts", StartLine: 10, EndLine: 30, Language: "ts",
+				Properties: map[string]string{
+					"entry_id": "f1", "entry_name": "handleSubmit",
+					"terminal_id": "f2", "step_count": "3",
+					"cross_stack": "false",
+					"chain":        "f1,f3,f2",
+					"chain_labels": "handleSubmit → submitOrder → validateForm",
+				}},
+			// Process entity 2: cross-stack (traverses http_endpoint).
+			{ID: "p2", Name: "handleSubmit → http:POST:/api/orders", Kind: "SCOPE.Process", SourceFile: "src/form.ts", StartLine: 10, EndLine: 30, Language: "ts",
+				Properties: map[string]string{
+					"entry_id": "f1", "entry_name": "handleSubmit",
+					"terminal_id": "ep", "step_count": "3",
+					"cross_stack": "true",
+					"chain":        "f1,f3,ep",
+					"chain_labels": "handleSubmit → submitOrder → http:POST:/api/orders",
+				}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "c1", FromID: "f1", ToID: "f3", Kind: "CALLS"},
+			{ID: "c2", FromID: "f3", ToID: "f2", Kind: "CALLS"},
+			{ID: "c3", FromID: "f3", ToID: "ep", Kind: "CALLS"},
+			// STEP_IN_PROCESS for p1.
+			{ID: "s1", FromID: "p1", ToID: "f1", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "0"}},
+			{ID: "s2", FromID: "p1", ToID: "f3", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
+			{ID: "s3", FromID: "p1", ToID: "f2", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "2"}},
+			// STEP_IN_PROCESS for p2.
+			{ID: "s4", FromID: "p2", ToID: "f1", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "0"}},
+			{ID: "s5", FromID: "p2", ToID: "f3", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
+			{ID: "s6", FromID: "p2", ToID: "ep", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "2"}},
+			// ENTRY_POINT_OF for both.
+			{ID: "e1", FromID: "f1", ToID: "p1", Kind: "ENTRY_POINT_OF"},
+			{ID: "e2", FromID: "f1", ToID: "p2", Kind: "ENTRY_POINT_OF"},
+		},
+	}
+	return doc
+}
+
+func setupTracesServer(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, processFixtureDoc("r1"))
+	reg := Registry{Groups: map[string]RegistryGroup{
+		"g": {Repos: map[string]RegistryRepo{"r1": {Path: repo}}},
+	}}
+	regPath := filepath.Join(dir, "registry.json")
+	d, _ := json.MarshalIndent(reg, "", "  ")
+	_ = os.WriteFile(regPath, d, 0o644)
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+func TestTraces_ListReturnsAllProcesses(t *testing.T) {
+	srv := setupTracesServer(t)
+	res := callTool(t, srv, "archigraph_traces", map[string]any{"action": "list"})
+	txt := resultText(res)
+	if !strings.Contains(txt, "\"count\": 2") {
+		t.Errorf("expected count=2, got: %s", txt)
+	}
+	if !strings.Contains(txt, "handleSubmit") {
+		t.Errorf("expected handleSubmit in list, got: %s", txt)
+	}
+}
+
+func TestTraces_ListCrossStackOnly(t *testing.T) {
+	srv := setupTracesServer(t)
+	res := callTool(t, srv, "archigraph_traces", map[string]any{
+		"action":           "list",
+		"cross_stack_only": true,
+	})
+	txt := resultText(res)
+	if !strings.Contains(txt, "\"count\": 1") {
+		t.Errorf("expected count=1 cross-stack process, got: %s", txt)
+	}
+	if !strings.Contains(txt, "/api/orders") {
+		t.Errorf("expected http endpoint in cross-stack process, got: %s", txt)
+	}
+}
+
+func TestTraces_GetReturnsFullChain(t *testing.T) {
+	srv := setupTracesServer(t)
+	res := callTool(t, srv, "archigraph_traces", map[string]any{
+		"action":     "get",
+		"process_id": "p1",
+	})
+	txt := resultText(res)
+	if !strings.Contains(txt, "\"found\": true") {
+		t.Errorf("expected found=true, got: %s", txt)
+	}
+	if !strings.Contains(txt, "validateForm") || !strings.Contains(txt, "submitOrder") {
+		t.Errorf("expected both steps in chain, got: %s", txt)
+	}
+}
+
+func TestTraces_FollowAdHocBFS(t *testing.T) {
+	srv := setupTracesServer(t)
+	res := callTool(t, srv, "archigraph_traces", map[string]any{
+		"action":         "follow",
+		"entry_point_id": "f1",
+		"max_depth":      5,
+	})
+	txt := resultText(res)
+	if !strings.Contains(txt, "handleSubmit") {
+		t.Errorf("expected handleSubmit in follow result, got: %s", txt)
+	}
+	// Should reach both terminals (f2 and ep) from f1.
+	if !strings.Contains(txt, "validateForm") {
+		t.Errorf("expected validateForm in follow result")
+	}
+}
+
+func TestTraces_InvalidActionReturnsError(t *testing.T) {
+	srv := setupTracesServer(t)
+	res := callTool(t, srv, "archigraph_traces", map[string]any{"action": "bogus"})
+	if res == nil || !res.IsError {
+		t.Errorf("expected tool error for bogus action")
+	}
+}


### PR DESCRIPTION
## Summary
Ports the language-agnostic process-flow BFS from competitor-tool analysis. Forward BFS over CALLS graph from heuristically-detected entry points; emits Process entities + STEP_IN_PROCESS edges.

Enables narrative documentation: "When user submits an order: handleSubmit → validateForm → submitOrder → POST /api/orders → OrderController.create → ..."

## Details
- New entity kind: \`Process\`
- New edge kinds: \`STEP_IN_PROCESS\`, \`ENTRY_POINT_OF\`
- BFS with depth ≤10, branching ≤4, dedup per (entry, terminal) pair
- Marks cross_stack Processes when traversing FETCHES edges
- New \`archigraph_traces\` MCP action (list / get / follow)

## Related
- #724
- ADR-0018 (patterns) — pattern docs can reference traces
- Phase 6 doc-gen (PR #731) — traces feed narrative sections

## Validation
TBD — needs measurement on fixture-d/e with proper isolation (per the standing rule established 2026-05-20). The agent that produced this committed the code but was killed before running validation due to fixture state collision risk with other in-flight agents.