### PR TITLE
fix(paths): filter XML namespace XPath strings from Paths list (#1125)

### DIFF
--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -99,6 +99,13 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			if path == "" {
 				path = e.Name
 			}
+			// Issue #1125 — drop XML namespace XPath strings (e.g.
+			// `./w:tblBorders`) that leaked into the entity graph via YAML
+			// rules firing on python-docx / lxml code. HTTP paths never
+			// start with "./" or contain short-alphabetic-prefix colons.
+			if !isHTTPEndpointPath(path) {
+				continue
+			}
 			verb := strings.ToUpper(e.Properties["verb"])
 			if verb == "" {
 				verb = "ANY"
@@ -529,6 +536,64 @@ func buildPrefixTree(rows []PathRow) []PathTreeNode {
 		return out
 	}
 	return toNodes(root)
+}
+
+// isHTTPEndpointPath reports whether path looks like a real HTTP endpoint
+// path rather than an XML namespace XPath expression or other non-HTTP
+// string that leaked into the entity graph. Issue #1125.
+//
+// Accepted:
+//   - Paths starting with "/" (absolute routes)
+//   - Full URLs starting with http(s)://
+//
+// Rejected:
+//   - Paths containing "./" (XPath relative notation)
+//   - Paths containing "[@" (XPath attribute selector)
+//   - Paths containing a short (≤4 char) alphabetic prefix:Name segment
+//     e.g. "w:tblBorders", "xml:lang" — classic XML namespace patterns
+func isHTTPEndpointPath(path string) bool {
+	if path == "" {
+		return false
+	}
+	// Full absolute URL — always valid.
+	if strings.HasPrefix(path, "http://") || strings.HasPrefix(path, "https://") {
+		return true
+	}
+	// Must start with "/" for an HTTP route.
+	if !strings.HasPrefix(path, "/") {
+		return false
+	}
+	// Reject XPath relative notation.
+	if strings.Contains(path, "./") {
+		return false
+	}
+	// Reject XPath attribute selectors.
+	if strings.Contains(path, "[@") {
+		return false
+	}
+	// Reject paths with XML namespace prefix:Name segments.
+	segments := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	for _, seg := range segments {
+		colonIdx := strings.IndexByte(seg, ':')
+		if colonIdx <= 0 || colonIdx == len(seg)-1 {
+			continue
+		}
+		prefix := seg[:colonIdx]
+		if len(prefix) > 4 {
+			continue
+		}
+		allAlpha := true
+		for _, c := range prefix {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+				allAlpha = false
+				break
+			}
+		}
+		if allAlpha {
+			return false
+		}
+	}
+	return true
 }
 
 // containsStr checks if a string slice contains a string.

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -520,6 +520,127 @@ func TestPathsList_SearchFilter(t *testing.T) {
 	}
 }
 
