### PR TITLE
[#532] Synthesise db:<table> external entities + IMPORTS edges

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -253,6 +253,184 @@ func Synthesize(doc *graph.Document) Stats {
 	}
 }
 
+// parseDataAccessQN parses a scope:dataaccess:<file>#<orm>:<op>:<table>
+// qualified name and returns (file, table, ok).
+// Returns ok=false if the form is invalid, table is empty, or table is "UNKNOWN".
+func parseDataAccessQN(qn string) (file, table string, ok bool) {
+	const prefix = "scope:dataaccess:"
+	if !strings.HasPrefix(qn, prefix) {
+		return "", "", false
+	}
+	rest := qn[len(prefix):]
+	hash := strings.IndexByte(rest, '#')
+	if hash < 0 {
+		return "", "", false
+	}
+	file = rest[:hash]
+	after := rest[hash+1:]
+	// after = <orm>:<op>:<table>
+	parts := strings.SplitN(after, ":", 3)
+	if len(parts) != 3 {
+		return "", "", false
+	}
+	table = parts[2]
+	if table == "" || table == "UNKNOWN" {
+		return "", "", false
+	}
+	return file, table, true
+}
+
+// SynthesizeDBEntities (issue #532) scans every SCOPE.DataAccess entity in
+// doc, extracts the table name from its QualifiedName
+// (scope:dataaccess:<file>#<orm>:<op>:<table>), and synthesises:
+//
+//  1. One ext:db.<table> external entity per distinct table seen.
+//  2. One IMPORTS edge per distinct (sourceFile, table) pair.
+//
+// UNKNOWN table entries are skipped. The pass is idempotent: calling it
+// twice on the same document is a no-op on the second call. Returns Stats
+// with Synthesized = new entity count and RelationshipsResolved = new IMPORTS
+// edge count.
+func SynthesizeDBEntities(doc *graph.Document) Stats {
+	if doc == nil {
+		return Stats{}
+	}
+
+	// Build a set of existing entity IDs for idempotency.
+	knownEntities := make(map[string]bool, len(doc.Entities))
+	for k := range doc.Entities {
+		knownEntities[doc.Entities[k].ID] = true
+	}
+
+	// Build a set of existing IMPORTS edges for deduplication.
+	// Key: fromID + "|" + toID
+	knownEdges := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		rel := &doc.Relationships[k]
+		if rel.Kind == string(types.RelationshipKindImports) {
+			knownEdges[rel.FromID+"|"+rel.ToID] = true
+		}
+	}
+
+	// Scan SCOPE.DataAccess entities.
+	// tables: table name → bool (distinct tables seen)
+	// seenFileTables: "file|table" → bool (dedup IMPORTS edges)
+	tables := make(map[string]bool)
+	seenFileTables := make(map[string]bool)
+	type importEdge struct {
+		fromID string
+		toID   string
+		table  string
+	}
+	var newEdges []importEdge
+
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Kind != "SCOPE.DataAccess" {
+			continue
+		}
+		file, table, ok := parseDataAccessQN(e.QualifiedName)
+		if !ok {
+			continue
+		}
+		tables[table] = true
+		extID := ExtIDPrefix + "db." + table
+		// Use SourceFile from the entity as the FromID of the IMPORTS edge.
+		// This is consistent with how other extractors emit IMPORTS edges
+		// from file paths (pre-#577 shape; works for MCP graph queries).
+		fromID := e.SourceFile
+		if fromID == "" {
+			fromID = file
+		}
+		fileTableKey := fromID + "|" + table
+		if seenFileTables[fileTableKey] {
+			continue
+		}
+		seenFileTables[fileTableKey] = true
+		edgeKey := fromID + "|" + extID
+		if knownEdges[edgeKey] {
+			continue
+		}
+		newEdges = append(newEdges, importEdge{
+			fromID: fromID,
+			toID:   extID,
+			table:  table,
+		})
+	}
+
+	if len(tables) == 0 {
+		return Stats{}
+	}
+
+	// Sort for deterministic append order.
+	sortedTables := make([]string, 0, len(tables))
+	for t := range tables {
+		sortedTables = append(sortedTables, t)
+	}
+	sort.Strings(sortedTables)
+
+	synthesised := 0
+	for _, table := range sortedTables {
+		extID := ExtIDPrefix + "db." + table
+		if knownEntities[extID] {
+			continue
+		}
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:            extID,
+			Name:          table,
+			QualifiedName: "db." + table,
+			Kind:          KindExternal,
+			Subtype:       "sql_table",
+			SourceFile:    "",
+			Language:      "",
+			Metadata: map[string]interface{}{
+				"is_external":    true,
+				"discovered_via": "db-synth",
+				"module":         "db",
+			},
+		})
+		knownEntities[extID] = true
+		synthesised++
+	}
+
+	// Sort edges for deterministic append order.
+	sort.Slice(newEdges, func(i, j int) bool {
+		if newEdges[i].fromID != newEdges[j].fromID {
+			return newEdges[i].fromID < newEdges[j].fromID
+		}
+		return newEdges[i].toID < newEdges[j].toID
+	})
+
+	edgesAdded := 0
+	for _, e := range newEdges {
+		edgeKey := e.fromID + "|" + e.toID
+		if knownEdges[edgeKey] {
+			continue
+		}
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     graph.RelationshipID(e.fromID, e.toID, string(types.RelationshipKindImports)),
+			FromID: e.fromID,
+			ToID:   e.toID,
+			Kind:   string(types.RelationshipKindImports),
+			Properties: map[string]string{
+				"generated": "true",
+				"table":     e.table,
+				"db_synth":  "531-532",
+			},
+		})
+		knownEdges[edgeKey] = true
+		edgesAdded++
+	}
+
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+
+	return Stats{
+		Synthesized:           synthesised,
+		RelationshipsResolved: edgesAdded,
+	}
+}
+
 // classifyExternal decides whether a stub-shaped ToID looks like an
 // external reference, and if so returns the canonical name we should
 // use for the placeholder entity.

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -1,6 +1,7 @@
 package external
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -4677,5 +4678,136 @@ func TestPoiKnownExternalPackages_EntryExists(t *testing.T) {
 				t.Errorf("isKnownExternalPackage(%q) = false; want true (entry missing from knownExternalPackages)", pkg)
 			}
 		})
