### PR TITLE
feat: Apache Pulsar edges + topology null-guard for nats_subjects

### DIFF
--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -463,6 +463,31 @@ func TestTopology_200(t *testing.T) {
 	}
 }
 
+// TestTopology_NullGuard_NatsSubjects verifies that a group with no NATS
+// edges returns nats_subjects: [] (not null) in the JSON wire shape (#944).
+func TestTopology_NullGuard_NatsSubjects(t *testing.T) {
+	ts, _ := newPhase1Server(t)
+	code, body := getJSON(t, ts.URL, "/api/topology/testgroup")
+	if code != 200 {
+		t.Fatalf("status=%d", code)
+	}
+	// All array fields must be present and be arrays (not null).
+	for _, field := range []string{"nats_subjects", "graphql_subscriptions", "transforms", "queues", "channels"} {
+		v, exists := body[field]
+		if !exists {
+			t.Errorf("field %q missing from topology response", field)
+			continue
+		}
+		if v == nil {
+			t.Errorf("field %q is null, want []", field)
+			continue
+		}
+		if _, ok := v.([]interface{}); !ok {
+			t.Errorf("field %q is type %T, want []interface{}", field, v)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // /api/search/{group}
 // ---------------------------------------------------------------------------

--- a/internal/dashboard/handlers_topology.go
+++ b/internal/dashboard/handlers_topology.go
@@ -4,18 +4,35 @@ package dashboard
 //
 //	GET /api/topology/{group}
 //	GET /api/groups/{group}/topics
+//
+// Wire contract: every array field in the JSON response MUST marshal as []
+// (never null) so the frontend can iterate without a null-guard. This is
+// enforced by using topologyResponse (a concrete struct with slice fields
+// initialised to empty non-nil slices) instead of a raw map.
 
 import (
 	"net/http"
 	"strings"
 )
 
-// Broker entity kinds.
+// Broker entity kinds (suffix after stripping the optional "SCOPE." prefix).
 const (
-	kindMessageTopic = "MessageTopic"
-	kindQueue        = "Queue"
-	kindChannelEvent = "ChannelEvent"
+	kindMessageTopic    = "MessageTopic"
+	kindQueue           = "Queue"
+	kindChannelEvent    = "ChannelEvent"
+	kindSubscription    = "Subscription" // GraphQL subscriptions
 )
+
+// topologyResponse is the wire shape for both topology endpoints.
+// Every slice field is guaranteed non-nil (JSON [] not null).
+type topologyResponse struct {
+	Topics               []map[string]any `json:"topics"`
+	Queues               []map[string]any `json:"queues"`
+	Channels             []map[string]any `json:"channels"`
+	NatsSubjects         []map[string]any `json:"nats_subjects"`
+	GraphQLSubscriptions []map[string]any `json:"graphql_subscriptions"`
+	Transforms           []map[string]any `json:"transforms"`
+}
 
 // handleTopology — GET /api/topology/{group}
 func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
@@ -30,13 +47,7 @@ func (s *Server) handleTopology(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topics, queues, channels := collectTopology(grp)
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"topics":   topics,
-		"queues":   queues,
-		"channels": channels,
-	})
+	writeJSON(w, http.StatusOK, collectTopologyResponse(grp))
 }
 
 // handleGroupTopics — GET /api/groups/{group}/topics
@@ -52,30 +63,27 @@ func (s *Server) handleGroupTopics(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	topics, queues, channels := collectTopology(grp)
-
-	writeJSON(w, http.StatusOK, map[string]any{
-		"topics":   topics,
-		"queues":   queues,
-		"channels": channels,
-	})
+	writeJSON(w, http.StatusOK, collectTopologyResponse(grp))
 }
 
-// collectTopology extracts broker topology from a loaded group.
-func collectTopology(grp *DashGroup) (topics, queues, channels []map[string]any) {
-	topics = []map[string]any{}
-	queues = []map[string]any{}
-	channels = []map[string]any{}
+// collectTopologyResponse builds the full topology wire payload from a loaded
+// group. All slice fields are initialised to non-nil empty slices so that
+// JSON encoding produces [] (not null) when no data exists — fixing the
+// frontend error boundary triggered by null nats_subjects / graphql_subscriptions
+// on groups with no NATS or GraphQL edges (#944).
+func collectTopologyResponse(grp *DashGroup) topologyResponse {
+	resp := topologyResponse{
+		Topics:               []map[string]any{},
+		Queues:               []map[string]any{},
+		Channels:             []map[string]any{},
+		NatsSubjects:         []map[string]any{},
+		GraphQLSubscriptions: []map[string]any{},
+		Transforms:           []map[string]any{},
+	}
 
 	for _, r := range sortedRepos(grp) {
 		if r.Doc == nil {
 			continue
-		}
-
-		// Build a quick index: entity local-ID -> entity index.
-		idIdx := map[string]int{}
-		for i := range r.Doc.Entities {
-			idIdx[r.Doc.Entities[i].ID] = i
 		}
 
 		// For each broker entity, collect producers and consumers from edges.
@@ -95,19 +103,28 @@ func collectTopology(grp *DashGroup) (topics, queues, channels []map[string]any)
 					"consumers":     consumers,
 					"transforms_to": transformsTo,
 				}
-				topics = append(topics, entry)
+				resp.Topics = append(resp.Topics, entry)
 
 			case kindQueue:
 				producers, consumers, _ := brokerEdges(r, e.ID)
+				broker := e.Properties["broker"]
 				entry := map[string]any{
 					"id":        dashPrefixedID(r.Slug, e.ID),
 					"repo":      r.Slug,
 					"label":     e.Name,
-					"broker":    e.Properties["broker"],
+					"broker":    broker,
 					"producers": producers,
 					"consumers": consumers,
 				}
-				queues = append(queues, entry)
+				// NATS subjects (SCOPE.Queue with broker=nats) are surfaced in
+				// the dedicated nats_subjects bucket so the frontend can render
+				// them with the correct icon and filter logic. All other queues
+				// (RabbitMQ, SQS, Pub/Sub, …) stay in the queues bucket.
+				if broker == "nats" {
+					resp.NatsSubjects = append(resp.NatsSubjects, entry)
+				} else {
+					resp.Queues = append(resp.Queues, entry)
+				}
 
 			case kindChannelEvent:
 				emitters, subscribers := channelEdges(r, e.ID)
@@ -123,11 +140,45 @@ func collectTopology(grp *DashGroup) (topics, queues, channels []map[string]any)
 					"emitters":     emitters,
 					"subscribers":  subscribers,
 				}
-				channels = append(channels, entry)
+				resp.Channels = append(resp.Channels, entry)
+
+			case kindSubscription:
+				// GraphQL subscriptions — emitted by applyGraphQLSubscriptionSynthesis.
+				publishers, subscribers := graphqlSubEdges(r, e.ID)
+				entry := map[string]any{
+					"id":          dashPrefixedID(r.Slug, e.ID),
+					"repo":        r.Slug,
+					"label":       e.Name,
+					"schema_type": e.Properties["schema_type"],
+					"return_type": e.Properties["return_type"],
+					"publishers":  publishers,
+					"subscribers": subscribers,
+				}
+				resp.GraphQLSubscriptions = append(resp.GraphQLSubscriptions, entry)
+			}
+		}
+
+		// Collect TRANSFORMS edges into the transforms bucket.
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind == "TRANSFORMS" {
+				resp.Transforms = append(resp.Transforms, map[string]any{
+					"from_id": dashPrefixedID(r.Slug, rel.FromID),
+					"to_id":   dashPrefixedID(r.Slug, rel.ToID),
+					"repo":    r.Slug,
+				})
 			}
 		}
 	}