+// TestIsHTTPEndpointPath verifies the path-shape predicate used by the
+// Paths list API to filter out XML namespace XPath strings (issue #1125).
+func TestIsHTTPEndpointPath(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Valid HTTP paths.
+		{"/api/v1/users", true},
+		{"/api/v1/users/{id}", true},
+		{"/webhooks/stripe", true},
+		{"/v1/orders/{pk}", true},
+		{"/", true},
+		{"https://example.com/api/v1/users", true},
+		{"http://localhost/api/orders", true},
+		// XML namespace XPath strings — must be rejected.
+		{"./w:tblBorders", false},
+		{"./w:tcBorders", false},
+		{"/./w:tblBorders", false},      // canonicalized form
+		{"/api/v1/w:something", false},  // XML prefix colon in segment
+		{"/w:root", false},
+		{"/div[@class='x']", false}, // XPath attribute selector
+		{"", false},
+		// Long "prefix" before colon — NOT XML namespace, should pass.
+		{"/version1/items", true},  // no colon at all
+	}
+	for _, tc := range cases {
+		got := isHTTPEndpointPath(tc.path)
+		if got != tc.want {
+			t.Errorf("isHTTPEndpointPath(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// TestPathsList_XMLNoiseFiltered verifies that XML namespace XPath strings
+// (e.g. "./w:tblBorders") are excluded from the Paths list even when they
+// are present as Route or http_endpoint entities in the graph (issue #1125).
+func TestPathsList_XMLNoiseFiltered(t *testing.T) {
+	// Build a server with extra XML-noise entities injected.
+	st := newFakeStore()
+	st.groups["xmlgroup"] = GroupSummary{
+		Name:       "xmlgroup",
+		ConfigPath: "/tmp/xmlgroup.json",
+		Repos:      []string{"svc"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	grp := fakeDashGroup()
+	grp.Name = "xmlgroup"
+
+	// Inject XML-noise Route and http_endpoint entities that should be
+	// filtered out from the Paths list.
+	xmlEntities := []graph.Entity{
+		{
+			ID:         "xml1",
+			Name:       "./w:tblBorders",
+			Kind:       "Route",
+			SourceFile: "docx_utils.py",
+			Language:   "python",
+			Properties: map[string]string{
+				"pattern_type": "ast_driven",
+				"framework":    "python",
+			},
+		},
+		{
+			ID:         "xml2",
+			Name:       "./w:tcBorders",
+			Kind:       "Route",
+			SourceFile: "docx_utils.py",
+			Language:   "python",
+			Properties: map[string]string{
+				"pattern_type": "ast_driven",
+				"framework":    "python",
+			},
+		},
+		{
+			ID:   "xml3",
+			Name: "http:ANY:/./w:tblBorders",
+			Kind: "http_endpoint",
+			Properties: map[string]string{
+				"path":         "/./w:tblBorders",
+				"verb":         "ANY",
+				"pattern_type": "http_endpoint_synthesis",
+			},
+		},
+	}
+	doc := grp.Repos["svc"].Doc
+	for _, e := range xmlEntities {
+		doc.Entities = append(doc.Entities, e)
+	}
+
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["xmlgroup"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	code, body := getJSON(t, ts.URL, "/api/paths/xmlgroup")
+	if code != 200 {
+		t.Fatalf("status=%d", code)
+	}
+	paths, _ := body["paths"].([]interface{})
+
+	// Verify none of the paths contain XML namespace strings.
+	for _, p := range paths {
+		pm := p.(map[string]any)
+		pathStr, _ := pm["path"].(string)
+		if strings.Contains(pathStr, "w:tblBorders") || strings.Contains(pathStr, "w:tcBorders") {
+			t.Errorf("XML namespace path %q should not appear in Paths list", pathStr)
+		}
+		if strings.Contains(pathStr, "./") {
+			t.Errorf("XPath relative path %q should not appear in Paths list", pathStr)
+		}
+	}
+}
+
 func TestPathDetail_200(t *testing.T) {
 	ts, _ := newPhase1Server(t)
 	// Compute the hash for /api/users.

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -383,6 +383,12 @@ func synthesizeDjangoFromComposed(entities []types.EntityRecord, path string, em
 		if canonical == "" {
 			continue
 		}
+		// Issue #1125 — reject XML namespace XPath strings that the Django
+		// YAML `path(...)` rule may have captured from python-docx / lxml
+		// code (e.g. `element.find(path('./w:tblBorders'))`).
+		if isXMLNamespacePath(canonical) {
+			continue
+		}
 		emit("ANY", canonical, "django", "Route", raw)
 
 		// #703 — DRF DefaultRouter / SimpleRouter auto-generates a
@@ -803,4 +809,57 @@ func hasDynamicBaseURLPath(path string) bool {
 	rest := strings.TrimPrefix(path, "/")
 	// First character of the first segment must open a placeholder.
 	return strings.HasPrefix(rest, "{")
+}
+
+// isXMLNamespacePath reports whether a canonical path looks like an XML
+// XPath namespace reference rather than an HTTP route. These arise when
+// YAML extraction rules fire on Python code that uses xml.etree, lxml,
+// or python-docx XPath APIs (e.g. `element.find('./w:tblBorders')`).
+//
+// Rejected patterns:
+//   - Paths containing a `prefix:Name` segment where `prefix` is a short
+//     (≤4 chars) purely alphabetic string — classic XML namespace prefix.
+//   - Paths with a `./` component (XPath relative path notation).
+//   - Paths containing `[@` (XPath attribute selector syntax).
+//
+// This guard is deliberately conservative: a false-negative (letting an
+// XML path through) is worse than a false-positive (dropping a
+// legitimate route). Legitimate HTTP paths never contain `./` or `[@`
+// and virtually never contain a short-prefix colon segment.
+func isXMLNamespacePath(canonical string) bool {
+	// XPath relative-path notation: ./elem or ./../elem
+	if strings.Contains(canonical, "./") {
+		return true
+	}
+	// XPath attribute selector: //div[@class='x']
+	if strings.Contains(canonical, "[@") {
+		return true
+	}
+	// XML namespace prefix: /api/w:tblBorders or just w:tblBorders
+	// Scan each slash-separated segment for the `prefix:Name` pattern.
+	segments := strings.Split(strings.TrimPrefix(canonical, "/"), "/")
+	for _, seg := range segments {
+		// Strip curly-brace path parameters before checking.
+		seg = strings.TrimPrefix(strings.TrimSuffix(seg, "}"), "{")
+		colonIdx := strings.IndexByte(seg, ':')
+		if colonIdx <= 0 || colonIdx == len(seg)-1 {
+			continue
+		}
+		prefix := seg[:colonIdx]
+		// XML namespace prefixes are short (1–4 chars) and purely alphabetic.
+		if len(prefix) > 4 {
+			continue
+		}
+		allAlpha := true
+		for _, c := range prefix {
+			if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z')) {
+				allAlpha = false
+				break
+			}
+		}
+		if allAlpha {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -972,3 +972,120 @@ func TestHasDynamicBaseURLPath(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1125 — isXMLNamespacePath unit tests
+// ---------------------------------------------------------------------------
+
+// TestIsXMLNamespacePath verifies that XML XPath expressions are correctly
+// identified so they can be excluded from http_endpoint synthesis.
+func TestIsXMLNamespacePath(t *testing.T) {
+	cases := []struct {
+		path    string
+		wantXML bool
+	}{
+		// XML XPath relative paths — must be detected.
+		{"./w:tblBorders", true},
+		{"./w:tcBorders", true},
+		{"./xml:element", true},
+		{"/./w:tblBorders", true}, // canonicalized form after normaliseSlashes
+		// XML namespace colons in path segments.
+		{"/api/v1/w:something", true},
+		{"/w:root/child", true},
+		// XPath attribute selector.
+		{"/div[@class='x']", true},
+		{"//div[@id]", true},
+		// Valid HTTP paths — must NOT be detected.
+		{"/api/v1/users", false},
+		{"/api/v1/users/{id}", false},
+		{"/webhooks/stripe", false},
+		{"/v1/orders/{pk}", false},
+		{"/", false},
+		{"", false},
+		// Paths with longer "prefixes" that are NOT XML namespaces.
+		{"/version:1/items", false},       // "version" is >4 chars
+		{"/abcde:something/foo", false},   // >4 chars prefix
+	}
+	for _, tc := range cases {
+		got := isXMLNamespacePath(tc.path)
+		if got != tc.wantXML {
+			t.Errorf("isXMLNamespacePath(%q) = %v, want %v", tc.path, got, tc.wantXML)
+		}
+	}
+}
+
+// TestSynth_DjangoComposed_RejectsXMLPaths verifies that synthesizeDjangoFromComposed
+// does not emit http_endpoint synthetics for XPath/XML namespace strings that
+// the Django YAML `path(...)` rule may have captured from python-docx / lxml
+// code (issue #1125).
+func TestSynth_DjangoComposed_RejectsXMLPaths(t *testing.T) {
+	// Simulate Route entities with XML XPath names that the YAML rule
+	// might capture from code like:
+	//   elem.find(path('./w:tblBorders'))
+	xmlRoutes := []types.EntityRecord{
+		{
+			ID:         "ast:Route:./w:tblBorders",
+			Name:       "./w:tblBorders",
+			Kind:       "Route",
+			SourceFile: "word_processor/docx_utils.py",
+			Language:   "python",
+			Properties: map[string]string{
+				"framework":    "python",
+				"pattern_type": "ast_driven",
+			},
+		},
+		{
+			ID:         "ast:Route:./w:tcBorders",
+			Name:       "./w:tcBorders",
+			Kind:       "Route",
+			SourceFile: "word_processor/docx_utils.py",
+			Language:   "python",
+			Properties: map[string]string{
+				"framework":    "python",
+				"pattern_type": "ast_driven",
+			},
+		},
+	}
+	// Also include a real Django route to verify it IS still emitted.
+	realRoute := types.EntityRecord{
+		ID:         "ast:Route:/api/v1/documents",
+		Name:       "/api/v1/documents",
+		Kind:       "Route",
+		SourceFile: "word_processor/urls.py",
+		Language:   "python",
+		Properties: map[string]string{
+			"framework":    "python",
+			"pattern_type": "ast_driven",
+		},
+	}
+
+	var emitted []string
+	emitFnCapture := func(method, canonicalPath, framework, refKind, refName string) {
+		id := httproutes.SyntheticID(method, canonicalPath)
+		emitted = append(emitted, id)
+	}
+
+	allRoutes := append(xmlRoutes, realRoute)
+	synthesizeDjangoFromComposed(allRoutes, "word_processor/docx_utils.py", emitFnCapture)
+	// Also run for the real url file.
+	synthesizeDjangoFromComposed(allRoutes, "word_processor/urls.py", emitFnCapture)
+
+	// XML XPath paths must NOT be emitted.
+	for _, id := range emitted {
+		if strings.Contains(id, "w:tblBorders") || strings.Contains(id, "w:tcBorders") {
+			t.Errorf("XML XPath string should not produce http_endpoint synthetic; got %q", id)
+		}
+	}
+
+	// Real route must still be emitted.
+	found := false
+	for _, id := range emitted {
+		if id == "http:ANY:/api/v1/documents" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("real Django route http:ANY:/api/v1/documents should be emitted; got %v", emitted)
+	}
+}

--- a/internal/engine/workflow_edges_test.go
+++ b/internal/engine/workflow_edges_test.go
@@ -68,7 +68,7 @@ func requireEntityKind(t *testing.T, ents []types.EntityRecord, kind, id, label 
 	}
 }
 
-func requireEdgeTo(t *testing.T, rels []types.RelationshipRecord, edgeKind, toID, label string) {
+func requireWorkflowEdgeTo(t *testing.T, rels []types.RelationshipRecord, edgeKind, toID, label string) {
 	t.Helper()
 	for _, r := range rels {
 		if r.Kind == edgeKind && r.ToID == toID {
@@ -132,7 +132,7 @@ func TestTemporalPythonWorkflowDefinition(t *testing.T) {
 	requireEntityKind(t, ents, activityKind, temporalActivityID("send_receipt"), "send_receipt activity (custom name)")
 
 	// STARTS_WORKFLOW: main → OrderWorkflow
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		workflowKind+":"+temporalWorkflowID("OrderWorkflow"), "starts_workflow from main")
 
 	// EXECUTES_ACTIVITY: OrderWorkflow → charge_card
@@ -212,7 +212,7 @@ func TestTemporalGoExecuteWorkflow(t *testing.T) {
 	ents, rels := runWorkflowEdges(t, "go", "worker/main.go", goTemporalSrc)
 
 	// STARTS_WORKFLOW from main → OrderWorkflow
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		workflowKind+":"+temporalWorkflowID("OrderWorkflow"), "ExecuteWorkflow triggers STARTS_WORKFLOW")
 	_ = ents
 }
@@ -269,7 +269,7 @@ func TestJavaTemporalWorkflowInterface(t *testing.T) {
 	requireEntityKind(t, ents, activityKind, temporalActivityID("PaymentActivities"), "PaymentActivities entity")
 
 	// STARTS_WORKFLOW via newWorkflowStub(OrderWorkflow.class)
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		workflowKind+":"+temporalWorkflowID("OrderWorkflow"), "java STARTS_WORKFLOW via newWorkflowStub")
 	_ = rels
 }
@@ -359,7 +359,7 @@ func TestTemporalTypeScriptWorkflow(t *testing.T) {
 func TestTemporalTypeScriptClientStart(t *testing.T) {
 	ents, rels := runWorkflowEdges(t, "typescript", "src/client.ts", tsClientSrc)
 
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		workflowKind+":"+temporalWorkflowID("orderWorkflow"), "TS client.start STARTS_WORKFLOW")
 	_ = ents
 }
@@ -444,7 +444,7 @@ func TestASLStatesLambdaInvokeResource(t *testing.T) {
 	_, rels := applyASLWorkflowEdges("infra/sm.asl.json", []byte(aslParamsJSON), nil, nil)
 
 	target := serverlessFunctionKind + ":" + lambdaFunctionID("process-order")
-	requireEdgeTo(t, rels, stepFunctionStepInvokesEdgeKind, target, "states:::lambda:invoke Parameters FunctionName")
+	requireWorkflowEdgeTo(t, rels, stepFunctionStepInvokesEdgeKind, target, "states:::lambda:invoke Parameters FunctionName")
 }
 
 // ---------------------------------------------------------------------------
@@ -500,7 +500,7 @@ func TestPythonSFNStartExecution(t *testing.T) {
 	ents, rels := runSFNStartEdges(t, "python", "handlers/trigger.py", pySFNInvokeSrc)
 
 	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("order-flow-machine"), "SFN entity from Python invocation")
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		stateMachineKind+":"+sfnStateMachineID("order-flow-machine"), "Python STARTS_WORKFLOW → SFN")
 }
 
@@ -524,7 +524,7 @@ func TestGoSFNStartExecution(t *testing.T) {
 	ents, rels := runSFNStartEdges(t, "go", "infra/trigger.go", goSFNInvokeSrc)
 
 	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("order-flow-machine"), "SFN entity from Go invocation")
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		stateMachineKind+":"+sfnStateMachineID("order-flow-machine"), "Go STARTS_WORKFLOW → SFN")
 }
 
@@ -545,7 +545,7 @@ func TestNodeSFNStartExecution(t *testing.T) {
 	ents, rels := runSFNStartEdges(t, "typescript", "src/trigger.ts", nodeSFNInvokeSrc)
 
 	requireEntityKind(t, ents, stateMachineKind, sfnStateMachineID("order-flow-machine"), "SFN entity from Node invocation")
-	requireEdgeTo(t, rels, startsWorkflowEdgeKind,
+	requireWorkflowEdgeTo(t, rels, startsWorkflowEdgeKind,
 		stateMachineKind+":"+sfnStateMachineID("order-flow-machine"), "Node STARTS_WORKFLOW → SFN")
 }
 


### PR DESCRIPTION
## Summary

- XML XPath expressions like \`./w:tblBorders\` were leaking into the \`/api/paths\` Paths list because the Django YAML \`path(...)\` rule fired on python-docx/lxml code and the dashboard collected all \`Route\`/\`http_endpoint\` entities with no HTTP-shape validation.
- Added \`isXMLNamespacePath()\` in the synthesis pass to block emission before the entity is created, and \`isHTTPEndpointPath()\` in the dashboard API as a defense-in-depth filter.
- Fixed a pre-existing \`requireEdgeTo\` redeclaration in the engine test suite (\`workflow_edges_test.go\` → \`requireWorkflowEdgeTo\`).

## Root cause

Three-step chain:
1. The Django YAML \`path\s*\(\s*["']...["']\` rule matched python-docx/lxml code such as \`element.find(path('./w:tblBorders'))\`, producing \`Route\` entities with XPath names.
2. \`synthesizeDjangoFromComposed\` canonicalized them via \`httproutes.Canonicalize\` (adding \`/\`) and emitted \`http:ANY:/./w:tblBorders\` synthetics.
3. \`handlePathsList\` collected all \`Route\` / \`http_endpoint\` / \`Endpoint\` entities with no validation that the path was HTTP-shaped.

## Changes

| File | Change |
|------|--------|
| \`internal/engine/http_endpoint_synthesis.go\` | Add \`isXMLNamespacePath()\` predicate; apply in \`synthesizeDjangoFromComposed\` |
| \`internal/dashboard/handlers_paths.go\` | Add \`isHTTPEndpointPath()\` predicate; apply in \`handlePathsList\` |
| \`internal/engine/http_endpoint_synthesis_test.go\` | \`TestIsXMLNamespacePath\` + \`TestSynth_DjangoComposed_RejectsXMLPaths\` |
| \`internal/dashboard/handlers_phase1_test.go\` | \`TestIsHTTPEndpointPath\` + \`TestPathsList_XMLNoiseFiltered\` |
| \`internal/engine/workflow_edges_test.go\` | Fix pre-existing \`requireEdgeTo\` redeclaration |

## Rejection rules

Both predicates reject a path if:
- It contains \`./\` (XPath relative notation)
- It contains \`[@\` (XPath attribute selector)
- Any path segment has a short (≤4 char) purely-alphabetic prefix before \`:\` — the classic XML namespace pattern (\`w:tblBorders\`, \`xml:lang\`)

## Test plan

- [x] \`TestIsXMLNamespacePath\` — unit tests all XPath patterns detected
- [x] \`TestSynth_DjangoComposed_RejectsXMLPaths\` — Word XML fixture → zero http_endpoint synthetics; real Django route still emitted
- [x] \`TestIsHTTPEndpointPath\` — unit tests for dashboard predicate
- [x] \`TestPathsList_XMLNoiseFiltered\` — XML entities injected → Paths API returns zero XML-noise rows
- [x] Full \`./internal/engine/...\` suite passes
- [x] Full \`./internal/dashboard/...\` suite passes
- [x] Full \`./internal/links/...\` suite passes

Closes #1125

🤖 Generated with [Claude Code](https://claude.com/claude-code)