### PR TITLE
[progress] Sub-C: SSE endpoint /api/index-progress for streaming events

### DIFF
--- a/internal/dashboard/handlers_progress.go
+++ b/internal/dashboard/handlers_progress.go
@@ -1,0 +1,145 @@
+package dashboard
+
+// handlers_progress.go — SSE endpoint for real-time indexing progress
+//
+// Routes registered in server.go:
+//
+//	GET /api/index-progress          — all groups (daemon-wide)
+//	GET /api/index-progress/{group}  — single group filtered stream
+//
+// The handler subscribes to the shared Broker on s.progressBroker, writes
+// Server-Sent Events to the response body, and tears down cleanly on client
+// disconnect. A 15-second heartbeat keeps load-balancers and reverse proxies
+// from closing idle connections.
+//
+// Wire format (SSE):
+//
+//	event: connected
+//	data: {"group":"<slug>","subscribed_at":<unix-ms>}\n\n
+//
+//	event: progress
+//	data: <JSON-encoded progress.Event>\n\n
+//
+//	event: heartbeat
+//	data: {}\n\n
+//
+//	event: close
+//	data: {}\n\n   (sent before the server closes the stream)
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/progress"
+)
+
+const (
+	heartbeatInterval = 15 * time.Second
+	// sseWildcardGroup is the sentinel used internally when a caller subscribes
+	// to all groups (the daemon-wide /api/index-progress endpoint).
+	sseWildcardGroup = ""
+)
+
+// handleIndexProgressAll streams progress events from every group.
+func (s *Server) handleIndexProgressAll(w http.ResponseWriter, r *http.Request) {
+	s.serveSSE(w, r, sseWildcardGroup)
+}
+
+// handleIndexProgressGroup streams progress events filtered to one group slug.
+func (s *Server) handleIndexProgressGroup(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "missing group slug")
+		return
+	}
+	s.serveSSE(w, r, group)
+}
+
+// serveSSE is the shared implementation for both SSE endpoints.
+// group == sseWildcardGroup means "all groups".
+func (s *Server) serveSSE(w http.ResponseWriter, r *http.Request, group string) {
+	if s.progressBroker == nil {
+		writeErr(w, http.StatusServiceUnavailable, "progress broker not available")
+		return
+	}
+
+	// SSE requires the response to be flushable.
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeErr(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	// Proxy-friendliness headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	// Subscribe to the broker. For the wildcard endpoint we subscribe to
+	// every group key by using an empty string; the broker treats that as its
+	// own group bucket, which is fine for heartbeat-only — but to receive
+	// events from all real groups we use BroadcastAll on the publish side.
+	// Here we need a different approach: subscribe per-group is not possible
+	// without knowing group names in advance. Instead, we maintain a dedicated
+	// "wildcard" subscription: publish side will call BroadcastAll which sends
+	// to every registered channel. We subscribe with the empty-string sentinel.
+	var (
+		ch     <-chan progress.Event
+		cancel func()
+	)
+	if group == sseWildcardGroup {
+		ch, cancel = s.progressBroker.SubscribeAll()
+	} else {
+		ch, cancel = s.progressBroker.Subscribe(group)
+	}
+	defer cancel()
+
+	// Send the initial "connected" event so the client knows the stream is live.
+	subscribedAt := time.Now().UnixMilli()
+	connPayload := fmt.Sprintf(`{"group":%q,"subscribed_at":%d}`, group, subscribedAt)
+	writeSSEEvent(w, "connected", connPayload)
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			// Client disconnected. Send a close event (best-effort; the
+			// write may fail if the connection is already gone, which is fine).
+			writeSSEEvent(w, "close", "{}")
+			flusher.Flush()
+			return
+
+		case e, ok := <-ch:
+			if !ok {
+				// Broker closed the channel (e.g. daemon shutdown).
+				writeSSEEvent(w, "close", "{}")
+				flusher.Flush()
+				return
+			}
+			data, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			writeSSEEvent(w, "progress", string(data))
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			writeSSEEvent(w, "heartbeat", "{}")
+			flusher.Flush()
+		}
+	}
+}
+
+// writeSSEEvent writes a single SSE event block to w.
+// It does NOT flush — callers must flush after writing.
+func writeSSEEvent(w http.ResponseWriter, event, data string) {
+	fmt.Fprintf(w, "event: %s\ndata: %s\n\n", event, data)
+}

