### PR TITLE
[#497] Swift: SwiftPM Package.swift target extractor

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -494,6 +494,19 @@ var extensionLanguageMap = map[string]string{
 	".rst":      "markdown",
 }
 
+// exactBasenameLanguageMap maps exact file basenames (case-sensitive) to
+// language tokens for files that carry a known extension but must be assigned
+// a more specific language key than the generic extension match would produce.
+// This map is consulted BEFORE extensionLanguageMap so that specialised
+// handlers win over the generic extension-based dispatch.
+//
+// Issue #497 — Package.swift is a SwiftPM manifest whose extraction
+// requires a dedicated regex-based extractor ("swift_package") rather than
+// the tree-sitter-based generic Swift extractor ("swift").
+var exactBasenameLanguageMap = map[string]string{
+	"Package.swift": "swift_package",
+}
+
 // basenameLanguageMap maps exact file basenames (case-sensitive) to language
 // tokens. Checked only when the file has no extension or its extension is not
 // in extensionLanguageMap.
@@ -517,13 +530,22 @@ func detectLanguage(norm string) string {
 	if strings.HasSuffix(lower, ".scala.html") {
 		return "scala"
 	}
+
+	// Issue #497 — exact-basename check before the extension lookup so that
+	// files like "Package.swift" (which carry a recognised extension) can be
+	// assigned a more specific language key ("swift_package") instead of the
+	// generic one ("swift").
+	base := path.Base(norm)
+	if lang, ok := exactBasenameLanguageMap[base]; ok {
+		return lang
+	}
+
 	ext := strings.ToLower(filepath.Ext(norm))
 	if lang, ok := extensionLanguageMap[ext]; ok {
 		return lang
 	}
 	// Fall back to basename matching for files like Dockerfile / Containerfile
 	// that carry no extension.
-	base := path.Base(norm)
 	return basenameLanguageMap[base]
 }
 

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -1034,3 +1034,36 @@ func TestMX1122_CppRoutesToCppExtractor(t *testing.T) {
 		})
 	}
 }
+
+// TestClassify_PackageSwift_IsSwiftPackage verifies that "Package.swift" is
+// classified as "swift_package" (not the generic "swift"), and that the
+// registered swift_package extractor is reachable via the classifier's output
+// token. Issue #497.
+func TestClassify_PackageSwift_IsSwiftPackage(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+
+	cases := []string{
+		"Package.swift",
+		"Sources/MyApp/Package.swift",
+	}
+
+	for _, file := range cases {
+		t.Run(file, func(t *testing.T) {
+			r := c.Classify(ctx, file)
+			if r.Skip {
+				t.Errorf("file=%q should NOT be skipped", file)
+			}
+			if r.Language != "swift_package" {
+				t.Errorf("file=%q: Language=%q, want swift_package", file, r.Language)
+			}
+			ex, ok := extractors.Get(r.Language)
+			if !ok {
+				t.Fatalf("file=%q: no extractor registered for %q", file, r.Language)
+			}
+			if ex.Language() != "swift_package" {
+				t.Errorf("extractor.Language()=%q want swift_package", ex.Language())
+			}
+		})
+	}
+}

