### PR TITLE
[#747] Fix cross-repo HTTP matcher verb confusion (-9 bogus links, honest recall)

### DIFF
--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -337,27 +337,31 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 		if len(producers) == 0 || len(consumers) == 0 {
 			continue
 		}
-		// Emit one link per (consumer-repo, producer-repo) cross-repo
-		// pair. Within a repo-pair we pick the first hit on each side
-		// (sorted by file then stampedID for determinism).
+		// Deterministic ordering for tie-breaking inside each verb tier.
 		sort.SliceStable(producers, func(i, j int) bool { return less(producers[i], producers[j]) })
 		sort.SliceStable(consumers, func(i, j int) bool { return less(consumers[i], consumers[j]) })
 
-		// Group by repo (first hit per repo, per side).
-		firstByRepo := func(hh []*httpEndpointHit) map[string]*httpEndpointHit {
-			out := map[string]*httpEndpointHit{}
-			for _, h := range hh {
-				if _, ok := out[h.repo]; !ok {
-					out[h.repo] = h
-				}
-			}
-			return out
+		// Group producers by repo so we can run the verb-aware picker
+		// independently for every (consumer-repo, producer-repo) pair.
+		producersByRepo := map[string][]*httpEndpointHit{}
+		for _, p := range producers {
+			producersByRepo[p.repo] = append(producersByRepo[p.repo], p)
 		}
-		producerRepos := firstByRepo(producers)
-		consumerRepos := firstByRepo(consumers)
+		// Group consumers by repo (first hit per repo — the deterministic
+		// ordering above means we keep the smallest stampedID per repo).
+		consumerRepos := map[string]*httpEndpointHit{}
+		for _, h := range consumers {
+			if _, ok := consumerRepos[h.repo]; !ok {
+				consumerRepos[h.repo] = h
+			}
+		}
 
 		consumerRepoNames := sortedKeys(consumerRepos)
-		producerRepoNames := sortedKeys(producerRepos)
+		producerRepoNames := make([]string, 0, len(producersByRepo))
+		for r := range producersByRepo {
+			producerRepoNames = append(producerRepoNames, r)
+		}
+		sort.Strings(producerRepoNames)
 
 		for _, cRepo := range consumerRepoNames {
 			for _, pRepo := range producerRepoNames {
@@ -365,7 +369,21 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					continue // never emit a self-pair as a cross-repo edge
 				}
 				c := consumerRepos[cRepo]
-				p := producerRepos[pRepo]
+				// Verb-aware producer selection (#747):
+				//   Tier 1 — producer with the SAME specific verb as the
+				//            consumer (exact_verb).
+				//   Tier 2 — producer with verb=ANY (any_fallback).
+				//   Tier 3 — none. We skip rather than fall through to a
+				//            different specific verb: DELETE/{id} must
+				//            never link to PATCH/{id} just because both
+				//            paths normalize the same.
+				// Producers within each tier are already sorted by
+				// less() above, so picking the first match is
+				// deterministic.
+				p, quality := pickProducerForConsumer(c, producersByRepo[pRepo])
+				if p == nil {
+					continue
+				}
 
 				// Source / target: consumer's caller → producer's handler.
 				// If either side hasn't resolved to a real entity, fall
@@ -403,6 +421,7 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						{c.sourceFile},
 						{p.sourceFile},
 					},
+					MatchQuality: quality,
 				}
 				fresh = append(fresh, link)
 			}
@@ -513,6 +532,62 @@ func canonicalIdentifier(c, p *httpEndpointHit) string {
 		path = p.canonicalPath
 	}
 	return "http:" + verb + ":" + path
