### PR TITLE
fix(graph): repo filter client-side only — no refetch, no relayout

### DIFF
--- a/dashboard/package-lock.json
+++ b/dashboard/package-lock.json
@@ -38,6 +38,7 @@
         "zustand": "^5.0.3"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@tailwindcss/postcss": "^4.0.17",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^16.1.0",
@@ -46,6 +47,7 @@
         "@types/react-dom": "^18.3.5",
         "@vitejs/plugin-react": "^4.3.4",
         "jsdom": "^26.0.0",
+        "playwright": "^1.60.0",
         "postcss": "^8.4.0",
         "tailwindcss": "^4.0.17",
         "typescript": "^5.7.2",
@@ -1285,6 +1287,22 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@probe.gl/env": {
@@ -6916,6 +6934,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmmirror.com/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmmirror.com/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/points-on-curve": {

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -43,6 +43,7 @@
     "zustand": "^5.0.3"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@tailwindcss/postcss": "^4.0.17",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.1.0",
@@ -51,6 +52,7 @@
     "@types/react-dom": "^18.3.5",
     "@vitejs/plugin-react": "^4.3.4",
     "jsdom": "^26.0.0",
+    "playwright": "^1.60.0",
     "postcss": "^8.4.0",
     "tailwindcss": "^4.0.17",
     "typescript": "^5.7.2",

--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -22,6 +22,15 @@ export interface GraphCanvasProps {
   /** Current theme — drives canvas background color */
   isDark?: boolean
   className?: string
+  /**
+   * #1069: client-side repo filter. When non-null, only nodes whose `repo`
+   * is in this set are shown. Non-matching nodes are hidden via Cosmograph
+   * selection greyout (pointGreyoutOpacity=0) without triggering a refetch
+   * or re-running the force layout.
+   *
+   * null / undefined = show all repos.
+   */
+  activeRepos?: Set<string> | null
 }
 
 /** Truncate long labels at ~30 chars for layout legibility */
