### PR TITLE
[#803] Fix RSS budget display showing 0MB when actual is multi-GB

### DIFF
--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -104,7 +104,10 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 		reply.PendingAlgo = snap.PendingAlgo
 		reply.PendingLinks = snap.PendingLinks
 		reply.RSSBudgetMB = snap.BudgetMB
-		reply.RSSUsedMB = snap.UsedMB
+		// RSSUsedMB reports actual measured daemon RSS (in MB), not predicted
+		// sum of in-flight jobs. This ensures the budget display shows the
+		// real memory pressure (#803).
+		reply.RSSUsedMB = int64(reply.RSSBytes / (1024 * 1024))
 		reply.BlockedJobs = snap.BlockedJobs
 		for _, j := range snap.InFlight {
 			reply.IndexInFlight = append(reply.IndexInFlight, j.Path)

--- a/internal/daemon/service_test.go
+++ b/internal/daemon/service_test.go
@@ -1,0 +1,66 @@
+package daemon
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/daemon/sched"
+)
+
+// TestStatusRSSReportsActualMemory verifies that Status.RSSUsedMB
+// reports the actual daemon memory (in MB) from runtime.MemStats,
+// not just the sum of predicted in-flight job allocations (issue #803).
+func TestStatusRSSReportsActualMemory(t *testing.T) {
+	svc := newService(
+		func(proto.IndexArgs) (string, string, error) { return "", "", nil },
+		func(proto.RebuildArgs) ([]string, string, error) { return []string{}, "", nil },
+		func(proto.QualityAuditRequest) (proto.QualityAuditReply, error) { return proto.QualityAuditReply{}, nil },
+		"/tmp/test.sock",
+		make(chan struct{}),
+	)
+
+	// Attach a scheduler with a non-zero budget.
+	svc.scheduler = sched.New(sched.Config{
+		Workers:  2,
+		BudgetMB: 500,
+		Predict:  func(_ string) int64 { return 50 },
+	})
+
+	// Call Status to get the RPC reply.
+	var reply proto.StatusReply
+	if err := svc.Status(&proto.StatusArgs{}, &reply); err != nil {
+		t.Fatalf("Status RPC failed: %v", err)
+	}
+
+	// RSSBytes should be populated from runtime.MemStats.Sys.
+	if reply.RSSBytes == 0 {
+		t.Errorf("expected RSSBytes > 0 (actual daemon memory), got 0")
+	}
+
+	// RSSUsedMB should be the RSSBytes converted to MB.
+	expectedUsedMB := int64(reply.RSSBytes / (1024 * 1024))
+	if reply.RSSUsedMB != expectedUsedMB {
+		t.Errorf("RSSUsedMB: got %d, want %d (RSSBytes %d / 1MB)",
+			reply.RSSUsedMB, expectedUsedMB, reply.RSSBytes)
+	}
+
+	// RSSUsedMB should be non-zero when daemon has allocated heap.
+	if reply.RSSUsedMB <= 0 {
+		t.Errorf("expected RSSUsedMB > 0 (actual daemon memory), got %d", reply.RSSUsedMB)
+	}
+
+	// The difference between header RSS and budget display should be
+	// within ~10% tolerance. Verify that they're using the same source.
+	var ms runtime.MemStats
+	runtime.ReadMemStats(&ms)
+	headerMB := int64(ms.Sys / (1024 * 1024))
+	budgetMB := reply.RSSUsedMB
+	if headerMB > 0 {
+		pctDiff := float64(headerMB-budgetMB) / float64(headerMB) * 100
+		if pctDiff < -10 || pctDiff > 10 {
+			t.Logf("warning: header RSS (≈%dMB) differs from budget display (%dMB) by >10%%",
+				headerMB, budgetMB)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fix `archigraph status` showing `rss budget: used=0MB / 500MB` while actual daemon RSS is multi-GB.

## Closes / Refs

Closes #803

## Root cause

`Status` RPC handler in `internal/daemon/service.go:107` used `snap.UsedMB` (sum of predicted in-flight job allocations) for the budget display. When no jobs running → 0MB displayed, even though `runtime.MemStats.Sys` shows multi-GB.

## Fix

Single-line change: budget display now derives from `reply.RSSBytes` (the same `runtime.MemStats.Sys` value as the header line). Admission control continues to use predicted values (correct for conservative gating).

## Testing

- [x] New test `TestStatusRSSReportsActualMemory` verifies RSSUsedMB matches actual daemon memory
- [x] `TestHarness_FixturesCorpus` green
- [x] No regression in admission control behavior