### PR TITLE
[dashboard] Cmd+K command palette — fuzzy search all surfaces + actions (#1234)

### DIFF
--- a/dashboard/src/components/layout/CommandPalette.tsx
+++ b/dashboard/src/components/layout/CommandPalette.tsx
@@ -1,0 +1,447 @@
+/**
+ * CommandPalette — Cmd+K (Mac) / Ctrl+K (Linux/Win) global command palette.
+ *
+ * Features:
+ *   - Fuzzy search over all surfaces + actions using fuse.js (already in deps)
+ *   - Two sections: Surfaces and Actions
+ *   - Arrow-key navigation, Enter to select, Esc to close
+ *   - Recent items (up to 5) stored in localStorage, shown when input empty
+ *   - Dimmed backdrop, smooth fade-in animation
+ *   - Mobile: accessible via data-testid="cmd-palette-chip" chip in header
+ *
+ * Closes: #1234
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import Fuse from 'fuse.js'
+import {
+  Network, Workflow, Radio, Globe, BookOpen, Clock,
+  Stethoscope, BarChart2, Sparkles, Server, RefreshCw,
+  Settings, Activity, Wrench, RotateCcw, Sun, Moon,
+  RefreshCcw, Home, HelpCircle,
+} from 'lucide-react'
+
+/* ── Types ──────────────────────────────────────────────────────────────────── */
+
+type CommandKind = 'surface' | 'action'
+
+interface Command {
+  id: string
+  label: string
+  description?: string
+  kind: CommandKind
+  /** For surfaces: navigate to this path */
+  to?: string
+  /** For actions: call this function */
+  fn?: () => void
+  icon: React.ReactNode
+  /** Coming soon — not wired yet */
+  comingSoon?: boolean
+}
+
+/* ── Constants ──────────────────────────────────────────────────────────────── */
+
+const RECENT_KEY = 'archigraph:cmd-recent'
+const MAX_RECENT = 5
+
+function loadRecent(): string[] {
+  try {
+    return JSON.parse(localStorage.getItem(RECENT_KEY) ?? '[]')
+  } catch {
+    return []
+  }
+}
+
+function saveRecent(id: string) {
+  const prev = loadRecent().filter((x) => x !== id)
+  localStorage.setItem(RECENT_KEY, JSON.stringify([id, ...prev].slice(0, MAX_RECENT)))
+}
+
+/* ── CommandPalette component ───────────────────────────────────────────────── */
+
+interface CommandPaletteProps {
+  open: boolean
+  onClose: () => void
+  /** Active group slug for group-scoped surface links */
+  group?: string
+}
+
+export function CommandPalette({ open, onClose, group = 'fixture-a' }: CommandPaletteProps) {
+  const navigate = useNavigate()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const listRef = useRef<HTMLDivElement>(null)
+
+  const [query, setQuery] = useState('')
+  const [activeIndex, setActiveIndex] = useState(0)
+
+  /* ── Build command list ──────────────────────────────────────────────────── */
+
+  const commands = useMemo((): Command[] => [
+    // Surfaces
+    { id: 'surface-graph',       label: 'Graph',       description: 'Dependency graph view',   kind: 'surface', to: `/graph/${group}`,       icon: <Network    className="w-4 h-4" /> },
+    { id: 'surface-flows',       label: 'Flows',       description: 'Execution flow traces',   kind: 'surface', to: `/flows/${group}`,       icon: <Workflow   className="w-4 h-4" /> },
+    { id: 'surface-topology',    label: 'Topology',    description: 'Service topology map',    kind: 'surface', to: `/topology/${group}`,    icon: <Radio      className="w-4 h-4" /> },
+    { id: 'surface-paths',       label: 'API Explorer', description: 'Browse all API paths',  kind: 'surface', to: `/paths/${group}`,       icon: <Globe      className="w-4 h-4" /> },
+    { id: 'surface-docs',        label: 'Docs',        description: 'Auto-generated docs',     kind: 'surface', to: `/docs/${group}`,        icon: <BookOpen   className="w-4 h-4" /> },
+    { id: 'surface-pending',     label: 'Pending',     description: 'Repair + enrichment queue', kind: 'surface', to: `/pending/${group}`,  icon: <Clock      className="w-4 h-4" /> },
+    { id: 'surface-diagnostics', label: 'Diagnostics', description: 'Health & error report',   kind: 'surface', to: '/diagnostics',          icon: <Stethoscope className="w-4 h-4" /> },
+    { id: 'surface-quality',     label: 'Quality',     description: 'Health-score history',    kind: 'surface', to: `/quality/${group}`,     icon: <BarChart2  className="w-4 h-4" /> },
+    { id: 'surface-patterns',    label: 'Patterns',    description: 'Detected code patterns',  kind: 'surface', to: `/patterns/${group}`,   icon: <Sparkles   className="w-4 h-4" /> },
+    { id: 'surface-system',      label: 'System',      description: 'Daemon control panel',    kind: 'surface', to: '/system',               icon: <Server     className="w-4 h-4" /> },
+    { id: 'surface-update',      label: 'Update',      description: 'Version management',      kind: 'surface', to: '/update',               icon: <RefreshCw  className="w-4 h-4" /> },
+    { id: 'surface-settings',    label: 'Settings',    description: 'App configuration',       kind: 'surface', to: '/settings',             icon: <Settings   className="w-4 h-4" /> },
+    { id: 'surface-mcp-activity', label: 'MCP Activity', description: 'MCP tool call log',   kind: 'surface', to: '/mcp-activity',          icon: <Activity   className="w-4 h-4" /> },
+    { id: 'surface-home',        label: 'Home',        description: 'Dashboard home',          kind: 'surface', to: '/',                     icon: <Home       className="w-4 h-4" /> },
+
+    // Actions
+    {
+      id: 'action-toggle-theme',
+      label: 'Toggle theme',
+      description: 'Switch between light and dark mode',
+      kind: 'action',
+      icon: <Sun className="w-4 h-4" />,
+      fn: () => {
+        // Dispatch a custom event — _layout.tsx ThemeToggle handles it
+        document.dispatchEvent(new CustomEvent('archigraph:toggle-theme'))
+      },
+    },
+    {
+      id: 'action-open-settings',
+      label: 'Open Settings',
+      description: 'Go to Settings page',
+      kind: 'action',
+      to: '/settings',
+      icon: <Settings className="w-4 h-4" />,
+    },
+    {
+      id: 'action-rebuild',
+      label: 'Rebuild this group',
+      description: 'Trigger a full re-index of the current group',
+      kind: 'action',
+      icon: <Wrench className="w-4 h-4" />,
+      comingSoon: true,
+      fn: () => { /* coming soon */ },
+    },
+    {
+      id: 'action-reset',
+      label: 'Reset layout',
+      description: 'Reset graph/topology layout to default',
+      kind: 'action',
+      icon: <RotateCcw className="w-4 h-4" />,
+      comingSoon: true,
+      fn: () => { /* coming soon */ },
+    },
+    {
+      id: 'action-cleanup',
+      label: 'Run cleanup',
+      description: 'Remove stale nodes from the index',
+      kind: 'action',
+      icon: <RefreshCcw className="w-4 h-4" />,
+      comingSoon: true,
+      fn: () => { /* coming soon */ },
+    },
+    {
+      id: 'action-restart-daemon',
+      label: 'Restart daemon',
+      description: 'Graceful daemon restart',
+      kind: 'action',
+      icon: <Server className="w-4 h-4" />,
+      comingSoon: true,
+      fn: () => { /* coming soon */ },
+    },
+    {
+      id: 'action-check-updates',
+      label: 'Check for updates',
+      description: 'Check for a newer archigraph version',
+      kind: 'action',
+      to: '/update',
+      icon: <RefreshCw className="w-4 h-4" />,
+    },
+    {
+      id: 'action-keyboard-shortcuts',
+      label: 'Keyboard shortcuts',
+      description: 'View all keyboard shortcuts (? overlay)',
+      kind: 'action',
+      icon: <HelpCircle className="w-4 h-4" />,
+      comingSoon: true,
+      fn: () => { /* coming soon */ },
+    },
+  ], [group])
+
+  /* ── Fuzzy search ─────────────────────────────────────────────────────────── */
+
+  const fuse = useMemo(() => new Fuse(commands, {
+    keys: ['label', 'description'],
+    threshold: 0.35,
+    includeScore: true,
+  }), [commands])
+
+  const recent = useMemo(() => loadRecent(), [open]) // eslint-disable-line react-hooks/exhaustive-deps
+
+  const filtered = useMemo((): Command[] => {
+    if (!query.trim()) {
+      // Show recent items first, then all
+      const recentCmds = recent
+        .map((id) => commands.find((c) => c.id === id))
+        .filter(Boolean) as Command[]
+      const rest = commands.filter((c) => !recent.includes(c.id))
+      return [...recentCmds, ...rest]
+    }
+    return fuse.search(query).map((r) => r.item)
+  }, [query, fuse, commands, recent])
+
+  const surfaces = filtered.filter((c) => c.kind === 'surface')
+  const actions  = filtered.filter((c) => c.kind === 'action')
+
+  const allVisible = [...surfaces, ...actions]
+
+  /* ── Reset state when opened ─────────────────────────────────────────────── */
+
+  useEffect(() => {
+    if (open) {
+      setQuery('')
+      setActiveIndex(0)
+      setTimeout(() => inputRef.current?.focus(), 0)
+    }
+  }, [open])
+
+  /* ── Keyboard navigation ─────────────────────────────────────────────────── */
+
+  const execute = useCallback((cmd: Command) => {
+    saveRecent(cmd.id)
+    onClose()
+    if (cmd.to) {
+      navigate(cmd.to)
+    } else if (cmd.fn && !cmd.comingSoon) {
+      cmd.fn()
+    }
+  }, [navigate, onClose])
+
+  useEffect(() => {
+    if (!open) return
+
+    const handler = (e: KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown':
+          e.preventDefault()
+          setActiveIndex((i) => Math.min(i + 1, allVisible.length - 1))
+          break
+        case 'ArrowUp':
+          e.preventDefault()
+          setActiveIndex((i) => Math.max(i - 1, 0))
+          break
+        case 'Enter': {
+          e.preventDefault()
+          const cmd = allVisible[activeIndex]
+          if (cmd) execute(cmd)
+          break
+        }
+        case 'Escape':
+          e.preventDefault()
+          onClose()
+          break
+      }
+    }
+
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [open, allVisible, activeIndex, execute, onClose])
+
+  /* ── Scroll active item into view ────────────────────────────────────────── */
+
+  useEffect(() => {
+    const el = listRef.current?.querySelector<HTMLElement>('[data-active="true"]')
+    el?.scrollIntoView({ block: 'nearest' })
+  }, [activeIndex])
+
+  /* ── Reset activeIndex on query change ───────────────────────────────────── */
+
+  useEffect(() => {
+    setActiveIndex(0)
+  }, [query])
+
+  if (!open) return null
+
+  /* ── Render ──────────────────────────────────────────────────────────────── */
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-start justify-center pt-[15vh]"
+      data-testid="cmd-palette-backdrop"
+      onClick={onClose}
+    >
+      {/* Dimmed backdrop */}
+      <div className="absolute inset-0 bg-black/50 animate-in fade-in-0 duration-150" />
+
+      {/* Palette container */}
+      <div
+        className={[
+          'relative w-full max-w-lg mx-4 rounded-xl border shadow-2xl overflow-hidden',
+          'bg-white dark:bg-slate-900',
+          'border-slate-200 dark:border-slate-700',
+          'animate-in fade-in-0 zoom-in-95 duration-150',
+        ].join(' ')}
+        data-testid="cmd-palette"
+        onClick={(e) => e.stopPropagation()}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Command palette"
+      >
+        {/* Search input */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-200 dark:border-slate-700">
+          <svg
+            className="w-4 h-4 text-slate-400 flex-shrink-0"
+            fill="none" viewBox="0 0 24 24" stroke="currentColor" strokeWidth={2}
+            aria-hidden
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M21 21l-4.35-4.35M17 11A6 6 0 1 1 5 11a6 6 0 0 1 12 0z" />
+          </svg>
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Search surfaces and actions…"
+            className={[
+              'flex-1 bg-transparent text-sm outline-none',
+              'text-slate-900 dark:text-slate-100',
+              'placeholder:text-slate-400 dark:placeholder:text-slate-500',
+            ].join(' ')}
+            data-testid="cmd-palette-input"
+            aria-label="Search command palette"
+            autoComplete="off"
+            spellCheck={false}
+          />
+          <kbd className="hidden sm:inline-flex items-center gap-0.5 px-1.5 py-0.5 rounded text-xs font-mono text-slate-400 dark:text-slate-500 border border-slate-200 dark:border-slate-700">
+            esc
+          </kbd>
+        </div>
+
+        {/* Results list */}
+        <div
+          ref={listRef}
+          className="max-h-[60vh] overflow-y-auto py-2"
+          role="listbox"
+          aria-label="Commands"
+        >
+          {allVisible.length === 0 && (
+            <p className="px-4 py-6 text-center text-sm text-slate-400 dark:text-slate-500">
+              No results for &ldquo;{query}&rdquo;
+            </p>
+          )}
+
+          {/* Surfaces section */}
+          {surfaces.length > 0 && (
+            <Section
+              heading={query ? 'Surfaces' : recent.length > 0 ? 'Recent & Surfaces' : 'Surfaces'}
+              commands={surfaces}
+              offset={0}
+              activeIndex={activeIndex}
+              onSelect={execute}
+              onHover={(idx) => setActiveIndex(idx)}
+            />
+          )}
+
+          {/* Actions section */}
+          {actions.length > 0 && (
+            <Section
+              heading="Actions"
+              commands={actions}
+              offset={surfaces.length}
+              activeIndex={activeIndex}
+              onSelect={execute}
+              onHover={(idx) => setActiveIndex(idx)}
+            />
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="flex items-center gap-3 px-4 py-2 border-t border-slate-100 dark:border-slate-800 text-xs text-slate-400 dark:text-slate-500">
+          <span><kbd className="font-mono">↑↓</kbd> navigate</span>
+          <span><kbd className="font-mono">↵</kbd> open</span>
+          <span><kbd className="font-mono">esc</kbd> close</span>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+/* ── Section ────────────────────────────────────────────────────────────────── */
+
+interface SectionProps {
+  heading: string
+  commands: Command[]
+  offset: number
+  activeIndex: number
+  onSelect: (cmd: Command) => void
+  onHover: (idx: number) => void
+}
+
+function Section({ heading, commands, offset, activeIndex, onSelect, onHover }: SectionProps) {
+  return (
+    <div>
+      <p className="px-3 pt-2 pb-1 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500">
+        {heading}
+      </p>
+      {commands.map((cmd, i) => {
+        const idx = offset + i
+        const isActive = idx === activeIndex
+        return (
+          <CommandRow
+            key={cmd.id}
+            cmd={cmd}
+            isActive={isActive}
+            onSelect={onSelect}
+            onHover={() => onHover(idx)}
+          />
+        )
+      })}
+    </div>
+  )
+}
+
+/* ── CommandRow ─────────────────────────────────────────────────────────────── */
+
+interface CommandRowProps {
+  cmd: Command
+  isActive: boolean
+  onSelect: (cmd: Command) => void
+  onHover: () => void
+}
+
+function CommandRow({ cmd, isActive, onSelect, onHover }: CommandRowProps) {
+  return (
+    <button
+      type="button"
+      role="option"
+      aria-selected={isActive}
+      data-active={isActive}
+      data-testid={`cmd-item-${cmd.id}`}
+      className={[
+        'w-full flex items-center gap-3 px-3 py-2 text-sm transition-colors text-left',
+        isActive
+          ? 'bg-sky-50 dark:bg-sky-950/40 text-sky-700 dark:text-sky-300'
+          : 'text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800/50',
+        cmd.comingSoon ? 'opacity-60' : '',
+      ].join(' ')}
+      onClick={() => onSelect(cmd)}
+      onMouseEnter={onHover}
+    >
+      <span className="flex-shrink-0 text-slate-400 dark:text-slate-500">{cmd.icon}</span>
+      <span className="flex-1 min-w-0">
+        <span className="font-medium">{cmd.label}</span>
+        {cmd.description && (
+          <span className="ml-2 text-xs text-slate-400 dark:text-slate-500 truncate">
+            {cmd.description}
+          </span>
+        )}
+      </span>
+      {cmd.comingSoon && (
+        <span className="flex-shrink-0 text-[10px] font-medium px-1.5 py-0.5 rounded bg-slate-100 dark:bg-slate-800 text-slate-400 dark:text-slate-500">
+          soon
+        </span>
+      )}
+    </button>
+  )
+}

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -1,10 +1,11 @@
 import { Link, Outlet, useParams } from 'react-router-dom'
-import { useEffect } from 'react'
-import { GitBranch, Moon, Sun } from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { GitBranch, Moon, Search, Sun } from 'lucide-react'
 import { useRegistry } from '@/hooks/shared/useRegistry'
 import { useThemeContext } from '@/context/ThemeContext'
 import { GroupSelector } from '@/components/layout/GroupSelector'
 import { VersionPopover } from '@/components/layout/VersionPopover'
+import { CommandPalette } from '@/components/layout/CommandPalette'
 import {
   NavMenu,
   exploreItems,
@@ -25,10 +26,36 @@ export function AppLayout() {
   const exploreActive = useIsGroupActive(EXPLORE_PREFIXES)
   const operateActive = useIsGroupActive(OPERATE_PREFIXES)
 
+  const [paletteOpen, setPaletteOpen] = useState(false)
+  const openPalette  = useCallback(() => setPaletteOpen(true),  [])
+  const closePalette = useCallback(() => setPaletteOpen(false), [])
+
+  // Keyboard shortcut: Cmd+K (Mac) / Ctrl+K (Linux/Win)
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === 'k' && (e.metaKey || e.ctrlKey)) {
+        e.preventDefault()
+        setPaletteOpen((prev) => !prev)
+      }
+    }
+    document.addEventListener('keydown', handler)
+    return () => document.removeEventListener('keydown', handler)
+  }, [])
+
+  // Listen for theme-toggle event dispatched by the CommandPalette action
+  const { toggle: toggleTheme } = useThemeContext()
+  useEffect(() => {
+    document.addEventListener('archigraph:toggle-theme', toggleTheme)
+    return () => document.removeEventListener('archigraph:toggle-theme', toggleTheme)
+  }, [toggleTheme])
+
   // Keyboard shortcut: g h → go home
   useEffect(() => {
     let lastG = false
     const handler = (e: KeyboardEvent) => {
+      // Don't fire shortcuts when the command palette is open or user is typing
+      if (paletteOpen) return
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return
       if (e.key === 'g' || e.key === 'G') {
         lastG = true
         setTimeout(() => { lastG = false }, 1000)
@@ -41,7 +68,7 @@ export function AppLayout() {
     }
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
-  }, [])
+  }, [paletteOpen])
 
   return (
     <div className="flex flex-col h-screen bg-white dark:bg-slate-950 text-slate-900 dark:text-slate-200">
@@ -70,6 +97,26 @@ export function AppLayout() {
         </nav>
 
         <div className="ml-auto flex items-center gap-2">
+          {/* Cmd+K chip — visible on mobile and as a quick-access button */}
+          <button
+            type="button"
+            aria-label="Open command palette (⌘K)"
+            title="Open command palette (⌘K)"
+            data-testid="cmd-palette-chip"
+            className={[
+              'flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs',
+              'text-slate-500 dark:text-slate-400',
+              'bg-slate-100 dark:bg-slate-800 hover:bg-slate-200 dark:hover:bg-slate-700',
+              'border border-slate-200 dark:border-slate-700',
+              'transition-colors',
+            ].join(' ')}
+            onClick={openPalette}
+          >
+            <Search className="w-3 h-3" aria-hidden />
+            <span className="hidden sm:inline">Search</span>
+            <kbd className="hidden md:inline-flex items-center font-mono text-[10px] text-slate-400 dark:text-slate-500">⌘K</kbd>
+          </button>
+
           {/* Group selector — sits between theme toggle and version info */}
           <GroupSelector groups={groups} />
           <ThemeToggle />
@@ -81,6 +128,9 @@ export function AppLayout() {
       <main className="flex-1 overflow-hidden">
         <Outlet />
       </main>
+
+      {/* ── Command Palette ───────────────────────────────────────────────────── */}
+      <CommandPalette open={paletteOpen} onClose={closePalette} group={group} />
     </div>
   )
 }

--- a/dashboard/tests/e2e/command-palette.spec.ts
+++ b/dashboard/tests/e2e/command-palette.spec.ts
@@ -1,0 +1,159 @@
+/**
+ * E2E: Cmd+K command palette (#1234)
+ *
+ * Verifies:
+ *   1. Cmd+K opens the palette from anywhere
+ *   2. Type 'top' → 'Topology' item appears in results
+ *   3. Type 'rebuild' → 'Rebuild this group' action appears
+ *   4. Enter on 'Graph' item navigates to /graph/*
+ *   5. Esc closes the palette
+ *   6. Chip button in header also opens palette
+ *   7. 0 console errors
+ *   8. Screenshots: palette open + filtered state
+ */
+
+import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import fs from 'fs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:5173'
+const SCREENSHOT_DIR = path.join(__dirname, '..', '..', 'e2e-screenshots')
+
+function ensureDir(dir: string) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+}
+
+test.describe('Command palette (#1234)', () => {
+  let consoleErrors: string[] = []
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        const text = msg.text()
+        // Ignore network errors from missing daemon
+        if (!text.includes('Failed to load resource') && !text.includes('ERR_CONNECTION')) {
+          consoleErrors.push(text)
+        }
+      }
+    })
+    await page.goto(BASE_URL, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(500)
+  })
+
+  // ── 1. Cmd+K opens palette ────────────────────────────────────────────────
+
+  test('Cmd+K opens the command palette', async ({ page }) => {
+    // Palette should be hidden initially
+    await expect(page.getByTestId('cmd-palette')).not.toBeVisible()
+
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+    await expect(page.getByTestId('cmd-palette-input')).toBeFocused()
+  })
+
+  // ── 2. Type 'top' → Topology appears ─────────────────────────────────────
+
+  test("Type 'top' shows Topology in results", async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+
+    await page.getByTestId('cmd-palette-input').fill('top')
+    await expect(page.getByTestId('cmd-item-surface-topology')).toBeVisible()
+  })
+
+  // ── 3. Type 'rebuild' → Rebuild action appears ────────────────────────────
+
+  test("Type 'rebuild' shows 'Rebuild this group' action", async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+
+    await page.getByTestId('cmd-palette-input').fill('rebuild')
+    await expect(page.getByTestId('cmd-item-action-rebuild')).toBeVisible()
+  })
+
+  // ── 4. Enter on Graph navigates to /graph/* ───────────────────────────────
+
+  test('Enter on Graph item navigates to /graph route', async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+
+    await page.getByTestId('cmd-palette-input').fill('graph')
+    // Arrow Down to surface-graph (it should already be first / selected)
+    // Press Enter
+    await page.keyboard.press('Enter')
+
+    // Palette should close
+    await expect(page.getByTestId('cmd-palette')).not.toBeVisible()
+    // URL should contain /graph/
+    await expect(page).toHaveURL(/\/graph\//)
+  })
+
+  // ── 5. Esc closes the palette ─────────────────────────────────────────────
+
+  test('Esc closes the command palette', async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('cmd-palette')).not.toBeVisible()
+  })
+
+  // ── 6. Header chip button opens palette ──────────────────────────────────
+
+  test('Chip button in header opens command palette', async ({ page }) => {
+    await expect(page.getByTestId('cmd-palette')).not.toBeVisible()
+
+    const chip = page.getByTestId('cmd-palette-chip')
+    await expect(chip).toBeVisible()
+    await chip.click()
+
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+  })
+
+  // ── 7. No console errors ──────────────────────────────────────────────────
+
+  test('No unexpected console errors during palette interaction', async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await page.waitForTimeout(300)
+
+    await page.getByTestId('cmd-palette-input').fill('graph')
+    await page.waitForTimeout(200)
+
+    await page.keyboard.press('Escape')
+    await page.waitForTimeout(300)
+
+    expect(consoleErrors).toHaveLength(0)
+  })
+
+  // ── 8. Screenshots (VIEW) ─────────────────────────────────────────────────
+
+  test('Screenshot — palette open empty state (VIEW)', async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+    await page.waitForTimeout(400)
+
+    ensureDir(SCREENSHOT_DIR)
+    const p = path.join(SCREENSHOT_DIR, 'command-palette-open.png')
+    await page.screenshot({ path: p, fullPage: false })
+    expect(fs.existsSync(p)).toBe(true)
+    console.log(`[VIEW] Command palette open: ${p}`)
+  })
+
+  test("Screenshot — palette filtered by 'flow' (VIEW)", async ({ page }) => {
+    await page.keyboard.press('Meta+k')
+    await expect(page.getByTestId('cmd-palette')).toBeVisible()
+    await page.getByTestId('cmd-palette-input').fill('flow')
+    await page.waitForTimeout(300)
+
+    ensureDir(SCREENSHOT_DIR)
+    const p = path.join(SCREENSHOT_DIR, 'command-palette-filtered.png')
+    await page.screenshot({ path: p, fullPage: false })
+    expect(fs.existsSync(p)).toBe(true)
+    console.log(`[VIEW] Command palette filtered: ${p}`)
+  })
+})


