### PR TITLE
feat(topology): broaden topology surface to Redis, serverless, and async task entities (#946)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -376,12 +376,18 @@ function applyTopologyMockFilters(
 
   return {
     ...data,
-    topics: protocols.has('kafka') ? data.topics : [],
-    queues: data.queues.filter((q) => protocols.has(q.broker as TopologyProtocol)),
-    channels: data.channels.filter((c) => protocols.has(c.channel_type as TopologyProtocol)),
-    graphql_subscriptions: protocols.has('graphql_subscription') ? data.graphql_subscriptions : [],
-    nats_subjects: protocols.has('nats') ? data.nats_subjects : [],
-    transforms: data.transforms,
+    topics: protocols.has('kafka') ? (data.topics ?? []) : [],
+    queues: (data.queues ?? []).filter((q) => {
+      const proto = (q.id?.startsWith('stream:redis:') ? 'redis-stream'
+        : q.id?.startsWith('task:') ? 'task-queue'
+        : q.broker) as TopologyProtocol
+      return protocols.has(proto) || protocols.has(q.broker as TopologyProtocol)
+    }),
+    channels: (data.channels ?? []).filter((c) => protocols.has(c.channel_type as TopologyProtocol)),
+    graphql_subscriptions: protocols.has('graphql_subscription') ? (data.graphql_subscriptions ?? []) : [],
+    nats_subjects: protocols.has('nats') ? (data.nats_subjects ?? []) : [],
+    transforms: data.transforms ?? [],
+    functions: (data.functions ?? []).filter(() => protocols.has('serverless')),
   }
 }
 

--- a/dashboard/src/components/topology/ChannelTrack.tsx
+++ b/dashboard/src/components/topology/ChannelTrack.tsx
@@ -3,6 +3,12 @@ import { RepoChip } from '@/components/shared/RepoChip'
 import { PROTOCOL_COLORS } from '@/lib/colors'
 import type { ChannelNode, GraphQLSubscription } from '@/types/api'
 
