### PR TITLE
fix(drf): resolve 200 ANY-verb paths — deduplicate http_endpoint_synthesis entries (#1126)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -528,6 +528,18 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 				len(nestedEntities)-len(deduplicatedNestedEntities))
 		}
 
+		// Issue #1126: Deduplicate http_endpoint_synthesis ANY entries emitted
+		// by synthesizeDjangoFromComposed when drf_router_expanded per-verb
+		// entries cover the same path. These ANY synthetics come from Pass 2.5
+		// (applyHTTPEndpointSynthesis, per-file) and coexist with the
+		// concrete-verb entries from Pass 2.6b because they have different IDs
+		// (http:ANY:<path> vs http:GET:<path> etc.), inflating the ANY count.
+		beforeDedup := len(pass2Records)
+		pass2Records = engine.DeduplicateHTTPSynthesisANY(pass2Records, drfEntities)
+		if deduped := beforeDedup - len(pass2Records); deduped > 0 {
+			fmt.Fprintf(os.Stderr, "archigraph: deduped %d http_endpoint_synthesis ANY entries (drf coverage)\n", deduped)
+		}
+
 		pass3Records = append(pass3Records, deduplicatedNestedEntities...)
 		pass3Records = append(pass3Records, drfEntities...)
 

--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -459,6 +459,87 @@ func DeduplicateNestedURLConfDRF(
 	return result
 }
 
