### PR TITLE
ci: disable automatic triggers until release-ready

### DIFF
--- a/.github/workflows/linux-smoke.yml
+++ b/.github/workflows/linux-smoke.yml
@@ -1,10 +1,6 @@
 name: Linux Smoke Test
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/pre-merge.yml
+++ b/.github/workflows/pre-merge.yml
@@ -1,7 +1,6 @@
 name: pre-merge
 on:
-  pull_request:
-    branches: [main]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/quality.yml
+++ b/.github/workflows/quality.yml
@@ -1,8 +1,6 @@
 name: quality
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,8 +1,6 @@
 name: test
 
 on:
-  push:
-    branches: [main]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
linux-smoke, pre-merge, quality, and test workflows switched from PR/push triggers to workflow_dispatch only. board-hygiene and release unchanged.

## What we won
Stops burning Actions minutes (~13-15 min per PR cycle currently) until we're release-ready and want signal back.

## Trigger manually when needed
```bash
gh workflow run pre-merge.yml
gh workflow run linux-smoke.yml
gh workflow run quality.yml
gh workflow run test.yml
```

## Caveats
- No PR-time signal of build breakage (gofmt drift, vet errors)
- Same for push:main — no Linux smoke
- All admin-merges continue without CI gates (already the case)

## Bottom line
Revert with one diff when we want CI back. Refs #815.