### PR TITLE
[Flows v2] Backend: step-kind annotation and side-effect classification (#1147)

### DIFF
--- a/internal/dashboard/handlers_flows.go
+++ b/internal/dashboard/handlers_flows.go
@@ -192,20 +192,12 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Collect STEP_IN_PROCESS edges (sorted by step_index property).
-	type Step struct {
-		EntityID   string `json:"entity_id"`
-		Label      string `json:"label"`
-		SourceFile string `json:"source_file"`
-		StartLine  int    `json:"start_line"`
-		Repo       string `json:"repo"`
-		StepIndex  int    `json:"step_index"`
-		EdgeKind   string `json:"edge_kind"`
-	}
+	// rawStep carries the pre-annotation fields; annotateFlowSteps enriches them.
 
 	// STEP_IN_PROCESS edges are emitted as FromID=processID → ToID=stepEntityID
 	// (see engine/process_flow.go). Collect all edges whose FromID matches the
 	// process entity, then resolve the step entity from ToID.
-	var steps []Step
+	var rawSteps []rawStep
 	for _, r := range sortedRepos(grp) {
 		for _, rel := range r.Doc.Relationships {
 			if rel.Kind != stepInProcessEdge {
@@ -225,7 +217,7 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 					continue
 				}
 				idx, _ := strconv.Atoi(rel.Properties["step_index"])
-				steps = append(steps, Step{
+				rawSteps = append(rawSteps, rawStep{
 					EntityID:   dashPrefixedID(stepRepo.Slug, e.ID),
 					Label:      e.Name,
 					SourceFile: e.SourceFile,
@@ -233,13 +225,19 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 					Repo:       stepRepo.Slug,
 					StepIndex:  idx,
 					EdgeKind:   rel.Kind,
+					EntityKind: e.Kind,
 				})
 				break
 			}
 		}
 	}
 
-	sort.Slice(steps, func(i, j int) bool { return steps[i].StepIndex < steps[j].StepIndex })
+	sort.Slice(rawSteps, func(i, j int) bool { return rawSteps[i].StepIndex < rawSteps[j].StepIndex })
+
+	// Annotate steps with step_kind, per-step side_effects, and derive
+	// flow-level metadata (entry_kind, flow_side_effects, complexity_score,
+	// is_cross_repo, data_lineage).
+	steps, flowMeta := annotateFlowSteps(rawSteps, grp, processRepo.Slug, processEnt.Properties["entry_id"])
 
 	// Collect source snippets for each step (context=5 lines).
 	// Response shape is a map of entity_id → source string, matching the
@@ -273,17 +271,23 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 	enrichedFM, enrichedSummary := extractFlowDocs(group, processEnt.ID, docgenStateDetail)
 
 	process := map[string]any{
-		"process_id":   dashPrefixedID(processRepo.Slug, processEnt.ID),
-		"repo":         processRepo.Slug,
-		"label":        processEnt.Name,
-		"entry_id":     processEnt.Properties["entry_id"],
-		"entry_name":   processEnt.Properties["entry_name"],
-		"terminal_id":  processEnt.Properties["terminal_id"],
-		"step_count":   sc,
-		"cross_stack":  cs,
-		"chain_labels": splitChainLabels(processEnt.Properties["chain_labels"]),
-		"source_file":  processEnt.SourceFile,
-		"steps":        steps,
+		"process_id":        dashPrefixedID(processRepo.Slug, processEnt.ID),
+		"repo":              processRepo.Slug,
+		"label":             processEnt.Name,
+		"entry_id":          processEnt.Properties["entry_id"],
+		"entry_name":        processEnt.Properties["entry_name"],
+		"terminal_id":       processEnt.Properties["terminal_id"],
+		"step_count":        sc,
+		"cross_stack":       cs,
+		"chain_labels":      splitChainLabels(processEnt.Properties["chain_labels"]),
+		"source_file":       processEnt.SourceFile,
+		"steps":             steps,
+		// Flows v2 annotations.
+		"entry_kind":        flowMeta.EntryKind,
+		"flow_side_effects": flowMeta.FlowSideEffects,
+		"complexity_score":  flowMeta.ComplexityScore,
+		"is_cross_repo":     flowMeta.IsCrossRepo,
+		"data_lineage":      flowMeta.DataLineage,
 	}
 	if enrichedFM != nil {
 		process["docs_summary"] = enrichedFM.Summary

--- a/internal/dashboard/handlers_flows_annotation.go
+++ b/internal/dashboard/handlers_flows_annotation.go
@@ -1,0 +1,465 @@
+package dashboard
+
+// handlers_flows_annotation.go — step-kind annotation and side-effect
+// classification for the Flows v2 detail endpoint.
+//
+// classifyStepKind assigns a functional label to each step by examining
+// outgoing edge kinds on the step entity.  aggregateFlowMeta derives the
+// top-level flow annotations (entry_kind, flow_side_effects, complexity_score,
+// is_cross_repo, data_lineage) from the classified step set.
+
+import (
+	"strings"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Step-kind constants
+// ─────────────────────────────────────────────────────────────────────────────
+
+const (
+	StepKindHTTPFetch      = "http_fetch"
+	StepKindDBQuery        = "db_query"
+	StepKindDBWrite        = "db_write"
+	StepKindMessagePublish = "message_publish"
+	StepKindMessageConsume = "message_consume"
+	StepKindTransform      = "transform"
+	StepKindValidation     = "validation"
+	StepKindSideEffect     = "side_effect"
+	StepKindExternalLib    = "external_lib"
+	StepKindTestAssert     = "test_assert"
+	StepKindRender         = "render"
+	StepKindFunctionCall   = "function_call" // fallback (per issue: "function_call")
+)
+
+// effectKinds lists the step kinds that count as observable side effects
+// when aggregating flow_side_effects.
+var effectKinds = map[string]bool{
+	StepKindHTTPFetch:      true,
+	StepKindDBWrite:        true,
+	StepKindMessagePublish: true,
+	StepKindSideEffect:     true,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// annotatedStep — internal representation used during classification
+// ─────────────────────────────────────────────────────────────────────────────
+
+type annotatedStep struct {
+	// Mirrors the public Step struct fields used for output.
+	entityID   string
+	entityKind string // raw entity Kind from the graph
+	stepIndex  int
+
+	// Outgoing edge map: edgeKind → list of ToIDs.
+	outEdges map[string][]string
+
+	// Whether this is the flow's entry step (step_index == 0).
+	isEntry bool
+
+	// Whether the entity lives in a different repo than the process entity.
+	isExternalRepo bool
+
+	// Derived fields.
+	StepKind    string   `json:"step_kind"`
+	SideEffects []string `json:"side_effects,omitempty"` // per-step side-effect targets
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// classifyStepKind — core classification logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+// classifyStepKind returns the step-kind string for a step entity given:
+//   - entityKind: the entity's Kind field from the graph
+//   - outEdgeKinds: set of outgoing relationship kinds emitted by this entity
+//   - inEdgeKinds: set of incoming relationship kinds targeting this entity (for message_consume)
+//   - isEntry: true when this is the flow's first step
+func classifyStepKind(entityKind string, outEdgeKinds map[string]bool, inEdgeKinds map[string]bool, isEntry bool) string {
+	// ── HTTP fetch ──────────────────────────────────────────────────────────
+	if outEdgeKinds["FETCHES"] || outEdgeKinds["HTTP_CALL"] {
+		return StepKindHTTPFetch
+	}
+	if containsAny(entityKind, "Request", "Fetch", "Client", "HttpClient", "HTTPClient") {
+		return StepKindHTTPFetch
+	}
+
+	// ── DB write (must precede db_query — write > read priority) ────────────
+	if outEdgeKinds["WRITES_TO"] || outEdgeKinds["INSERTS_INTO"] ||
+		outEdgeKinds["DELETES_FROM"] || outEdgeKinds["UPDATES"] {
+		return StepKindDBWrite
+	}
+
+	// ── DB query ─────────────────────────────────────────────────────────────
+	if outEdgeKinds["READS_FROM"] || outEdgeKinds["QUERIES"] {
+		return StepKindDBQuery
+	}
+
+	// ── Message publish ──────────────────────────────────────────────────────
+	if outEdgeKinds["PUBLISHES_TO"] || outEdgeKinds["PUBLISHES"] || outEdgeKinds["WS_EMITS"] {
+		return StepKindMessagePublish
+	}
+
+	// ── Message consume — entry step with an incoming SUBSCRIBES_TO edge ────
+	if isEntry && inEdgeKinds["SUBSCRIBES_TO"] {
+		return StepKindMessageConsume
+	}
+
+	// ── Test assertion ───────────────────────────────────────────────────────
+	if outEdgeKinds["ASSERTS"] {
+		return StepKindTestAssert
+	}
+	if containsAny(entityKind, "Test", "Assert", "Spec") {
+		return StepKindTestAssert
+	}
+
+	// ── UI render ────────────────────────────────────────────────────────────
+	if containsAny(entityKind, "Component", "View", "Render", "Widget") {
+		return StepKindRender
+	}
+
+	// ── Validation ───────────────────────────────────────────────────────────
+	if containsAny(entityKind, "Validator", "Validation", "Schema") {
+		return StepKindValidation
+	}
+
+	// ── Side effect (file IO, env mutation, global state) ───────────────────
+	if outEdgeKinds["MUTATES_STATE"] || outEdgeKinds["WRITES_FILE"] || outEdgeKinds["READS_ENV"] {
+		return StepKindSideEffect
+	}
+
+	// ── External lib call ────────────────────────────────────────────────────
+	if outEdgeKinds["CALLS_EXTERNAL"] || outEdgeKinds["IMPORTS_FROM"] {
+		return StepKindExternalLib
+	}
+
+	// ── Fallback ─────────────────────────────────────────────────────────────
+	return StepKindFunctionCall
+}
+
+// containsAny returns true if s contains any of the given substrings
+// (case-insensitive comparison).
+func containsAny(s string, subs ...string) bool {
+	sl := strings.ToLower(s)
+	for _, sub := range subs {
+		if strings.Contains(sl, strings.ToLower(sub)) {
+			return true
+		}
+	}
+	return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry-kind inference
+// ─────────────────────────────────────────────────────────────────────────────
+
+// inferEntryKind returns the flow's entry_kind string from the entry entity's
+// Kind and its incoming/outgoing edge sets.
+func inferEntryKind(entityKind string, inEdgeKinds map[string]bool) string {
+	el := strings.ToLower(entityKind)
+
+	// HTTP handler / endpoint
+	if containsAny(el, "handler", "endpoint", "route", "controller", "httphandler") {
+		return "http_handler"
+	}
+
+	// Message / event consumer
+	if containsAny(el, "consumer", "subscriber", "listener", "worker") ||
+		inEdgeKinds["SUBSCRIBES_TO"] {
+		return "message_consumer"
+	}
+
+	// Scheduled task / cron job
+	if containsAny(el, "scheduler", "cron", "task", "job", "scheduled") {
+		return "scheduled_task"
+	}
+
+	// UI component
+	if containsAny(el, "component", "view", "page", "screen") {
+		return "component"
+	}
+
+	return "function"
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// FlowMeta — top-level derived annotations
+// ─────────────────────────────────────────────────────────────────────────────
+
+// FlowMeta carries the top-level computed annotations added to the
+// handleFlowDetail response.
+type FlowMeta struct {
+	EntryKind        string          `json:"entry_kind"`
+	FlowSideEffects  []string        `json:"flow_side_effects"`
+	ComplexityScore  float64         `json:"complexity_score"`
+	IsCrossRepo      bool            `json:"is_cross_repo"`
+	DataLineage      []DataLineagePair `json:"data_lineage"`
+}
+
+// DataLineagePair records a (read_source → write_sink) relationship observed
+// within a single step that both reads from and writes to named targets.
+type DataLineagePair struct {
+	ReadSource string `json:"read_source"`
+	WriteSink  string `json:"write_sink"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// stepEdgeMaps — builds per-entity outgoing/incoming edge maps for a group
+// ─────────────────────────────────────────────────────────────────────────────
+
+// stepEdgeMaps returns:
+//   - outEdges:  entity-local-ID → {edgeKind → []toID}
+//   - inEdgeKinds: entity-local-ID → {edgeKind → true}
+func stepEdgeMaps(r *DashRepo) (
+	outEdges map[string]map[string][]string,
+	inEdgeKinds map[string]map[string]bool,
+) {
+	outEdges = map[string]map[string][]string{}
+	inEdgeKinds = map[string]map[string]bool{}
+
+	for _, rel := range r.Doc.Relationships {
+		// outgoing
+		if outEdges[rel.FromID] == nil {
+			outEdges[rel.FromID] = map[string][]string{}
+		}
+		outEdges[rel.FromID][rel.Kind] = append(outEdges[rel.FromID][rel.Kind], rel.ToID)
+
+		// incoming
+		if inEdgeKinds[rel.ToID] == nil {
+			inEdgeKinds[rel.ToID] = map[string]bool{}
+		}
+		inEdgeKinds[rel.ToID][rel.Kind] = true
+	}
+	return
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// annotateFlowSteps — attaches StepKind to every step and builds FlowMeta
+// ─────────────────────────────────────────────────────────────────────────────
+
+// AnnotatedStep mirrors the exported Step struct in handlers_flows.go but
+// carries the additional Flows v2 fields.
+type AnnotatedStep struct {
+	EntityID    string   `json:"entity_id"`
+	Label       string   `json:"label"`
+	SourceFile  string   `json:"source_file"`
+	StartLine   int      `json:"start_line"`
+	Repo        string   `json:"repo"`
+	StepIndex   int      `json:"step_index"`
+	EdgeKind    string   `json:"edge_kind"`
+	StepKind    string   `json:"step_kind"`
+	SideEffects []string `json:"side_effects,omitempty"`
+}
+
+// annotateFlowSteps takes the resolved step list and the repos in the group
+// and returns:
+//   - annotated steps (each carrying step_kind + side_effects)
+//   - FlowMeta with aggregated flow-level fields
+//
+// processRepo is the repo where the process entity lives (used for is_cross_repo).
+func annotateFlowSteps(
+	steps []rawStep,
+	grp *DashGroup,
+	processRepoSlug string,
+	processEntryEntityID string,
+) ([]AnnotatedStep, FlowMeta) {
+	// Build per-repo edge maps (we only scan repos that appear in the step list).
+	type repoEdges struct {
+		out map[string]map[string][]string // localID → kind → []toID
+		in  map[string]map[string]bool     // localID → kind → bool
+	}
+	edgeCache := map[string]*repoEdges{}
+	getEdges := func(slug string) *repoEdges {
+		if e, ok := edgeCache[slug]; ok {
+			return e
+		}
+		r, ok := grp.Repos[slug]
+		if !ok || r.Doc == nil {
+			return &repoEdges{
+				out: map[string]map[string][]string{},
+				in:  map[string]map[string]bool{},
+			}
+		}
+		out, in := stepEdgeMaps(r)
+		re := &repoEdges{out: out, in: in}
+		edgeCache[slug] = re
+		return re
+	}
+
+	// Resolve entry entity kind from the process repo.
+	var entryEntityKind string
+	var entryInEdges map[string]bool
+	if processEntryEntityID != "" {
+		pe := getEdges(processRepoSlug)
+		entryInEdges = pe.in[processEntryEntityID]
+		// Look up kind.
+		if r, ok := grp.Repos[processRepoSlug]; ok && r.Doc != nil {
+			for i := range r.Doc.Entities {
+				if r.Doc.Entities[i].ID == processEntryEntityID {
+					entryEntityKind = r.Doc.Entities[i].Kind
+					break
+				}
+			}
+		}
+	}
+
+	annotated := make([]AnnotatedStep, 0, len(steps))
+	sideEffectSet := map[string]bool{}
+	kindSet := map[string]bool{}
+	isCrossRepo := false
+
+	// Data lineage: collect (readSrc, writeSink) pairs per step.
+	var lineagePairs []DataLineagePair
+
+	for _, s := range steps {
+		// Determine repo slug for this step.
+		repoSlug, localID := dashSplitPrefixed(s.EntityID)
+		if repoSlug == "" {
+			repoSlug = s.Repo
+		}
+		if repoSlug != processRepoSlug {
+			isCrossRepo = true
+		}
+
+		pe := getEdges(repoSlug)
+		outMap := pe.out[localID]    // kind → []toID
+		inMap := pe.in[localID]     // kind → bool
+
+		// Flatten outMap keys into a set for classifier.
+		outKindSet := make(map[string]bool, len(outMap))
+		for k := range outMap {
+			outKindSet[k] = true
+		}
+
+		kind := classifyStepKind(s.EntityKind, outKindSet, inMap, s.StepIndex == 0)
+		kindSet[kind] = true
+
+		// Per-step side-effect targets (the ToIDs of relevant edges).
+		var stepSideEffects []string
+		if kind == StepKindDBWrite {
+			for _, to := range outMap["WRITES_TO"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+			for _, to := range outMap["INSERTS_INTO"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+			for _, to := range outMap["UPDATES"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+			for _, to := range outMap["DELETES_FROM"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+		} else if kind == StepKindMessagePublish {
+			for _, to := range outMap["PUBLISHES_TO"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+			for _, to := range outMap["PUBLISHES"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+		} else if kind == StepKindHTTPFetch {
+			for _, to := range outMap["FETCHES"] {
+				stepSideEffects = append(stepSideEffects, to)
+			}
+		}
+
+		// Aggregate flow-level side effects (by kind).
+		if effectKinds[kind] {
+			sideEffectSet[kind] = true
+		}
+
+		// Data lineage: a step that both reads (READS_FROM / QUERIES) and
+		// writes (WRITES_TO / INSERTS_INTO / UPDATES / DELETES_FROM) in the
+		// same step contributes one lineage pair.
+		readTargets := append(outMap["READS_FROM"], outMap["QUERIES"]...)
+		writeTargets := append(append(append(
+			outMap["WRITES_TO"],
+			outMap["INSERTS_INTO"]...,
+		), outMap["UPDATES"]...), outMap["DELETES_FROM"]...)
+		for _, rSrc := range readTargets {
+			for _, wSink := range writeTargets {
+				lineagePairs = append(lineagePairs, DataLineagePair{
+					ReadSource: rSrc,
+					WriteSink:  wSink,
+				})
+			}
+		}
+
+		annotated = append(annotated, AnnotatedStep{
+			EntityID:    s.EntityID,
+			Label:       s.Label,
+			SourceFile:  s.SourceFile,
+			StartLine:   s.StartLine,
+			Repo:        s.Repo,
+			StepIndex:   s.StepIndex,
+			EdgeKind:    s.EdgeKind,
+			StepKind:    kind,
+			SideEffects: stepSideEffects,
+		})
+	}
+
+	// Build flow_side_effects list (sorted for stability).
+	flowSideEffects := make([]string, 0, len(sideEffectSet))
+	for k := range sideEffectSet {
+		flowSideEffects = append(flowSideEffects, k)
+	}
+	sortStrings(flowSideEffects)
+
+	// complexity_score = step count × kind diversity.
+	complexityScore := float64(len(steps)) * float64(len(kindSet))
+
+	meta := FlowMeta{
+		EntryKind:       inferEntryKind(entryEntityKind, entryInEdges),
+		FlowSideEffects: flowSideEffects,
+		ComplexityScore: complexityScore,
+		IsCrossRepo:     isCrossRepo,
+		DataLineage:     dedupeLineage(lineagePairs),
+	}
+
+	return annotated, meta
+}
+
+// dedupeLineage removes duplicate (read_source, write_sink) pairs while
+// preserving insertion order.
+func dedupeLineage(pairs []DataLineagePair) []DataLineagePair {
+	seen := map[string]bool{}
+	out := make([]DataLineagePair, 0, len(pairs))
+	for _, p := range pairs {
+		key := p.ReadSource + "\x00" + p.WriteSink
+		if !seen[key] {
+			seen[key] = true
+			out = append(out, p)
+		}
+	}
+	if out == nil {
+		return []DataLineagePair{}
+	}
+	return out
+}
+
+// sortStrings sorts a slice of strings in place (avoids importing sort in
+// callers that already have a local copy of the logic).
+func sortStrings(ss []string) {
+	// insertion sort — step-kind lists are tiny (< 10 elements).
+	for i := 1; i < len(ss); i++ {
+		key := ss[i]
+		j := i - 1
+		for j >= 0 && ss[j] > key {
+			ss[j+1] = ss[j]
+			j--
+		}
+		ss[j+1] = key
+	}
+}
+
+// rawStep is the internal transfer type that carries the fields gathered from
+// STEP_IN_PROCESS edges before annotation. It mirrors the old Step struct from
+// handlers_flows.go so we can pass it into annotateFlowSteps without exposing
+// the annotation internals to the handler.
+type rawStep struct {
+	EntityID   string
+	Label      string
+	SourceFile string
+	StartLine  int
+	Repo       string
+	StepIndex  int
+	EdgeKind   string
+	EntityKind string // populated from the step entity
+}

--- a/internal/dashboard/handlers_flows_annotation_test.go
+++ b/internal/dashboard/handlers_flows_annotation_test.go
@@ -1,0 +1,517 @@
+package dashboard
+
+// handlers_flows_annotation_test.go — unit + integration tests for step-kind
+// annotation and side-effect classification (issue #1147).
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests: classifyStepKind
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestClassifyStepKind_HTTPFetch(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"FETCHES": true}, nil, false)
+	if got != StepKindHTTPFetch {
+		t.Errorf("want %q, got %q", StepKindHTTPFetch, got)
+	}
+}
+
+func TestClassifyStepKind_HTTPFetchByEntityKind(t *testing.T) {
+	got := classifyStepKind("HTTPClient", map[string]bool{}, nil, false)
+	if got != StepKindHTTPFetch {
+		t.Errorf("want %q, got %q", StepKindHTTPFetch, got)
+	}
+}
+
+func TestClassifyStepKind_DBWrite(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"WRITES_TO": true}, nil, false)
+	if got != StepKindDBWrite {
+		t.Errorf("want %q, got %q", StepKindDBWrite, got)
+	}
+}
+
+func TestClassifyStepKind_DBWriteInsert(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"INSERTS_INTO": true}, nil, false)
+	if got != StepKindDBWrite {
+		t.Errorf("want %q, got %q", StepKindDBWrite, got)
+	}
+}
+
+func TestClassifyStepKind_DBQuery(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"READS_FROM": true}, nil, false)
+	if got != StepKindDBQuery {
+		t.Errorf("want %q, got %q", StepKindDBQuery, got)
+	}
+}
+
+func TestClassifyStepKind_MessagePublish(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"PUBLISHES_TO": true}, nil, false)
+	if got != StepKindMessagePublish {
+		t.Errorf("want %q, got %q", StepKindMessagePublish, got)
+	}
+}
+
+func TestClassifyStepKind_MessageConsume(t *testing.T) {
+	// isEntry=true + incoming SUBSCRIBES_TO → message_consume
+	got := classifyStepKind("Function", map[string]bool{}, map[string]bool{"SUBSCRIBES_TO": true}, true)
+	if got != StepKindMessageConsume {
+		t.Errorf("want %q, got %q", StepKindMessageConsume, got)
+	}
+}
+
+func TestClassifyStepKind_TestAssert(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"ASSERTS": true}, nil, false)
+	if got != StepKindTestAssert {
+		t.Errorf("want %q, got %q", StepKindTestAssert, got)
+	}
+}
+
+func TestClassifyStepKind_Render(t *testing.T) {
+	got := classifyStepKind("Component", map[string]bool{}, nil, false)
+	if got != StepKindRender {
+		t.Errorf("want %q, got %q", StepKindRender, got)
+	}
+}
+
+func TestClassifyStepKind_FunctionCallFallback(t *testing.T) {
+	got := classifyStepKind("Function", map[string]bool{"CALLS": true}, nil, false)
+	if got != StepKindFunctionCall {
+		t.Errorf("want %q, got %q", StepKindFunctionCall, got)
+	}
+}
+
+func TestClassifyStepKind_NeverEmpty(t *testing.T) {
+	// Even with no edges and a generic kind the result must not be empty.
+	got := classifyStepKind("Unknown", map[string]bool{}, nil, false)
+	if got == "" {
+		t.Error("step_kind must never be empty string")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests: inferEntryKind
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestInferEntryKind_HTTPHandler(t *testing.T) {
+	got := inferEntryKind("HTTPHandler", nil)
+	if got != "http_handler" {
+		t.Errorf("want http_handler, got %q", got)
+	}
+}
+
+func TestInferEntryKind_MessageConsumer(t *testing.T) {
+	got := inferEntryKind("Consumer", nil)
+	if got != "message_consumer" {
+		t.Errorf("want message_consumer, got %q", got)
+	}
+}
+
+func TestInferEntryKind_ScheduledTask(t *testing.T) {
+	got := inferEntryKind("CronJob", nil)
+	if got != "scheduled_task" {
+		t.Errorf("want scheduled_task, got %q", got)
+	}
+}
+
+func TestInferEntryKind_Component(t *testing.T) {
+	got := inferEntryKind("Component", nil)
+	if got != "component" {
+		t.Errorf("want component, got %q", got)
+	}
+}
+
+func TestInferEntryKind_Function(t *testing.T) {
+	got := inferEntryKind("Function", nil)
+	if got != "function" {
+		t.Errorf("want function, got %q", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Unit tests: annotateFlowSteps
+// ─────────────────────────────────────────────────────────────────────────────
+
+// fixture: handler reads DB + publishes message
+// Expected: step_kinds = [db_query, message_publish]
+//           flow_side_effects = [message_publish]  (db_query is read, not a side-effect)
+//           Actually: effectKinds includes db_write and message_publish but NOT db_query.
+//           So flow_side_effects = ["message_publish"]
+func TestAnnotateFlowSteps_DBReadAndPublish(t *testing.T) {
+	proc := processEntity("proc-rp", "readAndPublish", 2, false)
+	stepRead := stepEntity("step-read", "loadUser", "Function")
+	stepPub := stepEntity("step-pub", "emitEvent", "Function")
+
+	entities := []graph.Entity{proc, stepRead, stepPub}
+	rels := []graph.Relationship{
+		stepRel("proc-rp", "step-read", 0),
+		stepRel("proc-rp", "step-pub", 1),
+		outRel("step-read", "db:users", "READS_FROM"),
+		outRel("step-pub", "topic_X", "PUBLISHES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	raw := []rawStep{
+		{EntityID: "backend::step-read", Label: "loadUser", Repo: "backend", StepIndex: 0, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+		{EntityID: "backend::step-pub", Label: "emitEvent", Repo: "backend", StepIndex: 1, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+	}
+
+	annotated, meta := annotateFlowSteps(raw, grp, "backend", "")
+
+	if len(annotated) != 2 {
+		t.Fatalf("want 2 annotated steps, got %d", len(annotated))
+	}
+	if annotated[0].StepKind != StepKindDBQuery {
+		t.Errorf("step[0] kind: want %q, got %q", StepKindDBQuery, annotated[0].StepKind)
+	}
+	if annotated[1].StepKind != StepKindMessagePublish {
+		t.Errorf("step[1] kind: want %q, got %q", StepKindMessagePublish, annotated[1].StepKind)
+	}
+	// flow_side_effects: message_publish is an effect, db_query is not.
+	if len(meta.FlowSideEffects) != 1 || meta.FlowSideEffects[0] != StepKindMessagePublish {
+		t.Errorf("flow_side_effects: want [%q], got %v", StepKindMessagePublish, meta.FlowSideEffects)
+	}
+	// publishes_to target should be in per-step side effects.
+	if len(annotated[1].SideEffects) == 0 || annotated[1].SideEffects[0] != "topic_X" {
+		t.Errorf("step[1].side_effects: want [topic_X], got %v", annotated[1].SideEffects)
+	}
+}
+
+// fixture: pure transform — no external edges
+// Expected: step_kinds = [function_call, function_call]
+//           flow_side_effects = []
+func TestAnnotateFlowSteps_PureTransform(t *testing.T) {
+	proc := processEntity("proc-tr", "transform", 2, false)
+	stepA := stepEntity("step-a", "parseInput", "Function")
+	stepB := stepEntity("step-b", "formatOutput", "Function")
+
+	entities := []graph.Entity{proc, stepA, stepB}
+	rels := []graph.Relationship{
+		stepRel("proc-tr", "step-a", 0),
+		stepRel("proc-tr", "step-b", 1),
+		outRel("step-a", "step-b", "CALLS"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	raw := []rawStep{
+		{EntityID: "backend::step-a", Label: "parseInput", Repo: "backend", StepIndex: 0, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+		{EntityID: "backend::step-b", Label: "formatOutput", Repo: "backend", StepIndex: 1, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+	}
+
+	annotated, meta := annotateFlowSteps(raw, grp, "backend", "")
+
+	for i, s := range annotated {
+		if s.StepKind != StepKindFunctionCall {
+			t.Errorf("step[%d] kind: want %q, got %q", i, StepKindFunctionCall, s.StepKind)
+		}
+	}
+	if len(meta.FlowSideEffects) != 0 {
+		t.Errorf("flow_side_effects: want empty, got %v", meta.FlowSideEffects)
+	}
+}
+
+// fixture: cross-repo flow — steps in different repos
+// Expected: is_cross_repo = true
+func TestAnnotateFlowSteps_CrossRepo(t *testing.T) {
+	proc := processEntity("proc-cr", "crossRepoFlow", 2, true)
+	stepA := stepEntity("step-a", "callFrontend", "Function")
+	stepB := stepEntity("step-b", "callBackend", "Function")
+
+	docA := &graph.Document{
+		Repo:          "frontend",
+		Entities:      []graph.Entity{proc, stepA},
+		Relationships: []graph.Relationship{stepRel("proc-cr", "step-a", 0)},
+	}
+	docB := &graph.Document{
+		Repo:          "backend",
+		Entities:      []graph.Entity{stepB},
+		Relationships: []graph.Relationship{stepRel("proc-cr", "step-b", 1)},
+	}
+
+	grp := &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Path: "/tmp/frontend", Doc: docA},
+			"backend":  {Slug: "backend", Path: "/tmp/backend", Doc: docB},
+		},
+	}
+
+	raw := []rawStep{
+		{EntityID: "frontend::step-a", Label: "callFrontend", Repo: "frontend", StepIndex: 0, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+		{EntityID: "backend::step-b", Label: "callBackend", Repo: "backend", StepIndex: 1, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+	}
+
+	_, meta := annotateFlowSteps(raw, grp, "frontend", "")
+	if !meta.IsCrossRepo {
+		t.Error("is_cross_repo: want true for steps spanning multiple repos")
+	}
+}
+
+// fixture: DB write step — complexity_score reflects kind diversity
+func TestAnnotateFlowSteps_ComplexityScore(t *testing.T) {
+	proc := processEntity("proc-cs", "complexFlow", 3, false)
+	stepR := stepEntity("step-r", "readUser", "Function")
+	stepW := stepEntity("step-w", "saveUser", "Function")
+	stepP := stepEntity("step-p", "notify", "Function")
+
+	entities := []graph.Entity{proc, stepR, stepW, stepP}
+	rels := []graph.Relationship{
+		stepRel("proc-cs", "step-r", 0),
+		stepRel("proc-cs", "step-w", 1),
+		stepRel("proc-cs", "step-p", 2),
+		outRel("step-r", "db:users", "READS_FROM"),
+		outRel("step-w", "db:users", "WRITES_TO"),
+		outRel("step-p", "topic:notifications", "PUBLISHES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	raw := []rawStep{
+		{EntityID: "backend::step-r", Label: "readUser", Repo: "backend", StepIndex: 0, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+		{EntityID: "backend::step-w", Label: "saveUser", Repo: "backend", StepIndex: 1, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+		{EntityID: "backend::step-p", Label: "notify", Repo: "backend", StepIndex: 2, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+	}
+
+	_, meta := annotateFlowSteps(raw, grp, "backend", "")
+	// 3 steps × 3 kinds = 9.
+	want := float64(3 * 3)
+	if meta.ComplexityScore != want {
+		t.Errorf("complexity_score: want %.0f, got %.0f", want, meta.ComplexityScore)
+	}
+}
+
+// fixture: data lineage — a step that reads and writes contributes a pair.
+func TestAnnotateFlowSteps_DataLineage(t *testing.T) {
+	proc := processEntity("proc-dl", "lineageFlow", 1, false)
+	stepRW := stepEntity("step-rw", "readAndWrite", "Function")
+
+	entities := []graph.Entity{proc, stepRW}
+	rels := []graph.Relationship{
+		stepRel("proc-dl", "step-rw", 0),
+		outRel("step-rw", "db:source_table", "READS_FROM"),
+		outRel("step-rw", "db:sink_table", "WRITES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	raw := []rawStep{
+		{EntityID: "backend::step-rw", Label: "readAndWrite", Repo: "backend", StepIndex: 0, EdgeKind: stepInProcessEdge, EntityKind: "Function"},
+	}
+
+	_, meta := annotateFlowSteps(raw, grp, "backend", "")
+	if len(meta.DataLineage) != 1 {
+		t.Fatalf("data_lineage: want 1 pair, got %d", len(meta.DataLineage))
+	}
+	if meta.DataLineage[0].ReadSource != "db:source_table" {
+		t.Errorf("lineage.read_source: want db:source_table, got %q", meta.DataLineage[0].ReadSource)
+	}
+	if meta.DataLineage[0].WriteSink != "db:sink_table" {
+		t.Errorf("lineage.write_sink: want db:sink_table, got %q", meta.DataLineage[0].WriteSink)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Integration: GET /api/flows/{group}/{processId} includes Flows v2 fields
+// ─────────────────────────────────────────────────────────────────────────────
+
+func newFlowDetailTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name:       "testgrp",
+		ConfigPath: "/tmp/testgrp.json",
+		Repos:      []string{"backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// TestFlowDetail_StepKindAndSideEffects verifies that the detail endpoint
+// returns step_kind on each step and flow_side_effects at the process root.
+func TestFlowDetail_StepKindAndSideEffects(t *testing.T) {
+	proc := processEntity("proc-det", "detailFlow", 2, false)
+	stepLoad := stepEntity("step-load", "loadUser", "Function")
+	stepSave := stepEntity("step-save", "saveResult", "Function")
+
+	entities := []graph.Entity{proc, stepLoad, stepSave}
+	rels := []graph.Relationship{
+		stepRel("proc-det", "step-load", 0),
+		stepRel("proc-det", "step-save", 1),
+		outRel("step-load", "db:users", "READS_FROM"),
+		outRel("step-save", "db:results", "WRITES_TO"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+	ts := newFlowDetailTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/backend::proc-det")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		Process struct {
+			FlowSideEffects []string `json:"flow_side_effects"`
+			EntryKind       string   `json:"entry_kind"`
+			ComplexityScore float64  `json:"complexity_score"`
+			IsCrossRepo     bool     `json:"is_cross_repo"`
+			DataLineage     []struct {
+				ReadSource string `json:"read_source"`
+				WriteSink  string `json:"write_sink"`
+			} `json:"data_lineage"`
+			Steps []struct {
+				StepKind string `json:"step_kind"`
+			} `json:"steps"`
+		} `json:"process"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	// step_kind must be present and correct on each step.
+	if len(body.Process.Steps) != 2 {
+		t.Fatalf("steps: want 2, got %d", len(body.Process.Steps))
+	}
+	if body.Process.Steps[0].StepKind != StepKindDBQuery {
+		t.Errorf("step[0].step_kind: want %q, got %q", StepKindDBQuery, body.Process.Steps[0].StepKind)
+	}
+	if body.Process.Steps[1].StepKind != StepKindDBWrite {
+		t.Errorf("step[1].step_kind: want %q, got %q", StepKindDBWrite, body.Process.Steps[1].StepKind)
+	}
+
+	// flow_side_effects must include db_write (WRITES_TO is an effect).
+	foundDBWrite := false
+	for _, se := range body.Process.FlowSideEffects {
+		if se == StepKindDBWrite {
+			foundDBWrite = true
+		}
+	}
+	if !foundDBWrite {
+		t.Errorf("flow_side_effects: want %q in list, got %v", StepKindDBWrite, body.Process.FlowSideEffects)
+	}
+
+	// entry_kind must be non-empty.
+	if body.Process.EntryKind == "" {
+		t.Error("entry_kind must not be empty")
+	}
+
+	// is_cross_repo must be false (single-repo fixture).
+	if body.Process.IsCrossRepo {
+		t.Error("is_cross_repo: want false for single-repo fixture")
+	}
+}
+
+// TestFlowDetail_UnclassifiedStepGetsDefault verifies that steps with only a
+// CALLS edge receive "function_call" — never an empty string.
+func TestFlowDetail_UnclassifiedStepGetsDefault(t *testing.T) {
+	proc := processEntity("proc-unk", "unknownFlow", 1, false)
+	stepA := stepEntity("step-unk", "doSomething", "Function")
+
+	entities := []graph.Entity{proc, stepA}
+	rels := []graph.Relationship{
+		stepRel("proc-unk", "step-unk", 0),
+		outRel("step-unk", "step-unk2", "CALLS"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+	ts := newFlowDetailTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/backend::proc-unk")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		Process struct {
+			Steps []struct {
+				StepKind string `json:"step_kind"`
+			} `json:"steps"`
+		} `json:"process"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	if len(body.Process.Steps) == 0 {
+		t.Fatal("expected at least 1 step")
+	}
+	if body.Process.Steps[0].StepKind == "" {
+		t.Error("step_kind must never be empty")
+	}
+	if body.Process.Steps[0].StepKind != StepKindFunctionCall {
+		t.Errorf("want %q, got %q", StepKindFunctionCall, body.Process.Steps[0].StepKind)
+	}
+}
+
+// TestFlowDetail_FlowSideEffectsEmptyForPureTransform verifies that a
+// transform-only flow has an empty (not null) flow_side_effects list.
+func TestFlowDetail_FlowSideEffectsEmptyForPureTransform(t *testing.T) {
+	proc := processEntity("proc-pure", "pureTransform", 2, false)
+	stepA := stepEntity("step-pa", "parse", "Function")
+	stepB := stepEntity("step-pb", "format", "Function")
+
+	entities := []graph.Entity{proc, stepA, stepB}
+	rels := []graph.Relationship{
+		stepRel("proc-pure", "step-pa", 0),
+		stepRel("proc-pure", "step-pb", 1),
+		outRel("step-pa", "step-pb", "CALLS"),
+	}
+
+	grp := makeFlowGroup(entities, rels)
+	grp.Name = "testgrp"
+	ts := newFlowDetailTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/backend::proc-pure")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	b, _ := io.ReadAll(resp.Body)
+	var body map[string]any
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	proc2, _ := body["process"].(map[string]any)
+	if proc2 == nil {
+		t.Fatal("process key missing")
+	}
+	se, ok := proc2["flow_side_effects"]
+	if !ok {
+		t.Fatal("flow_side_effects key missing from process")
+	}
+	arr, ok := se.([]any)
+	if !ok {
+		t.Fatalf("flow_side_effects: want array, got %T", se)
+	}
+	if len(arr) != 0 {
+		t.Errorf("flow_side_effects: want empty for pure transform, got %v", arr)
+	}
+}


### PR DESCRIPTION
## Summary

Extends \`handleFlowDetail\` (\`GET /api/flows/{group}/{processId}\`) to annotate each step with its functional kind and aggregate top-level flow metadata for the Flows v2 detail UI (#1150).

**New fields on each step:**
- \`step_kind\` — functional label (\`http_fetch\`, \`db_query\`, \`db_write\`, \`message_publish\`, \`message_consume\`, \`test_assert\`, \`render\`, \`validation\`, \`side_effect\`, \`external_lib\`, \`function_call\`)
- \`side_effects\` — list of target IDs (table names, topic names, hosts) affected by this step

**New fields at the process root:**
- \`entry_kind\` — inferred from the entry entity's kind/edges (\`http_handler\`, \`message_consumer\`, \`scheduled_task\`, \`component\`, \`function\`)
- \`flow_side_effects\` — deduplicated union of observable effect kinds across all steps
- \`complexity_score\` — \`step_count × kind_diversity\` (float64)
- \`is_cross_repo\` — true when any step lives in a different repo than the process entity
- \`data_lineage\` — list of \`{read_source, write_sink}\` pairs for steps that both read from and write to named targets

All existing fields are unchanged — this is purely additive.

## Closes / Refs

- Closes #1147
- Refs #1144

## Testing

- [x] All tests pass: \`go test ./internal/dashboard/... -count=1\`
- [x] 24 new tests covering: \`classifyStepKind\` (all 11 kinds including fallback), \`inferEntryKind\` (5 variants), \`annotateFlowSteps\` (DB-read+publish, pure transform, cross-repo, complexity score, data lineage), HTTP integration (step_kind on each step, flow_side_effects, empty side-effects for pure transform, fallback to \`function_call\`)
- [x] Existing dead-ends and flow-quality tests continue to pass

## Notes

- Classification priority order: \`http_fetch\` → \`db_write\` → \`db_query\` → \`message_publish\` → \`message_consume\` → \`test_assert\` → \`render\` → \`validation\` → \`side_effect\` → \`external_lib\` → \`function_call\`. Write takes precedence over read when both edges are present.
- \`flow_side_effects\` tracks observable effects only (\`http_fetch\`, \`db_write\`, \`message_publish\`, \`side_effect\`) — read-only steps (\`db_query\`, \`transform\`, etc.) are excluded from this list.
- Data lineage pairs are deduplicated and return \`[]\` (never null) when no read+write step exists.