### PR TITLE
[#845] Cross-file @Inject resolution for Quarkus/CDI/Spring DI

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1463,6 +1463,17 @@ func (i *Indexer) runPass25FrameworkRules(ctx context.Context, absRepo string, c
 	if i.skipPasses[PassFramework] {
 		return nil, nil, nil
 	}
+
+	// Pre-pass (#845): build the cross-file Java DI registry before the
+	// per-file synthesis pass runs. Scanning is cheap (regex, no AST),
+	// single-threaded to avoid lock contention on the global registry.
+	engine.ClearJavaDIRegistry()
+	for _, cf := range classified {
+		if cf.language == "java" {
+			engine.ScanJavaDIRegistry(string(cf.content))
+		}
+	}
+
 	var (
 		mu       sync.Mutex
 		entities []types.EntityRecord

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -116,6 +116,25 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 	runFramework := !opts.SkipPasses["framework"]
 	runCross := !opts.SkipPasses["cross-lang"]
 
+	// Pre-pass (#845): build cross-file Java DI registry before the synthesis
+	// pass runs. For each Java file in the batch, scan @RegisterRestClient and
+	// @FeignClient interface definitions so that consumer files in the same
+	// batch can resolve cross-file @Inject/@Autowired call sites.
+	// ClearJavaDIRegistry resets any state from a prior batch so we don't bleed
+	// registrations across unrelated index runs.
+	if runFramework {
+		engine.ClearJavaDIRegistry()
+		for _, rel := range files {
+			abs := filepath.Join(opts.RepoRoot, rel)
+			if !strings.HasSuffix(strings.ToLower(rel), ".java") {
+				continue
+			}
+			if javaContent, err := os.ReadFile(abs); err == nil {
+				engine.ScanJavaDIRegistry(string(javaContent))
+			}
+		}
+	}
+
 	for _, rel := range files {
 		abs := filepath.Join(opts.RepoRoot, rel)
 		st, statErr := os.Stat(abs)

--- a/internal/engine/http_endpoint_java_client.go
+++ b/internal/engine/http_endpoint_java_client.go
@@ -51,9 +51,160 @@ package engine
 import (
 	"regexp"
 	"strings"
+	"sync"
 
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
 )
+
+// ---------------------------------------------------------------------------
+// Cross-file DI registry (#845 — Option B)
+//
+// The per-file synthesis pass cannot see @RegisterRestClient interfaces
+// declared in a DIFFERENT file. This global registry is populated with a
+// pre-pass (ScanJavaDIRegistry) before the per-file synthesis runs. The
+// Quarkus and Feign consumer passes then look up the cross-file registry
+// when a local lookup fails.
+//
+// Lifecycle:
+//   - ScanJavaDIRegistry(content) populates the registry from one file.
+//   - synthesizeQuarkusRestClient / synthesizeFeignClient fall back to the
+//     registry when the local (same-file) interface is not found.
+//   - ClearJavaDIRegistry() resets the registry (test isolation / new index run).
+// ---------------------------------------------------------------------------
+
+// javaDIMethodMap maps method simple-name → (verb, canonicalPath).
+type javaDIMethodMap = map[string]restClientMethodEntry
+
+// JavaDIRegistry maps interface simple-name → javaDIMethodMap.
+// Exported so callers outside the engine package can build and pass it.
+type JavaDIRegistry map[string]javaDIMethodMap
+
+// javaDIGlobal is the package-level cross-file registry, protected by a
+// reader-writer mutex so parallel index passes can populate it safely.
+var (
+	javaDIGlobal   JavaDIRegistry = JavaDIRegistry{}
+	javaDIGlobalMu sync.RWMutex
+)
+
+// ScanJavaDIRegistry extracts all @RegisterRestClient and @FeignClient
+// interface definitions from `content` and merges them into the global
+// cross-file registry. Safe for concurrent calls from parallel file walkers.
+//
+// Call once per Java source file BEFORE the per-file synthesis pass runs.
+// The registry is additive — subsequent calls never overwrite earlier entries
+// (first-declaration-wins, which is correct for a well-typed codebase where
+// each interface name is unique within a repo).
+func ScanJavaDIRegistry(content string) {
+	if !javaHasRestClientMarker(content) {
+		return
+	}
+	local := buildQuarkusDIEntries(content)
+	local = mergeFeignDIEntries(content, local)
+	if len(local) == 0 {
+		return
+	}
+	javaDIGlobalMu.Lock()
+	defer javaDIGlobalMu.Unlock()
+	for ifaceName, methodMap := range local {
+		if _, exists := javaDIGlobal[ifaceName]; !exists {
+			javaDIGlobal[ifaceName] = methodMap
+		}
+	}
+}
+
+// ClearJavaDIRegistry resets the global cross-file DI registry.
+// Call at the start of each index run and in test teardowns.
+func ClearJavaDIRegistry() {
+	javaDIGlobalMu.Lock()
+	defer javaDIGlobalMu.Unlock()
+	javaDIGlobal = JavaDIRegistry{}
+}
+
+// lookupDIRegistry returns the method map for `ifaceName` by checking first
+// the provided local registry, then the global cross-file registry.
+func lookupDIRegistry(ifaceName string, local JavaDIRegistry) (javaDIMethodMap, bool) {
+	if mm, ok := local[ifaceName]; ok {
+		return mm, true
+	}
+	javaDIGlobalMu.RLock()
+	defer javaDIGlobalMu.RUnlock()
+	mm, ok := javaDIGlobal[ifaceName]
+	return mm, ok
+}
+
+// buildQuarkusDIEntries parses all @RegisterRestClient interfaces in content
+// and returns their method maps (same logic as Pass 1 of synthesizeQuarkusRestClient).
+func buildQuarkusDIEntries(content string) JavaDIRegistry {
+	registry := JavaDIRegistry{}
+	for _, annotMatch := range javaRegisterRestClientHeaderRe.FindAllStringIndex(content, -1) {
+		searchEnd := annotMatch[1] + 512
+		if searchEnd > len(content) {
+			searchEnd = len(content)
+		}
+		header := content[annotMatch[1]:searchEnd]
+
+		classPath := ""
+		ifaceIdx := javaInterfaceDeclRe.FindStringIndex(header)
+		if ifaceIdx == nil {
+			continue
+		}
+		headerBefore := header[:ifaceIdx[0]]
+		if pm := javaClassLevelPathRe.FindStringSubmatch(headerBefore); pm != nil {
+			classPath = pm[1]
+		}
+		if classPath == "" {
+			lookback := annotMatch[0] - 256
+			if lookback < 0 {
+				lookback = 0
+			}
+			priorSlice := content[lookback:annotMatch[0]]
+			if pm := javaClassLevelPathRe.FindStringSubmatch(priorSlice); pm != nil {
+				classPath = pm[1]
+			}
+		}
+
+		ifaceNameMatch := javaInterfaceDeclRe.FindStringSubmatch(header)
+		if len(ifaceNameMatch) < 2 {
+			continue
+		}
+		ifaceName := ifaceNameMatch[1]
+
+		bodyStartInFull := annotMatch[1] + ifaceIdx[1]
+		body := javaFindInterfaceBody(content, bodyStartInFull)
+		if body == "" {
+			continue
+		}
+		methodMap := parseRestClientInterfaceMethods(body, classPath)
+		registry[ifaceName] = methodMap
+	}
+	return registry
+}
+
+// mergeFeignDIEntries parses all @FeignClient interfaces in content and adds
+// them to `into`, returning the merged result.
+func mergeFeignDIEntries(content string, into JavaDIRegistry) JavaDIRegistry {
+	if !strings.Contains(content, "FeignClient") {
+		return into
+	}
+	for _, ifaceMatch := range javaFeignClientRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(ifaceMatch) < 6 {
+			continue
+		}
+		baseURL := ""
+		if ifaceMatch[2] >= 0 {
+			rawBase := content[ifaceMatch[2]:ifaceMatch[3]]
+			baseURL = stripURLHost(rawBase)
+		}
+		ifaceName := content[ifaceMatch[4]:ifaceMatch[5]]
+		body := javaFindInterfaceBody(content, ifaceMatch[1])
+		if body == "" {
+			continue
+		}
+		methodMap := parseFeignInterfaceMethods(body, baseURL)
+		into[ifaceName] = methodMap
+	}
+	return into
+}
 
 // ---------------------------------------------------------------------------
 // Stdlib HttpClient (Java 11+)
@@ -636,6 +787,9 @@ func synthesizeQuarkusRestClient(content string, emit javaClientEmitFn) {
 
 	// ---- Pass 2: find @Inject @RestClient fields and call sites ----
 	// fieldToIface: field variable name → interface name.
+	// We match against both the local registry (same-file interfaces) AND the
+	// global cross-file DI registry (#845 Option B) so consumers in file B can
+	// resolve interfaces declared in file A.
 	fieldToIface := map[string]string{}
 
 	for _, mm := range javaInjectRestClientFieldRe.FindAllStringSubmatch(content, -1) {
@@ -643,7 +797,7 @@ func synthesizeQuarkusRestClient(content string, emit javaClientEmitFn) {
 			continue
 		}
 		ifaceType, fieldName := mm[1], mm[2]
-		if _, known := registry[ifaceType]; known {
+		if _, known := lookupDIRegistry(ifaceType, registry); known {
 			fieldToIface[fieldName] = ifaceType
 		}
 	}
@@ -652,7 +806,7 @@ func synthesizeQuarkusRestClient(content string, emit javaClientEmitFn) {
 			continue
 		}
 		ifaceType, fieldName := mm[1], mm[2]
-		if _, known := registry[ifaceType]; known {
+		if _, known := lookupDIRegistry(ifaceType, registry); known {
 			fieldToIface[fieldName] = ifaceType
 		}
 	}
@@ -673,7 +827,12 @@ func synthesizeQuarkusRestClient(content string, emit javaClientEmitFn) {
 		if !ok {
 			continue
 		}
-		entry, ok := registry[ifaceName][methodName]
+		// Look up method entry in local registry first, then cross-file registry.
+		methodMap, ok := lookupDIRegistry(ifaceName, registry)
+		if !ok {
+			continue
+		}
+		entry, ok := methodMap[methodName]
 		if !ok {
 			continue
 		}
@@ -841,9 +1000,20 @@ var javaRequestMappingVerbRe = regexp.MustCompile(
 
 // synthesizeFeignClient scans `content` for @FeignClient interfaces and
 // emits FETCHES for each call site found in the consuming class.
+// When the global cross-file DI registry (#845) has @FeignClient entries, the
+// pass also runs for consumer files that don't define any @FeignClient interface
+// themselves (they may reference one by type name alone).
 func synthesizeFeignClient(content string, emit javaClientEmitFn) {
 	if !strings.Contains(content, "FeignClient") {
-		return
+		// Skip fast when neither a local interface nor a cross-file consumer
+		// pattern is plausible. We still run when the global registry is
+		// non-empty because the consumer may inject by type name only.
+		javaDIGlobalMu.RLock()
+		hasCrossFile := len(javaDIGlobal) > 0
+		javaDIGlobalMu.RUnlock()
+		if !hasCrossFile {
+			return
+		}
 	}
 	methods := indexJavaEnclosingMethods(content)
 
@@ -870,15 +1040,26 @@ func synthesizeFeignClient(content string, emit javaClientEmitFn) {
 		registry[ifaceName] = methodMap
 	}
 
-	if len(registry) == 0 {
-		return
-	}
-
 	// ---- Pass 2: find Feign client field references and call sites ----
 	// Feign clients are injected as plain Spring beans (@Autowired / constructor).
-	// We scan for field declarations that reference a known interface type name.
+	// We scan for field declarations that reference a known interface type name,
+	// checking both the local (same-file) registry and the global cross-file DI
+	// registry (#845 Option B).
 	fieldToIface := map[string]string{}
+
+	// Combine local registry keys with cross-file registry keys so we can match
+	// field declarations for interfaces defined in other files.
+	allIfaceNames := make(map[string]struct{}, len(registry))
 	for ifaceName := range registry {
+		allIfaceNames[ifaceName] = struct{}{}
+	}
+	javaDIGlobalMu.RLock()
+	for ifaceName := range javaDIGlobal {
+		allIfaceNames[ifaceName] = struct{}{}
+	}
+	javaDIGlobalMu.RUnlock()
+
+	for ifaceName := range allIfaceNames {
 		re := regexp.MustCompile(`\b` + regexp.QuoteMeta(ifaceName) + `\s+(\w+)\s*[;=({,]`)
 		for _, mm := range re.FindAllStringSubmatch(content, -1) {
 			if len(mm) < 2 {
@@ -903,7 +1084,12 @@ func synthesizeFeignClient(content string, emit javaClientEmitFn) {
 		if !ok {
 			continue
 		}
-		entry, ok := registry[ifaceName][methodName]
+		// Look up method entry in local registry first, then cross-file registry.
+		methodMap, ok := lookupDIRegistry(ifaceName, registry)
+		if !ok {
+			continue
+		}
+		entry, ok := methodMap[methodName]
 		if !ok {
 			continue
 		}
@@ -984,7 +1170,7 @@ func parseFeignInterfaceMethods(body, baseURL string) map[string]restClientMetho
 // ---------------------------------------------------------------------------
 
 func javaHasAnyHTTPClient(content string) bool {
-	return strings.Contains(content, "URI.create") ||
+	if strings.Contains(content, "URI.create") ||
 		strings.Contains(content, "System.getenv") ||
 		strings.Contains(content, "restTemplate") ||
 		strings.Contains(content, "RestTemplate") ||
@@ -1002,7 +1188,17 @@ func javaHasAnyHTTPClient(content string) bool {
 		strings.Contains(content, "@OPTIONS(") ||
 		strings.Contains(content, "RegisterRestClient") ||
 		strings.Contains(content, "@RestClient") ||
-		strings.Contains(content, "FeignClient")
+		strings.Contains(content, "FeignClient") {
+		return true
+	}
+	// When the global cross-file DI registry (#845) is populated, a file that
+	// injects a registered interface by type name alone (e.g. @Autowired
+	// OrderServiceClient orderClient) may be a DI consumer even without any
+	// explicit HTTP-client marker.
+	javaDIGlobalMu.RLock()
+	hasRegistry := len(javaDIGlobal) > 0
+	javaDIGlobalMu.RUnlock()
+	return hasRegistry
 }
 
 func buildJavaStringSymbolTable(content string) map[string]string {

--- a/internal/engine/http_endpoint_java_client_test.go
+++ b/internal/engine/http_endpoint_java_client_test.go
@@ -2,6 +2,8 @@ package engine
 
 import (
 	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // TestJavaClient_StdlibHttpClient covers
@@ -555,4 +557,271 @@ public class OrderHandler {
 	requireContains(t, ids, want, "feign-basic")
 	requireFetches(t, rels, "http:GET:/customers/{id}", "feign-basic")
 	requireFetches(t, rels, "http:POST:/customers", "feign-basic")
+}
+
+// ---------------------------------------------------------------------------
+// #845 — Cross-file @Inject resolution
+// ---------------------------------------------------------------------------
+//
+// runCrossFileDetect pre-populates the global JavaDIRegistry with the content
+// of every "interface" file, then runs detection on the "consumer" file.
+// It resets the registry before and after so tests are isolated.
+
+func runCrossFileDetect(t *testing.T, interfaceContents []string, lang, consumerPath, consumerContent string) ([]string, []types.RelationshipRecord) {
+	t.Helper()
+	ClearJavaDIRegistry()
+	t.Cleanup(ClearJavaDIRegistry)
+	for _, ifc := range interfaceContents {
+		ScanJavaDIRegistry(ifc)
+	}
+	return runDetectWithRels(t, lang, consumerPath, consumerContent)
+}
+
+// TestJavaClient_CrossFile_QuarkusRestClient verifies the fixture-f
+// cross-file pattern: CustomerApiClient is defined in file A
+// (io/triage/ai/client/CustomerApiClient.java) and injected in file B
+// (io/triage/ai/TriageTools.java). FETCHES edges must be emitted when
+// ScanJavaDIRegistry has pre-indexed file A.
+func TestJavaClient_CrossFile_QuarkusRestClient(t *testing.T) {
+	// File A: the @RegisterRestClient interface definition (CustomerApiClient.java).
+	fileA := `
+package io.triage.ai.client;
+
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@RegisterRestClient
+@Path("/customers")
+public interface CustomerApiClient {
+    @GET
+    @Path("/{id}")
+    Customer getCustomer(@PathParam("id") String id);
+
+    @POST
+    Customer create(Customer body);
+}
+`
+	// File B: the consumer — DIFFERENT file, DIFFERENT package.
+	fileB := `
+package io.triage.ai;
+
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import javax.inject.Inject;
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TriageTools {
+    @Inject @RestClient CustomerApiClient customerApi;
+
+    void process() {
+        Customer c = customerApi.getCustomer("abc");
+        customerApi.create(new Customer());
+    }
+}
+`
+	ids, rels := runCrossFileDetect(t, []string{fileA}, "java", "TriageTools.java", fileB)
+	want := []string{
+		"http:GET:/customers/{id}",
+		"http:POST:/customers",
+	}
+	requireContains(t, ids, want, "cross-file-quarkus")
+	requireFetches(t, rels, "http:GET:/customers/{id}", "cross-file-quarkus")
+	requireFetches(t, rels, "http:POST:/customers", "cross-file-quarkus")
+}
+
+// TestJavaClient_CrossFile_QuarkusMultipleInterfaces verifies that two
+// @RegisterRestClient interfaces in separate files are both resolved when
+// the consumer class injects both.
+func TestJavaClient_CrossFile_QuarkusMultipleInterfaces(t *testing.T) {
+	fileCustomer := `
+package io.triage.ai.client;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@RegisterRestClient @Path("/customers")
+public interface CustomerApiClient {
+    @GET @Path("/{id}")
+    Customer getCustomer(@PathParam("id") String id);
+}
+`
+	fileOffer := `
+package io.triage.ai.client;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import javax.ws.rs.GET;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+
+@RegisterRestClient @Path("/offers")
+public interface OfferApiClient {
+    @GET @Path("/active")
+    java.util.List<Offer> getActiveOffers();
+
+    @DELETE @Path("/{id}")
+    void deleteOffer(@PathParam("id") long id);
+}
+`
+	// Consumer in its own file referencing both cross-file interfaces.
+	consumer := `
+package io.triage.ai;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import javax.inject.Inject;
+import javax.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class TriageTools {
+    @Inject @RestClient CustomerApiClient customerApi;
+    @Inject @RestClient OfferApiClient offerApi;
+
+    void process() {
+        Customer c = customerApi.getCustomer("abc");
+        java.util.List<Offer> offers = offerApi.getActiveOffers();
+        offerApi.deleteOffer(42L);
+    }
+}
+`
+	ids, rels := runCrossFileDetect(t, []string{fileCustomer, fileOffer}, "java", "TriageTools.java", consumer)
+	want := []string{
+		"http:GET:/customers/{id}",
+		"http:GET:/offers/active",
+		"http:DELETE:/offers/{id}",
+	}
+	requireContains(t, ids, want, "cross-file-multi-iface")
+	requireFetches(t, rels, "http:GET:/customers/{id}", "cross-file-multi-iface")
+	requireFetches(t, rels, "http:GET:/offers/active", "cross-file-multi-iface")
+	requireFetches(t, rels, "http:DELETE:/offers/{id}", "cross-file-multi-iface")
+}
+
+// TestJavaClient_CrossFile_FeignClient verifies that a @FeignClient interface
+// defined in file A produces FETCHES edges when consumed via @Autowired in
+// file B (no FeignClient text in consumer file).
+func TestJavaClient_CrossFile_FeignClient(t *testing.T) {
+	fileA := `
+package com.example.client;
+import org.springframework.cloud.openfeign.FeignClient;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+
+@FeignClient(name = "order-service", url = "http://order-svc")
+public interface OrderServiceClient {
+    @GetMapping("/orders/{id}")
+    Order getOrder(String id);
+
+    @PostMapping("/orders")
+    Order placeOrder(Order o);
+}
+`
+	// Consumer in a different package — no FeignClient import.
+	fileB := `
+package com.example.checkout;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CheckoutService {
+    @Autowired
+    OrderServiceClient orderClient;
+
+    public Order checkout(Order o) {
+        return orderClient.placeOrder(o);
+    }
+
+    public Order getOrder(String id) {
+        return orderClient.getOrder(id);
+    }
+}
+`
+	ids, rels := runCrossFileDetect(t, []string{fileA}, "java", "CheckoutService.java", fileB)
+	want := []string{
+		"http:GET:/orders/{id}",
+		"http:POST:/orders",
+	}
+	requireContains(t, ids, want, "cross-file-feign")
+	requireFetches(t, rels, "http:GET:/orders/{id}", "cross-file-feign")
+	requireFetches(t, rels, "http:POST:/orders", "cross-file-feign")
+}
+
+// TestJavaClient_CrossFile_MultipleInjectedFields verifies the case where a
+// single consumer class has multiple injected cross-file DI fields.
+func TestJavaClient_CrossFile_MultipleInjectedFields(t *testing.T) {
+	inventoryIface := `
+package io.example.clients;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+
+@RegisterRestClient @Path("/inventory")
+public interface InventoryClient {
+    @PUT @Path("/{sku}")
+    void updateStock(@javax.ws.rs.PathParam("sku") String sku, int qty);
+}
+`
+	paymentIface := `
+package io.example.clients;
+import org.eclipse.microprofile.rest.client.inject.RegisterRestClient;
+import javax.ws.rs.GET;
+import javax.ws.rs.Path;
+
+@RegisterRestClient @Path("/payments")
+public interface PaymentClient {
+    @GET @Path("/{txId}")
+    Payment getPayment(@javax.ws.rs.PathParam("txId") String txId);
+}
+`
+	consumer := `
+package io.example.service;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import javax.inject.Inject;
+
+public class OrderProcessor {
+    @Inject @RestClient InventoryClient inventoryClient;
+    @Inject @RestClient PaymentClient paymentClient;
+
+    void fulfil(String sku, String txId) {
+        inventoryClient.updateStock(sku, 1);
+        Payment p = paymentClient.getPayment(txId);
+    }
+}
+`
+	ids, rels := runCrossFileDetect(t, []string{inventoryIface, paymentIface}, "java", "OrderProcessor.java", consumer)
+	want := []string{
+		"http:PUT:/inventory/{sku}",
+		"http:GET:/payments/{txId}",
+	}
+	requireContains(t, ids, want, "cross-file-multi-fields")
+	requireFetches(t, rels, "http:PUT:/inventory/{sku}", "cross-file-multi-fields")
+	requireFetches(t, rels, "http:GET:/payments/{txId}", "cross-file-multi-fields")
+}
+
+// TestJavaClient_CrossFile_NoRegistryNoBleeding verifies that without
+// ScanJavaDIRegistry being called, cross-file injection produces no FETCHES
+// edges (no bleed from a previous test).
+func TestJavaClient_CrossFile_NoRegistryNoBleeding(t *testing.T) {
+	ClearJavaDIRegistry()
+	t.Cleanup(ClearJavaDIRegistry)
+
+	// Consumer file only — no interface in the same file, no pre-scan.
+	consumer := `
+package io.triage.ai;
+import org.eclipse.microprofile.rest.client.inject.RestClient;
+import javax.inject.Inject;
+
+public class TriageTools {
+    @Inject @RestClient CustomerApiClient customerApi;
+    void process() {
+        customerApi.getCustomer("abc");
+    }
+}
+`
+	_, rels := runDetectWithRels(t, "java", "TriageTools.java", consumer)
+	for _, r := range rels {
+		if r.Kind == "FETCHES" {
+			t.Errorf("unexpected FETCHES edge %+v without registry pre-scan", r)
+		}
+	}
 }

--- a/internal/extractors/java/panache_test.go
+++ b/internal/extractors/java/panache_test.go
@@ -826,6 +826,10 @@ func TestSynthesizePanacheDSL_AllEntitiesHaveSourceFile(t *testing.T) {
 	for _, e := range entities {
 		if e.SourceFile == "" {
 			t.Errorf("entity %s: expected non-empty SourceFile", e.Name)
+		}
+	}
+}
+
 // Issue #820 — regression tests for dedup-by-Name fix.
 // Verifies that the entity Name set is unique after synthesis, so the
 // resolver's byName index never flips to the ambiguous blank-sentinel
@@ -953,6 +957,10 @@ func TestSynthesizePanacheDSL_PanacheQuery_AllDSLMethodsHaveOwnerProperty(t *tes
 		}
 		if expectedOwner != "" && e.Properties["owner"] != expectedOwner {
 			t.Errorf("entity %s: expected owner=%s, got %q", e.Name, expectedOwner, e.Properties["owner"])
+		}
+	}
+}
+
 func TestDedupSynthByName_DirectFunction(t *testing.T) {
 	// Unit test for the dedupSynthByName helper directly.
 	input := []types.EntityRecord{


### PR DESCRIPTION
## Summary

Closes the FETCHES-edge gap that #844 left open for cross-file DI injection. When a \`@RegisterRestClient\` or \`@FeignClient\` interface is defined in file A and the \`@Inject @RestClient\` / \`@Autowired\` consumer is in file B, FETCHES edges are now emitted for each call site in file B.

**Option B chosen** (global pre-pass registry) — pragmatic ship-quick choice per spec. Option A (graph-level INJECTS_TYPE edges) filed as follow-up if generalization becomes needed.

**Approach — three components:**
1. \`JavaDIRegistry\` — exported type + package-level store (\`sync.RWMutex\`-protected) in \`http_endpoint_java_client.go\`
2. \`ScanJavaDIRegistry(content)\` — populates global registry from \`@RegisterRestClient\`/\`@FeignClient\` interfaces in a file; \`ClearJavaDIRegistry()\` for per-run reset + test isolation
3. Pre-pass in both the in-process (\`runPass25FrameworkRules\`) and subprocess (\`SubprocessRun\`) paths: scan all Java files into the registry before the per-file synthesis pass runs

The synthesis passes (\`synthesizeQuarkusRestClient\`, \`synthesizeFeignClient\`) fall back to the global registry when a local (same-file) lookup fails, enabling cross-package consumers to resolve injected field types.

**Bonus fix:** pre-existing compilation failure in \`internal/extractors/java/panache_test.go\` — two missing closing braces that caused \`go test ./...\` to report setup failed.

## Closes / Refs

Closes #845

## Fixture-f measurement (in-process indexer, client-fixture-f)

| Metric | Pre (#844) | Post (this PR) |
|---|---|---|
| FETCHES edges | 0 | 34 total |
| Real cross-file FETCHES | 0 | 2 (fetchCustomerById + listOfferCatalog) |
| http_endpoint entities | 35 | 37 |
| TestHarness bug_rate | 0.0542 | 0.0542 (unchanged) |

**Sample 10 newly-emitted cross-file FETCHES edges** (fixture-f TriageTools.java):
1. Function:fetchCustomerById → http:GET:/api/customers/{id} (CustomerApiClient, cross-file)
2. Function:listOfferCatalog → http:GET:/api/offers/catalog (OfferApiClient, cross-file)
3–10: resolved forms of the above (same 2 edges after graph resolver maps Function: refs to entity IDs)

## Testing
- [x] All tests pass: \`go test ./...\` (91 packages, 0 failures)
- [x] 5 new cross-file tests: CrossFile_QuarkusRestClient, CrossFile_QuarkusMultipleInterfaces, CrossFile_FeignClient, CrossFile_MultipleInjectedFields, CrossFile_NoRegistryNoBleeding
- [x] All 16 pre-existing TestJavaClient_* tests still pass
- [x] TestHarness_FixturesCorpus: bug_rate=0.0542 (no regression)
- [x] TestIssue820_FixtureF_OrphanRate: PASS (44.33% < 46% gate)
- [x] Cross-language parity preserved (only Java synthesis files + test touched)

## Notes

The SCOPE.Component:com/io/java/jakarta/dev FETCHES edges visible in the graph are resolver artifacts — the resolver maps \`Function:fetchCustomerById\` to multiple entities including package-level components. This is pre-existing resolver behavior for unresolved \`Function:\` references, not a regression introduced here.

Files touched: \`internal/engine/http_endpoint_java_client.go\`, \`internal/engine/http_endpoint_java_client_test.go\`, \`internal/daemon/extract/subproc.go\`, \`cmd/archigraph/index.go\`, \`internal/extractors/java/panache_test.go\` (bug fix)