### PR TITLE
[#1218] Sub-B: /api/paths/{group} returns definitions grouped by owning_backend

### DIFF
--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -21,7 +21,8 @@ import (
 )
 
 const (
-	httpEndpointKind = "http_endpoint"
+	httpEndpointKind           = "http_endpoint"
+	httpEndpointDefinitionKind = "http_endpoint_definition"
 	// pageSize is kept for backward-compat but the default is now 5000 (all paths).
 	pageSize = 5000
 )
@@ -46,6 +47,29 @@ type PathTreeNode struct {
 	HasPaths bool           `json:"has_paths"`
 }
 
+// BackendEndpointRow is one endpoint definition inside a BackendGroup.
+type BackendEndpointRow struct {
+	PathHash          string   `json:"path_hash"`
+	Path              string   `json:"path"`
+	Verbs             []string `json:"verbs"`
+	Handlers          []string `json:"handlers"`
+	Multiplicity      int      `json:"multiplicity"`
+	Frameworks        []string `json:"frameworks"`
+	IsWebhook         bool     `json:"is_webhook"`
+	Repos             []string `json:"repos"`
+	OwningBackend     string   `json:"owning_backend"`
+	CrossBackendRef   bool     `json:"cross_backend_ref,omitempty"`
+}
+
+// BackendGroup groups endpoint definitions that belong to a single backend service.
+type BackendGroup struct {
+	Name          string               `json:"name"`
+	EndpointCount int                  `json:"endpoint_count"`
+	ServiceType   string               `json:"service_type,omitempty"`
+	Repos         []string             `json:"repos"`
+	Endpoints     []BackendEndpointRow `json:"endpoints"`
+}
+
 // handlePathsList — GET /api/paths/{group}
 func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 	group := r.PathValue("group")
@@ -66,17 +90,19 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Collect all http_endpoint entities across repos.
+	// Collect all http_endpoint / http_endpoint_definition entities across repos.
 	type rawEndpoint struct {
-		ID         string
-		Path       string
-		Verb       string
-		Handler    string
-		Framework  string
-		IsWebhook  bool
-		Repo       string
-		SourceFile string
-		StartLine  int
+		ID            string
+		Path          string
+		Verb          string
+		Handler       string
+		Framework     string
+		IsWebhook     bool
+		Repo          string
+		SourceFile    string
+		StartLine     int
+		OwningBackend string
+		IsDefinition  bool // true when kind == http_endpoint_definition
 	}
 
 	var endpoints []rawEndpoint
@@ -86,8 +112,11 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 		}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
-			if !strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) &&
-				e.Kind != "Endpoint" && e.Kind != "Route" {
+			kind := dashStripScopePrefix(e.Kind)
+			isDefinition := strings.EqualFold(kind, httpEndpointDefinitionKind)
+			isEndpoint := strings.EqualFold(kind, httpEndpointKind) ||
+				e.Kind == "Endpoint" || e.Kind == "Route"
+			if !isDefinition && !isEndpoint {
 				continue
 			}
 			// Skip frontend-only synthetic call-site entries — those belong
@@ -117,24 +146,36 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 			}
 			framework := e.Properties["framework"]
 			isWebhook := e.Properties["is_webhook"] == "true"
+			owningBackend := e.Properties["owning_backend"]
+			if owningBackend == "" {
+				// Fallback heuristic: use the handler name prefix or repo slug
+				// to infer a backend name when the property is absent (#1217
+				// may not have landed yet).
+				owningBackend = inferOwningBackend(e.Name, r.Slug)
+			}
 			endpoints = append(endpoints, rawEndpoint{
-				ID:         dashPrefixedID(r.Slug, e.ID),
-				Path:       path,
-				Verb:       verb,
-				Handler:    e.Name,
-				Framework:  framework,
-				IsWebhook:  isWebhook,
-				Repo:       r.Slug,
-				SourceFile: e.SourceFile,
-				StartLine:  e.StartLine,
+				ID:            dashPrefixedID(r.Slug, e.ID),
+				Path:          path,
+				Verb:          verb,
+				Handler:       e.Name,
+				Framework:     framework,
+				IsWebhook:     isWebhook,
+				Repo:          r.Slug,
+				SourceFile:    e.SourceFile,
+				StartLine:     e.StartLine,
+				OwningBackend: owningBackend,
+				IsDefinition:  isDefinition,
 			})
 		}
 	}
 
