### PR TITLE
[#745][daemon] Per-repo state isolation under ARCHIGRAPH_DAEMON_ROOT

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ and PR wiring it into `internal/mcp/server.go`), not from this file.
 - Verify no PIDs survive with `ps aux | grep archigraph`
 - Never `git stash` (concurrent worktree race; commit-checkpoint instead)
 - See `docs/adrs/0004-single-mcp-process-per-machine.md` for the daemon architecture
+- `ARCHIGRAPH_DAEMON_ROOT` isolates THREE things: the daemon socket, the registry, AND per-repo state (issue #745). When the env var is set, per-repo state lives at `$ARCHIGRAPH_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/` instead of `<repo>/.archigraph/`. This means two parallel agents can index the SAME fixture without racing, and the fixture's own `.archigraph/` is never touched. When the env var is unset, ADR-0007 co-located behavior is preserved. Helper: `internal/daemon.StateDirForRepo` / `GraphPathForRepo` — use it for every per-repo state read/write; never hardcode `<repo>/.archigraph/<file>`.
 
 ## Where things live
 - MCP server: `internal/mcp/`

--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -221,7 +221,7 @@ func daemonIndexFunc(args proto.IndexArgs) (string, string, error) {
 	}
 	graphPath := args.OutPath
 	if graphPath == "" {
-		graphPath = filepath.Join(args.RepoPath, ".archigraph", "graph.json")
+		graphPath = daemon.GraphPathForRepo(args.RepoPath)
 	}
 	return graphPath, statsBuf.String(), nil
 }
@@ -254,7 +254,7 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 			continue
 		}
 		if args.Wipe {
-			_ = os.RemoveAll(filepath.Join(r.Path, ".archigraph"))
+			_ = os.RemoveAll(daemon.StateDirForRepo(r.Path))
 		}
 		if err := Index(r.Path, "", "", nil, false, false); err != nil {
 			return rebuilt, "", fmt.Errorf("index %s: %w", r.Slug, err)

--- a/cmd/archigraph/daemon_mcp_cache.go
+++ b/cmd/archigraph/daemon_mcp_cache.go
@@ -3,6 +3,7 @@ package main
 import (
 	"path/filepath"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	daemonmcp "github.com/cajasmota/archigraph/internal/daemon/mcp"
 )
 
@@ -18,7 +19,7 @@ var daemonMCPCache = daemonmcp.NewCache(daemonmcp.DefaultCapacity)
 // repoGraphFBPath is the canonical on-disk location of a repo's
 // FlatBuffers graph, matching the path used in Index().
 func repoGraphFBPath(repoPath string) string {
-	return filepath.Join(repoPath, ".archigraph", "graph.fb")
+	return filepath.Join(daemon.StateDirForRepo(repoPath), "graph.fb")
 }
 
 // invalidateAfterIndex is the post-index hook: it drops any cached

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -18,6 +18,7 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/classifier"
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/extract"
 	"github.com/cajasmota/archigraph/internal/engine"
 	"github.com/cajasmota/archigraph/internal/enrichment"
@@ -183,7 +184,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 		repoTag = filepath.Base(absRepo)
 	}
 	if outPath == "" {
-		outPath = filepath.Join(absRepo, ".archigraph", "graph.json")
+		outPath = daemon.GraphPathForRepo(absRepo)
 	}
 
 	skipSet, err := parseSkipPasses(skipPasses)
