### PR TITLE
feat(topology): per-topic detail endpoint GET /api/topology/{group}/topic/{topicId}

### DIFF
--- a/internal/dashboard/handlers_topology_detail.go
+++ b/internal/dashboard/handlers_topology_detail.go
@@ -1,0 +1,496 @@
+package dashboard
+
+// handlers_topology_detail.go — per-topic detail endpoint
+//
+//	GET /api/topology/{group}/topic/{topicId}
+//
+// Returns the full detail record for one topology entity (topic, queue,
+// channel, NATS subject, scheduled job, or serverless function).  The
+// topicId uses the same "repo::localID" prefixed format as every other
+// dashboard detail endpoint.
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// topicEntityRecord is the resolved producer/consumer wire shape — matches
+// what the Paths v2 detail panel uses for step entities.
+type topicEntityRecord struct {
+	EntityID   string `json:"entity_id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file"`
+	StartLine  int    `json:"start_line"`
+	Repo       string `json:"repo"`
+}
+
+// topicDetailResponse is the wire shape for GET /api/topology/{group}/topic/{topicId}.
+// All slice fields are guaranteed non-nil (JSON [] not null).
+type topicDetailResponse struct {
+	ID             string              `json:"id"`
+	Label          string              `json:"label"`
+	Protocol       string              `json:"protocol"`
+	Broker         string              `json:"broker"`
+	Framework      string              `json:"framework"`
+	Schedule       string              `json:"schedule"`
+	Scheduled      bool                `json:"scheduled"`
+	MessageSchema  string              `json:"message_schema"`
+	Repo           string              `json:"repo"`
+	SourceFile     string              `json:"source_file"`
+	StartLine      int                 `json:"start_line"`
+	Producers      []topicEntityRecord `json:"producers"`
+	Consumers      []topicEntityRecord `json:"consumers"`
+	Tests          []topicEntityRecord `json:"tests"`
+	RelatedTopics  []string            `json:"related_topics"`
+	UsageHistory   []any               `json:"usage_history"`
+	FlowCount      int                 `json:"flow_count"`
+	CrossRepo      bool                `json:"cross_repo"`
+	LifecycleState string              `json:"lifecycle_state"`
+	DocsSummary    string              `json:"docs_summary,omitempty"`
+	Enrichment     *EnrichmentFrontmatter `json:"enrichment,omitempty"`
+}
+
+// handleTopicDetail — GET /api/topology/{group}/topic/{topicId}
+func (s *Server) handleTopicDetail(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	topicID := r.PathValue("topicId")
+	if group == "" || topicID == "" {
+		writeErr(w, http.StatusBadRequest, "group and topicId required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	detail, found := buildTopicDetail(grp, group, topicID)
+	if !found {
+		writeErr(w, http.StatusNotFound, "topic not found: "+topicID)
+		return
+	}
+
+	writeJSON(w, http.StatusOK, detail)
+}
+
+// buildTopicDetail constructs the full detail payload for a single topology
+// entity identified by its prefixed ID.  Returns (detail, true) when found.
+func buildTopicDetail(grp *DashGroup, groupName, topicID string) (topicDetailResponse, bool) {
+	repoHint, localID := dashSplitPrefixed(topicID)
+
+	// --- Locate the topic entity ---
+	var topicRepoSlug string
+	var topicEnt *graph.Entity
+
+	for _, r := range sortedRepos(grp) {
+		if repoHint != "" && r.Slug != repoHint {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			bucket := classifyTopologyBucket(e.Kind, e.Name, e.Properties)
+			if bucket == "" {
+				continue
+			}
+			if e.ID == localID || dashPrefixedID(r.Slug, e.ID) == topicID {
+				topicRepoSlug = r.Slug
+				topicEnt = e
+				break
+			}
+		}
+		if topicEnt != nil {
+			break
+		}
+	}
+
+	if topicEnt == nil {
+		return topicDetailResponse{}, false
+	}
+
+	// --- Infer broker, protocol, framework ---
+	broker := topicEnt.Properties["broker"]
+	if broker == "" {
+		broker = inferBrokerFromName(topicEnt.Name)
+	}
+	framework := topicEnt.Properties["framework"]
+	protocol := inferProtocol(topicEnt.Kind, topicEnt.Name, topicEnt.Properties, broker)
+
+	// --- Schedule fields ---
+	stripped := dashStripScopePrefix(topicEnt.Kind)
+	scheduled := stripped == kindScheduledJob
+	schedule := topicEnt.Properties["schedule"]
+
+	// --- Message schema ---
+	messageSchema := topicEnt.Properties["schema"]
+
+	// --- Resolve producers and consumers ---
+	// Scan ALL repos: cross-repo extractors may store relationships in any repo's
+	// doc whose edges reference the topic entity by its local ID.
+	rawProducerIDs, rawConsumerIDs := collectAllProducerConsumerIDs(grp, topicEnt.ID, dashPrefixedID(topicRepoSlug, topicEnt.ID))
+
+	// Deduplicate SUBSCRIBES_TO which may add same ID twice (from→to and to→from).
+	rawConsumerIDs = dedupStrings(rawConsumerIDs)
+	rawProducerIDs = dedupStrings(rawProducerIDs)
+
+	producers := resolveEntityRecords(grp, topicRepoSlug, rawProducerIDs)
+	consumers := resolveEntityRecords(grp, topicRepoSlug, rawConsumerIDs)
+
+	// Lifecycle is derived from how many edges exist, regardless of whether the
+	// peer entities resolve to known entity records.
+	nRawProducers := len(rawProducerIDs)
+	nRawConsumers := len(rawConsumerIDs)
+
+	// --- Tests: entities that TESTS this topic ---
+	tests := resolveTestEntities(grp, topicRepoSlug, topicEnt.ID, topicID)
+
+	// --- Related topics: topics sharing a producer or consumer ---
+	relatedTopics := findRelatedTopics(grp, topicRepoSlug, topicEnt.ID, rawProducerIDs, rawConsumerIDs)
+
+	// --- Flow count: number of Process flows whose STEP_IN_PROCESS chain includes this topic ---
+	flowCount := countFlowsTraversing(grp, topicEnt.ID, dashPrefixedID(topicRepoSlug, topicEnt.ID))
+
+	// --- Cross-repo: any producer or consumer in a different repo? ---
+	crossRepo := isCrossRepo(topicRepoSlug, producers, consumers)
+
+	// --- Lifecycle state ---
+	lifecycleState := computeLifecycleState(nRawProducers, nRawConsumers)
+
+	// --- Enrichment ---
+	docgenState, _ := mcp.LoadDocgenState(groupName)
+	entry := map[string]any{}
+	if groupName != "" {
+		applyTopologyEnrichment(entry, groupName, topicEnt.ID, docgenState)
+	}
+	docsSummary, _ := entry["docs_summary"].(string)
+	var enrichment *EnrichmentFrontmatter
+	if fm, ok := entry["enrichment"].(*EnrichmentFrontmatter); ok {
+		enrichment = fm
+	}
+
+	resp := topicDetailResponse{
+		ID:             dashPrefixedID(topicRepoSlug, topicEnt.ID),
+		Label:          topicEnt.Name,
+		Protocol:       protocol,
+		Broker:         broker,
+		Framework:      framework,
+		Schedule:       schedule,
+		Scheduled:      scheduled,
+		MessageSchema:  messageSchema,
+		Repo:           topicRepoSlug,
+		SourceFile:     topicEnt.SourceFile,
+		StartLine:      topicEnt.StartLine,
+		Producers:      producers,
+		Consumers:      consumers,
+		Tests:          tests,
+		RelatedTopics:  relatedTopics,
+		UsageHistory:   []any{},
+		FlowCount:      flowCount,
+		CrossRepo:      crossRepo,
+		LifecycleState: lifecycleState,
+		DocsSummary:    docsSummary,
+		Enrichment:     enrichment,
+	}
+	return resp, true
+}
+
+// collectAllProducerConsumerIDs scans every repo in the group for relationships
+// that reference the topic entity (by local ID or full prefixed ID) and returns
+// all producer/consumer local IDs.  This handles cross-repo extractors that
+// store edges in a different repo's document.
+func collectAllProducerConsumerIDs(grp *DashGroup, localEntityID, prefixedID string) (producers, consumers []string) {
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			isTarget := rel.ToID == localEntityID || dashPrefixedID(r.Slug, rel.ToID) == prefixedID
+			isSource := rel.FromID == localEntityID || dashPrefixedID(r.Slug, rel.FromID) == prefixedID
+			switch rel.Kind {
+			case "PUBLISHES_TO", "WRITES_TO":
+				if isTarget {
+					producers = append(producers, rel.FromID)
+				}
+			case "SUBSCRIBES_TO":
+				if isTarget {
+					consumers = append(consumers, rel.FromID)
+				}
+				if isSource {
+					consumers = append(consumers, rel.ToID)
+				}
+			case "READS_FROM":
+				if isTarget {
+					consumers = append(consumers, rel.FromID)
+				}
+			}
+		}
+	}
+	return
+}
+
+// resolveProducerConsumerIDs returns the raw local IDs for producers and
+// consumers of the given entity from a single repo's relationship list.
+// Used internally by findRelatedTopics which needs per-repo edge data.
+func resolveProducerConsumerIDs(doc *graph.Document, entityID string) (producers, consumers []string) {
+	for _, rel := range doc.Relationships {
+		switch rel.Kind {
+		case "PUBLISHES_TO", "WRITES_TO":
+			if rel.ToID == entityID {
+				producers = append(producers, rel.FromID)
+			}
+		case "SUBSCRIBES_TO":
+			if rel.ToID == entityID {
+				consumers = append(consumers, rel.FromID)
+			}
+			if rel.FromID == entityID {
+				consumers = append(consumers, rel.ToID)
+			}
+		case "READS_FROM":
+			if rel.ToID == entityID {
+				consumers = append(consumers, rel.FromID)
+			}
+		}
+	}
+	return
+}
+
+// resolveEntityRecords turns a list of local entity IDs (within ownerRepo) into
+// full topicEntityRecord values.  Cross-repo matches are searched by scanning
+// all repos in the group (the IDs stored in producer/consumer edges are always
+// local to the repo that contains the relationship).
+func resolveEntityRecords(grp *DashGroup, ownerRepo string, localIDs []string) []topicEntityRecord {
+	if len(localIDs) == 0 {
+		return []topicEntityRecord{}
+	}
+	out := make([]topicEntityRecord, 0, len(localIDs))
+	for _, localID := range localIDs {
+		found := false
+		// First try the owning repo for speed.
+		if r, ok := grp.Repos[ownerRepo]; ok && r.Doc != nil {
+			for i := range r.Doc.Entities {
+				e := &r.Doc.Entities[i]
+				if e.ID == localID {
+					out = append(out, entityToRecord(ownerRepo, e))
+					found = true
+					break
+				}
+			}
+		}
+		if found {
+			continue
+		}
+		// Search all repos.
+		for _, r := range sortedRepos(grp) {
+			if r.Slug == ownerRepo {
+				continue
+			}
+			for i := range r.Doc.Entities {
+				e := &r.Doc.Entities[i]
+				if e.ID == localID {
+					out = append(out, entityToRecord(r.Slug, e))
+					found = true
+					break
+				}
+			}
+			if found {
+				break
+			}
+		}
+	}
+	return out
+}
+
+func entityToRecord(repo string, e *graph.Entity) topicEntityRecord {
+	return topicEntityRecord{
+		EntityID:   dashPrefixedID(repo, e.ID),
+		Name:       e.Name,
+		Kind:       dashStripScopePrefix(e.Kind),
+		SourceFile: e.SourceFile,
+		StartLine:  e.StartLine,
+		Repo:       repo,
+	}
+}
+
+// resolveTestEntities finds entities that have a TESTS relationship pointing at
+// the topic entity.
+func resolveTestEntities(grp *DashGroup, ownerRepo, localEntityID, prefixedID string) []topicEntityRecord {
+	out := []topicEntityRecord{}
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind != "TESTS" {
+				continue
+			}
+			if rel.ToID != localEntityID && dashPrefixedID(r.Slug, rel.ToID) != prefixedID {
+				continue
+			}
+			// Resolve the test entity.
+			for i := range r.Doc.Entities {
+				e := &r.Doc.Entities[i]
+				if e.ID == rel.FromID {
+					out = append(out, entityToRecord(r.Slug, e))
+					break
+				}
+			}
+		}
+	}
+	return out
+}
+
+// findRelatedTopics returns prefixed IDs of other topology entities that share
+// at least one producer or consumer with the current entity.
+func findRelatedTopics(grp *DashGroup, ownerRepo, localEntityID string, producerIDs, consumerIDs []string) []string {
+	peerSet := make(map[string]struct{})
+	for pid := range producerIDs {
+		_ = pid // iterate index
+	}
+
+	// Build a set of connected entity IDs for fast lookup.
+	connectedSet := make(map[string]struct{}, len(producerIDs)+len(consumerIDs))
+	for _, id := range producerIDs {
+		connectedSet[id] = struct{}{}
+	}
+	for _, id := range consumerIDs {
+		connectedSet[id] = struct{}{}
+	}
+
+	for _, r := range sortedRepos(grp) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.ID == localEntityID && r.Slug == ownerRepo {
+				continue // skip self
+			}
+			bucket := classifyTopologyBucket(e.Kind, e.Name, e.Properties)
+			if bucket == "" {
+				continue
+			}
+			// Check whether this topology entity shares any connected entity.
+			peers, peerConsumers := resolveProducerConsumerIDs(r.Doc, e.ID)
+			for _, id := range append(peers, peerConsumers...) {
+				if _, ok := connectedSet[id]; ok {
+					peerSet[dashPrefixedID(r.Slug, e.ID)] = struct{}{}
+					break
+				}
+			}
+		}
+	}
+
+	out := make([]string, 0, len(peerSet))
+	for id := range peerSet {
+		out = append(out, id)
+	}
+	return out
+}
+
+// countFlowsTraversing counts how many Process entities have at least one
+// STEP_IN_PROCESS edge whose target entity is (or refers to) the topic entity.
+func countFlowsTraversing(grp *DashGroup, localEntityID, prefixedID string) int {
+	processSet := make(map[string]struct{})
+	for _, r := range sortedRepos(grp) {
+		for _, rel := range r.Doc.Relationships {
+			if rel.Kind != stepInProcessEdge {
+				continue
+			}
+			if rel.ToID == localEntityID || dashPrefixedID(r.Slug, rel.ToID) == prefixedID {
+				processSet[dashPrefixedID(r.Slug, rel.FromID)] = struct{}{}
+			}
+		}
+	}
+	return len(processSet)
+}
+
+// isCrossRepo returns true when any resolved producer or consumer entity
+// belongs to a different repo than ownerRepo.
+func isCrossRepo(ownerRepo string, producers, consumers []topicEntityRecord) bool {
+	for _, rec := range producers {
+		if rec.Repo != ownerRepo {
+			return true
+		}
+	}
+	for _, rec := range consumers {
+		if rec.Repo != ownerRepo {
+			return true
+		}
+	}
+	return false
+}
+
+// computeLifecycleState derives the lifecycle label from the presence of
+// producers and consumers.
+//
+//   - active            — has both producers AND consumers
+//   - orphan_publisher  — has producers but no consumers
+//   - orphan_subscriber — has consumers but no producers
+//   - orphan            — neither
+func computeLifecycleState(nProducers, nConsumers int) string {
+	switch {
+	case nProducers > 0 && nConsumers > 0:
+		return "active"
+	case nProducers > 0:
+		return "orphan_publisher"
+	case nConsumers > 0:
+		return "orphan_subscriber"
+	default:
+		return "orphan"
+	}
+}
+
+// inferProtocol derives a human-readable protocol name from entity kind /
+// name / properties, useful for the UI badge.
+func inferProtocol(kind, name string, props map[string]string, broker string) string {
+	stripped := dashStripScopePrefix(kind)
+	switch stripped {
+	case kindMessageTopic:
+		if broker != "" {
+			return broker
+		}
+		return "message_topic"
+	case kindQueue, kindTask, kindScheduledJob:
+		if fw := props["framework"]; fw != "" {
+			return fw
+		}
+		if broker != "" {
+			return broker
+		}
+		return "queue"
+	case kindChannelEvent:
+		if ct := props["channel_type"]; ct != "" {
+			return ct
+		}
+		return "channel"
+	case kindSubscription:
+		return "graphql_subscription"
+	case kindServerlessFunction:
+		if p := props["provider"]; p != "" {
+			return p
+		}
+		return "serverless"
+	}
+	switch {
+	case strings.HasPrefix(name, "channel:redis-pubsub:"):
+		return "redis_pubsub"
+	case strings.HasPrefix(name, "stream:redis:"):
+		return "redis_stream"
+	case strings.HasPrefix(name, "aws-lambda:"):
+		return "aws-lambda"
+	case strings.HasPrefix(name, "gcp-cloudfunction:"):
+		return "gcp-cloudfunction"
+	case strings.HasPrefix(name, "azure-function:"):
+		return "azure-function"
+	}
+	return "unknown"
+}
+
+// dedupStrings returns a copy of sl with duplicates removed, preserving order.
+func dedupStrings(sl []string) []string {
+	seen := make(map[string]struct{}, len(sl))
+	out := make([]string, 0, len(sl))
+	for _, s := range sl {
+		if _, ok := seen[s]; ok {
+			continue
+		}
+		seen[s] = struct{}{}
+		out = append(out, s)
+	}
+	return out
+}

