### PR TITLE
ci: drop pull_request trigger from go-heavy workflows

### DIFF
--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -3,8 +3,7 @@ name: quality
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,8 +3,7 @@ name: test
 on:
   push:
     branches: [main]
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read


### PR DESCRIPTION
## What we did
Removed the `pull_request:` trigger from `test.yml` and `quality.yml`. They now only run on push-to-main + manual workflow_dispatch.

## What we won
Stops burning ~10+ min of Actions runtime per PR. The current daemon test alone times out at 600s every run; the gofmt + vet step is fast but rides along with the slow part.

## What it means for the graph
No impact.

## What it means for MCP
No impact.

## Caveats
- PRs no longer enforce gofmt / go vet / go test pre-merge. Until we wire up a faster pre-merge gate (likely a thin "gofmt + go vet" job that skips the heavy tests + daemon integration), correctness lives entirely with the author.
- Distribution / matrix-build / release-artifact workflows are deliberately deferred per the same directive.
- Quality gate (extraction-quality fixtures) also moves to main-only — should be paired with a follow-up cheap PR gate later.

## Bottom line
Cost reduction. We'll re-instate a cheap pre-merge gate when distribution work begins.

Refs #815