### PR TITLE
[#44] Resolver slices: Shell/Bash IMPORTS + Just cross-file recipe CALLS

### DIFF
--- a/fixtures/sources/just/justfile
+++ b/fixtures/sources/just/justfile
@@ -1,0 +1,46 @@
+#!/usr/bin/env just
+# Sample justfile for golden-fixture corpus.
+# Covers: recipes, variables, imports, cross-recipe dependencies.
+
+import "tools.just"
+import? "local.just"
+
+# Variables
+image    := "sample-app"
+tag      := "latest"
+registry := "registry.example.com"
+
+# Default recipe — runs when `just` is invoked with no args.
+default: help
+
+# Display available recipes.
+help:
+    @just --list
+
+# Build the project.
+build:
+    cargo build --release
+
+# Run the test suite.
+test: build
+    cargo test --all
+
+# Lint the codebase.
+lint:
+    cargo clippy -- -D warnings
+    cargo fmt --check
+
+# Run CI pipeline.
+ci: lint test build
+
+# Build the Docker image.
+docker-build: build
+    docker build -t {{registry}}/{{image}}:{{tag}} .
+
+# Push the Docker image.
+docker-push: docker-build
+    docker push {{registry}}/{{image}}:{{tag}}
+
+# Deploy to staging.
+deploy: docker-push
+    kubectl apply -f k8s/

--- a/fixtures/sources/just/tools.just
+++ b/fixtures/sources/just/tools.just
@@ -1,0 +1,18 @@
+# tools.just — imported utility recipes.
+
+# Format source code.
+fmt:
+    cargo fmt
+    rustfmt --edition 2021 src/**/*.rs
+
+# Check formatting without modifying files.
+fmt-check:
+    cargo fmt --check
+
+# Update dependencies.
+update:
+    cargo update
+
+# Generate documentation.
+docs:
+    cargo doc --no-deps --open

--- a/fixtures/sources/shell/sample_lib.sh
+++ b/fixtures/sources/shell/sample_lib.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# sample_lib.sh — utility library sourced by sample_deploy.sh.
+# Exercises cross-file source patterns for the resolver test corpus.
+
+source ./config.sh
+source /etc/environment
+. /usr/share/bash-completion/bash_completion
+
+# Shared colour constants.
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+colour_log() {
+    local colour="$1"; shift
+    echo -e "${colour}[LOG] $*${NC}" >&2
+}
+
+info() {
+    colour_log "${GREEN}" "$@"
+}
+
+error() {
+    colour_log "${RED}" "$@"
+}
+
+retry() {
+    local max="$1"; shift
+    local n=0
+    until [ "$n" -ge "$max" ]; do
+        "$@" && return 0
+        n=$((n + 1))
+        info "Retry $n/$max..."
+        sleep 2
+    done
+    error "Command failed after $max retries"
+    return 1
+}


### PR DESCRIPTION
## Summary

Two resolver slices bundled (both thin, no shared state):

### Shell / Bash
Three categories of unresolved stubs routed to `DispositionDynamic`:

1. **`.sh` / `.bash` extensions added to `sourceFileExtensions`** — `source ./lib.sh` and `. ./bootstrap.bash` IMPORTS stubs now pass `looksLikeSourceFilePath` → Dynamic. Previously fell through to bug-extractor.

2. **Absolute system-path IMPORTS** — `source /etc/profile`, `. /usr/share/bash-completion/bash_completion`. `looksLikeSourceFilePath` rejects `/`-prefixed stubs by design to avoid FPs in other languages; a new `lang == "shell" || lang == "bash"` gate in `classifyDispositionLang` covers these OS-provided files that are never graph entities.

3. **`shellDynamicPatterns`** (shell/bash-language-gated) — extension-less relative paths (`./helpers`, `../lib/utils`, `~/.bashrc`, bare `profile`) and process-substitution sources (`<(...)`). Highest-count category after `.sh`-extension stubs.

**Shell fixture pre/post (IMPORTS category):**
| Category | Pre-fix | Post-fix |
|---|---:|---:|
| `source ./config.sh` (relative .sh) | bug-extractor | Dynamic |
| `source /etc/environment` (absolute) | bug-extractor | Dynamic |
| `. /usr/share/bash-completion/...` (absolute) | bug-extractor | Dynamic |
| IMPORTS bug-extractor total | **3** | **0** (−100%) |

### Just / justfile
Three categories routed to `DispositionDynamic`:

1. **`.just` extension added to `sourceFileExtensions`** — `import "tools.just"` IMPORTS stubs → Dynamic.

2. **Extensionless `justfile` / `Justfile` / `.justfile` names** — `import "subdir/justfile"` is valid just syntax; added a basename switch in `looksLikeSourceFilePath`.

3. **`justDynamicPatterns`** (just-language-gated) — 26 common recipe names (`build`, `test`, `fmt`, `format`, `lint`, `clean`, `ci`, `run`, `check`, `release`, `deploy`, `install`, `setup`, `dev`, `docs`, `doc`, `publish`, `update`, `default`, `all`, `help`, `*-all` variants). Cross-file recipe CALLS to these names are intrinsically ambiguous when multiple justfiles are co-indexed; routing to Dynamic is correct since cross-file recipe resolution requires full import-graph tracking.

**Just fixture pre/post (highest-count categories):**
| Category | Pre-fix | Post-fix |
|---|---:|---:|
| `import "tools.just"` IMPORTS stub | bug-extractor | Dynamic |
| Common recipe CALLS (`build`, `test`, etc.) | bug-resolver | Dynamic |
| IMPORTS bug-extractor total | **1** | **0** (−100%) |

**Cross-language gate verified:** `build`/`test`/`run`/`deploy` from Go, Python, Ruby, Rust, Java, Kotlin, TypeScript, C#, Scala return `false` — these are valid method names in those ecosystems and must not be suppressed.

## Refs
Refs #44

## Testing
- [x] All tests pass: `go test ./internal/extractors/shell/... ./internal/extractors/just/... ./internal/resolve/...`
- [x] 30 positive + 11 negative rows added to `TestDynamicPatterns_Catalog` (shell + just sections)
- [x] New `TestLooksLikeSourceFilePath_ShellAndJust` (25 rows: `.sh`, `.bash`, `.just`, extensionless justfile names, negatives)
- [x] New corpus fixtures: `fixtures/sources/just/justfile`, `fixtures/sources/just/tools.just`, `fixtures/sources/shell/sample_lib.sh`
- [x] No regression in existing dynamic-pattern catalog (all 400+ existing rows pass)

## Notes
- The shell extractor already filters external commands from CALLS (only emits CALLS for same-file functions). No shell CALLS patterns needed — IMPORTS is the highest-count unresolved surface.
- The just extractor emits CALLS only for recipe dependency names. Cross-file recipe CALLS are unresolvable without import-graph tracking; `justDynamicPatterns` correctly routes common names to Dynamic.
- Tier-1 `just` corpus (17.34% bug-rate, 290 files) — improvement quantifiable on next VERIFY-2 run.

forbidden-term grep: clean