### PR TITLE
[#1220] Sub-D: MCP http_endpoint kind alias + 3 focused endpoint tools

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -83,6 +83,9 @@ below; per-tool tables omit them unless the semantics differ.
 | [`archigraph_get_source`](#archigraph_get_source) | Return source-file snippet for a node from disk. |
 | [`archigraph_recent_activity`](#archigraph_recent_activity) | Entities whose source files were modified after a given time. |
 | [`archigraph_get_telemetry`](#archigraph_get_telemetry) | Server uptime, per-tool counters, reload counts. |
+| [`archigraph_endpoint_definitions`](#archigraph_endpoint_definitions) | List HTTP endpoint handler/route definitions. |
+| [`archigraph_endpoint_calls`](#archigraph_endpoint_calls) | List HTTP endpoint call-sites with orphan detection. |
+| [`archigraph_endpoint_stats`](#archigraph_endpoint_stats) | Count http\_endpoint\_definition/call/legacy entities + orphan callers. |
 
 ---
 
@@ -834,6 +837,145 @@ memory directory:
 - **No deduplication beyond the filename hash:** repeated calls with the
   same Q/A in the same UTC second collapse to one file; otherwise a fresh
   file is written.
+
+---
+
+### `archigraph_endpoint_definitions`
+
+> Added in #1220 (Sub-D of paths v2 epic #1115).
+
+List HTTP endpoint handler/route definitions. Returns entities of kind
+`http_endpoint_definition` as well as the legacy `http_endpoint` kind when the
+graph has not yet been re-indexed with Sub-A (#1217). Client-synthesis entities
+(call-side) are excluded.
+
+**Backward-compatibility note:** the legacy `http_endpoint` kind remains valid
+in all kind-filter parameters across the server and will transparently expand to
+both `http_endpoint_definition` and `http_endpoint_call`.
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `repo_filter` | string[] | no | [] | Repos to scope. |
+| `limit` | number | no | 200 | Max results. |
+| `group` / `cwd` | string | no | — | Standard routing args. |
+
+**Output** — JSON object:
+
+```json
+{
+  "definitions": [
+    {
+      "entity_id": "repo1::ep1",
+      "name": "POST /api/v1/orders",
+      "kind": "http_endpoint_definition",
+      "repo": "repo1",
+      "source_file": "routes/orders.go",
+      "start_line": 42,
+      "method": "POST",
+      "path": "/api/v1/orders"
+    }
+  ],
+  "count": 1,
+  "total": 1,
+  "truncated": false,
+  "note": "http_endpoint kind is deprecated; prefer http_endpoint_definition for handler/route entities."
+}
+```
+
+---
+
+### `archigraph_endpoint_calls`
+
+> Added in #1220 (Sub-D of paths v2 epic #1115).
+
+List HTTP endpoint call-sites (consumer side of FETCHES edges). Returns entities
+of kind `http_endpoint_call` plus legacy `http_endpoint` entities whose
+`pattern_type` is `http_endpoint_client_synthesis`. Call-sites with no matching
+definition in the group receive an `orphan_hint` field containing a reasoning
+note.
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `repo_filter` | string[] | no | [] | Repos to scope. |
+| `orphan_only` | boolean | no | false | When true, return only call-sites with no matching definition. |
+| `limit` | number | no | 200 | Max results. |
+| `group` / `cwd` | string | no | — | Standard routing args. |
+
+**Output** — JSON object:
+
+```json
+{
+  "calls": [
+    {
+      "entity_id": "repo1::call1",
+      "name": "fetchOrders",
+      "kind": "http_endpoint_call",
+      "repo": "repo1",
+      "source_file": "services/orders.go",
+      "start_line": 99,
+      "method": "POST",
+      "path": "/api/v1/orders",
+      "matched_definition": "repo1::ep1",
+      "orphan_hint": ""
+    }
+  ],
+  "count": 1,
+  "total": 1,
+  "truncated": false,
+  "note": "http_endpoint kind is deprecated; prefer http_endpoint_call for consumer-side call-site entities."
+}
+```
+
+When `orphan_hint` is non-empty it reads: `"this call to /some/path has no matching definition — see orphan_callers"`.
+
+---
+
+### `archigraph_endpoint_stats`
+
+> Added in #1220 (Sub-D of paths v2 epic #1115).
+
+Return a count breakdown of all HTTP-endpoint kind variants per repo, plus the
+number of orphan call-sites (FETCHES edges whose target is not a definition
+entity). Use to assess Sub-A (#1217) migration progress.
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `repo_filter` | string[] | no | [] | Repos to scope. |
+| `group` / `cwd` | string | no | — | Standard routing args. |
+
+**Output** — JSON object:
+
+```json
+{
+  "totals": {
+    "definitions":  12,
+    "calls":         8,
+    "legacy_kind":   0,
+    "orphan_calls":  2
+  },
+  "per_repo": [
+    {
+      "repo": "orders-service",
+      "definitions": 7,
+      "calls": 5,
+      "legacy_kind": 0,
+      "orphan_calls": 1
+    }
+  ],
+  "migrated": true,
+  "note": ""
+}
+```
+
+`migrated: true` means no legacy `http_endpoint` entities remain — all have been
+split into `http_endpoint_definition` / `http_endpoint_call` by Sub-A (#1217).
+When `migrated: false`, `note` contains a migration reminder.
 
 ---
 

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -495,7 +495,9 @@ func (s *Server) handleQualityOrphans(_ context.Context, req mcpapi.CallToolRequ
 			if connected[e.ID] {
 				continue
 			}
-			if kindFilter != "" && !strings.EqualFold(e.Kind, kindFilter) {
+			// matchesKindFilter expands alias kinds (e.g. "http_endpoint" →
+			// [http_endpoint, http_endpoint_definition, http_endpoint_call]).
+			if !matchesKindFilter(e, kindFilter) {
 				continue
 			}
 			out = append(out, item{
@@ -711,7 +713,9 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 		}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
-			if kindFilter != "" && !strings.EqualFold(e.Kind, kindFilter) {
+			// matchesKindFilter expands alias kinds (e.g. "http_endpoint" →
+			// [http_endpoint, http_endpoint_definition, http_endpoint_call]).
+			if !matchesKindFilter(e, kindFilter) {
 				continue
 			}
 			nameL := strings.ToLower(e.Name)

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -1,0 +1,469 @@
+// endpoint_tools.go — MCP tools for HTTP endpoint kinds (#1220).
+//
+// # Backward-compatibility aliasing
+//
+// Sub-A (#1217) splits the single "http_endpoint" kind into two finer-grained
+// kinds:
+//
+//	http_endpoint_definition — the handler/route that defines an HTTP endpoint
+//	http_endpoint_call       — a call-site (FETCHES edge source) that invokes one
+//
+// This file provides:
+//   - expandKindAlias: normalises a caller-supplied kind string so that the
+//     legacy "http_endpoint" value transparently expands to both new kinds. Any
+//     query that already uses "http_endpoint_definition" or "http_endpoint_call"
+//     continues to work as-is (no expansion needed).
+//   - matchesKindFilter: a drop-in replacement for the old
+//     strings.EqualFold(e.Kind, kindFilter) guard used by handleQualityOrphans
+//     and handleSearchEntities. It calls expandKindAlias so those tools gain
+//     alias support without further changes.
+//   - Three new focused tools:
+//       archigraph_endpoint_definitions — list definition-side entities only
+//       archigraph_endpoint_calls       — list call-site entities only
+//       archigraph_endpoint_stats       — counts of each kind + orphan summary
+//
+// Migration path (for agents and external callers)
+//
+//	Old value          Still works?  New preferred values
+//	──────────────────────────────────────────────────────
+//	http_endpoint      YES (alias)   http_endpoint_definition, http_endpoint_call
+//	http_endpoint_def… YES (exact)   (unchanged)
+//	http_endpoint_cal… YES (exact)   (unchanged)
+//
+// The legacy value "http_endpoint" is NOT removed from tool descriptions; it
+// remains a valid input and will always be recognised via alias expansion.
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Kind alias expansion
+// ---------------------------------------------------------------------------
+
+// kindAliases maps legacy / umbrella kind names to the canonical kinds that
+// should be matched when the user supplies the legacy name. Lookup is
+// case-insensitive (normalise to lower-case before consulting the map).
+//
+// NOTE: keep in sync with internal/types/kinds.go when new splits land.
+var kindAliases = map[string][]string{
+	// http_endpoint was split into definition + call in Sub-A (#1217).
+	// When Sub-A is not yet deployed, both new kind names may be absent from
+	// the graph — the query returns empty results in that case, which is
+	// correct and safe.
+	"http_endpoint": {
+		"http_endpoint",
+		"http_endpoint_definition",
+		"http_endpoint_call",
+	},
+}
+
+// expandKindAlias returns the set of kind strings that a caller-supplied kind
+// value should match. If the kind has a registered alias, the expanded set is
+// returned; otherwise a single-element slice containing the original kind is
+// returned. The comparison is case-insensitive.
+func expandKindAlias(kind string) []string {
+	if kind == "" {
+		return nil
+	}
+	if expanded, ok := kindAliases[strings.ToLower(kind)]; ok {
+		return expanded
+	}
+	return []string{kind}
+}
+
+// matchesKindFilter reports whether entity e matches kindFilter, respecting
+// alias expansion. An empty kindFilter always returns true (no filtering).
+//
+// Use this instead of strings.EqualFold(e.Kind, kindFilter) everywhere a kind
+// filter is applied to graph entities.
+func matchesKindFilter(e *graph.Entity, kindFilter string) bool {
+	if kindFilter == "" {
+		return true
+	}
+	for _, k := range expandKindAlias(kindFilter) {
+		if strings.EqualFold(e.Kind, k) {
+			return true
+		}
+	}
+	return false
+}
+
+// ---------------------------------------------------------------------------
+// isHTTPEndpointKind — shared predicate used by all three endpoint tools
+// ---------------------------------------------------------------------------
+
+// isHTTPEndpointKind reports whether kind (lowercased, scope-prefix stripped)
+// is any of the recognised HTTP-endpoint kinds.
+func isHTTPEndpointKind(kind string) bool {
+	k := strings.ToLower(stripScopePrefix(kind))
+	return k == "http_endpoint" ||
+		k == "http_endpoint_definition" ||
+		k == "http_endpoint_call"
+}
+
+// isDefinitionKind reports whether kind represents a handler/route definition.
+func isDefinitionKind(kind string) bool {
+	k := strings.ToLower(stripScopePrefix(kind))
+	return k == "http_endpoint" || k == "http_endpoint_definition"
+}
+
+// isCallKind reports whether kind represents a call-site (consumer side).
+func isCallKind(kind string) bool {
+	k := strings.ToLower(stripScopePrefix(kind))
+	return k == "http_endpoint_call"
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_definitions
+// ---------------------------------------------------------------------------
+
+// handleEndpointDefinitions lists http_endpoint_definition entities (and the
+// legacy http_endpoint kind when Sub-A has not yet landed). This tool returns
+// ONLY definition-side entries — no call-sites.
+//
+// Tool name: archigraph_endpoint_definitions
+func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	limit := argInt(req, "limit", 200)
+	group := argString(req, "group", "")
+	_ = group
+
+	type item struct {
+		EntityID   string            `json:"entity_id"`
+		Name       string            `json:"name"`
+		Kind       string            `json:"kind"`
+		Repo       string            `json:"repo"`
+		SourceFile string            `json:"source_file,omitempty"`
+		StartLine  int               `json:"start_line,omitempty"`
+		Method     string            `json:"method,omitempty"`
+		Path       string            `json:"path,omitempty"`
+		Properties map[string]string `json:"properties,omitempty"`
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isDefinitionKind(e.Kind) {
+				continue
+			}
+			// Exclude entities whose pattern_type marks them as client-synthesis
+			// (consumer-side) — those belong in archigraph_endpoint_calls.
+			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+				continue
+			}
+			out = append(out, item{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       e.Kind,
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+				StartLine:  e.StartLine,
+				Method:     e.Properties["verb"],
+				Path:       e.Properties["path"],
+				Properties: e.Properties,
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Name < out[j].Name
+	})
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"definitions": out,
+		"count":       len(out),
+		"total":       total,
+		"truncated":   total > len(out),
+		"note":        "http_endpoint kind is deprecated; prefer http_endpoint_definition for handler/route entities.",
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_calls
+// ---------------------------------------------------------------------------
+
+// handleEndpointCalls lists http_endpoint_call entities — call-sites that
+// invoke an HTTP endpoint (i.e. the FETCHES-edge source entities). For each
+// call-site that has no matching definition anywhere in the group, a reasoning
+// hint is included.
+//
+// Tool name: archigraph_endpoint_calls
+func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	limit := argInt(req, "limit", 200)
+	orphanOnly := argBool(req, "orphan_only", false)
+
+	// Build a set of all definition-side entity IDs so we can detect
+	// call-sites with no matching definition (orphan callers).
+	definitionIDs := map[string]bool{}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if isDefinitionKind(e.Kind) && e.Properties["pattern_type"] != "http_endpoint_client_synthesis" {
+				definitionIDs[prefixedID(r.Repo, e.ID)] = true
+				definitionIDs[e.ID] = true // bare form for same-repo lookups
+			}
+		}
+	}
+
+	type item struct {
+		EntityID         string            `json:"entity_id"`
+		Name             string            `json:"name"`
+		Kind             string            `json:"kind"`
+		Repo             string            `json:"repo"`
+		SourceFile       string            `json:"source_file,omitempty"`
+		StartLine        int               `json:"start_line,omitempty"`
+		Method           string            `json:"method,omitempty"`
+		Path             string            `json:"path,omitempty"`
+		MatchedDefinition string           `json:"matched_definition,omitempty"`
+		OrphanHint       string            `json:"orphan_hint,omitempty"`
+		Properties       map[string]string `json:"properties,omitempty"`
+	}
+
+	// Build FETCHES edge map: callerID → toID (definition target).
+	type fetchesEdge struct {
+		toID string
+		path string
+	}
+	callerToTarget := map[string]fetchesEdge{}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind != "FETCHES" {
+				continue
+			}
+			key := prefixedID(r.Repo, rel.FromID)
+			if _, exists := callerToTarget[key]; !exists {
+				fe := fetchesEdge{toID: rel.ToID}
+				if rel.Properties != nil {
+					fe.path = rel.Properties["path"]
+				}
+				callerToTarget[key] = fe
+			}
+		}
+	}
+
+	var out []item
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			// Accept explicit call kind OR client-synthesis http_endpoint.
+			isCall := isCallKind(e.Kind) ||
+				(isDefinitionKind(e.Kind) && e.Properties["pattern_type"] == "http_endpoint_client_synthesis")
+			if !isCall {
+				continue
+			}
+
+			eid := prefixedID(r.Repo, e.ID)
+
+			// Determine if this call-site has a matched definition.
+			matched := ""
+			orphanHint := ""
+			if fe, ok := callerToTarget[eid]; ok {
+				if definitionIDs[fe.toID] || definitionIDs[prefixedID(r.Repo, fe.toID)] {
+					matched = fe.toID
+				} else {
+					// No matching definition found — produce a reasoning hint.
+					urlPattern := fe.path
+					if urlPattern == "" {
+						urlPattern = e.Properties["path"]
+					}
+					if urlPattern != "" {
+						orphanHint = "this call to " + urlPattern + " has no matching definition — see orphan_callers"
+					} else {
+						orphanHint = "this call has no matching definition — see orphan_callers"
+					}
+				}
+			} else {
+				// No FETCHES edge at all — possibly an isolated call-site.
+				urlPattern := e.Properties["path"]
+				if urlPattern != "" {
+					orphanHint = "this call to " + urlPattern + " has no matching definition — see orphan_callers"
+				}
+			}
+
+			if orphanOnly && orphanHint == "" {
+				continue
+			}
+
+			out = append(out, item{
+				EntityID:          eid,
+				Name:              e.Name,
+				Kind:              e.Kind,
+				Repo:              r.Repo,
+				SourceFile:        e.SourceFile,
+				StartLine:         e.StartLine,
+				Method:            e.Properties["verb"],
+				Path:              e.Properties["path"],
+				MatchedDefinition: matched,
+				OrphanHint:        orphanHint,
+				Properties:        e.Properties,
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		// Orphans first, then by repo + name.
+		iOrphan := out[i].OrphanHint != ""
+		jOrphan := out[j].OrphanHint != ""
+		if iOrphan != jOrphan {
+			return iOrphan // orphans first
+		}
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"calls":     out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+		"note":      "http_endpoint kind is deprecated; prefer http_endpoint_call for consumer-side call-site entities.",
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_stats
+// ---------------------------------------------------------------------------
+
+// handleEndpointStats returns a count breakdown of each HTTP-endpoint kind
+// across the group, plus a summary of orphan call-sites (calls with no
+// matching definition).
+//
+// Tool name: archigraph_endpoint_stats
+func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+
+	type repoStats struct {
+		Repo        string `json:"repo"`
+		Definitions int    `json:"definitions"`
+		Calls       int    `json:"calls"`
+		LegacyKind  int    `json:"legacy_kind"` // entities whose kind is plain "http_endpoint" (not split yet)
+		OrphanCalls int    `json:"orphan_calls"`
+	}
+
+	// Build definition-ID set first (needed for orphan detection below).
+	definitionIDs := map[string]bool{}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if isDefinitionKind(e.Kind) && e.Properties["pattern_type"] != "http_endpoint_client_synthesis" {
+				definitionIDs[e.ID] = true
+				definitionIDs[prefixedID(r.Repo, e.ID)] = true
+			}
+		}
+	}
+
+	var perRepo []repoStats
+	totalDefs, totalCalls, totalLegacy, totalOrphans := 0, 0, 0, 0
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		rs := repoStats{Repo: r.Repo}
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			k := strings.ToLower(stripScopePrefix(e.Kind))
+			switch {
+			case k == "http_endpoint_definition":
+				rs.Definitions++
+			case k == "http_endpoint_call":
+				rs.Calls++
+			case k == "http_endpoint":
+				// Pre-Sub-A entity; count separately.
+				rs.LegacyKind++
+				if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+					rs.Calls++ // treat client-synthesis as a call
+				} else {
+					rs.Definitions++ // treat producer as a definition
+				}
+			}
+		}
+
+		// Count orphan call-sites: FETCHES edges whose ToID is not a definition.
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind != "FETCHES" {
+				continue
+			}
+			if !definitionIDs[rel.ToID] && !definitionIDs[prefixedID(r.Repo, rel.ToID)] {
+				rs.OrphanCalls++
+			}
+		}
+
+		totalDefs += rs.Definitions
+		totalCalls += rs.Calls
+		totalLegacy += rs.LegacyKind
+		totalOrphans += rs.OrphanCalls
+		perRepo = append(perRepo, rs)
+	}
+
+	sort.Slice(perRepo, func(i, j int) bool { return perRepo[i].Repo < perRepo[j].Repo })
+
+	migrated := totalLegacy == 0
+	note := ""
+	if !migrated {
+		note = "graph still contains legacy http_endpoint kind — run the indexer after Sub-A (#1217) lands to split into http_endpoint_definition / http_endpoint_call"
+	}
+
+	return jsonResult(map[string]any{
+		"totals": map[string]any{
+			"definitions":  totalDefs,
+			"calls":        totalCalls,
+			"legacy_kind":  totalLegacy,
+			"orphan_calls": totalOrphans,
+		},
+		"per_repo":  perRepo,
+		"migrated":  migrated,
+		"note":      note,
+	}), nil
+}

--- a/internal/mcp/endpoint_tools_test.go
+++ b/internal/mcp/endpoint_tools_test.go
@@ -1,0 +1,452 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// buildEndpointDoc builds a Document that exercises all three http_endpoint kind
+// variants: legacy, definition, and call.
+//
+//	Entities
+//	  ep_legacy       kind=http_endpoint  (producer / definition)
+//	  ep_def          kind=http_endpoint_definition
+//	  ep_call         kind=http_endpoint_call
+//	  ep_client_synth kind=http_endpoint   pattern_type=http_endpoint_client_synthesis
+//	  fn_other        kind=Function  (unrelated — should never appear in endpoint tools)
+//
+//	Relationships
+//	  fn_other –FETCHES→ ep_def   (resolved: ep_def is a definition)
+//	  ep_call  –FETCHES→ orphan   (unresolved: "orphan" entity does not exist)
+func buildEndpointDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "ep_legacy", Name: "POST /api/v1/orders", Kind: "http_endpoint",
+				SourceFile: "routes/orders.go", StartLine: 10,
+				Properties: map[string]string{"verb": "POST", "path": "/api/v1/orders"},
+			},
+			{
+				ID: "ep_def", Name: "GET /api/v2/users", Kind: "http_endpoint_definition",
+				SourceFile: "routes/users.go", StartLine: 20,
+				Properties: map[string]string{"verb": "GET", "path": "/api/v2/users"},
+			},
+			{
+				ID: "ep_call", Name: "fetchUsers", Kind: "http_endpoint_call",
+				SourceFile: "services/user_service.go", StartLine: 55,
+				Properties: map[string]string{"verb": "GET", "path": "/api/v2/users"},
+			},
+			{
+				ID: "ep_client_synth", Name: "POST /api/v1/orders (client)", Kind: "http_endpoint",
+				SourceFile: "client/orders.go", StartLine: 5,
+				Properties: map[string]string{
+					"verb":         "POST",
+					"path":         "/api/v1/orders",
+					"pattern_type": "http_endpoint_client_synthesis",
+				},
+			},
+			{
+				ID: "fn_other", Name: "doSomething", Kind: "Function",
+				SourceFile: "lib/util.go", StartLine: 1,
+			},
+		},
+		Relationships: []graph.Relationship{
+			// fn_other fetches ep_def — resolved call.
+			{FromID: "fn_other", ToID: "ep_def", Kind: "FETCHES"},
+			// ep_call fetches an unknown entity — orphan.
+			{FromID: "ep_call", ToID: "orphan_entity_id", Kind: "FETCHES"},
+		},
+	}
+}
+
+func newEndpointServer(t *testing.T) *Server {
+	t.Helper()
+	return newTestServerWithDoc(t, buildEndpointDoc())
+}
+
+func callEndpointTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	var out map[string]any
+	for _, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+	}
+	return out
+}
+
+func getSlice(t *testing.T, m map[string]any, key string) []any {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Fatalf("missing key %q in result %v", key, m)
+	}
+	s, ok := v.([]any)
+	if !ok {
+		t.Fatalf("key %q is %T, want []any", key, v)
+	}
+	return s
+}
+
+func getFloat(t *testing.T, m map[string]any, key string) float64 {
+	t.Helper()
+	v, ok := m[key]
+	if !ok {
+		t.Fatalf("missing key %q in result %v", key, m)
+	}
+	f, ok := v.(float64)
+	if !ok {
+		t.Fatalf("key %q is %T, want float64", key, v)
+	}
+	return f
+}
+
+// ---------------------------------------------------------------------------
+// expandKindAlias tests
+// ---------------------------------------------------------------------------
+
+func TestExpandKindAlias_LegacyExpandsToBoth(t *testing.T) {
+	expanded := expandKindAlias("http_endpoint")
+	if len(expanded) != 3 {
+		t.Fatalf("expected 3 kinds, got %d: %v", len(expanded), expanded)
+	}
+	found := map[string]bool{}
+	for _, k := range expanded {
+		found[k] = true
+	}
+	for _, want := range []string{"http_endpoint", "http_endpoint_definition", "http_endpoint_call"} {
+		if !found[want] {
+			t.Errorf("missing %q in expansion %v", want, expanded)
+		}
+	}
+}
+
+func TestExpandKindAlias_CaseInsensitive(t *testing.T) {
+	for _, input := range []string{"HTTP_ENDPOINT", "Http_Endpoint", "HTTP_endpoint"} {
+		expanded := expandKindAlias(input)
+		if len(expanded) != 3 {
+			t.Errorf("input %q: expected 3 kinds, got %d", input, len(expanded))
+		}
+	}
+}
+
+func TestExpandKindAlias_NewKindsPassThrough(t *testing.T) {
+	for _, k := range []string{"http_endpoint_definition", "http_endpoint_call", "Function"} {
+		expanded := expandKindAlias(k)
+		if len(expanded) != 1 || expanded[0] != k {
+			t.Errorf("kind %q: expected passthrough [{%q}], got %v", k, k, expanded)
+		}
+	}
+}
+
+func TestExpandKindAlias_Empty(t *testing.T) {
+	if got := expandKindAlias(""); got != nil {
+		t.Errorf("empty kind: expected nil, got %v", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// matchesKindFilter tests
+// ---------------------------------------------------------------------------
+
+func TestMatchesKindFilter_LegacyMatchesDefinition(t *testing.T) {
+	e := &graph.Entity{Kind: "http_endpoint_definition"}
+	if !matchesKindFilter(e, "http_endpoint") {
+		t.Error("http_endpoint_definition should match legacy filter http_endpoint")
+	}
+}
+
+func TestMatchesKindFilter_LegacyMatchesCall(t *testing.T) {
+	e := &graph.Entity{Kind: "http_endpoint_call"}
+	if !matchesKindFilter(e, "http_endpoint") {
+		t.Error("http_endpoint_call should match legacy filter http_endpoint")
+	}
+}
+
+func TestMatchesKindFilter_LegacyMatchesLegacy(t *testing.T) {
+	e := &graph.Entity{Kind: "http_endpoint"}
+	if !matchesKindFilter(e, "http_endpoint") {
+		t.Error("http_endpoint should match legacy filter http_endpoint")
+	}
+}
+
+func TestMatchesKindFilter_ExactKindMatchesOnly(t *testing.T) {
+	e := &graph.Entity{Kind: "http_endpoint_definition"}
+	if !matchesKindFilter(e, "http_endpoint_definition") {
+		t.Error("exact match should work")
+	}
+	if matchesKindFilter(e, "http_endpoint_call") {
+		t.Error("http_endpoint_definition should not match http_endpoint_call filter")
+	}
+}
+
+func TestMatchesKindFilter_EmptyFilterAlwaysTrue(t *testing.T) {
+	e := &graph.Entity{Kind: "Function"}
+	if !matchesKindFilter(e, "") {
+		t.Error("empty filter should always return true")
+	}
+}
+
+func TestMatchesKindFilter_NonHTTPKindNotAffected(t *testing.T) {
+	e := &graph.Entity{Kind: "Function"}
+	if matchesKindFilter(e, "http_endpoint") {
+		t.Error("Function should not match http_endpoint filter")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_definitions tests
+// ---------------------------------------------------------------------------
+
+func TestEndpointDefinitions_ReturnsDefinitionsOnly(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test"})
+
+	defs := getSlice(t, res, "definitions")
+	// Expect: ep_legacy (producer http_endpoint) + ep_def (http_endpoint_definition)
+	// NOT: ep_call, ep_client_synth, fn_other
+	if len(defs) != 2 {
+		t.Errorf("expected 2 definitions, got %d: %v", len(defs), defs)
+	}
+
+	kinds := map[string]bool{}
+	for _, d := range defs {
+		obj := d.(map[string]any)
+		kinds[obj["kind"].(string)] = true
+	}
+	if !kinds["http_endpoint"] {
+		t.Error("expected legacy http_endpoint kind in definitions")
+	}
+	if !kinds["http_endpoint_definition"] {
+		t.Error("expected http_endpoint_definition kind in definitions")
+	}
+}
+
+func TestEndpointDefinitions_ExcludesClientSynthesis(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test"})
+	defs := getSlice(t, res, "definitions")
+	for _, d := range defs {
+		obj := d.(map[string]any)
+		if name, ok := obj["name"].(string); ok && name == "POST /api/v1/orders (client)" {
+			t.Error("client-synthesis entity should not appear in definitions")
+		}
+	}
+}
+
+func TestEndpointDefinitions_NoteFieldPresent(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointDefinitions, map[string]any{"group": "test"})
+	if _, ok := res["note"]; !ok {
+		t.Error("response should contain deprecation note field")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_calls tests
+// ---------------------------------------------------------------------------
+
+func TestEndpointCalls_ReturnsCallsOnly(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointCalls, map[string]any{"group": "test"})
+
+	calls := getSlice(t, res, "calls")
+	// Expect: ep_call (http_endpoint_call) + ep_client_synth (client-synthesis http_endpoint)
+	if len(calls) != 2 {
+		t.Errorf("expected 2 calls, got %d: %v", len(calls), calls)
+	}
+}
+
+func TestEndpointCalls_OrphanHintPresent(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointCalls, map[string]any{"group": "test"})
+	calls := getSlice(t, res, "calls")
+
+	orphanFound := false
+	for _, c := range calls {
+		obj := c.(map[string]any)
+		hint, _ := obj["orphan_hint"].(string)
+		if hint != "" {
+			orphanFound = true
+		}
+	}
+	if !orphanFound {
+		t.Error("expected at least one call with an orphan_hint")
+	}
+}
+
+func TestEndpointCalls_OrphanOnly(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointCalls, map[string]any{
+		"group":       "test",
+		"orphan_only": true,
+	})
+	calls := getSlice(t, res, "calls")
+	for _, c := range calls {
+		obj := c.(map[string]any)
+		hint, _ := obj["orphan_hint"].(string)
+		if hint == "" {
+			t.Errorf("orphan_only=true but got call with no orphan_hint: %v", obj)
+		}
+	}
+}
+
+func TestEndpointCalls_ExcludesNonCallEntities(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointCalls, map[string]any{"group": "test"})
+	calls := getSlice(t, res, "calls")
+	for _, c := range calls {
+		obj := c.(map[string]any)
+		kind := obj["kind"].(string)
+		if kind == "Function" || kind == "http_endpoint_definition" {
+			t.Errorf("unexpected kind %q in calls list", kind)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_endpoint_stats tests
+// ---------------------------------------------------------------------------
+
+func TestEndpointStats_TotalsCorrect(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+
+	totals, ok := res["totals"].(map[string]any)
+	if !ok {
+		t.Fatalf("missing or malformed totals in %v", res)
+	}
+	// definitions: ep_legacy (1 legacy producer counted as def) + ep_def = 2
+	defs := getFloat(t, totals, "definitions")
+	if defs != 2 {
+		t.Errorf("definitions: want 2, got %v", defs)
+	}
+	// calls: ep_call + ep_client_synth = 2
+	calls := getFloat(t, totals, "calls")
+	if calls != 2 {
+		t.Errorf("calls: want 2, got %v", calls)
+	}
+	// legacy_kind: ep_legacy + ep_client_synth = 2
+	legacy := getFloat(t, totals, "legacy_kind")
+	if legacy != 2 {
+		t.Errorf("legacy_kind: want 2, got %v", legacy)
+	}
+}
+
+func TestEndpointStats_OrphanCallsDetected(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+	totals := res["totals"].(map[string]any)
+	orphans := getFloat(t, totals, "orphan_calls")
+	// ep_call fetches orphan_entity_id which is not in the definition set.
+	if orphans < 1 {
+		t.Errorf("orphan_calls: want ≥1, got %v", orphans)
+	}
+}
+
+func TestEndpointStats_MigratedFalseWhenLegacyPresent(t *testing.T) {
+	srv := newEndpointServer(t)
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+	migrated, ok := res["migrated"].(bool)
+	if !ok {
+		t.Fatalf("missing migrated field")
+	}
+	if migrated {
+		t.Error("migrated should be false when legacy http_endpoint entities exist")
+	}
+}
+
+func TestEndpointStats_MigratedTrueWhenNoLegacy(t *testing.T) {
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "d1", Kind: "http_endpoint_definition", Name: "GET /a"},
+			{ID: "c1", Kind: "http_endpoint_call", Name: "fetchA"},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	res := callEndpointTool(t, srv.handleEndpointStats, map[string]any{"group": "test"})
+	migrated, ok := res["migrated"].(bool)
+	if !ok {
+		t.Fatalf("missing migrated field")
+	}
+	if !migrated {
+		t.Error("migrated should be true when no legacy http_endpoint entities exist")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Backward-compatibility: existing tools honour alias expansion
+// ---------------------------------------------------------------------------
+
+// TestSearchEntities_LegacyKindFilterExpands verifies that
+// handleSearchEntities with kind_filter="http_endpoint" returns entities of
+// all three http_endpoint kinds (not just exact "http_endpoint").
+func TestSearchEntities_LegacyKindFilterExpands(t *testing.T) {
+	srv := newEndpointServer(t)
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"group":       "test",
+		"query":       "",           // empty query matches everything
+		"kind_filter": "http_endpoint",
+	}
+	res, err := srv.handleSearchEntities(context.Background(), req)
+	if err != nil || res.IsError {
+		t.Fatalf("handleSearchEntities error: err=%v, isError=%v", err, res)
+	}
+	var out map[string]any
+	for _, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		_ = tc
+	}
+	_ = out
+	// The test verifies compilation + no panic. Functional assertion is in
+	// TestMatchesKindFilter_* above which covers the underlying logic.
+}
+
+// TestQualityOrphans_LegacyKindFilterExpands verifies that the orphans handler
+// accepts "http_endpoint" as kind_filter without panicking or erroring.
+func TestQualityOrphans_LegacyKindFilterExpands(t *testing.T) {
+	// Build a doc with an isolated (no-edge) http_endpoint_definition.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "isolated_def", Kind: "http_endpoint_definition", Name: "GET /isolated"},
+			{ID: "isolated_call", Kind: "http_endpoint_call", Name: "fetchIsolated"},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	res := callDashboardTool(t, srv.handleQualityOrphans, map[string]any{
+		"group":       "test",
+		"kind_filter": "http_endpoint",
+	})
+	orphans := getSlice(t, res, "orphans")
+	if len(orphans) != 2 {
+		t.Errorf("expected 2 orphans (both http_endpoint_* kinds), got %d: %v", len(orphans), orphans)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -124,9 +124,10 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 27 (14 original + 13 new: topology×3, flows×3, diagnostics,
-// quality_orphans, patterns_list, patterns_get, search_entities, get_subgraph,
-// find_paths). Issue #1202.
+// Tool count: 34 (14 original + 13 from #1202 + 3 from #1220).
+// #1202 tools: topology×3, flows×3, diagnostics, quality_orphans,
+//   patterns_list, patterns_get, search_entities, get_subgraph, find_paths.
+// #1220 tools: endpoint_definitions, endpoint_calls, endpoint_stats.
 func (s *Server) registerTools() {
 	// -----------------------------------------------------------------------
 	// Unchanged tools (5)
@@ -481,6 +482,50 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_find_paths", s.handleFindPaths))
+
+	// -----------------------------------------------------------------------
+	// HTTP endpoint tools (#1220)
+	// Backward-compat: all tools that accept a kind_filter also recognise
+	// the legacy "http_endpoint" value, which expands to both
+	// "http_endpoint_definition" and "http_endpoint_call".
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoint_definitions",
+		mcpapi.WithDescription(
+			"List HTTP endpoint handler/route definitions (http_endpoint_definition kind). "+
+				"Also returns entities with the legacy http_endpoint kind that are identified as producers. "+
+				"'http_endpoint' kind is deprecated; prefer http_endpoint_definition for handler/route entities.",
+		),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("Repos to scope.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200), mcpapi.Description("Max definitions returned.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_endpoint_definitions", s.handleEndpointDefinitions))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoint_calls",
+		mcpapi.WithDescription(
+			"List HTTP endpoint call-sites (http_endpoint_call kind) — the consumer side of FETCHES edges. "+
+				"Also returns entities with the legacy http_endpoint kind that are identified as client-synthesis consumers. "+
+				"'http_endpoint' kind is deprecated; prefer http_endpoint_call for consumer-side call-site entities. "+
+				"Each unresolved call-site includes an orphan_hint field explaining that the call has no matching definition.",
+		),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("Repos to scope.")),
+		mcpapi.WithBoolean("orphan_only", mcpapi.DefaultBool(false), mcpapi.Description("When true, return only call-sites with no matching definition.")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200), mcpapi.Description("Max call-sites returned.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_endpoint_calls", s.handleEndpointCalls))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_endpoint_stats",
+		mcpapi.WithDescription(
+			"Return counts of http_endpoint_definition, http_endpoint_call, and legacy http_endpoint entities per repo, "+
+				"plus a count of orphan call-sites (FETCHES edges with no matching definition). "+
+				"Use to assess the migration status from the legacy http_endpoint kind to the new split kinds.",
+		),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("Repos to scope.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_endpoint_stats", s.handleEndpointStats))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -547,7 +547,7 @@ func TestToolNameSurface(t *testing.T) {
 	for _, st := range srv.MCP.ListTools() {
 		registered[st.Tool.Name] = true
 	}
-	// 31 tools: 18 original + 13 new (#1202).
+	// 34 tools: 18 original + 13 new (#1202) + 3 endpoint tools (#1220).
 	wantPresent := []string{
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
@@ -582,6 +582,10 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_search_entities",
 		"archigraph_get_subgraph",
 		"archigraph_find_paths",
+		// #1220 HTTP endpoint kind aliasing
+		"archigraph_endpoint_definitions",
+		"archigraph_endpoint_calls",
+		"archigraph_endpoint_stats",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -609,11 +613,12 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 31 (18 pre-#1202 + 13 new from #1202).
-	// New tools: topology×3, flows×3, diagnostics, quality_orphans,
+	// Total count must be exactly 34 (18 pre-#1202 + 13 from #1202 + 3 from #1220).
+	// #1202 tools: topology×3, flows×3, diagnostics, quality_orphans,
 	// patterns_list, patterns_get, search_entities, get_subgraph, find_paths.
-	if got := len(srv.MCP.ListTools()); got != 31 {
-		t.Errorf("expected 31 registered tools, got %d", got)
+	// #1220 tools: endpoint_definitions, endpoint_calls, endpoint_stats.
+	if got := len(srv.MCP.ListTools()); got != 34 {
+		t.Errorf("expected 34 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## What

Sub-D of paths v2 epic #1115. Closes #1220.

Adds backward-compatibility aliasing so any MCP query (or kind_filter) that
specifies \`http_endpoint\` transparently expands to **both** new kinds
(\`http_endpoint_definition\` + \`http_endpoint_call\`). External agent code that
uses the old kind string continues to work without modification — no regressions
when Sub-A (#1217) lands.

## Why

Sub-A splits the single \`http_endpoint\` kind into two finer-grained kinds.
Without this shim, the instant Sub-A lands every existing agent query
(\`kind_filter=\"http_endpoint\"\`) returns zero results because none of the new
entities carry the legacy kind string.

## How

### Core alias layer (\`internal/mcp/endpoint_tools.go\`)

| Symbol | Role |
|--------|------|
| \`kindAliases\` map | \`\"http_endpoint\"\` → \`[\"http_endpoint\", \"http_endpoint_definition\", \"http_endpoint_call\"]\` |
| \`expandKindAlias(kind)\` | Case-insensitive lookup; passthrough for unknown kinds |
| \`matchesKindFilter(e, filter)\` | Drop-in for \`strings.EqualFold(e.Kind, filter)\` — uses alias expansion |

### Existing tools patched (\`internal/mcp/dashboard_tools.go\`)

Both \`handleQualityOrphans\` and \`handleSearchEntities\` used a bare
\`strings.EqualFold(e.Kind, kindFilter)\` guard. Replaced with \`matchesKindFilter\`
so alias expansion flows through without any change to tool API.

### Three new focused tools (\`server.go\` + \`endpoint_tools.go\`)

| Tool | Description |
|------|-------------|
| \`archigraph_endpoint_definitions\` | Definition-side entities only (handler/route). Excludes client-synthesis. |
| \`archigraph_endpoint_calls\` | Consumer-side call-sites. Orphan call-sites get an \`orphan_hint\` field: \`\"this call to /foo has no matching definition — see orphan_callers\"\`. Supports \`orphan_only=true\` filter. |
| \`archigraph_endpoint_stats\` | Per-repo counts of each kind + orphan call-site count + \`migrated\` boolean (true when no legacy entities remain). |

Both new tools include a \`note\` field advertising the migration path.

The legacy value is **not removed** from descriptions — existing callers may
rely on it.

### Defensive for pre-Sub-A graphs

When Sub-A has not yet landed, \`http_endpoint_definition\` and
\`http_endpoint_call\` are absent from the graph. The alias expansion still
returns the legacy \`http_endpoint\` as one of the candidate kinds, so existing
queries continue to return results. The three new tools also handle this
gracefully: \`endpoint_stats.migrated\` will be \`false\` and the \`note\` field
explains what to do.

## Test coverage

\`internal/mcp/endpoint_tools_test.go\` — 23 new tests:

- \`expandKindAlias_*\` — expansion, case-insensitivity, passthrough, empty input
- \`matchesKindFilter_*\` — legacy filter matches all three kinds; exact filter isolates; empty always true; non-HTTP unaffected
- \`TestEndpointDefinitions_*\` — producer-only; excludes client-synthesis; note present
- \`TestEndpointCalls_*\` — call-side only; orphan_hint present; orphan_only filter; non-call entities excluded
- \`TestEndpointStats_*\` — totals correct; orphan detection; migrated flag both states
- Backward-compat smoke tests for \`handleSearchEntities\` and \`handleQualityOrphans\`

\`TestToolNameSurface\` updated: expected count 31 → 34. Full suite green.

## Migration path for callers

| Old kind value | Still works? | New preferred value |
|----------------|:---:|---------------------|
| \`http_endpoint\` | alias | \`http_endpoint_definition\` (handler) or \`http_endpoint_call\` (consumer) |
| \`http_endpoint_definition\` | exact | unchanged |
| \`http_endpoint_call\` | exact | unchanged |

Depends on Sub-A (#1217) for new kind strings to appear in the graph.
Safe to merge independently — degrades gracefully on pre-Sub-A graphs.