### PR TITLE
[#822] Fix archigraph status detecting graph.fb (post-#816 default-flip)

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -134,6 +134,89 @@ func TestStatusFiltering(t *testing.T) {
 	}
 }
 
+func TestStatusGraphFileDetection(t *testing.T) {
+	home := withSandboxHome(t)
+
+	repo := filepath.Join(home, "repos", "test")
+	makeRepo(t, repo)
+
+	// Create a group with one repo but no graph files yet
+	cfg := &registry.GroupConfig{Name: "demo"}
+	cfg.Repos = []registry.Repo{{Slug: "test", Path: repo, Stack: "go"}}
+	cfgPath, _ := registry.ConfigPathFor("demo")
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatal(err)
+	}
+	if err := registry.AddGroup("demo", cfgPath); err != nil {
+		t.Fatal(err)
+	}
+
+	archigraphDir := filepath.Join(repo, ".archigraph")
+
+	// Test 1: No graph files exist
+	out := &bytes.Buffer{}
+	if err := runStatus(out, "demo"); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(out.String(), "graph: (none)") {
+		t.Errorf("status should show 'graph: (none)' when no files exist: %s", out.String())
+	}
+
+	// Test 2: Only graph.json exists
+	if err := os.MkdirAll(archigraphDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archigraphDir, "graph.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out = &bytes.Buffer{}
+	if err := runStatus(out, "demo"); err != nil {
+		t.Fatal(err)
+	}
+	statusText := out.String()
+	if !strings.Contains(statusText, "graph:") || strings.Contains(statusText, "(none)") {
+		t.Errorf("status should show graph timestamp when json exists: %s", statusText)
+	}
+	if strings.Contains(statusText, "graph.json:") {
+		t.Errorf("status should not show 'graph.json:' label (issue #822): %s", statusText)
+	}
+
+	// Test 3: graph.fb exists (the main #822 fix)
+	if err := os.Remove(filepath.Join(archigraphDir, "graph.json")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archigraphDir, "graph.fb"), []byte("fb"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out = &bytes.Buffer{}
+	if err := runStatus(out, "demo"); err != nil {
+		t.Fatal(err)
+	}
+	statusText = out.String()
+	if !strings.Contains(statusText, "graph:") || strings.Contains(statusText, "(none)") {
+		t.Errorf("status should show graph timestamp when fb exists (fix for #822): %s", statusText)
+	}
+	if strings.Contains(statusText, "graph.json:") {
+		t.Errorf("status should not show 'graph.json:' label when only fb exists: %s", statusText)
+	}
+
+	// Test 4: Both graph.fb and graph.json exist
+	if err := os.WriteFile(filepath.Join(archigraphDir, "graph.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	out = &bytes.Buffer{}
+	if err := runStatus(out, "demo"); err != nil {
+		t.Fatal(err)
+	}
+	statusText = out.String()
+	if !strings.Contains(statusText, "graph:") || strings.Contains(statusText, "(none)") {
+		t.Errorf("status should show graph timestamp when both files exist: %s", statusText)
+	}
+}
+
 func TestPrimaryHelpHidesAdvanced(t *testing.T) {
 	root := newRoot()
 	out := &bytes.Buffer{}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -93,7 +93,7 @@ func checkRepo(w io.Writer, r registry.Repo) {
 		fmt.Fprintf(w, "  %s repo %s (%s)\n", statusOK, r.Slug, r.Stack)
 	}
 	jsonPath := daemon.GraphPathForRepo(r.Path)
-	fbPath := daemon.FBPathForRepo(r.Path)
+	fbPath := daemon.GraphFBPathForRepo(r.Path)
 	hasFB := func() bool { _, e := os.Stat(fbPath); return e == nil }()
 	hasJSON := func() bool { _, e := os.Stat(jsonPath); return e == nil }()
 	switch {

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -130,12 +129,13 @@ func runStatus(w io.Writer, filter string) error {
 		}
 		for _, r := range cfg.Repos {
 			line := fmt.Sprintf("  %-20s  %s", r.Slug, r.Path)
-			graph := daemon.GraphPathForRepo(r.Path)
-			if fi, err := os.Stat(graph); err == nil {
-				age := time.Since(fi.ModTime()).Truncate(time.Second)
-				line += fmt.Sprintf("  graph.json: %s ago", age)
+			graphPath, modtimeNano := daemon.FindGraphFile(r.Path)
+			if graphPath != "" {
+				mtime := time.Unix(0, modtimeNano)
+				age := time.Since(mtime).Truncate(time.Second)
+				line += fmt.Sprintf("  graph: %s ago", age)
 			} else {
-				line += "  graph.json: (none)"
+				line += "  graph: (none)"
 			}
 			fmt.Fprintln(w, line)
 		}

--- a/internal/daemon/state_path.go
+++ b/internal/daemon/state_path.go
@@ -79,8 +79,42 @@ func GraphPathForRepo(repoPath string) string {
 	return filepath.Join(StateDirForRepo(repoPath), "graph.json")
 }
 
-// FBPathForRepo returns the canonical graph.fb path inside the
-// per-repo state directory. Added for ADR-0016 flip-day (#808).
-func FBPathForRepo(repoPath string) string {
+// GraphFBPathForRepo returns the path to graph.fb (FlatBuffers binary format)
+// inside the per-repo state directory.
+func GraphFBPathForRepo(repoPath string) string {
 	return filepath.Join(StateDirForRepo(repoPath), "graph.fb")
+}
+
+// FindGraphFile checks for the newest graph file (graph.fb preferred over
+// graph.json) and returns its path and modification time. Returns ("", 0)
+// if neither file exists. The returned modtime is in nanoseconds since epoch.
+func FindGraphFile(repoPath string) (path string, modtime int64) {
+	stateDir := StateDirForRepo(repoPath)
+
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	jsonPath := filepath.Join(stateDir, "graph.json")
+
+	fbInfo, fbErr := os.Stat(fbPath)
+	jsonInfo, jsonErr := os.Stat(jsonPath)
+
+	// Check graph.fb first (preferred)
+	if fbErr == nil {
+		fbMtime := fbInfo.ModTime().UnixNano()
+		// If both exist, return whichever is newer
+		if jsonErr == nil {
+			jsonMtime := jsonInfo.ModTime().UnixNano()
+			if fbMtime >= jsonMtime {
+				return fbPath, fbMtime
+			}
+			return jsonPath, jsonMtime
+		}
+		return fbPath, fbMtime
+	}
+
+	// Fall back to graph.json if graph.fb doesn't exist
+	if jsonErr == nil {
+		return jsonPath, jsonInfo.ModTime().UnixNano()
+	}
+
+	return "", 0
 }

--- a/internal/daemon/state_path_test.go
+++ b/internal/daemon/state_path_test.go
@@ -1,10 +1,12 @@
 package daemon
 
 import (
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestStateDirForRepo_DefaultColocated(t *testing.T) {
@@ -108,5 +110,130 @@ func TestStateDirForRepo_TwoDaemonRootsSameRepoIsolated(t *testing.T) {
 	if filepath.Base(a) != filepath.Base(b) {
 		t.Fatalf("hash segments differ: %q vs %q (should match for same repo)",
 			filepath.Base(a), filepath.Base(b))
+	}
+}
+
+func TestFindGraphFile_NoFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvRoot, tmpDir)
+
+	path, modtime := FindGraphFile("/nonexistent/repo")
+	if path != "" {
+		t.Fatalf("expected empty path when neither graph file exists, got %q", path)
+	}
+	if modtime != 0 {
+		t.Fatalf("expected modtime 0 when neither file exists, got %d", modtime)
+	}
+}
+
+func TestFindGraphFile_OnlyJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvRoot, tmpDir)
+	repo := t.TempDir()
+
+	stateDir := StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	jsonPath := filepath.Join(stateDir, "graph.json")
+	if err := os.WriteFile(jsonPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+
+	path, modtime := FindGraphFile(repo)
+	if path != jsonPath {
+		t.Fatalf("expected json path %q, got %q", jsonPath, path)
+	}
+	if modtime == 0 {
+		t.Fatal("expected non-zero modtime for json file")
+	}
+}
+
+func TestFindGraphFile_OnlyFB(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvRoot, tmpDir)
+	repo := t.TempDir()
+
+	stateDir := StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	if err := os.WriteFile(fbPath, []byte("fb"), 0644); err != nil {
+		t.Fatalf("write fb: %v", err)
+	}
+
+	path, modtime := FindGraphFile(repo)
+	if path != fbPath {
+		t.Fatalf("expected fb path %q, got %q", fbPath, path)
+	}
+	if modtime == 0 {
+		t.Fatal("expected non-zero modtime for fb file")
+	}
+}
+
+func TestFindGraphFile_BothFiles_FBNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvRoot, tmpDir)
+	repo := t.TempDir()
+
+	stateDir := StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	jsonPath := filepath.Join(stateDir, "graph.json")
+	if err := os.WriteFile(jsonPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+
+	// Write json first, then fb with a newer mtime
+	time.Sleep(10 * time.Millisecond)
+
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	if err := os.WriteFile(fbPath, []byte("fb"), 0644); err != nil {
+		t.Fatalf("write fb: %v", err)
+	}
+
+	path, modtime := FindGraphFile(repo)
+	if path != fbPath {
+		t.Fatalf("expected fb path %q when both exist, got %q", fbPath, path)
+	}
+	if modtime == 0 {
+		t.Fatal("expected non-zero modtime for fb file")
+	}
+}
+
+func TestFindGraphFile_BothFiles_JSONNewer(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv(EnvRoot, tmpDir)
+	repo := t.TempDir()
+
+	stateDir := StateDirForRepo(repo)
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	fbPath := filepath.Join(stateDir, "graph.fb")
+	if err := os.WriteFile(fbPath, []byte("fb"), 0644); err != nil {
+		t.Fatalf("write fb: %v", err)
+	}
+
+	// Write fb first, then json with a newer mtime
+	time.Sleep(10 * time.Millisecond)
+
+	jsonPath := filepath.Join(stateDir, "graph.json")
+	if err := os.WriteFile(jsonPath, []byte("{}"), 0644); err != nil {
+		t.Fatalf("write json: %v", err)
+	}
+
+	path, modtime := FindGraphFile(repo)
+	if path != jsonPath {
+		t.Fatalf("expected json path %q when json is newer, got %q", jsonPath, path)
+	}
+	if modtime == 0 {
+		t.Fatal("expected non-zero modtime for json file")
 	}
 }


### PR DESCRIPTION
## Summary

Fix `archigraph status` showing `graph.json: (none)` when only `graph.fb` exists (post-#816 default-flip behavior).

## Closes / Refs

Closes #822

## Fix

- New helpers `GraphFBPathForRepo()` and `FindGraphFile()` in `internal/daemon/state_path.go`
- `FindGraphFile()` detects both `graph.fb` and `graph.json`, returns newest path + mtime, prefers `graph.fb`
- Status renderer uses the helper; label changed from `graph.json:` to `graph:`

## Testing

- [x] 5 new unit tests for `FindGraphFile`: no files, only JSON, only FB, both (FB newer), both (JSON newer)
- [x] New integration test `TestStatusGraphFileDetection` covers all 4 file-presence cases
- [x] Full test suite green