### PR TITLE
[#708] Track unfixable dynamic baseURL cases via repairs/enrichments flow

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1301,6 +1301,22 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 		}
 	}
 
+	// 4) Issue #708 — dynamic-baseurl endpoint candidates. Emitted
+	//    unconditionally (no resolver required) whenever there are
+	//    consumer-side http_endpoint entities whose baseURL is
+	//    runtime-determined (runtime_dynamic=true or dynamic_baseurl=true).
+	//    These surface in archigraph_repairs action=list so an agent can
+	//    annotate them with a curated baseURL hint.
+	dynBaseURL := enrichment.CollectDynamicBaseURLCandidates(doc)
+	if len(dynBaseURL) > 0 {
+		cands = append(cands, dynBaseURL...)
+		if verbose() {
+			fmt.Fprintf(os.Stderr,
+				"enrichment: collected %d dynamic_baseurl_endpoint candidates (#708)\n",
+				len(dynBaseURL))
+		}
+	}
+
 	if err := enrichment.WriteCandidates(archigraphDir, cands); err != nil {
 		fmt.Fprintf(os.Stderr, "archigraph: enrichment candidate write failed: %v\n", err)
 		return

--- a/internal/engine/http_endpoint_client_synthesis_test.go
+++ b/internal/engine/http_endpoint_client_synthesis_test.go
@@ -1291,3 +1291,67 @@ public class UserService {
 		t.Errorf("expected http:GET:/users with runtime_dynamic=true for System.getenv concat (Java)")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #708 — dynamic baseURL: template-literal paths that start with a
+// {<name>} placeholder (e.g. /${tenantId}/contracts/${contractId}) must
+// surface with dynamic_baseurl=true so the repair flow can annotate them.
+// ---------------------------------------------------------------------------
+
+// TestSynth708_DynamicBaseURL_TemplateLiteralLeadingParam verifies that
+// fetch(`/${tenantId}/contracts/${contractId}`) emits an http_endpoint
+// entity tagged with dynamic_baseurl=true and pattern_type=
+// http_endpoint_client_synthesis.
+func TestSynth708_DynamicBaseURL_TemplateLiteralLeadingParam(t *testing.T) {
+	src := `
+export async function fetchContracts(tenantId, contractId) {
+  return fetch(` + "`" + `/${tenantId}/contracts/${contractId}` + "`" + `);
+}
+`
+	_, res := runDetect(t, "typescript", "708-dynamic-baseurl.ts", src)
+	var foundPath, foundPatternType, foundDynBaseURL string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind && e.Properties["dynamic_baseurl"] == "true" {
+			foundPath = e.Properties["path"]
+			foundPatternType = e.Properties["pattern_type"]
+			foundDynBaseURL = e.Properties["dynamic_baseurl"]
+			break
+		}
+	}
+	if foundDynBaseURL != "true" {
+		t.Fatalf("expected http_endpoint with dynamic_baseurl=true; entities: %+v", res.Entities)
+	}
+	if foundPatternType != "http_endpoint_client_synthesis" {
+		t.Errorf("pattern_type: want http_endpoint_client_synthesis, got %q", foundPatternType)
+	}
+	// The canonical path must start with /{tenantId} or {tenantId} so the
+	// repair collector can extract the leading placeholder name.
+	strippedPath := strings.TrimPrefix(foundPath, "/")
+	if !strings.HasPrefix(strippedPath, "{tenantId}") {
+		t.Errorf("path: want prefix {tenantId} (with optional leading /), got %q", foundPath)
+	}
+}
+
+// TestSynth708_DynamicBaseURL_ProcessEnvBaseURL verifies that
+// const baseURL = process.env.API_URL; fetch(baseURL + '/users') produces
+// an entity with runtime_dynamic=true (env-var pattern, not leading-param
+// pattern). Both signals feed into CollectDynamicBaseURLCandidates.
+func TestSynth708_DynamicBaseURL_ProcessEnvBaseURL(t *testing.T) {
+	src := `
+export async function loadUsers() {
+  return fetch(process.env.API_URL + '/users');
+}
+`
+	_, res := runDetect(t, "typescript", "708-env-baseurl.ts", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointKind && e.ID == "http:GET:/users" {
+			if e.Properties["runtime_dynamic"] == "true" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("expected http:GET:/users with runtime_dynamic=true for process.env.API_URL + '/users'")
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -142,6 +142,20 @@ func applyHTTPEndpointSynthesis(
 			if refName != "" {
 				props[refPropKey] = fmt.Sprintf("%s:%s", refKind, refName)
 			}
+			// Issue #708 — mark consumer-side synthetics whose canonical
+			// path begins with a `{<name>}` placeholder, either at the
+			// very start or immediately after the leading slash (e.g.
+			// `{tenantId}/contracts/{id}` or `/{tenantId}/contracts/{id}`).
+			// The first segment is a tenant ID / environment selector that
+			// determines which backend the call targets at runtime — static
+			// link matching can never land these. The flag is consumed by
+			// enrichment.CollectDynamicBaseURLCandidates, which surfaces
+			// them in archigraph_repairs action=list with
+			// category="cross-repo runtime".
+			if patternType == "http_endpoint_client_synthesis" &&
+				hasDynamicBaseURLPath(canonicalPath) {
+				props["dynamic_baseurl"] = "true"
+			}
 
 			entities = append(entities, types.EntityRecord{
 				ID:                 id,
@@ -769,4 +783,24 @@ func joinPathFragments(prefix, method string) string {
 		return prefix + "/" + method
 	}
 	return prefix + method
+}
+
+// hasDynamicBaseURLPath reports whether a canonical URL path indicates a
+// dynamic-baseURL consumer call (issue #708). These are calls where the
+// FIRST path segment is a runtime variable (tenant ID, environment
+// selector, etc.) that determines which backend the request targets.
+//
+// Accepted forms:
+//
+//	{tenantId}/contracts/{id}   — leading placeholder, no root slash
+//	/{tenantId}/contracts/{id}  — leading placeholder after root slash
+//
+// We intentionally do NOT flag paths like `/api/{version}/users` where
+// the dynamic segment is NOT the first segment — those are normal
+// parameterised routes that the linker can match by shape.
+func hasDynamicBaseURLPath(path string) bool {
+	// Drop the optional leading slash so we can check the first segment.
+	rest := strings.TrimPrefix(path, "/")
+	// First character of the first segment must open a placeholder.
+	return strings.HasPrefix(rest, "{")
 }

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -941,3 +941,34 @@ func TestSynth_Django_AstDriven_StillWorks(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #708 — hasDynamicBaseURLPath unit test
+// ---------------------------------------------------------------------------
+
+// TestHasDynamicBaseURLPath verifies the path-classification helper used by
+// makeEmit to tag leading-param consumer endpoints with dynamic_baseurl=true.
+func TestHasDynamicBaseURLPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Leading placeholder — dynamic baseURL.
+		{"/{tenantId}/contracts/{id}", true},
+		{"{tenantId}/contracts/{id}", true},
+		{"/{x}", true},
+		{"{x}", true},
+		// Non-leading placeholder — NOT dynamic baseURL.
+		{"/api/{version}/users", false},
+		{"/users/{id}", false},
+		{"/api/v1/items", false},
+		{"/", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := hasDynamicBaseURLPath(tc.path)
+		if got != tc.want {
+			t.Errorf("hasDynamicBaseURLPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}

--- a/internal/enrichment/dynamic_baseurl.go
+++ b/internal/enrichment/dynamic_baseurl.go
@@ -1,0 +1,207 @@
+package enrichment
+
+// dynamic_baseurl.go surfaces consumer-side http_endpoint entities whose
+// baseURL cannot be resolved statically. These entities are genuine
+// cross-repo calls that static analysis can't link to a producer — they
+// deserve human/agent annotation rather than silent omission.
+//
+// Two patterns are detected:
+//
+//  1. runtime_dynamic=true — the URL was built from a runtime env-var
+//     concatenation (process.env.API_URL + "/path", os.environ["BASE"] +
+//     "/path", System.getenv("X") + "/path", etc.). The env-var prefix
+//     was stripped at synthesis time so only the static suffix survives in
+//     the canonical path. An agent can supply the base URL host/prefix so
+//     the cross-repo link resolves to the correct producer.
+//
+//  2. dynamic_baseurl=true — the canonical path starts with a `{<name>}`
+//     placeholder (first segment is a runtime variable). This arises from
+//     template literals like `/${tenantId}/contracts/${contractId}` where
+//     the leading segment determines which backend the call targets. These
+//     are structurally unmatchable by static analysis.
+//
+// Each detected entity is emitted as an enrichment Candidate of kind
+// KindDynamicBaseURLEndpoint with category "cross-repo runtime". The
+// candidates appear in archigraph_repairs action=list so an agent can
+// submit a baseURL hint via the repairs/enrichments curation surface.
+//
+// After annotation the link pass re-runs against the curated baseURL and
+// the consumer endpoint can resolve to the correct producer.
+//
+// This implements issue #708 (ADR-0015 extension for structural
+// unmatchables).
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// KindDynamicBaseURLEndpoint is the enrichment candidate kind for
+// http_endpoint entities whose baseURL is runtime-determined and cannot
+// be statically resolved.
+const KindDynamicBaseURLEndpoint = "dynamic_baseurl_endpoint"
+
+// CategoryCrossRepoRuntime is the category string written to every
+// dynamic-baseurl candidate's context so archigraph_repairs consumers can
+// filter by category.
+const CategoryCrossRepoRuntime = "cross-repo runtime"
+
+// dynamicBaseURLCandidateID produces a stable ec:<hex16> identifier for
+// a dynamic-baseurl candidate. Keyed on (entityID, kind) so it is
+// reproducible across index runs as long as the entity ID is stable.
+func dynamicBaseURLCandidateID(entityID string) string {
+	h := sha256.New()
+	h.Write([]byte(KindDynamicBaseURLEndpoint))
+	h.Write([]byte{0})
+	h.Write([]byte(entityID))
+	return "ec:" + hex.EncodeToString(h.Sum(nil))[:16]
+}
+
+// CollectDynamicBaseURLCandidates walks doc.Entities and emits a
+// Candidate of kind KindDynamicBaseURLEndpoint for every http_endpoint
+// entity that exhibits either of the two dynamic-baseurl signals:
+//
+//   - Properties["runtime_dynamic"] == "true"  — env-var URL prefix
+//   - Properties["dynamic_baseurl"] == "true"   — path starts with {<name>}
+//
+// The function is deliberately independent of the resolver so it can run
+// unconditionally after the synthesis pass completes (no --enable-repair-
+// candidates gate required). It is additive: existing candidates in
+// enrichment-candidates.json are merged by the WriteCandidates caller.
+func CollectDynamicBaseURLCandidates(doc *graph.Document) []Candidate {
+	if doc == nil {
+		return nil
+	}
+
+	out := make([]Candidate, 0, 16)
+	seen := make(map[string]bool, 16)
+
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != "http_endpoint" {
+			continue
+		}
+		props := e.Properties
+		if props == nil {
+			continue
+		}
+		// Only consumer-side synthetics are dynamic-baseurl candidates.
+		// Producer-side endpoints ARE the target; consumer-side are the
+		// callers whose target is indeterminate. The pattern_type property
+		// set by the synthesis pass distinguishes them.
+		if props["pattern_type"] != "http_endpoint_client_synthesis" {
+			continue
+		}
+
+		isDynamic := false
+		dynamicKind := ""
+
+		switch {
+		case props["runtime_dynamic"] == "true":
+			isDynamic = true
+			dynamicKind = "env-var-baseurl"
+		case props["dynamic_baseurl"] == "true":
+			isDynamic = true
+			dynamicKind = "leading-path-placeholder"
+		}
+
+		if !isDynamic {
+			continue
+		}
+
+		id := dynamicBaseURLCandidateID(e.ID)
+		if seen[id] {
+			continue
+		}
+		seen[id] = true
+
+		path := props["path"]
+		verb := props["verb"]
+		framework := props["framework"]
+		sourceCaller := props["source_caller"]
+
+		ctx := map[string]any{
+			"category":      CategoryCrossRepoRuntime,
+			"dynamic_kind":  dynamicKind,
+			"endpoint_id":   e.ID,
+			"endpoint_name": e.Name,
+			"path":          path,
+			"verb":          verb,
+			"framework":     framework,
+			"source_file":   e.SourceFile,
+			"start_line":    e.StartLine,
+			"language":      e.Language,
+		}
+		if sourceCaller != "" {
+			ctx["source_caller"] = sourceCaller
+		}
+		// Carry the raw dynamic-prefix identifier name when it can be
+		// extracted from the path (first {<name>} segment, with or without
+		// a leading slash: `{tenantId}/...` or `/{tenantId}/...`).
+		if dynamicKind == "leading-path-placeholder" {
+			// Strip an optional leading slash before looking for {name}.
+			stripped := strings.TrimPrefix(path, "/")
+			if strings.HasPrefix(stripped, "{") {
+				if end := strings.IndexByte(stripped[1:], '}'); end >= 0 {
+					ctx["dynamic_prefix_var"] = stripped[1 : 1+end]
+				}
+			}
+		}
+		// Expose the static path suffix (everything after the first {…}/
+		// segment) as a hint for the agent when searching the producer side.
+		ctx["static_path_suffix"] = staticPathSuffix(path)
+
+		out = append(out, Candidate{
+			ID:           id,
+			Kind:         KindDynamicBaseURLEndpoint,
+			SubjectID:    e.ID,
+			Context:      ctx,
+			DiscoveredAt: nowRFC3339(),
+		})
+	}
+
+	// Stable sort so byte output is deterministic across index runs.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].SubjectID != out[j].SubjectID {
+			return out[i].SubjectID < out[j].SubjectID
+		}
+		return out[i].ID < out[j].ID
+	})
+	return out
+}
+
+// staticPathSuffix strips the first dynamic segment from a URL path so
+// the remainder can be used to locate the producer endpoint.
+//
+// Examples:
+//
+//	{tenantId}/contracts/{contractId}   →  /contracts/{contractId}
+//	{param}/users/{id}                  →  /users/{id}
+//	/{tenantId}/contracts/{contractId}  →  /contracts/{contractId}
+//	/users/{id}                         →  /users/{id}  (no leading param)
+func staticPathSuffix(path string) string {
+	// Normalise: strip a leading slash before checking for a placeholder.
+	leadingSlash := strings.HasPrefix(path, "/")
+	stripped := strings.TrimPrefix(path, "/")
+	if !strings.HasPrefix(stripped, "{") {
+		// No leading placeholder — return as-is (re-add stripped slash).
+		if leadingSlash {
+			return "/" + stripped
+		}
+		return stripped
+	}
+	// Skip past the first {…} segment (placeholder + optional slash).
+	end := strings.IndexByte(stripped, '}')
+	if end < 0 {
+		return "/"
+	}
+	rest := stripped[end+1:]
+	if !strings.HasPrefix(rest, "/") {
+		rest = "/" + rest
+	}
+	return rest
+}

--- a/internal/enrichment/dynamic_baseurl_test.go
+++ b/internal/enrichment/dynamic_baseurl_test.go
@@ -1,0 +1,268 @@
+package enrichment
+
+// Tests for CollectDynamicBaseURLCandidates (#708).
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// makeHTTPEndpointEntity builds a minimal graph.Entity for testing.
+func makeHTTPEndpointEntity(id, path, patternType string, extraProps map[string]string) graph.Entity {
+	props := map[string]string{
+		"path":         path,
+		"verb":         "GET",
+		"pattern_type": patternType,
+	}
+	for k, v := range extraProps {
+		props[k] = v
+	}
+	return graph.Entity{
+		ID:         id,
+		Name:       "http:GET:" + path,
+		Kind:       "http_endpoint",
+		SourceFile: "src/api.ts",
+		Language:   "typescript",
+		Properties: props,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_RuntimeDynamic
+// Issue #708: consumer-side endpoint with runtime_dynamic=true (env-var
+// baseURL concat) must surface as a dynamic_baseurl_endpoint candidate.
+//
+// Acceptance criterion: fetch(process.env.API_URL + '/users') produces a
+// repair_candidate with category "cross-repo runtime".
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_RuntimeDynamic(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntity("id-env-1", "/users", "http_endpoint_client_synthesis", map[string]string{
+				"runtime_dynamic": "true",
+				"framework":       "fetch",
+			}),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(cands))
+	}
+
+	c := cands[0]
+	if c.Kind != KindDynamicBaseURLEndpoint {
+		t.Errorf("kind: want %q, got %q", KindDynamicBaseURLEndpoint, c.Kind)
+	}
+	if c.SubjectID != "id-env-1" {
+		t.Errorf("subject_id: want %q, got %q", "id-env-1", c.SubjectID)
+	}
+	if !strings.HasPrefix(c.ID, "ec:") || len(c.ID) != len("ec:")+16 {
+		t.Errorf("id shape wrong: %q", c.ID)
+	}
+	category, _ := c.Context["category"].(string)
+	if category != CategoryCrossRepoRuntime {
+		t.Errorf("category: want %q, got %q", CategoryCrossRepoRuntime, category)
+	}
+	dynamicKind, _ := c.Context["dynamic_kind"].(string)
+	if dynamicKind != "env-var-baseurl" {
+		t.Errorf("dynamic_kind: want %q, got %q", "env-var-baseurl", dynamicKind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_DynamicBaseURL
+// Issue #708: consumer-side endpoint whose canonical path starts with a
+// {<name>} placeholder (e.g. /${tenantId}/contracts/${contractId} →
+// {tenantId}/contracts/{contractId}) must surface as a candidate.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_DynamicBaseURL(t *testing.T) {
+	// Use the with-leading-slash form that the synthesis pass emits
+	// (fetch(`/${tenantId}/contracts/${contractId}`) → /{tenantId}/contracts/{contractId}).
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntity("id-tenant-1", "/{tenantId}/contracts/{contractId}",
+				"http_endpoint_client_synthesis", map[string]string{
+					"dynamic_baseurl": "true",
+					"framework":       "fetch",
+				}),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(cands))
+	}
+
+	c := cands[0]
+	if c.Kind != KindDynamicBaseURLEndpoint {
+		t.Errorf("kind: want %q, got %q", KindDynamicBaseURLEndpoint, c.Kind)
+	}
+	category, _ := c.Context["category"].(string)
+	if category != CategoryCrossRepoRuntime {
+		t.Errorf("category: want %q, got %q", CategoryCrossRepoRuntime, category)
+	}
+	dynamicKind, _ := c.Context["dynamic_kind"].(string)
+	if dynamicKind != "leading-path-placeholder" {
+		t.Errorf("dynamic_kind: want %q, got %q", "leading-path-placeholder", dynamicKind)
+	}
+	// Dynamic prefix var should be extracted (strip leading `/{` to get `tenantId`).
+	prefixVar, _ := c.Context["dynamic_prefix_var"].(string)
+	if prefixVar != "tenantId" {
+		t.Errorf("dynamic_prefix_var: want %q, got %q", "tenantId", prefixVar)
+	}
+	// Static suffix should strip the leading /{tenantId} segment.
+	suffix, _ := c.Context["static_path_suffix"].(string)
+	if suffix != "/contracts/{contractId}" {
+		t.Errorf("static_path_suffix: want %q, got %q", "/contracts/{contractId}", suffix)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_ProducerSideSkipped
+// Producer-side http_endpoint synthetics must never appear as candidates —
+// they ARE the targets, not the callers.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_ProducerSideSkipped(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// Producer side — must be skipped even if path starts with {.
+			makeHTTPEndpointEntity("id-prod-1", "/{version}/users",
+				"http_endpoint_synthesis", map[string]string{
+					"dynamic_baseurl": "true",
+				}),
+			// Non-http_endpoint entity — must be skipped.
+			{
+				ID:   "id-func-1",
+				Kind: "function",
+				Name: "fetchUsers",
+				Properties: map[string]string{
+					"runtime_dynamic": "true",
+				},
+			},
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates, got %d: %+v", len(cands), cands)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_StaticConsumerSkipped
+// A consumer-side endpoint with a plain static path (no runtime_dynamic,
+// no dynamic_baseurl) must not produce a candidate — it's the normal case.
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_StaticConsumerSkipped(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntity("id-static-1", "/users/{id}",
+				"http_endpoint_client_synthesis", nil),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 0 {
+		t.Fatalf("expected 0 candidates, got %d", len(cands))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_BothSignals
+// A file with both runtime_dynamic and dynamic_baseurl entities emits one
+// candidate per entity, both with category "cross-repo runtime".
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_BothSignals(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntity("id-env-2", "/items",
+				"http_endpoint_client_synthesis", map[string]string{
+					"runtime_dynamic": "true",
+				}),
+			makeHTTPEndpointEntity("id-tenant-2", "/{tenantId}/orders",
+				"http_endpoint_client_synthesis", map[string]string{
+					"dynamic_baseurl": "true",
+				}),
+			// Static consumer — must not appear.
+			makeHTTPEndpointEntity("id-static-2", "/products",
+				"http_endpoint_client_synthesis", nil),
+		},
+	}
+
+	cands := CollectDynamicBaseURLCandidates(doc)
+	if len(cands) != 2 {
+		t.Fatalf("expected 2 candidates, got %d", len(cands))
+	}
+	for _, c := range cands {
+		if c.Kind != KindDynamicBaseURLEndpoint {
+			t.Errorf("unexpected kind %q", c.Kind)
+		}
+		cat, _ := c.Context["category"].(string)
+		if cat != CategoryCrossRepoRuntime {
+			t.Errorf("category: want %q, got %q", CategoryCrossRepoRuntime, cat)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestCollectDynamicBaseURLCandidates_Idempotent
+// Running the collector twice on the same document must return identical
+// candidate IDs (deterministic / idempotent across index runs).
+// ---------------------------------------------------------------------------
+func TestCollectDynamicBaseURLCandidates_Idempotent(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			makeHTTPEndpointEntity("id-idem-1", "/orders/{id}",
+				"http_endpoint_client_synthesis", map[string]string{
+					"runtime_dynamic": "true",
+				}),
+		},
+	}
+
+	first := CollectDynamicBaseURLCandidates(doc)
+	second := CollectDynamicBaseURLCandidates(doc)
+	if len(first) != 1 || len(second) != 1 {
+		t.Fatalf("expected 1 candidate each run, got %d / %d", len(first), len(second))
+	}
+	if first[0].ID != second[0].ID {
+		t.Errorf("candidate IDs differ across runs: %q vs %q", first[0].ID, second[0].ID)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestStaticPathSuffix
+// Unit test for the staticPathSuffix helper.
+// ---------------------------------------------------------------------------
+func TestStaticPathSuffix(t *testing.T) {
+	cases := []struct {
+		input string
+		want  string
+	}{
+		// No-leading-slash placeholder forms.
+		{"{tenantId}/contracts/{id}", "/contracts/{id}"},
+		{"{param}/users/{id}", "/users/{id}"},
+		{"{x}", "/"},
+		{"{tenantId}", "/"},
+		// Leading-slash placeholder forms (what the synthesis pass emits).
+		{"/{tenantId}/contracts/{id}", "/contracts/{id}"},
+		{"/{param}/users/{id}", "/users/{id}"},
+		{"/{x}", "/"},
+		{"/{tenantId}", "/"},
+		// Already-static paths (no leading param) — must pass through.
+		{"/users/{id}", "/users/{id}"},
+		{"/api/v1/items", "/api/v1/items"},
+	}
+	for _, tc := range cases {
+		got := staticPathSuffix(tc.input)
+		if got != tc.want {
+			t.Errorf("staticPathSuffix(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}

--- a/internal/mcp/repair.go
+++ b/internal/mcp/repair.go
@@ -44,11 +44,15 @@ var allowedRepairResolutions = map[string]bool{
 	enrichment.RepairAbandon:              true,
 }
 
-// readRepairEdgeCandidates returns the repair_edge entries from a repo's
-// enrichment-candidates.json. We re-parse the file as
-// []enrichment.Candidate (the rich shape with Context) because the
-// simplified MCP EnrichmentCandidate struct drops the Context map the
-// repair tools depend on.
+// readRepairEdgeCandidates returns the repair_edge AND dynamic_baseurl_endpoint
+// entries from a repo's enrichment-candidates.json. Both kinds surface in
+// archigraph_repairs action=list — repair_edge for structurally ambiguous
+// symbol edges (ADR-0015 phase-1) and dynamic_baseurl_endpoint for
+// consumer-side HTTP calls whose baseURL is runtime-determined (#708).
+//
+// We re-parse the file as []enrichment.Candidate (the rich shape with
+// Context) because the simplified MCP EnrichmentCandidate struct drops the
+// Context map the repair tools depend on.
 func readRepairEdgeCandidates(repoPath string) []enrichment.Candidate {
 	if repoPath == "" {
 		return nil
@@ -70,9 +74,10 @@ func readRepairEdgeCandidates(repoPath string) []enrichment.Candidate {
 		}
 		arr = obj.Candidates
 	}
-	out := arr[:0]
+	out := make([]enrichment.Candidate, 0, len(arr))
 	for _, c := range arr {
-		if c.Kind == enrichment.KindRepairEdge {
+		if c.Kind == enrichment.KindRepairEdge ||
+			c.Kind == enrichment.KindDynamicBaseURLEndpoint {
 			out = append(out, c)
 		}
 	}
@@ -148,6 +153,12 @@ func writeRepairFile(repoPath string, rf repairFileOnDisk) error {
 // summarizeRepairEdge produces a compact, agent-friendly row for the
 // list_residuals output. The full Context is also included so an agent
 // pipeline can build a prompt without a second round-trip.
+//
+// The function handles both repair_edge candidates (ADR-0015 phase-1) and
+// dynamic_baseurl_endpoint candidates (#708). Dynamic-baseurl entries carry
+// category="cross-repo runtime" in their context; the summary promotes that
+// to a top-level field so callers can filter without inspecting the full
+// context object.
 func summarizeRepairEdge(repo string, c enrichment.Candidate) map[string]any {
 	row := map[string]any{
 		"candidate_id": c.ID,
@@ -158,6 +169,8 @@ func summarizeRepairEdge(repo string, c enrichment.Candidate) map[string]any {
 	if c.Context == nil {
 		return row
 	}
+
+	// repair_edge fields.
 	if v, ok := c.Context["edge_id"].(string); ok {
 		row["edge_id"] = v
 	}
@@ -176,6 +189,30 @@ func summarizeRepairEdge(repo string, c enrichment.Candidate) map[string]any {
 	if v, ok := c.Context["from_entity"]; ok {
 		row["from_entity"] = v
 	}
+
+	// dynamic_baseurl_endpoint fields (#708).
+	if v, ok := c.Context["category"].(string); ok {
+		row["category"] = v
+	}
+	if v, ok := c.Context["dynamic_kind"].(string); ok {
+		row["dynamic_kind"] = v
+	}
+	if v, ok := c.Context["path"].(string); ok && c.Kind == enrichment.KindDynamicBaseURLEndpoint {
+		row["path"] = v
+	}
+	if v, ok := c.Context["verb"].(string); ok && c.Kind == enrichment.KindDynamicBaseURLEndpoint {
+		row["verb"] = v
+	}
+	if v, ok := c.Context["source_file"].(string); ok && c.Kind == enrichment.KindDynamicBaseURLEndpoint {
+		row["source_file"] = v
+	}
+	if v, ok := c.Context["static_path_suffix"].(string); ok {
+		row["static_path_suffix"] = v
+	}
+	if v, ok := c.Context["dynamic_prefix_var"].(string); ok {
+		row["dynamic_prefix_var"] = v
+	}
+
 	// Expose the full context too so callers don't have to fetch the raw
 	// file. This is the most expensive field but it's bounded by the
 	// emitter's context-window cap (~50 lines).


### PR DESCRIPTION
## Summary

Consumer-side HTTP calls with a runtime-determined baseURL (\`/\${tenantId}/contracts/\${id}\`, \`process.env.API_URL + '/users'\`, etc.) were silently omitted from cross-repo analysis — they appeared as orphan endpoints with no path to resolution. This PR surfaces them as first-class \`dynamic_baseurl_endpoint\` repair candidates in \`archigraph_repairs action=list\` so an agent or human can annotate them with a curated baseURL hint.

**Two detection signals:**
- \`dynamic_baseurl=true\` — template-literal paths whose first segment is a \`{<name>}\` placeholder (e.g. \`/\${tenantId}/contracts/\${contractId}\`). The baseURL prefix determines which backend the call targets at runtime; static analysis can never match these.
- \`runtime_dynamic=true\` — env-var URL concatenation (\`process.env.API_URL + '/users'\`, \`os.environ["BASE"] + '/path'\`). Already emitted since #721; now surfaces via the repairs flow too.

**What an agent sees (archigraph_repairs action=list):**
\`\`\`json
{
  "kind": "dynamic_baseurl_endpoint",
  "category": "cross-repo runtime",
  "dynamic_kind": "leading-path-placeholder",
  "dynamic_prefix_var": "tenantId",
  "path": "/{tenantId}/contracts/{contractId}",
  "static_path_suffix": "/contracts/{contractId}",
  "source_file": "src/contracts/api.ts"
}
\`\`\`

## Closes / Refs

- Closes #708

## Changes

| File | What |
|---|---|
| \`internal/engine/http_endpoint_synthesis.go\` | Add \`hasDynamicBaseURLPath\` helper; tag consumer-side synthetics with \`dynamic_baseurl=true\` when first path segment is a \`{<name>}\` placeholder |
| \`internal/enrichment/dynamic_baseurl.go\` | New: \`CollectDynamicBaseURLCandidates(doc)\` emits \`dynamic_baseurl_endpoint\` candidates with \`category="cross-repo runtime"\` |
| \`internal/enrichment/dynamic_baseurl_test.go\` | New: 7 unit tests — both signals, producer-side skip, static skip, idempotency, staticPathSuffix |
| \`cmd/archigraph/index.go\` | Wire collector into Pass 6 (unconditional, no feature gate) |
| \`internal/mcp/repair.go\` | Include \`KindDynamicBaseURLEndpoint\` in repairs list; extend summarize with category/dynamic_kind/static_path_suffix/dynamic_prefix_var |
| \`internal/engine/http_endpoint_synthesis_test.go\` | Add \`TestHasDynamicBaseURLPath\` (10 cases) |
| \`internal/engine/http_endpoint_client_synthesis_test.go\` | Add \`TestSynth708_DynamicBaseURL_TemplateLiteralLeadingParam\` and \`TestSynth708_DynamicBaseURL_ProcessEnvBaseURL\` |

## Acceptance numbers

- \`fetch(\`/\${tenantId}/contracts/\${contractId}\`)\` → entity with \`dynamic_baseurl=true\` ✓
- \`fetch(process.env.API_URL + '/users')\` → entity with \`runtime_dynamic=true\` now surfaces via repairs ✓
- \`dynamic_baseurl=true\` entity → candidate with \`category="cross-repo runtime"\`, \`dynamic_prefix_var="tenantId"\`, \`static_path_suffix="/contracts/{contractId}"\` ✓
- Producer-side synthetics and static-path consumers never appear as candidates ✓
- All 10 \`hasDynamicBaseURLPath\` cases pass ✓
- \`go test ./...\` — 0 failures

## Testing
- [x] All tests pass: \`go test ./...\`
- [x] Relevant fixtures verified
- [x] No regression in cross-language parity

## Notes

Collector runs unconditionally — no \`--enable-repair-candidates\` gate needed (reads entity properties already set by synthesis, no resolver dependency). Dynamic-baseurl candidates appear alongside \`repair_edge\` candidates in \`archigraph_repairs action=list\`; \`kind\` field distinguishes them. The \`static_path_suffix\` field gives the agent a searchable suffix to locate the producer endpoint in the other repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)