### PR TITLE
[#981] Fix light theme: add dark: prefix to 7 escaped components

### DIFF
--- a/dashboard/src/components/docs/DocsEmptyState.tsx
+++ b/dashboard/src/components/docs/DocsEmptyState.tsx
@@ -21,15 +21,15 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
       role="status"
       aria-live="polite"
     >
-      <div className="rounded-full bg-slate-800 p-4 mb-4">
-        <BookOpen className="w-8 h-8 text-slate-500" aria-hidden />
+      <div className="rounded-full bg-slate-100 dark:bg-slate-800 p-4 mb-4">
+        <BookOpen className="w-8 h-8 text-slate-500 dark:text-slate-500" aria-hidden />
       </div>
 
-      <h2 className="text-lg font-semibold text-slate-200 mb-2">
+      <h2 className="text-lg font-semibold text-slate-800 dark:text-slate-200 mb-2">
         No documentation generated yet
       </h2>
 
-      <p className="max-w-md text-sm text-slate-400 mb-6">
+      <p className="max-w-md text-sm text-slate-600 dark:text-slate-400 mb-6">
         Archigraph can generate per-entity documentation summarising what each
         function, class, and component does — drawing context from the
         surrounding code graph. Once generated, docs appear here as a
@@ -37,24 +37,24 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
       </p>
 
       <ol className="text-left max-w-md w-full space-y-3 mb-6 list-none">
-        <li className="flex gap-3 text-sm text-slate-300">
+        <li className="flex gap-3 text-sm text-slate-700 dark:text-slate-300">
           <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
             1
           </span>
           <span>
             Open Claude Code in a repo registered under{' '}
-            <code className="px-1 py-0.5 rounded bg-slate-800 text-indigo-300 text-xs font-mono">
+            <code className="px-1 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-indigo-600 dark:text-indigo-300 text-xs font-mono">
               {group}
             </code>{' '}
             and run the skill:
             <br />
-            <code className="mt-1 inline-block px-2 py-1 rounded bg-slate-800 text-emerald-300 text-xs font-mono border border-slate-700">
+            <code className="mt-1 inline-block px-2 py-1 rounded bg-slate-100 dark:bg-slate-800 text-emerald-700 dark:text-emerald-300 text-xs font-mono border border-slate-200 dark:border-slate-700">
               /generate-docs
             </code>
           </span>
         </li>
 
-        <li className="flex gap-3 text-sm text-slate-300">
+        <li className="flex gap-3 text-sm text-slate-700 dark:text-slate-300">
           <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
             2
           </span>
@@ -64,7 +64,7 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
           </span>
         </li>
 
-        <li className="flex gap-3 text-sm text-slate-300">
+        <li className="flex gap-3 text-sm text-slate-700 dark:text-slate-300">
           <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
             3
           </span>
@@ -75,7 +75,7 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
       {onRetry && (
         <button
           onClick={onRetry}
-          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-slate-800 hover:bg-slate-700 text-sm text-slate-200 border border-slate-600 transition-colors"
+          className="inline-flex items-center gap-2 px-4 py-2 rounded-md bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700 text-sm text-slate-700 dark:text-slate-200 border border-slate-200 dark:border-slate-600 transition-colors"
           type="button"
         >
           <RefreshCw className="w-4 h-4" aria-hidden />

--- a/dashboard/src/components/flows/FlowRow.tsx
+++ b/dashboard/src/components/flows/FlowRow.tsx
@@ -48,7 +48,7 @@ export function FlowRow({ process, isSelected = false, onSelect }: FlowRowProps)
       aria-selected={isSelected}
       className={[
         'group flex items-start gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800',
-        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
+        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-200/80 dark:focus:bg-slate-800/80',
         'transition-colors duration-75',
         isSelected ? 'bg-slate-200/80 dark:bg-slate-800/80 border-l-2 border-l-sky-500' : '',
       ].filter(Boolean).join(' ')}

--- a/dashboard/src/components/layout/GroupSelector.tsx
+++ b/dashboard/src/components/layout/GroupSelector.tsx
@@ -163,10 +163,10 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
         onClick={() => (open ? closePanel() : openPanel())}
         className={[
           'flex items-center gap-1.5 px-3 py-1.5 rounded text-sm transition-colors',
-          'border border-slate-700',
+          'border border-slate-200 dark:border-slate-700',
           open
-            ? 'bg-slate-800 text-slate-200 border-sky-500'
-            : 'bg-slate-900 text-slate-400 hover:bg-slate-800 hover:text-slate-200',
+            ? 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-200 border-sky-500'
+            : 'bg-white dark:bg-slate-900 text-slate-600 dark:text-slate-400 hover:bg-slate-100 dark:hover:bg-slate-800 hover:text-slate-900 dark:hover:text-slate-200',
         ].join(' ')}
         data-testid="group-selector-trigger"
       >
@@ -188,10 +188,10 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
           className={[
             // Mobile: fixed full-screen sheet from top
             'sm:absolute sm:right-0 sm:top-full sm:mt-1 sm:w-72',
-            'sm:max-h-[min(480px,80vh)] sm:rounded-lg sm:shadow-xl sm:border sm:border-slate-700',
+            'sm:max-h-[min(480px,80vh)] sm:rounded-lg sm:shadow-xl sm:border sm:border-slate-200 dark:sm:border-slate-700',
             // Mobile overrides applied below via fixed
             'fixed sm:static inset-x-0 top-12 bottom-0 sm:inset-auto',
-            'bg-slate-950 z-50 flex flex-col',
+            'bg-white dark:bg-slate-950 z-50 flex flex-col',
           ].join(' ')}
           role="dialog"
           aria-modal="false"
@@ -199,24 +199,24 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
           data-testid="group-selector-panel"
         >
           {/* Mobile close strip */}
-          <div className="flex items-center justify-between px-3 py-2 border-b border-slate-800 sm:hidden">
-            <span className="text-xs font-semibold text-slate-400 uppercase tracking-wider">
+          <div className="flex items-center justify-between px-3 py-2 border-b border-slate-200 dark:border-slate-800 sm:hidden">
+            <span className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
               Switch group
             </span>
             <button
               type="button"
               aria-label="Close"
               onClick={closePanel}
-              className="p-1 rounded text-slate-500 hover:text-slate-300"
+              className="p-1 rounded text-slate-500 hover:text-slate-700 dark:hover:text-slate-300"
             >
               <X className="w-4 h-4" />
             </button>
           </div>
 
           {/* Search input */}
-          <div className="relative px-3 py-2 border-b border-slate-800">
+          <div className="relative px-3 py-2 border-b border-slate-200 dark:border-slate-800">
             <Search
-              className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-600 pointer-events-none"
+              className="absolute left-5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400 dark:text-slate-600 pointer-events-none"
               aria-hidden
             />
             <input
@@ -227,8 +227,8 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
               onChange={(e) => setQuery(e.target.value)}
               aria-label="Filter groups"
               className={[
-                'w-full bg-slate-900 border border-slate-700 rounded text-xs',
-                'pl-7 pr-2 py-1.5 text-slate-300 placeholder-slate-600',
+                'w-full bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded text-xs',
+                'pl-7 pr-2 py-1.5 text-slate-700 dark:text-slate-300 placeholder-slate-400 dark:placeholder-slate-600',
                 'focus:outline-none focus:ring-1 focus:ring-sky-500 focus:border-sky-500',
               ].join(' ')}
               data-testid="group-selector-search"
@@ -238,7 +238,7 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
           {/* Scrollable list */}
           <div className="overflow-y-auto flex-1" role="listbox" aria-label="Groups">
             {pinned.length === 0 && others.length === 0 && (
-              <p className="px-4 py-3 text-xs text-slate-600 select-none">
+              <p className="px-4 py-3 text-xs text-slate-500 dark:text-slate-600 select-none">
                 No groups match
               </p>
             )}
@@ -274,7 +274,7 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
   return (
     <div>
       {label && (
-        <p className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-slate-600 font-semibold select-none">
+        <p className="px-3 pt-2 pb-1 text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-600 font-semibold select-none">
           {label}
         </p>
       )}
@@ -295,8 +295,8 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
                   'group w-full flex items-center gap-2 px-3 py-2 text-xs text-left transition-colors',
                   'border-l-2',
                   isActive
-                    ? 'bg-slate-800 border-sky-500 text-slate-100'
-                    : 'border-transparent text-slate-400 hover:bg-slate-800/60 hover:text-slate-300',
+                    ? 'bg-slate-100 dark:bg-slate-800 border-sky-500 text-slate-900 dark:text-slate-100'
+                    : 'border-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100/60 dark:hover:bg-slate-800/60 hover:text-slate-800 dark:hover:text-slate-300',
                 ].join(' ')}
               >
                 {/* Group name */}
@@ -321,7 +321,7 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
                     'p-0.5 rounded transition-colors cursor-pointer',
                     isPinned
                       ? 'text-sky-400 opacity-100'
-                      : 'text-slate-600 opacity-0 group-hover:opacity-100',
+                      : 'text-slate-400 dark:text-slate-600 opacity-0 group-hover:opacity-100',
                     'hover:text-sky-300',
                   ].join(' ')}
                 >

