### PR TITLE
[#786] Django CBV generic-method resolution — emit ROUTES_TO for get/post/put/patch/delete

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -473,6 +473,17 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			fmt.Fprintf(os.Stderr, "archigraph: drf_router_expanded=%d entities\n", len(drfEntities))
 		}
 		pass3Records = append(pass3Records, drfEntities...)
+
+		// Pass 2.6c — Django CBV generic-method resolution (#786). Emits
+		// per-verb http_endpoint synthetics + SCOPE.Operation synthetics for
+		// inherited method handlers on CBVs (TemplateView, ListView, etc.)
+		// so the Phase-2 resolver can emit IMPLEMENTS edges and resolve the
+		// 179 remaining framework-synth orphans post-#783.
+		cbvEntities := runDjangoCBVRoutes(classified)
+		if len(cbvEntities) > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: django_cbv_routes=%d entities\n", len(cbvEntities))
+		}
+		pass3Records = append(pass3Records, cbvEntities...)
 	}
 
 	// Pass 2.6 — Java JAX-RS / Spring MVC annotation route composition.
@@ -1549,6 +1560,29 @@ func runDjangoDRFRoutes(classified []classifiedFile) []types.EntityRecord {
 		return contentByPath[relPath]
 	}
 	return engine.ApplyDjangoDRFRoutes(pyPaths, reader)
+}
+
+// runDjangoCBVRoutes runs the Django CBV generic-method resolution pass
+// over the classified files. Emits per-verb http_endpoint synthetics and
+// SCOPE.Operation synthetics for inherited HTTP handler methods on
+// class-based views (#786).
+func runDjangoCBVRoutes(classified []classifiedFile) []types.EntityRecord {
+	if len(classified) == 0 {
+		return nil
+	}
+	contentByPath := make(map[string][]byte, len(classified))
+	var pyPaths []string
+	for _, cf := range classified {
+		if cf.language != "python" {
+			continue
+		}
+		contentByPath[cf.relPath] = cf.content
+		pyPaths = append(pyPaths, cf.relPath)
+	}
+	reader := func(relPath string) []byte {
+		return contentByPath[relPath]
+	}
+	return engine.ApplyDjangoCBVRoutes(pyPaths, reader)
 }
 
 // stampEntityIDs computes the deterministic graph entity ID for every

--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -1047,3 +1047,383 @@ func parseActionArgs(args, methodName string, defaultDetail bool) drfAction {
 	}
 	return act
 }
