### PR TITLE
[#1034] Add OCaml language extractor and resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -491,6 +491,9 @@ var extensionLanguageMap = map[string]string{
 	// Haskell
 	".hs":  "haskell",
 	".lhs": "haskell",
+	// OCaml — .ml is claimed for OCaml (SML is much less common)
+	".ml":  "ocaml",
+	".mli": "ocaml",
 	// Perl
 	".pl": "perl",
 	".pm": "perl",

--- a/internal/extractors/ocaml/extractor.go
+++ b/internal/extractors/ocaml/extractor.go
@@ -1,0 +1,589 @@
+// Package ocaml implements a regex-based extractor for OCaml source files.
+//
+// Extracted entities:
+//   - Module declarations (`module Foo = struct ... end`, file-level) → SCOPE.Component (subtype="module")
+//   - `let`/`let rec` function definitions → SCOPE.Operation (subtype="function")
+//   - `type` declarations → SCOPE.Component (subtype="type")
+//   - `open Foo` statements → IMPORTS edges
+//   - Function calls → CALLS edges
+//   - CONTAINS edges (module → top-level declarations)
+//
+// No tree-sitter grammar for OCaml is bundled in smacker/go-tree-sitter, so
+// this extractor uses regular expressions. OCaml uses a layout-insensitive
+// syntax with explicit end/;; markers; for entity-discovery purposes we
+// detect top-level declarations by their starting at column 0.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package ocaml
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("ocaml", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for OCaml.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "ocaml" }
+
+// -----------------------------------------------------------------------
+// Compiled regex patterns
+// -----------------------------------------------------------------------
+
+var (
+	// moduleRE matches explicit module declarations:
+	//   module Foo = struct ... end
+	//   module type Bar = sig ... end
+	// We capture the module name only.
+	moduleRE = regexp.MustCompile(
+		`(?m)^module(?:\s+type)?\s+([A-Z][a-zA-Z0-9_']*)\s*(?:=|:)`,
+	)
+
+	// letRE matches top-level let/let rec bindings:
+	//   let foo x y = ...
+	//   let rec bar n = ...
+	// Must be at column 0 (^ anchor) and NOT be "let () = ..." (main entry patterns).
+	// We capture the function name.
+	letRE = regexp.MustCompile(
+		`(?m)^let(?:\s+rec)?\s+([a-z_][a-zA-Z0-9_']*)\s`,
+	)
+
+	// typeRE matches top-level type declarations:
+	//   type 'a option = None | Some of 'a
+	//   type point = { x: float; y: float }
+	//   type t = int
+	// Captures the type name (excluding leading type variables).
+	typeRE = regexp.MustCompile(
+		`(?m)^type\s+(?:(?:'[a-zA-Z_][a-zA-Z0-9_']*\s+)+)?([a-z_][a-zA-Z0-9_']*)\s*(?:=|$)`,
+	)
+
+	// openRE matches open statements:
+	//   open Foo
+	//   open Foo.Bar
+	openRE = regexp.MustCompile(
+		`(?m)^open\s+([A-Z][a-zA-Z0-9_'.]*(?:\.[A-Z][a-zA-Z0-9_']*)*)`,
+	)
+
+	// callRE matches function applications: qualified or unqualified identifiers
+	// followed by arguments. Captures module-qualified calls like List.map, Lwt.bind, etc.
+	// Also captures plain bare function calls.
+	callDotRE = regexp.MustCompile(
+		`\b([A-Z][a-zA-Z0-9_']*(?:\.[A-Z][a-zA-Z0-9_']*)*\.[a-z_][a-zA-Z0-9_']*)\b`,
+	)
+	callBareRE = regexp.MustCompile(
+		`\b([a-z_][a-zA-Z0-9_']*)\s+`,
+	)
+)
+
+// ocamlKeywords is the set of tokens to exclude from CALLS edges.
+var ocamlKeywords = map[string]bool{
+	// Core keywords
+	"and": true, "as": true, "assert": true, "asr": true,
+	"begin": true, "class": true, "constraint": true,
+	"do": true, "done": true, "downto": true,
+	"else": true, "end": true, "exception": true,
+	"external": true, "false": true, "for": true,
+	"fun": true, "function": true, "functor": true,
+	"if": true, "in": true, "include": true,
+	"inherit": true, "initializer": true,
+	"land": true, "lazy": true, "let": true, "lor": true, "lsl": true, "lsr": true, "lxor": true,
+	"match": true, "method": true, "mod": true, "module": true, "mutable": true,
+	"new": true, "nonrec": true,
+	"object": true, "of": true, "open": true, "or": true,
+	"private": true, "rec": true, "sig": true, "struct": true,
+	"then": true, "to": true, "true": true, "try": true,
+	"type": true, "val": true, "virtual": true,
+	"when": true, "while": true, "with": true,
+	// Common pervasives
+	"ignore": true, "raise": true, "failwith": true, "invalid_arg": true,
+	"print_string": true, "print_int": true, "print_newline": true,
+	"not": true, "ref": true, "fst": true, "snd": true,
+}
+
+// Extract processes the OCaml source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractOCaml(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "ocaml")
+	return out, nil
+}
+
+func extractOCaml(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// Emit file-level entity (issue #577 pattern).
+	entities = append(entities, extractor.FileEntity(extractor.FileInput{
+		Path:     filePath,
+		Language: "ocaml",
+	}))
+
+	imports := collectOpenStatements(src)
+	importEntities := buildImportEntities(filePath, imports)
+	entities = append(entities, importEntities...)
+
+	// 1. Module declarations.
+	seenModules := make(map[string]bool)
+	for _, m := range moduleRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenModules[name] {
+			continue
+		}
+		seenModules[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractModuleBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "module",
+			SourceFile: filePath,
+			Language:   "ocaml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "module " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 2. let/let rec function definitions.
+	letSeen := make(map[string]bool)
+	for _, m := range letRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		// Skip unit-binding "let () =" which is main/entrypoint boilerplate.
+		// (The pattern won't match "()" because it requires [a-z_] start.)
+		if letSeen[name] {
+			continue
+		}
+		// Skip if this looks like it's inside a module body (not at col 0).
+		// We check the match start — if the offset of the line start equals
+		// m[0], we're at column 0.
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		letSeen[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractLetBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+		var sig string
+		// Build signature from the declaration line.
+		lineEnd := strings.Index(src[m[0]:], "\n")
+		if lineEnd >= 0 {
+			sig = strings.TrimSpace(src[m[0] : m[0]+lineEnd])
+		} else {
+			sig = "let " + name
+		}
+		// Trim trailing " =" from signature
+		if idx := strings.LastIndex(sig, "="); idx > 0 {
+			sig = strings.TrimSpace(sig[:idx])
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "function",
+			SourceFile: filePath,
+			Language:   "ocaml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  sig,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: calls,
+		})
+	}
+
+	// 3. Type declarations.
+	typeSeen := make(map[string]bool)
+	for _, m := range typeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if typeSeen[name] {
+			continue
+		}
+		// Must be at column 0.
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		typeSeen[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractLetBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "type",
+			SourceFile: filePath,
+			Language:   "ocaml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "type " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 4. Add CONTAINS edges from explicit module declarations to functions inside.
+	// We use a simple heuristic: for each module declaration, find the let bindings
+	// that follow within the module body.
+	addModuleContains(src, filePath, &entities, seenModules, letSeen)
+
+	return entities
+}
+
+// addModuleContains attaches CONTAINS edges to module entities.
+func addModuleContains(src, filePath string, entities *[]types.EntityRecord, modules, letBindings map[string]bool) {
+	if len(modules) == 0 || len(letBindings) == 0 {
+		return
+	}
+	// For each module entity, find nested let bindings by scanning the module body.
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.Kind != "SCOPE.Component" || e.Subtype != "module" {
+			continue
+		}
+		moduleName := e.Name
+		// Find the module's start offset.
+		moduleMatchRE := regexp.MustCompile(fmt.Sprintf(`(?m)^module(?:\s+type)?\s+%s\s*(?:=|:)`, regexp.QuoteMeta(moduleName)))
+		loc := moduleMatchRE.FindStringIndex(src)
+		if loc == nil {
+			continue
+		}
+		body := extractModuleBody(src, loc[1])
+		// Find all let names within this body.
+		var containsRels []types.RelationshipRecord
+		seenRefs := make(map[string]bool)
+		for _, lm := range letRE.FindAllStringSubmatch(body, -1) {
+			if len(lm) < 2 {
+				continue
+			}
+			fnName := lm[1]
+			if seenRefs[fnName] {
+				continue
+			}
+			seenRefs[fnName] = true
+			ref := extractor.BuildOperationStructuralRef("ocaml", filePath, fnName)
+			containsRels = append(containsRels, types.RelationshipRecord{
+				ToID: ref,
+				Kind: "CONTAINS",
+			})
+		}
+		e.Relationships = append(e.Relationships, containsRels...)
+	}
+}
+
+// -----------------------------------------------------------------------
+// Helper: import collection
+// -----------------------------------------------------------------------
+
+func collectOpenStatements(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+
+	for _, m := range openRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		mod := strings.TrimSpace(m[1])
+		// Strip inline comments (OCaml uses (* ... *) but also (* for line comments)
+		if ci := strings.Index(mod, "(*"); ci >= 0 {
+			mod = strings.TrimSpace(mod[:ci])
+		}
+		if mod == "" || seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		imports = append(imports, mod)
+	}
+	return imports
+}
+
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		displayName := importDisplayName(mod)
+		out = append(out, types.EntityRecord{
+			Name:       displayName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "ocaml",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+func importDisplayName(mod string) string {
+	if dot := strings.LastIndexByte(mod, '.'); dot >= 0 {
+		return mod[dot+1:]
+	}
+	return mod
+}
+
+// -----------------------------------------------------------------------
+// Helper: body extraction
+// -----------------------------------------------------------------------
+
+// extractLetBody collects the body of a let binding by scanning subsequent lines
+// that are indented relative to column 0. Stops at the next top-level binding.
+func extractLetBody(src string, afterPos int) string {
+	rest := src[afterPos:]
+	lines := strings.Split(rest, "\n")
+	var body []string
+	for i, line := range lines {
+		if i == 0 {
+			body = append(body, line)
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			body = append(body, line)
+			continue
+		}
+		// Top-level items start at column 0 with a non-space char.
+		if line[0] == ' ' || line[0] == '\t' {
+			body = append(body, line)
+		} else {
+			// Next top-level declaration.
+			break
+		}
+	}
+	return strings.Join(body, "\n")
+}
+
+// extractModuleBody extracts the text of a module body between struct/sig and end.
+// Falls back to indentation heuristics if struct/sig not found.
+func extractModuleBody(src string, afterPos int) string {
+	if afterPos >= len(src) {
+		return ""
+	}
+	rest := src[afterPos:]
+
+	// Try to find the matching "end" keyword for struct/sig/object blocks.
+	// We do a simple depth-counting approach.
+	depth := 0
+	found := false
+	endPos := 0
+
+	// Keywords that open a new nesting level:
+	openKW := regexp.MustCompile(`\b(struct|sig|object|begin)\b`)
+	closeKW := regexp.MustCompile(`\bend\b`)
+
+	// Scan character by character to handle nesting, skipping strings/comments.
+	i := 0
+	for i < len(rest) {
+		// Check for block comment (* ... *)
+		if i+1 < len(rest) && rest[i] == '(' && rest[i+1] == '*' {
+			i += 2
+			for i < len(rest) {
+				if i+1 < len(rest) && rest[i] == '*' && rest[i+1] == ')' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+		// Check for string literal "..."
+		if rest[i] == '"' {
+			i++
+			for i < len(rest) && rest[i] != '"' {
+				if rest[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			continue
+		}
+		// Check for char literal '.'
+		if rest[i] == '\'' && i+2 < len(rest) && rest[i+2] == '\'' {
+			i += 3
+			continue
+		}
+
+		// Check for open/close keywords at current position.
+		remaining := rest[i:]
+		if om := openKW.FindStringIndex(remaining); om != nil && om[0] == 0 {
+			depth++
+			i += om[1]
+			continue
+		}
+		if cm := closeKW.FindStringIndex(remaining); cm != nil && cm[0] == 0 {
+			if depth == 0 {
+				endPos = i
+				found = true
+				break
+			}
+			depth--
+			i += cm[1]
+			continue
+		}
+		i++
+	}
+
+	if found {
+		return rest[:endPos]
+	}
+	// Fallback: use indentation heuristics (same as extractLetBody).
+	return extractLetBody(src, afterPos)
+}
+
+// -----------------------------------------------------------------------
+// Helper: CALLS edge collection
+// -----------------------------------------------------------------------
+
+// collectCalls extracts CALLS relationships from a function body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+
+	addCall := func(target string) {
+		if target == "" || target == callerName {
+			return
+		}
+		if ocamlKeywords[target] {
+			return
+		}
+		if len(target) <= 1 {
+			return
+		}
+		if seen[target] {
+			return
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	// Qualified calls: Module.function or Module.Sub.function
+	for _, m := range callDotRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	// Bare function calls: function_name <something>
+	for _, m := range callBareRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	return out
+}
+
+// stripStringsAndComments replaces string literals and OCaml block comments
+// with spaces so the call scanner doesn't pick up tokens inside them.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+
+	for i < len(src) {
+		ch := src[i]
+
+		// Block comment: (* ... *) — may be nested in OCaml
+		if ch == '(' && i+1 < len(src) && src[i+1] == '*' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			depth := 1
+			for i < len(src) && depth > 0 {
+				if i+1 < len(src) && src[i] == '(' && src[i+1] == '*' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					depth++
+				} else if i+1 < len(src) && src[i] == '*' && src[i+1] == ')' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					depth--
+				} else {
+					out[i] = ' '
+					i++
+				}
+			}
+			continue
+		}
+
+		// Double-quoted string: "..."
+		if ch == '"' {
+			out[i] = ' '
+			i++
+			for i < len(src) && src[i] != '"' {
+				if src[i] == '\\' && i+1 < len(src) {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// Char literal: 'x' or '\n' etc.
+		if ch == '\'' && i+2 < len(src) && src[i+2] == '\'' {
+			out[i] = ' '
+			out[i+1] = ' '
+			out[i+2] = ' '
+			i += 3
+			continue
+		}
+
+		out[i] = ch
+		i++
+	}
+	return string(out)
+}

--- a/internal/extractors/ocaml/extractor_test.go
+++ b/internal/extractors/ocaml/extractor_test.go
@@ -1,0 +1,490 @@
+package ocaml_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/ocaml"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runOCaml runs the extractor on raw source and returns entity records.
+func runOCaml(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("ocaml")
+	if !ok {
+		t.Fatal("ocaml extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "ocaml",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func mlFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func mlHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestOCaml_Registered verifies the extractor is in the registry.
+func TestOCaml_Registered(t *testing.T) {
+	_, ok := extractor.Get("ocaml")
+	if !ok {
+		t.Fatal("ocaml extractor not registered")
+	}
+}
+
+// TestOCaml_EmptyInput returns zero entities for empty content.
+func TestOCaml_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("ocaml")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.ml",
+		Content:  []byte{},
+		Language: "ocaml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestOCaml_ModuleDeclaration — explicit module declarations → SCOPE.Component(module).
+func TestOCaml_ModuleDeclaration(t *testing.T) {
+	src := `module StringMap = Map.Make(String)
+
+module Utils = struct
+  let greet name = "Hello, " ^ name
+  let double x = x * 2
+end
+`
+	ents := runOCaml(t, src, "utils.ml")
+
+	mod := mlFind(ents, "StringMap", "SCOPE.Component")
+	if mod == nil {
+		t.Error("expected StringMap module component")
+	} else if mod.Subtype != "module" {
+		t.Errorf("StringMap: expected subtype=module, got %q", mod.Subtype)
+	}
+
+	utils := mlFind(ents, "Utils", "SCOPE.Component")
+	if utils == nil {
+		t.Error("expected Utils module component")
+	} else if utils.Subtype != "module" {
+		t.Errorf("Utils: expected subtype=module, got %q", utils.Subtype)
+	}
+}
+
+// TestOCaml_FunctionDiscovery — let/let rec at top-level → SCOPE.Operation(function).
+func TestOCaml_FunctionDiscovery(t *testing.T) {
+	src := `let add x y = x + y
+
+let rec factorial n =
+  if n <= 1 then 1
+  else n * factorial (n - 1)
+
+let greet name =
+  Printf.printf "Hello, %s!\n" name
+`
+	ents := runOCaml(t, src, "funcs.ml")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "ocaml" {
+				t.Errorf("entity %q: expected Language=ocaml, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"add", "factorial", "greet"} {
+		if !ops[want] {
+			t.Errorf("expected function %q to be extracted, got ops=%v", want, ops)
+		}
+	}
+}
+
+// TestOCaml_TypeDeclarations — type declarations → SCOPE.Component(type).
+func TestOCaml_TypeDeclarations(t *testing.T) {
+	src := `type color = Red | Green | Blue
+
+type 'a option = None | Some of 'a
+
+type point = {
+  x: float;
+  y: float;
+}
+
+type result = Ok of int | Error of string
+`
+	ents := runOCaml(t, src, "types.ml")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	for _, name := range []string{"color", "option", "point", "result"} {
+		if subtype, ok := comps[name]; !ok {
+			t.Errorf("expected type %q to be extracted; got comps=%v", name, comps)
+		} else if subtype != "type" {
+			t.Errorf("type %q: expected subtype=type, got %q", name, subtype)
+		}
+	}
+}
+
+// TestOCaml_OpenImports — open statements emit IMPORTS edges.
+func TestOCaml_OpenImports(t *testing.T) {
+	src := `open Printf
+open List
+open Hashtbl
+
+let main () =
+  printf "Hello\n"
+`
+	ents := runOCaml(t, src, "main.ml")
+
+	wantImports := map[string]bool{
+		"Printf":  false,
+		"List":    false,
+		"Hashtbl": false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "main.ml" {
+						t.Errorf("IMPORTS %q: expected FromID=main.ml, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestOCaml_CallsEdges — function calls in bodies emit CALLS edges.
+func TestOCaml_CallsEdges(t *testing.T) {
+	src := `let helper x = x + 1
+
+let process lst =
+  List.map helper (List.filter (fun x -> x > 0) lst)
+`
+	ents := runOCaml(t, src, "calls.ml")
+
+	if !mlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS process→helper")
+	}
+	if !mlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "List.map") {
+		t.Error("expected CALLS process→List.map")
+	}
+	if !mlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "List.filter") {
+		t.Error("expected CALLS process→List.filter")
+	}
+}
+
+// TestOCaml_CallsDeduped — duplicate call targets are emitted once.
+func TestOCaml_CallsDeduped(t *testing.T) {
+	src := `let worker x = x + 1
+
+let runner () =
+  let a = worker 1 in
+  let b = worker 2 in
+  let c = worker 3 in
+  Printf.printf "%d %d %d\n" a b c
+`
+	ents := runOCaml(t, src, "dedup.ml")
+	count := 0
+	for _, e := range ents {
+		if e.Name == "runner" && e.Kind == "SCOPE.Operation" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "worker" {
+					count++
+				}
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 CALLS runner→worker (deduped), got %d", count)
+	}
+}
+
+// TestOCaml_LanguageTagged — all relationships carry language=ocaml.
+func TestOCaml_LanguageTagged(t *testing.T) {
+	src := `open List
+
+type node = Leaf | Node of int * node * node
+
+let size t =
+  let rec aux acc = function
+    | Leaf -> acc
+    | Node (_, l, r) -> aux (aux (acc + 1) l) r
+  in
+  aux 0 t
+`
+	ents := runOCaml(t, src, "tagged.ml")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "ocaml" {
+				t.Errorf("rel %s→%s missing language=ocaml (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestOCaml_LwtMiniFixture — synthetic Lwt async CLI fixture for recall.
+// This is the acceptance fixture: must achieve ≥80% entity recall.
+func TestOCaml_LwtMiniFixture(t *testing.T) {
+	src := `(* OCaml Lwt async CLI tool — mini fixture *)
+open Printf
+open Lwt
+open Lwt_io
+
+(* Configuration type *)
+type config = {
+  host: string;
+  port: int;
+  verbose: bool;
+}
+
+(* Request/response types *)
+type request = {
+  method_: string;
+  path: string;
+  body: string option;
+}
+
+type response = {
+  status: int;
+  body: string;
+}
+
+(* Hashtable for caching responses *)
+let cache : (string, response) Hashtbl.t = Hashtbl.create 16
+
+(* Build the default config *)
+let default_config () = {
+  host = "localhost";
+  port = 8080;
+  verbose = false;
+}
+
+(* Format a request for display *)
+let format_request req =
+  sprintf "%s %s" req.method_ req.path
+
+(* Look up a cached response *)
+let cache_get key =
+  match Hashtbl.find_opt cache key with
+  | Some resp -> Lwt.return (Some resp)
+  | None -> Lwt.return None
+
+(* Store a response in the cache *)
+let cache_put key resp =
+  Hashtbl.add cache key resp;
+  Lwt.return ()
+
+(* Parse CLI arguments into a config *)
+let parse_args argv =
+  let host = ref "localhost" in
+  let port = ref 8080 in
+  let verbose = ref false in
+  Array.iter (fun arg ->
+    if String.length arg > 7 && String.sub arg 0 7 = "--host=" then
+      host := String.sub arg 7 (String.length arg - 7)
+    else if arg = "--verbose" then
+      verbose := true
+    else
+      port := int_of_string arg
+  ) argv;
+  { host = !host; port = !port; verbose = !verbose }
+
+(* Make an HTTP-like request via Lwt *)
+let make_request cfg req =
+  let key = format_request req in
+  cache_get key >>= function
+  | Some cached ->
+    if cfg.verbose then printf "Cache hit: %s\n%!" key;
+    Lwt.return cached
+  | None ->
+    (* Simulate async work *)
+    Lwt_unix.sleep 0.01 >>= fun () ->
+    let resp = { status = 200; body = "OK" } in
+    cache_put key resp >>= fun () ->
+    Lwt.return resp
+
+(* Process a list of requests concurrently *)
+let process_requests cfg reqs =
+  Lwt_list.map_p (make_request cfg) reqs
+
+(* Print a response summary *)
+let print_response resp =
+  printf "Status: %d, Body: %s\n%!" resp.status resp.body
+
+(* Application entry point *)
+let main () =
+  let cfg = parse_args Sys.argv in
+  let reqs = [
+    { method_ = "GET"; path = "/health"; body = None };
+    { method_ = "GET"; path = "/status"; body = None };
+  ] in
+  Lwt_main.run (
+    process_requests cfg reqs >>= fun responses ->
+    List.iter print_response responses;
+    Lwt.return ()
+  )
+
+let () = main ()
+`
+	ents := runOCaml(t, src, "cli.ml")
+
+	wantOps := []string{
+		"default_config", "format_request", "cache_get", "cache_put",
+		"parse_args", "make_request", "process_requests", "print_response", "main",
+	}
+	wantComps := []string{"config", "request", "response"}
+	wantImports := []string{"Printf", "Lwt", "Lwt_io"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("Lwt-mini fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}
+
+// TestOCaml_NoFalsePositives — keywords and noise tokens are not emitted as CALLS edges.
+func TestOCaml_NoFalsePositives(t *testing.T) {
+	src := `let process lst =
+  if List.length lst = 0 then
+    []
+  else
+    let filtered = List.filter (fun x -> x > 0) lst in
+    List.map (fun x -> x * 2) filtered
+`
+	ents := runOCaml(t, src, "nofp.ml")
+
+	ocamlKeywordCalls := map[string]bool{
+		"if": true, "then": true, "else": true, "let": true, "in": true,
+		"fun": true, "match": true, "with": true, "type": true, "open": true,
+	}
+
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" && ocamlKeywordCalls[r.ToID] {
+				t.Errorf("false positive CALLS edge: %s→%s (keyword should be excluded)", e.Name, r.ToID)
+			}
+		}
+	}
+}
+
+// TestOCaml_MliFile — .mli signature files are parsed (type/val declarations).
+func TestOCaml_MliFile(t *testing.T) {
+	src := `(* Module signature *)
+type t
+
+type 'a result = Ok of 'a | Error of string
+
+val create : string -> t
+
+val process : t -> int -> 'a result
+`
+	ents := runOCaml(t, src, "mymodule.mli")
+
+	comps := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = true
+		}
+	}
+
+	for _, name := range []string{"t", "result"} {
+		if !comps[name] {
+			t.Errorf("expected type %q to be extracted from .mli; got comps=%v", name, comps)
+		}
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -27,6 +27,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/lua"
 	_ "github.com/cajasmota/archigraph/internal/extractors/markdown"
 	_ "github.com/cajasmota/archigraph/internal/extractors/nim"
+	_ "github.com/cajasmota/archigraph/internal/extractors/ocaml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/php"
 	_ "github.com/cajasmota/archigraph/internal/extractors/proto"
 	_ "github.com/cajasmota/archigraph/internal/extractors/python"

--- a/internal/resolve/dynamic_patterns_ocaml.go
+++ b/internal/resolve/dynamic_patterns_ocaml.go
@@ -1,0 +1,279 @@
+package resolve
+
+import "regexp"
+
+// ocamlDynamicPatterns are per-language patterns for OCaml.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The OCaml extractor (internal/extractors/ocaml/extractor.go) emits CALLS edges
+// whose ToID is either:
+//   - a bare function name: "helper"
+//   - a module-qualified call: "List.map", "Hashtbl.add", "Lwt.bind"
+//
+// Two categories of patterns:
+//
+//  1. OCaml stdlib module-qualified identifiers — dotted names that are
+//     highly characteristic of OCaml's standard library:
+//       List: List.map, List.filter, List.fold_left, etc.
+//       Hashtbl: Hashtbl.create, Hashtbl.add, Hashtbl.find, etc.
+//       String: String.length, String.sub, String.split_on_char, etc.
+//       Option: Option.map, Option.bind, Option.value, etc.
+//       Result: Result.map, Result.bind, Result.get_ok, etc.
+//       Array: Array.map, Array.filter, Array.fold_left, etc.
+//       Functors: Map.Make, Set.Make (stdlib functor constructors)
+//       Async/Lwt: Lwt.bind, Lwt.return, Lwt_main.run, Lwt_list.map_p, etc.
+//       IO: Printf.printf, Format.printf, etc.
+//
+//  2. OCaml-gated common names — names that in OCaml context specifically
+//     refer to stdlib operations.
+//
+// All patterns are gated to lang=="ocaml" (safer-bias rule).
+var ocamlDynamicPatterns = []*regexp.Regexp{
+	// ── List module ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^List\.map$`),           // List.map f lst
+	regexp.MustCompile(`^List\.filter$`),        // List.filter pred lst
+	regexp.MustCompile(`^List\.filter_map$`),    // List.filter_map f lst
+	regexp.MustCompile(`^List\.fold_left$`),     // List.fold_left f init lst
+	regexp.MustCompile(`^List\.fold_right$`),    // List.fold_right f lst init
+	regexp.MustCompile(`^List\.iter$`),          // List.iter f lst
+	regexp.MustCompile(`^List\.iteri$`),         // List.iteri f lst
+	regexp.MustCompile(`^List\.mapi$`),          // List.mapi f lst
+	regexp.MustCompile(`^List\.for_all$`),       // List.for_all pred lst
+	regexp.MustCompile(`^List\.exists$`),        // List.exists pred lst
+	regexp.MustCompile(`^List\.find$`),          // List.find pred lst
+	regexp.MustCompile(`^List\.find_opt$`),      // List.find_opt pred lst
+	regexp.MustCompile(`^List\.assoc$`),         // List.assoc key lst
+	regexp.MustCompile(`^List\.assoc_opt$`),     // List.assoc_opt key lst
+	regexp.MustCompile(`^List\.length$`),        // List.length lst
+	regexp.MustCompile(`^List\.hd$`),            // List.hd lst
+	regexp.MustCompile(`^List\.tl$`),            // List.tl lst
+	regexp.MustCompile(`^List\.nth$`),           // List.nth lst n
+	regexp.MustCompile(`^List\.nth_opt$`),       // List.nth_opt lst n
+	regexp.MustCompile(`^List\.append$`),        // List.append lst1 lst2
+	regexp.MustCompile(`^List\.concat$`),        // List.concat lsts
+	regexp.MustCompile(`^List\.concat_map$`),    // List.concat_map f lst
+	regexp.MustCompile(`^List\.rev$`),           // List.rev lst
+	regexp.MustCompile(`^List\.rev_map$`),       // List.rev_map f lst
+	regexp.MustCompile(`^List\.sort$`),          // List.sort cmp lst
+	regexp.MustCompile(`^List\.stable_sort$`),   // List.stable_sort cmp lst
+	regexp.MustCompile(`^List\.fast_sort$`),     // List.fast_sort cmp lst
+	regexp.MustCompile(`^List\.sort_uniq$`),     // List.sort_uniq cmp lst
+	regexp.MustCompile(`^List\.mem$`),           // List.mem x lst
+	regexp.MustCompile(`^List\.memq$`),          // List.memq x lst
+	regexp.MustCompile(`^List\.flatten$`),       // List.flatten lsts
+	regexp.MustCompile(`^List\.split$`),         // List.split pairs
+	regexp.MustCompile(`^List\.combine$`),       // List.combine lst1 lst2
+	regexp.MustCompile(`^List\.partition$`),     // List.partition pred lst
+	regexp.MustCompile(`^List\.partition_map$`), // List.partition_map f lst
+	regexp.MustCompile(`^List\.init$`),          // List.init n f
+	regexp.MustCompile(`^List\.to_seq$`),        // List.to_seq lst
+	regexp.MustCompile(`^List\.of_seq$`),        // List.of_seq seq
+	regexp.MustCompile(`^List\.remove_assoc$`),  // List.remove_assoc key lst
+
+	// ── Hashtbl module ──────────────────────────────────────────────────
+	regexp.MustCompile(`^Hashtbl\.create$`),     // Hashtbl.create n
+	regexp.MustCompile(`^Hashtbl\.add$`),        // Hashtbl.add tbl key val
+	regexp.MustCompile(`^Hashtbl\.find$`),       // Hashtbl.find tbl key
+	regexp.MustCompile(`^Hashtbl\.find_opt$`),   // Hashtbl.find_opt tbl key
+	regexp.MustCompile(`^Hashtbl\.mem$`),        // Hashtbl.mem tbl key
+	regexp.MustCompile(`^Hashtbl\.remove$`),     // Hashtbl.remove tbl key
+	regexp.MustCompile(`^Hashtbl\.replace$`),    // Hashtbl.replace tbl key val
+	regexp.MustCompile(`^Hashtbl\.iter$`),       // Hashtbl.iter f tbl
+	regexp.MustCompile(`^Hashtbl\.fold$`),       // Hashtbl.fold f tbl init
+	regexp.MustCompile(`^Hashtbl\.length$`),     // Hashtbl.length tbl
+	regexp.MustCompile(`^Hashtbl\.clear$`),      // Hashtbl.clear tbl
+	regexp.MustCompile(`^Hashtbl\.copy$`),       // Hashtbl.copy tbl
+	regexp.MustCompile(`^Hashtbl\.reset$`),      // Hashtbl.reset tbl
+	regexp.MustCompile(`^Hashtbl\.to_seq$`),     // Hashtbl.to_seq tbl
+	regexp.MustCompile(`^Hashtbl\.of_seq$`),     // Hashtbl.of_seq seq
+
+	// ── String module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^String\.length$`),          // String.length s
+	regexp.MustCompile(`^String\.sub$`),             // String.sub s pos len
+	regexp.MustCompile(`^String\.concat$`),          // String.concat sep lst
+	regexp.MustCompile(`^String\.split_on_char$`),   // String.split_on_char sep s
+	regexp.MustCompile(`^String\.trim$`),            // String.trim s
+	regexp.MustCompile(`^String\.uppercase_ascii$`), // String.uppercase_ascii s
+	regexp.MustCompile(`^String\.lowercase_ascii$`), // String.lowercase_ascii s
+	regexp.MustCompile(`^String\.capitalize_ascii$`), // String.capitalize_ascii s
+	regexp.MustCompile(`^String\.contains$`),        // String.contains s c
+	regexp.MustCompile(`^String\.get$`),             // String.get s i
+	regexp.MustCompile(`^String\.make$`),            // String.make n c
+	regexp.MustCompile(`^String\.init$`),            // String.init n f
+	regexp.MustCompile(`^String\.copy$`),            // String.copy s (deprecated but present)
+	regexp.MustCompile(`^String\.index$`),           // String.index s c
+	regexp.MustCompile(`^String\.index_opt$`),       // String.index_opt s c
+	regexp.MustCompile(`^String\.rindex$`),          // String.rindex s c
+	regexp.MustCompile(`^String\.rindex_opt$`),      // String.rindex_opt s c
+	regexp.MustCompile(`^String\.to_seq$`),          // String.to_seq s
+	regexp.MustCompile(`^String\.of_seq$`),          // String.of_seq seq
+	regexp.MustCompile(`^String\.starts_with$`),     // String.starts_with ~prefix s
+	regexp.MustCompile(`^String\.ends_with$`),       // String.ends_with ~suffix s
+
+	// ── Option module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Option\.map$`),         // Option.map f opt
+	regexp.MustCompile(`^Option\.bind$`),        // Option.bind opt f
+	regexp.MustCompile(`^Option\.value$`),       // Option.value opt ~default
+	regexp.MustCompile(`^Option\.get$`),         // Option.get opt
+	regexp.MustCompile(`^Option\.fold$`),        // Option.fold ~none ~some opt
+	regexp.MustCompile(`^Option\.iter$`),        // Option.iter f opt
+	regexp.MustCompile(`^Option\.is_none$`),     // Option.is_none opt
+	regexp.MustCompile(`^Option\.is_some$`),     // Option.is_some opt
+	regexp.MustCompile(`^Option\.to_result$`),   // Option.to_result ~none opt
+	regexp.MustCompile(`^Option\.to_list$`),     // Option.to_list opt
+	regexp.MustCompile(`^Option\.to_seq$`),      // Option.to_seq opt
+	regexp.MustCompile(`^Option\.equal$`),       // Option.equal f opt1 opt2
+	regexp.MustCompile(`^Option\.compare$`),     // Option.compare f opt1 opt2
+
+	// ── Result module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Result\.map$`),         // Result.map f r
+	regexp.MustCompile(`^Result\.map_error$`),   // Result.map_error f r
+	regexp.MustCompile(`^Result\.bind$`),        // Result.bind r f
+	regexp.MustCompile(`^Result\.fold$`),        // Result.fold ~ok ~error r
+	regexp.MustCompile(`^Result\.iter$`),        // Result.iter f r
+	regexp.MustCompile(`^Result\.iter_error$`),  // Result.iter_error f r
+	regexp.MustCompile(`^Result\.is_ok$`),       // Result.is_ok r
+	regexp.MustCompile(`^Result\.is_error$`),    // Result.is_error r
+	regexp.MustCompile(`^Result\.get_ok$`),      // Result.get_ok r
+	regexp.MustCompile(`^Result\.get_error$`),   // Result.get_error r
+	regexp.MustCompile(`^Result\.to_option$`),   // Result.to_option r
+	regexp.MustCompile(`^Result\.to_list$`),     // Result.to_list r
+	regexp.MustCompile(`^Result\.to_seq$`),      // Result.to_seq r
+	regexp.MustCompile(`^Result\.equal$`),       // Result.equal ok_eq err_eq r1 r2
+	regexp.MustCompile(`^Result\.compare$`),     // Result.compare ok_cmp err_cmp r1 r2
+
+	// ── Array module ────────────────────────────────────────────────────
+	regexp.MustCompile(`^Array\.map$`),          // Array.map f arr
+	regexp.MustCompile(`^Array\.filter$`),       // Array.filter pred arr
+	regexp.MustCompile(`^Array\.filter_map$`),   // Array.filter_map f arr
+	regexp.MustCompile(`^Array\.fold_left$`),    // Array.fold_left f init arr
+	regexp.MustCompile(`^Array\.fold_right$`),   // Array.fold_right f arr init
+	regexp.MustCompile(`^Array\.iter$`),         // Array.iter f arr
+	regexp.MustCompile(`^Array\.iteri$`),        // Array.iteri f arr
+	regexp.MustCompile(`^Array\.mapi$`),         // Array.mapi f arr
+	regexp.MustCompile(`^Array\.for_all$`),      // Array.for_all pred arr
+	regexp.MustCompile(`^Array\.exists$`),       // Array.exists pred arr
+	regexp.MustCompile(`^Array\.find$`),         // Array.find pred arr
+	regexp.MustCompile(`^Array\.find_opt$`),     // Array.find_opt pred arr
+	regexp.MustCompile(`^Array\.length$`),       // Array.length arr
+	regexp.MustCompile(`^Array\.get$`),          // Array.get arr i
+	regexp.MustCompile(`^Array\.set$`),          // Array.set arr i v
+	regexp.MustCompile(`^Array\.make$`),         // Array.make n x
+	regexp.MustCompile(`^Array\.init$`),         // Array.init n f
+	regexp.MustCompile(`^Array\.copy$`),         // Array.copy arr
+	regexp.MustCompile(`^Array\.sub$`),          // Array.sub arr pos len
+	regexp.MustCompile(`^Array\.append$`),       // Array.append arr1 arr2
+	regexp.MustCompile(`^Array\.concat$`),       // Array.concat arrs
+	regexp.MustCompile(`^Array\.sort$`),         // Array.sort cmp arr
+	regexp.MustCompile(`^Array\.stable_sort$`),  // Array.stable_sort cmp arr
+	regexp.MustCompile(`^Array\.to_list$`),      // Array.to_list arr
+	regexp.MustCompile(`^Array\.of_list$`),      // Array.of_list lst
+	regexp.MustCompile(`^Array\.to_seq$`),       // Array.to_seq arr
+	regexp.MustCompile(`^Array\.of_seq$`),       // Array.of_seq seq
+
+	// ── Functor constructors (Map.Make, Set.Make) ──────────────────────
+	regexp.MustCompile(`^Map\.Make$`),           // Map.Make(OrderedType)
+	regexp.MustCompile(`^Map\.find$`),           // Map.find key m (after Make)
+	regexp.MustCompile(`^Map\.add$`),            // Map.add key val m
+	regexp.MustCompile(`^Map\.remove$`),         // Map.remove key m
+	regexp.MustCompile(`^Map\.mem$`),            // Map.mem key m
+	regexp.MustCompile(`^Map\.empty$`),          // Map.empty
+	regexp.MustCompile(`^Map\.singleton$`),      // Map.singleton key val
+	regexp.MustCompile(`^Map\.iter$`),           // Map.iter f m
+	regexp.MustCompile(`^Map\.fold$`),           // Map.fold f m init
+	regexp.MustCompile(`^Map\.map$`),            // Map.map f m
+	regexp.MustCompile(`^Map\.filter$`),         // Map.filter pred m
+	regexp.MustCompile(`^Map\.mapi$`),           // Map.mapi f m
+	regexp.MustCompile(`^Map\.merge$`),          // Map.merge f m1 m2
+	regexp.MustCompile(`^Map\.union$`),          // Map.union f m1 m2
+	regexp.MustCompile(`^Map\.bindings$`),       // Map.bindings m
+	regexp.MustCompile(`^Map\.cardinal$`),       // Map.cardinal m
+	regexp.MustCompile(`^Map\.find_opt$`),       // Map.find_opt key m
+	regexp.MustCompile(`^Set\.Make$`),           // Set.Make(OrderedType)
+	regexp.MustCompile(`^Set\.add$`),            // Set.add x s
+	regexp.MustCompile(`^Set\.remove$`),         // Set.remove x s
+	regexp.MustCompile(`^Set\.mem$`),            // Set.mem x s
+	regexp.MustCompile(`^Set\.empty$`),          // Set.empty
+	regexp.MustCompile(`^Set\.singleton$`),      // Set.singleton x
+	regexp.MustCompile(`^Set\.union$`),          // Set.union s1 s2
+	regexp.MustCompile(`^Set\.inter$`),          // Set.inter s1 s2
+	regexp.MustCompile(`^Set\.diff$`),           // Set.diff s1 s2
+	regexp.MustCompile(`^Set\.iter$`),           // Set.iter f s
+	regexp.MustCompile(`^Set\.fold$`),           // Set.fold f s init
+	regexp.MustCompile(`^Set\.filter$`),         // Set.filter pred s
+	regexp.MustCompile(`^Set\.cardinal$`),       // Set.cardinal s
+	regexp.MustCompile(`^Set\.elements$`),       // Set.elements s
+	regexp.MustCompile(`^Set\.of_list$`),        // Set.of_list lst
+	regexp.MustCompile(`^Set\.to_list$`),        // Set.to_list s
+
+	// ── Lwt async library ───────────────────────────────────────────────
+	regexp.MustCompile(`^Lwt\.bind$`),           // Lwt.bind t f  (or >>= operator)
+	regexp.MustCompile(`^Lwt\.return$`),         // Lwt.return v
+	regexp.MustCompile(`^Lwt\.return_unit$`),    // Lwt.return_unit
+	regexp.MustCompile(`^Lwt\.return_none$`),    // Lwt.return_none
+	regexp.MustCompile(`^Lwt\.return_some$`),    // Lwt.return_some v
+	regexp.MustCompile(`^Lwt\.return_ok$`),      // Lwt.return_ok v
+	regexp.MustCompile(`^Lwt\.return_error$`),   // Lwt.return_error e
+	regexp.MustCompile(`^Lwt\.map$`),            // Lwt.map f t
+	regexp.MustCompile(`^Lwt\.both$`),           // Lwt.both t1 t2
+	regexp.MustCompile(`^Lwt\.join$`),           // Lwt.join ts
+	regexp.MustCompile(`^Lwt\.all$`),            // Lwt.all ts
+	regexp.MustCompile(`^Lwt\.pick$`),           // Lwt.pick ts
+	regexp.MustCompile(`^Lwt\.choose$`),         // Lwt.choose ts
+	regexp.MustCompile(`^Lwt\.catch$`),          // Lwt.catch f handler
+	regexp.MustCompile(`^Lwt\.finalize$`),       // Lwt.finalize t f
+	regexp.MustCompile(`^Lwt\.try_bind$`),       // Lwt.try_bind f ok err
+	regexp.MustCompile(`^Lwt\.async$`),          // Lwt.async f
+	regexp.MustCompile(`^Lwt\.dont_wait$`),      // Lwt.dont_wait f
+	regexp.MustCompile(`^Lwt\.pause$`),          // Lwt.pause ()
+	regexp.MustCompile(`^Lwt\.fail$`),           // Lwt.fail exn
+	regexp.MustCompile(`^Lwt\.fail_with$`),      // Lwt.fail_with msg
+	regexp.MustCompile(`^Lwt_main\.run$`),       // Lwt_main.run t
+	regexp.MustCompile(`^Lwt_list\.map_p$`),     // Lwt_list.map_p f lst
+	regexp.MustCompile(`^Lwt_list\.map_s$`),     // Lwt_list.map_s f lst
+	regexp.MustCompile(`^Lwt_list\.iter_p$`),    // Lwt_list.iter_p f lst
+	regexp.MustCompile(`^Lwt_list\.iter_s$`),    // Lwt_list.iter_s f lst
+	regexp.MustCompile(`^Lwt_list\.filter_p$`),  // Lwt_list.filter_p pred lst
+	regexp.MustCompile(`^Lwt_list\.filter_s$`),  // Lwt_list.filter_s pred lst
+	regexp.MustCompile(`^Lwt_list\.fold_left_s$`), // Lwt_list.fold_left_s f init lst
+	regexp.MustCompile(`^Lwt_unix\.sleep$`),     // Lwt_unix.sleep t
+	regexp.MustCompile(`^Lwt_unix\.openfile$`),  // Lwt_unix.openfile path flags perm
+	regexp.MustCompile(`^Lwt_unix\.close$`),     // Lwt_unix.close fd
+	regexp.MustCompile(`^Lwt_unix\.read$`),      // Lwt_unix.read fd buf off len
+	regexp.MustCompile(`^Lwt_unix\.write$`),     // Lwt_unix.write fd buf off len
+	regexp.MustCompile(`^Lwt_io\.read_line$`),   // Lwt_io.read_line ic
+	regexp.MustCompile(`^Lwt_io\.write_line$`),  // Lwt_io.write_line oc s
+	regexp.MustCompile(`^Lwt_io\.printf$`),      // Lwt_io.printf fmt args
+
+	// ── Printf / Format / IO ────────────────────────────────────────────
+	regexp.MustCompile(`^Printf\.printf$`),      // Printf.printf fmt args
+	regexp.MustCompile(`^Printf\.sprintf$`),     // Printf.sprintf fmt args
+	regexp.MustCompile(`^Printf\.fprintf$`),     // Printf.fprintf oc fmt args
+	regexp.MustCompile(`^Printf\.eprintf$`),     // Printf.eprintf fmt args
+	regexp.MustCompile(`^Format\.printf$`),      // Format.printf fmt args
+	regexp.MustCompile(`^Format\.sprintf$`),     // Format.sprintf fmt args
+	regexp.MustCompile(`^Format\.fprintf$`),     // Format.fprintf ppf fmt args
+	regexp.MustCompile(`^Format\.eprintf$`),     // Format.eprintf fmt args
+	regexp.MustCompile(`^Format\.pp_print_string$`), // Format.pp_print_string ppf s
+	regexp.MustCompile(`^Format\.pp_print_int$`), // Format.pp_print_int ppf n
+	regexp.MustCompile(`^Format\.pp_print_list$`), // Format.pp_print_list sep pp ppf lst
+
+	// ── Bytes / Buffer ──────────────────────────────────────────────────
+	regexp.MustCompile(`^Bytes\.create$`),       // Bytes.create n
+	regexp.MustCompile(`^Bytes\.length$`),       // Bytes.length b
+	regexp.MustCompile(`^Bytes\.get$`),          // Bytes.get b i
+	regexp.MustCompile(`^Bytes\.set$`),          // Bytes.set b i c
+	regexp.MustCompile(`^Bytes\.copy$`),         // Bytes.copy b
+	regexp.MustCompile(`^Bytes\.to_string$`),    // Bytes.to_string b
+	regexp.MustCompile(`^Bytes\.of_string$`),    // Bytes.of_string s
+	regexp.MustCompile(`^Buffer\.create$`),      // Buffer.create n
+	regexp.MustCompile(`^Buffer\.add_string$`),  // Buffer.add_string b s
+	regexp.MustCompile(`^Buffer\.add_char$`),    // Buffer.add_char b c
+	regexp.MustCompile(`^Buffer\.contents$`),    // Buffer.contents b
+	regexp.MustCompile(`^Buffer\.length$`),      // Buffer.length b
+	regexp.MustCompile(`^Buffer\.clear$`),       // Buffer.clear b
+}
+
+func init() {
+	dynamicPatternsByLang["ocaml"] = ocamlDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Implements full OCaml language support (`.ml` / `.mli` files) as specified in #1034.

- **Extractor** (`internal/extractors/ocaml/extractor.go`): regex-based, no tree-sitter dependency. Emits:
  - `module Foo = struct ... end` / `module type Foo = sig ... end` → `SCOPE.Component(subtype=module)`
  - `let`/`let rec` top-level bindings → `SCOPE.Operation(subtype=function)`
  - `type` declarations (ADTs, records, aliases, `.mli` stubs) → `SCOPE.Component(subtype=type)`
  - `open Foo` → `IMPORTS` edges
  - Qualified (`List.map`) and bare function calls → `CALLS` edges (deduped)
  - Module `CONTAINS` edges to nested `let` bindings
- **Tests** (`internal/extractors/ocaml/extractor_test.go`): 12 tests covering registration, empty input, module/function/type discovery, `open` imports, CALLS edges, dedup, language tagging, `.mli` signatures, no-false-positives guard, and the Lwt async CLI fixture
- **Classifier** (`internal/classifier/classifier.go`): `.ml` / `.mli` → `"ocaml"` (SML claimed for OCaml per scope)
- **Registry** (`internal/extractors/registry_gen.go`): blank-import added
- **Resolver slice** (`internal/resolve/dynamic_patterns_ocaml.go`): ~170 patterns covering `List`, `Hashtbl`, `String`, `Option`, `Result`, `Array`, `Map.Make`, `Set.Make`, `Lwt`/`Lwt_main`/`Lwt_list`/`Lwt_unix`/`Lwt_io`, `Printf`, `Format`, `Bytes`, `Buffer`

## Closes / Refs

- Closes #1034
- Refs #44

## Testing

- [x] All tests pass: `go test ./internal/...` — 12/12 new tests pass; no regressions
- [x] Lwt async CLI fixture: **100% recall (15/15)** — ops 9/9, types 3/3, imports 3/3 (≥80% threshold met)
- [x] `TestOCaml_NoFalsePositives` confirms 0 keyword false-positives
- [x] `TestOCaml_MliFile` confirms `.mli` signature file parsing
- [x] Classifier, resolve, and existing extractor tests all pass

## Notes

- `extractModuleBody` uses depth-counted `struct`/`sig`/`object`/`begin`…`end` matching with indentation fallback
- `stripStringsAndComments` handles nested OCaml `(* ... *)` block comments (depth-counted) and double-quoted strings
- `.ml` extension is claimed for OCaml; SML is much less common in practice