### PR TITLE
feat: Astro framework support

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -465,10 +465,11 @@ var extensionLanguageMap = map[string]string{
 	// Vue SFCs — dedicated vue extractor handles <template>+<script>+<style>
 	".vue": "vue",
 	// HTML / Templates — all route to "html" to match extractor.Register("html", …)
-	".html":    "html",
-	".htm":     "html",
-	".svelte":  "svelte",
-	".astro":      "html",
+	".html":   "html",
+	".htm":    "html",
+	".svelte": "svelte",
+	// Astro SFCs — dedicated astro extractor (feat/astro-extractor)
+	".astro": "astro",
 	".erb":        "html",
 	".ejs":        "html",
 	".hbs":        "html",

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -569,7 +569,6 @@ func TestMX1100_HTML_LanguageToken(t *testing.T) {
 		{"index.html"},
 		{"page.htm"},
 		{"templates/base.html"},
-		{"page.astro"},
 		{"view.erb"},
 		{"template.ejs"},
 		{"layout.hbs"},
@@ -593,6 +592,29 @@ func TestMX1100_HTML_LanguageToken(t *testing.T) {
 			}
 			if r.Language != "html" {
 				t.Errorf("file=%q: expected Language=html (not html_templates), got %q", tc.file, r.Language)
+			}
+		})
+	}
+}
+
+// TestAstroLanguageToken verifies that .astro files map to the "astro"
+// language token (matching extractor.Register("astro", …)).
+func TestAstroLanguageToken(t *testing.T) {
+	c := newTestClassifier(t)
+	ctx := context.Background()
+
+	for _, file := range []string{
+		"page.astro",
+		"src/pages/index.astro",
+		"src/components/Header.astro",
+	} {
+		t.Run(file, func(t *testing.T) {
+			r := c.Classify(ctx, file)
+			if r.Skip {
+				t.Errorf("file=%q: should NOT be skipped, reason=%q", file, r.SkipReason)
+			}
+			if r.Language != "astro" {
+				t.Errorf("file=%q: expected Language=astro, got %q", file, r.Language)
 			}
 		})
 	}

--- a/internal/extractors/astro/extractor.go
+++ b/internal/extractors/astro/extractor.go
@@ -1,0 +1,351 @@
+// Package astro implements a regex-based extractor for Astro single-file
+// components (.astro files).
+//
+// An Astro SFC has three sections:
+//
+//	Frontmatter (between --- markers)  — TypeScript with imports, props, data fetching
+//	HTML template body                 — markup with component references and expressions
+//	<style> blocks                     — scoped CSS (ignored for entity extraction)
+//
+// Extracted entities:
+//
+//	Whole file                        → SCOPE.Component   subtype="astro_page" (under pages/) or "astro_component"
+//	Frontmatter imports               → IMPORTS edges on the component entity
+//	const props = Astro.props         → SCOPE.Operation   subtype="props_binding"
+//	const { x } = Astro.props         → SCOPE.Operation   subtype="prop" per named prop
+//	<PascalCase />                    → RENDERS edges
+//	client:load / client:idle /       → IMPLEMENTS edges (framework island markers)
+//	  client:visible / client:only
+//
+// Astro globals (Astro.url, Astro.params, etc.), content-collection helpers
+// (getCollection, getEntry, defineCollection), and view-transition directives
+// (transition:name, transition:animate) are handled by the resolver slice
+// (dynamic_patterns_astro.go) to prevent dangling CALLS stubs.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package astro
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/trace"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("astro", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Astro SFC files.
+type Extractor struct{}
+
+// Language returns the canonical language key.
+func (e *Extractor) Language() string { return "astro" }
+
+// ── compiled regexps ─────────────────────────────────────────────────────────
+
+var (
+	// frontmatterRE captures the content between the opening and closing ---
+	// markers that begin an Astro file. The opening --- must be at the very
+	// start of the file (optional leading whitespace tolerated).
+	frontmatterRE = regexp.MustCompile(`(?s)^\s*---\n(.*?)\n---`)
+
+	// importRE matches TypeScript/JS import statements inside the frontmatter.
+	// Captures the module path (single or double quoted).
+	//   import Foo from './Foo.astro'
+	//   import { bar } from '../lib/bar'
+	importRE = regexp.MustCompile(`(?m)^import\s+.+\s+from\s+['"]([^'"]+)['"]`)
+
+	// astroPropsDestructureRE matches:
+	//   const { title, description = 'default' } = Astro.props
+	// Captures the interior of the braces (group 1).
+	astroPropsDestructureRE = regexp.MustCompile(`(?m)const\s+\{([^}]+)\}\s*=\s*Astro\.props`)
+
+	// astroPropsBindingRE matches the non-destructured form:
+	//   const props = Astro.props
+	// Captures the binding name (group 1).
+	astroPropsBindingRE = regexp.MustCompile(`(?m)const\s+([A-Za-z_$][A-Za-z0-9_$]*)\s*=\s*Astro\.props`)
+
+	// childComponentRE finds PascalCase component tags (including self-closing).
+	// A PascalCase tag in Astro is always a component (lowercase = HTML element).
+	childComponentRE = regexp.MustCompile(`<([A-Z][A-Za-z0-9]*)\b`)
+
+	// islandAttrRE detects framework-island client directives on a tag.
+	// Matches client:load, client:idle, client:visible, client:only="…",
+	// client:media="…".
+	islandAttrRE = regexp.MustCompile(`\bclient:(load|idle|visible|only(?:="[^"]*")?|media(?:="[^"]*")?)`)
+
+	// styleBlockRE strips <style …>…</style> from the body before template scan.
+	styleBlockRE = regexp.MustCompile(`(?si)<style(?:[^>]*)>.*?</style>`)
+)
+
+// Extract parses the Astro SFC source and returns entity records.
+func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	tracer := otel.Tracer("extractor.astro")
+	ctx, span := tracer.Start(ctx, "indexer.extract.astro",
+		trace.WithAttributes(attribute.String("language", "astro")),
+	)
+	defer span.End()
+
+	_ = ctx // used only for span
+
+	src := string(file.Content)
+	if len(src) == 0 {
+		span.SetAttributes(
+			attribute.Int("file_line_count", 0),
+			attribute.Int("entity_count", 0),
+		)
+		return nil, nil
+	}
+
+	lineCount := strings.Count(src, "\n") + 1
+	componentName := componentNameFromPath(file.Path)
+	subtype := pageSubtype(file.Path)
+
+	var entities []types.EntityRecord
+
+	// ── 1. Whole-file component entity ──────────────────────────────────────
+	componentEntity := types.EntityRecord{
+		Name:         componentName,
+		Kind:         "SCOPE.Component",
+		Subtype:      subtype,
+		SourceFile:   file.Path,
+		Language:     "astro",
+		StartLine:    1,
+		EndLine:      lineCount,
+		Signature:    componentName + ".astro",
+		QualityScore: 0.85,
+	}
+	entities = append(entities, componentEntity)
+
+	// ── 2. Frontmatter section ───────────────────────────────────────────────
+	frontmatter, fmStartLine := extractFrontmatter(src)
+	if frontmatter != "" {
+		// 2a. Import edges
+		importRels := extractImports(frontmatter, fmStartLine, file.Path)
+		entities[0].Relationships = append(entities[0].Relationships, importRels...)
+
+		// 2b. Astro.props bindings → SCOPE.Operation entities
+		propEntities := extractPropsEntities(frontmatter, fmStartLine, file.Path)
+		entities = append(entities, propEntities...)
+	}
+
+	// ── 3. Template: child components (RENDERS) and islands (IMPLEMENTS) ─────
+	body := extractBody(src)
+	if body != "" {
+		renderRels, islandRels := extractTemplateRelationships(body, file.Path, componentName)
+		entities[0].Relationships = append(entities[0].Relationships, renderRels...)
+		entities[0].Relationships = append(entities[0].Relationships, islandRels...)
+	}
+
+	span.SetAttributes(
+		attribute.Int("file_line_count", lineCount),
+		attribute.Int("entity_count", len(entities)),
+	)
+	return entities, nil
+}
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+// componentNameFromPath derives the component name from the file base name.
+// "src/pages/index.astro" → "index"
+// "src/components/Header.astro" → "Header"
+func componentNameFromPath(path string) string {
+	base := filepath.Base(path)
+	name := strings.TrimSuffix(base, ".astro")
+	if name == "" {
+		return "Component"
+	}
+	return name
+}
+
+// pageSubtype returns "astro_page" if the file is under a pages/ directory,
+// otherwise "astro_component".
+func pageSubtype(path string) string {
+	// Normalize separators for matching.
+	norm := filepath.ToSlash(path)
+	if strings.Contains(norm, "/pages/") || strings.HasPrefix(norm, "pages/") {
+		return "astro_page"
+	}
+	return "astro_component"
+}
+
+// extractFrontmatter returns the content between the --- markers and the
+// 1-based line number of the first content line inside the block.
+// Returns ("", 0) if no frontmatter is found.
+func extractFrontmatter(src string) (string, int) {
+	m := frontmatterRE.FindStringSubmatchIndex(src)
+	if m == nil {
+		return "", 0
+	}
+	inner := src[m[2]:m[3]]
+	// Line number of the first character of inner content.
+	startLine := strings.Count(src[:m[2]], "\n") + 1
+	return inner, startLine
+}
+
+// extractBody strips the frontmatter block and all <style> elements, returning
+// the remaining HTML template.
+func extractBody(src string) string {
+	// Remove frontmatter.
+	stripped := frontmatterRE.ReplaceAllString(src, "")
+	// Remove <style> blocks.
+	stripped = styleBlockRE.ReplaceAllString(stripped, "")
+	return strings.TrimSpace(stripped)
+}
+
+// extractImports returns IMPORTS relationship records for each import
+// statement found in the frontmatter.
+func extractImports(fm string, fmStartLine int, filePath string) []types.RelationshipRecord {
+	var rels []types.RelationshipRecord
+	seen := make(map[string]struct{})
+
+	for _, m := range importRE.FindAllStringSubmatchIndex(fm, -1) {
+		modulePath := fm[m[2]:m[3]]
+		if _, exists := seen[modulePath]; exists {
+			continue
+		}
+		seen[modulePath] = struct{}{}
+		rels = append(rels, types.RelationshipRecord{
+			FromID: filePath,
+			ToID:   modulePath,
+			Kind:   "IMPORTS",
+			Properties: map[string]string{
+				"source_module": modulePath,
+				"line":          fmt.Sprintf("%d", fmStartLine+strings.Count(fm[:m[0]], "\n")),
+			},
+		})
+	}
+	return rels
+}
+
+// extractPropsEntities parses Astro.props usages in the frontmatter and emits
+// SCOPE.Operation entities.
+//
+// Destructured form: const { title, description = 'default' } = Astro.props
+// → one entity per named prop (subtype="prop").
+//
+// Non-destructured form: const props = Astro.props
+// → one entity for the binding (subtype="props_binding").
+func extractPropsEntities(fm string, fmStartLine int, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	lineOf := func(idx int) int {
+		return fmStartLine + strings.Count(fm[:idx], "\n")
+	}
+
+	// Destructured: const { a, b = 'x' } = Astro.props
+	for _, m := range astroPropsDestructureRE.FindAllStringSubmatchIndex(fm, -1) {
+		lineNum := lineOf(m[0])
+		inner := fm[m[2]:m[3]]
+		for _, field := range strings.Split(inner, ",") {
+			field = strings.TrimSpace(field)
+			// Strip default-value suffix: `label = "hello"` → "label"
+			if idx := strings.IndexAny(field, "=:"); idx >= 0 {
+				field = strings.TrimSpace(field[:idx])
+			}
+			if field == "" {
+				continue
+			}
+			entities = append(entities, types.EntityRecord{
+				Name:         field,
+				Kind:         "SCOPE.Operation",
+				Subtype:      "prop",
+				SourceFile:   filePath,
+				Language:     "astro",
+				StartLine:    lineNum,
+				EndLine:      lineNum,
+				Signature:    "Astro.props: " + field,
+				QualityScore: 0.85,
+			})
+		}
+	}
+
+	// Non-destructured: const props = Astro.props
+	// Only match bindings that are NOT followed by '{', to avoid re-matching
+	// the destructured form.
+	for _, m := range astroPropsBindingRE.FindAllStringSubmatchIndex(fm, -1) {
+		name := fm[m[2]:m[3]]
+		// Skip if this is actually part of a destructured match (name == "{")
+		if name == "" {
+			continue
+		}
+		lineNum := lineOf(m[0])
+		entities = append(entities, types.EntityRecord{
+			Name:         name,
+			Kind:         "SCOPE.Operation",
+			Subtype:      "props_binding",
+			SourceFile:   filePath,
+			Language:     "astro",
+			StartLine:    lineNum,
+			EndLine:      lineNum,
+			Signature:    "const " + name + " = Astro.props",
+			QualityScore: 0.85,
+		})
+	}
+
+	return entities
+}
+
+// extractTemplateRelationships scans the HTML body for:
+//   - PascalCase component tags → RENDERS edges (deduplicated)
+//   - client:* directives on those tags → IMPLEMENTS edges
+func extractTemplateRelationships(body, filePath, componentName string) (renders []types.RelationshipRecord, islands []types.RelationshipRecord) {
+	seenRenders := make(map[string]struct{})
+	seenIslands := make(map[string]struct{})
+
+	for _, m := range childComponentRE.FindAllStringSubmatchIndex(body, -1) {
+		name := body[m[2]:m[3]]
+		lineIdx := strings.Count(body[:m[0]], "\n")
+
+		// RENDERS edge (deduplicated per component name).
+		if _, exists := seenRenders[name]; !exists {
+			seenRenders[name] = struct{}{}
+			renders = append(renders, types.RelationshipRecord{
+				FromID: filePath,
+				ToID:   name,
+				Kind:   "RENDERS",
+				Properties: map[string]string{
+					"from_component": componentName,
+					"to_component":   name,
+					"line":           fmt.Sprintf("%d", lineIdx+1),
+				},
+			})
+		}
+
+		// IMPLEMENTS edge — detect whether this particular tag occurrence has a
+		// client:* directive. We scan forward from the tag open to the next >.
+		tagEnd := strings.Index(body[m[0]:], ">")
+		if tagEnd < 0 {
+			continue
+		}
+		tagSrc := body[m[0] : m[0]+tagEnd+1]
+		if islandAttrRE.MatchString(tagSrc) {
+			islandKey := name
+			if _, exists := seenIslands[islandKey]; !exists {
+				seenIslands[islandKey] = struct{}{}
+				directive := islandAttrRE.FindString(tagSrc)
+				islands = append(islands, types.RelationshipRecord{
+					FromID: filePath,
+					ToID:   name,
+					Kind:   "IMPLEMENTS",
+					Properties: map[string]string{
+						"island_directive": directive,
+						"host_component":   componentName,
+						"framework_island": name,
+						"line":             fmt.Sprintf("%d", lineIdx+1),
+					},
+				})
+			}
+		}
+	}
+	return renders, islands
+}

