### PR TITLE
[#989] archigraph rebuild: real-time phase progress + rich final summary

### DIFF
--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -1,0 +1,304 @@
+package cli
+
+// rebuild_summary.go — client-side post-rebuild summary computation and rendering.
+//
+// After `archigraph rebuild` completes the daemon has written a fresh graph.fb
+// (and optional graph.json) plus enrichment-candidates.json into each repo's
+// .archigraph/ directory and a <group>-links.json under ~/.archigraph/groups/.
+// This file reads those artefacts to build the rich summary table requested in
+// issue #989, without requiring any daemon protocol changes.
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// RebuildSummary is the aggregated post-rebuild statistics across all repos
+// in a group. Computed client-side by reading the graph artefacts.
+type RebuildSummary struct {
+	Group string
+
+	// Totals.
+	TotalEntities      int
+	TotalRelationships int
+
+	// Per-kind breakdowns. Keys are display-normalised entity/relationship Kind values.
+	EntityByKind map[string]int
+	RelByKind    map[string]int
+
+	// Special counts derived from entity kinds.
+	HTTPEndpoints int // entities with kind == "http_endpoint"
+	ProcessFlows  int // SCOPE.Process entities emitted by Pass 7
+
+	// Cross-repo edges loaded from <group>-links.json.
+	CrossRepoEdges int
+
+	// Candidate counts loaded from each repo's enrichment-candidates.json.
+	EnrichmentCandidates int
+	RepairCandidates     int
+
+	// Orphan proxy — entities with no incoming relationships.
+	OrphanEntities int
+	OrphanRate     float64 // 0–100
+
+	// Elapsed is the wall-clock duration of the rebuild.
+	Elapsed time.Duration
+}
+
+// kindRow is one row in a top-N kind table.
+type kindRow struct {
+	Kind  string
+	Count int
+}
+
+// topNKinds returns up to n entries from a kind map sorted by count desc, and
+// the aggregate "other" total for the remaining entries.
+func topNKinds(m map[string]int, n int) ([]kindRow, int) {
+	rows := make([]kindRow, 0, len(m))
+	for k, v := range m {
+		rows = append(rows, kindRow{Kind: k, Count: v})
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if rows[i].Count != rows[j].Count {
+			return rows[i].Count > rows[j].Count
+		}
+		return rows[i].Kind < rows[j].Kind
+	})
+	if n <= 0 || len(rows) <= n {
+		return rows, 0
+	}
+	other := 0
+	for _, r := range rows[n:] {
+		other += r.Count
+	}
+	return rows[:n], other
+}
+
+// ComputeRebuildSummary loads the per-repo graphs and candidate files produced
+// by a rebuild and aggregates them into a RebuildSummary. repoPaths is the list
+// of absolute on-disk repo paths that were rebuilt (in order). group is the
+// group name, used to locate the group-links.json.
+//
+// Errors reading individual files are silently skipped so a partial result
+// (e.g. a repo that failed to index) does not prevent summary generation.
+func ComputeRebuildSummary(group string, repoPaths []string, elapsed time.Duration) *RebuildSummary {
+	s := &RebuildSummary{
+		Group:        group,
+		EntityByKind: make(map[string]int),
+		RelByKind:    make(map[string]int),
+		Elapsed:      elapsed,
+	}
+
+	// hasIncoming tracks entity IDs that appear as ToID in at least one
+	// relationship — used to identify orphans.
+	hasIncoming := make(map[string]struct{})
+
+	for _, repoPath := range repoPaths {
+		stateDir := daemon.StateDirForRepo(repoPath)
+
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err == nil && doc != nil {
+			for _, e := range doc.Entities {
+				s.TotalEntities++
+				k := normaliseEntityKind(e.Kind)
+				s.EntityByKind[k]++
+				if e.Kind == "http_endpoint" {
+					s.HTTPEndpoints++
+				}
+				if strings.HasPrefix(e.Kind, "SCOPE.Process") || e.Kind == "process" {
+					s.ProcessFlows++
+				}
+			}
+			for _, r := range doc.Relationships {
+				s.TotalRelationships++
+				s.RelByKind[r.Kind]++
+				if r.ToID != "" {
+					hasIncoming[r.ToID] = struct{}{}
+				}
+			}
+			// Orphans — entities in this repo with no incoming relationship.
+			for _, e := range doc.Entities {
+				if _, ok := hasIncoming[e.ID]; !ok {
+					s.OrphanEntities++
+				}
+			}
+		}
+
+		enrichCount, repairCount := loadCandidateCounts(stateDir)
+		s.EnrichmentCandidates += enrichCount
+		s.RepairCandidates += repairCount
+	}
+
+	if s.TotalEntities > 0 {
+		s.OrphanRate = 100.0 * float64(s.OrphanEntities) / float64(s.TotalEntities)
+	}
+
+	s.CrossRepoEdges = loadCrossRepoEdgeCount(group)
+
+	return s
+}
+
+// normaliseEntityKind maps raw entity Kind values to the display names used in
+// the summary table (Function, Class, Variable, HTTPEndpoint, or pass-through).
+func normaliseEntityKind(kind string) string {
+	switch kind {
+	case "function", "method":
+		return "Function"
+	case "class", "struct", "interface":
+		return "Class"
+	case "variable", "constant", "field":
+		return "Variable"
+	case "http_endpoint":
+		return "HTTPEndpoint"
+	default:
+		return kind
+	}
+}
+
+// loadCandidateCounts reads enrichment-candidates.json and returns (enrichCount,
+// repairCount). Both are zero on any read/parse error.
+func loadCandidateCounts(stateDir string) (enrich, repair int) {
+	path := filepath.Join(stateDir, "enrichment-candidates.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+
+	// The file is a bare JSON array of candidate objects (standard shape).
+	var arr []struct {
+		Kind string `json:"kind"`
+	}
+	if err := json.Unmarshal(data, &arr); err != nil {
+		// Try object envelope {"candidates": [...]} used by some older emitters.
+		var obj struct {
+			Candidates []struct {
+				Kind string `json:"kind"`
+			} `json:"candidates"`
+		}
+		if err2 := json.Unmarshal(data, &obj); err2 != nil {
+			return
+		}
+		arr = obj.Candidates
+	}
+	for _, c := range arr {
+		if c.Kind == "repair_edge" {
+			repair++
+		} else {
+			enrich++
+		}
+	}
+	return
+}
+
+// loadCrossRepoEdgeCount reads the group-links.json and returns the number of
+// confirmed cross-repo edges. Returns 0 on any error.
+func loadCrossRepoEdgeCount(group string) int {
+	// Locate via daemon layout so ARCHIGRAPH_DAEMON_ROOT test overrides are
+	// respected.
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		return 0
+	}
+	// Links files live at <root>/groups/<group>-links.json.
+	linksPath := filepath.Join(layout.Root, "groups", group+"-links.json")
+	return countLinksFile(linksPath)
+}
+
+// countLinksFile reads a links.json and returns the number of link entries.
+func countLinksFile(path string) int {
+	f, err := os.Open(path)
+	if err != nil {
+		return 0
+	}
+	defer f.Close()
+	var doc struct {
+		Links []json.RawMessage `json:"links"`
+	}
+	if err := json.NewDecoder(f).Decode(&doc); err != nil {
+		return 0
+	}
+	return len(doc.Links)
+}
+
+// PrintRebuildSummary writes the human-readable post-rebuild summary table to w.
+// The format matches the specification in issue #989.
+func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
+	elapsed := fmtDuration(s.Elapsed)
+	fmt.Fprintf(w, "\nGroup '%s' rebuilt (%s)\n", s.Group, elapsed)
+
+	// --- Entities ---
+	fmt.Fprintf(w, "\nEntities (%s total):\n", fmtInt(s.TotalEntities))
+	topEnts, otherEnts := topNKinds(s.EntityByKind, 5)
+	colW := maxKindLen(topEnts, otherEnts > 0)
+	for _, row := range topEnts {
+		fmt.Fprintf(w, "  %-*s  %s\n", colW, row.Kind, fmtInt(row.Count))
+	}
+	if otherEnts > 0 {
+		fmt.Fprintf(w, "  %-*s  %s\n", colW, "Other", fmtInt(otherEnts))
+	}
+
+	// --- Relationships ---
+	fmt.Fprintf(w, "\nRelationships (%s total):\n", fmtInt(s.TotalRelationships))
+	topRels, otherRels := topNKinds(s.RelByKind, 5)
+	colWR := maxKindLen(topRels, otherRels > 0)
+	for _, row := range topRels {
+		fmt.Fprintf(w, "  %-*s  %s\n", colWR, row.Kind, fmtInt(row.Count))
+	}
+	if otherRels > 0 {
+		fmt.Fprintf(w, "  %-*s  %s\n", colWR, "Other", fmtInt(otherRels))
+	}
+
+	// --- Derived stats ---
+	fmt.Fprintf(w, "\nCross-repo edges:       %s\n", fmtInt(s.CrossRepoEdges))
+	fmt.Fprintf(w, "Process flows:          %s\n", fmtInt(s.ProcessFlows))
+	fmt.Fprintf(w, "HTTP endpoints:         %s\n", fmtInt(s.HTTPEndpoints))
+	fmt.Fprintf(w, "Enrichment candidates:  %s\n", fmtInt(s.EnrichmentCandidates))
+	fmt.Fprintf(w, "Repair candidates:      %s\n", fmtInt(s.RepairCandidates))
+	if s.TotalEntities > 0 {
+		fmt.Fprintf(w, "Orphan entities:        %s (%.1f%%)\n",
+			fmtInt(s.OrphanEntities), s.OrphanRate)
+	}
+}
+
+// maxKindLen returns the maximum string length of Kind values in rows, with a
+// minimum of 5 (length of "Other") when withOther is true.
+func maxKindLen(rows []kindRow, withOther bool) int {
+	w := 0
+	if withOther {
+		w = 5 // len("Other")
+	}
+	for _, r := range rows {
+		if len(r.Kind) > w {
+			w = len(r.Kind)
+		}
+	}
+	return w
+}
+
+// fmtInt formats a non-negative integer with comma thousands separators.
+func fmtInt(n int) string {
+	if n < 0 {
+		return "-" + fmtInt(-n)
+	}
+	s := fmt.Sprintf("%d", n)
+	if len(s) <= 3 {
+		return s
+	}
+	out := make([]byte, 0, len(s)+len(s)/3)
+	for i, c := range s {
+		if i > 0 && (len(s)-i)%3 == 0 {
+			out = append(out, ',')
+		}
+		out = append(out, byte(c))
+	}
+	return string(out)
+}

