### PR TITLE
[#847] Response-shape extractor: walk DRF Serializer + Spring DTO classes

### DIFF
--- a/internal/engine/response_shape.go
+++ b/internal/engine/response_shape.go
@@ -40,14 +40,15 @@ import (
 // shape from scanning a single handler. Empty fields are not written to
 // the entity properties.
 type shape struct {
-	responseKeys    []string
-	responseSchema  map[string]string
-	errorKeys       []string
-	statusCodes     []int
-	requestKeys     []string
-	requestSchema   map[string]string
-	knownResponse   bool // true when at least one return was statically parsed
-	dynamicResponse bool // true when we saw a non-literal return value
+	responseKeys       []string
+	responseSchema     map[string]string
+	errorKeys          []string
+	statusCodes        []int
+	requestKeys        []string
+	requestSchema      map[string]string
+	knownResponse      bool   // true when at least one return was statically parsed
+	dynamicResponse    bool   // true when we saw a non-literal return value
+	responseKeysSource string // "drf_serializer" or "java_dto" when applicable
 }
 
 // applyResponseShapes scans the freshly-emitted http_endpoint entities and
@@ -143,6 +144,9 @@ func writeShapeProps(props map[string]string, sh shape) {
 		if s := marshalSchema(sh.requestSchema); s != "" {
 			props["request_schema"] = s
 		}
+	}
+	if sh.responseKeysSource != "" {
+		props["response_keys_source"] = sh.responseKeysSource
 	}
 }
 

--- a/internal/engine/response_shape_java.go
+++ b/internal/engine/response_shape_java.go
@@ -78,6 +78,7 @@ func extractJavaShape(src, handler, framework string) shape {
 				sh.responseKeys = append(sh.responseKeys, k)
 			}
 			sh.knownResponse = true
+			sh.responseKeysSource = "java_dto"
 		}
 	}
 
@@ -105,6 +106,7 @@ func extractJavaShape(src, handler, framework string) shape {
 						sh.responseKeys = append(sh.responseKeys, k)
 					}
 					sh.knownResponse = true
+					sh.responseKeysSource = "java_dto"
 				}
 			}
 		}
