### PR TITLE
fix(graph): four rendering pathologies — LoD threshold, Process pile-up, sizing, hash labels (#1121)

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -92,8 +92,8 @@ function buildRepoCenters(
  * small graphs (few high-degree nodes) still show something at overview.
  */
 const ZOOM_BANDS = [
-  { maxZoom: 0.5,      degreeMin: 50,  topN: 50,  label: 'overview', topLabels: 50 },
-  { maxZoom: 2.0,      degreeMin: 5,   topN: null, label: 'mid',      topLabels: 30 },
+  { maxZoom: 0.5,      degreeMin: 10,  topN: 150, label: 'overview', topLabels: 50 },
+  { maxZoom: 2.0,      degreeMin: 2,   topN: null, label: 'mid',      topLabels: 30 },
   { maxZoom: Infinity, degreeMin: 0,   topN: null, label: 'full',     topLabels: 20 },
 ] as const
 
@@ -335,6 +335,15 @@ const GraphCanvasInner = ({
     for (const n of nodes) { if ((n.pagerank ?? 0) > maxPR) maxPR = n.pagerank ?? 0 }
     if (maxPR === 0) maxPR = 1
 
+    // #1121 P2: per-repo entity count for proportional jitter radius.
+    // Flat ±50px collapses 600+ Process nodes into a single pixel blob.
+    // Radius = sqrt(repoEntityCount) × 8 so a 7000-entity repo spreads ~670px.
+    const repoEntityCount = new Map<string, number>()
+    for (const n of nodes) {
+      const repo = n.repo ?? ''
+      repoEntityCount.set(repo, (repoEntityCount.get(repo) ?? 0) + 1)
+    }
+
     return nodes.map((n, i) => {
       const repoIdx = repoToIdx.get(n.repo ?? '') ?? 0
       const cid = clusterIdFor(n, repoIdx)
@@ -345,13 +354,21 @@ const GraphCanvasInner = ({
       // each island into a single point rather than letting nodes spread naturally.
       const strength = 0.10 + normalizedPR * 0.08
       // #1089: pre-computed log-degree size for pointSizeByFn
-      const __size = computeSize(n.degree ?? 0)
+      // #1121 P3: Process entities use a flat small range — they have artificially
+      // high degree (aggregate all flow steps) so log-degree sizing maxes them out.
+      const __size = n.kind === 'Process'
+        ? 4 + Math.min((n.degree ?? 0) * 0.005, 6)  // 4–10 px flat range
+        : computeSize(n.degree ?? 0)
       // #1106: seed each node near its repo's canvas center so the sim starts in
       // the right region and converges without fighting a random-soup start state.
-      // Small jitter (±50px) prevents all nodes from stacking at the exact center.
+      // #1121 P2: jitter radius proportional to sqrt(entityCount) × 8 so large
+      // repos spread their 600+ Process nodes instead of stacking at center.
       const center = repoCenters.get(n.repo ?? '')
-      const __x = center ? center.x + (Math.random() * 100 - 50) : 0
-      const __y = center ? center.y + (Math.random() * 100 - 50) : 0
+      const jitterR = Math.sqrt(repoEntityCount.get(n.repo ?? '') ?? 1) * 8
+      const angle = Math.random() * 2 * Math.PI
+      const r = Math.random() * jitterR
+      const __x = center ? center.x + r * Math.cos(angle) : 0
+      const __y = center ? center.y + r * Math.sin(angle) : 0
       return { ...n, __idx: i, __cluster_id: cid, __cluster_strength: strength, __size, __x, __y }
     })
   // repoCenters and repoToIdx are derived from nodes — listing all three would

--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -9,8 +9,8 @@ package dashboard
 //
 // Three-tier graph data model:
 //
-//	Tier 1 (default): Compact render payload — nodes carry only id, repo,
-//	  degree, community_id. Edges carry source, target, kind.
+//	Tier 1 (default): Compact render payload — nodes carry id, repo, kind,
+//	  degree, community_id, and label (Process nodes only). Edges carry source, target, kind.
 //	  This is the only shape; there is no ?full= opt-in.
 //
 //	Tier 2: Labels endpoint — GET /api/graph/{group}/labels?top=200 returns
@@ -177,14 +177,24 @@ func (s *Server) serveGraphDense(w http.ResponseWriter, group string, repos []*D
 				continue
 			}
 			visible[pid] = true
-			// Tier 1 compact node: id, repo, degree, community_id only.
+			// Tier 1 compact node: id, repo, kind, degree, community_id.
+			// `kind` is included so the frontend can special-case Process sizing (#1121 P3)
+			// and `label` is included for Process entities so they never fall back to
+			// their hash ID in the Tier-2 top-200 labels window (#1121 P4).
 			node := map[string]any{
 				"id":   pid,
 				"repo": r.Slug,
+				"kind": dashStripScopePrefix(e.Kind),
 			}
 			node["degree"] = degreeMap[e.ID]
 			if e.CommunityID != nil {
 				node["community_id"] = *e.CommunityID
+			}
+			// Process entities carry their human label (entry → terminal) in e.Name.
+			// Include it inline so the frontend never falls back to the proc:<hash> ID.
+			// e.Kind is "SCOPE.Process" (the engine constant); strip prefix before comparing.
+			if dashStripScopePrefix(e.Kind) == "Process" {
+				node["label"] = e.Name
 			}
 			nodes = append(nodes, node)
 		}

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -377,7 +377,7 @@ func TestGraphLabels_UnknownGroup_404(t *testing.T) {
 	}
 }
 
-func TestGraph_LitePayload_NoLabelOrKind(t *testing.T) {
+func TestGraph_LitePayload_KindAlwaysLabelForProcess(t *testing.T) {
 	ts, _ := newPhase1Server(t)
 	code, body := getJSON(t, ts.URL, "/api/graph/testgroup")
 	if code != 200 {
@@ -387,15 +387,23 @@ func TestGraph_LitePayload_NoLabelOrKind(t *testing.T) {
 	if len(nodes) == 0 {
 		t.Fatalf("expected nodes")
 	}
-	// Tier 1 compact: nodes must NOT carry label, kind, source_file, pagerank.
+	// #1121: Tier 1 compact nodes now include `kind` for every node and `label`
+	// for Process nodes only. source_file and pagerank remain excluded.
 	for _, n := range nodes {
 		nm, _ := n.(map[string]any)
-		if nm["label"] != nil {
-			t.Errorf("Tier 1 node should not carry label field; got %v", nm["label"])
+		// kind is always present (#1121 P3 — frontend needs it for Process sizing)
+		if nm["kind"] == nil {
+			t.Errorf("Tier 1 node missing kind field; id=%v", nm["id"])
 		}
-		if nm["kind"] != nil {
-			t.Errorf("Tier 1 node should not carry kind field; got %v", nm["kind"])
+		// Process nodes carry label inline (#1121 P4 — avoid proc:<hash> fallback)
+		if nm["kind"] == "Process" && nm["label"] == nil {
+			t.Errorf("Tier 1 Process node missing label field; id=%v", nm["id"])
 		}
+		// Non-Process nodes must NOT carry label (kept compact)
+		if nm["kind"] != "Process" && nm["label"] != nil {
+			t.Errorf("Tier 1 non-Process node should not carry label field; kind=%v got label=%v", nm["kind"], nm["label"])
+		}
+		// source_file stays excluded
 		if nm["source_file"] != nil {
 			t.Errorf("Tier 1 node should not carry source_file field; got %v", nm["source_file"])
 		}


### PR DESCRIPTION
## Summary

Four graph rendering pathologies introduced after #1114 (repo-first layout) and #1120 (zoom LoD). All fixes verified via headless Playwright with 0 console errors.

- **P1 (frontend — LoD threshold):** `ZOOM_BANDS` overview band was `degreeMin:50, topN:50` — only ~3 upvate nodes have degree ≥ 50, producing a 3-dot degenerate view. Changed to `degreeMin:10, topN:150`; mid-band `degreeMin` 5→2.

- **P2 (frontend — Process pile-up):** Intra-repo jitter was flat ±50 px. With 626 Process nodes in core-mobile all starting within 100 px of the same center, they collapse into a single cyan blob. Jitter radius is now `sqrt(repoEntityCount) × 8` — ~670 px for a 7 000-entity repo.

- **P3 (frontend — Process node oversizing):** Process entities have artificially high degree (one `STEP_IN_PROCESS` edge per flow step). Combined with log-degree sizing they all hit the 80 px max. Process nodes now use a flat 4–10 px range.

- **P4 (backend — Process labels are hash IDs):** Tier-1 `/api/graph` payload did not include `kind` or `label`. Process nodes fell back to `n.id = "repo::proc:<hash>"`. Backend now includes `kind` for every node and `label` (= `entry → terminal` human name) inline for Process nodes only.

## Closes / Refs

Closes #1121

## Testing

- [x] `go test ./internal/dashboard/...` ✅ — `TestGraph_LitePayload_KindAlwaysLabelForProcess` (renamed + updated to assert new Tier-1 contract)
- [x] `vite build` ✅ — 28.57s, 0 errors
- [x] `go build ./cmd/archigraph` ✅
- [x] Headless Playwright: 3 distinct repo islands at zoom 0.3, 0 console errors
- [x] API spot-check: all 626 Process nodes carry `kind:"Process"` + `label:"AttachmentViewer → split"` (etc.), 0 without label
- [x] Pre-existing `internal/engine` duplicate-symbol failure confirmed on main, not introduced here

## Notes

- #1114 (repo islands) and #1120 (LoD bands) are untouched.
- P2 jitter uses uniform-disc polar coordinates instead of biased box jitter.
- Tier-1 `kind` field adds ~15 bytes/node (~300 KB for 19 860 nodes) — acceptable tradeoff.