### PR TITLE
[#986] Docs surface empty state with /generate-docs instructions

### DIFF
--- a/dashboard/src/components/docs/DocsEmptyState.tsx
+++ b/dashboard/src/components/docs/DocsEmptyState.tsx
@@ -1,0 +1,87 @@
+import { BookOpen, RefreshCw } from 'lucide-react'
+
+interface DocsEmptyStateProps {
+  group: string
+  onRetry?: () => void
+}
+
+/**
+ * Empty state shown when a group has no generated documentation yet.
+ *
+ * Renders:
+ *  - Heading + explanation paragraph
+ *  - Numbered step list with the /generate-docs skill command
+ *  - Code block for the command
+ *  - "Try Again" button to re-fetch
+ */
+export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
+  return (
+    <div
+      className="flex flex-col items-center justify-center h-full py-16 px-6 text-center"
+      role="status"
+      aria-live="polite"
+    >
+      <div className="rounded-full bg-slate-800 p-4 mb-4">
+        <BookOpen className="w-8 h-8 text-slate-500" aria-hidden />
+      </div>
+
+      <h2 className="text-lg font-semibold text-slate-200 mb-2">
+        No documentation generated yet
+      </h2>
+
+      <p className="max-w-md text-sm text-slate-400 mb-6">
+        Archigraph can generate per-entity documentation summarising what each
+        function, class, and component does — drawing context from the
+        surrounding code graph. Once generated, docs appear here as a
+        searchable, cross-linked portal.
+      </p>
+
+      <ol className="text-left max-w-md w-full space-y-3 mb-6 list-none">
+        <li className="flex gap-3 text-sm text-slate-300">
+          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
+            1
+          </span>
+          <span>
+            Open Claude Code in a repo registered under{' '}
+            <code className="px-1 py-0.5 rounded bg-slate-800 text-indigo-300 text-xs font-mono">
+              {group}
+            </code>{' '}
+            and run the skill:
+            <br />
+            <code className="mt-1 inline-block px-2 py-1 rounded bg-slate-800 text-emerald-300 text-xs font-mono border border-slate-700">
+              /generate-docs
+            </code>
+          </span>
+        </li>
+
+        <li className="flex gap-3 text-sm text-slate-300">
+          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
+            2
+          </span>
+          <span>
+            Wait for the pipeline to complete — typically 5–20 minutes
+            depending on codebase size.
+          </span>
+        </li>
+
+        <li className="flex gap-3 text-sm text-slate-300">
+          <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
+            3
+          </span>
+          <span>Refresh this page — the docs tree will appear in the sidebar.</span>
+        </li>
+      </ol>
+
+      {onRetry && (
+        <button
+          onClick={onRetry}
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-slate-800 hover:bg-slate-700 text-sm text-slate-200 border border-slate-600 transition-colors"
+          type="button"
+        >
+          <RefreshCw className="w-4 h-4" aria-hidden />
+          Try Again
+        </button>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/docs/DocsPage.tsx
+++ b/dashboard/src/components/docs/DocsPage.tsx
@@ -8,6 +8,7 @@ import { PathTreeSkeleton, CardSkeleton } from '@/components/shared/LoadingState
 import { EmptyState } from '@/components/shared/EmptyState'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
 import { BookOpen, FileX } from 'lucide-react'
+import { DocsEmptyState } from './DocsEmptyState'
 
 interface DocsPageProps {
   group: string
@@ -29,8 +30,12 @@ interface DocsPageProps {
  * - Keyboard: / focuses search, Esc closes dropdown
  */
 export function DocsPage({ group, docPath }: DocsPageProps) {
-  const { data: treeData, isLoading: treeLoading, error: treeError } = useDocTree(group)
+  const { data: treeData, isLoading: treeLoading, error: treeError, refetch: refetchTree } = useDocTree(group)
   const { data: content, isLoading: contentLoading, error: contentError } = useDocContent(group, docPath)
+
+  // Show docs-not-generated empty state when the tree loaded successfully but
+  // contains no entries (group exists but /generate-docs has never been run).
+  const isDocsEmpty = !treeLoading && !treeError && treeData && treeData.tree.length === 0
 
   return (
     <div className="flex flex-col h-full bg-slate-950">
@@ -85,7 +90,14 @@ export function DocsPage({ group, docPath }: DocsPageProps) {
             />
           }
         >
-          {!docPath && (
+          {isDocsEmpty && (
+            <DocsEmptyState
+              group={group}
+              onRetry={() => refetchTree()}
+            />
+          )}
+
+          {!isDocsEmpty && !docPath && (
             <div className="flex flex-col items-center justify-center h-full">
               <EmptyState
                 icon={BookOpen}
@@ -95,14 +107,14 @@ export function DocsPage({ group, docPath }: DocsPageProps) {
             </div>
           )}
 
-          {docPath && contentLoading && (
+          {!isDocsEmpty && docPath && contentLoading && (
             <div className="p-8 space-y-4 max-w-3xl">
               <CardSkeleton />
               <CardSkeleton />
             </div>
           )}
 
-          {docPath && contentError && (
+          {!isDocsEmpty && docPath && contentError && (
             <div className="flex flex-col items-center justify-center h-full">
               <EmptyState
                 icon={FileX}
@@ -112,7 +124,7 @@ export function DocsPage({ group, docPath }: DocsPageProps) {
             </div>
           )}
 
-          {docPath && content && (
+          {!isDocsEmpty && docPath && content && (
             <DocsContent group={group} content={content} />
           )}
         </ErrorBoundary>


### PR DESCRIPTION
## Summary

Add `DocsEmptyState` component that renders when a group's doc tree is empty (i.e. `/generate-docs` has never been run). Previously the docs surface showed a blank sidebar with no guidance. Now users see a friendly heading, an explanation of what doc generation does, a numbered 3-step guide showing the `/generate-docs` skill command, and a "Try Again" button that re-fetches the tree.

## Closes / Refs
- Closes #986

## What changed

- **New:** `dashboard/src/components/docs/DocsEmptyState.tsx` — self-contained component; renders icon, heading, explanation paragraph, 3-step OL with code-styled `/generate-docs` command, and a `Try Again` refetch button.
- **Modified:** `dashboard/src/components/docs/DocsPage.tsx` — derives `isDocsEmpty` from `treeData.tree.length === 0` (only when load succeeded, not on error); gates all doc-content renders behind `!isDocsEmpty`; passes `refetchTree` to `DocsEmptyState`.

## Why the command is `/generate-docs`

Verified in `skills/generate-docs/SKILL.md` and `internal/mcp/docstate.go` (`suggested_action: "run /generate-docs"`). There is no standalone CLI `archigraph docgen` subcommand — doc generation runs as a Claude Code skill.

## Testing

- [x] `npx vite build` succeeds (pre-existing tsc errors from react-native transitive deps unrelated to this change)
- [x] Playwright: empty-tree mock → empty state heading + steps + button visible, zero console errors
- [x] Playwright: full mock → tree + content render unchanged, empty-state text absent
- [x] `browser_evaluate` confirms `'No documentation generated yet'` in DOM for empty case
- [x] `browser_evaluate` confirms text absent for non-empty case

## Notes

The `isDocsEmpty` guard is conservative: it only fires when the fetch succeeded (`!treeError`) and the tree array is truly empty. A 404/network error still falls through to the existing error path, not the empty state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)