--- a/internal/cli/rebuild_summary_test.go
+++ b/internal/cli/rebuild_summary_test.go
@@ -1,0 +1,370 @@
+package cli
+
+// Tests for issue #989 — rich rebuild summary table generation and rendering.
+// These tests exercise the non-filesystem parts (formatting, topNKinds, fmtInt)
+// so they run without any on-disk artefacts.
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// fmtInt
+// ---------------------------------------------------------------------------
+
+func TestFmtInt_SmallValues(t *testing.T) {
+	cases := []struct {
+		n    int
+		want string
+	}{
+		{0, "0"},
+		{1, "1"},
+		{999, "999"},
+		{1000, "1,000"},
+		{1001, "1,001"},
+		{9999, "9,999"},
+		{10000, "10,000"},
+		{100000, "100,000"},
+		{1000000, "1,000,000"},
+		{20718, "20,718"},
+		{95213, "95,213"},
+	}
+	for _, tc := range cases {
+		got := fmtInt(tc.n)
+		if got != tc.want {
+			t.Errorf("fmtInt(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}
+
+func TestFmtInt_Negative(t *testing.T) {
+	got := fmtInt(-1234)
+	if got != "-1,234" {
+		t.Errorf("fmtInt(-1234) = %q, want %q", got, "-1,234")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// topNKinds
+// ---------------------------------------------------------------------------
+
+func TestTopNKinds_EmptyMap(t *testing.T) {
+	rows, other := topNKinds(map[string]int{}, 5)
+	if len(rows) != 0 {
+		t.Errorf("expected empty rows, got %v", rows)
+	}
+	if other != 0 {
+		t.Errorf("expected other=0, got %d", other)
+	}
+}
+
+func TestTopNKinds_FewerThanN(t *testing.T) {
+	m := map[string]int{"Function": 10, "Class": 5}
+	rows, other := topNKinds(m, 5)
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if other != 0 {
+		t.Errorf("expected other=0, got %d", other)
+	}
+	// Sorted by count desc.
+	if rows[0].Kind != "Function" || rows[0].Count != 10 {
+		t.Errorf("row[0] = %+v, want Function/10", rows[0])
+	}
+}
+
+func TestTopNKinds_MoreThanN(t *testing.T) {
+	m := map[string]int{
+		"Function":    4892,
+		"Class":       1231,
+		"Variable":    8402,
+		"HTTPEndpoint": 744,
+		"Other1":      3000,
+		"Other2":      2000,
+		"Other3":      1000,
+	}
+	rows, other := topNKinds(m, 5)
+	if len(rows) != 5 {
+		t.Fatalf("expected 5 rows, got %d", len(rows))
+	}
+	// Top 5 by count: Variable(8402), Function(4892), Other1(3000), Other2(2000), Class(1231).
+	if rows[0].Kind != "Variable" {
+		t.Errorf("row[0].Kind = %q, want Variable", rows[0].Kind)
+	}
+	if rows[0].Count != 8402 {
+		t.Errorf("row[0].Count = %d, want 8402", rows[0].Count)
+	}
+	// Other = HTTPEndpoint(744) + Other3(1000) = 1744.
+	wantOther := 744 + 1000
+	if other != wantOther {
+		t.Errorf("other = %d, want %d", other, wantOther)
+	}
+}
+
+func TestTopNKinds_TieBreakByName(t *testing.T) {
+	// Equal counts should be sorted alphabetically.
+	m := map[string]int{"Beta": 5, "Alpha": 5}
+	rows, _ := topNKinds(m, 5)
+	if rows[0].Kind != "Alpha" {
+		t.Errorf("expected Alpha first on tie, got %q", rows[0].Kind)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// maxKindLen
+// ---------------------------------------------------------------------------
+
+func TestMaxKindLen(t *testing.T) {
+	rows := []kindRow{{Kind: "Function"}, {Kind: "Class"}, {Kind: "HTTPEndpoint"}}
+	got := maxKindLen(rows, false)
+	if got != len("HTTPEndpoint") {
+		t.Errorf("maxKindLen = %d, want %d", got, len("HTTPEndpoint"))
+	}
+}
+
+func TestMaxKindLen_WithOther(t *testing.T) {
+	// When withOther=true the minimum width is 5 (len("Other")).
+	rows := []kindRow{{Kind: "A"}}
+	got := maxKindLen(rows, true)
+	if got != 5 {
+		t.Errorf("maxKindLen = %d, want 5", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// PrintRebuildSummary
+// ---------------------------------------------------------------------------
+
+func TestPrintRebuildSummary_BasicShape(t *testing.T) {
+	s := &RebuildSummary{
+		Group:              "mygroup",
+		TotalEntities:      20718,
+		TotalRelationships: 95213,
+		EntityByKind: map[string]int{
+			"Function":     4892,
+			"Class":        1231,
+			"Variable":     8402,
+			"HTTPEndpoint": 744,
+			"Other":        5449,
+		},
+		RelByKind: map[string]int{
+			"CALLS":      12818,
+			"IMPORTS":    8127,
+			"REFERENCES": 61902,
+			"CONTAINS":   6219,
+			"Other":      6147,
+		},
+		CrossRepoEdges:       234,
+		ProcessFlows:         50,
+		HTTPEndpoints:        744,
+		EnrichmentCandidates: 89,
+		RepairCandidates:     12,
+		OrphanEntities:       1341,
+		OrphanRate:           6.5,
+		Elapsed:              17 * time.Second,
+	}
+
+	var buf bytes.Buffer
+	PrintRebuildSummary(&buf, s)
+	out := buf.String()
+
+	// Header line.
+	if !strings.Contains(out, "Group 'mygroup' rebuilt (17s)") {
+		t.Errorf("missing header line in output:\n%s", out)
+	}
+
+	// Entities section.
+	if !strings.Contains(out, "Entities (20,718 total):") {
+		t.Errorf("missing entities total in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Variable") || !strings.Contains(out, "8,402") {
+		t.Errorf("missing Variable kind in output:\n%s", out)
+	}
+
+	// Relationships section.
+	if !strings.Contains(out, "Relationships (95,213 total):") {
+		t.Errorf("missing relationships total in output:\n%s", out)
+	}
+	if !strings.Contains(out, "REFERENCES") || !strings.Contains(out, "61,902") {
+		t.Errorf("missing REFERENCES kind in output:\n%s", out)
+	}
+
+	// Derived stats.
+	if !strings.Contains(out, "Cross-repo edges:") || !strings.Contains(out, "234") {
+		t.Errorf("missing cross-repo edges in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Process flows:") || !strings.Contains(out, "50") {
+		t.Errorf("missing process flows in output:\n%s", out)
+	}
+	if !strings.Contains(out, "HTTP endpoints:") || !strings.Contains(out, "744") {
+		t.Errorf("missing HTTP endpoints in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Enrichment candidates:") || !strings.Contains(out, "89") {
+		t.Errorf("missing enrichment candidates in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Repair candidates:") || !strings.Contains(out, "12") {
+		t.Errorf("missing repair candidates in output:\n%s", out)
+	}
+	if !strings.Contains(out, "Orphan entities:") || !strings.Contains(out, "1,341") {
+		t.Errorf("missing orphan entities in output:\n%s", out)
+	}
+	if !strings.Contains(out, "6.5%") {
+		t.Errorf("missing orphan rate in output:\n%s", out)
+	}
+}
+
+func TestPrintRebuildSummary_ZeroEntities_NoOrphanLine(t *testing.T) {
+	// When TotalEntities == 0, orphan line should be suppressed.
+	s := &RebuildSummary{
+		Group:   "empty",
+		Elapsed: 1 * time.Second,
+		EntityByKind: map[string]int{},
+		RelByKind:    map[string]int{},
+	}
+	var buf bytes.Buffer
+	PrintRebuildSummary(&buf, s)
+	out := buf.String()
+	if strings.Contains(out, "Orphan entities:") {
+		t.Errorf("orphan line should be absent when TotalEntities==0, got:\n%s", out)
+	}
+}
+
+func TestPrintRebuildSummary_OtherRowPresent(t *testing.T) {
+	// When more than 5 entity kinds exist, an "Other" row must appear.
+	s := &RebuildSummary{
+		Group:         "g",
+		TotalEntities: 600,
+		EntityByKind: map[string]int{
+			"A": 100, "B": 100, "C": 100, "D": 100, "E": 100, "F": 100,
+		},
+		RelByKind: map[string]int{},
+		Elapsed:   5 * time.Second,
+	}
+	var buf bytes.Buffer
+	PrintRebuildSummary(&buf, s)
+	out := buf.String()
+	if !strings.Contains(out, "Other") {
+		t.Errorf("expected 'Other' row when >5 kinds, got:\n%s", out)
+	}
+}
+
+func TestPrintRebuildSummary_ElapsedFormatting(t *testing.T) {
+	// A 2-minute rebuild should show "2m00s".
+	s := &RebuildSummary{
+		Group:        "g",
+		EntityByKind: map[string]int{},
+		RelByKind:    map[string]int{},
+		Elapsed:      2 * time.Minute,
+	}
+	var buf bytes.Buffer
+	PrintRebuildSummary(&buf, s)
+	out := buf.String()
+	if !strings.Contains(out, "2m00s") {
+		t.Errorf("expected '2m00s' in elapsed, got:\n%s", out)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countLinksFile
+// ---------------------------------------------------------------------------
+
+func TestCountLinksFile_NonExistent(t *testing.T) {
+	got := countLinksFile("/nonexistent/path/to/links.json")
+	if got != 0 {
+		t.Errorf("expected 0 for missing file, got %d", got)
+	}
+}
+
+func TestCountLinksFile_ValidFile(t *testing.T) {
+	// Write a temp file with two link entries.
+	tmp := t.TempDir()
+	path := tmp + "/g-links.json"
+	content := `{"version":1,"links":[{"id":"a"},{"id":"b"}]}`
+	if err := writeTestFile(path, content); err != nil {
+		t.Fatal(err)
+	}
+	got := countLinksFile(path)
+	if got != 2 {
+		t.Errorf("expected 2 links, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// loadCandidateCounts
+// ---------------------------------------------------------------------------
+
+func TestLoadCandidateCounts_MissingDir(t *testing.T) {
+	enrich, repair := loadCandidateCounts("/nonexistent/stateDir")
+	if enrich != 0 || repair != 0 {
+		t.Errorf("expected (0,0) for missing dir, got (%d,%d)", enrich, repair)
+	}
+}
+
+func TestLoadCandidateCounts_BareArray(t *testing.T) {
+	tmp := t.TempDir()
+	// Write a bare-array candidates file.
+	content := `[{"kind":"describe_entity"},{"kind":"repair_edge"},{"kind":"describe_entity"}]`
+	if err := writeTestFile(tmp+"/enrichment-candidates.json", content); err != nil {
+		t.Fatal(err)
+	}
+	enrich, repair := loadCandidateCounts(tmp)
+	if enrich != 2 {
+		t.Errorf("expected enrich=2, got %d", enrich)
+	}
+	if repair != 1 {
+		t.Errorf("expected repair=1, got %d", repair)
+	}
+}
+
+func TestLoadCandidateCounts_ObjectEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"candidates":[{"kind":"repair_edge"},{"kind":"repair_edge"}]}`
+	if err := writeTestFile(tmp+"/enrichment-candidates.json", content); err != nil {
+		t.Fatal(err)
+	}
+	enrich, repair := loadCandidateCounts(tmp)
+	if repair != 2 {
+		t.Errorf("expected repair=2, got %d", repair)
+	}
+	if enrich != 0 {
+		t.Errorf("expected enrich=0, got %d", enrich)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// normaliseEntityKind
+// ---------------------------------------------------------------------------
+
+func TestNormaliseEntityKind(t *testing.T) {
+	cases := []struct{ input, want string }{
+		{"function", "Function"},
+		{"method", "Function"},
+		{"class", "Class"},
+		{"struct", "Class"},
+		{"interface", "Class"},
+		{"variable", "Variable"},
+		{"constant", "Variable"},
+		{"field", "Variable"},
+		{"http_endpoint", "HTTPEndpoint"},
+		{"custom_kind", "custom_kind"},
+	}
+	for _, tc := range cases {
+		got := normaliseEntityKind(tc.input)
+		if got != tc.want {
+			t.Errorf("normaliseEntityKind(%q) = %q, want %q", tc.input, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// writeTestFile writes content to path.
+func writeTestFile(path, content string) error {
+	return os.WriteFile(path, []byte(content), 0o644)
+}

--- a/internal/cli/repair.go
+++ b/internal/cli/repair.go
@@ -242,10 +242,10 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 
 	reply := finalResult.reply
 
-	// Final summary line.
 	var elapsedStr string
+	elapsed := time.Duration(reply.ElapsedSec * float64(time.Second))
 	if reply.ElapsedSec > 0 {
-		elapsedStr = fmtDuration(time.Duration(reply.ElapsedSec * float64(time.Second)))
+		elapsedStr = fmtDuration(elapsed)
 	}
 
 	if jsonProgress {
@@ -271,21 +271,25 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 			Warning:  reply.Warning,
 		})
 	} else {
-		// Pretty summary.
-		summaryParts := []string{}
-		if elapsedStr != "" {
-			summaryParts = append(summaryParts, elapsedStr)
-		}
-		if reply.TotalEntities > 0 {
-			summaryParts = append(summaryParts,
-				fmt.Sprintf("%d entities", reply.TotalEntities),
-				fmt.Sprintf("%d relationships", reply.TotalRels))
-		}
-		if len(summaryParts) > 0 {
-			fmt.Fprintf(w, "Total: %s\n", strings.Join(summaryParts, ", "))
-		}
-		for _, r := range reply.Repos {
-			fmt.Fprintf(w, "rebuilt %s\n", r)
+		// Rich summary — read graph artefacts client-side and render the full table.
+		if len(reply.Repos) > 0 {
+			sum := ComputeRebuildSummary(group, reply.Repos, elapsed)
+			PrintRebuildSummary(w, sum)
+		} else {
+			// No repos reported (e.g. single-slug rebuild with no stats). Fall
+			// back to the legacy one-liner so the output is never empty.
+			summaryParts := []string{}
+			if elapsedStr != "" {
+				summaryParts = append(summaryParts, elapsedStr)
+			}
+			if reply.TotalEntities > 0 {
+				summaryParts = append(summaryParts,
+					fmt.Sprintf("%d entities", reply.TotalEntities),
+					fmt.Sprintf("%d relationships", reply.TotalRels))
+			}
+			if len(summaryParts) > 0 {
+				fmt.Fprintf(w, "Group '%s' rebuilt (%s)\n", group, strings.Join(summaryParts, ", "))
+			}
 		}
 		if reply.Warning != "" {
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: %s\n", reply.Warning)
@@ -295,59 +299,117 @@ func runRebuildClient(cmd *cobra.Command, args []string, wipe bool, quiet bool, 
 }
 
 // printProgressLine emits one human-readable progress line for a repo.
+//
+// Format follows the spec from issue #989:
+//
+//	core-mobile: scanning 1134 files…
+//	core-mobile: extracted 4521 entities (482 functions, 312 classes, …)
+//	core-mobile: 12,318 relationships emitted
+//	core-mobile: P4 algorithms running (PageRank, Communities)…
+//	core-mobile: DONE 5.2s
+//
+// In-progress phases (walking, extracting, finalizing) use a carriage-return
+// suffix when the writer is a TTY so the line updates in place. Terminal
+// phases (completed, failed) always use a newline so the final state is
+// preserved in the scroll-back buffer.
 func printProgressLine(w io.Writer, r proto.RepoProgressState) {
-	prefix := ""
-	if r.Total > 0 {
-		prefix = fmt.Sprintf("  [%d/%d] %s: ", r.Index, r.Total, r.Slug)
-	} else {
-		prefix = fmt.Sprintf("  %s: ", r.Slug)
+	slug := r.Slug
+	if slug == "" {
+		slug = r.Path
 	}
+	tty := isTTY(w)
 
 	switch r.Phase {
 	case proto.PhaseQueued:
-		fmt.Fprintf(w, "%squeued\n", prefix)
+		// Queued is transient and low-value; skip on TTY (overwritten next tick),
+		// print a single line on non-TTY so logs are complete.
+		if !tty {
+			fmt.Fprintf(w, "%s: queued\n", slug)
+		}
+
 	case proto.PhaseStarted:
-		fmt.Fprintf(w, "%sstarted\n", prefix)
+		if tty {
+			fmt.Fprintf(w, "%s: starting…\r", slug)
+		} else {
+			fmt.Fprintf(w, "%s: starting\n", slug)
+		}
+
 	case proto.PhaseWalking:
 		if r.FilesWalked > 0 {
-			fmt.Fprintf(w, "%swalking files... %d candidates\n", prefix, r.FilesWalked)
+			if tty {
+				fmt.Fprintf(w, "%s: scanning %s files…\r", slug, fmtInt(r.FilesWalked))
+			} else {
+				fmt.Fprintf(w, "%s: scanning %s files…\n", slug, fmtInt(r.FilesWalked))
+			}
 		} else {
-			fmt.Fprintf(w, "%swalking files...\n", prefix)
+			if tty {
+				fmt.Fprintf(w, "%s: scanning files…\r", slug)
+			} else {
+				fmt.Fprintf(w, "%s: scanning files…\n", slug)
+			}
 		}
+
 	case proto.PhaseExtracting:
-		if r.FilesExtracted > 0 && r.FilesWalked > 0 {
-			fmt.Fprintf(w, "%sextracting (%d/%d files, %s)\n",
-				prefix, r.FilesExtracted, r.FilesWalked,
-				fmtDuration(time.Duration(r.ElapsedSec*float64(time.Second))))
+		if r.FilesWalked > 0 {
+			pct := 0
+			if r.FilesWalked > 0 {
+				pct = 100 * r.FilesExtracted / r.FilesWalked
+			}
+			if tty {
+				fmt.Fprintf(w, "%s: extracting… %d%% (%s/%s files)\r",
+					slug, pct, fmtInt(r.FilesExtracted), fmtInt(r.FilesWalked))
+			} else {
+				fmt.Fprintf(w, "%s: extracting… %d%% (%s/%s files)\n",
+					slug, pct, fmtInt(r.FilesExtracted), fmtInt(r.FilesWalked))
+			}
 		} else {
-			fmt.Fprintf(w, "%sextracting...\n", prefix)
+			if tty {
+				fmt.Fprintf(w, "%s: extracting…\r", slug)
+			} else {
+				fmt.Fprintf(w, "%s: extracting…\n", slug)
+			}
 		}
+
 	case proto.PhaseFinalizing:
-		fmt.Fprintf(w, "%sfinalizing...\n", prefix)
+		// Finalizing covers Pass 4 graph algorithms (PageRank, communities).
+		if tty {
+			fmt.Fprintf(w, "%s: P4 algorithms running (PageRank, Communities)…\r", slug)
+		} else {
+			fmt.Fprintf(w, "%s: P4 algorithms running (PageRank, Communities)…\n", slug)
+		}
+
 	case proto.PhaseCompleted:
-		parts := []string{}
+		// Clear the in-progress line (if TTY) and print the final DONE line.
+		dur := time.Duration(r.ElapsedSec * float64(time.Second))
+		durStr := ""
 		if r.ElapsedSec > 0 {
-			parts = append(parts, fmtDuration(time.Duration(r.ElapsedSec*float64(time.Second))))
+			durStr = fmtDuration(dur)
 		}
-		if r.Entities > 0 {
-			parts = append(parts, fmt.Sprintf("%d entities", r.Entities))
+		if tty {
+			// Pad to overwrite any previous carriage-return line.
+			fmt.Fprintf(w, "\r%-80s\r", "")
 		}
-		if r.Rels > 0 {
-			parts = append(parts, fmt.Sprintf("%d rels", r.Rels))
-		}
-		if len(parts) > 0 {
-			fmt.Fprintf(w, "%scompleted (%s)\n", prefix, strings.Join(parts, ", "))
+		if r.Entities > 0 || r.Rels > 0 {
+			fmt.Fprintf(w, "%s: DONE %s  (%s entities, %s relationships)\n",
+				slug, durStr, fmtInt(int(r.Entities)), fmtInt(int(r.Rels)))
+		} else if durStr != "" {
+			fmt.Fprintf(w, "%s: DONE %s\n", slug, durStr)
 		} else {
-			fmt.Fprintf(w, "%scompleted\n", prefix)
+			fmt.Fprintf(w, "%s: DONE\n", slug)
 		}
+
 	case proto.PhaseFailed:
-		if r.ErrMsg != "" {
-			fmt.Fprintf(w, "%sfailed: %s\n", prefix, r.ErrMsg)
-		} else {
-			fmt.Fprintf(w, "%sfailed\n", prefix)
+		if tty {
+			fmt.Fprintf(w, "\r%-80s\r", "")
 		}
+		if r.ErrMsg != "" {
+			fmt.Fprintf(w, "%s: FAILED — %s\n", slug, r.ErrMsg)
+		} else {
+			fmt.Fprintf(w, "%s: FAILED\n", slug)
+		}
+
 	default:
-		fmt.Fprintf(w, "%s%s\n", prefix, r.Phase)
+		fmt.Fprintf(w, "%s: %s\n", slug, r.Phase)
 	}
 }
 

--- a/internal/cli/repair_progress_test.go
+++ b/internal/cli/repair_progress_test.go
@@ -44,6 +44,7 @@ func TestFmtDuration(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestPrintProgressLine_Queued(t *testing.T) {
+	// Queued phase is suppressed on TTY; on a bytes.Buffer (non-TTY) it prints.
 	var buf bytes.Buffer
 	printProgressLine(&buf, proto.RepoProgressState{
 		Slug:  "core",
@@ -52,7 +53,8 @@ func TestPrintProgressLine_Queued(t *testing.T) {
 		Phase: proto.PhaseQueued,
 	})
 	got := buf.String()
-	if !strings.Contains(got, "[1/3]") || !strings.Contains(got, "queued") {
+	// Non-TTY output must contain the slug and "queued".
+	if !strings.Contains(got, "core") || !strings.Contains(got, "queued") {
 		t.Errorf("unexpected queued line: %q", got)
 	}
 }
@@ -66,7 +68,8 @@ func TestPrintProgressLine_Started(t *testing.T) {
 		Phase: proto.PhaseStarted,
 	})
 	got := buf.String()
-	if !strings.Contains(got, "[2/3]") || !strings.Contains(got, "started") {
+	// New format: "frontend: starting\n" on non-TTY.
+	if !strings.Contains(got, "frontend") || !strings.Contains(got, "start") {
 		t.Errorf("unexpected started line: %q", got)
 	}
 }
@@ -83,17 +86,18 @@ func TestPrintProgressLine_Completed_WithStats(t *testing.T) {
 		Rels:       4012,
 	})
 	got := buf.String()
-	if !strings.Contains(got, "[3/3]") {
-		t.Errorf("missing position: %q", got)
+	// New format: "mobile: DONE 32s  (1,819 entities, 4,012 relationships)\n"
+	if !strings.Contains(got, "mobile") {
+		t.Errorf("missing slug in completed line: %q", got)
 	}
-	if !strings.Contains(got, "completed") {
-		t.Errorf("missing 'completed': %q", got)
+	if !strings.Contains(got, "DONE") {
+		t.Errorf("missing 'DONE' in completed line: %q", got)
 	}
-	if !strings.Contains(got, "1819 entities") {
-		t.Errorf("missing entity count: %q", got)
+	if !strings.Contains(got, "1,819") {
+		t.Errorf("missing entity count (1,819) in completed line: %q", got)
 	}
-	if !strings.Contains(got, "4012 rels") {
-		t.Errorf("missing rel count: %q", got)
+	if !strings.Contains(got, "4,012") {
+		t.Errorf("missing rel count (4,012) in completed line: %q", got)
 	}
 }
 
@@ -107,8 +111,9 @@ func TestPrintProgressLine_Failed(t *testing.T) {
 		ErrMsg: "permission denied",
 	})
 	got := buf.String()
-	if !strings.Contains(got, "failed") {
-		t.Errorf("missing 'failed': %q", got)
+	// New format: "broken: FAILED — permission denied\n"
+	if !strings.Contains(got, "FAILED") {
+		t.Errorf("missing 'FAILED': %q", got)
 	}
 	if !strings.Contains(got, "permission denied") {
 		t.Errorf("missing error message: %q", got)
@@ -116,16 +121,13 @@ func TestPrintProgressLine_Failed(t *testing.T) {
 }
 
 func TestPrintProgressLine_NoTotal(t *testing.T) {
-	// When Total=0 (e.g. single-repo index), prefix omits [n/n].
+	// Slug must always appear regardless of Total.
 	var buf bytes.Buffer
 	printProgressLine(&buf, proto.RepoProgressState{
 		Slug:  "myrepo",
 		Phase: proto.PhaseStarted,
 	})
 	got := buf.String()
-	if strings.Contains(got, "[0/0]") {
-		t.Errorf("should not contain [0/0]: %q", got)
-	}
 	if !strings.Contains(got, "myrepo") {
 		t.Errorf("missing repo name: %q", got)
 	}


### PR DESCRIPTION
## Summary

- **Real-time progress lines** during indexing — each repo now prints phase-by-phase output matching the spec: `scanning N files…`, `extracting… N%`, `P4 algorithms running (PageRank, Communities)…`, `DONE 5.2s  (N entities, N relationships)`. In-progress phases use `\r` on TTY for in-place updates; terminal phases always write `\n`.
- **Rich final summary table** after all repos complete — entities total + top-5 kinds, relationships total + top-5 kinds, cross-repo edges, process flows, HTTP endpoints, enrichment candidates, repair candidates, orphan count + rate.
- **No daemon protocol changes** — summary stats are computed client-side by reading `graph.fb`/`graph.json` + `enrichment-candidates.json` + `<group>-links.json` after the rebuild RPC returns.
- **`--json-progress` output shape preserved** — machine consumers are unaffected.

## Files changed

| File | What |
|---|---|
| `internal/cli/repair.go` | New `printProgressLine` format + call `ComputeRebuildSummary`/`PrintRebuildSummary` after rebuild |
| `internal/cli/rebuild_summary.go` | New — `RebuildSummary`, `ComputeRebuildSummary`, `PrintRebuildSummary`, `fmtInt`, `topNKinds`, `loadCandidateCounts`, `loadCrossRepoEdgeCount` |
| `internal/cli/rebuild_summary_test.go` | New — 16 tests covering formatting, table rendering, file I/O helpers, kind normalisation |
| `internal/cli/repair_progress_test.go` | Update progress-line assertions to match new DONE/FAILED/scanning/starting format |

## Sample output

Real-time progress (non-TTY log style):
```
Rebuilding group 'upvate'...
core-mobile: scanning 1,134 files…
core-mobile: extracting… 100% (1,134/1,134 files)
core-mobile: P4 algorithms running (PageRank, Communities)…
core-mobile: DONE 5s  (4,521 entities, 12,318 relationships)
```

Final summary table (spec values):
```
Group 'upvate' rebuilt (17s)

Entities (20,718 total):
  Variable      8,402
  Other         5,449
  Function      4,892
  Class         1,231
  HTTPEndpoint  744

Relationships (95,213 total):
  REFERENCES  61,902
  CALLS       12,818
  IMPORTS     8,127
  CONTAINS    6,219
  Other       6,147

Cross-repo edges:       234
Process flows:          50
HTTP endpoints:         744
Enrichment candidates:  89
Repair candidates:      12
Orphan entities:        1,341 (6.5%)
```

## Test plan

- [x] `go test ./internal/cli/...` — all tests pass, no regressions
- [x] Pre-existing daemon failures confirmed pre-existing on `main` (dashboard `dist/` missing — unrelated)
- [x] `--json-progress` JSON event shape unchanged
- [x] `--quiet` path unchanged (synchronous, no summary table)
- [x] `fmtInt` handles 0, 3-digit, 4-digit, 7-digit values and negatives
- [x] `topNKinds` tie-breaks alphabetically, handles empty map, ≤N entries, >N entries

Closes #989