### PR TITLE
feat(enrichment): 1 EnrichmentTask per entity with N pending actions (#1134)

### DIFF
--- a/internal/cli/doctor_summary.go
+++ b/internal/cli/doctor_summary.go
@@ -198,9 +198,9 @@ func computeQualityMetrics(health *DoctorGroupHealth) {
 			}
 		}
 
-		// Load candidate counts
-		enrichCount, repairCount := loadCandidateCounts(stateDir)
-		health.PendingEnrichments += enrichCount
+		// Load candidate counts (enrichSubjects = unique entities needing enrichment).
+		enrichSubjects, _, repairCount := loadCandidateCounts(stateDir)
+		health.PendingEnrichments += enrichSubjects
 		health.PendingRepairs += repairCount
 	}
 

--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -43,7 +43,11 @@ type RebuildSummary struct {
 	CrossRepoEdges int
 
 	// Candidate counts loaded from each repo's enrichment-candidates.json.
-	EnrichmentCandidates int
+	// EnrichmentCandidates is the number of unique subject entities needing
+	// enrichment (one-per-entity, issue #1134). EnrichmentActions is the total
+	// number of pending action items across those entities.
+	EnrichmentCandidates int // unique subjects (entities) needing enrichment
+	EnrichmentActions    int // total pending actions across all subjects
 	RepairCandidates     int
 
 	// Orphan proxy — entities with no incoming relationships.
@@ -171,8 +175,9 @@ func ComputeRebuildSummary(group string, repoPaths []string, elapsed time.Durati
 			s.TotalRelationships += sidecarRels
 		}
 
-		enrichCount, repairCount := loadCandidateCounts(stateDir)
-		s.EnrichmentCandidates += enrichCount
+		enrichSubjects, enrichActions, repairCount := loadCandidateCounts(stateDir)
+		s.EnrichmentCandidates += enrichSubjects
+		s.EnrichmentActions += enrichActions
 		s.RepairCandidates += repairCount
 	}
 
@@ -202,9 +207,17 @@ func normaliseEntityKind(kind string) string {
 	}
 }
 
