### PR TITLE
[#652][#654][http-extract] Template-literal const folding + fetch(url) variable traceback

### DIFF
--- a/internal/engine/http_endpoint_client_synthesis.go
+++ b/internal/engine/http_endpoint_client_synthesis.go
@@ -227,6 +227,55 @@ var jsConstStringRe = regexp.MustCompile(
 	`(?m)(?:const|let|var)\s+([A-Za-z_$][\w$]*)\s*=\s*['"]([^'"]{1,256})['"]`,
 )
 
+// jsConstTemplateLiteralRe matches template-literal variable assignments:
+//
+//	const url = `${process.env.API_URL}/users`;
+//	const url = `${apiUrl}/${endpoint}`;
+//
+// These are NOT captured by jsConstStringRe (which requires plain string
+// quotes) but ARE needed for #654: when fetch(url) is called with a
+// variable that holds a template literal, we must trace back to the
+// template literal to extract the URL pattern.
+//
+// Capture groups: 1=name, 2=template-literal body (between backticks).
+var jsConstTemplateLiteralRe = regexp.MustCompile(
+	"(?m)(?:const|let|var)\\s+([A-Za-z_$][\\w$]*)\\s*=\\s*`([^`\\n\\r]*\\$\\{[^`\\n\\r]*)`",
+)
+
+// fetchBareIdentRe matches `fetch(ident, ...)` where the argument is a bare
+// identifier (not a quoted string, not a template literal). Used by #654
+// to handle the pattern:
+//
+//	const url = `${process.env.API_URL}/users`;
+//	fetch(url, { method: "POST" });
+//
+// Capture groups:
+//
+//	1 = bare identifier (the URL variable name)
+//	2 = optional options object (for method extraction)
+var fetchBareIdentRe = regexp.MustCompile(
+	`(?:^|[^\w$.])fetch\s*\(\s*([A-Za-z_$][\w$]*)\s*(?:,(\s*\{[^}]*\}))?\)`,
+)
+
+// buildJSTemplateLiteralSymbolTable returns a map from identifier name →
+// raw template-literal body (excluding backticks) for every
+// const/let/var assignment of the form `const X = `...${...}...``.
+// Used by #654 to resolve bare-identifier fetch arguments.
+func buildJSTemplateLiteralSymbolTable(content string) map[string]string {
+	syms := make(map[string]string)
+	for _, m := range jsConstTemplateLiteralRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		tmplBody := content[m[4]:m[5]]
+		if _, dup := syms[name]; !dup {
+			syms[name] = tmplBody
+		}
+	}
+	return syms
+}
+
 // ---------------------------------------------------------------------------
 // Env-var URL patterns (#721 beyond-minimum)
 // ---------------------------------------------------------------------------
@@ -542,6 +591,41 @@ func synthesizeFetchAxios(content string, emit emitFn) {
 		caller := enclosingJSFuncAt(funcs, m[0])
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
 		emit(verb, canonical, "fetch", "Function", caller)
+	}
+
+	// fetch(url, ...) — bare identifier whose value is a template literal (#654)
+	// e.g.: const url = `${process.env.API_URL}/users`; fetch(url, { method: "POST" });
+	// Build the template literal symbol table (template-body values, not plain strings).
+	tmplSyms := buildJSTemplateLiteralSymbolTable(content)
+	if len(tmplSyms) > 0 {
+		for _, m := range fetchBareIdentRe.FindAllStringSubmatchIndex(content, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			ident := content[m[2]:m[3]]
+			// Skip if the identifier is a known string const (handled by fetchCallRe).
+			if _, ok := syms[ident]; ok {
+				continue
+			}
+			tmplBody, ok := tmplSyms[ident]
+			if !ok {
+				continue
+			}
+			verb := "GET"
+			if len(m) >= 6 && m[4] >= 0 {
+				opts := content[m[4]:m[5]]
+				if mv := fetchMethodRe.FindStringSubmatch(opts); len(mv) >= 2 {
+					verb = strings.ToUpper(mv[1])
+				}
+			}
+			path, ok2 := canonicalizeTemplateLiteral(tmplBody, syms)
+			if !ok2 {
+				continue
+			}
+			caller := enclosingJSFuncAt(funcs, m[0])
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			emit(verb, canonical, "fetch", "Function", caller)
+		}
 	}
 
 	// axios.<verb>(...) — static string literals

