### PR TITLE
[#548] ADR-0015 #5/8 — stale-repair detection via archigraph_repairs(include_stale=true)

### DIFF
--- a/internal/enrichment/repair_apply.go
+++ b/internal/enrichment/repair_apply.go
@@ -453,6 +453,24 @@ func buildContainsParents(doc *graph.Document) map[string]map[string]bool {
 	return out
 }
 
+// ReadRepairStats reads repair_stats.json from the archigraph dir. Returns
+// a zero-value RepairStats (with nil slices) if the file is absent — callers
+// can distinguish "no stats yet" from "zero stale" via the zero-value check.
+func ReadRepairStats(archigraphDir string) (RepairStats, error) {
+	data, err := os.ReadFile(repairStatsPath(archigraphDir))
+	if err != nil {
+		if os.IsNotExist(err) {
+			return RepairStats{}, nil
+		}
+		return RepairStats{}, err
+	}
+	var s RepairStats
+	if err := json.Unmarshal(data, &s); err != nil {
+		return RepairStats{}, fmt.Errorf("parse repair_stats.json: %w", err)
+	}
+	return s, nil
+}
+
 // WriteRepairStats writes repair_stats.json to the archigraph dir.
 // Always-emit-on-read so audit history is preserved even when no repairs
 // applied. The on-disk bytes are stable across runs of the same input

--- a/internal/enrichment/repair_apply_test.go
+++ b/internal/enrichment/repair_apply_test.go
@@ -408,6 +408,66 @@ func TestReadRepairs_Absent(t *testing.T) {
 	}
 }
 
+// ReadRepairStats round-trip from disk.
+func TestReadRepairStats_RoundTrip(t *testing.T) {
+	tmp := t.TempDir()
+	stats := RepairStats{
+		SchemaVersion: 1,
+		Applied:       []RepairAppliedRecord{{EdgeID: "er:aaa", Resolution: "bind_to_entity"}},
+		Stale:         []RepairStaleRecord{{EdgeID: "er:bbb", Resolution: "abandon", ResolvedAt: "2026-05-19T07:00:00Z"}},
+		AppliedCount:  1,
+		StaleCount:    1,
+	}
+	if err := WriteRepairStats(tmp, stats); err != nil {
+		t.Fatal(err)
+	}
+	got, err := ReadRepairStats(tmp)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.AppliedCount != 1 || got.StaleCount != 1 {
+		t.Fatalf("got=%+v", got)
+	}
+	if len(got.Stale) != 1 || got.Stale[0].EdgeID != "er:bbb" {
+		t.Fatalf("stale=%+v", got.Stale)
+	}
+}
+
+// ReadRepairStats returns a zero-value when the file is absent.
+func TestReadRepairStats_Absent(t *testing.T) {
+	tmp := t.TempDir()
+	got, err := ReadRepairStats(tmp)
+	if err != nil {
+		t.Fatalf("error on absent file: %v", err)
+	}
+	if got.AppliedCount != 0 || got.StaleCount != 0 {
+		t.Fatalf("non-zero stats on absent file: %+v", got)
+	}
+}
+
+// ApplyRepairs stale detection — repair whose edge_id is not in the
+// current relationship walk is recorded as stale, not applied.
+func TestApplyRepairs_StaleViaEdgeIDMismatch(t *testing.T) {
+	doc := mkRepairDoc()
+	// The repair references an edge_id that does not match any current edge.
+	staleID := "er:aaaa0000000000ff"
+	stats := ApplyRepairs(doc, []Repair{{
+		EdgeID:         staleID,
+		Resolution:     RepairBindToEntity,
+		TargetEntityID: "bbbbbbbbbbbbbbbb",
+		Reasoning:      "stale repair — source moved",
+		ResolvedAt:     "2026-05-18T00:00:00Z",
+	}}, ApplyRepairsOptions{})
+	if stats.AppliedCount != 0 {
+		t.Fatalf("stale repair was applied")
+	}
+	if stats.StaleCount != 1 || stats.Stale[0].EdgeID != staleID {
+		t.Fatalf("stale=%+v", stats.Stale)
+	}
+	// Stale repair does NOT delete itself from repair.json — that is up to
+	// the operator/agent. This test validates only the in-memory stats.
+}
+
 // WriteRepairStats writes a valid JSON document with sorted slices.
 func TestWriteRepairStats_Deterministic(t *testing.T) {
 	tmp := t.TempDir()

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -282,6 +282,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("(list) Repos to scope.")),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(20), mcpapi.Description("(list) Max residuals returned.")),
 		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0), mcpapi.Description("(list) Pagination offset.")),
