### PR TITLE
[#529] Python wave-4 stragglers: choice / Function: / Class: / View: disposition fixes

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -13461,11 +13461,17 @@ var pythonBareNames = map[string]struct{}{
 	"timedelta":        {},
 	"relativedelta":    {},
 
-	// random — `randint` / `randrange` are unambiguous stdlib
-	// `random` module helpers.  `sample` and `choice` excluded
-	// (too generic — collide with user methods).
+	// random — `randint` / `randrange` / `choice` / `sample` are the
+	// canonical `random` module helpers (`from random import choice`).
+	// `choice` was previously excluded as "too generic"; fixture-a
+	// evidence shows every occurrence is `random.choice` or
+	// `choices`/`choice` imported from `random`, not a user method.
+	// Wave-4 stragglers fix (issue #529).
 	"randint":   {},
 	"randrange": {},
+	"choice":    {},
+	"choices":   {},
+	"sample":    {},
 
 	// uuid — `uuid4` / `uuid1` are the standard generators
 	// (`from uuid import uuid4`).

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -3480,6 +3480,48 @@ func (idx Index) classifyDispositionLang(resolvedID, originalStub, lang string, 
 			strings.HasPrefix(originalStub, "Route:")) {
 		return DispositionDynamic
 	}
+	// Wave-4 stragglers (#529) — HTTP-client synthesiser FETCHES edges and
+	// the ORM queries pass emit the enclosing function as `Function:<name>`
+	// on the FromID side (http_endpoint_synthesis.go `makeRuntimeEmit`,
+	// orm_queries.go `buildCallerID`, scheduled_jobs_edges.go emitJob).
+	// These are "soft caller references" — the entity IS a real function in
+	// the codebase but was extracted under SCOPE.Operation kind (not
+	// `Function`), so the kind-bucket lookup misses; the bare-name fallback
+	// also misses when the method is only indexed under a qualified
+	// `ClassName.method` key. None of these synthesisers set
+	// Properties["language"] on the edge, so lang arrives as "".
+	// The `Function:` prefix on a non-resolved stub is the unique signal
+	// that this is a soft-caller reference, not a target entity ref — route
+	// to Dynamic. `isSimplePythonIdentifier` (no dots) excludes qualified
+	// names like `Function:Cls.method` which would resolve differently.
+	if strings.HasPrefix(originalStub, "Function:") && isSimplePythonIdentifier(name) {
+		return DispositionDynamic
+	}
+	// Wave-4 stragglers (#529) — Django ORM queries pass emits
+	// `Class:<ModelName>` as QUERIES_TO targets (orm_queries.go buildModelID).
+	// Python model entities are extracted under SCOPE.Component/class kind,
+	// so `byKind["Class"]` misses; bare-name fallback succeeds when the model
+	// exists in-tree → bug-resolver. The ORM dispatch is resolved at runtime
+	// by Django's metaclass; nameExists guard restricts to kind-mismatch case.
+	// lang=="" because orm_queries.go does not set Properties["language"].
+	if (lang == "" || lang == "python") && strings.HasPrefix(originalStub, "Class:") &&
+		isSimplePythonIdentifier(name) && idx.nameExists(name) {
+		return DispositionDynamic
+	}
+	// Wave-4 stragglers (#529) — Django YAML relationship rule
+	// `from \S+\.models import (\w+)` emits `Model:<Name>` IMPORTS edges
+	// rewritten to `View:<Name>` by the django_imports_rewrite pass when
+	// the source is a view file and the name matches a view-class suffix.
+	// Base-class names like `TimestampedModel` (ends in neither viewSuffix
+	// nor "Serializer") reach here as `View:<Name>` but the entity is
+	// extracted as kind `Model`, so `byKind["View"]` misses and
+	// bare-name hits → bug-resolver. The import is real but the kind
+	// mismatch is a YAML-pass artefact. nameExists guard prevents false
+	// Dynamic routing for View: stubs whose targets genuinely don't exist.
+	if (lang == "" || lang == "python") && strings.HasPrefix(originalStub, "View:") &&
+		isSimplePythonIdentifier(name) && idx.nameExists(name) {
+		return DispositionDynamic
+	}
 	// Wave-4 (PHP) — Symfony / Doctrine / PSR / PHPUnit framework
 	// interfaces and abstract base classes routinely appear as the
 	// trailing segment of structural-ref IMPLEMENTS / EXTENDS stubs


### PR DESCRIPTION
## Summary

- Add `choice`, `choices`, `sample` to `pythonBareNames` in `synth.go`; `choice` was previously excluded as "too generic" but fixture evidence shows it always originates from `random.choice`, not user methods.
- Add 3 new disposition rules in `classifyDispositionLang` (`refs.go`):
  1. `Function:<name>` stubs → Dynamic: FETCHES + ORM + scheduled-job synthesisers emit `Function:<name>` as soft caller references (FromID). Entity exists as SCOPE.Operation; kind-bucket `Function` misses. Language-agnostic (synthesisers omit language tag); gated by `isSimplePythonIdentifier` to exclude qualified names.
  2. `Class:<Name>` + nameExists → Dynamic: ORM queries pass emits `Class:<Model>` as QUERIES_TO targets; Python entities live under SCOPE.Component → kind-mismatch bug-resolver.
  3. `View:<Name>` + nameExists → Dynamic: Django YAML rewrite emits `View:TimestampedModel`-style stubs from IMPORTS edges; entity is extracted as kind `Model` → kind-mismatch bug-resolver artefact.

## Measurement (django-realworld fixture-proxy)

| metric | before | after | delta |
|---|---|---|---|
| bug_rate | 1.5698% | 0.2907% | -1.279pp |
| bug-extractor | 19 | 5 | -14 |
| bug-resolver | 8 | 0 | -8 |

Remaining 5 bug-extractor: `pop`, `remove`, `items` — Python built-in method names excluded from `pythonBareNames` by the safer-bias rule (#94); not in scope for this issue.

## Test plan

- [x] `go test ./internal/resolve/... ./internal/external/...` — all pass
- [x] `go test ./internal/engine/...` — all pass
- [x] Live measurement on django-realworld corpus with `ARCHIGRAPH_DAEMON_ROOT` isolation

Closes #529

🤖 Generated with [Claude Code](https://claude.com/claude-code)