--- a/dashboard/src/components/layout/VersionPopover.tsx
+++ b/dashboard/src/components/layout/VersionPopover.tsx
@@ -129,7 +129,7 @@ export function VersionPopover() {
         aria-expanded={open}
         aria-haspopup="true"
         onClick={() => setOpen((v) => !v)}
-        className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+        className="p-1.5 rounded text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
         data-testid="version-info-trigger"
       >
         <Info className="w-4 h-4" />
@@ -141,18 +141,18 @@ export function VersionPopover() {
           role="dialog"
           aria-label="Version info panel"
           data-testid="version-info-panel"
-          className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border border-slate-700 bg-slate-900 shadow-xl text-sm"
+          className="absolute right-0 top-full mt-1 z-50 w-72 rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-xl text-sm"
         >
           {/* Header */}
-          <div className="px-4 py-3 border-b border-slate-800">
-            <p className="font-semibold text-slate-100 tracking-tight">archigraph</p>
+          <div className="px-4 py-3 border-b border-slate-200 dark:border-slate-800">
+            <p className="font-semibold text-slate-900 dark:text-slate-100 tracking-tight">archigraph</p>
             {info ? (
-              <p className="text-slate-400 mt-0.5">
+              <p className="text-slate-600 dark:text-slate-400 mt-0.5">
                 Version{' '}
-                <span className="text-slate-200 font-mono">{info.version}</span>
+                <span className="text-slate-800 dark:text-slate-200 font-mono">{info.version}</span>
               </p>
             ) : error ? (
-              <p className="text-red-400 mt-0.5">{error}</p>
+              <p className="text-red-600 dark:text-red-400 mt-0.5">{error}</p>
             ) : (
               <p className="text-slate-500 mt-0.5">Loading…</p>
             )}
@@ -162,7 +162,7 @@ export function VersionPopover() {
           {info && (
             <div className="px-4 py-3 space-y-2">
               {/* Commit */}
-              <div className="flex items-center gap-2 text-slate-400">
+              <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400">
                 <GitCommit className="w-3.5 h-3.5 flex-shrink-0" />
                 <span className="flex-1 truncate">
                   Commit:{' '}
@@ -171,23 +171,23 @@ export function VersionPopover() {
                       href={commitUrl}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-sky-400 hover:text-sky-300 font-mono"
+                      className="text-sky-600 dark:text-sky-400 hover:text-sky-500 dark:hover:text-sky-300 font-mono"
                     >
                       {commitSHA}
                     </a>
                   ) : (
-                    <span className="text-slate-300 font-mono">{commitSHA}</span>
+                    <span className="text-slate-700 dark:text-slate-300 font-mono">{commitSHA}</span>
                   )}
                 </span>
               </div>
 
               {/* Built */}
               {info.built_at && info.built_at !== 'unknown' && (
-                <div className="flex items-center gap-2 text-slate-400">
+                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400">
                   <Clock className="w-3.5 h-3.5 flex-shrink-0" />
                   <span>
                     Built:{' '}
-                    <span className="text-slate-300" title={info.built_at}>
+                    <span className="text-slate-700 dark:text-slate-300" title={info.built_at}>
                       {relativeTime(info.built_at)}
                     </span>
                   </span>
@@ -196,21 +196,21 @@ export function VersionPopover() {
 
               {/* Daemon uptime */}
               {info.daemon_started_at && (
-                <div className="flex items-center gap-2 text-slate-400">
+                <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400">
                   <Clock className="w-3.5 h-3.5 flex-shrink-0" />
                   <span>
                     Daemon uptime:{' '}
-                    <span className="text-slate-300">{fmtUptime(info.daemon_started_at)}</span>
+                    <span className="text-slate-700 dark:text-slate-300">{fmtUptime(info.daemon_started_at)}</span>
                   </span>
                 </div>
               )}
 
               {/* Dashboard URL */}
-              <div className="flex items-center gap-2 text-slate-400">
+              <div className="flex items-center gap-2 text-slate-600 dark:text-slate-400">
                 <Globe className="w-3.5 h-3.5 flex-shrink-0" />
                 <span className="truncate">
                   Dashboard:{' '}
-                  <span className="text-slate-300 font-mono text-xs">{dashboardUrl}</span>
+                  <span className="text-slate-700 dark:text-slate-300 font-mono text-xs">{dashboardUrl}</span>
                 </span>
               </div>
             </div>
@@ -219,7 +219,7 @@ export function VersionPopover() {
           {/* Debug mode extras */}
           {IS_DEBUG && (
             <>
-              <div className="mx-4 border-t border-slate-800" />
+              <div className="mx-4 border-t border-slate-200 dark:border-slate-800" />
               <div className="px-4 py-2 text-xs text-amber-400">
                 Build mode:{' '}
                 {USE_MOCKS ? 'development (mocks)' : 'real-data (debug)'}
@@ -228,7 +228,7 @@ export function VersionPopover() {
           )}
 
           {/* Footer divider + GitHub link */}
-          <div className="mx-4 border-t border-slate-800" />
+          <div className="mx-4 border-t border-slate-200 dark:border-slate-800" />
           <div className="px-4 py-2">
             <a
               href="https://github.com/cajasmota/archigraph"

--- a/dashboard/src/components/paths/PathRow.tsx
+++ b/dashboard/src/components/paths/PathRow.tsx
@@ -37,7 +37,7 @@ export function PathRow({ path, group, isSelected = false, onSelect }: PathRowPr
       aria-selected={isSelected}
       className={[
         'group flex items-center gap-3 px-4 py-2.5 border-b border-slate-200 dark:border-slate-800',
-        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/80',
+        'cursor-pointer hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-200/80 dark:focus:bg-slate-800/80',
         'transition-colors duration-75',
         isSelected ? 'bg-slate-200/80 dark:bg-slate-800/80 border-l-2 border-l-sky-500' : '',
       ].filter(Boolean).join(' ')}

--- a/dashboard/src/components/paths/PathsGroup.tsx
+++ b/dashboard/src/components/paths/PathsGroup.tsx
@@ -70,7 +70,7 @@ export function PathsGroup({ group, isExpanded, onToggle, children }: PathsGroup
         className={[
           'w-full flex items-center gap-2 px-3 py-2',
           'bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800',
-          'hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-800/60',
+          'hover:bg-slate-200/60 dark:hover:bg-slate-800/60 focus:outline-none focus:bg-slate-200/60 dark:focus:bg-slate-800/60',
           'transition-colors duration-75 cursor-pointer',
           'sticky top-0 z-10',
         ].join(' ')}

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -35,9 +35,9 @@ export function AppLayout() {
   }, [])
 
   return (
-    <div className="flex flex-col h-screen bg-slate-950 text-slate-200">
+    <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
       {/* ── Top nav ──────────────────────────────────────────────────────────── */}
-      <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-800 flex-shrink-0 bg-slate-950/90 backdrop-blur-sm z-20">
+      <header className="flex items-center gap-4 px-4 h-12 border-b border-slate-200 dark:border-slate-800 flex-shrink-0 bg-white/90 dark:bg-slate-950/90 backdrop-blur-sm z-20">
         {/* Logo */}
         <Link to="/" className="flex items-center gap-2 font-bold text-sm tracking-tight text-sky-400 hover:text-sky-300">
           <GitBranch className="w-5 h-5" aria-hidden />
@@ -85,8 +85,8 @@ function NavItem({ to, icon, label }: NavItemProps) {
           'flex items-center gap-1.5 px-2 py-1.5 rounded text-sm transition-colors',
           'sm:px-3',
           isActive
-            ? 'bg-slate-800 text-slate-200'
-            : 'text-slate-500 hover:bg-slate-800/60 hover:text-slate-300',
+            ? 'bg-slate-100 dark:bg-slate-800 text-slate-900 dark:text-slate-200'
+            : 'text-slate-500 hover:bg-slate-100/60 dark:hover:bg-slate-800/60 hover:text-slate-700 dark:hover:text-slate-300',
         ].join(' ')
       }
     >
@@ -103,7 +103,7 @@ function ThemeToggle() {
     <button
       type="button"
       aria-label={isDark ? 'Switch to light mode' : 'Switch to dark mode'}
-      className="p-1.5 rounded text-slate-500 hover:text-slate-300 hover:bg-slate-800 transition-colors"
+      className="p-1.5 rounded text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
       onClick={toggle}
     >
       {isDark ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}


### PR DESCRIPTION
## Summary

Seven components escaped the `dark:`-prefix sweep from #993 and continued to render dark slate backgrounds/text regardless of theme. This PR adds light-mode equivalents to every unprefixed `bg-slate-{800,900,950}`, `border-slate-{700,800}`, and `text-slate-{100,200,300}` class in these files.

**Files changed:**
- `routes/_layout.tsx` — AppLayout outer wrapper, header bar, NavItem active/hover, ThemeToggle hover
- `components/layout/GroupSelector.tsx` — trigger button, dropdown panel bg, search input, mobile close strip, section labels, row active/hover states
- `components/layout/VersionPopover.tsx` — trigger button hover, panel border/bg, header text, all detail row text
- `components/docs/DocsEmptyState.tsx` — icon circle, heading, body text, code snippets, retry button
- `components/paths/PathRow.tsx` — `focus:bg-slate-800/80` → paired with `focus:bg-slate-200/80`
- `components/paths/PathsGroup.tsx` — `focus:bg-slate-800/60` → paired with `focus:bg-slate-200/60`
- `components/flows/FlowRow.tsx` — same focus-state fix as PathRow

## Closes / Refs

Refs #981

## Visual verification

Light mode (default — no `archigraph:theme` in localStorage):
- Top nav: white background, dark text on active nav chip, sky-400 logo — ✓ light
- Left path-list panel: white row backgrounds, light-gray group header bands — ✓ **BUG FIXED**
- Group headers: `bg-slate-100/80` on sticky headers, `bg-slate-200` count badges — ✓ light
- Path rows: transparent background (rgba(0,0,0,0) confirmed via `getComputedStyle`) — ✓ light
- Method distribution mini-bars: semantic verb colors retained (emerald/blue/orange/red) — ✓ unaffected
- Flows surface: white row backgrounds, dark-on-light repo chips — ✓ light
- Topology surface: fully light — ✓
- Docs surface: fully light — ✓

Dark mode (toggled via header button):
- All surfaces returned to full dark — ✓ no regression

## Testing

- [x] `vite build` succeeds (pre-existing `tsc -b` react-native typedef conflict is in main too — not introduced here)
- [x] Playwright visual verification on `/paths/upvate`, `/flows/upvate`, `/topology/upvate`, `/docs/upvate`
- [x] `getComputedStyle(rows[0]).backgroundColor` returns `rgba(0, 0, 0, 0)` in light mode (was `rgb(15, 23, 42)` = slate-950 before fix)
- [x] No console errors on any surface

## Notes

The `bg-slate-500/400` verb-bar colors in `PathsGroup.tsx` (HEAD/OPTIONS/ANY) are mid-gray semantic accents that work in both modes — left untouched per the "semantic accent = leave alone" rule.