### PR TITLE
[#1091] Paths v2: orphan-caller detector — GET /api/paths/{group}/orphan-callers

### DIFF
--- a/internal/dashboard/handlers_orphan_callers.go
+++ b/internal/dashboard/handlers_orphan_callers.go
@@ -1,0 +1,288 @@
+package dashboard
+
+// handlers_orphan_callers.go — Paths v2: orphan-caller detector (#1091).
+//
+//	GET /api/paths/{group}/orphan-callers
+//
+// Returns frontend FETCHES call sites where the URL does not resolve to any
+// backend http_endpoint entity in the indexed group. Each row is a repair
+// candidate that can be fed into the existing apply/reject flow (#1010).
+//
+// Detection logic:
+//  1. Walk every FETCHES relationship across all repos in the group.
+//  2. Check whether the edge's ToID resolves to an http_endpoint entity in
+//     any repo's graph. If not — or if the target entity itself is a
+//     consumer-side synthetic without a matched producer — the caller is
+//     orphaned.
+//  3. Classify the reason:
+//     - "dynamic_baseurl"  — target entity has runtime_dynamic=true or
+//       the relationship carries a dynamic env-var baseURL signal.
+//     - "template_literal" — the url_pattern contains a template-literal
+//       placeholder (${…} or {…}) that prevented static resolution.
+//     - "no_handler_found" — none of the above; the path simply has no
+//       matching producer endpoint anywhere in the group.
+//  4. Group by repo + file + line; deduplicate by (caller_id, url_pattern).
+
+import (
+	"net/http"
+	"sort"
+	"strings"
+)
+
+// OrphanCallerRow is one unresolved call site returned by the endpoint.
+type OrphanCallerRow struct {
+	CallerID           string `json:"caller_id"`
+	CallerFile         string `json:"caller_file"`
+	CallerLine         int    `json:"caller_line"`
+	URLPattern         string `json:"url_pattern"`
+	Method             string `json:"method"`
+	Reason             string `json:"reason"`
+	SuggestedRepairKind string `json:"suggested_repair_kind"`
+	Repo               string `json:"repo"`
+}
+
+// orphanCallerReason classifies why a FETCHES edge could not be resolved.
+type orphanCallerReason string
+
+const (
+	reasonDynamicBaseURL  orphanCallerReason = "dynamic_baseurl"
+	reasonTemplateLiteral orphanCallerReason = "template_literal"
+	reasonNoHandlerFound  orphanCallerReason = "no_handler_found"
+)
+
+// suggestedRepair maps reason → repair kind hint returned to callers.
+var suggestedRepair = map[orphanCallerReason]string{
+	reasonDynamicBaseURL:  "annotate_baseurl",
+	reasonTemplateLiteral: "resolve_template_url",
+	reasonNoHandlerFound:  "add_missing_handler",
+}
+
+// handleOrphanCallers — GET /api/paths/{group}/orphan-callers
+//
+// Returns the list of FETCHES edges that have no matching http_endpoint
+// producer in the group. The response is a JSON object:
+//
+//	{ "orphan_callers": [...], "total": N }
+func (s *Server) handleOrphanCallers(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	rows := collectOrphanCallers(grp)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"orphan_callers": rows,
+		"total":          len(rows),
+	})
+}
+
+// collectOrphanCallers runs the orphan-detection pass against a loaded group.
+// It is extracted so unit tests can call it without HTTP scaffolding.
+func collectOrphanCallers(grp *DashGroup) []OrphanCallerRow {
+	// Build a set of all http_endpoint entity IDs across the group —
+	// keyed by the bare local ID. We also index by prefixed ID for
+	// cross-repo lookups.
+	type endpointEntry struct {
+		repo       string
+		isProducer bool // pattern_type != "http_endpoint_client_synthesis"
+	}
+	endpointByID := make(map[string]endpointEntry, 256) // bare ID → entry
+	// Also build a map of bare entity ID → properties for fast reason lookup.
+	entityProps := make(map[string]map[string]string, 256)
+
+	for _, repo := range sortedRepos(grp) {
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+			bare := e.ID
+			prefixed := dashPrefixedID(repo.Slug, bare)
+
+			isHTTPEndpoint := strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind)
+			if !isHTTPEndpoint {
+				continue
+			}
+			isProducer := e.Properties["pattern_type"] != "http_endpoint_client_synthesis"
+
+			endpointByID[bare] = endpointEntry{repo: repo.Slug, isProducer: isProducer}
+			endpointByID[prefixed] = endpointEntry{repo: repo.Slug, isProducer: isProducer}
+
+			if e.Properties != nil {
+				entityProps[bare] = e.Properties
+				entityProps[prefixed] = e.Properties
+			}
+		}
+	}
+
+	// dedupKey prevents emitting duplicate rows for (callerID, urlPattern).
+	type dedupKey struct {
+		callerID   string
+		urlPattern string
+	}
+	seen := make(map[dedupKey]bool, 64)
+
+	var rows []OrphanCallerRow
+
+	for _, repo := range sortedRepos(grp) {
+		// Build a fast lookup of entity ID → entity for this repo so we
+		// can resolve the caller (FromID) to its source_file / start_line.
+		entityByID := make(map[string]int, len(repo.Doc.Entities))
+		for i := range repo.Doc.Entities {
+			entityByID[repo.Doc.Entities[i].ID] = i
+		}
+
+		for _, rel := range repo.Doc.Relationships {
+			if rel.Kind != "FETCHES" {
+				continue
+			}
+
+			toID := rel.ToID
+			fromID := rel.FromID
+
+			// Determine whether the target resolves to a producer-side
+			// http_endpoint anywhere in the group.
+			targetEntry, targetExists := endpointByID[toID]
+			if !targetExists {
+				// Try prefixed form (e.g. when cross-repo phantom edges
+				// embed the slug).
+				targetEntry, targetExists = endpointByID[dashPrefixedID(repo.Slug, toID)]
+			}
+
+			// The caller is orphaned when:
+			// (a) no entity with toID exists at all, OR
+			// (b) the entity exists but is itself a consumer-side synthetic
+			//     with no producer match (i.e. both sides are "client synthesis").
+			isOrphan := !targetExists || !targetEntry.isProducer
+
+			if !isOrphan {
+				continue
+			}
+
+			// Resolve the caller entity (fromID) so we can emit file + line.
+			callerIdx, callerKnown := entityByID[fromID]
+			var callerFile string
+			var callerLine int
+			if callerKnown {
+				ce := &repo.Doc.Entities[callerIdx]
+				callerFile = ce.SourceFile
+				callerLine = ce.StartLine
+			}
+
+			// Extract url_pattern and method from the relationship properties
+			// (set by makeRuntimeEmit in http_endpoint_synthesis.go) or from
+			// the target entity's properties if the relationship is bare.
+			urlPattern := ""
+			method := "GET"
+			if rel.Properties != nil {
+				if v := rel.Properties["path"]; v != "" {
+					urlPattern = v
+				}
+				if v := rel.Properties["verb"]; v != "" {
+					method = strings.ToUpper(v)
+				}
+			}
+			// Fall back to target entity properties when the rel has none.
+			if urlPattern == "" {
+				if props := entityProps[toID]; props != nil {
+					urlPattern = props["path"]
+					if v := props["verb"]; v != "" {
+						method = strings.ToUpper(v)
+					}
+				}
+			}
+
+			// Classify the reason.
+			reason := classifyOrphanReason(toID, urlPattern, entityProps)
+
+			callerID := dashPrefixedID(repo.Slug, fromID)
+
+			dk := dedupKey{callerID: callerID, urlPattern: urlPattern}
+			if seen[dk] {
+				continue
+			}
+			seen[dk] = true
+
+			repairKind := suggestedRepair[reason]
+
+			rows = append(rows, OrphanCallerRow{
+				CallerID:            callerID,
+				CallerFile:          callerFile,
+				CallerLine:          callerLine,
+				URLPattern:          urlPattern,
+				Method:              method,
+				Reason:              string(reason),
+				SuggestedRepairKind: repairKind,
+				Repo:                repo.Slug,
+			})
+		}
+	}
+
+	// Stable deterministic sort: repo → file → line → url_pattern.
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.Repo != b.Repo {
+			return a.Repo < b.Repo
+		}
+		if a.CallerFile != b.CallerFile {
+			return a.CallerFile < b.CallerFile
+		}
+		if a.CallerLine != b.CallerLine {
+			return a.CallerLine < b.CallerLine
+		}
+		return a.URLPattern < b.URLPattern
+	})
+
+	if rows == nil {
+		rows = []OrphanCallerRow{}
+	}
+	return rows
+}
+
+// classifyOrphanReason determines why a FETCHES edge has no resolved handler.
+// It checks the target entity's known properties (if any) and the URL pattern
+// itself for template-literal placeholders.
+func classifyOrphanReason(toID, urlPattern string, entityProps map[string]map[string]string) orphanCallerReason {
+	// Check entity-level dynamic flags first.
+	if props := entityProps[toID]; props != nil {
+		if props["runtime_dynamic"] == "true" {
+			return reasonDynamicBaseURL
+		}
+		if props["dynamic_baseurl"] == "true" {
+			return reasonDynamicBaseURL
+		}
+	}
+
+	// Template-literal placeholder in the URL pattern: ${…} (JS) or {…} (generic).
+	if urlPattern != "" && containsTemplatePlaceholder(urlPattern) {
+		return reasonTemplateLiteral
+	}
+
+	return reasonNoHandlerFound
+}
+
+// containsTemplatePlaceholder reports whether a URL pattern contains a
+// template-literal style variable reference: ${name} (JavaScript) or
+// {name} (URL template / Python f-string / Go fmt.Sprintf).
+func containsTemplatePlaceholder(s string) bool {
+	// JS-style: ${…}
+	if strings.Contains(s, "${") {
+		return true
+	}
+	// Generic placeholder: {…}  — but only when it is NOT the very first
+	// segment (leading {…} is classified as dynamic_baseurl by the synthesis
+	// pass, so we avoid double-classification here).
+	idx := strings.Index(s, "{")
+	if idx < 0 {
+		return false
+	}
+	// If the placeholder is at position 0 or 1 (after leading "/"), it is
+	// the leading-path-placeholder pattern handled above — skip.
+	leadingOK := idx > 1
+	return leadingOK && strings.Contains(s[idx:], "}")
+}

