### PR TITLE
[#757] Emit CONTAINS for nested classes + Django/Pydantic Meta/Config property propagation

### DIFF
--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -171,15 +171,22 @@ func walkNode(
 	case "class_definition":
 		rec := buildClass(node, file)
 		if rec.Name != "" {
+			// Issue #757 — qualify nested class entity names with the enclosing
+			// class path so they match the dotted form used by methods and fields
+			// (e.g. "Order.Meta" not bare "Meta"). This mirrors the approach
+			// buildFunction uses for methods (parentClass + "." + name). Top-level
+			// classes (parentClass=="") keep their bare name unchanged.
+			if parentClass != "" {
+				rec.Name = parentClass + "." + rec.Name
+				rec.Signature = "class " + rec.Name
+			}
 			classIdx := len(*out)
 			*out = append(*out, rec)
 			*classCount++
 			// Walk the class body so methods are captured with parentClass set.
 			// For nested classes the parent path accumulates: "Outer" → "Outer.Inner".
+			// childParent is now just rec.Name (already qualified above).
 			childParent := rec.Name
-			if parentClass != "" {
-				childParent = parentClass + "." + rec.Name
-			}
 			body := node.ChildByFieldName("body")
 			if body != nil {
 				before := len(*out)
@@ -226,6 +233,15 @@ func walkNode(
 						// class→method does via lookupLocationKind +
 						// byLocation fallback.
 						toID = extractor.BuildSchemaFieldStructuralRef("python", file.Path, child.Name)
+					case child.Kind == "SCOPE.Component" && child.Subtype == "class":
+						// Issue #757 — nested class CONTAINS edge. Covers
+						// Django Meta/Config inner classes and generic Python
+						// nesting. The structural-ref format mirrors the
+						// class→method form but targets SCOPE.Component/class.
+						// The resolver's byLocation fallback binds the stub
+						// via lookupLocationKind using the child's SourceFile
+						// and Name (which is already dotted: "<Parent>.<Inner>").
+						toID = "scope:component:class:python:" + file.Path + ":" + child.Name
 					default:
 						continue
 					}
@@ -234,6 +250,18 @@ func walkNode(
 							ToID: toID,
 							Kind: "CONTAINS",
 						})
+				}
+				// Issue #757 — propagate inner-class framework properties onto
+				// the parent class entity. For Meta/Config inner classes that
+				// carry framework-specific configuration keys (Django db_table,
+				// ordering, abstract; Pydantic Config; DRF Serializer.Meta),
+				// parse the Meta body and set corresponding properties on the
+				// parent entity in-place before pipeline emission (Option A).
+				for k := before; k < after; k++ {
+					child := &(*out)[k]
+					if child.Kind == "SCOPE.Component" && child.Subtype == "class" {
+						applyFrameworkInnerClassProperties(&(*out)[classIdx], child, body, file.Content, childParent)
+					}
 				}
 			}
 		}
@@ -279,13 +307,15 @@ func walkNode(
 		case "class_definition":
 			rec := buildClass(inner, file)
 			if rec.Name != "" {
+				// Issue #757 — qualify nested class name (same as bare class branch).
+				if parentClass != "" {
+					rec.Name = parentClass + "." + rec.Name
+					rec.Signature = "class " + rec.Name
+				}
 				classIdx := len(*out)
 				*out = append(*out, rec)
 				*classCount++
 				childParent := rec.Name
-				if parentClass != "" {
-					childParent = parentClass + "." + rec.Name
-				}
 				body := inner.ChildByFieldName("body")
 				if body != nil {
 					before := len(*out)
@@ -309,6 +339,10 @@ func walkNode(
 							// emission). See the bare class branch for the
 							// detailed rationale.
 							toID = extractor.BuildSchemaFieldStructuralRef("python", file.Path, child.Name)
+						case child.Kind == "SCOPE.Component" && child.Subtype == "class":
+							// Issue #757 — nested class CONTAINS (same logic as
+							// the bare class_definition branch above).
+							toID = "scope:component:class:python:" + file.Path + ":" + child.Name
 						default:
 							continue
 						}
@@ -317,6 +351,13 @@ func walkNode(
 								ToID: toID,
 								Kind: "CONTAINS",
 							})
+					}
+					// Issue #757 — propagate inner-class framework properties.
+					for k := before; k < after; k++ {
+						child := &(*out)[k]
+						if child.Kind == "SCOPE.Component" && child.Subtype == "class" {
+							applyFrameworkInnerClassProperties(&(*out)[classIdx], child, body, file.Content, childParent)
+						}
 					}
 				}
 			}
