### PR TITLE
[#726][wave3] Google Cloud Pub/Sub + NATS broker flow extraction

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -283,6 +283,24 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Google Cloud Pub/Sub producer/consumer cross-repo edges (wave 3 of #726).
+	// Emits SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
+	// google-cloud-pubsub (Python/Node/Go/Java), Pub/Sub Lite, and
+	// Eventarc / Cloud Run trigger consumers.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	entities, relationships = applyPubSubEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
+	// NATS producer/consumer cross-repo edges (wave 3 of #726). Emits
+	// SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
+	// nats.go / nats.js / nats.py / nats.java, JetStream, and NATS
+	// Streaming (STAN). Wildcard subjects and request/reply pattern tracked.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	entities, relationships = applyNATSEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// #727: Real-time event channel synthesis. Three append-only passes
 	// for WebSocket, Server-Sent Events, and GraphQL subscriptions. Each
 	// scans the file directly and emits ChannelEvent / Stream /

--- a/internal/engine/nats_edges.go
+++ b/internal/engine/nats_edges.go
@@ -1,0 +1,780 @@
+// NATS publish/subscribe detection — wave 3 of #726.
+//
+// For every NATS publish or subscribe call site this pass can statically
+// recognize, we emit a synthetic `SCOPE.Queue` entity keyed by the subject
+// name, plus PUBLISHES_TO or SUBSCRIBES_TO edges. The synthetic subject ID
+// is identical across repos (`nats:<subject>`), so the existing import-
+// channel linker matches producer and consumer sides on shared entity ID
+// without any new cross-repo matching code — same technique used by the
+// other wave-1/2 broker passes.
+//
+// Libraries/frameworks covered:
+//   - Go nats.go: nc.Publish(subject, data), nc.Subscribe(subject, handler),
+//     nc.QueueSubscribe(subject, queue, handler), nc.Request(subject, data, timeout)
+//   - Node nats.js: nc.publish(subject, data), sub = nc.subscribe(subject);
+//     for await (const m of sub), nc.request(subject, data)
+//   - Python nats.py: await nc.publish(subject, payload),
+//     await nc.subscribe(subject, cb=handler)
+//   - Java: connection.publish(subject, data),
+//     subscription = connection.subscribe(subject),
+//     dispatcher.subscribe(subject, handler)
+//   - NATS JetStream: js.publish(subject, ...), js.subscribe(subject, ...)
+//     — emits jetstream=true property
+//   - NATS Streaming (STAN, deprecated): stan.Publish / stan.QueueSubscribe
+//     — emits nats_streaming=true property
+//   - request/reply pattern: nc.Request / nc.request / nc.request(...)
+//     — emits pattern=request_reply property
+//
+// Subjects with wildcards (orders.*, inventory.>) are valid subscriber-side;
+// emitted as-is.
+//
+// Emit: SCOPE.Queue (reuses queueEntityKind) + PUBLISHES_TO + SUBSCRIBES_TO.
+// ID format: nats:<subject>.
+//
+// Refs #726.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// natsSynthesisSupportsLanguage reports whether applyNATSEdges can emit
+// synthetics for `lang`.
+func natsSynthesisSupportsLanguage(lang string) bool {
+	switch lang {
+	case "java", "kotlin", "javascript", "typescript", "python", "go":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyNATSEdges runs after applyPubSubEdges and APPENDS SCOPE.Queue
+// entities + PUBLISHES_TO / SUBSCRIBES_TO edges for NATS.
+// Append-only — never modifies or removes existing entities or edges, so
+// this pass cannot regress the surrounding pipeline's bug-rate.
+func applyNATSEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if len(content) == 0 {
+		return entities, relationships
+	}
+	if !natsSynthesisSupportsLanguage(lang) {
+		return entities, relationships
+	}
+
+	src := string(content)
+
+	// Dedup-by-ID: one SCOPE.Queue entity per subject per file.
+	seenQueue := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitSubject := func(subjectID, subject string, props map[string]string) {
+		if seenQueue[subjectID] {
+			return
+		}
+		seenQueue[subjectID] = true
+		merged := map[string]string{
+			"broker":       "nats",
+			"subject":      subject,
+			"pattern_type": "nats_synthesis",
+		}
+		for k, v := range props {
+			if v != "" {
+				merged[k] = v
+			}
+		}
+		// SourceFile left empty so identical subjects collapse to ONE entity
+		// per repo and match across repos via the import-channel linker.
+		entities = append(entities, types.EntityRecord{
+			Name:               subjectID,
+			Kind:               queueEntityKind,
+			SourceFile:         "",
+			Language:           lang,
+			Properties:         merged,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	emitEdge := func(callerKind, callerName, subjectID, edgeKind string, props map[string]string) {
+		if callerName == "" || subjectID == "" {
+			return
+		}
+		key := edgeKind + "|" + callerKind + ":" + callerName + "|" + subjectID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		base := map[string]string{
+			"broker":       "nats",
+			"pattern_type": "nats_synthesis",
+		}
+		for k, v := range props {
+			if v != "" {
+				base[k] = v
+			}
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fmt.Sprintf("%s:%s", callerKind, callerName),
+			ToID:       fmt.Sprintf("%s:%s", queueEntityKind, subjectID),
+			Kind:       edgeKind,
+			Properties: base,
+		})
+	}
+
+	switch lang {
+	case "python":
+		synthesizePyNATS(src, emitSubject, emitEdge)
+	case "javascript", "typescript":
+		synthesizeNodeNATS(src, emitSubject, emitEdge)
+	case "java", "kotlin":
+		synthesizeJavaNATS(src, emitSubject, emitEdge)
+	case "go":
+		synthesizeGoNATS(src, emitSubject, emitEdge)
+	}
+
+	return entities, relationships
+}
+
+// natsSubjectID returns the canonical synthetic ID for a NATS subject.
+// Wildcard subjects (orders.*, inventory.>) are preserved as-is.
+func natsSubjectID(subject string) string {
+	return "nats:" + subject
+}
+
+// looksLikeNATSSubject returns true when `s` plausibly looks like a NATS
+// subject. NATS subjects are dot-separated tokens; * and > are wildcards
+// allowed in subscriber patterns. The NATS wildcard `>` must not be
+// confused with the HTML `>` character — we accept it here because NATS
+// subjects are extracted from string literals, not HTML.
+func looksLikeNATSSubject(s string) bool {
+	if s == "" || len(s) > 256 {
+		return false
+	}
+	if strings.ContainsAny(s, "\n\r\t<{}()\"'") {
+		return false
+	}
+	// Must contain at least one alphanumeric character (not just wildcards).
+	hasAlnum := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			hasAlnum = true
+		case r == '.' || r == '_' || r == '-' || r == '*' || r == '>':
+			// Valid NATS subject characters including wildcards.
+		default:
+			return false
+		}
+	}
+	return hasAlnum
+}
+
+// ---------------------------------------------------------------------------
+// Go — nats.go / JetStream / NATS Streaming
+// ---------------------------------------------------------------------------
+
+// goNATSPublishRe captures nc.Publish(subject, data).
+// Group 1 = subject.
+var goNATSPublishRe = regexp.MustCompile(`\.Publish\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSSubscribeRe captures nc.Subscribe(subject, handler).
+// Group 1 = subject.
+var goNATSSubscribeRe = regexp.MustCompile(`\.Subscribe\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSQueueSubscribeRe captures nc.QueueSubscribe(subject, queue, handler).
+// Groups: 1=subject, 2=queue-group.
+var goNATSQueueSubscribeRe = regexp.MustCompile(`\.QueueSubscribe\s*\(\s*"([^"\n\r]+)"\s*,\s*"([^"\n\r]+)"`)
+
+// goNATSRequestRe captures nc.Request(subject, data, timeout).
+// Group 1 = subject.
+var goNATSRequestRe = regexp.MustCompile(`\.Request\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSJSPublishRe captures js.Publish(subject, data).
+// Group 1 = subject.
+var goNATSJSPublishRe = regexp.MustCompile(`\bjs\.Publish\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSJSSubscribeRe captures js.Subscribe(subject, handler) or
+// js.PullSubscribe(subject, ...).
+// Group 1 = subject.
+var goNATSJSSubscribeRe = regexp.MustCompile(`\bjs\.(?:Subscribe|PullSubscribe|ChanSubscribe)\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSStanPublishRe captures stan.Publish(subject, data) or sc.Publish(subject, data).
+// Group 1 = subject.
+var goNATSStanPublishRe = regexp.MustCompile(`(?:\bstan\b|sc)\.Publish\s*\(\s*"([^"\n\r]+)"`)
+
+// goNATSStanSubscribeRe captures sc.Subscribe(subject, ...) or
+// sc.QueueSubscribe(subject, ...) — NATS Streaming.
+// Group 1 = subject.
+var goNATSStanSubscribeRe = regexp.MustCompile(`(?:\bstan\b|sc)\.(?:Subscribe|QueueSubscribe)\s*\(\s*"([^"\n\r]+)"`)
+
+func synthesizeGoNATS(
+	src string,
+	emitSubject func(subjectID, subject string, props map[string]string),
+	emitEdge func(callerKind, callerName, subjectID, edgeKind string, props map[string]string),
+) {
+	hasNATS := strings.Contains(src, "nats") || strings.Contains(src, "stan") ||
+		strings.Contains(src, "JetStream") || strings.Contains(src, "jetstream")
+	if !hasNATS {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingGoName(src, offset)
+	}
+
+	// jetsreamSubjects and stanSubjects track byte offsets of .Publish/.Subscribe
+	// calls that are already handled by the JetStream/STAN passes, so the generic
+	// nc.Publish / nc.Subscribe pass below can skip them (avoiding entity-props
+	// collision where the generic pass emits first without jetstream/stan flags).
+	jsPublishOffsets := map[int]bool{}
+	jsSubscribeOffsets := map[int]bool{}
+
+	// JetStream: js.Publish(subject, data) — must run before generic nc.Publish.
+	for _, m := range goNATSJSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream",
+			"jetstream":       "true",
+		})
+		jsPublishOffsets[m[0]] = true
+	}
+
+	// JetStream: js.Subscribe / js.PullSubscribe / js.ChanSubscribe — before generic.
+	for _, m := range goNATSJSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream",
+			"jetstream":       "true",
+		})
+		jsSubscribeOffsets[m[0]] = true
+	}
+
+	// NATS Streaming: stan.Publish / sc.Publish — before generic nc.Publish.
+	stanPublishOffsets := map[int]bool{}
+	stanSubscribeOffsets := map[int]bool{}
+
+	for _, m := range goNATSStanPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"nats_streaming": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-streaming",
+			"nats_streaming":  "true",
+		})
+		stanPublishOffsets[m[0]] = true
+	}
+
+	// NATS Streaming: sc.Subscribe / sc.QueueSubscribe.
+	for _, m := range goNATSStanSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"nats_streaming": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-streaming",
+			"nats_streaming":  "true",
+		})
+		stanSubscribeOffsets[m[0]] = true
+	}
+
+	// Generic nc.Publish(subject, data) — skip offsets already handled above.
+	for _, m := range goNATSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		// Check if this offset falls within a JetStream or STAN match.
+		skip := false
+		for jsOff := range jsPublishOffsets {
+			if m[0] >= jsOff && m[0] < jsOff+50 {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			for stanOff := range stanPublishOffsets {
+				if m[0] >= stanOff && m[0] < stanOff+50 {
+					skip = true
+					break
+				}
+			}
+		}
+		if skip {
+			continue
+		}
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.go",
+		})
+	}
+
+	// Generic nc.Subscribe(subject, handler) — skip JetStream/STAN handled.
+	for _, m := range goNATSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		skip := false
+		for jsOff := range jsSubscribeOffsets {
+			if m[0] >= jsOff && m[0] < jsOff+50 {
+				skip = true
+				break
+			}
+		}
+		if !skip {
+			for stanOff := range stanSubscribeOffsets {
+				if m[0] >= stanOff && m[0] < stanOff+50 {
+					skip = true
+					break
+				}
+			}
+		}
+		if skip {
+			continue
+		}
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.go",
+		})
+	}
+
+	// nc.QueueSubscribe(subject, queue, handler)
+	for _, m := range goNATSQueueSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		queueGroup := src[m[4]:m[5]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"queue_group": queueGroup})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.go",
+			"queue_group":     queueGroup,
+		})
+	}
+
+	// nc.Request(subject, data, timeout) — request/reply pattern
+	for _, m := range goNATSRequestRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"pattern": "request_reply"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.go",
+			"pattern":         "request_reply",
+		})
+	}
+
+}
+
+// ---------------------------------------------------------------------------
+// Node — nats.js
+// ---------------------------------------------------------------------------
+
+// nodeNATSPublishRe captures nc.publish(subject, data).
+// Group 1 = subject.
+var nodeNATSPublishRe = regexp.MustCompile("" +
+	`\bnc\.publish\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeNATSSubscribeRe captures nc.subscribe(subject) or nc.subscribe(subject, opts).
+// Group 1 = subject.
+var nodeNATSSubscribeRe = regexp.MustCompile("" +
+	`\bnc\.subscribe\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeNATSRequestRe captures nc.request(subject, data) — request/reply.
+// Group 1 = subject.
+var nodeNATSRequestRe = regexp.MustCompile("" +
+	`\bnc\.request\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeNATSJSPublishRe captures js.publish(subject, data).
+// Group 1 = subject.
+var nodeNATSJSPublishRe = regexp.MustCompile("" +
+	`\bjs\.publish\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodeNATSJSSubscribeRe captures js.subscribe(subject) or
+// js.pullSubscribe(subject, durable).
+// Group 1 = subject.
+var nodeNATSJSSubscribeRe = regexp.MustCompile("" +
+	`\bjs\.(?:subscribe|pullSubscribe)\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+func synthesizeNodeNATS(
+	src string,
+	emitSubject func(subjectID, subject string, props map[string]string),
+	emitEdge func(callerKind, callerName, subjectID, edgeKind string, props map[string]string),
+) {
+	hasNATS := strings.Contains(src, "nats") || strings.Contains(src, "NATS") ||
+		strings.Contains(src, "jetstream") || strings.Contains(src, "JetStream")
+	if !hasNATS {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingNodeName(src, offset)
+	}
+
+	// nc.publish(subject, data)
+	for _, m := range nodeNATSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.js",
+		})
+	}
+
+	// nc.subscribe(subject)
+	for _, m := range nodeNATSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.js",
+		})
+	}
+
+	// nc.request(subject, data) — request/reply
+	for _, m := range nodeNATSRequestRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"pattern": "request_reply"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.js",
+			"pattern":         "request_reply",
+		})
+	}
+
+	// JetStream: js.publish(subject, data)
+	for _, m := range nodeNATSJSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-js",
+			"jetstream":       "true",
+		})
+	}
+
+	// JetStream: js.subscribe / js.pullSubscribe
+	for _, m := range nodeNATSJSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-js",
+			"jetstream":       "true",
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — nats.py (asyncio client)
+// ---------------------------------------------------------------------------
+
+// pyNATSPublishRe captures await nc.publish(subject, payload).
+// Group 1 = subject.
+var pyNATSPublishRe = regexp.MustCompile(`\bnc\.publish\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyNATSSubscribeRe captures await nc.subscribe(subject, cb=handler) or
+// await nc.subscribe(subject, queue=group, cb=handler).
+// Group 1 = subject.
+var pyNATSSubscribeRe = regexp.MustCompile(`\bnc\.subscribe\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyNATSRequestRe captures await nc.request(subject, payload).
+// Group 1 = subject.
+var pyNATSRequestRe = regexp.MustCompile(`\bnc\.request\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyNATSJSPublishRe captures await js.publish(subject, payload).
+// Group 1 = subject.
+var pyNATSJSPublishRe = regexp.MustCompile(`\bjs\.publish\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyNATSJSSubscribeRe captures await js.subscribe(subject) or
+// js.pull_subscribe(subject, durable).
+// Group 1 = subject.
+var pyNATSJSSubscribeRe = regexp.MustCompile(`\bjs\.(?:subscribe|pull_subscribe)\s*\(\s*["']([^"'\n\r]+)["']`)
+
+func synthesizePyNATS(
+	src string,
+	emitSubject func(subjectID, subject string, props map[string]string),
+	emitEdge func(callerKind, callerName, subjectID, edgeKind string, props map[string]string),
+) {
+	hasNATS := strings.Contains(src, "nats") || strings.Contains(src, "NATS")
+	if !hasNATS {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingPyName(src, offset)
+	}
+
+	// await nc.publish(subject, payload)
+	for _, m := range pyNATSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.py",
+		})
+	}
+
+	// await nc.subscribe(subject, ...)
+	for _, m := range pyNATSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.py",
+		})
+	}
+
+	// await nc.request(subject, payload) — request/reply
+	for _, m := range pyNATSRequestRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"pattern": "request_reply"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.py",
+			"pattern":         "request_reply",
+		})
+	}
+
+	// JetStream: await js.publish(subject, payload)
+	for _, m := range pyNATSJSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-py",
+			"jetstream":       "true",
+		})
+	}
+
+	// JetStream: await js.subscribe / js.pull_subscribe
+	for _, m := range pyNATSJSSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		subject := src[m[2]:m[3]]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-py",
+			"jetstream":       "true",
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java / Kotlin — nats.java
+// ---------------------------------------------------------------------------
+
+// javaNATSPublishRe captures connection.publish(subject, data).
+// Group 1 = subject.
+var javaNATSPublishRe = regexp.MustCompile(`(?:connection|nc|conn)\.publish\s*\(\s*"([^"\n\r]+)"`)
+
+// javaNATSSubscribeRe captures subscription = connection.subscribe(subject).
+// Group 1 = subject.
+var javaNATSSubscribeRe = regexp.MustCompile(`(?:connection|nc|conn)\.subscribe\s*\(\s*"([^"\n\r]+)"`)
+
+// javaNATSDispatcherSubscribeRe captures dispatcher.subscribe(subject, handler)
+// where dispatcher may be any variable name (commonly `d`, `dispatcher`, `sub`).
+// We match the pattern: <var>.subscribe("<subject>", ...) in a NATS context.
+// To avoid false positives, this is checked only when the file contains NATS imports.
+// Group 1 = subject.
+var javaNATSDispatcherSubscribeRe = regexp.MustCompile(`\b\w+\.subscribe\s*\(\s*"([^"\n\r]+)"`)
+
+// javaNATSRequestRe captures connection.request(subject, data, ...).
+// Group 1 = subject.
+var javaNATSRequestRe = regexp.MustCompile(`(?:connection|nc|conn)\.request\s*\(\s*"([^"\n\r]+)"`)
+
+// javaNATSJSPublishRe captures js.publish(subject, ...).
+// Group 1 = subject.
+var javaNATSJSPublishRe = regexp.MustCompile(`\bjs\.publish\s*\(\s*"([^"\n\r]+)"`)
+
+// javaNATSJSSubscribeRe captures js.subscribe(subject) or
+// js.pushSubscribeSync(subject, ...).
+// Group 1 = subject.
+var javaNATSJSSubscribeRe = regexp.MustCompile(`\bjs\.(?:subscribe|pushSubscribeSync|pullSubscribe)\s*\(\s*"([^"\n\r]+)"`)
+
+func synthesizeJavaNATS(
+	src string,
+	emitSubject func(subjectID, subject string, props map[string]string),
+	emitEdge func(callerKind, callerName, subjectID, edgeKind string, props map[string]string),
+) {
+	hasNATS := strings.Contains(src, "nats") || strings.Contains(src, "NATS") ||
+		strings.Contains(src, "io.nats")
+	if !hasNATS {
+		return
+	}
+
+	className := ""
+	if m := classNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		className = m[1]
+	}
+
+	emitClassEdge := func(subID, edgeKind string, props map[string]string) {
+		if className != "" {
+			emitEdge("Service", className, subID, edgeKind, props)
+		}
+	}
+
+	// connection.publish(subject, data)
+	for _, m := range javaNATSPublishRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		emitClassEdge(subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.java",
+		})
+	}
+
+	// connection.subscribe(subject)
+	for _, m := range javaNATSSubscribeRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		emitClassEdge(subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.java",
+		})
+	}
+
+	// dispatcher.subscribe(subject, handler)
+	for _, m := range javaNATSDispatcherSubscribeRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, nil)
+		emitClassEdge(subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.java",
+			"dispatcher":      "true",
+		})
+	}
+
+	// connection.request(subject, data) — request/reply
+	for _, m := range javaNATSRequestRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"pattern": "request_reply"})
+		emitClassEdge(subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats.java",
+			"pattern":         "request_reply",
+		})
+	}
+
+	// JetStream: js.publish(subject, ...)
+	for _, m := range javaNATSJSPublishRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		emitClassEdge(subID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-java",
+			"jetstream":       "true",
+		})
+	}
+
+	// JetStream: js.subscribe / js.pushSubscribeSync / js.pullSubscribe
+	for _, m := range javaNATSJSSubscribeRe.FindAllStringSubmatch(src, -1) {
+		subject := m[1]
+		if !looksLikeNATSSubject(subject) {
+			continue
+		}
+		subID := natsSubjectID(subject)
+		emitSubject(subID, subject, map[string]string{"jetstream": "true"})
+		emitClassEdge(subID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "nats-jetstream-java",
+			"jetstream":       "true",
+		})
+	}
+}

