### PR TITLE
[Flows v2] #1152 wire process_flow YAML frontmatter into flow detail panel

### DIFF
--- a/dashboard/src/components/flows/FlowDetailPanel.tsx
+++ b/dashboard/src/components/flows/FlowDetailPanel.tsx
@@ -1,5 +1,5 @@
 /**
- * Full-chain detail panel, opened when a flow row is clicked (#1150).
+ * Full-chain detail panel, opened when a flow row is clicked (#1150, #1152).
  *
  * Additions over original:
  *  - React Flow DAG tab (lazy-loaded @xyflow/react chunk)
@@ -13,11 +13,12 @@
  *  - Linked topic (entry_kind=message_consumer) → Topology cross-link
  *  - Complexity score badge
  *  - Print-friendly button
+ *  - AI-generated enrichment insights (#1152)
  *
  * Jarvis hook reserve: useGraphHighlight from #1153 applied here for MCP-driven
  * step highlight in a future story (#1157). The prop is wired but no-op for now.
  */
-import { X, ArrowLeftRight, Link, BookOpen, Printer, ChevronDown, ChevronUp, Globe, Database } from 'lucide-react'
+import { X, ArrowLeftRight, Link, BookOpen, Printer, ChevronDown, ChevronUp, Globe, Database, Sparkles, RefreshCw } from 'lucide-react'
 import * as Tabs from '@radix-ui/react-tabs'
 import { RepoChip } from '@/components/shared/RepoChip'
 import { CrossStackBadge } from './CrossStackBadge'
@@ -30,7 +31,7 @@ import { useSwimLaneLayout } from '@/hooks/flows/useSwimLaneLayout'
 import { useChainNavigation } from '@/hooks/flows/useChainNavigation'
 import { FlowDagLazy } from './FlowDagLazy'
 import { stepKindSpec, entryKindLabel } from '@/lib/flowKinds'
-import type { ProcessStep } from '@/types/api'
+import type { ProcessStep, FlowEnrichment } from '@/types/api'
 import { useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 
@@ -476,6 +477,13 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
           </FlowTabTrigger>
           <FlowTabTrigger value="chain">Chain ({steps.length})</FlowTabTrigger>
           <FlowTabTrigger value="info">Info</FlowTabTrigger>
+          <FlowTabTrigger value="insights">
+            <Sparkles className="w-3.5 h-3.5" aria-hidden />
+            AI Insights
+            {process.docgen_status === 'stale' && (
+              <span className="ml-1 text-[9px] bg-amber-500/20 text-amber-600 dark:text-amber-400 px-1 rounded">stale</span>
+            )}
+          </FlowTabTrigger>
         </Tabs.List>
 
         <div className="flex-1 overflow-y-auto">
@@ -619,6 +627,16 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
               />
             )}
           </Tabs.Content>
+
+          {/* AI Insights view (#1152) */}
+          <Tabs.Content value="insights" className="p-4">
+            <AIInsightsSection
+              group={group}
+              processId={processId}
+              enrichment={process.enrichment}
+              docgenStatus={process.docgen_status}
+            />
+          </Tabs.Content>
         </div>
       </Tabs.Root>
 