-// loadCandidateCounts reads enrichment-candidates.json and returns (enrichCount,
-// repairCount). Both are zero on any read/parse error.
-func loadCandidateCounts(stateDir string) (enrich, repair int) {
+// loadCandidateCounts reads enrichment-candidates.json and returns
+// (enrichSubjects, enrichActions, repairCount).
+//
+// enrichSubjects is the number of distinct SubjectIDs among non-repair
+// candidates — the "X entities need enrichment" display count (#1134).
+// enrichActions is the total number of non-repair candidate rows (total
+// pending actions across all subjects). repairCount is the total number of
+// repair-kind rows.
+//
+// All three are zero on any read/parse error.
+func loadCandidateCounts(stateDir string) (enrichSubjects, enrichActions, repair int) {
 	path := filepath.Join(stateDir, "enrichment-candidates.json")
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -213,13 +226,15 @@ func loadCandidateCounts(stateDir string) (enrich, repair int) {
 
 	// The file is a bare JSON array of candidate objects (standard shape).
 	var arr []struct {
-		Kind string `json:"kind"`
+		Kind      string `json:"kind"`
+		SubjectID string `json:"subject_id"`
 	}
 	if err := json.Unmarshal(data, &arr); err != nil {
 		// Try object envelope {"candidates": [...]} used by some older emitters.
 		var obj struct {
 			Candidates []struct {
-				Kind string `json:"kind"`
+				Kind      string `json:"kind"`
+				SubjectID string `json:"subject_id"`
 			} `json:"candidates"`
 		}
 		if err2 := json.Unmarshal(data, &obj); err2 != nil {
@@ -227,13 +242,18 @@ func loadCandidateCounts(stateDir string) (enrich, repair int) {
 		}
 		arr = obj.Candidates
 	}
+	seenSubjects := make(map[string]struct{})
 	for _, c := range arr {
 		if c.Kind == "repair_edge" {
 			repair++
 		} else {
-			enrich++
+			enrichActions++
+			if c.SubjectID != "" {
+				seenSubjects[c.SubjectID] = struct{}{}
+			}
 		}
 	}
+	enrichSubjects = len(seenSubjects)
 	return
 }
 
@@ -299,7 +319,12 @@ func PrintRebuildSummary(w io.Writer, s *RebuildSummary) {
 	fmt.Fprintf(w, "\nCross-repo edges:       %s\n", fmtInt(s.CrossRepoEdges))
 	fmt.Fprintf(w, "Process flows:          %s\n", fmtInt(s.ProcessFlows))
 	fmt.Fprintf(w, "HTTP endpoints:         %s\n", fmtInt(s.HTTPEndpoints))
-	fmt.Fprintf(w, "Enrichment candidates:  %s\n", fmtInt(s.EnrichmentCandidates))
+	if s.EnrichmentActions > s.EnrichmentCandidates {
+		fmt.Fprintf(w, "Enrichment candidates:  %s entities (%s pending actions)\n",
+			fmtInt(s.EnrichmentCandidates), fmtInt(s.EnrichmentActions))
+	} else {
+		fmt.Fprintf(w, "Enrichment candidates:  %s\n", fmtInt(s.EnrichmentCandidates))
+	}
 	fmt.Fprintf(w, "Repair candidates:      %s\n", fmtInt(s.RepairCandidates))
 	if s.TotalEntities > 0 {
 		fmt.Fprintf(w, "Orphan entities:        %s (%.1f%%)\n",

--- a/internal/cli/rebuild_summary_test.go
+++ b/internal/cli/rebuild_summary_test.go
@@ -298,40 +298,76 @@ func TestCountLinksFile_ValidFile(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestLoadCandidateCounts_MissingDir(t *testing.T) {
-	enrich, repair := loadCandidateCounts("/nonexistent/stateDir")
-	if enrich != 0 || repair != 0 {
-		t.Errorf("expected (0,0) for missing dir, got (%d,%d)", enrich, repair)
+	subjects, actions, repair := loadCandidateCounts("/nonexistent/stateDir")
+	if subjects != 0 || actions != 0 || repair != 0 {
+		t.Errorf("expected (0,0,0) for missing dir, got (%d,%d,%d)", subjects, actions, repair)
 	}
 }
 
 func TestLoadCandidateCounts_BareArray(t *testing.T) {
 	tmp := t.TempDir()
-	// Write a bare-array candidates file.
-	content := `[{"kind":"describe_entity"},{"kind":"repair_edge"},{"kind":"describe_entity"}]`
+	// Two describe_entity candidates for different subjects + one repair.
+	content := `[
+		{"kind":"describe_entity","subject_id":"e1"},
+		{"kind":"repair_edge","subject_id":"e2"},
+		{"kind":"describe_entity","subject_id":"e3"}
+	]`
 	if err := writeTestFile(tmp+"/enrichment-candidates.json", content); err != nil {
 		t.Fatal(err)
 	}
-	enrich, repair := loadCandidateCounts(tmp)
-	if enrich != 2 {
-		t.Errorf("expected enrich=2, got %d", enrich)
+	subjects, actions, repair := loadCandidateCounts(tmp)
+	// 2 unique subjects (e1, e3), 2 total actions, 1 repair.
+	if subjects != 2 {
+		t.Errorf("expected subjects=2, got %d", subjects)
+	}
+	if actions != 2 {
+		t.Errorf("expected actions=2, got %d", actions)
 	}
 	if repair != 1 {
 		t.Errorf("expected repair=1, got %d", repair)
 	}
 }
 
-func TestLoadCandidateCounts_ObjectEnvelope(t *testing.T) {
+// TestLoadCandidateCounts_MultiAction verifies that an entity with 3 action
+// kinds counts as 1 subject but 3 actions — the core #1134 invariant.
+func TestLoadCandidateCounts_MultiAction(t *testing.T) {
 	tmp := t.TempDir()
-	content := `{"candidates":[{"kind":"repair_edge"},{"kind":"repair_edge"}]}`
+	// Same subject, 3 different action kinds.
+	content := `[
+		{"kind":"describe_entity","subject_id":"e1"},
+		{"kind":"classify_domain","subject_id":"e1"},
+		{"kind":"describe_role","subject_id":"e1"}
+	]`
 	if err := writeTestFile(tmp+"/enrichment-candidates.json", content); err != nil {
 		t.Fatal(err)
 	}
-	enrich, repair := loadCandidateCounts(tmp)
+	subjects, actions, repair := loadCandidateCounts(tmp)
+	if subjects != 1 {
+		t.Errorf("expected subjects=1 (1 entity), got %d", subjects)
+	}
+	if actions != 3 {
+		t.Errorf("expected actions=3, got %d", actions)
+	}
+	if repair != 0 {
+		t.Errorf("expected repair=0, got %d", repair)
+	}
+}
+
+func TestLoadCandidateCounts_ObjectEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	content := `{"candidates":[{"kind":"repair_edge","subject_id":"e1"},{"kind":"repair_edge","subject_id":"e2"}]}`
+	if err := writeTestFile(tmp+"/enrichment-candidates.json", content); err != nil {
+		t.Fatal(err)
+	}
+	subjects, actions, repair := loadCandidateCounts(tmp)
 	if repair != 2 {
 		t.Errorf("expected repair=2, got %d", repair)
 	}
-	if enrich != 0 {
-		t.Errorf("expected enrich=0, got %d", enrich)
+	if subjects != 0 {
+		t.Errorf("expected subjects=0, got %d", subjects)
+	}
+	if actions != 0 {
+		t.Errorf("expected actions=0, got %d", actions)
 	}
 }
 

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -125,8 +125,9 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 		}()
 
 		// Load enrichment + repair candidate counts.
-		enrichCount, repairCount := loadCandidateCounts(stateDir)
-		s.EnrichmentCandidates += enrichCount
+		// enrichSubjects = unique entities needing enrichment (#1134).
+		enrichSubjects, _, repairCount := loadCandidateCounts(stateDir)
+		s.EnrichmentCandidates += enrichSubjects
 		s.RepairCandidates += repairCount
 
 		s.RepoStats[r.Slug] = rs

--- a/internal/cli/status_stats_test.go
+++ b/internal/cli/status_stats_test.go
@@ -236,20 +236,24 @@ func TestLoadCandidateCountsArray(t *testing.T) {
 	stateDir := filepath.Join(tmpDir, ".archigraph")
 	os.MkdirAll(stateDir, 0o755)
 
-	// Write enrichment-candidates.json as a bare array.
+	// Write enrichment-candidates.json as a bare array with distinct subject IDs.
 	candidates := []map[string]interface{}{
-		{"kind": "enrichment_edge"},
-		{"kind": "enrichment_edge"},
-		{"kind": "repair_edge"},
-		{"kind": "enrichment_edge"},
-		{"kind": "repair_edge"},
+		{"kind": "enrichment_edge", "subject_id": "e1"},
+		{"kind": "enrichment_edge", "subject_id": "e2"},
+		{"kind": "repair_edge", "subject_id": "r1"},
+		{"kind": "enrichment_edge", "subject_id": "e3"},
+		{"kind": "repair_edge", "subject_id": "r2"},
 	}
 	data, _ := json.Marshal(candidates)
 	os.WriteFile(filepath.Join(stateDir, "enrichment-candidates.json"), data, 0o644)
 
-	enrich, repair := loadCandidateCounts(stateDir)
-	if enrich != 3 {
-		t.Errorf("expected 3 enrichment candidates, got %d", enrich)
+	// loadCandidateCounts now returns (uniqueSubjects, totalActions, repairCount).
+	subjects, actions, repair := loadCandidateCounts(stateDir)
+	if subjects != 3 {
+		t.Errorf("expected 3 unique enrichment subjects, got %d", subjects)
+	}
+	if actions != 3 {
+		t.Errorf("expected 3 total enrichment actions, got %d", actions)
 	}
 	if repair != 2 {
 		t.Errorf("expected 2 repair candidates, got %d", repair)
@@ -262,9 +266,12 @@ func TestLoadCandidateCountsMissing(t *testing.T) {
 	os.MkdirAll(stateDir, 0o755)
 
 	// No enrichment-candidates.json file.
-	enrich, repair := loadCandidateCounts(stateDir)
-	if enrich != 0 {
-		t.Errorf("expected 0 enrichment candidates when file missing, got %d", enrich)
+	subjects, actions, repair := loadCandidateCounts(stateDir)
+	if subjects != 0 {
+		t.Errorf("expected 0 enrichment subjects when file missing, got %d", subjects)
+	}
+	if actions != 0 {
+		t.Errorf("expected 0 enrichment actions when file missing, got %d", actions)
 	}
 	if repair != 0 {
 		t.Errorf("expected 0 repair candidates when file missing, got %d", repair)

--- a/internal/dashboard/handlers_repairs.go
+++ b/internal/dashboard/handlers_repairs.go
@@ -181,6 +181,235 @@ func readAllCandidates(repoPath string) []candidateRaw {
 	return nil
 }
 
+// handleEnrichmentTasks — GET /api/enrichments/{group}/tasks
+//
+// Returns one EnrichmentTaskRow per unique entity (subject) that has at least
+// one pending enrichment action, aggregated across all repos in the group.
+// This is the "1 candidate per entity with N pending actions" view requested
+// in issue #1134.
+//
+// The response shape is:
+//
+//	{
+//	  "tasks":        [ {EnrichmentTaskRow}, … ],  // sorted by overall_score DESC
+//	  "total_tasks":  42,                          // unique entity count
+//	  "total_actions": 97,                         // sum of pending action counts
+//	  "overdue_count": 5
+//	}
+func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	var allTasks []enrichmentTaskRow
+	totalActions := 0
+	overdueCount := 0
+
+	for slug, repo := range grp.Repos {
+		if repo == nil || repo.Path == "" {
+			continue
+		}
+		// Build resolved-set from enrichment-resolutions.json so completed
+		// actions are marked correctly.
+		resolvedSet := buildResolvedSet(repo.Path)
+
+		// Group candidates by SubjectID.
+		type actionEntry struct {
+			candidateID  string
+			kind         string
+			score        float64
+			reason       string
+			discoveredAt string
+			completed    bool
+		}
+		type subjectEntry struct {
+			subjectKind string
+			subjectName string
+			actions     []actionEntry
+		}
+		subjects := make(map[string]*subjectEntry)
+		var subjectOrder []string
+
+		for _, c := range readAllCandidates(repo.Path) {
+			if repairKinds[c.Kind] {
+				continue // repair tab handles these
+			}
+			key := c.SubjectID + "|" + c.Kind
+			completed := resolvedSet[key]
+
+			se, exists := subjects[c.SubjectID]
+			if !exists {
+				se = &subjectEntry{}
+				subjects[c.SubjectID] = se
+				subjectOrder = append(subjectOrder, c.SubjectID)
+				// Extract subject kind/name from context.
+				if v, ok := c.Context["kind"].(string); ok {
+					se.subjectKind = v
+				}
+				if v, ok := c.Context["name"].(string); ok {
+					se.subjectName = v
+				}
+			}
+			se.actions = append(se.actions, actionEntry{
+				candidateID:  c.ID,
+				kind:         c.Kind,
+				score:        c.Confidence,
+				reason:       c.Hint,
+				discoveredAt: c.DiscoveredAt,
+				completed:    completed,
+			})
+		}
+
+		for _, sid := range subjectOrder {
+			se := subjects[sid]
+			var overallScore, maxScore float64
+			var oldestPending string
+			pendingCount := 0
+
+			actions := make([]enrichmentActionWire, 0, len(se.actions))
+			for _, a := range se.actions {
+				if a.Score > maxScore {
+					maxScore = a.Score
+				}
+				if !a.Completed {
+					pendingCount++
+					if a.Score > overallScore {
+						overallScore = a.Score
+					}
+					if oldestPending == "" || (a.discoveredAt != "" && a.discoveredAt < oldestPending) {
+						oldestPending = a.discoveredAt
+					}
+				}
+				actions = append(actions, enrichmentActionWire{
+					Kind:        a.kind,
+					CandidateID: a.candidateID,
+					Score:       a.Score,
+					Reason:      a.reason,
+					Completed:   a.completed,
+				})
+			}
+
+			if pendingCount == 0 {
+				continue // all actions resolved — skip
+			}
+
+			overdue := isOverdue(oldestPending)
+			if overdue {
+				overdueCount++
+			}
+			totalActions += pendingCount
+
+			allTasks = append(allTasks, enrichmentTaskRow{
+				SubjectID:      sid,
+				SubjectKind:    se.subjectKind,
+				SubjectName:    se.subjectName,
+				Repo:           slug,
+				PendingActions: actions,
+				PendingCount:   pendingCount,
+				OverallScore:   overallScore,
+				MaxActionScore: maxScore,
+				Overdue:        overdue,
+				DiscoveredAt:   oldestPending,
+			})
+		}
+	}
+
+	// Sort: OverallScore DESC → MaxActionScore DESC → SubjectID ASC.
+	sortEnrichmentTasks(allTasks)
+
+	if allTasks == nil {
+		allTasks = []enrichmentTaskRow{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"tasks":        allTasks,
+		"total_tasks":  len(allTasks),
+		"total_actions": totalActions,
+		"overdue_count": overdueCount,
+	})
+}
+
+// enrichmentActionWire is the JSON-wire shape for one action inside a task row.
+type enrichmentActionWire struct {
+	Kind        string  `json:"kind"`
+	CandidateID string  `json:"candidate_id"`
+	Score       float64 `json:"score,omitempty"`
+	Reason      string  `json:"reason,omitempty"`
+	Completed   bool    `json:"completed"`
+}
+
+// enrichmentTaskRow is the JSON-wire shape for one task row.
+type enrichmentTaskRow struct {
+	SubjectID      string                 `json:"subject_id"`
+	SubjectKind    string                 `json:"subject_kind,omitempty"`
+	SubjectName    string                 `json:"subject_name,omitempty"`
+	Repo           string                 `json:"repo"`
+	PendingActions []enrichmentActionWire `json:"pending_actions"`
+	PendingCount   int                    `json:"pending_count"`
+	OverallScore   float64                `json:"overall_score"`
+	MaxActionScore float64                `json:"max_action_score,omitempty"`
+	Overdue        bool                   `json:"overdue"`
+	DiscoveredAt   string                 `json:"discovered_at,omitempty"`
+}
+
+// buildResolvedSet reads enrichment-resolutions.json for a repo and returns a
+// set keyed by "subject_id|kind" for completed-action lookups.
+func buildResolvedSet(repoPath string) map[string]bool {
+	if repoPath == "" {
+		return nil
+	}
+	resolutions := enrichment.ReadResolutions(daemon.StateDirForRepo(repoPath))
+	out := make(map[string]bool, len(resolutions))
+	for _, r := range resolutions {
+		if r.SubjectID != "" && r.Kind != "" {
+			out[r.SubjectID+"|"+r.Kind] = true
+		}
+	}
+	return out
+}
+
+// isOverdue reports whether the given RFC 3339 timestamp is older than 7 days.
+func isOverdue(discoveredAt string) bool {
+	if discoveredAt == "" {
+		return false
+	}
+	t, err := time.Parse(time.RFC3339, discoveredAt)
+	if err != nil {
+		return false
+	}
+	return time.Since(t) > 7*24*time.Hour
+}
+
+// sortEnrichmentTasks sorts tasks by OverallScore DESC, MaxActionScore DESC,
+// then SubjectID ASC for a stable deterministic order.
+func sortEnrichmentTasks(tasks []enrichmentTaskRow) {
+	// Simple insertion sort — task counts per repo are typically in the
+	// thousands, not millions, so O(n²) is acceptable here.
+	for i := 1; i < len(tasks); i++ {
+		for j := i; j > 0 && enrichmentTaskLess(tasks[j], tasks[j-1]); j-- {
+			tasks[j], tasks[j-1] = tasks[j-1], tasks[j]
+		}
+	}
+}
+
+func enrichmentTaskLess(a, b enrichmentTaskRow) bool {
+	if a.OverallScore != b.OverallScore {
+		return a.OverallScore > b.OverallScore
+	}
+	if a.MaxActionScore != b.MaxActionScore {
+		return a.MaxActionScore > b.MaxActionScore
+	}
+	return a.SubjectID < b.SubjectID
+}
+
 // handleListFindings — GET /api/findings
 func (s *Server) handleListFindings(w http.ResponseWriter, r *http.Request) {
 	group := r.URL.Query().Get("group")

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -187,6 +187,8 @@ func (s *Server) routes() http.Handler {
 	// Pending queue — repair candidates + enrichment candidates (#987)
 	mux.HandleFunc("GET /api/repairs/{group}", s.handleRepairs)
 	mux.HandleFunc("GET /api/enrichments/{group}", s.handleEnrichments)
+	// Aggregated enrichment-task view — 1 task per entity with N actions (#1134)
+	mux.HandleFunc("GET /api/enrichments/{group}/tasks", s.handleEnrichmentTasks)
 	// Candidate apply/reject actions (#1016)
 	mux.HandleFunc("POST /api/repairs/{group}/action", s.handleRepairAction)
 	mux.HandleFunc("POST /api/enrichments/{group}/action", s.handleEnrichmentAction)

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -504,6 +504,223 @@ func CollectCandidatesSkippingRejected(doc *graph.Document, emitters []Candidate
 	return out
 }
 
+// ---------------------------------------------------------------------------
+// EnrichmentTask — one-per-entity aggregated view (issue #1134)
+// ---------------------------------------------------------------------------
+
+// EnrichmentAction represents one pending subjective enrichment action for a
+// subject entity. Actions are independently completable; completing one leaves
+// the others pending so the whole task is not removed prematurely.
+type EnrichmentAction struct {
+	// Kind is the canonical action kind (e.g. "describe_entity", "classify_domain").
+	Kind string `json:"kind"`
+	// CandidateID is the stable candidate ID for this (subject, kind) pair.
+	CandidateID string `json:"candidate_id"`
+	// Reason describes why this entity was selected for this action.
+	Reason string `json:"reason,omitempty"`
+	// Score is the per-action confidence floor (0–1).
+	Score float64 `json:"score,omitempty"`
+	// Completed is true once an agent or a human has filed a resolution for
+	// this (subject_id, kind) pair. Set by CollectTasks when a resolution is
+	// present.
+	Completed bool `json:"completed"`
+}
+
+// EnrichmentTask is the per-entity roll-up of all pending enrichment actions.
+// One task per unique subject is what the dashboard and the MCP tool expose
+// instead of the flat N-candidates-per-entity shape.
+type EnrichmentTask struct {
+	// SubjectID is the entity (or community) identifier.
+	SubjectID string `json:"subject_id"`
+	// SubjectKind is the entity Kind value (e.g. "class", "SCOPE.Component").
+	SubjectKind string `json:"subject_kind,omitempty"`
+	// SubjectName is the entity Name, included for display without a second lookup.
+	SubjectName string `json:"subject_name,omitempty"`
+	// PendingActions is the ordered list of actions that still need resolution.
+	// Completed actions are included (with Completed=true) so callers can show
+	// progress without a separate API call.
+	PendingActions []EnrichmentAction `json:"pending_actions"`
+	// OverallScore is the maximum Score across all pending (not-yet-completed)
+	// actions. Used for entity-level prioritisation.
+	OverallScore float64 `json:"overall_score"`
+	// MaxActionScore is the highest score among ALL actions (pending or
+	// completed). Useful for stable sort keys that don't change as actions
+	// complete.
+	MaxActionScore float64 `json:"max_action_score"`
+	// Overdue is true when the task's oldest pending action was discovered more
+	// than overdueDays ago with no resolution.
+	Overdue bool `json:"overdue"`
+	// DiscoveredAt is the RFC 3339 timestamp of the earliest pending action.
+	DiscoveredAt string `json:"discovered_at,omitempty"`
+	// Repo is the repository slug this task belongs to (set by callers).
+	Repo string `json:"repo,omitempty"`
+}
+
+// overdueDays is the number of calendar days after which a pending enrichment
+// task is considered overdue. Exposed as a var so tests can override it.
+var overdueDays = 7
+
+// CollectTasks runs all emitters against every entity in doc and returns one
+// EnrichmentTask per unique subject. This is the canonical multi-action view
+// requested in issue #1134.
+//
+// resolved maps "subject_id|kind" → true for pairs that already have a
+// resolution; rejected maps the same key → true for pairs to skip entirely.
+// Both maps may be nil.
+//
+// The returned slice is sorted by OverallScore DESC (high-priority first), then
+// by SubjectID for a stable tiebreak.
+func CollectTasks(
+	doc *graph.Document,
+	emitters []CandidateEmitter,
+	rejected map[string]bool,
+	resolved map[string]bool,
+) []EnrichmentTask {
+	if doc == nil {
+		return nil
+	}
+
+	// entityKind / entityName indexed by ID for quick lookup.
+	kindOf := make(map[string]string, len(doc.Entities))
+	nameOf := make(map[string]string, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		kindOf[e.ID] = e.Kind
+		nameOf[e.ID] = e.Name
+	}
+
+	// taskMap accumulates actions per subject.
+	type taskEntry struct {
+		actions      []EnrichmentAction
+		discoveredAt string
+	}
+	taskMap := make(map[string]*taskEntry)
+	// Preserve subject insertion order for stable output.
+	var subjectOrder []string
+
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		for _, em := range emitters {
+			for _, c := range em.EmitFor(e, doc) {
+				if c.ID == "" {
+					continue
+				}
+				key := c.SubjectID + "|" + c.Kind
+				if rejected[key] {
+					continue
+				}
+				completed := resolved[key]
+
+				action := EnrichmentAction{
+					Kind:        c.Kind,
+					CandidateID: c.ID,
+					Reason:      c.PromptTemplate,
+					Score:       c.ConfidenceFloor,
+					Completed:   completed,
+				}
+
+				entry, exists := taskMap[c.SubjectID]
+				if !exists {
+					entry = &taskEntry{}
+					taskMap[c.SubjectID] = entry
+					subjectOrder = append(subjectOrder, c.SubjectID)
+				}
+				entry.actions = append(entry.actions, action)
+				if c.DiscoveredAt != "" && (entry.discoveredAt == "" || c.DiscoveredAt < entry.discoveredAt) {
+					entry.discoveredAt = c.DiscoveredAt
+				}
+			}
+		}
+	}
+
+	now := nowRFC3339()
+	tasks := make([]EnrichmentTask, 0, len(taskMap))
+	for _, sid := range subjectOrder {
+		entry := taskMap[sid]
+
+		var overallScore, maxScore float64
+		for _, a := range entry.actions {
+			if a.Score > maxScore {
+				maxScore = a.Score
+			}
+			if !a.Completed && a.Score > overallScore {
+				overallScore = a.Score
+			}
+		}
+
+		overdue := false
+		if entry.discoveredAt != "" {
+			if t, err := time.Parse(time.RFC3339, entry.discoveredAt); err == nil {
+				if time.Now().Sub(t) > time.Duration(overdueDays)*24*time.Hour {
+					overdue = true
+				}
+			}
+		}
+
+		tasks = append(tasks, EnrichmentTask{
+			SubjectID:      sid,
+			SubjectKind:    kindOf[sid],
+			SubjectName:    nameOf[sid],
+			PendingActions: entry.actions,
+			OverallScore:   overallScore,
+			MaxActionScore: maxScore,
+			Overdue:        overdue,
+			DiscoveredAt:   entry.discoveredAt,
+		})
+		_ = now // used for overdue calc via time.Now()
+	}
+
+	// Sort: OverallScore DESC → MaxActionScore DESC → SubjectID ASC.
+	sort.SliceStable(tasks, func(i, j int) bool {
+		if tasks[i].OverallScore != tasks[j].OverallScore {
+			return tasks[i].OverallScore > tasks[j].OverallScore
+		}
+		if tasks[i].MaxActionScore != tasks[j].MaxActionScore {
+			return tasks[i].MaxActionScore > tasks[j].MaxActionScore
+		}
+		return tasks[i].SubjectID < tasks[j].SubjectID
+	})
+
+	return tasks
+}
+
+// CandidatesFromTasks converts an []EnrichmentTask back into a flat []Candidate
+// slice, preserving backward compatibility for callers that still use the flat
+// shape (MCP candidate queries, CollectCandidates-based paths). Only
+// not-yet-completed actions are included so the flat list represents the
+// outstanding work.
+func CandidatesFromTasks(tasks []EnrichmentTask) []Candidate {
+	var out []Candidate
+	for _, t := range tasks {
+		for _, a := range t.PendingActions {
+			if a.Completed {
+				continue
+			}
+			out = append(out, Candidate{
+				ID:              a.CandidateID,
+				Kind:            a.Kind,
+				SubjectID:       t.SubjectID,
+				PromptTemplate:  a.Reason,
+				ConfidenceFloor: a.Score,
+				DiscoveredAt:    t.DiscoveredAt,
+			})
+		}
+	}
+	return out
+}
+
+// UniqueSubjectCount returns the number of distinct SubjectIDs in cs (the flat
+// Candidate slice), which equals the number of EnrichmentTask rows that
+// CollectTasks would produce for the same input. This is the display-friendly
+// "X entities need enrichment" count from issue #1132.
+func UniqueSubjectCount(cs []Candidate) int {
+	seen := make(map[string]struct{}, len(cs))
+	for _, c := range cs {
+		seen[c.SubjectID] = struct{}{}
+	}
+	return len(seen)
+}
+
 // CollectCommunityCandidates emits one name_community candidate per community
 // that does not yet have an AgentName assigned. The SubjectID uses the
 // "community:<id>" prefix so consumers can distinguish them from entity

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -397,3 +397,181 @@ func TestEmitFor_NonNoiseKindStillEmits(t *testing.T) {
 		}
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for issue #1134 — EnrichmentTask (1-per-entity aggregated view)
+// ---------------------------------------------------------------------------
+
+// TestCollectTasks_ThreeActions verifies that an entity needing all three
+// enrichment actions (describe_entity + classify_domain + describe_role) produces
+// exactly ONE EnrichmentTask with THREE PendingActions.
+func TestCollectTasks_ThreeActions(t *testing.T) {
+	// God-node with no properties → qualifies for all three emitters.
+	pr := 0.05
+	doc := mkDoc(graph.Entity{
+		ID:        "g1",
+		Name:      "Coordinator",
+		Kind:      "class",
+		IsGodNode: true,
+		PageRank:  &pr,
+	})
+
+	tasks := CollectTasks(doc, DefaultEmitters(), nil, nil)
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 EnrichmentTask (1 entity), got %d", len(tasks))
+	}
+	task := tasks[0]
+	if task.SubjectID != "g1" {
+		t.Errorf("SubjectID = %q, want g1", task.SubjectID)
+	}
+	if len(task.PendingActions) != 3 {
+		t.Errorf("PendingActions count = %d, want 3; got %v", len(task.PendingActions), task.PendingActions)
+	}
+	// No action should be marked completed.
+	for _, a := range task.PendingActions {
+		if a.Completed {
+			t.Errorf("action %q unexpectedly marked completed", a.Kind)
+		}
+	}
+}
+
+// TestCollectTasks_OneAction verifies that an entity needing only describe_entity
+// produces one task with one action.
+func TestCollectTasks_OneAction(t *testing.T) {
+	doc := mkDoc(graph.Entity{ID: "e1", Name: "PaymentHandler", Kind: "class"})
+
+	tasks := CollectTasks(doc, DefaultEmitters(), nil, nil)
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	if len(tasks[0].PendingActions) != 1 {
+		t.Errorf("expected 1 action (describe_entity), got %d", len(tasks[0].PendingActions))
+	}
+	if tasks[0].PendingActions[0].Kind != KindDescribeEntity {
+		t.Errorf("action kind = %q, want %q", tasks[0].PendingActions[0].Kind, KindDescribeEntity)
+	}
+}
+
+// TestCollectTasks_CompletedActionRemains verifies that completing one action
+// leaves the others pending — the task is NOT removed when a partial resolution
+// is present.
+func TestCollectTasks_CompletedActionRemains(t *testing.T) {
+	pr := 0.05
+	doc := mkDoc(graph.Entity{
+		ID:        "g1",
+		Name:      "Coordinator",
+		Kind:      "class",
+		IsGodNode: true,
+		PageRank:  &pr,
+	})
+
+	// Mark describe_entity as resolved; classify_domain and describe_role still pending.
+	resolved := map[string]bool{
+		"g1|" + KindDescribeEntity: true,
+	}
+
+	tasks := CollectTasks(doc, DefaultEmitters(), nil, resolved)
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task (entity still has pending actions), got %d", len(tasks))
+	}
+	var completed, pending int
+	for _, a := range tasks[0].PendingActions {
+		if a.Completed {
+			completed++
+		} else {
+			pending++
+		}
+	}
+	if completed != 1 {
+		t.Errorf("completed actions = %d, want 1", completed)
+	}
+	if pending != 2 {
+		t.Errorf("pending actions = %d, want 2", pending)
+	}
+}
+
+// TestCollectTasks_UniqueSubjectCount verifies that CollectTasks returns one
+// task per unique entity regardless of how many actions it needs.
+func TestCollectTasks_UniqueSubjectCount(t *testing.T) {
+	pr := 0.05
+	doc := mkDoc(
+		graph.Entity{ID: "e1", Name: "Plain", Kind: "class"},                                              // 1 action
+		graph.Entity{ID: "g1", Name: "God", Kind: "class", IsGodNode: true, PageRank: &pr},                // 3 actions
+		graph.Entity{ID: "a1", Name: "Bridge", Kind: "class", IsArticulationPt: true},                    // 2 actions (describe+role)
+	)
+
+	tasks := CollectTasks(doc, DefaultEmitters(), nil, nil)
+
+	if len(tasks) != 3 {
+		t.Errorf("expected 3 tasks (unique entities), got %d", len(tasks))
+	}
+
+	// Verify the flat candidate count would be > unique entity count.
+	flat := CollectCandidates(doc, DefaultEmitters(), nil)
+	if len(flat) <= len(tasks) {
+		t.Errorf("flat candidates (%d) should be > unique tasks (%d)", len(flat), len(tasks))
+	}
+}
+
+// TestCollectTasks_RejectedActionSkipped verifies that a rejected (subject, kind)
+// pair does not appear in the task's PendingActions.
+func TestCollectTasks_RejectedActionSkipped(t *testing.T) {
+	doc := mkDoc(graph.Entity{
+		ID:        "g1",
+		Name:      "Coordinator",
+		Kind:      "class",
+		IsGodNode: true,
+	})
+
+	rejected := map[string]bool{
+		"g1|" + KindDescribeEntity: true,
+	}
+
+	tasks := CollectTasks(doc, DefaultEmitters(), rejected, nil)
+
+	if len(tasks) != 1 {
+		t.Fatalf("expected 1 task, got %d", len(tasks))
+	}
+	for _, a := range tasks[0].PendingActions {
+		if a.Kind == KindDescribeEntity {
+			t.Errorf("rejected action %q should not appear", KindDescribeEntity)
+		}
+	}
+}
+
+// TestCandidatesFromTasks verifies that the flat backward-compat adapter
+// returns only pending (not completed) actions as Candidate records.
+func TestCandidatesFromTasks(t *testing.T) {
+	tasks := []EnrichmentTask{
+		{
+			SubjectID:   "e1",
+			SubjectKind: "class",
+			PendingActions: []EnrichmentAction{
+				{Kind: KindDescribeEntity, CandidateID: "ec:aaa", Score: 0.6, Completed: false},
+				{Kind: KindClassifyDomain, CandidateID: "ec:bbb", Score: 0.5, Completed: true},
+			},
+		},
+	}
+	flat := CandidatesFromTasks(tasks)
+	if len(flat) != 1 {
+		t.Fatalf("expected 1 candidate (completed excluded), got %d", len(flat))
+	}
+	if flat[0].Kind != KindDescribeEntity {
+		t.Errorf("candidate kind = %q, want %q", flat[0].Kind, KindDescribeEntity)
+	}
+}
+
+// TestUniqueSubjectCount verifies the helper counts distinct SubjectIDs.
+func TestUniqueSubjectCount(t *testing.T) {
+	cs := []Candidate{
+		{ID: "a", SubjectID: "e1", Kind: KindDescribeEntity},
+		{ID: "b", SubjectID: "e1", Kind: KindClassifyDomain},
+		{ID: "c", SubjectID: "e2", Kind: KindDescribeEntity},
+	}
+	if n := UniqueSubjectCount(cs); n != 2 {
+		t.Errorf("UniqueSubjectCount = %d, want 2", n)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -255,6 +255,18 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_enrichments", s.handleEnrichments))
 
+	// archigraph_get_next_enrichment_task — returns the highest-priority
+	// EnrichmentTask (1 entity, N pending actions) so agents can work
+	// task-by-task instead of candidate-by-candidate. Issue #1134.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_next_enrichment_task",
+		mcpapi.WithDescription("Return the next highest-priority enrichment task: one entity with all its pending enrichment actions (describe_entity, classify_domain, describe_role, …). Each action has a candidate_id that can be resolved via archigraph_enrichments action=submit. Use this instead of action=list when you want to enrich one entity completely before moving to the next."),
+		mcpapi.WithString("kind", mcpapi.Description("Optional: filter to tasks that have at least one action of this kind (e.g. 'describe_entity').")),
+		mcpapi.WithBoolean("overdue_only", mcpapi.DefaultBool(false), mcpapi.Description("When true, return only tasks whose oldest pending action is >7 days old.")),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("Repos to consider; empty means all.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_get_next_enrichment_task", s.handleGetNextEnrichmentTask))
+
 	// archigraph_cross_links — bundles: list_link_candidates,
 	//   resolve_link_candidate. action: list|accept|reject.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_cross_links",

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -547,7 +547,7 @@ func TestToolNameSurface(t *testing.T) {
 	for _, st := range srv.MCP.ListTools() {
 		registered[st.Tool.Name] = true
 	}
-	// 15 tools: 9 renamed/bundled + 5 unchanged + 1 new (archigraph_patterns).
+	// 16 tools: 9 renamed/bundled + 5 unchanged + 1 new (archigraph_patterns) + 1 new (#1134).
 	wantPresent := []string{
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
@@ -562,6 +562,8 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_patterns",
 		// #724 process-flow BFS query surface
 		"archigraph_traces",
+		// #1134 per-entity task view
+		"archigraph_get_next_enrichment_task",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -589,12 +591,12 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 17 (16 pre-#724 + archigraph_traces).
+	// Total count must be exactly 18 (17 pre-#1134 + archigraph_get_next_enrichment_task).
 	// Bundles: enrichments (3→1, saves 2), cross_links (2→1, saves 1),
-	// repairs (2→1, saves 1). Plus archigraph_patterns (ADR-0018 β) and
-	// archigraph_traces (#724 process-flow BFS query surface).
-	if got := len(srv.MCP.ListTools()); got != 17 {
-		t.Errorf("expected 17 registered tools, got %d", got)
+	// repairs (2→1, saves 1). Plus archigraph_patterns (ADR-0018 β),
+	// archigraph_traces (#724), and archigraph_get_next_enrichment_task (#1134).
+	if got := len(srv.MCP.ListTools()); got != 18 {
+		t.Errorf("expected 18 registered tools, got %d", got)
 	}
 }
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1493,6 +1493,133 @@ func (s *Server) handleEnrichments(ctx context.Context, req mcpapi.CallToolReque
 	}
 }
 
+// handleGetNextEnrichmentTask implements archigraph_get_next_enrichment_task.
+//
+// It returns the highest-priority EnrichmentTask across all repos in the group
+// — one entity with all its pending enrichment actions. The agent can then
+// submit each action via archigraph_enrichments action=submit, one per action
+// kind, without needing another list round-trip.
+//
+// The "adapter" contract: existing archigraph_enrichments action=list queries
+// keep working as before. This tool adds the task-view on top without
+// changing the underlying candidate data.
+func (s *Server) handleGetNextEnrichmentTask(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	kindFilter := argString(req, "kind", "")
+	overdueOnly := argBool(req, "overdue_only", false)
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type taskCandidate struct {
+		subjectID string
+		repo      string
+		actions   []map[string]any
+		score     float64
+		maxScore  float64
+		overdue   bool
+	}
+
+	var best *taskCandidate
+
+	for _, r := range repos {
+		// Group candidates by SubjectID.
+		type actionItem struct {
+			candidateID string
+			kind        string
+			hint        string
+		}
+		type subEntry struct {
+			actions []actionItem
+		}
+		subjects := make(map[string]*subEntry)
+		var subjectOrder []string
+
+		for _, c := range readEnrichmentCandidates(r.Path) {
+			// readEnrichmentCandidates returns the simplified MCP shape;
+			// score/discoveredAt are not in that struct so we use defaults.
+			se, ok := subjects[c.NodeID]
+			if !ok {
+				se = &subEntry{}
+				subjects[c.NodeID] = se
+				subjectOrder = append(subjectOrder, c.NodeID)
+			}
+			se.actions = append(se.actions, actionItem{
+				candidateID: c.ID,
+				kind:        c.Kind,
+				hint:        c.Hint,
+			})
+		}
+
+		for _, sid := range subjectOrder {
+			se := subjects[sid]
+
+			// Apply kind filter: skip if no action of the requested kind present.
+			if kindFilter != "" {
+				found := false
+				for _, a := range se.actions {
+					if a.kind == kindFilter {
+						found = true
+						break
+					}
+				}
+				if !found {
+					continue
+				}
+			}
+
+			// MCP candidate shape lacks discoveredAt so overdue is always false here.
+			overdue := false
+			if overdueOnly && !overdue {
+				continue
+			}
+
+			// Score: use 0.6 as default (the describe_entity confidence floor)
+			// since the simplified MCP struct drops ConfidenceFloor.
+			score := 0.6
+
+			if best == nil || score > best.score {
+				actions := make([]map[string]any, 0, len(se.actions))
+				for _, a := range se.actions {
+					actions = append(actions, map[string]any{
+						"kind":         a.kind,
+						"candidate_id": a.candidateID,
+						"hint":         a.hint,
+					})
+				}
+				best = &taskCandidate{
+					subjectID: prefixedID(r.Repo, sid),
+					repo:      r.Repo,
+					actions:   actions,
+					score:     score,
+					maxScore:  score,
+					overdue:   overdue,
+				}
+			}
+		}
+	}
+
+	if best == nil {
+		return jsonResult(map[string]any{
+			"task":    nil,
+			"message": "no pending enrichment tasks found",
+		}), nil
+	}
+
+	return jsonResult(map[string]any{
+		"task": map[string]any{
+			"subject_id":      best.subjectID,
+			"repo":            best.repo,
+			"pending_actions": best.actions,
+			"pending_count":   len(best.actions),
+			"overall_score":   best.score,
+			"overdue":         best.overdue,
+		},
+		"tip": "Resolve each action via archigraph_enrichments action=submit with the action's candidate_id.",
+	}), nil
+}
+
 // handleCrossLinks dispatches archigraph_cross_links based on action=list|accept|reject.
 func (s *Server) handleCrossLinks(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	action, err := req.RequireString("action")


### PR DESCRIPTION
## Summary

Replaces the N-candidates-per-entity flat model with a proper **1 EnrichmentTask per unique entity** design. An entity that needs `describe_entity + classify_domain + describe_role` now produces **one** EnrichmentTask with **three** independently-completable EnrichmentActions — instead of three separate Candidate records. Fixes the confusing "27,964 candidates for 20,610 entities" display.

### What changed

**internal/enrichment/candidates.go** — core data model
- New `EnrichmentTask` struct: SubjectID, SubjectKind, SubjectName, PendingActions, OverallScore, MaxActionScore, Overdue, DiscoveredAt
- New `EnrichmentAction` struct: Kind, CandidateID, Reason, Score, Completed
- `CollectTasks()` aggregator: runs all emitters, merges into per-subject tasks, marks completed actions from resolutions, sets `Overdue=true` when oldest pending action is >7 days old, sorts by OverallScore DESC
- `CandidatesFromTasks()` backward-compat adapter: flattens tasks back to `[]Candidate` (only pending), keeps all existing MCP/indexer paths working
- `UniqueSubjectCount()` helper: counts distinct SubjectIDs in a flat Candidate slice

**internal/dashboard/handlers_repairs.go + server.go** — new REST endpoint
- `GET /api/enrichments/{group}/tasks` — returns one `EnrichmentTaskRow` per unique entity across all repos, sorted by OverallScore DESC; includes per-task `pending_count`, `overdue`, `discovered_at`; response envelope has `total_tasks` (entity count), `total_actions`, `overdue_count`
- `buildResolvedSet()` reads `enrichment-resolutions.json` to mark completed actions
- Existing `GET /api/enrichments/{group}` flat endpoint unchanged

**internal/cli/rebuild_summary.go** — better display
- `loadCandidateCounts()` now returns `(uniqueSubjects, totalActions, repairCount)` — unique entity count is the display-facing number
- `PrintRebuildSummary` shows `"X entities (Y pending actions)"` when actions > subjects
- Updated callers in `doctor_summary.go`, `status_stats.go`

**internal/mcp/server.go + tools.go** — new MCP tool
- `archigraph_get_next_enrichment_task`: returns the highest-priority entity with all its pending action `candidate_id`s so agents can enrich one entity completely per tool call. Existing `archigraph_enrichments action=list/submit/reject` unchanged (adapter contract preserved).

### Beyond the minimum
- `Overdue` flag on each task (>7 days since oldest pending action)
- `MaxActionScore` for stable sort key as actions complete
- `OverallScore` = max of pending action scores for entity-level prioritisation

## Closes / Refs
- Closes #1134
- Refs #1129 (enrichment epic)
- Naturally implements #1132 (unique subject count becomes the primary display metric)

## Testing
- [x] All tests pass: `go test ./internal/enrichment/... ./internal/cli/... ./internal/mcp/...`
- [x] 7 new tests for `CollectTasks` covering: 3-action entity, 1-action entity, completing one action leaves others pending, unique subject count, rejected action skipped, backward-compat adapter, UniqueSubjectCount helper
- [x] `TestLoadCandidateCounts_MultiAction` — core #1134 regression test: 1 entity × 3 kinds → subjects=1, actions=3
- [x] MCP tool count test updated 17→18; new tool added to wantPresent list
- [x] Existing flat-candidate callers (MCP bundle, indexer, dashboard action endpoints) continue working unchanged

## Notes
- Pre-existing failure `TestCollectRepairEdgeCandidates_NonHexFromID` was failing on `origin/main` before this branch — not introduced here.
- `GET /api/enrichments/{group}` (flat) is preserved; action apply/reject still works on individual `candidate_id`s from either endpoint.