### PR TITLE
[#721] Wave 2b: Ruby + C# HTTP FETCHES extraction-time edges

### DIFF
--- a/internal/engine/http_endpoint_csharp_client.go
+++ b/internal/engine/http_endpoint_csharp_client.go
@@ -1,0 +1,486 @@
+// C# consumer-side HTTP client synthesis (#721 wave 2b).
+//
+// Mirrors http_endpoint_go_client.go / http_endpoint_kotlin_client.go for
+// C# consumer-side HTTP patterns. Emits one synthetic `http_endpoint` entity
+// (consumer side) per detected client call site, AND a FETCHES edge from
+// the enclosing method to that endpoint.
+//
+// Patterns covered:
+//
+//   - HttpClient:
+//     await client.GetAsync(url), await client.PostAsync(url, content)
+//     await client.PutAsync(url, content), await client.DeleteAsync(url)
+//     await client.PatchAsync(url, content), await client.SendAsync(request)
+//     await client.GetStringAsync(url), await client.GetStreamAsync(url)
+//     new HttpRequestMessage(HttpMethod.Get, url) — verb inferred from method arg
+//
+//   - RestSharp:
+//     var client = new RestClient(url); var request = new RestRequest(path, Method.Get)
+//     client.ExecuteAsync(request), client.GetAsync(request), client.PostAsync(request)
+//
+//   - Refit (interface annotations):
+//     [Get("/users")], [Post("/users")], [Put("/users/{id}")],
+//     [Delete("/users/{id}")], [Patch("/users/{id}")], [Head("/users")],
+//     [Options("/users")] — on interface methods
+//
+//   - WebClient (legacy):
+//     wc.DownloadString(url), wc.DownloadStringAsync(url)
+//     wc.UploadString(url, data), wc.UploadData(url, data)
+//
+// Beyond-minimum behaviours:
+//   - Async/await variants for all HttpClient methods
+//   - Full Refit annotation suite: [Get], [Post], [Put], [Delete], [Patch], [Head]
+//   - WebClient deprecated patterns
+//   - Env-var concatenation: await client.GetAsync(Environment.GetEnvironmentVariable("API_URL") + "/users")
+//     → emit with runtime_dynamic=true
+//
+// The enclosing method is identified by scanning for the nearest preceding
+// `... <ReturnType> <Name>(` or `async Task ... <Name>(` declaration.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// HttpClient async verb methods
+// ---------------------------------------------------------------------------
+
+// csHttpClientVerbRe matches `await client.GetAsync(url)`, `await client.PostAsync(url, content)`.
+// Also matches non-awaited forms like `client.GetAsync(url)` (fire-and-forget or .Result).
+// Receiver allow-list: client, httpClient, _client, _httpClient, http, hc, httpClient.
+var csHttpClientVerbRe = regexp.MustCompile(
+	`\b(_?(?:client|httpClient|_client|http|hc|myClient))\s*\.\s*(GetAsync|PostAsync|PutAsync|DeleteAsync|PatchAsync|HeadAsync|OptionsAsync|GetStringAsync|GetStreamAsync|GetByteArrayAsync)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted url
+		`|` +
+		`@"([^"\n\r]+)"` + // group 4: verbatim string literal
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 5: bare identifier
+		`)`,
+)
+
+// csSendAsyncRe matches `await client.SendAsync(request)` where the request
+// is an HttpRequestMessage. We look for a preceding
+// `new HttpRequestMessage(HttpMethod.Get, url)` in a 512-byte window.
+var csSendAsyncRe = regexp.MustCompile(
+	`\b(_?(?:client|httpClient|_client|http|hc|myClient))\s*\.\s*SendAsync\s*\(`,
+)
+
+// csHttpRequestMessageRe captures `new HttpRequestMessage(HttpMethod.Get, url)`.
+// Capture groups: 1 = method name (Get/Post/Put/Delete/Patch/Head/Options),
+// 2 = double-quoted url, 3 = verbatim string url, 4 = identifier url.
+var csHttpRequestMessageRe = regexp.MustCompile(
+	`new\s+HttpRequestMessage\s*\(\s*HttpMethod\s*\.\s*([A-Za-z]+)\s*,\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`@"([^"\n\r]+)"` + // group 3: verbatim string url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// RestSharp
+// ---------------------------------------------------------------------------
+
+// csRestClientNewRe matches `new RestClient(url)` or `new RestClient("url")`.
+// We use this to detect that RestSharp is in use in the file.
+var csRestClientNewRe = regexp.MustCompile(
+	`new\s+RestClient\s*\(\s*(?:"([^"\n\r]+)"|([A-Za-z_][\w]*))`,
+)
+
+// csRestRequestNewRe matches `new RestRequest(path, Method.Get)` or
+// `new RestRequest("/path")`. Capture groups:
+// 1 = double-quoted path, 2 = identifier path, 3 = Method enum value (optional).
+var csRestRequestNewRe = regexp.MustCompile(
+	`new\s+RestRequest\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 1: double-quoted path
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 2: identifier path
+		`)\s*(?:,\s*Method\s*\.\s*([A-Za-z]+))?`,
+)
+
+// csRestClientExecuteRe matches `client.ExecuteAsync(request)` and
+// `client.GetAsync(request)` / `client.PostAsync(request)` in RestSharp context.
+// We use this as a signal that a RestRequest is being executed.
+var csRestClientExecuteRe = regexp.MustCompile(
+	`\b\w+\s*\.\s*(ExecuteAsync|Execute|GetAsync|PostAsync|PutAsync|DeleteAsync|PatchAsync)\s*\(\s*\w+`,
+)
+
+// ---------------------------------------------------------------------------
+// Refit interface annotations
+// ---------------------------------------------------------------------------
+
+// csRefitAnnotationRe captures Refit verb annotations on interface methods:
+// [Get("/path")], [Post("/path")], [Put("/path/{id}")], etc.
+// Both single and double brackets are valid in C# (single is standard).
+// Capture groups: 1 = verb (Get/Post/Put/Delete/Patch/Head/Options),
+// 2 = path string.
+var csRefitAnnotationRe = regexp.MustCompile(
+	`\[\s*(Get|Post|Put|Delete|Patch|Head|Options)\s*\(\s*"([^"\n\r]+)"\s*\)\s*\]`,
+)
+
+// ---------------------------------------------------------------------------
+// WebClient (legacy)
+// ---------------------------------------------------------------------------
+
+// csWebClientDownloadRe matches `wc.DownloadString(url)`, `wc.DownloadStringAsync(url)`,
+// `wc.DownloadData(url)`, `new WebClient().DownloadString(url)`.
+// Receiver allow-list: wc, webClient, _wc, client (when paired with WebClient).
+var csWebClientDownloadRe = regexp.MustCompile(
+	`\b(_?(?:wc|webClient|client|webClnt))\s*\.\s*(DownloadString(?:Async)?|DownloadData(?:Async)?|DownloadFile(?:Async)?)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// csWebClientUploadRe matches `wc.UploadString(url, data)`, `wc.UploadData(url, data)`.
+// These are POST-equivalent operations.
+var csWebClientUploadRe = regexp.MustCompile(
+	`\b(_?(?:wc|webClient|client|webClnt))\s*\.\s*(UploadString(?:Async)?|UploadData(?:Async)?|UploadFile(?:Async)?)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// csEnvGetenvFrag is the fragment matching C# environment variable access:
+// `Environment.GetEnvironmentVariable("NAME")`.
+const csEnvGetenvFrag = `Environment\s*\.\s*GetEnvironmentVariable\s*\([^)]+\)`
+
+// csHttpClientEnvVerbRe matches
+// `client.GetAsync(Environment.GetEnvironmentVariable("X") + "/path")`.
+// Capture groups: 1 = receiver, 2 = verb method name, 3 = path suffix.
+var csHttpClientEnvVerbRe = regexp.MustCompile(
+	`\b(_?(?:client|httpClient|_client|http|hc|myClient))\s*\.\s*(GetAsync|PostAsync|PutAsync|DeleteAsync|PatchAsync|HeadAsync|OptionsAsync)\s*\(\s*` +
+		csEnvGetenvFrag + `\s*\+\s*"([^"\n\r]*)"`,
+)
+
+// ---------------------------------------------------------------------------
+// String constant table
+// ---------------------------------------------------------------------------
+
+// csStringConstRe captures simple C# string constant declarations:
+//
+//	const string NAME = "/value";
+//	private const string NAME = "/value";
+//	var name = "/value";
+//	string name = "/value";
+var csStringConstRe = regexp.MustCompile(
+	`(?:const\s+string|private\s+const\s+string|string|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*"([^"\n\r]{1,256})"`,
+)
+
+// ---------------------------------------------------------------------------
+// Enclosing method index
+// ---------------------------------------------------------------------------
+
+// csEnclosingMethodRe captures C# method declarations:
+//
+//	public async Task<T> MethodName(
+//	private void MethodName(
+//	public static string MethodName(
+//	protected override Task MethodName(
+var csEnclosingMethodRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:public|private|protected|internal|static|virtual|override|abstract|async|\s)+\s+)[\w<>\[\],?\s]+\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// csClientEmitFn is the runtime-aware emitter type for C# clients.
+type csClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeCSharpClient is the package-level entry point referenced from
+// applyHTTPEndpointSynthesis.
+func synthesizeCSharpClient(content string, emit emitFn) {
+	synthesizeCSharpClientWithRuntime(content, func(method, canonicalPath, framework, refKind, refName string, _ bool) {
+		emit(method, canonicalPath, framework, refKind, refName)
+	})
+}
+
+// synthesizeCSharpClientWithRuntime runs the full C# client scan.
+func synthesizeCSharpClientWithRuntime(content string, emit csClientEmitFn) {
+	if !csHasAnyHTTPClient(content) {
+		return
+	}
+	funcs := indexCsEnclosingMethods(content)
+	syms := buildCsStringSymbolTable(content)
+
+	// ----- HttpClient async verbs: client.GetAsync/PostAsync/... -----
+	for _, m := range csHttpClientVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verbMethod := content[m[4]:m[5]]
+		verb := csVerbFromMethodName(verbMethod)
+		raw := csPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "httpclient", "Function", caller, false)
+	}
+
+	// ----- HttpClient.SendAsync with HttpRequestMessage(method, url) -----
+	for _, m := range csHttpRequestMessageRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := csPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "httpclient", "Function", caller, false)
+	}
+
+	// ----- RestSharp: new RestRequest(path, Method.Verb) -----
+	for _, m := range csRestRequestNewRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		// URL is group 1 (double-quoted) or group 2 (identifier).
+		raw := ""
+		if m[2] >= 0 {
+			raw = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			ident := content[m[4]:m[5]]
+			if val, ok := syms[ident]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		// Verb: from Method enum group 3, defaulting to GET.
+		verb := "GET"
+		if m[6] >= 0 {
+			verb = strings.ToUpper(content[m[6]:m[7]])
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "restsharp", "Function", caller, false)
+	}
+
+	// ----- Refit interface annotations: [Get("/path")], [Post("/path")] -----
+	for _, m := range csRefitAnnotationRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := csNextInterfaceMethod(content, m[1])
+		if caller == "" {
+			caller = enclosingCsMethodAt(funcs, m[0])
+		}
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "refit", "Function", caller, false)
+	}
+
+	// ----- WebClient.DownloadString/DownloadData (legacy GET-equivalent) -----
+	for _, m := range csWebClientDownloadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		raw := csPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit("GET", canonical, "webclient", "Function", caller, false)
+	}
+
+	// ----- WebClient.UploadString/UploadData (legacy POST-equivalent) -----
+	for _, m := range csWebClientUploadRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		raw := csPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit("POST", canonical, "webclient", "Function", caller, false)
+	}
+
+	// ----- Env-var concat: client.GetAsync(Environment.GetEnvironmentVariable("X") + "/path") -----
+	for _, m := range csHttpClientEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verbMethod := content[m[4]:m[5]]
+		verb := csVerbFromMethodName(verbMethod)
+		suffix := ""
+		if m[6] >= 0 {
+			suffix = content[m[6]:m[7]]
+		}
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingCsMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "httpclient", "Function", caller, true)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func csHasAnyHTTPClient(content string) bool {
+	return strings.Contains(content, "HttpClient") ||
+		strings.Contains(content, "HttpRequestMessage") ||
+		strings.Contains(content, "RestClient") ||
+		strings.Contains(content, "RestRequest") ||
+		strings.Contains(content, "[Get(") || strings.Contains(content, "[Post(") ||
+		strings.Contains(content, "[Put(") || strings.Contains(content, "[Delete(") ||
+		strings.Contains(content, "[Patch(") || strings.Contains(content, "[Head(") ||
+		strings.Contains(content, "[Options(") ||
+		strings.Contains(content, "WebClient") ||
+		strings.Contains(content, "GetAsync") || strings.Contains(content, "PostAsync") ||
+		strings.Contains(content, "client.GetAsync") || strings.Contains(content, "client.PostAsync") ||
+		strings.Contains(content, "Environment.GetEnvironmentVariable")
+}
+
+// buildCsStringSymbolTable returns a map from identifier → string value
+// for simple constant/var string declarations in the C# file.
+func buildCsStringSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range csStringConstRe.FindAllStringSubmatch(content, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		if _, dup := syms[m[1]]; !dup {
+			syms[m[1]] = m[2]
+		}
+	}
+	return syms
+}
+
+// csPickURLArg extracts the URL string from a match's double-quoted /
+// verbatim string / identifier group triple. `litStart` is the index
+// within `m` of the first literal group.
+func csPickURLArg(content string, m []int, litStart int, syms map[string]string) string {
+	// Double-quoted literal.
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	// Verbatim string @"..." (treated same as double-quoted for path extraction).
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	// Bare identifier — resolve via symbol table.
+	if litStart+5 < len(m) && m[litStart+4] >= 0 {
+		ident := content[m[litStart+4]:m[litStart+5]]
+		if val, ok := syms[ident]; ok {
+			return val
+		}
+	}
+	return ""
+}
+
+// csVerbFromMethodName maps an HttpClient async method name to its HTTP verb.
+// e.g. GetAsync → GET, PostAsync → POST, GetStringAsync → GET.
+func csVerbFromMethodName(methodName string) string {
+	switch {
+	case strings.HasPrefix(methodName, "Get"):
+		return "GET"
+	case strings.HasPrefix(methodName, "Post"):
+		return "POST"
+	case strings.HasPrefix(methodName, "Put"):
+		return "PUT"
+	case strings.HasPrefix(methodName, "Delete"):
+		return "DELETE"
+	case strings.HasPrefix(methodName, "Patch"):
+		return "PATCH"
+	case strings.HasPrefix(methodName, "Head"):
+		return "HEAD"
+	case strings.HasPrefix(methodName, "Options"):
+		return "OPTIONS"
+	default:
+		return "GET"
+	}
+}
+
+// csInterfaceMethodHeadRe captures C# interface method declarations
+// following a Refit annotation. Handles both async Task<T> and return-type
+// forms:
+//
+//	Task<List<User>> GetUsers();
+//	Task CreateUser([Body] User user);
+//	IObservable<User> GetUserById([AliasAs("id")] int id);
+var csInterfaceMethodHeadRe = regexp.MustCompile(
+	`(?:Task|IObservable|ValueTask)(?:<[^>]*>)?\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// csNextInterfaceMethod returns the method name on the line immediately
+// following a Refit annotation match.
+func csNextInterfaceMethod(content string, pos int) string {
+	end := pos + 512
+	if end > len(content) {
+		end = len(content)
+	}
+	window := content[pos:end]
+	mm := csInterfaceMethodHeadRe.FindStringSubmatch(window)
+	if len(mm) < 2 {
+		return ""
+	}
+	return mm[1]
+}
+
+// indexCsEnclosingMethods builds a sorted (offset, name) list for every
+// C# method declaration in the file.
+func indexCsEnclosingMethods(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range csEnclosingMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingCsMethodAt returns the name of the nearest preceding method
+// declaration for a call site at `pos`.
+func enclosingCsMethodAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_csharp_client_test.go
+++ b/internal/engine/http_endpoint_csharp_client_test.go
@@ -1,0 +1,372 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// HttpClient async verbs
+// ---------------------------------------------------------------------------
+
+// TestCsClient_HttpClientGetAsync covers `await client.GetAsync(url)` and
+// `await client.GetStringAsync(url)`.
+func TestCsClient_HttpClientGetAsync(t *testing.T) {
+	src := `
+using System.Net.Http;
+
+public class UserService
+{
+    private readonly HttpClient _client;
+
+    public async Task<string> GetUsersAsync()
+    {
+        var response = await _client.GetAsync("https://api.example.com/api/users");
+        return await response.Content.ReadAsStringAsync();
+    }
+
+    public async Task<string> GetUserStringAsync()
+    {
+        return await _client.GetStringAsync("/api/users/profile");
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "UserService.cs", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:GET:/api/users/profile",
+	}
+	requireContains(t, ids, want, "cs-httpclient-get-async")
+	requireFetches(t, rels, "http:GET:/api/users", "cs-httpclient-get-async")
+	requireFetches(t, rels, "http:GET:/api/users/profile", "cs-httpclient-get-async")
+}
+
+// TestCsClient_HttpClientPostAsync covers `await client.PostAsync(url, content)`.
+func TestCsClient_HttpClientPostAsync(t *testing.T) {
+	src := `
+using System.Net.Http;
+
+public class OrderService
+{
+    private readonly HttpClient _client;
+
+    public async Task<HttpResponseMessage> CreateOrderAsync(StringContent body)
+    {
+        return await _client.PostAsync("/api/orders", body);
+    }
+
+    public async Task UpdateOrderAsync(StringContent body)
+    {
+        await _client.PutAsync("/api/orders/1", body);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "OrderService.cs", src)
+	want := []string{
+		"http:POST:/api/orders",
+		"http:PUT:/api/orders/1",
+	}
+	requireContains(t, ids, want, "cs-httpclient-post-async")
+	requireFetches(t, rels, "http:POST:/api/orders", "cs-httpclient-post-async")
+	requireFetches(t, rels, "http:PUT:/api/orders/1", "cs-httpclient-post-async")
+}
+
+// TestCsClient_HttpClientDeletePatchAsync covers DELETE and PATCH async verbs.
+func TestCsClient_HttpClientDeletePatchAsync(t *testing.T) {
+	src := `
+using System.Net.Http;
+
+public class ProductService
+{
+    private readonly HttpClient _client;
+
+    public async Task DeleteProductAsync(int id)
+    {
+        await _client.DeleteAsync("/api/products/42");
+    }
+
+    public async Task PatchProductAsync(StringContent patch)
+    {
+        await _client.PatchAsync("/api/products/42", patch);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "ProductService.cs", src)
+	want := []string{
+		"http:DELETE:/api/products/42",
+		"http:PATCH:/api/products/42",
+	}
+	requireContains(t, ids, want, "cs-httpclient-delete-patch-async")
+	requireFetches(t, rels, "http:DELETE:/api/products/42", "cs-httpclient-delete-patch-async")
+	requireFetches(t, rels, "http:PATCH:/api/products/42", "cs-httpclient-delete-patch-async")
+}
+
+// TestCsClient_HttpRequestMessage covers `new HttpRequestMessage(HttpMethod.Post, url)`.
+func TestCsClient_HttpRequestMessage(t *testing.T) {
+	src := `
+using System.Net.Http;
+
+public class PaymentService
+{
+    private readonly HttpClient _client;
+
+    public async Task<HttpResponseMessage> ChargeAsync(StringContent body)
+    {
+        var request = new HttpRequestMessage(HttpMethod.Post, "/api/payments/charge");
+        request.Content = body;
+        return await _client.SendAsync(request);
+    }
+
+    public async Task<HttpResponseMessage> VoidAsync()
+    {
+        var request = new HttpRequestMessage(HttpMethod.Delete, "/api/payments/void");
+        return await _client.SendAsync(request);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "PaymentService.cs", src)
+	want := []string{
+		"http:POST:/api/payments/charge",
+		"http:DELETE:/api/payments/void",
+	}
+	requireContains(t, ids, want, "cs-httprequestmessage")
+	requireFetches(t, rels, "http:POST:/api/payments/charge", "cs-httprequestmessage")
+	requireFetches(t, rels, "http:DELETE:/api/payments/void", "cs-httprequestmessage")
+}
+
+// ---------------------------------------------------------------------------
+// RestSharp
+// ---------------------------------------------------------------------------
+
+// TestCsClient_RestSharp covers `new RestRequest(path, Method.Get)` + ExecuteAsync.
+func TestCsClient_RestSharp(t *testing.T) {
+	src := `
+using RestSharp;
+
+public class InventoryService
+{
+    public async Task<RestResponse> GetInventoryAsync()
+    {
+        var client = new RestClient("https://api.example.com");
+        var request = new RestRequest("/api/inventory", Method.Get);
+        return await client.ExecuteAsync(request);
+    }
+
+    public async Task<RestResponse> AddItemAsync()
+    {
+        var client = new RestClient("https://api.example.com");
+        var request = new RestRequest("/api/inventory", Method.Post);
+        return await client.ExecuteAsync(request);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "InventoryService.cs", src)
+	want := []string{
+		"http:GET:/api/inventory",
+		"http:POST:/api/inventory",
+	}
+	requireContains(t, ids, want, "cs-restsharp")
+	requireFetches(t, rels, "http:GET:/api/inventory", "cs-restsharp")
+	requireFetches(t, rels, "http:POST:/api/inventory", "cs-restsharp")
+}
+
+// ---------------------------------------------------------------------------
+// Refit
+// ---------------------------------------------------------------------------
+
+// TestCsClient_RefitAnnotations covers Refit verb annotations on interface methods.
+func TestCsClient_RefitAnnotations(t *testing.T) {
+	src := `
+using Refit;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+public interface IUserApi
+{
+    [Get("/api/users")]
+    Task<List<User>> GetUsersAsync();
+
+    [Post("/api/users")]
+    Task<User> CreateUserAsync([Body] User user);
+
+    [Put("/api/users/{id}")]
+    Task UpdateUserAsync(int id, [Body] User user);
+
+    [Delete("/api/users/{id}")]
+    Task DeleteUserAsync(int id);
+
+    [Patch("/api/users/{id}")]
+    Task PatchUserAsync(int id, [Body] UserPatch patch);
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "IUserApi.cs", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+		"http:PUT:/api/users/{id}",
+		"http:DELETE:/api/users/{id}",
+		"http:PATCH:/api/users/{id}",
+	}
+	requireContains(t, ids, want, "cs-refit-annotations")
+	requireFetches(t, rels, "http:GET:/api/users", "cs-refit-annotations")
+	requireFetches(t, rels, "http:POST:/api/users", "cs-refit-annotations")
+	requireFetches(t, rels, "http:DELETE:/api/users/{id}", "cs-refit-annotations")
+}
+
+// TestCsClient_RefitFullAnnotationSuite covers all Refit annotation verbs.
+func TestCsClient_RefitFullAnnotationSuite(t *testing.T) {
+	src := `
+using Refit;
+using System.Threading.Tasks;
+
+public interface IFullApi
+{
+    [Get("/api/resources")]
+    Task<string> GetAsync();
+
+    [Post("/api/resources")]
+    Task<string> PostAsync([Body] string body);
+
+    [Put("/api/resources/{id}")]
+    Task PutAsync(int id, [Body] string body);
+
+    [Delete("/api/resources/{id}")]
+    Task DeleteAsync(int id);
+
+    [Patch("/api/resources/{id}")]
+    Task PatchAsync(int id, [Body] string patch);
+
+    [Head("/api/resources")]
+    Task HeadAsync();
+}
+`
+	ids, _ := runDetectWithRels(t, "csharp", "IFullApi.cs", src)
+	want := []string{
+		"http:GET:/api/resources",
+		"http:POST:/api/resources",
+		"http:PUT:/api/resources/{id}",
+		"http:DELETE:/api/resources/{id}",
+		"http:PATCH:/api/resources/{id}",
+		"http:HEAD:/api/resources",
+	}
+	requireContains(t, ids, want, "cs-refit-full-suite")
+}
+
+// ---------------------------------------------------------------------------
+// WebClient (legacy)
+// ---------------------------------------------------------------------------
+
+// TestCsClient_WebClientDownload covers wc.DownloadString(url) → GET.
+func TestCsClient_WebClientDownload(t *testing.T) {
+	src := `
+using System.Net;
+
+public class LegacyService
+{
+    public string FetchData()
+    {
+        var wc = new WebClient();
+        return wc.DownloadString("https://api.example.com/api/legacy");
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "LegacyService.cs", src)
+	requireContains(t, ids, []string{"http:GET:/api/legacy"}, "cs-webclient-download")
+	requireFetches(t, rels, "http:GET:/api/legacy", "cs-webclient-download")
+}
+
+// TestCsClient_WebClientUpload covers wc.UploadString(url, data) → POST.
+func TestCsClient_WebClientUpload(t *testing.T) {
+	src := `
+using System.Net;
+
+public class LegacyUploadService
+{
+    public string SendData(string data)
+    {
+        var wc = new WebClient();
+        return wc.UploadString("https://api.example.com/api/legacy/upload", data);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "LegacyUploadService.cs", src)
+	requireContains(t, ids, []string{"http:POST:/api/legacy/upload"}, "cs-webclient-upload")
+	requireFetches(t, rels, "http:POST:/api/legacy/upload", "cs-webclient-upload")
+}
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// TestCsClient_EnvVarConcat covers
+// `await client.GetAsync(Environment.GetEnvironmentVariable("API_URL") + "/users")`
+// → runtime_dynamic=true.
+func TestCsClient_EnvVarConcat(t *testing.T) {
+	src := `
+using System;
+using System.Net.Http;
+
+public class RemoteService
+{
+    private readonly HttpClient _client;
+
+    public async Task<string> CallRemoteAsync()
+    {
+        var response = await _client.GetAsync(Environment.GetEnvironmentVariable("API_URL") + "/api/data");
+        return await response.Content.ReadAsStringAsync();
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "csharp", "RemoteService.cs", src)
+	requireContains(t, ids, []string{"http:GET:/api/data"}, "cs-env-var-concat")
+	requireFetches(t, rels, "http:GET:/api/data", "cs-env-var-concat")
+
+	// Verify runtime_dynamic=true.
+	_, res := runDetect(t, "csharp", "RemoteService.cs", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/api/data" && e.Properties["runtime_dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("cs-env-var-concat: expected runtime_dynamic=true on http:GET:/api/data")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative case
+// ---------------------------------------------------------------------------
+
+// TestCsClient_Negative verifies that a non-HTTP C# file does not emit
+// any http_endpoint synthetics.
+func TestCsClient_Negative(t *testing.T) {
+	src := `
+using System;
+using System.Collections.Generic;
+
+public class DataProcessor
+{
+    public List<string> Process(List<string> items)
+    {
+        var result = new List<string>();
+        foreach (var item in items)
+        {
+            result.Add(item.ToUpper());
+        }
+        return result;
+    }
+
+    public string FormatMessage(string name, int count)
+    {
+        return $"Hello {name}, you have {count} items.";
+    }
+}
+`
+	ids, _ := runDetectWithRels(t, "csharp", "DataProcessor.cs", src)
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			t.Errorf("cs-negative: unexpected http_endpoint %q from non-HTTP file", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_ruby_client.go
+++ b/internal/engine/http_endpoint_ruby_client.go
@@ -1,0 +1,584 @@
+// Ruby consumer-side HTTP client synthesis (#721 wave 2b).
+//
+// Mirrors http_endpoint_go_client.go / http_endpoint_kotlin_client.go for
+// Ruby consumer-side HTTP patterns. Emits one synthetic `http_endpoint`
+// entity (consumer side) per detected client call site, AND a FETCHES edge
+// from the enclosing function/method to that endpoint.
+//
+// Patterns covered:
+//
+//   - Net::HTTP standard library:
+//     Net::HTTP.get(URI(url)), Net::HTTP.post(URI(url), data)
+//     http = Net::HTTP.new(host, port); http.get(path), http.post(path)
+//     Net::HTTP.start(host, port) { |http| http.get(path) } (beyond-minimum)
+//
+//   - Faraday:
+//     Faraday.get(url), Faraday.post(url)
+//     conn = Faraday.new(url: ...); conn.get(path), conn.post(path) { |req| ... }
+//
+//   - HTTParty:
+//     HTTParty.get(url), HTTParty.post(url, body: ...)
+//     include HTTParty; get(path), post(path) (module-included form)
+//
+//   - RestClient:
+//     RestClient.get(url), RestClient.post(url, payload)
+//     RestClient::Resource.new(url).get, RestClient::Resource.new(url).post
+//
+// Beyond-minimum behaviours:
+//   - Net::HTTP.start(host, port) { |http| http.get(path) } — block form
+//   - Env-var concatenation: Net::HTTP.get(URI(ENV['API_URL'] + '/users'))
+//     → emit with runtime_dynamic=true
+//   - All standard HTTP verbs: get, post, put, patch, delete, head, options
+//
+// The enclosing method/function is identified by scanning for the nearest
+// preceding `def <name>` declaration.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Net::HTTP package-level class methods
+// ---------------------------------------------------------------------------
+
+// rubyNetHTTPClassVerbRe matches `Net::HTTP.get(URI(url))`,
+// `Net::HTTP.post(URI(url), data)`, `Net::HTTP.put_form(uri, data)`.
+// The url group accepts string literals in single or double quotes, or a
+// bare identifier.
+var rubyNetHTTPClassVerbRe = regexp.MustCompile(
+	`\bNet::HTTP\s*\.\s*(get|post|put|delete|head|patch|options)\s*\(\s*(?:URI\s*\(\s*)?(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted literal
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted literal
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier
+		`)`,
+)
+
+// rubyNetHTTPInstanceVerbRe matches instance method calls on a Net::HTTP
+// object: `http.get(path)`, `http.post(path, body)`, etc.
+// Receiver allow-list: http, conn, client, connection, net_http, nethttp, @http, @client.
+var rubyNetHTTPInstanceVerbRe = regexp.MustCompile(
+	`\b(@?(?:http|conn|client|connection|net_http|nethttp))\s*\.\s*(get|post|put|delete|head|patch|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted literal
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted literal
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 5: bare identifier
+		`)`,
+)
+
+// rubyNetHTTPStartBlockRe matches the block form:
+// `Net::HTTP.start(host, port) { |http| http.get(path) }`
+// and `Net::HTTP.start(host, port) do |http| http.post(path, body) end`.
+// We capture the path from the inner `http.<verb>(path)` call inside the block.
+var rubyNetHTTPStartBlockRe = regexp.MustCompile(
+	`\bNet::HTTP\s*\.\s*start\s*\([^)]+\)\s*(?:\{|do)\s*\|\s*\w+\s*\|[^}]*?\b(\w+)\s*\.\s*(get|post|put|delete|head|patch|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted path
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted path
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 5: identifier path
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Faraday
+// ---------------------------------------------------------------------------
+
+// rubyFaradayClassVerbRe matches `Faraday.get(url)`, `Faraday.post(url)`, etc.
+var rubyFaradayClassVerbRe = regexp.MustCompile(
+	`\bFaraday\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// rubyFaradayInstanceVerbRe matches `conn.get(path)`, `conn.post(path) { |req| ... }`.
+// Receiver allow-list: conn, connection, faraday, client, @conn, @connection, @client, @faraday.
+var rubyFaradayInstanceVerbRe = regexp.MustCompile(
+	`\b(@?(?:conn|connection|faraday|client))\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted path
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted path
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 5: identifier path
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// HTTParty
+// ---------------------------------------------------------------------------
+
+// rubyHTTPartyClassVerbRe matches `HTTParty.get(url)`, `HTTParty.post(url, body: ...)`.
+var rubyHTTPartyClassVerbRe = regexp.MustCompile(
+	`\bHTTParty\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// rubyHTTPartyIncludedVerbRe matches the included-module form where HTTParty
+// is mixed in and called as a plain method: `get(url)`, `post(url, body: ...)`.
+// We require `include HTTParty` in the same file as a guard.
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = single-quoted url,
+// 4 = identifier url.
+var rubyHTTPartyIncludedVerbRe = regexp.MustCompile(
+	`(?:^|[^\w.])(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// RestClient
+// ---------------------------------------------------------------------------
+
+// rubyRestClientClassVerbRe matches `RestClient.get(url)`, `RestClient.post(url, payload)`.
+var rubyRestClientClassVerbRe = regexp.MustCompile(
+	`\bRestClient\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: identifier url
+		`)`,
+)
+
+// rubyRestClientResourceVerbRe matches
+// `RestClient::Resource.new(url).get` and
+// `RestClient::Resource.new(url).post(payload)`.
+// We capture the verb from the method call after `.new(url)`.
+var rubyRestClientResourceVerbRe = regexp.MustCompile(
+	`\bRestClient::Resource\s*\.\s*new\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 1: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 2: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 3: identifier url
+		`)\s*\)\s*\.\s*(get|post|put|patch|delete|head|options)`,
+)
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// rubyEnvConcatRe matches `ENV['API_URL'] + '/path'` or
+// `ENV["API_URL"] + "/path"` as a URL prefix. Used to detect runtime-dynamic
+// URLs in Net::HTTP.get / HTTParty.get / RestClient.get / Faraday calls.
+//
+// Capture groups:
+//
+//	1 = path suffix (the string concatenated after the env var)
+var rubyEnvConcatRe = regexp.MustCompile(
+	`ENV\s*\[['"][^'"]+['"]\]\s*\+\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// rubyNetHTTPEnvVerbRe matches `Net::HTTP.get(URI(ENV['X'] + '/path'))`.
+// Capture groups: 1 = verb, 2 = path suffix (double-quoted), 3 = path suffix (single-quoted).
+var rubyNetHTTPEnvVerbRe = regexp.MustCompile(
+	`\bNet::HTTP\s*\.\s*(get|post|put|delete|head|patch|options)\s*\(\s*(?:URI\s*\(\s*)?ENV\s*\[['"][^'"]+['"]\]\s*\+\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// rubyHTTPartyEnvVerbRe matches `HTTParty.get(ENV['X'] + '/path')`.
+// Capture groups: 1 = verb, 2 = path suffix (double-quoted), 3 = path suffix (single-quoted).
+var rubyHTTPartyEnvVerbRe = regexp.MustCompile(
+	`\bHTTParty\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*ENV\s*\[['"][^'"]+['"]\]\s*\+\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// rubyRestClientEnvVerbRe matches `RestClient.get(ENV['X'] + '/path')`.
+// Capture groups: 1 = verb, 2 = path suffix (double-quoted), 3 = path suffix (single-quoted).
+var rubyRestClientEnvVerbRe = regexp.MustCompile(
+	`\bRestClient\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*ENV\s*\[['"][^'"]+['"]\]\s*\+\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// ---------------------------------------------------------------------------
+// String constant table
+// ---------------------------------------------------------------------------
+
+// rubyStringConstRe captures simple Ruby constant/variable declarations:
+//
+//	API_URL = "/value"
+//	base_url = "/value"
+//	BASE = '/value'
+var rubyStringConstRe = regexp.MustCompile(
+	`(?m)([A-Z_][A-Z0-9_]*|[a-z_][a-z0-9_]*)\s*=\s*(?:"([^"\n\r]{1,256})"|'([^'\n\r]{1,256})')`,
+)
+
+// ---------------------------------------------------------------------------
+// Enclosing function index
+// ---------------------------------------------------------------------------
+
+// rubyEnclosingMethodRe captures Ruby method definitions:
+//
+//	def foo(...)
+//	def self.foo(...)
+//	def initialize(...)
+var rubyEnclosingMethodRe = regexp.MustCompile(
+	`(?m)^\s*def\s+(?:self\s*\.\s*)?([A-Za-z_]\w*)\s*[(\n]`,
+)
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// rubyClientEmitFn is the runtime-aware emitter type for Ruby clients.
+type rubyClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeRubyClient is the package-level entry point referenced from
+// applyHTTPEndpointSynthesis.
+func synthesizeRubyClient(content string, emit emitFn) {
+	synthesizeRubyClientWithRuntime(content, func(method, canonicalPath, framework, refKind, refName string, _ bool) {
+		emit(method, canonicalPath, framework, refKind, refName)
+	})
+}
+
+// synthesizeRubyClientWithRuntime runs the full Ruby client scan.
+func synthesizeRubyClientWithRuntime(content string, emit rubyClientEmitFn) {
+	if !rubyHasAnyHTTPClient(content) {
+		return
+	}
+	funcs := indexRubyEnclosingMethods(content)
+	syms := buildRubyStringSymbolTable(content)
+	hasHTTPartyInclude := strings.Contains(content, "include HTTParty")
+
+	// ----- Net::HTTP class-level verbs: Net::HTTP.get/post/... -----
+	for _, m := range rubyNetHTTPClassVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rubyPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "net_http", "Function", caller, false)
+	}
+
+	// ----- Net::HTTP instance verbs: http.get(path), conn.post(path) -----
+	for _, m := range rubyNetHTTPInstanceVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		raw := rubyPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "net_http", "Function", caller, false)
+	}
+
+	// ----- Net::HTTP.start(host, port) { |http| http.get(path) } -----
+	for _, m := range rubyNetHTTPStartBlockRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		raw := rubyPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "net_http", "Function", caller, false)
+	}
+
+	// ----- Faraday class-level: Faraday.get(url) -----
+	for _, m := range rubyFaradayClassVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rubyPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "faraday", "Function", caller, false)
+	}
+
+	// ----- Faraday instance: conn.get(path), conn.post(path) { ... } -----
+	for _, m := range rubyFaradayInstanceVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		raw := rubyPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "faraday", "Function", caller, false)
+	}
+
+	// ----- HTTParty class-level: HTTParty.get(url) -----
+	for _, m := range rubyHTTPartyClassVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rubyPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "httparty", "Function", caller, false)
+	}
+
+	// ----- HTTParty included form: get(url), post(url) (only when include HTTParty present) -----
+	if hasHTTPartyInclude {
+		for _, m := range rubyHTTPartyIncludedVerbRe.FindAllStringSubmatchIndex(content, -1) {
+			if len(m) < 10 {
+				continue
+			}
+			verb := strings.ToUpper(content[m[2]:m[3]])
+			raw := rubyPickURLArg(content, m, 4, syms)
+			if raw == "" {
+				continue
+			}
+			path := stripURLHost(raw)
+			if !looksLikeURLPath(path) {
+				continue
+			}
+			caller := enclosingRubyMethodAt(funcs, m[0])
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			emit(verb, canonical, "httparty", "Function", caller, false)
+		}
+	}
+
+	// ----- RestClient class-level: RestClient.get(url) -----
+	for _, m := range rubyRestClientClassVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rubyPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "rest_client", "Function", caller, false)
+	}
+
+	// ----- RestClient::Resource.new(url).get / .post -----
+	for _, m := range rubyRestClientResourceVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		// URL is in groups 1 (double-quoted), 2 (single-quoted), 3 (identifier).
+		// Verb is in group 4.
+		raw := ""
+		if m[2] >= 0 {
+			raw = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			ident := content[m[6]:m[7]]
+			if val, ok := syms[ident]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		verb := strings.ToUpper(content[m[8]:m[9]])
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "rest_client", "Function", caller, false)
+	}
+
+	// ----- Env-var concat: Net::HTTP.get(URI(ENV['X'] + '/path')) -----
+	for _, m := range rubyNetHTTPEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := rubyPickEnvSuffix(content, m, 4)
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "net_http", "Function", caller, true)
+	}
+
+	// ----- Env-var concat: HTTParty.get(ENV['X'] + '/path') -----
+	for _, m := range rubyHTTPartyEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := rubyPickEnvSuffix(content, m, 4)
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "httparty", "Function", caller, true)
+	}
+
+	// ----- Env-var concat: RestClient.get(ENV['X'] + '/path') -----
+	for _, m := range rubyRestClientEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := rubyPickEnvSuffix(content, m, 4)
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRubyMethodAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "rest_client", "Function", caller, true)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func rubyHasAnyHTTPClient(content string) bool {
+	return strings.Contains(content, "Net::HTTP") ||
+		strings.Contains(content, "Faraday") ||
+		strings.Contains(content, "HTTParty") ||
+		strings.Contains(content, "RestClient") ||
+		strings.Contains(content, "faraday") ||
+		strings.Contains(content, "conn.get") ||
+		strings.Contains(content, "conn.post") ||
+		strings.Contains(content, "client.get") ||
+		strings.Contains(content, "client.post")
+}
+
+// buildRubyStringSymbolTable returns a map from identifier → string value
+// for simple constant/variable declarations in the file.
+func buildRubyStringSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range rubyStringConstRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name, val string
+		if m[2] >= 0 {
+			name = content[m[2]:m[3]]
+		}
+		if name == "" {
+			continue
+		}
+		if m[4] >= 0 {
+			val = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			val = content[m[6]:m[7]]
+		}
+		if _, dup := syms[name]; !dup {
+			syms[name] = val
+		}
+	}
+	return syms
+}
+
+// rubyPickURLArg extracts the URL string from a match's double-quoted /
+// single-quoted / identifier group triple. `litStart` is the index within
+// `m` of the first literal group.
+func rubyPickURLArg(content string, m []int, litStart int, syms map[string]string) string {
+	// Double-quoted literal.
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	// Single-quoted literal.
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	// Bare identifier — resolve via symbol table.
+	if litStart+5 < len(m) && m[litStart+4] >= 0 {
+		ident := content[m[litStart+4]:m[litStart+5]]
+		if val, ok := syms[ident]; ok {
+			return val
+		}
+	}
+	return ""
+}
+
+// rubyPickEnvSuffix extracts the path suffix string from an env-var concat
+// regex match. Groups at litStart (double-quoted) and litStart+2
+// (single-quoted) are checked.
+func rubyPickEnvSuffix(content string, m []int, litStart int) string {
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	return ""
+}
+
+// indexRubyEnclosingMethods builds a sorted (offset, name) list for every
+// Ruby method definition in the file.
+func indexRubyEnclosingMethods(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range rubyEnclosingMethodRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingRubyMethodAt returns the name of the nearest preceding method
+// definition for a call site at `pos`.
+func enclosingRubyMethodAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_ruby_client_test.go
+++ b/internal/engine/http_endpoint_ruby_client_test.go
@@ -1,0 +1,326 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Net::HTTP class-level verbs
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_NetHTTPClassLiteral covers Net::HTTP.get(URI(url)) and
+// Net::HTTP.post(URI(url), data) with literal string URLs.
+func TestRubyClient_NetHTTPClassLiteral(t *testing.T) {
+	src := `
+require 'net/http'
+require 'uri'
+
+def fetch_users
+  Net::HTTP.get(URI("https://api.example.com/api/users"))
+end
+
+def create_user(data)
+  Net::HTTP.post(URI("https://api.example.com/api/users"), data)
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "users_client.rb", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, ids, want, "ruby-net-http-class-literal")
+	requireFetches(t, rels, "http:GET:/api/users", "ruby-net-http-class-literal")
+	requireFetches(t, rels, "http:POST:/api/users", "ruby-net-http-class-literal")
+}
+
+// TestRubyClient_NetHTTPInstanceVerbs covers the instance form:
+// http = Net::HTTP.new(host, port); http.get(path), http.post(path)
+func TestRubyClient_NetHTTPInstanceVerbs(t *testing.T) {
+	src := `
+require 'net/http'
+
+def fetch_orders
+  http = Net::HTTP.new("api.example.com", 443)
+  http.get("/api/orders")
+end
+
+def place_order(body)
+  conn = Net::HTTP.new("api.example.com", 443)
+  conn.post("/api/orders", body)
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "orders_client.rb", src)
+	want := []string{
+		"http:GET:/api/orders",
+		"http:POST:/api/orders",
+	}
+	requireContains(t, ids, want, "ruby-net-http-instance")
+	requireFetches(t, rels, "http:GET:/api/orders", "ruby-net-http-instance")
+	requireFetches(t, rels, "http:POST:/api/orders", "ruby-net-http-instance")
+}
+
+// TestRubyClient_NetHTTPStartBlock covers the block form:
+// Net::HTTP.start(host, port) { |http| http.get(path) }
+func TestRubyClient_NetHTTPStartBlock(t *testing.T) {
+	src := `
+require 'net/http'
+
+def fetch_profile
+  Net::HTTP.start("api.example.com", 443) { |http| http.get("/api/profile") }
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "profile_client.rb", src)
+	requireContains(t, ids, []string{"http:GET:/api/profile"}, "ruby-net-http-start-block")
+	requireFetches(t, rels, "http:GET:/api/profile", "ruby-net-http-start-block")
+}
+
+// ---------------------------------------------------------------------------
+// Faraday
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_FaradayClass covers Faraday.get(url), Faraday.post(url).
+func TestRubyClient_FaradayClass(t *testing.T) {
+	src := `
+require 'faraday'
+
+def list_products
+  Faraday.get("https://api.example.com/api/products")
+end
+
+def create_product(body)
+  Faraday.post("https://api.example.com/api/products")
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "faraday_client.rb", src)
+	want := []string{
+		"http:GET:/api/products",
+		"http:POST:/api/products",
+	}
+	requireContains(t, ids, want, "ruby-faraday-class")
+	requireFetches(t, rels, "http:GET:/api/products", "ruby-faraday-class")
+	requireFetches(t, rels, "http:POST:/api/products", "ruby-faraday-class")
+}
+
+// TestRubyClient_FaradayInstance covers conn.get(path), conn.post(path) { |req| ... }
+func TestRubyClient_FaradayInstance(t *testing.T) {
+	src := `
+require 'faraday'
+
+def search_items(q)
+  conn = Faraday.new(url: 'https://api.example.com')
+  conn.get('/api/search')
+end
+
+def submit_form(data)
+  conn = Faraday.new(url: 'https://api.example.com')
+  conn.post('/api/submissions') do |req|
+    req.body = data
+  end
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "faraday_instance.rb", src)
+	want := []string{
+		"http:GET:/api/search",
+		"http:POST:/api/submissions",
+	}
+	requireContains(t, ids, want, "ruby-faraday-instance")
+	requireFetches(t, rels, "http:GET:/api/search", "ruby-faraday-instance")
+	requireFetches(t, rels, "http:POST:/api/submissions", "ruby-faraday-instance")
+}
+
+// ---------------------------------------------------------------------------
+// HTTParty
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_HTTPartyClass covers HTTParty.get(url), HTTParty.post(url, body: ...).
+func TestRubyClient_HTTPartyClass(t *testing.T) {
+	src := `
+require 'httparty'
+
+def get_status
+  HTTParty.get("https://api.example.com/api/status")
+end
+
+def login(creds)
+  HTTParty.post("https://api.example.com/api/auth/login", body: creds)
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "httparty_client.rb", src)
+	want := []string{
+		"http:GET:/api/status",
+		"http:POST:/api/auth/login",
+	}
+	requireContains(t, ids, want, "ruby-httparty-class")
+	requireFetches(t, rels, "http:GET:/api/status", "ruby-httparty-class")
+	requireFetches(t, rels, "http:POST:/api/auth/login", "ruby-httparty-class")
+}
+
+// TestRubyClient_HTTPartyIncluded covers the include HTTParty form where
+// HTTP methods are called without the HTTParty. prefix.
+func TestRubyClient_HTTPartyIncluded(t *testing.T) {
+	src := `
+require 'httparty'
+
+class UserService
+  include HTTParty
+  base_uri 'https://api.example.com'
+
+  def users
+    get('/api/users')
+  end
+
+  def create(user)
+    post('/api/users')
+  end
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "user_service.rb", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, ids, want, "ruby-httparty-included")
+	requireFetches(t, rels, "http:GET:/api/users", "ruby-httparty-included")
+	requireFetches(t, rels, "http:POST:/api/users", "ruby-httparty-included")
+}
+
+// ---------------------------------------------------------------------------
+// RestClient
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_RestClientClass covers RestClient.get(url), RestClient.post(url, payload).
+func TestRubyClient_RestClientClass(t *testing.T) {
+	src := `
+require 'rest-client'
+
+def fetch_payments
+  RestClient.get("https://api.example.com/api/payments")
+end
+
+def create_payment(payload)
+  RestClient.post("https://api.example.com/api/payments", payload)
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "rest_client_class.rb", src)
+	want := []string{
+		"http:GET:/api/payments",
+		"http:POST:/api/payments",
+	}
+	requireContains(t, ids, want, "ruby-rest-client-class")
+	requireFetches(t, rels, "http:GET:/api/payments", "ruby-rest-client-class")
+	requireFetches(t, rels, "http:POST:/api/payments", "ruby-rest-client-class")
+}
+
+// TestRubyClient_RestClientResource covers RestClient::Resource.new(url).get and .post.
+func TestRubyClient_RestClientResource(t *testing.T) {
+	src := `
+require 'rest-client'
+
+def fetch_inventory
+  RestClient::Resource.new("https://api.example.com/api/inventory").get
+end
+
+def add_item(payload)
+  RestClient::Resource.new("https://api.example.com/api/inventory").post(payload)
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "rest_resource.rb", src)
+	want := []string{
+		"http:GET:/api/inventory",
+		"http:POST:/api/inventory",
+	}
+	requireContains(t, ids, want, "ruby-rest-client-resource")
+	requireFetches(t, rels, "http:GET:/api/inventory", "ruby-rest-client-resource")
+	requireFetches(t, rels, "http:POST:/api/inventory", "ruby-rest-client-resource")
+}
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_EnvVarConcat covers Net::HTTP.get(URI(ENV['API_URL'] + '/users'))
+// → runtime_dynamic=true.
+func TestRubyClient_EnvVarConcat(t *testing.T) {
+	src := `
+require 'net/http'
+require 'uri'
+
+def call_remote
+  Net::HTTP.get(URI(ENV['API_URL'] + '/users'))
+end
+`
+	ids, rels := runDetectWithRels(t, "ruby", "env_client.rb", src)
+	requireContains(t, ids, []string{"http:GET:/users"}, "ruby-env-var-concat")
+	requireFetches(t, rels, "http:GET:/users", "ruby-env-var-concat")
+
+	// Verify runtime_dynamic=true is stamped on the entity.
+	_, res := runDetect(t, "ruby", "env_client.rb", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/users" && e.Properties["runtime_dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("ruby-env-var-concat: expected runtime_dynamic=true on http:GET:/users")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verb coverage
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_VerbCoverage covers all HTTP verbs on Net::HTTP and HTTParty.
+func TestRubyClient_VerbCoverage(t *testing.T) {
+	src := `
+require 'httparty'
+
+def all_verbs
+  HTTParty.get("https://api.example.com/api/items")
+  HTTParty.post("https://api.example.com/api/items")
+  HTTParty.put("https://api.example.com/api/items/1")
+  HTTParty.patch("https://api.example.com/api/items/1")
+  HTTParty.delete("https://api.example.com/api/items/1")
+  HTTParty.head("https://api.example.com/api/items")
+  HTTParty.options("https://api.example.com/api/items")
+end
+`
+	ids, _ := runDetectWithRels(t, "ruby", "all_verbs.rb", src)
+	want := []string{
+		"http:GET:/api/items",
+		"http:POST:/api/items",
+		"http:PUT:/api/items/1",
+		"http:PATCH:/api/items/1",
+		"http:DELETE:/api/items/1",
+		"http:HEAD:/api/items",
+		"http:OPTIONS:/api/items",
+	}
+	requireContains(t, ids, want, "ruby-verb-coverage")
+}
+
+// ---------------------------------------------------------------------------
+// Negative case
+// ---------------------------------------------------------------------------
+
+// TestRubyClient_Negative verifies that a non-HTTP Ruby file does not emit
+// any http_endpoint synthetics.
+func TestRubyClient_Negative(t *testing.T) {
+	src := `
+class DataProcessor
+  def process(items)
+    items.map { |item| item.upcase }
+  end
+
+  def filter(items, &block)
+    items.select(&block)
+  end
+end
+`
+	ids, _ := runDetectWithRels(t, "ruby", "data_processor.rb", src)
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			t.Errorf("ruby-negative: unexpected http_endpoint %q from non-HTTP file", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -83,7 +83,7 @@ func synthesisSupportsLanguage(lang string) bool {
 	// rules are compiled for them so the per-protocol synthesizers can
 	// run. Files in these languages that contain none of the recognised
 	// anchors are no-ops in the synthesizers themselves.
-	case "kotlin", "go", "csharp":
+	case "kotlin", "go", "csharp", "ruby":
 		return true
 	default:
 		return false
@@ -249,6 +249,12 @@ func applyHTTPEndpointSynthesis(
 	case "kotlin":
 		// Consumer side (#721 wave 2a): Ktor, OkHttp-Kotlin, Retrofit-K.
 		synthesizeKotlinClientWithRuntime(string(content), emitClientRuntime)
+	case "ruby":
+		// Consumer side (#721 wave 2b): Net::HTTP, Faraday, HTTParty, RestClient.
+		synthesizeRubyClientWithRuntime(string(content), emitClientRuntime)
+	case "csharp":
+		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
+		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	}
 
 	// #722 — response/request shape extraction. Mutates Properties on


### PR DESCRIPTION
## Summary

- **Ruby** (`http_endpoint_ruby_client.go`): Net::HTTP (class, instance, `start`-block), Faraday (class + instance), HTTParty (class + `include HTTParty` module form), RestClient (class + `Resource.new`). Env-var concat (`ENV['X'] + '/path'`) → `runtime_dynamic=true`.
- **C#** (`http_endpoint_csharp_client.go`): HttpClient async verbs (GetAsync/PostAsync/PutAsync/DeleteAsync/PatchAsync + HeadAsync), HttpRequestMessage + SendAsync, RestSharp (`RestRequest(path, Method.Verb)` + ExecuteAsync), Refit interface annotations (`[Get]` / `[Post]` / `[Put]` / `[Delete]` / `[Patch]` / `[Head]`), WebClient legacy (DownloadString → GET, UploadString → POST). Env-var concat (`Environment.GetEnvironmentVariable("X") + "/path"`) → `runtime_dynamic=true`.
- **Wiring**: both languages registered in `synthesisSupportsLanguage` and the `applyHTTPEndpointSynthesis` switch in `http_endpoint_synthesis.go`.

## Test counts

| Language | New unit tests | Pass |
|---|---|---|
| Ruby | 12 | ✅ all |
| C# | 11 | ✅ all |
| **Total new** | **23** | **✅** |

## Quality fixture FETCHES counts

No existing Ruby or C# quality fixtures contain HTTP client calls — as expected for Wave 2b. Unit tests are the primary deliverable; real-world counts wait for corpus expansion.

## Cross-language parity

Full engine suite (`go test ./internal/engine/... -count=1`) is green. All Wave 1 (Python, Java) and Wave 2a (Go, Kotlin) tests pass unchanged.

## Files touched

- `internal/engine/http_endpoint_ruby_client.go` (new)
- `internal/engine/http_endpoint_ruby_client_test.go` (new)
- `internal/engine/http_endpoint_csharp_client.go` (new)
- `internal/engine/http_endpoint_csharp_client_test.go` (new)
- `internal/engine/http_endpoint_synthesis.go` (wiring only — 4 lines)

## Beyond-minimum coverage delivered

- Ruby `Net::HTTP.start(host, port) { |http| http.get(path) }` block form
- C# `WebClient` legacy patterns (DownloadString → GET, UploadString → POST)
- All C# async/await variants (GetAsync/PostAsync/PutAsync/DeleteAsync/PatchAsync/HeadAsync/OptionsAsync)
- Full Refit annotation suite (`[Get]`, `[Post]`, `[Put]`, `[Delete]`, `[Patch]`, `[Head]`)

## Recommendation: Wave 2c

Next sub-wave should cover **Rust** (reqwest, hyper) and **PHP** (Guzzle, Symfony HttpClient, cURL wrappers). Both languages have clear library dominance analogous to Python/requests and Java/OkHttp — the synthesizer pattern from this PR ports directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)