### PR TITLE
[#984] Card footer: tech-stack chips + repo names, uniform card height

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -107,6 +107,7 @@ type WireGroup = {
   repos?: string[]
   entity_count?: number
   last_indexed?: string
+  frameworks?: string[]
 }
 
 function normalizeRegistry(raw: { groups: Array<WireGroup> }): Registry {
@@ -121,6 +122,7 @@ function normalizeRegistry(raw: { groups: Array<WireGroup> }): Registry {
     })),
     entity_count: g.entity_count ?? 0,
     indexed_at: g.last_indexed,
+    frameworks: g.frameworks,
   }))
   return { groups, version: '1' }
 }

--- a/dashboard/src/api/mocks/registry.json
+++ b/dashboard/src/api/mocks/registry.json
@@ -11,7 +11,8 @@
       "entity_count": 6916,
       "indexed_at": "2026-05-20T10:05:00Z",
       "bug_rate": 3.2,
-      "bug_rate_history": [4.8, 4.1, 3.9, 3.5, 3.4, 3.2]
+      "bug_rate_history": [4.8, 4.1, 3.9, 3.5, 3.4, 3.2],
+      "frameworks": ["Python", "Django", "React", "TypeScript", "Node", "FastAPI", "GraphQL"]
     },
     {
       "id": "go-chi-mini",
@@ -23,7 +24,8 @@
       "entity_count": 1592,
       "indexed_at": "2026-05-20T08:35:00Z",
       "bug_rate": 9.7,
-      "bug_rate_history": [12.3, 11.8, 11.2, 10.5, 9.9, 9.7]
+      "bug_rate_history": [12.3, 11.8, 11.2, 10.5, 9.9, 9.7],
+      "frameworks": ["Go/chi", "Go/net-http"]
     },
     {
       "id": "rust-tokio-mini",
@@ -34,7 +36,8 @@
       "entity_count": 2310,
       "indexed_at": "2026-05-20T07:20:00Z",
       "bug_rate": 18.4,
-      "bug_rate_history": [22.1, 20.5, 19.8, 19.1, 18.8, 18.4]
+      "bug_rate_history": [22.1, 20.5, 19.8, 19.1, 18.8, 18.4],
+      "frameworks": ["Axum", "Tokio"]
     },
     {
       "id": "python-django-mini",
@@ -46,7 +49,8 @@
       "entity_count": 4730,
       "indexed_at": "2026-05-20T06:05:00Z",
       "bug_rate": 6.1,
-      "bug_rate_history": [9.4, 8.2, 7.5, 7.0, 6.4, 6.1]
+      "bug_rate_history": [9.4, 8.2, 7.5, 7.0, 6.4, 6.1],
+      "frameworks": ["Django", "Python", "Celery", "DRF"]
     }
   ],
   "version": "1.0.0-m2"

