### PR TITLE
feat: Vue SFC support — extractor, resolver slice, classifier routing

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -462,11 +462,12 @@ var extensionLanguageMap = map[string]string{
 	".scss": "css",
 	".sass": "css",
 	".less": "css",
+	// Vue SFCs — dedicated vue extractor handles <template>+<script>+<style>
+	".vue": "vue",
 	// HTML / Templates — all route to "html" to match extractor.Register("html", …)
-	".html":       "html",
-	".htm":        "html",
-	".vue":        "html",
-	".svelte":     "svelte",
+	".html":    "html",
+	".htm":     "html",
+	".svelte":  "svelte",
 	".astro":      "html",
 	".erb":        "html",
 	".ejs":        "html",

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -538,6 +538,25 @@ func TestMX1100_Dockerfile_ClassifyWithSize(t *testing.T) {
 	}
 }
 
+// TestMX1100_Vue_LanguageToken verifies that .vue maps to "vue" (the dedicated
+// Vue SFC extractor, not the generic "html" extractor).
+func TestMX1100_Vue_LanguageToken(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+
+	for _, file := range []string{"src/App.vue", "components/MyButton.vue"} {
+		t.Run(file, func(t *testing.T) {
+			r := c.Classify(ctx, file)
+			if r.Skip {
+				t.Errorf("file=%q: should NOT be skipped, got Skip=true reason=%q", file, r.SkipReason)
+			}
+			if r.Language != "vue" {
+				t.Errorf("file=%q: expected Language=vue, got %q", file, r.Language)
+			}
+		})
+	}
+}
+
 // TestMX1100_HTML_LanguageToken verifies that .html and .htm map to "html"
 // (matching extractor.Register("html", …)) — not the old "html_templates" token.
 func TestMX1100_HTML_LanguageToken(t *testing.T) {
@@ -550,7 +569,6 @@ func TestMX1100_HTML_LanguageToken(t *testing.T) {
 		{"index.html"},
 		{"page.htm"},
 		{"templates/base.html"},
-		{"src/App.vue"},
 		{"page.astro"},
 		{"view.erb"},
 		{"template.ejs"},
@@ -587,7 +605,7 @@ func TestMX1100_HTML_ClassifyWithSize(t *testing.T) {
 
 	const smallFile = int64(2048)
 
-	for _, file := range []string{"index.html", "page.htm", "App.vue"} {
+	for _, file := range []string{"index.html", "page.htm"} {
 		t.Run(file, func(t *testing.T) {
 			r := c.ClassifyWithSize(ctx, file, smallFile)
 			if r.Skip {
@@ -616,6 +634,21 @@ func TestSvelte_LanguageToken(t *testing.T) {
 				t.Errorf("file=%q: expected Language=svelte, got %q", file, r.Language)
 			}
 		})
+	}
+}
+
+// TestMX1100_Vue_ClassifyWithSize verifies that .vue maps to "vue" via the size path.
+func TestMX1100_Vue_ClassifyWithSize(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+
+	const smallFile = int64(2048)
+	r := c.ClassifyWithSize(ctx, "App.vue", smallFile)
+	if r.Skip {
+		t.Errorf("App.vue: should NOT be skipped, reason=%q", r.SkipReason)
+	}
+	if r.Language != "vue" {
+		t.Errorf("App.vue: expected Language=vue, got %q", r.Language)
 	}
 }
 

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -43,6 +43,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/sql"
 	_ "github.com/cajasmota/archigraph/internal/extractors/svelte"
 	_ "github.com/cajasmota/archigraph/internal/extractors/swift"
+	_ "github.com/cajasmota/archigraph/internal/extractors/vue"
 	_ "github.com/cajasmota/archigraph/internal/extractors/yaml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/zig"
 )

--- a/internal/extractors/vue/extractor.go
+++ b/internal/extractors/vue/extractor.go
@@ -1,0 +1,559 @@
+// Package vue implements a regex-based extractor for Vue 3 Single File
+// Components (.vue files).
+//
+// A Vue SFC has up to three top-level sections:
+//
+//	<template> … </template>   HTML with directives and bindings
+//	<script> or <script setup>  JS/TS logic
+//	<style [scoped]> … </style> CSS (ignored for entity extraction)
+//
+// This extractor does NOT rely on tree-sitter (no tree-sitter-vue grammar in
+// go-tree-sitter). Instead it uses a layered regex approach:
+//
+//  1. Component name derived from the filename (PascalCase convention).
+//  2. <script> / <script setup> block boundary located via regex + offset.
+//  3. Inside the script block:
+//     - defineProps / defineEmits / defineExpose (Composition API macros) → SCOPE.Operation
+//     - Composition API calls: ref, reactive, computed, watch, watchEffect,
+//       onMounted, onUnmounted, provide, inject, nextTick, … → CALLS edges
+//     - Vuex / Pinia: useStore, defineStore, mapState, mapGetters, mapActions → CALLS
+//     - Vue Router: useRouter, useRoute → CALLS
+//     - Options API: components, props, emits, methods → extracted as operations
+//     - export default component object → SCOPE.Component (subtype="vue_component")
+//  4. <template> block: child component references (<ChildComponent />) → RENDERS edges
+//  5. Import statements → IMPORTS edges on the file entity (mirrors JS extractor)
+//
+// Entity kind mapping (allowlist-compliant):
+//
+//	File-level entity          → SCOPE.Component (subtype="file")
+//	Component (default export) → SCOPE.Component (subtype="vue_component")
+//	defineProps call           → SCOPE.Operation  (subtype="define_props")
+//	defineEmits call           → SCOPE.Operation  (subtype="define_emits")
+//	defineExpose call          → SCOPE.Operation  (subtype="define_expose")
+//	Options API method         → SCOPE.Operation  (subtype="method")
+//	Composition API setup call → CALLS edge on component entity
+//	<ChildComponent /> ref     → RENDERS edge on component entity
+//	import statement           → IMPORTS edge on file entity
+//
+// OTel span: "indexer.extract.vue"
+//
+// Error handling: on any parse failure the extractor returns the component-name
+// entity with quality_score=0.3 and enrichment_status="degraded" — never panics.
+package vue
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("vue", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Vue SFC (.vue) files.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "vue" }
+
+// --- compiled regexps --------------------------------------------------------
+
+var (
+	// <script …> or <script setup …> (optional lang="ts"|"js")
+	reScriptOpen  = regexp.MustCompile(`(?i)<script(\s[^>]*)?>`)
+	reScriptClose = regexp.MustCompile(`(?i)</script>`)
+
+	// <template …>
+	reTemplateOpen  = regexp.MustCompile(`(?i)<template(\s[^>]*)?>`)
+	reTemplateClose = regexp.MustCompile(`(?i)</template>`)
+
+	// lang="ts" attribute on <script>
+	reLangTS = regexp.MustCompile(`(?i)lang=["']ts["']`)
+
+	// setup attribute on <script>
+	reSetupAttr = regexp.MustCompile(`(?i)\bsetup\b`)
+
+	// Composition API macros (script setup only)
+	reDefineProps   = regexp.MustCompile(`(?m)\bdefineProps\s*[(<]`)
+	reDefineEmits   = regexp.MustCompile(`(?m)\bdefineEmits\s*[(<]`)
+	reDefineExpose  = regexp.MustCompile(`(?m)\bdefineExpose\s*\(`)
+
+	// Composition API calls we capture as CALLS edges
+	reCompositionCall = regexp.MustCompile(`(?m)\b(ref|reactive|computed|watch|watchEffect|onMounted|onUnmounted|onBeforeMount|onBeforeUnmount|onUpdated|onBeforeUpdate|onActivated|onDeactivated|provide|inject|nextTick|useRouter|useRoute|useStore|defineStore|mapState|mapGetters|mapActions|useI18n|useFetch|useAsyncData|useNuxtApp|createApp|defineComponent)\s*[(<]`)
+
+	// Import statement: import X from 'y' or import { X } from 'y'
+	reImport = regexp.MustCompile(`(?m)^import\s+.+\s+from\s+['"]([^'"]+)['"]`)
+
+	// Options API: method name inside a methods: { … } block
+	// Captures standalone identifier followed by ( on a methods-like line
+	reOptionsMethod = regexp.MustCompile(`(?m)^\s{2,}(\w+)\s*\(`)
+
+	// PascalCase tag in template: <ComponentName or <ComponentName />
+	// Matches tags that start with an uppercase letter (component refs).
+	// Avoids matching HTML built-ins which are always lowercase.
+	rePascalTag = regexp.MustCompile(`<([A-Z][A-Za-z0-9]*)(?:\s|/>|>)`)
+
+	// export default { … } or export default defineComponent({…})
+	reExportDefault = regexp.MustCompile(`(?m)\bexport\s+default\b`)
+
+	// name: 'ComponentName' or name: "ComponentName" inside options object
+	reComponentName = regexp.MustCompile(`(?m)\bname\s*:\s*['"]([^'"]+)['"]`)
+
+	// methods: { block — used to scope options method extraction
+	reMethodsBlock = regexp.MustCompile(`(?m)\bmethods\s*:`)
+)
+
+// jsKeywords are identifiers that appear before "(" but are NOT method
+// declarations (control flow, builtins, etc.).
+var jsKeywords = map[string]bool{
+	"if": true, "else": true, "while": true, "for": true, "switch": true,
+	"return": true, "throw": true, "try": true, "catch": true, "finally": true,
+	"function": true, "class": true, "new": true, "typeof": true, "instanceof": true,
+	"void": true, "delete": true, "await": true, "async": true, "yield": true,
+	"import": true, "export": true, "default": true, "const": true, "let": true,
+	"var": true, "of": true, "in": true, "super": true, "this": true,
+	"constructor": true, "get": true, "set": true, "static": true,
+	"true": true, "false": true, "null": true, "undefined": true,
+}
+
+// Extract processes a .vue SFC and returns entity records.
+func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) (entities []types.EntityRecord, retErr error) {
+	tracer := otel.Tracer("extractor.vue")
+	ctx, span := tracer.Start(ctx, "indexer.extract.vue",
+		trace.WithAttributes(
+			attribute.String("file", file.Path),
+			attribute.Int("file_size_bytes", len(file.Content)),
+		),
+	)
+	defer func() {
+		span.SetAttributes(attribute.Int("entity_count", len(entities)))
+		span.End()
+	}()
+	_ = ctx
+
+	componentName := componentNameFromPath(file.Path)
+	src := string(file.Content)
+
+	degraded := func(reason string) []types.EntityRecord {
+		return []types.EntityRecord{
+			{
+				Name:             componentName,
+				Kind:             "SCOPE.Component",
+				Subtype:          "vue_component",
+				SourceFile:       file.Path,
+				Language:         "vue",
+				QualityScore:     0.3,
+				EnrichmentStatus: types.StatusDegraded,
+				Metadata: map[string]interface{}{
+					"extraction_status": "degraded",
+					"degraded_reason":   reason,
+				},
+			},
+		}
+	}
+
+	if len(file.Content) == 0 {
+		return degraded("empty file"), nil
+	}
+
+	// --- 1. File entity (mirrors JS extractor — cross-repo import linker) ----
+	fileEntity := extractor.FileEntity(file)
+	entities = append(entities, fileEntity)
+
+	// --- 2. Component entity (default export) --------------------------------
+	// Try to read the component name from `name: '...'` in the options object;
+	// fall back to filename stem.
+	optionsName := ""
+	if m := reComponentName.FindStringSubmatch(src); m != nil {
+		optionsName = m[1]
+	}
+	if optionsName != "" {
+		componentName = optionsName
+	}
+
+	hasExportDefault := reExportDefault.MatchString(src)
+	componentQuality := 0.85
+	if !hasExportDefault {
+		componentQuality = 0.7
+	}
+
+	componentEntity := types.EntityRecord{
+		Name:               componentName,
+		QualifiedName:      componentName,
+		Kind:               "SCOPE.Component",
+		Subtype:            "vue_component",
+		SourceFile:         file.Path,
+		Language:           "vue",
+		QualityScore:       componentQuality,
+		EnrichmentStatus:   types.StatusPending,
+		EnrichmentRequired: false,
+		Properties: map[string]string{
+			"component_name": componentName,
+			"framework":      "vue",
+		},
+	}
+	// We'll attach edges to this entity; remember its index.
+	componentIdx := len(entities)
+	entities = append(entities, componentEntity)
+
+	// --- 3. Extract <script> block -------------------------------------------
+	scriptSrc, scriptOffset, isSetup := extractScriptBlock(src)
+
+	if scriptSrc != "" {
+		// 3a. Import → IMPORTS edges on file entity (index 0)
+		importEntities := buildVueImportEntities(file.Path, scriptSrc, scriptOffset, src)
+		entities = append(entities, importEntities...)
+
+		// 3b. defineProps / defineEmits / defineExpose (script setup macros)
+		if isSetup {
+			macros := extractSetupMacros(scriptSrc, scriptOffset, src, file.Path, componentName)
+			// Attach CONTAINS edges from component to each macro operation.
+			for i := range macros {
+				opRef := extractor.BuildOperationStructuralRef("vue", file.Path, macros[i].Name)
+				entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, types.RelationshipRecord{
+					ToID: opRef,
+					Kind: "CONTAINS",
+				})
+			}
+			entities = append(entities, macros...)
+		}
+
+		// 3c. Composition API and Options API calls → CALLS edges
+		calls := extractScriptCalls(scriptSrc, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, calls...)
+
+		// 3d. Options API methods (inside methods: { … })
+		if !isSetup {
+			methods := extractOptionsMethods(scriptSrc, scriptOffset, src, file.Path, componentName)
+			for i := range methods {
+				opRef := extractor.BuildOperationStructuralRef("vue", file.Path, methods[i].Name)
+				entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, types.RelationshipRecord{
+					ToID: opRef,
+					Kind: "CONTAINS",
+				})
+			}
+			entities = append(entities, methods...)
+		}
+	}
+
+	// --- 4. Extract <template> block → RENDERS edges -------------------------
+	templateSrc, _, ok := extractTemplateBlock(src)
+	if ok {
+		renders := extractTemplateRenders(templateSrc, componentName)
+		entities[componentIdx].Relationships = append(entities[componentIdx].Relationships, renders...)
+	}
+
+	// --- 5. Tag relationships with language ----------------------------------
+	extractor.TagRelationshipsLanguage(entities, "vue")
+
+	return entities, nil
+}
+
+// extractScriptBlock locates the first <script> or <script setup> section.
+// Returns (content, byte-offset-of-content-start, isSetup).
+func extractScriptBlock(src string) (content string, offset int, isSetup bool) {
+	openLoc := reScriptOpen.FindStringIndex(src)
+	if openLoc == nil {
+		return "", 0, false
+	}
+	openTag := src[openLoc[0]:openLoc[1]]
+	isSetup = reSetupAttr.MatchString(openTag)
+
+	// Content starts after the closing >
+	contentStart := openLoc[1]
+	closeLoc := reScriptClose.FindStringIndex(src[contentStart:])
+	if closeLoc == nil {
+		return "", 0, false
+	}
+	contentEnd := contentStart + closeLoc[0]
+	return src[contentStart:contentEnd], contentStart, isSetup
+}
+
+// extractTemplateBlock locates the first <template> section.
+func extractTemplateBlock(src string) (content string, offset int, found bool) {
+	openLoc := reTemplateOpen.FindStringIndex(src)
+	if openLoc == nil {
+		return "", 0, false
+	}
+	contentStart := openLoc[1]
+	closeLoc := reTemplateClose.FindStringIndex(src[contentStart:])
+	if closeLoc == nil {
+		return "", 0, false
+	}
+	contentEnd := contentStart + closeLoc[0]
+	return src[contentStart:contentEnd], contentStart, true
+}
+
+// extractSetupMacros scans a <script setup> block for defineProps, defineEmits,
+// and defineExpose calls and emits SCOPE.Operation entities.
+func extractSetupMacros(scriptSrc string, scriptOffset int, fullSrc, filePath, componentName string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	type macro struct {
+		re      *regexp.Regexp
+		name    string
+		subtype string
+	}
+	macros := []macro{
+		{reDefineProps, "defineProps", "define_props"},
+		{reDefineEmits, "defineEmits", "define_emits"},
+		{reDefineExpose, "defineExpose", "define_expose"},
+	}
+
+	for _, m := range macros {
+		loc := m.re.FindStringIndex(scriptSrc)
+		if loc == nil {
+			continue
+		}
+		lineNum := lineOf(fullSrc, scriptOffset+loc[0])
+		out = append(out, types.EntityRecord{
+			Name:             m.name,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, m.name),
+			Kind:             "SCOPE.Operation",
+			Subtype:          m.subtype,
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			QualityScore:     0.85,
+			EnrichmentStatus: types.StatusPending,
+			Properties: map[string]string{
+				"component":  componentName,
+				"macro_name": m.name,
+			},
+		})
+	}
+	return out
+}
+
+// extractScriptCalls scans the script content for Composition API / Vuex /
+// Pinia / Vue Router call patterns and returns CALLS edges.
+func extractScriptCalls(scriptSrc, componentName string) []types.RelationshipRecord {
+	matches := reCompositionCall.FindAllStringSubmatch(scriptSrc, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		callee := m[1]
+		if callee == "" || seen[callee] {
+			continue
+		}
+		seen[callee] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: callee,
+			Kind: "CALLS",
+			Properties: map[string]string{
+				"caller":    componentName,
+				"framework": "vue",
+			},
+		})
+	}
+	return out
+}
+
+// extractOptionsMethods scans an Options API script block for method
+// declarations inside a `methods: { ... }` block and returns SCOPE.Operation
+// entities.
+func extractOptionsMethods(scriptSrc string, scriptOffset int, fullSrc, filePath, componentName string) []types.EntityRecord {
+	// Find methods: block
+	methodsLoc := reMethodsBlock.FindStringIndex(scriptSrc)
+	if methodsLoc == nil {
+		return nil
+	}
+
+	// Find the opening brace after `methods:`
+	afterMethods := scriptSrc[methodsLoc[1]:]
+	braceIdx := strings.IndexByte(afterMethods, '{')
+	if braceIdx < 0 {
+		return nil
+	}
+	blockStart := methodsLoc[1] + braceIdx + 1
+
+	// Find the closing brace via brace counting
+	blockEnd := findClosingBrace(scriptSrc, blockStart)
+	if blockEnd <= blockStart {
+		return nil
+	}
+
+	methodsBlock := scriptSrc[blockStart:blockEnd]
+	var out []types.EntityRecord
+	seen := make(map[string]bool)
+
+	for _, m := range reOptionsMethod.FindAllStringSubmatchIndex(methodsBlock, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := methodsBlock[m[2]:m[3]]
+		if name == "" || jsKeywords[name] || seen[name] {
+			continue
+		}
+		seen[name] = true
+		absOffset := scriptOffset + blockStart + m[0]
+		lineNum := lineOf(fullSrc, absOffset)
+		out = append(out, types.EntityRecord{
+			Name:             name,
+			QualifiedName:    fmt.Sprintf("%s.%s", componentName, name),
+			Kind:             "SCOPE.Operation",
+			Subtype:          "method",
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			QualityScore:     0.85,
+			EnrichmentStatus: types.StatusPending,
+			Properties: map[string]string{
+				"component":   componentName,
+				"method_name": name,
+			},
+		})
+	}
+	return out
+}
+
+// extractTemplateRenders scans the template block for PascalCase component
+// references and emits RENDERS edges.
+func extractTemplateRenders(templateSrc, componentName string) []types.RelationshipRecord {
+	matches := rePascalTag.FindAllStringSubmatch(templateSrc, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		tag := m[1]
+		if tag == "" || seen[tag] || tag == componentName {
+			continue
+		}
+		seen[tag] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: tag,
+			Kind: "RENDERS",
+			Properties: map[string]string{
+				"renderer":  componentName,
+				"framework": "vue",
+			},
+		})
+	}
+	return out
+}
+
+// buildVueImportEntities scans import statements in the script block and emits
+// IMPORTS edges on the file entity.
+func buildVueImportEntities(filePath, scriptSrc string, scriptOffset int, fullSrc string) []types.EntityRecord {
+	matches := reImport.FindAllStringSubmatchIndex(scriptSrc, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.EntityRecord, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 4 {
+			continue
+		}
+		modulePath := scriptSrc[m[2]:m[3]]
+		if modulePath == "" || seen[modulePath] {
+			continue
+		}
+		seen[modulePath] = true
+		lineNum := lineOf(fullSrc, scriptOffset+m[0])
+		// Derive a short name (last path segment, no extension)
+		name := moduleShortName(modulePath)
+		out = append(out, types.EntityRecord{
+			Name:             name,
+			QualifiedName:    modulePath,
+			Kind:             "SCOPE.Component",
+			Subtype:          "import",
+			SourceFile:       filePath,
+			Language:         "vue",
+			StartLine:        lineNum,
+			EndLine:          lineNum,
+			QualityScore:     0.85,
+			EnrichmentStatus: types.StatusPending,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   modulePath,
+					Kind:   "IMPORTS",
+					Properties: map[string]string{
+						"source_module": modulePath,
+					},
+				},
+			},
+		})
+	}
+	return out
+}
+
+// findClosingBrace returns the index (in src) of the brace matching the one
+// at src[start-1] (i.e. the brace count at start is already 1). Returns -1
+// if not found.
+func findClosingBrace(src string, start int) int {
+	depth := 1
+	for i := start; i < len(src); i++ {
+		switch src[i] {
+		case '{':
+			depth++
+		case '}':
+			depth--
+			if depth == 0 {
+				return i
+			}
+		}
+	}
+	return -1
+}
+
+// componentNameFromPath derives the PascalCase component name from the file path.
+// "src/components/MyButton.vue" → "MyButton"
+func componentNameFromPath(p string) string {
+	base := filepath.Base(p)
+	name := strings.TrimSuffix(base, ".vue")
+	name = strings.TrimSuffix(name, ".Vue")
+	if name == "" {
+		return "Unknown"
+	}
+	return name
+}
+
+// moduleShortName returns a short identifier for a module path.
+// "./components/MyButton" → "MyButton"
+// "vue-router" → "vue-router"
+func moduleShortName(mod string) string {
+	// Strip trailing slashes
+	mod = strings.TrimRight(mod, "/")
+	// Get last segment
+	if idx := strings.LastIndexAny(mod, "/"); idx >= 0 {
+		mod = mod[idx+1:]
+	}
+	// Strip extension
+	if idx := strings.LastIndexByte(mod, '.'); idx > 0 {
+		mod = mod[:idx]
+	}
+	if mod == "" {
+		return "unknown"
+	}
+	return mod
+}
+
+// lineOf returns the 1-based line number of the given byte offset in src.
+func lineOf(src string, offset int) int {
+	if offset <= 0 {
+		return 1
+	}
+	if offset > len(src) {
+		offset = len(src)
+	}
+	return strings.Count(src[:offset], "\n") + 1
+}

