### PR TITLE
[#527] Django URLConf FBV view binding: emit IMPLEMENTS edges for path(pattern, views.fn)

### DIFF
--- a/internal/engine/django_urlconf_nested.go
+++ b/internal/engine/django_urlconf_nested.go
@@ -137,8 +137,8 @@ func ApplyDjangoNestedURLConf(
 
 			childRoutes := extractChildRoutes(string(childContent), fileReader, childRelPath, 0)
 
-			for _, childRoute := range childRoutes {
-				composed := joinDjangoRoutePaths(parentPrefix, childRoute)
+			for _, cr := range childRoutes {
+				composed := joinDjangoRoutePaths(parentPrefix, cr.pattern)
 				canonical := httproutes.Canonicalize(httproutes.FrameworkDjango, composed)
 				if canonical == "" || canonical == "/" {
 					continue
@@ -149,18 +149,29 @@ func ApplyDjangoNestedURLConf(
 				}
 				seen[id] = true
 
+				props := map[string]string{
+					"verb":         "ANY",
+					"path":         canonical,
+					"framework":    "django",
+					"pattern_type": "urlconf_nested_include",
+				}
+				// Issue #527 — wire FBV view functions as source_handler so
+				// the ResolveHTTPEndpointHandlers pass emits an IMPLEMENTS
+				// edge from the view function to this http_endpoint entity.
+				// CBV as_view() handlers are handled separately by the CBV
+				// pass (django_drf_actions.go) and are left without a
+				// source_handler here to avoid conflicts.
+				if cr.handler != "" {
+					props["source_handler"] = "Controller:" + cr.handler
+				}
+
 				out = append(out, types.EntityRecord{
 					ID:         id,
 					Name:       id,
 					Kind:       httpEndpointKind,
 					SourceFile: relPath,
 					Language:   "python",
-					Properties: map[string]string{
-						"verb":         "ANY",
-						"path":         canonical,
-						"framework":    "django",
-						"pattern_type": "urlconf_nested_include",
-					},
+					Properties: props,
 					EnrichmentRequired: false,
 					EnrichmentStatus:   types.StatusPending,
 					QualityScore:       0.8,
@@ -171,18 +182,27 @@ func ApplyDjangoNestedURLConf(
 	return out
 }
 
+// childRoute pairs a URL pattern with its resolved view handler reference.
+// handler is the bare function name extracted from the path() call (e.g.
+// "user_list" from "views.user_list"), or "" when the handler could not be
+// resolved to a simple FBV name (CBV as_view() calls, anonymous lambdas, etc.).
+type childRoute struct {
+	pattern string
+	handler string // bare FBV name, or "" for CBVs / unknown
+}
+
 // extractChildRoutes returns all route patterns declared in a child file
 // (urls.py, routers.py, or any Python file referenced by include()). It
 // handles two patterns:
 //
-//  1. Plain `path("pattern", view)` calls → extract pattern directly.
-//  2. DRF `<router>.register("prefix", ViewSet)` calls → extract prefix.
+//  1. Plain `path("pattern", view)` calls → extract pattern + handler directly.
+//  2. DRF `<router>.register("prefix", ViewSet)` calls → extract prefix only.
 //
 // It also handles one level of recursive string include() nesting (depth
 // limit prevents infinite loops on circular imports).
-func extractChildRoutes(src string, fileReader NestedURLConfFileReader, filePath string, depth int) []string {
+func extractChildRoutes(src string, fileReader NestedURLConfFileReader, filePath string, depth int) []childRoute {
 	const maxDepth = 2
-	var routes []string
+	var routes []childRoute
 
 	// Direct routes (non-include path() calls).
 	for _, m := range djangoChildPathRe.FindAllStringSubmatch(src, -1) {
@@ -194,13 +214,17 @@ func extractChildRoutes(src string, fileReader NestedURLConfFileReader, filePath
 		if strings.HasPrefix(strings.TrimSpace(handler), "include") {
 			continue
 		}
-		routes = append(routes, pattern)
+		routes = append(routes, childRoute{
+			pattern: pattern,
+			handler: resolveFBVHandler(handler),
+		})
 	}
 
 	// DRF router.register() calls — handles routers.py style child files.
 	// e.g. `router.register(r"users", UserViewSet)` → yields "users".
+	// No FBV handler to resolve for CBV ViewSet registrations.
 	for _, m := range djangoRouterRegisterRe.FindAllStringSubmatch(src, -1) {
-		routes = append(routes, m[1])
+		routes = append(routes, childRoute{pattern: m[1]})
 	}
 
 	// Recursive nested string include() calls in the child file.
@@ -222,12 +246,70 @@ func extractChildRoutes(src string, fileReader NestedURLConfFileReader, filePath
 			}
 			subRoutes := extractChildRoutes(string(subContent), fileReader, subRelPath, depth+1)
 			for _, sr := range subRoutes {
-				routes = append(routes, joinDjangoRoutePaths(subPrefix, sr))
+				routes = append(routes, childRoute{
+					pattern: joinDjangoRoutePaths(subPrefix, sr.pattern),
+					handler: sr.handler,
+				})
 			}
 		}
 	}
 
 	return routes
+}
+
+// resolveFBVHandler converts a Django path() view argument to a bare function
+// name suitable for use as a source_handler reference. It handles:
+//
+//   - "views.user_list"         → "user_list"   (module-qualified FBV)
+//   - "user_list"               → "user_list"   (bare FBV import)
+//   - "UserView.as_view()"      → ""            (CBV — no FBV name)
+//   - "views.UserView.as_view()"→ ""            (module-qualified CBV)
+//
+// Returns "" for CBV as_view() calls (they are handled by the existing
+// django_drf_actions.go CBV pass which sets its own source_handler).
+func resolveFBVHandler(handler string) string {
+	// Strip trailing whitespace.
+	handler = strings.TrimSpace(handler)
+	if handler == "" {
+		return ""
+	}
+	// CBV as_view() calls — skip; the CBV pass handles these separately.
+	if strings.Contains(handler, "as_view") {
+		return ""
+	}
+	// Strip module prefix: "views.user_list" → "user_list".
+	// Only strip ONE level (the module alias). Names with two dots
+	// (e.g. "app.views.fn") are uncommon and we take the last segment.
+	if idx := strings.LastIndex(handler, "."); idx >= 0 {
+		handler = handler[idx+1:]
+	}
+	// Must be a valid Python identifier — reject anything that still
+	// contains non-identifier characters.
+	if !isPythonIdentifier(handler) {
+		return ""
+	}
+	return handler
+}
+
+// isPythonIdentifier reports whether s is a valid Python bare identifier
+// (letters, digits, underscores; must not start with a digit).
+func isPythonIdentifier(s string) bool {
+	if s == "" {
+		return false
+	}
+	for i, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r == '_':
+			// always valid
+		case r >= '0' && r <= '9':
+			if i == 0 {
+				return false
+			}
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // modulePathToFilePath converts a Python module path (e.g. "api.urls" or

--- a/internal/engine/django_urlconf_nested_test.go
+++ b/internal/engine/django_urlconf_nested_test.go
@@ -350,6 +350,82 @@ urlpatterns = [
 	}
 }
 
+// TestApplyDjangoNestedURLConf_FBVSourceHandler verifies that direct FBV
+// view references in path() calls produce http_endpoint entities with a
+// source_handler property pointing to the view function (issue #527).
+func TestApplyDjangoNestedURLConf_FBVSourceHandler(t *testing.T) {
+	files := fileMap{
+		"conduit/urls.py": `
+from django.urls import path, include
+
+urlpatterns = [
+    path("api/", include("api.urls")),
+]
+`,
+		"api/urls.py": `
+from django.urls import path
+from api import views
+
+urlpatterns = [
+    path("users/", views.user_list, name="user-list"),
+    path("users/<int:pk>/", views.user_detail, name="user-detail"),
+    path("articles/", views.ArticleView.as_view(), name="article-list"),
+    path("health/", views.health_check, name="health"),
+]
+`,
+	}
+
+	pyPaths := []string{"conduit/urls.py", "api/urls.py"}
+	got := ApplyDjangoNestedURLConf(pyPaths, files.reader)
+
+	byID := map[string]string{} // id → source_handler
+	for _, e := range got {
+		if e.Kind != httpEndpointKind {
+			continue
+		}
+		byID[e.ID] = e.Properties["source_handler"]
+	}
+
+	// FBV: module-qualified → bare name as Controller:<name>
+	if h := byID["http:ANY:/api/users"]; h != "Controller:user_list" {
+		t.Errorf("http:ANY:/api/users source_handler = %q, want %q", h, "Controller:user_list")
+	}
+	if h := byID["http:ANY:/api/users/{pk}"]; h != "Controller:user_detail" {
+		t.Errorf("http:ANY:/api/users/{pk} source_handler = %q, want %q", h, "Controller:user_detail")
+	}
+	// FBV bare name (no module prefix)
+	if h := byID["http:ANY:/api/health"]; h != "Controller:health_check" {
+		t.Errorf("http:ANY:/api/health source_handler = %q, want %q", h, "Controller:health_check")
+	}
+	// CBV as_view() — source_handler must be absent (not set by this pass)
+	if h := byID["http:ANY:/api/articles"]; h != "" {
+		t.Errorf("http:ANY:/api/articles source_handler = %q, want empty (CBV)", h)
+	}
+}
+
+// TestResolveFBVHandler verifies the handler name extraction logic.
+func TestResolveFBVHandler(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"views.user_list", "user_list"},
+		{"user_list", "user_list"},
+		{"views.UserView.as_view()", ""},
+		{"UserView.as_view()", ""},
+		{"", ""},
+		{"app.views.fn", "fn"},
+		{"ALLOWED_HOSTS.append", "append"}, // bare word after last dot — valid identifier
+		{"include(router.urls)", ""},        // include() call — no handler
+	}
+	for _, tt := range tests {
+		got := resolveFBVHandler(tt.input)
+		if got != tt.want {
+			t.Errorf("resolveFBVHandler(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}
+
 // TestModulePathToFilePath verifies the module-path to file-path conversion.
 func TestModulePathToFilePath(t *testing.T) {
 	tests := []struct {

--- a/internal/engine/http_endpoint_resolve_test.go
+++ b/internal/engine/http_endpoint_resolve_test.go
@@ -100,6 +100,68 @@ func TestResolveHandlers_KeepsSyntheticWithNoHandlerProp(t *testing.T) {
 	}
 }
 
+// TestResolveHandlers_FBVCrossFileKindFallback verifies that a Django FBV
+// endpoint (pattern_type=urlconf_nested_include) whose source_handler uses
+// the "Controller:<name>" kind can be resolved cross-file via the
+// resolverKindEquivalents fallback — i.e. the entity lives in views.py as
+// SCOPE.Operation but the handler ref says Controller (issue #527).
+func TestResolveHandlers_FBVCrossFileKindFallback(t *testing.T) {
+	// SCOPE.Operation entity for health_check in views.py
+	handler := types.EntityRecord{
+		Kind:       "SCOPE.Operation",
+		Name:       "health_check",
+		SourceFile: "users/views.py",
+		Language:   "python",
+	}
+	// http_endpoint entity in urls.py (different SourceFile from handler)
+	synth := types.EntityRecord{
+		Kind:       httpEndpointKind,
+		Name:       "http:ANY:/users/health",
+		SourceFile: "myproject/urls.py",
+		Language:   "python",
+		Properties: map[string]string{
+			"source_handler": "Controller:health_check",
+			"framework":      "django",
+			"pattern_type":   "urlconf_nested_include",
+		},
+	}
+	merged := []types.EntityRecord{handler, synth}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.Synthetics != 1 {
+		t.Errorf("expected 1 synthetic, got %d", stats.Synthetics)
+	}
+	if stats.HandlerResolved != 1 {
+		t.Errorf("expected handler_resolved=1, got %d (handler_dropped=%d no_handler_prop=%d)",
+			stats.HandlerResolved, stats.HandlerDropped, stats.NoHandlerProp)
+	}
+	if stats.HandlerDropped != 0 {
+		t.Errorf("expected handler_dropped=0, got %d", stats.HandlerDropped)
+	}
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entities (no drop), got %d", len(out))
+	}
+	// Handler (health_check) gets the IMPLEMENTS edge appended.
+	if len(out[0].Relationships) != 1 {
+		t.Fatalf("expected 1 relationship on handler (health_check), got %d: %+v",
+			len(out[0].Relationships), out[0].Relationships)
+	}
+	rel := out[0].Relationships[0]
+	if rel.Kind != implementsEdgeKind {
+		t.Errorf("expected kind=%s, got %s", implementsEdgeKind, rel.Kind)
+	}
+	if rel.FromID != "SCOPE.Operation:health_check" {
+		t.Errorf("edge FromID wrong: got %q, want SCOPE.Operation:health_check", rel.FromID)
+	}
+	if rel.ToID != "http_endpoint:http:ANY:/users/health" {
+		t.Errorf("edge ToID wrong: got %q, want http_endpoint:http:ANY:/users/health", rel.ToID)
+	}
+	// source_handler cleared from synthetic.
+	if _, ok := out[1].Properties["source_handler"]; ok {
+		t.Errorf("source_handler should be cleared on synthetic, got %+v", out[1].Properties)
+	}
+}
+
 // TestResolveCallers_EmitsFetchesEdge (#754) verifies that a consumer
 // synthetic with a resolvable source_caller produces a FETCHES edge on
 // the caller's embedded relationships and clears the property.

--- a/internal/quality/golden/python-django-mini/expected.json
+++ b/internal/quality/golden/python-django-mini/expected.json
@@ -103,7 +103,11 @@
 
     { "from_name": "user_post_save", "from_kind": "SCOPE.Operation", "from_file": "users/signals.py",
       "kind": "CALLS", "to_bare_name": "full_label", "must_exist": false, "nice_to_have": true,
-      "note": "Bare-name CALLS — ideally resolves to User.full_label; currently pruned by import-placeholder-prune (bare-name CALLS to pruned stubs). Track without blocking CI; file a separate extractor chain-fix to restore." }
+      "note": "Bare-name CALLS — ideally resolves to User.full_label; currently pruned by import-placeholder-prune (bare-name CALLS to pruned stubs). Track without blocking CI; file a separate extractor chain-fix to restore." },
+
+    { "from_name": "health_check", "from_kind": "SCOPE.Operation", "from_file": "users/views.py",
+      "kind": "IMPLEMENTS", "to_name": "http:ANY:/users/health", "to_kind": "http_endpoint", "must_exist": false, "nice_to_have": true,
+      "note": "Issue #527 — FBV view function bound to its http_endpoint via source_handler (urlconf_nested_include IMPLEMENTS edge)." }
   ],
   "forbidden_relationships": [
     { "from_name": "UserListView.get", "from_kind": "SCOPE.Operation", "from_file": "users/views.py",


### PR DESCRIPTION
## Summary

- Refactors `extractChildRoutes` to return `childRoute` structs (pattern + bare FBV handler name) instead of plain strings, so the handler reference is not discarded
- Adds `resolveFBVHandler` helper that strips module prefix (`views.user_list` → `user_list`) and skips CBV `as_view()` calls (those are handled by the existing CBV pass)
- `ApplyDjangoNestedURLConf` now sets `source_handler=Controller:<fn>` on urlconf_nested_include http_endpoint entities for FBV handlers, enabling `ResolveHTTPEndpointHandlers` to emit IMPLEMENTS edges in the final graph

## Verification

- Unit tests: `TestApplyDjangoNestedURLConf_FBVSourceHandler`, `TestResolveFBVHandler`, `TestResolveHandlers_FBVCrossFileKindFallback` all pass
- Golden fixture `python-django-mini`: `health_check → http:ANY:/users/health` IMPLEMENTS edge confirmed present (nice-to-have recalled 2/6)
- Full test suite: 0 failures

Closes #527