+	}
+}
+
+// TestSynthesizeDBEntities_DjangoFixture (issue #532) — verifies that for a
+// Django-shaped fixture with multiple files querying overlapping tables the
+// synthesiser produces:
+//   - one ext:db.<table> entity per distinct table (deduped)
+//   - one IMPORTS edge per distinct (file, table) pair (deduped)
+//   - UNKNOWN table entries are skipped
+func TestSynthesizeDBEntities_DjangoFixture(t *testing.T) {
+	t.Parallel()
+	// Simulate five SCOPE.DataAccess entities:
+	//   app/views/orders.py -> SELECT users
+	//   app/views/orders.py -> INSERT orders  (same file, different table)
+	//   app/views/profile.py -> SELECT users  (different file, same table as first)
+	//   app/models/user.py -> SELECT users    (third file reading users)
+	//   app/views/sync.py -> SELECT UNKNOWN   (should be skipped)
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:            "aaaa000000000001",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "SELECT users",
+				QualifiedName: "scope:dataaccess:app/views/orders.py#psycopg2:SELECT:users",
+				SourceFile:    "app/views/orders.py",
+				Language:      "python",
+			},
+			{
+				ID:            "aaaa000000000002",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "INSERT orders",
+				QualifiedName: "scope:dataaccess:app/views/orders.py#psycopg2:INSERT:orders",
+				SourceFile:    "app/views/orders.py",
+				Language:      "python",
+			},
+			{
+				ID:            "aaaa000000000003",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "SELECT users",
+				QualifiedName: "scope:dataaccess:app/views/profile.py#psycopg2:SELECT:users",
+				SourceFile:    "app/views/profile.py",
+				Language:      "python",
+			},
+			{
+				ID:            "aaaa000000000004",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "SELECT users",
+				QualifiedName: "scope:dataaccess:app/models/user.py#sqlalchemy:SELECT:users",
+				SourceFile:    "app/models/user.py",
+				Language:      "python",
+			},
+			{
+				ID:            "aaaa000000000005",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "SELECT UNKNOWN",
+				QualifiedName: "scope:dataaccess:app/views/sync.py#psycopg2:SELECT:UNKNOWN",
+				SourceFile:    "app/views/sync.py",
+				Language:      "python",
+			},
+		},
+	}
+
+	stats := SynthesizeDBEntities(doc)
+
+	// 2 distinct tables: users, orders (UNKNOWN skipped)
+	if stats.Synthesized != 2 {
+		t.Fatalf("Synthesized=%d, want 2 (users, orders)", stats.Synthesized)
+	}
+
+	// 4 distinct (file, table) pairs:
+	//   (orders.py, users), (orders.py, orders), (profile.py, users), (models/user.py, users)
+	if stats.RelationshipsResolved != 4 {
+		t.Fatalf("RelationshipsResolved=%d, want 4 IMPORTS edges", stats.RelationshipsResolved)
+	}
+
+	// Verify ext:db.users and ext:db.orders entities exist
+	entityIDs := make(map[string]bool)
+	for _, e := range doc.Entities {
+		entityIDs[e.ID] = true
+	}
+	if !entityIDs["ext:db.users"] {
+		t.Error("missing ext:db.users entity")
+	}
+	if !entityIDs["ext:db.orders"] {
+		t.Error("missing ext:db.orders entity")
+	}
+
+	// Count IMPORTS edges to db:* targets
+	importCount := 0
+	importTargets := make(map[string]int)
+	for _, r := range doc.Relationships {
+		if r.Kind == "IMPORTS" && strings.HasPrefix(r.ToID, "ext:db.") {
+			importCount++
+			importTargets[r.ToID]++
+		}
+	}
+	if importCount != 4 {
+		t.Fatalf("got %d IMPORTS->db:* edges, want 4", importCount)
+	}
+	// users should have 3 callers; orders should have 1
+	if importTargets["ext:db.users"] != 3 {
+		t.Errorf("ext:db.users: %d IMPORTS edges, want 3", importTargets["ext:db.users"])
+	}
+	if importTargets["ext:db.orders"] != 1 {
+		t.Errorf("ext:db.orders: %d IMPORTS edges, want 1", importTargets["ext:db.orders"])
+	}
+}
+
+// TestSynthesizeDBEntities_Idempotent confirms running SynthesizeDBEntities
+// twice on the same document is a no-op on the second call.
+func TestSynthesizeDBEntities_Idempotent(t *testing.T) {
+	t.Parallel()
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:            "bbbb000000000001",
+				Kind:          "SCOPE.DataAccess",
+				Name:          "SELECT items",
+				QualifiedName: "scope:dataaccess:store/views.py#psycopg2:SELECT:items",
+				SourceFile:    "store/views.py",
+				Language:      "python",
+			},
+		},
+	}
+	first := SynthesizeDBEntities(doc)
+	if first.Synthesized != 1 || first.RelationshipsResolved != 1 {
+		t.Fatalf("first run: Synthesized=%d RelationshipsResolved=%d, want 1,1", first.Synthesized, first.RelationshipsResolved)
+	}
+	second := SynthesizeDBEntities(doc)
+	if second.Synthesized != 0 || second.RelationshipsResolved != 0 {
+		t.Fatalf("second run: Synthesized=%d RelationshipsResolved=%d, want 0,0 (idempotent)", second.Synthesized, second.RelationshipsResolved)
 	}
 }


