### PR TITLE
[#749] Django Model.Meta constraints CONTAINS edges — emit SCOPE.Constraint entities

### DIFF
--- a/internal/extractor/structural_ref.go
+++ b/internal/extractor/structural_ref.go
@@ -78,3 +78,18 @@ func BuildSchemaColumnStructuralRef(filePath, table, column string) string {
 func BuildSchemaFieldStructuralRef(lang, filePath, name string) string {
 	return "scope:schema:field:" + lang + ":" + filepath.ToSlash(filePath) + ":" + name
 }
+
+// BuildConstraintStructuralRef returns the canonical Format A structural-ref
+// for parent-class→constraint CONTAINS edges emitted by the Django Meta
+// constraint extractor (issue #749). Shape:
+//
+//	scope:constraint:python:<file>:<ParentClass>.<constraintName>
+//
+// where <file> is forward-slash normalized via filepath.ToSlash. The trailing
+// name segment matches the SCOPE.Constraint entity's Name ("<Parent>.<name>")
+// so the resolver's byLocation fallback binds the stub to the entity ID.
+// "python" is the only producer so the language is hard-coded to avoid
+// accidental cross-language collisions.
+func BuildConstraintStructuralRef(filePath, qualifiedName string) string {
+	return "scope:constraint:python:" + filepath.ToSlash(filePath) + ":" + qualifiedName
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -304,6 +304,14 @@ func walkNode(
 					child := &(*out)[k]
 					if child.Kind == "SCOPE.Component" && child.Subtype == "class" {
 						applyFrameworkInnerClassProperties(&(*out)[classIdx], child, body, file.Content, childParent)
+						// Issue #749 — Django Model.Meta constraints=[UniqueConstraint/
+						// CheckConstraint] emit SCOPE.Constraint entities that were
+						// previously orphaned because no CONTAINS edge linked them to
+						// the parent Model class. Parse the Meta.constraints list and
+						// emit synthetic SCOPE.Constraint entities with CONTAINS edges.
+						// extractMetaConstraintEntities is a no-op for non-Meta inner
+						// classes (Config, etc.) — it re-checks the name internally.
+						extractMetaConstraintEntities(body, file, child.Name, childParent, classIdx, out)
 					}
 				}
 			}
@@ -400,6 +408,9 @@ func walkNode(
 						child := &(*out)[k]
 						if child.Kind == "SCOPE.Component" && child.Subtype == "class" {
 							applyFrameworkInnerClassProperties(&(*out)[classIdx], child, body, file.Content, childParent)
+							// Issue #749 — emit SCOPE.Constraint entities for
+							// Meta.constraints=[UniqueConstraint/CheckConstraint].
+							extractMetaConstraintEntities(body, file, child.Name, childParent, classIdx, out)
 						}
 					}
 				}
@@ -1251,6 +1262,187 @@ func findAll(root *sitter.Node, kind string) []*sitter.Node {
 		}
 	}
 	return out