### PR DESCRIPTION
## What

Implements the Cmd+K command palette referenced in #1210 (nav redesign). Power users can now navigate all 13 surfaces and trigger 8 actions without touching the dropdown menus.

Closes #1234.

## Why

The nav redesign landed 2 grouped dropdowns for 13+ surfaces. Heavy users need a faster path — Cmd+K is the industry standard for this.

## Changes

### `dashboard/src/components/layout/CommandPalette.tsx` (new)
- Modal dialog with dimmed backdrop + animate-in fade/zoom
- Fuzzy search via fuse.js (already in deps — no new package)
- Two sections: Surfaces (13 entries) and Actions (8 entries)
- Arrow keys navigate, Enter selects, Esc closes, click-outside closes
- Recent items (up to 5) persisted in localStorage, shown when input is empty
- Actions wired: Toggle theme (via archigraph:toggle-theme custom event), Open Settings, Check for updates, Go home
- Actions with comingSoon: Rebuild, Reset layout, Cleanup, Restart daemon, Keyboard shortcuts — shown with 'soon' badge
- data-testid on every interactive element for Playwright

### `dashboard/src/routes/_layout.tsx` (modified)
- Global keydown listener: Cmd+K / Ctrl+K toggles palette open/closed
- archigraph:toggle-theme custom-event listener bridges palette action to ThemeToggle
- g h home shortcut now guards against firing when palette is open or user is typing
- Header chip button (data-testid="cmd-palette-chip") with Search icon + ⌘K hint

### `dashboard/tests/e2e/command-palette.spec.ts` (new)
8 headless Playwright tests:
1. Cmd+K opens palette + input focused
2. Type 'top' → Topology item visible
3. Type 'rebuild' → Rebuild action visible
4. Enter on Graph navigates to /graph/*
5. Esc closes palette
6. Header chip button opens palette
7. Zero console errors during interaction
8. Screenshots: palette open (empty) + filtered by 'flow'

## Beyond the minimum

- Coming soon placeholders so users can discover upcoming actions
- Mobile tap target (chip button) in the header
- Recent items shown when input empty
- Theme toggle bridged via custom event so ThemeContext is single source of truth

## Test plan

- [ ] `cd dashboard && npx playwright test tests/e2e/command-palette.spec.ts --headed` — all 8 pass
- [ ] Press Cmd+K from any surface → palette opens centered with dimmed backdrop
- [ ] Type 'top' → Topology highlighted; Enter navigates to /topology/fixture-a
- [ ] Type 'rebuild' → Rebuild action with 'soon' badge visible
- [ ] Esc closes; backdrop click closes
- [ ] Chip button in header opens palette on narrow viewport
- [ ] 0 console errors throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)