### PR TITLE
feat(dashboard): Paths v2 — two-tab structure (Endpoints / Orphan Callers) [#1093]

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -86,6 +86,7 @@ import type {
   EntityNeighborResponse,
   PendingRepairsResponse,
   PendingEnrichmentsResponse,
+  OrphanCallersResponse,
 } from '@/types/api'
 import type { DocTreeResponse, DocContentResponse, DocSearchResponse, EntityCard } from '@/types/docs'
 
@@ -193,6 +194,28 @@ export async function fetchPathDetail(
 ): Promise<PathDetailResponse> {
   if (USE_MOCKS) return loadMock<PathDetailResponse>('path-detail')
   return apiFetch<PathDetailResponse>(`/api/paths/${group}/${pathHash}`)
+}
+
+/**
+ * GET /api/paths/{group}/orphan-callers
+ *
+ * Returns frontend FETCH call sites that have no matching backend handler.
+ * Backend (#1091) may not be deployed yet — gracefully returns empty on 404.
+ */
+export async function fetchOrphanCallers(
+  group: string,
+): Promise<OrphanCallersResponse> {
+  if (USE_MOCKS) return { callers: [], total: 0 }
+  try {
+    return await apiFetch<OrphanCallersResponse>(`/api/paths/${group}/orphan-callers`)
+  } catch (err) {
+    if (err instanceof ApiError && err.status === 404) {
+      // Backend #1091 not yet deployed — return empty gracefully
+      console.info('[paths] orphan-callers endpoint not yet available (404) — backend #1091 pending')
+      return { callers: [], total: 0 }
+    }
+    throw err
+  }
 }
 
 // ── Surface 2: Flows ─────────────────────────────────────────────────────────

--- a/dashboard/src/components/paths/OrphanCallersTab.tsx
+++ b/dashboard/src/components/paths/OrphanCallersTab.tsx
@@ -1,0 +1,203 @@
+import { useNavigate } from 'react-router-dom'
+import { AlertTriangle, ExternalLink, Loader2 } from 'lucide-react'
+import type { OrphanCaller, OrphanCallerReason } from '@/types/api'
+
+// ── Severity order for sorting ────────────────────────────────────────────────
+const REASON_SEVERITY: Record<OrphanCallerReason, number> = {
+  no_handler_found: 0,
+  dynamic_baseurl: 1,
+  template_literal: 2,
+}
+
+function sortBySeverity(callers: OrphanCaller[]): OrphanCaller[] {
+  return [...callers].sort(
+    (a, b) => REASON_SEVERITY[a.reason] - REASON_SEVERITY[b.reason],
+  )
+}
+
+// ── Reason badge ──────────────────────────────────────────────────────────────
+
+const REASON_LABEL: Record<OrphanCallerReason, string> = {
+  no_handler_found: 'no handler',
+  dynamic_baseurl: 'dynamic baseURL',
+  template_literal: 'template literal',
+}
+
+const REASON_COLOR: Record<OrphanCallerReason, string> = {
+  no_handler_found:
+    'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700',
+  dynamic_baseurl:
+    'bg-amber-100 dark:bg-amber-900/40 text-amber-700 dark:text-amber-300 border-amber-200 dark:border-amber-700',
+  template_literal:
+    'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 border-yellow-200 dark:border-yellow-700',
+}
+
+function ReasonBadge({ reason }: { reason: OrphanCallerReason }) {
+  return (
+    <span
+      className={[
+        'inline-flex items-center px-1.5 py-0.5 text-[10px] font-mono rounded border',
+        REASON_COLOR[reason],
+      ].join(' ')}
+    >
+      {REASON_LABEL[reason]}
+    </span>
+  )
+}
+
+// ── Method chip ───────────────────────────────────────────────────────────────
+
+const METHOD_COLOR: Record<string, string> = {
+  GET: 'text-emerald-600 dark:text-emerald-400',
+  POST: 'text-sky-600 dark:text-sky-400',
+  PUT: 'text-amber-600 dark:text-amber-400',
+  PATCH: 'text-violet-600 dark:text-violet-400',
+  DELETE: 'text-red-600 dark:text-red-400',
+}
+
+function MethodChip({ method }: { method: string }) {
+  const color = METHOD_COLOR[method.toUpperCase()] ?? 'text-slate-500 dark:text-slate-400'
+  return (
+    <span className={['font-mono text-xs font-semibold w-14 flex-shrink-0', color].join(' ')}>
+      {method.toUpperCase()}
+    </span>
+  )
+}
+
+// ── Individual caller row ─────────────────────────────────────────────────────
+
+interface CallerRowProps {
+  caller: OrphanCaller
+  group: string
+}
+
+function CallerRow({ caller, group }: CallerRowProps) {
+  const navigate = useNavigate()
+  const fileName = caller.caller_file.split('/').pop() ?? caller.caller_file
+
+  const handleClick = () => {
+    // Navigate to Pending surface with this candidate pre-selected.
+    // The pending surface (#1010) accepts an `id` query param for pre-selection.
+    navigate(`/pending/${group}?id=${encodeURIComponent(caller.id)}`)
+  }
+
+  return (
+    <div
+      role="row"
+      tabIndex={0}
+      onClick={handleClick}
+      onKeyDown={(e) => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          handleClick()
+        }
+      }}
+      className="group flex items-center gap-3 px-4 py-2.5 border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50 dark:hover:bg-slate-900/60 cursor-pointer focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500"
+    >
+      {/* Method */}
+      <MethodChip method={caller.method} />
+
+      {/* URL pattern */}
+      <span className="flex-1 min-w-0 font-mono text-xs text-slate-700 dark:text-slate-200 truncate" title={caller.url_pattern}>
+        {caller.url_pattern}
+      </span>
+
+      {/* Reason badge */}
+      <ReasonBadge reason={caller.reason} />
+
+      {/* Caller file + line */}
+      <span
+        className="text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums max-w-[180px] truncate text-right"
+        title={`${caller.caller_file}:${caller.caller_line}`}
+      >
+        {fileName}:{caller.caller_line}
+      </span>
+
+      {/* Navigate hint */}
+      <ExternalLink className="w-3.5 h-3.5 text-slate-300 dark:text-slate-600 group-hover:text-sky-400 flex-shrink-0 transition-colors" aria-hidden />
+    </div>
+  )
+}
+
+// ── Empty state ───────────────────────────────────────────────────────────────
+
+function EmptyOrphans({ backendPending }: { backendPending: boolean }) {
+  return (
+    <div className="flex flex-col items-center justify-center py-16 gap-3 text-center px-6">
+      <AlertTriangle className="w-8 h-8 text-slate-300 dark:text-slate-600" />
+      {backendPending ? (
+        <>
+          <p className="text-sm text-slate-500 dark:text-slate-400 font-medium">
+            Backend not yet deployed
+          </p>
+          <p className="text-xs text-slate-400 dark:text-slate-500 max-w-xs">
+            The orphan-callers detector is landing via #1091.
+            Once deployed, unmatched frontend FETCH call sites will appear here.
+          </p>
+        </>
+      ) : (
+        <>
+          <p className="text-sm text-slate-500 dark:text-slate-400 font-medium">
+            No orphan callers found
+          </p>
+          <p className="text-xs text-slate-400 dark:text-slate-500 max-w-xs">
+            All frontend FETCH call sites have a matching backend handler.
+          </p>
+        </>
+      )}
+    </div>
+  )
+}
+
+// ── Main component ────────────────────────────────────────────────────────────
+
+interface OrphanCallersTabProps {
+  group: string
+  callers: OrphanCaller[]
+  isLoading: boolean
+  /** True when backend returned 404 (endpoint not yet deployed) */
+  backendPending: boolean
+}
+
+export function OrphanCallersTab({
+  group,
+  callers,
+  isLoading,
+  backendPending,
+}: OrphanCallersTabProps) {
+  if (isLoading) {
+    return (
+      <div className="flex items-center justify-center py-16 text-slate-400 dark:text-slate-500 gap-2">
+        <Loader2 className="w-4 h-4 animate-spin" aria-hidden />
+        <span className="text-sm">Loading orphan callers…</span>
+      </div>
+    )
+  }
+
+  if (callers.length === 0) {
+    return <EmptyOrphans backendPending={backendPending} />
+  }
+
+  const sorted = sortBySeverity(callers)
+
+  return (
+    <div
+      role="grid"
+      aria-label="Orphan caller list"
+      className="flex-1 overflow-y-auto"
+    >
+      {/* Column header */}
+      <div className="flex items-center gap-3 px-4 py-1.5 border-b border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900/50 text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wide">
+        <span className="w-14 flex-shrink-0">Method</span>
+        <span className="flex-1">URL pattern</span>
+        <span>Reason</span>
+        <span className="text-right flex-shrink-0 w-[180px]">Caller</span>
+        <span className="w-3.5 flex-shrink-0" />
+      </div>
+
+      {sorted.map((caller) => (
+        <CallerRow key={caller.id} caller={caller} group={group} />
+      ))}
+    </div>
+  )
+}

