### PR TITLE
Fix ThemeToggle icon and populate docs-tree repos

### DIFF
--- a/dashboard/src/api/mocks/docs-tree.json
+++ b/dashboard/src/api/mocks/docs-tree.json
@@ -1,4 +1,9 @@
 {
+  "repos": [
+    { "slug": "acme-web", "display_name": "ACME Web" },
+    { "slug": "acme-api", "display_name": "ACME API" },
+    { "slug": "acme-workers", "display_name": "ACME Workers" }
+  ],
   "tree": [
     {
       "type": "group",

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -1,4 +1,5 @@
 import { Link, NavLink, Outlet, useParams } from 'react-router-dom'
+import { useState, useEffect } from 'react'
 import {
   GitBranch, Network, Workflow, Radio, Globe, BookOpen,
   Moon, Sun, Settings,
@@ -97,10 +98,27 @@ function NavItem({ to, icon, label }: NavItemProps) {
 }
 
 function ThemeToggle() {
-  // Simple dark/light toggle — persists to localStorage + toggles .dark on <html>
-  const isDark =
-    typeof document !== 'undefined' &&
-    document.documentElement.classList.contains('dark')
+  // Use state to subscribe to theme changes + DOM class mutations.
+  // Persists to localStorage + toggles .dark on <html>.
+  const [isDark, setIsDark] = useState(() => {
+    if (typeof document === 'undefined') return false
+    return document.documentElement.classList.contains('dark')
+  })
+
+  useEffect(() => {
+    // Listen for changes to the .dark class on the document element
+    const observer = new MutationObserver(() => {
+      const newIsDark = document.documentElement.classList.contains('dark')
+      setIsDark(newIsDark)
+    })
+
+    observer.observe(document.documentElement, {
+      attributes: true,
+      attributeFilter: ['class'],
+    })
+
+    return () => observer.disconnect()
+  }, [])
 
   const toggle = () => {
     const html = document.documentElement
@@ -111,6 +129,8 @@ function ThemeToggle() {
       html.classList.add('dark')
       localStorage.setItem('theme', 'dark')
     }
+    // Update local state to trigger re-render
+    setIsDark(html.classList.contains('dark'))
   }
 
   return (

--- a/dashboard/src/types/docs.ts
+++ b/dashboard/src/types/docs.ts
@@ -24,6 +24,12 @@ export type DocTreeNode = DocTreeFile | DocTreeGroup
 export interface DocTreeResponse {
   tree: DocTreeNode[]
   recentFiles: DocTreeFile[]
+  repos: RepoMetadata[]
+}
+
+export interface RepoMetadata {
+  slug: string
+  display_name: string
 }
 
 // ────────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Fixed two frontend bugs in the m2 dashboard:

- **#864**: ThemeToggle was reading isDark from the DOM at render time only and never re-rendering. Now uses React state with MutationObserver to subscribe to class changes, ensuring the icon updates on every toggle.
- **#865**: docs-tree.json mock had an empty repos array, causing empty-state branches to trigger. Now populated with the 3 repo groups that the tree structure implies.

## Test Results

✅ Vite build succeeded
✅ Unit tests pass (1 pre-existing failure in ChainStep test unrelated to these changes)
✅ Playwright verification:
- Docs tree displays all 3 repo groups (ACME Web, ACME API, ACME Workers) — no empty state
- ThemeToggle icon updates on each click in both light and dark modes

Screenshots: docs/mockups/m2-smoke-test-2026-05-20-polish/

Closes #864 Closes #865