### PR TITLE
[#927] Managed event-bus discovery: EventBridge, EventGrid, CloudEvents

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -365,6 +365,16 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 	entities, relationships = applyRedisPubSubEdges(
 		file.Language, file.Path, file.Content, entities, relationships,
 	)
+	// Managed event-bus edges (#927): AWS EventBridge, Azure EventGrid, and
+	// CNCF CloudEvents. Emits SCOPE.EventBusEvent synthetic entities plus
+	// PUBLISHES_TO / SUBSCRIBES_TO edges for producers/consumers, and
+	// EVENTBRIDGE_TRIGGERS / EVENTGRID_TRIGGERS / CLOUDEVENT_FLOWS edges for
+	// rule-to-target linkage. EventBridge rule targets reference Lambda
+	// entity IDs from #925 (`aws-lambda:<name>`) without reinventing them.
+	// Append-only — cannot regress surrounding passes.
+	entities, relationships = applyEventBusEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
 	// Django models-import suffix rewrite (PR #580 wave-10 Chain-fix A):
 	// The YAML rule `from \S+\.models import (\w+)` emits Model:<name>
 	// for every captured identifier. In Django/DRF projects, a sibling

--- a/internal/engine/event_bus_edges.go
+++ b/internal/engine/event_bus_edges.go
@@ -1,0 +1,1207 @@
+// Managed event-bus producer/consumer detection — #927.
+//
+// Three append-only sub-detectors in one pass:
+//
+//  1. AWS EventBridge
+//     Producers: boto3 `events.put_events(Entries=[{Source,DetailType,...}])` (Python),
+//       `EventBridgeClient.send(new PutEventsCommand({Entries:[...]})` (Node/TS),
+//       `ebClient.PutEvents(ctx, &eventbridge.PutEventsInput{Entries:…})` (Go).
+//     Consumers / IaC rules: Terraform `aws_cloudwatch_event_rule` with `event_pattern`
+//       JSON containing `source` + `detail-type` fields; CDK / serverless.yml patterns
+//       detected via regex over raw text. Rule targets resolved to Lambda via
+//       lambdaFunctionID() from serverless_edges.go (#925).
+//     Synthetics: SCOPE.EventBusEvent keyed by `event:eventbridge:<source>:<detail-type>`.
+//     Edges: PUBLISHES_TO (producer→synthetic), SUBSCRIBES_TO (rule→synthetic),
+//            EVENTBRIDGE_TRIGGERS (rule→lambda target).
+//
+//  2. Azure EventGrid
+//     Producers: `EventGridPublisherClient.send(events)` (Python azure-eventgrid,
+//       Node @azure/eventgrid), `EventGridSenderClient.sendEvents` (Node SDK v12+).
+//     Consumers: `@app.event_grid_trigger(name='X')` (Python v2 model),
+//       `EventGridTrigger` binding attribute (C# / Python), Azure Function
+//       receiving an EventGridEvent.
+//     Synthetics: SCOPE.EventBusEvent keyed by `event:eventgrid:<topic>:<event-type>`.
+//     Edges: PUBLISHES_TO, SUBSCRIBES_TO, EVENTGRID_TRIGGERS.
+//
+//  3. CNCF CloudEvents (spec-level, language-agnostic)
+//     Producers: `CloudEvent(...)` builder + any HTTP POST with `ce-type`/`ce-source`
+//       headers, Go `cloudevents.NewEvent()`, Python cloudevents SDK `CloudEvent(...)`,
+//       Node `new CloudEvent(...)`.
+//     Consumers: HTTP handler that reads `ce-type`/`ce-source` headers; `@app.route`
+//       decorated with cloudevents handler; Go `cloudevents.NewClientHTTP()` receiver.
+//     Synthetics: SCOPE.EventBusEvent keyed by `event:cloudevents:<source>:<type>`.
+//     Edges: PUBLISHES_TO (producer→synthetic), SUBSCRIBES_TO (consumer→synthetic),
+//            CLOUDEVENT_FLOWS (emitter route → receiver route, same-file only).
+//
+// # False-positive guards
+//
+//   - Plain HTTP routes without CE headers are never tagged.
+//   - EventBridge guard: file must mention "eventbridge", "put_events", "EventBridge",
+//     or "PutEventsCommand" before scanning.
+//   - EventGrid guard: file must mention "eventgrid", "EventGrid", "EventGridPublisherClient".
+//   - CloudEvents guard: file must mention "CloudEvent", "ce-type", or "cloudevents".
+//
+// # Scope guard
+//
+// Append-only — this pass never modifies or removes existing entities or edges,
+// so it cannot regress the bug-rate of the surrounding pipeline.
+//
+// Builds on the aws-lambda entity-ID prefix from #925 for EventBridge→Lambda links.
+//
+// Refs #927.
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// eventBusEventKind is the SCOPE kind for synthetic managed event-bus events.
+const eventBusEventKind = "SCOPE.EventBusEvent"
+
+// eventBridgeTriggersEdge, eventGridTriggersEdge, cloudEventFlowsEdge are the
+// new edge kinds introduced by #927.
+const (
+	eventBridgeTriggersEdge = "EVENTBRIDGE_TRIGGERS"
+	eventGridTriggersEdge   = "EVENTGRID_TRIGGERS"
+	cloudEventFlowsEdge     = "CLOUDEVENT_FLOWS"
+)
+
+// eventBusSynthesisSupportsLanguage reports whether applyEventBusEdges can
+// emit synthetics for `lang`. The HCL/Terraform path is handled separately
+// via a text-based regex scan (no language gate needed — TF files come as
+// lang="hcl" or lang="terraform").
+func eventBusSynthesisSupportsLanguage(lang string) bool {
+	switch lang {
+	case "python", "javascript", "typescript", "go", "csharp", "hcl", "terraform":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyEventBusEdges is the single entry-point pass that runs after
+// applyRedisPubSubEdges. It dispatches to three sub-detectors and is
+// append-only.
+func applyEventBusEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if len(content) == 0 {
+		return entities, relationships
+	}
+	if !eventBusSynthesisSupportsLanguage(lang) {
+		return entities, relationships
+	}
+
+	src := string(content)
+
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	emitEvent := func(id, busType, source, detailType string, props map[string]string) {
+		if seenEnt[id] {
+			return
+		}
+		seenEnt[id] = true
+		merged := map[string]string{
+			"bus_type":     busType,
+			"source":       source,
+			"detail_type":  detailType,
+			"pattern_type": "event_bus_synthesis",
+		}
+		for k, v := range props {
+			if v != "" {
+				merged[k] = v
+			}
+		}
+		entities = append(entities, types.EntityRecord{
+			Name:               id,
+			Kind:               eventBusEventKind,
+			SourceFile:         "",
+			Language:           lang,
+			Properties:         merged,
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	emitEdge := func(fromID, toID, kind string, props map[string]string) {
+		if fromID == "" || toID == "" {
+			return
+		}
+		key := kind + "|" + fromID + "|" + toID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID:     fromID,
+			ToID:       toID,
+			Kind:       kind,
+			Properties: props,
+		})
+	}
+
+	applyEventBridgeEdges(lang, src, path, emitEvent, emitEdge)
+	applyEventGridEdges(lang, src, path, emitEvent, emitEdge)
+	applyCloudEventEdges(lang, src, path, emitEvent, emitEdge)
+
+	return entities, relationships
+}
+
+// eventBridgeEventID returns the canonical synthetic ID for an EventBridge
+// event routing key. Identical across repos for cross-repo linking.
+func eventBridgeEventID(source, detailType string) string {
+	return fmt.Sprintf("event:eventbridge:%s:%s", source, detailType)
+}
+
+// eventGridEventID returns the canonical synthetic ID for an EventGrid event.
+func eventGridEventID(topic, eventType string) string {
+	return fmt.Sprintf("event:eventgrid:%s:%s", topic, eventType)
+}
+
+// cloudEventID returns the canonical synthetic ID for a CloudEvents event.
+func cloudEventID(ceSource, ceType string) string {
+	return fmt.Sprintf("event:cloudevents:%s:%s", ceSource, ceType)
+}
+
+// ---------------------------------------------------------------------------
+// AWS EventBridge
+// ---------------------------------------------------------------------------
+
+// pyEventBridgePutEventsRe matches Python boto3:
+//
+//	events.put_events(Entries=[{...}])
+//	eb_client.put_events(Entries=[{'Source':'X','DetailType':'Y',...}])
+var pyEventBridgePutEventsRe = regexp.MustCompile(`\.put_events\s*\(\s*Entries\s*=\s*\[`)
+
+// pyEntrySourceRe extracts 'Source': 'value' from a Python dict literal.
+var pyEntrySourceRe = regexp.MustCompile(`['"]Source['"]\s*:\s*['"]([^'"]+)['"]`)
+
+// pyEntryDetailTypeRe extracts 'DetailType': 'value'.
+var pyEntryDetailTypeRe = regexp.MustCompile(`['"]DetailType['"]\s*:\s*['"]([^'"]+)['"]`)
+
+// nodeEBPutEventsCommandRe matches Node/TS AWS SDK v3:
+//
+//	new PutEventsCommand({ Entries: [{...}] })
+var nodeEBPutEventsCommandRe = regexp.MustCompile(`new\s+PutEventsCommand\s*\(\s*\{[^)]*Entries\s*:`)
+
+// nodeEBSourceRe extracts Source: 'value' (single/double/backtick quotes).
+var nodeEBSourceRe = regexp.MustCompile(`Source\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// nodeEBDetailTypeRe extracts DetailType: 'value'.
+var nodeEBDetailTypeRe = regexp.MustCompile(`DetailType\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// goEBPutEventsRe matches Go AWS SDK v2:
+//
+//	ebtypes.PutEventsRequestEntry{Source: aws.String("X"), DetailType: aws.String("Y")}
+var goEBPutEventsRe = regexp.MustCompile(`PutEventsRequestEntry\s*\{`)
+
+// goEBSourceRe extracts Source: aws.String("X") or Source: &"X".
+var goEBSourceRe = regexp.MustCompile(`Source\s*:\s*(?:aws\.String\s*\(\s*)?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]`)
+
+// goEBDetailTypeRe extracts DetailType: ...
+var goEBDetailTypeRe = regexp.MustCompile(`DetailType\s*:\s*(?:aws\.String\s*\(\s*)?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]`)
+
+// hclEventRuleRe matches `resource "aws_cloudwatch_event_rule" "name"` in a
+// line-oriented way to avoid brace-counting issues with nested jsonencode({}).
+// Group 1 = resource label name. We scan the full file and extract blocks
+// by finding the start of each resource block, then walking forward.
+var hclEventRuleRe = regexp.MustCompile(`resource\s+"aws_cloudwatch_event_rule"\s+"(\w+)"`)
+
+// hclEventPatternJSONStringRe matches the escaped-string form:
+//
+//	event_pattern = "{\"source\":[\"orders\"],\"detail-type\":[\"OrderPlaced\"]}"
+var hclEventPatternJSONStringRe = regexp.MustCompile(`event_pattern\s*=\s*"((?:[^"\\]|\\.)*)"`)
+
+// hclEventPatternJSONEncodeRe matches the jsonencode({...}) form by finding
+// the source/detail-type lines inside the call.
+// We rely on line-level extraction rather than balanced-brace extraction.
+var hclEventPatternSourceLineRe = regexp.MustCompile(`(?m)^\s*source\s*=\s*\[\s*"([^"]+)"`)
+var hclEventPatternDetailTypeLineRe = regexp.MustCompile(`(?m)["']detail-type["']\s*=\s*\[\s*"([^"]+)"`)
+
+// hclEventPatternJSONEncodeBlockRe finds `event_pattern = jsonencode({` and captures until the
+// matching `})`.
+var hclEventPatternJSONEncodeBlockRe = regexp.MustCompile(`event_pattern\s*=\s*jsonencode\s*\(`)
+
+// hclEventTargetRuleRe matches `resource "aws_cloudwatch_event_target" "name"` blocks
+// that contain a target_id + rule + arn referencing a lambda.
+var hclEventTargetRuleRe = regexp.MustCompile(`(?s)resource\s+"aws_cloudwatch_event_target"\s+"(\w+)"\s+\{([^}]*(?:\{[^}]*\}[^}]*)*)\}`)
+
+// hclTargetRuleNameRe extracts `rule = aws_cloudwatch_event_rule.<name>.name` or
+// `rule = "<name>"`.
+var hclTargetRuleNameRe = regexp.MustCompile(`rule\s*=\s*(?:aws_cloudwatch_event_rule\.(\w+)\.name|"([^"]+)")`)
+
+// hclTargetArnRe extracts `arn = aws_lambda_function.<name>.arn`.
+var hclTargetArnRe = regexp.MustCompile(`arn\s*=\s*aws_lambda_function\.(\w+)\.arn`)
+
+// hclTargetLambdaArnLiteralRe extracts `arn = "arn:aws:lambda:...:function:FnName"`.
+var hclTargetLambdaArnLiteralRe = regexp.MustCompile(`arn\s*=\s*"arn:aws:lambda:[^"]*:function:([^"]+)"`)
+
+// cdkEventPatternSourceRe matches CDK TypeScript/Python eventPattern: { source: ['X'], 'detail-type': ['Y'] }.
+var cdkEventPatternSourceRe = regexp.MustCompile(`source\s*:\s*\[\s*['"]([^'"]+)['"]`)
+var cdkEventPatternDetailTypeRe = regexp.MustCompile(`['"?]detail-type['"?]\s*:\s*\[\s*['"]([^'"]+)['"]`)
+
+// cdkLambdaTargetRe matches addTarget(new targets.LambdaFunction(fn)) or addTarget(lambdaFn).
+var cdkLambdaTargetRe = regexp.MustCompile(`addTarget\s*\(\s*(?:new\s+[A-Za-z.]+\s*\(\s*)?(\w+)\s*[,)]`)
+
+// serverlessEventBridgeRe matches serverless.yml event[Bridge] stanza:
+//
+//	eventBridge:
+//	  eventBus: ...
+//	  pattern:
+//	    source: [X]
+//	    detail-type: [Y]
+var serverlessYMLEBSourceRe = regexp.MustCompile(`source\s*:\s*\[\s*['"]?([^'"\]\s]+)['"]?`)
+var serverlessYMLEBDetailTypeRe = regexp.MustCompile(`detail-type\s*:\s*\[\s*['"]?([^'"\]\s]+)['"]?`)
+
+// applyEventBridgeEdges scans a single file for EventBridge patterns.
+func applyEventBridgeEdges(
+	lang, src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Fast-path guard — skip files with no EventBridge tokens.
+	if !strings.Contains(src, "eventbridge") &&
+		!strings.Contains(src, "EventBridge") &&
+		!strings.Contains(src, "put_events") &&
+		!strings.Contains(src, "PutEventsCommand") &&
+		!strings.Contains(src, "PutEventsRequestEntry") &&
+		!strings.Contains(src, "aws_cloudwatch_event_rule") &&
+		!strings.Contains(src, "eventBridge") &&
+		!strings.Contains(src, "EventBridgeClient") {
+		return
+	}
+
+	switch lang {
+	case "python":
+		applyEventBridgePython(src, path, emitEvent, emitEdge)
+	case "javascript", "typescript":
+		applyEventBridgeNode(src, path, emitEvent, emitEdge)
+	case "go":
+		applyEventBridgeGo(src, path, emitEvent, emitEdge)
+	case "hcl", "terraform":
+		applyEventBridgeHCL(src, path, emitEvent, emitEdge)
+	}
+
+	// CDK TypeScript patterns are caught under javascript/typescript above.
+	// serverless.yml is lang="yaml" — scan with a text-only path.
+	if strings.Contains(path, "serverless") && strings.HasSuffix(path, ".yml") {
+		applyEventBridgeServerlessYML(src, path, emitEvent, emitEdge)
+	}
+}
+
+func applyEventBridgePython(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Producer: .put_events(Entries=[{...}])
+	for _, m := range pyEventBridgePutEventsRe.FindAllStringIndex(src, -1) {
+		// Extract the list argument — walk to closing bracket.
+		start := m[1] - 1 // rewind to the opening [
+		inner := extractBalancedBracket(src, start)
+
+		source := ""
+		if sm := pyEntrySourceRe.FindStringSubmatch(inner); sm != nil {
+			source = sm[1]
+		}
+		detailType := ""
+		if dm := pyEntryDetailTypeRe.FindStringSubmatch(inner); dm != nil {
+			detailType = dm[1]
+		}
+		if source == "" || detailType == "" {
+			continue
+		}
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, nil)
+		caller := findEnclosingPyFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "eventbridge", "source": source, "detail_type": detailType, "sdk": "boto3"},
+		)
+	}
+}
+
+func applyEventBridgeNode(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Producer: new PutEventsCommand({ Entries: [...] })
+	for _, m := range nodeEBPutEventsCommandRe.FindAllStringIndex(src, -1) {
+		// Look for Source / DetailType in a window after the match.
+		end := m[1] + 800
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[m[0]:end]
+		source := ""
+		if sm := nodeEBSourceRe.FindStringSubmatch(window); sm != nil {
+			source = sm[1]
+		}
+		detailType := ""
+		if dm := nodeEBDetailTypeRe.FindStringSubmatch(window); dm != nil {
+			detailType = dm[1]
+		}
+		if source == "" || detailType == "" {
+			continue
+		}
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, nil)
+		caller := findEnclosingNodeFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "eventbridge", "source": source, "detail_type": detailType, "sdk": "aws-sdk-v3"},
+		)
+	}
+
+	// CDK: eventPattern: { source: ['X'], 'detail-type': ['Y'] }
+	if strings.Contains(src, "eventPattern") || strings.Contains(src, "EventPattern") {
+		applyCDKEventPattern(src, path, emitEvent, emitEdge)
+	}
+}
+
+func applyEventBridgeGo(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	for _, m := range goEBPutEventsRe.FindAllStringIndex(src, -1) {
+		end := m[1] + 600
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[m[0]:end]
+		source := ""
+		if sm := goEBSourceRe.FindStringSubmatch(window); sm != nil {
+			source = sm[1]
+		}
+		detailType := ""
+		if dm := goEBDetailTypeRe.FindStringSubmatch(window); dm != nil {
+			detailType = dm[1]
+		}
+		if source == "" || detailType == "" {
+			continue
+		}
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, nil)
+		caller := findEnclosingGoFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "eventbridge", "source": source, "detail_type": detailType, "sdk": "aws-sdk-go-v2"},
+		)
+	}
+}
+
+// applyEventBridgeHCL detects aws_cloudwatch_event_rule + aws_cloudwatch_event_target
+// resources in Terraform/HCL files.
+func applyEventBridgeHCL(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Step 1: parse rules — collect ruleName → (source, detailType)
+	type ruleInfo struct {
+		source     string
+		detailType string
+	}
+	rules := map[string]ruleInfo{}
+
+	for _, m := range hclEventRuleRe.FindAllStringSubmatchIndex(src, -1) {
+		ruleName := src[m[2]:m[3]]
+
+		// Extract the body of this resource block by finding the opening brace
+		// and walking forward with balanced-brace counting.
+		blockStart := m[1]
+		bracePos := strings.Index(src[blockStart:], "{")
+		if bracePos < 0 {
+			continue
+		}
+		bracePos += blockStart
+		body := extractBalancedBraces(src, bracePos)
+
+		source, detailType := extractEventBridgePattern(body)
+		if source == "" || detailType == "" {
+			continue
+		}
+
+		ri := ruleInfo{source: source, detailType: detailType}
+		rules[ruleName] = ri
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, map[string]string{"iac": "terraform", "rule_name": ruleName})
+		ruleEntityID := fmt.Sprintf("SCOPE.Component:aws_cloudwatch_event_rule.%s", ruleName)
+		emitEdge(ruleEntityID, fmt.Sprintf("%s:%s", eventBusEventKind, id), "SUBSCRIBES_TO",
+			map[string]string{"bus": "eventbridge", "source": source, "detail_type": detailType, "iac": "terraform"})
+	}
+
+	// Step 2: parse targets — link rule → lambda.
+	for _, m := range hclEventTargetRuleRe.FindAllStringSubmatch(src, -1) {
+		body := m[2]
+
+		// Resolve rule name from `rule = aws_cloudwatch_event_rule.X.name` or literal.
+		ruleName := ""
+		if rm := hclTargetRuleNameRe.FindStringSubmatch(body); rm != nil {
+			if rm[1] != "" {
+				ruleName = rm[1]
+			} else {
+				ruleName = rm[2]
+			}
+		}
+
+		// Find lambda function name from ARN reference or literal.
+		lambdaName := ""
+		if am := hclTargetArnRe.FindStringSubmatch(body); am != nil {
+			lambdaName = am[1]
+		} else if am := hclTargetLambdaArnLiteralRe.FindStringSubmatch(body); am != nil {
+			lambdaName = am[1]
+		}
+
+		if lambdaName == "" {
+			continue
+		}
+
+		// Emit EVENTBRIDGE_TRIGGERS: rule → lambda ServerlessFunction entity.
+		lambdaID := lambdaFunctionID(lambdaName)
+		var ruleEntityID string
+		if ruleName != "" {
+			ruleEntityID = fmt.Sprintf("SCOPE.Component:aws_cloudwatch_event_rule.%s", ruleName)
+		} else {
+			ruleEntityID = "SCOPE.Component:aws_cloudwatch_event_rule.unknown"
+		}
+		emitEdge(
+			ruleEntityID,
+			fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaID),
+			eventBridgeTriggersEdge,
+			map[string]string{"bus": "eventbridge", "target_type": "lambda", "lambda_name": lambdaName, "iac": "terraform"},
+		)
+
+		// Also emit SUBSCRIBES_TO from lambda to the event if we resolved the rule.
+		if ruleName != "" {
+			if ri, ok := rules[ruleName]; ok {
+				id := eventBridgeEventID(ri.source, ri.detailType)
+				emitEdge(
+					fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaID),
+					fmt.Sprintf("%s:%s", eventBusEventKind, id),
+					"SUBSCRIBES_TO",
+					map[string]string{"bus": "eventbridge", "via": "rule", "rule_name": ruleName, "iac": "terraform"},
+				)
+			}
+		}
+	}
+}
+
+// extractEventBridgePattern extracts source and detail-type from an HCL block body.
+// Handles three formats:
+//  1. event_pattern = "{\"source\":[\"X\"],\"detail-type\":[\"Y\"]}"  (escaped JSON string)
+//  2. event_pattern = jsonencode({ source = ["X"], "detail-type" = ["Y"] })  (HCL native)
+//  3. event_pattern = <<JSON ... JSON (heredoc — not yet handled, returns "","")
+func extractEventBridgePattern(body string) (source, detailType string) {
+	// Format 1: escaped JSON string.
+	if m := hclEventPatternJSONStringRe.FindStringSubmatch(body); m != nil {
+		// Unescape the string.
+		unescaped := strings.ReplaceAll(m[1], `\"`, `"`)
+		var pattern map[string]interface{}
+		if err := json.Unmarshal([]byte(unescaped), &pattern); err == nil {
+			source = extractFirstStringFromEventPatternField(pattern, "source")
+			detailType = extractFirstStringFromEventPatternField(pattern, "detail-type")
+			if source != "" && detailType != "" {
+				return
+			}
+		}
+		// Regex fallback.
+		source, detailType = extractEventPatternFieldsRegex(unescaped)
+		return
+	}
+
+	// Format 2: jsonencode({...}) — extract the block content and look for
+	// line-level source / detail-type assignments.
+	if m := hclEventPatternJSONEncodeBlockRe.FindStringIndex(body); m != nil {
+		// Walk forward from the opening paren to find the balanced content.
+		parenPos := strings.Index(body[m[0]:], "(")
+		if parenPos >= 0 {
+			parenPos += m[0]
+			inner := extractBalancedParensEngine(body, parenPos)
+			if sm := hclEventPatternSourceLineRe.FindStringSubmatch(inner); sm != nil {
+				source = sm[1]
+			}
+			if dm := hclEventPatternDetailTypeLineRe.FindStringSubmatch(inner); dm != nil {
+				detailType = dm[1]
+			}
+		}
+	}
+	return
+}
+
+// extractBalancedBraces extracts the content inside the first balanced `{`…`}`
+// starting at position start (which must point at the opening `{`).
+func extractBalancedBraces(src string, start int) string {
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return src[start+1 : i]
+			}
+		}
+	}
+	return src[start:]
+}
+
+// applyCDKEventPattern handles CDK TypeScript patterns like:
+//
+//	eventPattern: { source: ['order.svc'], 'detail-type': ['OrderPlaced'] }
+//	rule.addTarget(new targets.LambdaFunction(fn))
+func applyCDKEventPattern(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Find eventPattern blocks and extract source + detail-type.
+	sourceMatches := cdkEventPatternSourceRe.FindAllStringSubmatch(src, -1)
+	dtMatches := cdkEventPatternDetailTypeRe.FindAllStringSubmatch(src, -1)
+
+	for i, sm := range sourceMatches {
+		source := sm[1]
+		if i >= len(dtMatches) {
+			break
+		}
+		detailType := dtMatches[i][1]
+		if source == "" || detailType == "" {
+			continue
+		}
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, map[string]string{"iac": "cdk"})
+		// Rule entity — use caller context.
+		caller := findEnclosingNodeFunctionName(src, 0)
+		ruleID := fmt.Sprintf("SCOPE.Function:%s", caller)
+		emitEdge(ruleID, fmt.Sprintf("%s:%s", eventBusEventKind, id), "SUBSCRIBES_TO",
+			map[string]string{"bus": "eventbridge", "source": source, "detail_type": detailType, "iac": "cdk"})
+
+		// addTarget — link to lambda.
+		if tm := cdkLambdaTargetRe.FindStringSubmatch(src); tm != nil {
+			lambdaVarName := tm[1]
+			lambdaID := lambdaFunctionID(lambdaVarName)
+			emitEdge(ruleID,
+				fmt.Sprintf("%s:%s", serverlessFunctionKind, lambdaID),
+				eventBridgeTriggersEdge,
+				map[string]string{"bus": "eventbridge", "target_var": lambdaVarName, "iac": "cdk"})
+		}
+	}
+}
+
+// applyEventBridgeServerlessYML handles serverless.yml eventBridge trigger stanzas.
+func applyEventBridgeServerlessYML(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	if !strings.Contains(src, "eventBridge") {
+		return
+	}
+	sourceMatches := serverlessYMLEBSourceRe.FindAllStringSubmatch(src, -1)
+	dtMatches := serverlessYMLEBDetailTypeRe.FindAllStringSubmatch(src, -1)
+	for i, sm := range sourceMatches {
+		source := sm[1]
+		if i >= len(dtMatches) {
+			break
+		}
+		detailType := dtMatches[i][1]
+		if source == "" || detailType == "" {
+			continue
+		}
+		id := eventBridgeEventID(source, detailType)
+		emitEvent(id, "eventbridge", source, detailType, map[string]string{"iac": "serverless.yml"})
+		emitEdge(
+			fmt.Sprintf("SCOPE.Config:%s", path),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"SUBSCRIBES_TO",
+			map[string]string{"bus": "eventbridge", "iac": "serverless.yml"},
+		)
+	}
+}
+
+// extractEventPatternFieldsRegex falls back to regex-based extraction when JSON parsing fails.
+func extractEventPatternFieldsRegex(pattern string) (source, detailType string) {
+	if m := regexp.MustCompile(`"source"\s*:\s*\[\s*"([^"]+)"`).FindStringSubmatch(pattern); m != nil {
+		source = m[1]
+	}
+	if m := regexp.MustCompile(`"detail-type"\s*:\s*\[\s*"([^"]+)"`).FindStringSubmatch(pattern); m != nil {
+		detailType = m[1]
+	}
+	return
+}
+
+// extractFirstStringFromEventPatternField returns the first string element of a
+// JSON array field in an EventBridge event_pattern object.
+func extractFirstStringFromEventPatternField(pattern map[string]interface{}, field string) string {
+	v, ok := pattern[field]
+	if !ok {
+		return ""
+	}
+	arr, ok := v.([]interface{})
+	if !ok || len(arr) == 0 {
+		return ""
+	}
+	s, _ := arr[0].(string)
+	return s
+}
+
+// extractBalancedParensEngine extracts the content inside the first balanced `(`…`)`
+// starting at position start (which should point at the opening `(`).
+// Named with Engine suffix to avoid collision with the python package function.
+func extractBalancedParensEngine(src string, start int) string {
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[start+1 : i]
+			}
+		}
+	}
+	return ""
+}
+
+// extractBalancedBracket extracts the content inside the first balanced `[`…`]`
+// starting at position start.
+func extractBalancedBracket(src string, start int) string {
+	depth := 0
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '[':
+			depth++
+		case ']':
+			depth--
+			if depth == 0 {
+				return src[start+1 : i]
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Azure EventGrid
+// ---------------------------------------------------------------------------
+
+// pyEventGridSendRe matches Python azure-eventgrid send call:
+//
+//	client.send([EventGridEvent(subject=..., event_type='X', ...)], ...)
+//	EventGridPublisherClient(...).send(events)
+var pyEventGridSendRe = regexp.MustCompile(`EventGridPublisherClient|\.send\s*\(\s*\[`)
+
+// pyEventGridEventTypeRe extracts event_type='X' from a Python call.
+var pyEventGridEventTypeRe = regexp.MustCompile(`event_type\s*=\s*['"]([^'"]+)['"]`)
+
+// pyEventGridSubjectRe extracts subject='X'.
+var pyEventGridSubjectRe = regexp.MustCompile(`subject\s*=\s*['"]([^'"]+)['"]`)
+
+// pyEventGridTriggerRe matches @app.event_grid_trigger(name='fn') + def name(
+var pyEventGridTriggerRe = regexp.MustCompile(`(?m)@\w+\.event_grid_trigger\s*\([^)]*\)\s*\n(?:\s*#[^\n]*\n)*\s*(?:async\s+)?def\s+(\w+)\s*\(`)
+
+// pyEventGridTriggerAttrRe matches @app.route(..., trigger=EventGridTrigger())
+var pyEventGridTriggerAttrRe = regexp.MustCompile(`EventGridTrigger\s*\(`)
+
+// nodeEGSendRe matches Node @azure/eventgrid:
+//
+//	client.send(events) where client is EventGridPublisherClient / EventGridSenderClient
+var nodeEGSendRe = regexp.MustCompile(`EventGridPublisherClient|EventGridSenderClient|sendEvents\s*\(`)
+
+// nodeEGEventTypeRe extracts eventType: 'X' from a Node object literal
+// (single, double, or backtick quotes).
+var nodeEGEventTypeRe = regexp.MustCompile(`eventType\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// nodeEGSubjectRe extracts subject: 'X' (single, double, or backtick quotes).
+var nodeEGSubjectRe = regexp.MustCompile(`subject\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// nodeEGSendCallRe matches the sendEvents / send call site that contains
+// the event object array — used to anchor the event data extraction window.
+var nodeEGSendCallRe = regexp.MustCompile(`(?:sendEvents|\.send)\s*\(\s*\[`)
+
+// csharpEGSendRe matches C# EventGridPublisherClient.SendEventsAsync.
+var csharpEGSendRe = regexp.MustCompile(`SendEventsAsync\s*\(|EventGridPublisherClient`)
+
+// csharpEGEventTypeRe extracts EventType = "X" from a C# object initializer.
+var csharpEGEventTypeRe = regexp.MustCompile(`EventType\s*=\s*"([^"\n\r]+)"`)
+
+// csharpEGSubjectRe extracts Subject = "X".
+var csharpEGSubjectRe = regexp.MustCompile(`Subject\s*=\s*"([^"\n\r]+)"`)
+
+// csharpEGTriggerRe matches [EventGridTrigger] C# binding attribute.
+var csharpEGTriggerRe = regexp.MustCompile(`\[EventGridTrigger\]|\bEventGridEvent\b`)
+
+func applyEventGridEdges(
+	lang, src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Fast-path guard.
+	if !strings.Contains(src, "eventgrid") &&
+		!strings.Contains(src, "EventGrid") &&
+		!strings.Contains(src, "event_grid") {
+		return
+	}
+
+	switch lang {
+	case "python":
+		applyEventGridPython(src, path, emitEvent, emitEdge)
+	case "javascript", "typescript":
+		applyEventGridNode(src, path, emitEvent, emitEdge)
+	case "csharp":
+		applyEventGridCSharp(src, path, emitEvent, emitEdge)
+	}
+}
+
+func applyEventGridPython(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Producer: EventGridPublisherClient(...).send(...)
+	if pyEventGridSendRe.MatchString(src) {
+		// Extract event type + subject from call site window.
+		for _, m := range regexp.MustCompile(`EventGridEvent\s*\(`).FindAllStringIndex(src, -1) {
+			end := m[1] + 400
+			if end > len(src) {
+				end = len(src)
+			}
+			window := src[m[0]:end]
+			eventType := ""
+			if em := pyEventGridEventTypeRe.FindStringSubmatch(window); em != nil {
+				eventType = em[1]
+			}
+			subject := ""
+			if sm := pyEventGridSubjectRe.FindStringSubmatch(window); sm != nil {
+				subject = sm[1]
+			}
+			if eventType == "" {
+				continue
+			}
+			id := eventGridEventID(subject, eventType)
+			emitEvent(id, "eventgrid", subject, eventType, nil)
+			caller := findEnclosingPyFunctionName(src, m[0])
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", caller),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				"PUBLISHES_TO",
+				map[string]string{"bus": "eventgrid", "event_type": eventType, "subject": subject, "sdk": "azure-eventgrid-python"},
+			)
+		}
+	}
+
+	// Consumer: @app.event_grid_trigger(name='X') + def fn(
+	for _, m := range pyEventGridTriggerRe.FindAllStringSubmatchIndex(src, -1) {
+		fnName := src[m[2]:m[3]]
+		id := eventGridEventID("*", "*") // wildcard — consumer with no explicit topic
+		emitEvent(id, "eventgrid", "*", "*", map[string]string{"consumer": fnName})
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", fnName),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"SUBSCRIBES_TO",
+			map[string]string{"bus": "eventgrid", "trigger": "event_grid_trigger", "sdk": "azure-functions-python"},
+		)
+		// Also emit EVENTGRID_TRIGGERS → azure-function entity (from #925).
+		azID := azureFunctionID(fnName)
+		emitEdge(
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			fmt.Sprintf("%s:%s", serverlessFunctionKind, azID),
+			eventGridTriggersEdge,
+			map[string]string{"bus": "eventgrid", "function_name": fnName},
+		)
+	}
+}
+
+func applyEventGridNode(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	if !nodeEGSendRe.MatchString(src) {
+		return
+	}
+	// Producer: anchor on the send call site that contains the event array,
+	// then extract eventType + subject from the call window.
+	for _, m := range nodeEGSendCallRe.FindAllStringIndex(src, -1) {
+		// Extract the array content.
+		bracketPos := m[1] - 1 // rewind to `[`
+		inner := extractBalancedBracket(src, bracketPos)
+		eventType := ""
+		if em := nodeEGEventTypeRe.FindStringSubmatch(inner); em != nil {
+			eventType = em[1]
+		}
+		subject := ""
+		if sm := nodeEGSubjectRe.FindStringSubmatch(inner); sm != nil {
+			subject = sm[1]
+		}
+		if eventType == "" {
+			continue
+		}
+		id := eventGridEventID(subject, eventType)
+		emitEvent(id, "eventgrid", subject, eventType, nil)
+		caller := findEnclosingNodeFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "eventgrid", "event_type": eventType, "subject": subject, "sdk": "azure-eventgrid-js"},
+		)
+	}
+}
+
+func applyEventGridCSharp(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Producer: EventGridPublisherClient.SendEventsAsync
+	if csharpEGSendRe.MatchString(src) {
+		for _, m := range regexp.MustCompile(`EventGridEvent\s*\(`).FindAllStringIndex(src, -1) {
+			end := m[1] + 400
+			if end > len(src) {
+				end = len(src)
+			}
+			window := src[m[0]:end]
+			eventType := ""
+			if em := csharpEGEventTypeRe.FindStringSubmatch(window); em != nil {
+				eventType = em[1]
+			}
+			subject := ""
+			if sm := csharpEGSubjectRe.FindStringSubmatch(window); sm != nil {
+				subject = sm[1]
+			}
+			if eventType == "" {
+				continue
+			}
+			id := eventGridEventID(subject, eventType)
+			emitEvent(id, "eventgrid", subject, eventType, nil)
+			caller := findEnclosingCSharpMethod(src, m[0])
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", caller),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				"PUBLISHES_TO",
+				map[string]string{"bus": "eventgrid", "event_type": eventType, "subject": subject, "sdk": "azure-eventgrid-dotnet"},
+			)
+		}
+	}
+
+	// Consumer: [EventGridTrigger] — the attribute appears inside a method
+	// parameter list, so we search backward for the enclosing method declaration.
+	if csharpEGTriggerRe.MatchString(src) {
+		for _, m := range csharpEGTriggerRe.FindAllStringIndex(src, -1) {
+			// Search backward from trigger match to find the method.
+			methodName := findEnclosingCSharpMethod(src, m[0])
+			if methodName == "" {
+				// Fall back to forward search.
+				methodName = findFollowingCSharpMethod(src, m[1])
+			}
+			if methodName == "" {
+				continue
+			}
+			id := eventGridEventID("*", "*")
+			emitEvent(id, "eventgrid", "*", "*", map[string]string{"consumer": methodName})
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", methodName),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				"SUBSCRIBES_TO",
+				map[string]string{"bus": "eventgrid", "trigger": "EventGridTrigger", "sdk": "azure-functions-dotnet"},
+			)
+			azID := azureFunctionID(methodName)
+			emitEdge(
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				fmt.Sprintf("%s:%s", serverlessFunctionKind, azID),
+				eventGridTriggersEdge,
+				map[string]string{"bus": "eventgrid", "function_name": methodName},
+			)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CNCF CloudEvents
+// ---------------------------------------------------------------------------
+
+// ceHeaderRe matches HTTP header reads for CloudEvents mandatory attributes:
+//
+//	request.headers.get('ce-type'), req.header('ce-source'), etc.
+var ceHeaderRe = regexp.MustCompile(`(?i)["']ce-(?:type|source|id|specversion)["']`)
+
+// ceTypeHeaderRe extracts the literal ce-type value when known statically.
+var ceTypeHeaderRe = regexp.MustCompile(`(?i)ce-type["']\s*[):,=]\s*["']([^"'\n\r]+)["']`)
+
+// ceSourceHeaderRe extracts the literal ce-source value.
+var ceSourceHeaderRe = regexp.MustCompile(`(?i)ce-source["']\s*[):,=]\s*["']([^"'\n\r]+)["']`)
+
+// pyCloudEventBuilderRe matches Python cloudevents SDK:
+//
+//	CloudEvent({'type': 'X', 'source': '/Y', ...})
+var pyCloudEventBuilderRe = regexp.MustCompile(`CloudEvent\s*\(\s*\{`)
+
+// pyCloudEventTypeRe extracts 'type': 'X' from a Python CloudEvent constructor.
+var pyCloudEventTypeRe = regexp.MustCompile(`['"]type['"]\s*:\s*['"]([^'"]+)['"]`)
+
+// pyCloudEventSourceRe extracts 'source': '/X'.
+var pyCloudEventSourceRe = regexp.MustCompile(`['"]source['"]\s*:\s*['"]([^'"]+)['"]`)
+
+// nodeCloudEventBuilderRe matches Node/TS:
+//
+//	new CloudEvent({ type: 'X', source: '/Y' })
+var nodeCloudEventBuilderRe = regexp.MustCompile(`new\s+CloudEvent\s*\(\s*\{`)
+
+// nodeCloudEventTypeRe extracts type: 'X' from a JS CloudEvent constructor
+// (single, double, or backtick quotes).
+var nodeCloudEventTypeRe = regexp.MustCompile(`type\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// nodeCloudEventSourceRe extracts source: '/X' (single, double, or backtick quotes).
+var nodeCloudEventSourceRe = regexp.MustCompile(`source\s*:\s*["'` + "`" + `]([^"'` + "`" + `\n\r]+)["'` + "`" + `]`)
+
+// goCloudEventNewEventRe matches Go SDK:
+//
+//	cloudevents.NewEvent()
+var goCloudEventNewEventRe = regexp.MustCompile(`cloudevents\.NewEvent\s*\(\s*\)`)
+
+// goCloudEventSetTypeRe extracts event.SetType("X").
+var goCloudEventSetTypeRe = regexp.MustCompile(`\.SetType\s*\(\s*["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]`)
+
+// goCloudEventSetSourceRe extracts event.SetSource("X").
+var goCloudEventSetSourceRe = regexp.MustCompile(`\.SetSource\s*\(\s*["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]`)
+
+// goCloudEventClientRe matches Go SDK consumer: cloudevents.NewClientHTTP()
+var goCloudEventClientRe = regexp.MustCompile(`cloudevents\.NewClientHTTP\s*\(\s*\)`)
+
+func applyCloudEventEdges(
+	lang, src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Fast-path guard — skip files without CloudEvent tokens.
+	if !strings.Contains(src, "CloudEvent") &&
+		!strings.Contains(src, "cloudevents") &&
+		!strings.Contains(src, "ce-type") &&
+		!strings.Contains(src, "ce-source") {
+		return
+	}
+
+	switch lang {
+	case "python":
+		applyCloudEventPython(src, path, emitEvent, emitEdge)
+	case "javascript", "typescript":
+		applyCloudEventNode(src, path, emitEvent, emitEdge)
+	case "go":
+		applyCloudEventGo(src, path, emitEvent, emitEdge)
+	}
+
+	// HTTP-layer guard: any language — routes that explicitly read ce-type header.
+	// Only fire when the file does NOT already have a CloudEvent SDK constructor
+	// (avoids double-counting) and does reference the header.
+	hasSDKConstructor := pyCloudEventBuilderRe.MatchString(src) ||
+		nodeCloudEventBuilderRe.MatchString(src) ||
+		goCloudEventNewEventRe.MatchString(src)
+	if !hasSDKConstructor && ceHeaderRe.MatchString(src) {
+		applyCloudEventHTTPHeaders(lang, src, path, emitEvent, emitEdge)
+	}
+}
+
+func applyCloudEventPython(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	for _, m := range pyCloudEventBuilderRe.FindAllStringIndex(src, -1) {
+		end := m[1] + 400
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[m[0]:end]
+		ceType := ""
+		if tm := pyCloudEventTypeRe.FindStringSubmatch(window); tm != nil {
+			ceType = tm[1]
+		}
+		ceSource := ""
+		if sm := pyCloudEventSourceRe.FindStringSubmatch(window); sm != nil {
+			ceSource = sm[1]
+		}
+		if ceType == "" {
+			continue
+		}
+		id := cloudEventID(ceSource, ceType)
+		emitEvent(id, "cloudevents", ceSource, ceType, nil)
+		caller := findEnclosingPyFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "cloudevents", "ce_type": ceType, "ce_source": ceSource, "sdk": "cloudevents-python"},
+		)
+	}
+}
+
+func applyCloudEventNode(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	for _, m := range nodeCloudEventBuilderRe.FindAllStringIndex(src, -1) {
+		end := m[1] + 400
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[m[0]:end]
+		ceType := ""
+		if tm := nodeCloudEventTypeRe.FindStringSubmatch(window); tm != nil {
+			ceType = tm[1]
+		}
+		ceSource := ""
+		if sm := nodeCloudEventSourceRe.FindStringSubmatch(window); sm != nil {
+			ceSource = sm[1]
+		}
+		if ceType == "" {
+			continue
+		}
+		id := cloudEventID(ceSource, ceType)
+		emitEvent(id, "cloudevents", ceSource, ceType, nil)
+		caller := findEnclosingNodeFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "cloudevents", "ce_type": ceType, "ce_source": ceSource, "sdk": "cloudevents-js"},
+		)
+	}
+}
+
+func applyCloudEventGo(
+	src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Producer: cloudevents.NewEvent() + SetType + SetSource
+	for _, m := range goCloudEventNewEventRe.FindAllStringIndex(src, -1) {
+		end := m[1] + 400
+		if end > len(src) {
+			end = len(src)
+		}
+		window := src[m[0]:end]
+		ceType := ""
+		if tm := goCloudEventSetTypeRe.FindStringSubmatch(window); tm != nil {
+			ceType = tm[1]
+		}
+		ceSource := ""
+		if sm := goCloudEventSetSourceRe.FindStringSubmatch(window); sm != nil {
+			ceSource = sm[1]
+		}
+		if ceType == "" {
+			continue
+		}
+		id := cloudEventID(ceSource, ceType)
+		emitEvent(id, "cloudevents", ceSource, ceType, nil)
+		caller := findEnclosingGoFunctionName(src, m[0])
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"PUBLISHES_TO",
+			map[string]string{"bus": "cloudevents", "ce_type": ceType, "ce_source": ceSource, "sdk": "cloudevents-go"},
+		)
+	}
+
+	// Consumer: cloudevents.NewClientHTTP() — emit wildcard consumer entity.
+	if goCloudEventClientRe.MatchString(src) {
+		id := cloudEventID("*", "*")
+		emitEvent(id, "cloudevents", "*", "*", map[string]string{"consumer": "cloudevents-http"})
+		caller := findEnclosingGoFunctionName(src, 0)
+		emitEdge(
+			fmt.Sprintf("SCOPE.Function:%s", caller),
+			fmt.Sprintf("%s:%s", eventBusEventKind, id),
+			"SUBSCRIBES_TO",
+			map[string]string{"bus": "cloudevents", "sdk": "cloudevents-go"},
+		)
+	}
+}
+
+// applyCloudEventHTTPHeaders handles the spec-level CloudEvents detection path:
+// any HTTP handler that reads ce-type / ce-source headers without a full SDK.
+func applyCloudEventHTTPHeaders(
+	lang, src, path string,
+	emitEvent func(id, busType, source, detailType string, props map[string]string),
+	emitEdge func(fromID, toID, kind string, props map[string]string),
+) {
+	// Try to extract the literal ce-type and ce-source from the same handler.
+	ceType := ""
+	if m := ceTypeHeaderRe.FindStringSubmatch(src); m != nil {
+		ceType = m[1]
+	}
+	ceSource := ""
+	if m := ceSourceHeaderRe.FindStringSubmatch(src); m != nil {
+		ceSource = m[1]
+	}
+
+	// Only emit a CloudEvent entity if at least ce-type is readable statically.
+	if ceType == "" && !strings.Contains(src, "ce-specversion") {
+		return
+	}
+	if ceType == "" {
+		ceType = "*"
+	}
+
+	id := cloudEventID(ceSource, ceType)
+	emitEvent(id, "cloudevents", ceSource, ceType, map[string]string{"detection": "http-header"})
+
+	// Emit a CLOUDEVENT_FLOWS edge from the handler entity to the event.
+	switch lang {
+	case "python":
+		// Find function that reads the header.
+		for _, m := range ceHeaderRe.FindAllStringIndex(src, -1) {
+			caller := findEnclosingPyFunctionName(src, m[0])
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", caller),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				cloudEventFlowsEdge,
+				map[string]string{"bus": "cloudevents", "detection": "http-header", "ce_type": ceType},
+			)
+			break // one edge per handler
+		}
+	case "javascript", "typescript":
+		for _, m := range ceHeaderRe.FindAllStringIndex(src, -1) {
+			caller := findEnclosingNodeFunctionName(src, m[0])
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", caller),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				cloudEventFlowsEdge,
+				map[string]string{"bus": "cloudevents", "detection": "http-header", "ce_type": ceType},
+			)
+			break
+		}
+	case "go":
+		for _, m := range ceHeaderRe.FindAllStringIndex(src, -1) {
+			caller := findEnclosingGoFunctionName(src, m[0])
+			emitEdge(
+				fmt.Sprintf("SCOPE.Function:%s", caller),
+				fmt.Sprintf("%s:%s", eventBusEventKind, id),
+				cloudEventFlowsEdge,
+				map[string]string{"bus": "cloudevents", "detection": "http-header", "ce_type": ceType},
+			)
+			break
+		}
+	}
+}

