### PR TITLE
[Topology v2] Backend: orphan publisher detector (#1136)

### DIFF
--- a/internal/dashboard/handlers_topology_orphans.go
+++ b/internal/dashboard/handlers_topology_orphans.go
@@ -1,0 +1,155 @@
+package dashboard
+
+// handlers_topology_orphans.go — Topology v2: orphan publisher detector (#1136).
+//
+//	GET /api/topology/{group}/orphan-publishers
+//
+// Returns every topic/queue/channel entity that has at least one producer
+// (PUBLISHES_TO / WS_EMITS / STREAMS_TO / GRAPHQL_PUBLISHES / WRITES_TO)
+// but zero consumers (SUBSCRIBES_TO / WS_SUBSCRIBES_TO / STREAMS_FROM /
+// GRAPHQL_SUBSCRIBES / READS_FROM) anywhere in the group.
+//
+// These are "fire-and-forget" message producers with no known listener —
+// a likely dead-letter or integration gap.
+//
+// Detection algorithm:
+//  1. Walk all entities in the group; keep only those whose topology bucket
+//     is topic, queue, channel, or subscription (nats_subjects and
+//     graphql_subscriptions share these buckets).
+//  2. For each such entity, collect producers and consumers using the same
+//     brokerEdges / channelEdges helpers already used by collectTopologyResponse.
+//  3. Emit a row when len(producers) > 0 && len(consumers) == 0.
+//  4. Entities with zero producers AND zero consumers are NOT emitted
+//     (those are orphan subscribers, a different endpoint).
+//
+// Wire shape:
+//
+//	{
+//	  "orphan_publishers": [
+//	    {
+//	      "id":        "repo::entityId",
+//	      "label":     "orders.created",
+//	      "broker":    "rabbitmq",
+//	      "framework": "",
+//	      "repo":      "backend",
+//	      "producers": ["repo::entityId1"],
+//	      "reason":    "no_subscriber_found"
+//	    }
+//	  ],
+//	  "total": N
+//	}
+//
+// All array fields marshal as [] (never null).
+
+import (
+	"net/http"
+	"sort"
+)
+
+// OrphanPublisherRow is one entity returned by the orphan-publisher endpoint.
+type OrphanPublisherRow struct {
+	ID        string   `json:"id"`
+	Label     string   `json:"label"`
+	Broker    string   `json:"broker"`
+	Framework string   `json:"framework"`
+	Repo      string   `json:"repo"`
+	Producers []string `json:"producers"`
+	Reason    string   `json:"reason"`
+}
+
+// orphanPublisherReason is the reason value surfaced to callers.
+const reasonNoSubscriberFound = "no_subscriber_found"
+
+// handleOrphanPublishers — GET /api/topology/{group}/orphan-publishers
+func (s *Server) handleOrphanPublishers(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	rows := collectOrphanPublishers(grp)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"orphan_publishers": rows,
+		"total":             len(rows),
+	})
+}
+
+// collectOrphanPublishers runs the orphan-publisher detection pass against a
+// loaded group. Extracted so unit tests can call it without HTTP scaffolding.
+func collectOrphanPublishers(grp *DashGroup) []OrphanPublisherRow {
+	var rows []OrphanPublisherRow
+
+	for _, r := range sortedRepos(grp) {
+		if r.Doc == nil {
+			continue
+		}
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			bucket := classifyTopologyBucket(e.Kind, e.Name, e.Properties)
+
+			// Only inspect buckets that use broker/channel semantics.
+			switch bucket {
+			case "topic", "queue", "channel", "subscription":
+				// handled below
+			default:
+				continue
+			}
+
+			var producers, consumers []string
+
+			switch bucket {
+			case "topic", "queue":
+				producers, consumers, _ = brokerEdges(r, e.ID)
+			case "channel":
+				producers, consumers = channelEdges(r, e.ID)
+			case "subscription":
+				producers, consumers = graphqlSubEdges(r, e.ID)
+			}
+
+			// Emit only when there is at least one producer and zero consumers.
+			if len(producers) == 0 || len(consumers) > 0 {
+				continue
+			}
+
+			broker := e.Properties["broker"]
+			if broker == "" {
+				broker = inferBrokerFromName(e.Name)
+			}
+			framework := e.Properties["framework"]
+
+			row := OrphanPublisherRow{
+				ID:        dashPrefixedID(r.Slug, e.ID),
+				Label:     e.Name,
+				Broker:    broker,
+				Framework: framework,
+				Repo:      r.Slug,
+				Producers: producers,
+				Reason:    reasonNoSubscriberFound,
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	// Stable deterministic sort: repo → label.
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.Repo != b.Repo {
+			return a.Repo < b.Repo
+		}
+		return a.Label < b.Label
+	})
+
+	if rows == nil {
+		rows = []OrphanPublisherRow{}
+	}
+	return rows
+}

