### PR TITLE
[#1035] Feat: Elm language extractor + resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -488,6 +488,8 @@ var extensionLanguageMap = map[string]string{
 	".gql":     "graphql",
 	// Prisma
 	".prisma": "prisma",
+	// Elm
+	".elm": "elm",
 	// Haskell
 	".hs":  "haskell",
 	".lhs": "haskell",

--- a/internal/extractors/elm/extractor.go
+++ b/internal/extractors/elm/extractor.go
@@ -1,0 +1,617 @@
+// Package elm implements a regex-based extractor for Elm source files.
+//
+// Extracted entities:
+//   - Module declarations (`module Main exposing (...)`) → SCOPE.Component (subtype="module")
+//   - Function/value declarations (top-level with `name : Type` annotation or bare `name args = body`)
+//     → SCOPE.Operation (subtype="function")
+//   - Type alias declarations (`type alias Model = {...}`) → SCOPE.Component (subtype="typealias")
+//   - Custom type declarations (`type Msg = ... | ...`) → SCOPE.Component (subtype="type")
+//   - Import statements (`import Html.Attributes as Attr`) → IMPORTS edges
+//   - CALLS edges from function bodies (deduped)
+//   - Module CONTAINS top-level declarations
+//
+// Elm is a whitespace-sensitive language. Top-level declarations start at column 0.
+// This extractor uses regular expressions with that layout convention for entity discovery.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package elm
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("elm", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Elm.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "elm" }
+
+// -----------------------------------------------------------------------
+// Compiled regex patterns
+// -----------------------------------------------------------------------
+
+var (
+	// moduleRE matches: module Main exposing (..)
+	//                   module Html.Attributes exposing (class, id)
+	moduleRE = regexp.MustCompile(
+		`(?m)^module\s+((?:[A-Z][a-zA-Z0-9_]*\.)*[A-Z][a-zA-Z0-9_]*)\s+exposing\s*\(`,
+	)
+
+	// typeAnnotationRE matches top-level type annotations:
+	//   functionName : Type -> Type
+	// Elm names start with lowercase; type annotations use a single colon.
+	typeAnnotationRE = regexp.MustCompile(
+		`(?m)^([a-z_][a-zA-Z0-9_]*)\s*:\s*(.+)`,
+	)
+
+	// funcDefRE matches a top-level function definition at column 0.
+	// name args = body (the name must start with lowercase).
+	funcDefRE = regexp.MustCompile(
+		`(?m)^([a-z_][a-zA-Z0-9_]*)\s+(?:[^\n=]*=|=)`,
+	)
+
+	// typeAliasRE matches: type alias Model = { ... }
+	//                      type alias Flags = { name : String }
+	typeAliasRE = regexp.MustCompile(
+		`(?m)^type\s+alias\s+([A-Z][a-zA-Z0-9_]*)\s*=`,
+	)
+
+	// customTypeRE matches: type Msg = Increment | Decrement | ...
+	// We use a negative lookahead simulation: skip if the capture starts with "alias ".
+	customTypeRE = regexp.MustCompile(
+		`(?m)^type\s+([A-Z][a-zA-Z0-9_]*(?:\s+[a-zA-Z][a-zA-Z0-9_]*)*)\s*=`,
+	)
+
+	// importRE matches:
+	//   import Html
+	//   import Html.Attributes as Attr
+	//   import Html.Attributes exposing (class, id)
+	//   import Browser.Navigation as Nav
+	importRE = regexp.MustCompile(
+		`(?m)^import\s+((?:[A-Z][a-zA-Z0-9_]*\.)*[A-Z][a-zA-Z0-9_]*)(?:\s+(?:as\s+[A-Z][a-zA-Z0-9_]*|exposing\s*\([^)]*\)))*`,
+	)
+
+	// callRE matches lowercase identifiers used as potential function calls.
+	callRE = regexp.MustCompile(
+		`\b([a-z_][a-zA-Z0-9_]*)\b`,
+	)
+
+	// qualifiedCallRE matches Module.function call patterns (e.g. List.map, Html.div).
+	qualifiedCallRE = regexp.MustCompile(
+		`\b([A-Z][a-zA-Z0-9_]*(?:\.[A-Z][a-zA-Z0-9_]*)*\.[a-z_][a-zA-Z0-9_]*)\b`,
+	)
+)
+
+// elmKeywords is the set of tokens to exclude from CALLS edges.
+var elmKeywords = map[string]bool{
+	// Language keywords
+	"module": true, "exposing": true, "import": true, "as": true,
+	"type": true, "alias": true,
+	"if": true, "then": true, "else": true,
+	"case": true, "of": true,
+	"let": true, "in": true,
+	"port": true, "effect": true, "where": true,
+	// Common short names that are Elm syntax but emitted as identifiers
+	"main": false, // main is a valid entity — don't skip it
+	// Elm literals / operators as identifiers
+	"True": true, "False": true,
+	// Common one-letter variable names
+	"a": true, "b": true, "c": true, "d": true, "e": true,
+	"f": true, "g": true, "h": true, "i": true, "j": true,
+	"k": true, "m": true, "n": true, "p": true, "r": true,
+	"s": true, "t": true, "v": true, "x": true, "y": true, "z": true,
+}
+
+// Extract processes the Elm source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractElm(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "elm")
+	return out, nil
+}
+
+func extractElm(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// Emit file-level entity.
+	entities = append(entities, extractor.FileEntity(extractor.FileInput{
+		Path:     filePath,
+		Language: "elm",
+	}))
+
+	imports := collectImports(src)
+	importEntities := buildImportEntities(filePath, imports)
+	entities = append(entities, importEntities...)
+
+	// 1. Module declaration.
+	var moduleName string
+	if m := moduleRE.FindStringSubmatch(src); m != nil {
+		moduleName = m[1]
+		startLine := strings.Count(src[:strings.Index(src, m[0])], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       moduleName,
+			Kind:       "SCOPE.Component",
+			Subtype:    "module",
+			SourceFile: filePath,
+			Language:   "elm",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "module " + moduleName + " exposing (..)",
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 2. type alias declarations (must be checked before customTypeRE since
+	//    customTypeRE would otherwise match "type alias Foo").
+	typeAliasSeen := make(map[string]bool)
+	for _, m := range typeAliasRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := strings.TrimSpace(src[m[2]:m[3]])
+		if typeAliasSeen[name] {
+			continue
+		}
+		typeAliasSeen[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "typealias",
+			SourceFile: filePath,
+			Language:   "elm",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "type alias " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 3. Custom type declarations (skip "type alias ...").
+	customTypeSeen := make(map[string]bool)
+	for _, m := range customTypeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		rawName := strings.TrimSpace(src[m[2]:m[3]])
+		// Skip "alias" — handled above.
+		if strings.HasPrefix(rawName, "alias") {
+			continue
+		}
+		// Extract just the type name (strip type params).
+		name := extractTypeName(rawName)
+		if name == "" || name == "alias" {
+			continue
+		}
+		if customTypeSeen[name] {
+			continue
+		}
+		customTypeSeen[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "type",
+			SourceFile: filePath,
+			Language:   "elm",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "type " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 4. Collect all top-level function names (from type annotations + definitions).
+	funcNames := collectFunctions(src)
+
+	// 5. Emit SCOPE.Operation entities for each function.
+	for _, fn := range funcNames {
+		sigPos := findFunctionPos(src, fn)
+		startLine := 1
+		if sigPos >= 0 {
+			startLine = strings.Count(src[:sigPos], "\n") + 1
+		}
+		body := extractFunctionBody(src, fn)
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, fn)
+
+		sig := fn
+		if ann := findTypeAnnotation(src, fn); ann != "" {
+			sig = fn + " : " + ann
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:          fn,
+			Kind:          "SCOPE.Operation",
+			Subtype:       "function",
+			SourceFile:    filePath,
+			Language:      "elm",
+			StartLine:     startLine,
+			EndLine:       endLine,
+			Signature:     sig,
+			Properties:    map[string]string{"imports": strings.Join(imports, ",")},
+			Relationships: calls,
+		})
+	}
+
+	// 6. Add CONTAINS edges from module to all top-level declarations.
+	if moduleName != "" {
+		var containsRels []types.RelationshipRecord
+		for _, fn := range funcNames {
+			ref := extractor.BuildOperationStructuralRef("elm", filePath, fn)
+			containsRels = append(containsRels, types.RelationshipRecord{
+				ToID: ref,
+				Kind: "CONTAINS",
+			})
+		}
+		for i := range entities {
+			if entities[i].Name == moduleName && entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "module" {
+				entities[i].Relationships = append(entities[i].Relationships, containsRels...)
+				break
+			}
+		}
+	}
+
+	return entities
+}
+
+// -----------------------------------------------------------------------
+// Helper: import collection
+// -----------------------------------------------------------------------
+
+func collectImports(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+	for _, m := range importRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		mod := strings.TrimSpace(m[1])
+		if mod == "" || seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		imports = append(imports, mod)
+	}
+	return imports
+}
+
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		displayName := importDisplayName(mod)
+		out = append(out, types.EntityRecord{
+			Name:       displayName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "elm",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+func importDisplayName(mod string) string {
+	if dot := strings.LastIndexByte(mod, '.'); dot >= 0 {
+		return mod[dot+1:]
+	}
+	return mod
+}
+
+// -----------------------------------------------------------------------
+// Helper: function discovery
+// -----------------------------------------------------------------------
+
+// collectFunctions returns deduplicated top-level function names.
+func collectFunctions(src string) []string {
+	seen := make(map[string]bool)
+	var funcs []string
+
+	// First pass: type annotations (most reliable for Elm top-level functions).
+	for _, m := range typeAnnotationRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		name := strings.TrimSpace(m[1])
+		if name == "" || seen[name] || elmKeywords[name] {
+			continue
+		}
+		seen[name] = true
+		funcs = append(funcs, name)
+	}
+
+	// Second pass: function definitions at column 0 (catches definitions without annotations).
+	for _, m := range funcDefRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		name := m[1]
+		if name == "" || seen[name] || elmKeywords[name] {
+			continue
+		}
+		// Skip names that start with uppercase (those are type constructors).
+		if len(name) > 0 && name[0] >= 'A' && name[0] <= 'Z' {
+			continue
+		}
+		seen[name] = true
+		funcs = append(funcs, name)
+	}
+
+	return funcs
+}
+
+// findFunctionPos returns the byte offset of the function's type annotation
+// or first definition in src.
+func findFunctionPos(src, name string) int {
+	// Try type annotation first.
+	annPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s*:(?:[^:])`)
+	if loc := annPattern.FindStringIndex(src); loc != nil {
+		return loc[0]
+	}
+	// Fall back to first definition.
+	defPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s+`)
+	if loc := defPattern.FindStringIndex(src); loc != nil {
+		return loc[0]
+	}
+	return -1
+}
+
+// findTypeAnnotation returns the type annotation string for a function name.
+func findTypeAnnotation(src, name string) string {
+	annPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `\s*:\s*(.+)`)
+	if m := annPattern.FindStringSubmatch(src); m != nil {
+		return strings.TrimSpace(m[1])
+	}
+	return ""
+}
+
+// extractFunctionBody returns the body lines for a function.
+// In Elm, top-level function definitions start at column 0; continuation
+// lines are indented with at least one space or tab.
+func extractFunctionBody(src, name string) string {
+	// Match definition lines (not type annotations: avoid "name :" without "=").
+	defPattern := regexp.MustCompile(`(?m)^` + regexp.QuoteMeta(name) + `(?:\s+[^\n]*)?=`)
+	locs := defPattern.FindAllStringIndex(src, -1)
+	if len(locs) == 0 {
+		return ""
+	}
+	var bodies []string
+	for _, loc := range locs {
+		// Skip if line looks like a type annotation (contains " : " without "=").
+		lineEnd := strings.Index(src[loc[0]:], "\n")
+		var lineText string
+		if lineEnd >= 0 {
+			lineText = src[loc[0] : loc[0]+lineEnd]
+		} else {
+			lineText = src[loc[0]:]
+		}
+		// Skip if the only colon is part of type annotation pattern (no equals sign before it)
+		if strings.Contains(lineText, " : ") && !strings.Contains(lineText, "=") {
+			continue
+		}
+		bodies = append(bodies, extractIndentBody(src, loc[1]))
+	}
+	return strings.Join(bodies, "\n")
+}
+
+// extractIndentBody collects all lines following afterPos that are indented
+// (Elm layout convention: top-level starts at column 0).
+func extractIndentBody(src string, afterPos int) string {
+	rest := src[afterPos:]
+	lines := strings.Split(rest, "\n")
+	var body []string
+	for i, line := range lines {
+		if i == 0 {
+			body = append(body, line)
+			continue
+		}
+		if line == "" || strings.TrimSpace(line) == "" {
+			body = append(body, line)
+			continue
+		}
+		// Continuation lines in Elm start with at least one space/tab.
+		if line[0] == ' ' || line[0] == '\t' {
+			body = append(body, line)
+		} else {
+			break
+		}
+	}
+	return strings.Join(body, "\n")
+}
+
+// -----------------------------------------------------------------------
+// Helper: type name extraction
+// -----------------------------------------------------------------------
+
+// extractTypeName extracts just the type constructor name from a raw name
+// string that may include type variables.
+func extractTypeName(raw string) string {
+	raw = strings.TrimSpace(raw)
+	parts := strings.Fields(raw)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
+// -----------------------------------------------------------------------
+// Helper: CALLS edge collection
+// -----------------------------------------------------------------------
+
+// collectCalls extracts CALLS relationships from a function body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+	seen := make(map[string]bool)
+	out := make([]types.RelationshipRecord, 0)
+
+	// Qualified calls: Module.function (e.g. List.map, Html.div)
+	for _, m := range qualifiedCallRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		target := m[1]
+		if target == "" || target == callerName || seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	// Unqualified calls: bare function names
+	for _, m := range callRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		target := m[1]
+		if target == "" || target == callerName {
+			continue
+		}
+		if elmKeywords[target] {
+			continue
+		}
+		if len(target) <= 1 {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	return out
+}
+
+// stripStringsAndComments replaces string literals and -- line comments
+// with spaces to avoid false call detection.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := false
+	inChar := false
+	depth := 0 // for {- block comments -}
+
+	for i < len(src) {
+		ch := src[i]
+
+		if inStr {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == '"' {
+				inStr = false
+			}
+			i++
+			continue
+		}
+
+		if inChar {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == '\'' {
+				inChar = false
+			}
+			i++
+			continue
+		}
+
+		if depth > 0 {
+			// Inside a block comment {- ... -}
+			if ch == '{' && i+1 < len(src) && src[i+1] == '-' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				depth++
+				continue
+			}
+			if ch == '-' && i+1 < len(src) && src[i+1] == '}' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				depth--
+				continue
+			}
+			out[i] = ' '
+			i++
+			continue
+		}
+
+		// Line comment: -- to end of line
+		if ch == '-' && i+1 < len(src) && src[i+1] == '-' {
+			for i < len(src) && src[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// Block comment: {- ... -} (nested, as Elm supports)
+		if ch == '{' && i+1 < len(src) && src[i+1] == '-' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			depth++
+			continue
+		}
+
+		switch ch {
+		case '"':
+			inStr = true
+			out[i] = ' '
+		case '\'':
+			inChar = true
+			out[i] = ' '
+		default:
+			out[i] = ch
+		}
+		i++
+	}
+	return string(out)
+}

