### PR TITLE
[#426] DASH-3 Layer 2: agent-resolved community names

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1274,12 +1274,32 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 			fmt.Fprintf(os.Stderr,
 				"enrichment: applied %d resolutions to entities\n", applied)
 		}
+		// Also apply name_community resolutions so the AgentName field is
+		// populated on CommunityResult before candidate emission and before
+		// graph.json is written (issue #426).
+		appliedComm := enrichment.ApplyCommunityNameResolutions(doc, resolutions)
+		if verbose() && appliedComm > 0 {
+			fmt.Fprintf(os.Stderr,
+				"enrichment: applied %d community name resolutions\n", appliedComm)
+		}
 	}
 
-	// 2) Emit candidates. Rejected (subject_id, kind) pairs are dropped.
+	// 2) Emit entity candidates. Rejected (subject_id, kind) pairs are dropped.
 	cands := enrichment.CollectCandidatesSkippingRejected(
 		doc, enrichment.DefaultEmitters(), archigraphDir,
 	)
+
+	// 2b) Emit name_community candidates (issue #426 Layer 2). One candidate
+	//     per community that lacks an agent-resolved name.
+	rej := enrichment.ReadRejections(archigraphDir)
+	commCands := enrichment.CollectCommunityCandidates(doc, rej)
+	if len(commCands) > 0 {
+		cands = append(cands, commCands...)
+		if verbose() {
+			fmt.Fprintf(os.Stderr,
+				"enrichment: collected %d name_community candidates\n", len(commCands))
+		}
+	}
 
 	// 3) ADR-0015 phase-1 (#544) — repair_edge emission. Purely additive;
 	//    gated behind --enable-repair-candidates so we can land the

--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -67,6 +67,7 @@ func (s *Server) serveGraphCentroids(w http.ResponseWriter, group string, repos 
 		CommunityID  int      `json:"community_id"`
 		Size         int      `json:"size"`
 		AutoName     string   `json:"auto_name,omitempty"`
+		AgentName    string   `json:"agent_name,omitempty"`
 		Repo         string   `json:"repo"`
 		TopEntityIDs []string `json:"top_entity_ids"`
 	}
@@ -92,16 +93,21 @@ func (s *Server) serveGraphCentroids(w http.ResponseWriter, group string, repos 
 				CommunityID:  c.ID,
 				Size:         c.Size,
 				AutoName:     c.AutoName,
+				AgentName:    c.AgentName,
 				Repo:         r.Slug,
 				TopEntityIDs: prefixed,
 			})
-			communities = append(communities, map[string]any{
+			cm := map[string]any{
 				"id":           c.ID,
 				"size":         c.Size,
 				"auto_name":    c.AutoName,
 				"repo":         r.Slug,
 				"top_entities": prefixed,
-			})
+			}
+			if c.AgentName != "" {
+				cm["agent_name"] = c.AgentName
+			}
+			communities = append(communities, cm)
 		}
 	}
 
@@ -135,13 +141,17 @@ func (s *Server) serveGraphMid(w http.ResponseWriter, group string, repos []*Das
 			for i, id := range top {
 				prefixed[i] = dashPrefixedID(r.Slug, id)
 			}
-			communities = append(communities, map[string]any{
+			cm := map[string]any{
 				"id":           c.ID,
 				"size":         c.Size,
 				"auto_name":    c.AutoName,
 				"repo":         r.Slug,
 				"top_entities": prefixed,
-			})
+			}
+			if c.AgentName != "" {
+				cm["agent_name"] = c.AgentName
+			}
+			communities = append(communities, cm)
 		}
 
 		// Collect god-nodes: top-50 by PageRank per repo (or centrality).
@@ -246,13 +256,17 @@ func (s *Server) serveGraphFull(w http.ResponseWriter, group string, repos []*Da
 			for i, id := range top {
 				prefixed[i] = dashPrefixedID(r.Slug, id)
 			}
-			communities = append(communities, map[string]any{
+			cm := map[string]any{
 				"id":           c.ID,
 				"size":         c.Size,
 				"auto_name":    c.AutoName,
 				"repo":         r.Slug,
 				"top_entities": prefixed,
-			})
+			}
+			if c.AgentName != "" {
+				cm["agent_name"] = c.AgentName
+			}
+			communities = append(communities, cm)
 		}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
