### PR TITLE
feat(topology): broker_canonical + owning_service + broker_groups (#1139)

### DIFF
--- a/internal/dashboard/handlers_topology.go
+++ b/internal/dashboard/handlers_topology.go
@@ -12,6 +12,7 @@ package dashboard
 
 import (
 	"net/http"
+	"sort"
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/mcp"
@@ -41,6 +42,37 @@ type topologyResponse struct {
 	GraphQLSubscriptions []map[string]any `json:"graphql_subscriptions"`
 	Transforms           []map[string]any `json:"transforms"`
 	Functions            []map[string]any `json:"functions"`
+	// BrokerGroups is a top-level summary of all brokers present in the
+	// group, sorted alphabetically by broker name (stable).  Each entry
+	// contains per-service topic counts, orphan counts, cross-repo topic
+	// counts, a health summary, and the last index timestamp.
+	BrokerGroups []brokerGroup `json:"broker_groups"`
+}
+
+// brokerServiceStat holds per-service aggregated counts inside a broker group.
+type brokerServiceStat struct {
+	Name        string `json:"name"`
+	TopicCount  int    `json:"topic_count"`
+}
+
+// brokerHealthSummary breaks down entity health per broker.
+type brokerHealthSummary struct {
+	Active            int `json:"active"`
+	OrphanPublisher   int `json:"orphan_publisher"`
+	OrphanSubscriber  int `json:"orphan_subscriber"`
+	Orphan            int `json:"orphan"`
+}
+
+// brokerGroup is one element of topologyResponse.BrokerGroups.
+type brokerGroup struct {
+	Broker              string              `json:"broker"`
+	Count               int                 `json:"count"`
+	Services            []brokerServiceStat `json:"services"`
+	OrphanPublishers    int                 `json:"orphan_publishers"`
+	OrphanSubscribers   int                 `json:"orphan_subscribers"`
+	CrossRepoTopicCount int                 `json:"cross_repo_topic_count"`
+	HealthSummary       brokerHealthSummary `json:"health_summary"`
+	LastIndexTimestamp  string              `json:"last_index_timestamp,omitempty"`
 }
 
 // classifyTopologyBucket maps an entity (by kind + name + properties) to
@@ -136,6 +168,20 @@ func (s *Server) handleGroupTopics(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, collectTopologyResponse(grp, group, docgenState))
 }
 
+// brokerAccum accumulates per-broker data during collectTopologyResponse so we
+// can produce the BrokerGroups summary in a single pass.
+type brokerAccum struct {
+	count               int
+	services            map[string]int   // service name → topic/queue count
+	orphanPublishers    int
+	orphanSubscribers   int
+	crossRepoTopicCount int
+	healthSummary       brokerHealthSummary
+	lastIndexTS         string
+	// repoSlugs tracks which repos contributed entities to this broker bucket.
+	repoSlugs map[string]struct{}
+}
+
 // collectTopologyResponse builds the full topology wire payload from a loaded
 // group. All slice fields are initialised to non-nil empty slices so that
 // JSON encoding produces [] (not null) when no data exists — fixing the
@@ -152,11 +198,38 @@ func collectTopologyResponse(grp *DashGroup, groupName string, docgenState *mcp.
 		GraphQLSubscriptions: []map[string]any{},
 		Transforms:           []map[string]any{},
 		Functions:            []map[string]any{},
+		BrokerGroups:         []brokerGroup{},
+	}
+
+	// brokerAccums accumulates data keyed by broker_canonical for the top-level
+	// broker_groups summary. Channels and functions are excluded (they have a
+	// different classification axis).
+	brokerAccums := map[string]*brokerAccum{}
+
+	// ensureBroker returns (or creates) the accumulator for a canonical broker.
+	ensureBroker := func(canonical string) *brokerAccum {
+		if a, ok := brokerAccums[canonical]; ok {
+			return a
+		}
+		a := &brokerAccum{
+			services:  map[string]int{},
+			repoSlugs: map[string]struct{}{},
+		}
+		brokerAccums[canonical] = a
+		return a
 	}
 
 	for _, r := range sortedRepos(grp) {
 		if r.Doc == nil {
 			continue
+		}
+
+		// Capture the last-index timestamp for this repo to propagate to the
+		// broker_groups.  GeneratedAt is zero for test fixtures; emit only when
+		// non-zero.
+		var repoTS string
+		if !r.Doc.GeneratedAt.IsZero() {
+			repoTS = r.Doc.GeneratedAt.UTC().Format("2006-01-02T15:04:05Z")
 		}
 
 		// For each entity, classify into a topology bucket and collect edges.
@@ -169,20 +242,50 @@ func collectTopologyResponse(grp *DashGroup, groupName string, docgenState *mcp.
 			switch bucket {
 			case "topic":
 				producers, consumers, transformsTo := brokerEdges(r, e.ID)
+				rawBroker := e.Properties["broker"]
+				framework := e.Properties["framework"]
+				canonical := brokerCanonical(rawBroker, framework)
+				svc := owningService(e.Properties, r.Slug)
 				entry := map[string]any{
-					"id":            dashPrefixedID(r.Slug, e.ID),
-					"repo":          r.Slug,
-					"label":         e.Name,
-					"broker":        e.Properties["broker"],
-					"producers":     producers,
-					"consumers":     consumers,
-					"transforms_to": transformsTo,
+					"id":               dashPrefixedID(r.Slug, e.ID),
+					"repo":             r.Slug,
+					"label":            e.Name,
+					"broker":           rawBroker,
+					"broker_canonical": canonical,
+					"owning_service":   svc,
+					"producers":        producers,
+					"consumers":        consumers,
+					"transforms_to":    transformsTo,
 				}
 				// Enrich topic with frontmatter when available.
 				if groupName != "" {
 					applyTopologyEnrichment(entry, groupName, e.ID, docgenState)
 				}
 				resp.Topics = append(resp.Topics, entry)
+
+				// Accumulate broker_groups data.
+				a := ensureBroker(canonical)
+				a.count++
+				a.services[svc]++
+				a.repoSlugs[r.Slug] = struct{}{}
+				if repoTS > a.lastIndexTS {
+					a.lastIndexTS = repoTS
+				}
+				// Determine orphan / health status.
+				hasProducer := len(producers) > 0
+				hasConsumer := len(consumers) > 0
+				switch {
+				case hasProducer && hasConsumer:
+					a.healthSummary.Active++
+				case hasProducer && !hasConsumer:
+					a.orphanSubscribers++
+					a.healthSummary.OrphanSubscriber++
+				case !hasProducer && hasConsumer:
+					a.orphanPublishers++
+					a.healthSummary.OrphanPublisher++
+				default:
+					a.healthSummary.Orphan++
+				}
 
 			case "queue":
 				producers, consumers, _ := brokerEdges(r, e.ID)
@@ -193,14 +296,18 @@ func collectTopologyResponse(grp *DashGroup, groupName string, docgenState *mcp.
 				}
 				// Async task queues carry framework info instead of a broker name.
 				framework := e.Properties["framework"]
+				canonical := brokerCanonical(broker, framework)
+				svc := owningService(e.Properties, r.Slug)
 				entry := map[string]any{
-					"id":        dashPrefixedID(r.Slug, e.ID),
-					"repo":      r.Slug,
-					"label":     e.Name,
-					"broker":    broker,
-					"framework": framework,
-					"producers": producers,
-					"consumers": consumers,
+					"id":               dashPrefixedID(r.Slug, e.ID),
+					"repo":             r.Slug,
+					"label":            e.Name,
+					"broker":           broker,
+					"broker_canonical": canonical,
+					"framework":        framework,
+					"owning_service":   svc,
+					"producers":        producers,
+					"consumers":        consumers,
 				}
 				// #1116: ScheduledJob entities (emitted by the scheduled-job pass for
 				// Celery beat, APScheduler, node-cron, Spring @Scheduled, etc.) carry a
@@ -213,6 +320,31 @@ func collectTopologyResponse(grp *DashGroup, groupName string, docgenState *mcp.
 						entry["schedule"] = e.Properties["schedule"]
 					}
 				}
+
+				// Accumulate broker_groups data (NATS goes into nats_subjects but
+				// still counts in broker_groups).
+				a := ensureBroker(canonical)
+				a.count++
+				a.services[svc]++
+				a.repoSlugs[r.Slug] = struct{}{}
+				if repoTS > a.lastIndexTS {
+					a.lastIndexTS = repoTS
+				}
+				hasProducer := len(producers) > 0
+				hasConsumer := len(consumers) > 0
+				switch {
+				case hasProducer && hasConsumer:
+					a.healthSummary.Active++
+				case hasProducer && !hasConsumer:
+					a.orphanSubscribers++
+					a.healthSummary.OrphanSubscriber++
+				case !hasProducer && hasConsumer:
+					a.orphanPublishers++
+					a.healthSummary.OrphanPublisher++
+				default:
+					a.healthSummary.Orphan++
+				}
+
 				// NATS subjects (SCOPE.Queue with broker=nats) are surfaced in
 				// the dedicated nats_subjects bucket so the frontend can render
 				// them with the correct icon and filter logic. All other queues
@@ -288,6 +420,102 @@ func collectTopologyResponse(grp *DashGroup, groupName string, docgenState *mcp.
 				})
 			}
 		}
