### PR TITLE
[discoverability] Auto-inject Architecture Map into AGENTS.md after rebuild

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -16,9 +16,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/agents"
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/dashboard"
+	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/quality/audit"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -296,6 +298,19 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 		// enrichment-candidates.json) when building the post-rebuild summary.
 		// Returning slugs here was the root cause of #1076 (zero counts).
 		rebuilt = append(rebuilt, r.Path)
+
+		// Auto-inject Architecture Map block into AGENTS.md / CLAUDE.md when
+		// opted in. Best-effort: a write failure is logged but never fails the
+		// rebuild so a read-only repo or missing permissions don't surface as
+		// an error to the user (#1216).
+		if cfg.Features.AutoInjectAgentsMD {
+			mapStats := buildAgentsMapStats(cfg.Name, r.Path)
+			if err := agents.InjectArchitectureMap(r.Path, mapStats); err != nil {
+				fmt.Fprintf(os.Stderr,
+					"archigraph: auto-inject agents map for %s: %v (non-fatal)\n",
+					r.Slug, err)
+			}
+		}
 	}
 	// Cross-repo link passes run after every member is indexed.
 	warning := ""
@@ -304,6 +319,49 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 		warning = fmt.Sprintf("link passes failed: %v", err)
 	}
 	return rebuilt, warning, nil
+}
+
+// buildAgentsMapStats loads the per-repo graph artefacts produced by the
+// just-completed index and assembles the Stats struct passed to
+// agents.InjectArchitectureMap. It is intentionally best-effort — any read
+// failure yields a zero-valued field rather than an error.
+func buildAgentsMapStats(group, repoPath string) agents.Stats {
+	stateDir := daemon.StateDirForRepo(repoPath)
+
+	s := agents.Stats{
+		Group:         group,
+		DashboardPort: resolveDefaultDashboardPort(),
+	}
+
+	// Read graph.fb for per-kind entity breakdown. Falls back gracefully if the
+	// file is absent or the FB decoder is unavailable.
+	if doc, err := loadGraphFromStateDir(stateDir); err == nil && doc != nil {
+		s.Entities = doc.Stats.Entities
+		s.Relationships = doc.Stats.Relationships
+		for _, e := range doc.Entities {
+			switch e.Kind {
+			case "http_endpoint":
+				s.HTTPEndpoints++
+			case "queue":
+				s.Queues++
+			case "topic", "pubsub_topic":
+				s.Topics++
+			}
+			if strings.HasPrefix(e.Kind, "SCOPE.Process") || e.Kind == "process" {
+				s.ProcessFlows++
+			}
+		}
+	}
+
+	return s
+}
+
+// loadGraphFromStateDir is a thin wrapper around graph.LoadGraphFromDir that
+// isolates the graph-loading call used by buildAgentsMapStats. Keeping it
+// separate makes it easy to stub in tests without touching the full graph
+// package.
+func loadGraphFromStateDir(stateDir string) (*graph.Document, error) {
+	return graph.LoadGraphFromDir(stateDir)
 }
 
 // daemonQualityAuditFunc is the QualityAuditFunc handed to daemon.Run.