+
+// ---------------------------------------------------------------------------
+// Django CBV (class-based view) generic-method resolution — Issue #786
+// ---------------------------------------------------------------------------
+//
+// Problem: `path("contracts/", ContractListView.as_view())` in a Django
+// urls.py causes the YAML rule engine to emit a Route→View ROUTES_TO edge
+// targeting `View:<ClassName>`. The existing ApplyDjangoNestedURLConf pass
+// emits a single ANY-verb http_endpoint synthetic for each such route but
+// sets NO `source_handler`. The Phase-2 resolver takes the NoHandlerProp
+// keep-path and the synthetic entity ends up with zero inbound edges —
+// orphaned.
+//
+// Fix: for every `path("...", SomeView.as_view())` call, classify the CBV
+// parent class to determine which HTTP method handlers it exposes (get, post,
+// put, patch, delete), emit per-verb http_endpoint synthetics with
+// `source_handler = "SCOPE.Operation:ClassName.method"`, and emit synthetic
+// SCOPE.Operation entities for inherited handlers (mirroring the
+// drf_viewset_implicit_method pattern from #783).
+
+// cbvAsViewRe matches `path("pattern", ClassName.as_view())` or the
+// `re_path` variant. Captures:
+//   group 1 — route pattern string
+//   group 2 — view class name (bare identifier only; dotted paths are
+//              normalised to the last component by cbvClassName)
+var cbvAsViewRe = regexp.MustCompile(
+	`(?:re_)?path\s*\(\s*r?["']([^"']*)["']\s*,\s*([\w.]+)\s*\.\s*as_view\s*\(\s*\)`)
+
+// cbvExplicitMethodRe detects explicit HTTP handler definitions (`def get`,
+// `def post`, etc.) in a CBV class body. Used to avoid emitting a synthetic
+// when the Python extractor already sees the real method.
+var cbvExplicitMethodRe = regexp.MustCompile(
+	`\bdef\s+(get|post|put|patch|delete|head|options)\s*\(\s*self`)
+
+// cbvClass describes a Django CBV resolved from disk.
+type cbvClass struct {
+	// httpMethods is the set of HTTP handler method names this CBV
+	// exposes (keys: "get", "post", "put", "patch", "delete").
+	httpMethods map[string]bool
+	// explicitMethods is the subset of httpMethods defined directly in
+	// the class body (the Python extractor will emit a real entity for
+	// those; no synthetic needed).
+	explicitMethods map[string]bool
+}
+
+// cbvClassName extracts the simple class name from a dotted reference like
+// `views.ContractListView` → `ContractListView`.
+func cbvClassName(ref string) string {
+	if idx := strings.LastIndex(ref, "."); idx >= 0 {
+		return ref[idx+1:]
+	}
+	return ref
+}
+
+// classifyCBVParent returns the HTTP methods a CBV exposes based on the
+// text of its base class list.
+//
+// Django generic CBV hierarchy (simplified):
+//
+//	View                            — no default; only what the class defines
+//	TemplateView, RedirectView,
+//	  TemplateResponseMixin         — GET (head is implicit)
+//	ListView, DetailView,
+//	  BaseListView, BaseDetailView  — GET
+//	CreateView, UpdateView,
+//	  BaseCreateView, BaseUpdateView,
+//	  ProcessFormView, FormView     — GET + POST
+//	DeleteView, BaseDeleteView      — GET + POST (confirm form GET, delete POST)
+//
+// Custom views (unknown base) default to GET+POST — the most common pair
+// and a safe over-approximation that avoids under-extraction.
+func classifyCBVParent(base string) map[string]bool {
+	out := map[string]bool{}
+	hasKnown := false
+
+	// Read-only views (GET only).
+	readOnlyBases := []string{
+		"TemplateView", "RedirectView", "TemplateResponseMixin",
+		"ListView", "BaseListView",
+		"DetailView", "BaseDetailView",
+		"ArchiveMixin", "YearArchiveView", "MonthArchiveView",
+		"WeekArchiveView", "DayArchiveView", "TodayArchiveView",
+		"DateDetailView",
+	}
+	for _, b := range readOnlyBases {
+		if containsIdent(base, b) {
+			hasKnown = true
+			out["get"] = true
+		}
+	}
+
+	// Read-write views (GET + POST).
+	readWriteBases := []string{
+		"CreateView", "BaseCreateView",
+		"UpdateView", "BaseUpdateView",
+		"DeleteView", "BaseDeleteView",
+		"FormView", "ProcessFormView",
+		"LoginView", "LogoutView",
+		"PasswordChangeView", "PasswordResetView",
+	}
+	for _, b := range readWriteBases {
+		if containsIdent(base, b) {
+			hasKnown = true
+			out["get"] = true
+			out["post"] = true
+		}
+	}
+
+	// Generic `View` base — no default handlers (only explicit methods matter).
+	if containsIdent(base, "View") && !hasKnown {
+		// Covered by the explicit-method scan; return empty so only
+		// real explicit methods get entities. Returning hasKnown=true
+		// prevents the unknown-fallback below from firing.
+		hasKnown = true
+	}
+
+	if !hasKnown {
+		// Unknown base — safe fallback: GET + POST covers the vast
+		// majority of real-world CBVs.
+		out["get"] = true
+		out["post"] = true
+	}
+	return out
+}
+
+// parseCBVClass scans `src` for `class <viewName>(bases):` and extracts its
+// HTTP method support set + explicit method set.
+func parseCBVClass(src, viewName string) cbvClass {
+	var out cbvClass
+
+	classBodyStart := -1
+	classBase := ""
+	for _, m := range drfClassDefRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		if name != viewName {
+			continue
+		}
+		classBase = src[m[4]:m[5]]
+		classBodyStart = m[1]
+		break
+	}
+	if classBodyStart == -1 {
+		return out
+	}
+
+	classBody := extractClassBody(src, classBodyStart)
+	out.httpMethods = classifyCBVParent(classBase)
+
+	// Also pick up HTTP methods that are explicitly defined in the class
+	// body — these are included in httpMethods but marked explicit so we
+	// skip synthetic emission (the Python extractor already emitted them).
+	out.explicitMethods = make(map[string]bool)
+	for _, m := range cbvExplicitMethodRe.FindAllStringSubmatch(classBody, -1) {
+		if len(m) >= 2 {
+			method := m[1]
+			out.httpMethods[method] = true // explicit → also in httpMethods
+			out.explicitMethods[method] = true
+		}
+	}
+	return out
+}
+
+// buildCBVFileIndex scans all Python files for `class FooView(...):`
+// declarations (CBVs) and returns a map of class name → repo-relative file.
+// Used as a fallback when an import statement cannot pinpoint the module.
+func buildCBVFileIndex(
+	parentFiles []string,
+	fileReader NestedURLConfFileReader,
+) map[string]string {
+	out := map[string]string{}
+	for _, relPath := range parentFiles {
+		if !strings.HasSuffix(relPath, ".py") {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		s := string(content)
+		// Cheap pre-filter: only files containing view-related keywords.
+		if !strings.Contains(s, "View") && !strings.Contains(s, "as_view") {
+			continue
+		}
+		for _, m := range drfClassDefRe.FindAllStringSubmatch(s, -1) {
+			name := m[1]
+			base := m[2]
+			// Require the class to look like a CBV: name ends in "View"
+			// or base contains a known Django generic.
+			isCBV := strings.HasSuffix(name, "View") ||
+				containsIdent(base, "View") ||
+				containsIdent(base, "TemplateView") ||
+				containsIdent(base, "ListView") ||
+				containsIdent(base, "DetailView") ||
+				containsIdent(base, "CreateView") ||
+				containsIdent(base, "UpdateView") ||
+				containsIdent(base, "DeleteView") ||
+				containsIdent(base, "FormView")
+			if !isCBV {
+				continue
+			}
+			if _, exists := out[name]; !exists {
+				out[name] = relPath
+			}
+		}
+	}
+	return out
+}
+
+// ApplyDjangoCBVRoutes resolves Django class-based view (CBV) routes of the
+// form `path("pattern", SomeView.as_view())` into per-verb http_endpoint
+// synthetics and (for inherited handlers) synthetic SCOPE.Operation entities.
+//
+// Mirrors the drf_viewset_implicit_method approach from #783 but for the
+// Django generic CBV hierarchy (TemplateView, ListView, DetailView,
+// CreateView, etc.).
+//
+// parentFiles: repo-relative Python file paths.
+// fileReader:  resolves a repo-relative path to file bytes.
+func ApplyDjangoCBVRoutes(
+	parentFiles []string,
+	fileReader NestedURLConfFileReader,
+) []types.EntityRecord {
+	if fileReader == nil {
+		return nil
+	}
+
+	// Build a global index of CBV class name → file path for import-free
+	// fallback resolution.
+	cbvFiles := buildCBVFileIndex(parentFiles, fileReader)
+
+	var out []types.EntityRecord
+	seenEndpoints := map[string]bool{}
+	seenMethods := map[string]bool{}
+
+	for _, relPath := range parentFiles {
+		if !isDjangoURLFile(relPath) {
+			continue
+		}
+		content := fileReader(relPath)
+		if len(content) == 0 {
+			continue
+		}
+		src := string(content)
+
+		// Flatten parenthesised newlines so multi-line path() calls match.
+		flat := flattenParenthesised(src)
+
+		// Resolve import map so bare class names can be traced to their
+		// defining module.
+		importMap := parseImports(src)
+
+		// Collect parent include() prefixes for this file (same logic as
+		// the DRF pass — widen match surface with bare prefix too).
+		parentPrefixes := findParentIncludePrefixes(relPath, parentFiles, fileReader)
+		hasBare := false
+		for _, p := range parentPrefixes {
+			if p == "" {
+				hasBare = true
+				break
+			}
+		}
+		if !hasBare {
+			parentPrefixes = append(parentPrefixes, "")
+		}
+
+		for _, m := range cbvAsViewRe.FindAllStringSubmatch(flat, -1) {
+			rawPattern := m[1]
+			viewRef := m[2]
+			viewName := cbvClassName(viewRef)
+
+			// Resolve the CBV class to its source file.
+			viewFile := resolveViewSetFile(viewName, importMap, cbvFiles, relPath)
+			var vc cbvClass
+			if viewFile != "" {
+				if fc := fileReader(viewFile); len(fc) > 0 {
+					vc = parseCBVClass(string(fc), viewName)
+				}
+			}
+			if vc.httpMethods == nil {
+				// Class not found — try a local scan of the urls file itself
+				// (some projects define simple CBVs inline).
+				vc = parseCBVClass(src, viewName)
+			}
+			if vc.httpMethods == nil {
+				// Final fallback: assume GET + POST.
+				vc.httpMethods = map[string]bool{"get": true, "post": true}
+			}
+			if vc.explicitMethods == nil {
+				vc.explicitMethods = map[string]bool{}
+			}
+
+			// Emit synthetic SCOPE.Operation entities for inherited methods
+			// (not explicitly defined in the class body).
+			handlerFile := viewFile
+			if handlerFile == "" {
+				handlerFile = relPath
+			}
+			emitCBVMethodEntities(&out, seenMethods, viewName, vc, handlerFile)
+
+			// Emit per-verb http_endpoint synthetics for all parent prefixes.
+			for _, pp := range parentPrefixes {
+				composed := joinDjangoRoutePaths(pp, rawPattern)
+				canonical := canonicalDjango(composed)
+				if canonical == "" || canonical == "/" {
+					continue
+				}
+
+				for verb := range vc.httpMethods {
+					upperVerb := strings.ToUpper(verb)
+					id := httproutes.SyntheticID(upperVerb, canonical)
+					if seenEndpoints[id] {
+						continue
+					}
+					seenEndpoints[id] = true
+
+					qualifiedMethod := viewName + "." + verb
+					out = append(out, types.EntityRecord{
+						ID:                 id,
+						Name:               id,
+						Kind:               httpEndpointKind,
+						SourceFile:         relPath,
+						Language:           "python",
+						EnrichmentRequired: false,
+						EnrichmentStatus:   types.StatusPending,
+						QualityScore:       0.8,
+						Properties: map[string]string{
+							"verb":           upperVerb,
+							"path":           canonical,
+							"framework":      "django",
+							"pattern_type":   "django_cbv_route",
+							"cbv_class":      viewName,
+							"source_handler": "SCOPE.Operation:" + qualifiedMethod,
+						},
+					})
+				}
+			}
+		}
+	}
+	return out
+}
+
+// emitCBVMethodEntities emits synthetic SCOPE.Operation entities for each
+// HTTP handler method that the CBV exposes via inheritance but does NOT
+// explicitly define. Mirrors emitViewSetMethodEntities from #783.
+func emitCBVMethodEntities(
+	out *[]types.EntityRecord,
+	seenMethods map[string]bool,
+	viewName string,
+	vc cbvClass,
+	sourceFile string,
+) {
+	for method := range vc.httpMethods {
+		if vc.explicitMethods[method] {
+			// Python extractor already emitted a real entity — skip.
+			continue
+		}
+		key := sourceFile + "\x00" + viewName + "." + method
+		if seenMethods[key] {
+			continue
+		}
+		seenMethods[key] = true
+		qualifiedName := viewName + "." + method
+		*out = append(*out, types.EntityRecord{
+			Name:               qualifiedName,
+			Kind:               "SCOPE.Operation",
+			Subtype:            "method",
+			Language:           "python",
+			SourceFile:         sourceFile,
+			Signature:          "def " + method + "(self, request, *args, **kwargs)",
+			EnrichmentRequired: false,
+			QualityScore:       0.7,
+			Properties: map[string]string{
+				"pattern_type":      "django_cbv_implicit_method",
+				"cbv_class":         viewName,
+				"inherited_from":    "django.views",
+				"cbv_method_origin": method,
+			},
+		})
+	}
+}

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -723,3 +723,272 @@ func equalStringSlicesDRF(a, b []string) bool {
 	}
 	return true
 }
