### PR TITLE
[#513 #523 #610] JS/TS: state-setter lift, alias ternary/spread shapes, JSX RENDERS emission

### DIFF
--- a/internal/extractors/javascript/aliases.go
+++ b/internal/extractors/javascript/aliases.go
@@ -764,6 +764,13 @@ func parseBabelAliases(repoRoot string) []aliasEntry {
 // outer block to be syntactically well-formed JavaScript, only that
 // the inner object literal's first `{` appears after the inner key.
 //
+// Issue #523 — also handles ENV-based ternary values:
+//
+//	alias: process.env.NODE_ENV === 'test' ? { ... } : { ... }
+//
+// Both branches are parsed and their entries merged (union). This covers
+// the case where different alias maps are used in test vs production.
+//
 // Returns nil when the configured keys aren't present.
 func extractAliasBlock(src []byte, outer, inner string) []aliasEntry {
 	// Look for "outer:" anywhere in the source. We don't bother
@@ -785,11 +792,7 @@ func extractAliasBlock(src []byte, outer, inner string) []aliasEntry {
 	if innerIdx < 0 {
 		return nil
 	}
-	obj := extractObjectLiteral(body[innerIdx:])
-	if obj == "" {
-		return nil
-	}
-	return parseAliasObjectLiteral(obj)
+	return extractAliasValue(body[innerIdx:])
 }
 
 // extractBabelModuleResolverAliases is the babel-specific variant. It
@@ -805,11 +808,79 @@ func extractBabelModuleResolverAliases(src []byte) []aliasEntry {
 	if innerIdx < 0 {
 		return nil
 	}
-	obj := extractObjectLiteral(body[innerIdx:])
+	return extractAliasValue(body[innerIdx:])
+}
+
+// extractAliasValue resolves the alias value starting at the text fragment
+// that begins right after a key (`alias:`) position. It handles:
+//
+//   - Plain object literal `{ '@foo': './foo', ... }`
+//   - Object-spread form `{ ...base, '@foo': './foo' }` (spreads are silently
+//     skipped — only literal key/value pairs are extracted)
+//   - ENV-based ternary `cond ? { ... } : { ... }` — both branches are parsed
+//     and their entries merged (union). Issue #523.
+//
+// Computed key entries `{ [\`${expr}\`]: './foo' }` are silently skipped
+// because the key cannot be determined without evaluation.
+func extractAliasValue(fragment string) []aliasEntry {
+	// Skip whitespace and the ':' separator (indexOfKey returns the key
+	// start; the caller has already advanced to the key position, so the
+	// colon is the next non-space char after the key text — but
+	// extractAliasValue is called with the substring starting AT the key
+	// (or just after), so we look for the first '{' or '?' to
+	// determine the value shape).
+	colonIdx := strings.IndexByte(fragment, ':')
+	if colonIdx < 0 {
+		return nil
+	}
+	after := strings.TrimSpace(fragment[colonIdx+1:])
+
+	// Check for ternary pattern: `<cond> ? { ... } : { ... }`
+	// We look for '?' before the first '{'. If found, extract both
+	// the consequent and alternate object literals.
+	firstBrace := strings.IndexByte(after, '{')
+	firstQ := strings.IndexByte(after, '?')
+	if firstQ >= 0 && (firstBrace < 0 || firstQ < firstBrace) {
+		// Ternary shape — find both branches.
+		return extractTernaryAliasObjects(after)
+	}
+
+	obj := extractObjectLiteral(after)
 	if obj == "" {
 		return nil
 	}
 	return parseAliasObjectLiteral(obj)
+}
+
+// extractTernaryAliasObjects extracts alias entries from both branches of a
+// ternary expression: `cond ? { ... } : { ... }`. Returns the union of both
+// branches so aliases present in either environment are included. Issue #523.
+func extractTernaryAliasObjects(s string) []aliasEntry {
+	// Find the '?' and the first `{` after it (consequent branch).
+	qIdx := strings.IndexByte(s, '?')
+	if qIdx < 0 {
+		return nil
+	}
+	rest := s[qIdx+1:]
+	obj1 := extractObjectLiteral(rest)
+	var entries []aliasEntry
+	if obj1 != "" {
+		entries = append(entries, parseAliasObjectLiteral(obj1)...)
+		// Advance past the first object literal to find the alternate.
+		consumed := strings.Index(rest, obj1)
+		if consumed >= 0 {
+			rest = rest[consumed+len(obj1):]
+		}
+	}
+	// The alternate branch follows the ':' separator after the consequent.
+	colonIdx := strings.IndexByte(rest, ':')
+	if colonIdx >= 0 {
+		obj2 := extractObjectLiteral(rest[colonIdx+1:])
+		if obj2 != "" {
+			entries = append(entries, parseAliasObjectLiteral(obj2)...)
+		}
+	}
+	return entries
 }
 
 // indexOfKey returns the byte index of an unquoted key occurrence

--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -444,6 +444,10 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	params := n.ChildByFieldName("parameters")
 	frame := x.functionParamFrame(params, cb)
 	rels := x.extractCallRelationships(body, name, frame)
+	// Issue #610 — for PascalCase function components, scan the body for
+	// JSX child elements and emit RENDERS edges so the component-composition
+	// graph is complete.
+	rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 	x.emitWithRels(name, "SCOPE.Operation", n, subtype, sig, rels)
 
 	// Recurse into the body for nested declarations.
@@ -668,7 +672,13 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 	// branch below).
 	if nameNode.Type() == "object_pattern" || nameNode.Type() == "array_pattern" {
 		opLift := isMutationStyleHookCall(x, valueNode)
-		x.emitDestructuredEntities(nameNode, valueNode, opLift, parentClass, cb)
+		// Issue #513 — for state hooks returning [value, setter] tuples
+		// (useState, useReducer, useTransition, etc.), emit the setter
+		// elements (index ≥ 1 in the array pattern) with subtype
+		// "state_setter" so the resolver binds setX() calls to a real
+		// entity instead of landing in bug-extractor.
+		stateHook := nameNode.Type() == "array_pattern" && isStateHookCall(x, valueNode)
+		x.emitDestructuredEntities(nameNode, valueNode, opLift, stateHook, parentClass, cb)
 		if valueNode != nil {
 			x.walkChildren(valueNode, parentClass, cb)
 		}
@@ -694,6 +704,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		params := valueNode.ChildByFieldName("parameters")
 		frame := x.functionParamFrame(params, cb)
 		rels := x.extractCallRelationships(body, name, frame)
+		// Issue #610 — PascalCase arrow components emit RENDERS edges.
+		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = (...) =>", name), rels)
 		if body != nil {
 			x.walkChildren(body, parentClass, cb)
@@ -708,6 +720,8 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		params := valueNode.ChildByFieldName("parameters")
 		frame := x.functionParamFrame(params, cb)
 		rels := x.extractCallRelationships(body, name, frame)
+		// Issue #610 — PascalCase function-expression components emit RENDERS edges.
+		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = function", name), rels)
 		if body != nil {
 			x.walkChildren(body, parentClass, cb)
@@ -911,10 +925,12 @@ func (x *extractor) findInnerFunctionBody(n *sitter.Node) *sitter.Node {
 // Classification:
 //   - opLift=true → SCOPE.Operation (mutation hooks return callables)
 //   - opLift=false → SCOPE.Component
+//   - stateHook=true (issue #513) → array elements at index≥1 get subtype
+//     "state_setter" so setX() calls resolve to a real entity
 //
 // Each emit is anchored to valueNode for line numbers (the LHS doesn't
 // carry useful position info beyond what's already on the declarator).
-func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, opLift bool, parentClass string, cb *classBindings) {
+func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, opLift bool, stateHook bool, parentClass string, cb *classBindings) {
 	if pattern == nil {
 		return
 	}
@@ -931,17 +947,18 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 		sigPrefix = "const"
 	}
 
-	var walk func(p *sitter.Node)
-	walk = func(p *sitter.Node) {
+	var walk func(p *sitter.Node, arrayIdx int)
+	walk = func(p *sitter.Node, arrayIdx int) {
 		if p == nil {
 			return
 		}
 		switch p.Type() {
 		case "object_pattern":
 			for i := 0; i < int(p.ChildCount()); i++ {
-				walk(p.Child(i))
+				walk(p.Child(i), -1)
 			}
 		case "array_pattern":
+			elemIdx := 0
 			for i := 0; i < int(p.ChildCount()); i++ {
 				ch := p.Child(i)
 				if ch == nil {
@@ -950,14 +967,24 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 				switch ch.Type() {
 				case "identifier":
 					name := x.nodeText(ch)
-					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [%s, ...]", sigPrefix, name))
+					// Issue #513 — setters in state-hook array patterns
+					// (index ≥ 1) get subtype "state_setter" so the
+					// resolver can bind setX() CALLS to this entity.
+					elemSubtype := subtype
+					if stateHook && elemIdx >= 1 {
+						elemSubtype = "state_setter"
+					}
+					x.emit(name, kind, anchor, elemSubtype, fmt.Sprintf("%s [%s, ...]", sigPrefix, name))
+					elemIdx++
 				case "object_pattern", "array_pattern":
-					walk(ch)
+					walk(ch, elemIdx)
+					elemIdx++
 				case "rest_pattern":
 					if id := firstIdentifierChild(ch); id != nil {
 						name := x.nodeText(id)
 						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [...%s]", sigPrefix, name))
 					}
+					elemIdx++
 				case "assignment_pattern":
 					// e.g. [a = 1] — the binding name is the LHS identifier.
 					if left := ch.ChildByFieldName("left"); left != nil {
@@ -965,9 +992,10 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 							name := x.nodeText(left)
 							x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [%s = ...]", sigPrefix, name))
 						} else {
-							walk(left)
+							walk(left, -1)
 						}
 					}
+					elemIdx++
 				}
 			}
 		case "shorthand_property_identifier_pattern":
@@ -985,7 +1013,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 					name := x.nodeText(left)
 					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s = ... }", sigPrefix, name))
 				default:
-					walk(left)
+					walk(left, -1)
 				}
 			}
 		case "pair_pattern":
@@ -1000,14 +1028,14 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 				name := x.nodeText(value)
 				x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s }", sigPrefix, name))
 			case "object_pattern", "array_pattern":
-				walk(value)
+				walk(value, -1)
 			case "assignment_pattern":
 				if left := value.ChildByFieldName("left"); left != nil {
 					if left.Type() == "identifier" {
 						name := x.nodeText(left)
 						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s = ... }", sigPrefix, name))
 					} else {
-						walk(left)
+						walk(left, -1)
 					}
 				}
 			}
@@ -1022,7 +1050,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 					name := x.nodeText(left)
 					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s = ...", sigPrefix, name))
 				} else {
-					walk(left)
+					walk(left, -1)
 				}
 			}
 		case "identifier":
@@ -1030,7 +1058,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s", sigPrefix, name))
 		}
 	}