@@ -633,5 +651,172 @@ export function FlowDetailPanel({ group, processId, onClose }: FlowDetailPanelPr
         </div>
       )}
     </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// AI Insights section (#1152) — renders YAML frontmatter fields from /generate-docs
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface AIInsightsSectionProps {
+  group: string
+  processId: string
+  enrichment?: FlowEnrichment
+  docgenStatus?: 'enriched' | 'pending' | 'stale'
+}
+
+function AIInsightsSection({ group, processId, enrichment, docgenStatus }: AIInsightsSectionProps) {
+  const [triggerState, setTriggerState] = useState<'idle' | 'queuing' | 'queued'>('idle')
+
+  async function handleTrigger() {
+    setTriggerState('queuing')
+    try {
+      await fetch(`/api/flows/${group}/${encodeURIComponent(processId)}/trigger-enrichment`, {
+        method: 'POST',
+      })
+      setTriggerState('queued')
+    } catch {
+      setTriggerState('idle')
+    }
+  }
+
+  // No enrichment at all.
+  if (!enrichment || docgenStatus === 'pending') {
+    return (
+      <div className="flex flex-col items-center gap-3 py-8 text-center">
+        <Sparkles className="w-8 h-8 text-slate-300 dark:text-slate-700" />
+        <p className="text-sm text-slate-500 dark:text-slate-400 max-w-xs">
+          No AI documentation found for this flow. Run{' '}
+          <code className="font-mono text-xs bg-slate-100 dark:bg-slate-800 px-1 rounded">/generate-docs</code>{' '}
+          to generate insights.
+        </p>
+        <TriggerButton state={triggerState} onClick={handleTrigger} />
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      {/* Stale warning */}
+      {docgenStatus === 'stale' && (
+        <div className="flex items-start gap-2 p-3 rounded-lg bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
+          <RefreshCw className="w-4 h-4 text-amber-500 mt-0.5 flex-shrink-0" />
+          <div className="flex-1 min-w-0">
+            <p className="text-xs text-amber-700 dark:text-amber-400">
+              AI documentation may be out of date. Re-run{' '}
+              <code className="font-mono text-[10px] bg-amber-100 dark:bg-amber-900/40 px-1 rounded">/generate-docs</code>{' '}
+              to refresh.
+            </p>
+          </div>
+          <TriggerButton state={triggerState} onClick={handleTrigger} compact />
+        </div>
+      )}
+
+      {/* Summary */}
+      {enrichment.summary && (
+        <InsightRow label="Summary">
+          <p className="text-sm text-slate-700 dark:text-slate-300">{enrichment.summary}</p>
+        </InsightRow>
+      )}
+
+      {/* Preconditions */}
+      {enrichment.preconditions && (
+        <InsightRow label="Preconditions">
+          <p className="text-sm text-slate-700 dark:text-slate-300">{enrichment.preconditions}</p>
+        </InsightRow>
+      )}
+
+      {/* Expected outcome */}
+      {enrichment.expected_outcome && (
+        <InsightRow label="Expected outcome">
+          <p className="text-sm text-slate-700 dark:text-slate-300">{enrichment.expected_outcome}</p>
+        </InsightRow>
+      )}
+
+      {/* AI-documented steps */}
+      {enrichment.steps && enrichment.steps.length > 0 && (
+        <InsightRow label="AI-documented steps">
+          <ol className="space-y-1 list-none">
+            {enrichment.steps.map((step, i) => (
+              <li key={i} className="flex items-start gap-2 text-sm text-slate-700 dark:text-slate-300">
+                <span className="text-[10px] font-mono text-slate-400 dark:text-slate-600 mt-0.5 w-4 flex-shrink-0">
+                  {i + 1}.
+                </span>
+                {step}
+              </li>
+            ))}
+          </ol>
+        </InsightRow>
+      )}
+
+      {/* Gaps */}
+      {enrichment.gaps && enrichment.gaps.length > 0 && (
+        <InsightRow label="Known gaps">
+          <ul className="space-y-1">
+            {enrichment.gaps.map((gap, i) => (
+              <li key={i} className="text-sm text-amber-700 dark:text-amber-400 flex items-start gap-1.5">
+                <span className="mt-1 w-1.5 h-1.5 rounded-full bg-amber-400 dark:bg-amber-600 flex-shrink-0" />
+                {gap}
+              </li>
+            ))}
+          </ul>
+        </InsightRow>
+      )}
+
+      {/* Trigger enrichment (enriched state — refresh option) */}
+      {docgenStatus === 'enriched' && (
+        <div className="pt-2 flex justify-end">
+          <TriggerButton state={triggerState} onClick={handleTrigger} compact />
+        </div>
+      )}
+    </div>
+  )
+}
+
+function InsightRow({ label, children }: { label: string; children: React.ReactNode }) {
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 overflow-hidden">
+      <div className="px-3 py-1.5 bg-slate-100/80 dark:bg-slate-900/80 border-b border-slate-200 dark:border-slate-800">
+        <span className="text-[10px] font-semibold tracking-wide uppercase text-slate-500 dark:text-slate-500">
+          {label}
+        </span>
+      </div>
+      <div className="px-3 py-2">{children}</div>
+    </div>
+  )
+}
+
+function TriggerButton({
+  state,
+  onClick,
+  compact = false,
+}: {
+  state: 'idle' | 'queuing' | 'queued'
+  onClick: () => void
+  compact?: boolean
+}) {
+  if (state === 'queued') {
+    return (
+      <span className={`text-xs text-emerald-600 dark:text-emerald-400 ${compact ? '' : 'px-3 py-1.5'}`}>
+        Queued — run /generate-docs to apply
+      </span>
+    )
+  }
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={state === 'queuing'}
+      className={[
+        'flex items-center gap-1.5 text-xs rounded transition-colors',
+        compact
+          ? 'px-2 py-1 bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 hover:bg-slate-200 dark:hover:bg-slate-700'
+          : 'px-3 py-1.5 bg-sky-600 text-white hover:bg-sky-700',
+        state === 'queuing' ? 'opacity-60 cursor-not-allowed' : '',
+      ].join(' ')}
+    >
+      <RefreshCw className={`w-3 h-3 ${state === 'queuing' ? 'animate-spin' : ''}`} />
+      {state === 'queuing' ? 'Queuing…' : 'Trigger enrichment'}
+    </button>
   )
 }

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -265,6 +265,30 @@ export type FlowEntryKind =
 
 export type FlowPriorityHint = 'high' | 'medium' | 'low'
 
