### PR TITLE
[#980] Move group switcher from sidebar to top-right dropdown

### DIFF
--- a/dashboard/src/components/layout/GroupSelector.tsx
+++ b/dashboard/src/components/layout/GroupSelector.tsx
@@ -1,0 +1,344 @@
+/**
+ * GroupSelector — top-right dropdown for navigating between indexing groups.
+ *
+ * Desktop: dropdown panel anchored below the trigger button.
+ * Mobile (≤640 px): full-screen sheet from the top.
+ *
+ * Features:
+ *  - Trigger: current group display name + ChevronDown
+ *  - Search input at top of panel
+ *  - Pinned groups section (max 3, star toggle per row)
+ *  - Other groups section
+ *  - Bug-rate status dot: green ≤5% / amber 5–15% / red >15%
+ *  - Entity-count tooltip
+ *  - Selected row visually highlighted
+ *  - Closes on outside-click or Escape
+ *  - Switching preserves the current surface (path replacement)
+ */
+
+import {
+  useState,
+  useMemo,
+  useCallback,
+  useRef,
+  useEffect,
+  KeyboardEvent as ReactKeyboardEvent,
+} from 'react'
+import { useNavigate, useParams, useLocation } from 'react-router-dom'
+import { Search, Pin, PinOff, ChevronDown, X } from 'lucide-react'
+import type { GroupMeta } from '@/types/api'
+import { getPinnedGroups, togglePin } from '@/lib/groupPins'
+
+interface GroupSelectorProps {
+  groups: GroupMeta[]
+}
+
+/** Derive a synthetic bug-rate bucket from entity_count for mock data. */
+function bugRateBucket(g: GroupMeta): 'green' | 'amber' | 'red' {
+  const sum = g.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
+  const pct = sum % 30
+  if (pct <= 5) return 'green'
+  if (pct <= 15) return 'amber'
+  return 'red'
+}
+
+const bucketClass: Record<'green' | 'amber' | 'red', string> = {
+  green: 'bg-emerald-500',
+  amber: 'bg-amber-400',
+  red: 'bg-red-500',
+}
+
+const bucketLabel: Record<'green' | 'amber' | 'red', string> = {
+  green: '≤5% bug rate',
+  amber: '5–15% bug rate',
+  red: '>15% bug rate',
+}
+
+/** Extracts the current surface prefix from a pathname like "/flows/fixture-a" → "flows" */
+function surfaceFromPath(pathname: string): string {
+  const seg = pathname.split('/').filter(Boolean)[0]
+  return seg ?? 'graph'
+}
+
+export function GroupSelector({ groups }: GroupSelectorProps) {
+  const { group: activeGroup = '' } = useParams()
+  const navigate = useNavigate()
+  const location = useLocation()
+
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [pinnedIds, setPinnedIds] = useState<string[]>(() => getPinnedGroups())
+
+  const containerRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+
+  const surface = surfaceFromPath(location.pathname)
+
+  // Find display name for the active group
+  const activeDisplay = useMemo(() => {
+    return groups.find((g) => g.id === activeGroup)?.display_name ?? activeGroup
+  }, [groups, activeGroup])
+
+  // Filter groups by search query
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase()
+    if (!q) return groups
+    return groups.filter(
+      (g) =>
+        g.id.toLowerCase().includes(q) ||
+        g.display_name.toLowerCase().includes(q),
+    )
+  }, [groups, query])
+
+  // Split into pinned / other
+  const { pinned, others } = useMemo(() => {
+    const pinnedSet = new Set(pinnedIds)
+    return {
+      pinned: filtered.filter((g) => pinnedSet.has(g.id)),
+      others: filtered.filter((g) => !pinnedSet.has(g.id)),
+    }
+  }, [filtered, pinnedIds])
+
+  // Open/close helpers
+  const openPanel = useCallback(() => {
+    setOpen(true)
+    // Focus search after paint
+    requestAnimationFrame(() => searchRef.current?.focus())
+  }, [])
+
+  const closePanel = useCallback(() => {
+    setOpen(false)
+    setQuery('')
+  }, [])
+
+  // Close on outside-click
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (containerRef.current && !containerRef.current.contains(e.target as Node)) {
+        closePanel()
+      }
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open, closePanel])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: globalThis.KeyboardEvent) => {
+      if (e.key === 'Escape') closePanel()
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, closePanel])
+
+  const handleSelect = useCallback(
+    (groupId: string) => {
+      navigate(`/${surface}/${groupId}`)
+      closePanel()
+    },
+    [navigate, surface, closePanel],
+  )
+
+  const handleTogglePin = useCallback(
+    (e: React.MouseEvent | ReactKeyboardEvent, groupId: string) => {
+      e.stopPropagation()
+      const next = togglePin(groupId)
+      setPinnedIds(next)
+    },
+    [],
+  )
+
+  const isMobile = typeof window !== 'undefined' && window.innerWidth < 640
+
+  return (
+    <div ref={containerRef} className="relative" data-testid="group-selector">
+      {/* Trigger button */}
+      <button
+        type="button"
+        aria-label="Select group"
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        onClick={() => (open ? closePanel() : openPanel())}
+        className={[
+          'flex items-center gap-1.5 px-3 py-1.5 rounded text-sm transition-colors',
+          'border border-slate-700',
+          open
+            ? 'bg-slate-800 text-slate-200 border-sky-500'
+            : 'bg-slate-900 text-slate-400 hover:bg-slate-800 hover:text-slate-200',
+        ].join(' ')}
+        data-testid="group-selector-trigger"
+      >
+        <span className="font-mono max-w-[12rem] truncate" data-testid="group-selector-label">
+          {activeDisplay || 'Select group'}
+        </span>
+        <ChevronDown
+          className={[
+            'w-3.5 h-3.5 flex-shrink-0 transition-transform',
+            open ? 'rotate-180' : '',
+          ].join(' ')}
+          aria-hidden
+        />
+      </button>
+
+      {/* Dropdown / sheet panel */}
+      {open && (
+        <div
+          className={[
+            // Mobile: fixed full-screen sheet from top
+            'sm:absolute sm:right-0 sm:top-full sm:mt-1 sm:w-72',
+            'sm:max-h-[min(480px,80vh)] sm:rounded-lg sm:shadow-xl sm:border sm:border-slate-700',
+            // Mobile overrides applied below via fixed
+            'fixed sm:static inset-x-0 top-12 bottom-0 sm:inset-auto',
+            'bg-slate-950 z-50 flex flex-col',
+          ].join(' ')}
+          role="dialog"
+          aria-modal="false"
+          aria-label="Group selector"
+          data-testid="group-selector-panel"
+        >
+          {/* Mobile close strip */}
+          <div className="flex items-center justify-between px-3 py-2 border-b border-slate-800 sm:hidden">
+            <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+              Switch group
+            </span>
+            <button
+              type="button"
+              aria-label="Close"
+              onClick={closePanel}
+              className="p-1 rounded text-slate-500 hover:text-slate-300"
+            >
+              <X className="w-4 h-4" />
+            </button>
+          </div>
+
+          {/* Search input */}
+          <div className="relative px-3 py-2 border-b border-slate-800">
+            <Search
+              className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-600 pointer-events-none"
+              aria-hidden
+            />
+            <input
+              ref={searchRef}
+              type="search"
+              placeholder="Filter groups…"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              aria-label="Filter groups"
+              className={[
+                'w-full bg-slate-900 border border-slate-700 rounded text-xs',
+                'pl-7 pr-2 py-1.5 text-slate-300 placeholder-slate-600',
+                'focus:outline-none focus:ring-1 focus:ring-sky-500 focus:border-sky-500',
+              ].join(' ')}
+              data-testid="group-selector-search"
+            />
+          </div>
+
+          {/* Scrollable list */}
+          <div className="overflow-y-auto flex-1" role="listbox" aria-label="Groups">
+            {pinned.length === 0 && others.length === 0 && (
+              <p className="px-4 py-3 text-xs text-slate-600 select-none">
+                No groups match
+              </p>
+            )}
+
+            {/* Pinned section */}
+            {pinned.length > 0 && (
+              <GroupSection label="Pinned" groups={pinned} activeGroup={activeGroup} pinnedIds={pinnedIds} onSelect={handleSelect} onTogglePin={handleTogglePin} />
+            )}
+
+            {/* Other section */}
+            {others.length > 0 && (
+              <GroupSection label={pinned.length > 0 ? 'Other' : undefined} groups={others} activeGroup={activeGroup} pinnedIds={pinnedIds} onSelect={handleSelect} onTogglePin={handleTogglePin} />
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─── GroupSection ─────────────────────────────────────────────────────────────
+
+interface GroupSectionProps {
+  label?: string
+  groups: GroupMeta[]
+  activeGroup: string
+  pinnedIds: string[]
+  onSelect: (id: string) => void
+  onTogglePin: (e: React.MouseEvent | ReactKeyboardEvent, id: string) => void
+}
+
+function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onTogglePin }: GroupSectionProps) {
+  return (
+    <div>
+      {label && (
+        <p className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-slate-600 font-semibold select-none">
+          {label}
+        </p>
+      )}
+      <ul>
+        {groups.map((g) => {
+          const isActive = g.id === activeGroup
+          const isPinned = pinnedIds.includes(g.id)
+          const bucket = bugRateBucket(g)
+
+          return (
+            <li key={g.id}>
+              <button
+                type="button"
+                role="option"
+                aria-selected={isActive}
+                onClick={() => onSelect(g.id)}
+                className={[
+                  'group w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors',
+                  'border-l-2',
+                  isActive
+                    ? 'bg-slate-800 border-sky-500 text-slate-100'
+                    : 'border-transparent text-slate-400 hover:bg-slate-800/60 hover:text-slate-300',
+                ].join(' ')}
+              >
+                {/* Group name */}
+                <span className="flex-1 font-mono truncate" title={g.display_name}>
+                  {g.display_name}
+                </span>
+
+                {/* Pin toggle */}
+                <span
+                  role="button"
+                  tabIndex={0}
+                  onClick={(e) => onTogglePin(e, g.id)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' || e.key === ' ') {
+                      e.stopPropagation()
+                      onTogglePin(e, g.id)
+                    }
+                  }}
+                  aria-label={isPinned ? `Unpin ${g.display_name}` : `Pin ${g.display_name}`}
+                  title={isPinned ? 'Unpin' : 'Pin to top'}
+                  className={[
+                    'p-0.5 rounded transition-colors cursor-pointer',
+                    isPinned
+                      ? 'text-sky-400 opacity-100'
+                      : 'text-slate-600 opacity-0 group-hover:opacity-100',
+                    'hover:text-sky-300',
+                  ].join(' ')}
+                >
+                  {isPinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
+                </span>
+
+                {/* Bug-rate dot */}
+                <span
+                  title={`${bucketLabel[bucket]} — ${g.entity_count.toLocaleString()} entities`}
+                  aria-label={bucketLabel[bucket]}
+                  className={['w-2 h-2 rounded-full flex-shrink-0', bucketClass[bucket]].join(' ')}
+                />
+              </button>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
+}

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -1,12 +1,12 @@
 import { Link, NavLink, Outlet, useParams } from 'react-router-dom'
-import { useState, useEffect } from 'react'
+import { useEffect } from 'react'
 import {
   GitBranch, Network, Workflow, Radio, Globe, BookOpen,
-  Moon, Sun, Settings, Menu, X,
+  Moon, Sun, Settings,
 } from 'lucide-react'
 import { useRegistry } from '@/hooks/shared/useRegistry'
 import { useThemeContext } from '@/context/ThemeContext'
-import { GroupSwitcher } from '@/components/layout/GroupSwitcher'
+import { GroupSelector } from '@/components/layout/GroupSelector'
 
 const GROUP_DEFAULT = 'fixture-a'
 
@@ -33,25 +33,10 @@ export function AppLayout() {
     return () => document.removeEventListener('keydown', handler)
   }, [])
 
-  // Mobile sidebar state
-  const [drawerOpen, setDrawerOpen] = useState(false)
-  const closeDrawer = () => setDrawerOpen(false)
-
   return (
     <div className="flex flex-col h-screen bg-slate-950 text-slate-200">
       {/* ── Top nav ──────────────────────────────────────────────────────────── */}
       <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-800 flex-shrink-0 bg-slate-950/90 backdrop-blur-sm z-20">
-        {/* Mobile hamburger — only on small screens */}
-        <button
-          type="button"
-          aria-label="Open group navigation"
-          aria-expanded={drawerOpen}
-          onClick={() => setDrawerOpen((v) => !v)}
-          className="lg:hidden p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
-        >
-          {drawerOpen ? <X className="w-4 h-4" /> : <Menu className="w-4 h-4" />}
-        </button>
-
         {/* Logo */}
         <Link to="/" className="flex items-center gap-2 font-bold text-sm tracking-tight text-sky-400 hover:text-sky-300">
           <GitBranch className="w-5 h-5" aria-hidden />
@@ -59,7 +44,7 @@ export function AppLayout() {
         </Link>
 
         {/* Surface nav — 5 chips (Graph / Flows / Topology / Paths / Docs) */}
-        <nav className="flex items-center gap-1 ml-4" aria-label="Surface navigation">
+        <nav className="flex items-center gap-0.5 ml-2 sm:ml-4 sm:gap-1 flex-shrink-0" aria-label="Surface navigation">
           <NavItem to={`/graph/${group}`} icon={<Network className="w-4 h-4" />} label="Graph" />
           <NavItem to={`/flows/${group}`} icon={<Workflow className="w-4 h-4" />} label="Flows" />
           <NavItem to={`/topology/${group}`} icon={<Radio className="w-4 h-4" />} label="Topology" />
@@ -68,6 +53,8 @@ export function AppLayout() {
         </nav>
 
         <div className="ml-auto flex items-center gap-2">
+          {/* Group selector — sits between theme toggle and settings */}
+          <GroupSelector groups={groups} />
           <ThemeToggle />
           <Link
             to="/settings"
@@ -79,46 +66,10 @@ export function AppLayout() {
         </div>
       </header>
 
-      {/* ── Body: sidebar + content ───────────────────────────────────────────── */}
-      <div className="flex flex-1 min-h-0 overflow-hidden">
-        {/* ── Desktop sidebar ─────────────────────────────────────────────────── */}
-        <aside
-          className="hidden lg:flex flex-col w-52 min-w-[180px] border-r border-slate-800 bg-slate-950/80 py-3 overflow-y-auto flex-shrink-0"
-          aria-label="Group navigation"
-          data-testid="group-sidebar"
-        >
-          {groups.length > 0 ? (
-            <GroupSwitcher groups={groups} />
-          ) : (
-            <p className="px-3 text-xs text-slate-600">Loading…</p>
-          )}
-        </aside>
-
-        {/* ── Mobile slide-out drawer ──────────────────────────────────────────── */}
-        {drawerOpen && (
-          <>
-            {/* Backdrop */}
-            <div
-              className="lg:hidden fixed inset-0 z-30 bg-black/50"
-              aria-hidden
-              onClick={closeDrawer}
-            />
-            {/* Drawer panel */}
-            <div
-              className="lg:hidden fixed top-12 left-0 bottom-0 z-40 w-64 bg-slate-950 border-r border-slate-800 py-3 overflow-y-auto"
-              aria-label="Group navigation"
-              data-testid="group-drawer"
-            >
-              <GroupSwitcher groups={groups} onNavigate={closeDrawer} />
-            </div>
-          </>
-        )}
-
-        {/* ── Page content ─────────────────────────────────────────────────────── */}
-        <main className="flex-1 overflow-hidden">
-          <Outlet />
-        </main>
-      </div>
+      {/* ── Body: full-width content (sidebar removed) ───────────────────────── */}
+      <main className="flex-1 overflow-hidden">
+        <Outlet />
+      </main>
     </div>
   )
 }
@@ -133,9 +84,11 @@ function NavItem({ to, icon, label }: NavItemProps) {
   return (
     <NavLink
       to={to}
+      aria-label={label}
       className={({ isActive }) =>
         [
-          'flex items-center gap-1.5 px-3 py-1.5 rounded text-sm transition-colors',
+          'flex items-center gap-1.5 px-2 py-1.5 rounded text-sm transition-colors',
+          'sm:px-3',
           isActive
             ? 'bg-slate-800 text-slate-200'
             : 'text-slate-500 hover:bg-slate-800/60 hover:text-slate-300',
@@ -143,7 +96,7 @@ function NavItem({ to, icon, label }: NavItemProps) {
       }
     >
       {icon}
-      {label}
+      <span className="hidden sm:inline">{label}</span>
     </NavLink>
   )
 }

--- a/dashboard/tests/components/GroupSelector.test.tsx
+++ b/dashboard/tests/components/GroupSelector.test.tsx
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Route, Routes } from 'react-router-dom'
+import { GroupSelector } from '@/components/layout/GroupSelector'
+import type { GroupMeta } from '@/types/api'
+
+const mockGroups: GroupMeta[] = [
+  {
+    id: 'fixture-a',
+    display_name: 'Fixture A',
+    repos: [],
+    entity_count: 6916,
+    indexed_at: '2026-05-20T10:05:00Z',
+  },
+  {
+    id: 'fixture-b',
+    display_name: 'Fixture B',
+    repos: [],
+    entity_count: 4557,
+    indexed_at: '2026-05-20T09:05:00Z',
+  },
+]
+
+function renderWithRouter(path: string) {
+  return render(
+    <MemoryRouter initialEntries={[path]}>
+      <Routes>
+        <Route
+          path="/:surface/:group"
+          element={<GroupSelector groups={mockGroups} />}
+        />
+      </Routes>
+    </MemoryRouter>,
+  )
+}
+
+describe('GroupSelector', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('renders trigger with active group name', () => {
+    renderWithRouter('/graph/fixture-a')
+    expect(screen.getByTestId('group-selector-label').textContent).toBe('Fixture A')
+  })
+
+  it('opens panel when trigger is clicked', () => {
+    renderWithRouter('/graph/fixture-a')
+    expect(screen.queryByTestId('group-selector-panel')).toBeNull()
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    expect(screen.getByTestId('group-selector-panel')).toBeDefined()
+  })
+
+  it('renders all groups inside open panel', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    // 'Fixture A' appears in both the trigger label and the list row
+    expect(screen.getAllByText('Fixture A').length).toBeGreaterThanOrEqual(1)
+    expect(screen.getByText('Fixture B')).toBeDefined()
+  })
+
+  it('marks the active group as selected', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    const activeOption = screen.getAllByRole('option').find(
+      (o) => o.getAttribute('aria-selected') === 'true',
+    )
+    expect(activeOption?.textContent).toContain('Fixture A')
+  })
+
+  it('filters groups by search query', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    const input = screen.getByTestId('group-selector-search')
+    fireEvent.change(input, { target: { value: 'B' } })
+    const options = screen.getAllByRole('option')
+    expect(options).toHaveLength(1)
+    expect(options[0].textContent).toContain('Fixture B')
+  })
+
+  it('renders status dots for all groups', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    const dots = screen.getAllByRole('option').flatMap(
+      (o) => Array.from(o.querySelectorAll('[aria-label*="bug rate"]')),
+    )
+    expect(dots.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows "No groups match" when filter has no results', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    const input = screen.getByTestId('group-selector-search')
+    fireEvent.change(input, { target: { value: 'zzz' } })
+    expect(screen.getByText('No groups match')).toBeDefined()
+  })
+
+  it('closes panel on Escape key', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    expect(screen.getByTestId('group-selector-panel')).toBeDefined()
+    fireEvent.keyDown(document, { key: 'Escape' })
+    expect(screen.queryByTestId('group-selector-panel')).toBeNull()
+  })
+
+  it('closes panel when a group is selected', () => {
+    renderWithRouter('/graph/fixture-a')
+    fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    const fixtureB = screen.getAllByRole('option').find(
+      (o) => o.textContent?.includes('Fixture B'),
+    )!
+    fireEvent.click(fixtureB)
+    expect(screen.queryByTestId('group-selector-panel')).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

- Remove the left `<aside>` sidebar and mobile hamburger drawer entirely — all surfaces now expand to fill full window width
- Add `GroupSelector.tsx`: top-right dropdown trigger (current group name + chevron), opens a panel with search input, pinned-groups section (max 3, star toggle), other-groups section, bug-rate dots, entity-count tooltips, closes on outside-click or Escape
- On mobile (`< sm`): nav labels hidden (icons only), panel becomes a full-screen sheet from top with a close strip
- Switching group preserves the current surface via path replacement (`/flows/A → /flows/B`)
- Old `GroupSwitcher.tsx` superseded by new `GroupSelector.tsx`

## Test plan

- [x] `vite build` clean — 13.7 s, zero errors
- [x] 124 unit tests pass (`vitest run`, 20 test files)
- [x] `GroupSelector.test.tsx` — trigger renders active group, panel open/close, search filter, active-row highlight, status dots, no-match text, Escape close, select-closes-panel
- [x] Playwright E2E screenshots: graph/flows/topology/paths full-width, dropdown open + filtered + switched, mobile sheet mode
- [x] Surface-preserving navigation: `/paths/upvate → click other group → /paths/<group>`
- [x] Console clean (0 errors)

## Notes

- Bug-rate dot colours use a deterministic hash of `group.id` until a real `bug_rate` API field ships (same approach as the old `GroupSwitcher`)
- `GroupSwitcher.tsx` left in place but no longer imported — can be deleted in a follow-up

Closes #980