### PR TITLE
fix(build): remove em-dash/markdown junk from daemon.go

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -536,7 +536,6 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 		// Tell the dashboard server when the daemon started so /api/info
 		// can compute and report uptime (#991).
 		srv.SetDaemonStartedAt(daemonStartedAt)
-<<<<<<< HEAD
 
 		// Wire MCP activity broker (epic #1157, Phase 1: Jarvis).
 		// The same broker is injected into the shared MCP server so tool
@@ -556,11 +555,9 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 			mcpSrv.SetActivityBroker(activityBroker)
 		}
 
-=======
 		// Wire the recall runner so POST /api/quality/recall can run the
 		// in-process indexer against golden fixtures (#1198).
 		srv.SetRecallRunner(daemonRecallFunc)
->>>>>>> 20aa111 ([dashboard] Quality surface — orphan audit + recall measurement in web UI (#1198))
 		srv.UseListener(l)
 		if logger != nil {
 			logger.Printf("dashboard ready http://%s/", addr)


### PR DESCRIPTION
## Summary

- #1205 was merged with unresolved Git conflict markers left in `cmd/archigraph/daemon.go` (lines 539–563)
- The `>>>>>>> 20aa111 ([dashboard] Quality surface — orphan audit + recall measurement in web UI (#1198))` marker contained a Unicode em-dash (`U+2014`) and a `#` character, causing Go parse errors that broke the entire build:
  ```
  cmd/archigraph/daemon.go:563:46: invalid character U+2014 '—' in identifier
  cmd/archigraph/daemon.go:563:95: invalid character U+0023 '#'
  ```
- Fix: resolve conflict keeping **both** sides — MCP activity broker wiring (HEAD) and `srv.SetRecallRunner(daemonRecallFunc)` (#1198)

## Test plan

- [ ] `go build ./...` passes (requires frontend `dist/` to exist; Go syntax is valid — verified in main worktree which has dist)
- [ ] No conflict markers remain in `cmd/archigraph/daemon.go`
- [ ] Both `SetMCPActivityBroker` and `SetRecallRunner` wiring are present

🤖 Generated with [Claude Code](https://claude.com/claude-code)