### PR TITLE
[#611][ts] createContext() → SCOPE.Component subtype=context + RENDERS golden test

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -721,7 +721,14 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// We always recurse into the value so nested function expressions
 		// (e.g. inside `createSlice({ reducers: { add(state) {...} }})`)
 		// still get walked.
-		if x.isFunctionWrapperCall(valueNode) {
+		if x.isContextFactory(valueNode) {
+			// Issue #611 — createContext() and similar context-factory calls
+			// return a Context object (with .Provider / .Consumer / .displayName
+			// properties), NOT a callable function. Emit as SCOPE.Component with
+			// subtype="context" so Provider/Consumer relationships can attach and
+			// the entity is not confused with a regular callable.
+			x.emit(name, "SCOPE.Component", valueNode, "context", fmt.Sprintf("const %s = createContext()", name))
+		} else if x.isFunctionWrapperCall(valueNode) {
 			subtype := "function"
 			if parentClass != "" {
 				subtype = "method"
@@ -782,7 +789,7 @@ func (x *extractor) isFunctionWrapperCall(n *sitter.Node) bool {
 	switch leaf {
 	case
 		// React
-		"forwardRef", "memo", "lazy", "createContext",
+		"forwardRef", "memo", "lazy",
 		// MobX-react / MobX
 		"observer",
 		// styled-components / emotion
@@ -819,6 +826,37 @@ func (x *extractor) isFunctionWrapperCall(n *sitter.Node) bool {
 		// not values bound to a name — the `const cleanup =
 		// useEffect(...)` shape is not idiomatic.
 		"useCallback", "useMemo":
+		return true
+	}
+	return false
+}
+
+// isContextFactory returns true when valueNode is a call_expression whose
+// callee is one of the React context-factory functions. These return a Context
+// object (with .Provider / .Consumer) — NOT a callable — so the bound const
+// should be emitted as SCOPE.Component subtype="context" (issue #611).
+//
+// Recognised factories: createContext (React), createNamedContext (common
+// utility wrapper shape), createOptionalContext (pattern from some React libs).
+func (x *extractor) isContextFactory(n *sitter.Node) bool {
+	if n == nil || n.Type() != "call_expression" {
+		return false
+	}
+	fn := n.ChildByFieldName("function")
+	if fn == nil {
+		return false
+	}
+	var leaf string
+	switch fn.Type() {
+	case "identifier", "type_identifier":
+		leaf = x.nodeText(fn)
+	case "member_expression":
+		if prop := fn.ChildByFieldName("property"); prop != nil {
+			leaf = x.nodeText(prop)
+		}
+	}
+	switch leaf {
+	case "createContext", "createNamedContext", "createOptionalContext":
 		return true
 	}
 	return false

--- a/internal/extractors/javascript/extractor_test.go
+++ b/internal/extractors/javascript/extractor_test.go
@@ -1179,3 +1179,102 @@ class ItemService {
 		t.Errorf("ItemService has no CONTAINS relationships; list and detail should be contained")
 	}
 }
+
+// --------------------------------------------------------------------------
+// Issue #611 — createContext() emitted as SCOPE.Component subtype=context
+// --------------------------------------------------------------------------
+
+// TestCreateContext_BasicContext verifies that `const X = createContext(default)`
+// is emitted as SCOPE.Component with subtype="context", not SCOPE.Operation.
+func TestCreateContext_BasicContext(t *testing.T) {
+	src := []byte(`
+import { createContext } from 'react';
+const AuthContext = createContext(null);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	assertKind(t, entities, "AuthContext", "SCOPE.Component")
+	e := findByName(entities, "AuthContext")
+	if e == nil {
+		t.Fatal("AuthContext entity not found")
+	}
+	if e.Subtype != "context" {
+		t.Errorf("AuthContext: Subtype=%q, want 'context'", e.Subtype)
+	}
+}
+
+// TestCreateContext_Typed verifies the TypeScript generic form:
+// `const X = createContext<T | null>(null)` — still SCOPE.Component.
+func TestCreateContext_Typed(t *testing.T) {
+	src := []byte(`
+import { createContext } from 'react';
+interface AuthCtx { user: string; }
+const AuthContext = createContext<AuthCtx | null>(null);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	assertKind(t, entities, "AuthContext", "SCOPE.Component")
+	e := findByName(entities, "AuthContext")
+	if e != nil && e.Subtype != "context" {
+		t.Errorf("AuthContext (typed): Subtype=%q, want 'context'", e.Subtype)
+	}
+}
+
+// TestCreateContext_MultipleContexts verifies that multiple createContext calls
+// in one file each produce their own SCOPE.Component context entity.
+func TestCreateContext_MultipleContexts(t *testing.T) {
+	src := []byte(`
+import { createContext } from 'react';
+const UserContext = createContext(null);
+const ThemeContext = createContext({ color: 'blue' });
+const AuthContext = createContext(null);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	for _, name := range []string{"UserContext", "ThemeContext", "AuthContext"} {
+		assertKind(t, entities, name, "SCOPE.Component")
+		e := findByName(entities, name)
+		if e != nil && e.Subtype != "context" {
+			t.Errorf("%s: Subtype=%q, want 'context'", name, e.Subtype)
+		}
+	}
+}
+
+// TestCreateContext_NotAWrapper verifies that createContext is no longer treated
+// as a function wrapper (it must NOT be SCOPE.Operation).
+func TestCreateContext_NotAWrapper(t *testing.T) {
+	src := []byte(`
+import { createContext, createContext as createCtx } from 'react';
+const Ctx = createContext(defaultValue);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	e := findByName(entities, "Ctx")
+	if e == nil {
+		t.Fatal("Ctx entity not found")
+	}
+	if e.Kind == "SCOPE.Operation" {
+		t.Errorf("Ctx: should not be SCOPE.Operation (createContext result is a Context object, not a function)")
+	}
+	if e.Kind != "SCOPE.Component" {
+		t.Errorf("Ctx: Kind=%q, want SCOPE.Component", e.Kind)
+	}
+}
+
+// TestMemo_StillOperation verifies that memo() (a wrapper that DOES return a
+// component function) is still emitted as SCOPE.Operation, not affected by #611.
+func TestMemo_StillOperation(t *testing.T) {
+	src := []byte(`
+import { memo } from 'react';
+function CardInner({ user }) { return null; }
+const MemoCard = memo(CardInner);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	assertKind(t, entities, "MemoCard", "SCOPE.Operation")
+}

--- a/internal/quality/golden/typescript-react-mini/expected.json
+++ b/internal/quality/golden/typescript-react-mini/expected.json
@@ -31,7 +31,7 @@
 
     { "name": "App", "kind": "SCOPE.Operation", "source_file": "App.tsx", "must_exist": true },
 
-    { "name": "AuthContext", "kind": "SCOPE.Operation", "source_file": "context/AuthContext.tsx", "must_exist": false, "nice_to_have": true, "note": "Today emitted as SCOPE.Operation because createContext is treated as a callable; ideal kind would be SCOPE.Component." }
+    { "name": "AuthContext", "kind": "SCOPE.Component", "source_file": "context/AuthContext.tsx", "must_exist": true, "note": "Context object from createContext(); emitted as SCOPE.Component subtype=context after #611 fix." }
   ],
   "expected_relationships": [
     { "from_name": "App.tsx", "from_kind": "SCOPE.Component", "from_file": "App.tsx",
@@ -83,9 +83,9 @@
       "must_exist": true,
       "note": "Custom-hook call across files." },
 
-    { "from_name": "UserCard", "from_kind": "SCOPE.Operation", "from_file": "components/UserCard.tsx",
-      "kind": "CALLS", "to_name": "UserCard", "to_kind": "SCOPE.Operation", "to_file": "components/UserList.tsx",
-      "must_exist": false, "nice_to_have": true,
-      "note": "Ideal RENDERS edge for JSX <UserCard /> composition; today JSX usage isn't extracted as a RENDERS edge for plain function components." }
+    { "from_name": "UserList", "from_kind": "SCOPE.Operation", "from_file": "components/UserList.tsx",
+      "kind": "RENDERS", "to_name": "UserCard", "to_kind": "SCOPE.Operation", "to_file": "components/UserCard.tsx",
+      "must_exist": true,
+      "note": "JSX <UserCard /> composition emitted as RENDERS by the react_props cross-extractor (issue #611-related)." }
   ]
 }


### PR DESCRIPTION
## Summary

- **#611**: `const AuthContext = createContext<T>(null)` was emitted as `SCOPE.Operation` because `createContext` lived in `isFunctionWrapperCall`. `createContext` returns a Context object (`.Provider` / `.Consumer`), not a callable function. Fixed by removing it from the wrapper list and adding a dedicated `isContextFactory` check that emits `SCOPE.Component subtype="context"`.
- **JSX RENDERS golden test**: The `react_props` cross-extractor already emits `RENDERS` edges for `<ChildComponent />` composition. Updated the `typescript-react-mini` golden spec to reflect this: `AuthContext` is now `must_exist=true, kind=SCOPE.Component`, and `UserList → RENDERS → UserCard` is a required relationship.

## Closes / Refs

- `Closes #611`

## Testing

- [ ] All tests pass: `go test ./...`
- [x] `TestCreateContext_BasicContext` / `_Typed` / `_MultipleContexts` / `_NotAWrapper` — all PASS
- [x] `TestMemo_StillOperation` — memo() still emits SCOPE.Operation (no regression)
- [x] All existing JS extractor tests pass
- [x] `internal/types/...`, `internal/quality/...`, `internal/extractors/cross/...` — all PASS
- [x] Golden fixture spec updated: `AuthContext` now `SCOPE.Component`, `RENDERS` edge added

## Notes

`createContext`, `createNamedContext`, `createOptionalContext` are now handled by `isContextFactory` which fires BEFORE `isFunctionWrapperCall` in `handleVariableDeclaration`. Other React HOCs (`memo`, `forwardRef`, `observer`, etc.) are unaffected.