### PR TITLE
[#721][wave2c] Rust + PHP HTTP FETCHES extraction-time edges

### DIFF
--- a/internal/engine/http_endpoint_php_client.go
+++ b/internal/engine/http_endpoint_php_client.go
@@ -1,0 +1,607 @@
+// PHP consumer-side HTTP client synthesis (#721 wave 2c).
+//
+// Mirrors http_endpoint_ruby_client.go / http_endpoint_csharp_client.go for
+// PHP consumer-side HTTP patterns. Emits one synthetic `http_endpoint` entity
+// (consumer side) per detected client call site, AND a FETCHES edge from the
+// enclosing function/method to that endpoint.
+//
+// Patterns covered:
+//
+//   - Guzzle (most popular PHP HTTP client):
+//     $client = new Client(); $client->get($url), $client->post($url)
+//     $client->request('POST', $url, ['json' => $body])
+//     $client->request('GET', '/path')
+//
+//   - Symfony HttpClient:
+//     HttpClient::create()->request('GET', $url)
+//     $client->request('POST', $url, ['body' => $body])
+//     $response = $client->request('GET', 'https://example.com/api/users')
+//
+//   - cURL wrappers:
+//     curl_init($url); ... curl_setopt($ch, CURLOPT_POST, true); ... curl_exec($ch)
+//     We detect curl_init("url") as a GET and promote to POST if CURLOPT_POST
+//     or CURLOPT_CUSTOMREQUEST is set within a 1024-byte window.
+//
+//   - file_get_contents with HTTP URL:
+//     file_get_contents("https://api.example.com/path")
+//     file_get_contents($url) where $url looks HTTP-like
+//
+// Beyond-minimum behaviours:
+//   - WordPress HTTP API: wp_remote_get($url), wp_remote_post($url, $args)
+//   - Laravel HTTP facade: Http::get($url), Http::post($url, $body)
+//   - Env-var concat: $client->get(getenv('API_URL') . '/users')
+//     → emit with runtime_dynamic=true
+//   - All standard HTTP verbs on Guzzle/Symfony: GET, POST, PUT, PATCH, DELETE, HEAD
+//
+// The enclosing function is identified by scanning for the nearest preceding
+// `function <name>(` or `public function <name>(` declaration.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Guzzle: $client->get($url), $client->request('POST', $url, [...])
+// ---------------------------------------------------------------------------
+
+// phpGuzzleVerbRe matches `$client->get("url")`, `$client->post("url")`, etc.
+// Receiver allow-list: $client, $http, $guzzle, $httpClient.
+var phpGuzzleVerbRe = regexp.MustCompile(
+	`\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 4: variable url ($url, $endpoint)
+		`)`,
+)
+
+// phpGuzzleRequestRe matches `$client->request('POST', '/path', [...])` and
+// `$client->request("GET", "/path")`.
+// Capture groups: 1 = verb (single-quoted), 2 = verb (double-quoted),
+// 3 = path (double-quoted), 4 = path (single-quoted), 5 = path (variable).
+var phpGuzzleRequestRe = regexp.MustCompile(
+	`\$(?:client|http|guzzle|httpClient)\s*->\s*request\s*\(\s*(?:` +
+		`'([A-Za-z]+)'` + // group 1: single-quoted verb
+		`|` +
+		`"([A-Za-z]+)"` + // group 2: double-quoted verb
+		`)\s*,\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted path
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted path
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 5: variable path
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Symfony HttpClient: HttpClient::create()->request('GET', $url)
+// ---------------------------------------------------------------------------
+
+// phpSymfonyRequestRe matches `HttpClient::create()->request('GET', $url)` and
+// the stored-client form `$client->request('POST', $url, [...])`.
+// Capture groups: 1 = verb (single-quoted), 2 = verb (double-quoted),
+// 3 = path (double-quoted), 4 = path (single-quoted), 5 = path (variable).
+var phpSymfonyRequestRe = regexp.MustCompile(
+	`(?:HttpClient\s*::\s*create\s*\(\s*\)|(?:\$(?:client|httpClient|symfonyClient)))\s*->\s*request\s*\(\s*(?:` +
+		`'([A-Za-z]+)'` + // group 1: single-quoted verb
+		`|` +
+		`"([A-Za-z]+)"` + // group 2: double-quoted verb
+		`)\s*,\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted path
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted path
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 5: variable path
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// cURL: curl_init($url) ... curl_exec($ch)
+// ---------------------------------------------------------------------------
+
+// phpCurlInitRe matches `curl_init("url")` or `curl_init($url)`.
+// Capture groups: 1 = double-quoted url, 2 = single-quoted url, 3 = variable url.
+var phpCurlInitRe = regexp.MustCompile(
+	`\bcurl_init\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 1: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 2: single-quoted url
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 3: variable url
+		`)\s*\)`,
+)
+
+// phpCurlPostRe detects if a curl session is configured as POST via
+// curl_setopt($ch, CURLOPT_POST, true) or curl_setopt($ch, CURLOPT_CUSTOMREQUEST, "POST").
+// Used as a 1024-byte lookahead after curl_init.
+var phpCurlPostRe = regexp.MustCompile(
+	`\bcurl_setopt\s*\([^,]+,\s*CURLOPT_(?:POST|CUSTOMREQUEST)\s*,\s*(?:true|1|"([A-Za-z]+)"|'([A-Za-z]+)')`,
+)
+
+// ---------------------------------------------------------------------------
+// file_get_contents with HTTP URL
+// ---------------------------------------------------------------------------
+
+// phpFileGetContentsRe matches `file_get_contents("https://...")`.
+// Only triggers when the URL starts with http:// or https://.
+// Capture groups: 1 = double-quoted url, 2 = single-quoted url.
+var phpFileGetContentsRe = regexp.MustCompile(
+	`\bfile_get_contents\s*\(\s*(?:` +
+		`"(https?://[^"\n\r]+)"` + // group 1: double-quoted http(s) url
+		`|` +
+		`'(https?://[^'\n\r]+)'` + // group 2: single-quoted http(s) url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// WordPress HTTP API
+// ---------------------------------------------------------------------------
+
+// phpWPRemoteRe matches `wp_remote_get($url)`, `wp_remote_post($url, $args)`,
+// `wp_remote_request($url, ['method' => 'PUT', ...])`.
+// Capture groups: 1 = wp verb (get/post/request), 2 = double-quoted url,
+// 3 = single-quoted url, 4 = variable url.
+var phpWPRemoteRe = regexp.MustCompile(
+	`\bwp_remote_(get|post|request|put|delete|patch|head)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 4: variable url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Laravel HTTP facade: Http::get($url), Http::post($url, $body)
+// ---------------------------------------------------------------------------
+
+// phpLaravelHttpRe matches `Http::get("url")`, `Http::post("url", $data)`,
+// and the chained form `Http::withHeaders([...])->get("url")`.
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = single-quoted url, 4 = variable url.
+var phpLaravelHttpRe = regexp.MustCompile(
+	`\bHttp\s*(?:::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\([^)]*\)\s*->\s*)?\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 4: variable url
+		`)`,
+)
+
+// phpLaravelHttpChainedRe matches the chained form:
+// Http::withHeaders([...])->get("/path"), Http::withToken($t)->post("/path")
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = single-quoted url, 4 = variable url.
+var phpLaravelHttpChainedRe = regexp.MustCompile(
+	`\bHttp\s*::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\([^)]*\)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`(\$[A-Za-z_][\w]*)` + // group 4: variable url
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation: getenv('API_URL') . '/path'
+// ---------------------------------------------------------------------------
+
+// phpGetenvFrag is the fragment matching PHP getenv() or $_ENV[] access.
+const phpGetenvFrag = `(?:getenv\s*\([^)]+\)|\$_ENV\s*\[[^\]]+\]|\$_SERVER\s*\[[^\]]+\])`
+
+// phpGuzzleEnvVerbRe matches `$client->get(getenv('X') . '/path')`.
+// Capture groups: 1 = verb, 2 = path suffix (double-quoted), 3 = path suffix (single-quoted).
+var phpGuzzleEnvVerbRe = regexp.MustCompile(
+	`\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*` +
+		phpGetenvFrag + `\s*\.\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// phpLaravelEnvVerbRe matches `Http::get(getenv('X') . '/path')`.
+// Capture groups: 1 = verb, 2 = path suffix (double-quoted), 3 = path suffix (single-quoted).
+var phpLaravelEnvVerbRe = regexp.MustCompile(
+	`\bHttp\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*` +
+		phpGetenvFrag + `\s*\.\s*(?:"([^"\n\r]*)"|'([^'\n\r]*)')`,
+)
+
+// ---------------------------------------------------------------------------
+// PHP variable string table: $url = "/path"; $base = "https://...";
+// ---------------------------------------------------------------------------
+
+// phpStringVarRe captures PHP variable string assignments:
+//
+//	$url = "/path";
+//	$base_url = "https://api.example.com";
+//	$endpoint = '/api/v1/users';
+var phpStringVarRe = regexp.MustCompile(
+	`(?m)(\$[A-Za-z_][\w]*)\s*=\s*(?:"([^"\n\r]{1,256})"|'([^'\n\r]{1,256})')`,
+)
+
+// ---------------------------------------------------------------------------
+// Enclosing function index
+// ---------------------------------------------------------------------------
+
+// phpEnclosingFnRe captures PHP function/method definitions:
+//
+//	function foo(
+//	public function foo(
+//	private function foo(
+//	protected function foo(
+//	public static function foo(
+//	abstract public function foo(
+var phpEnclosingFnRe = regexp.MustCompile(
+	`(?m)^\s*(?:(?:abstract|final|public|protected|private|static|\s)+\s+)?function\s+([A-Za-z_]\w*)\s*\(`,
+)
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// phpClientEmitFn is the runtime-aware emitter type for PHP clients.
+type phpClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizePHPClient is the package-level entry point referenced from
+// applyHTTPEndpointSynthesis.
+func synthesizePHPClient(content string, emit emitFn) {
+	synthesizePHPClientWithRuntime(content, func(method, canonicalPath, framework, refKind, refName string, _ bool) {
+		emit(method, canonicalPath, framework, refKind, refName)
+	})
+}
+
+// synthesizePHPClientWithRuntime runs the full PHP client scan.
+func synthesizePHPClientWithRuntime(content string, emit phpClientEmitFn) {
+	if !phpHasAnyHTTPClient(content) {
+		return
+	}
+	funcs := indexPHPEnclosingFns(content)
+	syms := buildPHPStringSymbolTable(content)
+
+	// ----- Guzzle instance: $client->get($url), $client->post($url) -----
+	for _, m := range phpGuzzleVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := phpPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "guzzle", "Function", caller, false)
+	}
+
+	// ----- Guzzle request: $client->request('POST', $url, [...]) -----
+	for _, m := range phpGuzzleRequestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := phpPickVerb(content, m, 2)
+		raw := phpPickURLArg(content, m, 6, syms)
+		if verb == "" || raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "guzzle", "Function", caller, false)
+	}
+
+	// ----- Symfony HttpClient: HttpClient::create()->request('GET', $url) -----
+	for _, m := range phpSymfonyRequestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := phpPickVerb(content, m, 2)
+		raw := phpPickURLArg(content, m, 6, syms)
+		if verb == "" || raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "symfony_http", "Function", caller, false)
+	}
+
+	// ----- cURL: curl_init("url") -----
+	for _, m := range phpCurlInitRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		// Extract URL from groups 1 (double), 2 (single), 3 (variable).
+		raw := ""
+		if m[2] >= 0 {
+			raw = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			varName := content[m[6]:m[7]]
+			if val, ok := syms[varName]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+
+		// Determine verb: scan 1024 bytes forward for CURLOPT_POST or CURLOPT_CUSTOMREQUEST.
+		verb := "GET"
+		end := m[1] + 1024
+		if end > len(content) {
+			end = len(content)
+		}
+		window := content[m[1]:end]
+		if pm := phpCurlPostRe.FindStringSubmatch(window); pm != nil {
+			if pm[1] != "" {
+				verb = strings.ToUpper(pm[1])
+			} else if pm[2] != "" {
+				verb = strings.ToUpper(pm[2])
+			} else {
+				verb = "POST"
+			}
+		}
+
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "curl", "Function", caller, false)
+	}
+
+	// ----- file_get_contents("https://...") -----
+	for _, m := range phpFileGetContentsRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		raw := ""
+		if m[2] >= 0 {
+			raw = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit("GET", canonical, "file_get_contents", "Function", caller, false)
+	}
+
+	// ----- WordPress: wp_remote_get($url), wp_remote_post($url) -----
+	for _, m := range phpWPRemoteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		wpVerb := content[m[2]:m[3]]
+		// wp_remote_request gets verb from args; default to GET for request form.
+		verb := "GET"
+		switch wpVerb {
+		case "get":
+			verb = "GET"
+		case "post":
+			verb = "POST"
+		case "put":
+			verb = "PUT"
+		case "delete":
+			verb = "DELETE"
+		case "patch":
+			verb = "PATCH"
+		case "head":
+			verb = "HEAD"
+		case "request":
+			verb = "GET" // default; a later phase could inspect the $args array
+		}
+		raw := phpPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "wp_remote", "Function", caller, false)
+	}
+
+	// ----- Laravel Http facade: Http::get($url), Http::post($url) -----
+	for _, m := range phpLaravelHttpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := phpPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "laravel_http", "Function", caller, false)
+	}
+
+	// ----- Laravel Http chained: Http::withHeaders([...])->get("/path") -----
+	for _, m := range phpLaravelHttpChainedRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := phpPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "laravel_http", "Function", caller, false)
+	}
+
+	// ----- Env-var concat: $client->get(getenv('X') . '/path') -----
+	for _, m := range phpGuzzleEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := phpPickEnvSuffix(content, m, 4)
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "guzzle", "Function", caller, true)
+	}
+
+	// ----- Env-var concat: Http::get(getenv('X') . '/path') -----
+	for _, m := range phpLaravelEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := phpPickEnvSuffix(content, m, 4)
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "laravel_http", "Function", caller, true)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func phpHasAnyHTTPClient(content string) bool {
+	return strings.Contains(content, "GuzzleHttp") ||
+		strings.Contains(content, "->get(") ||
+		strings.Contains(content, "->post(") ||
+		strings.Contains(content, "->request(") ||
+		strings.Contains(content, "HttpClient") ||
+		strings.Contains(content, "curl_init") ||
+		strings.Contains(content, "file_get_contents") ||
+		strings.Contains(content, "wp_remote_get") ||
+		strings.Contains(content, "wp_remote_post") ||
+		strings.Contains(content, "wp_remote_request") ||
+		strings.Contains(content, "Http::get") ||
+		strings.Contains(content, "Http::post") ||
+		strings.Contains(content, "Http::put") ||
+		strings.Contains(content, "Http::delete") ||
+		strings.Contains(content, "Http::patch") ||
+		strings.Contains(content, "Http::withHeaders") ||
+		strings.Contains(content, "Http::withToken")
+}
+
+// buildPHPStringSymbolTable returns a map from $variable → string value
+// for simple PHP variable string assignments.
+func buildPHPStringSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range phpStringVarRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		if m[2] < 0 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		val := ""
+		if m[4] >= 0 {
+			val = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			val = content[m[6]:m[7]]
+		}
+		if _, dup := syms[name]; !dup {
+			syms[name] = val
+		}
+	}
+	return syms
+}
+
+// phpPickURLArg extracts the URL string from a match's double-quoted /
+// single-quoted / variable group triple. litStart is the index within m
+// of the first literal group.
+func phpPickURLArg(content string, m []int, litStart int, syms map[string]string) string {
+	// Double-quoted literal.
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	// Single-quoted literal.
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	// PHP variable ($url, $endpoint) — resolve via symbol table.
+	if litStart+5 < len(m) && m[litStart+4] >= 0 {
+		varName := content[m[litStart+4]:m[litStart+5]]
+		if val, ok := syms[varName]; ok {
+			return val
+		}
+	}
+	return ""
+}
+
+// phpPickVerb extracts the HTTP verb from a request() call match.
+// Groups at litStart (single-quoted) and litStart+2 (double-quoted) are checked.
+func phpPickVerb(content string, m []int, litStart int) string {
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return strings.ToUpper(content[m[litStart]:m[litStart+1]])
+	}
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return strings.ToUpper(content[m[litStart+2]:m[litStart+3]])
+	}
+	return ""
+}
+
+// phpPickEnvSuffix extracts the path suffix from an env-var concat match.
+// Groups at litStart (double-quoted) and litStart+2 (single-quoted).
+func phpPickEnvSuffix(content string, m []int, litStart int) string {
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	return ""
+}
+
+// indexPHPEnclosingFns builds a sorted (offset, name) list for every
+// PHP function/method definition in the file.
+func indexPHPEnclosingFns(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range phpEnclosingFnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingPHPFnAt returns the name of the nearest preceding function
+// definition for a call site at pos.
+func enclosingPHPFnAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_php_client_test.go
+++ b/internal/engine/http_endpoint_php_client_test.go
@@ -1,0 +1,340 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Guzzle instance methods
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_GuzzleVerbMethods covers $client->get($url), $client->post($url)
+// with an absolute URL.
+func TestPHPClient_GuzzleVerbMethods(t *testing.T) {
+	src := `<?php
+
+use GuzzleHttp\Client;
+
+function fetchUsers() {
+    $client = new Client();
+    $response = $client->get('https://api.example.com/api/users');
+    return $response->getBody();
+}
+
+function createUser($data) {
+    $client = new Client();
+    $response = $client->post('https://api.example.com/api/users');
+    return $response;
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "users_client.php", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, ids, want, "php-guzzle-verb-methods")
+	requireFetches(t, rels, "http:GET:/api/users", "php-guzzle-verb-methods")
+	requireFetches(t, rels, "http:POST:/api/users", "php-guzzle-verb-methods")
+}
+
+// TestPHPClient_GuzzleRequestMethod covers $client->request('POST', $url, ['json' => $body]).
+func TestPHPClient_GuzzleRequestMethod(t *testing.T) {
+	src := `<?php
+
+use GuzzleHttp\Client;
+
+function submitOrder($data) {
+    $client = new Client();
+    $response = $client->request('POST', 'https://api.example.com/api/orders', [
+        'json' => $data,
+    ]);
+    return $response;
+}
+
+function fetchOrder($id) {
+    $client = new Client();
+    $response = $client->request('GET', '/api/orders/' . $id);
+    return $response->getBody();
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "orders_client.php", src)
+	want := []string{
+		"http:POST:/api/orders",
+	}
+	requireContains(t, ids, want, "php-guzzle-request-method")
+	requireFetches(t, rels, "http:POST:/api/orders", "php-guzzle-request-method")
+}
+
+// ---------------------------------------------------------------------------
+// Symfony HttpClient
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_SymfonyHttpClient covers HttpClient::create()->request('GET', $url)
+// and the stored-client form.
+func TestPHPClient_SymfonyHttpClient(t *testing.T) {
+	src := `<?php
+
+use Symfony\Component\HttpClient\HttpClient;
+
+function fetchProducts() {
+    $response = HttpClient::create()->request('GET', 'https://api.example.com/api/products');
+    return $response->toArray();
+}
+
+function createProduct($data) {
+    $client = HttpClient::create();
+    $response = $client->request('POST', 'https://api.example.com/api/products', [
+        'json' => $data,
+    ]);
+    return $response->getStatusCode();
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "symfony_client.php", src)
+	want := []string{
+		"http:GET:/api/products",
+		"http:POST:/api/products",
+	}
+	requireContains(t, ids, want, "php-symfony-httpclient")
+	requireFetches(t, rels, "http:GET:/api/products", "php-symfony-httpclient")
+	requireFetches(t, rels, "http:POST:/api/products", "php-symfony-httpclient")
+}
+
+// ---------------------------------------------------------------------------
+// cURL
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_CurlGet covers curl_init($url) without CURLOPT_POST → GET.
+func TestPHPClient_CurlGet(t *testing.T) {
+	src := `<?php
+
+function fetchData($url) {
+    $ch = curl_init("https://api.example.com/api/payments");
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+    $result = curl_exec($ch);
+    curl_close($ch);
+    return $result;
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "curl_get.php", src)
+	requireContains(t, ids, []string{"http:GET:/api/payments"}, "php-curl-get")
+	requireFetches(t, rels, "http:GET:/api/payments", "php-curl-get")
+}
+
+// TestPHPClient_CurlPost covers curl_init + CURLOPT_POST=true → POST.
+func TestPHPClient_CurlPost(t *testing.T) {
+	src := `<?php
+
+function postData($data) {
+    $ch = curl_init("https://api.example.com/api/events");
+    curl_setopt($ch, CURLOPT_POST, true);
+    curl_setopt($ch, CURLOPT_POSTFIELDS, $data);
+    $result = curl_exec($ch);
+    curl_close($ch);
+    return $result;
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "curl_post.php", src)
+	requireContains(t, ids, []string{"http:POST:/api/events"}, "php-curl-post")
+	requireFetches(t, rels, "http:POST:/api/events", "php-curl-post")
+}
+
+// ---------------------------------------------------------------------------
+// file_get_contents
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_FileGetContents covers file_get_contents("https://...") → GET.
+func TestPHPClient_FileGetContents(t *testing.T) {
+	src := `<?php
+
+function fetchStatus() {
+    $data = file_get_contents("https://api.example.com/api/status");
+    return json_decode($data, true);
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "file_get_contents.php", src)
+	requireContains(t, ids, []string{"http:GET:/api/status"}, "php-file-get-contents")
+	requireFetches(t, rels, "http:GET:/api/status", "php-file-get-contents")
+}
+
+// ---------------------------------------------------------------------------
+// WordPress HTTP API
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_WPRemote covers wp_remote_get($url) and wp_remote_post($url, $args).
+func TestPHPClient_WPRemote(t *testing.T) {
+	src := `<?php
+
+function get_remote_data($url) {
+    $response = wp_remote_get('https://api.example.com/api/posts');
+    return wp_remote_retrieve_body($response);
+}
+
+function send_remote_data($data) {
+    $response = wp_remote_post('https://api.example.com/api/posts', [
+        'body' => json_encode($data),
+    ]);
+    return $response;
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "wp_remote.php", src)
+	want := []string{
+		"http:GET:/api/posts",
+		"http:POST:/api/posts",
+	}
+	requireContains(t, ids, want, "php-wp-remote")
+	requireFetches(t, rels, "http:GET:/api/posts", "php-wp-remote")
+	requireFetches(t, rels, "http:POST:/api/posts", "php-wp-remote")
+}
+
+// ---------------------------------------------------------------------------
+// Laravel HTTP facade
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_LaravelHttp covers Http::get($url), Http::post($url, $body).
+func TestPHPClient_LaravelHttp(t *testing.T) {
+	src := `<?php
+
+use Illuminate\Support\Facades\Http;
+
+function getNotifications() {
+    $response = Http::get('https://api.example.com/api/notifications');
+    return $response->json();
+}
+
+function sendNotification($data) {
+    $response = Http::post('https://api.example.com/api/notifications', $data);
+    return $response->status();
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "laravel_http.php", src)
+	want := []string{
+		"http:GET:/api/notifications",
+		"http:POST:/api/notifications",
+	}
+	requireContains(t, ids, want, "php-laravel-http")
+	requireFetches(t, rels, "http:GET:/api/notifications", "php-laravel-http")
+	requireFetches(t, rels, "http:POST:/api/notifications", "php-laravel-http")
+}
+
+// TestPHPClient_LaravelHttpChained covers the chained form:
+// Http::withHeaders([...])->get("/path").
+func TestPHPClient_LaravelHttpChained(t *testing.T) {
+	src := `<?php
+
+use Illuminate\Support\Facades\Http;
+
+function getProtectedResource($token) {
+    $response = Http::withToken($token)->get('https://api.example.com/api/protected');
+    return $response->json();
+}
+
+function postWithHeaders($data) {
+    $response = Http::withHeaders(['X-Custom' => 'value'])->post('https://api.example.com/api/secure');
+    return $response->json();
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "laravel_http_chained.php", src)
+	want := []string{
+		"http:GET:/api/protected",
+		"http:POST:/api/secure",
+	}
+	requireContains(t, ids, want, "php-laravel-http-chained")
+	requireFetches(t, rels, "http:GET:/api/protected", "php-laravel-http-chained")
+	requireFetches(t, rels, "http:POST:/api/secure", "php-laravel-http-chained")
+}
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_EnvVarConcat covers $client->get(getenv('API_URL') . '/users')
+// → runtime_dynamic=true.
+func TestPHPClient_EnvVarConcat(t *testing.T) {
+	src := `<?php
+
+use GuzzleHttp\Client;
+
+function callRemote() {
+    $client = new Client();
+    $response = $client->get(getenv('API_URL') . '/users');
+    return $response->getBody();
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "env_client.php", src)
+	requireContains(t, ids, []string{"http:GET:/users"}, "php-env-var-concat")
+	requireFetches(t, rels, "http:GET:/users", "php-env-var-concat")
+
+	// Verify runtime_dynamic=true is stamped on the entity.
+	_, res := runDetect(t, "php", "env_client.php", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/users" && e.Properties["runtime_dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("php-env-var-concat: expected runtime_dynamic=true on http:GET:/users")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Verb coverage
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_VerbCoverage covers all HTTP verbs via Guzzle request().
+func TestPHPClient_VerbCoverage(t *testing.T) {
+	src := `<?php
+
+use GuzzleHttp\Client;
+
+function allVerbs() {
+    $client = new Client();
+    $client->get('https://api.example.com/api/items');
+    $client->post('https://api.example.com/api/items');
+    $client->put('https://api.example.com/api/items');
+    $client->patch('https://api.example.com/api/items');
+    $client->delete('https://api.example.com/api/items');
+    $client->head('https://api.example.com/api/items');
+}
+`
+	ids, _ := runDetectWithRels(t, "php", "all_verbs.php", src)
+	want := []string{
+		"http:GET:/api/items",
+		"http:POST:/api/items",
+		"http:PUT:/api/items",
+		"http:PATCH:/api/items",
+		"http:DELETE:/api/items",
+		"http:HEAD:/api/items",
+	}
+	requireContains(t, ids, want, "php-verb-coverage")
+}
+
+// ---------------------------------------------------------------------------
+// Negative case
+// ---------------------------------------------------------------------------
+
+// TestPHPClient_Negative verifies that a non-HTTP PHP file does not emit
+// any http_endpoint synthetics.
+func TestPHPClient_Negative(t *testing.T) {
+	src := `<?php
+
+class DataProcessor {
+    public function process(array $items): array {
+        return array_map(function($item) {
+            return strtoupper($item);
+        }, $items);
+    }
+
+    public function filter(array $items, callable $callback): array {
+        return array_filter($items, $callback);
+    }
+}
+`
+	ids, _ := runDetectWithRels(t, "php", "data_processor.php", src)
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			t.Errorf("php-negative: unexpected http_endpoint %q from non-HTTP file", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_rust_client.go
+++ b/internal/engine/http_endpoint_rust_client.go
@@ -1,0 +1,556 @@
+// Rust consumer-side HTTP client synthesis (#721 wave 2c).
+//
+// Mirrors http_endpoint_ruby_client.go / http_endpoint_csharp_client.go for
+// Rust consumer-side HTTP patterns. Emits one synthetic `http_endpoint`
+// entity (consumer side) per detected client call site, AND a FETCHES edge
+// from the enclosing function to that endpoint.
+//
+// Patterns covered:
+//
+//   - reqwest (most popular Rust HTTP client):
+//     reqwest::get(url).await, reqwest::get(url).await?
+//     reqwest::Client::new().get(url).send().await
+//     client.get(url).send().await, client.post(url).json(&body).send().await
+//     client.put(url).send().await, client.delete(url).send().await
+//     client.patch(url).send().await, client.head(url).send().await
+//
+//   - hyper (low-level HTTP library):
+//     Client::new().get(url.parse().unwrap()).await
+//     Request::builder().method("POST").uri(url).body(body)
+//     client.request(req).await
+//
+//   - ureq (sync HTTP client):
+//     ureq::get(url).call(), ureq::post(url).send_json(json)
+//     ureq::put(url).send_string(s), ureq::delete(url).call()
+//     ureq::patch(url).send_bytes(b)
+//
+//   - surf (async HTTP client):
+//     surf::get(url).await, surf::post(url).body_json(&body).await
+//     surf::Client::new().get(url).recv_json::<T>().await
+//     surf::put(url).await, surf::delete(url).await
+//
+// Beyond-minimum behaviours:
+//   - .await and .await? propagation (both forms are matched)
+//   - Result<reqwest::Response, _> patterns (the call site is still captured)
+//   - Env-var concat: reqwest::get(format!("{}/users", env::var("API_URL").unwrap())).await
+//     → emit with runtime_dynamic=true
+//   - All standard HTTP verbs: get, post, put, patch, delete, head, options
+//
+// The enclosing function is identified by scanning for the nearest preceding
+// `fn <name>(` or `async fn <name>(` declaration.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// reqwest module-level functions: reqwest::get(url), reqwest::post(url)
+// ---------------------------------------------------------------------------
+
+// rustReqwestFnRe matches `reqwest::get("url").await`, `reqwest::get("url").await?`,
+// and the non-awaited fire-and-forget / .unwrap() forms.
+// Capture groups: 1 = verb (get/post/put/patch/delete/head/options),
+// 2 = double-quoted url, 3 = single-quoted url (rare in Rust but allowed),
+// 4 = bare identifier.
+var rustReqwestFnRe = regexp.MustCompile(
+	`\breqwest\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// reqwest::Client instance calls: client.get(url).send().await
+// ---------------------------------------------------------------------------
+
+// rustReqwestClientVerbRe matches `client.get("url")`, `client.post("url")`
+// on a reqwest client instance. Receiver allow-list covers common variable
+// names for reqwest::Client instances.
+var rustReqwestClientVerbRe = regexp.MustCompile(
+	`\b(client|http_client|reqwest_client|c)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 4: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 5: bare identifier
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// hyper: Request::builder().method("POST").uri(url)
+// ---------------------------------------------------------------------------
+
+// rustHyperRequestBuilderRe matches the hyper request builder pattern:
+// `Request::builder().method("POST").uri("url")` or `.method(Method::POST).uri("url")`.
+// Capture groups: 1 = verb string (from string literal, e.g. "POST" or "GET"),
+// 2 = verb enum (from Method::GET, etc.), 3 = double-quoted uri, 4 = bare identifier uri.
+var rustHyperRequestBuilderRe = regexp.MustCompile(
+	`Request\s*::\s*builder\s*\(\s*\)(?:[^;]*?)\.method\s*\(\s*(?:"([A-Za-z]+)"|(?:Method\s*::\s*([A-Za-z]+)))\s*\)(?:[^;]*?)\.uri\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 3: double-quoted uri
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier uri
+		`)`,
+)
+
+// rustHyperClientGetRe matches `client.get("url".parse().unwrap())` — hyper
+// Client::new().get(Uri) pattern where the URI is parsed inline.
+// Capture groups: 1 = double-quoted uri, 2 = bare identifier uri.
+var rustHyperClientGetRe = regexp.MustCompile(
+	`\b(?:client|hyper_client)\s*\.\s*get\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 1: double-quoted uri (may have .parse())
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 2: bare identifier
+		`)\s*(?:\.parse\s*\(\s*\)\.unwrap\s*\(\s*\))?`,
+)
+
+// ---------------------------------------------------------------------------
+// ureq module-level functions: ureq::get(url).call()
+// ---------------------------------------------------------------------------
+
+// rustUreqFnRe matches `ureq::get("url").call()`, `ureq::post("url").send_json(j)`,
+// and other ureq method calls.
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = single-quoted url, 4 = bare identifier.
+var rustUreqFnRe = regexp.MustCompile(
+	`\bureq\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// surf module-level functions: surf::get(url).await
+// ---------------------------------------------------------------------------
+
+// rustSurfFnRe matches `surf::get("url").await`, `surf::post("url").body_json(&b).await`.
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = single-quoted url, 4 = bare identifier.
+var rustSurfFnRe = regexp.MustCompile(
+	`\bsurf\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`'([^'\n\r]+)'` + // group 3: single-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 4: bare identifier
+		`)`,
+)
+
+// rustSurfClientVerbRe matches `surf::Client::new().get("url")` — the client
+// builder form of surf.
+// Capture groups: 1 = verb, 2 = double-quoted url, 3 = bare identifier.
+var rustSurfClientVerbRe = regexp.MustCompile(
+	`surf\s*::\s*Client\s*::\s*new\s*\(\s*\)\s*\.\s*(get|post|put|patch|delete|head|options)\s*\(\s*(?:` +
+		`"([^"\n\r]+)"` + // group 2: double-quoted url
+		`|` +
+		`([A-Za-z_][\w]*)` + // group 3: bare identifier
+		`)`,
+)
+
+// ---------------------------------------------------------------------------
+// Env-var concat: format!("{}/path", env::var("API_URL").unwrap())
+// ---------------------------------------------------------------------------
+
+// rustEnvVarFmtRe matches the `format!("{}/path", env::var("NAME").unwrap())`
+// pattern used in reqwest/ureq/surf calls. We detect the format! macro and
+// capture the path suffix.
+//
+// Capture groups:
+//
+//	1 = path suffix embedded in the format string after the placeholder
+var rustEnvVarFmtRe = regexp.MustCompile(
+	`format!\s*\(\s*"\{\}\s*(/[^"\n\r]*)"\s*,\s*(?:env\s*::\s*var|std\s*::\s*env\s*::\s*var|std\s*::\s*env\s*::\s*var_os)\s*\(`,
+)
+
+// rustReqwestEnvVerbRe matches `reqwest::get(format!("{}/path", env::var(...)))`.
+// Capture groups: 1 = verb, 2 = path suffix.
+var rustReqwestEnvVerbRe = regexp.MustCompile(
+	`\breqwest\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*format!\s*\(\s*"\{\}\s*(/[^"\n\r]*)"\s*,\s*(?:env\s*::\s*var|std\s*::\s*env\s*::\s*var)\s*\(`,
+)
+
+// rustUreqEnvVerbRe matches `ureq::get(format!("{}/path", env::var(...)))`.
+// Capture groups: 1 = verb, 2 = path suffix.
+var rustUreqEnvVerbRe = regexp.MustCompile(
+	`\bureq\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*format!\s*\(\s*"\{\}\s*(/[^"\n\r]*)"\s*,\s*(?:env\s*::\s*var|std\s*::\s*env\s*::\s*var)\s*\(`,
+)
+
+// rustSurfEnvVerbRe matches `surf::get(format!("{}/path", env::var(...)))`.
+// Capture groups: 1 = verb, 2 = path suffix.
+var rustSurfEnvVerbRe = regexp.MustCompile(
+	`\bsurf\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*format!\s*\(\s*"\{\}\s*(/[^"\n\r]*)"\s*,\s*(?:env\s*::\s*var|std\s*::\s*env\s*::\s*var)\s*\(`,
+)
+
+// ---------------------------------------------------------------------------
+// String constant table
+// ---------------------------------------------------------------------------
+
+// rustStringConstRe captures simple Rust constant/let declarations:
+//
+//	const API_URL: &str = "/value";
+//	let base_url = "/value";
+//	let url = "https://example.com/path";
+var rustStringConstRe = regexp.MustCompile(
+	`(?m)(?:const\s+[A-Z_][A-Z0-9_]*\s*:\s*&str|let\s+(?:mut\s+)?[a-z_][a-z0-9_]*)\s*=\s*"([^"\n\r]{1,256})"`,
+)
+
+// ---------------------------------------------------------------------------
+// Enclosing function index
+// ---------------------------------------------------------------------------
+
+// rustEnclosingFnRe captures Rust function definitions:
+//
+//	fn foo(
+//	async fn foo(
+//	pub fn foo(
+//	pub async fn foo(
+var rustEnclosingFnRe = regexp.MustCompile(
+	`(?m)^\s*(?:pub\s+)?(?:async\s+)?fn\s+([A-Za-z_]\w*)\s*[(<]`,
+)
+
+// ---------------------------------------------------------------------------
+// Public entry points
+// ---------------------------------------------------------------------------
+
+// rustClientEmitFn is the runtime-aware emitter type for Rust clients.
+type rustClientEmitFn func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool)
+
+// synthesizeRustClient is the package-level entry point referenced from
+// applyHTTPEndpointSynthesis.
+func synthesizeRustClient(content string, emit emitFn) {
+	synthesizeRustClientWithRuntime(content, func(method, canonicalPath, framework, refKind, refName string, _ bool) {
+		emit(method, canonicalPath, framework, refKind, refName)
+	})
+}
+
+// synthesizeRustClientWithRuntime runs the full Rust client scan.
+func synthesizeRustClientWithRuntime(content string, emit rustClientEmitFn) {
+	if !rustHasAnyHTTPClient(content) {
+		return
+	}
+	funcs := indexRustEnclosingFns(content)
+	syms := buildRustStringSymbolTable(content)
+
+	// ----- reqwest::get/post/... module-level functions -----
+	for _, m := range rustReqwestFnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rustPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "reqwest", "Function", caller, false)
+	}
+
+	// ----- reqwest client instance: client.get(url).send().await -----
+	for _, m := range rustReqwestClientVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 12 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[4]:m[5]])
+		raw := rustPickURLArg(content, m, 6, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "reqwest", "Function", caller, false)
+	}
+
+	// ----- hyper Request::builder().method(...).uri(...) -----
+	for _, m := range rustHyperRequestBuilderRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		// Verb: group 1 (string literal "POST") or group 2 (Method::POST enum).
+		verb := ""
+		if m[2] >= 0 {
+			verb = strings.ToUpper(content[m[2]:m[3]])
+		} else if m[4] >= 0 {
+			verb = strings.ToUpper(content[m[4]:m[5]])
+		}
+		if verb == "" {
+			verb = "GET"
+		}
+		// URI: group 3 (double-quoted) or group 4 (bare identifier).
+		raw := ""
+		if m[6] >= 0 {
+			raw = content[m[6]:m[7]]
+		} else if m[8] >= 0 {
+			ident := content[m[8]:m[9]]
+			if val, ok := syms[ident]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "hyper", "Function", caller, false)
+	}
+
+	// ----- hyper client.get("url".parse().unwrap()) -----
+	for _, m := range rustHyperClientGetRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		raw := ""
+		if m[2] >= 0 {
+			raw = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			ident := content[m[4]:m[5]]
+			if val, ok := syms[ident]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit("GET", canonical, "hyper", "Function", caller, false)
+	}
+
+	// ----- ureq::get/post/... -----
+	for _, m := range rustUreqFnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rustPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "ureq", "Function", caller, false)
+	}
+
+	// ----- surf::get/post/... module-level -----
+	for _, m := range rustSurfFnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 10 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := rustPickURLArg(content, m, 4, syms)
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "surf", "Function", caller, false)
+	}
+
+	// ----- surf::Client::new().get(...) -----
+	for _, m := range rustSurfClientVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := ""
+		if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			ident := content[m[6]:m[7]]
+			if val, ok := syms[ident]; ok {
+				raw = val
+			}
+		}
+		if raw == "" {
+			continue
+		}
+		path := stripURLHost(raw)
+		if !looksLikeURLPath(path) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+		emit(verb, canonical, "surf", "Function", caller, false)
+	}
+
+	// ----- Env-var concat: reqwest::get(format!("{}/path", env::var(...))) -----
+	for _, m := range rustReqwestEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := ""
+		if m[4] >= 0 {
+			suffix = content[m[4]:m[5]]
+		}
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "reqwest", "Function", caller, true)
+	}
+
+	// ----- Env-var concat: ureq::get(format!("{}/path", env::var(...))) -----
+	for _, m := range rustUreqEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := ""
+		if m[4] >= 0 {
+			suffix = content[m[4]:m[5]]
+		}
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "ureq", "Function", caller, true)
+	}
+
+	// ----- Env-var concat: surf::get(format!("{}/path", env::var(...))) -----
+	for _, m := range rustSurfEnvVerbRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		suffix := ""
+		if m[4] >= 0 {
+			suffix = content[m[4]:m[5]]
+		}
+		if suffix == "" || !looksLikeURLPath(suffix) {
+			continue
+		}
+		caller := enclosingRustFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
+		emit(verb, canonical, "surf", "Function", caller, true)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func rustHasAnyHTTPClient(content string) bool {
+	return strings.Contains(content, "reqwest") ||
+		strings.Contains(content, "ureq") ||
+		strings.Contains(content, "surf") ||
+		strings.Contains(content, "hyper") ||
+		strings.Contains(content, "Request::builder") ||
+		strings.Contains(content, "client.get") ||
+		strings.Contains(content, "client.post")
+}
+
+// buildRustStringSymbolTable returns a map from identifier → string value
+// for simple constant/let string declarations in the file.
+func buildRustStringSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range rustStringConstRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		if m[2] < 0 {
+			continue
+		}
+		// Extract the identifier name from before '='
+		// The regex doesn't capture name separately — we use the value only
+		// for identifier resolution via a secondary pass.
+		_ = content[m[2]:m[3]] // value
+	}
+	// Second pass: simpler name=value extraction for the symbol table
+	simpleRe := regexp.MustCompile(`(?m)(?:let\s+(?:mut\s+)?([a-z_][a-z0-9_]*)|const\s+([A-Z_][A-Z0-9_]*)\s*:\s*&str)\s*=\s*"([^"\n\r]{1,256})"`)
+	for _, m := range simpleRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		var name string
+		if m[2] >= 0 {
+			name = content[m[2]:m[3]]
+		} else if m[4] >= 0 {
+			name = content[m[4]:m[5]]
+		}
+		if name == "" {
+			continue
+		}
+		val := ""
+		if m[6] >= 0 {
+			val = content[m[6]:m[7]]
+		}
+		if _, dup := syms[name]; !dup {
+			syms[name] = val
+		}
+	}
+	return syms
+}
+
+// rustPickURLArg extracts the URL string from a match's double-quoted /
+// single-quoted / identifier group triple. litStart is the index within m
+// of the first literal group.
+func rustPickURLArg(content string, m []int, litStart int, syms map[string]string) string {
+	// Double-quoted literal.
+	if litStart+1 < len(m) && m[litStart] >= 0 {
+		return content[m[litStart]:m[litStart+1]]
+	}
+	// Single-quoted literal (rare in Rust but present in test fixtures).
+	if litStart+3 < len(m) && m[litStart+2] >= 0 {
+		return content[m[litStart+2]:m[litStart+3]]
+	}
+	// Bare identifier — resolve via symbol table.
+	if litStart+5 < len(m) && m[litStart+4] >= 0 {
+		ident := content[m[litStart+4]:m[litStart+5]]
+		if val, ok := syms[ident]; ok {
+			return val
+		}
+	}
+	return ""
+}
+
+// indexRustEnclosingFns builds a sorted (offset, name) list for every
+// Rust function definition in the file.
+func indexRustEnclosingFns(content string) []jsFuncSpan {
+	var out []jsFuncSpan
+	for _, m := range rustEnclosingFnRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		out = append(out, jsFuncSpan{offset: m[0], name: content[m[2]:m[3]]})
+	}
+	return out
+}
+
+// enclosingRustFnAt returns the name of the nearest preceding function
+// definition for a call site at pos.
+func enclosingRustFnAt(funcs []jsFuncSpan, pos int) string {
+	return enclosingJSFuncAt(funcs, pos)
+}