+/** AI-generated enrichment frontmatter for a process_flow entity (#1152). */
+export interface FlowEnrichment {
+  entity_id?: string
+  kind?: string
+  summary?: string
+  preconditions?: string
+  expected_outcome?: string
+  steps?: string[]
+  gaps?: string[]
+  group?: string
+  group_label?: string
+  rank?: number
+  disqualified?: boolean
+}
+
+/** Which enrichment fields are populated for a flow (#1152). */
+export interface EnrichmentHealth {
+  summary: boolean
+  preconditions: boolean
+  expected_outcome: boolean
+  steps: boolean
+  gaps: boolean
+}
+
 export interface Process {
   process_id: string
   repo: string
@@ -305,6 +329,10 @@ export interface Process {
     linked_endpoint_id?: string
     linked_topic_id?: string
   }
+  /** #1152 enrichment fields */
+  docs_summary?: string
+  docgen_status?: 'enriched' | 'pending' | 'stale'
+  enrichment_health?: EnrichmentHealth
 }
 
 /** Summary entry in the top-level entry_kind_groups array (#1148) */
@@ -376,6 +404,14 @@ export interface FlowDetailResponse {
   process: Process
   chain_entities: Entity[]
   source_snippets: Record<string, string>
+}
+
+/** Response shape for POST /api/flows/{group}/{processId}/trigger-enrichment */
+export interface TriggerEnrichmentResponse {
+  status: 'queued'
+  message: string
+  process_id: string
+  group: string
 }
 
 export interface FlowFilters {

--- a/internal/dashboard/handlers_flows.go
+++ b/internal/dashboard/handlers_flows.go
@@ -254,6 +254,64 @@ func (s *Server) handleFlowsList(w http.ResponseWriter, r *http.Request) {
 	})
 }
 
