### PR TITLE
[Flows v2] Backend: dead-end flow classifier (#1145)

### DIFF
--- a/internal/dashboard/handlers_flows_quality.go
+++ b/internal/dashboard/handlers_flows_quality.go
@@ -1,0 +1,207 @@
+package dashboard
+
+// handlers_flows_quality.go — Flows v2 quality classification endpoints
+//
+//	GET /api/flows/{group}/dead-ends
+
+import (
+	"net/http"
+	"strconv"
+	"strings"
+)
+
+// usefulSinkEdgeKinds is the set of outgoing relationship kinds that indicate
+// a step produces an observable side effect (DB write, HTTP response, message
+// publish, test assertion, render, or state mutation).
+var usefulSinkEdgeKinds = map[string]bool{
+	// DB writes
+	"WRITES_TO":    true,
+	"INSERTS_INTO": true,
+	"DELETES_FROM": true,
+	"UPDATES":      true,
+	// Message publishing
+	"PUBLISHES_TO": true,
+	"PUBLISHES":    true,
+	"WS_EMITS":     true,
+	"STREAMS_TO":   true,
+	// Test assertions
+	"ASSERTS": true,
+	// State mutation
+	"MUTATES_STATE": true,
+}
+
+// usefulSinkKindSubstrings lists entity kind substrings that by themselves
+// indicate a useful terminal (e.g. an HTTP response handler or test entity).
+var usefulSinkKindSubstrings = []string{
+	"Response",
+	"Handler",
+	"Test",
+	"Assert",
+	"Render",
+}
+
+// flowStepKey identifies a step entity by repo slug and local entity ID.
+type flowStepKey struct{ repo, id string }
+
+// DeadEndItem represents a single dead-end process flow in the API response.
+type DeadEndItem struct {
+	ProcessID  string `json:"process_id"`
+	Label      string `json:"label"`
+	EntryName  string `json:"entry_name"`
+	StepCount  int    `json:"step_count"`
+	Repo       string `json:"repo"`
+	Reason     string `json:"reason"`     // "no_useful_sink" | "single_step"
+	CrossStack bool   `json:"cross_stack"`
+}
+
+// classifyFlowDeadEnds inspects all Process entities in a group and returns
+// those that are considered dead-ends: flows whose step chain contains no
+// useful side-effect and flows with 0 or 1 steps.
+func classifyFlowDeadEnds(grp *DashGroup) []DeadEndItem {
+	// Build an index of entity kind by (repo slug, entity ID) so we can
+	// check step entity kinds without re-scanning every time.
+	entityKind := map[flowStepKey]string{}
+	for _, r := range sortedRepos(grp) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			entityKind[flowStepKey{r.Slug, e.ID}] = e.Kind
+		}
+	}
+
+	// Build a set of relationship kinds outgoing from each entity.
+	outEdgeKinds := map[flowStepKey]map[string]bool{}
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			k := flowStepKey{r.Slug, rel.FromID}
+			if outEdgeKinds[k] == nil {
+				outEdgeKinds[k] = map[string]bool{}
+			}
+			outEdgeKinds[k][rel.Kind] = true
+		}
+	}
+
+	var results []DeadEndItem
+
+	for _, r := range sortedRepos(grp) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind {
+				continue
+			}
+
+			sc, _ := strconv.Atoi(e.Properties["step_count"])
+			cs := e.Properties["cross_stack"] == "true"
+			pid := dashPrefixedID(r.Slug, e.ID)
+
+			// Single-step (or zero-step) flows are always classified separately.
+			if sc <= 1 {
+				results = append(results, DeadEndItem{
+					ProcessID:  pid,
+					Label:      e.Name,
+					EntryName:  e.Properties["entry_name"],
+					StepCount:  sc,
+					Repo:       r.Slug,
+					Reason:     "single_step",
+					CrossStack: cs,
+				})
+				continue
+			}
+
+			// Collect step entity keys via STEP_IN_PROCESS edges.
+			stepKeys := collectStepKeys(grp, e.ID, pid)
+
+			// Check whether any step has a useful sink.
+			if hasUsefulSink(stepKeys, entityKind, outEdgeKinds) {
+				continue
+			}
+
+			results = append(results, DeadEndItem{
+				ProcessID:  pid,
+				Label:      e.Name,
+				EntryName:  e.Properties["entry_name"],
+				StepCount:  sc,
+				Repo:       r.Slug,
+				Reason:     "no_useful_sink",
+				CrossStack: cs,
+			})
+		}
+	}
+
+	return results
+}
+
+// collectStepKeys gathers flowStepKey pairs for all steps in a process by
+// following STEP_IN_PROCESS edges whose FromID matches the process.
+func collectStepKeys(
+	grp *DashGroup,
+	processLocalID, processPrefixedID string,
+) []flowStepKey {
+	var steps []flowStepKey
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind != stepInProcessEdge {
+				continue
+			}
+			if rel.FromID != processLocalID &&
+				dashPrefixedID(r.Slug, rel.FromID) != processPrefixedID {
+				continue
+			}
+			steps = append(steps, flowStepKey{r.Slug, rel.ToID})
+		}
+	}
+	return steps
+}
+
+// hasUsefulSink returns true if any of the given step entities has an outgoing
+// useful-sink edge or an entity kind that indicates a useful terminal.
+func hasUsefulSink(
+	steps []flowStepKey,
+	entityKind map[flowStepKey]string,
+	outEdgeKinds map[flowStepKey]map[string]bool,
+) bool {
+	for _, step := range steps {
+		// Check entity kind substrings.
+		kind := entityKind[step]
+		for _, sub := range usefulSinkKindSubstrings {
+			if strings.Contains(kind, sub) {
+				return true
+			}
+		}
+		// Check outgoing edge kinds.
+		for edgeKind := range outEdgeKinds[step] {
+			if usefulSinkEdgeKinds[edgeKind] {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// handleFlowDeadEnds — GET /api/flows/{group}/dead-ends
+//
+// Returns all Process flows in the group that terminate in a useless sink:
+// no DB write, no HTTP response, no message publish, and no test assertion.
+// Single-step flows are included with reason "single_step".
+func (s *Server) handleFlowDeadEnds(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	deadEnds := classifyFlowDeadEnds(grp)
+	if deadEnds == nil {
+		deadEnds = []DeadEndItem{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"dead_ends": deadEnds,
+		"total":     len(deadEnds),
+	})
+}

--- a/internal/dashboard/handlers_flows_quality_test.go
+++ b/internal/dashboard/handlers_flows_quality_test.go
@@ -1,0 +1,477 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func makeFlowGroup(entities []graph.Entity, rels []graph.Relationship) *DashGroup {
+	doc := &graph.Document{
+		Repo:          "backend",
+		Entities:      entities,
+		Relationships: rels,
+	}
+	return &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"backend": {Slug: "backend", Path: "/tmp/fake-backend", Doc: doc},
+		},
+	}
+}
+
+// processEntity builds a SCOPE.Process graph.Entity with the given id,
+// step_count, and cross_stack flag.
+func processEntity(id, name string, stepCount int, crossStack bool) graph.Entity {
+	cs := "false"
+	if crossStack {
+		cs = "true"
+	}
+	return graph.Entity{
+		ID:   id,
+		Name: name,
+		Kind: processEntityKind,
+		Properties: map[string]string{
+			"entry_name":  name + "_entry",
+			"entry_id":    id + "_entry",
+			"terminal_id": id + "_terminal",
+			"step_count":  itoa(stepCount),
+			"cross_stack": cs,
+		},
+	}
+}
+
+// stepEntity builds a plain function entity that acts as a flow step.
+func stepEntity(id, name, kind string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       kind,
+		SourceFile: "src/" + id + ".go",
+		StartLine:  1,
+		Properties: map[string]string{},
+	}
+}
+
+// stepRel builds a STEP_IN_PROCESS relationship from processID to stepID.
+func stepRel(processID, stepID string, idx int) graph.Relationship {
+	return graph.Relationship{
+		ID:     "step-" + processID + "-" + stepID,
+		FromID: processID,
+		ToID:   stepID,
+		Kind:   stepInProcessEdge,
+		Properties: map[string]string{
+			"step_index": itoa(idx),
+		},
+	}
+}
+
+// outRel builds an outgoing relationship from a step entity.
+func outRel(fromID, toID, kind string) graph.Relationship {
+	return graph.Relationship{
+		ID:     "out-" + fromID + "-" + kind,
+		FromID: fromID,
+		ToID:   toID,
+		Kind:   kind,
+	}
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	s := ""
+	for n > 0 {
+		s = string(rune('0'+n%10)) + s
+		n /= 10
+	}
+	return s
+}
+
+// newFlowQualityTestServer builds an httptest.Server pre-loaded with grp.
+func newFlowQualityTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name:       "testgrp",
+		ConfigPath: "/tmp/testgrp.json",
+		Repos:      []string{"backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests: classifyFlowDeadEnds
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestDeadEnd_DBWrite — a flow whose steps include a WRITES_TO relationship
+// must NOT appear in dead-ends.
+func TestDeadEnd_DBWrite(t *testing.T) {
+	proc := processEntity("proc-db", "saveUser", 3, false)
+	step1 := stepEntity("step1", "validate", "Function")
+	step2 := stepEntity("step2", "persist", "Function")
+	step3 := stepEntity("step3", "audit", "Function")
+
+	entities := []graph.Entity{proc, step1, step2, step3}
+	rels := []graph.Relationship{
+		stepRel("proc-db", "step1", 0),
+		stepRel("proc-db", "step2", 1),
+		stepRel("proc-db", "step3", 2),
+		// step2 writes to the DB — this is the useful sink.
+		outRel("step2", "db:users", "WRITES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	for _, item := range items {
+		if item.ProcessID == "backend::proc-db" {
+			t.Errorf("flow with WRITES_TO must not be a dead-end, but found: %+v", item)
+		}
+	}
+}
+
+// TestDeadEnd_NoUsefulSink — a flow with 3 steps and no observable side
+// effects must appear with reason "no_useful_sink".
+func TestDeadEnd_NoUsefulSink(t *testing.T) {
+	proc := processEntity("proc-noop", "doNothing", 3, false)
+	step1 := stepEntity("noop1", "log", "Function")
+	step2 := stepEntity("noop2", "validate", "Function")
+	step3 := stepEntity("noop3", "pass", "Function") // if x: pass style
+
+	entities := []graph.Entity{proc, step1, step2, step3}
+	rels := []graph.Relationship{
+		stepRel("proc-noop", "noop1", 0),
+		stepRel("proc-noop", "noop2", 1),
+		stepRel("proc-noop", "noop3", 2),
+		// Only a CALLS edge — not a useful sink.
+		outRel("noop1", "noop2", "CALLS"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	var found *DeadEndItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-noop" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-noop to appear as dead-end, but it was not found")
+	}
+	if found.Reason != "no_useful_sink" {
+		t.Errorf("reason: want no_useful_sink, got %q", found.Reason)
+	}
+	if found.StepCount != 3 {
+		t.Errorf("step_count: want 3, got %d", found.StepCount)
+	}
+}
+
+// TestDeadEnd_SingleStep — a flow with step_count == 1 must appear with
+// reason "single_step".
+func TestDeadEnd_SingleStep(t *testing.T) {
+	proc := processEntity("proc-one", "trivial", 1, false)
+	step1 := stepEntity("one1", "onlyStep", "Function")
+
+	entities := []graph.Entity{proc, step1}
+	rels := []graph.Relationship{
+		stepRel("proc-one", "one1", 0),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	var found *DeadEndItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-one" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-one to appear as dead-end (single_step), but it was not found")
+	}
+	if found.Reason != "single_step" {
+		t.Errorf("reason: want single_step, got %q", found.Reason)
+	}
+}
+
+// TestDeadEnd_ZeroStep — a flow with step_count == 0 must appear with
+// reason "single_step" (same bucket as single-step).
+func TestDeadEnd_ZeroStep(t *testing.T) {
+	proc := processEntity("proc-zero", "empty", 0, false)
+
+	grp := makeFlowGroup([]graph.Entity{proc}, nil)
+	items := classifyFlowDeadEnds(grp)
+
+	var found *DeadEndItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-zero" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-zero to appear as dead-end (single_step), but not found")
+	}
+	if found.Reason != "single_step" {
+		t.Errorf("reason: want single_step, got %q", found.Reason)
+	}
+}
+
+// TestDeadEnd_HTTPResponse — a flow ending in a step whose entity kind
+// contains "Response" must NOT appear as dead-end.
+func TestDeadEnd_HTTPResponse(t *testing.T) {
+	proc := processEntity("proc-http", "serveUser", 2, false)
+	step1 := stepEntity("http1", "loadUser", "Function")
+	step2 := stepEntity("http2", "writeResponse", "HTTPResponse") // kind contains "Response"
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-http", "http1", 0),
+		stepRel("proc-http", "http2", 1),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	for _, item := range items {
+		if item.ProcessID == "backend::proc-http" {
+			t.Errorf("flow with HTTPResponse step must not be a dead-end, but found: %+v", item)
+		}
+	}
+}
+
+// TestDeadEnd_Publishes — a flow with a PUBLISHES_TO edge must NOT be dead-end.
+func TestDeadEnd_Publishes(t *testing.T) {
+	proc := processEntity("proc-pub", "notifyUser", 2, false)
+	step1 := stepEntity("pub1", "prepare", "Function")
+	step2 := stepEntity("pub2", "emit", "Function")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-pub", "pub1", 0),
+		stepRel("proc-pub", "pub2", 1),
+		outRel("pub2", "topic:user-events", "PUBLISHES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	for _, item := range items {
+		if item.ProcessID == "backend::proc-pub" {
+			t.Errorf("flow with PUBLISHES_TO must not be a dead-end, but found: %+v", item)
+		}
+	}
+}
+
+// TestDeadEnd_Asserts — a flow with an ASSERTS edge must NOT be dead-end.
+func TestDeadEnd_Asserts(t *testing.T) {
+	proc := processEntity("proc-test", "TestSomething", 2, false)
+	step1 := stepEntity("tst1", "arrange", "Function")
+	step2 := stepEntity("tst2", "assert", "Function")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-test", "tst1", 0),
+		stepRel("proc-test", "tst2", 1),
+		outRel("tst2", "value", "ASSERTS"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowDeadEnds(grp)
+
+	for _, item := range items {
+		if item.ProcessID == "backend::proc-test" {
+			t.Errorf("flow with ASSERTS edge must not be a dead-end, but found: %+v", item)
+		}
+	}
+}
+
+// TestDeadEnd_EmptyGroup — empty group returns no dead-ends.
+func TestDeadEnd_EmptyGroup(t *testing.T) {
+	grp := &DashGroup{
+		Name:  "empty",
+		Repos: map[string]*DashRepo{},
+	}
+	items := classifyFlowDeadEnds(grp)
+	if len(items) != 0 {
+		t.Errorf("expected 0 items for empty group, got %d", len(items))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration smoke: HTTP endpoint shape
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleFlowDeadEnds_HTTPSmoke(t *testing.T) {
+	proc := processEntity("proc-smoke", "smokeFlow", 3, false)
+	step1 := stepEntity("sm1", "log", "Function")
+	step2 := stepEntity("sm2", "check", "Function")
+	step3 := stepEntity("sm3", "idle", "Function")
+
+	entities := []graph.Entity{proc, step1, step2, step3}
+	rels := []graph.Relationship{
+		stepRel("proc-smoke", "sm1", 0),
+		stepRel("proc-smoke", "sm2", 1),
+		stepRel("proc-smoke", "sm3", 2),
+	}
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/dead-ends")
+	if err != nil {
+		t.Fatalf("GET dead-ends: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		DeadEnds []DeadEndItem `json:"dead_ends"`
+		Total    int           `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if len(body.DeadEnds) != 1 {
+		t.Fatalf("dead_ends len: want 1, got %d", len(body.DeadEnds))
+	}
+
+	item := body.DeadEnds[0]
+	if item.ProcessID != "backend::proc-smoke" {
+		t.Errorf("process_id: want backend::proc-smoke, got %q", item.ProcessID)
+	}
+	if item.Reason != "no_useful_sink" {
+		t.Errorf("reason: want no_useful_sink, got %q", item.Reason)
+	}
+	if item.StepCount != 3 {
+		t.Errorf("step_count: want 3, got %d", item.StepCount)
+	}
+	if item.Repo != "backend" {
+		t.Errorf("repo: want backend, got %q", item.Repo)
+	}
+}
+
+func TestHandleFlowDeadEnds_UnknownGroup(t *testing.T) {
+	grp := makeFlowGroup(nil, nil)
+	grp.Name = "testgrp"
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/nosuchgroup/dead-ends")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleFlowDeadEnds_EmptyResult(t *testing.T) {
+	// A group with only a DB-writing flow returns an empty list (not null).
+	proc := processEntity("proc-clean", "cleanFlow", 2, false)
+	step1 := stepEntity("cl1", "load", "Function")
+	step2 := stepEntity("cl2", "save", "Function")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-clean", "cl1", 0),
+		stepRel("proc-clean", "cl2", 1),
+		outRel("cl2", "db:records", "WRITES_TO"),
+	}
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/dead-ends")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	arr, ok := body["dead_ends"].([]any)
+	if !ok {
+		t.Fatalf("dead_ends should be an array, got %T", body["dead_ends"])
+	}
+	if len(arr) != 0 {
+		t.Errorf("expected empty dead_ends for clean flow, got %d items", len(arr))
+	}
+	if total, _ := body["total"].(float64); total != 0 {
+		t.Errorf("total: want 0, got %v", total)
+	}
+}
+
+func TestHandleFlowDeadEnds_SingleStepReason(t *testing.T) {
+	proc := processEntity("proc-tiny", "tinyFlow", 1, false)
+	step1 := stepEntity("tiny1", "onlyStep", "Function")
+
+	entities := []graph.Entity{proc, step1}
+	rels := []graph.Relationship{stepRel("proc-tiny", "tiny1", 0)}
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/dead-ends")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		DeadEnds []DeadEndItem `json:"dead_ends"`
+		Total    int           `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if body.DeadEnds[0].Reason != "single_step" {
+		t.Errorf("reason: want single_step, got %q", body.DeadEnds[0].Reason)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -162,6 +162,7 @@ func (s *Server) routes() http.Handler {
 
 	// Process flows
 	mux.HandleFunc("GET /api/flows/{group}", s.handleFlowsList)
+	mux.HandleFunc("GET /api/flows/{group}/dead-ends", s.handleFlowDeadEnds)
 	mux.HandleFunc("GET /api/flows/{group}/{processId}", s.handleFlowDetail)
 
 	// API paths / contracts


### PR DESCRIPTION
## What

Implements `GET /api/flows/{group}/dead-ends` — the dead-end flow classifier for Flows v2 (#1145, part of epic #1144).

## Why

Process flows that terminate without producing any observable side effect (no DB write, no HTTP response, no message publish, no test assertion) represent incomplete implementations or abandoned code paths. Surfacing them as a dedicated endpoint lets the frontend promote them to their own tab and lets engineers prioritise cleanup.

## How

- New file `internal/dashboard/handlers_flows_quality.go` with:
  - `flowStepKey` — package-level named struct used as map key to avoid anonymous-struct type mismatches.
  - `usefulSinkEdgeKinds` — exhaustive set of relationship kinds that signal a real side effect (`WRITES_TO`, `INSERTS_INTO`, `DELETES_FROM`, `UPDATES`, `PUBLISHES_TO`, `PUBLISHES`, `WS_EMITS`, `STREAMS_TO`, `ASSERTS`, `MUTATES_STATE`).
  - `usefulSinkKindSubstrings` — entity kind substrings that indicate a useful terminal (`Response`, `Handler`, `Test`, `Assert`, `Render`).
  - `classifyFlowDeadEnds(grp)` — iterates `SCOPE.Process` entities, follows `STEP_IN_PROCESS` edges via `collectStepKeys`, then calls `hasUsefulSink` to decide. Flows with `step_count ≤ 1` get `reason: "single_step"` immediately; others scan step outgoing edges and entity kinds.
  - `handleFlowDeadEnds` HTTP handler — returns `{ dead_ends: [...], total: N }` or 404 for unknown groups.
- Route registered in `server.go` between the existing `handleFlowsList` and `handleFlowDetail` handlers:
  `GET /api/flows/{group}/dead-ends`

## Tests

`internal/dashboard/handlers_flows_quality_test.go` — 12 tests covering:

| Test | Assertion |
|---|---|
| `TestDeadEnd_DBWrite` | Flow with `WRITES_TO` edge → not dead-end |
| `TestDeadEnd_NoUsefulSink` | 3-step flow with no side effects → `no_useful_sink` |
| `TestDeadEnd_SingleStep` | `step_count == 1` → `single_step` |
| `TestDeadEnd_ZeroStep` | `step_count == 0` → `single_step` |
| `TestDeadEnd_HTTPResponse` | Step kind contains "Response" → not dead-end |
| `TestDeadEnd_Publishes` | `PUBLISHES_TO` edge → not dead-end |
| `TestDeadEnd_Asserts` | `ASSERTS` edge → not dead-end |
| `TestDeadEnd_EmptyGroup` | Empty group → no dead-ends |
| `TestHandleFlowDeadEnds_HTTPSmoke` | Full HTTP round-trip, correct JSON shape |
| `TestHandleFlowDeadEnds_UnknownGroup` | Unknown group → 404 |
| `TestHandleFlowDeadEnds_EmptyResult` | DB-writing flow → empty `dead_ends` array (not null) |
| `TestHandleFlowDeadEnds_SingleStepReason` | HTTP response: `reason == "single_step"` |

All 12 pass; full existing test suite shows zero regressions.

## Checklist

- [x] Backend only — no frontend changes
- [x] Route registered in `server.go`, returns 404 for unknown groups
- [x] No client names in code, comments, or test fixtures
- [x] `classifyFlowDeadEnds` is a pure function — independently testable without an HTTP server

Closes #1145