+// DeduplicateHTTPSynthesisANY removes ANY-verb http_endpoint entities emitted
+// by synthesizeDjangoFromComposed (pattern_type="http_endpoint_synthesis")
+// when drf_router_expanded per-verb entries cover the same canonical path.
+//
+// Root cause (issue #1126): applyHTTPEndpointSynthesis runs per-file during
+// Pass 2.5 and calls synthesizeDjangoFromComposed, which always emits
+// http:ANY:<path> from each ast_driven Route entity. ApplyDjangoDRFRoutes
+// runs later in Pass 2.6b and emits the correct per-verb entries
+// (http:GET:..., http:POST:..., etc.). Because the IDs differ (ANY vs GET/
+// POST/etc.), both sets coexist in the merged entity list, producing ~200
+// spurious ANY paths.
+//
+// This function removes the ANY synthesis entries for every path already
+// covered by at least one drf_router_expanded per-verb entry. The ANY entry
+// from emitCRUDFamily (the detail-route wildcard) is NOT removed — it is
+// intentional and carries pattern_type="drf_router_expanded", not
+// "http_endpoint_synthesis".
+//
+// synthEntities: the merged entity slice from pass2 (from applyHTTPEndpointSynthesis)
+// drfEntities:   output from ApplyDjangoDRFRoutes
+// Returns: synthEntities with spurious ANY entries removed.
+func DeduplicateHTTPSynthesisANY(
+	synthEntities []types.EntityRecord,
+	drfEntities []types.EntityRecord,
+) []types.EntityRecord {
+	if len(synthEntities) == 0 || len(drfEntities) == 0 {
+		return synthEntities
+	}
+
+	// Build a set of canonical paths covered by drf_router_expanded entries
+	// with a concrete (non-ANY) verb. Key: canonical path string.
+	drfCoveredPaths := make(map[string]bool)
+	for _, e := range drfEntities {
+		if e.Properties == nil {
+			continue
+		}
+		if e.Properties["pattern_type"] != "drf_router_expanded" {
+			continue
+		}
+		verb := e.Properties["verb"]
+		path := e.Properties["path"]
+		if verb != "" && verb != "ANY" && path != "" {
+			drfCoveredPaths[path] = true
+		}
+	}
+
+	if len(drfCoveredPaths) == 0 {
+		return synthEntities
+	}
+
+	// Filter: remove http_endpoint_synthesis ANY entries whose path is
+	// already covered by drf_router_expanded concrete-verb entries.
+	result := synthEntities[:0:0]
+	for _, e := range synthEntities {
+		if e.Kind != httpEndpointKind {
+			result = append(result, e)
+			continue
+		}
+		if e.Properties == nil {
+			result = append(result, e)
+			continue
+		}
+		if e.Properties["pattern_type"] != "http_endpoint_synthesis" {
+			result = append(result, e)
+			continue
+		}
+		if e.Properties["verb"] != "ANY" {
+			result = append(result, e)
+			continue
+		}
+		// This is an http_endpoint_synthesis ANY entry. Drop it when the
+		// drf_router_expanded pass covers the same path with concrete verbs.
+		if drfCoveredPaths[e.Properties["path"]] {
+			continue
+		}
+		result = append(result, e)
+	}
+
+	return result
+}
+
 // isDjangoRoutersFile reports whether the file looks like a DRF routers
 // module (commonly named routers.py or *_routers.py). We expand the file
 // scan beyond urls.py so DRF-only files (no path() calls) still get their

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -1447,3 +1447,247 @@ func TestDeduplicateNestedURLConfDRF_FixtureAScenario(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1126 — DeduplicateHTTPSynthesisANY tests
+// ---------------------------------------------------------------------------
+
+// makeHTTPSynthesisANY is a helper that builds an http_endpoint_synthesis
+// ANY entity for the given path (mimicking synthesizeDjangoFromComposed output).
+func makeHTTPSynthesisANY(path string) types.EntityRecord {
+	id := "http:ANY:" + path
+	return types.EntityRecord{
+		ID:   id,
+		Name: id,
+		Kind: httpEndpointKind,
+		Properties: map[string]string{
+			"verb":         "ANY",
+			"path":         path,
+			"framework":    "django",
+			"pattern_type": "http_endpoint_synthesis",
+		},
+	}
+}
+
+// makeDRFExpanded builds an http_endpoint entity as ApplyDjangoDRFRoutes emits.
+func makeDRFExpanded(verb, path string) types.EntityRecord {
+	id := "http:" + verb + ":" + path
+	return types.EntityRecord{
+		ID:   id,
+		Name: id,
+		Kind: httpEndpointKind,
+		Properties: map[string]string{
+			"verb":         verb,
+			"path":         path,
+			"framework":    "django",
+			"pattern_type": "drf_router_expanded",
+		},
+	}
+}
+
+// TestDeduplicateHTTPSynthesisANY_BasicCRUD verifies that ANY synthesis entries
+// for a ModelViewSet-backed path are removed when concrete verbs are present.
+// Fixture: ModelViewSet on /api/v1/contracts — 6 concrete verbs + 1 ANY
+// detail catch-all from ApplyDjangoDRFRoutes. The per-file ANY synthesis
+// entry for /api/v1/contracts (list route) must be dropped; the detail
+// ANY catch-all (from drf_router_expanded) must be preserved.
+func TestDeduplicateHTTPSynthesisANY_BasicCRUD(t *testing.T) {
+	listPath := "/api/v1/contracts"
+	detailPath := "/api/v1/contracts/{pk}"
+
+	// Pass 2.5 synthesis entries (would have been ~200 ANY in upvate).
+	synthEntities := []types.EntityRecord{
+		makeHTTPSynthesisANY(listPath),
+		makeHTTPSynthesisANY(detailPath),
+		// Non-endpoint record — must be preserved unchanged.
+		{ID: "other:entity", Name: "other", Kind: "SCOPE.Component"},
+	}
+
+	// Pass 2.6b DRF entries (6 CRUD verbs + 1 ANY detail catch-all).
+	drfEntities := []types.EntityRecord{
+		makeDRFExpanded("GET", listPath),
+		makeDRFExpanded("POST", listPath),
+		makeDRFExpanded("GET", detailPath),
+		makeDRFExpanded("PUT", detailPath),
+		makeDRFExpanded("PATCH", detailPath),
+		makeDRFExpanded("DELETE", detailPath),
+		// Intentional ANY from emitCRUDFamily — pattern_type=drf_router_expanded.
+		{
+			ID:   "http:ANY:" + detailPath,
+			Name: "http:ANY:" + detailPath,
+			Kind: httpEndpointKind,
+			Properties: map[string]string{
+				"verb":         "ANY",
+				"path":         detailPath,
+				"framework":    "django",
+				"pattern_type": "drf_router_expanded",
+			},
+		},
+	}
+
+	got := DeduplicateHTTPSynthesisANY(synthEntities, drfEntities)
+
+	// Both http_endpoint_synthesis ANY entries (list + detail) must be gone.
+	for _, e := range got {
+		if e.Kind == httpEndpointKind &&
+			e.Properties != nil &&
+			e.Properties["pattern_type"] == "http_endpoint_synthesis" &&
+			e.Properties["verb"] == "ANY" {
+			t.Errorf("unexpected http_endpoint_synthesis ANY survived: id=%q path=%q",
+				e.ID, e.Properties["path"])
+		}
+	}
+
+	// The non-endpoint record must survive.
+	found := false
+	for _, e := range got {
+		if e.ID == "other:entity" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("non-endpoint entity was incorrectly removed")
+	}
+}
+
+// TestDeduplicateHTTPSynthesisANY_ReadOnly verifies that ANY synthesis entries
+// for a ReadOnlyModelViewSet path (list + retrieve only) are dropped when those
+// concrete-verb entries exist.
+func TestDeduplicateHTTPSynthesisANY_ReadOnly(t *testing.T) {
+	listPath := "/api/v1/products"
+	detailPath := "/api/v1/products/{pk}"
+
+	synthEntities := []types.EntityRecord{
+		makeHTTPSynthesisANY(listPath),
+		makeHTTPSynthesisANY(detailPath),
+	}
+
+	drfEntities := []types.EntityRecord{
+		makeDRFExpanded("GET", listPath),   // list
+		makeDRFExpanded("GET", detailPath), // retrieve
+		// ANY detail catch-all still emitted by emitCRUDFamily.
+		{
+			ID:   "http:ANY:" + detailPath,
+			Name: "http:ANY:" + detailPath,
+			Kind: httpEndpointKind,
+			Properties: map[string]string{
+				"verb":         "ANY",
+				"path":         detailPath,
+				"framework":    "django",
+				"pattern_type": "drf_router_expanded",
+			},
+		},
+	}
+
+	got := DeduplicateHTTPSynthesisANY(synthEntities, drfEntities)
+
+	// Both synthesis ANY entries must be removed.
+	for _, e := range got {
+		if e.Kind == httpEndpointKind &&
+			e.Properties != nil &&
+			e.Properties["pattern_type"] == "http_endpoint_synthesis" &&
+			e.Properties["verb"] == "ANY" {
+			t.Errorf("unexpected http_endpoint_synthesis ANY survived: id=%q path=%q",
+				e.ID, e.Properties["path"])
+		}
+	}
+
+	if len(got) != 0 {
+		t.Errorf("expected 0 remaining entities, got %d: %+v", len(got), got)
+	}
+}
+
+// TestDeduplicateHTTPSynthesisANY_NoDRFCoverage verifies that ANY synthesis
+// entries for paths NOT covered by drf_router_expanded are preserved.
+// These are genuine multi-verb endpoints or non-DRF routes.
+func TestDeduplicateHTTPSynthesisANY_NoDRFCoverage(t *testing.T) {
+	genuinePath := "/api/v1/some-custom-view"
+
+	synthEntities := []types.EntityRecord{
+		makeHTTPSynthesisANY(genuinePath),
+	}
+
+	// Only DRF entries for a different path — no coverage for genuinePath.
+	drfEntities := []types.EntityRecord{
+		makeDRFExpanded("GET", "/api/v1/contracts"),
+		makeDRFExpanded("POST", "/api/v1/contracts"),
+	}
+
+	got := DeduplicateHTTPSynthesisANY(synthEntities, drfEntities)
+
+	if len(got) != 1 {
+		t.Errorf("expected 1 entity preserved, got %d", len(got))
+	}
+	if len(got) > 0 && got[0].ID != "http:ANY:"+genuinePath {
+		t.Errorf("wrong entity preserved: %q", got[0].ID)
+	}
+}
+
+// TestDeduplicateHTTPSynthesisANY_EmptyInputs verifies nil-safety.
+func TestDeduplicateHTTPSynthesisANY_EmptyInputs(t *testing.T) {
+	if got := DeduplicateHTTPSynthesisANY(nil, nil); got != nil {
+		t.Errorf("expected nil for nil inputs, got %v", got)
+	}
+	entities := []types.EntityRecord{makeHTTPSynthesisANY("/api/v1/foo")}
+	if got := DeduplicateHTTPSynthesisANY(entities, nil); len(got) != 1 {
+		t.Errorf("expected 1 entity preserved with nil drfEntities, got %d", len(got))
+	}
+	if got := DeduplicateHTTPSynthesisANY(nil, []types.EntityRecord{makeDRFExpanded("GET", "/api/v1/foo")}); got != nil {
+		t.Errorf("expected nil for nil synthEntities, got %v", got)
+	}
+}
+
+// TestDeduplicateHTTPSynthesisANY_ModelViewSetAndAction verifies the full
+// fixture from issue #1126: a ModelViewSet with one @action emits 6+1=7
+// drf_router_expanded entries; the synthesis ANY for the same paths must be
+// dropped. The @action-path ANY synthesis entry should also be dropped when
+// covered.
+func TestDeduplicateHTTPSynthesisANY_ModelViewSetAndAction(t *testing.T) {
+	listPath := "/api/v1/users"
+	detailPath := "/api/v1/users/{pk}"
+	actionPath := "/api/v1/users/activate"
+
+	synthEntities := []types.EntityRecord{
+		makeHTTPSynthesisANY(listPath),
+		makeHTTPSynthesisANY(detailPath),
+		makeHTTPSynthesisANY(actionPath),
+	}
+
+	drfEntities := []types.EntityRecord{
+		makeDRFExpanded("GET", listPath),
+		makeDRFExpanded("POST", listPath),
+		makeDRFExpanded("GET", detailPath),
+		makeDRFExpanded("PUT", detailPath),
+		makeDRFExpanded("PATCH", detailPath),
+		makeDRFExpanded("DELETE", detailPath),
+		{
+			ID:   "http:ANY:" + detailPath,
+			Name: "http:ANY:" + detailPath,
+			Kind: httpEndpointKind,
+			Properties: map[string]string{
+				"verb": "ANY", "path": detailPath,
+				"framework": "django", "pattern_type": "drf_router_expanded",
+			},
+		},
+		// @action(detail=False, methods=["post"]) on activate endpoint.
+		makeDRFExpanded("POST", actionPath),
+	}
+
+	got := DeduplicateHTTPSynthesisANY(synthEntities, drfEntities)
+
+	// All three http_endpoint_synthesis ANY entries must be removed.
+	for _, e := range got {
+		if e.Kind == httpEndpointKind &&
+			e.Properties != nil &&
+			e.Properties["pattern_type"] == "http_endpoint_synthesis" &&
+			e.Properties["verb"] == "ANY" {
+			t.Errorf("unexpected http_endpoint_synthesis ANY survived: id=%q path=%q",
+				e.ID, e.Properties["path"])
+		}
+	}
+
+	if len(got) != 0 {
+		t.Errorf("expected 0 remaining entities, got %d", len(got))
+	}
+}

--- a/internal/engine/event_bus_edges_test.go
+++ b/internal/engine/event_bus_edges_test.go
@@ -64,7 +64,7 @@ func requireEventBusEntity(t *testing.T, ents []types.EntityRecord, id, label st
 	}
 }
 
