### PR TITLE
[#1094] Paths v2: Swagger++ detail panel

### DIFF
--- a/dashboard/src/api/mocks/path-detail.json
+++ b/dashboard/src/api/mocks/path-detail.json
@@ -13,13 +13,20 @@
         "start_line": 42,
         "end_line": 68,
         "language": "python",
-        "repo": "core-api"
+        "repo": "core-api",
+        "properties": {
+          "auth": "IsAuthenticated",
+          "parameters": "pk:path:integer"
+        }
       },
       "verb": "GET",
       "framework": "drf",
       "source_file": "apps/orders/views.py",
       "start_line": 42,
-      "language": "python"
+      "language": "python",
+      "has_docs": true,
+      "docs_summary": "Retrieve a single order by its primary key. Returns full order details including line items, shipping address, and current status. Raises 404 if the order does not exist or is not owned by the requesting user.",
+      "docs_path": "docs/api/orders/retrieve.md"
     },
     {
       "entity": {
@@ -31,13 +38,18 @@
         "start_line": 70,
         "end_line": 98,
         "language": "python",
-        "repo": "core-api"
+        "repo": "core-api",
+        "properties": {
+          "auth": "IsAuthenticated",
+          "parameters": "pk:path:integer,status:body:string,shipping_address:body:object"
+        }
       },
       "verb": "PUT",
       "framework": "drf",
       "source_file": "apps/orders/views.py",
       "start_line": 70,
-      "language": "python"
+      "language": "python",
+      "has_docs": false
     },
     {
       "entity": {
@@ -49,13 +61,18 @@
         "start_line": 100,
         "end_line": 125,
         "language": "python",
-        "repo": "core-api"
+        "repo": "core-api",
+        "properties": {
+          "auth": "IsAuthenticated",
+          "parameters": "pk:path:integer"
+        }
       },
       "verb": "PATCH",
       "framework": "drf",
       "source_file": "apps/orders/views.py",
       "start_line": 100,
-      "language": "python"
+      "language": "python",
+      "has_docs": false
     },
     {
       "entity": {
@@ -67,13 +84,17 @@
         "start_line": 127,
         "end_line": 145,
         "language": "python",
-        "repo": "core-api"
+        "repo": "core-api",
+        "properties": {
+          "auth": "IsAuthenticated, IsOrderOwner"
+        }
       },
       "verb": "DELETE",
       "framework": "drf",
       "source_file": "apps/orders/views.py",
       "start_line": 127,
-      "language": "python"
+      "language": "python",
+      "has_docs": false
     }
   ],
   "response_shapes": [
@@ -146,6 +167,28 @@
       "source_file": "apps/orders/serializers.py",
       "start_line": 18,
       "end_line": 22,
+      "language": "python",
+      "repo": "core-api"
+    },
+    {
+      "id": "core-api::0001aabb00030003",
+      "label": "order_status_changed",
+      "qualified_name": "apps.orders.events.order_status_changed",
+      "kind": "Event",
+      "source_file": "apps/orders/signals.py",
+      "start_line": 12,
+      "end_line": 18,
+      "language": "python",
+      "repo": "core-api"
+    },
+    {
+      "id": "core-api::0001aabb00030004",
+      "label": "test_order_retrieve",
+      "qualified_name": "apps.orders.tests.test_order_retrieve",
+      "kind": "Function",
+      "source_file": "apps/orders/tests/test_views.py",
+      "start_line": 88,
+      "end_line": 110,
       "language": "python",
       "repo": "core-api"
     }

--- a/dashboard/src/components/paths/PathDetailPage.tsx
+++ b/dashboard/src/components/paths/PathDetailPage.tsx
@@ -1,6 +1,10 @@
+import { useState } from 'react'
 import { useParams } from 'react-router-dom'
-import * as Tabs from '@radix-ui/react-tabs'
-import { ExternalLink, Webhook, Database, ArrowDownLeft, ArrowUpRight } from 'lucide-react'
+import {
+  Webhook, Lock, LockOpen, ChevronDown, ChevronRight,
+  ArrowDownLeft, ArrowUpRight, Database, Zap, TestTube2,
+  FileCode2, Info, ExternalLink,
+} from 'lucide-react'
 import { usePathDetail } from '@/hooks/paths/usePathDetail'
 import { VerbChip } from '@/components/shared/VerbChip'
 import { KindBadge } from '@/components/shared/KindBadge'
