### PR TITLE
feat(enrichment): #1131 add 0–100 confidence score to every Candidate

### DIFF
--- a/dashboard/src/routes/pending.tsx
+++ b/dashboard/src/routes/pending.tsx
@@ -60,6 +60,40 @@ function proposedValue(row: PendingCandidateRow): string | null {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// ScoreBadge — displays the 0–100 confidence score with criticality colouring
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ScoreBadgeProps {
+  score: number
+  band?: string
+  breakdown?: string
+}
+
+function ScoreBadge({ score, band, breakdown }: ScoreBadgeProps) {
+  const label = band
+    ? `${band.charAt(0).toUpperCase()}${band.slice(1)} ${score}`
+    : `${score}`
+
+  const colorClass =
+    band === 'critical'
+      ? 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700'
+      : band === 'high'
+        ? 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300 border-orange-200 dark:border-orange-700'
+        : band === 'medium'
+          ? 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 border-yellow-200 dark:border-yellow-700'
+          : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700'
+
+  return (
+    <span
+      className={`shrink-0 mt-0.5 inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-semibold border ${colorClass}`}
+      title={breakdown ?? `Score: ${score}`}
+    >
+      {label}
+    </span>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // CandidateRow component
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -125,12 +159,14 @@ function CandidateRow({ row, group, onApplied }: CandidateRowProps) {
         )}
       </div>
 
-      {/* Confidence */}
-      {row.confidence != null && row.confidence > 0 && (
+      {/* Score badge (issue #1131) — shown when a 0–100 score is present */}
+      {row.score != null && row.score > 0 ? (
+        <ScoreBadge score={row.score} band={row.criticality_band} breakdown={row.score_breakdown} />
+      ) : row.confidence != null && row.confidence > 0 ? (
         <span className="shrink-0 text-xs text-slate-400 dark:text-slate-500 tabular-nums mt-1">
           {(row.confidence * 100).toFixed(0)}%
         </span>
-      )}
+      ) : null}
 
       {/* Actions */}
       <div className="shrink-0 flex items-center gap-1.5 opacity-0 group-hover:opacity-100 transition-opacity focus-within:opacity-100">

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -560,6 +560,12 @@ export interface PendingCandidateRow {
   confidence?: number
   discovered_at?: string
   auto_resolvable?: boolean
+  /** 0–100 prioritisation score (issue #1131). Present on enrichment rows. */
+  score?: number
+  /** Human-readable modifier breakdown, e.g. "base:80 + god_node:20 = 100". */
+  score_breakdown?: string
+  /** "critical" | "high" | "medium" | "low" */
+  criticality_band?: string
 }
 
 export interface PendingRepairsResponse {

--- a/internal/dashboard/handlers_repairs.go
+++ b/internal/dashboard/handlers_repairs.go
@@ -29,15 +29,22 @@ var repairKinds = map[string]bool{
 // /api/enrichments. The richer Context map is forwarded as-is so the
 // dashboard can display subject / proposed-value without a second round-trip.
 type pendingCandidateRow struct {
-	CandidateID    string         `json:"candidate_id"`
-	Repo           string         `json:"repo"`
-	Kind           string         `json:"kind"`
-	SubjectID      string         `json:"subject_id"`
-	Context        map[string]any `json:"context,omitempty"`
-	Hint           string         `json:"hint,omitempty"`
-	Confidence     float64        `json:"confidence,omitempty"`
-	DiscoveredAt   string         `json:"discovered_at,omitempty"`
-	AutoResolvable bool           `json:"auto_resolvable"`
+	CandidateID     string         `json:"candidate_id"`
+	Repo            string         `json:"repo"`
+	Kind            string         `json:"kind"`
+	SubjectID       string         `json:"subject_id"`
+	Context         map[string]any `json:"context,omitempty"`
+	Hint            string         `json:"hint,omitempty"`
+	Confidence      float64        `json:"confidence,omitempty"`
+	DiscoveredAt    string         `json:"discovered_at,omitempty"`
+	AutoResolvable  bool           `json:"auto_resolvable"`
+	// Score is the 0–100 prioritisation score (issue #1131). Present on
+	// enrichment candidates; absent (0) on repair candidates.
+	Score           int    `json:"score,omitempty"`
+	// ScoreBreakdown lists the modifiers that produced Score.
+	ScoreBreakdown  string `json:"score_breakdown,omitempty"`
+	// CriticalityBand is "critical" / "high" / "medium" / "low".
+	CriticalityBand string `json:"criticality_band,omitempty"`
 }
 
 // handleRepairs — GET /api/repairs/{group}
@@ -124,15 +131,26 @@ func (s *Server) handleEnrichments(w http.ResponseWriter, r *http.Request) {
 				continue // repair tab handles these
 			}
 			items = append(items, pendingCandidateRow{
-				CandidateID:  c.ID,
-				Repo:         slug,
-				Kind:         c.Kind,
-				SubjectID:    c.SubjectID,
-				Context:      c.Context,
-				Hint:         c.Hint,
-				Confidence:   c.Confidence,
-				DiscoveredAt: c.DiscoveredAt,
+				CandidateID:     c.ID,
+				Repo:            slug,
+				Kind:            c.Kind,
+				SubjectID:       c.SubjectID,
+				Context:         c.Context,
+				Hint:            c.Hint,
+				Confidence:      c.Confidence,
+				DiscoveredAt:    c.DiscoveredAt,
+				Score:           c.Score,
+				ScoreBreakdown:  c.ScoreBreakdown,
+				CriticalityBand: c.CriticalityBand,
 			})
+		}
+	}
+
+	// Sort by Score DESC (high-priority first), then SubjectID for stable tiebreak.
+	for i := 1; i < len(items); i++ {
+		for j := i; j > 0 && (items[j].Score > items[j-1].Score ||
+			(items[j].Score == items[j-1].Score && items[j].SubjectID < items[j-1].SubjectID)); j-- {
+			items[j], items[j-1] = items[j-1], items[j]
 		}
 	}
 
@@ -146,13 +164,16 @@ func (s *Server) handleEnrichments(w http.ResponseWriter, r *http.Request) {
 // We parse the Context map so the REST layer can forward it without importing
 // internal/enrichment.
 type candidateRaw struct {
-	ID           string         `json:"id"`
-	Kind         string         `json:"kind"`
-	SubjectID    string         `json:"subject_id"`
-	Context      map[string]any `json:"context,omitempty"`
-	Hint         string         `json:"hint,omitempty"`
-	Confidence   float64        `json:"confidence,omitempty"`
-	DiscoveredAt string         `json:"discovered_at,omitempty"`
+	ID              string         `json:"id"`
+	Kind            string         `json:"kind"`
+	SubjectID       string         `json:"subject_id"`
+	Context         map[string]any `json:"context,omitempty"`
+	Hint            string         `json:"hint,omitempty"`
+	Confidence      float64        `json:"confidence,omitempty"`
+	DiscoveredAt    string         `json:"discovered_at,omitempty"`
+	Score           int            `json:"score,omitempty"`
+	ScoreBreakdown  string         `json:"score_breakdown,omitempty"`
+	CriticalityBand string         `json:"criticality_band,omitempty"`
 }
 
 // readAllCandidates reads every entry from a repo's enrichment-candidates.json.
@@ -223,12 +244,14 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 
 		// Group candidates by SubjectID.
 		type actionEntry struct {
-			candidateID  string
-			kind         string
-			score        float64
-			reason       string
-			discoveredAt string
-			completed    bool
+			candidateID     string
+			kind            string
+			score           float64
+			intScore        int
+			criticalityBand string
+			reason          string
+			discoveredAt    string
+			completed       bool
 		}
 		type subjectEntry struct {
 			subjectKind string
@@ -259,18 +282,21 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 			se.actions = append(se.actions, actionEntry{
-				candidateID:  c.ID,
-				kind:         c.Kind,
-				score:        c.Confidence,
-				reason:       c.Hint,
-				discoveredAt: c.DiscoveredAt,
-				completed:    completed,
+				candidateID:     c.ID,
+				kind:            c.Kind,
+				score:           c.Confidence,
+				intScore:        c.Score,
+				criticalityBand: c.CriticalityBand,
+				reason:          c.Hint,
+				discoveredAt:    c.DiscoveredAt,
+				completed:       completed,
 			})
 		}
 
 		for _, sid := range subjectOrder {
 			se := subjects[sid]
 			var overallScore, maxScore float64
+			var maxIntScore int
 			var oldestPending string
 			pendingCount := 0
 
@@ -278,6 +304,9 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 			for _, a := range se.actions {
 				if a.score > maxScore {
 					maxScore = a.score
+				}
+				if a.intScore > maxIntScore {
+					maxIntScore = a.intScore
 				}
 				if !a.completed {
 					pendingCount++
@@ -289,11 +318,13 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 					}
 				}
 				actions = append(actions, enrichmentActionWire{
-					Kind:        a.kind,
-					CandidateID: a.candidateID,
-					Score:       a.score,
-					Reason:      a.reason,
-					Completed:   a.completed,
+					Kind:            a.kind,
+					CandidateID:     a.candidateID,
+					Score:           a.score,
+					IntScore:        a.intScore,
+					CriticalityBand: a.criticalityBand,
+					Reason:          a.reason,
+					Completed:       a.completed,
 				})
 			}
 
@@ -307,17 +338,32 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 			}
 			totalActions += pendingCount
 
+			// Derive criticality band from the max integer score.
+			var taskBand string
+			switch {
+			case maxIntScore >= 80:
+				taskBand = "critical"
+			case maxIntScore >= 60:
+				taskBand = "high"
+			case maxIntScore >= 40:
+				taskBand = "medium"
+			default:
+				taskBand = "low"
+			}
+
 			allTasks = append(allTasks, enrichmentTaskRow{
-				SubjectID:      sid,
-				SubjectKind:    se.subjectKind,
-				SubjectName:    se.subjectName,
-				Repo:           slug,
-				PendingActions: actions,
-				PendingCount:   pendingCount,
-				OverallScore:   overallScore,
-				MaxActionScore: maxScore,
-				Overdue:        overdue,
-				DiscoveredAt:   oldestPending,
+				SubjectID:       sid,
+				SubjectKind:     se.subjectKind,
+				SubjectName:     se.subjectName,
+				Repo:            slug,
+				PendingActions:  actions,
+				PendingCount:    pendingCount,
+				OverallScore:    overallScore,
+				MaxActionScore:  maxScore,
+				IntScore:        maxIntScore,
+				CriticalityBand: taskBand,
+				Overdue:         overdue,
+				DiscoveredAt:    oldestPending,
 			})
 		}
 	}
