### PR TITLE
[#988] Replace pagination with all-groups-collapsed + infinite scroll

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -19,6 +19,7 @@
         "@radix-ui/react-tooltip": "^1.1.6",
         "@tanstack/react-query": "^5.64.2",
         "@tanstack/react-query-devtools": "^5.64.2",
+        "@tanstack/react-virtual": "^3.13.24",
         "3d-force-graph": "^1.80.0",
         "clsx": "^2.1.1",
         "fuse.js": "^7.3.0",
@@ -2714,6 +2715,33 @@
       "peerDependencies": {
         "@tanstack/react-query": "^5.100.11",
         "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-virtual": {
+      "version": "3.13.24",
+      "resolved": "https://registry.npmmirror.com/@tanstack/react-virtual/-/react-virtual-3.13.24.tgz",
+      "integrity": "sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/virtual-core": "3.14.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/@tanstack/virtual-core": {
+      "version": "3.14.0",
+      "resolved": "https://registry.npmmirror.com/@tanstack/virtual-core/-/virtual-core-3.14.0.tgz",
+      "integrity": "sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -24,6 +24,7 @@
     "@radix-ui/react-tooltip": "^1.1.6",
     "@tanstack/react-query": "^5.64.2",
     "@tanstack/react-query-devtools": "^5.64.2",
+    "@tanstack/react-virtual": "^3.13.24",
     "3d-force-graph": "^1.80.0",
     "clsx": "^2.1.1",
     "fuse.js": "^7.3.0",

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -472,19 +472,11 @@ function applyMockFilters(
     paths = paths.filter((p) => p.is_webhook === filters.is_webhook)
   }
 
-  const total = paths.length
-  const page = filters.page ?? 1
-  const pageSize = filters.page_size ?? 50
-  const start = (page - 1) * pageSize
-  const pageItems = paths.slice(start, start + pageSize)
-
   return {
     ...data,
-    paths: pageItems,
-    total,
-    has_more: start + pageSize < total,
-    page,
-    page_size: pageSize,
+    paths,
+    total: paths.length,
+    has_more: false,
   }
 }
 

--- a/dashboard/src/hooks/paths/usePathFilters.ts
+++ b/dashboard/src/hooks/paths/usePathFilters.ts
@@ -4,7 +4,7 @@ import type { PathFilters } from '@/types/api'
 
 /**
  * Reads / writes Surface 4 filter state from the URL search params.
- * Changes to any filter reset the page to 1.
+ * Pagination has been removed — all paths are returned in a single request.
  */
 export function usePathFilters(): {
   filters: PathFilters
@@ -26,8 +26,6 @@ export function usePathFilters(): {
       : params.get('is_webhook') === 'false'
         ? false
         : undefined,
-    page: Math.max(1, parseInt(params.get('page') ?? '1', 10) || 1),
-    page_size: 50,
   }
 
   const setFilter = useCallback(
@@ -38,10 +36,6 @@ export function usePathFilters(): {
           next.delete(key)
         } else {
           next.set(key, String(value))
-        }
-        // Reset page on filter change (not on page change itself)
-        if (key !== 'page') {
-          next.set('page', '1')
         }
         return next
       })

--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -1,17 +1,18 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useParams, Outlet, useNavigate } from 'react-router-dom'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronUp, ChevronDown, List, Globe } from 'lucide-react'
 import { PathRow } from '@/components/paths/PathRow'
 import { PathsGroup } from '@/components/paths/PathsGroup'
 import { PathFilterPanel } from '@/components/paths/PathFilterPanel'
 import { PathSearchInput } from '@/components/paths/PathSearchInput'
-import { Pagination } from '@/components/paths/Pagination'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PathListSkeleton } from '@/components/shared/LoadingState'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
 import { usePathList } from '@/hooks/paths/usePathList'
 import { usePathFilters } from '@/hooks/paths/usePathFilters'
 import { groupPaths } from '@/lib/groupPaths'
+import type { PathRow as PathRowType } from '@/types/api'
 
 // ─── localStorage key for flat/grouped preference ────────────────────────────
 const LS_FLAT_KEY = 'paths-view-flat'
@@ -22,6 +23,68 @@ function readFlatPref(): boolean {
   } catch {
     return false
   }