-	walk(pattern)
+	walk(pattern, -1)
 }
 
 // firstIdentifierChild returns the first identifier-typed child of n, or nil.
@@ -1046,6 +1074,29 @@ func firstIdentifierChild(n *sitter.Node) *sitter.Node {
 		}
 	}
 	return nil
+}
+
+// isStateHookCall returns true when the RHS is a call to one of the built-in
+// React state hooks that return a [value, setter] tuple. Used by #513 to tag
+// array-pattern setters with subtype="state_setter".
+func isStateHookCall(x *extractor, valueNode *sitter.Node) bool {
+	if valueNode == nil || valueNode.Type() != "call_expression" {
+		return false
+	}
+	fn := valueNode.ChildByFieldName("function")
+	if fn == nil {
+		return false
+	}
+	leaf := ""
+	switch fn.Type() {
+	case "identifier":
+		leaf = x.nodeText(fn)
+	case "member_expression":
+		if prop := fn.ChildByFieldName("property"); prop != nil {
+			leaf = x.nodeText(prop)
+		}
+	}
+	return isStateHookName(leaf)
 }
 
 // isMutationStyleHookCall returns true when the RHS of a destructuring
@@ -1102,12 +1153,29 @@ func isMutationStyleHookCall(x *extractor, valueNode *sitter.Node) bool {
 	return isMutationStyleHookName(leaf)
 }
 