--- a/internal/engine/event_bus_edges_test.go
+++ b/internal/engine/event_bus_edges_test.go
@@ -1,0 +1,575 @@
+// Tests for the managed event-bus edge detection pass added by #927.
+//
+// Coverage:
+//
+//  1. AWS EventBridge
+//     - Python boto3 put_events producer → PUBLISHES_TO synthetic event
+//     - Node PutEventsCommand producer → PUBLISHES_TO
+//     - Go PutEventsRequestEntry → PUBLISHES_TO
+//     - Terraform aws_cloudwatch_event_rule → SUBSCRIBES_TO synthetic event
+//     - Terraform aws_cloudwatch_event_target (Lambda ARN) → EVENTBRIDGE_TRIGGERS
+//     - Fixture: rule + target → Lambda from #925 receives EVENTBRIDGE_TRIGGERS edge
+//     - False-positive: plain Python function named put_events (no EventBridge guard) → 0 edges
+//
+//  2. Azure EventGrid
+//     - Python EventGridEvent producer → PUBLISHES_TO
+//     - Python @app.event_grid_trigger consumer → SUBSCRIBES_TO + EVENTGRID_TRIGGERS
+//     - Node EventGridSenderClient producer → PUBLISHES_TO
+//     - C# [EventGridTrigger] consumer → SUBSCRIBES_TO + EVENTGRID_TRIGGERS
+//
+//  3. CNCF CloudEvents
+//     - Python CloudEvent builder → PUBLISHES_TO
+//     - Node new CloudEvent builder → PUBLISHES_TO
+//     - Go cloudevents.NewEvent() + SetType + SetSource → PUBLISHES_TO
+//     - Go cloudevents.NewClientHTTP() consumer → SUBSCRIBES_TO
+//     - HTTP header detection (ce-type) → CLOUDEVENT_FLOWS
+//     - False-positive: plain HTTP handler without ce-type header → 0 edges
+//
+//  4. No-op guards
+//     - Unsupported language (ruby) → unchanged slices
+//     - Empty content → unchanged slices
+//
+// Refs #927.
+package engine
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func runEventBusDetect(t *testing.T, lang, path, src string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	return applyEventBusEdges(lang, path, []byte(src), nil, nil)
+}
+
+func eventBusEntityByID(ents []types.EntityRecord, id string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Kind == eventBusEventKind && ents[i].Name == id {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func requireEventBusEntity(t *testing.T, ents []types.EntityRecord, id, label string) {
+	t.Helper()
+	if eventBusEntityByID(ents, id) == nil {
+		t.Errorf("%s: expected EventBusEvent entity %q; got %v", label, id, entNames(ents))
+	}
+}
+
+func requireEdgeTo(t *testing.T, rels []types.RelationshipRecord, toID, kind, label string) {
+	t.Helper()
+	for _, r := range rels {
+		if r.Kind == kind && r.ToID == toID {
+			return
+		}
+	}
+	t.Errorf("%s: expected %s edge to %q; rels=%v", label, kind, toID, relSummary(rels))
+}
+
+func requireEdgeFromTo(t *testing.T, rels []types.RelationshipRecord, fromID, toID, kind, label string) {
+	t.Helper()
+	for _, r := range rels {
+		if r.Kind == kind && r.FromID == fromID && r.ToID == toID {
+			return
+		}
+	}
+	t.Errorf("%s: expected %s edge from %q to %q; rels=%v", label, kind, fromID, toID, relSummary(rels))
+}
+
+func requireNoEdgeKind(t *testing.T, rels []types.RelationshipRecord, kind, label string) {
+	t.Helper()
+	for _, r := range rels {
+		if r.Kind == kind {
+			t.Errorf("%s: unexpected %s edge: %+v", label, kind, r)
+		}
+	}
+}
+
+func entNames(ents []types.EntityRecord) []string {
+	var out []string
+	for _, e := range ents {
+		out = append(out, e.Kind+":"+e.Name)
+	}
+	return out
+}
+
+func relSummary(rels []types.RelationshipRecord) []string {
+	var out []string
+	for _, r := range rels {
+		out = append(out, r.Kind+"|"+r.FromID+"->"+r.ToID)
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// 1. AWS EventBridge
+// ---------------------------------------------------------------------------
+
+func TestEventBridgePythonProducer(t *testing.T) {
+	src := `
+import boto3
+
+def publish_order(order):
+    client = boto3.client('events', region_name='us-east-1')
+    client.put_events(
+        Entries=[
+            {
+                'Source': 'orders',
+                'DetailType': 'OrderPlaced',
+                'Detail': '{"orderId":"123"}',
+                'EventBusName': 'default',
+            }
+        ]
+    )
+`
+	ents, rels := runEventBusDetect(t, "python", "services/order_svc/events.py", src)
+
+	wantID := "event:eventbridge:orders:OrderPlaced"
+	requireEventBusEntity(t, ents, wantID, "boto3 producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "boto3 producer edge")
+}
+
+func TestEventBridgeNodeProducer(t *testing.T) {
+	src := `
+import { EventBridgeClient, PutEventsCommand } from '@aws-sdk/client-eventbridge';
+
+const client = new EventBridgeClient({ region: 'us-east-1' });
+
+async function emitOrderEvent() {
+  await client.send(new PutEventsCommand({
+    Entries: [
+      {
+        Source: 'order.svc',
+        DetailType: 'OrderPlaced',
+        Detail: JSON.stringify({ orderId: '123' }),
+        EventBusName: 'default',
+      },
+    ],
+  }));
+}
+`
+	ents, rels := runEventBusDetect(t, "typescript", "src/events/order.ts", src)
+
+	wantID := "event:eventbridge:order.svc:OrderPlaced"
+	requireEventBusEntity(t, ents, wantID, "Node PutEventsCommand producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node producer edge")
+}
+
+func TestEventBridgeGoProducer(t *testing.T) {
+	src := `
+package events
+
+import (
+	"context"
+	ebtypes "github.com/aws/aws-sdk-go-v2/service/eventbridge/types"
+)
+
+func PublishShipped(ctx context.Context, orderID string) error {
+	entry := ebtypes.PutEventsRequestEntry{
+		Source:      aws.String("fulfillment"),
+		DetailType:  aws.String("OrderShipped"),
+		Detail:      aws.String(`+"`"+`{"orderId":"`+"`"+`+orderID+`+"`"+`"}`+"`"+`),
+		EventBusName: aws.String("default"),
+	}
+	// ... send
+	return nil
+}
+`
+	ents, rels := runEventBusDetect(t, "go", "pkg/events/ship.go", src)
+
+	wantID := "event:eventbridge:fulfillment:OrderShipped"
+	requireEventBusEntity(t, ents, wantID, "Go producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Go producer edge")
+}
+
+func TestEventBridgeTerraformRuleAndTarget(t *testing.T) {
+	src := `
+resource "aws_cloudwatch_event_rule" "process_order" {
+  name        = "process-order-rule"
+  description = "Route OrderPlaced events to lambda"
+
+  event_pattern = jsonencode({
+    source      = ["orders"]
+    "detail-type" = ["OrderPlaced"]
+  })
+}
+
+resource "aws_cloudwatch_event_target" "lambda_target" {
+  rule = aws_cloudwatch_event_rule.process_order.name
+  arn  = aws_lambda_function.process_order.arn
+}
+`
+	ents, rels := runEventBusDetect(t, "terraform", "infra/eventbridge.tf", src)
+
+	wantEventID := "event:eventbridge:orders:OrderPlaced"
+	requireEventBusEntity(t, ents, wantEventID, "TF rule event entity")
+
+	// Rule should SUBSCRIBES_TO the synthetic event.
+	ruleID := "SCOPE.Component:aws_cloudwatch_event_rule.process_order"
+	requireEdgeFromTo(t, rels, ruleID, eventBusEventKind+":"+wantEventID, "SUBSCRIBES_TO", "TF rule SUBSCRIBES_TO")
+
+	// Target should emit EVENTBRIDGE_TRIGGERS to the Lambda.
+	lambdaTarget := serverlessFunctionKind + ":" + lambdaFunctionID("process_order")
+	requireEdgeTo(t, rels, lambdaTarget, eventBridgeTriggersEdge, "TF target EVENTBRIDGE_TRIGGERS")
+}
+
+func TestEventBridgeTerraformLambdaSubscribesToEvent(t *testing.T) {
+	// When both rule and target are in the same file, the Lambda entity should
+	// also get a SUBSCRIBES_TO edge into the event.
+	src := `
+resource "aws_cloudwatch_event_rule" "order_rule" {
+  name          = "order-rule"
+  event_pattern = "{\"source\":[\"orders\"],\"detail-type\":[\"OrderPlaced\"]}"
+}
+
+resource "aws_cloudwatch_event_target" "order_target" {
+  rule = aws_cloudwatch_event_rule.order_rule.name
+  arn  = aws_lambda_function.order_handler.arn
+}
+`
+	ents, rels := runEventBusDetect(t, "hcl", "infra/main.tf", src)
+
+	wantEventID := "event:eventbridge:orders:OrderPlaced"
+	requireEventBusEntity(t, ents, wantEventID, "HCL rule event entity")
+
+	lambdaID := serverlessFunctionKind + ":" + lambdaFunctionID("order_handler")
+	requireEdgeTo(t, rels, lambdaID, eventBridgeTriggersEdge, "HCL EVENTBRIDGE_TRIGGERS")
+	requireEdgeFromTo(t, rels, lambdaID, eventBusEventKind+":"+wantEventID, "SUBSCRIBES_TO", "Lambda SUBSCRIBES_TO event")
+}
+
+func TestEventBridgeFalsePositive_PlainPutEvents(t *testing.T) {
+	// A function named put_events that is NOT an EventBridge call — guard should
+	// prevent detection because the EventBridge guard tokens are absent.
+	src := `
+def send_data(entries):
+    # This just prints entries, nothing to do with EventBridge
+    for e in entries:
+        print(e)
+`
+	ents, rels := runEventBusDetect(t, "python", "utils/sender.py", src)
+	if len(ents) != 0 {
+		t.Errorf("false positive: expected 0 entities, got %v", entNames(ents))
+	}
+	if len(rels) != 0 {
+		t.Errorf("false positive: expected 0 rels, got %v", relSummary(rels))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Azure EventGrid
+// ---------------------------------------------------------------------------
+
+func TestEventGridPythonProducer(t *testing.T) {
+	src := `
+from azure.eventgrid import EventGridPublisherClient, EventGridEvent
+
+def publish_inventory(topic_key):
+    client = EventGridPublisherClient(topic_endpoint, AzureKeyCredential(topic_key))
+    events = [
+        EventGridEvent(
+            subject='/inventory/low',
+            event_type='Inventory.LowStock',
+            data={'sku': 'ABC-123'},
+            data_version='1.0'
+        )
+    ]
+    client.send(events)
+`
+	ents, rels := runEventBusDetect(t, "python", "svc/inventory/events.py", src)
+
+	wantID := "event:eventgrid:/inventory/low:Inventory.LowStock"
+	requireEventBusEntity(t, ents, wantID, "EventGrid Python producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Python producer edge")
+}
+
+func TestEventGridPythonConsumer(t *testing.T) {
+	src := `
+import azure.functions as func
+
+app = func.FunctionApp()
+
+@app.event_grid_trigger(name='event')
+async def handle_inventory_event(event: func.EventGridEvent):
+    data = event.get_json()
+`
+	ents, rels := runEventBusDetect(t, "python", "func/inventory_handler/__init__.py", src)
+
+	// Should emit wildcard EventBusEvent + SUBSCRIBES_TO + EVENTGRID_TRIGGERS.
+	wildcardID := "event:eventgrid:*:*"
+	requireEventBusEntity(t, ents, wildcardID, "EventGrid consumer wildcard entity")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "EventGrid consumer SUBSCRIBES_TO")
+	azureTarget := serverlessFunctionKind + ":" + azureFunctionID("handle_inventory_event")
+	requireEdgeTo(t, rels, azureTarget, eventGridTriggersEdge, "EventGrid EVENTGRID_TRIGGERS")
+}
+
+func TestEventGridNodeProducer(t *testing.T) {
+	src := `
+import { EventGridSenderClient } from '@azure/eventgrid';
+
+const client = new EventGridSenderClient(endpoint, new AzureKeyCredential(key), 'EventGrid');
+
+async function emitOrderShipped() {
+  await client.sendEvents([{
+    eventType: 'Order.Shipped',
+    subject: '/orders/shipped',
+    dataVersion: '1.0',
+    data: { orderId: '123' },
+  }]);
+}
+`
+	ents, rels := runEventBusDetect(t, "javascript", "src/events/shipping.js", src)
+
+	wantID := "event:eventgrid:/orders/shipped:Order.Shipped"
+	requireEventBusEntity(t, ents, wantID, "EventGrid Node producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Node producer edge")
+}
+
+func TestEventGridCSharpConsumer(t *testing.T) {
+	src := `
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.EventGrid.Models;
+
+public static class InventoryFunction
+{
+    [FunctionName("InventoryHandler")]
+    public static void Run(
+        [EventGridTrigger] EventGridEvent gridEvent,
+        ILogger log)
+    {
+        log.LogInformation(gridEvent.Data.ToString());
+    }
+}
+`
+	ents, rels := runEventBusDetect(t, "csharp", "Functions/InventoryFunction.cs", src)
+
+	wildcardID := "event:eventgrid:*:*"
+	requireEventBusEntity(t, ents, wildcardID, "C# EventGridTrigger consumer entity")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "C# EventGridTrigger SUBSCRIBES_TO")
+	azureTarget := serverlessFunctionKind + ":" + azureFunctionID("Run")
+	requireEdgeTo(t, rels, azureTarget, eventGridTriggersEdge, "C# EVENTGRID_TRIGGERS")
+}
+
+// ---------------------------------------------------------------------------
+// 3. CNCF CloudEvents
+// ---------------------------------------------------------------------------
+
+func TestCloudEventPythonProducer(t *testing.T) {
+	src := `
+from cloudevents.http import CloudEvent, to_structured
+
+def emit_shipment_event(order_id: str):
+    event = CloudEvent({
+        'type': 'com.example.order.shipped',
+        'source': '/shop/orders',
+        'id': order_id,
+    })
+    headers, body = to_structured(event)
+    # POST to channel
+`
+	ents, rels := runEventBusDetect(t, "python", "svc/shipping/events.py", src)
+
+	wantID := "event:cloudevents:/shop/orders:com.example.order.shipped"
+	requireEventBusEntity(t, ents, wantID, "Python CloudEvent producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Python CloudEvent PUBLISHES_TO")
+}
+
+func TestCloudEventNodeProducer(t *testing.T) {
+	src := `
+const { CloudEvent, emitterFor, httpTransport } = require('cloudevents');
+
+async function publishEvent() {
+  const event = new CloudEvent({
+    type: 'com.example.user.created',
+    source: '/users/signup',
+    data: { userId: 'abc123' },
+  });
+  const emit = emitterFor(httpTransport('http://receiver'));
+  await emit(event);
+}
+`
+	ents, rels := runEventBusDetect(t, "javascript", "src/events/user.js", src)
+
+	wantID := "event:cloudevents:/users/signup:com.example.user.created"
+	requireEventBusEntity(t, ents, wantID, "Node CloudEvent producer")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node CloudEvent PUBLISHES_TO")
+}
+
+func TestCloudEventGoProducer(t *testing.T) {
+	src := `
+package main
+
+import (
+	"context"
+	cloudevents "github.com/cloudevents/sdk-go/v2"
+)
+
+func SendEvent(ctx context.Context) error {
+	c, err := cloudevents.NewClientHTTP()
+	if err != nil {
+		return err
+	}
+	event := cloudevents.NewEvent()
+	event.SetSource("https://example.com/producer")
+	event.SetType("com.example.data.created")
+	event.SetData(cloudevents.ApplicationJSON, map[string]string{"key": "value"})
+	return c.Send(ctx, event)
+}
+`
+	ents, rels := runEventBusDetect(t, "go", "cmd/producer/main.go", src)
+
+	wantProducerID := "event:cloudevents:https://example.com/producer:com.example.data.created"
+	requireEventBusEntity(t, ents, wantProducerID, "Go CloudEvent producer entity")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wantProducerID, "PUBLISHES_TO", "Go CloudEvent PUBLISHES_TO")
+
+	// NewClientHTTP() also registers a consumer wildcard.
+	wildcardID := "event:cloudevents:*:*"
+	requireEventBusEntity(t, ents, wildcardID, "Go CloudEvent client consumer entity")
+	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "Go CloudEvent SUBSCRIBES_TO")
+}
+
+func TestCloudEventHTTPHeaderDetection(t *testing.T) {
+	// Plain HTTP handler that reads CloudEvents headers but no SDK.
+	src := `
+package handler
+
+import "net/http"
+
+func HandleEvent(w http.ResponseWriter, r *http.Request) {
+	ceType := r.Header.Get("ce-type")
+	ceSource := r.Header.Get("ce-source")
+	ceSpecVersion := r.Header.Get("ce-specversion")
+	if ceType == "" {
+		http.Error(w, "not a cloudevent", 400)
+		return
+	}
+	// process
+}
+`
+	_, rels := runEventBusDetect(t, "go", "handlers/event.go", src)
+
+	// Should emit at least a wildcard CLOUDEVENT_FLOWS edge because no type literal.
+	found := false
+	for _, r := range rels {
+		if r.Kind == cloudEventFlowsEdge {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected CLOUDEVENT_FLOWS edge from HTTP-header handler; rels=%v", relSummary(rels))
+	}
+}
+
+func TestCloudEventFalsePositive_PlainHTTPNoHeaders(t *testing.T) {
+	// A plain HTTP handler that does NOT reference any CloudEvent headers.
+	src := `
+package handler
+
+import "net/http"
+
+func ServeHealthCheck(w http.ResponseWriter, r *http.Request) {
+	w.WriteHeader(200)
+	w.Write([]byte("ok"))
+}
+`
+	ents, rels := runEventBusDetect(t, "go", "handlers/health.go", src)
+	if len(ents) != 0 {
+		t.Errorf("false positive: expected 0 entities, got %v", entNames(ents))
+	}
+	requireNoEdgeKind(t, rels, cloudEventFlowsEdge, "no CLOUDEVENT_FLOWS on plain HTTP")
+}
+
+// ---------------------------------------------------------------------------
+// 4. No-op guards
+// ---------------------------------------------------------------------------
+
+func TestEventBusEdgesUnsupportedLanguage(t *testing.T) {
+	src := `
+def handle(req):
+    pass
+`
+	ents, rels := runEventBusDetect(t, "ruby", "app.rb", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("ruby should be a no-op; ents=%v rels=%v", entNames(ents), relSummary(rels))
+	}
+}
+
+func TestEventBusEdgesEmptyContent(t *testing.T) {
+	ents, rels := applyEventBusEdges("python", "file.py", nil, nil, nil)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("empty content should be a no-op; ents=%v rels=%v", entNames(ents), relSummary(rels))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Cross-repo acceptance: producer in one file, Terraform rule in another.
+// ---------------------------------------------------------------------------
+
+func TestEventBridgeCrossRepoLinkage(t *testing.T) {
+	// Simulate producer in a Python microservice + Terraform rule in infra repo.
+	// Both files emit the same event ID, enabling cross-repo linking.
+	pyProducer := `
+import boto3
+
+def place_order(order_id):
+    client = boto3.client('events')
+    client.put_events(Entries=[{
+        'Source': 'orders',
+        'DetailType': 'OrderPlaced',
+        'Detail': '{}',
+    }])
+`
+	tfRule := `
+resource "aws_cloudwatch_event_rule" "process_order" {
+  name          = "process-order-rule"
+  event_pattern = "{\"source\":[\"orders\"],\"detail-type\":[\"OrderPlaced\"]}"
+}
+
+resource "aws_cloudwatch_event_target" "proc_target" {
+  rule = aws_cloudwatch_event_rule.process_order.name
+  arn  = aws_lambda_function.process_order.arn
+}
+`
+	entsA, relsA := runEventBusDetect(t, "python", "services/orders/publish.py", pyProducer)
+	entsB, relsB := runEventBusDetect(t, "terraform", "infra/eventbridge.tf", tfRule)
+
+	wantID := "event:eventbridge:orders:OrderPlaced"
+
+	// Both repos emit the same synthetic entity ID.
+	if eventBusEntityByID(entsA, wantID) == nil {
+		t.Errorf("cross-repo: producer repo missing entity %q; entities=%v", wantID, entNames(entsA))
+	}
+	if eventBusEntityByID(entsB, wantID) == nil {
+		t.Errorf("cross-repo: infra repo missing entity %q; entities=%v", wantID, entNames(entsB))
+	}
+
+	// Producer side has PUBLISHES_TO.
+	found := false
+	for _, r := range relsA {
+		if r.Kind == "PUBLISHES_TO" && strings.HasSuffix(r.ToID, wantID) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("cross-repo: no PUBLISHES_TO from producer; rels=%v", relSummary(relsA))
+	}
+
+	// Infra side has EVENTBRIDGE_TRIGGERS.
+	triggerFound := false
+	for _, r := range relsB {
+		if r.Kind == eventBridgeTriggersEdge {
+			triggerFound = true
+		}
+	}
+	if !triggerFound {
+		t.Errorf("cross-repo: no EVENTBRIDGE_TRIGGERS in infra repo; rels=%v", relSummary(relsB))
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -73,6 +73,17 @@ const (
 	// Both the invoker side (CALLS) and the handler side (HANDLES) emit the
 	// same entity ID so the import-channel linker joins them cross-repo.
 	EntityKindServerlessFunction EntityKind = "SCOPE.ServerlessFunction"
+
+	// #927: Managed event-bus entities. EventBusEvent is a synthetic entity
+	// representing a routable event type on a managed event bus. Cross-repo
+	// identity = bus-prefixed event key:
+	//   `event:eventbridge:<source>:<detail-type>`
+	//   `event:eventgrid:<topic>:<event-type>`
+	//   `event:cloudevents:<ce-source>:<ce-type>`
+	// Both producers (PUBLISHES_TO) and consumers / rules (SUBSCRIBES_TO) emit
+	// the same synthetic ID so the existing import-channel linker joins them
+	// without any new linker code.
+	EntityKindEventBusEvent EntityKind = "SCOPE.EventBusEvent"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -119,6 +130,8 @@ func AllEntityKinds() []EntityKind {
 		EntityKindConstraint,
 		// #925:
 		EntityKindServerlessFunction,
+		// #927:
+		EntityKindEventBusEvent,
 	}
 }
 
@@ -247,6 +260,22 @@ const (
 	// counterpart of CALLS — a handler function HANDLES a ServerlessFunction.
 	// CALLS is already declared above (RelationshipKindCalls) and is reused here.
 	RelationshipKindHandles RelationshipKind = "HANDLES"
+
+	// #927: Managed event-bus edges. Both sides emit a synthetic EventBusEvent
+	// entity with the same bus-prefixed key, so the import-channel linker joins
+	// producer ↔ rule/consumer without new linker code.
+	//   PUBLISHES_TO  : producer call site → EventBusEvent  (reuses existing constant)
+	//   SUBSCRIBES_TO : rule / trigger handler → EventBusEvent  (reuses existing constant)
+	// The two edge kinds above are already declared:
+	//   RelationshipKindPublishesTo  ("PUBLISHES_TO")
+	//   RelationshipKindSubscribesTo ("SUBSCRIBES_TO")
+	// New kinds introduced for #927:
+	//   EVENTBRIDGE_TRIGGERS : EventBridge rule entity → aws-lambda target
+	//   EVENTGRID_TRIGGERS   : EventGrid subscription → Azure Function target
+	//   CLOUDEVENT_FLOWS     : CloudEvent route → CloudEvent route (HTTP metadata match)
+	RelationshipKindEventBridgeTriggers RelationshipKind = "EVENTBRIDGE_TRIGGERS"
+	RelationshipKindEventGridTriggers   RelationshipKind = "EVENTGRID_TRIGGERS"
+	RelationshipKindCloudEventFlows     RelationshipKind = "CLOUDEVENT_FLOWS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -306,6 +335,10 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindGRPCHandles,
 		// #925 serverless:
 		RelationshipKindHandles,
+		// #927 managed event buses:
+		RelationshipKindEventBridgeTriggers,
+		RelationshipKindEventGridTriggers,
+		RelationshipKindCloudEventFlows,
 	}
 }
 

--- a/verify2/fixtures/runtime-eventbus/cloudevents_producer.py
+++ b/verify2/fixtures/runtime-eventbus/cloudevents_producer.py
@@ -1,0 +1,29 @@
+"""
+CloudEvents producer — fixture for #927 CloudEvents acceptance.
+
+Acceptance: CloudEvent(type='com.example.order.shipped', source='/shop/orders')
+builder → PUBLISHES_TO synthetic event:cloudevents:/shop/orders:com.example.order.shipped.
+
+Also validates 0 false positives on plain HTTP routes.
+"""
+from cloudevents.http import CloudEvent, to_structured
+import requests
+
+
+def emit_shipment_event(order_id: str) -> None:
+    """Emit a CloudEvent for a shipped order."""
+    event = CloudEvent(
+        {
+            "type": "com.example.order.shipped",
+            "source": "/shop/orders",
+            "id": order_id,
+        }
+    )
+    headers, body = to_structured(event)
+    # In production: POST headers+body to the channel endpoint.
+    _ = headers, body
+
+
+def plain_http_handler(request: dict) -> dict:
+    """Plain HTTP handler — must NOT trigger CloudEvent detection."""
+    return {"status": "ok", "data": request.get("data")}

--- a/verify2/fixtures/runtime-eventbus/eventgrid_consumer.py
+++ b/verify2/fixtures/runtime-eventbus/eventgrid_consumer.py
@@ -1,0 +1,18 @@
+"""
+Azure EventGrid consumer — fixture for #927 EventGrid trigger detection.
+
+Acceptance: AzureFunction subscribed via EventGridTrigger attribute links
+to #940's Azure Function entities (EVENTGRID_TRIGGERS edge).
+"""
+import azure.functions as func
+
+
+app = func.FunctionApp()
+
+
+@app.event_grid_trigger(name="event")
+async def handle_inventory_alert(event: func.EventGridEvent) -> None:
+    """Azure Function triggered by EventGrid events."""
+    data = event.get_json()
+    sku = data.get("sku", "unknown")
+    _ = sku

--- a/verify2/fixtures/runtime-eventbus/eventgrid_producer.py
+++ b/verify2/fixtures/runtime-eventbus/eventgrid_producer.py
@@ -1,0 +1,24 @@
+"""
+Azure EventGrid producer — fixture for #927 EventGrid acceptance.
+
+Acceptance: EventGridPublisherClient.send(events) → PUBLISHES_TO
+synthetic event:eventgrid:<subject>:<event-type>.
+"""
+from azure.core.credentials import AzureKeyCredential
+from azure.eventgrid import EventGridPublisherClient, EventGridEvent
+
+
+def publish_inventory_alert(topic_endpoint: str, topic_key: str, sku: str) -> None:
+    """Publish an Inventory.LowStock event to EventGrid."""
+    client = EventGridPublisherClient(
+        topic_endpoint, AzureKeyCredential(topic_key)
+    )
+    events = [
+        EventGridEvent(
+            subject="/inventory/low",
+            event_type="Inventory.LowStock",
+            data={"sku": sku, "quantity": 0},
+            data_version="1.0",
+        )
+    ]
+    client.send(events)

--- a/verify2/fixtures/runtime-eventbus/producer.py
+++ b/verify2/fixtures/runtime-eventbus/producer.py
@@ -1,0 +1,22 @@
+"""
+EventBridge producer — fixture for #927 acceptance criteria.
+
+Acceptance: Python publisher `events.put_events(Entries=[{'Source':'orders','DetailType':'OrderPlaced',...}])`
+→ PUBLISHES_TO synthetic `event:eventbridge:orders:OrderPlaced`.
+"""
+import boto3
+
+
+def place_order(order_id: str, amount: float) -> None:
+    """Publish an OrderPlaced event to EventBridge."""
+    client = boto3.client("events", region_name="us-east-1")
+    client.put_events(
+        Entries=[
+            {
+                "Source": "orders",
+                "DetailType": "OrderPlaced",
+                "Detail": f'{{"orderId":"{order_id}","amount":{amount}}}',
+                "EventBusName": "default",
+            }
+        ]
+    )

--- a/verify2/fixtures/runtime-eventbus/rule.tf
+++ b/verify2/fixtures/runtime-eventbus/rule.tf
@@ -1,0 +1,18 @@
+# EventBridge rule fixture — #927 acceptance criteria.
+#
+# Acceptance: Terraform aws_cloudwatch_event_rule with event_pattern matching
+# 'orders' + 'OrderPlaced' and target aws_lambda_function.process_order →
+# SUBSCRIBES_TO same synthetic event:eventbridge:orders:OrderPlaced;
+# EVENTBRIDGE_TRIGGERS edge into the lambda handler.
+
+resource "aws_cloudwatch_event_rule" "process_order" {
+  name        = "process-order-rule"
+  description = "Route OrderPlaced events to the process_order Lambda"
+
+  event_pattern = "{\"source\":[\"orders\"],\"detail-type\":[\"OrderPlaced\"]}"
+}
+
+resource "aws_cloudwatch_event_target" "order_lambda" {
+  rule = aws_cloudwatch_event_rule.process_order.name
+  arn  = aws_lambda_function.process_order.arn
+}


### PR DESCRIPTION
## What

Adds a single append-only engine pass (`applyEventBusEdges`) that detects managed event-bus publish/subscribe patterns across three cloud providers and emits cross-repo linkage edges. Wired after `applyRedisPubSubEdges` in `detector.go`.

## New schema additions (`internal/types/kinds.go`)

| Kind / Edge | Description |
|---|---|
| `SCOPE.EventBusEvent` | Synthetic entity keyed by `event:<bus>:<source>:<detail-type>` — same ID on both producer and consumer sides |
| `EVENTBRIDGE_TRIGGERS` | EventBridge rule entity → AWS Lambda `ServerlessFunction` (reuses `aws-lambda:*` IDs from #925) |
| `EVENTGRID_TRIGGERS` | EventGrid consumer handler → Azure Function `ServerlessFunction` |
| `CLOUDEVENT_FLOWS` | HTTP handler reading CloudEvents headers → `EventBusEvent` |

## Detection scope (`internal/engine/event_bus_edges.go`)

**AWS EventBridge**
- Python `boto3.client('events').put_events(Entries=[{Source,DetailType}])` → `PUBLISHES_TO`
- Node/TS `new PutEventsCommand({Entries:[{Source,DetailType}]})` → `PUBLISHES_TO`
- Go `ebtypes.PutEventsRequestEntry{Source,DetailType}` → `PUBLISHES_TO`
- Terraform `aws_cloudwatch_event_rule` with `event_pattern` (jsonencode + escaped-JSON string formats) → `SUBSCRIBES_TO` + `EVENTBRIDGE_TRIGGERS` to Lambda target
- CDK TypeScript `eventPattern:{source:[...], 'detail-type':[...]}` + `addTarget()`
- `serverless.yml` `eventBridge` stanza

**Azure EventGrid**
- Python `azure-eventgrid` `EventGridPublisherClient.send(events)` → `PUBLISHES_TO`
- Node `@azure/eventgrid` `EventGridSenderClient.sendEvents([...])` → `PUBLISHES_TO`
- C# `EventGridPublisherClient.SendEventsAsync` → `PUBLISHES_TO`
- Python `@app.event_grid_trigger` consumer → `SUBSCRIBES_TO` + `EVENTGRID_TRIGGERS`
- C# `[EventGridTrigger]` binding → `SUBSCRIBES_TO` + `EVENTGRID_TRIGGERS`

**CNCF CloudEvents (spec-level, language-agnostic)**
- Python `CloudEvent({type,source})` SDK builder → `PUBLISHES_TO`
- Node `new CloudEvent({type,source})` → `PUBLISHES_TO`
- Go `cloudevents.NewEvent()` + `SetType`/`SetSource` → `PUBLISHES_TO`; `NewClientHTTP()` → `SUBSCRIBES_TO`
- HTTP-layer fallback: handler reading `ce-type`/`ce-source` headers → `CLOUDEVENT_FLOWS`

## Acceptance criteria met

1. Python `boto3 put_events(Entries=[{Source:'orders', DetailType:'OrderPlaced'}])` → `PUBLISHES_TO` synthetic `event:eventbridge:orders:OrderPlaced` ✓
2. Terraform `aws_cloudwatch_event_rule` matching `orders`/`OrderPlaced` + `aws_cloudwatch_event_target` → `aws_lambda_function.process_order`: `SUBSCRIBES_TO` same synthetic + `EVENTBRIDGE_TRIGGERS` edge to Lambda ✓
3. Cross-repo: Python producer in one file + Terraform rule in another both emit the same `event:eventbridge:orders:OrderPlaced` ID → import-channel linker joins without new code ✓
4. EventGrid producer → consumer pair: `PUBLISHES_TO` + `EVENTGRID_TRIGGERS` across Python and C# ✓
5. CloudEvent HTTP route emits `SCOPE.EventBusEvent` ✓
6. 0 false positives on plain HTTP handlers without CE headers ✓
7. 0 regressions — all engine tests pass ✓

## Tests

16 new unit tests in `internal/engine/event_bus_edges_test.go` covering all three buses, producer/consumer/IaC paths, false-positive guards, cross-repo linkage, no-op guards (unsupported language, empty content).

5 fixture files in `verify2/fixtures/runtime-eventbus/`.

## Scope guard

Append-only — pass never modifies or removes existing entities or edges. Builds on `aws-lambda:*` entity IDs from #925 for EventBridge→Lambda links without reinventing them.

Closes #927