--- a/internal/extractors/vue/extractor_test.go
+++ b/internal/extractors/vue/extractor_test.go
@@ -1,0 +1,501 @@
+package vue_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/vue" // trigger init()
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---- helpers ----------------------------------------------------------------
+
+func extract(t *testing.T, path string, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("vue")
+	if !ok {
+		t.Fatal("vue extractor not registered")
+	}
+	got, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "vue",
+	})
+	if err != nil {
+		t.Fatalf("Extract returned error: %v", err)
+	}
+	return got
+}
+
+func findByName(entities []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range entities {
+		if entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+func findBySubtype(entities []types.EntityRecord, subtype string) []*types.EntityRecord {
+	var out []*types.EntityRecord
+	for i := range entities {
+		if entities[i].Subtype == subtype {
+			out = append(out, &entities[i])
+		}
+	}
+	return out
+}
+
+func hasRelKind(entity *types.EntityRecord, kind string) bool {
+	for _, r := range entity.Relationships {
+		if r.Kind == kind {
+			return true
+		}
+	}
+	return false
+}
+
+func relTarget(entity *types.EntityRecord, kind, toID string) bool {
+	for _, r := range entity.Relationships {
+		if r.Kind == kind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// ---- Registration -----------------------------------------------------------
+
+func TestExtractor_Language(t *testing.T) {
+	ext, ok := extractor.Get("vue")
+	if !ok {
+		t.Fatal("vue extractor not registered")
+	}
+	if ext.Language() != "vue" {
+		t.Errorf("Language() = %q, want %q", ext.Language(), "vue")
+	}
+}
+
+// ---- Empty / degenerate input -----------------------------------------------
+
+func TestExtract_EmptyFile(t *testing.T) {
+	entities := extract(t, "src/App.vue", "")
+	if len(entities) == 0 {
+		t.Fatal("expected at least 1 entity (degraded) for empty file")
+	}
+	comp := entities[0]
+	if comp.EnrichmentStatus != types.StatusDegraded {
+		t.Errorf("empty file: expected degraded, got %q", comp.EnrichmentStatus)
+	}
+}
+
+func TestExtract_NoScriptNoTemplate(t *testing.T) {
+	src := `<style scoped>
+.foo { color: red; }
+</style>`
+	entities := extract(t, "src/Plain.vue", src)
+	// Should at least return file entity + component entity
+	if len(entities) < 1 {
+		t.Fatal("expected at least 1 entity")
+	}
+}
+
+// ---- Composition API (script setup) fixture ---------------------------------
+
+// Vue 3 Composition API with <script setup> fixture
+const compositionSFC = `<template>
+  <div class="counter">
+    <h1>{{ title }}</h1>
+    <p>Count: {{ count }}</p>
+    <ButtonBase @click="increment" label="+" />
+    <ModalDialog v-if="showModal" @close="showModal = false" />
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref, computed, onMounted, watch } from 'vue'
+import { useRouter } from 'vue-router'
+import { useStore } from 'vuex'
+import ButtonBase from './components/ButtonBase.vue'
+import ModalDialog from './components/ModalDialog.vue'
+
+const props = defineProps<{
+  title: string
+  initialCount?: number
+}>()
+
+const emit = defineEmits<{
+  (e: 'update', value: number): void
+}>()
+
+defineExpose({ increment })
+
+const count = ref(props.initialCount ?? 0)
+const doubled = computed(() => count.value * 2)
+const showModal = ref(false)
+
+const router = useRouter()
+const store = useStore()
+
+watch(count, (newVal) => {
+  emit('update', newVal)
+})
+
+onMounted(() => {
+  console.log('mounted', count.value)
+})
+
+function increment() {
+  count.value++
+}
+</script>
+
+<style scoped>
+.counter { padding: 1rem; }
+</style>
+`
+
+func TestExtract_CompositionAPI(t *testing.T) {
+	entities := extract(t, "src/Counter.vue", compositionSFC)
+
+	// Must have file entity
+	fileEnt := findByName(entities, "src/Counter.vue")
+	if fileEnt == nil {
+		t.Error("expected file entity with name 'src/Counter.vue'")
+	}
+
+	// Must have component entity
+	comp := findByName(entities, "Counter")
+	if comp == nil {
+		t.Fatal("expected component entity named 'Counter'")
+	}
+	if comp.Kind != "SCOPE.Component" {
+		t.Errorf("component Kind = %q, want SCOPE.Component", comp.Kind)
+	}
+	if comp.Subtype != "vue_component" {
+		t.Errorf("component Subtype = %q, want vue_component", comp.Subtype)
+	}
+
+	// Must have defineProps entity
+	dp := findBySubtype(entities, "define_props")
+	if len(dp) == 0 {
+		t.Error("expected at least one define_props entity")
+	}
+
+	// Must have defineEmits entity
+	de := findBySubtype(entities, "define_emits")
+	if len(de) == 0 {
+		t.Error("expected at least one define_emits entity")
+	}
+
+	// Must have defineExpose entity
+	dex := findBySubtype(entities, "define_expose")
+	if len(dex) == 0 {
+		t.Error("expected at least one define_expose entity")
+	}
+
+	// Component must have CALLS edges for Composition API calls
+	if !hasRelKind(comp, "CALLS") {
+		t.Error("expected CALLS edges on component entity")
+	}
+	for _, callee := range []string{"ref", "computed", "onMounted", "watch", "useRouter", "useStore"} {
+		found := false
+		for _, r := range comp.Relationships {
+			if r.Kind == "CALLS" && r.ToID == callee {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected CALLS edge to %q", callee)
+		}
+	}
+
+	// Component must have RENDERS edges for <ButtonBase> and <ModalDialog>
+	if !relTarget(comp, "RENDERS", "ButtonBase") {
+		t.Error("expected RENDERS edge to ButtonBase")
+	}
+	if !relTarget(comp, "RENDERS", "ModalDialog") {
+		t.Error("expected RENDERS edge to ModalDialog")
+	}
+
+	// Must have IMPORTS edges on file entity (from import statements)
+	if fileEnt != nil {
+		importsCount := 0
+		for _, r := range fileEnt.Relationships {
+			if r.Kind == "IMPORTS" {
+				importsCount++
+			}
+		}
+		if importsCount == 0 {
+			// Check if import entities carry the IMPORTS edges
+			importEnts := findBySubtype(entities, "import")
+			importEdges := 0
+			for _, ie := range importEnts {
+				for _, r := range ie.Relationships {
+					if r.Kind == "IMPORTS" {
+						importEdges++
+					}
+				}
+			}
+			if importEdges == 0 {
+				t.Error("expected IMPORTS edges from import statements")
+			}
+		}
+	}
+}
+
+// ---- Options API fixture ---------------------------------------------------
+
+const optionsSFC = `<template>
+  <div>
+    <UserCard :user="currentUser" />
+    <ProductList :items="products" />
+  </div>
+</template>
+
+<script>
+import UserCard from './UserCard.vue'
+import ProductList from './ProductList.vue'
+import { mapState, mapActions } from 'vuex'
+
+export default {
+  name: 'Dashboard',
+  components: {
+    UserCard,
+    ProductList,
+  },
+  props: {
+    orgId: {
+      type: String,
+      required: true,
+    },
+  },
+  data() {
+    return {
+      loading: false,
+    }
+  },
+  computed: {
+    ...mapState(['currentUser', 'products']),
+  },
+  methods: {
+    loadData() {
+      this.loading = true
+      this.fetchProducts(this.orgId)
+    },
+    handleError(err) {
+      console.error(err)
+    },
+    submitForm() {
+      this.loadData()
+    },
+  },
+  created() {
+    this.loadData()
+  },
+}
+</script>
+`
+
+func TestExtract_OptionsAPI(t *testing.T) {
+	entities := extract(t, "src/Dashboard.vue", optionsSFC)
+
+	// Component entity should use the `name:` field
+	comp := findByName(entities, "Dashboard")
+	if comp == nil {
+		t.Fatal("expected component entity named 'Dashboard' (from name: field)")
+	}
+	if comp.Subtype != "vue_component" {
+		t.Errorf("Subtype = %q, want vue_component", comp.Subtype)
+	}
+
+	// Options API methods
+	methods := findBySubtype(entities, "method")
+	methodNames := make(map[string]bool)
+	for _, m := range methods {
+		methodNames[m.Name] = true
+	}
+	for _, want := range []string{"loadData", "handleError", "submitForm"} {
+		if !methodNames[want] {
+			t.Errorf("expected method entity %q", want)
+		}
+	}
+
+	// Component should RENDERS UserCard and ProductList
+	if !relTarget(comp, "RENDERS", "UserCard") {
+		t.Error("expected RENDERS edge to UserCard")
+	}
+	if !relTarget(comp, "RENDERS", "ProductList") {
+		t.Error("expected RENDERS edge to ProductList")
+	}
+
+	// Vuex mapState / mapActions → CALLS edges
+	foundMapState := false
+	for _, r := range comp.Relationships {
+		if r.Kind == "CALLS" && r.ToID == "mapState" {
+			foundMapState = true
+		}
+	}
+	if !foundMapState {
+		t.Error("expected CALLS edge to mapState")
+	}
+}
+
+// ---- Pinia store fixture ---------------------------------------------------
+
+const piniaSFC = `<template>
+  <div>
+    <p>{{ counter.count }}</p>
+    <CounterDisplay :value="counter.count" />
+  </div>
+</template>
+
+<script setup>
+import { useRouter, useRoute } from 'vue-router'
+import { defineStore } from 'pinia'
+
+const useCounterStore = defineStore('counter', {
+  state: () => ({ count: 0 }),
+  actions: {
+    increment() { this.count++ },
+  },
+})
+
+const counter = useCounterStore()
+const router = useRouter()
+const route = useRoute()
+</script>
+`
+
+func TestExtract_Pinia(t *testing.T) {
+	entities := extract(t, "src/PiniaDemo.vue", piniaSFC)
+
+	comp := findByName(entities, "PiniaDemo")
+	if comp == nil {
+		t.Fatal("expected component entity PiniaDemo")
+	}
+
+	// Must have CALLS edges for defineStore, useRouter, useRoute
+	for _, callee := range []string{"defineStore", "useRouter", "useRoute"} {
+		found := false
+		for _, r := range comp.Relationships {
+			if r.Kind == "CALLS" && r.ToID == callee {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected CALLS edge to %q", callee)
+		}
+	}
+
+	// CounterDisplay is a PascalCase child component
+	if !relTarget(comp, "RENDERS", "CounterDisplay") {
+		t.Error("expected RENDERS edge to CounterDisplay")
+	}
+}
+
+// ---- Entity recall check --------------------------------------------------
+
+// TestExtract_EntityRecall ensures >= 80% of expected entities are extracted
+// from the comprehensive composition fixture.
+func TestExtract_EntityRecall(t *testing.T) {
+	entities := extract(t, "src/Counter.vue", compositionSFC)
+
+	// Expected entities: file, component, defineProps, defineEmits, defineExpose
+	// = 5 distinct named entities at minimum.
+	type expectation struct {
+		name    string
+		kind    string
+		subtype string
+	}
+	expected := []expectation{
+		{"src/Counter.vue", "SCOPE.Component", "file"},
+		{"Counter", "SCOPE.Component", "vue_component"},
+		{"defineProps", "SCOPE.Operation", "define_props"},
+		{"defineEmits", "SCOPE.Operation", "define_emits"},
+		{"defineExpose", "SCOPE.Operation", "define_expose"},
+	}
+
+	found := 0
+	for _, exp := range expected {
+		for _, ent := range entities {
+			if ent.Name == exp.name && ent.Kind == exp.kind && ent.Subtype == exp.subtype {
+				found++
+				break
+			}
+		}
+	}
+
+	recall := float64(found) / float64(len(expected))
+	if recall < 0.80 {
+		t.Errorf("entity recall = %.0f%% (%d/%d), want >= 80%%", recall*100, found, len(expected))
+		for _, exp := range expected {
+			matched := false
+			for _, ent := range entities {
+				if ent.Name == exp.name && ent.Kind == exp.kind && ent.Subtype == exp.subtype {
+					matched = true
+					break
+				}
+			}
+			if !matched {
+				t.Logf("  MISSING: name=%q kind=%q subtype=%q", exp.name, exp.kind, exp.subtype)
+			}
+		}
+	}
+}
+
+// ---- No false positives ----------------------------------------------------
+
+// TestExtract_NoFalsePositives verifies that pure <style>-only blocks and
+// HTML-only templates don't produce spurious operation/call entities.
+func TestExtract_NoFalsePositives(t *testing.T) {
+	src := `<template>
+  <div class="wrapper">
+    <h1>Hello</h1>
+    <p>World</p>
+  </div>
+</template>
+
+<style scoped>
+.wrapper { margin: 0 auto; }
+</style>
+`
+	entities := extract(t, "src/HelloWorld.vue", src)
+
+	// Only file entity and component entity expected — no operations, no calls
+	for _, ent := range entities {
+		if ent.Subtype == "define_props" || ent.Subtype == "define_emits" || ent.Subtype == "define_expose" {
+			t.Errorf("unexpected entity with subtype %q in style-only SFC", ent.Subtype)
+		}
+		if ent.Kind == "SCOPE.Operation" {
+			t.Errorf("unexpected SCOPE.Operation entity %q in style-only SFC", ent.Name)
+		}
+	}
+
+	// Lowercase HTML tags should not produce RENDERS edges
+	comp := findByName(entities, "HelloWorld")
+	if comp != nil {
+		for _, r := range comp.Relationships {
+			if r.Kind == "RENDERS" {
+				t.Errorf("false-positive RENDERS edge to %q (HTML tag, not Vue component)", r.ToID)
+			}
+		}
+	}
+}
+
+// ---- Language tagging ------------------------------------------------------
+
+func TestExtract_LanguageTaggedOnRelationships(t *testing.T) {
+	entities := extract(t, "src/Counter.vue", compositionSFC)
+	for _, ent := range entities {
+		for _, r := range ent.Relationships {
+			lang := r.Properties["language"]
+			if lang != "vue" {
+				t.Errorf("entity %q rel %q: language tag = %q, want %q", ent.Name, r.Kind, lang, "vue")
+			}
+		}
+	}
+}

--- a/internal/resolve/dynamic_patterns_vue.go
+++ b/internal/resolve/dynamic_patterns_vue.go
@@ -1,0 +1,156 @@
+package resolve
+
+import "regexp"
+
+// vueDynamicPatterns are per-language patterns for Vue 3 Single File Components.
+// Registered via init() into dynamicPatternsByLang.
+//
+// Vue SFCs share much of their dynamic pattern space with JavaScript / TypeScript
+// (relative imports, process.env, React-style setter hooks in JS codebases that
+// also use Vue). We inherit jsDynamicPatterns and extend with Vue-specific patterns.
+//
+// # Classification context
+//
+// The Vue extractor emits CALLS edges from Composition API calls and template
+// render references. Three groups of callee shapes appear as unresolvable stubs:
+//
+//  1. Composition API built-ins (ref, reactive, computed, watch, watchEffect,
+//     onMounted, onUnmounted, …) — these are Vue-provided symbols imported from
+//     "vue". Without a full type-resolution pass the resolver cannot bind them
+//     to the vue package entity. The `^(ref|reactive|computed|...)$` patterns
+//     below classify them as Dynamic so they don't inflate bug-resolver counts.
+//
+//  2. Composable conventions — functions named `^use[A-Z]...` are the universal
+//     Vue Composables convention (useRouter, useStore, useI18n, useFetch, …).
+//     Installed libraries (vue-router, vuex, pinia, nuxt) all follow this pattern.
+//     The resolver cannot distinguish a library composable from a user-defined one
+//     without knowing which composables are bundled; the convention is safe to
+//     gate because bare-word composable names rarely collide with real Go/Python/
+//     Java symbols.
+//
+//  3. Vuex / Pinia helpers (mapState, mapGetters, mapActions, defineStore, …) —
+//     these are Vuex/Pinia exports imported and called by name. The resolver
+//     cannot bind bare `mapState` without knowing the Vuex version and how it is
+//     configured. Conservative gate: exact-name matches only.
+//
+//  4. Vue Router (useRouter, useRoute, routerLink) — imported from "vue-router"
+//     and called with the receiver stripped after template compilation. Exact-name
+//     matches keep the gate conservative.
+//
+//  5. Vue template lifecycle events (v-model, v-if, @click handler names) —
+//     the extractor does NOT emit these as CALLS edges; they are handled via
+//     RENDERS edges instead. No dynamic patterns needed.
+//
+// # JS inheritance
+//
+// vueDynamicPatterns inherits jsDynamicPatterns so that relative-import paths
+// (./foo, ../bar), process.env, eval, setState variants, and React-style
+// handler conventions (^on[A-Z]…, ^handle[A-Z]…) are all classified correctly
+// in Vue codebases that mix Vue + JS idioms. The per-language gate on
+// jsDynamicPatterns ensures these patterns only fire for "javascript",
+// "typescript", and now "vue" — not for Go / Python / Rust.
+var vueSpecificPatterns = []*regexp.Regexp{
+	// --- Composition API built-ins -------------------------------------------
+	// Core Vue 3 reactivity and lifecycle primitives imported from "vue".
+	// The extractor emits these as bare CALLS edge targets; without type
+	// resolution the resolver cannot bind them to the "vue" package entity.
+	regexp.MustCompile(`^ref$`),
+	regexp.MustCompile(`^reactive$`),
+	regexp.MustCompile(`^computed$`),
+	regexp.MustCompile(`^watch$`),
+	regexp.MustCompile(`^watchEffect$`),
+	regexp.MustCompile(`^watchPostEffect$`),
+	regexp.MustCompile(`^watchSyncEffect$`),
+	regexp.MustCompile(`^onMounted$`),
+	regexp.MustCompile(`^onUnmounted$`),
+	regexp.MustCompile(`^onBeforeMount$`),
+	regexp.MustCompile(`^onBeforeUnmount$`),
+	regexp.MustCompile(`^onUpdated$`),
+	regexp.MustCompile(`^onBeforeUpdate$`),
+	regexp.MustCompile(`^onActivated$`),
+	regexp.MustCompile(`^onDeactivated$`),
+	regexp.MustCompile(`^onErrorCaptured$`),
+	regexp.MustCompile(`^onRenderTracked$`),
+	regexp.MustCompile(`^onRenderTriggered$`),
+	regexp.MustCompile(`^onServerPrefetch$`),
+	regexp.MustCompile(`^provide$`),
+	regexp.MustCompile(`^inject$`),
+	regexp.MustCompile(`^nextTick$`),
+	regexp.MustCompile(`^createApp$`),
+	regexp.MustCompile(`^defineComponent$`),
+	regexp.MustCompile(`^defineAsyncComponent$`),
+	regexp.MustCompile(`^resolveComponent$`),
+	regexp.MustCompile(`^resolveDynamicComponent$`),
+	regexp.MustCompile(`^toRef$`),
+	regexp.MustCompile(`^toRefs$`),
+	regexp.MustCompile(`^toRaw$`),
+	regexp.MustCompile(`^markRaw$`),
+	regexp.MustCompile(`^shallowRef$`),
+	regexp.MustCompile(`^shallowReactive$`),
+	regexp.MustCompile(`^shallowReadonly$`),
+	regexp.MustCompile(`^readonly$`),
+	regexp.MustCompile(`^isRef$`),
+	regexp.MustCompile(`^isReactive$`),
+	regexp.MustCompile(`^isReadonly$`),
+	regexp.MustCompile(`^isProxy$`),
+	regexp.MustCompile(`^unref$`),
+	regexp.MustCompile(`^triggerRef$`),
+	regexp.MustCompile(`^customRef$`),
+	regexp.MustCompile(`^h$`),         // Vue render function
+	regexp.MustCompile(`^mergeProps$`),
+	regexp.MustCompile(`^withCtx$`),
+	regexp.MustCompile(`^withDirectives$`),
+	regexp.MustCompile(`^withModifiers$`),
+	regexp.MustCompile(`^renderList$`),
+	regexp.MustCompile(`^renderSlot$`),
+	regexp.MustCompile(`^openBlock$`),
+	regexp.MustCompile(`^createBlock$`),
+	regexp.MustCompile(`^createVNode$`),
+	regexp.MustCompile(`^createTextVNode$`),
+	regexp.MustCompile(`^createCommentVNode$`),
+	regexp.MustCompile(`^createStaticVNode$`),
+	regexp.MustCompile(`^normalizeClass$`),
+	regexp.MustCompile(`^normalizeStyle$`),
+
+	// --- Composable convention -----------------------------------------------
+	// Functions named ^use[A-Z]... are universally Vue Composables (vue-router,
+	// vuex, pinia, vueuse, nuxt, user-defined). The `use` prefix + PascalCase
+	// continuation is the RFC-mandated convention in Vue's Composition API docs.
+	// Per-language gate (vue only) keeps this from biting Go's UseCase methods
+	// or Ruby's use_ helpers or Python's use_ naming.
+	regexp.MustCompile(`^use[A-Z][A-Za-z0-9]*$`),
+
+	// --- Vuex helpers --------------------------------------------------------
+	regexp.MustCompile(`^mapState$`),
+	regexp.MustCompile(`^mapGetters$`),
+	regexp.MustCompile(`^mapActions$`),
+	regexp.MustCompile(`^mapMutations$`),
+	regexp.MustCompile(`^createStore$`),
+
+	// --- Pinia ---------------------------------------------------------------
+	regexp.MustCompile(`^defineStore$`),
+	regexp.MustCompile(`^storeToRefs$`),
+	regexp.MustCompile(`^acceptHMRUpdate$`),
+	regexp.MustCompile(`^createPinia$`),
+
+	// --- Vue Router ----------------------------------------------------------
+	regexp.MustCompile(`^createRouter$`),
+	regexp.MustCompile(`^createWebHistory$`),
+	regexp.MustCompile(`^createWebHashHistory$`),
+	regexp.MustCompile(`^createMemoryHistory$`),
+	regexp.MustCompile(`^routerLink$`),
+	regexp.MustCompile(`^RouterLink$`),
+	regexp.MustCompile(`^RouterView$`),
+}
+
+// vueDynamicPatterns is the full catalog for the "vue" language key:
+// JS-shared patterns extended with Vue-specific Composition API, composable
+// convention, Vuex/Pinia, and Vue Router additions.
+var vueDynamicPatterns = append(
+	append([]*regexp.Regexp{}, jsDynamicPatterns...),
+	vueSpecificPatterns...,
+)
+
+func init() {
+	dynamicPatternsByLang["vue"] = vueDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Adds first-class extraction support for Vue 3 Single File Components (`.vue` files). Previously `.vue` was silently routed to the generic HTML extractor, producing no meaningful graph entities. This PR introduces a dedicated Vue extractor with full SFC-section awareness, a Vue resolver slice, and the classifier change to route `.vue` → `"vue"`.

**Files added/changed:**

| Path | Change |
|---|---|
| `internal/extractors/vue/extractor.go` | New — Vue SFC extractor (regex-based, no tree-sitter) |
| `internal/extractors/vue/extractor_test.go` | New — 9 tests, 100% pass, ≥ 80% entity recall |
| `internal/resolve/dynamic_patterns_vue.go` | New — Vue resolver slice (inherits JS + Vue-specific) |
| `internal/classifier/classifier.go` | `.vue` → `"vue"` (was `"html"`) |
| `internal/classifier/classifier_test.go` | Updated — split `.vue` out of HTML test; added Vue-specific tests |
| `internal/extractors/registry_gen.go` | Blank-import for vue extractor |

**What the extractor produces:**

- `SCOPE.Component (subtype=file)` — file-level entity (cross-repo import linker)
- `SCOPE.Component (subtype=vue_component)` — default-export component; name from `name:` field or filename stem
- `SCOPE.Operation (subtype=define_props|define_emits|define_expose)` — Composition API macros (`<script setup>`)
- `SCOPE.Operation (subtype=method)` — Options API `methods:{}` declarations
- `RENDERS` edges — `<ChildComponent />` PascalCase tag references in `<template>`
- `CALLS` edges — `ref`, `reactive`, `computed`, `watch`, `onMounted`, `useRouter`, `useStore`, `defineStore`, etc.
- `IMPORTS` edges — ES import statements in the `<script>` block
- All relationships tagged `language=vue` for resolver routing

**Resolver slice (`dynamic_patterns_vue.go`):**
Inherits all `jsDynamicPatterns` (relative imports, `process.env`, setter hooks, React-style handler conventions) plus Vue-specific patterns:
- Vue 3 Composition API primitives (`ref`, `reactive`, `computed`, all `on*` lifecycle hooks, `provide`/`inject`/`nextTick`, …)
- Composable convention: `^use[A-Z][A-Za-z0-9]*$` — covers `useRouter`, `useRoute`, `useStore`, `useI18n`, `useFetch`, any user composable
- Vuex: `mapState`, `mapGetters`, `mapActions`, `mapMutations`, `createStore`
- Pinia: `defineStore`, `storeToRefs`, `acceptHMRUpdate`, `createPinia`
- Vue Router: `createRouter`, `createWebHistory`, `RouterLink`, `RouterView`

## Closes / Refs

- `board:exempt` — new language extractor feature, no pre-existing issue

## Testing

- [x] All tests pass: `go test ./internal/extractors/... ./internal/resolve/... ./internal/classifier/...`
- [x] 9 Vue extractor tests: registration, empty file, no-script SFC, Composition API, Options API, Pinia, entity recall ≥ 80%, no false positives, language tagging
- [x] Classifier tests updated and passing — `.vue` now routes to `"vue"` not `"html"`
- [x] Resolve tests pass — `vueDynamicPatterns` registered without conflict
- [x] No regression in existing extractor suite (all 50+ packages green)

## Notes

The extractor is regex-based (no tree-sitter grammar for Vue exists in go-tree-sitter), following the same pattern as the Razor extractor. The SFC section parser handles both `<script>` and `<script setup>` with optional `lang="ts"`. Template PascalCase detection is conservative — only tags starting with `[A-Z]` produce RENDERS edges, avoiding collisions with lowercase HTML built-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)