@@ -533,7 +534,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Default-off (--enable-repair-apply false) so existing bug-rate
 	// measurements across the 10-corpus regression set stay unchanged.
 	if i.enableRepairApply {
-		archigraphDir := filepath.Join(absRepo, ".archigraph")
+		archigraphDir := daemon.StateDirForRepo(absRepo)
 		repairs, rerr := enrichment.ReadRepairs(archigraphDir)
 		if rerr != nil {
 			fmt.Fprintf(os.Stderr,
@@ -1113,7 +1114,7 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 	if doc == nil {
 		return
 	}
-	archigraphDir := filepath.Join(absRepo, ".archigraph")
+	archigraphDir := daemon.StateDirForRepo(absRepo)
 
 	// 1) Merge resolutions back onto entities BEFORE emitting. This both
 	//    persists agent values across rebuilds and short-circuits emitters

--- a/docs/adrs/0017-single-binary-daemon-architecture.md
+++ b/docs/adrs/0017-single-binary-daemon-architecture.md
@@ -149,3 +149,24 @@ If a target is missed, the PR that lands the relevant phase must document why an
 **Migration**
 
 Users on any prior binary reinstall via `archigraph install`. There is no compat shim; the standalone subcommands listed above return helpful errors pointing at the new install path.
+
+## Amendment (2026-05-20) — Per-repo state isolation under `ARCHIGRAPH_DAEMON_ROOT` (issue #745)
+
+When parallel coding agents each run an isolated daemon (different `ARCHIGRAPH_DAEMON_ROOT`s) against a shared fixture corpus, the socket and registry are isolated but the per-repo state directory — `<repo>/.archigraph/` per ADR-0007 — is shared. Two daemons indexing the same fixture race on `graph.json` and corrupt each other's outputs.
+
+This amendment narrows the daemon's reach into the repo working tree:
+
+- **Default behavior (no env var set) is unchanged.** Per-repo state continues to live in `<repo>/.archigraph/` per ADR-0007. Single-user installs are not affected.
+- **When `ARCHIGRAPH_DAEMON_ROOT` is set,** the daemon writes ALL per-repo state under
+
+  ```
+  $ARCHIGRAPH_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/
+  ```
+
+  instead of into the repo working tree. The hash segment is deterministic (same repo → same segment across processes and hosts), filesystem-safe, and collision-resistant.
+- **The repo's own `.archigraph/` is never created or modified by the daemon under this mode.** Pristine read-only fixture corpora stay pristine, no matter how many parallel agents index them.
+- **Group-level metadata that lives co-located by design** (`<repo>/.archigraph/group.json`, written by the wizard for repo-to-group discovery via CWD walk) is NOT routed through the helper. That file is a configuration marker, not state, and must be discoverable regardless of which daemon is running.
+
+The helper is `internal/daemon.StateDirForRepo(repoPath)` (and the convenience wrapper `GraphPathForRepo`). All indexer write paths, reader paths (audit, dashboard, MCP, doctor, status, watch, links), and enrichment/repair persistence go through it. The variable name `ARCHIGRAPH_DAEMON_ROOT` becomes the single switch for the full three-dimensional isolation (socket + registry + per-repo state).
+
+This is a deliberate, env-gated exception to ADR-0007. ADR-0007's co-located default remains the right model for the single-user installation it was written for; the daemon-root override exists solely for the parallel-agent development workflow.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/install/mcpreg"
 	"github.com/cajasmota/archigraph/internal/registry"
 	"github.com/cajasmota/archigraph/internal/version"
@@ -91,7 +92,7 @@ func checkRepo(w io.Writer, r registry.Repo) {
 	} else {
 		fmt.Fprintf(w, "  %s repo %s (%s)\n", statusOK, r.Slug, r.Stack)
 	}
-	graph := filepath.Join(r.Path, ".archigraph", "graph.json")
+	graph := daemon.GraphPathForRepo(r.Path)
 	if _, err := os.Stat(graph); err == nil {
 		fmt.Fprintf(w, "         graph.json present\n")
 	}

--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/links"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -132,7 +133,7 @@ func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
 	}
 	cleanup := func() { _ = os.RemoveAll(tmp) }
 	for _, r := range cfg.Repos {
-		src := filepath.Join(r.Path, ".archigraph", "graph.json")
+		src := daemon.GraphPathForRepo(r.Path)
 		if _, err := os.Stat(src); err != nil {
 			continue
 		}

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -5,11 +5,11 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/spf13/cobra"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -130,7 +130,7 @@ func runStatus(w io.Writer, filter string) error {
 		}
 		for _, r := range cfg.Repos {
 			line := fmt.Sprintf("  %-20s  %s", r.Slug, r.Path)
-			graph := filepath.Join(r.Path, ".archigraph", "graph.json")
+			graph := daemon.GraphPathForRepo(r.Path)
 			if fi, err := os.Stat(graph); err == nil {
 				age := time.Since(fi.ModTime()).Truncate(time.Second)
 				line += fmt.Sprintf("  graph.json: %s ago", age)

--- a/internal/cli/watch.go
+++ b/internal/cli/watch.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/registry"
@@ -170,7 +171,7 @@ func snapshotGraphMtimes(repo, explicitGroup string) map[string]time.Time {
 	out := map[string]time.Time{}
 	for _, g := range groupsForRepo(repo, explicitGroup) {
 		for _, p := range repoPathsForGroup(g) {
-			gj := filepath.Join(p, ".archigraph", "graph.json")
+			gj := daemon.GraphPathForRepo(p)
 			if fi, err := os.Stat(gj); err == nil {
 				out[gj] = fi.ModTime()
 			} else {
@@ -192,7 +193,7 @@ func detectGraphChanges(repo, explicitGroup string, prev map[string]time.Time) [
 	graphToGroups := map[string][]string{}
 	for _, g := range groups {
 		for _, p := range repoPathsForGroup(g) {
-			gj := filepath.Join(p, ".archigraph", "graph.json")
+			gj := daemon.GraphPathForRepo(p)
 			graphToGroups[gj] = append(graphToGroups[gj], g)
 		}
 	}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -1,0 +1,80 @@
+// Per-repo state path resolution for issue #745.
+//
+// Background: ADR-0007 co-locates per-repo state in `<repo>/.archigraph/`.
+// That default is preserved for ordinary user installs. When multiple
+// agents run with isolated daemons via ARCHIGRAPH_DAEMON_ROOT, the
+// daemon socket and registry are already isolated, but the per-repo
+// state directory is shared — two agents indexing the same fixture
+// race on `<repo>/.archigraph/graph.json` and corrupt each other's
+// results.
+//
+// When ARCHIGRAPH_DAEMON_ROOT is set, StateDirForRepo returns a
+// daemon-private state directory at
+//
+//	$ARCHIGRAPH_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/
+//
+// instead of `<repo>/.archigraph/`. The fixture's own `.archigraph/`
+// directory is never touched by the daemon under this mode, so a
+// pristine read-only corpus stays pristine even across many parallel
+// agents.
+//
+// Identifier choice: sha256 of the absolute repo path, first 16 hex
+// chars. Reasons:
+//   - Deterministic (same input → same output across processes & hosts).
+//   - Filesystem-safe (16 hex chars, no separators or shell metachars).
+//   - Collision-resistant (2^64 namespace; far above any realistic
+//     fixture count on a single host).
+//   - Opaque (does not leak repo paths into shared tmp).
+//
+// Group-level config that lives co-located by design (group.json
+// manifests written by the wizard) is NOT routed through this helper —
+// it stays at `<repo>/.archigraph/group.json` so it can be discovered
+// by walking up from a CWD regardless of which daemon is running.
+package daemon
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+)
+
+// repoStateHash returns a deterministic, path-safe identifier for a
+// repo path. Callers MUST pass an absolute, lexically-clean path
+// (filepath.Abs + filepath.Clean) so that the same repo always maps
+// to the same hash regardless of how the caller addressed it.
+func repoStateHash(absRepoPath string) string {
+	sum := sha256.Sum256([]byte(absRepoPath))
+	return hex.EncodeToString(sum[:8]) // 16 hex chars
+}
+
+// StateDirForRepo returns the directory that holds per-repo state
+// (graph.json, repair.json, enrichment-*.json, …) for repoPath.
+//
+// When ARCHIGRAPH_DAEMON_ROOT is set, the directory is
+// `$ARCHIGRAPH_DAEMON_ROOT/state/<hash>/`. Otherwise it is the
+// ADR-0007 default of `<repoPath>/.archigraph/`.
+//
+// The directory is NOT created here; callers that write should
+// os.MkdirAll the returned path.
+func StateDirForRepo(repoPath string) string {
+	if repoPath == "" {
+		return ""
+	}
+	root := os.Getenv(EnvRoot)
+	if root == "" {
+		return filepath.Join(repoPath, ".archigraph")
+	}
+	abs, err := filepath.Abs(repoPath)
+	if err != nil {
+		abs = repoPath
+	}
+	abs = filepath.Clean(abs)
+	return filepath.Join(root, "state", repoStateHash(abs))
+}
+
+// GraphPathForRepo is a convenience wrapper that returns the
+// canonical graph.json path inside the per-repo state directory.
+func GraphPathForRepo(repoPath string) string {
+	return filepath.Join(StateDirForRepo(repoPath), "graph.json")
+}

--- a/internal/daemon/state_path_test.go
+++ b/internal/daemon/state_path_test.go
@@ -1,0 +1,112 @@
+package daemon
+
+import (
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+)
+
+func TestStateDirForRepo_DefaultColocated(t *testing.T) {
+	t.Setenv(EnvRoot, "")
+	got := StateDirForRepo("/some/repo")
+	want := filepath.Join("/some/repo", ".archigraph")
+	if got != want {
+		t.Fatalf("default state dir: got %q want %q", got, want)
+	}
+}
+
+func TestStateDirForRepo_WithDaemonRoot(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	got := StateDirForRepo("/some/repo")
+	if !strings.HasPrefix(got, filepath.Join(root, "state")+string(filepath.Separator)) {
+		t.Fatalf("expected DAEMON_ROOT-rooted path, got %q", got)
+	}
+	// Segment after .../state/ must be a 16-hex-char hash.
+	rel, _ := filepath.Rel(filepath.Join(root, "state"), got)
+	if !regexp.MustCompile(`^[0-9a-f]{16}$`).MatchString(rel) {
+		t.Fatalf("segment %q is not 16 hex chars", rel)
+	}
+}
+
+func TestStateDirForRepo_Deterministic(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	a := StateDirForRepo("/some/repo")
+	b := StateDirForRepo("/some/repo")
+	if a != b {
+		t.Fatalf("non-deterministic: %q != %q", a, b)
+	}
+}
+
+func TestStateDirForRepo_DistinctReposDistinctSegments(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	a := StateDirForRepo("/some/repo-a")
+	b := StateDirForRepo("/some/repo-b")
+	if a == b {
+		t.Fatalf("expected distinct paths for distinct repos; both = %q", a)
+	}
+}
+
+func TestStateDirForRepo_PathSafe(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	// Even with shell-metachar-laden input the hash segment must be
+	// purely [0-9a-f].
+	got := StateDirForRepo("/some path/with spaces & $weird?chars")
+	rel, _ := filepath.Rel(filepath.Join(root, "state"), got)
+	if strings.ContainsAny(rel, ` /$?&*'"\`+"`") {
+		t.Fatalf("segment %q is not shell/path safe", rel)
+	}
+}
+
+func TestGraphPathForRepo_RoutesThroughStateDir(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv(EnvRoot, root)
+	got := GraphPathForRepo("/some/repo")
+	if filepath.Base(got) != "graph.json" {
+		t.Fatalf("expected graph.json basename, got %q", got)
+	}
+	if filepath.Dir(got) != StateDirForRepo("/some/repo") {
+		t.Fatalf("graph path %q not under StateDirForRepo", got)
+	}
+}
+
+func TestStateDirForRepo_EmptyInput(t *testing.T) {
+	if got := StateDirForRepo(""); got != "" {
+		t.Fatalf("expected empty for empty input, got %q", got)
+	}
+}
+
+// TestStateDirForRepo_TwoDaemonRootsSameRepoIsolated is the regression
+// test for issue #745: two daemons with different ARCHIGRAPH_DAEMON_ROOTs
+// indexing the same fixture path must resolve to DIFFERENT state
+// directories (so they cannot race) while sharing the SAME hash segment
+// (so the mapping is deterministic per repo).
+func TestStateDirForRepo_TwoDaemonRootsSameRepoIsolated(t *testing.T) {
+	rootA := t.TempDir()
+	rootB := t.TempDir()
+	const repo = "/shared/fixture-X"
+
+	t.Setenv(EnvRoot, rootA)
+	a := StateDirForRepo(repo)
+	t.Setenv(EnvRoot, rootB)
+	b := StateDirForRepo(repo)
+
+	if a == b {
+		t.Fatalf("daemon A and B resolved to the same state dir: %q", a)
+	}
+	if !strings.HasPrefix(a, rootA) {
+		t.Fatalf("daemon A state dir %q not under root A %q", a, rootA)
+	}
+	if !strings.HasPrefix(b, rootB) {
+		t.Fatalf("daemon B state dir %q not under root B %q", b, rootB)
+	}
+	// Same repo path → same hash segment under each root.
+	if filepath.Base(a) != filepath.Base(b) {
+		t.Fatalf("hash segments differ: %q vs %q (should match for same repo)",
+			filepath.Base(a), filepath.Base(b))
+	}
+}

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -5,9 +5,9 @@ import (
 	"errors"
 	"fmt"
 	"os"
-	"path/filepath"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
 
@@ -71,7 +71,7 @@ func (liveStore) GroupGraph(group string) ([]byte, error) {
 	entries := make([]repoEntry, 0, len(cfg.Repos))
 	for _, r := range cfg.Repos {
 		e := repoEntry{Slug: r.Slug, Path: r.Path}
-		b, err := os.ReadFile(filepath.Join(r.Path, ".archigraph", "graph.json"))
+		b, err := os.ReadFile(daemon.GraphPathForRepo(r.Path))
 		if err != nil {
 			e.Error = err.Error()
 		} else {
@@ -94,7 +94,7 @@ func (liveStore) RepoGraph(group, repo string) ([]byte, error) {
 	}
 	for _, r := range cfg.Repos {
 		if r.Slug == repo {
-			return os.ReadFile(filepath.Join(r.Path, ".archigraph", "graph.json"))
+			return os.ReadFile(daemon.GraphPathForRepo(r.Path))
 		}
 	}
 	return nil, fmt.Errorf("repo %q not registered in group %q", repo, group)

--- a/internal/mcp/candidates.go
+++ b/internal/mcp/candidates.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
 )
 
 // LinkCandidate is one row in <group>-link-candidates.json.
@@ -68,7 +70,7 @@ func readEnrichmentCandidates(repoPath string) []EnrichmentCandidate {
 	if repoPath == "" {
 		return nil
 	}
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-candidates.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-candidates.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -88,7 +90,7 @@ func readEnrichmentCandidates(repoPath string) []EnrichmentCandidate {
 
 // writeEnrichmentCandidates persists candidates to a repo path (array form).
 func writeEnrichmentCandidates(repoPath string, cs []EnrichmentCandidate) error {
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-candidates.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-candidates.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -124,7 +126,7 @@ func appendResolution(repoPath string, res EnrichmentResolution) error {
 	if repoPath == "" {
 		return fmt.Errorf("repo path is empty")
 	}
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-resolutions.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-resolutions.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}
@@ -142,7 +144,7 @@ func appendRejection(repoPath string, candidateID, reason string) error {
 	if repoPath == "" {
 		return fmt.Errorf("repo path is empty")
 	}
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-rejections.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-rejections.json")
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return err
 	}

--- a/internal/mcp/enrichment.go
+++ b/internal/mcp/enrichment.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
 )
 
 // EnrichmentResolution is one resolved enrichment entry stored under a repo's
@@ -23,7 +25,7 @@ func readResolutions(repoPath string) []EnrichmentResolution {
 	if repoPath == "" {
 		return nil
 	}
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-resolutions.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-resolutions.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil

--- a/internal/mcp/repair.go
+++ b/internal/mcp/repair.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/enrichment"
 )
 
@@ -52,7 +53,7 @@ func readRepairEdgeCandidates(repoPath string) []enrichment.Candidate {
 	if repoPath == "" {
 		return nil
 	}
-	path := filepath.Join(repoPath, ".archigraph", "enrichment-candidates.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-candidates.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		return nil
@@ -80,7 +81,7 @@ func readRepairEdgeCandidates(repoPath string) []enrichment.Candidate {
 
 // readRepairFile reads repair.json. Absent file → empty struct, not error.
 func readRepairFile(repoPath string) (repairFileOnDisk, error) {
-	path := filepath.Join(repoPath, ".archigraph", "repair.json")
+	path := filepath.Join(daemon.StateDirForRepo(repoPath), "repair.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -111,7 +112,7 @@ func writeRepairFile(repoPath string, rf repairFileOnDisk) error {
 	if repoPath == "" {
 		return fmt.Errorf("repo path is empty")
 	}
-	dir := filepath.Join(repoPath, ".archigraph")
+	dir := daemon.StateDirForRepo(repoPath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return err
 	}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -25,6 +25,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/graph"
 )
 
@@ -93,7 +94,7 @@ func (r RegistryRepo) graphFile() string {
 	if r.Path == "" {
 		return ""
 	}
-	return filepath.Join(r.Path, ".archigraph", "graph.json")
+	return daemon.GraphPathForRepo(r.Path)
 }
 
 // CrossRepoLink is one entry in a group-links.json file.

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -19,6 +19,8 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
+
 	"github.com/cajasmota/archigraph/internal/graph"
 )
 
@@ -176,7 +178,7 @@ func AuditPath(path string, corpus bool) (*Report, error) {
 
 // hasGraphJSON returns true if dir/.archigraph/graph.json exists.
 func hasGraphJSON(dir string) bool {
-	_, err := os.Stat(filepath.Join(dir, ".archigraph", "graph.json"))
+	_, err := os.Stat(daemon.GraphPathForRepo(dir))
 	return err == nil
 }
 
@@ -237,7 +239,7 @@ func auditMany(paths []string) []*RepoReport {
 // large entities + relationships arrays so we avoid materialising the
 // whole document twice in memory.
 func auditRepo(repoPath string) (*RepoReport, error) {
-	graphPath := filepath.Join(repoPath, ".archigraph", "graph.json")
+	graphPath := daemon.GraphPathForRepo(repoPath)
 	rr := &RepoReport{
 		Path:                 repoPath,
 		EntitiesByLanguage:   map[string]int{},


### PR DESCRIPTION
Closes #745.

## Summary

When `ARCHIGRAPH_DAEMON_ROOT` is set, the daemon now writes per-repo state to `\$ARCHIGRAPH_DAEMON_ROOT/state/<sha256(abs_repo_path)[:16]>/` instead of `<repo>/.archigraph/`. Two coding agents running isolated daemons against a shared fixture corpus stop racing on `graph.json` (and on every other per-repo file: repair.json, enrichment-*.json, graph.fb, graph-stats.json). The fixture's own `.archigraph/` directory is never created or touched by the daemon under this mode.

When the env var is **unset** (normal user install), behavior is unchanged: ADR-0007 co-located state remains the default.

## Path resolution before / after

Same fixture at `/tmp/arch-745/fixtures/fixture-X`, two daemons with different `ARCHIGRAPH_DAEMON_ROOT`s:

- **Before (main):** both write to `/tmp/arch-745/fixtures/fixture-X/.archigraph/graph.json` (race)
- **After (this PR):**
  - daemon A → `/tmp/arch-A/state/84b9292d49877a00/graph.json`
  - daemon B → `/tmp/arch-B/state/84b9292d49877a00/graph.json`
  - fixture's own `.archigraph/` does not exist

Same repo path → same hash segment under each root (deterministic), different roots → different absolute paths (isolated).

## Implementation

- New helper `internal/daemon.StateDirForRepo(repoPath)` and convenience `GraphPathForRepo(repoPath)` in `internal/daemon/state_path.go`. Identifier is sha256 of the absolute repo path, first 16 hex chars: deterministic, filesystem-safe, collision-resistant, opaque.
- Replaced every hardcoded `<repo>/.archigraph/<file>` state path with the helper across:
  - indexer (graph.json + graph.fb writes, repair.json read/apply, enrichment-candidates write)
  - daemon RPC wrappers (default outPath, rebuild --wipe RemoveAll, mcp graph.fb cache key)
  - MCP server (repair.go, enrichment.go, candidates.go, state.go registry default)
  - audit (\`hasGraphJSON\`, \`auditRepo\`)
  - dashboard live store readers
  - cli: doctor, status, watch (mtime snapshots), links (symlink staging)
- Group-level `group.json` (wizard manifest, discovered via CWD walk for routing) intentionally NOT routed — it is configuration, not state, and must be discoverable independent of which daemon is running.
- ADR-0017 amended with the env-gated exception. ADR-0007 default remains the right model for single-user installs.
- AGENTS.md updated so contributors know to use the helper and never hardcode `<repo>/.archigraph/<file>`.

## Tests

- 8 unit tests in `internal/daemon/state_path_test.go`:
  - default co-located when env unset
  - DAEMON_ROOT honored when env set
  - sanitization deterministic + path-safe + collision-resistant
  - `GraphPathForRepo` routes through `StateDirForRepo`
  - regression: two distinct DAEMON_ROOTs + same repo → distinct dirs sharing same hash segment
- Full `go test ./...` green
- End-to-end measurement with two real daemons (steps below) confirms the race fix on the canonical scenario.

## Race-condition demonstration

Two daemons, different roots, same fixture, sequential index:

```
# main (before): both runs target the same file
indexed /tmp/arch-745/fixtures/fixture-X -> /tmp/arch-745/fixtures/fixture-X/.archigraph/graph.json
indexed /tmp/arch-745/fixtures/fixture-X -> /tmp/arch-745/fixtures/fixture-X/.archigraph/graph.json

# this PR (after): independent files under each daemon root
indexed /tmp/arch-745/fixtures/fixture-X -> /tmp/arch-A/state/84b9292d49877a00/graph.json
indexed /tmp/arch-745/fixtures/fixture-X -> /tmp/arch-B/state/84b9292d49877a00/graph.json
```

Re-indexing from the same daemon reuses the existing hash segment (no path churn). Fixture working tree stays empty.

## Test plan

- [ ] CI green (\`go test ./...\` + \`go vet ./...\`)
- [ ] Manual: two daemons / different roots / same fixture → independent state files
- [ ] Manual: unset env var → state still at \`<repo>/.archigraph/graph.json\` (ADR-0007 default preserved)
- [ ] \`archigraph quality audit-orphans\` against an indexed fixture under DAEMON_ROOT reads the right graph.json

## Constraints honored

- File-disjoint from in-flight #747 (verb matcher fix in \`internal/links/http_pass.go\`)
- Default ADR-0007 behavior preserved for user installs
- No real competitor names in code or this description