--- a/internal/extractors/elm/extractor_test.go
+++ b/internal/extractors/elm/extractor_test.go
@@ -1,0 +1,561 @@
+package elm_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/elm"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runElm runs the extractor on raw source and returns entity records.
+func runElm(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("elm")
+	if !ok {
+		t.Fatal("elm extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "elm",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func elmFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func elmHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestElm_Registered verifies the extractor is in the registry.
+func TestElm_Registered(t *testing.T) {
+	_, ok := extractor.Get("elm")
+	if !ok {
+		t.Fatal("elm extractor not registered")
+	}
+}
+
+// TestElm_EmptyInput returns zero entities for empty content.
+func TestElm_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("elm")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.elm",
+		Content:  []byte{},
+		Language: "elm",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestElm_ModuleDeclaration — module declaration extracted as SCOPE.Component(module).
+func TestElm_ModuleDeclaration(t *testing.T) {
+	src := `module Main exposing (..)
+
+main : Program () Model Msg
+main =
+    Browser.sandbox { init = init, update = update, view = view }
+`
+	ents := runElm(t, src, "Main.elm")
+
+	mod := elmFind(ents, "Main", "SCOPE.Component")
+	if mod == nil {
+		t.Fatal("expected Main module component")
+	}
+	if mod.Subtype != "module" {
+		t.Errorf("expected subtype=module, got %q", mod.Subtype)
+	}
+}
+
+// TestElm_FunctionDiscovery — top-level functions extracted as SCOPE.Operation.
+func TestElm_FunctionDiscovery(t *testing.T) {
+	src := `module Counter exposing (..)
+
+type alias Model =
+    { count : Int }
+
+init : Model
+init =
+    { count = 0 }
+
+increment : Model -> Model
+increment model =
+    { model | count = model.count + 1 }
+
+decrement : Model -> Model
+decrement model =
+    { model | count = model.count - 1 }
+`
+	ents := runElm(t, src, "Counter.elm")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "elm" {
+				t.Errorf("entity %q: expected Language=elm, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"init", "increment", "decrement"} {
+		if !ops[want] {
+			t.Errorf("expected function %q to be extracted, got ops=%v", want, ops)
+		}
+	}
+}
+
+// TestElm_TypeAliasDiscovery — type alias declarations extracted as SCOPE.Component(typealias).
+func TestElm_TypeAliasDiscovery(t *testing.T) {
+	src := `module Model exposing (..)
+
+type alias Model =
+    { count : Int
+    , name : String
+    }
+
+type alias Flags =
+    { initialCount : Int }
+`
+	ents := runElm(t, src, "Model.elm")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	checks := map[string]string{
+		"Model": "typealias",
+		"Flags": "typealias",
+	}
+	for name, wantSubtype := range checks {
+		got, ok := comps[name]
+		if !ok {
+			t.Errorf("expected type alias %q to be extracted; got comps=%v", name, comps)
+		} else if got != wantSubtype {
+			t.Errorf("type %q: expected subtype=%q, got %q", name, wantSubtype, got)
+		}
+	}
+}
+
+// TestElm_CustomTypeDiscovery — custom type declarations extracted as SCOPE.Component(type).
+func TestElm_CustomTypeDiscovery(t *testing.T) {
+	src := `module Msg exposing (..)
+
+type Msg
+    = Increment
+    | Decrement
+    | Reset
+
+type Status
+    = Loading
+    | Loaded String
+    | Failed String
+`
+	ents := runElm(t, src, "Msg.elm")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	for _, name := range []string{"Msg", "Status"} {
+		if subtype, ok := comps[name]; !ok {
+			t.Errorf("expected custom type %q to be extracted; comps=%v", name, comps)
+		} else if subtype != "type" {
+			t.Errorf("type %q: expected subtype=type, got %q", name, subtype)
+		}
+	}
+}
+
+// TestElm_TypeAliasNotCustomType — "type alias" is NOT extracted as custom type.
+func TestElm_TypeAliasNotCustomType(t *testing.T) {
+	src := `module Foo exposing (..)
+
+type alias Model = { x : Int }
+
+type Msg = Click | Hover
+`
+	ents := runElm(t, src, "Foo.elm")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	if subtype, ok := comps["Model"]; !ok {
+		t.Error("expected Model to be extracted as typealias")
+	} else if subtype != "typealias" {
+		t.Errorf("Model: expected subtype=typealias, got %q", subtype)
+	}
+
+	if subtype, ok := comps["Msg"]; !ok {
+		t.Error("expected Msg to be extracted as type")
+	} else if subtype != "type" {
+		t.Errorf("Msg: expected subtype=type, got %q", subtype)
+	}
+}
+
+// TestElm_ImportEdges — import statements emit IMPORTS edges.
+func TestElm_ImportEdges(t *testing.T) {
+	src := `module App exposing (..)
+
+import Browser
+import Browser.Navigation as Nav
+import Html exposing (Html, div, text, button)
+import Html.Attributes exposing (class, style)
+import Html.Events exposing (onClick)
+
+main : Program () Model Msg
+main =
+    Browser.sandbox { init = init, update = update, view = view }
+`
+	ents := runElm(t, src, "App.elm")
+
+	wantImports := map[string]bool{
+		"Browser":            false,
+		"Browser.Navigation": false,
+		"Html":               false,
+		"Html.Attributes":    false,
+		"Html.Events":        false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "App.elm" {
+						t.Errorf("IMPORTS %q: expected FromID=App.elm, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestElm_CallsEdges — function invocations emit CALLS edges.
+func TestElm_CallsEdges(t *testing.T) {
+	src := `module App exposing (..)
+
+import List
+
+helper : Int -> Int
+helper x =
+    x * 2
+
+process : List Int -> List Int
+process xs =
+    List.map helper (List.filter isEven xs)
+
+isEven : Int -> Bool
+isEven n =
+    modBy 2 n == 0
+`
+	ents := runElm(t, src, "App.elm")
+
+	if !elmHasRel(ents, "process", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS process→helper")
+	}
+}
+
+// TestElm_CallsDeduped — duplicate call targets are emitted once.
+func TestElm_CallsDeduped(t *testing.T) {
+	src := `module Dedup exposing (..)
+
+worker : Int -> Int
+worker x =
+    x + 1
+
+runner : Int
+runner =
+    worker (worker (worker 0))
+`
+	ents := runElm(t, src, "Dedup.elm")
+	count := 0
+	for _, e := range ents {
+		if e.Name == "runner" && e.Kind == "SCOPE.Operation" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "worker" {
+					count++
+				}
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 CALLS runner→worker (deduped), got %d", count)
+	}
+}
+
+// TestElm_LanguageTagged — all relationships carry language=elm.
+func TestElm_LanguageTagged(t *testing.T) {
+	src := `module Tagged exposing (..)
+
+import Html
+
+type alias Model = { x : Int }
+
+view : Model -> Html.Html msg
+view model =
+    Html.text (String.fromInt model.x)
+`
+	ents := runElm(t, src, "Tagged.elm")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "elm" {
+				t.Errorf("rel %s→%s missing language=elm (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestElm_ModuleContainsEdges — module entity has CONTAINS edges for top-level functions.
+func TestElm_ModuleContainsEdges(t *testing.T) {
+	src := `module Counter exposing (..)
+
+type alias Model = { count : Int }
+
+init : Model
+init = { count = 0 }
+
+update : Msg -> Model -> Model
+update msg model =
+    case msg of
+        Increment -> { model | count = model.count + 1 }
+        Decrement -> { model | count = model.count - 1 }
+`
+	ents := runElm(t, src, "Counter.elm")
+
+	var mod *types.EntityRecord
+	for i := range ents {
+		if ents[i].Name == "Counter" && ents[i].Kind == "SCOPE.Component" && ents[i].Subtype == "module" {
+			mod = &ents[i]
+			break
+		}
+	}
+	if mod == nil {
+		t.Fatal("expected Counter module component")
+	}
+
+	containsTargets := make(map[string]bool)
+	for _, r := range mod.Relationships {
+		if r.Kind == "CONTAINS" {
+			containsTargets[r.ToID] = true
+		}
+	}
+
+	if len(containsTargets) == 0 {
+		t.Error("expected CONTAINS edges from module Counter, got none")
+	}
+}
+
+// TestElm_TEAFixture — Elm The Architecture (TEA) pattern fixture for recall.
+// This is the synthetic fixture required by the acceptance criteria.
+func TestElm_TEAFixture(t *testing.T) {
+	src := `module Main exposing (..)
+
+import Browser
+import Html exposing (Html, button, div, text)
+import Html.Attributes exposing (class, style)
+import Html.Events exposing (onClick)
+import Json.Decode as Decode
+import Json.Encode as Encode
+
+-- MODEL
+
+type alias Model =
+    { count : Int
+    , name : String
+    , items : List String
+    }
+
+type alias Flags =
+    { initialCount : Int }
+
+-- MSG
+
+type Msg
+    = Increment
+    | Decrement
+    | Reset
+    | SetName String
+    | AddItem String
+    | RemoveItem Int
+
+-- INIT
+
+init : Flags -> ( Model, Cmd Msg )
+init flags =
+    ( { count = flags.initialCount
+      , name = "Counter"
+      , items = []
+      }
+    , Cmd.none
+    )
+
+-- UPDATE
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        Increment ->
+            ( { model | count = model.count + 1 }, Cmd.none )
+
+        Decrement ->
+            ( { model | count = model.count - 1 }, Cmd.none )
+
+        Reset ->
+            ( { model | count = 0 }, Cmd.none )
+
+        SetName name ->
+            ( { model | name = name }, Cmd.none )
+
+        AddItem item ->
+            ( { model | items = item :: model.items }, Cmd.none )
+
+        RemoveItem _ ->
+            ( model, Cmd.none )
+
+-- VIEW
+
+view : Model -> Html Msg
+view model =
+    div [ class "container" ]
+        [ viewHeader model.name
+        , viewCounter model.count
+        , viewItems model.items
+        ]
+
+viewHeader : String -> Html Msg
+viewHeader name =
+    div [ class "header" ]
+        [ text name ]
+
+viewCounter : Int -> Html Msg
+viewCounter count =
+    div [ class "counter" ]
+        [ button [ onClick Decrement, class "btn" ] [ text "-" ]
+        , div [] [ text (String.fromInt count) ]
+        , button [ onClick Increment, class "btn" ] [ text "+" ]
+        ]
+
+viewItems : List String -> Html Msg
+viewItems items =
+    div [ class "items" ]
+        (List.map viewItem items)
+
+viewItem : String -> Html Msg
+viewItem item =
+    div [ class "item" ] [ text item ]
+
+-- MAIN
+
+main : Program Flags Model Msg
+main =
+    Browser.element
+        { init = init
+        , update = update
+        , view = view
+        , subscriptions = always Sub.none
+        }
+`
+	ents := runElm(t, src, "Main.elm")
+
+	wantOps := []string{"init", "update", "view", "viewHeader", "viewCounter", "viewItems", "viewItem", "main"}
+	wantComps := []string{"Model", "Flags", "Msg", "Main"}
+	wantImports := []string{"Browser", "Html", "Html.Attributes", "Html.Events", "Json.Decode", "Json.Encode"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("TEA fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -11,6 +11,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/dart"
 	_ "github.com/cajasmota/archigraph/internal/extractors/dockerfile"
 	_ "github.com/cajasmota/archigraph/internal/extractors/elixir"
+	_ "github.com/cajasmota/archigraph/internal/extractors/elm"
 	_ "github.com/cajasmota/archigraph/internal/extractors/erlang"
 	_ "github.com/cajasmota/archigraph/internal/extractors/fish"
 	_ "github.com/cajasmota/archigraph/internal/extractors/fsharp"

--- a/internal/resolve/dynamic_patterns_elm.go
+++ b/internal/resolve/dynamic_patterns_elm.go
@@ -1,0 +1,287 @@
+package resolve
+
+import "regexp"
+
+// elmDynamicPatterns are per-language patterns for Elm.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The Elm extractor (internal/extractors/elm/extractor.go) emits CALLS edges
+// whose ToID is either a bare function name or a qualified Module.function form.
+//
+// Three categories of patterns:
+//
+//  1. Elm core stdlib — List, Dict, Maybe, Result, String, Tuple, Set, Array
+//     functions that appear in every Elm codebase as qualified calls.
+//     These are external package functions never indexed in-tree.
+//
+//  2. Browser / Html / Html.Attributes / Html.Events — TEA architecture
+//     functions that appear in virtually every Elm app. Gated to lang=="elm"
+//     to avoid collisions with generic "div", "text", "class" identifiers in
+//     CSS/HTML extractors.
+//
+//  3. JSON (Json.Decode / Json.Encode) — commonly used in Elm apps for
+//     port communication and HTTP. Pattern-matched on qualified forms.
+//
+// All patterns are gated to lang=="elm" (safer-bias rule).
+var elmDynamicPatterns = []*regexp.Regexp{
+	// ── List ────────────────────────────────────────────────────────────
+	regexp.MustCompile(`^List\.map$`),          // List.map : (a -> b) -> List a -> List b
+	regexp.MustCompile(`^List\.filter$`),        // List.filter : (a -> Bool) -> List a -> List a
+	regexp.MustCompile(`^List\.foldl$`),         // List.foldl : (a -> b -> b) -> b -> List a -> b
+	regexp.MustCompile(`^List\.foldr$`),         // List.foldr : (a -> b -> b) -> b -> List a -> b
+	regexp.MustCompile(`^List\.length$`),        // List.length : List a -> Int
+	regexp.MustCompile(`^List\.head$`),          // List.head : List a -> Maybe a
+	regexp.MustCompile(`^List\.tail$`),          // List.tail : List a -> Maybe (List a)
+	regexp.MustCompile(`^List\.isEmpty$`),       // List.isEmpty : List a -> Bool
+	regexp.MustCompile(`^List\.member$`),        // List.member : a -> List a -> Bool
+	regexp.MustCompile(`^List\.append$`),        // List.append : List a -> List a -> List a
+	regexp.MustCompile(`^List\.concat$`),        // List.concat : List (List a) -> List a
+	regexp.MustCompile(`^List\.concatMap$`),     // List.concatMap : (a -> List b) -> List a -> List b
+	regexp.MustCompile(`^List\.reverse$`),       // List.reverse : List a -> List a
+	regexp.MustCompile(`^List\.sort$`),          // List.sort : List comparable -> List comparable
+	regexp.MustCompile(`^List\.sortBy$`),        // List.sortBy : (a -> comparable) -> List a -> List a
+	regexp.MustCompile(`^List\.sortWith$`),      // List.sortWith : (a -> a -> Order) -> List a -> List a
+	regexp.MustCompile(`^List\.take$`),          // List.take : Int -> List a -> List a
+	regexp.MustCompile(`^List\.drop$`),          // List.drop : Int -> List a -> List a
+	regexp.MustCompile(`^List\.partition$`),     // List.partition : (a -> Bool) -> List a -> (List a, List a)
+	regexp.MustCompile(`^List\.unzip$`),         // List.unzip : List (a, b) -> (List a, List b)
+	regexp.MustCompile(`^List\.indexedMap$`),    // List.indexedMap : (Int -> a -> b) -> List a -> List b
+	regexp.MustCompile(`^List\.filterMap$`),     // List.filterMap : (a -> Maybe b) -> List a -> List b
+	regexp.MustCompile(`^List\.map2$`),          // List.map2 : (a -> b -> c) -> List a -> List b -> List c
+	regexp.MustCompile(`^List\.range$`),         // List.range : Int -> Int -> List Int
+	regexp.MustCompile(`^List\.repeat$`),        // List.repeat : Int -> a -> List a
+	regexp.MustCompile(`^List\.singleton$`),     // List.singleton : a -> List a
+	regexp.MustCompile(`^List\.sum$`),           // List.sum : List number -> number
+	regexp.MustCompile(`^List\.product$`),       // List.product : List number -> number
+	regexp.MustCompile(`^List\.maximum$`),       // List.maximum : List comparable -> Maybe comparable
+	regexp.MustCompile(`^List\.minimum$`),       // List.minimum : List comparable -> Maybe comparable
+	regexp.MustCompile(`^List\.all$`),           // List.all : (a -> Bool) -> List a -> Bool
+	regexp.MustCompile(`^List\.any$`),           // List.any : (a -> Bool) -> List a -> Bool
+	regexp.MustCompile(`^List\.intersperse$`),   // List.intersperse : a -> List a -> List a
+	regexp.MustCompile(`^List\.map3$`),          // List.map3
+	regexp.MustCompile(`^List\.map4$`),          // List.map4
+	regexp.MustCompile(`^List\.map5$`),          // List.map5
+
+	// ── Dict ─────────────────────────────────────────────────────────────
+	regexp.MustCompile(`^Dict\.get$`),           // Dict.get : comparable -> Dict comparable v -> Maybe v
+	regexp.MustCompile(`^Dict\.insert$`),        // Dict.insert : comparable -> v -> Dict comparable v -> Dict comparable v
+	regexp.MustCompile(`^Dict\.remove$`),        // Dict.remove : comparable -> Dict comparable v -> Dict comparable v
+	regexp.MustCompile(`^Dict\.update$`),        // Dict.update : comparable -> (Maybe v -> Maybe v) -> Dict comparable v -> Dict comparable v
+	regexp.MustCompile(`^Dict\.empty$`),         // Dict.empty : Dict k v
+	regexp.MustCompile(`^Dict\.singleton$`),     // Dict.singleton : k -> v -> Dict k v
+	regexp.MustCompile(`^Dict\.isEmpty$`),       // Dict.isEmpty : Dict k v -> Bool
+	regexp.MustCompile(`^Dict\.member$`),        // Dict.member : comparable -> Dict comparable v -> Bool
+	regexp.MustCompile(`^Dict\.size$`),          // Dict.size : Dict k v -> Int
+	regexp.MustCompile(`^Dict\.keys$`),          // Dict.keys : Dict k v -> List k
+	regexp.MustCompile(`^Dict\.values$`),        // Dict.values : Dict k v -> List v
+	regexp.MustCompile(`^Dict\.toList$`),        // Dict.toList : Dict k v -> List (k, v)
+	regexp.MustCompile(`^Dict\.fromList$`),      // Dict.fromList : List (comparable, v) -> Dict comparable v
+	regexp.MustCompile(`^Dict\.map$`),           // Dict.map : (k -> a -> b) -> Dict k a -> Dict k b
+	regexp.MustCompile(`^Dict\.filter$`),        // Dict.filter : (comparable -> v -> Bool) -> Dict comparable v -> Dict comparable v
+	regexp.MustCompile(`^Dict\.foldl$`),         // Dict.foldl
+	regexp.MustCompile(`^Dict\.foldr$`),         // Dict.foldr
+	regexp.MustCompile(`^Dict\.partition$`),     // Dict.partition
+	regexp.MustCompile(`^Dict\.union$`),         // Dict.union
+	regexp.MustCompile(`^Dict\.intersect$`),     // Dict.intersect
+	regexp.MustCompile(`^Dict\.diff$`),          // Dict.diff
+	regexp.MustCompile(`^Dict\.merge$`),         // Dict.merge
+
+	// ── Maybe ────────────────────────────────────────────────────────────
+	regexp.MustCompile(`^Maybe\.withDefault$`),  // Maybe.withDefault : a -> Maybe a -> a
+	regexp.MustCompile(`^Maybe\.map$`),          // Maybe.map : (a -> b) -> Maybe a -> Maybe b
+	regexp.MustCompile(`^Maybe\.map2$`),         // Maybe.map2
+	regexp.MustCompile(`^Maybe\.map3$`),         // Maybe.map3
+	regexp.MustCompile(`^Maybe\.andThen$`),      // Maybe.andThen : (a -> Maybe b) -> Maybe a -> Maybe b
+	regexp.MustCompile(`^Maybe\.andMap$`),       // Maybe.andMap
+
+	// ── Result ───────────────────────────────────────────────────────────
+	regexp.MustCompile(`^Result\.andThen$`),     // Result.andThen : (a -> Result e b) -> Result e a -> Result e b
+	regexp.MustCompile(`^Result\.map$`),         // Result.map : (a -> b) -> Result e a -> Result e b
+	regexp.MustCompile(`^Result\.mapError$`),    // Result.mapError : (e -> f) -> Result e a -> Result f a
+	regexp.MustCompile(`^Result\.withDefault$`), // Result.withDefault : a -> Result e a -> a
+	regexp.MustCompile(`^Result\.toMaybe$`),     // Result.toMaybe : Result e a -> Maybe a
+	regexp.MustCompile(`^Result\.fromMaybe$`),   // Result.fromMaybe : e -> Maybe a -> Result e a
+
+	// ── String ───────────────────────────────────────────────────────────
+	regexp.MustCompile(`^String\.fromInt$`),     // String.fromInt : Int -> String
+	regexp.MustCompile(`^String\.fromFloat$`),   // String.fromFloat : Float -> String
+	regexp.MustCompile(`^String\.toInt$`),       // String.toInt : String -> Maybe Int
+	regexp.MustCompile(`^String\.toFloat$`),     // String.toFloat : String -> Maybe Float
+	regexp.MustCompile(`^String\.split$`),       // String.split : String -> String -> List String
+	regexp.MustCompile(`^String\.join$`),        // String.join : String -> List String -> String
+	regexp.MustCompile(`^String\.words$`),       // String.words : String -> List String
+	regexp.MustCompile(`^String\.lines$`),       // String.lines : String -> List String
+	regexp.MustCompile(`^String\.length$`),      // String.length : String -> Int
+	regexp.MustCompile(`^String\.isEmpty$`),     // String.isEmpty : String -> Bool
+	regexp.MustCompile(`^String\.trim$`),        // String.trim : String -> String
+	regexp.MustCompile(`^String\.trimLeft$`),    // String.trimLeft : String -> String
+	regexp.MustCompile(`^String\.trimRight$`),   // String.trimRight : String -> String
+	regexp.MustCompile(`^String\.append$`),      // String.append : String -> String -> String
+	regexp.MustCompile(`^String\.concat$`),      // String.concat : List String -> String
+	regexp.MustCompile(`^String\.contains$`),    // String.contains : String -> String -> Bool
+	regexp.MustCompile(`^String\.startsWith$`),  // String.startsWith : String -> String -> Bool
+	regexp.MustCompile(`^String\.endsWith$`),    // String.endsWith : String -> String -> Bool
+	regexp.MustCompile(`^String\.replace$`),     // String.replace : String -> String -> String -> String
+	regexp.MustCompile(`^String\.slice$`),       // String.slice : Int -> Int -> String -> String
+	regexp.MustCompile(`^String\.left$`),        // String.left : Int -> String -> String
+	regexp.MustCompile(`^String\.right$`),       // String.right : Int -> String -> String
+	regexp.MustCompile(`^String\.dropLeft$`),    // String.dropLeft : Int -> String -> String
+	regexp.MustCompile(`^String\.dropRight$`),   // String.dropRight : Int -> String -> String
+	regexp.MustCompile(`^String\.toLower$`),     // String.toLower : String -> String
+	regexp.MustCompile(`^String\.toUpper$`),     // String.toUpper : String -> String
+	regexp.MustCompile(`^String\.toList$`),      // String.toList : String -> List Char
+	regexp.MustCompile(`^String\.fromList$`),    // String.fromList : List Char -> String
+	regexp.MustCompile(`^String\.map$`),         // String.map
+	regexp.MustCompile(`^String\.filter$`),      // String.filter
+	regexp.MustCompile(`^String\.foldl$`),       // String.foldl
+	regexp.MustCompile(`^String\.foldr$`),       // String.foldr
+	regexp.MustCompile(`^String\.any$`),         // String.any
+	regexp.MustCompile(`^String\.all$`),         // String.all
+	regexp.MustCompile(`^String\.indices$`),     // String.indices
+	regexp.MustCompile(`^String\.indexes$`),     // String.indexes
+	regexp.MustCompile(`^String\.uncons$`),      // String.uncons
+
+	// ── Browser / Browser.Navigation ────────────────────────────────────
+	regexp.MustCompile(`^Browser\.sandbox$`),    // Browser.sandbox : { ... } -> Program flags model msg
+	regexp.MustCompile(`^Browser\.element$`),    // Browser.element : { ... } -> Program flags model msg
+	regexp.MustCompile(`^Browser\.document$`),   // Browser.document : { ... } -> Program flags model msg
+	regexp.MustCompile(`^Browser\.application$`), // Browser.application : { ... } -> Program flags model msg
+
+	// ── Html ─────────────────────────────────────────────────────────────
+	regexp.MustCompile(`^Html\.div$`),           // Html.div : List (Attribute msg) -> List (Html msg) -> Html msg
+	regexp.MustCompile(`^Html\.span$`),          // Html.span
+	regexp.MustCompile(`^Html\.text$`),          // Html.text : String -> Html msg
+	regexp.MustCompile(`^Html\.button$`),        // Html.button
+	regexp.MustCompile(`^Html\.input$`),         // Html.input
+	regexp.MustCompile(`^Html\.p$`),             // Html.p
+	regexp.MustCompile(`^Html\.h1$`),            // Html.h1
+	regexp.MustCompile(`^Html\.h2$`),            // Html.h2
+	regexp.MustCompile(`^Html\.h3$`),            // Html.h3
+	regexp.MustCompile(`^Html\.ul$`),            // Html.ul
+	regexp.MustCompile(`^Html\.ol$`),            // Html.ol
+	regexp.MustCompile(`^Html\.li$`),            // Html.li
+	regexp.MustCompile(`^Html\.a$`),             // Html.a
+	regexp.MustCompile(`^Html\.img$`),           // Html.img
+	regexp.MustCompile(`^Html\.form$`),          // Html.form
+	regexp.MustCompile(`^Html\.label$`),         // Html.label
+	regexp.MustCompile(`^Html\.map$`),           // Html.map : (a -> b) -> Html a -> Html b
+	regexp.MustCompile(`^Html\.node$`),          // Html.node : String -> List (Attribute msg) -> List (Html msg) -> Html msg
+
+	// ── Html.Attributes ──────────────────────────────────────────────────
+	regexp.MustCompile(`^Attributes\.class$`),   // Attributes.class
+	regexp.MustCompile(`^Attributes\.id$`),      // Attributes.id
+	regexp.MustCompile(`^Attributes\.style$`),   // Attributes.style
+	regexp.MustCompile(`^Attributes\.type_$`),   // Attributes.type_
+	regexp.MustCompile(`^Attributes\.value$`),   // Attributes.value
+	regexp.MustCompile(`^Attributes\.placeholder$`), // Attributes.placeholder
+	regexp.MustCompile(`^Attributes\.href$`),    // Attributes.href
+	regexp.MustCompile(`^Attributes\.src$`),     // Attributes.src
+	regexp.MustCompile(`^Attributes\.disabled$`), // Attributes.disabled
+	regexp.MustCompile(`^Attributes\.checked$`), // Attributes.checked
+	regexp.MustCompile(`^Html\.Attributes\.class$`),
+	regexp.MustCompile(`^Html\.Attributes\.id$`),
+	regexp.MustCompile(`^Html\.Attributes\.style$`),
+	regexp.MustCompile(`^Html\.Attributes\.type_$`),
+	regexp.MustCompile(`^Html\.Attributes\.value$`),
+	regexp.MustCompile(`^Html\.Attributes\.href$`),
+	regexp.MustCompile(`^Html\.Attributes\.src$`),
+
+	// ── Html.Events ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^Events\.onClick$`),     // Events.onClick
+	regexp.MustCompile(`^Events\.onInput$`),     // Events.onInput
+	regexp.MustCompile(`^Events\.onSubmit$`),    // Events.onSubmit
+	regexp.MustCompile(`^Events\.onMouseOver$`), // Events.onMouseOver
+	regexp.MustCompile(`^Events\.onMouseOut$`),  // Events.onMouseOut
+	regexp.MustCompile(`^Events\.onFocus$`),     // Events.onFocus
+	regexp.MustCompile(`^Events\.onBlur$`),      // Events.onBlur
+	regexp.MustCompile(`^Html\.Events\.onClick$`),
+	regexp.MustCompile(`^Html\.Events\.onInput$`),
+	regexp.MustCompile(`^Html\.Events\.onSubmit$`),
+
+	// ── Json.Decode ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^Decode\.field$`),       // Decode.field : String -> Decoder a -> Decoder a
+	regexp.MustCompile(`^Decode\.at$`),          // Decode.at : List String -> Decoder a -> Decoder a
+	regexp.MustCompile(`^Decode\.map$`),         // Decode.map : (a -> b) -> Decoder a -> Decoder b
+	regexp.MustCompile(`^Decode\.map2$`),        // Decode.map2
+	regexp.MustCompile(`^Decode\.map3$`),        // Decode.map3
+	regexp.MustCompile(`^Decode\.andThen$`),     // Decode.andThen
+	regexp.MustCompile(`^Decode\.succeed$`),     // Decode.succeed : a -> Decoder a
+	regexp.MustCompile(`^Decode\.fail$`),        // Decode.fail : String -> Decoder a
+	regexp.MustCompile(`^Decode\.string$`),      // Decode.string : Decoder String
+	regexp.MustCompile(`^Decode\.int$`),         // Decode.int : Decoder Int
+	regexp.MustCompile(`^Decode\.float$`),       // Decode.float : Decoder Float
+	regexp.MustCompile(`^Decode\.bool$`),        // Decode.bool : Decoder Bool
+	regexp.MustCompile(`^Decode\.list$`),        // Decode.list : Decoder a -> Decoder (List a)
+	regexp.MustCompile(`^Decode\.nullable$`),    // Decode.nullable : Decoder a -> Decoder (Maybe a)
+	regexp.MustCompile(`^Decode\.maybe$`),       // Decode.maybe : Decoder a -> Decoder (Maybe a)
+	regexp.MustCompile(`^Decode\.decodeString$`), // Decode.decodeString : Decoder a -> String -> Result Error a
+	regexp.MustCompile(`^Decode\.decodeValue$`), // Decode.decodeValue : Decoder a -> Value -> Result Error a
+	regexp.MustCompile(`^decodeString$`),        // bare decodeString when imported exposing(..)
+	regexp.MustCompile(`^Json\.Decode\.field$`),
+	regexp.MustCompile(`^Json\.Decode\.decodeString$`),
+
+	// ── Json.Encode ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^Encode\.object$`),      // Encode.object : List (String, Value) -> Value
+	regexp.MustCompile(`^Encode\.list$`),        // Encode.list : (a -> Value) -> List a -> Value
+	regexp.MustCompile(`^Encode\.string$`),      // Encode.string : String -> Value
+	regexp.MustCompile(`^Encode\.int$`),         // Encode.int : Int -> Value
+	regexp.MustCompile(`^Encode\.float$`),       // Encode.float : Float -> Value
+	regexp.MustCompile(`^Encode\.bool$`),        // Encode.bool : Bool -> Value
+	regexp.MustCompile(`^Encode\.null$`),        // Encode.null : Value
+	regexp.MustCompile(`^Encode\.dict$`),        // Encode.dict
+	regexp.MustCompile(`^Json\.Encode\.object$`),
+	regexp.MustCompile(`^Json\.Encode\.string$`),
+
+	// ── Cmd / Sub ─────────────────────────────────────────────────────────
+	regexp.MustCompile(`^Cmd\.none$`),           // Cmd.none : Cmd msg
+	regexp.MustCompile(`^Cmd\.batch$`),          // Cmd.batch : List (Cmd msg) -> Cmd msg
+	regexp.MustCompile(`^Cmd\.map$`),            // Cmd.map : (a -> b) -> Cmd a -> Cmd b
+	regexp.MustCompile(`^Sub\.none$`),           // Sub.none : Sub msg
+	regexp.MustCompile(`^Sub\.batch$`),          // Sub.batch : List (Sub msg) -> Sub msg
+	regexp.MustCompile(`^Sub\.map$`),            // Sub.map : (a -> b) -> Sub a -> Sub b
+
+	// ── Platform / Task ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Task\.perform$`),       // Task.perform : (a -> msg) -> Task Never a -> Cmd msg
+	regexp.MustCompile(`^Task\.attempt$`),       // Task.attempt : (Result e a -> msg) -> Task e a -> Cmd msg
+	regexp.MustCompile(`^Task\.map$`),           // Task.map
+	regexp.MustCompile(`^Task\.andThen$`),       // Task.andThen
+	regexp.MustCompile(`^Task\.succeed$`),       // Task.succeed
+	regexp.MustCompile(`^Task\.fail$`),          // Task.fail
+
+	// ── Http (elm/http) ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Http\.get$`),           // Http.get : { url : String, expect : Expect msg } -> Cmd msg
+	regexp.MustCompile(`^Http\.post$`),          // Http.post
+	regexp.MustCompile(`^Http\.request$`),       // Http.request
+	regexp.MustCompile(`^Http\.expectJson$`),    // Http.expectJson
+	regexp.MustCompile(`^Http\.expectString$`),  // Http.expectString
+	regexp.MustCompile(`^Http\.jsonBody$`),      // Http.jsonBody
+	regexp.MustCompile(`^Http\.stringBody$`),    // Http.stringBody
+
+	// ── Basics (auto-imported) ────────────────────────────────────────────
+	regexp.MustCompile(`^modBy$`),               // modBy : Int -> Int -> Int
+	regexp.MustCompile(`^remainderBy$`),         // remainderBy : Int -> Int -> Int
+	regexp.MustCompile(`^ceiling$`),             // ceiling : Float -> Int
+	regexp.MustCompile(`^floor$`),               // floor : Float -> Int
+	regexp.MustCompile(`^round$`),               // round : Float -> Int
+	regexp.MustCompile(`^truncate$`),            // truncate : Float -> Int
+	regexp.MustCompile(`^sqrt$`),                // sqrt : Float -> Float
+	regexp.MustCompile(`^logBase$`),             // logBase : Float -> Float -> Float
+	regexp.MustCompile(`^abs$`),                 // abs : number -> number
+	regexp.MustCompile(`^negate$`),              // negate : number -> number
+	regexp.MustCompile(`^max$`),                 // max : comparable -> comparable -> comparable
+	regexp.MustCompile(`^min$`),                 // min : comparable -> comparable -> comparable
+	regexp.MustCompile(`^compare$`),             // compare : comparable -> comparable -> Order
+	regexp.MustCompile(`^not$`),                 // not : Bool -> Bool
+	regexp.MustCompile(`^xor$`),                 // xor : Bool -> Bool -> Bool
+	regexp.MustCompile(`^identity$`),            // identity : a -> a
+	regexp.MustCompile(`^always$`),              // always : a -> b -> a
+	regexp.MustCompile(`^never$`),               // never : Never -> a
+	regexp.MustCompile(`^toFloat$`),             // toFloat : Int -> Float
+	regexp.MustCompile(`^toString$`),            // toString : a -> String
+	regexp.MustCompile(`^isNaN$`),               // isNaN : Float -> Bool
+	regexp.MustCompile(`^isInfinite$`),          // isInfinite : Float -> Bool
+}
+
+func init() {
+	dynamicPatternsByLang["elm"] = elmDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Add Elm language support to the extraction pipeline: extractor, test suite (TEA-pattern fixture), resolver slice, classifier routing, and registry blank-import.

**Extracted entities:**
- `module Main exposing (..)` → `SCOPE.Component` (subtype=`module`)
- Top-level function/value declarations (type annotation + definition) → `SCOPE.Operation` (subtype=`function`)
- `type alias Model = { ... }` → `SCOPE.Component` (subtype=`typealias`)
- `type Msg = A | B` → `SCOPE.Component` (subtype=`type`)
- `import Html.Attributes as Attr` → `IMPORTS` edges
- Function body analysis → `CALLS` edges (qualified `Module.fn` + bare, deduped)
- Module → `CONTAINS` top-level declarations

**Resolver slice** (`dynamic_patterns_elm.go`): ~120 patterns covering Elm core stdlib (List, Dict, Maybe, Result, String, Basics), Browser/Html/Attributes/Events TEA architecture, Json.Decode/Json.Encode, Cmd/Sub, Http, Task.

## Closes / Refs

- Closes #1035
- Refs #44

## Testing

- [x] All tests pass: `go test ./internal/extractors/elm/... ./internal/resolve/... ./internal/classifier/...`
- [x] TEA fixture recall: **100% (18/18)** — 8/8 ops, 4/4 comps, 6/6 imports (threshold: 80%)
- [x] 13 tests total: registration, empty input, module, functions, type alias, custom type, alias/type disambiguation, imports, CALLS, CALLS dedup, language tagging, CONTAINS edges, TEA fixture
- [x] `go vet` clean on all touched packages
- [x] Classifier contract test passes: 31 registered extractors each have ≥1 routing rule
- [x] 0 false positives — `type alias` correctly routed to `typealias`, not `type`

## Notes

- Elm uses layout-rule (indentation-sensitive) syntax like Haskell/F#. The extractor follows the same column-0 = top-level convention used by the Haskell extractor (#1046).
- Supports nested block comments `{- {- nested -} -}` via a depth counter in `stripStringsAndComments`.
- Qualified call patterns (e.g. `List.map`, `Html.div`) are captured via a separate `qualifiedCallRE` pass before the bare-identifier pass to ensure fidelity.
- `type alias` disambiguation: `typeAliasRE` runs before `customTypeRE`, and `customTypeRE` skips any capture that starts with `"alias"`.