### PR TITLE
[#44] C# resolver slice 7: Quartz.NET builder + generic-factory CALLS → Dynamic

### DIFF
--- a/cmd/archigraph/index_test.go
+++ b/cmd/archigraph/index_test.go
@@ -617,6 +617,56 @@ func TestScopePatternContains_AllPatternsHaveContainsEdge(t *testing.T) {
 	}
 }
 
+// TestCSharpQuartzNetBuilderDynamic verifies that Quartz.NET fluent builder
+// method stubs and generic static-factory calls emitted by the C# extractor
+// (JobBuilder.Create<T>, TriggerBuilder.Create<T>, WithIdentity, StartNow,
+// BackgroundJob.Enqueue<T>) classify as DispositionDynamic rather than
+// DispositionBugExtractor after the fix in issue #44 slice-7.
+//
+// The fix extends csharpDynamicPatterns in internal/resolve/refs.go with:
+//   - a generic-factory pattern matching PascalCase.PascalCase<...> stubs, and
+//   - bare-name patterns for Quartz.NET builder leaf methods (WithIdentity,
+//     StartNow).
+//
+// Without the fix the csharp-quartz-net-mini fixture has 4 bug-extractor edges
+// (StartNow, WithIdentity, JobBuilder.Create<EmailJob>,
+// JobBuilder.Create<ReportJob>). After the fix all 4 move to dynamic and
+// bug-extractor drops to 0 for that fixture.
+func TestCSharpQuartzNetBuilderDynamic(t *testing.T) {
+	fixtureDir := filepath.Join("../../internal/quality/golden/csharp-quartz-net-mini/src")
+	abs, err := filepath.Abs(fixtureDir)
+	if err != nil {
+		t.Fatalf("abs: %v", err)
+	}
+	if _, serr := os.Stat(abs); serr != nil {
+		t.Skipf("csharp-quartz-net-mini fixture not found at %s: %v", abs, serr)
+	}
+
+	idx := newTestIndexer(t, "csharp-quartz-net-mini", nil)
+	doc, err := idx.Run(context.Background(), abs)
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if doc == nil {
+		t.Fatal("Run returned nil document")
+	}
+
+	// Pre-fix baseline: 4 bug-extractor (StartNow, WithIdentity,
+	// JobBuilder.Create<EmailJob>, JobBuilder.Create<ReportJob>).
+	// Post-fix: all 4 move to dynamic; bug-extractor must be 0.
+	bugCount := idx.finalDispositions.DispositionCounts[resolve.DispositionBugExtractor]
+	dynCount := idx.finalDispositions.DispositionCounts[resolve.DispositionDynamic]
+
+	if bugCount >= 4 {
+		samples := idx.finalDispositions.DispositionSamples[resolve.DispositionBugExtractor]
+		t.Errorf("bug-extractor count = %d (want < 4, pre-fix baseline); dynamic = %d; samples = %v",
+			bugCount, dynCount, samples)
+	}
+	if dynCount == 0 {
+		t.Errorf("dynamic count = 0, expected > 0 after Quartz.NET builder fix")
+	}
+}
+
 // TestKotlinSpringResponseEntityDynamic verifies that the Spring MVC
 // ResponseEntity fluent builder method stubs emitted by the Kotlin extractor
 // (notFound, ok, build, body, noContent) classify as DispositionDynamic

--- a/internal/quality/golden/csharp-aspnet-core-mini/expected.json
+++ b/internal/quality/golden/csharp-aspnet-core-mini/expected.json
@@ -1,0 +1,42 @@
+{
+  "fixture_name": "csharp-aspnet-core-mini",
+  "language": "csharp",
+  "description": "Minimal ASP.NET Core Web API project with [ApiController], [HttpGet/Post/Delete] action methods, and DI via constructor injection. Used to verify IActionResult return-helper CALLS (Ok, NotFound, BadRequest, NoContent, CreatedAtAction) are not classified as bug-extractor after the Quartz.NET / generic-factory fix in issue #44.",
+  "expected_entities": [
+    {
+      "name": "UsersController",
+      "kind": "SCOPE.Component",
+      "source_file": "Controllers/UsersController.cs",
+      "must_exist": true,
+      "note": "ASP.NET Core ApiController with DI constructor."
+    },
+    {
+      "name": "UsersController.GetById",
+      "kind": "SCOPE.Operation",
+      "source_file": "Controllers/UsersController.cs",
+      "must_exist": true,
+      "note": "HttpGet action returning Ok/NotFound."
+    },
+    {
+      "name": "UsersController.Create",
+      "kind": "SCOPE.Operation",
+      "source_file": "Controllers/UsersController.cs",
+      "must_exist": true,
+      "note": "HttpPost action returning BadRequest/CreatedAtAction."
+    },
+    {
+      "name": "UsersController.Delete",
+      "kind": "SCOPE.Operation",
+      "source_file": "Controllers/UsersController.cs",
+      "must_exist": true,
+      "note": "HttpDelete action returning NotFound/NoContent."
+    },
+    {
+      "name": "UserService",
+      "kind": "SCOPE.Component",
+      "source_file": "Services/UserService.cs",
+      "must_exist": true,
+      "note": "IUserService implementation."
+    }
+  ]
+}

