### PR TITLE
[#963 #967 #969 #970] Dashboard polish: theme toggle, sidebar removal, NaN counter, data-driven filters

### DIFF
--- a/dashboard/src/components/paths/Pagination.tsx
+++ b/dashboard/src/components/paths/Pagination.tsx
@@ -9,9 +9,12 @@ interface PaginationProps {
 }
 
 export function Pagination({ page, pageSize, total, hasMore, onPageChange }: PaginationProps) {
-  const start = (page - 1) * pageSize + 1
-  const end = Math.min(page * pageSize, total)
-  const hasPrev = page > 1
+  // Guard against NaN/0 from URL param parsing
+  const safePage = (Number.isFinite(page) && page >= 1) ? page : 1
+  const safePageSize = (Number.isFinite(pageSize) && pageSize >= 1) ? pageSize : 50
+  const start = (safePage - 1) * safePageSize + 1
+  const end = Math.min(safePage * safePageSize, total)
+  const hasPrev = safePage > 1
 
   return (
     <nav
@@ -26,16 +29,16 @@ export function Pagination({ page, pageSize, total, hasMore, onPageChange }: Pag
           label="Previous page"
           icon={<ChevronLeft className="w-4 h-4" />}
           disabled={!hasPrev}
-          onClick={() => onPageChange(page - 1)}
+          onClick={() => onPageChange(safePage - 1)}
         />
         <span className="px-2 text-xs text-slate-400">
-          Page {page}
+          Page {safePage}
         </span>
         <PaginationButton
           label="Next page"
           icon={<ChevronRight className="w-4 h-4" />}
           disabled={!hasMore}
-          onClick={() => onPageChange(page + 1)}
+          onClick={() => onPageChange(safePage + 1)}
         />
       </div>
     </nav>

--- a/dashboard/src/components/paths/PathFilterPanel.tsx
+++ b/dashboard/src/components/paths/PathFilterPanel.tsx
@@ -1,69 +1,84 @@
 import { X } from 'lucide-react'
-import type { PathFilters } from '@/types/api'
-
-const FRAMEWORKS = ['drf', 'django', 'fastapi', 'gin', 'express', 'flask', 'rails']
-const REPOS = ['core-api', 'admin-service', 'gateway']
+import type { PathFilters, PathRow } from '@/types/api'
 
 interface PathFilterPanelProps {
   filters: PathFilters
   setFilter: <K extends keyof PathFilters>(key: K, value: PathFilters[K]) => void
   clearFilters: () => void
+  /** All paths in the current group — used to derive unique repo/framework chips */
+  paths?: PathRow[]
 }
 
-export function PathFilterPanel({ filters, setFilter, clearFilters }: PathFilterPanelProps) {
+export function PathFilterPanel({ filters, setFilter, clearFilters, paths = [] }: PathFilterPanelProps) {
+  // Derive unique repos and frameworks from actual data; sort for stable order.
+  const uniqueRepos = Array.from(new Set(paths.flatMap((p) => p.repos ?? []))).sort()
+  const uniqueFrameworks = Array.from(new Set(paths.flatMap((p) => p.frameworks ?? []))).sort()
+
   const hasActiveFilters = !!(
     filters.repo || filters.framework || filters.status_code || filters.is_webhook !== undefined
   )
 
+  // Nothing to show if the data hasn't loaded yet
+  if (uniqueRepos.length === 0 && uniqueFrameworks.length === 0 && !hasActiveFilters) {
+    return null
+  }
+
   return (
-    <div className="flex flex-wrap items-center gap-2 px-4 py-2 border-b border-slate-800 text-xs">
-      {/* Repo chips */}
-      <span className="text-slate-500 mr-1">Repo:</span>
-      {REPOS.map((repo) => (
-        <FilterChip
-          key={repo}
-          label={repo}
-          active={filters.repo === repo}
-          onClick={() => setFilter('repo', filters.repo === repo ? undefined : repo)}
-        />
-      ))}
-
-      <span className="text-slate-700 mx-1">|</span>
-
-      {/* Framework chips */}
-      <span className="text-slate-500 mr-1">Framework:</span>
-      {FRAMEWORKS.map((fw) => (
-        <FilterChip
-          key={fw}
-          label={fw}
-          active={filters.framework === fw}
-          onClick={() => setFilter('framework', filters.framework === fw ? undefined : fw)}
-        />
-      ))}
-
-      <span className="text-slate-700 mx-1">|</span>
-
-      {/* Webhook toggle */}
-      <FilterChip
-        label="Webhooks only"
-        active={filters.is_webhook === true}
-        onClick={() =>
-          setFilter('is_webhook', filters.is_webhook === true ? undefined : true)
-        }
-      />
-
-      {/* Clear all */}
-      {hasActiveFilters && (
-        <button
-          type="button"
-          className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
-          onClick={clearFilters}
-          aria-label="Clear all filters"
-        >
-          <X className="w-3 h-3" />
-          Clear
-        </button>
+    <div className="flex flex-col gap-1.5 px-4 py-2 border-b border-slate-800 text-xs">
+      {/* Row 1 — Repos */}
+      {uniqueRepos.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-slate-500 shrink-0">Repos:</span>
+          {uniqueRepos.map((repo) => (
+            <FilterChip
+              key={repo}
+              label={repo}
+              active={filters.repo === repo}
+              onClick={() => setFilter('repo', filters.repo === repo ? undefined : repo)}
+            />
+          ))}
+        </div>
       )}
+
+      {/* Row 2 — Frameworks */}
+      {uniqueFrameworks.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-slate-500 shrink-0">Frameworks:</span>
+          {uniqueFrameworks.map((fw) => (
+            <FilterChip
+              key={fw}
+              label={fw}
+              active={filters.framework === fw}
+              onClick={() => setFilter('framework', filters.framework === fw ? undefined : fw)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Row 3 — Misc + clear */}
+      <div className="flex flex-wrap items-center gap-1.5">
+        {/* Webhook toggle */}
+        <FilterChip
+          label="Webhooks only"
+          active={filters.is_webhook === true}
+          onClick={() =>
+            setFilter('is_webhook', filters.is_webhook === true ? undefined : true)
+          }
+        />
+
+        {/* Clear all */}
+        {hasActiveFilters && (
+          <button
+            type="button"
+            className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+            onClick={clearFilters}
+            aria-label="Clear all filters"
+          >
+            <X className="w-3 h-3" />
+            Clear
+          </button>
+        )}
+      </div>
     </div>
   )
 }
@@ -82,7 +97,7 @@ function FilterChip({ label, active, onClick }: FilterChipProps) {
       className={[
         'px-2 py-0.5 rounded border transition-colors font-mono',
         active
-          ? 'bg-sky-900/50 border-sky-600 text-sky-300'
+          ? 'bg-sky-900/50 border-sky-500 text-sky-300'
           : 'bg-slate-900 border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-300',
       ].join(' ')}
       onClick={onClick}

--- a/dashboard/src/context/ThemeContext.tsx
+++ b/dashboard/src/context/ThemeContext.tsx
@@ -28,7 +28,14 @@ function applyTheme(theme: Theme) {
 }
 
 export function ThemeProvider({ children }: { children: ReactNode }) {
-  const [theme, setTheme] = useState<Theme>(getInitialTheme)
+  const [theme, setTheme] = useState<Theme>(() => {
+    const initial = getInitialTheme()
+    // Apply synchronously so first paint matches the stored/system preference.
+    // main.tsx already does this before React boots, but ThemeProvider guards
+    // against the edge-case where main.tsx runs before localStorage is ready.
+    applyTheme(initial)
+    return initial
+  })
 
   useEffect(() => {
     applyTheme(theme)

--- a/dashboard/src/hooks/paths/usePathFilters.ts
+++ b/dashboard/src/hooks/paths/usePathFilters.ts
@@ -18,13 +18,15 @@ export function usePathFilters(): {
     q: params.get('q') ?? undefined,
     repo: params.get('repo') ?? undefined,
     framework: params.get('framework') ?? undefined,
-    status_code: params.get('status_code') ? Number(params.get('status_code')) : undefined,
+    status_code: params.get('status_code')
+      ? (parseInt(params.get('status_code')!, 10) || undefined)
+      : undefined,
     is_webhook: params.get('is_webhook') === 'true'
       ? true
       : params.get('is_webhook') === 'false'
         ? false
         : undefined,
-    page: params.get('page') ? Number(params.get('page')) : 1,
+    page: Math.max(1, parseInt(params.get('page') ?? '1', 10) || 1),
     page_size: 50,
   }
 

--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useParams, Outlet, useNavigate } from 'react-router-dom'
-import { ChevronUp, ChevronDown, List } from 'lucide-react'
-import { PathTreeSidebar } from '@/components/paths/PathTreeSidebar'
+import { ChevronUp, ChevronDown, List, Globe } from 'lucide-react'
 import { PathRow } from '@/components/paths/PathRow'
 import { PathsGroup } from '@/components/paths/PathsGroup'
 import { PathFilterPanel } from '@/components/paths/PathFilterPanel'
@@ -11,10 +10,8 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { PathListSkeleton } from '@/components/shared/LoadingState'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
 import { usePathList } from '@/hooks/paths/usePathList'
-import { usePathTree } from '@/hooks/paths/usePathTree'
 import { usePathFilters } from '@/hooks/paths/usePathFilters'
 import { groupPaths } from '@/lib/groupPaths'
-import { Globe } from 'lucide-react'
 
 // ─── localStorage key for flat/grouped preference ────────────────────────────
 const LS_FLAT_KEY = 'paths-view-flat'
@@ -48,7 +45,6 @@ export function PathsRoute() {
   const { group = 'fixture-a' } = useParams<{ group: string }>()
   const { filters, setFilter, clearFilters } = usePathFilters()
   const { data, isLoading, isFetching } = usePathList(group, filters)
-  const { tree, isLoading: treeLoading } = usePathTree(group)
   const navigate = useNavigate()
   const searchRef = useRef<HTMLDivElement>(null)
   const listRef = useRef<HTMLDivElement>(null)
@@ -150,25 +146,7 @@ export function PathsRoute() {
 
   return (
     <div className="flex h-full overflow-hidden">
-      {/* Sidebar — prefix tree */}
-      <aside
-        className="w-52 flex-shrink-0 border-r border-slate-800 bg-slate-900/60 overflow-hidden"
-        aria-label="API path groups"
-      >
-        <div className="px-3 py-2 border-b border-slate-800">
-          <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
-            Prefixes
-          </h2>
-        </div>
-        <PathTreeSidebar
-          tree={tree}
-          isLoading={treeLoading}
-          activePrefix={filters.prefix}
-          onPrefixSelect={(prefix) => setFilter('prefix', prefix)}
-        />
-      </aside>
-
-      {/* Main content — list + detail */}
+      {/* Main content — list + detail (full width, no prefix-tree sidebar) */}
       <div className="flex flex-1 overflow-hidden">
         {/* Path list panel */}
         <div className="flex flex-col w-[520px] flex-shrink-0 border-r border-slate-800 overflow-hidden">
@@ -239,12 +217,13 @@ export function PathsRoute() {
             </div>
           )}
 
-          {/* Filters */}
+          {/* Filters — data-driven chips derived from current paths */}
           <ErrorBoundary>
             <PathFilterPanel
               filters={filters}
               setFilter={setFilter}
               clearFilters={clearFilters}
+              paths={paths}
             />
           </ErrorBoundary>
 

--- a/dashboard/src/styles/globals.css
+++ b/dashboard/src/styles/globals.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* ── Dark-mode variant: toggled via .dark class on <html> ──────────────────── */
+@variant dark (&:where(.dark, .dark *));
+
 /* ────────────────────────────────────────────────────────────────────────────
    Base / reset
 ────────────────────────────────────────────────────────────────────────────── */
@@ -22,10 +25,20 @@
     color-scheme: dark;
   }
 
+  html:not(.dark) {
+    color-scheme: light;
+  }
+
+  /* Dark mode body (default) */
   body {
     @apply bg-slate-950 text-slate-200;
     font-family: ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont,
       "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  }
+
+  /* Light mode body overrides */
+  html:not(.dark) body {
+    @apply bg-white text-slate-900;
   }
 
   /* Scrollbar styling — dark mode */


### PR DESCRIPTION
## Summary

- **#963** — Theme toggle now actually applies: added \`@variant dark\` directive so Tailwind v4 \`dark:\` classes respond to \`html.dark\`; \`ThemeProvider\` applies theme synchronously on init to prevent flash-of-wrong-theme; light-mode body override added
- **#967** — Removed prefix tree sidebar from \`/paths/:group\`; grouped list takes full width; \`usePathTree\` dependency dropped
- **#969** — Fixed \`NaN-NaN of 744\` counter: \`Pagination\` guards \`page\`/\`pageSize\` with \`Number.isFinite\`; \`usePathFilters\` uses \`parseInt(..., 10) || 1\` so malformed URL params never produce NaN
- **#970** — Filter chips are now data-driven: \`PathFilterPanel\` accepts a \`paths[]\` prop and derives unique repos/frameworks from actual API data; rendered as two labeled stacked rows (Repos / Frameworks); selected chip has sky-500 border; mobile chips wrap

## Root causes and fixes

| Issue | Root cause | Fix |
|-------|-----------|-----|
| #963 | Tailwind v4 \`dark:\` variant not configured for class-toggle strategy | \`@variant dark (&:where(.dark, .dark *))\` in globals.css + sync init in ThemeProvider |
| #967 | Prefix tree sidebar made grouped list redundant | Removed \`<aside>\` + \`PathTreeSidebar\` usage from paths.tsx |
| #969 | \`page\` param parsed with \`Number()\` returns NaN for invalid strings | \`parseInt(..., 10) || 1\` in hook; \`Number.isFinite\` guards in Pagination |
| #970 | Static hardcoded chip lists (flask, gin, rails) shown regardless of data | Compute from \`paths.flatMap(p => p.repos/frameworks)\`, deduplicate, sort |

## Playwright E2E

- Theme toggle: \`html.dark\` class added/removed on click; \`localStorage.theme\` persists correctly; visual dark/light switch confirmed on screenshots
- \`/paths/upvate\`: no sidebar, counter shows \`1–50 of 744\`, Repos row shows only \`upvate_core\` + \`upvate_core_frontend\`, Frameworks row shows only \`django\`/\`django_admin\`/\`http_wrapper\`/\`python\`/\`react_query\`
- Zero console errors on both surfaces

## Constraints

- Only Surface 4 (Paths) + shared theme infrastructure touched
- Graph / Flows / Topology / Docs untouched
- \`PathTreeSidebar.tsx\` file preserved; only its usage in \`paths.tsx\` removed

Closes #963 #967 #969 #970