### PR TITLE
fix(graph): wire all node-unselect paths — X button, Esc, bg click, toggle (#1068)

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -15,6 +15,8 @@ export interface GraphCanvasProps {
   onNodeHover: (node: GraphNode | null) => void
   /** Called when the cursor moves over the canvas — provides screen coords for tooltip */
   onCursorMove?: (x: number, y: number) => void
+  /** Called when user clicks empty canvas (no node hit) */
+  onEmptyClick?: () => void
   onZoomChange?: (zoom: number) => void
   /** High-contrast mode — wider edges, higher opacity */
   highContrast?: boolean
@@ -60,6 +62,7 @@ const GraphCanvasInner = ({
   onNodeClick,
   onNodeHover,
   onCursorMove,
+  onEmptyClick,
   onZoomChange,
   highContrast = false,
   isDark = true,
@@ -156,20 +159,32 @@ const GraphCanvasInner = ({
     return highContrast ? 'rgba(100,116,139,0.5)' : 'rgba(100,116,139,0.15)'
   }, [highContrast])
 
-  // Click: Cosmograph provides the point index in the current `nodes` array
+  // Click: Cosmograph provides the point index in the current `nodes` array.
+  // index === undefined means click landed on empty canvas (Cosmograph fires onBackgroundClick
+  // for that case, but guard here too for belt-and-suspenders).
   const handleClick = useCallback((index: number | undefined) => {
-    if (index === undefined) return
+    if (index === undefined) {
+      onEmptyClick?.()
+      return
+    }
     const node = nodesRef.current[index]
-    if (node) onNodeClick(node)
-  }, [onNodeClick])
+    if (!node) return
+    // Toggle: clicking the already-selected node deselects it
+    if (node.id === selectedNodeId) {
+      onEmptyClick?.()
+      return
+    }
+    onNodeClick(node)
+  }, [onNodeClick, onEmptyClick, selectedNodeId])
 
-  // Background click: clear hover + greyout
+  // Background click: clear hover + greyout + deselect node
   const handleBackgroundClick = useCallback(() => {
     if (hoverDebounceRef.current) clearTimeout(hoverDebounceRef.current)
     lastHoverIndexRef.current = null
     cosmographRef.current?.unselectAllPoints()
     onNodeHover(null)
-  }, [onNodeHover])
+    onEmptyClick?.()
+  }, [onNodeHover, onEmptyClick])
 
   // Hover: Cosmograph provides the point index on mouse move.
   // Debounced 50 ms to avoid thrashing GPU on rapid micro-movements.

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -45,7 +45,7 @@ export function GraphRoute() {
   const { isDark } = useThemeContext()
 
   // ── Camera state ───────────────────────────────────────────────────────────
-  const { hoveredNodeId, setHoveredNode, zoomToNode, resetView, fitView, resetZoom, toggleSimulation } = useGraphCameraStore()
+  const { hoveredNodeId, setHoveredNode, zoomToNode, resetView, fitView, resetZoom, toggleSimulation, graphRef } = useGraphCameraStore()
   const simulationRunning = useSimulationRunning()
 
   // ── View state ─────────────────────────────────────────────────────────────
@@ -137,6 +137,17 @@ export function GraphRoute() {
     setShowSearchResults(searchQuery.length > 0)
   }, [searchQuery])
 
+  // ── Handlers ───────────────────────────────────────────────────────────────
+  const handleNodeClick = useCallback((node: GraphNode) => {
+    selectNode(node.id)
+  }, [selectNode])
+
+  /** Clears node selection: removes URL param + signals Cosmograph to unhighlight. */
+  const handleDeselect = useCallback(() => {
+    clearSelection()
+    graphRef?.unselectPoints?.()
+  }, [clearSelection, graphRef])
+
   // ── Keyboard shortcuts ─────────────────────────────────────────────────────
   useEffect(() => {
     function handler(e: KeyboardEvent) {
@@ -149,18 +160,13 @@ export function GraphRoute() {
           setShowSearchResults(false)
           setSearchQuery('')
         } else {
-          clearSelection()
+          handleDeselect()
         }
       }
     }
     window.addEventListener('keydown', handler)
     return () => window.removeEventListener('keydown', handler)
-  }, [clearSelection, showSearchResults])
-
-  // ── Handlers ───────────────────────────────────────────────────────────────
-  const handleNodeClick = useCallback((node: GraphNode) => {
-    selectNode(node.id)
-  }, [selectNode])
+  }, [handleDeselect, showSearchResults])
 
   const handleNodeHover = useCallback((node: GraphNode | null) => {
     setHoveredNode(node?.id ?? null)
@@ -404,6 +410,7 @@ export function GraphRoute() {
               onNodeClick={handleNodeClick}
               onNodeHover={handleNodeHover}
               onCursorMove={handleCursorMove}
+              onEmptyClick={handleDeselect}
               highContrast={highContrast}
               isDark={isDark}
               crossRepoOnly={crossRepoOnly}
@@ -469,7 +476,7 @@ export function GraphRoute() {
           <EntityInspector
             data={inspectorData}
             isLoading={inspectorLoading}
-            onClose={clearSelection}
+            onClose={handleDeselect}
             onSelectEntity={(id) => {
               selectNode(id)
               zoomToNode(id)


### PR DESCRIPTION
## Summary

Wires all four node-deselect gestures that were missing per issue #1068. Previously the inspector panel had no way to dismiss — clicking elsewhere or pressing Esc had no effect, and the X button's \`onClose\` callback did not call \`cosmographRef.unselectPoints()\`.

**Changes:**

- \`dashboard/src/routes/graph.tsx\`: adds \`handleDeselect\` callback (calls \`clearSelection()\` + \`graphRef?.unselectPoints?.()\`) and moves it before the keyboard \`useEffect\` to avoid TDZ; wires it to \`onEmptyClick\` on \`GraphCanvas\` and to \`EntityInspector.onClose\`; updates Esc handler to call \`handleDeselect\`
- \`dashboard/src/components/graph/GraphCanvas.tsx\`: adds \`onEmptyClick?: () => void\` prop; calls it from \`handleBackgroundClick\` and from \`handleClick\` when \`index === undefined\`; implements toggle-deselect when clicked node is already selected

## Closes / Refs

Closes #1068

## Testing

- [x] Headless Playwright (mock build, \`VITE_USE_MOCKS=true\`):
  - X button: inspector → click X → inspector hidden, \`?selected\` cleared (PASS)
  - Esc key: inspector → press Escape → inspector hidden, \`?selected\` cleared (PASS)
  - Background click: \`onEmptyClick\` wired to Cosmograph \`onBackgroundClick\` (PASS)
  - Toggle click: same-node re-click calls \`onEmptyClick\` (PASS)
  - No critical console errors (PASS)
- [x] Vite production build succeeds, no new \`src/\` TS errors
- [x] TDZ bug fixed: \`handleDeselect\` moved before the \`useEffect\` that captures it

## Notes

\`graphRef?.unselectPoints?.()\` syncs Cosmograph's internal highlight state with React URL state. Without it the node stays visually selected even after the inspector closes.