+		mcpapi.WithBoolean("include_stale", mcpapi.DefaultBool(false), mcpapi.Description("(list) When true, return stale repairs from repair_stats.json instead of active residuals. Stale repairs are repairs whose edge_id no longer matches any current candidate — the source moved since the repair was submitted.")),
 		// submit args
 		mcpapi.WithString("residual_id", mcpapi.Description("(submit) er:<hex16> identifier from action=list.")),
 		mcpapi.WithString("resolution", mcpapi.Description("(submit) bind_to_entity|reclassify_as_external|reclassify_as_dynamic|reclassify_as_resolved|abandon")),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -979,6 +979,102 @@ func TestInspect_AgentResolvedEdges(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// Stale-repair detection tests (ADR-0015 #5/8 — issue #548)
+// ---------------------------------------------------------------------------
+
+// TestListResiduals_IncludeStale verifies that action=list with include_stale=true
+// returns stale repairs from repair_stats.json.
+func TestListResiduals_IncludeStale(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "rA")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, fixtureDoc("rA"))
+
+	// Write a repair_stats.json with two stale entries.
+	archDir := filepath.Join(repo, ".archigraph")
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	statsData, _ := json.Marshal(map[string]any{
+		"schema_version": 1,
+		"applied":        []any{},
+		"rejected":       []any{},
+		"stale": []any{
+			map[string]any{"edge_id": "er:stale0000000001", "resolution": "bind_to_entity", "resolved_at": "2026-05-19T07:00:00Z"},
+			map[string]any{"edge_id": "er:stale0000000002", "resolution": "abandon", "resolved_at": "2026-05-20T08:00:00Z"},
+		},
+		"applied_count": 0, "rejected_count": 0, "stale_count": 2,
+	})
+	if err := os.WriteFile(filepath.Join(archDir, "repair_stats.json"), statsData, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"rA": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Without include_stale the stale list is not returned.
+	res := callTool(t, srv, "archigraph_repairs", map[string]any{"action": "list"})
+	if res.IsError {
+		t.Fatalf("list error: %s", resultText(res))
+	}
+	if strings.Contains(resultText(res), "er:stale0000000001") {
+		t.Fatalf("stale entries should not appear in normal list: %s", resultText(res))
+	}
+
+	// With include_stale=true stale entries appear.
+	staleRes := callTool(t, srv, "archigraph_repairs", map[string]any{"action": "list", "include_stale": true})
+	if staleRes.IsError {
+		t.Fatalf("stale list error: %s", resultText(staleRes))
+	}
+	text := resultText(staleRes)
+	if !strings.Contains(text, "er:stale0000000001") {
+		t.Fatalf("stale entry 1 missing: %s", text)
+	}
+	if !strings.Contains(text, "er:stale0000000002") {
+		t.Fatalf("stale entry 2 missing: %s", text)
+	}
+	var out struct {
+		Stale []map[string]any `json:"stale"`
+		Total int              `json:"total"`
+	}
+	if err := json.Unmarshal([]byte(text), &out); err != nil {
+		t.Fatalf("unmarshal: %v: %s", err, text)
+	}
+	if out.Total != 2 || len(out.Stale) != 2 {
+		t.Fatalf("expected 2 stale, got total=%d len=%d", out.Total, len(out.Stale))
+	}
+	// Each stale entry carries the stale=true flag.
+	for _, s := range out.Stale {
+		if v, ok := s["stale"].(bool); !ok || !v {
+			t.Fatalf("stale flag missing or false: %v", s)
+		}
+	}
+
+	// Pagination: limit=1 offset=1 returns only the second stale entry.
+	pagedRes := callTool(t, srv, "archigraph_repairs", map[string]any{
+		"action":        "list",
+		"include_stale": true,
+		"limit":         1,
+		"offset":        1,
+	})
+	if pagedRes.IsError {
+		t.Fatalf("paged stale error: %s", resultText(pagedRes))
+	}
+	pagedText := resultText(pagedRes)
+	if !strings.Contains(pagedText, "er:stale0000000002") {
+		t.Fatalf("paged stale should contain entry 2: %s", pagedText)
+	}
+	if strings.Contains(pagedText, "er:stale0000000001") {
+		t.Fatalf("paged stale should NOT contain entry 1: %s", pagedText)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // archigraph_patterns tests (ADR-0018 β)
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/enrichment"
 	"github.com/cajasmota/archigraph/internal/graph"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
@@ -1271,8 +1272,13 @@ func (s *Server) handleGetTelemetry(ctx context.Context, req mcpapi.CallToolRequ
 // ---------------------------------------------------------------------------
 
 // handleListResiduals returns paginated repair_edge enrichment candidates
-// across the resolved group's repos. Filters: repo_filter, since (ignored
-// for v1 — candidate file has no per-row timestamp), limit, offset.
+// across the resolved group's repos. Filters: repo_filter, limit, offset.
+//
+// When include_stale=true the response lists stale repairs from
+// repair_stats.json (repairs whose edge_id no longer matches any current
+// candidate) instead of active residuals. Stale entries carry enough context
+// for the agent to re-submit: edge_id, resolution, resolved_at, repo.
+// (ADR-0015 #5/8 — issue #548)
 func (s *Server) handleListResiduals(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
@@ -1287,6 +1293,11 @@ func (s *Server) handleListResiduals(ctx context.Context, req mcpapi.CallToolReq
 		offset = 0
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	includeStale := argBool(req, "include_stale", false)
+	if includeStale {
+		return s.handleListStaleRepairs(repos, limit, offset)
+	}
 
 	// Collect first, then page. The candidate file is bounded per repo
 	// (max 8 candidates per ambiguous name) so flattening is cheap.
@@ -1314,6 +1325,49 @@ func (s *Server) handleListResiduals(ctx context.Context, req mcpapi.CallToolReq
 		"total":     total,
 		"offset":    offset,
 		"limit":     limit,
+	}), nil
+}
+
+// handleListStaleRepairs reads repair_stats.json for each repo and aggregates
+// the stale[] entries into a paginated response. Stale repairs are ones whose
+// edge_id no longer matches any current repair_edge candidate — the source
+// moved between index runs and the repair must be re-submitted.
+func (s *Server) handleListStaleRepairs(repos []*LoadedRepo, limit, offset int) (*mcpapi.CallToolResult, error) {
+	all := make([]map[string]any, 0, 32)
+	for _, r := range repos {
+		stats, err := enrichment.ReadRepairStats(daemon.StateDirForRepo(r.Path))
+		if err != nil {
+			continue // missing or malformed stats file — skip silently
+		}
+		for _, st := range stats.Stale {
+			entry := map[string]any{
+				"edge_id":     st.EdgeID,
+				"resolution":  st.Resolution,
+				"resolved_at": st.ResolvedAt,
+				"repo":        r.Repo,
+				"stale":       true,
+			}
+			all = append(all, entry)
+		}
+	}
+	total := len(all)
+	if offset >= total {
+		return jsonResult(map[string]any{
+			"stale":  []map[string]any{},
+			"total":  total,
+			"offset": offset,
+			"limit":  limit,
+		}), nil
+	}
+	end := offset + limit
+	if end > total {
+		end = total
+	}
+	return jsonResult(map[string]any{
+		"stale":  all[offset:end],
+		"total":  total,
+		"offset": offset,
+		"limit":  limit,
 	}), nil
 }
 


### PR DESCRIPTION
## Summary

- Exposes stale repairs through the existing `archigraph_repairs` MCP tool: passing `include_stale=true` returns entries from `repair_stats.json` that were written but not applied on the last index run
- Adds `ReadRepairStats()` to the enrichment package for reading `repair_stats.json` from disk

## Changes

- `internal/enrichment/repair_apply.go` — new `ReadRepairStats(archigraphDir string)` function
- `internal/mcp/tools.go` — `handleListResiduals` checks `include_stale`; new `handleListStaleRepairs()` method reads stats and returns stale entries with pagination
- `internal/mcp/server.go` — registers `include_stale` boolean parameter on the `archigraph_repairs` tool

## Test plan

- [x] `go test ./internal/enrichment/... -run TestReadRepairStats` — stats reader tests pass
- [x] `go test ./internal/mcp/...` — full MCP suite green
- [x] `go test ./...` — full suite green

Closes #548

🤖 Generated with [Claude Code](https://claude.com/claude-code)