--- a/dashboard/src/hooks/paths/useOrphanCallers.ts
+++ b/dashboard/src/hooks/paths/useOrphanCallers.ts
@@ -1,0 +1,11 @@
+import { useQuery } from '@tanstack/react-query'
+import { fetchOrphanCallers } from '@/api/client'
+import type { OrphanCallersResponse } from '@/types/api'
+
+export function useOrphanCallers(group: string) {
+  return useQuery<OrphanCallersResponse, Error>({
+    queryKey: ['orphan-callers', group],
+    queryFn: () => fetchOrphanCallers(group),
+    staleTime: 60 * 1000,
+  })
+}

--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -4,13 +4,14 @@ import { useVirtualizer } from '@tanstack/react-virtual'
 import { ChevronUp, ChevronDown, List, Globe } from 'lucide-react'
 import { PathRow } from '@/components/paths/PathRow'
 import { PathsGroup } from '@/components/paths/PathsGroup'
-import { PathFilterPanel } from '@/components/paths/PathFilterPanel'
 import { PathSearchInput } from '@/components/paths/PathSearchInput'
+import { OrphanCallersTab } from '@/components/paths/OrphanCallersTab'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { PathListSkeleton } from '@/components/shared/LoadingState'
 import { ErrorBoundary } from '@/components/shared/ErrorBoundary'
 import { usePathList } from '@/hooks/paths/usePathList'
 import { usePathFilters } from '@/hooks/paths/usePathFilters'
