### PR TITLE
[#557] Python extractor: bind PascalCase bare-identifier receivers to class methods

### DIFF
--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -641,8 +641,22 @@ func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
 	}
 	switch recv.Type() {
 	case "identifier":
-		if nodeText(recv, src) == "self" {
+		text := nodeText(recv, src)
+		if text == "self" || text == "cls" {
 			return parentClass
+		}
+		// Issue #557 — bare PascalCase/CamelCase identifier as receiver, e.g.
+		// `User.save(...)`, `Article.objects.create(...)`.  Python convention
+		// reserves TitleCase identifiers for class names (PEP 8).  When the
+		// first rune is uppercase we treat the identifier as a class-name
+		// reference and qualify the call site: `User.save` instead of the bare
+		// ambiguous `save`. This is intentionally conservative — all-lowercase
+		// identifiers (module aliases, instance variables) are left unresolved
+		// so we never bind to the wrong class.  SCREAMING_SNAKE constants are
+		// also excluded because their first rune is uppercase but they are
+		// clearly not class names (e.g. `ALLOWED_HOSTS.append`).
+		if isPascalCaseClassName(text) {
+			return text
 		}
 		return ""
 	case "call":
@@ -661,6 +675,37 @@ func receiverClass(recv *sitter.Node, src []byte, parentClass string) string {
 		}
 	}
 	return ""
+}
+
+// isPascalCaseClassName reports whether name looks like a Python class name
+// by PEP 8 convention: starts with an uppercase letter and contains at least
+// one lowercase letter (to exclude SCREAMING_SNAKE_CASE constants and single
+// uppercase letters used as type variables). Examples:
+//
+//	User            → true   (class name)
+//	ArticleManager  → true   (class name)
+//	BaseViewSet     → true   (class name)
+//	user            → false  (instance variable / module alias)
+//	ALLOWED_HOSTS   → false  (module-level constant)
+//	T               → false  (single-letter type variable)
+func isPascalCaseClassName(name string) bool {
+	if name == "" {
+		return false
+	}
+	first := rune(name[0])
+	if first < 'A' || first > 'Z' {
+		return false
+	}
+	// Must contain at least one lowercase letter so that SCREAMING_SNAKE and
+	// single-uppercase-letter type vars are excluded.
+	hasLower := false
+	for _, r := range name[1:] {
+		if r >= 'a' && r <= 'z' {
+			hasLower = true
+			break
+		}
+	}
+	return hasLower
 }
 
 // extractImports walks the parse tree for top-level Python import statements

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -1455,6 +1455,59 @@ class Mailer:
 	}
 }
 
+// TestPascalCaseReceiverCALLSEdges verifies that bare PascalCase identifier
+// receivers (e.g. `User.save(...)`) produce qualified CALLS edges
+// `User.save` instead of an ambiguous bare `save`. Regression test for
+// issue #557: Python dotted-receiver class member binding.
+func TestPascalCaseReceiverCALLSEdges(t *testing.T) {
+	src := `
+def create_user():
+    User.objects.create(username="alice")
+    User.save(obj)
+    Article.objects.filter(title="foo")
+    lower_case_var.some_method()
+    ALLOWED_HOSTS.append("example.com")
+`
+	tree := parse(t, []byte(src))
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+
+	// Collect all CALLS ToIDs across all entities.
+	calledTargets := map[string]bool{}
+	for _, e := range entities {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" {
+				calledTargets[r.ToID] = true
+			}
+		}
+	}
+
+	// Qualified CALLS edges expected (PascalCase receiver → class name prefix).
+	// Note: chained `User.objects.create` — the receiver is `User.objects`
+	// which is an attribute access, not a plain identifier, so `create` stays
+	// bare-ambiguous. `User.save` has a plain identifier receiver `User`.
+	wantQualified := "User.save"
+	if !calledTargets[wantQualified] {
+		t.Errorf("expected qualified CALLS edge %q; got targets: %v", wantQualified, calledTargets)
+	}
+
+	// Lower-case receiver (`lower_case_var`) must NOT produce a qualified edge.
+	if calledTargets["lower_case_var.some_method"] {
+		t.Errorf("should not produce qualified edge for lowercase receiver lower_case_var")
+	}
+
+	// SCREAMING_SNAKE receiver (`ALLOWED_HOSTS`) must NOT produce a qualified edge.
+	if calledTargets["ALLOWED_HOSTS.append"] {
+		t.Errorf("should not produce qualified edge for SCREAMING_SNAKE receiver ALLOWED_HOSTS")
+	}
+}
+
 // entityNames returns entity names for test diagnostics.
 func entityNames(entities []types.EntityRecord) []string {
 	names := make([]string, len(entities))


### PR DESCRIPTION
## Summary

- `receiverClass()` now recognises bare PascalCase identifiers as class-name receivers (PEP 8 convention). `User.save(obj)` → CALLS edge `User.save` instead of ambiguous bare `save`.
- New helper `isPascalCaseClassName()`: starts with uppercase + has at least one lowercase letter. Excludes SCREAMING_SNAKE constants and single-letter type vars.
- Also adds `cls` → `parentClass` alongside the existing `self` → `parentClass` handling.

## What changes

| Before | After |
|---|---|
| `User.save(obj)` → bare `save` (ambiguous) | `User.save(obj)` → qualified `User.save` |
| `User.objects.create(...)` → bare `create` (ambiguous) | unchanged — chain receiver stays ambiguous |
| `lower_case_var.method()` → bare `method` (ambiguous) | unchanged — lowercase stays ambiguous |
| `ALLOWED_HOSTS.append(...)` → bare `append` (ambiguous) | unchanged — SCREAMING_SNAKE excluded |

## Test plan

- [x] `TestPascalCaseReceiverCALLSEdges` added to `extractor_test.go` — covers PascalCase resolution + lowercase non-qualification + SCREAMING_SNAKE non-qualification
- [x] `go test ./internal/extractors/python/...` — all pass (including all existing tests)
- [x] Live measurement on django-realworld: no regression (resolved=1180 unchanged, baseline maintained)

Closes #557

🤖 Generated with [Claude Code](https://claude.com/claude-code)