+}
+
+// extractMetaConstraintEntities parses the `constraints = [...]` assignment
+// inside a Django Model.Meta inner class body and emits a SCOPE.Constraint
+// entity for each UniqueConstraint / CheckConstraint entry that carries a
+// `name=` keyword argument. It also appends CONTAINS relationships from the
+// parent class entity (at index classIdx in *out) to each emitted constraint.
+//
+// Issue #749 — previously these Meta.constraints declarations either produced
+// no entities (when the Meta body was only parsed for properties) or produced
+// orphan Constraint entities (from the SQLAlchemy YAML rule misfiring on Django
+// model files). This function closes the gap by emitting them directly from the
+// Python extractor with proper CONTAINS edges.
+//
+// Parameters:
+//
+//	metaClassBody  — the class body sitter.Node of the enclosing class (not the
+//	                 Meta body itself — we search downward for the Meta assignment)
+//	file           — the source file input
+//	innerClassName — the full dotted name of the Meta inner class (e.g. "Order.Meta")
+//	parentClass    — the name of the enclosing parent class (e.g. "Order")
+//	classIdx       — index of the parent class entity in *out
+//	out            — the shared entity accumulator
+//
+// The function is a no-op when innerClassName does not end in ".Meta" or when
+// no `constraints = [...]` assignment is present in the Meta body.
+func extractMetaConstraintEntities(
+	metaClassBody *sitter.Node,
+	file extractor.FileInput,
+	innerClassName string,
+	parentClass string,
+	classIdx int,
+	out *[]types.EntityRecord,
+) {
+	// Only act on inner classes whose bare name is "Meta".
+	bareName := innerClassName
+	if dot := strings.LastIndexByte(bareName, '.'); dot >= 0 {
+		bareName = bareName[dot+1:]
+	}
+	if bareName != "Meta" {
+		return
+	}
+
+	// Locate the Meta class_definition node inside metaClassBody so we can
+	// walk its body for the `constraints = [...]` assignment.
+	var metaBody *sitter.Node
+	for i := range int(metaClassBody.ChildCount()) {
+		ch := metaClassBody.Child(i)
+		if ch == nil {
+			continue
+		}
+		var candidate *sitter.Node
+		switch ch.Type() {
+		case "class_definition":
+			candidate = ch
+		case "decorated_definition":
+			if inner := ch.ChildByFieldName("definition"); inner != nil && inner.Type() == "class_definition" {
+				candidate = inner
+			}
+		}
+		if candidate == nil {
+			continue
+		}
+		nameNode := candidate.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		if nodeText(nameNode, file.Content) == "Meta" {
+			metaBody = candidate.ChildByFieldName("body")
+			break
+		}
+	}
+	if metaBody == nil {
+		return
+	}
+
+	// Walk the Meta body for `constraints = [...]` assignments.
+	for i := range int(metaBody.ChildCount()) {
+		stmt := metaBody.Child(i)
+		if stmt == nil {
+			continue
+		}
+		if stmt.Type() != "expression_statement" {
+			continue
+		}
+		for j := range int(stmt.NamedChildCount()) {
+			expr := stmt.NamedChild(j)
+			if expr == nil || expr.Type() != "assignment" {
+				continue
+			}
+			lhs := expr.ChildByFieldName("left")
+			rhs := expr.ChildByFieldName("right")
+			if lhs == nil || rhs == nil {
+				continue
+			}
+			if lhs.Type() != "identifier" || nodeText(lhs, file.Content) != "constraints" {
+				continue
+			}
+			// Found `constraints = <rhs>`. Walk rhs for UniqueConstraint /
+			// CheckConstraint call nodes and extract their `name=` argument.
+			constraintCalls := findAll(rhs, "call")
+			for _, call := range constraintCalls {
+				funcNode := call.ChildByFieldName("function")
+				if funcNode == nil {
+					continue
+				}
+				funcText := nodeText(funcNode, file.Content)
+				// Accept models.UniqueConstraint, models.CheckConstraint,
+				// UniqueConstraint, CheckConstraint (with or without module prefix).
+				isConstraintCall := strings.HasSuffix(funcText, "UniqueConstraint") ||
+					strings.HasSuffix(funcText, "CheckConstraint")
+				if !isConstraintCall {
+					continue
+				}
+				// Extract the `name=` keyword argument value.
+				argsNode := call.ChildByFieldName("arguments")
+				if argsNode == nil {
+					continue
+				}
+				var constraintName string
+				for a := range int(argsNode.ChildCount()) {
+					arg := argsNode.Child(a)
+					if arg == nil || arg.Type() != "keyword_argument" {
+						continue
+					}
+					keyNode := arg.ChildByFieldName("name")
+					valNode := arg.ChildByFieldName("value")
+					if keyNode == nil || valNode == nil {
+						continue
+					}
+					if nodeText(keyNode, file.Content) == "name" {
+						constraintName = stripQuotes(strings.TrimSpace(nodeText(valNode, file.Content)))
+						break
+					}
+				}
+				if constraintName == "" {
+					// No `name=` found — skip (anonymous constraints can't be
+					// stably identified; leave them unlinked).
+					continue
+				}
+
+				// Qualified constraint name: "ParentClass.constraint_name" so
+				// multiple models in the same file don't collide.
+				qualifiedName := parentClass + "." + constraintName
+
+				// Determine whether this is UniqueConstraint or CheckConstraint.
+				constraintSubtype := "check"
+				if strings.HasSuffix(funcText, "UniqueConstraint") {
+					constraintSubtype = "unique"
+				}
+
+				// Emit the SCOPE.Constraint entity.
+				constRec := types.EntityRecord{
+					Name:       qualifiedName,
+					Kind:       "SCOPE.Constraint",
+					Subtype:    constraintSubtype,
+					SourceFile: file.Path,
+					Language:   file.Language,
+					StartLine:  int(call.StartPoint().Row) + 1,
+					EndLine:    int(call.EndPoint().Row) + 1,
+					Properties: map[string]string{
+						"pattern_type":    "django_meta_constraint",
+						"constraint_name": constraintName,
+						"constraint_kind": funcText[strings.LastIndex(funcText, ".")+1:],
+					},
+					QualityScore: 0.8,
+				}
+				*out = append(*out, constRec)
+
+				// Emit CONTAINS edge from parent class to this constraint.
+				// Use a structural-ref ToID so the resolver can bind the stub
+				// via byLocation[file][qualifiedName].
+				toID := extractor.BuildConstraintStructuralRef(file.Path, qualifiedName)
+				(*out)[classIdx].Relationships = append((*out)[classIdx].Relationships,
+					types.RelationshipRecord{
+						ToID: toID,
+						Kind: "CONTAINS",
+					})
+			}
+		}
+	}
 }
 
 // nodeText returns the raw source bytes for a tree-sitter node as a string.

