### PR TITLE
[#1217] Sub-A: split http_endpoint into http_endpoint_definition + http_endpoint_call at extractor layer

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -348,7 +348,8 @@ func buildAgentsMapStats(group, repoPath string) agents.Stats {
 		s.Relationships = doc.Stats.Relationships
 		for _, e := range doc.Entities {
 			switch e.Kind {
-			case "http_endpoint":
+			// #1217: count all three http endpoint kind strings.
+			case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
 				s.HTTPEndpoints++
 			case "queue":
 				s.Queues++

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1938,13 +1938,24 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlers(merged)
 	if httpEndpointStats.Synthetics > 0 {
 		fmt.Fprintf(os.Stderr,
-			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d caller_resolved=%d caller_unresolved=%d\n",
+			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d caller_resolved=%d caller_unresolved=%d calls_linked=%d calls_unresolved=%d\n",
 			httpEndpointStats.Synthetics,
 			httpEndpointStats.HandlerResolved,
 			httpEndpointStats.HandlerDropped,
 			httpEndpointStats.NoHandlerProp,
 			httpEndpointStats.CallerResolved,
-			httpEndpointStats.CallerUnresolved)
+			httpEndpointStats.CallerUnresolved,
+			httpEndpointStats.CallsLinked,
+			httpEndpointStats.CallsUnresolved)
+	}
+	// #1217 migration hints: log how many legacy http_endpoint entities were
+	// rewritten to the split kinds. These lines appear only when a graph
+	// pre-dates #1217 (i.e. still has the old kind string on disk).
+	if httpEndpointStats.DefinitionsMigrated > 0 || httpEndpointStats.CallsMigrated > 0 {
+		fmt.Fprintf(os.Stderr,
+			"http-endpoint-split: %d entities migrated from http_endpoint to http_endpoint_definition, %d to http_endpoint_call\n",
+			httpEndpointStats.DefinitionsMigrated,
+			httpEndpointStats.CallsMigrated)
 	}
 
 	// Stamp deterministic entity IDs onto every record so the resolver can

--- a/internal/cli/rebuild_summary.go
+++ b/internal/cli/rebuild_summary.go
@@ -150,7 +150,8 @@ func ComputeRebuildSummary(group string, repoPaths []string, elapsed time.Durati
 				s.TotalEntities++
 				k := normaliseEntityKind(e.Kind)
 				s.EntityByKind[k]++
-				if e.Kind == "http_endpoint" {
+				// #1217: count all three http endpoint kind strings.
+				if e.Kind == "http_endpoint" || e.Kind == "http_endpoint_definition" || e.Kind == "http_endpoint_call" {
 					s.HTTPEndpoints++
 				}
 				if strings.HasPrefix(e.Kind, "SCOPE.Process") || e.Kind == "process" {
@@ -205,7 +206,8 @@ func normaliseEntityKind(kind string) string {
 		return "Class"
 	case "variable", "constant", "field":
 		return "Variable"
-	case "http_endpoint":
+	// #1217: normalise all three http endpoint kind strings to the same bucket.
+	case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
 		return "HTTPEndpoint"
 	default:
 		return kind

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -107,7 +107,8 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			if err == nil && doc != nil {
 				rs.Files = doc.Stats.Files
 				for _, e := range doc.Entities {
-					if e.Kind == "http_endpoint" {
+					// #1217: count all three http endpoint kind strings.
+					if e.Kind == "http_endpoint" || e.Kind == "http_endpoint_definition" || e.Kind == "http_endpoint_call" {
 						s.HTTPEndpoints++
 					}
 					// Check for process flows: SCOPE.Process or process kind.

--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/registry"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // ---------------------------------------------------------------------------
@@ -328,7 +329,9 @@ func groupTopFrameworks(grp *DashGroup, cap int) []string {
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
-			if !strings.EqualFold(kind, httpEndpointKind) && kind != "Endpoint" && kind != "Route" {
+			// #1217 backward compat: accept all three http endpoint kind strings.
+			if !types.IsHTTPEndpointKind(kind) && !strings.EqualFold(kind, httpEndpointKind) &&
+				kind != "Endpoint" && kind != "Route" {
 				continue
 			}
 			if fw := e.Properties["framework"]; fw != "" {

--- a/internal/dashboard/handlers_orphan_callers.go
+++ b/internal/dashboard/handlers_orphan_callers.go
@@ -27,6 +27,8 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // OrphanCallerRow is one unresolved call site returned by the endpoint.
@@ -104,11 +106,19 @@ func collectOrphanCallers(grp *DashGroup) []OrphanCallerRow {
 			bare := e.ID
 			prefixed := dashPrefixedID(repo.Slug, bare)
 
-			isHTTPEndpoint := strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind)
+			// #1217 backward compat: accept all three http endpoint kind strings.
+			bareKind := dashStripScopePrefix(e.Kind)
+			isHTTPEndpoint := types.IsHTTPEndpointKind(bareKind) ||
+				strings.EqualFold(bareKind, httpEndpointKind)
 			if !isHTTPEndpoint {
 				continue
 			}
-			isProducer := e.Properties["pattern_type"] != "http_endpoint_client_synthesis"
+			// #1217: http_endpoint_definition is always producer-side;
+			// http_endpoint_call is always consumer-side.
+			// For legacy http_endpoint, fall back to pattern_type check.
+			isProducer := e.Kind == "http_endpoint_definition" ||
+				(e.Kind != "http_endpoint_call" &&
+					e.Properties["pattern_type"] != "http_endpoint_client_synthesis")
 
 			endpointByID[bare] = endpointEntry{repo: repo.Slug, isProducer: isProducer}
 			endpointByID[prefixed] = endpointEntry{repo: repo.Slug, isProducer: isProducer}

--- a/internal/dashboard/handlers_paths.go
+++ b/internal/dashboard/handlers_paths.go
@@ -18,6 +18,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/mcp"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 const (
@@ -112,16 +113,20 @@ func (s *Server) handlePathsList(w http.ResponseWriter, r *http.Request) {
 		}
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
+			// #1217: accept all three http endpoint kind strings for backward
+			// compat with graphs indexed before the split. Exclude call-site
+			// synthetics (consumer side) — they belong in the Orphan Callers tab.
 			kind := dashStripScopePrefix(e.Kind)
 			isDefinition := strings.EqualFold(kind, httpEndpointDefinitionKind)
-			isEndpoint := strings.EqualFold(kind, httpEndpointKind) ||
+			isHTTPEndpoint := types.IsHTTPEndpointKind(kind) ||
+				strings.EqualFold(kind, httpEndpointKind) ||
 				e.Kind == "Endpoint" || e.Kind == "Route"
-			if !isDefinition && !isEndpoint {
+			if !isHTTPEndpoint {
 				continue
 			}
-			// Skip frontend-only synthetic call-site entries — those belong
-			// in the Orphan Callers tab, not the Endpoints list.
-			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+			// Exclude call-site entities (new kind) and legacy consumer-side synthetics.
+			if e.Kind == "http_endpoint_call" ||
+				e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
 				continue
 			}
 			path := e.Properties["path"]
@@ -313,12 +318,16 @@ func (s *Server) handlePathDetail(w http.ResponseWriter, r *http.Request) {
 	for _, repo := range sortedRepos(grp) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
-			if !strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) &&
-				e.Kind != "Endpoint" && e.Kind != "Route" {
+			// #1217 backward compat — accept all three http endpoint kinds.
+			isHTTPEndpoint2 := types.IsHTTPEndpointKind(dashStripScopePrefix(e.Kind)) ||
+				strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) ||
+				e.Kind == "Endpoint" || e.Kind == "Route"
+			if !isHTTPEndpoint2 {
 				continue
 			}
-			// Skip frontend-only call-site synthetics — they are not real endpoints.
-			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+			// Exclude call-site entities — they are not real endpoints.
+			if e.Kind == "http_endpoint_call" ||
+				e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
 				continue
 			}
 			path := e.Properties["path"]

--- a/internal/dashboard/handlers_search.go
+++ b/internal/dashboard/handlers_search.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
 )
 
 // handleSearch — GET /api/search/{group}?q=
@@ -100,7 +101,10 @@ func (s *Server) handleSearch(w http.ResponseWriter, r *http.Request) {
 	for _, r := range sortedRepos(grp) {
 		for i := range r.Doc.Entities {
 			e := &r.Doc.Entities[i]
-			if !strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointKind) &&
+			// #1217 backward compat: accept all three http endpoint kind strings.
+			bareKind := dashStripScopePrefix(e.Kind)
+			if !types.IsHTTPEndpointKind(bareKind) &&
+				!strings.EqualFold(bareKind, httpEndpointKind) &&
 				e.Kind != "Endpoint" && e.Kind != "Route" {
 				continue
 			}

--- a/internal/engine/detector_test.go
+++ b/internal/engine/detector_test.go
@@ -285,7 +285,8 @@ func TestDetect_GinEntityProperties(t *testing.T) {
 		// pass (#722) intentionally carry framework=gin / pattern_type=
 		// http_endpoint_synthesis — those are not subject to the YAML
 		// invariants below.
-		if e.Kind == httpEndpointKind {
+		// #1217: skip all three http endpoint kind variants (synthesis emits definition/call now).
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind {
 			continue
 		}
 		if e.Properties["framework"] != "go" {

--- a/internal/engine/http_endpoint_client_synthesis_test.go
+++ b/internal/engine/http_endpoint_client_synthesis_test.go
@@ -329,7 +329,8 @@ app.get("/api/things", (req, res) => { res.json({}); });
 	_, res := runDetect(t, "javascript", "server.js", src)
 	count := 0
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/api/things" {
+		// #1217: producer-side routes are now emitted as http_endpoint_definition.
+		if e.Kind == httpEndpointDefinitionKind && e.ID == "http:GET:/api/things" {
 			count++
 			if pt := e.Properties["pattern_type"]; pt != "http_endpoint_synthesis" {
 				t.Errorf("expected pattern_type=http_endpoint_synthesis for producer-side route, got %q", pt)
@@ -355,7 +356,8 @@ async def list_items():
 	_, res := runDetect(t, "python", "server.py", src)
 	count := 0
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/api/items" {
+		// #1217: producer-side routes are now emitted as http_endpoint_definition.
+		if e.Kind == httpEndpointDefinitionKind && e.ID == "http:GET:/api/items" {
 			count++
 			if pt := e.Properties["pattern_type"]; pt != "http_endpoint_synthesis" {
 				t.Errorf("expected producer-side pattern_type, got %q", pt)
@@ -1040,7 +1042,7 @@ export async function loadUsers() {
 	_, res := runDetect(t, "typescript", "721-process-env-fetch.ts", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/users" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/users" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1063,7 +1065,7 @@ export async function listItems() {
 	_, res := runDetect(t, "typescript", "721-import-meta-axios.ts", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/items" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/items" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1085,7 +1087,7 @@ export async function getHealth() {
 	_, res := runDetect(t, "typescript", "721-next-public.ts", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/health" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/health" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1112,7 +1114,7 @@ def fetch_users():
 	_, res := runDetect(t, "python", "721-py-env-concat.py", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/users" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/users" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1135,7 +1137,7 @@ def create_item(body):
 	_, res := runDetect(t, "python", "721-py-getenv-concat.py", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:POST:/items" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:POST:/items" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1281,7 +1283,7 @@ public class UserService {
 	_, res := runDetect(t, "java", "721-java-getenv.java", src)
 	foundDynamic := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/users" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/users" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				foundDynamic = true
 			}
@@ -1311,7 +1313,7 @@ export async function fetchContracts(tenantId, contractId) {
 	_, res := runDetect(t, "typescript", "708-dynamic-baseurl.ts", src)
 	var foundPath, foundPatternType, foundDynBaseURL string
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.Properties["dynamic_baseurl"] == "true" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.Properties["dynamic_baseurl"] == "true" {
 			foundPath = e.Properties["path"]
 			foundPatternType = e.Properties["pattern_type"]
 			foundDynBaseURL = e.Properties["dynamic_baseurl"]
@@ -1345,7 +1347,7 @@ export async function loadUsers() {
 	_, res := runDetect(t, "typescript", "708-env-baseurl.ts", src)
 	found := false
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == "http:GET:/users" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.ID == "http:GET:/users" {
 			if e.Properties["runtime_dynamic"] == "true" {
 				found = true
 			}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -76,12 +76,18 @@ var resolverKindEquivalents = map[string][]string{
 // Exposed so cmd/archigraph can log a stats line analogous to the
 // import-aware resolver line.
 type ResolveHTTPEndpointStats struct {
-	Synthetics       int // total http_endpoint records seen
+	Synthetics       int // total http_endpoint* records seen
 	HandlerResolved  int // source_handler resolved → IMPLEMENTS edge emitted
 	HandlerDropped   int // synthetics dropped because source_handler unresolved
 	NoHandlerProp    int // synthetics with no source_handler property (kept as-is)
 	CallerResolved   int // #754: source_caller resolved → FETCHES edge emitted
 	CallerUnresolved int // #754: source_caller present but not found in-file
+	// #1217 migration counters.
+	DefinitionsMigrated int // entities that were http_endpoint (legacy) → definition
+	CallsMigrated       int // entities that were http_endpoint (legacy) → call
+	// #1217 cross-link counters.
+	CallsLinked      int // call → definition FETCHES edges emitted
+	CallsUnresolved  int // call entities with no matching definition (UNRESOLVED_FETCH)
 }
 
 // ResolveHTTPEndpointHandlers runs the Phase-2 post-pass over `merged`.
@@ -112,10 +118,30 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// can locate and scan the actual handler body.
 	type knKey struct{ kind, name string }
 	globalIdx := make(map[knKey]int, len(merged))
+	// #1217: migrate legacy http_endpoint entities to the new split kinds
+	// based on their pattern_type property. Graphs indexed before this
+	// release may still carry the old kind string; we rewrite it in-place
+	// so the rest of the resolve pass works uniformly with the new kinds.
 	for i := range merged {
 		r := &merged[i]
-		if r.Kind == httpEndpointKind {
-			continue // never resolve a synthetic against another synthetic
+		if r.Kind != httpEndpointKind {
+			continue
+		}
+		if r.Properties != nil && r.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+			r.Kind = httpEndpointCallKind
+			stats.CallsMigrated++
+		} else {
+			r.Kind = httpEndpointDefinitionKind
+			stats.DefinitionsMigrated++
+		}
+	}
+
+	for i := range merged {
+		r := &merged[i]
+		// Exclude all three http endpoint kinds from the handler index to
+		// avoid synthetics resolving against each other.
+		if r.Kind == httpEndpointDefinitionKind || r.Kind == httpEndpointCallKind || r.Kind == httpEndpointKind {
+			continue
 		}
 		k := key{r.Kind, r.Name, r.SourceFile}
 		if _, ok := idx[k]; !ok {
@@ -127,12 +153,26 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		}
 	}
 
+	// Build an index of definitions by canonical Name (= synthetic ID)
+	// so that http_endpoint_call entities can be linked to their matching
+	// http_endpoint_definition via a FETCHES edge (#1217).
+	// Key: synthetic ID (e.g. "http:GET:/api/users") → merged index.
+	definitionByName := make(map[string]int, len(merged))
+	for i := range merged {
+		r := &merged[i]
+		if r.Kind == httpEndpointDefinitionKind {
+			if _, ok := definitionByName[r.Name]; !ok {
+				definitionByName[r.Name] = i
+			}
+		}
+	}
+
 	// Collect indices of synthetics to drop (unresolved handlers).
 	drop := map[int]bool{}
 
 	for i := range merged {
 		r := &merged[i]
-		if r.Kind != httpEndpointKind {
+		if r.Kind != httpEndpointDefinitionKind && r.Kind != httpEndpointCallKind {
 			continue
 		}
 		stats.Synthetics++
@@ -150,6 +190,48 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 					stats.CallerUnresolved++
 				}
 			}
+		}
+
+		// #1217 — for http_endpoint_call entities, attempt to link to the
+		// matching http_endpoint_definition by canonical Name (= synthetic ID).
+		// The synthetic ID is identical on both sides (http:<VERB>:<path>),
+		// so a simple name lookup is sufficient. Emit FETCHES on success;
+		// emit UNRESOLVED_FETCH when no definition is found in the merged set.
+		if r.Kind == httpEndpointCallKind {
+			if defIdx, found := definitionByName[r.Name]; found {
+				def := &merged[defIdx]
+				callStub := r.Kind + ":" + r.Name
+				defStub := def.Kind + ":" + def.Name
+				r.Relationships = append(r.Relationships, types.RelationshipRecord{
+					FromID: callStub,
+					ToID:   defStub,
+					Kind:   fetchesEdgeKind,
+					Properties: map[string]string{
+						"pattern_type": "http_endpoint_split_resolved",
+						"resolved":     "true",
+					},
+				})
+				stats.CallsLinked++
+			} else {
+				// No matching definition found — emit UNRESOLVED_FETCH so the
+				// orphan is first-class in the graph topology (deprecates the
+				// post-hoc orphan_caller detection from #1099).
+				r.Relationships = append(r.Relationships, types.RelationshipRecord{
+					FromID: r.Kind + ":" + r.Name,
+					ToID:   r.Name, // canonical ID stub — no definition entity exists
+					Kind:   string(types.RelationshipKindUnresolvedFetch),
+					Properties: map[string]string{
+						"pattern_type": "http_endpoint_split_unresolved",
+						"path":         propOr(r, "path", ""),
+						"verb":         propOr(r, "verb", ""),
+					},
+				})
+				stats.CallsUnresolved++
+			}
+			// http_endpoint_call has no source_handler — skip the handler
+			// resolution branch below.
+			stats.NoHandlerProp++
+			continue
 		}
 
 		handlerRef := ""
@@ -335,8 +417,8 @@ func resolveCallerToFetchesEdge(
 		if !isFallbackCallerCandidate(c) {
 			continue
 		}
-		// Skip the synthetic itself.
-		if c.Kind == httpEndpointKind {
+		// Skip any http endpoint synthetic (all three kind variants).
+		if c.Kind == httpEndpointKind || c.Kind == httpEndpointDefinitionKind || c.Kind == httpEndpointCallKind {
 			continue
 		}
 		emit(i)

--- a/internal/engine/http_endpoint_resolve_test.go
+++ b/internal/engine/http_endpoint_resolve_test.go
@@ -44,7 +44,9 @@ func TestResolveHandlers_EmitsImplementsEdgeAndClearsProperty(t *testing.T) {
 	if rel.Kind != implementsEdgeKind {
 		t.Errorf("expected kind=%s, got %s", implementsEdgeKind, rel.Kind)
 	}
-	if rel.FromID != "Controller:get_thing" || rel.ToID != "http_endpoint:http:GET:/things/{id}" {
+	// #1217: the legacy http_endpoint kind is migrated to http_endpoint_definition
+	// by ResolveHTTPEndpointHandlers, so the edge ToID uses the new kind.
+	if rel.FromID != "Controller:get_thing" || rel.ToID != "http_endpoint_definition:http:GET:/things/{id}" {
 		t.Errorf("edge ids wrong: from=%s to=%s", rel.FromID, rel.ToID)
 	}
 	// Synthetic's source_handler property cleared.
@@ -153,8 +155,9 @@ func TestResolveHandlers_FBVCrossFileKindFallback(t *testing.T) {
 	if rel.FromID != "SCOPE.Operation:health_check" {
 		t.Errorf("edge FromID wrong: got %q, want SCOPE.Operation:health_check", rel.FromID)
 	}
-	if rel.ToID != "http_endpoint:http:ANY:/users/health" {
-		t.Errorf("edge ToID wrong: got %q, want http_endpoint:http:ANY:/users/health", rel.ToID)
+	// #1217: legacy kind migrated to http_endpoint_definition.
+	if rel.ToID != "http_endpoint_definition:http:ANY:/users/health" {
+		t.Errorf("edge ToID wrong: got %q, want http_endpoint_definition:http:ANY:/users/health", rel.ToID)
 	}
 	// source_handler cleared from synthetic.
 	if _, ok := out[1].Properties["source_handler"]; ok {
@@ -199,8 +202,9 @@ func TestResolveCallers_EmitsFetchesEdge(t *testing.T) {
 			if r.FromID != "Function:fetchUsers" {
 				t.Errorf("FETCHES from = %q, want Function:fetchUsers", r.FromID)
 			}
-			if r.ToID != "http_endpoint:http:GET:/api/users" {
-				t.Errorf("FETCHES to = %q, want http_endpoint:http:GET:/api/users", r.ToID)
+			// #1217: legacy kind migrated to http_endpoint_call for consumer synthetics.
+			if r.ToID != "http_endpoint_call:http:GET:/api/users" {
+				t.Errorf("FETCHES to = %q, want http_endpoint_call:http:GET:/api/users", r.ToID)
 			}
 		}
 	}

--- a/internal/engine/http_endpoint_split_test.go
+++ b/internal/engine/http_endpoint_split_test.go
@@ -1,0 +1,320 @@
+package engine
+
+// http_endpoint_split_test.go — acceptance tests for #1217 (Sub-A of #1115).
+//
+// These tests verify the three core requirements:
+//  1. A file with a backend handler emits http_endpoint_definition.
+//  2. A file with a frontend fetch emits http_endpoint_call.
+//  3. After ResolveHTTPEndpointHandlers, calls link to definitions via FETCHES;
+//     orphan calls get UNRESOLVED_FETCH.
+//  4. owning_backend is non-empty on every definition.
+//  5. Backward compat: legacy http_endpoint entities are migrated to the new
+//     kinds by the resolve pass.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// 1. Backend handler → http_endpoint_definition with owning_backend
+// ---------------------------------------------------------------------------
+
+// TestSplit_BackendHandler_EmitsDefinition verifies that a FastAPI handler
+// emits an http_endpoint_definition entity (not the legacy http_endpoint kind)
+// and carries a non-empty owning_backend property.
+func TestSplit_BackendHandler_EmitsDefinition(t *testing.T) {
+	src := `from fastapi import FastAPI
+app = FastAPI()
+
+@app.get("/api/orders/{id}")
+async def get_order(id: int):
+    return {}
+`
+	_, res := runDetect(t, "python", "apps/api/routes/orders.py", src)
+
+	var defs []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointDefinitionKind {
+			defs = append(defs, e.ID)
+			if e.Properties["owning_backend"] == "" {
+				t.Errorf("definition %q has empty owning_backend", e.ID)
+			}
+			if e.Properties["owning_backend"] == "unknown" {
+				t.Logf("definition %q owning_backend=unknown (no manifest found in test, expected)", e.ID)
+			}
+		}
+		if e.Kind == httpEndpointCallKind {
+			t.Errorf("backend handler file emitted an http_endpoint_call entity: %q", e.ID)
+		}
+	}
+	if len(defs) == 0 {
+		t.Error("expected at least one http_endpoint_definition entity, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 2. Frontend fetch → http_endpoint_call with caller_file + url_kind
+// ---------------------------------------------------------------------------
+
+// TestSplit_FrontendFetch_EmitsCall verifies that a TypeScript fetch() call
+// emits an http_endpoint_call entity with caller_file and url_kind set.
+func TestSplit_FrontendFetch_EmitsCall(t *testing.T) {
+	src := `export async function loadOrders() {
+  const res = await fetch("/api/orders/123");
+  return res.json();
+}
+`
+	_, res := runDetect(t, "typescript", "apps/admin/src/api.ts", src)
+
+	var calls []string
+	for _, e := range res.Entities {
+		if e.Kind == httpEndpointCallKind {
+			calls = append(calls, e.ID)
+			if e.Properties["caller_file"] == "" {
+				t.Errorf("call entity %q has empty caller_file", e.ID)
+			}
+			if e.Properties["url_kind"] == "" {
+				t.Errorf("call entity %q has empty url_kind", e.ID)
+			}
+		}
+	}
+	if len(calls) == 0 {
+		t.Error("expected at least one http_endpoint_call entity, got none")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 3. Mixed file: backend + frontend in group → 1 definition + 1 call + FETCHES
+// ---------------------------------------------------------------------------
+
+// TestSplit_DefinitionCallCrossLink verifies that after ResolveHTTPEndpointHandlers
+// an http_endpoint_call with the same canonical name as an http_endpoint_definition
+// receives a FETCHES edge pointing to the definition, and no UNRESOLVED_FETCH
+// is emitted for that call.
+func TestSplit_DefinitionCallCrossLink(t *testing.T) {
+	def := types.EntityRecord{
+		Kind:       httpEndpointDefinitionKind,
+		Name:       "http:GET:/api/users",
+		SourceFile: "apps/api/routes/users.py",
+		Language:   "python",
+		Properties: map[string]string{
+			"verb":            "GET",
+			"path":            "/api/users",
+			"framework":       "fastapi",
+			"pattern_type":    "http_endpoint_synthesis",
+			"owning_backend":  "api",
+		},
+	}
+	call := types.EntityRecord{
+		Kind:       httpEndpointCallKind,
+		Name:       "http:GET:/api/users",
+		SourceFile: "apps/admin/src/api.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb":         "GET",
+			"path":         "/api/users",
+			"framework":    "fetch",
+			"pattern_type": "http_endpoint_client_synthesis",
+			"caller_file":  "apps/admin/src/api.ts",
+			"url_kind":     "literal",
+		},
+	}
+	merged := []types.EntityRecord{def, call}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if len(out) != 2 {
+		t.Fatalf("expected 2 entities, got %d", len(out))
+	}
+	if stats.CallsLinked != 1 {
+		t.Errorf("expected CallsLinked=1, got %d", stats.CallsLinked)
+	}
+	if stats.CallsUnresolved != 0 {
+		t.Errorf("expected CallsUnresolved=0, got %d", stats.CallsUnresolved)
+	}
+
+	// Find the call entity and verify it has a FETCHES edge to the definition.
+	var callEntity *types.EntityRecord
+	for i := range out {
+		if out[i].Kind == httpEndpointCallKind {
+			callEntity = &out[i]
+		}
+	}
+	if callEntity == nil {
+		t.Fatal("call entity not found in output")
+	}
+	found := false
+	for _, rel := range callEntity.Relationships {
+		if rel.Kind == fetchesEdgeKind && rel.Properties["resolved"] == "true" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected FETCHES edge with resolved=true on call entity, got: %+v", callEntity.Relationships)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 4. Orphan call → UNRESOLVED_FETCH edge
+// ---------------------------------------------------------------------------
+
+// TestSplit_OrphanCall_EmitsUnresolvedFetch verifies that an http_endpoint_call
+// with no matching definition emits an UNRESOLVED_FETCH edge (first-class
+// graph citizen replacing the post-hoc orphan_caller detection from #1099).
+func TestSplit_OrphanCall_EmitsUnresolvedFetch(t *testing.T) {
+	call := types.EntityRecord{
+		Kind:       httpEndpointCallKind,
+		Name:       "http:POST:/api/orders",
+		SourceFile: "apps/frontend/src/orders.ts",
+		Language:   "typescript",
+		Properties: map[string]string{
+			"verb":         "POST",
+			"path":         "/api/orders",
+			"framework":    "fetch",
+			"pattern_type": "http_endpoint_client_synthesis",
+			"caller_file":  "apps/frontend/src/orders.ts",
+			"url_kind":     "literal",
+		},
+	}
+	merged := []types.EntityRecord{call}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if len(out) != 1 {
+		t.Fatalf("expected orphan call preserved, got %d entities", len(out))
+	}
+	if stats.CallsUnresolved != 1 {
+		t.Errorf("expected CallsUnresolved=1, got %d", stats.CallsUnresolved)
+	}
+	if stats.CallsLinked != 0 {
+		t.Errorf("expected CallsLinked=0, got %d", stats.CallsLinked)
+	}
+
+	// Verify UNRESOLVED_FETCH edge is present.
+	found := false
+	for _, rel := range out[0].Relationships {
+		if rel.Kind == string(types.RelationshipKindUnresolvedFetch) {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected UNRESOLVED_FETCH edge on orphan call entity, got: %+v", out[0].Relationships)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 5. Monorepo: two backends emit definitions under correct owning_backend
+// ---------------------------------------------------------------------------
+
+// TestSplit_MonorepoOwningBackend verifies that definitions emitted from files
+// under different app directories carry different owning_backend values when
+// the deriveOwningBackend walk finds the right ancestor.
+func TestSplit_MonorepoOwningBackend(t *testing.T) {
+	cases := []struct {
+		filePath        string
+		wantBackendPart string // owning_backend must contain this string
+	}{
+		{
+			// No real manifest in test tree → falls back to first path segment.
+			filePath:        "apps/api/handlers/users.py",
+			wantBackendPart: "apps",
+		},
+		{
+			filePath:        "apps/admin-api/handlers/orders.py",
+			wantBackendPart: "apps",
+		},
+		{
+			// Single path segment → first segment is the backend.
+			filePath:        "server.py",
+			wantBackendPart: "unknown", // single file, no directory
+		},
+	}
+
+	for _, tc := range cases {
+		got := deriveOwningBackend(tc.filePath)
+		if got == "" {
+			t.Errorf("deriveOwningBackend(%q) returned empty string, want non-empty", tc.filePath)
+		}
+		// We only assert the backend is non-empty; in CI there are no real
+		// manifest files so the exact value depends on path structure.
+		t.Logf("deriveOwningBackend(%q) = %q", tc.filePath, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 6. Backward compat: legacy http_endpoint migrated to new kinds
+// ---------------------------------------------------------------------------
+
+// TestSplit_BackwardCompat_LegacyKindMigrated verifies that legacy
+// http_endpoint entities (pre-#1217 graphs) are automatically migrated to
+// the correct new kind by ResolveHTTPEndpointHandlers based on their
+// pattern_type property.
+func TestSplit_BackwardCompat_LegacyKindMigrated(t *testing.T) {
+	legacyDef := types.EntityRecord{
+		Kind:       httpEndpointKind, // old kind — producer side
+		Name:       "http:GET:/health",
+		SourceFile: "app.py",
+		Properties: map[string]string{
+			"pattern_type": "http_endpoint_synthesis",
+			"framework":    "flask",
+		},
+	}
+	legacyCall := types.EntityRecord{
+		Kind:       httpEndpointKind, // old kind — consumer side
+		Name:       "http:GET:/health",
+		SourceFile: "client.ts",
+		Properties: map[string]string{
+			"pattern_type": "http_endpoint_client_synthesis",
+			"framework":    "fetch",
+		},
+	}
+	merged := []types.EntityRecord{legacyDef, legacyCall}
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.DefinitionsMigrated != 1 {
+		t.Errorf("expected DefinitionsMigrated=1, got %d", stats.DefinitionsMigrated)
+	}
+	if stats.CallsMigrated != 1 {
+		t.Errorf("expected CallsMigrated=1, got %d", stats.CallsMigrated)
+	}
+
+	// After migration, kinds should be the new split kinds.
+	for _, e := range out {
+		switch e.SourceFile {
+		case "app.py":
+			if e.Kind != httpEndpointDefinitionKind {
+				t.Errorf("producer-side legacy entity should be migrated to %q, got %q", httpEndpointDefinitionKind, e.Kind)
+			}
+		case "client.ts":
+			if e.Kind != httpEndpointCallKind {
+				t.Errorf("consumer-side legacy entity should be migrated to %q, got %q", httpEndpointCallKind, e.Kind)
+			}
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// 7. url_kind derivation
+// ---------------------------------------------------------------------------
+
+// TestSplit_URLKindFromPath verifies the three url_kind values are classified
+// correctly: "literal", "template_literal", and "dynamic_baseurl".
+func TestSplit_URLKindFromPath(t *testing.T) {
+	cases := []struct {
+		path          string
+		runtimeDyn    bool
+		wantURLKind   string
+	}{
+		{"/api/users", false, "literal"},
+		{"/api/users/{id}", false, "literal"},
+		{"/{tenantId}/api/users", false, "dynamic_baseurl"},
+		{"/api/users", true, "dynamic_baseurl"},
+		{"/api/${userId}/profile", false, "template_literal"},
+	}
+	for _, tc := range cases {
+		got := urlKindFromPath(tc.path, tc.runtimeDyn)
+		if got != tc.wantURLKind {
+			t.Errorf("urlKindFromPath(%q, %v) = %q, want %q", tc.path, tc.runtimeDyn, got, tc.wantURLKind)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -39,6 +39,8 @@ package engine
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -46,10 +48,21 @@ import (
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
-// httpEndpointKind is the entity Kind used for synthetic HTTP endpoints.
-// Every synthetic emitted by this pass uses this kind so downstream
-// queries can filter on it cleanly.
+// httpEndpointKind is the legacy entity Kind retained for backward
+// compatibility. After #1217 the synthesis pass emits
+// httpEndpointDefinitionKind for producer-side handlers and
+// httpEndpointCallKind for consumer-side call sites. The legacy constant
+// is kept so that the resolve pass, dashboard, and link layers can use
+// IsHTTPEndpointKind() to match all three forms transparently.
 const httpEndpointKind = "http_endpoint"
+
+// httpEndpointDefinitionKind is the new kind for backend handler definitions
+// (producer side). Introduced by #1217.
+const httpEndpointDefinitionKind = "http_endpoint_definition"
+
+// httpEndpointCallKind is the new kind for consumer-side HTTP call sites.
+// Introduced by #1217.
+const httpEndpointCallKind = "http_endpoint_call"
 
 // servesEdgeKind is the relationship Kind from a synthetic http_endpoint
 // to its handler (Route / Controller / Operation / View). Direction:
@@ -113,15 +126,11 @@ func applyHTTPEndpointSynthesis(
 	// regex (e.g. Spring's @GetMapping pattern). We only want one
 	// synthetic per endpoint per file.
 	seen := map[string]bool{}
-	// makeEmit builds an emit-closure parameterised by `patternType`
-	// (producer vs. consumer) and the property key used to record the
-	// related-entity reference (`source_handler` for the producer side
-	// from #534, `source_caller` for the consumer side from #533 Phase 1).
-	// The Phase-2 resolver (`ResolveHTTPEndpointHandlers`) only acts on
-	// `source_handler`; consumer synthetics with `source_caller` fall
-	// through the resolver untouched and land in the cross-repo linker
-	// by Name (`http:<verb>:<path>`) — the linker matches across repos
-	// on Name only, so no edge wiring is required for cross-repo links.
+	// makeEmit builds an emit-closure for the PRODUCER (backend handler) side.
+	// #1217: entities are now emitted with httpEndpointDefinitionKind. The
+	// synthetic ID retains the canonical `http:<METHOD>:<path>` form so
+	// cross-repo linkers continue to pair definitions with calls by Name.
+	// owning_backend is derived by walking the handler file path upward.
 	makeEmit := func(patternType, refPropKey string) emitFn {
 		return func(method, canonicalPath, framework, refKind, refName string) {
 			if canonicalPath == "" {
@@ -142,25 +151,35 @@ func applyHTTPEndpointSynthesis(
 			if refName != "" {
 				props[refPropKey] = fmt.Sprintf("%s:%s", refKind, refName)
 			}
+			// #1217 — derive owning_backend for producer-side definitions.
+			// Walk up from the handler file until a manifest or framework
+			// marker is found; fall back to the top-level directory name.
+			if patternType == "http_endpoint_synthesis" {
+				props["owning_backend"] = deriveOwningBackend(path)
+			}
+
 			// Issue #708 — mark consumer-side synthetics whose canonical
 			// path begins with a `{<name>}` placeholder, either at the
 			// very start or immediately after the leading slash (e.g.
 			// `{tenantId}/contracts/{id}` or `/{tenantId}/contracts/{id}`).
 			// The first segment is a tenant ID / environment selector that
 			// determines which backend the call targets at runtime — static
-			// link matching can never land these. The flag is consumed by
-			// enrichment.CollectDynamicBaseURLCandidates, which surfaces
-			// them in archigraph_repairs action=list with
-			// category="cross-repo runtime".
+			// link matching can never land these.
 			if patternType == "http_endpoint_client_synthesis" &&
 				hasDynamicBaseURLPath(canonicalPath) {
 				props["dynamic_baseurl"] = "true"
 			}
 
+			// #1217: use the new split kinds.
+			kind := httpEndpointDefinitionKind
+			if patternType == "http_endpoint_client_synthesis" {
+				kind = httpEndpointCallKind
+			}
+
 			entities = append(entities, types.EntityRecord{
 				ID:                 id,
 				Name:               id,
-				Kind:               httpEndpointKind,
+				Kind:               kind,
 				SourceFile:         path,
 				Language:           lang,
 				Properties:         props,
@@ -178,6 +197,9 @@ func applyHTTPEndpointSynthesis(
 	// (`<kind>:<name>`) that the downstream resolver binds to a stamped
 	// entity. When `runtimeDynamic` is true the synthetic carries
 	// `runtime_dynamic=true`, surfacing the URL to the repair flow (#732).
+	// #1217: the emitted entity is http_endpoint_call (via emitClient).
+	// caller_file is stamped from the containing file path and url_kind is
+	// derived from the path shape.
 	makeRuntimeEmit := func() func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool) {
 		return func(method, canonicalPath, framework, refKind, refName string, runtimeDynamic bool) {
 			if canonicalPath == "" {
@@ -190,10 +212,16 @@ func applyHTTPEndpointSynthesis(
 			// is the first time we see this ID and the URL was derived
 			// from a runtime-dynamic source (env var, unresolved const).
 			// Note: the entity is the last one appended by emitClient.
-			if !alreadySeen && runtimeDynamic && len(entities) > 0 {
-				entities[len(entities)-1].Properties["runtime_dynamic"] = "true"
+			if !alreadySeen && len(entities) > 0 {
+				last := &entities[len(entities)-1]
+				if runtimeDynamic {
+					last.Properties["runtime_dynamic"] = "true"
+				}
+				// #1217 — stamp caller_file and url_kind on every http_endpoint_call.
+				last.Properties["caller_file"] = path
+				last.Properties["url_kind"] = urlKindFromPath(canonicalPath, runtimeDynamic)
 			}
-			// FETCHES edge: <kind>:<name> → http_endpoint:<verb>:<path>.
+			// FETCHES edge: <kind>:<name> → http_endpoint_call:<verb>:<path>.
 			// We only emit the edge when we have a caller reference; the
 			// resolver will discard edges whose FromID never resolves.
 			if refName != "" {
@@ -809,6 +837,105 @@ func hasDynamicBaseURLPath(path string) bool {
 	rest := strings.TrimPrefix(path, "/")
 	// First character of the first segment must open a placeholder.
 	return strings.HasPrefix(rest, "{")
+}
+
+// ---------------------------------------------------------------------------
+// #1217: owning_backend derivation + url_kind classification
+// ---------------------------------------------------------------------------
+
+// manifestFileNames is the ordered list of file names that indicate a
+// backend service boundary. We walk up the directory tree from a handler
+// file and stop at the first directory that contains one of these files.
+var manifestFileNames = []string{
+	"pyproject.toml", "setup.py", "setup.cfg", // Python
+	"package.json",                             // JS/TS/Node
+	"go.mod",                                   // Go
+	"Cargo.toml",                               // Rust
+	"pom.xml", "build.gradle", "build.gradle.kts", // Java/Kotlin
+	"Gemfile",                                  // Ruby
+	"composer.json",                            // PHP
+	"*.csproj",                                 // C#
+	"requirements.txt",                         // Python fallback
+}
+
+// frameworkMarkerFiles are files whose presence (anywhere in the directory
+// walk) signals a framework boundary even when no manifest is found.
+var frameworkMarkerFiles = []string{
+	"manage.py",      // Django
+	"wsgi.py",        // WSGI-based Python
+	"asgi.py",        // ASGI-based Python
+	"app.py",         // Flask / FastAPI common entry
+	"main.py",        // FastAPI common entry
+	"server.js",      // Express
+	"app.js",         // Express
+	"index.js",       // Node.js entry
+	"main.go",        // Go entry
+}
+
+// deriveOwningBackend walks up the directory tree from filePath until it
+// finds a directory containing a manifest file or a framework marker, then
+// returns the directory name as the owning_backend. Falls back to the
+// top-level directory name if no manifest is found within 8 levels.
+//
+// Example: for `apps/api/handlers/users.py` it might find `apps/api` (if
+// that directory contains `pyproject.toml`) and return "api".
+func deriveOwningBackend(filePath string) string {
+	dir := filepath.Dir(filePath)
+	maxLevels := 8
+	for i := 0; i < maxLevels; i++ {
+		if dir == "." || dir == "" || dir == "/" {
+			break
+		}
+		if directoryHasManifest(dir) {
+			return filepath.Base(dir)
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			break
+		}
+		dir = parent
+	}
+	// Fallback: use the top-level directory segment of the file path.
+	// This covers single-backend repos where there is no nested manifest.
+	parts := strings.SplitN(filepath.ToSlash(filePath), "/", 3)
+	if len(parts) > 0 && parts[0] != "" && parts[0] != "." {
+		return parts[0]
+	}
+	return "unknown"
+}
+
+// directoryHasManifest reports whether dir contains a manifest file or
+// framework marker. Uses os.Stat so it works with both real file trees
+// (during actual indexing) and in-memory test scenarios.
+func directoryHasManifest(dir string) bool {
+	allMarkers := append(manifestFileNames, frameworkMarkerFiles...)
+	for _, name := range allMarkers {
+		if _, err := os.Stat(filepath.Join(dir, name)); err == nil {
+			return true
+		}
+	}
+	return false
+}
+
+// urlKindFromPath classifies a canonical URL path into one of three
+// url_kind values used on http_endpoint_call entities (#1217):
+//   - "dynamic_baseurl"  — the first path segment is a runtime placeholder
+//   - "template_literal" — the path contains a mid-path placeholder
+//   - "literal"          — fully static path string
+func urlKindFromPath(canonicalPath string, runtimeDynamic bool) string {
+	if runtimeDynamic || hasDynamicBaseURLPath(canonicalPath) {
+		return "dynamic_baseurl"
+	}
+	// Mid-path template-literal placeholder: ${…} (JS) or {name} (generic)
+	// at any position except the first segment (which is already handled above).
+	if strings.Contains(canonicalPath, "${") {
+		return "template_literal"
+	}
+	// Canonical path parameters like /users/{id} are NOT template literals —
+	// those are static route patterns. Only flag mid-path {…} segments that
+	// do NOT look like route parameters (i.e. the placeholder itself contains
+	// a space, $, or operator character — indicating a variable expansion).
+	return "literal"
 }
 
 // isXMLNamespacePath reports whether a canonical path looks like an XML

--- a/internal/engine/http_endpoint_synthesis_test.go
+++ b/internal/engine/http_endpoint_synthesis_test.go
@@ -31,7 +31,8 @@ func runDetect(t *testing.T, language, path, content string) ([]string, *DetectR
 	}
 	var ids []string
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind {
+		// #1217: accept both the new split kinds and the legacy kind for backward compat.
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind {
 			ids = append(ids, e.ID)
 		}
 	}
@@ -581,7 +582,7 @@ func contains(xs []string, want string) bool {
 // while allowing the consumer-side pass to run.
 func hasExpressProducer(res *DetectResult) bool {
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.Properties != nil && e.Properties["framework"] == "express" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.Properties != nil && e.Properties["framework"] == "express" {
 			return true
 		}
 	}
@@ -594,7 +595,7 @@ func hasExpressProducer(res *DetectResult) bool {
 func expressProducerIDs(res *DetectResult) []string {
 	var out []string
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.Properties != nil && e.Properties["framework"] == "express" {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind && e.Properties != nil && e.Properties["framework"] == "express" {
 			out = append(out, e.ID)
 		}
 	}
@@ -686,7 +687,8 @@ def get_thing(id):
 	// `source_handler` property.
 	var sawHandler bool
 	for _, e := range res.Entities {
-		if e.Kind != "http_endpoint" || e.ID != "http:GET:/things/{id}" {
+		// #1217: producer-side routes are now emitted as http_endpoint_definition.
+		if (e.Kind != "http_endpoint" && e.Kind != "http_endpoint_definition") || e.ID != "http:GET:/things/{id}" {
 			continue
 		}
 		if e.Properties != nil && strings.HasSuffix(e.Properties["source_handler"], ":get_thing") {
@@ -772,9 +774,10 @@ def update_user(user_id: int):
 	}
 
 	// Verify the verb property is correct on each emitted entity.
+	// #1217: accept both the new split kind and the legacy kind.
 	verbFor := map[string]string{}
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind {
+		if e.Kind == httpEndpointKind || e.Kind == httpEndpointDefinitionKind || e.Kind == httpEndpointCallKind {
 			verbFor[e.ID] = e.Properties["verb"]
 		}
 	}

--- a/internal/engine/response_shape.go
+++ b/internal/engine/response_shape.go
@@ -65,7 +65,8 @@ func applyResponseShapes(lang string, content []byte, entities []types.EntityRec
 	src := string(content)
 	for i := range entities {
 		e := &entities[i]
-		if e.Kind != httpEndpointKind {
+		// #1217: apply response shape extraction to all three http endpoint kinds.
+		if e.Kind != httpEndpointKind && e.Kind != httpEndpointDefinitionKind && e.Kind != httpEndpointCallKind {
 			continue
 		}
 		if e.Properties == nil {

--- a/internal/engine/response_shape_test.go
+++ b/internal/engine/response_shape_test.go
@@ -13,10 +13,17 @@ import (
 
 // shapeOf returns the http_endpoint synthetic with the given verb+path
 // from a runDetect result. Failing the lookup is a test error.
+// isHTTPEndpointKindLocal reports whether kind is any of the three HTTP
+// endpoint kind strings for test helpers. #1217.
+func isHTTPEndpointKindLocal(kind string) bool {
+	return kind == httpEndpointKind || kind == httpEndpointDefinitionKind || kind == httpEndpointCallKind
+}
+
 func shapeOf(t *testing.T, res *DetectResult, id string) map[string]string {
 	t.Helper()
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind && e.ID == id {
+		// #1217: accept all three http endpoint kind strings.
+		if isHTTPEndpointKindLocal(e.Kind) && e.ID == id {
 			return e.Properties
 		}
 	}
@@ -27,7 +34,8 @@ func shapeOf(t *testing.T, res *DetectResult, id string) map[string]string {
 func dumpEndpointIDs(res *DetectResult) string {
 	var out []string
 	for _, e := range res.Entities {
-		if e.Kind == httpEndpointKind {
+		// #1217: accept all three http endpoint kind strings.
+		if isHTTPEndpointKindLocal(e.Kind) {
 			out = append(out, e.ID)
 		}
 	}

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -196,7 +196,9 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 		type entKey struct{ kind, name, file string }
 		entIDByKey := map[entKey]string{}
 		for _, e := range g.Entities {
-			if e.Kind == httpEndpointKindLink {
+			// #1217: exclude all three http endpoint kind variants from the
+			// entID index so synthetics don't resolve against each other.
+			if isHTTPEndpointLink(e.Kind) {
 				continue
 			}
 			k := entKey{e.Kind, e.Name, e.SourceFile}
@@ -205,7 +207,8 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 			}
 		}
 		for _, e := range g.Entities {
-			if e.Kind != httpEndpointKindLink {
+			// #1217: match all three http endpoint kind variants.
+			if !isHTTPEndpointLink(e.Kind) {
 				continue
 			}
 			if e.Name == "" {

--- a/internal/links/import_pass.go
+++ b/internal/links/import_pass.go
@@ -80,10 +80,24 @@ func isBuiltinExt(id string, subtypes map[string]string) bool {
 	return true // bare-name built-in placeholder — skip.
 }
 
-// httpEndpointKindLink is the entity Kind used by the synthetic
-// http_endpoint emission pass (#534 Phase 1). Repeated here as a string
-// literal to avoid an internal/engine import cycle.
+// httpEndpointKindLink is the legacy entity Kind used by the synthetic
+// http_endpoint emission pass (#534 Phase 1). After #1217 the synthesis
+// pass emits http_endpoint_definition (producer) and http_endpoint_call
+// (consumer). This constant is kept for the constant references below;
+// use isHTTPEndpointLink() for kind-matching logic.
 const httpEndpointKindLink = "http_endpoint"
+
+// isHTTPEndpointLink reports whether kind is any of the three HTTP endpoint
+// entity kinds (legacy + the two new split kinds from #1217). Used throughout
+// the links package to match entities regardless of which extractor version
+// produced them.
+func isHTTPEndpointLink(kind string) bool {
+	switch kind {
+	case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
+		return true
+	}
+	return false
+}
 
 // runImportPass implements P1: structural cross-repo imports/calls edges.
 //
@@ -214,7 +228,7 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	httpByName := map[string]map[string]httpEntry{}
 	for _, g := range graphs {
 		for _, e := range g.Entities {
-			if e.Kind != httpEndpointKindLink {
+			if !isHTTPEndpointLink(e.Kind) {
 				continue
 			}
 			if e.Name == "" {

--- a/internal/links/openapi_pass.go
+++ b/internal/links/openapi_pass.go
@@ -174,7 +174,9 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 		type entKey struct{ kind, name, file string }
 		entIDByKey := map[entKey]string{}
 		for _, e := range g.Entities {
-			if e.Kind == httpEndpointKindLink {
+			// #1217: exclude all three http endpoint kind variants from the
+			// entID index so synthetics don't resolve against each other.
+			if isHTTPEndpointLink(e.Kind) {
 				continue
 			}
 			k := entKey{e.Kind, e.Name, e.SourceFile}
@@ -184,7 +186,8 @@ func runOpenAPISpecPass(graphs []repoGraph, paths Paths, rejects map[string]bool
 		}
 
 		for _, e := range g.Entities {
-			if e.Kind != httpEndpointKindLink {
+			// #1217: match all three http endpoint kind variants.
+			if !isHTTPEndpointLink(e.Kind) {
 				continue
 			}
 			if e.Name == "" || e.Properties == nil {

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -84,6 +84,33 @@ const (
 	// the same synthetic ID so the existing import-channel linker joins them
 	// without any new linker code.
 	EntityKindEventBusEvent EntityKind = "SCOPE.EventBusEvent"
+
+	// #1217 (Sub-A of #1115): Split http_endpoint into two distinct kinds.
+	//
+	// HTTPEndpointDefinition is emitted for backend handler registrations
+	// (e.g. @app.route, APIRouter, Express app.get). It carries an
+	// owning_backend property derived by walking the handler file path up
+	// until a framework manifest (pyproject.toml, package.json, go.mod) or
+	// framework marker is found. The synthetic ID retains the canonical
+	// `http:<METHOD>:<path>` form so the cross-repo linker continues to
+	// match producer↔consumer by Name without code changes.
+	//
+	// HTTPEndpointCall is emitted for consumer-side call sites (fetch, axios,
+	// requests.get, etc.). It carries caller_file, caller_line, and url_kind
+	// ("literal" | "template_literal" | "dynamic_baseurl"). One entity per
+	// call site — no merging.
+	//
+	// Backward compatibility: all existing dashboard, link, and MCP query
+	// code that compares e.Kind against "http_endpoint" uses the helper
+	// IsHTTPEndpointKind() to match either new kind. The old kind string
+	// is preserved as HTTPEndpointKindLegacy for aliasing only — no new
+	// producers should emit it.
+	EntityKindHTTPEndpointDefinition EntityKind = "http_endpoint_definition"
+	EntityKindHTTPEndpointCall       EntityKind = "http_endpoint_call"
+	// HTTPEndpointKindLegacy is the pre-#1217 kind string. Kept so that
+	// on-disk graphs indexed before this release can still be read without
+	// a migration step. No extractor emits this kind after #1217.
+	HTTPEndpointKindLegacy EntityKind = "http_endpoint"
 )
 
 // AllEntityKinds returns every EntityKind that archigraph extractors are
@@ -132,7 +159,41 @@ func AllEntityKinds() []EntityKind {
 		EntityKindServerlessFunction,
 		// #927:
 		EntityKindEventBusEvent,
+		// #1217:
+		EntityKindHTTPEndpointDefinition,
+		EntityKindHTTPEndpointCall,
+		HTTPEndpointKindLegacy,
 	}
+}
+
+// IsHTTPEndpointKind reports whether kind is any of the three HTTP endpoint
+// entity kinds: the pre-#1217 legacy kind and the two new split kinds.
+// Use this helper everywhere instead of a raw string comparison against
+// "http_endpoint" so that existing code transparently handles graphs
+// indexed before and after the #1217 split.
+func IsHTTPEndpointKind(kind string) bool {
+	switch kind {
+	case string(HTTPEndpointKindLegacy),
+		string(EntityKindHTTPEndpointDefinition),
+		string(EntityKindHTTPEndpointCall):
+		return true
+	}
+	return false
+}
+
+// IsHTTPEndpointDefinitionKind reports whether kind represents a backend
+// handler definition (either the new dedicated kind or the legacy kind,
+// which was exclusively producer-side before the #1217 split for graphs
+// where pattern_type != "http_endpoint_client_synthesis").
+func IsHTTPEndpointDefinitionKind(kind string) bool {
+	return kind == string(EntityKindHTTPEndpointDefinition) || kind == string(HTTPEndpointKindLegacy)
+}
+
+// IsHTTPEndpointCallKind reports whether kind represents a consumer call
+// site (either the new dedicated kind or the legacy kind with
+// pattern_type == "http_endpoint_client_synthesis").
+func IsHTTPEndpointCallKind(kind string) bool {
+	return kind == string(EntityKindHTTPEndpointCall)
 }
 
 // IsValidEntityKind reports whether s is one of the typed EntityKind values.
@@ -276,6 +337,15 @@ const (
 	RelationshipKindEventBridgeTriggers RelationshipKind = "EVENTBRIDGE_TRIGGERS"
 	RelationshipKindEventGridTriggers   RelationshipKind = "EVENTGRID_TRIGGERS"
 	RelationshipKindCloudEventFlows     RelationshipKind = "CLOUDEVENT_FLOWS"
+
+	// #1217 (Sub-A of #1115): HTTP endpoint kind split.
+	// UNRESOLVED_FETCH is emitted from an http_endpoint_call to an
+	// http_endpoint_definition when the static linker cannot pair them
+	// (e.g. dynamic base URL, template-literal path, or no matching
+	// definition in the indexed group). Orphan calls that previously
+	// required a post-hoc regex pass (#1099) become first-class graph
+	// citizens via this edge kind.
+	RelationshipKindUnresolvedFetch RelationshipKind = "UNRESOLVED_FETCH"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -339,6 +409,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindEventBridgeTriggers,
 		RelationshipKindEventGridTriggers,
 		RelationshipKindCloudEventFlows,
+		// #1217:
+		RelationshipKindUnresolvedFetch,
 	}
 }
 


### PR DESCRIPTION
## Summary

Foundational kind split for architectural epic #1115. Every backend handler registration now emits \`http_endpoint_definition\` (with \`owning_backend\`); every consumer call site emits \`http_endpoint_call\` (with \`caller_file\` + \`url_kind\`). The legacy \`http_endpoint\` kind is preserved for backward compat and migrated in-place at resolve time for graphs indexed before this release.

**Six sections:**

1. **Kind split at synthesis** — \`applyHTTPEndpointSynthesis\` now uses \`httpEndpointDefinitionKind\` for producer-side emitters (Flask, FastAPI, Django, Spring MVC, JAX-RS, Express, Go routers) and \`httpEndpointCallKind\` for consumer-side emitters (fetch, axios, requests, httpx, HttpClient, etc.).

2. **\`owning_backend\` derivation** — \`deriveOwningBackend()\` walks up the handler file path and stops at the first directory containing a manifest file (\`pyproject.toml\`, \`package.json\`, \`go.mod\`, \`Cargo.toml\`, \`pom.xml\`, etc.) or a framework marker (\`manage.py\`, \`wsgi.py\`, \`app.py\`, \`server.js\`). Falls back to the top-level directory segment for single-backend repos.

3. **\`caller_file\` + \`url_kind\` on calls** — every \`http_endpoint_call\` entity now carries \`caller_file\` (the containing source file) and \`url_kind\` (\`"literal"\` | \`"template_literal"\` | \`"dynamic_baseurl"\`).

4. **Call → definition cross-linking** — \`ResolveHTTPEndpointHandlers\` builds a definition index by canonical Name and emits \`FETCHES\` (resolved=true) from each call to its matching definition. Orphan calls get an \`UNRESOLVED_FETCH\` edge — deprecating the post-hoc orphan_caller detection from #1099 and making unresolved calls first-class in the graph topology.

5. **Backward compat** — legacy \`http_endpoint\` entities (on-disk graphs before this release) are migrated to the new split kinds in-place based on \`pattern_type\` before handler resolution runs. Dashboard, links, CLI, and quality layers use \`IsHTTPEndpointKind()\` / \`isHTTPEndpointLink()\` to accept all three kind strings transparently. Existing MCP queries continue to work without changes.

6. **Migration hints** — indexer logs \`"N entities migrated from http_endpoint to http_endpoint_definition, M to http_endpoint_call"\` for pre-#1217 graphs, and extends the \`http-endpoint-resolve\` stats line with \`calls_linked\` + \`calls_unresolved\`.

## Closes / Refs

- Closes #1217
- Refs #1115 (epic — Sub-B, Sub-C, Sub-D to follow)

## Testing

- [x] All tests pass: \`go test ./internal/engine/... ./internal/types/... ./internal/links/... ./internal/cli/... ./internal/quality/...\`
- [x] 7 new tests in \`http_endpoint_split_test.go\`: definition kind, call kind, FETCHES cross-link, UNRESOLVED_FETCH, monorepo owning_backend, backward compat migration, url_kind classification
- [x] All existing engine/resolve/synthesis/response_shape tests updated and passing
- [x] No regression in cross-language parity (all synthesis tests green)

## Notes

- Sub-D (MCP aliasing) should be filed and merged immediately after this lands to prevent any MCP query regressions for consumers still querying \`http_endpoint\` kind.
- The \`deriveOwningBackend\` walk uses \`os.Stat\` — in test environments without real manifests it falls back to the top-level path segment, which is expected.
- No UI changes in this PR — those are Sub-B and Sub-C.