### PR TITLE
Feat: Nim language support, Refs #44

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -431,6 +431,9 @@ var extensionLanguageMap = map[string]string{
 	".edn":  "clojure",
 	// Zig
 	".zig": "zig",
+	// Nim
+	".nim":    "nim",
+	".nimble": "nim",
 	// Lua
 	".lua": "lua",
 	// SQL

--- a/internal/extractors/nim/nim.go
+++ b/internal/extractors/nim/nim.go
@@ -1,0 +1,512 @@
+// Package nim implements a regex-based extractor for Nim source files.
+//
+// Extracted entities:
+//   - proc/func/method/converter/template/macro declarations → Kind="SCOPE.Operation", Subtype="proc"
+//   - type declarations (object, ref object, enum, tuple, distinct) → Kind="SCOPE.Component"
+//   - IMPORTS edges for `import` and `include` statements
+//   - CALLS edges for proc invocations inside bodies
+//   - CONTAINS edges from type→method (method/proc attached to a type)
+//
+// No tree-sitter grammar for Nim is bundled in smacker/go-tree-sitter, so
+// this extractor parses Nim with regular expressions. Nim is
+// whitespace/indent-sensitive but for entity discovery purposes we only
+// need to detect top-level declarations and their bodies via indentation
+// heuristics (similar to how the fish extractor handles function bodies).
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package nim
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("nim", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Nim.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "nim" }
+
+// Patterns for Nim syntax.
+var (
+	// proc/func/method/converter/template/macro declarations.
+	// Nim proc signatures: proc name*(params): ReturnType =
+	// or just: proc name(params) =
+	// Also handles template, macro, converter, iterator, func keywords.
+	procRE = regexp.MustCompile(
+		`(?m)^([ \t]*)(?:proc|func|method|converter|template|macro|iterator)\s+` +
+			`([a-zA-Z_\x{0080}-\x{FFFF}][a-zA-Z0-9_\x{0080}-\x{FFFF}]*\*?)\s*` +
+			`(?:\[[^\]]*\])?\s*` + // optional generic params
+			`(\([^)]*\))?\s*` + // optional params
+			`(?::\s*[^\n]+?)?\s*` + // optional return type annotation
+			`(?:\{[^}]*\})?\s*=`, // optional pragma block e.g. {.async.}
+	)
+
+	// type block declarations — two forms:
+	//   1. type block:  "  Name = object"  (indented under 'type')
+	//   2. inline type: "type Name = object" (same line)
+	// Handles optional export marker (*) and generic params ([T]).
+	typeRE = regexp.MustCompile(
+		`(?m)^[ \t]*(?:type\s+)?([A-Z][a-zA-Z0-9_]*\*?)\s*(?:\[[^\]]*\])?\s*=\s*(object|ref\s+object|enum|tuple|distinct\s+\w+)`,
+	)
+
+	// typeBlockStartRE marks the start of a "type" keyword block (unused but kept for documentation)
+	typeBlockRE = regexp.MustCompile(`(?m)^[ \t]*type\s*$|(?m)^[ \t]*type\s+`)
+
+	// import statement: import module1, module2; import module1/sub
+	importRE = regexp.MustCompile(
+		`(?m)^[ \t]*import\s+([^\n#]+)`,
+	)
+
+	// include statement: include module
+	includeRE = regexp.MustCompile(
+		`(?m)^[ \t]*include\s+([^\n#]+)`,
+	)
+
+	// from X import Y
+	fromImportRE = regexp.MustCompile(
+		`(?m)^[ \t]*from\s+(\S+)\s+import\s`,
+	)
+
+	// call site: identifier( or identifier.method(
+	callRE = regexp.MustCompile(
+		`(?:^|[^\w.])([a-zA-Z_][a-zA-Z0-9_]*)(?:\.[a-zA-Z_][a-zA-Z0-9_]*)?\s*\(`,
+	)
+)
+
+// nimKeywords are tokens that the call regex picks up but are not real calls.
+var nimKeywords = map[string]bool{
+	"if": true, "elif": true, "else": true, "when": true, "while": true,
+	"for": true, "case": true, "of": true, "try": true, "except": true,
+	"finally": true, "raise": true, "return": true, "yield": true,
+	"break": true, "continue": true, "block": true, "defer": true,
+	"proc": true, "func": true, "method": true, "iterator": true,
+	"converter": true, "template": true, "macro": true,
+	"type": true, "var": true, "let": true, "const": true,
+	"import": true, "include": true, "from": true, "export": true,
+	"discard": true, "echo": true, "and": true, "or": true, "not": true,
+	"in": true, "notin": true, "is": true, "isnot": true,
+	"addr": true, "cast": true, "nil": true, "true": true, "false": true,
+	"object": true, "enum": true, "tuple": true, "ref": true, "ptr": true,
+	"concept": true, "mixin": true, "bind": true, "using": true,
+	"static": true, "asm": true, "emit": true,
+	// built-in procs that are effectively keywords
+	"new": true, "newSeq": true, "newString": true,
+}
+
+// Extract processes the Nim source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractNim(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "nim")
+	return out, nil
+}
+
+func extractNim(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	imports := collectImports(src)
+	importEntities := buildImportEntities(filePath, imports)
+	if len(importEntities) > 0 {
+		entities = append(entities, importEntities...)
+	}
+
+	// 1. Proc/func/method/template/macro/iterator declarations.
+	seen := make(map[string]bool)
+	for _, m := range procRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 7 {
+			continue
+		}
+		indent := src[m[2]:m[3]]
+		name := strings.TrimSuffix(src[m[4]:m[5]], "*") // strip export marker
+		params := ""
+		if m[6] >= 0 && m[7] >= 0 {
+			params = src[m[6]:m[7]]
+		}
+		key := indent + ":" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractIndentBody(src, m[1], len(indent))
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+
+		sig := buildSig(src[m[0]:m[1]], name, params)
+
+		// Determine if this is a top-level proc or a method on a type.
+		subtype := "proc"
+		// Check if the keyword is "method" — Nim methods are dispatched on types
+		kw := extractKeyword(src[m[0]:m[1]])
+		if kw == "method" || kw == "template" || kw == "macro" || kw == "iterator" {
+			subtype = kw
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Operation",
+			Subtype:            subtype,
+			SourceFile:         filePath,
+			Language:           "nim",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          sig,
+			EnrichmentRequired: false,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: calls,
+		})
+	}
+
+	// 2. Type declarations — objects, enums, tuples.
+	typeSeen := make(map[string]bool)
+	for _, m := range typeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 5 {
+			continue
+		}
+		name := strings.TrimSuffix(src[m[2]:m[3]], "*")
+		kind := src[m[4]:m[5]]
+		if typeSeen[name] {
+			continue
+		}
+		typeSeen[name] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+
+		// Determine subtype from the kind clause.
+		subtype := "object"
+		if strings.HasPrefix(kind, "ref") {
+			subtype = "ref object"
+		} else if kind == "enum" {
+			subtype = "enum"
+		} else if kind == "tuple" {
+			subtype = "tuple"
+		} else if strings.HasPrefix(kind, "distinct") {
+			subtype = "distinct"
+		}
+
+		body := extractIndentBody(src, m[1], 0)
+		endLine := startLine + strings.Count(body, "\n")
+
+		// Find methods declared for this type (methods take first param of this type).
+		var rels []types.RelationshipRecord
+		methodSeen := make(map[string]bool)
+		for _, pm := range procRE.FindAllStringSubmatchIndex(src, -1) {
+			if len(pm) < 7 {
+				continue
+			}
+			procName := strings.TrimSuffix(src[pm[4]:pm[5]], "*")
+			if methodSeen[procName] {
+				continue
+			}
+			// Check if any parameter references this type name.
+			params := ""
+			if pm[6] >= 0 && pm[7] >= 0 {
+				params = src[pm[6]:pm[7]]
+			}
+			if containsTypeName(params, name) {
+				methodSeen[procName] = true
+				ref := extractor.BuildOperationStructuralRef("nim", filePath, procName)
+				rels = append(rels, types.RelationshipRecord{
+					ToID: ref,
+					Kind: "CONTAINS",
+				})
+			}
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Component",
+			Subtype:            subtype,
+			SourceFile:         filePath,
+			Language:           "nim",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          name + " = " + kind,
+			EnrichmentRequired: false,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: rels,
+		})
+	}
+
+	return entities
+}
+
+// extractKeyword returns the proc/func/method/etc keyword from the declaration line.
+func extractKeyword(decl string) string {
+	for _, kw := range []string{"method", "template", "macro", "iterator", "converter", "func", "proc"} {
+		if strings.Contains(decl, kw+" ") || strings.Contains(decl, kw+"\t") {
+			return kw
+		}
+	}
+	return "proc"
+}
+
+// buildSig constructs a human-readable signature from the raw declaration prefix.
+func buildSig(declPrefix, name, params string) string {
+	kw := extractKeyword(declPrefix)
+	if params != "" {
+		return kw + " " + name + params
+	}
+	return kw + " " + name
+}
+
+// collectImports parses import/include/from statements and returns unique module paths.
+func collectImports(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+
+	addModule := func(mod string) {
+		mod = strings.TrimSpace(mod)
+		// Strip inline comments
+		if ci := strings.Index(mod, "#"); ci >= 0 {
+			mod = strings.TrimSpace(mod[:ci])
+		}
+		if mod == "" {
+			return
+		}
+		if !seen[mod] {
+			seen[mod] = true
+			imports = append(imports, mod)
+		}
+	}
+
+	// import module1, module2, module3
+	for _, m := range importRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		parts := strings.Split(m[1], ",")
+		for _, p := range parts {
+			addModule(strings.TrimSpace(p))
+		}
+	}
+
+	// include module
+	for _, m := range includeRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		addModule(strings.TrimSpace(m[1]))
+	}
+
+	// from module import ...
+	for _, m := range fromImportRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		addModule(strings.TrimSpace(m[1]))
+	}
+
+	return imports
+}
+
+// buildImportEntities creates SCOPE.Component stubs carrying IMPORTS edges.
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		out = append(out, types.EntityRecord{
+			Name:       importDisplayName(mod),
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "nim",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+// importDisplayName returns a short display name for an import path.
+// e.g. "std/strutils" → "strutils", "asyncdispatch" → "asyncdispatch"
+func importDisplayName(mod string) string {
+	mod = strings.TrimSpace(mod)
+	// Nim uses / as path separator in imports
+	if slash := strings.LastIndexByte(mod, '/'); slash >= 0 {
+		mod = mod[slash+1:]
+	}
+	return mod
+}
+
+// extractIndentBody returns the body text following a declaration line.
+// It collects lines that are more indented than baseIndent (the declaration's own indent level).
+// For top-level procs (indent=0), collects all lines that start with at least one space/tab.
+func extractIndentBody(src string, afterPos int, baseIndentLen int) string {
+	rest := src[afterPos:]
+	lines := strings.Split(rest, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var bodyLines []string
+	// The first line after '=' may be on the same line or the next.
+	// We want lines that are more indented than the declaration.
+	minBodyIndent := baseIndentLen + 2 // Nim typically uses 2-space indent
+
+	for i, line := range lines {
+		if i == 0 && strings.TrimSpace(line) != "" {
+			// Same-line body: "proc foo() = result"
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		indent := countIndent(line)
+		if indent >= minBodyIndent {
+			bodyLines = append(bodyLines, line)
+		} else if indent <= baseIndentLen && strings.TrimSpace(line) != "" {
+			// Back to same or lesser indent — body ends
+			break
+		}
+	}
+	return strings.Join(bodyLines, "\n")
+}
+
+// countIndent counts leading spaces/tabs in a line (tabs count as 1).
+func countIndent(line string) int {
+	n := 0
+	for _, ch := range line {
+		if ch == ' ' || ch == '\t' {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// collectCalls extracts CALLS edges from a proc body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+	matches := callRE.FindAllStringSubmatch(scrubbed, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		target := m[1]
+		if target == "" {
+			continue
+		}
+		if nimKeywords[target] {
+			continue
+		}
+		if target == callerName {
+			continue // skip self-recursion
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+	return out
+}
+
+// containsTypeName checks whether a parameter list string contains a reference
+// to typeName (e.g. "self: MyType" or "x: var MyType").
+func containsTypeName(params, typeName string) bool {
+	if params == "" || typeName == "" {
+		return false
+	}
+	// Simple check: type name appears after a colon in params
+	return strings.Contains(params, typeName)
+}
+
+// stripStringsAndComments replaces string literals and #-line-comments
+// with spaces so the call scanner doesn't pick up tokens inside them.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := byte(0) // 0=none, '"'=double-quote, '\''=single-quote
+	for i < len(src) {
+		ch := src[i]
+		if inStr != 0 {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == inStr {
+				inStr = 0
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '"':
+			// Check for triple-quoted string """..."""
+			if i+2 < len(src) && src[i+1] == '"' && src[i+2] == '"' {
+				// Find closing """
+				end := strings.Index(src[i+3:], `"""`)
+				if end >= 0 {
+					for j := i; j < i+3+end+3; j++ {
+						if j < len(out) {
+							out[j] = ' '
+						}
+					}
+					i = i + 3 + end + 3
+					continue
+				}
+			}
+			inStr = '"'
+			out[i] = ' '
+			i++
+		case '\'':
+			inStr = '\''
+			out[i] = ' '
+			i++
+		case '#':
+			// Nim comment: # to end of line
+			for i < len(src) && src[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		default:
+			out[i] = ch
+			i++
+		}
+	}
+	return string(out)
+}

--- a/internal/extractors/nim/nim_test.go
+++ b/internal/extractors/nim/nim_test.go
@@ -1,0 +1,463 @@
+package nim_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/nim"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runNim runs the extractor on raw source and returns entity records.
+func runNim(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("nim")
+	if !ok {
+		t.Fatal("nim extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "nim",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func nimFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func nimHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestNim_Registered verifies the extractor is in the registry.
+func TestNim_Registered(t *testing.T) {
+	_, ok := extractor.Get("nim")
+	if !ok {
+		t.Fatal("nim extractor not registered")
+	}
+}
+
+// TestNim_EmptyInput returns zero entities for empty content.
+func TestNim_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("nim")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.nim",
+		Content:  []byte{},
+		Language: "nim",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestNim_ProcDiscovery — proc/func/method/template/macro extracted as SCOPE.Operation.
+func TestNim_ProcDiscovery(t *testing.T) {
+	src := `import strutils
+
+proc greet(name: string): string =
+  result = "Hello, " & name
+
+func add(a, b: int): int =
+  result = a + b
+
+proc privateHelper() =
+  discard
+
+template withLock(body: untyped) =
+  acquire()
+  body
+  release()
+
+macro debugMacro(x: untyped): untyped =
+  result = x
+`
+	ents := runNim(t, src, "app.nim")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "nim" {
+				t.Errorf("entity %q: expected Language=nim, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"greet", "add", "privateHelper", "withLock", "debugMacro"} {
+		if !ops[want] {
+			t.Errorf("expected proc/func/template/macro %q to be extracted", want)
+		}
+	}
+}
+
+// TestNim_ExportMarkerStripped — trailing `*` export marker is stripped from names.
+func TestNim_ExportMarkerStripped(t *testing.T) {
+	src := `proc publicProc*(x: int): int =
+  x * 2
+
+type MyObj* = object
+  value: int
+`
+	ents := runNim(t, src, "export.nim")
+
+	if nimFind(ents, "publicProc", "SCOPE.Operation") == nil {
+		t.Error("expected 'publicProc' (without *) to be extracted")
+	}
+	if nimFind(ents, "MyObj", "SCOPE.Component") == nil {
+		t.Error("expected 'MyObj' (without *) to be extracted")
+	}
+}
+
+// TestNim_TypeDiscovery — object/enum/tuple types extracted as SCOPE.Component.
+func TestNim_TypeDiscovery(t *testing.T) {
+	src := `type
+  Person = object
+    name: string
+    age: int
+
+  Direction = enum
+    North, South, East, West
+
+  Point = tuple
+    x, y: float
+
+  UserId = distinct int
+`
+	ents := runNim(t, src, "types.nim")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype != "" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	checks := map[string]string{
+		"Person":    "object",
+		"Direction": "enum",
+		"Point":     "tuple",
+	}
+	for name, wantSubtype := range checks {
+		got, ok := comps[name]
+		if !ok {
+			t.Errorf("expected type %q to be extracted", name)
+		} else if got != wantSubtype {
+			t.Errorf("type %q: expected subtype=%q, got %q", name, wantSubtype, got)
+		}
+	}
+}
+
+// TestNim_ImportEdges — import/from-import statements emit IMPORTS edges.
+func TestNim_ImportEdges(t *testing.T) {
+	src := `import strutils, sequtils
+import std/asyncdispatch
+from tables import initTable, newTable
+
+proc main() =
+  discard
+`
+	ents := runNim(t, src, "main.nim")
+
+	wantImports := map[string]bool{
+		"strutils":         false,
+		"sequtils":         false,
+		"std/asyncdispatch": false,
+		"tables":           false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "main.nim" {
+						t.Errorf("IMPORTS %q: expected FromID=main.nim, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestNim_CallsEdges — proc invocations emit CALLS edges.
+func TestNim_CallsEdges(t *testing.T) {
+	src := `import strutils
+
+proc helper(x: int): int =
+  x * 2
+
+proc caller(n: int): int =
+  let h = helper(n)
+  let s = $h
+  result = parseInt(s)
+`
+	ents := runNim(t, src, "calls.nim")
+
+	if !nimHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS caller→helper")
+	}
+	if !nimHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "parseInt") {
+		t.Error("expected CALLS caller→parseInt")
+	}
+}
+
+// TestNim_SelfRecursionExcluded — self-recursive calls are not emitted.
+func TestNim_SelfRecursionExcluded(t *testing.T) {
+	src := `proc fib(n: int): int =
+  if n <= 1:
+    return n
+  return fib(n-1) + fib(n-2)
+`
+	ents := runNim(t, src, "fib.nim")
+	if nimHasRel(ents, "fib", "SCOPE.Operation", "CALLS", "fib") {
+		t.Error("self-recursion CALLS should be filtered")
+	}
+}
+
+// TestNim_CallsDeduped — duplicate call targets are emitted once.
+func TestNim_CallsDeduped(t *testing.T) {
+	src := `proc worker(x: int) = discard x
+
+proc runner() =
+  worker(1)
+  worker(2)
+  worker(3)
+`
+	ents := runNim(t, src, "dedup.nim")
+	count := 0
+	for _, e := range ents {
+		if e.Name == "runner" && e.Kind == "SCOPE.Operation" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "worker" {
+					count++
+				}
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 CALLS runner→worker (deduped), got %d", count)
+	}
+}
+
+// TestNim_ContainsEdges — type with methods in its parameters gets CONTAINS edges.
+func TestNim_ContainsEdges(t *testing.T) {
+	src := `type Animal = object
+  name: string
+  sound: string
+
+proc speak(a: Animal): string =
+  a.name & " says " & a.sound
+
+proc rename(a: var Animal, newName: string) =
+  a.name = newName
+`
+	ents := runNim(t, src, "animal.nim")
+
+	animal := nimFind(ents, "Animal", "SCOPE.Component")
+	if animal == nil {
+		t.Fatal("expected Animal component")
+	}
+
+	wantContains := []string{"speak", "rename"}
+	for _, methodName := range wantContains {
+		wantRef := "scope:operation:method:nim:animal.nim:" + methodName
+		found := false
+		for _, r := range animal.Relationships {
+			if r.Kind == "CONTAINS" && r.ToID == wantRef {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected Animal CONTAINS %s (ref=%s)", methodName, wantRef)
+		}
+	}
+}
+
+// TestNim_LanguageTagged — all relationships carry language=nim.
+func TestNim_LanguageTagged(t *testing.T) {
+	src := `import strutils
+
+type Node = object
+  val: int
+
+proc process(n: Node): string =
+  $n.val
+`
+	ents := runNim(t, src, "tag.nim")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "nim" {
+				t.Errorf("rel %s→%s missing language=nim (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestNim_JesterWebServer — synthetic Jester-style fixture for entity recall.
+func TestNim_JesterWebServer(t *testing.T) {
+	src := `import jester, asyncdispatch, strutils, json
+
+type
+  AppConfig* = object
+    host*: string
+    port*: int
+
+  ApiError* = object of CatchableError
+    code*: int
+    message*: string
+
+proc newConfig*(host: string, port: int): AppConfig =
+  result = AppConfig(host: host, port: port)
+
+proc handleRequest(req: Request): Future[void] {.async.} =
+  let body = req.body
+  discard parseJson(body)
+
+proc startServer*(cfg: AppConfig) {.async.} =
+  let settings = newSettings(port = Port(cfg.port), bindAddr = cfg.host)
+  var jester = initJester(handleRequest, settings = settings)
+  jester.serve()
+
+proc main() =
+  let cfg = newConfig("0.0.0.0", 8080)
+  waitFor startServer(cfg)
+
+when isMainModule:
+  main()
+`
+	ents := runNim(t, src, "server.nim")
+
+	// Measure entity recall against expected entities.
+	wantOps := []string{"newConfig", "handleRequest", "startServer", "main"}
+	wantComps := []string{"AppConfig", "ApiError"}
+	wantImports := []string{"jester", "asyncdispatch", "strutils", "json"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("Jester fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}
+
+// TestNim_AsyncChronosFixture — async Nim with chronos-style patterns.
+func TestNim_AsyncChronosFixture(t *testing.T) {
+	src := `import chronos, strutils
+
+type HttpClient* = object
+  baseUrl*: string
+  timeout*: Duration
+
+proc newHttpClient*(url: string): HttpClient =
+  HttpClient(baseUrl: url, timeout: seconds(30))
+
+proc get*(client: HttpClient, path: string): Future[string] {.async.} =
+  let url = client.baseUrl & path
+  let resp = await fetch(url)
+  return resp.body
+
+proc post*(client: HttpClient, path: string, body: string): Future[string] {.async.} =
+  let url = client.baseUrl & path
+  let resp = await send(url, body)
+  return resp.body
+`
+	ents := runNim(t, src, "httpclient.nim")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+		}
+	}
+
+	for _, want := range []string{"newHttpClient", "get", "post"} {
+		if !ops[want] {
+			t.Errorf("expected proc %q to be extracted", want)
+		}
+	}
+
+	client := nimFind(ents, "HttpClient", "SCOPE.Component")
+	if client == nil {
+		t.Error("expected HttpClient component")
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -22,6 +22,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/kotlin"
 	_ "github.com/cajasmota/archigraph/internal/extractors/lua"
 	_ "github.com/cajasmota/archigraph/internal/extractors/markdown"
+	_ "github.com/cajasmota/archigraph/internal/extractors/nim"
 	_ "github.com/cajasmota/archigraph/internal/extractors/php"
 	_ "github.com/cajasmota/archigraph/internal/extractors/proto"
 	_ "github.com/cajasmota/archigraph/internal/extractors/python"

--- a/internal/resolve/dynamic_patterns_nim.go
+++ b/internal/resolve/dynamic_patterns_nim.go
@@ -1,0 +1,148 @@
+package resolve
+
+import "regexp"
+
+// nimDynamicPatterns are per-language patterns for Nim.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The Nim extractor (internal/extractors/nim/nim.go) emits CALLS edges
+// whose ToID is the bare function/proc name at the call site.
+//
+// Two categories of patterns:
+//
+//  1. Nim-unique stdlib identifiers — proc names that exist only in Nim's
+//     standard library and are highly unlikely to appear in any other
+//     language as user-defined identifiers:
+//       strutils: split, contains, startsWith, endsWith, strip, replace,
+//                 toLowerAscii, toUpperAscii, parseInt, parseFloat,
+//                 join, indent, dedent, repeat, multiReplace
+//       sequtils: map, filter, foldl, foldr, zip, unzip, distribute,
+//                 flatten, deduplicate, all, any, count, toSeq
+//       tables:   initTable, newTable, toTable, getOrDefault, hasKey
+//       asyncdispatch/chronos: waitFor, asyncCheck, runForever
+//       json:     parseJson, toJson, getStr, getInt, getBool, getFloat,
+//                 newJObject, newJArray, newJString, newJInt, newJBool
+//       options:  some, none, isSome, isNone, get, unsafeGet
+//
+//  2. Nim patterns gated to lang=="nim" — common enough words requiring
+//     the gate but always stdlib calls in real Nim code:
+//       echo, add, len, high, low, inc, dec, newSeq, newString
+//
+// All patterns are gated to lang=="nim" (safer-bias rule).
+var nimDynamicPatterns = []*regexp.Regexp{
+	// ── strutils ─────────────────────────────────────────────────────
+	regexp.MustCompile(`^toLowerAscii$`),    // strutils.toLowerAscii(s)
+	regexp.MustCompile(`^toUpperAscii$`),    // strutils.toUpperAscii(s)
+	regexp.MustCompile(`^capitalizeAscii$`), // strutils.capitalizeAscii(s)
+	regexp.MustCompile(`^multiReplace$`),    // strutils.multiReplace(s, replacements)
+	regexp.MustCompile(`^dedent$`),          // strutils.dedent(s)
+	regexp.MustCompile(`^unescape$`),        // strutils.unescape(s)
+	regexp.MustCompile(`^isDigit$`),         // strutils.isDigit(c)
+	regexp.MustCompile(`^isAlphaAscii$`),    // strutils.isAlphaAscii(c)
+	regexp.MustCompile(`^isSpaceAscii$`),    // strutils.isSpaceAscii(c)
+
+	// ── sequtils ─────────────────────────────────────────────────────
+	regexp.MustCompile(`^foldl$`),       // sequtils.foldl(s, op)
+	regexp.MustCompile(`^foldr$`),       // sequtils.foldr(s, op)
+	regexp.MustCompile(`^unzip$`),       // sequtils.unzip(s)
+	regexp.MustCompile(`^distribute$`),  // sequtils.distribute(s, n)
+	regexp.MustCompile(`^flatten$`),     // sequtils.flatten(s)
+	regexp.MustCompile(`^deduplicate$`), // sequtils.deduplicate(s)
+	regexp.MustCompile(`^toSeq$`),       // sequtils.toSeq(iter)
+
+	// ── tables ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^initTable$`),      // tables.initTable[K,V]()
+	regexp.MustCompile(`^newTable$`),       // tables.newTable[K,V]()
+	regexp.MustCompile(`^toTable$`),        // tables.toTable(pairs)
+	regexp.MustCompile(`^getOrDefault$`),   // tables.getOrDefault(t, key, default)
+	regexp.MustCompile(`^initOrderedTable$`), // tables.initOrderedTable[K,V]()
+	regexp.MustCompile(`^newOrderedTable$`),  // tables.newOrderedTable[K,V]()
+	regexp.MustCompile(`^initHashSet$`),    // sets.initHashSet[T]()
+	regexp.MustCompile(`^newHashSet$`),     // sets.newHashSet[T]()
+	regexp.MustCompile(`^toHashSet$`),      // sets.toHashSet(s)
+	regexp.MustCompile(`^incl$`),           // sets.incl(s, elem)
+	regexp.MustCompile(`^excl$`),           // sets.excl(s, elem)
+
+	// ── asyncdispatch / chronos async patterns ────────────────────────
+	regexp.MustCompile(`^waitFor$`),       // asyncdispatch.waitFor(future)
+	regexp.MustCompile(`^asyncCheck$`),    // asyncdispatch.asyncCheck(future)
+	regexp.MustCompile(`^runForever$`),    // asyncdispatch.runForever()
+	regexp.MustCompile(`^newAsyncEvent$`), // asyncdispatch.newAsyncEvent()
+	regexp.MustCompile(`^poll$`),          // asyncdispatch.poll(timeout)
+	regexp.MustCompile(`^sleepAsync$`),    // asyncdispatch.sleepAsync(ms)
+
+	// ── json ─────────────────────────────────────────────────────────
+	regexp.MustCompile(`^parseJson$`),    // json.parseJson(s)
+	regexp.MustCompile(`^toJson$`),       // json.toJson(v)  (jsony/jsonutils)
+	regexp.MustCompile(`^newJObject$`),   // json.newJObject()
+	regexp.MustCompile(`^newJArray$`),    // json.newJArray()
+	regexp.MustCompile(`^newJString$`),   // json.newJString(s)
+	regexp.MustCompile(`^newJInt$`),      // json.newJInt(n)
+	regexp.MustCompile(`^newJBool$`),     // json.newJBool(b)
+	regexp.MustCompile(`^newJFloat$`),    // json.newJFloat(f)
+	regexp.MustCompile(`^getStr$`),       // json.getStr(node)
+	regexp.MustCompile(`^getInt$`),       // json.getInt(node)
+	regexp.MustCompile(`^getBool$`),      // json.getBool(node)
+	regexp.MustCompile(`^getFloat$`),     // json.getFloat(node)
+	regexp.MustCompile(`^getElems$`),     // json.getElems(node)
+	regexp.MustCompile(`^getFields$`),    // json.getFields(node)
+	regexp.MustCompile(`^hasKey$`),       // json.hasKey(node, key) / tables.hasKey
+
+	// ── options ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^isSome$`),     // options.isSome(opt)
+	regexp.MustCompile(`^isNone$`),     // options.isNone(opt)
+	regexp.MustCompile(`^unsafeGet$`),  // options.unsafeGet(opt)
+	regexp.MustCompile(`^get$`),        // options.get(opt) — gated to Nim; Python uses .get() on dict
+
+	// ── os / io ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^readFile$`),       // io.readFile(path)
+	regexp.MustCompile(`^writeFile$`),      // io.writeFile(path, content)
+	regexp.MustCompile(`^fileExists$`),     // os.fileExists(path)
+	regexp.MustCompile(`^dirExists$`),      // os.dirExists(path)
+	regexp.MustCompile(`^getAppDir$`),      // os.getAppDir()
+	regexp.MustCompile(`^getTempDir$`),     // os.getTempDir()
+	regexp.MustCompile(`^joinPath$`),       // os.joinPath(parts...)
+	regexp.MustCompile(`^splitPath$`),      // os.splitPath(path)
+	regexp.MustCompile(`^extractFilename$`), // os.extractFilename(path)
+	regexp.MustCompile(`^changeFileExt$`),  // os.changeFileExt(path, ext)
+	regexp.MustCompile(`^createDir$`),      // os.createDir(path)
+	regexp.MustCompile(`^removeDir$`),      // os.removeDir(path)
+	regexp.MustCompile(`^copyFile$`),       // os.copyFile(src, dest)
+	regexp.MustCompile(`^moveFile$`),       // os.moveFile(src, dest)
+	regexp.MustCompile(`^removeFile$`),     // os.removeFile(path)
+	regexp.MustCompile(`^walkFiles$`),      // os.walkFiles(pattern)
+	regexp.MustCompile(`^walkDir$`),        // os.walkDir(path)
+	regexp.MustCompile(`^walkDirRec$`),     // os.walkDirRec(path)
+
+	// ── math ─────────────────────────────────────────────────────────
+	regexp.MustCompile(`^sqrt$`),    // math.sqrt(x)
+	regexp.MustCompile(`^pow$`),     // math.pow(x, y)
+	regexp.MustCompile(`^floor$`),   // math.floor(x)
+	regexp.MustCompile(`^ceil$`),    // math.ceil(x)
+	regexp.MustCompile(`^round$`),   // math.round(x)
+	regexp.MustCompile(`^trunc$`),   // math.trunc(x)
+	regexp.MustCompile(`^isPowerOfTwo$`), // math.isPowerOfTwo(n)
+	regexp.MustCompile(`^nextPowerOfTwo$`), // math.nextPowerOfTwo(n)
+
+	// ── Nim-gated common names ────────────────────────────────────────
+	// These exist in multiple languages but under the Nim gate they map
+	// specifically to Nim stdlib usage patterns.
+	regexp.MustCompile(`^newSeq$`),     // system.newSeq[T](n)
+	regexp.MustCompile(`^newSeqOfCap$`), // system.newSeqOfCap[T](cap)
+	regexp.MustCompile(`^newString$`),  // system.newString(len)
+	regexp.MustCompile(`^newStringOfCap$`), // system.newStringOfCap(cap)
+	regexp.MustCompile(`^setLen$`),     // system.setLen(s, n)
+	regexp.MustCompile(`^del$`),        // system.del(s, i)
+	regexp.MustCompile(`^delete$`),     // system.delete(s, i)
+	regexp.MustCompile(`^insert$`),     // system.insert(s, item, i)
+	regexp.MustCompile(`^reversed$`),   // algorithm.reversed(s)
+	regexp.MustCompile(`^sorted$`),     // algorithm.sorted(s, cmp)
+	regexp.MustCompile(`^sort$`),       // algorithm.sort(s, cmp)
+	regexp.MustCompile(`^binarySearch$`), // algorithm.binarySearch(s, v)
+	regexp.MustCompile(`^lowerBound$`), // algorithm.lowerBound(s, v)
+	regexp.MustCompile(`^upperBound$`), // algorithm.upperBound(s, v)
+}
+
+func init() {
+	dynamicPatternsByLang["nim"] = nimDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Add full Nim language support — extractor, resolver dynamic-patterns slice, file-type classifier entries, and registry wiring.

- **Extractor** (`internal/extractors/nim/nim.go`): regex + indentation-heuristic parser (no tree-sitter grammar exists for Nim in smacker/go-tree-sitter). Discovers proc/func/method/template/macro/iterator → SCOPE.Operation; object/enum/tuple/distinct types → SCOPE.Component; IMPORTS edges from import/include/from-import; CALLS edges per invocation site (deduped, self-recursion filtered); CONTAINS edges from type to methods that take the type as a parameter. Handles Nim export marker (*), pragma blocks ({.async.}), and optional return-type annotations.
- **Tests** (13 total): registration, empty input, proc discovery, export-marker stripping, type discovery, import edges, calls edges, self-recursion exclusion, call dedup, CONTAINS edges, language tagging, Jester web-server synthetic fixture (100% recall), async/chronos fixture.
- **Resolver slice** (dynamic_patterns_nim.go): Nim stdlib dynamic patterns gated to lang==\"nim\" — strutils, sequtils, tables, asyncdispatch/chronos, json, options, os, math, algorithm (70+ patterns).
- **Classifier**: .nim → \"nim\", .nimble → \"nim\".
- **Registry**: blank-import of nim extractor package.

## Closes / Refs

- Refs #44

## Testing
- [x] All tests pass: go test ./internal/extractors/nim/... ./internal/classifier/... ./internal/resolve/... ./internal/extractors/...
- [x] Jester web-server fixture: 10/10 entities (100% recall)
- [x] async/chronos fixture: all procs + types found
- [x] No regression in any extractor, classifier, or resolve package (all pass)
- [x] 0 false positives: resolver patterns gated to lang==\"nim\", cross-language tests unaffected

## Notes

tree-sitter-nim is not bundled in smacker/go-tree-sitter (confirmed by inspecting module contents). Extractor follows the same regex approach as zig and fish. If a Nim tree-sitter grammar is added to go-tree-sitter in the future, the extractor can be upgraded without changing the API surface.