### PR TITLE
[#44] Fix Go per-import gate: ext: prefix stripping + package-fold sentinels

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -63,6 +63,22 @@ func upsertImportSet(set map[string]bool, rel *graph.Relationship) map[string]bo
 	}
 	if rel.ToID != "" {
 		set[rel.ToID] = true
+		// Refs #44 — Go per-import gate fix. The Go extractor rewrites
+		// IMPORTS edge ToIDs to the `ext:<path>` form (e.g.
+		// "ext:time", "ext:github.com/go-chi/chi") BEFORE Synthesize()
+		// builds the fileImports map, so upsertImportSet always inserts
+		// the ext:-prefixed value. Per-import gates like
+		// `fromImports["time"]` and `hasGoChiImport` check for the
+		// bare path (e.g. "time", "github.com/go-chi/chi") — they never
+		// matched because the bare form was never inserted. Fix: when
+		// the ToID carries an "ext:" prefix, also add the bare path so
+		// all existing gate predicates fire correctly.
+		if strings.HasPrefix(rel.ToID, ExtIDPrefix) {
+			bare := rel.ToID[len(ExtIDPrefix):]
+			if bare != "" {
+				set[bare] = true
+			}
+		}
 	}
 	if rel.Properties != nil {
 		mod := rel.Properties["source_module"]
@@ -1070,6 +1086,26 @@ func classifyExternal(stub, relKind, lang, fromFile string, fromImports map[stri
 			return "org.apache.poi", "package", true
 		case "pdfbox_type":
 			return "org.apache.pdfbox", "package", true
+		// Refs #44 — Go per-import gate sentinels. Each sentinel folds
+		// bare-name stubs to their canonical stdlib/framework package so
+		// the resolver routes to ExternalKnown instead of ExternalUnknown.
+		// The per-package fold is required because the bare name ("Now",
+		// "Get", "Marshal", ...) is too collision-prone to use as the
+		// canonical placeholder across all Go codebases.
+		case "go_time_function":
+			return "time", "function", true
+		case "go_net_function":
+			return "net", "function", true
+		case "go_sync_atomic_function":
+			return "sync/atomic", "function", true
+		case "go_errors_function":
+			return "errors", "function", true
+		case "go_encoding_json_function":
+			return "encoding/json", "function", true
+		case "go_chi_function":
+			// Fold to the canonical chi v5 path. The allowlist already carries
+			// "github.com/go-chi/chi" so the resolver routes to ExternalKnown.
+			return "github.com/go-chi/chi", "function", true
 		}
 		return name, subtype, true
 	}
@@ -1940,9 +1976,11 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 		// for non-chi callers, matching the safer-bias rule from #94 (a
 		// missed external is strictly better than a synthesised placeholder
 		// shadowing a real user method).
+		// Returns "go_chi_function" sentinel so classifyExternal folds to
+		// ext:github.com/go-chi/chi rather than ext:<bare-name>. Refs #44.
 		if hasGoChiImport(fromImports) {
 			if _, ok := goChiRouterNames[name]; ok {
-				return "function", true
+				return "go_chi_function", true
 			}
 		}
 		// Issue #44 / proto-fix — google.golang.org/grpc + protobuf
@@ -2027,27 +2065,31 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 		// Issue #44 / proto-fix — time package PascalCase helpers gated
 		// on `time` import. `Now`, `After` collide with user methods on
 		// any timestamp-shaped type, so the import gate is required.
+		// Returns the "go_time_function" sentinel so classifyExternal folds
+		// the edge to ext:time rather than ext:<bare-name>.
 		if fromImports != nil && fromImports["time"] {
 			switch name {
 			case "Now", "After", "Date", "Unix", "UnixMilli", "UnixMicro", "UnixNano":
-				return "function", true
+				return "go_time_function", true
 			}
 		}
 		// Issue #44 / proto-fix — net package PascalCase helpers gated
 		// on `net` (or `net/http`) import. `Listen`, `Accept`, `Addr`
 		// are universal net.Listener / net.Conn idioms; collide with
 		// generic verb methods so the import gate is required.
+		// Returns "go_net_function" so classifyExternal folds to ext:net.
 		if fromImports != nil && (fromImports["net"] || fromImports["net/http"]) {
 			switch name {
 			case "Listen", "ListenPacket", "Accept", "Addr", "LocalAddr",
 				"RemoteAddr", "SetDeadline", "SetReadDeadline", "SetWriteDeadline":
-				return "function", true
+				return "go_net_function", true
 			}
 		}
 		// Issue #44 / proto-fix — sync/atomic Load*/Store*/Add*/Swap*
 		// helpers gated on `sync/atomic` import. The full type-suffix
 		// shape (`LoadUint64`, `StoreInt32`, `AddInt64`, ...) is
 		// distinctive enough that the import gate is belt-and-braces.
+		// Returns "go_sync_atomic_function" for classifyExternal folding.
 		if fromImports != nil && fromImports["sync/atomic"] {
 			switch name {
 			case "LoadUint32", "LoadUint64", "LoadInt32", "LoadInt64",
@@ -2058,7 +2100,7 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 				"CompareAndSwapUint64", "CompareAndSwapInt32",
 				"CompareAndSwapInt64", "CompareAndSwapPointer",
 				"Load", "Store", "Add", "Swap":
-				return "function", true
+				return "go_sync_atomic_function", true
 			}
 		}
 		// Issue #44 / proto-fix — reflect package PascalCase helpers
@@ -2114,6 +2156,33 @@ func stdlibFunction(name, lang, fromFile string, fromImports map[string]bool) (s
 				"Replace", "NewReader", "NewReplacer", "Map", "Trim",
 				"Title", "Fields":
 				return "function", true
+			}
+		}
+		// Refs #44 — errors package helpers gated on `errors` import.
+		// `errors.New(msg)` is receiver-stripped to bare "New" by the
+		// Go extractor. "New" is too generic for goBareNames (it appears
+		// as a constructor pattern in virtually every Go codebase), so
+		// the import gate is required. "As", "Is", "Unwrap" are
+		// likewise generic but their errors-package semantics are
+		// unambiguous when the file imports "errors".
+		// Returns "go_errors_function" so classifyExternal folds to ext:errors.
+		if fromImports != nil && fromImports["errors"] {
+			switch name {
+			case "New", "As", "Is", "Unwrap":
+				return "go_errors_function", true
+			}
+		}
+		// Refs #44 — encoding/json constructor gated on `encoding` (or
+		// `encoding/json`) import. `json.NewEncoder(w)` /
+		// `json.NewDecoder(r)` are the dominant shapes; bare "NewEncoder"
+		// / "NewDecoder" are short enough to collide with project-local
+		// constructors so the import gate is required.
+		// Returns "go_encoding_json_function" for classifyExternal folding.
+		if fromImports != nil && (fromImports["encoding"] || fromImports["encoding/json"]) {
+			switch name {
+			case "NewEncoder", "NewDecoder", "Marshal", "Unmarshal",
+				"MarshalIndent", "Compact", "HTMLEscape":
+				return "go_encoding_json_function", true
 			}
 		}
 	}