-func requireEdgeTo(t *testing.T, rels []types.RelationshipRecord, toID, kind, label string) {
+func requireEdgeToEB(t *testing.T, rels []types.RelationshipRecord, toID, kind, label string) {
 	t.Helper()
 	for _, r := range rels {
 		if r.Kind == kind && r.ToID == toID {
@@ -73,6 +73,7 @@ func requireEdgeTo(t *testing.T, rels []types.RelationshipRecord, toID, kind, la
 	}
 	t.Errorf("%s: expected %s edge to %q; rels=%v", label, kind, toID, relSummary(rels))
 }
+
 
 func requireEdgeFromTo(t *testing.T, rels []types.RelationshipRecord, fromID, toID, kind, label string) {
 	t.Helper()
@@ -134,7 +135,7 @@ def publish_order(order):
 
 	wantID := "event:eventbridge:orders:OrderPlaced"
 	requireEventBusEntity(t, ents, wantID, "boto3 producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "boto3 producer edge")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "boto3 producer edge")
 }
 
 func TestEventBridgeNodeProducer(t *testing.T) {
@@ -160,7 +161,7 @@ async function emitOrderEvent() {
 
 	wantID := "event:eventbridge:order.svc:OrderPlaced"
 	requireEventBusEntity(t, ents, wantID, "Node PutEventsCommand producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node producer edge")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node producer edge")
 }
 
 func TestEventBridgeGoProducer(t *testing.T) {
@@ -187,7 +188,7 @@ func PublishShipped(ctx context.Context, orderID string) error {
 
 	wantID := "event:eventbridge:fulfillment:OrderShipped"
 	requireEventBusEntity(t, ents, wantID, "Go producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Go producer edge")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Go producer edge")
 }
 
 func TestEventBridgeTerraformRuleAndTarget(t *testing.T) {
@@ -218,7 +219,7 @@ resource "aws_cloudwatch_event_target" "lambda_target" {
 
 	// Target should emit EVENTBRIDGE_TRIGGERS to the Lambda.
 	lambdaTarget := serverlessFunctionKind + ":" + lambdaFunctionID("process_order")
-	requireEdgeTo(t, rels, lambdaTarget, eventBridgeTriggersEdge, "TF target EVENTBRIDGE_TRIGGERS")
+	requireEdgeToEB(t, rels, lambdaTarget, eventBridgeTriggersEdge, "TF target EVENTBRIDGE_TRIGGERS")
 }
 
 func TestEventBridgeTerraformLambdaSubscribesToEvent(t *testing.T) {
@@ -241,7 +242,7 @@ resource "aws_cloudwatch_event_target" "order_target" {
 	requireEventBusEntity(t, ents, wantEventID, "HCL rule event entity")
 
 	lambdaID := serverlessFunctionKind + ":" + lambdaFunctionID("order_handler")
-	requireEdgeTo(t, rels, lambdaID, eventBridgeTriggersEdge, "HCL EVENTBRIDGE_TRIGGERS")
+	requireEdgeToEB(t, rels, lambdaID, eventBridgeTriggersEdge, "HCL EVENTBRIDGE_TRIGGERS")
 	requireEdgeFromTo(t, rels, lambdaID, eventBusEventKind+":"+wantEventID, "SUBSCRIBES_TO", "Lambda SUBSCRIBES_TO event")
 }
 
@@ -287,7 +288,7 @@ def publish_inventory(topic_key):
 
 	wantID := "event:eventgrid:/inventory/low:Inventory.LowStock"
 	requireEventBusEntity(t, ents, wantID, "EventGrid Python producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Python producer edge")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Python producer edge")
 }
 
 func TestEventGridPythonConsumer(t *testing.T) {
@@ -305,9 +306,9 @@ async def handle_inventory_event(event: func.EventGridEvent):
 	// Should emit wildcard EventBusEvent + SUBSCRIBES_TO + EVENTGRID_TRIGGERS.
 	wildcardID := "event:eventgrid:*:*"
 	requireEventBusEntity(t, ents, wildcardID, "EventGrid consumer wildcard entity")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "EventGrid consumer SUBSCRIBES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "EventGrid consumer SUBSCRIBES_TO")
 	azureTarget := serverlessFunctionKind + ":" + azureFunctionID("handle_inventory_event")
-	requireEdgeTo(t, rels, azureTarget, eventGridTriggersEdge, "EventGrid EVENTGRID_TRIGGERS")
+	requireEdgeToEB(t, rels, azureTarget, eventGridTriggersEdge, "EventGrid EVENTGRID_TRIGGERS")
 }
 
 func TestEventGridNodeProducer(t *testing.T) {
@@ -329,7 +330,7 @@ async function emitOrderShipped() {
 
 	wantID := "event:eventgrid:/orders/shipped:Order.Shipped"
 	requireEventBusEntity(t, ents, wantID, "EventGrid Node producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Node producer edge")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "EventGrid Node producer edge")
 }
 
 func TestEventGridCSharpConsumer(t *testing.T) {
@@ -352,9 +353,9 @@ public static class InventoryFunction
 
 	wildcardID := "event:eventgrid:*:*"
 	requireEventBusEntity(t, ents, wildcardID, "C# EventGridTrigger consumer entity")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "C# EventGridTrigger SUBSCRIBES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "C# EventGridTrigger SUBSCRIBES_TO")
 	azureTarget := serverlessFunctionKind + ":" + azureFunctionID("Run")
-	requireEdgeTo(t, rels, azureTarget, eventGridTriggersEdge, "C# EVENTGRID_TRIGGERS")
+	requireEdgeToEB(t, rels, azureTarget, eventGridTriggersEdge, "C# EVENTGRID_TRIGGERS")
 }
 
 // ---------------------------------------------------------------------------
@@ -378,7 +379,7 @@ def emit_shipment_event(order_id: str):
 
 	wantID := "event:cloudevents:/shop/orders:com.example.order.shipped"
 	requireEventBusEntity(t, ents, wantID, "Python CloudEvent producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Python CloudEvent PUBLISHES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Python CloudEvent PUBLISHES_TO")
 }
 
 func TestCloudEventNodeProducer(t *testing.T) {
@@ -399,7 +400,7 @@ async function publishEvent() {
 
 	wantID := "event:cloudevents:/users/signup:com.example.user.created"
 	requireEventBusEntity(t, ents, wantID, "Node CloudEvent producer")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node CloudEvent PUBLISHES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantID, "PUBLISHES_TO", "Node CloudEvent PUBLISHES_TO")
 }
 
 func TestCloudEventGoProducer(t *testing.T) {
@@ -427,12 +428,12 @@ func SendEvent(ctx context.Context) error {
 
 	wantProducerID := "event:cloudevents:https://example.com/producer:com.example.data.created"
 	requireEventBusEntity(t, ents, wantProducerID, "Go CloudEvent producer entity")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wantProducerID, "PUBLISHES_TO", "Go CloudEvent PUBLISHES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wantProducerID, "PUBLISHES_TO", "Go CloudEvent PUBLISHES_TO")
 
 	// NewClientHTTP() also registers a consumer wildcard.
 	wildcardID := "event:cloudevents:*:*"
 	requireEventBusEntity(t, ents, wildcardID, "Go CloudEvent client consumer entity")
-	requireEdgeTo(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "Go CloudEvent SUBSCRIBES_TO")
+	requireEdgeToEB(t, rels, eventBusEventKind+":"+wildcardID, "SUBSCRIBES_TO", "Go CloudEvent SUBSCRIBES_TO")
 }
 
 func TestCloudEventHTTPHeaderDetection(t *testing.T) {


### PR DESCRIPTION
## Summary

DRF ViewSet routes were showing \`ANY\` verb instead of concrete HTTP methods in archigraph. Root cause: two passes both emitted entries for the same paths with different IDs, so both coexisted:

- **Pass 2.5** (\`applyHTTPEndpointSynthesis\` → \`synthesizeDjangoFromComposed\`): emits \`http:ANY:<path>\` for every \`ast_driven\` Route entity — one per urlconf file, per-file pass.
- **Pass 2.6b** (\`ApplyDjangoDRFRoutes\`): emits the correct per-verb entries (\`http:GET:<path>\`, \`http:POST:<path>\`, etc.) by introspecting ViewSet parent classes.

Because \`http:ANY:/api/v1/contracts\` ≠ \`http:GET:/api/v1/contracts\`, both sets coexisted in the merged entity list, inflating the ANY count to ~200.

**Fix**: Add \`DeduplicateHTTPSynthesisANY\` (mirroring the existing \`DeduplicateNestedURLConfDRF\`) which drops \`http_endpoint_synthesis\` ANY entries for every canonical path already covered by at least one \`drf_router_expanded\` concrete-verb entry. The intentional ANY catch-all emitted by \`emitCRUDFamily\` (pattern_type=\`drf_router_expanded\`) is explicitly preserved.

Wire the new dedup step in \`index.go\` immediately after \`drfEntities\` are computed, before they are appended to \`pass3Records\`.

**Scope**: ~200 DRF ViewSet-backed paths in upvate_core drop from \`ANY\` to concrete methods. Genuine multi-verb endpoints (non-DRF, or routes without \`drf_router_expanded\` coverage) are unaffected.

**Pre-existing fix bundled**: \`requireEdgeTo\` was declared twice in the engine test package (\`event_bus_edges_test.go\` and \`workflow_edges_test.go\`) with incompatible parameter signatures, blocking ALL engine tests from compiling. Renamed the declaration in \`event_bus_edges_test.go\` to \`requireEdgeToEB\` and updated its 15 call sites. This unblocks the new tests and all existing engine tests.

## Closes / Refs

Closes #1126

## Testing

- [x] 5 new unit tests for \`DeduplicateHTTPSynthesisANY\` covering: ModelViewSet CRUD, ReadOnlyModelViewSet, no-DRF-coverage preservation, nil-safety, ModelViewSet + @action
- [x] All existing \`TestApplyDjangoDRFRoutes_*\` and \`TestDeduplicateNestedURLConfDRF_*\` tests pass
- [x] Full engine package: \`go test ./internal/engine/\` passes (7.9s)
- [x] Engine package builds clean: \`go build ./internal/engine/...\`

## Notes

The \`drf_router_expanded\` ANY catch-all in \`emitCRUDFamily\` (the detail-route wildcard for verb-agnostic consumer matching) is intentionally preserved — it has \`pattern_type=drf_router_expanded\` not \`http_endpoint_synthesis\`, so the filter skips it.

Live verification command (after rebuild):
\`\`\`
curl -sf http://127.0.0.1:47274/api/paths/upvate | python3 -c '
import json,sys
d=json.load(sys.stdin)
any_count=sum(1 for p in d.get("paths",[]) if p.get("method")=="ANY")
print("ANY:", any_count)
'
\`\`\`
Expected: drop from ~200 to <30.