+}
+
+// ─── Estimated row height for react-virtual ──────────────────────────────────
+const FLAT_ROW_HEIGHT = 38
+
+/**
+ * Virtualized flat list — renders only visible PathRows using @tanstack/react-virtual.
+ * Handles 1000+ paths without jank.
+ */
+function VirtualFlatList({
+  paths,
+  group,
+  onSelect,
+}: {
+  paths: PathRowType[]
+  group: string
+  onSelect: (hash: string) => void
+}) {
+  const parentRef = useRef<HTMLDivElement>(null)
+
+  const virtualizer = useVirtualizer({
+    count: paths.length,
+    getScrollElement: () => parentRef.current,
+    estimateSize: () => FLAT_ROW_HEIGHT,
+    overscan: 10,
+  })
+
+  return (
+    <div
+      ref={parentRef}
+      className="flex-1 overflow-y-auto"
+      role="grid"
+      aria-label="API paths"
+    >
+      <div
+        role="rowgroup"
+        style={{ height: virtualizer.getTotalSize(), position: 'relative' }}
+      >
+        {virtualizer.getVirtualItems().map((virtualRow) => {
+          const path = paths[virtualRow.index]
+          return (
+            <div
+              key={path.path_hash}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualRow.start}px)`,
+              }}
+            >
+              <PathRow
+                path={path}
+                group={group}
+                onSelect={() => onSelect(path.path_hash)}
+              />
+            </div>
+          )
+        })}
+      </div>
+    </div>
+  )
 }
 
 /**
@@ -36,6 +99,9 @@ function readFlatPref(): boolean {
  *   - Filter input auto-expands matching groups
  *   - Expand all / Collapse all / Flat list controls
  *
+ * Flat view:
+ *   - Virtualized with @tanstack/react-virtual — handles 1000+ rows
+ *
  * Keyboard shortcuts:
  *   /  → focus search input
  *   ↑↓ → move selection in path list
@@ -47,7 +113,7 @@ export function PathsRoute() {
   const { data, isLoading, isFetching } = usePathList(group, filters)
   const navigate = useNavigate()
   const searchRef = useRef<HTMLDivElement>(null)
-  const listRef = useRef<HTMLDivElement>(null)
+  const groupedListRef = useRef<HTMLDivElement>(null)
 
   // ── View mode ─────────────────────────────────────────────────────────────
   const [isFlat, setIsFlat] = useState<boolean>(readFlatPref)
@@ -129,7 +195,7 @@ export function PathsRoute() {
   }, [])
 
   useEffect(() => {
-    const list = listRef.current
+    const list = groupedListRef.current
     if (!list) return
     const handler = (e: KeyboardEvent) => {
       if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp') return
@@ -229,78 +295,63 @@ export function PathsRoute() {
 
           {/* Path list */}
           <ErrorBoundary>
-          <div
-            ref={listRef}
-            className="flex-1 overflow-y-auto"
-            role="grid"
-            aria-label="API paths"
-            aria-busy={isLoading}
-          >
             {isLoading ? (
               <PathListSkeleton count={12} />
             ) : paths.length === 0 ? (
-              <EmptyState
-                icon={Globe}
-                title="No paths match"
-                message="Try adjusting the search or filters."
-                action={
-                  <button
-                    type="button"
-                    className="text-sm text-sky-400 hover:underline"
-                    onClick={clearFilters}
-                  >
-                    Clear filters
-                  </button>
-                }
-              />
-            ) : isFlat ? (
-              /* ── Flat list (legacy) ─────────────────────────────────────── */
-              <div role="rowgroup">
-                {paths.map((path) => (
-                  <PathRow
-                    key={path.path_hash}
-                    path={path}
-                    group={group}
-                    onSelect={() => navigate(`/paths/${group}/${path.path_hash}`)}
-                  />
-                ))}
+              <div className="flex-1 overflow-y-auto">
+                <EmptyState
+                  icon={Globe}
+                  title="No paths match"
+                  message="Try adjusting the search or filters."
+                  action={
+                    <button
+                      type="button"
+                      className="text-sm text-sky-400 hover:underline"
+                      onClick={clearFilters}
+                    >
+                      Clear filters
+                    </button>
+                  }
+                />
               </div>
+            ) : isFlat ? (
+              /* ── Flat list — virtualized with @tanstack/react-virtual ──── */
+              <VirtualFlatList
+                paths={paths}
+                group={group}
+                onSelect={(hash) => navigate(`/paths/${group}/${hash}`)}
+              />
             ) : (
-              /* ── Grouped list ────────────────────────────────────────────── */
-              <div>
-                {groups.map((g) => (
-                  <PathsGroup
-                    key={g.name}
-                    group={g}
-                    isExpanded={!!expandedGroups[g.name]}
-                    onToggle={() => toggleGroup(g.name)}
-                  >
-                    {g.paths.map((path) => (
-                      <PathRow
-                        key={path.path_hash}
-                        path={path}
-                        group={group}
-                        onSelect={() => navigate(`/paths/${group}/${path.path_hash}`)}
-                      />
-                    ))}
-                  </PathsGroup>
-                ))}
+              /* ── Grouped list ──────────────────────────────────────────── */
+              <div
+                ref={groupedListRef}
+                className="flex-1 overflow-y-auto"
+                role="grid"
+                aria-label="API paths"
+                aria-busy={isLoading}
+              >
+                <div>
+                  {groups.map((g) => (
+                    <PathsGroup
+                      key={g.name}
+                      group={g}
+                      isExpanded={!!expandedGroups[g.name]}
+                      onToggle={() => toggleGroup(g.name)}
+                    >
+                      {g.paths.map((path) => (
+                        <PathRow
+                          key={path.path_hash}
+                          path={path}
+                          group={group}
+                          onSelect={() => navigate(`/paths/${group}/${path.path_hash}`)}
+                        />
+                      ))}
+                    </PathsGroup>
+                  ))}
+                </div>
               </div>
             )}
-          </div>
-
           </ErrorBoundary>
-
-          {/* Pagination */}
-          {!isLoading && data && data.total > (data.page_size ?? 50) && (
-            <Pagination
-              page={data.page}
-              pageSize={data.page_size}
-              total={data.total}
-              hasMore={data.has_more}
-              onPageChange={(p) => setFilter('page', p)}
-            />
-          )}
         </div>
 
         {/* Detail panel — rendered by nested route */}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -156,9 +156,12 @@ export interface PathListResponse {
   paths: PathRow[]
   tree: PathTreeNode[]
   total: number
-  has_more: boolean
-  page: number
-  page_size: number
+  /** @deprecated pagination removed — always false */
+  has_more?: boolean
+  /** @deprecated pagination removed */
+  page?: number
+  /** @deprecated pagination removed */
+  page_size?: number
 }
 
 export interface PathFilters {
@@ -168,8 +171,6 @@ export interface PathFilters {
   framework?: string
   status_code?: number
   is_webhook?: boolean
-  page?: number
-  page_size?: number
 }
 
 /** Full detail for one path — GET /api/paths/{group}/{pathHash} */

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -18,7 +18,8 @@ import (
 
 const (
 	httpEndpointKind = "http_endpoint"
-	pageSize         = 50
+	// pageSize is kept for backward-compat but the default is now 5000 (all paths).
+	pageSize = 5000
 )
 
 // PathRow is one grouped API path returned by the list endpoint.
@@ -62,7 +63,8 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 	}
 	size := pageSize
 	if v := q.Get("size"); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 200 {
+		// Allow explicit override up to 10000 for API consumers.
+		if n, err := strconv.Atoi(v); err == nil && n > 0 && n <= 10000 {
 			size = n
 		}
 	}


### PR DESCRIPTION
## What we did

- Removed the \`Pagination\` component entirely from \`/paths/<group>\` — no more prev/next controls
- Backend (\`handlers_paths.go\`): raised default \`page_size\` from 50 → 5000, returning all paths in one request; explicit \`?size=\` override allowed up to 10 000
- Added \`@tanstack/react-virtual\` for the flat-list mode — only visible rows are rendered (handles 1000+ paths without jank)
- All groups render collapsed by default (pre-existing behavior from #918, verified)
- Filter auto-expands matching groups; clearing filter collapses all
- Expand all / Collapse all / Flat list controls preserved

## What changed (files)

| File | Change |
|---|---|
| \`internal/dashboard/handlers_paths.go\` | \`pageSize\` const 50 → 5000; \`size\` cap 200 → 10000 |
| \`dashboard/src/routes/paths.tsx\` | Remove \`Pagination\` import/render; add \`VirtualFlatList\` with \`useVirtualizer\` |
| \`dashboard/src/hooks/paths/usePathFilters.ts\` | Drop \`page\` / \`page_size\` from URL state |
| \`dashboard/src/types/api.ts\` | \`has_more\`/\`page\`/\`page_size\` marked deprecated-optional on \`PathListResponse\`; removed from \`PathFilters\` |
| \`dashboard/src/api/client.ts\` | Mock filter path: return all filtered paths, no slicing |
| \`dashboard/package.json\` + \`package-lock.json\` | Add \`@tanstack/react-virtual ^3.13.24\` |

## Performance

- Grouped view: group headers always rendered; bodies lazy-render on expand (unchanged from #918)
- Flat list: \`useVirtualizer\` with \`overscan: 10\` and estimated row height 38px — only visible rows are in the DOM
- For 744 paths (upvate corpus), total payload is well under 1 MB — no gzip needed

## Playwright E2E results

All checks pass on the mock fixture (20 paths across 5 groups):

1. \`/paths/fixture-a\` loads → all 5 groups collapsed, no pagination controls visible
2. "Expand all" click → all groups open, all 20 paths visible
3. "Flat list" toggle → virtualized list renders all 20 rows, no pagination
4. Filter \`orders\` → 5 paths remain, OrdersController auto-expands, other groups hidden
5. \`hasPagination: false\` confirmed via JS evaluation
6. Console: 0 errors from paths surface in current session

## Caveats

- \`Pagination.tsx\` component is now unreferenced (dead file) — can be deleted in a follow-up cleanup PR
- Backend still echoes \`has_more: false\` / \`page: 0\` / \`size: 5000\` in the JSON response for backward compat with any API consumers; frontend ignores them

## Closes

Closes #988