### PR TITLE
feat(links): P5 OpenAPI spec cross-repo linker — method+path pivot for backend↔frontend graphs

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -243,6 +243,15 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 	}
 	res.Results = append(res.Results, p4)
 
+	// P5 — OpenAPI spec → HTTP route cross-linker. Uses openapi_operation
+	// entities emitted by the patterns extractor as the pivot to create
+	// consumer-caller → producer-handler links with method=openapi-spec.
+	p5, err := runOpenAPISpecPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("openapi-spec pass: %w", err)
+	}
+	res.Results = append(res.Results, p5)
+
 	for _, r := range res.Results {
 		res.TotalLinks += r.LinksAdded
 		res.TotalCandid += r.Candidates

--- a/internal/links/openapi_pass.go
+++ b/internal/links/openapi_pass.go
@@ -1,0 +1,409 @@
+package links
+
+// openapi_pass.go implements the cross-repo OpenAPI spec linker (P5).
+//
+// Overview
+// --------
+// When a repository contains an OpenAPI/Swagger spec, the per-repo
+// indexer (internal/patterns/openapi_extractor.go) emits one
+// `openapi_operation` entity per path+method pair, carrying:
+//
+//	kind       = "openapi_operation"
+//	Properties["method"] = "GET" | "POST" | ...
+//	Properties["path"]   = "/api/users/{id}"
+//
+// This pass treats those entities as the authoritative contract
+// definition and creates cross-repo FETCHES links between:
+//
+//   - producer side: any `http_endpoint` entity in any other repo with
+//     pattern_type=http_endpoint_synthesis, whose (verb, path) matches
+//     the spec operation (after path-parameter normalisation).
+//   - consumer side: any `http_endpoint` entity in any other repo with
+//     pattern_type=http_endpoint_client_synthesis, whose (verb, path)
+//     matches the spec operation.
+//
+// For each matched (consumer-caller → producer-handler) pair we emit
+// one cross-repo Link with:
+//
+//	method       = "openapi-spec"
+//	relation     = "calls"
+//	channel      = "http"
+//	identifier   = "http:<VERB>:<canonical-path>"
+//	match_quality = "openapi-spec"
+//
+// This is P5 — it runs after the structural (P1), label (P2), string
+// (P3), and direct-HTTP (P4) passes. Method-segregated overwrite means
+// re-running it cleanly replaces its own prior output without touching
+// P1–P4 entries.
+//
+// Relation to the direct-HTTP pass (P4)
+// --------------------------------------
+// P4 matches http_endpoint synthetics by shared canonical Name across
+// repos (the `http:<VERB>:<path>` string). P5 uses the OpenAPI spec
+// itself as the pivot: it resolves (verb, path) ← spec → (handler,
+// caller) even when the two repos never both emit an http_endpoint
+// synthetic with the identical name string, e.g. because the spec is
+// hosted in a third "api-contracts" repo.
+//
+// When both P4 and P5 fire for the same consumer→producer pair the
+// method-segregated IDs differ (P4: "http"; P5: "openapi-spec") so
+// both entries coexist — downstream consumers can filter by method to
+// prefer the higher-provenance source.
+
+import (
+	"sort"
+	"strings"
+)
+
+// MethodOpenAPISpec identifies this pass's emissions in links.json.
+const MethodOpenAPISpec = "openapi-spec"
+
+// openAPISpecChannel is written to Link.Channel for every P5 emission.
+const openAPISpecChannel = "http"
+
+// openAPISpecMatchQuality is written to Link.MatchQuality.
+const openAPISpecMatchQuality = "openapi-spec"
+
+// openAPIOperationKind is the entity Kind emitted by the patterns
+// openapi_extractor.go for every path+method in a spec file.
+const openAPIOperationKind = "openapi_operation"
+
+// opHit collects one openapi_operation entity from a specific repo.
+type opHit struct {
+	repo       string
+	entityID   string
+	verb       string // normalised to UPPER
+	path       string // raw from Properties["path"]
+	sourceFile string
+}
+
+// runOpenAPISpecPass implements P5.
+func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "openapi-spec"}
+
+	if len(graphs) < 2 {
+		// Clean up any prior openapi-spec entries even when the group
+		// shrinks to one repo.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodOpenAPISpec), nil, rejects)
+		return res, err
+	}
+
+	// ── Step 1: collect openapi_operation entities, keyed by normalised
+	//            (verb, path) so we can cross-reference against http_endpoint
+	//            entities from the same or other repos.
+	//
+	// normalKey → []opHit
+	specOps := map[string][]opHit{}
+	for _, g := range graphs {
+		for _, e := range g.Entities {
+			if e.Kind != openAPIOperationKind {
+				continue
+			}
+			if e.Properties == nil {
+				continue
+			}
+			verb := strings.ToUpper(e.Properties["method"])
+			path := e.Properties["path"]
+			if verb == "" || path == "" {
+				continue
+			}
+			key := normalizePathForIndex(path)
+			hit := opHit{
+				repo:       g.Repo,
+				entityID:   e.ID,
+				verb:       verb,
+				path:       path,
+				sourceFile: e.SourceFile,
+			}
+			specOps[key] = append(specOps[key], hit)
+		}
+	}
+
+	if len(specOps) == 0 {
+		// No spec files indexed in this group — nothing to do.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodOpenAPISpec), nil, rejects)
+		return res, err
+	}
+
+	// ── Step 2: collect http_endpoint (producer & consumer) entities,
+	//            also keyed by normalised path (with verb for matching).
+	//
+	// We reuse httpEndpointHit from http_pass.go plus the same
+	// producer/consumer disambiguation logic (pattern_type property,
+	// edge-based fallback, default-producer).
+	//
+	// Pre-compute per-repo edge maps (IMPLEMENTS / CALLS) so we can
+	// resolve handler / caller IDs quickly.
+	type endpointEdges struct {
+		implementsFrom []string
+		callsFrom      []string
+	}
+	edgesByEndpoint := map[string]map[string]*endpointEdges{}
+	for _, g := range graphs {
+		m := map[string]*endpointEdges{}
+		edgesByEndpoint[g.Repo] = m
+		for _, e := range g.Edges {
+			switch strings.ToUpper(e.Kind) {
+			case "IMPLEMENTS":
+				ee := m[e.ToID]
+				if ee == nil {
+					ee = &endpointEdges{}
+					m[e.ToID] = ee
+				}
+				ee.implementsFrom = append(ee.implementsFrom, e.FromID)
+			case "CALLS":
+				ee := m[e.ToID]
+				if ee == nil {
+					ee = &endpointEdges{}
+					m[e.ToID] = ee
+				}
+				ee.callsFrom = append(ee.callsFrom, e.FromID)
+			}
+		}
+	}
+
+	// normalKey → side → []httpEndpointHit
+	type sideMap struct {
+		producers []*httpEndpointHit
+		consumers []*httpEndpointHit
+	}
+	byNormPath := map[string]*sideMap{}
+
+	for _, g := range graphs {
+		// Build (kind,name,file) → entityID index for source_caller resolution.
+		type entKey struct{ kind, name, file string }
+		entIDByKey := map[entKey]string{}
+		for _, e := range g.Entities {
+			if e.Kind == httpEndpointKindLink {
+				continue
+			}
+			k := entKey{e.Kind, e.Name, e.SourceFile}
+			if _, ok := entIDByKey[k]; !ok {
+				entIDByKey[k] = e.ID
+			}
+		}
+
+		for _, e := range g.Entities {
+			if e.Kind != httpEndpointKindLink {
+				continue
+			}
+			if e.Name == "" || e.Properties == nil {
+				continue
+			}
+			verb := strings.ToUpper(e.Properties["verb"])
+			path := e.Properties["path"]
+			if verb == "" && path == "" {
+				// Fall back to parsing from canonical name.
+				if v, p, ok := parseHTTPName(e.Name); ok {
+					verb = strings.ToUpper(v)
+					path = p
+				}
+			}
+			if path == "" {
+				continue
+			}
+			normKey := normalizePathForIndex(path)
+
+			hit := &httpEndpointHit{
+				repo:          g.Repo,
+				stampedID:     e.ID,
+				name:          e.Name,
+				verb:          verb,
+				canonicalPath: path,
+				sourceFile:    e.SourceFile,
+				framework:     e.Properties["framework"],
+			}
+
+			// Determine side from pattern_type property.
+			switch e.Properties["pattern_type"] {
+			case patternTypeProducer:
+				hit.side = sideProducer
+			case patternTypeConsumer:
+				hit.side = sideConsumer
+			}
+
+			// Resolve source_caller (consumer side).
+			if ref := e.Properties["source_caller"]; ref != "" {
+				if kind, name, ok := splitKindNameRef(ref); ok {
+					if id := entIDByKey[entKey{kind, name, e.SourceFile}]; id != "" {
+						hit.callerID = id
+					}
+				}
+			}
+
+			// Edge-based side + handler/caller resolution.
+			if ee := edgesByEndpoint[g.Repo][e.ID]; ee != nil {
+				if len(ee.implementsFrom) > 0 {
+					if hit.side == sideUnknown {
+						hit.side = sideProducer
+					}
+					hit.handlerID = ee.implementsFrom[0]
+				}
+				if len(ee.callsFrom) > 0 {
+					if hit.side == sideUnknown {
+						hit.side = sideConsumer
+					}
+					if hit.callerID == "" {
+						hit.callerID = ee.callsFrom[0]
+					}
+				}
+			}
+
+			// Default: treat as producer when no signal.
+			if hit.side == sideUnknown {
+				hit.side = sideProducer
+			}
+
+			sm := byNormPath[normKey]
+			if sm == nil {
+				sm = &sideMap{}
+				byNormPath[normKey] = sm
+			}
+			switch hit.side {
+			case sideProducer:
+				sm.producers = append(sm.producers, hit)
+			case sideConsumer:
+				sm.consumers = append(sm.consumers, hit)
+			}
+		}
+	}
+
+	// ── Step 3: for each openapi_operation, look up producers and
+	//            consumers with matching (verb, normPath) and emit links.
+	//
+	// The spec operation acts as a bridge: the link direction is always
+	// consumer-caller → producer-handler (same as P4).
+	//
+	// For each (spec-repo, normKey) we first filter producers and
+	// consumers to those in *different* repos from the spec, then apply
+	// the same verb-aware tier selection as pickProducerForConsumer.
+
+	now := discoveredAt()
+	emitted := map[string]bool{}
+	var fresh []Link
+
+	// Iterate in deterministic order (sorted normPath keys).
+	sortedNormKeys := make([]string, 0, len(specOps))
+	for k := range specOps {
+		sortedNormKeys = append(sortedNormKeys, k)
+	}
+	sort.Strings(sortedNormKeys)
+
+	for _, normKey := range sortedNormKeys {
+		ops := specOps[normKey]
+		sm := byNormPath[normKey]
+		if sm == nil {
+			// No http_endpoint entities for this path at all.
+			continue
+		}
+
+		for _, op := range ops {
+			// Filter producers and consumers to those from repos OTHER
+			// than the spec repo. Same-repo links are meaningless here.
+			var producers, consumers []*httpEndpointHit
+			for _, h := range sm.producers {
+				if h.repo == op.repo {
+					continue
+				}
+				if !verbsCompatible(op.verb, h.verb) {
+					continue
+				}
+				producers = append(producers, h)
+			}
+			for _, h := range sm.consumers {
+				if h.repo == op.repo {
+					continue
+				}
+				if !verbsCompatible(op.verb, h.verb) {
+					continue
+				}
+				consumers = append(consumers, h)
+			}
+
+			if len(producers) == 0 || len(consumers) == 0 {
+				continue
+			}
+
+			// Deterministic ordering.
+			sort.SliceStable(producers, func(i, j int) bool { return less(producers[i], producers[j]) })
+			sort.SliceStable(consumers, func(i, j int) bool { return less(consumers[i], consumers[j]) })
+
+			// Group by repo for cross-product emission.
+			producersByRepo := map[string][]*httpEndpointHit{}
+			for _, p := range producers {
+				producersByRepo[p.repo] = append(producersByRepo[p.repo], p)
+			}
+			consumerRepos := map[string]*httpEndpointHit{}
+			for _, c := range consumers {
+				if _, ok := consumerRepos[c.repo]; !ok {
+					consumerRepos[c.repo] = c
+				}
+			}
+
+			cRepoNames := sortedKeys(consumerRepos)
+			pRepoNames := make([]string, 0, len(producersByRepo))
+			for r := range producersByRepo {
+				pRepoNames = append(pRepoNames, r)
+			}
+			sort.Strings(pRepoNames)
+
+			for _, cRepo := range cRepoNames {
+				for _, pRepo := range pRepoNames {
+					if cRepo == pRepo {
+						continue
+					}
+					c := consumerRepos[cRepo]
+					p, _ := pickProducerForConsumer(c, producersByRepo[pRepo])
+					if p == nil {
+						continue
+					}
+
+					srcID := c.callerID
+					if srcID == "" {
+						srcID = c.stampedID
+					}
+					tgtID := p.handlerID
+					if tgtID == "" {
+						tgtID = p.stampedID
+					}
+					source := entityKey(c.repo, srcID)
+					target := entityKey(p.repo, tgtID)
+					id := MakeID(source, target, MethodOpenAPISpec)
+					if emitted[id] {
+						continue
+					}
+					emitted[id] = true
+
+					ident := canonicalIdentifier(c, p)
+					ch := openAPISpecChannel
+					link := Link{
+						ID:           id,
+						Source:       source,
+						Target:       target,
+						Relation:     RelationCalls,
+						Method:       MethodOpenAPISpec,
+						Confidence:   ScoreImport(), // spec-backed = high confidence
+						Channel:      &ch,
+						Identifier:   &ident,
+						DiscoveredAt: now,
+						SourceLocations: [][]string{
+							{c.sourceFile},
+							{op.sourceFile},
+							{p.sourceFile},
+						},
+						MatchQuality: openAPISpecMatchQuality,
+					}
+					fresh = append(fresh, link)
+				}
+			}
+		}
+	}
+
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodOpenAPISpec), fresh, rejects)
+	if err != nil {
+		return res, err
+	}
+	res.LinksAdded = added
+	res.Skipped = skipped
+	return res, nil
+}

