### PR TITLE
[#531] Add external-sql Disposition bucket for SQL surface area

### DIFF
--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -141,6 +141,12 @@ const (
 	// placeholder but the package is NOT on the allowlist. Likely a real
 	// external dep we haven't catalogued yet.
 	DispositionExternalUnknown
+	// DispositionExternalSQL — the endpoint is an unresolved
+	// scope:dataaccess:<file>#<orm>:<op>:<table> stub identifying SQL
+	// surface area (issue #531). Distinct from ExternalKnown so that
+	// SQL surface area is counted separately in disposition_counts output
+	// and is queryable via archigraph doctor as its own metric bucket.
+	DispositionExternalSQL
 	// DispositionDynamic — the stub matches a pattern that is intrinsically
 	// static-unresolvable (reflection, dynamic import, env-driven names,
 	// template-built strings). Not a bug; the call cannot be resolved
@@ -168,6 +174,8 @@ func (d Disposition) String() string {
 		return "external-known"
 	case DispositionExternalUnknown:
 		return "external-unknown"
+	case DispositionExternalSQL:
+		return "external-sql"
 	case DispositionDynamic:
 		return "dynamic"
 	case DispositionBugExtractor:
@@ -187,6 +195,7 @@ var AllDispositions = []Disposition{
 	DispositionResolved,
 	DispositionExternalKnown,
 	DispositionExternalUnknown,
+	DispositionExternalSQL,
 	DispositionDynamic,
 	DispositionBugExtractor,
 	DispositionBugResolver,
@@ -3355,7 +3364,7 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 	// (client-fixture-a, Django backend pre-fix). The new external-sql disposition
 	// bucket is tracked as a chain-fix.
 	if isDataAccessSQLStub(originalStub) {
-		return DispositionExternalKnown
+		return DispositionExternalSQL
 	}
 	// Issue #120 — IMPORTS edges across every language extractor
 	// emit FromID = the importing file's source path (the file the

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -1642,12 +1642,13 @@ func TestIsDataAccessSQLStub(t *testing.T) {
 	}
 }
 
-// TestDisposition_DataAccessSQLRoutesToExternalKnown is the issue #507
+// TestDisposition_DataAccessSQLRoutesToExternalSQL is the issue #531
 // regression test. When a SCOPE.DataAccess structural-ref doesn't resolve
 // to a concrete entity (e.g. UNKNOWN table, edge survives dedup miss) it
-// must land in ExternalKnown — not bug-extractor — so backend SQL surface
-// area stops polluting the bug-rate on Django / Flask / FastAPI repos.
-func TestDisposition_DataAccessSQLRoutesToExternalKnown(t *testing.T) {
+// must land in ExternalSQL — not bug-extractor and not the generic
+// ExternalKnown bucket — so SQL surface area is counted separately from
+// generic external package imports in disposition_counts.
+func TestDisposition_DataAccessSQLRoutesToExternalSQL(t *testing.T) {
 	t.Parallel()
 	stubs := []string{
 		"scope:dataaccess:app/views/sync_viewset.py#psycopg2:SELECT:UNKNOWN",
@@ -1666,8 +1667,11 @@ func TestDisposition_DataAccessSQLRoutesToExternalKnown(t *testing.T) {
 	}
 	idx := BuildIndex(nil)
 	stats := idx.ClassifyEndpoints(endpoints, allowDjango)
-	if got := stats.DispositionCounts[DispositionExternalKnown]; got != len(stubs) {
-		t.Fatalf("expected %d external-known, got counts=%+v", len(stubs), stats.DispositionCounts)
+	if got := stats.DispositionCounts[DispositionExternalSQL]; got != len(stubs) {
+		t.Fatalf("expected %d external-sql, got counts=%+v", len(stubs), stats.DispositionCounts)
+	}
+	if got := stats.DispositionCounts[DispositionExternalKnown]; got != 0 {
+		t.Fatalf("unexpected external-known count %d (SQL stubs must use external-sql bucket post #531)", got)
 	}
 	if got := stats.DispositionCounts[DispositionBugExtractor]; got != 0 {
 		t.Fatalf("unexpected bug-extractor count %d (should be zero post #507)", got)


### PR DESCRIPTION
## Summary

- Adds `DispositionExternalSQL` (string: `external-sql`) constant to the Disposition enum in `internal/resolve/refs.go`
- Routes `isDataAccessSQLStub` branch in `classifyDispositionLang` to `DispositionExternalSQL` instead of `DispositionExternalKnown`
- Updates `AllDispositions` slice and `String()` method
- Renames `TestDisposition_DataAccessSQLRoutesToExternalKnown` → `TestDisposition_DataAccessSQLRoutesToExternalSQL` and flips assertion to `DispositionExternalSQL`
- SQL surface area (Django/Flask/FastAPI psycopg2/sqlalchemy/asyncpg dataaccess stubs) now counted in its own `external-sql` bucket in `disposition_counts` — separate from generic external package imports

## Why

Lets users and `archigraph doctor` distinguish "this code talks to a SQL database" from generic external package imports. Bug-rate metric is unchanged (SQL stubs were already non-bug via `external-known`); the split makes SQL surface area queryable as its own metric per repo. Prerequisite for chain-fix #532 (db:table entity synthesis).

## Test plan
- [x] `TestDisposition_DataAccessSQLRoutesToExternalSQL` passes
- [x] `TestDisposition_DataAccessSQLResolvedWhenEntityPresent` still passes (happy path unchanged)
- [x] `go test ./internal/resolve/...` green
- [x] `go build ./...` clean

Closes #531