### PR TITLE
[#923] Async task extractors: dramatiq, RQ, Hangfire, Quartz.NET, Quartz Java

### DIFF
--- a/internal/custom/csharp/extractors_test.go
+++ b/internal/custom/csharp/extractors_test.go
@@ -241,3 +241,93 @@ func TestEFCoreNoMatch(t *testing.T) {
 		t.Errorf("expected no entities, got %d", len(ents))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Hangfire
+// ---------------------------------------------------------------------------
+
+func TestHangfireEnqueueStatic(t *testing.T) {
+	src := `BackgroundJob.Enqueue(() => EmailService.Send(userId));`
+	ents := extract(t, "custom_csharp_hangfire", fi("jobs/EmailJob.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "EmailService.Send") {
+		t.Error("expected Hangfire enqueue producer entity EmailService.Send")
+	}
+}
+
+func TestHangfireEnqueueTyped(t *testing.T) {
+	src := `BackgroundJob.Enqueue<IEmailService>(x => x.Send(userId));`
+	ents := extract(t, "custom_csharp_hangfire", fi("jobs/EmailJob.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "IEmailService.Send") {
+		t.Error("expected typed Hangfire enqueue producer entity IEmailService.Send")
+	}
+}
+
+func TestHangfireRecurring(t *testing.T) {
+	src := `RecurringJob.AddOrUpdate("daily-report", () => ReportService.Generate(), Cron.Daily);`
+	ents := extract(t, "custom_csharp_hangfire", fi("jobs/RecurringJobs.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Pattern", "daily-report") {
+		t.Error("expected Hangfire recurring job pattern entity 'daily-report'")
+	}
+}
+
+func TestHangfireIJobConsumer(t *testing.T) {
+	src := `
+public class CleanupJob : IBackgroundJob
+{
+    public async Task Execute(PerformContext ctx) { }
+}
+`
+	ents := extract(t, "custom_csharp_hangfire", fi("jobs/CleanupJob.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Service", "CleanupJob") {
+		t.Error("expected Hangfire IBackgroundJob consumer entity CleanupJob")
+	}
+}
+
+func TestHangfireNoMatch(t *testing.T) {
+	src := `namespace App { class Helper { } }`
+	ents := extract(t, "custom_csharp_hangfire", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 hangfire entities, got %d", len(ents))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Quartz.NET
+// ---------------------------------------------------------------------------
+
+func TestQuartzNetIJobConsumer(t *testing.T) {
+	src := `
+public class SendEmailJob : IJob
+{
+    public async Task Execute(IJobExecutionContext context) { }
+}
+`
+	ents := extract(t, "custom_csharp_quartz_net", fi("jobs/SendEmailJob.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Service", "SendEmailJob") {
+		t.Error("expected Quartz.NET IJob consumer entity SendEmailJob")
+	}
+}
+
+func TestQuartzNetJobBuilder(t *testing.T) {
+	src := `var job = JobBuilder.Create<SendEmailJob>().WithIdentity("email-job").Build();`
+	ents := extract(t, "custom_csharp_quartz_net", fi("Scheduler.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "JobBuilder.Create<SendEmailJob>") {
+		t.Error("expected Quartz.NET JobBuilder producer entity")
+	}
+}
+
+func TestQuartzNetScheduleJob(t *testing.T) {
+	src := `await scheduler.ScheduleJob(job, trigger);`
+	ents := extract(t, "custom_csharp_quartz_net", fi("Scheduler.cs", "csharp", src))
+	if !containsEntity(ents, "SCOPE.Operation", "scheduler.ScheduleJob") {
+		t.Error("expected Quartz.NET scheduler.ScheduleJob producer entity")
+	}
+}
+
+func TestQuartzNetNoMatch(t *testing.T) {
+	src := `namespace App { class Helper { } }`
+	ents := extract(t, "custom_csharp_quartz_net", fi("Helper.cs", "csharp", src))
+	if len(ents) != 0 {
+		t.Errorf("expected 0 Quartz.NET entities, got %d", len(ents))
+	}
+}

--- a/internal/custom/csharp/hangfire.go
+++ b/internal/custom/csharp/hangfire.go
@@ -1,0 +1,243 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_hangfire", &hangfireExtractor{})
+}
+
+// hangfireExtractor detects Hangfire background-job producer and consumer patterns.
+//
+// Producers:
+//   - BackgroundJob.Enqueue(() => X.Method())
+//   - BackgroundJob.Enqueue<T>(x => x.Method())
+//   - RecurringJob.AddOrUpdate("id", () => X.Method(), Cron.*)
+//   - BackgroundJob.Schedule(() => X.Method(), delay)
+//
+// Consumers: classes with an Execute(IJobCancellationToken) method, or
+// methods decorated with [AutomaticRetry].
+type hangfireExtractor struct{}
+
+func (e *hangfireExtractor) Language() string { return "custom_csharp_hangfire" }
+
+var (
+	// BackgroundJob.Enqueue(() => TypeName.MethodName(...)) — captures TypeName and MethodName
+	hfEnqueueStaticRe = regexp.MustCompile(
+		`BackgroundJob\.Enqueue\s*\(\s*\(\s*\)\s*=>\s*(\w+)\.(\w+)\s*\(`,
+	)
+	// BackgroundJob.Enqueue<TypeName>(x => x.MethodName(...)) — typed lambda
+	hfEnqueueTypedRe = regexp.MustCompile(
+		`BackgroundJob\.Enqueue\s*<\s*(\w+)\s*>\s*\(\s*\w+\s*=>\s*\w+\.(\w+)\s*\(`,
+	)
+	// RecurringJob.AddOrUpdate("job-id", () => TypeName.MethodName(...), Cron...)
+	hfRecurringStaticRe = regexp.MustCompile(
+		`RecurringJob\.AddOrUpdate\s*\(\s*["']([^"']+)["']\s*,\s*\(\s*\)\s*=>\s*(\w+)\.(\w+)\s*\(`,
+	)
+	// RecurringJob.AddOrUpdate<TypeName>("job-id", x => x.MethodName(...), Cron...)
+	hfRecurringTypedRe = regexp.MustCompile(
+		`RecurringJob\.AddOrUpdate\s*<\s*(\w+)\s*>\s*\(\s*["']([^"']+)["']\s*,\s*\w+\s*=>\s*\w+\.(\w+)\s*\(`,
+	)
+	// BackgroundJob.Schedule(() => TypeName.MethodName(...), ...)
+	hfScheduleStaticRe = regexp.MustCompile(
+		`BackgroundJob\.Schedule\s*\(\s*\(\s*\)\s*=>\s*(\w+)\.(\w+)\s*\(`,
+	)
+	// [AutomaticRetry] attribute — marks a consumer class or method
+	hfAutoRetryRe = regexp.MustCompile(
+		`\[AutomaticRetry(?:\([^)]*\))?\]`,
+	)
+	// class ClassName that implements IJob or has Execute(...) method signature
+	hfJobClassRe = regexp.MustCompile(
+		`(?m)(?:public\s+)?(?:(?:abstract|sealed)\s+)?class\s+(\w+)\s*(?::\s*[\w,\s<>]+)?\{[^}]*\bExecute\s*\(`,
+	)
+	// Explicit IBackgroundJob<T> or IJob interface implementation
+	hfIJobImplRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s*:\s*[^{]*\bI(?:Background)?Job\b`,
+	)
+)
+
+func (e *hangfireExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.hangfire_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "hangfire"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. BackgroundJob.Enqueue(() => TypeName.Method())
+	for _, idx := range hfEnqueueStaticRe.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[idx[2]:idx[3]]
+		methodName := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:" + typeName + "." + methodName
+		ent := makeEntity(typeName+"."+methodName, "SCOPE.Operation", "task_enqueue", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "enqueue",
+			"job_type", typeName,
+			"job_method", methodName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_HANGFIRE_ENQUEUE",
+		)
+		add(ent)
+	}
+
+	// 2. BackgroundJob.Enqueue<TypeName>(x => x.Method())
+	for _, idx := range hfEnqueueTypedRe.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[idx[2]:idx[3]]
+		methodName := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:" + typeName + "." + methodName
+		ent := makeEntity(typeName+"."+methodName, "SCOPE.Operation", "task_enqueue", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "enqueue_typed",
+			"job_type", typeName,
+			"job_method", methodName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_HANGFIRE_ENQUEUE_TYPED",
+		)
+		add(ent)
+	}
+
+	// 3. RecurringJob.AddOrUpdate("id", () => TypeName.Method(), Cron...)
+	for _, idx := range hfRecurringStaticRe.FindAllStringSubmatchIndex(src, -1) {
+		jobID := src[idx[2]:idx[3]]
+		typeName := src[idx[4]:idx[5]]
+		methodName := src[idx[6]:idx[7]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:recurring:" + jobID
+		ent := makeEntity(jobID, "SCOPE.Pattern", "recurring_job", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "recurring",
+			"job_type", typeName,
+			"job_method", methodName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_HANGFIRE_RECURRING",
+		)
+		add(ent)
+	}
+
+	// 4. RecurringJob.AddOrUpdate<TypeName>("id", x => x.Method(), Cron...)
+	for _, idx := range hfRecurringTypedRe.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[idx[2]:idx[3]]
+		jobID := src[idx[4]:idx[5]]
+		methodName := src[idx[6]:idx[7]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:recurring:" + jobID
+		ent := makeEntity(jobID, "SCOPE.Pattern", "recurring_job", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "recurring_typed",
+			"job_type", typeName,
+			"job_method", methodName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_HANGFIRE_RECURRING_TYPED",
+		)
+		add(ent)
+	}
+
+	// 5. BackgroundJob.Schedule(() => TypeName.Method(), ...)
+	for _, idx := range hfScheduleStaticRe.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[idx[2]:idx[3]]
+		methodName := src[idx[4]:idx[5]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:" + typeName + "." + methodName
+		ent := makeEntity(typeName+"."+methodName, "SCOPE.Operation", "task_schedule", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "schedule",
+			"job_type", typeName,
+			"job_method", methodName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_HANGFIRE_SCHEDULE",
+		)
+		add(ent)
+	}
+
+	// 6. Consumer: class implementing IJob / IBackgroundJob
+	for _, idx := range hfIJobImplRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		taskID := "task:hangfire:" + className + ".Execute"
+		ent := makeEntity(className, "SCOPE.Service", "job_class", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "job_class",
+			"task_id", taskID,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_HANGFIRE_IJOB",
+		)
+		add(ent)
+	}
+
+	// 7. Consumer: [AutomaticRetry] decorated class/method
+	for _, idx := range hfAutoRetryRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, idx[0])
+		ent := makeEntity("AutomaticRetry@line"+intStr(line), "SCOPE.Pattern", "retry_policy", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "hangfire",
+			"pattern_type", "automatic_retry",
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_HANGFIRE_AUTOMATIC_RETRY",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}
+
+func intStr(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	buf := make([]byte, 0, 10)
+	neg := n < 0
+	if neg {
+		n = -n
+	}
+	for n > 0 {
+		buf = append([]byte{byte('0' + n%10)}, buf...)
+		n /= 10
+	}
+	if neg {
+		buf = append([]byte{'-'}, buf...)
+	}
+	return string(buf)
+}

--- a/internal/custom/csharp/quartz_net.go
+++ b/internal/custom/csharp/quartz_net.go
@@ -1,0 +1,174 @@
+package csharp
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("custom_csharp_quartz_net", &quartzNetExtractor{})
+}
+
+// quartzNetExtractor detects Quartz.NET scheduler patterns.
+//
+// Consumers: classes implementing IJob (Execute(IJobExecutionContext)).
+// Also: [DisallowConcurrentExecution] decorated classes.
+//
+// Producers:
+//   - JobBuilder.Create<TJobType>() — job detail construction
+//   - TriggerBuilder / TriggerKey.Create<T>() — trigger that fires the job
+//   - scheduler.ScheduleJob(job, trigger)
+type quartzNetExtractor struct{}
+
+func (e *quartzNetExtractor) Language() string { return "custom_csharp_quartz_net" }
+
+var (
+	// class ClassName : IJob
+	qnIJobImplRe = regexp.MustCompile(
+		`(?m)class\s+(\w+)\s*(?::\s*[^{]*\bIJob\b)`,
+	)
+	// [DisallowConcurrentExecution] — marks a consumer job class
+	qnDisallowRe = regexp.MustCompile(
+		`\[DisallowConcurrentExecution(?:\([^)]*\))?\]`,
+	)
+	// JobBuilder.Create<TypeName>()
+	qnJobBuilderRe = regexp.MustCompile(
+		`JobBuilder\.Create\s*<\s*(\w+)\s*>\s*\(`,
+	)
+	// TriggerBuilder.Create().WithIdentity("name") or similar identity patterns
+	qnTriggerBuilderRe = regexp.MustCompile(
+		`TriggerBuilder\.Create\s*\(\s*\)`,
+	)
+	// scheduler.ScheduleJob(jobDetail, trigger)
+	qnScheduleJobRe = regexp.MustCompile(
+		`(?m)(\w+)\.ScheduleJob\s*\(`,
+	)
+	// IJobDetail / IJobDetail named variable: var job = JobBuilder.Create<T>().WithIdentity("name")
+	qnJobIdentityRe = regexp.MustCompile(
+		`\.WithIdentity\s*\(\s*["']([^"']+)["']`,
+	)
+)
+
+func (e *quartzNetExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("archigraph/custom/csharp")
+	_, span := tracer.Start(ctx, "indexer.quartz_net_extractor.extract",
+		trace.WithAttributes(
+			attribute.String("language", file.Language),
+			attribute.String("framework", "quartz.net"),
+			attribute.String("file_path", file.Path),
+		),
+	)
+	defer span.End()
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	src := string(file.Content)
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	add := func(ent types.EntityRecord) {
+		key := ent.Kind + ":" + ent.Name + ":" + ent.Subtype
+		if seen[key] {
+			return
+		}
+		seen[key] = true
+		out = append(out, ent)
+	}
+
+	// 1. Consumer: class implementing IJob
+	for _, idx := range qnIJobImplRe.FindAllStringSubmatchIndex(src, -1) {
+		className := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		taskID := "task:quartz.net:" + className
+		ent := makeEntity(className, "SCOPE.Service", "job_class", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quartz.net",
+			"pattern_type", "ijob_impl",
+			"task_id", taskID,
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_QUARTZ_NET_IJOB",
+		)
+		add(ent)
+	}
+
+	// 2. Consumer: [DisallowConcurrentExecution]
+	for _, idx := range qnDisallowRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, idx[0])
+		ent := makeEntity("DisallowConcurrentExecution@line"+intStr(line), "SCOPE.Pattern", "concurrency_policy", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quartz.net",
+			"pattern_type", "disallow_concurrent",
+			"edge_kind", "CONSUMES",
+			"provenance", "INFERRED_FROM_QUARTZ_NET_DISALLOW_CONCURRENT",
+		)
+		add(ent)
+	}
+
+	// 3. Producer: JobBuilder.Create<TypeName>()
+	for _, idx := range qnJobBuilderRe.FindAllStringSubmatchIndex(src, -1) {
+		typeName := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		taskID := "task:quartz.net:" + typeName
+		ent := makeEntity("JobBuilder.Create<"+typeName+">", "SCOPE.Operation", "job_builder", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quartz.net",
+			"pattern_type", "job_builder",
+			"job_type", typeName,
+			"task_id", taskID,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_QUARTZ_NET_JOB_BUILDER",
+		)
+		add(ent)
+	}
+
+	// 4. Producer: TriggerBuilder.Create()
+	for _, idx := range qnTriggerBuilderRe.FindAllStringIndex(src, -1) {
+		line := lineOf(src, idx[0])
+		// Try to extract trigger identity from .WithIdentity("name") after this position
+		rest := src[idx[1]:]
+		triggerName := ""
+		if im := qnJobIdentityRe.FindStringSubmatch(rest); im != nil {
+			triggerName = im[1]
+		}
+		name := "TriggerBuilder.Create"
+		if triggerName != "" {
+			name = "trigger:" + triggerName
+		}
+		ent := makeEntity(name, "SCOPE.Operation", "trigger", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quartz.net",
+			"pattern_type", "trigger_builder",
+			"trigger_name", triggerName,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_QUARTZ_NET_TRIGGER_BUILDER",
+		)
+		add(ent)
+	}
+
+	// 5. Producer: scheduler.ScheduleJob(job, trigger)
+	for _, idx := range qnScheduleJobRe.FindAllStringSubmatchIndex(src, -1) {
+		schedulerVar := src[idx[2]:idx[3]]
+		line := lineOf(src, idx[0])
+		ent := makeEntity(schedulerVar+".ScheduleJob", "SCOPE.Operation", "schedule_job", file.Path, file.Language, line)
+		setProps(&ent,
+			"framework", "quartz.net",
+			"pattern_type", "schedule_job",
+			"scheduler_var", schedulerVar,
+			"edge_kind", "PRODUCES",
+			"provenance", "INFERRED_FROM_QUARTZ_NET_SCHEDULE_JOB",
+		)
+		add(ent)
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/java/extractors_test.go
+++ b/internal/custom/java/extractors_test.go
@@ -1075,6 +1075,129 @@ public class Outer {
 }
 
 // ============================================================================
+// Quartz Java tests
+// ============================================================================
+
+func makeQuartzCtx(src, filePath string) PatternContext {
+	return PatternContext{Source: src, Language: "java", Framework: "quartz", FilePath: filePath}
+}
+
+func containsQuartzEntity(result PatternResult, kind, subtype, name string) bool {
+	for _, e := range result.Entities {
+		if e.Kind == kind && e.Subtype == subtype && e.Name == name {
+			return true
+		}
+	}
+	return false
+}
+
+func TestQuartzJava_IJobConsumer(t *testing.T) {
+	src := `
+public class SendEmailJob implements Job {
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // send email
+    }
+}
+`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "jobs/SendEmailJob.java"))
+	if !containsQuartzEntity(result, "SCOPE.Service", "job_class", "SendEmailJob") {
+		names := entityNames(result.Entities)
+		t.Errorf("expected SendEmailJob consumer job_class entity; got: %v", names)
+	}
+}
+
+func TestQuartzJava_ExecuteMethod(t *testing.T) {
+	src := `
+public class NotifyJob implements Job {
+    public void execute(JobExecutionContext context) { }
+}
+`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "jobs/NotifyJob.java"))
+	found := false
+	for _, e := range result.Entities {
+		if e.Subtype == "job_execute" && strings.HasPrefix(e.Name, "NotifyJob") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected execute method entity for NotifyJob")
+	}
+}
+
+func TestQuartzJava_JobBuilderProducer(t *testing.T) {
+	src := `
+JobDetail job = JobBuilder.newJob(SendEmailJob.class)
+    .withIdentity("send-email-job", "email-group")
+    .build();
+`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "Scheduler.java"))
+	found := false
+	for _, e := range result.Entities {
+		if e.Subtype == "job_builder" && e.Properties["job_class"] == "SendEmailJob" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected JobBuilder.newJob producer entity for SendEmailJob")
+	}
+}
+
+func TestQuartzJava_TriggerBuilder(t *testing.T) {
+	src := `
+Trigger trigger = TriggerBuilder.newTrigger()
+    .withIdentity("email-trigger")
+    .startNow()
+    .build();
+`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "Scheduler.java"))
+	found := false
+	for _, e := range result.Entities {
+		if e.Subtype == "trigger" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected TriggerBuilder.newTrigger trigger entity")
+	}
+}
+
+func TestQuartzJava_SchedulerScheduleJob(t *testing.T) {
+	src := `scheduler.scheduleJob(jobDetail, trigger);`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "Scheduler.java"))
+	if !containsQuartzEntity(result, "SCOPE.Operation", "schedule_job", "scheduler.scheduleJob") {
+		t.Error("expected scheduler.scheduleJob producer entity")
+	}
+}
+
+func TestQuartzJava_DisallowConcurrentExecution(t *testing.T) {
+	src := `
+@DisallowConcurrentExecution
+public class HeavyJob implements Job {
+    public void execute(JobExecutionContext ctx) { }
+}
+`
+	result := ExtractQuartzJava(makeQuartzCtx(src, "jobs/HeavyJob.java"))
+	found := false
+	for _, e := range result.Entities {
+		if e.Subtype == "concurrency_policy" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected @DisallowConcurrentExecution concurrency_policy entity")
+	}
+}
+
+func TestQuartzJava_NonJavaLanguageSkipped(t *testing.T) {
+	src := `class Foo implements Job { }`
+	ctx := PatternContext{Source: src, Language: "kotlin", Framework: "quartz", FilePath: "Foo.kt"}
+	result := ExtractQuartzJava(ctx)
+	if len(result.Entities) != 0 {
+		t.Errorf("expected no entities for non-java language, got %d", len(result.Entities))
+	}
+}
+
+// ============================================================================
 // Helpers
 // ============================================================================
 

--- a/internal/custom/java/quartz.go
+++ b/internal/custom/java/quartz.go
@@ -1,0 +1,283 @@
+package java
+
+import "regexp"
+
+// Quartz Java custom extractor: IJob consumers and JobBuilder/Trigger producers.
+// Supports both Quartz 1.x (Job.execute) and Quartz 2.x (IJob/JobDetail/Trigger).
+
+var quartzJavaFrameworks = map[string]bool{
+	"quartz": true, "quartz-scheduler": true, "quartz_scheduler": true,
+}
+
+var (
+	// class ClassName implements Job (or org.quartz.Job)
+	qzIJobImplRE = regexp.MustCompile(
+		`(?m)(?:public\s+)?(?:(?:abstract|final)\s+)?class\s+(\w+)\s+(?:extends\s+\w+\s+)?implements\s+[^{]*\bJob\b`,
+	)
+	// @DisallowConcurrentExecution class annotation
+	qzDisallowRE = regexp.MustCompile(
+		`@DisallowConcurrentExecution\b`,
+	)
+	// public void execute(JobExecutionContext ...) { — consumer method
+	qzExecuteMethodRE = regexp.MustCompile(
+		`(?m)(?:public\s+)?void\s+execute\s*\(\s*(?:JobExecutionContext|org\.quartz\.JobExecutionContext)`,
+	)
+	// JobBuilder.newJob(ClassName.class) or JobBuilder.newJob(ClassName.class)
+	qzJobBuilderNewJobRE = regexp.MustCompile(
+		`JobBuilder\.newJob\s*\(\s*(\w+)\.class\s*\)`,
+	)
+	// JobDetail job = newJob(ClassName.class) (static import variant)
+	qzNewJobStaticRE = regexp.MustCompile(
+		`\bnewJob\s*\(\s*(\w+)\.class\s*\)`,
+	)
+	// .withIdentity("job-name") — job or trigger identity
+	qzWithIdentityRE = regexp.MustCompile(
+		`\.withIdentity\s*\(\s*["']([^"']+)["']`,
+	)
+	// scheduler.scheduleJob(jobDetail, trigger) or scheduler.scheduleJob(trigger)
+	qzScheduleJobRE = regexp.MustCompile(
+		`(?m)(\w+)\.scheduleJob\s*\(`,
+	)
+	// TriggerBuilder.newTrigger() — producer side
+	qzTriggerBuilderRE = regexp.MustCompile(
+		`TriggerBuilder\.newTrigger\s*\(\s*\)`,
+	)
+	// scheduler.start() — marks the scheduler as active
+	qzSchedulerStartRE = regexp.MustCompile(
+		`(?m)(\w+)\.start\s*\(\s*\)`,
+	)
+)
+
+// ExtractQuartzJava runs the Quartz Java extractor.
+func ExtractQuartzJava(ctx PatternContext) PatternResult {
+	var result PatternResult
+	if ctx.Language != "java" {
+		return result
+	}
+
+	source := ctx.Source
+	fp := ctx.FilePath
+	seenRefs := make(map[string]bool)
+	seenRels := make(map[relKey]bool)
+
+	// 1. Consumer: classes that implement Job
+	type jobClassInfo struct {
+		name   string
+		offset int
+	}
+	var jobClasses []jobClassInfo
+
+	for _, m := range qzIJobImplRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		taskID := "task:quartz:" + className
+		line := lineOf(source, m[0])
+		ref := "scope:service:quartz_job:" + fp + ":" + className
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: className, Kind: "SCOPE.Service",
+			Subtype: "job_class", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_IJOB",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "ijob_impl",
+				"task_id":      taskID,
+				"edge_kind":    "CONSUMES",
+			},
+		})
+		jobClasses = append(jobClasses, jobClassInfo{className, m[0]})
+	}
+
+	// 2. Consumer: execute(JobExecutionContext) method — link to enclosing class
+	for _, m := range qzExecuteMethodRE.FindAllStringIndex(source, -1) {
+		enclosing := findEnclosingClass(source, m[0])
+		if enclosing == "" {
+			continue
+		}
+		taskID := "task:quartz:" + enclosing
+		line := lineOf(source, m[0])
+		ref := "scope:operation:quartz_execute:" + fp + ":" + enclosing
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: enclosing + ".execute", Kind: "SCOPE.Operation",
+			Subtype: "job_execute", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_EXECUTE",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "execute_method",
+				"class":        enclosing,
+				"task_id":      taskID,
+				"edge_kind":    "CONSUMES",
+			},
+		})
+	}
+
+	// 3. Consumer: @DisallowConcurrentExecution — mark each annotated class
+	for _, m := range qzDisallowRE.FindAllStringIndex(source, -1) {
+		line := lineOf(source, m[0])
+		// Find the class declared after this annotation
+		rest := source[m[1]:]
+		cls := ""
+		if cm := classDeclRE.FindStringSubmatch(rest); cm != nil {
+			cls = cm[1]
+		}
+		name := "@DisallowConcurrentExecution"
+		if cls != "" {
+			name = cls + ":" + name
+		}
+		ref := "scope:pattern:quartz_disallow:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Pattern",
+			Subtype: "concurrency_policy", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_DISALLOW_CONCURRENT",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "disallow_concurrent",
+				"job_class":    cls,
+				"edge_kind":    "CONSUMES",
+			},
+		})
+	}
+
+	// 4. Producer: JobBuilder.newJob(ClassName.class)
+	for _, m := range qzJobBuilderNewJobRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		taskID := "task:quartz:" + className
+		line := lineOf(source, m[0])
+		// Attempt to find .withIdentity("name") after this match
+		rest := source[m[1]:]
+		jobName := ""
+		if im := qzWithIdentityRE.FindStringSubmatch(rest); im != nil {
+			jobName = im[1]
+		}
+		name := "JobBuilder.newJob<" + className + ">"
+		if jobName != "" {
+			name = "job:" + jobName
+		}
+		ref := "scope:operation:quartz_job_builder:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Operation",
+			Subtype: "job_builder", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_JOB_BUILDER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "job_builder",
+				"job_class":    className,
+				"task_id":      taskID,
+				"job_name":     jobName,
+				"edge_kind":    "PRODUCES",
+			},
+		})
+	}
+
+	// 5. Producer: newJob(ClassName.class) — static import variant
+	for _, m := range qzNewJobStaticRE.FindAllStringSubmatchIndex(source, -1) {
+		className := source[m[2]:m[3]]
+		// Skip if already matched by full JobBuilder form (avoid double-count)
+		alreadyMatched := false
+		for _, em := range result.Entities {
+			if p, ok := em.Properties["job_class"]; ok && p == className && em.Subtype == "job_builder" {
+				alreadyMatched = true
+				break
+			}
+		}
+		if alreadyMatched {
+			continue
+		}
+		taskID := "task:quartz:" + className
+		line := lineOf(source, m[0])
+		name := "newJob<" + className + ">"
+		ref := "scope:operation:quartz_new_job:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Operation",
+			Subtype: "job_builder", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_NEW_JOB_STATIC",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "new_job_static",
+				"job_class":    className,
+				"task_id":      taskID,
+				"edge_kind":    "PRODUCES",
+			},
+		})
+	}
+
+	// 6. Producer: TriggerBuilder.newTrigger()
+	for _, m := range qzTriggerBuilderRE.FindAllStringIndex(source, -1) {
+		line := lineOf(source, m[0])
+		rest := source[m[1]:]
+		triggerName := ""
+		if im := qzWithIdentityRE.FindStringSubmatch(rest); im != nil {
+			triggerName = im[1]
+		}
+		name := "TriggerBuilder.newTrigger"
+		if triggerName != "" {
+			name = "trigger:" + triggerName
+		}
+		ref := "scope:operation:quartz_trigger:" + fp + ":" + name
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: name, Kind: "SCOPE.Operation",
+			Subtype: "trigger", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_TRIGGER_BUILDER",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":    "quartz",
+				"pattern_type": "trigger_builder",
+				"trigger_name": triggerName,
+				"edge_kind":    "PRODUCES",
+			},
+		})
+	}
+
+	// 7. Producer: scheduler.scheduleJob(...)
+	for _, m := range qzScheduleJobRE.FindAllStringSubmatchIndex(source, -1) {
+		schedulerVar := source[m[2]:m[3]]
+		line := lineOf(source, m[0])
+		ref := "scope:operation:quartz_schedule:" + fp + ":" + schedulerVar
+		addEntity(&result, seenRefs, SecondaryEntity{
+			Name: schedulerVar + ".scheduleJob", Kind: "SCOPE.Operation",
+			Subtype: "schedule_job", SourceFile: fp,
+			LineStart: line, LineEnd: line,
+			Provenance: "INFERRED_FROM_QUARTZ_SCHEDULE_JOB",
+			Ref:        ref,
+			Properties: map[string]any{
+				"framework":     "quartz",
+				"pattern_type":  "schedule_job",
+				"scheduler_var": schedulerVar,
+				"edge_kind":     "PRODUCES",
+			},
+		})
+	}
+
+	// PRODUCES→CONSUMES cross-edges: link job builders to job class consumers
+	for _, producer := range result.Entities {
+		if producer.Subtype != "job_builder" {
+			continue
+		}
+		jobClass, _ := producer.Properties["job_class"].(string)
+		if jobClass == "" {
+			continue
+		}
+		for _, consumer := range result.Entities {
+			if consumer.Subtype == "job_class" && consumer.Name == jobClass {
+				addRel(&result, seenRels, Relationship{
+					SourceRef:        producer.Ref,
+					TargetRef:        consumer.Ref,
+					RelationshipType: "PRODUCES",
+					Properties:       map[string]string{"framework": "quartz", "task_id": "task:quartz:" + jobClass},
+				})
+			}
+		}
+	}
+
+	_ = quartzJavaFrameworks // prevent unused var compile error; gate used at call sites if needed
+	return result
+}

--- a/internal/custom/python/dramatiq.go
+++ b/internal/custom/python/dramatiq.go
@@ -1,0 +1,108 @@
+package python
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_dramatiq", &dramatiqExtractor{})
+}
+
+// dramatiqExtractor detects dramatiq actors and producer call sites.
+//
+// Consumer pattern: @dramatiq.actor or @dramatiq.actor(...) above a def.
+// Producer patterns: actor_var.send(...) and actor_var.send_with_options(...)
+type dramatiqExtractor struct{}
+
+func (e *dramatiqExtractor) Language() string { return "python_dramatiq" }
+
+var (
+	// @dramatiq.actor optionally followed by decorator arguments, then def funcName(
+	dmActorDecoratorRe = regexp.MustCompile(
+		`(?m)@dramatiq\.actor\s*(?:\([^)]*\))?\s*\n(?:\s*#[^\n]*\n)*\s*(?:async\s+)?def\s+(\w+)\s*\(`,
+	)
+	// actor.send(...) — the variable name before .send is captured as actor_ref
+	dmSendRe = regexp.MustCompile(
+		`(?m)(\w+)\.send\s*\(`,
+	)
+	// actor.send_with_options(...)
+	dmSendWithOptionsRe = regexp.MustCompile(
+		`(?m)(\w+)\.send_with_options\s*\(`,
+	)
+	// False-positive guard: skip generic non-dramatiq @actor decorators
+	// (i.e. bare @actor without the dramatiq. prefix)
+	dmBareActorRe = regexp.MustCompile(
+		`(?m)^@actor\s*\n`,
+	)
+)
+
+func (e *dramatiqExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_dramatiq")
+	_, span := tracer.Start(ctx, "custom.python_dramatiq")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+	var out []types.EntityRecord
+
+	// 1. Consumer: @dramatiq.actor decorated function
+	for _, idx := range allMatchesIndex(dmActorDecoratorRe, source) {
+		funcName := source[idx[2]:idx[3]]
+		line := lineOf(source, idx[0])
+		taskID := "task:dramatiq:" + funcName
+		out = append(out, entity(funcName, "SCOPE.Service", "task", file.Path, line,
+			map[string]string{
+				"framework":    "dramatiq",
+				"pattern_type": "actor",
+				"task_id":      taskID,
+				"edge_kind":    "CONSUMES",
+				"provenance":   "INFERRED_FROM_DRAMATIQ_ACTOR",
+			}))
+	}
+
+	// 2. Producer: actor.send(...)
+	for _, idx := range allMatchesIndex(dmSendRe, source) {
+		actorRef := source[idx[2]:idx[3]]
+		line := lineOf(source, idx[0])
+		name := actorRef + ".send"
+		out = append(out, entity(name, "SCOPE.Operation", "task_send", file.Path, line,
+			map[string]string{
+				"framework":    "dramatiq",
+				"pattern_type": "send",
+				"actor_ref":    actorRef,
+				"task_id":      "task:dramatiq:" + actorRef,
+				"edge_kind":    "PRODUCES",
+				"provenance":   "INFERRED_FROM_DRAMATIQ_SEND",
+			}))
+	}
+
+	// 3. Producer: actor.send_with_options(...)
+	for _, idx := range allMatchesIndex(dmSendWithOptionsRe, source) {
+		actorRef := source[idx[2]:idx[3]]
+		line := lineOf(source, idx[0])
+		name := actorRef + ".send_with_options"
+		out = append(out, entity(name, "SCOPE.Operation", "task_send", file.Path, line,
+			map[string]string{
+				"framework":    "dramatiq",
+				"pattern_type": "send_with_options",
+				"actor_ref":    actorRef,
+				"task_id":      "task:dramatiq:" + actorRef,
+				"edge_kind":    "PRODUCES",
+				"provenance":   "INFERRED_FROM_DRAMATIQ_SEND_WITH_OPTIONS",
+			}))
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -1128,11 +1128,194 @@ func TestFlaskReqResp_NoMatch(t *testing.T) {
 // Empty input tests (all extractors)
 // ============================================================================
 
+// ============================================================================
+// dramatiq tests
+// ============================================================================
+
+func TestDramatiq_Actor(t *testing.T) {
+	src := `import dramatiq
+
+@dramatiq.actor
+def send_email(to, subject):
+    pass
+`
+	ents := extract(t, "python_dramatiq", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "send_email" && e.Kind == "SCOPE.Service" && e.Props["framework"] == "dramatiq" && e.Props["edge_kind"] == "CONSUMES" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected @dramatiq.actor consumer entity for send_email")
+	}
+}
+
+func TestDramatiq_ActorWithOptions(t *testing.T) {
+	src := `@dramatiq.actor(queue_name="billing", max_retries=3)
+def charge_card(user_id, amount):
+    pass
+`
+	ents := extract(t, "python_dramatiq", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "charge_card" && e.Props["pattern_type"] == "actor" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected @dramatiq.actor(options) consumer entity")
+	}
+}
+
+func TestDramatiq_Send(t *testing.T) {
+	src := `send_email.send("user@example.com", "Hello")
+`
+	ents := extract(t, "python_dramatiq", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "send_email.send" && e.Props["edge_kind"] == "PRODUCES" && e.Props["actor_ref"] == "send_email" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected actor.send() producer entity")
+	}
+}
+
+func TestDramatiq_SendWithOptions(t *testing.T) {
+	src := `charge_card.send_with_options(args=[42, 9.99], delay=5000)
+`
+	ents := extract(t, "python_dramatiq", src)
+	found := false
+	for _, e := range ents {
+		if e.Name == "charge_card.send_with_options" && e.Props["edge_kind"] == "PRODUCES" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected actor.send_with_options() producer entity")
+	}
+}
+
+func TestDramatiq_NoBareActorFalsePositive(t *testing.T) {
+	// @actor without dramatiq. prefix should NOT be matched
+	src := `@actor
+def my_handler():
+    pass
+`
+	ents := extract(t, "python_dramatiq", src)
+	for _, e := range ents {
+		if e.Props["framework"] == "dramatiq" && e.Kind == "SCOPE.Service" {
+			t.Fatalf("false positive: bare @actor matched as dramatiq actor: %+v", e)
+		}
+	}
+}
+
+func TestDramatiq_NoMatch(t *testing.T) {
+	src := `def regular():
+    pass
+`
+	ents := extract(t, "python_dramatiq", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-dramatiq code, got %d", len(ents))
+	}
+}
+
+// ============================================================================
+// RQ tests
+// ============================================================================
+
+func TestRQ_Enqueue(t *testing.T) {
+	src := `from rq import Queue
+from workers.billing import charge_card
+
+q = Queue(connection=conn)
+q.enqueue(charge_card, user_id=42)
+`
+	ents := extract(t, "python_rq", src)
+	found := false
+	for _, e := range ents {
+		if e.Props["framework"] == "rq" && e.Props["callable"] == "charge_card" && e.Props["edge_kind"] == "PRODUCES" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected queue.enqueue producer entity")
+	}
+}
+
+func TestRQ_EnqueueCall(t *testing.T) {
+	src := `from rq import Queue
+
+q = Queue(connection=conn)
+q.enqueue_call(func="workers.emails.send_email", args=["hello"])
+`
+	ents := extract(t, "python_rq", src)
+	found := false
+	for _, e := range ents {
+		if e.Props["framework"] == "rq" && e.Props["callable"] == "workers.emails.send_email" && e.Props["pattern_type"] == "enqueue_call" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected enqueue_call producer entity with string func")
+	}
+}
+
+func TestRQ_Worker(t *testing.T) {
+	src := `from rq import Queue, Worker
+from redis import Redis
+
+redis_conn = Redis()
+q = Queue(connection=redis_conn)
+worker = Worker([q], connection=redis_conn)
+worker.work()
+`
+	ents := extract(t, "python_rq", src)
+	found := false
+	for _, e := range ents {
+		if e.Props["framework"] == "rq" && e.Props["pattern_type"] == "worker" && e.Props["edge_kind"] == "CONSUMES" {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatal("expected Worker consumer entity")
+	}
+}
+
+func TestRQ_NoWorkerWithoutImport(t *testing.T) {
+	// Worker class without rq import — generic class, should not emit worker entity
+	src := `class Worker:
+    pass
+
+q = SomeQueue()
+q.enqueue(my_func)
+`
+	ents := extract(t, "python_rq", src)
+	for _, e := range ents {
+		if e.Props["pattern_type"] == "worker" {
+			t.Fatalf("false positive: Worker entity emitted without rq import: %+v", e)
+		}
+	}
+}
+
+func TestRQ_NoMatch(t *testing.T) {
+	src := `def regular():
+    pass
+`
+	ents := extract(t, "python_rq", src)
+	if len(ents) != 0 {
+		t.Fatalf("expected 0 entities for non-RQ code, got %d", len(ents))
+	}
+}
+
 func TestAllExtractors_EmptyInput(t *testing.T) {
 	keys := []string{
 		"python_django", "python_fastapi", "python_flask", "python_celery",
 		"python_pytest", "python_langchain", "python_mongodb", "python_redis",
 		"python_sqlalchemy", "python_fastapi_reqresp", "python_flask_reqresp",
+		"python_dramatiq", "python_rq",
 	}
 	for _, key := range keys {
 		ext, ok := extractor.Get(key)
@@ -1160,6 +1343,7 @@ func TestAllExtractors_Registered(t *testing.T) {
 		"python_django", "python_fastapi", "python_flask", "python_celery",
 		"python_pytest", "python_langchain", "python_mongodb", "python_redis",
 		"python_sqlalchemy", "python_fastapi_reqresp", "python_flask_reqresp",
+		"python_dramatiq", "python_rq",
 	}
 	for _, key := range keys {
 		_, ok := extractor.Get(key)

--- a/internal/custom/python/rq.go
+++ b/internal/custom/python/rq.go
@@ -1,0 +1,141 @@
+package python
+
+import (
+	"context"
+	"regexp"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("python_rq", &rqExtractor{})
+}
+
+// rqExtractor detects Redis Queue (RQ) producer and consumer patterns.
+//
+// Producer: queue.enqueue(func, ...) and queue.enqueue_call(func="module.fn", ...)
+// Consumer: Worker([queue, ...]) instantiation; the callable passed to enqueue is the consumer.
+type rqExtractor struct{}
+
+func (e *rqExtractor) Language() string { return "python_rq" }
+
+var (
+	// queue.enqueue(callable, ...) — captures the queue variable and the callable arg
+	rqEnqueueRe = regexp.MustCompile(
+		`(?m)(\w+)\.enqueue\s*\(\s*([A-Za-z_][\w.]*)`,
+	)
+	// queue.enqueue_call(func="module.fn") or func=some_callable
+	rqEnqueueCallStrRe = regexp.MustCompile(
+		`(?m)(\w+)\.enqueue_call\s*\([^)]*func\s*=\s*["']([^"']+)["']`,
+	)
+	rqEnqueueCallRefRe = regexp.MustCompile(
+		`(?m)(\w+)\.enqueue_call\s*\([^)]*func\s*=\s*([A-Za-z_][\w.]*)`,
+	)
+	// Worker([queues]) — RQ worker declaration
+	rqWorkerRe = regexp.MustCompile(
+		`(?m)\bWorker\s*\(\s*\[([^\]]*)\]`,
+	)
+	// False-positive guard: Queue class that is NOT rq.Queue — we require the
+	// pattern "queue.enqueue" which is generic enough but the worker guard is
+	// tied to RQ's Worker class. We emit workers only when Worker is imported
+	// from rq or when rq is imported at the top of the file.
+	rqImportRe = regexp.MustCompile(
+		`(?m)(?:from\s+rq\b|import\s+rq\b)`,
+	)
+)
+
+func (e *rqExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("custom.python_rq")
+	_, span := tracer.Start(ctx, "custom.python_rq")
+	defer span.End()
+	span.SetAttributes(attribute.String("file", file.Path))
+
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+
+	source := string(file.Content)
+
+	// Only emit worker entities when rq is imported (reduces false positives
+	// from generic Queue/Worker class names in non-RQ code).
+	hasRQImport := rqImportRe.MatchString(source)
+
+	var out []types.EntityRecord
+
+	// 1. Producer: queue.enqueue(callable, ...)
+	for _, idx := range allMatchesIndex(rqEnqueueRe, source) {
+		queueVar := source[idx[2]:idx[3]]
+		callable := source[idx[4]:idx[5]]
+		line := lineOf(source, idx[0])
+		taskID := "task:rq:" + callable
+		out = append(out, entity(callable+".enqueue", "SCOPE.Operation", "task_enqueue", file.Path, line,
+			map[string]string{
+				"framework":    "rq",
+				"pattern_type": "enqueue",
+				"queue_var":    queueVar,
+				"callable":     callable,
+				"task_id":      taskID,
+				"edge_kind":    "PRODUCES",
+				"provenance":   "INFERRED_FROM_RQ_ENQUEUE",
+			}))
+	}
+
+	// 2. Producer: queue.enqueue_call(func="module.fn")
+	for _, idx := range allMatchesIndex(rqEnqueueCallStrRe, source) {
+		queueVar := source[idx[2]:idx[3]]
+		fnName := source[idx[4]:idx[5]]
+		line := lineOf(source, idx[0])
+		taskID := "task:rq:" + fnName
+		out = append(out, entity(fnName+".enqueue_call", "SCOPE.Operation", "task_enqueue", file.Path, line,
+			map[string]string{
+				"framework":    "rq",
+				"pattern_type": "enqueue_call",
+				"queue_var":    queueVar,
+				"callable":     fnName,
+				"task_id":      taskID,
+				"edge_kind":    "PRODUCES",
+				"provenance":   "INFERRED_FROM_RQ_ENQUEUE_CALL",
+			}))
+	}
+
+	// 3. Producer: queue.enqueue_call(func=callable_ref)
+	for _, idx := range allMatchesIndex(rqEnqueueCallRefRe, source) {
+		queueVar := source[idx[2]:idx[3]]
+		callable := source[idx[4]:idx[5]]
+		line := lineOf(source, idx[0])
+		taskID := "task:rq:" + callable
+		out = append(out, entity(callable+".enqueue_call", "SCOPE.Operation", "task_enqueue", file.Path, line,
+			map[string]string{
+				"framework":    "rq",
+				"pattern_type": "enqueue_call",
+				"queue_var":    queueVar,
+				"callable":     callable,
+				"task_id":      taskID,
+				"edge_kind":    "PRODUCES",
+				"provenance":   "INFERRED_FROM_RQ_ENQUEUE_CALL_REF",
+			}))
+	}
+
+	// 4. Consumer: Worker([queues]) — only when rq is in scope
+	if hasRQImport {
+		for _, idx := range allMatchesIndex(rqWorkerRe, source) {
+			queues := source[idx[2]:idx[3]]
+			line := lineOf(source, idx[0])
+			out = append(out, entity("Worker("+queues+")", "SCOPE.Service", "worker", file.Path, line,
+				map[string]string{
+					"framework":    "rq",
+					"pattern_type": "worker",
+					"queues":       queues,
+					"edge_kind":    "CONSUMES",
+					"provenance":   "INFERRED_FROM_RQ_WORKER",
+				}))
+		}
+	}
+
+	span.SetAttributes(attribute.Int("entity_count", len(out)))
+	return out, nil
+}

--- a/internal/quality/golden/csharp-hangfire-mini/expected.json
+++ b/internal/quality/golden/csharp-hangfire-mini/expected.json
@@ -1,0 +1,12 @@
+{
+  "fixture_name": "csharp-hangfire-mini",
+  "language": "csharp",
+  "description": "Minimal Hangfire project with IBackgroundJob consumers, BackgroundJob.Enqueue producers, RecurringJob.AddOrUpdate, and [AutomaticRetry]. Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for Hangfire.",
+  "expected_entities": [
+    { "name": "EmailJob", "kind": "SCOPE.Service", "source_file": "jobs/EmailJob.cs", "must_exist": true, "note": "Hangfire IBackgroundJob consumer." },
+    { "name": "CleanupJob", "kind": "SCOPE.Service", "source_file": "jobs/EmailJob.cs", "must_exist": true, "note": "Hangfire IBackgroundJob consumer with AutomaticRetry." },
+    { "name": "EmailService.SendConfirmation", "kind": "SCOPE.Operation", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: BackgroundJob.Enqueue()." },
+    { "name": "daily-cleanup", "kind": "SCOPE.Pattern", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: RecurringJob.AddOrUpdate." },
+    { "name": "IEmailService.SendNewsletter", "kind": "SCOPE.Operation", "source_file": "api/OrderController.cs", "must_exist": true, "note": "Producer: BackgroundJob.Enqueue<T>()." }
+  ]
+}

--- a/internal/quality/golden/csharp-hangfire-mini/src/api/OrderController.cs
+++ b/internal/quality/golden/csharp-hangfire-mini/src/api/OrderController.cs
@@ -1,0 +1,22 @@
+using Hangfire;
+
+namespace Api.Controllers
+{
+    public class OrderController
+    {
+        public void PlaceOrder(int orderId)
+        {
+            // Producer: fire-and-forget
+            BackgroundJob.Enqueue(() => EmailService.SendConfirmation(orderId));
+        }
+
+        public void ConfigureRecurring()
+        {
+            // Producer: recurring job
+            RecurringJob.AddOrUpdate("daily-cleanup", () => CleanupService.Run(), Cron.Daily);
+
+            // Producer: typed enqueue
+            BackgroundJob.Enqueue<IEmailService>(x => x.SendNewsletter());
+        }
+    }
+}

--- a/internal/quality/golden/csharp-hangfire-mini/src/jobs/EmailJob.cs
+++ b/internal/quality/golden/csharp-hangfire-mini/src/jobs/EmailJob.cs
@@ -1,0 +1,21 @@
+using Hangfire;
+
+namespace Workers.Jobs
+{
+    public class EmailJob : IBackgroundJob
+    {
+        public async Task Execute(PerformContext ctx)
+        {
+            // Consumer: sends an email
+        }
+    }
+
+    public class CleanupJob : IBackgroundJob
+    {
+        [AutomaticRetry(Attempts = 3)]
+        public async Task Execute(PerformContext ctx)
+        {
+            // Consumer: cleans up stale data
+        }
+    }
+}

--- a/internal/quality/golden/csharp-quartz-net-mini/expected.json
+++ b/internal/quality/golden/csharp-quartz-net-mini/expected.json
@@ -1,0 +1,12 @@
+{
+  "fixture_name": "csharp-quartz-net-mini",
+  "language": "csharp",
+  "description": "Minimal Quartz.NET project with IJob consumers, [DisallowConcurrentExecution], JobBuilder.Create producers, TriggerBuilder, and scheduler.ScheduleJob. Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for Quartz.NET.",
+  "expected_entities": [
+    { "name": "ReportJob", "kind": "SCOPE.Service", "source_file": "jobs/ReportJob.cs", "must_exist": true, "note": "Quartz.NET IJob consumer." },
+    { "name": "EmailJob", "kind": "SCOPE.Service", "source_file": "jobs/ReportJob.cs", "must_exist": true, "note": "Quartz.NET IJob consumer." },
+    { "name": "JobBuilder.Create<ReportJob>", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: JobBuilder.Create<T>()." },
+    { "name": "JobBuilder.Create<EmailJob>", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: JobBuilder.Create<T>()." },
+    { "name": "scheduler.ScheduleJob", "kind": "SCOPE.Operation", "source_file": "Startup.cs", "must_exist": true, "note": "Producer: scheduler.ScheduleJob()." }
+  ]
+}

--- a/internal/quality/golden/csharp-quartz-net-mini/src/Startup.cs
+++ b/internal/quality/golden/csharp-quartz-net-mini/src/Startup.cs
@@ -1,0 +1,28 @@
+using Quartz;
+
+namespace App
+{
+    public class Startup
+    {
+        public async Task ConfigureScheduler(IScheduler scheduler)
+        {
+            // Producer: build job detail
+            var reportJob = JobBuilder.Create<ReportJob>()
+                .WithIdentity("report-job", "reports")
+                .Build();
+
+            var emailJob = JobBuilder.Create<EmailJob>()
+                .WithIdentity("email-job")
+                .Build();
+
+            // Producer: build trigger
+            var trigger = TriggerBuilder.Create()
+                .WithIdentity("report-trigger")
+                .StartNow()
+                .Build();
+
+            // Producer: schedule job
+            await scheduler.ScheduleJob(reportJob, trigger);
+        }
+    }
+}

--- a/internal/quality/golden/csharp-quartz-net-mini/src/jobs/ReportJob.cs
+++ b/internal/quality/golden/csharp-quartz-net-mini/src/jobs/ReportJob.cs
@@ -1,0 +1,21 @@
+using Quartz;
+
+namespace Workers.Jobs
+{
+    [DisallowConcurrentExecution]
+    public class ReportJob : IJob
+    {
+        public async Task Execute(IJobExecutionContext context)
+        {
+            // Consumer: generate a report
+        }
+    }
+
+    public class EmailJob : IJob
+    {
+        public async Task Execute(IJobExecutionContext context)
+        {
+            // Consumer: send an email
+        }
+    }
+}

--- a/internal/quality/golden/java-quartz-mini/expected.json
+++ b/internal/quality/golden/java-quartz-mini/expected.json
@@ -1,0 +1,14 @@
+{
+  "fixture_name": "java-quartz-mini",
+  "language": "java",
+  "description": "Minimal Quartz Java project with two Job consumers (@DisallowConcurrentExecution on one), JobBuilder.newJob producers, TriggerBuilder.newTrigger, and scheduler.scheduleJob call sites. Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for Quartz Java.",
+  "expected_entities": [
+    { "name": "SendEmailJob", "kind": "SCOPE.Service", "source_file": "jobs/SendEmailJob.java", "must_exist": true, "note": "Quartz Job consumer (implements Job)." },
+    { "name": "GenerateReportJob", "kind": "SCOPE.Service", "source_file": "jobs/SendEmailJob.java", "must_exist": true, "note": "Quartz Job consumer with @DisallowConcurrentExecution." },
+    { "name": "SendEmailJob.execute", "kind": "SCOPE.Operation", "source_file": "jobs/SendEmailJob.java", "must_exist": true, "note": "Consumer execute method." },
+    { "name": "GenerateReportJob.execute", "kind": "SCOPE.Operation", "source_file": "jobs/SendEmailJob.java", "must_exist": true, "note": "Consumer execute method." },
+    { "name": "JobBuilder.newJob<SendEmailJob>", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: JobBuilder.newJob()." },
+    { "name": "newJob<GenerateReportJob>", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: static import newJob()." },
+    { "name": "scheduler.scheduleJob", "kind": "SCOPE.Operation", "source_file": "AppScheduler.java", "must_exist": true, "note": "Producer: scheduler.scheduleJob()." }
+  ]
+}

--- a/internal/quality/golden/java-quartz-mini/src/AppScheduler.java
+++ b/internal/quality/golden/java-quartz-mini/src/AppScheduler.java
@@ -1,0 +1,34 @@
+import org.quartz.*;
+import org.quartz.impl.StdSchedulerFactory;
+import static org.quartz.JobBuilder.newJob;
+import static org.quartz.TriggerBuilder.newTrigger;
+
+/**
+ * Producer: builds and schedules Quartz jobs.
+ */
+public class AppScheduler {
+    public void start() throws Exception {
+        Scheduler scheduler = StdSchedulerFactory.getDefaultScheduler();
+
+        // Producer: build email job detail
+        JobDetail emailJob = JobBuilder.newJob(SendEmailJob.class)
+                .withIdentity("email-job", "email-group")
+                .build();
+
+        // Producer: build trigger
+        Trigger emailTrigger = TriggerBuilder.newTrigger()
+                .withIdentity("email-trigger", "email-group")
+                .startNow()
+                .build();
+
+        // Producer: build report job using static import
+        JobDetail reportJob = newJob(GenerateReportJob.class)
+                .withIdentity("report-job", "report-group")
+                .build();
+
+        // Producer: schedule both jobs
+        scheduler.scheduleJob(emailJob, emailTrigger);
+        scheduler.scheduleJob(reportJob, emailTrigger);
+        scheduler.start();
+    }
+}

--- a/internal/quality/golden/java-quartz-mini/src/jobs/SendEmailJob.java
+++ b/internal/quality/golden/java-quartz-mini/src/jobs/SendEmailJob.java
@@ -1,0 +1,26 @@
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.DisallowConcurrentExecution;
+
+/**
+ * Consumer: sends emails as a Quartz job.
+ */
+public class SendEmailJob implements Job {
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // consumer logic
+    }
+}
+
+/**
+ * Consumer: generates a PDF report. Marked @DisallowConcurrentExecution
+ * to prevent concurrent runs.
+ */
+@DisallowConcurrentExecution
+public class GenerateReportJob implements Job {
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        // consumer logic
+    }
+}

--- a/internal/quality/golden/python-dramatiq-mini/expected.json
+++ b/internal/quality/golden/python-dramatiq-mini/expected.json
@@ -1,0 +1,11 @@
+{
+  "fixture_name": "python-dramatiq-mini",
+  "language": "python",
+  "description": "Minimal dramatiq project with two @dramatiq.actor consumers and producer call sites using .send() and .send_with_options(). Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for dramatiq.",
+  "expected_entities": [
+    { "name": "charge_card", "kind": "SCOPE.Service", "source_file": "workers/billing.py", "must_exist": true, "note": "Dramatiq actor consumer." },
+    { "name": "send_receipt", "kind": "SCOPE.Service", "source_file": "workers/billing.py", "must_exist": true, "note": "Bare @dramatiq.actor consumer." },
+    { "name": "charge_card.send", "kind": "SCOPE.Operation", "source_file": "api/checkout.py", "must_exist": true, "note": "Producer: actor.send() call." },
+    { "name": "send_receipt.send_with_options", "kind": "SCOPE.Operation", "source_file": "api/checkout.py", "must_exist": true, "note": "Producer: actor.send_with_options() call." }
+  ]
+}

--- a/internal/quality/golden/python-dramatiq-mini/src/api/checkout.py
+++ b/internal/quality/golden/python-dramatiq-mini/src/api/checkout.py
@@ -1,0 +1,7 @@
+from workers.billing import charge_card, send_receipt
+
+
+def process_checkout(user_id: int, amount: float) -> None:
+    """Producer: enqueue billing tasks from the checkout flow."""
+    charge_card.send(user_id, amount)
+    send_receipt.send_with_options(args=[user_id, amount], delay=2000)

--- a/internal/quality/golden/python-dramatiq-mini/src/workers/billing.py
+++ b/internal/quality/golden/python-dramatiq-mini/src/workers/billing.py
@@ -1,0 +1,12 @@
+import dramatiq
+
+@dramatiq.actor(queue_name="billing", max_retries=3)
+def charge_card(user_id: int, amount: float) -> None:
+    """Consumer: charge a card in the background."""
+    pass
+
+
+@dramatiq.actor
+def send_receipt(user_id: int, amount: float) -> None:
+    """Consumer: send a payment receipt."""
+    pass

--- a/internal/quality/golden/python-rq-mini/expected.json
+++ b/internal/quality/golden/python-rq-mini/expected.json
@@ -1,0 +1,10 @@
+{
+  "fixture_name": "python-rq-mini",
+  "language": "python",
+  "description": "Minimal RQ (Redis Queue) project with enqueue producers and a Worker consumer. Used by the extraction-quality benchmark to verify PRODUCES/CONSUMES edge emission for RQ.",
+  "expected_entities": [
+    { "name": "send_email.enqueue", "kind": "SCOPE.Operation", "source_file": "api/notifications.py", "must_exist": true, "note": "Producer: queue.enqueue(callable)." },
+    { "name": "workers.email.generate_report.enqueue_call", "kind": "SCOPE.Operation", "source_file": "api/notifications.py", "must_exist": true, "note": "Producer: queue.enqueue_call(func=string)." },
+    { "name": "Worker([notification_queue, report_queue])", "kind": "SCOPE.Service", "source_file": "worker_runner.py", "must_exist": true, "note": "Consumer: RQ Worker declaration." }
+  ]
+}

--- a/internal/quality/golden/python-rq-mini/src/api/notifications.py
+++ b/internal/quality/golden/python-rq-mini/src/api/notifications.py
@@ -1,0 +1,17 @@
+from rq import Queue
+from redis import Redis
+from workers.email import send_email, generate_report
+
+redis_conn = Redis()
+notification_queue = Queue("notifications", connection=redis_conn)
+report_queue = Queue("reports", connection=redis_conn)
+
+
+def notify_user(user_id: int, message: str) -> None:
+    """Producer: enqueue an email notification."""
+    notification_queue.enqueue(send_email, "user@example.com", "Notification", message)
+
+
+def request_report(report_id: int) -> None:
+    """Producer: enqueue a report generation job."""
+    report_queue.enqueue_call(func="workers.email.generate_report", args=[report_id])

--- a/internal/quality/golden/python-rq-mini/src/worker_runner.py
+++ b/internal/quality/golden/python-rq-mini/src/worker_runner.py
@@ -1,0 +1,10 @@
+from rq import Queue, Worker
+from redis import Redis
+
+redis_conn = Redis()
+notification_queue = Queue("notifications", connection=redis_conn)
+report_queue = Queue("reports", connection=redis_conn)
+
+# Consumer: runs jobs from notification and report queues
+worker = Worker([notification_queue, report_queue], connection=redis_conn)
+worker.work()

--- a/internal/quality/golden/python-rq-mini/src/workers/email.py
+++ b/internal/quality/golden/python-rq-mini/src/workers/email.py
@@ -1,0 +1,8 @@
+def send_email(to: str, subject: str, body: str) -> None:
+    """RQ consumer: send an email. Called via queue.enqueue()."""
+    pass
+
+
+def generate_report(report_id: int) -> None:
+    """RQ consumer: generate a report asynchronously."""
+    pass


### PR DESCRIPTION
## What

Extends async-task coverage (#515) with five new framework extractors for the four systems listed in #923.

## New files

| File | Framework | Language |
|---|---|---|
| `internal/custom/python/dramatiq.go` | dramatiq | Python |
| `internal/custom/python/rq.go` | RQ (Redis Queue) | Python |
| `internal/custom/csharp/hangfire.go` | Hangfire | C# |
| `internal/custom/csharp/quartz_net.go` | Quartz.NET | C# |
| `internal/custom/java/quartz.go` | Quartz Java | Java |

## Edge model

Each extractor emits `task_id` (`task:<framework>:<name>`) and `edge_kind` (`PRODUCES` / `CONSUMES`) properties so the cross-repo linker can match producers to consumers by task-name identity.

- **dramatiq** — `@dramatiq.actor` decorator → CONSUMES; `actor.send()` / `actor.send_with_options()` → PRODUCES. False-positive guard: bare `@actor` without `dramatiq.` namespace is ignored.
- **RQ** — `queue.enqueue(callable)` / `queue.enqueue_call(func=...)` → PRODUCES; `Worker([queues])` → CONSUMES. Guard: Worker entity only emitted when `from rq` or `import rq` is present in the file.
- **Hangfire** — `BackgroundJob.Enqueue` (static + typed lambda), `RecurringJob.AddOrUpdate`, `BackgroundJob.Schedule` → PRODUCES; `IBackgroundJob` / `IJob` implementors + `[AutomaticRetry]` → CONSUMES.
- **Quartz.NET** — `IJob` implementors + `[DisallowConcurrentExecution]` → CONSUMES; `JobBuilder.Create<T>()`, `TriggerBuilder.Create()`, `scheduler.ScheduleJob()` → PRODUCES.
- **Quartz Java** — `implements Job` + `execute(JobExecutionContext)` + `@DisallowConcurrentExecution` → CONSUMES; `JobBuilder.newJob(T.class)`, `newJob()` (static import), `TriggerBuilder.newTrigger()`, `scheduler.scheduleJob()` → PRODUCES. Inline PRODUCES→CONSUMES cross-edges emitted between job builders and their matching job class entities.

## Tests

- 11 new Python tests (6 dramatiq, 5 RQ) — all pass
- 9 new C# tests (5 Hangfire, 4 Quartz.NET) — all pass
- 7 new Java tests (Quartz Java) — all pass
- **27 new test functions total; 0 regressions** across all 14 `internal/custom/...` packages

## Golden fixtures

Five new fixtures under `internal/quality/golden/`:
- `python-dramatiq-mini` — actor consumers + send/send_with_options producers
- `python-rq-mini` — enqueue/enqueue_call producers + Worker consumer
- `csharp-hangfire-mini` — IBackgroundJob consumers + Enqueue/RecurringJob producers
- `csharp-quartz-net-mini` — IJob consumers + JobBuilder/TriggerBuilder/ScheduleJob producers
- `java-quartz-mini` — Job implementors + @DisallowConcurrentExecution + full scheduler setup

## Test plan

- [ ] `go test ./internal/custom/...` — all 14 packages green
- [ ] Review false-positive guards: bare `@actor` (Python), generic `Queue`/`Worker` without rq import (Python)
- [ ] Spot-check golden fixture src files match expected.json entity names
- [ ] Verify `task_id` property format is consistent across all five extractors (`task:<framework>:<name>`)

Closes #923