### PR TITLE
fix(paths): orphan callers empty list + frontend leak into Endpoints + Source→Defined in

### DIFF
--- a/dashboard/src/components/paths/PathDetailPage.tsx
+++ b/dashboard/src/components/paths/PathDetailPage.tsx
@@ -442,32 +442,41 @@ function TestsSection({ entities }: { entities: Entity[] }) {
   )
 }
 
-// ─── Source section ───────────────────────────────────────────────────────────
+// ─── Defined-in section (backend handler definitions only) ───────────────────
 
-function SourceSection({ handlers }: { handlers: HandlerDetail[] }) {
+function DefinedInSection({ handlers }: { handlers: HandlerDetail[] }) {
   return (
-    <Section id="source" title="Source" icon={<FileCode2 className="w-4 h-4" />} defaultOpen>
-      <ul className="space-y-2" role="list">
-        {handlers.map((h, i) => (
-          <li
-            key={i}
-            className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
-          >
-            <VerbChip verb={h.verb} />
-            <span
-              className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate"
-              title={`${h.source_file}:${h.start_line}`}
+    <Section id="defined-in" title="Defined in" icon={<FileCode2 className="w-4 h-4" />} count={handlers.length} defaultOpen>
+      {handlers.length === 0 ? (
+        <div className="flex items-start gap-2 px-3 py-2.5 rounded-lg bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800">
+          <Info className="w-4 h-4 text-amber-500 flex-shrink-0 mt-0.5" aria-hidden />
+          <p className="text-sm text-amber-700 dark:text-amber-300">
+            No backend handler found — this endpoint is an orphan call.
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-2" role="list">
+          {handlers.map((h, i) => (
+            <li
+              key={i}
+              className="flex items-center gap-2.5 px-3 py-2 rounded-lg bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-800"
             >
-              {h.source_file}
-              <span className="text-slate-400 dark:text-slate-500">:{h.start_line}</span>
-            </span>
-            {h.framework && (
-              <span className="text-[10px] text-slate-400 dark:text-slate-500 font-mono hidden sm:block">{h.framework}</span>
-            )}
-            <RepoChip repo={h.entity.repo} />
-          </li>
-        ))}
-      </ul>
+              <VerbChip verb={h.verb} />
+              <span
+                className="font-mono text-xs text-slate-700 dark:text-slate-300 flex-1 min-w-0 truncate"
+                title={`${h.source_file}:${h.start_line}`}
+              >
+                {h.source_file}
+                <span className="text-slate-400 dark:text-slate-500">:{h.start_line}</span>
+              </span>
+              {h.framework && (
+                <span className="text-[10px] text-slate-400 dark:text-slate-500 font-mono hidden sm:block">{h.framework}</span>
+              )}
+              <RepoChip repo={h.entity.repo} />
+            </li>
+          ))}
+        </ul>
+      )}
     </Section>
   )
 }
@@ -586,7 +595,10 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
         {/* Response shapes */}
         <ResponseShapesSection shapes={data.response_shapes} />
 
-        {/* Called by */}
+        {/* Defined in — backend handler definitions only */}
+        <DefinedInSection handlers={data.handlers} />
+
+        {/* Called by — frontend / service call sites that FETCHES this path */}
         <CalledBySection entities={data.inbound_fetches} />
 
         {/* Downstream */}
@@ -597,9 +609,6 @@ export function PathDetailPage({ group }: PathDetailPageProps) {
 
         {/* Tests */}
         <TestsSection entities={testEntities} />
-
-        {/* Source */}
-        <SourceSection handlers={data.handlers} />
 
       </div>
     </div>

--- a/internal/dashboard/handlers_orphan_callers.go
+++ b/internal/dashboard/handlers_orphan_callers.go
@@ -31,14 +31,14 @@ import (
 
 // OrphanCallerRow is one unresolved call site returned by the endpoint.
 type OrphanCallerRow struct {
-	CallerID           string `json:"caller_id"`
-	CallerFile         string `json:"caller_file"`
-	CallerLine         int    `json:"caller_line"`
-	URLPattern         string `json:"url_pattern"`
-	Method             string `json:"method"`
-	Reason             string `json:"reason"`
+	ID                  string `json:"id"`
+	CallerFile          string `json:"caller_file"`
+	CallerLine          int    `json:"caller_line"`
+	URLPattern          string `json:"url_pattern"`
+	Method              string `json:"method"`
+	Reason              string `json:"reason"`
 	SuggestedRepairKind string `json:"suggested_repair_kind"`
-	Repo               string `json:"repo"`
+	Repo                string `json:"repo"`
 }
 
 // orphanCallerReason classifies why a FETCHES edge could not be resolved.
@@ -79,8 +79,8 @@ func (s *Server) handleOrphanCallers(w http.ResponseWriter, r *http.Request) {
 	rows := collectOrphanCallers(grp)
 
 	writeJSON(w, http.StatusOK, map[string]any{
-		"orphan_callers": rows,
-		"total":          len(rows),
+		"callers": rows,
+		"total":   len(rows),
 	})
 }
 
@@ -211,7 +211,7 @@ func collectOrphanCallers(grp *DashGroup) []OrphanCallerRow {
 			repairKind := suggestedRepair[reason]
 
 			rows = append(rows, OrphanCallerRow{
-				CallerID:            callerID,
+				ID:                  callerID,
 				CallerFile:          callerFile,
 				CallerLine:          callerLine,
 				URLPattern:          urlPattern,

--- a/internal/dashboard/handlers_orphan_callers_test.go
+++ b/internal/dashboard/handlers_orphan_callers_test.go
@@ -79,8 +79,8 @@ func TestCollectOrphanCallers_NoHandlerFound(t *testing.T) {
 	if r.SuggestedRepairKind != "add_missing_handler" {
 		t.Errorf("suggested_repair_kind: want add_missing_handler, got %q", r.SuggestedRepairKind)
 	}
-	if r.CallerID != "frontend::caller_fn" {
-		t.Errorf("caller_id: want frontend::caller_fn, got %q", r.CallerID)
+	if r.ID != "frontend::caller_fn" {
+		t.Errorf("id: want frontend::caller_fn, got %q", r.ID)
 	}
 }
 
@@ -363,8 +363,8 @@ func TestHandleOrphanCallers_HTTPSmoke(t *testing.T) {
 
 	b, _ := io.ReadAll(resp.Body)
 	var body struct {
-		OrphanCallers []OrphanCallerRow `json:"orphan_callers"`
-		Total         int               `json:"total"`
+		Callers []OrphanCallerRow `json:"callers"`
+		Total   int               `json:"total"`
 	}
 	if err := json.Unmarshal(b, &body); err != nil {
 		t.Fatalf("decode response: %v\nbody: %s", err, b)
@@ -373,11 +373,11 @@ func TestHandleOrphanCallers_HTTPSmoke(t *testing.T) {
 	if body.Total != 1 {
 		t.Errorf("total: want 1, got %d", body.Total)
 	}
-	if len(body.OrphanCallers) != 1 {
-		t.Fatalf("orphan_callers len: want 1, got %d", len(body.OrphanCallers))
+	if len(body.Callers) != 1 {
+		t.Fatalf("callers len: want 1, got %d", len(body.Callers))
 	}
 
-	row := body.OrphanCallers[0]
+	row := body.Callers[0]
 	if row.Method != "DELETE" {
 		t.Errorf("method: want DELETE, got %q", row.Method)
 	}
@@ -427,9 +427,9 @@ func TestHandleOrphanCallers_EmptyResult(t *testing.T) {
 		t.Fatalf("decode: %v", err)
 	}
 
-	callers, ok := body["orphan_callers"]
+	callers, ok := body["callers"]
 	if !ok {
-		t.Fatal("orphan_callers key missing")
+		t.Fatal("callers key missing")
 	}
 	arr, ok := callers.([]any)
 	if !ok || len(arr) != 0 {

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -90,6 +90,11 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 				e.Kind != "Endpoint" && e.Kind != "Route" {
 				continue
 			}
+			// Skip frontend-only synthetic call-site entries — those belong
+			// in the Orphan Callers tab, not the Endpoints list.
+			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+				continue
+			}
 			path := e.Properties["path"]
 			if path == "" {
 				path = e.Name
@@ -248,6 +253,10 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 			e := &repo.Doc.Entities[i]
 			if !strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) &&
 				e.Kind != "Endpoint" && e.Kind != "Route" {
+				continue
+			}
+			// Skip frontend-only call-site synthetics — they are not real endpoints.
+			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
 				continue
 			}
 			path := e.Properties["path"]


### PR DESCRIPTION
## Summary

Three data-plumbing bugs in the Paths surface fixed in a single commit.

- **Bug 1 (#1109)** — Orphan Callers tab badge showed 634 but list rendered empty. Root cause: backend emitted `orphan_callers` JSON key but `OrphanCallersResponse` type expected `callers`; backend struct field was `caller_id` but `OrphanCaller` type expected `id`. Fixed by renaming both to match the declared contract. Tests updated.
- **Bug 2 (#1110)** — Frontend-only `http_endpoint_client_synthesis` entities leaked into the Endpoints list. Fixed by filtering `pattern_type == "http_endpoint_client_synthesis"` in both `handlePathsList` and `handlePathDetail`.
- **Bug 3 (#1111)** — Ambiguous "Source" section renamed to "Defined in" (backend handlers only). Added count badge and orphan-case helper text. Section moved before "Called by".

## Diagnosis

| Bug | Side | Root cause |
|-----|------|-----------|
| #1109 | Frontend | `orphan_callers` vs `callers` key mismatch; `caller_id` vs `id` field mismatch |
| #1110 | Backend | `handlePathsList` included all `http_endpoint` entities without filtering out `pattern_type=http_endpoint_client_synthesis` |
| #1111 | Frontend | `SourceSection` showed all handlers under "Source"; no label or empty-state separation |

## Changes

**Backend (`internal/dashboard/`)**
- `handlers_orphan_callers.go`: rename JSON response key `orphan_callers` → `callers`; rename struct field `CallerID` → `ID` (JSON: `caller_id` → `id`)
- `handlers_orphan_callers_test.go`: update assertions to use renamed fields/keys
- `handlers_paths.go`: add `pattern_type == "http_endpoint_client_synthesis"` skip guard in both list and detail handlers

**Frontend (`dashboard/src/`)**
- `components/paths/PathDetailPage.tsx`: rename `SourceSection` → `DefinedInSection`; add count badge; add amber helper text for orphan case; reorder sections (Defined in → Called by → Downstream → Side effects → Tests)

## Test plan

- [x] `go test ./internal/dashboard/...` — all 11 orphan-caller tests pass (`ok 1.034s`)
- [x] Vite build succeeds with zero errors in changed files
- [x] Playwright headless: Paths page loads, "Orphan Callers 634" badge renders, detail panel shows "Defined in" section with backend handler
- [ ] `atLeastOneJurisdictionHasMaintenanceEvaluation` absent from Endpoints list after binary rebuild

Closes #1109
Closes #1110
Closes #1111

🤖 Generated with [Claude Code](https://claude.com/claude-code)