### PR TITLE
feat(graph): hover-to-focus — dim non-neighbors, highlight hovered neighborhood

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -14,6 +14,8 @@ export interface GraphCanvasProps {
   hoveredNodeId: string | null
   onNodeClick: (node: GraphNode) => void
   onNodeHover: (node: GraphNode | null) => void
+  /** Called when the cursor moves over the canvas — provides screen coords for tooltip */
+  onCursorMove?: (x: number, y: number) => void
   onZoomChange?: (zoom: number) => void
   /** High-contrast mode — wider edges, higher opacity */
   highContrast?: boolean
@@ -43,6 +45,11 @@ function truncateLabel(text: string): string {
  *
  * Click handling: Cosmograph provides the point _index_ in onClick.
  * We keep a ref mirror of `nodes` so we can do O(1) lookup without async API calls.
+ *
+ * Hover-to-focus (#1060): When a node is hovered, selectPoint with connected
+ * neighbors is called so non-adjacent nodes are greyed out via Cosmograph's
+ * built-in greyout system (pointGreyoutOpacity / linkGreyoutOpacity).
+ * unselectAllPoints() restores full opacity on mouse leave.
  */
 const GraphCanvasInner = ({
   nodes,
@@ -51,6 +58,7 @@ const GraphCanvasInner = ({
   hoveredNodeId,
   onNodeClick,
   onNodeHover,
+  onCursorMove,
   onZoomChange,
   highContrast = false,
   isDark = true,
@@ -62,6 +70,12 @@ const GraphCanvasInner = ({
   // Mirror of nodes so click handler can resolve index → GraphNode synchronously
   const nodesRef = useRef<GraphNode[]>(nodes)
   nodesRef.current = nodes
+
+  // Debounce timer for hover — prevents thrashing on rapid micro-movements
+  const hoverDebounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Track the last hovered index so we can avoid redundant selectPoint calls
+  const lastHoverIndexRef = useRef<number | null>(null)
 
   // Cosmograph requires a sequential numeric index column on both points and links.
   // We derive these from the incoming arrays rather than mutating the originals.
@@ -93,6 +107,7 @@ const GraphCanvasInner = ({
   useEffect(() => {
     return () => {
       setGraphRef(null)
+      if (hoverDebounceRef.current) clearTimeout(hoverDebounceRef.current)
     }
   }, [setGraphRef])
 
@@ -126,20 +141,49 @@ const GraphCanvasInner = ({
     if (node) onNodeClick(node)
   }, [onNodeClick])
 
-  // Background click: clear hover
+  // Background click: clear hover + greyout
   const handleBackgroundClick = useCallback(() => {
+    if (hoverDebounceRef.current) clearTimeout(hoverDebounceRef.current)
+    lastHoverIndexRef.current = null
+    cosmographRef.current?.unselectAllPoints()
     onNodeHover(null)
   }, [onNodeHover])
 
-  // Hover: Cosmograph provides the point index on mouse move
+  // Hover: Cosmograph provides the point index on mouse move.
+  // Debounced 50 ms to avoid thrashing GPU on rapid micro-movements.
+  // When a node is hovered, selectPoint with selectConnectedPoints=true activates
+  // Cosmograph's greyout: non-selected/non-adjacent nodes get pointGreyoutOpacity.
   const handleMouseMove = useCallback((index: number | undefined) => {
+    if (hoverDebounceRef.current) clearTimeout(hoverDebounceRef.current)
+
     if (index === undefined) {
-      onNodeHover(null)
+      // Schedule clear with slight delay so leaving a node doesn't flicker
+      hoverDebounceRef.current = setTimeout(() => {
+        lastHoverIndexRef.current = null
+        cosmographRef.current?.unselectAllPoints()
+        onNodeHover(null)
+      }, 50)
       return
     }
-    const node = nodesRef.current[index]
-    onNodeHover(node ?? null)
+
+    // Same node — no work needed
+    if (index === lastHoverIndexRef.current) return
+
+    hoverDebounceRef.current = setTimeout(() => {
+      lastHoverIndexRef.current = index
+      const node = nodesRef.current[index]
+      if (!node) return
+      // selectPoint with selectConnectedPoints=true highlights the hovered node
+      // and its direct neighbors; all others get greyout opacity applied by Cosmograph.
+      cosmographRef.current?.selectPoint(index, false, true)
+      onNodeHover(node)
+    }, 50)
   }, [onNodeHover])
+
+  // Track raw screen cursor position for tooltip overlay
+  const handleWrapperMouseMove = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    onCursorMove?.(e.clientX, e.clientY)
+  }, [onCursorMove])
 
   // Zoom: Cosmograph's onZoom fires with a D3 zoom event; extract the k scale
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -166,6 +210,7 @@ const GraphCanvasInner = ({
       aria-label="Dependency graph"
       role="img"
       aria-describedby="graph-canvas-a11y-desc"
+      onMouseMove={handleWrapperMouseMove}
     >
       <span id="graph-canvas-a11y-desc" className="sr-only">
         Interactive GPU-accelerated force-directed graph. Use the inspector panel to navigate nodes with keyboard.
@@ -221,6 +266,11 @@ const GraphCanvasInner = ({
 
         // ── Background ────────────────────────────────────────────────────
         backgroundColor={canvasBg}
+
+        // ── Hover-to-focus greyout (#1060) ─────────────────────────────────
+        // When selectPoint is called, non-selected nodes get these opacity values.
+        pointGreyoutOpacity={0.15}
+        linkGreyoutOpacity={0.1}
 
         // ── Labels ────────────────────────────────────────────────────────
         // Truncate long entity names at 30 chars; pill background for readability.

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from 'react'
+import { useState, useCallback, useEffect, useRef, useMemo } from 'react'
 import { useParams, useNavigate } from 'react-router-dom'
 import { useGraphData } from '@/hooks/graph/useGraphData'
 import { useGraphSelection } from '@/hooks/graph/useGraphSelection'
@@ -53,6 +53,10 @@ export function GraphRoute() {
   const [showSearchResults, setShowSearchResults] = useState(false)
   const [highContrast, setHighContrast] = useState(false)
   const [hoveredCommunityId, setHoveredCommunityId] = useState<number | null>(null)
+
+  // ── Hover tooltip state (#1060) ────────────────────────────────────────────
+  // Track cursor position in screen coordinates for tooltip placement
+  const [cursorPos, setCursorPos] = useState<{ x: number; y: number } | null>(null)
   const searchContainerRef = useRef<HTMLDivElement>(null)
 
   // ── Community drill-in state ───────────────────────────────────────────────
@@ -90,6 +94,20 @@ export function GraphRoute() {
     )
 
   const colorMap = useCommunityColors(communities)
+
+  // ── Hover neighbor counts (#1060) ──────────────────────────────────────────
+  // Pre-index edges by source and target so neighbor lookup is O(1) per query.
+  const edgeIndex = useMemo(() => {
+    const callers = new Map<string, number>()  // target → inbound count
+    const callees = new Map<string, number>()  // source → outbound count
+    for (const e of edges) {
+      const src = String(e.source)
+      const tgt = String(e.target)
+      callees.set(src, (callees.get(src) ?? 0) + 1)
+      callers.set(tgt, (callers.get(tgt) ?? 0) + 1)
+    }
+    return { callers, callees }
+  }, [edges])
 
   // Derive unique repo slugs from communities once data loads
   useEffect(() => {
@@ -145,7 +163,12 @@ export function GraphRoute() {
 
   const handleNodeHover = useCallback((node: GraphNode | null) => {
     setHoveredNode(node?.id ?? null)
+    if (!node) setCursorPos(null)
   }, [setHoveredNode])
+
+  const handleCursorMove = useCallback((x: number, y: number) => {
+    if (hoveredNodeId) setCursorPos({ x, y })
+  }, [hoveredNodeId])
 
   const handleSearchSelect = useCallback((node: GraphNode) => {
     selectNode(node.id)
@@ -377,11 +400,38 @@ export function GraphRoute() {
               hoveredNodeId={hoveredNodeId}
               onNodeClick={handleNodeClick}
               onNodeHover={handleNodeHover}
+              onCursorMove={handleCursorMove}
               highContrast={highContrast}
               isDark={isDark}
               className="w-full h-full"
             />
           )}
+
+          {/* Hover tooltip — label + neighbor counts (#1060) */}
+          {hoveredNodeId && cursorPos && (() => {
+            const hovNode = nodes.find((n) => n.id === hoveredNodeId)
+            if (!hovNode) return null
+            const callerCount = edgeIndex.callers.get(String(hoveredNodeId)) ?? 0
+            const calleeCount = edgeIndex.callees.get(String(hoveredNodeId)) ?? 0
+            // Offset tooltip so it doesn't overlap the cursor
+            const tx = cursorPos.x + 14
+            const ty = cursorPos.y - 36
+            return (
+              <div
+                className="pointer-events-none fixed z-50 px-2.5 py-1.5 rounded-md border border-slate-700 bg-slate-900/95 text-xs text-slate-200 shadow-lg max-w-[220px]"
+                style={{ left: tx, top: ty }}
+                aria-hidden="true"
+              >
+                <div className="font-medium truncate">{hovNode.label ?? hovNode.id}</div>
+                {(callerCount > 0 || calleeCount > 0) && (
+                  <div className="mt-0.5 text-slate-400 flex gap-2">
+                    {callerCount > 0 && <span>{callerCount} caller{callerCount !== 1 ? 's' : ''}</span>}
+                    {calleeCount > 0 && <span>{calleeCount} callee{calleeCount !== 1 ? 's' : ''}</span>}
+                  </div>
+                )}
+              </div>
+            )
+          })()}
 
           {/* Node count + high-contrast toggle */}
           {!isLoading && !error && (


### PR DESCRIPTION
## Summary

- **Greyout on hover**: when a node is hovered, \`selectPoint(index, false, true)\` activates Cosmograph's built-in selection system; non-adjacent nodes render at \`pointGreyoutOpacity=0.15\` and non-adjacent links at \`linkGreyoutOpacity=0.1\`. \`unselectAllPoints()\` fires on mouse leave to restore full opacity.
- **Debounce + guard**: 50 ms debounce on the \`onMouseMove\` handler prevents GPU thrashing on rapid micro-movements; \`lastHoverIndexRef\` skips redundant \`selectPoint\` calls when the index hasn't changed.
- **Hover tooltip**: small fixed-position overlay near the cursor shows node label + caller count + callee count, computed from a pre-indexed edge map (O(1) per query, built once per \`edges\` change via \`useMemo\`). Disappears immediately on mouse leave.

## Changes

| File | What changed |
|---|---|
| \`dashboard/src/components/graph/GraphCanvas.tsx\` | Added \`onCursorMove\` prop, debounced hover handler with \`selectPoint\`/\`unselectAllPoints\`, \`pointGreyoutOpacity\`/\`linkGreyoutOpacity\` props on \`<Cosmograph>\` |
| \`dashboard/src/routes/graph.tsx\` | Added \`cursorPos\` state, \`edgeIndex\` memo (caller/callee maps), \`handleCursorMove\` callback, tooltip overlay JSX |

## Test plan

- [x] Vite build passes clean (✓ built in 17.50s, no TypeScript errors in modified files)
- [x] Playwright headless smoke: navigated to \`/graph/upvate\` (20 717 nodes, 57 555 edges), swept cursor over canvas
- [x] Screenshot hover-02: clear greyout — hovered neighborhood lit up, peripheral nodes visibly dimmed
- [x] Screenshot hover-03: different hub highlighted at offset position, confirms dynamic focus works
- [x] Screenshot hover-04: cursor at corner with no node → full opacity restored, no residual greyout
- [x] Zero console errors across all interactions

## Performance notes

- \`selectPoint\` / \`unselectAllPoints\` are synchronous WebGL buffer updates handled by Cosmograph — no React re-renders triggered per frame
- Debounce (50 ms) eliminates most redundant calls during fast sweeps
- \`edgeIndex\` maps built once per \`edges\` reference change, not per hover event

## Closes

Closes #1060

🤖 Generated with [Claude Code](https://claude.com/claude-code)