@@ -409,14 +423,18 @@ func (s *Server) handleGroupCommunities(w http.ResponseWriter, r *http.Request) 
 			for i, id := range top {
 				prefixed[i] = dashPrefixedID(r.Slug, id)
 			}
-			out = append(out, map[string]any{
+			cm := map[string]any{
 				"repo":         r.Slug,
 				"id":           c.ID,
 				"size":         c.Size,
 				"modularity":   c.Modularity,
 				"auto_name":    c.AutoName,
 				"top_entities": prefixed,
-			})
+			}
+			if c.AgentName != "" {
+				cm["agent_name"] = c.AgentName
+			}
+			out = append(out, cm)
 		}
 	}
 	writeJSON(w, http.StatusOK, map[string]any{"communities": out})

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -28,13 +28,21 @@ import (
 // Candidate kinds. These are the canonical "kind" string values the agent
 // branches on when deciding which prompt to apply.
 const (
-	KindDescribeEntity = "describe_entity"
-	KindClassifyDomain = "classify_domain"
-	KindInferXLangCall = "infer_xlang_call"
-	KindSummarizeAPI   = "summarize_api"
-	KindFlagDeadCode   = "flag_dead_code"
-	KindDescribeRole   = "describe_role"
+	KindDescribeEntity  = "describe_entity"
+	KindClassifyDomain  = "classify_domain"
+	KindInferXLangCall  = "infer_xlang_call"
+	KindSummarizeAPI    = "summarize_api"
+	KindFlagDeadCode    = "flag_dead_code"
+	KindDescribeRole    = "describe_role"
+	KindNameCommunity   = "name_community"
 )
+
+// communitySubjectID returns the synthetic subject ID for a community
+// enrichment candidate. The prefix "community:" distinguishes it from
+// entity IDs so the resolution consumer can route correctly.
+func communitySubjectID(communityID int) string {
+	return fmt.Sprintf("community:%d", communityID)
+}
 
 // CandidatesSchemaVersion is the integer version of the on-disk
 // enrichment-candidates.json schema. Bump on a breaking change.
@@ -460,6 +468,78 @@ func CollectCandidatesSkippingRejected(doc *graph.Document, emitters []Candidate
 		out = append(out, c)
 	}
 	return out
+}
+
+// CollectCommunityCandidates emits one name_community candidate per community
+// that does not yet have an AgentName assigned. The SubjectID uses the
+// "community:<id>" prefix so consumers can distinguish them from entity
+// candidates. Context includes the top-10 entities by centrality so the
+// agent can infer a business label.
+func CollectCommunityCandidates(doc *graph.Document, rejected map[string]bool) []Candidate {
+	if doc == nil {
+		return nil
+	}
+	var out []Candidate
+	for i := range doc.Communities {
+		c := &doc.Communities[i]
+		if c.AgentName != "" {
+			// Already resolved — skip.
+			continue
+		}
+		sid := communitySubjectID(c.ID)
+		key := sid + "|" + KindNameCommunity
+		if rejected[key] {
+			continue
+		}
+		// Top-10 entities by position in TopEntities (already ranked by centrality).
+		top := c.TopEntities
+		if len(top) > 10 {
+			top = top[:10]
+		}
+		out = append(out, Candidate{
+			ID:        candidateID(sid, KindNameCommunity),
+			Kind:      KindNameCommunity,
+			SubjectID: sid,
+			Context: map[string]any{
+				"community_id": c.ID,
+				"auto_name":    c.AutoName,
+				"size":         c.Size,
+				"top_entities": top,
+			},
+			PromptTemplate:  "Give a concise business name (UpperCamelCase, ≤30 chars) for the module cluster whose top members are {{top_entities}}.",
+			ConfidenceFloor: 0.6,
+			DiscoveredAt:    nowRFC3339(),
+		})
+	}
+	return out
+}
+
+// ApplyCommunityNameResolutions scans resolutions for kind="name_community"
+// entries and writes the resolved Value into the matching community's
+// AgentName field. Returns the count of applied resolutions.
+func ApplyCommunityNameResolutions(doc *graph.Document, resolutions []Resolution) int {
+	if doc == nil {
+		return 0
+	}
+	applied := 0
+	for _, r := range resolutions {
+		if r.Kind != KindNameCommunity || r.Value == "" {
+			continue
+		}
+		// SubjectID format: "community:<id>"
+		var cid int
+		if _, err := fmt.Sscanf(r.SubjectID, "community:%d", &cid); err != nil {
+			continue
+		}
+		for i := range doc.Communities {
+			if doc.Communities[i].ID == cid {
+				doc.Communities[i].AgentName = r.Value
+				applied++
+				break
+			}
+		}
+	}
+	return applied
 }
 
 // ApplyResolutions merges resolved enrichment values into the document

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -199,3 +199,84 @@ func TestWriteCandidates_ByteIdenticalAcrossRuns(t *testing.T) {
 			string(bytes1), string(bytes2))
 	}
 }