+}
+
+// Match-quality labels written to Link.MatchQuality.
+const (
+	matchQualityExactVerb   = "exact_verb"
+	matchQualityAnyFallback = "any_fallback"
+	matchQualityWildcard    = "wildcard"
+)
+
+// pickProducerForConsumer selects the best producer for a consumer hit
+// from a single producer-repo's candidate pool. See #747.
+//
+// Selection tiers (first non-empty wins):
+//  1. Producer with EXACT same specific verb as consumer (exact_verb).
+//  2. Producer with verb=ANY (any_fallback) — Django ViewSets without
+//     per-method routing legitimately emit ANY-verb endpoints; the
+//     pre-fix matcher was right to consider them, just not to pick a
+//     mismatched specific verb in preference.
+//  3. If consumer itself is ANY, fall back to first producer (wildcard).
+//  4. Otherwise: no match. We deliberately do NOT cross-link to a
+//     different specific verb — that is the verb-confusion bug.
+//
+// `candidates` MUST already be sorted by `less()` so tier-internal tie
+// breaking is deterministic.
+func pickProducerForConsumer(c *httpEndpointHit, candidates []*httpEndpointHit) (*httpEndpointHit, string) {
+	if len(candidates) == 0 {
+		return nil, ""
+	}
+	cVerb := strings.ToUpper(c.verb)
+	// Tier 1: exact specific-verb match.
+	if cVerb != "" && cVerb != "ANY" {
+		for _, p := range candidates {
+			if strings.ToUpper(p.verb) == cVerb {
+				return p, matchQualityExactVerb
+			}
+		}
+		// Tier 2: ANY-verb fallback.
+		for _, p := range candidates {
+			if strings.ToUpper(p.verb) == "ANY" {
+				return p, matchQualityAnyFallback
+			}
+		}
+		// Tier 3: no match. Drop rather than pick a different specific
+		// verb — that is exactly the bug #747 fixes.
+		return nil, ""
+	}
+	// Consumer verb is ANY (or empty). Prefer an ANY-verb producer
+	// when one exists (wildcard-on-wildcard); otherwise take the
+	// first specific-verb producer (consumer is unspecified, so
+	// any specific verb is a defensible match).
+	for _, p := range candidates {
+		if strings.ToUpper(p.verb) == "ANY" {
+			return p, matchQualityWildcard
+		}
+	}
+	return candidates[0], matchQualityWildcard
 }
 
 // splitKindNameRef parses "<Kind>:<Name>" into (kind, name). The Kind

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"path/filepath"
+	"sort"
 	"testing"
 )
 
