### PR TITLE
feat: Standard ML (SML) extractor + resolver slice

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -502,6 +502,10 @@ var extensionLanguageMap = map[string]string{
 	// OCaml — .ml is claimed for OCaml (SML is much less common)
 	".ml":  "ocaml",
 	".mli": "ocaml",
+	// Standard ML — .ml is OCaml above; SML uses .sml/.sig/.fun
+	".sml": "sml",
+	".sig": "sml",
+	".fun": "sml",
 	// ReScript
 	".res":  "rescript",
 	".resi": "rescript",

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -37,6 +37,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/rescript"
 	_ "github.com/cajasmota/archigraph/internal/extractors/ruby"
 	_ "github.com/cajasmota/archigraph/internal/extractors/rust"
+	_ "github.com/cajasmota/archigraph/internal/extractors/sml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/scala"
 	_ "github.com/cajasmota/archigraph/internal/extractors/solidity"
 	_ "github.com/cajasmota/archigraph/internal/extractors/shell"

--- a/internal/extractors/sml/extractor.go
+++ b/internal/extractors/sml/extractor.go
@@ -1,0 +1,661 @@
+// Package sml implements a regex-based extractor for Standard ML source files.
+//
+// Extracted entities:
+//   - `structure Foo : SIG = struct ... end` → SCOPE.Component (subtype="structure")
+//   - `signature SIG = sig ... end`          → SCOPE.Component (subtype="signature")
+//   - `functor Foo (X : SIG) = struct ... end` → SCOPE.Component (subtype="functor")
+//   - `fun name args = body`                 → SCOPE.Operation (subtype="function")
+//   - `val name = expr`                      → SCOPE.Operation (subtype="val")
+//   - `datatype 'a tree = Leaf | Node`       → SCOPE.Component (subtype="datatype")
+//   - `open Foo` statements                  → IMPORTS edges
+//   - Function applications                  → CALLS edges
+//
+// File extensions handled: .sml, .sig, .fun
+// NOTE: .ml is intentionally left mapped to OCaml — do NOT change that.
+//
+// No tree-sitter grammar for SML is available in smacker/go-tree-sitter, so
+// this extractor uses regular expressions. SML uses explicit struct/sig/end
+// block delimiters, making indentation-independent parsing feasible.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package sml
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("sml", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for Standard ML.
+type Extractor struct{}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return "sml" }
+
+// -----------------------------------------------------------------------
+// Compiled regex patterns
+// -----------------------------------------------------------------------
+
+var (
+	// structureRE matches structure declarations:
+	//   structure Foo = struct ... end
+	//   structure Foo : SIG = struct ... end
+	structureRE = regexp.MustCompile(
+		`(?m)^structure\s+([A-Za-z][A-Za-z0-9_']*)\s*(?::[^=]*)?\s*=`,
+	)
+
+	// signatureRE matches signature declarations:
+	//   signature SIG = sig ... end
+	signatureRE = regexp.MustCompile(
+		`(?m)^signature\s+([A-Z][A-Za-z0-9_']*)\s*=`,
+	)
+
+	// functorRE matches functor declarations:
+	//   functor Foo (X : SIG) = struct ... end
+	//   functor Foo (X : SIG) : OUTSIG = struct ... end
+	functorRE = regexp.MustCompile(
+		`(?m)^functor\s+([A-Za-z][A-Za-z0-9_']*)\s*\(`,
+	)
+
+	// funRE matches top-level fun declarations (at column 0):
+	//   fun name args = body
+	//   fun name args = body | name args = body   (clausal)
+	funRE = regexp.MustCompile(
+		`(?m)^fun\s+([a-z_][A-Za-z0-9_']*)\s`,
+	)
+
+	// valRE matches top-level val declarations (at column 0):
+	//   val name = expr
+	//   val rec name = fn ...
+	valRE = regexp.MustCompile(
+		`(?m)^val(?:\s+rec)?\s+([a-z_][A-Za-z0-9_']*)\s*=`,
+	)
+
+	// datatypeRE matches datatype declarations:
+	//   datatype 'a tree = Leaf | Node of 'a * 'a tree
+	//   datatype color = Red | Green | Blue
+	datatypeRE = regexp.MustCompile(
+		`(?m)^datatype\s+(?:(?:'[A-Za-z_][A-Za-z0-9_']*\s+)+)?([A-Za-z][A-Za-z0-9_']*)\s*=`,
+	)
+
+	// openRE matches open statements:
+	//   open Foo
+	//   open Foo.Bar
+	openRE = regexp.MustCompile(
+		`(?m)^open\s+([A-Z][A-Za-z0-9_'.]*(?:\.[A-Z][A-Za-z0-9_']*)*)`,
+	)
+
+	// callDotRE matches module-qualified calls: Structure.function
+	callDotRE = regexp.MustCompile(
+		`\b([A-Z][A-Za-z0-9_']*(?:\.[A-Z][A-Za-z0-9_']*)*\.[a-z_][A-Za-z0-9_']*)\b`,
+	)
+
+	// callBareRE matches bare function applications: identifier <space>
+	callBareRE = regexp.MustCompile(
+		`\b([a-z_][A-Za-z0-9_']*)\s+`,
+	)
+)
+
+// smlKeywords is the set of SML tokens to exclude from CALLS edges.
+var smlKeywords = map[string]bool{
+	// Core keywords
+	"abstype": true, "and": true, "andalso": true, "as": true,
+	"case": true, "datatype": true, "do": true,
+	"else": true, "end": true, "eqtype": true, "exception": true,
+	"fn": true, "fun": true, "functor": true,
+	"handle": true,
+	"if": true, "in": true, "include": true, "infix": true, "infixr": true,
+	"let": true, "local": true,
+	"nonfix": true,
+	"of": true, "op": true, "open": true, "orelse": true,
+	"raise": true, "rec": true,
+	"sharing": true, "sig": true, "signature": true, "struct": true,
+	"structure": true,
+	"then": true, "type": true,
+	"val": true,
+	"where": true, "while": true, "with": true, "withtype": true,
+	// Common pervasives
+	"true": true, "false": true, "nil": true,
+	"not": true, "hd": true, "tl": true, "null": true,
+	"fst": true, "snd": true,
+	"print": true, "ignore": true,
+	"ref": true,
+}
+
+// Extract processes an SML source file and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	out := extractSML(string(file.Content), file.Path)
+	extractor.TagRelationshipsLanguage(out, "sml")
+	return out, nil
+}
+
+func extractSML(src, filePath string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// Emit file-level entity.
+	entities = append(entities, extractor.FileEntity(extractor.FileInput{
+		Path:     filePath,
+		Language: "sml",
+	}))
+
+	imports := collectOpenStatements(src)
+	importEntities := buildImportEntities(filePath, imports)
+	entities = append(entities, importEntities...)
+
+	// 1. Structure declarations.
+	seenStructures := make(map[string]bool)
+	for _, m := range structureRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenStructures[name] {
+			continue
+		}
+		// Must be at column 0.
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenStructures[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractBlockBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "structure",
+			SourceFile: filePath,
+			Language:   "sml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "structure " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 2. Signature declarations.
+	seenSignatures := make(map[string]bool)
+	for _, m := range signatureRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenSignatures[name] {
+			continue
+		}
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenSignatures[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractBlockBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "signature",
+			SourceFile: filePath,
+			Language:   "sml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "signature " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 3. Functor declarations.
+	seenFunctors := make(map[string]bool)
+	for _, m := range functorRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenFunctors[name] {
+			continue
+		}
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenFunctors[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractBlockBody(src, m[1])
+		endLine := startLine + strings.Count(body, "\n")
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "functor",
+			SourceFile: filePath,
+			Language:   "sml",
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  "functor " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 4. Datatype declarations.
+	seenDatatypes := make(map[string]bool)
+	for _, m := range datatypeRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenDatatypes[name] {
+			continue
+		}
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenDatatypes[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		entities = append(entities, types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "datatype",
+			SourceFile: filePath,
+			Language:   "sml",
+			StartLine:  startLine,
+			EndLine:    startLine, // single logical line for datatypes
+			Signature:  "datatype " + name,
+			Properties: map[string]string{
+				"imports": strings.Join(imports, ","),
+			},
+		})
+	}
+
+	// 5. fun function declarations (top-level only, at column 0).
+	seenFuns := make(map[string]bool)
+	for _, m := range funRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenFuns[name] {
+			continue
+		}
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenFuns[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractFunBody(src, m[0])
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+
+		// Build signature from declaration line.
+		sig := buildOneLinerSig(src, m[0])
+
+		entities = append(entities, types.EntityRecord{
+			Name:          name,
+			Kind:          "SCOPE.Operation",
+			Subtype:       "function",
+			SourceFile:    filePath,
+			Language:      "sml",
+			StartLine:     startLine,
+			EndLine:       endLine,
+			Signature:     sig,
+			Properties:    map[string]string{"imports": strings.Join(imports, ",")},
+			Relationships: calls,
+		})
+	}
+
+	// 6. val declarations (top-level only, at column 0).
+	seenVals := make(map[string]bool)
+	for _, m := range valRE.FindAllStringSubmatchIndex(src, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := src[m[2]:m[3]]
+		if seenVals[name] || seenFuns[name] {
+			continue
+		}
+		lineStart := strings.LastIndex(src[:m[0]], "\n") + 1
+		if lineStart != m[0] {
+			continue
+		}
+		seenVals[name] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		body := extractFunBody(src, m[0])
+		endLine := startLine + strings.Count(body, "\n")
+		calls := collectCalls(body, name)
+		sig := buildOneLinerSig(src, m[0])
+
+		entities = append(entities, types.EntityRecord{
+			Name:          name,
+			Kind:          "SCOPE.Operation",
+			Subtype:       "val",
+			SourceFile:    filePath,
+			Language:      "sml",
+			StartLine:     startLine,
+			EndLine:       endLine,
+			Signature:     sig,
+			Properties:    map[string]string{"imports": strings.Join(imports, ",")},
+			Relationships: calls,
+		})
+	}
+
+	return entities
+}
+
+// -----------------------------------------------------------------------
+// Helper: import collection
+// -----------------------------------------------------------------------
+
+func collectOpenStatements(src string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+	for _, m := range openRE.FindAllStringSubmatch(src, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		mod := strings.TrimSpace(m[1])
+		// Strip inline SML comments (* ... *)
+		if ci := strings.Index(mod, "(*"); ci >= 0 {
+			mod = strings.TrimSpace(mod[:ci])
+		}
+		if mod == "" || seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		imports = append(imports, mod)
+	}
+	return imports
+}
+
+func buildImportEntities(filePath string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		displayName := importDisplayName(mod)
+		out = append(out, types.EntityRecord{
+			Name:       displayName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   "sml",
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+func importDisplayName(mod string) string {
+	if dot := strings.LastIndexByte(mod, '.'); dot >= 0 {
+		return mod[dot+1:]
+	}
+	return mod
+}
+
+// -----------------------------------------------------------------------
+// Helper: body extraction
+// -----------------------------------------------------------------------
+
+// extractBlockBody extracts the body of an SML structure/signature/functor
+// by counting struct/sig/let/local/fn...end depth.
+func extractBlockBody(src string, afterPos int) string {
+	if afterPos >= len(src) {
+		return ""
+	}
+	rest := src[afterPos:]
+
+	// depth-counting: track keywords that open new nesting levels.
+	openKW := regexp.MustCompile(`\b(struct|sig|let|local|fn)\b`)
+	closeKW := regexp.MustCompile(`\bend\b`)
+
+	depth := 0
+	found := false
+	endPos := 0
+
+	i := 0
+	for i < len(rest) {
+		// Skip SML block comment (* ... *) — not nested in SML.
+		if i+1 < len(rest) && rest[i] == '(' && rest[i+1] == '*' {
+			i += 2
+			for i < len(rest) {
+				if i+1 < len(rest) && rest[i] == '*' && rest[i+1] == ')' {
+					i += 2
+					break
+				}
+				i++
+			}
+			continue
+		}
+		// Skip string literal "..."
+		if rest[i] == '"' {
+			i++
+			for i < len(rest) && rest[i] != '"' {
+				if rest[i] == '\\' {
+					i++
+				}
+				i++
+			}
+			i++
+			continue
+		}
+		// Skip char literal #"."
+		if i+2 < len(rest) && rest[i] == '#' && rest[i+1] == '"' {
+			i += 2
+			for i < len(rest) && rest[i] != '"' {
+				i++
+			}
+			i++
+			continue
+		}
+
+		remaining := rest[i:]
+		if om := openKW.FindStringIndex(remaining); om != nil && om[0] == 0 {
+			depth++
+			i += om[1]
+			continue
+		}
+		if cm := closeKW.FindStringIndex(remaining); cm != nil && cm[0] == 0 {
+			if depth == 0 {
+				endPos = i
+				found = true
+				break
+			}
+			depth--
+			i += cm[1]
+			continue
+		}
+		i++
+	}
+
+	if found {
+		return rest[:endPos]
+	}
+	// Fallback to indentation heuristics.
+	return extractFunBody(src, afterPos)
+}
+
+// extractFunBody collects the body of a fun/val binding by scanning subsequent
+// lines that are indented or blank until the next top-level declaration.
+func extractFunBody(src string, startPos int) string {
+	rest := src[startPos:]
+	lines := strings.Split(rest, "\n")
+	var body []string
+	for i, line := range lines {
+		if i == 0 {
+			body = append(body, line)
+			continue
+		}
+		if strings.TrimSpace(line) == "" {
+			body = append(body, line)
+			continue
+		}
+		if len(line) > 0 && (line[0] == ' ' || line[0] == '\t') {
+			body = append(body, line)
+		} else {
+			break
+		}
+	}
+	return strings.Join(body, "\n")
+}
+
+// buildOneLinerSig extracts and trims the first line of a declaration.
+func buildOneLinerSig(src string, startPos int) string {
+	rest := src[startPos:]
+	nl := strings.IndexByte(rest, '\n')
+	var line string
+	if nl >= 0 {
+		line = strings.TrimSpace(rest[:nl])
+	} else {
+		line = strings.TrimSpace(rest)
+	}
+	// Trim trailing " ="
+	if idx := strings.LastIndex(line, "="); idx > 0 {
+		line = strings.TrimSpace(line[:idx])
+	}
+	return line
+}
+
+// -----------------------------------------------------------------------
+// Helper: CALLS edge collection
+// -----------------------------------------------------------------------
+
+// collectCalls extracts CALLS relationships from a function body.
+func collectCalls(body, callerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	scrubbed := stripSMLStringsAndComments(body)
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+
+	addCall := func(target string) {
+		if target == "" || target == callerName {
+			return
+		}
+		if smlKeywords[target] {
+			return
+		}
+		if len(target) <= 1 {
+			return
+		}
+		if seen[target] {
+			return
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+
+	// Qualified calls: Structure.function
+	for _, m := range callDotRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+	// Bare function calls
+	for _, m := range callBareRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) >= 2 {
+			addCall(m[1])
+		}
+	}
+
+	return out
+}
+
+// stripSMLStringsAndComments replaces SML string literals and (* ... *) block
+// comments with spaces so the call scanner doesn't pick up tokens inside them.
+func stripSMLStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	for i < len(src) {
+		ch := src[i]
+
+		// SML block comment: (* ... *) — NOT nested (unlike OCaml).
+		if ch == '(' && i+1 < len(src) && src[i+1] == '*' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			for i < len(src) {
+				if i+1 < len(src) && src[i] == '*' && src[i+1] == ')' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					break
+				}
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// String literal: "..."
+		if ch == '"' {
+			out[i] = ' '
+			i++
+			for i < len(src) && src[i] != '"' {
+				if src[i] == '\\' && i+1 < len(src) {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					continue
+				}
+				out[i] = ' '
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// Char literal: #"x"
+		if ch == '#' && i+1 < len(src) && src[i+1] == '"' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			for i < len(src) && src[i] != '"' {
+				out[i] = ' '
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		out[i] = ch
+		i++
+	}
+	return string(out)
+}

--- a/internal/extractors/sml/extractor_test.go
+++ b/internal/extractors/sml/extractor_test.go
@@ -1,0 +1,558 @@
+package sml_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/sml"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runSML runs the SML extractor on raw source and returns entity records.
+func runSML(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("sml")
+	if !ok {
+		t.Fatal("sml extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "sml",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func smlFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func smlHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// TestSML_Registered verifies the extractor is in the registry.
+func TestSML_Registered(t *testing.T) {
+	_, ok := extractor.Get("sml")
+	if !ok {
+		t.Fatal("sml extractor not registered")
+	}
+}
+
+// TestSML_EmptyInput returns zero entities for empty content.
+func TestSML_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("sml")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.sml",
+		Content:  []byte{},
+		Language: "sml",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestSML_StructureDeclaration — structure declarations → SCOPE.Component(structure).
+func TestSML_StructureDeclaration(t *testing.T) {
+	src := `structure Math = struct
+  fun square x = x * x
+  fun cube x = x * x * x
+end
+
+structure StringUtils : sig
+  val upper : string -> string
+end = struct
+  fun upper s = String.map Char.toUpper s
+end
+`
+	ents := runSML(t, src, "math.sml")
+
+	math := smlFind(ents, "Math", "SCOPE.Component")
+	if math == nil {
+		t.Error("expected Math structure component")
+	} else if math.Subtype != "structure" {
+		t.Errorf("Math: expected subtype=structure, got %q", math.Subtype)
+	}
+
+	utils := smlFind(ents, "StringUtils", "SCOPE.Component")
+	if utils == nil {
+		t.Error("expected StringUtils structure component")
+	} else if utils.Subtype != "structure" {
+		t.Errorf("StringUtils: expected subtype=structure, got %q", utils.Subtype)
+	}
+}
+
+// TestSML_SignatureDeclaration — signature declarations → SCOPE.Component(signature).
+func TestSML_SignatureDeclaration(t *testing.T) {
+	src := `signature ORDERED = sig
+  type t
+  val compare : t * t -> order
+end
+
+signature COLLECTION = sig
+  type 'a t
+  val empty : 'a t
+  val insert : 'a -> 'a t -> 'a t
+end
+`
+	ents := runSML(t, src, "sigs.sig")
+
+	ordered := smlFind(ents, "ORDERED", "SCOPE.Component")
+	if ordered == nil {
+		t.Error("expected ORDERED signature component")
+	} else if ordered.Subtype != "signature" {
+		t.Errorf("ORDERED: expected subtype=signature, got %q", ordered.Subtype)
+	}
+
+	coll := smlFind(ents, "COLLECTION", "SCOPE.Component")
+	if coll == nil {
+		t.Error("expected COLLECTION signature component")
+	} else if coll.Subtype != "signature" {
+		t.Errorf("COLLECTION: expected subtype=signature, got %q", coll.Subtype)
+	}
+}
+
+// TestSML_FunctorDeclaration — functor declarations → SCOPE.Component(functor).
+func TestSML_FunctorDeclaration(t *testing.T) {
+	src := `functor MakeSet (Elem : ORDERED) : SET = struct
+  type t = Elem.t list
+  val empty = []
+  fun insert x s = x :: s
+end
+
+functor MakeMap (Key : ORDERED) = struct
+  type 'a t = (Key.t * 'a) list
+  val empty = []
+end
+`
+	ents := runSML(t, src, "functors.fun")
+
+	makeSet := smlFind(ents, "MakeSet", "SCOPE.Component")
+	if makeSet == nil {
+		t.Error("expected MakeSet functor component")
+	} else if makeSet.Subtype != "functor" {
+		t.Errorf("MakeSet: expected subtype=functor, got %q", makeSet.Subtype)
+	}
+
+	makeMap := smlFind(ents, "MakeMap", "SCOPE.Component")
+	if makeMap == nil {
+		t.Error("expected MakeMap functor component")
+	} else if makeMap.Subtype != "functor" {
+		t.Errorf("MakeMap: expected subtype=functor, got %q", makeMap.Subtype)
+	}
+}
+
+// TestSML_FunctionDiscovery — fun declarations → SCOPE.Operation(function).
+func TestSML_FunctionDiscovery(t *testing.T) {
+	src := `fun add x y = x + y
+
+fun factorial 0 = 1
+  | factorial n = n * factorial (n - 1)
+
+fun greet name =
+  print ("Hello, " ^ name ^ "\n")
+`
+	ents := runSML(t, src, "funcs.sml")
+
+	ops := make(map[string]bool)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = true
+			if e.Language != "sml" {
+				t.Errorf("entity %q: expected Language=sml, got %q", e.Name, e.Language)
+			}
+		}
+	}
+
+	for _, want := range []string{"add", "factorial", "greet"} {
+		if !ops[want] {
+			t.Errorf("expected function %q to be extracted, got ops=%v", want, ops)
+		}
+	}
+}
+
+// TestSML_ValDiscovery — val declarations → SCOPE.Operation(val).
+func TestSML_ValDiscovery(t *testing.T) {
+	src := `val pi = 3.14159
+
+val greeting = "Hello, SML!"
+
+val double = fn x => x * 2
+`
+	ents := runSML(t, src, "vals.sml")
+
+	ops := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" {
+			ops[e.Name] = e.Subtype
+		}
+	}
+
+	for _, want := range []string{"pi", "greeting", "double"} {
+		if ops[want] == "" {
+			t.Errorf("expected val %q to be extracted, got ops=%v", want, ops)
+		} else if ops[want] != "val" {
+			t.Errorf("val %q: expected subtype=val, got %q", want, ops[want])
+		}
+	}
+}
+
+// TestSML_DatatypeDeclarations — datatype declarations → SCOPE.Component(datatype).
+func TestSML_DatatypeDeclarations(t *testing.T) {
+	src := `datatype color = Red | Green | Blue
+
+datatype 'a tree = Leaf | Node of 'a * 'a tree * 'a tree
+
+datatype 'a option = NONE | SOME of 'a
+`
+	ents := runSML(t, src, "types.sml")
+
+	comps := make(map[string]string)
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" {
+			comps[e.Name] = e.Subtype
+		}
+	}
+
+	for _, name := range []string{"color", "tree", "option"} {
+		if subtype, ok := comps[name]; !ok {
+			t.Errorf("expected datatype %q to be extracted; got comps=%v", name, comps)
+		} else if subtype != "datatype" {
+			t.Errorf("datatype %q: expected subtype=datatype, got %q", name, subtype)
+		}
+	}
+}
+
+// TestSML_OpenImports — open statements emit IMPORTS edges.
+func TestSML_OpenImports(t *testing.T) {
+	src := `open List
+open String
+open TextIO
+
+fun main () =
+  let
+    val lst = [1, 2, 3]
+  in
+    app print (map Int.toString lst)
+  end
+`
+	ents := runSML(t, src, "main.sml")
+
+	wantImports := map[string]bool{
+		"List":   false,
+		"String": false,
+		"TextIO": false,
+	}
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				if _, ok := wantImports[r.ToID]; ok {
+					wantImports[r.ToID] = true
+					if r.FromID != "main.sml" {
+						t.Errorf("IMPORTS %q: expected FromID=main.sml, got %q", r.ToID, r.FromID)
+					}
+				}
+			}
+		}
+	}
+	for mod, found := range wantImports {
+		if !found {
+			t.Errorf("expected IMPORTS edge for %q", mod)
+		}
+	}
+}
+
+// TestSML_CallsEdges — function calls in bodies emit CALLS edges.
+func TestSML_CallsEdges(t *testing.T) {
+	src := `fun helper x = x + 1
+
+fun process lst =
+  List.map helper (List.filter (fn x => x > 0) lst)
+`
+	ents := runSML(t, src, "calls.sml")
+
+	if !smlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "helper") {
+		t.Error("expected CALLS process→helper")
+	}
+	if !smlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "List.map") {
+		t.Error("expected CALLS process→List.map")
+	}
+	if !smlHasRel(ents, "process", "SCOPE.Operation", "CALLS", "List.filter") {
+		t.Error("expected CALLS process→List.filter")
+	}
+}
+
+// TestSML_CallsDeduped — duplicate call targets are emitted once.
+func TestSML_CallsDeduped(t *testing.T) {
+	src := `fun worker x = x + 1
+
+fun runner () =
+  let
+    val a = worker 1
+    val b = worker 2
+    val c = worker 3
+  in
+    Int.toString (a + b + c)
+  end
+`
+	ents := runSML(t, src, "dedup.sml")
+	count := 0
+	for _, e := range ents {
+		if e.Name == "runner" && e.Kind == "SCOPE.Operation" {
+			for _, r := range e.Relationships {
+				if r.Kind == "CALLS" && r.ToID == "worker" {
+					count++
+				}
+			}
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected 1 CALLS runner→worker (deduped), got %d", count)
+	}
+}
+
+// TestSML_LanguageTagged — all relationships carry language=sml.
+func TestSML_LanguageTagged(t *testing.T) {
+	src := `open List
+
+datatype 'a tree = Leaf | Node of 'a * 'a tree * 'a tree
+
+fun size Leaf = 0
+  | size (Node (_, l, r)) = 1 + size l + size r
+`
+	ents := runSML(t, src, "tagged.sml")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "sml" {
+				t.Errorf("rel %s→%s missing language=sml (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// TestSML_NoFalsePositives — keywords are not emitted as CALLS edges.
+func TestSML_NoFalsePositives(t *testing.T) {
+	src := `fun process lst =
+  if List.null lst then
+    []
+  else
+    let
+      val filtered = List.filter (fn x => x > 0) lst
+    in
+      List.map (fn x => x * 2) filtered
+    end
+`
+	ents := runSML(t, src, "nofp.sml")
+
+	smlKWCalls := map[string]bool{
+		"if": true, "then": true, "else": true, "let": true, "in": true,
+		"fn": true, "fun": true, "val": true, "end": true, "of": true,
+	}
+
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" && smlKWCalls[r.ToID] {
+				t.Errorf("false positive CALLS edge: %s→%s (keyword)", e.Name, r.ToID)
+			}
+		}
+	}
+}
+
+// TestSML_SigFile — .sig files are parsed (signature declarations).
+func TestSML_SigFile(t *testing.T) {
+	src := `(* Collection signature *)
+signature STACK = sig
+  type 'a stack
+  val empty  : 'a stack
+  val push   : 'a -> 'a stack -> 'a stack
+  val pop    : 'a stack -> ('a * 'a stack) option
+  val peek   : 'a stack -> 'a option
+  val isEmpty : 'a stack -> bool
+end
+`
+	ents := runSML(t, src, "stack.sig")
+
+	stack := smlFind(ents, "STACK", "SCOPE.Component")
+	if stack == nil {
+		t.Error("expected STACK signature component from .sig file")
+	} else if stack.Subtype != "signature" {
+		t.Errorf("STACK: expected subtype=signature, got %q", stack.Subtype)
+	}
+}
+
+// TestSML_FunFile — .fun files are parsed (functor declarations).
+func TestSML_FunFile(t *testing.T) {
+	src := `functor BinarySearch (Elem : ORDERED) = struct
+  fun search cmp lst key =
+    case lst of
+      [] => NONE
+    | x :: rest =>
+        (case cmp (key, x) of
+          EQUAL => SOME x
+        | LESS  => NONE
+        | GREATER => search cmp rest key)
+end
+`
+	ents := runSML(t, src, "bsearch.fun")
+
+	bs := smlFind(ents, "BinarySearch", "SCOPE.Component")
+	if bs == nil {
+		t.Error("expected BinarySearch functor from .fun file")
+	} else if bs.Subtype != "functor" {
+		t.Errorf("BinarySearch: expected subtype=functor, got %q", bs.Subtype)
+	}
+}
+
+// TestSML_FinanceFixture — synthetic financial-domain SML fixture for recall.
+// Must achieve ≥80% entity recall (acceptance criterion).
+func TestSML_FinanceFixture(t *testing.T) {
+	src := `(* SML financial calculations — synthetic fixture *)
+open List
+open Real
+
+(* ─── Domain types ─── *)
+datatype currency = USD | EUR | GBP | JPY
+
+datatype transaction =
+    Deposit of real * currency
+  | Withdrawal of real * currency
+  | Transfer of real * currency * string
+
+(* ─── Signatures ─── *)
+signature ACCOUNT = sig
+  type t
+  val create     : string -> real -> t
+  val balance    : t -> real
+  val apply      : transaction -> t -> t
+end
+
+(* ─── Functor ─── *)
+functor MakeAccount (Cur : sig val base : currency end) : ACCOUNT = struct
+  type t = { id : string, balance : real }
+  fun create id bal = { id = id, balance = bal }
+  fun balance acct = #balance acct
+  fun apply txn acct =
+    case txn of
+      Deposit (amt, _)    => { id = #id acct, balance = #balance acct + amt }
+    | Withdrawal (amt, _) => { id = #id acct, balance = #balance acct - amt }
+    | Transfer (amt, _, _) => { id = #id acct, balance = #balance acct - amt }
+end
+
+(* ─── Utility functions ─── *)
+fun fxRate (USD, EUR) = 0.92
+  | fxRate (USD, GBP) = 0.79
+  | fxRate (USD, JPY) = 149.5
+  | fxRate (EUR, GBP) = 0.86
+  | fxRate (c1, c2)   = if c1 = c2 then 1.0 else 1.0 / fxRate (c2, c1)
+
+fun convertAmount amt fromC toC =
+  amt * fxRate (fromC, toC)
+
+fun applyAll txns acct =
+  foldl (fn (txn, a) => a) acct txns
+
+fun totalDeposits txns =
+  foldl (fn (Deposit (amt, _), acc) => acc + amt | (_, acc) => acc) 0.0 txns
+
+fun totalWithdrawals txns =
+  foldl (fn (Withdrawal (amt, _), acc) => acc + amt | (_, acc) => acc) 0.0 txns
+
+fun netFlow txns =
+  totalDeposits txns - totalWithdrawals txns
+
+val zeroBalance = 0.0
+
+val defaultCurrency = USD
+`
+	ents := runSML(t, src, "finance.sml")
+
+	wantOps := []string{
+		"fxRate", "convertAmount", "applyAll",
+		"totalDeposits", "totalWithdrawals", "netFlow",
+		"zeroBalance", "defaultCurrency",
+	}
+	wantComps := []string{
+		"currency", "transaction", "ACCOUNT", "MakeAccount",
+	}
+	wantImports := []string{"List", "Real"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundImports := make(map[string]bool)
+
+	for _, e := range ents {
+		switch e.Kind {
+		case "SCOPE.Operation":
+			foundOps[e.Name] = true
+		case "SCOPE.Component":
+			foundComps[e.Name] = true
+			for _, r := range e.Relationships {
+				if r.Kind == "IMPORTS" {
+					foundImports[r.ToID] = true
+				}
+			}
+		}
+	}
+
+	opHits := 0
+	for _, name := range wantOps {
+		if foundOps[name] {
+			opHits++
+		} else {
+			t.Logf("missing operation: %s", name)
+		}
+	}
+	compHits := 0
+	for _, name := range wantComps {
+		if foundComps[name] {
+			compHits++
+		} else {
+			t.Logf("missing component: %s", name)
+		}
+	}
+	importHits := 0
+	for _, mod := range wantImports {
+		if foundImports[mod] {
+			importHits++
+		} else {
+			t.Logf("missing import: %s", mod)
+		}
+	}
+
+	totalWant := len(wantOps) + len(wantComps) + len(wantImports)
+	totalFound := opHits + compHits + importHits
+	recall := float64(totalFound) / float64(totalWant) * 100
+
+	t.Logf("Finance fixture recall: %d/%d (%.0f%%): ops=%d/%d comps=%d/%d imports=%d/%d",
+		totalFound, totalWant, recall,
+		opHits, len(wantOps),
+		compHits, len(wantComps),
+		importHits, len(wantImports))
+
+	if recall < 80.0 {
+		t.Errorf("entity recall %.0f%% below 80%% threshold (%d/%d found)",
+			recall, totalFound, totalWant)
+	}
+}

--- a/internal/resolve/dynamic_patterns_sml.go
+++ b/internal/resolve/dynamic_patterns_sml.go
@@ -1,0 +1,303 @@
+package resolve
+
+import "regexp"
+
+// smlDynamicPatterns are per-language patterns for Standard ML.
+// Registered via init() into dynamicPatternsByLang.
+//
+// The SML extractor (internal/extractors/sml/extractor.go) emits CALLS edges
+// whose ToID is either:
+//   - a bare function name: "helper"
+//   - a module-qualified call: "List.map", "String.tokens", "Int.toString"
+//
+// Two categories of patterns:
+//
+//  1. SML stdlib module-qualified identifiers — dotted names characteristic of
+//     SML's Basis Library:
+//       List: List.map, List.filter, List.foldl, List.app, etc.
+//       String: String.tokens, String.concat, String.sub, etc.
+//       Int: Int.toString, Int.fromString, Int.compare, etc.
+//       Real: Real.toString, Real.fromString, Real.floor, etc.
+//       IO: TextIO.print, TextIO.inputLine, BinIO.openIn, etc.
+//       OS: OS.FileSys.*, OS.Path.*, OS.Process.*
+//       Array/Vector: Array.sub, Vector.map, etc.
+//
+//  2. MLton / SML/NJ specific patterns — runtime/system-specific names.
+//
+// All patterns are gated to lang=="sml" (safer-bias rule).
+var smlDynamicPatterns = []*regexp.Regexp{
+	// ── List module (SML Basis) ───────────────────────────────────────────
+	regexp.MustCompile(`^List\.map$`),        // List.map f lst
+	regexp.MustCompile(`^List\.filter$`),     // List.filter pred lst
+	regexp.MustCompile(`^List\.foldl$`),      // List.foldl f init lst
+	regexp.MustCompile(`^List\.foldr$`),      // List.foldr f init lst
+	regexp.MustCompile(`^List\.app$`),        // List.app f lst
+	regexp.MustCompile(`^List\.appi$`),       // List.appi f lst
+	regexp.MustCompile(`^List\.mapi$`),       // List.mapi f lst
+	regexp.MustCompile(`^List\.find$`),       // List.find pred lst
+	regexp.MustCompile(`^List\.exists$`),     // List.exists pred lst
+	regexp.MustCompile(`^List\.all$`),        // List.all pred lst
+	regexp.MustCompile(`^List\.null$`),       // List.null lst
+	regexp.MustCompile(`^List\.hd$`),         // List.hd lst
+	regexp.MustCompile(`^List\.tl$`),         // List.tl lst
+	regexp.MustCompile(`^List\.last$`),       // List.last lst
+	regexp.MustCompile(`^List\.length$`),     // List.length lst
+	regexp.MustCompile(`^List\.nth$`),        // List.nth (lst, n)
+	regexp.MustCompile(`^List\.rev$`),        // List.rev lst
+	regexp.MustCompile(`^List\.revAppend$`),  // List.revAppend lst1 lst2
+	regexp.MustCompile(`^List\.append$`),     // List.append lst1 lst2
+	regexp.MustCompile(`^List\.concat$`),     // List.concat lsts
+	regexp.MustCompile(`^List\.partition$`),  // List.partition pred lst
+	regexp.MustCompile(`^List\.getItem$`),    // List.getItem lst
+	regexp.MustCompile(`^List\.collate$`),    // List.collate cmp lst1 lst2
+	regexp.MustCompile(`^List\.tabulate$`),   // List.tabulate (n, f)
+
+	// ── ListPair module ───────────────────────────────────────────────────
+	regexp.MustCompile(`^ListPair\.map$`),    // ListPair.map f (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.app$`),    // ListPair.app f (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.foldl$`),  // ListPair.foldl f init (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.foldr$`),  // ListPair.foldr f init (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.zip$`),    // ListPair.zip (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.unzip$`),  // ListPair.unzip pairs
+	regexp.MustCompile(`^ListPair\.all$`),    // ListPair.all pred (lst1, lst2)
+	regexp.MustCompile(`^ListPair\.exists$`), // ListPair.exists pred (lst1, lst2)
+
+	// ── String module (SML Basis) ─────────────────────────────────────────
+	regexp.MustCompile(`^String\.tokens$`),       // String.tokens pred s
+	regexp.MustCompile(`^String\.fields$`),       // String.fields pred s
+	regexp.MustCompile(`^String\.concat$`),       // String.concat lst
+	regexp.MustCompile(`^String\.concatWith$`),   // String.concatWith sep lst
+	regexp.MustCompile(`^String\.sub$`),          // String.sub (s, i)
+	regexp.MustCompile(`^String\.substring$`),    // String.substring (s, i, n)
+	regexp.MustCompile(`^String\.extract$`),      // String.extract (s, i, opt)
+	regexp.MustCompile(`^String\.size$`),         // String.size s
+	regexp.MustCompile(`^String\.str$`),          // String.str c
+	regexp.MustCompile(`^String\.implode$`),      // String.implode chars
+	regexp.MustCompile(`^String\.explode$`),      // String.explode s
+	regexp.MustCompile(`^String\.map$`),          // String.map f s
+	regexp.MustCompile(`^String\.app$`),          // String.app f s
+	regexp.MustCompile(`^String\.compare$`),      // String.compare (s1, s2)
+	regexp.MustCompile(`^String\.<$`),            // String.< (s1, s2)
+	regexp.MustCompile(`^String\.<=$`),           // String.<= (s1, s2)
+	regexp.MustCompile(`^String\.>$`),            // String.> (s1, s2)
+	regexp.MustCompile(`^String\.>=$`),           // String.>= (s1, s2)
+	regexp.MustCompile(`^String\.isPrefix$`),     // String.isPrefix prefix s
+	regexp.MustCompile(`^String\.isSuffix$`),     // String.isSuffix suffix s
+	regexp.MustCompile(`^String\.isSubstring$`),  // String.isSubstring sub s
+	regexp.MustCompile(`^String\.toUpper$`),      // String.toUpper s
+	regexp.MustCompile(`^String\.toLower$`),      // String.toLower s
+	regexp.MustCompile(`^String\.collate$`),      // String.collate cmp (s1, s2)
+	regexp.MustCompile(`^String\.fromString$`),   // String.fromString s
+	regexp.MustCompile(`^String\.toString$`),     // String.toString s
+
+	// ── Int module (SML Basis) ────────────────────────────────────────────
+	regexp.MustCompile(`^Int\.toString$`),     // Int.toString n
+	regexp.MustCompile(`^Int\.fromString$`),   // Int.fromString s
+	regexp.MustCompile(`^Int\.compare$`),      // Int.compare (i1, i2)
+	regexp.MustCompile(`^Int\.min$`),          // Int.min (i1, i2)
+	regexp.MustCompile(`^Int\.max$`),          // Int.max (i1, i2)
+	regexp.MustCompile(`^Int\.abs$`),          // Int.abs n
+	regexp.MustCompile(`^Int\.sign$`),         // Int.sign n
+	regexp.MustCompile(`^Int\.sameSign$`),     // Int.sameSign (i1, i2)
+	regexp.MustCompile(`^Int\.fmt$`),          // Int.fmt radix n
+	regexp.MustCompile(`^Int\.scan$`),         // Int.scan radix reader
+	regexp.MustCompile(`^Int\.toInt$`),        // Int.toInt n
+	regexp.MustCompile(`^Int\.fromInt$`),      // Int.fromInt n
+	regexp.MustCompile(`^Int\.toLarge$`),      // Int.toLarge n
+	regexp.MustCompile(`^Int\.fromLarge$`),    // Int.fromLarge n
+	regexp.MustCompile(`^Int\.div$`),          // Int.div (n, m)
+	regexp.MustCompile(`^Int\.mod$`),          // Int.mod (n, m)
+	regexp.MustCompile(`^Int\.quot$`),         // Int.quot (n, m)
+	regexp.MustCompile(`^Int\.rem$`),          // Int.rem (n, m)
+
+	// ── Real module (SML Basis) ───────────────────────────────────────────
+	regexp.MustCompile(`^Real\.toString$`),    // Real.toString r
+	regexp.MustCompile(`^Real\.fromString$`),  // Real.fromString s
+	regexp.MustCompile(`^Real\.compare$`),     // Real.compare (r1, r2)
+	regexp.MustCompile(`^Real\.min$`),         // Real.min (r1, r2)
+	regexp.MustCompile(`^Real\.max$`),         // Real.max (r1, r2)
+	regexp.MustCompile(`^Real\.abs$`),         // Real.abs r
+	regexp.MustCompile(`^Real\.sign$`),        // Real.sign r
+	regexp.MustCompile(`^Real\.floor$`),       // Real.floor r
+	regexp.MustCompile(`^Real\.ceil$`),        // Real.ceil r
+	regexp.MustCompile(`^Real\.round$`),       // Real.round r
+	regexp.MustCompile(`^Real\.trunc$`),       // Real.trunc r
+	regexp.MustCompile(`^Real\.toInt$`),       // Real.toInt mode r
+	regexp.MustCompile(`^Real\.fromInt$`),     // Real.fromInt n
+	regexp.MustCompile(`^Real\.toLarge$`),     // Real.toLarge r
+	regexp.MustCompile(`^Real\.fromLarge$`),   // Real.fromLarge mode r
+	regexp.MustCompile(`^Real\.fmt$`),         // Real.fmt spec r
+	regexp.MustCompile(`^Real\.scan$`),        // Real.scan reader
+	regexp.MustCompile(`^Real\.isNan$`),       // Real.isNan r
+	regexp.MustCompile(`^Real\.isFinite$`),    // Real.isFinite r
+	regexp.MustCompile(`^Real\.posInf$`),      // Real.posInf
+	regexp.MustCompile(`^Real\.negInf$`),      // Real.negInf
+	regexp.MustCompile(`^Real\.sqrt$`),        // Real.sqrt r
+	regexp.MustCompile(`^Real\.exp$`),         // Real.exp r
+	regexp.MustCompile(`^Real\.ln$`),          // Real.ln r
+	regexp.MustCompile(`^Real\.log10$`),       // Real.log10 r
+	regexp.MustCompile(`^Real\.pow$`),         // Real.pow (r, p)
+	regexp.MustCompile(`^Real\.sin$`),         // Real.sin r
+	regexp.MustCompile(`^Real\.cos$`),         // Real.cos r
+	regexp.MustCompile(`^Real\.tan$`),         // Real.tan r
+	regexp.MustCompile(`^Real\.atan$`),        // Real.atan r
+	regexp.MustCompile(`^Real\.atan2$`),       // Real.atan2 (y, x)
+
+	// ── TextIO module (SML Basis IO) ──────────────────────────────────────
+	regexp.MustCompile(`^TextIO\.print$`),         // TextIO.print s
+	regexp.MustCompile(`^TextIO\.inputLine$`),     // TextIO.inputLine is
+	regexp.MustCompile(`^TextIO\.input$`),         // TextIO.input is
+	regexp.MustCompile(`^TextIO\.input1$`),        // TextIO.input1 is
+	regexp.MustCompile(`^TextIO\.inputAll$`),      // TextIO.inputAll is
+	regexp.MustCompile(`^TextIO\.output$`),        // TextIO.output (os, s)
+	regexp.MustCompile(`^TextIO\.output1$`),       // TextIO.output1 (os, c)
+	regexp.MustCompile(`^TextIO\.flushOut$`),      // TextIO.flushOut os
+	regexp.MustCompile(`^TextIO\.closeIn$`),       // TextIO.closeIn is
+	regexp.MustCompile(`^TextIO\.closeOut$`),      // TextIO.closeOut os
+	regexp.MustCompile(`^TextIO\.openIn$`),        // TextIO.openIn path
+	regexp.MustCompile(`^TextIO\.openOut$`),       // TextIO.openOut path
+	regexp.MustCompile(`^TextIO\.openAppend$`),    // TextIO.openAppend path
+	regexp.MustCompile(`^TextIO\.stdIn$`),         // TextIO.stdIn
+	regexp.MustCompile(`^TextIO\.stdOut$`),        // TextIO.stdOut
+	regexp.MustCompile(`^TextIO\.stdErr$`),        // TextIO.stdErr
+	regexp.MustCompile(`^TextIO\.endOfStream$`),   // TextIO.endOfStream is
+
+	// ── BinIO module ──────────────────────────────────────────────────────
+	regexp.MustCompile(`^BinIO\.openIn$`),    // BinIO.openIn path
+	regexp.MustCompile(`^BinIO\.openOut$`),   // BinIO.openOut path
+	regexp.MustCompile(`^BinIO\.input$`),     // BinIO.input is
+	regexp.MustCompile(`^BinIO\.output$`),    // BinIO.output (os, vec)
+	regexp.MustCompile(`^BinIO\.closeIn$`),   // BinIO.closeIn is
+	regexp.MustCompile(`^BinIO\.closeOut$`),  // BinIO.closeOut os
+
+	// ── IO module (generic) ───────────────────────────────────────────────
+	regexp.MustCompile(`^IO\.input$`),       // IO.input
+	regexp.MustCompile(`^IO\.output$`),      // IO.output
+
+	// ── Array module (SML Basis) ──────────────────────────────────────────
+	regexp.MustCompile(`^Array\.array$`),    // Array.array (n, init)
+	regexp.MustCompile(`^Array\.tabulate$`), // Array.tabulate (n, f)
+	regexp.MustCompile(`^Array\.sub$`),      // Array.sub (arr, i)
+	regexp.MustCompile(`^Array\.update$`),   // Array.update (arr, i, x)
+	regexp.MustCompile(`^Array\.length$`),   // Array.length arr
+	regexp.MustCompile(`^Array\.copy$`),     // Array.copy {src, dst, di}
+	regexp.MustCompile(`^Array\.app$`),      // Array.app f arr
+	regexp.MustCompile(`^Array\.appi$`),     // Array.appi f arr
+	regexp.MustCompile(`^Array\.map$`),      // Array.map f arr
+	regexp.MustCompile(`^Array\.mapi$`),     // Array.mapi f arr
+	regexp.MustCompile(`^Array\.foldl$`),    // Array.foldl f init arr
+	regexp.MustCompile(`^Array\.foldr$`),    // Array.foldr f init arr
+	regexp.MustCompile(`^Array\.foldli$`),   // Array.foldli f init arr
+	regexp.MustCompile(`^Array\.foldri$`),   // Array.foldri f init arr
+	regexp.MustCompile(`^Array\.find$`),     // Array.find pred arr
+	regexp.MustCompile(`^Array\.exists$`),   // Array.exists pred arr
+	regexp.MustCompile(`^Array\.all$`),      // Array.all pred arr
+	regexp.MustCompile(`^Array\.toList$`),   // Array.toList arr
+	regexp.MustCompile(`^Array\.fromList$`), // Array.fromList lst
+
+	// ── Vector module (SML Basis) ─────────────────────────────────────────
+	regexp.MustCompile(`^Vector\.tabulate$`), // Vector.tabulate (n, f)
+	regexp.MustCompile(`^Vector\.sub$`),      // Vector.sub (v, i)
+	regexp.MustCompile(`^Vector\.length$`),   // Vector.length v
+	regexp.MustCompile(`^Vector\.app$`),      // Vector.app f v
+	regexp.MustCompile(`^Vector\.map$`),      // Vector.map f v
+	regexp.MustCompile(`^Vector\.foldl$`),    // Vector.foldl f init v
+	regexp.MustCompile(`^Vector\.foldr$`),    // Vector.foldr f init v
+	regexp.MustCompile(`^Vector\.find$`),     // Vector.find pred v
+	regexp.MustCompile(`^Vector\.exists$`),   // Vector.exists pred v
+	regexp.MustCompile(`^Vector\.all$`),      // Vector.all pred v
+	regexp.MustCompile(`^Vector\.toList$`),   // Vector.toList v
+	regexp.MustCompile(`^Vector\.fromList$`), // Vector.fromList lst
+	regexp.MustCompile(`^Vector\.concat$`),   // Vector.concat vecs
+
+	// ── Char module (SML Basis) ───────────────────────────────────────────
+	regexp.MustCompile(`^Char\.isAlpha$`),     // Char.isAlpha c
+	regexp.MustCompile(`^Char\.isDigit$`),     // Char.isDigit c
+	regexp.MustCompile(`^Char\.isAlphaNum$`),  // Char.isAlphaNum c
+	regexp.MustCompile(`^Char\.isSpace$`),     // Char.isSpace c
+	regexp.MustCompile(`^Char\.isUpper$`),     // Char.isUpper c
+	regexp.MustCompile(`^Char\.isLower$`),     // Char.isLower c
+	regexp.MustCompile(`^Char\.toUpper$`),     // Char.toUpper c
+	regexp.MustCompile(`^Char\.toLower$`),     // Char.toLower c
+	regexp.MustCompile(`^Char\.ord$`),         // Char.ord c
+	regexp.MustCompile(`^Char\.chr$`),         // Char.chr n
+	regexp.MustCompile(`^Char\.compare$`),     // Char.compare (c1, c2)
+	regexp.MustCompile(`^Char\.fromString$`),  // Char.fromString s
+	regexp.MustCompile(`^Char\.toString$`),    // Char.toString c
+
+	// ── OS module (SML Basis) ─────────────────────────────────────────────
+	regexp.MustCompile(`^OS\.FileSys\.getDir$`),      // OS.FileSys.getDir()
+	regexp.MustCompile(`^OS\.FileSys\.setDir$`),      // OS.FileSys.setDir path
+	regexp.MustCompile(`^OS\.FileSys\.mkDir$`),       // OS.FileSys.mkDir path
+	regexp.MustCompile(`^OS\.FileSys\.rmDir$`),       // OS.FileSys.rmDir path
+	regexp.MustCompile(`^OS\.FileSys\.isDir$`),       // OS.FileSys.isDir path
+	regexp.MustCompile(`^OS\.FileSys\.access$`),      // OS.FileSys.access (path, modes)
+	regexp.MustCompile(`^OS\.FileSys\.getHomeDir$`),  // OS.FileSys.getHomeDir()
+	regexp.MustCompile(`^OS\.FileSys\.openDir$`),     // OS.FileSys.openDir path
+	regexp.MustCompile(`^OS\.FileSys\.readDir$`),     // OS.FileSys.readDir ds
+	regexp.MustCompile(`^OS\.FileSys\.closeDir$`),    // OS.FileSys.closeDir ds
+	regexp.MustCompile(`^OS\.Path\.concat$`),         // OS.Path.concat (base, file)
+	regexp.MustCompile(`^OS\.Path\.dir$`),            // OS.Path.dir path
+	regexp.MustCompile(`^OS\.Path\.file$`),           // OS.Path.file path
+	regexp.MustCompile(`^OS\.Path\.ext$`),            // OS.Path.ext path
+	regexp.MustCompile(`^OS\.Path\.isAbsolute$`),     // OS.Path.isAbsolute path
+	regexp.MustCompile(`^OS\.Path\.isRelative$`),     // OS.Path.isRelative path
+	regexp.MustCompile(`^OS\.Path\.mkAbsolute$`),     // OS.Path.mkAbsolute {path, relativeTo}
+	regexp.MustCompile(`^OS\.Path\.mkRelative$`),     // OS.Path.mkRelative {path, relativeTo}
+	regexp.MustCompile(`^OS\.Process\.exit$`),        // OS.Process.exit n
+	regexp.MustCompile(`^OS\.Process\.getEnv$`),      // OS.Process.getEnv name
+	regexp.MustCompile(`^OS\.Process\.system$`),      // OS.Process.system cmd
+	regexp.MustCompile(`^OS\.Process\.success$`),     // OS.Process.success
+	regexp.MustCompile(`^OS\.Process\.failure$`),     // OS.Process.failure
+
+	// ── Option module (SML Basis) ─────────────────────────────────────────
+	regexp.MustCompile(`^Option\.map$`),          // Option.map f opt
+	regexp.MustCompile(`^Option\.mapPartial$`),   // Option.mapPartial f opt
+	regexp.MustCompile(`^Option\.compose$`),      // Option.compose (f, g) x
+	regexp.MustCompile(`^Option\.composePartial$`), // Option.composePartial (f, g) x
+	regexp.MustCompile(`^Option\.filter$`),       // Option.filter pred x
+	regexp.MustCompile(`^Option\.join$`),         // Option.join opt
+	regexp.MustCompile(`^Option\.app$`),          // Option.app f opt
+	regexp.MustCompile(`^Option\.getOpt$`),       // Option.getOpt (opt, default)
+	regexp.MustCompile(`^Option\.isSome$`),       // Option.isSome opt
+	regexp.MustCompile(`^Option\.isNone$`),       // Option.isNone opt
+	regexp.MustCompile(`^Option\.valOf$`),        // Option.valOf opt
+	regexp.MustCompile(`^Option\.collate$`),      // Option.collate cmp (opt1, opt2)
+
+	// ── SML/NJ-specific ───────────────────────────────────────────────────
+	regexp.MustCompile(`^SMLofNJ\.Cont\.callcc$`),    // SML/NJ first-class continuations
+	regexp.MustCompile(`^SMLofNJ\.Cont\.throw$`),     // SML/NJ continuation throw
+	regexp.MustCompile(`^SMLofNJ\.Susp\.delay$`),     // SML/NJ lazy suspension
+	regexp.MustCompile(`^SMLofNJ\.Susp\.force$`),     // SML/NJ lazy force
+	regexp.MustCompile(`^Control\.Print\.printDepth$`), // SML/NJ REPL depth control
+	regexp.MustCompile(`^Control\.Print\.printLength$`), // SML/NJ REPL length control
+
+	// ── MLton-specific ────────────────────────────────────────────────────
+	regexp.MustCompile(`^MLton\.share$`),     // MLton heap sharing
+	regexp.MustCompile(`^MLton\.size$`),      // MLton object size
+	regexp.MustCompile(`^MLton\.GC\.collect$`), // MLton GC.collect
+	regexp.MustCompile(`^MLton\.GC\.pack$`),    // MLton GC.pack
+	regexp.MustCompile(`^MLton\.Thread\.new$`), // MLton thread creation
+	regexp.MustCompile(`^MLton\.Thread\.switch$`), // MLton thread switch
+	regexp.MustCompile(`^MLton\.IO\.print$`),   // MLton IO.print
+
+	// ── Math module (SML Basis) ───────────────────────────────────────────
+	regexp.MustCompile(`^Math\.sqrt$`),    // Math.sqrt x
+	regexp.MustCompile(`^Math\.sin$`),     // Math.sin x
+	regexp.MustCompile(`^Math\.cos$`),     // Math.cos x
+	regexp.MustCompile(`^Math\.tan$`),     // Math.tan x
+	regexp.MustCompile(`^Math\.asin$`),    // Math.asin x
+	regexp.MustCompile(`^Math\.acos$`),    // Math.acos x
+	regexp.MustCompile(`^Math\.atan$`),    // Math.atan x
+	regexp.MustCompile(`^Math\.atan2$`),   // Math.atan2 (y, x)
+	regexp.MustCompile(`^Math\.exp$`),     // Math.exp x
+	regexp.MustCompile(`^Math\.pow$`),     // Math.pow (x, y)
+	regexp.MustCompile(`^Math\.ln$`),      // Math.ln x
+	regexp.MustCompile(`^Math\.log10$`),   // Math.log10 x
+	regexp.MustCompile(`^Math\.pi$`),      // Math.pi
+	regexp.MustCompile(`^Math\.e$`),       // Math.e
+}
+
+func init() {
+	dynamicPatternsByLang["sml"] = smlDynamicPatterns
+}


### PR DESCRIPTION
## Summary

Add Standard ML (SML) language support. SML is used in academia (type-theory courses, programming-languages research) and in quantitative finance (Jane Street historically; several high-frequency trading shops still maintain SML codebases).

**Files changed:**
- `internal/extractors/sml/extractor.go` — regex-based extractor for `.sml`/`.sig`/`.fun`
- `internal/extractors/sml/extractor_test.go` — 16 tests covering all entity kinds + 100% recall on synthetic finance fixture
- `internal/classifier/classifier.go` — `.sml`/`.sig`/`.fun` → `"sml"` (`.ml` stays → `"ocaml"`)
- `internal/extractors/registry_gen.go` — blank-import registration
- `internal/resolve/dynamic_patterns_sml.go` — SML Basis Library + MLton/SML-NJ patterns

**Entities extracted:**

| SML syntax | Entity kind | Subtype |
|---|---|---|
| `structure Foo = struct … end` | `SCOPE.Component` | `structure` |
| `signature SIG = sig … end` | `SCOPE.Component` | `signature` |
| `functor Foo (X : SIG) = struct … end` | `SCOPE.Component` | `functor` |
| `datatype 'a tree = Leaf \| Node` | `SCOPE.Component` | `datatype` |
| `fun name args = body` | `SCOPE.Operation` | `function` |
| `val name = expr` | `SCOPE.Operation` | `val` |
| `open Foo` | `IMPORTS` edge | — |
| function applications | `CALLS` edge | — |

**Resolver slice** covers SML Basis Library modules: `List`, `ListPair`, `String`, `Int`, `Real`, `TextIO`, `BinIO`, `IO`, `Array`, `Vector`, `Char`, `OS`, `Option`, `Math`, plus MLton and SML/NJ runtime-specific patterns.

## Closes / Refs

`board:exempt`

## Testing

- [x] All tests pass: `go test ./internal/extractors/sml/... ./internal/classifier/... ./internal/resolve/...`
- [x] Acceptance fixture recall: **100% (14/14)** — ops 8/8, comps 4/4, imports 2/2 (threshold ≥80%)
- [x] Zero false-positive CALLS on SML keywords
- [x] `.ml` → `ocaml` mapping unchanged; no regression to existing extractors
- [x] Language relationships tagged `language=sml`

## Notes

`.fun` is the functor-file extension used by SML/NJ and Poly/ML. `.sig` is the standard SML signature file extension. Neither conflicts with any existing extension mapping.