--- a/internal/extractors/astro/extractor_test.go
+++ b/internal/extractors/astro/extractor_test.go
@@ -1,0 +1,435 @@
+package astro_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/astro" // trigger init()
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+func mustExtract(t *testing.T, path, src string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("astro")
+	if !ok {
+		t.Fatal("astro extractor not registered")
+	}
+	recs, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "astro",
+	})
+	if err != nil {
+		t.Fatalf("Extract error: %v", err)
+	}
+	return recs
+}
+
+func findByName(recs []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range recs {
+		if recs[i].Name == name {
+			return &recs[i]
+		}
+	}
+	return nil
+}
+
+func findBySubtype(recs []types.EntityRecord, subtype string) []types.EntityRecord {
+	var out []types.EntityRecord
+	for _, r := range recs {
+		if r.Subtype == subtype {
+			out = append(out, r)
+		}
+	}
+	return out
+}
+
+func hasRelKind(recs []types.EntityRecord, kind, toID string) bool {
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == kind && (toID == "" || rel.ToID == toID) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func countRelKind(recs []types.EntityRecord, kind string) int {
+	n := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == kind {
+				n++
+			}
+		}
+	}
+	return n
+}
+
+// ── synthetic fixture — Astro page under pages/ ──────────────────────────────
+//
+// BlogPost.astro — represents a typical Astro page with:
+//   - frontmatter: imports, Astro.props destructure
+//   - framework islands (React + Vue)
+//   - child component references
+//   - duplicate tags (should be deduplicated in RENDERS)
+//   - <style> block (should be ignored)
+const blogPostAstro = `---
+import Layout from '../layouts/Layout.astro';
+import Header from '../components/Header.astro';
+import ReactCounter from '../components/ReactCounter.jsx';
+import VueLikeButton from '../components/VueLikeButton.vue';
+import { getCollection, getEntry } from 'astro:content';
+
+const { title, description = 'No description', publishDate } = Astro.props;
+const posts = await getCollection('blog');
+---
+
+<Layout title={title}>
+  <Header />
+  <article>
+    <h1>{title}</h1>
+    <p>{description}</p>
+    <ReactCounter client:load initialCount={0} />
+    <VueLikeButton client:idle postId="123" />
+    <!-- Duplicate Header — should produce only one RENDERS edge -->
+    <Header />
+  </article>
+</Layout>
+
+<style>
+  article {
+    max-width: 65ch;
+    margin: 0 auto;
+  }
+</style>
+`
+
+// ── registration ─────────────────────────────────────────────────────────────
+
+func TestExtractor_Language(t *testing.T) {
+	ext, ok := extractor.Get("astro")
+	if !ok {
+		t.Fatal("astro extractor not registered")
+	}
+	if ext.Language() != "astro" {
+		t.Errorf("Language() = %q, want %q", ext.Language(), "astro")
+	}
+}
+
+// ── component entity — page subtype ──────────────────────────────────────────
+
+func TestExtractor_PageEntity(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	comp := findByName(recs, "BlogPost")
+	if comp == nil {
+		t.Fatal("expected SCOPE.Component entity named 'BlogPost'")
+	}
+	if comp.Kind != "SCOPE.Component" {
+		t.Errorf("Kind = %q, want SCOPE.Component", comp.Kind)
+	}
+	if comp.Subtype != "astro_page" {
+		t.Errorf("Subtype = %q, want astro_page", comp.Subtype)
+	}
+	if comp.StartLine != 1 {
+		t.Errorf("StartLine = %d, want 1", comp.StartLine)
+	}
+	if comp.Language != "astro" {
+		t.Errorf("Language = %q, want astro", comp.Language)
+	}
+}
+
+// ── component entity — non-page subtype ──────────────────────────────────────
+
+func TestExtractor_ComponentSubtype(t *testing.T) {
+	const src = `---
+const { label } = Astro.props;
+---
+<button>{label}</button>
+`
+	recs := mustExtract(t, "src/components/MyButton.astro", src)
+	comp := findByName(recs, "MyButton")
+	if comp == nil {
+		t.Fatal("expected component entity 'MyButton'")
+	}
+	if comp.Subtype != "astro_component" {
+		t.Errorf("Subtype = %q, want astro_component", comp.Subtype)
+	}
+}
+
+// ── frontmatter imports → IMPORTS edges ──────────────────────────────────────
+
+func TestExtractor_ImportEdges(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	for _, want := range []string{
+		"../layouts/Layout.astro",
+		"../components/Header.astro",
+		"../components/ReactCounter.jsx",
+		"../components/VueLikeButton.vue",
+		"astro:content",
+	} {
+		if !hasRelKind(recs, "IMPORTS", want) {
+			t.Errorf("expected IMPORTS edge to %q", want)
+		}
+	}
+}
+
+// ── Astro.props destructured → prop entities ─────────────────────────────────
+
+func TestExtractor_DestructuredProps(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	props := findBySubtype(recs, "prop")
+	propNames := make(map[string]bool)
+	for _, p := range props {
+		propNames[p.Name] = true
+	}
+
+	for _, want := range []string{"title", "description", "publishDate"} {
+		if !propNames[want] {
+			t.Errorf("expected prop entity %q, got: %v", want, propNames)
+		}
+	}
+
+	// Verify Kind on each prop
+	titleProp := findByName(recs, "title")
+	if titleProp == nil {
+		t.Fatal("expected entity named 'title'")
+	}
+	if titleProp.Kind != "SCOPE.Operation" {
+		t.Errorf("title Kind = %q, want SCOPE.Operation", titleProp.Kind)
+	}
+}
+
+// ── Astro.props non-destructured binding ─────────────────────────────────────
+
+func TestExtractor_PropsBinding(t *testing.T) {
+	const src = `---
+const props = Astro.props;
+---
+<div>{props.title}</div>
+`
+	recs := mustExtract(t, "src/components/Widget.astro", src)
+
+	binding := findByName(recs, "props")
+	if binding == nil {
+		t.Fatal("expected entity 'props' for non-destructured Astro.props binding")
+	}
+	if binding.Subtype != "props_binding" {
+		t.Errorf("Subtype = %q, want props_binding", binding.Subtype)
+	}
+}
+
+// ── template RENDERS edges ────────────────────────────────────────────────────
+
+func TestExtractor_RendersEdges(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	for _, child := range []string{"Layout", "Header", "ReactCounter", "VueLikeButton"} {
+		if !hasRelKind(recs, "RENDERS", child) {
+			t.Errorf("expected RENDERS edge to %q", child)
+		}
+	}
+
+	// Header appears twice but must be deduplicated to a single RENDERS edge.
+	headerCount := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "RENDERS" && rel.ToID == "Header" {
+				headerCount++
+			}
+		}
+	}
+	if headerCount != 1 {
+		t.Errorf("Header RENDERS count = %d, want 1 (deduplication)", headerCount)
+	}
+}
+
+// ── framework island IMPLEMENTS edges ────────────────────────────────────────
+
+func TestExtractor_IslandImplementsEdges(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	// ReactCounter uses client:load, VueLikeButton uses client:idle.
+	for _, island := range []string{"ReactCounter", "VueLikeButton"} {
+		if !hasRelKind(recs, "IMPLEMENTS", island) {
+			t.Errorf("expected IMPLEMENTS edge to %q (framework island)", island)
+		}
+	}
+
+	// Non-island components should NOT get an IMPLEMENTS edge.
+	if hasRelKind(recs, "IMPLEMENTS", "Header") {
+		t.Error("Header is not an island; should not have IMPLEMENTS edge")
+	}
+}
+
+// ── island directives captured in properties ─────────────────────────────────
+
+func TestExtractor_IslandDirectiveProperty(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPLEMENTS" && rel.ToID == "ReactCounter" {
+				if !strings.Contains(rel.Properties["island_directive"], "client:load") {
+					t.Errorf("ReactCounter IMPLEMENTS directive = %q, want client:load",
+						rel.Properties["island_directive"])
+				}
+				return
+			}
+		}
+	}
+	t.Error("ReactCounter IMPLEMENTS edge not found")
+}
+
+// ── client:visible directive ──────────────────────────────────────────────────
+
+func TestExtractor_ClientVisibleIsland(t *testing.T) {
+	const src = `---
+import LazyChart from '../components/LazyChart.jsx';
+---
+<LazyChart client:visible width={800} />
+`
+	recs := mustExtract(t, "src/pages/Dashboard.astro", src)
+	if !hasRelKind(recs, "IMPLEMENTS", "LazyChart") {
+		t.Error("expected IMPLEMENTS edge for client:visible island LazyChart")
+	}
+}
+
+// ── entity recall (≥ 80%) ────────────────────────────────────────────────────
+
+// Expected entities in blogPostAstro:
+//
+//	BlogPost (component)           = 1
+//	title, description, publishDate = 3 (props)
+//
+// Total = 4.  Threshold 80% → 4 * 0.8 = 3.2 → ceil → 4 minimum.
+// We also count import + renders edges separately via relationship tests.
+func TestExtractor_EntityRecall(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	expected := []string{"BlogPost", "title", "description", "publishDate"}
+	found := 0
+	for _, want := range expected {
+		if findByName(recs, want) != nil {
+			found++
+		}
+	}
+	total := len(expected)
+	threshold := int(float64(total)*0.8 + 0.5)
+	if found < threshold {
+		t.Errorf("entity recall: found %d/%d (want ≥%d)", found, total, threshold)
+	}
+}
+
+// ── zero false positives ─────────────────────────────────────────────────────
+
+func TestExtractor_NoFalsePositives(t *testing.T) {
+	recs := mustExtract(t, "src/pages/BlogPost.astro", blogPostAstro)
+
+	for _, r := range recs {
+		if strings.TrimSpace(r.Name) == "" {
+			t.Errorf("entity with blank Name: %+v", r)
+		}
+		if strings.TrimSpace(r.Kind) == "" {
+			t.Errorf("entity with blank Kind: %+v", r)
+		}
+		if r.QualityScore < 0 || r.QualityScore > 1 {
+			t.Errorf("entity %q QualityScore = %.2f outside [0,1]", r.Name, r.QualityScore)
+		}
+		if r.SourceFile == "" {
+			t.Errorf("entity %q has empty SourceFile", r.Name)
+		}
+		if r.Language != "astro" {
+			t.Errorf("entity %q Language = %q, want astro", r.Name, r.Language)
+		}
+	}
+}
+
+// ── empty file ────────────────────────────────────────────────────────────────
+
+func TestExtractor_EmptyFile(t *testing.T) {
+	recs := mustExtract(t, "Empty.astro", "")
+	if len(recs) != 0 {
+		t.Errorf("expected 0 entities for empty file, got %d", len(recs))
+	}
+}
+
+// ── template-only (no frontmatter) ───────────────────────────────────────────
+
+func TestExtractor_NoFrontmatter(t *testing.T) {
+	const src = `<main>
+  <h1>Hello from Astro</h1>
+  <p>No frontmatter at all.</p>
+</main>
+`
+	recs := mustExtract(t, "src/components/Simple.astro", src)
+	comp := findByName(recs, "Simple")
+	if comp == nil {
+		t.Fatal("expected component entity 'Simple'")
+	}
+	if comp.Subtype != "astro_component" {
+		t.Errorf("Subtype = %q, want astro_component", comp.Subtype)
+	}
+	// No props entities expected.
+	if len(findBySubtype(recs, "prop")) != 0 {
+		t.Error("expected no prop entities for template-only file")
+	}
+}
+
+// ── style block stripped from template scan ───────────────────────────────────
+
+func TestExtractor_StyleBlockIgnored(t *testing.T) {
+	const src = `---
+import Nav from './Nav.astro';
+---
+<Nav />
+<style>
+  /* Nav should not be extracted as a component from here */
+  .Nav { color: red; }
+</style>
+`
+	recs := mustExtract(t, "src/components/Page.astro", src)
+	// Only one RENDERS edge to Nav (from the template, not from style).
+	navCount := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "RENDERS" && rel.ToID == "Nav" {
+				navCount++
+			}
+		}
+	}
+	if navCount != 1 {
+		t.Errorf("Nav RENDERS count = %d, want 1", navCount)
+	}
+}
+
+// ── import deduplication ──────────────────────────────────────────────────────
+
+func TestExtractor_ImportDeduplication(t *testing.T) {
+	const src = `---
+import Foo from './Foo.astro';
+import Foo from './Foo.astro';
+---
+<Foo />
+`
+	recs := mustExtract(t, "src/pages/Dedup.astro", src)
+	fooImports := 0
+	for _, r := range recs {
+		for _, rel := range r.Relationships {
+			if rel.Kind == "IMPORTS" && rel.ToID == "./Foo.astro" {
+				fooImports++
+			}
+		}
+	}
+	if fooImports != 1 {
+		t.Errorf("expected exactly 1 IMPORTS edge for './Foo.astro', got %d", fooImports)
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -3,6 +3,7 @@
 package extractors
 
 import (
+	_ "github.com/cajasmota/archigraph/internal/extractors/astro"
 	_ "github.com/cajasmota/archigraph/internal/extractors/clojure"
 	_ "github.com/cajasmota/archigraph/internal/extractors/crystal"
 	_ "github.com/cajasmota/archigraph/internal/extractors/cpp"

--- a/internal/resolve/dynamic_patterns_astro.go
+++ b/internal/resolve/dynamic_patterns_astro.go
@@ -1,0 +1,76 @@
+package resolve
+
+import "regexp"
+
+// astroDynamicPatterns are per-language patterns for Astro (.astro) files.
+// Registered via init() into dynamicPatternsByLang.
+//
+// Three groups of callee shapes appear as unresolvable stubs without this catalog:
+//
+//  1. Astro global object accessors — Astro.url, Astro.params, Astro.props,
+//     Astro.request, Astro.cookies, Astro.redirect, Astro.glob, Astro.site,
+//     Astro.generator, Astro.self, Astro.slots, Astro.locals.
+//     These are injected by the Astro runtime; they are never graph entities.
+//
+//  2. Content collection helpers — getCollection, getEntry, getEntries,
+//     defineCollection, reference.  Imported from "astro:content".
+//
+//  3. View transition directives — transition:name, transition:animate,
+//     transition:persist. These appear as template attributes, not callable
+//     functions; resolving them prevents false CALLS stubs.
+//
+//  4. Astro.fetchContent (deprecated v1 API) and Image/Picture built-ins
+//     from "astro:assets".
+//
+// All patterns are gated to lang=="astro" to prevent collisions with other
+// languages.
+var astroDynamicPatterns = []*regexp.Regexp{
+	// ── Astro global accessors ────────────────────────────────────────────
+	regexp.MustCompile(`^Astro\.url$`),
+	regexp.MustCompile(`^Astro\.params$`),
+	regexp.MustCompile(`^Astro\.props$`),
+	regexp.MustCompile(`^Astro\.request$`),
+	regexp.MustCompile(`^Astro\.cookies$`),
+	regexp.MustCompile(`^Astro\.redirect$`),
+	regexp.MustCompile(`^Astro\.glob$`),
+	regexp.MustCompile(`^Astro\.site$`),
+	regexp.MustCompile(`^Astro\.generator$`),
+	regexp.MustCompile(`^Astro\.self$`),
+	regexp.MustCompile(`^Astro\.slots$`),
+	regexp.MustCompile(`^Astro\.locals$`),
+	// Catch-all for any remaining Astro.* property access.
+	regexp.MustCompile(`^Astro\.[A-Za-z][A-Za-z0-9_]*$`),
+
+	// ── Content collection helpers ────────────────────────────────────────
+	// Imported from "astro:content".
+	regexp.MustCompile(`^getCollection$`),
+	regexp.MustCompile(`^getEntry$`),
+	regexp.MustCompile(`^getEntries$`),
+	regexp.MustCompile(`^defineCollection$`),
+	regexp.MustCompile(`^reference$`),
+	regexp.MustCompile(`^z$`), // zod re-export from astro:content
+
+	// ── View transition directives ────────────────────────────────────────
+	// Template attributes treated as dynamic call targets by the resolver.
+	regexp.MustCompile(`^transition:name$`),
+	regexp.MustCompile(`^transition:animate$`),
+	regexp.MustCompile(`^transition:persist$`),
+
+	// ── Astro assets ──────────────────────────────────────────────────────
+	// Imported from "astro:assets".
+	regexp.MustCompile(`^Image$`),
+	regexp.MustCompile(`^Picture$`),
+	regexp.MustCompile(`^getImage$`),
+
+	// ── Deprecated v1 API ─────────────────────────────────────────────────
+	regexp.MustCompile(`^Astro\.fetchContent$`),
+
+	// ── Astro middleware ──────────────────────────────────────────────────
+	// Imported from "astro:middleware".
+	regexp.MustCompile(`^defineMiddleware$`),
+	regexp.MustCompile(`^sequence$`),
+}
+
+func init() {
+	dynamicPatternsByLang["astro"] = astroDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Adds full extraction support for Astro `.astro` single-file components — a rapidly growing modern frontend framework. The extractor handles both page files (under `pages/`) and component files, along with framework islands (client hydration directives) which are unique to Astro.

**Changed files:**
- `internal/extractors/astro/extractor.go` — parses frontmatter (`---` block), HTML template body, and emits: `SCOPE.Component` (subtype `astro_page` / `astro_component`), `IMPORTS` edges from frontmatter import statements, `SCOPE.Operation` entities from `Astro.props` destructure and binding patterns, `RENDERS` edges from PascalCase template tags (deduplicated), and `IMPLEMENTS` edges for framework islands (`client:load`, `client:idle`, `client:visible`, `client:only`).
- `internal/extractors/astro/extractor_test.go` — 16 tests; synthetic fixture with page + components + islands. Covers entity recall ≥80%, zero false positives, deduplication, directive property capture, style-block stripping, template-only and empty-file edge cases.
- `internal/resolve/dynamic_patterns_astro.go` — resolver slice preventing dangling CALLS stubs for Astro globals (`Astro.*`), content-collection helpers (`getCollection`, `getEntry`, `defineCollection`), view-transition directives, and `astro:assets` / `astro:middleware` built-ins.
- `internal/classifier/classifier.go` — `.astro` → `"astro"` (was `"html"`).
- `internal/classifier/classifier_test.go` — removes `.astro` from the HTML token test; adds `TestAstroLanguageToken`.
- `internal/extractors/registry_gen.go` — blank-import astro package so `init()` fires.

## Closes / Refs
- `board:exempt`

## Testing
- [x] All tests pass: `go test ./internal/extractors/astro/... ./internal/classifier/... ./internal/resolve/...`
- [x] 16/16 extractor tests pass — 100%
- [x] Entity recall: 4/4 named entities extracted (100%, threshold 80%)
- [x] Zero false positives (all entities have non-blank Name/Kind, Language="astro", QualityScore in [0,1])
- [x] RENDERS deduplication confirmed (Header appears twice in fixture, one RENDERS edge produced)
- [x] Framework islands: `client:load` → IMPLEMENTS on ReactCounter, `client:idle` → IMPLEMENTS on VueLikeButton
- [x] Classifier test updated — `TestAstroLanguageToken` passes for page.astro, src/pages/index.astro, src/components/Header.astro
- [x] Resolve tests pass — no regression in cross-language dynamic patterns

## Notes

The `pageSubtype` function distinguishes pages from components by path — any file under a `pages/` directory segment gets `astro_page`, everything else gets `astro_component`. This matches Astro's routing convention.

`IMPLEMENTS` edges on framework islands encode the specific `client:*` directive in the `island_directive` property, enabling downstream tooling to distinguish hydration strategies without re-parsing the source.