### PR TITLE
feat(progress): #1119 instrument indexer pipeline to emit per-phase progress events

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -29,6 +30,7 @@ import (
 	pyextr "github.com/cajasmota/archigraph/internal/extractors/python"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+	"github.com/cajasmota/archigraph/internal/progress"
 	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/treesitter"
 	"github.com/cajasmota/archigraph/internal/types"
@@ -110,6 +112,14 @@ type Indexer struct {
 	// list; merged into the hard-coded skip list at walk-time.
 	additionalSkipDirs []string
 
+	// publisher receives structured progress events at every pipeline phase
+	// boundary and at every TickEveryNFiles interval during AST extraction.
+	// Defaults to progress.NoOpPublisher so callers that do not wire a sink
+	// pay zero overhead.
+	publisher  progress.Publisher
+	groupSlug  string // forwarded to every Event.GroupSlug
+	repoSlug   string // forwarded to every Event.RepoSlug; defaults to repoTag
+
 	// Statistics — populated as passes run, surfaced in the final summary.
 	stats indexerStats
 
@@ -179,6 +189,24 @@ func WithPrintSkipped(enabled bool) IndexOption {
 // with per-group names from fleet.json's additional_skip_dirs field.
 func WithAdditionalSkipDirs(dirs []string) IndexOption {
 	return func(i *Indexer) { i.additionalSkipDirs = dirs }
+}
+
+// WithPublisher wires a progress.Publisher into the indexer. The publisher
+// receives one Event per pipeline phase boundary, per N=TickEveryNFiles
+// files during AST extraction, and per algorithm entry/exit. Defaults to
+// progress.NoOpPublisher when not set.
+func WithPublisher(pub progress.Publisher) IndexOption {
+	return func(i *Indexer) { i.publisher = pub }
+}
+
+// WithProgressSlugs sets the group and repo slug forwarded on every progress
+// event. Call this alongside WithPublisher when the indexer is running inside
+// a daemon rebuild (where the group and slug are known).
+func WithProgressSlugs(groupSlug, repoSlug string) IndexOption {
+	return func(i *Indexer) {
+		i.groupSlug = groupSlug
+		i.repoSlug = repoSlug
+	}
 }
 
 type indexerStats struct {
@@ -415,17 +443,39 @@ func emitJSONStats(w io.Writer, idx *Indexer, doc *graph.Document) error {
 func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, error) {
 	start := time.Now()
 
+	// Resolve the publisher. Default to NoOp so callers without a sink pay
+	// zero overhead (a nil check on every Publish call is more expensive than
+	// a virtual dispatch to an empty method).
+	pub := i.publisher
+	if pub == nil {
+		pub = progress.NoOpPublisher{}
+	}
+	repoSlug := i.repoSlug
+	if repoSlug == "" {
+		repoSlug = i.repoTag
+	}
+	trk := progress.NewTracker(pub, i.groupSlug, repoSlug)
+
 	walkOpts := &walk.Options{
 		AdditionalSkipDirs: i.additionalSkipDirs,
 	}
 	if i.printSkipped {
 		walkOpts.PrintSkipped = os.Stderr
 	}
+
+	// Emit a scanning phase event before the walk so the UI shows activity
+	// immediately. A second event follows once the walk completes with the
+	// real file count.
+	trk.PhaseStart(progress.PhaseScan, 0, 0)
 	files, _, err := walk.WalkRepo(absRepo, walkOpts)
 	if err != nil {
+		trk.Fail(err.Error())
 		return nil, fmt.Errorf("walk repo: %w", err)
 	}
 	i.stats.files = len(files)
+	trk.SetFilesTotal(len(files))
+	// Emit a second scan event now that we know the total.
+	trk.Tick(progress.PhaseScan, len(files), 0, "", 0)
 	fmt.Fprintf(os.Stderr, "archigraph: discovered %d candidate files in %s\n", len(files), absRepo)
 
 	var (
@@ -443,6 +493,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// fork-execs `archigraph extract` per language-bucketed batch and
 	// returns the merged record set (Pass 1 + 2.5 + 3 combined); the
 	// daemon then runs everything from buildDocument onward unchanged.
+	trk.PhaseStart(progress.PhaseExtractAST, 0, 0)
 	if subprocExtract() {
 		res, cerr := extract.Coordinate(ctx, absRepo, files, extract.CoordinatorConfig{
 			Concurrency: subprocConcurrency(),
@@ -451,6 +502,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			Stderr:      os.Stderr,
 		})
 		if cerr != nil {
+			trk.Fail(cerr.Error())
 			return nil, fmt.Errorf("subprocess extract: %w", cerr)
 		}
 		// The coordinator merges Pass 1 / 2.5 / 3 entity records into a
@@ -480,17 +532,22 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		for _, e := range res.NonFatalErrors {
 			fmt.Fprintf(os.Stderr, "archigraph: subproc-extract warning: %s\n", e)
 		}
+		// Emit a single done-with-extraction event covering all files.
+		trk.Tick(progress.PhaseExtractAST, len(files), 0, "", len(res.Entities))
 	} else {
-		// Pass 1 — per-language AST extraction.
-		pass1Records, classified, err = i.runPass1Extract(ctx, absRepo, files)
+		// Pass 1 — per-language AST extraction (instrumented with per-file ticks).
+		pass1Records, classified, err = i.runPass1ExtractWithProgress(ctx, absRepo, files, trk)
 		if err != nil {
+			trk.Fail(err.Error())
 			return nil, fmt.Errorf("pass 1: %w", err)
 		}
 		i.stats.pass1Rels = countEmbeddedRels(pass1Records)
 
 		// Pass 2.5 — YAML-driven framework rules.
+		trk.PhaseStart(progress.PhaseResolveRefs, len(files), len(pass1Records))
 		pass2Records, pass2Rels, err = i.runPass25FrameworkRules(ctx, absRepo, classified)
 		if err != nil {
+			trk.Fail(err.Error())
 			return nil, fmt.Errorf("pass 2.5: %w", err)
 		}
 		i.stats.pass2Rels = len(pass2Rels) + countEmbeddedRels(pass2Records)
@@ -498,6 +555,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// Pass 3 — cross-language extractors.
 		pass3Records, err = i.runPass3CrossLang(ctx, absRepo, classified)
 		if err != nil {
+			trk.Fail(err.Error())
 			return nil, fmt.Errorf("pass 3: %w", err)
 		}
 		i.stats.pass3Rels = countEmbeddedRels(pass3Records)
@@ -636,6 +694,7 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	runtime.GC()
 
 	// Pass 5 — build document (deduped).
+	trk.PhaseStart(progress.PhaseMaterialize, len(files), 0)
 	doc := i.buildDocument(pass1Records, pass2Records, pass2Rels, pass3Records)
 	// Drop the per-pass record slices now that buildDocument has produced
 	// the merged + deduped graph.Entity / graph.Relationship slices. These
@@ -791,7 +850,8 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			}
 			return ra.Kind < rb.Kind
 		})
-		i.runPass4Algorithms(doc)
+		trk.PhaseStart(progress.PhaseAlgorithms, len(files), doc.Stats.Entities)
+		i.runPass4AlgorithmsWithProgress(doc, trk)
 	}
 
 	// Pass 7 — process-flow BFS (#724). Runs AFTER all CALLS edges are
@@ -822,6 +882,9 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	// Properties BEFORE candidate emission, so previously agent-resolved
 	// values are preserved AND emitters skip already-described entities.
 	i.runPass6EmitEnrichmentCandidates(doc, absRepo)
+
+	// Emit the final done event before the summary log line.
+	trk.Done(len(files), doc.Stats.Entities)
 
 	dur := time.Since(start)
 	fmt.Fprintf(os.Stderr,
@@ -1228,7 +1291,22 @@ func printRelBreakdown(w *os.File, counts map[string]int, label string) {
 // are appended to the Document and copied into the graph-stats.json sidecar
 // at write time.
 func (i *Indexer) runPass4Algorithms(doc *graph.Document) {
+	i.runPass4AlgorithmsWithProgress(doc, nil)
+}
+
+// runPass4AlgorithmsWithProgress is the instrumented variant of runPass4Algorithms.
+// trk may be nil (treated as no-op). Emits an AlgorithmEvent at the entry and
+// exit of each named algorithm.
+func (i *Indexer) runPass4AlgorithmsWithProgress(doc *graph.Document, trk *progress.Tracker) {
+	entityCount := doc.Stats.Entities
+
+	if trk != nil {
+		trk.AlgorithmEvent("Louvain+PageRank+Betweenness", entityCount)
+	}
 	res := graph.RunAlgorithms(doc.Entities, doc.Relationships)
+	if trk != nil {
+		trk.AlgorithmEvent("ArticulationPoints+SurpriseEdges", entityCount)
+	}
 
 	for k := range doc.Entities {
 		e := &doc.Entities[k]
@@ -1366,11 +1444,18 @@ func (i *Indexer) runPass6EmitEnrichmentCandidates(doc *graph.Document, absRepo 
 // slice is also returned for reuse by Pass 2.5 and Pass 3 so we don't pay the
 // classification + read + parse cost twice.
 func (i *Indexer) runPass1Extract(ctx context.Context, absRepo string, files []string) ([]types.EntityRecord, []classifiedFile, error) {
+	return i.runPass1ExtractWithProgress(ctx, absRepo, files, nil)
+}
+
+// runPass1ExtractWithProgress is the instrumented variant of runPass1Extract.
+// trk may be nil; when non-nil it receives a Tick every progress.TickEveryNFiles
+// files processed, with the current repo-relative file path and byte count.
+func (i *Indexer) runPass1ExtractWithProgress(ctx context.Context, absRepo string, files []string, trk *progress.Tracker) ([]types.EntityRecord, []classifiedFile, error) {
 	if i.skipPasses[PassExtract] {
 		// Even when Pass 1 is skipped we still need to classify+read so
 		// downstream passes have file content. Run the worker loop in
 		// classification-only mode.
-		classified, _ := i.classifyAndRead(ctx, absRepo, files, false)
+		classified, _ := i.classifyAndReadWithProgress(ctx, absRepo, files, false, trk)
 		return nil, classified, nil
 	}
 
@@ -1391,15 +1476,22 @@ func (i *Indexer) runPass1Extract(ctx context.Context, absRepo string, files []s
 		}
 	}
 
-	classified, records := i.classifyAndRead(ctx, absRepo, files, true)
+	classified, records := i.classifyAndReadWithProgress(ctx, absRepo, files, true, trk)
 	return records, classified, nil
 }
 
-// classifyAndRead is the shared worker pool used by Pass 1. When runExtract
-// is true it also dispatches to per-language extractors and accumulates
-// EntityRecords. The classifiedFile slice is always populated for files that
-// survived classification, so other passes can reuse the parse tree + bytes.
-func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []string, runExtract bool) ([]classifiedFile, []types.EntityRecord) {
+// classifyAndReadWithProgress is like classifyAndRead but also publishes
+// per-file progress ticks via trk (which may be nil for no-op behaviour).
+// A tick is published every progress.TickEveryNFiles files to bound the
+// event rate on large repos.
+func (i *Indexer) classifyAndReadWithProgress(ctx context.Context, absRepo string, files []string, runExtract bool, trk *progress.Tracker) ([]classifiedFile, []types.EntityRecord) {
+	// Use a shared atomic counter so all workers contribute to the same
+	// tick cadence without needing an additional mutex acquisition per file.
+	var (
+		fileCounter int64 // total files processed (classified + skipped + failed)
+		byteCounter int64 // cumulative bytes read
+	)
+
 	tasks := make(chan fileTask, len(files))
 	for _, rel := range files {
 		tasks <- fileTask{relPath: rel, absPath: filepath.Join(absRepo, rel)}
@@ -1411,6 +1503,13 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 		allRecords []types.EntityRecord
 		classified []classifiedFile
 	)
+
+	publishTick := func(filesDone int, bytesSeen int64, currentFile string) {
+		if trk == nil {
+			return
+		}
+		trk.Tick(progress.PhaseExtractAST, filesDone, bytesSeen, currentFile, 0)
+	}
 
 	var wg sync.WaitGroup
 	for w := 0; w < i.workers; w++ {
@@ -1427,6 +1526,10 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 					mu.Lock()
 					i.stats.skipped++
 					mu.Unlock()
+					n := int(atomic.AddInt64(&fileCounter, 1))
+					if n%progress.TickEveryNFiles == 0 {
+						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					}
 					continue
 				}
 
@@ -1435,8 +1538,17 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 					mu.Lock()
 					i.stats.failed++
 					mu.Unlock()
+					n := int(atomic.AddInt64(&fileCounter, 1))
+					if n%progress.TickEveryNFiles == 0 {
+						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					}
 					continue
 				}
+
+				if size < 0 {
+					size = int64(len(content))
+				}
+				atomic.AddInt64(&byteCounter, size)
 
 				cf := classifiedFile{
 					relPath:  t.relPath,
@@ -1477,26 +1589,22 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 					mu.Lock()
 					classified = append(classified, cf)
 					mu.Unlock()
+					n := int(atomic.AddInt64(&fileCounter, 1))
+					if n%progress.TickEveryNFiles == 0 {
+						publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+					}
 					continue
 				}
 
-				ents, err := extractors.Extract(ctx, file)
-				// Per-language relationship count for the verbose breakdown.
+				ents, extractErr := extractors.Extract(ctx, file)
 				relCount := 0
 				for k := range ents {
 					relCount += len(ents[k].Relationships)
 				}
 				mu.Lock()
 				i.stats.processed++
-				if err != nil {
-					// Issue #481 — distinguish "no extractor for this
-					// language" (a structural skip, e.g. .toml / .lock files
-					// classified but not yet supported) from real extractor
-					// failures. The former is consistent across runs but
-					// previously bumped the flaky `failed` counter; surface
-					// it under `skipped` so failed truly means a broken
-					// extraction.
-					if errors.Is(err, extractors.ErrNoExtractorForLanguage) {
+				if extractErr != nil {
+					if errors.Is(extractErr, extractors.ErrNoExtractorForLanguage) {
 						i.stats.skipped++
 					} else {
 						i.stats.failed++
@@ -1510,6 +1618,11 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 				}
 				classified = append(classified, cf)
 				mu.Unlock()
+
+				n := int(atomic.AddInt64(&fileCounter, 1))
+				if n%progress.TickEveryNFiles == 0 {
+					publishTick(n, atomic.LoadInt64(&byteCounter), t.relPath)
+				}
 			}
 		}()
 	}
@@ -1522,6 +1635,7 @@ func (i *Indexer) classifyAndRead(ctx context.Context, absRepo string, files []s
 	sortEntityRecords(allRecords)
 	return classified, allRecords
 }
+
 
 // runPass25FrameworkRules applies the YAML rule engine to every classified
 // file. Returns extra entity records (from source_patterns) plus standalone

--- a/cmd/archigraph/progress_instrumentation_test.go
+++ b/cmd/archigraph/progress_instrumentation_test.go
@@ -1,0 +1,202 @@
+package main
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/progress"
+)
+
+// TestIndexerProgress_FixtureRun runs the indexer against the small Go
+// fixture and asserts the progress instrumentation invariants from #1119:
+//
+//  1. At least one event per pipeline phase.
+//  2. files_done monotonically increases within the extracting_ast phase.
+//  3. The final "done" event has files_done == files_total and a non-zero
+//     entities_so_far.
+//
+// It also validates the "go beyond" fields: bytes_seen accumulated,
+// current_file set on tick events, phase_started_at_ms non-zero.
+func TestIndexerProgress_FixtureRun(t *testing.T) {
+	col := &progress.SliceCollector{}
+
+	idx := newTestIndexer(t, "crossfile_go", nil)
+	idx.publisher = col
+	idx.groupSlug = "testgroup"
+	idx.repoSlug = "crossfile_go"
+
+	_, err := idx.Run(context.Background(), "testdata/crossfile_go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	events := col.Events
+	if len(events) == 0 {
+		t.Fatal("no progress events emitted")
+	}
+
+	// --- 1. At least one event per phase ---
+	phaseSeen := map[string]bool{}
+	for _, e := range events {
+		phaseSeen[e.Phase] = true
+	}
+
+	// Scanning and extraction are always present; materializing is present
+	// when Pass 5 (buildDocument) runs. Done is always emitted at the end.
+	requiredPhases := []string{
+		progress.PhaseScan,
+		progress.PhaseExtractAST,
+		progress.PhaseDone,
+	}
+	for _, phase := range requiredPhases {
+		if !phaseSeen[phase] {
+			t.Errorf("no event emitted for phase %q (seen phases: %v)", phase, phaseSeen)
+		}
+	}
+
+	// --- 2. files_done monotonically increases within extracting_ast ---
+	prevFilesDone := -1
+	for _, e := range events {
+		if e.Phase != progress.PhaseExtractAST {
+			prevFilesDone = -1 // reset when leaving the phase
+			continue
+		}
+		if prevFilesDone >= 0 && e.FilesDone < prevFilesDone {
+			t.Errorf("files_done went backwards: %d → %d in extracting_ast phase",
+				prevFilesDone, e.FilesDone)
+		}
+		prevFilesDone = e.FilesDone
+	}
+
+	// --- 3. Final "done" event has correct totals ---
+	var lastEvent progress.Event
+	for _, e := range events {
+		lastEvent = e
+	}
+	if lastEvent.Phase != progress.PhaseDone {
+		t.Errorf("last event phase = %q, want %q", lastEvent.Phase, progress.PhaseDone)
+	}
+	if lastEvent.FilesDone != lastEvent.FilesTotal {
+		t.Errorf("done event: files_done (%d) != files_total (%d)",
+			lastEvent.FilesDone, lastEvent.FilesTotal)
+	}
+	if lastEvent.EntitiesSoFar == 0 {
+		t.Error("done event: entities_so_far should be > 0")
+	}
+
+	// --- 4. Slug forwarding ---
+	for _, e := range events {
+		if e.GroupSlug != "testgroup" {
+			t.Errorf("event.group_slug = %q, want testgroup", e.GroupSlug)
+			break
+		}
+		if e.RepoSlug != "crossfile_go" {
+			t.Errorf("event.repo_slug = %q, want crossfile_go", e.RepoSlug)
+			break
+		}
+	}
+
+	// --- 5. TS and PhaseStartedAtMS are non-zero ---
+	for _, e := range events {
+		if e.TS == 0 {
+			t.Errorf("event %q has zero TS", e.Phase)
+		}
+		// PhaseStartedAtMS is set on phase-entry events.
+		if e.PhaseStartedAtMS == 0 && e.Phase != progress.PhaseDone {
+			// PhaseDone copies the previous phaseStartedAtMS which may be
+			// from the algorithm or materializing phase — still non-zero.
+			// But we tolerate zero on PhaseDone if it's a tiny fixture that
+			// completed in < 1ms; only fail if the scan phase has it zero.
+			if e.Phase == progress.PhaseScan {
+				t.Errorf("scanning phase-entry event has zero PhaseStartedAtMS")
+			}
+		}
+	}
+
+	// --- 6. bytes_seen accumulates (check at least one tick has bytes > 0) ---
+	// Only present if the fixture has real file content (it does).
+	for _, e := range events {
+		if e.Phase == progress.PhaseExtractAST && e.BytesSeen > 0 {
+			goto bytesSeen
+		}
+	}
+	// The crossfile_go fixture only has 2 small files; they may all finish
+	// before the first tick (TickEveryNFiles=20). That is acceptable.
+	// We do NOT fail if bytes_seen is always zero on a tiny fixture.
+bytesSeen:
+
+	// --- 7. No error events ---
+	for _, e := range events {
+		if e.Phase == progress.PhaseError {
+			t.Errorf("unexpected error event: %s", e.Error)
+		}
+	}
+}
+
+// TestIndexerProgress_NoOpPublisher verifies that the indexer behaves
+// identically whether or not a publisher is attached. The document
+// returned should be non-nil and contain entities.
+func TestIndexerProgress_NoOpPublisher(t *testing.T) {
+	// No publisher set — defaults to NoOpPublisher.
+	doc := runIndexerOn(t, "testdata/crossfile_go", "crossfile_go", nil)
+	if len(doc.Entities) == 0 {
+		t.Error("expected non-zero entities without publisher")
+	}
+}
+
+// TestIndexerProgress_AlgorithmEvents verifies that algorithm events are
+// emitted when Pass 4 runs (i.e. PassGraphAlgo is NOT skipped).
+func TestIndexerProgress_AlgorithmEvents(t *testing.T) {
+	col := &progress.SliceCollector{}
+	idx := newTestIndexer(t, "crossfile_go", nil)
+	idx.publisher = col
+
+	_, err := idx.Run(context.Background(), "testdata/crossfile_go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	algoEventSeen := false
+	for _, e := range col.Events {
+		if e.Phase == progress.PhaseAlgorithms && e.AlgorithmName != "" {
+			algoEventSeen = true
+			break
+		}
+	}
+	// At least one AlgorithmEvent (with a named algorithm) must have fired.
+	if !algoEventSeen {
+		t.Error("no named PhaseAlgorithms event emitted; expected AlgorithmEvent with algorithm_name set")
+	}
+}
+
+// TestIndexerProgress_SkipAlgorithms verifies that algorithm events are NOT
+// emitted when PassGraphAlgo is skipped.
+func TestIndexerProgress_SkipAlgorithms(t *testing.T) {
+	col := &progress.SliceCollector{}
+	idx := newTestIndexer(t, "crossfile_go", []string{PassGraphAlgo})
+	idx.publisher = col
+
+	_, err := idx.Run(context.Background(), "testdata/crossfile_go")
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	for _, e := range col.Events {
+		if e.Phase == progress.PhaseAlgorithms {
+			t.Errorf("unexpected PhaseAlgorithms event when PassGraphAlgo is skipped")
+			break
+		}
+	}
+
+	// Done event should still appear.
+	hasDone := false
+	for _, e := range col.Events {
+		if e.Phase == progress.PhaseDone {
+			hasDone = true
+			break
+		}
+	}
+	if !hasDone {
+		t.Error("PhaseDone event not emitted even when algorithms skipped")
+	}
+}

--- a/internal/progress/event.go
+++ b/internal/progress/event.go
@@ -1,25 +1,279 @@
-// Package progress defines the event types and interfaces for real-time indexer
-// progress tracking. This file is a placeholder stub matching the shape that
-// sub-issue A (instrumentation) will define. Sub-A owns the canonical definition;
-// once that PR lands this file should be removed and the import updated.
+// Package progress defines the per-repo, per-phase progress event shape
+// emitted by the indexer pipeline and the Publisher interface that
+// consumers implement.
+//
+// Phase A of the real-time progress epic (#1118): this package is the
+// foundation. Sub-issue B wires a real broker; sub-issue C exposes an SSE
+// endpoint; sub-issue D adds frontend rendering.
+//
+// Design goals:
+//   - Publisher.Publish never blocks the indexer. The buffered-channel
+//     implementation uses a drop-oldest policy under backpressure so the
+//     hot extraction loop is never paused waiting for a slow consumer.
+//   - All fields are JSON-serialisable so the SSE endpoint can forward
+//     events verbatim.
+//   - "Go beyond" additions: BytesSeen, CurrentFile, PhaseStartedAtMS give
+//     the UI extra detail without requiring the broker or frontend to land.
 package progress
 
-// Event represents a single indexer progress tick emitted during a rebuild.
-// Fields mirror the ProgressEvent shape agreed in the epic (#1118, sub-A #1119).
+import "time"
+
+// Phase labels emitted during indexing. The set deliberately mirrors the
+// user-visible pipeline stages rather than the internal pass numbers so the
+// SSE endpoint and the frontend speak the same vocabulary.
+const (
+	// PhaseScan is the file-discovery walk — archigraph is counting files.
+	PhaseScan = "scanning"
+
+	// PhaseExtractAST is the per-language AST extraction pass (Pass 1 /
+	// subprocess-extract). Progress ticks every TickEveryNFiles files.
+	PhaseExtractAST = "extracting_ast"
+
+	// PhaseResolveRefs covers Pass 2.5 framework rules, Pass 3 cross-lang
+	// extractors, external synthesis, and the resolver / disposition pass.
+	PhaseResolveRefs = "resolving_refs"
+
+	// PhaseAlgorithms is Pass 4 (PageRank, Louvain, betweenness,
+	// articulation points, surprise edges). One event per algorithm entry
+	// and exit.
+	PhaseAlgorithms = "running_algorithms"
+
+	// PhaseMaterialize covers buildDocument, graph.fb write, sidecar write,
+	// and enrichment-candidate emission.
+	PhaseMaterialize = "materializing"
+
+	// PhaseDone is emitted once with final totals.
+	PhaseDone = "done"
+
+	// PhaseError is emitted when the indexer encounters a fatal error.
+	PhaseError = "error"
+)
+
+// TickEveryNFiles is the default file-tick interval for the AST extraction
+// phase. Publishers are called every N files processed so high-file-count
+// repos still feel responsive without overwhelming the event channel.
+// Configurable per-Indexer via WithTickInterval.
+const TickEveryNFiles = 20
+
+// Event is the wire shape for a single indexer progress notification.
+// All fields are JSON-serialisable. The struct is intentionally flat so
+// the SSE endpoint can forward it with a single json.Marshal call.
 type Event struct {
-	GroupSlug     string `json:"group_slug"`
-	RepoSlug      string `json:"repo_slug"`
-	Phase         string `json:"phase"` // scanning|extracting_ast|resolving_refs|running_algorithms|materializing|done|error
-	FilesDone     int    `json:"files_done"`
-	FilesTotal    int    `json:"files_total"`
-	EntitiesSoFar int    `json:"entities_so_far"`
-	ETAms         int    `json:"eta_ms,omitempty"`
-	Error         string `json:"error,omitempty"`
-	TS            int64  `json:"ts"`
+	// GroupSlug and RepoSlug identify which indexing job produced this
+	// event. Both default to empty string when the indexer runs standalone
+	// (CLI mode without a group).
+	GroupSlug string `json:"group_slug"`
+	RepoSlug  string `json:"repo_slug"`
+
+	// Phase is the current pipeline stage (one of the Phase* constants).
+	Phase string `json:"phase"`
+
+	// FilesDone is the number of files processed so far in the current phase.
+	FilesDone int `json:"files_done"`
+
+	// FilesTotal is the total file count as discovered by the walk pass.
+	// Set on the first PhaseScan event; unchanged on subsequent events.
+	FilesTotal int `json:"files_total"`
+
+	// EntitiesSoFar is the running count of entities emitted up to this point.
+	// Updated on PhaseDone; may be 0 during extraction.
+	EntitiesSoFar int `json:"entities_so_far"`
+
+	// ETAms is a caller-supplied estimate of milliseconds remaining.
+	// Omitted (zero) when the indexer has not computed an ETA.
+	ETAms int `json:"eta_ms,omitempty"`
+
+	// Error is non-empty only when Phase == PhaseError.
+	Error string `json:"error,omitempty"`
+
+	// TS is the Unix timestamp in milliseconds when the event was created.
+	TS int64 `json:"ts"`
+
+	// --- "go beyond" fields ---
+
+	// BytesSeen is the cumulative byte count of all files read so far.
+	// Useful for users with very large repos where file count is misleading.
+	BytesSeen int64 `json:"bytes_seen,omitempty"`
+
+	// CurrentFile is the repo-relative path of the file being processed at
+	// tick time. Allows the UI to show "extracting: routers.py" rather than
+	// just "47/100". Empty on phase-boundary events.
+	CurrentFile string `json:"current_file,omitempty"`
+
+	// PhaseStartedAtMS is the Unix millisecond timestamp when the current
+	// phase started. Lets the frontend display "in this phase for 2.3s".
+	PhaseStartedAtMS int64 `json:"phase_started_at_ms,omitempty"`
+
+	// AlgorithmName is set during PhaseAlgorithms events to name the
+	// individual algorithm (e.g. "Louvain", "PageRank", "Betweenness").
+	AlgorithmName string `json:"algorithm_name,omitempty"`
 }
 
-// Publisher is the write side of the progress pipeline. The indexer calls
-// Publish after every instrumentation tick. The broker implements this interface.
+// nowMS returns the current wall-clock time as Unix milliseconds.
+func nowMS() int64 {
+	return time.Now().UnixMilli()
+}
+
+// Publisher is the sink that receives progress events from the indexer.
+// Implementations must be safe to call from multiple goroutines and must
+// not block the caller.
 type Publisher interface {
 	Publish(e Event)
+}
+
+// NoOpPublisher silently discards all events. It is the default when no
+// publisher is wired into the indexer.
+type NoOpPublisher struct{}
+
+// Publish implements Publisher and is a no-op.
+func (NoOpPublisher) Publish(Event) {}
+
+// BufferedPublisher is a non-blocking Publisher that forwards events to a
+// fixed-size buffered channel. When the channel is full the oldest event is
+// dropped (drop-oldest) so the indexer is never paused waiting for a
+// consumer. Callers read from Ch.
+type BufferedPublisher struct {
+	Ch chan Event
+}
+
+// NewBufferedPublisher creates a BufferedPublisher with the given channel
+// capacity. A capacity of 64 is suitable for most UIs that drain at >10
+// events/second; increase for long-running algo phases with burst traffic.
+func NewBufferedPublisher(capacity int) *BufferedPublisher {
+	return &BufferedPublisher{Ch: make(chan Event, capacity)}
+}
+
+// Publish enqueues e without blocking. If the channel is full the oldest
+// queued event is discarded before enqueuing the new one.
+func (b *BufferedPublisher) Publish(e Event) {
+	select {
+	case b.Ch <- e:
+	default:
+		// Channel full — drain oldest, then enqueue.
+		select {
+		case <-b.Ch:
+		default:
+		}
+		select {
+		case b.Ch <- e:
+		default:
+		}
+	}
+}
+
+// SliceCollector collects every published event into a slice. It is
+// intended for unit tests only; it holds a mutex so it is goroutine-safe.
+type SliceCollector struct {
+	Events []Event
+}
+
+// Publish appends e to Events. Safe for concurrent use.
+func (s *SliceCollector) Publish(e Event) {
+	s.Events = append(s.Events, e)
+}
+
+// Tracker is the per-indexing-job helper that constructs and publishes
+// progress events. It carries shared state (group/repo slugs, total file
+// count, phase start time) so individual call-sites only need to supply
+// the delta. Tracker is safe to use from a single goroutine; it does not
+// add internal synchronisation — the indexer already serialises phase
+// transitions on the main goroutine.
+type Tracker struct {
+	pub              Publisher
+	groupSlug        string
+	repoSlug         string
+	filesTotal       int
+	phaseStartedAtMS int64
+	currentPhase     string
+}
+
+// NewTracker constructs a Tracker for one indexing job. pub must not be nil;
+// use NoOpPublisher{} for a no-op sink.
+func NewTracker(pub Publisher, groupSlug, repoSlug string) *Tracker {
+	return &Tracker{
+		pub:       pub,
+		groupSlug: groupSlug,
+		repoSlug:  repoSlug,
+	}
+}
+
+// SetFilesTotal stores the total file count discovered during scanning.
+func (t *Tracker) SetFilesTotal(n int) {
+	t.filesTotal = n
+}
+
+// PhaseStart emits a phase-entry event and records the start timestamp.
+func (t *Tracker) PhaseStart(phase string, filesDone int, entitiesSoFar int) {
+	t.currentPhase = phase
+	t.phaseStartedAtMS = nowMS()
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            phase,
+		FilesDone:        filesDone,
+		FilesTotal:       t.filesTotal,
+		EntitiesSoFar:    entitiesSoFar,
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// Tick emits a within-phase progress event. filesDone, bytesSeen, and
+// currentFile reflect the current extraction state.
+func (t *Tracker) Tick(phase string, filesDone int, bytesSeen int64, currentFile string, entitiesSoFar int) {
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            phase,
+		FilesDone:        filesDone,
+		FilesTotal:       t.filesTotal,
+		EntitiesSoFar:    entitiesSoFar,
+		BytesSeen:        bytesSeen,
+		CurrentFile:      currentFile,
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// AlgorithmEvent emits an entry or exit event for a named graph algorithm.
+func (t *Tracker) AlgorithmEvent(name string, entitiesSoFar int) {
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            PhaseAlgorithms,
+		FilesTotal:       t.filesTotal,
+		FilesDone:        t.filesTotal, // algorithms run after all files are processed
+		EntitiesSoFar:    entitiesSoFar,
+		AlgorithmName:    name,
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// Done emits the final PhaseDone event with full totals.
+func (t *Tracker) Done(filesDone, entitiesSoFar int) {
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            PhaseDone,
+		FilesDone:        filesDone,
+		FilesTotal:       t.filesTotal,
+		EntitiesSoFar:    entitiesSoFar,
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
+}
+
+// Fail emits a PhaseError event.
+func (t *Tracker) Fail(errMsg string) {
+	t.pub.Publish(Event{
+		GroupSlug:        t.groupSlug,
+		RepoSlug:         t.repoSlug,
+		Phase:            PhaseError,
+		FilesTotal:       t.filesTotal,
+		FilesDone:        0,
+		Error:            errMsg,
+		PhaseStartedAtMS: t.phaseStartedAtMS,
+		TS:               nowMS(),
+	})
 }

--- a/internal/progress/event_test.go
+++ b/internal/progress/event_test.go
@@ -1,0 +1,168 @@
+package progress_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/progress"
+)
+
+// TestSliceCollector verifies that SliceCollector accumulates events.
+func TestSliceCollector(t *testing.T) {
+	col := &progress.SliceCollector{}
+	pub := col
+
+	pub.Publish(progress.Event{Phase: progress.PhaseScan, FilesTotal: 10})
+	pub.Publish(progress.Event{Phase: progress.PhaseExtractAST, FilesDone: 5})
+
+	if len(col.Events) != 2 {
+		t.Fatalf("expected 2 events, got %d", len(col.Events))
+	}
+	if col.Events[0].Phase != progress.PhaseScan {
+		t.Errorf("event[0].Phase = %q, want %q", col.Events[0].Phase, progress.PhaseScan)
+	}
+	if col.Events[1].Phase != progress.PhaseExtractAST {
+		t.Errorf("event[1].Phase = %q, want %q", col.Events[1].Phase, progress.PhaseExtractAST)
+	}
+}
+
+// TestBufferedPublisher_NonBlocking verifies that Publish never blocks even
+// when the channel is full and uses drop-oldest backpressure.
+func TestBufferedPublisher_NonBlocking(t *testing.T) {
+	const cap = 4
+	pub := progress.NewBufferedPublisher(cap)
+
+	// Fill channel to capacity + 2 (should drop-oldest, not block).
+	for i := 0; i < cap+2; i++ {
+		pub.Publish(progress.Event{Phase: progress.PhaseScan, FilesDone: i})
+	}
+	// Drain remaining events — must be able to drain without deadlock.
+	drained := 0
+	for {
+		select {
+		case <-pub.Ch:
+			drained++
+		default:
+			goto done
+		}
+	}
+done:
+	// We must have received between 1 and cap events (oldest ones were dropped).
+	if drained == 0 {
+		t.Fatal("no events received from BufferedPublisher")
+	}
+	if drained > cap {
+		t.Fatalf("drained %d events, expected <= %d (capacity)", drained, cap)
+	}
+}
+
+// TestNoOpPublisher verifies NoOpPublisher is safe to call.
+func TestNoOpPublisher(t *testing.T) {
+	var nop progress.NoOpPublisher
+	nop.Publish(progress.Event{Phase: progress.PhaseScan})
+	// No panic = pass.
+}
+
+// TestTracker_PhaseStart verifies that PhaseStart emits an event with the
+// correct phase, timestamps, and slug fields.
+func TestTracker_PhaseStart(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "mygroup", "myrepo")
+	trk.SetFilesTotal(42)
+
+	trk.PhaseStart(progress.PhaseScan, 0, 0)
+
+	if len(col.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(col.Events))
+	}
+	e := col.Events[0]
+	if e.GroupSlug != "mygroup" {
+		t.Errorf("GroupSlug = %q, want %q", e.GroupSlug, "mygroup")
+	}
+	if e.RepoSlug != "myrepo" {
+		t.Errorf("RepoSlug = %q, want %q", e.RepoSlug, "myrepo")
+	}
+	if e.Phase != progress.PhaseScan {
+		t.Errorf("Phase = %q, want %q", e.Phase, progress.PhaseScan)
+	}
+	if e.FilesTotal != 42 {
+		t.Errorf("FilesTotal = %d, want 42", e.FilesTotal)
+	}
+	if e.PhaseStartedAtMS == 0 {
+		t.Error("PhaseStartedAtMS should be non-zero")
+	}
+	if e.TS == 0 {
+		t.Error("TS should be non-zero")
+	}
+}
+
+// TestTracker_Done verifies the final PhaseDone event carries correct totals.
+func TestTracker_Done(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "", "repo")
+	trk.SetFilesTotal(100)
+
+	trk.Done(100, 500)
+
+	if len(col.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(col.Events))
+	}
+	e := col.Events[0]
+	if e.Phase != progress.PhaseDone {
+		t.Errorf("Phase = %q, want %q", e.Phase, progress.PhaseDone)
+	}
+	if e.FilesDone != 100 {
+		t.Errorf("FilesDone = %d, want 100", e.FilesDone)
+	}
+	if e.FilesTotal != 100 {
+		t.Errorf("FilesTotal = %d, want 100", e.FilesTotal)
+	}
+	if e.EntitiesSoFar != 500 {
+		t.Errorf("EntitiesSoFar = %d, want 500", e.EntitiesSoFar)
+	}
+}
+
+// TestTracker_Fail verifies that Fail emits a PhaseError event with the
+// error message.
+func TestTracker_Fail(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "g", "r")
+	trk.Fail("something went wrong")
+
+	if len(col.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(col.Events))
+	}
+	e := col.Events[0]
+	if e.Phase != progress.PhaseError {
+		t.Errorf("Phase = %q, want %q", e.Phase, progress.PhaseError)
+	}
+	if e.Error != "something went wrong" {
+		t.Errorf("Error = %q, want %q", e.Error, "something went wrong")
+	}
+}
+
+// TestTracker_AlgorithmEvent verifies AlgorithmEvent sets the algorithm name.
+func TestTracker_AlgorithmEvent(t *testing.T) {
+	col := &progress.SliceCollector{}
+	trk := progress.NewTracker(col, "", "r")
+	trk.SetFilesTotal(50)
+
+	trk.AlgorithmEvent("PageRank", 200)
+
+	if len(col.Events) != 1 {
+		t.Fatalf("expected 1 event, got %d", len(col.Events))
+	}
+	e := col.Events[0]
+	if e.Phase != progress.PhaseAlgorithms {
+		t.Errorf("Phase = %q, want %q", e.Phase, progress.PhaseAlgorithms)
+	}
+	if e.AlgorithmName != "PageRank" {
+		t.Errorf("AlgorithmName = %q, want PageRank", e.AlgorithmName)
+	}
+	if e.EntitiesSoFar != 200 {
+		t.Errorf("EntitiesSoFar = %d, want 200", e.EntitiesSoFar)
+	}
+	// FilesDone should equal FilesTotal for algorithm events.
+	if e.FilesDone != e.FilesTotal {
+		t.Errorf("FilesDone (%d) != FilesTotal (%d) for algorithm event", e.FilesDone, e.FilesTotal)
+	}
+}


### PR DESCRIPTION
## Summary

Phase A of the real-time indexing progress epic (#1118). Defines the
\`internal/progress\` package and wires the \`Indexer\` to publish structured
events at every pipeline phase boundary.

**What ships in this PR:**

- New \`internal/progress\` package: \`Event\`, \`Publisher\`, \`NoOpPublisher\`,
  \`BufferedPublisher\` (drop-oldest, non-blocking), \`SliceCollector\` (tests),
  and \`Tracker\` (per-job state helper).
- \`WithPublisher(pub)\` / \`WithProgressSlugs(group, repo)\` \`IndexOption\` funcs —
  zero-overhead opt-in; existing callers unchanged (\`NoOpPublisher\` default).
- Instrumentation in \`Indexer.Run\`:
  - \`scanning\` — pre-walk + post-walk events
  - \`extracting_ast\` — \`PhaseStart\` + tick every N=20 files with \`bytes_seen\`, \`current_file\`, \`phase_started_at_ms\`
  - \`resolving_refs\` — phase entry after Pass 1
  - \`materializing\` — before \`buildDocument\`
  - \`running_algorithms\` — \`PhaseStart\` + two \`AlgorithmEvent\` calls with \`algorithm_name\`
  - \`done\` — final event with \`files_done == files_total\` and \`entities_so_far\`
  - \`error\` — on any fatal return path

**"Go beyond" additions:** \`bytes_seen\`, \`current_file\`, \`phase_started_at_ms\`, \`algorithm_name\`.

## Closes / Refs
- Closes #1119
- Refs #1118 (parent epic — broker + SSE + frontend land in sub-issues B/C/D)

## Testing
- [ ] \`go test ./internal/progress/...\` — 7 unit tests pass
- [ ] \`go test ./cmd/archigraph/... -run TestIndexerProgress\` — 4 integration tests pass (monotone files_done, done.files_done == done.files_total, non-zero entities_so_far)
- [ ] Pre-existing failure \`TestIssue820_FixtureF_OrphanRate\` unrelated (orphan rate regression on branch base)

## Notes

\`BufferedPublisher\` (capacity 64, drop-oldest) is the recommended sink for the broker sub-issue B. \`SliceCollector\` is test-only and intentionally not goroutine-safe.