--- a/internal/dashboard/handlers_progress_test.go
+++ b/internal/dashboard/handlers_progress_test.go
@@ -1,0 +1,335 @@
+package dashboard
+
+// handlers_progress_test.go — tests for the /api/index-progress SSE endpoints.
+
+import (
+	"bufio"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/progress"
+)
+
+// newTestServerWithBroker builds a minimal *Server wired to the given broker
+// and returns a running httptest.Server. The test is responsible for calling
+// ts.Close().
+func newTestServerWithBroker(t *testing.T, broker *progress.Broker) *httptest.Server {
+	t.Helper()
+	srv, err := NewServer(Config{
+		Bind:      "127.0.0.1",
+		PortRange: PortRange{Min: 47300, Max: 47399},
+	}, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.SetProgressBroker(broker)
+	return httptest.NewServer(srv.routes())
+}
+
+// readSSELines reads lines from r until either n "data:" lines are collected
+// or the deadline expires. It returns only the data lines (without the
+// "data: " prefix).
+func readSSELines(t *testing.T, r *bufio.Reader, n int, timeout time.Duration) []string {
+	t.Helper()
+	var lines []string
+	done := time.After(timeout)
+	for len(lines) < n {
+		lineCh := make(chan string, 1)
+		errCh := make(chan error, 1)
+		go func() {
+			l, err := r.ReadString('\n')
+			if err != nil {
+				errCh <- err
+				return
+			}
+			lineCh <- l
+		}()
+		select {
+		case <-done:
+			return lines
+		case <-errCh:
+			return lines
+		case l := <-lineCh:
+			l = strings.TrimSpace(l)
+			if strings.HasPrefix(l, "data:") {
+				lines = append(lines, strings.TrimPrefix(strings.TrimSpace(l[5:]), " "))
+			}
+		}
+	}
+	return lines
+}
+
+// TestSSE_GroupEndpoint_ReceivesEvent verifies that a subscriber on
+// /api/index-progress/{group} receives an event published to that group.
+func TestSSE_GroupEndpoint_ReceivesEvent(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/team-alpha", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/index-progress/team-alpha: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("want text/event-stream Content-Type, got %q", ct)
+	}
+
+	reader := bufio.NewReader(resp.Body)
+
+	// The first data line should be the "connected" event payload.
+	connected := readSSELines(t, reader, 1, 2*time.Second)
+	if len(connected) == 0 {
+		t.Fatal("did not receive connected event")
+	}
+	if !strings.Contains(connected[0], "subscribed_at") {
+		t.Errorf("connected payload missing subscribed_at: %q", connected[0])
+	}
+
+	// Publish an event and expect it on the stream.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Publish(progress.Event{
+			GroupSlug:  "team-alpha",
+			RepoSlug:   "service-x",
+			Phase:      "scanning",
+			FilesDone:  5,
+			FilesTotal: 100,
+			TS:         time.Now().UnixMilli(),
+		})
+	}()
+
+	lines := readSSELines(t, reader, 1, 3*time.Second)
+	if len(lines) == 0 {
+		t.Fatal("did not receive progress event on SSE stream")
+	}
+	if !strings.Contains(lines[0], "scanning") {
+		t.Errorf("expected phase=scanning in payload, got: %q", lines[0])
+	}
+}
+
+// TestSSE_GroupEndpoint_Isolation verifies that events for group-B do not
+// appear on a subscription for group-A.
+func TestSSE_GroupEndpoint_Isolation(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/group-a", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// Publish to a different group — this should NOT appear on the group-a stream.
+	broker.Publish(progress.Event{
+		GroupSlug: "group-b",
+		RepoSlug:  "svc",
+		Phase:     "done",
+		TS:        time.Now().UnixMilli(),
+	})
+
+	// Drain for 300ms — expect no data lines (only possible heartbeats, but
+	// 300ms < 15s heartbeat so none should arrive either).
+	extra := readSSELines(t, reader, 1, 300*time.Millisecond)
+	if len(extra) != 0 {
+		t.Errorf("group-a stream received unexpected event from group-b: %q", extra)
+	}
+}
+
+// TestSSE_AllGroups_ReceivesEventsFromMultipleGroups verifies the wildcard
+// endpoint /api/index-progress delivers events from every group.
+func TestSSE_AllGroups_ReceivesEventsFromMultipleGroups(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/index-progress: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// Publish events to two different groups.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Publish(progress.Event{GroupSlug: "alpha", Phase: "scanning", TS: time.Now().UnixMilli()})
+		broker.Publish(progress.Event{GroupSlug: "beta", Phase: "done", TS: time.Now().UnixMilli()})
+	}()
+
+	// Expect two data lines (one per group).
+	lines := readSSELines(t, reader, 2, 3*time.Second)
+	if len(lines) < 2 {
+		t.Fatalf("wildcard stream: want 2 events, got %d", len(lines))
+	}
+	combined := strings.Join(lines, " ")
+	if !strings.Contains(combined, "scanning") {
+		t.Errorf("wildcard stream missing alpha/scanning event: %q", lines)
+	}
+	if !strings.Contains(combined, "done") {
+		t.Errorf("wildcard stream missing beta/done event: %q", lines)
+	}
+}
+
+// TestSSE_MultipleSubscribers verifies that two concurrent SSE connections for
+// the same group both receive the same published event.
+func TestSSE_MultipleSubscribers(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	makeConn := func() (*bufio.Reader, context.CancelFunc, *http.Response) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/shared-group", nil)
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			cancel()
+			t.Fatalf("GET: %v", err)
+		}
+		return bufio.NewReader(resp.Body), cancel, resp
+	}
+
+	r1, cancel1, resp1 := makeConn()
+	defer cancel1()
+	defer resp1.Body.Close()
+
+	r2, cancel2, resp2 := makeConn()
+	defer cancel2()
+	defer resp2.Body.Close()
+
+	// Drain connected events from both.
+	readSSELines(t, r1, 1, 2*time.Second)
+	readSSELines(t, r2, 1, 2*time.Second)
+
+	// Give the broker a moment to register both subscribers.
+	time.Sleep(50 * time.Millisecond)
+
+	broker.Publish(progress.Event{
+		GroupSlug: "shared-group",
+		Phase:     "extracting_ast",
+		TS:        time.Now().UnixMilli(),
+	})
+
+	l1 := readSSELines(t, r1, 1, 2*time.Second)
+	l2 := readSSELines(t, r2, 1, 2*time.Second)
+
+	if len(l1) == 0 {
+		t.Error("subscriber 1 did not receive event")
+	}
+	if len(l2) == 0 {
+		t.Error("subscriber 2 did not receive event")
+	}
+}
+
+// TestSSE_DisconnectRemovesSubscriber verifies that after the client context is
+// cancelled the broker holds no lingering subscriber for the group.
+func TestSSE_DisconnectRemovesSubscriber(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/temp-group", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		cancel()
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	reader := bufio.NewReader(resp.Body)
+	// Consume the connected event so we know the subscription is active.
+	readSSELines(t, reader, 1, 2*time.Second)
+
+	// Cancel the client context to simulate disconnect.
+	cancel()
+
+	// Allow the server goroutine to detect the disconnect and call cancel().
+	time.Sleep(200 * time.Millisecond)
+
+	stats := broker.Stats()
+	if n := stats["temp-group"]; n != 0 {
+		t.Errorf("broker still has %d subscriber(s) for temp-group after disconnect", n)
+	}
+}
+
+// TestSSE_NoBroker_Returns503 checks that the endpoint gracefully returns 503
+// when no broker is configured.
+func TestSSE_NoBroker_Returns503(t *testing.T) {
+	srv, err := NewServer(Config{
+		Bind:      "127.0.0.1",
+		PortRange: PortRange{Min: 47300, Max: 47399},
+	}, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// No broker set.
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/index-progress/any-group")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("want 503, got %d", resp.StatusCode)
+	}
+}
+
+// TestSSE_ProxyHeaders verifies the proxy-friendliness headers are set.
+func TestSSE_ProxyHeaders(t *testing.T) {
+	broker := progress.NewBroker()
+	ts := newTestServerWithBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, ts.URL+"/api/index-progress/hdr-group", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	tests := []struct{ header, want string }{
+		{"Cache-Control", "no-cache, no-transform"},
+		{"X-Accel-Buffering", "no"},
+	}
+	for _, tc := range tests {
+		if got := resp.Header.Get(tc.header); got != tc.want {
+			t.Errorf("header %q: want %q, got %q", tc.header, tc.want, got)
+		}
+	}
+}

