### PR TITLE
Add wait-time guidance and discoverability for /generate-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,22 @@ make build
 ./archigraph --version
 ```
 
+## Quick start
+
+```sh
+# 1. Create a group and index your repos
+archigraph wizard
+archigraph install <group>
+
+# 2. Open the dashboard
+archigraph dashboard
+
+# 3. Generate docs (in Claude Code)
+/generate-docs
+```
+
+The `/generate-docs` skill produces per-repo documentation (overview, module guides, API reference, patterns) and a cross-repo synthesis. It runs a 12-pass pipeline that typically takes 25–60 minutes for small repos, 1–2 hours for medium repos, and 2–4 hours for large repos. Estimates and pass details are in the [generate-docs skill docs](skills/generate-docs/SKILL.md).
+
 ## Usage
 
 archigraph is a CLI plus a unified daemon process that manages indexing,

--- a/dashboard/src/components/docs/DocsEmptyState.tsx
+++ b/dashboard/src/components/docs/DocsEmptyState.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, RefreshCw } from 'lucide-react'
+import { BookOpen, RefreshCw, ExternalLink } from 'lucide-react'
 
 interface DocsEmptyStateProps {
   group: string
@@ -11,7 +11,8 @@ interface DocsEmptyStateProps {
  * Renders:
  *  - Heading + explanation paragraph
  *  - Numbered step list with the /generate-docs skill command
- *  - Code block for the command
+ *  - Structured time-estimate table (per repo size)
+ *  - Links to skill documentation and troubleshooting
  *  - "Try Again" button to re-fetch
  */
 export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
@@ -36,7 +37,7 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
         searchable, cross-linked portal.
       </p>
 
-      <ol className="text-left max-w-md w-full space-y-3 mb-6 list-none">
+      <ol className="text-left max-w-2xl w-full space-y-3 mb-6 list-none">
         <li className="flex gap-3 text-sm text-slate-700 dark:text-slate-300">
           <span className="flex-shrink-0 w-5 h-5 rounded-full bg-indigo-600 text-white text-xs flex items-center justify-center font-semibold">
             1
@@ -59,8 +60,33 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
             2
           </span>
           <span>
-            Wait for the pipeline to complete — typically 5–20 minutes
-            depending on codebase size.
+            <span className="block mb-3">
+              Wait for the pipeline to complete. Time depends on codebase size:
+            </span>
+            <div className="inline-block text-left text-xs border border-slate-300 dark:border-slate-600 rounded overflow-hidden">
+              <table className="border-collapse">
+                <thead>
+                  <tr className="bg-slate-100 dark:bg-slate-800 border-b border-slate-300 dark:border-slate-600">
+                    <th className="px-3 py-2 text-left font-semibold">Codebase size</th>
+                    <th className="px-3 py-2 text-left font-semibold">Est. time</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <tr className="border-b border-slate-300 dark:border-slate-600">
+                    <td className="px-3 py-1.5">Small (1k entities)</td>
+                    <td className="px-3 py-1.5">~25–30 min</td>
+                  </tr>
+                  <tr className="border-b border-slate-300 dark:border-slate-600">
+                    <td className="px-3 py-1.5">Medium (10k entities)</td>
+                    <td className="px-3 py-1.5">~1–2 hours</td>
+                  </tr>
+                  <tr>
+                    <td className="px-3 py-1.5">Large (100k+ entities)</td>
+                    <td className="px-3 py-1.5">~2–4 hours</td>
+                  </tr>
+                </tbody>
+              </table>
+            </div>
           </span>
         </li>
 
@@ -71,6 +97,36 @@ export function DocsEmptyState({ group, onRetry }: DocsEmptyStateProps) {
           <span>Refresh this page — the docs tree will appear in the sidebar.</span>
         </li>
       </ol>
+
+      <div className="max-w-2xl w-full mb-6 p-4 rounded border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/30">
+        <p className="text-xs text-slate-600 dark:text-slate-400 mb-3">
+          <strong>Learning more:</strong>
+        </p>
+        <ul className="text-xs text-slate-600 dark:text-slate-400 space-y-2">
+          <li className="flex items-start gap-2">
+            <span className="text-slate-400 dark:text-slate-500 mt-0.5">•</span>
+            <span>
+              For detailed pass-by-pass timing, pass descriptions, and troubleshooting, see the{' '}
+              <a
+                href="https://github.com/cajasmota/archigraph/blob/main/skills/generate-docs/SKILL.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-indigo-600 dark:text-indigo-300 hover:underline inline-flex items-center gap-1"
+              >
+                /generate-docs skill documentation
+                <ExternalLink className="w-3 h-3" aria-hidden />
+              </a>
+              .
+            </span>
+          </li>
+          <li className="flex items-start gap-2">
+            <span className="text-slate-400 dark:text-slate-500 mt-0.5">•</span>
+            <span>
+              If the pipeline hangs, consult the "If a pass appears to hang" section in the skill docs for recovery steps.
+            </span>
+          </li>
+        </ul>
+      </div>
 
       {onRetry && (
         <button

--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -25,24 +25,35 @@ If the daemon is not running, the skill stops at Pass 0 and tells the user to ru
 
 The skill is a strict pipeline. Each pass has a dedicated prompt file under `prompts/`. A subagent reads the prompt and follows it; the orchestrator (this skill) tracks progress and gates each pass on the previous one's output.
 
-| Pass | Prompt | Purpose |
-|------|--------|---------|
-| 0 | `prompts/00-domain-qa.md` | First-run domain interview: what is this group, who owns it, what are the deployment boundaries. |
-| 1 | `prompts/01-inventory.md` | Discover repos and entities via `archigraph_find` / `archigraph_stats` / `archigraph_clusters`. |
-| 1a | `prompts/01a-residual-repair-sweep.md` | Pre-Q&A repair sweep (ADR-0015): list residuals via `archigraph_repairs(action=list)`, auto-resolve unambiguous ones, surface the rest as questions for Pass 1b. |
-| 1b | `prompts/01b-repair-aware-qa.md` | Repair-aware Q&A: walk the user through residuals Pass 1a could not auto-resolve; each answer becomes an `archigraph_repairs(action=submit)` call. |
-| 2 | `prompts/02-plan.md` | Produce a per-module documentation plan with token estimates. |
-| 3 | `prompts/03-overview.md` | Repo-level `overview.md` for every repo. |
-| 3a | `prompts/03a-generation-time-repair.md` | Hook (not a standalone pass): every writer in Passes 3-6 + 12 inspects outbound residuals of the entity it is about to describe, repairs in-place when possible, documents as runtime-resolved otherwise. |
-| 4 | `prompts/04-cluster.md` | Per-module deep-dive (parallel writer subagents, one per cluster). |
-| 5 | `prompts/05-reference.md` | Reference docs: API, config, deployment, scripts, dependencies. |
-| 6 | `prompts/06-cross-cutting.md` | Cross-cutting concerns: auth, logging, error handling, observability. |
-| 7 | `prompts/07-group-synthesis.md` | Group-level synthesis page that ties the repos together. (Cross-repo chains pending #769; until then writers should reach cross-repo via `archigraph_cross_links`). |
-| 8 | `prompts/08-cross-link.md` | Validate links and resolve cross-repo link candidates via `archigraph_cross_links`. |
-| — | *(Pass 9 reserved — planned for milestone-2 doc-site work)* | |
-| 10 | `prompts/10-pattern-convergence.md` | Aggregate subagent pattern candidates + promote convergent ones (ADR-0018 Phase 4). |
-| 11 | `prompts/11-pattern-cross-link.md` | Populate each approved pattern's `documentation_url` (ADR-0018 Phase 5). |
-| 12 | `prompts/12-pattern-prose.md` | Emit `docs/patterns/<category>/<id>.md` per approved pattern (ADR-0018 Phase 6). |
+### Expected time per pass
+
+Time estimates assume typical small-to-medium codebases (1k–10k source entities). Larger corpora (100k+ entities) may take 2–3× longer in inventory and parallel passes.
+
+| Pass | Prompt | Purpose | Est. time |
+|------|--------|---------|-----------|
+| 0 | `prompts/00-domain-qa.md` | First-run domain interview: what is this group, who owns it, what are the deployment boundaries. | 5–10 min interactive |
+| 1 | `prompts/01-inventory.md` | Discover repos and entities via `archigraph_find` / `archigraph_stats` / `archigraph_clusters`. | 2–5 min |
+| 1a | `prompts/01a-residual-repair-sweep.md` | Pre-Q&A repair sweep (ADR-0015): list residuals via `archigraph_repairs(action=list)`, auto-resolve unambiguous ones, surface the rest as questions for Pass 1b. | 1–3 min |
+| 1b | `prompts/01b-repair-aware-qa.md` | Repair-aware Q&A: walk the user through residuals Pass 1a could not auto-resolve; each answer becomes an `archigraph_repairs(action=submit)` call. | 2–10 min (depends on residual count) |
+| 2 | `prompts/02-plan.md` | Produce a per-module documentation plan with token estimates. | 2–3 min |
+| 3 | `prompts/03-overview.md` | Repo-level `overview.md` for every repo. | 3–5 min |
+| 3a | `prompts/03a-generation-time-repair.md` | Hook (not a standalone pass): every writer in Passes 3-6 + 12 inspects outbound residuals of the entity it is about to describe, repairs in-place when possible, documents as runtime-resolved otherwise. | (integrated into Passes 3–6 + 12) |
+| 4 | `prompts/04-cluster.md` | Per-module deep-dive (parallel writer subagents, one per cluster). | 5–20 min (highly parallelized) |
+| 5 | `prompts/05-reference.md` | Reference docs: API, config, deployment, scripts, dependencies. | 3–8 min |
+| 6 | `prompts/06-cross-cutting.md` | Cross-cutting concerns: auth, logging, error handling, observability. | 2–5 min |
+| 7 | `prompts/07-group-synthesis.md` | Group-level synthesis page that ties the repos together. (Cross-repo chains pending #769; until then writers should reach cross-repo via `archigraph_cross_links`). | 3–5 min |
+| 8 | `prompts/08-cross-link.md` | Validate links and resolve cross-repo link candidates via `archigraph_cross_links`. | 2–4 min |
+| — | *(Pass 9 reserved — planned for milestone-2 doc-site work)* | | |
+| 10 | `prompts/10-pattern-convergence.md` | Aggregate subagent pattern candidates + promote convergent ones (ADR-0018 Phase 4). | 2–3 min |
+| 11 | `prompts/11-pattern-cross-link.md` | Populate each approved pattern's `documentation_url` (ADR-0018 Phase 5). | 1–2 min |
+| 12 | `prompts/12-pattern-prose.md` | Emit `docs/patterns/<category>/<id>.md` per approved pattern (ADR-0018 Phase 6). | 2–4 min |
+
+**Total wall time:** typically **25–60 minutes** for small repos (1k entities), **1–2 hours** for medium repos (10k entities), **2–4 hours** for large repos (100k+ entities). Pass 4 parallelizes across module clusters, so the critical path is dominated by Pass 0 (user interaction), Passes 1–2 (discovery), and Passes 4–5 (content generation).
+
+If a pass appears to hang:
+1. Check `archigraph status` — the daemon must be running and idle (not indexing another repo).
+2. Check the agent console in Claude Code for errors. Common issues: daemon timeout, network glitch, or user timeout in Pass 1b (too many residuals to resolve interactively).
+3. To resume, re-invoke `/generate-docs` in the same CWD — the orchestrator checks for completed passes and skips them.
 
 During Pass 4 (per-module writers), each subagent additionally emits `PatternCandidate` entities via `archigraph_patterns(action=record, as_candidate=true)` whenever it observes ≥ `per_subagent_threshold` (default 2) instances of a structural recurrence in its slice. The candidates aggregate in Pass 10, cross-link in Pass 11, and produce dedicated markdown in Pass 12. The full design is in [ADR-0018](../../docs/adrs/0018-agent-learned-patterns.md).
 


### PR DESCRIPTION
## Summary

This PR bundles fixes for two related docs-system UX issues:
- **#1017**: Users invoking `/generate-docs` lack guidance on expected runtime per pass
- **#1018**: New users see an empty docs state with no path to discovery of the skill

## What we did

### #1017 — Expected-wait-time guidance
- **`skills/generate-docs/SKILL.md`**: Added per-pass time estimates to the Pass table (e.g., "Pass 0: 5–10 min interactive", "Pass 4: 5–20 min"). Included a summary table mapping repo size (small/medium/large) to total wall time (25–60 min to 2–4 hours)
- Added troubleshooting section covering hang detection and recovery steps

### #1018 — Discoverability gap
- **`DocsEmptyState.tsx`**: Replaced generic "5–20 minutes" placeholder with a structured timing table showing estimates for small (1k entities), medium (10k), and large (100k+) codebases
- Added "Learning more" section with a direct GitHub link to the full `/generate-docs` skill documentation
- Expanded component max-width to accommodate new table layout

- **`README.md`**: Added a new "Quick start" section at the top of Usage, immediately highlighting `/generate-docs` as the post-install entrypoint for documentation generation. Included links to the skill docs for detailed pass descriptions and time estimates

## What we won

- **Reduced friction**: Users no longer wonder if the pipeline is hung or progressing normally
- **Increased discoverability**: New users with empty docs immediately see how to invoke documentation generation, plus direct links to detailed guidance
- **Clearer expectations**: Three-tier timing (small/medium/large) helps users mentally model duration based on their codebase
- **Better discovery path**: README → Quick start → /generate-docs → dashboard link in DocsEmptyState forms a coherent onboarding flow

## What it means for memory

These changes are baseline UX hygiene for the docs portal. Future work can build on this foundation (e.g., real-time progress tracking via `docgen_status.json` in #1017 optional section).

## What it means for MCP

No MCP changes. The skill definition remains stable; these are documentation and UI enhancements only.

## Caveats

- Time estimates assume typical small-to-medium codebases (1k–10k entities); larger corpora may see 2–3× variance
- Troubleshooting section gives manual recovery steps; automated resume logic was deferred to future work
- DocsEmptyState table uses responsive table styling but does not adapt column count for very narrow mobile viewports (acceptable for now, can refine in future polish passes)

## Bottom-line

Users now have clear, visible guidance on expected wait times and an obvious path to discovering `/generate-docs` from the empty docs state. Both issues resolved via minimal, focused changes to documentation and UI text.

Closes #1017 #1018