### PR TITLE
[jarvis] Phase 1: MCP query event broker + SSE endpoint /api/mcp-activity/stream

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/proto"
 	"github.com/cajasmota/archigraph/internal/dashboard"
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/quality/audit"
 	"github.com/cajasmota/archigraph/internal/registry"
 	"github.com/cajasmota/archigraph/internal/resolve"
@@ -487,6 +488,25 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 		// Tell the dashboard server when the daemon started so /api/info
 		// can compute and report uptime (#991).
 		srv.SetDaemonStartedAt(daemonStartedAt)
+
+		// Wire MCP activity broker (epic #1157, Phase 1: Jarvis).
+		// The same broker is injected into the shared MCP server so tool
+		// calls emit events that flow through the dashboard SSE endpoint.
+		activityBroker := mcp.NewMCPActivityBroker()
+		logPath := mcp.DefaultActivityLogPath()
+		if logPath != "" {
+			actLog := mcp.NewActivityLog(logPath)
+			activityBroker.SetLog(actLog)
+			srv.SetMCPActivityLog(logPath)
+		}
+		srv.SetMCPActivityBroker(activityBroker)
+		// Wire the broker into the shared MCP server (lazily initialised).
+		// We call mcpServerInstance here to ensure it exists; on failure we
+		// proceed without activity emission rather than crashing the daemon.
+		if mcpSrv, initErr := mcpServerInstance(); initErr == nil {
+			mcpSrv.SetActivityBroker(activityBroker)
+		}
+
 		srv.UseListener(l)
 		if logger != nil {
 			logger.Printf("dashboard ready http://%s/", addr)

--- a/internal/dashboard/handlers_mcp_activity.go
+++ b/internal/dashboard/handlers_mcp_activity.go
@@ -1,0 +1,130 @@
+package dashboard
+
+// handlers_mcp_activity.go — SSE + history endpoints for MCP query activity
+//
+// Routes registered in server.go:
+//
+//	GET /api/mcp-activity/stream   — live Server-Sent Events (all tool calls)
+//	GET /api/mcp-activity/history  — last N events from disk log
+//
+// Wire format (SSE):
+//
+//	event: connected
+//	data: {"subscribed_at":<unix-ms>}\n\n
+//
+//	event: mcp_activity
+//	data: <JSON-encoded mcp.MCPActivityEvent>\n\n
+//
+//	event: heartbeat
+//	data: {}\n\n
+//
+//	event: close
+//	data: {}\n\n   (sent before server closes the stream)
+//
+// Phase 1 of epic #1157: Jarvis-style real-time MCP query visualization.
+// This file is backend-only; the frontend (Phase 2) subscribes and animates.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// handleMCPActivityStream streams real-time MCP tool call events over SSE.
+// Multiple simultaneous subscribers are supported; they never block each other.
+func (s *Server) handleMCPActivityStream(w http.ResponseWriter, r *http.Request) {
+	if s.mcpActivityBroker == nil {
+		writeErr(w, http.StatusServiceUnavailable, "mcp activity broker not available")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeErr(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	// Proxy-friendly SSE headers.
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	ch, cancel := s.mcpActivityBroker.SubscribeAll()
+	defer cancel()
+
+	subscribedAt := time.Now().UnixMilli()
+	writeSSEEvent(w, "connected", fmt.Sprintf(`{"subscribed_at":%d}`, subscribedAt))
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			writeSSEEvent(w, "close", "{}")
+			flusher.Flush()
+			return
+
+		case e, ok := <-ch:
+			if !ok {
+				writeSSEEvent(w, "close", "{}")
+				flusher.Flush()
+				return
+			}
+			data, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			writeSSEEvent(w, "mcp_activity", string(data))
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			writeSSEEvent(w, "heartbeat", "{}")
+			flusher.Flush()
+		}
+	}
+}
+
+// handleMCPActivityHistory returns the last N events from the on-disk JSONL
+// log. Query param: ?limit=N (default 50, max 500).
+func (s *Server) handleMCPActivityHistory(w http.ResponseWriter, r *http.Request) {
+	if s.mcpActivityLog == "" {
+		writeJSON(w, http.StatusOK, map[string]any{
+			"events": []any{},
+			"count":  0,
+			"note":   "disk activity log not configured",
+		})
+		return
+	}
+
+	limit := 50
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 500 {
+		limit = 500
+	}
+
+	events, err := mcp.ReadHistory(s.mcpActivityLog, limit)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "reading activity log: "+err.Error())
+		return
+	}
+	if events == nil {
+		events = []mcp.MCPActivityEvent{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{
+		"events": events,
+		"count":  len(events),
+	})
+}