--- a/internal/dashboard/handlers_topology_detail.go
+++ b/internal/dashboard/handlers_topology_detail.go
@@ -60,12 +60,12 @@ type topicDetailResponse struct {
 	DocgenStatus    string             `json:"docgen_status"`
 	// EnrichmentHealth reports which structured fields are populated.
 	// Only present when DocgenStatus == "enriched" or "stale".
-	EnrichmentHealth *enrichmentHealth  `json:"enrichment_health,omitempty"`
+	EnrichmentHealth *topicEnrichmentHealth  `json:"enrichment_health,omitempty"`
 }
 
 // enrichmentHealth reports which message_topic enrichment fields are present,
 // so the frontend can surface a completeness hint alongside the detail panel.
-type enrichmentHealth struct {
+type topicEnrichmentHealth struct {
 	HasSummary              bool `json:"has_summary"`
 	HasSchema               bool `json:"has_schema"`
 	HasVolumeEstimate       bool `json:"has_volume_estimate"`
@@ -196,7 +196,7 @@ func buildTopicDetail(grp *DashGroup, groupName, topicID string) (topicDetailRes
 
 	// --- Docgen status + stale detection ---
 	docgenStatus := "pending"
-	var enrichHealth *enrichmentHealth
+	var enrichHealth *topicEnrichmentHealth
 	if enrichment != nil {
 		// Determine stale/enriched by comparing the doc file's mtime against
 		// the topic's last_indexed timestamp (r.Doc.GeneratedAt for its repo).
@@ -563,14 +563,14 @@ func dedupStrings(sl []string) []string {
 	return out
 }
 
-// computeEnrichmentHealth returns a populated enrichmentHealth for a message_topic
+// computeEnrichmentHealth returns a populated topicEnrichmentHealth for a message_topic
 // frontmatter, counting which of the six structured fields are filled.
-func computeEnrichmentHealth(fm *EnrichmentFrontmatter) *enrichmentHealth {
+func computeEnrichmentHealth(fm *EnrichmentFrontmatter) *topicEnrichmentHealth {
 	if fm == nil {
 		return nil
 	}
 	const total = 6
-	h := &enrichmentHealth{
+	h := &topicEnrichmentHealth{
 		HasSummary:            fm.Summary != "",
 		HasSchema:             fm.Schema != "",
 		HasVolumeEstimate:     fm.VolumeEstimate != "",

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -14,6 +14,8 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/progress"
 )
 
 // Server is an embedded HTTP dashboard. It is intentionally small: it
@@ -28,6 +30,11 @@ type Server struct {
 	srv             *http.Server
 	rng             *rand.Rand
 	daemonStartedAt time.Time // zero when not embedded inside a daemon process
+
+	// progressBroker is the shared pub/sub bus for real-time indexing progress.
+	// It is optional: when nil the /api/index-progress endpoints return 503.
+	// Set via SetProgressBroker before calling Serve.
+	progressBroker *progress.Broker
 }
 
 // NewServer wires a server against the given config and registry-store
@@ -56,6 +63,13 @@ func NewServer(cfg Config, store RegistryStore) (*Server, error) {
 // after the daemon's embedded server is wired up.
 func (s *Server) SetDaemonStartedAt(t time.Time) {
 	s.daemonStartedAt = t
+}
+
+// SetProgressBroker wires the shared indexer progress broker into the server
+// so that /api/index-progress endpoints can stream live events. Call this from
+// cmd/archigraph (or any daemon entrypoint) before Serve.
+func (s *Server) SetProgressBroker(b *progress.Broker) {
+	s.progressBroker = b
 }
 
 // Listen binds to a random free port within cfg.PortRange. It is
@@ -210,6 +224,10 @@ func (s *Server) routes() http.Handler {
 
 	// WebSocket push
 	mux.HandleFunc("/ws/events", s.handleWSEvents)
+
+	// SSE progress streams (Sub-C of epic #1118)
+	mux.HandleFunc("GET /api/index-progress", s.handleIndexProgressAll)
+	mux.HandleFunc("GET /api/index-progress/{group}", s.handleIndexProgressGroup)
 
 	return s.withAuth(mux)
 }

--- a/internal/progress/broker.go
+++ b/internal/progress/broker.go
@@ -48,19 +48,27 @@ func NewBroker() *Broker {
 	}
 }
 
-// Publish fans an event out to every subscriber registered for e.GroupSlug.
-// Each send is attempted with a non-blocking select; if the subscriber's channel
-// is full the event is discarded for that subscriber (drop-on-full, not
-// drop-oldest). This keeps the publisher lock-free on the hot path.
+// wildcardGroup is the internal key used to register subscribers that want
+// events from every group. It must not be a valid group slug (group slugs are
+// non-empty URL path segments).
+const wildcardGroup = "\x00wildcard"
+
+// Publish fans an event out to every subscriber registered for e.GroupSlug,
+// plus any wildcard subscribers registered via SubscribeAll. Each send is
+// attempted with a non-blocking select; if the subscriber's channel is full the
+// event is discarded for that subscriber (drop-on-full, not drop-oldest). This
+// keeps the publisher lock-free on the hot path.
 //
 // Publish implements the Publisher interface so the indexer can use the broker
 // without importing a concrete type.
 func (b *Broker) Publish(e Event) {
 	b.mu.RLock()
-	subs := b.subs[e.GroupSlug]
-	// Snapshot the slice under the read lock so we can send without holding it.
-	targets := make([]*subscriber, len(subs))
-	copy(targets, subs)
+	groupSubs := b.subs[e.GroupSlug]
+	wildcardSubs := b.subs[wildcardGroup]
+	// Snapshot both slices under the read lock so we can send without holding it.
+	targets := make([]*subscriber, 0, len(groupSubs)+len(wildcardSubs))
+	targets = append(targets, groupSubs...)
+	targets = append(targets, wildcardSubs...)
 	b.mu.RUnlock()
 
 	for _, s := range targets {
@@ -72,8 +80,10 @@ func (b *Broker) Publish(e Event) {
 	}
 }
 
-// BroadcastAll delivers an event to every subscriber across all groups. Useful
-// for daemon-level lifecycle events (e.g. daemon shutdown notice).
+// BroadcastAll delivers an event to every subscriber across all groups,
+// including wildcard subscribers registered via SubscribeAll. Useful for
+// daemon-level lifecycle events (e.g. daemon shutdown notice) and for the
+// daemon-wide SSE endpoint.
 func (b *Broker) BroadcastAll(e Event) {
 	b.mu.RLock()
 	var targets []*subscriber
@@ -88,6 +98,16 @@ func (b *Broker) BroadcastAll(e Event) {
 		default:
 		}
 	}
+}
+
+// SubscribeAll registers a consumer that receives events from every group.
+// It works by registering under the internal wildcardGroup key; Publish
+// delivers to wildcardGroup in addition to the event's own group.
+//
+// Returns a receive-only channel and a cancel function. The caller must call
+// cancel when done (e.g. when the HTTP connection closes).
+func (b *Broker) SubscribeAll() (<-chan Event, func()) {
+	return b.Subscribe(wildcardGroup)
 }
 
 // Subscribe registers a new consumer for progress events from the given group.


### PR DESCRIPTION
## Summary

Implements Sub-C of epic #1118: a Server-Sent Events endpoint that streams real-time indexer progress from the in-memory Broker (Sub-B, #1184, already merged).

**What changed:**

- `internal/progress/broker.go` — add `wildcardGroup` sentinel constant, extend `Publish` to also deliver to wildcard subscribers, add `SubscribeAll()` method for daemon-wide consumers
- `internal/dashboard/server.go` — add `progressBroker *progress.Broker` field, `SetProgressBroker(b)` setter, register two new routes
- `internal/dashboard/handlers_progress.go` — new file; `handleIndexProgressAll` + `handleIndexProgressGroup` + shared `serveSSE` implementation
- `internal/dashboard/handlers_topology_detail.go` — fix pre-existing build error: rename `enrichmentHealth` struct → `topicEnrichmentHealth` to resolve clash with same-named function in `handlers_flows.go` (introduced by #1182, blocking compilation of the whole package)

**Wire format (SSE):**
```
event: connected
data: {"group":"<slug>","subscribed_at":<unix-ms>}

event: progress
data: <JSON-encoded progress.Event>

event: heartbeat
data: {}

event: close
data: {}
```

**Proxy-friendliness headers on every response:**
- `Content-Type: text/event-stream`
- `Cache-Control: no-cache, no-transform`
- `X-Accel-Buffering: no`
- `Connection: keep-alive`

**TODO (deferred):** `?since=<ts>` replay of buffered events — requires an event-log ring buffer in the broker; punted to a future sub-issue as noted in handler comments.

## Closes / Refs

- Closes #1186
- Refs #1118 (epic)
- Depends on #1184 (broker, merged)

## Testing

- [x] All tests pass: `go test ./internal/progress/... ./internal/dashboard/...`
- [x] 7 new SSE-specific tests: event delivery, group isolation, wildcard endpoint (all groups), multiple concurrent subscribers, disconnect cleanup, 503 on missing broker, proxy headers
- [x] Existing broker tests unchanged and passing
- [x] Existing dashboard tests unchanged and passing

## Notes

The `enrichmentHealth` rename in `handlers_topology_detail.go` is a **pre-existing bug fix** — the package failed to compile on `main` before this PR. JSON field name (`"enrichment_health"`) is unchanged so there is no API break. The rename is internal only (`topicEnrichmentHealth`).