### PR TITLE
[#955 #957] Fix paths crash on real data + registry entity_count/last_indexed

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -91,7 +91,7 @@ import type { DocTreeResponse, DocContentResponse, DocSearchResponse, EntityCard
 
 /**
  * Wire-format group from GET /api/registry:
- *   { name, config_path, repos: string[] }
+ *   { name, config_path, repos: string[], entity_count, last_indexed? }
  *
  * Frontend GroupMeta expects:
  *   { id, display_name, repos: RepoMeta[], entity_count, indexed_at? }
@@ -99,7 +99,15 @@ import type { DocTreeResponse, DocContentResponse, DocSearchResponse, EntityCard
  * normalizeRegistry maps the wire format to the frontend type so the SPA
  * group-selector and routing work without modification.
  */
-function normalizeRegistry(raw: { groups: Array<{ name: string; config_path?: string; repos?: string[] }> }): Registry {
+type WireGroup = {
+  name: string
+  config_path?: string
+  repos?: string[]
+  entity_count?: number
+  last_indexed?: string
+}
+
+function normalizeRegistry(raw: { groups: Array<WireGroup> }): Registry {
   const groups = (raw.groups ?? []).map((g) => ({
     id: g.name,
     display_name: g.name,
@@ -109,18 +117,57 @@ function normalizeRegistry(raw: { groups: Array<{ name: string; config_path?: st
       language: 'unknown',
       entity_count: 0,
     })),
-    entity_count: 0,
+    entity_count: g.entity_count ?? 0,
+    indexed_at: g.last_indexed,
   }))
   return { groups, version: '1' }
 }
 
 export async function fetchRegistry(): Promise<Registry> {
   if (USE_MOCKS) return loadMock<Registry>('registry')
-  const raw = await apiFetch<{ groups: Array<{ name: string; config_path?: string; repos?: string[] }> }>('/api/registry')
+  const raw = await apiFetch<{ groups: Array<WireGroup> }>('/api/registry')
   return normalizeRegistry(raw)
 }
 
 // ── Surface 4: Paths ─────────────────────────────────────────────────────────
+
+/**
+ * Wire tree node shape from the backend (handlers_paths.go buildPrefixTree).
+ * Different from the frontend PathTreeNode — normalize before returning.
+ */
+type WireTreeNode = {
+  segment?: string
+  path?: string
+  has_paths?: boolean
+  children?: WireTreeNode[]
+  // Frontend-style fields (from mock data)
+  prefix?: string
+  label?: string
+  count?: number
+}
+
+function normalizeTreeNode(n: WireTreeNode): PathTreeNode {
+  return {
+    prefix: n.prefix ?? n.path ?? '',
+    label: n.label ?? n.segment ?? '',
+    count: n.count ?? 0,
+    children: (n.children ?? []).map(normalizeTreeNode),
+  }
+}
+
+function normalizePathListResponse(raw: PathListResponse): PathListResponse {
+  return {
+    ...raw,
+    paths: (raw.paths ?? []).map((p) => ({
+      ...p,
+      verbs: p.verbs ?? [],
+      handlers: (p as unknown as { handlers?: unknown[] }).handlers as never ?? [],
+      repos: p.repos ?? [],
+      frameworks: p.frameworks ?? [],
+    })),
+    tree: (raw.tree ?? []).map((n) => normalizeTreeNode(n as unknown as WireTreeNode)),
+  }
+}
 
 export async function fetchPaths(
   group: string,
@@ -132,7 +179,8 @@ export async function fetchPaths(
     return applyMockFilters(data, filters)
   }
   const params = buildParams(filters)
-  return apiFetch<PathListResponse>(`/api/paths/${group}?${params}`)
+  const raw = await apiFetch<PathListResponse>(`/api/paths/${group}?${params}`)
+  return normalizePathListResponse(raw)
 }
 
 export async function fetchPathDetail(

--- a/dashboard/src/components/paths/PathRow.tsx
+++ b/dashboard/src/components/paths/PathRow.tsx
@@ -16,7 +16,7 @@ interface PathRowProps {
 export function PathRow({ path, group, isSelected = false, onSelect }: PathRowProps) {
   const navigate = useNavigate()
   const parts = splitPathParts(path.path)
-  const verbs = sortVerbs(path.verbs)
+  const verbs = sortVerbs(path.verbs ?? [])
 
   const handleClick = () => {
     onSelect?.(path.path_hash)
@@ -78,13 +78,13 @@ export function PathRow({ path, group, isSelected = false, onSelect }: PathRowPr
       )}
 
       {/* Repo chips (only shown if multiple repos) */}
-      {path.repos.length > 0 && (
+      {(path.repos ?? []).length > 0 && (
         <span className="hidden md:flex items-center gap-1 flex-shrink-0">
-          {path.repos.slice(0, 2).map((r) => (
+          {(path.repos ?? []).slice(0, 2).map((r) => (
             <RepoChip key={r} repo={r} />
           ))}
-          {path.repos.length > 2 && (
-            <span className="text-xs text-slate-500">+{path.repos.length - 2}</span>
+          {(path.repos ?? []).length > 2 && (
+            <span className="text-xs text-slate-500">+{(path.repos ?? []).length - 2}</span>
           )}
         </span>
       )}

--- a/dashboard/src/lib/groupPaths.ts
+++ b/dashboard/src/lib/groupPaths.ts
@@ -42,8 +42,8 @@ function groupKey(path: PathRow): string {
 /** Sort paths within a group: by method order, then alphabetically by path */
 function sortPathRows(rows: PathRow[]): PathRow[] {
   return [...rows].sort((a, b) => {
-    const aVerb = sortVerbs(a.verbs)[0] ?? 'ANY'
-    const bVerb = sortVerbs(b.verbs)[0] ?? 'ANY'
+    const aVerb = sortVerbs(a.verbs ?? [])[0] ?? 'ANY'
+    const bVerb = sortVerbs(b.verbs ?? [])[0] ?? 'ANY'
     const aIdx = VERB_ORDER.indexOf(aVerb)
     const bIdx = VERB_ORDER.indexOf(bVerb)
     if (aIdx !== bIdx) return aIdx - bIdx
@@ -55,7 +55,7 @@ function sortPathRows(rows: PathRow[]): PathRow[] {
 function buildVerbCounts(rows: PathRow[]): { verb: HttpVerb; count: number }[] {
   const counts = new Map<HttpVerb, number>()
   for (const row of rows) {
-    for (const verb of row.verbs) {
+    for (const verb of (row.verbs ?? [])) {
       counts.set(verb, (counts.get(verb) ?? 0) + 1)
     }
   }

--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -249,6 +249,7 @@ export function PathsRoute() {
           </ErrorBoundary>
 
           {/* Path list */}
+          <ErrorBoundary>
           <div
             ref={listRef}
             className="flex-1 overflow-y-auto"
@@ -308,6 +309,8 @@ export function PathsRoute() {
               </div>
             )}
           </div>
+
+          </ErrorBoundary>
 
           {/* Pagination */}
           {!isLoading && data && data.total > (data.page_size ?? 50) && (

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -134,8 +134,12 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 	for _, ep := range endpoints {
 		if _, ok := grouped[ep.Path]; !ok {
 			grouped[ep.Path] = &PathRow{
-				PathHash: hashStr(ep.Path),
-				Path:     ep.Path,
+				PathHash:   hashStr(ep.Path),
+				Path:       ep.Path,
+				Verbs:      []string{},
+				Handlers:   []string{},
+				Frameworks: []string{},
+				Repos:      []string{},
 			}
 			pathOrder = append(pathOrder, ep.Path)
 		}
@@ -198,6 +202,9 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 		end = total
 	}
 	paged := rows[start:end]
+	if paged == nil {
+		paged = []PathRow{}
+	}
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"paths":    paged,

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
@@ -24,10 +26,80 @@ type RegistryStore interface {
 }
 
 // GroupSummary is the registry list shape returned by GET /api/registry.
+// entity_count, last_indexed are aggregated from per-repo graph-stats.json
+// sidecars (written by `archigraph index`). The aggregation is cached in
+// registryStatsCache and refreshed at most once every 30 s.
 type GroupSummary struct {
-	Name       string   `json:"name"`
-	ConfigPath string   `json:"config_path"`
-	Repos      []string `json:"repos"`
+	Name        string   `json:"name"`
+	ConfigPath  string   `json:"config_path"`
+	Repos       []string `json:"repos"`
+	EntityCount int      `json:"entity_count"`
+	LastIndexed string   `json:"last_indexed,omitempty"` // RFC3339, most-recent across repos
+}
+
+// ---------------------------------------------------------------------------
+// Per-group registry-stats cache
+// ---------------------------------------------------------------------------
+
+type registryStatsCacheEntry struct {
+	entityCount int
+	lastIndexed time.Time
+	computedAt  time.Time
+}
+
+var (
+	registryStatsMu    sync.Mutex
+	registryStatsCache = map[string]registryStatsCacheEntry{}
+	registryStatsTTL   = 30 * time.Second
+)
+
+// aggregateGroupStats reads graph-stats.json for each repo in the group and
+// returns (entity_count_sum, most_recent_computed_at). Results are cached for
+// registryStatsTTL to keep /api/registry latency well under 100 ms on warm
+// paths.
+func aggregateGroupStats(groupName string, repos []registry.Repo) (entityCount int, lastIndexed time.Time) {
+	registryStatsMu.Lock()
+	if e, ok := registryStatsCache[groupName]; ok && time.Since(e.computedAt) < registryStatsTTL {
+		registryStatsMu.Unlock()
+		return e.entityCount, e.lastIndexed
+	}
+	registryStatsMu.Unlock()
+
+	// Compute fresh — no lock held during I/O.
+	var totalEntities int
+	var latest time.Time
+	for _, r := range repos {
+		stateDir := daemon.StateDirForRepo(r.Path)
+		sidecarPath := filepath.Join(stateDir, "graph-stats.json")
+		data, err := os.ReadFile(sidecarPath)
+		if err != nil {
+			// Sidecar not yet written — fall back to graph.fb/graph.json mtime.
+			if info, e2 := os.Stat(filepath.Join(stateDir, "graph.fb")); e2 == nil {
+				if info.ModTime().After(latest) {
+					latest = info.ModTime()
+				}
+			}
+			continue
+		}
+		var side graph.GraphStatsSidecar
+		if json.Unmarshal(data, &side) != nil {
+			continue
+		}
+		totalEntities += side.TotalEntities
+		if side.ComputedAt.After(latest) {
+			latest = side.ComputedAt
+		}
+	}
+
+	registryStatsMu.Lock()
+	registryStatsCache[groupName] = registryStatsCacheEntry{
+		entityCount: totalEntities,
+		lastIndexed: latest,
+		computedAt:  time.Now(),
+	}
+	registryStatsMu.Unlock()
+
+	return totalEntities, latest
 }
 
 // liveStore is the production RegistryStore: it reads from the on-disk
@@ -45,10 +117,18 @@ func (liveStore) ListGroups() ([]GroupSummary, error) {
 	out := make([]GroupSummary, 0, len(groups))
 	for _, g := range groups {
 		s := GroupSummary{Name: g.Name, ConfigPath: g.ConfigPath}
+		var repos []registry.Repo
 		if cfg, err := registry.LoadGroupConfig(g.ConfigPath); err == nil {
+			repos = cfg.Repos
 			for _, r := range cfg.Repos {
 				s.Repos = append(s.Repos, r.Slug)
 			}
+		}
+		// Aggregate entity_count + last_indexed from per-repo graph-stats.json.
+		entityCount, lastIndexed := aggregateGroupStats(g.Name, repos)
+		s.EntityCount = entityCount
+		if !lastIndexed.IsZero() {
+			s.LastIndexed = lastIndexed.UTC().Format(time.RFC3339)
 		}
 		out = append(out, s)
 	}


### PR DESCRIPTION
## Summary

- **#957 (URGENT)** — \`/paths/<group>\` crashed with "Cannot read properties of undefined (reading 'length')" on real data. Two root causes: (1) backend PathRow had nil slices when no verbs/repos/frameworks matched; (2) the tree nodes from \`buildPrefixTree\` use \`{segment, path, has_paths}\` but \`PathTreeSidebar\` expects \`{prefix, label, count, children}\` — the shape mismatch caused the crash before any PathRow rendered.
- **#955** — Landing cards showed "0 entities / never" because \`GET /api/registry\` returned no \`entity_count\` or \`last_indexed\`. Now reads \`graph-stats.json\` sidecars and aggregates per group with a 30 s in-process cache.

## Changes

### Backend

**\`internal/dashboard/store.go\`**
- \`GroupSummary\` gains \`entity_count int\` + \`last_indexed string\` fields
- \`aggregateGroupStats()\` reads \`<stateDir>/graph-stats.json\` per repo, sums \`total_entities\`, takes most-recent \`computed_at\`; falls back to \`graph.fb\` mtime when sidecar absent; cached 30 s
- \`ListGroups()\` calls \`aggregateGroupStats()\` per group

**\`internal/dashboard/handlers_paths.go\`**
- \`PathRow\` \`Verbs\`, \`Handlers\`, \`Frameworks\`, \`Repos\` initialised to \`[]string{}\` (not nil) so JSON always serialises \`[]\` not \`null\`

### Frontend

**\`dashboard/src/api/client.ts\`**
- \`normalizeRegistry\` passes through \`entity_count\` + \`last_indexed\` from wire format
- \`normalizePathListResponse\` coerces null arrays to \`[]\`
- \`normalizeTreeNode\` maps backend \`{segment, path, has_paths}\` → frontend \`{prefix, label, count, children}\` — this was the actual crash root cause (shape mismatch in sidebar)

**\`dashboard/src/lib/groupPaths.ts\`** + **\`PathRow.tsx\`**
- \`path.verbs ?? []\` and \`path.repos ?? []\` guards throughout

**\`dashboard/src/routes/paths.tsx\`**
- Path-list panel wrapped in \`ErrorBoundary\`

## Test plan

- [x] \`make build\` passes
- [x] \`GET /api/registry\` returns \`entity_count: 20718, last_indexed: "2026-05-20T13:17:07Z"\`
- [x] Landing cards show 20.7k entities + relative time (E2E screenshot)
- [x] \`/paths/upvate\` renders 744 paths, grouped view, sidebar tree, zero console errors (E2E screenshot)
- [x] \`/topology/upvate\` loads cleanly, zero console errors (E2E screenshot)
- [x] \`fixture-946\` (not indexed) shows 0 entities / never gracefully

## Notes

\`bug_rate\` is intentionally omitted — it is runtime-computed during \`archigraph index\` and not persisted to any on-disk file. \`GroupMeta.bug_rate\` stays optional (\`?\`) and shows \`— bug-rate\` in the UI, which is correct until a persistence mechanism exists.

Closes #955
Closes #957

🤖 Generated with [Claude Code](https://claude.com/claude-code)