### PR TITLE
[#615 #616] Rust: qualify impl fn names + dyn receiver dispatch

### DIFF
--- a/internal/extractors/rust/relationships_test.go
+++ b/internal/extractors/rust/relationships_test.go
@@ -80,7 +80,9 @@ impl Foo {
 	}
 	// Issue #144 — CONTAINS targets are structural-ref stubs (Format A)
 	// keyed on the source file so impl→method edges disambiguate by location.
-	for _, m := range []string{"a", "b", "c"} {
+	// Issue #615 — impl method names are now qualified as "Foo.a", so the
+	// structural ref is "scope:operation:method:rust:test.rs:Foo.a".
+	for _, m := range []string{"Foo.a", "Foo.b", "Foo.c"} {
 		want := "scope:operation:method:rust:test.rs:" + m
 		found := false
 		for _, r := range impl.Relationships {

--- a/internal/extractors/rust/rust.go
+++ b/internal/extractors/rust/rust.go
@@ -115,12 +115,28 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 			return
 		}
 		implIdx := len(*out)
+		implName := rec.Name
 		*out = append(*out, rec)
 		body := findRustDeclList(node)
 		if body != nil {
 			before := len(*out)
 			for i := range body.ChildCount() {
-				walk(body.Child(int(i)), file, out)
+				ch := body.Child(int(i))
+				if ch.Type() == "function_item" {
+					// Issue #615 — emit impl methods qualified as "TypeName.fnName"
+					// so they are traceable back to their owner type.
+					if fnRec, ok2 := buildOperation(ch, file); ok2 {
+						paramTypes := collectRustParamTypes(ch, file.Content)
+						// Issue #616 — resolve self.method() and dyn-param calls.
+						fnRec.Relationships = append(fnRec.Relationships,
+							extractCallRelationships(ch.ChildByFieldName("body"), file.Content, fnRec.Name, implName, paramTypes)...)
+						// Qualify the name with the impl type owner.
+						fnRec.Name = implName + "." + fnRec.Name
+						*out = append(*out, fnRec)
+					}
+				} else {
+					walk(ch, file, out)
+				}
 			}
 			after := len(*out)
 			for k := before; k < after; k++ {
@@ -131,6 +147,7 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 				// Issue #144 — structural-ref (Format A) keyed on file path
 				// so impl→method CONTAINS edges disambiguate when two files
 				// each define an `impl Foo { fn new() }` shape.
+				// Use the already-qualified name (e.g. "Foo.bar") for the ref.
 				toID := extractor.BuildOperationStructuralRef("rust", file.Path, child.Name)
 				(*out)[implIdx].Relationships = append((*out)[implIdx].Relationships,
 					types.RelationshipRecord{
@@ -143,8 +160,9 @@ func walk(node *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord
 
 	case "function_item":
 		if rec, ok := buildOperation(node, file); ok {
+			paramTypes := collectRustParamTypes(node, file.Content)
 			rec.Relationships = append(rec.Relationships,
-				extractCallRelationships(node.ChildByFieldName("body"), file.Content, rec.Name)...)
+				extractCallRelationships(node.ChildByFieldName("body"), file.Content, rec.Name, "", paramTypes)...)
 			*out = append(*out, rec)
 		}
 		return
@@ -176,7 +194,12 @@ func findRustDeclList(node *sitter.Node) *sitter.Node {
 // call_expression / macro_invocation descendant of body. Targets resolve to
 // the rightmost identifier in the function expression; FromID is left empty
 // so buildDocument substitutes the caller's entity ID at emit time.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName string) []types.RelationshipRecord {
+//
+// Issue #616 — ownerName is the impl type this function belongs to (e.g.
+// "Foo"); it enables `self.method()` calls to resolve to "Foo.method".
+// paramTypes maps parameter names to their declared types so that calls
+// through typed receivers (e.g. `r: &dyn Repo`) resolve to "Repo.method".
+func extractCallRelationships(body *sitter.Node, src []byte, callerName, ownerName string, paramTypes map[string]string) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -187,7 +210,7 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 	seen := make(map[string]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
-		target := rustCallTarget(call, src)
+		target := rustCallTarget(call, src, ownerName, paramTypes)
 		if target == "" || target == callerName {
 			continue
 		}
@@ -206,7 +229,11 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName string) 
 // rustCallTarget resolves the callee identifier from a Rust call_expression
 // or macro_invocation. For call_expression the function is the first child;
 // for scoped_identifier / field_expression we use the rightmost identifier.
-func rustCallTarget(call *sitter.Node, src []byte) string {
+//
+// Issue #616 — ownerName and paramTypes enable receiver-qualified targets:
+//   - "self.method()" inside impl Foo → "Foo.method"
+//   - "repo.find()" where repo: &dyn Repo → "Repo.find"
+func rustCallTarget(call *sitter.Node, src []byte, ownerName string, paramTypes map[string]string) string {
 	switch call.Type() {
 	case "call_expression":
 		fn := call.ChildByFieldName("function")
@@ -224,9 +251,27 @@ func rustCallTarget(call *sitter.Node, src []byte) string {
 				return string(src[name.StartByte():name.EndByte()])
 			}
 		case "field_expression":
+			method := ""
 			if name := fn.ChildByFieldName("field"); name != nil {
-				return string(src[name.StartByte():name.EndByte()])
+				method = string(src[name.StartByte():name.EndByte()])
 			}
+			if method == "" {
+				return ""
+			}
+			// Issue #616 — resolve receiver type for self and typed params.
+			recv := ""
+			if value := fn.ChildByFieldName("value"); value != nil {
+				recv = string(src[value.StartByte():value.EndByte()])
+			}
+			if recv == "self" && ownerName != "" {
+				return ownerName + "." + method
+			}
+			if recv != "" && len(paramTypes) > 0 {
+				if recvType, ok := paramTypes[recv]; ok && recvType != "" {
+					return recvType + "." + method
+				}
+			}
+			return method
 		case "generic_function":
 			if path := fn.ChildByFieldName("function"); path != nil {
 				switch path.Type() {
@@ -257,6 +302,71 @@ func rustCallTarget(call *sitter.Node, src []byte) string {
 		}
 	}
 	return ""
+}
+
+// collectRustParamTypes scans a function_item node's parameters child and
+// returns a map of parameter-name → declared leaf type. Type references are
+// normalised by stripping leading `&`, `&mut`, `Box<dyn `, `dyn `, `Arc<`,
+// `Rc<`, and trailing `>` so that `r: &dyn Repo` → {"r": "Repo"}.
+//
+// Issue #616 — used by extractCallRelationships to qualify dyn-receiver
+// CALLS edges (e.g. `r.find(1)` → "Repo.find").
+func collectRustParamTypes(node *sitter.Node, src []byte) map[string]string {
+	out := map[string]string{}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() != "parameters" {
+			continue
+		}
+		for j := 0; j < int(ch.ChildCount()); j++ {
+			p := ch.Child(j)
+			if p.Type() != "parameter" {
+				continue
+			}
+			nameNode := p.ChildByFieldName("pattern")
+			typeNode := p.ChildByFieldName("type")
+			if nameNode == nil || typeNode == nil {
+				continue
+			}
+			name := string(src[nameNode.StartByte():nameNode.EndByte()])
+			if name == "self" || name == "&self" || name == "&mut self" {
+				continue
+			}
+			typ := string(src[typeNode.StartByte():typeNode.EndByte()])
+			typ = normalizeRustType(typ)
+			if name != "" && typ != "" {
+				out[name] = typ
+			}
+		}
+		break
+	}
+	return out
+}
+
+// normalizeRustType strips common Rust type wrappers to extract the bare
+// type name for receiver binding. Examples:
+//
+//	"&dyn Repo"        → "Repo"
+//	"Box<dyn Repo>"    → "Repo"
+//	"Arc<MyService>"   → "MyService"
+//	"&mut Writer"      → "Writer"
+func normalizeRustType(typ string) string {
+	// Strip leading reference/mut.
+	for _, prefix := range []string{"&mut ", "&"} {
+		if strings.HasPrefix(typ, prefix) {
+			typ = strings.TrimPrefix(typ, prefix)
+			break
+		}
+	}
+	// Strip wrapper types.
+	for _, wrap := range []string{"Box<dyn ", "Box<", "Arc<dyn ", "Arc<", "Rc<dyn ", "Rc<", "dyn "} {
+		if strings.HasPrefix(typ, wrap) {
+			typ = strings.TrimPrefix(typ, wrap)
+			typ = strings.TrimSuffix(typ, ">")
+			break
+		}
+	}
+	return strings.TrimSpace(typ)
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.

--- a/internal/extractors/rust/rust_test.go
+++ b/internal/extractors/rust/rust_test.go
@@ -2,6 +2,7 @@ package rust_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -427,6 +428,225 @@ func TestRustExtractor_ImportRootOnly(t *testing.T) {
 	}
 	if foundToID != "tokio" {
 		t.Fatalf("root-only `use tokio;` should emit IMPORTS ToID=%q, got %q", "tokio", foundToID)
+	}
+}
+
+// Issue #615 — fn names inside impl blocks must be qualified as "TypeName.fnName".
+func TestRustExtractor_ImplFnQualified(t *testing.T) {
+	src := `
+struct Foo {}
+impl Foo {
+    fn bar(&self) {}
+    fn new() -> Foo { Foo {} }
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "foo.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundBar, foundNew bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "Foo.bar" {
+			foundBar = true
+		}
+		if e.Kind == "SCOPE.Operation" && e.Name == "Foo.new" {
+			foundNew = true
+		}
+		// Bare names must NOT appear as SCOPE.Operation.
+		if e.Kind == "SCOPE.Operation" && (e.Name == "bar" || e.Name == "new") {
+			t.Errorf("bare function name %q leaked — should be qualified as Foo.bar/Foo.new", e.Name)
+		}
+	}
+	if !foundBar {
+		t.Error("expected SCOPE.Operation Name=Foo.bar")
+	}
+	if !foundNew {
+		t.Error("expected SCOPE.Operation Name=Foo.new")
+	}
+
+	// The Foo impl entity must have CONTAINS edges pointing to qualified refs.
+	for _, e := range got {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "impl" && e.Name == "Foo" {
+			var barRef, newRef bool
+			for _, r := range e.Relationships {
+				if r.Kind == "CONTAINS" && strings.Contains(r.ToID, "Foo.bar") {
+					barRef = true
+				}
+				if r.Kind == "CONTAINS" && strings.Contains(r.ToID, "Foo.new") {
+					newRef = true
+				}
+			}
+			if !barRef {
+				t.Error("Foo impl CONTAINS edge missing ref to Foo.bar")
+			}
+			if !newRef {
+				t.Error("Foo impl CONTAINS edge missing ref to Foo.new")
+			}
+		}
+	}
+}
+
+// Issue #615 — multiple impl blocks must not cross-contaminate names.
+func TestRustExtractor_ImplMultipleTypes(t *testing.T) {
+	src := `
+struct A {}
+struct B {}
+impl A { fn hello(&self) {} }
+impl B { fn world(&self) {} }
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "multi.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundAHello, foundBWorld bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "A.hello" {
+			foundAHello = true
+		}
+		if e.Kind == "SCOPE.Operation" && e.Name == "B.world" {
+			foundBWorld = true
+		}
+		// Bare names must NOT appear.
+		if e.Kind == "SCOPE.Operation" && (e.Name == "hello" || e.Name == "world") {
+			t.Errorf("bare function name %q leaked from impl block", e.Name)
+		}
+	}
+	if !foundAHello {
+		t.Error("expected SCOPE.Operation Name=A.hello")
+	}
+	if !foundBWorld {
+		t.Error("expected SCOPE.Operation Name=B.world")
+	}
+}
+
+// Issue #616 — self.method() inside an impl block should resolve to TypeName.method.
+func TestRustExtractor_DynReceiverSelf(t *testing.T) {
+	src := `
+trait Processor { fn process(&self, x: u32) -> u32; }
+impl Processor for MyImpl {
+    fn process(&self, x: u32) -> u32 {
+        self.transform(x)
+    }
+    fn transform(&self, x: u32) -> u32 { x * 2 }
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "processor.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Find the "MyImpl.process" function entity and check its CALLS edges.
+	var callsTransform bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "MyImpl.process" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && strings.Contains(r.ToID, "transform") {
+					callsTransform = true
+				}
+			}
+		}
+	}
+	if !callsTransform {
+		t.Error("expected MyImpl.process to have a CALLS edge containing 'transform' (should be MyImpl.transform)")
+	}
+}
+
+// Issue #616 — typed dyn-receiver parameter calls should resolve to TraitName.method.
+func TestRustExtractor_DynParamReceiver(t *testing.T) {
+	src := `
+trait Repo { fn find(&self, id: u32) -> u32; }
+fn use_repo(r: &dyn Repo) {
+    r.find(1);
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "repo.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	var foundRepoFind bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "use_repo" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "Repo.find" {
+					foundRepoFind = true
+				}
+			}
+		}
+	}
+	if !foundRepoFind {
+		t.Error("expected use_repo to have CALLS edge with ToID=Repo.find")
+	}
+}
+
+// Issue #615 negative — trait method bodies must NOT be owner-qualified.
+// Only impl methods get the "TypeName." prefix; trait methods remain bare.
+func TestRustExtractor_TraitFnNotQualified(t *testing.T) {
+	src := `
+trait MyTrait {
+    fn method(&self) {}
+}
+`
+	tree := parseForTest(t, src)
+	ext, _ := extractor.Get("rust")
+
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "trait.rs",
+		Content:  []byte(src),
+		Language: "rust",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "MyTrait.method" {
+			t.Error("trait method should NOT be qualified — expected Name=method, got MyTrait.method")
+		}
+	}
+	var foundBare bool
+	for _, e := range got {
+		if e.Kind == "SCOPE.Operation" && e.Name == "method" {
+			foundBare = true
+		}
+	}
+	if !foundBare {
+		t.Error("expected trait method Name=method (bare, unqualified)")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Qualify \`fn\` names inside \`impl\` blocks as \`TypeName.fn_name\` so methods are traceable back to their owner type (#615). Trait methods remain bare.
- Resolve \`self.method()\` calls inside impl blocks to \`TypeName.method\` via \`ownerName\` threading (#616)
- Resolve typed dyn-param receiver calls (e.g. \`r: &dyn Repo\` → \`r.find()\`) to \`Repo.find\` via \`collectRustParamTypes()\` + \`normalizeRustType()\` helpers (#616)
- Updated \`TestRust_ContainsImplMethods\` to expect qualified structural refs (\`Foo.a\` instead of bare \`a\`)

## Test plan
- [ ] \`TestRustExtractor_ImplFnQualified\` — impl fn names are owner-qualified (Foo.bar, Foo.new)
- [ ] \`TestRustExtractor_ImplMultipleTypes\` — no bare-name leakage across multiple impl blocks
- [ ] \`TestRustExtractor_DynReceiverSelf\` — self.method() resolves to TypeName.method
- [ ] \`TestRustExtractor_DynParamReceiver\` — dyn-param calls resolve to TraitName.method
- [ ] \`TestRustExtractor_TraitFnNotQualified\` — trait fns remain bare (negative test)
- [ ] All 4 existing Rust relationship/extractor tests still pass

Closes #615 Closes #616

🤖 Generated with [Claude Code](https://claude.com/claude-code)