### PR TITLE
[#44] Resolver slice 9: Elixir Ecto/Phoenix/OTP/Changeset dynamic-pattern catalog

### DIFF
--- a/internal/quality/golden/elixir-phoenix-mini/expected.json
+++ b/internal/quality/golden/elixir-phoenix-mini/expected.json
@@ -1,0 +1,75 @@
+{
+  "fixture_name": "elixir-phoenix-mini",
+  "language": "elixir",
+  "description": "Small Phoenix/Ecto application exercising a controller, an Ecto schema with a changeset pipeline, a repository context wrapping Ecto.Repo operations, and a GenServer cache. Used by the extraction-quality benchmark to detect recall regressions in the elixir extractor + Elixir-gated dynamic-pattern resolver path.",
+  "expected_entities": [
+    { "name": "DemoWeb.UserController", "kind": "SCOPE.Component", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true, "note": "Phoenix controller module." },
+    { "name": "index", "kind": "SCOPE.Operation", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true },
+    { "name": "show", "kind": "SCOPE.Operation", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true },
+    { "name": "create", "kind": "SCOPE.Operation", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true },
+    { "name": "update", "kind": "SCOPE.Operation", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true },
+    { "name": "delete", "kind": "SCOPE.Operation", "source_file": "lib/demo_web/controllers/user_controller.ex", "must_exist": true },
+
+    { "name": "Demo.Schemas.User", "kind": "SCOPE.Component", "source_file": "lib/demo/schemas/user.ex", "must_exist": true, "note": "Ecto schema module." },
+    { "name": "changeset", "kind": "SCOPE.Operation", "source_file": "lib/demo/schemas/user.ex", "must_exist": true, "note": "Ecto changeset builder." },
+
+    { "name": "Demo.UserRepo", "kind": "SCOPE.Component", "source_file": "lib/demo/user_repo.ex", "must_exist": true, "note": "Repository context wrapping Ecto.Repo." },
+    { "name": "list_users", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+    { "name": "get_user!", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+    { "name": "get_user", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+    { "name": "create_user", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+    { "name": "update_user", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+    { "name": "delete_user", "kind": "SCOPE.Operation", "source_file": "lib/demo/user_repo.ex", "must_exist": true },
+
+    { "name": "Demo.CacheServer", "kind": "SCOPE.Component", "source_file": "lib/demo/cache_server.ex", "must_exist": true, "note": "GenServer cache module." },
+    { "name": "start_link", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true },
+    { "name": "init", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true },
+    { "name": "handle_call", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true },
+    { "name": "handle_cast", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true },
+    { "name": "handle_info", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true },
+    { "name": "terminate", "kind": "SCOPE.Operation", "source_file": "lib/demo/cache_server.ex", "must_exist": true }
+  ],
+  "expected_relationships": [
+    { "from_name": "DemoWeb.UserController", "from_kind": "SCOPE.Component", "from_file": "lib/demo_web/controllers/user_controller.ex",
+      "kind": "CONTAINS", "to_name": "index", "to_kind": "SCOPE.Operation", "to_file": "lib/demo_web/controllers/user_controller.ex",
+      "must_exist": true },
+    { "from_name": "DemoWeb.UserController", "from_kind": "SCOPE.Component", "from_file": "lib/demo_web/controllers/user_controller.ex",
+      "kind": "CONTAINS", "to_name": "create", "to_kind": "SCOPE.Operation", "to_file": "lib/demo_web/controllers/user_controller.ex",
+      "must_exist": true },
+    { "from_name": "DemoWeb.UserController", "from_kind": "SCOPE.Component", "from_file": "lib/demo_web/controllers/user_controller.ex",
+      "kind": "CONTAINS", "to_name": "delete", "to_kind": "SCOPE.Operation", "to_file": "lib/demo_web/controllers/user_controller.ex",
+      "must_exist": true },
+
+    { "from_name": "Demo.CacheServer", "from_kind": "SCOPE.Component", "from_file": "lib/demo/cache_server.ex",
+      "kind": "CONTAINS", "to_name": "handle_call", "to_kind": "SCOPE.Operation", "to_file": "lib/demo/cache_server.ex",
+      "must_exist": true },
+    { "from_name": "Demo.CacheServer", "from_kind": "SCOPE.Component", "from_file": "lib/demo/cache_server.ex",
+      "kind": "CONTAINS", "to_name": "handle_cast", "to_kind": "SCOPE.Operation", "to_file": "lib/demo/cache_server.ex",
+      "must_exist": true },
+    { "from_name": "Demo.CacheServer", "from_kind": "SCOPE.Component", "from_file": "lib/demo/cache_server.ex",
+      "kind": "CONTAINS", "to_name": "terminate", "to_kind": "SCOPE.Operation", "to_file": "lib/demo/cache_server.ex",
+      "must_exist": true },
+
+    { "from_name": "index", "from_kind": "SCOPE.Operation", "from_file": "lib/demo_web/controllers/user_controller.ex",
+      "kind": "CALLS", "to_name": "list_users", "to_kind": "SCOPE.Operation", "to_file": "lib/demo/user_repo.ex",
+      "must_exist": true,
+      "note": "Cross-module call: UserController.index → UserRepo.list_users." },
+
+    { "from_name": "list_users", "from_kind": "SCOPE.Operation", "from_file": "lib/demo/user_repo.ex",
+      "kind": "CALLS", "to_bare_name": "all", "must_exist": true,
+      "note": "Ecto.Repo.all — external, not in-tree; classified Dynamic by elixirDynamicPatterns." },
+
+    { "from_name": "changeset", "from_kind": "SCOPE.Operation", "from_file": "lib/demo/schemas/user.ex",
+      "kind": "CALLS", "to_bare_name": "cast", "must_exist": true,
+      "note": "Ecto.Changeset.cast — external macro-injected function; classified Dynamic." },
+
+    { "from_name": "changeset", "from_kind": "SCOPE.Operation", "from_file": "lib/demo/schemas/user.ex",
+      "kind": "CALLS", "to_bare_name": "validate_required", "must_exist": true,
+      "note": "Ecto.Changeset.validate_required — external macro-injected function; classified Dynamic." }
+  ],
+  "forbidden_relationships": [
+    { "from_name": "list_users", "from_kind": "SCOPE.Operation",
+      "kind": "CALLS", "to_bare_name": "Repo",
+      "note": "The receiver alias must NOT appear as a CALLS target — only the trailing method name." }
+  ]
+}

--- a/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/cache_server.ex
+++ b/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/cache_server.ex
@@ -1,0 +1,58 @@
+defmodule Demo.CacheServer do
+  @moduledoc """
+  A GenServer that caches user lookup results in memory.
+  Demonstrates OTP callback patterns: init/1, handle_call/3,
+  handle_cast/2, handle_info/2.
+  """
+
+  use GenServer
+
+  ## Client API
+
+  def start_link(opts \\ []) do
+    GenServer.start_link(__MODULE__, %{}, opts)
+  end
+
+  def get(server, key) do
+    GenServer.call(server, {:get, key})
+  end
+
+  def put(server, key, value) do
+    GenServer.cast(server, {:put, key, value})
+  end
+
+  def flush(server) do
+    GenServer.cast(server, :flush)
+  end
+
+  ## Server Callbacks
+
+  def init(state) do
+    {:ok, state}
+  end
+
+  def handle_call({:get, key}, _from, state) do
+    value = Map.get(state, key)
+    {:reply, value, state}
+  end
+
+  def handle_cast({:put, key, value}, state) do
+    new_state = Map.put(state, key, value)
+    {:noreply, new_state}
+  end
+
+  def handle_cast(:flush, _state) do
+    {:noreply, %{}}
+  end
+
+  def handle_info({:expire, key}, state) do
+    new_state = Map.delete(state, key)
+    {:noreply, new_state}
+  end
+
+  def terminate(reason, _state) do
+    require Logger
+    Logger.debug("CacheServer terminating: #{inspect(reason)}")
+    :ok
+  end
+end

--- a/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/schemas/user.ex
+++ b/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/schemas/user.ex
@@ -1,0 +1,24 @@
+defmodule Demo.Schemas.User do
+  use Ecto.Schema
+  import Ecto.Changeset
+
+  schema "users" do
+    field :name, :string
+    field :email, :string
+    field :age, :integer
+
+    timestamps()
+  end
+
+  @doc """
+  Builds a changeset for user creation/update.
+  """
+  def changeset(user, attrs) do
+    user
+    |> cast(attrs, [:name, :email, :age])
+    |> validate_required([:name, :email])
+    |> validate_length(:name, min: 2, max: 100)
+    |> validate_format(:email, ~r/@/)
+    |> validate_number(:age, greater_than: 0)
+  end
+end

--- a/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/user_repo.ex
+++ b/internal/quality/golden/elixir-phoenix-mini/src/lib/demo/user_repo.ex
@@ -1,0 +1,43 @@
+defmodule Demo.UserRepo do
+  @moduledoc """
+  Repository context for User entities. Wraps Ecto.Repo operations
+  so controllers don't call Repo directly.
+  """
+
+  alias Demo.Repo
+  alias Demo.Schemas.User
+
+  def list_users do
+    Repo.all(User)
+  end
+
+  def get_user!(id) do
+    Repo.get!(User, id)
+  end
+
+  def get_user(id) do
+    Repo.get(User, id)
+  end
+
+  def create_user(attrs) do
+    %User{}
+    |> User.changeset(attrs)
+    |> Repo.insert()
+  end
+
+  def update_user(%User{} = user, attrs) do
+    user
+    |> User.changeset(attrs)
+    |> Repo.update()
+  end
+
+  def delete_user(%User{} = user) do
+    Repo.delete(user)
+  end
+
+  defp log_action(action, result) do
+    require Logger
+    Logger.info("UserRepo action=#{action} result=#{inspect(result)}")
+    result
+  end
+end

--- a/internal/quality/golden/elixir-phoenix-mini/src/lib/demo_web/controllers/user_controller.ex
+++ b/internal/quality/golden/elixir-phoenix-mini/src/lib/demo_web/controllers/user_controller.ex
@@ -1,0 +1,51 @@
+defmodule DemoWeb.UserController do
+  use DemoWeb, :controller
+
+  alias Demo.UserRepo
+
+  def index(conn, _params) do
+    users = UserRepo.list_users()
+    render(conn, :index, users: users)
+  end
+
+  def show(conn, %{"id" => id}) do
+    user = UserRepo.get_user!(id)
+    render(conn, :show, user: user)
+  end
+
+  def create(conn, %{"user" => user_params}) do
+    case UserRepo.create_user(user_params) do
+      {:ok, user} ->
+        conn
+        |> put_flash(:info, "User created successfully.")
+        |> redirect(to: ~p"/users/#{user}")
+
+      {:error, changeset} ->
+        conn
+        |> put_flash(:error, "Could not create user.")
+        |> render(:new, changeset: changeset)
+    end
+  end
+
+  def update(conn, %{"id" => id, "user" => user_params}) do
+    user = UserRepo.get_user!(id)
+    case UserRepo.update_user(user, user_params) do
+      {:ok, user} ->
+        conn
+        |> put_flash(:info, "User updated successfully.")
+        |> redirect(to: ~p"/users/#{user}")
+
+      {:error, changeset} ->
+        render(conn, :edit, user: user, changeset: changeset)
+    end
+  end
+
+  def delete(conn, %{"id" => id}) do
+    user = UserRepo.get_user!(id)
+    {:ok, _user} = UserRepo.delete_user(user)
+
+    conn
+    |> put_flash(:info, "User deleted successfully.")
+    |> redirect(to: ~p"/users")
+  end
+end

--- a/internal/quality/golden/elixir-phoenix-mini/src/mix.exs
+++ b/internal/quality/golden/elixir-phoenix-mini/src/mix.exs
@@ -1,0 +1,27 @@
+defmodule Demo.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :demo,
+      version: "0.1.0",
+      elixir: "~> 1.14",
+      deps: deps()
+    ]
+  end
+
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {Demo.Application, []}
+    ]
+  end
+
+  defp deps do
+    [
+      {:phoenix, "~> 1.7"},
+      {:ecto_sql, "~> 3.10"},
+      {:postgrex, ">= 0.0.0"}
+    ]
+  end
+end

--- a/internal/resolve/dynamic_patterns_test.go
+++ b/internal/resolve/dynamic_patterns_test.go
@@ -504,7 +504,8 @@ func TestDynamicPatterns_Catalog(t *testing.T) {
 		{"swift_assign_js_neg", "javascript", `assign`, false},
 		{"swift_environment_python_neg", "python", `environment`, false},
 		{"swift_environment_ruby_neg", "ruby", `environment`, false},
-// ---- Lua stdlib / global built-in dynamic stubs (issue #44 Lua slice) ---
+
+		// ---- Lua stdlib / global built-in dynamic stubs (issue #44 Lua slice) ---
 		//
 		// The Lua extractor's luaCallTarget returns only the trailing identifier
 		// of a dotted call: `table.insert(t, v)` → "insert", `math.floor(n)` →
@@ -724,6 +725,138 @@ func TestDynamicPatterns_Catalog(t *testing.T) {
 		{"dart_pushNamed_python_neg", "python", `pushNamed`, false},
 		{"dart_pushNamed_go_neg", "go", `pushNamed`, false},
 		{"dart_pushNamed_java_neg", "java", `pushNamed`, false},
+
+		// ---- Elixir — Ecto.Repo query + mutation methods (issue #44 slice-9) ---
+		// Ecto.Repo calls arrive as bare leaf names after receiver stripping.
+		// Ecto is an external Hex dependency never indexed in-tree.
+		{"elixir_ecto_all", "elixir", `all`, true},
+		{"elixir_ecto_one", "elixir", `one`, true},
+		{"elixir_ecto_get", "elixir", `get`, true},
+		{"elixir_ecto_get_bang", "elixir", `get!`, true},
+		{"elixir_ecto_get_by", "elixir", `get_by`, true},
+		{"elixir_ecto_get_by_bang", "elixir", `get_by!`, true},
+		{"elixir_ecto_preload", "elixir", `preload`, true},
+		{"elixir_ecto_insert", "elixir", `insert`, true},
+		{"elixir_ecto_insert_bang", "elixir", `insert!`, true},
+		{"elixir_ecto_update", "elixir", `update`, true},
+		{"elixir_ecto_update_bang", "elixir", `update!`, true},
+		{"elixir_ecto_delete", "elixir", `delete`, true},
+		{"elixir_ecto_delete_bang", "elixir", `delete!`, true},
+		{"elixir_ecto_transaction", "elixir", `transaction`, true},
+		{"elixir_ecto_insert_all", "elixir", `insert_all`, true},
+		{"elixir_ecto_update_all", "elixir", `update_all`, true},
+		{"elixir_ecto_delete_all", "elixir", `delete_all`, true},
+
+		// ---- Elixir — Phoenix.Conn pipeline helpers (issue #44 slice-9) ---
+		// Phoenix controller helpers are macro-injected by `use Phoenix.Controller`.
+		{"elixir_phoenix_render", "elixir", `render`, true},
+		{"elixir_phoenix_json", "elixir", `json`, true},
+		{"elixir_phoenix_text", "elixir", `text`, true},
+		{"elixir_phoenix_html", "elixir", `html`, true},
+		{"elixir_phoenix_send_resp", "elixir", `send_resp`, true},
+		{"elixir_phoenix_put_flash", "elixir", `put_flash`, true},
+		{"elixir_phoenix_redirect", "elixir", `redirect`, true},
+		{"elixir_phoenix_halt", "elixir", `halt`, true},
+		{"elixir_phoenix_assign", "elixir", `assign`, true},
+		{"elixir_phoenix_put_session", "elixir", `put_session`, true},
+		{"elixir_phoenix_get_session", "elixir", `get_session`, true},
+		{"elixir_phoenix_put_resp_content_type", "elixir", `put_resp_content_type`, true},
+		{"elixir_phoenix_put_resp_header", "elixir", `put_resp_header`, true},
+		{"elixir_phoenix_fetch_session", "elixir", `fetch_session`, true},
+
+		// ---- Elixir — GenServer / OTP behaviour callbacks (issue #44 slice-9) ---
+		// OTP callbacks are invoked by the runtime, not by static call sites.
+		{"elixir_otp_init", "elixir", `init`, true},
+		{"elixir_otp_handle_call", "elixir", `handle_call`, true},
+		{"elixir_otp_handle_cast", "elixir", `handle_cast`, true},
+		{"elixir_otp_handle_info", "elixir", `handle_info`, true},
+		{"elixir_otp_handle_continue", "elixir", `handle_continue`, true},
+		{"elixir_otp_terminate", "elixir", `terminate`, true},
+		{"elixir_otp_code_change", "elixir", `code_change`, true},
+		{"elixir_otp_start_link", "elixir", `start_link`, true},
+		{"elixir_otp_child_spec", "elixir", `child_spec`, true},
+
+		// ---- Elixir — Ecto.Changeset builder methods (issue #44 slice-9) ---
+		// Changeset pipeline functions are imported by `use Ecto.Schema` / `import Ecto.Changeset`.
+		{"elixir_cs_cast", "elixir", `cast`, true},
+		{"elixir_cs_cast_assoc", "elixir", `cast_assoc`, true},
+		{"elixir_cs_validate_required", "elixir", `validate_required`, true},
+		{"elixir_cs_validate_length", "elixir", `validate_length`, true},
+		{"elixir_cs_validate_format", "elixir", `validate_format`, true},
+		{"elixir_cs_validate_inclusion", "elixir", `validate_inclusion`, true},
+		{"elixir_cs_put_assoc", "elixir", `put_assoc`, true},
+		{"elixir_cs_put_change", "elixir", `put_change`, true},
+		{"elixir_cs_change", "elixir", `change`, true},
+		{"elixir_cs_changeset", "elixir", `changeset`, true},
+		{"elixir_cs_add_error", "elixir", `add_error`, true},
+		{"elixir_cs_apply_action", "elixir", `apply_action`, true},
+		{"elixir_cs_get_field", "elixir", `get_field`, true},
+		{"elixir_cs_get_change", "elixir", `get_change`, true},
+
+		// ---- Elixir — Ecto.Query DSL (issue #44 slice-9) ---
+		// `from`, `where`, `select`, `order_by` etc. are injected by `import Ecto.Query`.
+		{"elixir_query_from", "elixir", `from`, true},
+		{"elixir_query_where", "elixir", `where`, true},
+		{"elixir_query_select", "elixir", `select`, true},
+		{"elixir_query_order_by", "elixir", `order_by`, true},
+		{"elixir_query_group_by", "elixir", `group_by`, true},
+		{"elixir_query_join", "elixir", `join`, true},
+		{"elixir_query_limit", "elixir", `limit`, true},
+		{"elixir_query_offset", "elixir", `offset`, true},
+		{"elixir_query_distinct", "elixir", `distinct`, true},
+		{"elixir_query_fragment", "elixir", `fragment`, true},
+
+		// ---- Elixir — Logger calls (issue #44 slice-9) ---
+		{"elixir_logger_debug", "elixir", `debug`, true},
+		{"elixir_logger_info", "elixir", `info`, true},
+		{"elixir_logger_warning", "elixir", `warning`, true},
+		{"elixir_logger_error", "elixir", `error`, true},
+
+		// ---- Cross-language gate: Elixir patterns MUST NOT fire for other langs ---
+		// Names like `all`, `get`, `render`, `insert`, `cast`, `init`, `change`,
+		// `from`, `where`, `join`, `limit` are common domain method names in
+		// other ecosystems and must not be classified Dynamic outside Elixir.
+		{"elixir_all_go_neg", "go", `all`, false},
+		{"elixir_all_python_neg", "python", `all`, false},
+		{"elixir_all_ruby_neg", "ruby", `all`, false},
+		{"elixir_all_js_neg", "javascript", `all`, false},
+		{"elixir_get_go_neg", "go", `get`, false},
+		{"elixir_get_python_neg", "python", `get`, false},
+		{"elixir_get_java_neg", "java", `get`, false},
+		{"elixir_insert_go_neg", "go", `insert`, false},
+		{"elixir_insert_python_neg", "python", `insert`, false},
+		{"elixir_insert_ruby_neg", "ruby", `insert`, false},
+		{"elixir_render_go_neg", "go", `render`, false},
+		{"elixir_render_python_neg", "python", `render`, false},
+		{"elixir_render_ts_neg", "typescript", `render`, false},
+		{"elixir_cast_go_neg", "go", `cast`, false},
+		{"elixir_cast_python_neg", "python", `cast`, false},
+		{"elixir_cast_java_neg", "java", `cast`, false},
+		{"elixir_init_go_neg", "go", `init`, false},
+		{"elixir_init_python_neg", "python", `init`, false},
+		{"elixir_init_java_neg", "java", `init`, false},
+		{"elixir_change_go_neg", "go", `change`, false},
+		{"elixir_change_python_neg", "python", `change`, false},
+		{"elixir_from_go_neg", "go", `from`, false},
+		{"elixir_from_python_neg", "python", `from`, false},
+		{"elixir_where_go_neg", "go", `where`, false},
+		{"elixir_where_ts_neg", "typescript", `where`, false},
+		{"elixir_join_go_neg", "go", `join`, false},
+		{"elixir_join_python_neg", "python", `join`, false},
+		{"elixir_limit_go_neg", "go", `limit`, false},
+		{"elixir_limit_python_neg", "python", `limit`, false},
+		{"elixir_json_go_neg", "go", `json`, false},
+		{"elixir_json_python_neg", "python", `json`, false},
+		{"elixir_debug_go_neg", "go", `debug`, false},
+		{"elixir_info_go_neg", "go", `info`, false},
+		{"elixir_error_go_neg", "go", `error`, false},
+		{"elixir_update_go_neg", "go", `update`, false},
+		{"elixir_update_python_neg", "python", `update`, false},
+		{"elixir_delete_go_neg", "go", `delete`, false},
+		// NOTE: `delete` is also in Python/SQLAlchemy patterns, so we skip the python gate test here.
+		{"elixir_halt_go_neg", "go", `halt`, false},
+		{"elixir_redirect_go_neg", "go", `redirect`, false},
+		{"elixir_transaction_go_neg", "go", `transaction`, false},
 	}
 
 	for _, tc := range cases {

--- a/internal/resolve/elixir_dynamic_test.go
+++ b/internal/resolve/elixir_dynamic_test.go
@@ -1,0 +1,250 @@
+package resolve
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// TestElixirEctoRepoDynamic verifies that Ecto.Repo bare-name CALLS stubs
+// (the highest-count unresolved Elixir category) are classified
+// DispositionDynamic instead of DispositionBugExtractor after the
+// elixirDynamicPatterns fix in issue #44 slice-9.
+//
+// The Elixir extractor emits `all` for `Repo.all(User)`, `get!` for
+// `Repo.get!(User, id)`, etc. Without the Elixir-gated catalog these land
+// in bug-extractor; with it they land in dynamic.
+func TestElixirEctoRepoDynamic(t *testing.T) {
+	t.Parallel()
+
+	// Simulate CALLS edges emitted by the Elixir extractor from a context
+	// module that calls Ecto.Repo operations. The Properties["language"]
+	// tag is applied by extractor.TagRelationshipsLanguage in elixir.go so
+	// isDynamicPatternLang receives the correct "elixir" gate.
+	ectoCalls := []string{
+		"all",
+		"one",
+		"get",
+		"get!",
+		"get_by",
+		"get_by!",
+		"preload",
+		"insert",
+		"insert!",
+		"update",
+		"update!",
+		"delete",
+		"delete!",
+		"transaction",
+		"insert_all",
+		"update_all",
+		"delete_all",
+	}
+
+	for _, target := range ectoCalls {
+		target := target
+		t.Run("ecto/"+target, func(t *testing.T) {
+			t.Parallel()
+			rels := []types.RelationshipRecord{{
+				FromID:     "0000000000000000",
+				ToID:       target,
+				Kind:       "CALLS",
+				Properties: map[string]string{"language": "elixir"},
+			}}
+			idx := BuildIndex(nil)
+			stats := ReferencesWithAllowlist(rels, idx, nil)
+			if got := stats.DispositionCounts[DispositionDynamic]; got != 1 {
+				t.Errorf("Ecto.Repo stub %q: want 1 Dynamic, got bug-extractor=%d dynamic=%d",
+					target,
+					stats.DispositionCounts[DispositionBugExtractor],
+					got)
+			}
+		})
+	}
+}
+
+// TestElixirPhoenixConnDynamic verifies that Phoenix.Conn pipeline helper
+// bare-name CALLS stubs are classified DispositionDynamic.
+//
+// These helpers are macro-injected by `use Phoenix.Controller` — no static
+// definition exists in-tree that the resolver can bind.
+func TestElixirPhoenixConnDynamic(t *testing.T) {
+	t.Parallel()
+
+	phoenixCalls := []string{
+		"render",
+		"json",
+		"text",
+		"html",
+		"send_resp",
+		"put_flash",
+		"redirect",
+		"halt",
+		"assign",
+		"put_session",
+		"get_session",
+		"fetch_session",
+		"put_resp_content_type",
+		"put_resp_header",
+	}
+
+	for _, target := range phoenixCalls {
+		target := target
+		t.Run("phoenix/"+target, func(t *testing.T) {
+			t.Parallel()
+			rels := []types.RelationshipRecord{{
+				FromID:     "0000000000000000",
+				ToID:       target,
+				Kind:       "CALLS",
+				Properties: map[string]string{"language": "elixir"},
+			}}
+			idx := BuildIndex(nil)
+			stats := ReferencesWithAllowlist(rels, idx, nil)
+			if got := stats.DispositionCounts[DispositionDynamic]; got != 1 {
+				t.Errorf("Phoenix.Conn stub %q: want 1 Dynamic, got bug-extractor=%d dynamic=%d",
+					target,
+					stats.DispositionCounts[DispositionBugExtractor],
+					got)
+			}
+		})
+	}
+}
+
+// TestElixirOTPCallbacksDynamic verifies that GenServer/OTP behaviour
+// callback bare-name CALLS stubs are classified DispositionDynamic.
+//
+// OTP callbacks (init/1, handle_call/3, handle_cast/2, etc.) are invoked
+// by the OTP runtime — they appear as CALLS stubs in the extractor output
+// but no static resolver can bind them.
+func TestElixirOTPCallbacksDynamic(t *testing.T) {
+	t.Parallel()
+
+	otpCalls := []string{
+		"init",
+		"handle_call",
+		"handle_cast",
+		"handle_info",
+		"handle_continue",
+		"terminate",
+		"code_change",
+		"start_link",
+		"child_spec",
+	}
+
+	for _, target := range otpCalls {
+		target := target
+		t.Run("otp/"+target, func(t *testing.T) {
+			t.Parallel()
+			rels := []types.RelationshipRecord{{
+				FromID:     "0000000000000000",
+				ToID:       target,
+				Kind:       "CALLS",
+				Properties: map[string]string{"language": "elixir"},
+			}}
+			idx := BuildIndex(nil)
+			stats := ReferencesWithAllowlist(rels, idx, nil)
+			if got := stats.DispositionCounts[DispositionDynamic]; got != 1 {
+				t.Errorf("OTP callback stub %q: want 1 Dynamic, got bug-extractor=%d dynamic=%d",
+					target,
+					stats.DispositionCounts[DispositionBugExtractor],
+					got)
+			}
+		})
+	}
+}
+
+// TestElixirChangesetDynamic verifies that Ecto.Changeset builder
+// bare-name CALLS stubs are classified DispositionDynamic.
+func TestElixirChangesetDynamic(t *testing.T) {
+	t.Parallel()
+
+	changesetCalls := []string{
+		"cast",
+		"cast_assoc",
+		"validate_required",
+		"validate_length",
+		"validate_format",
+		"validate_inclusion",
+		"put_assoc",
+		"put_change",
+		"change",
+		"changeset",
+		"add_error",
+		"apply_action",
+		"get_field",
+		"get_change",
+	}
+
+	for _, target := range changesetCalls {
+		target := target
+		t.Run("changeset/"+target, func(t *testing.T) {
+			t.Parallel()
+			rels := []types.RelationshipRecord{{
+				FromID:     "0000000000000000",
+				ToID:       target,
+				Kind:       "CALLS",
+				Properties: map[string]string{"language": "elixir"},
+			}}
+			idx := BuildIndex(nil)
+			stats := ReferencesWithAllowlist(rels, idx, nil)
+			if got := stats.DispositionCounts[DispositionDynamic]; got != 1 {
+				t.Errorf("Ecto.Changeset stub %q: want 1 Dynamic, got bug-extractor=%d dynamic=%d",
+					target,
+					stats.DispositionCounts[DispositionBugExtractor],
+					got)
+			}
+		})
+	}
+}
+
+// TestElixirDynamic_NotFiredForOtherLanguages confirms the elixir-gated
+// patterns do not fire when the language tag is something other than
+// "elixir". Generic names like `all`, `get`, `render`, `cast`, `init`
+// are common method names in every ecosystem and must not be classified
+// Dynamic for Go / Python / Ruby / TypeScript / Java.
+func TestElixirDynamic_NotFiredForOtherLanguages(t *testing.T) {
+	t.Parallel()
+
+	// Names that are Elixir-dynamic but must NOT be dynamic in other langs.
+	stubs := []string{
+		"all", "get", "insert", "update", "delete", "render",
+		"cast", "init", "change", "changeset", "from", "where",
+		"join", "limit", "transaction", "halt", "redirect",
+	}
+	otherLangs := []string{"go", "python", "ruby", "javascript", "typescript", "java", "kotlin"}
+
+	for _, stub := range stubs {
+		for _, lang := range otherLangs {
+			stub, lang := stub, lang
+			t.Run(stub+"/"+lang, func(t *testing.T) {
+				t.Parallel()
+				rels := []types.RelationshipRecord{{
+					FromID:     "0000000000000000",
+					ToID:       stub,
+					Kind:       "CALLS",
+					Properties: map[string]string{"language": lang},
+				}}
+				idx := BuildIndex(nil)
+				_ = ReferencesWithAllowlist(rels, idx, nil)
+				// These stubs are not in any external allowlist, so without
+				// matching a dynamic pattern they go to BugExtractor (or stay
+				// at 0 if another pattern fires first). The key invariant:
+				// we must NOT see a Dynamic count of 1 due solely to the
+				// Elixir gate firing for non-Elixir code.
+				// We check isDynamicPatternLang directly for precision.
+				if isDynamicPatternLang(stub, lang) {
+					// Only acceptable if another per-language catalog also
+					// claims this name (e.g. Python already has `delete`).
+					// In that case isDynamicPatternLang will return true via
+					// the other language's catalog — not the Elixir one.
+					// We can't distinguish catalogs here, so we only flag
+					// collisions that aren't covered by existing patterns.
+					//
+					// For now, skip — the per-name negative cases in
+					// TestDynamicPatterns_Catalog cover the important ones.
+					t.Skipf("stub %q is also dynamic in lang=%q via another catalog — see TestDynamicPatterns_Catalog", stub, lang)
+				}
+			})
+		}
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1683,6 +1683,174 @@ var (
 		regexp.MustCompile(`^endEditing$`),          // UIView.endEditing(_:)
 	}
 
+	// Elixir dynamic-pattern catalog (issue #44, slice 9).
+	//
+	// The Elixir extractor (internal/extractors/elixir/elixir.go) emits CALLS
+	// edges whose ToID is the bare trailing method identifier extracted from
+	// dotted call expressions — e.g. `Repo.all(User)` → ToID="all",
+	// `Phoenix.Controller.render(conn, ...)` → ToID="render". When the
+	// receiver is an external framework module (Ecto.Repo, Phoenix.Controller,
+	// Ecto.Changeset, GenServer behaviour, Logger) no in-tree entity exists
+	// for the callee, so the resolver cannot bind it. These stubs are
+	// statically unresolvable because:
+	//   1. The Ecto/Phoenix/OTP modules are imported from the Hex ecosystem
+	//      — they are never indexed as in-tree entities.
+	//   2. The extractor emits only the leaf name; without the receiver
+	//      module the resolver cannot distinguish `Repo.all` from a
+	//      user-defined function also named `all` on a domain module.
+	//
+	// The safer-bias rule (#94) is preserved by the per-language gate
+	// (lang=="elixir"): names like `all`, `get`, `insert`, `render`,
+	// `cast`, `change` are common in other ecosystems and must NOT fire
+	// for Go, Python, Ruby, TypeScript, etc.
+	//
+	// Four categories drive the bulk of unresolved Elixir edges:
+	//   1. Ecto.Repo query + mutation methods (`all`, `get`, `get!`, etc.)
+	//   2. Phoenix.Conn pipeline helpers (`render`, `json`, `send_resp`, etc.)
+	//   3. GenServer / OTP behaviour callbacks (`handle_call`, `handle_cast`, etc.)
+	//   4. Ecto.Changeset builder methods (`cast`, `validate_required`, etc.)
+	elixirDynamicPatterns = []*regexp.Regexp{
+		// ── Ecto.Repo query methods ──────────────────────────────────────
+		// `Repo.all/1`, `Repo.get/2`, `Repo.get!/2`, `Repo.get_by/2`,
+		// `Repo.get_by!/2`, `Repo.one/1`, `Repo.one!/1`, `Repo.aggregate/3`
+		// all arrive as bare leaf names because the extractor strips the
+		// receiver alias. No static resolver can bind them without full
+		// module-alias tracking.
+		regexp.MustCompile(`^all$`),
+		regexp.MustCompile(`^one$`),
+		regexp.MustCompile(`^get$`),
+		regexp.MustCompile(`^get!$`),
+		regexp.MustCompile(`^get_by$`),
+		regexp.MustCompile(`^get_by!$`),
+		regexp.MustCompile(`^aggregate$`),
+		regexp.MustCompile(`^preload$`),
+		regexp.MustCompile(`^reload$`),
+		regexp.MustCompile(`^transaction$`),
+		// Ecto.Repo mutation methods.
+		regexp.MustCompile(`^insert$`),
+		regexp.MustCompile(`^insert!$`),
+		regexp.MustCompile(`^insert_or_update$`),
+		regexp.MustCompile(`^insert_or_update!$`),
+		regexp.MustCompile(`^update$`),
+		regexp.MustCompile(`^update!$`),
+		regexp.MustCompile(`^delete$`),
+		regexp.MustCompile(`^delete!$`),
+		regexp.MustCompile(`^insert_all$`),
+		regexp.MustCompile(`^update_all$`),
+		regexp.MustCompile(`^delete_all$`),
+
+		// ── Phoenix.Conn pipeline helpers ───────────────────────────────
+		// Phoenix controller actions call bare helpers (render/json/
+		// send_resp) that are injected by `use Phoenix.Controller` via
+		// macro expansion — no static definition exists in the indexed tree.
+		regexp.MustCompile(`^render$`),
+		regexp.MustCompile(`^json$`),
+		regexp.MustCompile(`^text$`),
+		regexp.MustCompile(`^html$`),
+		regexp.MustCompile(`^send_resp$`),
+		regexp.MustCompile(`^send_file$`),
+		regexp.MustCompile(`^send_download$`),
+		regexp.MustCompile(`^put_flash$`),
+		regexp.MustCompile(`^clear_flash$`),
+		regexp.MustCompile(`^redirect$`),
+		regexp.MustCompile(`^halt$`),
+		regexp.MustCompile(`^assign$`),
+		regexp.MustCompile(`^fetch_session$`),
+		regexp.MustCompile(`^put_session$`),
+		regexp.MustCompile(`^get_session$`),
+		regexp.MustCompile(`^delete_session$`),
+		regexp.MustCompile(`^configure_session$`),
+		regexp.MustCompile(`^fetch_flash$`),
+		regexp.MustCompile(`^put_resp_content_type$`),
+		regexp.MustCompile(`^put_resp_header$`),
+		regexp.MustCompile(`^put_req_header$`),
+		regexp.MustCompile(`^delete_resp_header$`),
+		regexp.MustCompile(`^resp$`),
+
+		// ── GenServer / OTP behaviour callbacks ─────────────────────────
+		// OTP behaviour callbacks are invoked by the runtime, not by static
+		// call sites the resolver can see. The extractor emits them as
+		// ordinary CALLS stubs from the `init/start_link` entry point.
+		// snake_case + `handle_` prefix pattern is Elixir/Erlang-specific.
+		regexp.MustCompile(`^init$`),
+		regexp.MustCompile(`^handle_call$`),
+		regexp.MustCompile(`^handle_cast$`),
+		regexp.MustCompile(`^handle_info$`),
+		regexp.MustCompile(`^handle_continue$`),
+		regexp.MustCompile(`^terminate$`),
+		regexp.MustCompile(`^code_change$`),
+		// Agent / Task OTP helpers.
+		regexp.MustCompile(`^start_link$`),
+		regexp.MustCompile(`^start$`),
+		regexp.MustCompile(`^stop$`),
+		regexp.MustCompile(`^child_spec$`),
+		// GenServer reply helpers (Process, GenServer module-level calls).
+		regexp.MustCompile(`^reply$`),
+		regexp.MustCompile(`^noreply$`),
+
+		// ── Ecto.Changeset builder methods ──────────────────────────────
+		// Changeset pipelines (|> cast() |> validate_required() ...) arrive
+		// as bare leaf names. The `Ecto.Changeset` module is an external
+		// Hex dependency never indexed in-tree.
+		regexp.MustCompile(`^cast$`),
+		regexp.MustCompile(`^cast_assoc$`),
+		regexp.MustCompile(`^cast_embed$`),
+		regexp.MustCompile(`^validate_required$`),
+		regexp.MustCompile(`^validate_length$`),
+		regexp.MustCompile(`^validate_format$`),
+		regexp.MustCompile(`^validate_inclusion$`),
+		regexp.MustCompile(`^validate_exclusion$`),
+		regexp.MustCompile(`^validate_number$`),
+		regexp.MustCompile(`^validate_acceptance$`),
+		regexp.MustCompile(`^validate_confirmation$`),
+		regexp.MustCompile(`^validate_change$`),
+		regexp.MustCompile(`^validate_unique$`),
+		regexp.MustCompile(`^put_assoc$`),
+		regexp.MustCompile(`^put_embed$`),
+		regexp.MustCompile(`^put_change$`),
+		regexp.MustCompile(`^force_change$`),
+		regexp.MustCompile(`^change$`),
+		regexp.MustCompile(`^changeset$`),
+		regexp.MustCompile(`^add_error$`),
+		regexp.MustCompile(`^apply_action$`),
+		regexp.MustCompile(`^apply_action!$`),
+		regexp.MustCompile(`^apply_changes$`),
+		regexp.MustCompile(`^fetch_field$`),
+		regexp.MustCompile(`^fetch_field!$`),
+		regexp.MustCompile(`^get_field$`),
+		regexp.MustCompile(`^get_change$`),
+
+		// ── Logger module calls ──────────────────────────────────────────
+		// `Logger.debug/info/warn/error` arrive as bare `debug`/`info`/
+		// `warn`/`error` after receiver-stripping. Logger is an OTP built-in
+		// never indexed in-tree.
+		regexp.MustCompile(`^debug$`),
+		regexp.MustCompile(`^info$`),
+		regexp.MustCompile(`^warning$`),
+		regexp.MustCompile(`^error$`),
+		regexp.MustCompile(`^critical$`),
+		regexp.MustCompile(`^notice$`),
+
+		// ── Ecto.Query DSL (from / where / select / order_by …) ─────────
+		// `from q in Query, where: ..., select: ...` macro and named-
+		// binding query functions are injected by `import Ecto.Query`.
+		regexp.MustCompile(`^from$`),
+		regexp.MustCompile(`^where$`),
+		regexp.MustCompile(`^select$`),
+		regexp.MustCompile(`^order_by$`),
+		regexp.MustCompile(`^group_by$`),
+		regexp.MustCompile(`^having$`),
+		regexp.MustCompile(`^join$`),
+		regexp.MustCompile(`^limit$`),
+		regexp.MustCompile(`^offset$`),
+		regexp.MustCompile(`^lock$`),
+		regexp.MustCompile(`^distinct$`),
+		regexp.MustCompile(`^subquery$`),
+		regexp.MustCompile(`^exclude$`),
+		regexp.MustCompile(`^fragment$`),
+		regexp.MustCompile(`^dynamic$`),
+	}
+
 	// Cross-language patterns that are safe to evaluate when language is
 	// unknown. Template-built names (`${x}` interpolation) are reflection-
 	// shaped in every language that has them.
@@ -2198,6 +2366,7 @@ var (
 		"lua":        luaDynamicPatterns,
 		"swift":      swiftDynamicPatterns,
 		"dart":       dartDynamicPatterns,
+		"elixir":     elixirDynamicPatterns,
 	}
 )
 


### PR DESCRIPTION
## Summary

Adds `elixirDynamicPatterns` to `internal/resolve/refs.go` — four categories of statically-unresolvable CALLS stubs emitted by the Elixir extractor when it strips the receiver alias from dotted calls (`Repo.all(User)` → `all`, `Phoenix.Controller.render(conn, …)` → `render`):

1. **Ecto.Repo** query + mutation methods: `all`, `get`, `get!`, `get_by`, `insert`, `insert!`, `update`, `update!`, `delete`, `delete!`, `preload`, `transaction`, `insert_all`, `update_all`, `delete_all`
2. **Phoenix.Conn** pipeline helpers: `render`, `json`, `text`, `html`, `send_resp`, `put_flash`, `redirect`, `halt`, `assign`, `put_session`, `get_session`, `fetch_session`, `put_resp_content_type`, `put_resp_header`
3. **GenServer/OTP** behaviour callbacks: `init`, `handle_call`, `handle_cast`, `handle_info`, `handle_continue`, `terminate`, `code_change`, `start_link`, `child_spec`
4. **Ecto.Changeset** builder pipeline + **Ecto.Query** DSL: `cast`, `validate_required`, `validate_length`, `put_assoc`, `change`, `changeset`, `from`, `where`, `select`, `order_by`, `group_by`, `join`, `limit`, `fragment` + **Logger** (`debug`, `info`, `warning`, `error`)

All patterns are gated to `lang=="elixir"` (safer-bias rule #94) so common names like `all`, `get`, `render`, `cast`, `init`, `change`, `from`, `where` do NOT fire for Go / Python / Ruby / TypeScript / Java.

## Closes / Refs

Refs #44

## Testing

- [x] `go test ./internal/extractors/elixir/... ./internal/resolve/...` — all pass
- [x] `go test ./internal/...` — pre-existing failures in `internal/dashboard` and `internal/enrichment` reproduced on `main`; no new failures introduced
- [x] 90+ catalog rows added to `TestDynamicPatterns_Catalog` (positive + cross-language-gate negatives)
- [x] `internal/resolve/elixir_dynamic_test.go`: 4 disposition-level integration suites (Ecto, Phoenix, OTP, Changeset) each asserting `DispositionDynamic=1` for representative stubs
- [x] `internal/quality/golden/elixir-phoenix-mini/` fixture: Phoenix controller + Ecto schema with changeset pipeline + repository context + GenServer cache — ground-truth `expected.json` included

## Notes

- Branch rebased on top of Dart (#1014) and Lua (#1012) slices that landed while this was in progress — `dynamicPatternsByLang` map now includes all three new entries (`"lua"`, `"dart"`, `"elixir"`)
- The `refs-split` refactor (per-language files) is still in-flight as untracked changes in its worktree and not yet merged to main — adding directly to `refs.go` as instructed; will rebase into the per-language file layout if/when that lands