### PR TITLE
docs(generate-docs skill): add Topology v2 + Flows v2 frontmatter schemas, Pass 14 validation

### DIFF
--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -48,8 +48,9 @@ Time estimates assume typical small-to-medium codebases (1k–10k source entitie
 | 11 | `prompts/11-pattern-cross-link.md` | Populate each approved pattern's `documentation_url` (ADR-0018 Phase 5). | 1–2 min |
 | 12 | `prompts/12-pattern-prose.md` | Emit `docs/patterns/<category>/<id>.md` per approved pattern (ADR-0018 Phase 6). | 2–4 min |
 | 13 | `prompts/13-enrichment.md` | LLM enrichment pass: emit unified YAML frontmatter for `http_endpoint`, `process_flow`, and `message_topic` entities (merge, disqualify, rank, group, summarise, detect gaps). Dashboard surfaces consume this data. | 5–15 min |
+| 14 | `prompts/14-frontmatter-validation.md` | Frontmatter validation pass: re-read every enriched doc file, parse its YAML frontmatter, and verify each field against the backend parser's expectations. Catches schema drift between the skill and the dashboard consumers. | 2–5 min |
 
-**Total wall time:** typically **25–60 minutes** for small repos (1k entities), **1–2 hours** for medium repos (10k entities), **2–4 hours** for large repos (100k+ entities). Pass 4 parallelizes across module clusters, so the critical path is dominated by Pass 0 (user interaction), Passes 1–2 (discovery), and Passes 4–5 (content generation).
+**Total wall time:** typically **25–65 minutes** for small repos (1k entities), **1–2 hours** for medium repos (10k entities), **2–4 hours** for large repos (100k+ entities). Pass 4 parallelizes across module clusters, so the critical path is dominated by Pass 0 (user interaction), Passes 1–2 (discovery), and Passes 4–5 (content generation).
 
 If a pass appears to hang:
 1. Check `archigraph status` — the daemon must be running and idle (not indexing another repo).
@@ -83,9 +84,49 @@ For every entity of kind `http_endpoint`, `process_flow`, or `message_topic`, th
 
 The subagent writes the enrichment as YAML frontmatter at the **top** of the entity's existing doc file. If no doc file exists for the entity, a minimal file is created containing only the frontmatter block.
 
+### Doc file discovery convention
+
+The backend parsers locate enriched doc files via `docgen-state.json` (`GeneratedPaths` list). Each parser applies a two-pass lookup:
+
+**For `message_topic` (Topology panel — `applyTopologyEnrichment`):**
+1. Pass 1 (fast): any `GeneratedPaths` entry whose path contains the entity ID as a substring.
+2. Pass 2 (fallback): any path containing `"topic"` or `"topology"` (case-insensitive) whose frontmatter has `kind: message_topic`. Used for hashed entity IDs where the path alone cannot match.
+
+**For `process_flow` (Flows panel — `extractFlowDocsWithResolver`):**
+1. Fast path: any path containing the entity ID or the word `"flow"` (case-insensitive) whose frontmatter has `kind: process_flow` or no `kind` set.
+2. Tertiary pass: scan all paths for frontmatter whose `entity_id` field matches the entity ID (handles hashed IDs).
+
+**For `http_endpoint` (Paths panel):** same entity-ID substring match; frontmatter `kind: http_endpoint` is used to reject wrong-kind docs.
+
+When no match is found, the parser falls back to scanning the first non-heading non-empty line of the file as a plain-text summary.
+
+**Canonical file placement** (when no prior doc exists for the entity):
+
+```
+<repo>/docs/enrichments/<kind>/<entity_id>.md
+```
+
+Example: `api/docs/enrichments/message_topic/order-created.md`
+
+This path will contain `"topic"` and the entity ID, making both lookup passes reliable.
+
+### `docgen_status` states
+
+The dashboard exposes a `docgen_status` field on every entity row:
+
+| Status | Meaning |
+|--------|---------|
+| `enriched` | A doc file with valid YAML frontmatter (`kind` + `summary` present) was found and parsed. |
+| `stale` | A doc file exists but its frontmatter is absent or has no `kind`/`summary` (legacy plain-prose file). For `message_topic`, stale is also set when the doc file's `mtime` is older than the topic's last index timestamp. |
+| `pending` | No doc file found for this entity in `GeneratedPaths`. |
+
+The skill should aim to move all entities from `pending` or `stale` to `enriched` by the end of Pass 13. Re-running Pass 13 on a `stale` entity re-emits the frontmatter block.
+
 ### Unified frontmatter schema
 
 Every enriched entity doc file starts with a YAML frontmatter block delimited by `---`. **All fields are optional** — omit any field the LLM cannot determine with confidence. The dashboard backend falls back to first-line prose summary when frontmatter is absent.
+
+The per-kind templates in `templates/` give copy-paste starting points. Example completed files are in `examples/`.
 
 ```yaml
 ---
@@ -126,6 +167,11 @@ responses:
     description: Invalid query params
 auth: 'Bearer token required (JWT)'
 tables_touched: [orders, order_items]
+# Prose-enrichment fields (consumed by Paths detail panel):
+parameters_explained: 'page and limit control pagination; limit is capped at 200 server-side'
+response_shapes_explained: 'orders array contains Order objects with id, total, status, created_at'
+examples: 'GET /api/orders?page=2&limit=20 — returns second page of 20 orders'
+caveats: 'Soft-deleted orders are excluded unless ?include_deleted=true is passed'
 
 # ── process_flow-specific fields ─────────────────────────────────────────────
 steps:
@@ -135,12 +181,19 @@ steps:
   - Emit order.created event to broker
 preconditions: 'User is authenticated and cart is non-empty'
 expected_outcome: 'Order persisted, confirmation email dispatched, inventory decremented'
+# Prose-enrichment fields (consumed by Flows detail panel):
+examples: 'Happy path: user checks out 3 items, payment succeeds, order.created emitted'
+caveats: 'Stock check is advisory — race conditions possible under high load'
 
 # ── message_topic-specific fields ────────────────────────────────────────────
+purpose: 'Signals that a new order was placed; consumed by fulfillment, analytics, and notifications'
 schema: '{ order_id: string, total: float, items: OrderItem[], user_id: string }'
 typical_payload_size_bytes: 512
 volume_estimate: high          # low | medium | high | very-high
 expected_consumers: [order-fulfillment, analytics, notifications]
+# Prose-enrichment fields (consumed by Topology detail panel):
+examples: 'order.created published after checkout with order_id and items array'
+caveats: 'Schema version 2 — consumers must handle missing discount_code field from v1 payloads'
 ---
 
 ## Description
@@ -149,11 +202,71 @@ Free-form prose continues here (existing content unchanged below this block).
 ```
 
 > **Field selection rules**
-> - Emit only `kind`-relevant per-kind fields. Do not emit `steps` for an `http_endpoint`.
+> - Emit only `kind`-relevant per-kind fields. Do not emit `steps` for an `http_endpoint`; do not emit `method`/`path` for a `message_topic`.
 > - Omit `rank` when you have no signal; do not fabricate a number.
 > - `disqualified: true` suppresses the entity from the default dashboard view; only set it when clearly a false positive.
 > - `merged_into` must reference an `entity_id` that exists in the same group.
 > - `gaps` entries should be actionable (the user can act on them); avoid tautological observations.
+> - `purpose` (message_topic) is distinct from `summary`: `summary` is a one-sentence overview for list views; `purpose` explains the business reason the topic exists, used in the detail panel.
+> - `parameters_explained`, `response_shapes_explained`, `examples`, `caveats` are freeform prose fields consumed by the detail panel. They are not parsed structurally — write them as natural language.
+
+### Per-kind field matrix
+
+The backend parser (`enrichment_frontmatter.go`) reads all of these fields. Fields marked **consumed** are actively surfaced in the dashboard; **parsed** means they are stored but not yet rendered.
+
+| Field | `http_endpoint` | `process_flow` | `message_topic` | Backend field |
+|-------|----------------|----------------|-----------------|--------------|
+| `entity_id` | consumed | consumed | consumed | `EntityID` |
+| `kind` | consumed | consumed | consumed | `Kind` |
+| `disqualified` | consumed | consumed | consumed | `Disqualified` |
+| `merged_into` | consumed | consumed | consumed | `MergedInto` |
+| `rank` | consumed | consumed | consumed | `Rank` |
+| `group` | consumed | consumed | consumed | `Group` |
+| `group_label` | consumed | consumed | consumed | `GroupLabel` |
+| `summary` | consumed | consumed | consumed | `Summary` |
+| `gaps` | consumed | consumed | consumed | `Gaps` |
+| `method` | consumed | — | — | `Method` |
+| `path` | consumed | — | — | `Path` |
+| `parameters` | parsed | — | — | `Parameters` |
+| `responses` | parsed | — | — | `Responses` |
+| `auth` | consumed | — | — | `Auth` |
+| `tables_touched` | consumed | — | — | `TablesTouched` |
+| `parameters_explained` | prose | — | — | *(prose field — not parsed by backend)* |
+| `response_shapes_explained` | prose | — | — | *(prose field — not parsed by backend)* |
+| `steps` | — | consumed | — | `Steps` |
+| `preconditions` | — | consumed | — | `Preconditions` |
+| `expected_outcome` | — | consumed | — | `ExpectedOutcome` |
+| `purpose` | — | — | prose | *(prose field — not parsed by backend)* |
+| `schema` | — | — | consumed | `Schema` |
+| `typical_payload_size_bytes` | — | — | consumed | `TypicalPayloadSizeBytes` |
+| `volume_estimate` | — | — | consumed | `VolumeEstimate` |
+| `expected_consumers` | — | — | consumed | `ExpectedConsumers` |
+| `examples` | prose | prose | prose | *(prose field — not parsed by backend)* |
+| `caveats` | prose | prose | prose | *(prose field — not parsed by backend)* |
+
+> **Prose fields** (`parameters_explained`, `response_shapes_explained`, `purpose`, `examples`, `caveats`) are scalar string values stored in the YAML block for documentation completeness. The backend parser does not currently map them to struct fields — they pass through as unrecognised keys and are ignored. The dashboard detail panels read them from the raw frontmatter when the backend returns the full `enrichment` object. Emit them only when you have concrete information.
+
+### `enrichment_health` per kind
+
+The detail panels expose an `enrichment_health` object that reports which structured fields are filled. The fields checked differ per kind:
+
+**`message_topic` (Topology detail panel — `computeEnrichmentHealth`):**
+- `has_summary` — `summary` present
+- `has_schema` — `schema` present
+- `has_volume_estimate` — `volume_estimate` present
+- `has_typical_payload_size` — `typical_payload_size_bytes` > 0
+- `has_expected_consumers` — `expected_consumers` non-empty
+- `has_gaps` — `gaps` non-empty
+- `filled_field_count` / `total_field_count` (total = 6)
+
+**`process_flow` (Flows detail panel — `enrichmentHealth`):**
+- `summary` — `summary` present
+- `preconditions` — `preconditions` present
+- `expected_outcome` — `expected_outcome` present
+- `steps` — `steps` non-empty
+- `gaps` — `gaps` non-empty
+
+Aim to populate all health-tracked fields when writing Pass 13 output.
 
 ### Pass 13 procedure
 
@@ -177,6 +290,44 @@ archigraph_enrichments(action=submit, entity_id="<id>", summary="...", kind="<ki
 ```
 
 After writing, run `snippets/verification-checklist.md` for each entity. Hand back to the orchestrator when all entities processed.
+
+## Pass 14 — Frontmatter validation pass
+
+Pass 14 validates the YAML frontmatter emitted by Pass 13 against the backend parser's expectations. It catches schema drift (a field renamed in Go, a new required field added to the health check) before the user notices a blank panel in the dashboard.
+
+### When to run Pass 14
+
+Run Pass 14 immediately after Pass 13 completes. It is mandatory when enriching a group for the first time and recommended after any archigraph upgrade that mentions changes to `enrichment_frontmatter.go`.
+
+### What Pass 14 checks
+
+For every doc file in `GeneratedPaths` that contains a frontmatter block:
+
+1. **Structural validity** — the file opens with `---` on line 1 and has a matching closing `---`.
+2. **Required universal fields** — `kind` is one of `http_endpoint`, `process_flow`, `message_topic`.
+3. **Kind isolation** — no cross-kind fields present (e.g. `steps` on an `http_endpoint`).
+4. **Rank bounds** — if `rank` is present, it is a float in `[0, 1]`.
+5. **`merged_into` integrity** — if non-empty, the referenced `entity_id` appears in another doc file in the same group.
+6. **Health-tracked field coverage** — for each entity kind, report which health-tracked fields are missing:
+   - `message_topic`: `summary`, `schema`, `volume_estimate`, `typical_payload_size_bytes`, `expected_consumers`, `gaps`.
+   - `process_flow`: `summary`, `preconditions`, `expected_outcome`, `steps`, `gaps`.
+7. **Discovery-path reachability** — the doc file's path is listed in `docgen-state.json`'s `GeneratedPaths`, ensuring the backend can locate it.
+
+### Pass 14 output
+
+The pass emits a validation report as a finding:
+
+```
+archigraph_save_finding(
+  question="Pass 14 frontmatter validation report",
+  answer="<summary of pass/fail counts, list of files with issues>",
+  type="enrichment_validation",
+)
+```
+
+Any entity with validation failures is **not** marked `enriched`; the pass sets those entities back to `pending` in the finding so a re-run of Pass 13 knows to revisit them.
+
+Pass 14 does **not** modify doc files directly — it only reports. The user must re-run Pass 13 for any entity with failures.
 
 ## archigraph MCP tool surface
 
@@ -228,6 +379,13 @@ docs/
   how-to/
     local-dev.md
   glossary.md
+  enrichments/                 # Pass 13 — created only for entities with no prior doc file
+    http_endpoint/
+      <entity_id>.md           # template: templates/http_endpoint.md
+    process_flow/
+      <entity_id>.md           # template: templates/process_flow.md
+    message_topic/
+      <entity_id>.md           # template: templates/message_topic.md
 ```
 
 Group-level output lands at `~/.archigraph/groups/<group>/docs/`:
@@ -258,3 +416,9 @@ Before any pass commits its output, the writer subagent runs the checks in `snip
 - `docs/specs/repair-trust-model.md` - allowlist + verification rules enforced by `archigraph_repairs(action=submit)`.
 - ADR-0007 (`docs/adrs/0007-doc-as-bridge-for-cross-repo-and-dynamic-connections.md`) - why backticked code identifiers in headings matter.
 - ADR-0008 - caller-CWD-aware routing, which is why `repo_filter` defaults work without the agent passing `cwd` explicitly.
+- `internal/dashboard/enrichment_frontmatter.go` - backend YAML frontmatter parser; source of truth for which fields are consumed vs. ignored.
+- `internal/dashboard/handlers_topology.go` `applyTopologyEnrichment` - Topology panel enrichment lookup (PR #1182).
+- `internal/dashboard/handlers_topology_detail.go` `computeEnrichmentHealth` - health field coverage check for `message_topic`.
+- `internal/dashboard/handlers_flows.go` `extractFlowDocsWithResolver` + `enrichmentHealth` - Flows panel enrichment lookup and health check (PR #1181).
+- `skills/generate-docs/templates/` - per-kind frontmatter template files for Pass 13.
+- `skills/generate-docs/examples/` - fully-populated example enriched doc files per kind.

--- a/skills/generate-docs/examples/http_endpoint.md
+++ b/skills/generate-docs/examples/http_endpoint.md
@@ -1,0 +1,61 @@
+---
+entity_id: ep-orders-list
+kind: http_endpoint
+disqualified: false
+merged_into: ""
+rank: 0.82
+group: orders
+group_label: 'Order management'
+summary: 'Returns a paginated list of orders for the authenticated user, sorted by creation date descending.'
+gaps:
+  - 'No 429 rate-limit response documented'
+  - 'limit parameter has no server-side cap documented — actual max is 200'
+
+# ── http_endpoint-specific fields ────────────────────────────────────────────
+method: GET
+path: /api/orders
+parameters:
+  - name: page
+    in: query
+    type: int
+    required: false
+    default: 1
+    description: Page number (1-indexed)
+  - name: limit
+    in: query
+    type: int
+    required: false
+    default: 50
+    description: Items per page (server-side cap at 200)
+  - name: status
+    in: query
+    type: string
+    required: false
+    description: Filter by order status (pending, confirmed, shipped, cancelled)
+responses:
+  '200':
+    description: Paginated order list
+    shape: '{ orders: Order[], total: int, page: int, pages: int }'
+  '400':
+    description: Invalid query parameters (non-integer page, unknown status value)
+  '401':
+    description: Missing or expired JWT
+auth: 'Bearer token required (JWT) — user identity derived from token sub claim'
+tables_touched: [orders, order_items]
+parameters_explained: 'page is 1-indexed; page=0 returns a 400. limit is capped at 200 server-side regardless of the requested value — callers should not assume they received fewer items than limit means there are no more pages.'
+response_shapes_explained: 'orders contains Order objects with fields: id (UUID), status (enum), total_cents (int), created_at (ISO-8601), items (OrderItem[]). OrderItem has sku, quantity, unit_price_cents.'
+examples: 'GET /api/orders?page=2&limit=20&status=shipped — returns the second page of 20 shipped orders for the authenticated user'
+caveats: 'Soft-deleted orders are excluded unless the caller has the admin role and passes ?include_deleted=true. The response total reflects the filtered count, not the global order count.'
+---
+
+## `GET /api/orders` — List orders
+
+Returns a paginated list of orders belonging to the authenticated user. Orders are sorted by `created_at` descending (newest first).
+
+### Authentication
+
+Requires a valid Bearer JWT in the `Authorization` header. The endpoint derives the user identity from the token `sub` claim.
+
+### Pagination
+
+Use `page` and `limit` to paginate. The response `pages` field tells you the total page count. When `page` exceeds `pages`, an empty `orders` array is returned (not a 404).

--- a/skills/generate-docs/examples/message_topic.md
+++ b/skills/generate-docs/examples/message_topic.md
@@ -1,0 +1,47 @@
+---
+entity_id: topic-order-created
+kind: message_topic
+disqualified: false
+merged_into: ""
+rank: 0.92
+group: orders
+group_label: 'Order management'
+summary: 'Published when a new order is confirmed; triggers fulfillment, analytics ingest, and customer notification.'
+gaps:
+  - 'schema.discount_code field present in v2 payloads but absent from v1 — consumers must handle both'
+  - 'No dead-letter queue documented for failed consumer deliveries'
+
+# ── message_topic-specific fields ────────────────────────────────────────────
+purpose: 'Primary integration point for the orders domain. Any service that needs to react to a new confirmed order subscribes here rather than polling the orders database directly.'
+schema: '{ order_id: string (UUID), user_id: string (UUID), total_cents: int, currency: string (ISO-4217), items: [{ sku: string, quantity: int, unit_price_cents: int }], discount_code: string|null (v2 only), created_at: string (ISO-8601) }'
+typical_payload_size_bytes: 640
+volume_estimate: high
+expected_consumers: [order-fulfillment, analytics, notifications]
+examples: 'order.created published after a checkout with order_id="ord-abc123", user_id="usr-xyz", total_cents=4999, items=[{sku:"WIDGET-1", quantity:2, unit_price_cents:2000}]'
+caveats: 'Schema v1 (pre-2025-Q3) payloads lack discount_code — consumers must treat it as optional. Message ordering within the topic is not guaranteed. Retry semantics: the broker delivers at-least-once; consumers must be idempotent on order_id.'
+---
+
+## `order.created` — Order created topic
+
+Published by the checkout flow immediately after an order is successfully persisted. This is the authoritative signal that a purchase has been confirmed.
+
+### Broker
+
+RabbitMQ, exchange `orders.events`, routing key `order.created`.
+
+### Schema versions
+
+| Version | Added | Changes |
+|---------|-------|---------|
+| v1 | 2024-Q1 | Initial schema |
+| v2 | 2025-Q3 | Added `discount_code` field (nullable) |
+
+Consumers must handle both versions. Use `discount_code` only when non-null.
+
+### Consumers
+
+| Service | Action |
+|---------|--------|
+| `order-fulfillment` | Begins pick-and-pack sequence |
+| `analytics` | Ingests order into the data warehouse |
+| `notifications` | Sends order confirmation email to the user |

--- a/skills/generate-docs/examples/process_flow.md
+++ b/skills/generate-docs/examples/process_flow.md
@@ -1,0 +1,39 @@
+---
+entity_id: flow-checkout
+kind: process_flow
+disqualified: false
+merged_into: ""
+rank: 0.95
+group: orders
+group_label: 'Order management'
+summary: 'Handles the full checkout sequence: stock validation, payment, order persistence, and post-purchase event emission.'
+gaps:
+  - 'No rollback path documented if the order.created event fails to publish'
+  - 'Stock check is advisory — race condition possible under concurrent checkouts'
+
+# ── process_flow-specific fields ─────────────────────────────────────────────
+steps:
+  - Authenticate user and validate session
+  - Validate cart contents — check each SKU exists and quantity is available
+  - Reserve stock (advisory lock, not transactional)
+  - Charge payment method via payment service
+  - Persist order record and order_items rows to database
+  - Emit order.created event to broker
+  - Return order confirmation to client
+preconditions: 'User is authenticated, cart is non-empty, and at least one payment method is on file'
+expected_outcome: 'Order row persisted with status=confirmed, payment captured, order.created event published, inventory decremented (async via fulfillment service)'
+examples: 'Happy path: user checks out 3 items (SKUs A, B, C), payment succeeds on first attempt — order row created with id=uuid, order.created published within 50 ms. Retry path: payment fails on first attempt, user retries with a different card — first charge is voided, second succeeds.'
+caveats: 'Stock reservation is advisory: two concurrent checkouts for the last unit of a SKU may both succeed. The fulfillment service is responsible for detecting and handling oversell. The flow does not send the confirmation email directly — the notifications service consumes order.created for that.'
+---
+
+## `checkout` — Checkout flow
+
+Orchestrates the full purchase sequence from cart validation through to order confirmation. This is the highest-traffic flow in the orders domain and the primary source of `order.created` events.
+
+### Entry point
+
+`POST /api/checkout` handled by `CheckoutHandler.handle` in `apps/api/handlers/checkout.py`.
+
+### Error handling
+
+Payment failures return a `402 Payment Required` with a structured error body. Stock shortfalls after reservation return `409 Conflict`. All other failures return `500` and trigger a Sentry alert.

--- a/skills/generate-docs/prompts/13-enrichment.md
+++ b/skills/generate-docs/prompts/13-enrichment.md
@@ -5,6 +5,11 @@ Produce structured YAML frontmatter enrichments for every `http_endpoint`,
 Flows, and Topology surfaces consume this data to surface summaries, group
 badges, rank scores, gap warnings, and disqualification signals.
 
+**Dashboard consumers:**
+- `http_endpoint` → Paths panel (`handlers_paths.go`)
+- `process_flow` → Flows list + detail panel (`handlers_flows.go`, `enrichmentHealth`)
+- `message_topic` → Topology list + detail panel (`handlers_topology.go` `applyTopologyEnrichment`, `handlers_topology_detail.go` `computeEnrichmentHealth`)
+
 > **Pass 3a hook active** for any entity where a doc file is being written
 > from scratch (i.e., no existing doc). Before writing the prose section,
 > run the generation-time repair hook from `prompts/03a-generation-time-repair.md`.
@@ -15,6 +20,8 @@ badges, rank scores, gap warnings, and disqualification signals.
 - Existing doc files under `<repo>/docs/` (Pass 4–6 output) — enrich in-place.
 - `archigraph_enrichments(action=list)` — pre-computed enrichment candidates
   from the daemon; use as signals, not as verbatim output.
+- Per-kind templates at `skills/generate-docs/templates/<kind>.md` — use as
+  starting point when creating new files.
 
 ## Procedure
 
@@ -67,7 +74,9 @@ For each entity in the working list:
 
 5. **Write summary** — one sentence, no jargon, from the user's perspective.
 
-6. **Detect gaps** — use the checklist below.
+6. **Detect gaps** — use the gap checklist below.
+
+7. **Write per-kind fields** — follow the field guidance for each kind below.
 
 #### Gap checklist
 
@@ -86,30 +95,104 @@ For `message_topic`:
 - [ ] Orphan producer (no SUBSCRIBES_TO consumer anywhere in the group)
 - [ ] Orphan consumer (no PUBLISHES_TO producer anywhere in the group)
 - [ ] Incompatible schemas (two consumers expect different field sets)
-- [ ] No expected_consumers listed
+- [ ] No `expected_consumers` listed
+
+#### Per-kind field guidance
+
+**`http_endpoint` — Paths panel**
+
+All fields below are consumed by the Paths panel. Populate as many as you have
+confident data for:
+
+- `method`, `path` — copy from the entity properties or handler signature.
+- `parameters` — list every query/path/header/body parameter with type and
+  required flag. Inferred from function signature or docstring.
+- `responses` — document at least `200` and the most likely error codes.
+  Shape is a compact inline TypeScript-style type string.
+- `auth` — one-sentence description of the auth requirement.
+- `tables_touched` — list DB tables or ORM models that this handler reads or writes.
+- `parameters_explained` — prose expanding on non-obvious parameter semantics.
+- `response_shapes_explained` — prose describing nested object structures,
+  enum values, and optional fields.
+- `examples` — one or two representative call-and-response examples in prose.
+- `caveats` — edge cases, rate limits, soft-delete behaviour, deprecation notes.
+
+**`process_flow` — Flows list + detail panel**
+
+The Flows panel's `enrichmentHealth` checks: `summary`, `preconditions`,
+`expected_outcome`, `steps`, `gaps`. Populate all five to achieve full health.
+
+- `steps` — numbered list of discrete actions in the flow's happy path.
+  Use short imperative phrases (verb + noun). Order must match execution order.
+  Aim for 3–10 steps; collapse trivially-small steps (e.g. a single assignment)
+  into their parent action.
+- `preconditions` — the minimum state required for the flow to begin. One sentence.
+- `expected_outcome` — what the system state looks like after a successful run.
+  Include persistence, events emitted, and side effects.
+- `examples` — prose: happy path narrative + one failure/retry scenario.
+- `caveats` — known failure modes, retry behaviour, race conditions, async gaps.
+
+**`message_topic` — Topology list + detail panel**
+
+The Topology detail panel's `computeEnrichmentHealth` checks six fields:
+`summary`, `schema`, `volume_estimate`, `typical_payload_size_bytes`,
+`expected_consumers`, `gaps`. Populate all six to achieve a `filled_field_count`
+of 6/6.
+
+- `purpose` — distinct from `summary`: explain the business reason this topic
+  exists and how it fits into the architecture. Consumed by the detail panel prose
+  section. Two to four sentences.
+- `schema` — inline compact type string representing the message payload.
+  Use TypeScript-style notation: `{ field: type, ... }`. If the schema has
+  multiple versions, document the latest and note version history in `caveats`.
+  **Important:** when `schema` is present in the frontmatter, the Topology detail
+  panel prefers it over the entity-derived `schema` property from the graph — so
+  this is the authoritative source for the UI.
+- `typical_payload_size_bytes` — integer estimate. Useful for capacity planning.
+  Omit if you have no data rather than guessing wildly.
+- `volume_estimate` — one of `low | medium | high | very-high`. Base on
+  known traffic patterns or the flow rank of the publishing flow.
+- `expected_consumers` — list of service/repo slugs that subscribe. The Topology
+  detail panel merges these hints into the graph-derived related-topics list, so
+  include any consumer whose subscription edge may not be in the graph (e.g.
+  external services consuming via a shared subscription).
+- `examples` — prose: sample publish event with representative field values.
+- `caveats` — schema version compatibility, at-least-once vs. exactly-once
+  delivery, ordering guarantees, dead-letter-queue status.
 
 ### Step 4 — Write frontmatter
 
 For each entity, prepend the YAML frontmatter block to the **top** of the
 existing doc file. Do not alter the prose body below the closing `---`.
 
-If no doc file exists for the entity, create a minimal file:
+Use the template for the entity's `kind` as your starting point:
+
+```
+skills/generate-docs/templates/http_endpoint.md
+skills/generate-docs/templates/process_flow.md
+skills/generate-docs/templates/message_topic.md
+```
+
+See `skills/generate-docs/examples/` for fully-populated reference examples.
+
+If no doc file exists for the entity, create a minimal file at:
 
 ```
 <repo>/docs/enrichments/<kind>/<entity_id>.md
 ```
 
-containing only the frontmatter block followed by a one-paragraph prose
-description.
+This path must contain the entity ID as a substring so the backend's
+fast-path lookup (`applyTopologyEnrichment` pass 1, `extractFlowDocsWithResolver`
+fast path) can resolve it without a full frontmatter scan.
 
-Use the schema documented in `SKILL.md § Unified frontmatter schema`. Emit
-only fields relevant to the entity's `kind`. Omit fields where you have no
-confident data rather than fabricating values.
+Emit only fields relevant to the entity's `kind`. Do not emit `steps` on an
+`http_endpoint` or `method`/`path` on a `message_topic`. Omit any field where
+you have no confident data rather than fabricating values.
 
 ### Step 5 — Submit enrichment record
 
 After writing the frontmatter, record the enrichment in the daemon so the
-group state reflects it:
+group state reflects it and the `docgen_status` transitions to `enriched`:
 
 ```
 archigraph_enrichments(
@@ -127,11 +210,14 @@ verify:
 
 - [ ] Frontmatter opens with `---` on line 1.
 - [ ] Frontmatter closes with `---` before any prose.
-- [ ] `kind` matches the graph entity kind.
+- [ ] `kind` matches the graph entity kind (`http_endpoint`, `process_flow`, or `message_topic`).
 - [ ] `rank` is in 0..1 (or absent).
-- [ ] `merged_into` references an entity_id that exists in this group (or is absent).
+- [ ] `merged_into` references an `entity_id` that exists in this group (or is absent).
 - [ ] `disqualified: true` is justified in a `gaps` entry or comment.
-- [ ] No per-kind fields from the wrong kind (e.g. no `steps` on an `http_endpoint`).
+- [ ] No per-kind fields from the wrong kind (e.g. no `steps` on an `http_endpoint`, no `method` on a `message_topic`).
+- [ ] For `process_flow`: `summary`, `preconditions`, `expected_outcome`, `steps`, and `gaps` are all present (needed for full `enrichment_health`).
+- [ ] For `message_topic`: `summary`, `schema`, `volume_estimate`, `typical_payload_size_bytes`, `expected_consumers`, and `gaps` are all present (needed for `filled_field_count` = 6).
+- [ ] The doc file path is registered in `docgen-state.json` `GeneratedPaths` so the backend can locate it.
 
 ### Step 7 — Hand back
 
@@ -140,10 +226,10 @@ Save a finding summarising enrichment coverage:
 ```
 archigraph_save_finding(
   question="What enrichment data was produced for this group?",
-  answer="Pass 13 enriched <N> http_endpoints, <M> process_flows, <K> message_topics. <X> disqualified. <Y> merged.",
+  answer="Pass 13 enriched <N> http_endpoints, <M> process_flows, <K> message_topics. <X> disqualified. <Y> merged. Health coverage: <Z> message_topics at 6/6, <W> process_flows at 5/5.",
   type="enrichment",
 )
 ```
 
 Hand control back to the orchestrator. The orchestrator marks Pass 13 complete
-in docgen-state.json.
+in docgen-state.json and queues Pass 14 (frontmatter validation).

--- a/skills/generate-docs/prompts/14-frontmatter-validation.md
+++ b/skills/generate-docs/prompts/14-frontmatter-validation.md
@@ -1,0 +1,142 @@
+# Pass 14 — Frontmatter Validation
+
+Validate every enriched doc file written by Pass 13. Catch schema drift between
+the skill output and the backend parser's expectations before the user sees a
+blank panel in the dashboard.
+
+> **Read-only pass** — Pass 14 does not modify any doc file. It only reports.
+> Re-run Pass 13 to fix any entity with validation failures.
+
+## Inputs
+
+- `docgen-state.json` `GeneratedPaths` list — the set of files to validate.
+- The enriched doc files themselves.
+- The field matrix in `SKILL.md § Per-kind field matrix` — source of truth for
+  which fields are consumed vs. prose-only.
+
+## Procedure
+
+### Step 1 — Load file list
+
+Read `docgen-state.json` for the group and collect all entries in `GeneratedPaths`.
+Filter to files that contain a frontmatter block (i.e., the file begins with `---`).
+
+### Step 2 — Per-file validation
+
+For each file in the filtered list, run all checks below. Record pass/fail per
+check per file.
+
+#### Check A — Structural validity
+
+- [ ] File begins with `---` on line 1 (no leading blank line or BOM).
+- [ ] There is a second `---` line that closes the frontmatter block.
+- [ ] The YAML between the delimiters parses without syntax errors (no unquoted
+  colons in values, no mismatched list indentation).
+
+#### Check B — `kind` field
+
+- [ ] `kind` is present.
+- [ ] `kind` is exactly one of: `http_endpoint`, `process_flow`, `message_topic`.
+- [ ] `kind` matches the entity kind recorded in the daemon for this `entity_id`
+  (if `entity_id` is present and resolvable via `archigraph_inspect`).
+
+#### Check C — Kind isolation
+
+No cross-kind fields present. Specifically:
+
+- `http_endpoint`: must NOT contain `steps`, `preconditions`, `expected_outcome`,
+  `schema`, `typical_payload_size_bytes`, `volume_estimate`, `expected_consumers`,
+  `purpose`.
+- `process_flow`: must NOT contain `method`, `path`, `parameters`, `responses`,
+  `auth`, `tables_touched`, `schema`, `typical_payload_size_bytes`,
+  `volume_estimate`, `expected_consumers`, `purpose`.
+- `message_topic`: must NOT contain `method`, `path`, `parameters`, `responses`,
+  `auth`, `tables_touched`, `steps`, `preconditions`, `expected_outcome`.
+
+#### Check D — Scalar field types
+
+- [ ] `rank` (if present) is a float in `[0.0, 1.0]`.
+- [ ] `typical_payload_size_bytes` (if present) is a positive integer.
+- [ ] `disqualified` (if present) is `true` or `false` (not a string).
+- [ ] `volume_estimate` (if present) is one of `low`, `medium`, `high`, `very-high`.
+
+#### Check E — Referential integrity
+
+- [ ] `merged_into` (if non-empty) references an `entity_id` that appears in at
+  least one other doc file in this group or is resolvable via `archigraph_inspect`.
+
+#### Check F — Health-tracked field coverage
+
+Report missing fields per kind (these are the fields that determine `enrichment_health`):
+
+**`message_topic`** (backend `computeEnrichmentHealth`, total = 6):
+- `summary` — present?
+- `schema` — present?
+- `volume_estimate` — present?
+- `typical_payload_size_bytes` — present and > 0?
+- `expected_consumers` — present and non-empty?
+- `gaps` — present and non-empty?
+
+**`process_flow`** (backend `enrichmentHealth`):
+- `summary` — present?
+- `preconditions` — present?
+- `expected_outcome` — present?
+- `steps` — present and non-empty?
+- `gaps` — present and non-empty?
+
+**`http_endpoint`** (no structured health check in current backend, but completeness still matters):
+- `summary` — present?
+- `method` — present?
+- `path` — present?
+- `auth` — present?
+
+#### Check G — Discovery-path reachability
+
+The backend locates enrichment docs via path matching, not just a DB lookup.
+Verify the matching strategy will succeed for each file:
+
+For `message_topic` files: the path must contain either the `entity_id` substring
+OR contain `"topic"` or `"topology"` (case-insensitive) so `applyTopologyEnrichment`
+pass 2 can reach it.
+
+For `process_flow` files: the path must contain either the `entity_id` substring
+OR contain `"flow"` (case-insensitive) so `extractFlowDocsWithResolver` fast-path
+can reach it. If neither matches, the tertiary pass will still work if `entity_id`
+is set in the frontmatter — but flag it as a discovery risk.
+
+For `http_endpoint` files: the path must contain the `entity_id` substring, or
+`entity_id` must be set in the frontmatter for fallback matching.
+
+### Step 3 — Compile results
+
+Produce a structured summary with:
+
+- Total files scanned.
+- Pass count (all checks A–G passed).
+- Fail count, broken down by check.
+- For each failing file: the file path, which checks failed, and the specific
+  problem (e.g. "Check C: `steps` found on `http_endpoint`").
+- For each entity with incomplete health coverage: the entity ID, kind, and the
+  list of missing health-tracked fields.
+
+### Step 4 — Save finding
+
+```
+archigraph_save_finding(
+  question="Pass 14 frontmatter validation report",
+  answer="<Structured summary: N files scanned, M passed, K failed. Failing files: [list]. Incomplete health: [list]>",
+  type="enrichment_validation",
+)
+```
+
+### Step 5 — Hand back
+
+Report to the orchestrator:
+
+- If **all checks passed**: mark Pass 14 complete. Passes 13–14 are done.
+- If **any checks failed**: list the affected entity IDs. The orchestrator should
+  queue a targeted re-run of Pass 13 for those entities only, then re-run Pass 14
+  to confirm. Do not mark Pass 14 complete until no failures remain.
+
+Pass 14 does **not** modify doc files. It only reports. The fix is always a
+Pass 13 re-run for the affected entity.

--- a/skills/generate-docs/templates/http_endpoint.md
+++ b/skills/generate-docs/templates/http_endpoint.md
@@ -1,0 +1,43 @@
+---
+entity_id: <entity_id>
+kind: http_endpoint
+disqualified: false
+merged_into: ""
+rank: <0..1 or omit>
+group: <domain-key>
+group_label: '<Human-readable domain name>'
+summary: '<One sentence from the user perspective>'
+gaps:
+  - '<Actionable gap or omit this block>'
+
+# ── http_endpoint-specific fields ────────────────────────────────────────────
+method: <GET|POST|PUT|PATCH|DELETE>
+path: /api/<path>
+parameters:
+  - name: <param>
+    in: <query|path|header|body>
+    type: <string|int|bool|...>
+    required: <true|false>
+    default: <value or omit>
+    description: '<Short description>'
+responses:
+  '200':
+    description: '<Success description>'
+    shape: '<{ field: type, ... }>'
+  '400':
+    description: '<Validation error>'
+  '401':
+    description: '<Unauthenticated>'
+  '404':
+    description: '<Not found>'
+auth: '<Bearer token required (JWT) | No auth required | ...>'
+tables_touched: [<table1>, <table2>]
+parameters_explained: '<Prose: clarify non-obvious parameter semantics, defaults, limits>'
+response_shapes_explained: '<Prose: describe nested object shapes, enum values>'
+examples: '<Prose: one or two representative call examples with expected outcome>'
+caveats: '<Prose: edge cases, rate limits, soft-delete behaviour, deprecations>'
+---
+
+## `<EntityName>`
+
+<!-- Prose description continues here. Do not alter this section when prepending frontmatter. -->

--- a/skills/generate-docs/templates/message_topic.md
+++ b/skills/generate-docs/templates/message_topic.md
@@ -1,0 +1,25 @@
+---
+entity_id: <entity_id>
+kind: message_topic
+disqualified: false
+merged_into: ""
+rank: <0..1 or omit>
+group: <domain-key>
+group_label: '<Human-readable domain name>'
+summary: '<One sentence overview for list views>'
+gaps:
+  - '<Actionable gap or omit this block>'
+
+# ── message_topic-specific fields ────────────────────────────────────────────
+purpose: '<Prose: business reason this topic exists — consumed by Topology detail panel>'
+schema: '<{ field: type, field: type }>'
+typical_payload_size_bytes: <integer or omit>
+volume_estimate: <low|medium|high|very-high>
+expected_consumers: [<service-a>, <service-b>]
+examples: '<Prose: example publish event, key field values>'
+caveats: '<Prose: schema version history, consumer compatibility notes, ordering guarantees>'
+---
+
+## `<TopicName>`
+
+<!-- Prose description continues here. Do not alter this section when prepending frontmatter. -->

--- a/skills/generate-docs/templates/process_flow.md
+++ b/skills/generate-docs/templates/process_flow.md
@@ -1,0 +1,26 @@
+---
+entity_id: <entity_id>
+kind: process_flow
+disqualified: false
+merged_into: ""
+rank: <0..1 or omit>
+group: <domain-key>
+group_label: '<Human-readable domain name>'
+summary: '<One sentence describing what this flow achieves>'
+gaps:
+  - '<Actionable gap or omit this block>'
+
+# ── process_flow-specific fields ─────────────────────────────────────────────
+steps:
+  - '<Step 1 — brief action description>'
+  - '<Step 2>'
+  - '<Step 3>'
+preconditions: '<What must be true before this flow can execute>'
+expected_outcome: '<What the system state is after a successful run>'
+examples: '<Prose: happy-path narrative, one or two concrete scenarios>'
+caveats: '<Prose: failure modes, retry behaviour, race conditions, side effects>'
+---
+
+## `<FlowName>`
+
+<!-- Prose description continues here. Do not alter this section when prepending frontmatter. -->


### PR DESCRIPTION
## Summary

The `/generate-docs` skill's Pass 13 previously documented only `http_endpoint` frontmatter. Topology v2 (#1182) and Flows v2 (#1181) now consume `message_topic` and `process_flow` frontmatter respectively, so the skill spec needed to catch up.

**What changed:**

- **`SKILL.md`** — expanded Pass 13 with: doc-file discovery convention (how each backend parser locates the doc), `docgen_status` states table (`enriched` / `stale` / `pending`), per-kind field matrix (which fields are consumed vs. prose-only vs. ignored), `enrichment_health` field lists per kind (6-field `message_topic`, 5-field `process_flow`), prose-enrichment fields (`parameters_explained`, `response_shapes_explained`, `purpose`, `examples`, `caveats`). Added Pass 14 to the pass table, spec section, and Related links. Updated output-layout tree with `enrichments/` subdirs.
- **`prompts/13-enrichment.md`** — per-kind field guidance for each dashboard consumer; health-field coverage targets; template/example references; discovery-path reachability requirement; updated Step 7 finding to report health coverage stats.
- **`prompts/14-frontmatter-validation.md`** — new read-only validation pass with 7 checks: structural validity, `kind` field, kind isolation, scalar types, referential integrity, health-tracked field coverage (per-kind), and discovery-path reachability. Reports to orchestrator; re-queues Pass 13 for any failures.
- **`templates/`** — three per-kind frontmatter starters (`http_endpoint.md`, `process_flow.md`, `message_topic.md`).
- **`examples/`** — three fully-populated reference enrichment files, one per kind.

## Closes / Refs

- `board:exempt` — documentation-only change (skill spec, no Go code touched)

## Testing

- No Go code changed — no test suite to run.
- Checked field names against `internal/dashboard/enrichment_frontmatter.go` `EnrichmentFrontmatter` struct, `handlers_topology_detail.go` `computeEnrichmentHealth`, and `handlers_flows.go` `enrichmentHealth` and `extractFlowDocsWithResolver` — all field names in the templates and matrix match the backend parser exactly.

## Notes

The three `examples/` files use the `orders` domain as a consistent illustration. They are not part of any repo's `docs/` tree — they live under `skills/generate-docs/examples/` as reference material for the skill agent only.

Pass 14 is read-only by design: it never writes files, only reports. This keeps it safe to re-run at any time and avoids the orchestrator having to diff-detect partial re-enrichments.