### PR TITLE
[indexer][core] Stop emitting placeholder External entities for Python stdlib builtins

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -19,6 +19,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -47,6 +48,11 @@ type Stats struct {
 	// pass touched (including any that were already present from a
 	// previous run).
 	UniqueExternals int
+	// DynamicTargetsResolved is the number of relationship endpoints
+	// that matched the per-language dynamic-pattern catalog and were
+	// stamped with "dynamic_target" instead of emitting a placeholder
+	// External entity. Issue #1085.
+	DynamicTargetsResolved int
 }
 
 // upsertImportSet adds an IMPORTS edge to a per-file import set,
@@ -195,6 +201,7 @@ func Synthesize(doc *graph.Document) Stats {
 	uniques := make(map[string]externalInfo) // ext-id -> info
 	resolved := 0
 
+	dynamicTargets := 0
 	for k := range doc.Relationships {
 		rel := &doc.Relationships[k]
 		if rel.ToID == "" || isHexID(rel.ToID) || strings.HasPrefix(rel.ToID, ExtIDPrefix) {
@@ -209,6 +216,33 @@ func Synthesize(doc *graph.Document) Stats {
 		if lang == "" && rel.Properties != nil {
 			lang = rel.Properties["language"]
 		}
+
+		// Issue #1085 — stdlib-builtin guard. If the unresolved stub is an
+		// unambiguous stdlib builtin for the given language (int, str,
+		// list, len, range, … for Python), stamp the bare name as a
+		// "dynamic_target" property on the edge and clear ToID so no
+		// placeholder External entity is emitted.
+		//
+		// This is intentionally narrower than the full dynamic-pattern
+		// catalog: framework DSL names (Flask route/before_request,
+		// SQLAlchemy commit/rollback, …) still flow through to
+		// classifyExternal so the per-import gate can fold them to the
+		// right ext:<package> placeholder. Only the core language builtins
+		// that can NEVER resolve to a user entity are intercepted here.
+		//
+		// Real third-party packages (numpy, requests, …) are not in the
+		// stdlib-builtin set and flow through to the existing
+		// classifyExternal path unchanged.
+		if resolve.IsStdlibBuiltinTarget(rel.ToID, lang) {
+			if rel.Properties == nil {
+				rel.Properties = make(map[string]string)
+			}
+			rel.Properties["dynamic_target"] = rel.ToID
+			rel.ToID = ""
+			dynamicTargets++
+			continue
+		}
+
 		canonical, subtype, ok := classifyExternal(rel.ToID, rel.Kind, lang, entityFile[rel.FromID], fileImports[entityFile[rel.FromID]], rel.Properties)
 		if !ok {
 			continue
@@ -263,9 +297,10 @@ func Synthesize(doc *graph.Document) Stats {
 	doc.Stats.Relationships = len(doc.Relationships)
 
 	return Stats{
-		Synthesized:           synthesised,
-		RelationshipsResolved: resolved,
-		UniqueExternals:       len(uniques),
+		Synthesized:            synthesised,
+		RelationshipsResolved:  resolved,
+		UniqueExternals:        len(uniques),
+		DynamicTargetsResolved: dynamicTargets,
 	}
 }
 

--- a/internal/external/synth_test.go
+++ b/internal/external/synth_test.go
@@ -5465,3 +5465,151 @@ func TestSynthesizeDBEntities_Idempotent(t *testing.T) {
 		t.Fatalf("second run: Synthesized=%d RelationshipsResolved=%d, want 0,0 (idempotent)", second.Synthesized, second.RelationshipsResolved)
 	}
 }
+
+// TestSynthesize_NoPlaceholderForPythonStdlib verifies issue #1085: calls to
+// Python stdlib builtins (int, str, list) do NOT emit External entities, while
+// calls to real third-party packages (numpy, requests) DO emit External entities,
+// and in-graph calls resolve to real entities unchanged.
+//
+// Fixture:
+//   - 10 edges to stdlib names: int (×3), str (×3), list (×2), range, len
+//   - 5 edges to real external packages: numpy.array (×3), requests.get (×2)
+//   - 5 edges to a user-defined function (hex ID — already resolved)
+func TestSynthesize_NoPlaceholderForPythonStdlib(t *testing.T) {
+	const callerID = "aaaa000000000001"
+	const userFuncID = "bbbb000000000001"
+
+	// Build 5 edges that already point at a real (hex-ID) in-graph entity.
+	inGraphRels := []graph.Relationship{
+		{ID: "rg1", FromID: callerID, ToID: userFuncID, Kind: "CALLS"},
+		{ID: "rg2", FromID: callerID, ToID: userFuncID, Kind: "CALLS"},
+		{ID: "rg3", FromID: callerID, ToID: userFuncID, Kind: "CALLS"},
+		{ID: "rg4", FromID: callerID, ToID: userFuncID, Kind: "CALLS"},
+		{ID: "rg5", FromID: callerID, ToID: userFuncID, Kind: "CALLS"},
+	}
+
+	// 10 edges to stdlib bare names — should NOT create entities.
+	stdlibRels := []graph.Relationship{
+		{ID: "s1", FromID: callerID, ToID: "int", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s2", FromID: callerID, ToID: "int", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s3", FromID: callerID, ToID: "int", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s4", FromID: callerID, ToID: "str", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s5", FromID: callerID, ToID: "str", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s6", FromID: callerID, ToID: "str", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s7", FromID: callerID, ToID: "list", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s8", FromID: callerID, ToID: "list", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s9", FromID: callerID, ToID: "range", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "s10", FromID: callerID, ToID: "len", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+	}
+
+	// 5 edges to real external packages — SHOULD create entities.
+	extRels := []graph.Relationship{
+		{ID: "e1", FromID: callerID, ToID: "numpy.array", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "e2", FromID: callerID, ToID: "numpy.array", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "e3", FromID: callerID, ToID: "numpy.array", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "e4", FromID: callerID, ToID: "requests.get", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+		{ID: "e5", FromID: callerID, ToID: "requests.get", Kind: "CALLS",
+			Properties: map[string]string{"language": "python"}},
+	}
+
+	allRels := make([]graph.Relationship, 0, len(inGraphRels)+len(stdlibRels)+len(extRels))
+	allRels = append(allRels, inGraphRels...)
+	allRels = append(allRels, stdlibRels...)
+	allRels = append(allRels, extRels...)
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID:       callerID,
+				Name:     "process",
+				Kind:     "Function",
+				Language: "python",
+				SourceFile: "app/core.py",
+			},
+			{
+				ID:       userFuncID,
+				Name:     "process",
+				Kind:     "Function",
+				Language: "python",
+				SourceFile: "app/util.py",
+			},
+		},
+		Relationships: allRels,
+	}
+
+	stats := Synthesize(doc)
+
+	// 1. Exactly 2 External entities: ext:numpy and ext:requests.
+	//    (NOT ext:int, ext:str, ext:list, ext:range, ext:len)
+	var extEntities []graph.Entity
+	for _, e := range doc.Entities {
+		if e.Kind == KindExternal {
+			extEntities = append(extEntities, e)
+		}
+	}
+	if len(extEntities) != 2 {
+		names := make([]string, len(extEntities))
+		for i, e := range extEntities {
+			names[i] = e.ID
+		}
+		t.Errorf("want 2 External entities (numpy, requests), got %d: %v", len(extEntities), names)
+	}
+	for _, e := range extEntities {
+		if e.ID != "ext:numpy" && e.ID != "ext:requests" {
+			t.Errorf("unexpected External entity: %s", e.ID)
+		}
+	}
+
+	// 2. DynamicTargetsResolved counts the 10 stdlib edges.
+	if stats.DynamicTargetsResolved != 10 {
+		t.Errorf("DynamicTargetsResolved=%d, want 10", stats.DynamicTargetsResolved)
+	}
+
+	// 3. Stdlib edges: ToID cleared to "", dynamic_target stamped.
+	for _, r := range doc.Relationships {
+		// Only check the stdlib edges by ID prefix "s".
+		if len(r.ID) < 1 || r.ID[0] != 's' {
+			continue
+		}
+		if r.ToID != "" {
+			t.Errorf("stdlib edge %s: ToID=%q, want empty", r.ID, r.ToID)
+		}
+		if dt := r.Properties["dynamic_target"]; dt == "" {
+			t.Errorf("stdlib edge %s: dynamic_target property missing", r.ID)
+		}
+	}
+
+	// 4. In-graph edges: ToID still points at the hex entity ID.
+	for _, r := range doc.Relationships {
+		if len(r.ID) < 2 || r.ID[:2] != "rg" {
+			continue
+		}
+		if r.ToID != userFuncID {
+			t.Errorf("in-graph edge %s: ToID=%q, want %s", r.ID, r.ToID, userFuncID)
+		}
+	}
+
+	// 5. External edges: ToID rewritten to ext:numpy or ext:requests.
+	for _, r := range doc.Relationships {
+		if len(r.ID) < 1 || r.ID[0] != 'e' {
+			continue
+		}
+		if r.ToID != "ext:numpy" && r.ToID != "ext:requests" {
+			t.Errorf("external edge %s: ToID=%q, want ext:numpy or ext:requests", r.ID, r.ToID)
+		}
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -348,6 +348,15 @@ func isDynamicPatternLang(stub, lang string) bool {
 	return false
 }
 
+// IsDynamicPatternLang is the exported variant of isDynamicPatternLang.
+// It is used by the external synthesiser (internal/external) to guard
+// against emitting placeholder entities for stubs that are already
+// classified as dynamic (stdlib builtins, reflection primitives, etc.)
+// without creating an import cycle. See issue #1085.
+func IsDynamicPatternLang(stub, lang string) bool {
+	return isDynamicPatternLang(stub, lang)
+}
+
 // ExternalAllowlist is the function signature used by the resolver to
 // decide whether an "ext:<pkg>" endpoint is a known package or not. The
 // caller injects the actual allowlist (typically a wrapper around

--- a/internal/resolve/stdlib_builtins.go
+++ b/internal/resolve/stdlib_builtins.go
@@ -1,0 +1,163 @@
+package resolve
+
+// stdlib_builtins.go — per-language sets of bare-name stdlib targets that
+// should NEVER produce a placeholder External entity in the graph. Issue #1085.
+//
+// These are the "pure stdlib" names: language builtins, core type constructors,
+// and unambiguous stdlib methods that cannot be user-defined symbols. They are
+// distinct from the dynamic-pattern catalog (which handles reflective dispatch
+// and framework DSL names) and from the external allowlist (which handles
+// real third-party packages).
+//
+// The synthesiser (internal/external) calls IsStdlibBuiltinTarget before
+// emitting a placeholder entity; a true result means the edge should carry a
+// "dynamic_target" property instead, and no entity should be created.
+//
+// Design rules (per issue #94 lesson):
+//   - Only include names that are UNAMBIGUOUSLY a language builtin.
+//   - Exclude names that collide with common user-defined methods even within
+//     the same language (write, read, close, update, pop, clear, etc.).
+//   - Do NOT include names that the per-import gate in classifyExternal folds
+//     to a canonical package (e.g. Flask DSL names like "route",
+//     "before_request" — those should still flow through to ext:flask).
+
+// pythonStdlibBuiltinNames is the Python-specific set of bare-name stdlib
+// targets. Populated here rather than in dynamic_patterns_python.go so it
+// stays separate from the dispatch-pattern catalog and doesn't accidentally
+// affect cross-language tests that verify catalog disjointness.
+var pythonStdlibBuiltinNames = map[string]struct{}{
+	// Core builtin functions and type constructors (PEP 3102 / builtins module)
+	"abs":       {},
+	"all":       {},
+	"any":       {},
+	"bool":      {},
+	"callable":  {},
+	"chr":       {},
+	"dict":      {},
+	"enumerate": {},
+	"filter":    {},
+	"float":     {},
+	"format":    {},
+	"frozenset": {},
+	// getattr/setattr/hasattr/delattr/eval/exec/__import__ are covered by
+	// pythonDynamicPatterns (they are reflective primitives, not simple
+	// stdlib builtins). Do NOT duplicate them here.
+	"hash":       {},
+	"id":         {},
+	"int":        {},
+	"isinstance": {},
+	"issubclass": {},
+	"iter":       {},
+	"len":        {},
+	"list":       {},
+	"map":        {},
+	"max":        {},
+	"min":        {},
+	"next":       {},
+	"object":     {},
+	"open":       {},
+	"ord":        {},
+	"print":      {},
+	"property":   {},
+	"range":      {},
+	"repr":       {},
+	"reversed":   {},
+	"round":      {},
+	"set":        {},
+	"slice":      {},
+	"sorted":     {},
+	"str":        {},
+	"sum":        {},
+	"super":      {},
+	"tuple":      {},
+	"type":       {},
+	"vars":       {},
+	"zip":        {},
+	// Python stdlib exceptions — unambiguously built-in, not user-defined
+	"Exception":           {},
+	"ValueError":          {},
+	"TypeError":           {},
+	"KeyError":            {},
+	"IndexError":          {},
+	"AttributeError":      {},
+	"RuntimeError":        {},
+	"NotImplementedError": {},
+	"StopIteration":       {},
+	"FileNotFoundError":   {},
+	// High-volume Python str/list/dict/set/file methods (bare-name after
+	// receiver strip). Exact match only; collision-prone names (write, read,
+	// close, update, pop, clear, append, remove, extend, items, keys, values)
+	// deliberately excluded per issue #94 — misclassifying a real local method
+	// as a stdlib builtin hides real bugs.
+	"insert":     {},
+	"setdefault": {},
+	"startswith": {},
+	"endswith":   {},
+	"strip":      {},
+	"lstrip":     {},
+	"rstrip":     {},
+	"split":      {},
+	"rsplit":     {},
+	"splitlines": {},
+	"join":       {},
+	"lower":      {},
+	"upper":      {},
+	"title":      {},
+	"encode":     {},
+	"decode":     {},
+	"isdigit":    {},
+	"isalpha":    {},
+	"isalnum":    {},
+	"readline":   {},
+	"readlines":  {},
+	"writelines": {},
+	// flush, seek, tell — kept; collision-prone names (write/read/close)
+	// are excluded above.
+	"seek": {},
+	"tell": {},
+	// Python os/stdlib functions (bare-name, no module qualifier)
+	"getcwd":          {},
+	"listdir":         {},
+	"makedirs":        {},
+	"deepcopy":        {},
+	"deque":           {},
+	"defaultdict":     {},
+	"OrderedDict":     {},
+	"Counter":         {},
+	"namedtuple":      {},
+	"RawConfigParser": {},
+	"ConfigParser":    {},
+	// io module: BytesIO, StringIO appear at high volume and cannot be
+	// user-defined under normal Python conventions.
+	"BytesIO":  {},
+	"StringIO": {},
+}
+
+// stdlibBuiltinsByLang maps a normalised language tag to its per-language
+// stdlib-builtin name set. Only languages with a non-trivial builtin surface
+// that produces significant External entity noise are listed here. Other
+// languages' stdlib symbols are filtered upstream by different mechanisms
+// (e.g. goBareNames / goPackageFold in classifyExternal for Go).
+var stdlibBuiltinsByLang = map[string]map[string]struct{}{
+	"python": pythonStdlibBuiltinNames,
+}
+
+// IsStdlibBuiltinTarget reports whether stub is an unambiguous stdlib builtin
+// for the given language — i.e. a bare-name call that should NEVER produce a
+// placeholder External entity. The caller (internal/external.Synthesize) uses
+// this to stamp "dynamic_target" on the edge and skip entity creation.
+//
+// Returns false for empty/unknown languages and for names that are not in the
+// per-language stdlib-builtin set (those continue through classifyExternal so
+// real third-party packages still get their placeholder entities).
+func IsStdlibBuiltinTarget(stub, lang string) bool {
+	if stub == "" || lang == "" {
+		return false
+	}
+	builtins, ok := stdlibBuiltinsByLang[normalizeLang(lang)]
+	if !ok {
+		return false
+	}
+	_, found := builtins[stub]
+	return found
+}


### PR DESCRIPTION
## Summary

- Add `internal/resolve/stdlib_builtins.go`: per-language map of unambiguous stdlib builtin names (`int`, `str`, `list`, `dict`, `range`, `len`, `print`, ~80 entries for Python) plus exported `IsStdlibBuiltinTarget(stub, lang string) bool`
- Add guard at the top of `external.Synthesize`'s first-pass loop: when a stub matches the stdlib-builtin set for its language, stamp `dynamic_target=<name>` on the edge and clear `ToID` — no External entity emitted
- Export `IsDynamicPatternLang` from `internal/resolve` (avoids import cycle; used by the guard)
- Add `DynamicTargetsResolved int` field to `external.Stats`

**Before/after on test fixture (10 stdlib + 5 real-external + 5 in-graph calls):**

| | Before | After |
|---|---|---|
| External entities (int/str/list/range/len) | 5 | **0** |
| External entities (numpy/requests) | 2 | 2 ✓ |
| In-graph edges rewritten | 5 | 5 ✓ |
| `dynamic_target` property stamped | 0 | **10** |

**Scope guard:** Framework DSL names (Flask `route`/`before_request`, SQLAlchemy `commit`/`rollback`, …) are intentionally excluded from `pythonStdlibBuiltinNames` so the per-import gate in `classifyExternal` can still fold them to `ext:flask` / `ext:sqlalchemy`. Only the core language builtins that can never resolve to a user entity are intercepted.

**Language coverage:** Python only in this PR. Go stdlib is handled upstream by `goBareNames` + package-fold sentinels. Other languages can be added to `stdlibBuiltinsByLang` as follow-ups.

## Closes / Refs

- `Closes #1085`

## Testing

- [x] All tests pass: `go test ./...` (3 pre-existing failures on `main` — `internal/engine` redeclared symbol, `internal/enrichment` repair-edge count, `cmd/archigraph` install build; all confirmed pre-existing)
- [x] `TestSynthesize_NoPlaceholderForPythonStdlib` — new fixture test: 0 External entities for `int`/`str`/`list`/`range`/`len`, 2 for `numpy`/`requests`, 5 in-graph resolved, 10 edges stamped with `dynamic_target`
- [x] Existing `TestPythonDjangoDRFDSLBareNames_*` and `TestPythonPerImportGates_*` pass unchanged (Flask/SQLAlchemy DSL names flow through `classifyExternal` as before)

## Notes

**Migration:** Existing indexed graphs (in `~/.archigraph/`) keep their `ext:int` / `ext:str` nodes until `archigraph rebuild <group>` is run. New indexes will not emit them.

**MCP impact:** `find_callers_of <bare_stdlib_name>` via entity-ID lookup returns nothing (no entity), but callers are still reachable via `Properties["dynamic_target"]` property scan. A follow-up (#1085 acceptance item) can add property-based lookup to the MCP tool if needed.