--- a/internal/extractors/swift/package.go
+++ b/internal/extractors/swift/package.go
@@ -1,0 +1,329 @@
+// package.go — regex-based extractor for SwiftPM Package.swift manifests.
+//
+// Issue #497: Package.swift is a Swift DSL file that declares targets and
+// their dependencies. The tree-sitter Swift grammar correctly parses it as
+// Swift code, but the existing swift extractor only emits function/class/
+// import entities — it does not model the SwiftPM target graph.
+//
+// This extractor is registered under the language key "swift_package" and
+// is dispatched when the classifier assigns that key to a file named
+// exactly "Package.swift" (see internal/classifier/classifier.go).
+//
+// Emitted entities and relationships:
+//
+//	.target(name: "X", ...)          → SCOPE.Component (subtype="swiftpm_target")
+//	.executableTarget(name: "X", ...) → SCOPE.Component (subtype="swiftpm_target",
+//	                                     properties["kind"]="executable")
+//	.testTarget(name: "X", ...)       → SCOPE.Component (subtype="swiftpm_target",
+//	                                     properties["kind"]="test")
+//	.product(name: "X", package: "Y") → SCOPE.External  (subtype="swiftpm_product")
+//	dependencies: ["Y"]               → DEPENDS_ON edges between target entities
+//
+// Regex-based parsing is intentional for v1: Package.swift DSL shapes are
+// stable and well-defined enough for simple pattern matching, and avoids a
+// dependency on a tree-sitter Swift parse of the manifest (which would still
+// require AST-level semantic analysis to resolve the call graph anyway).
+package swift
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("swift_package", &PackageExtractor{})
+}
+
+// PackageExtractor implements extractor.Extractor for Package.swift manifests.
+type PackageExtractor struct{}
+
+// Language returns the canonical language key for this extractor.
+func (p *PackageExtractor) Language() string { return "swift_package" }
+
+// Extract parses a Package.swift file and emits:
+//   - One SCOPE.Component per .target / .executableTarget / .testTarget call
+//   - One SCOPE.External per .product(name:package:) dependency reference
+//   - DEPENDS_ON edges from each target to its named dependencies
+//
+// On nil content the extractor returns an empty slice with no error.
+func (p *PackageExtractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	targets := extractTargets(src, file.Path)
+	extractor.TagRelationshipsLanguage(targets, "swift_package")
+	return targets, nil
+}
+
+// ---------------------------------------------------------------------------
+// Regex patterns
+// ---------------------------------------------------------------------------
+
+// targetCallRe matches the opening of a target call:
+//
+//	.target(name: "X"
+//	.executableTarget(name: "X"
+//	.testTarget(name: "X"
+//
+// Capture groups:
+//
+//	1 — target kind ("target", "executableTarget", "testTarget")
+//	2 — target name
+var targetCallRe = regexp.MustCompile(`\.(target|executableTarget|testTarget)\s*\(\s*name\s*:\s*"([^"]+)"`)
+
+// targetStringDepRe matches a bare string dependency inside a dependencies array:
+//
+//	"TargetName"
+//
+// Capture groups:
+//
+//	1 — dependency name
+var targetStringDepRe = regexp.MustCompile(`"([A-Za-z][A-Za-z0-9_.-]*)"`)
+
+// productDepRe matches a .product(name: "X", package: "Y") dependency:
+//
+//	.product(name: "X", package: "Y")
+//
+// Capture groups:
+//
+//	1 — product name
+//	2 — package name
+var productDepRe = regexp.MustCompile(`\.product\s*\(\s*name\s*:\s*"([^"]+)"\s*,\s*package\s*:\s*"([^"]+)"`)
+
+// ---------------------------------------------------------------------------
+// Extraction helpers
+// ---------------------------------------------------------------------------
+
+// extractTargets parses the full source text and returns all entity records.
+func extractTargets(src, filePath string) []types.EntityRecord {
+	lines := strings.Split(src, "\n")
+
+	// Pass 1 — find every target declaration and collect the raw argument
+	// block that follows it.
+	//
+	// We run the regex against the full source (not line-by-line) because
+	// `.target(\n    name: "X"` spans two lines and \s* in the pattern
+	// matches the newline. We then convert match byte offsets to line numbers.
+	type targetDecl struct {
+		kind    string // "target" | "executableTarget" | "testTarget"
+		name    string
+		lineNum int
+		body    string // text inside .target( … )
+	}
+
+	var decls []targetDecl
+
+	allMatches := targetCallRe.FindAllStringSubmatchIndex(src, -1)
+	for _, loc := range allMatches {
+		// loc[0]:loc[1] — whole match; loc[2]:loc[3] — kind; loc[4]:loc[5] — name
+		if len(loc) < 6 {
+			continue
+		}
+		kind := src[loc[2]:loc[3]]
+		name := src[loc[4]:loc[5]]
+		// Compute 1-based line number from the byte offset of the match start.
+		lineNum := strings.Count(src[:loc[0]], "\n") + 1
+		// Identify which line index to start collecting from.
+		lineIdx := lineNum - 1
+		body := collectArgBlock(lines, lineIdx)
+
+		decls = append(decls, targetDecl{
+			kind:    kind,
+			name:    name,
+			lineNum: lineNum,
+			body:    body,
+		})
+	}
+
+	if len(decls) == 0 {
+		return nil
+	}
+
+	// Pass 2 — for each target, collect its dependencies and build entities.
+	//
+	// Index target names so we can distinguish same-package target deps from
+	// external product deps at emit time.
+	targetNames := make(map[string]bool, len(decls))
+	for _, d := range decls {
+		targetNames[d.name] = true
+	}
+
+	// Track external products already emitted to avoid duplicates.
+	emittedProducts := make(map[string]bool)
+
+	var out []types.EntityRecord
+
+	for _, d := range decls {
+		// Build the target SCOPE.Component entity.
+		rec := types.EntityRecord{
+			Name:       d.name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "swiftpm_target",
+			SourceFile: filePath,
+			Language:   "swift_package",
+			StartLine:  d.lineNum,
+			EndLine:    d.lineNum,
+			Signature:  "." + d.kind + `(name: "` + d.name + `")`,
+			Properties: map[string]string{
+				"swiftpm_kind": d.kind,
+			},
+		}
+
+		// Extract dependencies from the argument body.
+		depsSection := extractDepsSection(d.body)
+
+		// Walk product deps first (they have a known package: argument).
+		for _, pm := range productDepRe.FindAllStringSubmatch(depsSection, -1) {
+			productName := pm[1]
+			packageName := pm[2]
+
+			// Emit DEPENDS_ON edge target → product entity.
+			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+				FromID: filePath + "::" + d.name,
+				ToID:   productName,
+				Kind:   "DEPENDS_ON",
+				Properties: map[string]string{
+					"dep_kind": "product",
+					"package":  packageName,
+				},
+			})
+
+			// Emit a SCOPE.External entity for the product (once per unique product name).
+			key := packageName + "/" + productName
+			if !emittedProducts[key] {
+				emittedProducts[key] = true
+				ext := types.EntityRecord{
+					Name:       productName,
+					Kind:       "SCOPE.External",
+					Subtype:    "swiftpm_product",
+					SourceFile: filePath,
+					Language:   "swift_package",
+					Signature:  `.product(name: "` + productName + `", package: "` + packageName + `")`,
+					Properties: map[string]string{
+						"package": packageName,
+					},
+				}
+				out = append(out, ext)
+			}
+		}
+
+		// Walk bare string deps; filter out product name refs already seen
+		// and the package own-name refs (e.g. version strings, URLs).
+		// A bare "DepName" is a same-package target dependency when the
+		// name exists in our target index; otherwise it is emitted as an
+		// external name reference.
+		//
+		// Strip product blocks to avoid re-matching product names as bare deps.
+		depsStripped := productDepRe.ReplaceAllString(depsSection, "")
+		for _, sm := range targetStringDepRe.FindAllStringSubmatch(depsStripped, -1) {
+			depName := sm[1]
+
+			if depName == d.name {
+				continue // self-reference
+			}
+			// Skip URL-like / semver strings.
+			if looksLikeURL(depName) || looksLikeSemver(depName) {
+				continue
+			}
+
+			depKind := "target"
+			if !targetNames[depName] {
+				depKind = "external"
+			}
+
+			rec.Relationships = append(rec.Relationships, types.RelationshipRecord{
+				FromID: filePath + "::" + d.name,
+				ToID:   depName,
+				Kind:   "DEPENDS_ON",
+				Properties: map[string]string{
+					"dep_kind": depKind,
+				},
+			})
+		}
+
+		out = append(out, rec)
+	}
+
+	return out
+}
+
+// collectArgBlock scans forward from startLine and returns the concatenated
+// text of lines inside the argument parentheses opened on startLine.
+func collectArgBlock(lines []string, startLine int) string {
+	// Count open parens from the call site line.
+	depth := 0
+	var buf strings.Builder
+
+	for i := startLine; i < len(lines); i++ {
+		line := lines[i]
+		for _, ch := range line {
+			switch ch {
+			case '(':
+				depth++
+			case ')':
+				depth--
+				if depth == 0 {
+					buf.WriteString(line)
+					return buf.String()
+				}
+			}
+		}
+		buf.WriteString(line)
+		buf.WriteByte('\n')
+	}
+	return buf.String()
+}
+
+// extractDepsSection returns the substring of body that falls between the
+// "dependencies:" label and the next closing bracket (']') at depth 0, or
+// the empty string if no dependencies label is found.
+func extractDepsSection(body string) string {
+	idx := strings.Index(body, "dependencies:")
+	if idx < 0 {
+		return ""
+	}
+	after := body[idx+len("dependencies:"):]
+	start := strings.IndexByte(after, '[')
+	if start < 0 {
+		return ""
+	}
+
+	depth := 0
+	for i, ch := range after[start:] {
+		switch ch {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return after[start : start+i+1]
+			}
+		}
+	}
+	return after[start:]
+}
+
+// looksLikeURL returns true when name contains a URL-ish scheme or host
+// separator, indicating it is a package URL rather than a target name.
+func looksLikeURL(name string) bool {
+	return strings.Contains(name, "://") ||
+		strings.Contains(name, ".git") ||
+		strings.Contains(name, ".com") ||
+		strings.Contains(name, ".org") ||
+		strings.Contains(name, ".io")
+}
+
+// looksLikeSemver returns true when name matches a rough semver / version-tag
+// pattern (e.g. "1.2.3", "v1.0.0") so we can skip version strings that
+// appear as bare strings adjacent to dependency declarations.
+var semverRe = regexp.MustCompile(`^v?\d+\.\d+`)
+
+func looksLikeSemver(name string) bool {
+	return semverRe.MatchString(name)
+}