--- a/internal/dashboard/handlers_topology_detail_test.go
+++ b/internal/dashboard/handlers_topology_detail_test.go
@@ -1,0 +1,472 @@
+package dashboard
+
+// handlers_topology_detail_test.go — unit tests for the per-topic detail
+// endpoint (GET /api/topology/{group}/topic/{topicId}).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// testServer returns a *Server wired against an in-memory fake store. The
+// caller must populate srv.graphs via the returned *GraphCache.
+func testServerForDetail(t *testing.T) (*Server, *GraphCache) {
+	t.Helper()
+	cache := NewGraphCache(60 * time.Second)
+	srv := &Server{
+		graphs: cache,
+	}
+	return srv, cache
+}
+
+func injectGroup(cache *GraphCache, groupName string, grp *DashGroup) {
+	cache.mu.Lock()
+	defer cache.mu.Unlock()
+	cache.entries[groupName] = &cacheEntry{group: grp, loadedAt: time.Now()}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_TwoProducersOneConsumer — fixture: 2 producers + 1 consumer
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_TwoProducersOneConsumer(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID:         "topic:orders",
+				Name:       "orders",
+				Kind:       "MessageTopic",
+				SourceFile: "kafka/topics.go",
+				StartLine:  10,
+				Properties: map[string]string{"broker": "kafka", "schema": "OrderCreated{id,amount}"},
+			},
+			{
+				ID:         "fn:api",
+				Name:       "ApiHandler",
+				Kind:       "SCOPE.Function",
+				SourceFile: "api/handler.go",
+				StartLine:  42,
+			},
+			{
+				ID:         "fn:checkout",
+				Name:       "CheckoutService",
+				Kind:       "SCOPE.Function",
+				SourceFile: "checkout/service.go",
+				StartLine:  7,
+			},
+			{
+				ID:         "fn:warehouse",
+				Name:       "WarehouseConsumer",
+				Kind:       "SCOPE.Function",
+				SourceFile: "warehouse/consumer.go",
+				StartLine:  15,
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:api", ToID: "topic:orders", Kind: "PUBLISHES_TO"},
+			{ID: "r2", FromID: "fn:checkout", ToID: "topic:orders", Kind: "PUBLISHES_TO"},
+			{ID: "r3", FromID: "fn:warehouse", ToID: "topic:orders", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "testgroup",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	srv, cache := testServerForDetail(t)
+	injectGroup(cache, "testgroup", grp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/testgroup/topic/svc::topic:orders", nil)
+	req.SetPathValue("group", "testgroup")
+	req.SetPathValue("topicId", "svc::topic:orders")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", rw.Code, rw.Body.String())
+	}
+
+	var resp topicDetailResponse
+	if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Basic identity.
+	if resp.ID != "svc::topic:orders" {
+		t.Errorf("ID = %q, want svc::topic:orders", resp.ID)
+	}
+	if resp.Label != "orders" {
+		t.Errorf("Label = %q, want orders", resp.Label)
+	}
+	if resp.Broker != "kafka" {
+		t.Errorf("Broker = %q, want kafka", resp.Broker)
+	}
+	if resp.MessageSchema != "OrderCreated{id,amount}" {
+		t.Errorf("MessageSchema = %q, want OrderCreated{id,amount}", resp.MessageSchema)
+	}
+	if resp.Repo != "svc" {
+		t.Errorf("Repo = %q, want svc", resp.Repo)
+	}
+	if resp.SourceFile != "kafka/topics.go" {
+		t.Errorf("SourceFile = %q, want kafka/topics.go", resp.SourceFile)
+	}
+	if resp.StartLine != 10 {
+		t.Errorf("StartLine = %d, want 10", resp.StartLine)
+	}
+
+	// Producers: 2.
+	if len(resp.Producers) != 2 {
+		t.Fatalf("Producers len = %d, want 2", len(resp.Producers))
+	}
+	// Each producer must have source_file populated.
+	for _, p := range resp.Producers {
+		if p.SourceFile == "" {
+			t.Errorf("producer %q missing source_file", p.Name)
+		}
+	}
+
+	// Consumers: 1.
+	if len(resp.Consumers) != 1 {
+		t.Fatalf("Consumers len = %d, want 1", len(resp.Consumers))
+	}
+	if resp.Consumers[0].Name != "WarehouseConsumer" {
+		t.Errorf("consumer name = %q, want WarehouseConsumer", resp.Consumers[0].Name)
+	}
+	if resp.Consumers[0].SourceFile != "warehouse/consumer.go" {
+		t.Errorf("consumer source_file = %q, want warehouse/consumer.go", resp.Consumers[0].SourceFile)
+	}
+
+	// Lifecycle: active (has both).
+	if resp.LifecycleState != "active" {
+		t.Errorf("LifecycleState = %q, want active", resp.LifecycleState)
+	}
+
+	// Beyond-minimum fields must be present.
+	if resp.UsageHistory == nil {
+		t.Error("UsageHistory must not be nil")
+	}
+	// CrossRepo false: all entities in same repo.
+	if resp.CrossRepo {
+		t.Error("CrossRepo should be false — all entities in same repo")
+	}
+
+	// Tests array must be non-nil even when empty.
+	if resp.Tests == nil {
+		t.Error("Tests must not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_CeleryScheduledJob — framework=celery + schedule field
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_CeleryScheduledJob(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "worker",
+		Entities: []graph.Entity{
+			{
+				ID:         "celery_beat:nightly",
+				Name:       "nightly_cleanup",
+				Kind:       "SCOPE.ScheduledJob",
+				SourceFile: "worker/beat.py",
+				StartLine:  5,
+				Properties: map[string]string{
+					"framework": "celery_beat",
+					"schedule":  "*/5 * * * *",
+				},
+			},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "grp2",
+		Repos: map[string]*DashRepo{"worker": {Slug: "worker", Doc: doc}},
+	}
+
+	srv, cache := testServerForDetail(t)
+	injectGroup(cache, "grp2", grp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/grp2/topic/worker::celery_beat:nightly", nil)
+	req.SetPathValue("group", "grp2")
+	req.SetPathValue("topicId", "worker::celery_beat:nightly")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", rw.Code, rw.Body.String())
+	}
+
+	var resp topicDetailResponse
+	if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Schedule fields.
+	if !resp.Scheduled {
+		t.Errorf("Scheduled = false, want true for ScheduledJob")
+	}
+	if resp.Schedule != "*/5 * * * *" {
+		t.Errorf("Schedule = %q, want */5 * * * *", resp.Schedule)
+	}
+	if resp.Framework != "celery_beat" {
+		t.Errorf("Framework = %q, want celery_beat", resp.Framework)
+	}
+
+	// Lifecycle: orphan (no producers/consumers).
+	if resp.LifecycleState != "orphan" {
+		t.Errorf("LifecycleState = %q, want orphan", resp.LifecycleState)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_UnknownTopic — 404 for unknown topicId
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_UnknownTopic(t *testing.T) {
+	doc := &graph.Document{
+		Repo:     "svc",
+		Entities: []graph.Entity{},
+	}
+	grp := &DashGroup{
+		Name:  "grp3",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	srv, cache := testServerForDetail(t)
+	injectGroup(cache, "grp3", grp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/grp3/topic/svc::does-not-exist", nil)
+	req.SetPathValue("group", "grp3")
+	req.SetPathValue("topicId", "svc::does-not-exist")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("expected 404, got %d", rw.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_UnknownGroup — 404 for unknown group
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_UnknownGroup(t *testing.T) {
+	srv, _ := testServerForDetail(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/nogroup/topic/svc::x", nil)
+	req.SetPathValue("group", "nogroup")
+	req.SetPathValue("topicId", "svc::x")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusNotFound {
+		t.Errorf("expected 404 for unknown group, got %d", rw.Code)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_LifecycleStates — orphan_publisher / orphan_subscriber
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_LifecycleStates(t *testing.T) {
+	cases := []struct {
+		name           string
+		relationships  []graph.Relationship
+		wantLifecycle  string
+	}{
+		{
+			name: "orphan_publisher",
+			relationships: []graph.Relationship{
+				{ID: "r1", FromID: "fn:producer", ToID: "topic:t", Kind: "PUBLISHES_TO"},
+			},
+			wantLifecycle: "orphan_publisher",
+		},
+		{
+			name: "orphan_subscriber",
+			relationships: []graph.Relationship{
+				{ID: "r1", FromID: "fn:consumer", ToID: "topic:t", Kind: "SUBSCRIBES_TO"},
+			},
+			wantLifecycle: "orphan_subscriber",
+		},
+		{
+			name:          "full_orphan",
+			relationships: []graph.Relationship{},
+			wantLifecycle: "orphan",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := &graph.Document{
+				Repo: "svc",
+				Entities: []graph.Entity{
+					{
+						ID:         "topic:t",
+						Name:       "test-topic",
+						Kind:       "MessageTopic",
+						Properties: map[string]string{"broker": "kafka"},
+					},
+				},
+				Relationships: tc.relationships,
+			}
+			grp := &DashGroup{
+				Name:  tc.name,
+				Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+			}
+			srv, cache := testServerForDetail(t)
+			injectGroup(cache, tc.name, grp)
+
+			req := httptest.NewRequest(http.MethodGet, "/api/topology/"+tc.name+"/topic/svc::topic:t", nil)
+			req.SetPathValue("group", tc.name)
+			req.SetPathValue("topicId", "svc::topic:t")
+			rw := httptest.NewRecorder()
+			srv.handleTopicDetail(rw, req)
+
+			if rw.Code != http.StatusOK {
+				t.Fatalf("expected 200, got %d", rw.Code)
+			}
+			var resp topicDetailResponse
+			if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+				t.Fatalf("decode: %v", err)
+			}
+			if resp.LifecycleState != tc.wantLifecycle {
+				t.Errorf("lifecycle = %q, want %q", resp.LifecycleState, tc.wantLifecycle)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_CrossRepo — cross_repo=true when entities in different repos
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_CrossRepo(t *testing.T) {
+	docA := &graph.Document{
+		Repo: "svc-a",
+		Entities: []graph.Entity{
+			{
+				ID:         "topic:payments",
+				Name:       "payments",
+				Kind:       "MessageTopic",
+				SourceFile: "events/topics.go",
+				Properties: map[string]string{"broker": "kafka"},
+			},
+			{
+				ID:         "fn:publisher",
+				Name:       "PaymentPublisher",
+				Kind:       "SCOPE.Function",
+				SourceFile: "payments/publisher.go",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "fn:publisher", ToID: "topic:payments", Kind: "PUBLISHES_TO"},
+		},
+	}
+	docB := &graph.Document{
+		Repo: "svc-b",
+		Entities: []graph.Entity{
+			{
+				ID:         "fn:consumer",
+				Name:       "PaymentConsumer",
+				Kind:       "SCOPE.Function",
+				SourceFile: "billing/consumer.go",
+			},
+		},
+		Relationships: []graph.Relationship{
+			// Consumer in svc-b subscribes to the topic in svc-a (local ID resolves across repos).
+			{ID: "r2", FromID: "fn:consumer", ToID: "topic:payments", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+	grp := &DashGroup{
+		Name: "cross",
+		Repos: map[string]*DashRepo{
+			"svc-a": {Slug: "svc-a", Doc: docA},
+			"svc-b": {Slug: "svc-b", Doc: docB},
+		},
+	}
+
+	srv, cache := testServerForDetail(t)
+	injectGroup(cache, "cross", grp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/cross/topic/svc-a::topic:payments", nil)
+	req.SetPathValue("group", "cross")
+	req.SetPathValue("topicId", "svc-a::topic:payments")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d — body: %s", rw.Code, rw.Body.String())
+	}
+
+	var resp topicDetailResponse
+	if err := json.NewDecoder(rw.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if !resp.CrossRepo {
+		t.Error("CrossRepo should be true when consumer is in different repo")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestTopicDetail_ArrayFieldsNeverNull — wire contract: [] not null
+// ---------------------------------------------------------------------------
+
+func TestTopicDetail_ArrayFieldsNeverNull(t *testing.T) {
+	// Topic with no edges — every array field must marshal as [].
+	doc := &graph.Document{
+		Repo: "svc",
+		Entities: []graph.Entity{
+			{
+				ID:         "topic:empty",
+				Name:       "empty-topic",
+				Kind:       "MessageTopic",
+				Properties: map[string]string{"broker": "kafka"},
+			},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "nullcheck",
+		Repos: map[string]*DashRepo{"svc": {Slug: "svc", Doc: doc}},
+	}
+
+	srv, cache := testServerForDetail(t)
+	injectGroup(cache, "nullcheck", grp)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/topology/nullcheck/topic/svc::topic:empty", nil)
+	req.SetPathValue("group", "nullcheck")
+	req.SetPathValue("topicId", "svc::topic:empty")
+	rw := httptest.NewRecorder()
+	srv.handleTopicDetail(rw, req)
+
+	if rw.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rw.Code)
+	}
+
+	// Decode into raw JSON to verify [] not null.
+	var raw map[string]json.RawMessage
+	if err := json.NewDecoder(rw.Body).Decode(&raw); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	arrayFields := []string{"producers", "consumers", "tests", "related_topics", "usage_history"}
+	for _, field := range arrayFields {
+		v, ok := raw[field]
+		if !ok {
+			t.Errorf("field %q missing from response", field)
+			continue
+		}
+		if string(v) == "null" {
+			t.Errorf("field %q is null, want []", field)
+		}
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -172,6 +172,7 @@ func (s *Server) routes() http.Handler {
 
 	// Broker topology
 	mux.HandleFunc("GET /api/topology/{group}", s.handleTopology)
+	mux.HandleFunc("GET /api/topology/{group}/topic/{topicId}", s.handleTopicDetail)
 	mux.HandleFunc("GET /api/topology/{group}/orphan-publishers", s.handleOrphanPublishers)
 
 	// Docs portal


### PR DESCRIPTION
## Summary

Add \`GET /api/topology/{group}/topic/{topicId}\` — the Topology v2 per-entity detail endpoint. Returns the full detail record for one topology entity (topic, queue, channel, NATS subject, scheduled job, or serverless function) with resolved producer/consumer entity records, message schema, schedule expression, framework metadata, enrichment frontmatter, and beyond-minimum computed fields.

## Closes / Refs

- Closes #1138
- Refs #1135

## What changed

**\`internal/dashboard/handlers_topology_detail.go\`** (new file)
- \`handleTopicDetail\` — request handler, calls \`buildTopicDetail\`, returns 200/404
- \`buildTopicDetail\` — locates the entity across repos, resolves all fields, returns \`topicDetailResponse\`
- \`collectAllProducerConsumerIDs\` — scans **all** repo docs for edges referencing the topic (handles cross-repo extractors)
- \`resolveEntityRecords\` — turns raw local IDs into full \`{entity_id, name, kind, source_file, start_line, repo}\` records
- \`resolveTestEntities\` — finds entities with \`TESTS\` edges pointing at the topic
- \`findRelatedTopics\` — topics sharing a producer or consumer with this topic
- \`countFlowsTraversing\` — number of Process entities with a \`STEP_IN_PROCESS\` step referencing this topic
- \`computeLifecycleState\` — \`active\` / \`orphan_publisher\` / \`orphan_subscriber\` / \`orphan\` from raw edge counts
- \`isCrossRepo\` — true when any resolved producer/consumer is in a different repo
- \`inferProtocol\` — derives human-readable protocol badge from kind/name/props/broker

**\`internal/dashboard/server.go\`**
- Registers \`GET /api/topology/{group}/topic/{topicId}\` → \`s.handleTopicDetail\`

**\`internal/dashboard/handlers_topology_detail_test.go\`** (new file, 8 tests)
- Fixture: 2 producers + 1 consumer → all fields populated, lifecycle_state=active
- Fixture: framework=celery_beat + schedule=*/5 * * * * → scheduled=true, schedule populated
- Unknown topic → 404
- Unknown group → 404
- Lifecycle sub-tests: orphan_publisher, orphan_subscriber, full_orphan
- Cross-repo: consumer entity in different repo → cross_repo=true
- All array fields (producers, consumers, tests, related_topics, usage_history) serialize as [] not null

## Beyond the minimum

| Field | Description |
|---|---|
| flow_count | Number of Process flows traversing this topic via STEP_IN_PROCESS |
| cross_repo | true when producers and consumers span multiple repos |
| lifecycle_state | active / orphan_publisher / orphan_subscriber / orphan |
| related_topics | Topics sharing a producer or consumer with this entity |
| usage_history | Placeholder [] for future time-series data |

## Testing
- [x] All tests pass: go test ./internal/dashboard/ — ok (1.179s)
- [x] 8 new tests covering all acceptance criteria + beyond-minimum fields
- [x] No regression in existing topology / flows / paths tests