+// isStateHookName returns true when the hook name is one of the built-in
+// React hooks that return a [value, setter] tuple. Issue #513 — setters from
+// these hooks (e.g. setIsOpen, setActive) must be lifted as SCOPE.Operation
+// with subtype="state_setter" so the resolver can bind same-file CALLS edges
+// instead of routing them to bug-extractor.
+func isStateHookName(leaf string) bool {
+	switch leaf {
+	case "useState", "useReducer", "useTransition", "useOptimistic",
+		"useActionState", "useFormState":
+		return true
+	}
+	return false
+}
+
 // isMutationStyleHookName encodes the name-shape rule documented on
 // isMutationStyleHookCall. Pure function, exported via test seam.
 func isMutationStyleHookName(leaf string) bool {
+	// State hooks are a subset of mutation-style — they return callables.
+	if isStateHookName(leaf) {
+		return true
+	}
 	switch leaf {
 	case
-		"useState", "useReducer",
 		"useMutation", "useSWRMutation",
 		"useForm",
 		"useModal", "useMessage", "useNotification", "useApp",
@@ -1292,6 +1360,75 @@ func (x *extractor) callTarget(call *sitter.Node, frame *classBindings) string {
 		}
 	}
 	return ""
+}
+
+// extractJSXRendersRelationships scans body for JSX elements whose tag name
+// begins with an uppercase ASCII letter (= React component convention) and
+// emits one RENDERS RelationshipRecord per unique component. Issue #610.
+//
+// Only emits when callerName is itself PascalCase (isComponentName returns
+// true) so hook functions and plain utilities don't pick up spurious RENDERS
+// edges from JSX fragments inside non-component functions.
+//
+// The ToID is the bare PascalCase component name. The cross-file resolver
+// (or the react_props cross-extractor) will bind it to the declaring entity.
+// Self-renders (caller == tag name) are skipped.
+func (x *extractor) extractJSXRendersRelationships(body *sitter.Node, callerName string) []types.RelationshipRecord {
+	if body == nil || !isComponentName(callerName) {
+		return nil
+	}
+	jsxNodes := findAllNodes(body,
+		"jsx_opening_element",
+		"jsx_self_closing_element",
+	)
+	if len(jsxNodes) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(jsxNodes))
+	var rels []types.RelationshipRecord
+	for _, jx := range jsxNodes {
+		nameNode := jx.ChildByFieldName("name")
+		if nameNode == nil {
+			continue
+		}
+		tag := x.nodeText(nameNode)
+		// Only PascalCase tags — HTML intrinsics (div, span, …) start lowercase.
+		if !isComponentName(tag) {
+			continue
+		}
+		// Skip self-renders.
+		if tag == callerName {
+			continue
+		}
+		// Skip known React namespace tags (React.Fragment etc.) — take
+		// the member object as the effective tag for e.g. styled.div.
+		if strings.Contains(tag, ".") {
+			// member_expression: take the trailing property as the tag.
+			tag = tag[strings.LastIndex(tag, ".")+1:]
+			if !isComponentName(tag) {
+				continue
+			}
+		}
+		if seen[tag] {
+			continue
+		}
+		seen[tag] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID: tag,
+			Kind: "RENDERS",
+		})
+	}
+	return rels
+}
+
+// isComponentName returns true when name starts with an ASCII uppercase
+// letter — the React convention for function component identifiers.
+func isComponentName(name string) bool {
+	if name == "" {
+		return false
+	}
+	c := name[0]
+	return c >= 'A' && c <= 'Z'
 }
 
 // findAllNodes returns every descendant of root whose Type() is in kinds.

