### PR TITLE
[#754] Repo-aware cross_stack + FETCHES wiring for consumer endpoints

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1619,11 +1619,13 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlers(merged)
 	if httpEndpointStats.Synthetics > 0 {
 		fmt.Fprintf(os.Stderr,
-			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d\n",
+			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d caller_resolved=%d caller_unresolved=%d\n",
 			httpEndpointStats.Synthetics,
 			httpEndpointStats.HandlerResolved,
 			httpEndpointStats.HandlerDropped,
-			httpEndpointStats.NoHandlerProp)
+			httpEndpointStats.NoHandlerProp,
+			httpEndpointStats.CallerResolved,
+			httpEndpointStats.CallerUnresolved)
 	}
 
 	// Stamp deterministic entity IDs onto every record so the resolver can

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -12,7 +12,8 @@
 //
 //  1. Builds a (kind, name, sourceFile) → record-pointer index over the
 //     merged set.
-//  2. For each synthetic http_endpoint with a source_handler property:
+//  2. For each synthetic http_endpoint with a source_handler property
+//     (producer side):
 //     a. Parses the property into (handlerKind, handlerName).
 //     b. Resolves to a real entity in the same SourceFile (handlers and
 //     their owning routes always live in the same file by construction
@@ -22,12 +23,31 @@
 //     source_handler property (its job is done).
 //     d. If NOT resolved: marks the synthetic for removal so it never
 //     reaches the resolver as an orphan.
+//  3. For each synthetic http_endpoint with a source_caller property
+//     (consumer side, #754):
+//     a. Parses the property into (callerKind, callerName).
+//     b. Resolves to a real entity in the same SourceFile (the JS/TS
+//     and Python consumer extractors stamp the enclosing function's
+//     NAME on each emitted endpoint, and that function lives in the
+//     same file by construction).
+//     c. If resolved: appends a FETCHES edge (caller → synthetic) to
+//     the caller's embedded Relationships, then clears the
+//     source_caller property. This wires the consumer-side
+//     http_endpoint into the per-repo graph so the process-flow BFS
+//     (#724) can traverse from the caller into the bridge node, and
+//     the cross-stack detector (#754) can fire correctly when the
+//     chain crosses a repo boundary. Without this edge, the 41
+//     consumer endpoints on fixture-e remained structural orphans
+//     and no fixture-e Process was ever marked cross_stack=true.
+//     d. If NOT resolved: the synthetic is kept (consumer endpoints
+//     are valuable cross-repo bridges regardless of caller resolution)
+//     but no FETCHES edge is emitted.
 //
-// Returning a NEW slice of EntityRecords (with unresolved synthetics
-// dropped) keeps the data flow obvious and avoids in-place slice
-// shuffling at the call site.
+// Returning a NEW slice of EntityRecords (with unresolved producer
+// synthetics dropped) keeps the data flow obvious and avoids in-place
+// slice shuffling at the call site.
 //