-	return
+
+	return resp
+}
+
+// collectTopology is retained for callers that only need the three core
+// buckets (topics, queues, channels). It delegates to collectTopologyResponse
+// for consistency.
+func collectTopology(grp *DashGroup) (topics, queues, channels []map[string]any) {
+	resp := collectTopologyResponse(grp)
+	return resp.Topics, resp.Queues, resp.Channels
 }
 
 // brokerEdges returns producers, consumers, and TRANSFORMS targets for a
@@ -177,6 +228,26 @@ func channelEdges(r *DashRepo, entityID string) (emitters, subscribers []string)
 				emitters = append(emitters, dashPrefixedID(r.Slug, rel.FromID))
 			}
 		case "WS_SUBSCRIBES_TO", "STREAMS_FROM", "GRAPHQL_SUBSCRIBES":
+			if rel.ToID == entityID {
+				subscribers = append(subscribers, dashPrefixedID(r.Slug, rel.FromID))
+			}
+		}
+	}
+	return
+}
+
+// graphqlSubEdges returns publishers and subscribers for a GraphQL Subscription
+// entity, scanning GRAPHQL_PUBLISHES and GRAPHQL_SUBSCRIBES edges.
+func graphqlSubEdges(r *DashRepo, entityID string) (publishers, subscribers []string) {
+	publishers = []string{}
+	subscribers = []string{}
+	for _, rel := range r.Doc.Relationships {
+		switch rel.Kind {
+		case "GRAPHQL_PUBLISHES":
+			if rel.ToID == entityID {
+				publishers = append(publishers, dashPrefixedID(r.Slug, rel.FromID))
+			}
+		case "GRAPHQL_SUBSCRIBES":
 			if rel.ToID == entityID {
 				subscribers = append(subscribers, dashPrefixedID(r.Slug, rel.FromID))
 			}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -301,6 +301,17 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Apache Pulsar producer/consumer cross-repo edges (#936). Emits
+	// SCOPE.MessageTopic entities (broker=pulsar) + PUBLISHES_TO /
+	// SUBSCRIBES_TO edges for pulsar-client (Python/Java/Kotlin),
+	// pulsar-client-go (Go), and pulsar-client (Node/TS). Topic names are
+	// canonicalised to the full persistent://tenant/namespace/topic URI so
+	// the cross-repo linker matches producer and consumer sides on the same
+	// entity ID. Append-only — cannot regress the surrounding pipeline.
+	entities, relationships = applyPulsarEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// #727: Real-time event channel synthesis. Three append-only passes
 	// for WebSocket, Server-Sent Events, and GraphQL subscriptions. Each
 	// scans the file directly and emits ChannelEvent / Stream /

--- a/internal/engine/pulsar_edges.go
+++ b/internal/engine/pulsar_edges.go
@@ -1,0 +1,446 @@
+// Apache Pulsar producer/consumer detection — extends #515.
+//
+// For every Pulsar producer or consumer call site this pass can statically
+// recognize, we emit a synthetic `SCOPE.MessageTopic` entity keyed by the
+// canonical Pulsar topic URI, plus PUBLISHES_TO or SUBSCRIBES_TO edges.
+//
+// Pulsar topic naming:
+//
+//	Full URI:  persistent://tenant/namespace/topic
+//	           non-persistent://tenant/namespace/topic
+//	Short form: "orders"  →  canonical: "persistent://public/default/orders"
+//
+// The cross-repo matching key is ALWAYS the full canonical URI so that
+// a producer in repo A and a consumer in repo B sharing the same topic name
+// will match via identical entity IDs — the same trick used by the Kafka
+// and NATS passes (#726).
+//
+// SDKs covered:
+//
+//	Python  (pulsar-client):    client.create_producer(topic='…') + producer.send(…)
+//	                            client.subscribe(topic, subscription_name)
+//	Java    (pulsar-client):    client.newProducer().topic("…").create()
+//	                            client.newConsumer().topic("…").subscriptionName("…").subscribe()
+//	Go      (pulsar-client-go): client.CreateProducer(pulsar.ProducerOptions{Topic: "…"})
+//	                            client.Subscribe(pulsar.ConsumerOptions{Topic: "…", SubscriptionName: "…"})
+//	Node    (pulsar-client):    client.createProducer({ topic: "…" })
+//	                            client.subscribe({ topic: "…", subscription: "…" })
+//
+// False-positive guard:
+//
+//	Python: create_producer is matched only when the file imports pulsar
+//	        (import pulsar / from pulsar …). boto3 SQS uses a different
+//	        signature and is never confused because it never imports pulsar.
+//	Java:   newProducer/newConsumer matches only after a PulsarClient or
+//	        PulsarClient.builder() token in the same file.
+//	Go:     CreateProducer/Subscribe matches only when the file imports the
+//	        pulsar-client-go SDK (github.com/apache/pulsar-client-go/pulsar).
+//	Node:   createProducer matches only when the file imports/requires
+//	        pulsar-client.
+//
+// Refs #936.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pulsarTopicEntityKind is the Kind used for synthetic Pulsar topic entities.
+// We reuse the existing MessageTopic kind so the dashboard topology surface
+// picks up Pulsar topics in the same "topics" bucket, distinguished by
+// broker=pulsar in entity properties.
+const pulsarTopicEntityKind = messageTopicKind // "SCOPE.MessageTopic"
+
+// pulsarProducesEdge / pulsarConsumesEdge — reuse existing edge vocabulary.
+const pulsarProducesEdge = publishesToEdgeKind   // "PUBLISHES_TO"
+const pulsarConsumesEdge = subscribesToEdgeKind  // "SUBSCRIBES_TO"
+
+// pulsarDefaultScheme is the scheme used when normalising a bare topic name.
+const pulsarDefaultScheme = "persistent"
+
+// pulsarDefaultTenant / pulsarDefaultNamespace are the Pulsar defaults.
+const pulsarDefaultTenant = "public"
+const pulsarDefaultNamespace = "default"
+
+// ---------------------------------------------------------------------------
+// Topic canonicalisation
+// ---------------------------------------------------------------------------
+
+// normalisePulsarTopic returns the canonical full-URI form of a Pulsar topic.
+//
+//	"orders"                       → "persistent://public/default/orders"
+//	"public/default/orders"        → "persistent://public/default/orders"
+//	"persistent://t/ns/orders"     → "persistent://t/ns/orders"
+//	"non-persistent://t/ns/orders" → "non-persistent://t/ns/orders"
+func normalisePulsarTopic(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	// Already a full URI.
+	if strings.Contains(raw, "://") {
+		return raw
+	}
+	parts := strings.SplitN(raw, "/", 3)
+	switch len(parts) {
+	case 3:
+		// tenant/namespace/topic
+		return pulsarDefaultScheme + "://" + raw
+	case 1:
+		// bare topic name
+		return fmt.Sprintf("%s://%s/%s/%s",
+			pulsarDefaultScheme, pulsarDefaultTenant, pulsarDefaultNamespace, raw)
+	default:
+		// Ambiguous — return as-is with default scheme.
+		return pulsarDefaultScheme + "://" + raw
+	}
+}
+
+// pulsarTopicID returns the synthetic entity ID for a Pulsar topic.
+func pulsarTopicID(canonical string) string {
+	return "topic:pulsar:" + canonical
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+// pulsarSynthesisSupportsLanguage reports whether applyPulsarEdges can emit
+// synthetics for lang.
+func pulsarSynthesisSupportsLanguage(lang string) bool {
+	switch lang {
+	case "python", "java", "kotlin", "go", "javascript", "typescript":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyPulsarEdges runs after applyNATSEdges and APPENDS synthetic
+// SCOPE.MessageTopic entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
+// Apache Pulsar. Append-only — never touches existing entities or edges.
+func applyPulsarEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if len(content) == 0 {
+		return entities, relationships
+	}
+	if !pulsarSynthesisSupportsLanguage(lang) {
+		return entities, relationships
+	}
+
+	src := string(content)
+
+	seenTopic := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitTopic := func(canonical string) {
+		id := pulsarTopicID(canonical)
+		if seenTopic[id] {
+			return
+		}
+		seenTopic[id] = true
+		entities = append(entities, types.EntityRecord{
+			Name:               id,
+			Kind:               pulsarTopicEntityKind,
+			SourceFile:         "",
+			Language:           lang,
+			Properties: map[string]string{
+				"broker":       "pulsar",
+				"topic_name":   canonical,
+				"pattern_type": "pulsar_synthesis",
+			},
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	emitEdge := func(callerKind, callerName, topicCanonical, edgeKind string) {
+		if callerName == "" || topicCanonical == "" {
+			return
+		}
+		topicID := pulsarTopicID(topicCanonical)
+		key := edgeKind + "|" + callerKind + ":" + callerName + "|" + topicID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: fmt.Sprintf("%s:%s", callerKind, callerName),
+			ToID:   fmt.Sprintf("%s:%s", pulsarTopicEntityKind, topicID),
+			Kind:   edgeKind,
+			Properties: map[string]string{
+				"broker":       "pulsar",
+				"pattern_type": "pulsar_synthesis",
+			},
+		})
+	}
+
+	switch lang {
+	case "python":
+		synthesizePyPulsar(src, emitTopic, emitEdge)
+	case "java", "kotlin":
+		synthesizeJavaPulsar(src, emitTopic, emitEdge)
+	case "go":
+		synthesizeGoPulsar(src, emitTopic, emitEdge)
+	case "javascript", "typescript":
+		synthesizeNodePulsar(src, emitTopic, emitEdge)
+	}
+
+	return entities, relationships
+}
+
+// ---------------------------------------------------------------------------
+// Python — pulsar-client
+// ---------------------------------------------------------------------------
+
+// pyPulsarImportRe detects `import pulsar` or `from pulsar import …`.
+var pyPulsarImportRe = regexp.MustCompile(`(?m)^\s*(?:import pulsar|from pulsar\b)`)
+
+// pyPulsarCreateProducerRe captures `client.create_producer(topic='…')` or
+// `client.create_producer(topic="…")`.
+var pyPulsarCreateProducerRe = regexp.MustCompile(`\.create_producer\s*\(\s*(?:topic\s*=\s*)?["']([^"'\n\r]+)["']`)
+
+// pyPulsarSubscribeRe captures `client.subscribe(topic, subscription_name)`.
+// Group 1 = topic (string literal only).
+var pyPulsarSubscribeRe = regexp.MustCompile(`\.subscribe\s*\(\s*["']([^"'\n\r]+)["']`)
+
+func synthesizePyPulsar(
+	src string,
+	emitTopic func(canonical string),
+	emitEdge func(callerKind, callerName, canonical, edgeKind string),
+) {
+	// Guard: file must import pulsar SDK.
+	if !pyPulsarImportRe.MatchString(src) {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingPyName(src, offset)
+	}
+
+	for _, m := range pyPulsarCreateProducerRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarProducesEdge)
+	}
+
+	for _, m := range pyPulsarSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarConsumesEdge)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java / Kotlin — pulsar-client
+// ---------------------------------------------------------------------------
+
+// jPulsarClientRe detects PulsarClient (import or usage) as a file-level
+// guard so we don't match newProducer/newConsumer on other frameworks.
+var jPulsarClientRe = regexp.MustCompile(`\bPulsarClient\b`)
+
+// jPulsarProducerTopicRe captures `.topic("…")` immediately following a
+// `.newProducer()` chain. Group 1 = topic literal.
+var jPulsarProducerTopicRe = regexp.MustCompile(`\.newProducer\s*\([^)]*\)\s*(?:\.[^.()]+\([^)]*\)\s*)*\.topic\s*\(\s*"([^"\n\r]+)"\s*\)`)
+
+// jPulsarConsumerTopicRe captures `.topic("…")` immediately following a
+// `.newConsumer()` chain.
+var jPulsarConsumerTopicRe = regexp.MustCompile(`\.newConsumer\s*\([^)]*\)\s*(?:\.[^.()]+\([^)]*\)\s*)*\.topic\s*\(\s*"([^"\n\r]+)"\s*\)`)
+
+// jPulsarReaderTopicRe captures `.newReader().topic("…")` (Pulsar Reader API).
+var jPulsarReaderTopicRe = regexp.MustCompile(`\.newReader\s*\([^)]*\)\s*(?:\.[^.()]+\([^)]*\)\s*)*\.topic\s*\(\s*"([^"\n\r]+)"\s*\)`)
+
+func synthesizeJavaPulsar(
+	src string,
+	emitTopic func(canonical string),
+	emitEdge func(callerKind, callerName, canonical, edgeKind string),
+) {
+	if !jPulsarClientRe.MatchString(src) {
+		return
+	}
+
+	// Class name for caller attribution — same heuristic as Java Kafka pass.
+	caller := ""
+	if m := classNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		caller = m[1]
+	}
+	if caller == "" {
+		caller = "module"
+	}
+
+	for _, m := range jPulsarProducerTopicRe.FindAllStringSubmatch(src, -1) {
+		canonical := normalisePulsarTopic(m[1])
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Service", caller, canonical, pulsarProducesEdge)
+	}
+
+	for _, m := range jPulsarConsumerTopicRe.FindAllStringSubmatch(src, -1) {
+		canonical := normalisePulsarTopic(m[1])
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Service", caller, canonical, pulsarConsumesEdge)
+	}
+
+	for _, m := range jPulsarReaderTopicRe.FindAllStringSubmatch(src, -1) {
+		canonical := normalisePulsarTopic(m[1])
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Service", caller, canonical, pulsarConsumesEdge)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Go — pulsar-client-go
+// ---------------------------------------------------------------------------
+
+// goPulsarImportRe detects import of the Apache Pulsar Go client SDK.
+var goPulsarImportRe = regexp.MustCompile(`"github\.com/apache/pulsar-client-go/pulsar"`)
+
+// goPulsarProducerTopicRe captures `Topic: "…"` inside a
+// pulsar.ProducerOptions{…} literal.
+var goPulsarProducerTopicRe = regexp.MustCompile(`pulsar\.ProducerOptions\s*\{[^}]*?Topic\s*:\s*"([^"\n\r]+)"`)
+
+// goPulsarConsumerTopicRe captures `Topic: "…"` inside a
+// pulsar.ConsumerOptions{…} literal.
+var goPulsarConsumerTopicRe = regexp.MustCompile(`pulsar\.ConsumerOptions\s*\{[^}]*?Topic\s*:\s*"([^"\n\r]+)"`)
+
+// goPulsarConsumerTopicsRe captures `Topics: []string{"a","b"}` inside a
+// pulsar.ConsumerOptions literal.
+var goPulsarConsumerTopicsRe = regexp.MustCompile(`pulsar\.ConsumerOptions\s*\{[^}]*?Topics\s*:\s*\[\]string\s*\{([^}]+)\}`)
+
+// goPulsarReaderTopicRe captures `Topic: "…"` inside a
+// pulsar.ReaderOptions{…} literal.
+var goPulsarReaderTopicRe = regexp.MustCompile(`pulsar\.ReaderOptions\s*\{[^}]*?Topic\s*:\s*"([^"\n\r]+)"`)
+
+func synthesizeGoPulsar(
+	src string,
+	emitTopic func(canonical string),
+	emitEdge func(callerKind, callerName, canonical, edgeKind string),
+) {
+	if !goPulsarImportRe.MatchString(src) {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingGoName(src, offset)
+	}
+
+	for _, m := range goPulsarProducerTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarProducesEdge)
+	}
+
+	for _, m := range goPulsarConsumerTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarConsumesEdge)
+	}
+
+	for _, m := range goPulsarConsumerTopicsRe.FindAllStringSubmatchIndex(src, -1) {
+		body := src[m[2]:m[3]]
+		offset := m[0]
+		caller := enclosing(offset)
+		for _, tok := range strings.Split(body, ",") {
+			if raw, ok := unquote(tok); ok {
+				canonical := normalisePulsarTopic(raw)
+				if canonical == "" {
+					continue
+				}
+				emitTopic(canonical)
+				emitEdge("Function", caller, canonical, pulsarConsumesEdge)
+			}
+		}
+	}
+
+	for _, m := range goPulsarReaderTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarConsumesEdge)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node / TypeScript — pulsar-client
+// ---------------------------------------------------------------------------
+
+// nodePulsarImportRe detects `require('pulsar-client')` or
+// `import … from 'pulsar-client'`.
+var nodePulsarImportRe = regexp.MustCompile(`(?:require|from)\s*\(\s*["']pulsar-client["']\s*\)|from\s+["']pulsar-client["']`)
+
+// nodePulsarCreateProducerRe captures `client.createProducer({ topic: "…" })`.
+var nodePulsarCreateProducerRe = regexp.MustCompile(`\.createProducer\s*\(\s*\{[^}]*?topic\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// nodePulsarSubscribeRe captures `client.subscribe({ topic: "…", … })`.
+var nodePulsarSubscribeRe = regexp.MustCompile(`\.subscribe\s*\(\s*\{[^}]*?topic\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+func synthesizeNodePulsar(
+	src string,
+	emitTopic func(canonical string),
+	emitEdge func(callerKind, callerName, canonical, edgeKind string),
+) {
+	if !nodePulsarImportRe.MatchString(src) {
+		return
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingNodeName(src, offset)
+	}
+
+	for _, m := range nodePulsarCreateProducerRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarProducesEdge)
+	}
+
+	for _, m := range nodePulsarSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		raw := src[m[2]:m[3]]
+		canonical := normalisePulsarTopic(raw)
+		if canonical == "" {
+			continue
+		}
+		emitTopic(canonical)
+		emitEdge("Function", enclosing(m[0]), canonical, pulsarConsumesEdge)
+	}
+}

--- a/internal/engine/pulsar_edges_test.go
+++ b/internal/engine/pulsar_edges_test.go
@@ -1,0 +1,419 @@
+// Tests for the Apache Pulsar producer/consumer detection pass (#936).
+//
+// Acceptance matrix:
+//  1. Python client.create_producer(topic='persistent://public/default/orders') → PUBLISHES_TO
+//  2. Java short-name consumer canonicalised to persistent://public/default/orders → SUBSCRIBES_TO
+//  3. Cross-repo matching: producer entity ID == consumer entity ID for same topic
+//  4. No false match against non-Pulsar create_producer (boto3 SQS)
+//  5. No false match against Kafka .subscribe() calls in the same file
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+// runPulsarDetect is a lightweight driver for the Pulsar pass.
+func runPulsarDetect(t *testing.T, lang, path, src string) ([]entityResult, []relResult) {
+	t.Helper()
+	ents, rels := applyPulsarEdges(lang, path, []byte(src), nil, nil)
+	out := make([]entityResult, 0, len(ents))
+	for _, e := range ents {
+		out = append(out, entityResult{kind: e.Kind, name: e.Name, props: e.Properties})
+	}
+	relOut := make([]relResult, 0, len(rels))
+	for _, r := range rels {
+		relOut = append(relOut, relResult{from: r.FromID, to: r.ToID, kind: r.Kind, props: r.Properties})
+	}
+	return out, relOut
+}
+
+// pulsarTopicByCanonical returns the first SCOPE.MessageTopic entity whose
+// Name matches pulsarTopicID(canonical).
+func pulsarTopicByCanonical(ents []entityResult, canonical string) *entityResult {
+	id := pulsarTopicID(canonical)
+	for i := range ents {
+		if ents[i].kind == pulsarTopicEntityKind && ents[i].name == id {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// Topic normalisation unit tests
+// ---------------------------------------------------------------------------
+
+func TestNormalisePulsarTopic(t *testing.T) {
+	cases := []struct {
+		raw  string
+		want string
+	}{
+		{"persistent://acme/payments/orders", "persistent://acme/payments/orders"},
+		{"non-persistent://acme/payments/orders", "non-persistent://acme/payments/orders"},
+		{"public/default/orders", "persistent://public/default/orders"},
+		{"orders", "persistent://public/default/orders"},
+		{"", ""},
+		{"  persistent://t/ns/q  ", "persistent://t/ns/q"},
+	}
+	for _, c := range cases {
+		got := normalisePulsarTopic(c.raw)
+		if got != c.want {
+			t.Errorf("normalisePulsarTopic(%q) = %q, want %q", c.raw, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Python — pulsar-client
+// ---------------------------------------------------------------------------
+
+func TestPulsar_Py_CreateProducerFullURI(t *testing.T) {
+	src := `
+import pulsar
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+def send_order(payload: bytes):
+    producer = client.create_producer(topic='persistent://public/default/orders')
+    producer.send(payload)
+`
+	ents, rels := runPulsarDetect(t, "python", "producer.py", src)
+
+	canonical := "persistent://public/default/orders"
+	e := pulsarTopicByCanonical(ents, canonical)
+	if e == nil {
+		t.Fatalf("expected SCOPE.MessageTopic for %q, got none", canonical)
+	}
+	if e.props["broker"] != "pulsar" {
+		t.Errorf("broker = %q, want pulsar", e.props["broker"])
+	}
+
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarProducesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected PUBLISHES_TO edge to %q, got %+v", canonical, rels)
+	}
+}
+
+func TestPulsar_Py_SubscribeFullURI(t *testing.T) {
+	src := `
+import pulsar
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+def consume_orders():
+    consumer = client.subscribe('persistent://public/default/orders', subscription_name='my-sub')
+    while True:
+        msg = consumer.receive()
+        consumer.acknowledge(msg)
+`
+	ents, rels := runPulsarDetect(t, "python", "consumer.py", src)
+
+	canonical := "persistent://public/default/orders"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Fatalf("expected topic entity for %q", canonical)
+	}
+
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarConsumesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SUBSCRIBES_TO edge to %q, got %+v", canonical, rels)
+	}
+}
+
+func TestPulsar_Py_ShortNameNormalised(t *testing.T) {
+	src := `
+import pulsar
+client = pulsar.Client('pulsar://localhost:6650')
+producer = client.create_producer(topic='orders')
+`
+	ents, _ := runPulsarDetect(t, "python", "short.py", src)
+	canonical := "persistent://public/default/orders"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Errorf("expected canonicalised topic %q, got none", canonical)
+	}
+}
+
+// TestPulsar_Py_NoFalsePositive_Boto3 ensures boto3 SQS create_queue / send_message
+// does NOT trigger a Pulsar match even though the call chain is superficially
+// similar.
+func TestPulsar_Py_NoFalsePositive_Boto3(t *testing.T) {
+	src := `
+import boto3
+
+sqs = boto3.client('sqs', region_name='us-east-1')
+
+def send_sqs(msg):
+    url = sqs.create_queue(QueueName='orders')['QueueUrl']
+    sqs.send_message(QueueUrl=url, MessageBody=msg)
+`
+	ents, rels := runPulsarDetect(t, "python", "sqs_producer.py", src)
+	if len(ents) > 0 || len(rels) > 0 {
+		t.Errorf("expected 0 entities/rels for non-Pulsar file, got %d/%d", len(ents), len(rels))
+	}
+}
+
+// TestPulsar_Py_NoFalsePositive_KafkaSubscribe ensures a Kafka .subscribe()
+// call in a Python file that does NOT import pulsar is not matched.
+func TestPulsar_Py_NoFalsePositive_KafkaSubscribe(t *testing.T) {
+	src := `
+from confluent_kafka import Consumer
+
+c = Consumer({'bootstrap.servers': 'localhost:9092', 'group.id': 'grp'})
+c.subscribe(['orders'])
+`
+	ents, rels := runPulsarDetect(t, "python", "kafka_consumer.py", src)
+	if len(ents) > 0 || len(rels) > 0 {
+		t.Errorf("expected 0 entities/rels for non-Pulsar file, got %d/%d", len(ents), len(rels))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java — pulsar-client
+// ---------------------------------------------------------------------------
+
+func TestPulsar_Java_ProducerConsumerCrossRepoMatch(t *testing.T) {
+	producerSrc := `
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Producer;
+
+public class OrderProducer {
+    public void send(byte[] payload) throws Exception {
+        PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
+        Producer<byte[]> producer = client.newProducer()
+            .topic("persistent://public/default/orders")
+            .create();
+        producer.send(payload);
+    }
+}
+`
+	consumerSrc := `
+import org.apache.pulsar.client.api.PulsarClient;
+import org.apache.pulsar.client.api.Consumer;
+
+public class OrderConsumer {
+    public void consume() throws Exception {
+        PulsarClient client = PulsarClient.builder().serviceUrl("pulsar://localhost:6650").build();
+        Consumer<byte[]> consumer = client.newConsumer()
+            .topic("orders")
+            .subscriptionName("my-sub")
+            .subscribe();
+    }
+}
+`
+	entsP, relsP := runPulsarDetect(t, "java", "OrderProducer.java", producerSrc)
+	entsC, relsC := runPulsarDetect(t, "java", "OrderConsumer.java", consumerSrc)
+
+	canonical := "persistent://public/default/orders"
+	epID := pulsarTopicID(canonical)
+
+	eP := pulsarTopicByCanonical(entsP, canonical)
+	eC := pulsarTopicByCanonical(entsC, canonical)
+
+	if eP == nil {
+		t.Fatalf("producer: expected topic entity %q, got none", canonical)
+	}
+	if eC == nil {
+		t.Fatalf("consumer: expected topic entity %q, got none (short-name canonicalisation failed)", canonical)
+	}
+
+	// Entity IDs must match (cross-repo join key).
+	if eP.name != eC.name {
+		t.Errorf("cross-repo mismatch: producer entity %q != consumer entity %q", eP.name, eC.name)
+	}
+	if eP.name != epID {
+		t.Errorf("entity name = %q, want %q", eP.name, epID)
+	}
+
+	foundPub := false
+	for _, r := range relsP {
+		if r.kind == pulsarProducesEdge && strings.Contains(r.to, epID) {
+			foundPub = true
+		}
+	}
+	if !foundPub {
+		t.Errorf("producer: expected PUBLISHES_TO edge, got %+v", relsP)
+	}
+
+	foundSub := false
+	for _, r := range relsC {
+		if r.kind == pulsarConsumesEdge && strings.Contains(r.to, epID) {
+			foundSub = true
+		}
+	}
+	if !foundSub {
+		t.Errorf("consumer: expected SUBSCRIBES_TO edge, got %+v", relsC)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Go — pulsar-client-go
+// ---------------------------------------------------------------------------
+
+func TestPulsar_Go_ProducerOptions(t *testing.T) {
+	src := `
+package main
+
+import (
+	"github.com/apache/pulsar-client-go/pulsar"
+)
+
+func publishOrder(client pulsar.Client, payload []byte) error {
+	producer, err := client.CreateProducer(pulsar.ProducerOptions{
+		Topic: "persistent://acme/billing/invoices",
+	})
+	if err != nil {
+		return err
+	}
+	_, err = producer.Send(ctx, &pulsar.ProducerMessage{Payload: payload})
+	return err
+}
+`
+	ents, rels := runPulsarDetect(t, "go", "producer.go", src)
+	canonical := "persistent://acme/billing/invoices"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Fatalf("expected topic %q, got none", canonical)
+	}
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarProducesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected PUBLISHES_TO, got %+v", rels)
+	}
+}
+
+func TestPulsar_Go_ConsumerOptions(t *testing.T) {
+	src := `
+package main
+
+import (
+	"github.com/apache/pulsar-client-go/pulsar"
+)
+
+func consumeInvoices(client pulsar.Client) {
+	consumer, err := client.Subscribe(pulsar.ConsumerOptions{
+		Topic:            "persistent://acme/billing/invoices",
+		SubscriptionName: "invoice-consumer",
+	})
+	_ = consumer
+	_ = err
+}
+`
+	ents, rels := runPulsarDetect(t, "go", "consumer.go", src)
+	canonical := "persistent://acme/billing/invoices"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Fatalf("expected topic %q, got none", canonical)
+	}
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarConsumesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SUBSCRIBES_TO, got %+v", rels)
+	}
+}
+
+func TestPulsar_Go_NoFalsePositive_NonPulsarImport(t *testing.T) {
+	src := `
+package main
+
+import "fmt"
+
+func main() {
+	opts := struct{ Topic string }{Topic: "orders"}
+	fmt.Println(opts.Topic)
+}
+`
+	ents, rels := runPulsarDetect(t, "go", "no_pulsar.go", src)
+	if len(ents) > 0 || len(rels) > 0 {
+		t.Errorf("expected 0 entities/rels, got %d/%d", len(ents), len(rels))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Node / TypeScript — pulsar-client
+// ---------------------------------------------------------------------------
+
+func TestPulsar_Node_CreateProducer(t *testing.T) {
+	src := `
+const Pulsar = require('pulsar-client')
+
+async function publishOrders() {
+  const client = new Pulsar.Client({ serviceUrl: 'pulsar://localhost:6650' })
+  const producer = await client.createProducer({ topic: 'persistent://public/default/orders' })
+  await producer.send({ data: Buffer.from('hello') })
+}
+`
+	ents, rels := runPulsarDetect(t, "javascript", "producer.js", src)
+	canonical := "persistent://public/default/orders"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Fatalf("expected topic %q, got none", canonical)
+	}
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarProducesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected PUBLISHES_TO, got %+v", rels)
+	}
+}
+
+func TestPulsar_Node_Subscribe(t *testing.T) {
+	src := `
+import Pulsar from 'pulsar-client'
+
+async function consumeOrders() {
+  const client = new Pulsar.Client({ serviceUrl: 'pulsar://localhost:6650' })
+  const consumer = await client.subscribe({
+    topic: 'persistent://public/default/orders',
+    subscription: 'my-sub',
+  })
+  const msg = await consumer.receive()
+  await consumer.acknowledge(msg)
+}
+`
+	ents, rels := runPulsarDetect(t, "typescript", "consumer.ts", src)
+	canonical := "persistent://public/default/orders"
+	if pulsarTopicByCanonical(ents, canonical) == nil {
+		t.Fatalf("expected topic %q, got none", canonical)
+	}
+	found := false
+	for _, r := range rels {
+		if r.kind == pulsarConsumesEdge && strings.Contains(r.to, pulsarTopicID(canonical)) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected SUBSCRIBES_TO, got %+v", rels)
+	}
+}
+
+func TestPulsar_Node_NoFalsePositive_NonPulsarImport(t *testing.T) {
+	src := `
+const kafka = require('kafkajs')
+const producer = kafka.producer()
+await producer.send({ topic: 'orders', messages: [{ value: 'hello' }] })
+`
+	ents, rels := runPulsarDetect(t, "javascript", "kafka_producer.js", src)
+	if len(ents) > 0 || len(rels) > 0 {
+		t.Errorf("expected 0 entities/rels for non-Pulsar file, got %d/%d", len(ents), len(rels))
+	}
+}

--- a/verify2/fixtures/runtime-pulsar/consumer.py
+++ b/verify2/fixtures/runtime-pulsar/consumer.py
@@ -1,0 +1,18 @@
+"""
+Pulsar Python consumer fixture — verify2/fixtures/runtime-pulsar/consumer.py
+
+Emits SUBSCRIBES_TO edge to topic:pulsar:persistent://public/default/orders.
+"""
+import pulsar
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+
+def consume_orders() -> None:
+    consumer = client.subscribe(
+        'persistent://public/default/orders',
+        subscription_name='order-consumer',
+    )
+    while True:
+        msg = consumer.receive()
+        consumer.acknowledge(msg)

--- a/verify2/fixtures/runtime-pulsar/non_pulsar_boto3.py
+++ b/verify2/fixtures/runtime-pulsar/non_pulsar_boto3.py
@@ -1,0 +1,14 @@
+"""
+Non-Pulsar boto3 fixture — verify2/fixtures/runtime-pulsar/non_pulsar_boto3.py
+
+Must NOT produce any Pulsar edges. boto3 SQS uses create_queue / send_message
+with a completely different call signature; the Pulsar pass must ignore it.
+"""
+import boto3
+
+sqs = boto3.client('sqs', region_name='us-east-1')
+
+
+def send_sqs(message: str) -> None:
+    url = sqs.create_queue(QueueName='orders')['QueueUrl']
+    sqs.send_message(QueueUrl=url, MessageBody=message)

--- a/verify2/fixtures/runtime-pulsar/producer.py
+++ b/verify2/fixtures/runtime-pulsar/producer.py
@@ -1,0 +1,13 @@
+"""
+Pulsar Python producer fixture — verify2/fixtures/runtime-pulsar/producer.py
+
+Emits PUBLISHES_TO edge to topic:pulsar:persistent://public/default/orders.
+"""
+import pulsar
+
+client = pulsar.Client('pulsar://localhost:6650')
+
+
+def send_order(payload: bytes) -> None:
+    producer = client.create_producer(topic='persistent://public/default/orders')
+    producer.send(payload)


### PR DESCRIPTION
## Summary

Two targeted fixes in two clean commits.

**Commit 1 — #936: Apache Pulsar producer/consumer edge detection**

Adds `applyPulsarEdges` pass covering Python (`pulsar-client`), Java, Go (`pulsar-client-go`), and Node/TS (`pulsar-client`). Emits `SCOPE.MessageTopic` entities with `broker=pulsar` and `PUBLISHES_TO` / `SUBSCRIBES_TO` edges. Topic names are canonicalised to the full `persistent://tenant/namespace/topic` URI so cross-repo joins work via identical entity IDs — same strategy as the Kafka and NATS passes.

False-positive guards per language:
- Python: requires `import pulsar` or `from pulsar` in the file
- Java/Kotlin: requires `PulsarClient` token in scope
- Go: requires `github.com/apache/pulsar-client-go/pulsar` import
- Node/TS: requires `pulsar-client` require/import

Kafka `.subscribe()` and boto3 SQS `create_queue` never match. 12 unit tests cover all four languages, the normalisation helper, cross-repo match invariant, and false-positive guards.

**Commit 2 — #944: Topology surface null-guard**

Replaces the ad-hoc `map[string]any` topology response with a concrete `topologyResponse` struct whose slice fields are initialised to non-nil empty slices. JSON encoding therefore always produces `[]` (never `null`) for all array fields, fixing the frontend error boundary that fires when a group has no NATS edges.

Additionally routes NATS subjects (`SCOPE.Queue` with `broker=nats`) to the `nats_subjects` bucket, collects GraphQL subscriptions into `graphql_subscriptions`, and populates the `transforms` array — all fields the frontend already expects but the backend previously omitted entirely.

## Changes

| File | Change |
|---|---|
| `internal/engine/pulsar_edges.go` | New — Pulsar detection pass |
| `internal/engine/pulsar_edges_test.go` | New — 12 tests |
| `internal/engine/detector.go` | Register `applyPulsarEdges` after `applyNATSEdges` |
| `internal/dashboard/handlers_topology.go` | `topologyResponse` struct + null-safe collection + NATS/GraphQL routing |
| `internal/dashboard/handlers_phase1_test.go` | Add `TestTopology_NullGuard_NatsSubjects` |
| `verify2/fixtures/runtime-pulsar/` | Synthetic fixtures (producer, consumer, non-Pulsar boto3) |

## Test plan

- [x] `go test ./internal/engine/...` — all pass including 12 new Pulsar tests
- [x] `go test ./internal/dashboard/...` — all pass including `TestTopology_NullGuard_NatsSubjects`
- [x] False-positive: boto3 SQS fixture produces 0 entities/edges
- [x] False-positive: Kafka consumer Python file (no `import pulsar`) produces 0 entities/edges
- [x] Cross-repo: producer entity ID == consumer entity ID for same topic name (short-name and full URI canonicalise identically)
- [x] `nats_subjects` field in topology response is `[]` not `null` for groups with no NATS edges

Closes #936 #944

🤖 Generated with [Claude Code](https://claude.com/claude-code)