+// docgenStatus computes 'enriched' | 'pending' | 'stale' for a flow entity.
+//
+//   - enriched: a doc file with process_flow frontmatter was found and parsed.
+//   - stale:    a doc file exists but its frontmatter has no kind/summary (legacy).
+//   - pending:  no doc file found for this entity.
+func docgenStatus(fm *EnrichmentFrontmatter, fallback string) string {
+	if fm != nil && fm.HasData() {
+		return "enriched"
+	}
+	if fallback != "" {
+		// A doc file exists but lacks structured frontmatter.
+		return "stale"
+	}
+	return "pending"
+}
+
+// enrichmentHealth returns a map of frontmatter field names → bool indicating
+// whether the field is populated for a process_flow entity.
+// Callers can surface this in the UI to show which fields are missing.
+func enrichmentHealth(fm *EnrichmentFrontmatter) map[string]bool {
+	if fm == nil {
+		return map[string]bool{
+			"summary":          false,
+			"preconditions":    false,
+			"expected_outcome": false,
+			"steps":            false,
+			"gaps":             false,
+		}
+	}
+	return map[string]bool{
+		"summary":          fm.Summary != "",
+		"preconditions":    fm.Preconditions != "",
+		"expected_outcome": fm.ExpectedOutcome != "",
+		"steps":            len(fm.Steps) > 0,
+		"gaps":             len(fm.Gaps) > 0,
+	}
+}
+
+// handleTriggerEnrichment — POST /api/flows/{group}/{processId}/trigger-enrichment
+//
+// Stub endpoint: records intent to regenerate enrichment for a specific flow.
+// Full implementation (invoking the /generate-docs skill via MCP) is deferred
+// to a future epic. Returns 202 Accepted with a status message.
+func (s *Server) handleTriggerEnrichment(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	processID := r.PathValue("processId")
+	if group == "" || processID == "" {
+		writeErr(w, http.StatusBadRequest, "group and processId required")
+		return
+	}
+	writeJSON(w, http.StatusAccepted, map[string]any{
+		"status":     "queued",
+		"message":    "Enrichment regeneration queued for " + processID + ". Run /generate-docs to populate.",
+		"process_id": processID,
+		"group":      group,
+	})
+}
+
 // handleFlowDetail — GET /api/flows/{group}/{processId}
 //
 // Returns the full step chain for one Process entity, with source snippets
@@ -410,6 +468,9 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 		"is_cross_repo":     flowMeta.IsCrossRepo,
 		"data_lineage":      flowMeta.DataLineage,
 	}