--- a/internal/links/openapi_pass_test.go
+++ b/internal/links/openapi_pass_test.go
@@ -1,0 +1,543 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestOpenAPISpecPass_HappyPath verifies the canonical three-repo scenario:
+//   - repo "api-spec" contains an openapi_operation entity (GET /users/{id})
+//   - repo "backend" contains an http_endpoint producer + IMPLEMENTS edge
+//   - repo "frontend" contains an http_endpoint consumer + source_caller
+//
+// Expected: one openapi-spec method link from frontend::fn1 → backend::h1
+// with channel=http and identifier=http:GET:/users/{id}.
+func TestOpenAPISpecPass_HappyPath(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Spec repo: openapi_operation entity for GET /users/{id}.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "api-spec",
+		Entities: []map[string]any{
+			{
+				"id":          "op1",
+				"name":        "openapi_op_get__users_{id}",
+				"kind":        "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties": map[string]any{
+					"method": "GET",
+					"path":   "/users/{id}",
+					"kind":   "openapi",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	// Backend repo: handler + producer http_endpoint.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "h1",
+				"name":        "UserView",
+				"kind":        "Controller",
+				"source_file": "app/views.py",
+			},
+			{
+				"id":          "ep1",
+				"name":        "http:GET:/users/{id}",
+				"kind":        "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/users/{id}",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+
+	// Frontend repo: caller function + consumer http_endpoint.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id":          "fn1",
+				"name":        "loadUser",
+				"kind":        "Function",
+				"source_file": "src/api.ts",
+			},
+			{
+				"id":          "ep2",
+				"name":        "http:GET:/users/{id}",
+				"kind":        "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/users/{id}",
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:loadUser",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("goa", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "goa-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var hit *Link
+	for i, l := range doc.Links {
+		if l.Method == MethodOpenAPISpec {
+			hit = &doc.Links[i]
+			break
+		}
+	}
+	if hit == nil {
+		t.Fatalf("expected at least one openapi-spec link, got links: %+v", doc.Links)
+	}
+	if hit.Source != "frontend::fn1" {
+		t.Errorf("source: want frontend::fn1 (resolved caller), got %s", hit.Source)
+	}
+	if hit.Target != "backend::h1" {
+		t.Errorf("target: want backend::h1 (resolved handler), got %s", hit.Target)
+	}
+	if hit.Relation != RelationCalls {
+		t.Errorf("relation: want calls, got %s", hit.Relation)
+	}
+	if hit.Channel == nil || *hit.Channel != "http" {
+		t.Errorf("channel: want http, got %v", hit.Channel)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "http:GET:/users/{id}" {
+		t.Errorf("identifier: want http:GET:/users/{id}, got %v", hit.Identifier)
+	}
+	if hit.MatchQuality != openAPISpecMatchQuality {
+		t.Errorf("match_quality: want %q, got %q", openAPISpecMatchQuality, hit.MatchQuality)
+	}
+}
+
+// TestOpenAPISpecPass_AnyVerbProducer checks that a Django ANY-verb producer
+// correctly matches a spec GET operation and a GET consumer.
+func TestOpenAPISpecPass_AnyVerbProducer(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "contracts",
+		Entities: []map[string]any{
+			{
+				"id":          "op1",
+				"name":        "openapi_op_post__items",
+				"kind":        "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties": map[string]any{
+					"method": "POST",
+					"path":   "/items",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "h1",
+				"name":        "ItemView",
+				"kind":        "Controller",
+				"source_file": "views.py",
+			},
+			{
+				"id":          "ep1",
+				"name":        "http:ANY:/items",
+				"kind":        "http_endpoint",
+				"source_file": "views.py",
+				"properties": map[string]any{
+					"verb":         "ANY",
+					"path":         "/items",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "mobile",
+		Entities: []map[string]any{
+			{
+				"id":          "fn2",
+				"name":        "createItem",
+				"kind":        "Function",
+				"source_file": "api.js",
+			},
+			{
+				"id":          "ep2",
+				"name":        "http:POST:/items",
+				"kind":        "http_endpoint",
+				"source_file": "api.js",
+				"properties": map[string]any{
+					"verb":          "POST",
+					"path":          "/items",
+					"framework":     "axios",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:createItem",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("goa2", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "goa2-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodOpenAPISpec && l.Source == "mobile::fn2" && l.Target == "backend::h1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected openapi-spec link mobile::fn2 → backend::h1, got %+v", doc.Links)
+	}
+}
+
+// TestOpenAPISpecPass_NoMatchWhenNoSpec ensures the pass emits nothing when
+// no openapi_operation entities exist in the group (pure direct-HTTP group).
+func TestOpenAPISpecPass_NoMatchWhenNoSpec(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Two repos with http_endpoints but no spec.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "ep1",
+				"name":        "http:GET:/foo",
+				"kind":        "http_endpoint",
+				"source_file": "views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/foo",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id":          "ep2",
+				"name":        "http:GET:/foo",
+				"kind":        "http_endpoint",
+				"source_file": "api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/foo",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchFoo",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gnos", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gnos-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodOpenAPISpec {
+			t.Errorf("expected no openapi-spec links when no spec present, got %+v", l)
+		}
+	}
+}
+
+// TestOpenAPISpecPass_VerbMismatch ensures the pass does NOT link a spec
+// GET operation to a consumer that calls POST (different verb).
+func TestOpenAPISpecPass_VerbMismatch(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "contracts",
+		Entities: []map[string]any{
+			{
+				"id":          "op1",
+				"name":        "openapi_op_get__users",
+				"kind":        "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties": map[string]any{
+					"method": "GET",
+					"path":   "/users",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "ep1",
+				"name":        "http:GET:/users",
+				"kind":        "http_endpoint",
+				"source_file": "views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/users",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id":          "ep2",
+				"name":        "http:POST:/users",
+				"kind":        "http_endpoint",
+				"source_file": "api.ts",
+				"properties": map[string]any{
+					"verb":          "POST",  // mismatch with spec GET
+					"path":          "/users",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:createUser",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gverb", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gverb-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method == MethodOpenAPISpec {
+			t.Errorf("expected no openapi-spec links on verb mismatch, got %+v", l)
+		}
+	}
+}
+
+// TestOpenAPISpecPass_PathParamNormalisation verifies that path parameter
+// name differences ({id} vs {pk} vs :id) are normalised before matching.
+func TestOpenAPISpecPass_PathParamNormalisation(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Spec uses {id} style.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "contracts",
+		Entities: []map[string]any{
+			{
+				"id":          "op1",
+				"name":        "openapi_op_get__products_{id}",
+				"kind":        "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties": map[string]any{
+					"method": "GET",
+					"path":   "/products/{id}",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	// Backend uses {pk} style (Django default).
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "h1",
+				"name":        "ProductView",
+				"kind":        "Controller",
+				"source_file": "views.py",
+			},
+			{
+				"id":          "ep1",
+				"name":        "http:GET:/products/{pk}",
+				"kind":        "http_endpoint",
+				"source_file": "views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/products/{pk}",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	// Frontend uses :id Express style.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id":          "fn1",
+				"name":        "getProduct",
+				"kind":        "Function",
+				"source_file": "api.ts",
+			},
+			{
+				"id":          "ep2",
+				"name":        "http:GET:/products/:id",
+				"kind":        "http_endpoint",
+				"source_file": "api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/products/:id",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:getProduct",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gparam", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gparam-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodOpenAPISpec && l.Source == "frontend::fn1" && l.Target == "backend::h1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("expected openapi-spec link across path-param style differences; got %+v", doc.Links)
+	}
+}
+
+// TestOpenAPISpecPass_CoexistsWithHTTPPass verifies that when BOTH the
+// http pass (P4) and the openapi-spec pass (P5) fire for the same
+// consumer→producer pair, both links appear in the output (they have
+// distinct method values and therefore distinct IDs).
+func TestOpenAPISpecPass_CoexistsWithHTTPPass(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "contracts",
+		Entities: []map[string]any{
+			{
+				"id":          "op1",
+				"name":        "openapi_op_get__items",
+				"kind":        "openapi_operation",
+				"source_file": "openapi.yaml",
+				"properties": map[string]any{
+					"method": "GET",
+					"path":   "/items",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id":          "h1",
+				"name":        "ItemsView",
+				"kind":        "Controller",
+				"source_file": "views.py",
+			},
+			{
+				"id":          "ep1",
+				"name":        "http:GET:/items",
+				"kind":        "http_endpoint",
+				"source_file": "views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/items",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id":          "fn1",
+				"name":        "fetchItems",
+				"kind":        "Function",
+				"source_file": "api.ts",
+			},
+			{
+				"id":          "ep2",
+				"name":        "http:GET:/items",
+				"kind":        "http_endpoint",
+				"source_file": "api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/items",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:fetchItems",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("gcoex", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "gcoex-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var hasHTTP, hasOASpec bool
+	for _, l := range doc.Links {
+		if l.Source == "frontend::fn1" && l.Target == "backend::h1" {
+			switch l.Method {
+			case MethodHTTP:
+				hasHTTP = true
+			case MethodOpenAPISpec:
+				hasOASpec = true
+			}
+		}
+	}
+	if !hasHTTP {
+		t.Errorf("expected a method=http link from P4 pass; got %+v", doc.Links)
+	}
+	if !hasOASpec {
+		t.Errorf("expected a method=openapi-spec link from P5 pass; got %+v", doc.Links)
+	}
+}


### PR DESCRIPTION
## Summary

Add **P5 — the OpenAPI spec cross-repo linker** (`method=openapi-spec`), a new links pass that treats `openapi_operation` entities (already emitted by `internal/patterns/openapi_extractor.go`) as the authoritative contract pivot for cross-repo backend↔frontend linking.

**How it works:**
- During per-repo indexing, the patterns extractor already writes one `openapi_operation` entity per `(method, path)` pair found in `openapi.yaml` / `openapi.json` / `swagger.json` spec files.
- P5 reads those entities from `graph.json` at link-time, normalises path parameters (`{id}`, `{pk}`, `:id` → `{*}`), and finds matching `http_endpoint` producer entities (Django handlers, etc.) and consumer entities (fetch/axios call-sites) in **other repos** in the group.
- For each matched (consumer-caller → producer-handler) pair, it emits a cross-repo `CALLS` link with:
  - `method = "openapi-spec"` (distinct from P4's `"http"`, so both coexist when applicable)
  - `channel = "http"`
  - `identifier = "http:<VERB>:<path>"`
  - `match_quality = "openapi-spec"` (provenance annotation)
  - `confidence = 1.0` (spec-backed = same confidence as structural imports)

**What this enables:** "Which frontend components call the `/api/devices/` endpoint, and which backend view handles it?" now works across repos even when the spec lives in a dedicated `api-contracts` repo, and the two service repos never share an identical `http_endpoint` synthetic name.

**Relationship to P4 (direct-HTTP pass):**
- P4 matches by shared `http:<VERB>:<path>` entity name across repos (both repos must have indexed the same canonical name).
- P5 uses the spec as the pivot — it works when the spec is in a third repo or when name-string alignment between producer and consumer is imperfect.
- Method-segregated IDs differ (`"http"` vs `"openapi-spec"`), so both entries coexist and callers can filter by provenance.

**Implementation:**
- New file: `internal/links/openapi_pass.go` — `runOpenAPISpecPass()` (P5)
- Modified: `internal/links/links.go` — wires P5 into `RunAllPasses()` after P4
- New file: `internal/links/openapi_pass_test.go` — 6 tests

## Closes / Refs

- Closes #510

## Testing

- [x] All tests pass: `go test ./...`
- [x] 6 new unit tests in `internal/links/openapi_pass_test.go`:
  - `TestOpenAPISpecPass_HappyPath` — three-repo scenario (contracts+backend+frontend), resolves caller→handler via source_caller + IMPLEMENTS edge
  - `TestOpenAPISpecPass_AnyVerbProducer` — Django ANY-verb producer matches spec POST + consumer POST
  - `TestOpenAPISpecPass_NoMatchWhenNoSpec` — guard: emits nothing when no openapi_operation entities present
  - `TestOpenAPISpecPass_VerbMismatch` — guard: does NOT link spec GET to consumer POST on same path
  - `TestOpenAPISpecPass_PathParamNormalisation` — spec `{id}` vs backend `{pk}` vs frontend `:id` all normalise and match
  - `TestOpenAPISpecPass_CoexistsWithHTTPPass` — P4 (`method=http`) and P5 (`method=openapi-spec`) both appear for the same pair
- [x] Full `internal/links` suite: no regressions (2.4s)
- [x] `go build ./...` clean

## Notes

The OpenAPI extractor (`internal/patterns/openapi_extractor.go`) was **not changed** — it already emits `openapi_operation` entities with `Properties["method"]` and `Properties["path"]` populated. P5 is purely a links-layer pass that consumes those already-indexed entities.