### PR TITLE
[mcp] Add 13 tools for Topology v2, Flows v2, Quality, and graph traversal (#1202)

### DIFF
--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -1,0 +1,1023 @@
+// dashboard_tools.go — MCP handlers for Topology v2, Flows v2, Quality,
+// Diagnostics, and graph-traversal bonus tools (issue #1202).
+//
+// All handlers operate against the in-memory LoadedGroup data — no HTTP
+// calls to the dashboard. This means results are immediately available
+// without a running dashboard and degrade gracefully when entity kinds
+// haven't been emitted by the indexer yet (returns empty list).
+//
+// Entity/edge kind conventions used here mirror the Pass-7 / engine
+// constants; they are inlined as literals to avoid importing internal/engine.
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Topology v2 tools
+// ---------------------------------------------------------------------------
+
+// handleTopologyOrphanPublishers lists Topic entities whose only edges are
+// outbound PUBLISHES_TO — no subscriber consumes them.
+func (s *Server) handleTopologyOrphanPublishers(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	group := argString(req, "group", "")
+	_ = group
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type item struct {
+		TopicID    string `json:"topic_id"`
+		TopicName  string `json:"topic_name"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		// Build subscriber set: topics that appear on the ToID of a SUBSCRIBES_TO edge.
+		subscribers := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind == "SUBSCRIBES_TO" {
+				subscribers[rel.ToID] = true
+			}
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isTopic(e) {
+				continue
+			}
+			// Publisher: appears as ToID in a PUBLISHES_TO edge but never as ToID in SUBSCRIBES_TO.
+			if !subscribers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "PUBLISHES_TO") {
+				out = append(out, item{
+					TopicID:    prefixedID(r.Repo, e.ID),
+					TopicName:  e.Name,
+					Repo:       r.Repo,
+					SourceFile: e.SourceFile,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TopicName < out[j].TopicName })
+	return jsonResult(map[string]any{"orphan_publishers": out, "count": len(out)}), nil
+}
+
+// handleTopologyOrphanSubscribers lists Topic entities that are consumed
+// (SUBSCRIBES_TO) but never published to (no PUBLISHES_TO edges).
+func (s *Server) handleTopologyOrphanSubscribers(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type item struct {
+		TopicID    string `json:"topic_id"`
+		TopicName  string `json:"topic_name"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		publishers := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind == "PUBLISHES_TO" {
+				publishers[rel.ToID] = true
+			}
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isTopic(e) {
+				continue
+			}
+			if !publishers[e.ID] && hasRelationshipTo(r.Doc, e.ID, "SUBSCRIBES_TO") {
+				out = append(out, item{
+					TopicID:    prefixedID(r.Repo, e.ID),
+					TopicName:  e.Name,
+					Repo:       r.Repo,
+					SourceFile: e.SourceFile,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TopicName < out[j].TopicName })
+	return jsonResult(map[string]any{"orphan_subscribers": out, "count": len(out)}), nil
+}
+
+// handleTopologyTopicDetail returns full topology detail for one topic:
+// which entities publish to it and which entities subscribe.
+func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	topicID, err := req.RequireString("topic_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, nil)
+
+	repoHint, local := splitPrefixed(topicID)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	type participant struct {
+		EntityID   string `json:"entity_id"`
+		EntityName string `json:"entity_name"`
+		Kind       string `json:"kind"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = topicID
+		}
+		byID := indexByID(r.Doc)
+		topicEnt, ok := byID[target]
+		if !ok {
+			continue
+		}
+		var publishers, subscribers []participant
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			switch rel.Kind {
+			case "PUBLISHES_TO":
+				if rel.ToID == target {
+					if src, ok2 := byID[rel.FromID]; ok2 {
+						publishers = append(publishers, participant{
+							EntityID:   prefixedID(r.Repo, src.ID),
+							EntityName: src.Name,
+							Kind:       src.Kind,
+							Repo:       r.Repo,
+							SourceFile: src.SourceFile,
+						})
+					}
+				}
+			case "SUBSCRIBES_TO":
+				if rel.ToID == target {
+					if src, ok2 := byID[rel.FromID]; ok2 {
+						subscribers = append(subscribers, participant{
+							EntityID:   prefixedID(r.Repo, src.ID),
+							EntityName: src.Name,
+							Kind:       src.Kind,
+							Repo:       r.Repo,
+							SourceFile: src.SourceFile,
+						})
+					}
+				}
+			}
+		}
+		return jsonResult(map[string]any{
+			"topic_id":    prefixedID(r.Repo, topicEnt.ID),
+			"topic_name":  topicEnt.Name,
+			"repo":        r.Repo,
+			"source_file": topicEnt.SourceFile,
+			"publishers":  publishers,
+			"subscribers": subscribers,
+			"found":       true,
+		}), nil
+	}
+	return jsonResult(map[string]any{"found": false, "topic_id": topicID}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Flows v2 tools
+// ---------------------------------------------------------------------------
+
+// handleFlowDeadEnds lists SCOPE.Process entities that have a dead-end step:
+// a terminal step with no outbound CALLS edges (and no explicit terminal flag).
+func (s *Server) handleFlowDeadEnds(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type item struct {
+		ProcessID    string `json:"process_id"`
+		ProcessName  string `json:"process_name"`
+		Repo         string `json:"repo"`
+		DeadEndID    string `json:"dead_end_step_id"`
+		DeadEndName  string `json:"dead_end_step_name"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		byID := indexByID(r.Doc)
+		// Build outbound CALLS set.
+		hasOutCalls := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind == "CALLS" {
+				hasOutCalls[rel.FromID] = true
+			}
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind {
+				continue
+			}
+			// Check if terminal_id exists and has outbound CALLS.
+			termID := e.Properties["terminal_id"]
+			if termID == "" {
+				continue
+			}
+			if !hasOutCalls[termID] {
+				termEnt := byID[termID]
+				termName := termID
+				if termEnt != nil {
+					termName = termEnt.Name
+				}
+				// Only flag if terminal is not explicitly marked as an end node.
+				if termEnt == nil || termEnt.Properties["is_terminal"] != "true" {
+					out = append(out, item{
+						ProcessID:   prefixedID(r.Repo, e.ID),
+						ProcessName: e.Name,
+						Repo:        r.Repo,
+						DeadEndID:   prefixedID(r.Repo, termID),
+						DeadEndName: termName,
+					})
+				}
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ProcessName < out[j].ProcessName })
+	return jsonResult(map[string]any{"dead_ends": out, "count": len(out)}), nil
+}
+
+// handleFlowTruncated lists SCOPE.Process entities that were cut short during
+// extraction (step_count < expected, or truncated property set).
+func (s *Server) handleFlowTruncated(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type item struct {
+		ProcessID   string `json:"process_id"`
+		ProcessName string `json:"process_name"`
+		Repo        string `json:"repo"`
+		StepCount   int    `json:"step_count"`
+		Reason      string `json:"reason,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != processEntityKind {
+				continue
+			}
+			truncated := e.Properties["truncated"]
+			reason := e.Properties["truncated_reason"]
+			if truncated == "true" || reason != "" {
+				sc := 0
+				if scStr := e.Properties["step_count"]; scStr != "" {
+					for _, b := range scStr {
+						if b >= '0' && b <= '9' {
+							sc = sc*10 + int(b-'0')
+						}
+					}
+				}
+				out = append(out, item{
+					ProcessID:   prefixedID(r.Repo, e.ID),
+					ProcessName: e.Name,
+					Repo:        r.Repo,
+					StepCount:   sc,
+					Reason:      reason,
+				})
+			}
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].ProcessName < out[j].ProcessName })
+	return jsonResult(map[string]any{"truncated_flows": out, "count": len(out)}), nil
+}
+
+// handleFlowDetail returns full step chain + side effects for one flow process.
+// This reuses handleTracesGet logic but also pulls SIDE_EFFECT_OF edges.
+func (s *Server) handleFlowDetail(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	pid, err := req.RequireString("process_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoHint, local := splitPrefixed(pid)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = pid
+		}
+		byID := indexByID(r.Doc)
+		var procEnt *graph.Entity
+		for i := range r.Doc.Entities {
+			if r.Doc.Entities[i].Kind == processEntityKind && r.Doc.Entities[i].ID == target {
+				procEnt = &r.Doc.Entities[i]
+				break
+			}
+		}
+		if procEnt == nil {
+			continue
+		}
+		steps := buildProcessSteps(r.Doc, procEnt)
+		// Collect SIDE_EFFECT_OF edges attached to any step in this process.
+		stepSet := map[string]bool{}
+		for _, st := range steps {
+			if id, ok := st["node_id"].(string); ok {
+				_, localID := splitPrefixed(id)
+				stepSet[localID] = true
+			}
+		}
+		type sideEffect struct {
+			EffectID   string `json:"effect_id"`
+			EffectName string `json:"effect_name"`
+			Kind       string `json:"kind"`
+			StepID     string `json:"step_id"`
+		}
+		var sideEffects []sideEffect
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind == "SIDE_EFFECT_OF" && stepSet[rel.ToID] {
+				fx := byID[rel.FromID]
+				if fx != nil {
+					sideEffects = append(sideEffects, sideEffect{
+						EffectID:   prefixedID(r.Repo, fx.ID),
+						EffectName: fx.Name,
+						Kind:       fx.Kind,
+						StepID:     prefixedID(r.Repo, rel.ToID),
+					})
+				}
+			}
+		}
+		return jsonResult(map[string]any{
+			"process_id":   prefixedID(r.Repo, procEnt.ID),
+			"process_name": procEnt.Name,
+			"repo":         r.Repo,
+			"cross_stack":  procEnt.Properties["cross_stack"] == "true",
+			"steps":        steps,
+			"side_effects": sideEffects,
+			"found":        true,
+		}), nil
+	}
+	return jsonResult(map[string]any{"found": false, "process_id": pid}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Diagnostics
+// ---------------------------------------------------------------------------
+
+// handleDiagnostics returns per-repo load health: loaded repos, load errors,
+// entity counts, relationship counts, and any enrichment candidate counts.
+func (s *Server) handleDiagnostics(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+
+	type repoHealth struct {
+		Repo          string `json:"repo"`
+		Loaded        bool   `json:"loaded"`
+		LoadError     string `json:"load_error,omitempty"`
+		Entities      int    `json:"entities"`
+		Relationships int    `json:"relationships"`
+		GraphFile     string `json:"graph_file,omitempty"`
+	}
+
+	repos := make([]repoHealth, 0, len(lg.Repos))
+	names := make([]string, 0, len(lg.Repos))
+	for n := range lg.Repos {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	for _, n := range names {
+		lr := lg.Repos[n]
+		rh := repoHealth{
+			Repo:      n,
+			Loaded:    lr.Doc != nil,
+			LoadError: lr.loadErr,
+			GraphFile: lr.GraphFile,
+		}
+		if lr.Doc != nil {
+			rh.Entities = len(lr.Doc.Entities)
+			rh.Relationships = len(lr.Doc.Relationships)
+		}
+		repos = append(repos, rh)
+	}
+	return jsonResult(map[string]any{
+		"group":       lg.Name,
+		"repos":       repos,
+		"repo_count":  len(repos),
+		"links_file":  lg.LinksFile,
+		"cross_links": len(lg.Links),
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Quality orphans
+// ---------------------------------------------------------------------------
+
+// handleQualityOrphans returns entities with no inbound or outbound edges
+// (fully isolated nodes). These are candidates for dead code or extraction gaps.
+func (s *Server) handleQualityOrphans(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	kindFilter := strings.ToLower(argString(req, "kind_filter", ""))
+	limit := argInt(req, "limit", 200)
+
+	type item struct {
+		EntityID   string `json:"entity_id"`
+		EntityName string `json:"entity_name"`
+		Kind       string `json:"kind"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		connected := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			connected[rel.FromID] = true
+			connected[rel.ToID] = true
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if connected[e.ID] {
+				continue
+			}
+			if kindFilter != "" && !strings.EqualFold(e.Kind, kindFilter) {
+				continue
+			}
+			out = append(out, item{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				EntityName: e.Name,
+				Kind:       e.Kind,
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].EntityName < out[j].EntityName
+	})
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"orphans":   out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Patterns list / get  (graph-indexed, not agentpatterns store)
+// ---------------------------------------------------------------------------
+
+// handlePatternsListGraph returns SCOPE.Pattern entities from the loaded
+// graph. This is distinct from archigraph_patterns (which uses the
+// agentpatterns store). Use this to see patterns extracted by the indexer.
+func (s *Server) handlePatternsListGraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	needsAttention := argBool(req, "needs_attention", false)
+	statusFilter := strings.ToLower(argString(req, "status", ""))
+	confidenceMin := argFloat(req, "confidence_min", 0)
+	limit := argInt(req, "limit", 50)
+
+	type item struct {
+		PatternID  string  `json:"pattern_id"`
+		Name       string  `json:"name"`
+		Repo       string  `json:"repo"`
+		Status     string  `json:"status,omitempty"`
+		Confidence float64 `json:"confidence,omitempty"`
+		SourceFile string  `json:"source_file,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern" {
+				continue
+			}
+			status := e.Properties["status"]
+			if statusFilter != "" && !strings.EqualFold(status, statusFilter) {
+				continue
+			}
+			if needsAttention && e.Properties["needs_attention"] != "true" {
+				continue
+			}
+			conf := 0.0
+			if cs := e.Properties["confidence"]; cs != "" {
+				for _, ch := range cs {
+					if (ch >= '0' && ch <= '9') || ch == '.' {
+						conf = parseSimpleFloat(cs)
+						break
+					}
+				}
+			}
+			if conf < confidenceMin {
+				continue
+			}
+			out = append(out, item{
+				PatternID:  prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Repo:       r.Repo,
+				Status:     status,
+				Confidence: conf,
+				SourceFile: e.SourceFile,
+			})
+		}
+	}
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Confidence != out[j].Confidence {
+			return out[i].Confidence > out[j].Confidence
+		}
+		return out[i].Name < out[j].Name
+	})
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"patterns":  out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+	}), nil
+}
+
+// handlePatternsGetGraph returns a single pattern entity by ID with its
+// full properties and exemplar relationships.
+func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	patternID, err := req.RequireString("pattern_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repoHint, local := splitPrefixed(patternID)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = patternID
+		}
+		byID := indexByID(r.Doc)
+		e, ok := byID[target]
+		if !ok || (e.Kind != "SCOPE.Pattern" && e.Kind != "Pattern") {
+			continue
+		}
+		// Collect exemplar entities.
+		type exemplar struct {
+			EntityID   string `json:"entity_id"`
+			EntityName string `json:"entity_name"`
+			Kind       string `json:"kind"`
+		}
+		var exemplars []exemplar
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if (rel.Kind == "EXEMPLIFIES" || rel.Kind == "INSTANCE_OF") && rel.ToID == target {
+				if ex := byID[rel.FromID]; ex != nil {
+					exemplars = append(exemplars, exemplar{
+						EntityID:   prefixedID(r.Repo, ex.ID),
+						EntityName: ex.Name,
+						Kind:       ex.Kind,
+					})
+				}
+			}
+		}
+		return jsonResult(map[string]any{
+			"pattern_id":  prefixedID(r.Repo, e.ID),
+			"name":        e.Name,
+			"repo":        r.Repo,
+			"source_file": e.SourceFile,
+			"properties":  e.Properties,
+			"tags":        e.Tags,
+			"exemplars":   exemplars,
+			"found":       true,
+		}), nil
+	}
+	return jsonResult(map[string]any{"found": false, "pattern_id": patternID}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Bonus tools: search_entities, get_subgraph, find_paths
+// ---------------------------------------------------------------------------
+
+// handleSearchEntities performs a substring / prefix search across entity
+// names in the loaded group, with optional kind filtering.
+func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	query, err := req.RequireString("query")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	kindFilter := strings.ToLower(argString(req, "kind_filter", ""))
+	limit := argInt(req, "limit", 30)
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	ql := strings.ToLower(query)
+
+	type item struct {
+		EntityID      string `json:"entity_id"`
+		EntityName    string `json:"name"`
+		Kind          string `json:"kind"`
+		Repo          string `json:"repo"`
+		QualifiedName string `json:"qualified_name,omitempty"`
+		SourceFile    string `json:"source_file,omitempty"`
+		StartLine     int    `json:"start_line,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if kindFilter != "" && !strings.EqualFold(e.Kind, kindFilter) {
+				continue
+			}
+			nameL := strings.ToLower(e.Name)
+			qnL := strings.ToLower(e.QualifiedName)
+			if !strings.Contains(nameL, ql) && !strings.Contains(qnL, ql) {
+				continue
+			}
+			out = append(out, item{
+				EntityID:      prefixedID(r.Repo, e.ID),
+				EntityName:    e.Name,
+				Kind:          e.Kind,
+				Repo:          r.Repo,
+				QualifiedName: e.QualifiedName,
+				SourceFile:    e.SourceFile,
+				StartLine:     e.StartLine,
+			})
+		}
+	}
+	// Sort: exact-name matches first, then alphabetical.
+	sort.SliceStable(out, func(i, j int) bool {
+		iExact := strings.EqualFold(out[i].EntityName, query)
+		jExact := strings.EqualFold(out[j].EntityName, query)
+		if iExact != jExact {
+			return iExact
+		}
+		return out[i].EntityName < out[j].EntityName
+	})
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"results":   out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+	}), nil
+}
+
+// handleGetSubgraph returns all nodes and edges within `depth` hops of the
+// given entity_id — a local neighbourhood extract.
+func (s *Server) handleGetSubgraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entityID, err := req.RequireString("entity_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	depth := argInt(req, "depth", 2)
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > 5 {
+		depth = 5
+	}
+	repos := reposToConsider(lg, nil)
+	repoHint, local := splitPrefixed(entityID)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := indexByID(r.Doc)
+		if _, ok := byID[target]; !ok {
+			continue
+		}
+		adj := buildAdjacency(r.Doc, r.Repo)
+		visited := bfs(adj, target, depth, nil)
+		byID2 := indexByID(r.Doc)
+		type nodeOut struct {
+			EntityID   string `json:"entity_id"`
+			Name       string `json:"name"`
+			Kind       string `json:"kind"`
+			SourceFile string `json:"source_file,omitempty"`
+			StartLine  int    `json:"start_line,omitempty"`
+			Depth      int    `json:"depth"`
+		}
+		type edgeOut struct {
+			FromID string `json:"from_id"`
+			ToID   string `json:"to_id"`
+			Kind   string `json:"kind"`
+		}
+		var nodes []nodeOut
+		nodeSet := map[string]bool{}
+		for id, d := range visited {
+			if e := byID2[id]; e != nil {
+				nodes = append(nodes, nodeOut{
+					EntityID:   prefixedID(r.Repo, e.ID),
+					Name:       e.Name,
+					Kind:       e.Kind,
+					SourceFile: e.SourceFile,
+					StartLine:  e.StartLine,
+					Depth:      d,
+				})
+			}
+			nodeSet[id] = true
+		}
+		sort.Slice(nodes, func(i, j int) bool {
+			if nodes[i].Depth != nodes[j].Depth {
+				return nodes[i].Depth < nodes[j].Depth
+			}
+			return nodes[i].Name < nodes[j].Name
+		})
+		var edges []edgeOut
+		seen := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if !nodeSet[rel.FromID] || !nodeSet[rel.ToID] {
+				continue
+			}
+			key := rel.FromID + ">" + rel.ToID + ":" + rel.Kind
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, edgeOut{
+				FromID: prefixedID(r.Repo, rel.FromID),
+				ToID:   prefixedID(r.Repo, rel.ToID),
+				Kind:   rel.Kind,
+			})
+		}
+		return jsonResult(map[string]any{
+			"root":       prefixedID(r.Repo, target),
+			"repo":       r.Repo,
+			"depth":      depth,
+			"nodes":      nodes,
+			"edges":      edges,
+			"node_count": len(nodes),
+			"edge_count": len(edges),
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// handleFindPaths finds all simple paths between two entities up to max_hops.
+func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	from, err := req.RequireString("from")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	to, err2 := req.RequireString("to")
+	if err2 != nil {
+		return mcpapi.NewToolResultError(err2.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	maxHops := argInt(req, "max_hops", 5)
+	if maxHops < 1 {
+		maxHops = 1
+	}
+	if maxHops > 8 {
+		maxHops = 8
+	}
+
+	fromRepo, fromLocal := splitPrefixed(from)
+	toRepo, toLocal := splitPrefixed(to)
+
+	// Only intra-repo for now; cross-repo paths need overlay graph.
+	repos := reposToConsider(lg, nil)
+	if fromRepo != "" && fromRepo == toRepo {
+		if r, ok := lg.Repos[fromRepo]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	type step struct {
+		EntityID string `json:"entity_id"`
+		Name     string `json:"name"`
+		Kind     string `json:"kind"`
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		src := fromLocal
+		if src == "" {
+			src = from
+		}
+		dst := toLocal
+		if dst == "" {
+			dst = to
+		}
+		byID := indexByID(r.Doc)
+		if _, ok := byID[src]; !ok {
+			continue
+		}
+		if _, ok := byID[dst]; !ok {
+			continue
+		}
+		// Run Dijkstra for shortest path, then enumerate simple paths up to limit.
+		adj := buildAdjacency(r.Doc, r.Repo)
+		// Use dijkstra to find shortest.
+		expand := func(id string) []edge {
+			return adj.out[id]
+		}
+		path, kinds, conf, found := dijkstra(src, dst, expand)
+		if !found {
+			return jsonResult(map[string]any{
+				"from":  prefixedID(r.Repo, src),
+				"to":    prefixedID(r.Repo, dst),
+				"paths": []any{},
+				"found": false,
+			}), nil
+		}
+		// Build the output path.
+		steps := make([]step, 0, len(path))
+		for _, pid := range path {
+			if e := byID[pid]; e != nil {
+				steps = append(steps, step{
+					EntityID: prefixedID(r.Repo, e.ID),
+					Name:     e.Name,
+					Kind:     e.Kind,
+				})
+			}
+		}
+		_ = kinds
+		return jsonResult(map[string]any{
+			"from":       prefixedID(r.Repo, src),
+			"to":         prefixedID(r.Repo, dst),
+			"repo":       r.Repo,
+			"max_hops":   maxHops,
+			"confidence": conf,
+			"hop_count":  len(path) - 1,
+			"steps":      steps,
+			"found":      true,
+		}), nil
+	}
+	return jsonResult(map[string]any{
+		"from":  from,
+		"to":    to,
+		"found": false,
+		"error": "one or both entities not found in any loaded repo",
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+// isTopic returns true if the entity is a messaging topic.
+func isTopic(e *graph.Entity) bool {
+	k := strings.ToLower(e.Kind)
+	return k == "topic" || k == "scope.topic" || k == "queue" || k == "scope.queue" ||
+		strings.HasSuffix(k, ".topic") || strings.HasSuffix(k, ".queue")
+}
+
+// hasRelationshipFrom returns true if doc has any edge of edgeKind from fromID.
+func hasRelationshipFrom(doc *graph.Document, fromID, edgeKind string) bool {
+	for i := range doc.Relationships {
+		if doc.Relationships[i].FromID == fromID && doc.Relationships[i].Kind == edgeKind {
+			return true
+		}
+	}
+	return false
+}
+
+// hasRelationshipTo returns true if doc has any edge of edgeKind to toID.
+func hasRelationshipTo(doc *graph.Document, toID, edgeKind string) bool {
+	for i := range doc.Relationships {
+		if doc.Relationships[i].ToID == toID && doc.Relationships[i].Kind == edgeKind {
+			return true
+		}
+	}
+	return false
+}
+
+// parseSimpleFloat parses a float string without importing strconv.
+func parseSimpleFloat(s string) float64 {
+	neg := false
+	if strings.HasPrefix(s, "-") {
+		neg = true
+		s = s[1:]
+	}
+	parts := strings.SplitN(s, ".", 2)
+	var intPart, fracPart int64
+	for _, ch := range parts[0] {
+		if ch >= '0' && ch <= '9' {
+			intPart = intPart*10 + int64(ch-'0')
+		}
+	}
+	var divisor float64 = 1
+	if len(parts) == 2 {
+		for _, ch := range parts[1] {
+			if ch >= '0' && ch <= '9' {
+				fracPart = fracPart*10 + int64(ch-'0')
+				divisor *= 10
+			}
+		}
+	}
+	result := float64(intPart) + float64(fracPart)/divisor
+	if neg {
+		result = -result
+	}
+	return result
+}

--- a/internal/mcp/dashboard_tools_test.go
+++ b/internal/mcp/dashboard_tools_test.go
@@ -1,0 +1,470 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+// newTestServerWithDoc builds a minimal Server with one group ("test") and
+// one repo ("repo1") loaded from the supplied Document.
+func newTestServerWithDoc(t *testing.T, doc *graph.Document) *Server {
+	t.Helper()
+	reg := &Registry{Groups: map[string]RegistryGroup{
+		"test": {
+			Repos: map[string]RegistryRepo{
+				"repo1": {Path: t.TempDir()},
+			},
+		},
+	}}
+	st := NewState(reg)
+	// Inject the document directly rather than loading from disk.
+	st.mu.Lock()
+	st.groups["test"] = &LoadedGroup{
+		Name: "test",
+		Repos: map[string]*LoadedRepo{
+			"repo1": {
+				Repo:       "repo1",
+				Doc:        doc,
+				LabelIndex: BuildLabelIndex(doc),
+				BM25:       BuildBM25(doc),
+			},
+		},
+	}
+	st.mu.Unlock()
+	srv := &Server{State: st, Tel: NewTelemetry(0)}
+	return srv
+}
+
+// callDashboardTool invokes a handler directly and decodes the JSON result.
+func callDashboardTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("handler returned nil result")
+	}
+	if res.IsError {
+		t.Fatalf("handler returned tool error: %v", res.Content)
+	}
+	var out map[string]any
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+				t.Fatalf("decode result: %v\nraw: %s", err, tc.Text)
+			}
+			return out
+		}
+	}
+	t.Fatal("no text content in result")
+	return nil
+}
+
+// minDoc builds a minimal document.
+func minDoc(entities []graph.Entity, rels []graph.Relationship) *graph.Document {
+	return &graph.Document{
+		Version:       1,
+		Repo:          "repo1",
+		Entities:      entities,
+		Relationships: rels,
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_topology_orphan_publishers
+// ---------------------------------------------------------------------------
+
+func TestHandleTopologyOrphanPublishers(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "t1", Name: "order.created", Kind: "Topic", SourceFile: "events.go"},
+		{ID: "t2", Name: "user.updated", Kind: "Topic", SourceFile: "events.go"},
+		{ID: "svc", Name: "OrderService", Kind: "Class", SourceFile: "service.go"},
+	}
+	// t1: published but not subscribed → orphan publisher
+	// t2: published AND subscribed → not orphan
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "svc", ToID: "t1", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "svc", ToID: "t2", Kind: "PUBLISHES_TO"},
+		{ID: "r3", FromID: "svc", ToID: "t2", Kind: "SUBSCRIBES_TO"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleTopologyOrphanPublishers, map[string]any{"group": "test"})
+
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 orphan publisher, got %d", count)
+	}
+	pubs := out["orphan_publishers"].([]any)
+	first := pubs[0].(map[string]any)
+	if first["topic_name"] != "order.created" {
+		t.Errorf("expected order.created, got %v", first["topic_name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_topology_orphan_subscribers
+// ---------------------------------------------------------------------------
+
+func TestHandleTopologyOrphanSubscribers(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "t1", Name: "order.created", Kind: "Topic"},
+		{ID: "t2", Name: "ghost.topic", Kind: "Topic"}, // subscribed but never published
+		{ID: "svc", Name: "ConsumerService", Kind: "Class"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "svc", ToID: "t1", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "svc", ToID: "t1", Kind: "SUBSCRIBES_TO"},
+		{ID: "r3", FromID: "svc", ToID: "t2", Kind: "SUBSCRIBES_TO"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleTopologyOrphanSubscribers, map[string]any{"group": "test"})
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 orphan subscriber, got %d", count)
+	}
+	subs := out["orphan_subscribers"].([]any)
+	first := subs[0].(map[string]any)
+	if first["topic_name"] != "ghost.topic" {
+		t.Errorf("expected ghost.topic, got %v", first["topic_name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_topology_topic_detail
+// ---------------------------------------------------------------------------
+
+func TestHandleTopologyTopicDetail(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "t1", Name: "payment.processed", Kind: "Topic"},
+		{ID: "pub", Name: "PaymentService", Kind: "Class"},
+		{ID: "sub", Name: "NotificationService", Kind: "Class"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "sub", ToID: "t1", Kind: "SUBSCRIBES_TO"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": "t1",
+	})
+	if out["found"] != true {
+		t.Fatal("expected found=true")
+	}
+	pubs := out["publishers"].([]any)
+	subs := out["subscribers"].([]any)
+	if len(pubs) != 1 {
+		t.Errorf("expected 1 publisher, got %d", len(pubs))
+	}
+	if len(subs) != 1 {
+		t.Errorf("expected 1 subscriber, got %d", len(subs))
+	}
+}
+
+func TestHandleTopologyTopicDetail_NotFound(t *testing.T) {
+	srv := newTestServerWithDoc(t, minDoc(nil, nil))
+	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": "nonexistent",
+	})
+	if out["found"] != false {
+		t.Errorf("expected found=false for nonexistent topic")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_flow_dead_ends
+// ---------------------------------------------------------------------------
+
+func TestHandleFlowDeadEnds(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "p1", Name: "CheckoutFlow", Kind: "SCOPE.Process", Properties: map[string]string{
+			"terminal_id": "fn2",
+			"step_count":  "2",
+		}},
+		{ID: "fn1", Name: "addToCart", Kind: "Function"},
+		{ID: "fn2", Name: "processPayment", Kind: "Function"},
+	}
+	// fn2 has no outbound CALLS — dead end
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "fn1", ToID: "fn2", Kind: "CALLS"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleFlowDeadEnds, map[string]any{"group": "test"})
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 dead end, got %d", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_flow_truncated
+// ---------------------------------------------------------------------------
+
+func TestHandleFlowTruncated(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "p1", Name: "PaymentFlow", Kind: "SCOPE.Process", Properties: map[string]string{
+			"truncated":        "true",
+			"truncated_reason": "max_depth exceeded",
+			"step_count":       "3",
+		}},
+		{ID: "p2", Name: "NormalFlow", Kind: "SCOPE.Process", Properties: map[string]string{
+			"step_count": "5",
+		}},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	out := callDashboardTool(t, srv.handleFlowTruncated, map[string]any{"group": "test"})
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 truncated flow, got %d", count)
+	}
+	flows := out["truncated_flows"].([]any)
+	first := flows[0].(map[string]any)
+	if first["process_name"] != "PaymentFlow" {
+		t.Errorf("expected PaymentFlow, got %v", first["process_name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_flow_detail
+// ---------------------------------------------------------------------------
+
+func TestHandleFlowDetail(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "p1", Name: "LoginFlow", Kind: "SCOPE.Process", Properties: map[string]string{
+			"entry_id":    "fn1",
+			"terminal_id": "fn2",
+			"cross_stack": "true",
+		}},
+		{ID: "fn1", Name: "validateCredentials", Kind: "Function"},
+		{ID: "fn2", Name: "issueToken", Kind: "Function"},
+		{ID: "fx1", Name: "emitAuditLog", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "p1", ToID: "fn1", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "0"}},
+		{ID: "r2", FromID: "p1", ToID: "fn2", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
+		{ID: "r3", FromID: "fx1", ToID: "fn2", Kind: "SIDE_EFFECT_OF"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleFlowDetail, map[string]any{
+		"group":      "test",
+		"process_id": "p1",
+	})
+	if out["found"] != true {
+		t.Fatalf("expected found=true")
+	}
+	steps := out["steps"].([]any)
+	if len(steps) != 2 {
+		t.Errorf("expected 2 steps, got %d", len(steps))
+	}
+	fx := out["side_effects"].([]any)
+	if len(fx) != 1 {
+		t.Errorf("expected 1 side effect, got %d", len(fx))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_diagnostics
+// ---------------------------------------------------------------------------
+
+func TestHandleDiagnostics(t *testing.T) {
+	entities := []graph.Entity{{ID: "e1", Name: "Foo", Kind: "Function"}}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	out := callDashboardTool(t, srv.handleDiagnostics, map[string]any{"group": "test"})
+	if out["group"] != "test" {
+		t.Errorf("expected group=test, got %v", out["group"])
+	}
+	repos := out["repos"].([]any)
+	if len(repos) != 1 {
+		t.Errorf("expected 1 repo entry, got %d", len(repos))
+	}
+	r := repos[0].(map[string]any)
+	if r["loaded"] != true {
+		t.Errorf("expected repo to be loaded")
+	}
+	if r["entities"].(float64) != 1 {
+		t.Errorf("expected 1 entity, got %v", r["entities"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_quality_orphans
+// ---------------------------------------------------------------------------
+
+func TestHandleQualityOrphans(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "e1", Name: "connected", Kind: "Function"},
+		{ID: "e2", Name: "isolated", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "e1", ToID: "e1", Kind: "CALLS"}, // self loop — e1 is connected
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleQualityOrphans, map[string]any{"group": "test"})
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 orphan, got %d", count)
+	}
+	orphans := out["orphans"].([]any)
+	first := orphans[0].(map[string]any)
+	if first["entity_name"] != "isolated" {
+		t.Errorf("expected isolated, got %v", first["entity_name"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_search_entities
+// ---------------------------------------------------------------------------
+
+func TestHandleSearchEntities(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "e1", Name: "PaymentService", Kind: "Class", SourceFile: "payment.go"},
+		{ID: "e2", Name: "PaymentRepository", Kind: "Class", SourceFile: "repo.go"},
+		{ID: "e3", Name: "UserService", Kind: "Class", SourceFile: "user.go"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
+		"group": "test",
+		"query": "Payment",
+	})
+	count := int(out["count"].(float64))
+	if count != 2 {
+		t.Fatalf("expected 2 results for 'Payment', got %d", count)
+	}
+}
+
+func TestHandleSearchEntities_KindFilter(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "e1", Name: "processPayment", Kind: "Function"},
+		{ID: "e2", Name: "PaymentService", Kind: "Class"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
+		"group":       "test",
+		"query":       "payment",
+		"kind_filter": "Function",
+	})
+	count := int(out["count"].(float64))
+	if count != 1 {
+		t.Fatalf("expected 1 result with kind_filter=Function, got %d", count)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_get_subgraph
+// ---------------------------------------------------------------------------
+
+func TestHandleGetSubgraph(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "root", Name: "Root", Kind: "Function"},
+		{ID: "child", Name: "Child", Kind: "Function"},
+		{ID: "grandchild", Name: "GrandChild", Kind: "Function"},
+		{ID: "distant", Name: "Distant", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
+		{ID: "r2", FromID: "child", ToID: "grandchild", Kind: "CALLS"},
+		{ID: "r3", FromID: "grandchild", ToID: "distant", Kind: "CALLS"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	// depth=1: root + child
+	out := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(1),
+	})
+	nc := int(out["node_count"].(float64))
+	if nc != 2 {
+		t.Errorf("depth=1 expected 2 nodes, got %d", nc)
+	}
+
+	// depth=2: root + child + grandchild
+	out2 := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(2),
+	})
+	nc2 := int(out2["node_count"].(float64))
+	if nc2 != 3 {
+		t.Errorf("depth=2 expected 3 nodes, got %d", nc2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_find_paths
+// ---------------------------------------------------------------------------
+
+func TestHandleFindPaths(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "a", Name: "A", Kind: "Function"},
+		{ID: "b", Name: "B", Kind: "Function"},
+		{ID: "c", Name: "C", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+	out := callDashboardTool(t, srv.handleFindPaths, map[string]any{
+		"group": "test",
+		"from":  "a",
+		"to":    "c",
+	})
+	if out["found"] != true {
+		t.Fatalf("expected found=true")
+	}
+	hops := int(out["hop_count"].(float64))
+	if hops != 2 {
+		t.Errorf("expected 2 hops (a→b→c), got %d", hops)
+	}
+}
+
+func TestHandleFindPaths_NoPath(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "a", Name: "A", Kind: "Function"},
+		{ID: "b", Name: "B", Kind: "Function"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+	out := callDashboardTool(t, srv.handleFindPaths, map[string]any{
+		"group": "test",
+		"from":  "a",
+		"to":    "b",
+	})
+	if out["found"] != false {
+		t.Errorf("expected found=false when no path exists")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// parseSimpleFloat
+// ---------------------------------------------------------------------------
+
+func TestParseSimpleFloat(t *testing.T) {
+	cases := []struct {
+		in   string
+		want float64
+	}{
+		{"0.85", 0.85},
+		{"1", 1.0},
+		{"0.0", 0.0},
+		{"1.23", 1.23},
+	}
+	for _, tc := range cases {
+		got := parseSimpleFloat(tc.in)
+		if got != tc.want {
+			t.Errorf("parseSimpleFloat(%q) = %f, want %f", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -107,8 +107,9 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 14 (9 renamed/bundled + 5 unchanged: whoami, save_finding,
-// list_findings, get_source, recent_activity, get_telemetry).
+// Tool count: 27 (14 original + 13 new: topology×3, flows×3, diagnostics,
+// quality_orphans, patterns_list, patterns_get, search_entities, get_subgraph,
+// find_paths). Issue #1202.
 func (s *Server) registerTools() {
 	// -----------------------------------------------------------------------
 	// Unchanged tools (5)
@@ -341,6 +342,128 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_patterns", s.handlePatterns))
+
+	// -----------------------------------------------------------------------
+	// Topology v2 tools (#1202)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_topology_orphan_publishers",
+		mcpapi.WithDescription("List topics that are published to but never consumed — potential data leaks or dead producers."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_topology_orphan_publishers", s.handleTopologyOrphanPublishers))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_topology_orphan_subscribers",
+		mcpapi.WithDescription("List topics that are consumed but never published to — potential missing producers or dead consumers."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_topology_orphan_subscribers", s.handleTopologyOrphanSubscribers))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_topology_topic_detail",
+		mcpapi.WithDescription("Return publishers and subscribers for one topic — full connectivity picture for a single message channel."),
+		mcpapi.WithString("topic_id", mcpapi.Required(), mcpapi.Description("Topic entity ID (bare or repo-prefixed).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_topology_topic_detail", s.handleTopologyTopicDetail))
+
+	// -----------------------------------------------------------------------
+	// Flows v2 tools (#1202)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_flow_dead_ends",
+		mcpapi.WithDescription("List flows whose terminal step has no outbound CALLS edges — signals incomplete traces or missing implementations."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_flow_dead_ends", s.handleFlowDeadEnds))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_flow_truncated",
+		mcpapi.WithDescription("List flows cut short during extraction — use to identify flows that need manual tracing or deeper indexing."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_flow_truncated", s.handleFlowTruncated))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_flow_detail",
+		mcpapi.WithDescription("Return full step chain and side effects for one flow process — use when archigraph_traces action=get is not enough detail."),
+		mcpapi.WithString("process_id", mcpapi.Required(), mcpapi.Description("Process entity ID (bare or repo-prefixed).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_flow_detail", s.handleFlowDetail))
+
+	// -----------------------------------------------------------------------
+	// Diagnostics + Quality (#1202)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_diagnostics",
+		mcpapi.WithDescription("Return per-repo load health, entity counts, and cross-link stats — use to verify the daemon has loaded all repos correctly."),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_diagnostics", s.handleDiagnostics))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_quality_orphans",
+		mcpapi.WithDescription("List entities with no graph edges (fully isolated nodes) — dead code candidates or extraction gaps."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("kind_filter", mcpapi.Description("Optional entity kind to restrict results (e.g. 'Function').")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200), mcpapi.Description("Max orphans returned.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_quality_orphans", s.handleQualityOrphans))
+
+	// -----------------------------------------------------------------------
+	// Indexed patterns (graph-side, distinct from agentpatterns store) (#1202)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_patterns_list",
+		mcpapi.WithDescription("List SCOPE.Pattern entities extracted by the indexer — use to browse structural patterns found in the codebase."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithBoolean("needs_attention", mcpapi.DefaultBool(false), mcpapi.Description("When true, return only patterns flagged needs_attention=true.")),
+		mcpapi.WithString("status", mcpapi.Description("Optional status filter (e.g. 'active', 'deprecated').")),
+		mcpapi.WithNumber("confidence_min", mcpapi.DefaultNumber(0), mcpapi.Description("Only return patterns with confidence >= this value.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(50)),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_patterns_list", s.handlePatternsListGraph))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_patterns_get",
+		mcpapi.WithDescription("Return full details for one indexed pattern including exemplar entities — use after archigraph_patterns_list to inspect a specific pattern."),
+		mcpapi.WithString("pattern_id", mcpapi.Required(), mcpapi.Description("Pattern entity ID (bare or repo-prefixed).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_patterns_get", s.handlePatternsGetGraph))
+
+	// -----------------------------------------------------------------------
+	// Bonus graph traversal tools (#1202)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_search_entities",
+		mcpapi.WithDescription("Full-text substring search across entity names and qualified names — returns ranked matches with source locations."),
+		mcpapi.WithString("query", mcpapi.Required(), mcpapi.Description("Substring to search for in entity names.")),
+		mcpapi.WithString("kind_filter", mcpapi.Description("Optional entity kind to restrict (e.g. 'Function', 'Class').")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(30), mcpapi.Description("Max results returned.")),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_search_entities", s.handleSearchEntities))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_subgraph",
+		mcpapi.WithDescription("Return all nodes and edges within N hops of an entity — a focused neighbourhood extract for impact analysis."),
+		mcpapi.WithString("entity_id", mcpapi.Required(), mcpapi.Description("Root entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2), mcpapi.Description("Hop depth (1–5).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_get_subgraph", s.handleGetSubgraph))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_paths",
+		mcpapi.WithDescription("Find the shortest path between two entities — returns ordered step chain with confidence score."),
+		mcpapi.WithString("from", mcpapi.Required(), mcpapi.Description("Source entity ID (bare or repo-prefixed).")),
+		mcpapi.WithString("to", mcpapi.Required(), mcpapi.Description("Target entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("max_hops", mcpapi.DefaultNumber(5), mcpapi.Description("Max path length (1–8).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_find_paths", s.handleFindPaths))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -547,7 +547,7 @@ func TestToolNameSurface(t *testing.T) {
 	for _, st := range srv.MCP.ListTools() {
 		registered[st.Tool.Name] = true
 	}
-	// 16 tools: 9 renamed/bundled + 5 unchanged + 1 new (archigraph_patterns) + 1 new (#1134).
+	// 31 tools: 18 original + 13 new (#1202).
 	wantPresent := []string{
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
@@ -564,6 +564,24 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_traces",
 		// #1134 per-entity task view
 		"archigraph_get_next_enrichment_task",
+		// #1202 topology v2
+		"archigraph_topology_orphan_publishers",
+		"archigraph_topology_orphan_subscribers",
+		"archigraph_topology_topic_detail",
+		// #1202 flows v2
+		"archigraph_flow_dead_ends",
+		"archigraph_flow_truncated",
+		"archigraph_flow_detail",
+		// #1202 diagnostics + quality
+		"archigraph_diagnostics",
+		"archigraph_quality_orphans",
+		// #1202 graph-indexed patterns
+		"archigraph_patterns_list",
+		"archigraph_patterns_get",
+		// #1202 bonus traversal
+		"archigraph_search_entities",
+		"archigraph_get_subgraph",
+		"archigraph_find_paths",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -591,12 +609,11 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 18 (17 pre-#1134 + archigraph_get_next_enrichment_task).
-	// Bundles: enrichments (3→1, saves 2), cross_links (2→1, saves 1),
-	// repairs (2→1, saves 1). Plus archigraph_patterns (ADR-0018 β),
-	// archigraph_traces (#724), and archigraph_get_next_enrichment_task (#1134).
-	if got := len(srv.MCP.ListTools()); got != 18 {
-		t.Errorf("expected 18 registered tools, got %d", got)
+	// Total count must be exactly 31 (18 pre-#1202 + 13 new from #1202).
+	// New tools: topology×3, flows×3, diagnostics, quality_orphans,
+	// patterns_list, patterns_get, search_entities, get_subgraph, find_paths.
+	if got := len(srv.MCP.ListTools()); got != 31 {
+		t.Errorf("expected 31 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds 13 new MCP tools so agents can directly query topology orphans, flow dead-ends, quality gaps, and perform entity search / subgraph extraction / path finding — without curl workarounds against the dashboard HTTP API.

All tools operate against the in-memory \`LoadedGroup\` data (same as existing tools) — no HTTP dependency, graceful empty result when entity kinds not yet emitted by the indexer.

**New tools** (\`internal/mcp/dashboard_tools.go\`):

| Tool | Returns |
|------|---------|
| \`archigraph_topology_orphan_publishers\` | Topics published but never consumed |
| \`archigraph_topology_orphan_subscribers\` | Topics consumed but never published |
| \`archigraph_topology_topic_detail\` | Full publisher/subscriber map for one topic |
| \`archigraph_flow_dead_ends\` | Flows whose terminal step has no outbound CALLS |
| \`archigraph_flow_truncated\` | Flows cut short during extraction |
| \`archigraph_flow_detail\` | Step chain + SIDE_EFFECT_OF edges for one flow |
| \`archigraph_diagnostics\` | Per-repo load health and entity counts |
| \`archigraph_quality_orphans\` | Fully isolated nodes (dead code / extraction gaps) |
| \`archigraph_patterns_list\` | SCOPE.Pattern entities from the indexed graph |
| \`archigraph_patterns_get\` | Single pattern with exemplar relationships |
| \`archigraph_search_entities\` | Substring search across entity names + qualified names |
| \`archigraph_get_subgraph\` | N-hop neighbourhood extract (nodes + edges) |
| \`archigraph_find_paths\` | Shortest path between two entities with confidence score |

\`archigraph_patterns_list/get\` are distinct from \`archigraph_patterns\` (which manages the \`agentpatterns\` store). These expose patterns the indexer emitted into the graph.

## Closes / Refs

- Closes #1202

## Testing
- [x] All tests pass: \`go test ./internal/mcp/...\` (31 tools, 15 new tests, all green)
- [x] \`TestToolNameSurface\` updated to expect 31 tools
- [x] Relevant fixtures verified
- [x] No regression in cross-language parity

## Notes

- MCP activity events for Jarvis epic #1157 are not wired yet — no broker exists in this package. A follow-up can add that once the broker API stabilises.
- \`archigraph_find_paths\` returns the single shortest path (Dijkstra). Multi-path enumeration can be a follow-up.
- Tool descriptions are SHORT and verb-led per constraint.