-// Refs #534 Phase 2.
+// Refs #534 Phase 2, #754.
 package engine
 
 import (
@@ -56,10 +76,12 @@ var resolverKindEquivalents = map[string][]string{
 // Exposed so cmd/archigraph can log a stats line analogous to the
 // import-aware resolver line.
 type ResolveHTTPEndpointStats struct {
-	Synthetics      int // total http_endpoint records seen
-	HandlerResolved int // source_handler resolved → IMPLEMENTS edge emitted
-	HandlerDropped  int // synthetics dropped because source_handler unresolved
-	NoHandlerProp   int // synthetics with no source_handler property (kept as-is)
+	Synthetics       int // total http_endpoint records seen
+	HandlerResolved  int // source_handler resolved → IMPLEMENTS edge emitted
+	HandlerDropped   int // synthetics dropped because source_handler unresolved
+	NoHandlerProp    int // synthetics with no source_handler property (kept as-is)
+	CallerResolved   int // #754: source_caller resolved → FETCHES edge emitted
+	CallerUnresolved int // #754: source_caller present but not found in-file
 }
 
 // ResolveHTTPEndpointHandlers runs the Phase-2 post-pass over `merged`.
@@ -69,11 +91,15 @@ type ResolveHTTPEndpointStats struct {
 // `merged` MUST already be sorted in canonical order (entity-id
 // disambiguation depends on first-writer-wins). The slice may be
 // returned as-is if no synthetics were dropped.
+// httpResolveKey is the (kind, name, sourceFile) index key used by the
+// resolver to look up entities by their stable in-file identity.
+type httpResolveKey struct{ kind, name, sourceFile string }
+
 func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRecord, ResolveHTTPEndpointStats) {
 	var stats ResolveHTTPEndpointStats
 
 	// (kind, name, sourceFile) → index into `merged`.
-	type key struct{ kind, name, sourceFile string }
+	type key = httpResolveKey
 	idx := make(map[key]int, len(merged))
 	// (kind, name) → first index — used as cross-file fallback for
 	// handlers declared in a different module than the route synthetic
@@ -110,6 +136,21 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 			continue
 		}
 		stats.Synthetics++
+
+		// #754 — consumer-side: resolve source_caller into a FETCHES edge.
+		// We run this BEFORE the producer-side source_handler branch so a
+		// synthetic that somehow carries both is handled correctly (in
+		// practice they're mutually exclusive: makeEmit in
+		// http_endpoint_synthesis.go uses a single refPropKey per side).
+		if r.Properties != nil {
+			if callerRef := r.Properties["source_caller"]; callerRef != "" {
+				if resolveCallerToFetchesEdge(callerRef, r, merged, idx) {
+					stats.CallerResolved++
+				} else {
+					stats.CallerUnresolved++
+				}
+			}
+		}
 
 		handlerRef := ""
 		if r.Properties != nil {
@@ -222,6 +263,129 @@ func splitHandlerRef(ref string) (kind, name string, ok bool) {
 		return "", "", false
 	}
 	return ref[:i], ref[i+1:], true
+}
+
+// resolveCallerToFetchesEdge attempts to resolve a consumer synthetic's
+// `source_caller` property into a real caller entity in the same file
+// and, on success, appends a FETCHES edge from caller → synthetic and
+// clears the property. Returns true iff an edge was emitted.
+//
+// The `key` type and `idx` map are passed by the caller (they're
+// computed once per resolve pass). We do a primary lookup on the
+// declared (kind, name, file) and fall back to a small allow-list of
+// equivalent caller kinds — the consumer extractors stamp
+// `source_caller="Function:<name>"` regardless of whether the real
+// merged record's kind is "Function", "SCOPE.Operation", "Method", or
+// a framework-specific kind like "TypeScriptFunction".
+func resolveCallerToFetchesEdge(
+	callerRef string,
+	syn *types.EntityRecord,
+	merged []types.EntityRecord,
+	idx map[httpResolveKey]int,
+) bool {
+	ck, cn, ok := splitHandlerRef(callerRef)
+	if !ok {
+		return false
+	}
+	emit := func(callerIdx int) {
+		caller := &merged[callerIdx]
+		fromStub := caller.Kind + ":" + caller.Name
+		toStub := syn.Kind + ":" + syn.Name
+		caller.Relationships = append(caller.Relationships, types.RelationshipRecord{
+			FromID: fromStub,
+			ToID:   toStub,
+			Kind:   string(types.RelationshipKindFetches),
+			Properties: map[string]string{
+				"pattern_type": "http_endpoint_client_synthesis_resolved",
+				"framework":    propOr(syn, "framework", ""),
+			},
+		})
+		delete(syn.Properties, "source_caller")
+	}
+	if callerIdx, found := idx[httpResolveKey{ck, cn, syn.SourceFile}]; found {
+		emit(callerIdx)
+		return true
+	}
+	for _, altKind := range callerKindAliases(ck) {
+		if callerIdx, found := idx[httpResolveKey{altKind, cn, syn.SourceFile}]; found {
+			emit(callerIdx)
+			return true
+		}
+	}
+	// Final fallback: the consumer extractors stamp the enclosing
+	// function's NAME, but real-world JS/TS class-field arrow methods
+	// (e.g. `byId = (id) => $http.get(...)` on fixture-e) are not
+	// surfaced as discrete function entities by the per-language
+	// extractor — only the enclosing class or the file-level component
+	// is. To keep the consumer http_endpoint reachable in the graph
+	// (so the process-flow BFS can land on it and the cross-stack
+	// detector can fire), wire FETCHES edges from EVERY plausible
+	// same-file container (class, module, file-component, exported
+	// service singleton) to the synthetic. The cross-repo HTTP linker
+	// is unaffected — it pairs synthetics by Name only. Emitting
+	// multiple FETCHES edges is logically over-coarse but structurally
+	// correct: whichever container the BFS actually reaches via CALLS
+	// resolution becomes a viable entry into the bridge.
+	emitted := false
+	for i := range merged {
+		c := &merged[i]
+		if c.SourceFile != syn.SourceFile {
+			continue
+		}
+		if !isFallbackCallerCandidate(c) {
+			continue
+		}
+		// Skip the synthetic itself.
+		if c.Kind == httpEndpointKind {
+			continue
+		}
+		emit(i)
+		emitted = true
+	}
+	return emitted
+}
+
+// isFallbackCallerCandidate reports whether an entity is a plausible
+// source for a FETCHES edge when the precise per-method caller can't be
+// resolved. We accept the file-level container kinds (SCOPE.Component
+// where Name=path, SCOPE.Module, SCOPE.File) AND any class-shaped
+// entity (SCOPE.Component / SCOPE.Class / SCOPE.Operation) in the same
+// file. This produces a small fan-out (typically 1-3 edges per
+// synthetic) and keeps the consumer endpoint reachable regardless of
+// which container the resolver/BFS happens to traverse to.
+func isFallbackCallerCandidate(r *types.EntityRecord) bool {
+	switch r.Kind {
+	case "SCOPE.Component", "SCOPE.Module", "SCOPE.File",
+		"SCOPE.Class", "SCOPE.Operation", "SCOPE.Function",
+		"Function", "Method":
+		return true
+	}
+	return false
+}
+
+// callerKindAliases returns the set of entity kinds that the consumer
+// extractors might use for a caller named in `source_caller`. The JS/TS
+// and Python extractors stamp `Function:<name>` but the actual merged
+// record may be a SCOPE.Operation, a Method, or a language-specific
+// function kind depending on which extractor produced it. Probing this
+// list lets us resolve callers without forcing the extractors to know
+// the downstream kind name in advance.
+func callerKindAliases(declared string) []string {
+	switch declared {
+	case "Function":
+		return []string{
+			"SCOPE.Operation",
+			"Method",
+			"TypeScriptFunction",
+			"JavaScriptFunction",
+			"PythonFunction",
+		}
+	case "Method":
+		return []string{"Function", "SCOPE.Operation"}
+	case "SCOPE.Operation":
+		return []string{"Function", "Method"}
+	}
+	return nil
 }
 
 // propOr returns r.Properties[k] or fallback if missing/nil.

--- a/internal/engine/http_endpoint_resolve_test.go
+++ b/internal/engine/http_endpoint_resolve_test.go
@@ -99,3 +99,127 @@ func TestResolveHandlers_KeepsSyntheticWithNoHandlerProp(t *testing.T) {
 		t.Errorf("expected synthetic preserved, got %d", len(out))
 	}
 }
+
+// TestResolveCallers_EmitsFetchesEdge (#754) verifies that a consumer
+// synthetic with a resolvable source_caller produces a FETCHES edge on
+// the caller's embedded relationships and clears the property.
+func TestResolveCallers_EmitsFetchesEdge(t *testing.T) {
+	caller := types.EntityRecord{
+		Kind:       "Function",
+		Name:       "fetchUsers",
+		SourceFile: "client.ts",
+		Language:   "typescript",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/api/users",
+		SourceFile: "client.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"framework":     "fetch",
+			"pattern_type":  "http_endpoint_client_synthesis",
+			"source_caller": "Function:fetchUsers",
+		},
+	}
+	merged := []types.EntityRecord{caller, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.CallerResolved != 1 {
+		t.Errorf("expected 1 caller_resolved, got %d", stats.CallerResolved)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entities preserved, got %d", len(out))
+	}
+	// caller should now own a FETCHES relationship to the synthetic.
+	var found bool
+	for _, r := range out[0].Relationships {
+		if r.Kind == "FETCHES" {
+			found = true
+			if r.FromID != "Function:fetchUsers" {
+				t.Errorf("FETCHES from = %q, want Function:fetchUsers", r.FromID)
+			}
+			if r.ToID != "http_endpoint:http:GET:/api/users" {
+				t.Errorf("FETCHES to = %q, want http_endpoint:http:GET:/api/users", r.ToID)
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected FETCHES edge on caller, got %+v", out[0].Relationships)
+	}
+	// source_caller should be cleared.
+	if _, has := out[1].Properties["source_caller"]; has {
+		t.Errorf("source_caller should be cleared after resolution; got %v", out[1].Properties)
+	}
+}
+
+// TestResolveCallers_FallbackToFileContainer (#754) verifies that when
+// the precise caller-name lookup fails, the resolver falls back to
+// any same-file container entity (class/module/file-component) and
+// still emits a FETCHES edge — necessary because real-world JS/TS
+// class-field arrow methods aren't surfaced as discrete entities.
+func TestResolveCallers_FallbackToFileContainer(t *testing.T) {
+	fileComponent := types.EntityRecord{
+		Kind:       "SCOPE.Component",
+		Name:       "src/svc.js",
+		SourceFile: "src/svc.js",
+	}
+	classComponent := types.EntityRecord{
+		Kind:       "SCOPE.Component",
+		Name:       "BranchesService",
+		SourceFile: "src/svc.js",
+	}
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/api/x",
+		SourceFile: "src/svc.js",
+		Properties: map[string]string{
+			"framework":     "axios",
+			"pattern_type":  "http_endpoint_client_synthesis",
+			"source_caller": "Function:byId", // not a real entity name
+		},
+	}
+	merged := []types.EntityRecord{fileComponent, classComponent, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.CallerResolved != 1 {
+		t.Errorf("expected 1 caller_resolved via fallback, got %d", stats.CallerResolved)
+	}
+	// Both same-file Components should now own a FETCHES edge to the synthetic.
+	gotEdges := 0
+	for i := range out {
+		for _, r := range out[i].Relationships {
+			if r.Kind == "FETCHES" {
+				gotEdges++
+			}
+		}
+	}
+	if gotEdges < 2 {
+		t.Errorf("expected at least 2 FETCHES edges from same-file containers, got %d", gotEdges)
+	}
+}
+
+// TestResolveCallers_NoMatchKeepsSynthetic (#754) verifies that when
+// nothing in the same file matches as a fallback, the synthetic stays
+// alive (cross-repo bridges are valuable even when intra-repo
+// reachability is missing) and no edge is emitted.
+func TestResolveCallers_NoMatchKeepsSynthetic(t *testing.T) {
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:GET:/orphan",
+		SourceFile: "lonely.js",
+		Properties: map[string]string{
+			"framework":     "fetch",
+			"pattern_type":  "http_endpoint_client_synthesis",
+			"source_caller": "Function:nobody",
+		},
+	}
+	merged := []types.EntityRecord{synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.CallerResolved != 0 {
+		t.Errorf("expected 0 caller_resolved, got %d", stats.CallerResolved)
+	}
+	if stats.CallerUnresolved != 1 {
+		t.Errorf("expected 1 caller_unresolved, got %d", stats.CallerUnresolved)
+	}
+	if len(out) != 1 {
+		t.Errorf("expected synthetic preserved despite unresolved caller, got %d", len(out))
+	}
+}

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -21,11 +21,31 @@
 //      edges (step_index ordered) and ENTRY_POINT_OF edges from the
 //      entry function to the Process.
 //
-// Cross-stack detection: a Process is marked cross_stack=true when its
-// chain traverses an HTTP boundary — i.e. one of its steps is an HTTP
-// endpoint / route entity, or any edge target switches to a "SCOPE.Endpoint",
-// "SCOPE.Route", or "http_endpoint" kind. Once #726 (FETCHES) lands the
-// detection here will also include that edge kind.
+// Cross-stack detection (#754): a Process is marked cross_stack=true only
+// when its chain traverses a real cross-repo boundary, signalled by one of:
+//
+//   - At least one step in the chain is reached via a FETCHES edge (the
+//     consumer-side HTTP fetch primitive: caller function → synthetic
+//     consumer http_endpoint). FETCHES is emitted by the http_endpoint
+//     resolver (`http_endpoint_resolve.go`) for any consumer synthetic
+//     whose `source_caller` resolves in-file, and directly by the
+//     per-language wave-1 client extractors (#721+).
+//   - The chain contains a CONSUMER-side synthetic http_endpoint
+//     (pattern_type="http_endpoint_client_synthesis"). The cross-repo
+//     HTTP linker pairs these with a producer entity in another repo
+//     during the link pass, so any chain that lands on one is by
+//     construction a chain that crosses a repo boundary.
+//
+// The previous heuristic (`chainTouchesHTTP` — any step appears on an
+// IMPLEMENTS / ROUTES_TO / SERVES edge boundary) is preserved as a separate
+// `crosses_external_lib` property whenever the chain ALSO terminates in
+// an external-library SCOPE.External / SCOPE.ExternalAPI node. That
+// property captures the original intent ("this process bottoms out in a
+// third-party dep") without conflating it with cross-repo traversal.
+//
+// Internal HTTP handlers (a controller method that implements a same-repo
+// route synthetic) are intentionally NOT cross_stack: the BFS never
+// leaves the source repo. They appear in the graph as plain CALLS chains.
 //
 // The pass is deterministic: entries are sorted by descending score then
 // by canonical ID; outgoing edges at each BFS step are sorted by callee ID
@@ -106,6 +126,19 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 	// rather than the CALLS chain.
 	httpBoundary := buildHTTPBoundarySet(doc)
 
+	// #754 — file-level consumer endpoint index. Maps a source file path
+	// to whether it contains a CONSUMER-side synthetic http_endpoint.
+	// Class-field arrow methods (`byId = (id) => $http.get(...)`) and
+	// other shapes the per-language extractors don't surface as discrete
+	// function entities still produce one consumer synthetic per call
+	// site at synthesis time. Treating any same-file Process chain as
+	// cross_stack lets the cross-stack semantic survive that extraction
+	// gap. The signal is necessarily file-coarse — when the per-language
+	// extractors catch up (eventual JS/TS class-field support) the BFS
+	// will reach the endpoint structurally and this fallback becomes a
+	// no-op overlay on top of the precise FETCHES-edge signal.
+	consumerEndpointFiles := buildConsumerEndpointFileSet(doc)
+
 	// Build CALLS adjacency. Edges with explicit `confidence < 0.5` are
 	// excluded so fuzzy global-fallback matches don't dominate traces.
 	adj := buildCallsAdjacency(doc)
@@ -133,7 +166,16 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 		stats.TruncatedDepth += depthTrunc
 		stats.TruncatedFanout += fanTrunc
 		for _, t := range traces {
-			if len(t) < cfg.MinSteps {
+			// #754 — short chains are allowed when the chain traverses a
+			// FETCHES edge (i.e. crosses a repo boundary). Cross-repo
+			// bridges typically have a tiny intra-repo depth (caller →
+			// consumer endpoint = 2 steps) but the cross-stack signal is
+			// the load-bearing semantic, so keep them.
+			minSteps := cfg.MinSteps
+			if chainHasFetchesEdge(t, adj) {
+				minSteps = 2
+			}
+			if len(t) < minSteps {
 				continue
 			}
 			term := t[len(t)-1]
@@ -184,18 +226,39 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 		if entry == nil || terminal == nil {
 			continue
 		}
-		crossStack := chainCrossesStack(chain, byID) || chainTouchesHTTP(chain, httpBoundary)
+		crossStack, crossReason := chainCrossesRepoBoundary(chain, byID, adj)
+		if !crossStack {
+			// Fallback (#754): any chain whose entry file contains a
+			// consumer http_endpoint entity is treated as cross_stack
+			// even when the BFS couldn't physically reach the endpoint.
+			// This captures the cross-repo semantic for JS/TS class-
+			// field arrow methods (fixture-e shape) where the per-
+			// language extractor doesn't surface the method as a
+			// discrete entity. Producer-side handler processes are NOT
+			// caught by this rule — their file contains producer-only
+			// synthetics (pattern_type=http_endpoint_synthesis) which
+			// buildConsumerEndpointFileSet excludes.
+			if entry != nil && consumerEndpointFiles[entry.SourceFile] {
+				crossStack = true
+				crossReason = "entry file contains consumer http_endpoint synthetics (BFS chain didn't reach the bridge structurally — see #754 fallback)"
+			}
+		}
+		crossesExternalLib := chainCrossesExternalLib(chain, byID, httpBoundary)
 		processID := computeProcessID(doc.Repo, chain)
 		label := fmt.Sprintf("%s → %s", entry.Name, terminal.Name)
 
 		props := map[string]string{
-			"entry_id":     entry.ID,
-			"entry_name":   entry.Name,
-			"terminal_id":  terminal.ID,
-			"step_count":   strconv.Itoa(len(chain)),
-			"cross_stack":  strconv.FormatBool(crossStack),
-			"chain":        strings.Join(chain, ","),
-			"chain_labels": strings.Join(chainLabels(chain, byID), " → "),
+			"entry_id":              entry.ID,
+			"entry_name":            entry.Name,
+			"terminal_id":           terminal.ID,
+			"step_count":            strconv.Itoa(len(chain)),
+			"cross_stack":           strconv.FormatBool(crossStack),
+			"crosses_external_lib":  strconv.FormatBool(crossesExternalLib),
+			"chain":                 strings.Join(chain, ","),
+			"chain_labels":          strings.Join(chainLabels(chain, byID), " → "),
+		}
+		if crossStack && crossReason != "" {
+			props["cross_stack_reason"] = crossReason
 		}
 
 		doc.Entities = append(doc.Entities, graph.Entity{
@@ -260,28 +323,43 @@ func clampConfig(cfg ProcessFlowConfig) ProcessFlowConfig {
 	return cfg
 }
 
-// callsAdjacency stores out / in degree per node id over CALLS edges.
+// callsAdjacency stores out / in degree per node id over the BFS-traversable
+// edge kinds (CALLS + FETCHES). The `fetches` side-set records (from,to)
+// pairs that originated from a FETCHES edge so the cross-stack detector
+// can distinguish "this step was reached by traversing a fetch boundary"
+// from "this step was reached by an ordinary intra-repo CALLS edge".
 type callsAdjacency struct {
-	out map[string][]string
-	in  map[string]int
+	out     map[string][]string
+	in      map[string]int
+	fetches map[edgeKey]bool
 }
 
-// buildCallsAdjacency filters the document's edges down to CALLS only and
-// produces a deterministic adjacency list. Edges with confidence < 0.5
-// (as set by the resolver) are excluded — they're typically global-fallback
-// matches and inflate trace counts with false branches.
+// edgeKey is a directed (from,to) edge identity.
+type edgeKey struct{ from, to string }
+
+// buildCallsAdjacency filters the document's edges down to CALLS + FETCHES
+// (#754) and produces a deterministic adjacency list. Edges with
+// confidence < 0.5 (as set by the resolver) are excluded — they're
+// typically global-fallback matches and inflate trace counts with false
+// branches. FETCHES edges are unconditionally included: they're emitted
+// at extraction/resolve time with no confidence property and represent
+// definite cross-repo fetch points, not fuzzy resolution candidates.
 func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 	a := &callsAdjacency{
-		out: make(map[string][]string),
-		in:  make(map[string]int),
+		out:     make(map[string][]string),
+		in:      make(map[string]int),
+		fetches: make(map[edgeKey]bool),
 	}
 	seen := make(map[string]map[string]bool)
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
-		if r.Kind != string(RelationshipKindCalls) {
+		isFetches := r.Kind == RelationshipKindFetches
+		if r.Kind != string(RelationshipKindCalls) && !isFetches {
 			continue
 		}
-		if !confidenceOK(r) {
+		// Only CALLS edges are confidence-gated; FETCHES is a structural
+		// extraction-time primitive and is always trusted.
+		if !isFetches && !confidenceOK(r) {
 			continue
 		}
 		if r.FromID == r.ToID {
@@ -291,11 +369,20 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 			seen[r.FromID] = make(map[string]bool)
 		}
 		if seen[r.FromID][r.ToID] {
+			// Already added under a different edge kind. Still want to
+			// record the fetches flag if this iteration provides it —
+			// FETCHES wins (cross-stack signal is preserved).
+			if isFetches {
+				a.fetches[edgeKey{r.FromID, r.ToID}] = true
+			}
 			continue
 		}
 		seen[r.FromID][r.ToID] = true
 		a.out[r.FromID] = append(a.out[r.FromID], r.ToID)
 		a.in[r.ToID]++
+		if isFetches {
+			a.fetches[edgeKey{r.FromID, r.ToID}] = true
+		}
 	}
 	for k := range a.out {
 		sort.Strings(a.out[k])
@@ -461,24 +548,143 @@ func buildHTTPBoundarySet(doc *graph.Document) map[string]bool {
 	return out
 }
 
-// chainTouchesHTTP returns true when any step in the chain is on the
-// HTTP-boundary set (i.e. is the source or target of an IMPLEMENTS /
-// ROUTES_TO / SERVES edge).
-func chainTouchesHTTP(chain []string, boundary map[string]bool) bool {
-	for _, id := range chain {
-		if boundary[id] {
+// buildConsumerEndpointFileSet returns a set of source-file paths that
+// contain at least one CONSUMER-side synthetic http_endpoint entity
+// (pattern_type="http_endpoint_client_synthesis"). Files where the only
+// http_endpoint entities are PRODUCER-side synthetics (handlers /
+// routes) are EXCLUDED — producer synthetics represent the handler's
+// own HTTP surface, not a cross-repo fetch call site.
+//
+// Used by RunProcessFlow as a file-coarse fallback for cross_stack when
+// a chain's entry lives in a file with consumer endpoints that the BFS
+// couldn't structurally reach (typically because the per-language
+// extractor doesn't surface class-field arrow methods as entities).
+func buildConsumerEndpointFileSet(doc *graph.Document) map[string]bool {
+	out := map[string]bool{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if strings.ToLower(e.Kind) != "http_endpoint" {
+			continue
+		}
+		if e.Properties == nil {
+			continue
+		}
+		if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+			out[e.SourceFile] = true
+			continue
+		}
+		// Fallback recognition for older synthetics that lost their
+		// pattern_type stamp: any http_endpoint stamped with a
+		// source_caller property is consumer-side by construction.
+		if _, hasCaller := e.Properties["source_caller"]; hasCaller {
+			out[e.SourceFile] = true
+		}
+	}
+	return out
+}
+
+// chainHasFetchesEdge returns true when any consecutive pair in the chain
+// is connected by a FETCHES edge (recorded in adj.fetches at adjacency-
+// build time). Used to relax the MinSteps gate for cross-repo chains so
+// the 2-step caller → consumer-endpoint bridge survives.
+func chainHasFetchesEdge(chain []string, adj *callsAdjacency) bool {
+	if adj == nil {
+		return false
+	}
+	for i := 1; i < len(chain); i++ {
+		if adj.fetches[edgeKey{chain[i-1], chain[i]}] {
 			return true
 		}
 	}
 	return false
 }
 
-// chainCrossesStack reports whether any step in the chain points at an
-// entity whose kind represents an HTTP / service boundary. Once the
-// FETCHES edge kind lands (#726) the detection is extended in
-// buildCallsAdjacency to flag the transition there.
-func chainCrossesStack(chain []string, byID map[string]*graph.Entity) bool {
+// chainCrossesRepoBoundary reports whether the BFS chain actually crosses
+// a repo boundary (#754). The two recognised signals are:
+//
+//  1. An edge in the chain is a FETCHES edge: the BFS stepped from a
+//     calling function into a consumer-side synthetic http_endpoint,
+//     which the cross-repo HTTP linker pairs with a producer in another
+//     repo. This is the canonical "definitely cross-stack" marker.
+//  2. A step in the chain is a CONSUMER-side synthetic http_endpoint
+//     entity (pattern_type="http_endpoint_client_synthesis"). Even
+//     without a direct FETCHES edge, landing on a consumer synthetic
+//     means the chain reached a cross-repo bridge node — the linker
+//     joins the same Name to a producer entity in another repo.
+//
+// The second argument returns a short human-readable reason that the
+// caller stamps onto `cross_stack_reason` for the emitted Process so
+// docs can say "this process enters another repo at step N via FETCHES".
+//
+// PRODUCER-side synthetics (pattern_type="http_endpoint_synthesis") are
+// deliberately NOT a cross-stack signal: they're the local handler for
+// an HTTP route that lives in this repo. A controller method calling
+// its same-repo route synthetic is intra-repo by definition.
+func chainCrossesRepoBoundary(
+	chain []string,
+	byID map[string]*graph.Entity,
+	adj *callsAdjacency,
+) (bool, string) {
+	// Walk pairwise — every transition has an originating edge.
+	for i := 1; i < len(chain); i++ {
+		from, to := chain[i-1], chain[i]
+		if adj != nil && adj.fetches[edgeKey{from, to}] {
+			return true, fmt.Sprintf("FETCHES edge at step %d (%s → %s)", i, from, to)
+		}
+		if isConsumerHTTPEndpoint(byID[to]) {
+			return true, fmt.Sprintf("consumer http_endpoint at step %d (%s)", i, to)
+		}
+	}
+	// Also check the entry itself — a Process whose entry IS a consumer
+	// synthetic (unusual but possible) still crosses repos.
+	if len(chain) > 0 && isConsumerHTTPEndpoint(byID[chain[0]]) {
+		return true, fmt.Sprintf("consumer http_endpoint at step 0 (%s)", chain[0])
+	}
+	return false, ""
+}
+
+// isConsumerHTTPEndpoint returns true when the entity is an http_endpoint
+// synthetic emitted by the consumer-side (client) synthesizer rather than
+// the producer-side route synthesizer. We discriminate on the
+// `pattern_type` property the synthesisers stamp on every entity:
+//
+//   - producer: pattern_type="http_endpoint_synthesis"
+//   - consumer: pattern_type="http_endpoint_client_synthesis"
+//
+// When pattern_type is missing (older docs) we fall back to a presence
+// check on `source_caller`, the property the consumer side always sets.
+func isConsumerHTTPEndpoint(e *graph.Entity) bool {
+	if e == nil {
+		return false
+	}
+	if strings.ToLower(e.Kind) != "http_endpoint" {
+		return false
+	}
+	if e.Properties == nil {
+		return false
+	}
+	if pt, ok := e.Properties["pattern_type"]; ok {
+		return pt == "http_endpoint_client_synthesis"
+	}
+	// Fallback: the consumer side stamps `source_caller` on every entity.
+	_, hasCaller := e.Properties["source_caller"]
+	return hasCaller
+}
+
+// chainCrossesExternalLib captures the OLD `chainCrossesStack ||
+// chainTouchesHTTP` heuristic (#754): the chain either includes a step
+// whose entity kind is HTTP/route-like, or touches the HTTP-boundary set
+// (IMPLEMENTS / ROUTES_TO / SERVES). It is preserved as a separate
+// boolean property so consumers that previously relied on the inflated
+// `cross_stack` flag for "this process touches an HTTP handler" can
+// switch to this label without losing that signal. The check is also
+// useful for documentation generators that want to highlight processes
+// terminating in third-party libraries (SCOPE.External / SCOPE.ExternalAPI).
+func chainCrossesExternalLib(chain []string, byID map[string]*graph.Entity, boundary map[string]bool) bool {
 	for _, id := range chain {
+		if boundary[id] {
+			return true
+		}
 		e, ok := byID[id]
 		if !ok {
 			continue
@@ -487,7 +693,8 @@ func chainCrossesStack(chain []string, byID map[string]*graph.Entity) bool {
 		case "http_endpoint",
 			strings.ToLower(string(EntityKindEndpoint)),
 			strings.ToLower(string(EntityKindRoute)),
-			strings.ToLower(string(EntityKindExternalAPI)):
+			strings.ToLower(string(EntityKindExternalAPI)),
+			"scope.external":
 			return true
 		}
 	}

--- a/internal/engine/process_flow_kinds.go
+++ b/internal/engine/process_flow_kinds.go
@@ -23,6 +23,21 @@ const RelationshipKindEntryPointOf = "ENTRY_POINT_OF"
 // this package without an internal/types import cycle.
 const RelationshipKindCalls = "CALLS"
 
+// RelationshipKindFetches is the consumer-side HTTP fetch edge: caller
+// function → synthetic consumer http_endpoint. Emitted by
+// http_endpoint_resolve.go for any consumer synthetic that carries a
+// resolvable `source_caller` property (per-language extractor wave-1
+// work in #721 will emit the same kind directly once it lands).
+//
+// The process-flow BFS treats FETCHES as a traversable edge AND as the
+// canonical signal that a chain crosses a repo boundary: the consumer
+// http_endpoint is the bridge node that the cross-repo HTTP linker
+// pairs with a producer-side endpoint in another repo. Without a
+// FETCHES edge into the consumer endpoint, the BFS has no way to reach
+// the bridge, and the chain can never be (correctly) marked
+// cross_stack=true. See issue #754.
+const RelationshipKindFetches = "FETCHES"
+
 // EntityKindEndpoint, EntityKindRoute, EntityKindExternalAPI are referenced
 // by chainCrossesStack and match the canonical SCOPE.* names produced by
 // the per-language extractors. Duplicated here as raw strings to avoid an

--- a/internal/engine/process_flow_test.go
+++ b/internal/engine/process_flow_test.go
@@ -159,12 +159,20 @@ func TestProcessFlow_DedupByEntryTerminal(t *testing.T) {
 }
 
 func TestProcessFlow_CrossStack(t *testing.T) {
-	// entry → call → http_endpoint. Should mark cross_stack=true.
+	// #754 — repo-aware cross_stack: a chain that lands on a CONSUMER-side
+	// synthetic http_endpoint (pattern_type=http_endpoint_client_synthesis)
+	// crosses a repo boundary. The consumer synthetic is the bridge node
+	// the cross-repo HTTP linker pairs with a producer in another repo.
 	doc := &graph.Document{Repo: "r"}
 	doc.Entities = []graph.Entity{
 		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
 		{ID: "svc", Name: "callService", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
-		{ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "ts", SourceFile: "api.ts"},
+		{
+			ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "ts", SourceFile: "api.ts",
+			Properties: map[string]string{
+				"pattern_type": "http_endpoint_client_synthesis",
+			},
+		},
 	}
 	doc.Relationships = []graph.Relationship{
 		{ID: "1", FromID: "entry", ToID: "svc", Kind: "CALLS"},
@@ -183,16 +191,56 @@ func TestProcessFlow_CrossStack(t *testing.T) {
 	}
 }
 
-func TestProcessFlow_CrossStackViaImplements(t *testing.T) {
-	// Handler function implements an http_endpoint via an IMPLEMENTS edge
-	// (not by appearing on the CALLS chain). The Process should still
-	// be marked cross_stack=true because the entry is on the HTTP boundary.
+func TestProcessFlow_CrossStackViaFetches(t *testing.T) {
+	// #754 — chain reaches a consumer endpoint via a FETCHES edge. The
+	// presence of the FETCHES edge alone is the canonical cross-stack
+	// signal: caller → consumer http_endpoint represents a real
+	// cross-repo call site.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleSubmit", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
+		{ID: "svc", Name: "callService", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
+		{
+			ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "ts", SourceFile: "x.ts",
+			Properties: map[string]string{"pattern_type": "http_endpoint_client_synthesis"},
+		},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "svc", Kind: "CALLS"},
+		{ID: "2", FromID: "svc", ToID: "ep", Kind: "FETCHES"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	var got, reason string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			got = e.Properties["cross_stack"]
+			reason = e.Properties["cross_stack_reason"]
+			break
+		}
+	}
+	if got != "true" {
+		t.Errorf("cross_stack = %q, want true (via FETCHES)", got)
+	}
+	if reason == "" {
+		t.Errorf("cross_stack_reason missing; want FETCHES-step annotation")
+	}
+}
+
+func TestProcessFlow_InternalHandlerNotCrossStack(t *testing.T) {
+	// #754 — regression for fixture-d false-labeling. An intra-repo HTTP
+	// handler that IMPLEMENTS a producer-side endpoint synthetic and
+	// terminates in an external library is NOT cross_stack (the BFS never
+	// leaves the source repo). It IS crosses_external_lib=true.
 	doc := &graph.Document{Repo: "r"}
 	doc.Entities = []graph.Entity{
 		{ID: "h", Name: "handleOrders", Kind: "SCOPE.Function", Language: "py", SourceFile: "api.py"},
 		{ID: "svc", Name: "callService", Kind: "SCOPE.Function", Language: "py", SourceFile: "api.py"},
 		{ID: "db", Name: "writeRecord", Kind: "SCOPE.Function", Language: "py", SourceFile: "db.py"},
-		{ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "py", SourceFile: "api.py"},
+		{
+			ID: "ep", Name: "http:POST:/api/orders", Kind: "http_endpoint", Language: "py", SourceFile: "api.py",
+			// Producer-side synthetic — NOT a cross-repo bridge.
+			Properties: map[string]string{"pattern_type": "http_endpoint_synthesis"},
+		},
 	}
 	doc.Relationships = []graph.Relationship{
 		{ID: "1", FromID: "h", ToID: "svc", Kind: "CALLS"},
@@ -200,15 +248,49 @@ func TestProcessFlow_CrossStackViaImplements(t *testing.T) {
 		{ID: "3", FromID: "h", ToID: "ep", Kind: "IMPLEMENTS"},
 	}
 	RunProcessFlow(doc, DefaultProcessFlowConfig())
-	var got string
+	var crossStack, externalLib string
 	for _, e := range doc.Entities {
 		if e.Kind == EntityKindProcess {
-			got = e.Properties["cross_stack"]
+			crossStack = e.Properties["cross_stack"]
+			externalLib = e.Properties["crosses_external_lib"]
 			break
 		}
 	}
-	if got != "true" {
-		t.Errorf("expected cross_stack=true via IMPLEMENTS, got %q", got)
+	if crossStack != "false" {
+		t.Errorf("intra-repo handler: cross_stack = %q, want false", crossStack)
+	}
+	if externalLib != "true" {
+		t.Errorf("intra-repo handler touching HTTP boundary: crosses_external_lib = %q, want true", externalLib)
+	}
+}
+
+func TestProcessFlow_ExternalLibTerminalNotCrossStack(t *testing.T) {
+	// #754 — chain terminating in SCOPE.External / SCOPE.ExternalAPI is
+	// crosses_external_lib=true but NOT cross_stack=true.
+	doc := &graph.Document{Repo: "r"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "handleJob", Kind: "SCOPE.Function", Language: "java", SourceFile: "Job.java"},
+		{ID: "svc", Name: "doWork", Kind: "SCOPE.Function", Language: "java", SourceFile: "Job.java"},
+		{ID: "ext", Name: "jakarta.enterprise", Kind: "SCOPE.External", Language: "java", SourceFile: ""},
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "svc", Kind: "CALLS"},
+		{ID: "2", FromID: "svc", ToID: "ext", Kind: "CALLS"},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+	var crossStack, externalLib string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			crossStack = e.Properties["cross_stack"]
+			externalLib = e.Properties["crosses_external_lib"]
+			break
+		}
+	}
+	if crossStack != "false" {
+		t.Errorf("external-lib terminal: cross_stack = %q, want false", crossStack)
+	}
+	if externalLib != "true" {
+		t.Errorf("external-lib terminal: crosses_external_lib = %q, want true", externalLib)
 	}
 }
 


### PR DESCRIPTION
Closes #754. Unblocks #755 (re-validation).

## Summary

Two-part fix for the cross_stack determination + consumer-endpoint connectivity gap that made PR #750's cross-stack narrative chains structurally impossible.

### Part 1 — Repo-aware cross_stack (process_flow.go)

`cross_stack=true` now requires a real cross-repo signal:

- **FETCHES edge in chain** — the BFS stepped from a caller function into a consumer http_endpoint synthetic via a FETCHES edge. The cross-repo HTTP linker pairs the consumer synthetic with a producer in another repo, so this is the canonical cross-stack marker.
- **Chain contains a consumer http_endpoint** (`pattern_type=http_endpoint_client_synthesis`). Landing on one means the chain reached a cross-repo bridge node.

The previous heuristic (`chainTouchesHTTP` + `chainCrossesStack`) is preserved as a separate `crosses_external_lib` property — captures the old intent ("touches an HTTP boundary or terminates in SCOPE.External") without conflating it with cross-repo traversal.

New properties on Process entities:
- `cross_stack` (now correct)
- `crosses_external_lib` (was previously folded into cross_stack)
- `cross_stack_reason` (e.g. "FETCHES edge at step 3 (caller → consumer-endpoint)")

### Part 2 — FETCHES edges from caller → consumer endpoint

Consumer synthetics carried a `source_caller` property but no resolver materialized it. The extended resolver:
1. Resolves precise `source_caller="Function:<name>"` lookups in the same file.
2. Falls back to fanning FETCHES edges across every plausible same-file container (Class/Module/file-Component) when precise resolution fails — necessary for JS/TS class-field arrow methods that the per-language extractor doesn't surface as discrete entities.

Also extended `jsFuncDeclRe` to recognise class-field arrows (`byId = (id) => ...`) and class-body methods (`byId(id) {}`) — without this, every consumer synthetic in a class was emitted without a `source_caller` property at all.

### Coordination with #721 W1

#721 W1 (in flight) emits FETCHES from per-language Python + Java extractors. This PR uses the same `RelationshipKindFetches` constant — both pathways converge on the same edge type. **File-disjoint** with #721 W1.

## Before / after measurements

Isolated daemon root `/tmp/arch-754`, baseline = `main@ae0b02d`, PR = this branch.

| Metric | fixture-d (baseline) | fixture-d (PR) | fixture-e (baseline) | fixture-e (PR) |
|---|---|---|---|---|
| processes | 197 | 199 | 300 | 300 |
| cross_stack | **156** (false +) | **0** ✓ | 0 | 0 ⚠ |
| crosses_external_lib | 0 (didn't exist) | **187** ✓ | 0 (didn't exist) | **127** ✓ |
| FETCHES edges | 0 | 0 (no consumer code) | 0 | **164** ✓ |

**fixture-d: 156 false-positive cross_stack eliminated** (these were intra-repo Quarkus controller chains terminating in jakarta.enterprise — never crossed a repo boundary). They're now correctly labeled `crosses_external_lib=true, cross_stack=false`.

**fixture-e: 164 FETCHES edges materialized** where 0 existed before (caller-side wiring for the 41 consumer endpoints — multi-fanout via the file/class fallback because the JS extractor doesn't emit class-field methods as entities).

### Known limitation (out of scope of #754)

fixture-e cross_stack count stays at 0 even with the new plumbing: the JS/TS extractor doesn't emit class-field arrow methods as discrete entities, so the BFS entry pool never roots a chain in `branches.service.js`-style files. The structural plumbing (FETCHES edges + repo-aware detection) is in place; once the JS extractor surfaces class methods as entities (separate ticket), fixture-e will produce cross_stack chains naturally without any change to #754's logic.

## Test plan

- [x] `go test ./...` green (full suite)
- [x] 4 new tests in `process_flow_test.go`: chain reaches consumer endpoint, chain traverses FETCHES, intra-repo handler regression (the fixture-d false-positive), external-lib terminal regression
- [x] 3 new tests in `http_endpoint_resolve_test.go`: precise caller resolution, same-file fallback, no-match keep behaviour
- [x] Quality fixtures preserved (entity counts unchanged on producer-side; relationship counts grow by FETCHES additions only)
- [x] Baseline + PR comparison on fixture-d + fixture-e (table above)

## Files touched

- `internal/types/kinds.go` — `RelationshipKindFetches` (1 line, will trivially conflict with #721 W1's same addition)
- `internal/engine/process_flow.go` — repo-aware cross_stack, FETCHES traversal, file-level fallback
- `internal/engine/process_flow_kinds.go` — `RelationshipKindFetches` re-export
- `internal/engine/process_flow_test.go` — 4 new tests
- `internal/engine/http_endpoint_resolve.go` — `source_caller` → FETCHES wiring + multi-level fallback
- `internal/engine/http_endpoint_resolve_test.go` — 3 new tests
- `internal/engine/http_endpoint_client_synthesis.go` — class-field arrow + class-method recognition in `jsFuncDeclRe`
- `cmd/archigraph/index.go` — extended resolver stats line

## Recommendation on #721 W1 coordination

#721 W1 emits **FETCHES** edges (read the WIP `internal/engine/http_endpoint_python_client.go`). This PR follows the same convention — both define `RelationshipKindFetches` independently; they'll merge with a one-line conflict in `kinds.go` and `AllRelationshipKinds()`. No design changes needed in either.

Daemon cleanup: only the test harness invoked the in-process indexer; no long-running daemon was spawned during measurement (ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-754 set for isolation but the path was unused since `go test` runs the indexer directly).