--- a/internal/extractors/python/extractor_test.go
+++ b/internal/extractors/python/extractor_test.go
@@ -1455,6 +1455,7 @@ class Mailer:
 	}
 }
 
+
 // TestPascalCaseReceiverCALLSEdges verifies that bare PascalCase identifier
 // receivers (e.g. `User.save(...)`) produce qualified CALLS edges
 // `User.save` instead of an ambiguous bare `save`. Regression test for
@@ -1505,6 +1506,158 @@ def create_user():
 	// SCREAMING_SNAKE receiver (`ALLOWED_HOSTS`) must NOT produce a qualified edge.
 	if calledTargets["ALLOWED_HOSTS.append"] {
 		t.Errorf("should not produce qualified edge for SCREAMING_SNAKE receiver ALLOWED_HOSTS")
+	}
+}
+
+// Issue #749 — Django Model.Meta constraints CONTAINS edges
+// ---------------------------------------------------------------------------
+
+// TestExtract_DjangoModel_MetaConstraints verifies that a Django model with
+// Meta.constraints = [UniqueConstraint(...), CheckConstraint(...)] emits:
+//  1. Two SCOPE.Constraint entities with the correct Name, Kind, and Subtype.
+//  2. CONTAINS edges from the parent class to each constraint.
+//
+// This closes the gap where constraints were either missing from the graph
+// entirely or emitted as orphans by the SQLAlchemy ForeignKey YAML rule
+// misfiring on Django model files.
+func TestExtract_DjangoModel_MetaConstraints(t *testing.T) {
+	src := `class Order(models.Model):
+    user = models.ForeignKey(User, on_delete=models.CASCADE)
+    quantity = models.IntegerField(default=0)
+
+    class Meta:
+        db_table = "orders"
+        constraints = [
+            models.UniqueConstraint(
+                fields=["user", "post"],
+                name="unique_user_post",
+            ),
+            models.CheckConstraint(
+                condition=models.Q(quantity__gte=0),
+                name="check_quantity_gte_zero",
+            ),
+        ]
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	// 1. Both SCOPE.Constraint entities must exist.
+	wantConstraints := map[string]string{
+		"Order.unique_user_post":       "unique",
+		"Order.check_quantity_gte_zero": "check",
+	}
+	for wantName, wantSubtype := range wantConstraints {
+		var found *types.EntityRecord
+		for i := range entities {
+			if entities[i].Name == wantName {
+				found = &entities[i]
+				break
+			}
+		}
+		if found == nil {
+			t.Errorf("constraint entity %q not found; got %v", wantName, entityNames(entities))
+			continue
+		}
+		if found.Kind != "SCOPE.Constraint" {
+			t.Errorf("%q: expected Kind=SCOPE.Constraint, got %q", wantName, found.Kind)
+		}
+		if found.Subtype != wantSubtype {
+			t.Errorf("%q: expected Subtype=%q, got %q", wantName, wantSubtype, found.Subtype)
+		}
+	}
+
+	// 2. Order class must have CONTAINS edges to each constraint.
+	var orderEntity *types.EntityRecord
+	for i := range entities {
+		if entities[i].Name == "Order" && entities[i].Kind == "SCOPE.Component" {
+			orderEntity = &entities[i]
+			break
+		}
+	}
+	if orderEntity == nil {
+		t.Fatalf("Order class entity not found; got %v", entityNames(entities))
+	}
+	for wantName := range wantConstraints {
+		wantToID := "scope:constraint:python:test.py:" + wantName
+		found := false
+		for _, rel := range orderEntity.Relationships {
+			if rel.Kind == "CONTAINS" && rel.ToID == wantToID {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Order: missing CONTAINS edge to %q; got rels=%+v", wantToID, orderEntity.Relationships)
+		}
+	}
+}
+
+// TestExtract_DjangoModel_MetaConstraints_BareNames verifies that constraints
+// expressed without the `models.` prefix (e.g. after `from django.db.models
+// import UniqueConstraint`) are also captured.
+func TestExtract_DjangoModel_MetaConstraints_BareNames(t *testing.T) {
+	src := `from django.db.models import UniqueConstraint, CheckConstraint
+
+class Article(models.Model):
+    class Meta:
+        constraints = [
+            UniqueConstraint(fields=["slug"], name="unique_article_slug"),
+            CheckConstraint(condition=Q(rating__gte=0), name="article_rating_gte_zero"),
+        ]
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+
+	wantConstraints := []string{
+		"Article.unique_article_slug",
+		"Article.article_rating_gte_zero",
+	}
+	for _, wantName := range wantConstraints {
+		var found bool
+		for _, e := range entities {
+			if e.Name == wantName && e.Kind == "SCOPE.Constraint" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("bare-name constraint %q not found; got %v", wantName, entityNames(entities))
+		}
+	}
+}
+
+// TestExtract_DjangoModel_MetaConstraints_NoNameArg verifies that constraints
+// lacking a `name=` keyword argument are NOT emitted (they cannot be stably
+// identified across indexing runs). The test ensures no partial/unnamed
+// entities are added.
+func TestExtract_DjangoModel_MetaConstraints_NoNameArg(t *testing.T) {
+	src := `class Product(models.Model):
+    class Meta:
+        constraints = [
+            models.UniqueConstraint(fields=["sku"]),
+        ]
+`
+	tree := parse(t, []byte(src))
+	ext, _ := extractor.Get("python")
+	entities, err := ext.Extract(context.Background(), makeFile(src, tree))
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	entities = stripFileEntity(entities)
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Constraint" {
+			t.Errorf("unexpected SCOPE.Constraint entity for unnamed constraint: %+v", e)
+		}
 	}
 }
 

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -60,6 +60,11 @@ const (
 	//   sides so the import-channel linker can join them without new linker code.
 	EntityKindGrpcService EntityKind = "SCOPE.GrpcService"
 	EntityKindGrpcMethod  EntityKind = "SCOPE.GrpcMethod"
+
+	// #749: Django Model.Meta constraints=[UniqueConstraint/CheckConstraint]
+	// emit SCOPE.Constraint entities bound to the parent Model via CONTAINS.
+	// Subtypes: "unique" (UniqueConstraint) and "check" (CheckConstraint).
+	EntityKindConstraint EntityKind = "SCOPE.Constraint"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -102,6 +107,8 @@ func AllEntityKinds() []EntityKind {
 		// #725:
 		EntityKindGrpcService,
 		EntityKindGrpcMethod,
+		// #749:
+		EntityKindConstraint,
 	}
 }
 


### PR DESCRIPTION
## Summary

Django model classes declaring `constraints = [UniqueConstraint(...), CheckConstraint(...)]` inside `class Meta` produced no entities in the graph, leaving ~34 Constraint entities on fixture-a orphaned (either missing entirely, or emitted as bare-kind `Constraint` entities from the SQLAlchemy ForeignKey YAML rule misfiring on Django model files).

**Root cause:** `applyFrameworkInnerClassProperties` parsed Meta body assignments for `abstract`, `db_table`, `ordering` etc. but silently ignored the `constraints = [...]` list. No `SCOPE.Constraint` entities were emitted and no CONTAINS edges connected constraints to the parent Model.

**Fix:** New `extractMetaConstraintEntities` function (AST-based, no regex) called from `walkNode` in both bare `class_definition` and `decorated_definition` branches after `applyFrameworkInnerClassProperties`:

1. Finds `constraints = [...]` in the Meta body
2. Walks the RHS list for `UniqueConstraint(name="...")` and `CheckConstraint(name="...")` — accepts both `models.` prefixed and bare-import forms
3. Emits a `SCOPE.Constraint` entity (new Kind in `types/kinds.go`) with qualified name `<ParentClass>.<constraintName>`, Subtype `"unique"` or `"check"`
4. Appends CONTAINS edge from parent class via `scope:constraint:python:<file>:<name>` structural-ref (new `BuildConstraintStructuralRef`)
5. Constraints without `name=` argument are silently skipped

## Closes / Refs

Closes #749

## Testing
- [x] All tests pass: `go test ./...`
- [x] 3 new unit tests: full extraction + CONTAINS edges, bare-name imports, anonymous-constraint skip
- [x] `TestHarness_FixturesCorpus` PASS, `bug_rate=0.0542` unchanged
- [x] No regression in cross-language parity

## Measurements

**django-realworld** (main `4cb4c76` → post-fix `ae7c6c4`):

| Metric | Baseline | Post-fix |
|--------|----------|----------|
| Orphans | 7 (1.7%) | 7 (1.7%) |
| Python orphans | 0 | 0 |
| bug_rate (harness) | 0.0542 | 0.0542 |

Parity maintained. New `SCOPE.Constraint` entities are emitted with CONTAINS edges so they never enter the orphan pool.

## Notes

`SCOPE.Constraint` resolves through the kind-agnostic `byLocation` fallback in `internal/resolve/refs.go` — no resolver changes needed. Fix touches only `internal/extractors/python/` and `internal/extractor/structural_ref.go` + `internal/types/kinds.go`.