+
+// TestCollectCommunityCandidates verifies that one name_community candidate is
+// emitted per community without an AgentName, and that communities that
+// already have an AgentName are skipped.
+func TestCollectCommunityCandidates(t *testing.T) {
+	doc := &graph.Document{
+		Communities: []graph.CommunityResult{
+			{ID: 0, Size: 100, AutoName: "Order Fulfillment", TopEntities: []string{"e1", "e2"}},
+			{ID: 1, Size: 50, AutoName: "Auth", AgentName: "AlreadyNamed", TopEntities: []string{"e3"}},
+			{ID: 2, Size: 30, AutoName: "Payments", TopEntities: []string{"e4", "e5", "e6"}},
+		},
+	}
+	cands := CollectCommunityCandidates(doc, nil)
+	if len(cands) != 2 {
+		t.Fatalf("expected 2 candidates (skip AlreadyNamed), got %d", len(cands))
+	}
+	for _, c := range cands {
+		if c.Kind != KindNameCommunity {
+			t.Errorf("kind = %q, want %q", c.Kind, KindNameCommunity)
+		}
+	}
+	// IDs must be stable (deterministic).
+	ids := map[string]bool{}
+	for _, c := range cands {
+		if ids[c.ID] {
+			t.Errorf("duplicate candidate ID %q", c.ID)
+		}
+		ids[c.ID] = true
+	}
+	// Subject IDs use the "community:<id>" prefix.
+	if cands[0].SubjectID != "community:0" {
+		t.Errorf("subject_id = %q, want community:0", cands[0].SubjectID)
+	}
+	if cands[1].SubjectID != "community:2" {
+		t.Errorf("subject_id = %q, want community:2", cands[1].SubjectID)
+	}
+}
+
+// TestCollectCommunityCandidates_Rejected verifies that a rejected
+// (community:<id>, name_community) pair produces no candidate.
+func TestCollectCommunityCandidates_Rejected(t *testing.T) {
+	doc := &graph.Document{
+		Communities: []graph.CommunityResult{
+			{ID: 0, Size: 10, AutoName: "Foo"},
+		},
+	}
+	rejected := map[string]bool{
+		"community:0|" + KindNameCommunity: true,
+	}
+	cands := CollectCommunityCandidates(doc, rejected)
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates after rejection, got %d", len(cands))
+	}
+}
+
+// TestApplyCommunityNameResolutions verifies that matching resolutions are
+// written onto the correct CommunityResult.AgentName and that non-matching
+// kinds are ignored.
+func TestApplyCommunityNameResolutions(t *testing.T) {
+	doc := &graph.Document{
+		Communities: []graph.CommunityResult{
+			{ID: 0, AutoName: "Order Fulfillment"},
+			{ID: 1, AutoName: "Auth"},
+		},
+	}
+	resolutions := []Resolution{
+		{SubjectID: "community:0", Kind: KindNameCommunity, Value: "OrderProcessing"},
+		{SubjectID: "community:1", Kind: "describe_entity", Value: "should be ignored"},
+		{SubjectID: "community:99", Kind: KindNameCommunity, Value: "no such community"},
+	}
+	n := ApplyCommunityNameResolutions(doc, resolutions)
+	if n != 1 {
+		t.Fatalf("applied = %d, want 1", n)
+	}
+	if doc.Communities[0].AgentName != "OrderProcessing" {
+		t.Errorf("community 0 AgentName = %q, want OrderProcessing", doc.Communities[0].AgentName)
+	}
+	if doc.Communities[1].AgentName != "" {
+		t.Errorf("community 1 AgentName = %q, want empty (wrong kind)", doc.Communities[1].AgentName)
+	}
+}

