### PR TITLE
[#769] Phantom CALLS edges: promote cross-repo Links into BFS-traversable graph relationships

### DIFF
--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -1,14 +1,19 @@
 package cli
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"github.com/spf13/cobra"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/engine"
+	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/links"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -28,10 +33,13 @@ func newLinksCmd() *cobra.Command {
 }
 
 // RunLinksForGroup is the watcher-facing entry point. It re-runs the
-// three cross-repo link passes for a named group, writing all output
-// to the canonical archigraph home. Returns nil when the group has
-// no per-repo graph.json files yet (links are a no-op until the
-// indexer has run at least once).
+// cross-repo link passes for a named group, then runs the phantom-edge
+// pass (#769) to promote cross-repo CALLS links into phantom Relationships
+// on each source repo's graph.Document, and re-runs RunProcessFlow on
+// any doc that gained phantom edges so Process entities reflect the new
+// cross-repo chains. Writes all output to the canonical archigraph home.
+// Returns nil when the group has no per-repo graph.json files yet
+// (links are a no-op until the indexer has run at least once).
 func RunLinksForGroup(group string) error {
 	groups, err := registry.Groups()
 	if err != nil {
@@ -56,8 +64,14 @@ func RunLinksForGroup(group string) error {
 		return err
 	}
 	defer cleanup()
-	if _, err := links.RunAllPasses(group, graphsDir, ""); err != nil {
+	res, err := links.RunAllPasses(group, graphsDir, "")
+	if err != nil {
 		return err
+	}
+	// P5 — phantom-edge promotion (#769).
+	if _, perr := runPhantomEdgePass(group, cfg, res.OutLinks); perr != nil {
+		// Best-effort: log but don't fail the link pass.
+		fmt.Fprintf(os.Stderr, "archigraph: phantom-edge pass warning: %v\n", perr)
 	}
 	return nil
 }
@@ -119,6 +133,14 @@ func runLinksForGroup(cmd *cobra.Command, group string) error {
 			r.Pass, r.LinksAdded, r.Candidates, r.Skipped)
 	}
 	fmt.Fprintf(out, "  output: %s\n", res.OutLinks)
+
+	// P5 — phantom-edge promotion (#769).
+	phantomAdded, perr := runPhantomEdgePass(group, cfg, res.OutLinks)
+	if perr != nil {
+		fmt.Fprintf(out, "  phantom-edge pass warning: %v\n", perr)
+	} else {
+		fmt.Fprintf(out, "  phantom  edges_added=%-4d\n", phantomAdded)
+	}
 	return nil
 }
 
@@ -149,4 +171,188 @@ func stageGraphsDir(cfg *registry.GroupConfig) (string, func(), error) {
 		}
 	}
 	return tmp, cleanup, nil
+}
+
+// runPhantomEdgePass is the P5 phantom-edge promotion pass (#769).
+//
+// After links.RunAllPasses writes <group>-links.json, this pass:
+//  1. Reads the links file.
+//  2. Loads each source repo's graph.Document from disk.
+//  3. Calls links.PromoteToPhantomEdges to inject phantom CALLS edges.
+//  4. For each mutated document, strips the stale SCOPE.Process entities
+//     (they were emitted before phantom edges existed) and re-runs
+//     engine.RunProcessFlow so Process entities reflect the new
+//     cross-repo chains.
+//  5. Writes each updated document back to disk atomically.
+//
+// Returns the total number of phantom edges added across all repos.
+// On error, returns what was added so far plus the first error — the
+// caller decides whether to treat it as fatal.
+//
+// Architecture note (why here and not inside links.RunAllPasses):
+// RunAllPasses operates on the links-internal `repoGraph` projection
+// (no internal/graph import). Moving phantom-edge logic there would add
+// a large bidirectional import between internal/links ↔ internal/graph ↔
+// internal/engine. Placing it in the CLI layer (which already imports all
+// three packages) keeps the dependency arrow pointing inward.
+func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath string) (int, error) {
+	// Read the just-written links file.
+	allLinks, err := links.LoadLinksDocument(linksPath)
+	if err != nil {
+		return 0, fmt.Errorf("phantom-edge pass: load links: %w", err)
+	}
+	if len(allLinks) == 0 {
+		return 0, nil // nothing to promote
+	}
+
+	// Load each repo's graph.Document.
+	docs := make(map[string]*graph.Document, len(cfg.Repos))
+	graphPaths := make(map[string]string, len(cfg.Repos)) // slug → on-disk path
+	for _, r := range cfg.Repos {
+		p := daemon.GraphPathForRepo(r.Path)
+		if _, err := os.Stat(p); err != nil {
+			continue // repo not indexed yet
+		}
+		doc, err := loadGraphDocument(p)
+		if err != nil {
+			return 0, fmt.Errorf("phantom-edge pass: load %s: %w", r.Slug, err)
+		}
+		docs[r.Slug] = doc
+		graphPaths[r.Slug] = p
+	}
+	if len(docs) == 0 {
+		return 0, nil
+	}
+
+	// Determine which source repos will receive phantom edges so we can
+	// strip stale SCOPE.Process entities and re-run process flow.
+	affectedRepos := make(map[string]bool)
+	for _, lk := range allLinks {
+		if !strings.EqualFold(lk.Relation, links.RelationCalls) {
+			continue
+		}
+		srcRepo, _, ok := splitKey(lk.Source)
+		if ok {
+			affectedRepos[srcRepo] = true
+		}
+	}
+
+	// Promote phantom edges.
+	added, err := links.PromoteToPhantomEdges(allLinks, docs, group)
+	if err != nil {
+		return added, fmt.Errorf("phantom-edge pass: promote: %w", err)
+	}
+
+	// Re-run RunProcessFlow on each affected doc + write back to disk.
+	slugs := sortedStringKeys(affectedRepos)
+	for _, slug := range slugs {
+		doc, ok := docs[slug]
+		if !ok {
+			continue
+		}
+		// Strip stale SCOPE.Process entities + their edges so the re-run
+		// starts clean. Process entities have Kind=engine.EntityKindProcess.
+		doc.Entities, doc.Relationships = stripProcessEntities(doc)
+
+		// Re-run process flow.
+		_ = engine.RunProcessFlow(doc, engine.DefaultProcessFlowConfig())
+
+		// Update stats.
+		doc.Stats.Entities = len(doc.Entities)
+		doc.Stats.Relationships = len(doc.Relationships)
+
+		// Sort entities + relationships for determinism (mirrors index.go).
+		sort.SliceStable(doc.Entities, func(a, b int) bool {
+			return doc.Entities[a].ID < doc.Entities[b].ID
+		})
+		sort.SliceStable(doc.Relationships, func(a, b int) bool {
+			ra, rb := &doc.Relationships[a], &doc.Relationships[b]
+			if ra.FromID != rb.FromID {
+				return ra.FromID < rb.FromID
+			}
+			if ra.ToID != rb.ToID {
+				return ra.ToID < rb.ToID
+			}
+			return ra.Kind < rb.Kind
+		})
+
+		// Write atomically.
+		p := graphPaths[slug]
+		if werr := graph.WriteAtomic(p, doc, false); werr != nil {
+			return added, fmt.Errorf("phantom-edge pass: write %s: %w", slug, werr)
+		}
+		fmt.Fprintf(os.Stderr,
+			"archigraph: phantom-edge pass group=%s repo=%s phantom_edges=%d\n",
+			group, slug, added)
+	}
+	return added, nil
+}
+
+// stripProcessEntities returns new entity and relationship slices with all
+// SCOPE.Process entities and their STEP_IN_PROCESS / ENTRY_POINT_OF edges
+// removed. Used before re-running RunProcessFlow after phantom-edge injection.
+func stripProcessEntities(doc *graph.Document) ([]graph.Entity, []graph.Relationship) {
+	// Collect process entity IDs to drop.
+	processIDs := make(map[string]bool)
+	for _, e := range doc.Entities {
+		if e.Kind == string(engine.EntityKindProcess) {
+			processIDs[e.ID] = true
+		}
+	}
+	if len(processIDs) == 0 {
+		return doc.Entities, doc.Relationships
+	}
+	entities := doc.Entities[:0:0]
+	for _, e := range doc.Entities {
+		if !processIDs[e.ID] {
+			entities = append(entities, e)
+		}
+	}
+	rels := doc.Relationships[:0:0]
+	for _, r := range doc.Relationships {
+		// Drop STEP_IN_PROCESS and ENTRY_POINT_OF edges for removed processes.
+		if processIDs[r.FromID] || processIDs[r.ToID] {
+			if r.Kind == string(engine.RelationshipKindStepInProcess) ||
+				r.Kind == string(engine.RelationshipKindEntryPointOf) {
+				continue
+			}
+		}
+		rels = append(rels, r)
+	}
+	return entities, rels
+}
+
+// loadGraphDocument reads and decodes a graph.json file from disk.
+func loadGraphDocument(path string) (*graph.Document, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	var doc graph.Document
+	if err := json.NewDecoder(f).Decode(&doc); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", path, err)
+	}
+	return &doc, nil
+}
+
+// splitKey is a local thin wrapper around the shape used by Link.Source/Target:
+// "<repo>::<entityID>".
+func splitKey(key string) (repo, entityID string, ok bool) {
+	const sep = "::"
+	i := strings.Index(key, sep)
+	if i <= 0 || i+len(sep) >= len(key) {
+		return "", "", false
+	}
+	return key[:i], key[i+len(sep):], true
+}
+
+// sortedStringKeys returns the sorted key list of a map[string]bool.
+func sortedStringKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
 }

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -172,7 +172,10 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 			// consumer endpoint = 2 steps) but the cross-stack signal is
 			// the load-bearing semantic, so keep them.
 			minSteps := cfg.MinSteps
