### PR TITLE
feat(graph): degree-based node sizing + labels + UX cleanup

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -101,14 +101,9 @@ const GraphCanvasInner = ({
     return repoColor(node.repo)
   }, [selectedNodeId, hoveredNodeId])
 
-  // Point size accessor — receives the node id (same column as pointColorBy)
-  const pointSizeByFn = useCallback((nodeId: string) => {
-    const node = nodesRef.current.find((n) => n.id === nodeId)
-    if (!node) return 4
-    if (node.is_centroid) return Math.max(4, Math.min(20, (node.centroid_size ?? 100) / 25))
-    if ((node.pagerank ?? 0) > 0.6) return 10  // god node
-    return 4 + (node.pagerank ?? 0) * 12
-  }, [])
+  // #1059: size nodes by degree (hub nodes appear larger than leaves).
+  // CosmographPointSizeStrategy.Degree uses quantile-bounded degree distribution.
+  // pointSizeRange controls min/max pixel sizes across the full degree spectrum.
 
   // Link color accessor — receives the value of the `linkColorBy` column ('kind')
   const linkColorByFn = useCallback((kind: string) => {
@@ -148,7 +143,7 @@ const GraphCanvasInner = ({
 
   return (
     <div
-      className={['w-full h-full', className].join(' ')}
+      className={['w-full h-full cursor-pointer', className].join(' ')}
       aria-label="Dependency graph"
       role="img"
       aria-describedby="graph-canvas-a11y-desc"
@@ -168,7 +163,7 @@ const GraphCanvasInner = ({
         // Explicit allowlist guards against any future non-primitive field reaching
         // DuckDB-WASM (nested objects/arrays crash columnar type inference).
         // __idx is included so Cosmograph can resolve its numeric index lookups.
-        pointIncludeColumns={['__idx', 'id', 'label', 'kind', 'repo', 'community_id', 'pagerank', 'is_centroid', 'centroid_size', 'source_file', 'start_line']}
+        pointIncludeColumns={['__idx', 'id', 'label', 'kind', 'repo', 'community_id', 'pagerank', 'is_centroid', 'centroid_size', 'source_file', 'start_line', 'degree']}
 
         links={cosmographLinks as unknown as Record<string, unknown>[]}
         linkSourceBy="source"
@@ -180,9 +175,24 @@ const GraphCanvasInner = ({
         // ── Node appearance ────────────────────────────────────────────────
         pointColorBy="id"
         pointColorByFn={pointColorByFn as (value: unknown) => string}
-        pointSizeBy="id"
-        pointSizeByFn={pointSizeByFn as (value: unknown) => number}
+        // #1059: size by degree — hub nodes are visually larger than leaf nodes.
+        // CosmographPointSizeStrategy.Degree uses quantile-bounded (p5–p95) degree distribution.
+        pointSizeStrategy="degree"
+        pointSizeRange={[4, 30]}
         pointLabelBy="label"
+
+        // ── Labels ────────────────────────────────────────────────────────
+        // #1059: show dynamic + top labels so hubs are named at a glance.
+        // showDynamicLabels: evenly distributed visible nodes get labels automatically.
+        // showTopLabels: highest-degree nodes always show labels regardless of viewport.
+        showDynamicLabels={true}
+        showTopLabels={true}
+        showTopLabelsLimit={15}
+        showDynamicLabelsLimit={20}
+        showHoveredPointLabel={true}
+        pointLabelClassName="text-xs font-mono"
+        pointLabelColor="#e2e8f0"
+        pointLabelFontSize={11}
 
         // ── Edge appearance ────────────────────────────────────────────────
         linkColorBy="kind"

--- a/dashboard/src/components/graph/GraphToolbar.tsx
+++ b/dashboard/src/components/graph/GraphToolbar.tsx
@@ -1,18 +1,14 @@
 import { Search, RotateCcw, Camera } from 'lucide-react'
 import { useRef } from 'react'
 
-// #1023: layout modes collapsed to 'force' only — Cosmograph 2D GPU force is the single renderer.
-// Tree layout removed (was broken with cyclic graphs; dagMode not supported by Cosmograph).
-// 3D toggle removed (3d-force-graph dependency dropped).
-export type LayoutMode = 'force'
+// #1023: Tree + 3D layout modes removed — Cosmograph is 2D-only GPU force renderer.
+// #1059: LayoutMode type + dead props scrubbed (no-tech-debt).
 
 interface GraphToolbarProps {
   searchQuery: string
   onSearchChange: (q: string) => void
   onResetView: () => void
   onSaveSnapshot: () => void
-  layoutMode: LayoutMode
-  onLayoutChange: (mode: LayoutMode) => void
   className?: string
 }
 
@@ -28,10 +24,7 @@ export function GraphToolbar({
   onResetView,
   onSaveSnapshot,
   className = '',
-}: Omit<GraphToolbarProps, 'layoutMode' | 'onLayoutChange'> & {
-  layoutMode?: LayoutMode
-  onLayoutChange?: (mode: LayoutMode) => void
-}) {
+}: GraphToolbarProps) {
   const searchRef = useRef<HTMLInputElement>(null)
 
   return (


### PR DESCRIPTION
## Summary

- **Degree-based node sizing**: replaces the old `pointSizeByFn` (pagerank heuristic) with `pointSizeStrategy="degree"` + `pointSizeRange=[4, 30]`. Cosmograph's built-in `Degree` strategy uses quantile-bounded (p5–p95) degree distribution, so hub nodes are visually larger than leaves without any manual tuning.
- **Hub labels**: enabled `showTopLabels` (top 15 by degree always visible), `showDynamicLabels` (up to 20 evenly distributed across the viewport), and `showHoveredPointLabel`. Labels are styled `font-mono 11px slate-200`.
- **Toolbar dead-code removal**: the `LayoutMode` type, `layoutMode` prop, and `onLayoutChange` prop were orphaned after #1023 removed the actual buttons. Scrubbed per no-tech-debt rule.
- **Click affordance**: added `cursor-pointer` to the canvas wrapper div.

## What changed

| File | Change |
|------|--------|
| `dashboard/src/components/graph/GraphCanvas.tsx` | Drop `pointSizeByFn`, use `pointSizeStrategy="degree"`, add label props, add `degree` to `pointIncludeColumns`, `cursor-pointer` |
| `dashboard/src/components/graph/GraphToolbar.tsx` | Delete dead `LayoutMode` type + interface fields `layoutMode` / `onLayoutChange` |

## Verification

Headless Playwright on the built preview (`npm run build` → `vite preview`):

- Canvas renders at 1248×763 px with 20,717 nodes  
- Large hub node clearly dominant at center; tiny leaf nodes at perimeter — degree sizing confirmed visually  
- Zero console errors  
- No Tree/3D/2D layout buttons in the DOM (`querySelectorAll` confirmed empty)  
- Search input present and functional  

Visual: dense ball of 20,717 nodes with an obviously large centroid hub (~200 px diameter) at center, medium-sized nodes ringing the perimeter, tiny 4 px leaf nodes at the outer fringe. Size differential between hub and leaves is unmistakable.

## API compatibility

`pointSizeStrategy="degree"` is a first-class `PointSizeStrategy` enum value in `@cosmograph/cosmograph` (verified in `node_modules/@cosmograph/cosmograph/cosmograph/strategies/point-size.d.ts`). No custom accessor needed.

## Test plan

- [ ] Open `/graph/<group>` — confirm nodes are visibly sized by connectivity (high-degree nodes larger)
- [ ] Zoom in — confirm top labels appear on hub nodes without heavy overlap
- [ ] Hover a node — confirm hover label appears
- [ ] Confirm no Tree / 3D / 2D toggle buttons in toolbar
- [ ] Search still works (`/` shortcut, typeahead results)
- [ ] Snapshot button still works

Closes #1059

🤖 Generated with [Claude Code](https://claude.com/claude-code)