### PR TITLE
[#991] Replace dead settings cog with version/info popover

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
@@ -121,7 +122,8 @@ func runDaemon(argv []string) error {
 
 		// Dashboard HTTP server (#929/#931): fold the SPA + REST API
 		// into the daemon process so a single launchd unit serves both.
-		DashboardServe: daemonDashboardServe,
+		// Capture startedAt so /api/info can report daemon uptime (#991).
+		DashboardServe: makeDaemonDashboardServe(time.Now()),
 		DashboardPort:  dashPort,
 		DashboardBind:  "127.0.0.1",
 	}
@@ -390,32 +392,37 @@ func daemonPatternGroupDirs() map[string]string {
 	return out
 }
 
-// daemonDashboardServe is the DashboardServe hook injected into daemon.Config.
-// It binds a TCP listener on the given address:port and serves the embedded
-// SPA plus the REST API. Blocks until ctx is done.
+// makeDaemonDashboardServe returns the DashboardServe hook injected into
+// daemon.Config. It captures daemonStartedAt so the /api/info endpoint can
+// report uptime without a separate RPC call (#991).
 //
 // This function lives in cmd/archigraph (not internal/daemon) to avoid the
 // import cycle: internal/dashboard already imports internal/daemon.
-func daemonDashboardServe(ctx context.Context, bind string, port int, logger *log.Logger) error {
-	addr := net.JoinHostPort(bind, strconv.Itoa(port))
-	l, err := net.Listen("tcp", addr)
-	if err != nil {
-		return fmt.Errorf("dashboard listen %s: %w", addr, err)
-	}
+func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Context, bind string, port int, logger *log.Logger) error {
+	return func(ctx context.Context, bind string, port int, logger *log.Logger) error {
+		addr := net.JoinHostPort(bind, strconv.Itoa(port))
+		l, err := net.Listen("tcp", addr)
+		if err != nil {
+			return fmt.Errorf("dashboard listen %s: %w", addr, err)
+		}
 
-	// Build dashboard config: fixed port (the daemon already owns the listener).
-	cfg := dashboard.Config{
-		PortRange: dashboard.PortRange{Min: port, Max: port},
-		Bind:      bind,
+		// Build dashboard config: fixed port (the daemon already owns the listener).
+		cfg := dashboard.Config{
+			PortRange: dashboard.PortRange{Min: port, Max: port},
+			Bind:      bind,
+		}
+		srv, err := dashboard.NewServer(cfg, dashboard.NewLiveStore())
+		if err != nil {
+			_ = l.Close()
+			return fmt.Errorf("dashboard new server: %w", err)
+		}
+		// Tell the dashboard server when the daemon started so /api/info
+		// can compute and report uptime (#991).
+		srv.SetDaemonStartedAt(daemonStartedAt)
+		srv.UseListener(l)
+		if logger != nil {
+			logger.Printf("dashboard ready http://%s/", addr)
+		}
+		return srv.Serve(ctx)
 	}
-	srv, err := dashboard.NewServer(cfg, dashboard.NewLiveStore())
-	if err != nil {
-		_ = l.Close()
-		return fmt.Errorf("dashboard new server: %w", err)
-	}
-	srv.UseListener(l)
-	if logger != nil {
-		logger.Printf("dashboard ready http://%s/", addr)
-	}
-	return srv.Serve(ctx)
 }

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -544,6 +544,31 @@ export async function fetchDocsSearch(group: string, query: string): Promise<Doc
   return apiFetch<DocSearchResponse>(`/api/search/${group}?${params}`)
 }
 
+// ── Build / version info ──────────────────────────────────────────────────────
+
+/** Wire shape of GET /api/info */
+export interface DaemonInfo {
+  version: string
+  commit: string
+  built_at: string
+  daemon_started_at?: string
+  dashboard_port?: number
+}
+
+/** Mock info returned when VITE_USE_MOCKS=true */
+const MOCK_INFO: DaemonInfo = {
+  version: '0.0.0-dev',
+  commit: 'abc1234567890',
+  built_at: new Date().toISOString(),
+  daemon_started_at: new Date(Date.now() - 83 * 60 * 1000).toISOString(), // 1h 23m ago
+  dashboard_port: 47274,
+}
+
+export async function fetchInfo(): Promise<DaemonInfo> {
+  if (USE_MOCKS) return MOCK_INFO
+  return apiFetch<DaemonInfo>('/api/info')
+}
+
 /** Fetch minimal entity metadata for a hovercard */
 export async function fetchEntityHovercard(entityId: string): Promise<EntityCard> {
   if (USE_MOCKS) {

--- a/dashboard/src/components/layout/VersionPopover.tsx
+++ b/dashboard/src/components/layout/VersionPopover.tsx
@@ -1,0 +1,247 @@
+/**
+ * VersionPopover — replaces the dead Settings cog in the top-nav.
+ *
+ * Trigger: lucide `Info` icon button.
+ * Panel: anchored top-right, ~280 px wide.
+ * Closes on outside-click or Escape.
+ * Fetches /api/info on open; re-uses cached result for 5 s.
+ */
+
+import { useState, useEffect, useRef, useCallback } from 'react'
+import { Info, ExternalLink, GitCommit, Clock, Globe } from 'lucide-react'
+import { fetchInfo, type DaemonInfo } from '@/api/client'
+
+const CACHE_TTL_MS = 5_000
+
+let cachedInfo: DaemonInfo | null = null
+let cachedAt = 0
+
+/** Format an ISO timestamp as a relative human string, e.g. "2 hours ago". */
+function relativeTime(iso: string): string {
+  const diff = Date.now() - new Date(iso).getTime()
+  const secs = Math.floor(diff / 1000)
+  if (secs < 60) return 'just now'
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m ago`
+  const hours = Math.floor(mins / 60)
+  if (hours < 24) {
+    const rem = mins % 60
+    return rem > 0 ? `${hours}h ${rem}m ago` : `${hours}h ago`
+  }
+  const days = Math.floor(hours / 24)
+  return `${days}d ago`
+}
+
+/** Format a duration in seconds as "Xh Ym" or "Ym Zs". */
+function fmtUptime(startedAt: string): string {
+  const secs = Math.floor((Date.now() - new Date(startedAt).getTime()) / 1000)
+  if (secs < 60) return `${secs}s`
+  const mins = Math.floor(secs / 60)
+  if (mins < 60) return `${mins}m`
+  const h = Math.floor(mins / 60)
+  const m = mins % 60
+  return m > 0 ? `${h}h ${m}m` : `${h}h`
+}
+
+/** Shorten a commit SHA to 7 characters. */
+function shortSHA(commit: string): string {
+  if (!commit || commit === 'unknown') return 'unknown'
+  return commit.length > 7 ? commit.slice(0, 7) : commit
+}
+
+/** Whether the app is running in debug / mock mode. */
+const USE_MOCKS = import.meta.env.VITE_USE_MOCKS === 'true'
+const DEBUG_PARAM =
+  typeof window !== 'undefined' && new URLSearchParams(window.location.search).has('debug')
+const IS_DEBUG = USE_MOCKS || DEBUG_PARAM
+
+export function VersionPopover() {
+  const [open, setOpen] = useState(false)
+  const [info, setInfo] = useState<DaemonInfo | null>(null)
+  const [error, setError] = useState<string | null>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const panelRef = useRef<HTMLDivElement>(null)
+
+  // Fetch info when the popover opens, respecting the 5 s cache.
+  const loadInfo = useCallback(async () => {
+    const now = Date.now()
+    if (cachedInfo && now - cachedAt < CACHE_TTL_MS) {
+      setInfo(cachedInfo)
+      return
+    }
+    try {
+      const data = await fetchInfo()
+      cachedInfo = data
+      cachedAt = Date.now()
+      setInfo(data)
+      setError(null)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load info')
+    }
+  }, [])
+
+  useEffect(() => {
+    if (open) loadInfo()
+  }, [open, loadInfo])
+
+  // Close on outside-click.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (
+        triggerRef.current?.contains(e.target as Node) ||
+        panelRef.current?.contains(e.target as Node)
+      )
+        return
+      setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  // Close on Escape.
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open])
+
+  const dashboardUrl =
+    info?.dashboard_port
+      ? `http://127.0.0.1:${info.dashboard_port}/`
+      : 'http://127.0.0.1:47274/'
+
+  const commitSHA = info ? shortSHA(info.commit) : null
+  const commitUrl =
+    commitSHA && commitSHA !== 'unknown'
+      ? `https://github.com/cajasmota/archigraph/commit/${info!.commit}`
+      : null
+
+  return (
+    <div className="relative">
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-label="Version info"
+        aria-expanded={open}
+        aria-haspopup="true"
+        onClick={() => setOpen((v) => !v)}
+        className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+        data-testid="version-info-trigger"
+      >
+        <Info className="w-4 h-4" />
+      </button>
+
+      {open && (
+        <div
+          ref={panelRef}
+          role="dialog"
+          aria-label="Version info panel"
+          data-testid="version-info-panel"
+          className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border border-slate-700 bg-slate-900 shadow-xl text-sm"
+        >
+          {/* Header */}
+          <div className="px-4 py-3 border-b border-slate-800">
+            <p className="font-semibold text-slate-100 tracking-tight">archigraph</p>
+            {info ? (
+              <p className="text-slate-400 mt-0.5">
+                Version{' '}
+                <span className="text-slate-200 font-mono">{info.version}</span>
+              </p>
+            ) : error ? (
+              <p className="text-red-400 mt-0.5">{error}</p>
+            ) : (
+              <p className="text-slate-500 mt-0.5">Loading…</p>
+            )}
+          </div>
+
+          {/* Details */}
+          {info && (
+            <div className="px-4 py-3 space-y-2">
+              {/* Commit */}
+              <div className="flex items-center gap-2 text-slate-400">
+                <GitCommit className="w-3.5 h-3.5 flex-shrink-0" />
+                <span className="flex-1 truncate">
+                  Commit:{' '}
+                  {commitUrl ? (
+                    <a
+                      href={commitUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-sky-400 hover:text-sky-300 font-mono"
+                    >
+                      {commitSHA}
+                    </a>
+                  ) : (
+                    <span className="text-slate-300 font-mono">{commitSHA}</span>
+                  )}
+                </span>
+              </div>
+
+              {/* Built */}
+              {info.built_at && info.built_at !== 'unknown' && (
+                <div className="flex items-center gap-2 text-slate-400">
+                  <Clock className="w-3.5 h-3.5 flex-shrink-0" />
+                  <span>
+                    Built:{' '}
+                    <span className="text-slate-300" title={info.built_at}>
+                      {relativeTime(info.built_at)}
+                    </span>
+                  </span>
+                </div>
+              )}
+
+              {/* Daemon uptime */}
+              {info.daemon_started_at && (
+                <div className="flex items-center gap-2 text-slate-400">
+                  <Clock className="w-3.5 h-3.5 flex-shrink-0" />
+                  <span>
+                    Daemon uptime:{' '}
+                    <span className="text-slate-300">{fmtUptime(info.daemon_started_at)}</span>
+                  </span>
+                </div>
+              )}
+
+              {/* Dashboard URL */}
+              <div className="flex items-center gap-2 text-slate-400">
+                <Globe className="w-3.5 h-3.5 flex-shrink-0" />
+                <span className="truncate">
+                  Dashboard:{' '}
+                  <span className="text-slate-300 font-mono text-xs">{dashboardUrl}</span>
+                </span>
+              </div>
+            </div>
+          )}
+
+          {/* Debug mode extras */}
+          {IS_DEBUG && (
+            <>
+              <div className="mx-4 border-t border-slate-800" />
+              <div className="px-4 py-2 text-xs text-amber-400">
+                Build mode:{' '}
+                {USE_MOCKS ? 'development (mocks)' : 'real-data (debug)'}
+              </div>
+            </>
+          )}
+
+          {/* Footer divider + GitHub link */}
+          <div className="mx-4 border-t border-slate-800" />
+          <div className="px-4 py-2">
+            <a
+              href="https://github.com/cajasmota/archigraph"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="flex items-center gap-1.5 text-sky-400 hover:text-sky-300 transition-colors"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              View on GitHub
+            </a>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -2,11 +2,12 @@ import { Link, NavLink, Outlet, useParams } from 'react-router-dom'
 import { useEffect } from 'react'
 import {
   GitBranch, Network, Workflow, Radio, Globe, BookOpen,
-  Moon, Sun, Settings,
+  Moon, Sun,
 } from 'lucide-react'
 import { useRegistry } from '@/hooks/shared/useRegistry'
 import { useThemeContext } from '@/context/ThemeContext'
 import { GroupSelector } from '@/components/layout/GroupSelector'
+import { VersionPopover } from '@/components/layout/VersionPopover'
 
 const GROUP_DEFAULT = 'fixture-a'
 
@@ -53,16 +54,10 @@ export function AppLayout() {
         </nav>
 
         <div className="ml-auto flex items-center gap-2">
-          {/* Group selector — sits between theme toggle and settings */}
+          {/* Group selector — sits between theme toggle and version info */}
           <GroupSelector groups={groups} />
           <ThemeToggle />
-          <Link
-            to="/settings"
-            className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
-            aria-label="Settings"
-          >
-            <Settings className="w-4 h-4" />
-          </Link>
+          <VersionPopover />
         </div>
       </header>
 

--- a/internal/dashboard/handlers_info.go
+++ b/internal/dashboard/handlers_info.go
@@ -1,0 +1,48 @@
+package dashboard
+
+import (
+	"net"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/version"
+)
+
+// infoReply is the wire shape for GET /api/info.
+// All fields are optional-on-the-wire (omitempty) so future additions
+// stay backwards-compatible with older frontend builds.
+type infoReply struct {
+	Version         string `json:"version"`
+	Commit          string `json:"commit"`
+	BuiltAt         string `json:"built_at"`
+	DaemonStartedAt string `json:"daemon_started_at,omitempty"`
+	DashboardPort   int    `json:"dashboard_port,omitempty"`
+}
+
+// handleInfo — GET /api/info. Returns build metadata and, when the
+// server was started by the embedded-daemon path, runtime info. The
+// endpoint is deliberately side-effect-free and cheap — the frontend
+// may call it on every popover open.
+func (s *Server) handleInfo(w http.ResponseWriter, _ *http.Request) {
+	reply := infoReply{
+		Version: version.Version,
+		Commit:  version.Commit,
+		BuiltAt: version.Date,
+	}
+	// Resolve the bound port from the listener so the frontend can
+	// construct the canonical dashboard URL.
+	if s.listener != nil {
+		if _, portStr, err := net.SplitHostPort(s.listener.Addr().String()); err == nil {
+			if p, err := strconv.Atoi(portStr); err == nil {
+				reply.DashboardPort = p
+			}
+		}
+	}
+	// daemonStartedAt is set when the server is embedded inside a daemon
+	// process (non-zero). When serving standalone it remains zero/empty.
+	if !s.daemonStartedAt.IsZero() {
+		reply.DaemonStartedAt = s.daemonStartedAt.UTC().Format(time.RFC3339)
+	}
+	writeJSON(w, http.StatusOK, reply)
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -20,13 +20,14 @@ import (
 // composes a chi-style router by hand on top of net/http so we keep the
 // stdlib-only constraint from the issue body.
 type Server struct {
-	cfg      Config
-	registry RegistryStore
-	graphs   *GraphCache
-	hub      *wsHub
-	listener net.Listener
-	srv      *http.Server
-	rng      *rand.Rand
+	cfg             Config
+	registry        RegistryStore
+	graphs          *GraphCache
+	hub             *wsHub
+	listener        net.Listener
+	srv             *http.Server
+	rng             *rand.Rand
+	daemonStartedAt time.Time // zero when not embedded inside a daemon process
 }
 
 // NewServer wires a server against the given config and registry-store
@@ -48,6 +49,13 @@ func NewServer(cfg Config, store RegistryStore) (*Server, error) {
 		hub:      h,
 		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
 	}, nil
+}
+
+// SetDaemonStartedAt records when the parent daemon process started so
+// the /api/info endpoint can report uptime. Call this from cmd/archigraph
+// after the daemon's embedded server is wired up.
+func (s *Server) SetDaemonStartedAt(t time.Time) {
+	s.daemonStartedAt = t
 }
 
 // Listen binds to a random free port within cfg.PortRange. It is
@@ -174,6 +182,9 @@ func (s *Server) routes() http.Handler {
 
 	// Repair queue (admin)
 	mux.HandleFunc("GET /api/repairs/{group}", s.handleRepairs)
+
+	// Build / version info
+	mux.HandleFunc("GET /api/info", s.handleInfo)
 
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)


### PR DESCRIPTION
## Summary

Removes the dead Settings cog from the top-nav and replaces it with a working \`Info\` icon button that opens a version/build popover. The popover is backed by a new \`/api/info\` REST endpoint on the dashboard server.

**Backend**
- New \`GET /api/info\` endpoint (\`internal/dashboard/handlers_info.go\`) returns \`{version, commit, built_at, daemon_started_at, dashboard_port}\` — reads from \`internal/version\` package (ldflags-injected at build time).
- \`Server.SetDaemonStartedAt(t time.Time)\` setter added so the embedded-daemon path can report uptime.
- \`makeDaemonDashboardServe\` closure in \`cmd/archigraph/daemon.go\` captures \`time.Now()\` at daemon startup and calls \`SetDaemonStartedAt\` after constructing the server.

**Frontend**
- New \`dashboard/src/components/layout/VersionPopover.tsx\` — \`Info\` icon trigger, ~280 px wide popover anchored top-right. Shows: version, commit SHA (linked to GitHub), relative "built N ago", daemon uptime, dashboard URL, "View on GitHub" link.
- Closes on outside-click or Escape.
- Fetches \`/api/info\` on open; caches result for 5 s so rapid re-opens are free.
- Debug mode section shown when \`VITE_USE_MOCKS=true\` or \`?debug\` query param present.
- \`_layout.tsx\`: Settings \`<Link>\` + \`Settings\` lucide import removed; \`<VersionPopover />\` dropped in same slot.
- \`client.ts\`: \`fetchInfo()\` + \`DaemonInfo\` type added; mock stub for dev mode.

## Closes / Refs

Closes #991

## Testing

- [x] \`go build ./...\` clean (after \`make dashboard-build\`)
- [x] \`make build\` succeeds end-to-end
- [x] \`GET /api/info\` returns \`{version, commit, built_at, daemon_started_at, dashboard_port}\` verified with \`curl\`
- [x] Playwright: Info button visible, Settings cog absent
- [x] Playwright: popover opens with live version + commit + built + uptime + dashboard URL
- [x] Playwright: Escape closes popover
- [x] Playwright: outside-click closes popover
- [x] Zero console errors

## Notes

Changelog generation (the second half of the original issue scope) is deferred — the issue body explicitly says "skip changelog and just show version info for v1". File a follow-up issue to add the static JSON / CHANGELOG.md build step.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)