-			if chainHasFetchesEdge(t, adj) {
+			if chainHasFetchesEdge(t, adj) || chainCrossesRepo(t, adj) {
+				// #769 — phantom cross-repo CALLS chains are typically
+				// shallow (caller → phantom terminal = 2 steps). Relax the
+				// MinSteps gate so they survive emission.
 				minSteps = 2
 			}
 			if len(t) < minSteps {
@@ -223,7 +226,14 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 		chain := best[k]
 		entry := byID[chain[0]]
 		terminal := byID[chain[len(chain)-1]]
-		if entry == nil || terminal == nil {
+		// #769 — phantom cross-repo terminals live in another repo's
+		// Entities slice and are intentionally absent from this doc's byID
+		// map. Allow chains that end on a phantom edge even when terminal
+		// is nil: the phantom edge Properties carry the target_repo and
+		// link_method so we can still emit a meaningful Process label.
+		terminalIsPhantom := terminal == nil && len(chain) >= 2 &&
+			adj != nil && adj.phantom[edgeKey{chain[len(chain)-2], chain[len(chain)-1]}]
+		if entry == nil || (terminal == nil && !terminalIsPhantom) {
 			continue
 		}
 		crossStack, crossReason := chainCrossesRepoBoundary(chain, byID, adj)
@@ -245,17 +255,37 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 		}
 		crossesExternalLib := chainCrossesExternalLib(chain, byID, httpBoundary)
 		processID := computeProcessID(doc.Repo, chain)
-		label := fmt.Sprintf("%s → %s", entry.Name, terminal.Name)
+
+		// Resolve terminal name/ID — phantom terminals are not in byID.
+		terminalID := chain[len(chain)-1]
+		terminalName := terminalID // fallback for phantom targets
+		if terminal != nil {
+			terminalID = terminal.ID
+			terminalName = terminal.Name
+		} else if terminalIsPhantom {
+			// Try to derive a human-readable label from the phantom edge
+			// Properties. This makes the Process label less cryptic.
+			phantomEdge := phantomEdgeForStep(chain[len(chain)-2], chain[len(chain)-1], doc)
+			if phantomEdge != nil {
+				if tgt := phantomEdge.Properties["target_repo"]; tgt != "" {
+					terminalName = tgt + ":<cross-repo>"
+				}
+			}
+		}
+		label := fmt.Sprintf("%s → %s", entry.Name, terminalName)
 
 		props := map[string]string{
 			"entry_id":              entry.ID,
 			"entry_name":            entry.Name,
-			"terminal_id":           terminal.ID,
+			"terminal_id":           terminalID,
 			"step_count":            strconv.Itoa(len(chain)),
 			"cross_stack":           strconv.FormatBool(crossStack),
 			"crosses_external_lib":  strconv.FormatBool(crossesExternalLib),
 			"chain":                 strings.Join(chain, ","),
 			"chain_labels":          strings.Join(chainLabels(chain, byID), " → "),
+		}
+		if terminalIsPhantom {
+			props["terminal_is_phantom"] = "true"
 		}
 		if crossStack && crossReason != "" {
 			props["cross_stack_reason"] = crossReason
@@ -328,10 +358,15 @@ func clampConfig(cfg ProcessFlowConfig) ProcessFlowConfig {
 // pairs that originated from a FETCHES edge so the cross-stack detector
 // can distinguish "this step was reached by traversing a fetch boundary"
 // from "this step was reached by an ordinary intra-repo CALLS edge".
+// The `phantom` side-set records (from,to) pairs that originated from a
+// phantom CALLS edge (cross_repo="true" property) injected by the phantom-
+// edge pass (#769). chainCrossesRepo uses this to mark Process entities
+// cross_stack=true when a chain traverses a phantom edge.
 type callsAdjacency struct {
 	out     map[string][]string
 	in      map[string]int
 	fetches map[edgeKey]bool
+	phantom map[edgeKey]bool
 }
 
 // edgeKey is a directed (from,to) edge identity.
@@ -349,17 +384,19 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		out:     make(map[string][]string),
 		in:      make(map[string]int),
 		fetches: make(map[edgeKey]bool),
+		phantom: make(map[edgeKey]bool),
 	}
 	seen := make(map[string]map[string]bool)
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
 		isFetches := r.Kind == RelationshipKindFetches
+		isPhantom := isPhantomCallsEdge(r)
 		if r.Kind != string(RelationshipKindCalls) && !isFetches {
 			continue
 		}
-		// Only CALLS edges are confidence-gated; FETCHES is a structural
-		// extraction-time primitive and is always trusted.
-		if !isFetches && !confidenceOK(r) {
+		// Only CALLS edges are confidence-gated; FETCHES and phantom edges are
+		// structural primitives always trusted.
+		if !isFetches && !isPhantom && !confidenceOK(r) {
 			continue
 		}
 		if r.FromID == r.ToID {
@@ -370,10 +407,13 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		}
 		if seen[r.FromID][r.ToID] {
 			// Already added under a different edge kind. Still want to
-			// record the fetches flag if this iteration provides it —
-			// FETCHES wins (cross-stack signal is preserved).
+			// record the fetches/phantom flag if this iteration provides it —
+			// both cross-stack signals are preserved.
 			if isFetches {
 				a.fetches[edgeKey{r.FromID, r.ToID}] = true
+			}
+			if isPhantom {
+				a.phantom[edgeKey{r.FromID, r.ToID}] = true
 			}
 			continue
 		}
@@ -383,11 +423,27 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		if isFetches {
 			a.fetches[edgeKey{r.FromID, r.ToID}] = true
 		}
+		if isPhantom {
+			a.phantom[edgeKey{r.FromID, r.ToID}] = true
+		}
 	}
 	for k := range a.out {
 		sort.Strings(a.out[k])
 	}
 	return a
+}
+
+// isPhantomCallsEdge reports whether a CALLS relationship is a phantom
+// cross-repo edge injected by the phantom-edge pass (#769). Phantom
+// edges carry cross_repo="true" in their Properties.
+func isPhantomCallsEdge(r *graph.Relationship) bool {
+	if r.Kind != string(RelationshipKindCalls) {
+		return false
+	}
+	if r.Properties == nil {
+		return false
+	}
+	return r.Properties["cross_repo"] == "true"
 }
 
 // confidenceOK returns true when the relationship has either no
@@ -631,6 +687,13 @@ func chainCrossesRepoBoundary(
 		if adj != nil && adj.fetches[edgeKey{from, to}] {
 			return true, fmt.Sprintf("FETCHES edge at step %d (%s → %s)", i, from, to)
 		}
+		// #769 — phantom CALLS edge: cross-repo link promoted by the
+		// phantom-edge pass. The target entity lives in another repo; the
+		// BFS terminates there (no outgoing edges), making this the final
+		// step. Separate label from crosses_external_lib.
+		if adj != nil && adj.phantom[edgeKey{from, to}] {
+			return true, fmt.Sprintf("phantom cross-repo CALLS edge at step %d (%s → %s)", i, from, to)
+		}
 		if isConsumerHTTPEndpoint(byID[to]) {
 			return true, fmt.Sprintf("consumer http_endpoint at step %d (%s)", i, to)
 		}
@@ -641,6 +704,44 @@ func chainCrossesRepoBoundary(
 		return true, fmt.Sprintf("consumer http_endpoint at step 0 (%s)", chain[0])
 	}
 	return false, ""
+}
+
+// phantomEdgeForStep returns the first phantom CALLS relationship between
+// fromID and toID in the document, or nil when no such edge exists.
+// Used to extract Properties (target_repo, link_method) for label generation
+// when the terminal entity is a phantom target absent from byID.
+func phantomEdgeForStep(fromID, toID string, doc *graph.Document) *graph.Relationship {
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.FromID != fromID || r.ToID != toID {
+			continue
+		}
+		if r.Kind != string(RelationshipKindCalls) {
+			continue
+		}
+		if r.Properties != nil && r.Properties["cross_repo"] == "true" {
+			return r
+		}
+	}
+	return nil
+}
+
+// chainCrossesRepo is a convenience predicate that returns true iff any
+// step in the chain is connected to the next by a phantom cross-repo CALLS
+// edge (#769). Used by tests and by RunProcessFlow's MinSteps relaxation.
+// Distinct from chainCrossesRepoBoundary which also fires on FETCHES edges
+// and consumer http_endpoint kinds — this one is narrowly scoped to
+// phantom edges only, which is what the phantom-edge pass emits.
+func chainCrossesRepo(chain []string, adj *callsAdjacency) bool {
+	if adj == nil {
+		return false
+	}
+	for i := 1; i < len(chain); i++ {
+		if adj.phantom[edgeKey{chain[i-1], chain[i]}] {
+			return true
+		}
+	}
+	return false
 }
 
 // isConsumerHTTPEndpoint returns true when the entity is an http_endpoint

--- a/internal/engine/process_flow_test.go
+++ b/internal/engine/process_flow_test.go
@@ -358,3 +358,88 @@ func TestProcessFlow_DeterministicAcrossRuns(t *testing.T) {
 		}
 	}
 }
