### PR TITLE
Fix #917: Add missing lucide-react icons to ChainStep test mock

### DIFF
--- a/dashboard/tests/components/flows/ChainStep.test.tsx
+++ b/dashboard/tests/components/flows/ChainStep.test.tsx
@@ -4,10 +4,31 @@ import { ChainStep } from '@/components/flows/ChainStep'
 import type { ProcessStep } from '@/types/api'
 
 vi.mock('lucide-react', () => ({
-  FunctionSquare: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Box: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Code: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Component: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
   Database: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
   File: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  FileText: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Folder: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  FunctionSquare: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
   Globe: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Hash: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Layers: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  LayoutGrid: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Link2: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  MessageSquare: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Network: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Package: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Play: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Puzzle: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Radio: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Server: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Settings: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Shapes: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Table: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Workflow: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
+  Zap: (props: React.SVGProps<SVGSVGElement>) => <svg {...props} />,
 }))
 
 vi.mock('@/lib/colors', () => ({


### PR DESCRIPTION
## What we did
Updated the lucide-react mock in `ChainStep.test.tsx` to include all 25 icons needed by the KindIcon component. The test was failing because KindIcon imports 23 distinct lucide-react icon exports, but the test mock only provided 4.

## What we won
- All 18 dashboard test files now pass (109 total tests)
- ChainStep.test.tsx now properly renders with the default entityKind='Function' and uses KindIcon without errors
- The mock is now comprehensive enough to handle any icon that KindIcon might render

## What it means for memory
The fix follows the pattern of providing complete mock exports for dependencies that expose large icon libraries. Future icon-heavy components won't hit the same issue.

## Testing
Verified locally:
- `npm test -- ChainStep` passes (7 tests)
- Full dashboard test suite passes (109 tests across 18 files)

Closes #917