--- a/internal/agents/inject_map.go
+++ b/internal/agents/inject_map.go
@@ -1,0 +1,254 @@
+// Package agents provides the Architecture Map injector that appends (or
+// updates) an idempotent marker block in a project's AGENTS.md (or CLAUDE.md)
+// after every archigraph rebuild. The block tells AI coding agents that this
+// repo is indexed, where the dashboard lives, and which MCP endpoints to
+// query.
+//
+// Design notes:
+//   - The block is bounded by <!-- archigraph:architecture-map:start --> …
+//     <!-- archigraph:architecture-map:end --> so re-runs UPDATE in place.
+//   - If the marker pair is missing from an existing file the block is
+//     appended at the end with a blank-line separator.
+//   - If no agent file exists at all, AGENTS.md is created.
+//   - The feature is gated by GroupConfig.AutoInjectAgentsMD (default false).
+//   - AI-tool detection: if .claude/ or .cursor/ exist in the repo root the
+//     block includes a tailored hint for that toolchain.
+package agents
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// Marker tokens for the architecture-map block. Use a distinct namespace
+// from the patterns block (archigraph:patterns) so the two can coexist
+// independently in the same file.
+const (
+	MapStartMarker = "<!-- archigraph:architecture-map:start -->"
+	MapEndMarker   = "<!-- archigraph:architecture-map:end -->"
+)
+
+// blockRegex matches the entire marker-wrapped region (start + content + end),
+// using DOTALL so newlines inside the block are consumed.
+var blockRegex = regexp.MustCompile(`(?s)` +
+	regexp.QuoteMeta(MapStartMarker) +
+	`.*?` +
+	regexp.QuoteMeta(MapEndMarker))
+
+// Stats carries the per-repo counters that the Architecture Map block
+// displays. All fields are optional — zero values render as 0.
+type Stats struct {
+	// Group is the archigraph group this repo belongs to (used to construct
+	// the dashboard URL fragment).
+	Group string
+
+	// DashboardPort is the local dashboard port (default 47274).
+	DashboardPort int
+
+	// Entities is the total entity count after the rebuild.
+	Entities int
+
+	// Relationships is the total relationship count.
+	Relationships int
+
+	// HTTPEndpoints is the count of http_endpoint entities.
+	HTTPEndpoints int
+
+	// ProcessFlows is the count of process-flow entities.
+	ProcessFlows int
+
+	// Queues is the count of queue entities.
+	Queues int
+
+	// Topics is the count of topic/pub-sub entities.
+	Topics int
+
+	// IndexedAt is the timestamp written into the block. Defaults to now.
+	IndexedAt time.Time
+
+	// BinaryPath is the absolute path to the archigraph binary used for the
+	// MCP snippet. Defaults to os.Executable() at render time if empty.
+	BinaryPath string
+}
+
+// InjectArchitectureMap finds the best agent-facing file in repoPath
+// (AGENTS.md > CLAUDE.md > GEMINI.md), creates AGENTS.md if none exists, and
+// upserts the Architecture Map marker block with the provided stats.
+//
+// The function is intentionally best-effort: it logs a non-fatal warning to
+// stderr and returns nil when the file cannot be read or written, so a transient
+// filesystem issue never fails the rebuild.
+func InjectArchitectureMap(repoPath string, stats Stats) error {
+	targetPath := resolveTargetFile(repoPath)
+
+	if stats.DashboardPort == 0 {
+		stats.DashboardPort = 47274
+	}
+	if stats.IndexedAt.IsZero() {
+		stats.IndexedAt = time.Now().UTC()
+	}
+	if stats.BinaryPath == "" {
+		if exe, err := os.Executable(); err == nil {
+			stats.BinaryPath = exe
+		} else {
+			stats.BinaryPath = "archigraph"
+		}
+	}
+
+	detected := detectAITools(repoPath)
+	block := renderBlock(stats, detected)
+	return upsertFile(targetPath, block)
+}
+
+// resolveTargetFile returns the first agent-facing file that already exists in
+// repoPath, in preference order: AGENTS.md, CLAUDE.md, GEMINI.md. If none
+// exist it returns the path for AGENTS.md (which will be created on write).
+func resolveTargetFile(repoPath string) string {
+	candidates := []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
+	for _, name := range candidates {
+		p := filepath.Join(repoPath, name)
+		if _, err := os.Stat(p); err == nil {
+			return p
+		}
+	}
+	return filepath.Join(repoPath, "AGENTS.md")
+}
+
+// detectedTools is the set of AI toolchains the injector found in the repo.
+type detectedTools struct {
+	claude bool // .claude/ directory present
+	cursor bool // .cursor/ directory present
+}
+
+// detectAITools scans the repo root for well-known AI tool configuration
+// directories and returns which ones were found.
+func detectAITools(repoPath string) detectedTools {
+	var d detectedTools
+	if _, err := os.Stat(filepath.Join(repoPath, ".claude")); err == nil {
+		d.claude = true
+	}
+	if _, err := os.Stat(filepath.Join(repoPath, ".cursor")); err == nil {
+		d.cursor = true
+	}
+	return d
+}
+
+// renderBlock builds the full marker-wrapped Architecture Map block.
+func renderBlock(s Stats, tools detectedTools) string {
+	var b strings.Builder
+
+	fmt.Fprintln(&b, MapStartMarker)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "## Architecture Map")
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "This repo is indexed by [archigraph](https://archigraph.dev).")
+	fmt.Fprintln(&b)
+
+	dashURL := fmt.Sprintf("http://127.0.0.1:%d", s.DashboardPort)
+	if s.Group != "" {
+		dashURL = fmt.Sprintf("http://127.0.0.1:%d/graph/%s", s.DashboardPort, s.Group)
+	}
+	fmt.Fprintf(&b, "- **Dashboard**: %s\n", dashURL)
+
+	if s.Group != "" {
+		fmt.Fprintf(&b, "- **Entities**: %d — `/api/entities/%s`\n", s.Entities, s.Group)
+		fmt.Fprintf(&b, "- **Relationships**: %d — `/api/relationships/%s`\n", s.Relationships, s.Group)
+		if s.HTTPEndpoints > 0 {
+			fmt.Fprintf(&b, "- **HTTP Endpoints**: %d — `/paths/%s`\n", s.HTTPEndpoints, s.Group)
+		}
+		if s.ProcessFlows > 0 {
+			fmt.Fprintf(&b, "- **Process Flows**: %d — `/flows/%s`\n", s.ProcessFlows, s.Group)
+		}
+		if s.Queues > 0 || s.Topics > 0 {
+			fmt.Fprintf(&b, "- **Topology**: %d queues, %d topics — `/topology/%s`\n",
+				s.Queues, s.Topics, s.Group)
+		}
+	} else {
+		fmt.Fprintf(&b, "- **Entities**: %d\n", s.Entities)
+		fmt.Fprintf(&b, "- **Relationships**: %d\n", s.Relationships)
+		if s.HTTPEndpoints > 0 {
+			fmt.Fprintf(&b, "- **HTTP Endpoints**: %d\n", s.HTTPEndpoints)
+		}
+		if s.ProcessFlows > 0 {
+			fmt.Fprintf(&b, "- **Process Flows**: %d\n", s.ProcessFlows)
+		}
+		if s.Queues > 0 || s.Topics > 0 {
+			fmt.Fprintf(&b, "- **Topology**: %d queues, %d topics\n", s.Queues, s.Topics)
+		}
+	}
+
+	fmt.Fprintf(&b, "- **Last indexed**: %s\n", s.IndexedAt.Format("2006-01-02 15:04 UTC"))
+	fmt.Fprintln(&b)
+
+	// MCP snippet — tailor to detected toolchain.
+	fmt.Fprintln(&b, "### MCP server (for AI agents)")
+	fmt.Fprintln(&b)
+
+	if tools.claude {
+		fmt.Fprintln(&b, "Claude Code (`.claude/settings.json`) — archigraph is already registered via `archigraph install`.")
+		fmt.Fprintln(&b, "If you need to add it manually:")
+	} else if tools.cursor {
+		fmt.Fprintln(&b, "Cursor (`.cursor/mcp.json`) — add the archigraph MCP server:")
+	} else {
+		fmt.Fprintln(&b, "Add the archigraph MCP server to your AI agent config:")
+	}
+
+	fmt.Fprintln(&b)
+	fmt.Fprintf(&b, "```json\n{ \"mcpServers\": { \"archigraph\": { \"command\": \"%s\", \"args\": [\"mcp\"] } } }\n```\n",
+		s.BinaryPath)
+	fmt.Fprintln(&b)
+	fmt.Fprintln(&b, "_Do not edit between the markers — this block is auto-updated by `archigraph rebuild`._")
+	fmt.Fprintln(&b)
+	fmt.Fprint(&b, MapEndMarker)
+
+	return b.String()
+}
+
+// upsertFile reads path, replaces the marker block (or appends if absent),
+// and writes back atomically. Creates the file (and parent dirs) if missing.
+// User content outside the markers is preserved byte-for-byte.
+func upsertFile(path, block string) error {
+	existing, err := os.ReadFile(path)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("read %s: %w", path, err)
+	}
+
+	var out []byte
+	switch {
+	case os.IsNotExist(err) || len(existing) == 0:
+		// New or empty file — write the block directly.
+		out = []byte(block)
+	case blockRegex.Match(existing):
+		// Existing block — replace in-place (idempotent).
+		out = blockRegex.ReplaceAll(existing, []byte(strings.TrimRight(block, "\n")))
+	default:
+		// File exists but no block — append with blank-line separator.
+		buf := bytes.NewBuffer(existing)
+		if len(existing) > 0 && existing[len(existing)-1] != '\n' {
+			buf.WriteByte('\n')
+		}
+		buf.WriteByte('\n')
+		buf.WriteString(block)
+		out = buf.Bytes()
+	}
+
+	// Ensure parent directory exists (in case this is a brand-new repo).
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("mkdir %s: %w", filepath.Dir(path), err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, out, 0o644); err != nil {
+		return fmt.Errorf("write tmp: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename: %w", err)
+	}
+	return nil
+}