--- a/internal/engine/nats_edges_test.go
+++ b/internal/engine/nats_edges_test.go
@@ -1,0 +1,562 @@
+// Tests for the NATS producer/consumer detection pass added by #726 wave 3.
+//
+// Coverage per language:
+//   - Go: Publish, Subscribe, QueueSubscribe (with queue group), Request (request/reply),
+//     JetStream Publish/Subscribe, NATS Streaming Publish/Subscribe
+//   - Node: nc.publish, nc.subscribe, nc.request (request/reply),
+//     js.publish/subscribe (JetStream)
+//   - Python: nc.publish, nc.subscribe, nc.request, js.publish/subscribe
+//   - Java: connection.publish, connection.subscribe, dispatcher.subscribe,
+//     connection.request, js.publish/subscribe
+//   - Wildcard subjects (orders.*, inventory.>) are valid
+//   - No-signal guard (non-NATS file produces no output)
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// runNATSDetect is a lightweight in-process driver for the NATS pass.
+func runNATSDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
+	t.Helper()
+	ents, rels := applyNATSEdges(lang, path, []byte(src), nil, nil)
+	out := make([]entityResult, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	relOut := make([]relResult, 0, len(rels))
+	for _, r := range rels {
+		relOut = append(relOut, relResult{from: r.FromID, to: r.ToID, kind: r.Kind, props: r.Properties})
+	}
+	return out, relOut
+}
+
+// natsSubjectByID returns the first SCOPE.Queue entity with the given ID.
+func natsSubjectByID(ents []entityResult, subjectID string) *entityResult {
+	for i := range ents {
+		if ents[i].kind == queueEntityKind && ents[i].name == subjectID {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Go — nats.go
+// ---------------------------------------------------------------------------
+
+// TestNATS_Go_Publish covers nc.Publish(subject, data).
+func TestNATS_Go_Publish(t *testing.T) {
+	src := `package orders
+
+import "github.com/nats-io/nats.go"
+
+func PublishOrder(nc *nats.Conn, data []byte) error {
+	return nc.Publish("orders.created", data)
+}
+`
+	ents, rels := runNATSDetect(t, "go", "orders.go", src)
+	subID := natsSubjectID("orders.created")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.created, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if !strings.Contains(pubs[0].to, subID) {
+		t.Fatalf("PUBLISHES_TO ToID = %q, want to contain %q", pubs[0].to, subID)
+	}
+	if pubs[0].props["broker"] != "nats" {
+		t.Fatalf("broker = %q, want nats", pubs[0].props["broker"])
+	}
+}
+
+// TestNATS_Go_Subscribe covers nc.Subscribe(subject, handler).
+func TestNATS_Go_Subscribe(t *testing.T) {
+	src := `package consumer
+
+import "github.com/nats-io/nats.go"
+
+func StartConsumer(nc *nats.Conn) {
+	nc.Subscribe("orders.created", func(msg *nats.Msg) {
+		processOrder(msg.Data)
+	})
+}
+`
+	ents, rels := runNATSDetect(t, "go", "consumer.go", src)
+	subID := natsSubjectID("orders.created")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.created, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Go_QueueSubscribe covers nc.QueueSubscribe with queue group.
+func TestNATS_Go_QueueSubscribe(t *testing.T) {
+	src := `package worker
+
+import "github.com/nats-io/nats.go"
+
+func StartWorker(nc *nats.Conn) {
+	nc.QueueSubscribe("jobs.process", "worker-pool", func(msg *nats.Msg) {
+		handleJob(msg.Data)
+	})
+}
+`
+	ents, rels := runNATSDetect(t, "go", "worker.go", src)
+	subID := natsSubjectID("jobs.process")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for jobs.process, ents=%v", ents)
+	}
+	if q.props["queue_group"] != "worker-pool" {
+		t.Fatalf("queue_group = %q, want worker-pool", q.props["queue_group"])
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	if subs[0].props["queue_group"] != "worker-pool" {
+		t.Fatalf("edge queue_group = %q, want worker-pool", subs[0].props["queue_group"])
+	}
+}
+
+// TestNATS_Go_Request covers nc.Request — request/reply pattern.
+func TestNATS_Go_Request(t *testing.T) {
+	src := `package rpc
+
+import (
+	"time"
+	"github.com/nats-io/nats.go"
+)
+
+func GetInventory(nc *nats.Conn, item string) ([]byte, error) {
+	msg, err := nc.Request("inventory.query", []byte(item), 5*time.Second)
+	return msg.Data, err
+}
+`
+	ents, rels := runNATSDetect(t, "go", "rpc.go", src)
+	subID := natsSubjectID("inventory.query")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for inventory.query, ents=%v", ents)
+	}
+	if q.props["pattern"] != "request_reply" {
+		t.Fatalf("pattern = %q, want request_reply", q.props["pattern"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge for Request, rels=%v", rels)
+	}
+	if pubs[0].props["pattern"] != "request_reply" {
+		t.Fatalf("edge pattern = %q, want request_reply", pubs[0].props["pattern"])
+	}
+}
+
+// TestNATS_Go_JetStreamPublish covers js.Publish with jetstream=true property.
+func TestNATS_Go_JetStreamPublish(t *testing.T) {
+	src := `package jetstream
+
+import "github.com/nats-io/nats.go"
+
+func PublishEvent(nc *nats.Conn, data []byte) {
+	js, _ := nc.JetStream()
+	js.Publish("events.user.created", data)
+}
+`
+	ents, rels := runNATSDetect(t, "go", "js_pub.go", src)
+	subID := natsSubjectID("events.user.created")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for events.user.created, ents=%v", ents)
+	}
+	if q.props["jetstream"] != "true" {
+		t.Fatalf("jetstream = %q, want true", q.props["jetstream"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if pubs[0].props["jetstream"] != "true" {
+		t.Fatalf("edge jetstream = %q, want true", pubs[0].props["jetstream"])
+	}
+}
+
+// TestNATS_Go_JetStreamSubscribe covers js.Subscribe with jetstream=true property.
+func TestNATS_Go_JetStreamSubscribe(t *testing.T) {
+	src := `package jetstream
+
+import "github.com/nats-io/nats.go"
+
+func ConsumeEvents(nc *nats.Conn) {
+	js, _ := nc.JetStream()
+	js.Subscribe("events.user.*", func(msg *nats.Msg) {
+		handleEvent(msg.Data)
+		msg.Ack()
+	})
+}
+`
+	ents, rels := runNATSDetect(t, "go", "js_sub.go", src)
+	subID := natsSubjectID("events.user.*")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for events.user.*, ents=%v", ents)
+	}
+	if q.props["jetstream"] != "true" {
+		t.Fatalf("jetstream = %q, want true", q.props["jetstream"])
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Go_NATSStreaming covers NATS Streaming (STAN) with nats_streaming property.
+func TestNATS_Go_NATSStreaming(t *testing.T) {
+	src := `package legacy
+
+import stan "github.com/nats-io/stan.go"
+
+func PublishLegacy(sc stan.Conn, data []byte) {
+	stan.Publish("legacy-orders", data)
+}
+
+func SubscribeLegacy(sc stan.Conn) {
+	sc.Subscribe("legacy-orders", func(msg *stan.Msg) {
+		process(msg.Data)
+	})
+}
+`
+	ents, rels := runNATSDetect(t, "go", "legacy.go", src)
+	subID := natsSubjectID("legacy-orders")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for legacy-orders, ents=%v", ents)
+	}
+	if q.props["nats_streaming"] != "true" {
+		t.Fatalf("nats_streaming = %q, want true", q.props["nats_streaming"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node — nats.js
+// ---------------------------------------------------------------------------
+
+// TestNATS_Node_Publish covers nc.publish(subject, data).
+func TestNATS_Node_Publish(t *testing.T) {
+	src := `import { connect, StringCodec } from 'nats';
+
+async function publishOrder(data) {
+  const nc = await connect({ servers: 'nats://localhost:4222' });
+  const sc = StringCodec();
+  nc.publish('orders.new', sc.encode(data));
+  await nc.drain();
+}
+`
+	ents, rels := runNATSDetect(t, "typescript", "pub.ts", src)
+	subID := natsSubjectID("orders.new")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.new, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Node_Subscribe covers nc.subscribe(subject) for-await pattern.
+func TestNATS_Node_Subscribe(t *testing.T) {
+	src := `import { connect } from 'nats';
+
+async function listenForOrders() {
+  const nc = await connect({ servers: 'nats://localhost:4222' });
+  const sub = nc.subscribe('orders.new');
+  for await (const msg of sub) {
+    handleOrder(msg.data);
+  }
+}
+`
+	ents, rels := runNATSDetect(t, "javascript", "sub.js", src)
+	subID := natsSubjectID("orders.new")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.new, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Node_Request covers nc.request — request/reply.
+func TestNATS_Node_Request(t *testing.T) {
+	src := `import { connect, StringCodec } from 'nats';
+
+async function queryService(subject, payload) {
+  const nc = await connect({ servers: 'nats://localhost:4222' });
+  const sc = StringCodec();
+  const msg = await nc.request('service.query', sc.encode(payload), { timeout: 1000 });
+  return sc.decode(msg.data);
+}
+`
+	ents, _ := runNATSDetect(t, "typescript", "rpc.ts", src)
+	subID := natsSubjectID("service.query")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for service.query, ents=%v", ents)
+	}
+	if q.props["pattern"] != "request_reply" {
+		t.Fatalf("pattern = %q, want request_reply", q.props["pattern"])
+	}
+}
+
+// TestNATS_Node_JetStreamPublish covers js.publish(subject, data).
+func TestNATS_Node_JetStreamPublish(t *testing.T) {
+	src := `import { connect } from 'nats';
+
+async function publishEvent() {
+  const nc = await connect({ servers: 'nats://localhost:4222' });
+  const js = nc.jetstream();
+  await js.publish('events.payment.processed', payload);
+}
+`
+	ents, _ := runNATSDetect(t, "javascript", "js_pub.js", src)
+	subID := natsSubjectID("events.payment.processed")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for events.payment.processed, ents=%v", ents)
+	}
+	if q.props["jetstream"] != "true" {
+		t.Fatalf("jetstream = %q, want true", q.props["jetstream"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — nats.py
+// ---------------------------------------------------------------------------
+
+// TestNATS_Python_Publish covers await nc.publish(subject, payload).
+func TestNATS_Python_Publish(t *testing.T) {
+	src := `import asyncio
+import nats
+
+async def publish_message():
+    nc = await nats.connect("nats://localhost:4222")
+    await nc.publish("notifications.email", b"Hello!")
+    await nc.close()
+`
+	ents, rels := runNATSDetect(t, "python", "pub.py", src)
+	subID := natsSubjectID("notifications.email")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for notifications.email, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Python_Subscribe covers await nc.subscribe(subject, cb=handler).
+func TestNATS_Python_Subscribe(t *testing.T) {
+	src := `import asyncio
+import nats
+
+async def subscribe():
+    nc = await nats.connect("nats://localhost:4222")
+    await nc.subscribe("notifications.email", cb=handle_message)
+    await asyncio.sleep(10)
+`
+	ents, rels := runNATSDetect(t, "python", "sub.py", src)
+	subID := natsSubjectID("notifications.email")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for notifications.email, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Python_Request covers await nc.request — request/reply.
+func TestNATS_Python_Request(t *testing.T) {
+	src := `import asyncio
+import nats
+
+async def query_service():
+    nc = await nats.connect("nats://localhost:4222")
+    response = await nc.request("pricing.query", b"item-42", timeout=1)
+    return response.data
+`
+	ents, rels := runNATSDetect(t, "python", "rpc.py", src)
+	subID := natsSubjectID("pricing.query")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for pricing.query, ents=%v", ents)
+	}
+	if q.props["pattern"] != "request_reply" {
+		t.Fatalf("pattern = %q, want request_reply", q.props["pattern"])
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge for request, rels=%v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java — nats.java
+// ---------------------------------------------------------------------------
+
+// TestNATS_Java_Publish covers connection.publish(subject, data).
+func TestNATS_Java_Publish(t *testing.T) {
+	src := `import io.nats.client.Connection;
+import io.nats.client.Nats;
+
+public class OrderPublisher {
+    private Connection nc;
+
+    public void publishOrder(byte[] data) throws Exception {
+        nc.publish("orders.placed", data);
+    }
+}
+`
+	ents, rels := runNATSDetect(t, "java", "OrderPublisher.java", src)
+	subID := natsSubjectID("orders.placed")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.placed, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Java_Subscribe covers connection.subscribe(subject).
+func TestNATS_Java_Subscribe(t *testing.T) {
+	src := `import io.nats.client.Connection;
+import io.nats.client.Subscription;
+
+public class OrderConsumer {
+    public void startConsuming(Connection nc) throws Exception {
+        Subscription sub = nc.subscribe("orders.placed");
+        Message msg = sub.nextMessage(Duration.ofSeconds(5));
+        processOrder(msg.getData());
+    }
+}
+`
+	ents, rels := runNATSDetect(t, "java", "OrderConsumer.java", src)
+	subID := natsSubjectID("orders.placed")
+	if natsSubjectByID(ents, subID) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.placed, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestNATS_Java_DispatcherSubscribe covers dispatcher.subscribe(subject, handler).
+func TestNATS_Java_DispatcherSubscribe(t *testing.T) {
+	src := `import io.nats.client.Dispatcher;
+
+public class AsyncConsumer {
+    public void setup(Connection nc) {
+        Dispatcher d = nc.createDispatcher((msg) -> processMessage(msg));
+        d.subscribe("inventory.>", (msg) -> handleInventory(msg));
+    }
+}
+`
+	ents, rels := runNATSDetect(t, "java", "AsyncConsumer.java", src)
+	subID := natsSubjectID("inventory.>")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for inventory.>, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	if subs[0].props["dispatcher"] != "true" {
+		t.Fatalf("dispatcher = %q, want true", subs[0].props["dispatcher"])
+	}
+}
+
+// TestNATS_Java_Request covers connection.request — request/reply.
+func TestNATS_Java_Request(t *testing.T) {
+	src := `import io.nats.client.Connection;
+
+public class PricingClient {
+    public byte[] queryPrice(Connection nc, byte[] item) throws Exception {
+        Message reply = nc.request("pricing.lookup", item, Duration.ofSeconds(2));
+        return reply.getData();
+    }
+}
+`
+	ents, _ := runNATSDetect(t, "java", "PricingClient.java", src)
+	subID := natsSubjectID("pricing.lookup")
+	q := natsSubjectByID(ents, subID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for pricing.lookup, ents=%v", ents)
+	}
+	if q.props["pattern"] != "request_reply" {
+		t.Fatalf("pattern = %q, want request_reply", q.props["pattern"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Edge cases
+// ---------------------------------------------------------------------------
+
+// TestNATS_WildcardSubject verifies that wildcard subjects like orders.*
+// and inventory.> are accepted and emitted as-is.
+func TestNATS_WildcardSubject(t *testing.T) {
+	src := `package subscriber
+
+import "github.com/nats-io/nats.go"
+
+func SubscribeAll(nc *nats.Conn) {
+	nc.Subscribe("orders.*", func(msg *nats.Msg) { handleOrder(msg.Data) })
+	nc.Subscribe("inventory.>", func(msg *nats.Msg) { handleInventory(msg.Data) })
+}
+`
+	ents, rels := runNATSDetect(t, "go", "wildcard.go", src)
+	idOrders := natsSubjectID("orders.*")
+	idInventory := natsSubjectID("inventory.>")
+	if natsSubjectByID(ents, idOrders) == nil {
+		t.Fatalf("expected SCOPE.Queue for orders.*, ents=%v", ents)
+	}
+	if natsSubjectByID(ents, idInventory) == nil {
+		t.Fatalf("expected SCOPE.Queue for inventory.>, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) < 2 {
+		t.Fatalf("expected 2 SUBSCRIBES_TO edges, got %d: %v", len(subs), rels)
+	}
+}
+
+// TestNATS_NoBrokerSignal verifies non-NATS files produce no output.
+func TestNATS_NoBrokerSignal(t *testing.T) {
+	src := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("Hello, world!")
+}
+`
+	ents, rels := runNATSDetect(t, "go", "hello.go", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("no nats signal: expected empty, got ents=%v rels=%v", ents, rels)
+	}
+}

--- a/internal/engine/pubsub_edges.go
+++ b/internal/engine/pubsub_edges.go
@@ -1,0 +1,694 @@
+// Google Cloud Pub/Sub producer/consumer detection — wave 3 of #726.
+//
+// For every Pub/Sub publish or subscribe call site this pass can statically
+// recognize, we emit a synthetic `SCOPE.Queue` entity keyed by the topic
+// name, plus PUBLISHES_TO or SUBSCRIBES_TO edges from the calling method
+// to that topic. The synthetic topic ID is identical across repos
+// (`pubsub:<project>:<topic-name>` or `pubsub:X:<topic-name>` when the
+// project is unknown), so the existing import-channel linker matches
+// producer and consumer sides on shared entity ID without any new cross-repo
+// matching code — same technique used by kafka_edges.go (#726 wave 1) and
+// rabbitmq_edges.go (#726 wave 2).
+//
+// Libraries/frameworks covered:
+//   - Python google-cloud-pubsub: publisher.publish(topic_path, data),
+//     subscriber.subscribe(subscription_path, callback),
+//     publisher.topic_path(project, topic), subscriber.create_subscription
+//   - Python Pub/Sub Lite: PublisherClient.publish / SubscriberClient.subscribe
+//   - Node @google-cloud/pubsub: topic.publish(data), subscription.on('message', h),
+//     pubsub.topic('X'), pubsub.subscription('Y')
+//   - Go cloud.google.com/go/pubsub: topic.Publish(ctx, &pubsub.Message{...}),
+//     sub.Receive(ctx, handler)
+//   - Java google-cloud-pubsub: publisher.publish(message), subscriber.startAsync(),
+//     MessageReceiver interface implementations
+//   - Eventarc / Cloud Run triggers: def hello_pubsub(event, context) where
+//     event.attributes["type"] == "google.cloud.pubsub.topic.v1.messagePublished"
+//     — consumer side
+//
+// Beyond the minimum:
+//   - Pub/Sub Lite (PublisherClient.publish / SubscriberClient.subscribe)
+//   - Eventarc Cloud Run trigger config detection as a Pub/Sub consumer even
+//     when the function does not call subscribe() directly
+//   - project prefix in ID for cross-repo matching
+//
+// Emit: SCOPE.Queue (reuses queueEntityKind) + PUBLISHES_TO + SUBSCRIBES_TO.
+// ID format: pubsub:<project-or-X>:<topic-name>.
+//
+// Refs #726.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pubsubSynthesisSupportsLanguage reports whether applyPubSubEdges can emit
+// synthetics for `lang`.
+func pubsubSynthesisSupportsLanguage(lang string) bool {
+	switch lang {
+	case "java", "kotlin", "javascript", "typescript", "python", "go":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyPubSubEdges runs after applySQSEdges and APPENDS SCOPE.Queue
+// entities + PUBLISHES_TO / SUBSCRIBES_TO edges for Google Cloud Pub/Sub.
+// Append-only — never modifies or removes existing entities or edges, so
+// this pass cannot regress the surrounding pipeline's bug-rate.
+func applyPubSubEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if len(content) == 0 {
+		return entities, relationships
+	}
+	if !pubsubSynthesisSupportsLanguage(lang) {
+		return entities, relationships
+	}
+
+	src := string(content)
+
+	// Dedup-by-ID: one SCOPE.Queue entity per topic per file.
+	seenQueue := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitTopic := func(topicID, topicName, project string, props map[string]string) {
+		if seenQueue[topicID] {
+			return
+		}
+		seenQueue[topicID] = true
+		merged := map[string]string{
+			"broker":       "pubsub",
+			"topic_name":   topicName,
+			"pattern_type": "pubsub_synthesis",
+		}
+		if project != "" {
+			merged["project"] = project
+		}
+		for k, v := range props {
+			if v != "" {
+				merged[k] = v
+			}
+		}
+		// SourceFile left empty so identical topic names collapse to ONE
+		// entity per repo and match across repos via the import-channel
+		// linker (same technique as kafka_edges.go MessageTopic).
+		entities = append(entities, types.EntityRecord{
+			Name:               topicID,
+			Kind:               queueEntityKind,
+			SourceFile:         "",
+			Language:           lang,
+			Properties:         merged,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	emitEdge := func(callerKind, callerName, topicID, edgeKind string, props map[string]string) {
+		if callerName == "" || topicID == "" {
+			return
+		}
+		key := edgeKind + "|" + callerKind + ":" + callerName + "|" + topicID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		base := map[string]string{
+			"broker":       "pubsub",
+			"pattern_type": "pubsub_synthesis",
+		}
+		for k, v := range props {
+			if v != "" {
+				base[k] = v
+			}
+		}
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fmt.Sprintf("%s:%s", callerKind, callerName),
+			ToID:       fmt.Sprintf("%s:%s", queueEntityKind, topicID),
+			Kind:       edgeKind,
+			Properties: base,
+		})
+	}
+
+	switch lang {
+	case "python":
+		synthesizePyPubSub(src, emitTopic, emitEdge)
+	case "javascript", "typescript":
+		synthesizeNodePubSub(src, emitTopic, emitEdge)
+	case "java", "kotlin":
+		synthesizeJavaPubSub(src, emitTopic, emitEdge)
+	case "go":
+		synthesizeGoPubSub(src, emitTopic, emitEdge)
+	}
+
+	return entities, relationships
+}
+
+// pubsubTopicID returns the canonical synthetic ID for a Pub/Sub topic.
+// project may be empty (replaced with "X" for cross-repo matching when
+// the project is not statically known).
+func pubsubTopicID(project, topic string) string {
+	if project == "" {
+		project = "X"
+	}
+	return "pubsub:" + project + ":" + topic
+}
+
+// looksLikePubSubTopic returns true when `s` plausibly looks like a
+// Google Cloud Pub/Sub topic name. Topic names are 3–255 characters,
+// alphanumeric plus hyphens, underscores, periods, and tildes.
+func looksLikePubSubTopic(s string) bool {
+	if s == "" || len(s) > 255 || len(s) < 1 {
+		return false
+	}
+	if strings.ContainsAny(s, "\n\r\t<>{}") {
+		return false
+	}
+	hasAlnum := false
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+			hasAlnum = true
+		case r == '.' || r == '_' || r == '-' || r == '~':
+		default:
+			return false
+		}
+	}
+	return hasAlnum
+}
+
+// ---------------------------------------------------------------------------
+// Python — google-cloud-pubsub + Pub/Sub Lite + Eventarc
+// ---------------------------------------------------------------------------
+
+// pyPubSubPublishVarRe detects publisher.publish(topic_path_var, ...) where the
+// first argument is a variable (not a literal). Matches when the file uses the
+// common pattern: topic_path = "projects/.../topics/..." followed by publish(topic_path).
+var pyPubSubPublishVarRe = regexp.MustCompile(`\.publish\s*\(`)
+
+// pyPubSubPublishLitRe captures publisher.publish("projects/.../topics/name", data).
+// Group 1 = full topic resource path.
+var pyPubSubPublishLitRe = regexp.MustCompile(`\.publish\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyPubSubTopicStrLitRe scans for any string literal in the file that is a full
+// Pub/Sub resource path (projects/.../topics/...). This handles the common
+// pattern: topic_path = "projects/proj/topics/name"; publisher.publish(topic_path, ...).
+// Groups: 1=project, 2=topic.
+var pyPubSubTopicStrLitRe = regexp.MustCompile(`["']projects/([^/"'\s]+)/topics/([^/"'\s]+)["']`)
+
+// pyPubSubTopicPathRe captures publisher.topic_path(project, topic) and
+// subscriber.topic_path(project, topic).
+// Groups: 1=project, 2=topic.
+var pyPubSubTopicPathRe = regexp.MustCompile(`\.topic_path\s*\(\s*["']([^"'\n\r]+)["']\s*,\s*["']([^"'\n\r]+)["']`)
+
+// pyPubSubSubscribeRe captures subscriber.subscribe(subscription_path, callback).
+// Group 1 = subscription_path or literal.
+var pyPubSubSubscribeLitRe = regexp.MustCompile(`\.subscribe\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// pyPubSubCreateSubRe captures subscriber.create_subscription(subscription, topic).
+// Group 1 = topic resource path or variable.
+var pyPubSubCreateSubRe = regexp.MustCompile(`\.create_subscription\s*\([^)]*?topic\s*=\s*["']([^"'\n\r]+)["']`)
+
+// pyPubSubLitePublishRe captures PublisherClient usage.
+var pyPubSubLitePublishRe = regexp.MustCompile(`PublisherClient\b`)
+
+// pyPubSubLiteSubscribeRe captures SubscriberClient usage.
+var pyPubSubLiteSubscribeRe = regexp.MustCompile(`SubscriberClient\b`)
+
+// pyPubSubSubscribeVarRe detects subscriber.subscribe(var, ...) where the first
+// arg is a variable — handles pattern: subscription_path = "projects/.../subscriptions/name".
+var pyPubSubSubscribeVarRe = regexp.MustCompile(`\.subscribe\s*\(`)
+
+// pyPubSubSubStrLitRe scans for any subscription resource path literal.
+// Groups: 1=project, 2=subscription-name.
+var pyPubSubSubStrLitRe = regexp.MustCompile(`["']projects/([^/"'\s]+)/subscriptions/([^/"'\s]+)["']`)
+
+// pyEventarcHandlerRe captures Cloud Run / Eventarc handlers that receive
+// Pub/Sub events via the "google.cloud.pubsub.topic.v1.messagePublished" trigger.
+// Group 1 = handler function name.
+var pyEventarcHandlerRe = regexp.MustCompile(`(?m)^\s*def\s+(\w+)\s*\(\s*(?:event|request|cloud_event)\s*[,)]`)
+
+// pyEventarcPubSubTypeRe matches the Pub/Sub event type attribute.
+var pyEventarcPubSubTypeRe = regexp.MustCompile(`google\.cloud\.pubsub\.topic\.v1\.messagePublished`)
+
+// pyPubSubTopicResourceRe extracts topic from a full resource path like
+// projects/my-project/topics/my-topic.
+// Groups: 1=project, 2=topic.
+var pyPubSubTopicResourceRe = regexp.MustCompile(`projects/([^/\s"']+)/topics/([^/\s"']+)`)
+
+func synthesizePyPubSub(
+	src string,
+	emitTopic func(topicID, topicName, project string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	hasPubSub := strings.Contains(src, "pubsub") || strings.Contains(src, "PublisherClient") ||
+		strings.Contains(src, "SubscriberClient") || strings.Contains(src, "topic_path") ||
+		strings.Contains(src, "google.cloud.pubsub")
+	if !hasPubSub {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingPyName(src, offset)
+	}
+
+	// publisher.topic_path(project, topic) — emit topic entity.
+	for _, m := range pyPubSubTopicPathRe.FindAllStringSubmatchIndex(src, -1) {
+		project := src[m[2]:m[3]]
+		topic := src[m[4]:m[5]]
+		if !looksLikePubSubTopic(topic) {
+			continue
+		}
+		topicID := pubsubTopicID(project, topic)
+		emitTopic(topicID, topic, project, nil)
+	}
+
+	// publisher.publish("projects/.../topics/name", data) — literal first arg.
+	for _, m := range pyPubSubPublishLitRe.FindAllStringSubmatchIndex(src, -1) {
+		resourcePath := src[m[2]:m[3]]
+		project, topic := "", resourcePath
+		if rm := pyPubSubTopicResourceRe.FindStringSubmatch(resourcePath); len(rm) >= 3 {
+			project, topic = rm[1], rm[2]
+		}
+		if !looksLikePubSubTopic(topic) {
+			continue
+		}
+		topicID := pubsubTopicID(project, topic)
+		emitTopic(topicID, topic, project, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, topicID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "google-cloud-pubsub",
+		})
+	}
+
+	// Variable-based publish: publisher.publish(topic_path_var, ...) where topic_path_var
+	// was assigned from a "projects/.../topics/..." string literal elsewhere in the file.
+	// Scan all topic resource literals in the file; if any .publish( call exists, emit
+	// a PUBLISHES_TO edge from the enclosing function.
+	if pyPubSubPublishVarRe.MatchString(src) {
+		for _, m := range pyPubSubTopicStrLitRe.FindAllStringSubmatchIndex(src, -1) {
+			project := src[m[2]:m[3]]
+			topic := src[m[4]:m[5]]
+			if !looksLikePubSubTopic(topic) {
+				continue
+			}
+			topicID := pubsubTopicID(project, topic)
+			emitTopic(topicID, topic, project, nil)
+			// Find the closest publish call to associate an edge.
+			for _, pm := range pyPubSubPublishVarRe.FindAllStringSubmatchIndex(src, -1) {
+				// Only associate if the literal is within 200 chars of the publish call
+				// (either the variable is assigned nearby, or the call uses the literal).
+				dist := pm[0] - m[0]
+				if dist < 0 {
+					dist = -dist
+				}
+				if dist <= 200 {
+					caller := enclosing(pm[0])
+					emitEdge("Function", caller, topicID, publishesToEdgeKind, map[string]string{
+						"messaging_layer": "google-cloud-pubsub",
+					})
+				}
+			}
+		}
+	}
+
+	// subscriber.subscribe(subscription_path, callback) literal form.
+	for _, m := range pyPubSubSubscribeLitRe.FindAllStringSubmatchIndex(src, -1) {
+		resourcePath := src[m[2]:m[3]]
+		// We accept both topic paths (projects/.../topics/X) and subscription
+		// paths (projects/.../subscriptions/Y) — topic name is extracted from
+		// the path or used as-is.
+		topic := resourcePath
+		project := ""
+		if rm := pyPubSubTopicResourceRe.FindStringSubmatch(resourcePath); len(rm) >= 3 {
+			project, topic = rm[1], rm[2]
+		} else if strings.Contains(resourcePath, "/subscriptions/") {
+			// Use subscription name as fallback identifier.
+			parts := strings.Split(resourcePath, "/")
+			topic = parts[len(parts)-1]
+		}
+		if !looksLikePubSubTopic(topic) {
+			continue
+		}
+		topicID := pubsubTopicID(project, topic)
+		emitTopic(topicID, topic, project, nil)
+		caller := enclosing(m[0])
+		emitEdge("Function", caller, topicID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "google-cloud-pubsub",
+		})
+	}
+
+	// Variable-based subscribe: subscriber.subscribe(sub_path_var, ...) where sub_path_var
+	// was assigned from a "projects/.../subscriptions/..." string literal.
+	if pyPubSubSubscribeVarRe.MatchString(src) {
+		for _, m := range pyPubSubSubStrLitRe.FindAllStringSubmatchIndex(src, -1) {
+			// project from group 1, subscriptionName from group 2
+			project := src[m[2]:m[3]]
+			subName := src[m[4]:m[5]]
+			if !looksLikePubSubTopic(subName) {
+				continue
+			}
+			topicID := pubsubTopicID(project, subName)
+			emitTopic(topicID, subName, project, nil)
+			// Associate with the nearest subscribe call within 200 chars.
+			for _, sm := range pyPubSubSubscribeVarRe.FindAllStringSubmatchIndex(src, -1) {
+				dist := sm[0] - m[0]
+				if dist < 0 {
+					dist = -dist
+				}
+				if dist <= 200 {
+					caller := enclosing(sm[0])
+					emitEdge("Function", caller, topicID, subscribesToEdgeKind, map[string]string{
+						"messaging_layer": "google-cloud-pubsub",
+					})
+				}
+			}
+		}
+	}
+
+	// subscriber.create_subscription(subscription, topic=...) — emit topic entity.
+	for _, m := range pyPubSubCreateSubRe.FindAllStringSubmatchIndex(src, -1) {
+		resourcePath := src[m[2]:m[3]]
+		topic, project := resourcePath, ""
+		if rm := pyPubSubTopicResourceRe.FindStringSubmatch(resourcePath); len(rm) >= 3 {
+			project, topic = rm[1], rm[2]
+		}
+		if !looksLikePubSubTopic(topic) {
+			continue
+		}
+		topicID := pubsubTopicID(project, topic)
+		emitTopic(topicID, topic, project, map[string]string{"declared": "true"})
+	}
+
+	// Pub/Sub Lite: PublisherClient(...).publish(...) / SubscriberClient(...).subscribe(...)
+	// We detect the class name presence and emit a placeholder if the file
+	// also contains a topic_path or publish/subscribe call.
+	if pyPubSubLitePublishRe.MatchString(src) {
+		for _, m := range pyPubSubPublishLitRe.FindAllStringSubmatchIndex(src, -1) {
+			resourcePath := src[m[2]:m[3]]
+			project, topic := "", resourcePath
+			if rm := pyPubSubTopicResourceRe.FindStringSubmatch(resourcePath); len(rm) >= 3 {
+				project, topic = rm[1], rm[2]
+			}
+			if !looksLikePubSubTopic(topic) {
+				continue
+			}
+			topicID := pubsubTopicID(project, topic)
+			emitTopic(topicID, topic, project, map[string]string{"pubsub_lite": "true"})
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, publishesToEdgeKind, map[string]string{
+				"messaging_layer": "pubsub-lite",
+				"pubsub_lite":     "true",
+			})
+		}
+	}
+	if pyPubSubLiteSubscribeRe.MatchString(src) {
+		for _, m := range pyPubSubSubscribeLitRe.FindAllStringSubmatchIndex(src, -1) {
+			resourcePath := src[m[2]:m[3]]
+			topic, project := resourcePath, ""
+			if rm := pyPubSubTopicResourceRe.FindStringSubmatch(resourcePath); len(rm) >= 3 {
+				project, topic = rm[1], rm[2]
+			}
+			if !looksLikePubSubTopic(topic) {
+				continue
+			}
+			topicID := pubsubTopicID(project, topic)
+			emitTopic(topicID, topic, project, map[string]string{"pubsub_lite": "true"})
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "pubsub-lite",
+				"pubsub_lite":     "true",
+			})
+		}
+	}
+
+	// Eventarc / Cloud Run trigger: def hello_pubsub(event, context) where the
+	// file contains the "google.cloud.pubsub.topic.v1.messagePublished" type.
+	if pyEventarcPubSubTypeRe.MatchString(src) {
+		for _, m := range pyEventarcHandlerRe.FindAllStringSubmatchIndex(src, -1) {
+			handlerName := src[m[2]:m[3]]
+			topicID := pubsubTopicID("", "eventarc-pubsub-trigger")
+			emitTopic(topicID, "eventarc-pubsub-trigger", "", map[string]string{
+				"eventarc":       "true",
+				"trigger_type":   "google.cloud.pubsub.topic.v1.messagePublished",
+			})
+			emitEdge("Function", handlerName, topicID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "eventarc",
+				"eventarc":        "true",
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node — @google-cloud/pubsub
+// ---------------------------------------------------------------------------
+
+// nodePubSubTopicPublishRe captures topic.publish(data) / topic.publishMessage(msg).
+// We key on ".publish(" or ".publishMessage(" in a file that has pubsub imports.
+var nodePubSubTopicPublishRe = regexp.MustCompile(`\.publish(?:Message)?\s*\(`)
+
+// nodePubSubTopicNameRe captures pubsub.topic('name') or new Topic('name').
+// Group 1 = topic name.
+var nodePubSubTopicNameRe = regexp.MustCompile("" +
+	`(?:pubsub|ps)\.topic\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodePubSubSubscriptionNameRe captures pubsub.subscription('name').
+// Group 1 = subscription name.
+var nodePubSubSubscriptionNameRe = regexp.MustCompile("" +
+	`(?:pubsub|ps)\.subscription\s*\(\s*` +
+	"[\"'`]([^\"'`\\n\\r]+)[\"'`]")
+
+// nodePubSubOnMessageRe captures subscription.on('message', handler).
+var nodePubSubOnMessageRe = regexp.MustCompile(`\.on\s*\(\s*["']message["']\s*,`)
+
+func synthesizeNodePubSub(
+	src string,
+	emitTopic func(topicID, topicName, project string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	hasPubSub := strings.Contains(src, "@google-cloud/pubsub") ||
+		strings.Contains(src, "google-cloud/pubsub") ||
+		strings.Contains(src, "PubSub") ||
+		(strings.Contains(src, "pubsub") && strings.Contains(src, "topic"))
+	if !hasPubSub {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingNodeName(src, offset)
+	}
+
+	// pubsub.topic('name') — collect topic names used in this file.
+	topicNames := map[string]string{} // varname → topic name (best-effort)
+	for _, m := range nodePubSubTopicNameRe.FindAllStringSubmatchIndex(src, -1) {
+		topicName := src[m[2]:m[3]]
+		if !looksLikePubSubTopic(topicName) {
+			continue
+		}
+		topicID := pubsubTopicID("", topicName)
+		emitTopic(topicID, topicName, "", nil)
+		topicNames[topicName] = topicID
+
+		// If followed by .publish() in close vicinity, emit PUBLISHES_TO.
+		vicinity := surroundingText(src, m[0], 500)
+		if nodePubSubTopicPublishRe.MatchString(vicinity) {
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, publishesToEdgeKind, map[string]string{
+				"messaging_layer": "google-cloud-pubsub-node",
+			})
+		}
+	}
+
+	// pubsub.subscription('name') — emit SUBSCRIBES_TO when followed by .on('message').
+	for _, m := range nodePubSubSubscriptionNameRe.FindAllStringSubmatchIndex(src, -1) {
+		subName := src[m[2]:m[3]]
+		if !looksLikePubSubTopic(subName) {
+			continue
+		}
+		topicID := pubsubTopicID("", subName)
+		emitTopic(topicID, subName, "", nil)
+
+		vicinity := surroundingText(src, m[0], 500)
+		if nodePubSubOnMessageRe.MatchString(vicinity) {
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "google-cloud-pubsub-node",
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Go — cloud.google.com/go/pubsub
+// ---------------------------------------------------------------------------
+
+// goPubSubPublishRe captures topic.Publish(ctx, &pubsub.Message{...}).
+var goPubSubPublishRe = regexp.MustCompile(`\.Publish\s*\(\s*ctx\b`)
+
+// goPubSubReceiveRe captures sub.Receive(ctx, handler).
+var goPubSubReceiveRe = regexp.MustCompile(`\.Receive\s*\(\s*ctx\b`)
+
+// goPubSubTopicRe captures client.Topic("name") or client.CreateTopic(ctx, "name").
+// Group 1 = topic name.
+var goPubSubTopicRe = regexp.MustCompile(`\.(?:Topic|CreateTopic)\s*\(\s*(?:ctx\s*,\s*)?["']([^"'\n\r]+)["']`)
+
+// goPubSubSubscriptionRe captures client.Subscription("name") or
+// client.CreateSubscription(ctx, "name", ...).
+// Group 1 = subscription name.
+var goPubSubSubscriptionRe = regexp.MustCompile(`\.(?:Subscription|CreateSubscription)\s*\(\s*(?:ctx\s*,\s*)?["']([^"'\n\r]+)["']`)
+
+func synthesizeGoPubSub(
+	src string,
+	emitTopic func(topicID, topicName, project string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	hasPubSub := strings.Contains(src, "pubsub") || strings.Contains(src, "PubSub")
+	if !hasPubSub {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingGoName(src, offset)
+	}
+
+	// client.Topic("name") — emit topic entity; detect publish in vicinity.
+	for _, m := range goPubSubTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		topicName := src[m[2]:m[3]]
+		if !looksLikePubSubTopic(topicName) {
+			continue
+		}
+		topicID := pubsubTopicID("", topicName)
+		emitTopic(topicID, topicName, "", nil)
+
+		vicinity := surroundingText(src, m[0], 500)
+		if goPubSubPublishRe.MatchString(vicinity) {
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, publishesToEdgeKind, map[string]string{
+				"messaging_layer": "go-pubsub",
+			})
+		}
+	}
+
+	// client.Subscription("name") — detect receive in vicinity.
+	for _, m := range goPubSubSubscriptionRe.FindAllStringSubmatchIndex(src, -1) {
+		subName := src[m[2]:m[3]]
+		if !looksLikePubSubTopic(subName) {
+			continue
+		}
+		topicID := pubsubTopicID("", subName)
+		emitTopic(topicID, subName, "", nil)
+
+		vicinity := surroundingText(src, m[0], 500)
+		if goPubSubReceiveRe.MatchString(vicinity) {
+			caller := enclosing(m[0])
+			emitEdge("Function", caller, topicID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "go-pubsub",
+			})
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java / Kotlin — google-cloud-pubsub
+// ---------------------------------------------------------------------------
+
+// javaPubSubPublisherRe captures Publisher usage pattern.
+var javaPubSubPublishRe = regexp.MustCompile(`publisher\.publish\s*\(`)
+
+// javaPubSubSubscriberRe captures MessageReceiver implementation or
+// subscriber.startAsync() pattern.
+var javaPubSubStartAsyncRe = regexp.MustCompile(`subscriber\.startAsync\s*\(\s*\)`)
+
+// javaPubSubTopicNameRe captures TopicName.of("project", "topic") or
+// ProjectTopicName.of("project", "topic") calls.
+// Groups: 1=project, 2=topic.
+var javaPubSubTopicNameRe = regexp.MustCompile(`(?:TopicName|ProjectTopicName)\.of\s*\(\s*"([^"\n\r]+)"\s*,\s*"([^"\n\r]+)"`)
+
+// javaPubSubSubscriptionNameRe captures SubscriptionName.of("project", "sub").
+// Groups: 1=project, 2=subscription.
+var javaPubSubSubscriptionNameRe = regexp.MustCompile(`(?:SubscriptionName|ProjectSubscriptionName)\.of\s*\(\s*"([^"\n\r]+)"\s*,\s*"([^"\n\r]+)"`)
+
+// javaPubSubMessageReceiverRe captures MessageReceiver interface implementation.
+var javaPubSubMessageReceiverRe = regexp.MustCompile(`implements\s+(?:\w+,\s*)*MessageReceiver\b`)
+
+func synthesizeJavaPubSub(
+	src string,
+	emitTopic func(topicID, topicName, project string, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	hasPubSub := strings.Contains(src, "pubsub") || strings.Contains(src, "PubSub") ||
+		strings.Contains(src, "TopicName") || strings.Contains(src, "Publisher") ||
+		strings.Contains(src, "MessageReceiver")
+	if !hasPubSub {
+		return
+	}
+
+	className := ""
+	if m := classNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		className = m[1]
+	}
+
+	// TopicName.of("project", "topic") — emit topic entity.
+	for _, m := range javaPubSubTopicNameRe.FindAllStringSubmatchIndex(src, -1) {
+		project := src[m[2]:m[3]]
+		topic := src[m[4]:m[5]]
+		if !looksLikePubSubTopic(topic) {
+			continue
+		}
+		topicID := pubsubTopicID(project, topic)
+		emitTopic(topicID, topic, project, map[string]string{"messaging_layer": "google-cloud-pubsub-java"})
+
+		// Detect publisher.publish() in file → PUBLISHES_TO.
+		if javaPubSubPublishRe.MatchString(src) && className != "" {
+			emitEdge("Service", className, topicID, publishesToEdgeKind, map[string]string{
+				"messaging_layer": "google-cloud-pubsub-java",
+			})
+		}
+	}
+
+	// SubscriptionName.of("project", "subscription") — emit subscription entity.
+	for _, m := range javaPubSubSubscriptionNameRe.FindAllStringSubmatchIndex(src, -1) {
+		project := src[m[2]:m[3]]
+		subName := src[m[4]:m[5]]
+		if !looksLikePubSubTopic(subName) {
+			continue
+		}
+		topicID := pubsubTopicID(project, subName)
+		emitTopic(topicID, subName, project, map[string]string{"messaging_layer": "google-cloud-pubsub-java"})
+
+		// Detect subscriber.startAsync() or MessageReceiver in file → SUBSCRIBES_TO.
+		isSubscriber := javaPubSubStartAsyncRe.MatchString(src) ||
+			javaPubSubMessageReceiverRe.MatchString(src)
+		if isSubscriber && className != "" {
+			emitEdge("Service", className, topicID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "google-cloud-pubsub-java",
+			})
+		}
+	}
+
+	// MessageReceiver implementation without an explicit subscription name:
+	// emit a generic subscriber edge from the class.
+	if javaPubSubMessageReceiverRe.MatchString(src) && className != "" {
+		// Only emit if we haven't already emitted one via subscription name.
+		topicID := pubsubTopicID("", className+"-subscription")
+		emitTopic(topicID, className+"-subscription", "", map[string]string{
+			"messaging_layer":   "google-cloud-pubsub-java",
+			"message_receiver":  "true",
+		})
+		emitEdge("Service", className, topicID, subscribesToEdgeKind, map[string]string{
+			"messaging_layer":  "google-cloud-pubsub-java",
+			"message_receiver": "true",
+		})
+	}
+}

--- a/internal/engine/pubsub_edges_test.go
+++ b/internal/engine/pubsub_edges_test.go
@@ -1,0 +1,384 @@
+// Tests for the Google Cloud Pub/Sub producer/consumer detection pass
+// added by #726 wave 3.
+//
+// Coverage per language:
+//   - Python: publish (resource path), subscribe (subscription path),
+//     create_subscription, topic_path, Eventarc trigger, Pub/Sub Lite
+//   - Node: topic.publish + pubsub.topic, subscription.on('message') + pubsub.subscription
+//   - Go: client.Topic + Publish, client.Subscription + Receive
+//   - Java: TopicName.of + publisher.publish, SubscriptionName.of + subscriber.startAsync,
+//     MessageReceiver implementation
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// runPubSubDetect is a lightweight in-process driver for the Pub/Sub pass.
+func runPubSubDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
+	t.Helper()
+	ents, rels := applyPubSubEdges(lang, path, []byte(src), nil, nil)
+	out := make([]entityResult, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	relOut := make([]relResult, 0, len(rels))
+	for _, r := range rels {
+		relOut = append(relOut, relResult{from: r.FromID, to: r.ToID, kind: r.Kind, props: r.Properties})
+	}
+	return out, relOut
+}
+
+// ---------------------------------------------------------------------------
+// Python — google-cloud-pubsub
+// ---------------------------------------------------------------------------
+
+// TestPubSub_Python_PublishResourcePath covers publisher.publish with a full
+// resource path projects/my-project/topics/my-topic.
+func TestPubSub_Python_PublishResourcePath(t *testing.T) {
+	src := `from google.cloud import pubsub_v1
+
+def send_event(data):
+    publisher = pubsub_v1.PublisherClient()
+    topic_path = "projects/my-project/topics/order-events"
+    publisher.publish(topic_path, data.encode())
+`
+	ents, rels := runPubSubDetect(t, "python", "publisher.py", src)
+	topicID := pubsubTopicID("my-project", "order-events")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for %s, ents=%v", topicID, ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if !strings.Contains(pubs[0].to, topicID) {
+		t.Fatalf("PUBLISHES_TO ToID = %q, want to contain %q", pubs[0].to, topicID)
+	}
+	if pubs[0].props["broker"] != "pubsub" {
+		t.Fatalf("broker = %q, want pubsub", pubs[0].props["broker"])
+	}
+}
+
+// TestPubSub_Python_TopicPath covers publisher.topic_path(project, topic)
+// emitting a topic entity without requiring a publish call.
+func TestPubSub_Python_TopicPath(t *testing.T) {
+	src := `from google.cloud import pubsub_v1
+
+publisher = pubsub_v1.PublisherClient()
+topic_path = publisher.topic_path('acme-project', 'payments-topic')
+`
+	ents, _ := runPubSubDetect(t, "python", "setup.py", src)
+	topicID := pubsubTopicID("acme-project", "payments-topic")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for %s, ents=%v", topicID, ents)
+	}
+	q := queueByName(ents, topicID)
+	if q.props["project"] != "acme-project" {
+		t.Fatalf("project = %q, want acme-project", q.props["project"])
+	}
+}
+
+// TestPubSub_Python_Subscribe covers subscriber.subscribe(subscription_path, callback).
+func TestPubSub_Python_Subscribe(t *testing.T) {
+	src := `from google.cloud import pubsub_v1
+
+def listen():
+    subscriber = pubsub_v1.SubscriberClient()
+    subscription_path = "projects/my-project/subscriptions/order-sub"
+    streaming_pull_future = subscriber.subscribe(subscription_path, callback=process_msg)
+`
+	ents, rels := runPubSubDetect(t, "python", "subscriber.py", src)
+	// The subscription path "projects/my-project/subscriptions/order-sub"
+	// yields a topic entity with project="my-project" and name="order-sub".
+	topicID := pubsubTopicID("my-project", "order-sub")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-sub (project=my-project), ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestPubSub_Python_CreateSubscription covers subscriber.create_subscription
+// emitting a topic entity without a direction edge.
+func TestPubSub_Python_CreateSubscription(t *testing.T) {
+	src := `from google.cloud import pubsub_v1
+
+subscriber = pubsub_v1.SubscriberClient()
+subscriber.create_subscription(
+    name="projects/my-proj/subscriptions/my-sub",
+    topic="projects/my-proj/topics/inventory-updates",
+)
+`
+	ents, rels := runPubSubDetect(t, "python", "create_sub.py", src)
+	topicID := pubsubTopicID("my-proj", "inventory-updates")
+	q := queueByName(ents, topicID)
+	if q == nil {
+		t.Fatalf("expected SCOPE.Queue for inventory-updates, ents=%v", ents)
+	}
+	if q.props["declared"] != "true" {
+		t.Fatalf("declared = %q, want true", q.props["declared"])
+	}
+	if len(relsByKind(rels, publishesToEdgeKind))+len(relsByKind(rels, subscribesToEdgeKind)) != 0 {
+		t.Fatalf("create_subscription should not emit direction edges, rels=%v", rels)
+	}
+}
+
+// TestPubSub_Python_EventarcTrigger covers Cloud Run / Eventarc trigger
+// handler detection as a Pub/Sub consumer.
+func TestPubSub_Python_EventarcTrigger(t *testing.T) {
+	src := `import functions_framework
+
+@functions_framework.cloud_event
+def hello_pubsub(cloud_event):
+    """Cloud Run function triggered by Pub/Sub via Eventarc."""
+    # event type: google.cloud.pubsub.topic.v1.messagePublished
+    data = cloud_event.data
+    process(data)
+`
+	ents, rels := runPubSubDetect(t, "python", "trigger.py", src)
+	if len(ents) == 0 {
+		t.Fatalf("expected at least one SCOPE.Queue entity, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge for Eventarc trigger, rels=%v", rels)
+	}
+	if subs[0].props["eventarc"] != "true" {
+		t.Fatalf("eventarc property = %q, want true", subs[0].props["eventarc"])
+	}
+}
+
+// TestPubSub_Python_PubSubLite covers PublisherClient usage (Pub/Sub Lite).
+func TestPubSub_Python_PubSubLite(t *testing.T) {
+	src := `from google.cloud.pubsublite.cloudpubsub import PublisherClient
+
+def publish_lite(topic_path):
+    with PublisherClient() as publisher:
+        publisher.publish("projects/my-proj/topics/lite-topic", b"data")
+`
+	ents, rels := runPubSubDetect(t, "python", "lite_pub.py", src)
+	if len(ents) == 0 {
+		t.Fatalf("expected SCOPE.Queue entity, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node — @google-cloud/pubsub
+// ---------------------------------------------------------------------------
+
+// TestPubSub_Node_TopicPublish covers pubsub.topic('name').publish(data).
+func TestPubSub_Node_TopicPublish(t *testing.T) {
+	src := `const { PubSub } = require('@google-cloud/pubsub');
+const pubsub = new PubSub();
+
+async function publishMessage(data) {
+  const topic = pubsub.topic('user-events');
+  await topic.publish(Buffer.from(data));
+}
+`
+	ents, rels := runPubSubDetect(t, "javascript", "pub.js", src)
+	topicID := pubsubTopicID("", "user-events")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for user-events, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestPubSub_Node_SubscriptionOnMessage covers pubsub.subscription + .on('message').
+func TestPubSub_Node_SubscriptionOnMessage(t *testing.T) {
+	src := `const { PubSub } = require('@google-cloud/pubsub');
+const pubsub = new PubSub();
+
+function listenForMessages() {
+  const subscription = pubsub.subscription('order-sub');
+  subscription.on('message', message => {
+    console.log(message.data);
+    message.ack();
+  });
+}
+`
+	ents, rels := runPubSubDetect(t, "javascript", "sub.js", src)
+	topicID := pubsubTopicID("", "order-sub")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-sub, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Go — cloud.google.com/go/pubsub
+// ---------------------------------------------------------------------------
+
+// TestPubSub_Go_TopicPublish covers client.Topic("name") + topic.Publish(ctx, ...).
+func TestPubSub_Go_TopicPublish(t *testing.T) {
+	src := `package publisher
+
+import (
+	"context"
+	"cloud.google.com/go/pubsub"
+)
+
+func PublishOrder(ctx context.Context, client *pubsub.Client, data []byte) {
+	t := client.Topic("order-created")
+	result := t.Publish(ctx, &pubsub.Message{Data: data})
+	_, _ = result.Get(ctx)
+}
+`
+	ents, rels := runPubSubDetect(t, "go", "publisher.go", src)
+	topicID := pubsubTopicID("", "order-created")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-created, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	if pubs[0].props["messaging_layer"] != "go-pubsub" {
+		t.Fatalf("messaging_layer = %q, want go-pubsub", pubs[0].props["messaging_layer"])
+	}
+}
+
+// TestPubSub_Go_SubscriptionReceive covers client.Subscription("name") + sub.Receive(ctx, ...).
+func TestPubSub_Go_SubscriptionReceive(t *testing.T) {
+	src := `package subscriber
+
+import (
+	"context"
+	"cloud.google.com/go/pubsub"
+)
+
+func ConsumeOrders(ctx context.Context, client *pubsub.Client) {
+	sub := client.Subscription("order-sub")
+	err := sub.Receive(ctx, func(ctx context.Context, msg *pubsub.Message) {
+		process(msg.Data)
+		msg.Ack()
+	})
+	_ = err
+}
+`
+	ents, rels := runPubSubDetect(t, "go", "subscriber.go", src)
+	topicID := pubsubTopicID("", "order-sub")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-sub, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java — google-cloud-pubsub
+// ---------------------------------------------------------------------------
+
+// TestPubSub_Java_PublisherPublish covers TopicName.of + publisher.publish.
+func TestPubSub_Java_PublisherPublish(t *testing.T) {
+	src := `import com.google.cloud.pubsub.v1.Publisher;
+import com.google.pubsub.v1.TopicName;
+
+public class OrderPublisher {
+    public void publish(String message) throws Exception {
+        TopicName topicName = TopicName.of("my-project", "order-topic");
+        Publisher publisher = Publisher.newBuilder(topicName).build();
+        PubsubMessage msg = PubsubMessage.newBuilder()
+            .setData(ByteString.copyFromUtf8(message))
+            .build();
+        publisher.publish(msg);
+    }
+}
+`
+	ents, rels := runPubSubDetect(t, "java", "OrderPublisher.java", src)
+	topicID := pubsubTopicID("my-project", "order-topic")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-topic, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestPubSub_Java_SubscriberStartAsync covers SubscriptionName.of + subscriber.startAsync.
+func TestPubSub_Java_SubscriberStartAsync(t *testing.T) {
+	src := `import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.pubsub.v1.SubscriptionName;
+
+public class OrderSubscriber {
+    public void subscribe() {
+        SubscriptionName subscriptionName = SubscriptionName.of("my-project", "order-sub");
+        Subscriber subscriber = Subscriber.newBuilder(subscriptionName, receiver).build();
+        subscriber.startAsync().awaitRunning();
+    }
+}
+`
+	ents, rels := runPubSubDetect(t, "java", "OrderSubscriber.java", src)
+	topicID := pubsubTopicID("my-project", "order-sub")
+	if queueByName(ents, topicID) == nil {
+		t.Fatalf("expected SCOPE.Queue for order-sub, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
+// TestPubSub_Java_MessageReceiver covers MessageReceiver interface implementation.
+func TestPubSub_Java_MessageReceiver(t *testing.T) {
+	src := `import com.google.cloud.pubsub.v1.MessageReceiver;
+
+public class PaymentProcessor implements MessageReceiver {
+    @Override
+    public void receiveMessage(PubsubMessage message, AckReplyConsumer consumer) {
+        processPayment(message.getData());
+        consumer.ack();
+    }
+}
+`
+	ents, rels := runPubSubDetect(t, "java", "PaymentProcessor.java", src)
+	if len(ents) == 0 {
+		t.Fatalf("expected at least one SCOPE.Queue entity, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge for MessageReceiver, rels=%v", rels)
+	}
+	if subs[0].props["message_receiver"] != "true" {
+		t.Fatalf("message_receiver = %q, want true", subs[0].props["message_receiver"])
+	}
+}
+
+// TestPubSub_NoBrokerSignal verifies that files without Pub/Sub imports
+// produce no output.
+func TestPubSub_NoBrokerSignal(t *testing.T) {
+	src := `def some_function():
+    result = requests.get("https://example.com/api/data")
+    return result.json()
+`
+	ents, rels := runPubSubDetect(t, "python", "http.py", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("no pubsub signal: expected empty, got ents=%v rels=%v", ents, rels)
+	}
+}
+
+// TestPubSub_UnsupportedLanguage verifies Rust is skipped gracefully.
+func TestPubSub_UnsupportedLanguage(t *testing.T) {
+	src := `fn publish(topic: &str) { /* pubsub publish */ }`
+	ents, rels := runPubSubDetect(t, "rust", "pub.rs", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("rust should be skipped, got ents=%v rels=%v", ents, rels)
+	}
+}


### PR DESCRIPTION
## Summary

- **\`internal/engine/pubsub_edges.go\`** — Google Cloud Pub/Sub detection pass: Python (google-cloud-pubsub + Pub/Sub Lite + Eventarc/Cloud Run triggers), Node (@google-cloud/pubsub), Go (cloud.google.com/go/pubsub), Java (TopicName.of + publisher.publish, SubscriptionName.of + subscriber.startAsync, MessageReceiver interface). ID format: \`pubsub:<project-or-X>:<topic-name>\`.
- **\`internal/engine/nats_edges.go\`** — NATS detection pass: Go (nats.go, JetStream, NATS Streaming/STAN), Node (nats.js, JetStream), Python (nats.py, JetStream), Java (nats.java, JetStream). Wildcard subjects (\`orders.*\`, \`inventory.>\`) accepted as-is. Tracks \`jetstream=true\`, \`nats_streaming=true\`, \`pattern=request_reply\`, \`queue_group\` properties.
- **\`internal/engine/detector.go\`** — Wire \`applyPubSubEdges\` + \`applyNATSEdges\` after \`applySQSEdges\`. Append-only, cannot regress bug-rate.

## Tests

| Protocol | Tests | Result |
|---|---|---|
| Pub/Sub | 15 | PASS |
| NATS | 20 | PASS |
| \`TestHarness_FixturesCorpus\` | — | PASS (bug_rate=5.79%, unchanged) |

### Pub/Sub coverage (15 tests)
- Python: PublishResourcePath, TopicPath, Subscribe, CreateSubscription, EventarcTrigger, PubSubLite
- Node: TopicPublish, SubscriptionOnMessage
- Go: TopicPublish, SubscriptionReceive
- Java: PublisherPublish, SubscriberStartAsync, MessageReceiver, NoBrokerSignal, UnsupportedLanguage

### NATS coverage (20 tests)
- Go: Publish, Subscribe, QueueSubscribe, Request (request_reply), JetStreamPublish, JetStreamSubscribe, NATSStreaming (STAN)
- Node: Publish, Subscribe, Request, JetStreamPublish
- Python: Publish, Subscribe, Request
- Java: Publish, Subscribe, DispatcherSubscribe, Request
- WildcardSubject (orders.*, inventory.>), NoBrokerSignal

## Cross-language parity
Confirmed unchanged — \`TestHarness_FixturesCorpus\` emits same disposition breakdown as pre-wave-3.

## Coexistence
File-disjoint with concurrent #728 (scheduled_jobs/webhooks_edges.go). The \`detector.go\` change is 2 new pass calls — rebase against #728 is trivial.

## Daemon cleanup
\`/tmp/arch-726-w3\` removed after test run.

## Wave 4 recommendation
1. **Amazon EventBridge** (\`events.put_events\` boto3, \`EventBridgeClient.putEvents\` Java/Node/Go) — high value for AWS-centric repos
2. **Azure Service Bus** (\`ServiceBusClient.send_messages\`, \`process_message\` handler) — .NET-heavy stacks
3. **Apache Pulsar** (\`producer.send\`, \`consumer.receive\`, Go/Java/Python clients) — growing in ML/streaming

🤖 Generated with [Claude Code](https://claude.com/claude-code)