### PR TITLE
[dashboard] hotfix: root / redirects to /graph, not stale /api

### DIFF
--- a/dashboard/src/routes/index.tsx
+++ b/dashboard/src/routes/index.tsx
@@ -1,5 +1,5 @@
-import { Navigate } from 'react-router-dom'
+import { Navigate } from "react-router-dom"
 
 export function IndexRoute() {
-  return <Navigate to="/api/fixture-a" replace />
+  return <Navigate to="/graph/fixture-a" replace />
 }


### PR DESCRIPTION
## What we did
One-character route fix in dashboard/src/routes/index.tsx — root index now redirects to /graph/fixture-a instead of the dead /api/fixture-a path that #875 retired.

## What we won
http://127.0.0.1:5173/ now lands on Surface 1 (Graph) instead of the React Router default error boundary.

## What it means for the graph
No graph impact.

## What it means for MCP
No MCP impact.

## Caveats
Picked Graph as the landing surface (Surface 1, most general). If you prefer Paths/Topology as the default, easy follow-up. Doesn't replace #890 (proper branded 404 for unknown paths is still worth shipping).

## Bottom line
Restores a working dashboard home page. Two-line PR.