+
+func TestProcessFlow_PhantomEdgeCrossStack(t *testing.T) {
+	// #769 — a phantom CALLS edge (cross_repo="true") injected by the
+	// phantom-edge pass should mark the resulting Process cross_stack=true
+	// with a cross_stack_reason indicating the phantom edge step.
+	doc := &graph.Document{Repo: "fixture-b"}
+	doc.Entities = []graph.Entity{
+		{ID: "entry", Name: "fetchUsers", Kind: "SCOPE.Function", Language: "ts", SourceFile: "svc.ts"},
+		{ID: "caller", Name: "callUsers", Kind: "SCOPE.Function", Language: "ts", SourceFile: "svc.ts"},
+		// phantom target lives in another repo — NOT in doc.Entities
+	}
+	doc.Relationships = []graph.Relationship{
+		{ID: "1", FromID: "entry", ToID: "caller", Kind: "CALLS"},
+		{
+			ID:     "2",
+			FromID: "caller",
+			ToID:   "fixture-a-handler-xyz",
+			Kind:   "CALLS",
+			Properties: map[string]string{
+				"cross_repo":  "true",
+				"target_repo": "fixture-a",
+				"link_method": "http",
+				"via":         "phantom_edge_pass_#769 group=test",
+			},
+		},
+	}
+	RunProcessFlow(doc, DefaultProcessFlowConfig())
+
+	var crossStack, reason string
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			crossStack = e.Properties["cross_stack"]
+			reason = e.Properties["cross_stack_reason"]
+			break
+		}
+	}
+	if crossStack != "true" {
+		t.Errorf("cross_stack = %q, want true for phantom-edge chain", crossStack)
+	}
+	if reason == "" {
+		t.Errorf("cross_stack_reason should be set for phantom-edge chains")
+	}
+	if !strings.Contains(reason, "phantom") {
+		t.Errorf("cross_stack_reason %q should mention 'phantom'", reason)
+	}
+}
+
+func TestProcessFlow_PhantomEdgeMinStepsRelaxed(t *testing.T) {
+	// #769 — a 2-step chain caller→phantom should survive even when
+	// cfg.MinSteps=3, because the phantom edge relaxes the gate.
+	doc := &graph.Document{Repo: "b"}
+	doc.Entities = []graph.Entity{
+		{ID: "caller", Name: "doFetch", Kind: "SCOPE.Function", Language: "ts", SourceFile: "x.ts"},
+	}
+	doc.Relationships = []graph.Relationship{
+		{
+			ID:     "p1",
+			FromID: "caller",
+			ToID:   "remote-handler",
+			Kind:   "CALLS",
+			Properties: map[string]string{
+				"cross_repo":  "true",
+				"target_repo": "a",
+				"link_method": "http",
+				"via":         "phantom_edge_pass_#769 group=g",
+			},
+		},
+	}
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 3
+	RunProcessFlow(doc, cfg)
+
+	var found bool
+	for _, e := range doc.Entities {
+		if e.Kind == EntityKindProcess {
+			found = true
+			if e.Properties["cross_stack"] != "true" {
+				t.Errorf("cross_stack = %q, want true", e.Properties["cross_stack"])
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected a Process entity for 2-step phantom chain, got none")
+	}
+}

--- a/internal/links/phantom_edges.go
+++ b/internal/links/phantom_edges.go
@@ -1,0 +1,200 @@
+// phantom_edges.go — P5 pass (#769).
+//
+// After the HTTP/Kafka/WS link passes emit cross-repo Link records into
+// <group>-links.json, this pass promotes every Link with
+//
+//	relation = "calls"
+//	method   ∈ {"http", "kafka_topic", "ws_channel"}
+//
+// into a phantom Relationship inside the SOURCE repo's graph.Document. The
+// phantom edge has Kind="CALLS" plus a set of properties that annotate it as
+// a cross-repo terminal step:
+//
+//	cross_repo:  "true"
+//	target_repo: "<slug>"       (the repo slug encoded in Link.Target)
+//	link_method: link.Method    ("http", "kafka_topic", "ws_channel")
+//	via:         "phantom_edge_pass_#769"
+//
+// The target entity ID (Link.Target) lives in a different repo's Entities
+// slice and will NOT appear in the source doc's byID map — that is
+// intentional. The BFS in RunProcessFlow terminates at any node with no
+// outgoing CALLS edges; a phantom edge target has no outgoing edges by
+// definition, so the chain terminates there. RunProcessFlow's
+// chainCrossesRepo helper (see process_flow.go) detects the
+// "cross_repo=true" property on the relationship and marks the resulting
+// Process entity cross_stack=true.
+//
+// Why this file vs. modifying RunAllPasses inline?
+//
+// RunAllPasses operates on []repoGraph (a links-internal projection) and
+// does not import internal/graph — adding phantom-edge emission there would
+// require either a new package dependency or passing graph.Document maps as
+// parameters. Instead we expose PromoteToPhantomEdges as a standalone
+// function that the CLI/daemon passes call AFTER links.RunAllPasses returns,
+// keeping the links package free of graph.Document knowledge and letting
+// callers (RunLinksForGroup, daemonRebuildFunc) hold both the links result
+// and the loaded documents.
+//
+// Refs: issue #769, PR #769.
+package links
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// phantomEdgeMethods lists the Link.Method values that are promoted to
+// phantom CALLS edges. Only CALLS-relation links with these methods
+// represent actual code calling across repo boundaries; IMPORTS,
+// SHARED_LABEL, and STRING_MATCH links are not traversable call steps.
+var phantomEdgeMethods = map[string]bool{
+	MethodHTTP:       true,
+	"kafka_topic":    true,
+	"ws_channel":     true,
+}
+
+// PhantomEdgeResult summarises one PromoteToPhantomEdges call.
+type PhantomEdgeResult struct {
+	PassResult
+	PhantomEdgesAdded int
+	ReposUpdated      int
+}
+
+// PromoteToPhantomEdges promotes cross-repo CALLS Link records into
+// phantom Relationships on the source repo's *graph.Document. docs maps
+// repo slug → pointer to the in-memory document that will be mutated.
+// group is used only for logging / the "via" property annotation.
+//
+// Only links with relation="calls" and a method in phantomEdgeMethods
+// are promoted; others are silently skipped.
+//
+// Edges are appended in sorted (Source, Target) order to preserve
+// determinism. Duplicate phantom edges (same Source, Target, Method) are
+// deduplicated.
+//
+// Returns the number of phantom edges added across all repos and the
+// first error encountered (remaining repos are still processed).
+func PromoteToPhantomEdges(
+	links []Link,
+	docs map[string]*graph.Document,
+	group string,
+) (added int, err error) {
+	// Collect candidate links: relation=calls, method ∈ phantomEdgeMethods.
+	type candidate struct {
+		link      Link
+		sourceRepo string
+		targetRepo string
+		sourceID   string // local entity ID in source repo
+		targetID   string // entity ID in target repo (opaque to source)
+	}
+
+	var candidates []candidate
+	for _, lk := range links {
+		if !strings.EqualFold(lk.Relation, RelationCalls) {
+			continue
+		}
+		if !phantomEdgeMethods[strings.ToLower(lk.Method)] {
+			continue
+		}
+		srcRepo, srcID, ok1 := splitEntityKey(lk.Source)
+		tgtRepo, tgtID, ok2 := splitEntityKey(lk.Target)
+		if !ok1 || !ok2 || srcRepo == tgtRepo {
+			continue
+		}
+		candidates = append(candidates, candidate{
+			link:       lk,
+			sourceRepo: srcRepo,
+			targetRepo: tgtRepo,
+			sourceID:   srcID,
+			targetID:   tgtID,
+		})
+	}
+
+	// Sort by (Source, Target) for determinism before appending.
+	sort.Slice(candidates, func(i, j int) bool {
+		if candidates[i].link.Source != candidates[j].link.Source {
+			return candidates[i].link.Source < candidates[j].link.Source
+		}
+		return candidates[i].link.Target < candidates[j].link.Target
+	})
+
+	// Dedup within the candidate list itself: same (Source, Target, Method)
+	// must not produce two phantom edges.
+	type edgeKey struct{ source, target, method string }
+	emitted := make(map[edgeKey]bool)
+
+	// Track which docs need their existing SCOPE.Process entities stripped
+	// before re-running RunProcessFlow. We do this lazily per doc.
+	docsUpdated := make(map[string]bool)
+
+	for _, c := range candidates {
+		doc, ok := docs[c.sourceRepo]
+		if !ok {
+			// Source repo's document not present — skip silently.
+			// This can happen when a partial group has docs missing.
+			continue
+		}
+
+		ek := edgeKey{c.link.Source, c.link.Target, c.link.Method}
+		if emitted[ek] {
+			continue
+		}
+		emitted[ek] = true
+
+		relID := graph.RelationshipID(c.sourceID, c.targetID, "CALLS:phantom:"+c.link.Method)
+		rel := graph.Relationship{
+			ID:     relID,
+			FromID: c.sourceID,
+			ToID:   c.targetID,
+			Kind:   "CALLS",
+			Properties: map[string]string{
+				"cross_repo":  "true",
+				"target_repo": c.targetRepo,
+				"link_method": c.link.Method,
+				"via":         fmt.Sprintf("phantom_edge_pass_#769 group=%s", group),
+			},
+		}
+		doc.Relationships = append(doc.Relationships, rel)
+		added++
+		docsUpdated[c.sourceRepo] = true
+	}
+
+	return added, nil
+}
+
+// splitEntityKey parses a Link.Source or Link.Target string of the form
+// "<repo>::<entityID>" into its components. Returns ok=false when the
+// string doesn't match the expected shape.
+func splitEntityKey(key string) (repo, entityID string, ok bool) {
+	const sep = "::"
+	i := strings.Index(key, sep)
+	if i <= 0 || i+len(sep) >= len(key) {
+		return "", "", false
+	}
+	return key[:i], key[i+len(sep):], true
+}
+
+// LoadLinksDocument reads a group's links.json file and returns its Link
+// slice. Returns nil,nil when the file does not exist yet (group has not
+// been linked). Exported so callers outside the links package (cli, daemon)
+// can read the links after RunAllPasses has written them.
+func LoadLinksDocument(path string) ([]Link, error) {
+	f, err := os.Open(path)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("open links: %w", err)
+	}
+	defer f.Close()
+	var d Document
+	if err := json.NewDecoder(f).Decode(&d); err != nil {
+		return nil, fmt.Errorf("decode links: %w", err)
+	}
+	return d.Links, nil
+}

--- a/internal/links/phantom_edges_integration_test.go
+++ b/internal/links/phantom_edges_integration_test.go
@@ -1,0 +1,187 @@
+package links
+
+import (
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestPhantomEdges_CrossRepoBFSChain is an end-to-end integration test
+// (#769) that exercises the full pipeline:
+//
+//  1. Two synthetic graph.Documents (fixture-b, fixture-a) connected by a
+//     cross-repo HTTP CALLS link.
+//  2. PromoteToPhantomEdges injects a phantom CALLS edge into fixture-b's
+//     document.
+//  3. engine.RunProcessFlow on fixture-b produces a cross_stack=true Process
+//     entity whose chain ends at the phantom terminal (a handler in fixture-a).
+//
+// The test asserts:
+//   - At least one phantom edge was added to fixture-b.
+//   - At least one SCOPE.Process entity in fixture-b has cross_stack=true.
+//   - That Process entity's cross_stack_reason mentions "phantom".
+//   - That Process entity has terminal_is_phantom=true.
+//   - No SCOPE.Process in fixture-b is incorrectly labeled cross_stack=true
+//     for the intra-repo chain (the pure CALLS-only chain within fixture-b).
+//
+// This covers the "fixture-b/c → fixture-a" chain scenario described in
+// issue #769 acceptance criteria.
+func TestPhantomEdges_CrossRepoBFSChain(t *testing.T) {
+	// ---- Fixture-a (producer) ----
+	// Has a handler entity that the HTTP link targets.
+	docA := &graph.Document{
+		Repo: "fixture-a",
+		Entities: []graph.Entity{
+			{ID: "handler1", Name: "getUsersHandler", Kind: "SCOPE.Function", Language: "python", SourceFile: "api.py"},
+		},
+	}
+
+	// ---- Fixture-b (consumer) ----
+	// Has a consumer call chain: entry → svc → (phantom edge to fixture-a).
+	// The consumer endpoint synthetic is the bridge the link pass matched on.
+	docB := &graph.Document{
+		Repo: "fixture-b",
+		Entities: []graph.Entity{
+			{ID: "entry", Name: "loadUsers", Kind: "SCOPE.Function", Language: "ts", SourceFile: "users.ts"},
+			{ID: "svc", Name: "fetchFromAPI", Kind: "SCOPE.Function", Language: "ts", SourceFile: "users.ts"},
+			// An intra-b chain that should NOT be cross_stack.
+			{ID: "entry2", Name: "localOp", Kind: "SCOPE.Function", Language: "ts", SourceFile: "local.ts"},
+			{ID: "dep1", Name: "doSomething", Kind: "SCOPE.Function", Language: "ts", SourceFile: "local.ts"},
+			{ID: "dep2", Name: "helper", Kind: "SCOPE.Function", Language: "ts", SourceFile: "local.ts"},
+			{ID: "dep3", Name: "finish", Kind: "SCOPE.Function", Language: "ts", SourceFile: "local.ts"},
+		},
+		Relationships: []graph.Relationship{
+			// Consumer CALLS chain (no phantom yet).
+			{ID: "r1", FromID: "entry", ToID: "svc", Kind: "CALLS"},
+			// Intra-b chain (should remain cross_stack=false after phantom pass).
+			{ID: "r2", FromID: "entry2", ToID: "dep1", Kind: "CALLS"},
+			{ID: "r3", FromID: "dep1", ToID: "dep2", Kind: "CALLS"},
+			{ID: "r4", FromID: "dep2", ToID: "dep3", Kind: "CALLS"},
+		},
+	}
+
+	// ---- Cross-repo Link (as produced by the HTTP pass) ----
+	// Source: fixture-b::svc (the caller in fixture-b)
+	// Target: fixture-a::handler1 (the handler in fixture-a)
+	crossLinks := []Link{
+		{
+			ID:       "http1",
+			Source:   entityKey("fixture-b", "svc"),
+			Target:   entityKey("fixture-a", "handler1"),
+			Relation: RelationCalls,
+			Method:   MethodHTTP,
+		},
+	}
+
+	docs := map[string]*graph.Document{
+		"fixture-a": docA,
+		"fixture-b": docB,
+	}
+
+	// ---- Step 1: promote phantom edges ----
+	added, err := PromoteToPhantomEdges(crossLinks, docs, "test-group")
+	if err != nil {
+		t.Fatalf("PromoteToPhantomEdges: %v", err)
+	}
+	if added != 1 {
+		t.Errorf("phantom edges added = %d, want 1", added)
+	}
+
+	// Verify phantom edge is in docB.
+	var phantomRel *graph.Relationship
+	for i := range docB.Relationships {
+		r := &docB.Relationships[i]
+		if r.Properties != nil && r.Properties["cross_repo"] == "true" {
+			phantomRel = r
+			break
+		}
+	}
+	if phantomRel == nil {
+		t.Fatal("expected phantom edge in fixture-b, found none")
+	}
+	if phantomRel.FromID != "svc" {
+		t.Errorf("phantom edge FromID = %q, want svc", phantomRel.FromID)
+	}
+	if phantomRel.ToID != "handler1" {
+		t.Errorf("phantom edge ToID = %q, want handler1", phantomRel.ToID)
+	}
+	if phantomRel.Properties["target_repo"] != "fixture-a" {
+		t.Errorf("target_repo = %q, want fixture-a", phantomRel.Properties["target_repo"])
+	}
+
+	// ---- Step 2: run process flow on fixture-b ----
+	engine.RunProcessFlow(docB, engine.DefaultProcessFlowConfig())
+
+	// Collect Process entities.
+	type proc struct {
+		name               string
+		crossStack         bool
+		crossStackReason   string
+		terminalIsPhantom  bool
+	}
+	var procs []proc
+	for _, e := range docB.Entities {
+		if e.Kind != engine.EntityKindProcess {
+			continue
+		}
+		p := proc{
+			name:       e.Name,
+			crossStack: e.Properties["cross_stack"] == "true",
+		}
+		p.crossStackReason = e.Properties["cross_stack_reason"]
+		p.terminalIsPhantom = e.Properties["terminal_is_phantom"] == "true"
+		procs = append(procs, p)
+	}
+	if len(procs) == 0 {
+		t.Fatal("RunProcessFlow emitted no Process entities in fixture-b")
+	}
+
+	// Sort for determinism in output.
+	sort.Slice(procs, func(i, j int) bool { return procs[i].name < procs[j].name })
+
+	// At least one cross_stack process must exist (the b→a chain).
+	var crossProc *proc
+	for i := range procs {
+		if procs[i].crossStack {
+			crossProc = &procs[i]
+			break
+		}
+	}
+	if crossProc == nil {
+		var names []string
+		for _, p := range procs {
+			names = append(names, p.name)
+		}
+		t.Fatalf("no cross_stack=true Process found; processes: %s", strings.Join(names, ", "))
+	}
+	if crossProc.crossStackReason == "" {
+		t.Errorf("cross_stack Process %q: cross_stack_reason is empty", crossProc.name)
+	}
+	if !strings.Contains(crossProc.crossStackReason, "phantom") {
+		t.Errorf("cross_stack_reason %q should contain 'phantom'", crossProc.crossStackReason)
+	}
+	if !crossProc.terminalIsPhantom {
+		t.Errorf("cross_stack Process %q: terminal_is_phantom should be true", crossProc.name)
+	}
+
+	// The intra-b chain (localOp→doSomething→helper→finish) must NOT be cross_stack.
+	for _, p := range procs {
+		if strings.Contains(p.name, "localOp") || strings.Contains(p.name, "doSomething") {
+			if p.crossStack {
+				t.Errorf("intra-b Process %q should have cross_stack=false, got true", p.name)
+			}
+		}
+	}
+
+	crossCount := 0
+	for _, p := range procs {
+		if p.crossStack {
+			crossCount++
+		}
+	}
+	t.Logf("fixture-b processes: %d total, cross_stack=%d", len(procs), crossCount)
+	t.Logf("cross_stack reason: %q", crossProc.crossStackReason)
+}

--- a/internal/links/phantom_edges_test.go
+++ b/internal/links/phantom_edges_test.go
@@ -1,0 +1,219 @@
+package links
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestPromoteToPhantomEdges_BasicHTTP verifies that a CALLS/http Link
+// between two repos produces one phantom CALLS relationship on the
+// source repo's document.
+func TestPromoteToPhantomEdges_BasicHTTP(t *testing.T) {
+	docA := &graph.Document{Repo: "fixture-a"}
+	docB := &graph.Document{
+		Repo: "fixture-b",
+		Entities: []graph.Entity{
+			{ID: "caller1", Name: "fetchUsers", Kind: "SCOPE.Function"},
+		},
+	}
+
+	links := []Link{
+		{
+			ID:       "link1",
+			Source:   "fixture-b::caller1",
+			Target:   "fixture-a::handler1",
+			Relation: RelationCalls,
+			Method:   MethodHTTP,
+		},
+	}
+
+	docs := map[string]*graph.Document{
+		"fixture-a": docA,
+		"fixture-b": docB,
+	}
+
+	added, err := PromoteToPhantomEdges(links, docs, "test-group")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added != 1 {
+		t.Errorf("added = %d, want 1", added)
+	}
+
+	// docB should have the phantom edge.
+	if len(docB.Relationships) != 1 {
+		t.Fatalf("docB.Relationships len = %d, want 1", len(docB.Relationships))
+	}
+	rel := docB.Relationships[0]
+	if rel.Kind != "CALLS" {
+		t.Errorf("Kind = %q, want CALLS", rel.Kind)
+	}
+	if rel.FromID != "caller1" {
+		t.Errorf("FromID = %q, want caller1", rel.FromID)
+	}
+	if rel.ToID != "handler1" {
+		t.Errorf("ToID = %q, want handler1", rel.ToID)
+	}
+	if rel.Properties["cross_repo"] != "true" {
+		t.Errorf("cross_repo = %q, want true", rel.Properties["cross_repo"])
+	}
+	if rel.Properties["target_repo"] != "fixture-a" {
+		t.Errorf("target_repo = %q, want fixture-a", rel.Properties["target_repo"])
+	}
+	if rel.Properties["link_method"] != MethodHTTP {
+		t.Errorf("link_method = %q, want %s", rel.Properties["link_method"], MethodHTTP)
+	}
+	if rel.Properties["via"] == "" {
+		t.Errorf("via property is empty")
+	}
+}
+
+// TestPromoteToPhantomEdges_KafkaAndWS verifies that kafka_topic and
+// ws_channel method links are also promoted.
+func TestPromoteToPhantomEdges_KafkaAndWS(t *testing.T) {
+	docSrc := &graph.Document{Repo: "src"}
+	docs := map[string]*graph.Document{"src": docSrc, "tgt": {Repo: "tgt"}}
+
+	links := []Link{
+		{ID: "k1", Source: "src::pub1", Target: "tgt::sub1", Relation: RelationCalls, Method: "kafka_topic"},
+		{ID: "w1", Source: "src::ws1", Target: "tgt::ws2", Relation: RelationCalls, Method: "ws_channel"},
+	}
+
+	added, err := PromoteToPhantomEdges(links, docs, "grp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added != 2 {
+		t.Errorf("added = %d, want 2 (kafka + ws)", added)
+	}
+	methods := make(map[string]bool)
+	for _, r := range docSrc.Relationships {
+		methods[r.Properties["link_method"]] = true
+	}
+	if !methods["kafka_topic"] {
+		t.Errorf("expected kafka_topic phantom edge, got %v", methods)
+	}
+	if !methods["ws_channel"] {
+		t.Errorf("expected ws_channel phantom edge, got %v", methods)
+	}
+}
+
+// TestPromoteToPhantomEdges_SkipsNonCalls verifies that IMPORTS,
+// SHARED_LABEL, and STRING_MATCH links are not promoted.
+func TestPromoteToPhantomEdges_SkipsNonCalls(t *testing.T) {
+	docSrc := &graph.Document{Repo: "src"}
+	docs := map[string]*graph.Document{"src": docSrc, "tgt": {Repo: "tgt"}}
+
+	links := []Link{
+		{ID: "i1", Source: "src::e1", Target: "tgt::e2", Relation: RelationImports, Method: MethodImport},
+		{ID: "l1", Source: "src::e1", Target: "tgt::e3", Relation: RelationSharedLabel, Method: MethodLabelMatch},
+		{ID: "s1", Source: "src::e1", Target: "tgt::e4", Relation: RelationStringMatch, Method: MethodString},
+	}
+
+	added, err := PromoteToPhantomEdges(links, docs, "grp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added != 0 {
+		t.Errorf("added = %d, want 0 for non-CALLS links", added)
+	}
+	if len(docSrc.Relationships) != 0 {
+		t.Errorf("expected no phantom edges for non-CALLS links, got %d", len(docSrc.Relationships))
+	}
+}
+
+// TestPromoteToPhantomEdges_Dedup verifies that duplicate links (same
+// Source, Target, Method) produce only one phantom edge.
+func TestPromoteToPhantomEdges_Dedup(t *testing.T) {
+	docSrc := &graph.Document{Repo: "src"}
+	docs := map[string]*graph.Document{"src": docSrc, "tgt": {Repo: "tgt"}}
+
+	links := []Link{
+		{ID: "a1", Source: "src::e1", Target: "tgt::e2", Relation: RelationCalls, Method: MethodHTTP},
+		{ID: "a2", Source: "src::e1", Target: "tgt::e2", Relation: RelationCalls, Method: MethodHTTP}, // dup
+	}
+
+	added, err := PromoteToPhantomEdges(links, docs, "grp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added != 1 {
+		t.Errorf("added = %d, want 1 (deduped)", added)
+	}
+	if len(docSrc.Relationships) != 1 {
+		t.Errorf("expected 1 relationship, got %d", len(docSrc.Relationships))
+	}
+}
+
+// TestPromoteToPhantomEdges_SelfPairSkipped verifies that same-repo links
+// are not promoted (they're intra-repo, not cross-repo).
+func TestPromoteToPhantomEdges_SelfPairSkipped(t *testing.T) {
+	docSrc := &graph.Document{Repo: "src"}
+	docs := map[string]*graph.Document{"src": docSrc}
+
+	links := []Link{
+		{ID: "s1", Source: "src::e1", Target: "src::e2", Relation: RelationCalls, Method: MethodHTTP},
+	}
+
+	added, _ := PromoteToPhantomEdges(links, docs, "grp")
+	if added != 0 {
+		t.Errorf("added = %d, want 0 for same-repo link", added)
+	}
+}
+
+// TestPromoteToPhantomEdges_MissingSourceDocSkipped verifies that when
+// the source repo's doc is not in the map, the link is silently skipped.
+func TestPromoteToPhantomEdges_MissingSourceDocSkipped(t *testing.T) {
+	// Only tgt present, src missing.
+	docs := map[string]*graph.Document{"tgt": {Repo: "tgt"}}
+
+	links := []Link{
+		{ID: "m1", Source: "src::e1", Target: "tgt::e2", Relation: RelationCalls, Method: MethodHTTP},
+	}
+
+	added, err := PromoteToPhantomEdges(links, docs, "grp")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if added != 0 {
+		t.Errorf("added = %d, want 0 when source doc missing", added)
+	}
+}
+
+// TestPromoteToPhantomEdges_Determinism verifies that running the function
+// twice produces the same set of phantom edges (no random ordering).
+func TestPromoteToPhantomEdges_Determinism(t *testing.T) {
+	makeLinks := func() []Link {
+		return []Link{
+			{ID: "l3", Source: "src::e3", Target: "tgt::h3", Relation: RelationCalls, Method: MethodHTTP},
+			{ID: "l1", Source: "src::e1", Target: "tgt::h1", Relation: RelationCalls, Method: MethodHTTP},
+			{ID: "l2", Source: "src::e2", Target: "tgt::h2", Relation: RelationCalls, Method: MethodHTTP},
+		}
+	}
+	makeDocs := func() map[string]*graph.Document {
+		return map[string]*graph.Document{
+			"src": {Repo: "src"},
+			"tgt": {Repo: "tgt"},
+		}
+	}
+
+	docs1 := makeDocs()
+	docs2 := makeDocs()
+	PromoteToPhantomEdges(makeLinks(), docs1, "grp") //nolint:errcheck
+	PromoteToPhantomEdges(makeLinks(), docs2, "grp") //nolint:errcheck
+
+	rels1 := docs1["src"].Relationships
+	rels2 := docs2["src"].Relationships
+	if len(rels1) != len(rels2) {
+		t.Fatalf("length mismatch: %d vs %d", len(rels1), len(rels2))
+	}
+	for i := range rels1 {
+		if rels1[i].ID != rels2[i].ID {
+			t.Errorf("rel[%d] ID mismatch: %s vs %s", i, rels1[i].ID, rels2[i].ID)
+		}
+		if rels1[i].FromID != rels2[i].FromID {
+			t.Errorf("rel[%d] FromID mismatch: %s vs %s", i, rels1[i].FromID, rels2[i].FromID)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **P5 phantom-edge pass** (`internal/links/phantom_edges.go`): `PromoteToPhantomEdges` converts every cross-repo `Link` with `relation=calls` + `method ∈ {http, kafka_topic, ws_channel}` into a real `graph.Relationship` (Kind=CALLS) inside the source repo's `graph.Document`. Phantom edges carry `cross_repo="true"`, `target_repo`, `link_method`, and `via="phantom_edge_pass_#769 group=<g>"` properties.
- **RunProcessFlow extended** (`internal/engine/process_flow.go`): added `phantom` map to `callsAdjacency`, `isPhantomCallsEdge`, `chainCrossesRepo`, `phantomEdgeForStep`, and `terminalIsPhantom` handling so BFS chains reaching a phantom terminal emit `cross_stack=true` Process entities with `cross_stack_reason` containing "phantom" and `terminal_is_phantom=true`.
- **CLI integration** (`internal/cli/links.go`): `RunLinksForGroup` now calls `runPhantomEdgePass` after `RunAllPasses`. The pass loads each repo's document, calls `PromoteToPhantomEdges`, strips stale `SCOPE.Process` entities, re-runs `RunProcessFlow`, sorts for determinism, and writes back atomically.

## Files touched

| File | +lines | -lines |
|------|--------|--------|
| `internal/links/phantom_edges.go` | +200 | 0 (new) |
| `internal/links/phantom_edges_test.go` | +219 | 0 (new) |
| `internal/links/phantom_edges_integration_test.go` | +187 | 0 (new) |
| `internal/engine/process_flow.go` | +119 | -7 |
| `internal/engine/process_flow_test.go` | +85 | 0 |
| `internal/cli/links.go` | +216 | -7 |
| **Total** | **+1026** | **-14** |

## Test results

All tests pass (`go test ./...`):

- 7 unit tests in `phantom_edges_test.go`: BasicHTTP, KafkaAndWS, SkipsNonCalls, Dedup, SelfPairSkipped, MissingSourceDocSkipped, Determinism
- 2 process_flow unit tests: PhantomEdgeCrossStack, PhantomEdgeMinStepsRelaxed
- Integration test `TestPhantomEdges_CrossRepoBFSChain` (end-to-end: synthetic fixture-b → fixture-a via HTTP link):
  - 1 phantom edge added to fixture-b
  - `RunProcessFlow` on fixture-b: 2 Process entities, 1 with `cross_stack=true`
  - `cross_stack_reason`: `"phantom cross-repo CALLS edge at step 2 (svc → handler1)"`
  - `terminal_is_phantom=true` confirmed
  - Intra-b chain (localOp chain): `cross_stack=false`
- `TestHarness_FixturesCorpus`: bug_rate=0.0584 (unchanged from pre-PR baseline)

## Measurement table

| Target | Spec | Actual | Notes |
|--------|------|--------|-------|
| Phantom edges (client-fixture a/b/c group) | ≥30 | BLOCKED | Pre-existing panic in `response_shape_python.go:111` crashes daemon on fixture-a indexing (identical on main `372effd`) |
| Phantom edges (client-fixture-de group) | ≥40 | BLOCKED | Same panic |
| fixture-b cross_stack chains (JS/TS → fixture-a) | ≥5 | BLOCKED | Same panic |
| fixture-c cross_stack chains into fixture-a | ≥3 | BLOCKED | Same panic |
| fixture-e cross_stack chains into fixture-d | ≥0 | Gated on #771 | Per spec |
| fixture-d intra-repo cross_stack | 0 (regression gate) | N/A | Cannot measure |
| bug_rate regression | unchanged | 0.0584 | Harness green |

The panic in `response_shape_python.go` (`slice bounds out of range [:1505] with length 1504` at line 111) affects all fixture-a indexing attempts and pre-dates this PR. Live fixture measurements will be added once that panic is fixed (tracked separately, background agent #773).

## Sample cross-repo chain (from integration test)

```
fixture-b: entry(loadUsers) → CALLS → svc(fetchFromAPI) → [phantom CALLS, cross_repo=true, target_repo=fixture-a] → handler1(getUsersHandler)

Process emitted on fixture-b:
  Kind: SCOPE.Process
  cross_stack: "true"
  cross_stack_reason: "phantom cross-repo CALLS edge at step 2 (svc → handler1)"
  terminal_is_phantom: "true"
```

## Coordination notes with #770

- `cross_stack=true` semantics remain as defined in #770: real cross-repo CALLS boundaries only.
- `crosses_external_lib=true` (HTTP boundary / external lib heuristic from #770) is untouched.
- `chainCrossesRepoBoundary` from #770 is extended (not replaced) — phantom detection is additive.
- MinSteps relaxation now covers both FETCHES chains (#770) and phantom chains (#769): 2-step chains survive when `chainCrossesRepo` returns true.

## Daemon cleanup

No live daemon was left running. The `/tmp/arch-769` daemon crashed due to the pre-existing `response_shape_python.go` panic and was not running at PR creation time.

## Follow-ups

- **#773** (tracked separately): Fix `response_shape_python.go:111` panic to unblock live fixture measurements for this PR.
- **#771** dependency: fixture-e → fixture-d cross_stack chains are gated on #771 emitting the relevant cross-repo Links for that group.
- After #773 lands: re-run live fixture indexing, add measurement numbers to this PR table.

Generated with Claude Code