--- a/internal/engine/http_endpoint_rust_client_test.go
+++ b/internal/engine/http_endpoint_rust_client_test.go
@@ -1,0 +1,311 @@
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// reqwest module-level functions
+// ---------------------------------------------------------------------------
+
+// TestRustClient_ReqwestFnLiteral covers reqwest::get("url").await and
+// reqwest::get("url").await? with an absolute URL.
+func TestRustClient_ReqwestFnLiteral(t *testing.T) {
+	src := `
+use reqwest;
+
+async fn fetch_users() -> Result<reqwest::Response, reqwest::Error> {
+    let resp = reqwest::get("https://api.example.com/api/users").await?;
+    Ok(resp)
+}
+
+async fn create_user(body: &str) -> Result<reqwest::Response, reqwest::Error> {
+    let resp = reqwest::post("https://api.example.com/api/users").await?;
+    Ok(resp)
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "users_client.rs", src)
+	want := []string{
+		"http:GET:/api/users",
+		"http:POST:/api/users",
+	}
+	requireContains(t, ids, want, "rust-reqwest-fn-literal")
+	requireFetches(t, rels, "http:GET:/api/users", "rust-reqwest-fn-literal")
+	requireFetches(t, rels, "http:POST:/api/users", "rust-reqwest-fn-literal")
+}
+
+// TestRustClient_ReqwestClientInstance covers client.get(url).send().await and
+// client.post(url).json(&body).send().await patterns.
+func TestRustClient_ReqwestClientInstance(t *testing.T) {
+	src := `
+use reqwest::Client;
+
+async fn fetch_orders() -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let resp = client.get("https://api.example.com/api/orders")
+        .send()
+        .await?;
+    Ok(())
+}
+
+async fn place_order(body: serde_json::Value) -> Result<(), Box<dyn std::error::Error>> {
+    let client = Client::new();
+    let resp = client.post("https://api.example.com/api/orders")
+        .json(&body)
+        .send()
+        .await?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "orders_client.rs", src)
+	want := []string{
+		"http:GET:/api/orders",
+		"http:POST:/api/orders",
+	}
+	requireContains(t, ids, want, "rust-reqwest-client-instance")
+	requireFetches(t, rels, "http:GET:/api/orders", "rust-reqwest-client-instance")
+	requireFetches(t, rels, "http:POST:/api/orders", "rust-reqwest-client-instance")
+}
+
+// ---------------------------------------------------------------------------
+// hyper
+// ---------------------------------------------------------------------------
+
+// TestRustClient_HyperRequestBuilder covers Request::builder().method("POST").uri(url)
+// and the enum form .method(Method::GET).
+func TestRustClient_HyperRequestBuilder(t *testing.T) {
+	src := `
+use hyper::{Client, Request, Method, Body};
+
+async fn submit_data(body: &str) -> Result<(), Box<dyn std::error::Error>> {
+    let req = Request::builder()
+        .method("POST")
+        .uri("https://api.example.com/api/events")
+        .body(Body::from(body.to_owned()))?;
+    let client = Client::new();
+    let _ = client.request(req).await?;
+    Ok(())
+}
+
+async fn fetch_config() -> Result<(), Box<dyn std::error::Error>> {
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("https://api.example.com/api/config")
+        .body(Body::empty())?;
+    let client = Client::new();
+    let _ = client.request(req).await?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "hyper_client.rs", src)
+	want := []string{
+		"http:POST:/api/events",
+		"http:GET:/api/config",
+	}
+	requireContains(t, ids, want, "rust-hyper-request-builder")
+	requireFetches(t, rels, "http:POST:/api/events", "rust-hyper-request-builder")
+	requireFetches(t, rels, "http:GET:/api/config", "rust-hyper-request-builder")
+}
+
+// ---------------------------------------------------------------------------
+// ureq
+// ---------------------------------------------------------------------------
+
+// TestRustClient_UreqFunctions covers ureq::get(url).call() and
+// ureq::post(url).send_json(json).
+func TestRustClient_UreqFunctions(t *testing.T) {
+	src := `
+fn get_items() -> Result<String, ureq::Error> {
+    let body: String = ureq::get("https://api.example.com/api/items")
+        .call()?
+        .into_string()?;
+    Ok(body)
+}
+
+fn create_item(data: &str) -> Result<(), ureq::Error> {
+    ureq::post("https://api.example.com/api/items")
+        .send_string(data)?;
+    Ok(())
+}
+
+fn update_item(id: u32, data: &str) -> Result<(), ureq::Error> {
+    ureq::put("https://api.example.com/api/items/1")
+        .send_string(data)?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "ureq_client.rs", src)
+	want := []string{
+		"http:GET:/api/items",
+		"http:POST:/api/items",
+		"http:PUT:/api/items/1",
+	}
+	requireContains(t, ids, want, "rust-ureq-functions")
+	requireFetches(t, rels, "http:GET:/api/items", "rust-ureq-functions")
+	requireFetches(t, rels, "http:POST:/api/items", "rust-ureq-functions")
+}
+
+// ---------------------------------------------------------------------------
+// surf
+// ---------------------------------------------------------------------------
+
+// TestRustClient_SurfFunctions covers surf::get(url).await and
+// surf::post(url).body_json(&body).await.
+func TestRustClient_SurfFunctions(t *testing.T) {
+	src := `
+use surf;
+
+async fn get_profile() -> surf::Result<()> {
+    let mut res = surf::get("https://api.example.com/api/profile").await?;
+    Ok(())
+}
+
+async fn update_profile(body: &serde_json::Value) -> surf::Result<()> {
+    surf::post("https://api.example.com/api/profile")
+        .body_json(body)?
+        .await?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "surf_client.rs", src)
+	want := []string{
+		"http:GET:/api/profile",
+		"http:POST:/api/profile",
+	}
+	requireContains(t, ids, want, "rust-surf-functions")
+	requireFetches(t, rels, "http:GET:/api/profile", "rust-surf-functions")
+	requireFetches(t, rels, "http:POST:/api/profile", "rust-surf-functions")
+}
+
+// TestRustClient_SurfClientNew covers surf::Client::new().get(url) builder form.
+func TestRustClient_SurfClientNew(t *testing.T) {
+	src := `
+use surf;
+
+async fn fetch_stats() -> surf::Result<()> {
+    let mut res = surf::Client::new()
+        .get("https://api.example.com/api/stats")
+        .recv_json::<serde_json::Value>()
+        .await?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "surf_client_new.rs", src)
+	requireContains(t, ids, []string{"http:GET:/api/stats"}, "rust-surf-client-new")
+	requireFetches(t, rels, "http:GET:/api/stats", "rust-surf-client-new")
+}
+
+// ---------------------------------------------------------------------------
+// All HTTP verbs
+// ---------------------------------------------------------------------------
+
+// TestRustClient_VerbCoverage covers all HTTP verbs via reqwest module-level fns.
+func TestRustClient_VerbCoverage(t *testing.T) {
+	src := `
+use reqwest;
+
+async fn all_verbs() {
+    let _ = reqwest::get("https://api.example.com/api/resources").await;
+    let _ = reqwest::post("https://api.example.com/api/resources").await;
+    let _ = reqwest::put("https://api.example.com/api/resources/1").await;
+    let _ = reqwest::patch("https://api.example.com/api/resources/1").await;
+    let _ = reqwest::delete("https://api.example.com/api/resources/1").await;
+    let _ = reqwest::head("https://api.example.com/api/resources").await;
+}
+`
+	ids, _ := runDetectWithRels(t, "rust", "all_verbs.rs", src)
+	want := []string{
+		"http:GET:/api/resources",
+		"http:POST:/api/resources",
+		"http:PUT:/api/resources/1",
+		"http:PATCH:/api/resources/1",
+		"http:DELETE:/api/resources/1",
+		"http:HEAD:/api/resources",
+	}
+	requireContains(t, ids, want, "rust-verb-coverage")
+}
+
+// ---------------------------------------------------------------------------
+// Env-var concatenation
+// ---------------------------------------------------------------------------
+
+// TestRustClient_EnvVarConcat covers reqwest::get(format!("{}/users", env::var("API_URL").unwrap()))
+// → runtime_dynamic=true.
+func TestRustClient_EnvVarConcat(t *testing.T) {
+	src := `
+use reqwest;
+use std::env;
+
+async fn call_remote() -> Result<(), reqwest::Error> {
+    let resp = reqwest::get(format!("{}/users", env::var("API_URL").unwrap())).await?;
+    Ok(())
+}
+`
+	ids, rels := runDetectWithRels(t, "rust", "env_client.rs", src)
+	requireContains(t, ids, []string{"http:GET:/users"}, "rust-env-var-concat")
+	requireFetches(t, rels, "http:GET:/users", "rust-env-var-concat")
+
+	// Verify runtime_dynamic=true is stamped on the entity.
+	_, res := runDetect(t, "rust", "env_client.rs", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:GET:/users" && e.Properties["runtime_dynamic"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("rust-env-var-concat: expected runtime_dynamic=true on http:GET:/users")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Identifier resolution (symbol table)
+// ---------------------------------------------------------------------------
+
+// TestRustClient_IdentifierResolution covers the case where the URL is stored
+// in a let-binding and resolved via the symbol table.
+func TestRustClient_IdentifierResolution(t *testing.T) {
+	src := `
+use reqwest;
+
+async fn fetch_reports() -> Result<(), reqwest::Error> {
+    let url = "/api/reports";
+    let _ = reqwest::get(url).await?;
+    Ok(())
+}
+`
+	ids, _ := runDetectWithRels(t, "rust", "ident_client.rs", src)
+	requireContains(t, ids, []string{"http:GET:/api/reports"}, "rust-identifier-resolution")
+}
+
+// ---------------------------------------------------------------------------
+// Negative case
+// ---------------------------------------------------------------------------
+
+// TestRustClient_Negative verifies that a non-HTTP Rust file does not emit
+// any http_endpoint synthetics.
+func TestRustClient_Negative(t *testing.T) {
+	src := `
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
+
+struct Config {
+    timeout: u32,
+    retries: u8,
+}
+
+impl Config {
+    fn new(timeout: u32) -> Self {
+        Config { timeout, retries: 3 }
+    }
+}
+`
+	ids, _ := runDetectWithRels(t, "rust", "math.rs", src)
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			t.Errorf("rust-negative: unexpected http_endpoint %q from non-HTTP file", id)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -255,6 +255,13 @@ func applyHTTPEndpointSynthesis(
 	case "csharp":
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
+	case "rust":
+		// Consumer side (#721 wave 2c): reqwest, hyper, ureq, surf.
+		synthesizeRustClientWithRuntime(string(content), emitClientRuntime)
+	case "php":
+		// Consumer side (#721 wave 2c): Guzzle, Symfony HttpClient, cURL, file_get_contents,
+		// WordPress HTTP API, Laravel Http facade.
+		synthesizePHPClientWithRuntime(string(content), emitClientRuntime)
 	}
 
 	// #722 — response/request shape extraction. Mutates Properties on


### PR DESCRIPTION
## Summary

Implements wave 2c of #721 (extraction-time FETCHES edges) for Rust and PHP consumer-side HTTP clients. Mirrors the pattern established in wave 1 (Python+Java #761), wave 2a (Go+Kotlin #772), and wave 2b (Ruby+C# #776).

## Files touched

- `internal/engine/http_endpoint_rust_client.go` — new (Rust synthesizer)
- `internal/engine/http_endpoint_rust_client_test.go` — new (10 unit tests)
- `internal/engine/http_endpoint_php_client.go` — new (PHP synthesizer)
- `internal/engine/http_endpoint_php_client_test.go` — new (12 unit tests)
- `internal/engine/http_endpoint_synthesis.go` — +6 lines wiring case "rust" and case "php"

## Rust patterns (reqwest, hyper, ureq, surf)

- reqwest::get(url).await / .await? — both propagation forms
- reqwest::Client instance: client.get(url).send().await, .post().json(&body).send().await
- hyper Request::builder().method("POST").uri(url) and Method::GET enum form
- ureq::get(url).call(), ureq::post(url).send_json(j), ureq::put().send_string()
- surf::get(url).await, surf::post(url).body_json(&b).await
- surf::Client::new().get(url).recv_json::<T>()
- Env-var concat: format!("{}/path", env::var("API_URL")) → runtime_dynamic=true
- Symbol table resolution for let url = "/path" bindings
- All verbs: GET, POST, PUT, PATCH, DELETE, HEAD

## PHP patterns (Guzzle, Symfony, cURL, WordPress, Laravel)

- Guzzle: $client->get($url), $client->request('POST', $url, ['json' => $body])
- Symfony HttpClient: HttpClient::create()->request('GET', $url) and stored-client form
- cURL: curl_init($url) + 1024-byte lookahead for CURLOPT_POST/CURLOPT_CUSTOMREQUEST verb detection
- file_get_contents("https://...") → GET
- WordPress: wp_remote_get($url), wp_remote_post($url, $args)
- Laravel Http facade: Http::get($url), Http::post($url, $body)
- Laravel Http chained: Http::withHeaders([])->get($url), Http::withToken($t)->post($url)
- Env-var concat: getenv('API_URL') . '/path' → runtime_dynamic=true
- All verbs: GET, POST, PUT, PATCH, DELETE, HEAD

## Test counts

| Language | Tests | Result |
|---|---|---|
| Rust | 10 | PASS |
| PHP | 12 | PASS |

## Cross-language parity

TestHarness_FixturesCorpus: PASS — bug_rate=0.0579, unchanged from main HEAD 008426f. No Rust or PHP fixtures exist yet; real-world FETCHES count is 0 as expected (unit tests are the deliverable).

## Daemon cleanup

ARCHIGRAPH_DAEMON_ROOT=/tmp/arch-721-w2c used for harness run. No daemon spawned by unit tests. /tmp/arch-721-w2c cleaned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)