@@ -3035,6 +3104,15 @@ var goChiRouterNames = map[string]struct{}{
 	"Handle":           {},
 	"NotFound":         {},
 	"MethodNotAllowed": {},
+
+	// chi constructor / URL-param helpers. Refs #44 — bare-name calls
+	// `chi.NewRouter()` → "NewRouter" and `chi.URLParam(r,"id")` →
+	// "URLParam" are receiver-stripped by the Go extractor. Both names
+	// are distinctive enough within non-chi Go code but the import gate
+	// provides belt-and-braces safety.
+	"NewRouter": {},
+	"URLParam":  {},
+	"URLParamFromCtx": {},
 }
 
 // goChiImportPaths is the set of canonical import paths that signal a

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -3333,11 +3333,16 @@ func TestGoTestingTBareNames_NoDuplicatesWithGoBareNames(t *testing.T) {
 // TestGoChiRouterNames_ClassifiedWithChiImport locks in issue #131:
 // go-chi router-method bare names (Get/Post/Put/Delete/Mount/Group/...)
 // that arrive at the resolver after the Go extractor strips the
-// receiver (`r.Get("/x", h)` → `Get`) must classify as stdlib bare-names
+// receiver (`r.Get("/x", h)` → `Get`) must classify under the chi gate
 // — but only when (a) the source entity's language is "go" AND (b) the
 // source file's IMPORTS edges include any canonical go-chi import path.
 // The dual gate keeps these collision-prone names from shadowing user
 // methods like `Repository.Get` in non-chi code.
+//
+// Refs #44: after the package-fold sentinel fix, stdlibFunction returns
+// "go_chi_function" (not "function") and classifyExternal folds to the
+// canonical chi placeholder ext:github.com/go-chi/chi — a better outcome
+// than per-verb ext:<name> placeholders.
 func TestGoChiRouterNames_ClassifiedWithChiImport(t *testing.T) {
 	names := []string{
 		"Get", "Post", "Put", "Delete", "Patch",
@@ -3364,13 +3369,19 @@ func TestGoChiRouterNames_ClassifiedWithChiImport(t *testing.T) {
 					t.Fatalf("stdlibFunction(%q, \"go\", chi=%q) = (_, false); want classified",
 						name, chiPath)
 				}
-				if subtype != "function" {
-					t.Fatalf("stdlibFunction(%q, \"go\", chi=%q) subtype=%q, want %q",
-						name, chiPath, subtype, "function")
+				// Refs #44 — names that are also in goBareNames fire that
+				// catalog first and return "function"; names that are ONLY in
+				// goChiRouterNames return the "go_chi_function" sentinel so
+				// classifyExternal folds to the package placeholder.
+				// Either outcome means the name is classified — that is the
+				// structural invariant we assert here.
+				if subtype != "function" && subtype != "go_chi_function" {
+					t.Fatalf("stdlibFunction(%q, \"go\", chi=%q) subtype=%q, want function or go_chi_function",
+						name, chiPath, subtype)
 				}
-				// End-to-end: a Go entity in a file that emits an IMPORTS
-				// edge to the chi package must rewrite a CALLS edge with a
-				// chi-router method name to ext:<name>.
+				// End-to-end: a Go entity in a file that imports chi must
+				// rewrite chi-router bare stubs to ext:github.com/go-chi/chi
+				// (the package canonical), NOT to ext:<bare-name>. Refs #44.
 				doc := &graph.Document{
 					Entities: []graph.Entity{{
 						ID:         "go-chi-src",
@@ -3385,7 +3396,6 @@ func TestGoChiRouterNames_ClassifiedWithChiImport(t *testing.T) {
 					},
 				}
 				Synthesize(doc)
-				want := "ext:" + name
 				// Find the CALLS edge and check it was rewritten.
 				var got string
 				for _, r := range doc.Relationships {
@@ -3394,9 +3404,31 @@ func TestGoChiRouterNames_ClassifiedWithChiImport(t *testing.T) {
 						break
 					}
 				}
-				if got != want {
-					t.Fatalf("CALLS edge ToID=%q, want %q "+
-						"(name=%q, chi import=%q)", got, want, name, chiPath)
+				// The stub must have been rewritten to some ext: form.
+				if got == name {
+					t.Fatalf("CALLS edge ToID=%q unchanged; chi gate did not fire "+
+						"(name=%q, chi import=%q)", got, name, chiPath)
+				}
+				if !strings.HasPrefix(got, "ext:") {
+					t.Fatalf("CALLS edge ToID=%q, want ext: prefix "+
+						"(name=%q, chi import=%q)", got, name, chiPath)
+				}
+				// Names that are only in goChiRouterNames (not in goBareNames)
+				// fold to the chi package canonical. Names that are in BOTH
+				// (HandleFunc, NotFound, MethodNotAllowed) fire goBareNames
+				// first and produce ext:<bare-name> — that is still correct
+				// because they are goBareNames members. We only assert the
+				// chi-exclusive names fold to the package.
+				chiExclusiveNames := map[string]bool{
+					"Get": true, "Post": true, "Put": true, "Delete": true,
+					"Patch": true, "Head": true, "Options": true, "Connect": true,
+					"Trace": true, "Mount": true, "Group": true, "Route": true,
+					"Use": true, "With": true, "NewRouter": true,
+					"URLParam": true, "URLParamFromCtx": true,
+				}
+				if chiExclusiveNames[name] && !strings.HasPrefix(got, "ext:github.com/go-chi") {
+					t.Fatalf("CALLS edge ToID=%q, want prefix ext:github.com/go-chi for chi-exclusive name "+
+						"(name=%q, chi import=%q)", got, name, chiPath)
 				}
 			})
 		}
@@ -4652,6 +4684,209 @@ func TestHasPdfBoxImport_Variants(t *testing.T) {
 			t.Parallel()
 			if got := hasPdfBoxImport(c.imports); got != c.want {
 				t.Errorf("hasPdfBoxImport(%v) = %v, want %v", c.imports, got, c.want)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Refs #44 — Go per-import gate fix: upsertImportSet must strip the ext:
+// prefix so bare package paths (e.g. "time", "errors", "github.com/go-chi/chi")
+// are inserted alongside the ext:-prefixed form that the Go extractor writes.
+// ---------------------------------------------------------------------------
+
+// TestUpsertImportSet_GoExtractorExtPrefix verifies that when the Go extractor
+// rewrites an IMPORTS edge ToID to the "ext:<path>" form (no Properties set),
+// upsertImportSet adds BOTH the ext:-prefixed value AND the bare path to the
+// import set, enabling all existing per-import gate predicates.
+func TestUpsertImportSet_GoExtractorExtPrefix(t *testing.T) {
+	cases := []struct {
+		name     string
+		toID     string
+		wantBare string
+	}{
+		{"time", "ext:time", "time"},
+		{"errors", "ext:errors", "errors"},
+		{"encoding/json", "ext:encoding/json", "encoding/json"},
+		{"sync/atomic", "ext:sync/atomic", "sync/atomic"},
+		{"chi v5", "ext:github.com/go-chi/chi", "github.com/go-chi/chi"},
+		{"chi v5 full", "ext:github.com/go-chi/chi/v5", "github.com/go-chi/chi/v5"},
+		{"net/http", "ext:net/http", "net/http"},
+		{"bare ext (no path)", "ext:", ""}, // degenerate: empty bare path should not panic
+	}
+	for _, c := range cases {
+		c := c
+		t.Run(c.name, func(t *testing.T) {
+			t.Parallel()
+			rel := &graph.Relationship{ToID: c.toID, Kind: "IMPORTS"}
+			set := upsertImportSet(nil, rel)
+			// ext:-prefixed form must always be present.
+			if !set[c.toID] {
+				t.Errorf("set[%q] = false; want true (ext:-prefixed form must be inserted)", c.toID)
+			}
+			// bare form must also be present (unless the path is empty).
+			if c.wantBare != "" && !set[c.wantBare] {
+				t.Errorf("set[%q] = false; want true (bare form must be inserted for gate predicates)", c.wantBare)
+			}
+		})
+	}
+}
+
+// TestSynthesize_GoTimeImport_ExtPrefixedImports verifies end-to-end that
+// a Go source file whose IMPORTS edges use the ext:-prefixed ToID form (as
+// the Go extractor writes) correctly activates the `time` import gate,
+// causing bare stubs like "Now" to be classified as ext:time. Refs #44.
+func TestSynthesize_GoTimeImport_ExtPrefixedImports(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:         "file-ent",
+				Name:       "worker.go",
+				Kind:       "SCOPE.Component",
+				Language:   "go",
+				SourceFile: "worker.go",
+			},
+			{
+				ID:         "fn-ent",
+				Name:       "RunJob",
+				Kind:       "function",
+				Language:   "go",
+				SourceFile: "worker.go",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				// Go extractor writes ext: form — no Properties set.
+				ID:     "imp-time",
+				FromID: "file-ent",
+				ToID:   "ext:time",
+				Kind:   "IMPORTS",
+			},
+			{
+				// Bare stub emitted by Go extractor for `time.Now()` call.
+				ID:     "call-now",
+				FromID: "fn-ent",
+				ToID:   "Now",
+				Kind:   "CALLS",
+			},
+		},
+	}
+	Synthesize(doc)
+	got := doc.Relationships[1].ToID
+	if got != "ext:time" {
+		t.Fatalf("ToID=%q, want ext:time — time import gate did not fire; upsertImportSet ext: stripping is broken", got)
+	}
+}
+
+// TestSynthesize_GoChiImport_ExtPrefixedImports verifies end-to-end that a
+// Go source file whose IMPORTS edge for chi uses the ext:-prefixed ToID form
+// correctly activates hasGoChiImport, so bare router-method stubs like "Get",
+// "NewRouter", and "URLParam" synthesise to ext:github.com/go-chi/chi. Refs #44.
+func TestSynthesize_GoChiImport_ExtPrefixedImports(t *testing.T) {
+	chiNames := []string{"Get", "Post", "Route", "Use", "NewRouter", "URLParam", "URLParamFromCtx"}
+	for _, name := range chiNames {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					{
+						ID:         "file-ent",
+						Name:       "main.go",
+						Kind:       "SCOPE.Component",
+						Language:   "go",
+						SourceFile: "main.go",
+					},
+					{
+						ID:         "fn-ent",
+						Name:       "SetupRouter",
+						Kind:       "function",
+						Language:   "go",
+						SourceFile: "main.go",
+					},
+				},
+				Relationships: []graph.Relationship{
+					{
+						// Go extractor uses ext: prefix — no Properties.
+						ID:     "imp-chi",
+						FromID: "file-ent",
+						ToID:   "ext:github.com/go-chi/chi",
+						Kind:   "IMPORTS",
+					},
+					{
+						ID:     "call-chi",
+						FromID: "fn-ent",
+						ToID:   name,
+						Kind:   "CALLS",
+					},
+				},
+			}
+			Synthesize(doc)
+			got := doc.Relationships[1].ToID
+			if got == name {
+				t.Fatalf("name=%q: stub not rewritten; hasGoChiImport gate did not fire — upsertImportSet ext: stripping is broken", name)
+			}
+			if !strings.HasPrefix(got, "ext:github.com/go-chi") {
+				t.Fatalf("name=%q: ToID=%q, want prefix ext:github.com/go-chi", name, got)
+			}
+		})
+	}
+}
+
+// TestSynthesize_GoErrorsImport_ExtPrefixedImports verifies that the errors
+// import gate fires when the IMPORTS edge is in ext:-prefixed form. Refs #44.
+func TestSynthesize_GoErrorsImport_ExtPrefixedImports(t *testing.T) {
+	for _, stub := range []string{"New", "As", "Is", "Unwrap"} {
+		stub := stub
+		t.Run(stub, func(t *testing.T) {
+			t.Parallel()
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					{ID: "file-ent", Name: "errs.go", Kind: "SCOPE.Component", Language: "go", SourceFile: "errs.go"},
+					{ID: "fn-ent", Name: "wrap", Kind: "function", Language: "go", SourceFile: "errs.go"},
+				},
+				Relationships: []graph.Relationship{
+					{ID: "imp-errors", FromID: "file-ent", ToID: "ext:errors", Kind: "IMPORTS"},
+					{ID: "call-stub", FromID: "fn-ent", ToID: stub, Kind: "CALLS"},
+				},
+			}
+			Synthesize(doc)
+			got := doc.Relationships[1].ToID
+			if got == stub {
+				t.Fatalf("stub=%q: not rewritten; errors import gate did not fire", stub)
+			}
+			if got != "ext:errors" {
+				t.Fatalf("stub=%q: ToID=%q, want ext:errors", stub, got)
+			}
+		})
+	}
+}
+
+// TestSynthesize_GoEncodingJsonImport_ExtPrefixedImports verifies that the
+// encoding/json import gate fires when the IMPORTS edge uses the ext: form.
+// Refs #44.
+func TestSynthesize_GoEncodingJsonImport_ExtPrefixedImports(t *testing.T) {
+	for _, stub := range []string{"Marshal", "Unmarshal", "NewEncoder", "NewDecoder"} {
+		stub := stub
+		t.Run(stub, func(t *testing.T) {
+			t.Parallel()
+			doc := &graph.Document{
+				Entities: []graph.Entity{
+					{ID: "file-ent", Name: "codec.go", Kind: "SCOPE.Component", Language: "go", SourceFile: "codec.go"},
+					{ID: "fn-ent", Name: "encode", Kind: "function", Language: "go", SourceFile: "codec.go"},
+				},
+				Relationships: []graph.Relationship{
+					{ID: "imp-json", FromID: "file-ent", ToID: "ext:encoding/json", Kind: "IMPORTS"},
+					{ID: "call-stub", FromID: "fn-ent", ToID: stub, Kind: "CALLS"},
+				},
+			}
+			Synthesize(doc)
+			got := doc.Relationships[1].ToID
+			if got == stub {
+				t.Fatalf("stub=%q: not rewritten; encoding/json import gate did not fire", stub)
+			}
+			if !strings.HasPrefix(got, "ext:encoding") {
+				t.Fatalf("stub=%q: ToID=%q, want ext:encoding prefix", stub, got)
 			}
 		})
 	}


### PR DESCRIPTION
## What changed

Three coordinated fixes in `internal/external/synth.go` to repair the Go per-import gate pipeline — a systemic bug introduced when the Go extractor (#577) started rewriting IMPORTS edge ToIDs to `ext:<path>` form.

### Fix 1 — `upsertImportSet`: strip `ext:` prefix

When the Go extractor runs `resolveImportToIDs`, every IMPORTS edge ToID is rewritten to `"ext:time"`, `"ext:github.com/go-chi/chi"` etc. **before** `Synthesize()` builds `fileImports`. The map stored only the prefixed form. All existing per-import gate predicates (`fromImports["time"]`, `hasGoChiImport`) check the bare path — they **never matched**.

Fix: when `ToID` starts with `"ext:"`, also insert the bare path.

### Fix 2 — sentinel return values in `stdlibFunction`

The per-import gates (`time`, `errors`, `encoding/json`, `net`, `sync/atomic`, chi) previously returned generic `"function"`. Without a sentinel, `classifyExternal` used the bare stub name as canonical, producing `ext:Now` / `ext:Get` / `ext:Marshal` instead of the package placeholder.

Each gate now returns a unique sentinel (`go_time_function`, `go_chi_function`, `go_errors_function`, `go_encoding_json_function`, `go_net_function`, `go_sync_atomic_function`).

### Fix 3 — sentinel switch in `classifyExternal`

Mirrors the existing Python gate pattern: each sentinel maps to its canonical package name (`"time"`, `"github.com/go-chi/chi"`, `"errors"`, `"encoding/json"`, `"net"`, `"sync/atomic"`). All targets are on the `knownExternalPackages` allowlist so the resolver routes to `ExternalKnown`.

Also adds `NewRouter`, `URLParam`, `URLParamFromCtx` to `goChiRouterNames`.

## Before / after (golden fixtures)

| fixture | before bug-extractor | after bug-extractor | before bug_rate | after bug_rate |
|---|---|---|---|---|
| go-chi-mini | 6 | 1 | 2.83% | 0.47% |
| python-django-mini | 8 | 8 | 3.81% | 3.81% |
| typescript-react-mini | 14 | 14 | 6.94% | 6.94% |
| java-spring-mini | 0 | 0 | 0% | 0% |

go-chi-mini: **83% drop** in bug-extractor count. Other fixtures unchanged (no regressions).

## Tests

Five new test functions in `synth_test.go`:

- `TestUpsertImportSet_GoExtractorExtPrefix` — unit-tests that bare paths are inserted alongside `ext:` form for time, errors, encoding/json, sync/atomic, chi, net/http
- `TestSynthesize_GoTimeImport_ExtPrefixedImports` — end-to-end: `ext:time` IMPORTS edge → `Now` stub folds to `ext:time`
- `TestSynthesize_GoChiImport_ExtPrefixedImports` — `ext:github.com/go-chi/chi` → Get/Post/Route/Use/NewRouter/URLParam/URLParamFromCtx fold to `ext:github.com/go-chi/chi`
- `TestSynthesize_GoErrorsImport_ExtPrefixedImports` — errors gate: New/As/Is/Unwrap fold to `ext:errors`
- `TestSynthesize_GoEncodingJsonImport_ExtPrefixedImports` — encoding/json gate: Marshal/Unmarshal/NewEncoder/NewDecoder fold to `ext:encoding/json`

All 27 `internal/...` package test suites pass with no regressions.

## Scope

This PR fixes **one root cause** (the systemic ext: prefix mismatch that silently disabled every Go per-import gate since #577). It does not address Python, TypeScript, or Java fixture residuals — those are separate patterns tracked in #44.

Refs #44