--- a/internal/extractors/javascript/issue513_state_setter_test.go
+++ b/internal/extractors/javascript/issue513_state_setter_test.go
@@ -1,0 +1,141 @@
+// Package javascript — unit tests for issue #513: useState/useReducer/etc.
+// setters are lifted as SCOPE.Operation with subtype="state_setter".
+package javascript_test
+
+import (
+	"testing"
+)
+
+// TestStateSetterLift_useState — the setter element of a useState call
+// (index 1 in the array pattern) must be emitted as SCOPE.Operation with
+// subtype="state_setter", not land in bug-extractor as an unresolvable name.
+func TestStateSetterLift_useState(t *testing.T) {
+	src := []byte(`
+const [isOpen, setIsOpen] = useState(false);
+const [active, setActive] = useState(0);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	// Both setters must be present as SCOPE.Operation.
+	for _, setterName := range []string{"setIsOpen", "setActive"} {
+		e := findByName(entities, setterName)
+		if e == nil {
+			t.Errorf("entity %q not found; all names: %v", setterName, entityNames(entities))
+			continue
+		}
+		if e.Kind != "SCOPE.Operation" {
+			t.Errorf("%q: kind=%q, want SCOPE.Operation", setterName, e.Kind)
+		}
+		if e.Subtype != "state_setter" {
+			t.Errorf("%q: subtype=%q, want state_setter", setterName, e.Subtype)
+		}
+	}
+
+	// The value (index 0) keeps its regular subtype, not state_setter.
+	for _, valName := range []string{"isOpen", "active"} {
+		e := findByName(entities, valName)
+		if e == nil {
+			t.Errorf("value entity %q not found", valName)
+			continue
+		}
+		if e.Subtype == "state_setter" {
+			t.Errorf("%q (value element) should NOT have subtype state_setter", valName)
+		}
+	}
+}
+
+// TestStateSetterLift_useReducer — useReducer dispatch function (index 1)
+// must be lifted as state_setter.
+func TestStateSetterLift_useReducer(t *testing.T) {
+	src := []byte(`
+const [state, dispatch] = useReducer(reducer, initialState);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	e := findByName(entities, "dispatch")
+	if e == nil {
+		t.Fatal("dispatch entity not found")
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("dispatch: kind=%q, want SCOPE.Operation", e.Kind)
+	}
+	if e.Subtype != "state_setter" {
+		t.Errorf("dispatch: subtype=%q, want state_setter", e.Subtype)
+	}
+}
+
+// TestStateSetterLift_useTransition — useTransition returns [isPending, startTransition].
+// startTransition (index 1) must be lifted as state_setter.
+func TestStateSetterLift_useTransition(t *testing.T) {
+	src := []byte(`
+const [isPending, startTransition] = useTransition();
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	e := findByName(entities, "startTransition")
+	if e == nil {
+		t.Fatal("startTransition entity not found")
+	}
+	if e.Subtype != "state_setter" {
+		t.Errorf("startTransition: subtype=%q, want state_setter", e.Subtype)
+	}
+}
+
+// TestStateSetterLift_useOptimistic — useOptimistic returns [value, updateFn].
+// The update function (index 1) must be lifted as state_setter.
+func TestStateSetterLift_useOptimistic(t *testing.T) {
+	src := []byte(`
+const [optimisticCart, updateOptimisticCart] = useOptimistic(cart);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	e := findByName(entities, "updateOptimisticCart")
+	if e == nil {
+		t.Fatal("updateOptimisticCart entity not found")
+	}
+	if e.Kind != "SCOPE.Operation" {
+		t.Errorf("updateOptimisticCart: kind=%q, want SCOPE.Operation", e.Kind)
+	}
+	if e.Subtype != "state_setter" {
+		t.Errorf("updateOptimisticCart: subtype=%q, want state_setter", e.Subtype)
+	}
+}
+
+// TestStateSetterLift_useActionState — new React 19 hook.
+func TestStateSetterLift_useActionState(t *testing.T) {
+	src := []byte(`
+const [state, dispatch, isPending] = useActionState(action, initialState);
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	// dispatch (index 1) must be state_setter.
+	e := findByName(entities, "dispatch")
+	if e == nil {
+		t.Fatal("dispatch entity not found")
+	}
+	if e.Subtype != "state_setter" {
+		t.Errorf("dispatch: subtype=%q, want state_setter", e.Subtype)
+	}
+}
+
+// TestStateSetterLift_nonStateHook — object-destructure from a non-state hook
+// must NOT get state_setter subtype (regression guard).
+func TestStateSetterLift_nonStateHook(t *testing.T) {
+	src := []byte(`
+const { data, isLoading } = useQuery({ queryKey: ['todos'] });
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	for _, name := range []string{"data", "isLoading"} {
+		e := findByName(entities, name)
+		if e != nil && e.Subtype == "state_setter" {
+			t.Errorf("%q from useQuery should NOT have subtype state_setter", name)
+		}
+	}
+}

--- a/internal/extractors/javascript/issue523_alias_shapes_test.go
+++ b/internal/extractors/javascript/issue523_alias_shapes_test.go
@@ -1,0 +1,124 @@
+// Package javascript — unit tests for issue #523: Vite/Babel alias parsing
+// extended to handle object-spread, computed keys, and ENV-based ternary.
+package javascript
+
+import (
+	"testing"
+)
+
+// TestAliasObjectSpread — `{ ...sharedAliases, '@foo': './foo' }` must extract
+// the literal entries and silently skip the spread.
+func TestAliasObjectSpread(t *testing.T) {
+	// Simulate the output of extractObjectLiteral on a spread object literal.
+	obj := `{ ...sharedAliases, '@foo': './foo', '@bar': './bar' }`
+	entries := parseAliasObjectLiteral(obj)
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 entries (spread skipped), got %d: %+v", len(entries), entries)
+	}
+	m := AliasMap{entries: entries}
+	sortByPrefixLen(m.entries)
+	if got := m.Resolve("@foo/btn"); got != "foo/btn" {
+		t.Errorf("@foo glob: got %q, want %q", got, "foo/btn")
+	}
+	if got := m.Resolve("@bar/x"); got != "bar/x" {
+		t.Errorf("@bar glob: got %q, want %q", got, "bar/x")
+	}
+}
+
+// TestAliasComputedKey — `{ [\`${prefix}/foo\`]: './foo' }` must be silently
+// skipped; no panic and no spurious entry.
+func TestAliasComputedKey(t *testing.T) {
+	obj := "{ [`${prefix}/foo`]: './foo', '@bar': './bar' }"
+	entries := parseAliasObjectLiteral(obj)
+	// Only the literal entry survives — computed key is skipped.
+	for _, e := range entries {
+		if e.prefix == "" {
+			t.Errorf("empty prefix entry should not be emitted")
+		}
+	}
+	// At least the literal entry must be present.
+	found := false
+	for _, e := range entries {
+		if e.prefix == "@bar" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("literal entry @bar not found in %+v", entries)
+	}
+}
+
+// TestAliasENVTernary — `alias: cond ? { '@test': './test' } : { '@prod': './prod' }`
+// must return entries from BOTH branches.
+func TestAliasENVTernary(t *testing.T) {
+	fragment := `alias: process.env.NODE_ENV === 'test' ? { '@test': './test-utils' } : { '@prod': './prod-utils' }`
+	entries := extractAliasValue(fragment)
+	if len(entries) == 0 {
+		t.Fatal("expected entries from ternary branches, got none")
+	}
+	hasProd := false
+	hasTest := false
+	for _, e := range entries {
+		if e.prefix == "@test" {
+			hasTest = true
+		}
+		if e.prefix == "@prod" {
+			hasProd = true
+		}
+	}
+	if !hasTest {
+		t.Errorf("@test entry missing from ternary consequent: %+v", entries)
+	}
+	if !hasProd {
+		t.Errorf("@prod entry missing from ternary alternate: %+v", entries)
+	}
+}
+
+// TestAliasENVTernary_ViteConfig — integration-level: parse a vite.config.js
+// body containing a ternary alias declaration. Verifies extractAliasBlock
+// handles it end-to-end.
+func TestAliasENVTernary_ViteConfig(t *testing.T) {
+	src := []byte(`
+import { defineConfig } from 'vite'
+import path from 'path'
+export default defineConfig({
+  resolve: {
+    alias: process.env.VITEST
+      ? { '@': path.resolve(__dirname, 'src'), '@test': path.resolve(__dirname, 'test') }
+      : { '@': path.resolve(__dirname, 'src') }
+  }
+})
+`)
+	entries := extractAliasBlock(src, "resolve", "alias")
+	m := AliasMap{entries: entries}
+	sortByPrefixLen(m.entries)
+	if got := m.Resolve("@/components/Button"); got != "src/components/Button" {
+		t.Errorf("@ glob: got %q, want %q", got, "src/components/Button")
+	}
+	// @test should come from the consequent branch.
+	if got := m.Resolve("@test/helpers"); got == "" {
+		t.Errorf("@test entry from ternary consequent missing")
+	}
+}
+
+// TestAliasObjectSpread_ViteConfig — vite.config.js with spread alias shape.
+func TestAliasObjectSpread_ViteConfig(t *testing.T) {
+	src := []byte(`
+const sharedAliases = { '@shared': './shared' }
+export default {
+  resolve: {
+    alias: { ...sharedAliases, '@app': './src' }
+  }
+}
+`)
+	entries := extractAliasBlock(src, "resolve", "alias")
+	found := false
+	for _, e := range entries {
+		if e.prefix == "@app" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("@app entry not found in spread alias object; entries: %+v", entries)
+	}
+}

--- a/internal/extractors/javascript/issue610_jsx_renders_test.go
+++ b/internal/extractors/javascript/issue610_jsx_renders_test.go
@@ -1,0 +1,235 @@
+// Package javascript — unit tests for issue #610: JSX function-component
+// composition emitted as RENDERS relationships.
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	sitter "github.com/smacker/go-tree-sitter"
+	tstsx "github.com/smacker/go-tree-sitter/typescript/tsx"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// parseTSX parses source with the TypeScript TSX grammar (JSX-enabled).
+func parseTSX(t *testing.T, src []byte) *sitter.Tree {
+	t.Helper()
+	p := sitter.NewParser()
+	p.SetLanguage(tstsx.GetLanguage())
+	tree, err := p.ParseCtx(context.Background(), nil, src)
+	if err != nil {
+		t.Fatalf("parseTSX: %v", err)
+	}
+	return tree
+}
+
+// extractTSX runs the extractor on TSX source.
+func extractTSX(t *testing.T, content []byte, tree *sitter.Tree) []types.EntityRecord {
+	t.Helper()
+	ext, _ := extreg.Get("typescript")
+	ents, err := ext.Extract(context.Background(), extreg.FileInput{
+		Path:     "test.tsx",
+		Content:  content,
+		Language: "typescript",
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func findByNameTSX(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// TestJSXRenders_FunctionComponent — `<UserCard />` inside `function UserList()`
+// must emit a RENDERS edge from UserList to UserCard.
+func TestJSXRenders_FunctionComponent(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+import { UserCard } from './UserCard';
+
+function UserList({ users }) {
+  return (
+    <div>
+      {users.map(u => <UserCard key={u.id} user={u} />)}
+    </div>
+  );
+}
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	ul := findByNameTSX(entities, "UserList")
+	if ul == nil {
+		t.Fatal("UserList entity not found")
+	}
+	found := false
+	for _, r := range ul.Relationships {
+		if r.Kind == "RENDERS" && r.ToID == "UserCard" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected RENDERS UserList→UserCard; relationships: %+v", ul.Relationships)
+	}
+}
+
+// TestJSXRenders_ArrowComponent — arrow-function component also emits RENDERS.
+func TestJSXRenders_ArrowComponent(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+
+const ProductCard = ({ product }) => (
+  <div>{product.name}</div>
+);
+
+const ProductList = ({ products }) => (
+  <section>
+    {products.map(p => <ProductCard key={p.id} product={p} />)}
+  </section>
+);
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	pl := findByNameTSX(entities, "ProductList")
+	if pl == nil {
+		t.Fatal("ProductList entity not found")
+	}
+	found := false
+	for _, r := range pl.Relationships {
+		if r.Kind == "RENDERS" && r.ToID == "ProductCard" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected RENDERS ProductList→ProductCard; relationships: %+v", pl.Relationships)
+	}
+}
+
+// TestJSXRenders_NoHTMLIntrinsics — lowercase HTML tags must NOT generate RENDERS.
+func TestJSXRenders_NoHTMLIntrinsics(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+
+function Page() {
+  return (
+    <div>
+      <span>text</span>
+      <button onClick={() => {}}>click</button>
+    </div>
+  );
+}
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	page := findByNameTSX(entities, "Page")
+	if page == nil {
+		t.Fatal("Page entity not found")
+	}
+	for _, r := range page.Relationships {
+		if r.Kind != "RENDERS" {
+			continue
+		}
+		tag := r.ToID
+		if len(tag) > 0 && tag[0] >= 'a' && tag[0] <= 'z' {
+			t.Errorf("HTML intrinsic %q should NOT generate RENDERS edge", tag)
+		}
+	}
+}
+
+// TestJSXRenders_NoSelfRender — self-reference must not produce a RENDERS edge.
+func TestJSXRenders_NoSelfRender(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+
+function Tree({ node }) {
+  if (!node.children) return null;
+  return (
+    <div>
+      {node.children.map(c => <Tree key={c.id} node={c} />)}
+    </div>
+  );
+}
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	treeEnt := findByNameTSX(entities, "Tree")
+	if treeEnt == nil {
+		t.Fatal("Tree entity not found")
+	}
+	for _, r := range treeEnt.Relationships {
+		if r.Kind == "RENDERS" && r.ToID == "Tree" {
+			t.Errorf("self-RENDERS should be filtered out")
+		}
+	}
+}
+
+// TestJSXRenders_DeduplicatesMultipleUses — same child used N times produces
+// exactly ONE RENDERS edge.
+func TestJSXRenders_DeduplicatesMultipleUses(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+
+function Dashboard() {
+  return (
+    <div>
+      <Widget id="a" />
+      <Widget id="b" />
+      <Widget id="c" />
+    </div>
+  );
+}
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	dash := findByNameTSX(entities, "Dashboard")
+	if dash == nil {
+		t.Fatal("Dashboard entity not found")
+	}
+	count := 0
+	for _, r := range dash.Relationships {
+		if r.Kind == "RENDERS" && r.ToID == "Widget" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 deduplicated RENDERS Dashboard→Widget, got %d", count)
+	}
+}
+
+// TestJSXRenders_LowercaseFunctionNotEmitted — a lowercase function name
+// (non-component) should NOT emit RENDERS even if it contains JSX.
+func TestJSXRenders_LowercaseFunctionNotEmitted(t *testing.T) {
+	src := []byte(`
+import React from 'react';
+
+function renderItem(item) {
+  return <ItemCard item={item} />;
+}
+`)
+	tree := parseTSX(t, src)
+	entities := extractTSX(t, src, tree)
+
+	ri := findByNameTSX(entities, "renderItem")
+	if ri == nil {
+		t.Fatal("renderItem entity not found")
+	}
+	for _, r := range ri.Relationships {
+		if r.Kind == "RENDERS" {
+			t.Errorf("lowercase function renderItem should NOT emit RENDERS; got %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Three related JS/TS extractor improvements bundled as one PR.

- **#513 useState-setter lift** — `setIsOpen`, `setActive`, `updateOptimisticCart` etc. are now emitted as `SCOPE.Operation` with `subtype="state_setter"`, preventing them from landing in bug-extractor. Covers `useState`, `useReducer`, `useTransition`, `useOptimistic`, `useActionState`, `useFormState`.
- **#523 Vite/Babel alias parsing** — ENV-based ternary alias values (`process.env.NODE_ENV === 'test' ? {...} : {...}`) are now parsed with both branches merged. Object-spread (`...shared`) and computed key (`[\`${expr}\`]`) entries are silently skipped (no panic, no false entries).
- **#610 JSX RENDERS emission** — `function UserList()` containing `<UserCard />` now emits a `RENDERS` edge `UserList → UserCard`. Covers `function_declaration`, `arrow_function`, and `function_expression` shapes. Guarded to PascalCase callers only; HTML intrinsics, self-renders, and duplicates are filtered.

## Changes

- `internal/extractors/javascript/extractor.go` — `isStateHookName`, `isStateHookCall`, `emitDestructuredEntities` extended with `stateHook` flag; `extractJSXRendersRelationships` + `isComponentName` added; RENDERS wired into function/arrow handlers
- `internal/extractors/javascript/aliases.go` — `extractAliasValue` centralises alias-value dispatch; `extractTernaryAliasObjects` handles ENV ternary; `extractAliasBlock` + `extractBabelModuleResolverAliases` delegate to new helpers
- `internal/extractors/javascript/issue513_state_setter_test.go` — 6 tests covering useState, useReducer, useTransition, useOptimistic, useActionState, regression guard
- `internal/extractors/javascript/issue523_alias_shapes_test.go` — 5 tests: spread skip, computed key skip, ENV ternary union, Vite ternary integration, Vite spread integration
- `internal/extractors/javascript/issue610_jsx_renders_test.go` — 6 tests: function component, arrow component, no HTML intrinsics, no self-render, dedup, lowercase guard

## Test results

`go test ./internal/extractors/javascript/... ` — all 17 new tests pass, 0 regressions.
`go test ./... ` — full suite clean.

## Acceptance checklist

- [x] `setIsOpen`, `setActive`, `updateOptimisticCart` lift to `SCOPE.Operation/state_setter`
- [x] `useTransition`, `useOptimistic`, `useActionState`, `useFormState` included
- [x] ENV ternary alias: both branches extracted
- [x] Object-spread alias: skipped without error
- [x] Computed key alias: skipped without error
- [x] `UserList --RENDERS--> UserCard` edge emitted from `.tsx` files
- [x] HTML intrinsics (`div`, `span`) excluded
- [x] Self-renders excluded
- [x] Duplicate tags deduplicated
- [x] `go test ./internal/extractors/javascript/...` clean

Closes #513 #523 #610