### PR TITLE
[#1016] Wire POST /api/{enrichments,repairs}/{group}/action — apply/reject RPC

### DIFF
--- a/internal/dashboard/handlers_action_test.go
+++ b/internal/dashboard/handlers_action_test.go
@@ -1,0 +1,371 @@
+package dashboard
+
+// handlers_action_test.go — unit tests for POST /api/{enrichments|repairs}/{group}/action
+// (#1016). Uses a temp-dir-backed repo so reads/writes land in <t.TempDir()>/.archigraph/.
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// newActionServer creates a test HTTP server with a DashGroup whose "svc"
+// repo points to repoPath.  The caller is responsible for creating the
+// .archigraph directory and seeding any candidate files before calling
+// this helper.
+func newActionServer(t *testing.T, repoPath string) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgroup"] = GroupSummary{
+		Name:       "testgroup",
+		ConfigPath: "/tmp/testgroup.json",
+		Repos:      []string{"svc"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	grp := &DashGroup{
+		Name: "testgroup",
+		Repos: map[string]*DashRepo{
+			"svc": {Slug: "svc", Path: repoPath},
+		},
+		Links: []CrossRepoLink{},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgroup"] = &cacheEntry{
+		group:    grp,
+		loadedAt: time.Now().Add(60 * time.Second), // never expire during test
+	}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// seedEnrichmentCandidates writes an enrichment-candidates.json with the
+// given candidates under <repoPath>/.archigraph/.
+func seedEnrichmentCandidates(t *testing.T, repoPath string, cs []candidateRaw) {
+	t.Helper()
+	archDir := filepath.Join(repoPath, ".archigraph")
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	data, err := json.MarshalIndent(cs, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal candidates: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(archDir, "enrichment-candidates.json"), data, 0o644); err != nil {
+		t.Fatalf("write candidates: %v", err)
+	}
+}
+
+// postAction sends a POST to url with the given body and returns the status
+// code plus parsed JSON body.
+func postAction(t *testing.T, url string, body any) (int, map[string]any) {
+	t.Helper()
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal body: %v", err)
+	}
+	resp, err := http.Post(url, "application/json", bytes.NewReader(raw)) //nolint:noctx
+	if err != nil {
+		t.Fatalf("POST %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	var out map[string]any
+	_ = json.NewDecoder(resp.Body).Decode(&out)
+	return resp.StatusCode, out
+}
+
+// ---------------------------------------------------------------------------
+// Validation tests
+// ---------------------------------------------------------------------------
+
+func TestCandidateAction_MissingCandidateID(t *testing.T) {
+	repoPath := t.TempDir()
+	ts := newActionServer(t, repoPath)
+	code, body := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"action": "reject",
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%v", code, body)
+	}
+	if !strings.Contains(body["error"].(string), "candidate_id") {
+		t.Fatalf("error should mention candidate_id, got %v", body)
+	}
+}
+
+func TestCandidateAction_InvalidAction(t *testing.T) {
+	repoPath := t.TempDir()
+	ts := newActionServer(t, repoPath)
+	code, body := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"candidate_id": "ec:abc",
+		"action":       "invalid",
+	})
+	if code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d body=%v", code, body)
+	}
+}
+
+func TestCandidateAction_UnknownCandidate_404(t *testing.T) {
+	repoPath := t.TempDir()
+	ts := newActionServer(t, repoPath)
+	code, _ := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"candidate_id": "ec:notexist",
+		"action":       "reject",
+	})
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", code)
+	}
+}
+
+func TestCandidateAction_BadGroup_404(t *testing.T) {
+	repoPath := t.TempDir()
+	ts := newActionServer(t, repoPath)
+	code, _ := postAction(t, ts.URL+"/api/enrichments/nosuchgroup/action", map[string]any{
+		"candidate_id": "ec:abc",
+		"action":       "reject",
+	})
+	if code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Reject enrichment candidate
+// ---------------------------------------------------------------------------
+
+func TestCandidateAction_Reject_Enrichment(t *testing.T) {
+	repoPath := t.TempDir()
+	const candidateID = "ec:aabbccddeeff0011"
+	candidates := []candidateRaw{
+		{
+			ID:           candidateID,
+			Kind:         "describe_entity",
+			SubjectID:    "entity:e1",
+			Confidence:   0.7,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+			Context:      map[string]any{"name": "UserService"},
+		},
+		{
+			ID:           "ec:other",
+			Kind:         "describe_entity",
+			SubjectID:    "entity:e2",
+			Confidence:   0.6,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+		},
+	}
+	seedEnrichmentCandidates(t, repoPath, candidates)
+
+	ts := newActionServer(t, repoPath)
+	code, body := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"candidate_id": candidateID,
+		"action":       "reject",
+		"reason":       "not needed",
+	})
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%v", code, body)
+	}
+	if body["success"] != true {
+		t.Fatalf("expected success=true, got %v", body)
+	}
+	if body["updated_candidate_id"] != candidateID {
+		t.Fatalf("wrong updated_candidate_id: %v", body)
+	}
+
+	// Verify rejection was written.
+	rejPath := filepath.Join(repoPath, ".archigraph", "enrichment-rejections.json")
+	rejData, err := os.ReadFile(rejPath)
+	if err != nil {
+		t.Fatalf("rejection file not created: %v", err)
+	}
+	var rejs []map[string]any
+	if err := json.Unmarshal(rejData, &rejs); err != nil {
+		t.Fatalf("parse rejections: %v", err)
+	}
+	if len(rejs) == 0 {
+		t.Fatal("expected at least one rejection entry")
+	}
+
+	// Verify candidate was removed.
+	archDir := filepath.Join(repoPath, ".archigraph")
+	remaining := readAllCandidates(repoPath)
+	// The candidates file is under repoPath (StateDirForRepo uses repoPath/.archigraph)
+	_ = archDir
+	for _, c := range remaining {
+		if c.ID == candidateID {
+			t.Fatalf("candidate %s was not removed from candidates file", candidateID)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Apply enrichment candidate
+// ---------------------------------------------------------------------------
+
+func TestCandidateAction_Apply_Enrichment(t *testing.T) {
+	repoPath := t.TempDir()
+	const candidateID = "ec:112233445566"
+	candidates := []candidateRaw{
+		{
+			ID:           candidateID,
+			Kind:         "describe_entity",
+			SubjectID:    "entity:e3",
+			Confidence:   0.9,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+		},
+	}
+	seedEnrichmentCandidates(t, repoPath, candidates)
+
+	ts := newActionServer(t, repoPath)
+	code, body := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"candidate_id": candidateID,
+		"action":       "apply",
+		"value":        "Handles user authentication and session management.",
+	})
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%v", code, body)
+	}
+	if body["success"] != true {
+		t.Fatalf("expected success=true, got %v", body)
+	}
+
+	// Verify resolution was written.
+	resPath := filepath.Join(repoPath, ".archigraph", "enrichment-resolutions.json")
+	resData, err := os.ReadFile(resPath)
+	if err != nil {
+		t.Fatalf("resolution file not created: %v", err)
+	}
+	var ress []map[string]any
+	if err := json.Unmarshal(resData, &ress); err != nil {
+		t.Fatalf("parse resolutions: %v", err)
+	}
+	if len(ress) == 0 {
+		t.Fatal("expected at least one resolution entry")
+	}
+	res := ress[0]
+	if res["kind"] != "describe_entity" {
+		t.Fatalf("wrong kind: %v", res["kind"])
+	}
+	if res["value"] != "Handles user authentication and session management." {
+		t.Fatalf("wrong value: %v", res["value"])
+	}
+
+	// Verify candidate was removed.
+	remaining := readAllCandidates(repoPath)
+	for _, c := range remaining {
+		if c.ID == candidateID {
+			t.Fatalf("candidate %s still present after apply", candidateID)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repair endpoint enforces repair-kind partition
+// ---------------------------------------------------------------------------
+
+func TestCandidateAction_RepairEndpoint_RefusesEnrichmentKind(t *testing.T) {
+	repoPath := t.TempDir()
+	const candidateID = "ec:aabb1122"
+	// Seed a non-repair candidate (describe_entity).
+	candidates := []candidateRaw{
+		{
+			ID:           candidateID,
+			Kind:         "describe_entity",
+			SubjectID:    "entity:e1",
+			Confidence:   0.7,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+		},
+	}
+	seedEnrichmentCandidates(t, repoPath, candidates)
+
+	ts := newActionServer(t, repoPath)
+	// POST to /api/repairs endpoint — should NOT find the enrichment candidate.
+	code, _ := postAction(t, ts.URL+"/api/repairs/testgroup/action", map[string]any{
+		"candidate_id": candidateID,
+		"action":       "reject",
+	})
+	if code != http.StatusNotFound {
+		t.Fatalf("repairs endpoint must not match enrichment candidates; got %d", code)
+	}
+}
+
+func TestCandidateAction_EnrichmentEndpoint_RefusesRepairKind(t *testing.T) {
+	repoPath := t.TempDir()
+	const candidateID = "ec:repaircandidate"
+	// Seed a repair_edge candidate.
+	candidates := []candidateRaw{
+		{
+			ID:           candidateID,
+			Kind:         "repair_edge",
+			SubjectID:    "entity:e1",
+			Confidence:   0.8,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+		},
+	}
+	seedEnrichmentCandidates(t, repoPath, candidates)
+
+	ts := newActionServer(t, repoPath)
+	// POST to /api/enrichments endpoint — should NOT find the repair candidate.
+	code, _ := postAction(t, ts.URL+"/api/enrichments/testgroup/action", map[string]any{
+		"candidate_id": candidateID,
+		"action":       "reject",
+	})
+	if code != http.StatusNotFound {
+		t.Fatalf("enrichments endpoint must not match repair candidates; got %d", code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Repair candidate apply/reject via repairs endpoint
+// ---------------------------------------------------------------------------
+
+func TestCandidateAction_Apply_Repair(t *testing.T) {
+	repoPath := t.TempDir()
+	const candidateID = "ec:repairtest"
+	candidates := []candidateRaw{
+		{
+			ID:           candidateID,
+			Kind:         "repair_edge",
+			SubjectID:    "entity:e5",
+			Confidence:   0.95,
+			DiscoveredAt: "2024-01-01T00:00:00Z",
+			Context:      map[string]any{"edge_id": "someedgehash"},
+		},
+	}
+	seedEnrichmentCandidates(t, repoPath, candidates)
+
+	ts := newActionServer(t, repoPath)
+	code, body := postAction(t, ts.URL+"/api/repairs/testgroup/action", map[string]any{
+		"candidate_id": candidateID,
+		"action":       "apply",
+		"value":        "bind_to_entity",
+		"reason":       "Manually confirmed binding.",
+	})
+	if code != http.StatusOK {
+		t.Fatalf("expected 200, got %d body=%v", code, body)
+	}
+	if body["success"] != true {
+		t.Fatalf("expected success=true, got %v", body)
+	}
+
+	// Verify resolution written.
+	resPath := filepath.Join(repoPath, ".archigraph", "enrichment-resolutions.json")
+	if _, err := os.Stat(resPath); os.IsNotExist(err) {
+		t.Fatal("resolution file not created for repair candidate")
+	}
+}

--- a/internal/dashboard/handlers_repairs.go
+++ b/internal/dashboard/handlers_repairs.go
@@ -2,16 +2,20 @@ package dashboard
 
 // handlers_repairs.go — Pending queue endpoints for the dashboard (#987).
 //
-//	GET /api/repairs/{group}      — repair_edge + dynamic_baseurl_endpoint candidates
-//	GET /api/enrichments/{group}  — all other enrichment candidates (describe_entity, classify_domain, …)
+//	GET  /api/repairs/{group}           — repair_edge + dynamic_baseurl_endpoint candidates
+//	GET  /api/enrichments/{group}       — all other enrichment candidates (describe_entity, classify_domain, …)
+//	POST /api/repairs/{group}/action    — apply or reject a repair candidate (#1016)
+//	POST /api/enrichments/{group}/action — apply or reject an enrichment candidate (#1016)
 
 import (
 	"encoding/json"
 	"net/http"
 	"os"
 	"path/filepath"
+	"time"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/enrichment"
 )
 
 // repairKinds is the closed set of candidate kinds surfaced on the "Repair
@@ -286,4 +290,172 @@ func parseInt(s string) (int, error) {
 		n = n*10 + int(c-'0')
 	}
 	return n, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Action endpoints — POST /api/{enrichments|repairs}/{group}/action (#1016)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// candidateActionReq is the JSON body accepted by both action endpoints.
+type candidateActionReq struct {
+	CandidateID string `json:"candidate_id"`
+	// Action is "apply" or "reject".
+	Action string `json:"action"`
+	// Value is the proposed resolved value for apply; optional for enrichment candidates.
+	Value string `json:"value,omitempty"`
+	// Reason is an optional note stored in the rejection record.
+	Reason string `json:"reason,omitempty"`
+}
+
+// candidateActionResp is the JSON body returned on success.
+type candidateActionResp struct {
+	Success     bool   `json:"success"`
+	CandidateID string `json:"updated_candidate_id"`
+	ResolutionID string `json:"resolution_id,omitempty"`
+}
+
+// handleEnrichmentAction — POST /api/enrichments/{group}/action
+//
+// Applies or rejects one enrichment candidate. The write path mirrors the
+// MCP's handleSubmitEnrichment / handleRejectEnrichment using the shared
+// helpers extracted in internal/enrichment (#1016 tech-debt rule).
+func (s *Server) handleEnrichmentAction(w http.ResponseWriter, r *http.Request) {
+	s.handleCandidateAction(w, r, false)
+}
+
+// handleRepairAction — POST /api/repairs/{group}/action
+//
+// Applies or rejects one repair candidate. Rejects are stored in
+// enrichment-rejections.json; applies write a resolution row so the next
+// index run can consume them.
+func (s *Server) handleRepairAction(w http.ResponseWriter, r *http.Request) {
+	s.handleCandidateAction(w, r, true)
+}
+
+// handleCandidateAction is the shared body for both POST endpoints.
+// repairOnly=true means only repair-kind candidates are searched.
+func (s *Server) handleCandidateAction(w http.ResponseWriter, r *http.Request, repairOnly bool) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	var req candidateActionReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+	if req.CandidateID == "" {
+		writeErr(w, http.StatusBadRequest, "candidate_id required")
+		return
+	}
+	if req.Action != "apply" && req.Action != "reject" {
+		writeErr(w, http.StatusBadRequest, "action must be \"apply\" or \"reject\"")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// Search every repo for the candidate.
+	type matchResult struct {
+		repoPath  string
+		candidate candidateRaw
+	}
+	var match *matchResult
+	for _, repo := range grp.Repos {
+		if repo == nil || repo.Path == "" {
+			continue
+		}
+		for _, c := range readAllCandidates(repo.Path) {
+			if c.ID != req.CandidateID {
+				continue
+			}
+			// Enforce repair/enrichment partition.
+			isRepair := repairKinds[c.Kind]
+			if repairOnly && !isRepair {
+				continue
+			}
+			if !repairOnly && isRepair {
+				continue
+			}
+			match = &matchResult{repoPath: repo.Path, candidate: c}
+			break
+		}
+		if match != nil {
+			break
+		}
+	}
+	if match == nil {
+		writeErr(w, http.StatusNotFound, "candidate not found: "+req.CandidateID)
+		return
+	}
+
+	archigraphDir := daemon.StateDirForRepo(match.repoPath)
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	switch req.Action {
+	case "apply":
+		// Build a Resolution using the enrichment package's canonical type.
+		// SubjectID comes from the candidate; Kind and Value are required.
+		subjectID, _ := match.candidate.Context["subject_id"].(string)
+		if subjectID == "" {
+			subjectID = match.candidate.SubjectID
+		}
+		value := req.Value
+		if value == "" {
+			// Fall back to proposed_value from context if the caller omitted the field.
+			if pv, ok := match.candidate.Context["proposed_value"].(string); ok {
+				value = pv
+			}
+		}
+		res := enrichment.Resolution{
+			ID:         match.candidate.ID,
+			SubjectID:  subjectID,
+			Kind:       match.candidate.Kind,
+			Value:      value,
+			Confidence: match.candidate.Confidence,
+			Reason:     req.Reason,
+			ResolvedAt: now,
+		}
+		if err := enrichment.AppendResolution(archigraphDir, res); err != nil {
+			writeErr(w, http.StatusInternalServerError, "write resolution: "+err.Error())
+			return
+		}
+		if err := enrichment.RemoveCandidateByID(archigraphDir, match.candidate.ID); err != nil {
+			// Non-fatal: the candidate list will be rebuilt on the next index
+			// run, and the resolution is already written. Log and continue.
+			_ = err
+		}
+		writeJSON(w, http.StatusOK, candidateActionResp{
+			Success:      true,
+			CandidateID:  match.candidate.ID,
+			ResolutionID: match.candidate.ID,
+		})
+
+	case "reject":
+		subjectID, _ := match.candidate.Context["subject_id"].(string)
+		if subjectID == "" {
+			subjectID = match.candidate.SubjectID
+		}
+		reason := req.Reason
+		if reason == "" {
+			reason = "rejected via dashboard"
+		}
+		if err := enrichment.AppendRejection(archigraphDir, match.candidate.ID, subjectID, match.candidate.Kind, reason); err != nil {
+			writeErr(w, http.StatusInternalServerError, "write rejection: "+err.Error())
+			return
+		}
+		if err := enrichment.RemoveCandidateByID(archigraphDir, match.candidate.ID); err != nil {
+			_ = err
+		}
+		writeJSON(w, http.StatusOK, candidateActionResp{
+			Success:     true,
+			CandidateID: match.candidate.ID,
+		})
+	}
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -183,6 +183,9 @@ func (s *Server) routes() http.Handler {
 	// Pending queue — repair candidates + enrichment candidates (#987)
 	mux.HandleFunc("GET /api/repairs/{group}", s.handleRepairs)
 	mux.HandleFunc("GET /api/enrichments/{group}", s.handleEnrichments)
+	// Candidate apply/reject actions (#1016)
+	mux.HandleFunc("POST /api/repairs/{group}/action", s.handleRepairAction)
+	mux.HandleFunc("POST /api/enrichments/{group}/action", s.handleEnrichmentAction)
 
 	// Build / version info
 	mux.HandleFunc("GET /api/info", s.handleInfo)

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -542,6 +542,125 @@ func ApplyCommunityNameResolutions(doc *graph.Document, resolutions []Resolution
 	return applied
 }
 
+// AppendResolution appends one resolution record to
+// <archigraphDir>/enrichment-resolutions.json atomically. The existing
+// array is read, the new entry appended, and the file rewritten so
+// callers never leave a half-written file.
+func AppendResolution(archigraphDir string, res Resolution) error {
+	if archigraphDir == "" {
+		return fmt.Errorf("enrichment: archigraphDir is empty")
+	}
+	if err := os.MkdirAll(archigraphDir, 0o755); err != nil {
+		return err
+	}
+	path := resolutionsPath(archigraphDir)
+	cur := ReadResolutions(archigraphDir)
+	cur = append(cur, res)
+	data, err := json.MarshalIndent(cur, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// AppendRejection appends one rejection record to
+// <archigraphDir>/enrichment-rejections.json. Tolerates a missing file.
+func AppendRejection(archigraphDir, candidateID, subjectID, kind, reason string) error {
+	if archigraphDir == "" {
+		return fmt.Errorf("enrichment: archigraphDir is empty")
+	}
+	if err := os.MkdirAll(archigraphDir, 0o755); err != nil {
+		return err
+	}
+	path := rejectionsPath(archigraphDir)
+	var cur []Rejection
+	if data, err := os.ReadFile(path); err == nil {
+		_ = json.Unmarshal(data, &cur)
+	}
+	now := time.Now().UTC().Format(time.RFC3339)
+	cur = append(cur, Rejection{
+		ID:         candidateID,
+		SubjectID:  subjectID,
+		Kind:       kind,
+		Reason:     reason,
+		RejectedAt: now,
+	})
+	data, err := json.MarshalIndent(cur, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
+// RemoveCandidateByID removes the candidate with the given ID from
+// <archigraphDir>/enrichment-candidates.json (if present). Returns nil
+// when the candidate is absent (idempotent).
+func RemoveCandidateByID(archigraphDir, candidateID string) error {
+	if archigraphDir == "" {
+		return fmt.Errorf("enrichment: archigraphDir is empty")
+	}
+	path := candidatesPath(archigraphDir)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return err
+	}
+	// Parse using whichever shape is on disk.
+	var candidates []Candidate
+	var envelope candidatesEnvelope
+	useEnvelope := false
+	if jsonErr := json.Unmarshal(data, &envelope); jsonErr == nil && (envelope.Version > 0 || len(envelope.Candidates) > 0) {
+		candidates = envelope.Candidates
+		useEnvelope = true
+	} else if jsonErr := json.Unmarshal(data, &candidates); jsonErr != nil {
+		return jsonErr
+	}
+	// Filter out the target.
+	filtered := candidates[:0]
+	for _, c := range candidates {
+		if c.ID != candidateID {
+			filtered = append(filtered, c)
+		}
+	}
+	var out []byte
+	if useEnvelope {
+		envelope.Candidates = filtered
+		out, err = json.MarshalIndent(envelope, "", "  ")
+	} else {
+		out, err = json.MarshalIndent(filtered, "", "  ")
+	}
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return err
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return err
+	}
+	return nil
+}
+
 // ApplyResolutions merges resolved enrichment values into the document
 // in-place. The resolution.Value is written to entity.Properties under
 // the resolution.Kind key, mirroring internal/mcp/enrichment.go.

--- a/internal/mcp/candidates.go
+++ b/internal/mcp/candidates.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/enrichment"
 )
 
 // LinkCandidate is one row in <group>-link-candidates.json.
@@ -129,45 +130,29 @@ func appendLink(group string, link CrossRepoLink) error {
 }
 
 // appendResolution appends an enrichment resolution to the repo's
-// enrichment-resolutions.json (array form).
+// enrichment-resolutions.json. Delegates to the canonical implementation
+// in internal/enrichment to avoid parallel implementations (#1016).
 func appendResolution(repoPath string, res EnrichmentResolution) error {
 	if repoPath == "" {
 		return fmt.Errorf("repo path is empty")
 	}
-	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-resolutions.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	cur := readResolutions(repoPath)
-	cur = append(cur, res)
-	data, err := json.MarshalIndent(cur, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o644)
+	archigraphDir := daemon.StateDirForRepo(repoPath)
+	return enrichment.AppendResolution(archigraphDir, enrichment.Resolution{
+		ID:         res.CandidateID,
+		SubjectID:  res.NodeID,
+		Kind:       res.Kind,
+		Value:      res.Value,
+		Confidence: res.Confidence,
+		Reason:     res.Reason,
+	})
 }
 
 // appendRejection appends a rejection record to enrichment-rejections.json.
+// Delegates to the canonical implementation in internal/enrichment (#1016).
 func appendRejection(repoPath string, candidateID, reason string) error {
 	if repoPath == "" {
 		return fmt.Errorf("repo path is empty")
 	}
-	path := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-rejections.json")
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return err
-	}
-	type rej struct {
-		CandidateID string `json:"candidate_id"`
-		Reason      string `json:"reason"`
-	}
-	var cur []rej
-	if data, err := os.ReadFile(path); err == nil {
-		_ = json.Unmarshal(data, &cur)
-	}
-	cur = append(cur, rej{CandidateID: candidateID, Reason: reason})
-	data, err := json.MarshalIndent(cur, "", "  ")
-	if err != nil {
-		return err
-	}
-	return os.WriteFile(path, data, 0o644)
+	archigraphDir := daemon.StateDirForRepo(repoPath)
+	return enrichment.AppendRejection(archigraphDir, candidateID, "", "", reason)
 }


### PR DESCRIPTION
## Summary

- Wire `POST /api/enrichments/{group}/action` and `POST /api/repairs/{group}/action` in the dashboard REST layer so the Pending surface Apply/Reject buttons actually reach the backend.
- Extract `AppendResolution`, `AppendRejection`, `RemoveCandidateByID` into `internal/enrichment` as the single canonical write path — MCP delegates to the same helpers (no parallel implementations).
- 9 new unit tests covering all paths; 6/6 E2E integration assertions pass.

## What changed

### `internal/enrichment/candidates.go`
Three new exported helpers extracted from the MCP layer:
- `AppendResolution(archigraphDir, Resolution)` — atomic append to enrichment-resolutions.json
- `AppendRejection(archigraphDir, candidateID, subjectID, kind, reason)` — atomic append to enrichment-rejections.json
- `RemoveCandidateByID(archigraphDir, candidateID)` — idempotent candidate removal (tolerates both envelope and bare-array schemas)

### `internal/dashboard/handlers_repairs.go`
- `handleEnrichmentAction` / `handleRepairAction` — thin wrappers around shared `handleCandidateAction`
- `handleCandidateAction(repairOnly bool)` — validates body, locates candidate in the group's repos, enforces repair-vs-enrichment partition, delegates apply/reject to the `internal/enrichment` helpers
- apply path: writes resolution + removes candidate; reject path: writes rejection + removes candidate

### `internal/dashboard/server.go`
```
POST /api/enrichments/{group}/action  →  handleEnrichmentAction
POST /api/repairs/{group}/action      →  handleRepairAction
```

### `internal/mcp/candidates.go`
`appendResolution` and `appendRejection` now delegate to `enrichment.AppendResolution` / `enrichment.AppendRejection` — the duplicate write logic is gone.

### `internal/dashboard/handlers_action_test.go` (new)
9 unit tests: missing `candidate_id` → 400, bad action → 400, unknown candidate → 404, bad group → 404, reject enrichment (writes rejections.json + removes candidate), apply enrichment (writes resolutions.json + removes candidate), repair endpoint refuses enrichment kind, enrichment endpoint refuses repair kind, apply repair candidate.

## Test plan

- [x] `go test ./internal/enrichment/ ./internal/dashboard/ ./internal/mcp/` — 9 new tests PASS; 3 pre-existing failures unchanged
- [x] `go build ./...` clean
- [x] `go vet ./internal/enrichment/ ./internal/dashboard/ ./internal/mcp/` clean
- [x] E2E integration (curl against new binary + live upvate group): reject 200 + candidate removed from list, apply 200 + resolution_id in response, invalid action → 400, unknown candidate → 404, repair endpoint rejects enrichment-kind candidate → 404

Closes #1016

🤖 Generated with [Claude Code](https://claude.com/claude-code)