@@ -339,25 +385,32 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 
 // enrichmentActionWire is the JSON-wire shape for one action inside a task row.
 type enrichmentActionWire struct {
-	Kind        string  `json:"kind"`
-	CandidateID string  `json:"candidate_id"`
-	Score       float64 `json:"score,omitempty"`
-	Reason      string  `json:"reason,omitempty"`
-	Completed   bool    `json:"completed"`
+	Kind            string  `json:"kind"`
+	CandidateID     string  `json:"candidate_id"`
+	Score           float64 `json:"score,omitempty"`
+	// IntScore is the 0–100 integer score from issue #1131.
+	IntScore        int     `json:"int_score,omitempty"`
+	CriticalityBand string  `json:"criticality_band,omitempty"`
+	Reason          string  `json:"reason,omitempty"`
+	Completed       bool    `json:"completed"`
 }
 
 // enrichmentTaskRow is the JSON-wire shape for one task row.
 type enrichmentTaskRow struct {
-	SubjectID      string                 `json:"subject_id"`
-	SubjectKind    string                 `json:"subject_kind,omitempty"`
-	SubjectName    string                 `json:"subject_name,omitempty"`
-	Repo           string                 `json:"repo"`
-	PendingActions []enrichmentActionWire `json:"pending_actions"`
-	PendingCount   int                    `json:"pending_count"`
-	OverallScore   float64                `json:"overall_score"`
-	MaxActionScore float64                `json:"max_action_score,omitempty"`
-	Overdue        bool                   `json:"overdue"`
-	DiscoveredAt   string                 `json:"discovered_at,omitempty"`
+	SubjectID       string                 `json:"subject_id"`
+	SubjectKind     string                 `json:"subject_kind,omitempty"`
+	SubjectName     string                 `json:"subject_name,omitempty"`
+	Repo            string                 `json:"repo"`
+	PendingActions  []enrichmentActionWire `json:"pending_actions"`
+	PendingCount    int                    `json:"pending_count"`
+	OverallScore    float64                `json:"overall_score"`
+	MaxActionScore  float64                `json:"max_action_score,omitempty"`
+	// IntScore is the maximum integer 0–100 score across pending actions (issue #1131).
+	IntScore        int     `json:"int_score,omitempty"`
+	// CriticalityBand is derived from IntScore: critical/high/medium/low.
+	CriticalityBand string  `json:"criticality_band,omitempty"`
+	Overdue         bool    `json:"overdue"`
+	DiscoveredAt    string  `json:"discovered_at,omitempty"`
 }
 
 // buildResolvedSet reads enrichment-resolutions.json for a repo and returns a