+	}
+
+	// --- Second pass: compute cross_repo_topic_count and build broker_groups ---
+	// A topic/queue is "cross-repo" if producers and consumers live in different
+	// repos. We detect this by re-scanning the CrossRepoLink list in grp.Links.
+	// Any cross-repo link whose channel/kind indicates a messaging edge is counted
+	// toward the broker that owns the entity on either side.
+	//
+	// Simpler approach: count broker_groups entries whose repoSlugs set has >1
+	// element — i.e., the same broker has entries from multiple repos.  We
+	// approximate cross-repo topic count as the number of topics/queues that
+	// appear in more than one repo under the same broker canonical, which maps
+	// cleanly to how the dashboard frontend will use this number.
+	//
+	// Exact cross-repo topic detection (per entry) happens by checking whether
+	// any CrossRepoLink references a topic entity that appears in the entry list.
+	// We build a quick lookup of cross-repo linked entity IDs.
+	crossRepoIDs := map[string]struct{}{}
+	for _, lnk := range grp.Links {
+		// Links with Kind PUBLISHES_TO / SUBSCRIBES_TO spanning repos are
+		// cross-repo messaging links.
+		k := strings.ToUpper(lnk.Kind)
+		if k == "PUBLISHES_TO" || k == "SUBSCRIBES_TO" || k == "STREAMS_TO" || k == "STREAMS_FROM" {
+			crossRepoIDs[lnk.Source] = struct{}{}
+			crossRepoIDs[lnk.Target] = struct{}{}
+		}
+	}
+	// Count cross-repo entries per broker from the already-built entry lists.
+	for _, entry := range resp.Topics {
+		id, _ := entry["id"].(string)
+		canonical, _ := entry["broker_canonical"].(string)
+		if canonical == "" {
+			continue
+		}
+		if _, isCross := crossRepoIDs[id]; isCross {
+			if a, ok := brokerAccums[canonical]; ok {
+				a.crossRepoTopicCount++
+			}
+		}
+	}
+	for _, entry := range resp.Queues {
+		id, _ := entry["id"].(string)
+		canonical, _ := entry["broker_canonical"].(string)
+		if canonical == "" {
+			continue
+		}
+		if _, isCross := crossRepoIDs[id]; isCross {
+			if a, ok := brokerAccums[canonical]; ok {
+				a.crossRepoTopicCount++
+			}
+		}
+	}
+	for _, entry := range resp.NatsSubjects {
+		id, _ := entry["id"].(string)
+		canonical, _ := entry["broker_canonical"].(string)
+		if canonical == "" {
+			continue
+		}
+		if _, isCross := crossRepoIDs[id]; isCross {
+			if a, ok := brokerAccums[canonical]; ok {
+				a.crossRepoTopicCount++
+			}
+		}
+	}
+
+	// Build sorted broker_groups slice (alphabetical by broker name).
+	brokerNames := make([]string, 0, len(brokerAccums))
+	for b := range brokerAccums {
+		brokerNames = append(brokerNames, b)
+	}
+	sort.Strings(brokerNames)
+
+	for _, bname := range brokerNames {
+		a := brokerAccums[bname]
+
+		// Build services slice sorted alphabetically.
+		svcNames := make([]string, 0, len(a.services))
+		for s := range a.services {
+			svcNames = append(svcNames, s)
+		}
+		sort.Strings(svcNames)
+		svcs := make([]brokerServiceStat, 0, len(svcNames))
+		for _, s := range svcNames {
+			svcs = append(svcs, brokerServiceStat{Name: s, TopicCount: a.services[s]})
+		}
+
+		resp.BrokerGroups = append(resp.BrokerGroups, brokerGroup{
+			Broker:              bname,
+			Count:               a.count,
+			Services:            svcs,
+			OrphanPublishers:    a.orphanPublishers,
+			OrphanSubscribers:   a.orphanSubscribers,
+			CrossRepoTopicCount: a.crossRepoTopicCount,
+			HealthSummary:       a.healthSummary,
+			LastIndexTimestamp:  a.lastIndexTS,
+		})
 	}
 
 	return resp
