### PR TITLE
[#938] archigraph dashboard opens browser; start/stop cover all services

### DIFF
--- a/cmd/archigraph/dashboard.go
+++ b/cmd/archigraph/dashboard.go
@@ -5,30 +5,169 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"os/exec"
 	"os/signal"
+	"runtime"
+	"strconv"
 	"syscall"
+	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon/client"
 	"github.com/cajasmota/archigraph/internal/dashboard"
 )
 
 // runDashboard is wired into cli.Hooks and dispatches the `dashboard`
-// subcommand verbs. Currently only `serve` is implemented; future verbs
-// (open, status) plug in here.
+// subcommand verbs. With no verb it opens the running (or auto-started)
+// daemon's dashboard in the user's default browser. The `serve` verb
+// starts a standalone dev server (existing behaviour, preserved as-is).
 func runDashboard(argv []string) error {
-	if len(argv) == 0 || argv[0] == "-h" || argv[0] == "--help" {
-		fmt.Fprintln(os.Stderr, "usage: archigraph dashboard <serve> [flags]")
+	// No args → open-browser flow.
+	if len(argv) == 0 {
+		return runDashboardOpen()
+	}
+	if argv[0] == "-h" || argv[0] == "--help" {
+		fmt.Fprintln(os.Stderr, dashboardHelpText)
 		return nil
 	}
 	switch argv[0] {
 	case "serve":
 		return runDashboardServe(argv[1:])
+	case "open":
+		// Explicit `dashboard open` alias.
+		return runDashboardOpen()
 	default:
-		return fmt.Errorf("unknown dashboard verb: %s", argv[0])
+		return fmt.Errorf("unknown dashboard verb %q\n\n%s", argv[0], dashboardHelpText)
 	}
+}
+
+const dashboardHelpText = `usage: archigraph dashboard [serve] [flags]
+
+With no arguments, opens the dashboard in your default browser,
+auto-starting the daemon if it is not already running.
+
+Subcommands:
+  (none)         Open dashboard in browser (same as: open)
+  open           Open dashboard in browser
+  serve          Run a standalone dashboard HTTP server (dev/advanced)
+
+Flags for 'serve':
+  --bind string  Override bind address
+  --port int     Pin to a specific port (useful for Vite proxy)
+
+The daemon (started via 'archigraph start') owns MCP, indexer,
+watchers, and the dashboard on port 47274 by default.
+Set ARCHIGRAPH_DASHBOARD_PORT to override the port.
+
+Use 'archigraph dashboard serve --port N' for standalone dev workflows.`
+
+// runDashboardOpen ensures the daemon is running, resolves the dashboard
+// URL, prints it to stdout, and opens it in the user's default browser.
+func runDashboardOpen() error {
+	port, err := ensureDaemonAndGetPort()
+	if err != nil {
+		return err
+	}
+	url := fmt.Sprintf("http://127.0.0.1:%d/", port)
+	fmt.Printf("Dashboard: %s\n", url)
+	if openErr := openBrowser(url); openErr != nil {
+		// Non-fatal: headless server, missing desktop environment, etc.
+		// The URL was already printed so the user can paste it manually.
+		fmt.Fprintf(os.Stderr, "note: could not open browser (%v); visit the URL above\n", openErr)
+	}
+	return nil
+}
+
+// ensureDaemonAndGetPort returns the dashboard TCP port, starting the
+// daemon first if it is not already running. Port resolution order:
+//  1. Daemon Status RPC (single source of truth once daemon is up)
+//  2. ARCHIGRAPH_DASHBOARD_PORT env var
+//  3. Hard-coded default (defaultDashboardPort = 47274)
+func ensureDaemonAndGetPort() (int, error) {
+	c, dialErr := client.Dial()
+	if dialErr != nil {
+		// Daemon not running — fork the current binary with "start" so
+		// the exact same start logic runs (binary-mismatch check, readiness
+		// poll, etc.). This avoids duplicating the start implementation here.
+		fmt.Fprintln(os.Stderr, "daemon not running — starting…")
+		if err := execStart(); err != nil {
+			return 0, fmt.Errorf("auto-start daemon: %w", err)
+		}
+		// execStart blocks until the daemon is ready (5 s poll in the start
+		// subcommand). Re-dial to get a client for the Status call.
+		var retryErr error
+		for i := 0; i < 10; i++ {
+			c, retryErr = client.Dial()
+			if retryErr == nil {
+				break
+			}
+			time.Sleep(200 * time.Millisecond)
+		}
+		if retryErr != nil {
+			return 0, fmt.Errorf("daemon started but socket still unreachable: %w", retryErr)
+		}
+	}
+	defer c.Close()
+
+	st, err := c.Status()
+	if err == nil && st.DashboardPort > 0 {
+		return st.DashboardPort, nil
+	}
+	// Fallback: env var or compiled-in default.
+	return resolveDefaultDashboardPort(), nil
+}
+
+// execStart runs the current binary with the "start" subcommand and waits
+// for it to return. This piggy-backs on all the existing start logic
+// (binary-mismatch check, readiness poll, etc.) without duplicating it.
+func execStart() error {
+	bin, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("resolve binary: %w", err)
+	}
+	cmd := exec.Command(bin, "start")
+	cmd.Stdout = os.Stderr // route daemon's "daemon started" message to stderr
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// resolveDefaultDashboardPort returns the dashboard port from the env var
+// ARCHIGRAPH_DASHBOARD_PORT, falling back to defaultDashboardPort (47274).
+func resolveDefaultDashboardPort() int {
+	if v := os.Getenv("ARCHIGRAPH_DASHBOARD_PORT"); v != "" {
+		if p, err := strconv.Atoi(v); err == nil && p > 0 && p <= 65535 {
+			return p
+		}
+	}
+	return defaultDashboardPort
+}
+
+// openBrowser launches the platform's default browser for url.
+// Returns an error if the launch command cannot be started; callers
+// treat this as non-fatal (no desktop environment, CI, etc.).
+func openBrowser(url string) error {
+	var cmd *exec.Cmd
+	switch runtime.GOOS {
+	case "darwin":
+		cmd = exec.Command("open", url)
+	case "windows":
+		cmd = exec.Command("rundll32", "url.dll,FileProtocolHandler", url)
+	default:
+		// Linux / other Unix: prefer xdg-open, fall back to sensible-browser.
+		if _, err := exec.LookPath("xdg-open"); err == nil {
+			cmd = exec.Command("xdg-open", url)
+		} else {
+			cmd = exec.Command("sensible-browser", url)
+		}
+	}
+	// Start is non-blocking — we don't wait for the browser to exit.
+	return cmd.Start()
 }
 
 // runDashboardServe parses serve-only flags, picks a free port, prints it
 // to stdout, and blocks until SIGINT/SIGTERM.
+//
+// This is the advanced / dev workflow. The daemon's embedded dashboard
+// (started via `archigraph start`) is the recommended path for normal use.
 func runDashboardServe(argv []string) error {
 	fs := flag.NewFlagSet("dashboard serve", flag.ContinueOnError)
 	bindOverride := fs.String("bind", "", "override Bind (default from ~/.archigraph/dashboard.json)")

--- a/internal/cli/dashboard.go
+++ b/internal/cli/dashboard.go
@@ -9,10 +9,14 @@ import (
 // newDashboardCmd is the cobra shim for `archigraph dashboard ...`. The
 // real implementation lives in cmd/archigraph/dashboard.go and is wired
 // in via activeHooks.RunDashboard.
+//
+// With no arguments (or `open`), opens the daemon's dashboard in the
+// default browser — auto-starting the daemon if necessary.
+// With `serve`, runs a standalone HTTP server for dev use.
 func newDashboardCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:                "dashboard <serve> [flags]",
-		Short:              "Run the local archigraph dashboard server",
+		Use:                "dashboard [serve] [flags]",
+		Short:              "Open the dashboard in browser (or run standalone with 'serve')",
 		DisableFlagParsing: true,
 		RunE: func(_ *cobra.Command, args []string) error {
 			if activeHooks.RunDashboard == nil {

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -9,14 +9,15 @@ import (
 // primarySurface is the small command list shown by `archigraph --help`.
 // Power commands live under `archigraph help advanced`.
 var primarySurface = map[string]bool{
-	"wizard":  true,
-	"onboard": true,
-	"install": true,
-	"update":  true,
-	"doctor":  true,
-	"status":  true,
-	"list":    true,
-	"help":    true,
+	"wizard":    true,
+	"onboard":   true,
+	"install":   true,
+	"update":    true,
+	"doctor":    true,
+	"status":    true,
+	"list":      true,
+	"dashboard": true,
+	"help":      true,
 }
 
 // newRoot constructs the cobra root command with every subcommand
@@ -87,6 +88,7 @@ Operate:
   doctor        Run health checks across all groups
   status        Show daemon + index status
   list          List registered groups (alias: ls)
+  dashboard     Open the code-graph dashboard in your browser
 
 Help:
   help          Show this message
@@ -121,7 +123,9 @@ Maintenance:
   cleanup [--dry-run]             Remove orphaned registry entries
 
 Daemon (manual):
-  start | stop | restart          Daemon lifecycle (ADR-0017)
+  start                           Start daemon (MCP + indexer + dashboard + watchers)
+  stop                            Stop daemon and all managed services
+  restart                         Restart daemon (MCP + indexer + dashboard + watchers)
   logs [-f] [-n N]                Print or follow the daemon log
   watch <repo>                    Long-lived watcher (legacy; daemon owns watching)
 
@@ -137,7 +141,8 @@ MCP:
   mcp                             (removed) daemon serves MCP; see ADR-0017
 
 Dashboard:
-  dashboard serve                 Run the local dashboard HTTP server
+  dashboard                       Open dashboard in browser (auto-starts daemon if needed)
+  dashboard serve [--port N]      Run standalone dashboard HTTP server (dev/advanced)
 
 Quality:
   quality <fixture-dir>                       Measure extraction recall vs a golden fixture

--- a/internal/cli/status.go
+++ b/internal/cli/status.go
@@ -59,6 +59,9 @@ func runStatus(w io.Writer, filter string) error {
 					st.PID, uptime, humanBytes(st.RSSBytes), st.InFlight)
 				fmt.Fprintf(w, "  version: %s\n", st.Version)
 				fmt.Fprintf(w, "  socket:  %s\n", st.SocketPath)
+				if st.DashboardPort > 0 {
+					fmt.Fprintf(w, "  dashboard: http://127.0.0.1:%d/\n", st.DashboardPort)
+				}
 			}
 			if st.WatcherRepos > 0 || st.WatcherEvents > 0 {
 				fmt.Fprintf(w, "  watcher: repos=%d dirs=%d events=%d dropped=%d\n",

--- a/internal/cli/watcher_ctl.go
+++ b/internal/cli/watcher_ctl.go
@@ -25,7 +25,16 @@ func newStartCmd() *cobra.Command {
 	var maxRSSBudget int64
 	cmd := &cobra.Command{
 		Use:   "start",
-		Short: "Start the archigraph daemon",
+		Short: "Start the daemon (manages MCP, indexer, dashboard, and watchers)",
+		Long: `Start the archigraph daemon.
+
+The daemon is a single long-running process that owns:
+  - MCP server (AI assistant tools)
+  - Indexer + file-watcher (reactive re-index on save)
+  - Dashboard HTTP server (default http://127.0.0.1:47274/)
+
+Use 'archigraph stop' to stop all of the above at once.
+Use 'archigraph dashboard' to open the dashboard in your browser.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDaemonStartWithBudget(cmd.OutOrStdout(), maxRSSBudget)
 		},
@@ -38,7 +47,15 @@ func newStartCmd() *cobra.Command {
 func newStopCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "stop",
-		Short: "Stop the archigraph daemon",
+		Short: "Stop the daemon and all managed services",
+		Long: `Stop the archigraph daemon.
+
+Stopping the daemon also stops all services it manages:
+  - MCP server
+  - Indexer + file-watcher
+  - Dashboard HTTP server
+
+Use 'archigraph start' to bring everything back up.`,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			return runDaemonStop(cmd.OutOrStdout())
 		},
@@ -48,7 +65,7 @@ func newStopCmd() *cobra.Command {
 func newRestartCmd() *cobra.Command {
 	return &cobra.Command{
 		Use:   "restart",
-		Short: "Restart the archigraph daemon",
+		Short: "Restart the daemon (MCP, indexer, dashboard, watchers)",
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if err := runDaemonStop(cmd.OutOrStdout()); err != nil &&
 				!errors.Is(err, client.ErrDaemonNotRunning) {

--- a/internal/daemon/proto/proto.go
+++ b/internal/daemon/proto/proto.go
@@ -59,6 +59,11 @@ type StatusReply struct {
 	RSSUsedMB    int64              `json:"rss_used_mb,omitempty"`
 	InFlightJobs []InFlightJobState `json:"in_flight_jobs,omitempty"`
 	BlockedJobs  []string           `json:"blocked_jobs,omitempty"`
+
+	// DashboardPort is the TCP port the daemon's embedded dashboard HTTP
+	// server is bound to. Zero means the dashboard is not running.
+	// Added in #938.
+	DashboardPort int `json:"dashboard_port,omitempty"`
 }
 
 // InFlightJobState mirrors sched.InFlightJob on the wire.

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -147,6 +147,9 @@ func Run(ctx context.Context, cfg Config) error {
 	svc := newService(cfg.Index, cfg.Rebuild, cfg.QualityAudit, cfg.Layout.SocketPath, stopReq, logger)
 	svc.mcpListTools = cfg.MCPListTools
 	svc.mcpCallTool = cfg.MCPCallTool
+	if cfg.DashboardPort > 0 {
+		svc.dashboardPort = cfg.DashboardPort
+	}
 
 	// Layer 2 self-defense: start CPU watchdog for ephemeral /tmp daemons.
 	// The watchdog passes the service's real inFlight counter so it can

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -119,6 +119,11 @@ type Service struct {
 	// logger is the daemon's structured logger, forwarded to the MCP
 	// dispatcher for per-call debug logging (tool=name elapsed=X repo=Y).
 	logger *log.Logger
+
+	// dashboardPort is the TCP port the embedded dashboard server is
+	// bound to. Set by server.go after the dashboard goroutine starts.
+	// Zero means dashboard is not running. Read by Status RPC (#938).
+	dashboardPort int
 }
 
 // newService wires the injected entrypoints onto a fresh Service. The
@@ -164,6 +169,9 @@ func (s *Service) Status(_ *proto.StatusArgs, reply *proto.StatusReply) error {
 	if bin, err := os.Executable(); err == nil {
 		reply.BinaryPath = bin
 	}
+	// Report the dashboard port so `archigraph dashboard` can construct
+	// the URL without a separate config read (#938).
+	reply.DashboardPort = s.dashboardPort
 
 	if s.watcher != nil {
 		repos, dirs, events, dropped := s.watcher.Stats()


### PR DESCRIPTION
## Summary

Implements `archigraph dashboard` (no-args) to open the dashboard in the user's default browser, auto-starting the daemon if it is not running. Also audits and updates `start`/`stop`/`restart` help text to reflect that the daemon owns MCP + indexer + dashboard + watchers as a unified process.

**Changes:**
- `cmd/archigraph/dashboard.go` — new default verb: no args → `runDashboardOpen()` which (1) ensures daemon is running, (2) resolves port via Status RPC / env / default 47274, (3) prints `Dashboard: http://127.0.0.1:47274/`, (4) calls `open`/`xdg-open`/`rundll32` for browser launch; `serve` subcommand unchanged
- `internal/daemon/proto/proto.go` — adds `DashboardPort int` to `StatusReply` (single source of truth for port discovery)
- `internal/daemon/service.go` — `Status` RPC populates `reply.DashboardPort` from `Service.dashboardPort`; new `dashboardPort` field on `Service`
- `internal/daemon/server.go` — sets `svc.dashboardPort = cfg.DashboardPort` when dashboard is configured
- `internal/cli/status.go` — `archigraph status` now prints `dashboard: http://127.0.0.1:47274/` line when daemon is up
- `internal/cli/watcher_ctl.go` — `start`/`stop`/`restart` Short/Long text updated to call out all 4 managed services
- `internal/cli/dashboard.go` — cobra shim Use/Short updated to match new behaviour
- `internal/cli/root.go` — `dashboard` added to `primarySurface`; primary and advanced help updated

## Closes / Refs

Closes #938

## Testing
- [x] All tests pass: `go test ./...`
- [x] `make build` succeeds
- [x] macOS E2E: `./archigraph dashboard` — daemon auto-started, URL printed, browser opened to http://127.0.0.1:47274/ (Playwright confirmed HTTP 200 + page title "Archigraph")
- [x] `./archigraph status` — shows `dashboard: http://127.0.0.1:47274/`
- [x] `./archigraph stop` — daemon + dashboard goes down; `curl` returns connection refused
- [x] Second `./archigraph dashboard` — re-starts daemon and dashboard correctly
- [x] `archigraph dashboard serve --port N` still works (dev workflow not broken)

## Notes

- `ARCHIGRAPH_DASHBOARD_PORT` env var overrides the default port in both the daemon and the `dashboard` open command
- Browser open is non-fatal: on headless servers the URL is still printed to stdout
- Linux/Windows code paths compiled but E2E tested later via #856 sub-issues
- `archigraph dashboard open` is a synonym for the no-args form