@@ -9,11 +13,476 @@ import { EmptyState } from '@/components/shared/EmptyState'
 import { CardSkeleton } from '@/components/shared/LoadingState'
 import { MultiImplBanner } from './MultiImplBanner'
 import { splitPathParts } from '@/lib/pathUtils'
-import type { HandlerDetail, ResponseShape } from '@/types/api'
+import type { Entity, HandlerDetail, HttpVerb, ResponseShape } from '@/types/api'
 
 interface PathDetailPageProps {
   group: string
 }
+
+// ─── Collapsible section wrapper ─────────────────────────────────────────────
+
+interface SectionProps {
+  id: string
+  title: string
+  icon: React.ReactNode
+  count?: number
+  defaultOpen?: boolean
+  children: React.ReactNode
+}
+
+function Section({ id, title, icon, count, defaultOpen = true, children }: SectionProps) {
+  const [open, setOpen] = useState(defaultOpen)
+  return (
+    <section aria-labelledby={`section-${id}`} className="border-b border-slate-200 dark:border-slate-800 last:border-b-0">
+      <button
+        type="button"
+        id={`section-${id}`}
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+        className="w-full flex items-center gap-2 px-6 py-3 text-sm font-semibold text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-900/50 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500"
+      >
+        <span className="text-slate-400 dark:text-slate-500 flex-shrink-0">{icon}</span>
+        <span className="flex-1 text-left">{title}</span>
+        {count !== undefined && count > 0 && (
+          <span className="inline-flex items-center justify-center min-w-[20px] px-1.5 py-0.5 text-[10px] rounded-full bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400">
+            {count}
+          </span>
+        )}
+        {open
+          ? <ChevronDown className="w-4 h-4 text-slate-400 flex-shrink-0" aria-hidden />
+          : <ChevronRight className="w-4 h-4 text-slate-400 flex-shrink-0" aria-hidden />
+        }
+      </button>
+      {open && <div className="px-6 pb-5 pt-1">{children}</div>}
+    </section>
+  )
+}
+
+// ─── AI Summary section ───────────────────────────────────────────────────────
+
+function AISummarySection({ handlers }: { handlers: HandlerDetail[] }) {
+  // Use the first handler that has docs; otherwise show the hint.
+  const withDocs = handlers.find((h) => h.has_docs && h.docs_summary)
+
+  return (
+    <Section id="description" title="Description" icon={<Info className="w-4 h-4" />} defaultOpen>
+      {withDocs ? (
+        <p className="text-sm text-slate-700 dark:text-slate-300 leading-relaxed">
+          {withDocs.docs_summary}
+        </p>
+      ) : (
+        <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800">
+          <Info className="w-4 h-4 text-slate-400 flex-shrink-0 mt-0.5" aria-hidden />
+          <p className="text-sm text-slate-400 dark:text-slate-500 italic">
+            No documentation generated yet. Run{' '}
+            <code className="font-mono text-xs text-sky-500 dark:text-sky-400">/generate-docs</code>{' '}
+            in Claude Code to enable AI summaries.
+          </p>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+// ─── Parameters table ─────────────────────────────────────────────────────────
+
+interface Param {
+  name: string
+  location: 'path' | 'query' | 'body'
+  type: string
+}
+
+function parseParams(handlers: HandlerDetail[]): Param[] {
+  const seen = new Set<string>()
+  const params: Param[] = []
+  for (const h of handlers) {
+    const raw = (h.entity.properties?.parameters as string | undefined) ?? ''
+    if (!raw) continue
+    for (const segment of raw.split(',')) {
+      const parts = segment.trim().split(':')
+      if (parts.length < 2) continue
+      const [name, location, type = 'string'] = parts
+      const key = `${name}:${location}`
+      if (!seen.has(key)) {
+        seen.add(key)
+        params.push({ name, location: location as Param['location'], type })
+      }
+    }
+  }
+  return params
+}
+
+const LOCATION_BADGE: Record<Param['location'], string> = {
+  path:  'bg-violet-900/30 text-violet-300 border-violet-700',
+  query: 'bg-sky-900/30 text-sky-300 border-sky-700',
+  body:  'bg-teal-900/30 text-teal-300 border-teal-700',
+}
+
+function ParametersSection({ handlers }: { handlers: HandlerDetail[] }) {
+  const params = parseParams(handlers)
+  return (
+    <Section id="parameters" title="Parameters" icon={<FileCode2 className="w-4 h-4" />} count={params.length} defaultOpen>
+      {params.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">No parameters extracted.</p>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm border-collapse">
+            <thead>
+              <tr className="text-left text-xs text-slate-400 dark:text-slate-500 border-b border-slate-200 dark:border-slate-800">
+                <th className="py-1.5 pr-4 font-medium">Name</th>
+                <th className="py-1.5 pr-4 font-medium">In</th>
+                <th className="py-1.5 font-medium">Type</th>
+              </tr>
+            </thead>
+            <tbody>
+              {params.map((p) => (
+                <tr
+                  key={`${p.name}-${p.location}`}
+                  className="border-b border-slate-100 dark:border-slate-900 last:border-b-0"
+                >
+                  <td className="py-2 pr-4 font-mono text-slate-800 dark:text-slate-200 text-xs">{p.name}</td>
+                  <td className="py-2 pr-4">
+                    <span className={`inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold border ${LOCATION_BADGE[p.location]}`}>
+                      {p.location}
+                    </span>
+                  </td>
+                  <td className="py-2 text-xs text-slate-500 dark:text-slate-400 font-mono">{p.type}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </Section>
+  )
+}
+
+// ─── Response shapes section ──────────────────────────────────────────────────
+
+function statusCodeClass(code: number): string {
+  if (code < 300) return 'bg-emerald-900/40 text-emerald-300 border-emerald-700'
+  if (code < 400) return 'bg-yellow-900/40 text-yellow-300 border-yellow-700'
+  return 'bg-red-900/40 text-red-300 border-red-700'
+}
+
+function ResponseShapeCard({ shape }: { shape: ResponseShape }) {
+  const [expanded, setExpanded] = useState(false)
+  const hasKeys = shape.keys.length > 0
+
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+      <button
+        type="button"
+        aria-expanded={expanded}
+        onClick={() => setExpanded((v) => !v)}
+        className="w-full flex items-center gap-2 px-3 py-2.5 bg-slate-50 dark:bg-slate-900/60 hover:bg-slate-100 dark:hover:bg-slate-900 transition-colors focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500"
+      >
+        <VerbChip verb={shape.verb} />
+        <div className="flex gap-1 flex-wrap">
+          {shape.status_codes.map((code) => (
+            <span key={code} className={`px-1.5 py-0.5 rounded text-xs font-mono font-bold border ${statusCodeClass(code)}`}>
+              {code}
+            </span>
+          ))}
+        </div>
+        {shape.dynamic && (
+          <span className="ml-auto text-xs text-amber-400 italic">dynamic</span>
+        )}
+        {!shape.dynamic && (
+          <span className="ml-auto text-xs text-slate-400">{shape.keys.length} fields</span>
+        )}
+        {expanded
+          ? <ChevronDown className="w-3.5 h-3.5 text-slate-400 flex-shrink-0" aria-hidden />
+          : <ChevronRight className="w-3.5 h-3.5 text-slate-400 flex-shrink-0" aria-hidden />
+        }
+      </button>
+      {expanded && (
+        <div className="px-3 py-3 border-t border-slate-200 dark:border-slate-800 bg-white dark:bg-slate-950">
+          {hasKeys ? (
+            <div className="flex flex-wrap gap-1.5">
+              {shape.keys.map((key) => (
+                <code
+                  key={key}
+                  className="px-2 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-xs font-mono border border-slate-300 dark:border-slate-700"
+                >
+                  {key}
+                </code>
+              ))}
+            </div>
+          ) : (
+            <p className="text-xs text-slate-400 dark:text-slate-500 italic">
+              {shape.dynamic ? 'Response shape determined at runtime.' : 'Empty response body.'}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function ResponseShapesSection({ shapes }: { shapes: ResponseShape[] }) {
+  return (
+    <Section id="responses" title="Response shapes" icon={<ArrowUpRight className="w-4 h-4" />} count={shapes.length} defaultOpen>
+      {shapes.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">Response shapes could not be statically determined.</p>
+      ) : (
+        <div className="space-y-2">
+          {shapes.map((shape, i) => <ResponseShapeCard key={i} shape={shape} />)}
+        </div>
+      )}
+    </Section>
+  )
+}
+
+// ─── Called-by section ────────────────────────────────────────────────────────
+
+function CalledBySection({ entities }: { entities: Entity[] }) {
+  return (
+    <Section
+      id="called-by"
+      title="Called by"
+      icon={<ArrowDownLeft className="w-4 h-4" />}
+      count={entities.length}
+      defaultOpen={entities.length > 0}
+    >
+      {entities.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">No inbound callers detected.</p>
+      ) : (
+        <ul className="space-y-1.5" role="list">
+          {entities.map((e) => (
+            <li
+              key={e.id}
+              className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+            >
+              <KindBadge kind={e.kind} />
+              <span className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate" title={e.label}>
+                {e.label}
+              </span>
+              <span className="font-mono text-[10px] text-slate-400 dark:text-slate-500 flex-shrink-0 hidden sm:block">
+                {e.source_file}:{e.start_line}
+              </span>
+              <RepoChip repo={e.repo} />
+              <a
+                href={`#entity-${e.id}`}
+                title={`Inspect ${e.label}`}
+                className="flex-shrink-0 text-sky-400 hover:text-sky-300 transition-colors"
+                aria-label={`Inspect ${e.label}`}
+              >
+                <ExternalLink className="w-3.5 h-3.5" />
+              </a>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  )
+}
+
+// ─── Downstream section ───────────────────────────────────────────────────────
+
+type DownstreamKind = 'db' | 'event' | 'queue' | 'http' | 'grpc' | 'other'
+
+function classifyDownstream(e: Entity): DownstreamKind {
+  const k = e.kind
+  if (k === 'DataAccess' || k === 'Datastore') return 'db'
+  if (k === 'Event' || k === 'MessageTopic') return 'event'
+  if (k === 'Queue') return 'queue'
+  if (k === 'ExternalAPI') return 'http'
+  if (k === 'Service') return 'grpc'
+  return 'other'
+}
+
+const DOWNSTREAM_ICONS: Record<DownstreamKind, React.ReactNode> = {
+  db:    <Database className="w-3.5 h-3.5 text-amber-400" aria-hidden />,
+  event: <Zap className="w-3.5 h-3.5 text-pink-400" aria-hidden />,
+  queue: <ArrowUpRight className="w-3.5 h-3.5 text-rose-400" aria-hidden />,
+  http:  <ExternalLink className="w-3.5 h-3.5 text-sky-400" aria-hidden />,
+  grpc:  <ArrowUpRight className="w-3.5 h-3.5 text-indigo-400" aria-hidden />,
+  other: <ArrowUpRight className="w-3.5 h-3.5 text-slate-400" aria-hidden />,
+}
+
+const DOWNSTREAM_LABELS: Record<DownstreamKind, string> = {
+  db:    'DB',
+  event: 'Event',
+  queue: 'Queue',
+  http:  'HTTP',
+  grpc:  'gRPC',
+  other: '',
+}
+
+function DownstreamSection({ entities }: { entities: Entity[] }) {
+  // Group by kind
+  const groups = entities.reduce<Record<DownstreamKind, Entity[]>>((acc, e) => {
+    const dk = classifyDownstream(e)
+    if (!acc[dk]) acc[dk] = []
+    acc[dk].push(e)
+    return acc
+  }, {} as Record<DownstreamKind, Entity[]>)
+
+  const order: DownstreamKind[] = ['db', 'queue', 'event', 'http', 'grpc', 'other']
+
+  return (
+    <Section
+      id="downstream"
+      title="Downstream"
+      icon={<ArrowUpRight className="w-4 h-4" />}
+      count={entities.length}
+      defaultOpen={entities.length > 0}
+    >
+      {entities.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">No downstream dependencies detected.</p>
+      ) : (
+        <div className="space-y-3">
+          {order.filter((dk) => (groups[dk] ?? []).length > 0).map((dk) => (
+            <div key={dk}>
+              {DOWNSTREAM_LABELS[dk] && (
+                <div className="flex items-center gap-1.5 mb-1.5 text-xs font-semibold text-slate-400 dark:text-slate-500 uppercase tracking-wide">
+                  {DOWNSTREAM_ICONS[dk]}
+                  {DOWNSTREAM_LABELS[dk]}
+                </div>
+              )}
+              <ul className="space-y-1" role="list">
+                {(groups[dk] ?? []).map((e) => (
+                  <li
+                    key={e.id}
+                    className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+                  >
+                    {DOWNSTREAM_ICONS[dk]}
+                    <span className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate" title={e.label}>
+                      {e.label}
+                    </span>
+                    <span className="font-mono text-[10px] text-slate-400 dark:text-slate-500 flex-shrink-0 hidden sm:block">
+                      {e.source_file}:{e.start_line}
+                    </span>
+                    <RepoChip repo={e.repo} />
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+      )}
+    </Section>
+  )
+}
+
+// ─── Side-effects section (Events emitted) ────────────────────────────────────
+
+function SideEffectsSection({ entities }: { entities: Entity[] }) {
+  const events = entities.filter((e) => e.kind === 'Event' || e.kind === 'MessageTopic')
+  return (
+    <Section
+      id="side-effects"
+      title="Side effects"
+      icon={<Zap className="w-4 h-4" />}
+      count={events.length}
+      defaultOpen={false}
+    >
+      {events.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">No events emitted.</p>
+      ) : (
+        <ul className="space-y-1.5" role="list">
+          {events.map((e) => (
+            <li
+              key={e.id}
+              className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+            >
+              <Zap className="w-3.5 h-3.5 text-pink-400 flex-shrink-0" aria-hidden />
+              <span className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate" title={e.label}>
+                {e.label}
+              </span>
+              <RepoChip repo={e.repo} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  )
+}
+
+// ─── Tests section ────────────────────────────────────────────────────────────
+
+function TestsSection({ entities }: { entities: Entity[] }) {
+  const tests = entities.filter((e) => {
+    const lbl = e.label.toLowerCase()
+    const file = e.source_file.toLowerCase()
+    return lbl.startsWith('test') || file.includes('test') || file.includes('spec') || e.kind === 'Function' && (lbl.includes('_test') || lbl.includes('test_'))
+  })
+
+  return (
+    <Section
+      id="tests"
+      title="Tests"
+      icon={<TestTube2 className="w-4 h-4" />}
+      count={tests.length}
+      defaultOpen={false}
+    >
+      {tests.length === 0 ? (
+        <p className="text-xs text-slate-400 dark:text-slate-500 italic">No test coverage detected via TESTS edges.</p>
+      ) : (
+        <ul className="space-y-1.5" role="list">
+          {tests.map((e) => (
+            <li
+              key={e.id}
+              className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+            >
+              <TestTube2 className="w-3.5 h-3.5 text-emerald-400 flex-shrink-0" aria-hidden />
+              <span className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate" title={e.label}>
+                {e.label}
+              </span>
+              <span className="font-mono text-[10px] text-slate-400 dark:text-slate-500 hidden sm:block">
+                {e.source_file}:{e.start_line}
+              </span>
+              <RepoChip repo={e.repo} />
+            </li>
+          ))}
+        </ul>
+      )}
+    </Section>
+  )
+}
+
+// ─── Source section ───────────────────────────────────────────────────────────
+
+function SourceSection({ handlers }: { handlers: HandlerDetail[] }) {
+  return (
+    <Section id="source" title="Source" icon={<FileCode2 className="w-4 h-4" />} defaultOpen>
+      <ul className="space-y-2" role="list">
+        {handlers.map((h, i) => (
+          <li
+            key={i}
+            className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
+          >
+            <VerbChip verb={h.verb} />
+            <span
+              className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate"
+              title={`${h.source_file}:${h.start_line}`}
+            >
+              {h.source_file}
+              <span className="text-slate-400 dark:text-slate-500">:{h.start_line}</span>
+            </span>
+            {h.framework && (
+              <span className="text-[10px] text-slate-400 dark:text-slate-500 font-mono hidden sm:block">{h.framework}</span>
+            )}
+            <RepoChip repo={h.entity.repo} />
+          </li>
+        ))}
+      </ul>
+    </Section>
+  )
+}
+
+// ─── Auth badge helpers ───────────────────────────────────────────────────────
+
+function extractAuth(handlers: HandlerDetail[]): string | null {
+  for (const h of handlers) {
+    const auth = h.entity.properties?.auth as string | undefined
+    if (auth) return auth
+  }
+  return null
+}
+
+// ─── Main component ───────────────────────────────────────────────────────────
 
 export function PathDetailPage({ group }: PathDetailPageProps) {
   const { pathHash } = useParams<{ pathHash: string }>()
@@ -31,204 +500,122 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
   }
 
   const pathParts = splitPathParts(data.path)
+  const authInfo = extractAuth(data.handlers)
+
+  // Split outbound_queries into downstream + events + tests for display
+  const downstreamEntities = data.outbound_queries.filter(
+    (e) => e.kind !== 'Event' && e.kind !== 'MessageTopic' && !isTestEntity(e),
+  )
+  const sideEffectEntities = data.outbound_queries.filter(
+    (e) => e.kind === 'Event' || e.kind === 'MessageTopic',
+  )
+  const testEntities = data.outbound_queries.filter(isTestEntity)
 
   return (
     <div className="flex flex-col h-full overflow-hidden">
-      {/* Header */}
-      <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-900/80">
+
+      {/* ── Header ────────────────────────────────────────────────────────── */}
+      <div className="px-6 py-4 border-b border-slate-200 dark:border-slate-800 bg-slate-100/80 dark:bg-slate-900/80 flex-shrink-0">
         <div className="flex items-start gap-3 flex-wrap">
-          <h1 className="font-mono text-base font-semibold text-slate-800 dark:text-slate-200 flex-1 min-w-0">
+          {/* Verb chips */}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
+            {(data.verbs as HttpVerb[]).map((v) => <VerbChip key={v} verb={v} />)}
+          </div>
+
+          {/* Path */}
+          <h1 className="font-mono text-sm font-semibold text-slate-800 dark:text-slate-200 flex-1 min-w-0 mt-0.5">
             {pathParts.map((part, i) => (
               <span key={i} className={part.isDynamic ? 'text-amber-400' : ''}>
                 {part.text}
               </span>
             ))}
           </h1>
-          <div className="flex items-center gap-2 flex-shrink-0">
-            {data.verbs.map((v) => <VerbChip key={v} verb={v} />)}
+
+          {/* Badges: webhook, auth */}
+          <div className="flex items-center gap-1.5 flex-shrink-0">
             {data.is_webhook && (
               <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-violet-900/40 text-violet-300 border border-violet-700">
-                <Webhook className="w-3 h-3" />
+                <Webhook className="w-3 h-3" aria-hidden />
                 {data.webhook_provider ?? 'webhook'}
+              </span>
+            )}
+            {authInfo ? (
+              <span
+                title={`Auth: ${authInfo}`}
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-emerald-900/30 text-emerald-300 border border-emerald-800"
+                aria-label={`Auth required: ${authInfo}`}
+              >
+                <Lock className="w-3 h-3" aria-hidden />
+                Auth
+              </span>
+            ) : (
+              <span
+                className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs bg-slate-800/40 text-slate-500 border border-slate-700"
+                aria-label="No auth decorator detected"
+              >
+                <LockOpen className="w-3 h-3" aria-hidden />
+                No auth
               </span>
             )}
           </div>
         </div>
-        <div className="mt-1 text-xs text-slate-400 dark:text-slate-500 font-mono">{data.path_hash}</div>
+
+        {/* Repo pills */}
+        <div className="mt-2 flex items-center gap-1.5 flex-wrap">
+          {Array.from(new Set(data.handlers.map((h) => h.entity.repo))).map((repo) => (
+            <RepoChip key={repo} repo={repo} />
+          ))}
+          <span className="text-[10px] font-mono text-slate-400 dark:text-slate-600 ml-1 hidden sm:block">
+            {data.path_hash}
+          </span>
+        </div>
       </div>
 
       {/* Multi-impl banner */}
       <MultiImplBanner count={data.handlers.length} path={data.path} />
 
-      {/* Tabs */}
-      <Tabs.Root defaultValue="handlers" className="flex flex-col flex-1 overflow-hidden">
-        <Tabs.List
-          className="flex border-b border-slate-200 dark:border-slate-800 px-6 bg-slate-100/60 dark:bg-slate-900/60"
-          aria-label="Path detail sections"
-        >
-          <TabTrigger value="handlers">
-            Handlers ({data.handlers.length})
-          </TabTrigger>
-          <TabTrigger value="responses">
-            Response shapes ({data.response_shapes.length})
-          </TabTrigger>
-          <TabTrigger value="inbound">
-            Inbound ({data.inbound_fetches.length})
-          </TabTrigger>
-          <TabTrigger value="outbound">
-            Outbound ({data.outbound_queries.length})
-          </TabTrigger>
-        </Tabs.List>
+      {/* ── Scrollable body ───────────────────────────────────────────────── */}
+      <div className="flex-1 overflow-y-auto divide-y-0">
 
-        <div className="flex-1 overflow-y-auto">
-          {/* Handlers tab */}
-          <Tabs.Content value="handlers" className="p-6 space-y-4">
-            {data.handlers.length === 0 ? (
-              <EmptyState title="No handlers found" />
-            ) : (
-              data.handlers.map((h, i) => <HandlerCard key={i} handler={h} />)
-            )}
-          </Tabs.Content>
+        {/* Description / AI Summary */}
+        <AISummarySection handlers={data.handlers} />
 
-          {/* Response shapes tab */}
-          <Tabs.Content value="responses" className="p-6 space-y-4">
-            {data.response_shapes.length === 0 ? (
-              <EmptyState title="No response shapes extracted" message="Response shapes could not be statically determined." />
-            ) : (
-              data.response_shapes.map((shape, i) => <ResponseShapeCard key={i} shape={shape} />)
-            )}
-          </Tabs.Content>
+        {/* Parameters */}
+        <ParametersSection handlers={data.handlers} />
 
-          {/* Inbound fetches tab */}
-          <Tabs.Content value="inbound" className="p-6">
-            {data.inbound_fetches.length === 0 ? (
-              <EmptyState
-                icon={ArrowDownLeft}
-                title="No inbound fetches"
-                message="No other services or functions were detected calling this path."
-              />
-            ) : (
-              <ul className="space-y-2">
-                {data.inbound_fetches.map((e) => (
-                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800">
-                    <KindBadge kind={e.kind} />
-                    <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">{e.label}</span>
-                    <RepoChip repo={e.repo} />
-                    <a
-                      href={`#entity-${e.id}`}
-                      className="text-xs text-sky-400 hover:underline flex items-center gap-0.5"
-                    >
-                      <ExternalLink className="w-3 h-3" />
-                      Inspect
-                    </a>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Tabs.Content>
+        {/* Response shapes */}
+        <ResponseShapesSection shapes={data.response_shapes} />
 
-          {/* Outbound queries tab */}
-          <Tabs.Content value="outbound" className="p-6">
-            {data.outbound_queries.length === 0 ? (
-              <EmptyState
-                icon={ArrowUpRight}
-                title="No outbound queries"
-                message="No database queries were detected from this handler."
-              />
-            ) : (
-              <ul className="space-y-2">
-                {data.outbound_queries.map((e) => (
-                  <li key={e.id} className="flex items-center gap-3 px-3 py-2 rounded-lg bg-slate-100 dark:bg-slate-900 border border-slate-200 dark:border-slate-800">
-                    <Database className="w-4 h-4 text-amber-400" aria-hidden />
-                    <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">{e.label}</span>
-                    <RepoChip repo={e.repo} />
-                  </li>
-                ))}
-              </ul>
-            )}
-          </Tabs.Content>
-        </div>
-      </Tabs.Root>
-    </div>
-  )
-}
+        {/* Called by */}
+        <CalledBySection entities={data.inbound_fetches} />
 
-function TabTrigger({ value, children }: { value: string; children: React.ReactNode }) {
-  return (
-    <Tabs.Trigger
-      value={value}
-      className={[
-        'px-4 py-2.5 text-sm border-b-2 border-transparent transition-colors',
-        'text-slate-400 dark:text-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
-        'data-[state=active]:border-sky-500 data-[state=active]:text-slate-800 dark:data-[state=active]:text-slate-200',
-        'focus:outline-none focus-visible:ring-1 focus-visible:ring-sky-500',
-      ].join(' ')}
-    >
-      {children}
-    </Tabs.Trigger>
-  )
-}
+        {/* Downstream */}
+        <DownstreamSection entities={downstreamEntities} />
 
-function HandlerCard({ handler }: { handler: HandlerDetail }) {
-  return (
-    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100 dark:bg-slate-900 overflow-hidden">
-      <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-800">
-        <VerbChip verb={handler.verb} />
-        <KindBadge kind={handler.entity.kind} />
-        <span className="font-mono text-sm text-slate-700 dark:text-slate-300 flex-1 truncate">
-          {handler.entity.label}
-        </span>
-        <RepoChip repo={handler.entity.repo} />
-      </div>
-      <div className="px-4 py-2 text-xs text-slate-400 dark:text-slate-500 font-mono">
-        {handler.source_file}:{handler.start_line}
+        {/* Side effects */}
+        <SideEffectsSection entities={sideEffectEntities} />
+
+        {/* Tests */}
+        <TestsSection entities={testEntities} />
+
+        {/* Source */}
+        <SourceSection handlers={data.handlers} />
+
       </div>
     </div>
   )
 }
 
-function ResponseShapeCard({ shape }: { shape: ResponseShape }) {
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function isTestEntity(e: Entity): boolean {
+  const lbl = e.label.toLowerCase()
+  const file = e.source_file.toLowerCase()
   return (
-    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-100 dark:bg-slate-900 p-4">
-      <div className="flex items-center gap-2 mb-3">
-        <VerbChip verb={shape.verb} />
-        <div className="flex gap-1">
-          {shape.status_codes.map((code) => (
-            <span
-              key={code}
-              className={[
-                'px-1.5 py-0.5 rounded text-xs font-mono font-bold',
-                code < 300
-                  ? 'bg-emerald-900/40 text-emerald-300'
-                  : code < 400
-                    ? 'bg-yellow-900/40 text-yellow-300'
-                    : 'bg-red-900/40 text-red-300',
-              ].join(' ')}
-            >
-              {code}
-            </span>
-          ))}
-        </div>
-        {shape.dynamic && (
-          <span className="ml-auto text-xs text-amber-400 italic">dynamic response</span>
-        )}
-      </div>
-      {shape.keys.length > 0 ? (
-        <div className="flex flex-wrap gap-1.5">
-          {shape.keys.map((key) => (
-            <code
-              key={key}
-              className="px-2 py-0.5 rounded bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300 text-xs font-mono border border-slate-300 dark:border-slate-700"
-            >
-              {key}
-            </code>
-          ))}
-        </div>
-      ) : (
-        <p className="text-xs text-slate-400 dark:text-slate-500 italic">
-          {shape.dynamic ? 'Response shape determined at runtime.' : 'Empty response body.'}
-        </p>
-      )}
-    </div>
+    lbl.startsWith('test') ||
+    lbl.includes('_test') ||
+    lbl.includes('test_') ||
+    file.includes('/test') ||
+    file.includes('/spec')
   )
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -208,6 +208,12 @@ export interface HandlerDetail {
   source_file: string
   start_line: number
   language: string
+  /** True when docgen has run and produced a summary for this handler */
+  has_docs?: boolean
+  /** AI-generated summary from /generate-docs */
+  docs_summary?: string
+  /** Path to the generated docs file */
+  docs_path?: string
 }
 
 export interface ResponseShape {


### PR DESCRIPTION
## Summary

Rewrites the Paths detail panel as a Swagger-UI-with-steroids view (no execution). Replaces the old 4-tab layout (Handlers / Response shapes / Inbound / Outbound) with a single-scroll sectioned panel that surfaces all available signals at a glance.

**Sections (all collapsible):**
- **Header** — verb chips + colored path (`{params}` in amber) + Auth badge (Lock when decorator detected, LockOpen when absent) + repo pills + path_hash
- **Description** — AI summary when `has_docs=true`; graceful hint ("Run `/generate-docs` in Claude Code") when false — no in-app run button
- **Parameters** — table parsed from `entity.properties.parameters` (name:location:type CSV) with color-coded location badges (path/query/body)
- **Response shapes** — collapsible chip-grid per verb, status codes color-coded (2xx emerald / 3xx yellow / 4xx red), click to expand field list
- **Called by** — `inbound_fetches` list with KindBadge + `file:line` + RepoChip + deep-link inspect icon
- **Downstream** — `outbound_queries` grouped by kind: DB / Event / Queue / HTTP / gRPC
- **Side effects** — Event / MessageTopic entities filtered from outbound_queries
- **Tests** — test entities detected by label/file naming convention
- **Source** — per-handler `file:line` + framework + repo

**Types:** `HandlerDetail` extended with optional `has_docs`, `docs_summary`, `docs_path` fields (matching backend #1098 shape).

**Dead code removed:** old `HandlerCard`, standalone `ResponseShapeCard`, `TabTrigger` helpers — all deleted.

## Closes / Refs

Closes #1094
Refs #1082

## Testing

- [x] `npx vite build` — clean build
- [x] Playwright headless (real daemon): `/paths/upvate` → clicked `/admin` → panel renders with "No documentation generated yet" hint, auth "No auth" badge, response shapes, source section — 0 console errors
- [x] Playwright headless (mocks): `/paths/fixture-a` → clicked `/api/v1/orders/{id}` → AI summary visible, parameters table (3 rows: pk/path/integer, status/body/string, shipping_address/body/object), 4 response shape cards (GET expanded = 8 fields), called-by 2 callers with deep-link, downstream 2 DB entries, side-effects 1 event, tests 1 entry, source 4 handlers
- [x] Auth badge: "Auth required: IsAuthenticated" rendered for handlers with auth decorator; "No auth" badge for endpoints without
- [x] Console errors: 0

## Notes

Parameters parsing is convention-based (`name:location:type` CSV in `entity.properties.parameters`). When the backend populates this field from decorator/schema inspection, the table auto-populates. When absent, section shows "No parameters extracted" gracefully.

Side-effects and Tests sections are derived from `outbound_queries` by entity kind / naming heuristic — no extra API call needed.