### PR TITLE
[Flows v2] Backend: truncated flow detector (#1146)

### DIFF
--- a/internal/dashboard/handlers_flows_quality.go
+++ b/internal/dashboard/handlers_flows_quality.go
@@ -3,6 +3,7 @@ package dashboard
 // handlers_flows_quality.go — Flows v2 quality classification endpoints
 //
 //	GET /api/flows/{group}/dead-ends
+//	GET /api/flows/{group}/truncated
 
 import (
 	"net/http"
@@ -175,6 +176,277 @@ func hasUsefulSink(
 		}
 	}
 	return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Truncated flow detector
+// ─────────────────────────────────────────────────────────────────────────────
+
+// truncationSeverity maps a truncation reason to an informational severity
+// level surfaced in the API response.
+//
+//	external_dependency  → info  (expected; known SDK / stdlib boundary)
+//	unresolved_reference → warn  (likely an indexing gap or dynamic dispatch)
+//	unindexed_repo       → error (cross-service edge to a repo never indexed)
+var truncationSeverity = map[string]string{
+	"unresolved_callee":    "warn",
+	"cross_repo_unindexed": "error",
+	"dynamic_dispatch":     "info",
+}
+
+// TruncatedFlowItem represents a single truncated process flow in the API
+// response.
+type TruncatedFlowItem struct {
+	ProcessID        string `json:"process_id"`
+	Label            string `json:"label"`
+	EntryName        string `json:"entry_name"`
+	StepCount        int    `json:"step_count"`
+	Repo             string `json:"repo"`
+	Reason           string `json:"reason"`     // "unresolved_callee" | "cross_repo_unindexed" | "dynamic_dispatch"
+	Severity         string `json:"severity"`   // "info" | "warn" | "error"
+	TruncationStep   string `json:"truncation_step"`         // entity ID of the offending step
+	TruncationIndex  int    `json:"truncation_point"`        // 0-based index into the step chain
+	UnresolvedTarget string `json:"unresolved_target"`       // name/ID of the entity that could not be resolved
+	IsTruncated      bool   `json:"is_truncated"`
+	CrossStack       bool   `json:"cross_stack"`
+}
+
+// truncationCheck holds the result of inspecting a single step for truncation.
+type truncationCheck struct {
+	reason           string
+	truncationStep   string
+	truncationIndex  int
+	unresolvedTarget string
+}
+
+// classifyFlowTruncated inspects all Process entities in a group and returns
+// those whose step chain hits an unresolved or external edge mid-stream.
+//
+// Detection rules (in priority order):
+//  1. A step has property dynamic="true"  → dynamic_dispatch
+//  2. A step has an outgoing CALLS edge to a ToID that is NOT present in any
+//     repo in the group                   → unresolved_callee
+//  3. A step has cross_stack="true" AND the terminal entity is absent from all
+//     group repos                         → cross_repo_unindexed
+func classifyFlowTruncated(grp *DashGroup) []TruncatedFlowItem {
+	// Build a set of all known entity IDs across every repo in the group.
+	// We key by bare local ID (entities reference each other by local ID within
+	// the same repo, and by cross-repo prefixed ID across repos).
+	knownLocalIDs := map[flowStepKey]bool{}
+	knownBareIDs := map[string]bool{} // bare ID, repo-agnostic lookup
+	entityProps := map[flowStepKey]map[string]string{}
+
+	for _, r := range sortedRepos(grp) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			k := flowStepKey{r.Slug, e.ID}
+			knownLocalIDs[k] = true
+			knownBareIDs[e.ID] = true
+			if e.Properties != nil {
+				entityProps[k] = e.Properties
+			}
+		}
+	}
+
+	// Build per-step outgoing CALLS edges: map (repo, fromID) → []toID
+	callEdges := map[flowStepKey][]string{}
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind != "CALLS" {
+				continue
+			}
+			k := flowStepKey{r.Slug, rel.FromID}
+			callEdges[k] = append(callEdges[k], rel.ToID)
+		}
+	}
+
+	var results []TruncatedFlowItem
+
+	for _, r := range sortedRepos(grp) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind {
+				continue
+			}
+
+			sc, _ := strconv.Atoi(e.Properties["step_count"])
+			cs := e.Properties["cross_stack"] == "true"
+			pid := dashPrefixedID(r.Slug, e.ID)
+
+			// Collect ordered step keys.
+			stepKeys := collectStepKeysOrdered(grp, e.ID, pid)
+			if len(stepKeys) == 0 {
+				continue
+			}
+
+			check := findTruncationPoint(stepKeys, entityProps, callEdges, knownLocalIDs, knownBareIDs)
+			if check == nil {
+				// Fully resolved — not truncated.
+				continue
+			}
+
+			severity := truncationSeverity[check.reason]
+			if severity == "" {
+				severity = "warn"
+			}
+
+			results = append(results, TruncatedFlowItem{
+				ProcessID:        pid,
+				Label:            e.Name,
+				EntryName:        e.Properties["entry_name"],
+				StepCount:        sc,
+				Repo:             r.Slug,
+				Reason:           check.reason,
+				Severity:         severity,
+				TruncationStep:   check.truncationStep,
+				TruncationIndex:  check.truncationIndex,
+				UnresolvedTarget: check.unresolvedTarget,
+				IsTruncated:      true,
+				CrossStack:       cs,
+			})
+		}
+	}
+
+	return results
+}
+
+// orderedStep pairs a step key with its declared step_index.
+type orderedStep struct {
+	key   flowStepKey
+	index int
+}
+
+// collectStepKeysOrdered gathers flowStepKey pairs for all steps in a process
+// by following STEP_IN_PROCESS edges, preserving step_index order where
+// available. Falls back to insertion order for steps without an index.
+func collectStepKeysOrdered(
+	grp *DashGroup,
+	processLocalID, processPrefixedID string,
+) []flowStepKey {
+	var indexed []orderedStep
+
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind != stepInProcessEdge {
+				continue
+			}
+			if rel.FromID != processLocalID &&
+				dashPrefixedID(r.Slug, rel.FromID) != processPrefixedID {
+				continue
+			}
+			idx := -1
+			if rel.Properties != nil {
+				if raw, ok := rel.Properties["step_index"]; ok {
+					idx, _ = strconv.Atoi(raw)
+				}
+			}
+			indexed = append(indexed, orderedStep{
+				key:   flowStepKey{r.Slug, rel.ToID},
+				index: idx,
+			})
+		}
+	}
+
+	// Stable insertion sort by step_index; steps without an index stay at end.
+	for i := 1; i < len(indexed); i++ {
+		j := i
+		for j > 0 && indexed[j].index >= 0 && indexed[j-1].index > indexed[j].index {
+			indexed[j-1], indexed[j] = indexed[j], indexed[j-1]
+			j--
+		}
+	}
+
+	keys := make([]flowStepKey, len(indexed))
+	for i, s := range indexed {
+		keys[i] = s.key
+	}
+	return keys
+}
+
+// findTruncationPoint walks the step list and returns the first step that
+// represents a truncation point, or nil if the flow is fully resolved.
+func findTruncationPoint(
+	steps []flowStepKey,
+	entityProps map[flowStepKey]map[string]string,
+	callEdges map[flowStepKey][]string,
+	knownLocalIDs map[flowStepKey]bool,
+	knownBareIDs map[string]bool,
+) *truncationCheck {
+	for idx, step := range steps {
+		props := entityProps[step]
+
+		// Rule 1: dynamic dispatch flag on the step entity.
+		if props != nil && props["dynamic"] == "true" {
+			target := props["dynamic_target"]
+			if target == "" {
+				target = step.id
+			}
+			return &truncationCheck{
+				reason:           "dynamic_dispatch",
+				truncationStep:   step.id,
+				truncationIndex:  idx,
+				unresolvedTarget: target,
+			}
+		}
+
+		// Rule 2: CALLS edge to an entity not present in any repo.
+		for _, toID := range callEdges[step] {
+			// Check if the toID is known as a bare local ID in any repo.
+			if !knownBareIDs[toID] && !strings.HasPrefix(toID, "external:") {
+				return &truncationCheck{
+					reason:           "unresolved_callee",
+					truncationStep:   step.id,
+					truncationIndex:  idx,
+					unresolvedTarget: toID,
+				}
+			}
+		}
+
+		// Rule 3: cross_stack step whose terminal is absent from all repos.
+		if props != nil && props["cross_stack"] == "true" {
+			terminalID := props["terminal_id"]
+			if terminalID != "" && !knownBareIDs[terminalID] {
+				return &truncationCheck{
+					reason:           "cross_repo_unindexed",
+					truncationStep:   step.id,
+					truncationIndex:  idx,
+					unresolvedTarget: terminalID,
+				}
+			}
+		}
+	}
+	return nil
+}
+
+// handleFlowTruncated — GET /api/flows/{group}/truncated
+//
+// Returns all Process flows in the group that hit an external or unresolved
+// edge mid-stream: the flow is cut off before reaching its natural sink.
+// Each item identifies the step at which the chain breaks (truncation_step,
+// truncation_point) and the entity name/ID that could not be resolved
+// (unresolved_target), with a severity tag to guide triage priority.
+func (s *Server) handleFlowTruncated(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	truncated := classifyFlowTruncated(grp)
+	if truncated == nil {
+		truncated = []TruncatedFlowItem{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"truncated_flows": truncated,
+		"total":           len(truncated),
+	})
 }
 
 // handleFlowDeadEnds — GET /api/flows/{group}/dead-ends