--- a/internal/engine/http_endpoint_client_synthesis_test.go
+++ b/internal/engine/http_endpoint_client_synthesis_test.go
@@ -1152,6 +1152,115 @@ def create_item(body):
 
 // TestSynth721_JavaGetenvConcatRuntimeDynamic verifies that
 // URI.create(System.getenv("API_URL") + "/users") emits runtime_dynamic=true.
+// ---------------------------------------------------------------------------
+// Issue #652 — template-literal URLs with file-local const BASE_PATH
+// ---------------------------------------------------------------------------
+
+// TestSynth652_FetchTemplateLiteralWithBasePath verifies that fetch() calls
+// using template literals whose first substitution is a file-local const
+// string are resolved to the correct endpoint.
+// Covers the primary fixture-c pattern: await $http.get(`${BASE_PATH}${id}/`).
+func TestSynth652_FetchTemplateLiteralWithBasePath(t *testing.T) {
+	src := `import { $http } from "./httpClient";
+const BASE_PATH = '/api/v1';
+
+export async function getUser(id) {
+  return await fetch(` + "`" + `${BASE_PATH}/users/${id}/` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "652-fetch-template.ts", src)
+	requireContains(t, got, []string{"http:GET:/api/v1/users/{id}"}, "#652 fetch template with BASE_PATH")
+}
+
+// TestSynth652_HttpClientTemplateLiteralMultipleRoutes verifies that multiple
+// $http template-literal calls with the same const prefix all produce endpoints.
+// This mirrors the fixture-c api-service files.
+func TestSynth652_HttpClientTemplateLiteralMultipleRoutes(t *testing.T) {
+	src := `import { $http } from "./httpClient";
+const BASE_PATH = '/inspections/';
+
+export async function getInspection(id) {
+  return $http.get(` + "`" + `${BASE_PATH}${id}/` + "`" + `);
+}
+
+export async function patchInspection(id) {
+  return $http.patch(` + "`" + `${BASE_PATH}${id}/` + "`" + `);
+}
+
+export async function getCounts() {
+  return $http.get(` + "`" + `${BASE_PATH}get_counts/` + "`" + `);
+}
+
+export async function postNotes(id) {
+  return $http.post(` + "`" + `${BASE_PATH}notes/` + "`" + `);
+}
+`
+	got, _ := runDetect(t, "typescript", "652-http-multiple.ts", src)
+	requireContains(t, got, []string{
+		"http:GET:/inspections/{id}",
+		"http:PATCH:/inspections/{id}",
+		"http:GET:/inspections/get_counts",
+		"http:POST:/inspections/notes",
+	}, "#652 multiple $http template routes")
+}
+
+// ---------------------------------------------------------------------------
+// Issue #654 — fetch()/axios() with env-var or dynamic URL variable
+// ---------------------------------------------------------------------------
+
+// TestSynth654_FetchBareIdentTemplateLiteral verifies that
+// `const url = `${process.env.API_URL}/users`; fetch(url);`
+// produces the extracted path /users.
+func TestSynth654_FetchBareIdentTemplateLiteral(t *testing.T) {
+	src := "const url = `${process.env.API_URL}/users`;\nawait fetch(url);"
+	got, _ := runDetect(t, "typescript", "654-bare-ident.ts", src)
+	requireContains(t, got, []string{"http:GET:/users"}, "#654 fetch(url) where url is template literal with env prefix")
+}
+
+// TestSynth654_FetchBareIdentWithMethod verifies that the HTTP method is
+// extracted from the options object when fetch(url, { method: "POST" }) is used.
+func TestSynth654_FetchBareIdentWithMethod(t *testing.T) {
+	src := "const url = `${process.env.API_URL}/login/`;\nawait fetch(url, { method: \"POST\" });"
+	got, _ := runDetect(t, "typescript", "654-bare-ident-method.ts", src)
+	requireContains(t, got, []string{"http:POST:/login"}, "#654 fetch(url, {method:POST}) with env prefix")
+}
+
+// TestSynth654_FetchBareIdentImportMetaEnv verifies that import.meta.env
+// prefix is also stripped from template literal variables.
+func TestSynth654_FetchBareIdentImportMetaEnv(t *testing.T) {
+	src := "const url = `${import.meta.env.VITE_CORE_API}/devices/`;\nconst response = await fetch(url);"
+	got, _ := runDetect(t, "typescript", "654-import-meta.ts", src)
+	requireContains(t, got, []string{"http:GET:/devices"}, "#654 fetch(url) with import.meta.env prefix")
+}
+
+// TestSynth654_FetchBareIdentLocalConst verifies that file-local const
+// variable is resolved when used as base URL via variable traceback.
+func TestSynth654_FetchBareIdentLocalConst(t *testing.T) {
+	src := `const CORE_API = '/api';
+const url = ` + "`${CORE_API}/buildings/`" + `;
+const response = await fetch(url);`
+	got, _ := runDetect(t, "typescript", "654-local-const-base.ts", src)
+	requireContains(t, got, []string{"http:GET:/api/buildings"}, "#654 fetch(url) with local const base URL")
+}
+
+// TestSynth654_StringConstNotDoubled verifies that a bare-identifier fetch
+// call whose variable holds a plain string is NOT double-emitted (once by
+// fetchCallRe already, once by fetchBareIdentRe).
+func TestSynth654_StringConstNotDoubled(t *testing.T) {
+	src := `const url = '/users';
+fetch(url);`
+	got, _ := runDetect(t, "typescript", "654-string-const-no-double.ts", src)
+	count := 0
+	for _, id := range got {
+		if id == "http:GET:/users" {
+			count++
+		}
+	}
+	if count > 1 {
+		t.Errorf("#654 plain string const emitted %d times, want ≤1", count)
+	}
+}
+
 func TestSynth721_JavaGetenvConcatRuntimeDynamic(t *testing.T) {
 	src := `import java.net.http.HttpClient;
 import java.net.http.HttpRequest;


### PR DESCRIPTION
## Summary

- **#652**: Explicit test coverage confirming that fetch(\`\${BASE_PATH}/users\`) and \$http.get(\`\${BASE_PATH}\${id}/\`) are correctly resolved via the existing canonicalizeTemplateLiteral constant-folding path.
- **#654**: New feature — when a file assigns a template literal to a variable and then calls fetch(url), the extractor now traces back to the template literal and extracts the URL pattern.

Pattern now handled:
```ts
const url = `${process.env.API_URL}/users`;
fetch(url);  →  http:GET:/users

const url = `${import.meta.env.VITE_CORE_API}/login/`;
fetch(url, { method: "POST" });  →  http:POST:/login
```

## Closes / Refs

- `Closes #652`
- `Closes #654`

## Testing

- [ ] All tests pass: `go test ./...`
- [x] 7 new tests — all PASS (TestSynth652_*, TestSynth654_*)
- [x] Full `internal/engine/...` suite green — no regressions

## Notes

Three new additions to `http_endpoint_client_synthesis.go`: `jsConstTemplateLiteralRe`, `buildJSTemplateLiteralSymbolTable`, `fetchBareIdentRe`. Logic in `synthesizeFetchAxios` traces the ident through `tmplSyms` then calls `canonicalizeTemplateLiteral`. DO NOT touch: Python/Java/Go extractors, process_flow, broker passes.