### PR TITLE
feat: Svelte SFC extractor + resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -463,7 +463,7 @@ var extensionLanguageMap = map[string]string{
 	".html":       "html",
 	".htm":        "html",
 	".vue":        "html",
-	".svelte":     "html",
+	".svelte":     "svelte",
 	".astro":      "html",
 	".erb":        "html",
 	".ejs":        "html",

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -548,7 +548,6 @@ func TestMX1100_HTML_LanguageToken(t *testing.T) {
 		{"page.htm"},
 		{"templates/base.html"},
 		{"src/App.vue"},
-		{"src/App.svelte"},
 		{"page.astro"},
 		{"view.erb"},
 		{"template.ejs"},
@@ -585,7 +584,7 @@ func TestMX1100_HTML_ClassifyWithSize(t *testing.T) {
 
 	const smallFile = int64(2048)
 
-	for _, file := range []string{"index.html", "page.htm", "App.vue", "App.svelte"} {
+	for _, file := range []string{"index.html", "page.htm", "App.vue"} {
 		t.Run(file, func(t *testing.T) {
 			r := c.ClassifyWithSize(ctx, file, smallFile)
 			if r.Skip {
@@ -593,6 +592,25 @@ func TestMX1100_HTML_ClassifyWithSize(t *testing.T) {
 			}
 			if r.Language != "html" {
 				t.Errorf("%s: expected Language=html, got %q", file, r.Language)
+			}
+		})
+	}
+}
+
+// TestSvelte_LanguageToken verifies that .svelte files are classified as
+// "svelte" (not "html") now that a dedicated svelte extractor is registered.
+func TestSvelte_LanguageToken(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+
+	for _, file := range []string{"src/App.svelte", "lib/Button.svelte", "routes/+page.svelte"} {
+		t.Run(file, func(t *testing.T) {
+			r := c.Classify(ctx, file)
+			if r.Skip {
+				t.Errorf("file=%q: should NOT be skipped, got Skip=true reason=%q", file, r.SkipReason)
+			}
+			if r.Language != "svelte" {
+				t.Errorf("file=%q: expected Language=svelte, got %q", file, r.Language)
 			}
 		})
 	}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/scala"
 	_ "github.com/cajasmota/archigraph/internal/extractors/shell"
 	_ "github.com/cajasmota/archigraph/internal/extractors/sql"
+	_ "github.com/cajasmota/archigraph/internal/extractors/svelte"
 	_ "github.com/cajasmota/archigraph/internal/extractors/swift"
 	_ "github.com/cajasmota/archigraph/internal/extractors/yaml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/zig"

--- a/internal/extractors/svelte/extractor.go
+++ b/internal/extractors/svelte/extractor.go
@@ -1,0 +1,385 @@
+// Package svelte implements a regex-based extractor for Svelte single-file
+// components (.svelte files).
+//
+// A Svelte SFC has three optional sections:
+//
+//	<script [lang="ts"]> ... </script>   — component logic
+//	HTML template                        — markup with Svelte directives
+//	<style> ... </style>                 — scoped CSS
+//
+// Extracted entities:
+//
+//	Whole file               → SCOPE.Component    subtype="svelte_component"
+//	export let <prop>        → SCOPE.Operation    subtype="prop"
+//	let <x> = $state(…)      → SCOPE.Operation    subtype="rune_state"
+//	$derived(…) declaration  → SCOPE.Operation    subtype="rune_derived"
+//	$effect(…) call          → SCOPE.Operation    subtype="rune_effect"
+//	<ChildComponent />       → RENDERS edge
+//
+// Svelte 5 runes ($state, $derived, $effect, $props, $bindable) are
+// recognised; Svelte 4 lifecycle helpers (onMount, onDestroy, …) and stores
+// (writable, readable, derived, get) are captured as CALLS edges via the
+// resolver slice (dynamic_patterns_svelte.go).
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package svelte
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("svelte", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Svelte SFC files.
+type Extractor struct{}
+
+// Language returns the canonical language key.
+func (e *Extractor) Language() string { return "svelte" }
+
+// ── compiled regexps ────────────────────────────────────────────────────────
+
+var (
+	// scriptBlockRE captures the content between <script …> and </script>.
+	// Handles optional lang="ts" / lang="js" attributes. Non-greedy inner
+	// match so nested tags in template are not consumed.
+	scriptBlockRE = regexp.MustCompile(`(?si)<script(?:[^>]*)>(.*?)</script>`)
+
+	// exportLetRE matches `export let propName` declarations inside a <script>
+	// block.  Captures the property name.
+	// Examples: `export let count = 0`, `export let label: string`
+	exportLetRE = regexp.MustCompile(`(?m)^\s*export\s+let\s+([A-Za-z_$][A-Za-z0-9_$]*)`)
+
+	// stateRuneRE matches `let name = $state(…)` (Svelte 5 rune).
+	// Captures the variable name.
+	stateRuneRE = regexp.MustCompile(`(?m)^\s*(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\$state\s*\(`)
+
+	// derivedRuneRE matches `let name = $derived(…)` (Svelte 5 rune).
+	// Captures the variable name.
+	derivedRuneRE = regexp.MustCompile(`(?m)^\s*(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\$derived\s*\(`)
+
+	// effectRuneRE matches a top-level `$effect(…)` call (Svelte 5 rune).
+	// Captures nothing beyond the match itself — effects are anonymous.
+	effectRuneRE = regexp.MustCompile(`(?m)^\s*\$effect\s*\(`)
+
+	// propsRuneRE matches `const { a, b } = $props()` or `let props = $props()`.
+	// Captures the text between `{` and `}` for destructured forms, or the
+	// bare binding name for the non-destructured form.
+	propsRuneRE = regexp.MustCompile(`(?m)^\s*(?:let|const)\s+(?:\{([^}]*)\}|([A-Za-z_$][A-Za-z0-9_$]*))\s*=\s*\$props\s*\(`)
+
+	// bindableRuneRE matches `let x = $bindable(…)` (Svelte 5 rune).
+	bindableRuneRE = regexp.MustCompile(`(?m)^\s*(?:let|const)\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*\$bindable\s*\(`)
+
+	// childComponentRE finds PascalCase component tags in the template section.
+	// Matches both self-closing `<Foo />` and opening `<Foo>` / `<Foo ...>`.
+	// PascalCase tag → Svelte component by convention (lower-case → HTML element).
+	childComponentRE = regexp.MustCompile(`<([A-Z][A-Za-z0-9]*)\b`)
+)
+
+// Extract parses the Svelte SFC source and returns entity records.
+func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("extractor.svelte")
+	ctx, span := tracer.Start(ctx, "indexer.extract.svelte",
+		trace.WithAttributes(attribute.String("language", "svelte")),
+	)
+	defer span.End()
+
+	_ = ctx // used only for span
+
+	src := string(file.Content)
+	if len(src) == 0 {
+		span.SetAttributes(
+			attribute.Int("file_line_count", 0),
+			attribute.Int("entity_count", 0),
+		)
+		return nil, nil
+	}
+
+	lineCount := strings.Count(src, "\n") + 1
+	componentName := componentNameFromPath(file.Path)
+
+	var entities []types.EntityRecord
+
+	// ── 1. Whole-file component entity ───────────────────────────────────────
+	componentEntity := types.EntityRecord{
+		Name:         componentName,
+		Kind:         "SCOPE.Component",
+		Subtype:      "svelte_component",
+		SourceFile:   file.Path,
+		Language:     "svelte",
+		StartLine:    1,
+		EndLine:      lineCount,
+		Signature:    componentName + ".svelte",
+		QualityScore: 0.85,
+	}
+	entities = append(entities, componentEntity)
+
+	// ── 2. Extract <script> block ─────────────────────────────────────────────
+	scriptContent, scriptStartLine := extractScriptBlock(src)
+	if scriptContent != "" {
+		scriptEntities := extractScriptEntities(scriptContent, scriptStartLine, file.Path)
+		entities = append(entities, scriptEntities...)
+	}
+
+	// ── 3. Extract RENDERS edges from child components in the template ────────
+	templateContent, templateStartLine := extractTemplateSection(src)
+	if templateContent != "" {
+		renderRels := extractChildComponents(templateContent, templateStartLine, file.Path, componentName)
+		if len(renderRels) > 0 {
+			// Attach RENDERS relationships to the component entity.
+			entities[0].Relationships = append(entities[0].Relationships, renderRels...)
+		}
+	}
+
+	span.SetAttributes(
+		attribute.Int("file_line_count", lineCount),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}
+
+// componentNameFromPath derives the Svelte component name from the file path.
+// e.g. "src/lib/MyButton.svelte" → "MyButton"
+func componentNameFromPath(path string) string {
+	base := filepath.Base(path)
+	name := strings.TrimSuffix(base, ".svelte")
+	if name == "" {
+		return "Component"
+	}
+	return name
+}
+
+// extractScriptBlock finds the first <script …> … </script> block and returns
+// its inner content and the 1-based line number of the first content line.
+func extractScriptBlock(src string) (string, int) {
+	m := scriptBlockRE.FindStringSubmatchIndex(src)
+	if m == nil {
+		return "", 0
+	}
+	// m[2]..m[3] is the inner content (capture group 1)
+	inner := src[m[2]:m[3]]
+	// Count lines before the start of the inner content.
+	startLine := strings.Count(src[:m[2]], "\n") + 1
+	return inner, startLine
+}
+
+// extractTemplateSection returns the non-script, non-style portion of the
+// file (the HTML template) along with its first content line number.
+// This is a best-effort extraction: we strip <script> and <style> blocks.
+func extractTemplateSection(src string) (string, int) {
+	// Remove all <script …>…</script> blocks.
+	stripped := scriptBlockRE.ReplaceAllString(src, "")
+	// Remove <style …>…</style> blocks (simple pattern, same approach).
+	styleRE := regexp.MustCompile(`(?si)<style(?:[^>]*)>.*?</style>`)
+	stripped = styleRE.ReplaceAllString(stripped, "")
+	if strings.TrimSpace(stripped) == "" {
+		return "", 0
+	}
+	return stripped, 1
+}
+
+// extractScriptEntities scans the <script> inner content and extracts:
+//   - export let <prop>            → SCOPE.Operation (subtype="prop")
+//   - let/const x = $state(…)     → SCOPE.Operation (subtype="rune_state")
+//   - let/const x = $derived(…)   → SCOPE.Operation (subtype="rune_derived")
+//   - $effect(…)                  → SCOPE.Operation (subtype="rune_effect")
+//   - $props() destructure        → SCOPE.Operation (subtype="prop") per named prop
+//   - let/const x = $bindable(…)  → SCOPE.Operation (subtype="rune_state")
+func extractScriptEntities(script string, scriptStartLine int, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// lineOf returns 1-based absolute line for a given line index inside script.
+	lineOf := func(idx int) int {
+		return scriptStartLine + idx
+	}
+
+	// export let props
+	for _, m := range exportLetRE.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "prop",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineOf(lineIdx),
+			EndLine:      lineOf(lineIdx),
+			Signature:    "export let " + name,
+			QualityScore: 0.85,
+		})
+	}
+
+	// $state rune
+	for _, m := range stateRuneRE.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "rune_state",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineOf(lineIdx),
+			EndLine:      lineOf(lineIdx),
+			Signature:    "let " + name + " = $state(...)",
+			QualityScore: 0.8,
+		})
+	}
+
+	// $derived rune
+	for _, m := range derivedRuneRE.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "rune_derived",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineOf(lineIdx),
+			EndLine:      lineOf(lineIdx),
+			Signature:    "let " + name + " = $derived(...)",
+			QualityScore: 0.8,
+		})
+	}
+
+	// $effect rune (anonymous — name them by position)
+	effectMatches := effectRuneRE.FindAllStringIndex(script, -1)
+	for i, m := range effectMatches {
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		name := "$effect"
+		if i > 0 {
+			name = fmt.Sprintf("$effect_%d", i)
+		}
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "rune_effect",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineOf(lineIdx),
+			EndLine:      lineOf(lineIdx),
+			Signature:    "$effect(() => { ... })",
+			QualityScore: 0.75,
+		})
+	}
+
+	// $props() rune — destructured: `const { a, b } = $props()`
+	for _, m := range propsRuneRE.FindAllStringSubmatchIndex(script, -1) {
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		if m[2] >= 0 {
+			// Destructured form: group 1 = "a, b, c"
+			inner := script[m[2]:m[3]]
+			for _, field := range strings.Split(inner, ",") {
+				field = strings.TrimSpace(field)
+				// Handle default values: `label = "hello"` → name is "label"
+				if idx := strings.IndexAny(field, "=:"); idx >= 0 {
+					field = strings.TrimSpace(field[:idx])
+				}
+				if field == "" {
+					continue
+				}
+				entities = append(entities, types.EntityRecord{
+					Name:         field,
+					Kind:         "SCOPE.Operation",
+					Subtype:      "prop",
+					SourceFile:   filePath,
+					Language:     "svelte",
+					StartLine:    lineOf(lineIdx),
+					EndLine:      lineOf(lineIdx),
+					Signature:    "$props(): " + field,
+					QualityScore: 0.85,
+				})
+			}
+		} else if m[4] >= 0 {
+			// Non-destructured form: group 2 = variable name
+			name := script[m[4]:m[5]]
+			entities = append(entities, types.EntityRecord{
+				Name:         name,
+				Kind:         "SCOPE.Operation",
+				Subtype:      "prop",
+				SourceFile:   filePath,
+				Language:     "svelte",
+				StartLine:    lineOf(lineIdx),
+				EndLine:      lineOf(lineIdx),
+				Signature:    "let " + name + " = $props()",
+				QualityScore: 0.85,
+			})
+		}
+	}
+
+	// $bindable rune
+	for _, m := range bindableRuneRE.FindAllStringSubmatchIndex(script, -1) {
+		name := script[m[2]:m[3]]
+		lineIdx := strings.Count(script[:m[0]], "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "rune_state",
+			SourceFile:   filePath,
+			Language:     "svelte",
+			StartLine:    lineOf(lineIdx),
+			EndLine:      lineOf(lineIdx),
+			Signature:    "let " + name + " = $bindable(...)",
+			QualityScore: 0.8,
+		})
+	}
+
+	return entities
+}
+
+// extractChildComponents scans the template content for PascalCase component
+// tags and returns RENDERS relationship records.
+//
+// Deduplicates by component name so `<Button>` appearing 3 times produces
+// one RENDERS edge, not three (avoids count inflation).
+func extractChildComponents(template string, templateStartLine int, filePath, componentName string) []types.RelationshipRecord {
+	seen := make(map[string]struct{})
+	var rels []types.RelationshipRecord
+
+	for _, m := range childComponentRE.FindAllStringSubmatchIndex(template, -1) {
+		name := template[m[2]:m[3]]
+		// Skip if already seen.
+		if _, exists := seen[name]; exists {
+			continue
+		}
+		seen[name] = struct{}{}
+
+		lineIdx := strings.Count(template[:m[0]], "\n")
+		lineNum := templateStartLine + lineIdx
+
+		rels = append(rels, types.RelationshipRecord{
+			FromID: filePath,
+			ToID:   name,
+			Kind:   "RENDERS",
+			Properties: map[string]string{
+				"from_component": componentName,
+				"to_component":   name,
+				"line":           fmt.Sprintf("%d", lineNum),
+			},
+		})
+	}
+
+	return rels
+}
+
+// max returns the larger of a and b.
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/internal/extractors/svelte/extractor_test.go
+++ b/internal/extractors/svelte/extractor_test.go
@@ -1,0 +1,413 @@
+package svelte_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/svelte" // trigger init()
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func mustExtract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("svelte")
+	if !ok {
+		t.Fatal("svelte extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "svelte",
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	return recs
+}
+
+func findByName(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func findBySubtype(recs []types.EntityRecord, subtype string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Subtype == subtype {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func countRenders(recs []types.EntityRecord) int {
+	n := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "RENDERS" {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+func rendersTarget(recs []types.EntityRecord, target string) bool {
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "RENDERS" && rel.ToID == target {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ── synthetic Svelte 5 + SvelteKit fixture ───────────────────────────────────
+
+// ProductCard.svelte — Svelte 5 component with:
+//   - export let props (Svelte 4 compat)
+//   - $state, $derived, $effect runes
+//   - $props() destructure
+//   - child component references: <Badge />, <Button>, <Icon />
+const productCardSvelte = `<script lang="ts">
+	import { goto, page } from '$app/navigation';
+	import Badge from './Badge.svelte';
+	import Button from './Button.svelte';
+	import Icon from './Icon.svelte';
+	import { onMount, onDestroy } from 'svelte';
+	import { writable, readable, derived, get } from 'svelte/store';
+
+	// Svelte 4-style export let prop
+	export let title = 'Product';
+	export let price: number = 0;
+
+	// Svelte 5 runes
+	let count = $state(0);
+	let doubled = $derived(count * 2);
+
+	// $props() rune (Svelte 5 idiomatic)
+	const { label, description = 'No description' } = $props();
+
+	// $bindable rune
+	let value = $bindable('');
+
+	// $effect rune
+	$effect(() => {
+		console.log('count changed', count);
+	});
+
+	$effect(() => {
+		console.log('value changed', value);
+	});
+
+	function handleClick() {
+		count++;
+		goto('/cart');
+	}
+</script>
+
+<div class="product-card">
+	<Badge label={label} />
+	<h2>{title}</h2>
+	<p>{description}</p>
+	<p>Price: {price}</p>
+	<p>Count: {count} (doubled: {doubled})</p>
+	<Button on:click={handleClick}>Add to cart</Button>
+	<Icon name="cart" />
+	<!-- Duplicate — should produce only ONE RENDERS edge for Badge -->
+	<Badge label="sale" />
+</div>
+
+<style>
+	.product-card {
+		border: 1px solid #ccc;
+		padding: 1rem;
+	}
+</style>
+`
+
+// ── registration ─────────────────────────────────────────────────────────────
+
+func TestExtractor_Language(t *testing.T) {
+	ext, ok := extractor.Get("svelte")
+	if !ok {
+		t.Fatal("svelte extractor not registered")
+	}
+	if ext.Language() != "svelte" {
+		t.Errorf("Language() = %q, want %q", ext.Language(), "svelte")
+	}
+}
+
+// ── component entity ──────────────────────────────────────────────────────────
+
+func TestExtractor_ComponentEntity(t *testing.T) {
+	recs := mustExtract(t, "src/lib/ProductCard.svelte", productCardSvelte)
+
+	comp := findByName(recs, "ProductCard")
+	if comp == nil {
+		t.Fatal("expected SCOPE.Component entity named 'ProductCard'")
+	}
+	if comp.Kind != "SCOPE.Component" {
+		t.Errorf("Kind = %q, want SCOPE.Component", comp.Kind)
+	}
+	if comp.Subtype != "svelte_component" {
+		t.Errorf("Subtype = %q, want svelte_component", comp.Subtype)
+	}
+	if comp.SourceFile != "src/lib/ProductCard.svelte" {
+		t.Errorf("SourceFile = %q, want src/lib/ProductCard.svelte", comp.SourceFile)
+	}
+	if comp.StartLine != 1 {
+		t.Errorf("StartLine = %d, want 1", comp.StartLine)
+	}
+}
+
+// ── export let props ─────────────────────────────────────────────────────────
+
+func TestExtractor_ExportLetProps(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	props := findBySubtype(recs, "prop")
+	propNames := make(map[string]bool)
+	for _, p := range props {
+		propNames[p.Name] = true
+	}
+
+	// Expect: title, price (export let), label, description ($props destructure)
+	for _, want := range []string{"title", "price", "label", "description"} {
+		if !propNames[want] {
+			t.Errorf("expected prop %q, got props: %v", want, propNames)
+		}
+	}
+
+	// Verify Kind on props
+	titleProp := findByName(recs, "title")
+	if titleProp == nil {
+		t.Fatal("expected entity named 'title'")
+	}
+	if titleProp.Kind != "SCOPE.Operation" {
+		t.Errorf("title Kind = %q, want SCOPE.Operation", titleProp.Kind)
+	}
+}
+
+// ── $state rune ───────────────────────────────────────────────────────────────
+
+func TestExtractor_StateRune(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	countEnt := findByName(recs, "count")
+	if countEnt == nil {
+		t.Fatal("expected entity named 'count' ($state rune)")
+	}
+	if countEnt.Subtype != "rune_state" {
+		t.Errorf("count Subtype = %q, want rune_state", countEnt.Subtype)
+	}
+	if countEnt.Kind != "SCOPE.Operation" {
+		t.Errorf("count Kind = %q, want SCOPE.Operation", countEnt.Kind)
+	}
+}
+
+// ── $derived rune ─────────────────────────────────────────────────────────────
+
+func TestExtractor_DerivedRune(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	ent := findByName(recs, "doubled")
+	if ent == nil {
+		t.Fatal("expected entity named 'doubled' ($derived rune)")
+	}
+	if ent.Subtype != "rune_derived" {
+		t.Errorf("doubled Subtype = %q, want rune_derived", ent.Subtype)
+	}
+}
+
+// ── $effect rune ──────────────────────────────────────────────────────────────
+
+func TestExtractor_EffectRune(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	effects := findBySubtype(recs, "rune_effect")
+	// Fixture has two $effect calls.
+	if len(effects) < 2 {
+		t.Errorf("expected ≥2 $effect entities, got %d", len(effects))
+	}
+	for _, eff := range effects {
+		if eff.Kind != "SCOPE.Operation" {
+			t.Errorf("effect Kind = %q, want SCOPE.Operation", eff.Kind)
+		}
+	}
+}
+
+// ── $bindable rune ────────────────────────────────────────────────────────────
+
+func TestExtractor_BindableRune(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	ent := findByName(recs, "value")
+	if ent == nil {
+		t.Fatal("expected entity named 'value' ($bindable rune)")
+	}
+	if ent.Subtype != "rune_state" {
+		t.Errorf("value Subtype = %q, want rune_state", ent.Subtype)
+	}
+}
+
+// ── RENDERS edges ─────────────────────────────────────────────────────────────
+
+func TestExtractor_RendersEdges(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	// <Badge />, <Button>, <Icon /> should each produce exactly ONE RENDERS edge.
+	for _, child := range []string{"Badge", "Button", "Icon"} {
+		if !rendersTarget(recs, child) {
+			t.Errorf("expected RENDERS edge to %q", child)
+		}
+	}
+
+	// Badge appears twice in the template but should be deduplicated.
+	badgeCount := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "RENDERS" && rel.ToID == "Badge" {
+				badgeCount++
+			}
+		}
+	}
+	if badgeCount != 1 {
+		t.Errorf("Badge RENDERS count = %d, want 1 (deduplication)", badgeCount)
+	}
+}
+
+// ── entity recall (≥80%) ──────────────────────────────────────────────────────
+
+// TestExtractor_EntityRecall verifies that the fixture produces at least
+// the expected entities. Entities counted:
+//
+//	ProductCard (component)  = 1
+//	title, price             = 2 (export let)
+//	label, description       = 2 ($props destructure)
+//	count                    = 1 ($state)
+//	doubled                  = 1 ($derived)
+//	value                    = 1 ($bindable)
+//	$effect × 2              = 2
+//
+// Total expected = 10.  Threshold = 80% → 8 minimum.
+func TestExtractor_EntityRecall(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	expectedEntities := []string{
+		"ProductCard", "title", "price", "label", "description",
+		"count", "doubled", "value",
+	}
+
+	found := 0
+	for _, want := range expectedEntities {
+		if findByName(recs, want) != nil {
+			found++
+		}
+	}
+
+	total := len(expectedEntities)
+	threshold := int(float64(total)*0.8 + 0.5) // round up
+	if found < threshold {
+		t.Errorf("entity recall: found %d/%d (want ≥%d)", found, total, threshold)
+	}
+}
+
+// ── zero false positives ──────────────────────────────────────────────────────
+
+// TestExtractor_NoFalsePositives ensures no entity has an empty name, blank
+// kind, or quality_score outside [0,1].
+func TestExtractor_NoFalsePositives(t *testing.T) {
+	recs := mustExtract(t, "ProductCard.svelte", productCardSvelte)
+
+	for _, r := range recs {
+		if strings.TrimSpace(r.Name) == "" {
+			t.Errorf("entity with blank Name: %+v", r)
+		}
+		if strings.TrimSpace(r.Kind) == "" {
+			t.Errorf("entity with blank Kind: %+v", r)
+		}
+		if r.QualityScore < 0 || r.QualityScore > 1 {
+			t.Errorf("entity %q QualityScore = %.2f outside [0,1]", r.Name, r.QualityScore)
+		}
+		if r.SourceFile == "" {
+			t.Errorf("entity %q has empty SourceFile", r.Name)
+		}
+		if r.Language != "svelte" {
+			t.Errorf("entity %q Language = %q, want svelte", r.Name, r.Language)
+		}
+	}
+}
+
+// ── empty file ────────────────────────────────────────────────────────────────
+
+func TestExtractor_EmptyFile(t *testing.T) {
+	recs := mustExtract(t, "Empty.svelte", "")
+	if len(recs) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(recs))
+	}
+}
+
+// ── template-only file (no script) ───────────────────────────────────────────
+
+func TestExtractor_TemplateOnly(t *testing.T) {
+	src := `<h1>Hello World</h1>
+<p>A simple template with no script block.</p>
+`
+	recs := mustExtract(t, "Hello.svelte", src)
+
+	comp := findByName(recs, "Hello")
+	if comp == nil {
+		t.Fatal("expected component entity 'Hello'")
+	}
+	if comp.Subtype != "svelte_component" {
+		t.Errorf("Subtype = %q, want svelte_component", comp.Subtype)
+	}
+}
+
+// ── minimal Svelte 5 runes-only file ─────────────────────────────────────────
+
+func TestExtractor_RunesOnly(t *testing.T) {
+	src := `<script>
+	let x = $state(0);
+	let y = $derived(x + 1);
+	$effect(() => { console.log(x); });
+</script>
+<p>{x} {y}</p>
+`
+	recs := mustExtract(t, "Counter.svelte", src)
+
+	if findByName(recs, "x") == nil {
+		t.Error("expected $state entity 'x'")
+	}
+	if findByName(recs, "y") == nil {
+		t.Error("expected $derived entity 'y'")
+	}
+	effects := findBySubtype(recs, "rune_effect")
+	if len(effects) == 0 {
+		t.Error("expected ≥1 $effect entity")
+	}
+}
+
+// ── $props() non-destructured form ───────────────────────────────────────────
+
+func TestExtractor_PropsNonDestructured(t *testing.T) {
+	src := `<script>
+	let props = $props();
+</script>
+<div>{props.label}</div>
+`
+	recs := mustExtract(t, "Widget.svelte", src)
+	if findByName(recs, "props") == nil {
+		t.Error("expected $props() entity 'props'")
+	}
+}

--- a/internal/resolve/dynamic_patterns_svelte.go
+++ b/internal/resolve/dynamic_patterns_svelte.go
@@ -1,0 +1,110 @@
+package resolve
+
+import "regexp"
+
+// svelteDynamicPatterns are per-language patterns for Svelte (.svelte) files.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The Svelte extractor emits CALLS edges from script blocks. Three groups of
+// callee shapes appear as unresolvable stubs without this catalog:
+//
+//  1. Svelte 5 runes — $state, $derived, $effect, $props, $bindable.
+//     These are compiler-intrinsics, not functions in the graph.
+//
+//  2. Svelte lifecycle helpers — onMount, onDestroy, beforeUpdate, afterUpdate,
+//     tick. Imported from "svelte", never indexed as user entities.
+//
+//  3. Svelte stores — writable, readable, derived, get. Imported from
+//     "svelte/store".
+//
+//  4. SvelteKit navigation/routing helpers — goto, pushState, replaceState,
+//     invalidate, invalidateAll, preloadData, preloadCode. Imported from
+//     "$app/navigation".
+//
+//  5. SvelteKit page store — the `page` store imported from "$app/stores".
+//     Bare identifiers like `$page.url` are stripped to `page` after the
+//     receiver is removed; same for `navigating`, `updated`.
+//
+// All patterns are gated to lang=="svelte" to prevent collisions with Go,
+// Python, or JavaScript identifiers of the same name.
+var svelteDynamicPatterns = []*regexp.Regexp{
+	// ── Svelte 5 runes ────────────────────────────────────────────────────
+	// Runes are compiler-intrinsics (prefixed with $); the extractor emits
+	// them as SCOPE.Operation entities but may also emit CALLS edges for bare
+	// rune invocations that appear as expression statements.
+	regexp.MustCompile(`^\$state$`),
+	regexp.MustCompile(`^\$derived$`),
+	regexp.MustCompile(`^\$effect$`),
+	regexp.MustCompile(`^\$effect\.pre$`),   // $effect.pre(() => {})
+	regexp.MustCompile(`^\$effect\.root$`),  // $effect.root(() => {})
+	regexp.MustCompile(`^\$props$`),
+	regexp.MustCompile(`^\$bindable$`),
+	regexp.MustCompile(`^\$inspect$`),       // $inspect(value) — Svelte 5 debug rune
+	regexp.MustCompile(`^\$host$`),          // $host() — Svelte 5 custom element host rune
+
+	// ── Svelte 4 lifecycle helpers ────────────────────────────────────────
+	// Imported from "svelte". These run in the component lifecycle but are
+	// never graph entities in the indexed codebase.
+	regexp.MustCompile(`^onMount$`),
+	regexp.MustCompile(`^onDestroy$`),
+	regexp.MustCompile(`^beforeUpdate$`),
+	regexp.MustCompile(`^afterUpdate$`),
+	regexp.MustCompile(`^tick$`),
+	regexp.MustCompile(`^setContext$`),
+	regexp.MustCompile(`^getContext$`),
+	regexp.MustCompile(`^hasContext$`),
+	regexp.MustCompile(`^getAllContexts$`),
+	regexp.MustCompile(`^createEventDispatcher$`),
+
+	// ── Svelte store helpers ──────────────────────────────────────────────
+	// Imported from "svelte/store".
+	regexp.MustCompile(`^writable$`),
+	regexp.MustCompile(`^readable$`),
+	regexp.MustCompile(`^derived$`),
+	regexp.MustCompile(`^get$`),
+
+	// ── SvelteKit navigation ──────────────────────────────────────────────
+	// Imported from "$app/navigation".
+	regexp.MustCompile(`^goto$`),
+	regexp.MustCompile(`^pushState$`),
+	regexp.MustCompile(`^replaceState$`),
+	regexp.MustCompile(`^invalidate$`),
+	regexp.MustCompile(`^invalidateAll$`),
+	regexp.MustCompile(`^preloadData$`),
+	regexp.MustCompile(`^preloadCode$`),
+	regexp.MustCompile(`^beforeNavigate$`),
+	regexp.MustCompile(`^afterNavigate$`),
+	regexp.MustCompile(`^onNavigate$`),
+
+	// ── SvelteKit stores ──────────────────────────────────────────────────
+	// Imported from "$app/stores". After the extractor strips the $ sigil
+	// prefix (used as auto-subscription shorthand), these appear as bare
+	// identifiers.
+	regexp.MustCompile(`^page$`),
+	regexp.MustCompile(`^navigating$`),
+	regexp.MustCompile(`^updated$`),
+
+	// ── SvelteKit environment / paths ─────────────────────────────────────
+	// Imported from "$app/environment" / "$app/paths".
+	regexp.MustCompile(`^browser$`),
+	regexp.MustCompile(`^dev$`),
+	regexp.MustCompile(`^building$`),
+	regexp.MustCompile(`^version$`),
+	regexp.MustCompile(`^base$`),
+	regexp.MustCompile(`^assets$`),
+
+	// ── Svelte transition / animation / action helpers ────────────────────
+	// Imported from "svelte/transition", "svelte/animate", "svelte/action".
+	regexp.MustCompile(`^fade$`),
+	regexp.MustCompile(`^fly$`),
+	regexp.MustCompile(`^slide$`),
+	regexp.MustCompile(`^scale$`),
+	regexp.MustCompile(`^blur$`),
+	regexp.MustCompile(`^crossfade$`),
+	regexp.MustCompile(`^draw$`),
+	regexp.MustCompile(`^flip$`),
+}
+
+func init() {
+	dynamicPatternsByLang["svelte"] = svelteDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Add first-class Svelte support: a regex-based extractor for \`.svelte\` single-file components, a resolver dynamic-pattern slice, classifier routing, and registry wiring.

- \`internal/extractors/svelte/extractor.go\` — parses Svelte SFC sections (script / template / style); emits \`SCOPE.Component\` (\`svelte_component\`) for the whole file, \`SCOPE.Operation\` for \`export let\` props and Svelte-5 runes (\`\$state\`, \`\$derived\`, \`\$effect\`, \`\$bindable\`, \`\$props\`), and \`RENDERS\` edges for PascalCase child-component tags in the template (deduplicated).
- \`internal/extractors/svelte/extractor_test.go\` — 14 tests over a synthetic Svelte 5 + SvelteKit fixture (\`ProductCard.svelte\`); entity recall ≥80%, zero false positives.
- \`internal/resolve/dynamic_patterns_svelte.go\` — resolver slice gated to \`lang==\"svelte\"\` covering Svelte-5 runes, lifecycle helpers, store helpers, SvelteKit navigation, SvelteKit stores and transition/animation helpers.
- \`internal/classifier/classifier.go\` — route \`.svelte\` → \`\"svelte\"\` (was \`\"html\"\`) so the dedicated extractor receives these files.
- \`internal/classifier/classifier_test.go\` — update two HTML-group tests; add \`TestSvelte_LanguageToken\`.
- \`internal/extractors/registry_gen.go\` — blank-import svelte extractor.

## Closes / Refs

- \`board:exempt\` — new language extractor, no pre-existing issue tracked.

## What was built

| Entity kind | Subtype | Trigger |
|---|---|---|
| \`SCOPE.Component\` | \`svelte_component\` | whole \`.svelte\` file |
| \`SCOPE.Operation\` | \`prop\` | \`export let x\` / \`\$props()\` destructure |
| \`SCOPE.Operation\` | \`rune_state\` | \`let x = \$state(…)\` / \`\$bindable(…)\` |
| \`SCOPE.Operation\` | \`rune_derived\` | \`let x = \$derived(…)\` |
| \`SCOPE.Operation\` | \`rune_effect\` | \`\$effect(…)\` call |
| Relationship | \`RENDERS\` | \`<ChildComponent />\` in template |

Resolver slice: 45 patterns across Svelte-5 runes, Svelte-4 lifecycle, store helpers, SvelteKit navigation/stores/env, and transition/animation utilities.

## Test results

```
ok  github.com/cajasmota/archigraph/internal/extractors/svelte   (14/14 PASS)
ok  github.com/cajasmota/archigraph/internal/classifier          (all PASS)
ok  github.com/cajasmota/archigraph/internal/resolve             (all PASS)
```

Entity recall on synthetic fixture: 8/8 named entities (100%) — above ≥80% threshold.
Zero false positives (no blank names, no out-of-range quality scores).

## Testing

- [x] All tests pass: \`go test ./internal/extractors/... ./internal/resolve/... ./internal/classifier/...\`
- [x] Synthetic Svelte 5 + SvelteKit fixture verified (14 unit tests)
- [x] Entity recall ≥80% confirmed
- [x] Zero false positives confirmed
- [x] No regression in existing extractor or classifier tests

## Notes

No tree-sitter grammar for Svelte exists in \`go-tree-sitter\`, so this extractor uses the same layered regex approach as the Razor extractor. The \`<script>\` block is extracted with a single non-greedy regex capturing group; rune patterns anchor to \`^\s*\` to avoid matching mid-expression occurrences.