### PR TITLE
ci: fast pre-merge gate (gofmt + vet + dashboard build)

### DIFF
--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,0 +1,38 @@
+name: pre-merge
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+jobs:
+  pre-merge-fast:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache: true
+      - name: gofmt
+        run: |
+          diff=$(gofmt -l $(git ls-files '*.go') 2>&1)
+          if [ -n "$diff" ]; then
+            echo "::error::gofmt found unformatted files:"
+            echo "$diff"
+            exit 1
+          fi
+      - name: go vet
+        run: go vet ./...
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dashboard/package-lock.json
+      - name: dashboard typecheck + build
+        working-directory: dashboard
+        run: |
+          npm ci
+          npm run build


### PR DESCRIPTION
## What we did
Added .github/workflows/pre-merge.yml that runs on every PR. Three checks: gofmt, go vet, dashboard build. Target wall-clock <60s after warm cache.

## What we won
Brings back PR-time signal removed by #901 (which disabled the heavy go test suite). Catches obvious mistakes without burning 10+ min per PR.

## Caveats
- No go test in this gate (kept on push:main via test.yml)
- No quality fixtures (kept on push:main via quality.yml)
- linux-smoke from #939 still runs only on push:main

## Bottom line
Cheap signal restored. Refs #815.