--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -32,14 +32,18 @@ import (
 // AutoName is the deterministic Layer-1 label produced by AssignCommunityNames
 // (TF-IDF over member entity names). It is always populated when communities
 // are computed; consumers that previously fell back to "community_<id>" can
-// now display AutoName directly. A future Layer-2 agent-resolved label will
-// take precedence over AutoName when present.
+// now display AutoName directly.
+//
+// AgentName is the Layer-2 label resolved by an MCP agent via
+// submit_enrichment(kind="name_community"). It takes precedence over AutoName
+// when present (issue #426).
 type CommunityResult struct {
 	ID          int      `json:"id"`
 	Size        int      `json:"size"`
 	Modularity  float64  `json:"modularity"`
 	TopEntities []string `json:"top_entities"`
 	AutoName    string   `json:"auto_name,omitempty"`
+	AgentName   string   `json:"agent_name,omitempty"`
 }
 
 // SurpriseEdge is a cross-community edge whose pair frequency is rare.


### PR DESCRIPTION
## Summary

- **Backend**: Added \`AgentName\` field to \`CommunityResult\`, a new \`name_community\` enrichment candidate kind, and \`CollectCommunityCandidates\` / \`ApplyCommunityNameResolutions\` functions so MCP agents can supply business labels for Louvain communities via \`submit_enrichment\`.
- **Indexer**: \`runPass6\` now applies \`name_community\` resolutions onto \`doc.Communities[].AgentName\` before writing graph.json, and emits one \`name_community\` candidate per community that lacks an agent-resolved name (context includes top-10 entities by centrality).
- **Dashboard**: All graph API serialization paths (\`centroids\`, \`mid\`, \`full\`, \`handleGroupCommunities\`) include \`agent_name\` when set; the frontend \`CommunityLegend\` already preferred \`agent_name ?? auto_name\` — no frontend code change required beyond seeding the mock.

## What changed

| File | Change |
|------|--------|
| \`internal/graph/algorithms.go\` | Add \`AgentName string\` (\`agent_name\` JSON) to \`CommunityResult\` |
| \`internal/enrichment/candidates.go\` | \`KindNameCommunity\`, \`CollectCommunityCandidates\`, \`ApplyCommunityNameResolutions\` |
| \`internal/enrichment/candidates_test.go\` | 3 new unit tests |
| \`cmd/archigraph/index.go\` | Apply community name resolutions + collect \`name_community\` candidates in \`runPass6\` |
| \`internal/dashboard/handlers_graph.go\` | Include \`agent_name\` in all 4 community serialization sites |
| \`dashboard/src/api/mocks/graph-mock.json\` | Seed community 0 with \`agent_name="OrderProcessing"\` for E2E verification |

## Test plan

- [x] \`go test ./...\` — full suite green
- [x] \`npx vite build\` — clean build
- [x] Dev server started with \`VITE_USE_MOCKS=true\`; navigated to \`/graph/acme-web\`
- [x] Community legend shows **OrderProcessing** (agent_name) for community 0; remaining communities show TF-IDF auto_name fallback
- [x] \`browser_console_messages(level=error)\` → 0 errors

## Acceptance criteria (from issue)

- [x] \`name_community\` candidate emitted per community lacking AgentName
- [x] \`submit_enrichment\` round-trip persists via \`enrichment-resolutions.json\`; next index run hydrates \`AgentName\`
- [x] Dashboard displays agent-resolved name when present, otherwise \`auto_name\`

Closes #426

🤖 Generated with [Claude Code](https://claude.com/claude-code)