--- a/internal/quality/golden/csharp-aspnet-core-mini/src/Controllers/UsersController.cs
+++ b/internal/quality/golden/csharp-aspnet-core-mini/src/Controllers/UsersController.cs
@@ -1,0 +1,45 @@
+using Microsoft.AspNetCore.Mvc;
+using System.Threading.Tasks;
+
+namespace AspNetCoreMini.Controllers
+{
+    [ApiController]
+    [Route("api/[controller]")]
+    public class UsersController : ControllerBase
+    {
+        private readonly IUserService _userService;
+
+        public UsersController(IUserService userService)
+        {
+            _userService = userService;
+        }
+
+        [HttpGet("{id}")]
+        public async Task<IActionResult> GetById(int id)
+        {
+            var user = await _userService.GetByIdAsync(id);
+            if (user == null)
+                return NotFound();
+            return Ok(user);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Create([FromBody] CreateUserRequest request)
+        {
+            if (!ModelState.IsValid)
+                return BadRequest(ModelState);
+
+            var user = await _userService.CreateAsync(request);
+            return CreatedAtAction(nameof(GetById), new { id = user.Id }, user);
+        }
+
+        [HttpDelete("{id}")]
+        public async Task<IActionResult> Delete(int id)
+        {
+            var deleted = await _userService.DeleteAsync(id);
+            if (!deleted)
+                return NotFound();
+            return NoContent();
+        }
+    }
+}

--- a/internal/quality/golden/csharp-aspnet-core-mini/src/Services/UserService.cs
+++ b/internal/quality/golden/csharp-aspnet-core-mini/src/Services/UserService.cs
@@ -1,0 +1,23 @@
+using System.Threading.Tasks;
+
+namespace AspNetCoreMini.Services
+{
+    public class UserService : IUserService
+    {
+        public async Task<User> GetByIdAsync(int id)
+        {
+            // stubbed: real impl would query a DbContext
+            return null;
+        }
+
+        public async Task<User> CreateAsync(CreateUserRequest request)
+        {
+            return new User { Id = 1, Name = request.Name };
+        }
+
+        public async Task<bool> DeleteAsync(int id)
+        {
+            return true;
+        }
+    }
+}

--- a/internal/resolve/dynamic_patterns_test.go
+++ b/internal/resolve/dynamic_patterns_test.go
@@ -347,6 +347,28 @@ func TestDynamicPatterns_Catalog(t *testing.T) {
 		{"scala_list_map_go_neg", "go", `List.map`, false},
 		{"scala_map_get_python_neg", "python", `Map.get`, false},
 		{"scala_map_get_go_neg", "go", `Map.get`, false},
+
+		// ---- Quartz.NET / Hangfire C# fluent builder + generic factory (issue #44) ---
+		// Quartz.NET: JobBuilder.Create<T>() / TriggerBuilder.Create<T>() generic calls
+		// land as dotted + generic stubs that the existing PascalCase-dotted pattern
+		// cannot match (it rejects the `<` suffix). The new generic-factory pattern
+		// promotes them to Dynamic instead of BugExtractor.
+		{"quartz_jobbuilder_create_generic", "csharp", `JobBuilder.Create<ReportJob>`, true},
+		{"quartz_jobbuilder_create_email", "csharp", `JobBuilder.Create<EmailJob>`, true},
+		{"quartz_triggerbuilder_create_generic", "csharp", `TriggerBuilder.Create<DailyTrigger>`, true},
+		// Hangfire: BackgroundJob.Enqueue<T>() / RecurringJob.AddOrUpdate<T>()
+		{"hangfire_backgroundjob_enqueue_generic", "csharp", `BackgroundJob.Enqueue<IEmailService>`, true},
+		{"hangfire_recurringjob_addorupdate_generic", "csharp", `RecurringJob.AddOrUpdate<IReportService>`, true},
+		// Quartz.NET fluent builder bare-name leaf methods.
+		{"quartz_withidentity", "csharp", `WithIdentity`, true},
+		{"quartz_startnow", "csharp", `StartNow`, true},
+		// Cross-language gate: Quartz.NET patterns MUST NOT fire for non-C# languages.
+		{"quartz_withidentity_go_neg", "go", `WithIdentity`, false},
+		{"quartz_startnow_python_neg", "python", `StartNow`, false},
+		{"quartz_withidentity_java_neg", "java", `WithIdentity`, false},
+		{"quartz_generic_factory_go_neg", "go", `JobBuilder.Create<ReportJob>`, false},
+		{"quartz_generic_factory_python_neg", "python", `BackgroundJob.Enqueue<IEmailService>`, false},
+		{"quartz_generic_factory_ts_neg", "typescript", `JobBuilder.Create<EmailJob>`, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1286,6 +1286,30 @@ var (
 		// / Microsoft / EF Core ecosystem roots at the caller (handled in
 		// isDynamicPatternLang via a startsWith check before regex eval).
 		regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*(?:\.[A-Z][A-Za-z0-9_]*)+$`),
+
+		// Issue #44 — Quartz.NET / Hangfire generic static-factory calls.
+		// The C# extractor emits `JobBuilder.Create<ReportJob>` and
+		// `BackgroundJob.Enqueue<IEmailService>` as bare CALLS stubs when the
+		// receiver type carries a generic type argument. The existing PascalCase-
+		// dotted pattern above only matches stubs without a `<` suffix; these
+		// generic forms fall through to BugExtractor. Pattern: PascalCase
+		// dotted identifier immediately followed by `<` (the opening of the
+		// type-argument list). C#-language gate keeps this from firing on
+		// non-.NET codebases (Go generics, TypeScript generics, etc.).
+		regexp.MustCompile(`^[A-Z][A-Za-z0-9_]*\.[A-Z][A-Za-z0-9_]*<`),
+
+		// Issue #44 — Quartz.NET fluent builder bare-name leaf methods.
+		// The Quartz.NET JobBuilder / TriggerBuilder API uses a fluent chain:
+		//   JobBuilder.Create<T>().WithIdentity("name").Build()
+		//   TriggerBuilder.Create().WithIdentity("t").StartNow().Build()
+		// After the extractor strips the receiver the bare method leaves
+		// `WithIdentity` and `StartNow` land in BugExtractor because they
+		// are not in any allowlist. Without full type inference the resolver
+		// cannot bind these to the Quartz.NET builder — Dynamic is the
+		// correct disposition. C#-language gate (#94 safer-bias rule) keeps
+		// these from polluting non-.NET graphs.
+		regexp.MustCompile(`^WithIdentity$`), // JobBuilder/TriggerBuilder.WithIdentity(...)
+		regexp.MustCompile(`^StartNow$`),     // TriggerBuilder.StartNow()
 	}
 
 	// csharpExternalNamespaceRoots lists the dotted namespace roots that


### PR DESCRIPTION
## What

Seventh resolver slice for issue #44 — C# language. Fixes the highest-count unresolved CALLS category on `csharp-quartz-net-mini`: Quartz.NET fluent builder method leaves and generic static-factory calls that fell through to `bug-extractor`.

## Root cause

The C# extractor emits `JobBuilder.Create<ReportJob>` and `BackgroundJob.Enqueue<IEmailService>` as bare CALLS stubs when the method name carries a generic type argument. The existing `csharpDynamicPatterns` PascalCase-dotted pattern (`^[A-Z]...[A-Z]+\$`) rejects stubs containing `<` — so all generic static-factory calls landed in `bug-extractor` instead of `dynamic`. Similarly, Quartz.NET fluent builder leaves (`WithIdentity`, `StartNow`) had no catalog entry.

## Fix

Extended `csharpDynamicPatterns` in \`internal/resolve/refs.go\` with three new patterns, all C#-language-gated (#94 safer-bias rule):

| Pattern | Covers |
|---|---|
| \`^[A-Z][A-Za-z0-9_]*\.[A-Z][A-Za-z0-9_]*<\` | \`JobBuilder.Create<T>\`, \`BackgroundJob.Enqueue<T>\`, \`TriggerBuilder.Create<T>\`, \`RecurringJob.AddOrUpdate<T>\` |
| \`^WithIdentity\$\` | Quartz.NET \`JobBuilder/TriggerBuilder.WithIdentity(...)\` |
| \`^StartNow\$\` | Quartz.NET \`TriggerBuilder.StartNow()\` |

C#-language gate prevents these patterns from firing on Go generics, TypeScript generics, JVM, Python, or Ruby.

## Audit numbers

| Fixture | Before | After | Change |
|---|---|---|---|
| csharp-quartz-net-mini | Bug=4 (21.43%) | Bug=0 (7.14%) | -100% target category |
| csharp-hangfire-mini | Bug=2 (14.29%) | Bug=1 (10.71%) | generic enqueue fixed |

Target category (Quartz.NET builder + generic factory) dropped 100% (>=50% required). Remaining \`SendNewsletter\` in hangfire is a user-defined interface method call — a different category, not a framework stub.

## Tests added

- 12 new rows in \`internal/resolve/dynamic_patterns_test.go\`: positive C# gate tests + cross-language negative gate tests (go/python/java/typescript must NOT fire)
- \`TestCSharpQuartzNetBuilderDynamic\` integration test in \`cmd/archigraph/index_test.go\` — end-to-end: indexes \`csharp-quartz-net-mini\`, asserts \`bug-extractor < 4\` and \`dynamic > 0\`
- New \`csharp-aspnet-core-mini\` golden fixture (ASP.NET Core UsersController with DI + IActionResult return helpers) for future ASP.NET Core slice coverage

## Verification

\`\`\`
go test ./internal/extractors/csharp/... ./internal/resolve/...  # PASS
go test -run TestCSharpQuartzNetBuilderDynamic ./cmd/archigraph/  # PASS
\`\`\`

Refs #44