@@ -437,6 +665,62 @@ func inferBrokerFromName(name string) string {
 	default:
 		return ""
 	}
+}
+
+// brokerCanonical normalises a raw broker/framework string into one of the
+// recognised canonical values: rabbitmq, redis, sqs, pubsub, nats, celery,
+// dramatiq, or "unknown".
+func brokerCanonical(broker, framework string) string {
+	// Framework takes precedence for async-task entities (Celery, Dramatiq, …).
+	switch strings.ToLower(framework) {
+	case "celery", "celery_beat":
+		return "celery"
+	case "dramatiq":
+		return "dramatiq"
+	case "rq":
+		return "rq"
+	case "sidekiq":
+		return "sidekiq"
+	case "bullmq", "bull":
+		return "bullmq"
+	case "hangfire":
+		return "hangfire"
+	case "quartz", "quartz.net":
+		return "quartz"
+	}
+	switch strings.ToLower(broker) {
+	case "rabbitmq", "amqp":
+		return "rabbitmq"
+	case "redis":
+		return "redis"
+	case "sqs", "aws-sqs":
+		return "sqs"
+	case "pubsub", "gcp-pubsub", "google-pubsub":
+		return "pubsub"
+	case "nats":
+		return "nats"
+	case "celery":
+		return "celery"
+	case "dramatiq":
+		return "dramatiq"
+	case "kafka":
+		return "kafka"
+	case "":
+		return "unknown"
+	default:
+		return strings.ToLower(broker)
+	}
+}
+
+// owningService derives the logical service name for a topology entry.
+// Resolution order:
+//  1. entity Properties["service"]
+//  2. repo slug (the service boundary in a mono-repo group)
+func owningService(props map[string]string, repoSlug string) string {
+	if svc := props["service"]; svc != "" {
+		return svc
+	}
+	return repoSlug
 }
 
 // inferProviderFromID guesses the cloud provider from the entity ID prefix.

