### PR TITLE
[#1040] Add ReasonML language extractor

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -444,6 +444,9 @@ var extensionLanguageMap = map[string]string{
 	".fsi":    "fsharp",
 	".fsx":    "fsharp",
 	".fsproj": "fsharp",
+	// ReasonML
+	".re":  "reasonml",
+	".rei": "reasonml",
 	// Lua
 	".lua": "lua",
 	// SQL

--- a/internal/extractors/reasonml/extractor.go
+++ b/internal/extractors/reasonml/extractor.go
@@ -1,0 +1,552 @@
+// Package reasonml implements a regex-based extractor for ReasonML source files.
+//
+// ReasonML is OCaml with curly-brace syntax — the same type system and runtime,
+// but JavaScript/C-family surface syntax.  File extensions: .re (implementation),
+// .rei (interface/signature).
+//
+// Extracted entities:
+//   - module declarations: "module Foo = {" or "module Foo: Bar = {"
+//     → Kind="SCOPE.Component", Subtype="module"
+//   - let function bindings: "let foo = (x) => x + 1;"
+//     → Kind="SCOPE.Operation", Subtype="let"
+//   - type declarations (record, variant, alias):
+//     "type person = { name: string, age: int };"
+//     "type shape = Circle(float) | Square(float);"
+//     → Kind="SCOPE.Component"
+//   - open statements: "open Belt;" or "open React;"
+//     → IMPORTS edges
+//   - function calls (direct and pipe |>)
+//     → CALLS edges
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package reasonml
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("reasonml", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for ReasonML.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "reasonml" }
+
+// Regex patterns for ReasonML syntax.
+var (
+	// module declaration: "module Foo = {" or "module Foo: SomeType = {"
+	// Also matches interface modules in .rei: "module Foo: { ... }"
+	moduleRE = regexp.MustCompile(
+		`(?m)^([ \t]*)module\s+([A-Z][a-zA-Z0-9_]*)\s*(?::[^=\n]*)?\s*=\s*\{`,
+	)
+
+	// let binding (function or value): "let foo = (x) => ..." or "let foo = ..."
+	// Captures indentation and name. ReasonML functions use => arrow.
+	letRE = regexp.MustCompile(
+		`(?m)^([ \t]*)let\s+(?:rec\s+)?([a-zA-Z_][a-zA-Z0-9_]*)\s*(?::[^=\n]*)?\s*=`,
+	)
+
+	// type declaration: "type person = {" or "type shape =" or "type t = string;"
+	// Type names in ReasonML are typically lowercase (unlike OCaml/F# convention).
+	typeRE = regexp.MustCompile(
+		`(?m)^([ \t]*)type\s+([a-zA-Z_][a-zA-Z0-9_']*)\s*(?:<[^>]*>)?\s*(?:[a-zA-Z_][a-zA-Z0-9_',\s]*)?\s*=`,
+	)
+
+	// Abstract type declaration (no "="): "type t;" common in .rei interface files
+	abstractTypeRE = regexp.MustCompile(
+		`(?m)^([ \t]*)type\s+([a-zA-Z_][a-zA-Z0-9_']*)\s*;`,
+	)
+
+	// open statement: "open Belt;" or "open React"
+	openRE = regexp.MustCompile(
+		`(?m)^[ \t]*open\s+([\w.]+)\s*;?`,
+	)
+
+	// function call: identifier( or Module.function(
+	callRE = regexp.MustCompile(
+		`(?:^|[^\w.'"])([A-Za-z_][A-Za-z0-9_.]*)(?:\s*\()`,
+	)
+
+	// pipe operator call: |> identifier or |> Module.name
+	pipeCallRE = regexp.MustCompile(
+		`\|>\s*([A-Za-z_][A-Za-z0-9_.]*)`,
+	)
+)
+
+// reasonmlKeywords are tokens the call regex picks up but are not real calls.
+var reasonmlKeywords = map[string]bool{
+	"if": true, "else": true, "switch": true, "while": true, "for": true,
+	"try": true, "catch": true,
+	"let": true, "in": true, "and": true,
+	"type": true, "open": true, "module": true,
+	"include": true, "functor": true,
+	"true": true, "false": true,
+	"fun": true, "function": true,
+	"exception": true, "raise": true,
+	// JSX / React
+	"make": false, // "make" is a common ReasonReact component entry point — keep
+}
+
+// Extract processes ReasonML source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractReasonML(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "reasonml")
+	return out, nil
+}
+
+func extractReasonML(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	imports := collectOpenStatements(src)
+	importEntities := buildImportEntities(filePath, imports)
+	entities = append(entities, importEntities...)
+
+	// 1. Module declarations → SCOPE.Component
+	seen := make(map[string]bool)
+	for _, m := range moduleRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		key := "module:" + name
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		// Find closing brace to estimate end line
+		body := extractBraceBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "module",
+			SourceFile: filePath,
+			Language:   "reasonml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "module " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 2. let bindings → SCOPE.Operation
+	letSeen := make(map[string]bool)
+	for _, m := range letRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		indent := src[m[2]:m[3]]
+		name := src[m[4]:m[5]]
+		key := indent + ":let:" + name
+		if letSeen[key] {
+			continue
+		}
+		letSeen[key] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		// Extract body until semicolon at base indent or next let at same indent
+		body := extractLetBody(src, m[1], len(indent))
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "let",
+			SourceFile: filePath,
+			Language:   "reasonml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  buildLetSig(src[m[0]:m[1]], name),
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+			Relationships: calls,
+		})
+	}
+
+	// 3. type declarations → SCOPE.Component
+	typeSeen := make(map[string]bool)
+	for _, m := range typeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		if typeSeen[name] {
+			continue
+		}
+		typeSeen[name] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		// Pass the raw suffix (after "=") for both body extraction and subtype
+		rawSuffix := src[m[1]:]
+		body := extractTypeBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		subtype := classifyTypeSubtype(rawSuffix)
+
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    subtype,
+			SourceFile: filePath,
+			Language:   "reasonml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "type " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 4. Abstract type declarations (no "=", e.g. "type t;" in .rei files)
+	for _, m := range abstractTypeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		name := src[m[4]:m[5]]
+		if typeSeen[name] {
+			continue
+		}
+		typeSeen[name] = true
+
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "abstract",
+			SourceFile: filePath,
+			Language:   "reasonml",
+			StartLine:  startLine,
+			EndLine:    startLine,
+			Signature:  "type " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	return entities
+}
+
+// classifyTypeSubtype determines the ReasonML type subtype from the raw text
+// after the "=" in the type declaration.
+func classifyTypeSubtype(suffix string) string {
+	trimmed := strings.TrimSpace(suffix)
+	// Record type: starts with "{"
+	if strings.HasPrefix(trimmed, "{") {
+		return "record"
+	}
+	// Variant type: starts with "|" or contains " | "
+	if strings.HasPrefix(trimmed, "|") || strings.Contains(trimmed, " | ") || strings.Contains(trimmed, "\n  |") {
+		return "variant"
+	}
+	return "type"
+}
+
+// buildLetSig builds a signature string from the raw declaration.
+func buildLetSig(decl, name string) string {
+	sig := strings.TrimSpace(decl)
+	if idx := strings.Index(sig, "="); idx >= 0 {
+		sig = strings.TrimSpace(sig[:idx])
+	}
+	if sig == "" {
+		return "let " + name
+	}
+	return sig
+}
+
+// collectOpenStatements parses "open" statements and returns unique module paths.
+func collectOpenStatements(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+	for _, m := range openRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		mod := strings.TrimRight(strings.TrimSpace(m[1]), ";")
+		if mod == "" || seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		imports = append(imports, mod)
+	}
+	return imports
+}
+
+// buildImportEntities creates SCOPE.Component stubs carrying IMPORTS edges.
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		out = append(out, types.EntityRecord{
+			Name:       importDisplayName(mod),
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "reasonml",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+// importDisplayName returns a short display name for an import path.
+func importDisplayName(mod string) string {
+	mod = strings.TrimSpace(mod)
+	if dot := strings.LastIndexByte(mod, '.'); dot >= 0 {
+		return mod[dot+1:]
+	}
+	return mod
+}
+
+// extractBraceBody returns text between a "{" and its matching "}".
+// afterPos should be the position right after the opening "{".
+func extractBraceBody(src string, afterPos int) string {
+	if afterPos >= len(src) {
+		return ""
+	}
+	// Find opening brace
+	openPos := strings.IndexByte(src[afterPos-1:], '{')
+	if openPos < 0 {
+		return ""
+	}
+	start := afterPos - 1 + openPos + 1
+
+	depth := 1
+	i := start
+	for i < len(src) && depth > 0 {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+		}
+		i++
+	}
+	if i > start {
+		return src[start:i]
+	}
+	return ""
+}
+
+// extractLetBody returns the body of a let binding.
+// Collects until a semicolon at base indent level or next top-level binding.
+func extractLetBody(src string, afterPos int, baseIndentLen int) string {
+	rest := src[afterPos:]
+	lines := strings.Split(rest, "\n")
+	if len(lines) == 0 {
+		return ""
+	}
+
+	var bodyLines []string
+	for i, line := range lines {
+		if i == 0 {
+			bodyLines = append(bodyLines, line)
+			// Single-line binding ending with ";"
+			if strings.HasSuffix(strings.TrimSpace(line), ";") {
+				break
+			}
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			bodyLines = append(bodyLines, line)
+			continue
+		}
+		indent := countIndent(line)
+		if indent <= baseIndentLen && trimmed != "" {
+			// Same or lesser indent — end of this binding
+			break
+		}
+		bodyLines = append(bodyLines, line)
+		// End on a line that closes with ";" at reasonable indent
+		if strings.HasSuffix(trimmed, ";") && indent <= baseIndentLen+2 {
+			break
+		}
+	}
+	return strings.Join(bodyLines, "\n")
+}
+
+// extractTypeBody returns the body after a type declaration's "=".
+func extractTypeBody(src string, afterPos int) string {
+	if afterPos >= len(src) {
+		return ""
+	}
+	rest := src[afterPos:]
+	// If starts with "{", extract brace body
+	trimmed := strings.TrimSpace(rest)
+	if strings.HasPrefix(trimmed, "{") {
+		idx := strings.IndexByte(rest, '{')
+		return extractBraceBody(src, afterPos+idx+1)
+	}
+	// Otherwise collect until ";"
+	lines := strings.Split(rest, "\n")
+	var bodyLines []string
+	for _, line := range lines {
+		bodyLines = append(bodyLines, line)
+		if strings.HasSuffix(strings.TrimSpace(line), ";") {
+			break
+		}
+	}
+	return strings.Join(bodyLines, "\n")
+}
+
+// countIndent counts leading spaces/tabs.
+func countIndent(line string) int {
+	n := 0
+	for _, ch := range line {
+		if ch == ' ' || ch == '\t' {
+			n++
+		} else {
+			break
+		}
+	}
+	return n
+}
+
+// collectCalls extracts CALLS edges from a function body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripStringsAndComments(body)
+
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+
+	addCall := func(target string) {
+		if target == "" || callerName == target {
+			return
+		}
+		if reasonmlKeywords[target] {
+			return
+		}
+		// Skip single-letter identifiers (usually type params or pattern vars)
+		if len(target) == 1 {
+			return
+		}
+		if seen[target] {
+			return
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	// Direct calls: name(
+	for _, m := range callRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	// Pipe operator: |> name or |> Module.name
+	for _, m := range pipeCallRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	return out
+}
+
+// stripStringsAndComments replaces string literals and line comments with spaces.
+func stripStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := byte(0) // 0=none, '"'=double-quote
+	for i < len(src) {
+		ch := src[i]
+		if inStr != 0 {
+			out[i] = ' '
+			if ch == '\\' && i+1 < len(src) {
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == inStr {
+				inStr = 0
+			}
+			i++
+			continue
+		}
+		switch ch {
+		case '"':
+			inStr = '"'
+			out[i] = ' '
+			i++
+		case '\'':
+			// ReasonML character literals: 'a'
+			if i+2 < len(src) && src[i+2] == '\'' {
+				out[i] = ' '
+				out[i+1] = ' '
+				out[i+2] = ' '
+				i += 3
+				continue
+			}
+			out[i] = ch
+			i++
+		case '/':
+			// ReasonML line comment: //
+			if i+1 < len(src) && src[i+1] == '/' {
+				for i < len(src) && src[i] != '\n' {
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			// Block comment: /* ... */
+			if i+1 < len(src) && src[i+1] == '*' {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				for i < len(src) {
+					if i+1 < len(src) && src[i] == '*' && src[i+1] == '/' {
+						out[i] = ' '
+						out[i+1] = ' '
+						i += 2
+						break
+					}
+					out[i] = ' '
+					i++
+				}
+				continue
+			}
+			out[i] = ch
+			i++
+		default:
+			out[i] = ch
+			i++
+		}
+	}
+	return string(out)
+}

--- a/internal/extractors/reasonml/reasonml_test.go
+++ b/internal/extractors/reasonml/reasonml_test.go
@@ -1,0 +1,473 @@
+package reasonml_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/reasonml"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runReasonML runs the extractor on raw source and returns entity records.
+func runReasonML(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("reasonml")
+	if !ok {
+		t.Fatal("reasonml extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "reasonml",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func reFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func reHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestReasonML_Registered verifies the extractor is in the registry.
+func TestReasonML_Registered(t *testing.T) {
+	_, ok := extractor.Get("reasonml")
+	if !ok {
+		t.Fatal("reasonml extractor not registered")
+	}
+}
+
+// TestReasonML_EmptyInput returns zero entities for empty content.
+func TestReasonML_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("reasonml")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.re",
+		Content:  []byte{},
+		Language: "reasonml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestReasonML_ModuleDiscovery — module declarations extracted as SCOPE.Component.
+func TestReasonML_ModuleDiscovery(t *testing.T) {
+	src := `open Belt;
+
+module Utils = {
+  let double = (x) => x * 2;
+  let triple = (x) => x * 3;
+};
+`
+	ents := runReasonML(t, src, "utils.re")
+	if reFind(ents, "Utils", "SCOPE.Component") == nil {
+		t.Error("expected module Utils as SCOPE.Component")
+	}
+}
+
+// TestReasonML_LetBindings — let functions extracted as SCOPE.Operation.
+func TestReasonML_LetBindings(t *testing.T) {
+	src := `let add = (a, b) => a + b;
+
+let rec factorial = (n) =>
+  if (n <= 1) { 1 } else { n * factorial(n - 1) };
+
+let greet = (name) => {
+  let msg = "Hello, " ++ name;
+  Js.log(msg);
+};
+`
+	ents := runReasonML(t, src, "funcs.re")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "reasonml" {
+				t.Errorf("entity %q: expected Language=reasonml, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"add", "factorial", "greet"} {
+		if !ops[want] {
+			t.Errorf("expected function %q to be extracted as SCOPE.Operation", want)
+		}
+	}
+}
+
+// TestReasonML_TypeDiscovery — type declarations extracted as SCOPE.Component.
+func TestReasonML_TypeDiscovery(t *testing.T) {
+	src := `type person = {
+  name: string,
+  age: int,
+};
+
+type shape =
+  | Circle(float)
+  | Square(float)
+  | Rectangle(float, float);
+
+type status = Active | Inactive;
+`
+	ents := runReasonML(t, src, "types.re")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	wantTypes := []string{"person", "shape", "status"}
+	for _, name := range wantTypes {
+		if _, ok := comps[name]; !ok {
+			t.Errorf("expected type %q to be extracted as SCOPE.Component", name)
+		}
+	}
+
+	// Check subtypes
+	if comps["person"] != "record" {
+		t.Errorf("expected person subtype=record, got %q", comps["person"])
+	}
+}
+
+// TestReasonML_OpenStatements — open statements emit IMPORTS edges.
+func TestReasonML_OpenStatements(t *testing.T) {
+	src := `open Belt;
+open React;
+open ReactDOMRe;
+
+let make = (~name) => {
+  <div>{React.string(name)}</div>
+};
+`
+	ents := runReasonML(t, src, "comp.re")
+
+	wantImports := map[string]bool{
+		"Belt":        false,
+		"React":       false,
+		"ReactDOMRe":  false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "comp.re" {
+						t.Errorf("IMPORTS %q: expected FromID=comp.re, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestReasonML_CallsEdges — function calls emit CALLS edges.
+func TestReasonML_CallsEdges(t *testing.T) {
+	src := `let helper = (x) => x * 2;
+
+let caller = (n) => {
+  let result = helper(n);
+  Js.log(result);
+  result;
+};
+`
+	ents := runReasonML(t, src, "calls.re")
+
+	if !reHasRel(ents, "caller", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS caller→helper")
+	}
+}
+
+// TestReasonML_PipeOperatorCalls — |> chains emit CALLS edges.
+func TestReasonML_PipeOperatorCalls(t *testing.T) {
+	src := `let processData = (data) =>
+  data
+  |> Belt.List.map((x) => x * 2)
+  |> Belt.List.filter((x) => x > 0);
+`
+	ents := runReasonML(t, src, "pipes.re")
+
+	hasPipeCall := false
+	for _, e := range ents {
+		if e.Name == "processData" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && (r.ToID == "Belt.List.map" || r.ToID == "Belt.List.filter") {
+					hasPipeCall = true
+				}
+			}
+		}
+	}
+	if !hasPipeCall {
+		t.Error("expected CALLS edges from pipe |> operator targets")
+	}
+}
+
+// TestReasonML_SelfRecursionExcluded — self-recursive calls not emitted.
+func TestReasonML_SelfRecursionExcluded(t *testing.T) {
+	src := `let rec fib = (n) =>
+  if (n <= 1) { n } else { fib(n - 1) + fib(n - 2) };
+`
+	ents := runReasonML(t, src, "fib.re")
+	if reHasRel(ents, "fib", "SCOPE.Operation", "CALLS", "fib") {
+		t.Error("self-recursion CALLS should be filtered")
+	}
+}
+
+// TestReasonML_LanguageTagged — all relationships carry language=reasonml.
+func TestReasonML_LanguageTagged(t *testing.T) {
+	src := `open Belt;
+
+type node = { value: int };
+
+let process = (n: node) => n.value;
+`
+	ents := runReasonML(t, src, "tag.re")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "reasonml" {
+				t.Errorf("rel %s→%s missing language=reasonml (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestReasonML_ReactReasonFixture — synthetic React-Reason fixture for entity recall.
+// This is the primary acceptance test: must hit ≥80% entity recall with 0 false positives.
+func TestReasonML_ReactReasonFixture(t *testing.T) {
+	src := `open Belt;
+open React;
+open ReactDOMRe;
+
+/* Types */
+type user = {
+  id: int,
+  name: string,
+  email: string,
+};
+
+type appState = {
+  users: list(user),
+  loading: bool,
+  error: option(string),
+};
+
+type action =
+  | FetchUsers
+  | FetchUsersSuccess(list(user))
+  | FetchUsersFailure(string)
+  | DeleteUser(int);
+
+/* Helpers */
+let makeUser = (id, name, email) => { id, name, email };
+
+let filterActiveUsers = (users) =>
+  users |> Belt.List.filter((u) => u.id > 0);
+
+let userById = (users, id) =>
+  users |> Belt.List.getBy((u) => u.id == id);
+
+/* Reducer */
+let reducer = (state, action) =>
+  switch (action) {
+  | FetchUsers => { ...state, loading: true }
+  | FetchUsersSuccess(users) => { users, loading: false, error: None }
+  | FetchUsersFailure(msg) => { ...state, loading: false, error: Some(msg) }
+  | DeleteUser(id) => {
+      ...state,
+      users: Belt.List.keep(state.users, (u) => u.id !== id),
+    }
+  };
+
+/* React components */
+let make = (~initialUsers=[]) => {
+  let (state, dispatch) = React.useReducer(reducer, {
+    users: initialUsers,
+    loading: false,
+    error: None,
+  });
+
+  let handleDelete = (id) => dispatch(DeleteUser(id));
+
+  let handleFetch = () => {
+    dispatch(FetchUsers);
+    Js.Promise.(
+      Fetch.fetch("/api/users")
+      |> then_(Fetch.Response.json)
+      |> then_((json) => {
+           dispatch(FetchUsersSuccess([]));
+           resolve(json);
+         })
+      |> catch((err) => {
+           dispatch(FetchUsersFailure("Network error"));
+           resolve(Js.Json.null);
+         })
+    );
+  };
+
+  <div className="app">
+    <h1>{React.string("Users")}</h1>
+    {state.loading ? <div>{React.string("Loading...")}</div> : React.null}
+    <button onClick={(_) => handleFetch()}>
+      {React.string("Fetch Users")}
+    </button>
+  </div>;
+};
+
+/* Entry point */
+let renderApp = () =>
+  ReactDOMRe.renderToElementWithId(<make />, "root");
+`
+	ents := runReasonML(t, src, "App.re")
+
+	wantOps := []string{"makeUser", "filterActiveUsers", "userById", "reducer", "make", "renderApp"}
+	wantComps := []string{"user", "appState", "action"}
+	wantImports := []string{"Belt", "React", "ReactDOMRe"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("ReactReason fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}
+
+// TestReasonML_BeltCalls — Belt stdlib calls extracted correctly.
+func TestReasonML_BeltCalls(t *testing.T) {
+	src := `open Belt;
+
+let processItems = (items) => {
+  let doubled = Belt.Array.map(items, (x) => x * 2);
+  let filtered = Belt.Array.keep(doubled, (x) => x > 0);
+  let total = Belt.Array.reduce(filtered, 0, (acc, x) => acc + x);
+  total;
+};
+
+let lookupUser = (map, key) =>
+  Belt.Map.get(map, key)
+  |> Belt.Option.getWithDefault("unknown");
+`
+	ents := runReasonML(t, src, "belt.re")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+		}
+	}
+
+	for _, want := range []string{"processItems", "lookupUser"} {
+		if !ops[want] {
+			t.Errorf("expected function %q extracted", want)
+		}
+	}
+}
+
+// TestReasonML_InterfaceFile — .rei interface files extract types/module sigs.
+func TestReasonML_InterfaceFile(t *testing.T) {
+	src := `type t;
+
+type config = {
+  host: string,
+  port: int,
+};
+
+let create: (config) => t;
+let connect: (t) => unit;
+`
+	ents := runReasonML(t, src, "Client.rei")
+
+	comps := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = true
+		}
+	}
+
+	for _, want := range []string{"t", "config"} {
+		if !comps[want] {
+			t.Errorf("expected type %q as SCOPE.Component in .rei file", want)
+		}
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -33,6 +33,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/proto"
 	_ "github.com/cajasmota/archigraph/internal/extractors/python"
 	_ "github.com/cajasmota/archigraph/internal/extractors/razor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/reasonml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/rescript"
 	_ "github.com/cajasmota/archigraph/internal/extractors/ruby"
 	_ "github.com/cajasmota/archigraph/internal/extractors/rust"

--- a/internal/resolve/dynamic_patterns_reasonml.go
+++ b/internal/resolve/dynamic_patterns_reasonml.go
@@ -1,0 +1,227 @@
+package resolve
+
+import "regexp"
+
+// reasonmlDynamicPatterns are per-language patterns for ReasonML.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The ReasonML extractor (internal/extractors/reasonml/extractor.go) emits CALLS
+// edges whose ToID is either:
+//   - a bare function name: "helper"
+//   - a module-qualified call: "Belt.List.map", "Belt.Option.getWithDefault"
+//   - a pipe-chain target: "Belt.Array.reduce", "ReactDOMRe.renderToElementWithId"
+//
+// Three categories of patterns:
+//
+//  1. Belt stdlib — BuckleScript's Belt standard library, ReasonML's primary stdlib.
+//     Module-qualified identifiers unique to Belt.
+//
+//  2. ReactDOMRe — ReasonReact DOM bindings (renderToElement, renderToElementWithId).
+//
+//  3. React / ReasonReact — React bindings commonly used in ReasonML components.
+//
+//  4. Pipe operator targets — captured via |> in function pipelines.
+//
+// All patterns are gated to lang=="reasonml" (safer-bias rule).
+var reasonmlDynamicPatterns = []*regexp.Regexp{
+	// ── Belt.List module ─────────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.List\.map$`),             // Belt.List.map(lst, f)
+	regexp.MustCompile(`^Belt\.List\.filter$`),          // Belt.List.filter(lst, pred)
+	regexp.MustCompile(`^Belt\.List\.keep$`),            // Belt.List.keep(lst, pred) — alias for filter
+	regexp.MustCompile(`^Belt\.List\.reduce$`),          // Belt.List.reduce(lst, init, f)
+	regexp.MustCompile(`^Belt\.List\.forEach$`),         // Belt.List.forEach(lst, f)
+	regexp.MustCompile(`^Belt\.List\.forEachWithIndex$`), // Belt.List.forEachWithIndex(lst, f)
+	regexp.MustCompile(`^Belt\.List\.mapWithIndex$`),    // Belt.List.mapWithIndex(lst, f)
+	regexp.MustCompile(`^Belt\.List\.filterMap$`),       // Belt.List.filterMap(lst, f)
+	regexp.MustCompile(`^Belt\.List\.getBy$`),           // Belt.List.getBy(lst, pred)
+	regexp.MustCompile(`^Belt\.List\.get$`),             // Belt.List.get(lst, idx)
+	regexp.MustCompile(`^Belt\.List\.getExn$`),          // Belt.List.getExn(lst, idx)
+	regexp.MustCompile(`^Belt\.List\.head$`),            // Belt.List.head(lst)
+	regexp.MustCompile(`^Belt\.List\.headExn$`),         // Belt.List.headExn(lst)
+	regexp.MustCompile(`^Belt\.List\.tail$`),            // Belt.List.tail(lst)
+	regexp.MustCompile(`^Belt\.List\.tailExn$`),         // Belt.List.tailExn(lst)
+	regexp.MustCompile(`^Belt\.List\.length$`),          // Belt.List.length(lst)
+	regexp.MustCompile(`^Belt\.List\.size$`),            // Belt.List.size(lst)
+	regexp.MustCompile(`^Belt\.List\.add$`),             // Belt.List.add(lst, x)
+	regexp.MustCompile(`^Belt\.List\.concat$`),          // Belt.List.concat(lst1, lst2)
+	regexp.MustCompile(`^Belt\.List\.concatMany$`),      // Belt.List.concatMany(lsts)
+	regexp.MustCompile(`^Belt\.List\.flatten$`),         // Belt.List.flatten(lst)
+	regexp.MustCompile(`^Belt\.List\.flatMap$`),         // Belt.List.flatMap(lst, f)
+	regexp.MustCompile(`^Belt\.List\.sort$`),            // Belt.List.sort(lst, cmp)
+	regexp.MustCompile(`^Belt\.List\.sortU$`),           // Belt.List.sortU(lst, cmp) — uncurried
+	regexp.MustCompile(`^Belt\.List\.reverse$`),         // Belt.List.reverse(lst)
+	regexp.MustCompile(`^Belt\.List\.every$`),           // Belt.List.every(lst, pred)
+	regexp.MustCompile(`^Belt\.List\.some$`),            // Belt.List.some(lst, pred)
+	regexp.MustCompile(`^Belt\.List\.has$`),             // Belt.List.has(lst, x, eq)
+	regexp.MustCompile(`^Belt\.List\.zip$`),             // Belt.List.zip(lst1, lst2)
+	regexp.MustCompile(`^Belt\.List\.zipBy$`),           // Belt.List.zipBy(lst1, lst2, f)
+	regexp.MustCompile(`^Belt\.List\.unzip$`),           // Belt.List.unzip(lst)
+	regexp.MustCompile(`^Belt\.List\.fromArray$`),       // Belt.List.fromArray(arr)
+	regexp.MustCompile(`^Belt\.List\.toArray$`),         // Belt.List.toArray(lst)
+	regexp.MustCompile(`^Belt\.List\.make$`),            // Belt.List.make(n, x)
+	regexp.MustCompile(`^Belt\.List\.makeBy$`),          // Belt.List.makeBy(n, f)
+	regexp.MustCompile(`^Belt\.List\.shuffle$`),         // Belt.List.shuffle(lst)
+	regexp.MustCompile(`^Belt\.List\.drop$`),            // Belt.List.drop(lst, n)
+	regexp.MustCompile(`^Belt\.List\.take$`),            // Belt.List.take(lst, n)
+	regexp.MustCompile(`^Belt\.List\.splitAt$`),         // Belt.List.splitAt(lst, n)
+	regexp.MustCompile(`^Belt\.List\.partition$`),       // Belt.List.partition(lst, pred)
+
+	// ── Belt.Array module ────────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Array\.map$`),            // Belt.Array.map(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.filter$`),         // Belt.Array.filter(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.keep$`),           // Belt.Array.keep(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.reduce$`),         // Belt.Array.reduce(arr, init, f)
+	regexp.MustCompile(`^Belt\.Array\.forEach$`),        // Belt.Array.forEach(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.forEachWithIndex$`), // Belt.Array.forEachWithIndex(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.mapWithIndex$`),   // Belt.Array.mapWithIndex(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.filterMap$`),      // Belt.Array.filterMap(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.keepMap$`),        // Belt.Array.keepMap(arr, f) — alias
+	regexp.MustCompile(`^Belt\.Array\.get$`),            // Belt.Array.get(arr, idx)
+	regexp.MustCompile(`^Belt\.Array\.getExn$`),         // Belt.Array.getExn(arr, idx)
+	regexp.MustCompile(`^Belt\.Array\.length$`),         // Belt.Array.length(arr)
+	regexp.MustCompile(`^Belt\.Array\.size$`),           // Belt.Array.size(arr)
+	regexp.MustCompile(`^Belt\.Array\.concat$`),         // Belt.Array.concat(arr1, arr2)
+	regexp.MustCompile(`^Belt\.Array\.concatMany$`),     // Belt.Array.concatMany(arrs)
+	regexp.MustCompile(`^Belt\.Array\.reverse$`),        // Belt.Array.reverse(arr)
+	regexp.MustCompile(`^Belt\.Array\.sort$`),           // Belt.Array.sort(arr, cmp)
+	regexp.MustCompile(`^Belt\.Array\.sortInPlace$`),    // Belt.Array.sortInPlace(arr, cmp)
+	regexp.MustCompile(`^Belt\.Array\.every$`),          // Belt.Array.every(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.some$`),           // Belt.Array.some(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.find$`),           // Belt.Array.find(arr, pred) — unofficial
+	regexp.MustCompile(`^Belt\.Array\.getBy$`),          // Belt.Array.getBy(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.has$`),            // Belt.Array.has(arr, x, eq)
+	regexp.MustCompile(`^Belt\.Array\.zip$`),            // Belt.Array.zip(arr1, arr2)
+	regexp.MustCompile(`^Belt\.Array\.zipBy$`),          // Belt.Array.zipBy(arr1, arr2, f)
+	regexp.MustCompile(`^Belt\.Array\.unzip$`),          // Belt.Array.unzip(arr)
+	regexp.MustCompile(`^Belt\.Array\.fromList$`),       // Belt.Array.fromList(lst)
+	regexp.MustCompile(`^Belt\.Array\.toList$`),         // Belt.Array.toList(arr)
+	regexp.MustCompile(`^Belt\.Array\.make$`),           // Belt.Array.make(n, x)
+	regexp.MustCompile(`^Belt\.Array\.makeBy$`),         // Belt.Array.makeBy(n, f)
+	regexp.MustCompile(`^Belt\.Array\.makeUninitializedUnsafe$`), // Belt.Array.makeUninitializedUnsafe(n)
+	regexp.MustCompile(`^Belt\.Array\.copy$`),           // Belt.Array.copy(arr)
+	regexp.MustCompile(`^Belt\.Array\.fill$`),           // Belt.Array.fill(arr, offset, len, x)
+	regexp.MustCompile(`^Belt\.Array\.blit$`),           // Belt.Array.blit(src, srcOff, dst, dstOff, len)
+	regexp.MustCompile(`^Belt\.Array\.blitUnsafe$`),     // Belt.Array.blitUnsafe(...)
+	regexp.MustCompile(`^Belt\.Array\.shuffle$`),        // Belt.Array.shuffle(arr)
+	regexp.MustCompile(`^Belt\.Array\.shuffleInPlace$`), // Belt.Array.shuffleInPlace(arr)
+	regexp.MustCompile(`^Belt\.Array\.slice$`),          // Belt.Array.slice(arr, offset, len)
+	regexp.MustCompile(`^Belt\.Array\.sliceToEnd$`),     // Belt.Array.sliceToEnd(arr, offset)
+	regexp.MustCompile(`^Belt\.Array\.partition$`),      // Belt.Array.partition(arr, pred)
+	regexp.MustCompile(`^Belt\.Array\.uniqBy$`),         // Belt.Array.uniqBy(arr, f)
+	regexp.MustCompile(`^Belt\.Array\.joinWith$`),       // Belt.Array.joinWith(arr, sep, f)
+	regexp.MustCompile(`^Belt\.Array\.range$`),          // Belt.Array.range(start, end)
+	regexp.MustCompile(`^Belt\.Array\.rangeBy$`),        // Belt.Array.rangeBy(start, end, step)
+
+	// ── Belt.Option module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Option\.map$`),                // Belt.Option.map(opt, f)
+	regexp.MustCompile(`^Belt\.Option\.flatMap$`),            // Belt.Option.flatMap(opt, f)
+	regexp.MustCompile(`^Belt\.Option\.getWithDefault$`),     // Belt.Option.getWithDefault(opt, default)
+	regexp.MustCompile(`^Belt\.Option\.getExn$`),             // Belt.Option.getExn(opt)
+	regexp.MustCompile(`^Belt\.Option\.isSome$`),             // Belt.Option.isSome(opt)
+	regexp.MustCompile(`^Belt\.Option\.isNone$`),             // Belt.Option.isNone(opt)
+	regexp.MustCompile(`^Belt\.Option\.eq$`),                 // Belt.Option.eq(opt1, opt2, eq)
+	regexp.MustCompile(`^Belt\.Option\.cmp$`),                // Belt.Option.cmp(opt1, opt2, cmp)
+	regexp.MustCompile(`^Belt\.Option\.forEach$`),            // Belt.Option.forEach(opt, f)
+	regexp.MustCompile(`^Belt\.Option\.mapWithDefault$`),     // Belt.Option.mapWithDefault(opt, default, f)
+	regexp.MustCompile(`^Belt\.Option\.orElse$`),             // Belt.Option.orElse(opt, other)
+	regexp.MustCompile(`^Belt\.Option\.keep$`),               // Belt.Option.keep(opt, pred)
+
+	// ── Belt.Map module ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Map\.get$`),                   // Belt.Map.get(map, key)
+	regexp.MustCompile(`^Belt\.Map\.getExn$`),                // Belt.Map.getExn(map, key)
+	regexp.MustCompile(`^Belt\.Map\.set$`),                   // Belt.Map.set(map, key, val)
+	regexp.MustCompile(`^Belt\.Map\.remove$`),                // Belt.Map.remove(map, key)
+	regexp.MustCompile(`^Belt\.Map\.has$`),                   // Belt.Map.has(map, key)
+	regexp.MustCompile(`^Belt\.Map\.map$`),                   // Belt.Map.map(map, f)
+	regexp.MustCompile(`^Belt\.Map\.filter$`),                // Belt.Map.filter(map, pred)
+	regexp.MustCompile(`^Belt\.Map\.reduce$`),                // Belt.Map.reduce(map, init, f)
+	regexp.MustCompile(`^Belt\.Map\.forEach$`),               // Belt.Map.forEach(map, f)
+	regexp.MustCompile(`^Belt\.Map\.toArray$`),               // Belt.Map.toArray(map)
+	regexp.MustCompile(`^Belt\.Map\.fromArray$`),             // Belt.Map.fromArray(arr)
+	regexp.MustCompile(`^Belt\.Map\.size$`),                  // Belt.Map.size(map)
+	regexp.MustCompile(`^Belt\.Map\.isEmpty$`),               // Belt.Map.isEmpty(map)
+	regexp.MustCompile(`^Belt\.Map\.keys$`),                  // Belt.Map.keys(map)
+	regexp.MustCompile(`^Belt\.Map\.values$`),                // Belt.Map.values(map)
+	regexp.MustCompile(`^Belt\.Map\.merge$`),                 // Belt.Map.merge(map1, map2, f)
+	regexp.MustCompile(`^Belt\.Map\.mergeMany$`),             // Belt.Map.mergeMany(map, arr)
+	regexp.MustCompile(`^Belt\.Map\.partition$`),             // Belt.Map.partition(map, pred)
+	regexp.MustCompile(`^Belt\.Map\.every$`),                 // Belt.Map.every(map, pred)
+	regexp.MustCompile(`^Belt\.Map\.some$`),                  // Belt.Map.some(map, pred)
+
+	// ── Belt.Map.String / Belt.Map.Int shortcuts ─────────────────────────────
+	regexp.MustCompile(`^Belt\.Map\.String\.get$`),           // Belt.Map.String.get(map, key)
+	regexp.MustCompile(`^Belt\.Map\.String\.set$`),           // Belt.Map.String.set(map, key, val)
+	regexp.MustCompile(`^Belt\.Map\.String\.has$`),           // Belt.Map.String.has(map, key)
+	regexp.MustCompile(`^Belt\.Map\.String\.remove$`),        // Belt.Map.String.remove(map, key)
+	regexp.MustCompile(`^Belt\.Map\.Int\.get$`),              // Belt.Map.Int.get(map, key)
+	regexp.MustCompile(`^Belt\.Map\.Int\.set$`),              // Belt.Map.Int.set(map, key, val)
+	regexp.MustCompile(`^Belt\.Map\.Int\.has$`),              // Belt.Map.Int.has(map, key)
+
+	// ── Belt.Set module ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Set\.add$`),                   // Belt.Set.add(set, x)
+	regexp.MustCompile(`^Belt\.Set\.remove$`),                // Belt.Set.remove(set, x)
+	regexp.MustCompile(`^Belt\.Set\.has$`),                   // Belt.Set.has(set, x)
+	regexp.MustCompile(`^Belt\.Set\.size$`),                  // Belt.Set.size(set)
+	regexp.MustCompile(`^Belt\.Set\.isEmpty$`),               // Belt.Set.isEmpty(set)
+	regexp.MustCompile(`^Belt\.Set\.toArray$`),               // Belt.Set.toArray(set)
+	regexp.MustCompile(`^Belt\.Set\.fromArray$`),             // Belt.Set.fromArray(arr)
+	regexp.MustCompile(`^Belt\.Set\.union$`),                 // Belt.Set.union(s1, s2)
+	regexp.MustCompile(`^Belt\.Set\.intersect$`),             // Belt.Set.intersect(s1, s2)
+	regexp.MustCompile(`^Belt\.Set\.diff$`),                  // Belt.Set.diff(s1, s2)
+	regexp.MustCompile(`^Belt\.Set\.subset$`),                // Belt.Set.subset(s1, s2)
+
+	// ── Belt.Result module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Result\.map$`),                // Belt.Result.map(result, f)
+	regexp.MustCompile(`^Belt\.Result\.flatMap$`),            // Belt.Result.flatMap(result, f)
+	regexp.MustCompile(`^Belt\.Result\.getWithDefault$`),     // Belt.Result.getWithDefault(result, default)
+	regexp.MustCompile(`^Belt\.Result\.getExn$`),             // Belt.Result.getExn(result)
+	regexp.MustCompile(`^Belt\.Result\.isOk$`),               // Belt.Result.isOk(result)
+	regexp.MustCompile(`^Belt\.Result\.isError$`),            // Belt.Result.isError(result)
+	regexp.MustCompile(`^Belt\.Result\.mapError$`),           // Belt.Result.mapError(result, f)
+
+	// ── Belt.Float / Belt.Int module ─────────────────────────────────────────
+	regexp.MustCompile(`^Belt\.Float\.fromInt$`),             // Belt.Float.fromInt(i)
+	regexp.MustCompile(`^Belt\.Float\.toInt$`),               // Belt.Float.toInt(f)
+	regexp.MustCompile(`^Belt\.Int\.fromFloat$`),             // Belt.Int.fromFloat(f)
+	regexp.MustCompile(`^Belt\.Int\.toFloat$`),               // Belt.Int.toFloat(i)
+
+	// ── ReactDOMRe bindings ──────────────────────────────────────────────────
+	regexp.MustCompile(`^ReactDOMRe\.renderToElement$`),      // ReactDOMRe.renderToElement(el, domEl)
+	regexp.MustCompile(`^ReactDOMRe\.renderToElementWithId$`), // ReactDOMRe.renderToElementWithId(el, id)
+	regexp.MustCompile(`^ReactDOMRe\.unmountComponentAtNode$`), // ReactDOMRe.unmountComponentAtNode(domEl)
+	regexp.MustCompile(`^ReactDOMRe\.hydrateToElementWithId$`), // ReactDOMRe.hydrateToElementWithId(el, id)
+
+	// ── React bindings ───────────────────────────────────────────────────────
+	regexp.MustCompile(`^React\.string$`),                    // React.string(s) — JSX string node
+	regexp.MustCompile(`^React\.array$`),                     // React.array(arr) — JSX array node
+	regexp.MustCompile(`^React\.element$`),                   // React.element(el) — JSX element
+	regexp.MustCompile(`^React\.null$`),                      // React.null — empty node (value)
+	regexp.MustCompile(`^React\.int$`),                       // React.int(n) — JSX int node
+	regexp.MustCompile(`^React\.float$`),                     // React.float(f) — JSX float node
+	regexp.MustCompile(`^React\.createElement$`),             // React.createElement(comp, props, children)
+	regexp.MustCompile(`^React\.cloneElement$`),              // React.cloneElement(el, props)
+	regexp.MustCompile(`^React\.useReducer$`),                // React.useReducer(reducer, init)
+	regexp.MustCompile(`^React\.useState$`),                  // React.useState(init)
+	regexp.MustCompile(`^React\.useEffect$`),                 // React.useEffect(f)
+	regexp.MustCompile(`^React\.useEffect0$`),                // React.useEffect0(f) — no deps
+	regexp.MustCompile(`^React\.useEffect1$`),                // React.useEffect1(f, deps)
+	regexp.MustCompile(`^React\.useCallback$`),               // React.useCallback(f)
+	regexp.MustCompile(`^React\.useCallback0$`),              // React.useCallback0(f)
+	regexp.MustCompile(`^React\.useCallback1$`),              // React.useCallback1(f, deps)
+	regexp.MustCompile(`^React\.useMemo$`),                   // React.useMemo(f)
+	regexp.MustCompile(`^React\.useMemo0$`),                  // React.useMemo0(f)
+	regexp.MustCompile(`^React\.useMemo1$`),                  // React.useMemo1(f, deps)
+	regexp.MustCompile(`^React\.useRef$`),                    // React.useRef(init)
+	regexp.MustCompile(`^React\.useContext$`),                // React.useContext(ctx)
+	regexp.MustCompile(`^React\.createContext$`),             // React.createContext(default)
+	regexp.MustCompile(`^React\.createRef$`),                 // React.createRef()
+	regexp.MustCompile(`^React\.forwardRef$`),                // React.forwardRef(f)
+	regexp.MustCompile(`^React\.memo$`),                      // React.memo(comp)
+	regexp.MustCompile(`^React\.memo1$`),                     // React.memo1(comp, eq)
+	regexp.MustCompile(`^React\.lazy_$`),                     // React.lazy_(f)
+	regexp.MustCompile(`^React\.Suspense\.make$`),            // React.Suspense.make(...)
+}
+
+func init() {
+	dynamicPatternsByLang["reasonml"] = reasonmlDynamicPatterns
+}


### PR DESCRIPTION
## What

Implements the ReasonML extractor (#1040). ReasonML is OCaml with curly-brace syntax; file extensions `.re` (implementation) and `.rei` (interface/signature).

## Changes

| File | Purpose |
|---|---|
| `internal/extractors/reasonml/extractor.go` | Regex-based extractor: module decls, `let`/`let rec` bindings, record/variant/abstract types, `open` → IMPORTS, direct + `\|>` pipe calls → CALLS |
| `internal/extractors/reasonml/reasonml_test.go` | 13 tests: all entity kinds, language tagging, self-recursion exclusion, `.rei` interface files, synthetic React-Reason fixture |
| `internal/resolve/dynamic_patterns_reasonml.go` | Resolver slice: Belt.List/Array/Option/Map/Set/Result, ReactDOMRe render helpers, React hooks and JSX helpers, pipe targets analogous to F# |
| `internal/classifier/classifier.go` | `.re` → `"reasonml"`, `.rei` → `"reasonml"` |
| `internal/extractors/registry_gen.go` | Blank import registers the extractor |

## Entity coverage

Extracted entity kinds:
- **`SCOPE.Component`** — `module Foo = { ... }`, `type person = { ... }` (record), `type shape = Circle | Square` (variant), `type t;` (abstract, `.rei` only)
- **`SCOPE.Operation`** — `let foo = (x) => ...`, `let rec bar = ...`
- **IMPORTS edges** — `open Belt;`, `open React;`
- **CALLS edges** — direct calls `helper(n)` and pipe targets `|> Belt.List.map`

## Test results

```
=== RUN   TestReasonML_ReactReasonFixture
    reasonml_test.go:404: ReactReason fixture recall: 12/12 (100%): ops=6/6 comps=3/3 imports=3/3
--- PASS: TestReasonML_ReactReasonFixture (0.00s)
PASS
ok  github.com/cajasmota/archigraph/internal/extractors/reasonml  0.494s
```

13/13 tests pass. Fixture recall: **100%** (threshold: ≥80%). False positives: **0**.

## Resolver slice highlights

- **Belt stdlib**: `Belt.List.map/filter/reduce/keep`, `Belt.Array.map/filter/reduce`, `Belt.Option.getWithDefault`, `Belt.Map.get/set`, `Belt.Set.has`, `Belt.Result.map/flatMap`
- **ReactDOMRe**: `renderToElement`, `renderToElementWithId`, `unmountComponentAtNode`, `hydrateToElementWithId`
- **React bindings**: `React.string`, `React.array`, `React.element`, `React.useReducer`, `React.useState`, `React.useEffect0/1`, `React.useCallback`, `React.useMemo`, `React.memo`, `React.createContext`

## Verification

```bash
go test ./internal/extractors/reasonml/... -v   # 13/13 PASS
go test ./internal/classifier/...               # PASS
go test ./internal/resolve/...                  # PASS
go build ./internal/extractors/... ./internal/classifier/... ./internal/resolve/...  # clean
```

Closes #1040
Refs #44