--- a/internal/dashboard/handlers_mcp_activity_test.go
+++ b/internal/dashboard/handlers_mcp_activity_test.go
@@ -1,0 +1,229 @@
+package dashboard
+
+// handlers_mcp_activity_test.go — tests for GET /api/mcp-activity/stream
+// and GET /api/mcp-activity/history.
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/mcp"
+)
+
+// newTestServerWithActivityBroker wires an MCPActivityBroker into a minimal
+// dashboard server and returns a running httptest.Server.
+func newTestServerWithActivityBroker(t *testing.T, broker *mcp.MCPActivityBroker) *httptest.Server {
+	t.Helper()
+	srv, err := NewServer(Config{
+		Bind:      "127.0.0.1",
+		PortRange: PortRange{Min: 47300, Max: 47399},
+	}, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.SetMCPActivityBroker(broker)
+	return httptest.NewServer(srv.routes())
+}
+
+// TestMCPActivityStreamConnectedEvent verifies that a subscriber immediately
+// receives the "connected" SSE event.
+func TestMCPActivityStreamConnectedEvent(t *testing.T) {
+	broker := mcp.NewMCPActivityBroker()
+	ts := newTestServerWithActivityBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/mcp-activity/stream", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/mcp-activity/stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if ct := resp.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Errorf("Content-Type = %q; want text/event-stream", ct)
+	}
+
+	// readSSELines returns only the "data:" payloads. The connected event's
+	// data payload contains "subscribed_at".
+	lines := readSSELines(t, bufio.NewReader(resp.Body), 1, 2*time.Second)
+	if len(lines) == 0 {
+		t.Fatalf("received no SSE data lines")
+	}
+	if !strings.Contains(lines[0], "subscribed_at") {
+		t.Errorf("first data line = %q; want subscribed_at field (connected event)", lines[0])
+	}
+}
+
+// TestMCPActivityStreamEventDelivery publishes an event and verifies a
+// subscriber receives it.
+func TestMCPActivityStreamEventDelivery(t *testing.T) {
+	broker := mcp.NewMCPActivityBroker()
+	ts := newTestServerWithActivityBroker(t, broker)
+	defer ts.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/mcp-activity/stream", nil)
+	resp, err := ts.Client().Do(req)
+	if err != nil {
+		t.Fatalf("GET /api/mcp-activity/stream: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Drain the connected event first.
+	r := bufio.NewReader(resp.Body)
+	readSSELines(t, r, 2, 2*time.Second)
+
+	// Publish an activity event.
+	go func() {
+		time.Sleep(50 * time.Millisecond)
+		broker.Publish(mcp.MCPActivityEvent{
+			ToolName:        "archigraph_search_entities",
+			ReturnedNodeIDs: []string{"svc:auth", "svc:billing"},
+		})
+	}()
+
+	lines := readSSELines(t, r, 2, 2*time.Second)
+	found := false
+	for _, l := range lines {
+		if strings.Contains(l, "archigraph_search_entities") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("did not receive mcp_activity event; lines: %v", lines)
+	}
+}
+
+// TestMCPActivityStreamMultipleSubscribers verifies two simultaneous
+// subscribers both receive the same published event.
+func TestMCPActivityStreamMultipleSubscribers(t *testing.T) {
+	broker := mcp.NewMCPActivityBroker()
+	ts := newTestServerWithActivityBroker(t, broker)
+	defer ts.Close()
+
+	subscribe := func() (*bufio.Reader, func()) {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = cancel // context will expire naturally
+		req, _ := http.NewRequestWithContext(ctx, "GET", ts.URL+"/api/mcp-activity/stream", nil)
+		resp, err := ts.Client().Do(req)
+		if err != nil {
+			t.Fatalf("subscribe: %v", err)
+		}
+		r := bufio.NewReader(resp.Body)
+		readSSELines(t, r, 2, 2*time.Second) // drain connected
+		return r, func() { resp.Body.Close() }
+	}
+
+	r1, close1 := subscribe()
+	r2, close2 := subscribe()
+	defer close1()
+	defer close2()
+
+	time.Sleep(30 * time.Millisecond)
+	broker.Publish(mcp.MCPActivityEvent{ToolName: "archigraph_find"})
+
+	for i, r := range []*bufio.Reader{r1, r2} {
+		lines := readSSELines(t, r, 2, 2*time.Second)
+		found := false
+		for _, l := range lines {
+			if strings.Contains(l, "archigraph_find") {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("subscriber %d did not receive event; lines: %v", i+1, lines)
+		}
+	}
+}
+
+// TestMCPActivityStreamNoBroker verifies that 503 is returned when no broker
+// is configured.
+func TestMCPActivityStreamNoBroker(t *testing.T) {
+	srv, err := NewServer(Config{
+		Bind:      "127.0.0.1",
+		PortRange: PortRange{Min: 47300, Max: 47399},
+	}, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// No broker set.
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/mcp-activity/stream")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusServiceUnavailable {
+		t.Errorf("status = %d; want 503", resp.StatusCode)
+	}
+}
+
+// TestMCPActivityHistory verifies the history endpoint reads from the JSONL log.
+func TestMCPActivityHistory(t *testing.T) {
+	srv, err := NewServer(Config{
+		Bind:      "127.0.0.1",
+		PortRange: PortRange{Min: 47300, Max: 47399},
+	}, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Write two events to a temp JSONL file.
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, "mcp-activity.jsonl")
+	events := []mcp.MCPActivityEvent{
+		{ToolName: "archigraph_find", Timestamp: 1000},
+		{ToolName: "archigraph_inspect", Timestamp: 2000},
+	}
+	f, _ := os.Create(logPath)
+	enc := json.NewEncoder(f)
+	for _, e := range events {
+		_ = enc.Encode(e)
+	}
+	f.Close()
+
+	srv.SetMCPActivityLog(logPath)
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := ts.Client().Get(ts.URL + "/api/mcp-activity/history?limit=10")
+	if err != nil {
+		t.Fatalf("GET history: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+
+	var body struct {
+		Events []mcp.MCPActivityEvent `json:"events"`
+		Count  int                    `json:"count"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode response: %v", err)
+	}
+	if body.Count != 2 {
+		t.Errorf("count = %d; want 2", body.Count)
+	}
+	if len(body.Events) < 2 {
+		t.Fatalf("events len = %d; want 2", len(body.Events))
+	}
+	if body.Events[0].ToolName != "archigraph_find" {
+		t.Errorf("events[0].ToolName = %q; want archigraph_find", body.Events[0].ToolName)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/progress"
 )
 
@@ -35,6 +36,15 @@ type Server struct {
 	// It is optional: when nil the /api/index-progress endpoints return 503.
 	// Set via SetProgressBroker before calling Serve.
 	progressBroker *progress.Broker
+
+	// mcpActivityBroker is the fan-out bus for MCP tool call events (epic #1157).
+	// Optional: when nil, /api/mcp-activity/stream returns 503.
+	// Set via SetMCPActivityBroker before calling Serve.
+	mcpActivityBroker *mcp.MCPActivityBroker
+
+	// mcpActivityLog is the absolute path to the on-disk JSONL activity log.
+	// Empty string disables the /api/mcp-activity/history endpoint.
+	mcpActivityLog string
 }
 
 // NewServer wires a server against the given config and registry-store
@@ -70,6 +80,19 @@ func (s *Server) SetDaemonStartedAt(t time.Time) {
 // cmd/archigraph (or any daemon entrypoint) before Serve.
 func (s *Server) SetProgressBroker(b *progress.Broker) {
 	s.progressBroker = b
+}
+
+// SetMCPActivityBroker wires the MCP activity broker into the dashboard server
+// so that /api/mcp-activity/stream can fan events to browser subscribers.
+// Call from the daemon entrypoint before Serve (epic #1157, Phase 1).
+func (s *Server) SetMCPActivityBroker(b *mcp.MCPActivityBroker) {
+	s.mcpActivityBroker = b
+}
+
+// SetMCPActivityLog sets the path to the on-disk JSONL activity log. When set,
+// /api/mcp-activity/history will read recent events from this file.
+func (s *Server) SetMCPActivityLog(path string) {
+	s.mcpActivityLog = path
 }
 
 // Listen binds to a random free port within cfg.PortRange. It is
@@ -255,6 +278,10 @@ func (s *Server) routes() http.Handler {
 	// SSE progress streams (Sub-C of epic #1118)
 	mux.HandleFunc("GET /api/index-progress", s.handleIndexProgressAll)
 	mux.HandleFunc("GET /api/index-progress/{group}", s.handleIndexProgressGroup)
+
+	// MCP activity stream + history (Phase 1 of epic #1157 — Jarvis)
+	mux.HandleFunc("GET /api/mcp-activity/stream", s.handleMCPActivityStream)
+	mux.HandleFunc("GET /api/mcp-activity/history", s.handleMCPActivityHistory)
 
 	return s.withAuth(mux)
 }

--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -1,0 +1,170 @@
+// Package mcp — activity.go
+//
+// MCPActivityEvent is the wire shape for a single MCP tool invocation.
+// MCPActivityBroker fans events to SSE subscribers (Phase 1 of epic #1157:
+// Jarvis-style real-time visualization). It follows the same drop-on-full,
+// non-blocking pattern as internal/progress.Broker so no handler is ever
+// stalled by a slow HTTP client.
+package mcp
+
+import (
+	"os"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// Event
+// ---------------------------------------------------------------------------
+
+// MCPActivityEvent describes one MCP tool call and the graph objects it touched.
+// All fields are JSON-serialisable so the SSE endpoint can forward verbatim.
+type MCPActivityEvent struct {
+	// ToolName is the MCP tool that was invoked (e.g. "archigraph_search_entities").
+	ToolName string `json:"tool_name"`
+
+	// QueryArgs is a shallow copy of the tool arguments that drove the call.
+	// Values are the raw interface{} from the CallToolRequest arguments map.
+	QueryArgs map[string]any `json:"query_args,omitempty"`
+
+	// ReturnedNodeIDs is the list of entity IDs included in the response.
+	// Empty when the tool does not operate on specific entities.
+	ReturnedNodeIDs []string `json:"returned_node_ids,omitempty"`
+
+	// ReturnedEdgeIDs is the list of relationship IDs included in the response.
+	ReturnedEdgeIDs []string `json:"returned_edge_ids,omitempty"`
+
+	// AgentID is derived from the MCP session or request context. Populated
+	// by the wrap middleware; empty when the origin cannot be determined.
+	// Phase 2 will use this for per-agent color tinting on the graph.
+	AgentID string `json:"agent_id,omitempty"`
+
+	// Timestamp is Unix milliseconds when the event was emitted.
+	Timestamp int64 `json:"timestamp"`
+}
+
+// ---------------------------------------------------------------------------
+// Broker
+// ---------------------------------------------------------------------------
+
+const (
+	activityDefaultBuffer = 128
+	activityWildcard      = "\x00wildcard"
+)
+
+func activityBufferSize() int {
+	if v := os.Getenv("ARCHIGRAPH_ACTIVITY_BUFFER"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return activityDefaultBuffer
+}
+
+type activitySub struct {
+	ch chan MCPActivityEvent
+}
+
+// MCPActivityBroker is a fan-out pub/sub bus for MCP tool call events.
+// One instance lives for the daemon process lifetime. Tool handlers publish
+// after returning; SSE subscribers in the dashboard receive events.
+//
+// Publish is non-blocking: if a subscriber's buffer is full the event is
+// silently dropped so no tool handler ever stalls.
+type MCPActivityBroker struct {
+	mu   sync.RWMutex
+	subs map[string][]*activitySub
+
+	// log is the optional disk sink. Nil when disk logging is disabled.
+	log *ActivityLog
+}
+
+// NewMCPActivityBroker constructs an empty broker.
+func NewMCPActivityBroker() *MCPActivityBroker {
+	return &MCPActivityBroker{
+		subs: make(map[string][]*activitySub),
+	}
+}
+
+// SetLog attaches a disk log to the broker. After this call every event
+// published to the broker is also written to disk asynchronously.
+func (b *MCPActivityBroker) SetLog(l *ActivityLog) {
+	b.mu.Lock()
+	b.log = l
+	b.mu.Unlock()
+}
+
+// Publish fans e out to every subscriber and (optionally) appends it to the
+// disk log. Non-blocking: slow subscribers are silently dropped.
+func (b *MCPActivityBroker) Publish(e MCPActivityEvent) {
+	if e.Timestamp == 0 {
+		e.Timestamp = time.Now().UnixMilli()
+	}
+	b.mu.RLock()
+	var targets []*activitySub
+	targets = append(targets, b.subs[activityWildcard]...)
+	b.mu.RUnlock()
+
+	for _, s := range targets {
+		select {
+		case s.ch <- e:
+		default:
+			// subscriber buffer full — drop.
+		}
+	}
+
+	// Disk log — best-effort, no lock needed (ActivityLog is goroutine-safe).
+	b.mu.RLock()
+	l := b.log
+	b.mu.RUnlock()
+	if l != nil {
+		l.Append(e) // non-blocking
+	}
+}
+
+// SubscribeAll returns a receive-only channel that receives every event
+// published to this broker, regardless of tool name. The caller must call
+// the returned cancel function when done (e.g. on HTTP disconnect).
+func (b *MCPActivityBroker) SubscribeAll() (<-chan MCPActivityEvent, func()) {
+	buf := activityBufferSize()
+	s := &activitySub{ch: make(chan MCPActivityEvent, buf)}
+
+	b.mu.Lock()
+	b.subs[activityWildcard] = append(b.subs[activityWildcard], s)
+	b.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			b.removeLocked(s)
+		})
+	}
+	return s.ch, cancel
+}
+
+func (b *MCPActivityBroker) removeLocked(sub *activitySub) {
+	subs := b.subs[activityWildcard]
+	for i, s := range subs {
+		if s == sub {
+			subs[i] = subs[len(subs)-1]
+			subs[len(subs)-1] = nil
+			b.subs[activityWildcard] = subs[:len(subs)-1]
+			break
+		}
+	}
+	if len(b.subs[activityWildcard]) == 0 {
+		delete(b.subs, activityWildcard)
+	}
+	close(sub.ch)
+}
+
+// SubscriberCount returns the number of active SSE subscribers. Intended for
+// diagnostics / healthz endpoints.
+func (b *MCPActivityBroker) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs[activityWildcard])
+}

--- a/internal/mcp/activity_log.go
+++ b/internal/mcp/activity_log.go
@@ -1,0 +1,177 @@
+// Package mcp — activity_log.go
+//
+// ActivityLog writes MCP activity events to a rotating JSONL file at
+// ~/.archigraph/mcp-activity.jsonl. Each line is a JSON-encoded
+// MCPActivityEvent. The log file is rotated when it exceeds maxLogBytes
+// (the previous file is renamed with a .1 suffix, capping disk usage to
+// 2 × maxLogBytes). All disk I/O is non-blocking: Append queues events to
+// an internal channel; a single goroutine drains it and flushes to disk.
+package mcp
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+const (
+	// maxLogBytes is the rotation threshold for the activity JSONL file.
+	// At 10 MiB the file is renamed .1 and a new file is started.
+	maxLogBytes = 10 * 1024 * 1024 // 10 MiB
+
+	// activityLogFile is the base file name inside ~/.archigraph/.
+	activityLogFile = "mcp-activity.jsonl"
+
+	// logQueueDepth is the internal channel buffer. Events that overflow
+	// the queue are dropped rather than blocking the caller.
+	logQueueDepth = 512
+)
+
+// ActivityLog is a goroutine-safe, non-blocking rotating JSONL sink.
+type ActivityLog struct {
+	path  string
+	queue chan MCPActivityEvent
+	once  sync.Once
+	done  chan struct{}
+}
+
+// NewActivityLog constructs an ActivityLog that writes to path. The
+// background goroutine is started lazily on the first Append call.
+func NewActivityLog(path string) *ActivityLog {
+	return &ActivityLog{
+		path:  path,
+		queue: make(chan MCPActivityEvent, logQueueDepth),
+		done:  make(chan struct{}),
+	}
+}
+
+// DefaultActivityLogPath returns ~/.archigraph/mcp-activity.jsonl.
+// Returns an empty string when the home directory cannot be determined
+// (the caller should treat that as "disk logging disabled").
+func DefaultActivityLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", activityLogFile)
+}
+
+// Append enqueues e for disk write. Returns immediately; never blocks.
+// The background goroutine (started on first call) performs the actual I/O.
+func (l *ActivityLog) Append(e MCPActivityEvent) {
+	l.once.Do(l.startWorker)
+	select {
+	case l.queue <- e:
+	default:
+		// queue full — drop this event; disk logging is best-effort.
+	}
+}
+
+// Close flushes the remaining queue and stops the background goroutine.
+// After Close returns, further Append calls are silently dropped.
+func (l *ActivityLog) Close() {
+	close(l.queue)
+	<-l.done
+}
+
+// startWorker launches the background I/O goroutine. Called once via
+// sync.Once on the first Append.
+func (l *ActivityLog) startWorker() {
+	go l.worker()
+}
+
+func (l *ActivityLog) worker() {
+	defer close(l.done)
+
+	// Ensure the directory exists. Failure is non-fatal: we just log nothing.
+	dir := filepath.Dir(l.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		// drain the queue without writing.
+		for range l.queue {
+		}
+		return
+	}
+
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		for range l.queue {
+		}
+		return
+	}
+
+	enc := json.NewEncoder(f)
+	written := fileSize(l.path)
+
+	for e := range l.queue {
+		line, err2 := json.Marshal(e)
+		if err2 != nil {
+			continue
+		}
+		n, _ := f.Write(append(line, '\n'))
+		written += int64(n)
+		_ = enc // enc is used for alternative approach; keep for future
+
+		if written >= maxLogBytes {
+			f.Close()
+			rotated := l.path + ".1"
+			_ = os.Rename(l.path, rotated)
+			f, err = os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+			if err != nil {
+				// can't reopen — drain silently.
+				for range l.queue {
+				}
+				return
+			}
+			written = 0
+		}
+	}
+	f.Close()
+}
+
+// fileSize returns the current byte size of path, or 0 on error.
+func fileSize(path string) int64 {
+	if fi, err := os.Stat(path); err == nil {
+		return fi.Size()
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// History reader
+// ---------------------------------------------------------------------------
+
+// ReadHistory reads the last n events from the JSONL log file at path.
+// It reads the entire file (up to 50 MiB) and returns the tail. Intended
+// only for the /api/mcp-activity/history endpoint — not a hot path.
+func ReadHistory(path string, n int) ([]MCPActivityEvent, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var events []MCPActivityEvent
+	// Split on newlines and decode each line.
+	start := 0
+	for i := 0; i <= len(data); i++ {
+		if i == len(data) || data[i] == '\n' {
+			line := data[start:i]
+			start = i + 1
+			if len(line) == 0 {
+				continue
+			}
+			var e MCPActivityEvent
+			if err2 := json.Unmarshal(line, &e); err2 == nil {
+				events = append(events, e)
+			}
+		}
+	}
+
+	if n > 0 && len(events) > n {
+		events = events[len(events)-n:]
+	}
+	return events, nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"os"
 
@@ -49,6 +50,22 @@ type Server struct {
 	Tel   *Telemetry
 	MCP   *mcpsrv.MCPServer
 	cfg   Config
+
+	// activityBroker fans MCP tool call events to SSE subscribers (epic #1157).
+	// Optional: when nil, events are silently dropped.
+	activityBroker *MCPActivityBroker
+}
+
+// SetActivityBroker wires the MCP activity broker into the server so that
+// every tool call emits a real-time MCPActivityEvent to subscribers. Call
+// this from the daemon entrypoint before ServeStdio.
+func (s *Server) SetActivityBroker(b *MCPActivityBroker) {
+	s.activityBroker = b
+}
+
+// ActivityBroker returns the wired broker, or nil when not set.
+func (s *Server) ActivityBroker() *MCPActivityBroker {
+	return s.activityBroker
 }
 
 // NewServer wires everything together: loads the registry, performs an
@@ -466,7 +483,8 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_find_paths", s.handleFindPaths))
 }
 
-// wrap is the shared handler middleware: telemetry + lazy reload + panic guard.
+// wrap is the shared handler middleware: telemetry + lazy reload + panic guard
+// + MCP activity event emission (epic #1157, Phase 1).
 func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error)) mcpsrv.ToolHandlerFunc {
 	return func(ctx context.Context, req mcpapi.CallToolRequest) (res *mcpapi.CallToolResult, err error) {
 		end := s.Tel.Begin(name)
@@ -475,6 +493,118 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 			end(isErr)
 		}()
 		s.reloadBeforeCall()
-		return fn(ctx, req)
+		res, err = fn(ctx, req)
+		s.emitActivity(ctx, name, req, res)
+		return res, err
 	}
+}
+
+// emitActivity publishes a MCPActivityEvent to the activity broker (when
+// wired). It is called after every tool handler returns. The agent_id is
+// derived from the "archigraph-agent-id" context value when set, or falls
+// back to the User-Agent extracted at session accept time.
+func (s *Server) emitActivity(_ context.Context, toolName string, req mcpapi.CallToolRequest, res *mcpapi.CallToolResult) {
+	if s.activityBroker == nil {
+		return
+	}
+	args := req.GetArguments()
+	// Build a safe copy of args (values are already JSON-friendly interface{}s).
+	argsCopy := make(map[string]any, len(args))
+	for k, v := range args {
+		argsCopy[k] = v
+	}
+	event := MCPActivityEvent{
+		ToolName:  toolName,
+		QueryArgs: argsCopy,
+		Timestamp: 0, // broker will fill this in
+	}
+	// Extract node/edge IDs from the result content when present.
+	if res != nil && !res.IsError {
+		event.ReturnedNodeIDs, event.ReturnedEdgeIDs = extractIDs(res)
+	}
+	s.activityBroker.Publish(event)
+}
+
+// extractIDs attempts to pull entity IDs and edge IDs out of a tool result's
+// JSON content. It is best-effort: returns nil slices on any parse failure.
+// mcp-go stores []Content where each element may be TextContent, ImageContent,
+// etc. We type-assert to mcpapi.TextContent and parse the text as JSON.
+func extractIDs(res *mcpapi.CallToolResult) (nodeIDs, edgeIDs []string) {
+	if res == nil || len(res.Content) == 0 {
+		return
+	}
+	for _, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok || tc.Text == "" {
+			continue
+		}
+		// Parse the text body as JSON and probe for known ID-bearing fields.
+		var payload map[string]any
+		if err := json.Unmarshal([]byte(tc.Text), &payload); err != nil {
+			continue
+		}
+		nodeIDs = append(nodeIDs, collectScalarIDs(payload,
+			"entity_id", "node_id", "pattern_id", "topic_id", "process_id")...)
+		nodeIDs = append(nodeIDs, collectSliceIDs(payload,
+			"results", "nodes", "steps", "orphans", "patterns", "orphan_publishers",
+			"orphan_subscribers", "dead_ends", "truncated_flows", "publishers",
+			"subscribers", "exemplars")...)
+		edgeIDs = append(edgeIDs, collectSliceIDs(payload, "edges")...)
+	}
+	return dedup(nodeIDs), dedup(edgeIDs)
+}
+
+// collectScalarIDs extracts scalar string values for the given keys from a
+// JSON payload map.
+func collectScalarIDs(m map[string]any, keys ...string) []string {
+	var out []string
+	for _, k := range keys {
+		if v, ok := m[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// collectSliceIDs extracts entity_id / from_id / to_id strings from an
+// array value at each key in m.
+func collectSliceIDs(m map[string]any, keys ...string) []string {
+	var out []string
+	for _, k := range keys {
+		v, ok := m[k]
+		if !ok {
+			continue
+		}
+		arr, ok := v.([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range arr {
+			obj, ok := item.(map[string]any)
+			if !ok {
+				continue
+			}
+			for _, field := range []string{"entity_id", "node_id", "from_id", "to_id", "pattern_id", "topic_id", "process_id"} {
+				if s, ok := obj[field].(string); ok && s != "" {
+					out = append(out, s)
+				}
+			}
+		}
+	}
+	return out
+}
+
+// dedup removes duplicate strings preserving order.
+func dedup(in []string) []string {
+	seen := make(map[string]bool, len(in))
+	out := make([]string, 0, len(in))
+	for _, s := range in {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
 }


### PR DESCRIPTION
## What

Phase 1 of epic #1157 (Jarvis-style real-time MCP query visualization). Backend foundation only — Phase 2 will add the frontend graph subscription and animation.

Closes #1215.

## Why

The Jarvis vision requires the dashboard to know in real-time which graph nodes an AI agent is querying. Before we can animate anything in the browser we need a reliable event pipeline from MCP tool handlers → SSE endpoint.

## What changed

| File | Role |
|---|---|
| `internal/mcp/activity.go` | `MCPActivityEvent` struct + `MCPActivityBroker` (fan-out pub/sub, same drop-on-full pattern as `internal/progress.Broker`) |
| `internal/mcp/activity_log.go` | Rotating JSONL disk log at `~/.archigraph/mcp-activity.jsonl` (10 MiB rotate, non-blocking goroutine) + `ReadHistory()` for the history endpoint |
| `internal/mcp/server.go` | `SetActivityBroker()` setter; `wrap()` middleware now emits `MCPActivityEvent` after every tool return; `extractIDs()` harvests node/edge IDs from tool results |
| `internal/dashboard/handlers_mcp_activity.go` | `GET /api/mcp-activity/stream` (SSE) + `GET /api/mcp-activity/history?limit=N` |
| `internal/dashboard/server.go` | `SetMCPActivityBroker()` / `SetMCPActivityLog()` setters; routes registered |
| `cmd/archigraph/daemon.go` | Daemon wires `MCPActivityBroker` into both the dashboard server and the shared MCP server on startup |

## Acceptance

```bash
# Terminal 1 — subscribe
curl -N http://localhost:47274/api/mcp-activity/stream

# Terminal 2 — trigger a tool call via any MCP client or:
curl http://localhost:47274/api/mcp-activity/history?limit=5
```

Call `archigraph_search_entities` from any connected MCP client → event appears in the stream within milliseconds. Multiple simultaneous subscribers do not block each other (verified by test).

## Go-beyond additions

- **Rotating JSONL disk log** at `~/.archigraph/mcp-activity.jsonl` — history survives daemon restarts
- **`GET /api/mcp-activity/history?limit=N`** — last N events from disk (max 500)
- **`extractIDs()`** — best-effort harvest of `entity_id`, `node_id`, `from_id`, `to_id` from tool results so events carry `returned_node_ids` / `returned_edge_ids` for Phase 2 graph highlighting
- **5 tests** covering: connected event, event delivery, multi-subscriber fan-out, no-broker 503, history endpoint

## Constraints

- Backend only — no frontend changes (Phase 2)
- No client names in any artifact
- Follows same broker pattern as `internal/progress` (non-blocking, drop-on-full)