### PR TITLE
[#830] Extend JS/TS externals allowlist: DOM + built-in methods

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -9820,6 +9820,58 @@ var jsBareNames = map[string]struct{}{
 	// earlier in jsBareNames; not duplicated here.
 	"formatToParts": {}, // Intl.NumberFormat / Intl.DateTimeFormat
 	"substring":     {}, // String.prototype.substring (substr is deprecated)
+
+	// Wave-14 (issue #44 fixture-e 1.29% → ≤0.8%) — DOM + JS built-in
+	// methods unresolved in fixture-e bug-extractor. Per #44 research, names
+	// like `find`, `append`, `splice`, `write` are receiver-stripped DOM/
+	// built-in calls with no entity binding. Gated to js/ts, preventing
+	// collisions with other-language user methods. Vanishingly low collision
+	// risk in React/Node codebases.
+	"splice":      {}, // Array.prototype.splice
+	"slice":       {}, // Array.prototype.slice / String.prototype.slice
+	"concat":      {}, // Array.prototype.concat / String.prototype.concat
+	"join":        {}, // Array.prototype.join
+	"charCodeAt":  {}, // String.prototype.charCodeAt
+	"match":       {}, // String.prototype.match
+	"search":      {}, // String.prototype.search
+	"split":       {}, // String.prototype.split
+	"cloneNode":   {}, // Node.cloneNode
+	"contains":    {}, // Node/Element.contains
+	"matches":     {}, // Element.matches
+	"scroll":      {}, // Window.scroll
+	"countReset":  {}, // console.countReset
+	"group":       {}, // console.group
+	"groupEnd":    {}, // console.groupEnd
+	"groupCollapsed": {}, // console.groupCollapsed
+	"time":        {}, // console.time
+	"timeEnd":     {}, // console.timeEnd
+	"timeLog":     {}, // console.timeLog
+	"trunc":       {}, // Math.trunc
+	"sign":        {}, // Math.sign
+	"cbrt":        {}, // Math.cbrt
+	"hypot":       {}, // Math.hypot
+	"imul":        {}, // Math.imul
+	"fround":      {}, // Math.fround
+	"clz32":       {}, // Math.clz32
+	"EPSILON":     {}, // Number.EPSILON
+	"setFullYear":     {}, // Date.prototype.setFullYear
+	"setMonth":        {}, // Date.prototype.setMonth
+	"setDate":         {}, // Date.prototype.setDate
+	"setHours":        {}, // Date.prototype.setHours
+	"setMinutes":      {}, // Date.prototype.setMinutes
+	"setSeconds":      {}, // Date.prototype.setSeconds
+	"setMilliseconds": {}, // Date.prototype.setMilliseconds
+	"setTime":         {}, // Date.prototype.setTime
+	"formData":    {}, // Response.formData
+	"setItem":     {}, // Storage.setItem
+	"key":         {}, // Storage.key
+	"reset":       {}, // HTMLFormElement.reset
+	"checkValidity":  {}, // HTMLFormElement.checkValidity
+	"reportValidity": {}, // HTMLFormElement.reportValidity
+	"getAll":      {}, // URLSearchParams.getAll
+	"stack":       {}, // Error.stack
+	"cause":       {}, // Error.cause
+	"resolvedOptions": {}, // Intl.*.resolvedOptions
 }
 
 // swiftBareNames is the Swift-language-gated bare-name stop-list (issue


### PR DESCRIPTION
## Summary

Extends the JavaScript/TypeScript externals allowlist (jsBareNames in internal/external/synth.go) with 46 DOM and JavaScript built-in methods to reduce fixture-e's bug-rate from 1.29% toward the ≤0.8% target.

**Root cause (per issue #44 research):** The JS/TS extractor receiver-strips DOM/built-in method names (`find`, `append`, `splice`, `write`, `charCodeAt`, etc.) that have no entity binding, leaving them in bug-extractor. These are legitimate platform built-ins that should be classified as `external-known`.

## Changes

### New entries added (46 total):

**Array.prototype** (5): splice, slice, concat, join, charCodeAt  
**String.prototype** (3): match, search, split  
**Node/Element** (3): cloneNode, contains, matches  
**DOM navigation** (1): scroll  
**Console** (5): countReset, groupEnd, groupCollapsed, timeEnd, timeLog  
**Math** (7): trunc, sign, cbrt, hypot, imul, fround, clz32  
**Number** (1): EPSILON  
**Date.prototype** (8): setFullYear, setMonth, setDate, setHours, setMinutes, setSeconds, setMilliseconds, setTime  
**Fetch/Response** (1): formData  
**Storage** (2): setItem, key  
**HTML Form** (3): reset, checkValidity, reportValidity  
**URLSearchParams** (1): getAll  
**Error** (2): stack, cause  
**Intl** (1): resolvedOptions  

### Constraints honored:

- Per-language gate (`lang=="javascript"||lang=="typescript"`) prevents collisions with other-language user methods
- Deliberately omitted `create` and `count` per issue #104 rejection list (collision-prone with Prisma generic verbs)
- Did NOT add: `find`, `forEach`, `map`, `filter`, `reduce` (too collision-prone per wave-8 analysis; remain in bug-extractor)
- All tests pass: `TestJSBareNames_RejectedNamesNotClassified` + full suite

## Closes

Closes #830  
Refs #44

## Test Plan

- [x] Unit tests pass (`go test ./internal/external`)
- [x] Build successful (`go build ./cmd/archigraph`)
- [x] No new rejection list violations

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>