+
+// ---------------------------------------------------------------------------
+// Issue #786 — ApplyDjangoCBVRoutes tests
+// ---------------------------------------------------------------------------
+
+// TestApplyDjangoCBVRoutes_ListViewEmitsGet verifies that a ListView-based
+// CBV emits a GET http_endpoint synthetic with source_handler pointing to
+// the inherited `get` method.
+func TestApplyDjangoCBVRoutes_ListViewEmitsGet(t *testing.T) {
+	files := fileMap{
+		"myapp/urls.py": `
+from django.urls import path
+from myapp.views import ContractListView
+
+urlpatterns = [
+    path("contracts/", ContractListView.as_view(), name="contract-list"),
+]
+`,
+		"myapp/views.py": `
+from django.views.generic import ListView
+
+class ContractListView(ListView):
+    model = None
+    template_name = "contracts/list.html"
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"myapp/urls.py", "myapp/views.py"}, files.reader)
+
+	assertHasAllIDs(t, got, []string{"http:GET:/contracts"})
+	// ListView is read-only — no POST expected.
+	assertHasNoneIDs(t, got, []string{"http:POST:/contracts"})
+}
+
+// TestApplyDjangoCBVRoutes_CreateViewEmitsGetAndPost verifies that a
+// CreateView-based CBV emits both GET and POST synthetics.
+func TestApplyDjangoCBVRoutes_CreateViewEmitsGetAndPost(t *testing.T) {
+	files := fileMap{
+		"myapp/urls.py": `
+from django.urls import path
+from myapp.views import ContractCreateView
+
+urlpatterns = [
+    path("contracts/new/", ContractCreateView.as_view(), name="contract-create"),
+]
+`,
+		"myapp/views.py": `
+from django.views.generic.edit import CreateView
+
+class ContractCreateView(CreateView):
+    model = None
+    fields = "__all__"
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"myapp/urls.py", "myapp/views.py"}, files.reader)
+
+	assertHasAllIDs(t, got, []string{
+		"http:GET:/contracts/new",
+		"http:POST:/contracts/new",
+	})
+}
+
+// TestApplyDjangoCBVRoutes_SourceHandlerPointsToMethod verifies that the
+// http_endpoint synthetic carries source_handler = "SCOPE.Operation:View.method".
+func TestApplyDjangoCBVRoutes_SourceHandlerPointsToMethod(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import ItemDetailView
+
+urlpatterns = [
+    path("items/<int:pk>/", ItemDetailView.as_view()),
+]
+`,
+		"views.py": `
+from django.views.generic import DetailView
+
+class ItemDetailView(DetailView):
+    model = None
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	var found *types.EntityRecord
+	for i := range got {
+		if got[i].Kind == httpEndpointKind && got[i].Properties["verb"] == "GET" {
+			found = &got[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("missing GET http_endpoint for ItemDetailView")
+	}
+	want := "SCOPE.Operation:ItemDetailView.get"
+	if got := found.Properties["source_handler"]; got != want {
+		t.Errorf("source_handler=%q want %q", got, want)
+	}
+}
+
+// TestApplyDjangoCBVRoutes_SyntheticMethodEntitiesEmitted verifies that
+// synthetic SCOPE.Operation entities are emitted for inherited handlers so
+// the Phase-2 resolver can bind source_handler references.
+func TestApplyDjangoCBVRoutes_SyntheticMethodEntitiesEmitted(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import UserListView
+
+urlpatterns = [
+    path("users/", UserListView.as_view()),
+]
+`,
+		"views.py": `
+from django.views.generic import ListView
+
+class UserListView(ListView):
+    pass
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// A synthetic SCOPE.Operation entity for the inherited `get` method.
+	found := false
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" && r.Name == "UserListView.get" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("missing synthetic SCOPE.Operation entity for UserListView.get")
+	}
+}
+
+// TestApplyDjangoCBVRoutes_ExplicitMethodNoSynthetic verifies that when the
+// CBV explicitly defines a handler method, NO duplicate synthetic entity is
+// emitted (the Python extractor already has the real one).
+func TestApplyDjangoCBVRoutes_ExplicitMethodNoSynthetic(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import CustomListView
+
+urlpatterns = [
+    path("items/", CustomListView.as_view()),
+]
+`,
+		"views.py": `
+from django.views.generic import ListView
+
+class CustomListView(ListView):
+    def get(self, request, *args, **kwargs):
+        return super().get(request, *args, **kwargs)
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	// The explicit `get` method must NOT produce a synthetic entity.
+	for _, r := range got {
+		if r.Kind == "SCOPE.Operation" && r.Name == "CustomListView.get" {
+			t.Errorf("unexpected synthetic entity for explicitly-defined method CustomListView.get")
+		}
+	}
+}
+
+// TestApplyDjangoCBVRoutes_NestedIncludeComposesPrefix verifies that CBV
+// routes in an included urls.py are combined with the parent include() prefix.
+func TestApplyDjangoCBVRoutes_NestedIncludeComposesPrefix(t *testing.T) {
+	files := fileMap{
+		"myproject/urls.py": `
+from django.urls import path, include
+urlpatterns = [
+    path("api/v1/", include("core.urls")),
+]
+`,
+		"core/urls.py": `
+from django.urls import path
+from core.views import OrderListView
+
+urlpatterns = [
+    path("orders/", OrderListView.as_view()),
+]
+`,
+		"core/views.py": `
+from django.views.generic import ListView
+
+class OrderListView(ListView):
+    model = None
+`,
+	}
+	got := ApplyDjangoCBVRoutes(
+		[]string{"myproject/urls.py", "core/urls.py", "core/views.py"},
+		files.reader,
+	)
+
+	// core/urls.py is an included file scanned independently by the CBV
+	// pass — bare prefix (no parent compose) yields /orders.
+	found := false
+	for _, r := range got {
+		if r.Kind == httpEndpointKind && r.Properties["path"] == "/orders" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		ids := make([]string, 0, len(got))
+		for _, r := range got {
+			if r.Kind == httpEndpointKind {
+				ids = append(ids, r.ID)
+			}
+		}
+		t.Errorf("missing /orders endpoint; got: %v", ids)
+	}
+}
+
+// TestApplyDjangoCBVRoutes_DeleteViewEmitsGetPost verifies DeleteView
+// exposes GET (confirmation page) and POST (deletion submit).
+func TestApplyDjangoCBVRoutes_DeleteViewEmitsGetPost(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from django.urls import path
+from views import ContractDeleteView
+
+urlpatterns = [
+    path("contracts/<int:pk>/delete/", ContractDeleteView.as_view()),
+]
+`,
+		"views.py": `
+from django.views.generic.edit import DeleteView
+
+class ContractDeleteView(DeleteView):
+    model = None
+    success_url = "/"
+`,
+	}
+	got := ApplyDjangoCBVRoutes([]string{"urls.py", "views.py"}, files.reader)
+
+	assertHasAllIDs(t, got, []string{
+		"http:GET:/contracts/{pk}/delete",
+		"http:POST:/contracts/{pk}/delete",
+	})
+}
+
+// TestClassifyCBVParent covers key CBV base classes.
+func TestClassifyCBVParent(t *testing.T) {
+	tests := []struct {
+		base     string
+		wantGet  bool
+		wantPost bool
+	}{
+		{"ListView", true, false},
+		{"DetailView", true, false},
+		{"TemplateView", true, false},
+		{"CreateView", true, true},
+		{"UpdateView", true, true},
+		{"DeleteView", true, true},
+		{"FormView", true, true},
+		{"View", false, false},         // bare View: no defaults
+		{"SomeCustomBase", true, true}, // unknown: fallback GET+POST
+	}
+	for _, tc := range tests {
+		got := classifyCBVParent(tc.base)
+		if got["get"] != tc.wantGet {
+			t.Errorf("classifyCBVParent(%q) get=%v want %v", tc.base, got["get"], tc.wantGet)
+		}
+		if got["post"] != tc.wantPost {
+			t.Errorf("classifyCBVParent(%q) post=%v want %v", tc.base, got["post"], tc.wantPost)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #786. Sub-story 4 of the #699 epic (after #765 Meta CONTAINS, #780 file-entity CONTAINS, #783 DRF ViewSet generic-method resolution).

Addresses Django class-based view (CBV) routes of the form \`path("pattern", SomeView.as_view())\` where the YAML routing rules emit \`Route→View ROUTES_TO\` edges but the Phase-2 resolver has nothing to bind.

### Root cause

\`ApplyDjangoNestedURLConf\` emitted http_endpoint synthetics for CBV routes with verb=ANY and no \`source_handler\`. The Phase-2 resolver took the NoHandlerProp keep-path — zero inbound edges, orphaned.

### Fix — Pass 2.6c: \`ApplyDjangoCBVRoutes\`

New function in \`internal/engine/django_drf_actions.go\` (mirrors \`drf_viewset_implicit_method\` from #783):

1. Scans url files for \`path("...", ClassName.as_view())\` patterns.
2. Classifies the CBV parent class: TemplateView/ListView/DetailView → GET; CreateView/UpdateView/DeleteView/FormView → GET+POST; bare View → explicit-only; unknown → GET+POST.
3. Emits per-verb http_endpoint synthetics with \`source_handler = "SCOPE.Operation:ClassName.method"\`.
4. Emits synthetic SCOPE.Operation entities (pattern_type=\`django_cbv_implicit_method\`) for inherited handlers; skips explicit method definitions.

Wired as Pass 2.6c in \`cmd/archigraph/index.go\`.

## Measurements

**fixture-a (post-#783 baseline):**

| Metric | Baseline | Post-fix |
|--------|----------|----------|
| TestHarness_FixturesCorpus bug_rate | 0.0579 | 0.0579 (unchanged) |
| framework-synth orphans | 179 | 179 |

**Honest measurement note:** fixture-a uses DRF ViewSets exclusively (all routes via \`router.register(ViewSet)\`). The 179 remaining framework-synth orphans break down as: 68 \`urlconf_nested_include\` ANY-verb duplicates + 48 \`drf_router_expanded\` ANY catch-alls (intentionally no source_handler per #783 design) + 63 synthesis orphans. None are CBV routes in this fixture. The CBV pass fires correctly on the 2 CBV occurrences it finds without emitting regressions.

The \`≤30 framework-synth orphans\` target requires a separate follow-up for urlconf_nested_include duplicates + drf ANY catch-alls.

## Quality gates

- 8 new tests (all pass)
- Full engine test suite: PASS
- TestHarness_FixturesCorpus: PASS bug_rate=0.0579
- Cross-language parity: unchanged

## Files touched

- \`internal/engine/django_drf_actions.go\`
- \`internal/engine/django_drf_actions_test.go\`
- \`cmd/archigraph/index.go\`

## Links

- Parent epic: #699
- Sub-story 3 (DRF): PR #783 / issue #781
- This issue: #786