### PR TITLE
[#981] Fix light theme: default light, add dark: prefixes to all 59 components

### DIFF
--- a/dashboard/index.html
+++ b/dashboard/index.html
@@ -1,11 +1,23 @@
 <!doctype html>
-<html lang="en" class="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/archigraph.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="Archigraph — Code Knowledge Graph Dashboard" />
     <title>Archigraph</title>
+    <!-- FOUC prevention: apply theme before first paint, default = light -->
+    <script>
+      (function() {
+        var stored = localStorage.getItem('theme');
+        var theme = (stored === 'dark' || stored === 'light') ? stored : 'light';
+        document.documentElement.classList.remove('dark', 'light');
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+        // No class needed for light — html:not(.dark) handles it
+      })();
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -53,7 +53,7 @@ const router = createBrowserRouter([
           {
             index: true,
             element: (
-              <div className="h-full flex items-center justify-center text-slate-600">
+              <div className="h-full flex items-center justify-center text-slate-500 dark:text-slate-600">
                 <EmptyState
                   icon={Globe}
                   title="Select a path"

--- a/dashboard/src/components/RouterErrorBoundary.tsx
+++ b/dashboard/src/components/RouterErrorBoundary.tsx
@@ -11,57 +11,57 @@ export function RouterErrorBoundary() {
 
     if (status === 404) {
       return (
-        <div className="flex flex-col h-screen bg-slate-950 text-slate-200">
-          <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-800 flex-shrink-0 bg-slate-950/90 backdrop-blur-sm z-20">
+        <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-slate-800 dark:text-slate-200">
+          <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-200 dark:border-slate-800 flex-shrink-0 bg-white/90 dark:bg-slate-950/90 backdrop-blur-sm z-20">
             <span className="text-sm font-bold tracking-tight text-sky-400">archigraph</span>
           </header>
 
           <main className="flex-1 flex items-center justify-center overflow-hidden">
             <div className="flex flex-col items-center gap-8 text-center max-w-lg px-4">
               {/* Icon */}
-              <div className="rounded-full bg-slate-800 p-4">
+              <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
                 <AlertTriangle className="w-8 h-8 text-amber-500" aria-hidden />
               </div>
 
               {/* Title */}
               <div className="space-y-2">
-                <h1 className="text-3xl font-bold text-slate-200">Page Not Found</h1>
-                <p className="text-sm text-slate-500">
-                  We couldn't find <code className="font-mono text-slate-400 bg-slate-800 px-2 py-1 rounded">{attemptedPath}</code>
+                <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-200">Page Not Found</h1>
+                <p className="text-sm text-slate-400 dark:text-slate-500">
+                  We couldn't find <code className="font-mono text-slate-400 dark:text-slate-400 bg-slate-200 dark:bg-slate-800 px-2 py-1 rounded">{attemptedPath}</code>
                 </p>
               </div>
 
               {/* Navigation surfaces */}
               <div className="space-y-4 w-full">
-                <p className="text-sm text-slate-400">Navigate to one of these surfaces:</p>
+                <p className="text-sm text-slate-400 dark:text-slate-400">Navigate to one of these surfaces:</p>
                 <nav className="grid grid-cols-2 gap-3 sm:grid-cols-3">
                   <a
                     href="/graph/fixture-a"
-                    className="px-4 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors text-sm font-medium border border-slate-700 hover:border-slate-600"
+                    className="px-4 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors text-sm font-medium border border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-600"
                   >
                     Graph
                   </a>
                   <a
                     href="/flows/fixture-a"
-                    className="px-4 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors text-sm font-medium border border-slate-700 hover:border-slate-600"
+                    className="px-4 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors text-sm font-medium border border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-600"
                   >
                     Flows
                   </a>
                   <a
                     href="/topology/fixture-a"
-                    className="px-4 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors text-sm font-medium border border-slate-700 hover:border-slate-600"
+                    className="px-4 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors text-sm font-medium border border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-600"
                   >
                     Topology
                   </a>
                   <a
                     href="/paths/fixture-a"
-                    className="px-4 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors text-sm font-medium border border-slate-700 hover:border-slate-600"
+                    className="px-4 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors text-sm font-medium border border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-600"
                   >
                     Paths
                   </a>
                   <a
                     href="/docs/fixture-a"
-                    className="px-4 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors text-sm font-medium border border-slate-700 hover:border-slate-600"
+                    className="px-4 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors text-sm font-medium border border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-600"
                   >
                     Docs
                   </a>
@@ -84,28 +84,28 @@ export function RouterErrorBoundary() {
 
     // Other HTTP errors (5xx, etc.)
     return (
-      <div className="flex flex-col h-screen bg-slate-950 text-slate-200">
-        <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-800 flex-shrink-0 bg-slate-950/90 backdrop-blur-sm z-20">
+      <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-slate-800 dark:text-slate-200">
+        <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-200 dark:border-slate-800 flex-shrink-0 bg-white/90 dark:bg-slate-950/90 backdrop-blur-sm z-20">
           <span className="text-sm font-bold tracking-tight text-sky-400">archigraph</span>
         </header>
 
         <main className="flex-1 flex items-center justify-center overflow-hidden">
           <div className="flex flex-col items-center gap-6 text-center max-w-lg px-4">
             {/* Icon */}
-            <div className="rounded-full bg-slate-800 p-4">
+            <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
               <AlertTriangle className="w-8 h-8 text-red-500" aria-hidden />
             </div>
 
             {/* Title */}
             <div className="space-y-2">
-              <h1 className="text-3xl font-bold text-slate-200">Error {status}</h1>
-              <p className="text-sm text-slate-500">{error.statusText || 'An error occurred'}</p>
+              <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-200">Error {status}</h1>
+              <p className="text-sm text-slate-400 dark:text-slate-500">{error.statusText || 'An error occurred'}</p>
             </div>
 
             {/* Error details */}
             {error.data && (
               <div className="w-full text-left">
-                <p className="text-xs text-slate-400 bg-slate-900/50 border border-slate-800 rounded p-3 font-mono break-words">
+                <p className="text-xs text-slate-400 dark:text-slate-400 bg-slate-100/50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800 rounded p-3 font-mono break-words">
                   {error.data}
                 </p>
               </div>
@@ -115,7 +115,7 @@ export function RouterErrorBoundary() {
             <div className="flex flex-col gap-3 w-full">
               <button
                 onClick={() => window.location.reload()}
-                className="px-6 py-3 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors font-semibold"
+                className="px-6 py-3 rounded-lg bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors font-semibold"
               >
                 Reload
               </button>
@@ -123,7 +123,7 @@ export function RouterErrorBoundary() {
                 href="https://github.com/cajasmota/archigraph/issues/new"
                 target="_blank"
                 rel="noopener noreferrer"
-                className="px-6 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors font-semibold flex items-center justify-center gap-2"
+                className="px-6 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors font-semibold flex items-center justify-center gap-2"
               >
                 <Bug className="w-4 h-4" aria-hidden />
                 Report Issue
@@ -137,28 +137,28 @@ export function RouterErrorBoundary() {
 
   // Unhandled runtime error
   return (
-    <div className="flex flex-col h-screen bg-slate-950 text-slate-200">
-      <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-800 flex-shrink-0 bg-slate-950/90 backdrop-blur-sm z-20">
+    <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-slate-800 dark:text-slate-200">
+      <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-200 dark:border-slate-800 flex-shrink-0 bg-white/90 dark:bg-slate-950/90 backdrop-blur-sm z-20">
         <span className="text-sm font-bold tracking-tight text-sky-400">archigraph</span>
       </header>
 
       <main className="flex-1 flex items-center justify-center overflow-hidden">
         <div className="flex flex-col items-center gap-6 text-center max-w-lg px-4">
           {/* Icon */}
-          <div className="rounded-full bg-slate-800 p-4">
+          <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
             <AlertTriangle className="w-8 h-8 text-red-500" aria-hidden />
           </div>
 
           {/* Title */}
           <div className="space-y-2">
-            <h1 className="text-3xl font-bold text-slate-200">Something Went Wrong</h1>
-            <p className="text-sm text-slate-500">An unexpected error occurred while rendering this page.</p>
+            <h1 className="text-3xl font-bold text-slate-800 dark:text-slate-200">Something Went Wrong</h1>
+            <p className="text-sm text-slate-400 dark:text-slate-500">An unexpected error occurred while rendering this page.</p>
           </div>
 
           {/* Error message */}
           {error instanceof Error && (
             <div className="w-full text-left">
-              <p className="text-xs text-slate-400 bg-slate-900/50 border border-slate-800 rounded p-3 font-mono break-words">
+              <p className="text-xs text-slate-400 dark:text-slate-400 bg-slate-100/50 dark:bg-slate-900/50 border border-slate-200 dark:border-slate-800 rounded p-3 font-mono break-words">
                 {error.message}
               </p>
             </div>
@@ -168,7 +168,7 @@ export function RouterErrorBoundary() {
           <div className="flex flex-col gap-3 w-full">
             <button
               onClick={() => window.location.reload()}
-              className="px-6 py-3 rounded-lg bg-slate-800 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors font-semibold"
+              className="px-6 py-3 rounded-lg bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors font-semibold"
             >
               Reload
             </button>
@@ -176,7 +176,7 @@ export function RouterErrorBoundary() {
               href="https://github.com/cajasmota/archigraph/issues/new"
               target="_blank"
               rel="noopener noreferrer"
-              className="px-6 py-3 rounded-lg bg-slate-800/50 hover:bg-slate-700 text-slate-300 hover:text-slate-200 transition-colors font-semibold flex items-center justify-center gap-2"
+              className="px-6 py-3 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 hover:text-slate-800 dark:hover:text-slate-200 transition-colors font-semibold flex items-center justify-center gap-2"
             >
               <Bug className="w-4 h-4" aria-hidden />
               Report Issue

--- a/dashboard/src/components/docs/CodeBlock.tsx
+++ b/dashboard/src/components/docs/CodeBlock.tsx
@@ -37,17 +37,17 @@ export function CodeBlock({ code, language = 'text', showLineNumbers = false, fi
 
   return (
     <figure
-      className="my-4 rounded-lg overflow-hidden border border-slate-800 bg-slate-950"
+      className="my-4 rounded-lg overflow-hidden border border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950"
       aria-label={`Code block: ${language}`}
     >
       {/* Header */}
-      <div className="flex items-center justify-between gap-2 px-4 py-2 bg-slate-900 border-b border-slate-800">
+      <div className="flex items-center justify-between gap-2 px-4 py-2 bg-slate-100 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
         <div className="flex items-center gap-2 min-w-0">
           {filename && (
-            <span className="text-xs font-mono text-slate-400 truncate">{filename}</span>
+            <span className="text-xs font-mono text-slate-400 dark:text-slate-400 truncate">{filename}</span>
           )}
           {!filename && language && language !== 'text' && (
-            <span className="text-xs font-mono text-slate-500">{language}</span>
+            <span className="text-xs font-mono text-slate-400 dark:text-slate-500">{language}</span>
           )}
         </div>
         <button
@@ -57,7 +57,7 @@ export function CodeBlock({ code, language = 'text', showLineNumbers = false, fi
             'flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors',
             copied
               ? 'text-emerald-400 bg-emerald-950/50'
-              : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800',
+              : 'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800',
           )}
           onClick={handleCopy}
         >
@@ -97,7 +97,7 @@ export function CodeBlock({ code, language = 'text', showLineNumbers = false, fi
                 >
                   {showLineNumbers && (
                     <span
-                      className="table-cell pr-4 text-right select-none text-slate-600 text-xs"
+                      className="table-cell pr-4 text-right select-none text-slate-500 dark:text-slate-600 text-xs"
                       aria-hidden
                     >
                       {i + 1}

--- a/dashboard/src/components/docs/DocsBreadcrumbs.tsx
+++ b/dashboard/src/components/docs/DocsBreadcrumbs.tsx
@@ -13,19 +13,19 @@ interface DocsBreadcrumbsProps {
  */
 export function DocsBreadcrumbs({ group, crumbs }: DocsBreadcrumbsProps) {
   return (
-    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-slate-500 mb-6">
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm text-slate-400 dark:text-slate-500 mb-6">
       {crumbs.map((crumb, i) => (
         <span key={i} className="flex items-center gap-1 min-w-0">
-          {i > 0 && <ChevronRight className="w-3.5 h-3.5 flex-shrink-0 text-slate-600" aria-hidden />}
+          {i > 0 && <ChevronRight className="w-3.5 h-3.5 flex-shrink-0 text-slate-500 dark:text-slate-600" aria-hidden />}
           {crumb.path ? (
             <Link
               to={`/docs/${group}/${crumb.path}`}
-              className="hover:text-slate-300 transition-colors truncate"
+              className="hover:text-slate-700 dark:hover:text-slate-300 transition-colors truncate"
             >
               {crumb.label}
             </Link>
           ) : (
-            <span className="text-slate-300 truncate" aria-current="page">
+            <span className="text-slate-700 dark:text-slate-300 truncate" aria-current="page">
               {crumb.label}
             </span>
           )}

--- a/dashboard/src/components/docs/DocsPage.tsx
+++ b/dashboard/src/components/docs/DocsPage.tsx
@@ -33,10 +33,10 @@ export function DocsPage({ group, docPath }: DocsPageProps) {
   const { data: content, isLoading: contentLoading, error: contentError } = useDocContent(group, docPath)
 
   return (
-    <div className="flex flex-col h-full bg-slate-950">
+    <div className="flex flex-col h-full bg-white dark:bg-slate-950">
       {/* Search bar at top */}
-      <div className="flex items-center gap-4 px-4 py-3 border-b border-slate-800 bg-slate-950/50 flex-shrink-0">
-        <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Docs Search</span>
+      <div className="flex items-center gap-4 px-4 py-3 border-b border-slate-200 dark:border-slate-800 bg-white/50 dark:bg-slate-950/50 flex-shrink-0">
+        <span className="text-xs font-semibold text-slate-400 dark:text-slate-400 uppercase tracking-wider">Docs Search</span>
         <DocsTopSearch group={group} />
       </div>
 
@@ -49,12 +49,12 @@ export function DocsPage({ group, docPath }: DocsPageProps) {
 
         {/* Sidebar */}
         <aside
-          className="hidden md:flex flex-col w-60 flex-shrink-0 border-r border-slate-800 bg-slate-950/80 overflow-y-auto"
+          className="hidden md:flex flex-col w-60 flex-shrink-0 border-r border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 overflow-y-auto"
           aria-label="Documentation navigation"
         >
           {/* Sidebar header */}
-          <div className="flex items-center px-4 py-3 border-b border-slate-800">
-            <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">Navigation</span>
+          <div className="flex items-center px-4 py-3 border-b border-slate-200 dark:border-slate-800">
+            <span className="text-xs font-semibold text-slate-400 dark:text-slate-400 uppercase tracking-wider">Navigation</span>
           </div>
 
           {treeLoading && (

--- a/dashboard/src/components/docs/DocsPrevNext.tsx
+++ b/dashboard/src/components/docs/DocsPrevNext.tsx
@@ -18,17 +18,17 @@ export function DocsPrevNext({ group, prev, next }: DocsPrevNextProps) {
   return (
     <nav
       aria-label="Pagination navigation"
-      className="flex items-stretch justify-between gap-4 mt-12 pt-6 border-t border-slate-800"
+      className="flex items-stretch justify-between gap-4 mt-12 pt-6 border-t border-slate-200 dark:border-slate-800"
     >
       {prev ? (
         <Link
           to={`/docs/${group}/${prev.path}`}
-          className="flex items-center gap-3 flex-1 max-w-[calc(50%-8px)] p-4 rounded-lg border border-slate-800 hover:border-slate-600 hover:bg-slate-900 transition-colors group"
+          className="flex items-center gap-3 flex-1 max-w-[calc(50%-8px)] p-4 rounded-lg border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 hover:bg-slate-200 dark:hover:bg-slate-900 transition-colors group"
         >
-          <ChevronLeft className="w-5 h-5 flex-shrink-0 text-slate-500 group-hover:text-sky-400 transition-colors" aria-hidden />
+          <ChevronLeft className="w-5 h-5 flex-shrink-0 text-slate-400 dark:text-slate-500 group-hover:text-sky-400 transition-colors" aria-hidden />
           <div className="min-w-0">
-            <div className="text-xs text-slate-500 mb-0.5">Previous</div>
-            <div className="text-sm font-medium text-slate-300 group-hover:text-slate-100 truncate">
+            <div className="text-xs text-slate-400 dark:text-slate-500 mb-0.5">Previous</div>
+            <div className="text-sm font-medium text-slate-700 dark:text-slate-300 group-hover:text-slate-100 truncate">
               {prev.label}
             </div>
           </div>
@@ -40,15 +40,15 @@ export function DocsPrevNext({ group, prev, next }: DocsPrevNextProps) {
       {next ? (
         <Link
           to={`/docs/${group}/${next.path}`}
-          className="flex items-center gap-3 flex-1 max-w-[calc(50%-8px)] p-4 rounded-lg border border-slate-800 hover:border-slate-600 hover:bg-slate-900 transition-colors group text-right justify-end"
+          className="flex items-center gap-3 flex-1 max-w-[calc(50%-8px)] p-4 rounded-lg border border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600 hover:bg-slate-200 dark:hover:bg-slate-900 transition-colors group text-right justify-end"
         >
           <div className="min-w-0">
-            <div className="text-xs text-slate-500 mb-0.5">Next</div>
-            <div className="text-sm font-medium text-slate-300 group-hover:text-slate-100 truncate">
+            <div className="text-xs text-slate-400 dark:text-slate-500 mb-0.5">Next</div>
+            <div className="text-sm font-medium text-slate-700 dark:text-slate-300 group-hover:text-slate-100 truncate">
               {next.label}
             </div>
           </div>
-          <ChevronRight className="w-5 h-5 flex-shrink-0 text-slate-500 group-hover:text-sky-400 transition-colors" aria-hidden />
+          <ChevronRight className="w-5 h-5 flex-shrink-0 text-slate-400 dark:text-slate-500 group-hover:text-sky-400 transition-colors" aria-hidden />
         </Link>
       ) : (
         <div className="flex-1" />

--- a/dashboard/src/components/docs/DocsSearch.tsx
+++ b/dashboard/src/components/docs/DocsSearch.tsx
@@ -50,8 +50,8 @@ export function DocsSearch({ group }: DocsSearchProps) {
   return (
     <div className="relative">
       <label htmlFor="docs-search-input" className="sr-only">Search documentation</label>
-      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-800 border border-slate-700 focus-within:border-sky-500 transition-colors">
-        <Search className="w-4 h-4 text-slate-500 flex-shrink-0" aria-hidden />
+      <div className="flex items-center gap-2 px-3 py-1.5 rounded-lg bg-slate-200 dark:bg-slate-800 border border-slate-300 dark:border-slate-700 focus-within:border-sky-500 transition-colors">
+        <Search className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden />
         <input
           id="docs-search-input"
           ref={inputRef}
@@ -63,7 +63,7 @@ export function DocsSearch({ group }: DocsSearchProps) {
           aria-controls={listboxId}
           aria-autocomplete="list"
           autoComplete="off"
-          className="bg-transparent text-sm text-slate-200 placeholder:text-slate-500 outline-none min-w-0 w-40 focus:w-56 transition-all"
+          className="bg-transparent text-sm text-slate-800 dark:text-slate-200 placeholder:text-slate-500 outline-none min-w-0 w-40 focus:w-56 transition-all"
           onChange={(e) => {
             setQuery(e.target.value)
             setOpen(true)
@@ -75,14 +75,14 @@ export function DocsSearch({ group }: DocsSearchProps) {
           <button
             type="button"
             aria-label="Clear search"
-            className="text-slate-500 hover:text-slate-300"
+            className="text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             onClick={() => { setQuery(''); setOpen(false) }}
           >
             <X className="w-3.5 h-3.5" aria-hidden />
           </button>
         )}
         {!query && (
-          <kbd className="hidden sm:flex items-center px-1.5 py-0.5 rounded text-xs bg-slate-700 text-slate-400 border border-slate-600" aria-label="Press / to focus search">
+          <kbd className="hidden sm:flex items-center px-1.5 py-0.5 rounded text-xs bg-slate-300 dark:bg-slate-700 text-slate-400 dark:text-slate-400 border border-slate-400 dark:border-slate-600" aria-label="Press / to focus search">
             /
           </kbd>
         )}
@@ -93,15 +93,15 @@ export function DocsSearch({ group }: DocsSearchProps) {
           id={listboxId}
           role="listbox"
           aria-label="Search results"
-          className="absolute right-0 mt-2 w-80 max-h-80 overflow-y-auto rounded-lg bg-slate-900 border border-slate-700 shadow-xl z-50"
+          className="absolute right-0 mt-2 w-80 max-h-80 overflow-y-auto rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow-xl z-50"
         >
           {isFetching && (
             <div className="p-3">
-              <div className="animate-pulse h-4 rounded bg-slate-800" role="status" aria-label="Searching…" />
+              <div className="animate-pulse h-4 rounded bg-slate-200 dark:bg-slate-800" role="status" aria-label="Searching…" />
             </div>
           )}
           {!isFetching && !hasResults && query.length >= 2 && (
-            <div className="p-4 text-sm text-slate-500 text-center">
+            <div className="p-4 text-sm text-slate-400 dark:text-slate-500 text-center">
               No results for "{query}"
             </div>
           )}
@@ -111,11 +111,11 @@ export function DocsSearch({ group }: DocsSearchProps) {
                 <li key={result.path} role="option" aria-selected={false}>
                   <Link
                     to={`/docs/${group}/${result.path}`}
-                    className="block px-4 py-3 hover:bg-slate-800 transition-colors border-b border-slate-800 last:border-0"
+                    className="block px-4 py-3 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors border-b border-slate-200 dark:border-slate-800 last:border-0"
                     onClick={() => { setQuery(''); setOpen(false) }}
                   >
-                    <div className="text-sm font-medium text-slate-200 mb-0.5">{result.title}</div>
-                    <div className="text-xs text-slate-500 truncate">{result.excerpt}</div>
+                    <div className="text-sm font-medium text-slate-800 dark:text-slate-200 mb-0.5">{result.title}</div>
+                    <div className="text-xs text-slate-400 dark:text-slate-500 truncate">{result.excerpt}</div>
                   </Link>
                 </li>
               ))}

--- a/dashboard/src/components/docs/DocsSidebar.tsx
+++ b/dashboard/src/components/docs/DocsSidebar.tsx
@@ -65,7 +65,7 @@ function SidebarGroup({
         type="button"
         aria-expanded={isOpen}
         className={cn(
-          'flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-slate-400 hover:text-slate-200 hover:bg-slate-800/60 transition-colors text-left',
+          'flex w-full items-center gap-2 rounded px-2 py-1.5 text-sm text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200/60 dark:hover:bg-slate-800/60 transition-colors text-left',
           depth > 0 && 'pl-4',
         )}
         style={{ paddingLeft: `${(depth + 1) * 12}px` }}
@@ -74,15 +74,15 @@ function SidebarGroup({
       >
         <ChevronRight
           className={cn(
-            'w-3.5 h-3.5 flex-shrink-0 transition-transform text-slate-600',
+            'w-3.5 h-3.5 flex-shrink-0 transition-transform text-slate-500 dark:text-slate-600',
             isOpen && 'rotate-90',
           )}
           aria-hidden
         />
         {isOpen ? (
-          <FolderOpen className="w-3.5 h-3.5 flex-shrink-0 text-slate-500" aria-hidden />
+          <FolderOpen className="w-3.5 h-3.5 flex-shrink-0 text-slate-400 dark:text-slate-500" aria-hidden />
         ) : (
-          <Folder className="w-3.5 h-3.5 flex-shrink-0 text-slate-500" aria-hidden />
+          <Folder className="w-3.5 h-3.5 flex-shrink-0 text-slate-400 dark:text-slate-500" aria-hidden />
         )}
         <span className="truncate">{node.label}</span>
       </button>
@@ -128,7 +128,7 @@ function SidebarFile({
           'flex items-center gap-2 rounded py-1.5 pr-2 text-sm transition-colors',
           isActive
             ? 'bg-sky-950/60 text-sky-300 font-medium border-l-2 border-sky-500'
-            : 'text-slate-500 hover:text-slate-200 hover:bg-slate-800/40',
+            : 'text-slate-400 dark:text-slate-500 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-800/40',
         )}
         style={{ paddingLeft: `${(depth + 1) * 12 + 6}px` }}
       >

--- a/dashboard/src/components/docs/DocsTOC.tsx
+++ b/dashboard/src/components/docs/DocsTOC.tsx
@@ -27,7 +27,7 @@ export function DocsTOC({ headings, activeId }: DocsTOCProps) {
       aria-label="On this page"
       className="space-y-0.5"
     >
-      <p className="text-xs font-semibold text-slate-400 uppercase tracking-wider mb-3">
+      <p className="text-xs font-semibold text-slate-400 dark:text-slate-400 uppercase tracking-wider mb-3">
         On this page
       </p>
       {headings.map(({ id, text, depth }) => (
@@ -40,7 +40,7 @@ export function DocsTOC({ headings, activeId }: DocsTOCProps) {
             depth === 3 && 'pl-4',
             activeId === id
               ? 'text-sky-400 font-medium'
-              : 'text-slate-500 hover:text-slate-300',
+              : 'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
           )}
         >
           {text}

--- a/dashboard/src/components/docs/DocsTopSearch.tsx
+++ b/dashboard/src/components/docs/DocsTopSearch.tsx
@@ -50,8 +50,8 @@ export function DocsTopSearch({ group }: DocsTopSearchProps) {
   return (
     <div className="relative flex-1 max-w-md">
       <label htmlFor="docs-top-search-input" className="sr-only">Search documentation</label>
-      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-800/50 border border-slate-700 focus-within:border-sky-500 transition-colors">
-        <Search className="w-4 h-4 text-slate-500 flex-shrink-0" aria-hidden />
+      <div className="flex items-center gap-2 px-3 py-2 rounded-lg bg-slate-200/50 dark:bg-slate-800/50 border border-slate-300 dark:border-slate-700 focus-within:border-sky-500 transition-colors">
+        <Search className="w-4 h-4 text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden />
         <input
           id="docs-top-search-input"
           ref={inputRef}
@@ -63,7 +63,7 @@ export function DocsTopSearch({ group }: DocsTopSearchProps) {
           aria-controls={listboxId}
           aria-autocomplete="list"
           autoComplete="off"
-          className="bg-transparent text-sm text-slate-200 placeholder:text-slate-500 outline-none flex-1 w-full"
+          className="bg-transparent text-sm text-slate-800 dark:text-slate-200 placeholder:text-slate-500 outline-none flex-1 w-full"
           onChange={(e) => {
             setQuery(e.target.value)
             setOpen(true)
@@ -75,14 +75,14 @@ export function DocsTopSearch({ group }: DocsTopSearchProps) {
           <button
             type="button"
             aria-label="Clear search"
-            className="text-slate-500 hover:text-slate-300 flex-shrink-0"
+            className="text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 flex-shrink-0"
             onClick={() => { setQuery(''); setOpen(false) }}
           >
             <X className="w-3.5 h-3.5" aria-hidden />
           </button>
         )}
         {!query && (
-          <kbd className="hidden sm:flex items-center px-1.5 py-0.5 rounded text-xs bg-slate-700 text-slate-400 border border-slate-600 flex-shrink-0" aria-label="Press / to focus search">
+          <kbd className="hidden sm:flex items-center px-1.5 py-0.5 rounded text-xs bg-slate-300 dark:bg-slate-700 text-slate-400 dark:text-slate-400 border border-slate-400 dark:border-slate-600 flex-shrink-0" aria-label="Press / to focus search">
             /
           </kbd>
         )}
@@ -93,15 +93,15 @@ export function DocsTopSearch({ group }: DocsTopSearchProps) {
           id={listboxId}
           role="listbox"
           aria-label="Search results"
-          className="absolute left-0 right-0 top-full mt-2 max-h-96 overflow-y-auto rounded-lg bg-slate-900 border border-slate-700 shadow-xl z-50"
+          className="absolute left-0 right-0 top-full mt-2 max-h-96 overflow-y-auto rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow-xl z-50"
         >
           {isLoading && (
             <div className="p-3">
-              <div className="animate-pulse h-4 rounded bg-slate-800" role="status" aria-label="Searching…" />
+              <div className="animate-pulse h-4 rounded bg-slate-200 dark:bg-slate-800" role="status" aria-label="Searching…" />
             </div>
           )}
           {!isLoading && !hasResults && query.length >= 2 && (
-            <div className="p-4 text-sm text-slate-500 text-center">
+            <div className="p-4 text-sm text-slate-400 dark:text-slate-500 text-center">
               No results for "{query}"
             </div>
           )}
@@ -111,11 +111,11 @@ export function DocsTopSearch({ group }: DocsTopSearchProps) {
                 <li key={result.path} role="option" aria-selected={false}>
                   <Link
                     to={`/docs/${group}/${result.path}`}
-                    className="block px-4 py-3 hover:bg-slate-800 transition-colors border-b border-slate-800 last:border-0"
+                    className="block px-4 py-3 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors border-b border-slate-200 dark:border-slate-800 last:border-0"
                     onClick={() => { setQuery(''); setOpen(false) }}
                   >
-                    <div className="text-sm font-medium text-slate-200">{result.title}</div>
-                    <div className="text-xs text-slate-500 truncate">{result.excerpt}</div>
+                    <div className="text-sm font-medium text-slate-800 dark:text-slate-200">{result.title}</div>
+                    <div className="text-xs text-slate-400 dark:text-slate-500 truncate">{result.excerpt}</div>
                   </Link>
                 </li>
               ))}

--- a/dashboard/src/components/docs/EntityHovercard.tsx
+++ b/dashboard/src/components/docs/EntityHovercard.tsx
@@ -38,25 +38,25 @@ export function EntityHovercard({ entityId, prefetchedCard, children }: EntityHo
             side="top"
             align="start"
             sideOffset={6}
-            className="z-50 rounded-lg bg-slate-900 border border-slate-700 shadow-xl p-3 max-w-xs text-sm"
+            className="z-50 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow-xl p-3 max-w-xs text-sm"
             onEscapeKeyDown={() => setOpen(false)}
           >
             {!card ? (
-              <div className="text-slate-500 text-xs">Loading…</div>
+              <div className="text-slate-400 dark:text-slate-500 text-xs">Loading…</div>
             ) : (
               <div className="space-y-2">
                 <div className="flex items-center gap-2 justify-between">
                   <span className="font-mono font-medium text-sky-300 text-xs">{card.label}</span>
                   <KindBadge kind={card.kind as EntityKind} />
                 </div>
-                <div className="text-xs text-slate-500 truncate">
+                <div className="text-xs text-slate-400 dark:text-slate-500 truncate">
                   {card.source_file}:{card.start_line}
                 </div>
                 {card.outbound_edges.length > 0 && (
                   <ul className="space-y-1 text-xs">
                     {card.outbound_edges.slice(0, 3).map((e, i) => (
-                      <li key={i} className="flex items-center gap-1.5 text-slate-400">
-                        <span className="px-1 py-0.5 rounded bg-slate-800 text-slate-500 font-mono text-[10px]">
+                      <li key={i} className="flex items-center gap-1.5 text-slate-400 dark:text-slate-400">
+                        <span className="px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-400 dark:text-slate-500 font-mono text-[10px]">
                           {e.kind}
                         </span>
                         <span className="truncate">{e.target_label}</span>

--- a/dashboard/src/components/docs/EntityLink.tsx
+++ b/dashboard/src/components/docs/EntityLink.tsx
@@ -22,7 +22,7 @@ export function EntityLink({ symbol, entityId, prefetchedCard }: EntityLinkProps
   if (!resolvedId && !prefetchedCard) {
     // No entity match — just render styled code
     return (
-      <code className="px-1 py-0.5 rounded bg-slate-800 text-slate-300 font-mono text-[0.875em] border border-slate-700">
+      <code className="px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-mono text-[0.875em] border border-slate-300 dark:border-slate-700">
         {symbol}
       </code>
     )

--- a/dashboard/src/components/docs/FlowDiagram.tsx
+++ b/dashboard/src/components/docs/FlowDiagram.tsx
@@ -62,16 +62,16 @@ export function FlowDiagram({ entryEntityId }: FlowDiagramProps) {
 
   if (isLoading) {
     return (
-      <div className="my-6 rounded-lg border border-slate-700 bg-slate-900 p-4 animate-pulse">
-        <div className="h-4 w-48 rounded bg-slate-800 mb-2" />
-        <div className="h-32 rounded bg-slate-800" />
+      <div className="my-6 rounded-lg border border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 p-4 animate-pulse">
+        <div className="h-4 w-48 rounded bg-slate-200 dark:bg-slate-800 mb-2" />
+        <div className="h-32 rounded bg-slate-200 dark:bg-slate-800" />
       </div>
     )
   }
 
   if (!steps || steps.length === 0) {
     return (
-      <div className="my-6 rounded-lg border border-slate-700 bg-slate-900 px-4 py-6 text-center text-sm text-slate-500">
+      <div className="my-6 rounded-lg border border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 px-4 py-6 text-center text-sm text-slate-400 dark:text-slate-500">
         <GitBranch className="w-8 h-8 mx-auto mb-2 text-slate-700" aria-hidden />
         No flow data for this entry point.
       </div>
@@ -81,13 +81,13 @@ export function FlowDiagram({ entryEntityId }: FlowDiagramProps) {
   const mermaidCode = stepsToMermaid(steps)
 
   return (
-    <figure className="my-6 rounded-lg border border-slate-700 bg-slate-900 overflow-hidden" aria-label="Process flow diagram">
-      <figcaption className="px-4 py-2 border-b border-slate-800 flex items-center gap-2 text-xs text-slate-400">
+    <figure className="my-6 rounded-lg border border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 overflow-hidden" aria-label="Process flow diagram">
+      <figcaption className="px-4 py-2 border-b border-slate-200 dark:border-slate-800 flex items-center gap-2 text-xs text-slate-400 dark:text-slate-400">
         <GitBranch className="w-3.5 h-3.5" aria-hidden />
         Process Flow
       </figcaption>
       <div className="p-4">
-        <Suspense fallback={<div className="h-40 animate-pulse rounded bg-slate-800" />}>
+        <Suspense fallback={<div className="h-40 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />}>
           <MermaidBlock code={mermaidCode} />
         </Suspense>
       </div>

--- a/dashboard/src/components/docs/MarkdownRenderer.tsx
+++ b/dashboard/src/components/docs/MarkdownRenderer.tsx
@@ -76,7 +76,7 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
 
       if (lang === 'mermaid') {
         return (
-          <Suspense fallback={<div className="h-40 animate-pulse rounded bg-slate-800" />}>
+          <Suspense fallback={<div className="h-40 animate-pulse rounded bg-slate-200 dark:bg-slate-800" />}>
             <MermaidBlock code={code} />
           </Suspense>
         )
@@ -100,7 +100,7 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
       }
 
       return (
-        <code className="px-1 py-0.5 rounded bg-slate-800 text-slate-300 font-mono text-[0.875em] border border-slate-700">
+        <code className="px-1 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-mono text-[0.875em] border border-slate-300 dark:border-slate-700">
           {children}
         </code>
       )
@@ -108,7 +108,7 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
 
     // ── Headings ─────────────────────────────────────────────────────────────
     h1({ children }) {
-      return <h1 className="text-3xl font-bold text-slate-100 mt-0 mb-6 leading-tight">{children}</h1>
+      return <h1 className="text-3xl font-bold text-slate-900 dark:text-slate-100 mt-0 mb-6 leading-tight">{children}</h1>
     },
     h2({ children }) {
       const text = String(children)
@@ -117,7 +117,7 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
       return (
         <h2
           id={id}
-          className="text-xl font-semibold text-slate-100 mt-10 mb-4 pb-2 border-b border-slate-800 scroll-mt-20"
+          className="text-xl font-semibold text-slate-900 dark:text-slate-100 mt-10 mb-4 pb-2 border-b border-slate-200 dark:border-slate-800 scroll-mt-20"
         >
           <a href={`#${id}`} className="no-underline hover:text-sky-400 transition-colors">{children}</a>
         </h2>
@@ -130,7 +130,7 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
       return (
         <h3
           id={id}
-          className="text-lg font-semibold text-slate-200 mt-8 mb-3 scroll-mt-20"
+          className="text-lg font-semibold text-slate-800 dark:text-slate-200 mt-8 mb-3 scroll-mt-20"
         >
           <a href={`#${id}`} className="no-underline hover:text-sky-400 transition-colors">{children}</a>
         </h3>
@@ -149,22 +149,22 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
         const directive = parseDirective(children[0])
         if (directive) return <>{directive}</>
       }
-      return <p className="text-slate-400 leading-7 my-4">{children}</p>
+      return <p className="text-slate-400 dark:text-slate-400 leading-7 my-4">{children}</p>
     },
 
     blockquote({ children }) {
       return (
-        <blockquote className="my-4 pl-4 border-l-4 border-sky-700 text-slate-400 italic">
+        <blockquote className="my-4 pl-4 border-l-4 border-sky-700 text-slate-400 dark:text-slate-400 italic">
           {children}
         </blockquote>
       )
     },
 
     ul({ children }) {
-      return <ul className="my-4 ml-6 space-y-1.5 list-disc text-slate-400">{children}</ul>
+      return <ul className="my-4 ml-6 space-y-1.5 list-disc text-slate-400 dark:text-slate-400">{children}</ul>
     },
     ol({ children }) {
-      return <ol className="my-4 ml-6 space-y-1.5 list-decimal text-slate-400">{children}</ol>
+      return <ol className="my-4 ml-6 space-y-1.5 list-decimal text-slate-400 dark:text-slate-400">{children}</ol>
     },
     li({ children }) {
       return <li className="leading-7 pl-1">{children}</li>
@@ -173,23 +173,23 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
     // ── Tables ────────────────────────────────────────────────────────────────
     table({ children }) {
       return (
-        <div className="my-6 overflow-x-auto rounded-lg border border-slate-800">
+        <div className="my-6 overflow-x-auto rounded-lg border border-slate-200 dark:border-slate-800">
           <table className="min-w-full text-sm">{children}</table>
         </div>
       )
     },
     thead({ children }) {
-      return <thead className="bg-slate-900">{children}</thead>
+      return <thead className="bg-slate-100 dark:bg-slate-900">{children}</thead>
     },
     th({ children }) {
       return (
-        <th className="px-4 py-2.5 text-left text-xs font-semibold text-slate-400 uppercase tracking-wider border-b border-slate-800">
+        <th className="px-4 py-2.5 text-left text-xs font-semibold text-slate-400 dark:text-slate-400 uppercase tracking-wider border-b border-slate-200 dark:border-slate-800">
           {children}
         </th>
       )
     },
     td({ children }) {
-      return <td className="px-4 py-2.5 text-slate-400 border-b border-slate-800/50">{children}</td>
+      return <td className="px-4 py-2.5 text-slate-400 dark:text-slate-400 border-b border-slate-200 dark:border-slate-800/50">{children}</td>
     },
 
     // ── Links ─────────────────────────────────────────────────────────────────
@@ -208,18 +208,18 @@ export function MarkdownRenderer({ markdown, hovercards = {}, onHeadingsFound }:
 
     // ── Horizontal rule ───────────────────────────────────────────────────────
     hr() {
-      return <hr className="my-8 border-slate-800" />
+      return <hr className="my-8 border-slate-200 dark:border-slate-800" />
     },
 
     // ── Strong / em ───────────────────────────────────────────────────────────
     strong({ children }) {
-      return <strong className="font-semibold text-slate-200">{children}</strong>
+      return <strong className="font-semibold text-slate-800 dark:text-slate-200">{children}</strong>
     },
     em({ children }) {
-      return <em className="italic text-slate-300">{children}</em>
+      return <em className="italic text-slate-700 dark:text-slate-300">{children}</em>
     },
     del({ children }) {
-      return <del className="line-through text-slate-500">{children}</del>
+      return <del className="line-through text-slate-400 dark:text-slate-500">{children}</del>
     },
   }
 

--- a/dashboard/src/components/docs/MermaidBlock.tsx
+++ b/dashboard/src/components/docs/MermaidBlock.tsx
@@ -94,7 +94,7 @@ export function MermaidBlock({ code, theme: themeProp }: MermaidBlockProps) {
   if (!svg) {
     return (
       <div
-        className="animate-pulse rounded bg-slate-800 h-40"
+        className="animate-pulse rounded bg-slate-200 dark:bg-slate-800 h-40"
         role="status"
         aria-label="Loading diagram"
       />

--- a/dashboard/src/components/docs/PatternCallout.tsx
+++ b/dashboard/src/components/docs/PatternCallout.tsx
@@ -80,16 +80,16 @@ export function PatternCallout({ patternId }: PatternCalloutProps) {
             <span className="text-xs font-semibold uppercase tracking-wider text-amber-400">
               Pattern
             </span>
-            <span className="text-sm font-semibold text-slate-200">{pattern.title}</span>
+            <span className="text-sm font-semibold text-slate-800 dark:text-slate-200">{pattern.title}</span>
           </div>
-          <p className="text-sm text-slate-400 leading-relaxed">{pattern.description}</p>
+          <p className="text-sm text-slate-400 dark:text-slate-400 leading-relaxed">{pattern.description}</p>
           {pattern.exemplars.length > 0 && (
             <div className="flex flex-wrap gap-2 pt-1">
-              <span className="text-xs text-slate-500">Exemplars:</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500">Exemplars:</span>
               {pattern.exemplars.map((name) => (
                 <code
                   key={name}
-                  className="px-1.5 py-0.5 rounded bg-slate-800 text-slate-300 font-mono text-xs border border-slate-700"
+                  className="px-1.5 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 font-mono text-xs border border-slate-300 dark:border-slate-700"
                 >
                   {name}
                 </code>

--- a/dashboard/src/components/docs/ThemeToggle.tsx
+++ b/dashboard/src/components/docs/ThemeToggle.tsx
@@ -13,7 +13,7 @@ export function ThemeToggle({ className }: { className?: string }) {
       type="button"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
       className={[
-        'p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors',
+        'p-1.5 rounded text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors',
         className,
       ]
         .filter(Boolean)

--- a/dashboard/src/components/flows/ChainStep.tsx
+++ b/dashboard/src/components/flows/ChainStep.tsx
@@ -47,8 +47,8 @@ export function ChainStep({
       {/* Edge connector label (skip for entry) */}
       {!isEntry && (
         <div className="flex items-center gap-1 pl-3 py-0.5">
-          <span className="w-px h-3 bg-slate-700" aria-hidden />
-          <span className="text-[10px] text-slate-600 font-mono">{edgeLabel}</span>
+          <span className="w-px h-3 bg-slate-300 dark:bg-slate-700" aria-hidden />
+          <span className="text-[10px] text-slate-500 dark:text-slate-600 font-mono">{edgeLabel}</span>
         </div>
       )}
 
@@ -64,7 +64,7 @@ export function ChainStep({
           'focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500',
           isFocused
             ? 'bg-sky-900/40 ring-1 ring-sky-700'
-            : 'hover:bg-slate-800/60',
+            : 'hover:bg-slate-200/60 dark:hover:bg-slate-800/60',
           isPhantom
             ? 'opacity-75 border border-dashed border-violet-700/50'
             : '',
@@ -76,7 +76,7 @@ export function ChainStep({
         <span
           className={[
             'flex-shrink-0',
-            isPhantom ? 'text-violet-400' : 'text-slate-500',
+            isPhantom ? 'text-violet-400' : 'text-slate-400 dark:text-slate-500',
           ].join(' ')}
           aria-hidden
         >
@@ -86,7 +86,7 @@ export function ChainStep({
         <span
           className={[
             'flex-1 min-w-0 font-mono text-xs truncate',
-            isPhantom ? 'text-violet-300 italic' : 'text-slate-300',
+            isPhantom ? 'text-violet-300 italic' : 'text-slate-700 dark:text-slate-300',
           ].join(' ')}
           title={step.label}
         >

--- a/dashboard/src/components/flows/ChainStepDetail.tsx
+++ b/dashboard/src/components/flows/ChainStepDetail.tsx
@@ -26,14 +26,14 @@ export function ChainStepDetail({
     >
       {/* Header */}
       <div className="flex items-start gap-3">
-        <span className="text-slate-400 mt-0.5" aria-hidden>
+        <span className="text-slate-400 dark:text-slate-400 mt-0.5" aria-hidden>
           <KindIcon kind={entityKind} className="w-4 h-4" />
         </span>
         <div className="flex-1 min-w-0">
-          <h3 className="font-mono text-sm font-semibold text-slate-200 truncate">
+          <h3 className="font-mono text-sm font-semibold text-slate-800 dark:text-slate-200 truncate">
             {step.label}
           </h3>
-          <p className="text-xs text-slate-500 font-mono mt-0.5">
+          <p className="text-xs text-slate-400 dark:text-slate-500 font-mono mt-0.5">
             step {step.step_index + 1} · {step.edge_kind}
           </p>
         </div>
@@ -42,7 +42,7 @@ export function ChainStepDetail({
           <button
             type="button"
             onClick={onClose}
-            className="p-1 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+            className="p-1 rounded text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
             aria-label="Close step detail"
           >
             <X className="w-4 h-4" />

--- a/dashboard/src/components/flows/FlowDetailPanel.tsx
+++ b/dashboard/src/components/flows/FlowDetailPanel.tsx
@@ -51,7 +51,7 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
           <button
             type="button"
             onClick={() => refetch()}
-            className="px-3 py-1.5 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors"
+            className="px-3 py-1.5 rounded text-sm bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
           >
             Retry
           </button>
@@ -71,15 +71,15 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
       aria-label={`Flow detail: ${process.label}`}
     >
       {/* Header */}
-      <div className="flex items-start gap-3 px-4 py-3 border-b border-slate-800 bg-slate-900/80 flex-shrink-0">
+      <div className="flex items-start gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-900/80 flex-shrink-0">
         <div className="flex-1 min-w-0">
-          <h2 className="font-mono text-sm font-semibold text-slate-200 truncate">
+          <h2 className="font-mono text-sm font-semibold text-slate-800 dark:text-slate-200 truncate">
             {process.label}
           </h2>
           <div className="flex items-center gap-2 mt-1 flex-wrap">
             <RepoChip repo={process.repo} />
             {process.cross_stack && <CrossStackBadge />}
-            <span className="text-xs text-slate-500 font-mono">
+            <span className="text-xs text-slate-400 dark:text-slate-500 font-mono">
               {process.step_count} steps
             </span>
           </div>
@@ -88,7 +88,7 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
           <button
             type="button"
             onClick={onClose}
-            className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors flex-shrink-0"
+            className="p-1.5 rounded text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors flex-shrink-0"
             aria-label="Close flow detail"
           >
             <X className="w-4 h-4" />
@@ -98,8 +98,8 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
 
       {/* Keyboard nav hint */}
       {steps.length > 0 && (
-        <div className="px-4 py-1.5 border-b border-slate-800 bg-slate-950/60 flex-shrink-0">
-          <p className="text-[10px] text-slate-600">
+        <div className="px-4 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-950/60 flex-shrink-0">
+          <p className="text-[10px] text-slate-500 dark:text-slate-600">
             ↑ ↓ navigate steps · Enter expand source
           </p>
         </div>
@@ -108,7 +108,7 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
       {/* Tabs: Swim lane + Chain list */}
       <Tabs.Root defaultValue="lanes" className="flex flex-col flex-1 overflow-hidden">
         <Tabs.List
-          className="flex border-b border-slate-800 px-4 bg-slate-900/60 flex-shrink-0"
+          className="flex border-b border-slate-200 dark:border-slate-800 px-4 bg-slate-100/60 dark:bg-slate-900/60 flex-shrink-0"
           aria-label="Flow detail views"
         >
           <FlowTabTrigger value="lanes">
@@ -154,7 +154,7 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
                     'rounded-lg border transition-colors cursor-pointer',
                     focusedIndex === idx
                       ? 'border-sky-700 bg-sky-900/20'
-                      : 'border-slate-800 hover:border-slate-700 hover:bg-slate-900/60',
+                      : 'border-slate-200 dark:border-slate-800 hover:border-slate-300 dark:hover:border-slate-700 hover:bg-slate-200/60 dark:hover:bg-slate-900/60',
                   ].join(' ')}
                   onClick={() => { setSelectedStep(step); focusStep(idx) }}
                   role="button"
@@ -169,8 +169,8 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
                   }}
                 >
                   <div className="px-3 py-2">
-                    <span className="text-[10px] text-slate-600 font-mono mr-2">{idx + 1}.</span>
-                    <span className="font-mono text-xs text-slate-300">{step.label}</span>
+                    <span className="text-[10px] text-slate-500 dark:text-slate-600 font-mono mr-2">{idx + 1}.</span>
+                    <span className="font-mono text-xs text-slate-700 dark:text-slate-300">{step.label}</span>
                     <RepoChip repo={step.repo} className="ml-2" />
                   </div>
                 </div>
@@ -182,7 +182,7 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
 
       {/* Selected step detail slide-in */}
       {selectedStep && (
-        <div className="border-t border-slate-800 p-4 bg-slate-900/60 flex-shrink-0 max-h-64 overflow-y-auto">
+        <div className="border-t border-slate-200 dark:border-slate-800 p-4 bg-slate-100/60 dark:bg-slate-900/60 flex-shrink-0 max-h-64 overflow-y-auto">
           <ChainStepDetail
             step={selectedStep}
             sourceCode={data.source_snippets?.[selectedStep.entity_id]}
@@ -200,8 +200,8 @@ function FlowTabTrigger({ value, children }: { value: string; children: React.Re
       value={value}
       className={[
         'flex items-center gap-1.5 px-4 py-2.5 text-sm border-b-2 border-transparent transition-colors',
-        'text-slate-500 hover:text-slate-300',
-        'data-[state=active]:border-sky-500 data-[state=active]:text-slate-200',
+        'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
+        'data-[state=active]:border-sky-500 data-[state=active]:text-slate-800 dark:data-[state=active]:text-slate-200',
         'focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500',
       ].join(' ')}
     >

--- a/dashboard/src/components/flows/FlowEntryPicker.tsx
+++ b/dashboard/src/components/flows/FlowEntryPicker.tsx
@@ -32,11 +32,11 @@ export function FlowEntryPicker({
   const showRecent = !searchQuery && recent.length > 0
 
   return (
-    <div className="flex flex-col gap-3 p-4 border-b border-slate-800">
+    <div className="flex flex-col gap-3 p-4 border-b border-slate-200 dark:border-slate-800">
       {/* Search input */}
       <div className="relative">
         <Search
-          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none"
+          className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500 pointer-events-none"
           aria-hidden
         />
         <input
@@ -49,7 +49,7 @@ export function FlowEntryPicker({
           placeholder="Search entry points…"
           className={[
             'w-full pl-9 pr-4 py-2 rounded-lg text-sm',
-            'bg-slate-900 border border-slate-700 text-slate-200 placeholder-slate-500',
+            'bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 text-slate-800 dark:text-slate-200 placeholder-slate-500',
             'focus:outline-none focus:border-sky-600 focus:ring-1 focus:ring-sky-600/50',
             'transition-colors',
           ].join(' ')}
@@ -60,12 +60,12 @@ export function FlowEntryPicker({
       </div>
 
       {/* Cross-stack filter */}
-      <label className="flex items-center gap-2 text-xs text-slate-400 cursor-pointer select-none">
+      <label className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-400 cursor-pointer select-none">
         <input
           type="checkbox"
           checked={crossStackOnly}
           onChange={(e) => onCrossStackChange(e.target.checked)}
-          className="rounded border-slate-700 bg-slate-900 text-sky-500 focus:ring-sky-500"
+          className="rounded border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 text-sky-500 focus:ring-sky-500"
           aria-label="Show cross-stack flows only"
         />
         <Filter className="w-3 h-3" aria-hidden />
@@ -75,7 +75,7 @@ export function FlowEntryPicker({
       {/* Recent section */}
       {showRecent && (
         <div>
-          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-600 mb-1.5 flex items-center gap-1">
+          <p className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-600 mb-1.5 flex items-center gap-1">
             <Clock className="w-3 h-3" aria-hidden />
             Recent
           </p>
@@ -96,7 +96,7 @@ export function FlowEntryPicker({
       {searchQuery && (
         <div>
           {entryPoints.length === 0 ? (
-            <p className="text-xs text-slate-500 py-2">No entry points match "{searchQuery}"</p>
+            <p className="text-xs text-slate-400 dark:text-slate-500 py-2">No entry points match "{searchQuery}"</p>
           ) : (
             <div className="space-y-0.5 max-h-56 overflow-y-auto">
               {entryPoints.map((p) => (
@@ -142,12 +142,12 @@ function EntryPointItem({
         'transition-colors duration-75',
         isSelected
           ? 'bg-sky-900/40 text-sky-200'
-          : 'hover:bg-slate-800/60 text-slate-300',
+          : 'hover:bg-slate-200/60 dark:hover:bg-slate-800/60 text-slate-700 dark:text-slate-300',
       ].join(' ')}
       onClick={() => onSelect(process)}
       onKeyDown={handleKeyDown}
     >
-      <span className="text-slate-500 flex-shrink-0" aria-hidden>
+      <span className="text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden>
         <KindIcon kind={process.entry_kind ?? 'Function'} className="w-3.5 h-3.5" />
       </span>
       <span className="flex-1 min-w-0 font-mono text-xs truncate" title={process.entry_name}>

--- a/dashboard/src/components/flows/FlowRow.tsx
+++ b/dashboard/src/components/flows/FlowRow.tsx
@@ -47,17 +47,17 @@ export function FlowRow({ process, isSelected = false, onSelect }: FlowRowProps)
       tabIndex={0}
       aria-selected={isSelected}
       className={[
-        'group flex items-start gap-3 px-4 py-3 border-b border-slate-800',
-        'cursor-pointer hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
+        'group flex items-start gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800',
+        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
         'transition-colors duration-75',
-        isSelected ? 'bg-slate-800/80 border-l-2 border-l-sky-500' : '',
+        isSelected ? 'bg-slate-200/80 dark:bg-slate-800/80 border-l-2 border-l-sky-500' : '',
       ].filter(Boolean).join(' ')}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
     >
       {/* Kind icon */}
       <span
-        className="flex-shrink-0 mt-0.5 text-slate-500 group-hover:text-slate-400"
+        className="flex-shrink-0 mt-0.5 text-slate-400 dark:text-slate-500 group-hover:text-slate-600 dark:hover:text-slate-400"
         title={kindLabel}
         aria-label={kindLabel}
       >
@@ -68,14 +68,14 @@ export function FlowRow({ process, isSelected = false, onSelect }: FlowRowProps)
       <div className="flex-1 min-w-0">
         {/* Entry name + repo */}
         <div className="flex items-center gap-2 flex-wrap">
-          <span className="font-mono text-sm text-slate-200 truncate max-w-xs" title={process.entry_name}>
+          <span className="font-mono text-sm text-slate-800 dark:text-slate-200 truncate max-w-xs" title={process.entry_name}>
             {process.entry_name}
           </span>
           <RepoChip repo={process.repo} />
         </div>
 
         {/* Chain summary */}
-        <p className="mt-1 text-xs text-slate-500 font-mono truncate" title={summary}>
+        <p className="mt-1 text-xs text-slate-400 dark:text-slate-500 font-mono truncate" title={summary}>
           {summary}
         </p>
       </div>
@@ -87,7 +87,7 @@ export function FlowRow({ process, isSelected = false, onSelect }: FlowRowProps)
         )}
         {/* Step count badge */}
         <span
-          className="px-1.5 py-0.5 rounded text-xs font-mono bg-slate-800 text-slate-400 border border-slate-700"
+          className="px-1.5 py-0.5 rounded text-xs font-mono bg-slate-200 dark:bg-slate-800 text-slate-400 dark:text-slate-400 border border-slate-300 dark:border-slate-700"
           title={`${process.step_count} steps`}
           aria-label={`${process.step_count} steps`}
         >

--- a/dashboard/src/components/flows/SwimLanePanel.tsx
+++ b/dashboard/src/components/flows/SwimLanePanel.tsx
@@ -53,7 +53,7 @@ export function SwimLanePanel({
             <div
               key={lane.repo}
               className={[
-                'flex flex-col min-w-[240px] border-r border-slate-800',
+                'flex flex-col min-w-[240px] border-r border-slate-200 dark:border-slate-800',
                 isLastLane ? 'border-r-0' : '',
               ].join(' ')}
             >
@@ -61,12 +61,12 @@ export function SwimLanePanel({
               <div
                 className={[
                   'flex items-center gap-2 px-3 py-2',
-                  'border-b border-slate-800 bg-slate-900/60',
+                  'border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60',
                 ].join(' ')}
               >
                 <span className={`w-2 h-2 rounded-full ${colors.dot}`} aria-hidden />
                 <RepoChip repo={lane.repo} />
-                <span className="ml-auto text-[10px] text-slate-600 font-mono">
+                <span className="ml-auto text-[10px] text-slate-500 dark:text-slate-600 font-mono">
                   {lane.steps.length} step{lane.steps.length !== 1 ? 's' : ''}
                 </span>
               </div>
@@ -96,7 +96,7 @@ export function SwimLanePanel({
 
       {/* Cross-lane phantom edge indicator */}
       {allSteps.some((s) => s.edge_kind === 'FETCHES') && (
-        <div className="px-3 py-2 border-t border-slate-800 bg-slate-900/40">
+        <div className="px-3 py-2 border-t border-slate-200 dark:border-slate-800 bg-slate-100/40 dark:bg-slate-900/40">
           <span className="text-[10px] text-violet-400 flex items-center gap-1.5">
             <span className="inline-block w-8 border-t border-dashed border-violet-500" aria-hidden />
             Phantom edge (cross-repo boundary)

--- a/dashboard/src/components/graph/CommunityLegend.tsx
+++ b/dashboard/src/components/graph/CommunityLegend.tsx
@@ -42,7 +42,7 @@ export function CommunityLegend({
             role="listitem"
             className={[
               'flex items-center gap-2 px-2 py-1 rounded text-left',
-              'hover:bg-slate-800/60 transition-colors text-xs w-full',
+              'hover:bg-slate-200/60 dark:hover:bg-slate-800/60 transition-colors text-xs w-full',
               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
               dimmed ? 'opacity-40' : '',
             ].join(' ')}
@@ -56,8 +56,8 @@ export function CommunityLegend({
               style={{ background: color }}
               aria-hidden
             />
-            <span className="flex-1 truncate text-slate-300">{name}</span>
-            <span className="text-slate-600 tabular-nums">{c.size.toLocaleString()}</span>
+            <span className="flex-1 truncate text-slate-700 dark:text-slate-300">{name}</span>
+            <span className="text-slate-500 dark:text-slate-600 tabular-nums">{c.size.toLocaleString()}</span>
           </button>
         )
       })}

--- a/dashboard/src/components/graph/EdgeBadge.tsx
+++ b/dashboard/src/components/graph/EdgeBadge.tsx
@@ -12,9 +12,9 @@ const EDGE_KIND_COLORS: Partial<Record<RelationshipKind, string>> = {
   CALLS:          'bg-sky-900/50 text-sky-300 border-sky-800',
   IMPORTS:        'bg-indigo-900/50 text-indigo-300 border-indigo-800',
   DEPENDS_ON:     'bg-blue-900/50 text-blue-300 border-blue-800',
-  USES:           'bg-slate-800/60 text-slate-300 border-slate-700',
-  USES_HOOK:      'bg-slate-800/60 text-slate-300 border-slate-700',
-  CONTAINS:       'bg-slate-800/60 text-slate-400 border-slate-700',
+  USES:           'bg-slate-200/60 dark:bg-slate-800/60 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700',
+  USES_HOOK:      'bg-slate-200/60 dark:bg-slate-800/60 text-slate-700 dark:text-slate-300 border-slate-300 dark:border-slate-700',
+  CONTAINS:       'bg-slate-200/60 dark:bg-slate-800/60 text-slate-400 dark:text-slate-400 border-slate-300 dark:border-slate-700',
   // Data
   QUERIES:        'bg-amber-900/50 text-amber-300 border-amber-800',
   FETCHES:        'bg-yellow-900/50 text-yellow-300 border-yellow-800',
@@ -35,13 +35,13 @@ const EDGE_KIND_COLORS: Partial<Record<RelationshipKind, string>> = {
   // OOP
   EXTENDS:        'bg-cyan-900/50 text-cyan-300 border-cyan-800',
   IMPLEMENTS:     'bg-teal-900/50 text-teal-300 border-teal-800',
-  RETURNS:        'bg-slate-800/60 text-slate-400 border-slate-700',
+  RETURNS:        'bg-slate-200/60 dark:bg-slate-800/60 text-slate-400 dark:text-slate-400 border-slate-300 dark:border-slate-700',
   // HTTP
   ROUTES_TO:      'bg-emerald-900/50 text-emerald-300 border-emerald-800',
   SERVES:         'bg-green-900/50 text-green-300 border-green-800',
 }
 
-const EDGE_DEFAULT = 'bg-slate-800/50 text-slate-400 border-slate-700'
+const EDGE_DEFAULT = 'bg-slate-200/50 dark:bg-slate-800/50 text-slate-400 dark:text-slate-400 border-slate-300 dark:border-slate-700'
 
 export function EdgeBadge({ kind, crossRepo, className = '' }: EdgeBadgeProps) {
   const colorClass = EDGE_KIND_COLORS[kind] ?? EDGE_DEFAULT

--- a/dashboard/src/components/graph/EdgeKindFilters.tsx
+++ b/dashboard/src/components/graph/EdgeKindFilters.tsx
@@ -52,7 +52,7 @@ export function EdgeKindFilters({
         <button
           type="button"
           onClick={onClear}
-          className="text-[10px] text-slate-500 hover:text-slate-300 px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400 rounded transition-colors"
+          className="text-[10px] text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 px-1 focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400 rounded transition-colors"
           aria-label="Clear all edge filters"
         >
           clear

--- a/dashboard/src/components/graph/EntityInspector.tsx
+++ b/dashboard/src/components/graph/EntityInspector.tsx
@@ -30,20 +30,20 @@ export function EntityInspector({
 }: EntityInspectorProps) {
   return (
     <aside
-      className="flex flex-col h-full bg-slate-950 border-l border-slate-800 w-[340px] min-w-[280px] max-w-md overflow-y-auto"
+      className="flex flex-col h-full bg-white dark:bg-slate-950 border-l border-slate-200 dark:border-slate-800 w-[340px] min-w-[280px] max-w-md overflow-y-auto"
       aria-label="Entity inspector"
       role="complementary"
     >
       {/* Header */}
-      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-800 bg-slate-900/60 sticky top-0 z-10">
-        <h2 className="text-sm font-semibold text-slate-200 truncate">
+      <div className="flex items-center justify-between px-4 py-3 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 sticky top-0 z-10">
+        <h2 className="text-sm font-semibold text-slate-800 dark:text-slate-200 truncate">
           {isLoading ? 'Loading…' : (data?.entity.label ?? 'Inspector')}
         </h2>
         <button
           type="button"
           onClick={onClose}
           aria-label="Close inspector"
-          className="p-1 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
+          className="p-1 rounded text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
         >
           <X className="w-4 h-4" />
         </button>
@@ -59,11 +59,11 @@ export function EntityInspector({
               <KindBadge kind={data.entity.kind} />
               <RepoChip repo={data.entity.repo} />
             </div>
-            <p className="text-xs font-mono text-slate-400 mt-1 break-all">
+            <p className="text-xs font-mono text-slate-400 dark:text-slate-400 mt-1 break-all">
               {data.entity.qualified_name}
             </p>
             {data.entity.pagerank !== undefined && (
-              <p className="text-xs text-slate-600 mt-0.5">
+              <p className="text-xs text-slate-500 dark:text-slate-600 mt-0.5">
                 PageRank: {data.entity.pagerank.toFixed(4)}
               </p>
             )}
@@ -116,7 +116,7 @@ export function EntityInspector({
               )}
               <a
                 href={`vscode://file/${data.entity.source_file}:${data.entity.start_line}`}
-                className="flex items-center gap-2 text-xs text-slate-400 hover:text-slate-200 transition-colors"
+                className="flex items-center gap-2 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 transition-colors"
                 onClick={(e) => e.stopPropagation()}
               >
                 <MapPin className="w-3.5 h-3.5" />
@@ -128,7 +128,7 @@ export function EntityInspector({
       )}
 
       {!isLoading && !data && (
-        <div className="flex-1 flex items-center justify-center p-6 text-center text-sm text-slate-600">
+        <div className="flex-1 flex items-center justify-center p-6 text-center text-sm text-slate-500 dark:text-slate-600">
           Select a node to inspect it.
         </div>
       )}
@@ -140,9 +140,9 @@ export function EntityInspector({
 
 function Section({ title, children }: { title: string; children: React.ReactNode }) {
   return (
-    <div className="px-4 py-3 border-b border-slate-800/60">
+    <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-800/60">
       {title && (
-        <h3 className="text-[10px] font-semibold uppercase tracking-wider text-slate-600 mb-2">
+        <h3 className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 dark:text-slate-600 mb-2">
           {title}
         </h3>
       )}
@@ -185,7 +185,7 @@ function NeighborList({
               </li>
             ))}
             {entries.length > 15 && (
-              <li className="text-[10px] text-slate-600 pl-2">
+              <li className="text-[10px] text-slate-500 dark:text-slate-600 pl-2">
                 +{entries.length - 15} more
               </li>
             )}
@@ -199,11 +199,11 @@ function NeighborList({
 function InspectorSkeleton() {
   return (
     <div className="p-4 flex flex-col gap-3" role="status" aria-label="Loading entity…">
-      <div className="h-5 w-3/4 rounded animate-pulse bg-slate-800" />
-      <div className="h-4 w-1/2 rounded animate-pulse bg-slate-800" />
-      <div className="h-20 w-full rounded animate-pulse bg-slate-800" />
-      <div className="h-4 w-full rounded animate-pulse bg-slate-800" />
-      <div className="h-4 w-5/6 rounded animate-pulse bg-slate-800" />
+      <div className="h-5 w-3/4 rounded animate-pulse bg-slate-200 dark:bg-slate-800" />
+      <div className="h-4 w-1/2 rounded animate-pulse bg-slate-200 dark:bg-slate-800" />
+      <div className="h-20 w-full rounded animate-pulse bg-slate-200 dark:bg-slate-800" />
+      <div className="h-4 w-full rounded animate-pulse bg-slate-200 dark:bg-slate-800" />
+      <div className="h-4 w-5/6 rounded animate-pulse bg-slate-200 dark:bg-slate-800" />
       <span className="sr-only">Loading…</span>
     </div>
   )

--- a/dashboard/src/components/graph/GraphEmptyState.tsx
+++ b/dashboard/src/components/graph/GraphEmptyState.tsx
@@ -45,7 +45,7 @@ interface GraphLoadingStateProps {
  */
 export function GraphLoadingState({ label = 'Loading graph…' }: GraphLoadingStateProps) {
   return (
-    <div className="relative w-full h-full flex items-center justify-center bg-slate-950">
+    <div className="relative w-full h-full flex items-center justify-center bg-white dark:bg-slate-950">
       {/* Animated gradient circles mimicking a force graph */}
       <div className="absolute inset-0 overflow-hidden" aria-hidden>
         {Array.from({ length: 12 }, (_, i) => (
@@ -64,7 +64,7 @@ export function GraphLoadingState({ label = 'Loading graph…' }: GraphLoadingSt
         ))}
       </div>
       <div role="status" aria-live="polite" className="relative z-10 text-center">
-        <p className="text-sm text-slate-400 animate-pulse">{label}</p>
+        <p className="text-sm text-slate-400 dark:text-slate-400 animate-pulse">{label}</p>
         <span className="sr-only">{label}</span>
       </div>
     </div>
@@ -87,7 +87,7 @@ export function GraphErrorState({ message, onRetry }: GraphErrorStateProps) {
           <button
             type="button"
             onClick={onRetry}
-            className="px-3 py-1.5 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
+            className="px-3 py-1.5 rounded text-sm bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-400"
           >
             Retry
           </button>

--- a/dashboard/src/components/graph/GraphSearchTypeahead.tsx
+++ b/dashboard/src/components/graph/GraphSearchTypeahead.tsx
@@ -40,7 +40,7 @@ export function GraphSearchTypeahead({
     <div
       className={[
         'absolute top-full left-0 right-0 z-50 mt-1',
-        'rounded-lg border border-slate-700 bg-slate-900 shadow-xl',
+        'rounded-lg border border-slate-300 dark:border-slate-700 bg-slate-100 dark:bg-slate-900 shadow-xl',
         'max-h-72 overflow-y-auto',
       ].join(' ')}
       role="listbox"
@@ -48,7 +48,7 @@ export function GraphSearchTypeahead({
       aria-label="Search results"
     >
       {isSearching && (
-        <div className="flex items-center gap-2 px-3 py-2 text-xs text-slate-500">
+        <div className="flex items-center gap-2 px-3 py-2 text-xs text-slate-400 dark:text-slate-500">
           <Loader2 className="w-3 h-3 animate-spin" />
           Searching…
         </div>
@@ -66,12 +66,12 @@ export function GraphSearchTypeahead({
               }}
               className={[
                 'w-full flex items-center gap-2 px-3 py-2 text-left',
-                'hover:bg-slate-800 transition-colors',
-                'focus-visible:outline-none focus-visible:bg-slate-800',
+                'hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors',
+                'focus-visible:outline-none focus-visible:bg-slate-200 dark:focus-visible:bg-slate-800',
               ].join(' ')}
             >
               <NodeChip kind={node.kind} label={node.label} repo={node.repo} />
-              <span className="ml-auto text-[10px] text-slate-600 truncate max-w-[100px]">
+              <span className="ml-auto text-[10px] text-slate-500 dark:text-slate-600 truncate max-w-[100px]">
                 {node.repo}
               </span>
             </button>

--- a/dashboard/src/components/graph/GraphToolbar.tsx
+++ b/dashboard/src/components/graph/GraphToolbar.tsx
@@ -40,7 +40,7 @@ export function GraphToolbar({
     <div
       className={[
         'flex items-center gap-2 px-3 py-2',
-        'bg-slate-900/80 backdrop-blur-sm border-b border-slate-800',
+        'bg-slate-100/80 dark:bg-slate-900/80 backdrop-blur-sm border-b border-slate-200 dark:border-slate-800',
         className,
       ].join(' ')}
       role="toolbar"
@@ -48,7 +48,7 @@ export function GraphToolbar({
     >
       {/* Search */}
       <div className="relative flex-1 max-w-xs">
-        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-500" aria-hidden />
+        <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400 dark:text-slate-500" aria-hidden />
         <input
           ref={searchRef}
           id="graph-search"
@@ -58,8 +58,8 @@ export function GraphToolbar({
           placeholder="Search nodes… (/)"
           className={[
             'w-full pl-8 pr-3 py-1.5 rounded text-sm',
-            'bg-slate-800 text-slate-200 placeholder-slate-500',
-            'border border-slate-700 focus:border-sky-600 focus:outline-none focus:ring-1 focus:ring-sky-600',
+            'bg-slate-200 dark:bg-slate-800 text-slate-800 dark:text-slate-200 placeholder-slate-500',
+            'border border-slate-300 dark:border-slate-700 focus:border-sky-600 focus:outline-none focus:ring-1 focus:ring-sky-600',
           ].join(' ')}
           aria-label="Search graph nodes"
           aria-controls="graph-search-results"
@@ -81,7 +81,7 @@ export function GraphToolbar({
               'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
               layoutMode === mode
                 ? 'bg-sky-700/60 text-sky-200 border border-sky-700'
-                : 'text-slate-400 hover:text-slate-200 hover:bg-slate-800 border border-transparent',
+                : 'text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-800 border border-transparent',
             ].join(' ')}
             title={label}
             aria-label={`Switch to ${label} layout`}
@@ -99,7 +99,7 @@ export function GraphToolbar({
         type="button"
         onClick={onResetView}
         title="Reset view"
-        className="p-1.5 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
+        className="p-1.5 rounded text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
         aria-label="Reset camera view"
       >
         <RotateCcw className="w-4 h-4" />
@@ -110,7 +110,7 @@ export function GraphToolbar({
         type="button"
         onClick={onSaveSnapshot}
         title="Save snapshot"
-        className="p-1.5 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
+        className="p-1.5 rounded text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
         aria-label="Save graph snapshot as PNG"
       >
         <Camera className="w-4 h-4" />

--- a/dashboard/src/components/graph/LodLevelIndicator.tsx
+++ b/dashboard/src/components/graph/LodLevelIndicator.tsx
@@ -14,9 +14,9 @@ const LOD_LABELS: Record<LodLevel, string> = {
 }
 
 const LOD_COLORS: Record<LodLevel, string> = {
-  'zoom-out': 'bg-slate-800/80 text-slate-400 border-slate-700',
-  'mid': 'bg-slate-800/80 text-sky-400 border-sky-900',
-  'zoom-in': 'bg-slate-800/80 text-emerald-400 border-emerald-900',
+  'zoom-out': 'bg-slate-200/80 dark:bg-slate-800/80 text-slate-400 dark:text-slate-400 border-slate-300 dark:border-slate-700',
+  'mid': 'bg-slate-200/80 dark:bg-slate-800/80 text-sky-400 border-sky-900',
+  'zoom-in': 'bg-slate-200/80 dark:bg-slate-800/80 text-emerald-400 border-emerald-900',
   'blocked': 'bg-red-950/80 text-red-400 border-red-900',
 }
 

--- a/dashboard/src/components/landing/GroupSelector.tsx
+++ b/dashboard/src/components/landing/GroupSelector.tsx
@@ -28,7 +28,7 @@ function relativeTime(iso?: string): string {
 }
 
 function bugRateColor(rate?: number): string {
-  if (rate === undefined) return 'text-slate-500'
+  if (rate === undefined) return 'text-slate-400 dark:text-slate-500'
   if (rate <= 5) return 'text-emerald-400'
   if (rate <= 15) return 'text-amber-400'
   return 'text-red-400'
@@ -65,7 +65,7 @@ function Tooltip({ tip, children }: TooltipProps) {
         role="tooltip"
         className={[
           'pointer-events-none absolute bottom-full left-1/2 -translate-x-1/2 mb-1.5 z-20',
-          'whitespace-nowrap rounded bg-slate-700 px-2 py-1 text-xs text-slate-200 shadow-lg',
+          'whitespace-nowrap rounded bg-slate-300 dark:bg-slate-700 px-2 py-1 text-xs text-slate-800 dark:text-slate-200 shadow-lg',
           'opacity-0 group-hover/tip:opacity-100 transition-opacity duration-150',
         ].join(' ')}
       >
@@ -125,21 +125,21 @@ function Sparkline({ history, bugRate, width = 60, height = 24 }: SparklineProps
 function GroupCardSkeleton() {
   return (
     <div
-      className="rounded-xl border border-slate-800 bg-slate-900/60 p-5 h-[152px] space-y-4"
+      className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 p-5 h-[152px] space-y-4"
       role="status"
       aria-label="Loading group…"
     >
       {/* header row */}
       <div className="flex items-center justify-between">
-        <div className="h-5 w-32 rounded bg-slate-800 animate-pulse" />
-        <div className="h-6 w-16 rounded bg-slate-800 animate-pulse" />
+        <div className="h-5 w-32 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
+        <div className="h-6 w-16 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
       </div>
       {/* stats row */}
       <div className="flex items-center gap-4">
-        <div className="h-4 w-12 rounded bg-slate-800 animate-pulse" />
-        <div className="h-4 w-16 rounded bg-slate-800 animate-pulse" />
-        <div className="h-4 w-14 rounded bg-slate-800 animate-pulse" />
-        <div className="h-4 w-16 rounded bg-slate-800 animate-pulse" />
+        <div className="h-4 w-12 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
+        <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
+        <div className="h-4 w-14 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
+        <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
       </div>
       <span className="sr-only">Loading…</span>
     </div>
@@ -159,13 +159,13 @@ interface StatPillProps {
   dimmed?: boolean
 }
 
-function StatPill({ icon, tooltip, label, value, valueClass = 'text-slate-300', dimmed = false }: StatPillProps) {
+function StatPill({ icon, tooltip, label, value, valueClass = 'text-slate-700 dark:text-slate-300', dimmed = false }: StatPillProps) {
   return (
     <span className={`flex items-center gap-1 min-w-0 ${dimmed ? 'opacity-40' : ''}`}>
       <Tooltip tip={tooltip}>
-        <span className="text-slate-500 shrink-0">{icon}</span>
+        <span className="text-slate-400 dark:text-slate-500 shrink-0">{icon}</span>
       </Tooltip>
-      <span className="text-slate-500 text-xs shrink-0">{label}:</span>
+      <span className="text-slate-400 dark:text-slate-500 text-xs shrink-0">{label}:</span>
       <span className={`text-xs font-medium truncate ${valueClass}`}>{value}</span>
     </span>
   )
@@ -192,11 +192,11 @@ function GroupCard({ group, onClick }: GroupCardProps) {
       type="button"
       onClick={onClick}
       className={[
-        'w-full text-left rounded-xl border bg-slate-900/60 p-5',
+        'w-full text-left rounded-xl border bg-slate-100/60 dark:bg-slate-900/60 p-5',
         // Fixed height ensures all cards are the same regardless of bug-rate / sparkline presence
         'h-[152px] flex flex-col justify-between',
         'transition-all duration-150 cursor-pointer',
-        'border-slate-800 hover:border-sky-500/40 hover:-translate-y-px hover:bg-slate-900',
+        'border-slate-200 dark:border-slate-800 hover:border-sky-500/40 hover:-translate-y-px hover:bg-slate-200 dark:hover:bg-slate-900',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60',
       ].join(' ')}
     >
@@ -204,7 +204,7 @@ function GroupCard({ group, onClick }: GroupCardProps) {
       <div className="flex items-start justify-between gap-3">
         <div className="flex items-center gap-2 min-w-0">
           <GitBranch className="w-4 h-4 text-sky-400 shrink-0" aria-hidden />
-          <span className="text-xl font-semibold text-slate-100 truncate">
+          <span className="text-xl font-semibold text-slate-900 dark:text-slate-100 truncate">
             {group.display_name}
           </span>
         </div>
@@ -262,25 +262,25 @@ function GroupCard({ group, onClick }: GroupCardProps) {
 function NoGroupsState() {
   return (
     <div className="flex flex-col items-center justify-center gap-6 py-24 px-8 text-center">
-      <div className="rounded-full bg-slate-800 p-5">
-        <GitBranch className="w-10 h-10 text-slate-500" aria-hidden />
+      <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-5">
+        <GitBranch className="w-10 h-10 text-slate-400 dark:text-slate-500" aria-hidden />
       </div>
       <div className="space-y-2">
-        <h2 className="text-xl font-semibold text-slate-200">No groups indexed yet</h2>
-        <p className="max-w-sm text-sm text-slate-400">
+        <h2 className="text-xl font-semibold text-slate-800 dark:text-slate-200">No groups indexed yet</h2>
+        <p className="max-w-sm text-sm text-slate-400 dark:text-slate-400">
           Register a group and index at least one repo to see it here.
         </p>
       </div>
       <div className="w-full max-w-md space-y-3 text-left">
-        <div className="rounded-lg bg-slate-900 border border-slate-800 p-4">
-          <p className="text-xs text-slate-500 mb-2 font-mono uppercase tracking-wider">Step 1 — register a group</p>
-          <pre className="text-sm text-slate-300 font-mono whitespace-pre-wrap">
+        <div className="rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 p-4">
+          <p className="text-xs text-slate-400 dark:text-slate-500 mb-2 font-mono uppercase tracking-wider">Step 1 — register a group</p>
+          <pre className="text-sm text-slate-700 dark:text-slate-300 font-mono whitespace-pre-wrap">
             <code>archigraph register --group my-service --path ./my-repo</code>
           </pre>
         </div>
-        <div className="rounded-lg bg-slate-900 border border-slate-800 p-4">
-          <p className="text-xs text-slate-500 mb-2 font-mono uppercase tracking-wider">Step 2 — index the repo</p>
-          <pre className="text-sm text-slate-300 font-mono whitespace-pre-wrap">
+        <div className="rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800 p-4">
+          <p className="text-xs text-slate-400 dark:text-slate-500 mb-2 font-mono uppercase tracking-wider">Step 2 — index the repo</p>
+          <pre className="text-sm text-slate-700 dark:text-slate-300 font-mono whitespace-pre-wrap">
             <code>archigraph index my-service</code>
           </pre>
         </div>
@@ -301,8 +301,8 @@ export function GroupSelector() {
     return (
       <div className="px-6 py-8 max-w-7xl mx-auto">
         <div className="mb-6">
-          <div className="h-7 w-48 rounded bg-slate-800 animate-pulse mb-1" />
-          <div className="h-4 w-72 rounded bg-slate-800 animate-pulse" />
+          <div className="h-7 w-48 rounded bg-slate-200 dark:bg-slate-800 animate-pulse mb-1" />
+          <div className="h-4 w-72 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
         </div>
         <div
           className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4"
@@ -332,8 +332,8 @@ export function GroupSelector() {
   return (
     <div className="px-6 py-8 max-w-7xl mx-auto">
       <div className="mb-6">
-        <h1 className="text-2xl font-bold text-slate-100">Groups</h1>
-        <p className="text-sm text-slate-400 mt-1">
+        <h1 className="text-2xl font-bold text-slate-900 dark:text-slate-100">Groups</h1>
+        <p className="text-sm text-slate-400 dark:text-slate-400 mt-1">
           Select a group to explore its graph, flows, topology, paths and docs.
         </p>
       </div>

--- a/dashboard/src/components/layout/GroupSwitcher.tsx
+++ b/dashboard/src/components/layout/GroupSwitcher.tsx
@@ -7,7 +7,7 @@
  *  - Bug-rate status dot: green ≤5% / amber 5-15% / red >15%
  *    (uses entity_count as proxy until a real bug_rate field ships)
  *  - Entity count in tooltip
- *  - Active group: bg-slate-800 + sky-500 left border
+ *  - Active group: bg-slate-200 dark:bg-slate-800 + sky-500 left border
  *  - Switching preserves current surface (e.g. /flows/A → /flows/B)
  */
 
@@ -101,14 +101,14 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
   return (
     <div className="flex flex-col gap-1">
       {/* Section label */}
-      <p className="text-[10px] uppercase tracking-wider text-slate-600 font-semibold px-2 pb-1 select-none">
+      <p className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-600 font-semibold px-2 pb-1 select-none">
         Groups
       </p>
 
       {/* Search input */}
       <div className="relative px-2 mb-1">
         <Search
-          className="absolute left-4 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-600 pointer-events-none"
+          className="absolute left-4 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-500 dark:text-slate-600 pointer-events-none"
           aria-hidden
         />
         <input
@@ -118,8 +118,8 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
           onChange={(e) => setQuery(e.target.value)}
           aria-label="Filter groups"
           className={[
-            'w-full bg-slate-900 border border-slate-700 rounded text-xs',
-            'pl-7 pr-2 py-1 text-slate-300 placeholder-slate-600',
+            'w-full bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded text-xs',
+            'pl-7 pr-2 py-1 text-slate-700 dark:text-slate-300 placeholder-slate-600',
             'focus:outline-none focus:ring-1 focus:ring-sky-500 focus:border-sky-500',
           ].join(' ')}
         />
@@ -133,7 +133,7 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
         aria-label="Groups"
       >
         {sorted.length === 0 && (
-          <li className="px-3 py-2 text-xs text-slate-600 select-none">
+          <li className="px-3 py-2 text-xs text-slate-500 dark:text-slate-600 select-none">
             No groups match
           </li>
         )}
@@ -154,8 +154,8 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
                   'group w-full flex items-center gap-2 px-3 py-1.5 text-xs text-left transition-colors',
                   'border-l-2',
                   isActive
-                    ? 'bg-slate-800 border-sky-500 text-slate-100'
-                    : 'border-transparent text-slate-400 hover:bg-slate-800/60 hover:text-slate-300',
+                    ? 'bg-slate-200 dark:bg-slate-800 border-sky-500 text-slate-900 dark:text-slate-100'
+                    : 'border-transparent text-slate-400 dark:text-slate-400 hover:bg-slate-200/60 dark:hover:bg-slate-800/60 hover:text-slate-700 dark:hover:text-slate-300',
                 ].join(' ')}
               >
                 {/* Group name */}
@@ -181,7 +181,7 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
                     'p-0.5 rounded transition-colors cursor-pointer',
                     isPinned
                       ? 'text-sky-400 opacity-100'
-                      : 'text-slate-600 opacity-0 group-hover:opacity-100',
+                      : 'text-slate-500 dark:text-slate-600 opacity-0 group-hover:opacity-100',
                     'hover:text-sky-300',
                   ].join(' ')}
                 >

--- a/dashboard/src/components/paths/MultiplicityBadge.tsx
+++ b/dashboard/src/components/paths/MultiplicityBadge.tsx
@@ -11,7 +11,7 @@ export function MultiplicityBadge({ count, className = '' }: MultiplicityBadgePr
   if (count <= 1) return null
   return (
     <span
-      className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-slate-800 text-slate-400 border border-slate-700 ${className}`}
+      className={`inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-slate-200 dark:bg-slate-800 text-slate-400 dark:text-slate-400 border border-slate-300 dark:border-slate-700 ${className}`}
       title={`${count} endpoints behind this path`}
       aria-label={`${count} endpoints`}
     >

--- a/dashboard/src/components/paths/Pagination.tsx
+++ b/dashboard/src/components/paths/Pagination.tsx
@@ -18,10 +18,10 @@ export function Pagination({ page, pageSize, total, hasMore, onPageChange }: Pag
 
   return (
     <nav
-      className="flex items-center justify-between px-4 py-2 border-t border-slate-800"
+      className="flex items-center justify-between px-4 py-2 border-t border-slate-200 dark:border-slate-800"
       aria-label="Pagination"
     >
-      <span className="text-xs text-slate-500">
+      <span className="text-xs text-slate-400 dark:text-slate-500">
         {total > 0 ? `${start}–${end} of ${total}` : 'No results'}
       </span>
       <div className="flex items-center gap-1">
@@ -31,7 +31,7 @@ export function Pagination({ page, pageSize, total, hasMore, onPageChange }: Pag
           disabled={!hasPrev}
           onClick={() => onPageChange(safePage - 1)}
         />
-        <span className="px-2 text-xs text-slate-400">
+        <span className="px-2 text-xs text-slate-400 dark:text-slate-400">
           Page {safePage}
         </span>
         <PaginationButton
@@ -63,7 +63,7 @@ function PaginationButton({ label, icon, disabled, onClick }: PaginationButtonPr
         'transition-colors',
         disabled
           ? 'text-slate-700 cursor-not-allowed'
-          : 'text-slate-400 hover:bg-slate-800 hover:text-slate-200',
+          : 'text-slate-400 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-800 hover:text-slate-800 dark:hover:text-slate-200',
       ].join(' ')}
       onClick={onClick}
     >

--- a/dashboard/src/components/paths/PathDetailPage.tsx
+++ b/dashboard/src/components/paths/PathDetailPage.tsx
@@ -35,9 +35,9 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Header */}
-      <div className="px-6 py-4 border-b border-slate-800 bg-slate-900/80">
+      <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-900/80">
         <div className="flex items-start gap-3 flex-wrap">
-          <h1 className="font-mono text-base font-semibold text-slate-200 flex-1 min-w-0">
+          <h1 className="font-mono text-base font-semibold text-slate-800 dark:text-slate-200 flex-1 min-w-0">
             {pathParts.map((part, i) => (
               <span key={i} className={part.isDynamic ? 'text-amber-400' : ''}>
                 {part.text}
@@ -54,7 +54,7 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
             )}
           </div>
         </div>
-        <div className="mt-1 text-xs text-slate-500 font-mono">{data.path_hash}</div>
+        <div className="mt-1 text-xs text-slate-400 dark:text-slate-500 font-mono">{data.path_hash}</div>
       </div>
 
       {/* Multi-impl banner */}
@@ -63,7 +63,7 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
       {/* Tabs */}
       <Tabs.Root defaultValue="handlers" className="flex flex-col flex-1 overflow-hidden">
         <Tabs.List
-          className="flex border-b border-slate-800 px-6 bg-slate-900/60"
+          className="flex border-b border-slate-200 dark:border-slate-800 px-6 bg-slate-100/60 dark:bg-slate-900/60"
           aria-label="Path detail sections"
         >
           <TabTrigger value="handlers">
@@ -110,9 +110,9 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
             ) : (
               <ul className="space-y-2">
                 {data.inbound_fetches.map((e) => (
-                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-900 border border-slate-800">
+                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800">
                     <KindBadge kind={e.kind} />
-                    <span className="font-mono text-sm text-slate-300 flex-1 truncate">{e.label}</span>
+                    <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">{e.label}</span>
                     <RepoChip repo={e.repo} />
                     <a
                       href={`#entity-${e.id}`}
@@ -138,9 +138,9 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
             ) : (
               <ul className="space-y-2">
                 {data.outbound_queries.map((e) => (
-                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-900 border border-slate-800">
+                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800">
                     <Database className="w-4 h-4 text-amber-400" aria-hidden />
-                    <span className="font-mono text-sm text-slate-300 flex-1 truncate">{e.label}</span>
+                    <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">{e.label}</span>
                     <RepoChip repo={e.repo} />
                   </li>
                 ))}
@@ -159,8 +159,8 @@ function TabTrigger({ value, children }: { value: string; children: React.ReactN
       value={value}
       className={[
         'px-4 py-2.5 text-sm border-b-2 border-transparent transition-colors',
-        'text-slate-500 hover:text-slate-300',
-        'data-[state=active]:border-sky-500 data-[state=active]:text-slate-200',
+        'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
+        'data-[state=active]:border-sky-500 data-[state=active]:text-slate-800 dark:data-[state=active]:text-slate-200',
         'focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500',
       ].join(' ')}
     >
@@ -171,16 +171,16 @@ function TabTrigger({ value, children }: { value: string; children: React.ReactN
 
 function HandlerCard({ handler }: { handler: HandlerDetail }) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800">
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100 dark:bg-slate-900 overflow-hidden">
+      <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800">
         <VerbChip verb={handler.verb} />
         <KindBadge kind={handler.entity.kind} />
-        <span className="font-mono text-sm text-slate-300 flex-1 truncate">
+        <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">
           {handler.entity.label}
         </span>
         <RepoChip repo={handler.entity.repo} />
       </div>
-      <div className="px-4 py-2 text-xs text-slate-500 font-mono">
+      <div className="px-4 py-2 text-xs text-slate-400 dark:text-slate-500 font-mono">
         {handler.source_file}:{handler.start_line}
       </div>
     </div>
@@ -189,7 +189,7 @@ function HandlerCard({ handler }: { handler: HandlerDetail }) {
 
 function ResponseShapeCard({ shape }: { shape: ResponseShape }) {
   return (
-    <div className="rounded-lg border border-slate-800 bg-slate-900 p-4">
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100 dark:bg-slate-900 p-4">
       <div className="flex items-center gap-2 mb-3">
         <VerbChip verb={shape.verb} />
         <div className="flex gap-1">
@@ -218,14 +218,14 @@ function ResponseShapeCard({ shape }: { shape: ResponseShape }) {
           {shape.keys.map((key) => (
             <code
               key={key}
-              className="px-2 py-0.5 rounded bg-slate-800 text-slate-300 text-xs font-mono border border-slate-700"
+              className="px-2 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-xs font-mono border border-slate-300 dark:border-slate-700"
             >
               {key}
             </code>
           ))}
         </div>
       ) : (
-        <p className="text-xs text-slate-500 italic">
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">
           {shape.dynamic ? 'Response shape determined at runtime.' : 'Empty response body.'}
         </p>
       )}

--- a/dashboard/src/components/paths/PathFilterPanel.tsx
+++ b/dashboard/src/components/paths/PathFilterPanel.tsx
@@ -24,11 +24,11 @@ export function PathFilterPanel({ filters, setFilter, clearFilters, paths = [] }
   }
 
   return (
-    <div className="flex flex-col gap-1.5 px-4 py-2 border-b border-slate-800 text-xs">
+    <div className="flex flex-col gap-1.5 px-4 py-2 border-b border-slate-200 dark:border-slate-800 text-xs">
       {/* Row 1 — Repos */}
       {uniqueRepos.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-slate-500 shrink-0">Repos:</span>
+          <span className="text-slate-400 dark:text-slate-500 shrink-0">Repos:</span>
           {uniqueRepos.map((repo) => (
             <FilterChip
               key={repo}
@@ -43,7 +43,7 @@ export function PathFilterPanel({ filters, setFilter, clearFilters, paths = [] }
       {/* Row 2 — Frameworks */}
       {uniqueFrameworks.length > 0 && (
         <div className="flex flex-wrap items-center gap-1.5">
-          <span className="text-slate-500 shrink-0">Frameworks:</span>
+          <span className="text-slate-400 dark:text-slate-500 shrink-0">Frameworks:</span>
           {uniqueFrameworks.map((fw) => (
             <FilterChip
               key={fw}
@@ -70,7 +70,7 @@ export function PathFilterPanel({ filters, setFilter, clearFilters, paths = [] }
         {hasActiveFilters && (
           <button
             type="button"
-            className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors"
+            className="ml-auto inline-flex items-center gap-1 px-2 py-0.5 rounded text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
             onClick={clearFilters}
             aria-label="Clear all filters"
           >
@@ -98,7 +98,7 @@ function FilterChip({ label, active, onClick }: FilterChipProps) {
         'px-2 py-0.5 rounded border transition-colors font-mono',
         active
           ? 'bg-sky-900/50 border-sky-500 text-sky-300'
-          : 'bg-slate-900 border-slate-700 text-slate-400 hover:border-slate-500 hover:text-slate-300',
+          : 'bg-slate-100 dark:bg-slate-900 border-slate-300 dark:border-slate-700 text-slate-400 dark:text-slate-400 hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
       ].join(' ')}
       onClick={onClick}
     >

--- a/dashboard/src/components/paths/PathRow.tsx
+++ b/dashboard/src/components/paths/PathRow.tsx
@@ -36,10 +36,10 @@ export function PathRow({ path, group, isSelected = false, onSelect }: PathRowPr
       tabIndex={0}
       aria-selected={isSelected}
       className={[
-        'group flex items-center gap-3 px-4 py-2.5 border-b border-slate-800',
-        'cursor-pointer hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
+        'group flex items-center gap-3 px-4 py-2.5 border-b border-slate-200 dark:border-slate-800',
+        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
         'transition-colors duration-75',
-        isSelected ? 'bg-slate-800/80 border-l-2 border-l-sky-500' : '',
+        isSelected ? 'bg-slate-200/80 dark:bg-slate-800/80 border-l-2 border-l-sky-500' : '',
       ].filter(Boolean).join(' ')}
       onClick={handleClick}
       onKeyDown={handleKeyDown}
@@ -49,7 +49,7 @@ export function PathRow({ path, group, isSelected = false, onSelect }: PathRowPr
         {parts.map((part, i) => (
           <span
             key={i}
-            className={part.isDynamic ? 'text-amber-400' : 'text-slate-300'}
+            className={part.isDynamic ? 'text-amber-400' : 'text-slate-700 dark:text-slate-300'}
           >
             {part.text}
           </span>
@@ -84,7 +84,7 @@ export function PathRow({ path, group, isSelected = false, onSelect }: PathRowPr
             <RepoChip key={r} repo={r} />
           ))}
           {(path.repos ?? []).length > 2 && (
-            <span className="text-xs text-slate-500">+{(path.repos ?? []).length - 2}</span>
+            <span className="text-xs text-slate-400 dark:text-slate-500">+{(path.repos ?? []).length - 2}</span>
           )}
         </span>
       )}

--- a/dashboard/src/components/paths/PathSearchInput.tsx
+++ b/dashboard/src/components/paths/PathSearchInput.tsx
@@ -37,7 +37,7 @@ export function PathSearchInput({
   return (
     <div className="relative flex-1">
       <Search
-        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500 pointer-events-none"
+        className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-400 dark:text-slate-500 pointer-events-none"
         aria-hidden
       />
       <input
@@ -49,8 +49,8 @@ export function PathSearchInput({
         onChange={handleChange}
         placeholder={placeholder}
         className={[
-          'w-full bg-slate-900 border border-slate-700 rounded-lg',
-          'pl-9 pr-8 py-2 text-sm text-slate-200 placeholder:text-slate-500',
+          'w-full bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 rounded-lg',
+          'pl-9 pr-8 py-2 text-sm text-slate-800 dark:text-slate-200 placeholder:text-slate-500',
           'focus:outline-none focus:ring-1 focus:ring-sky-500 focus:border-sky-500',
           'transition-colors',
         ].join(' ')}
@@ -59,7 +59,7 @@ export function PathSearchInput({
         <button
           type="button"
           aria-label="Clear search"
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-500 hover:text-slate-300"
+          className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
           onClick={handleClear}
         >
           <X className="w-4 h-4" />

--- a/dashboard/src/components/paths/PathTreeSidebar.tsx
+++ b/dashboard/src/components/paths/PathTreeSidebar.tsx
@@ -31,7 +31,7 @@ export function PathTreeSidebar({
             'transition-colors',
             !activePrefix
               ? 'bg-sky-900/40 text-sky-300'
-              : 'text-slate-400 hover:bg-slate-800 hover:text-slate-300',
+              : 'text-slate-400 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-800 hover:text-slate-700 dark:hover:text-slate-300',
           ].join(' ')}
           onClick={() => onPrefixSelect(undefined)}
           aria-current={!activePrefix ? 'page' : undefined}
@@ -89,7 +89,7 @@ function TreeNode({ node, depth, activePrefix, onPrefixSelect }: TreeNodeProps) 
           'transition-colors group',
           isActive
             ? 'bg-sky-900/40 text-sky-300'
-            : 'text-slate-400 hover:bg-slate-800 hover:text-slate-300',
+            : 'text-slate-400 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-800 hover:text-slate-700 dark:hover:text-slate-300',
         ].join(' ')}
         style={{ paddingLeft: `${0.5 + depth * 0.75}rem` }}
         onClick={() => {
@@ -109,7 +109,7 @@ function TreeNode({ node, depth, activePrefix, onPrefixSelect }: TreeNodeProps) 
           <span className="w-3 h-3 flex-shrink-0" aria-hidden />
         )}
         <span className="font-mono truncate flex-1">{node.label}/</span>
-        <span className="text-slate-600 tabular-nums ml-1">{node.count}</span>
+        <span className="text-slate-500 dark:text-slate-600 tabular-nums ml-1">{node.count}</span>
       </button>
 
       {hasChildren && expanded && (

--- a/dashboard/src/components/paths/PathsGroup.tsx
+++ b/dashboard/src/components/paths/PathsGroup.tsx
@@ -69,8 +69,8 @@ export function PathsGroup({ group, isExpanded, onToggle, children }: PathsGroup
         type="button"
         className={[
           'w-full flex items-center gap-2 px-3 py-2',
-          'bg-slate-900/80 border-b border-slate-800',
-          'hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/60',
+          'bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800',
+          'hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/60',
           'transition-colors duration-75 cursor-pointer',
           'sticky top-0 z-10',
         ].join(' ')}
@@ -81,7 +81,7 @@ export function PathsGroup({ group, isExpanded, onToggle, children }: PathsGroup
         {/* Caret */}
         <ChevronRight
           className={[
-            'w-3.5 h-3.5 text-slate-500 flex-shrink-0',
+            'w-3.5 h-3.5 text-slate-400 dark:text-slate-500 flex-shrink-0',
             'transition-transform duration-150',
             isExpanded ? 'rotate-90' : '',
           ].join(' ')}
@@ -89,7 +89,7 @@ export function PathsGroup({ group, isExpanded, onToggle, children }: PathsGroup
         />
 
         {/* Controller / module name */}
-        <span className="flex-1 min-w-0 text-left text-base font-medium text-slate-200 truncate">
+        <span className="flex-1 min-w-0 text-left text-base font-medium text-slate-800 dark:text-slate-200 truncate">
           {group.name}
         </span>
 
@@ -98,7 +98,7 @@ export function PathsGroup({ group, isExpanded, onToggle, children }: PathsGroup
 
         {/* Total count badge */}
         <span
-          className="flex-shrink-0 text-xs tabular-nums text-slate-400 bg-slate-800 border border-slate-700 rounded px-1.5 py-0.5 ml-1"
+          className="flex-shrink-0 text-xs tabular-nums text-slate-400 dark:text-slate-400 bg-slate-200 dark:bg-slate-800 border border-slate-300 dark:border-slate-700 rounded px-1.5 py-0.5 ml-1"
           title={`${group.totalEndpoints} endpoints`}
         >
           {group.paths.length}

--- a/dashboard/src/components/shared/EmptyState.tsx
+++ b/dashboard/src/components/shared/EmptyState.tsx
@@ -15,11 +15,11 @@ export function EmptyState({ icon: Icon = SearchX, title, message, action }: Emp
       role="status"
       aria-live="polite"
     >
-      <div className="rounded-full bg-slate-800 p-4">
-        <Icon className="w-8 h-8 text-slate-500" aria-hidden />
+      <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
+        <Icon className="w-8 h-8 text-slate-400 dark:text-slate-500" aria-hidden />
       </div>
-      <h3 className="text-base font-semibold text-slate-300">{title}</h3>
-      {message && <p className="max-w-sm text-sm text-slate-500">{message}</p>}
+      <h3 className="text-base font-semibold text-slate-700 dark:text-slate-300">{title}</h3>
+      {message && <p className="max-w-sm text-sm text-slate-400 dark:text-slate-500">{message}</p>}
       {action && <div className="mt-2">{action}</div>}
     </div>
   )

--- a/dashboard/src/components/shared/ErrorBoundary.tsx
+++ b/dashboard/src/components/shared/ErrorBoundary.tsx
@@ -35,15 +35,15 @@ export class ErrorBoundary extends React.Component<Props, State> {
           role="alert"
         >
           <AlertTriangle className="w-10 h-10 text-red-400" />
-          <h3 className="text-base font-semibold text-slate-200">Something went wrong</h3>
+          <h3 className="text-base font-semibold text-slate-800 dark:text-slate-200">Something went wrong</h3>
           {import.meta.env.DEV && this.state.error && (
-            <pre className="mt-2 max-w-lg overflow-auto rounded bg-slate-900 p-3 text-left text-xs text-red-300">
+            <pre className="mt-2 max-w-lg overflow-auto rounded bg-slate-100 dark:bg-slate-900 p-3 text-left text-xs text-red-300">
               {this.state.error.message}
             </pre>
           )}
           <button
             type="button"
-            className="mt-2 rounded px-3 py-1.5 text-sm bg-slate-800 hover:bg-slate-700 text-slate-300 transition-colors"
+            className="mt-2 rounded px-3 py-1.5 text-sm bg-slate-200 dark:bg-slate-800 hover:bg-slate-300 dark:hover:bg-slate-700 text-slate-700 dark:text-slate-300 transition-colors"
             onClick={() => this.setState({ hasError: false, error: null })}
           >
             Try again

--- a/dashboard/src/components/shared/LoadingState.tsx
+++ b/dashboard/src/components/shared/LoadingState.tsx
@@ -10,7 +10,7 @@ interface SkeletonProps {
 function Skeleton({ className = '' }: SkeletonProps) {
   return (
     <div
-      className={`animate-pulse rounded bg-slate-800 ${className}`}
+      className={`animate-pulse rounded bg-slate-200 dark:bg-slate-800 ${className}`}
       aria-hidden
     />
   )
@@ -19,7 +19,7 @@ function Skeleton({ className = '' }: SkeletonProps) {
 /** Skeleton for a single PathRow */
 export function PathRowSkeleton() {
   return (
-    <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800">
+    <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800">
       <Skeleton className="h-4 w-48" />
       <Skeleton className="h-5 w-10 rounded" />
       <Skeleton className="h-5 w-10 rounded" />
@@ -60,7 +60,7 @@ export function PathTreeSkeleton() {
 /** Generic card skeleton */
 export function CardSkeleton() {
   return (
-    <div className="rounded-lg border border-slate-800 p-4 space-y-3" role="status" aria-label="Loading…">
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 p-4 space-y-3" role="status" aria-label="Loading…">
       <Skeleton className="h-5 w-3/4" />
       <Skeleton className="h-4 w-full" />
       <Skeleton className="h-4 w-5/6" />
@@ -72,7 +72,7 @@ export function CardSkeleton() {
 /** Skeleton for a single FlowRow */
 export function FlowRowSkeleton() {
   return (
-    <div className="flex items-start gap-3 px-4 py-3 border-b border-slate-800">
+    <div className="flex items-start gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800">
       <Skeleton className="w-4 h-4 mt-0.5 rounded" />
       <div className="flex-1 space-y-2">
         <div className="flex items-center gap-2">
@@ -99,7 +99,7 @@ export function FlowListSkeleton({ count = 8 }: { count?: number }) {
 /** Skeleton chip row for topology protocol filters */
 export function ProtocolChipsSkeleton() {
   return (
-    <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-800" role="status" aria-label="Loading filters…">
+    <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800" role="status" aria-label="Loading filters…">
       {Array.from({ length: 9 }, (_, i) => (
         <Skeleton key={i} className={`h-6 rounded-full ${i === 0 ? 'w-8' : 'w-16'}`} />
       ))}
@@ -113,8 +113,8 @@ export function SwimLaneSkeleton() {
   return (
     <div className="flex gap-0 overflow-x-auto" role="status" aria-label="Loading flow visualization…">
       {Array.from({ length: 2 }, (_, i) => (
-        <div key={i} className="min-w-[240px] border-r border-slate-800 last:border-r-0">
-          <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-800 bg-slate-900/60">
+        <div key={i} className="min-w-[240px] border-r border-slate-200 dark:border-slate-800 last:border-r-0">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
             <Skeleton className="w-2 h-2 rounded-full" />
             <Skeleton className="h-5 w-24 rounded" />
           </div>

--- a/dashboard/src/components/shared/SourceSnippet.tsx
+++ b/dashboard/src/components/shared/SourceSnippet.tsx
@@ -14,29 +14,29 @@ interface SourceSnippetProps {
 
 export function SourceSnippet({ sourceFile, startLine, endLine, language, code }: SourceSnippetProps) {
   return (
-    <div className="rounded-lg overflow-hidden border border-slate-800 text-xs">
+    <div className="rounded-lg overflow-hidden border border-slate-200 dark:border-slate-800 text-xs">
       {/* Header */}
-      <div className="flex items-center justify-between px-3 py-1.5 bg-slate-900 border-b border-slate-800">
-        <span className="font-mono text-slate-400">
+      <div className="flex items-center justify-between px-3 py-1.5 bg-slate-100 dark:bg-slate-900 border-b border-slate-200 dark:border-slate-800">
+        <span className="font-mono text-slate-400 dark:text-slate-400">
           {sourceFile}
-          <span className="text-slate-600">:{startLine}</span>
+          <span className="text-slate-500 dark:text-slate-600">:{startLine}</span>
           {endLine && endLine !== startLine && (
-            <span className="text-slate-600">–{endLine}</span>
+            <span className="text-slate-500 dark:text-slate-600">–{endLine}</span>
           )}
         </span>
         {language && (
-          <span className="text-slate-600 uppercase tracking-wider">{language}</span>
+          <span className="text-slate-500 dark:text-slate-600 uppercase tracking-wider">{language}</span>
         )}
       </div>
 
       {/* Code body */}
-      <div className="bg-slate-950 p-3 overflow-x-auto">
+      <div className="bg-white dark:bg-slate-950 p-3 overflow-x-auto">
         {code ? (
-          <pre className="font-mono text-slate-300 whitespace-pre leading-relaxed">
+          <pre className="font-mono text-slate-700 dark:text-slate-300 whitespace-pre leading-relaxed">
             <code>{code}</code>
           </pre>
         ) : (
-          <p className="text-slate-600 italic">
+          <p className="text-slate-500 dark:text-slate-600 italic">
             Source loading requires live Go server connection.
           </p>
         )}

--- a/dashboard/src/components/topology/ChannelTrack.tsx
+++ b/dashboard/src/components/topology/ChannelTrack.tsx
@@ -27,13 +27,13 @@ export function ChannelTrack({ channels, graphqlSubscriptions, selectedId, onSel
   if (!hasChannels) return null
 
   return (
-    <div className="border-t border-slate-800 bg-slate-950/60">
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-800/60">
-        <Wifi className="w-3.5 h-3.5 text-slate-500" aria-hidden />
-        <span className="text-xs font-medium text-slate-400 uppercase tracking-wider">
+    <div className="border-t border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-950/60">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800/60">
+        <Wifi className="w-3.5 h-3.5 text-slate-400 dark:text-slate-500" aria-hidden />
+        <span className="text-xs font-medium text-slate-400 dark:text-slate-400 uppercase tracking-wider">
           Real-time Channels
         </span>
-        <span className="ml-auto text-xs text-slate-600">
+        <span className="ml-auto text-xs text-slate-500 dark:text-slate-600">
           {channels.length + graphqlSubscriptions.length} channel{channels.length + graphqlSubscriptions.length !== 1 ? 's' : ''}
         </span>
       </div>
@@ -121,7 +121,7 @@ function ChannelCard({
         'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-slate-950',
         isSelected
           ? `${spec.bg} ${spec.border} border`
-          : 'bg-slate-900 border-slate-800 hover:border-slate-600',
+          : 'bg-slate-100 dark:bg-slate-900 border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600',
       ].join(' ')}
     >
       {/* Header row */}
@@ -135,19 +135,19 @@ function ChannelCard({
       </div>
 
       {/* Label */}
-      <p className="font-mono text-xs text-slate-200 truncate mb-1" title={label}>
+      <p className="font-mono text-xs text-slate-800 dark:text-slate-200 truncate mb-1" title={label}>
         {label}
       </p>
 
       {/* Endpoint if present */}
       {endpoint && (
-        <p className="font-mono text-xs text-slate-500 truncate mb-2" title={endpoint}>
+        <p className="font-mono text-xs text-slate-400 dark:text-slate-500 truncate mb-2" title={endpoint}>
           {endpoint}
         </p>
       )}
 
       {/* Stats row */}
-      <div className="flex items-center gap-3 text-xs text-slate-500">
+      <div className="flex items-center gap-3 text-xs text-slate-400 dark:text-slate-500">
         <span title={`${emitterCount} emitter${emitterCount !== 1 ? 's' : ''}`}>
           ↑ {emitterCount}
         </span>
@@ -203,7 +203,7 @@ function GraphQLSubCard({
         'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-slate-950',
         isSelected
           ? `${spec.bg} ${spec.border} border`
-          : 'bg-slate-900 border-slate-800 hover:border-slate-600',
+          : 'bg-slate-100 dark:bg-slate-900 border-slate-200 dark:border-slate-800 hover:border-slate-400 dark:hover:border-slate-600',
       ].join(' ')}
     >
       {/* Header */}
@@ -216,17 +216,17 @@ function GraphQLSubCard({
         </span>
       </div>
 
-      <p className="font-mono text-xs text-slate-200 truncate mb-1" title={label}>
+      <p className="font-mono text-xs text-slate-800 dark:text-slate-200 truncate mb-1" title={label}>
         subscription {label}
       </p>
 
       {returnType && (
-        <p className="font-mono text-xs text-slate-500 truncate mb-2" title={returnType}>
+        <p className="font-mono text-xs text-slate-400 dark:text-slate-500 truncate mb-2" title={returnType}>
           → {returnType}
         </p>
       )}
 
-      <div className="flex items-center gap-3 text-xs text-slate-500">
+      <div className="flex items-center gap-3 text-xs text-slate-400 dark:text-slate-500">
         <span title={`${publisherCount} publisher${publisherCount !== 1 ? 's' : ''}`}>
           ↑ {publisherCount}
         </span>

--- a/dashboard/src/components/topology/GraphQLSubscriptionPanel.tsx
+++ b/dashboard/src/components/topology/GraphQLSubscriptionPanel.tsx
@@ -25,17 +25,17 @@ export function GraphQLSubscriptionPanel({
 
   return (
     <aside
-      className="w-80 flex flex-col border-l border-slate-800 bg-slate-950 overflow-y-auto"
+      className="w-80 flex flex-col border-l border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 overflow-y-auto"
       aria-label={`GraphQL subscription detail: ${subscription.label}`}
     >
       {/* Header */}
-      <div className={`flex items-center gap-2 px-4 py-3 border-b border-slate-800 ${spec.bg}`}>
+      <div className={`flex items-center gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-800 ${spec.bg}`}>
         <div className={`p-1.5 rounded ${spec.bg}`}>
           <Zap className={`w-4 h-4 ${spec.text}`} aria-hidden />
         </div>
         <div className="flex-1 min-w-0">
-          <p className="text-xs text-slate-400">{spec.label}</p>
-          <p className="font-mono text-sm text-slate-100 truncate" title={subscription.label}>
+          <p className="text-xs text-slate-400 dark:text-slate-400">{spec.label}</p>
+          <p className="font-mono text-sm text-slate-900 dark:text-slate-100 truncate" title={subscription.label}>
             subscription {subscription.label}
           </p>
         </div>
@@ -43,26 +43,26 @@ export function GraphQLSubscriptionPanel({
           type="button"
           aria-label="Close GraphQL subscription panel"
           onClick={onClose}
-          className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors flex-shrink-0"
+          className="p-1.5 rounded text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors flex-shrink-0"
         >
           <X className="w-4 h-4" />
         </button>
       </div>
 
       {/* Schema info */}
-      <div className="px-4 py-3 border-b border-slate-800 space-y-1.5">
+      <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-800 space-y-1.5">
         <div className="flex items-center justify-between text-xs">
-          <span className="text-slate-500">Schema type</span>
-          <span className="font-mono text-slate-300">{subscription.schema_type}</span>
+          <span className="text-slate-400 dark:text-slate-500">Schema type</span>
+          <span className="font-mono text-slate-700 dark:text-slate-300">{subscription.schema_type}</span>
         </div>
         {subscription.return_type && (
           <div className="flex items-center justify-between text-xs">
-            <span className="text-slate-500">Return type</span>
-            <span className="font-mono text-slate-300">{subscription.return_type}</span>
+            <span className="text-slate-400 dark:text-slate-500">Return type</span>
+            <span className="font-mono text-slate-700 dark:text-slate-300">{subscription.return_type}</span>
           </div>
         )}
         <div className="flex items-center justify-between text-xs">
-          <span className="text-slate-500">Repo</span>
+          <span className="text-slate-400 dark:text-slate-500">Repo</span>
           <RepoChip repo={subscription.repo} />
         </div>
       </div>
@@ -98,23 +98,23 @@ function EntityList({
   emptyMessage: string
 }) {
   return (
-    <div className="flex flex-col border-b border-slate-800 last:border-b-0">
-      <div className="flex items-center gap-1.5 px-4 py-2 bg-slate-900/40">
-        <span className="text-slate-500">{icon}</span>
-        <span className="text-xs font-medium text-slate-400">{title}</span>
-        <span className="ml-auto text-xs text-slate-600">{entities.length}</span>
+    <div className="flex flex-col border-b border-slate-200 dark:border-slate-800 last:border-b-0">
+      <div className="flex items-center gap-1.5 px-4 py-2 bg-slate-100/40 dark:bg-slate-900/40">
+        <span className="text-slate-400 dark:text-slate-500">{icon}</span>
+        <span className="text-xs font-medium text-slate-400 dark:text-slate-400">{title}</span>
+        <span className="ml-auto text-xs text-slate-500 dark:text-slate-600">{entities.length}</span>
       </div>
       {entities.length === 0 ? (
-        <p className="px-4 py-3 text-xs text-slate-600 italic">{emptyMessage}</p>
+        <p className="px-4 py-3 text-xs text-slate-500 dark:text-slate-600 italic">{emptyMessage}</p>
       ) : (
         <ul className="divide-y divide-slate-800/60">
           {entities.map((e) => (
             <li key={e.id} className="flex items-start gap-2.5 px-4 py-2.5">
               <div className="flex-1 min-w-0">
-                <p className="font-mono text-xs text-slate-200 truncate" title={e.label}>
+                <p className="font-mono text-xs text-slate-800 dark:text-slate-200 truncate" title={e.label}>
                   {e.label}
                 </p>
-                <p className="text-xs text-slate-500 truncate" title={e.source_file}>
+                <p className="text-xs text-slate-400 dark:text-slate-500 truncate" title={e.source_file}>
                   {e.source_file}:{e.start_line}
                 </p>
               </div>

--- a/dashboard/src/components/topology/ProtocolFilterChips.tsx
+++ b/dashboard/src/components/topology/ProtocolFilterChips.tsx
@@ -25,7 +25,7 @@ export function ProtocolFilterChips({
     <div
       role="group"
       aria-label="Filter by protocol"
-      className="flex items-center gap-1.5 flex-wrap px-4 py-2 border-b border-slate-800"
+      className="flex items-center gap-1.5 flex-wrap px-4 py-2 border-b border-slate-200 dark:border-slate-800"
     >
       {/* "All" chip */}
       <button
@@ -37,8 +37,8 @@ export function ProtocolFilterChips({
           'inline-flex items-center gap-1 px-2.5 py-1 rounded text-xs font-medium border transition-colors',
           'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-slate-950',
           isAllActive
-            ? 'bg-slate-700 text-slate-200 border-slate-500'
-            : 'bg-slate-900 text-slate-500 border-slate-700 hover:border-slate-500 hover:text-slate-300',
+            ? 'bg-slate-300 dark:bg-slate-700 text-slate-800 dark:text-slate-200 border-slate-500'
+            : 'bg-slate-100 dark:bg-slate-900 text-slate-400 dark:text-slate-500 border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
         ].join(' ')}
       >
         All
@@ -60,7 +60,7 @@ export function ProtocolFilterChips({
               'focus:outline-none focus:ring-2 focus:ring-offset-1 focus:ring-offset-slate-950',
               isActive
                 ? `${spec.bg} ${spec.text} ${spec.border}`
-                : 'bg-slate-900 text-slate-500 border-slate-700 hover:border-slate-500 hover:text-slate-300',
+                : 'bg-slate-100 dark:bg-slate-900 text-slate-400 dark:text-slate-500 border-slate-300 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
             ].join(' ')}
             style={isActive ? {} : undefined}
           >

--- a/dashboard/src/components/topology/TopicDetailPanel.tsx
+++ b/dashboard/src/components/topology/TopicDetailPanel.tsx
@@ -36,49 +36,49 @@ export function TopicDetailPanel({ detail, onClose, onNavigateToTopic }: TopicDe
 
   return (
     <aside
-      className="w-80 flex flex-col border-l border-slate-800 bg-slate-950 overflow-y-auto"
+      className="w-80 flex flex-col border-l border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 overflow-y-auto"
       aria-label={`Topic detail: ${label}`}
     >
       {/* Header */}
-      <div className={`flex items-start gap-2 px-4 py-3 border-b border-slate-800 ${spec.bg}`}>
+      <div className={`flex items-start gap-2 px-4 py-3 border-b border-slate-200 dark:border-slate-800 ${spec.bg}`}>
         <div className="flex-1 min-w-0">
           <div className="flex items-center gap-2 mb-0.5">
             <span className={`inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-xs font-medium ${spec.bg} ${spec.text} ${spec.border} border`}>
               {spec.label}
             </span>
             {queueType && (
-              <span className="text-xs text-slate-500 capitalize">{queueType}</span>
+              <span className="text-xs text-slate-400 dark:text-slate-500 capitalize">{queueType}</span>
             )}
           </div>
-          <p className="font-mono text-sm text-slate-100 truncate" title={label}>
+          <p className="font-mono text-sm text-slate-900 dark:text-slate-100 truncate" title={label}>
             {label}
           </p>
           {serverEndpoint && (
-            <p className="font-mono text-xs text-slate-400 truncate mt-0.5" title={serverEndpoint}>
+            <p className="font-mono text-xs text-slate-400 dark:text-slate-400 truncate mt-0.5" title={serverEndpoint}>
               {serverEndpoint}
             </p>
           )}
           {returnType && (
-            <p className="font-mono text-xs text-slate-400 mt-0.5">→ {returnType}</p>
+            <p className="font-mono text-xs text-slate-400 dark:text-slate-400 mt-0.5">→ {returnType}</p>
           )}
         </div>
         <button
           type="button"
           aria-label="Close topic detail panel"
           onClick={onClose}
-          className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors flex-shrink-0 mt-0.5"
+          className="p-1.5 rounded text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors flex-shrink-0 mt-0.5"
         >
           <X className="w-4 h-4" />
         </button>
       </div>
 
       {/* Metadata row */}
-      <div className="flex items-center gap-3 px-4 py-2 border-b border-slate-800 text-xs">
+      <div className="flex items-center gap-3 px-4 py-2 border-b border-slate-200 dark:border-slate-800 text-xs">
         <RepoChip repo={node.repo} />
-        <span className="text-slate-600">
+        <span className="text-slate-500 dark:text-slate-600">
           {producers.length} producer{producers.length !== 1 ? 's' : ''}
         </span>
-        <span className="text-slate-600">
+        <span className="text-slate-500 dark:text-slate-600">
           {consumers.length} consumer{consumers.length !== 1 ? 's' : ''}
         </span>
       </div>
@@ -103,7 +103,7 @@ export function TopicDetailPanel({ detail, onClose, onNavigateToTopic }: TopicDe
 
       {/* Transform chains */}
       {transformsTo.length > 0 && (
-        <div className="flex flex-col border-b border-slate-800">
+        <div className="flex flex-col border-b border-slate-200 dark:border-slate-800">
           <div className="flex items-center gap-1.5 px-4 py-2 bg-amber-950/20">
             <ArrowRight className="w-3.5 h-3.5 text-amber-400" aria-hidden />
             <span className="text-xs font-medium text-amber-300">Transforms To</span>
@@ -116,7 +116,7 @@ export function TopicDetailPanel({ detail, onClose, onNavigateToTopic }: TopicDe
                   <p className="font-mono text-xs text-amber-200 truncate" title={t.label}>
                     {t.label}
                   </p>
-                  <p className="text-xs text-slate-500 capitalize">
+                  <p className="text-xs text-slate-400 dark:text-slate-500 capitalize">
                     {'broker' in t ? (t as TopicNode | QueueNode).broker : 'nats'}
                   </p>
                 </div>
@@ -124,7 +124,7 @@ export function TopicDetailPanel({ detail, onClose, onNavigateToTopic }: TopicDe
                   type="button"
                   aria-label={`Navigate to ${t.label}`}
                   onClick={() => onNavigateToTopic(t.id)}
-                  className="p-1 rounded text-slate-500 hover:text-amber-300 hover:bg-slate-800 transition-colors"
+                  className="p-1 rounded text-slate-400 dark:text-slate-500 hover:text-amber-300 hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
                 >
                   <ExternalLink className="w-3 h-3" />
                 </button>
@@ -151,24 +151,24 @@ function EntitySection({
   arrowLabel: string
 }) {
   return (
-    <div className="flex flex-col border-b border-slate-800 last:border-b-0">
-      <div className="flex items-center gap-1.5 px-4 py-2 bg-slate-900/40">
-        <span className="text-slate-500">{icon}</span>
-        <span className="text-xs font-medium text-slate-400">{title}</span>
-        <span className="ml-auto text-xs text-slate-600">{entities.length}</span>
+    <div className="flex flex-col border-b border-slate-200 dark:border-slate-800 last:border-b-0">
+      <div className="flex items-center gap-1.5 px-4 py-2 bg-slate-100/40 dark:bg-slate-900/40">
+        <span className="text-slate-400 dark:text-slate-500">{icon}</span>
+        <span className="text-xs font-medium text-slate-400 dark:text-slate-400">{title}</span>
+        <span className="ml-auto text-xs text-slate-500 dark:text-slate-600">{entities.length}</span>
       </div>
 
       {entities.length === 0 ? (
-        <p className="px-4 py-3 text-xs text-slate-600 italic">{emptyMessage}</p>
+        <p className="px-4 py-3 text-xs text-slate-500 dark:text-slate-600 italic">{emptyMessage}</p>
       ) : (
         <ul className="divide-y divide-slate-800/60" aria-label={arrowLabel}>
           {entities.map((e) => (
             <li key={e.id} className="flex items-start gap-2.5 px-4 py-2.5">
               <div className="flex-1 min-w-0">
-                <p className="font-mono text-xs text-slate-200 truncate" title={e.label}>
+                <p className="font-mono text-xs text-slate-800 dark:text-slate-200 truncate" title={e.label}>
                   {e.label}
                 </p>
-                <p className="text-xs text-slate-500 truncate" title={e.source_file}>
+                <p className="text-xs text-slate-400 dark:text-slate-500 truncate" title={e.source_file}>
                   {e.source_file}:{e.start_line}
                 </p>
               </div>

--- a/dashboard/src/components/topology/TopologyEmptyState.tsx
+++ b/dashboard/src/components/topology/TopologyEmptyState.tsx
@@ -17,11 +17,11 @@ export function TopologyEmptyState({
         role="status"
         className="flex flex-col items-center justify-center gap-3 py-16 text-center"
       >
-        <div className="rounded-full bg-slate-800 p-4">
-          <Radio className="w-8 h-8 text-slate-500" aria-hidden />
+        <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
+          <Radio className="w-8 h-8 text-slate-400 dark:text-slate-500" aria-hidden />
         </div>
-        <h3 className="text-base font-semibold text-slate-300">No group selected</h3>
-        <p className="max-w-sm text-sm text-slate-500">
+        <h3 className="text-base font-semibold text-slate-700 dark:text-slate-300">No group selected</h3>
+        <p className="max-w-sm text-sm text-slate-400 dark:text-slate-500">
           Select a group from the navigation to view its broker topology.
         </p>
       </div>
@@ -34,18 +34,18 @@ export function TopologyEmptyState({
         role="status"
         className="flex flex-col items-center justify-center gap-3 py-16 text-center"
       >
-        <div className="rounded-full bg-slate-800 p-4">
-          <Radio className="w-8 h-8 text-slate-500" aria-hidden />
+        <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
+          <Radio className="w-8 h-8 text-slate-400 dark:text-slate-500" aria-hidden />
         </div>
-        <h3 className="text-base font-semibold text-slate-300">No topics match filters</h3>
-        <p className="max-w-sm text-sm text-slate-500">
+        <h3 className="text-base font-semibold text-slate-700 dark:text-slate-300">No topics match filters</h3>
+        <p className="max-w-sm text-sm text-slate-400 dark:text-slate-500">
           Try selecting a different protocol or clearing the filter.
         </p>
         {onClearFilters && (
           <button
             type="button"
             onClick={onClearFilters}
-            className="mt-1 px-3 py-1.5 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors"
+            className="mt-1 px-3 py-1.5 rounded text-sm bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
           >
             Clear filters
           </button>
@@ -59,11 +59,11 @@ export function TopologyEmptyState({
       role="status"
       className="flex flex-col items-center justify-center gap-3 py-16 text-center"
     >
-      <div className="rounded-full bg-slate-800 p-4">
-        <Radio className="w-8 h-8 text-slate-500" aria-hidden />
+      <div className="rounded-full bg-slate-200 dark:bg-slate-800 p-4">
+        <Radio className="w-8 h-8 text-slate-400 dark:text-slate-500" aria-hidden />
       </div>
-      <h3 className="text-base font-semibold text-slate-300">No broker topology found</h3>
-      <p className="max-w-sm text-sm text-slate-500">
+      <h3 className="text-base font-semibold text-slate-700 dark:text-slate-300">No broker topology found</h3>
+      <p className="max-w-sm text-sm text-slate-400 dark:text-slate-500">
         No message topics, queues, or channels were indexed for this group.
         Make sure the indexer has run against repos that use Kafka, RabbitMQ, SQS, or similar.
       </p>

--- a/dashboard/src/components/topology/TopologyErrorState.tsx
+++ b/dashboard/src/components/topology/TopologyErrorState.tsx
@@ -14,12 +14,12 @@ export function TopologyErrorState({ error, onRetry }: TopologyErrorStateProps) 
       <div className="rounded-full bg-red-950/40 p-4">
         <AlertCircle className="w-8 h-8 text-red-400" aria-hidden />
       </div>
-      <h3 className="text-base font-semibold text-slate-300">Failed to load topology</h3>
-      <p className="max-w-sm text-sm text-slate-500 font-mono">{error.message}</p>
+      <h3 className="text-base font-semibold text-slate-700 dark:text-slate-300">Failed to load topology</h3>
+      <p className="max-w-sm text-sm text-slate-400 dark:text-slate-500 font-mono">{error.message}</p>
       <button
         type="button"
         onClick={onRetry}
-        className="mt-1 px-3 py-1.5 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
+        className="mt-1 px-3 py-1.5 rounded text-sm bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors focus:outline-none focus:ring-2 focus:ring-sky-500"
       >
         Retry
       </button>

--- a/dashboard/src/components/topology/TopologyList.tsx
+++ b/dashboard/src/components/topology/TopologyList.tsx
@@ -88,10 +88,10 @@ function TopologyListRowItem({ row, isSelected, onSelect }: TopologyListRowProps
       onClick={() => onSelect(row.id)}
       className={[
         'w-full flex items-center gap-2.5 px-4 py-2.5 text-left transition-colors group',
-        'focus:outline-none focus:bg-slate-800',
+        'focus:outline-none focus:bg-slate-200 dark:focus:bg-slate-800',
         isSelected
-          ? 'bg-slate-800 border-l-2 border-sky-500'
-          : 'hover:bg-slate-900/60 border-l-2 border-transparent',
+          ? 'bg-slate-200 dark:bg-slate-800 border-l-2 border-sky-500'
+          : 'hover:bg-slate-200/60 dark:hover:bg-slate-900/60 border-l-2 border-transparent',
       ].join(' ')}
     >
       {/* Protocol icon */}
@@ -101,7 +101,7 @@ function TopologyListRowItem({ row, isSelected, onSelect }: TopologyListRowProps
 
       {/* Label */}
       <span
-        className="font-mono text-xs text-slate-200 flex-1 truncate min-w-0"
+        className="font-mono text-xs text-slate-800 dark:text-slate-200 flex-1 truncate min-w-0"
         title={row.label}
       >
         {row.label}
@@ -109,19 +109,19 @@ function TopologyListRowItem({ row, isSelected, onSelect }: TopologyListRowProps
 
       {/* Producer count */}
       <span
-        className="flex items-center gap-0.5 text-xs text-slate-500 flex-shrink-0 tabular-nums"
+        className="flex items-center gap-0.5 text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums"
         title={`${row.producerCount} producer${row.producerCount !== 1 ? 's' : ''}`}
       >
-        <ArrowUp className="w-3 h-3 text-slate-600" aria-hidden />
+        <ArrowUp className="w-3 h-3 text-slate-500 dark:text-slate-600" aria-hidden />
         {row.producerCount}
       </span>
 
       {/* Consumer count */}
       <span
-        className="flex items-center gap-0.5 text-xs text-slate-500 flex-shrink-0 tabular-nums"
+        className="flex items-center gap-0.5 text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums"
         title={`${row.consumerCount} consumer${row.consumerCount !== 1 ? 's' : ''}`}
       >
-        <ArrowDown className="w-3 h-3 text-slate-600" aria-hidden />
+        <ArrowDown className="w-3 h-3 text-slate-500 dark:text-slate-600" aria-hidden />
         {row.consumerCount}
       </span>
 
@@ -151,16 +151,16 @@ function GroupSection({ name, rows, isExpanded, onToggle, selectedId, onSelect }
         type="button"
         onClick={onToggle}
         aria-expanded={isExpanded}
-        className="w-full flex items-center gap-2 px-4 py-2 bg-slate-900/80 border-b border-slate-800 hover:bg-slate-900 transition-colors focus:outline-none focus:bg-slate-900 group"
+        className="w-full flex items-center gap-2 px-4 py-2 bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800 hover:bg-slate-200 dark:hover:bg-slate-900 transition-colors focus:outline-none focus:bg-slate-900 group"
       >
         {isExpanded
-          ? <ChevronDown className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" aria-hidden />
-          : <ChevronRight className="w-3.5 h-3.5 text-slate-500 flex-shrink-0" aria-hidden />
+          ? <ChevronDown className="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden />
+          : <ChevronRight className="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden />
         }
-        <span className="text-xs font-semibold text-slate-300 flex-1 truncate text-left">
+        <span className="text-xs font-semibold text-slate-700 dark:text-slate-300 flex-1 truncate text-left">
           {name}
         </span>
-        <span className="text-xs text-slate-600 tabular-nums flex-shrink-0">
+        <span className="text-xs text-slate-500 dark:text-slate-600 tabular-nums flex-shrink-0">
           {rows.length}
         </span>
       </button>
@@ -222,8 +222,8 @@ export function TopologyList({ data, searchQuery, selectedId, onSelectEntity }: 
   return (
     <div className="flex flex-col h-full overflow-hidden">
       {/* Grouping selector */}
-      <div className="flex items-center gap-1 px-4 py-2 border-b border-slate-800 bg-slate-950/90 flex-shrink-0">
-        <span className="text-xs text-slate-500 mr-1">Group:</span>
+      <div className="flex items-center gap-1 px-4 py-2 border-b border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-950/90 flex-shrink-0">
+        <span className="text-xs text-slate-400 dark:text-slate-500 mr-1">Group:</span>
         <button
           type="button"
           onClick={() => setGrouping('repo')}
@@ -232,7 +232,7 @@ export function TopologyList({ data, searchQuery, selectedId, onSelectEntity }: 
             'text-xs px-2 py-0.5 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-sky-500',
             grouping === 'repo'
               ? 'bg-sky-900/50 text-sky-300 border border-sky-700'
-              : 'text-slate-400 hover:text-slate-200 border border-transparent hover:border-slate-700',
+              : 'text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 border border-transparent hover:border-slate-300 dark:hover:border-slate-700',
           ].join(' ')}
         >
           By repo
@@ -245,13 +245,13 @@ export function TopologyList({ data, searchQuery, selectedId, onSelectEntity }: 
             'text-xs px-2 py-0.5 rounded transition-colors focus:outline-none focus:ring-1 focus:ring-sky-500',
             grouping === 'protocol'
               ? 'bg-sky-900/50 text-sky-300 border border-sky-700'
-              : 'text-slate-400 hover:text-slate-200 border border-transparent hover:border-slate-700',
+              : 'text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 border border-transparent hover:border-slate-300 dark:hover:border-slate-700',
           ].join(' ')}
         >
           By protocol
         </button>
         <span className="flex-1" />
-        <span className="text-xs text-slate-600 tabular-nums">
+        <span className="text-xs text-slate-500 dark:text-slate-600 tabular-nums">
           {rows.length} {rows.length === 1 ? 'entity' : 'entities'}
         </span>
       </div>
@@ -259,7 +259,7 @@ export function TopologyList({ data, searchQuery, selectedId, onSelectEntity }: 
       {/* Groups */}
       {rows.length === 0 ? (
         <div className="flex-1 flex items-center justify-center">
-          <p className="text-sm text-slate-600 italic">
+          <p className="text-sm text-slate-500 dark:text-slate-600 italic">
             {searchQuery ? 'No entities match the filter.' : 'No entities to display.'}
           </p>
         </div>

--- a/dashboard/src/components/topology/TopologyLoadingState.tsx
+++ b/dashboard/src/components/topology/TopologyLoadingState.tsx
@@ -1,5 +1,5 @@
 function Skeleton({ className = '', style }: { className?: string; style?: React.CSSProperties }) {
-  return <div className={`animate-pulse rounded bg-slate-800 ${className}`} style={style} aria-hidden />
+  return <div className={`animate-pulse rounded bg-slate-200 dark:bg-slate-800 ${className}`} style={style} aria-hidden />
 }
 
 /**
@@ -9,14 +9,14 @@ export function TopologyLoadingState() {
   return (
     <div role="status" aria-label="Loading topology…" className="flex flex-col h-full">
       {/* Filter chips skeleton */}
-      <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-800">
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800">
         {Array.from({ length: 9 }, (_, i) => (
           <Skeleton key={i} className={`h-6 rounded-full ${i === 0 ? 'w-8' : 'w-16'}`} />
         ))}
       </div>
 
       {/* Canvas skeleton — scattered circles representing topic nodes */}
-      <div className="flex-1 relative bg-slate-950 overflow-hidden">
+      <div className="flex-1 relative bg-white dark:bg-slate-950 overflow-hidden">
         {/* Simulated scattered nodes */}
         {[
           { top: '20%', left: '25%', size: 48 },
@@ -43,8 +43,8 @@ export function TopologyLoadingState() {
       </div>
 
       {/* Channel track skeleton */}
-      <div className="border-t border-slate-800">
-        <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-800/60">
+      <div className="border-t border-slate-200 dark:border-slate-800">
+        <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800/60">
           <Skeleton className="w-3.5 h-3.5 rounded" />
           <Skeleton className="h-3.5 w-32 rounded" />
         </div>

--- a/dashboard/src/components/topology/TopologyMap.tsx
+++ b/dashboard/src/components/topology/TopologyMap.tsx
@@ -126,7 +126,7 @@ export function TopologyMap({ layout, data, selectedId, onSelectTopic }: Topolog
 
   if (layout.nodes.length === 0) {
     return (
-      <div className="flex-1 flex items-center justify-center text-slate-600 text-sm">
+      <div className="flex-1 flex items-center justify-center text-slate-500 dark:text-slate-600 text-sm">
         No topics match the current filters
       </div>
     )
@@ -137,7 +137,7 @@ export function TopologyMap({ layout, data, selectedId, onSelectTopic }: Topolog
       ref={svgRef}
       role="application"
       aria-label="Broker topology map — use arrow keys to navigate topics, Enter to select"
-      className="flex-1 w-full h-full bg-slate-950 cursor-grab active:cursor-grabbing select-none"
+      className="flex-1 w-full h-full bg-white dark:bg-slate-950 cursor-grab active:cursor-grabbing select-none"
       viewBox={`0 0 ${CANVAS_W} ${CANVAS_H}`}
       onMouseDown={handleMouseDown}
       onMouseMove={handleMouseMove}

--- a/dashboard/src/context/ThemeContext.tsx
+++ b/dashboard/src/context/ThemeContext.tsx
@@ -11,10 +11,11 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined)
 
 function getInitialTheme(): Theme {
-  if (typeof window === 'undefined') return 'dark'
+  if (typeof window === 'undefined') return 'light'
   const stored = localStorage.getItem('theme')
   if (stored === 'dark' || stored === 'light') return stored
-  return window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark'
+  // Default is light — no stored preference means first-time visitor gets light
+  return 'light'
 }
 
 function applyTheme(theme: Theme) {

--- a/dashboard/src/main.tsx
+++ b/dashboard/src/main.tsx
@@ -3,13 +3,8 @@ import { createRoot } from 'react-dom/client'
 import './styles/globals.css'
 import { App } from './App'
 
-// Apply saved theme before first paint to avoid flash
-const savedTheme = localStorage.getItem('theme')
-if (savedTheme === 'light') {
-  document.documentElement.classList.remove('dark')
-} else {
-  document.documentElement.classList.add('dark')
-}
+// NOTE: Theme class is applied before first paint by the inline script in index.html.
+// ThemeProvider (ThemeContext.tsx) takes over from here and keeps class in sync.
 
 const root = document.getElementById('root')
 if (!root) throw new Error('Root element not found')

--- a/dashboard/src/routes/flows.tsx
+++ b/dashboard/src/routes/flows.tsx
@@ -71,7 +71,7 @@ export function FlowsRoute() {
       {/* Left panel: entry picker + flow list */}
       <div
         className={[
-          'flex flex-col border-r border-slate-800 bg-slate-950',
+          'flex flex-col border-r border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950',
           'transition-[width] duration-200',
           hasSelection ? 'w-[360px] min-w-[280px]' : 'flex-1',
         ].join(' ')}
@@ -91,14 +91,14 @@ export function FlowsRoute() {
 
         {/* Active filter banner */}
         {filters.entry && (
-          <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-800 bg-slate-900/60 text-xs text-slate-400">
+          <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 text-xs text-slate-400 dark:text-slate-400">
             <span className="flex-1 truncate font-mono">
               Entry: <span className="text-sky-400">{filters.entry}</span>
             </span>
             <button
               type="button"
               onClick={clearFilters}
-              className="text-slate-600 hover:text-slate-300 transition-colors px-1"
+              className="text-slate-500 dark:text-slate-600 hover:text-slate-700 dark:hover:text-slate-300 transition-colors px-1"
               aria-label="Clear entry filter"
             >
               Clear
@@ -112,11 +112,11 @@ export function FlowsRoute() {
         ) : listError ? (
           <div className="flex flex-col items-center justify-center gap-3 p-8 text-center">
             <AlertCircle className="w-8 h-8 text-red-400" aria-hidden />
-            <p className="text-sm text-slate-400">{listError.message}</p>
+            <p className="text-sm text-slate-400 dark:text-slate-400">{listError.message}</p>
             <button
               type="button"
               onClick={() => refetch()}
-              className="px-3 py-1.5 rounded text-sm bg-slate-800 text-slate-300 hover:bg-slate-700 transition-colors"
+              className="px-3 py-1.5 rounded text-sm bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 hover:bg-slate-300 dark:hover:bg-slate-700 transition-colors"
             >
               Retry
             </button>
@@ -151,7 +151,7 @@ export function FlowsRoute() {
 
       {/* Empty right side hint */}
       {!hasSelection && processes.length > 0 && (
-        <div className="hidden xl:flex flex-1 items-center justify-center text-slate-600 text-sm">
+        <div className="hidden xl:flex flex-1 items-center justify-center text-slate-500 dark:text-slate-600 text-sm">
           Select a flow to see its chain
         </div>
       )}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -185,7 +185,7 @@ export function GraphRoute() {
 
       {/* Edge kind filters */}
       {allEdgeKinds.length > 0 && (
-        <div className="px-3 py-1.5 border-b border-slate-800 bg-slate-950/80 overflow-x-auto">
+        <div className="px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 overflow-x-auto">
           <EdgeKindFilters
             kinds={allEdgeKinds}
             activeKinds={activeKinds}
@@ -199,10 +199,10 @@ export function GraphRoute() {
       <div className="flex flex-1 min-h-0 overflow-hidden">
         {/* Left: community legend */}
         <aside
-          className="hidden lg:flex flex-col w-48 min-w-[160px] border-r border-slate-800 bg-slate-950/80 p-2"
+          className="hidden lg:flex flex-col w-48 min-w-[160px] border-r border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 p-2"
           aria-label="Community legend sidebar"
         >
-          <p className="text-[10px] uppercase tracking-wider text-slate-600 font-semibold px-2 pb-1">
+          <p className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-600 font-semibold px-2 pb-1">
             Communities
           </p>
           <CommunityLegend
@@ -277,7 +277,7 @@ export function GraphRoute() {
                   'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
                   highContrast
                     ? 'bg-slate-200 text-slate-900 border-slate-300'
-                    : 'bg-slate-800/80 text-slate-400 border-slate-700',
+                    : 'bg-slate-200/80 dark:bg-slate-800/80 text-slate-400 dark:text-slate-400 border-slate-300 dark:border-slate-700',
                 ].join(' ')}
                 aria-pressed={highContrast}
                 aria-label="Toggle high-contrast mode"

--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -149,9 +149,9 @@ export function PathsRoute() {
       {/* Main content — list + detail (full width, no prefix-tree sidebar) */}
       <div className="flex flex-1 overflow-hidden">
         {/* Path list panel */}
-        <div className="flex flex-col w-[520px] flex-shrink-0 border-r border-slate-800 overflow-hidden">
+        <div className="flex flex-col w-[520px] flex-shrink-0 border-r border-slate-200 dark:border-slate-800 overflow-hidden">
           {/* Search + header */}
-          <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-800 bg-slate-900/80">
+          <div className="flex items-center gap-2 px-3 py-2 border-b border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-900/80">
             <div ref={searchRef} className="flex-1">
               <PathSearchInput
                 value={filters.q ?? ''}
@@ -159,7 +159,7 @@ export function PathsRoute() {
               />
             </div>
             {totalLabel && (
-              <span className="text-xs text-slate-500 flex-shrink-0 tabular-nums">
+              <span className="text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums">
                 {isFetching && !isLoading ? '↻ ' : ''}{totalLabel}
               </span>
             )}
@@ -167,12 +167,12 @@ export function PathsRoute() {
 
           {/* Grouped-view controls — hidden in flat mode */}
           {!isFlat && !isLoading && paths.length > 0 && (
-            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-800 bg-slate-900/60">
+            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
               <button
                 type="button"
                 title="Expand all groups"
                 onClick={expandAll}
-                className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-800 transition-colors"
+                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
               >
                 <ChevronDown className="w-3.5 h-3.5" aria-hidden />
                 Expand all
@@ -181,7 +181,7 @@ export function PathsRoute() {
                 type="button"
                 title="Collapse all groups"
                 onClick={collapseAll}
-                className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-800 transition-colors"
+                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
               >
                 <ChevronUp className="w-3.5 h-3.5" aria-hidden />
                 Collapse all
@@ -191,7 +191,7 @@ export function PathsRoute() {
                 type="button"
                 title="Switch to flat list"
                 onClick={toggleFlat}
-                className="flex items-center gap-1 text-xs text-slate-400 hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-800 transition-colors"
+                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
                 aria-pressed={false}
               >
                 <List className="w-3.5 h-3.5" aria-hidden />
@@ -202,13 +202,13 @@ export function PathsRoute() {
 
           {/* Flat-mode: show toggle to switch back to grouped */}
           {isFlat && !isLoading && paths.length > 0 && (
-            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-800 bg-slate-900/60">
+            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
               <span className="flex-1" />
               <button
                 type="button"
                 title="Switch to grouped view"
                 onClick={toggleFlat}
-                className="flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300 px-1.5 py-0.5 rounded hover:bg-slate-800 transition-colors"
+                className="flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
                 aria-pressed={true}
               >
                 <List className="w-3.5 h-3.5" aria-hidden />
@@ -304,7 +304,7 @@ export function PathsRoute() {
         </div>
 
         {/* Detail panel — rendered by nested route */}
-        <div className="flex-1 overflow-hidden bg-slate-950">
+        <div className="flex-1 overflow-hidden bg-white dark:bg-slate-950">
           <ErrorBoundary>
             <Outlet />
           </ErrorBoundary>

--- a/dashboard/src/routes/topology.tsx
+++ b/dashboard/src/routes/topology.tsx
@@ -173,9 +173,9 @@ export function TopologyRoute() {
   )
 
   return (
-    <div className="flex flex-col h-full overflow-hidden bg-slate-950">
+    <div className="flex flex-col h-full overflow-hidden bg-white dark:bg-slate-950">
       {/* Protocol filter chips + search + view mode toggle */}
-      <div className="flex items-center gap-0 border-b border-slate-800 bg-slate-950/90 backdrop-blur-sm z-10 flex-shrink-0">
+      <div className="flex items-center gap-0 border-b border-slate-200 dark:border-slate-800 bg-white/90 dark:bg-slate-950/90 backdrop-blur-sm z-10 flex-shrink-0">
         <ProtocolFilterChips
           allProtocols={availableProtocols}
           activeProtocols={activeProtocols}
@@ -185,15 +185,15 @@ export function TopologyRoute() {
         />
 
         {/* Typeahead search */}
-        <div className="relative px-3 py-1.5 border-l border-slate-800 flex-shrink-0">
-          <div className="flex items-center gap-2 h-7 px-2 rounded bg-slate-900 border border-slate-700 focus-within:border-sky-700">
-            <Search className="w-3 h-3 text-slate-500 flex-shrink-0" aria-hidden />
+        <div className="relative px-3 py-1.5 border-l border-slate-200 dark:border-slate-800 flex-shrink-0">
+          <div className="flex items-center gap-2 h-7 px-2 rounded bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 focus-within:border-sky-700">
+            <Search className="w-3 h-3 text-slate-400 dark:text-slate-500 flex-shrink-0" aria-hidden />
             <input
               type="search"
               placeholder="Find topic…"
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="bg-transparent text-xs text-slate-200 placeholder-slate-600 outline-none w-36"
+              className="bg-transparent text-xs text-slate-800 dark:text-slate-200 placeholder-slate-600 outline-none w-36"
               aria-label="Search topics and queues"
               aria-controls="topology-search-results"
               aria-expanded={searchResults.length > 0}
@@ -203,7 +203,7 @@ export function TopologyRoute() {
                 type="button"
                 aria-label="Clear search"
                 onClick={() => setSearchQuery('')}
-                className="text-slate-600 hover:text-slate-300"
+                className="text-slate-500 dark:text-slate-600 hover:text-slate-700 dark:hover:text-slate-300"
               >
                 <X className="w-3 h-3" />
               </button>
@@ -216,21 +216,21 @@ export function TopologyRoute() {
               id="topology-search-results"
               role="listbox"
               aria-label="Search results"
-              className="absolute right-3 top-full mt-1 w-72 rounded-lg bg-slate-900 border border-slate-700 shadow-xl z-50 max-h-60 overflow-y-auto"
+              className="absolute right-3 top-full mt-1 w-72 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-300 dark:border-slate-700 shadow-xl z-50 max-h-60 overflow-y-auto"
             >
               {searchResults.map((r) => (
                 <li key={r.id} role="option" aria-selected={r.id === selectedId}>
                   <button
                     type="button"
-                    className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-800 focus:outline-none focus:bg-slate-800 transition-colors"
+                    className="w-full flex items-center gap-2 px-3 py-2 text-left hover:bg-slate-200 dark:hover:bg-slate-800 focus:outline-none focus:bg-slate-200 dark:focus:bg-slate-800 transition-colors"
                     onClick={() => {
                       setSelectedTopic(r.id)
                       setSearchQuery('')
                     }}
                   >
-                    <span className="font-mono text-xs text-slate-200 flex-1 truncate">{r.label}</span>
-                    <span className="text-xs text-slate-500 capitalize">{r.protocol}</span>
-                    <span className="text-xs text-slate-600 font-mono">{r.repo}</span>
+                    <span className="font-mono text-xs text-slate-800 dark:text-slate-200 flex-1 truncate">{r.label}</span>
+                    <span className="text-xs text-slate-400 dark:text-slate-500 capitalize">{r.protocol}</span>
+                    <span className="text-xs text-slate-500 dark:text-slate-600 font-mono">{r.repo}</span>
                   </button>
                 </li>
               ))}
@@ -240,7 +240,7 @@ export function TopologyRoute() {
 
         {/* View mode toggle — hidden on mobile (locked to list) */}
         {!isMobile && (
-          <div className="flex items-center gap-0.5 px-3 py-1.5 border-l border-slate-800 flex-shrink-0 ml-auto">
+          <div className="flex items-center gap-0.5 px-3 py-1.5 border-l border-slate-200 dark:border-slate-800 flex-shrink-0 ml-auto">
             <button
               type="button"
               aria-pressed={viewMode === 'map'}
@@ -251,7 +251,7 @@ export function TopologyRoute() {
                 'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-slate-950',
                 viewMode === 'map'
                   ? 'bg-sky-900/50 text-sky-300 border-sky-700 z-10'
-                  : 'bg-slate-900 text-slate-500 border-slate-700 hover:text-slate-300 hover:border-slate-500',
+                  : 'bg-slate-100 dark:bg-slate-900 text-slate-400 dark:text-slate-500 border-slate-300 dark:border-slate-700 hover:text-slate-700 dark:hover:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500',
               ].join(' ')}
             >
               <Map className="w-3.5 h-3.5" aria-hidden />
@@ -267,7 +267,7 @@ export function TopologyRoute() {
                 'focus:outline-none focus:ring-2 focus:ring-sky-500 focus:ring-offset-1 focus:ring-offset-slate-950',
                 viewMode === 'list'
                   ? 'bg-sky-900/50 text-sky-300 border-sky-700 z-10'
-                  : 'bg-slate-900 text-slate-500 border-slate-700 hover:text-slate-300 hover:border-slate-500',
+                  : 'bg-slate-100 dark:bg-slate-900 text-slate-400 dark:text-slate-500 border-slate-300 dark:border-slate-700 hover:text-slate-700 dark:hover:text-slate-300 hover:border-slate-400 dark:hover:border-slate-500',
               ].join(' ')}
             >
               <List className="w-3.5 h-3.5" aria-hidden />


### PR DESCRIPTION
## Summary

Three-layer root-cause fix for the light-theme regression, plus make **light** the new default for first-time visitors.

**Root causes found and fixed:**

1. \`dashboard/index.html\` had \`<html class="dark">\` hardcoded — dark class was present before any JS ran, making every first paint dark regardless of ThemeProvider
2. \`dashboard/src/main.tsx\` defaulted to dark when no \`localStorage\` value was set (\`savedTheme === 'light'\` guard only removed dark on explicit opt-in)
3. \`ThemeContext.tsx\` \`getInitialTheme()\` returned \`'dark'\` as SSR fallback and also fell back to dark when no system preference matched light
4. All 59 component TSX files used bare dark-only Tailwind classes (\`bg-slate-950\`, \`bg-slate-900/80\`, \`text-slate-200\`, \`border-slate-800\`, etc.) without \`dark:\` prefixes — so even with the class toggle working, components rendered dark in both modes

**Changes:**

- \`dashboard/index.html\`: Remove \`class="dark"\`, add inline FOUC-prevention \`<script>\` that reads \`localStorage('theme')\` synchronously before paint and defaults to \`light\`
- \`dashboard/src/main.tsx\`: Remove duplicate class-apply block (now owned by inline script + ThemeProvider)
- \`dashboard/src/context/ThemeContext.tsx\`: Change SSR fallback + default from \`'dark'\` to \`'light'\`
- \`dashboard/src/styles/globals.css\`: Already had correct \`@variant dark (&:where(.dark, .dark *))\` and \`html:not(.dark) body\` light overrides — no change needed
- **59 TSX files**: Convert all unprefixed \`bg-slate-9xx/8xx/7xx\`, \`text-slate-1-6xx\`, \`border-slate-6/7/8xx\` to \`light-value dark:dark-value\` pairs

## Closes / Refs

Closes #981

## Testing

- [x] \`make build\` succeeds (Vite + Go)
- [x] Playwright: fresh load (no localStorage) → \`bodyBg: rgb(255, 255, 255)\`, \`hasDarkClass: false\`, screenshot shows white UI
- [x] Playwright: click toggle → \`bodyBg: oklch(0.129 0.042 264.695)\`, \`hasDarkClass: true\`, screenshot shows dark UI
- [x] Playwright: navigate to /paths/upvate → dark persists
- [x] Playwright: reload → \`hasDarkClass: true\`, dark persists

## Notes

Light theme color mapping used throughout: \`bg-slate-950\` → \`bg-white dark:bg-slate-950\`, \`bg-slate-900\` → \`bg-slate-100 dark:bg-slate-900\`, \`text-slate-200\` → \`text-slate-800 dark:text-slate-200\`, \`border-slate-800\` → \`border-slate-200 dark:border-slate-800\`, etc.