--- a/internal/dashboard/handlers_flows_quality_test.go
+++ b/internal/dashboard/handlers_flows_quality_test.go
@@ -475,3 +475,330 @@ func TestHandleFlowDeadEnds_SingleStepReason(t *testing.T) {
 		t.Errorf("reason: want single_step, got %q", body.DeadEnds[0].Reason)
 	}
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests: classifyFlowTruncated
+// ─────────────────────────────────────────────────────────────────────────────
+
+// callsRel builds a CALLS relationship from a step entity to a target ID.
+func callsRel(fromID, toID string) graph.Relationship {
+	return graph.Relationship{
+		ID:     "calls-" + fromID + "-" + toID,
+		FromID: fromID,
+		ToID:   toID,
+		Kind:   "CALLS",
+	}
+}
+
+// dynamicStepEntity builds a step entity with dynamic="true".
+func dynamicStepEntity(id, name string, dynamicTarget string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       "Function",
+		SourceFile: "src/" + id + ".go",
+		StartLine:  1,
+		Properties: map[string]string{
+			"dynamic":        "true",
+			"dynamic_target": dynamicTarget,
+		},
+	}
+}
+
+// crossStackStepEntity builds a step entity with cross_stack="true" and an
+// unresolved terminal_id.
+func crossStackStepEntity(id, name, terminalID string) graph.Entity {
+	return graph.Entity{
+		ID:         id,
+		Name:       name,
+		Kind:       "Function",
+		SourceFile: "src/" + id + ".go",
+		StartLine:  1,
+		Properties: map[string]string{
+			"cross_stack": "true",
+			"terminal_id": terminalID,
+		},
+	}
+}
+
+// TestTruncated_UnresolvedCallee — a flow whose intermediate step has a CALLS
+// edge to an entity ID not present in any repo must appear with reason
+// "unresolved_callee" and severity "warn".
+func TestTruncated_UnresolvedCallee(t *testing.T) {
+	proc := processEntity("proc-trunc", "fetchData", 3, false)
+	step1 := stepEntity("tr1", "parse", "Function")
+	step2 := stepEntity("tr2", "callExternal", "Function")
+	step3 := stepEntity("tr3", "respond", "Function")
+
+	entities := []graph.Entity{proc, step1, step2, step3}
+	rels := []graph.Relationship{
+		stepRel("proc-trunc", "tr1", 0),
+		stepRel("proc-trunc", "tr2", 1),
+		stepRel("proc-trunc", "tr3", 2),
+		// tr2 calls an entity that is not in the graph.
+		callsRel("tr2", "unknown-lib::parseJSON"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowTruncated(grp)
+
+	var found *TruncatedFlowItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-trunc" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-trunc to appear as truncated, but it was not found")
+	}
+	if found.Reason != "unresolved_callee" {
+		t.Errorf("reason: want unresolved_callee, got %q", found.Reason)
+	}
+	if found.Severity != "warn" {
+		t.Errorf("severity: want warn, got %q", found.Severity)
+	}
+	if found.TruncationStep != "tr2" {
+		t.Errorf("truncation_step: want tr2, got %q", found.TruncationStep)
+	}
+	if found.TruncationIndex != 1 {
+		t.Errorf("truncation_point: want 1, got %d", found.TruncationIndex)
+	}
+	if found.UnresolvedTarget == "" {
+		t.Error("unresolved_target must not be empty")
+	}
+	if !found.IsTruncated {
+		t.Error("is_truncated must be true")
+	}
+}
+
+// TestTruncated_DynamicDispatch — a flow with a step whose dynamic="true"
+// property set must appear with reason "dynamic_dispatch" and severity "info".
+func TestTruncated_DynamicDispatch(t *testing.T) {
+	proc := processEntity("proc-dyn", "dispatchCmd", 2, false)
+	step1 := stepEntity("dyn1", "prepare", "Function")
+	step2 := dynamicStepEntity("dyn2", "dispatch", "cmd.Handler")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-dyn", "dyn1", 0),
+		stepRel("proc-dyn", "dyn2", 1),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowTruncated(grp)
+
+	var found *TruncatedFlowItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-dyn" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-dyn to appear as truncated (dynamic_dispatch), but not found")
+	}
+	if found.Reason != "dynamic_dispatch" {
+		t.Errorf("reason: want dynamic_dispatch, got %q", found.Reason)
+	}
+	if found.Severity != "info" {
+		t.Errorf("severity: want info, got %q", found.Severity)
+	}
+	if found.TruncationStep != "dyn2" {
+		t.Errorf("truncation_step: want dyn2, got %q", found.TruncationStep)
+	}
+	if found.UnresolvedTarget != "cmd.Handler" {
+		t.Errorf("unresolved_target: want cmd.Handler, got %q", found.UnresolvedTarget)
+	}
+}
+
+// TestTruncated_CrossRepoUnindexed — a flow that has a cross-stack step whose
+// terminal_id is not in any indexed repo must appear with reason
+// "cross_repo_unindexed" and severity "error".
+func TestTruncated_CrossRepoUnindexed(t *testing.T) {
+	proc := processEntity("proc-cs", "callService", 2, true)
+	step1 := stepEntity("cs1", "prepare", "Function")
+	step2 := crossStackStepEntity("cs2", "rpcCall", "remote-svc::handleOrder")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-cs", "cs1", 0),
+		stepRel("proc-cs", "cs2", 1),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowTruncated(grp)
+
+	var found *TruncatedFlowItem
+	for i := range items {
+		if items[i].ProcessID == "backend::proc-cs" {
+			found = &items[i]
+			break
+		}
+	}
+	if found == nil {
+		t.Fatal("expected proc-cs to appear as truncated (cross_repo_unindexed), but not found")
+	}
+	if found.Reason != "cross_repo_unindexed" {
+		t.Errorf("reason: want cross_repo_unindexed, got %q", found.Reason)
+	}
+	if found.Severity != "error" {
+		t.Errorf("severity: want error, got %q", found.Severity)
+	}
+	if found.UnresolvedTarget != "remote-svc::handleOrder" {
+		t.Errorf("unresolved_target: want remote-svc::handleOrder, got %q", found.UnresolvedTarget)
+	}
+}
+
+// TestTruncated_FullyResolvedFlow — a flow whose every CALLS edge points to a
+// known entity must NOT appear as truncated.
+func TestTruncated_FullyResolvedFlow(t *testing.T) {
+	proc := processEntity("proc-clean-tr", "cleanFlow", 3, false)
+	step1 := stepEntity("rc1", "validate", "Function")
+	step2 := stepEntity("rc2", "process", "Function")
+	step3 := stepEntity("rc3", "save", "Function")
+
+	entities := []graph.Entity{proc, step1, step2, step3}
+	rels := []graph.Relationship{
+		stepRel("proc-clean-tr", "rc1", 0),
+		stepRel("proc-clean-tr", "rc2", 1),
+		stepRel("proc-clean-tr", "rc3", 2),
+		// All CALLS edges point to known entities in the graph.
+		callsRel("rc1", "rc2"),
+		callsRel("rc2", "rc3"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	items := classifyFlowTruncated(grp)
+
+	for _, item := range items {
+		if item.ProcessID == "backend::proc-clean-tr" {
+			t.Errorf("fully-resolved flow must NOT appear as truncated, but found: %+v", item)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration smoke: HTTP endpoint shape for truncated flows
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleFlowTruncated_HTTPSmoke(t *testing.T) {
+	proc := processEntity("proc-smoke-tr", "smokeFlow", 2, false)
+	step1 := stepEntity("sm-tr1", "prepare", "Function")
+	step2 := stepEntity("sm-tr2", "callUnknown", "Function")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-smoke-tr", "sm-tr1", 0),
+		stepRel("proc-smoke-tr", "sm-tr2", 1),
+		callsRel("sm-tr2", "nowhere::missingFn"),
+	}
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/truncated")
+	if err != nil {
+		t.Fatalf("GET truncated: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		TruncatedFlows []TruncatedFlowItem `json:"truncated_flows"`
+		Total          int                 `json:"total"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	if body.Total != 1 {
+		t.Errorf("total: want 1, got %d", body.Total)
+	}
+	if len(body.TruncatedFlows) == 0 {
+		t.Fatal("truncated_flows must not be empty")
+	}
+
+	item := body.TruncatedFlows[0]
+	if item.ProcessID != "backend::proc-smoke-tr" {
+		t.Errorf("process_id: want backend::proc-smoke-tr, got %q", item.ProcessID)
+	}
+	if item.Reason != "unresolved_callee" {
+		t.Errorf("reason: want unresolved_callee, got %q", item.Reason)
+	}
+	if item.Severity != "warn" {
+		t.Errorf("severity: want warn, got %q", item.Severity)
+	}
+	if !item.IsTruncated {
+		t.Error("is_truncated must be true")
+	}
+	if item.TruncationStep == "" {
+		t.Error("truncation_step must not be empty")
+	}
+	if item.UnresolvedTarget == "" {
+		t.Error("unresolved_target must not be empty")
+	}
+}
+
+func TestHandleFlowTruncated_UnknownGroup(t *testing.T) {
+	grp := makeFlowGroup(nil, nil)
+	grp.Name = "testgrp"
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/nosuchgroup/truncated")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusNotFound {
+		t.Errorf("status: want 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestHandleFlowTruncated_EmptyResult(t *testing.T) {
+	// A group with only a fully-resolved flow returns an empty list (not null).
+	proc := processEntity("proc-ok", "resolvedFlow", 2, false)
+	step1 := stepEntity("ok1", "stepA", "Function")
+	step2 := stepEntity("ok2", "stepB", "Function")
+
+	entities := []graph.Entity{proc, step1, step2}
+	rels := []graph.Relationship{
+		stepRel("proc-ok", "ok1", 0),
+		stepRel("proc-ok", "ok2", 1),
+		callsRel("ok1", "ok2"),
+	}
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+
+	ts := newFlowQualityTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/truncated")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	arr, ok := body["truncated_flows"].([]any)
+	if !ok {
+		t.Fatalf("truncated_flows should be an array, got %T", body["truncated_flows"])
+	}
+	if len(arr) != 0 {
+		t.Errorf("expected empty truncated_flows for fully-resolved flow, got %d items", len(arr))
+	}
+	if total, _ := body["total"].(float64); total != 0 {
+		t.Errorf("total: want 0, got %v", total)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -163,6 +163,7 @@ func (s *Server) routes() http.Handler {
 	// Process flows
 	mux.HandleFunc("GET /api/flows/{group}", s.handleFlowsList)
 	mux.HandleFunc("GET /api/flows/{group}/dead-ends", s.handleFlowDeadEnds)
+	mux.HandleFunc("GET /api/flows/{group}/truncated", s.handleFlowTruncated)
 	mux.HandleFunc("GET /api/flows/{group}/{processId}", s.handleFlowDetail)
 
 	// API paths / contracts


### PR DESCRIPTION
## What

Implements \`GET /api/flows/{group}/truncated\` — the truncated flow detector for Flows v2 (#1146, part of epic #1144).

Returns Process flows that hit an unresolved or external edge mid-stream: the flow is cut off before reaching its natural sink. Each item includes the offending step, the unresolved target name, and a severity tag to guide triage priority.

## Why

Truncated flows expose indexing gaps and cross-service boundaries that need annotation. Surfacing them as a dedicated endpoint lets engineers see exactly where a flow breaks — which step, what it tried to call, and how severe the gap is — without manual graph traversal.

## How

- New logic in \`internal/dashboard/handlers_flows_quality.go\` (same file as the dead-end classifier, #1145):
  - \`TruncatedFlowItem\` — response struct with \`process_id\`, \`label\`, \`entry_name\`, \`step_count\`, \`repo\`, \`reason\`, \`severity\`, \`truncation_step\`, \`truncation_point\`, \`unresolved_target\`, \`is_truncated\`, \`cross_stack\`.
  - \`orderedStep\` — named struct used in \`collectStepKeysOrdered\` (avoids anonymous-struct type issues, mirrors \`flowStepKey\` discipline from dead-ends).
  - \`truncationSeverity\` — maps reason → severity: \`dynamic_dispatch\`=info, \`unresolved_callee\`=warn, \`cross_repo_unindexed\`=error.
  - \`classifyFlowTruncated(grp)\` — iterates \`SCOPE.Process\` entities, collects steps via \`collectStepKeysOrdered\` (step_index-ordered), then calls \`findTruncationPoint\` which walks each step checking (in priority order): dynamic flag, unresolved CALLS target, cross-stack terminal absent from all repos.
  - \`findTruncationPoint\` — returns a \`truncationCheck\` with reason, step ID, 0-based step index, and the unresolved target name/ID. Returns nil for fully-resolved flows.
  - \`handleFlowTruncated\` — HTTP handler returning \`{ truncated_flows: [...], total: N }\` or 404 for unknown groups.
- Route registered in \`server.go\` between \`handleFlowDeadEnds\` and \`handleFlowDetail\`:
  \`GET /api/flows/{group}/truncated\`

## Tests

\`internal/dashboard/handlers_flows_quality_test.go\` — 7 new tests:

| Test | Assertion |
|---|---|
| \`TestTruncated_UnresolvedCallee\` | Step with CALLS to unknown ID → \`unresolved_callee\`, severity=warn, correct truncation_step and truncation_point |
| \`TestTruncated_DynamicDispatch\` | Step with \`dynamic=true\` → \`dynamic_dispatch\`, severity=info, target from \`dynamic_target\` property |
| \`TestTruncated_CrossRepoUnindexed\` | Cross-stack step with absent terminal_id → \`cross_repo_unindexed\`, severity=error |
| \`TestTruncated_FullyResolvedFlow\` | All CALLS edges resolve to known entities → NOT in results |
| \`TestHandleFlowTruncated_HTTPSmoke\` | Full HTTP round-trip, correct JSON shape, non-empty truncation_step and unresolved_target |
| \`TestHandleFlowTruncated_UnknownGroup\` | Unknown group → 404 |
| \`TestHandleFlowTruncated_EmptyResult\` | Fully-resolved flow → empty \`truncated_flows\` array (not null) |

All 7 pass; all 12 pre-existing dead-end tests and full suite show zero regressions.

## Checklist

- [x] Backend only — no frontend changes
- [x] Route registered in \`server.go\`, returns 404 for unknown groups
- [x] No client names in code, comments, or test fixtures
- [x] \`classifyFlowTruncated\` is a pure function — independently testable without an HTTP server
- [x] Beyond-the-minimum: \`truncation_step\` (step ID), \`truncation_point\` (0-based index), \`unresolved_target\` (name/ID of missing entity), \`severity\` field, \`is_truncated\` bool on every item

Closes #1146