### PR TITLE
feat(topology): orphan subscriber detector — GET /api/topology/{group}/orphan-subscribers (#1137)

### DIFF
--- a/internal/dashboard/handlers_topology_orphans.go
+++ b/internal/dashboard/handlers_topology_orphans.go
@@ -1,6 +1,9 @@
 package dashboard
 
-// handlers_topology_orphans.go — Topology v2: orphan publisher detector (#1136).
+// handlers_topology_orphans.go — Topology v2: orphan publisher (#1136) and
+// orphan subscriber (#1137) detectors.
+//
+// Orphan publishers:
 //
 //	GET /api/topology/{group}/orphan-publishers
 //
@@ -12,17 +15,26 @@ package dashboard
 // These are "fire-and-forget" message producers with no known listener —
 // a likely dead-letter or integration gap.
 //
-// Detection algorithm:
-//  1. Walk all entities in the group; keep only those whose topology bucket
-//     is topic, queue, channel, or subscription (nats_subjects and
-//     graphql_subscriptions share these buckets).
-//  2. For each such entity, collect producers and consumers using the same
-//     brokerEdges / channelEdges helpers already used by collectTopologyResponse.
-//  3. Emit a row when len(producers) > 0 && len(consumers) == 0.
-//  4. Entities with zero producers AND zero consumers are NOT emitted
-//     (those are orphan subscribers, a different endpoint).
+// Orphan subscribers:
 //
-// Wire shape:
+//	GET /api/topology/{group}/orphan-subscribers
+//
+// Returns every topic/queue/channel entity that has at least one consumer
+// but zero producers anywhere in the group. These are listeners waiting for
+// messages that no known code publishes — typically dead consumers or
+// misconfigured queue bindings.
+//
+// Detection algorithms:
+//  1. Walk all entities in the group; keep only those whose topology bucket
+//     is topic, queue, channel, or subscription.
+//  2. For each such entity collect producers and consumers using the same
+//     brokerEdges / channelEdges helpers used by collectTopologyResponse.
+//  3. Orphan publisher: len(producers) > 0 && len(consumers) == 0.
+//  4. Orphan subscriber: len(consumers) > 0 && len(producers) == 0.
+//  5. Entities with zero producers AND zero consumers are NOT emitted by
+//     either endpoint.
+//
+// Orphan-publisher wire shape:
 //
 //	{
 //	  "orphan_publishers": [
@@ -39,7 +51,26 @@ package dashboard
 //	  "total": N
 //	}
 //
-// All array fields marshal as [] (never null).
+// Orphan-subscriber wire shape:
+//
+//	{
+//	  "orphan_subscribers": [
+//	    {
+//	      "id":               "repo::entityId",
+//	      "label":            "orders.created",
+//	      "broker":           "rabbitmq",
+//	      "framework":        "",
+//	      "repo":             "backend",
+//	      "consumers":        ["repo::entityId1"],
+//	      "reason":           "no_publisher_found",
+//	      "last_message_seen": null
+//	    }
+//	  ],
+//	  "total": N
+//	}
+//
+// All array fields marshal as [] (never null). last_message_seen is always
+// null today but the field is reserved for future timestamp population.
 
 import (
 	"net/http"
@@ -150,6 +181,141 @@ func collectOrphanPublishers(grp *DashGroup) []OrphanPublisherRow {
 
 	if rows == nil {
 		rows = []OrphanPublisherRow{}
+	}
+	return rows
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Orphan subscriber detector (#1137)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// OrphanSubscriberRow is one entity returned by the orphan-subscriber endpoint.
+type OrphanSubscriberRow struct {
+	ID              string   `json:"id"`
+	Label           string   `json:"label"`
+	Broker          string   `json:"broker"`
+	Framework       string   `json:"framework"`
+	Repo            string   `json:"repo"`
+	Consumers       []string `json:"consumers"`
+	Reason          string   `json:"reason"`
+	LastMessageSeen *string  `json:"last_message_seen"` // always null today; field reserved
+}
+
+// reason constants for the orphan-subscriber endpoint.
+const (
+	reasonNoPublisherFound        = "no_publisher_found"
+	reasonPublisherOnlyInExternal = "publisher_only_in_external_lib"
+)
+
+// handleOrphanSubscribers — GET /api/topology/{group}/orphan-subscribers
+func (s *Server) handleOrphanSubscribers(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	rows := collectOrphanSubscribers(grp)
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"orphan_subscribers": rows,
+		"total":              len(rows),
+	})
+}
+
+// collectOrphanSubscribers runs the orphan-subscriber detection pass against a
+// loaded group. Extracted so unit tests can call it without HTTP scaffolding.
+func collectOrphanSubscribers(grp *DashGroup) []OrphanSubscriberRow {
+	var rows []OrphanSubscriberRow
+
+	for _, r := range sortedRepos(grp) {
+		if r.Doc == nil {
+			continue
+		}
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			bucket := classifyTopologyBucket(e.Kind, e.Name, e.Properties)
+
+			// Only inspect buckets that use broker/channel semantics.
+			switch bucket {
+			case "topic", "queue", "channel", "subscription":
+				// handled below
+			default:
+				continue
+			}
+
+			var producers, consumers []string
+
+			switch bucket {
+			case "topic", "queue":
+				producers, consumers, _ = brokerEdges(r, e.ID)
+			case "channel":
+				// channelEdges returns (emitters, subscribers); map to producers/consumers.
+				producers, consumers = channelEdges(r, e.ID)
+			case "subscription":
+				// graphqlSubEdges returns (publishers, subscribers).
+				producers, consumers = graphqlSubEdges(r, e.ID)
+			}
+
+			// Emit only when there is at least one consumer and zero producers.
+			if len(consumers) == 0 || len(producers) > 0 {
+				continue
+			}
+
+			broker := e.Properties["broker"]
+			if broker == "" {
+				broker = inferBrokerFromName(e.Name)
+			}
+			framework := e.Properties["framework"]
+
+			// Reason classification: if the entity properties hint that the
+			// publisher lives in an external library, surface that explicitly;
+			// otherwise default to no_publisher_found.
+			reason := reasonNoPublisherFound
+			if e.Properties["publisher_source"] == "external" ||
+				e.Properties["producer_source"] == "external" {
+				reason = reasonPublisherOnlyInExternal
+			}
+
+			row := OrphanSubscriberRow{
+				ID:              dashPrefixedID(r.Slug, e.ID),
+				Label:           e.Name,
+				Broker:          broker,
+				Framework:       framework,
+				Repo:            r.Slug,
+				Consumers:       consumers,
+				Reason:          reason,
+				LastMessageSeen: nil, // reserved for future timestamp
+			}
+			rows = append(rows, row)
+		}
+	}
+
+	// Stable deterministic sort: repo → label → first consumer label.
+	sort.Slice(rows, func(i, j int) bool {
+		a, b := rows[i], rows[j]
+		if a.Repo != b.Repo {
+			return a.Repo < b.Repo
+		}
+		if a.Label != b.Label {
+			return a.Label < b.Label
+		}
+		// Tertiary: first consumer ID for full stability.
+		if len(a.Consumers) > 0 && len(b.Consumers) > 0 {
+			return a.Consumers[0] < b.Consumers[0]
+		}
+		return len(a.Consumers) < len(b.Consumers)
+	})
+
+	if rows == nil {
+		rows = []OrphanSubscriberRow{}
 	}
 	return rows
 }

--- a/internal/dashboard/handlers_topology_orphans_test.go
+++ b/internal/dashboard/handlers_topology_orphans_test.go
@@ -391,3 +391,407 @@ func TestHandleOrphanPublishers_UnknownGroup(t *testing.T) {
 		t.Errorf("status: want 404, got %d", resp.StatusCode)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests for collectOrphanSubscribers (#1137)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestOrphanSubscribers_ConsumerOnly — consumer subscribes to topic-X but no
+// producer exists → 1 orphan subscriber row.
+func TestOrphanSubscribers_ConsumerOnly(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-x",
+			Name:       "topic-X",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "rabbitmq"},
+		},
+		{
+			ID:   "consumer-svc",
+			Name: "OrderListener",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{
+			ID:     "r1",
+			FromID: "topic-x",
+			ToID:   "consumer-svc",
+			Kind:   "SUBSCRIBES_TO",
+		},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan subscriber row, got %d", len(rows))
+	}
+	row := rows[0]
+	if row.Label != "topic-X" {
+		t.Errorf("label: want topic-X, got %q", row.Label)
+	}
+	if row.Broker != "rabbitmq" {
+		t.Errorf("broker: want rabbitmq, got %q", row.Broker)
+	}
+	if row.Repo != "backend" {
+		t.Errorf("repo: want backend, got %q", row.Repo)
+	}
+	if row.Reason != reasonNoPublisherFound {
+		t.Errorf("reason: want %q, got %q", reasonNoPublisherFound, row.Reason)
+	}
+	if len(row.Consumers) != 1 {
+		t.Errorf("consumers: want 1, got %d", len(row.Consumers))
+	}
+	if row.Consumers[0] != "backend::consumer-svc" {
+		t.Errorf("consumers[0]: want backend::consumer-svc, got %q", row.Consumers[0])
+	}
+	if row.LastMessageSeen != nil {
+		t.Errorf("last_message_seen: want nil, got %v", row.LastMessageSeen)
+	}
+}
+
+// TestOrphanSubscribers_ProducerAndConsumer — both sides present → 0 orphan
+// subscribers.
+func TestOrphanSubscribers_ProducerAndConsumer(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-a",
+			Name:       "queue-A",
+			Kind:       "Queue",
+			Properties: map[string]string{"broker": "sqs"},
+		},
+		{
+			ID:   "pub-svc",
+			Name: "Sender",
+			Kind: "Function",
+		},
+		{
+			ID:   "sub-svc",
+			Name: "Receiver",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub-svc", ToID: "topic-a", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "topic-a", ToID: "sub-svc", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 orphan subscribers when producer exists, got %d", len(rows))
+	}
+}
+
+// TestOrphanSubscribers_ProducerOnly — topic has only a producer and no
+// consumer → NOT an orphan subscriber (different endpoint).
+func TestOrphanSubscribers_ProducerOnly(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-b",
+			Name:       "orders.created",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "kafka"},
+		},
+		{
+			ID:   "producer-svc",
+			Name: "OrderPublisher",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "producer-svc", ToID: "topic-b", Kind: "PUBLISHES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 orphan subscribers for producer-only topic, got %d", len(rows))
+	}
+}
+
+// TestOrphanSubscribers_ZeroProducersZeroConsumers — isolated topic is not
+// reported by either endpoint.
+func TestOrphanSubscribers_ZeroProducersZeroConsumers(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "lonely-topic", Name: "lonely", Kind: "MessageTopic"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, nil)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows for isolated topic, got %d", len(rows))
+	}
+}
+
+// TestOrphanSubscribers_ChannelOrphan — a ChannelEvent with a subscriber and
+// no emitter is an orphan subscriber.
+func TestOrphanSubscribers_ChannelOrphan(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "chan-1",
+			Name: "updates",
+			Kind: "ChannelEvent",
+			Properties: map[string]string{
+				"channel_type": "websocket",
+			},
+		},
+		{
+			ID:   "listener-svc",
+			Name: "FrontendListener",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		// WS_SUBSCRIBES_TO: subscriber points TO the channel entity (same
+		// convention as WS_EMITS pointing TO the channel from the emitter).
+		{ID: "r1", FromID: "listener-svc", ToID: "chan-1", Kind: "WS_SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 orphan channel subscriber row, got %d", len(rows))
+	}
+	if rows[0].Label != "updates" {
+		t.Errorf("label: want updates, got %q", rows[0].Label)
+	}
+}
+
+// TestOrphanSubscribers_ExternalPublisherReason — if publisher_source=external
+// the row reason must be 'publisher_only_in_external_lib'.
+func TestOrphanSubscribers_ExternalPublisherReason(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "ext-topic",
+			Name: "vendor.events",
+			Kind: "MessageTopic",
+			Properties: map[string]string{
+				"broker":           "kafka",
+				"publisher_source": "external",
+			},
+		},
+		{
+			ID:   "inner-consumer",
+			Name: "VendorEventConsumer",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "ext-topic", ToID: "inner-consumer", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 1 {
+		t.Fatalf("expected 1 row, got %d", len(rows))
+	}
+	if rows[0].Reason != reasonPublisherOnlyInExternal {
+		t.Errorf("reason: want %q, got %q", reasonPublisherOnlyInExternal, rows[0].Reason)
+	}
+}
+
+// TestOrphanSubscribers_EmptyGroup — empty group returns [] not nil.
+func TestOrphanSubscribers_EmptyGroup(t *testing.T) {
+	grp := &DashGroup{
+		Name:  "empty",
+		Repos: map[string]*DashRepo{},
+	}
+	rows := collectOrphanSubscribers(grp)
+
+	if rows == nil {
+		t.Fatal("expected non-nil slice for empty group")
+	}
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows, got %d", len(rows))
+	}
+}
+
+// TestOrphanSubscribers_NonTopologyEntitiesIgnored — Function entities must
+// not appear in orphan subscriber output.
+func TestOrphanSubscribers_NonTopologyEntitiesIgnored(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "fn1", Name: "doWork", Kind: "Function"},
+		{ID: "fn2", Name: "helper", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 0 {
+		t.Errorf("expected 0 rows for non-topology entities, got %d", len(rows))
+	}
+}
+
+// TestOrphanSubscribers_StableSort — multiple orphan subscribers are sorted
+// repo → label.
+func TestOrphanSubscribers_StableSort(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "topic-z", Name: "zzz-queue", Kind: "Queue", Properties: map[string]string{"broker": "sqs"}},
+		{ID: "topic-a", Name: "aaa-queue", Kind: "Queue", Properties: map[string]string{"broker": "sqs"}},
+		{ID: "cons-1", Name: "ConsumerA", Kind: "Function"},
+		{ID: "cons-2", Name: "ConsumerB", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "topic-z", ToID: "cons-1", Kind: "SUBSCRIBES_TO"},
+		{ID: "r2", FromID: "topic-a", ToID: "cons-2", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	rows := collectOrphanSubscribers(grp)
+
+	if len(rows) != 2 {
+		t.Fatalf("expected 2 rows, got %d", len(rows))
+	}
+	if rows[0].Label != "aaa-queue" || rows[1].Label != "zzz-queue" {
+		t.Errorf("sort order wrong: [%q, %q]", rows[0].Label, rows[1].Label)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration smoke: HTTP endpoint for orphan-subscribers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleOrphanSubscribers_HTTPSmoke(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:         "topic-smoke",
+			Name:       "topic-X",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "rabbitmq"},
+		},
+		{
+			ID:   "cons-smoke",
+			Name: "SmokeConsumer",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "rs1", FromID: "topic-smoke", ToID: "cons-smoke", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	grp.Name = "mygrp"
+
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/mygrp/orphan-subscribers")
+	if err != nil {
+		t.Fatalf("GET orphan-subscribers: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200, got %d", resp.StatusCode)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		OrphanSubscribers []OrphanSubscriberRow `json:"orphan_subscribers"`
+		Total             int                   `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode response: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if len(body.OrphanSubscribers) != 1 {
+		t.Fatalf("orphan_subscribers len: want 1, got %d", len(body.OrphanSubscribers))
+	}
+
+	row := body.OrphanSubscribers[0]
+	if row.Label != "topic-X" {
+		t.Errorf("label: want topic-X, got %q", row.Label)
+	}
+	if row.Broker != "rabbitmq" {
+		t.Errorf("broker: want rabbitmq, got %q", row.Broker)
+	}
+	if row.Reason != reasonNoPublisherFound {
+		t.Errorf("reason: want %q, got %q", reasonNoPublisherFound, row.Reason)
+	}
+	if row.Consumers == nil {
+		t.Error("consumers must not be nil")
+	}
+	if row.LastMessageSeen != nil {
+		t.Errorf("last_message_seen: want null, got %v", row.LastMessageSeen)
+	}
+}
+
+func TestHandleOrphanSubscribers_EmptyResult_ArrayNotNull(t *testing.T) {
+	// A group where the topic has both producer and consumer must return [].
+	entities := []graph.Entity{
+		{
+			ID:         "topic-covered",
+			Name:       "covered",
+			Kind:       "MessageTopic",
+			Properties: map[string]string{"broker": "kafka"},
+		},
+		{
+			ID:   "pub",
+			Name: "Publisher",
+			Kind: "Function",
+		},
+		{
+			ID:   "sub",
+			Name: "Subscriber",
+			Kind: "Function",
+		},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub", ToID: "topic-covered", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "topic-covered", ToID: "sub", Kind: "SUBSCRIBES_TO"},
+	}
+
+	grp := makeTopologyOrphanGroup(entities, rels)
+	grp.Name = "mygrp"
+
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/mygrp/orphan-subscribers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	subscribers, ok := body["orphan_subscribers"]
+	if !ok {
+		t.Fatal("orphan_subscribers key missing")
+	}
+	arr, ok := subscribers.([]any)
+	if !ok || len(arr) != 0 {
+		t.Errorf("expected empty array, got %v", subscribers)
+	}
+}
+
+func TestHandleOrphanSubscribers_UnknownGroup(t *testing.T) {
+	grp := makeTopologyOrphanGroup(nil, nil)
+	grp.Name = "mygrp"
+	ts := newOrphanPublisherTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/topology/nosuchgroup/orphan-subscribers")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -173,6 +173,7 @@ func (s *Server) routes() http.Handler {
 	// Broker topology
 	mux.HandleFunc("GET /api/topology/{group}", s.handleTopology)
 	mux.HandleFunc("GET /api/topology/{group}/orphan-publishers", s.handleOrphanPublishers)
+	mux.HandleFunc("GET /api/topology/{group}/orphan-subscribers", s.handleOrphanSubscribers)
 
 	// Docs portal
 	mux.HandleFunc("GET /api/docs/{group}", s.handleDocTree)


### PR DESCRIPTION
## What

Adds `GET /api/topology/{group}/orphan-subscribers` — the inverse of the orphan-publisher endpoint (#1136, PR #1155). Returns every topic/queue/channel that has at least one consumer but zero producers anywhere in the group: dead listeners waiting for messages that no known backend code sends.

## Why

Part of Topology v2 epic #1135. Orphan subscribers surface misconfigured queue bindings and dead consumers — the counterpart to fire-and-forget producers.

## How

Detection mirrors `collectOrphanPublishers` exactly:
- Walk all entities; keep only `topic`, `queue`, `channel`, `subscription` buckets.
- Call `brokerEdges` / `channelEdges` / `graphqlSubEdges` (existing helpers, no changes).
- Emit a row when `len(consumers) > 0 && len(producers) == 0`.

**Beyond the minimum (per issue spec):**
- Reason classification: `"no_publisher_found"` (default) or `"publisher_only_in_external_lib"` when entity property `publisher_source`/`producer_source` is `"external"`.
- `last_message_seen: null` field reserved on every row for future timestamp population.
- Three-key stable sort: repo → label → first consumer ID.

Wire shape:
```json
{
  "orphan_subscribers": [
    {
      "id": "backend::topic-x",
      "label": "topic-X",
      "broker": "rabbitmq",
      "framework": "",
      "repo": "backend",
      "consumers": ["backend::consumer-svc"],
      "reason": "no_publisher_found",
      "last_message_seen": null
    }
  ],
  "total": 1
}
```

## Files changed

| File | Change |
|------|--------|
| `internal/dashboard/handlers_topology_orphans.go` | `OrphanSubscriberRow` type, `collectOrphanSubscribers`, `handleOrphanSubscribers`; reason constants; extended file-level docblock |
| `internal/dashboard/handlers_topology_orphans_test.go` | 12 new tests (unit + HTTP integration) |
| `internal/dashboard/server.go` | Route registration `GET /api/topology/{group}/orphan-subscribers` |

## Tests

12 new tests, all green. Full dashboard suite passes.

| Test | Covers |
|------|--------|
| `TestOrphanSubscribers_ConsumerOnly` | 1 consumer, 0 producers → 1 orphan row |
| `TestOrphanSubscribers_ProducerAndConsumer` | Both sides → 0 orphans |
| `TestOrphanSubscribers_ProducerOnly` | Producer only → 0 orphans (publisher endpoint territory) |
| `TestOrphanSubscribers_ZeroProducersZeroConsumers` | Isolated topic → 0 orphans |
| `TestOrphanSubscribers_ChannelOrphan` | `WS_SUBSCRIBES_TO` channel with no emitter |
| `TestOrphanSubscribers_ExternalPublisherReason` | `publisher_source=external` → `publisher_only_in_external_lib` |
| `TestOrphanSubscribers_EmptyGroup` | Empty group → `[]` not nil |
| `TestOrphanSubscribers_NonTopologyEntitiesIgnored` | Function nodes never appear |
| `TestOrphanSubscribers_StableSort` | repo → label sort order |
| `TestHandleOrphanSubscribers_HTTPSmoke` | 200 + correct JSON shape |
| `TestHandleOrphanSubscribers_EmptyResult_ArrayNotNull` | `[]` not null when no orphans |
| `TestHandleOrphanSubscribers_UnknownGroup` | 404 for unknown group |

Closes #1137. Part of epic #1135.