### PR TITLE
feat: VHDL extractor — hardware-design language coverage alongside Verilog

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -519,6 +519,9 @@ var extensionLanguageMap = map[string]string{
 	".vh":  "verilog",
 	".sv":  "systemverilog",
 	".svh": "systemverilog",
+	// VHDL — hardware description language (EDA / silicon)
+	".vhd":  "vhdl",
+	".vhdl": "vhdl",
 	// OCaml — .ml is claimed for OCaml (SML is much less common)
 	".ml":  "ocaml",
 	".mli": "ocaml",

--- a/internal/extractors/registry_gen.go
+++ b/internal/extractors/registry_gen.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/cajasmota/archigraph/internal/extractors/svelte"
 	_ "github.com/cajasmota/archigraph/internal/extractors/swift"
 	_ "github.com/cajasmota/archigraph/internal/extractors/verilog"
+	_ "github.com/cajasmota/archigraph/internal/extractors/vhdl"
 	_ "github.com/cajasmota/archigraph/internal/extractors/vue"
 	_ "github.com/cajasmota/archigraph/internal/extractors/yaml"
 	_ "github.com/cajasmota/archigraph/internal/extractors/zig"

--- a/internal/extractors/vhdl/extractor.go
+++ b/internal/extractors/vhdl/extractor.go
@@ -1,0 +1,818 @@
+// Package vhdl implements a regex-based extractor for VHDL source files.
+//
+// VHDL is the second hardware-description language supported by archigraph,
+// alongside Verilog/SystemVerilog (internal/extractors/verilog).
+//
+// Extracted entities:
+//   - `entity Name is ... end [entity] [Name];`     → SCOPE.Component (entity)
+//   - `architecture Name of Foo is ... end [architecture] [Name];`
+//     → SCOPE.Component (architecture) + PORT_OF edge to the entity
+//   - `package Name is ... end [package] [Name];`   → SCOPE.Component (package)
+//   - `package body Name is ... end [package body] [Name];`
+//     → SCOPE.Component (package_body) + PORT_OF edge to the package
+//   - `function name (...) return T is ... end [function] [name];`
+//     → SCOPE.Operation (function)
+//   - `procedure name (...) is ... end [procedure] [name];`
+//     → SCOPE.Operation (procedure)
+//   - `library ieee;` / `use ieee.std_logic_1164.all;`
+//     → IMPORTS edges
+//   - Component instantiation `inst: ComponentName port map (...)`
+//     → USES edges
+//
+// Signal declarations (`signal name : type;`) are skipped — they are leaf
+// data items that contribute noise rather than structural signal.
+//
+// File extensions handled: .vhd, .vhdl
+//
+// No tree-sitter grammar for VHDL is bundled in smacker/go-tree-sitter, so
+// this extractor uses regular expressions on comment-stripped source.
+//
+// Registers itself via init() and is imported by registry_gen.go.
+package vhdl
+
+import (
+	"context"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func init() {
+	extractor.Register("vhdl", &Extractor{})
+}
+
+// Extractor implements extractor.Extractor for VHDL.
+type Extractor struct{}
+
+// Language returns "vhdl".
+func (e *Extractor) Language() string { return "vhdl" }
+
+// -----------------------------------------------------------------------
+// Compiled regex patterns
+// -----------------------------------------------------------------------
+
+var (
+	// entityRE matches VHDL entity declarations (case-insensitive):
+	//   entity CounterTop is
+	//   entity AluCore is
+	entityRE = regexp.MustCompile(
+		`(?im)^\s*entity\s+([A-Za-z_][A-Za-z0-9_]*)\s+is\b`,
+	)
+
+	// architectureRE matches architecture declarations:
+	//   architecture rtl of CounterTop is
+	//   architecture behavioral of AluCore is
+	// Group 1 = architecture name, Group 2 = entity name.
+	architectureRE = regexp.MustCompile(
+		`(?im)^\s*architecture\s+([A-Za-z_][A-Za-z0-9_]*)\s+of\s+([A-Za-z_][A-Za-z0-9_]*)\s+is\b`,
+	)
+
+	// packageRE matches package declarations (but NOT package body).
+	// We match "package <name> is" where <name> is not the literal "body".
+	// Go regexp has no negative lookahead, so we filter "body" in code.
+	packageRE = regexp.MustCompile(
+		`(?im)^\s*package\s+([A-Za-z_][A-Za-z0-9_]*)\s+is\b`,
+	)
+
+	// packageBodyRE matches package body declarations:
+	//   package body ieee_arith is
+	// Group 1 = package name.
+	packageBodyRE = regexp.MustCompile(
+		`(?im)^\s*package\s+body\s+([A-Za-z_][A-Za-z0-9_]*)\s+is\b`,
+	)
+
+	// functionRE matches function declarations:
+	//   function to_integer (v : std_logic_vector) return integer is
+	//   function clamp (val : integer) return integer is
+	// Matches both the declaration within an architecture/package and
+	// standalone protected-body functions.  The "return ... is" suffix
+	// is used to anchor to the definition (not a forward declaration).
+	functionRE = regexp.MustCompile(
+		`(?im)^\s*function\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:\([^)]*\))?\s+return\s+\S+\s+is\b`,
+	)
+
+	// procedureRE matches procedure declarations:
+	//   procedure reset_counter (signal cnt : out integer) is
+	// The "is" suffix anchors to the definition body.
+	procedureRE = regexp.MustCompile(
+		`(?im)^\s*procedure\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?:\([^)]*\))?\s+is\b`,
+	)
+
+	// libraryRE matches library clauses:
+	//   library ieee;
+	//   library work;
+	libraryRE = regexp.MustCompile(
+		`(?im)^\s*library\s+([A-Za-z_][A-Za-z0-9_]*)\s*;`,
+	)
+
+	// useRE matches use clauses:
+	//   use ieee.std_logic_1164.all;
+	//   use work.alu_pkg.all;
+	// Group 1 = library/package name (first dotted segment).
+	useRE = regexp.MustCompile(
+		`(?im)^\s*use\s+([A-Za-z_][A-Za-z0-9_]*)\.`,
+	)
+
+	// componentInstRE matches component instantiations:
+	//   u_counter : CounterTop port map (...)
+	//   u_alu     : entity work.AluCore port map (...)
+	// Group 1 = instance label, Group 2 = component/entity name.
+	// The "entity work." prefix is optional.
+	componentInstRE = regexp.MustCompile(
+		`(?im)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*(?:entity\s+\w+\.)?([A-Za-z_][A-Za-z0-9_]*)\s+port\s+map\s*\(`,
+	)
+)
+
+// vhdlKeywords is the set of VHDL reserved words that must not be treated as
+// component instance types in USES edges.
+var vhdlKeywords = map[string]bool{
+	"entity": true, "architecture": true, "package": true, "body": true,
+	"is": true, "end": true, "begin": true, "port": true, "generic": true,
+	"map": true, "of": true, "in": true, "out": true, "inout": true,
+	"buffer": true, "linkage": true, "signal": true, "variable": true,
+	"constant": true, "file": true, "type": true, "subtype": true,
+	"use": true, "library": true, "work": true, "all": true,
+	"if": true, "then": true, "else": true, "elsif": true, "when": true,
+	"case": true, "for": true, "loop": true, "while": true,
+	"process": true, "wait": true, "until": true,
+	"function": true, "procedure": true, "return": true,
+	"component": true, "configuration": true, "generate": true,
+	"assert": true, "report": true, "severity": true,
+	"null": true, "others": true, "open": true,
+	"std_logic": true, "std_logic_vector": true, "bit": true, "bit_vector": true,
+	"integer": true, "natural": true, "positive": true, "boolean": true,
+	"string": true, "real": true, "time": true, "severity_level": true,
+	"array": true, "record": true, "access": true, "protected": true,
+	"impure": true, "pure": true, "shared": true, "new": true,
+	"with": true, "select": true, "after": true, "transport": true,
+	"reject": true, "inertial": true, "unaffected": true, "guarded": true,
+	"block": true, "disconnect": true, "postponed": true,
+	"attribute": true, "group": true, "label": true, "literal": true,
+	"range": true, "reverse_range": true, "downto": true, "to": true,
+	"and": true, "or": true, "not": true, "nand": true, "nor": true,
+	"xor": true, "xnor": true, "mod": true, "rem": true, "abs": true,
+	"sll": true, "srl": true, "sla": true, "sra": true, "rol": true,
+	"ror": true,
+}
+
+// Extract processes a VHDL source file and returns entity records.
+func (e *Extractor) Extract(_ context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
+	if len(file.Content) == 0 {
+		return nil, nil
+	}
+	lang := file.Language
+	if lang == "" {
+		lang = "vhdl"
+	}
+	out := extractVHDL(string(file.Content), file.Path, lang)
+	extractor.TagRelationshipsLanguage(out, lang)
+	return out, nil
+}
+
+// extractVHDL is the testable core.
+func extractVHDL(src, filePath, lang string) []types.EntityRecord {
+	var entities []types.EntityRecord
+
+	// Emit file-level entity.
+	entities = append(entities, extractor.FileEntity(extractor.FileInput{
+		Path:     filePath,
+		Language: lang,
+	}))
+
+	scrubbed := stripVHDLComments(src)
+
+	// ── 1. Library / use clauses (IMPORTS edges) ──────────────────────────
+	entities = append(entities, buildVHDLImportEntities(filePath, scrubbed, lang)...)
+
+	// ── 2. Design units ───────────────────────────────────────────────────
+	entities = append(entities, findVHDLEntities(scrubbed, filePath, lang)...)
+	entities = append(entities, findVHDLArchitectures(scrubbed, filePath, lang)...)
+	entities = append(entities, findVHDLPackages(scrubbed, filePath, lang)...)
+	entities = append(entities, findVHDLPackageBodies(scrubbed, filePath, lang)...)
+
+	return entities
+}
+
+// -----------------------------------------------------------------------
+// Import extraction
+// -----------------------------------------------------------------------
+
+func buildVHDLImportEntities(filePath, scrubbed, lang string) []types.EntityRecord {
+	seen := make(map[string]bool)
+	var out []types.EntityRecord
+
+	// library clauses
+	for _, m := range libraryRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		libName := strings.ToLower(strings.TrimSpace(m[1]))
+		if libName == "work" || libName == "" || seen["lib:"+libName] {
+			continue
+		}
+		seen["lib:"+libName] = true
+
+		props := map[string]string{
+			"source_module": libName,
+			"imported_name": libName,
+			"local_name":    libName,
+		}
+		out = append(out, types.EntityRecord{
+			Name:       libName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   lang,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID:     filePath,
+					ToID:       libName,
+					Kind:       "IMPORTS",
+					Properties: props,
+				},
+			},
+		})
+	}
+
+	// use clauses — emit IMPORTS for the library/package (first segment)
+	for _, m := range useRE.FindAllStringSubmatch(scrubbed, -1) {
+		if len(m) < 2 {
+			continue
+		}
+		libName := strings.ToLower(strings.TrimSpace(m[1]))
+		if libName == "work" || libName == "" || seen["use:"+libName] {
+			continue
+		}
+		seen["use:"+libName] = true
+
+		props := map[string]string{
+			"source_module": libName,
+			"imported_name": libName,
+			"local_name":    libName,
+		}
+		out = append(out, types.EntityRecord{
+			Name:       libName,
+			Kind:       "SCOPE.Component",
+			SourceFile: filePath,
+			Language:   lang,
+			Relationships: []types.RelationshipRecord{
+				{
+					FromID:     filePath,
+					ToID:       libName,
+					Kind:       "IMPORTS",
+					Properties: props,
+				},
+			},
+		})
+	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Entity declarations
+// -----------------------------------------------------------------------
+
+func findVHDLEntities(scrubbed, filePath, lang string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	for _, m := range entityRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := scrubbed[m[2]:m[3]]
+		startLine := strings.Count(scrubbed[:m[0]], "\n") + 1
+
+		// Find the matching "end [entity] [Name];" to determine endLine.
+		endLine := findVHDLEnd(scrubbed, m[1], "entity", name, startLine)
+
+		rec := types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "entity",
+			SourceFile: filePath,
+			Language:   lang,
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  strings.Join(strings.Fields(scrubbed[m[0]:m[1]]), " "),
+		}
+		out = append(out, rec)
+	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Architecture declarations
+// -----------------------------------------------------------------------
+
+func findVHDLArchitectures(scrubbed, filePath, lang string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	for _, m := range architectureRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		archName := scrubbed[m[2]:m[3]]
+		entityName := scrubbed[m[4]:m[5]]
+		qualName := archName + "_of_" + entityName
+		startLine := strings.Count(scrubbed[:m[0]], "\n") + 1
+
+		// Find the begin keyword to locate the concurrent body.
+		body, endLine := extractVHDLArchBody(scrubbed, m[1])
+		if endLine == 0 {
+			endLine = startLine
+		}
+
+		rec := types.EntityRecord{
+			Name:       qualName,
+			Kind:       "SCOPE.Component",
+			Subtype:    "architecture",
+			SourceFile: filePath,
+			Language:   lang,
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  strings.Join(strings.Fields(scrubbed[m[0]:m[1]]), " "),
+			// PORT_OF edge: this architecture belongs to the named entity.
+			Relationships: []types.RelationshipRecord{
+				{
+					ToID: entityName,
+					Kind: "PORT_OF",
+				},
+			},
+		}
+
+		archIdx := len(out)
+		out = append(out, rec)
+
+		if body == "" {
+			continue
+		}
+
+		bodyOffset := startLine
+
+		// Functions inside architecture.
+		for _, fm := range functionRE.FindAllStringSubmatchIndex(body, -1) {
+			if len(fm) < 4 {
+				continue
+			}
+			fnName := body[fm[2]:fm[3]]
+			fnQual := qualName + "." + fnName
+			fnStart := bodyOffset + strings.Count(body[:fm[0]], "\n")
+
+			fnRec := types.EntityRecord{
+				Name:       fnQual,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "function",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  fnStart,
+				EndLine:    fnStart,
+				Signature:  strings.Join(strings.Fields(body[fm[0]:fm[1]]), " "),
+			}
+			out = append(out, fnRec)
+
+			toID := extractor.BuildOperationStructuralRef(lang, filePath, fnQual)
+			out[archIdx].Relationships = append(out[archIdx].Relationships, types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+		}
+
+		// Procedures inside architecture.
+		for _, pm := range procedureRE.FindAllStringSubmatchIndex(body, -1) {
+			if len(pm) < 4 {
+				continue
+			}
+			procName := body[pm[2]:pm[3]]
+			procQual := qualName + "." + procName
+			pStart := bodyOffset + strings.Count(body[:pm[0]], "\n")
+
+			pRec := types.EntityRecord{
+				Name:       procQual,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "procedure",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  pStart,
+				EndLine:    pStart,
+				Signature:  strings.Join(strings.Fields(body[pm[0]:pm[1]]), " "),
+			}
+			out = append(out, pRec)
+
+			toID := extractor.BuildOperationStructuralRef(lang, filePath, procQual)
+			out[archIdx].Relationships = append(out[archIdx].Relationships, types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+		}
+
+		// Component instantiations (USES edges).
+		for _, usesRel := range collectVHDLInstantiations(body, qualName) {
+			out[archIdx].Relationships = append(out[archIdx].Relationships, usesRel)
+		}
+	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Package declarations
+// -----------------------------------------------------------------------
+
+func findVHDLPackages(scrubbed, filePath, lang string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	for _, m := range packageRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := scrubbed[m[2]:m[3]]
+		// Skip "package body <name> is" matches — packageBodyRE handles those.
+		if strings.EqualFold(name, "body") {
+			continue
+		}
+		startLine := strings.Count(scrubbed[:m[0]], "\n") + 1
+		endLine := findVHDLEnd(scrubbed, m[1], "package", name, startLine)
+
+		body, _ := extractVHDLBody(scrubbed, m[1])
+
+		rec := types.EntityRecord{
+			Name:       name,
+			Kind:       "SCOPE.Component",
+			Subtype:    "package",
+			SourceFile: filePath,
+			Language:   lang,
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  strings.Join(strings.Fields(scrubbed[m[0]:m[1]]), " "),
+		}
+
+		pkgIdx := len(out)
+		out = append(out, rec)
+
+		// Functions declared in the package header.
+		for _, fm := range functionRE.FindAllStringSubmatchIndex(body, -1) {
+			if len(fm) < 4 {
+				continue
+			}
+			fnName := body[fm[2]:fm[3]]
+			fnQual := name + "." + fnName
+			fnStart := startLine + strings.Count(body[:fm[0]], "\n")
+
+			fnRec := types.EntityRecord{
+				Name:       fnQual,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "function",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  fnStart,
+				EndLine:    fnStart,
+				Signature:  strings.Join(strings.Fields(body[fm[0]:fm[1]]), " "),
+			}
+			out = append(out, fnRec)
+
+			toID := extractor.BuildOperationStructuralRef(lang, filePath, fnQual)
+			out[pkgIdx].Relationships = append(out[pkgIdx].Relationships, types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+		}
+	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Package body declarations
+// -----------------------------------------------------------------------
+
+func findVHDLPackageBodies(scrubbed, filePath, lang string) []types.EntityRecord {
+	var out []types.EntityRecord
+
+	for _, m := range packageBodyRE.FindAllStringSubmatchIndex(scrubbed, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := scrubbed[m[2]:m[3]]
+		qualName := name + "_body"
+		startLine := strings.Count(scrubbed[:m[0]], "\n") + 1
+		endLine := findVHDLEnd(scrubbed, m[1], "package body", name, startLine)
+
+		body, _ := extractVHDLBody(scrubbed, m[1])
+
+		rec := types.EntityRecord{
+			Name:       qualName,
+			Kind:       "SCOPE.Component",
+			Subtype:    "package_body",
+			SourceFile: filePath,
+			Language:   lang,
+			StartLine:  startLine,
+			EndLine:    endLine,
+			Signature:  strings.Join(strings.Fields(scrubbed[m[0]:m[1]]), " "),
+			// PORT_OF edge: this body belongs to the named package.
+			Relationships: []types.RelationshipRecord{
+				{
+					ToID: name,
+					Kind: "PORT_OF",
+				},
+			},
+		}
+
+		bodyIdx := len(out)
+		out = append(out, rec)
+
+		// Functions in the package body.
+		for _, fm := range functionRE.FindAllStringSubmatchIndex(body, -1) {
+			if len(fm) < 4 {
+				continue
+			}
+			fnName := body[fm[2]:fm[3]]
+			fnQual := qualName + "." + fnName
+			fnStart := startLine + strings.Count(body[:fm[0]], "\n")
+
+			fnRec := types.EntityRecord{
+				Name:       fnQual,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "function",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  fnStart,
+				EndLine:    fnStart,
+				Signature:  strings.Join(strings.Fields(body[fm[0]:fm[1]]), " "),
+			}
+			out = append(out, fnRec)
+
+			toID := extractor.BuildOperationStructuralRef(lang, filePath, fnQual)
+			out[bodyIdx].Relationships = append(out[bodyIdx].Relationships, types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+		}
+
+		// Procedures in the package body.
+		for _, pm := range procedureRE.FindAllStringSubmatchIndex(body, -1) {
+			if len(pm) < 4 {
+				continue
+			}
+			procName := body[pm[2]:pm[3]]
+			procQual := qualName + "." + procName
+			pStart := startLine + strings.Count(body[:pm[0]], "\n")
+
+			pRec := types.EntityRecord{
+				Name:       procQual,
+				Kind:       "SCOPE.Operation",
+				Subtype:    "procedure",
+				SourceFile: filePath,
+				Language:   lang,
+				StartLine:  pStart,
+				EndLine:    pStart,
+				Signature:  strings.Join(strings.Fields(body[pm[0]:pm[1]]), " "),
+			}
+			out = append(out, pRec)
+
+			toID := extractor.BuildOperationStructuralRef(lang, filePath, procQual)
+			out[bodyIdx].Relationships = append(out[bodyIdx].Relationships, types.RelationshipRecord{
+				ToID: toID,
+				Kind: "CONTAINS",
+			})
+		}
+	}
+
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Component instantiation (USES edges)
+// -----------------------------------------------------------------------
+
+func collectVHDLInstantiations(body, ownerName string) []types.RelationshipRecord {
+	if body == "" {
+		return nil
+	}
+	seen := make(map[string]bool)
+	var out []types.RelationshipRecord
+
+	for _, m := range componentInstRE.FindAllStringSubmatch(body, -1) {
+		if len(m) < 3 {
+			continue
+		}
+		instLabel := strings.ToLower(m[1])
+		compType := m[2]
+
+		// Skip VHDL keywords.
+		if vhdlKeywords[strings.ToLower(compType)] {
+			continue
+		}
+		if vhdlKeywords[instLabel] {
+			continue
+		}
+		// Skip the owner itself (avoid self-loops).
+		if strings.EqualFold(compType, ownerName) {
+			continue
+		}
+		// Skip very short names (likely variables).
+		if len(compType) <= 1 {
+			continue
+		}
+
+		key := instLabel + ":" + strings.ToLower(compType)
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+
+		out = append(out, types.RelationshipRecord{
+			ToID: compType,
+			Kind: "USES",
+		})
+	}
+	return out
+}
+
+// -----------------------------------------------------------------------
+// Body extraction helpers
+// -----------------------------------------------------------------------
+
+// extractVHDLBody extracts the text between the declarative/statement region
+// opener (afterPos) and the matching "end" keyword. Returns the body text
+// and the 1-based end line.
+func extractVHDLBody(src string, afterPos int) (string, int) {
+	if afterPos >= len(src) {
+		return "", 0
+	}
+	rest := src[afterPos:]
+
+	// VHDL nests with "begin ... end" for architecture/process/generate.
+	// We track depth using begin/end pairs, where "is" also opens a region.
+	// For simplicity: scan for the top-level "end" that is not inside a nested
+	// "begin...end" — depth starts at 0, increment on is/begin, decrement on end.
+
+	beginRE := regexp.MustCompile(`(?i)\b(begin|is)\b`)
+	endRE := regexp.MustCompile(`(?i)\bend\b`)
+
+	depth := 0
+	i := 0
+	for i < len(rest) {
+		// Check for end first at depth==0.
+		if loc := endRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			if depth == 0 {
+				body := rest[:i]
+				endLine := strings.Count(src[:afterPos+i+loc[1]], "\n") + 1
+				return body, endLine
+			}
+			depth--
+			i += loc[1]
+			continue
+		}
+		// Check for begin/is that opens a nested block.
+		if loc := beginRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			depth++
+			i += loc[1]
+			continue
+		}
+		i++
+	}
+	return rest, 0
+}
+
+// extractVHDLArchBody extracts an architecture body starting from afterPos.
+// The architecture declarative region ends at "begin" and the concurrent
+// statement region ends at "end architecture ...;". We return the full
+// text so subunit extractors can find functions, procedures, and instantiations.
+func extractVHDLArchBody(src string, afterPos int) (string, int) {
+	if afterPos >= len(src) {
+		return "", 0
+	}
+	rest := src[afterPos:]
+
+	// Find the top-level "end" that closes this architecture.
+	// We increment depth on every "is" or "begin" and decrement on "end".
+	openRE := regexp.MustCompile(`(?i)\b(begin|is)\b`)
+	endRE := regexp.MustCompile(`(?i)\bend\b`)
+
+	depth := 0
+	i := 0
+	for i < len(rest) {
+		if loc := endRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			if depth == 0 {
+				body := rest[:i]
+				endLine := strings.Count(src[:afterPos+i+loc[1]], "\n") + 1
+				return body, endLine
+			}
+			depth--
+			i += loc[1]
+			continue
+		}
+		if loc := openRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			depth++
+			i += loc[1]
+			continue
+		}
+		i++
+	}
+	return rest, 0
+}
+
+// findVHDLEnd returns the 1-based end line for a design unit.
+// keyword is the unit keyword (e.g. "entity", "package", "package body"),
+// name is the unit name. afterPos is where to start scanning.
+func findVHDLEnd(src string, afterPos int, keyword, name string, startLine int) int {
+	if afterPos >= len(src) {
+		return startLine
+	}
+	rest := src[afterPos:]
+	// Build a pattern that matches "end [keyword] [name] ;" with optional parts.
+	endRE := regexp.MustCompile(`(?i)\bend\b`)
+
+	openRE := regexp.MustCompile(`(?i)\b(begin|is)\b`)
+
+	depth := 0
+	i := 0
+	for i < len(rest) {
+		if loc := endRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			if depth == 0 {
+				return strings.Count(src[:afterPos+i+loc[1]], "\n") + 1
+			}
+			depth--
+			i += loc[1]
+			continue
+		}
+		if loc := openRE.FindStringIndex(rest[i:]); loc != nil && loc[0] == 0 {
+			depth++
+			i += loc[1]
+			continue
+		}
+		i++
+	}
+	_ = keyword
+	_ = name
+	return startLine
+}
+
+// -----------------------------------------------------------------------
+// Comment stripping
+// -----------------------------------------------------------------------
+
+// stripVHDLComments replaces VHDL single-line comments (-- ...) and string
+// literals with spaces so regexes don't match inside them.
+// VHDL does not have block comments in VHDL-87/93/2000/2002; VHDL-2008
+// introduced /* */ but they are uncommon; we handle both.
+func stripVHDLComments(src string) string {
+	out := make([]byte, len(src))
+	copy(out, src)
+	i := 0
+	for i < len(src) {
+		ch := src[i]
+
+		// Single-line comment: -- ...
+		if ch == '-' && i+1 < len(src) && src[i+1] == '-' {
+			for i < len(src) && src[i] != '\n' {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		// Block comment (VHDL-2008): /* ... */
+		if ch == '/' && i+1 < len(src) && src[i+1] == '*' {
+			out[i] = ' '
+			out[i+1] = ' '
+			i += 2
+			for i+1 < len(src) {
+				if src[i] == '*' && src[i+1] == '/' {
+					out[i] = ' '
+					out[i+1] = ' '
+					i += 2
+					break
+				}
+				if src[i] != '\n' {
+					out[i] = ' '
+				}
+				i++
+			}
+			continue
+		}
+
+		// String literal: "..."
+		if ch == '"' {
+			out[i] = ' '
+			i++
+			for i < len(src) && src[i] != '"' {
+				if src[i] != '\n' {
+					out[i] = ' '
+				}
+				i++
+			}
+			if i < len(src) {
+				out[i] = ' '
+				i++
+			}
+			continue
+		}
+
+		i++
+	}
+	return string(out)
+}

--- a/internal/extractors/vhdl/extractor_test.go
+++ b/internal/extractors/vhdl/extractor_test.go
@@ -1,0 +1,519 @@
+package vhdl_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/vhdl"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+func runVHDL(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("vhdl")
+	if !ok {
+		t.Fatal("vhdl extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "vhdl",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+func vhFind(ents []types.EntityRecord, name, kind string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func vhFindSubtype(ents []types.EntityRecord, name, kind, subtype string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name && ents[i].Kind == kind && ents[i].Subtype == subtype {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+func vhHasRel(ents []types.EntityRecord, name, kind, edgeKind, toID string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && r.ToID == toID {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func vhHasRelPartial(ents []types.EntityRecord, name, kind, edgeKind, toIDContains string) bool {
+	for i := range ents {
+		if ents[i].Name != name || ents[i].Kind != kind {
+			continue
+		}
+		for _, r := range ents[i].Relationships {
+			if r.Kind == edgeKind && strings.Contains(r.ToID, toIDContains) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ── Registration ──────────────────────────────────────────────────────────────
+
+func TestVHDL_Registered(t *testing.T) {
+	_, ok := extractor.Get("vhdl")
+	if !ok {
+		t.Fatal("vhdl extractor not registered")
+	}
+}
+
+func TestVHDL_EmptyInput(t *testing.T) {
+	ext, _ := extractor.Get("vhdl")
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "empty.vhd",
+		Content:  []byte{},
+		Language: "vhdl",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// ── Entity declaration ────────────────────────────────────────────────────────
+
+func TestVHDL_EntityDeclaration(t *testing.T) {
+	src := `
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity CounterTop is
+  port (
+    clk   : in  std_logic;
+    rst   : in  std_logic;
+    count : out std_logic_vector(7 downto 0)
+  );
+end entity CounterTop;
+`
+	ents := runVHDL(t, src, "counter.vhd")
+	e := vhFindSubtype(ents, "CounterTop", "SCOPE.Component", "entity")
+	if e == nil {
+		t.Fatal("expected SCOPE.Component(entity) CounterTop")
+	}
+}
+
+// ── Architecture declaration ──────────────────────────────────────────────────
+
+func TestVHDL_ArchitectureDeclaration(t *testing.T) {
+	src := `
+entity AluCore is
+  port (
+    a, b : in  std_logic_vector(7 downto 0);
+    result : out std_logic_vector(7 downto 0)
+  );
+end entity AluCore;
+
+architecture rtl of AluCore is
+begin
+  result <= a or b;
+end architecture rtl;
+`
+	ents := runVHDL(t, src, "alu.vhd")
+
+	if vhFindSubtype(ents, "AluCore", "SCOPE.Component", "entity") == nil {
+		t.Fatal("expected SCOPE.Component(entity) AluCore")
+	}
+	arch := vhFindSubtype(ents, "rtl_of_AluCore", "SCOPE.Component", "architecture")
+	if arch == nil {
+		t.Fatal("expected SCOPE.Component(architecture) rtl_of_AluCore")
+	}
+	// PORT_OF edge: architecture → entity.
+	if !vhHasRel(ents, "rtl_of_AluCore", "SCOPE.Component", "PORT_OF", "AluCore") {
+		t.Error("expected PORT_OF edge: rtl_of_AluCore → AluCore")
+	}
+}
+
+// ── Package declaration ───────────────────────────────────────────────────────
+
+func TestVHDL_PackageDeclaration(t *testing.T) {
+	src := `
+package alu_pkg is
+  type alu_op_t is (OP_ADD, OP_SUB, OP_AND, OP_OR);
+
+  function to_slv (val : integer; width : integer) return std_logic_vector;
+end package alu_pkg;
+`
+	ents := runVHDL(t, src, "alu_pkg.vhd")
+	p := vhFindSubtype(ents, "alu_pkg", "SCOPE.Component", "package")
+	if p == nil {
+		t.Fatal("expected SCOPE.Component(package) alu_pkg")
+	}
+}
+
+// ── Package body declaration ──────────────────────────────────────────────────
+
+func TestVHDL_PackageBodyDeclaration(t *testing.T) {
+	src := `
+package body alu_pkg is
+  function to_slv (val : integer; width : integer) return std_logic_vector is
+    variable result : std_logic_vector(width-1 downto 0);
+  begin
+    result := std_logic_vector(to_unsigned(val, width));
+    return result;
+  end function to_slv;
+end package body alu_pkg;
+`
+	ents := runVHDL(t, src, "alu_pkg.vhd")
+	pb := vhFindSubtype(ents, "alu_pkg_body", "SCOPE.Component", "package_body")
+	if pb == nil {
+		t.Fatal("expected SCOPE.Component(package_body) alu_pkg_body")
+	}
+	// PORT_OF edge: body → package.
+	if !vhHasRel(ents, "alu_pkg_body", "SCOPE.Component", "PORT_OF", "alu_pkg") {
+		t.Error("expected PORT_OF edge: alu_pkg_body → alu_pkg")
+	}
+}
+
+// ── Function extraction ───────────────────────────────────────────────────────
+
+func TestVHDL_FunctionInPackageBody(t *testing.T) {
+	src := `
+package body math_pkg is
+  function clamp (val : integer; lo, hi : integer) return integer is
+  begin
+    if val < lo then return lo;
+    elsif val > hi then return hi;
+    else return val;
+    end if;
+  end function clamp;
+
+  function abs_val (val : integer) return integer is
+  begin
+    if val < 0 then return -val; else return val; end if;
+  end function abs_val;
+end package body math_pkg;
+`
+	ents := runVHDL(t, src, "math_pkg.vhd")
+	if vhFind(ents, "math_pkg_body.clamp", "SCOPE.Operation") == nil {
+		t.Error("expected SCOPE.Operation math_pkg_body.clamp")
+	}
+	if vhFind(ents, "math_pkg_body.abs_val", "SCOPE.Operation") == nil {
+		t.Error("expected SCOPE.Operation math_pkg_body.abs_val")
+	}
+}
+
+// ── Procedure extraction ──────────────────────────────────────────────────────
+
+func TestVHDL_ProcedureInArchitecture(t *testing.T) {
+	src := `
+entity CounterTop is
+  port (clk : in std_logic);
+end entity CounterTop;
+
+architecture rtl of CounterTop is
+  procedure reset_count (signal cnt : out integer) is
+  begin
+    cnt <= 0;
+  end procedure reset_count;
+begin
+end architecture rtl;
+`
+	ents := runVHDL(t, src, "counter.vhd")
+	if vhFindSubtype(ents, "rtl_of_CounterTop.reset_count", "SCOPE.Operation", "procedure") == nil {
+		t.Error("expected SCOPE.Operation(procedure) rtl_of_CounterTop.reset_count")
+	}
+}
+
+// ── Library / use imports ─────────────────────────────────────────────────────
+
+func TestVHDL_LibraryImports(t *testing.T) {
+	src := `
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+entity CounterTop is
+end entity CounterTop;
+`
+	ents := runVHDL(t, src, "counter.vhd")
+	if !vhHasRel(ents, "ieee", "SCOPE.Component", "IMPORTS", "ieee") {
+		t.Error("expected IMPORTS edge for ieee")
+	}
+}
+
+// ── Component instantiation (USES edges) ─────────────────────────────────────
+
+func TestVHDL_ComponentInstantiation(t *testing.T) {
+	src := `
+entity TbCounterTop is
+end entity TbCounterTop;
+
+architecture tb of TbCounterTop is
+begin
+  u_dut : CounterTop port map (
+    clk   => clk_s,
+    rst   => rst_s,
+    count => count_s
+  );
+
+  u_clk : ClockGen port map (
+    clk => clk_s
+  );
+end architecture tb;
+`
+	ents := runVHDL(t, src, "tb.vhd")
+	if !vhHasRel(ents, "tb_of_TbCounterTop", "SCOPE.Component", "USES", "CounterTop") {
+		t.Error("expected USES edge: tb_of_TbCounterTop → CounterTop")
+	}
+	if !vhHasRel(ents, "tb_of_TbCounterTop", "SCOPE.Component", "USES", "ClockGen") {
+		t.Error("expected USES edge: tb_of_TbCounterTop → ClockGen")
+	}
+}
+
+// ── CONTAINS edges ────────────────────────────────────────────────────────────
+
+func TestVHDL_ContainsEdges(t *testing.T) {
+	src := `
+package body math_pkg is
+  function add (a, b : integer) return integer is
+  begin return a + b; end function add;
+end package body math_pkg;
+`
+	ents := runVHDL(t, src, "math_pkg.vhd")
+	if !vhHasRelPartial(ents, "math_pkg_body", "SCOPE.Component", "CONTAINS", "math_pkg_body.add") {
+		t.Error("expected CONTAINS edge to math_pkg_body.add")
+	}
+}
+
+// ── Language tagging on relationships ────────────────────────────────────────
+
+func TestVHDL_LanguageTagOnRelationships(t *testing.T) {
+	src := `
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity Foo is end entity Foo;
+`
+	ents := runVHDL(t, src, "foo.vhd")
+	for _, ent := range ents {
+		for _, r := range ent.Relationships {
+			if r.Kind == "IMPORTS" || r.Kind == "USES" || r.Kind == "CONTAINS" || r.Kind == "PORT_OF" {
+				if r.Properties == nil || r.Properties["language"] != "vhdl" {
+					t.Errorf("relationship %s → %q missing language=vhdl tag", r.Kind, r.ToID)
+				}
+			}
+		}
+	}
+}
+
+// ── Synthetic fixture: counter + testbench ────────────────────────────────────
+//
+// counterSrc: 8-bit up-counter with synchronous reset.
+// Expected entities:
+//   - SCOPE.Component(entity):       CounterTop
+//   - SCOPE.Component(architecture): rtl_of_CounterTop
+//   - PORT_OF edge:                  rtl_of_CounterTop → CounterTop
+const counterSrc = `
+library ieee;
+use ieee.std_logic_1164.all;
+use ieee.numeric_std.all;
+
+-- 8-bit up-counter with synchronous reset
+entity CounterTop is
+  port (
+    clk   : in  std_logic;
+    rst   : in  std_logic;
+    en    : in  std_logic;
+    count : out std_logic_vector(7 downto 0)
+  );
+end entity CounterTop;
+
+architecture rtl of CounterTop is
+  signal cnt_reg : unsigned(7 downto 0);
+
+  procedure do_reset (signal cnt : out unsigned) is
+  begin
+    cnt <= (others => '0');
+  end procedure do_reset;
+
+begin
+  process (clk)
+  begin
+    if rising_edge(clk) then
+      if rst = '1' then
+        cnt_reg <= (others => '0');
+      elsif en = '1' then
+        cnt_reg <= cnt_reg + 1;
+      end if;
+    end if;
+  end process;
+
+  count <= std_logic_vector(cnt_reg);
+end architecture rtl;
+`
+
+// tbSrc: testbench for CounterTop.
+// Expected entities:
+//   - SCOPE.Component(entity):       TbCounterTop
+//   - SCOPE.Component(architecture): tb_of_TbCounterTop
+//   - USES edge:                     tb_of_TbCounterTop → CounterTop
+const tbCounterSrc = `
+library ieee;
+use ieee.std_logic_1164.all;
+
+entity TbCounterTop is
+end entity TbCounterTop;
+
+architecture tb of TbCounterTop is
+  signal clk_s   : std_logic := '0';
+  signal rst_s   : std_logic := '1';
+  signal en_s    : std_logic := '0';
+  signal count_s : std_logic_vector(7 downto 0);
+begin
+  -- Instantiate DUT
+  u_dut : CounterTop port map (
+    clk   => clk_s,
+    rst   => rst_s,
+    en    => en_s,
+    count => count_s
+  );
+
+  -- Clock generation: 10 ns period
+  clk_s <= not clk_s after 5 ns;
+
+  -- Stimulus
+  stim_proc : process
+  begin
+    rst_s <= '1';
+    wait for 20 ns;
+    rst_s <= '0';
+    en_s  <= '1';
+    wait for 100 ns;
+    assert false report "Simulation complete" severity note;
+    wait;
+  end process;
+end architecture tb;
+`
+
+func TestVHDL_CounterFixture(t *testing.T) {
+	ents := runVHDL(t, counterSrc, "counter.vhd")
+
+	type check struct {
+		name    string
+		kind    string
+		subtype string
+	}
+	expected := []check{
+		{"CounterTop", "SCOPE.Component", "entity"},
+		{"rtl_of_CounterTop", "SCOPE.Component", "architecture"},
+		{"rtl_of_CounterTop.do_reset", "SCOPE.Operation", "procedure"},
+	}
+
+	hit, miss := 0, 0
+	for _, ex := range expected {
+		if vhFindSubtype(ents, ex.name, ex.kind, ex.subtype) != nil {
+			hit++
+		} else {
+			miss++
+			t.Logf("MISS: %s %s(%s)", ex.kind, ex.name, ex.subtype)
+		}
+	}
+	recall := float64(hit) / float64(len(expected))
+	t.Logf("Counter fixture recall: %d/%d = %.0f%%", hit, len(expected), recall*100)
+	if recall < 0.80 {
+		t.Errorf("entity recall %.0f%% < 80%% threshold", recall*100)
+	}
+
+	// PORT_OF edge: rtl architecture → entity.
+	if !vhHasRel(ents, "rtl_of_CounterTop", "SCOPE.Component", "PORT_OF", "CounterTop") {
+		t.Error("expected PORT_OF edge: rtl_of_CounterTop → CounterTop")
+	}
+
+	// IMPORTS: ieee library.
+	if !vhHasRel(ents, "ieee", "SCOPE.Component", "IMPORTS", "ieee") {
+		t.Error("expected IMPORTS edge for ieee")
+	}
+}
+
+func TestVHDL_TestbenchFixture(t *testing.T) {
+	ents := runVHDL(t, tbCounterSrc, "tb_counter.vhd")
+
+	type check struct {
+		name    string
+		kind    string
+		subtype string
+	}
+	expected := []check{
+		{"TbCounterTop", "SCOPE.Component", "entity"},
+		{"tb_of_TbCounterTop", "SCOPE.Component", "architecture"},
+	}
+
+	hit, miss := 0, 0
+	for _, ex := range expected {
+		if vhFindSubtype(ents, ex.name, ex.kind, ex.subtype) != nil {
+			hit++
+		} else {
+			miss++
+			t.Logf("MISS: %s %s(%s)", ex.kind, ex.name, ex.subtype)
+		}
+	}
+	recall := float64(hit) / float64(len(expected))
+	t.Logf("Testbench fixture recall: %d/%d = %.0f%%", hit, len(expected), recall*100)
+	if recall < 0.80 {
+		t.Errorf("entity recall %.0f%% < 80%% threshold", recall*100)
+	}
+
+	// USES edge: testbench instantiates CounterTop.
+	if !vhHasRel(ents, "tb_of_TbCounterTop", "SCOPE.Component", "USES", "CounterTop") {
+		t.Error("expected USES edge: tb_of_TbCounterTop → CounterTop")
+	}
+
+	// IMPORTS: ieee library.
+	if !vhHasRel(ents, "ieee", "SCOPE.Component", "IMPORTS", "ieee") {
+		t.Error("expected IMPORTS edge for ieee")
+	}
+}
+
+// TestVHDL_NoFalsePositives verifies that VHDL keywords do not appear as USES edges.
+func TestVHDL_NoFalsePositives(t *testing.T) {
+	ents := runVHDL(t, counterSrc, "counter.vhd")
+
+	falsePositiveCandidates := []string{
+		"begin", "end", "if", "else", "elsif", "then",
+		"process", "signal", "when", "case", "for", "loop",
+		"wait", "port", "map", "is", "in", "out",
+	}
+
+	for _, ent := range ents {
+		for _, rel := range ent.Relationships {
+			if rel.Kind != "USES" {
+				continue
+			}
+			toLower := strings.ToLower(rel.ToID)
+			for _, kw := range falsePositiveCandidates {
+				if toLower == kw {
+					t.Errorf("false positive USES edge: %s → %q (should be filtered)", ent.Name, rel.ToID)
+				}
+			}
+		}
+	}
+}

--- a/internal/resolve/dynamic_patterns_vhdl.go
+++ b/internal/resolve/dynamic_patterns_vhdl.go
@@ -1,0 +1,99 @@
+package resolve
+
+import "regexp"
+
+// vhdlDynamicPatterns are per-language patterns for VHDL.
+// Registered for "vhdl" via init().
+//
+// The VHDL extractor emits USES edges whose ToID is a component type name
+// found in component instantiation statements ("inst : CompType port map (...)").
+// The following categories should be resolved as Dynamic (not expected to
+// resolve to an in-tree entity):
+//
+//  1. IEEE standard libraries — std_logic_1164, numeric_std, std_logic_arith,
+//     std_logic_unsigned, std_logic_signed, math_real, math_complex.
+//     These are part of the IEEE library and will never appear as in-tree entities.
+//
+//  2. VITAL (VHDL Initiative Towards ASIC Libraries) primitives — used for
+//     ASIC/FPGA timing simulation.  Names follow the VITAL_Primitives /
+//     VITAL_Timing naming convention.
+//
+//  3. Common synthesisable conversion/arithmetic functions that appear as
+//     component-lookalike calls in older VHDL code — to_integer, to_unsigned,
+//     to_signed, resize, unsigned, signed.  In VHDL these are functions, not
+//     components, but older code using component configurations may expose them.
+//
+//  4. Simulation support: assert / report are VHDL keywords that the regex may
+//     occasionally surface as a component label if the design is unusual.
+//
+//  5. Well-known vendor IP primitive prefixes — UNISIM/Xilinx, ALTERA/Intel,
+//     SkyWater PDK sky130, Mentor/Cadence generic std-cell prefixes.
+var vhdlDynamicPatterns = []*regexp.Regexp{
+	// ── 1. IEEE standard packages ─────────────────────────────────────────
+	regexp.MustCompile(`^std_logic_1164$`),    // IEEE.std_logic_1164
+	regexp.MustCompile(`^std_logic_arith$`),   // IEEE.std_logic_arith (obsolete but common)
+	regexp.MustCompile(`^std_logic_unsigned$`), // IEEE.std_logic_unsigned (obsolete)
+	regexp.MustCompile(`^std_logic_signed$`),  // IEEE.std_logic_signed (obsolete)
+	regexp.MustCompile(`^numeric_std$`),       // IEEE.numeric_std (modern replacement)
+	regexp.MustCompile(`^numeric_bit$`),       // IEEE.numeric_bit
+	regexp.MustCompile(`^math_real$`),         // IEEE.math_real
+	regexp.MustCompile(`^math_complex$`),      // IEEE.math_complex
+	regexp.MustCompile(`^std_textio$`),        // STD.textio
+	regexp.MustCompile(`^textio$`),            // shorthand alias
+
+	// ── 2. VITAL primitives ───────────────────────────────────────────────
+	regexp.MustCompile(`^VITAL_`),   // VITAL_Primitives, VITAL_Timing, etc.
+	regexp.MustCompile(`^vital_`),   // lowercase variant
+	regexp.MustCompile(`^VITALComp`), // VITALComponent (Synopsys naming)
+
+	// ── 3. Synthesisable conversion functions (may surface as identifiers) ─
+	regexp.MustCompile(`^to_integer$`),
+	regexp.MustCompile(`^to_unsigned$`),
+	regexp.MustCompile(`^to_signed$`),
+	regexp.MustCompile(`^to_std_logic_vector$`),
+	regexp.MustCompile(`^to_bit_vector$`),
+	regexp.MustCompile(`^to_bit$`),
+	regexp.MustCompile(`^resize$`),
+	regexp.MustCompile(`^unsigned$`),
+	regexp.MustCompile(`^signed$`),
+	regexp.MustCompile(`^std_logic_vector$`),
+	regexp.MustCompile(`^std_ulogic_vector$`),
+
+	// ── 4. Simulation / assertion identifiers ─────────────────────────────
+	regexp.MustCompile(`^assert$`),
+	regexp.MustCompile(`^report$`),
+	regexp.MustCompile(`^severity$`),
+
+	// ── 5. Vendor IP primitive prefixes ──────────────────────────────────
+	// Xilinx/Vivado UNISIM primitives.
+	regexp.MustCompile(`^BUFG`),    // BUFG, BUFGCE, BUFGMUX
+	regexp.MustCompile(`^IBUF`),    // IBUF, IBUFDS, IBUFGDS
+	regexp.MustCompile(`^OBUF`),    // OBUF, OBUFT, OBUFDS
+	regexp.MustCompile(`^IOBUF`),   // IOBUF, IOBUFDS
+	regexp.MustCompile(`^MMCM`),    // MMCME2_ADV, MMCME4_ADV
+	regexp.MustCompile(`^PLL`),     // PLLE2_ADV, PLLE4_ADV
+	regexp.MustCompile(`^BRAM_`),   // BRAM_SDP_MACRO, BRAM_TDP_MACRO
+	regexp.MustCompile(`^RAMB`),    // RAMB16, RAMB18E2
+	regexp.MustCompile(`^LUT[1-6]$`), // LUT1 … LUT6
+	regexp.MustCompile(`^FDRE$`),   // D flip-flop with reset
+	regexp.MustCompile(`^FDSE$`),   // D flip-flop with set
+	regexp.MustCompile(`^FDCE$`),   // D flip-flop CE
+	regexp.MustCompile(`^FDPE$`),   // D flip-flop PE
+	regexp.MustCompile(`^LDCE$`),   // Latch with CE
+	regexp.MustCompile(`^DSP48`),   // DSP48E1, DSP48E2
+	// SkyWater PDK standard cells.
+	regexp.MustCompile(`^sky130_`),
+	// Intel/Altera Quartus primitives.
+	regexp.MustCompile(`^altera_`),
+	regexp.MustCompile(`^cyclone`),
+	regexp.MustCompile(`^stratix`),
+	regexp.MustCompile(`^GLOBAL$`),
+	// Generic ASIC std-cell prefixes.
+	regexp.MustCompile(`^SC_`),
+	regexp.MustCompile(`^gf_`),  // GlobalFoundries primitives
+	regexp.MustCompile(`^tsmc_`), // TSMC IP cells
+}
+
+func init() {
+	dynamicPatternsByLang["vhdl"] = vhdlDynamicPatterns
+}


### PR DESCRIPTION
## What

Adds a complete VHDL extractor to archigraph, completing hardware-description language coverage alongside the Verilog/SystemVerilog extractor (#1073).

## Implementation

**\`internal/extractors/vhdl/extractor.go\`** — regex-based extractor (no tree-sitter grammar available for VHDL):
- \`entity Name is ... end [entity];\` → \`SCOPE.Component\` (subtype: \`entity\`)
- \`architecture Name of Foo is ... end [architecture];\` → \`SCOPE.Component\` (subtype: \`architecture\`) + \`PORT_OF\` edge to the entity
- \`package Name is ... end [package];\` → \`SCOPE.Component\` (subtype: \`package\`)
- \`package body Name is ... end [package body];\` → \`SCOPE.Component\` (subtype: \`package_body\`) + \`PORT_OF\` edge to the package
- \`function name (...) return T is ... end function;\` → \`SCOPE.Operation\` (subtype: \`function\`) with \`CONTAINS\` edge from parent
- \`procedure name (...) is ... end procedure;\` → \`SCOPE.Operation\` (subtype: \`procedure\`) with \`CONTAINS\` edge from parent
- \`library ieee;\` / \`use ieee.std_logic_1164.all;\` → \`IMPORTS\` edges
- \`inst : CompType port map (...)\` → \`USES\` edges
- Signal declarations skipped (noise, not structural signal)
- VHDL-87/93 \`--\` line comments + VHDL-2008 \`/* */\` block comments stripped before matching

**\`internal/extractors/vhdl/extractor_test.go\`** — 15 tests covering all entity types, relationship edges, language tagging, synthetic counter + testbench fixture, and false-positive guard.

**\`internal/classifier/classifier.go\`** — \`.vhd\` / \`.vhdl\` → \`"vhdl"\`

**\`internal/extractors/registry_gen.go\`** — blank-import for \`vhdl\` package

**\`internal/resolve/dynamic_patterns_vhdl.go\`** — resolver slice:
- IEEE stdlib: \`std_logic_1164\`, \`numeric_std\`, \`std_logic_arith\`, \`math_real\`, \`textio\`, etc.
- VITAL primitives (\`VITAL_*\`)
- Synthesisable conversion functions: \`to_integer\`, \`to_unsigned\`, \`to_signed\`, \`resize\`, \`unsigned\`, \`signed\`
- Simulation keywords: \`assert\`, \`report\`, \`severity\`
- FPGA/ASIC vendor IP prefixes: Xilinx UNISIM (\`BUFG\`, \`IBUF\`, \`MMCM\`, \`BRAM_\`, \`FDRE\`, \`DSP48\`...), SkyWater PDK (\`sky130_\`), Intel/Altera (\`altera_\`, \`cyclone\`, \`stratix\`), GlobalFoundries (\`gf_\`), TSMC (\`tsmc_\`)

## Acceptance results

Counter fixture recall: 3/3 = 100%
Testbench fixture recall: 2/2 = 100%
False positives: 0
All 15 tests pass. Full classifier + extractors + resolve suite green.

## Test plan

- [ ] \`go test ./internal/extractors/vhdl/...\` — all 15 tests pass
- [ ] \`go test ./internal/classifier/...\` — .vhd/.vhdl classification correct
- [ ] \`go test ./internal/resolve/...\` — VHDL dynamic patterns registered
- [ ] \`go test ./internal/extractors/...\` — no regressions in existing extractors

🤖 Generated with [Claude Code](https://claude.com/claude-code)