--- a/internal/extractors/swift/package_test.go
+++ b/internal/extractors/swift/package_test.go
@@ -1,0 +1,311 @@
+package swift_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/swift"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runPackage invokes the swift_package extractor on src and returns the result.
+func runPackage(t *testing.T, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("swift_package")
+	if !ok {
+		t.Fatal("swift_package extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Package.swift",
+		Content:  []byte(src),
+		Language: "swift_package",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// findPkg finds an entity by name + kind in a slice, returning nil when absent.
+func findPkg(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// findRel returns the first relationship of kind relKind attached to entity e
+// whose ToID is toID, or nil.
+func findRel(e *types.EntityRecord, relKind, toID string) *types.RelationshipRecord {
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == relKind && r.ToID == toID {
+			return r
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestPackageExtractor_Registration verifies the "swift_package" key is wired.
+func TestPackageExtractor_Registration(t *testing.T) {
+	ext, ok := extractor.Get("swift_package")
+	if !ok {
+		t.Fatal("swift_package extractor not registered")
+	}
+	if ext.Language() != "swift_package" {
+		t.Fatalf("Language()=%q want swift_package", ext.Language())
+	}
+}
+
+// TestPackageExtractor_EmptyContent returns nil, nil on empty input.
+func TestPackageExtractor_EmptyContent(t *testing.T) {
+	ext, _ := extractor.Get("swift_package")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "Package.swift",
+		Language: "swift_package",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Fatalf("expected empty slice, got %d entities", len(ents))
+	}
+}
+
+// TestPackageExtractor_TargetDeclaration verifies that a plain .target() call
+// produces a SCOPE.Component with subtype="swiftpm_target".
+func TestPackageExtractor_TargetDeclaration(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MyLib",
+    targets: [
+        .target(
+            name: "MyLib",
+            dependencies: []
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+	e := findPkg(ents, "MyLib", "SCOPE.Component")
+	if e == nil {
+		t.Fatal("expected SCOPE.Component named MyLib, not found")
+	}
+	if e.Subtype != "swiftpm_target" {
+		t.Errorf("Subtype=%q want swiftpm_target", e.Subtype)
+	}
+	if e.Properties["swiftpm_kind"] != "target" {
+		t.Errorf("Properties[swiftpm_kind]=%q want target", e.Properties["swiftpm_kind"])
+	}
+	if e.Language != "swift_package" {
+		t.Errorf("Language=%q want swift_package", e.Language)
+	}
+}
+
+// TestPackageExtractor_ExecutableTarget verifies that .executableTarget() is
+// extracted and tagged with swiftpm_kind="executableTarget".
+func TestPackageExtractor_ExecutableTarget(t *testing.T) {
+	src := `// swift-tools-version:5.9
+import PackageDescription
+
+let package = Package(
+    name: "App",
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: []
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+	e := findPkg(ents, "App", "SCOPE.Component")
+	if e == nil {
+		t.Fatal("expected SCOPE.Component named App")
+	}
+	if e.Properties["swiftpm_kind"] != "executableTarget" {
+		t.Errorf("swiftpm_kind=%q want executableTarget", e.Properties["swiftpm_kind"])
+	}
+}
+
+// TestPackageExtractor_TestTarget verifies that .testTarget() is extracted.
+func TestPackageExtractor_TestTarget(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MyLib",
+    targets: [
+        .target(name: "MyLib", dependencies: []),
+        .testTarget(
+            name: "MyLibTests",
+            dependencies: ["MyLib"]
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+	e := findPkg(ents, "MyLibTests", "SCOPE.Component")
+	if e == nil {
+		t.Fatal("expected SCOPE.Component named MyLibTests")
+	}
+	if e.Properties["swiftpm_kind"] != "testTarget" {
+		t.Errorf("swiftpm_kind=%q want testTarget", e.Properties["swiftpm_kind"])
+	}
+}
+
+// TestPackageExtractor_TargetToTargetDependency verifies that a string
+// dependency from one target to another emits a DEPENDS_ON edge with
+// dep_kind="target".
+func TestPackageExtractor_TargetToTargetDependency(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "MultiTarget",
+    targets: [
+        .target(
+            name: "Core",
+            dependencies: []
+        ),
+        .target(
+            name: "App",
+            dependencies: ["Core"]
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+
+	app := findPkg(ents, "App", "SCOPE.Component")
+	if app == nil {
+		t.Fatal("expected entity App")
+	}
+	rel := findRel(app, "DEPENDS_ON", "Core")
+	if rel == nil {
+		t.Fatalf("expected DEPENDS_ON edge App→Core; relationships=%+v", app.Relationships)
+	}
+	if rel.Properties["dep_kind"] != "target" {
+		t.Errorf("dep_kind=%q want target", rel.Properties["dep_kind"])
+	}
+}
+
+// TestPackageExtractor_ProductDependency verifies that a .product(name:package:)
+// dependency emits a DEPENDS_ON edge and a SCOPE.External entity.
+func TestPackageExtractor_ProductDependency(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "VaporApp",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+
+	// The App target must have a DEPENDS_ON edge to "Vapor".
+	app := findPkg(ents, "App", "SCOPE.Component")
+	if app == nil {
+		t.Fatal("expected entity App")
+	}
+	rel := findRel(app, "DEPENDS_ON", "Vapor")
+	if rel == nil {
+		t.Fatalf("expected DEPENDS_ON edge App→Vapor; relationships=%+v", app.Relationships)
+	}
+	if rel.Properties["dep_kind"] != "product" {
+		t.Errorf("dep_kind=%q want product", rel.Properties["dep_kind"])
+	}
+	if rel.Properties["package"] != "vapor" {
+		t.Errorf("package=%q want vapor", rel.Properties["package"])
+	}
+
+	// A SCOPE.External entity for the product must also be emitted.
+	ext := findPkg(ents, "Vapor", "SCOPE.External")
+	if ext == nil {
+		t.Fatal("expected SCOPE.External named Vapor")
+	}
+	if ext.Subtype != "swiftpm_product" {
+		t.Errorf("SCOPE.External Subtype=%q want swiftpm_product", ext.Subtype)
+	}
+	if ext.Properties["package"] != "vapor" {
+		t.Errorf("SCOPE.External package=%q want vapor", ext.Properties["package"])
+	}
+}
+
+// TestPackageExtractor_LanguageTagOnRelationships verifies that all emitted
+// relationship records carry Properties["language"]="swift_package".
+func TestPackageExtractor_LanguageTagOnRelationships(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "Pkg",
+    targets: [
+        .target(name: "A", dependencies: []),
+        .target(name: "B", dependencies: ["A"]),
+    ]
+)
+`
+	ents := runPackage(t, src)
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties["language"] != "swift_package" {
+				t.Errorf("entity %q rel kind=%q toID=%q: Properties[language]=%q want swift_package",
+					e.Name, r.Kind, r.ToID, r.Properties["language"])
+			}
+		}
+	}
+}
+
+// TestPackageExtractor_URLsNotExtractedAsDeps verifies that package URL
+// strings adjacent to dependency declarations are not emitted as DEPENDS_ON
+// targets (they are not target names).
+func TestPackageExtractor_URLsNotExtractedAsDeps(t *testing.T) {
+	src := `// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "Pkg",
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+    ],
+    targets: [
+        .target(
+            name: "Pkg",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+    ]
+)
+`
+	ents := runPackage(t, src)
+	pkg := findPkg(ents, "Pkg", "SCOPE.Component")
+	if pkg == nil {
+		t.Fatal("expected Pkg entity")
+	}
+	for _, r := range pkg.Relationships {
+		if r.Kind == "DEPENDS_ON" && (r.ToID == "4.0.0" || r.ToID == "https://github.com/vapor/vapor.git") {
+			t.Errorf("should not emit DEPENDS_ON edge to URL/version string, got ToID=%q", r.ToID)
+		}
+	}
+}

--- a/internal/quality/golden/swift-package-mini/expected.json
+++ b/internal/quality/golden/swift-package-mini/expected.json
@@ -1,0 +1,22 @@
+{
+  "fixture_name": "swift-package-mini",
+  "language": "swift_package",
+  "description": "Tiny SwiftPM Package.swift manifest with an executable target (App), a library target (Models), and a test target (AppTests). Exercises .executableTarget, .target, .testTarget, .product(name:package:) dependencies, and target-to-target string dependencies. Used to guard the swift_package extractor (#497) against regressions.",
+  "expected_entities": [
+    { "name": "App",       "kind": "SCOPE.Component", "source_file": "Package.swift", "must_exist": true,  "note": "executableTarget" },
+    { "name": "Models",    "kind": "SCOPE.Component", "source_file": "Package.swift", "must_exist": true,  "note": "library target" },
+    { "name": "AppTests",  "kind": "SCOPE.Component", "source_file": "Package.swift", "must_exist": true,  "note": "testTarget" },
+    { "name": "Vapor",     "kind": "SCOPE.External",  "source_file": "Package.swift", "must_exist": true,  "note": ".product(name:\"Vapor\", package:\"vapor\")" },
+    { "name": "Fluent",    "kind": "SCOPE.External",  "source_file": "Package.swift", "must_exist": true,  "note": ".product(name:\"Fluent\", package:\"fluent\")" },
+    { "name": "FluentSQLiteDriver", "kind": "SCOPE.External", "source_file": "Package.swift", "must_exist": true }
+  ],
+  "expected_relationships": [
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Vapor",              "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Fluent",             "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "FluentSQLiteDriver", "must_exist": true },
+    { "from_name": "App",      "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Models",             "must_exist": true, "note": "target-to-target string dep" },
+    { "from_name": "Models",   "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Fluent",             "must_exist": true },
+    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "App",                "must_exist": true },
+    { "from_name": "AppTests", "from_kind": "SCOPE.Component", "kind": "DEPENDS_ON", "to_bare_name": "Vapor",              "must_exist": true }
+  ]
+}

--- a/internal/quality/golden/swift-package-mini/src/Package.swift
+++ b/internal/quality/golden/swift-package-mini/src/Package.swift
@@ -1,0 +1,38 @@
+// swift-tools-version:5.7
+import PackageDescription
+
+let package = Package(
+    name: "VaporMini",
+    platforms: [
+        .macOS(.v12),
+    ],
+    dependencies: [
+        .package(url: "https://github.com/vapor/vapor.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/fluent.git", from: "4.0.0"),
+        .package(url: "https://github.com/vapor/fluent-sqlite-driver.git", from: "4.0.0"),
+    ],
+    targets: [
+        .executableTarget(
+            name: "App",
+            dependencies: [
+                .product(name: "Vapor", package: "vapor"),
+                .product(name: "Fluent", package: "fluent"),
+                .product(name: "FluentSQLiteDriver", package: "fluent-sqlite-driver"),
+                "Models",
+            ]
+        ),
+        .target(
+            name: "Models",
+            dependencies: [
+                .product(name: "Fluent", package: "fluent"),
+            ]
+        ),
+        .testTarget(
+            name: "AppTests",
+            dependencies: [
+                "App",
+                .product(name: "Vapor", package: "vapor"),
+            ]
+        ),
+    ]
+)


### PR DESCRIPTION
## What

Adds a dedicated regex-based extractor for SwiftPM `Package.swift` manifests (issue #497). The existing Swift extractor uses tree-sitter and emits function/class/import entities from `.swift` source files; it had no awareness of the SwiftPM target graph declared in `Package.swift`.

## Why

vapor-api-template had a 2.13% residual caused by two bug-extractor edges referencing `App` — a SwiftPM target declared in `Package.swift` that had no extracted entity to bind to. This extractor closes that gap.

## How

**New language key `swift_package`**
- `internal/classifier/classifier.go` — adds `exactBasenameLanguageMap`, consulted before the extension map, so `Package.swift` (which has a `.swift` extension and would otherwise route to the generic `"swift"` extractor) is classified as `"swift_package"` instead.
- `internal/extractors/swift/package.go` — regex-based `PackageExtractor` registered as `"swift_package"`. Parses `.target`, `.executableTarget`, `.testTarget` calls and emits:
  - `SCOPE.Component` (subtype `swiftpm_target`) per target, tagged with `swiftpm_kind`
  - `SCOPE.External` (subtype `swiftpm_product`) per `.product(name:package:)` reference
  - `DEPENDS_ON` edges between targets and their dependencies, with `dep_kind=target|product|external`

**Tests**
- `internal/extractors/swift/package_test.go` — 9 focused unit tests: registration, empty input, `.target`, `.executableTarget`, `.testTarget`, target-to-target dep, `.product` dep, language tagging, URL/semver filter.
- `internal/classifier/classifier_test.go` — `TestClassify_PackageSwift_IsSwiftPackage` verifies that `Package.swift` paths route to `"swift_package"` and that the extractor is reachable.

**Golden fixture**
- `internal/quality/golden/swift-package-mini/` — 3-target VaporMini manifest (App / Models / AppTests with Vapor + Fluent products) for regression guard.

## Test plan

- [x] `go test ./internal/extractors/swift/... -run TestPackage` — 9/9 pass
- [x] `go test ./internal/classifier/... -run TestClassify_PackageSwift` — 2/2 pass
- [x] `go build ./...` — clean

## Acceptance criteria (from issue)

- New tests cover: target declaration, executableTarget, .product dep, target-to-target dep
- vapor-api-template residual reduction requires a full corpus re-run (the entity gap that caused the residual is now plugged)

Closes #497