-	// Group by path.
+	// Group by path (flat list — kept for backward compat).
 	type pathKey = string
 	grouped := map[pathKey]*PathRow{}
 	pathOrder := []string{}
+
+	// Also track per-path owning backend (first seen wins for the flat list).
+	pathBackend := map[pathKey]string{}
 
 	for _, ep := range endpoints {
 		if _, ok := grouped[ep.Path]; !ok {
@@ -147,6 +188,7 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 				Repos:      []string{},
 			}
 			pathOrder = append(pathOrder, ep.Path)
+			pathBackend[ep.Path] = ep.OwningBackend
 		}
 		pr := grouped[ep.Path]
 		pr.Multiplicity++
@@ -204,10 +246,23 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 
 	total := len(rows)
 
+	// Build owning_backends grouping (new response field — sub-B #1218).
+	// Convert local rawEndpoint slice to the exported type for the grouping helper.
+	groupingEps := make([]rawEndpointForGrouping, len(endpoints))
+	for i, ep := range endpoints {
+		groupingEps[i] = rawEndpointForGrouping{
+			Path:          ep.Path,
+			Repo:          ep.Repo,
+			OwningBackend: ep.OwningBackend,
+		}
+	}
+	owningBackends := buildOwningBackends(rows, groupingEps, pathBackend)
+
 	writeJSON(w, http.StatusOK, map[string]any{
-		"paths": rows,
-		"tree":  tree,
-		"total": total,
+		"paths":           rows,
+		"tree":            tree,
+		"total":           total,
+		"owning_backends": owningBackends,
 	})
 }
 
@@ -536,6 +591,164 @@ func buildPrefixTree(rows []PathRow) []PathTreeNode {
 		return out
 	}
 	return toNodes(root)
