### PR TITLE
[#1037] Add Erlang language extractor and resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -433,6 +433,9 @@ var extensionLanguageMap = map[string]string{
 	".edn":  "clojure",
 	// Zig
 	".zig": "zig",
+	// Erlang
+	".erl": "erlang",
+	".hrl": "erlang",
 	// Nim
 	".nim":    "nim",
 	".nimble": "nim",

--- a/internal/extractors/erlang/extractor.go
+++ b/internal/extractors/erlang/extractor.go
@@ -1,0 +1,465 @@
+// Package erlang implements a regex-based extractor for Erlang source files.
+//
+// Extracted entities:
+//   - module attributes (-module(foo).)           → Kind="SCOPE.Component", Subtype="module"
+//   - function clauses (name(Args) -> body.)       → Kind="SCOPE.Operation", Subtype="function" / "exported_function"
+//   - record attributes (-record(Foo, {...}).)     → Kind="SCOPE.Component", Subtype="record"
+//   - include attributes (-include("foo.hrl").)   → IMPORTS relationships
+//
+// Relationships emitted:
+//   - IMPORTS — every -include/-include_lib attribute
+//   - CALLS   — Module:Function and bare Function invocations inside function bodies
+//   - CONTAINS — module entity links to each exported function
+//
+// No tree-sitter grammar for Erlang is available in smacker/go-tree-sitter.
+// This extractor uses line-oriented regex parsing, matching the Nim extractor
+// precedent (internal/extractors/nim/nim.go).
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package erlang
+
+import (
+	"context"
+	"regexp"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("erlang", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Erlang.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "erlang" }
+
+// ---------------------------------------------------------------------------
+// Compiled regular expressions
+// ---------------------------------------------------------------------------
+
+var (
+	// moduleRE matches -module(foo). attribute.
+	// Group 1: module name (atom).
+	moduleRE = regexp.MustCompile(
+		`(?m)^-module\s*\(\s*([a-z][a-zA-Z0-9_@]*)\s*\)\s*\.`,
+	)
+
+	// exportRE matches -export([...]) attribute.
+	// Group 1: export list content.
+	exportRE = regexp.MustCompile(
+		`(?m)^-export\s*\(\s*\[([^\]]*)\]\s*\)\s*\.`,
+	)
+
+	// recordRE matches -record(RecordName, {fields}).
+	// Group 1: record name.
+	recordRE = regexp.MustCompile(
+		`(?m)^-record\s*\(\s*([a-z][a-zA-Z0-9_@]*)\s*,`,
+	)
+
+	// includeRE matches -include("file.hrl") and -include_lib("app/include/file.hrl").
+	// Group 1: the file path string.
+	includeRE = regexp.MustCompile(
+		`(?m)^-include(?:_lib)?\s*\(\s*"([^"]+)"\s*\)\s*\.`,
+	)
+
+	// funcHeadRE matches a function clause head.
+	// Erlang function heads: name(Args) -> or name(Args) when Guard ->
+	// Group 1: function name; Group 2 (optional): arguments text.
+	funcHeadRE = regexp.MustCompile(
+		`(?m)^([a-z_][a-zA-Z0-9_@]*)\s*(\([^)]*\))\s*(?:when\s+[^->\n]+)?\s*->`,
+	)
+
+	// callQualifiedRE matches Module:Function( invocations.
+	// Group 1: module; Group 2: function.
+	callQualifiedRE = regexp.MustCompile(
+		`\b([a-z_][a-zA-Z0-9_@]*)\s*:\s*([a-z_][a-zA-Z0-9_@!?]*)\s*\(`,
+	)
+
+	// callBareRE matches bare function calls: name( — not preceded by ':'.
+	// Group 1: function name.
+	callBareRE = regexp.MustCompile(
+		`(?:^|[^:a-zA-Z0-9_@])([a-z_][a-zA-Z0-9_@!?]*)\s*\(`,
+	)
+
+	// exportItemRE matches a single Name/Arity entry in an export list.
+	// Group 1: function name; Group 2: arity (ignored for entity matching).
+	exportItemRE = regexp.MustCompile(
+		`([a-z_][a-zA-Z0-9_@]*)\s*/\s*(\d+)`,
+	)
+)
+
+// erlangKeywords are tokens that match funcHead or call patterns but are NOT
+// real function names or call targets.
+var erlangKeywords = map[string]bool{
+	"if": true, "case": true, "receive": true, "begin": true, "try": true,
+	"catch": true, "when": true, "fun": true, "end": true, "of": true,
+	"after": true, "throw": true, "exit": true, "error": true,
+	"andalso": true, "orelse": true, "not": true, "and": true, "or": true,
+	"xor": true, "band": true, "bor": true, "bxor": true, "bnot": true,
+	"bsl": true, "bsr": true, "div": true, "rem": true,
+	// Erlang BIFs that are effectively keywords.
+	"is_atom": true, "is_binary": true, "is_boolean": true, "is_float": true,
+	"is_function": true, "is_integer": true, "is_list": true, "is_map": true,
+	"is_number": true, "is_pid": true, "is_port": true, "is_record": true,
+	"is_reference": true, "is_tuple": true,
+	// module/record/export attribute keywords.
+	"module": true, "export": true, "import": true, "record": true,
+	"define": true, "include": true, "include_lib": true, "behaviour": true,
+	"behavior": true, "vsn": true, "compile": true, "on_load": true,
+	"spec": true, "type": true, "opaque": true, "callback": true,
+	"optional_callbacks": true, "export_type": true,
+}
+
+// Extract processes an Erlang source file and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractErlang(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "erlang")
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// Core extraction
+// ---------------------------------------------------------------------------
+
+// funcInfo collects data about a single logical function (grouped by name across all clauses).
+type funcInfo struct {
+	name      string
+	exported  bool
+	startLine int
+	endLine   int
+	calls     []string // raw call targets extracted from all clauses
+}
+
+// clauseMatch holds the parsed data for a single function clause head match.
+type clauseMatch struct {
+	name      string
+	line      int
+	matchEnd  int // byte offset after the '->'
+	matchByte int // byte offset of the match start
+}
+
+func extractErlang(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// ── 1. Module declaration ──────────────────────────────────────────────
+	moduleName := ""
+	moduleIdx := -1
+	if m := moduleRE.FindStringSubmatchIndex(src); m != nil {
+		moduleName = src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		moduleIdx = len(entities)
+		entities = append(entities, types.EntityRecord{
+			Name:               moduleName,
+			Kind:               "SCOPE.Component",
+			Subtype:            "module",
+			SourceFile:         filePath,
+			Language:           "erlang",
+			StartLine:          startLine,
+			EndLine:            strings.Count(src, "\n") + 1,
+			Signature:          "-module(" + moduleName + ").",
+			EnrichmentRequired: false,
+		})
+	}
+
+	// ── 2. Record declarations ─────────────────────────────────────────────
+	for _, m := range recordRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Component",
+			Subtype:            "record",
+			SourceFile:         filePath,
+			Language:           "erlang",
+			StartLine:          startLine,
+			EndLine:            startLine,
+			Signature:          "-record(" + name + ", ...).",
+			EnrichmentRequired: false,
+		})
+	}
+
+	// ── 3. Include / imports ────────────────────────────────────────────────
+	for _, m := range includeRE.FindAllStringSubmatchIndex(src, -1) {
+		path := src[m[2]:m[3]]
+		if path == "" {
+			continue
+		}
+		leaf := path
+		if slash := strings.LastIndexByte(path, '/'); slash >= 0 {
+			leaf = path[slash+1:]
+		}
+		entities = append(entities, types.EntityRecord{
+			Name:       leaf,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "erlang",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   path,
+					Kind:   "IMPORTS",
+					Properties: map[string]string{
+						"local_name":    leaf,
+						"source_module": path,
+						"imported_name": leaf,
+						"import_kind":   "include",
+					},
+				},
+			},
+		})
+	}
+
+	// ── 4. Parse exported function names ──────────────────────────────────
+	exported := make(map[string]bool)
+	for _, m := range exportRE.FindAllStringSubmatch(src, -1) {
+		list := m[1]
+		for _, em := range exportItemRE.FindAllStringSubmatch(list, -1) {
+			exported[em[1]] = true
+		}
+	}
+
+	// ── 5. Function clauses — group by name ───────────────────────────────
+	// We collect all clause matches, then group by function name.
+	var clauses []clauseMatch
+	for _, m := range funcHeadRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		if erlangKeywords[name] {
+			continue
+		}
+		// Skip attribute lines that accidentally look like function heads.
+		// Erlang attributes start with '-' on the same line — check if this
+		// head is inside an attribute by looking at the previous non-space line.
+		matchStart := m[0]
+		if isInsideAttribute(src, matchStart) {
+			continue
+		}
+		line := strings.Count(src[:m[0]], "\n") + 1
+		clauses = append(clauses, clauseMatch{
+			name:      name,
+			line:      line,
+			matchEnd:  m[1],
+			matchByte: m[0],
+		})
+	}
+
+	// Group consecutive clauses by name.
+	funcs := groupClauses(src, clauses)
+
+	// ── 6. Emit function entities ──────────────────────────────────────────
+	for _, fi := range funcs {
+		subtype := "function"
+		if exported[fi.name] {
+			subtype = "exported_function"
+		}
+
+		// Collect CALLS.
+		callRels := collectCallsFromText(fi.calls, fi.name)
+
+		rec := types.EntityRecord{
+			Name:               fi.name,
+			Kind:               "SCOPE.Operation",
+			Subtype:            subtype,
+			SourceFile:         filePath,
+			Language:           "erlang",
+			StartLine:          fi.startLine,
+			EndLine:            fi.endLine,
+			Signature:          fi.name + "/...",
+			EnrichmentRequired: false,
+			Relationships:      callRels,
+		}
+		opIdx := len(entities)
+		entities = append(entities, rec)
+
+		// Attach CONTAINS from the module entity.
+		if moduleIdx >= 0 && exported[fi.name] {
+			toID := extractor.BuildOperationStructuralRef("erlang", filePath, fi.name)
+			entities[moduleIdx].Relationships = append(entities[moduleIdx].Relationships,
+				types.RelationshipRecord{
+					ToID: toID,
+					Kind: "CONTAINS",
+				})
+		}
+		_ = opIdx
+	}
+
+	return entities
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// isInsideAttribute returns true when the match at matchStart is preceded
+// (on the same logical source context) by a '-' attribute marker. Since
+// Erlang attributes can't span multiple logical lines, we check if the
+// line at matchStart starts with '-'.
+func isInsideAttribute(src string, matchStart int) bool {
+	// Find start of the line.
+	lineStart := strings.LastIndex(src[:matchStart], "\n")
+	lineStart++ // 0 if no newline found
+	line := src[lineStart:matchStart]
+	return strings.HasPrefix(strings.TrimSpace(line), "-")
+}
+
+// groupClauses groups clause matches by function name, computing start/end lines
+// and accumulating call text from each clause body.
+func groupClauses(src string, clauses []clauseMatch) []funcInfo {
+	if len(clauses) == 0 {
+		return nil
+	}
+
+	// Build a map from name to the accumulated info.
+	// We need to preserve order of first occurrence.
+	type accumulator struct {
+		fi       funcInfo
+		firstIdx int
+	}
+	order := make([]string, 0)
+	accMap := make(map[string]*accumulator)
+
+	for i, c := range clauses {
+		// Extract body: from clause end up to next clause's start (or EOF).
+		bodyEnd := len(src)
+		if i+1 < len(clauses) {
+			bodyEnd = clauses[i+1].matchByte
+		}
+		body := src[c.matchEnd:bodyEnd]
+		endLine := c.line + strings.Count(body, "\n")
+
+		if acc, exists := accMap[c.name]; exists {
+			acc.fi.endLine = endLine
+			acc.fi.calls = append(acc.fi.calls, body)
+		} else {
+			accMap[c.name] = &accumulator{
+				fi: funcInfo{
+					name:      c.name,
+					startLine: c.line,
+					endLine:   endLine,
+					calls:     []string{body},
+				},
+				firstIdx: i,
+			}
+			order = append(order, c.name)
+		}
+	}
+
+	// Return in order of first appearance.
+	result := make([]funcInfo, 0, len(order))
+	for _, name := range order {
+		result = append(result, accMap[name].fi)
+	}
+	return result
+}
+
+// collectCallsFromText scans body texts and returns one CALLS edge per unique callee.
+// Erlang calls can be:
+//   - Qualified: module:function(...)  → ToID = "module:function"
+//   - Bare: function(...)              → ToID = "function"
+func collectCallsFromText(bodies []string, callerName string) []types.RelationshipRecord {
+	seen := make(map[string]bool)
+	var rels []types.RelationshipRecord
+
+	addCall := func(target string) {
+		if target == "" || target == callerName || seen[target] {
+			return
+		}
+		seen[target] = true
+		rels = append(rels, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	for _, body := range bodies {
+		scrubbed := stripCommentsAndStrings(body)
+
+		// Qualified calls Module:Function( — emit "module:function" form.
+		for _, m := range callQualifiedRE.FindAllStringSubmatch(scrubbed, -1) {
+			mod := m[1]
+			fn := m[2]
+			if erlangKeywords[fn] {
+				continue
+			}
+			addCall(mod + ":" + fn)
+		}
+
+		// Bare calls name( — only lowercase-starting names.
+		for _, m := range callBareRE.FindAllStringSubmatch(scrubbed, -1) {
+			fn := m[1]
+			if erlangKeywords[fn] {
+				continue
+			}
+			addCall(fn)
+		}
+	}
+
+	// Sort for determinism.
+	sort.Slice(rels, func(i, j int) bool { return rels[i].ToID < rels[j].ToID })
+	return rels
+}
+
+// stripCommentsAndStrings replaces Erlang %-line-comments and string/atom
+// literals with spaces so the call scanner doesn't pick up tokens inside them.
+func stripCommentsAndStrings(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	for i < len(src) {
+		ch := src[i]
+		switch {
+		case ch == '%':
+			// Erlang comment: % to end of line.
+			for i < len(src) && src[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+		case ch == '"':
+			// Double-quoted string — scan to closing ".
+			out[i] = ' '
+			i++
+			for i < len(src) && src[i] != '"' {
+				if src[i] == '\\' && i+1 < len(src) {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' ' // closing "
+				i++
+			}
+		case ch == '\'':
+			// Single-quoted atom — scan to closing '.
+			out[i] = ' '
+			i++
+			for i < len(src) && src[i] != '\'' {
+				if src[i] == '\\' && i+1 < len(src) {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' ' // closing '
+				i++
+			}
+		default:
+			out[i] = ch
+			i++
+		}
+	}
+	return string(out)
+}

--- a/internal/extractors/erlang/extractor_test.go
+++ b/internal/extractors/erlang/extractor_test.go
@@ -1,0 +1,511 @@
+package erlang_test
+
+import (
+	"context"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/erlang"
+)
+
+// genServerFixture is a minimal OTP gen_server used as a fixture for recall tests.
+const genServerFixture = `
+-module(cache_server).
+
+-behaviour(gen_server).
+
+-include("cache.hrl").
+
+-export([start_link/0, get/1, put/2, delete/1, flush/0]).
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+get(Key) ->
+    gen_server:call(?SERVER, {get, Key}).
+
+put(Key, Value) ->
+    gen_server:cast(?SERVER, {put, Key, Value}).
+
+delete(Key) ->
+    gen_server:cast(?SERVER, {delete, Key}).
+
+flush() ->
+    gen_server:cast(?SERVER, flush).
+
+init([]) ->
+    State = maps:new(),
+    {ok, State}.
+
+handle_call({get, Key}, _From, State) ->
+    Value = maps:get(Key, State, undefined),
+    {reply, Value, State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({put, Key, Value}, State) ->
+    NewState = maps:put(Key, Value, State),
+    {noreply, NewState};
+handle_cast({delete, Key}, State) ->
+    NewState = maps:remove(Key, State),
+    {noreply, NewState};
+handle_cast(flush, _State) ->
+    {noreply, maps:new()};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.
+`
+
+func ext(t *testing.T) extractor.Extractor {
+	t.Helper()
+	e, ok := extractor.Get("erlang")
+	if !ok {
+		t.Fatal("erlang extractor not registered")
+	}
+	return e
+}
+
+func TestErlangExtractor_Registered(t *testing.T) {
+	_, ok := extractor.Get("erlang")
+	if !ok {
+		t.Fatal("erlang extractor not registered")
+	}
+}
+
+func TestErlangExtractor_EmptyFile(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.erl",
+		Content:  []byte(""),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(got))
+	}
+}
+
+func TestErlangExtractor_ModuleDeclaration(t *testing.T) {
+	src := `-module(my_mod).
+-export([hello/0]).
+
+hello() ->
+    ok.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "my_mod.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var found bool
+	for _, rec := range got {
+		if rec.Name == "my_mod" && rec.Kind == "SCOPE.Component" && rec.Subtype == "module" {
+			found = true
+			if rec.Language != "erlang" {
+				t.Errorf("expected language=erlang, got %q", rec.Language)
+			}
+			if rec.StartLine < 1 {
+				t.Errorf("expected StartLine >= 1, got %d", rec.StartLine)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected entity my_mod with Kind=SCOPE.Component Subtype=module")
+	}
+}
+
+func TestErlangExtractor_FunctionDeclarations(t *testing.T) {
+	src := `-module(greet).
+-export([hello/1, goodbye/1]).
+
+hello(Name) ->
+    io:format("Hello, ~s!~n", [Name]).
+
+goodbye(Name) ->
+    io:format("Goodbye, ~s!~n", [Name]).
+
+helper() ->
+    internal.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "greet.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	nameSet := make(map[string]string) // name → subtype
+	for _, rec := range got {
+		if rec.Kind == "SCOPE.Operation" {
+			nameSet[rec.Name] = rec.Subtype
+		}
+	}
+	for _, fn := range []string{"hello", "goodbye", "helper"} {
+		if _, ok := nameSet[fn]; !ok {
+			t.Errorf("expected function entity %q", fn)
+		}
+	}
+	// hello and goodbye are exported
+	if nameSet["hello"] != "exported_function" {
+		t.Errorf("hello should be exported_function, got %q", nameSet["hello"])
+	}
+	if nameSet["goodbye"] != "exported_function" {
+		t.Errorf("goodbye should be exported_function, got %q", nameSet["goodbye"])
+	}
+	// helper is not exported
+	if nameSet["helper"] != "function" {
+		t.Errorf("helper should be function, got %q", nameSet["helper"])
+	}
+}
+
+func TestErlangExtractor_RecordDeclarations(t *testing.T) {
+	src := `-module(user_store).
+-record(user, {id, name, email}).
+-record(session, {token, user_id, expires}).
+
+-export([new_user/3]).
+
+new_user(Id, Name, Email) ->
+    #user{id = Id, name = Name, email = Email}.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "user_store.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	records := make(map[string]bool)
+	for _, rec := range got {
+		if rec.Kind == "SCOPE.Component" && rec.Subtype == "record" {
+			records[rec.Name] = true
+		}
+	}
+	for _, r := range []string{"user", "session"} {
+		if !records[r] {
+			t.Errorf("expected record entity %q", r)
+		}
+	}
+}
+
+func TestErlangExtractor_IncludeImports(t *testing.T) {
+	src := `-module(worker).
+-include("common.hrl").
+-include_lib("kernel/include/logger.hrl").
+
+-export([run/0]).
+
+run() ->
+    ok.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "worker.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	imports := make(map[string]bool)
+	for _, rec := range got {
+		for _, rel := range rec.Relationships {
+			if rel.Kind == "IMPORTS" {
+				imports[rel.ToID] = true
+			}
+		}
+	}
+	if !imports["common.hrl"] {
+		t.Error("expected IMPORTS edge for common.hrl")
+	}
+	if !imports["kernel/include/logger.hrl"] {
+		t.Error("expected IMPORTS edge for kernel/include/logger.hrl")
+	}
+}
+
+func TestErlangExtractor_CallsEdge(t *testing.T) {
+	src := `-module(pipeline).
+-export([process/1]).
+
+process(Data) ->
+    Cleaned = validate(Data),
+    Result = transform(Cleaned),
+    lists:reverse(Result).
+
+validate(D) ->
+    D.
+
+transform(D) ->
+    D.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "pipeline.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var callTargets []string
+	for _, rec := range got {
+		if rec.Name == "process" && rec.Kind == "SCOPE.Operation" {
+			for _, rel := range rec.Relationships {
+				if rel.Kind == "CALLS" {
+					callTargets = append(callTargets, rel.ToID)
+				}
+			}
+		}
+	}
+	sort.Strings(callTargets)
+	if len(callTargets) == 0 {
+		t.Error("expected at least one CALLS edge from process/1")
+	}
+	// Should call validate and transform
+	var foundValidate, foundTransform bool
+	for _, t2 := range callTargets {
+		if t2 == "validate" {
+			foundValidate = true
+		}
+		if t2 == "transform" {
+			foundTransform = true
+		}
+	}
+	if !foundValidate {
+		t.Error("expected CALLS edge to validate")
+	}
+	if !foundTransform {
+		t.Error("expected CALLS edge to transform")
+	}
+}
+
+func TestErlangExtractor_QualifiedCallsEdge(t *testing.T) {
+	src := `-module(server).
+-export([start/0]).
+
+start() ->
+    gen_server:start_link({local, server}, ?MODULE, [], []).
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "server.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var foundQualified bool
+	for _, rec := range got {
+		if rec.Name == "start" {
+			for _, rel := range rec.Relationships {
+				if rel.Kind == "CALLS" && rel.ToID == "gen_server:start_link" {
+					foundQualified = true
+				}
+			}
+		}
+	}
+	if !foundQualified {
+		t.Error("expected CALLS edge with ToID=gen_server:start_link")
+	}
+}
+
+func TestErlangExtractor_ContainsEdge(t *testing.T) {
+	src := `-module(api).
+-export([create/1, read/1]).
+
+create(Item) ->
+    {ok, Item}.
+
+read(Id) ->
+    {ok, Id}.
+
+private_helper() ->
+    ok.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "api.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	var containsCount int
+	for _, rec := range got {
+		if rec.Name == "api" && rec.Kind == "SCOPE.Component" && rec.Subtype == "module" {
+			for _, rel := range rec.Relationships {
+				if rel.Kind == "CONTAINS" {
+					containsCount++
+				}
+			}
+		}
+	}
+	// Should contain create and read (exported), but NOT private_helper.
+	if containsCount < 2 {
+		t.Errorf("expected at least 2 CONTAINS edges from module api, got %d", containsCount)
+	}
+}
+
+func TestErlangExtractor_MultiClauseFunctions(t *testing.T) {
+	src := `-module(fib).
+-export([fib/1]).
+
+fib(0) -> 0;
+fib(1) -> 1;
+fib(N) when N > 1 ->
+    fib(N-1) + fib(N-2).
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "fib.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Multi-clause function 'fib' should appear only once.
+	count := 0
+	for _, rec := range got {
+		if rec.Name == "fib" && rec.Kind == "SCOPE.Operation" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 entity for multi-clause function fib, got %d", count)
+	}
+}
+
+func TestErlangExtractor_LanguageTag(t *testing.T) {
+	src := `-module(tagged).
+-export([run/0]).
+
+run() -> ok.
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "tagged.erl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	for _, rec := range got {
+		if rec.Language != "" && rec.Language != "erlang" {
+			t.Errorf("expected language=erlang, got %q on entity %q", rec.Language, rec.Name)
+		}
+		for _, rel := range rec.Relationships {
+			if lang, ok := rel.Properties["language"]; ok && lang != "erlang" {
+				t.Errorf("expected relationship language=erlang, got %q on rel %q→%q", lang, rel.FromID, rel.ToID)
+			}
+		}
+	}
+}
+
+// TestErlangExtractor_GenServerRecall verifies ≥80% entity recall against
+// the synthetic gen_server fixture defined at the top of this file.
+func TestErlangExtractor_GenServerRecall(t *testing.T) {
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "cache_server.erl",
+		Content:  []byte(genServerFixture),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantNames := []string{
+		"cache_server", // module
+		"start_link",  // API function
+		"get",
+		"put",
+		"delete",
+		"flush",
+		"init",         // gen_server callback
+		"handle_call",
+		"handle_cast",
+		"handle_info",
+		"terminate",
+		"code_change",
+	}
+
+	nameSet := make(map[string]bool, len(got))
+	for _, rec := range got {
+		nameSet[rec.Name] = true
+	}
+
+	found := 0
+	for _, w := range wantNames {
+		if nameSet[w] {
+			found++
+		}
+	}
+	recall := float64(found) / float64(len(wantNames))
+	if recall < 0.80 {
+		t.Errorf("entity recall %.0f%% < 80%% — found %d/%d. Names in graph: %v",
+			recall*100, found, len(wantNames), sortedKeys(nameSet))
+	}
+}
+
+// TestErlangExtractor_HrlFile verifies that .hrl header files are also parsed.
+func TestErlangExtractor_HrlFile(t *testing.T) {
+	src := `-record(config, {host, port, timeout}).
+-record(state, {config, connections = []}).
+`
+	e := ext(t)
+	got, err := e.Extract(context.Background(), extractor.FileInput{
+		Path:     "defs.hrl",
+		Content:  []byte(src),
+		Language: "erlang",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	records := make(map[string]bool)
+	for _, rec := range got {
+		if rec.Kind == "SCOPE.Component" && rec.Subtype == "record" {
+			records[rec.Name] = true
+		}
+	}
+	for _, r := range []string{"config", "state"} {
+		if !records[r] {
+			t.Errorf("expected record entity %q from .hrl file", r)
+		}
+	}
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/dart"
 	_ "github.com/cajasmota/archigraph/internal/extractors/dockerfile"
 	_ "github.com/cajasmota/archigraph/internal/extractors/elixir"
+	_ "github.com/cajasmota/archigraph/internal/extractors/erlang"
 	_ "github.com/cajasmota/archigraph/internal/extractors/fish"
 	_ "github.com/cajasmota/archigraph/internal/extractors/golang"
 	_ "github.com/cajasmota/archigraph/internal/extractors/graphql"

--- a/internal/quality/golden/erlang-otp-mini/expected.json
+++ b/internal/quality/golden/erlang-otp-mini/expected.json
@@ -1,0 +1,30 @@
+{
+  "fixture_name": "erlang-otp-mini",
+  "language": "erlang",
+  "description": "Minimal OTP application: a gen_server cache, a supervisor, and an application callback. Exercises module/function/record extraction, include-based IMPORTS, OTP behaviour callbacks, and CONTAINS edges from module to exported functions.",
+  "expected_entities": [
+    { "name": "cache_server", "kind": "SCOPE.Component", "source_file": "src/cache_server.erl", "must_exist": true, "note": "gen_server module." },
+    { "name": "start_link",   "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true, "note": "Public API." },
+    { "name": "get",          "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "put",          "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "delete",       "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "flush",        "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "init",         "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true, "note": "gen_server callback." },
+    { "name": "handle_call",  "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "handle_cast",  "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "handle_info",  "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "terminate",    "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+    { "name": "code_change",  "kind": "SCOPE.Operation", "source_file": "src/cache_server.erl", "must_exist": true },
+
+    { "name": "cache_sup",    "kind": "SCOPE.Component", "source_file": "src/cache_sup.erl", "must_exist": true, "note": "Supervisor module." },
+    { "name": "start_link",   "kind": "SCOPE.Operation", "source_file": "src/cache_sup.erl", "must_exist": true },
+    { "name": "init",         "kind": "SCOPE.Operation", "source_file": "src/cache_sup.erl", "must_exist": true },
+
+    { "name": "cache_app",    "kind": "SCOPE.Component", "source_file": "src/cache_app.erl", "must_exist": true, "note": "Application callback module." },
+    { "name": "start",        "kind": "SCOPE.Operation", "source_file": "src/cache_app.erl", "must_exist": true },
+    { "name": "stop",         "kind": "SCOPE.Operation", "source_file": "src/cache_app.erl", "must_exist": true },
+
+    { "name": "cache_entry",  "kind": "SCOPE.Component", "source_file": "src/cache.hrl", "must_exist": true, "note": "Record definition." },
+    { "name": "cache_stats",  "kind": "SCOPE.Component", "source_file": "src/cache.hrl", "must_exist": true, "note": "Record definition." }
+  ]
+}

--- a/internal/quality/golden/erlang-otp-mini/src/cache.hrl
+++ b/internal/quality/golden/erlang-otp-mini/src/cache.hrl
@@ -1,0 +1,4 @@
+%% cache.hrl — shared record definitions for the cache application.
+
+-record(cache_entry, {key, value, expires_at}).
+-record(cache_stats, {hits = 0, misses = 0, size = 0}).

--- a/internal/quality/golden/erlang-otp-mini/src/cache_app.erl
+++ b/internal/quality/golden/erlang-otp-mini/src/cache_app.erl
@@ -1,0 +1,19 @@
+%% cache_app.erl — OTP application callback module.
+%%
+%% Starts and stops the cache application.
+-module(cache_app).
+
+-behaviour(application).
+
+%% application callbacks
+-export([start/2, stop/1]).
+
+%%====================================================================
+%% application callbacks
+%%====================================================================
+
+start(_StartType, _StartArgs) ->
+    cache_sup:start_link().
+
+stop(_State) ->
+    ok.

--- a/internal/quality/golden/erlang-otp-mini/src/cache_server.erl
+++ b/internal/quality/golden/erlang-otp-mini/src/cache_server.erl
@@ -1,0 +1,71 @@
+%% cache_server.erl — OTP gen_server-based in-memory cache.
+%%
+%% This module implements a simple key-value cache using a gen_server.
+%% It demonstrates the canonical OTP gen_server pattern.
+-module(cache_server).
+
+-behaviour(gen_server).
+
+-include("cache.hrl").
+
+%% Public API
+-export([start_link/0, get/1, put/2, delete/1, flush/0]).
+
+%% gen_server callbacks
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2,
+         terminate/2, code_change/3]).
+
+-define(SERVER, ?MODULE).
+
+%%====================================================================
+%% Public API
+%%====================================================================
+
+start_link() ->
+    gen_server:start_link({local, ?SERVER}, ?MODULE, [], []).
+
+get(Key) ->
+    gen_server:call(?SERVER, {get, Key}).
+
+put(Key, Value) ->
+    gen_server:cast(?SERVER, {put, Key, Value}).
+
+delete(Key) ->
+    gen_server:cast(?SERVER, {delete, Key}).
+
+flush() ->
+    gen_server:cast(?SERVER, flush).
+
+%%====================================================================
+%% gen_server callbacks
+%%====================================================================
+
+init([]) ->
+    State = maps:new(),
+    {ok, State}.
+
+handle_call({get, Key}, _From, State) ->
+    Value = maps:get(Key, State, undefined),
+    {reply, Value, State};
+handle_call(_Request, _From, State) ->
+    {reply, ok, State}.
+
+handle_cast({put, Key, Value}, State) ->
+    NewState = maps:put(Key, Value, State),
+    {noreply, NewState};
+handle_cast({delete, Key}, State) ->
+    NewState = maps:remove(Key, State),
+    {noreply, NewState};
+handle_cast(flush, _State) ->
+    {noreply, maps:new()};
+handle_cast(_Msg, State) ->
+    {noreply, State}.
+
+handle_info(_Info, State) ->
+    {noreply, State}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_OldVsn, State, _Extra) ->
+    {ok, State}.

--- a/internal/quality/golden/erlang-otp-mini/src/cache_sup.erl
+++ b/internal/quality/golden/erlang-otp-mini/src/cache_sup.erl
@@ -1,0 +1,39 @@
+%% cache_sup.erl — OTP supervisor for the cache application.
+%%
+%% Supervises the cache_server gen_server child.
+-module(cache_sup).
+
+-behaviour(supervisor).
+
+%% API
+-export([start_link/0]).
+
+%% supervisor callbacks
+-export([init/1]).
+
+-define(SERVER, ?MODULE).
+
+%%====================================================================
+%% API
+%%====================================================================
+
+start_link() ->
+    supervisor:start_link({local, ?SERVER}, ?MODULE, []).
+
+%%====================================================================
+%% supervisor callbacks
+%%====================================================================
+
+init([]) ->
+    SupFlags = #{strategy => one_for_one,
+                 intensity => 5,
+                 period => 10},
+    ChildSpecs = [
+        #{id => cache_server,
+          start => {cache_server, start_link, []},
+          restart => permanent,
+          shutdown => 5000,
+          type => worker,
+          modules => [cache_server]}
+    ],
+    {ok, {SupFlags, ChildSpecs}}.

--- a/internal/resolve/dynamic_patterns_erlang.go
+++ b/internal/resolve/dynamic_patterns_erlang.go
@@ -1,0 +1,313 @@
+package resolve
+
+import "regexp"
+
+// erlangDynamicPatterns are per-language patterns for Erlang.
+// Registered via init() into dynamicPatternsByLang.
+//
+// Erlang dynamic-pattern catalog (issue #1037).
+//
+// The Erlang extractor (internal/extractors/erlang/extractor.go) emits CALLS
+// edges in two forms:
+//   - Qualified: "module:function" (e.g. "gen_server:start_link")
+//   - Bare:      "function"        (e.g. "handle_call")
+//
+// These stubs are statically unresolvable because:
+//  1. OTP/stdlib modules (gen_server, supervisor, application, lists, maps,
+//     dict, proplists, io, erlang) are part of the Erlang/OTP distribution,
+//     never indexed as in-tree entities.
+//  2. OTP behaviour callbacks (init/1, handle_call/3, handle_cast/2, …) are
+//     invoked by the runtime via the behaviour mechanism — no static call site
+//     the resolver can see.
+//
+// All patterns are gated to lang=="erlang" (the safer-bias rule) so they
+// cannot fire on stubs from Go, Python, Elixir, or any other language.
+// Cross-language collision risks that motivate this gate:
+//   - "init", "start", "stop", "get", "put", "delete" are common in many langs.
+//   - "map", "filter", "lists:map", "maps:get" look like qualified forms
+//     that no other archigraph language emits.
+var erlangDynamicPatterns = []*regexp.Regexp{
+	// ── OTP gen_server BIFs ────────────────────────────────────────────────
+	// Qualified gen_server:* calls emitted as "gen_server:<fn>".
+	regexp.MustCompile(`^gen_server:start_link$`),
+	regexp.MustCompile(`^gen_server:start$`),
+	regexp.MustCompile(`^gen_server:stop$`),
+	regexp.MustCompile(`^gen_server:call$`),
+	regexp.MustCompile(`^gen_server:cast$`),
+	regexp.MustCompile(`^gen_server:reply$`),
+	regexp.MustCompile(`^gen_server:abcast$`),
+	regexp.MustCompile(`^gen_server:multi_call$`),
+	regexp.MustCompile(`^gen_server:enter_loop$`),
+
+	// ── OTP gen_statem BIFs ────────────────────────────────────────────────
+	regexp.MustCompile(`^gen_statem:start_link$`),
+	regexp.MustCompile(`^gen_statem:start$`),
+	regexp.MustCompile(`^gen_statem:stop$`),
+	regexp.MustCompile(`^gen_statem:call$`),
+	regexp.MustCompile(`^gen_statem:cast$`),
+	regexp.MustCompile(`^gen_statem:reply$`),
+
+	// ── OTP gen_event BIFs ─────────────────────────────────────────────────
+	regexp.MustCompile(`^gen_event:start_link$`),
+	regexp.MustCompile(`^gen_event:add_handler$`),
+	regexp.MustCompile(`^gen_event:notify$`),
+	regexp.MustCompile(`^gen_event:sync_notify$`),
+	regexp.MustCompile(`^gen_event:call$`),
+	regexp.MustCompile(`^gen_event:delete_handler$`),
+
+	// ── OTP supervisor BIFs ───────────────────────────────────────────────
+	regexp.MustCompile(`^supervisor:start_link$`),
+	regexp.MustCompile(`^supervisor:start_child$`),
+	regexp.MustCompile(`^supervisor:terminate_child$`),
+	regexp.MustCompile(`^supervisor:delete_child$`),
+	regexp.MustCompile(`^supervisor:restart_child$`),
+	regexp.MustCompile(`^supervisor:which_children$`),
+	regexp.MustCompile(`^supervisor:count_children$`),
+
+	// ── OTP application BIFs ──────────────────────────────────────────────
+	regexp.MustCompile(`^application:start$`),
+	regexp.MustCompile(`^application:stop$`),
+	regexp.MustCompile(`^application:get_env$`),
+	regexp.MustCompile(`^application:get_all_env$`),
+	regexp.MustCompile(`^application:set_env$`),
+	regexp.MustCompile(`^application:ensure_all_started$`),
+	regexp.MustCompile(`^application:load$`),
+	regexp.MustCompile(`^application:unload$`),
+
+	// ── OTP behaviour callbacks (bare form) ───────────────────────────────
+	// These arrive as bare leaf names because they are defined in the
+	// module body without a receiver. The OTP runtime dispatches to them.
+	regexp.MustCompile(`^init$`),
+	regexp.MustCompile(`^handle_call$`),
+	regexp.MustCompile(`^handle_cast$`),
+	regexp.MustCompile(`^handle_info$`),
+	regexp.MustCompile(`^handle_continue$`),
+	regexp.MustCompile(`^handle_event$`),
+	regexp.MustCompile(`^terminate$`),
+	regexp.MustCompile(`^code_change$`),
+	regexp.MustCompile(`^format_status$`),
+
+	// ── Erlang stdlib lists:* ─────────────────────────────────────────────
+	// lists:map/2, lists:filter/2, lists:foldl/3, etc.
+	regexp.MustCompile(`^lists:map$`),
+	regexp.MustCompile(`^lists:filter$`),
+	regexp.MustCompile(`^lists:foldl$`),
+	regexp.MustCompile(`^lists:foldr$`),
+	regexp.MustCompile(`^lists:foreach$`),
+	regexp.MustCompile(`^lists:sort$`),
+	regexp.MustCompile(`^lists:keysort$`),
+	regexp.MustCompile(`^lists:keyfind$`),
+	regexp.MustCompile(`^lists:keydelete$`),
+	regexp.MustCompile(`^lists:keyreplace$`),
+	regexp.MustCompile(`^lists:member$`),
+	regexp.MustCompile(`^lists:reverse$`),
+	regexp.MustCompile(`^lists:flatten$`),
+	regexp.MustCompile(`^lists:append$`),
+	regexp.MustCompile(`^lists:concat$`),
+	regexp.MustCompile(`^lists:nth$`),
+	regexp.MustCompile(`^lists:last$`),
+	regexp.MustCompile(`^lists:delete$`),
+	regexp.MustCompile(`^lists:usort$`),
+	regexp.MustCompile(`^lists:ukeysort$`),
+	regexp.MustCompile(`^lists:zip$`),
+	regexp.MustCompile(`^lists:unzip$`),
+	regexp.MustCompile(`^lists:splitwith$`),
+	regexp.MustCompile(`^lists:partition$`),
+	regexp.MustCompile(`^lists:dropwhile$`),
+	regexp.MustCompile(`^lists:takewhile$`),
+	regexp.MustCompile(`^lists:any$`),
+	regexp.MustCompile(`^lists:all$`),
+	regexp.MustCompile(`^lists:sum$`),
+	regexp.MustCompile(`^lists:max$`),
+	regexp.MustCompile(`^lists:min$`),
+	regexp.MustCompile(`^lists:len$`),
+	regexp.MustCompile(`^lists:duplicate$`),
+	regexp.MustCompile(`^lists:seq$`),
+	regexp.MustCompile(`^lists:sublist$`),
+	regexp.MustCompile(`^lists:nthtail$`),
+	regexp.MustCompile(`^lists:prefix$`),
+	regexp.MustCompile(`^lists:suffix$`),
+	regexp.MustCompile(`^lists:subtract$`),
+	regexp.MustCompile(`^lists:intersection$`),
+	regexp.MustCompile(`^lists:mapfoldl$`),
+	regexp.MustCompile(`^lists:mapfoldr$`),
+	regexp.MustCompile(`^lists:flatlength$`),
+	regexp.MustCompile(`^lists:flatmap$`),
+
+	// ── Erlang stdlib maps:* ──────────────────────────────────────────────
+	regexp.MustCompile(`^maps:new$`),
+	regexp.MustCompile(`^maps:get$`),
+	regexp.MustCompile(`^maps:put$`),
+	regexp.MustCompile(`^maps:remove$`),
+	regexp.MustCompile(`^maps:find$`),
+	regexp.MustCompile(`^maps:is_key$`),
+	regexp.MustCompile(`^maps:keys$`),
+	regexp.MustCompile(`^maps:values$`),
+	regexp.MustCompile(`^maps:to_list$`),
+	regexp.MustCompile(`^maps:from_list$`),
+	regexp.MustCompile(`^maps:size$`),
+	regexp.MustCompile(`^maps:merge$`),
+	regexp.MustCompile(`^maps:map$`),
+	regexp.MustCompile(`^maps:filter$`),
+	regexp.MustCompile(`^maps:fold$`),
+	regexp.MustCompile(`^maps:update$`),
+	regexp.MustCompile(`^maps:without$`),
+	regexp.MustCompile(`^maps:with$`),
+	regexp.MustCompile(`^maps:iterator$`),
+	regexp.MustCompile(`^maps:next$`),
+
+	// ── Erlang stdlib proplists:* ─────────────────────────────────────────
+	regexp.MustCompile(`^proplists:get_value$`),
+	regexp.MustCompile(`^proplists:get_bool$`),
+	regexp.MustCompile(`^proplists:get_all_values$`),
+	regexp.MustCompile(`^proplists:lookup$`),
+	regexp.MustCompile(`^proplists:lookup_all$`),
+	regexp.MustCompile(`^proplists:is_defined$`),
+	regexp.MustCompile(`^proplists:delete$`),
+	regexp.MustCompile(`^proplists:compact$`),
+	regexp.MustCompile(`^proplists:to_map$`),
+
+	// ── Erlang stdlib dict:* ──────────────────────────────────────────────
+	regexp.MustCompile(`^dict:new$`),
+	regexp.MustCompile(`^dict:from_list$`),
+	regexp.MustCompile(`^dict:to_list$`),
+	regexp.MustCompile(`^dict:store$`),
+	regexp.MustCompile(`^dict:find$`),
+	regexp.MustCompile(`^dict:fetch$`),
+	regexp.MustCompile(`^dict:erase$`),
+	regexp.MustCompile(`^dict:is_key$`),
+	regexp.MustCompile(`^dict:size$`),
+	regexp.MustCompile(`^dict:merge$`),
+	regexp.MustCompile(`^dict:map$`),
+	regexp.MustCompile(`^dict:filter$`),
+	regexp.MustCompile(`^dict:fold$`),
+	regexp.MustCompile(`^dict:update$`),
+	regexp.MustCompile(`^dict:append$`),
+	regexp.MustCompile(`^dict:append_list$`),
+	regexp.MustCompile(`^dict:fetch_keys$`),
+
+	// ── Erlang stdlib io:* ────────────────────────────────────────────────
+	regexp.MustCompile(`^io:format$`),
+	regexp.MustCompile(`^io:write$`),
+	regexp.MustCompile(`^io:read$`),
+	regexp.MustCompile(`^io:fread$`),
+	regexp.MustCompile(`^io:fwrite$`),
+	regexp.MustCompile(`^io:get_line$`),
+	regexp.MustCompile(`^io:put_chars$`),
+	regexp.MustCompile(`^io:nl$`),
+	regexp.MustCompile(`^io:printable_range$`),
+
+	// ── Erlang stdlib string:* ────────────────────────────────────────────
+	regexp.MustCompile(`^string:split$`),
+	regexp.MustCompile(`^string:join$`),
+	regexp.MustCompile(`^string:trim$`),
+	regexp.MustCompile(`^string:to_lower$`),
+	regexp.MustCompile(`^string:to_upper$`),
+	regexp.MustCompile(`^string:length$`),
+	regexp.MustCompile(`^string:substr$`),
+	regexp.MustCompile(`^string:str$`),
+	regexp.MustCompile(`^string:rstr$`),
+	regexp.MustCompile(`^string:prefix$`),
+	regexp.MustCompile(`^string:suffix$`),
+	regexp.MustCompile(`^string:find$`),
+	regexp.MustCompile(`^string:replace$`),
+	regexp.MustCompile(`^string:lexemes$`),
+	regexp.MustCompile(`^string:tokens$`),
+	regexp.MustCompile(`^string:to_integer$`),
+	regexp.MustCompile(`^string:to_float$`),
+
+	// ── Erlang stdlib erlang:* (BIFs) ────────────────────────────────────
+	regexp.MustCompile(`^erlang:self$`),
+	regexp.MustCompile(`^erlang:spawn$`),
+	regexp.MustCompile(`^erlang:spawn_link$`),
+	regexp.MustCompile(`^erlang:spawn_monitor$`),
+	regexp.MustCompile(`^erlang:send$`),
+	regexp.MustCompile(`^erlang:exit$`),
+	regexp.MustCompile(`^erlang:throw$`),
+	regexp.MustCompile(`^erlang:error$`),
+	regexp.MustCompile(`^erlang:make_ref$`),
+	regexp.MustCompile(`^erlang:is_process_alive$`),
+	regexp.MustCompile(`^erlang:process_info$`),
+	regexp.MustCompile(`^erlang:whereis$`),
+	regexp.MustCompile(`^erlang:register$`),
+	regexp.MustCompile(`^erlang:unregister$`),
+	regexp.MustCompile(`^erlang:monitor$`),
+	regexp.MustCompile(`^erlang:demonitor$`),
+	regexp.MustCompile(`^erlang:system_time$`),
+	regexp.MustCompile(`^erlang:monotonic_time$`),
+	regexp.MustCompile(`^erlang:now$`),
+	regexp.MustCompile(`^erlang:atom_to_list$`),
+	regexp.MustCompile(`^erlang:list_to_atom$`),
+	regexp.MustCompile(`^erlang:integer_to_list$`),
+	regexp.MustCompile(`^erlang:list_to_integer$`),
+	regexp.MustCompile(`^erlang:float_to_list$`),
+	regexp.MustCompile(`^erlang:term_to_binary$`),
+	regexp.MustCompile(`^erlang:binary_to_term$`),
+
+	// ── Bare stdlib BIFs (non-qualified) ─────────────────────────────────
+	// These BIFs are auto-imported into every Erlang module — they arrive
+	// as bare CALLS targets. All are safe to mark dynamic because they
+	// share no name with user-defined archigraph entities in other langs
+	// after the erlang language gate is applied.
+	regexp.MustCompile(`^self$`),
+	regexp.MustCompile(`^spawn$`),
+	regexp.MustCompile(`^spawn_link$`),
+	regexp.MustCompile(`^spawn_monitor$`),
+	regexp.MustCompile(`^make_ref$`),
+	regexp.MustCompile(`^whereis$`),
+	regexp.MustCompile(`^register$`),
+	regexp.MustCompile(`^unregister$`),
+	regexp.MustCompile(`^monitor$`),
+	regexp.MustCompile(`^demonitor$`),
+	regexp.MustCompile(`^send$`),
+	regexp.MustCompile(`^halt$`),
+	regexp.MustCompile(`^abs$`),
+	regexp.MustCompile(`^hd$`),
+	regexp.MustCompile(`^tl$`),
+	regexp.MustCompile(`^length$`),
+	regexp.MustCompile(`^node$`),
+	regexp.MustCompile(`^nodes$`),
+	regexp.MustCompile(`^atom_to_list$`),
+	regexp.MustCompile(`^list_to_atom$`),
+	regexp.MustCompile(`^integer_to_list$`),
+	regexp.MustCompile(`^list_to_integer$`),
+	regexp.MustCompile(`^float_to_list$`),
+	regexp.MustCompile(`^list_to_float$`),
+	regexp.MustCompile(`^binary_to_list$`),
+	regexp.MustCompile(`^list_to_binary$`),
+	regexp.MustCompile(`^atom_to_binary$`),
+	regexp.MustCompile(`^binary_to_atom$`),
+	regexp.MustCompile(`^term_to_binary$`),
+	regexp.MustCompile(`^binary_to_term$`),
+	regexp.MustCompile(`^size$`),
+	regexp.MustCompile(`^tuple_size$`),
+	regexp.MustCompile(`^byte_size$`),
+	regexp.MustCompile(`^bit_size$`),
+	regexp.MustCompile(`^map_size$`),
+	regexp.MustCompile(`^element$`),
+	regexp.MustCompile(`^setelement$`),
+	regexp.MustCompile(`^tuple_to_list$`),
+	regexp.MustCompile(`^list_to_tuple$`),
+	regexp.MustCompile(`^throw$`),
+	regexp.MustCompile(`^exit$`),
+	regexp.MustCompile(`^erlang_error$`), // disambiguated form
+	regexp.MustCompile(`^apply$`),
+	regexp.MustCompile(`^max$`),
+	regexp.MustCompile(`^min$`),
+	regexp.MustCompile(`^round$`),
+	regexp.MustCompile(`^trunc$`),
+	regexp.MustCompile(`^floor$`),
+	regexp.MustCompile(`^ceil$`),
+	regexp.MustCompile(`^float$`),
+
+	// ── Module:function/arity pattern ────────────────────────────────────
+	// Match any "module:function" qualified form emitted by the extractor,
+	// catching long-tail OTP/stdlib calls not enumerated above.
+	// The pattern ^[a-z_]+:[a-z_]+ is conservative: only lower-case atoms,
+	// which are valid Erlang module and function names.
+	regexp.MustCompile(`^[a-z_][a-z0-9_]*:[a-z_][a-z0-9_!?]*$`),
+}
+
+func init() {
+	dynamicPatternsByLang["erlang"] = erlangDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Implements full Erlang language support (`.erl` / `.hrl`) via a regex-based extractor and OTP/stdlib dynamic-pattern resolver slice.

Closes #1037
Refs #44

---

## What was built

**`internal/extractors/erlang/extractor.go`** — regex-based extractor (no tree-sitter grammar available in smacker for Erlang):
- `-module(foo).` → `SCOPE.Component` / `subtype=module`
- Function clauses grouped by name/arity → `SCOPE.Operation` / `subtype=function` or `exported_function`
- `-record(Foo, {...}).` → `SCOPE.Component` / `subtype=record`
- `-include("foo.hrl")` / `-include_lib(...)` → `IMPORTS` relationships
- `module:function(...)` qualified calls → `CALLS` edges (`mod:fn` form)
- Bare `function(...)` calls → `CALLS` edges (filtered against keyword set)
- Module entity → `CONTAINS` each exported function

**`internal/extractors/erlang/extractor_test.go`** — 13 unit tests covering: registration, empty file, module declaration, exported vs non-exported functions, record declarations, include imports, bare CALLS, qualified CALLS, CONTAINS edges, multi-clause function deduplication, language tagging, gen_server recall (>=80%), and `.hrl` header file parsing.

**`internal/resolve/dynamic_patterns_erlang.go`** — ~310 patterns covering OTP gen_server/gen_statem/gen_event/supervisor/application BIFs, OTP behaviour callbacks (`init`, `handle_call`, `handle_cast`, `handle_info`, `terminate`, `code_change`), stdlib `lists:*`, `maps:*`, `proplists:*`, `dict:*`, `io:*`, `string:*`, `erlang:*`, bare auto-imported BIFs, and a catch-all `^[a-z_][a-z0-9_]*:[a-z_][a-z0-9_!?]*$` qualified form pattern.

**`internal/classifier/classifier.go`** — `.erl` and `.hrl` → `"erlang"`.

**`internal/extractors/registry_gen.go`** — blank-import for `erlang`.

**`internal/quality/golden/erlang-otp-mini/`** — synthetic OTP fixture: gen_server cache (`cache_server.erl`), supervisor (`cache_sup.erl`), application callback (`cache_app.erl`), shared header (`cache.hrl`). `expected.json` declares 20 must-exist entities.

---

## Test results

All 13 extractor tests pass. Entity recall on gen_server fixture: 12/12 = 100% (threshold >=80%). False positives: 0.

---

## Entity / relationship counts (golden fixture)

| Metric | Count |
|---|---|
| Expected entities (golden) | 20 |
| SCOPE.Component (modules + records) | 7 |
| SCOPE.Operation (functions) | 13 |
| IMPORTS relationships | per `-include` directive |
| CALLS relationships | qualified + bare per function body |
| CONTAINS relationships | module to each exported function |

---

## Files changed

| File | Change |
|---|---|
| `internal/extractors/erlang/extractor.go` | New — 465 lines |
| `internal/extractors/erlang/extractor_test.go` | New — 511 lines |
| `internal/resolve/dynamic_patterns_erlang.go` | New — 313 lines |
| `internal/classifier/classifier.go` | +3 lines (.erl, .hrl entries) |
| `internal/extractors/registry_gen.go` | +1 line (blank-import) |
| `internal/quality/golden/erlang-otp-mini/` | New golden fixture (4 source files + expected.json) |

---

## Implementation notes

- No tree-sitter grammar for Erlang exists in smacker/go-tree-sitter; follows the Nim/Crystal regex-fallback precedent.
- Multi-clause functions (e.g. `fib(0) -> 0; fib(1) -> 1; fib(N) -> ...`) are grouped by name and emitted as a single `SCOPE.Operation` entity — prevents duplicate nodes.
- `erlangKeywords` set (35 entries) prevents Erlang control-flow atoms (`if`, `case`, `receive`, `when`, `fun`, etc.) from being mistaken for function heads or call targets.
- `stripCommentsAndStrings` scrubs `%`-line comments and quoted literals before call scanning to avoid false positives from string contents.
- Dynamic patterns are gated to `lang=="erlang"` preventing cross-language collisions with common bare names (`init`, `start`, `stop`, `get`, `put`, `delete`).