### PR TITLE
feat(#605, #606): integrate golden fixtures (go-chi, rust-tokio)

### DIFF
--- a/internal/quality/golden/rust-tokio-mini/expected.json
+++ b/internal/quality/golden/rust-tokio-mini/expected.json
@@ -8,9 +8,9 @@
     { "name": "User", "kind": "SCOPE.Component", "source_file": "store.rs", "must_exist": true, "note": "Domain struct." },
     { "name": "UserStore", "kind": "SCOPE.Component", "source_file": "store.rs", "must_exist": true, "note": "Trait declaration." },
     { "name": "MemoryStore", "kind": "SCOPE.Component", "source_file": "store.rs", "must_exist": true, "note": "Struct that implements UserStore." },
-    { "name": "new", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true, "note": "MemoryStore constructor." },
-    { "name": "get", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true, "note": "Trait method implementation." },
-    { "name": "put", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true },
+    { "name": "MemoryStore.new", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true, "note": "MemoryStore constructor." },
+    { "name": "MemoryStore.get", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true, "note": "Trait method implementation." },
+    { "name": "MemoryStore.put", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": true },
 
     { "name": "create_user", "kind": "SCOPE.Operation", "source_file": "handler.rs", "must_exist": true, "note": "Async fn." },
     { "name": "fetch_user", "kind": "SCOPE.Operation", "source_file": "handler.rs", "must_exist": true },
@@ -24,7 +24,6 @@
     { "name": "worker.rs", "kind": "SCOPE.Component", "source_file": "worker.rs", "must_exist": true },
     { "name": "lib.rs", "kind": "SCOPE.Component", "source_file": "lib.rs", "must_exist": true, "note": "mod root." },
 
-    { "name": "MemoryStore.new", "kind": "SCOPE.Operation", "source_file": "store.rs", "must_exist": false, "nice_to_have": true, "note": "Ideal: receiver-qualified names like MemoryStore.new. Today rust extractor emits the bare fn name." },
     { "name": "create_user", "kind": "SCOPE.Operation", "source_file": "handler.rs", "must_exist": false, "nice_to_have": true, "note": "Ideal: async-flag in metadata on the entity." }
   ],
   "expected_relationships": [
@@ -34,14 +33,14 @@
       "note": "impl UserStore for MemoryStore — captured by the cross/hierarchy rust extractor." },
 
     { "from_name": "MemoryStore", "from_kind": "SCOPE.Component", "from_file": "store.rs",
-      "kind": "CONTAINS", "to_name": "new", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CONTAINS", "to_name": "MemoryStore.new", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true,
-      "note": "impl block CONTAINS fn — bare fn name, not receiver-qualified." },
+      "note": "impl block CONTAINS fn — receiver-qualified name." },
     { "from_name": "MemoryStore", "from_kind": "SCOPE.Component", "from_file": "store.rs",
-      "kind": "CONTAINS", "to_name": "get", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CONTAINS", "to_name": "MemoryStore.get", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true },
     { "from_name": "MemoryStore", "from_kind": "SCOPE.Component", "from_file": "store.rs",
-      "kind": "CONTAINS", "to_name": "put", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CONTAINS", "to_name": "MemoryStore.put", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true },
 
     { "from_name": "main", "from_kind": "SCOPE.Operation", "from_file": "main.rs",
@@ -52,17 +51,17 @@
       "kind": "CALLS", "to_name": "run_worker", "to_kind": "SCOPE.Operation", "to_file": "worker.rs",
       "must_exist": true },
     { "from_name": "main", "from_kind": "SCOPE.Operation", "from_file": "main.rs",
-      "kind": "CALLS", "to_name": "new", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CALLS", "to_name": "MemoryStore.new", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true,
-      "note": "MemoryStore::new() resolves to bare 'new' fn — bare-name CALL." },
+      "note": "MemoryStore::new() resolves to receiver-qualified 'MemoryStore.new'." },
 
     { "from_name": "create_user", "from_kind": "SCOPE.Operation", "from_file": "handler.rs",
-      "kind": "CALLS", "to_name": "put", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CALLS", "to_name": "MemoryStore.put", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true,
-      "note": "Cross-module method call store.put(u) — currently resolves to the bare 'put' fn." },
+      "note": "Cross-module method call store.put(u) — resolves to receiver-qualified 'MemoryStore.put'." },
 
     { "from_name": "fetch_user", "from_kind": "SCOPE.Operation", "from_file": "handler.rs",
-      "kind": "CALLS", "to_name": "get", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
+      "kind": "CALLS", "to_name": "MemoryStore.get", "to_kind": "SCOPE.Operation", "to_file": "store.rs",
       "must_exist": true },
 
     { "from_name": "run_worker", "from_kind": "SCOPE.Operation", "from_file": "worker.rs",
@@ -76,10 +75,6 @@
     { "from_name": "worker.rs", "from_kind": "SCOPE.Component", "from_file": "worker.rs",
       "kind": "IMPORTS", "to_bare_name": "ext:tokio", "must_exist": true },
     { "from_name": "store.rs", "from_kind": "SCOPE.Component", "from_file": "store.rs",
-      "kind": "IMPORTS", "to_bare_name": "ext:std", "must_exist": true },
-
-    { "from_name": "create_user", "from_kind": "SCOPE.Operation", "from_file": "handler.rs",
-      "kind": "CALLS", "to_bare_name": "MemoryStore.put", "must_exist": false, "nice_to_have": true,
-      "note": "Receiver-qualified resolution for trait method dispatch is not yet implemented." }
+      "kind": "IMPORTS", "to_bare_name": "ext:std", "must_exist": true }
   ]
 }


### PR DESCRIPTION
## Summary
Verified and integrated two golden test fixtures into the archigraph quality harness. Both fixtures now pass the extraction-quality benchmark with 100% entity and relationship recall.

## What was done
- **go-chi-mini**: 6 Go source files, 20 entities, 19 relationships — 100% recall
- **rust-tokio-mini**: 5 Rust source files, 16 entities, 13 relationships — 100% recall

## Changes
Updated `internal/quality/golden/rust-tokio-mini/expected.json` to match current Rust extractor behavior:
- Fixed entity names: bare `new`/`get`/`put` → receiver-qualified `MemoryStore.new`/`MemoryStore.get`/`MemoryStore.put`
- Updated all 6 relationships that reference these methods
- Removed obsolete nice-to-have assertions that are now satisfied by the extractor

## Verification
All quality tests pass:
- `./build/archigraph quality internal/quality/golden/go-chi-mini` ✓ (100% recall)
- `./build/archigraph quality internal/quality/golden/rust-tokio-mini` ✓ (100% recall)
- `bash scripts/quality/run.sh` — both fixtures pass full harness

## Metrics
- **go-chi-mini**: 20/20 entities, 19/19 relationships, 64 total extracted
- **rust-tokio-mini**: 16/16 entities, 13/13 relationships, 28 total extracted

## Closes
Fixes #605, #606

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>