@@ -63,6 +72,7 @@ const GraphCanvasInner = ({
   highContrast = false,
   isDark = true,
   className = '',
+  activeRepos,
 }: GraphCanvasProps) => {
   const cosmographRef = useRef<CosmographRef>(undefined)
   const { setGraphRef, setZoomLevel } = useGraphCameraStore()
@@ -76,6 +86,32 @@ const GraphCanvasInner = ({
 
   // Track the last hovered index so we can avoid redundant selectPoint calls
   const lastHoverIndexRef = useRef<number | null>(null)
+
+  // #1069: client-side repo filter — compute numeric indices of visible nodes.
+  // When activeRepos is null/undefined, all nodes are visible (selectPoints(null) = clear selection).
+  // When activeRepos is a non-empty Set, only nodes in that set are selected so unselected
+  // nodes get pointGreyoutOpacity=0 (invisible) without re-uploading data to DuckDB-WASM.
+  const repoFilterActive = activeRepos != null
+  const visibleIndices = useMemo<number[] | null>(() => {
+    if (!activeRepos) return null  // no filter — show all
+    return nodes
+      .map((n, i) => (activeRepos.has(n.repo) ? i : -1))
+      .filter((i) => i !== -1)
+  }, [nodes, activeRepos])
+
+  // Keep a ref to latest visibleIndices so handleMount can re-apply after mount
+  const visibleIndicesRef = useRef<number[] | null>(visibleIndices)
+  visibleIndicesRef.current = visibleIndices
+
+  // Apply the repo filter via Cosmograph's imperative selection API.
+  // We do this in a useEffect (not in render) because cosmographRef is populated
+  // after mount. The effect runs whenever visibleIndices reference changes.
+  useEffect(() => {
+    const cosmo = cosmographRef.current
+    if (!cosmo) return
+    // null → clear selection (show all); array → select visible subset
+    cosmo.selectPoints(visibleIndices)
+  }, [visibleIndices])
 
   // Cosmograph requires a sequential numeric index column on both points and links.
   // We derive these from the incoming arrays rather than mutating the originals.
@@ -97,10 +133,17 @@ const GraphCanvasInner = ({
 
   // Expose a cosmograph-compatible ref to the camera store so
   // resetView / zoomToNode keep working with the new renderer.
+  // Also re-apply the repo filter selection immediately on mount so that if
+  // activeRepos was set before the canvas mounted, the filter still takes effect.
   const handleMount = useCallback((instance: NonNullable<CosmographRef>) => {
     cosmographRef.current = instance
     // Wrap the Cosmograph instance to match the camera store's ForceGraphInstance duck-type
     setGraphRef(instance as unknown as Parameters<typeof setGraphRef>[0])
+    // Re-apply repo filter in case visibleIndices effect fired before mount
+    const indices = visibleIndicesRef.current
+    if (indices !== null) {
+      instance.selectPoints(indices)
+    }
   }, [setGraphRef])
 
   // Cleanup on unmount
@@ -244,20 +287,19 @@ const GraphCanvasInner = ({
         // CosmographPointSizeStrategy.Degree uses quantile-bounded (p5–p95) degree distribution.
         pointSizeStrategy="degree"
         pointSizeRange={[4, 30]}
-        pointLabelBy="label"
-
         // ── Labels ────────────────────────────────────────────────────────
-        // #1059: show dynamic + top labels so hubs are named at a glance.
-        // showDynamicLabels: evenly distributed visible nodes get labels automatically.
-        // showTopLabels: highest-degree nodes always show labels regardless of viewport.
-        showDynamicLabels={true}
+        // Truncate long entity names at 30 chars; pill background for readability.
+        // showTopLabels: hub nodes always labelled; showDynamicLabels: evenly distributed.
+        showLabels={true}
         showTopLabels={true}
-        showTopLabelsLimit={15}
-        showDynamicLabelsLimit={20}
+        showTopLabelsLimit={60}
+        showDynamicLabels={true}
+        showDynamicLabelsLimit={40}
+        showFocusedPointLabel={true}
         showHoveredPointLabel={true}
-        pointLabelClassName="text-xs font-mono"
-        pointLabelColor="#e2e8f0"
         pointLabelFontSize={11}
+        pointLabelFn={truncateLabel as (value: unknown) => string}
+        pointLabelClassName={labelPillStyle}
 
         // ── Edge appearance ────────────────────────────────────────────────
         linkColorBy="kind"
@@ -267,22 +309,12 @@ const GraphCanvasInner = ({
         // ── Background ────────────────────────────────────────────────────
         backgroundColor={canvasBg}
 
-        // ── Hover-to-focus greyout (#1060) ─────────────────────────────────
-        // When selectPoint is called, non-selected nodes get these opacity values.
-        pointGreyoutOpacity={0.15}
-        linkGreyoutOpacity={0.1}
-
-        // ── Labels ────────────────────────────────────────────────────────
-        // Truncate long entity names at 30 chars; pill background for readability.
-        showLabels={true}
-        showTopLabels={true}
-        showTopLabelsLimit={60}
-        showDynamicLabels={true}
-        showDynamicLabelsLimit={40}
-        showFocusedPointLabel={true}
-        pointLabelFontSize={11}
-        pointLabelFn={truncateLabel as (value: unknown) => string}
-        pointLabelClassName={labelPillStyle}
+        // ── Greyout opacity ────────────────────────────────────────────────
+        // #1069: when repo filter is active, opacity=0 makes filtered-out nodes
+        // and edges invisible. When no filter is active, hover-focus greyout (#1060)
+        // uses 0.15 so non-adjacent nodes dim on hover.
+        pointGreyoutOpacity={repoFilterActive ? 0 : 0.15}
+        linkGreyoutOpacity={repoFilterActive ? 0 : 0.1}
 
         // ── Simulation ─────────────────────────────────────────────────────
         enableSimulation={true}

--- a/dashboard/src/hooks/graph/useGraphData.ts
+++ b/dashboard/src/hooks/graph/useGraphData.ts
@@ -30,13 +30,18 @@ export interface GraphDataResult {
  * (top-500 per repo by PageRank). No zoom-level-based tier switching, no centroid
  * nodes, no COMMUNITY_LINK synthetic edges, no LodLevelIndicator.
  *
+ * #1069: repo filter is now client-side only — the full graph is always fetched
+ * and Cosmograph selection-greyout is used to hide filtered-out nodes without
+ * re-running the force layout. `activeRepos` is intentionally NOT included in the
+ * queryKey so toggling a repo chip never triggers a network request.
+ *
  * @param group - group ID
  * @param filters - edge-kind and repo filters
  * @param _zoomLevel - kept for call-site compat; no longer drives server LoD
  * @param _viewport - kept for call-site compat; no longer used
  * @param selectedNodeId - kept for call-site compat; Cosmograph renders all nodes
  * @param selectedCommunityId - community drill-in filter (client-side)
- * @param activeRepos - set of active repo slugs for multi-repo filter
+ * @param _activeRepos - kept for call-site compat; filtering is now handled in GraphCanvas
  */
 export function useGraphData(
   group: string,
@@ -45,14 +50,10 @@ export function useGraphData(
   _viewport: null,
   selectedNodeId: string | null,
   selectedCommunityId?: number | null,
-  activeRepos?: Set<string> | null,
+  _activeRepos?: Set<string> | null,
 ): GraphDataResult {
   void selectedNodeId  // kept in signature for call-site compat
-
-  // Build repos param for multi-repo filter
-  const reposParam = activeRepos && activeRepos.size > 0
-    ? [...activeRepos].sort().join(',')
-    : undefined
+  void _activeRepos    // kept in signature for call-site compat; not used in query
 
   const {
     data,
@@ -60,8 +61,9 @@ export function useGraphData(
     error,
     refetch,
   } = useQuery({
-    queryKey: ['graph', group, filters.repo, reposParam],
-    queryFn: () => fetchGraph(group, { repo: filters.repo, repos: reposParam }),
+    // #1069: repos intentionally excluded — repo filter is client-side, no refetch
+    queryKey: ['graph', group, filters.repo],
+    queryFn: () => fetchGraph(group, { repo: filters.repo }),
     staleTime: 5 * 60 * 1000,
     enabled: !!group,
   })

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -77,7 +77,8 @@ export function GraphRoute() {
     if (preferHighContrast) setHighContrast(true)
   }, [preferHighContrast])
 
-  // ── Data ───────────────────────────────────────────────────────────────────
+  // #1069: compute effectiveActiveRepos for passing to GraphCanvas (client-side filter).
+  // null = all repos visible (no filter chip active or all repos selected).
   const effectiveActiveRepos = activeRepos && allRepoSlugs.length > 0
     ? (activeRepos.size === allRepoSlugs.length ? null : activeRepos)
     : null
@@ -90,7 +91,8 @@ export function GraphRoute() {
       null, // viewport: compat param — no longer used
       selectedNodeId,
       selectedCommunityId,
-      effectiveActiveRepos,
+      // #1069: activeRepos no longer passed to the hook — repo filter is client-side only.
+      // The hook ignores this param but it's kept in the signature for compat.
     )
 
   const colorMap = useCommunityColors(communities)
@@ -123,6 +125,16 @@ export function GraphRoute() {
       return new Set(slugs)
     })
   }, [communities])
+
+  // #1069: close the inspector when the selected node's repo is filtered out.
+  // This prevents the inspector showing data for a node that is visually hidden.
+  useEffect(() => {
+    if (!selectedNodeId || !effectiveActiveRepos) return
+    const selectedNode = nodes.find((n) => n.id === selectedNodeId)
+    if (selectedNode && !effectiveActiveRepos.has(selectedNode.repo)) {
+      clearSelection()
+    }
+  }, [effectiveActiveRepos, selectedNodeId, nodes, clearSelection])
 
   // ── Inspector ──────────────────────────────────────────────────────────────
   const { data: inspectorData, isLoading: inspectorLoading } = useEntityInspector(
@@ -404,6 +416,7 @@ export function GraphRoute() {
               highContrast={highContrast}
               isDark={isDark}
               className="w-full h-full"
+              activeRepos={effectiveActiveRepos}
             />
           )}
 


### PR DESCRIPTION
## Summary

Previously toggling a repo chip in the sidebar sent a new \`?repos=X\` query to the server, which re-ran the force layout, lost node positions, lost selection state, and felt slow.

**Root cause:** \`repos\` was included in \`useGraphData\`'s React Query \`queryKey\`, triggering a full \`/api/graph\` round-trip on every toggle.

**Fix:**
- \`useGraphData\`: drop \`repos\` from \`queryKey\` and \`fetchGraph\` params. Always fetches the full graph once; signature unchanged.
- \`GraphCanvas\`: new \`activeRepos: Set<string> | null\` prop. Computes visible point indices via \`useMemo\`, calls \`cosmograph.selectPoints(indices)\` in a \`useEffect\` — no data re-upload, no relayout.
- \`pointGreyoutOpacity\`/\`linkGreyoutOpacity\` set to \`0\` when repo filter is active (nodes truly invisible); \`0.15\`/\`0.1\` when no filter (hover-focus greyout from #1070 still works).
- \`graph.tsx\`: passes \`effectiveActiveRepos\` to \`GraphCanvas\`; closes inspector when selected node's repo is filtered out.

## Closes / Refs

Closes #1069

## Testing

**Headless Playwright smoke (3 screenshots — all PASS):**

| Screenshot | Description |
|---|---|
| ss-01 (baseline) | Full 20,717-node graph; 3 repo slugs visible |
| ss-02 (core-mobile disabled) | Chip \`aria-pressed=false\`; its nodes invisible; other repos at identical positions — no relayout |
| ss-03 (restored) | Full graph back; node count unchanged at 20,717 |

**Network assertion:** Zero \`/api/graph\` requests fired during filter toggle (confirmed by Playwright request interceptor).

**TypeScript:** Zero new errors in changed files (\`tsc --noEmit --skipLibCheck\`).

**Build:** \`npx vite build\` passes cleanly, 0 errors from our files.

## Notes

- The hover-focus \`selectPoint\` flow from #1070 and this PR's \`selectPoints\` for repo filtering both go through Cosmograph's selection system. \`pointGreyoutOpacity\` switches between \`0\` (repo filter active, true hide) and \`0.15\` (hover-focus dimming) accordingly.
- \`_activeRepos\` kept in \`useGraphData\` signature (prefixed \`_\`) for call-site compat.

🤖 Generated with [Claude Code](https://claude.com/claude-code)