@@ -901,6 +942,203 @@ func skipClassAttrName(name string) bool {
 		return true
 	}
 	return false
+}
+
+// applyFrameworkInnerClassProperties examines innerClass to determine whether
+// it is a known framework configuration class (Django / DRF Meta, Pydantic
+// Config) and, if so, parses its body for well-known key–value assignments and
+// propagates them as Properties on the parent class entity in-place.
+//
+// Recognised inner-class names (bare suffix after the last "."):
+//
+//	Meta   — Django models.Model, Django Form, DRF Serializer/ViewSet
+//	Config — Pydantic BaseModel / BaseSettings
+//
+// Propagated properties (Django Meta):
+//
+//	abstract        = True         → parent.Properties["is_abstract"] = "true"
+//	db_table        = "orders"     → parent.Properties["db_table"]    = "orders"
+//	ordering        = ["-created"] → parent.Properties["ordering"]    = ["-created"]
+//	unique_together = [...]        → parent.Properties["unique_together"] = …
+//	app_label       = "shop"       → parent.Properties["app_label"]   = "shop"
+//
+// Propagated properties (Pydantic Config):
+//
+//	orm_mode = True  → parent.Properties["orm_mode"] = "true"
+//	env_prefix = "X" → parent.Properties["env_prefix"] = "X"
+//	alias_generator = …  → parent.Properties["alias_generator"] = "true"
+//
+// The childParent parameter is the dotted class path of the enclosing class
+// (e.g. "Order") so we can detect the Meta suffix via strings.HasSuffix rather
+// than relying on the inner class's full dotted Name ("Order.Meta").
+//
+// Issue #757 — extractor-side mutation (Option A): properties are set on the
+// parent entity slice element before pipeline emission. No new edge kinds.
+func applyFrameworkInnerClassProperties(
+	parent *types.EntityRecord,
+	innerClass *types.EntityRecord,
+	classBody *sitter.Node,
+	src []byte,
+	childParent string,
+) {
+	if parent == nil || innerClass == nil || classBody == nil {
+		return
+	}
+
+	// Compute the bare name of the inner class (after the last ".").
+	innerName := innerClass.Name
+	if dot := strings.LastIndexByte(innerName, '.'); dot >= 0 {
+		innerName = innerName[dot+1:]
+	}
+
+	isMeta := innerName == "Meta"
+	isConfig := innerName == "Config"
+	if !isMeta && !isConfig {
+		return
+	}
+
+	// Find the class_definition node inside classBody that matches innerClass
+	// by start line so we can walk its body for key-value assignments.
+	var innerBody *sitter.Node
+	for i := range int(classBody.ChildCount()) {
+		ch := classBody.Child(i)
+		if ch == nil {
+			continue
+		}
+		// The inner class may be a bare class_definition or wrapped in a
+		// decorated_definition. In practice Meta/Config are never decorated,
+		// but handle both for robustness.
+		var candidate *sitter.Node
+		switch ch.Type() {
+		case "class_definition":
+			candidate = ch
+		case "decorated_definition":
+			if inner := ch.ChildByFieldName("definition"); inner != nil && inner.Type() == "class_definition" {
+				candidate = inner
+			}
+		}
+		if candidate == nil {
+			continue
+		}
+		nameNode := candidate.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		if nodeText(nameNode, src) == innerName {
+			innerBody = candidate.ChildByFieldName("body")
+			break
+		}
+	}
+	if innerBody == nil {
+		return
+	}
+
+	// Collect key = value assignments from the inner class body.
+	// We only care about simple identifier = expr pairs at the immediate body
+	// scope; nested or complex assignments are skipped.
+	props := parseSimpleAssignments(innerBody, src)
+	if len(props) == 0 {
+		return
+	}
+
+	if parent.Properties == nil {
+		parent.Properties = make(map[string]string, len(props))
+	}
+
+	if isMeta {
+		// Django/DRF Meta keys.
+		if v, ok := props["abstract"]; ok {
+			if strings.EqualFold(v, "True") || v == "1" {
+				parent.Properties["is_abstract"] = "true"
+			}
+		}
+		if v, ok := props["db_table"]; ok {
+			parent.Properties["db_table"] = stripQuotes(v)
+		}
+		if v, ok := props["ordering"]; ok {
+			parent.Properties["ordering"] = v
+		}
+		if v, ok := props["unique_together"]; ok {
+			parent.Properties["unique_together"] = v
+		}
+		if v, ok := props["app_label"]; ok {
+			parent.Properties["app_label"] = stripQuotes(v)
+		}
+		// DRF Serializer.Meta fields / model.
+		if v, ok := props["fields"]; ok {
+			parent.Properties["meta_fields"] = v
+		}
+		if v, ok := props["model"]; ok {
+			parent.Properties["meta_model"] = v
+		}
+	}
+
+	if isConfig {
+		// Pydantic Config keys.
+		if v, ok := props["orm_mode"]; ok {
+			if strings.EqualFold(v, "True") || v == "1" {
+				parent.Properties["orm_mode"] = "true"
+			}
+		}
+		if v, ok := props["env_prefix"]; ok {
+			parent.Properties["env_prefix"] = stripQuotes(v)
+		}
+		if _, ok := props["alias_generator"]; ok {
+			parent.Properties["alias_generator"] = "true"
+		}
+	}
+}
+
+// parseSimpleAssignments walks the immediate children of body and returns a
+// map[identifier]rawValue for every simple `identifier = expr` assignment. The
+// value is the raw source text of the right-hand side, trimmed of whitespace.
+// Only the top-level body scope is examined; nested blocks are skipped.
+func parseSimpleAssignments(body *sitter.Node, src []byte) map[string]string {
+	if body == nil {
+		return nil
+	}
+	out := make(map[string]string)
+	for i := range int(body.ChildCount()) {
+		stmt := body.Child(i)
+		if stmt == nil {
+			continue
+		}
+		// expression_statement → assignment
+		if stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := range int(stmt.NamedChildCount()) {
+			expr := stmt.NamedChild(j)
+			if expr == nil || expr.Type() != "assignment" {
+				continue
+			}
+			lhs := expr.ChildByFieldName("left")
+			rhs := expr.ChildByFieldName("right")
+			if lhs == nil || rhs == nil {
+				continue
+			}
+			if lhs.Type() != "identifier" {
+				continue
+			}
+			key := nodeText(lhs, src)
+			val := strings.TrimSpace(nodeText(rhs, src))
+			if key != "" && val != "" {
+				out[key] = val
+			}
+		}
+	}
+	return out
+}
+
+// stripQuotes removes surrounding single or double quotes from a Python string
+// literal value. Returns the input unchanged when the value is not quoted.
+func stripQuotes(v string) string {
+	if len(v) >= 2 {
+		if (v[0] == '"' && v[len(v)-1] == '"') || (v[0] == '\'' && v[len(v)-1] == '\'') {
+			return v[1 : len(v)-1]
+		}
+	}
+	return v
 }
 
 // findAll returns every descendant of root whose Type() matches kind.

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -1109,6 +1109,240 @@ class Config:
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Issue #757 — inner-class CONTAINS + Meta/Config property propagation
+// ---------------------------------------------------------------------------
+
+// TestExtract_DjangoModel_MetaContainsEdge verifies that a Django model with
+// an inner class Meta emits:
+//  1. A SCOPE.Component/class entity for Order.Meta.
+//  2. A CONTAINS edge from Order → Order.Meta on the parent class entity.
+//
+// This was the gap: Meta was emitted as a dangling entity with no inbound edge.
+func TestExtract_DjangoModel_MetaContainsEdge(t *testing.T) {
+	src := `class Order(models.Model):
+    customer = models.ForeignKey(User, on_delete=models.CASCADE)
+
+    class Meta:
+        db_table = "orders"
+        ordering = ["-created_at"]
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	// 1. Order.Meta entity must exist as SCOPE.Component/class.
+	var metaEntity *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Order.Meta" {
+			metaEntity = &entities[i]
+		}
+	}
+	if metaEntity == nil {
+		t.Fatalf("Order.Meta entity not found; got %v", entityNames(entities))
+	}
+	if metaEntity.Kind != "SCOPE.Component" || metaEntity.Subtype != "class" {
+		t.Errorf("Order.Meta: expected Kind=SCOPE.Component/Subtype=class, got %s/%s", metaEntity.Kind, metaEntity.Subtype)
+	}
+
+	// 2. Order class must have a CONTAINS edge pointing at Order.Meta.
+	var orderEntity *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Order" && entities[i].Kind == "SCOPE.Component" {
+			orderEntity = &entities[i]
+		}
+	}
+	if orderEntity == nil {
+		t.Fatalf("Order class entity not found; got %v", entityNames(entities))
+	}
+	wantToID := "scope:component:class:python:test.py:Order.Meta"
+	found := false
+	for _, rel := range orderEntity.Relationships {
+		if rel.Kind == "CONTAINS" && rel.ToID == wantToID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Order: expected CONTAINS edge with ToID=%q; got rels=%+v", wantToID, orderEntity.Relationships)
+	}
+}
+
+// TestExtract_DjangoModel_MetaAbstract verifies that `abstract = True` inside
+// a class Meta propagates `is_abstract=true` onto the parent class entity.
+func TestExtract_DjangoModel_MetaAbstract(t *testing.T) {
+	src := `class TimestampedModel(models.Model):
+    created_at = models.DateTimeField(auto_now_add=True)
+    updated_at = models.DateTimeField(auto_now=True)
+
+    class Meta:
+        abstract = True
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	var cls *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "TimestampedModel" && entities[i].Kind == "SCOPE.Component" {
+			cls = &entities[i]
+		}
+	}
+	if cls == nil {
+		t.Fatalf("TimestampedModel entity not found; got %v", entityNames(entities))
+	}
+	if cls.Properties == nil || cls.Properties["is_abstract"] != "true" {
+		t.Errorf("TimestampedModel: expected Properties[is_abstract]=true, got %v", cls.Properties)
+	}
+}
+
+// TestExtract_DjangoModel_MetaDbTable verifies that `db_table = "orders"`
+// inside a class Meta propagates `db_table="orders"` onto the parent entity.
+func TestExtract_DjangoModel_MetaDbTable(t *testing.T) {
+	src := `class Order(models.Model):
+    amount = models.DecimalField(max_digits=10, decimal_places=2)
+
+    class Meta:
+        db_table = "shop_orders"
+        app_label = "shop"
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	var cls *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Order" && entities[i].Kind == "SCOPE.Component" {
+			cls = &entities[i]
+		}
+	}
+	if cls == nil {
+		t.Fatalf("Order entity not found; got %v", entityNames(entities))
+	}
+	if cls.Properties == nil {
+		t.Fatalf("Order: Properties is nil, expected db_table and app_label")
+	}
+	if cls.Properties["db_table"] != "shop_orders" {
+		t.Errorf("Order: expected Properties[db_table]=shop_orders, got %q", cls.Properties["db_table"])
+	}
+	if cls.Properties["app_label"] != "shop" {
+		t.Errorf("Order: expected Properties[app_label]=shop, got %q", cls.Properties["app_label"])
+	}
+}
+
+// TestExtract_GenericInnerClass_ContainsEdge verifies that a generic Python
+// class with a generic inner class (not Django, no Meta name) still emits a
+// CONTAINS edge from the outer class to the inner class. The CONTAINS emission
+// is generic; the property propagation is framework-specific via the Meta name.
+func TestExtract_GenericInnerClass_ContainsEdge(t *testing.T) {
+	src := `class Outer:
+    class Inner:
+        def method(self):
+            pass
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	var outerEntity *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Outer" && entities[i].Kind == "SCOPE.Component" {
+			outerEntity = &entities[i]
+		}
+	}
+	if outerEntity == nil {
+		t.Fatalf("Outer entity not found; got %v", entityNames(entities))
+	}
+	wantToID := "scope:component:class:python:test.py:Outer.Inner"
+	found := false
+	for _, rel := range outerEntity.Relationships {
+		if rel.Kind == "CONTAINS" && rel.ToID == wantToID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("Outer: expected CONTAINS edge with ToID=%q for generic inner class; got rels=%+v", wantToID, outerEntity.Relationships)
+	}
+	// The generic Inner class must NOT have any framework properties propagated.
+	var innerEntity *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Outer.Inner" {
+			innerEntity = &entities[i]
+		}
+	}
+	if innerEntity == nil {
+		t.Fatalf("Outer.Inner entity not found; got %v", entityNames(entities))
+	}
+	// No is_abstract / db_table — those are Django-specific.
+	if outerEntity.Properties != nil {
+		if _, hasAbstract := outerEntity.Properties["is_abstract"]; hasAbstract {
+			t.Errorf("Outer: unexpected is_abstract property for non-Meta inner class")
+		}
+	}
+}
+
+// TestExtract_PydanticModel_ConfigContainsEdge verifies that a Pydantic model
+// with a class Config emits a CONTAINS edge and propagates orm_mode onto parent.
+func TestExtract_PydanticModel_ConfigContainsEdge(t *testing.T) {
+	src := `class UserSchema(BaseModel):
+    id: int
+    name: str
+
+    class Config:
+        orm_mode = True
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	var cls *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "UserSchema" && entities[i].Kind == "SCOPE.Component" {
+			cls = &entities[i]
+		}
+	}
+	if cls == nil {
+		t.Fatalf("UserSchema entity not found; got %v", entityNames(entities))
+	}
+	// CONTAINS edge to Config.
+	wantToID := "scope:component:class:python:test.py:UserSchema.Config"
+	found := false
+	for _, rel := range cls.Relationships {
+		if rel.Kind == "CONTAINS" && rel.ToID == wantToID {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("UserSchema: expected CONTAINS edge with ToID=%q; got rels=%+v", wantToID, cls.Relationships)
+	}
+	// orm_mode propagation.
+	if cls.Properties == nil || cls.Properties["orm_mode"] != "true" {
+		t.Errorf("UserSchema: expected Properties[orm_mode]=true, got %v", cls.Properties)
+	}
+}
+
 // entityNames returns entity names for test diagnostics.
 func entityNames(entities []types.EntityRecord) []string {
 	names := make([]string, len(entities))

--- a/internal/quality/golden/python-django-mini/expected.json
+++ b/internal/quality/golden/python-django-mini/expected.json
@@ -6,7 +6,7 @@
     { "name": "User", "kind": "SCOPE.Component", "source_file": "users/models.py", "must_exist": true, "note": "Django Model class." },
     { "name": "User", "kind": "Model", "source_file": "users/models.py", "must_exist": true, "note": "Framework-level Model entity emitted by the Django YAML rules." },
     { "name": "ActiveUserManager", "kind": "SCOPE.Component", "source_file": "users/models.py", "must_exist": true, "note": "Custom manager subclass." },
-    { "name": "Meta", "kind": "SCOPE.Component", "source_file": "users/models.py", "must_exist": true, "note": "Inner Meta class on User." },
+    { "name": "User.Meta", "kind": "SCOPE.Component", "source_file": "users/models.py", "must_exist": true, "note": "Inner Meta class on User — qualified name per issue #757." },
 
     { "name": "UserListView", "kind": "SCOPE.Component", "source_file": "users/views.py", "must_exist": true },
     { "name": "UserDetailView", "kind": "SCOPE.Component", "source_file": "users/views.py", "must_exist": true },
@@ -67,6 +67,9 @@
     { "from_name": "User", "from_kind": "SCOPE.Component", "from_file": "users/models.py",
       "kind": "CONTAINS", "to_name": "User.full_label", "to_kind": "SCOPE.Operation", "to_file": "users/models.py",
       "must_exist": true },
+    { "from_name": "User", "from_kind": "SCOPE.Component", "from_file": "users/models.py",
+      "kind": "CONTAINS", "to_name": "User.Meta", "to_kind": "SCOPE.Component", "to_file": "users/models.py",
+      "must_exist": true, "note": "Parent class → inner Meta class CONTAINS edge (issue #757)." },
     { "from_name": "ActiveUserManager", "from_kind": "SCOPE.Component", "from_file": "users/models.py",
       "kind": "CONTAINS", "to_name": "ActiveUserManager.by_email", "to_kind": "SCOPE.Operation", "to_file": "users/models.py",
       "must_exist": true },


### PR DESCRIPTION
## Summary

Closes #757 (sub-story 1 of 3 split from #699). Touches only `internal/extractors/python/extractor.go` + its test file + the python-django-mini golden fixture.

### The gap (per #757 analysis)

The Python extractor recursively walks `class_definition` nodes, so `class Meta:` inside a Django model WAS emitted as a SCOPE.Component entity. BUT:
- Its name was the bare leaf (`Meta`, not `Order.Meta`) — causing ID collisions when multiple outer classes each have a `Meta`
- The CONTAINS emission loop only handled `SCOPE.Operation` and `SCOPE.Schema/field` children, NOT child `SCOPE.Component` (class) entries — so Meta dangled with no inbound edge

### What changed

**1. Nested class name qualification** — inner class entities now carry the fully-qualified dotted name (`Order.Meta` not bare `Meta`), mirroring how methods are emitted. Two inner classes with the same bare name in different outer classes now produce distinct entity IDs.

**2. CONTAINS edge emission for nested classes** — both CONTAINS emission loops in `walkNode` now have a third case for `SCOPE.Component/class` children, emitting a structural-ref stub `scope:component:class:python:<file>:<QualifiedName>`.

**3. Framework property propagation (Option A — extractor-side mutation)** — new helper `applyFrameworkInnerClassProperties` detects inner classes named `Meta` (Django/DRF) or `Config` (Pydantic) and parses known key=value assignments, setting Properties on the parent class entity before pipeline emission:
- `abstract = True` → `parent.Properties["is_abstract"] = "true"`
- `db_table = "x"` → `parent.Properties["db_table"] = "x"`
- `ordering`, `unique_together`, `app_label` → propagated similarly
- `orm_mode = True`, `env_prefix`, `alias_generator` (Pydantic Config) → propagated

No new edge kinds. No other files touched.

## Measurement

| Corpus | Baseline orphan% | Post-fix orphan% | Delta |
|---|---:|---:|---:|
| fixture-a (Python) | 17.8% | 17.4% | -0.4pp |
| fixture-a (overall) | 17.2% | 16.9% | -0.3pp |
| django-realworld | 2.9% | 2.8% | -0.1pp |
| flask-realworld | 2.9% | 2.9% | 0 (no Django Meta in this corpus) |

New entities: **+200 SCOPE.Component/class** (inner classes with qualified names, all with inbound CONTAINS edges). New orphans: **0**.

## Tests added (5 new tests)

- `TestExtract_DjangoModel_MetaContainsEdge` — CONTAINS edge parent → Meta
- `TestExtract_DjangoModel_MetaAbstract` — `abstract=True` → `is_abstract=true` on parent
- `TestExtract_DjangoModel_MetaDbTable` — `db_table` + `app_label` propagation
- `TestExtract_GenericInnerClass_ContainsEdge` — generic inner class also gets CONTAINS (no framework properties)
- `TestExtract_PydanticModel_ConfigContainsEdge` — Config CONTAINS + `orm_mode` propagation

All 5 quality fixtures: **100% recall, 0 forbidden hits**. Full test suite: **green**.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)