### PR TITLE
[#1092] Expose docgen status per endpoint

### DIFF
--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -11,9 +11,13 @@ package dashboard
 
 import (
 	"net/http"
+	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/cajasmota/archigraph/internal/mcp"
 )
 
 const (
@@ -225,12 +229,18 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 		Repo            string   `json:"repo"`
 		SourceFile      string   `json:"source_file"`
 		StartLine       int      `json:"start_line"`
+		HasDocs         bool     `json:"has_docs,omitempty"`
+		DocsSummary     string   `json:"docs_summary,omitempty"`
+		DocsPath        string   `json:"docs_path,omitempty"`
 	}
 
 	var matched []endpointDetail
 	var pathStr string
 	isWebhook := false
 	var webhookProvider string
+
+	// Load docgen state for documentation enrichment.
+	docgenState, _ := mcp.LoadDocgenState(group)
 
 	for _, repo := range sortedRepos(grp) {
 		for i := range repo.Doc.Entities {
@@ -293,6 +303,9 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 				webhookProvider = e.Properties["webhook_provider"]
 			}
 
+			// Enrich with docgen data.
+			hasDocs, docsSummary, docsPath := extractEndpointDocs(group, pathHash, docgenState)
+
 			matched = append(matched, endpointDetail{
 				ID:              dashPrefixedID(repo.Slug, e.ID),
 				Verb:            verb,
@@ -307,6 +320,9 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 				Repo:            repo.Slug,
 				SourceFile:      e.SourceFile,
 				StartLine:       e.StartLine,
+				HasDocs:         hasDocs,
+				DocsSummary:     docsSummary,
+				DocsPath:        docsPath,
 			})
 		}
 	}
@@ -329,24 +345,30 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 
 	// Transform handlers to HandlerDetail shape with resolved entities.
 	type HandlerDetail struct {
-		Entity     map[string]any `json:"entity"`
-		Verb       string         `json:"verb"`
-		Framework  string         `json:"framework,omitempty"`
-		SourceFile string         `json:"source_file"`
-		StartLine  int            `json:"start_line"`
-		Language   string         `json:"language"`
+		Entity      map[string]any `json:"entity"`
+		Verb        string         `json:"verb"`
+		Framework   string         `json:"framework,omitempty"`
+		SourceFile  string         `json:"source_file"`
+		StartLine   int            `json:"start_line"`
+		Language    string         `json:"language"`
+		HasDocs     bool           `json:"has_docs,omitempty"`
+		DocsSummary string         `json:"docs_summary,omitempty"`
+		DocsPath    string         `json:"docs_path,omitempty"`
 	}
 
 	handlers := make([]HandlerDetail, len(matched))
 	for i, m := range matched {
 		_, entity := findEntity(grp, m.ID)
 		handlers[i] = HandlerDetail{
-			Entity:     serializeEntity(m.Repo, entity),
-			Verb:       m.Verb,
-			Framework:  m.Framework,
-			SourceFile: m.SourceFile,
-			StartLine:  m.StartLine,
-			Language:   entity.Language,
+			Entity:      serializeEntity(m.Repo, entity),
+			Verb:        m.Verb,
+			Framework:   m.Framework,
+			SourceFile:  m.SourceFile,
+			StartLine:   m.StartLine,
+			Language:    entity.Language,
+			HasDocs:     m.HasDocs,
+			DocsSummary: m.DocsSummary,
+			DocsPath:    m.DocsPath,
 		}
 	}
 
@@ -515,4 +537,67 @@ func containsSubstr(sl []string, sub string) bool {
 		}
 	}
 	return false
+}
+
+// extractEndpointDocs reads documentation for an endpoint identified by pathHash.
+// It checks docgen-state.json for the group and attempts to find and parse the
+// generated documentation file for this endpoint.
+//
+// Returns: (hasDocs bool, docsSummary string, docsPath string)
+// - hasDocs is true if documentation exists
+// - docsSummary is the first line/paragraph of the doc file (if exists)
+// - docsPath is the relative path to the doc file (if exists)
+func extractEndpointDocs(group string, pathHash string, docgenState *mcp.DocgenState) (bool, string, string) {
+	if docgenState == nil || docgenState.GeneratedPaths == nil {
+		return false, "", ""
+	}
+
+	// Try to find a doc file matching this endpoint.
+	// Expected pattern: something like "reference/endpoints/{pathHash}.md" or similar.
+	// For now, we'll search GeneratedPaths for a file that contains the pathHash.
+	for _, docPath := range docgenState.GeneratedPaths {
+		// Check if the path contains the pathHash or looks like an endpoint doc.
+		if !strings.Contains(docPath, pathHash) && !strings.Contains(docPath, "endpoint") {
+			continue
+		}
+
+		// Try to read the file from the standard docgen location.
+		fullPath := getDocFilePath(group, docPath)
+		data, err := os.ReadFile(fullPath)
+		if err != nil {
+			continue
+		}
+
+		// Extract summary from the file (first non-empty line).
+		lines := strings.Split(string(data), "\n")
+		var summary string
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if trimmed != "" && !strings.HasPrefix(trimmed, "#") {
+				// Get first 150 chars of content as summary.
+				if len(trimmed) > 150 {
+					summary = trimmed[:150] + "..."
+				} else {
+					summary = trimmed
+				}
+				break
+			}
+		}
+
+		return true, summary, docPath
+	}
+
+	return false, "", ""
+}
+
+// getDocFilePath constructs the full file path to a generated documentation file.
+// Docs are stored in ~/.archigraph/groups/<group>/docs/<docPath>
+func getDocFilePath(group string, docPath string) string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	// Remove leading "./" if present
+	docPath = strings.TrimPrefix(docPath, "./")
+	return filepath.Join(home, ".archigraph", "groups", group, "docs", docPath)
 }

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -12,11 +12,14 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
 )
 
 // ---------------------------------------------------------------------------