+}
+
+// buildOwningBackends groups filtered path rows by owning_backend, computes
+// aggregates, infers service_type, and sets cross_backend_ref for endpoints
+// referenced from another backend's repo. Backends are sorted by endpoint
+// count descending.
+//
+// rawEps is the full (unfiltered) endpoint slice used to detect cross-backend
+// references. pathBackend maps path strings to their primary owning backend.
+func buildOwningBackends(rows []PathRow, rawEps []rawEndpointForGrouping, pathBackend map[string]string) []BackendGroup {
+	// backend name → BackendGroup builder state
+	type backendState struct {
+		name      string
+		endpoints map[string]*BackendEndpointRow // keyed by path
+		repoSet   map[string]bool
+	}
+	states := map[string]*backendState{}
+	order := []string{}
+
+	for _, row := range rows {
+		backend := pathBackend[row.Path]
+		if backend == "" {
+			backend = "unknown"
+		}
+		if _, ok := states[backend]; !ok {
+			states[backend] = &backendState{
+				name:      backend,
+				endpoints: map[string]*BackendEndpointRow{},
+				repoSet:   map[string]bool{},
+			}
+			order = append(order, backend)
+		}
+		st := states[backend]
+		if _, ok := st.endpoints[row.Path]; !ok {
+			st.endpoints[row.Path] = &BackendEndpointRow{
+				PathHash:      row.PathHash,
+				Path:          row.Path,
+				Verbs:         row.Verbs,
+				Handlers:      row.Handlers,
+				Multiplicity:  row.Multiplicity,
+				Frameworks:    row.Frameworks,
+				IsWebhook:     row.IsWebhook,
+				Repos:         row.Repos,
+				OwningBackend: backend,
+			}
+		}
+		for _, repo := range row.Repos {
+			st.repoSet[repo] = true
+		}
+	}
+
+	// Build a set of (path, backend) pairs so we can detect cross-backend refs:
+	// an endpoint is cross-backend if another backend's repo also references it.
+	// We use the raw endpoints to find repos that reference each path.
+	pathRepoBackend := map[string]map[string]string{} // path → repo → owning_backend
+	for _, ep := range rawEps {
+		if _, ok := pathRepoBackend[ep.Path]; !ok {
+			pathRepoBackend[ep.Path] = map[string]string{}
+		}
+		pathRepoBackend[ep.Path][ep.Repo] = ep.OwningBackend
+	}
+
+	// Mark cross-backend refs and collect service types.
+	for _, st := range states {
+		for path, epRow := range st.endpoints {
+			repoBackends := pathRepoBackend[path]
+			for _, rb := range repoBackends {
+				if rb != st.name {
+					epRow.CrossBackendRef = true
+					break
+				}
+			}
+		}
+	}
+
+	// Convert to slice, infer service_type, sort by endpoint_count desc.
+	groups := make([]BackendGroup, 0, len(states))
+	for _, name := range order {
+		st := states[name]
+		eps := make([]BackendEndpointRow, 0, len(st.endpoints))
+		for _, ep := range st.endpoints {
+			eps = append(eps, *ep)
+		}
+		// Sort endpoints within each backend by path for determinism.
+		sort.Slice(eps, func(i, j int) bool { return eps[i].Path < eps[j].Path })
+
+		repos := make([]string, 0, len(st.repoSet))
+		for r := range st.repoSet {
+			repos = append(repos, r)
+		}
+		sort.Strings(repos)
+
+		groups = append(groups, BackendGroup{
+			Name:          name,
+			EndpointCount: len(eps),
+			ServiceType:   inferServiceType(name, repos),
+			Repos:         repos,
+			Endpoints:     eps,
+		})
+	}
+	sort.Slice(groups, func(i, j int) bool {
+		if groups[i].EndpointCount != groups[j].EndpointCount {
+			return groups[i].EndpointCount > groups[j].EndpointCount
+		}
+		return groups[i].Name < groups[j].Name
+	})
+	return groups
+}
+
+// rawEndpointForGrouping is an alias so buildOwningBackends can access the
+// rawEndpoint fields without the local type escaping the function scope.
+// We re-declare a minimal struct here to avoid coupling to the local type
+// declared inside handlePathsList.
+type rawEndpointForGrouping struct {
+	Path          string
+	Repo          string
+	OwningBackend string
+}
+
+// inferOwningBackend derives a backend name from an entity name or repo slug
+// when the owning_backend property is absent (pre-#1217 graphs).
+//
+// Heuristic: if the handler name contains a recognisable suffix like "Handler",
+// "Controller", "Router", or "Service" preceded by a capitalised word, strip
+// the suffix and lower-case the root.  Otherwise fall back to the repo slug.
+func inferOwningBackend(handlerName, repoSlug string) string {
+	suffixes := []string{"Handler", "Controller", "Router", "Service", "View"}
+	for _, suf := range suffixes {
+		if idx := strings.Index(handlerName, suf); idx > 0 {
+			root := handlerName[:idx]
+			if root != "" {
+				return strings.ToLower(root)
+			}
+		}
+	}
+	return repoSlug
+}
+
+// inferServiceType returns a best-guess service_type label for a backend based
+// on its name and repo list.  Categories: api, web, cron, worker.
+func inferServiceType(backendName string, repos []string) string {
+	combined := strings.ToLower(backendName)
+	for _, r := range repos {
+		combined += " " + strings.ToLower(r)
+	}
+	switch {
+	case strings.Contains(combined, "cron") || strings.Contains(combined, "scheduler") ||
+		strings.Contains(combined, "beat"):
+		return "cron"
+	case strings.Contains(combined, "worker") || strings.Contains(combined, "celery") ||
+		strings.Contains(combined, "consumer") || strings.Contains(combined, "queue"):
+		return "worker"
+	case strings.Contains(combined, "web") || strings.Contains(combined, "frontend") ||
+		strings.Contains(combined, "ui") || strings.Contains(combined, "spa"):
+		return "web"
+	default:
+		return "api"
+	}
 }
 
 // isHTTPEndpointPath reports whether path looks like a real HTTP endpoint

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -520,6 +520,224 @@ func TestPathsList_SearchFilter(t *testing.T) {
 	}
 }
 