@@ -765,5 +766,278 @@ func TestHTTPPass_ParseHTTPName(t *testing.T) {
 		if ok != c.ok || v != c.verb || p != c.path {
 			t.Errorf("parseHTTPName(%q) = (%q,%q,%v), want (%q,%q,%v)", c.in, v, p, ok, c.verb, c.path, c.ok)
 		}
+	}
+}
+
+// --- #747 verb-confusion regression tests ----------------------------
+//
+// These exercise the multi-verb producer pool created when DRF detail
+// routes (PR #729) coexist with the legacy ANY-verb synthesizer output.
+// Before the #747 fix, `firstByRepo` sorted by stampedID lexicographically
+// and could pick (e.g.) PATCH as the "winner" for a DELETE consumer just
+// because the PATCH endpoint's stamped ID sorted first.
+
+// TestHTTPPass_VerbConfusion_ExactVerbPreference verifies that when
+// producers cover multiple specific verbs on the same path, the matcher
+// picks the producer whose verb EXACTLY matches the consumer's verb.
+// Lexicographic order of stampedIDs must NOT win over verb match.
+func TestHTTPPass_VerbConfusion_ExactVerbPreference(t *testing.T) {
+	root := fixtureRoot(t)
+	// Producer emits the full DRF CRUD family plus a legacy ANY-verb
+	// synthetic. IDs are crafted so that PATCH and DELETE sort BEFORE
+	// the consumer's verb (GET) when ordered lexicographically — this
+	// is the exact stampedID-ordering regime that produced the bug in
+	// production data.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h-delete", "name": "destroy", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-patch", "name": "partial_update", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-get", "name": "retrieve", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-any", "name": "InspectionViewSet", "kind": "Class", "source_file": "app/views.py"},
+			{
+				"id": "ep-delete", "name": "http:DELETE:/inspections/{pk}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "DELETE", "path": "/inspections/{pk}", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-patch", "name": "http:PATCH:/inspections/{pk}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "PATCH", "path": "/inspections/{pk}", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-get", "name": "http:GET:/inspections/{pk}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "GET", "path": "/inspections/{pk}", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-any", "name": "http:ANY:/inspections/{pk}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "ANY", "path": "/inspections/{pk}", "pattern_type": "http_endpoint_synthesis"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h-delete", "to_id": "ep-delete", "kind": "IMPLEMENTS"},
+			{"from_id": "h-patch", "to_id": "ep-patch", "kind": "IMPLEMENTS"},
+			{"from_id": "h-get", "to_id": "ep-get", "kind": "IMPLEMENTS"},
+			{"from_id": "h-any", "to_id": "ep-any", "kind": "IMPLEMENTS"},
+		},
+	})
+	// Consumer is DELETE. Pre-fix matcher would link to PATCH (because
+	// "ep-patch" < "ep-delete" lexicographically inside the producer
+	// pool entered via the ANY-verb pivot). Post-fix it MUST land on
+	// the DELETE handler.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn-delete", "name": "deleteInspection", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep-c-delete", "name": "http:DELETE:/inspections/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "DELETE",
+					"path":          "/inspections/{id}",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:deleteInspection",
+				},
+			},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g747-exact", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g747-exact-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var httpLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			httpLinks = append(httpLinks, l)
+		}
+	}
+	if len(httpLinks) != 1 {
+		t.Fatalf("want exactly one http link (DELETE→DELETE), got %d: %+v", len(httpLinks), httpLinks)
+	}
+	l := httpLinks[0]
+	if l.Target != "backend::h-delete" {
+		t.Errorf("verb-confusion regression: DELETE consumer must link to DELETE handler, got target=%s", l.Target)
+	}
+	if l.Identifier == nil || *l.Identifier != "http:DELETE:/inspections/{id}" {
+		t.Errorf("identifier: want http:DELETE:/inspections/{id}, got %v", l.Identifier)
+	}
+	if l.MatchQuality != "exact_verb" {
+		t.Errorf("match_quality: want exact_verb, got %q", l.MatchQuality)
+	}
+}
+
+// TestHTTPPass_VerbConfusion_AnyFallback verifies that when no producer
+// matches the consumer's specific verb but an ANY-verb producer exists,
+// the matcher falls back to ANY (and tags the link with match_quality
+// = "any_fallback").
+func TestHTTPPass_VerbConfusion_AnyFallback(t *testing.T) {
+	root := fixtureRoot(t)
+	// Backend has PATCH + DELETE + ANY producers but NO GET. The
+	// consumer asks for GET — we must take the ANY producer, never
+	// the PATCH or DELETE.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h-patch", "name": "partial_update", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-delete", "name": "destroy", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-any", "name": "RoleViewSet", "kind": "Class", "source_file": "app/views.py"},
+			{
+				"id": "ep-patch", "name": "http:PATCH:/roles/{roleId}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "PATCH", "path": "/roles/{roleId}", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-delete", "name": "http:DELETE:/roles/{roleId}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "DELETE", "path": "/roles/{roleId}", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-any", "name": "http:ANY:/roles/{roleId}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "ANY", "path": "/roles/{roleId}", "pattern_type": "http_endpoint_synthesis"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h-patch", "to_id": "ep-patch", "kind": "IMPLEMENTS"},
+			{"from_id": "h-delete", "to_id": "ep-delete", "kind": "IMPLEMENTS"},
+			{"from_id": "h-any", "to_id": "ep-any", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn-get", "name": "loadRole", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep-c-get", "name": "http:GET:/roles/{roleId}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/roles/{roleId}",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadRole",
+				},
+			},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g747-any", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g747-any-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var httpLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			httpLinks = append(httpLinks, l)
+		}
+	}
+	if len(httpLinks) != 1 {
+		t.Fatalf("want exactly one http link (GET→ANY), got %d: %+v", len(httpLinks), httpLinks)
+	}
+	if httpLinks[0].Target != "backend::h-any" {
+		t.Errorf("any-fallback regression: GET consumer must fall back to ANY handler, got target=%s", httpLinks[0].Target)
+	}
+	if httpLinks[0].MatchQuality != "any_fallback" {
+		t.Errorf("match_quality: want any_fallback, got %q", httpLinks[0].MatchQuality)
+	}
+}
+
+// TestHTTPPass_VerbConfusion_NoMatchWhenOnlyWrongVerbs verifies that a
+// consumer whose verb has no exact-verb producer AND no ANY-verb
+// producer is DROPPED — we never cross-link to a different specific
+// verb. This is the linchpin of #747.
+func TestHTTPPass_VerbConfusion_NoMatchWhenOnlyWrongVerbs(t *testing.T) {
+	root := fixtureRoot(t)
+	// Backend only emits GET and DELETE — consumer wants POST.
+	// Pre-fix matcher would have happily linked to GET (smallest
+	// stampedID after path-normalization). Post-fix we MUST emit no
+	// link.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h-get", "name": "list", "kind": "Function", "source_file": "app/views.py"},
+			{"id": "h-delete", "name": "destroy", "kind": "Function", "source_file": "app/views.py"},
+			{
+				"id": "ep-get", "name": "http:GET:/widgets", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "GET", "path": "/widgets", "pattern_type": "http_endpoint_synthesis"},
+			},
+			{
+				"id": "ep-delete", "name": "http:DELETE:/widgets", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{"verb": "DELETE", "path": "/widgets", "pattern_type": "http_endpoint_synthesis"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h-get", "to_id": "ep-get", "kind": "IMPLEMENTS"},
+			{"from_id": "h-delete", "to_id": "ep-delete", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn-post", "name": "createWidget", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep-c-post", "name": "http:POST:/widgets", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "POST",
+					"path":          "/widgets",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:createWidget",
+				},
+			},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g747-nomatch", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g747-nomatch-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			t.Errorf("unexpected http link emitted (POST should not link to GET or DELETE): %+v", l)
+		}
+	}
+}
+
+// TestHTTPPass_VerbConfusion_Determinism verifies that repeated runs
+// over the same producer set yield the same picked producer (no
+// dependency on map iteration order leaking into link target).
+func TestHTTPPass_VerbConfusion_Determinism(t *testing.T) {
+	candidates := []*httpEndpointHit{
+		{repo: "backend", stampedID: "z-last", verb: "GET"},
+		{repo: "backend", stampedID: "a-first", verb: "GET"},
+		{repo: "backend", stampedID: "m-mid", verb: "PATCH"},
+	}
+	// less() puts a-first before z-last for the same repo.
+	sort.SliceStable(candidates, func(i, j int) bool { return less(candidates[i], candidates[j]) })
+	consumer := &httpEndpointHit{repo: "frontend", verb: "GET"}
+	var first *httpEndpointHit
+	for i := 0; i < 50; i++ {
+		p, q := pickProducerForConsumer(consumer, candidates)
+		if q != "exact_verb" {
+			t.Fatalf("iter %d: want exact_verb, got %q", i, q)
+		}
+		if first == nil {
+			first = p
+		}
+		if p != first {
+			t.Fatalf("non-deterministic pick on iter %d: %+v vs %+v", i, p, first)
+		}
+	}
+	if first.stampedID != "a-first" {
+		t.Errorf("want smallest-stampedID GET producer (a-first), got %s", first.stampedID)
 	}
 }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -69,6 +69,17 @@ type Link struct {
 	DiscoveredAt    string     `json:"discovered_at"`
 	SourceLocations [][]string `json:"source_locations,omitempty"`
 
+	// MatchQuality, when set, annotates how a method-specific matcher
+	// (currently only the HTTP pass) selected this producer:
+	//   "exact_verb"   — consumer's HTTP verb matched the producer's
+	//   "any_fallback" — consumer had a specific verb, no specific-verb
+	//                    producer existed; matched against an ANY-verb
+	//                    producer (Django ViewSet without per-method
+	//                    routing, etc.)
+	//   "wildcard"     — both sides used ANY (no specific verb on either)
+	// Empty for any non-HTTP method.
+	MatchQuality string `json:"match_quality,omitempty"`
+
 	// Reason is populated only on candidate entries (not in links.json).
 	Reason string `json:"reason,omitempty"`
 


### PR DESCRIPTION
## Summary

The cross-repo HTTP matcher in `internal/links/http_pass.go` was picking producers by lexicographic stampedID inside each repo, ignoring HTTP verb. With DRF detail-route emission (#729) putting `DELETE/PATCH/GET/ANY` producers on the same path, a DELETE consumer could be linked to the PATCH handler simply because `ep-patch` < `ep-delete`.

Replaced `firstByRepo` with a verb-aware picker (`pickProducerForConsumer`) that selects in tiers:
1. **`exact_verb`** — producer with same specific verb as consumer
2. **`any_fallback`** — producer with `verb=ANY` (legitimate Django ViewSet pattern)
3. **drop** — never cross-link to a *different* specific verb

Producers within each tier are sorted by `less()` for deterministic tie-breaking. Added a new `MatchQuality` field to `Link` so downstream tooling can surface non-exact matches in the repairs queue (beyond-the-minimum addition).

## Measured impact (private client fixtures, isolated daemon at `/tmp/arch-747`)

| Metric | Baseline (main) | With fix |
|---|---:|---:|
| Total http links | 131 | 122 |
| b → a links | 91 | 85 |
| c → a links | 40 | 37 |
| **Verb-confused (bogus)** | **9** | **0** |
| exact_verb | n/a | 110 |
| any_fallback | n/a | 12 |

The 9-link drop is exactly the bogus matches the issue enumerates. Pre-fix samples observed in production data:

- `PUT /contracts/{id}` → PATCH handler
- `GET /jurisdictions/{id}` → PUT handler
- `DELETE /alternate-addresses/{id}` → PATCH handler
- `GET /contracts` → POST handler
- `POST /roles` → GET handler
- `PATCH /user-profile/{id}` → DELETE handler
- `GET /checklist-catalogs/{id}` → DELETE handler
- `DELETE /inspections/{id}` → PATCH handler
- `GET /buildings/{id}` → PATCH handler

## Honest revised cross-repo recall

The 87.5% b→a and "100%" c→a numbers reported recently were inflated by the bogus matches. Post-fix the numbers drop — this is expected and correct:

- **b → a: 91 → 85 unique correct matches**
- **c → a: 40 → 37 unique correct matches**

## Tests added (`internal/links/http_pass_test.go`)

- `TestHTTPPass_VerbConfusion_ExactVerbPreference` — DELETE consumer vs `[GET, PATCH, DELETE, ANY]` producer pool MUST land on DELETE handler (the regression).
- `TestHTTPPass_VerbConfusion_AnyFallback` — GET consumer vs `[PATCH, DELETE, ANY]` MUST fall back to ANY, never PATCH/DELETE.
- `TestHTTPPass_VerbConfusion_NoMatchWhenOnlyWrongVerbs` — POST consumer vs `[GET, DELETE]` MUST emit no link.
- `TestHTTPPass_VerbConfusion_Determinism` — same producer set produces the same pick across 50 iterations.

## Test plan

- [x] `go test ./...` — all packages green
- [x] `go vet ./...` — clean
- [x] Quality fixtures preserved (existing `TestHTTPPass_*` continue to pass — ANY-verb wildcard, pk-vs-param matching, etc.)
- [x] Cross-language: Python (DRF), JS (fetch), RN consumers all measured in the same run
- [x] Measured baseline (current main, commit `bbf0ab0`) and fix side-by-side using two binaries: `/tmp/arch-747/baseline-bin` vs `/tmp/arch-747/pr-bin`

## Daemon + race avoidance

Isolation followed the standing rule (multi-dimensional):
- Daemon socket: `/tmp/arch-747/sockets/daemon.sock` via `ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-747`
- Per-repo state: fixtures `rsync`'d into `/tmp/arch-747/fixtures/` — never touched `~/private/archigraph-fixtures/`
- Group config: `XDG_CONFIG_HOME=/tmp/arch-747/xdg` → `/tmp/arch-747/xdg/archigraph/fx.fleet.json`
- Daemon registry: `ARCHIGRAPH_HOME=/tmp/arch-747/home` → `/tmp/arch-747/home/registry.json`
- Output snapshots: `/tmp/arch-747/output/{baseline,pr}-fx-links.json`

PIDs killed during cleanup: **74340** (PR daemon), **69259** (baseline daemon prior). `rm -rf /tmp/arch-747` verified empty. `ps aux | grep arch-747` returns nothing.

Closes #747.

🤖 Generated with [Claude Code](https://claude.com/claude-code)