@@ -401,6 +454,11 @@ func sortEnrichmentTasks(tasks []enrichmentTaskRow) {
 }
 
 func enrichmentTaskLess(a, b enrichmentTaskRow) bool {
+	// Primary: integer 0–100 score DESC (issue #1131) — prefers the new field
+	// when both tasks have been scored. Falls back to the legacy float score.
+	if a.IntScore != b.IntScore {
+		return a.IntScore > b.IntScore
+	}
 	if a.OverallScore != b.OverallScore {
 		return a.OverallScore > b.OverallScore
 	}

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -21,6 +21,8 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
+	"strings"
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -65,6 +67,173 @@ type Candidate struct {
 	ConfidenceFloor      float64        `json:"confidence_floor,omitempty"`
 	DiscoveredAt         string         `json:"discovered_at,omitempty"`
 	QualificationSignals []string       `json:"qualification_signals,omitempty"`
+	// Score is the 0–100 prioritisation score for this candidate, computed at
+	// emit time by ComputeScore. Higher scores indicate higher enrichment value
+	// (UX-critical: used to sort the dashboard pending queue and determine the
+	// criticality band displayed to the user).
+	Score          int    `json:"score,omitempty"`
+	// ScoreBreakdown is a human-readable string listing every modifier that
+	// fired, e.g. "base:40 + ambiguous_name:+15 + articulation:+15 = 70".
+	// Provided for debugging and agent reasoning.
+	ScoreBreakdown string `json:"score_breakdown,omitempty"`
+	// CriticalityBand is the tier derived from Score:
+	//   critical (>=80) / high (60–79) / medium (40–59) / low (<40)
+	CriticalityBand string `json:"criticality_band,omitempty"`
+}
+
+// kindBaseScore returns the base score for an entity kind.
+// Values calibrated against the enrichment research from issue #1162.
+func kindBaseScore(kind string) (int, string) {
+	switch kind {
+	// Public API surface — always highest priority.
+	case "http_endpoint", "HTTPEndpoint", "SCOPE.HTTPEndpoint", "Route", "SCOPE.Route":
+		return 80, "base_http_endpoint:80"
+	// Named architectural roles.
+	case "Service", "SCOPE.Service", "Controller", "SCOPE.Controller",
+		"View", "SCOPE.View":
+		return 65, "base_service_controller:65"
+	case "Schema", "Model":
+		return 60, "base_schema_model:60"
+	case "DataAccess", "SCOPE.DataAccess":
+		return 55, "base_data_access:55"
+	// Background task / process kinds.
+	case "Task", "SCOPE.ScheduledJob", "Process":
+		return 45, "base_process:45"
+	// Generic operations.
+	case "Operation", "SCOPE.Operation":
+		return 40, "base_operation:40"
+	// Components.
+	case "Component", "SCOPE.Component":
+		return 35, "base_component:35"
+	default:
+		return 35, "base_default:35"
+	}
+}
+
+// ambiguousNames is the set of very common verb names that indicate an entity
+// whose role is unclear from the name alone (+15 modifier).
+var ambiguousNames = map[string]bool{
+	"process": true, "handle": true, "run": true, "make": true,
+	"do": true, "main": true, "init": true, "setup": true,
+	"update": true, "execute": true,
+}
+
+// criticalityBand returns the criticality tier name for a 0–100 score.
+func criticalityBand(score int) string {
+	switch {
+	case score >= 80:
+		return "critical"
+	case score >= 60:
+		return "high"
+	case score >= 40:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+// ComputeScore calculates the 0–100 confidence score for a candidate, together
+// with a human-readable breakdown and a criticality band. The entity e must be
+// the same entity whose ID is c.SubjectID; passing nil produces a safe zero.
+//
+// Scoring formula (from issue #1131 spec):
+//
+//	Base by kind:
+//	  http_endpoint / Route              → 80
+//	  Service / Controller / View / Route → 65
+//	  Schema / Model                     → 60
+//	  DataAccess                         → 55
+//	  Process / Task / ScheduledJob      → 45
+//	  Operation                          → 40
+//	  Component                          → 35 (default)
+//
+//	Positive modifiers:
+//	  +20  is_god_node
+//	  +15  is_articulation_point
+//	  +10  pagerank >= 0.01
+//	  +15  name in {process, handle, run, make, do, main, init, setup, update, execute}
+//
+//	Negative modifiers:
+//	  -15  len(name) <= 4
+//	  -10  source_file empty
+//	  -20  all-lowercase-underscore name with len < 10 (private helper heuristic)
+//
+// The result is clamped to [0, 100].
+func ComputeScore(e *graph.Entity) (score int, breakdown string, band string) {
+	if e == nil {
+		return 0, "nil_entity", "low"
+	}
+
+	base, baseLabel := kindBaseScore(e.Kind)
+	total := base
+	parts := []string{baseLabel}
+
+	// +20 god node.
+	if e.IsGodNode {
+		total += 20
+		parts = append(parts, "+god_node:20")
+	}
+	// +15 articulation point.
+	if e.IsArticulationPt {
+		total += 15
+		parts = append(parts, "+articulation:15")
+	}
+	// +10 high pagerank.
+	if e.PageRank != nil && *e.PageRank >= 0.01 {
+		total += 10
+		parts = append(parts, "+pagerank:10")
+	}
+	// +15 genuinely ambiguous name (common verb with no domain context).
+	nameLower := strings.ToLower(e.Name)
+	if ambiguousNames[nameLower] {
+		total += 15
+		parts = append(parts, "+ambiguous_name:15")
+	}
+
+	// -15 very short name (≤4 chars, hard to describe meaningfully).
+	if len(e.Name) <= 4 {
+		total -= 15
+		parts = append(parts, "-short_name:15")
+	}
+	// -10 no source file (synthetic / cross-repo placeholder).
+	if e.SourceFile == "" {
+		total -= 10
+		parts = append(parts, "-no_source_file:10")
+	}
+	// -20 private helper heuristic: all-lowercase with underscore prefix or
+	// pure snake_case name shorter than 10 chars.
+	if len(e.Name) < 10 && isPrivateHelper(e.Name) {
+		total -= 20
+		parts = append(parts, "-private_helper:20")
+	}
+
+	// Clamp.
+	if total > 100 {
+		total = 100
+	}
+	if total < 0 {
+		total = 0
+	}
+
+	bd := strings.Join(parts, " ") + " = " + strconv.Itoa(total)
+	return total, bd, criticalityBand(total)
+}
+
+// isPrivateHelper returns true for names that follow lowercase-underscore
+// conventions typical of private helper functions (e.g. "__helper", "_run",
+// "do_it", "run_fn").
+func isPrivateHelper(name string) bool {
+	if len(name) == 0 {
+		return false
+	}
+	// Must start with underscore or be all lowercase with underscores/digits only.
+	for _, ch := range name {
+		if ch >= 'A' && ch <= 'Z' {
+			return false // has uppercase → not private helper
+		}
+	}
+	// Require underscore to indicate snake_case or dunder naming.
+	return strings.ContainsRune(name, '_')
 }
 
 // Resolution is one row in <repo>/.archigraph/enrichment-resolutions.json.
@@ -340,6 +509,7 @@ func (describeEntityEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 	if !ok {
 		return nil
 	}
+	sc, bd, band := ComputeScore(e)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindDescribeEntity),
 		Kind:      KindDescribeEntity,
@@ -355,6 +525,9 @@ func (describeEntityEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 		ConfidenceFloor:      0.6,
 		DiscoveredAt:         nowRFC3339(),
 		QualificationSignals: sigs,
+		Score:                sc,
+		ScoreBreakdown:       bd,
+		CriticalityBand:      band,
 	}}
 }
 
@@ -389,6 +562,7 @@ func (classifyDomainEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 	if len(sigs) == 0 {
 		return nil
 	}
+	sc, bd, band := ComputeScore(e)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindClassifyDomain),
 		Kind:      KindClassifyDomain,
@@ -402,6 +576,9 @@ func (classifyDomainEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 		ConfidenceFloor:      0.5,
 		DiscoveredAt:         nowRFC3339(),
 		QualificationSignals: sigs,
+		Score:                sc,
+		ScoreBreakdown:       bd,
+		CriticalityBand:      band,
 	}}
 }
 
