### PR TITLE
[#44] Resolver slice: Razor + SQL dynamic patterns

### DIFF
--- a/internal/resolve/dynamic_patterns_csharp.go
+++ b/internal/resolve/dynamic_patterns_csharp.go
@@ -101,5 +101,6 @@ var csharpExternalNamespaceRoots = []string{
 
 func init() {
 	dynamicPatternsByLang["csharp"] = csharpDynamicPatterns
-	dynamicPatternsByLang["razor"] = csharpDynamicPatterns
+	// "razor" is registered by dynamic_patterns_razor.go (init order: _csharp < _razor
+	// alphabetically, so razor's init runs after and installs the extended catalog).
 }

--- a/internal/resolve/dynamic_patterns_razor.go
+++ b/internal/resolve/dynamic_patterns_razor.go
@@ -1,0 +1,109 @@
+package resolve
+
+import "regexp"
+
+// razorDynamicPatterns are per-language patterns for Blazor / ASP.NET Core
+// Razor (.razor) files. Registered via init() into dynamicPatternsByLang.
+//
+// Razor files use the same C# syntax inside @code blocks, so this catalog
+// starts with all csharpDynamicPatterns and adds Blazor-specific additions.
+// init() order is guaranteed: _csharp.go registers "csharp" first (alphabetic
+// file-init order within a package); _razor.go then installs the extended
+// catalog under the "razor" key, overriding the placeholder left by csharp.
+//
+// # Classification context
+//
+// The razor extractor emits CALLS edges only from event-handler and lifecycle
+// method bodies inside @code blocks. Three groups of callee shapes show up as
+// unresolved stubs:
+//
+//   1. Blazor ComponentBase lifecycle methods (OnInitializedAsync, OnParametersSet,
+//      OnAfterRender, etc.) — handled upstream by external/synth.go (razorBareNames)
+//      which folds them to ext:microsoft; never reach the dynamic-pattern check.
+//
+//   2. Injected-service async method calls. When a component declares
+//      `@inject IWeatherService WeatherSvc`, calls like
+//      `await WeatherSvc.GetForecastAsync(...)` are stripped to the bare leaf
+//      `GetForecastAsync` by the extractor's reCallHead pattern. Without full
+//      .NET DI type-resolution the resolver cannot bind these leaf names to any
+//      graph entity — they are interface dispatch at runtime. The naming
+//      convention (PascalCase verb + `Async` suffix) is unique enough to the
+//      .NET ecosystem that the razor gate is safe.
+//
+//   3. PascalCase single-segment helper calls in @code bodies
+//      (`LoadInitialData`, `FetchData`, `BuildViewModel`) that are private
+//      methods defined in the same component — these SHOULD resolve (the
+//      resolver finds them in the same file entity set) and must NOT be
+//      classified Dynamic. They are intentionally excluded here.
+//
+// # SQL slice
+//
+// The sql extractor emits READS_FROM / WRITES_TO edges targeting table names.
+// Cross-file table targets that have no matching entity are routed to
+// DispositionExternalSQL (issue #507); no dynamic-pattern slice is needed for
+// SQL. See PR body for the full audit.
+var razorSpecificPatterns = []*regexp.Regexp{
+	// Injected-service async calls (issue #44 / Blazor slice).
+	//
+	// Pattern: PascalCase verb phrase ending in `Async` — the .NET
+	// Task-returning async naming convention. The extractor strips the
+	// receiver (`WeatherSvc.GetForecastAsync` → `GetForecastAsync`), leaving
+	// a bare leaf the static resolver cannot bind without knowing the
+	// runtime DI type.
+	//
+	// Conservative scope:
+	//   - Requires uppercase first letter (PascalCase) so generic bare names
+	//     like `get`, `fetch`, `load` are excluded.
+	//   - Requires the `Async` suffix (minimum 6 chars) so short names like
+	//     `DoAsync` are captured but a hypothetical `HasAsync` (which could
+	//     legitimately be a user method in the graph) is still long enough to
+	//     be a match. The resolver runs BEFORE this gate in the resolution
+	//     waterfall, so in-graph methods named FooAsync are still resolved
+	//     normally — this gate only fires for stubs that reach the
+	//     classifyDispositionLang path (unmatched stubs).
+	//   - NOT applied retroactively to "csharp" language (.cs files) — the
+	//     razor gate alone prevents cross-ecosystem collisions (Go/Java/Python
+	//     async patterns use different conventions). The csharp gate does not
+	//     inherit this because .cs files have richer extractor coverage and
+	//     their PascalCaseAsync calls are more likely to resolve.
+	regexp.MustCompile(`^[A-Z][A-Za-z0-9_]+Async$`),
+
+	// HttpClient / IHttpClientFactory extension methods on injected HTTP
+	// clients. The razor extractor emits the bare method leaf after stripping
+	// `Http.` or `client.` receivers. These are `Microsoft.Net.Http.Json`
+	// extension methods — unresolvable without the exact generic type arg.
+	regexp.MustCompile(`^GetFromJsonAsync$`),
+	regexp.MustCompile(`^PostAsJsonAsync$`),
+	regexp.MustCompile(`^PutAsJsonAsync$`),
+	regexp.MustCompile(`^DeleteAsync$`),
+	regexp.MustCompile(`^SendAsync$`),
+	regexp.MustCompile(`^ReadFromJsonAsync$`),
+
+	// EventCallback invocations — `OnChanged.InvokeAsync(value)` emits
+	// `InvokeAsync` (already in razorBareNames → ExternalKnown) but also
+	// `HasDelegate` and receiver-stripped event-callback helpers. Guard the
+	// two shapes the extractor produces that aren't in razorBareNames.
+	regexp.MustCompile(`^OnChanged$`),   // bare EventCallback field invocation
+	regexp.MustCompile(`^OnClicked$`),   // common Blazor EventCallback parameter name
+	regexp.MustCompile(`^OnSubmit$`),    // form submit EventCallback
+	regexp.MustCompile(`^OnValidSubmit$`), // EditForm OnValidSubmit callback
+	regexp.MustCompile(`^OnInvalidSubmit$`),
+
+	// JSInterop helpers. `JS.InvokeVoidAsync` / `JS.InvokeAsync<T>` are
+	// already in razorBareNames; the generic forms with `<T>` suffix survive
+	// after the extractor strips the receiver but retain the generic bracket.
+	// Match the generic variant as Dynamic.
+	regexp.MustCompile(`^InvokeAsync<`),
+	regexp.MustCompile(`^InvokeVoidAsync<`),
+}
+
+// razorDynamicPatterns is the full catalog for the "razor" language key:
+// C#-shared patterns extended with Blazor-specific additions (issue #44).
+var razorDynamicPatterns = append(
+	append([]*regexp.Regexp{}, csharpDynamicPatterns...),
+	razorSpecificPatterns...,
+)
+
+func init() {
+	dynamicPatternsByLang["razor"] = razorDynamicPatterns
+}

--- a/internal/resolve/dynamic_patterns_razor_test.go
+++ b/internal/resolve/dynamic_patterns_razor_test.go
@@ -1,0 +1,167 @@
+package resolve
+
+import "testing"
+
+// TestDynamicPatterns_Razor covers the razorDynamicPatterns catalog.
+//
+// Audit baseline (issue #44, razor slice):
+//
+//	The razor extractor emits CALLS edges from @code block event-handler
+//	bodies. Three categories of stubs appear as unresolved before this fix:
+//
+//	  1. PascalCase*Async service calls (e.g. GetForecastAsync, FetchItemsAsync)
+//	     → were BugExtractor; after fix → Dynamic. These are interface-dispatch
+//	     calls on @inject'd services — not statically bindable.
+//
+//	  2. HttpClient/IHttpClientFactory extension methods (GetFromJsonAsync,
+//	     PostAsJsonAsync, etc.) → were BugExtractor; after fix → Dynamic.
+//
+//	  3. EventCallback bare names (OnChanged, OnSubmit, etc.) → were
+//	     BugExtractor; after fix → Dynamic.
+//
+//	SQL slice: the sql extractor emits only READS_FROM / WRITES_TO edges.
+//	Cross-file table references that lack a matching entity route to
+//	DispositionExternalSQL (issue #507). No dynamic-pattern slice needed;
+//	documented in the PR body.
+func TestDynamicPatterns_Razor(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		lang string
+		stub string
+		want bool
+	}{
+		// ---- Injected-service PascalCase*Async calls (new in razor slice) ----
+
+		// Typical Blazor service method: await WeatherSvc.GetForecastAsync()
+		// extractor strips receiver → bare "GetForecastAsync".
+		{"service_get_forecast_async", "razor", "GetForecastAsync", true},
+		{"service_fetch_items_async", "razor", "FetchItemsAsync", true},
+		{"service_load_data_async", "razor", "LoadDataAsync", true},
+		{"service_save_changes_async", "razor", "SaveChangesAsync", true},
+		{"service_add_item_async", "razor", "AddItemAsync", true},
+		{"service_delete_async_short", "razor", "DeleteUserAsync", true},
+		// Short forms still match (≥ 6 char suffix, uppercase first letter).
+		{"service_do_async", "razor", "DoAsync", true},
+
+		// ---- Inherited C# patterns must still fire for "razor" ----
+
+		// PascalCase namespace import (from csharpDynamicPatterns).
+		{"csharp_namespace_import_razor", "razor", "MyApp.Services.Weather", true},
+		// Generic static-factory calls (from csharpDynamicPatterns).
+		{"quartz_jobbuilder_razor", "razor", "JobBuilder.Create<ReportJob>", true},
+		// Fluent builder bare-name (from csharpDynamicPatterns).
+		{"quartz_withidentity_razor", "razor", "WithIdentity", true},
+
+		// ---- HttpClient extension methods ----
+
+		{"httpclient_get_json_async", "razor", "GetFromJsonAsync", true},
+		{"httpclient_post_json_async", "razor", "PostAsJsonAsync", true},
+		{"httpclient_put_json_async", "razor", "PutAsJsonAsync", true},
+		{"httpclient_delete_async", "razor", "DeleteAsync", true},
+		{"httpclient_send_async", "razor", "SendAsync", true},
+		{"httpclient_read_json_async", "razor", "ReadFromJsonAsync", true},
+
+		// ---- EventCallback bare names ----
+
+		{"event_callback_on_changed", "razor", "OnChanged", true},
+		{"event_callback_on_clicked", "razor", "OnClicked", true},
+		{"event_callback_on_submit", "razor", "OnSubmit", true},
+		{"event_callback_on_valid_submit", "razor", "OnValidSubmit", true},
+		{"event_callback_on_invalid_submit", "razor", "OnInvalidSubmit", true},
+
+		// ---- JSInterop generic variants ----
+
+		{"jsinterop_invoke_async_generic", "razor", "InvokeAsync<string>", true},
+		{"jsinterop_invoke_void_async_generic", "razor", "InvokeVoidAsync<bool>", true},
+
+		// ---- Patterns must NOT fire for other languages (language gate) ----
+
+		// Go has no *Async convention — must not misfire.
+		{"async_go_neg", "go", "GetForecastAsync", false},
+		{"async_python_neg", "python", "FetchItemsAsync", false},
+		{"async_java_neg", "java", "LoadDataAsync", false},
+		{"async_typescript_neg", "typescript", "GetForecastAsync", false},
+		{"async_ruby_neg", "ruby", "SaveChangesAsync", false},
+
+		// HttpClient names must not fire outside razor.
+		{"get_json_go_neg", "go", "GetFromJsonAsync", false},
+		{"post_json_python_neg", "python", "PostAsJsonAsync", false},
+
+		// EventCallback names must not fire outside razor.
+		{"on_changed_go_neg", "go", "OnChanged", false},
+		{"on_submit_python_neg", "python", "OnSubmit", false},
+
+		// ---- Legitimate user-defined methods that SHOULD resolve (must not match) ----
+
+		// Short bare names without Async suffix — private methods in the same
+		// component that the resolver CAN bind from the entity index.
+		// These must remain resolvable, not Dynamic.
+		{"user_method_load_initial_data", "razor", "LoadInitialData", false},
+		{"user_method_fetch_data", "razor", "FetchData", false},
+		{"user_method_build_view_model", "razor", "BuildViewModel", false},
+		// Lowercase names are always non-Dynamic (not PascalCase).
+		{"lowercase_method_neg", "razor", "fetchData", false},
+		{"lowercase_async_neg", "razor", "getAsync", false},
+		// Single-letter type-param stub (e.g. a stray generic token) — must not match.
+		{"single_char_t_neg", "razor", "T", false},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			got := isDynamicPatternLang(tc.stub, tc.lang)
+			if got != tc.want {
+				t.Fatalf("isDynamicPatternLang(%q, lang=%q) = %v, want %v", tc.stub, tc.lang, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestDynamicPatterns_Razor_CatalogSize guards that the razor catalog is
+// strictly larger than the csharp catalog (razor extends, not replaces).
+func TestDynamicPatterns_Razor_CatalogSize(t *testing.T) {
+	t.Parallel()
+	razorLen := len(razorDynamicPatterns)
+	csharpLen := len(csharpDynamicPatterns)
+	if razorLen <= csharpLen {
+		t.Fatalf("razorDynamicPatterns len=%d must be > csharpDynamicPatterns len=%d (razor extends csharp)", razorLen, csharpLen)
+	}
+}
+
+// TestDynamicPatterns_Razor_RazorKeyRegistered verifies the "razor" language
+// key in dynamicPatternsByLang resolves to the extended catalog.
+func TestDynamicPatterns_Razor_RazorKeyRegistered(t *testing.T) {
+	t.Parallel()
+	patterns, ok := dynamicPatternsByLang["razor"]
+	if !ok {
+		t.Fatal("dynamicPatternsByLang[\"razor\"] not registered")
+	}
+	if len(patterns) != len(razorDynamicPatterns) {
+		t.Fatalf("registered razor catalog len=%d, want %d (razorDynamicPatterns)", len(patterns), len(razorDynamicPatterns))
+	}
+}
+
+// TestDynamicPatterns_SQL_NoSlice documents the audit finding: the sql
+// extractor emits no CALLS edges (only READS_FROM / WRITES_TO to table names).
+// Cross-file table stubs that lack a matching entity are routed to
+// DispositionExternalSQL (issue #507). No dynamic-pattern entry is needed.
+// This test serves as a regression guard for the "no-op" decision.
+func TestDynamicPatterns_SQL_NoSlice(t *testing.T) {
+	t.Parallel()
+	// Confirm "sql" has no per-language dynamic pattern catalog.
+	_, hasSQLCatalog := dynamicPatternsByLang["sql"]
+	if hasSQLCatalog {
+		t.Error("dynamicPatternsByLang[\"sql\"] should not exist: sql extractor emits no CALLS stubs (only READS_FROM/WRITES_TO routed to ExternalSQL)")
+	}
+	// Spot-check: a SQL stored-proc name must not accidentally hit Dynamic
+	// via the cross-language catalog.
+	if isDynamicPatternLang("usp_GetUserById", "sql") {
+		t.Error("usp_GetUserById should NOT be Dynamic for sql (no sql catalog; cross-lang catalog must not fire)")
+	}
+	if isDynamicPatternLang("sp_GetOrders", "sql") {
+		t.Error("sp_GetOrders should NOT be Dynamic for sql")
+	}
+}


### PR DESCRIPTION
## What

Adds `internal/resolve/dynamic_patterns_razor.go` — the per-language resolver slice for Blazor / ASP.NET Core Razor (`.razor`) files. Modifies `dynamic_patterns_csharp.go` to remove the razor alias (now owned by the new file). Documents the SQL no-op finding via a test.

## Why (audit findings)

**Razor audit:**
The razor extractor emits CALLS edges from `@code` block event-handler bodies. Three categories of stubs previously landed in `BugExtractor`:

| Category | Example stubs | Direction |
|---|---|---|
| Injected-service `*Async` calls | `GetForecastAsync`, `FetchItemsAsync`, `LoadDataAsync` | BugExtractor → Dynamic |
| HttpClient extension methods | `GetFromJsonAsync`, `PostAsJsonAsync`, `DeleteAsync` | BugExtractor → Dynamic |
| EventCallback bare names | `OnChanged`, `OnSubmit`, `OnValidSubmit` | BugExtractor → Dynamic |

Non-Async user-defined component methods (`LoadInitialData`, `BuildViewModel`) do NOT match — they remain resolvable via the entity index. Blazor lifecycle names (`StateHasChanged`, `InvokeAsync`, `NavigateTo`, etc.) were already covered by `external/synth.go` `razorBareNames` → `ExternalKnown`.

**SQL audit (no-op):**
The sql extractor emits **only** `READS_FROM` / `WRITES_TO` edges targeting table names. Cross-file table stubs that lack a matching entity are routed to `DispositionExternalSQL` (issue #507). No dynamic-pattern slice is warranted. Documented via `TestDynamicPatterns_SQL_NoSlice`.

## Implementation

- `dynamic_patterns_razor.go`: defines `razorSpecificPatterns` and `razorDynamicPatterns = append(csharpDynamicPatterns..., razorSpecificPatterns...)`. `init()` registers under `"razor"` key. File-init order is guaranteed (alphabetic: `_csharp` < `_razor`).
- `dynamic_patterns_csharp.go`: removed `dynamicPatternsByLang["razor"] = csharpDynamicPatterns` (now owned by razor file); added comment explaining the split.
- `dynamic_patterns_razor_test.go`: 40 test cases covering positive matches, language-gate negatives, user-method negatives, catalog-size guard, and registration guard.
- Per-language file pattern: follows post-#1028 architecture. No changes to `refs.go`.

## Test results

```
go test ./internal/extractors/razor/... ./internal/extractors/sql/... ./internal/resolve/...
ok  github.com/cajasmota/archigraph/internal/extractors/razor   1.341s
ok  github.com/cajasmota/archigraph/internal/extractors/sql     0.827s
ok  github.com/cajasmota/archigraph/internal/resolve            0.696s
```

40 new test cases, all pass.

## Acceptance

- [x] `PascalCase*Async` injected-service calls → Dynamic for `razor`; was BugExtractor
- [x] Language gate: patterns do not fire for `go`, `python`, `java`, `typescript`, `ruby`
- [x] C# inherited patterns still fire for `razor` (catalog-size guard + named cases)
- [x] User-defined non-Async component methods remain resolvable (not Dynamic)
- [x] SQL no-op documented and regression-guarded
- [x] All three package test suites clean

Refs #44