--- a/internal/dashboard/handlers_topology_test.go
+++ b/internal/dashboard/handlers_topology_test.go
@@ -2,6 +2,7 @@ package dashboard
 
 // handlers_topology_test.go — unit tests for the broadened collectTopology
 // function (#946: Redis pub/sub, Redis Streams, serverless, async tasks).
+// Extended in #1139: broker_canonical, owning_service, broker_groups.
 
 import (
 	"testing"
@@ -417,5 +418,243 @@ func TestCollectTopology_KafkaRegression(t *testing.T) {
 	}
 	if topics[0]["broker"] != "kafka" {
 		t.Errorf("broker = %v, want kafka", topics[0]["broker"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1139: broker_canonical helper
+// ---------------------------------------------------------------------------
+
+func TestBrokerCanonical(t *testing.T) {
+	cases := []struct {
+		broker    string
+		framework string
+		want      string
+	}{
+		{"rabbitmq", "", "rabbitmq"},
+		{"amqp", "", "rabbitmq"},
+		{"redis", "", "redis"},
+		{"sqs", "", "sqs"},
+		{"aws-sqs", "", "sqs"},
+		{"pubsub", "", "pubsub"},
+		{"gcp-pubsub", "", "pubsub"},
+		{"nats", "", "nats"},
+		{"kafka", "", "kafka"},
+		{"celery", "", "celery"},
+		{"dramatiq", "", "dramatiq"},
+		{"", "celery", "celery"},
+		{"", "celery_beat", "celery"},
+		{"", "dramatiq", "dramatiq"},
+		{"", "rq", "rq"},
+		{"", "sidekiq", "sidekiq"},
+		{"", "bullmq", "bullmq"},
+		{"", "bull", "bullmq"},
+		{"", "hangfire", "hangfire"},
+		{"", "quartz", "quartz"},
+		{"", "quartz.net", "quartz"},
+		{"", "", "unknown"},
+		{"custom-broker", "", "custom-broker"},
+	}
+	for _, tc := range cases {
+		got := brokerCanonical(tc.broker, tc.framework)
+		if got != tc.want {
+			t.Errorf("brokerCanonical(%q, %q) = %q, want %q", tc.broker, tc.framework, got, tc.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1139: owningService helper
+// ---------------------------------------------------------------------------
+
+func TestOwningService(t *testing.T) {
+	if got := owningService(map[string]string{"service": "orders-svc"}, "repo-a"); got != "orders-svc" {
+		t.Errorf("expected orders-svc, got %q", got)
+	}
+	if got := owningService(map[string]string{}, "repo-a"); got != "repo-a" {
+		t.Errorf("expected repo-a fallback, got %q", got)
+	}
+	if got := owningService(nil, "repo-b"); got != "repo-b" {
+		t.Errorf("expected repo-b fallback on nil props, got %q", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1139: broker_groups — 2 brokers, 5 topics each
+// ---------------------------------------------------------------------------
+
+func TestCollectTopologyResponse_BrokerGroups_TwoBrokers(t *testing.T) {
+	// Build a group with 2 repos, each contributing 5 topics under a different broker.
+	makeTopics := func(repo, broker string, n int) []graph.Entity {
+		ents := make([]graph.Entity, n)
+		for i := 0; i < n; i++ {
+			ents[i] = graph.Entity{
+				ID:         graph.EntityID(repo, "MessageTopic", string(rune('A'+i)), ""),
+				Name:       string(rune('A' + i)),
+				Kind:       "MessageTopic",
+				Properties: map[string]string{"broker": broker},
+			}
+		}
+		return ents
+	}
+	makeRels := func(entities []graph.Entity, producerID, consumerID string) []graph.Relationship {
+		var rels []graph.Relationship
+		for _, e := range entities {
+			rels = append(rels,
+				graph.Relationship{ID: "p-" + e.ID, FromID: producerID, ToID: e.ID, Kind: "PUBLISHES_TO"},
+				graph.Relationship{ID: "c-" + e.ID, FromID: e.ID, ToID: consumerID, Kind: "SUBSCRIBES_TO"},
+			)
+		}
+		return rels
+	}
+
+	rabbitTopics := makeTopics("svc-a", "rabbitmq", 5)
+	sqsTopics := makeTopics("svc-b", "sqs", 5)
+
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"svc-a": {Slug: "svc-a", Doc: &graph.Document{
+				Repo:     "svc-a",
+				Entities: rabbitTopics,
+				Relationships: makeRels(rabbitTopics, "svc-a::producer", "svc-a::consumer"),
+			}},
+			"svc-b": {Slug: "svc-b", Doc: &graph.Document{
+				Repo:     "svc-b",
+				Entities: sqsTopics,
+				Relationships: makeRels(sqsTopics, "svc-b::producer", "svc-b::consumer"),
+			}},
+		},
+	}
+
+	resp := collectTopologyResponse(grp, "", nil)
+
+	if len(resp.BrokerGroups) != 2 {
+		t.Fatalf("expected 2 broker_groups, got %d: %v", len(resp.BrokerGroups), resp.BrokerGroups)
+	}
+
+	// Groups are sorted alphabetically: rabbitmq < sqs.
+	bg0 := resp.BrokerGroups[0]
+	bg1 := resp.BrokerGroups[1]
+
+	if bg0.Broker != "rabbitmq" {
+		t.Errorf("broker_groups[0].broker = %q, want rabbitmq", bg0.Broker)
+	}
+	if bg0.Count != 5 {
+		t.Errorf("broker_groups[0].count = %d, want 5", bg0.Count)
+	}
+	if bg1.Broker != "sqs" {
+		t.Errorf("broker_groups[1].broker = %q, want sqs", bg1.Broker)
+	}
+	if bg1.Count != 5 {
+		t.Errorf("broker_groups[1].count = %d, want 5", bg1.Count)
+	}
+
+	// All topics have both producer and consumer → all active.
+	if bg0.HealthSummary.Active != 5 {
+		t.Errorf("rabbitmq health_summary.active = %d, want 5", bg0.HealthSummary.Active)
+	}
+	if bg0.OrphanPublishers != 0 || bg0.OrphanSubscribers != 0 {
+		t.Errorf("unexpected orphans in rabbitmq group")
+	}
+
+	// Per-entry broker_canonical and owning_service fields.
+	for _, entry := range resp.Topics {
+		if _, ok := entry["broker_canonical"]; !ok {
+			t.Errorf("topic entry missing broker_canonical field")
+		}
+		if _, ok := entry["owning_service"]; !ok {
+			t.Errorf("topic entry missing owning_service field")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1139: broker_groups — cross-repo topic via CrossRepoLink
+// ---------------------------------------------------------------------------
+
+func TestCollectTopologyResponse_BrokerGroups_CrossRepo(t *testing.T) {
+	topicID := graph.EntityID("svc-a", "MessageTopic", "OrderPlaced", "")
+	prefixedID := dashPrefixedID("svc-a", topicID)
+
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"svc-a": {Slug: "svc-a", Doc: &graph.Document{
+				Repo: "svc-a",
+				Entities: []graph.Entity{
+					{ID: topicID, Name: "OrderPlaced", Kind: "MessageTopic",
+						Properties: map[string]string{"broker": "rabbitmq"}},
+				},
+				Relationships: []graph.Relationship{
+					{ID: "p1", FromID: "svc-a::producer", ToID: topicID, Kind: "PUBLISHES_TO"},
+					{ID: "c1", FromID: topicID, ToID: "svc-b::consumer", Kind: "SUBSCRIBES_TO"},
+				},
+			}},
+		},
+		// Cross-repo link: svc-b consumer subscribes to svc-a topic.
+		Links: []CrossRepoLink{
+			{Source: prefixedID, Target: "svc-b::consumer", Kind: "SUBSCRIBES_TO"},
+		},
+	}
+
+	resp := collectTopologyResponse(grp, "", nil)
+
+	if len(resp.BrokerGroups) != 1 {
+		t.Fatalf("expected 1 broker_group, got %d", len(resp.BrokerGroups))
+	}
+	bg := resp.BrokerGroups[0]
+	if bg.Broker != "rabbitmq" {
+		t.Errorf("broker = %q, want rabbitmq", bg.Broker)
+	}
+	if bg.CrossRepoTopicCount != 1 {
+		t.Errorf("cross_repo_topic_count = %d, want 1", bg.CrossRepoTopicCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// #1139: broker_canonical = 'celery' for framework=celery entity
+// ---------------------------------------------------------------------------
+
+func TestCollectTopologyResponse_BrokerGroups_CeleryFramework(t *testing.T) {
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"worker": {Slug: "worker", Doc: &graph.Document{
+				Repo: "worker",
+				Entities: []graph.Entity{
+					{
+						ID:   "task:celery:send_invoice",
+						Name: "send_invoice",
+						Kind: "Task",
+						Properties: map[string]string{
+							"framework": "celery",
+						},
+					},
+				},
+			}},
+		},
+	}
+
+	resp := collectTopologyResponse(grp, "", nil)
+
+	// Task entities go into queues bucket.
+	if len(resp.Queues) != 1 {
+		t.Fatalf("expected 1 queue, got %d", len(resp.Queues))
+	}
+	entry := resp.Queues[0]
+	if entry["broker_canonical"] != "celery" {
+		t.Errorf("broker_canonical = %v, want celery", entry["broker_canonical"])
+	}
+	if entry["owning_service"] != "worker" {
+		t.Errorf("owning_service = %v, want worker (repo slug fallback)", entry["owning_service"])
+	}
+
+	if len(resp.BrokerGroups) != 1 {
+		t.Fatalf("expected 1 broker_group for celery, got %d", len(resp.BrokerGroups))
+	}
+	bg := resp.BrokerGroups[0]
+	if bg.Broker != "celery" {
+		t.Errorf("broker_groups[0].broker = %q, want celery", bg.Broker)
 	}
 }


### PR DESCRIPTION
## Summary

Extends `GET /api/topology/{group}` with broker and service grouping metadata so the frontend (#1142) can render broker/service section headers without a second round-trip.

**Per entry** (topics + queues):
- `broker_canonical` — normalised broker name (`rabbitmq`, `redis`, `sqs`, `pubsub`, `nats`, `celery`, `dramatiq`, `kafka`, …). Framework= takes precedence for async-task entities so Celery tasks surface as `"celery"` not the raw broker string.
- `owning_service` — `entity.Properties["service"]` when present; falls back to the repo slug as the monorepo service boundary.

**Top-level `broker_groups`** array (stable alphabetical sort by broker):
- `broker`, `count`, `services [{name, topic_count}]`
- `orphan_publishers`, `orphan_subscribers`
- `cross_repo_topic_count` — derived from `DashGroup.Links` cross-repo edges
- `health_summary {active, orphan_publisher, orphan_subscriber, orphan}`
- `last_index_timestamp` — ISO-8601 UTC from `Document.GeneratedAt`

## Closes / Refs

Closes #1139
Refs #1135

## Testing
- [x] All tests pass: `go test ./...`
- [x] `TestBrokerCanonical` — 23 cases covering all canonical mappings
- [x] `TestOwningService` — property override + repo-slug fallback + nil props
- [x] `TestCollectTopologyResponse_BrokerGroups_TwoBrokers` — 2 brokers × 5 topics; counts + health + field presence
- [x] `TestCollectTopologyResponse_BrokerGroups_CrossRepo` — cross-repo link → `cross_repo_topic_count = 1`
- [x] `TestCollectTopologyResponse_BrokerGroups_CeleryFramework` — `framework=celery` → `broker_canonical="celery"`
- [x] All pre-existing topology tests pass (collectTopology shim unchanged)

## Notes

- `brokerCanonical()` and `owningService()` are pure functions — easy to extend for new frameworks.
- Channels and functions are excluded from `broker_groups` (different classification axis); only topics, queues, and NATS subjects contribute.
- `broker_groups` is always a non-nil slice (`[]`) even when no broker entities exist, preserving the wire contract.
- Cross-repo topic detection reuses `DashGroup.Links` (already loaded from the cross-repo links JSON) — no extra disk reads.