+// TestPathsList_OwningBackends_Present verifies that owning_backends is
+// present in the response and has at least one entry (#1218).
+func TestPathsList_OwningBackends_Present(t *testing.T) {
+	ts, _ := newPhase1Server(t)
+	code, body := getJSON(t, ts.URL, "/api/paths/testgroup")
+	if code != 200 {
+		t.Fatalf("status=%d", code)
+	}
+	// owning_backends must be present and be an array.
+	raw, ok := body["owning_backends"]
+	if !ok {
+		t.Fatalf("owning_backends missing from response")
+	}
+	backends, ok := raw.([]interface{})
+	if !ok {
+		t.Fatalf("owning_backends is not an array: %T", raw)
+	}
+	if len(backends) == 0 {
+		t.Fatalf("expected at least 1 backend entry, got 0")
+	}
+	// Verify required fields are present on each entry.
+	for i, b := range backends {
+		bm, ok := b.(map[string]any)
+		if !ok {
+			t.Fatalf("backend[%d] is not an object", i)
+		}
+		if bm["name"] == nil {
+			t.Errorf("backend[%d] missing name", i)
+		}
+		if bm["endpoint_count"] == nil {
+			t.Errorf("backend[%d] missing endpoint_count", i)
+		}
+		if bm["endpoints"] == nil {
+			t.Errorf("backend[%d] missing endpoints array", i)
+		}
+		if bm["repos"] == nil {
+			t.Errorf("backend[%d] missing repos array", i)
+		}
+	}
+}
+
+// TestPathsList_OwningBackends_MultiBackend verifies that a group with
+// two repos each owning distinct http_endpoint_definition entities produces
+// two entries in owning_backends sorted by endpoint_count descending.
+func TestPathsList_OwningBackends_MultiBackend(t *testing.T) {
+	st := newFakeStore()
+	st.groups["multigrp"] = GroupSummary{
+		Name:       "multigrp",
+		ConfigPath: "/tmp/multigrp.json",
+		Repos:      []string{"core-api", "admin-api"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// core-api: 3 http_endpoint_definition endpoints owned by "core"
+	coreDoc := &graph.Document{
+		Repo: "core-api",
+		Entities: []graph.Entity{
+			{
+				ID: "ce1", Name: "GET /api/users", Kind: "http_endpoint_definition",
+				SourceFile: "routes.go", Language: "go",
+				Properties: map[string]string{"verb": "GET", "path": "/api/users", "owning_backend": "core"},
+			},
+			{
+				ID: "ce2", Name: "POST /api/users", Kind: "http_endpoint_definition",
+				SourceFile: "routes.go", Language: "go",
+				Properties: map[string]string{"verb": "POST", "path": "/api/users/create", "owning_backend": "core"},
+			},
+			{
+				ID: "ce3", Name: "GET /api/products", Kind: "http_endpoint_definition",
+				SourceFile: "routes.go", Language: "go",
+				Properties: map[string]string{"verb": "GET", "path": "/api/products", "owning_backend": "core"},
+			},
+		},
+	}
+	// admin-api: 1 http_endpoint_definition endpoint owned by "admin"
+	adminDoc := &graph.Document{
+		Repo: "admin-api",
+		Entities: []graph.Entity{
+			{
+				ID: "ae1", Name: "GET /admin/users", Kind: "http_endpoint_definition",
+				SourceFile: "admin_routes.go", Language: "go",
+				Properties: map[string]string{"verb": "GET", "path": "/admin/users", "owning_backend": "admin"},
+			},
+		},
+	}
+
+	grp := &DashGroup{
+		Name: "multigrp",
+		Repos: map[string]*DashRepo{
+			"core-api":  {Slug: "core-api", Path: "/tmp/core-api", Doc: coreDoc},
+			"admin-api": {Slug: "admin-api", Path: "/tmp/admin-api", Doc: adminDoc},
+		},
+		Links: []CrossRepoLink{},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["multigrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	code, body := getJSON(t, ts.URL, "/api/paths/multigrp")
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	backends, ok := body["owning_backends"].([]interface{})
+	if !ok {
+		t.Fatalf("owning_backends missing or not array: %v", body["owning_backends"])
+	}
+	if len(backends) != 2 {
+		t.Fatalf("expected 2 backends (core, admin), got %d: %v", len(backends), backends)
+	}
+
+	// First backend should be "core" (3 endpoints > 1 endpoint).
+	first := backends[0].(map[string]any)
+	if first["name"] != "core" {
+		t.Errorf("expected first backend = core (most endpoints), got %v", first["name"])
+	}
+	firstCount := int(first["endpoint_count"].(float64))
+	if firstCount != 3 {
+		t.Errorf("expected core endpoint_count=3, got %d", firstCount)
+	}
+
+	second := backends[1].(map[string]any)
+	if second["name"] != "admin" {
+		t.Errorf("expected second backend = admin, got %v", second["name"])
+	}
+	secondCount := int(second["endpoint_count"].(float64))
+	if secondCount != 1 {
+		t.Errorf("expected admin endpoint_count=1, got %d", secondCount)
+	}
+
+	// Verify total endpoint count across backends matches top-level total.
+	total := int(body["total"].(float64))
+	if total != firstCount+secondCount {
+		t.Errorf("total=%d does not match sum of backend counts %d+%d", total, firstCount, secondCount)
+	}
+}
+
+// TestPathsList_OwningBackends_SingleBackend verifies that a group with all
+// endpoints from one backend produces exactly one entry in owning_backends.
+func TestPathsList_OwningBackends_SingleBackend(t *testing.T) {
+	st := newFakeStore()
+	st.groups["singlegrp"] = GroupSummary{
+		Name:       "singlegrp",
+		ConfigPath: "/tmp/singlegrp.json",
+		Repos:      []string{"my-api"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	doc := &graph.Document{
+		Repo: "my-api",
+		Entities: []graph.Entity{
+			{
+				ID: "ep1", Name: "GET /health", Kind: "http_endpoint_definition",
+				SourceFile: "routes.go", Language: "go",
+				Properties: map[string]string{"verb": "GET", "path": "/health", "owning_backend": "my-api"},
+			},
+			{
+				ID: "ep2", Name: "GET /api/items", Kind: "http_endpoint_definition",
+				SourceFile: "routes.go", Language: "go",
+				Properties: map[string]string{"verb": "GET", "path": "/api/items", "owning_backend": "my-api"},
+			},
+		},
+	}
+
+	grp := &DashGroup{
+		Name: "singlegrp",
+		Repos: map[string]*DashRepo{
+			"my-api": {Slug: "my-api", Path: "/tmp/my-api", Doc: doc},
+		},
+		Links: []CrossRepoLink{},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["singlegrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	code, body := getJSON(t, ts.URL, "/api/paths/singlegrp")
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	backends, ok := body["owning_backends"].([]interface{})
+	if !ok {
+		t.Fatalf("owning_backends missing or not array: %v", body["owning_backends"])
+	}
+	if len(backends) != 1 {
+		t.Fatalf("expected 1 backend entry for single-backend group, got %d", len(backends))
+	}
+
+	bm := backends[0].(map[string]any)
+	if bm["name"] != "my-api" {
+		t.Errorf("expected backend name my-api, got %v", bm["name"])
+	}
+	cnt := int(bm["endpoint_count"].(float64))
+	if cnt != 2 {
+		t.Errorf("expected endpoint_count=2, got %d", cnt)
+	}
+
+	// Count math: total must equal sum of backend endpoint_counts.
+	total := int(body["total"].(float64))
+	if total != cnt {
+		t.Errorf("total=%d does not match backend endpoint_count=%d", total, cnt)
+	}
+}
+
 // TestIsHTTPEndpointPath verifies the path-shape predicate used by the
 // Paths list API to filter out XML namespace XPath strings (issue #1125).
 func TestIsHTTPEndpointPath(t *testing.T) {


### PR DESCRIPTION
## Summary

\`GET /api/paths/{group}\` now recognises \`http_endpoint_definition\` entities (introduced by Sub-A #1217) and adds a new top-level \`owning_backends\` field to the response that groups endpoint definitions by their owning backend service. The existing \`paths\`, \`tree\`, and \`total\` fields are unchanged — this is fully backward-compatible.

**New response shape (added field only):**
\`\`\`json
{
  "owning_backends": [
    { "name": "core-api", "endpoint_count": 80, "service_type": "api", "repos": ["core-api"], "endpoints": [...] },
    { "name": "admin-api", "endpoint_count": 30, "service_type": "api", "repos": ["admin-api"], "endpoints": [...] }
  ],
  "paths": [...],
  "tree": [...],
  "total": 110
}
\`\`\`

## Closes / Refs

- Closes #1218
- Refs #1115 (parent epic)

## What changed

**\`internal/dashboard/handlers_paths.go\`**
- Added \`httpEndpointDefinitionKind = "http_endpoint_definition"\` constant.
- Extended \`rawEndpoint\` with \`OwningBackend\` and \`IsDefinition\` fields.
- Kind filter accepts both \`http_endpoint_definition\` (post-#1217) and legacy \`http_endpoint\` / \`Endpoint\` / \`Route\` — no entities are dropped if #1217 hasn't landed.
- Added \`inferOwningBackend()\`: derives backend name from handler suffix (Handler/Controller/Router/Service/View) or falls back to repo slug.
- Added \`inferServiceType()\`: classifies backends as \`api\`, \`web\`, \`cron\`, or \`worker\` from name/repo keywords.
- Added \`buildOwningBackends()\`: groups filtered rows by \`owning_backend\`, computes \`endpoint_count\`, sets \`cross_backend_ref\` for cross-backend references, sorts by count descending.
- New response structs: \`BackendEndpointRow\`, \`BackendGroup\`.
- \`owning_backends\` included in JSON alongside the existing fields.

**\`internal/dashboard/handlers_phase1_test.go\`**
- \`TestPathsList_OwningBackends_Present\` — shape validation on default fixture.
- \`TestPathsList_OwningBackends_MultiBackend\` — 2 repos × 2 backends; verifies count-descending sort and total-math invariant.
- \`TestPathsList_OwningBackends_SingleBackend\` — degenerate single-backend case.

## Testing
- [x] All tests pass: \`go test ./internal/dashboard/... -timeout 120s\` — ok (13.15 s)
- [x] New fixtures cover: 2-backend ordering, 1-backend degenerate, field presence
- [x] Existing paths/prefix/search/detail/XML-noise tests continue to pass (11/11)
- [x] No regression in cross-language parity

## Notes

- Sub-A (#1217) is not required to merge this PR; graphs without \`http_endpoint_definition\` entities work via the fallback kind-filter path and \`inferOwningBackend\` heuristic.
- Sub-C (UI) can be developed against this response shape immediately.
- \`cross_backend_ref\` lights up once multi-repo graphs share paths across backend repos.