### PR TITLE
[#922 #924] Cross-platform phase 1: Linux smoke + XDG socket paths

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,0 +1,66 @@
+name: Linux Smoke Test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26'
+
+      - name: Build archigraph
+        run: go build -o archigraph ./cmd/archigraph
+        timeout-minutes: 2
+
+      - name: Start daemon
+        run: |
+          set -x
+          export ARCHIGRAPH_DAEMON_ROOT=$(mktemp -d)
+          timeout 30 ./archigraph daemon &
+          DAEMON_PID=$!
+          sleep 2
+
+          # Verify daemon is running
+          if ! kill -0 $DAEMON_PID 2>/dev/null; then
+            echo "Daemon failed to start"
+            exit 1
+          fi
+
+          echo "DAEMON_PID=$DAEMON_PID" >> $GITHUB_ENV
+          echo "ARCHIGRAPH_DAEMON_ROOT=$ARCHIGRAPH_DAEMON_ROOT" >> $GITHUB_ENV
+
+      - name: Onboard golden fixture
+        run: |
+          export ARCHIGRAPH_DAEMON_ROOT=${{ env.ARCHIGRAPH_DAEMON_ROOT }}
+          timeout 30 ./archigraph onboard ./internal/quality/golden/go-chi-mini
+
+      - name: Check daemon indexed the repo
+        run: |
+          export ARCHIGRAPH_DAEMON_ROOT=${{ env.ARCHIGRAPH_DAEMON_ROOT }}
+          output=$(timeout 10 ./archigraph status)
+          echo "$output"
+
+          # Verify status shows indexed = true
+          if ! echo "$output" | grep -q '"indexed":true'; then
+            echo "Repository not indexed"
+            exit 1
+          fi
+
+      - name: Kill daemon
+        if: always()
+        run: |
+          if [ -n "${{ env.DAEMON_PID }}" ]; then
+            kill ${{ env.DAEMON_PID }} 2>/dev/null || true
+            sleep 1
+          fi

--- a/internal/daemon/paths.go
+++ b/internal/daemon/paths.go
@@ -5,8 +5,14 @@
 package daemon
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+)
+
+const (
+	// UnixSocketPathMax is the kernel limit for sun_path on most Unix systems.
+	UnixSocketPathMax = 104
 )
 
 // Layout is the on-disk footprint of a daemon: socket path, pid file,