+/** Support both *_ids (TypeScript type) and plain * (REST API) field names */
+function getIds(node: unknown, idsKey: string, plainKey: string): string[] {
+  const r = node as Record<string, unknown>
+  return (r[idsKey] as string[] | undefined) ?? (r[plainKey] as string[] | undefined) ?? []
+}
+
 interface ChannelTrackProps {
   channels: ChannelNode[]
   graphqlSubscriptions: GraphQLSubscription[]
@@ -45,8 +51,8 @@ export function ChannelTrack({ channels, graphqlSubscriptions, selectedId, onSel
             channelType={ch.channel_type}
             repo={ch.repo}
             endpoint={ch.server_endpoint}
-            emitterCount={ch.emitter_ids.length}
-            subscriberCount={ch.subscriber_ids.length}
+            emitterCount={getIds(ch, 'emitter_ids', 'emitters').length}
+            subscriberCount={getIds(ch, 'subscriber_ids', 'subscribers').length}
             isSelected={ch.id === selectedId}
             onSelect={onSelect}
           />
@@ -58,8 +64,8 @@ export function ChannelTrack({ channels, graphqlSubscriptions, selectedId, onSel
             label={sub.label}
             repo={sub.repo}
             returnType={sub.return_type}
-            publisherCount={sub.publisher_ids.length}
-            subscriberCount={sub.subscriber_ids.length}
+            publisherCount={getIds(sub, 'publisher_ids', 'publishers').length}
+            subscriberCount={getIds(sub, 'subscriber_ids', 'subscribers').length}
             isSelected={sub.id === selectedId}
             onSelect={onSelect}
           />
@@ -72,7 +78,7 @@ export function ChannelTrack({ channels, graphqlSubscriptions, selectedId, onSel
 interface ChannelCardProps {
   id: string
   label: string
-  channelType: 'websocket' | 'sse' | 'graphql_subscription'
+  channelType: 'websocket' | 'sse' | 'graphql_subscription' | 'redis_pubsub'
   repo: string
   endpoint?: string
   emitterCount: number

--- a/dashboard/src/components/topology/ProtocolFilterChips.tsx
+++ b/dashboard/src/components/topology/ProtocolFilterChips.tsx
@@ -139,6 +139,40 @@ function ProtocolShapeGlyph({
           <path d="M3,0.5 H5 V3 H7.5 V5 H5 V7.5 H3 V5 H0.5 V3 H3 Z" fill={fill} />
         </svg>
       )
+    // ── new runtime entities (#946) ─────────────────────────────────────
+    case 'redis':
+    case 'redis_pubsub':
+      // Ring shape — concentric circles (pub/sub broadcast feel)
+      return (
+        <svg width={size} height={size} viewBox="0 0 8 8" aria-hidden>
+          <circle cx="4" cy="4" r="3.5" fill="none" stroke={fill} strokeWidth="1.5" />
+          <circle cx="4" cy="4" r="1.5" fill={fill} />
+        </svg>
+      )
+    case 'redis-stream':
+      // Chevron / right-arrow (stream direction)
+      return (
+        <svg width={size} height={size} viewBox="0 0 8 8" aria-hidden>
+          <polyline points="1,1 5,4 1,7" fill="none" stroke={fill} strokeWidth="1.5" strokeLinejoin="round" />
+          <polyline points="4,1 8,4 4,7" fill="none" stroke={fill} strokeWidth="1.5" strokeLinejoin="round" />
+        </svg>
+      )
+    case 'task-queue':
+      // Clock shape — 12/3/6/9 tick marks
+      return (
+        <svg width={size} height={size} viewBox="0 0 8 8" aria-hidden>
+          <circle cx="4" cy="4" r="3.5" fill="none" stroke={fill} strokeWidth="1" />
+          <line x1="4" y1="1" x2="4" y2="2.2" stroke={fill} strokeWidth="1" />
+          <line x1="4" y1="4" x2="5.8" y2="4" stroke={fill} strokeWidth="1" />
+        </svg>
+      )
+    case 'serverless':
+      // Lightning bolt
+      return (
+        <svg width={size} height={size} viewBox="0 0 8 8" aria-hidden>
+          <polygon points="4.5,0.5 2,4.5 4,4.5 3.5,7.5 6,3.5 4,3.5" fill={fill} />
+        </svg>
+      )
     default:
       return (
         <svg width={size} height={size} viewBox="0 0 8 8" aria-hidden>

--- a/dashboard/src/components/topology/TopologyMap.tsx
+++ b/dashboard/src/components/topology/TopologyMap.tsx
@@ -121,8 +121,8 @@ export function TopologyMap({ layout, data, selectedId, onSelectTopic }: Topolog
   }, [onSelectTopic])
 
   // Build producer/consumer entity positions alongside their topics
-  const allProducerStubs = data.producers
-  const allConsumerStubs = data.consumers
+  const allProducerStubs = data.producers ?? {}
+  const allConsumerStubs = data.consumers ?? {}
 
   if (layout.nodes.length === 0) {
     return (
@@ -174,14 +174,23 @@ export function TopologyMap({ layout, data, selectedId, onSelectTopic }: Topolog
 
           // Collect producer_ids and consumer_ids for this node
           const topicData =
-            data.topics.find((t) => t.id === node.id) ??
-            data.queues.find((q) => q.id === node.id) ??
-            data.nats_subjects.find((n) => n.id === node.id)
+            (data.topics ?? []).find((t) => t.id === node.id) ??
+            (data.queues ?? []).find((q) => q.id === node.id) ??
+            (data.nats_subjects ?? []).find((n) => n.id === node.id) ??
+            (data.functions ?? []).find((f) => f.id === node.id)
 
           if (!topicData) return null
 
-          const producerIds = topicData.producer_ids
-          const consumerIds = topicData.consumer_ids
+          // FunctionNode uses invoker_ids/handler_ids; all other node types use
+          // producer_ids/consumer_ids. Fall back to empty arrays when absent.
+          const producerIds: string[] =
+            ('producer_ids' in topicData ? topicData.producer_ids : null) ??
+            ('invoker_ids' in topicData ? (topicData as { invoker_ids: string[] }).invoker_ids : null) ??
+            []
+          const consumerIds: string[] =
+            ('consumer_ids' in topicData ? topicData.consumer_ids : null) ??
+            ('handler_ids' in topicData ? (topicData as { handler_ids: string[] }).handler_ids : null) ??
+            []
 
           const producerEndpoints = getSpokeEndpoints(node.x, node.y, producerIds, 'in')
           const consumerEndpoints = getSpokeEndpoints(node.x, node.y, consumerIds, 'out')

--- a/dashboard/src/hooks/topology/useProtocolFilters.ts
+++ b/dashboard/src/hooks/topology/useProtocolFilters.ts
@@ -2,14 +2,22 @@ import { useSearchParams } from 'react-router-dom'
 import type { TopologyProtocol } from '@/types/api'
 
 const ALL_PROTOCOLS: TopologyProtocol[] = [
+  // Broker protocols
   'kafka',
   'rabbitmq',
   'sqs',
   'pubsub',
   'nats',
+  // Channel protocols
   'websocket',
   'sse',
   'graphql_subscription',
+  // New runtime entities (#946)
+  'redis',
+  'redis-stream',
+  'redis_pubsub',
+  'task-queue',
+  'serverless',
 ]
 
 /**

--- a/dashboard/src/hooks/topology/useTopicDetail.ts
+++ b/dashboard/src/hooks/topology/useTopicDetail.ts
@@ -1,7 +1,7 @@
 import { useMemo } from 'react'
-import type { TopologyResponse, TopicNode, QueueNode, NatsSubject, ChannelNode, GraphQLSubscription, TopologyEntityStub } from '@/types/api'
+import type { TopologyResponse, TopicNode, QueueNode, NatsSubject, ChannelNode, GraphQLSubscription, FunctionNode, TopologyEntityStub } from '@/types/api'
 
-export type AnyTopologyNode = TopicNode | QueueNode | NatsSubject | ChannelNode | GraphQLSubscription
+export type AnyTopologyNode = TopicNode | QueueNode | NatsSubject | ChannelNode | GraphQLSubscription | FunctionNode
 
 export interface TopicDetailData {
   node: AnyTopologyNode | null
@@ -24,35 +24,45 @@ export function useTopicDetail(
 
     // Find the node across all collections
     const allNodes: AnyTopologyNode[] = [
-      ...data.topics,
-      ...data.queues,
-      ...data.nats_subjects,
-      ...data.channels,
-      ...data.graphql_subscriptions,
+      ...(data.topics ?? []),
+      ...(data.queues ?? []),
+      ...(data.nats_subjects ?? []),
+      ...(data.channels ?? []),
+      ...(data.graphql_subscriptions ?? []),
+      ...(data.functions ?? []),
     ]
     const node = allNodes.find((n) => n.id === topicId) ?? null
 
     if (!node) return { node: null, producers: [], consumers: [], transformsTo: [] }
 
     // Resolve producer/consumer stubs
+    const allProducers = data.producers ?? {}
+    const allConsumers = data.consumers ?? {}
     const resolveIds = (ids: string[]): TopologyEntityStub[] =>
       ids.flatMap((id) => {
-        const stub = data.producers[id] ?? data.consumers[id]
+        const stub = allProducers[id] ?? allConsumers[id]
         return stub ? [stub] : []
       })
 
     let producerIds: string[] = []
     let consumerIds: string[] = []
 
-    if ('producer_ids' in node) producerIds = node.producer_ids
-    if ('consumer_ids' in node) consumerIds = node.consumer_ids
+    if ('producer_ids' in node) producerIds = (node as TopicNode | QueueNode).producer_ids
+    if ('consumer_ids' in node) consumerIds = (node as TopicNode | QueueNode).consumer_ids
     if ('emitter_ids' in node) producerIds = (node as ChannelNode).emitter_ids
     if ('subscriber_ids' in node) consumerIds = (node as ChannelNode | GraphQLSubscription).subscriber_ids
     if ('publisher_ids' in node) producerIds = (node as GraphQLSubscription).publisher_ids
+    // FunctionNode uses invoker_ids / handler_ids
+    if ('invoker_ids' in node) producerIds = (node as FunctionNode).invoker_ids
+    if ('handler_ids' in node) consumerIds = (node as FunctionNode).handler_ids
 
     // Resolve topic→topic transforms
     const transformIds = 'transforms_to' in node ? (node as TopicNode).transforms_to : []
-    const allBrokerNodes = [...data.topics, ...data.queues, ...data.nats_subjects]
+    const allBrokerNodes = [
+      ...(data.topics ?? []),
+      ...(data.queues ?? []),
+      ...(data.nats_subjects ?? []),
+    ]
     const transformsTo = transformIds.flatMap((id) => {
       const found = allBrokerNodes.find((n) => n.id === id)
       return found ? [found] : []

--- a/dashboard/src/hooks/topology/useTopologyLayout.ts
+++ b/dashboard/src/hooks/topology/useTopologyLayout.ts
@@ -81,49 +81,115 @@ export function useTopologyLayout(
 
     const showAll = activeProtocols.size === 0
 
+    // Helper: the REST API returns `producers`/`consumers` (plural, no _ids suffix)
+    // while the TypeScript interface uses `producer_ids`/`consumer_ids`.
+    // Support both forms so the layout works against real API responses and mock data.
+    function getProducers(node: Record<string, unknown>): string[] {
+      return (node.producer_ids as string[] | undefined) ?? (node.producers as string[] | undefined) ?? []
+    }
+    function getConsumers(node: Record<string, unknown>): string[] {
+      return (node.consumer_ids as string[] | undefined) ?? (node.consumers as string[] | undefined) ?? []
+    }
+    function getEmitters(node: Record<string, unknown>): string[] {
+      return (node.emitter_ids as string[] | undefined) ?? (node.emitters as string[] | undefined) ?? []
+    }
+    function getSubscribers(node: Record<string, unknown>): string[] {
+      return (node.subscriber_ids as string[] | undefined) ?? (node.subscribers as string[] | undefined) ?? []
+    }
+
     // Kafka topics
     if (showAll || activeProtocols.has('kafka')) {
-      for (const t of data.topics) {
-        nodes.push(buildNode(t.id, t.label, 'kafka', t.repo, t.producer_ids.length + t.consumer_ids.length))
-        for (const pid of t.producer_ids) edges.push({ source: pid, target: t.id, kind: 'producer' })
-        for (const cid of t.consumer_ids) edges.push({ source: t.id, target: cid, kind: 'consumer' })
-        for (const tid of t.transforms_to) edges.push({ source: t.id, target: tid, kind: 'transform' })
+      for (const t of (data.topics ?? [])) {
+        const pids = getProducers(t as unknown as Record<string, unknown>)
+        const cids = getConsumers(t as unknown as Record<string, unknown>)
+        const xids: string[] = (t.transforms_to ?? []) as string[]
+        nodes.push(buildNode(t.id, t.label, 'kafka', t.repo, pids.length + cids.length))
+        for (const pid of pids) edges.push({ source: pid, target: t.id, kind: 'producer' })
+        for (const cid of cids) edges.push({ source: t.id, target: cid, kind: 'consumer' })
+        for (const tid of xids) edges.push({ source: t.id, target: tid, kind: 'transform' })
       }
     }
 
-    // Queues (RabbitMQ, SQS, Pub/Sub)
-    for (const q of data.queues) {
-      const protocol = q.broker as TopologyProtocol
+    // Queues (RabbitMQ, SQS, Pub/Sub, Redis Streams, task-queues)
+    for (const q of (data.queues ?? [])) {
+      // Derive the display protocol: broker field maps to TopologyProtocol.
+      // For Redis Streams and task queues, the broker field carries the
+      // framework name; we map it to the canonical TopologyProtocol.
+      const qRaw = q as unknown as Record<string, unknown>
+      const qLabel = (qRaw.label as string) ?? ''
+      let protocol: TopologyProtocol = (q.broker as TopologyProtocol) ?? 'sqs'
+      if (qLabel.startsWith('stream:redis:')) {
+        protocol = 'redis-stream'
+      } else if (
+        qLabel.startsWith('task:') ||
+        q.broker === 'dramatiq' ||
+        q.broker === 'rq' ||
+        q.broker === 'celery' ||
+        q.broker === 'hangfire' ||
+        q.broker?.startsWith('quartz')
+      ) {
+        protocol = 'task-queue'
+      } else if (q.broker === 'redis') {
+        protocol = 'redis'
+      }
       if (!showAll && !activeProtocols.has(protocol)) continue
-      nodes.push(buildNode(q.id, q.label, protocol, q.repo, q.producer_ids.length + q.consumer_ids.length))
-      for (const pid of q.producer_ids) edges.push({ source: pid, target: q.id, kind: 'producer' })
-      for (const cid of q.consumer_ids) edges.push({ source: q.id, target: cid, kind: 'consumer' })
+      const pids = getProducers(qRaw)
+      const cids = getConsumers(qRaw)
+      nodes.push(buildNode(q.id, q.label, protocol, q.repo, pids.length + cids.length))
+      for (const pid of pids) edges.push({ source: pid, target: q.id, kind: 'producer' })
+      for (const cid of cids) edges.push({ source: q.id, target: cid, kind: 'consumer' })
     }
 
     // NATS subjects
     if (showAll || activeProtocols.has('nats')) {
-      for (const n of data.nats_subjects) {
-        nodes.push(buildNode(n.id, n.label, 'nats', n.repo, n.producer_ids.length + n.consumer_ids.length))
-        for (const pid of n.producer_ids) edges.push({ source: pid, target: n.id, kind: 'producer' })
-        for (const cid of n.consumer_ids) edges.push({ source: n.id, target: cid, kind: 'consumer' })
+      for (const n of (data.nats_subjects ?? [])) {
+        const nRaw = n as unknown as Record<string, unknown>
+        const pids = getProducers(nRaw)
+        const cids = getConsumers(nRaw)
+        nodes.push(buildNode(n.id, n.label, 'nats', n.repo, pids.length + cids.length))
+        for (const pid of pids) edges.push({ source: pid, target: n.id, kind: 'producer' })
+        for (const cid of cids) edges.push({ source: n.id, target: cid, kind: 'consumer' })
       }
     }
 
-    // WebSocket/SSE channels
-    for (const c of data.channels) {
-      const protocol = c.channel_type as TopologyProtocol
+    // WebSocket/SSE/Redis pub-sub channels
+    for (const c of (data.channels ?? [])) {
+      // channel_type from backend: 'websocket' | 'sse' | 'graphql_subscription' | 'redis_pubsub' | 'pubsub'
+      const cRaw = c as unknown as Record<string, unknown>
+      const cLabel = (cRaw.label as string) ?? ''
+      let protocol: TopologyProtocol = c.channel_type as TopologyProtocol
+      if (c.channel_type === 'pubsub' || c.channel_type === 'redis_pubsub' || cLabel.startsWith('channel:redis-pubsub:')) {
+        protocol = 'redis_pubsub'
+      }
       if (!showAll && !activeProtocols.has(protocol)) continue
-      nodes.push(buildNode(c.id, c.label, protocol, c.repo, c.emitter_ids.length + c.subscriber_ids.length))
-      for (const eid of c.emitter_ids) edges.push({ source: eid, target: c.id, kind: 'producer' })
-      for (const sid of c.subscriber_ids) edges.push({ source: c.id, target: sid, kind: 'consumer' })
+      const eids = getEmitters(cRaw)
+      const sids = getSubscribers(cRaw)
+      nodes.push(buildNode(c.id, c.label, protocol, c.repo, eids.length + sids.length))
+      for (const eid of eids) edges.push({ source: eid, target: c.id, kind: 'producer' })
+      for (const sid of sids) edges.push({ source: c.id, target: sid, kind: 'consumer' })
     }
 
     // GraphQL subscriptions
     if (showAll || activeProtocols.has('graphql_subscription')) {
-      for (const g of data.graphql_subscriptions) {
-        nodes.push(buildNode(g.id, g.label, 'graphql_subscription', g.repo, g.publisher_ids.length + g.subscriber_ids.length))
-        for (const pid of g.publisher_ids) edges.push({ source: pid, target: g.id, kind: 'producer' })
-        for (const sid of g.subscriber_ids) edges.push({ source: g.id, target: sid, kind: 'consumer' })
+      for (const g of (data.graphql_subscriptions ?? [])) {
+        const gRaw = g as unknown as Record<string, unknown>
+        const pids: string[] = (gRaw.publisher_ids as string[] | undefined) ?? (gRaw.publishers as string[] | undefined) ?? []
+        const sids: string[] = (gRaw.subscriber_ids as string[] | undefined) ?? (gRaw.subscribers as string[] | undefined) ?? []
+        nodes.push(buildNode(g.id, g.label, 'graphql_subscription', g.repo, pids.length + sids.length))
+        for (const pid of pids) edges.push({ source: pid, target: g.id, kind: 'producer' })
+        for (const sid of sids) edges.push({ source: g.id, target: sid, kind: 'consumer' })
+      }
+    }
+
+    // Serverless functions (#946)
+    if (showAll || activeProtocols.has('serverless')) {
+      for (const f of (data.functions ?? [])) {
+        const fRaw = f as unknown as Record<string, unknown>
+        const iids: string[] = (fRaw.invoker_ids as string[] | undefined) ?? (fRaw.invokers as string[] | undefined) ?? []
+        const hids: string[] = (fRaw.handler_ids as string[] | undefined) ?? (fRaw.handlers as string[] | undefined) ?? []
+        nodes.push(buildNode(f.id, f.label, 'serverless', f.repo, iids.length + hids.length))
+        for (const iid of iids) edges.push({ source: iid, target: f.id, kind: 'producer' })
+        for (const hid of hids) edges.push({ source: f.id, target: hid, kind: 'consumer' })
       }
     }
 

--- a/dashboard/src/hooks/topology/useTopologySearch.ts
+++ b/dashboard/src/hooks/topology/useTopologySearch.ts
@@ -6,7 +6,7 @@ export interface TopologySearchResult {
   label: string
   protocol: string
   repo: string
-  kind: 'topic' | 'queue' | 'channel' | 'nats' | 'graphql'
+  kind: 'topic' | 'queue' | 'channel' | 'nats' | 'graphql' | 'function'
 }
 
 /**
@@ -32,25 +32,29 @@ export function useTopologySearch(
       return 0
     }
 
-    for (const t of data.topics) {
+    for (const t of (data.topics ?? [])) {
       const s = score(t.label)
       if (s > 0) results.push({ id: t.id, label: t.label, protocol: 'kafka', repo: t.repo, kind: 'topic', score: s })
     }
-    for (const q_ of data.queues) {
+    for (const q_ of (data.queues ?? [])) {
       const s = score(q_.label)
       if (s > 0) results.push({ id: q_.id, label: q_.label, protocol: q_.broker, repo: q_.repo, kind: 'queue', score: s })
     }
-    for (const n of data.nats_subjects) {
+    for (const n of (data.nats_subjects ?? [])) {
       const s = score(n.label)
       if (s > 0) results.push({ id: n.id, label: n.label, protocol: 'nats', repo: n.repo, kind: 'nats', score: s })
     }
-    for (const c of data.channels) {
+    for (const c of (data.channels ?? [])) {
       const s = score(c.label)
       if (s > 0) results.push({ id: c.id, label: c.label, protocol: c.channel_type, repo: c.repo, kind: 'channel', score: s })
     }
-    for (const g of data.graphql_subscriptions) {
+    for (const g of (data.graphql_subscriptions ?? [])) {
       const s = score(g.label)
       if (s > 0) results.push({ id: g.id, label: g.label, protocol: 'graphql_subscription', repo: g.repo, kind: 'graphql', score: s })
+    }
+    for (const f of (data.functions ?? [])) {
+      const s = score(f.label)
+      if (s > 0) results.push({ id: f.id, label: f.label, protocol: 'serverless', repo: f.repo, kind: 'function', score: s })
     }
 
     return results

--- a/dashboard/src/lib/colors.ts
+++ b/dashboard/src/lib/colors.ts
@@ -108,12 +108,13 @@ export interface ProtocolColorSpec {
   /** CSS hex for canvas rendering (SVG / canvas cannot use Tailwind classes) */
   hex: string
   /** Accessible shape name for protocol nodes */
-  shape: 'square' | 'circle' | 'hexagon' | 'diamond' | 'triangle' | 'star' | 'pentagon' | 'cross'
+  shape: 'square' | 'circle' | 'hexagon' | 'diamond' | 'triangle' | 'star' | 'pentagon' | 'cross' | 'chevron' | 'bolt' | 'clock' | 'ring'
   /** Human-readable label */
   label: string
 }
 
 export const PROTOCOL_COLORS: Record<TopologyProtocol, ProtocolColorSpec> = {
+  // ── existing ──────────────────────────────────────────────────────────────
   kafka:                { bg: 'bg-cyan-900/40',    text: 'text-cyan-300',    border: 'border-cyan-700',    hex: '#22d3ee', shape: 'square',   label: 'Kafka' },
   rabbitmq:             { bg: 'bg-amber-900/40',   text: 'text-amber-300',   border: 'border-amber-700',   hex: '#fbbf24', shape: 'circle',   label: 'RabbitMQ' },
   sqs:                  { bg: 'bg-orange-900/40',  text: 'text-orange-300',  border: 'border-orange-700',  hex: '#fb923c', shape: 'hexagon',  label: 'SQS' },
@@ -122,6 +123,17 @@ export const PROTOCOL_COLORS: Record<TopologyProtocol, ProtocolColorSpec> = {
   websocket:            { bg: 'bg-teal-900/40',    text: 'text-teal-300',    border: 'border-teal-700',    hex: '#2dd4bf', shape: 'triangle', label: 'WebSocket' },
   sse:                  { bg: 'bg-indigo-900/40',  text: 'text-indigo-300',  border: 'border-indigo-700',  hex: '#818cf8', shape: 'star',     label: 'SSE' },
   graphql_subscription: { bg: 'bg-pink-900/40',    text: 'text-pink-300',    border: 'border-pink-700',    hex: '#f472b6', shape: 'cross',    label: 'GraphQL Sub' },
+  // ── new runtime entities (#946) ───────────────────────────────────────────
+  /** Redis pub/sub channels (channel:redis-pubsub:*) */
+  redis_pubsub:         { bg: 'bg-red-900/40',     text: 'text-red-300',     border: 'border-red-700',     hex: '#f87171', shape: 'ring',     label: 'Redis P/S' },
+  /** Redis Streams (stream:redis:*) */
+  'redis-stream':       { bg: 'bg-rose-900/40',    text: 'text-rose-300',    border: 'border-rose-700',    hex: '#fb7185', shape: 'chevron',  label: 'Redis Stream' },
+  /** Top-level redis broker protocol (folded view) */
+  redis:                { bg: 'bg-red-900/40',     text: 'text-red-300',     border: 'border-red-700',     hex: '#f87171', shape: 'ring',     label: 'Redis' },
+  /** Async task queues (dramatiq / RQ / Hangfire / Quartz) */
+  'task-queue':         { bg: 'bg-lime-900/40',    text: 'text-lime-300',    border: 'border-lime-700',    hex: '#a3e635', shape: 'clock',    label: 'Task Queue' },
+  /** Serverless functions (AWS Lambda / GCF / Azure) */
+  serverless:           { bg: 'bg-yellow-900/40',  text: 'text-yellow-300',  border: 'border-yellow-700',  hex: '#fde047', shape: 'bolt',     label: 'Serverless' },
 }
 
 export function protocolColor(protocol: TopologyProtocol): ProtocolColorSpec {

--- a/dashboard/src/routes/topology.tsx
+++ b/dashboard/src/routes/topology.tsx
@@ -58,7 +58,7 @@ export function TopologyRoute() {
 
   // Determine if a GraphQL subscription is selected
   const selectedGqlSub = selectedId
-    ? data?.graphql_subscriptions.find((g) => g.id === selectedId)
+    ? (data?.graphql_subscriptions ?? []).find((g) => g.id === selectedId)
     : undefined
 
   const gqlPublishers = selectedGqlSub
@@ -77,8 +77,8 @@ export function TopologyRoute() {
   // Is the selected item a channel/GQL (shown in channel track, not topology map)?
   const isChannelSelected =
     selectedId &&
-    (data?.channels.some((c) => c.id === selectedId) ||
-      data?.graphql_subscriptions.some((g) => g.id === selectedId))
+    ((data?.channels ?? []).some((c) => c.id === selectedId) ||
+      (data?.graphql_subscriptions ?? []).some((g) => g.id === selectedId))
 
   if (!group) {
     return (
@@ -165,11 +165,12 @@ export function TopologyRoute() {
               <TopologyErrorState error={error} onRetry={() => void refetch()} />
             </div>
           ) : !data || (
-            data.topics.length === 0 &&
-            data.queues.length === 0 &&
-            data.nats_subjects.length === 0 &&
-            data.channels.length === 0 &&
-            data.graphql_subscriptions.length === 0
+            (data.topics ?? []).length === 0 &&
+            (data.queues ?? []).length === 0 &&
+            (data.nats_subjects ?? []).length === 0 &&
+            (data.channels ?? []).length === 0 &&
+            (data.graphql_subscriptions ?? []).length === 0 &&
+            (data.functions ?? []).length === 0
           ) ? (
             <div className="flex-1 flex items-center justify-center">
               <TopologyEmptyState hasFilters={!isAllActive} onClearFilters={setAll} />
@@ -187,10 +188,10 @@ export function TopologyRoute() {
               </div>
 
               {/* Channel track (WebSocket/SSE/GraphQL) */}
-              {(data.channels.length > 0 || data.graphql_subscriptions.length > 0) && (
+              {((data.channels ?? []).length > 0 || (data.graphql_subscriptions ?? []).length > 0) && (
                 <ChannelTrack
-                  channels={data.channels}
-                  graphqlSubscriptions={data.graphql_subscriptions}
+                  channels={data.channels ?? []}
+                  graphqlSubscriptions={data.graphql_subscriptions ?? []}
                   selectedId={isChannelSelected ? selectedId : null}
                   onSelect={setSelectedTopic}
                 />

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -264,9 +264,10 @@ export interface SwimLaneEntry {
 // Surface 3 — Broker Topology
 // ────────────────────────────────────────────────────────────────────────────
 
-export type BrokerProtocol = 'kafka' | 'rabbitmq' | 'sqs' | 'pubsub' | 'nats'
-export type ChannelProtocol = 'websocket' | 'sse' | 'graphql_subscription'
-export type TopologyProtocol = BrokerProtocol | ChannelProtocol
+export type BrokerProtocol = 'kafka' | 'rabbitmq' | 'sqs' | 'pubsub' | 'nats' | 'redis' | 'redis-stream' | 'task-queue'
+export type ChannelProtocol = 'websocket' | 'sse' | 'graphql_subscription' | 'redis_pubsub'
+export type ServerlessProtocol = 'serverless'
+export type TopologyProtocol = BrokerProtocol | ChannelProtocol | ServerlessProtocol
 
 /** A lightweight entity stub carried in topology responses (avoids re-fetching full Entity) */
 export interface TopologyEntityStub {
@@ -334,10 +335,25 @@ export interface TopologyTransform {
   repo: string
 }
 
+/** A serverless function node — AWS Lambda, GCP Cloud Functions, Azure Functions */
+export interface FunctionNode {
+  id: string
+  repo: string
+  label: string
+  /** Cloud provider: 'aws-lambda' | 'gcp-cloudfunction' | 'azure-function' | 'serverless' */
+  provider: string
+  /** Entities that invoke (CALLS) this function */
+  invoker_ids: string[]
+  /** Entities that handle (HANDLES) this function */
+  handler_ids: string[]
+}
+
 export interface TopologyResponse {
   topics: TopicNode[]
   queues: QueueNode[]
   channels: ChannelNode[]
+  /** Serverless functions (#946) */
+  functions: FunctionNode[]
   graphql_subscriptions: GraphQLSubscription[]
   nats_subjects: NatsSubject[]
   transforms: TopologyTransform[]

--- a/internal/dashboard/handlers_topology.go
+++ b/internal/dashboard/handlers_topology.go
@@ -17,10 +17,11 @@ import (
 
 // Broker entity kinds (suffix after stripping the optional "SCOPE." prefix).
 const (
-	kindMessageTopic    = "MessageTopic"
-	kindQueue           = "Queue"
-	kindChannelEvent    = "ChannelEvent"
-	kindSubscription    = "Subscription" // GraphQL subscriptions
+	kindMessageTopic       = "MessageTopic"
+	kindQueue              = "Queue"
+	kindChannelEvent       = "ChannelEvent"
+	kindSubscription       = "Subscription"       // GraphQL subscriptions
+	kindServerlessFunction = "ServerlessFunction" // SCOPE.ServerlessFunction stripped
 )
 
 // topologyResponse is the wire shape for both topology endpoints.
@@ -32,6 +33,60 @@ type topologyResponse struct {
 	NatsSubjects         []map[string]any `json:"nats_subjects"`
 	GraphQLSubscriptions []map[string]any `json:"graphql_subscriptions"`
 	Transforms           []map[string]any `json:"transforms"`
+	Functions            []map[string]any `json:"functions"`
+}
+
+// classifyTopologyBucket maps an entity (by kind + name + properties) to
+// one of the topology buckets.  Returns "" when the entity should be
+// ignored by the topology surface.
+//
+// NOTE: `name` is the graph.Entity.Name field (human-readable / canonical
+// identifier), NOT the hashed graph.Entity.ID.  Synthetic runtime entities
+// emitted by the engine passes (redis_pubsub_edges, serverless_edges, etc.)
+// store the semantic prefix in the Name field (e.g. "channel:redis-pubsub:foo",
+// "aws-lambda:OrderProcessor") rather than in the hashed ID.
+//
+// Bucket values: "topic" | "queue" | "channel" | "function" | "subscription"
+func classifyTopologyBucket(kind, name string, props map[string]string) string {
+	stripped := dashStripScopePrefix(kind)
+
+	// --- Existing kinds (order matters: check specific first) ---
+	switch stripped {
+	case kindMessageTopic:
+		return "topic"
+	case kindChannelEvent:
+		return "channel"
+	case kindServerlessFunction:
+		return "function"
+	case kindSubscription:
+		return "subscription"
+	}
+
+	// --- Name-prefix classification (new runtime extractors, #930 / #925 / #941) ---
+	// These synthetic entities use the semantic name as a cross-repo key.
+	switch {
+	case strings.HasPrefix(name, "channel:redis-pubsub:"):
+		return "channel"
+	case strings.HasPrefix(name, "stream:redis:"):
+		return "queue"
+	case strings.HasPrefix(name, "aws-lambda:"),
+		strings.HasPrefix(name, "gcp-cloudfunction:"),
+		strings.HasPrefix(name, "azure-function:"):
+		return "function"
+	case strings.HasPrefix(name, "task:"):
+		return "queue"
+	}
+
+	// --- Properties-based classification (channel_type = pubsub/stream) ---
+	if stripped == kindQueue {
+		switch props["channel_type"] {
+		case "pubsub":
+			return "channel" // Redis pub/sub folded into channel track
+		}
+		return "queue"
+	}
+
+	return ""
 }
 
 // handleTopology — GET /api/topology/{group}
@@ -79,6 +134,7 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 		NatsSubjects:         []map[string]any{},
 		GraphQLSubscriptions: []map[string]any{},
 		Transforms:           []map[string]any{},
+		Functions:            []map[string]any{},
 	}
 
 	for _, r := range sortedRepos(grp) {
@@ -86,13 +142,15 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 			continue
 		}
 
-		// For each broker entity, collect producers and consumers from edges.
+		// For each entity, classify into a topology bucket and collect edges.
+		// classifyTopologyBucket uses the entity Name (not hashed ID) because
+		// synthetic runtime entities store the semantic prefix in the Name field.
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
-			kind := dashStripScopePrefix(e.Kind)
+			bucket := classifyTopologyBucket(e.Kind, e.Name, e.Properties)
 
-			switch kind {
-			case kindMessageTopic:
+			switch bucket {
+			case "topic":
 				producers, consumers, transformsTo := brokerEdges(r, e.ID)
 				entry := map[string]any{
 					"id":            dashPrefixedID(r.Slug, e.ID),
@@ -105,14 +163,21 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 				}
 				resp.Topics = append(resp.Topics, entry)
 
-			case kindQueue:
+			case "queue":
 				producers, consumers, _ := brokerEdges(r, e.ID)
 				broker := e.Properties["broker"]
+				if broker == "" {
+					// Fall back to inferring from the entity Name prefix.
+					broker = inferBrokerFromName(e.Name)
+				}
+				// Async task queues carry framework info instead of a broker name.
+				framework := e.Properties["framework"]
 				entry := map[string]any{
 					"id":        dashPrefixedID(r.Slug, e.ID),
 					"repo":      r.Slug,
 					"label":     e.Name,
 					"broker":    broker,
+					"framework": framework,
 					"producers": producers,
 					"consumers": consumers,
 				}
@@ -126,11 +191,18 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 					resp.Queues = append(resp.Queues, entry)
 				}
 
-			case kindChannelEvent:
+			case "channel":
 				emitters, subscribers := channelEdges(r, e.ID)
 				channelType := e.Properties["channel_type"]
 				if channelType == "" {
 					channelType = inferChannelType(e.Kind)
+					if channelType == "websocket" && strings.HasPrefix(e.Name, "channel:redis-pubsub:") {
+						channelType = "redis_pubsub"
+					}
+				}
+				// Normalize redis pub/sub channel_type for frontend protocol matching.
+				if channelType == "pubsub" && strings.HasPrefix(e.Name, "channel:redis-pubsub:") {
+					channelType = "redis_pubsub"
 				}
 				entry := map[string]any{
 					"id":           dashPrefixedID(r.Slug, e.ID),
@@ -142,7 +214,23 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 				}
 				resp.Channels = append(resp.Channels, entry)
 
-			case kindSubscription:
+			case "function":
+				invokers, handlers := serverlessEdges(r, e.ID)
+				provider := e.Properties["provider"]
+				if provider == "" {
+					provider = inferProviderFromID(e.ID)
+				}
+				entry := map[string]any{
+					"id":       dashPrefixedID(r.Slug, e.ID),
+					"repo":     r.Slug,
+					"label":    e.Name,
+					"provider": provider,
+					"invokers": invokers,
+					"handlers": handlers,
+				}
+				resp.Functions = append(resp.Functions, entry)
+
+			case "subscription":
 				// GraphQL subscriptions — emitted by applyGraphQLSubscriptionSynthesis.
 				publishers, subscribers := graphqlSubEdges(r, e.ID)
 				entry := map[string]any{
@@ -171,14 +259,6 @@ func collectTopologyResponse(grp *DashGroup) topologyResponse {
 	}
 
 	return resp
-}
-
-// collectTopology is retained for callers that only need the three core
-// buckets (topics, queues, channels). It delegates to collectTopologyResponse
-// for consistency.
-func collectTopology(grp *DashGroup) (topics, queues, channels []map[string]any) {
-	resp := collectTopologyResponse(grp)
-	return resp.Topics, resp.Queues, resp.Channels
 }
 
 // brokerEdges returns producers, consumers, and TRANSFORMS targets for a
@@ -217,7 +297,9 @@ func brokerEdges(r *DashRepo, entityID string) (producers, consumers, transforms
 	return
 }
 
-// channelEdges returns emitters and subscribers for a ChannelEvent entity.
+// channelEdges returns emitters and subscribers for a ChannelEvent or Redis
+// pub/sub entity.  Redis pub/sub uses PUBLISHES_TO / SUBSCRIBES_TO (same as
+// brokers) so we also include those edge kinds here.
 func channelEdges(r *DashRepo, entityID string) (emitters, subscribers []string) {
 	emitters = []string{}
 	subscribers = []string{}
@@ -230,6 +312,39 @@ func channelEdges(r *DashRepo, entityID string) (emitters, subscribers []string)
 		case "WS_SUBSCRIBES_TO", "STREAMS_FROM", "GRAPHQL_SUBSCRIBES":
 			if rel.ToID == entityID {
 				subscribers = append(subscribers, dashPrefixedID(r.Slug, rel.FromID))
+			}
+		// Redis pub/sub and similar emit PUBLISHES_TO / SUBSCRIBES_TO.
+		case "PUBLISHES_TO":
+			if rel.ToID == entityID {
+				emitters = append(emitters, dashPrefixedID(r.Slug, rel.FromID))
+			}
+		case "SUBSCRIBES_TO":
+			if rel.ToID == entityID {
+				subscribers = append(subscribers, dashPrefixedID(r.Slug, rel.FromID))
+			}
+			if rel.FromID == entityID {
+				subscribers = append(subscribers, dashPrefixedID(r.Slug, rel.ToID))
+			}
+		}
+	}
+	return
+}
+
+// serverlessEdges returns invokers (callers) and handlers for a
+// ServerlessFunction entity.  Invokers arrive via CALLS edges; handlers via
+// HANDLES edges.
+func serverlessEdges(r *DashRepo, entityID string) (invokers, handlers []string) {
+	invokers = []string{}
+	handlers = []string{}
+	for _, rel := range r.Doc.Relationships {
+		switch rel.Kind {
+		case "CALLS":
+			if rel.ToID == entityID {
+				invokers = append(invokers, dashPrefixedID(r.Slug, rel.FromID))
+			}
+		case "HANDLES":
+			if rel.ToID == entityID {
+				handlers = append(handlers, dashPrefixedID(r.Slug, rel.FromID))
 			}
 		}
 	}
@@ -266,5 +381,42 @@ func inferChannelType(kind string) string {
 		return "sse"
 	default:
 		return "websocket"
+	}
+}
+
+// inferBrokerFromName guesses the broker name from the entity Name prefix.
+// Used when the "broker" property is absent (e.g. Redis Streams, task queues).
+func inferBrokerFromName(name string) string {
+	switch {
+	case strings.HasPrefix(name, "stream:redis:"):
+		return "redis"
+	case strings.HasPrefix(name, "task:dramatiq:"):
+		return "dramatiq"
+	case strings.HasPrefix(name, "task:rq:"):
+		return "rq"
+	case strings.HasPrefix(name, "task:celery:"):
+		return "celery"
+	case strings.HasPrefix(name, "task:hangfire:"):
+		return "hangfire"
+	case strings.HasPrefix(name, "task:quartz"):
+		return "quartz"
+	case strings.HasPrefix(name, "task:"):
+		return "task-queue"
+	default:
+		return ""
+	}
+}
+
+// inferProviderFromID guesses the cloud provider from the entity ID prefix.
+func inferProviderFromID(id string) string {
+	switch {
+	case strings.HasPrefix(id, "aws-lambda:"):
+		return "aws-lambda"
+	case strings.HasPrefix(id, "gcp-cloudfunction:"):
+		return "gcp-cloudfunction"
+	case strings.HasPrefix(id, "azure-function:"):
+		return "azure-function"
+	default:
+		return "serverless"
 	}
 }

--- a/internal/dashboard/handlers_topology_test.go
+++ b/internal/dashboard/handlers_topology_test.go
@@ -1,0 +1,315 @@
+package dashboard
+
+// handlers_topology_test.go — unit tests for the broadened collectTopology
+// function (#946: Redis pub/sub, Redis Streams, serverless, async tasks).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// classifyTopologyBucket — uses entity Name (not hashed ID)
+// ---------------------------------------------------------------------------
+
+func TestClassifyTopologyBucket(t *testing.T) {
+	cases := []struct {
+		kind   string
+		name   string // entity Name, not hashed ID
+		props  map[string]string
+		expect string
+	}{
+		// Existing kinds — pass any name; classification is by kind
+		{"MessageTopic", "UserCreated", nil, "topic"},
+		{"Queue", "orders", map[string]string{"broker": "rabbitmq"}, "queue"},
+		{"ChannelEvent", "chat-events", nil, "channel"},
+		{"SCOPE.Queue", "some-queue", nil, "queue"},
+		// New Name-prefix classifications
+		{"SCOPE.Queue", "channel:redis-pubsub:orders", nil, "channel"},
+		{"SCOPE.Queue", "channel:redis-pubsub:notifications", map[string]string{"channel_type": "pubsub"}, "channel"},
+		{"SCOPE.Queue", "stream:redis:events", nil, "queue"},
+		{"SCOPE.Queue", "task:dramatiq:send_email", nil, "queue"},
+		{"SCOPE.Queue", "task:rq:process_order", nil, "queue"},
+		{"SCOPE.Queue", "task:hangfire:BackgroundJob", nil, "queue"},
+		// ServerlessFunction: matched by kind
+		{"SCOPE.ServerlessFunction", "aws-lambda:OrderProcessor", nil, "function"},
+		{"SCOPE.ServerlessFunction", "gcp-cloudfunction:onUserCreate", nil, "function"},
+		{"SCOPE.ServerlessFunction", "azure-function:HttpTrigger", nil, "function"},
+		// Name-prefix serverless (when kind is already ServerlessFunction)
+		{"SCOPE.ServerlessFunction", "aws-lambda:fn", nil, "function"},
+		// Unrelated entities
+		{"Function", "myFunc", nil, ""},
+		{"Class", "MyClass", nil, ""},
+	}
+
+	for _, tc := range cases {
+		got := classifyTopologyBucket(tc.kind, tc.name, tc.props)
+		if got != tc.expect {
+			t.Errorf("classifyTopologyBucket(%q, %q, %v) = %q, want %q", tc.kind, tc.name, tc.props, got, tc.expect)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// inferBrokerFromName
+// ---------------------------------------------------------------------------
+
+func TestInferBrokerFromName(t *testing.T) {
+	cases := []struct {
+		name   string
+		expect string
+	}{
+		{"stream:redis:orders", "redis"},
+		{"task:dramatiq:send_email", "dramatiq"},
+		{"task:rq:process_order", "rq"},
+		{"task:hangfire:Job.Execute", "hangfire"},
+		{"task:quartz:MyJob", "quartz"},
+		{"task:quartz.net:MyJob", "quartz"},
+		{"task:unknown-framework:job", "task-queue"},
+		{"aws-lambda:fn", ""},
+		{"channel:redis-pubsub:orders", ""},
+	}
+	for _, tc := range cases {
+		got := inferBrokerFromName(tc.name)
+		if got != tc.expect {
+			t.Errorf("inferBrokerFromName(%q) = %q, want %q", tc.name, got, tc.expect)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectTopology — Redis pub/sub channels
+// ---------------------------------------------------------------------------
+
+func TestCollectTopology_RedisPubSub(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				// Entity ID is a hash (as stored by the engine); Name carries the semantic prefix.
+				ID:         "abcd1234",
+				Name:       "channel:redis-pubsub:notifications",
+				Kind:       "SCOPE.Queue",
+				SourceFile: "",
+				Language:   "python",
+				Properties: map[string]string{
+					"broker":       "redis",
+					"channel_type": "pubsub",
+				},
+			},
+			{
+				ID:         "fn:publisher",
+				Name:       "publisher",
+				Kind:       "SCOPE.Function",
+				SourceFile: "app/notify.py",
+			},
+			{
+				ID:         "fn:subscriber",
+				Name:       "subscriber",
+				Kind:       "SCOPE.Function",
+				SourceFile: "app/handler.py",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:publisher", ToID: "abcd1234", Kind: "PUBLISHES_TO"},
+			{ID: "r2", FromID: "fn:subscriber", ToID: "abcd1234", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	topics, queues, channels, functions := collectTopology(grp)
+	if len(topics) != 0 {
+		t.Errorf("expected 0 topics, got %d", len(topics))
+	}
+	if len(queues) != 0 {
+		t.Errorf("expected 0 queues, got %d", len(queues))
+	}
+	if len(functions) != 0 {
+		t.Errorf("expected 0 functions, got %d", len(functions))
+	}
+	if len(channels) != 1 {
+		t.Fatalf("expected 1 channel, got %d", len(channels))
+	}
+	ch := channels[0]
+	// Redis pub/sub channel_type is normalized to "redis_pubsub" for frontend
+	// protocol matching (#946).
+	if ch["channel_type"] != "redis_pubsub" {
+		t.Errorf("channel_type = %q, want redis_pubsub", ch["channel_type"])
+	}
+	emitters, _ := ch["emitters"].([]string)
+	subscribers, _ := ch["subscribers"].([]string)
+	if len(emitters) != 1 {
+		t.Errorf("expected 1 emitter, got %d", len(emitters))
+	}
+	if len(subscribers) != 1 {
+		t.Errorf("expected 1 subscriber, got %d", len(subscribers))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectTopology — Redis Streams
+// ---------------------------------------------------------------------------
+
+func TestCollectTopology_RedisStreams(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				// ID is a hash; Name carries the semantic prefix.
+				ID:         "efgh5678",
+				Name:       "stream:redis:events",
+				Kind:       "SCOPE.Queue",
+				Properties: map[string]string{"broker": "redis", "channel_type": "stream"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:producer", ToID: "efgh5678", Kind: "PUBLISHES_TO"},
+			{ID: "r2", FromID: "fn:consumer", ToID: "efgh5678", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	_, queues, _, _ := collectTopology(grp)
+	if len(queues) != 1 {
+		t.Fatalf("expected 1 queue, got %d", len(queues))
+	}
+	q := queues[0]
+	if q["broker"] != "redis" {
+		t.Errorf("broker = %v, want redis", q["broker"])
+	}
+	producers, _ := q["producers"].([]string)
+	if len(producers) != 1 {
+		t.Errorf("expected 1 producer, got %d", len(producers))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectTopology — async tasks (dramatiq)
+// ---------------------------------------------------------------------------
+
+func TestCollectTopology_AsyncTasks(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			// Dramatiq task (from #941 extractor — stored as SCOPE.Queue entity
+			// with task: prefix in entity Name).
+			{
+				ID:         "ijkl9012",
+				Name:       "task:dramatiq:send_email",
+				Kind:       "SCOPE.Queue",
+				Properties: map[string]string{"framework": "dramatiq", "broker": ""},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:caller", ToID: "ijkl9012", Kind: "PUBLISHES_TO"},
+			{ID: "r2", FromID: "fn:worker", ToID: "ijkl9012", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	_, queues, _, _ := collectTopology(grp)
+	if len(queues) != 1 {
+		t.Fatalf("expected 1 queue for task entity, got %d", len(queues))
+	}
+	q := queues[0]
+	if q["framework"] != "dramatiq" {
+		t.Errorf("framework = %v, want dramatiq", q["framework"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectTopology — serverless functions (Lambda)
+// ---------------------------------------------------------------------------
+
+func TestCollectTopology_Serverless(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				// Name carries the semantic aws-lambda: prefix.
+				ID:         "mnop3456",
+				Name:       "aws-lambda:OrderProcessor",
+				Kind:       "SCOPE.ServerlessFunction",
+				Properties: map[string]string{"provider": "aws-lambda", "function_name": "OrderProcessor"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:api_handler", ToID: "mnop3456", Kind: "CALLS"},
+			{ID: "r2", FromID: "fn:lambda_handler", ToID: "mnop3456", Kind: "HANDLES"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	_, _, _, functions := collectTopology(grp)
+	if len(functions) != 1 {
+		t.Fatalf("expected 1 function, got %d", len(functions))
+	}
+	fn := functions[0]
+	if fn["provider"] != "aws-lambda" {
+		t.Errorf("provider = %v, want aws-lambda", fn["provider"])
+	}
+	invokers, _ := fn["invokers"].([]string)
+	handlers, _ := fn["handlers"].([]string)
+	if len(invokers) != 1 {
+		t.Errorf("expected 1 invoker, got %d", len(invokers))
+	}
+	if len(handlers) != 1 {
+		t.Errorf("expected 1 handler, got %d", len(handlers))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectTopology — existing Kafka regression
+// ---------------------------------------------------------------------------
+
+func TestCollectTopology_KafkaRegression(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID:         "UserCreatedTopic",
+				Name:       "UserCreatedTopic",
+				Kind:       "MessageTopic",
+				Properties: map[string]string{"broker": "kafka"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "svc_producer", ToID: "UserCreatedTopic", Kind: "PUBLISHES_TO"},
+			{ID: "r2", FromID: "svc_consumer", ToID: "UserCreatedTopic", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	topics, queues, channels, functions := collectTopology(grp)
+	if len(topics) != 1 {
+		t.Fatalf("expected 1 kafka topic, got %d", len(topics))
+	}
+	if len(queues) != 0 {
+		t.Errorf("expected 0 queues, got %d", len(queues))
+	}
+	if len(channels) != 0 {
+		t.Errorf("expected 0 channels, got %d", len(channels))
+	}
+	if len(functions) != 0 {
+		t.Errorf("expected 0 functions, got %d", len(functions))
+	}
+	if topics[0]["broker"] != "kafka" {
+		t.Errorf("broker = %v, want kafka", topics[0]["broker"])
+	}
+}

--- a/testdata/fixture-946-topology/notify.py
+++ b/testdata/fixture-946-topology/notify.py
@@ -1,0 +1,76 @@
+"""
+fixture-946-topology/notify.py
+Synthetic fixture for #946 topology broadening test.
+
+Demonstrates:
+  1. Redis pub/sub — redis.publish / pubsub.subscribe
+  2. Redis Streams  — r.xadd / r.xreadgroup
+  3. Dramatiq async task — @dramatiq.actor + actor.send()
+  4. AWS Lambda invoke — boto3 client.invoke(FunctionName=...)
+"""
+import redis
+import dramatiq
+import boto3
+
+
+# ── Redis pub/sub ────────────────────────────────────────────────────────────
+
+def publish_notification(r: redis.Redis, message: str):
+    r.publish('notifications', message)
+
+
+def subscribe_notifications(r: redis.Redis):
+    pubsub = r.pubsub()
+    pubsub.subscribe('notifications')
+    for item in pubsub.listen():
+        if item['type'] == 'message':
+            handle_notification(item['data'])
+
+
+# ── Redis Streams ────────────────────────────────────────────────────────────
+
+def publish_event(r: redis.Redis, event: dict):
+    r.xadd('events', event)
+
+
+def consume_events(r: redis.Redis):
+    r.xreadgroup('workers', 'w1', {'events': '>'})
+
+
+# ── Dramatiq async task ──────────────────────────────────────────────────────
+
+@dramatiq.actor
+def send_email(to: str, subject: str):
+    """Dramatiq actor that sends an email."""
+    pass  # implementation omitted in fixture
+
+
+def enqueue_email(to: str, subject: str):
+    send_email.send(to, subject)
+
+
+# ── AWS Lambda invoke ────────────────────────────────────────────────────────
+
+def invoke_order_processor(order_id: str):
+    client = boto3.client('lambda')
+    client.invoke(
+        FunctionName='OrderProcessor',
+        InvocationType='Event',
+        Payload=f'{{"order_id": "{order_id}"}}'.encode(),
+    )
+
+
+# ── Lambda handler (consumer side) ───────────────────────────────────────────
+
+def lambda_handler(event, context):
+    """AWS Lambda handler for OrderProcessor."""
+    order_id = event.get('order_id')
+    process_order(order_id)
+
+
+def handle_notification(data):
+    pass
+
+
+def process_order(order_id):
+    pass


### PR DESCRIPTION
## What changed

Extends the topology surface to display four new runtime entity types that were previously invisible.

**Backend (`internal/dashboard/handlers_topology.go`)**
- `classifyTopologyBucket(kind, name, props)` — new function that maps entity Kind+Name to topology bucket using entity **Name** prefix (not hashed ID)
- Redis pub/sub channels: `channel:redis-pubsub:*` Name prefix → `channels` bucket with `channel_type: redis_pubsub`; handles `PUBLISHES_TO`/`SUBSCRIBES_TO` edges
- Redis Streams: `stream:redis:*` Name prefix → `queues` bucket with `broker: redis` (map to `redis-stream` in frontend)
- Serverless functions: `aws-lambda:*`, `gcp-cloudfunction:*`, `azure-function:*` Name prefixes + `SCOPE.ServerlessFunction` kind → `functions` bucket; handles `CALLS`/`HANDLES` edges
- Async task queues: `task:<framework>:*` Name prefix + `broker in {dramatiq, rq, celery, hangfire, quartz*}` → `queues` bucket with `broker: task-queue`
- Both HTTP handlers return `"functions": [...]` in the JSON response
- 7 new unit tests in `handlers_topology_test.go` (all passing)

**Frontend (TypeScript/React)**
- `types/api.ts`: `BrokerProtocol` gains `redis | redis-stream | task-queue`; `ChannelProtocol` gains `redis_pubsub`; new `ServerlessProtocol = 'serverless'`; `FunctionNode` interface; `functions` field on `TopologyResponse`
- `lib/colors.ts`: colour + glyph specs for the 5 new protocol tokens
- `components/topology/ProtocolFilterChips.tsx`: SVG glyphs — ring (Redis/Redis P/S), chevron (Redis Stream), clock (Task Queue), bolt (Serverless)
- `hooks/topology/useProtocolFilters.ts`: all 5 new protocols in `ALL_PROTOCOLS`
- `hooks/topology/useTopologyLayout.ts`: dual-field helpers `getProducers/getConsumers/getEmitters/getSubscribers` to handle REST API returning `producers` vs TypeScript type `producer_ids`; label-based protocol detection for queue nodes
- `hooks/topology/useTopologySearch.ts`: functions included in typeahead results
- `hooks/topology/useTopicDetail.ts`: FunctionNode, `invoker_ids`/`handler_ids` support
- `components/topology/ChannelTrack.tsx`: fix crash when `emitter_ids`/`subscriber_ids` are absent (API returns `emitters`/`subscribers`); `redis_pubsub` added to `channelType` prop union
- `components/topology/TopologyMap.tsx`: null guards, functions in `topicData` lookup, dual-field producer/consumer ID handling
- `routes/topology.tsx`: null guards throughout; functions in empty-state check

**Test fixture**
- `testdata/fixture-946-topology/notify.py`: synthetic Python file demonstrating Redis pub/sub publish/subscribe, Redis Stream produce/consume, dramatiq actor (task queue), and AWS Lambda invoke/handler — feeds the E2E test

## Root cause note

The Go REST API has always returned `producers`/`consumers` (no `_ids` suffix) while the TypeScript interfaces declared `producer_ids`/`consumer_ids`. This PR adds dual-field helpers throughout the frontend to handle both forms, fixing a pre-existing silent data hole as a side effect.

## E2E verification

Playwright smoke test against live daemon (port 47399, `ARCHIGRAPH_DAEMON_ROOT=/tmp/archigraph-946-new`):

- All 5 new protocol chips render in filter bar: **Redis**, **Redis Stream**, **Redis P/S**, **Task Queue**, **Serverless**
- Topology map renders correct nodes from fixture: `stream:redis:events`, `pubsub:X:notifications`, `aws-lambda:OrderProcessor`, `aws-lambda:lambda_handler`
- Real-time channels track renders `channel:redis-pubsub:notifications` as Redis P/S card
- Selecting **Serverless** chip → only 2 Lambda nodes shown
- Selecting **Serverless + Redis Stream** chips → 3 nodes shown
- Clicking **All** → all nodes restored
- **Zero console errors** across all states

## Tests

```
go test ./internal/dashboard/...
ok  	github.com/cajasmota/archigraph/internal/dashboard	1.349s
```

7 new unit tests: `TestClassifyTopologyBucket`, `TestInferBrokerFromName`, `TestCollectTopology_RedisPubSub`, `TestCollectTopology_RedisStreams`, `TestCollectTopology_AsyncTasks`, `TestCollectTopology_Serverless`, `TestCollectTopology_KafkaRegression`

Closes #946