### PR DESCRIPTION
## Summary

- Adds `SynthesizeDBEntities(doc *graph.Document) Stats` pass in `internal/external/synth.go`
- Adds `parseDataAccessQN` helper that parses `scope:dataaccess:<file>#<orm>:<op>:<table>` qualified names
- Walks every `SCOPE.DataAccess` entity and extracts the table name from its QualifiedName
- Emits one `ext:db.<table>` external entity per distinct table (`Kind: "external"`, `Subtype: "sql_table"`)
- Emits one `IMPORTS` edge per distinct (sourceFile, table) pair, deduped per (FromID, ToID)
- Skips `UNKNOWN` table entries
- Idempotent: second call on same document is a no-op
- Tests: `TestSynthesizeDBEntities_DjangoFixture` + `TestSynthesizeDBEntities_Idempotent`

## Why

Makes "which files read this table?" directly queryable via `archigraph_find db:users` without walking per-file DataAccess intermediates. Aligns SQL surface with how every other external surface (npm/pypi/swift modules) is modelled — one external entity, N IMPORTS edges.

## Depends on

PR #867 (#531) — `DispositionExternalSQL` bucket. Both PRs are file-disjoint and can merge independently; #532 is logically the second in the chain.

## Test plan
- [x] `TestSynthesizeDBEntities_DjangoFixture` passes (Synthesized=2, RelationshipsResolved=4, correct dedup)
- [x] `TestSynthesizeDBEntities_Idempotent` passes
- [x] `go test ./internal/external/...` green (all existing tests still pass)
- [x] `go build ./...` clean

Closes #532