### PR TITLE
feat: Lisp family (Common Lisp + Scheme + Racket) support

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -431,6 +431,15 @@ var extensionLanguageMap = map[string]string{
 	".cljs": "clojure",
 	".cljc": "clojure",
 	".edn":  "clojure",
+	// Common Lisp
+	".lisp": "commonlisp",
+	".lsp":  "commonlisp",
+	".cl":   "commonlisp",
+	// Scheme
+	".scm": "scheme",
+	".ss":  "scheme",
+	// Racket
+	".rkt": "racket",
 	// Zig
 	".zig": "zig",
 	// Erlang

--- a/internal/extractors/lisp/extractor.go
+++ b/internal/extractors/lisp/extractor.go
@@ -1,0 +1,830 @@
+// Package lisp implements a shared regex-based extractor for the Lisp family:
+// Common Lisp (.lisp/.lsp/.cl), Scheme (.scm/.ss), and Racket (.rkt).
+//
+// All three dialects share s-expression syntax so one extractor handles them;
+// a dialect parameter is derived from file extension and controls which
+// form-names are matched for each construct.
+//
+// Extracted entities:
+//   - (defun name ...) / (define (name ...) ...) → SCOPE.Operation (subtype="function")
+//   - (defmacro ...) / (define-syntax ...) → SCOPE.Operation (subtype="macro")
+//   - (defstruct ...) / (define-struct ...) / (struct ...) → SCOPE.Component (subtype="struct")
+//   - (defclass ...) / (define-class ...) → SCOPE.Component (subtype="class")
+//   - (define/contract name ...) → SCOPE.Operation (subtype="function", Racket contracts)
+//   - (in-package "name") → namespace entity (subtype="namespace")
+//   - (load "file") / (require ...) → IMPORTS edges
+//   - Module CONTAINS top-level forms
+//
+// Registers itself via init() under "commonlisp", "scheme", and "racket"
+// and is imported by registry_gen.go.
+package lisp
+
+import (
+	"context"
+	"path/filepath"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("commonlisp", &Extractor{dialect: "commonlisp"})
+	extractor.Register("scheme", &Extractor{dialect: "scheme"})
+	extractor.Register("racket", &Extractor{dialect: "racket"})
+}
+
+// Extractor implements extractor.Extractor for the Lisp family.
+type Extractor struct {
+	dialect string // "commonlisp" | "scheme" | "racket"
+}
+
+// Language returns the canonical language name.
+func (e *Extractor) Language() string { return e.dialect }
+
+// ---------------------------------------------------------------------------
+// Compiled regex patterns
+// ---------------------------------------------------------------------------
+
+var (
+	// Common Lisp: (defun name (args) body)
+	defunRE = regexp.MustCompile(
+		`(?m)^\s*\(defun\s+([\w\-\?!\*'+<>=.]+)\s*\(`,
+	)
+
+	// Scheme/Racket: (define (name args) body)
+	defineRE = regexp.MustCompile(
+		`(?m)^\s*\(define\s+\(\s*([\w\-\?!\*'+<>=./]+)`,
+	)
+
+	// Scheme/Racket: (define name ...) — bare defines at top level
+	defineVarRE = regexp.MustCompile(
+		`(?m)^\s*\(define\s+([\w\-\?!\*'+<>=./]+)\s+`,
+	)
+
+	// Racket: (define/contract (name args) ...) or (define/contract name ...)
+	defineContractRE = regexp.MustCompile(
+		`(?m)^\s*\(define/contract\s+(?:\(\s*)?([\w\-\?!\*'+<>=./]+)`,
+	)
+
+	// Racket: (require/typed ...)
+	requireTypedRE = regexp.MustCompile(
+		`(?m)^\s*\(require/typed\s+([^\s)]+)`,
+	)
+
+	// Common Lisp: (defmacro name ...)
+	defmacroRE = regexp.MustCompile(
+		`(?m)^\s*\(defmacro\s+([\w\-\?!\*'+<>=.]+)\s`,
+	)
+
+	// Scheme: (define-syntax name ...)
+	defineSyntaxRE = regexp.MustCompile(
+		`(?m)^\s*\(define-syntax\s+([\w\-\?!\*'+<>=.]+)`,
+	)
+
+	// Common Lisp: (defstruct name ...)
+	defstructRE = regexp.MustCompile(
+		`(?m)^\s*\(defstruct\s+([\w\-\?!\*'+<>=.]+)`,
+	)
+
+	// Scheme: (define-struct name ...)
+	defineStructRE = regexp.MustCompile(
+		`(?m)^\s*\(define-struct\s+([\w\-\?!\*'+<>=./]+)`,
+	)
+
+	// Racket: (struct name ...)
+	structRE = regexp.MustCompile(
+		`(?m)^\s*\(struct\s+([\w\-\?!\*'+<>=./]+)`,
+	)
+
+	// Common Lisp: (defclass name ...)
+	defclassRE = regexp.MustCompile(
+		`(?m)^\s*\(defclass\s+([\w\-\?!\*'+<>=.]+)`,
+	)
+
+	// Scheme: (define-class name ...)
+	defineClassRE = regexp.MustCompile(
+		`(?m)^\s*\(define-class\s+([\w\-\?!\*'+<>=./]+)`,
+	)
+
+	// Common Lisp: (defmethod name ...)
+	defmethodRE = regexp.MustCompile(
+		`(?m)^\s*\(defmethod\s+([\w\-\?!\*'+<>=.]+)`,
+	)
+
+	// Common Lisp: (in-package "name") or (in-package :name)
+	inPackageRE = regexp.MustCompile(
+		`(?m)^\s*\(in-package\s+(?:"([^"]+)"|:?([\w\-]+))\s*\)`,
+	)
+
+	// Common Lisp / Scheme: (load "filename")
+	loadRE = regexp.MustCompile(
+		`(?m)^\s*\(load\s+"([^"]+)"`,
+	)
+
+	// Scheme: (require "module") or (require module-name)
+	requireRE = regexp.MustCompile(
+		`(?m)^\s*\(require\s+(?:"([^"]+)"|([\w\-\./]+))`,
+	)
+
+	// Racket: (require racket/list) — module paths
+	requirePathRE = regexp.MustCompile(
+		`(?m)^\s*\(require\s+([\w\-\./]+)`,
+	)
+
+	// Generic s-expression call: (name ...) — captures callee names
+	callRE = regexp.MustCompile(
+		`\(\s*([\w\-\?!\*'+<>=./]+)`,
+	)
+)
+
+// lispSpecialForms are s-expression heads that are NOT function calls.
+var lispSpecialForms = map[string]bool{
+	// Common Lisp special operators
+	"let": true, "let*": true, "letrec": true, "letrec*": true,
+	"flet": true, "labels": true, "macrolet": true,
+	"if": true, "cond": true, "case": true, "when": true, "unless": true,
+	"and": true, "or": true, "not": true,
+	"progn": true, "prog1": true, "prog2": true,
+	"block": true, "return-from": true, "return": true,
+	"catch": true, "throw": true, "unwind-protect": true,
+	"lambda": true, "function": true,
+	"setf": true, "setq": true, "set": true, "psetf": true, "psetq": true,
+	"defun": true, "defmacro": true, "defstruct": true, "defclass": true,
+	"defmethod": true, "defvar": true, "defparameter": true, "defconstant": true,
+	"deftype": true, "declaim": true, "declare": true,
+	"in-package": true, "defpackage": true,
+	"load": true, "require": true, "provide": true,
+	"quote": true, "quasiquote": true, "backquote": true,
+	"do": true, "do*": true, "dolist": true, "dotimes": true, "loop": true,
+	"with-open-file": true, "with-output-to-string": true,
+	"multiple-value-bind": true, "multiple-value-list": true,
+	"values": true, "nth-value": true,
+	"eval-when": true, "load-time-value": true,
+	"the": true, "locally": true, "symbol-macrolet": true,
+	// Scheme additional
+	"define": true, "define-syntax": true, "define-struct": true,
+	"define-class": true, "define/contract": true,
+	"begin": true, "delay": true, "force": true,
+	"call-with-current-continuation": true,
+	"syntax-rules": true, "syntax-case": true,
+	"let-values": true, "let*-values": true,
+	"receive": true, "guard": true,
+	// Racket additional
+	"struct": true, "require/typed": true, "provide/contract": true,
+	"module": true, "module*": true, "module+": true,
+	"parameterize": true, "with-syntax": true,
+	"for": true, "for/list": true, "for/fold": true, "for/vector": true,
+	"match": true, "match-define": true,
+	"define-values": true, "let-syntax": true, "letrec-syntax": true,
+}
+
+// dialectFromPath derives the dialect from file extension.
+func dialectFromPath(path string) string {
+	ext := strings.ToLower(filepath.Ext(path))
+	switch ext {
+	case ".lisp", ".lsp", ".cl":
+		return "commonlisp"
+	case ".scm", ".ss":
+		return "scheme"
+	case ".rkt":
+		return "racket"
+	}
+	return "commonlisp" // fallback
+}
+
+// Extract processes the Lisp source and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	dialect := dialectFromPath(file.Path)
+	out := extractLisp(string(file.Content), file.Path, dialect)
+	extractor.TagRelationshipsLanguage(out, dialect)
+	return out, nil
+}
+
+func extractLisp(src, filePath, dialect string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// Emit file-level entity.
+	entities = append(entities, extractor.FileEntity(extractor.FileInput{
+		Path:     filePath,
+		Language: dialect,
+	}))
+
+	// Scrub strings and comments to avoid false positives.
+	scrubbed := stripLispStringsAndComments(src)
+
+	// 1. Package/namespace (Common Lisp).
+	var packageName string
+	if dialect == "commonlisp" {
+		if m := inPackageRE.FindStringSubmatch(scrubbed); m != nil {
+			pkgName := m[1]
+			if pkgName == "" {
+				pkgName = strings.ToLower(m[2])
+			}
+			if pkgName != "" {
+				packageName = pkgName
+				startLine := lineOf(src, inPackageRE.FindStringIndex(scrubbed)[0])
+				entities = append(entities, types.EntityRecord{
+					Name:       packageName,
+					Kind:       "SCOPE.Component",
+					Subtype:    "namespace",
+					SourceFile: filePath,
+					Language:   dialect,
+					StartLine:  startLine,
+					EndLine:    startLine,
+					Signature:  "(in-package " + packageName + ")",
+				})
+			}
+		}
+	}
+
+	// 2. Collect imports (use original source so string literals are intact).
+	imports := collectLispImports(src, dialect)
+	importEntities := buildLispImportEntities(filePath, dialect, imports)
+	entities = append(entities, importEntities...)
+
+	// 3. Operations (functions, macros, methods).
+	var operationNames []string
+	seen := make(map[string]bool)
+
+	// defun (Common Lisp)
+	if dialect == "commonlisp" {
+		for _, m := range defunRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			sig := "(defun " + name + " ...)"
+			body := extractSexprBody(src, m[0])
+			endLine := startLine + strings.Count(body, "\n")
+			calls := collectLispCalls(body, name, dialect)
+			entities = append(entities, types.EntityRecord{
+				Name:          name,
+				Kind:          "SCOPE.Operation",
+				Subtype:       "function",
+				SourceFile:    filePath,
+				Language:      dialect,
+				StartLine:     startLine,
+				EndLine:       endLine,
+				Signature:     sig,
+				Relationships: calls,
+			})
+		}
+
+		// defmacro (Common Lisp)
+		for _, m := range defmacroRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "macro",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(defmacro " + name + " ...)",
+			})
+		}
+
+		// defmethod (Common Lisp)
+		for _, m := range defmethodRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "function",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(defmethod " + name + " ...)",
+			})
+		}
+	}
+
+	// define function (Scheme/Racket)
+	if dialect == "scheme" || dialect == "racket" {
+		for _, m := range defineRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] || name == "" {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			body := extractSexprBody(src, m[0])
+			endLine := startLine + strings.Count(body, "\n")
+			calls := collectLispCalls(body, name, dialect)
+			entities = append(entities, types.EntityRecord{
+				Name:          name,
+				Kind:          "SCOPE.Operation",
+				Subtype:       "function",
+				SourceFile:    filePath,
+				Language:      dialect,
+				StartLine:     startLine,
+				EndLine:       endLine,
+				Signature:     "(define (" + name + " ...) ...)",
+				Relationships: calls,
+			})
+		}
+
+		// define-syntax (Scheme/Racket)
+		for _, m := range defineSyntaxRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "macro",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(define-syntax " + name + " ...)",
+			})
+		}
+	}
+
+	// define/contract (Racket)
+	if dialect == "racket" {
+		for _, m := range defineContractRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if seen[name] {
+				continue
+			}
+			seen[name] = true
+			operationNames = append(operationNames, name)
+			startLine := lineOf(src, m[0])
+			body := extractSexprBody(src, m[0])
+			endLine := startLine + strings.Count(body, "\n")
+			calls := collectLispCalls(body, name, dialect)
+			entities = append(entities, types.EntityRecord{
+				Name:          name,
+				Kind:          "SCOPE.Operation",
+				Subtype:       "function",
+				SourceFile:    filePath,
+				Language:      dialect,
+				StartLine:     startLine,
+				EndLine:       endLine,
+				Signature:     "(define/contract " + name + " ...)",
+				Relationships: calls,
+			})
+		}
+	}
+
+	// 4. Components (structs, classes).
+	compSeen := make(map[string]bool)
+
+	// defstruct (Common Lisp)
+	if dialect == "commonlisp" {
+		for _, m := range defstructRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if compSeen[name] {
+				continue
+			}
+			compSeen[name] = true
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Component",
+				Subtype:    "struct",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(defstruct " + name + " ...)",
+			})
+		}
+
+		// defclass (Common Lisp)
+		for _, m := range defclassRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if compSeen[name] {
+				continue
+			}
+			compSeen[name] = true
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(defclass " + name + " ...)",
+			})
+		}
+	}
+
+	// define-struct (Scheme)
+	if dialect == "scheme" {
+		for _, m := range defineStructRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if compSeen[name] {
+				continue
+			}
+			compSeen[name] = true
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Component",
+				Subtype:    "struct",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(define-struct " + name + " ...)",
+			})
+		}
+
+		// define-class (Scheme)
+		for _, m := range defineClassRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if compSeen[name] {
+				continue
+			}
+			compSeen[name] = true
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(define-class " + name + " ...)",
+			})
+		}
+	}
+
+	// struct (Racket)
+	if dialect == "racket" {
+		for _, m := range structRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+			if len(m) < 4 {
+				continue
+			}
+			name := scrubbed[m[2]:m[3]]
+			if compSeen[name] {
+				continue
+			}
+			compSeen[name] = true
+			startLine := lineOf(src, m[0])
+			entities = append(entities, types.EntityRecord{
+				Name:       name,
+				Kind:       "SCOPE.Component",
+				Subtype:    "struct",
+				SourceFile: filePath,
+				Language:   dialect,
+				StartLine:  startLine,
+				EndLine:    startLine,
+				Signature:  "(struct " + name + " ...)",
+			})
+		}
+	}
+
+	// 5. CONTAINS edges from package to top-level operations.
+	if packageName != "" && len(operationNames) > 0 {
+		var containsRels []types.RelationshipRecord
+		for _, opName := range operationNames {
+			ref := extractor.BuildOperationStructuralRef(dialect, filePath, opName)
+			containsRels = append(containsRels, types.RelationshipRecord{
+				ToID: ref,
+				Kind: "CONTAINS",
+			})
+		}
+		for i := range entities {
+			if entities[i].Name == packageName && entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "namespace" {
+				entities[i].Relationships = append(entities[i].Relationships, containsRels...)
+				break
+			}
+		}
+	}
+
+	return entities
+}
+
+// ---------------------------------------------------------------------------
+// Import collection
+// ---------------------------------------------------------------------------
+
+func collectLispImports(src, dialect string) []string {
+	seen := make(map[string]bool)
+	var imports []string
+
+	add := func(name string) {
+		name = strings.TrimSpace(name)
+		if name == "" || seen[name] {
+			return
+		}
+		seen[name] = true
+		imports = append(imports, name)
+	}
+
+	switch dialect {
+	case "commonlisp":
+		// (load "filename")
+		for _, m := range loadRE.FindAllStringSubmatch(src, -1) {
+			if len(m) >= 2 {
+				add(m[1])
+			}
+		}
+		// (require ...) bare
+		for _, m := range requireRE.FindAllStringSubmatch(src, -1) {
+			if len(m) >= 3 {
+				if m[1] != "" {
+					add(m[1])
+				} else if m[2] != "" {
+					add(m[2])
+				}
+			}
+		}
+	case "scheme":
+		for _, m := range requireRE.FindAllStringSubmatch(src, -1) {
+			if len(m) >= 3 {
+				if m[1] != "" {
+					add(m[1])
+				} else if m[2] != "" {
+					add(m[2])
+				}
+			}
+		}
+	case "racket":
+		// Racket (require racket/list) — module path form
+		for _, m := range requirePathRE.FindAllStringSubmatch(src, -1) {
+			if len(m) >= 2 {
+				add(m[1])
+			}
+		}
+		// (require/typed ...)
+		for _, m := range requireTypedRE.FindAllStringSubmatch(src, -1) {
+			if len(m) >= 2 {
+				add(m[1])
+			}
+		}
+	}
+
+	return imports
+}
+
+func buildLispImportEntities(filePath, dialect string, imports []string) []types.EntityRecord {
+	if len(imports) == 0 {
+		return nil
+	}
+	out := make([]types.EntityRecord, 0, len(imports))
+	seen := make(map[string]bool, len(imports))
+	for _, mod := range imports {
+		if seen[mod] {
+			continue
+		}
+		seen[mod] = true
+		displayName := lispImportDisplayName(mod)
+		out = append(out, types.EntityRecord{
+			Name:       displayName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   dialect,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID: filePath,
+					ToID:   mod,
+					Kind:   "IMPORTS",
+				},
+			},
+		})
+	}
+	return out
+}
+
+func lispImportDisplayName(mod string) string {
+	// "path/to/module" → "module"; "module-name" → "module-name"
+	if slash := strings.LastIndexByte(mod, '/'); slash >= 0 {
+		return mod[slash+1:]
+	}
+	return mod
+}
+
+// ---------------------------------------------------------------------------
+// CALLS edge collection
+// ---------------------------------------------------------------------------
+
+func collectLispCalls(body, callerName, dialect string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	matches := callRE.FindAllStringSubmatch(body, -1)
+	if len(matches) == 0 {
+		return nil
+	}
+	seen := make(map[string]bool, len(matches))
+	out := make([]types.RelationshipRecord, 0, len(matches))
+	for _, m := range matches {
+		if len(m) < 2 {
+			continue
+		}
+		target := m[1]
+		if target == "" || target == callerName {
+			continue
+		}
+		if lispSpecialForms[target] {
+			continue
+		}
+		if len(target) <= 1 {
+			continue
+		}
+		if seen[target] {
+			continue
+		}
+		seen[target] = true
+		out = append(out, types.RelationshipRecord{
+			ToID: target,
+			Kind: "CALLS",
+		})
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// S-expression body extraction
+// ---------------------------------------------------------------------------
+
+// extractSexprBody returns the text of the top-level s-expression starting at
+// startOffset by matching parentheses.
+func extractSexprBody(src string, startOffset int) string {
+	// Find the opening paren.
+	openIdx := strings.IndexByte(src[startOffset:], '(')
+	if openIdx < 0 {
+		return ""
+	}
+	openIdx += startOffset
+
+	depth := 0
+	inStr := false
+	for i := openIdx; i < len(src); i++ {
+		ch := src[i]
+		if inStr {
+			if ch == '\\' && i+1 < len(src) {
+				i++ // skip escaped char
+				continue
+			}
+			if ch == '"' {
+				inStr = false
+			}
+			continue
+		}
+		switch ch {
+		case '"':
+			inStr = true
+		case ';':
+			// Line comment — skip to end of line.
+			for i < len(src) && src[i] != '\n' {
+				i++
+			}
+		case '(':
+			depth++
+		case ')':
+			depth--
+			if depth == 0 {
+				return src[openIdx : i+1]
+			}
+		}
+	}
+	return src[openIdx:]
+}
+
+// ---------------------------------------------------------------------------
+// String/comment stripping
+// ---------------------------------------------------------------------------
+
+// stripLispStringsAndComments replaces string literals and ; line comments
+// with spaces to avoid false pattern matches.
+func stripLispStringsAndComments(src string) string {
+	out := make([]byte, len(src))
+	i := 0
+	inStr := false
+
+	for i < len(src) {
+		ch := src[i]
+
+		if inStr {
+			if ch == '\\' && i+1 < len(src) {
+				out[i] = ' '
+				out[i+1] = ' '
+				i += 2
+				continue
+			}
+			if ch == '"' {
+				inStr = false
+				out[i] = ' '
+			} else {
+				out[i] = ' '
+			}
+			i++
+			continue
+		}
+
+		// Lisp line comment: ; to end of line
+		if ch == ';' {
+			for i < len(src) && src[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// Block comment: #| ... |# (Common Lisp / SRFI)
+		if ch == '#' && i+1 < len(src) && src[i+1] == '|' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			for i < len(src) {
+				if src[i] == '|' && i+1 < len(src) && src[i+1] == '#' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					break
+				}
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		if ch == '"' {
+			inStr = true
+			out[i] = ' '
+			i++
+			continue
+		}
+
+		out[i] = ch
+		i++
+	}
+	return string(out)
+}
+
+// ---------------------------------------------------------------------------
+// Line number helper
+// ---------------------------------------------------------------------------
+
+func lineOf(src string, offset int) int {
+	if offset > len(src) {
+		offset = len(src)
+	}
+	return strings.Count(src[:offset], "\n") + 1
+}

--- a/internal/extractors/lisp/lisp_test.go
+++ b/internal/extractors/lisp/lisp_test.go
@@ -1,0 +1,710 @@
+package lisp_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/lisp"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func runLisp(t *testing.T, lang, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get(lang)
+	if !ok {
+		t.Fatalf("%s extractor not registered", lang)
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: lang,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func lispFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func lispFindSubtype(ents []types.EntityRecord, name, kind, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func lispHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// Registration tests
+// ---------------------------------------------------------------------------
+
+func TestLisp_Registered(t *testing.T) {
+	for _, lang := range []string{"commonlisp", "scheme", "racket"} {
+		_, ok := extractor.Get(lang)
+		if !ok {
+			t.Errorf("%s extractor not registered", lang)
+		}
+	}
+}
+
+func TestLisp_EmptyInput(t *testing.T) {
+	for _, lang := range []string{"commonlisp", "scheme", "racket"} {
+		ext, _ := extractor.Get(lang)
+		ents, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path:     "empty.lisp",
+			Content:  []byte{},
+			Language: lang,
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", lang, err)
+		}
+		if len(ents) != 0 {
+			t.Errorf("%s: expected 0 entities, got %d", lang, len(ents))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Common Lisp fixture
+// ---------------------------------------------------------------------------
+
+const clSrc = `
+(in-package :myapp)
+
+(defstruct point
+  x y)
+
+(defclass animal ()
+  ((name :initarg :name :accessor animal-name)
+   (sound :initarg :sound :accessor animal-sound)))
+
+(defmacro with-logging (&body body)
+  ` + "`" + `(progn
+     (format t "start~%")
+     ,@body
+     (format t "end~%")))
+
+(defun greet (name)
+  (format t "Hello, ~a!~%" name))
+
+(defun factorial (n)
+  (if (<= n 1)
+      1
+      (* n (factorial (- n 1)))))
+
+(defmethod animal-speak ((a animal))
+  (format t "~a says ~a~%"
+          (animal-name a)
+          (animal-sound a)))
+
+(defun make-animal (name sound)
+  (make-instance 'animal :name name :sound sound))
+`
+
+func TestCommonLisp_Functions(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+
+	wantOps := []string{"greet", "factorial", "make-animal"}
+	for _, name := range wantOps {
+		e := lispFind(ents, name, "SCOPE.Operation")
+		if e == nil {
+			t.Errorf("expected SCOPE.Operation %q", name)
+		} else if e.Language != "commonlisp" {
+			t.Errorf("%q: expected Language=commonlisp, got %q", name, e.Language)
+		}
+	}
+}
+
+func TestCommonLisp_Macro(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+	e := lispFindSubtype(ents, "with-logging", "SCOPE.Operation", "macro")
+	if e == nil {
+		t.Error("expected macro with-logging as SCOPE.Operation(macro)")
+	}
+}
+
+func TestCommonLisp_Struct(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+	e := lispFindSubtype(ents, "point", "SCOPE.Component", "struct")
+	if e == nil {
+		t.Error("expected SCOPE.Component(struct) for point")
+	}
+}
+
+func TestCommonLisp_Class(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+	e := lispFindSubtype(ents, "animal", "SCOPE.Component", "class")
+	if e == nil {
+		t.Error("expected SCOPE.Component(class) for animal")
+	}
+}
+
+func TestCommonLisp_Namespace(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+	e := lispFindSubtype(ents, "myapp", "SCOPE.Component", "namespace")
+	if e == nil {
+		t.Error("expected SCOPE.Component(namespace) for myapp")
+	}
+}
+
+func TestCommonLisp_CallsEdge(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clSrc, "myapp.lisp")
+	// factorial should call factorial (recursion) — not emitted (self-ref filtered) —
+	// but make-animal should call make-instance
+	if !lispHasRel(ents, "make-animal", "SCOPE.Operation", "CALLS", "make-instance") {
+		t.Error("expected CALLS make-animal→make-instance")
+	}
+}
+
+func TestCommonLisp_DefclassNotMatchScheme(t *testing.T) {
+	// Ensure defclass is NOT matched in a Scheme file
+	schemeSrc := `
+(define (foo x) (+ x 1))
+`
+	ents := runLisp(t, "scheme", schemeSrc, "foo.scm")
+	for _, e := range ents {
+		if e.Subtype == "class" {
+			t.Errorf("scheme should not produce class entities, got: %+v", e)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Common Lisp recall fixture
+// ---------------------------------------------------------------------------
+
+const clRecallSrc = `
+(in-package :cl-web)
+
+(defstruct request
+  method path headers body)
+
+(defstruct response
+  status headers body)
+
+(defclass server ()
+  ((host :initarg :host :accessor server-host :initform "localhost")
+   (port :initarg :port :accessor server-port :initform 8080)
+   (routes :initarg :routes :accessor server-routes :initform nil)))
+
+(defmacro defroute (path method handler)
+  ` + "`" + `(list ,path ,method ,handler))
+
+(defun make-server (&key (host "localhost") (port 8080))
+  (make-instance 'server :host host :port port))
+
+(defun add-route (srv path method handler)
+  (push (defroute path method handler)
+        (server-routes srv)))
+
+(defun handle-request (srv req)
+  (let ((route (find-route srv (request-method req) (request-path req))))
+    (if route
+        (funcall (third route) req)
+        (make-response 404 "Not Found"))))
+
+(defun find-route (srv method path)
+  (find-if (lambda (r)
+              (and (string= (first r) path)
+                   (string= (second r) method)))
+            (server-routes srv)))
+
+(defun make-response (status body)
+  (make-instance 'response :status status :body body))
+
+(defun start-server (srv)
+  (format t "Starting server on ~a:~a~%"
+          (server-host srv)
+          (server-port srv)))
+`
+
+func TestCommonLisp_RecallFixture(t *testing.T) {
+	ents := runLisp(t, "commonlisp", clRecallSrc, "cl-web.lisp")
+
+	wantOps := []string{
+		"make-server", "add-route", "handle-request",
+		"find-route", "make-response", "start-server",
+	}
+	wantComps := []string{"request", "response", "server"}
+	wantMacros := []string{"defroute"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundMacros := make(map[string]bool)
+
+	for _, e := range ents {
+		switch {
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "function":
+			foundOps[e.Name] = true
+		case e.Kind == "SCOPE.Component" && (e.Subtype == "class" || e.Subtype == "struct"):
+			foundComps[e.Name] = true
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "macro":
+			foundMacros[e.Name] = true
+		}
+	}
+
+	opHits, compHits, macroHits := 0, 0, 0
+	for _, n := range wantOps {
+		if foundOps[n] {
+			opHits++
+		} else {
+			t.Logf("CL: missing op: %s", n)
+		}
+	}
+	for _, n := range wantComps {
+		if foundComps[n] {
+			compHits++
+		} else {
+			t.Logf("CL: missing comp: %s", n)
+		}
+	}
+	for _, n := range wantMacros {
+		if foundMacros[n] {
+			macroHits++
+		} else {
+			t.Logf("CL: missing macro: %s", n)
+		}
+	}
+
+	total := len(wantOps) + len(wantComps) + len(wantMacros)
+	found := opHits + compHits + macroHits
+	recall := float64(found) / float64(total) * 100
+	t.Logf("CL recall: %d/%d (%.0f%%)", found, total, recall)
+	if recall < 80 {
+		t.Errorf("CL recall %.0f%% below 80%% (%d/%d)", recall, found, total)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scheme fixture
+// ---------------------------------------------------------------------------
+
+const schemeSrc = `
+(require "srfi-1")
+(require "srfi-13")
+
+(define-struct point (x y))
+
+(define (make-point x y)
+  (point x y))
+
+(define (point-distance p1 p2)
+  (let ((dx (- (point-x p2) (point-x p1)))
+        (dy (- (point-y p2) (point-y p1))))
+    (sqrt (+ (* dx dx) (* dy dy)))))
+
+(define (map-points f pts)
+  (map f pts))
+
+(define (fold-sum lst)
+  (fold + 0 lst))
+
+(define-syntax while
+  (syntax-rules ()
+    ((_ test body ...)
+     (let loop ()
+       (when test
+         body ...
+         (loop))))))
+`
+
+func TestScheme_Functions(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeSrc, "points.scm")
+
+	wantOps := []string{"make-point", "point-distance", "map-points", "fold-sum"}
+	for _, name := range wantOps {
+		e := lispFind(ents, name, "SCOPE.Operation")
+		if e == nil {
+			t.Errorf("scheme: expected SCOPE.Operation %q", name)
+		} else if e.Language != "scheme" {
+			t.Errorf("%q: expected Language=scheme, got %q", name, e.Language)
+		}
+	}
+}
+
+func TestScheme_Struct(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeSrc, "points.scm")
+	e := lispFindSubtype(ents, "point", "SCOPE.Component", "struct")
+	if e == nil {
+		t.Error("scheme: expected SCOPE.Component(struct) for point")
+	}
+}
+
+func TestScheme_Macro(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeSrc, "points.scm")
+	e := lispFindSubtype(ents, "while", "SCOPE.Operation", "macro")
+	if e == nil {
+		t.Error("scheme: expected SCOPE.Operation(macro) for while")
+	}
+}
+
+func TestScheme_ImportEdge(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeSrc, "points.scm")
+	if !lispHasRel(ents, "srfi-1", "SCOPE.Component", "IMPORTS", "srfi-1") {
+		t.Error("scheme: expected IMPORTS edge for srfi-1")
+	}
+}
+
+func TestScheme_CallsEdge(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeSrc, "points.scm")
+	// map-points body calls map
+	if !lispHasRel(ents, "map-points", "SCOPE.Operation", "CALLS", "map") {
+		t.Error("scheme: expected CALLS map-points→map")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Scheme recall fixture
+// ---------------------------------------------------------------------------
+
+const schemeRecallSrc = `
+(require "srfi-1")
+(require "srfi-9")
+(require "srfi-13")
+
+(define-struct person (name age email))
+
+(define (make-person name age email)
+  (person name age email))
+
+(define (greet-person p)
+  (string-append "Hello, " (person-name p) "!"))
+
+(define (adults lst)
+  (filter (lambda (p) (>= (person-age p) 18)) lst))
+
+(define (names lst)
+  (map person-name lst))
+
+(define (email-list lst)
+  (map person-email lst))
+
+(define (find-by-name lst name)
+  (find (lambda (p) (string=? (person-name p) name)) lst))
+
+(define (sort-by-age lst)
+  (sort lst (lambda (a b) (< (person-age a) (person-age b)))))
+
+(define-syntax when-defined
+  (syntax-rules ()
+    ((_ val body ...)
+     (if val (begin body ...) #f))))
+`
+
+func TestScheme_RecallFixture(t *testing.T) {
+	ents := runLisp(t, "scheme", schemeRecallSrc, "people.scm")
+
+	wantOps := []string{
+		"make-person", "greet-person", "adults",
+		"names", "email-list", "find-by-name", "sort-by-age",
+	}
+	wantComps := []string{"person"}
+	wantMacros := []string{"when-defined"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundMacros := make(map[string]bool)
+
+	for _, e := range ents {
+		switch {
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "function":
+			foundOps[e.Name] = true
+		case e.Kind == "SCOPE.Component" && e.Subtype == "struct":
+			foundComps[e.Name] = true
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "macro":
+			foundMacros[e.Name] = true
+		}
+	}
+
+	opHits, compHits, macroHits := 0, 0, 0
+	for _, n := range wantOps {
+		if foundOps[n] {
+			opHits++
+		} else {
+			t.Logf("Scheme: missing op: %s", n)
+		}
+	}
+	for _, n := range wantComps {
+		if foundComps[n] {
+			compHits++
+		} else {
+			t.Logf("Scheme: missing comp: %s", n)
+		}
+	}
+	for _, n := range wantMacros {
+		if foundMacros[n] {
+			macroHits++
+		} else {
+			t.Logf("Scheme: missing macro: %s", n)
+		}
+	}
+
+	total := len(wantOps) + len(wantComps) + len(wantMacros)
+	found := opHits + compHits + macroHits
+	recall := float64(found) / float64(total) * 100
+	t.Logf("Scheme recall: %d/%d (%.0f%%)", found, total, recall)
+	if recall < 80 {
+		t.Errorf("Scheme recall %.0f%% below 80%% (%d/%d)", recall, found, total)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Racket fixture
+// ---------------------------------------------------------------------------
+
+const racketSrc = `
+#lang racket/base
+
+(require racket/list)
+(require racket/string)
+(require/typed racket/match [match-define (-> Any Void)])
+
+(struct point (x y) #:transparent)
+(struct circle (center radius) #:transparent)
+
+(define (make-point x y)
+  (point x y))
+
+(define (circle-area c)
+  (let ([r (circle-radius c)])
+    (* 3.14159 r r)))
+
+(define/contract (safe-divide a b)
+  (-> number? (and/c number? (not/c zero?)) number?)
+  (/ a b))
+
+(define/contract (greet name)
+  (-> string? string?)
+  (string-append "Hello, " name "!"))
+
+(define-syntax swap!
+  (syntax-rules ()
+    ((_ a b)
+     (let ([tmp a])
+       (set! a b)
+       (set! b tmp)))))
+
+(define (filter-positives lst)
+  (filter positive? lst))
+`
+
+func TestRacket_Functions(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+
+	wantOps := []string{"make-point", "circle-area", "safe-divide", "greet", "filter-positives"}
+	for _, name := range wantOps {
+		e := lispFind(ents, name, "SCOPE.Operation")
+		if e == nil {
+			t.Errorf("racket: expected SCOPE.Operation %q", name)
+		} else if e.Language != "racket" {
+			t.Errorf("%q: expected Language=racket, got %q", name, e.Language)
+		}
+	}
+}
+
+func TestRacket_Structs(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+	for _, name := range []string{"point", "circle"} {
+		e := lispFindSubtype(ents, name, "SCOPE.Component", "struct")
+		if e == nil {
+			t.Errorf("racket: expected SCOPE.Component(struct) for %q", name)
+		}
+	}
+}
+
+func TestRacket_DefineContract(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+	e := lispFind(ents, "safe-divide", "SCOPE.Operation")
+	if e == nil {
+		t.Error("racket: expected SCOPE.Operation for safe-divide (define/contract)")
+	}
+}
+
+func TestRacket_Macro(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+	e := lispFindSubtype(ents, "swap!", "SCOPE.Operation", "macro")
+	if e == nil {
+		t.Error("racket: expected SCOPE.Operation(macro) for swap!")
+	}
+}
+
+func TestRacket_ImportEdge(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+	if !lispHasRel(ents, "list", "SCOPE.Component", "IMPORTS", "racket/list") {
+		t.Error("racket: expected IMPORTS edge for racket/list")
+	}
+}
+
+func TestRacket_LanguageTagged(t *testing.T) {
+	ents := runLisp(t, "racket", racketSrc, "geometry.rkt")
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Properties == nil || r.Properties["language"] != "racket" {
+				t.Errorf("rel %s→%s missing language=racket (got %v)", r.Kind, r.ToID, r.Properties)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Racket recall fixture
+// ---------------------------------------------------------------------------
+
+const racketRecallSrc = `
+#lang racket
+
+(require racket/list)
+(require racket/string)
+(require racket/match)
+(require racket/contract)
+
+(struct user (id name email role) #:transparent)
+(struct session (token user-id expires) #:transparent)
+
+(define/contract (make-user id name email)
+  (-> exact-integer? string? string? user?)
+  (user id name email 'member))
+
+(define/contract (make-admin id name email)
+  (-> exact-integer? string? string? user?)
+  (user id name email 'admin))
+
+(define (user-admin? u)
+  (eq? (user-role u) 'admin))
+
+(define/contract (create-session token user-id ttl)
+  (-> string? exact-integer? exact-integer? session?)
+  (session token user-id (+ (current-seconds) ttl)))
+
+(define (session-expired? s)
+  (> (current-seconds) (session-expires s)))
+
+(define (find-user users id)
+  (findf (lambda (u) (= (user-id u) id)) users))
+
+(define-syntax with-auth
+  (syntax-rules ()
+    ((_ sess body ...)
+     (if (not (session-expired? sess))
+         (begin body ...)
+         (error "Session expired")))))
+`
+
+func TestRacket_RecallFixture(t *testing.T) {
+	ents := runLisp(t, "racket", racketRecallSrc, "auth.rkt")
+
+	wantOps := []string{
+		"make-user", "make-admin", "user-admin?",
+		"create-session", "session-expired?", "find-user",
+	}
+	wantComps := []string{"user", "session"}
+	wantMacros := []string{"with-auth"}
+
+	foundOps := make(map[string]bool)
+	foundComps := make(map[string]bool)
+	foundMacros := make(map[string]bool)
+
+	for _, e := range ents {
+		switch {
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "function":
+			foundOps[e.Name] = true
+		case e.Kind == "SCOPE.Component" && e.Subtype == "struct":
+			foundComps[e.Name] = true
+		case e.Kind == "SCOPE.Operation" && e.Subtype == "macro":
+			foundMacros[e.Name] = true
+		}
+	}
+
+	opHits, compHits, macroHits := 0, 0, 0
+	for _, n := range wantOps {
+		if foundOps[n] {
+			opHits++
+		} else {
+			t.Logf("Racket: missing op: %s", n)
+		}
+	}
+	for _, n := range wantComps {
+		if foundComps[n] {
+			compHits++
+		} else {
+			t.Logf("Racket: missing comp: %s", n)
+		}
+	}
+	for _, n := range wantMacros {
+		if foundMacros[n] {
+			macroHits++
+		} else {
+			t.Logf("Racket: missing macro: %s", n)
+		}
+	}
+
+	total := len(wantOps) + len(wantComps) + len(wantMacros)
+	found := opHits + compHits + macroHits
+	recall := float64(found) / float64(total) * 100
+	t.Logf("Racket recall: %d/%d (%.0f%%)", found, total, recall)
+	if recall < 80 {
+		t.Errorf("Racket recall %.0f%% below 80%% (%d/%d)", recall, found, total)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Cross-dialect isolation tests
+// ---------------------------------------------------------------------------
+
+func TestCrossDialect_CLDefclassNotInRacket(t *testing.T) {
+	src := "(defclass animal () ())"
+	ents := runLisp(t, "racket", src, "test.rkt")
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			t.Errorf("racket: defclass should not match, got entity: %+v", e)
+		}
+	}
+}
+
+func TestCrossDialect_RacketStructNotInCL(t *testing.T) {
+	src := "(struct point (x y))"
+	ents := runLisp(t, "commonlisp", src, "test.lisp")
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "struct" && e.Name == "point" {
+			t.Errorf("commonlisp: (struct ...) should not match defstruct, got entity: %+v", e)
+		}
+	}
+}
+
+func TestCrossDialect_DefunNotInScheme(t *testing.T) {
+	src := "(defun foo (x) (+ x 1))"
+	ents := runLisp(t, "scheme", src, "test.scm")
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Operation" && e.Name == "foo" {
+			t.Errorf("scheme: defun should not match, got entity: %+v", e)
+		}
+	}
+}

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -25,6 +25,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/javascript"
 	_ "github.com/cajasmota/archigraph/internal/extractors/just"
 	_ "github.com/cajasmota/archigraph/internal/extractors/kotlin"
+	_ "github.com/cajasmota/archigraph/internal/extractors/lisp"
 	_ "github.com/cajasmota/archigraph/internal/extractors/lua"
 	_ "github.com/cajasmota/archigraph/internal/extractors/markdown"
 	_ "github.com/cajasmota/archigraph/internal/extractors/nim"

--- a/internal/resolve/dynamic_patterns_lisp.go
+++ b/internal/resolve/dynamic_patterns_lisp.go
@@ -1,0 +1,470 @@
+package resolve
+
+import "regexp"
+
+// lispDynamicPatterns covers all three Lisp-family dialects.
+// Each dialect slice is registered separately under its language key.
+//
+// Three dialect categories:
+//
+//  1. Common Lisp — CLOS operations (make-instance, defmethod, slot-value),
+//     CL stdlib (mapcar, reduce, format, getf, setf, car, cdr, ...).
+//
+//  2. Scheme — R5RS/R7RS stdlib (map, for-each, apply, call/cc,
+//     dynamic-wind, string operations, list operations, arithmetic).
+//
+//  3. Racket — contracts (define/contract, provide/contract),
+//     DrRacket bindings (require/typed, provide/contract),
+//     racket/* standard library functions.
+//
+// All patterns are gated to their respective dialect language key
+// (lang=="commonlisp", lang=="scheme", lang=="racket") following the
+// safer-bias rule to prevent cross-language collisions.
+
+// ============================================================
+// Common Lisp dynamic patterns
+// ============================================================
+
+var commonlispDynamicPatterns = []*regexp.Regexp{
+	// ── CLOS operations ──────────────────────────────────────
+	regexp.MustCompile(`^make-instance$`),     // (make-instance 'class-name ...) — CLOS constructor
+	regexp.MustCompile(`^slot-value$`),        // (slot-value obj 'slot) — CLOS slot accessor
+	regexp.MustCompile(`^slot-boundp$`),       // (slot-boundp obj 'slot)
+	regexp.MustCompile(`^slot-exists-p$`),     // (slot-exists-p obj 'slot)
+	regexp.MustCompile(`^class-of$`),          // (class-of obj) — returns class
+	regexp.MustCompile(`^find-class$`),        // (find-class 'name)
+	regexp.MustCompile(`^initialize-instance$`), // (initialize-instance obj ...) — CLOS init
+	regexp.MustCompile(`^change-class$`),      // (change-class obj new-class)
+	regexp.MustCompile(`^reinitialize-instance$`),
+	regexp.MustCompile(`^compute-applicable-methods$`),
+	regexp.MustCompile(`^no-applicable-method$`),
+	regexp.MustCompile(`^no-next-method$`),
+
+	// ── CL stdlib: list operations ────────────────────────────
+	regexp.MustCompile(`^car$`),               // first element
+	regexp.MustCompile(`^cdr$`),               // rest of list
+	regexp.MustCompile(`^cadr$`),              // second element
+	regexp.MustCompile(`^caddr$`),             // third element
+	regexp.MustCompile(`^cadddr$`),            // fourth element
+	regexp.MustCompile(`^cons$`),              // (cons head tail)
+	regexp.MustCompile(`^list$`),              // (list ...)
+	regexp.MustCompile(`^list\*$`),            // (list* ...)
+	regexp.MustCompile(`^append$`),            // (append list1 list2 ...)
+	regexp.MustCompile(`^nconc$`),             // destructive append
+	regexp.MustCompile(`^reverse$`),           // (reverse list)
+	regexp.MustCompile(`^nreverse$`),          // destructive reverse
+	regexp.MustCompile(`^length$`),            // (length seq)
+	regexp.MustCompile(`^elt$`),               // (elt seq index)
+	regexp.MustCompile(`^nth$`),               // (nth n list)
+	regexp.MustCompile(`^nthcdr$`),            // (nthcdr n list)
+	regexp.MustCompile(`^last$`),              // (last list)
+	regexp.MustCompile(`^butlast$`),           // (butlast list)
+	regexp.MustCompile(`^first$`),             // (first list) — alias for car
+	regexp.MustCompile(`^second$`),            // (second list)
+	regexp.MustCompile(`^third$`),             // (third list)
+	regexp.MustCompile(`^rest$`),              // (rest list) — alias for cdr
+	regexp.MustCompile(`^mapcar$`),            // (mapcar fn list ...) — map over list
+	regexp.MustCompile(`^maplist$`),           // (maplist fn list)
+	regexp.MustCompile(`^mapc$`),              // (mapc fn list) — side-effect map
+	regexp.MustCompile(`^mapcan$`),            // (mapcan fn list) — flatmap
+	regexp.MustCompile(`^reduce$`),            // (reduce fn list)
+	regexp.MustCompile(`^remove$`),            // (remove item list)
+	regexp.MustCompile(`^remove-if$`),         // (remove-if pred list)
+	regexp.MustCompile(`^remove-if-not$`),     // (remove-if-not pred list)
+	regexp.MustCompile(`^delete$`),            // destructive remove
+	regexp.MustCompile(`^delete-if$`),         // destructive remove-if
+	regexp.MustCompile(`^find$`),              // (find item list)
+	regexp.MustCompile(`^find-if$`),           // (find-if pred list)
+	regexp.MustCompile(`^find-if-not$`),       // (find-if-not pred list)
+	regexp.MustCompile(`^position$`),          // (position item list)
+	regexp.MustCompile(`^position-if$`),       // (position-if pred list)
+	regexp.MustCompile(`^count$`),             // (count item list)
+	regexp.MustCompile(`^count-if$`),          // (count-if pred list)
+	regexp.MustCompile(`^sort$`),              // (sort list pred)
+	regexp.MustCompile(`^stable-sort$`),       // (stable-sort list pred)
+	regexp.MustCompile(`^member$`),            // (member item list)
+	regexp.MustCompile(`^assoc$`),             // (assoc key alist)
+	regexp.MustCompile(`^rassoc$`),            // (rassoc val alist)
+	regexp.MustCompile(`^getf$`),              // (getf plist key) — property list access
+	regexp.MustCompile(`^setf$`),              // (setf place value)
+	regexp.MustCompile(`^pushnew$`),           // (pushnew item place)
+	regexp.MustCompile(`^push$`),              // (push item place)
+	regexp.MustCompile(`^pop$`),               // (pop place)
+	regexp.MustCompile(`^subseq$`),            // (subseq seq start end)
+	regexp.MustCompile(`^copy-list$`),         // (copy-list list)
+	regexp.MustCompile(`^copy-seq$`),          // (copy-seq seq)
+	regexp.MustCompile(`^coerce$`),            // (coerce object type)
+	regexp.MustCompile(`^apply$`),             // (apply fn args)
+	regexp.MustCompile(`^funcall$`),           // (funcall fn args...)
+
+	// ── CL stdlib: string / IO ────────────────────────────────
+	regexp.MustCompile(`^format$`),            // (format dest ctrl-str args...) — formatted output
+	regexp.MustCompile(`^write$`),             // (write obj)
+	regexp.MustCompile(`^writeln$`),           // (writeln obj)
+	regexp.MustCompile(`^read$`),              // (read)
+	regexp.MustCompile(`^read-line$`),         // (read-line)
+	regexp.MustCompile(`^print$`),             // (print obj)
+	regexp.MustCompile(`^princ$`),             // (princ obj)
+	regexp.MustCompile(`^terpri$`),            // (terpri) — newline
+	regexp.MustCompile(`^fresh-line$`),        // (fresh-line)
+	regexp.MustCompile(`^string$`),            // (string char)
+	regexp.MustCompile(`^string-upcase$`),     // (string-upcase s)
+	regexp.MustCompile(`^string-downcase$`),   // (string-downcase s)
+	regexp.MustCompile(`^string=`),            // string comparisons
+	regexp.MustCompile(`^string<`),
+	regexp.MustCompile(`^string>`),
+	regexp.MustCompile(`^concatenate$`),       // (concatenate 'string ...)
+	regexp.MustCompile(`^string-trim$`),       // (string-trim chars s)
+	regexp.MustCompile(`^string-left-trim$`),
+	regexp.MustCompile(`^string-right-trim$`),
+	regexp.MustCompile(`^char$`),              // (char string index)
+	regexp.MustCompile(`^char=`),              // char comparison
+	regexp.MustCompile(`^char<`),
+	regexp.MustCompile(`^char>`),
+	regexp.MustCompile(`^with-open-file$`),    // (with-open-file (var file) ...)
+	regexp.MustCompile(`^open$`),              // (open path)
+	regexp.MustCompile(`^close$`),             // (close stream)
+	regexp.MustCompile(`^pathname$`),          // (pathname string)
+	regexp.MustCompile(`^namestring$`),        // (namestring path)
+
+	// ── CL stdlib: arithmetic / predicates ────────────────────
+	regexp.MustCompile(`^zerop$`),             // (zerop n)
+	regexp.MustCompile(`^plusp$`),             // (plusp n)
+	regexp.MustCompile(`^minusp$`),            // (minusp n)
+	regexp.MustCompile(`^evenp$`),             // (evenp n)
+	regexp.MustCompile(`^oddp$`),              // (oddp n)
+	regexp.MustCompile(`^numberp$`),           // (numberp x)
+	regexp.MustCompile(`^integerp$`),          // (integerp x)
+	regexp.MustCompile(`^stringp$`),           // (stringp x)
+	regexp.MustCompile(`^symbolp$`),           // (symbolp x)
+	regexp.MustCompile(`^consp$`),             // (consp x)
+	regexp.MustCompile(`^listp$`),             // (listp x)
+	regexp.MustCompile(`^null$`),              // (null x) — empty-list check
+	regexp.MustCompile(`^atom$`),              // (atom x)
+	regexp.MustCompile(`^not$`),               // (not x)
+	regexp.MustCompile(`^equal$`),             // (equal x y)
+	regexp.MustCompile(`^equalp$`),            // (equalp x y)
+	regexp.MustCompile(`^eql$`),               // (eql x y)
+	regexp.MustCompile(`^eq$`),                // (eq x y) — identity
+	regexp.MustCompile(`^max$`),               // (max a b ...)
+	regexp.MustCompile(`^min$`),               // (min a b ...)
+	regexp.MustCompile(`^abs$`),               // (abs n)
+	regexp.MustCompile(`^mod$`),               // (mod n m)
+	regexp.MustCompile(`^rem$`),               // (rem n m)
+	regexp.MustCompile(`^floor$`),             // (floor n)
+	regexp.MustCompile(`^ceiling$`),           // (ceiling n)
+	regexp.MustCompile(`^round$`),             // (round n)
+	regexp.MustCompile(`^truncate$`),          // (truncate n)
+	regexp.MustCompile(`^sqrt$`),              // (sqrt n)
+	regexp.MustCompile(`^expt$`),              // (expt base exp)
+	regexp.MustCompile(`^log$`),               // (log n) / (log n base)
+	regexp.MustCompile(`^gcd$`),               // (gcd a b)
+	regexp.MustCompile(`^lcm$`),               // (lcm a b)
+	regexp.MustCompile(`^incf$`),              // (incf var) — increment
+	regexp.MustCompile(`^decf$`),              // (decf var) — decrement
+	regexp.MustCompile(`^1\+$`),               // (1+ n)
+	regexp.MustCompile(`^1-$`),                // (1- n)
+
+	// ── CL stdlib: hash tables ────────────────────────────────
+	regexp.MustCompile(`^make-hash-table$`),   // (make-hash-table)
+	regexp.MustCompile(`^gethash$`),           // (gethash key table)
+	regexp.MustCompile(`^puthash$`),           // (puthash key val table)
+	regexp.MustCompile(`^remhash$`),           // (remhash key table)
+	regexp.MustCompile(`^maphash$`),           // (maphash fn table)
+	regexp.MustCompile(`^hash-table-count$`),  // (hash-table-count table)
+	regexp.MustCompile(`^hash-table-keys$`),   // (hash-table-keys table)
+	regexp.MustCompile(`^hash-table-values$`), // (hash-table-values table)
+
+	// ── CL stdlib: conditions / restarts ──────────────────────
+	regexp.MustCompile(`^error$`),             // (error condition ...)
+	regexp.MustCompile(`^warn$`),              // (warn format ...)
+	regexp.MustCompile(`^signal$`),            // (signal condition)
+	regexp.MustCompile(`^handler-bind$`),      // (handler-bind ...)
+	regexp.MustCompile(`^handler-case$`),      // (handler-case ...)
+	regexp.MustCompile(`^ignore-errors$`),     // (ignore-errors ...)
+	regexp.MustCompile(`^restart-case$`),      // (restart-case ...)
+	regexp.MustCompile(`^invoke-restart$`),    // (invoke-restart name)
+}
+
+// ============================================================
+// Scheme dynamic patterns
+// ============================================================
+
+var schemeDynamicPatterns = []*regexp.Regexp{
+	// ── R5RS/R7RS: list operations ────────────────────────────
+	regexp.MustCompile(`^cons$`),              // (cons head tail)
+	regexp.MustCompile(`^car$`),               // (car pair)
+	regexp.MustCompile(`^cdr$`),               // (cdr pair)
+	regexp.MustCompile(`^cadr$`),              // (cadr pair) — second
+	regexp.MustCompile(`^caddr$`),             // (caddr pair) — third
+	regexp.MustCompile(`^list$`),              // (list ...)
+	regexp.MustCompile(`^length$`),            // (length list)
+	regexp.MustCompile(`^append$`),            // (append list ...)
+	regexp.MustCompile(`^reverse$`),           // (reverse list)
+	regexp.MustCompile(`^list-ref$`),          // (list-ref list k)
+	regexp.MustCompile(`^list-tail$`),         // (list-tail list k)
+	regexp.MustCompile(`^map$`),               // (map proc list ...) — functional map
+	regexp.MustCompile(`^for-each$`),          // (for-each proc list ...) — side-effect map
+	regexp.MustCompile(`^filter$`),            // (filter pred list) — SRFI-1
+	regexp.MustCompile(`^fold$`),              // (fold f init list) — SRFI-1
+	regexp.MustCompile(`^fold-right$`),        // (fold-right f init list) — SRFI-1
+	regexp.MustCompile(`^reduce$`),            // (reduce f init list) — SRFI-1
+	regexp.MustCompile(`^find$`),              // (find pred list) — SRFI-1
+	regexp.MustCompile(`^any$`),               // (any pred list) — SRFI-1
+	regexp.MustCompile(`^every$`),             // (every pred list) — SRFI-1
+	regexp.MustCompile(`^take$`),              // (take list n) — SRFI-1
+	regexp.MustCompile(`^drop$`),              // (drop list n) — SRFI-1
+	regexp.MustCompile(`^iota$`),              // (iota count) — SRFI-1
+	regexp.MustCompile(`^delete$`),            // (delete x list) — SRFI-1
+	regexp.MustCompile(`^member$`),            // (member x list)
+	regexp.MustCompile(`^assoc$`),             // (assoc key alist)
+	regexp.MustCompile(`^assq$`),              // (assq key alist)
+	regexp.MustCompile(`^assv$`),              // (assv key alist)
+	regexp.MustCompile(`^null\?$`),            // (null? x)
+	regexp.MustCompile(`^pair\?$`),            // (pair? x)
+	regexp.MustCompile(`^list\?$`),            // (list? x)
+	regexp.MustCompile(`^last-pair$`),         // (last-pair list)
+	regexp.MustCompile(`^set-car!$`),          // (set-car! pair val)
+	regexp.MustCompile(`^set-cdr!$`),          // (set-cdr! pair val)
+
+	// ── R5RS/R7RS: higher-order / continuations ───────────────
+	regexp.MustCompile(`^apply$`),             // (apply proc args)
+	regexp.MustCompile(`^call/cc$`),           // (call/cc proc)
+	regexp.MustCompile(`^call-with-current-continuation$`), // long form
+	regexp.MustCompile(`^dynamic-wind$`),      // (dynamic-wind in thunk out)
+	regexp.MustCompile(`^values$`),            // (values ...)
+	regexp.MustCompile(`^call-with-values$`),  // (call-with-values producer consumer)
+
+	// ── R5RS/R7RS: string operations ─────────────────────────
+	regexp.MustCompile(`^string\?$`),          // (string? x)
+	regexp.MustCompile(`^string$`),            // (string char ...)
+	regexp.MustCompile(`^string-length$`),     // (string-length s)
+	regexp.MustCompile(`^string-ref$`),        // (string-ref s k)
+	regexp.MustCompile(`^string-set!$`),       // (string-set! s k ch)
+	regexp.MustCompile(`^string=\?$`),         // (string=? s1 s2)
+	regexp.MustCompile(`^string<\?$`),         // (string<? s1 s2)
+	regexp.MustCompile(`^string>\?$`),         // (string>? s1 s2)
+	regexp.MustCompile(`^string-append$`),     // (string-append s1 s2 ...)
+	regexp.MustCompile(`^substring$`),         // (substring s start end)
+	regexp.MustCompile(`^string->list$`),      // (string->list s)
+	regexp.MustCompile(`^list->string$`),      // (list->string chars)
+	regexp.MustCompile(`^string-copy$`),       // (string-copy s)
+	regexp.MustCompile(`^string-upcase$`),     // SRFI-13
+	regexp.MustCompile(`^string-downcase$`),   // SRFI-13
+	regexp.MustCompile(`^string-contains$`),   // SRFI-13
+	regexp.MustCompile(`^string-split$`),      // SRFI-13
+	regexp.MustCompile(`^string-join$`),       // SRFI-13
+
+	// ── R5RS/R7RS: IO ─────────────────────────────────────────
+	regexp.MustCompile(`^display$`),           // (display obj)
+	regexp.MustCompile(`^newline$`),           // (newline)
+	regexp.MustCompile(`^write$`),             // (write obj)
+	regexp.MustCompile(`^read$`),              // (read)
+	regexp.MustCompile(`^read-char$`),         // (read-char)
+	regexp.MustCompile(`^peek-char$`),         // (peek-char)
+	regexp.MustCompile(`^open-input-file$`),   // (open-input-file path)
+	regexp.MustCompile(`^open-output-file$`),  // (open-output-file path)
+	regexp.MustCompile(`^close-input-port$`),  // (close-input-port p)
+	regexp.MustCompile(`^close-output-port$`), // (close-output-port p)
+	regexp.MustCompile(`^call-with-port$`),    // R7RS
+	regexp.MustCompile(`^with-output-to-file$`),
+	regexp.MustCompile(`^with-input-from-file$`),
+
+	// ── R5RS/R7RS: arithmetic / predicates ───────────────────
+	regexp.MustCompile(`^number\?$`),          // (number? x)
+	regexp.MustCompile(`^integer\?$`),         // (integer? x)
+	regexp.MustCompile(`^zero\?$`),            // (zero? n)
+	regexp.MustCompile(`^positive\?$`),        // (positive? n)
+	regexp.MustCompile(`^negative\?$`),        // (negative? n)
+	regexp.MustCompile(`^odd\?$`),             // (odd? n)
+	regexp.MustCompile(`^even\?$`),            // (even? n)
+	regexp.MustCompile(`^equal\?$`),           // (equal? a b)
+	regexp.MustCompile(`^eqv\?$`),             // (eqv? a b)
+	regexp.MustCompile(`^eq\?$`),              // (eq? a b)
+	regexp.MustCompile(`^not$`),               // (not x)
+	regexp.MustCompile(`^boolean\?$`),         // (boolean? x)
+	regexp.MustCompile(`^max$`),               // (max a b ...)
+	regexp.MustCompile(`^min$`),               // (min a b ...)
+	regexp.MustCompile(`^abs$`),               // (abs n)
+	regexp.MustCompile(`^modulo$`),            // (modulo n m)
+	regexp.MustCompile(`^remainder$`),         // (remainder n m)
+	regexp.MustCompile(`^quotient$`),          // (quotient n m)
+	regexp.MustCompile(`^gcd$`),               // (gcd a b)
+	regexp.MustCompile(`^lcm$`),               // (lcm a b)
+	regexp.MustCompile(`^floor$`),             // (floor n)
+	regexp.MustCompile(`^ceiling$`),           // (ceiling n)
+	regexp.MustCompile(`^round$`),             // (round n)
+	regexp.MustCompile(`^truncate$`),          // (truncate n)
+	regexp.MustCompile(`^sqrt$`),              // (sqrt n)
+	regexp.MustCompile(`^expt$`),              // (expt base exp)
+	regexp.MustCompile(`^exact->inexact$`),    // (exact->inexact n)
+	regexp.MustCompile(`^inexact->exact$`),    // (inexact->exact n)
+	regexp.MustCompile(`^number->string$`),    // (number->string n)
+	regexp.MustCompile(`^string->number$`),    // (string->number s)
+	regexp.MustCompile(`^symbol->string$`),    // (symbol->string sym)
+	regexp.MustCompile(`^string->symbol$`),    // (string->symbol s)
+	regexp.MustCompile(`^char->integer$`),     // (char->integer ch)
+	regexp.MustCompile(`^integer->char$`),     // (integer->char n)
+	regexp.MustCompile(`^vector->list$`),      // (vector->list v)
+	regexp.MustCompile(`^list->vector$`),      // (list->vector lst)
+
+	// ── R7RS: misc ────────────────────────────────────────────
+	regexp.MustCompile(`^error$`),             // (error msg ...)
+	regexp.MustCompile(`^make-vector$`),       // (make-vector k)
+	regexp.MustCompile(`^vector-ref$`),        // (vector-ref v k)
+	regexp.MustCompile(`^vector-set!$`),       // (vector-set! v k x)
+	regexp.MustCompile(`^vector-length$`),     // (vector-length v)
+	regexp.MustCompile(`^make-parameter$`),    // (make-parameter val) — R7RS parameters
+	regexp.MustCompile(`^parameterize$`),      // (parameterize ...)
+	regexp.MustCompile(`^with-exception-handler$`),
+	regexp.MustCompile(`^raise$`),             // (raise obj)
+	regexp.MustCompile(`^raise-continuable$`), // (raise-continuable obj)
+}
+
+// ============================================================
+// Racket dynamic patterns
+// ============================================================
+
+var racketDynamicPatterns = []*regexp.Regexp{
+	// ── Contracts ─────────────────────────────────────────────
+	regexp.MustCompile(`^->$`),                // (-> domain ... range) — function contract
+	regexp.MustCompile(`^->i$`),               // (->i ...) — dependent contract
+	regexp.MustCompile(`^->*$`),               // (->* ...) — opt-arg contract
+	regexp.MustCompile(`^contract\?$`),        // (contract? x)
+	regexp.MustCompile(`^flat-contract$`),     // (flat-contract pred)
+	regexp.MustCompile(`^flat-contract-predicate$`),
+	regexp.MustCompile(`^and/c$`),             // (and/c c1 c2)
+	regexp.MustCompile(`^or/c$`),              // (or/c c1 c2)
+	regexp.MustCompile(`^not/c$`),             // (not/c c)
+	regexp.MustCompile(`^any/c$`),             // any/c — always satisfied
+	regexp.MustCompile(`^none/c$`),            // none/c — never satisfied
+	regexp.MustCompile(`^listof$`),            // (listof c)
+	regexp.MustCompile(`^vectorof$`),          // (vectorof c)
+	regexp.MustCompile(`^hash/c$`),            // (hash/c key-c val-c)
+	regexp.MustCompile(`^between/c$`),         // (between/c lo hi)
+	regexp.MustCompile(`^integer-in$`),        // (integer-in lo hi)
+	regexp.MustCompile(`^provide/contract$`),  // (provide/contract ...)
+	regexp.MustCompile(`^require/typed$`),     // (require/typed ...)
+
+	// ── racket/list ───────────────────────────────────────────
+	regexp.MustCompile(`^first$`),             // (first lst)
+	regexp.MustCompile(`^second$`),            // (second lst)
+	regexp.MustCompile(`^third$`),             // (third lst)
+	regexp.MustCompile(`^fourth$`),            // (fourth lst)
+	regexp.MustCompile(`^rest$`),              // (rest lst)
+	regexp.MustCompile(`^last$`),              // (last lst)
+	regexp.MustCompile(`^take$`),              // (take lst n)
+	regexp.MustCompile(`^drop$`),              // (drop lst n)
+	regexp.MustCompile(`^take-right$`),        // (take-right lst n)
+	regexp.MustCompile(`^drop-right$`),        // (drop-right lst n)
+	regexp.MustCompile(`^filter$`),            // (filter pred lst)
+	regexp.MustCompile(`^foldl$`),             // (foldl f init lst)
+	regexp.MustCompile(`^foldr$`),             // (foldr f init lst)
+	regexp.MustCompile(`^andmap$`),            // (andmap pred lst)
+	regexp.MustCompile(`^ormap$`),             // (ormap pred lst)
+	regexp.MustCompile(`^count$`),             // (count pred lst)
+	regexp.MustCompile(`^flatten$`),           // (flatten lst)
+	regexp.MustCompile(`^remove$`),            // (remove x lst)
+	regexp.MustCompile(`^remove-duplicates$`), // (remove-duplicates lst)
+	regexp.MustCompile(`^sort$`),              // (sort lst <)
+	regexp.MustCompile(`^append-map$`),        // (append-map f lst)
+	regexp.MustCompile(`^list-update$`),       // (list-update lst k f)
+	regexp.MustCompile(`^findf$`),             // (findf pred lst)
+	regexp.MustCompile(`^index-of$`),          // (index-of lst x)
+	regexp.MustCompile(`^indexes-of$`),        // (indexes-of lst x)
+	regexp.MustCompile(`^range$`),             // (range n) or (range lo hi)
+	regexp.MustCompile(`^make-list$`),         // (make-list n x)
+
+	// ── racket/string ─────────────────────────────────────────
+	regexp.MustCompile(`^string-split$`),      // (string-split s)
+	regexp.MustCompile(`^string-join$`),       // (string-join lst sep)
+	regexp.MustCompile(`^string-contains$`),   // (string-contains s needle)
+	regexp.MustCompile(`^string-replace$`),    // (string-replace s from to)
+	regexp.MustCompile(`^string-trim$`),       // (string-trim s)
+	regexp.MustCompile(`^string-prefix\?$`),   // (string-prefix? pre s)
+	regexp.MustCompile(`^string-suffix\?$`),   // (string-suffix? suf s)
+	regexp.MustCompile(`^string-upcase$`),     // (string-upcase s)
+	regexp.MustCompile(`^string-downcase$`),   // (string-downcase s)
+	regexp.MustCompile(`^~a$`),                // format shorthand
+	regexp.MustCompile(`^~v$`),                // format shorthand
+	regexp.MustCompile(`^format$`),            // (format "~a" ...)
+
+	// ── racket/match ──────────────────────────────────────────
+	regexp.MustCompile(`^match$`),             // (match val clause ...)
+	regexp.MustCompile(`^match\*$`),           // (match* ...)
+	regexp.MustCompile(`^match-define$`),      // (match-define pat val)
+	regexp.MustCompile(`^match-lambda$`),      // (match-lambda clause ...)
+	regexp.MustCompile(`^match-lambda\*$`),    // (match-lambda* ...)
+
+	// ── racket/hash ───────────────────────────────────────────
+	regexp.MustCompile(`^hash$`),              // (hash k v ...)
+	regexp.MustCompile(`^make-hash$`),         // (make-hash)
+	regexp.MustCompile(`^hash-ref$`),          // (hash-ref h k)
+	regexp.MustCompile(`^hash-set$`),          // (hash-set h k v)
+	regexp.MustCompile(`^hash-set!$`),         // (hash-set! h k v)
+	regexp.MustCompile(`^hash-remove$`),       // (hash-remove h k)
+	regexp.MustCompile(`^hash-remove!$`),      // (hash-remove! h k)
+	regexp.MustCompile(`^hash-has-key\?$`),    // (hash-has-key? h k)
+	regexp.MustCompile(`^hash-keys$`),         // (hash-keys h)
+	regexp.MustCompile(`^hash-values$`),       // (hash-values h)
+	regexp.MustCompile(`^hash-count$`),        // (hash-count h)
+	regexp.MustCompile(`^hash-update$`),       // (hash-update h k f)
+	regexp.MustCompile(`^hash-update!$`),      // (hash-update! h k f)
+	regexp.MustCompile(`^hash-for-each$`),     // (hash-for-each h proc)
+	regexp.MustCompile(`^hash-map$`),          // (hash-map h proc)
+	regexp.MustCompile(`^hash\?$`),            // (hash? x)
+
+	// ── racket: IO / ports ────────────────────────────────────
+	regexp.MustCompile(`^displayln$`),         // (displayln x)
+	regexp.MustCompile(`^println$`),           // (println x)
+	regexp.MustCompile(`^printf$`),            // (printf fmt ...)
+	regexp.MustCompile(`^current-output-port$`),
+	regexp.MustCompile(`^current-input-port$`),
+	regexp.MustCompile(`^with-output-to-string$`),
+	regexp.MustCompile(`^open-input-string$`), // (open-input-string s)
+	regexp.MustCompile(`^port->string$`),      // (port->string p)
+	regexp.MustCompile(`^file->string$`),      // (file->string path)
+	regexp.MustCompile(`^file->lines$`),       // (file->lines path)
+	regexp.MustCompile(`^display-to-file$`),   // (display-to-file s path)
+	regexp.MustCompile(`^write-to-file$`),     // (write-to-file val path)
+
+	// ── racket: arithmetic / predicates ──────────────────────
+	regexp.MustCompile(`^exact\?$`),           // (exact? n)
+	regexp.MustCompile(`^inexact\?$`),         // (inexact? n)
+	regexp.MustCompile(`^exact->inexact$`),    // (exact->inexact n)
+	regexp.MustCompile(`^inexact->exact$`),    // (inexact->exact n)
+	regexp.MustCompile(`^zero\?$`),            // (zero? n)
+	regexp.MustCompile(`^positive\?$`),        // (positive? n)
+	regexp.MustCompile(`^negative\?$`),        // (negative? n)
+	regexp.MustCompile(`^odd\?$`),             // (odd? n)
+	regexp.MustCompile(`^even\?$`),            // (even? n)
+	regexp.MustCompile(`^equal\?$`),           // (equal? a b)
+	regexp.MustCompile(`^eqv\?$`),             // (eqv? a b)
+	regexp.MustCompile(`^eq\?$`),              // (eq? a b)
+	regexp.MustCompile(`^not$`),               // (not x)
+	regexp.MustCompile(`^void$`),              // (void) — no-op result
+	regexp.MustCompile(`^void\?$`),            // (void? x)
+	regexp.MustCompile(`^current-seconds$`),   // (current-seconds) — unix time
+	regexp.MustCompile(`^random$`),            // (random n)
+	regexp.MustCompile(`^error$`),             // (error msg ...)
+	regexp.MustCompile(`^raise$`),             // (raise exn)
+	regexp.MustCompile(`^raise-argument-error$`),
+	regexp.MustCompile(`^raise-type-error$`),
+	regexp.MustCompile(`^exn:fail\?$`),        // (exn:fail? x) — exception predicate
+	regexp.MustCompile(`^with-handlers$`),     // (with-handlers ([pred handler] ...) ...)
+	regexp.MustCompile(`^dynamic-require$`),   // (dynamic-require mod-path binding)
+	regexp.MustCompile(`^symbol\?$`),          // (symbol? x)
+	regexp.MustCompile(`^procedure\?$`),       // (procedure? x)
+	regexp.MustCompile(`^apply$`),             // (apply proc args)
+	regexp.MustCompile(`^map$`),               // (map f lst)
+	regexp.MustCompile(`^for-each$`),          // (for-each f lst)
+	regexp.MustCompile(`^values$`),            // (values ...)
+	regexp.MustCompile(`^call-with-values$`),  // (call-with-values ...)
+	regexp.MustCompile(`^call/cc$`),           // (call/cc ...)
+}
+
+func init() {
+	dynamicPatternsByLang["commonlisp"] = commonlispDynamicPatterns
+	dynamicPatternsByLang["scheme"] = schemeDynamicPatterns
+	dynamicPatternsByLang["racket"] = racketDynamicPatterns
+}


### PR DESCRIPTION
## What

Adds indexing support for the Lisp language family: Common Lisp, Scheme, and Racket. All three dialects share s-expression syntax, so one shared extractor handles them with dialect-aware form matching.

## Files changed

| File | Role |
|------|------|
| \`internal/extractors/lisp/extractor.go\` | Shared extractor, parameterised by dialect from file extension |
| \`internal/extractors/lisp/lisp_test.go\` | 27 tests — registration, per-dialect unit tests, 3 recall fixtures, cross-dialect isolation |
| \`internal/classifier/classifier.go\` | 3 new classifier entries: \`.lisp\`/\`.lsp\`/\`.cl\` → \`commonlisp\`, \`.scm\`/\`.ss\` → \`scheme\`, \`.rkt\` → \`racket\` |
| \`internal/extractors/registry_gen.go\` | Import of lisp package |
| \`internal/resolve/dynamic_patterns_lisp.go\` | Per-dialect resolver slices: CL CLOS + stdlib, Scheme R5RS/R7RS + SRFI-1/13, Racket contracts + racket/* stdlib |

## Entity extraction scope

**Common Lisp** (`.lisp` / `.lsp` / `.cl`):
- `(defun name ...)` → `SCOPE.Operation` subtype=`function`
- `(defmacro ...)` → `SCOPE.Operation` subtype=`macro`
- `(defmethod ...)` → `SCOPE.Operation` subtype=`function`
- `(defstruct ...)` → `SCOPE.Component` subtype=`struct`
- `(defclass ...)` → `SCOPE.Component` subtype=`class`
- `(in-package ...)` → `SCOPE.Component` subtype=`namespace` + CONTAINS edges
- `(load ...)` / `(require ...)` → IMPORTS edges

**Scheme** (`.scm` / `.ss`):
- `(define (name args) ...)` → `SCOPE.Operation` subtype=`function`
- `(define-syntax ...)` → `SCOPE.Operation` subtype=`macro`
- `(define-struct ...)` → `SCOPE.Component` subtype=`struct`
- `(define-class ...)` → `SCOPE.Component` subtype=`class`
- `(require ...)` → IMPORTS edges

**Racket** (`.rkt`):
- `(define (name ...) ...)` → `SCOPE.Operation` subtype=`function`
- `(define/contract (name ...) ...)` → `SCOPE.Operation` subtype=`function`
- `(define-syntax ...)` → `SCOPE.Operation` subtype=`macro`
- `(struct name ...)` → `SCOPE.Component` subtype=`struct`
- `(require ...)` / `(require/typed ...)` → IMPORTS edges

## Recall (fixtures)

| Dialect | Recall |
|---------|--------|
| Common Lisp | 10/10 (100%) |
| Scheme | 9/9 (100%) |
| Racket | 9/9 (100%) |

All three recall fixtures exceed the ≥80% acceptance bar.

## Cross-dialect isolation

Three tests verify dialect isolation:
- `defclass` in a `.rkt` file does not produce class entities (CL-only form)
- `(struct ...)` in a `.lisp` file does not match defstruct (Racket-only form)
- `(defun ...)` in a `.scm` file produces no function entity (CL-only form)

## Tests

```
ok  github.com/cajasmota/archigraph/internal/extractors/lisp   (27 tests, all PASS)
ok  github.com/cajasmota/archigraph/internal/classifier
ok  github.com/cajasmota/archigraph/internal/resolve
```