--- a/internal/dashboard/handlers_topology_orphans_test.go
+++ b/internal/dashboard/handlers_topology_orphans_test.go
@@ -1,0 +1,393 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helper: build a minimal DashGroup for topology orphan tests.
+// ─────────────────────────────────────────────────────────────────────────────
+
+func makeTopologyOrphanGroup(entities []graph.Entity, rels []graph.Relationship) *DashGroup {
+	doc := &graph.Document{
+		Repo:          "backend",
+		Entities:      entities,
+		Relationships: rels,
+	}
+	return &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"backend": {Slug: "backend", Path: "/tmp/fake-backend", Doc: doc},
+		},
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for collectOrphanPublishers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestOrphanPublishers_ProducerOnly — producer publishes to topic-X but no
+// consumer exists → 1 orphan row.
+func TestOrphanPublishers_ProducerOnly(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-x",
+			Name:       "topic-X",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "rabbitmq"},
+		},
+		{
+			ID:   "producer-svc",
+			Name: "OrderPublisher",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r1",
+			FromID: "producer-svc",
+			ToID:   "topic-x",
+			Kind:   "PUBLISHES_TO",
+		},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.Label != "topic-X" {
+		t.Errorf("label: want topic-X, got %q", row.Label)
+	}
+	if row.Broker != "rabbitmq" {
+		t.Errorf("broker: want rabbitmq, got %q", row.Broker)
+	}
+	if row.Repo != "backend" {
+		t.Errorf("repo: want backend, got %q", row.Repo)
+	}
+	if row.Reason != reasonNoSubscriberFound {
+		t.Errorf("reason: want %q, got %q", reasonNoSubscriberFound, row.Reason)
+	}
+	if len(row.Producers) != 1 {
+		t.Errorf("producers: want 1, got %d", len(row.Producers))
+	}
+	// Producers should be prefixed IDs.
+	if row.Producers[0] != "backend::producer-svc" {
+		t.Errorf("producers[0]: want backend::producer-svc, got %q", row.Producers[0])
+	}
+}
+
+// TestOrphanPublishers_ProducerAndConsumer — both sides present → 0 orphans.
+func TestOrphanPublishers_ProducerAndConsumer(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-a",
+			Name:       "queue-A",
+			Kind:       "Queue",
+			Properties: map[string]string{"broker": "sqs"},
+		},
+		{
+			ID:   "pub-svc",
+			Name: "Sender",
+			Kind: "Function",
+		},
+		{
+			ID:   "sub-svc",
+			Name: "Receiver",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub-svc", ToID: "topic-a", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "topic-a", ToID: "sub-svc", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 orphan rows when consumer exists, got %d", len(rows))
+	}
+}
+
+// TestOrphanPublishers_ConsumerOnly — topic has only a consumer and no
+// producer → NOT an orphan publisher (different endpoint).
+func TestOrphanPublishers_ConsumerOnly(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-b",
+			Name:       "broker-1",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "kafka"},
+		},
+		{
+			ID:   "consumer-svc",
+			Name: "Listener",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "topic-b", ToID: "consumer-svc", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 orphan rows for consumer-only topic, got %d", len(rows))
+	}
+}
+
+// TestOrphanPublishers_ZeroProducersZeroConsumers — neither side present →
+// NOT reported by this endpoint (would be orphan subscriber territory).
+func TestOrphanPublishers_ZeroProducersZeroConsumers(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "lonely-topic",
+			Name: "lonely",
+			Kind: "MessageTopic",
+		},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, nil)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows for isolated topic, got %d", len(rows))
+	}
+}
+
+// TestOrphanPublishers_ChannelOrphan — a ChannelEvent with an emitter and no
+// subscriber is an orphan publisher too.
+func TestOrphanPublishers_ChannelOrphan(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "chan-1",
+			Name: "updates",
+			Kind: "ChannelEvent",
+			Properties: map[string]string{
+				"channel_type": "websocket",
+			},
+		},
+		{
+			ID:   "emitter-svc",
+			Name: "Notifier",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "emitter-svc", ToID: "chan-1", Kind: "WS_EMITS"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan channel row, got %d", len(rows))
+	}
+	if rows[0].Label != "updates" {
+		t.Errorf("label: want updates, got %q", rows[0].Label)
+	}
+}
+
+// TestOrphanPublishers_EmptyGroup — empty group returns [] not nil.
+func TestOrphanPublishers_EmptyGroup(t *testing.T) {
+	grp := &DashGroup{
+		Name:  "empty",
+		Repos: map[string]*DashRepo{},
+	}
+	rows := collectOrphanPublishers(grp)
+
+	if rows == nil {
+		t.Fatal("expected non-nil slice for empty group")
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+// TestOrphanPublishers_NonTopologyEntitiesIgnored — Function entities must
+// not appear in orphan publisher output.
+func TestOrphanPublishers_NonTopologyEntitiesIgnored(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "fn1", Name: "doWork", Kind: "Function"},
+		{ID: "fn2", Name: "helper", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanPublishers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows for non-topology entities, got %d", len(rows))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration smoke: HTTP endpoint returns correct JSON shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newOrphanPublisherTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["mygrp"] = GroupSummary{
+		Name:       "mygrp",
+		ConfigPath: "/tmp/mygrp.json",
+		Repos:      []string{"backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["mygrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func TestHandleOrphanPublishers_HTTPSmoke(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-smoke",
+			Name:       "topic-X",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "rabbitmq"},
+		},
+		{
+			ID:   "prod-smoke",
+			Name: "SmokePublisher",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "rs1", FromID: "prod-smoke", ToID: "topic-smoke", Kind: "PUBLISHES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	grp.Name = "mygrp"
+
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/mygrp/orphan-publishers")
+	if err != nil {
+		t.Fatalf("GET orphan-publishers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		OrphanPublishers []OrphanPublisherRow `json:"orphan_publishers"`
+		Total            int                  `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if len(body.OrphanPublishers) != 1 {
+		t.Fatalf("orphan_publishers len: want 1, got %d", len(body.OrphanPublishers))
+	}
+
+	row := body.OrphanPublishers[0]
+	if row.Label != "topic-X" {
+		t.Errorf("label: want topic-X, got %q", row.Label)
+	}
+	if row.Broker != "rabbitmq" {
+		t.Errorf("broker: want rabbitmq, got %q", row.Broker)
+	}
+	if row.Reason != reasonNoSubscriberFound {
+		t.Errorf("reason: want %q, got %q", reasonNoSubscriberFound, row.Reason)
+	}
+	if row.Producers == nil {
+		t.Error("producers must not be nil")
+	}
+}
+
+func TestHandleOrphanPublishers_EmptyResult_ArrayNotNull(t *testing.T) {
+	// A group with no PUBLISHES_TO edges must return [] (not null).
+	entities := []graph.Entity{
+		{
+			ID:         "topic-covered",
+			Name:       "covered",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "kafka"},
+		},
+		{
+			ID:   "pub",
+			Name: "Publisher",
+			Kind: "Function",
+		},
+		{
+			ID:   "sub",
+			Name: "Subscriber",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub", ToID: "topic-covered", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "topic-covered", ToID: "sub", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	grp.Name = "mygrp"
+
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/mygrp/orphan-publishers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	publishers, ok := body["orphan_publishers"]
+	if !ok {
+		t.Fatal("orphan_publishers key missing")
+	}
+	arr, ok := publishers.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty array, got %v", publishers)
+	}
+}
+
+func TestHandleOrphanPublishers_UnknownGroup(t *testing.T) {
+	grp := makeTopologyOrphanGroup(nil, nil)
+	grp.Name = "mygrp"
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/nosuchgroup/orphan-publishers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -171,6 +171,7 @@ func (s *Server) routes() http.Handler {
 
 	// Broker topology
 	mux.HandleFunc("GET /api/topology/{group}", s.handleTopology)
+	mux.HandleFunc("GET /api/topology/{group}/orphan-publishers", s.handleOrphanPublishers)
 
 	// Docs portal
 	mux.HandleFunc("GET /api/docs/{group}", s.handleDocTree)


### PR DESCRIPTION
## Summary

Adds \`GET /api/topology/{group}/orphan-publishers\` — the backend detector for broker entities (topics, queues, channels, GraphQL subscriptions) that have at least one producer but zero consumers anywhere in the group. These are "fire-and-forget" message producers with no known listener, surfacing dead-letter and integration gaps.

**New files:**
- \`internal/dashboard/handlers_topology_orphans.go\` — \`handleOrphanPublishers\` HTTP handler + \`collectOrphanPublishers\` detection logic
- \`internal/dashboard/handlers_topology_orphans_test.go\` — 10 unit + HTTP integration tests

**Modified:**
- \`internal/dashboard/server.go\` — registers the new route

**Detection algorithm:** iterates all entities, buckets them via the existing \`classifyTopologyBucket\` helper, calls \`brokerEdges\` / \`channelEdges\` / \`graphqlSubEdges\` per entity, and emits a row when \`len(producers) > 0 && len(consumers) == 0\`. Zero-producer entities are excluded (orphan-subscriber territory).

**Wire shape** (all arrays guaranteed \`[]\` not \`null\`):
\`\`\`json
{
  "orphan_publishers": [
    {
      "id": "backend::topic-x",
      "label": "topic-X",
      "broker": "rabbitmq",
      "framework": "",
      "repo": "backend",
      "producers": ["backend::prod-svc"],
      "reason": "no_subscriber_found"
    }
  ],
  "total": 1
}
\`\`\`

## Closes / Refs

- Refs #1135
- Closes #1136

## Testing

- [x] All tests pass: \`go test ./internal/dashboard/... -run "TestOrphanPublisher|TestHandleOrphanPublisher"\` — 10/10 PASS
- [x] No regression: \`go test ./internal/dashboard/... -run "TestTopology"\` — 8/8 PASS
- [x] Fixture: producer-only topic → 1 orphan row (\`TestOrphanPublishers_ProducerOnly\`)
- [x] Fixture: producer + consumer same topic → 0 orphans (\`TestOrphanPublishers_ProducerAndConsumer\`)
- [x] Fixture: consumer-only topic → 0 orphans (\`TestOrphanPublishers_ConsumerOnly\`)
- [x] Fixture: zero producers + zero consumers → 0 orphans (not publisher territory)
- [x] HTTP smoke: 200 with correct JSON shape including \`[]\` never \`null\` for arrays

## Notes

- Backend only — no frontend changes in this PR (frontend tabs land in #1140).
- \`reason\` is always \`"no_subscriber_found"\` for now; the field is reserved for future sub-classifications.
- Route registered between the existing \`GET /api/topology/{group}\` and docs routes in \`server.go\` to preserve logical grouping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)