### PR TITLE
[#1032] Fix Cosmograph DuckDB crash: strip nested objects in normalizeGraphNode

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -251,11 +251,39 @@ function normalizeEdge(raw: { from_id: string; to_id: string; kind: string; cros
  *
  * #1023: lod field removed — server always returns dense tier.
  */
+/**
+ * Strip non-primitive fields from a raw node before passing it to Cosmograph.
+ *
+ * Cosmograph uses DuckDB-WASM for columnar storage and requires every column
+ * to be a primitive (string | number | boolean | null).  The `properties`
+ * field is a nested Record that causes a `TypeError: Cannot read properties
+ * of undefined (reading 'constructor')` during DuckDB type inference (#1032).
+ *
+ * We keep only the fields declared on GraphNode and known to be primitives.
+ */
+function normalizeGraphNode(raw: Record<string, unknown>): import('@/types/api').GraphNode {
+  return {
+    id:           String(raw.id ?? ''),
+    label:        String(raw.label ?? raw.id ?? ''),
+    kind:         raw.kind as import('@/types/api').EntityKind,
+    repo:         String(raw.repo ?? ''),
+    community_id: raw.community_id as number | undefined,
+    pagerank:     raw.pagerank as number | undefined,
+    is_centroid:  raw.is_centroid as boolean | undefined,
+    centroid_size: raw.centroid_size as number | undefined,
+    source_file:  raw.source_file != null ? String(raw.source_file) : undefined,
+    start_line:   raw.start_line as number | undefined,
+    // `properties` intentionally omitted — nested object breaks DuckDB-WASM
+    // columnar ingestion.  Entity detail is fetched separately via /api/graph/{group}/entity/{id}.
+  }
+}
+
 function normalizeGraphResponse(raw: Record<string, unknown>): GraphResponse {
   type RawEdge = { from_id: string; to_id: string; kind: string; cross_repo?: boolean }
   const rawEdges = (raw.edges as RawEdge[] | undefined) ?? []
+  const rawNodes = (raw.nodes as Record<string, unknown>[] | undefined) ?? []
   return {
-    nodes: (raw.nodes as GraphResponse['nodes'] | undefined) ?? [],
+    nodes: rawNodes.map(normalizeGraphNode),
     edges: rawEdges.map(normalizeEdge),
     communities: (raw.communities as GraphResponse['communities'] | undefined) ?? [],
     lod: 'zoom-in',  // compat: always 'zoom-in' (dense) — no LoD switching

--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -146,7 +146,9 @@ const GraphCanvasInner = ({
         // ── Data ──────────────────────────────────────────────────────────────
         points={nodes as unknown as Record<string, unknown>[]}
         pointIdBy="id"
-        pointIncludeColumns={['*']}
+        // Explicit allowlist guards against any future non-primitive field reaching
+        // DuckDB-WASM (nested objects/arrays crash columnar type inference).
+        pointIncludeColumns={['id', 'label', 'kind', 'repo', 'community_id', 'pagerank', 'is_centroid', 'centroid_size', 'source_file', 'start_line']}
 
         links={edges as unknown as Record<string, unknown>[]}
         linkSourceBy="source"


### PR DESCRIPTION
## Summary

Cosmograph uses DuckDB-WASM for columnar storage and requires every column to be a primitive (`string | number | boolean | null`). The `/api/graph/{group}` response includes `properties: Record<string,unknown>` on nodes (React props metadata, framework annotations, operation subtypes). Passing that nested dict to `<Cosmograph points={nodes}>` caused a hard crash during type inference:

```
[Cosmograph > _uploadData]: TypeError: Cannot read properties of undefined (reading 'constructor')
[Cosmograph > validatePoints]: Table "cosmograph_points" does not exist
```

**Root cause**: 988 of 1500 nodes in the upvate corpus had `properties: dict` — the only non-primitive field. The old `normalizeGraphResponse` passed nodes through as-is (`raw.nodes as GraphResponse['nodes']`), so the dict reached DuckDB unchanged.

**Fix — two-layer defence**:

1. `dashboard/src/api/client.ts` — add `normalizeGraphNode()` that explicitly constructs a new object with only the 10 primitive-typed fields declared on `GraphNode`, omitting `properties`. Wire it into `normalizeGraphResponse`: `nodes: rawNodes.map(normalizeGraphNode)`.

2. `dashboard/src/components/graph/GraphCanvas.tsx` — replace `pointIncludeColumns={['*']}` with an explicit allowlist of the same 10 safe columns, so any future field additions cannot accidentally reach DuckDB.

**Verification**:
- Simulated `normalizeGraphNode` against live corpus: 988 raw nodes had nested objects → 0 after normaliser.
- `npx vite build` succeeds; zero new TypeScript errors introduced.
- Minified bundle confirmed: `kL()` is our normaliser — all primitive coercions, no `properties` key present.

## Closes / Refs

Closes #1032

## Testing
- [ ] All tests pass: `go test ./...`
- [ ] Relevant fixtures verified
- [ ] No regression in cross-language parity

## Notes

`properties` is intentionally excluded from the Cosmograph data layer — entity detail is fetched on demand via `/api/graph/{group}/entity/{id}` when a node is selected. Nothing that consumes `GraphNode` in the renderer needs `properties`; it was vestigial here.