### PR TITLE
[#982] Rename UI label 'Bug-rate' → 'Unresolved edges'

### DIFF
--- a/dashboard/src/components/landing/GroupSelector.tsx
+++ b/dashboard/src/components/landing/GroupSelector.tsx
@@ -2,7 +2,7 @@
  * GroupSelector — landing page card grid.
  *
  * Shows all indexed groups as cards with name, sparkline, repo count,
- * entity count, bug-rate and last-indexed time. Clicking a card navigates
+ * entity count, unresolved edges and last-indexed time. Clicking a card navigates
  * to /graph/<group>.
  */
 
@@ -315,11 +315,11 @@ function GroupCard({ group, onClick }: GroupCardProps) {
             dimmed={!hasRealData}
           />
 
-          {/* Bug rate */}
+          {/* Unresolved edges */}
           <StatPill
             icon={<Activity className="w-3.5 h-3.5" aria-hidden />}
-            tooltip="Percentage of unresolved/ambiguous edges (lower is better)"
-            label="Bug-rate"
+            tooltip="Percentage of graph edges that point to unknown or ambiguous targets. Lower is better. Drops as the resolver improves."
+            label="Unresolved edges"
             value={rateLabel}
             valueClass={`text-xs font-medium font-mono ${rateColor}`}
             dimmed={group.bug_rate === undefined}

--- a/dashboard/src/components/layout/GroupSelector.tsx
+++ b/dashboard/src/components/layout/GroupSelector.tsx
@@ -9,7 +9,7 @@
  *  - Search input at top of panel
  *  - Pinned groups section (max 3, star toggle per row)
  *  - Other groups section
- *  - Bug-rate status dot: green ≤5% / amber 5–15% / red >15%
+ *  - Unresolved edges status dot: green ≤5% / amber 5–15% / red >15%
  *  - Entity-count tooltip
  *  - Selected row visually highlighted
  *  - Closes on outside-click or Escape
@@ -33,7 +33,7 @@ interface GroupSelectorProps {
   groups: GroupMeta[]
 }
 
-/** Derive a synthetic bug-rate bucket from entity_count for mock data. */
+/** Derive a synthetic unresolved edges bucket from entity_count for mock data. */
 function bugRateBucket(g: GroupMeta): 'green' | 'amber' | 'red' {
   const sum = g.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
   const pct = sum % 30
@@ -49,9 +49,9 @@ const bucketClass: Record<'green' | 'amber' | 'red', string> = {
 }
 
 const bucketLabel: Record<'green' | 'amber' | 'red', string> = {
-  green: '≤5% bug rate',
-  amber: '5–15% bug rate',
-  red: '>15% bug rate',
+  green: '≤5% unresolved edges',
+  amber: '5–15% unresolved edges',
+  red: '>15% unresolved edges',
 }
 
 /** Extracts the current surface prefix from a pathname like "/flows/fixture-a" → "flows" */
@@ -328,7 +328,7 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
                   {isPinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
                 </span>
 
-                {/* Bug-rate dot */}
+                {/* Unresolved edges dot */}
                 <span
                   title={`${bucketLabel[bucket]} — ${g.entity_count.toLocaleString()} entities`}
                   aria-label={bucketLabel[bucket]}

--- a/dashboard/src/components/layout/GroupSwitcher.tsx
+++ b/dashboard/src/components/layout/GroupSwitcher.tsx
@@ -4,8 +4,8 @@
  * Features:
  *  - Search/filter input
  *  - Pinned groups float to top (localStorage, max 3)
- *  - Bug-rate status dot: green ≤5% / amber 5-15% / red >15%
- *    (uses entity_count as proxy until a real bug_rate field ships)
+ *  - Unresolved edges status dot: green ≤5% / amber 5-15% / red >15%
+ *    (uses entity_count as proxy until a real unresolved_edges field ships)
  *  - Entity count in tooltip
  *  - Active group: bg-slate-200 dark:bg-slate-800 + sky-500 left border
  *  - Switching preserves current surface (e.g. /flows/A → /flows/B)
@@ -22,9 +22,9 @@ interface GroupSwitcherProps {
   onNavigate?: () => void   // called after navigation (e.g. close mobile drawer)
 }
 
-/** Derive a synthetic bug-rate bucket from entity_count for mock data. */
+/** Derive a synthetic unresolved edges bucket from entity_count for mock data. */
 function bugRateBucket(g: GroupMeta): 'green' | 'amber' | 'red' {
-  // Real API will eventually carry a `bug_rate` field.
+  // Real API will eventually carry a `unresolved_edges` field.
   // Until then we use a deterministic hash of the id so fixture groups get
   // stable (but varied) colours in the UI.
   const sum = g.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
@@ -41,9 +41,9 @@ const bucketClass: Record<'green' | 'amber' | 'red', string> = {
 }
 
 const bucketLabel: Record<'green' | 'amber' | 'red', string> = {
-  green: '≤5% bug rate',
-  amber: '5–15% bug rate',
-  red: '>15% bug rate',
+  green: '≤5% unresolved edges',
+  amber: '5–15% unresolved edges',
+  red: '>15% unresolved edges',
 }
 
 /** Extracts the current surface prefix from a pathname like "/flows/fixture-a" → "flows" */
@@ -192,7 +192,7 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
                   )}
                 </span>
 
-                {/* Bug-rate status dot */}
+                {/* Unresolved edges status dot */}
                 <span
                   title={`${bucketLabel[bucket]} — ${g.entity_count.toLocaleString()} entities`}
                   aria-label={bucketLabel[bucket]}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -92,9 +92,9 @@ export interface GroupMeta {
   repos: RepoMeta[]
   entity_count: number
   indexed_at?: string
-  /** Bug-rate percentage for the group (0–100). Present when the group has been indexed. */
+  /** Unresolved edges percentage for the group (0–100). Percentage of graph edges that point to unknown or ambiguous targets. Present when the group has been indexed. */
   bug_rate?: number
-  /** Rolling bug-rate history (oldest → newest), used for the sparkline. */
+  /** Rolling unresolved edges history (oldest → newest), used for the sparkline. */
   bug_rate_history?: number[]
   /** Top frameworks detected across all repos in the group (sorted by usage, capped at 8). */
   frameworks?: string[]


### PR DESCRIPTION
## What we did
Renamed UI label, tooltip text, and status labels from 'Bug-rate' to 'Unresolved edges'. Variable + API field names unchanged for backward compat.

## What we won
User won't misread metric as 'percentage of bugs in code'. Tooltip now clearly explains it measures graph edges pointing to unknown/ambiguous targets and how it improves.

## Graph impact
None.

## MCP impact
None.

## Caveats
JSON wire format unchanged (`bug_rate` key stays); internal field names unchanged for backward compat.

## Bottom line
Closes #982.