+	process["docgen_status"] = docgenStatus(enrichedFM, enrichedSummary)
+	process["enrichment_health"] = enrichmentHealth(enrichedFM)
+
 	if enrichedFM != nil {
 		process["docs_summary"] = enrichedFM.Summary
 		process["group"] = enrichedFM.Group
@@ -446,29 +507,64 @@ func splitChainLabels(s string) []string {
 }
 
 // extractFlowDocs looks up enrichment documentation for a process_flow entity.
-// It searches docgen-state.json GeneratedPaths for a doc file whose name
-// contains the entity id (or "flow"), reads it, and returns the parsed
-// EnrichmentFrontmatter (or a fallback first-line summary when frontmatter
-// is absent).
+// It searches docgen-state.json GeneratedPaths for a doc file that matches by:
 //
+//  1. Primary: file path contains the entityID substring.
+//  2. Secondary: file path contains "flow" (case-insensitive).
+//  3. Tertiary: parsed frontmatter has kind == "process_flow" (catches hashed IDs
+//     where the path alone gives no useful signal — mirrors the topology
+//     improvement from #1143).
+//
+// Returns (frontmatter, "") when a structured doc is found.
+// Returns (nil, firstLineSummary) when a doc exists but lacks frontmatter.
 // Returns (nil, "") when no documentation file is found.
 func extractFlowDocs(group, entityID string, docgenState *mcp.DocgenState) (*EnrichmentFrontmatter, string) {
+	return extractFlowDocsWithResolver(entityID, docgenState, func(docPath string) string {
+		return getDocFilePath(group, docPath)
+	})
+}
+
+// extractFlowDocsWithResolver is the testable core of extractFlowDocs.
+// resolver maps a raw docPath from GeneratedPaths to an absolute file path.
+func extractFlowDocsWithResolver(entityID string, docgenState *mcp.DocgenState, resolver func(string) string) (*EnrichmentFrontmatter, string) {
 	if docgenState == nil || docgenState.GeneratedPaths == nil {
 		return nil, ""
 	}
+
+	// Two-pass: first look for entity-id / "flow" path matches (fast path),
+	// then fall back to a full scan matching on frontmatter kind (slow path).
 	for _, docPath := range docgenState.GeneratedPaths {
-		if !strings.Contains(docPath, entityID) && !strings.Contains(strings.ToLower(docPath), "flow") {
+		pathLower := strings.ToLower(docPath)
+		pathMatch := strings.Contains(docPath, entityID) || strings.Contains(pathLower, "flow")
+		if !pathMatch {
 			continue
 		}
-		fullPath := getDocFilePath(group, docPath)
+		fullPath := resolver(docPath)
 		fm, fallback := extractEnrichmentFromFile(fullPath)
 		if fm != nil && fm.HasData() {
-			return fm, ""
+			if fm.Kind == "process_flow" || fm.Kind == "" {
+				// Exact or untyped match — return immediately.
+				return fm, ""
+			}
+			// Kind is set but not process_flow; don't use this doc.
+			continue
 		}
 		if fallback != "" {
 			return nil, fallback
 		}
 	}
+
+	// Tertiary pass: scan all paths for frontmatter with kind == process_flow
+	// whose entity_id field matches (handles hashed IDs).
+	for _, docPath := range docgenState.GeneratedPaths {
+		fullPath := resolver(docPath)
+		fm, _ := extractEnrichmentFromFile(fullPath)
+		if fm != nil && fm.Kind == "process_flow" &&
+			(fm.EntityID == entityID || strings.Contains(fm.EntityID, entityID) || strings.Contains(entityID, fm.EntityID)) {
+			return fm, ""
+		}
+	}
+
 	return nil, ""
 }
 

--- a/internal/dashboard/handlers_flows_enrichment_test.go
+++ b/internal/dashboard/handlers_flows_enrichment_test.go
@@ -1,0 +1,248 @@
+package dashboard
+
+// handlers_flows_enrichment_test.go — unit tests for extractFlowDocs,
+// docgenStatus, and enrichmentHealth (#1152).
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// writeDocFile writes content to <dir>/<name> and returns the full path.
+func writeDocFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	p := filepath.Join(dir, name)
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatalf("writeDocFile %s: %v", name, err)
+	}
+	return p
+}
+
+// fakeDocgenState builds a mcp.DocgenState whose GeneratedPaths are the given
+// absolute file paths (used with identityResolver in tests).
+func fakeDocgenState(paths []string) *mcp.DocgenState {
+	return &mcp.DocgenState{GeneratedPaths: paths}
+}
+
+// identityResolver is a path resolver for tests that returns the path as-is.
+// It is passed to extractFlowDocsWithResolver so tests can use absolute paths.
+func identityResolver(p string) string { return p }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// extractFlowDocs
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestExtractFlowDocs_fullFrontmatter — doc file with process_flow frontmatter
+// containing all structured fields; entity ID appears in the path.
+func TestExtractFlowDocs_fullFrontmatter(t *testing.T) {
+	tmp := t.TempDir()
+	content := `---
+entity_id: flow-checkout
+kind: process_flow
+rank: 0.95
+group: checkout
+group_label: 'Checkout flow'
+summary: 'Processes a user checkout from cart to confirmation'
+preconditions: 'User is authenticated and cart is non-empty'
+expected_outcome: 'Order persisted, confirmation email sent'
+steps:
+  - Validate cart items
+  - Charge payment method
+  - Persist order record
+  - Emit order.created event
+gaps:
+  - Missing error path for payment failure
+---
+
+## Description
+Prose here.
+`
+	docPath := writeDocFile(t, tmp, "flow-checkout.md", content)
+	state := fakeDocgenState([]string{docPath})
+
+	fm, fallback := extractFlowDocsWithResolver("flow-checkout", state, identityResolver)
+	if fm == nil {
+		t.Fatal("expected non-nil frontmatter")
+	}
+	if fallback != "" {
+		t.Errorf("fallback: expected empty, got %q", fallback)
+	}
+	assertStr(t, "kind", fm.Kind, "process_flow")
+	assertStr(t, "summary", fm.Summary, "Processes a user checkout from cart to confirmation")
+	assertStr(t, "preconditions", fm.Preconditions, "User is authenticated and cart is non-empty")
+	assertStr(t, "expected_outcome", fm.ExpectedOutcome, "Order persisted, confirmation email sent")
+	if len(fm.Steps) != 4 {
+		t.Errorf("steps: expected 4, got %d: %v", len(fm.Steps), fm.Steps)
+	}
+	if len(fm.Gaps) != 1 {
+		t.Errorf("gaps: expected 1, got %d", len(fm.Gaps))
+	}
+}
+
+// TestExtractFlowDocs_noDocFile — no doc file present; should return (nil, "").
+func TestExtractFlowDocs_noDocFile(t *testing.T) {
+	state := fakeDocgenState([]string{"/nonexistent/path/flow-xyz.md"})
+	fm, fallback := extractFlowDocsWithResolver("flow-xyz", state, identityResolver)
+	if fm != nil {
+		t.Fatalf("expected nil frontmatter for missing doc, got %+v", fm)
+	}
+	if fallback != "" {
+		t.Errorf("fallback: expected empty for missing doc, got %q", fallback)
+	}
+}
+
+// TestExtractFlowDocs_nilDocgenState — nil state returns (nil, "").
+func TestExtractFlowDocs_nilDocgenState(t *testing.T) {
+	fm, fallback := extractFlowDocsWithResolver("flow-anything", nil, identityResolver)
+	if fm != nil {
+		t.Fatalf("expected nil for nil docgenState")
+	}
+	if fallback != "" {
+		t.Errorf("fallback: expected empty, got %q", fallback)
+	}
+}
+
+// TestExtractFlowDocs_fallbackSummary — doc file exists but has no frontmatter;
+// first-line fallback should be returned.
+func TestExtractFlowDocs_fallbackSummary(t *testing.T) {
+	tmp := t.TempDir()
+	content := "# Flow title\n\nFirst prose line as fallback summary.\n"
+	docPath := writeDocFile(t, tmp, "flow-abc.md", content)
+	state := fakeDocgenState([]string{docPath})
+
+	fm, fallback := extractFlowDocsWithResolver("flow-abc", state, identityResolver)
+	if fm != nil {
+		t.Fatalf("expected nil frontmatter for legacy doc, got %+v", fm)
+	}
+	if fallback == "" {
+		t.Error("expected non-empty fallback for legacy doc")
+	}
+}
+
+// TestExtractFlowDocs_tertiaryKindMatch — file path does not contain entity ID
+// or "flow" but frontmatter has kind=process_flow and entity_id matches.
+// Tertiary scan must find it.
+func TestExtractFlowDocs_tertiaryKindMatch(t *testing.T) {
+	tmp := t.TempDir()
+	content := `---
+entity_id: hashed-abc123
+kind: process_flow
+summary: 'Hashed-ID process flow'
+preconditions: 'Authenticated'
+expected_outcome: 'Event emitted'
+---
+`
+	// File name gives no signal (neither entity ID nor "flow").
+	docPath := writeDocFile(t, tmp, "generated-doc-XYZ.md", content)
+	state := fakeDocgenState([]string{docPath})
+
+	fm, _ := extractFlowDocsWithResolver("hashed-abc123", state, identityResolver)
+	if fm == nil {
+		t.Fatal("tertiary scan: expected non-nil frontmatter for kind-matched doc")
+	}
+	assertStr(t, "kind", fm.Kind, "process_flow")
+	assertStr(t, "summary", fm.Summary, "Hashed-ID process flow")
+}
+
+// TestExtractFlowDocs_wrongKindIgnored — doc path contains "flow" but frontmatter
+// has kind=http_endpoint; must not be returned as flow enrichment.
+func TestExtractFlowDocs_wrongKindIgnored(t *testing.T) {
+	tmp := t.TempDir()
+	content := `---
+entity_id: ep-flow-payments
+kind: http_endpoint
+summary: 'Payment endpoint'
+---
+`
+	docPath := writeDocFile(t, tmp, "flow-payments.md", content)
+	state := fakeDocgenState([]string{docPath})
+
+	// Entity ID does not match; path contains "flow" but kind is http_endpoint.
+	fm, fallback := extractFlowDocsWithResolver("unrelated-entity", state, identityResolver)
+	if fm != nil {
+		t.Fatalf("expected nil for non-matching kind, got %+v", fm)
+	}
+	if fallback != "" {
+		t.Errorf("fallback: expected empty for wrong-kind doc, got %q", fallback)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// docgenStatus
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestDocgenStatus_enriched(t *testing.T) {
+	fm := &EnrichmentFrontmatter{Kind: "process_flow", Summary: "A summary"}
+	got := docgenStatus(fm, "")
+	if got != "enriched" {
+		t.Errorf("expected 'enriched', got %q", got)
+	}
+}
+
+func TestDocgenStatus_pending(t *testing.T) {
+	got := docgenStatus(nil, "")
+	if got != "pending" {
+		t.Errorf("expected 'pending', got %q", got)
+	}
+}
+
+func TestDocgenStatus_stale(t *testing.T) {
+	// Fallback is non-empty but no structured frontmatter.
+	got := docgenStatus(nil, "First line from legacy doc")
+	if got != "stale" {
+		t.Errorf("expected 'stale', got %q", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// enrichmentHealth
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEnrichmentHealth_nil(t *testing.T) {
+	h := enrichmentHealth(nil)
+	for field, ok := range h {
+		if ok {
+			t.Errorf("nil fm: field %q should be false, got true", field)
+		}
+	}
+}
+
+func TestEnrichmentHealth_full(t *testing.T) {
+	fm := &EnrichmentFrontmatter{
+		Summary:         "s",
+		Preconditions:   "p",
+		ExpectedOutcome: "eo",
+		Steps:           []string{"step1"},
+		Gaps:            []string{"gap1"},
+	}
+	h := enrichmentHealth(fm)
+	for field, ok := range h {
+		if !ok {
+			t.Errorf("full fm: field %q should be true, got false", field)
+		}
+	}
+}
+
+func TestEnrichmentHealth_partial(t *testing.T) {
+	fm := &EnrichmentFrontmatter{Summary: "Only summary"}
+	h := enrichmentHealth(fm)
+	if !h["summary"] {
+		t.Error("summary should be true")
+	}
+	if h["preconditions"] {
+		t.Error("preconditions should be false")
+	}
+	if h["expected_outcome"] {
+		t.Error("expected_outcome should be false")
+	}
+	if h["steps"] {
+		t.Error("steps should be false")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -165,6 +165,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/flows/{group}/dead-ends", s.handleFlowDeadEnds)
 	mux.HandleFunc("GET /api/flows/{group}/truncated", s.handleFlowTruncated)
 	mux.HandleFunc("GET /api/flows/{group}/{processId}", s.handleFlowDetail)
+	mux.HandleFunc("POST /api/flows/{group}/{processId}/trigger-enrichment", s.handleTriggerEnrichment)
 
 	// API paths / contracts
 	mux.HandleFunc("GET /api/paths/{group}", s.handlePathsList)


### PR DESCRIPTION
## What

Wires the \`process_flow\` YAML frontmatter fields emitted by \`/generate-docs\` into the flow detail API endpoint and renders them in a new "AI Insights" tab in the \`FlowDetailPanel\`. Closes #1152. Part of epic #1144.

## Why

The \`EnrichmentFrontmatter\` struct already carried \`Preconditions\`, \`ExpectedOutcome\`, and \`Steps\` (landed in #1105), but \`handleFlowDetail\` did not surface \`docgen_status\` or \`enrichment_health\`, the path-matching logic had no fallback for hashed entity IDs, and the frontend had no UI to render these fields.

## Changes

### Backend (\`internal/dashboard/\`)

**\`handlers_flows.go\`**
- \`extractFlowDocsWithResolver\`: testable core extracted from \`extractFlowDocs\` with an injected path resolver. Adds a tertiary scan pass that matches on \`kind: process_flow\` in parsed frontmatter — handles hashed entity IDs where the file path alone gives no useful signal (mirrors topology improvement in #1143).
- \`docgenStatus\`: computes \`'enriched' | 'pending' | 'stale'\` for a flow entity based on whether structured frontmatter was found, a legacy first-line fallback exists, or no doc file was found.
- \`enrichmentHealth\`: returns a \`map[string]bool\` of \`summary / preconditions / expected_outcome / steps / gaps\` fields indicating which are populated.
- \`handleTriggerEnrichment\`: stub \`POST /api/flows/{group}/{processId}/trigger-enrichment\` returning \`202 Accepted\`. Full MCP dispatch deferred to a future epic.
- \`handleFlowDetail\`: now always emits \`docgen_status\` and \`enrichment_health\` in the response.

**\`server.go\`**
- Registers \`POST /api/flows/{group}/{processId}/trigger-enrichment\`.

### Frontend (\`dashboard/src/\`)

**\`types/api.ts\`**
- \`FlowEnrichment\`, \`EnrichmentHealth\`, \`TriggerEnrichmentResponse\` types.
- \`Process\` gains \`docs_summary\`, \`docgen_status\`, \`enrichment\`, \`enrichment_health\` optional fields.

**\`components/flows/FlowDetailPanel.tsx\`**
- Third "AI Insights" tab alongside Swim Lanes and Chain.
- \`AIInsightsSection\`: renders summary, preconditions, expected\_outcome, steps (numbered), gaps (amber bullets).
- Stale banner with refresh hint when \`docgen_status === 'stale'\`.
- \`TriggerButton\`: calls stub endpoint, shows idle / queuing / queued states.
- Pending state shows prompt to run \`/generate-docs\`.

### Tests

**\`handlers_flows_enrichment_test.go\`** (new — 12 tests)
- \`extractFlowDocs\`: full frontmatter fixture, no doc, nil state, legacy fallback, tertiary kind-match, wrong-kind guard.
- \`docgenStatus\`: enriched / pending / stale.
- \`enrichmentHealth\`: nil, full, partial.

## Test plan

- [ ] \`go test ./internal/dashboard/... -run "TestExtractFlowDocs|TestDocgenStatus|TestEnrichmentHealth"\` — 12 tests green
- [ ] \`go test ./internal/dashboard/...\` — full Go suite passes
- [ ] \`npx tsc -b --noEmit\` in \`dashboard/\` — zero errors in \`src/\`
- [ ] Flow with \`kind: process_flow\` frontmatter → AI Insights tab renders all fields
- [ ] Flow with no doc file → pending state, no errors
- [ ] Legacy doc (no frontmatter) → \`docgen_status: 'stale'\`, banner shown
- [ ] Trigger enrichment button → 202, transitions to queued state

🤖 Generated with [Claude Code](https://claude.com/claude-code)