### PR TITLE
[#546] ADR-0015 #3/8 — trust-model R1-R7 enforcement on MCP submit_repair

### DIFF
--- a/internal/mcp/repair_verify.go
+++ b/internal/mcp/repair_verify.go
@@ -1,0 +1,196 @@
+package mcp
+
+// repair_verify implements ADR-0015 trust-model rules R1-R7 on the MCP
+// submit path. The indexer's apply-side already validates on apply; this
+// layer enforces the same rules at submit time so an agent gets immediate
+// feedback rather than discovering a rejection only at the next index run.
+//
+// Rules mirror docs/specs/repair-trust-model.md exactly.
+// Issue: #546 — ADR-0015 #3/8
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/enrichment"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// submitVerifyModuleRe is the R5 module-identifier regex from repair-trust-model.md.
+// Same pattern as enrichment.moduleIdentRe; redeclared here to avoid exporting from enrichment.
+var submitVerifyModuleRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_\-./]*$`)
+
+// RepairVerifyResult is the structured outcome of trust-model verification on
+// a proposed submit. ok=true means the repair passed all rules; ok=false means
+// at least one rule rejected it and RejectedReason is set to a stable code.
+type RepairVerifyResult struct {
+	OK             bool   `json:"ok"`
+	RejectedReason string `json:"rejected_reason,omitempty"`
+}
+
+// VerifyRepairSubmit runs R1-R7 against a proposed repair before it is
+// written to repair.json. It mirrors the apply-side validateRepair in
+// internal/enrichment/repair_apply.go but operates against the live
+// loaded graph (via docEnts) and the current candidate set (via candidateEdgeIDs).
+//
+//   - R1  edge_id_unknown:               edgeID not present in candidateEdgeIDs
+//   - R2  target_entity_not_found:       bind_to_entity target missing from docEnts
+//   - R3  self_loop_disallowed:          bind_to_entity target == fromEntityID
+//   - R4  contradicts_contains_hierarchy: target is a CONTAINS ancestor of fromEntityID
+//   - R5  invalid_module_identifier:     reclassify_as_external module fails regex
+//   - R6  missing_required_field:        conditional required field absent for resolution kind
+//   - R7  reasoning_too_short:           reasoning is empty or whitespace-only
+func VerifyRepairSubmit(
+	rep enrichment.Repair,
+	fromEntityID string,
+	candidateEdgeIDs map[string]bool,
+	docEnts map[string]*graph.Entity,
+	containsParents map[string]map[string]bool,
+) RepairVerifyResult {
+	// R1 — edge_id must match a current candidate.
+	if len(candidateEdgeIDs) > 0 && !candidateEdgeIDs[rep.EdgeID] {
+		return RepairVerifyResult{RejectedReason: "edge_id_unknown"}
+	}
+
+	// R7 — reasoning must be substantive.
+	if strings.TrimSpace(rep.Reasoning) == "" {
+		return RepairVerifyResult{RejectedReason: "reasoning_too_short"}
+	}
+
+	// Resolution-specific R2/R3/R4/R5/R6.
+	switch rep.Resolution {
+	case enrichment.RepairBindToEntity:
+		// R6 — required field.
+		if rep.TargetEntityID == "" {
+			return RepairVerifyResult{RejectedReason: "missing_required_field"}
+		}
+		// R2 — target must exist in graph.
+		if docEnts != nil {
+			if _, ok := docEnts[rep.TargetEntityID]; !ok {
+				return RepairVerifyResult{RejectedReason: "target_entity_not_found"}
+			}
+		}
+		// R3 — no self-loop.
+		if fromEntityID != "" && rep.TargetEntityID == fromEntityID {
+			return RepairVerifyResult{RejectedReason: "self_loop_disallowed"}
+		}
+		// R4 — target cannot be a CONTAINS ancestor.
+		if containsParents != nil {
+			if ancestors, ok := containsParents[fromEntityID]; ok {
+				if ancestors[rep.TargetEntityID] {
+					return RepairVerifyResult{RejectedReason: "contradicts_contains_hierarchy"}
+				}
+			}
+		}
+	case enrichment.RepairReclassifyAsExternal:
+		// R6 — required field.
+		if rep.Module == "" {
+			return RepairVerifyResult{RejectedReason: "missing_required_field"}
+		}
+		// R5 — module must be a safe identifier.
+		if !submitVerifyModuleRe.MatchString(rep.Module) ||
+			strings.Contains(rep.Module, "..") ||
+			strings.HasPrefix(rep.Module, "/") {
+			return RepairVerifyResult{RejectedReason: "invalid_module_identifier"}
+		}
+	case enrichment.RepairReclassifyAsDynamic:
+		// R6 — dynamic_reason required.
+		if strings.TrimSpace(rep.DynamicReason) == "" {
+			return RepairVerifyResult{RejectedReason: "missing_required_field"}
+		}
+	case enrichment.RepairReclassifyAsResolved:
+		// R6 — new_target required.
+		if strings.TrimSpace(rep.NewTarget) == "" {
+			return RepairVerifyResult{RejectedReason: "missing_required_field"}
+		}
+	case enrichment.RepairAbandon:
+		// R6 — abandon_reason required.
+		if strings.TrimSpace(rep.AbandonReason) == "" {
+			return RepairVerifyResult{RejectedReason: "missing_required_field"}
+		}
+	default:
+		// Not in the allowlist — the caller checks this separately, but
+		// guard here for completeness.
+		return RepairVerifyResult{RejectedReason: fmt.Sprintf("resolution_kind_unsupported: %s", rep.Resolution)}
+	}
+
+	return RepairVerifyResult{OK: true}
+}
+
+// buildVerifyContext extracts the from_entity_id and the CONTAINS-parent
+// map from the loaded graph document. Used by handleSubmitRepair to
+// populate VerifyRepairSubmit's context arguments.
+func buildVerifyContext(doc *graph.Document) (map[string]*graph.Entity, map[string]map[string]bool) {
+	if doc == nil {
+		return nil, nil
+	}
+	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		byID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+	// Build transitive CONTAINS-parent map for R4.
+	directParents := make(map[string]map[string]bool)
+	for _, r := range doc.Relationships {
+		if r.Kind != "CONTAINS" {
+			continue
+		}
+		if directParents[r.ToID] == nil {
+			directParents[r.ToID] = map[string]bool{}
+		}
+		directParents[r.ToID][r.FromID] = true
+	}
+	out := make(map[string]map[string]bool, len(directParents))
+	var walk func(id string, acc map[string]bool, seen map[string]bool)
+	walk = func(id string, acc map[string]bool, seen map[string]bool) {
+		if seen[id] {
+			return
+		}
+		seen[id] = true
+		for p := range directParents[id] {
+			acc[p] = true
+			walk(p, acc, seen)
+		}
+	}
+	for id := range directParents {
+		acc := map[string]bool{}
+		walk(id, acc, map[string]bool{})
+		out[id] = acc
+	}
+	return byID, out
+}
+
+// candidateEdgeIDSet builds the set of known edge_ids from a repo's current
+// repair_edge candidates. R1 checks against this set.
+func candidateEdgeIDSet(candidates []enrichment.Candidate) map[string]bool {
+	s := make(map[string]bool, len(candidates))
+	for _, c := range candidates {
+		if c.Context == nil {
+			continue
+		}
+		if v, ok := c.Context["edge_id"].(string); ok && v != "" {
+			s[v] = true
+		}
+	}
+	return s
+}
+
+// fromEntityIDForEdge extracts the from_entity.id from a repair_edge
+// candidate that matches edgeID. Returns "" if not found.
+func fromEntityIDForEdge(candidates []enrichment.Candidate, edgeID string) string {
+	for _, c := range candidates {
+		if c.Context == nil {
+			continue
+		}
+		eid, _ := c.Context["edge_id"].(string)
+		if eid != edgeID {
+			continue
+		}
+		if fe, ok := c.Context["from_entity"].(map[string]any); ok {
+			if id, ok := fe["id"].(string); ok {
+				return id
+			}
+		}
+	}
+	return ""
+}

--- a/internal/mcp/repair_verify_test.go
+++ b/internal/mcp/repair_verify_test.go
@@ -1,0 +1,215 @@
+package mcp
+
+// Tests for ADR-0015 trust-model R1-R7 verification on the MCP submit path.
+// Issue: #546 — ADR-0015 #3/8
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/enrichment"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// baseRepair returns a valid bind_to_entity repair for tests to mutate.
+func baseRepair() enrichment.Repair {
+	return enrichment.Repair{
+		EdgeID:         "er:aabbccddeeff0011",
+		Resolution:     enrichment.RepairBindToEntity,
+		TargetEntityID: "bbbbbbbbbbbbbbbb",
+		Confidence:     0.9,
+		Reasoning:      "imported from b.py per import line",
+		Source:         "generate-docs/pass-1a",
+	}
+}
+
+func baseDocEnts() map[string]*graph.Entity {
+	return map[string]*graph.Entity{
+		"aaaaaaaaaaaaaaaa": {ID: "aaaaaaaaaaaaaaaa", Kind: "Function", Name: "caller"},
+		"bbbbbbbbbbbbbbbb": {ID: "bbbbbbbbbbbbbbbb", Kind: "Function", Name: "target"},
+		"cccccccccccccccc": {ID: "cccccccccccccccc", Kind: "Class", Name: "Wrapper"},
+	}
+}
+
+func baseCandidateEdgeIDs() map[string]bool {
+	return map[string]bool{"er:aabbccddeeff0011": true}
+}
+
+// TestVerifyRepairSubmit_Happy verifies a valid repair passes all rules.
+func TestVerifyRepairSubmit_Happy(t *testing.T) {
+	vr := VerifyRepairSubmit(baseRepair(), "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+	if !vr.OK {
+		t.Fatalf("expected ok, got rejected_reason=%q", vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R1_EdgeIDUnknown — edge_id not in candidate set.
+func TestVerifyRepairSubmit_R1_EdgeIDUnknown(t *testing.T) {
+	rep := baseRepair()
+	rep.EdgeID = "er:0000000000000000" // not in candidate set
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+	if vr.OK || vr.RejectedReason != "edge_id_unknown" {
+		t.Fatalf("R1: got ok=%v reason=%q", vr.OK, vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R1_SkippedWhenCandidateSetEmpty — R1 is skipped when
+// the candidate set is empty (repo hasn't been indexed yet; agent passes
+// edge_id from a cached candidate list).
+func TestVerifyRepairSubmit_R1_SkippedWhenCandidateSetEmpty(t *testing.T) {
+	rep := baseRepair()
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", nil, baseDocEnts(), nil)
+	if !vr.OK {
+		t.Fatalf("R1 should be skipped on empty candidate set: %q", vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R2_TargetEntityNotFound — bind_to_entity to unknown entity.
+func TestVerifyRepairSubmit_R2_TargetEntityNotFound(t *testing.T) {
+	rep := baseRepair()
+	rep.TargetEntityID = "deadbeefdeadbeef" // not in docEnts
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+	if vr.OK || vr.RejectedReason != "target_entity_not_found" {
+		t.Fatalf("R2: got ok=%v reason=%q", vr.OK, vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R3_SelfLoopDisallowed — bind_to_entity to own entity.
+func TestVerifyRepairSubmit_R3_SelfLoopDisallowed(t *testing.T) {
+	rep := baseRepair()
+	rep.TargetEntityID = "aaaaaaaaaaaaaaaa" // == fromEntityID
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+	if vr.OK || vr.RejectedReason != "self_loop_disallowed" {
+		t.Fatalf("R3: got ok=%v reason=%q", vr.OK, vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R4_ContradictsContainsHierarchy — target is a CONTAINS ancestor.
+func TestVerifyRepairSubmit_R4_ContradictsContainsHierarchy(t *testing.T) {
+	rep := baseRepair()
+	rep.TargetEntityID = "cccccccccccccccc" // Wrapper CONTAINS caller
+	// Build containsParents so Wrapper is a known ancestor of caller.
+	containsParents := map[string]map[string]bool{
+		"aaaaaaaaaaaaaaaa": {"cccccccccccccccc": true},
+	}
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), containsParents)
+	if vr.OK || vr.RejectedReason != "contradicts_contains_hierarchy" {
+		t.Fatalf("R4: got ok=%v reason=%q", vr.OK, vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R5_InvalidModuleIdentifier — reclassify_as_external with bad module.
+func TestVerifyRepairSubmit_R5_InvalidModuleIdentifier(t *testing.T) {
+	for _, badModule := range []string{"../etc/passwd", "/absolute", "has spaces", "a..b"} {
+		rep := baseRepair()
+		rep.Resolution = enrichment.RepairReclassifyAsExternal
+		rep.TargetEntityID = ""
+		rep.Module = badModule
+		vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+		if vr.OK || vr.RejectedReason != "invalid_module_identifier" {
+			t.Fatalf("R5 bad module=%q: ok=%v reason=%q", badModule, vr.OK, vr.RejectedReason)
+		}
+	}
+	// Valid module should pass.
+	rep := baseRepair()
+	rep.Resolution = enrichment.RepairReclassifyAsExternal
+	rep.TargetEntityID = ""
+	rep.Module = "django.db.models"
+	vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+	if !vr.OK {
+		t.Fatalf("R5 valid module rejected: %q", vr.RejectedReason)
+	}
+}
+
+// TestVerifyRepairSubmit_R6_MissingRequiredField — each resolution kind checked.
+func TestVerifyRepairSubmit_R6_MissingRequiredField(t *testing.T) {
+	cases := []struct {
+		resolution string
+		mutate     func(*enrichment.Repair)
+	}{
+		{enrichment.RepairBindToEntity, func(r *enrichment.Repair) { r.TargetEntityID = "" }},
+		{enrichment.RepairReclassifyAsExternal, func(r *enrichment.Repair) { r.Module = "" }},
+		{enrichment.RepairReclassifyAsDynamic, func(r *enrichment.Repair) { r.DynamicReason = "" }},
+		{enrichment.RepairReclassifyAsResolved, func(r *enrichment.Repair) { r.NewTarget = "" }},
+		{enrichment.RepairAbandon, func(r *enrichment.Repair) { r.AbandonReason = "" }},
+	}
+	for _, tc := range cases {
+		rep := baseRepair()
+		rep.Resolution = tc.resolution
+		tc.mutate(&rep)
+		vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+		if vr.OK || vr.RejectedReason != "missing_required_field" {
+			t.Errorf("R6 resolution=%s: ok=%v reason=%q", tc.resolution, vr.OK, vr.RejectedReason)
+		}
+	}
+}
+
+// TestVerifyRepairSubmit_R7_ReasoningTooShort — empty/whitespace reasoning.
+func TestVerifyRepairSubmit_R7_ReasoningTooShort(t *testing.T) {
+	for _, bad := range []string{"", "   ", "\t"} {
+		rep := baseRepair()
+		rep.Reasoning = bad
+		vr := VerifyRepairSubmit(rep, "aaaaaaaaaaaaaaaa", baseCandidateEdgeIDs(), baseDocEnts(), nil)
+		if vr.OK || vr.RejectedReason != "reasoning_too_short" {
+			t.Fatalf("R7 reasoning=%q: ok=%v reason=%q", bad, vr.OK, vr.RejectedReason)
+		}
+	}
+}
+
+// TestBuildVerifyContext_BasicGraph confirms entity map and CONTAINS parent
+// map are populated from a simple document.
+func TestBuildVerifyContext_BasicGraph(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "aaaaaaaaaaaaaaaa", Kind: "Function", Name: "caller"},
+			{ID: "bbbbbbbbbbbbbbbb", Kind: "Class", Name: "Wrapper"},
+		},
+		Relationships: []graph.Relationship{
+			{FromID: "bbbbbbbbbbbbbbbb", ToID: "aaaaaaaaaaaaaaaa", Kind: "CONTAINS"},
+		},
+	}
+	ents, parents := buildVerifyContext(doc)
+	if len(ents) != 2 {
+		t.Fatalf("ents len=%d want 2", len(ents))
+	}
+	if !parents["aaaaaaaaaaaaaaaa"]["bbbbbbbbbbbbbbbb"] {
+		t.Fatalf("CONTAINS parent not found: %+v", parents)
+	}
+}
+
+// TestCandidateEdgeIDSet confirms the set is populated from context.edge_id.
+func TestCandidateEdgeIDSet(t *testing.T) {
+	cands := []enrichment.Candidate{
+		{Context: map[string]any{"edge_id": "er:001122334455aabb"}},
+		{Context: map[string]any{"edge_id": "er:aabbccddeeff0011"}},
+		{Context: nil},
+	}
+	s := candidateEdgeIDSet(cands)
+	if !s["er:001122334455aabb"] || !s["er:aabbccddeeff0011"] {
+		t.Fatalf("set=%v", s)
+	}
+	if len(s) != 2 {
+		t.Fatalf("len=%d want 2", len(s))
+	}
+}
+
+// TestFromEntityIDForEdge confirms from_entity.id is extracted from the
+// matching candidate.
+func TestFromEntityIDForEdge(t *testing.T) {
+	cands := []enrichment.Candidate{
+		{
+			Context: map[string]any{
+				"edge_id":     "er:aabbccddeeff0011",
+				"from_entity": map[string]any{"id": "aaaaaaaaaaaaaaaa"},
+			},
+		},
+	}
+	got := fromEntityIDForEdge(cands, "er:aabbccddeeff0011")
+	if got != "aaaaaaaaaaaaaaaa" {
+		t.Fatalf("got=%q want aaaaaaaaaaaaaaaa", got)
+	}
+	// Missing edge returns empty string.
+	got2 := fromEntityIDForEdge(cands, "er:0000000000000000")
+	if got2 != "" {
+		t.Fatalf("missing edge: got=%q", got2)
+	}
+}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -777,6 +777,7 @@ func TestRepairToolsRoundTrip(t *testing.T) {
 		"residual_id":    "er:deadbeef00000001",
 		"resolution":     "abandon",
 		"abandon_reason": "test-only dynamic dispatch",
+		"reasoning":      "no static binding possible; dynamic dispatch confirmed",
 		"confidence":     0.4,
 	})
 	if okRes2.IsError {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1489,6 +1489,9 @@ func (s *Server) handleRepairs(ctx context.Context, req mcpapi.CallToolRequest) 
 
 // handleSubmitRepairFromBundle is handleSubmitRepair adapted for the bundled
 // archigraph_repairs tool where the edge identifier comes in as residual_id.
+// Trust-model rules R1-R7 (ADR-0015 / repair-trust-model.md) are enforced
+// before the repair is written so the agent gets immediate feedback rather
+// than discovering a rejection only on the next index run (#546).
 func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.CallToolRequest, edgeID string) (*mcpapi.CallToolResult, error) {
 	resolution := argString(req, "resolution", "")
 	if resolution == "" {
@@ -1519,6 +1522,7 @@ func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.Ca
 
 	repos := reposToConsider(lg, nil)
 	var target *LoadedRepo
+	var candidates []enrichment.Candidate
 	if repoOverride != "" {
 		for _, r := range repos {
 			if r.Repo == repoOverride {
@@ -1529,11 +1533,14 @@ func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.Ca
 		if target == nil {
 			return mcpapi.NewToolResultError(fmt.Sprintf("repo %q not loaded in group", repoOverride)), nil
 		}
+		candidates = readRepairEdgeCandidates(target.Path)
 	} else {
 		for _, r := range repos {
-			for _, c := range readRepairEdgeCandidates(r.Path) {
+			cands := readRepairEdgeCandidates(r.Path)
+			for _, c := range cands {
 				if v, ok := c.Context["edge_id"].(string); ok && v == edgeID {
 					target = r
+					candidates = cands
 					break
 				}
 			}
@@ -1546,12 +1553,13 @@ func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.Ca
 		}
 	}
 
-	rf, err := readRepairFile(target.Path)
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
-	}
-	now := time.Now().UTC().Format(time.RFC3339)
-	repair := enrichment.Repair{
+	// ── Trust-model R1-R7 ────────────────────────────────────────────────
+	// Build verify context from the loaded graph document.
+	docEnts, containsParents := buildVerifyContext(target.Doc)
+	edgeIDSet := candidateEdgeIDSet(candidates)
+	fromEntityID := fromEntityIDForEdge(candidates, edgeID)
+
+	repairProposal := enrichment.Repair{
 		EdgeID:         edgeID,
 		Resolution:     resolution,
 		TargetEntityID: targetEntity,
@@ -1562,13 +1570,28 @@ func (s *Server) handleSubmitRepairFromBundle(ctx context.Context, req mcpapi.Ca
 		Confidence:     confidence,
 		Reasoning:      reasoning,
 		Source:         source,
-		ResolvedAt:     now,
 	}
-	rf.Repairs = append(rf.Repairs, repair)
+	if vr := VerifyRepairSubmit(repairProposal, fromEntityID, edgeIDSet, docEnts, containsParents); !vr.OK {
+		return jsonResult(map[string]any{
+			"ok":              false,
+			"rejected_reason": vr.RejectedReason,
+			"residual_id":     edgeID,
+		}), nil
+	}
+	// ── End trust-model ──────────────────────────────────────────────────
+
+	rf, err := readRepairFile(target.Path)
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	repairProposal.ResolvedAt = now
+	rf.Repairs = append(rf.Repairs, repairProposal)
 	if err := writeRepairFile(target.Path, rf); err != nil {
 		return mcpapi.NewToolResultError(err.Error()), nil
 	}
 	return jsonResult(map[string]any{
+		"ok":           true,
 		"residual_id":  edgeID,
 		"repo":         target.Repo,
 		"resolution":   resolution,


### PR DESCRIPTION
## Summary

- Implements trust-model R1-R7 verification inside the MCP `submit_repair` handler (new `VerifyRepairSubmit` function in `internal/mcp/repair_verify.go`)
- Returns structured `rejected_reason` codes when validation fails instead of silently accepting bad repairs
- Adds 12 targeted unit tests covering all 7 rules plus helper functions

## Changes

- `internal/mcp/repair_verify.go` — new file with `VerifyRepairSubmit()`, `buildVerifyContext()`, `candidateEdgeIDSet()`, `fromEntityIDForEdge()`
- `internal/mcp/tools.go` — `handleSubmitRepairFromBundle` now calls verify before writing; returns `{"ok":false,"rejected_reason":"..."}` on any violation
- `internal/mcp/repair_verify_test.go` — 12 tests for R1–R7 + helpers
- `internal/mcp/server_test.go` — fixed existing `TestRepairToolsRoundTrip` to include reasoning on the `abandon` repair (R7 now enforced at submit time)

## Test plan

- [x] `go test ./internal/mcp/... -run TestVerifyRepairSubmit` — all 12 new tests pass
- [x] `go test ./internal/mcp/... -run TestRepairToolsRoundTrip` — existing round-trip passes with reasoning fix
- [x] `go test ./...` — full suite green

Closes #546

🤖 Generated with [Claude Code](https://claude.com/claude-code)