@@ -25,6 +31,34 @@ type Layout struct {
 // freshly-built daemon at a tempdir without touching the real ~/.archigraph.
 const EnvRoot = "ARCHIGRAPH_DAEMON_ROOT"
 
+// selectSocketPath returns a suitable socket path, trying XDG_RUNTIME_DIR first
+// if available, then falling back to ~/.archigraph/sockets. Returns an error
+// if both paths exceed UnixSocketPathMax (104 chars).
+func selectSocketPath() (string, error) {
+	// Try XDG_RUNTIME_DIR first if set
+	xdgRuntime := os.Getenv("XDG_RUNTIME_DIR")
+	if xdgRuntime != "" {
+		path := filepath.Join(xdgRuntime, "archigraph", "daemon.sock")
+		if len(path) <= UnixSocketPathMax {
+			return path, nil
+		}
+	}
+
+	// Fall back to ~/.archigraph/sockets
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	path := filepath.Join(home, ".archigraph", "sockets", "daemon.sock")
+	if len(path) <= UnixSocketPathMax {
+		return path, nil
+	}
+
+	// Both paths too long
+	return "", fmt.Errorf("socket path exceeds %d character limit: "+
+		"XDG_RUNTIME_DIR=%q, home=%q", UnixSocketPathMax, xdgRuntime, home)
+}
+
 // DefaultLayout returns the standard on-disk layout for the current
 // user. It does not create directories; callers responsible for daemon
 // startup invoke EnsureLayout. We split the two so client-side code
@@ -35,12 +69,26 @@ const EnvRoot = "ARCHIGRAPH_DAEMON_ROOT"
 func DefaultLayout() (Layout, error) {
 	root := os.Getenv(EnvRoot)
 	if root == "" {
+		socketPath, err := selectSocketPath()
+		if err != nil {
+			return Layout{}, err
+		}
 		home, err := os.UserHomeDir()
 		if err != nil {
 			return Layout{}, err
 		}
 		root = filepath.Join(home, ".archigraph")
+		return Layout{
+			Root:       root,
+			SocketDir:  filepath.Dir(socketPath),
+			SocketPath: socketPath,
+			PIDPath:    filepath.Join(root, "daemon.pid"),
+			LogDir:     filepath.Join(root, "logs"),
+			LogPath:    filepath.Join(root, "logs", "daemon.log"),
+		}, nil
 	}
+
+	// When ARCHIGRAPH_DAEMON_ROOT is set (test mode), use it for everything
 	socketDir := filepath.Join(root, "sockets")
 	logDir := filepath.Join(root, "logs")
 	return Layout{
@@ -56,11 +104,18 @@ func DefaultLayout() (Layout, error) {
 // EnsureLayout creates the directories the daemon writes to. The socket
 // path itself is not created here — the listener does that. Permissions
 // are 0700/0600 because the daemon shares state across nothing and the
-// socket is per-user.
+// socket is per-user. Note that when XDG_RUNTIME_DIR is used, the socket
+// directory may not be under l.Root.
 func EnsureLayout(l Layout) error {
-	for _, d := range []string{l.Root, l.SocketDir, l.LogDir} {
-		if err := os.MkdirAll(d, 0o700); err != nil {
-			return err
+	dirs := []string{l.Root, l.SocketDir, l.LogDir}
+	// Remove duplicates (happens if SocketDir is outside Root)
+	seen := make(map[string]bool)
+	for _, d := range dirs {
+		if !seen[d] && d != "" {
+			seen[d] = true
+			if err := os.MkdirAll(d, 0o700); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/internal/daemon/paths_test.go
+++ b/internal/daemon/paths_test.go
@@ -1,0 +1,166 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSelectSocketPath_PreferXDGWhenSet(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+	t.Setenv("HOME", "/home/user")
+
+	path, err := selectSocketPath()
+	if err != nil {
+		t.Fatalf("selectSocketPath: %v", err)
+	}
+
+	expected := "/run/user/1000/archigraph/daemon.sock"
+	if path != expected {
+		t.Fatalf("expected %q, got %q", expected, path)
+	}
+
+	if len(path) > UnixSocketPathMax {
+		t.Fatalf("XDG path exceeds limit: %d > %d", len(path), UnixSocketPathMax)
+	}
+}
+
+func TestSelectSocketPath_FallbackToHomeWhenXDGTooLong(t *testing.T) {
+	// Simulate XDG path exceeding limit
+	t.Setenv("XDG_RUNTIME_DIR", "/very/long/path/that/would/exceed/the/socket/limit/when/combined/with/archigraph/daemon/sock")
+	t.Setenv("HOME", "/home/user")
+
+	path, err := selectSocketPath()
+	if err != nil {
+		t.Fatalf("selectSocketPath: %v", err)
+	}
+
+	expected := "/home/user/.archigraph/sockets/daemon.sock"
+	if path != expected {
+		t.Fatalf("expected fallback to home %q, got %q", expected, path)
+	}
+}
+
+func TestSelectSocketPath_UseHomeWhenXDGNotSet(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "")
+	t.Setenv("HOME", "/home/user")
+
+	path, err := selectSocketPath()
+	if err != nil {
+		t.Fatalf("selectSocketPath: %v", err)
+	}
+
+	expected := "/home/user/.archigraph/sockets/daemon.sock"
+	if path != expected {
+		t.Fatalf("expected %q, got %q", expected, path)
+	}
+
+	if len(path) > UnixSocketPathMax {
+		t.Fatalf("home path exceeds limit: %d > %d", len(path), UnixSocketPathMax)
+	}
+}
+
+func TestSelectSocketPath_ErrorWhenBothTooLong(t *testing.T) {
+	// Both XDG and home paths exceed 104 char limit
+	// Use a realistic but long path: /very/long/directory/path/that/when/combined/with/archigraph/daemon/sock/exceeds/limit
+	longPath := "/very/long/directory/path/that/when/combined/with/archigraph/daemon/sock/exceeds/the/limit/constraint"
+	t.Setenv("XDG_RUNTIME_DIR", longPath)
+	t.Setenv("HOME", longPath)
+
+	_, err := selectSocketPath()
+	if err == nil {
+		t.Fatal("expected error when both paths exceed 104 char limit")
+	}
+}
+
+func TestDefaultLayout_XDGPathWhenAvailable(t *testing.T) {
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+	t.Setenv("HOME", "/home/user")
+	t.Setenv(EnvRoot, "")
+
+	layout, err := DefaultLayout()
+	if err != nil {
+		t.Fatalf("DefaultLayout: %v", err)
+	}
+
+	if len(layout.SocketPath) > UnixSocketPathMax {
+		t.Fatalf("socket path exceeds limit: %d > %d", len(layout.SocketPath), UnixSocketPathMax)
+	}
+
+	// Home-based paths should still work (PID, logs under ~/.archigraph)
+	if !filepath.HasPrefix(layout.LogDir, "/home/user/.archigraph") {
+		t.Fatalf("expected log dir under home, got %q", layout.LogDir)
+	}
+}
+
+func TestDefaultLayout_DaemonRootEnvOverridesXDG(t *testing.T) {
+	tmpRoot := t.TempDir()
+
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", tmpRoot)
+	t.Setenv("XDG_RUNTIME_DIR", "/run/user/1000")
+	t.Setenv("HOME", "/home/user")
+
+	layout, err := DefaultLayout()
+	if err != nil {
+		t.Fatalf("DefaultLayout: %v", err)
+	}
+
+	// When ARCHIGRAPH_DAEMON_ROOT is set, it overrides all paths
+	if !filepath.HasPrefix(layout.SocketPath, tmpRoot) {
+		t.Fatalf("expected socket under ARCHIGRAPH_DAEMON_ROOT %q, got %q", tmpRoot, layout.SocketPath)
+	}
+	if !filepath.HasPrefix(layout.LogDir, tmpRoot) {
+		t.Fatalf("expected log dir under ARCHIGRAPH_DAEMON_ROOT %q, got %q", tmpRoot, layout.LogDir)
+	}
+}
+
+func TestEnsureLayout_CreatesDirs(t *testing.T) {
+	tmpRoot := t.TempDir()
+
+	layout := Layout{
+		Root:       tmpRoot,
+		SocketDir:  filepath.Join(tmpRoot, "sockets"),
+		SocketPath: filepath.Join(tmpRoot, "sockets", "daemon.sock"),
+		PIDPath:    filepath.Join(tmpRoot, "daemon.pid"),
+		LogDir:     filepath.Join(tmpRoot, "logs"),
+		LogPath:    filepath.Join(tmpRoot, "logs", "daemon.log"),
+	}
+
+	if err := EnsureLayout(layout); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+
+	// Check directories were created
+	for _, dir := range []string{layout.Root, layout.SocketDir, layout.LogDir} {
+		if _, err := os.Stat(dir); err != nil {
+			t.Fatalf("directory not created: %q: %v", dir, err)
+		}
+	}
+}
+
+func TestEnsureLayout_HandlesSeparateSocketDir(t *testing.T) {
+	// Test when socket dir is outside root (e.g., XDG path)
+	tmpRoot := t.TempDir()
+	tmpXDG := t.TempDir()
+
+	layout := Layout{
+		Root:       tmpRoot,
+		SocketDir:  filepath.Join(tmpXDG, "archigraph"),
+		SocketPath: filepath.Join(tmpXDG, "archigraph", "daemon.sock"),
+		PIDPath:    filepath.Join(tmpRoot, "daemon.pid"),
+		LogDir:     filepath.Join(tmpRoot, "logs"),
+		LogPath:    filepath.Join(tmpRoot, "logs", "daemon.log"),
+	}
+
+	if err := EnsureLayout(layout); err != nil {
+		t.Fatalf("EnsureLayout: %v", err)
+	}
+
+	// Both socket dir and log dir should exist
+	if _, err := os.Stat(layout.SocketDir); err != nil {
+		t.Fatalf("socket dir not created: %v", err)
+	}
+	if _, err := os.Stat(layout.LogDir); err != nil {
+		t.Fatalf("log dir not created: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
Bundles two cross-platform infrastructure issues into one PR for phase-1 Linux smoke test coverage and robust socket path handling.

**Issue #922**: Linux daemon smoke test workflow that builds, starts daemon, onboards golden fixture, and verifies indexing in < 2 min.

**Issue #924**: XDG_RUNTIME_DIR support with fallback logic and 104-char socket path limit validation to prevent bind failures on systems with long home paths.

## What We Did

### #922 — Linux Smoke Test Workflow
- Created `.github/workflows/linux-smoke.yml` 
- Triggers: push to main, pull_request, workflow_dispatch
- Job: Ubuntu runner → build archigraph → start daemon → onboard go-chi-mini → verify indexing
- Target runtime: < 2 min (excludes heavy Go test suite)
- Uses ARCHIGRAPH_DAEMON_ROOT for test isolation

### #924 — Socket Path XDG Support + Validation
- Modified `internal/daemon/paths.go`:
  - New `selectSocketPath()` function prefers `$XDG_RUNTIME_DIR/archigraph/daemon.sock`
  - Falls back to `~/.archigraph/sockets/daemon.sock` if XDG too long or unset
  - Validates both paths against Unix socket limit (104 chars)
  - Returns clear error if both exceed limit
- Added `internal/daemon/paths_test.go` with 8 unit tests
- Updated `EnsureLayout()` to handle socket dir outside root (XDG case)

## Test Plan
- [x] Unit tests for socket path selection pass (8/8)
- [x] Existing daemon test suite passes
- [x] Binary builds cleanly
- [x] Workflow YAML valid (reviewed structure)

## What It Means
- Phase-1 Linux coverage now in CI on every push/PR
- Systems with long home paths (> 80 chars to ~/.archigraph/sockets/) will use XDG_RUNTIME_DIR automatically, preventing bind() failures
- ARCHIGRAPH_DAEMON_ROOT continues to override both for testing

Closes #922 #924

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>