--- a/internal/dashboard/handlers_orphan_callers_test.go
+++ b/internal/dashboard/handlers_orphan_callers_test.go
@@ -1,0 +1,438 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for collectOrphanCallers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func makeOrphanGroup(entities []graph.Entity, rels []graph.Relationship) *DashGroup {
+	doc := &graph.Document{
+		Repo:          "frontend",
+		Entities:      entities,
+		Relationships: rels,
+	}
+	return &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Path: "/tmp/fake-frontend", Doc: doc},
+		},
+	}
+}
+
+func TestCollectOrphanCallers_NoHandlerFound(t *testing.T) {
+	// A FETCHES edge whose ToID doesn't map to any http_endpoint in the group.
+	entities := []graph.Entity{
+		{
+			ID:         "caller_fn",
+			Name:       "fetchUsers",
+			Kind:       "Function",
+			SourceFile: "src/api/users.ts",
+			StartLine:  42,
+			Properties: map[string]string{},
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r1",
+			FromID: "caller_fn",
+			ToID:   "http:GET:/api/users",
+			Kind:   "FETCHES",
+			Properties: map[string]string{
+				"verb": "GET",
+				"path": "/api/users",
+			},
+		},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan row, got %d", len(rows))
+	}
+	r := rows[0]
+	if r.Reason != "no_handler_found" {
+		t.Errorf("reason: want no_handler_found, got %q", r.Reason)
+	}
+	if r.CallerFile != "src/api/users.ts" {
+		t.Errorf("caller_file: want src/api/users.ts, got %q", r.CallerFile)
+	}
+	if r.CallerLine != 42 {
+		t.Errorf("caller_line: want 42, got %d", r.CallerLine)
+	}
+	if r.URLPattern != "/api/users" {
+		t.Errorf("url_pattern: want /api/users, got %q", r.URLPattern)
+	}
+	if r.Method != "GET" {
+		t.Errorf("method: want GET, got %q", r.Method)
+	}
+	if r.SuggestedRepairKind != "add_missing_handler" {
+		t.Errorf("suggested_repair_kind: want add_missing_handler, got %q", r.SuggestedRepairKind)
+	}
+	if r.CallerID != "frontend::caller_fn" {
+		t.Errorf("caller_id: want frontend::caller_fn, got %q", r.CallerID)
+	}
+}
+
+func TestCollectOrphanCallers_DynamicBaseURL(t *testing.T) {
+	// A consumer-side http_endpoint with runtime_dynamic=true is orphaned
+	// because the baseURL could not be statically resolved.
+	entities := []graph.Entity{
+		{
+			ID:         "caller_fn2",
+			Name:       "postOrder",
+			Kind:       "Function",
+			SourceFile: "src/api/orders.ts",
+			StartLine:  10,
+			Properties: map[string]string{},
+		},
+		{
+			ID:   "http:POST:/orders",
+			Name: "http:POST:/orders",
+			Kind: "http_endpoint",
+			Properties: map[string]string{
+				"pattern_type":    "http_endpoint_client_synthesis",
+				"runtime_dynamic": "true",
+				"verb":            "POST",
+				"path":            "/orders",
+			},
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r2",
+			FromID: "caller_fn2",
+			ToID:   "http:POST:/orders",
+			Kind:   "FETCHES",
+			Properties: map[string]string{
+				"verb": "POST",
+				"path": "/orders",
+			},
+		},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan row, got %d", len(rows))
+	}
+	if rows[0].Reason != "dynamic_baseurl" {
+		t.Errorf("reason: want dynamic_baseurl, got %q", rows[0].Reason)
+	}
+	if rows[0].SuggestedRepairKind != "annotate_baseurl" {
+		t.Errorf("suggested_repair_kind: want annotate_baseurl, got %q", rows[0].SuggestedRepairKind)
+	}
+}
+
+func TestCollectOrphanCallers_TemplateLiteral(t *testing.T) {
+	// A FETCHES edge whose path contains a template-literal placeholder.
+	entities := []graph.Entity{
+		{
+			ID:         "caller_fn3",
+			Name:       "getUser",
+			Kind:       "Function",
+			SourceFile: "src/api/user.ts",
+			StartLine:  7,
+			Properties: map[string]string{},
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r3",
+			FromID: "caller_fn3",
+			ToID:   "http:GET:/api/users/${userId}",
+			Kind:   "FETCHES",
+			Properties: map[string]string{
+				"verb": "GET",
+				"path": "/api/users/${userId}",
+			},
+		},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan row, got %d", len(rows))
+	}
+	if rows[0].Reason != "template_literal" {
+		t.Errorf("reason: want template_literal, got %q", rows[0].Reason)
+	}
+	if rows[0].SuggestedRepairKind != "resolve_template_url" {
+		t.Errorf("suggested_repair_kind: want resolve_template_url, got %q", rows[0].SuggestedRepairKind)
+	}
+}
+
+func TestCollectOrphanCallers_ResolvedEdgeNotOrphan(t *testing.T) {
+	// A FETCHES edge whose ToID resolves to a producer-side http_endpoint — NOT orphan.
+	entities := []graph.Entity{
+		{
+			ID:         "caller_fn4",
+			Name:       "fetchHealth",
+			Kind:       "Function",
+			SourceFile: "src/api/health.ts",
+			StartLine:  3,
+			Properties: map[string]string{},
+		},
+		{
+			ID:   "http:GET:/health",
+			Name: "http:GET:/health",
+			Kind: "http_endpoint",
+			Properties: map[string]string{
+				"pattern_type": "http_endpoint_synthesis", // producer side
+				"verb":         "GET",
+				"path":         "/health",
+			},
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r4",
+			FromID: "caller_fn4",
+			ToID:   "http:GET:/health",
+			Kind:   "FETCHES",
+			Properties: map[string]string{
+				"verb": "GET",
+				"path": "/health",
+			},
+		},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 orphan rows for resolved edge, got %d", len(rows))
+	}
+}
+
+func TestCollectOrphanCallers_Deduplication(t *testing.T) {
+	// Two FETCHES edges with the same (caller_id, url_pattern) must produce only one row.
+	entities := []graph.Entity{
+		{
+			ID:         "caller_dup",
+			Name:       "callTwice",
+			Kind:       "Function",
+			SourceFile: "src/dup.ts",
+			StartLine:  5,
+			Properties: map[string]string{},
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "rdup1", FromID: "caller_dup", ToID: "http:GET:/dup", Kind: "FETCHES",
+			Properties: map[string]string{"verb": "GET", "path": "/dup"}},
+		{ID: "rdup2", FromID: "caller_dup", ToID: "http:GET:/dup", Kind: "FETCHES",
+			Properties: map[string]string{"verb": "GET", "path": "/dup"}},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 1 {
+		t.Errorf("expected 1 deduplicated row, got %d", len(rows))
+	}
+}
+
+func TestCollectOrphanCallers_EmptyGroup(t *testing.T) {
+	grp := &DashGroup{
+		Name:  "empty",
+		Repos: map[string]*DashRepo{},
+	}
+	rows := collectOrphanCallers(grp)
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows for empty group, got %d", len(rows))
+	}
+}
+
+func TestCollectOrphanCallers_NonFetchesEdgesIgnored(t *testing.T) {
+	// CALLS and QUERIES edges should not contribute orphan rows.
+	entities := []graph.Entity{
+		{ID: "fn1", Name: "fn1", Kind: "Function", SourceFile: "src/a.go", StartLine: 1},
+	}
+	rels := []graph.Relationship{
+		{ID: "rc1", FromID: "fn1", ToID: "missing_target", Kind: "CALLS"},
+		{ID: "rc2", FromID: "fn1", ToID: "missing_target2", Kind: "QUERIES"},
+	}
+
+	grp := makeOrphanGroup(entities, rels)
+	rows := collectOrphanCallers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows (non-FETCHES edges must be ignored), got %d", len(rows))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for classification helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestContainsTemplatePlaceholder(t *testing.T) {
+	cases := []struct {
+		url  string
+		want bool
+	}{
+		{"/api/users/${userId}", true},
+		{"/api/users/{id}/profile", true},
+		{"/api/users", false},
+		{"/{tenantId}/contracts", false}, // leading placeholder (no $) — handled as dynamic_baseurl
+		{"{param}/users/{id}", false},    // leading placeholder
+		{"/api/{version}/users", true},   // mid-path placeholder
+	}
+	for _, tc := range cases {
+		got := containsTemplatePlaceholder(tc.url)
+		if got != tc.want {
+			t.Errorf("containsTemplatePlaceholder(%q): want %v, got %v", tc.url, tc.want, got)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration smoke: HTTP endpoint returns correct JSON shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newOrphanTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["mygrp"] = GroupSummary{
+		Name:       "mygrp",
+		ConfigPath: "/tmp/mygrp.json",
+		Repos:      []string{"frontend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["mygrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestHandleOrphanCallers_HTTPSmoke(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "caller_smoke",
+			Name:       "callAPI",
+			Kind:       "Function",
+			SourceFile: "src/api/smoke.ts",
+			StartLine:  99,
+			Properties: map[string]string{},
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "rsmoke",
+			FromID: "caller_smoke",
+			ToID:   "http:DELETE:/smoke",
+			Kind:   "FETCHES",
+			Properties: map[string]string{
+				"verb": "DELETE",
+				"path": "/smoke",
+			},
+		},
+	}
+	grp := makeOrphanGroup(entities, rels)
+	grp.Name = "mygrp"
+
+	ts := newOrphanTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/paths/mygrp/orphan-callers")
+	if err != nil {
+		t.Fatalf("GET orphan-callers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		OrphanCallers []OrphanCallerRow `json:"orphan_callers"`
+		Total         int               `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if len(body.OrphanCallers) != 1 {
+		t.Fatalf("orphan_callers len: want 1, got %d", len(body.OrphanCallers))
+	}
+
+	row := body.OrphanCallers[0]
+	if row.Method != "DELETE" {
+		t.Errorf("method: want DELETE, got %q", row.Method)
+	}
+	if row.CallerFile != "src/api/smoke.ts" {
+		t.Errorf("caller_file: want src/api/smoke.ts, got %q", row.CallerFile)
+	}
+	if row.CallerLine != 99 {
+		t.Errorf("caller_line: want 99, got %d", row.CallerLine)
+	}
+}
+
+func TestHandleOrphanCallers_UnknownGroup(t *testing.T) {
+	grp := makeOrphanGroup(nil, nil)
+	grp.Name = "mygrp"
+	ts := newOrphanTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/paths/nosuchgroup/orphan-callers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleOrphanCallers_EmptyResult(t *testing.T) {
+	// A group with no FETCHES edges returns an empty list (not null).
+	grp := makeOrphanGroup([]graph.Entity{
+		{ID: "e1", Name: "e1", Kind: "Function", SourceFile: "src/x.go"},
+	}, []graph.Relationship{
+		{ID: "r1", FromID: "e1", ToID: "e2", Kind: "CALLS"},
+	})
+	grp.Name = "mygrp"
+	ts := newOrphanTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/paths/mygrp/orphan-callers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	callers, ok := body["orphan_callers"]
+	if !ok {
+		t.Fatal("orphan_callers key missing")
+	}
+	arr, ok := callers.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty array, got %v", callers)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -165,6 +165,7 @@ func (s *Server) routes() http.Handler {
 
 	// API paths / contracts
 	mux.HandleFunc("GET /api/paths/{group}", s.handlePathsList)
+	mux.HandleFunc("GET /api/paths/{group}/orphan-callers", s.handleOrphanCallers)
 	mux.HandleFunc("GET /api/paths/{group}/{pathHash}", s.handlePathDetail)
 
 	// Broker topology


### PR DESCRIPTION
## Summary

Implements the orphan-caller detector for Paths v2 (#1091). Walks every
`FETCHES` relationship across all repos in a group and surfaces call sites
whose target does not resolve to a producer-side `http_endpoint` anywhere
in the indexed group. Each unresolved caller becomes a repair candidate
that feeds directly into the existing apply/reject flow.

**New endpoint:** `GET /api/paths/{group}/orphan-callers`

Response shape (per spec):
```json
{
  "orphan_callers": [
    {
      "caller_id":             "frontend::caller_fn",
      "caller_file":           "src/api/users.ts",
      "caller_line":           42,
      "url_pattern":           "/api/users/\${userId}",
      "method":                "GET",
      "reason":                "template_literal",
      "suggested_repair_kind": "resolve_template_url",
      "repo":                  "frontend"
    }
  ],
  "total": 1
}
```

**Detection logic (in `collectOrphanCallers`):**
1. Build an index of all `http_endpoint` entities across the group, tagging
   each as producer-side or consumer-side (by `pattern_type`).
2. Walk every `FETCHES` edge. An edge is orphaned when its `ToID` maps to no
   entity, or maps only to a consumer-side synthetic with no matched producer.
3. Classify reason:
   - `dynamic_baseurl` — target entity carries `runtime_dynamic=true` or
     `dynamic_baseurl=true` (env-var / leading-placeholder URL).
   - `template_literal` — URL pattern contains a `\${…}` or mid-path `{…}`
     placeholder that prevented static resolution.
   - `no_handler_found` — path has no matching producer in the group.
4. Deduplicate by `(caller_id, url_pattern)`; sort deterministically by
   repo → file → line → url_pattern.

**Route registration:** `GET /api/paths/{group}/orphan-callers` is registered
before the `{pathHash}` wildcard so Go's most-specific-match routing resolves
it correctly.

## Closes / Refs
- Closes #1091

## Testing
- [x] All tests pass: `go test ./internal/dashboard/...` — 11 new tests added
  (7 unit tests for `collectOrphanCallers`, 1 for `containsTemplatePlaceholder`,
  3 HTTP integration smoke tests)
- [x] All existing dashboard tests continue to pass (no regressions)
- [x] Rebased on current main

## Notes

The `suggested_repair_kind` field maps each reason to the existing repair
vocabulary so the Pending surface can route candidates without new plumbing:

| reason | suggested_repair_kind |
|---|---|
| `dynamic_baseurl` | `annotate_baseurl` |
| `template_literal` | `resolve_template_url` |
| `no_handler_found` | `add_missing_handler` |

The handler is read-only — it does not mutate any state. Future work can wire
the rows into `POST /api/repairs/{group}/action` via the existing apply/reject
flow (#1010).