@@ -436,6 +613,7 @@ func (describeRoleEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candida
 	if e.IsArticulationPt {
 		sigs = append(sigs, "articulation_point")
 	}
+	sc, bd, band := ComputeScore(e)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindDescribeRole),
 		Kind:      KindDescribeRole,
@@ -450,6 +628,9 @@ func (describeRoleEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candida
 		ConfidenceFloor:      0.5,
 		DiscoveredAt:         nowRFC3339(),
 		QualificationSignals: sigs,
+		Score:                sc,
+		ScoreBreakdown:       bd,
+		CriticalityBand:      band,
 	}}
 }
 

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -729,3 +729,149 @@ func TestUniqueSubjectCount(t *testing.T) {
 		t.Errorf("UniqueSubjectCount = %d, want 2", n)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for issue #1131: 0–100 confidence score on every Candidate
+// ---------------------------------------------------------------------------
+
+// TestComputeScore_GodHTTPEndpoint — a god-node HTTP endpoint is the highest
+// possible signal: base 80 + god_node 20 = 100 (clamped).
+func TestComputeScore_GodHTTPEndpoint(t *testing.T) {
+	e := &graph.Entity{
+		ID:        "e1",
+		Name:      "http:POST:/api/orders",
+		Kind:      "http_endpoint",
+		IsGodNode: true,
+		SourceFile: "handlers/orders.go",
+	}
+	score, breakdown, band := ComputeScore(e)
+	if score != 100 {
+		t.Errorf("god HTTP endpoint score = %d, want 100 (breakdown: %s)", score, breakdown)
+	}
+	if band != "critical" {
+		t.Errorf("band = %q, want critical", band)
+	}
+}
+
+// TestComputeScore_PrivateHelper — a short snake_case name with no source file
+// should land in the low band.
+func TestComputeScore_PrivateHelper(t *testing.T) {
+	pr := 0.001 // low pagerank
+	e := &graph.Entity{
+		ID:       "e2",
+		Name:     "__helper",
+		Kind:     "SCOPE.Operation",
+		PageRank: &pr,
+		// SourceFile intentionally empty → -10
+		// __helper: isPrivateHelper → -20, len=8 > 4 so no -15 short name
+	}
+	score, breakdown, band := ComputeScore(e)
+	// base_operation:40 - private_helper:20 - no_source_file:10 = 10
+	if score > 20 {
+		t.Errorf("private helper score = %d, want ≤20 (breakdown: %s)", score, breakdown)
+	}
+	if band == "critical" || band == "high" {
+		t.Errorf("private helper band = %q, want medium or low", band)
+	}
+}
+
+// TestComputeScore_AmbiguousNameOperation — an ambiguous-name operation with an
+// articulation point signal.
+func TestComputeScore_AmbiguousNameOperation(t *testing.T) {
+	e := &graph.Entity{
+		ID:               "e3",
+		Name:             "process",
+		Kind:             "SCOPE.Operation",
+		IsArticulationPt: true,
+		SourceFile:       "core/handler.py",
+	}
+	score, _, _ := ComputeScore(e)
+	// base_operation:40 + articulation:15 + ambiguous_name:15 = 70
+	if score != 70 {
+		t.Errorf("ambiguous-name articulation-point score = %d, want 70", score)
+	}
+}
+
+// TestComputeScore_CriticalityBands — verify the four bands map correctly.
+func TestComputeScore_CriticalityBands(t *testing.T) {
+	cases := []struct {
+		score int
+		band  string
+	}{
+		{100, "critical"},
+		{80, "critical"},
+		{79, "high"},
+		{60, "high"},
+		{59, "medium"},
+		{40, "medium"},
+		{39, "low"},
+		{0, "low"},
+	}
+	for _, tc := range cases {
+		got := criticalityBand(tc.score)
+		if got != tc.band {
+			t.Errorf("criticalityBand(%d) = %q, want %q", tc.score, got, tc.band)
+		}
+	}
+}
+
+// TestComputeScore_ScoreOnEmittedCandidate — verify that Score, ScoreBreakdown,
+// and CriticalityBand are populated on candidates emitted by the built-in
+// emitters (end-to-end check).
+func TestComputeScore_ScoreOnEmittedCandidate(t *testing.T) {
+	pr := 0.05 // high pagerank → +10
+	doc := mkDoc(graph.Entity{
+		ID:         "e1",
+		Name:       "http:GET:/api/users",
+		Kind:       "http_endpoint",
+		PageRank:   &pr,
+		SourceFile: "handlers.go",
+	})
+	cands := CollectCandidates(doc, []CandidateEmitter{describeEntityEmitter{}}, nil)
+	if len(cands) != 1 {
+		t.Fatalf("expected 1 candidate, got %d", len(cands))
+	}
+	c := cands[0]
+	if c.Score == 0 {
+		t.Errorf("Score = 0, want > 0 (breakdown: %s)", c.ScoreBreakdown)
+	}
+	if c.ScoreBreakdown == "" {
+		t.Errorf("ScoreBreakdown is empty")
+	}
+	if c.CriticalityBand == "" {
+		t.Errorf("CriticalityBand is empty")
+	}
+	// http_endpoint base=80 + high_pagerank=10 = 90 → critical.
+	if c.Score != 90 {
+		t.Errorf("http_endpoint + high_pagerank score = %d, want 90 (breakdown: %s)", c.Score, c.ScoreBreakdown)
+	}
+	if c.CriticalityBand != "critical" {
+		t.Errorf("band = %q, want critical", c.CriticalityBand)
+	}
+}
+
+// TestComputeScore_ScoreClampZero — modifiers cannot push below 0.
+func TestComputeScore_ScoreClampZero(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "e4",
+		Name: "_x",
+		Kind: "SCOPE.Component",
+		// len 2 → -15, no source file → -10, isPrivateHelper("_x")==true → -20
+		// base 35 - 15 - 10 - 20 = -10 → clamped to 0
+	}
+	score, _, _ := ComputeScore(e)
+	if score < 0 {
+		t.Errorf("score below zero: %d", score)
+	}
+}
+
+// TestComputeScore_NilEntity — nil entity must return (0, ..., "low") safely.
+func TestComputeScore_NilEntity(t *testing.T) {
+	score, _, band := ComputeScore(nil)
+	if score != 0 {
+		t.Errorf("nil entity score = %d, want 0", score)
+	}
+	if band != "low" {
+		t.Errorf("nil entity band = %q, want low", band)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `Score int` (0–100), `ScoreBreakdown string`, and `CriticalityBand string` to `Candidate` in `internal/enrichment/candidates.go`, computed at emit time by a new `ComputeScore(e *graph.Entity)` function
- Dashboard pending queue (`/api/enrichments/{group}`) now sorts by Score DESC; `/api/enrichments/{group}/tasks` uses IntScore as the primary sort key
- Frontend `CandidateRow` displays a colour-coded `ScoreBadge` ("Critical 85", "High 62", etc.) replacing the raw confidence % when a score is present

## Score formula

Base by kind: http_endpoint → 80, Service/Controller/View → 65, Schema/Model → 60, DataAccess → 55, Process/Task → 45, Operation → 40, Component → 35.
Modifiers: +20 god_node, +15 articulation_pt, +10 pagerank≥0.01, +15 ambiguous name; −15 short name (≤4), −10 no source file, −20 private helper.
Capped [0,100]. Bands: critical ≥80, high 60–79, medium 40–59, low <40.

## Files changed

- `internal/enrichment/candidates.go` — `Candidate` struct extended; `ComputeScore`, `kindBaseScore`, `criticalityBand`, `isPrivateHelper` added; all 3 built-in emitters call `ComputeScore` at emit time
- `internal/dashboard/handlers_repairs.go` — wire types extended; sort-by-score in `handleEnrichments`; IntScore-first sort in `handleEnrichmentTasks`
- `dashboard/src/types/api.ts` — `PendingCandidateRow` gains `score`, `score_breakdown`, `criticality_band`
- `dashboard/src/routes/pending.tsx` — new `ScoreBadge` component; renders colour-coded badge when score > 0
- `internal/enrichment/candidates_test.go` — 7 new tests

## Test plan

- [x] `go test ./internal/enrichment/... -run TestComputeScore` — 7 tests, all green
- [x] `go test ./internal/dashboard/...` — all green
- [x] `go build ./internal/enrichment/ ./internal/dashboard/` — clean compile
- [ ] Manual: index a repo, open dashboard /pending/{group}, confirm colour-coded score badges sorted DESC
- [ ] Boundary: god HTTP endpoint → 100 (critical); private `__helper` → ≤20 (low)

Closes #1131
Parent epic: #1129

🤖 Generated with [Claude Code](https://claude.com/claude-code)