### PR TITLE
[#781] DRF ViewSet generic-method resolution — emit ROUTES_TO for list/create/retrieve/update/destroy

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -120,6 +120,15 @@ var drfRouterVarDeclRe = regexp.MustCompile(
 	`(\w+)\s*=\s*\w*\.?(?:Default|Simple|Extended|Nested(?:Simple|Default)?)Router\s*\(`,
 )
 
+// drfExplicitMethodRe detects explicit CRUD method definitions in a ViewSet
+// class body. Matches `def <method>(self` where <method> is one of the six
+// standard DRF CRUD method names. Used to distinguish methods that are
+// explicitly defined (handler entity already emitted by the Python extractor)
+// from inherited methods (no entity exists — we must emit a synthetic one).
+var drfExplicitMethodRe = regexp.MustCompile(
+	`\bdef\s+(list|create|retrieve|update|partial_update|destroy)\s*\(\s*self`,
+)
+
 // drfViewSetClass describes a ViewSet class located on disk and parsed for
 // its CRUD method support + @action endpoints + lookup_field override.
 type drfViewSetClass struct {
@@ -127,6 +136,11 @@ type drfViewSetClass struct {
 	// derived from its parent classes (ModelViewSet etc.). Keys are
 	// "list", "create", "retrieve", "update", "partial_update", "destroy".
 	crudMethods map[string]bool
+	// explicitMethods is the subset of crudMethods that are directly defined
+	// in the ViewSet class body (not merely inherited). When a method is in
+	// crudMethods but NOT in explicitMethods, we emit a synthetic
+	// SCOPE.Operation entity for it so source_handler can resolve.
+	explicitMethods map[string]bool
 	// lookupField is the placeholder name to use for detail routes
 	// (default "pk").
 	lookupField string
@@ -175,6 +189,12 @@ func ApplyDjangoDRFRoutes(
 	var out []types.EntityRecord
 	seen := map[string]bool{}
 
+	// seenMethods tracks (viewSetFile, viewSet.method) pairs for which we
+	// have already emitted a synthetic SCOPE.Operation entity. Prevents
+	// duplicate synthetic method entities when a ViewSet is registered on
+	// multiple prefixes (e.g. the bare-prefix + parent-include variants).
+	seenMethods := map[string]bool{}
+
 	emit := func(verb, canonical, sourceFile, viewSet, methodName string) {
 		if canonical == "" || canonical == "/" {
 			return
@@ -185,18 +205,20 @@ func ApplyDjangoDRFRoutes(
 		}
 		seen[id] = true
 
-		// NOTE: we deliberately do NOT set the `source_handler` property
-		// here. The Phase-2 resolver (`ResolveHTTPEndpointHandlers`) drops
-		// any synthetic whose `source_handler` does not resolve against
-		// the merged entity index — and the ViewSet method entity lives
-		// in a different file with a different name shape than our
-		// synthetic refers to. Leaving it unset routes the synthetic
-		// through the `NoHandlerProp` keep-path of the resolver, so all
-		// the expanded routes survive and can be matched by the
-		// cross-repo HTTP linker via their canonical Name.
-		// We record the ViewSet method in `drf_view_method` instead so
-		// downstream consumers retain the link without going through the
-		// resolver.
+		// Issue #699c — set source_handler so the Phase-2 resolver
+		// (ResolveHTTPEndpointHandlers) can emit an IMPLEMENTS edge from the
+		// ViewSet method entity to this synthetic. The resolver's cross-file
+		// globalIdx fallback (PR #753) finds the handler even though it lives
+		// in a different file than the urlconf synthetic.
+		//
+		// When the CRUD method is inherited (not explicitly defined in the
+		// ViewSet class body), emitViewSetMethodEntities emits a synthetic
+		// SCOPE.Operation entity for it BEFORE the http_endpoint synthetics
+		// are added to `out`. The resolver therefore sees a candidate in the
+		// merged entity index and resolves successfully.
+		//
+		// For the ANY-verb detail catch-all (methodName == ""), we skip
+		// source_handler because ANY has no single owning handler method.
 		props := map[string]string{
 			"verb":         strings.ToUpper(verb),
 			"path":         canonical,
@@ -205,9 +227,13 @@ func ApplyDjangoDRFRoutes(
 		}
 		if viewSet != "" {
 			if methodName != "" {
-				props["drf_view_method"] = viewSet + "." + methodName
+				qualifiedMethod := viewSet + "." + methodName
+				props["drf_view_method"] = qualifiedMethod
+				props["source_handler"] = "SCOPE.Operation:" + qualifiedMethod
 			} else {
 				props["drf_view_method"] = viewSet
+				// ANY catch-all: no single handler — leave source_handler unset
+				// so the resolver takes the NoHandlerProp keep-path.
 			}
 		}
 
@@ -301,6 +327,23 @@ func ApplyDjangoDRFRoutes(
 			// Compose the prefix with any parent include() prefix and any
 			// nested-router parent prefix the router was attached to.
 			composedPrefixes := expandRegisterPrefixes(prefix, parentPrefixes, nestedPrefixes, src)
+
+			// Issue #699c — emit synthetic SCOPE.Operation entities for each
+			// CRUD method that the ViewSet exposes via inheritance but does NOT
+			// explicitly define. Without these entities, source_handler cannot
+			// resolve against the merged entity index and the http_endpoint
+			// synthetics would remain orphaned. emitViewSetMethodEntities must
+			// run BEFORE emitCRUDFamily so the method entities appear in `out`
+			// ahead of the http_endpoint synthetics (first-writer-wins dedup).
+			//
+			// We use the ViewSet's source file when available; fall back to the
+			// urlconf file. seenMethods prevents duplicate emission when the
+			// same ViewSet is registered on multiple prefixes.
+			handlerFile := viewFile
+			if handlerFile == "" {
+				handlerFile = relPath
+			}
+			emitViewSetMethodEntities(&out, seenMethods, viewSetName, vc, handlerFile)
 
 			for _, fullPrefix := range composedPrefixes {
 				emitCRUDFamily(emit, fullPrefix, vc, relPath, viewSetName)
@@ -542,6 +585,71 @@ func emitActionRoutes(
 	}
 }
 
+// emitViewSetMethodEntities emits synthetic SCOPE.Operation entities for each
+// CRUD method that the ViewSet exposes via inheritance but does NOT explicitly
+// define in its class body (i.e. methods in crudMethods but NOT in
+// explicitMethods). These synthetic entities give ResolveHTTPEndpointHandlers
+// a target for the source_handler = "SCOPE.Operation:ViewSet.method" property
+// set on http_endpoint synthetics, so it can emit IMPLEMENTS edges and resolve
+// the orphan.
+//
+// Without these, a `ModelViewSet` with no overridden methods would have 6
+// http_endpoint entities with source_handler set, but none of the CRUD method
+// entities in the index (the Python extractor only emits methods it actually
+// parses from the file). The resolver would drop all 6 synthetics as
+// HandlerDropped.
+//
+// Design notes:
+//   - Uses kind=SCOPE.Operation, subtype=method — identical to what the Python
+//     extractor emits for explicitly-defined ViewSet methods.
+//   - Name = "<ViewSet>.<method>" — the resolver's globalIdx key (kind, name)
+//     will find this entity when looking up source_handler references.
+//   - SourceFile = the ViewSet's source file (or the urlconf file as fallback).
+//   - QualityScore = 0.7 (below extractor-emitted entities at 1.0, above the
+//     http_endpoint synthetic at 0.8) so dedup-by-ID prefers the real entity
+//     if the extractor later emits one for the same method.
+//   - seenMethods prevents duplicate emission when the same ViewSet is
+//     registered on multiple URL prefixes (bare + parent-include variants).
+func emitViewSetMethodEntities(
+	out *[]types.EntityRecord,
+	seenMethods map[string]bool,
+	viewSetName string,
+	vc drfViewSetClass,
+	sourceFile string,
+) {
+	for method := range vc.crudMethods {
+		if vc.explicitMethods[method] {
+			// The Python extractor already emitted a real SCOPE.Operation
+			// entity for this method — no synthetic needed.
+			continue
+		}
+		key := sourceFile + "\x00" + viewSetName + "." + method
+		if seenMethods[key] {
+			continue
+		}
+		seenMethods[key] = true
+		qualifiedName := viewSetName + "." + method
+		*out = append(*out, types.EntityRecord{
+			// ID is left blank — stampEntityIDs in the indexer pipeline
+			// will compute it from (repoTag, Kind, Name, SourceFile).
+			Name:               qualifiedName,
+			Kind:               "SCOPE.Operation",
+			Subtype:            "method",
+			Language:           "python",
+			SourceFile:         sourceFile,
+			Signature:          "def " + method + "(self, request, *args, **kwargs)",
+			EnrichmentRequired: false,
+			QualityScore:       0.7,
+			Properties: map[string]string{
+				"pattern_type":      "drf_viewset_implicit_method",
+				"viewset_class":     viewSetName,
+				"inherited_from":    "rest_framework",
+				"drf_method_origin": method,
+			},
+		})
+	}
+}
+
 // canonicalDjango is a small convenience wrapper around
 // httproutes.Canonicalize tuned for the Django framework.
 func canonicalDjango(raw string) string {
@@ -721,6 +829,17 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 		out.lookupField = m[1]
 	}
 	out.actions = extractActions(classBody)
+
+	// Issue #699c — detect which CRUD methods are explicitly defined in
+	// the class body. Only methods with an explicit `def <name>(self` in
+	// the body are marked explicit; all others are inherited from a mixin
+	// or parent class and need a synthetic SCOPE.Operation entity.
+	out.explicitMethods = make(map[string]bool)
+	for _, m := range drfExplicitMethodRe.FindAllStringSubmatch(classBody, -1) {
+		if len(m) >= 2 {
+			out.explicitMethods[m[1]] = true
+		}
+	}
 	return out
 }
 

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -422,6 +422,296 @@ func TestClassifyViewSetParent(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Issue #699c — source_handler + synthetic SCOPE.Operation entity tests
+// ---------------------------------------------------------------------------
+
+// TestApplyDjangoDRFRoutes_SourceHandlerSet verifies that each http_endpoint
+// synthetic emitted for a CRUD method carries source_handler =
+// "SCOPE.Operation:<ViewSet>.<method>" so ResolveHTTPEndpointHandlers can
+// emit an IMPLEMENTS edge. The ANY catch-all must NOT carry source_handler
+// (it has no single owning method).
+func TestApplyDjangoDRFRoutes_SourceHandlerSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import UserViewSet
+
+router = routers.DefaultRouter()
+router.register(r"users", UserViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class UserViewSet(ModelViewSet):
+    pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	wantHandlers := map[string]string{
+		"http:GET:/users":         "SCOPE.Operation:UserViewSet.list",
+		"http:POST:/users":        "SCOPE.Operation:UserViewSet.create",
+		"http:GET:/users/{pk}":    "SCOPE.Operation:UserViewSet.retrieve",
+		"http:PUT:/users/{pk}":    "SCOPE.Operation:UserViewSet.update",
+		"http:PATCH:/users/{pk}":  "SCOPE.Operation:UserViewSet.partial_update",
+		"http:DELETE:/users/{pk}": "SCOPE.Operation:UserViewSet.destroy",
+	}
+
+	for _, r := range got {
+		if r.Kind != httpEndpointKind {
+			continue
+		}
+		want, ok := wantHandlers[r.ID]
+		if !ok {
+			continue
+		}
+		got := r.Properties["source_handler"]
+		if got != want {
+			t.Errorf("entity %q: source_handler=%q want %q", r.ID, got, want)
+		}
+	}
+
+	// ANY catch-all must NOT have source_handler.
+	for _, r := range got {
+		if r.Kind != httpEndpointKind {
+			continue
+		}
+		if r.Properties["verb"] == "ANY" && r.Properties["source_handler"] != "" {
+			t.Errorf("ANY catch-all entity %q has unexpected source_handler=%q",
+				r.ID, r.Properties["source_handler"])
+		}
+	}
+}
+
+// TestApplyDjangoDRFRoutes_SyntheticMethodEntitiesEmittedForInherited verifies
+// that when a ModelViewSet does NOT explicitly define a CRUD method, a
+// synthetic SCOPE.Operation entity is emitted for that method so the
+// source_handler resolver has a target to bind.
+func TestApplyDjangoDRFRoutes_SyntheticMethodEntitiesEmittedForInherited(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ArticleViewSet
+
+router = routers.DefaultRouter()
+router.register(r"articles", ArticleViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class ArticleViewSet(ModelViewSet):
+    # No methods defined — all 6 are inherited from ModelViewSet.
+    queryset = None
+    serializer_class = None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// All six CRUD method entities should be emitted as synthetics.
+	wantMethodNames := []string{
+		"ArticleViewSet.list",
+		"ArticleViewSet.create",
+		"ArticleViewSet.retrieve",
+		"ArticleViewSet.update",
+		"ArticleViewSet.partial_update",
+		"ArticleViewSet.destroy",
+	}
+
+	nameSet := make(map[string]bool)
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" {
+			nameSet[r.Name] = true
+		}
+	}
+
+	for _, want := range wantMethodNames {
+		if !nameSet[want] {
+			t.Errorf("missing synthetic SCOPE.Operation entity for %q", want)
+		}
+	}
+}
+
+// TestApplyDjangoDRFRoutes_NoSyntheticForExplicitMethods verifies that when
+// a ViewSet explicitly defines a CRUD method, NO duplicate synthetic entity
+// is emitted (the Python extractor will have already emitted a real one).
+func TestApplyDjangoDRFRoutes_NoSyntheticForExplicitMethods(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import PostViewSet
+
+router = routers.DefaultRouter()
+router.register(r"posts", PostViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class PostViewSet(ModelViewSet):
+    def list(self, request):
+        return super().list(request)
+    def retrieve(self, request, pk=None):
+        return super().retrieve(request, pk=pk)
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// list and retrieve are explicitly defined — no synthetic entity expected.
+	explicitMethods := map[string]bool{
+		"PostViewSet.list":     true,
+		"PostViewSet.retrieve": true,
+	}
+
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" && explicitMethods[r.Name] {
+			t.Errorf("unexpected synthetic SCOPE.Operation entity for explicitly-defined method %q", r.Name)
+		}
+	}
+
+	// create, update, partial_update, destroy are inherited — synthetics expected.
+	inheritedMethods := []string{
+		"PostViewSet.create",
+		"PostViewSet.update",
+		"PostViewSet.partial_update",
+		"PostViewSet.destroy",
+	}
+	nameSet := make(map[string]bool)
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" {
+			nameSet[r.Name] = true
+		}
+	}
+	for _, want := range inheritedMethods {
+		if !nameSet[want] {
+			t.Errorf("missing synthetic SCOPE.Operation entity for inherited method %q", want)
+		}
+	}
+}
+
+// TestApplyDjangoDRFRoutes_ReadOnlyViewSetSyntheticMethods verifies that
+// ReadOnlyModelViewSet emits synthetics only for list + retrieve.
+func TestApplyDjangoDRFRoutes_ReadOnlyViewSetSyntheticMethods(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ReadOnlyVS
+
+router = routers.DefaultRouter()
+router.register(r"items", ReadOnlyVS)
+`,
+		"views.py": `
+from rest_framework.viewsets import ReadOnlyModelViewSet
+
+class ReadOnlyVS(ReadOnlyModelViewSet):
+    pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	nameSet := make(map[string]bool)
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" {
+			nameSet[r.Name] = true
+		}
+	}
+
+	// Only list and retrieve should be emitted for ReadOnly.
+	if !nameSet["ReadOnlyVS.list"] {
+		t.Error("missing ReadOnlyVS.list synthetic entity")
+	}
+	if !nameSet["ReadOnlyVS.retrieve"] {
+		t.Error("missing ReadOnlyVS.retrieve synthetic entity")
+	}
+
+	// Mutable methods must NOT be emitted.
+	for _, unwanted := range []string{"ReadOnlyVS.create", "ReadOnlyVS.update", "ReadOnlyVS.destroy"} {
+		if nameSet[unwanted] {
+			t.Errorf("unexpected synthetic entity for ReadOnly-unsupported method %q", unwanted)
+		}
+	}
+}
+
+// TestApplyDjangoDRFRoutes_ActionSourceHandlerSet verifies that @action
+// endpoints also receive source_handler pointing to the action method name.
+func TestApplyDjangoDRFRoutes_ActionSourceHandlerSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import ContractViewSet
+
+router = routers.DefaultRouter()
+router.register(r"contracts", ContractViewSet)
+`,
+		"views.py": `
+from rest_framework.viewsets import ModelViewSet
+from rest_framework.decorators import action
+
+class ContractViewSet(ModelViewSet):
+    @action(detail=True, methods=["post"], url_path="cancel")
+    def cancel(self, request, pk=None):
+        pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	var cancelEndpoint *types.EntityRecord
+	for i := range got {
+		if got[i].Kind == httpEndpointKind && got[i].ID == "http:POST:/contracts/{pk}/cancel" {
+			cancelEndpoint = &got[i]
+			break
+		}
+	}
+	if cancelEndpoint == nil {
+		t.Fatal("missing http:POST:/contracts/{pk}/cancel entity")
+	}
+	wantHandler := "SCOPE.Operation:ContractViewSet.cancel"
+	if got := cancelEndpoint.Properties["source_handler"]; got != wantHandler {
+		t.Errorf("cancel action source_handler=%q want %q", got, wantHandler)
+	}
+}
+
+// TestApplyDjangoDRFRoutes_NoDuplicateSyntheticEntities verifies that when a
+// ViewSet is registered on multiple prefixes (bare + parent-include), only ONE
+// set of synthetic method entities is emitted (not one per prefix).
+func TestApplyDjangoDRFRoutes_NoDuplicateSyntheticEntities(t *testing.T) {
+	files := fileMap{
+		"myproject/urls.py": `
+from django.urls import path, include
+urlpatterns = [
+    path("api/v1/", include("core.routers")),
+]
+`,
+		"core/routers.py": `
+from rest_framework import routers
+from core.views import UserViewSet
+
+router = routers.DefaultRouter()
+router.register(r"users", UserViewSet)
+`,
+		"core/views.py": `
+from rest_framework.viewsets import ModelViewSet
+
+class UserViewSet(ModelViewSet):
+    pass
+`,
+	}
+	got := ApplyDjangoDRFRoutes(
+		[]string{"myproject/urls.py", "core/routers.py", "core/views.py"},
+		files.reader,
+	)
+
+	// Count synthetic SCOPE.Operation entities for UserViewSet.list.
+	var listCount int
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" && r.Name == "UserViewSet.list" {
+			listCount++
+		}
+	}
+	if listCount != 1 {
+		t.Errorf("UserViewSet.list synthetic entity count=%d want 1", listCount)
+	}
+}
+
 func equalStringSlicesDRF(a, b []string) bool {
 	if len(a) != len(b) {
 		return false


### PR DESCRIPTION
## Summary

Closes #781. Sub-story 3 of 3 split from #699 (after #765/#780).

- **Root cause**: `ApplyDjangoDRFRoutes` emitted DRF CRUD http_endpoint synthetics but deliberately left `source_handler` unset (pre-#753 comment). Without `source_handler`, `ResolveHTTPEndpointHandlers` took the NoHandlerProp keep-path — entities had zero inbound edges and were all orphaned (1146 framework-synth orphans on client-fixture-a).
- **Fix 1**: Set `source_handler = "SCOPE.Operation:<ViewSet>.<method>"` on each CRUD and @action http_endpoint synthetic so the Phase-2 resolver's cross-file globalIdx fallback (landed in #753) emits IMPLEMENTS edges.
- **Fix 2**: Emit synthetic SCOPE.Operation entities (subtype=method, pattern_type=drf_viewset_implicit_method) for CRUD methods that a ViewSet exposes via inheritance but does NOT explicitly define. 90%+ of real-world ViewSets rely on ModelViewSet inheritance — without these entities source_handler would resolve to nothing. The explicitMethods set (populated by drfExplicitMethodRe) prevents duplicate emission when the Python extractor already has the real entity.
- **Fix 3**: seenMethods map prevents duplicate synthetic entity emission when the same ViewSet is registered on multiple URL prefixes.
- **ANY catch-all**: intentionally left without source_handler (no single owning method — NoHandlerProp keep-path is correct).

## Measurements

**client-fixture-a** (post-#780 baseline -> post-fix):

| Metric | Baseline | Post-fix | Delta |
|--------|----------|----------|-------|
| Total orphans | 1293 (16.9%) | 331 (4.2%) | -962 |
| framework-synth orphans | 1146 | 179 | -967 |
| Python orphan rate | 17.5% | 4.3% | -13.2pp |
| bug_rate | 5.62% | 5.41% | -0.21pp |
| Total entities | 7646 | 7809 | +163 synthetic method entities |

Target was >=800 DRF synthetics resolved — achieved **967**.

**Remaining 179 framework-synth** orphans are non-DRF synthetics (Django class-based views YAML routes without matching SCOPE.Operation). Separate issue.

## Quality gates

- 5 golden quality fixtures: 100% recall, 0 forbidden hits
- TestHarness_FixturesCorpus: PASS (bug_rate=5.79%)
- Full test suite: green
- Cross-language parity (express-realworld JS): bug_rate=0.04767 unchanged

## Files touched

- internal/engine/django_drf_actions.go — source_handler emission, synthetic method entity emission, explicitMethods tracking, drfExplicitMethodRe regex
- internal/engine/django_drf_actions_test.go — 6 new test cases for #699c behavior

## Links

- Parent epic: #699
- Sub-story 1 (Meta CONTAINS): PR #765 / issue #757
- Sub-story 2 (file-entity CONTAINS): PR #780 / issue #779
- This PR: closes #781