@@ -441,6 +444,103 @@ func TestPathDetail_NotFound_404(t *testing.T) {
 	code, _ := getJSON(t, ts.URL, "/api/paths/testgroup/badhash00")
 	if code != 404 {
 		t.Fatalf("expected 404, got %d", code)
+	}
+}
+
+func TestPathDetail_DocgenFields(t *testing.T) {
+	ts, _ := newPhase1Server(t)
+	// Compute the hash for /api/users.
+	h := hashStr("/api/users")
+	code, body := getJSON(t, ts.URL, "/api/paths/testgroup/"+h)
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	// Verify response structure is valid.
+	if body["handlers"] == nil {
+		t.Fatalf("handlers field missing")
+	}
+
+	// Check that response is valid JSON and handlers is an array.
+	handlers, ok := body["handlers"].([]interface{})
+	if !ok {
+		t.Fatalf("handlers is not an array: %T", body["handlers"])
+	}
+	if len(handlers) == 0 {
+		t.Fatal("handlers array is empty")
+	}
+
+	// When docgen hasn't run, has_docs should be absent or false.
+	// Since we use omitempty, it will be absent when false.
+	handler := handlers[0].(map[string]any)
+	if hasDocs, ok := handler["has_docs"].(bool); ok && hasDocs {
+		t.Fatalf("has_docs should not be true when docgen hasn't run")
+	}
+
+	// Verify the handler has the basic fields we expect.
+	if handler["entity"] == nil {
+		t.Fatalf("entity field missing from handler")
+	}
+	if handler["verb"] == nil {
+		t.Fatalf("verb field missing from handler")
+	}
+}
+
+func TestPathDetail_DocgenFields_WithDocumentation(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("HOME", tmp)
+
+	ts, _ := newPhase1Server(t)
+
+	// Create docgen state with a generated doc file for the /api/users endpoint.
+	pathHash := hashStr("/api/users")
+	docPath := "reference/endpoints/" + pathHash + ".md"
+	docsDir := filepath.Join(tmp, ".archigraph", "groups", "testgroup", "docs", "reference", "endpoints")
+	if err := os.MkdirAll(docsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write a sample doc file.
+	docContent := "# GET /api/users\n\nFetch all users from the system with pagination support.\n\n## Parameters\n- page: Page number\n- limit: Results per page\n"
+	if err := os.WriteFile(filepath.Join(docsDir, pathHash+".md"), []byte(docContent), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Save docgen state.
+	now := time.Now().UTC()
+	docgenState := mcp.DocgenState{
+		LastDocgenAt:   &now,
+		GeneratedPaths: []string{docPath},
+	}
+	if err := mcp.SaveDocgenState("testgroup", docgenState); err != nil {
+		t.Fatal(err)
+	}
+
+	// Query the endpoint.
+	code, body := getJSON(t, ts.URL, "/api/paths/testgroup/"+pathHash)
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	// Verify has_docs is true.
+	handlers, ok := body["handlers"].([]interface{})
+	if !ok || len(handlers) == 0 {
+		t.Fatal("handlers empty or not found")
+	}
+
+	handler := handlers[0].(map[string]any)
+	if hasDocs, ok := handler["has_docs"].(bool); !ok || !hasDocs {
+		t.Fatalf("has_docs should be true when docs exist, got: %v", handler["has_docs"])
+	}
+
+	// Verify docs_summary is populated.
+	if summary, ok := handler["docs_summary"].(string); !ok || summary == "" {
+		t.Fatalf("docs_summary should be populated, got: %v", handler["docs_summary"])
+	}
+
+	// Verify docs_path is populated.
+	if path, ok := handler["docs_path"].(string); !ok || path == "" {
+		t.Fatalf("docs_path should be populated, got: %v", handler["docs_path"])
 	}
 }
 


### PR DESCRIPTION
## Summary
Adds three new fields to the HTTP path detail endpoint response to surface documentation generation status:
- `has_docs`: bool — whether AI-generated documentation exists for this endpoint
- `docs_summary`: string — first paragraph of generated docs (extracted when available)
- `docs_path`: string — relative path to the doc file in ~/.archigraph/groups/<group>/docs

## What we did
- Extended `endpointDetail` struct with doc tracking fields
- Updated `HandlerDetail` response shape to include docgen metadata
- Implemented `extractEndpointDocs()` helper to read docgen-state.json and parse matching doc files
- Added `getDocFilePath()` utility for constructing paths to generated documentation
- Expanded `/api/paths/{group}/{pathHash}` response to include docs for each handler variant

## What we won
- Frontend can now detect when an endpoint lacks documentation and prompt users to run `/generate-docs`
- Agents integrating with the API can inspect `has_docs` to prioritize documentation generation
- Documentation metadata enriches the contract explorer UI without requiring schema changes

## Acceptance
- ✅ Detail response includes new fields (omitted when false/empty per `omitempty` tags)
- ✅ Empty state tested (docgen hasn't run → `has_docs` absent)
- ✅ Populated state tested (docs found → all three fields present with real content)
- ✅ All existing tests pass
- ✅ Two new comprehensive integration tests added

## Testing
- `TestPathDetail_DocgenFields`: Verifies empty state behavior
- `TestPathDetail_DocgenFields_WithDocumentation`: Demonstrates populated state with actual docgen files

Closes #1092

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>