--- a/dashboard/src/components/landing/GroupSelector.tsx
+++ b/dashboard/src/components/landing/GroupSelector.tsx
@@ -125,7 +125,7 @@ function Sparkline({ history, bugRate, width = 60, height = 24 }: SparklineProps
 function GroupCardSkeleton() {
   return (
     <div
-      className="rounded-xl border border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60 p-5 h-[152px] space-y-4"
+      className="rounded-xl border border-slate-800 bg-slate-900/60 p-5 h-[232px] space-y-4"
       role="status"
       aria-label="Loading group…"
     >
@@ -140,6 +140,15 @@ function GroupCardSkeleton() {
         <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
         <div className="h-4 w-14 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
         <div className="h-4 w-16 rounded bg-slate-200 dark:bg-slate-800 animate-pulse" />
+      </div>
+      {/* footer skeleton */}
+      <div className="border-t border-slate-800/60 pt-3 space-y-2">
+        <div className="flex gap-1">
+          <div className="h-4 w-14 rounded bg-slate-800 animate-pulse" />
+          <div className="h-4 w-12 rounded bg-slate-800 animate-pulse" />
+          <div className="h-4 w-10 rounded bg-slate-800 animate-pulse" />
+        </div>
+        <div className="h-3 w-36 rounded bg-slate-800 animate-pulse" />
       </div>
       <span className="sr-only">Loading…</span>
     </div>
@@ -172,6 +181,76 @@ function StatPill({ icon, tooltip, label, value, valueClass = 'text-slate-700 da
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// FrameworkChips — Row 1 of the card footer
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MAX_VISIBLE_CHIPS = 4
+
+interface FrameworkChipsProps {
+  frameworks?: string[]
+}
+
+function FrameworkChips({ frameworks }: FrameworkChipsProps) {
+  if (!frameworks || frameworks.length === 0) {
+    return <div className="flex items-center gap-1 h-5" aria-label="No frameworks detected" />
+  }
+
+  const visible = frameworks.slice(0, MAX_VISIBLE_CHIPS)
+  const overflow = frameworks.slice(MAX_VISIBLE_CHIPS)
+  const overflowTip = overflow.join(', ')
+
+  return (
+    <div className="flex items-center gap-1 flex-wrap min-h-[20px]" role="list" aria-label="Frameworks">
+      {visible.map((fw) => (
+        <span
+          key={fw}
+          role="listitem"
+          className="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono leading-none bg-slate-700 text-sky-400"
+        >
+          {fw}
+        </span>
+      ))}
+      {overflow.length > 0 && (
+        <Tooltip tip={overflowTip}>
+          <span
+            data-overflow-chip
+            className="inline-block px-1.5 py-0.5 rounded text-[10px] font-mono leading-none cursor-default bg-slate-700 text-sky-400"
+          >
+            +{overflow.length} more
+          </span>
+        </Tooltip>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// RepoRow — Row 2 of the card footer
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface RepoRowProps {
+  repos: Array<{ slug: string }>
+}
+
+function RepoRow({ repos }: RepoRowProps) {
+  const names = repos.map((r) => r.slug)
+  const joined = names.join(', ')
+  const tip = names.length > 1 ? joined : ''
+
+  return (
+    <Tooltip tip={tip}>
+      <span
+        data-repo-row
+        className="block text-[10px] text-slate-500 truncate w-full leading-snug"
+        aria-label={`Repos: ${joined}`}
+      >
+        {joined}
+      </span>
+    </Tooltip>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Group card
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -190,66 +269,77 @@ function GroupCard({ group, onClick }: GroupCardProps) {
   return (
     <button
       type="button"
+      data-card
       onClick={onClick}
       className={[
-        'w-full text-left rounded-xl border bg-slate-100/60 dark:bg-slate-900/60 p-5',
-        // Fixed height ensures all cards are the same regardless of bug-rate / sparkline presence
-        'h-[152px] flex flex-col justify-between',
+        'w-full text-left rounded-xl border bg-slate-900/60 p-5',
+        // Fixed height: 152px (stats) + 80px (footer) = 232px.
+        // All cards identical height regardless of framework count.
+        'h-[232px] flex flex-col',
         'transition-all duration-150 cursor-pointer',
         'border-slate-200 dark:border-slate-800 hover:border-sky-500/40 hover:-translate-y-px hover:bg-slate-200 dark:hover:bg-slate-900',
         'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-sky-500/60',
       ].join(' ')}
     >
-      {/* Header: group name + sparkline */}
-      <div className="flex items-start justify-between gap-3">
-        <div className="flex items-center gap-2 min-w-0">
-          <GitBranch className="w-4 h-4 text-sky-400 shrink-0" aria-hidden />
-          <span className="text-xl font-semibold text-slate-900 dark:text-slate-100 truncate">
-            {group.display_name}
-          </span>
+      {/* Main content — grows to fill available space */}
+      <div className="flex-1 flex flex-col justify-between min-h-0">
+        {/* Header: group name + sparkline */}
+        <div className="flex items-start justify-between gap-3">
+          <div className="flex items-center gap-2 min-w-0">
+            <GitBranch className="w-4 h-4 text-sky-400 shrink-0" aria-hidden />
+            <span className="text-xl font-semibold text-slate-100 truncate">
+              {group.display_name}
+            </span>
+          </div>
+          <div className="shrink-0 pt-0.5">
+            <Sparkline history={group.bug_rate_history} bugRate={group.bug_rate} />
+          </div>
         </div>
-        <div className="shrink-0 pt-0.5">
-          <Sparkline history={group.bug_rate_history} bugRate={group.bug_rate} />
+
+        {/* Stats grid — 2×2 to keep consistent height */}
+        <div className="grid grid-cols-2 gap-x-3 gap-y-2">
+          {/* Repos */}
+          <StatPill
+            icon={<Database className="w-3.5 h-3.5" aria-hidden />}
+            tooltip="Number of repositories in this group"
+            label="Repos"
+            value={String(group.repos.length)}
+          />
+
+          {/* Entities */}
+          <StatPill
+            icon={<TerminalSquare className="w-3.5 h-3.5" aria-hidden />}
+            tooltip="Total entities across all repos"
+            label="Entities"
+            value={formatCount(group.entity_count)}
+            dimmed={!hasRealData}
+          />
+
+          {/* Bug rate */}
+          <StatPill
+            icon={<Activity className="w-3.5 h-3.5" aria-hidden />}
+            tooltip="Percentage of unresolved/ambiguous edges (lower is better)"
+            label="Bug-rate"
+            value={rateLabel}
+            valueClass={`text-xs font-medium font-mono ${rateColor}`}
+            dimmed={group.bug_rate === undefined}
+          />
+
+          {/* Last indexed */}
+          <StatPill
+            icon={<Clock className="w-3.5 h-3.5" aria-hidden />}
+            tooltip="Time since most recent indexing"
+            label="Indexed"
+            value={relativeTime(group.indexed_at)}
+            dimmed={!hasIndexedAt}
+          />
         </div>
       </div>
 
-      {/* Stats grid — 2×2 to keep consistent height */}
-      <div className="grid grid-cols-2 gap-x-3 gap-y-2">
-        {/* Repos */}
-        <StatPill
-          icon={<Database className="w-3.5 h-3.5" aria-hidden />}
-          tooltip="Number of repositories in this group"
-          label="Repos"
-          value={String(group.repos.length)}
-        />
-
-        {/* Entities */}
-        <StatPill
-          icon={<TerminalSquare className="w-3.5 h-3.5" aria-hidden />}
-          tooltip="Total entities across all repos"
-          label="Entities"
-          value={formatCount(group.entity_count)}
-          dimmed={!hasRealData}
-        />
-
-        {/* Bug rate */}
-        <StatPill
-          icon={<Activity className="w-3.5 h-3.5" aria-hidden />}
-          tooltip="Percentage of unresolved/ambiguous edges (lower is better)"
-          label="Bug-rate"
-          value={rateLabel}
-          valueClass={`text-xs font-medium font-mono ${rateColor}`}
-          dimmed={group.bug_rate === undefined}
-        />
-
-        {/* Last indexed */}
-        <StatPill
-          icon={<Clock className="w-3.5 h-3.5" aria-hidden />}
-          tooltip="Time since most recent indexing"
-          label="Indexed"
-          value={relativeTime(group.indexed_at)}
-          dimmed={!hasIndexedAt}
-        />
+      {/* Footer — fixed 80px: framework chips + repo names */}
+      <div className="h-[80px] flex flex-col justify-center gap-1.5 pt-3 border-t border-slate-800/60 mt-3 shrink-0">
+        <FrameworkChips frameworks={group.frameworks} />
+        <RepoRow repos={group.repos} />
       </div>
     </button>
   )

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -96,6 +96,8 @@ export interface GroupMeta {
   bug_rate?: number
   /** Rolling bug-rate history (oldest → newest), used for the sparkline. */
   bug_rate_history?: number[]
+  /** Top frameworks detected across all repos in the group (sorted by usage, capped at 8). */
+  frameworks?: string[]
 }
 
 export interface Registry {

--- a/dashboard/tsconfig.node.json
+++ b/dashboard/tsconfig.node.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "composite": true,
     "target": "ES2022",
     "lib": ["ES2022"],
     "module": "ESNext",
@@ -7,7 +8,8 @@
     "allowImportingTsExtensions": true,
     "isolatedModules": true,
     "moduleDetection": "force",
-    "noEmit": true,
+    "noEmit": false,
+    "emitDeclarationOnly": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -315,3 +315,51 @@ func hashStr(s string) string {
 	h := sha256.Sum256([]byte(s))
 	return fmt.Sprintf("%x", h[:8])
 }
+
+// groupTopFrameworks scans all http_endpoint / Endpoint / Route entities
+// across the group and returns the top-N framework names sorted by usage
+// frequency (descending). cap controls the maximum number returned (≤8).
+func groupTopFrameworks(grp *DashGroup, cap int) []string {
+	freq := map[string]int{}
+	for _, r := range sortedRepos(grp) {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			kind := dashStripScopePrefix(e.Kind)
+			if !strings.EqualFold(kind, httpEndpointKind) && kind != "Endpoint" && kind != "Route" {
+				continue
+			}
+			if fw := e.Properties["framework"]; fw != "" {
+				freq[fw]++
+			}
+		}
+	}
+	if len(freq) == 0 {
+		return nil
+	}
+
+	type kv struct {
+		k string
+		v int
+	}
+	pairs := make([]kv, 0, len(freq))
+	for k, v := range freq {
+		pairs = append(pairs, kv{k, v})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].v != pairs[j].v {
+			return pairs[i].v > pairs[j].v
+		}
+		return pairs[i].k < pairs[j].k
+	})
+	if cap > 0 && len(pairs) > cap {
+		pairs = pairs[:cap]
+	}
+	out := make([]string, len(pairs))
+	for i, p := range pairs {
+		out[i] = p.k
+	}
+	return out
+}

--- a/internal/dashboard/handlers.go
+++ b/internal/dashboard/handlers.go
@@ -18,6 +18,12 @@ func (s *Server) handleListRegistry(w http.ResponseWriter, _ *http.Request) {
 	if groups == nil {
 		groups = []GroupSummary{}
 	}
+	// Best-effort: enrich with top frameworks from the in-memory graph cache.
+	for i := range groups {
+		if grp, gErr := s.graphs.GetGroup(groups[i].Name); gErr == nil {
+			groups[i].Frameworks = groupTopFrameworks(grp, 8)
+		}
+	}
 	writeJSON(w, http.StatusOK, map[string]any{"groups": groups})
 }
 

--- a/internal/dashboard/handlers_init.go
+++ b/internal/dashboard/handlers_init.go
@@ -68,6 +68,9 @@ func (s *Server) handleDashboardInit(w http.ResponseWriter, r *http.Request) {
 			}
 			entry["total_entities"] = totalE
 			entry["total_relationships"] = totalR
+			if fws := groupTopFrameworks(grp, 8); len(fws) > 0 {
+				entry["frameworks"] = fws
+			}
 		}
 		enriched = append(enriched, entry)
 	}

--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -35,6 +35,7 @@ type GroupSummary struct {
 	Repos       []string `json:"repos"`
 	EntityCount int      `json:"entity_count"`
 	LastIndexed string   `json:"last_indexed,omitempty"` // RFC3339, most-recent across repos
+	Frameworks  []string `json:"frameworks,omitempty"`  // top-8 frameworks by frequency, desc
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Backend**: \`GroupSummary\` gains \`frameworks []string\` (top-8 by endpoint-entity frequency, desc). New \`groupTopFrameworks()\` helper in \`graphstate.go\` scans \`http_endpoint\`/\`Endpoint\`/\`Route\` entities across all repos in a group. Result enriched into both \`GET /api/registry\` and \`GET /api/dashboard/init\` (same 30s best-effort cache pattern as \`entity_count\`).
- **Frontend**: \`GroupMeta.frameworks?: string[]\` added to \`api.ts\`; \`normalizeRegistry\` in \`client.ts\` passes the field through; mock registry updated with representative framework arrays per group.
- **Card redesign**: \`GroupCard\` grows from \`h-[152px]\` to \`h-[232px]\` with \`flex-col\`. A fixed \`h-[80px]\` footer holds two rows: ① \`FrameworkChips\` — up to 4 visible monospace pills, \`+N more\` overflow chip with CSS tooltip showing full list; ② \`RepoRow\` — comma-separated slugs, truncated, full list on hover tooltip. \`GroupCardSkeleton\` matched to same height.
- **tsconfig fix**: \`tsconfig.node.json\` was missing \`"composite": true\` (pre-existing breakage; added \`composite\` + \`emitDeclarationOnly\`).

## Playwright verification

- Screenshot confirms chips + repo names visible on all 4 cards
- \`getBoundingClientRect().height\` → \`[232, 232, 232, 232]\` — all identical
- \`[data-overflow-chip]\` present (\`+3 more\`) with CSS tooltip wrapping
- \`[data-repo-row]\` × 4 with correct comma-separated slug text
- Console errors: **0**

## Test plan

- [ ] \`go build ./internal/dashboard/...\` passes
- [ ] \`cd dashboard && npx vite build\` passes
- [ ] Landing page: all cards same height, chips + repos visible
- [ ] Hover \`+N more\` chip → tooltip shows remaining frameworks
- [ ] Hover repo row → tooltip shows full slug list
- [ ] Live daemon: \`GET /api/registry\` includes \`frameworks\` field when group is indexed

Closes #984

🤖 Generated with [Claude Code](https://claude.com/claude-code)