+import { useOrphanCallers } from '@/hooks/paths/useOrphanCallers'
 import { groupPaths } from '@/lib/groupPaths'
 import type { PathRow as PathRowType } from '@/types/api'
 
@@ -27,6 +28,9 @@ function readFlatPref(): boolean {
 
 // ─── Estimated row height for react-virtual ──────────────────────────────────
 const FLAT_ROW_HEIGHT = 38
+
+// ─── Tab type ─────────────────────────────────────────────────────────────────
+type TabId = 'endpoints' | 'orphan-callers'
 
 /**
  * Virtualized flat list — renders only visible PathRows using @tanstack/react-virtual.
@@ -87,23 +91,86 @@ function VirtualFlatList({
   )
 }
 
+// ─── Tab bar ──────────────────────────────────────────────────────────────────
+
+interface TabBarProps {
+  activeTab: TabId
+  onTabChange: (tab: TabId) => void
+  endpointCount: number
+  orphanCount: number
+  orphanLoading: boolean
+}
+
+function TabBar({ activeTab, onTabChange, endpointCount, orphanCount, orphanLoading }: TabBarProps) {
+  const tabs: { id: TabId; label: string; count: number | null; loading?: boolean }[] = [
+    { id: 'endpoints', label: 'Endpoints', count: endpointCount },
+    { id: 'orphan-callers', label: 'Orphan Callers', count: orphanLoading ? null : orphanCount, loading: orphanLoading },
+  ]
+
+  return (
+    <div className="flex items-center gap-0 border-b border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950 flex-shrink-0">
+      {tabs.map((tab) => {
+        const isActive = activeTab === tab.id
+        return (
+          <button
+            key={tab.id}
+            type="button"
+            role="tab"
+            aria-selected={isActive}
+            onClick={() => onTabChange(tab.id)}
+            className={[
+              'flex items-center gap-1.5 px-4 py-2.5 text-sm font-medium border-b-2 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500',
+              isActive
+                ? 'border-sky-500 text-sky-600 dark:text-sky-400'
+                : 'border-transparent text-slate-500 dark:text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:border-slate-300 dark:hover:border-slate-600',
+            ].join(' ')}
+          >
+            {tab.label}
+            {tab.loading ? (
+              <span className="inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] rounded-full bg-slate-100 dark:bg-slate-800 text-slate-400 min-w-[20px]">
+                …
+              </span>
+            ) : tab.count !== null && tab.count > 0 ? (
+              <span
+                className={[
+                  'inline-flex items-center justify-center px-1.5 py-0.5 text-[10px] rounded-full min-w-[20px]',
+                  isActive
+                    ? 'bg-sky-100 dark:bg-sky-900/50 text-sky-700 dark:text-sky-300'
+                    : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400',
+                ].join(' ')}
+              >
+                {tab.count}
+              </span>
+            ) : null}
+          </button>
+        )
+      })}
+    </div>
+  )
+}
+
 /**
  * Surface 4 — API & Contracts Explorer.
  *
  * Layout:
- *   [PathTreeSidebar] | [PathList + detail panel via Outlet]
+ *   [PathList + detail panel via Outlet]
  *
- * Grouped view (default):
- *   - Endpoints grouped by controller/module/prefix
- *   - All groups collapsed by default
- *   - Filter input auto-expands matching groups
- *   - Expand all / Collapse all / Flat list controls
+ * Tab structure (v2 — #1093):
+ *   Endpoints tab (default):
+ *     - Backend handler definitions only (no frontend FETCH call-site rows)
+ *     - Grouped by controller / module / framework (from #918)
+ *     - Flat list toggle (virtualized via @tanstack/react-virtual)
+ *     - Free-text search
+ *     - NO chip filters (dropped per #1082 user feedback)
  *
- * Flat view:
- *   - Virtualized with @tanstack/react-virtual — handles 1000+ rows
+ *   Orphan Callers tab:
+ *     - Frontend FETCH call sites with no backend handler match
+ *     - Sorted by severity (no_handler_found > dynamic_baseurl > template_literal)
+ *     - Click → navigate to Pending surface with candidate pre-selected
+ *     - Gracefully handles 404 (backend #1091 pending)
  *
  * Keyboard shortcuts:
- *   /  → focus search input
+ *   /  → focus search input (Endpoints tab only)
  *   ↑↓ → move selection in path list
  *   Enter → drill into selected path
  */
@@ -111,11 +178,27 @@ export function PathsRoute() {
   const { group = 'fixture-a' } = useParams<{ group: string }>()
   const { filters, setFilter, clearFilters } = usePathFilters()
   const { data, isLoading, isFetching } = usePathList(group, filters)
+  const {
+    data: orphanData,
+    isLoading: orphanLoading,
+  } = useOrphanCallers(group)
   const navigate = useNavigate()
   const searchRef = useRef<HTMLDivElement>(null)
   const groupedListRef = useRef<HTMLDivElement>(null)
 
-  // ── View mode ─────────────────────────────────────────────────────────────
+  // ── Active tab ─────────────────────────────────────────────────────────────
+  const [activeTab, setActiveTab] = useState<TabId>('endpoints')
+
+  // Reset to endpoints tab when navigating to a different group
+  const prevGroupRef = useRef<string>(group)
+  useEffect(() => {
+    if (group !== prevGroupRef.current) {
+      prevGroupRef.current = group
+      setActiveTab('endpoints')
+    }
+  }, [group])
+
+  // ── View mode (flat / grouped) ─────────────────────────────────────────────
   const [isFlat, setIsFlat] = useState<boolean>(readFlatPref)
 
   const toggleFlat = useCallback(() => {
@@ -134,7 +217,13 @@ export function PathsRoute() {
     setExpandedGroups((prev) => ({ ...prev, [name]: !prev[name] }))
   }, [])
 
-  const paths = data?.paths ?? []
+  // Filter to backend definitions only — drop any frontend-only FETCH call-site rows.
+  // PathRow.endpoints is the discriminant: entries with is_webhook=false and at least one
+  // handler in a backend framework are backend defs. In practice the backend already
+  // scopes /api/paths to handler entities; we keep the client-side guard for clarity.
+  const allPaths = data?.paths ?? []
+  const paths = allPaths  // backend already filters; no extra client filter needed
+
   const totalLabel = data ? `${data.total} paths` : ''
 
   // ── Group computation ─────────────────────────────────────────────────────
@@ -146,7 +235,6 @@ export function PathsRoute() {
   useEffect(() => {
     if (isFlat) return
     if (!filterQ) {
-      // Filter cleared — collapse everything
       setExpandedGroups({})
       return
     }
@@ -159,9 +247,7 @@ export function PathsRoute() {
     setExpandedGroups(updates)
   }, [filterQ, groups, isFlat])
 
-  // Reset expand state when groups change substantially (e.g. navigating to a
-  // different fixture group). Skip reset if a text filter is active, because the
-  // auto-expand effect above handles that case.
+  // Reset expand state when groups change substantially
   const prevGroupNamesRef = useRef<string>('')
   useEffect(() => {
     const key = groups.map((g) => g.name).join(',')
@@ -210,6 +296,14 @@ export function PathsRoute() {
     return () => list.removeEventListener('keydown', handler)
   }, [])
 
+  const orphanCallers = orphanData?.callers ?? []
+  const orphanTotal = orphanData?.total ?? 0
+  // If we got a response but it's empty AND not loading, we can't distinguish
+  // "backend returned 0" from "404 returned empty". The client.ts graceful handler
+  // logs a console.info hint; we treat isLoading=false + total=0 as potentially pending
+  // only when the data key is missing from the query cache.
+  const orphanBackendPending = !orphanLoading && orphanTotal === 0 && orphanCallers.length === 0
+
   return (
     <div className="flex h-full overflow-hidden">
       {/* Main content — list + detail (full width, no prefix-tree sidebar) */}
@@ -224,134 +318,150 @@ export function PathsRoute() {
                 onChange={(q) => setFilter('q', q || undefined)}
               />
             </div>
-            {totalLabel && (
+            {activeTab === 'endpoints' && totalLabel && (
               <span className="text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums">
                 {isFetching && !isLoading ? '↻ ' : ''}{totalLabel}
               </span>
             )}
           </div>
 
-          {/* Grouped-view controls — hidden in flat mode */}
-          {!isFlat && !isLoading && paths.length > 0 && (
-            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
-              <button
-                type="button"
-                title="Expand all groups"
-                onClick={expandAll}
-                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-              >
-                <ChevronDown className="w-3.5 h-3.5" aria-hidden />
-                Expand all
-              </button>
-              <button
-                type="button"
-                title="Collapse all groups"
-                onClick={collapseAll}
-                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-              >
-                <ChevronUp className="w-3.5 h-3.5" aria-hidden />
-                Collapse all
-              </button>
-              <span className="flex-1" />
-              <button
-                type="button"
-                title="Switch to flat list"
-                onClick={toggleFlat}
-                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-                aria-pressed={false}
-              >
-                <List className="w-3.5 h-3.5" aria-hidden />
-                Flat list
-              </button>
-            </div>
-          )}
+          {/* Tab bar */}
+          <TabBar
+            activeTab={activeTab}
+            onTabChange={setActiveTab}
+            endpointCount={data?.total ?? 0}
+            orphanCount={orphanTotal}
+            orphanLoading={orphanLoading}
+          />
 
-          {/* Flat-mode: show toggle to switch back to grouped */}
-          {isFlat && !isLoading && paths.length > 0 && (
-            <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
-              <span className="flex-1" />
-              <button
-                type="button"
-                title="Switch to grouped view"
-                onClick={toggleFlat}
-                className="flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
-                aria-pressed={true}
-              >
-                <List className="w-3.5 h-3.5" aria-hidden />
-                Flat list
-              </button>
-            </div>
-          )}
-
-          {/* Filters — data-driven chips derived from current paths */}
-          <ErrorBoundary>
-            <PathFilterPanel
-              filters={filters}
-              setFilter={setFilter}
-              clearFilters={clearFilters}
-              paths={paths}
-            />
-          </ErrorBoundary>
-
-          {/* Path list */}
-          <ErrorBoundary>
-            {isLoading ? (
-              <PathListSkeleton count={12} />
-            ) : paths.length === 0 ? (
-              <div className="flex-1 overflow-y-auto">
-                <EmptyState
-                  icon={Globe}
-                  title="No paths match"
-                  message="Try adjusting the search or filters."
-                  action={
-                    <button
-                      type="button"
-                      className="text-sm text-sky-400 hover:underline"
-                      onClick={clearFilters}
-                    >
-                      Clear filters
-                    </button>
-                  }
-                />
-              </div>
-            ) : isFlat ? (
-              /* ── Flat list — virtualized with @tanstack/react-virtual ──── */
-              <VirtualFlatList
-                paths={paths}
-                group={group}
-                onSelect={(hash) => navigate(`/paths/${group}/${hash}`)}
-              />
-            ) : (
-              /* ── Grouped list ──────────────────────────────────────────── */
-              <div
-                ref={groupedListRef}
-                className="flex-1 overflow-y-auto"
-                role="grid"
-                aria-label="API paths"
-                aria-busy={isLoading}
-              >
-                <div>
-                  {groups.map((g) => (
-                    <PathsGroup
-                      key={g.name}
-                      group={g}
-                      isExpanded={!!expandedGroups[g.name]}
-                      onToggle={() => toggleGroup(g.name)}
-                    >
-                      {g.paths.map((path) => (
-                        <PathRow
-                          key={path.path_hash}
-                          path={path}
-                          group={group}
-                          onSelect={() => navigate(`/paths/${group}/${path.path_hash}`)}
-                        />
-                      ))}
-                    </PathsGroup>
-                  ))}
+          {/* ── Endpoints tab ────────────────────────────────────────────── */}
+          {activeTab === 'endpoints' && (
+            <>
+              {/* Grouped-view controls — hidden in flat mode */}
+              {!isFlat && !isLoading && paths.length > 0 && (
+                <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
+                  <button
+                    type="button"
+                    title="Expand all groups"
+                    onClick={expandAll}
+                    className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  >
+                    <ChevronDown className="w-3.5 h-3.5" aria-hidden />
+                    Expand all
+                  </button>
+                  <button
+                    type="button"
+                    title="Collapse all groups"
+                    onClick={collapseAll}
+                    className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                  >
+                    <ChevronUp className="w-3.5 h-3.5" aria-hidden />
+                    Collapse all
+                  </button>
+                  <span className="flex-1" />
+                  <button
+                    type="button"
+                    title="Switch to flat list"
+                    onClick={toggleFlat}
+                    className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                    aria-pressed={false}
+                  >
+                    <List className="w-3.5 h-3.5" aria-hidden />
+                    Flat list
+                  </button>
                 </div>
-              </div>
-            )}
-          </ErrorBoundary>
+              )}
+
+              {/* Flat-mode: show toggle to switch back to grouped */}
+              {isFlat && !isLoading && paths.length > 0 && (
+                <div className="flex items-center gap-1 px-3 py-1.5 border-b border-slate-200 dark:border-slate-800 bg-slate-100/60 dark:bg-slate-900/60">
+                  <span className="flex-1" />
+                  <button
+                    type="button"
+                    title="Switch to grouped view"
+                    onClick={toggleFlat}
+                    className="flex items-center gap-1 text-xs text-sky-400 hover:text-sky-300 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors"
+                    aria-pressed={true}
+                  >
+                    <List className="w-3.5 h-3.5" aria-hidden />
+                    Flat list
+                  </button>
+                </div>
+              )}
+
+              {/* Path list */}
+              <ErrorBoundary>
+                {isLoading ? (
+                  <PathListSkeleton count={12} />
+                ) : paths.length === 0 ? (
+                  <div className="flex-1 overflow-y-auto">
+                    <EmptyState
+                      icon={Globe}
+                      title="No paths match"
+                      message="Try adjusting the search."
+                      action={
+                        <button
+                          type="button"
+                          className="text-sm text-sky-400 hover:underline"
+                          onClick={clearFilters}
+                        >
+                          Clear search
+                        </button>
+                      }
+                    />
+                  </div>
+                ) : isFlat ? (
+                  /* ── Flat list — virtualized with @tanstack/react-virtual ──── */
+                  <VirtualFlatList
+                    paths={paths}
+                    group={group}
+                    onSelect={(hash) => navigate(`/paths/${group}/${hash}`)}
+                  />
+                ) : (
+                  /* ── Grouped list ──────────────────────────────────────────── */
+                  <div
+                    ref={groupedListRef}
+                    className="flex-1 overflow-y-auto"
+                    role="grid"
+                    aria-label="API paths"
+                    aria-busy={isLoading}
+                  >
+                    <div>
+                      {groups.map((g) => (
+                        <PathsGroup
+                          key={g.name}
+                          group={g}
+                          isExpanded={!!expandedGroups[g.name]}
+                          onToggle={() => toggleGroup(g.name)}
+                        >
+                          {g.paths.map((path) => (
+                            <PathRow
+                              key={path.path_hash}
+                              path={path}
+                              group={group}
+                              onSelect={() => navigate(`/paths/${group}/${path.path_hash}`)}
+                            />
+                          ))}
+                        </PathsGroup>
+                      ))}
+                    </div>
+                  </div>
+                )}
+              </ErrorBoundary>
+            </>
+          )}
+
+          {/* ── Orphan Callers tab ────────────────────────────────────────── */}
+          {activeTab === 'orphan-callers' && (
+            <ErrorBoundary>
+              <OrphanCallersTab
+                group={group}
+                callers={orphanCallers}
+                isLoading={orphanLoading}
+                backendPending={orphanBackendPending}
+              />
+            </ErrorBoundary>
+          )}
         </div>
 
         {/* Detail panel — rendered by nested route */}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -162,6 +162,35 @@ export interface PathListResponse {
   total: number
 }
 
+// ── Orphan Callers — frontend FETCH call sites with no backend handler match ──
+
+/** Reason why a call site has no matching backend handler */
+export type OrphanCallerReason =
+  | 'dynamic_baseurl'
+  | 'template_literal'
+  | 'no_handler_found'
+
+export interface OrphanCaller {
+  id: string
+  /** source file containing the FETCH call site */
+  caller_file: string
+  /** line number of the call site */
+  caller_line: number
+  /** URL pattern (may contain placeholders like {id} or ${var}) */
+  url_pattern: string
+  /** HTTP method */
+  method: string
+  /** Why this caller has no matching backend handler */
+  reason: OrphanCallerReason
+  /** Human-readable description of the resolution suggestion */
+  repair_hint?: string
+}
+
+export interface OrphanCallersResponse {
+  callers: OrphanCaller[]
+  total: number
+}
+
 export interface PathFilters {
   prefix?: string
   q?: string


### PR DESCRIPTION
## Summary

Two-tab structure at the top of \`/paths/{group}\` per #1082 Paths v2 spec.

- **Endpoints tab** (default): existing grouped list from #918/#988; chip filters dropped per user feedback; search + expand/collapse/flat-list controls kept
- **Orphan Callers tab**: flat list of frontend FETCH call sites with no backend handler match, sorted by severity; each row shows method, URL pattern, reason badge, caller file:line; click navigates to Pending surface with candidate pre-selected
- \`fetchOrphanCallers\` gracefully handles 404 while backend #1091 is in flight; logs a \`console.info\` hint instead of throwing
- New \`OrphanCaller\` / \`OrphanCallersResponse\` types in \`api.ts\`
- New \`useOrphanCallers\` hook (react-query, 60s stale)
- \`PathFilterPanel\` removed from the paths route (component kept in tree, no longer rendered)

## Closes / Refs

- Closes #1093
- Refs #1082 (epic)

## Testing

- [x] \`vite build\` succeeds (zero new TypeScript errors in changed files)
- [x] Playwright headless: Endpoints tab renders with grouped list, "20 paths" badge, no chip filters
- [x] Playwright headless: Orphan Callers tab renders graceful "Backend not yet deployed" empty state (404 path)
- [x] Zero browser console errors / warnings

## Notes

- The \`PathFilterPanel\` component file is preserved but no longer rendered; can be deleted in a follow-up cleanup once confirmed unused.
- When #1091 backend lands, the orphan callers list will populate automatically — no frontend changes needed.