### PR TITLE
[#908] Wire dashboard to real daemon data (drop mocks default)

### DIFF
--- a/cmd/archigraph/dashboard.go
+++ b/cmd/archigraph/dashboard.go
@@ -32,6 +32,7 @@ func runDashboard(argv []string) error {
 func runDashboardServe(argv []string) error {
 	fs := flag.NewFlagSet("dashboard serve", flag.ContinueOnError)
 	bindOverride := fs.String("bind", "", "override Bind (default from ~/.archigraph/dashboard.json)")
+	portOverride := fs.Int("port", 0, "pin to a specific port instead of picking from port_range (useful for Vite proxy)")
 	if err := fs.Parse(argv); err != nil {
 		return err
 	}
@@ -42,6 +43,11 @@ func runDashboardServe(argv []string) error {
 	}
 	if *bindOverride != "" {
 		cfg.Bind = *bindOverride
+	}
+	if *portOverride > 0 {
+		// Pin the range to a single port so Listen() always picks it.
+		cfg.PortRange.Min = *portOverride
+		cfg.PortRange.Max = *portOverride
 	}
 
 	srv, err := dashboard.NewServer(cfg, dashboard.NewLiveStore())

--- a/dashboard/.env.example
+++ b/dashboard/.env.example
@@ -1,7 +1,8 @@
-# Set to true to use mock JSON data instead of the live Go server.
-# In development (pnpm dev), this is automatically true via .env.
-# In production builds, set to false or omit — the Go server provides real data.
+# Set to 'true' to use bundled mock JSON instead of the live Go server.
+# Omit or set to 'false' to proxy all /api calls to the dashboard server.
 VITE_USE_MOCKS=false
 
-# Optional: override the Go server base URL (default: localhost:7070)
-# VITE_API_BASE=http://localhost:7070
+# Port that `archigraph dashboard serve --port <N>` binds on.
+# Must match the value you pass to --port (default: 31000).
+# The Vite dev proxy forwards /api/* and /ws/* to http://127.0.0.1:<port>.
+VITE_API_PORT=31000

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,79 @@
+# Archigraph Dashboard
+
+The dashboard is a React/Vite SPA that visualises indexed graph data served by
+`archigraph dashboard serve`. It can run against live daemon data or against
+bundled mock JSON for UI development.
+
+## Running with real data
+
+Follow these steps to view actual indexed graph data in the dashboard.
+
+### 1. Build the CLI
+
+```sh
+go build -o archigraph ./cmd/archigraph
+```
+
+### 2. Register and index a repository
+
+```sh
+# Create a group (one-time)
+./archigraph register --group my-group /path/to/your/repo
+
+# Index it (re-run after code changes)
+./archigraph index /path/to/your/repo
+```
+
+For a quick local fixture use the bundled golden corpus:
+
+```sh
+./archigraph register --group golden internal/quality/golden/go-chi-mini
+./archigraph index internal/quality/golden/go-chi-mini
+```
+
+### 3. Start the dashboard server on a fixed port
+
+Pin the server to port 31000 so the Vite proxy always knows where to find it:
+
+```sh
+./archigraph dashboard serve --port 31000
+# Output: 31000
+# Stderr: archigraph dashboard listening on http://127.0.0.1:31000/
+```
+
+### 4. Start the Vite dev server
+
+In a separate terminal, from the `dashboard/` directory:
+
+```sh
+# Copy the example env if you haven't already
+cp .env.example .env
+
+# VITE_USE_MOCKS must be absent or 'false'; VITE_API_PORT must match --port above
+VITE_API_PORT=31000 VITE_USE_MOCKS=false npm run dev
+```
+
+Open <http://127.0.0.1:5173> — all five surfaces (Graph, Flows, Topology, Paths,
+Docs) now render live data from the group you registered.
+
+### 5. Switching between mock and real mode
+
+| Mode | Command |
+|------|---------|
+| Real data (default) | `VITE_USE_MOCKS=false npm run dev` |
+| Mock data (UI development) | `VITE_USE_MOCKS=true npm run dev` |
+
+No rebuild is needed when switching modes — just restart the dev server.
+
+## Running tests
+
+```sh
+npm test
+```
+
+## Environment variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `VITE_USE_MOCKS` | `false` | Set to `true` to use bundled mock JSON |
+| `VITE_API_PORT` | `31000` | Port the dashboard server is bound to |

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -4,9 +4,13 @@
  * Set VITE_USE_MOCKS=true in .env to load from src/api/mocks/*.json instead
  * of hitting the live Go server. The mock switch is compile-time (import.meta.env)
  * so the mock modules are tree-shaken in production builds.
+ *
+ * When VITE_USE_MOCKS is absent or set to anything other than 'true', all
+ * calls are proxied to the archigraph dashboard server (see vite.config.ts
+ * proxy and VITE_API_PORT).
  */
 
-const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true' || import.meta.env.DEV
+const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true'
 
 // ────────────────────────────────────────────────────────────────────────────
 // HTTP fetch wrapper
@@ -85,9 +89,35 @@ import type { DocTreeResponse, DocContentResponse, DocSearchResponse, EntityCard
 
 // ── Registry ────────────────────────────────────────────────────────────────
 
+/**
+ * Wire-format group from GET /api/registry:
+ *   { name, config_path, repos: string[] }
+ *
+ * Frontend GroupMeta expects:
+ *   { id, display_name, repos: RepoMeta[], entity_count, indexed_at? }
+ *
+ * normalizeRegistry maps the wire format to the frontend type so the SPA
+ * group-selector and routing work without modification.
+ */
+function normalizeRegistry(raw: { groups: Array<{ name: string; config_path?: string; repos?: string[] }> }): Registry {
+  const groups = (raw.groups ?? []).map((g) => ({
+    id: g.name,
+    display_name: g.name,
+    repos: (g.repos ?? []).map((slug) => ({
+      slug,
+      display_name: slug,
+      language: 'unknown',
+      entity_count: 0,
+    })),
+    entity_count: 0,
+  }))
+  return { groups, version: '1' }
+}
+
 export async function fetchRegistry(): Promise<Registry> {
   if (USE_MOCKS) return loadMock<Registry>('registry')
-  return apiFetch<Registry>('/api/registry')
+  const raw = await apiFetch<{ groups: Array<{ name: string; config_path?: string; repos?: string[] }> }>('/api/registry')
+  return normalizeRegistry(raw)
 }
 
 // ── Surface 4: Paths ─────────────────────────────────────────────────────────
@@ -146,6 +176,40 @@ export async function fetchFlowDetail(
 
 // ── Surface 1: Graph ─────────────────────────────────────────────────────────
 
+/**
+ * Wire-format edge from the Go server: { from_id, to_id, kind, cross_repo? }
+ * The frontend type (GraphEdge) uses { id, source, target, kind, cross_repo? }.
+ * normalizeEdge converts from the wire format to the frontend type.
+ */
+function normalizeEdge(raw: { from_id: string; to_id: string; kind: string; cross_repo?: boolean }): import('@/types/api').GraphEdge {
+  return {
+    id: `${raw.from_id}::${raw.to_id}::${raw.kind}`,
+    source: raw.from_id,
+    target: raw.to_id,
+    kind: raw.kind as import('@/types/api').RelationshipKind,
+    cross_repo: raw.cross_repo ?? false,
+  }
+}
+
+/**
+ * Normalise a raw /api/graph response to the GraphResponse shape the
+ * frontend types expect.  The Go server uses:
+ *   - edges[].from_id / to_id  →  edges[].source / target (+ synthetic id)
+ *   - lod_level                →  lod
+ *   - total_nodes              →  total_node_count
+ */
+function normalizeGraphResponse(raw: Record<string, unknown>): GraphResponse {
+  type RawEdge = { from_id: string; to_id: string; kind: string; cross_repo?: boolean }
+  const rawEdges = (raw.edges as RawEdge[] | undefined) ?? []
+  return {
+    nodes: (raw.nodes as GraphResponse['nodes'] | undefined) ?? [],
+    edges: rawEdges.map(normalizeEdge),
+    communities: (raw.communities as GraphResponse['communities'] | undefined) ?? [],
+    lod: ((raw.lod ?? raw.lod_level) as GraphResponse['lod'] | undefined) ?? 'full',
+    total_node_count: (raw.total_node_count ?? raw.total_nodes ?? 0) as number,
+  }
+}
+
 export async function fetchGraph(
   group: string,
   filters: GraphFilters = {},
@@ -155,7 +219,8 @@ export async function fetchGraph(
     return applyGraphMockFilters(data, filters)
   }
   const params = buildParams({ lod: filters.lod, repo: filters.repo })
-  return apiFetch<GraphResponse>(`/api/graph/${group}?${params}`)
+  const raw = await apiFetch<Record<string, unknown>>(`/api/graph/${group}?${params}`)
+  return normalizeGraphResponse(raw)
 }
 
 export async function fetchEntityNeighbors(
@@ -193,7 +258,43 @@ export async function fetchEntityNeighbors(
       inbound,
     }
   }
-  return apiFetch<EntityNeighborResponse>(`/api/graph/${group}/entity/${encodeURIComponent(entityId)}`)
+  // Server returns { entity, inbound_edges, outbound_edges, neighbors }
+  // where edges are wire-format { from_id, to_id, kind }.
+  // Normalise to the EntityNeighborResponse shape the frontend expects.
+  type RawEdge = { from_id: string; to_id: string; kind: string; cross_repo?: boolean }
+  type RawNeighbor = { id: string; label: string; kind: string; source_file: string; start_line: number; repo: string }
+  const raw = await apiFetch<{
+    entity: import('@/types/api').Entity
+    inbound_edges: RawEdge[]
+    outbound_edges: RawEdge[]
+    neighbors: RawNeighbor[]
+  }>(`/api/graph/${group}/entity/${encodeURIComponent(entityId)}`)
+
+  const neighborMap = new Map((raw.neighbors ?? []).map((n) => [n.id, n]))
+
+  const toEdgeNode = (re: RawEdge, peerId: string) => {
+    const edge = normalizeEdge(re)
+    const peer = neighborMap.get(peerId)
+    if (!peer) return null
+    const node: import('@/types/api').GraphNode = {
+      id: peer.id,
+      label: peer.label,
+      kind: peer.kind as import('@/types/api').EntityKind,
+      source_file: peer.source_file,
+      start_line: peer.start_line,
+      repo: peer.repo,
+    }
+    return { edge, node }
+  }
+
+  const outbound = (raw.outbound_edges ?? [])
+    .map((re) => toEdgeNode(re, re.to_id))
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+  const inbound = (raw.inbound_edges ?? [])
+    .map((re) => toEdgeNode(re, re.from_id))
+    .filter((x): x is NonNullable<typeof x> => x !== null)
+
+  return { entity: raw.entity, outbound, inbound }
 }
 
 // ── Surface 3: Topology ───────────────────────────────────────────────────────

--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -1,51 +1,58 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import { resolve } from 'path'
 
 // https://vitejs.dev/config/
-export default defineConfig({
-  plugins: [react()],
-  resolve: {
-    alias: {
-      '@': resolve(__dirname, './src'),
-    },
-  },
-  server: {
-    port: 5173,
-    proxy: {
-      '/api': {
-        target: 'http://localhost:7070',
-        changeOrigin: true,
-      },
-      '/ws': {
-        target: 'ws://localhost:7070',
-        ws: true,
+export default defineConfig(({ mode }) => {
+  // Load env so VITE_API_PORT is available at config-build time
+  const env = loadEnv(mode, process.cwd(), '')
+  const apiPort = env.VITE_API_PORT ?? '31000'
+  const apiBase = `http://127.0.0.1:${apiPort}`
+
+  return {
+    plugins: [react()],
+    resolve: {
+      alias: {
+        '@': resolve(__dirname, './src'),
       },
     },
-  },
-  build: {
-    outDir: 'dist',
-    sourcemap: true,
-    rollupOptions: {
-      output: {
-        manualChunks: {
-          vendor: ['react', 'react-dom', 'react-router-dom'],
-          query: ['@tanstack/react-query'],
-          radix: [
-            '@radix-ui/react-dialog',
-            '@radix-ui/react-tabs',
-            '@radix-ui/react-tooltip',
-            '@radix-ui/react-dropdown-menu',
-            '@radix-ui/react-select',
-          ],
+    server: {
+      port: 5173,
+      proxy: {
+        '/api': {
+          target: apiBase,
+          changeOrigin: true,
+        },
+        '/ws': {
+          target: apiBase.replace('http://', 'ws://'),
+          ws: true,
         },
       },
     },
-  },
-  test: {
-    globals: true,
-    environment: 'jsdom',
-    setupFiles: ['./tests/setup.ts'],
-    css: false,
-  },
+    build: {
+      outDir: 'dist',
+      sourcemap: true,
+      rollupOptions: {
+        output: {
+          manualChunks: {
+            vendor: ['react', 'react-dom', 'react-router-dom'],
+            query: ['@tanstack/react-query'],
+            radix: [
+              '@radix-ui/react-dialog',
+              '@radix-ui/react-tabs',
+              '@radix-ui/react-tooltip',
+              '@radix-ui/react-dropdown-menu',
+              '@radix-ui/react-select',
+            ],
+          },
+        },
+      },
+    },
+    test: {
+      globals: true,
+      environment: 'jsdom',
+      setupFiles: ['./tests/setup.ts'],
+      css: false,
+    },
+  }
 })


### PR DESCRIPTION
## Summary

Implements [#908](https://github.com/cajasmota/archigraph/issues/908): wires the dashboard SPA to the real \`archigraph dashboard serve\` HTTP server instead of bundled mock JSON.

## What changed

**\`dashboard/src/api/client.ts\`**
- Drop \`|| import.meta.env.DEV\` from \`USE_MOCKS\` — mocks only active when \`VITE_USE_MOCKS=true\` is explicitly set; real mode is the default
- Add \`normalizeRegistry\` adapter: server returns \`{ name, repos: string[] }\` per group; frontend \`GroupMeta\` expects \`{ id, display_name, repos: RepoMeta[] }\`
- Add \`normalizeGraphResponse\` + \`normalizeEdge\` adapters: server emits \`{ from_id, to_id, lod_level, total_nodes }\`; frontend types expect \`{ id, source, target, lod, total_node_count }\`
- Add entity-neighbor normaliser: server returns \`inbound_edges\`/\`outbound_edges\` + flat \`neighbors[]\`; client shape is \`{ inbound, outbound }\` of \`{ edge, node }\` pairs

**\`dashboard/vite.config.ts\`**
- Proxy target reads \`VITE_API_PORT\` (default \`31000\`); replaces hard-coded \`localhost:7070\` that never matched the real port range (31000–31999)

**\`cmd/archigraph/dashboard.go\`**
- Add \`--port N\` flag to \`archigraph dashboard serve\` — pins to a stable port for the Vite proxy

**\`dashboard/README.md\`** (new)
- "Running with real data" end-to-end walkthrough

## End-to-end steps

\`\`\`sh
go build -o archigraph ./cmd/archigraph
./archigraph register --group golden internal/quality/golden/go-chi-mini
./archigraph index    internal/quality/golden/go-chi-mini
./archigraph dashboard serve --port 31000
# in another terminal:
cd dashboard && VITE_API_PORT=31000 VITE_USE_MOCKS=false npm run dev
# open http://localhost:5174
\`\`\`

Mock mode unchanged: \`VITE_USE_MOCKS=true npm run dev\`

## Test plan

- [x] \`go build ./cmd/archigraph/...\` — clean
- [x] \`npm test\` — 17/18 suites pass; 1 pre-existing failure (\`ChainStep.test.tsx\` lucide-react Box mock) on \`main\`
- [x] Playwright E2E with real fixture:
  - Graph surface: edge chips show \`REFERENCES\`, \`CALLS\`, \`DEPENDS_ON\`, \`IMPORTS\`, \`ROUTES_TO\`, \`IMPLEMENTS\`, \`STEP_IN_PROCESS\` (real go-chi kinds, not mock); counter shows \`MID 0 / 64\` (64 real indexed entities)
  - Flows surface: real call chains — \`main → runWorker → processEvent → Printf\`, \`UsersHandler.Get → writeJSON → net/http\` — all tagged \`go-chi-mini\`, zero mock entries
  - Console: 0 application errors

Closes #908

🤖 Generated with [Claude Code](https://claude.com/claude-code)