### PR TITLE
[#964 #965 #966] Fix three empty dashboard surfaces on real data

### DIFF
--- a/dashboard/src/components/graph/GraphEmptyState.tsx
+++ b/dashboard/src/components/graph/GraphEmptyState.tsx
@@ -13,8 +13,8 @@ export function GraphEmptyState({ reason = 'no-group' }: GraphEmptyStateProps) {
     return (
       <EmptyState
         icon={Filter}
-        title="Graph too large to render"
-        message="This graph has more than 20 000 nodes. Apply a filter or select a specific repo to render it."
+        title="Graph too large to render at full resolution"
+        message="This group has more than 20 000 entities. Use the edge-kind filters above to narrow the view, or zoom out to explore community clusters."
       />
     )
   }
@@ -23,7 +23,7 @@ export function GraphEmptyState({ reason = 'no-group' }: GraphEmptyStateProps) {
       <EmptyState
         icon={Filter}
         title="No nodes match current filters"
-        message="Try adjusting the edge-kind filters or clearing the repo filter."
+        message="Try adjusting the edge-kind filters to show more of the graph."
       />
     )
   }

--- a/dashboard/src/routes/topology.tsx
+++ b/dashboard/src/routes/topology.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect } from 'react'
+import { useState, useCallback, useEffect, useMemo } from 'react'
 import { useParams } from 'react-router-dom'
 import { useTopologyData } from '@/hooks/topology/useTopologyData'
 import { useTopicDetail } from '@/hooks/topology/useTopicDetail'
@@ -15,6 +15,28 @@ import { TopologyLoadingState } from '@/components/topology/TopologyLoadingState
 import { TopologyEmptyState } from '@/components/topology/TopologyEmptyState'
 import { TopologyErrorState } from '@/components/topology/TopologyErrorState'
 import { Search, X, Map, List } from 'lucide-react'
+import type { TopologyResponse, TopologyProtocol } from '@/types/api'
+
+// ── derive available protocols from actual data ───────────────────────────────
+// Only show chips for protocols that have at least one entity in the response.
+// This prevents phantom chips (e.g. "Kafka") for groups with no Kafka data.
+function deriveAvailableProtocols(data: TopologyResponse | undefined): TopologyProtocol[] {
+  if (!data) return []
+  const protocols = new Set<TopologyProtocol>()
+  for (const t of data.topics ?? []) protocols.add(t.broker as TopologyProtocol)
+  for (const q of data.queues ?? []) {
+    const broker = q.broker as TopologyProtocol
+    // Redis stream queues use a synthetic id prefix; normalise to redis-stream.
+    if (q.id?.startsWith('stream:redis:')) protocols.add('redis-stream')
+    else if (q.id?.startsWith('task:')) protocols.add('task-queue')
+    else protocols.add(broker)
+  }
+  for (const c of data.channels ?? []) protocols.add(c.channel_type as TopologyProtocol)
+  for (const _ of data.graphql_subscriptions ?? []) protocols.add('graphql_subscription')
+  for (const _ of data.nats_subjects ?? []) protocols.add('nats')
+  for (const _ of data.functions ?? []) protocols.add('serverless')
+  return [...protocols].sort()
+}
 
 // ────────────────────────────────────────────────────────────────────────────
 // localStorage persistence for view mode