@@ -250,21 +252,44 @@ func splitJavaParams(params string) []string {
 // walkJavaClassFields locates `class X` or `record X(...)` in the source
 // and returns a map of field name -> type. Records have a different
 // shape — their components are declared in the parentheses.
+//
+// Enhanced to handle:
+// - Java records: `public record X(String id, String name)`
+// - Lombok @Value / @Data classes: all declared fields (any access modifier)
+// - @JsonProperty("alias") annotations: use the alias string as the key name
 var javaFieldRe = regexp.MustCompile(`(?m)^\s*(?:@\w+(?:\([^)]*\))?\s+)*(?:public|private|protected|static|final|\s)+\s*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
+
+// javaJsonPropertyRe captures the string value from @JsonProperty("fieldName").
+var javaJsonPropertyRe = regexp.MustCompile(`@JsonProperty\s*\(\s*["']?([A-Za-z_][\w-]*)["']?\s*\)`)
+
+// javaAnyFieldRe matches field declarations with any access modifier (or none),
+// used for Lombok classes where private fields are the serialized shape.
+// The modifier group is optional so package-private and Lombok @Value fields
+// without explicit modifiers are also matched.
+var javaAnyFieldRe = regexp.MustCompile(`(?m)^\s*((?:@\w+(?:\([^)]*\))?\s+)*)(?:(?:public|private|protected|static|final|transient|volatile)\s+)*([A-Za-z_][\w<>,.\[\]]*?)\s+([a-zA-Z_]\w*)\s*[;=]`)
 
 func walkJavaClassFields(src, name string) map[string]string {
 	// Record form first: `record X(Type a, Type b)`.
-	rec := regexp.MustCompile(`(?m)^(?:public\s+|private\s+|protected\s+)?record\s+` + regexp.QuoteMeta(name) + `\s*\(([^)]*)\)`)
-	if m := rec.FindStringSubmatch(src); len(m) >= 2 {
-		out := map[string]string{}
-		for _, p := range splitJavaParams(m[1]) {
-			parts := strings.Fields(strings.TrimSpace(p))
-			if len(parts) >= 2 {
-				out[parts[len(parts)-1]] = parts[len(parts)-2]
+	// Handle multi-line records by finding the opening paren and matching bracket.
+	recHeaderRe := regexp.MustCompile(`(?m)^(?:public\s+|private\s+|protected\s+)?record\s+` + regexp.QuoteMeta(name) + `\s*\(`)
+	if loc := recHeaderRe.FindStringIndex(src); loc != nil {
+		parenStart := loc[1] - 1
+		parenEnd := findMatchingBracket(src, parenStart)
+		if parenEnd > parenStart {
+			params := src[parenStart+1 : parenEnd]
+			out := map[string]string{}
+			for _, p := range splitJavaParams(params) {
+				// Strip leading annotations from each record component.
+				p = strings.TrimSpace(p)
+				p = regexp.MustCompile(`^(?:@\w+(?:\([^)]*\))?\s+)*`).ReplaceAllString(p, "")
+				parts := strings.Fields(strings.TrimSpace(p))
+				if len(parts) >= 2 {
+					out[parts[len(parts)-1]] = parts[len(parts)-2]
+				}
 			}
-		}
-		if len(out) > 0 {
-			return out
+			if len(out) > 0 {
+				return out
+			}
 		}
 	}
 	// Class / interface form.
@@ -273,6 +298,15 @@ func walkJavaClassFields(src, name string) map[string]string {
 	if loc == nil {
 		return nil
 	}
+	// Detect Lombok @Value or @Data annotation in the 200-char window before the class keyword.
+	preClass := ""
+	if loc[0] > 200 {
+		preClass = src[loc[0]-200 : loc[0]]
+	} else {
+		preClass = src[:loc[0]]
+	}
+	isLombok := strings.Contains(preClass, "@Value") || strings.Contains(preClass, "@Data")
+
 	braceIdx := loc[1] - 1
 	end := findMatchingBracket(src, braceIdx)
 	if end < 0 {
@@ -280,16 +314,56 @@ func walkJavaClassFields(src, name string) map[string]string {
 	}
 	body := src[braceIdx+1 : end]
 	out := map[string]string{}
-	for _, m := range javaFieldRe.FindAllStringSubmatch(body, -1) {
-		fname := m[2]
-		ftype := m[1]
-		// Skip obvious non-field declarations: method bodies start with `(`.
-		// Also skip if the "type" looks like a method-return that wasn't
-		// followed by `;` or `=` — defensive.
+
+	if isLombok {
+		// For Lombok classes, walk all declared fields regardless of access modifier.
+		// Use javaAnyFieldRe which accepts any access combination.
+		for _, m := range javaAnyFieldRe.FindAllStringSubmatch(body, -1) {
+			annotations := m[1]
+			ftype := m[2]
+			fname := m[3]
+			if strings.Contains(ftype, "(") {
+				continue
+			}
+			// Check for @JsonProperty alias.
+			if jp := javaJsonPropertyRe.FindStringSubmatch(annotations); len(jp) >= 2 {
+				fname = jp[1]
+			}
+			out[fname] = strings.TrimSpace(ftype)
+		}
+		return out
+	}
+
+	// Plain class: walk public/package-visible fields and @JsonProperty-annotated fields.
+	for _, m := range javaAnyFieldRe.FindAllStringSubmatch(body, -1) {
+		annotations := m[1]
+		ftype := m[2]
+		fname := m[3]
 		if strings.Contains(ftype, "(") {
 			continue
 		}
-		out[fname] = strings.TrimSpace(ftype)
+		// @JsonProperty-annotated field → include regardless of access modifier.
+		if jp := javaJsonPropertyRe.FindStringSubmatch(annotations); len(jp) >= 2 {
+			out[jp[1]] = strings.TrimSpace(ftype)
+			continue
+		}
+		// Public fields are always included.
+		fieldLine := m[0]
+		if strings.Contains(fieldLine, "public") {
+			out[fname] = strings.TrimSpace(ftype)
+		}
+	}
+	// If nothing was found with the new logic, fall back to the original field regex
+	// (for plain public-field DTOs without @JsonProperty).
+	if len(out) == 0 {
+		for _, m := range javaFieldRe.FindAllStringSubmatch(body, -1) {
+			fname := m[2]
+			ftype := m[1]
+			if strings.Contains(ftype, "(") {
+				continue
+			}
+			out[fname] = strings.TrimSpace(ftype)
+		}
 	}
 	return out
 }

--- a/internal/engine/response_shape_python.go
+++ b/internal/engine/response_shape_python.go
@@ -158,13 +158,26 @@ func extractPythonShape(src, handler, framework string) shape {
 		if expr == "" || expr == "None" {
 			continue
 		}
-		parsePyReturn(src, expr, &sh)
+		parsePyReturn(src, body, expr, &sh)
+	}
+	// If we still have only dynamicResponse (e.g. `return serializer.data`
+	// resolved via self.get_serializer()), try the class-level serializer_class
+	// as a last resort.
+	if sh.dynamicResponse && !sh.knownResponse {
+		if keys := drfResolveAndWalk(src, "", body); len(keys) > 0 {
+			sh.responseKeys = append(sh.responseKeys, keys...)
+			sh.knownResponse = true
+			sh.dynamicResponse = false
+			sh.responseKeysSource = "drf_serializer"
+		}
 	}
 	return sh
 }
 
 // parsePyReturn inspects a single `return <expr>` and updates `sh` in place.
-func parsePyReturn(src, expr string, sh *shape) {
+// `handlerBody` is the text of the enclosing function body, used for DRF
+// local-variable resolution.
+func parsePyReturn(src, handlerBody, expr string, sh *shape) {
 	// Strip a trailing comment.
 	if i := strings.Index(expr, " #"); i >= 0 {
 		expr = strings.TrimSpace(expr[:i])
@@ -190,7 +203,7 @@ func parsePyReturn(src, expr string, sh *shape) {
 			if parenIdx >= 0 {
 				args := extractArgList(expr, idx+parenIdx)
 				if len(args) > 0 {
-					applyPyReturnArg(src, args[0], status, sh)
+					applyPyReturnArg(src, handlerBody, args[0], status, sh)
 					recordStatus(sh, status, looksLikeError(args[0]))
 					return
 				}
@@ -210,7 +223,7 @@ func parsePyReturn(src, expr string, sh *shape) {
 					status = n
 				}
 			}
-			applyPyReturnArg(src, dict, status, sh)
+			applyPyReturnArg(src, handlerBody, dict, status, sh)
 			recordStatus(sh, status, false)
 			return
 		}
@@ -230,9 +243,27 @@ func parsePyReturn(src, expr string, sh *shape) {
 			return
 		}
 	}
-	// `return serializer.data` — known DRF idiom; we cannot resolve the
-	// serializer from the local return alone, but mark known-dynamic.
+	// `return serializer.data` / `return Response(serializer.data)` —
+	// DRF idiom: try to resolve the serializer class and walk its fields.
 	if strings.Contains(expr, ".data") || strings.Contains(expr, ".to_dict()") {
+		// Extract the variable name before ".data" (e.g. "serializer" from "serializer.data").
+		if dotIdx := strings.Index(expr, ".data"); dotIdx > 0 {
+			varName := strings.TrimSpace(expr[:dotIdx])
+			// Strip any wrapper: Response(serializer.data) → varName stays "serializer"
+			if parenIdx := strings.LastIndexAny(varName, "("); parenIdx >= 0 {
+				varName = strings.TrimSpace(varName[parenIdx+1:])
+			}
+			if varName != "" && varName != "self" {
+				if keys := drfResolveAndWalk(src, varName, handlerBody); len(keys) > 0 {
+					for _, k := range keys {
+						sh.responseKeys = append(sh.responseKeys, k)
+					}
+					sh.knownResponse = true
+					sh.responseKeysSource = "drf_serializer"
+					return
+				}
+			}
+		}
 		sh.dynamicResponse = true
 		return
 	}
@@ -241,8 +272,9 @@ func parsePyReturn(src, expr string, sh *shape) {
 }
 
 // applyPyReturnArg merges a single argument (typically the body literal
-// passed to Response(...)) into `sh`.
-func applyPyReturnArg(src, arg string, status int, sh *shape) {
+// passed to Response(...)) into `sh`. `handlerBody` is passed for DRF
+// serializer resolution when the arg is `serializer.data`.
+func applyPyReturnArg(src, handlerBody, arg string, status int, sh *shape) {
 	keys := extractDictKeys(arg)
 	if len(keys) > 0 {
 		sh.knownResponse = true
@@ -251,6 +283,22 @@ func applyPyReturnArg(src, arg string, status int, sh *shape) {
 		} else {
 			sh.responseKeys = append(sh.responseKeys, keys...)
 		}
+		return
+	}
+	// `Response(serializer.data)` — DRF pattern: the arg is `serializer.data`.
+	if strings.Contains(arg, ".data") {
+		if dotIdx := strings.Index(arg, ".data"); dotIdx > 0 {
+			varName := strings.TrimSpace(arg[:dotIdx])
+			if varName != "" && varName != "self" {
+				if drfKeys := drfResolveAndWalk(src, varName, handlerBody); len(drfKeys) > 0 {
+					sh.responseKeys = append(sh.responseKeys, drfKeys...)
+					sh.knownResponse = true
+					sh.responseKeysSource = "drf_serializer"
+					return
+				}
+			}
+		}
+		sh.dynamicResponse = true
 		return
 	}
 	// `return SomeModel(...)` inside a wrapper, e.g. Response(SomeModel(...)).
@@ -376,6 +424,187 @@ func walkPyClassFields(src, name string) map[string]string {
 		out[fname] = ftype
 	}
 	return out
+}
+
+// ---------------------------------------------------------------------------
+// DRF Serializer walking
+// ---------------------------------------------------------------------------
+
+// drfSerializerFieldRe matches class-attribute serializer field assignments:
+//
+//	field_name = serializers.CharField(...)
+//	field_name = serializers.IntegerField(read_only=True)
+//	nested_field = NestedSerializer()
+//	nested_field = NestedSerializer(many=True)
+var drfSerializerFieldRe = regexp.MustCompile(`(?m)^[ \t]+([a-zA-Z_]\w*)\s*=\s*(?:serializers\.\w+|[A-Z][A-Za-z0-9_]*Serializer|[A-Z][A-Za-z0-9_]*)\s*\(`)
+
+// drfMetaFieldsListRe captures `fields = ['id', 'name']` or `fields = ("id", "name")` in a Meta class.
+var drfMetaFieldsListRe = regexp.MustCompile(`(?m)fields\s*=\s*[\[\(](.*?)[\]\)]`)
+
+// drfLocalVarTypeRe matches `varname = SomeSerializer(...)` to track local variable types.
+var drfLocalVarTypeRe = regexp.MustCompile(`(?m)[ \t]+([a-zA-Z_]\w*)\s*=\s*([A-Z][A-Za-z0-9_]*)\s*\(`)
+
+// drfSerializerClassRe matches `varname = self.get_serializer(...)` or `varname = self.serializer_class(...)`.
+var drfGetSerializerRe = regexp.MustCompile(`(?m)[ \t]+([a-zA-Z_]\w*)\s*=\s*self\.(?:get_serializer|serializer_class)\s*\(`)
+
+// drfClassSerializerClassRe finds `serializer_class = SomeSerializer` as a class-level attribute.
+var drfClassSerializerClassRe = regexp.MustCompile(`(?m)[ \t]+serializer_class\s*=\s*([A-Z][A-Za-z0-9_]*)`)
+
+// drfResolveAndWalk resolves a DRF serializer variable/class to its field names.
+// `varName` is the local variable name (e.g. "serializer"), `handlerBody` is the
+// method body text. Falls back to class-level `serializer_class` in the full source.
+// Returns nil when resolution fails.
+func drfResolveAndWalk(src, varName, handlerBody string) []string {
+	// 1. Look for local var assignment: `varName = SomeSerializer(...)`
+	varRe := regexp.MustCompile(`(?m)[ \t]+` + regexp.QuoteMeta(varName) + `\s*=\s*([A-Z][A-Za-z0-9_]*)\s*\(`)
+	if m := varRe.FindStringSubmatch(src); len(m) >= 2 {
+		if keys := walkDRFSerializer(src, m[1]); len(keys) > 0 {
+			return keys
+		}
+	}
+	// 2. Look for `self.get_serializer(...)` or `self.serializer_class(...)`
+	//    in the handler body — resolve via class-level serializer_class.
+	if m := drfGetSerializerRe.FindStringSubmatch(handlerBody + src); len(m) >= 2 {
+		// Ignore the variable name matched — just resolve via class attribute.
+		if m2 := drfClassSerializerClassRe.FindStringSubmatch(src); len(m2) >= 2 {
+			if keys := walkDRFSerializer(src, m2[1]); len(keys) > 0 {
+				return keys
+			}
+		}
+	}
+	// 3. Class-level serializer_class attribute.
+	if m := drfClassSerializerClassRe.FindStringSubmatch(src); len(m) >= 2 {
+		if keys := walkDRFSerializer(src, m[1]); len(keys) > 0 {
+			return keys
+		}
+	}
+	return nil
+}
+
+// walkDRFSerializer walks a DRF Serializer class by name and returns its field names.
+// Handles:
+// - Plain Serializer: field attrs like `name = serializers.CharField(...)`
+// - ModelSerializer with `Meta.fields = [...]`: reads the list
+// - Nested serializers: `nested = NestedSerializer()` → adds "nested" as a key
+func walkDRFSerializer(src, name string) []string {
+	// Find the class body.
+	re := regexp.MustCompile(`(?m)^([ \t]*)class\s+` + regexp.QuoteMeta(name) + `\b[^\n]*:`)
+	loc := re.FindStringSubmatchIndex(src)
+	if loc == nil {
+		return nil
+	}
+	classIndent := loc[3] - loc[2]
+	headEnd := strings.Index(src[loc[0]:], "\n")
+	if headEnd < 0 {
+		return nil
+	}
+	bodyStart := loc[0] + headEnd + 1
+	i := bodyStart
+	bodyEnd := bodyStart
+	for i < len(src) {
+		lineEnd := strings.Index(src[i:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(src) - i
+		}
+		line := src[i : i+lineEnd]
+		stripped := strings.TrimLeft(line, " \t")
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			i += lineEnd + 1
+			bodyEnd = i
+			continue
+		}
+		indent := len(line) - len(stripped)
+		if indent <= classIndent {
+			break
+		}
+		i += lineEnd + 1
+		bodyEnd = i
+	}
+	if bodyEnd > len(src) {
+		bodyEnd = len(src)
+	}
+	body := src[bodyStart:bodyEnd]
+
+	// Check if this is a ModelSerializer with Meta.fields.
+	if metaKeys := drfReadMetaFields(body); len(metaKeys) > 0 {
+		return metaKeys
+	}
+
+	// Walk explicit field assignments.
+	var keys []string
+	for _, m := range drfSerializerFieldRe.FindAllStringSubmatch(body, -1) {
+		fname := m[1]
+		if strings.HasPrefix(fname, "_") {
+			continue
+		}
+		// Skip class Meta itself.
+		if fname == "Meta" {
+			continue
+		}
+		keys = append(keys, fname)
+	}
+	return keys
+}
+
+// drfReadMetaFields looks for a `class Meta:` block inside a Serializer body
+// and extracts the `fields` list.
+func drfReadMetaFields(body string) []string {
+	// Locate `class Meta:` in the body.
+	metaRe := regexp.MustCompile(`(?m)^([ \t]*)class\s+Meta\s*:`)
+	loc := metaRe.FindStringSubmatchIndex(body)
+	if loc == nil {
+		return nil
+	}
+	metaIndent := loc[3] - loc[2]
+	headEnd := strings.Index(body[loc[0]:], "\n")
+	if headEnd < 0 {
+		return nil
+	}
+	metaBodyStart := loc[0] + headEnd + 1
+	j := metaBodyStart
+	metaBodyEnd := metaBodyStart
+	for j < len(body) {
+		lineEnd := strings.Index(body[j:], "\n")
+		if lineEnd < 0 {
+			lineEnd = len(body) - j
+		}
+		line := body[j : j+lineEnd]
+		stripped := strings.TrimLeft(line, " \t")
+		if stripped == "" || strings.HasPrefix(stripped, "#") {
+			j += lineEnd + 1
+			metaBodyEnd = j
+			continue
+		}
+		indent := len(line) - len(stripped)
+		if indent <= metaIndent {
+			break
+		}
+		j += lineEnd + 1
+		metaBodyEnd = j
+	}
+	if metaBodyEnd > len(body) {
+		metaBodyEnd = len(body)
+	}
+	metaBody := body[metaBodyStart:metaBodyEnd]
+
+	// Look for `fields = ['id', 'name', ...]` or `fields = ("id", "name")`.
+	// Handle multi-line by collapsing newlines.
+	collapsed := strings.ReplaceAll(metaBody, "\n", " ")
+	m := drfMetaFieldsListRe.FindStringSubmatch(collapsed)
+	if len(m) < 2 {
+		return nil
+	}
+	// Check for `fields = '__all__'`.
+	inner := strings.TrimSpace(m[1])
+	if strings.Contains(inner, "__all__") {
+		return nil // can't statically enumerate __all__
+	}
+	// Extract quoted field names.
+	var keys []string
+	for _, km := range regexp.MustCompile(`["']([a-zA-Z_]\w*)["']`).FindAllStringSubmatch(inner, -1) {
+		keys = append(keys, km[1])
+	}
+	return keys
 }
 
 // recordStatus appends an observed status code; defaults to 200 when none

--- a/internal/engine/response_shape_test.go
+++ b/internal/engine/response_shape_test.go
@@ -403,3 +403,367 @@ func TestFindHandlerBody_MultiLineNoTrailingNewline(t *testing.T) {
 		t.Error("findHandlerBody returned empty body for multi-line function; want non-empty")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// DRF Serializer walking (Python)
+// ---------------------------------------------------------------------------
+
+// TestResponseShape_DRF_SerializerData_LocalVar exercises the most common DRF
+// pattern: a local variable assigned from a Serializer class whose fields are
+// declared as class attributes, then returned as `serializer.data`.
+func TestResponseShape_DRF_SerializerData_LocalVar(t *testing.T) {
+	src := `from rest_framework import serializers
+from rest_framework.response import Response
+from rest_framework.decorators import api_view
+
+class UserSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField(max_length=100)
+    email = serializers.EmailField()
+
+@app.route("/api/users/<int:id>", methods=["GET"])
+def get_user(id):
+    serializer = UserSerializer(instance)
+    return Response(serializer.data)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/users/{id}")
+	for _, want := range []string{"id", "name", "email"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF local var: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+	assertProp(t, props, "response_keys_known", "true")
+	assertProp(t, props, "response_keys_source", "drf_serializer")
+}
+
+// TestResponseShape_DRF_SerializerClass_ViewSet exercises a DRF ViewSet that
+// declares `serializer_class = UserSerializer` as a class attribute. The
+// extractor resolves the class-level attribute and walks the serializer.
+func TestResponseShape_DRF_SerializerClass_ViewSet(t *testing.T) {
+	src := `from rest_framework import serializers, viewsets
+from rest_framework.response import Response
+
+class UserSerializer(serializers.Serializer):
+    id = serializers.IntegerField(read_only=True)
+    name = serializers.CharField()
+    email = serializers.EmailField()
+
+class UserViewSet(viewsets.ModelViewSet):
+    serializer_class = UserSerializer
+
+    @app.route("/api/users/<int:pk>", methods=["GET"])
+    def retrieve(self, request, pk=None):
+        serializer = self.get_serializer(self.get_object())
+        return Response(serializer.data)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/users/{pk}")
+	for _, want := range []string{"id", "name", "email"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF ViewSet serializer_class: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+	assertProp(t, props, "response_keys_source", "drf_serializer")
+}
+
+// TestResponseShape_DRF_ModelSerializer_MetaFields exercises a ModelSerializer
+// that declares `Meta.fields = ['id', 'name', 'email']`.
+func TestResponseShape_DRF_ModelSerializer_MetaFields(t *testing.T) {
+	src := `from rest_framework import serializers
+from rest_framework.response import Response
+
+class UserSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = User
+        fields = ['id', 'name', 'email']
+
+@app.route("/api/users/<int:id>", methods=["GET"])
+def get_user(id):
+    serializer = UserSerializer(User.objects.get(pk=id))
+    return Response(serializer.data)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/users/{id}")
+	for _, want := range []string{"id", "name", "email"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF ModelSerializer Meta.fields: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+	assertProp(t, props, "response_keys_source", "drf_serializer")
+}
+
+// TestResponseShape_DRF_NestedSerializer exercises a Serializer that contains
+// a nested serializer field. The nested field name itself becomes a response_key.
+func TestResponseShape_DRF_NestedSerializer(t *testing.T) {
+	src := `from rest_framework import serializers
+from rest_framework.response import Response
+
+class AddressSerializer(serializers.Serializer):
+    street = serializers.CharField()
+    city = serializers.CharField()
+
+class UserSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    address = AddressSerializer()
+
+@app.route("/api/users/<int:id>", methods=["GET"])
+def get_user(id):
+    serializer = UserSerializer(instance)
+    return Response(serializer.data)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/users/{id}")
+	for _, want := range []string{"id", "name", "address"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF nested serializer: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+}
+
+// TestResponseShape_DRF_ModelSerializer_MetaFields_Tuple exercises
+// Meta.fields declared with a tuple instead of a list.
+func TestResponseShape_DRF_ModelSerializer_MetaFields_Tuple(t *testing.T) {
+	src := `from rest_framework import serializers
+from rest_framework.response import Response
+
+class ProductSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = Product
+        fields = ('sku', 'price', 'stock')
+
+@app.route("/api/products/<int:pk>", methods=["GET"])
+def get_product(pk):
+    serializer = ProductSerializer(Product.objects.get(pk=pk))
+    return Response(serializer.data)
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/products/{pk}")
+	for _, want := range []string{"sku", "price", "stock"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF Meta.fields tuple: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+}
+
+// TestResponseShape_DRF_ResponseData_Bare exercises `return serializer.data`
+// (without a Response(...) wrapper) — a common shorthand in DRF APIViews.
+func TestResponseShape_DRF_ResponseData_Bare(t *testing.T) {
+	src := `from rest_framework import serializers
+from rest_framework.views import APIView
+
+class CommentSerializer(serializers.Serializer):
+    id = serializers.IntegerField()
+    body = serializers.CharField()
+    author = serializers.CharField()
+
+@app.route("/api/comments/<int:id>", methods=["GET"])
+def get_comment(id):
+    serializer = CommentSerializer(Comment.objects.get(pk=id))
+    return serializer.data
+`
+	_, res := runDetect(t, "python", "views.py", src)
+	props := shapeOf(t, res, "http:GET:/api/comments/{id}")
+	for _, want := range []string{"id", "body", "author"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("DRF bare .data: expected response_keys to contain %q; got %q", want, props["response_keys"])
+		}
+	}
+	assertProp(t, props, "response_keys_source", "drf_serializer")
+}
+
+// ---------------------------------------------------------------------------
+// Java DTO class walking (Spring / JAX-RS)
+// ---------------------------------------------------------------------------
+
+// TestResponseShape_Java_Record exercises a Java 17+ record DTO.
+// Records declare their components in the constructor parameter list;
+// each component becomes a response_key.
+func TestResponseShape_Java_Record(t *testing.T) {
+	src := `package com.example;
+import org.springframework.web.bind.annotation.*;
+
+public record UserDTO(Long id, String name, String email) {}
+
+@RestController
+public class UserController {
+    @GetMapping("/users/{id}")
+    public UserDTO getUser(@PathVariable Long id) {
+        return new UserDTO(id, "alice", "a@b");
+    }
+}
+`
+	_, res := runDetect(t, "java", "UserController.java", src)
+	props := shapeOf(t, res, "http:ANY:/users/{id}")
+	for _, want := range []string{"id", "name", "email"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("Java record: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+	assertProp(t, props, "response_keys_source", "java_dto")
+}
+
+// TestResponseShape_Java_LombokValue exercises a Lombok @Value class.
+// All declared fields (private final) are included as response_keys.
+func TestResponseShape_Java_LombokValue(t *testing.T) {
+	src := `package com.example;
+import lombok.Value;
+import org.springframework.web.bind.annotation.*;
+
+@Value
+public class OrderDTO {
+    Long id;
+    String status;
+    Double total;
+}
+
+@RestController
+public class OrderController {
+    @GetMapping("/orders/{id}")
+    public OrderDTO getOrder(@PathVariable Long id) {
+        return new OrderDTO(id, "PENDING", 99.99);
+    }
+}
+`
+	_, res := runDetect(t, "java", "OrderController.java", src)
+	props := shapeOf(t, res, "http:ANY:/orders/{id}")
+	for _, want := range []string{"id", "status", "total"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("Lombok @Value: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+	assertProp(t, props, "response_keys_source", "java_dto")
+}
+
+// TestResponseShape_Java_LombokData exercises a Lombok @Data class.
+func TestResponseShape_Java_LombokData(t *testing.T) {
+	src := `package com.example;
+import lombok.Data;
+import org.springframework.web.bind.annotation.*;
+
+@Data
+public class ProductDTO {
+    private Long id;
+    private String sku;
+    private Double price;
+}
+
+@RestController
+public class ProductController {
+    @GetMapping("/products/{id}")
+    public ProductDTO getProduct(@PathVariable Long id) {
+        return new ProductDTO();
+    }
+}
+`
+	_, res := runDetect(t, "java", "ProductController.java", src)
+	props := shapeOf(t, res, "http:ANY:/products/{id}")
+	for _, want := range []string{"id", "sku", "price"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("Lombok @Data: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+	assertProp(t, props, "response_keys_source", "java_dto")
+}
+
+// TestResponseShape_Java_JsonProperty exercises a plain Java class where
+// fields are annotated with @JsonProperty. The annotation string value
+// is used as the response_key (supporting alias names).
+func TestResponseShape_Java_JsonProperty(t *testing.T) {
+	src := `package com.example;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.web.bind.annotation.*;
+
+public class CustomerDTO {
+    @JsonProperty("customer_id")
+    private Long id;
+
+    @JsonProperty("full_name")
+    private String name;
+
+    @JsonProperty("email_address")
+    private String email;
+}
+
+@RestController
+public class CustomerController {
+    @GetMapping("/customers/{id}")
+    public CustomerDTO getCustomer(@PathVariable Long id) {
+        return new CustomerDTO();
+    }
+}
+`
+	_, res := runDetect(t, "java", "CustomerController.java", src)
+	props := shapeOf(t, res, "http:ANY:/customers/{id}")
+	for _, want := range []string{"customer_id", "full_name", "email_address"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("@JsonProperty: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+	assertProp(t, props, "response_keys_source", "java_dto")
+}
+
+// TestResponseShape_Java_ResponseEntity_DTO exercises a Spring controller that
+// returns ResponseEntity<SomeDTO> with a Lombok @Value DTO.
+func TestResponseShape_Java_ResponseEntity_DTO(t *testing.T) {
+	src := `package com.example;
+import lombok.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@Value
+public class InvoiceDTO {
+    Long invoiceId;
+    String description;
+    Double amount;
+}
+
+@RestController
+public class InvoiceController {
+    @GetMapping("/invoices/{id}")
+    public ResponseEntity<InvoiceDTO> getInvoice(@PathVariable Long id) {
+        return ResponseEntity.ok(new InvoiceDTO(id, "Service fee", 120.0));
+    }
+}
+`
+	_, res := runDetect(t, "java", "InvoiceController.java", src)
+	props := shapeOf(t, res, "http:ANY:/invoices/{id}")
+	for _, want := range []string{"invoiceId", "description", "amount"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("ResponseEntity<DTO> Lombok: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+	assertProp(t, props, "response_keys_source", "java_dto")
+}
+
+// TestResponseShape_Java_Record_WithAnnotations exercises a Java record whose
+// components have annotations (common with validation or Jackson annotations).
+func TestResponseShape_Java_Record_WithAnnotations(t *testing.T) {
+	src := `package com.example;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.springframework.web.bind.annotation.*;
+
+public record PaymentDTO(
+    @JsonProperty("payment_id") Long id,
+    String currency,
+    Double amount
+) {}
+
+@RestController
+public class PaymentController {
+    @GetMapping("/payments/{id}")
+    public PaymentDTO getPayment(@PathVariable Long id) {
+        return new PaymentDTO(id, "USD", 50.0);
+    }
+}
+`
+	_, res := runDetect(t, "java", "PaymentController.java", src)
+	props := shapeOf(t, res, "http:ANY:/payments/{id}")
+	// The record has "id", "currency", "amount" as component names.
+	for _, want := range []string{"currency", "amount"} {
+		if !strings.Contains(props["response_keys"], want) {
+			t.Errorf("record with annotations: expected response_keys to contain %q; got %q (all: %v)", want, props["response_keys"], props)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Walk DRF Serializer classes (Python) and Java DTO types (records, Lombok @Value/@Data, @JsonProperty-annotated) to extract `response_keys` for endpoints that return `serializer.data` or typed DTO objects — fixing the gap exposed by #766 where cross-file handler lookup revealed endpoints with correct `source_handler` but empty `response_keys`.

**Python — DRF Serializer walking:**
- `return serializer.data` or `return Response(serializer.data)` → resolves serializer type via local variable assignment, `self.get_serializer()`, or class-level `serializer_class` attribute
- Walks `Serializer` field attrs (`name = serializers.CharField(...)`)
- Walks `ModelSerializer` with `Meta.fields = ['id', 'name']` or tuple form
- Nested serializers (`address = AddressSerializer()`) → adds field name as response_key
- Tags `response_keys_source=drf_serializer`

**Java — DTO class walking improvements:**
- Java records: multi-line records + per-component annotations now handled correctly
- Lombok `@Value` classes: all declared fields (including without access modifiers)
- Lombok `@Data` classes: private fields included
- `@JsonProperty("alias")` annotation: alias string used as the key name
- Tags `response_keys_source=java_dto`

## Closes / Refs
- Closes #847

## Testing
- [x] All tests pass: `go test ./internal/engine/...`
- [x] 6 new Python tests (DRF Serializer local var, ViewSet serializer_class, ModelSerializer Meta.fields list, Meta.fields tuple, nested, bare .data)
- [x] 6 new Java tests (record, @Value, @Data, @JsonProperty, ResponseEntity<DTO>, multi-line record with annotations)
- [x] No regression in cross-language parity (Flask, FastAPI, Express, Spring, JAX-RS, Gin all still pass)
- [x] Pre-existing `internal/extractors/java` syntax error is on main (panache_test.go:834) — not introduced by this PR

## Notes

File-disjoint with #845 (cross-file `@Inject`, touches `http_endpoint_java_client.go`).

Only `response_shape.go`, `response_shape_python.go`, `response_shape_java.go`, `response_shape_test.go` touched.