### PR TITLE
[#1036] Add F# language extractor + resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -436,6 +436,11 @@ var extensionLanguageMap = map[string]string{
 	// Nim
 	".nim":    "nim",
 	".nimble": "nim",
+	// F#
+	".fs":     "fsharp",
+	".fsi":    "fsharp",
+	".fsx":    "fsharp",
+	".fsproj": "fsharp",
 	// Lua
 	".lua": "lua",
 	// SQL

--- a/internal/extractors/fsharp/extractor.go
+++ b/internal/extractors/fsharp/extractor.go
@@ -1,0 +1,618 @@
+// Package fsharp implements a regex-based extractor for F# source files.
+//
+// Extracted entities:
+//   - module/namespace declarations → Kind="SCOPE.Component", Subtype="module"|"namespace"
+//   - let/let rec/let mutable bindings (functions) → Kind="SCOPE.Operation", Subtype="let"
+//   - member function definitions → Kind="SCOPE.Operation", Subtype="member"
+//   - type declarations (record, discriminated union, class, interface, struct, alias)
+//     → Kind="SCOPE.Component"
+//   - open statements → IMPORTS edges
+//   - function applications → CALLS edges
+//   - Module CONTAINS members
+//
+// No tree-sitter grammar for F# is available in smacker/go-tree-sitter, so
+// this extractor parses F# with regular expressions. F# is
+// whitespace/indent-sensitive; for entity discovery purposes we rely on
+// indentation heuristics similar to the Nim extractor.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package fsharp
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("fsharp", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for F#.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "fsharp" }
+
+// Regex patterns for F# syntax.
+var (
+	// module declaration: "module Foo" or "module Foo.Bar" or "module rec Foo"
+	moduleRE = regexp.MustCompile(
+		`(?m)^([ \t]*)module(?:\s+rec)?\s+([\w.]+)\s*$`,
+	)
+
+	// namespace declaration: "namespace Foo" or "namespace Foo.Bar"
+	namespaceRE = regexp.MustCompile(
+		`(?m)^([ \t]*)namespace\s+([\w.]+)\s*$`,
+	)
+
+	// let binding: "let [rec] [mutable] name [<params>] =" or "let name ="
+	// Captures indentation and name. Handles generic type params like <'T>.
+	letRE = regexp.MustCompile(
+		`(?m)^([ \t]*)let(?:\s+rec)?(?:\s+mutable)?\s+([a-zA-Z_][a-zA-Z0-9_']*)\s*(?:<[^>]*>)?\s*(?:[^=\n]*)=`,
+	)
+
+	// member: "member [this.]Name" or "member _.Name" or "override this.Name"
+	memberRE = regexp.MustCompile(
+		`(?m)^([ \t]*)(?:member|override|abstract member|default)\s+(?:[a-zA-Z_][a-zA-Z0-9_']*\.)?([a-zA-Z_][a-zA-Z0-9_']*)\s*(?:<[^>]*>)?\s*(?:[^=\n]*)=`,
+	)
+
+	// type declaration: "type Foo =" or "type Foo<'T> ="
+	// Matches record, DU, class, interface, struct, alias, exception types.
+	typeRE = regexp.MustCompile(
+		`(?m)^([ \t]*)type\s+([A-Z][a-zA-Z0-9_']*)\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*=`,
+	)
+
+	// type kind after "=" — helps classify subtype
+	typeKindRE = regexp.MustCompile(
+		`(?m)^([ \t]*)type\s+[A-Z][a-zA-Z0-9_']*\s*(?:<[^>]*>)?\s*(?:\([^)]*\))?\s*=\s*(\{|interface|class|\|)`,
+	)
+
+	// open statement: "open Foo" or "open Foo.Bar"
+	openRE = regexp.MustCompile(
+		`(?m)^[ \t]*open\s+([\w.]+)`,
+	)
+
+	// function application call: identifier( or Module.function(
+	// Also detects pipe targets: |> identifier or |> Module.name
+	callRE = regexp.MustCompile(
+		`(?:^|[^\w.'"])([A-Za-z_][A-Za-z0-9_.]*)(?:\s*<[^>]*>)?\s*\(`,
+	)
+
+	// pipe operator call: |> Module.name or |> name
+	pipeCallRE = regexp.MustCompile(
+		`\|>\s*([A-Za-z_][A-Za-z0-9_.]*)`,
+	)
+
+	// compose operator: >> Module.name
+	composeCallRE = regexp.MustCompile(
+		`>>\s*([A-Za-z_][A-Za-z0-9_.]*)`,
+	)
+)
+
+// fsharpKeywords are tokens the call regex picks up but are not real calls.
+var fsharpKeywords = map[string]bool{
+	"if": true, "elif": true, "else": true, "then": true,
+	"while": true, "for": true, "do": true, "done": true,
+	"match": true, "with": true, "when": true,
+	"try": true, "finally": true,
+	"raise": true, "failwith": true, "failwithf": true,
+	"return": true, "yield": true, "and": true, "or": true, "not": true,
+	"let": true, "in": true, "fun": true, "function": true,
+	"type": true, "open": true, "module": true, "namespace": true,
+	"begin": true, "end": true, "inherit": true, "interface": true,
+	"member": true, "override": true, "default": true, "abstract": true,
+	"static": true, "mutable": true, "rec": true, "new": true,
+	"null": true, "true": true, "false": true,
+	"async": true, "seq": true, "query": true,
+	"upcast": true, "downcast": true, "typeof": true, "typedefof": true,
+	"sizeof": true, "nameof": true, "use": true, "using": true,
+	// common computation expression keywords
+	"async.Return": true, "async.Bind": true, "async.Zero": true,
+}
+
+// Extract processes F# source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractFSharp(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "fsharp")
+	return out, nil
+}
+
+func extractFSharp(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	imports := collectOpenStatements(src)
+	importEntities := buildImportEntities(filePath, imports)
+	entities = append(entities, importEntities...)
+
+	// 1. Module/namespace declarations → SCOPE.Component
+	seen := make(map[string]bool)
+	for _, m := range moduleRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		key := "module:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "module",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "module " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	for _, m := range namespaceRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		key := "namespace:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "namespace",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "namespace " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 2. let bindings (functions) → SCOPE.Operation
+	letSeen := make(map[string]bool)
+	for _, m := range letRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		indent := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		key := indent + ":let:" + name
+		if letSeen[key] {
+			continue
+		}
+		letSeen[key] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractIndentBody(src, m[1], len(indent))
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "let",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  buildLetSig(src[m[0]:m[1]], name),
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: calls,
+		})
+	}
+
+	// 3. member definitions → SCOPE.Operation
+	memberSeen := make(map[string]bool)
+	for _, m := range memberRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		indent := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		// Skip if same name already from let bindings (avoid double-counting)
+		if letSeen[indent+":let:"+name] {
+			continue
+		}
+		key := indent + ":member:" + name
+		if memberSeen[key] {
+			continue
+		}
+		memberSeen[key] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractIndentBody(src, m[1], len(indent))
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "member",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "member " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: calls,
+		})
+	}
+
+	// 4. type declarations → SCOPE.Component
+	typeSeen := make(map[string]bool)
+	for _, m := range typeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		if typeSeen[name] {
+			continue
+		}
+		typeSeen[name] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractIndentBody(src, m[1], len(src[m[2]:m[3]]))
+		endLine := startLine + strings.Count(body, "\n")
+
+		// Determine subtype
+		subtype := classifyTypeSubtype(src[m[0]:m[1]], body)
+
+		// Find members/functions that belong to this type (CONTAINS edges)
+		var rels []types.RelationshipRecord
+		memberRef := make(map[string]bool)
+		// Check members declared at higher indentation after this type
+		typeIndentLen := len(src[m[2]:m[3]])
+		for _, pm := range memberRE.FindAllStringSubmatchIndex(src, -1) {
+			if len(pm) < 6 {
+				continue
+			}
+			pmIndentLen := len(src[pm[2]:pm[3]])
+			if pmIndentLen <= typeIndentLen {
+				continue
+			}
+			// Member must appear after the type declaration start
+			if pm[0] < m[0] {
+				continue
+			}
+			mName := src[pm[4]:pm[5]]
+			if memberRef[mName] {
+				continue
+			}
+			memberRef[mName] = true
+			ref := extractor.BuildOperationStructuralRef("fsharp", filePath, mName)
+			rels = append(rels, types.RelationshipRecord{
+				ToID: ref,
+				Kind: "CONTAINS",
+			})
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    subtype,
+			SourceFile: filePath,
+			Language:   "fsharp",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "type " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: rels,
+		})
+	}
+
+	return entities
+}
+
+// classifyTypeSubtype determines the F# type subtype from the declaration context.
+func classifyTypeSubtype(decl, body string) string {
+	// Check for "= {" → record
+	if strings.Contains(decl, "= {") || strings.TrimSpace(body) != "" && strings.HasPrefix(strings.TrimSpace(body), "{") {
+		return "record"
+	}
+	// Check for "= |" or body starting with "|" → discriminated union
+	if strings.Contains(decl, "= |") {
+		return "discriminated_union"
+	}
+	bodyTrimmed := strings.TrimSpace(body)
+	if strings.HasPrefix(bodyTrimmed, "|") {
+		return "discriminated_union"
+	}
+	// Check for interface/class keywords
+	if strings.Contains(decl, "interface") || strings.HasPrefix(bodyTrimmed, "interface") {
+		return "interface"
+	}
+	if strings.Contains(decl, "class") || strings.HasPrefix(bodyTrimmed, "class") {
+		return "class"
+	}
+	if strings.Contains(decl, "struct") {
+		return "struct"
+	}
+	return "type"
+}
+
+// buildLetSig builds a signature string for a let binding from the raw declaration.
+func buildLetSig(decl, name string) string {
+	// Trim whitespace and return a reasonable signature
+	sig := strings.TrimSpace(decl)
+	if idx := strings.Index(sig, "="); idx >= 0 {
+		sig = strings.TrimSpace(sig[:idx])
+	}
+	if sig == "" {
+		return "let " + name
+	}
+	return sig
+}
+
+// collectOpenStatements parses "open" statements and returns unique module paths.
+func collectOpenStatements(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+
+	for _, m := range openRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		mod := strings.TrimSpace(m[1])
+		// Strip inline comments
+		if ci := strings.IndexAny(mod, "//"); ci >= 0 {
+			mod = strings.TrimSpace(mod[:ci])
+		}
+		if mod == "" || seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		imports = append(imports, mod)
+	}
+	return imports
+}
+
+// buildImportEntities creates SCOPE.Component stubs carrying IMPORTS edges.
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		out = append(out, types.EntityRecord{
+			Name:       importDisplayName(mod),
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "fsharp",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+// importDisplayName returns a short display name for an import path.
+// e.g. "Microsoft.FSharp.Collections" → "Collections"
+func importDisplayName(mod string) string {
+	mod = strings.TrimSpace(mod)
+	if dot := strings.LastIndexByte(mod, '.'); dot >= 0 {
+		return mod[dot+1:]
+	}
+	return mod
+}
+
+// extractIndentBody returns the body text following a declaration line.
+// Collects lines that are more indented than baseIndent.
+func extractIndentBody(src string, afterPos int, baseIndentLen int) string {
+	rest := src[afterPos:]
+	lines := strings.Split(rest, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var bodyLines []string
+	minBodyIndent := baseIndentLen + 2 // F# typically uses 4-space indent, but 2 is minimum
+
+	for i, line := range lines {
+		if i == 0 && strings.TrimSpace(line) != "" {
+			// Same-line body
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		indent := countIndent(line)
+		if indent >= minBodyIndent {
+			bodyLines = append(bodyLines, line)
+		} else if indent <= baseIndentLen && strings.TrimSpace(line) != "" {
+			break
+		}
+	}
+	return strings.Join(bodyLines, "\n")
+}
+
+// countIndent counts leading spaces/tabs.
+func countIndent(line string) int {
+	n := 0
+	for _, ch := range line {
+		if ch == ' ' || ch == '\t' {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// collectCalls extracts CALLS edges from a function body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+
+	addCall := func(target string) {
+		if target == "" || callerName == target {
+			return
+		}
+		// Strip module qualifier if present (e.g. "List.map" → "List.map" kept as-is)
+		if fsharpKeywords[target] {
+			return
+		}
+		// Skip single-letter identifiers (usually type params)
+		if len(target) == 1 {
+			return
+		}
+		if seen[target] {
+			return
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	// Regular function calls: name(
+	for _, m := range callRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	// Pipe operator: |> name or |> Module.name
+	for _, m := range pipeCallRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	// Compose operator: >> name
+	for _, m := range composeCallRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	return out
+}
+
+// stripStringsAndComments replaces string literals and //-line comments
+// with spaces so the call scanner doesn't pick up tokens inside them.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := byte(0) // 0=none, '"'=double-quote
+	inTriple := false
+	for i < len(src) {
+		ch := src[i]
+		if inTriple {
+			out[i] = ' '
+			if i+2 < len(src) && ch == '"' && src[i+1] == '"' && src[i+2] == '"' {
+				out[i+1] = ' '
+				out[i+2] = ' '
+				i += 3
+				inTriple = false
+				continue
+			}
+			i++
+			continue
+		}
+		if inStr != 0 {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == inStr {
+				inStr = 0
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '"':
+			// Check for triple-quoted string
+			if i+2 < len(src) && src[i+1] == '"' && src[i+2] == '"' {
+				out[i] = ' '
+				out[i+1] = ' '
+				out[i+2] = ' '
+				i += 3
+				inTriple = true
+				continue
+			}
+			// Check for verbatim string @"..."
+			inStr = '"'
+			out[i] = ' '
+			i++
+		case '/':
+			// F# line comment: //
+			if i+1 < len(src) && src[i+1] == '/' {
+				for i < len(src) && src[i] != '\n' {
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			out[i] = ch
+			i++
+		case '(':
+			// F# block comment: (* ... *)
+			if i+1 < len(src) && src[i+1] == '*' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				for i < len(src) {
+					if i+1 < len(src) && src[i] == '*' && src[i+1] == ')' {
+						out[i] = ' '
+						out[i+1] = ' '
+						i += 2
+						break
+					}
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			out[i] = ch
+			i++
+		default:
+			out[i] = ch
+			i++
+		}
+	}
+	return string(out)
+}

--- a/internal/extractors/fsharp/fsharp_test.go
+++ b/internal/extractors/fsharp/fsharp_test.go
@@ -1,0 +1,503 @@
+package fsharp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/fsharp"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runFSharp runs the extractor on raw source and returns entity records.
+func runFSharp(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("fsharp")
+	if !ok {
+		t.Fatal("fsharp extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "fsharp",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func fsFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func fsHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestFSharp_Registered verifies the extractor is in the registry.
+func TestFSharp_Registered(t *testing.T) {
+	_, ok := extractor.Get("fsharp")
+	if !ok {
+		t.Fatal("fsharp extractor not registered")
+	}
+}
+
+// TestFSharp_EmptyInput returns zero entities for empty content.
+func TestFSharp_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("fsharp")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.fs",
+		Content:  []byte{},
+		Language: "fsharp",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestFSharp_ModuleDiscovery — module declarations extracted as SCOPE.Component.
+func TestFSharp_ModuleDiscovery(t *testing.T) {
+	src := `module MyApp.Domain
+
+open System
+open System.Collections.Generic
+
+let greet name = sprintf "Hello, %s" name
+`
+	ents := runFSharp(t, src, "domain.fs")
+	if fsFind(ents, "MyApp.Domain", "SCOPE.Component") == nil {
+		t.Error("expected module MyApp.Domain as SCOPE.Component")
+	}
+}
+
+// TestFSharp_NamespaceDiscovery — namespace declarations extracted as SCOPE.Component.
+func TestFSharp_NamespaceDiscovery(t *testing.T) {
+	src := `namespace MyApp.Infrastructure
+
+open System
+
+type Repository() =
+    member _.FindAll() = []
+`
+	ents := runFSharp(t, src, "infra.fs")
+	if fsFind(ents, "MyApp.Infrastructure", "SCOPE.Component") == nil {
+		t.Error("expected namespace MyApp.Infrastructure as SCOPE.Component")
+	}
+}
+
+// TestFSharp_LetBindings — let/let rec functions extracted as SCOPE.Operation.
+func TestFSharp_LetBindings(t *testing.T) {
+	src := `module App
+
+let add a b = a + b
+
+let rec factorial n =
+    if n <= 1 then 1
+    else n * factorial (n - 1)
+
+let mutable counter = 0
+
+let processItems items =
+    items |> List.map (fun x -> x * 2)
+`
+	ents := runFSharp(t, src, "app.fs")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "fsharp" {
+				t.Errorf("entity %q: expected Language=fsharp, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"add", "factorial", "processItems"} {
+		if !ops[want] {
+			t.Errorf("expected function %q to be extracted", want)
+		}
+	}
+}
+
+// TestFSharp_TypeDiscovery — type declarations extracted as SCOPE.Component.
+func TestFSharp_TypeDiscovery(t *testing.T) {
+	src := `module Types
+
+type Person = {
+    Name: string
+    Age: int
+}
+
+type Shape =
+    | Circle of float
+    | Rectangle of float * float
+    | Triangle of float * float * float
+
+type Animal =
+    | Dog
+    | Cat
+    | Bird
+
+type IService =
+    abstract member Process: string -> string
+`
+	ents := runFSharp(t, src, "types.fs")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	wantTypes := []string{"Person", "Shape", "Animal"}
+	for _, name := range wantTypes {
+		if _, ok := comps[name]; !ok {
+			t.Errorf("expected type %q to be extracted as SCOPE.Component", name)
+		}
+	}
+}
+
+// TestFSharp_OpenStatements — open statements emit IMPORTS edges.
+func TestFSharp_OpenStatements(t *testing.T) {
+	src := `module App
+
+open System
+open System.IO
+open Microsoft.FSharp.Collections
+
+let readFile path = File.ReadAllText(path)
+`
+	ents := runFSharp(t, src, "main.fs")
+
+	wantImports := map[string]bool{
+		"System":                       false,
+		"System.IO":                    false,
+		"Microsoft.FSharp.Collections": false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "main.fs" {
+						t.Errorf("IMPORTS %q: expected FromID=main.fs, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestFSharp_CallsEdges — function calls emit CALLS edges.
+func TestFSharp_CallsEdges(t *testing.T) {
+	src := `module App
+
+open System
+
+let helper x = x * 2
+
+let caller n =
+    let result = helper(n)
+    printfn "Result: %d" result
+    result
+`
+	ents := runFSharp(t, src, "calls.fs")
+
+	if !fsHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS caller→helper")
+	}
+}
+
+// TestFSharp_PipeOperatorCalls — |> chains emit CALLS edges.
+func TestFSharp_PipeOperatorCalls(t *testing.T) {
+	src := `module App
+
+open System.Collections.Generic
+
+let processData data =
+    data
+    |> List.filter (fun x -> x > 0)
+    |> List.map (fun x -> x * 2)
+    |> List.sum
+`
+	ents := runFSharp(t, src, "pipes.fs")
+
+	// pipe targets should be extracted as CALLS
+	hasPipeCall := false
+	for _, e := range ents {
+		if e.Name == "processData" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && (r.ToID == "List.filter" || r.ToID == "List.map" || r.ToID == "List.sum") {
+					hasPipeCall = true
+				}
+			}
+		}
+	}
+	if !hasPipeCall {
+		t.Error("expected CALLS edges from pipe |> operator targets")
+	}
+}
+
+// TestFSharp_SelfRecursionExcluded — self-recursive calls not emitted.
+func TestFSharp_SelfRecursionExcluded(t *testing.T) {
+	src := `module App
+
+let rec fib n =
+    if n <= 1 then n
+    else fib(n-1) + fib(n-2)
+`
+	ents := runFSharp(t, src, "fib.fs")
+	if fsHasRel(ents, "fib", "SCOPE.Operation", "CALLS", "fib") {
+		t.Error("self-recursion CALLS should be filtered")
+	}
+}
+
+// TestFSharp_LanguageTagged — all relationships carry language=fsharp.
+func TestFSharp_LanguageTagged(t *testing.T) {
+	src := `module App
+
+open System
+
+type Node = { Value: int }
+
+let process (n: Node) = n.Value
+`
+	ents := runFSharp(t, src, "tag.fs")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "fsharp" {
+				t.Errorf("rel %s→%s missing language=fsharp (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestFSharp_MemberFunctions — member definitions extracted as SCOPE.Operation.
+func TestFSharp_MemberFunctions(t *testing.T) {
+	src := `module App
+
+open System
+
+type Calculator() =
+    member this.Add(a: int, b: int) = a + b
+    member this.Subtract(a: int, b: int) = a - b
+    member this.Multiply(a: int, b: int) = a * b
+`
+	ents := runFSharp(t, src, "calc.fs")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+		}
+	}
+
+	for _, want := range []string{"Add", "Subtract", "Multiply"} {
+		if !ops[want] {
+			t.Errorf("expected member %q to be extracted as SCOPE.Operation", want)
+		}
+	}
+}
+
+// TestFSharp_GiraffeWebApp — synthetic Giraffe-style fixture for entity recall.
+func TestFSharp_GiraffeWebApp(t *testing.T) {
+	src := `module GiraffeApp.App
+
+open System
+open Microsoft.AspNetCore.Builder
+open Microsoft.AspNetCore.Hosting
+open Microsoft.Extensions.DependencyInjection
+open Giraffe
+
+// Models
+type User = {
+    Id: int
+    Name: string
+    Email: string
+}
+
+type CreateUserRequest = {
+    Name: string
+    Email: string
+}
+
+// Handlers
+let getUser (userId: int) : HttpHandler =
+    fun next ctx ->
+        let user = { Id = userId; Name = "Alice"; Email = "alice@example.com" }
+        json user next ctx
+
+let createUser : HttpHandler =
+    fun next ctx ->
+        task {
+            let! req = ctx.BindJsonAsync<CreateUserRequest>()
+            let user = { Id = 1; Name = req.Name; Email = req.Email }
+            return! json user next ctx
+        }
+
+let listUsers : HttpHandler =
+    fun next ctx ->
+        let users = [
+            { Id = 1; Name = "Alice"; Email = "alice@example.com" }
+            { Id = 2; Name = "Bob"; Email = "bob@example.com" }
+        ]
+        json users next ctx
+
+// Router
+let webApp =
+    choose [
+        GET >=> route "/users" >=> listUsers
+        GET >=> routef "/users/%i" getUser
+        POST >=> route "/users" >=> createUser
+        setStatusCode 404 >=> text "Not Found"
+    ]
+
+// Service configuration
+let configureServices (services: IServiceCollection) =
+    services.AddGiraffe() |> ignore
+
+let configureApp (app: IApplicationBuilder) =
+    app.UseGiraffe(webApp)
+
+// Entry point
+[<EntryPoint>]
+let main argv =
+    WebHostBuilder()
+        .UseKestrel()
+        .ConfigureServices(configureServices)
+        .Configure(configureApp)
+        .Build()
+        .Run()
+    0
+`
+	ents := runFSharp(t, src, "app.fs")
+
+	wantOps := []string{"getUser", "createUser", "listUsers", "configureServices", "configureApp", "main"}
+	wantComps := []string{"User", "CreateUserRequest"}
+	wantImports := []string{
+		"System",
+		"Microsoft.AspNetCore.Builder",
+		"Microsoft.AspNetCore.Hosting",
+		"Microsoft.Extensions.DependencyInjection",
+		"Giraffe",
+	}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("Giraffe fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}
+
+// TestFSharp_AsyncWorkflow — async workflows emit correct entities.
+func TestFSharp_AsyncWorkflow(t *testing.T) {
+	src := `module AsyncApp
+
+open System
+open System.Threading.Tasks
+
+let fetchData (url: string) =
+    async {
+        let! response = Async.AwaitTask(Task.FromResult("data"))
+        return response
+    }
+
+let processAsync () =
+    async {
+        let! data = fetchData "http://example.com"
+        return data.Length
+    }
+    |> Async.RunSynchronously
+`
+	ents := runFSharp(t, src, "async.fs")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+		}
+	}
+
+	for _, want := range []string{"fetchData", "processAsync"} {
+		if !ops[want] {
+			t.Errorf("expected async function %q to be extracted", want)
+		}
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -12,6 +12,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/dockerfile"
 	_ "github.com/cajasmota/archigraph/internal/extractors/elixir"
 	_ "github.com/cajasmota/archigraph/internal/extractors/fish"
+	_ "github.com/cajasmota/archigraph/internal/extractors/fsharp"
 	_ "github.com/cajasmota/archigraph/internal/extractors/golang"
 	_ "github.com/cajasmota/archigraph/internal/extractors/graphql"
 	_ "github.com/cajasmota/archigraph/internal/extractors/groovy"

--- a/internal/resolve/dynamic_patterns_fsharp.go
+++ b/internal/resolve/dynamic_patterns_fsharp.go
@@ -1,0 +1,353 @@
+package resolve
+
+import "regexp"
+
+// fsharpDynamicPatterns are per-language patterns for F#.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The F# extractor (internal/extractors/fsharp/extractor.go) emits CALLS edges
+// whose ToID is either:
+//   - a bare function name: "helper"
+//   - a module-qualified call: "List.map", "Option.defaultValue"
+//   - a pipe-chain target: captured as "List.filter", "Async.RunSynchronously"
+//
+// Two categories of patterns:
+//
+//  1. F#-unique stdlib module-qualified identifiers — dotted names that exist
+//     only in F#'s core library and are highly unlikely to appear in other
+//     languages as user-defined identifiers:
+//       Collections.List: List.map, List.filter, List.fold, List.iter, etc.
+//       Collections.Seq:  Seq.iter, Seq.map, Seq.filter, Seq.toList, etc.
+//       Option:           Option.map, Option.bind, Option.defaultValue, etc.
+//       Result:           Result.bind, Result.map, Result.mapError, etc.
+//       Array:            Array.map, Array.filter, Array.fold, etc.
+//       Async/Task:       Async.RunSynchronously, Async.AwaitTask, etc.
+//       Giraffe HTTP:     route, routef, choose, setStatusCode, text, json, htmlString
+//
+//  2. F#-gated common names — common enough words requiring the gate:
+//       printfn, sprintf, failwith, ignore, id, fst, snd
+//
+// All patterns are gated to lang=="fsharp" (safer-bias rule).
+var fsharpDynamicPatterns = []*regexp.Regexp{
+	// ── List module ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^List\.map$`),        // List.map f lst
+	regexp.MustCompile(`^List\.filter$`),     // List.filter pred lst
+	regexp.MustCompile(`^List\.fold$`),       // List.fold f init lst
+	regexp.MustCompile(`^List\.foldBack$`),   // List.foldBack f lst init
+	regexp.MustCompile(`^List\.iter$`),       // List.iter f lst
+	regexp.MustCompile(`^List\.iteri$`),      // List.iteri f lst
+	regexp.MustCompile(`^List\.mapi$`),       // List.mapi f lst
+	regexp.MustCompile(`^List\.collect$`),    // List.collect f lst
+	regexp.MustCompile(`^List\.choose$`),     // List.choose f lst
+	regexp.MustCompile(`^List\.forall$`),     // List.forall pred lst
+	regexp.MustCompile(`^List\.exists$`),     // List.exists pred lst
+	regexp.MustCompile(`^List\.find$`),       // List.find pred lst
+	regexp.MustCompile(`^List\.tryFind$`),    // List.tryFind pred lst
+	regexp.MustCompile(`^List\.head$`),       // List.head lst
+	regexp.MustCompile(`^List\.tail$`),       // List.tail lst
+	regexp.MustCompile(`^List\.last$`),       // List.last lst
+	regexp.MustCompile(`^List\.length$`),     // List.length lst
+	regexp.MustCompile(`^List\.isEmpty$`),    // List.isEmpty lst
+	regexp.MustCompile(`^List\.append$`),     // List.append lst1 lst2
+	regexp.MustCompile(`^List\.concat$`),     // List.concat lsts
+	regexp.MustCompile(`^List\.rev$`),        // List.rev lst
+	regexp.MustCompile(`^List\.sort$`),       // List.sort lst
+	regexp.MustCompile(`^List\.sortBy$`),     // List.sortBy key lst
+	regexp.MustCompile(`^List\.sortWith$`),   // List.sortWith cmp lst
+	regexp.MustCompile(`^List\.sum$`),        // List.sum lst
+	regexp.MustCompile(`^List\.sumBy$`),      // List.sumBy f lst
+	regexp.MustCompile(`^List\.min$`),        // List.min lst
+	regexp.MustCompile(`^List\.max$`),        // List.max lst
+	regexp.MustCompile(`^List\.minBy$`),      // List.minBy key lst
+	regexp.MustCompile(`^List\.maxBy$`),      // List.maxBy key lst
+	regexp.MustCompile(`^List\.take$`),       // List.take n lst
+	regexp.MustCompile(`^List\.skip$`),       // List.skip n lst
+	regexp.MustCompile(`^List\.zip$`),        // List.zip lst1 lst2
+	regexp.MustCompile(`^List\.unzip$`),      // List.unzip lst
+	regexp.MustCompile(`^List\.partition$`),  // List.partition pred lst
+	regexp.MustCompile(`^List\.distinct$`),   // List.distinct lst
+	regexp.MustCompile(`^List\.distinctBy$`), // List.distinctBy key lst
+	regexp.MustCompile(`^List\.groupBy$`),    // List.groupBy key lst
+	regexp.MustCompile(`^List\.countBy$`),    // List.countBy key lst
+	regexp.MustCompile(`^List\.pairwise$`),   // List.pairwise lst
+	regexp.MustCompile(`^List\.windowed$`),   // List.windowed n lst
+	regexp.MustCompile(`^List\.init$`),       // List.init n f
+	regexp.MustCompile(`^List\.replicate$`),  // List.replicate n x
+	regexp.MustCompile(`^List\.ofSeq$`),      // List.ofSeq seq
+	regexp.MustCompile(`^List\.toSeq$`),      // List.toSeq lst
+	regexp.MustCompile(`^List\.ofArray$`),    // List.ofArray arr
+	regexp.MustCompile(`^List\.toArray$`),    // List.toArray lst
+	regexp.MustCompile(`^List\.indexed$`),    // List.indexed lst
+	regexp.MustCompile(`^List\.item$`),       // List.item i lst
+	regexp.MustCompile(`^List\.nth$`),        // List.nth lst i (legacy)
+
+	// ── Seq module ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^Seq\.map$`),       // Seq.map f seq
+	regexp.MustCompile(`^Seq\.filter$`),    // Seq.filter pred seq
+	regexp.MustCompile(`^Seq\.fold$`),      // Seq.fold f init seq
+	regexp.MustCompile(`^Seq\.iter$`),      // Seq.iter f seq
+	regexp.MustCompile(`^Seq\.iteri$`),     // Seq.iteri f seq
+	regexp.MustCompile(`^Seq\.collect$`),   // Seq.collect f seq
+	regexp.MustCompile(`^Seq\.choose$`),    // Seq.choose f seq
+	regexp.MustCompile(`^Seq\.forall$`),    // Seq.forall pred seq
+	regexp.MustCompile(`^Seq\.exists$`),    // Seq.exists pred seq
+	regexp.MustCompile(`^Seq\.find$`),      // Seq.find pred seq
+	regexp.MustCompile(`^Seq\.tryFind$`),   // Seq.tryFind pred seq
+	regexp.MustCompile(`^Seq\.head$`),      // Seq.head seq
+	regexp.MustCompile(`^Seq\.length$`),    // Seq.length seq
+	regexp.MustCompile(`^Seq\.isEmpty$`),   // Seq.isEmpty seq
+	regexp.MustCompile(`^Seq\.toList$`),    // Seq.toList seq
+	regexp.MustCompile(`^Seq\.toArray$`),   // Seq.toArray seq
+	regexp.MustCompile(`^Seq\.ofList$`),    // Seq.ofList lst
+	regexp.MustCompile(`^Seq\.ofArray$`),   // Seq.ofArray arr
+	regexp.MustCompile(`^Seq\.take$`),      // Seq.take n seq
+	regexp.MustCompile(`^Seq\.skip$`),      // Seq.skip n seq
+	regexp.MustCompile(`^Seq\.zip$`),       // Seq.zip seq1 seq2
+	regexp.MustCompile(`^Seq\.append$`),    // Seq.append seq1 seq2
+	regexp.MustCompile(`^Seq\.concat$`),    // Seq.concat seqs
+	regexp.MustCompile(`^Seq\.sort$`),      // Seq.sort seq
+	regexp.MustCompile(`^Seq\.sortBy$`),    // Seq.sortBy key seq
+	regexp.MustCompile(`^Seq\.groupBy$`),   // Seq.groupBy key seq
+	regexp.MustCompile(`^Seq\.distinct$`),  // Seq.distinct seq
+	regexp.MustCompile(`^Seq\.distinctBy$`), // Seq.distinctBy key seq
+	regexp.MustCompile(`^Seq\.sum$`),       // Seq.sum seq
+	regexp.MustCompile(`^Seq\.sumBy$`),     // Seq.sumBy f seq
+	regexp.MustCompile(`^Seq\.min$`),       // Seq.min seq
+	regexp.MustCompile(`^Seq\.max$`),       // Seq.max seq
+	regexp.MustCompile(`^Seq\.init$`),      // Seq.init n f
+	regexp.MustCompile(`^Seq\.initInfinite$`), // Seq.initInfinite f
+	regexp.MustCompile(`^Seq\.unfold$`),    // Seq.unfold f state
+	regexp.MustCompile(`^Seq\.scan$`),      // Seq.scan f init seq
+	regexp.MustCompile(`^Seq\.pairwise$`),  // Seq.pairwise seq
+	regexp.MustCompile(`^Seq\.windowed$`),  // Seq.windowed n seq
+	regexp.MustCompile(`^Seq\.indexed$`),   // Seq.indexed seq
+	regexp.MustCompile(`^Seq\.item$`),      // Seq.item i seq
+	regexp.MustCompile(`^Seq\.nth$`),       // Seq.nth seq i (legacy)
+
+	// ── Array module ─────────────────────────────────────────────────────
+	regexp.MustCompile(`^Array\.map$`),      // Array.map f arr
+	regexp.MustCompile(`^Array\.filter$`),   // Array.filter pred arr
+	regexp.MustCompile(`^Array\.fold$`),     // Array.fold f init arr
+	regexp.MustCompile(`^Array\.foldBack$`), // Array.foldBack f arr init
+	regexp.MustCompile(`^Array\.iter$`),     // Array.iter f arr
+	regexp.MustCompile(`^Array\.iteri$`),    // Array.iteri f arr
+	regexp.MustCompile(`^Array\.mapi$`),     // Array.mapi f arr
+	regexp.MustCompile(`^Array\.collect$`),  // Array.collect f arr
+	regexp.MustCompile(`^Array\.choose$`),   // Array.choose f arr
+	regexp.MustCompile(`^Array\.forall$`),   // Array.forall pred arr
+	regexp.MustCompile(`^Array\.exists$`),   // Array.exists pred arr
+	regexp.MustCompile(`^Array\.find$`),     // Array.find pred arr
+	regexp.MustCompile(`^Array\.tryFind$`),  // Array.tryFind pred arr
+	regexp.MustCompile(`^Array\.length$`),   // Array.length arr
+	regexp.MustCompile(`^Array\.isEmpty$`),  // Array.isEmpty arr
+	regexp.MustCompile(`^Array\.append$`),   // Array.append arr1 arr2
+	regexp.MustCompile(`^Array\.concat$`),   // Array.concat arrs
+	regexp.MustCompile(`^Array\.rev$`),      // Array.rev arr
+	regexp.MustCompile(`^Array\.sort$`),     // Array.sort arr
+	regexp.MustCompile(`^Array\.sortBy$`),   // Array.sortBy key arr
+	regexp.MustCompile(`^Array\.sortWith$`), // Array.sortWith cmp arr
+	regexp.MustCompile(`^Array\.sum$`),      // Array.sum arr
+	regexp.MustCompile(`^Array\.sumBy$`),    // Array.sumBy f arr
+	regexp.MustCompile(`^Array\.init$`),     // Array.init n f
+	regexp.MustCompile(`^Array\.create$`),   // Array.create n x
+	regexp.MustCompile(`^Array\.zeroCreate$`), // Array.zeroCreate n
+	regexp.MustCompile(`^Array\.copy$`),     // Array.copy arr
+	regexp.MustCompile(`^Array\.sub$`),      // Array.sub arr start len
+	regexp.MustCompile(`^Array\.take$`),     // Array.take n arr
+	regexp.MustCompile(`^Array\.skip$`),     // Array.skip n arr
+	regexp.MustCompile(`^Array\.zip$`),      // Array.zip arr1 arr2
+	regexp.MustCompile(`^Array\.unzip$`),    // Array.unzip arr
+	regexp.MustCompile(`^Array\.partition$`), // Array.partition pred arr
+	regexp.MustCompile(`^Array\.distinct$`), // Array.distinct arr
+	regexp.MustCompile(`^Array\.groupBy$`),  // Array.groupBy key arr
+	regexp.MustCompile(`^Array\.toList$`),   // Array.toList arr
+	regexp.MustCompile(`^Array\.toSeq$`),    // Array.toSeq arr
+	regexp.MustCompile(`^Array\.ofList$`),   // Array.ofList lst
+	regexp.MustCompile(`^Array\.ofSeq$`),    // Array.ofSeq seq
+	regexp.MustCompile(`^Array\.indexed$`),  // Array.indexed arr
+
+	// ── Option module ────────────────────────────────────────────────────
+	regexp.MustCompile(`^Option\.map$`),           // Option.map f opt
+	regexp.MustCompile(`^Option\.bind$`),          // Option.bind f opt
+	regexp.MustCompile(`^Option\.defaultValue$`),  // Option.defaultValue def opt
+	regexp.MustCompile(`^Option\.defaultWith$`),   // Option.defaultWith f opt
+	regexp.MustCompile(`^Option\.filter$`),        // Option.filter pred opt
+	regexp.MustCompile(`^Option\.count$`),         // Option.count opt
+	regexp.MustCompile(`^Option\.fold$`),          // Option.fold f init opt
+	regexp.MustCompile(`^Option\.foldBack$`),      // Option.foldBack f opt init
+	regexp.MustCompile(`^Option\.forall$`),        // Option.forall pred opt
+	regexp.MustCompile(`^Option\.exists$`),        // Option.exists pred opt
+	regexp.MustCompile(`^Option\.iter$`),          // Option.iter f opt
+	regexp.MustCompile(`^Option\.isNone$`),        // Option.isNone opt
+	regexp.MustCompile(`^Option\.isSome$`),        // Option.isSome opt
+	regexp.MustCompile(`^Option\.get$`),           // Option.get opt
+	regexp.MustCompile(`^Option\.toArray$`),       // Option.toArray opt
+	regexp.MustCompile(`^Option\.toList$`),        // Option.toList opt
+	regexp.MustCompile(`^Option\.toNullable$`),    // Option.toNullable opt
+	regexp.MustCompile(`^Option\.ofNullable$`),    // Option.ofNullable n
+	regexp.MustCompile(`^Option\.ofObj$`),         // Option.ofObj obj
+	regexp.MustCompile(`^Option\.toObj$`),         // Option.toObj opt
+	regexp.MustCompile(`^Option\.flatten$`),       // Option.flatten opt
+	regexp.MustCompile(`^Option\.orElse$`),        // Option.orElse alt opt
+	regexp.MustCompile(`^Option\.orElseWith$`),    // Option.orElseWith f opt
+	regexp.MustCompile(`^Option\.contains$`),      // Option.contains v opt
+
+	// ── Result module ────────────────────────────────────────────────────
+	regexp.MustCompile(`^Result\.map$`),       // Result.map f r
+	regexp.MustCompile(`^Result\.mapError$`),  // Result.mapError f r
+	regexp.MustCompile(`^Result\.bind$`),      // Result.bind f r
+	regexp.MustCompile(`^Result\.isOk$`),      // Result.isOk r
+	regexp.MustCompile(`^Result\.isError$`),   // Result.isError r
+	regexp.MustCompile(`^Result\.defaultValue$`), // Result.defaultValue def r
+	regexp.MustCompile(`^Result\.defaultWith$`),  // Result.defaultWith f r
+	regexp.MustCompile(`^Result\.count$`),     // Result.count r
+	regexp.MustCompile(`^Result\.fold$`),      // Result.fold ok err r
+	regexp.MustCompile(`^Result\.foldBack$`),  // Result.foldBack ok err r init
+	regexp.MustCompile(`^Result\.iter$`),      // Result.iter f r
+	regexp.MustCompile(`^Result\.iterError$`), // Result.iterError f r
+	regexp.MustCompile(`^Result\.exists$`),    // Result.exists pred r
+	regexp.MustCompile(`^Result\.forall$`),    // Result.forall pred r
+	regexp.MustCompile(`^Result\.filter$`),    // Result.filter pred err r
+	regexp.MustCompile(`^Result\.toArray$`),   // Result.toArray r
+	regexp.MustCompile(`^Result\.toList$`),    // Result.toList r
+	regexp.MustCompile(`^Result\.toOption$`),  // Result.toOption r
+	regexp.MustCompile(`^Result\.ofOption$`),  // Result.ofOption err opt
+
+	// ── Map module ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^Map\.add$`),         // Map.add k v m
+	regexp.MustCompile(`^Map\.remove$`),      // Map.remove k m
+	regexp.MustCompile(`^Map\.find$`),        // Map.find k m
+	regexp.MustCompile(`^Map\.tryFind$`),     // Map.tryFind k m
+	regexp.MustCompile(`^Map\.containsKey$`), // Map.containsKey k m
+	regexp.MustCompile(`^Map\.map$`),         // Map.map f m
+	regexp.MustCompile(`^Map\.filter$`),      // Map.filter pred m
+	regexp.MustCompile(`^Map\.fold$`),        // Map.fold f init m
+	regexp.MustCompile(`^Map\.iter$`),        // Map.iter f m
+	regexp.MustCompile(`^Map\.toList$`),      // Map.toList m
+	regexp.MustCompile(`^Map\.toSeq$`),       // Map.toSeq m
+	regexp.MustCompile(`^Map\.toArray$`),     // Map.toArray m
+	regexp.MustCompile(`^Map\.ofList$`),      // Map.ofList pairs
+	regexp.MustCompile(`^Map\.ofSeq$`),       // Map.ofSeq pairs
+	regexp.MustCompile(`^Map\.ofArray$`),     // Map.ofArray pairs
+	regexp.MustCompile(`^Map\.isEmpty$`),     // Map.isEmpty m
+	regexp.MustCompile(`^Map\.count$`),       // Map.count m
+	regexp.MustCompile(`^Map\.keys$`),        // Map.keys m
+	regexp.MustCompile(`^Map\.values$`),      // Map.values m
+	regexp.MustCompile(`^Map\.merge$`),       // Map.merge m1 m2
+	regexp.MustCompile(`^Map\.mergeWith$`),   // Map.mergeWith f m1 m2
+	regexp.MustCompile(`^Map\.partition$`),   // Map.partition pred m
+	regexp.MustCompile(`^Map\.exists$`),      // Map.exists pred m
+	regexp.MustCompile(`^Map\.forall$`),      // Map.forall pred m
+	regexp.MustCompile(`^Map\.pick$`),        // Map.pick f m
+	regexp.MustCompile(`^Map\.tryPick$`),     // Map.tryPick f m
+	regexp.MustCompile(`^Map\.change$`),      // Map.change k f m
+	regexp.MustCompile(`^Map\.findKey$`),     // Map.findKey pred m
+	regexp.MustCompile(`^Map\.tryFindKey$`),  // Map.tryFindKey pred m
+
+	// ── Set module ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^Set\.add$`),        // Set.add x s
+	regexp.MustCompile(`^Set\.remove$`),     // Set.remove x s
+	regexp.MustCompile(`^Set\.contains$`),   // Set.contains x s
+	regexp.MustCompile(`^Set\.union$`),      // Set.union s1 s2
+	regexp.MustCompile(`^Set\.intersect$`),  // Set.intersect s1 s2
+	regexp.MustCompile(`^Set\.difference$`), // Set.difference s1 s2
+	regexp.MustCompile(`^Set\.isSubset$`),   // Set.isSubset s1 s2
+	regexp.MustCompile(`^Set\.isEmpty$`),    // Set.isEmpty s
+	regexp.MustCompile(`^Set\.count$`),      // Set.count s
+	regexp.MustCompile(`^Set\.toList$`),     // Set.toList s
+	regexp.MustCompile(`^Set\.toSeq$`),      // Set.toSeq s
+	regexp.MustCompile(`^Set\.toArray$`),    // Set.toArray s
+	regexp.MustCompile(`^Set\.ofList$`),     // Set.ofList lst
+	regexp.MustCompile(`^Set\.ofSeq$`),      // Set.ofSeq seq
+	regexp.MustCompile(`^Set\.ofArray$`),    // Set.ofArray arr
+	regexp.MustCompile(`^Set\.map$`),        // Set.map f s
+	regexp.MustCompile(`^Set\.filter$`),     // Set.filter pred s
+	regexp.MustCompile(`^Set\.fold$`),       // Set.fold f init s
+	regexp.MustCompile(`^Set\.foldBack$`),   // Set.foldBack f s init
+	regexp.MustCompile(`^Set\.iter$`),       // Set.iter f s
+	regexp.MustCompile(`^Set\.forall$`),     // Set.forall pred s
+	regexp.MustCompile(`^Set\.exists$`),     // Set.exists pred s
+	regexp.MustCompile(`^Set\.partition$`),  // Set.partition pred s
+	regexp.MustCompile(`^Set\.minElement$`), // Set.minElement s
+	regexp.MustCompile(`^Set\.maxElement$`), // Set.maxElement s
+
+	// ── Async / Task patterns ─────────────────────────────────────────────
+	regexp.MustCompile(`^Async\.RunSynchronously$`), // Async.RunSynchronously async
+	regexp.MustCompile(`^Async\.AwaitTask$`),        // Async.AwaitTask task
+	regexp.MustCompile(`^Async\.AwaitWaitHandle$`),  // Async.AwaitWaitHandle wh
+	regexp.MustCompile(`^Async\.Start$`),            // Async.Start async
+	regexp.MustCompile(`^Async\.StartAsTask$`),      // Async.StartAsTask async
+	regexp.MustCompile(`^Async\.Parallel$`),         // Async.Parallel asyncs
+	regexp.MustCompile(`^Async\.Sequential$`),       // Async.Sequential asyncs
+	regexp.MustCompile(`^Async\.Sleep$`),            // Async.Sleep ms
+	regexp.MustCompile(`^Async\.Catch$`),            // Async.Catch async
+	regexp.MustCompile(`^Async\.TryCancelled$`),     // Async.TryCancelled async handler
+	regexp.MustCompile(`^Async\.CancellationToken$`), // Async.CancellationToken
+	regexp.MustCompile(`^Async\.CancelDefaultToken$`), // Async.CancelDefaultToken
+	regexp.MustCompile(`^Async\.Ignore$`),           // Async.Ignore async
+	regexp.MustCompile(`^Async\.map$`),              // Async.map f async
+
+	// ── String / Printf ──────────────────────────────────────────────────
+	regexp.MustCompile(`^String\.concat$`),  // String.concat sep strs
+	regexp.MustCompile(`^String\.split$`),   // String.split sep str
+	regexp.MustCompile(`^String\.join$`),    // String.Join sep strs (BCL)
+	regexp.MustCompile(`^String\.IsNullOrEmpty$`), // String.IsNullOrEmpty s
+	regexp.MustCompile(`^String\.IsNullOrWhiteSpace$`), // String.IsNullOrWhiteSpace s
+
+	// ── Giraffe HTTP handlers ────────────────────────────────────────────
+	// These are highly Giraffe-specific and unlikely to appear in other languages.
+	regexp.MustCompile(`^route$`),           // route "/path"
+	regexp.MustCompile(`^routef$`),          // routef "/path/%i" handler
+	regexp.MustCompile(`^routex$`),          // routex "pattern" handler
+	regexp.MustCompile(`^routeStartsWith$`), // routeStartsWith prefix handler
+	regexp.MustCompile(`^choose$`),          // choose [handler1; handler2]
+	regexp.MustCompile(`^setStatusCode$`),   // setStatusCode 404
+	regexp.MustCompile(`^setHttpHeader$`),   // setHttpHeader name value
+	regexp.MustCompile(`^text$`),            // text "response body"
+	regexp.MustCompile(`^json$`),            // json obj
+	regexp.MustCompile(`^htmlString$`),      // htmlString "<html>..."
+	regexp.MustCompile(`^htmlFile$`),        // htmlFile path
+	regexp.MustCompile(`^negotiateWith$`),   // negotiateWith rules
+	regexp.MustCompile(`^negotiate$`),       // negotiate obj
+	regexp.MustCompile(`^redirectTo$`),      // redirectTo permanent url
+	regexp.MustCompile(`^GET$`),             // GET >=>
+	regexp.MustCompile(`^POST$`),            // POST >=>
+	regexp.MustCompile(`^PUT$`),             // PUT >=>
+	regexp.MustCompile(`^PATCH$`),           // PATCH >=>
+	regexp.MustCompile(`^DELETE$`),          // DELETE >=>
+	regexp.MustCompile(`^HEAD$`),            // HEAD >=>
+	regexp.MustCompile(`^OPTIONS$`),         // OPTIONS >=>
+	regexp.MustCompile(`^subRoute$`),        // subRoute prefix handler
+	regexp.MustCompile(`^subRoutef$`),       // subRoutef fmt handler
+	regexp.MustCompile(`^warbler$`),         // warbler (Giraffe task combinators)
+
+	// ── F#-gated common names ────────────────────────────────────────────
+	// These are common English words but in F# they specifically refer to
+	// F# stdlib operations.
+	regexp.MustCompile(`^printfn$`),         // printfn fmt args — F# stdout
+	regexp.MustCompile(`^sprintf$`),         // sprintf fmt args — F# string format
+	regexp.MustCompile(`^failwith$`),        // failwith msg — F# exception helper
+	regexp.MustCompile(`^failwithf$`),       // failwithf fmt args
+	regexp.MustCompile(`^invalidArg$`),      // invalidArg paramName msg
+	regexp.MustCompile(`^invalidOp$`),       // invalidOp msg
+	regexp.MustCompile(`^nullArg$`),         // nullArg paramName
+	regexp.MustCompile(`^raise$`),           // raise exn
+	regexp.MustCompile(`^reraise$`),         // reraise()
+	regexp.MustCompile(`^ignore$`),          // ignore x — F# value discard
+	regexp.MustCompile(`^id$`),              // id x — identity function
+	regexp.MustCompile(`^fst$`),             // fst (a, b) — tuple first
+	regexp.MustCompile(`^snd$`),             // snd (a, b) — tuple second
+	regexp.MustCompile(`^not$`),             // not b — boolean negate
+	regexp.MustCompile(`^typeof$`),          // typeof<'T>
+	regexp.MustCompile(`^typedefof$`),       // typedefof<'T>
+	regexp.MustCompile(`^sizeof$`),          // sizeof<'T>
+	regexp.MustCompile(`^nameof$`),          // nameof x
+	regexp.MustCompile(`^box$`),             // box x — F# boxing
+	regexp.MustCompile(`^unbox$`),           // unbox<'T> x — F# unboxing
+	regexp.MustCompile(`^upcast$`),          // upcast x
+	regexp.MustCompile(`^downcast$`),        // downcast<'T> x
+}
+
+func init() {
+	dynamicPatternsByLang["fsharp"] = fsharpDynamicPatterns
+}


### PR DESCRIPTION
## What

Adds a first-pass F# extractor so resolver coverage can be measured against real edges, unblocking the resolver slice for issue #44.

## Changes

**`internal/extractors/fsharp/extractor.go`** — new regex-based extractor:
- \`module\` / \`namespace\` declarations → \`SCOPE.Component\` (subtype \`module\` / \`namespace\`)
- \`let\` / \`let rec\` / \`let mutable\` bindings → \`SCOPE.Operation\` (subtype \`let\`)
- \`member\` / \`override\` / \`default\` definitions → \`SCOPE.Operation\` (subtype \`member\`)
- \`type\` declarations (record, discriminated union, class, interface, struct, alias) → \`SCOPE.Component\`
- \`open\` statements → \`IMPORTS\` edges
- Function application calls, pipe \`|>\` targets, compose \`>>\` targets → \`CALLS\` edges
- Type CONTAINS member edges; all relationships tagged \`language=fsharp\`

**\`internal/extractors/fsharp/fsharp_test.go\`** — 14 tests: registration, empty input, module/namespace/let/member/type discovery, open-statement IMPORTS edges, CALLS edges, pipe-operator CALLS, self-recursion exclusion, language tagging, member functions, Giraffe HTTP web app fixture (100% recall), async workflow fixture.

**\`internal/classifier/classifier.go\`** — \`.fs\` / \`.fsi\` / \`.fsx\` / \`.fsproj\` → \`"fsharp"\`

**\`internal/extractors/registry_gen.go\`** — blank-import for \`fsharp\` package

**\`internal/resolve/dynamic_patterns_fsharp.go\`** — 180+ resolver patterns covering \`List.*\`, \`Seq.*\`, \`Array.*\`, \`Option.*\`, \`Result.*\`, \`Map.*\`, \`Set.*\`, \`Async.*\`, Giraffe HTTP handlers (\`route\`, \`choose\`, \`setStatusCode\`, \`text\`, \`json\`, \`htmlString\`, \`GET\`/\`POST\`/etc.), and F#-gated builtins (\`printfn\`, \`sprintf\`, \`failwith\`, \`ignore\`, \`id\`, \`fst\`, \`snd\`).

## Test results

```
go test ./internal/extractors/fsharp/...
  14/14 PASS — Giraffe fixture recall: 13/13 (100%)

go test ./internal/classifier/...   PASS
go test ./internal/resolve/...      PASS
go test ./internal/...              all PASS
```

## Acceptance criteria

- [x] Synthetic Giraffe fixture: ≥80% entity recall — **100% (13/13)**
- [x] 0 false positives on cross-language gate (TestDynamicPatterns_Cross passes)
- [x] go test ./internal/extractors/fsharp/... ./internal/classifier/... ./internal/resolve/... clean

## File extensions registered

\`.fs\`, \`.fsi\`, \`.fsx\`, \`.fsproj\`

Closes #1036
Refs #44