@@ -84,7 +106,6 @@ export function TopologyRoute() {
 
   const {
     activeProtocols,
-    allProtocols,
     isAllActive,
     toggle,
     setAll,
@@ -100,6 +121,9 @@ export function TopologyRoute() {
   } = useTopologyData(group ?? '', {
     protocols: isAllActive ? [] : [...activeProtocols],
   })
+
+  // Derive the chip list from actual data — only show protocols that exist.
+  const availableProtocols = useMemo(() => deriveAvailableProtocols(data), [data])
 
   const layout = useTopologyLayout(data, activeProtocols)
   const searchResults = useTopologySearch(searchQuery, data)
@@ -153,7 +177,7 @@ export function TopologyRoute() {
       {/* Protocol filter chips + search + view mode toggle */}
       <div className="flex items-center gap-0 border-b border-slate-800 bg-slate-950/90 backdrop-blur-sm z-10 flex-shrink-0">
         <ProtocolFilterChips
-          allProtocols={allProtocols}
+          allProtocols={availableProtocols}
           activeProtocols={activeProtocols}
           isAllActive={isAllActive}
           onToggle={toggle}

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -179,6 +179,13 @@ func (c *GraphCache) loadGroup(groupName string) (*DashGroup, error) {
 		if err != nil {
 			dr.err = err.Error()
 		} else {
+			// graph.fb (the canonical store) omits community/pagerank/god-node
+			// data — those fields live only in graph.json and are not encoded in
+			// the FlatBuffers schema. Re-derive them from the loaded entities so
+			// the dashboard graph endpoints (centroids, mid, full) see the data.
+			if len(doc.Communities) == 0 && len(doc.Entities) > 0 {
+				attachAlgorithmResults(doc)
+			}
 			dr.Doc = doc
 			// Record the newer of fb/json mtime for cache invalidation.
 			if info, e := os.Stat(filepath.Join(stateDir, "graph.fb")); e == nil {
@@ -200,6 +207,35 @@ func (c *GraphCache) loadGroup(groupName string) (*DashGroup, error) {
 	}
 
 	return grp, nil
+}
+
+// attachAlgorithmResults re-derives community, pagerank, and god-node data
+// for a Document loaded from graph.fb.  graph.fb does not encode these
+// fields (they are only present in graph.json), so the dashboard server runs
+// the same Pass-4 algorithms that the indexer ran at index time.  Results are
+// attached in place so subsequent handler calls see the community-derived
+// topology needed by serveGraphCentroids and serveGraphMid.
+func attachAlgorithmResults(doc *graph.Document) {
+	res := graph.RunAlgorithms(doc.Entities, doc.Relationships)
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if cid, ok := res.CommunityID[e.ID]; ok {
+			cidCopy := cid
+			e.CommunityID = &cidCopy
+		}
+		if pr, ok := res.PageRank[e.ID]; ok {
+			prCopy := pr
+			e.PageRank = &prCopy
+		}
+		if res.GodNodes[e.ID] {
+			e.IsGodNode = true
+		}
+	}
+	doc.Communities = res.Communities
+	if doc.AlgorithmStats == nil {
+		stats := res.Stats
+		doc.AlgorithmStats = &stats
+	}
 }
 
 // defaultLinksFile mirrors mcp.defaultLinksFile.

--- a/internal/dashboard/handlers_flows.go
+++ b/internal/dashboard/handlers_flows.go
@@ -176,19 +176,21 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 		EdgeKind   string `json:"edge_kind"`
 	}
 
-	// Build reverse adjacency: edges pointing INTO the process entity.
+	// STEP_IN_PROCESS edges are emitted as FromID=processID → ToID=stepEntityID
+	// (see engine/process_flow.go). Collect all edges whose FromID matches the
+	// process entity, then resolve the step entity from ToID.
 	var steps []Step
 	for _, r := range sortedRepos(grp) {
 		for _, rel := range r.Doc.Relationships {
 			if rel.Kind != stepInProcessEdge {
 				continue
 			}
-			// ToID should be the process entity ID.
-			if rel.ToID != processEnt.ID && dashPrefixedID(r.Slug, rel.ToID) != processID {
+			// FromID is the process entity ID.
+			if rel.FromID != processEnt.ID && dashPrefixedID(r.Slug, rel.FromID) != processID {
 				continue
 			}
-			// FromID is the step entity.
-			stepIDLocal := rel.FromID
+			// ToID is the step entity.
+			stepIDLocal := rel.ToID
 			stepRepo := r
 			// Find the step entity.
 			for i := range stepRepo.Doc.Entities {
@@ -214,12 +216,9 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 	sort.Slice(steps, func(i, j int) bool { return steps[i].StepIndex < steps[j].StepIndex })
 
 	// Collect source snippets for each step (context=5 lines).
-	type SourceSnippet struct {
-		EntityID string `json:"entity_id"`
-		Source   string `json:"source"`
-		Language string `json:"language"`
-	}
-	snippets := []SourceSnippet{}
+	// Response shape is a map of entity_id → source string, matching the
+	// FlowDetailResponse.source_snippets: Record<string, string> frontend type.
+	snippets := map[string]string{}
 	for _, step := range steps {
 		rSlug, localID := dashSplitPrefixed(step.EntityID)
 		r, ok := grp.Repos[rSlug]
@@ -233,11 +232,9 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 			src, _ := readSourceLines(e.SourceFile, r.Path, e.StartLine, e.EndLine, 5)
-			snippets = append(snippets, SourceSnippet{
-				EntityID: step.EntityID,
-				Source:   src,
-				Language: e.Language,
-			})
+			if src != "" {
+				snippets[step.EntityID] = src
+			}
 			break
 		}
 	}

--- a/internal/dashboard/handlers_topology.go
+++ b/internal/dashboard/handlers_topology.go
@@ -420,3 +420,16 @@ func inferProviderFromID(id string) string {
 		return "serverless"
 	}
 }
+
+// collectTopology is a compatibility shim used by the unit tests.  It
+// delegates to collectTopologyResponse and unpacks the struct into the
+// four slices the tests expect: (topics, queues, channels, functions).
+func collectTopology(grp *DashGroup) (
+	topics []map[string]any,
+	queues []map[string]any,
+	channels []map[string]any,
+	functions []map[string]any,
+) {
+	resp := collectTopologyResponse(grp)
+	return resp.Topics, resp.Queues, resp.Channels, resp.Functions
+}


### PR DESCRIPTION
## Summary

Three dashboard surfaces showed blank/empty content against real 20k-entity data. All three had different root causes.

## Root cause per surface

### #964 Graph — community data lost after graph.fb load
\`loadFBDocument\` (the FlatBuffers loader) reconstructs Entities and Relationships from graph.fb but omits Communities, PageRank, and IsGodNode — those fields are not encoded in the FB schema. Without community data, \`serveGraphCentroids\` and \`serveGraphMid\` return 0 nodes. \`serveGraphFull\` returns \`lod_level: "blocked"\` (>20k entities), which is correct but the empty-state message referenced a non-existent "repo filter" UI.

**Fix:** Added \`attachAlgorithmResults()\` in graphstate.go. When a doc is loaded from FB with no community data, it re-runs \`graph.RunAlgorithms\` (same pass the indexer runs) to reconstruct communities, PageRank, and god-nodes in-memory before caching. Updated \`GraphEmptyState\` messages to remove the phantom "repo filter" mention.

### #965 Flows detail — FromID/ToID swapped in step-collection loop
\`engine/process_flow.go\` emits STEP_IN_PROCESS edges as FromID=processID → ToID=stepEntity. The handler in handlers_flows.go was checking \`rel.ToID == processID\` (reversed), so it matched nothing and returned \`steps: null\`. Also changed \`source_snippets\` from \`[]SourceSnippet\` to \`map[string]string\` to match the FlowDetailResponse.source_snippets: Record<string, string> frontend type.

**Fix:** Flip the FromID/ToID check; change snippets accumulator to map[string]string keyed by entity ID.

### #966 Topology chips — hardcoded protocol list showed phantom chips
\`useProtocolFilters\` returned a static ALL_PROTOCOLS list of 13 protocols regardless of what data exists. Groups with no topology data had 13 chips before an empty canvas.

**Fix:** TopologyRoute now calls \`deriveAvailableProtocols(data)\` to build the chip list from the actual TopologyResponse. Groups with no topology entities show only "All" chip + honest empty state.

**Bonus:** Fixed pre-existing test compilation failure — collectTopology was renamed to collectTopologyResponse without updating the test file. Added compatibility shim.

## Test plan

- [x] \`go test ./internal/dashboard/\` — all 14 tests pass
- [x] \`go build ./...\` — clean
- [x] \`npx vite build\` — clean
- [x] Playwright /graph/upvate — 1570 centroid nodes rendered
- [x] Playwright /flows/upvate — click flow → swim lane shows all 6 steps
- [x] Playwright /topology/upvate — honest empty state, only "All" chip (no phantom Kafka)
- [x] Console errors: 0

## Screenshots

Saved to dashboard/e2e-screenshots/:
- 964-graph-upvate.png — community centroids visible
- 965-flows-detail.png — swim lane with 6 steps populated
- 966-topology-upvate.png — honest empty state, no phantom chips
- 966-topology-fixture946.png — honest empty state for un-indexed group

Closes #964 Closes #965 Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)