--- a/internal/agents/inject_map_test.go
+++ b/internal/agents/inject_map_test.go
@@ -1,0 +1,281 @@
+package agents
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func fixedTime() time.Time {
+	return time.Date(2026, 5, 21, 9, 47, 0, 0, time.UTC)
+}
+
+func baseStats(group string) Stats {
+	return Stats{
+		Group:         group,
+		DashboardPort: 47274,
+		Entities:      500,
+		Relationships: 1200,
+		HTTPEndpoints: 42,
+		ProcessFlows:  10,
+		Queues:        3,
+		Topics:        1,
+		IndexedAt:     fixedTime(),
+		BinaryPath:    "/usr/local/bin/archigraph",
+	}
+}
+
+// TestRenderBlock_containsMarkers verifies the rendered block has both markers.
+func TestRenderBlock_containsMarkers(t *testing.T) {
+	block := renderBlock(baseStats("mygroup"), detectedTools{})
+	if !strings.Contains(block, MapStartMarker) {
+		t.Error("block missing start marker")
+	}
+	if !strings.Contains(block, MapEndMarker) {
+		t.Error("block missing end marker")
+	}
+}
+
+// TestRenderBlock_withGroup verifies group-scoped API paths appear when Group is set.
+func TestRenderBlock_withGroup(t *testing.T) {
+	block := renderBlock(baseStats("mygroup"), detectedTools{})
+	if !strings.Contains(block, "/graph/mygroup") {
+		t.Error("block missing dashboard path with group")
+	}
+	if !strings.Contains(block, "/paths/mygroup") {
+		t.Error("block missing /paths/<group>")
+	}
+	if !strings.Contains(block, "/flows/mygroup") {
+		t.Error("block missing /flows/<group>")
+	}
+	if !strings.Contains(block, "/topology/mygroup") {
+		t.Error("block missing /topology/<group>")
+	}
+}
+
+// TestRenderBlock_noGroup verifies the block renders without group-scoped paths.
+func TestRenderBlock_noGroup(t *testing.T) {
+	s := baseStats("")
+	block := renderBlock(s, detectedTools{})
+	if strings.Contains(block, "/graph/") {
+		t.Error("block should not contain /graph/<group> when group is empty")
+	}
+	if !strings.Contains(block, "Entities") {
+		t.Error("block missing Entities line")
+	}
+}
+
+// TestRenderBlock_timestamp verifies the indexed-at timestamp is included.
+func TestRenderBlock_timestamp(t *testing.T) {
+	block := renderBlock(baseStats("g"), detectedTools{})
+	if !strings.Contains(block, "2026-05-21 09:47 UTC") {
+		t.Errorf("block missing timestamp; got:\n%s", block)
+	}
+}
+
+// TestRenderBlock_claudeHint verifies Claude-specific hint when .claude/ detected.
+func TestRenderBlock_claudeHint(t *testing.T) {
+	block := renderBlock(baseStats("g"), detectedTools{claude: true})
+	if !strings.Contains(block, "Claude Code") {
+		t.Error("block missing Claude Code hint for detected .claude/ dir")
+	}
+}
+
+// TestRenderBlock_cursorHint verifies Cursor-specific hint when .cursor/ detected.
+func TestRenderBlock_cursorHint(t *testing.T) {
+	block := renderBlock(baseStats("g"), detectedTools{cursor: true})
+	if !strings.Contains(block, "Cursor") {
+		t.Error("block missing Cursor hint for detected .cursor/ dir")
+	}
+}
+
+// TestRenderBlock_binaryPath verifies the binary path appears in the MCP snippet.
+func TestRenderBlock_binaryPath(t *testing.T) {
+	block := renderBlock(baseStats("g"), detectedTools{})
+	if !strings.Contains(block, "/usr/local/bin/archigraph") {
+		t.Error("block missing binary path in MCP snippet")
+	}
+}
+
+// TestUpsertFile_createsNewFile verifies that upsertFile creates AGENTS.md when missing.
+func TestUpsertFile_createsNewFile(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "AGENTS.md")
+	block := renderBlock(baseStats("g"), detectedTools{})
+
+	if err := upsertFile(p, block); err != nil {
+		t.Fatalf("upsertFile: %v", err)
+	}
+	data, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	if !strings.Contains(string(data), MapStartMarker) {
+		t.Error("created file missing start marker")
+	}
+}
+
+// TestUpsertFile_appendsToExisting verifies the block is appended when file has no markers.
+func TestUpsertFile_appendsToExisting(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "AGENTS.md")
+	existing := "# My Project\n\nSome existing content.\n"
+	if err := os.WriteFile(p, []byte(existing), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	block := renderBlock(baseStats("g"), detectedTools{})
+	if err := upsertFile(p, block); err != nil {
+		t.Fatalf("upsertFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(p)
+	s := string(data)
+	if !strings.HasPrefix(s, "# My Project") {
+		t.Error("existing content should be preserved at top")
+	}
+	if !strings.Contains(s, MapStartMarker) {
+		t.Error("marker block not appended")
+	}
+}
+
+// TestUpsertFile_replacesExistingBlock verifies idempotent in-place update.
+func TestUpsertFile_replacesExistingBlock(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, "AGENTS.md")
+
+	// Write an initial block with stale timestamp.
+	stale := baseStats("g")
+	stale.IndexedAt = time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	stale.Entities = 100
+	block1 := renderBlock(stale, detectedTools{})
+	if err := os.WriteFile(p, []byte("# Header\n\n"+block1+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Now upsert with fresh stats.
+	fresh := baseStats("g")
+	fresh.Entities = 999
+	block2 := renderBlock(fresh, detectedTools{})
+	if err := upsertFile(p, block2); err != nil {
+		t.Fatalf("upsertFile: %v", err)
+	}
+
+	data, _ := os.ReadFile(p)
+	s := string(data)
+
+	// Header must be intact.
+	if !strings.HasPrefix(s, "# Header") {
+		t.Error("header lost after upsert")
+	}
+
+	// Should contain new entity count, not old.
+	if !strings.Contains(s, "999") {
+		t.Error("updated entity count (999) not found")
+	}
+	if strings.Contains(s, "Entities**: 100") {
+		t.Error("stale entity count (100) still present after update")
+	}
+
+	// Exactly one start marker.
+	count := strings.Count(s, MapStartMarker)
+	if count != 1 {
+		t.Errorf("expected 1 start marker, got %d", count)
+	}
+}
+
+// TestResolveTargetFile_prefersAGENTSMD verifies AGENTS.md wins over CLAUDE.md.
+func TestResolveTargetFile_prefersAGENTSMD(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"AGENTS.md", "CLAUDE.md"} {
+		os.WriteFile(filepath.Join(dir, name), []byte("x"), 0o644)
+	}
+	got := resolveTargetFile(dir)
+	if filepath.Base(got) != "AGENTS.md" {
+		t.Errorf("expected AGENTS.md, got %s", filepath.Base(got))
+	}
+}
+
+// TestResolveTargetFile_fallsBackToCLAUDE verifies CLAUDE.md is chosen when AGENTS.md absent.
+func TestResolveTargetFile_fallsBackToCLAUDE(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte("x"), 0o644)
+	got := resolveTargetFile(dir)
+	if filepath.Base(got) != "CLAUDE.md" {
+		t.Errorf("expected CLAUDE.md, got %s", filepath.Base(got))
+	}
+}
+
+// TestResolveTargetFile_defaultsToAGENTSMD verifies default path when no file exists.
+func TestResolveTargetFile_defaultsToAGENTSMD(t *testing.T) {
+	dir := t.TempDir()
+	got := resolveTargetFile(dir)
+	if filepath.Base(got) != "AGENTS.md" {
+		t.Errorf("expected AGENTS.md default, got %s", filepath.Base(got))
+	}
+}
+
+// TestDetectAITools verifies .claude/ and .cursor/ detection.
+func TestDetectAITools(t *testing.T) {
+	dir := t.TempDir()
+
+	// No tools.
+	d := detectAITools(dir)
+	if d.claude || d.cursor {
+		t.Error("no tools should be detected in empty dir")
+	}
+
+	// Add .claude/
+	os.MkdirAll(filepath.Join(dir, ".claude"), 0o755)
+	d = detectAITools(dir)
+	if !d.claude {
+		t.Error(".claude/ not detected")
+	}
+	if d.cursor {
+		t.Error("cursor should not be detected")
+	}
+
+	// Add .cursor/
+	os.MkdirAll(filepath.Join(dir, ".cursor"), 0o755)
+	d = detectAITools(dir)
+	if !d.claude || !d.cursor {
+		t.Error("both tools should be detected")
+	}
+}
+
+// TestInjectArchitectureMap_endToEnd exercises the full public entrypoint.
+func TestInjectArchitectureMap_endToEnd(t *testing.T) {
+	dir := t.TempDir()
+	// Pre-seed a CLAUDE.md so that file is chosen over new AGENTS.md.
+	claudePath := filepath.Join(dir, "CLAUDE.md")
+	os.WriteFile(claudePath, []byte("# Existing\n"), 0o644)
+
+	s := baseStats("mygroup")
+	if err := InjectArchitectureMap(dir, s); err != nil {
+		t.Fatalf("InjectArchitectureMap: %v", err)
+	}
+
+	// CLAUDE.md should now have the block.
+	data, _ := os.ReadFile(claudePath)
+	if !strings.Contains(string(data), MapStartMarker) {
+		t.Error("CLAUDE.md missing architecture map block")
+	}
+	// AGENTS.md should NOT have been created since CLAUDE.md existed.
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err == nil {
+		t.Error("AGENTS.md should not have been created when CLAUDE.md exists")
+	}
+}
+
+// TestInjectArchitectureMap_createsAGENTSMD verifies file creation when none exists.
+func TestInjectArchitectureMap_createsAGENTSMD(t *testing.T) {
+	dir := t.TempDir()
+	s := baseStats("g")
+	if err := InjectArchitectureMap(dir, s); err != nil {
+		t.Fatalf("InjectArchitectureMap: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, "AGENTS.md")); err != nil {
+		t.Error("AGENTS.md should have been created")
+	}
+}

--- a/internal/registry/registry.go
+++ b/internal/registry/registry.go
@@ -51,6 +51,12 @@ type GroupConfig struct {
 	Features  struct {
 		Watchers bool `json:"watchers"`
 		GitHooks bool `json:"git_hooks"`
+		// AutoInjectAgentsMD, when true, causes archigraph to append (or
+		// update) an "Architecture Map" marker block in each repo's AGENTS.md
+		// (or CLAUDE.md / GEMINI.md) after every rebuild. The block tells AI
+		// coding agents that the repo is indexed, where the dashboard is, and
+		// which MCP endpoints to query. Default false — opt-in only.
+		AutoInjectAgentsMD bool `json:"auto_inject_agents_md,omitempty"`
 	} `json:"features"`
 }
 


### PR DESCRIPTION
## What

Adds `internal/agents` package with `InjectArchitectureMap(repoPath string, stats Stats) error` that upserts an idempotent marker-wrapped block into a repo's `AGENTS.md` (or `CLAUDE.md` / `GEMINI.md`) after every `archigraph rebuild`.

Closes #1216.

## Why

Today users must manually configure their AI agent to discover archigraph. This makes archigraph self-describing: any agent that reads `AGENTS.md` learns the dashboard URL, endpoint counts, and MCP config without any manual setup.

## How

**New package** `internal/agents/inject_map.go`:
- `InjectArchitectureMap(repoPath, stats)` — public entrypoint; resolves target file, renders block, upserts atomically
- `resolveTargetFile` — prefers `AGENTS.md` > `CLAUDE.md` > `GEMINI.md`; creates `AGENTS.md` if none exist
- `detectAITools` — scans for `.claude/` and `.cursor/` to tailor the MCP config hint
- `renderBlock` — builds the marker-wrapped Markdown; includes dashboard URL, entity/relationship/endpoint/flow/topology counts, timestamp, MCP JSON snippet
- `upsertFile` — atomic tmp+rename write; replaces existing block in-place or appends with separator

**Registry** (`internal/registry/registry.go`):
- Added `Features.AutoInjectAgentsMD bool` field (`json:"auto_inject_agents_md,omitempty"`) to `GroupConfig`; default `false` (opt-in only, no surprises)

**Daemon** (`cmd/archigraph/daemon.go`):
- Import `internal/agents` and `internal/graph`
- `daemonRebuildFunc` calls `agents.InjectArchitectureMap` per repo after a successful `Index()` when `cfg.Features.AutoInjectAgentsMD` is true
- `buildAgentsMapStats` reads the just-written `graph.fb` via `graph.LoadGraphFromDir` and assembles the `Stats` struct
- Failure is logged to stderr and never fails the rebuild (best-effort)

## Testing

16 unit tests in `internal/agents/inject_map_test.go`:
- Marker round-trip (start/end markers present)
- Group-scoped vs. no-group rendering
- Timestamp formatting
- Claude / Cursor hint detection
- Binary path in MCP snippet
- File creation, append-to-existing, idempotent in-place update
- `resolveTargetFile` preference order
- `detectAITools` coverage
- End-to-end `InjectArchitectureMap` (prefers CLAUDE.md, creates AGENTS.md)

All existing registry and CLI tests continue to pass.

## Default: off

`AutoInjectAgentsMD` defaults to `false`. Users opt in by adding `"auto_inject_agents_md": true` to `features` in their `<group>.fleet.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)