### PR TITLE
[#815] Add PR template + board-hygiene CI workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+<!-- Short description of what changed -->
+
+## Closes / Refs
+<!-- REQUIRED — use ONE of: -->
+- `Closes #<N>` — this PR fully resolves the issue (GitHub auto-closes on merge)
+- `Refs #<N>` — this PR contributes to but doesn't close the issue (e.g., one wave of a multi-wave feature)
+- `Closes-epic-on-merge-of-PR-#<X> #<N>` — this PR is part of an epic; explicit closure happens on PR #X
+- `board:exempt` label — for docs-only changes or one-off cleanups
+
+## Testing
+- [ ] All tests pass: `go test ./...`
+- [ ] Relevant fixtures verified
+- [ ] No regression in cross-language parity
+
+## Notes
+<!-- Optional reviewer notes -->

--- a/.github/workflows/board-hygiene.yml
+++ b/.github/workflows/board-hygiene.yml
@@ -1,0 +1,33 @@
+name: board-hygiene
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  closure-keyword:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check PR body has closure keyword
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const body = context.payload.pull_request.body || '';
+            const labels = context.payload.pull_request.labels.map(l => l.name);
+            if (labels.includes('board:exempt')) {
+              core.info('PR has board:exempt label, skipping closure-keyword check.');
+              return;
+            }
+            const closureRegex = /(?:closes|fixes|resolves)\s+#\d+/i;
+            const refsRegex = /refs\s+#\d+/i;
+            const epicRegex = /closes-epic-on-merge-of-pr-#\d+\s+#\d+/i;
+            const hasClosing = closureRegex.test(body) || refsRegex.test(body) || epicRegex.test(body);
+            if (!hasClosing) {
+              core.setFailed(
+                'PR body must include one of: `Closes #N`, `Fixes #N`, `Resolves #N`, ' +
+                '`Refs #N`, or `Closes-epic-on-merge-of-PR-#X #N`. ' +
+                'See issue #815 for the board-hygiene convention.\n' +
+                'Add the `board:exempt` label for one-off cleanups that legitimately don\'t map to an issue.'
+              );
+            } else {
+              core.info('PR body has a valid closure keyword.');
+            }

--- a/docs/board-hygiene.md
+++ b/docs/board-hygiene.md
@@ -1,0 +1,76 @@
+# Board hygiene
+
+Every PR must declare its relationship to issues. Pick ONE convention:
+
+## Single-issue PRs
+
+If the PR fully resolves an issue, use:
+
+```
+Closes #<N>
+```
+
+GitHub auto-closes the issue when the PR merges. Aliases: `Fixes #N`, `Resolves #N`.
+
+## Multi-wave features
+
+For features with multiple sub-PRs (e.g., HTTP FETCHES across multiple languages, landed as separate waves):
+
+- First through second-to-last waves: `Refs #N (wave X of N)`
+- Final wave: `Closes #N`
+
+The epic stays open until the last wave merges.
+
+Example: HTTP FETCHES epic (#721) was solved with multiple language implementations. Early PRs used `Refs #721 (wave 1 of 3)`, and the final PR used `Closes #721`.
+
+## Epic + sub-stories
+
+For epics with multiple independent sub-stories, create a sub-issue per sub-story and close those individually. The parent epic stays open until ALL sub-stories close.
+
+Example: An epic like "Graph visualization" might have sub-issues "UI mockups" (#793), "Frontend component" (#804), "Backend API" (#814). Each sub-issue's PR uses `Closes #<sub-issue>`, and the parent epic only closes when all sub-issues are complete.
+
+```
+Closes #793
+```
+
+This closes only the sub-issue; the parent epic remains open.
+
+## Exempt PRs
+
+For docs-only, formatting, or one-off cleanups that don't map to an issue, add the `board:exempt` label. CI skips the keyword check.
+
+Apply the label when:
+- You're fixing a typo in docs with no related issue
+- You're reformatting code for consistency without a spec
+- You're updating a README or workflow that isn't tied to a feature issue
+
+The label is managed via GitHub's UI: when you open a PR, add it to the PR's labels section.
+
+## Why this convention exists
+
+Board hygiene matters because:
+
+1. **Traceability**: Code changes should link to the issues they resolve. Without this, debugging and understanding the history of a change becomes harder.
+
+2. **Closure automation**: When you use `Closes #N`, GitHub automatically closes the issue on merge. Without the keyword, issues stay open indefinitely even though they're fixed.
+
+3. **Board hygiene**: A board cleanup sweep on 2026-05-20 found 18 merged PRs with no closure keyword, leaving their issues orphaned. Without process enforcement, this pattern recurs.
+
+## CI enforcement
+
+The `board-hygiene` workflow runs on every PR and checks that:
+
+- PR body contains one of: `Closes #N`, `Fixes #N`, `Resolves #N`, `Refs #N`, or `Closes-epic-on-merge-of-PR-#X #N`
+- OR the PR has the `board:exempt` label
+
+If neither condition is met, the workflow fails with a helpful message. Fix it by adding a closure keyword to the PR description, or add the `board:exempt` label if the PR legitimately doesn't map to an issue.
+
+## Agents
+
+When agents land PRs, they must:
+
+1. Include a closure keyword in the PR description
+2. OR add the `board:exempt` label
+3. Do not silence or ignore CI failures from the `board-hygiene` workflow
+
+This ensures the board stays clean and issues are properly closed.


### PR DESCRIPTION
## Summary
Implements issue #815 by adding a PR template, CI lint workflow, and documentation to enforce closure keywords on all PRs.

## What we did
- **PR template** (`.github/pull_request_template.md`): Instructs authors to use `Closes #N`, `Refs #N`, or `Closes-epic-on-merge-of-PR-#X #N`
- **CI workflow** (`.github/workflows/board-hygiene.yml`): Validates every PR has a closure keyword in the body; respects `board:exempt` label for docs-only changes
- **Documentation** (`docs/board-hygiene.md`): Explains single-issue, multi-wave, epic+sub-story, and exempt patterns with examples

## Testing
- actionlint validates workflow syntax (no errors)
- Files only touch `.github/` and `docs/` — no code changes
- Workflow uses only built-in github-script@v7

## Implementation notes
- Regex patterns cover: `Closes #N`, `Fixes #N`, `Resolves #N`, `Refs #N`, `Closes-epic-on-merge-of-PR-#X #N`
- board:exempt label allows override for legitimate one-off cleanups
- Label doesn't exist yet in repo; user will create manually or CI will fail closed for exempt PRs until label exists

## Board sweep context
Closes #815