### PR TITLE
[dashboard] Live indexing badges on landing cards (#1235)

### DIFF
--- a/dashboard/src/components/landing/GroupSelector.tsx
+++ b/dashboard/src/components/landing/GroupSelector.tsx
@@ -4,14 +4,22 @@
  * Shows all indexed groups as cards with name, sparkline, repo count,
  * entity count, unresolved edges and last-indexed time. Clicking a card navigates
  * to /graph/<group>.
+ *
+ * Live indexing badges: when a group is being rebuilt the card shows a pulsing
+ * chip overlay courtesy of useAllIndexProgress. Clicking the chip opens the
+ * full IndexingProgressModal.
  */
 
+import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
-import { Database, GitBranch, Clock, TerminalSquare, Activity } from 'lucide-react'
+import { Database, GitBranch, Clock, TerminalSquare, Activity, Loader2, CheckCircle2, AlertCircle } from 'lucide-react'
 import { useRegistry } from '@/hooks/shared/useRegistry'
+import { useAllIndexProgress } from '@/hooks/shared/useAllIndexProgress'
 import { GroupGraphThumbnail } from '@/components/landing/GroupGraphThumbnail'
 import { GroupOpsMenu } from '@/components/landing/GroupOpsMenu'
+import { IndexingProgressModal } from '@/components/indexing/IndexingProgressModal'
 import type { GroupMeta } from '@/types/api'
+import type { IndexProgressState } from '@/types/indexProgress'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -258,6 +266,87 @@ function RepoRow({ repos }: RepoRowProps) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// IndexingBadge — pulsing chip overlay shown on cards during active indexing
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface IndexingBadgeProps {
+  state: IndexProgressState
+  onOpenModal: () => void
+}
+
+function IndexingBadge({ state, onOpenModal }: IndexingBadgeProps) {
+  const { status, overall_pct, repos } = state
+
+  // Build the aggregate repo sub-status label for the tooltip
+  const repoSummary = repos.length > 0
+    ? repos.map((r) => `${r.slug}: ${r.phase}`).join(', ')
+    : undefined
+
+  if (status === 'done') {
+    return (
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onOpenModal() }}
+        aria-label="Indexing complete"
+        title={repoSummary}
+        data-testid="indexing-badge-done"
+        className={[
+          'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
+          'bg-emerald-900/80 border border-emerald-700 text-emerald-300',
+          'shadow-lg backdrop-blur-sm',
+          'animate-[fadeIn_0.2s_ease-out]',
+        ].join(' ')}
+      >
+        <CheckCircle2 className="w-3.5 h-3.5 shrink-0" aria-hidden />
+        Done
+      </button>
+    )
+  }
+
+  if (status === 'error') {
+    return (
+      <button
+        type="button"
+        onClick={(e) => { e.stopPropagation(); onOpenModal() }}
+        aria-label="Indexing error — click to view details"
+        title={state.error ?? repoSummary}
+        data-testid="indexing-badge-error"
+        className={[
+          'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
+          'bg-red-900/80 border border-red-700 text-red-300',
+          'shadow-lg backdrop-blur-sm',
+        ].join(' ')}
+      >
+        <AlertCircle className="w-3.5 h-3.5 shrink-0" aria-hidden />
+        Error
+      </button>
+    )
+  }
+
+  // 'indexing' or 'connecting'
+  const pctLabel = overall_pct > 0 ? `${overall_pct}%` : '…'
+
+  return (
+    <button
+      type="button"
+      onClick={(e) => { e.stopPropagation(); onOpenModal() }}
+      aria-label={`Indexing in progress — ${pctLabel} complete. Click to view details.`}
+      title={repoSummary}
+      data-testid="indexing-badge-active"
+      className={[
+        'flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium',
+        'bg-sky-900/80 border border-sky-700 text-sky-200',
+        'shadow-lg backdrop-blur-sm',
+        'animate-pulse',
+      ].join(' ')}
+    >
+      <Loader2 className="w-3.5 h-3.5 shrink-0 animate-spin" aria-hidden />
+      Indexing {pctLabel}
+    </button>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Group card
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -265,17 +354,28 @@ interface GroupCardProps {
   group: GroupMeta
   onClick: () => void
   onNavigateToNode?: (nodeId: string) => void
+  /** Present when this group has an active/recent indexing run. */
+  indexProgress?: IndexProgressState
 }
 
-function GroupCard({ group, onClick, onNavigateToNode }: GroupCardProps) {
+function GroupCard({ group, onClick, onNavigateToNode, indexProgress }: GroupCardProps) {
   // Stop propagation on ops menu clicks so they don't trigger card navigation.
+  const [modalOpen, setModalOpen] = useState(false)
   const rateColor = bugRateColor(group.bug_rate)
   const rateLabel =
     group.bug_rate !== undefined ? `${group.bug_rate.toFixed(1)}%` : 'not measured'
   const hasRealData = group.entity_count > 0
   const hasIndexedAt = Boolean(group.indexed_at)
 
+  const isIndexing =
+    indexProgress &&
+    (indexProgress.status === 'indexing' ||
+      indexProgress.status === 'connecting' ||
+      indexProgress.status === 'done' ||
+      indexProgress.status === 'error')
+
   return (
+    <>
     <div
       data-card
       className={[
@@ -285,17 +385,26 @@ function GroupCard({ group, onClick, onNavigateToNode }: GroupCardProps) {
         'h-[312px] flex flex-col',
         'transition-all duration-150',
         'border-slate-200 dark:border-slate-800 hover:border-sky-500/40 hover:-translate-y-px hover:bg-slate-200 dark:hover:bg-slate-900',
+        isIndexing && indexProgress.status !== 'done' && indexProgress.status !== 'error'
+          ? 'opacity-80'
+          : '',
       ].join(' ')}
     >
       {/* Thumbnail — 80px, lazy-loaded, lazy-rendered (#983) */}
-      {/* Ops menu sits in the top-right corner, overlaid on the thumbnail. */}
+      {/* Ops menu + optional indexing badge sit in the top-right corner. */}
       <div className="relative">
         <GroupGraphThumbnail
           group={group.id}
           enabled={hasRealData}
           onNodeClick={onNavigateToNode}
         />
-        <div className="absolute top-2 right-2">
+        <div className="absolute top-2 right-2 flex items-center gap-1.5">
+          {indexProgress && isIndexing && (
+            <IndexingBadge
+              state={indexProgress}
+              onOpenModal={() => setModalOpen(true)}
+            />
+          )}
           <GroupOpsMenu group={group.id} displayName={group.display_name} />
         </div>
       </div>
@@ -372,6 +481,17 @@ function GroupCard({ group, onClick, onNavigateToNode }: GroupCardProps) {
         </div>
       </button>
     </div>
+
+    {/* IndexingProgressModal — rendered when user clicks the badge */}
+    {modalOpen && (
+      <IndexingProgressModal
+        isOpen={modalOpen}
+        groupSlug={group.id}
+        onClose={() => setModalOpen(false)}
+        onReopen={() => setModalOpen(true)}
+      />
+    )}
+    </>
   )
 }
 
@@ -416,6 +536,7 @@ function NoGroupsState() {
 export function GroupSelector() {
   const navigate = useNavigate()
   const { data: registry, isLoading, isError } = useRegistry()
+  const { progress: allProgress } = useAllIndexProgress()
 
   if (isLoading) {
     return (
@@ -466,6 +587,7 @@ export function GroupSelector() {
             onNavigateToNode={(nodeId) =>
               navigate(`/graph/${group.id}`, { state: { selectedNodeId: nodeId } })
             }
+            indexProgress={allProgress.get(group.id)}
           />
         ))}
       </div>

--- a/dashboard/src/hooks/shared/useAllIndexProgress.ts
+++ b/dashboard/src/hooks/shared/useAllIndexProgress.ts
@@ -1,0 +1,270 @@
+/**
+ * useAllIndexProgress — SSE-backed hook that monitors indexing progress across
+ * ALL groups simultaneously.
+ *
+ * Subscribes to GET /api/index-progress (wildcard stream) and returns a Map
+ * from group slug → { status, overall_pct, repos } so the landing page can
+ * show per-card badges without opening one EventSource per card.
+ *
+ * Lifecycle:
+ *   - Opens a single EventSource on mount; closes on unmount.
+ *   - Auto-reconnects (native EventSource behaviour).
+ *   - When a group transitions to 'done' the entry stays in the map for
+ *     DONE_LINGER_MS so the checkmark animation plays, then is removed.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import type {
+  IndexProgressState,
+  RepoProgress,
+  SseClosePayload,
+  SseProgressPayload,
+} from '@/types/indexProgress'
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Constants
+// ──────────────────────────────────────────────────────────────────────────────
+
+/** How long a 'done' entry lingers in the map before being removed (ms). */
+const DONE_LINGER_MS = 10_000
+
+/** How long an 'error' entry lingers in the map before being removed (ms). */
+const ERROR_LINGER_MS = 15_000
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+function computeOverallPct(repos: RepoProgress[]): number {
+  if (repos.length === 0) return 0
+  const totalFiles = repos.reduce((sum, r) => sum + r.files_total, 0)
+  if (totalFiles === 0) {
+    const doneCount = repos.filter((r) => r.phase === 'done' || r.phase === 'writing_graph').length
+    return Math.round((doneCount / repos.length) * 100)
+  }
+  const doneFiles = repos.reduce((sum, r) => sum + r.files_done, 0)
+  return Math.min(100, Math.round((doneFiles / totalFiles) * 100))
+}
+
+function mergeRepos(
+  existing: Map<string, RepoProgress>,
+  incoming: RepoProgress[],
+): Map<string, RepoProgress> {
+  const next = new Map(existing)
+  for (const r of incoming) {
+    next.set(r.slug, r)
+  }
+  return next
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────────────────────────────────────
+
+export type GroupProgressMap = Map<string, IndexProgressState>
+
+export interface UseAllIndexProgressReturn {
+  /** Map from group slug → current IndexProgressState. Empty when no group is indexing. */
+  progress: GroupProgressMap
+  /** Manually clear a group entry (e.g. after user dismisses the card badge). */
+  dismiss: (group: string) => void
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Hook
+// ──────────────────────────────────────────────────────────────────────────────
+
+export function useAllIndexProgress(): UseAllIndexProgressReturn {
+  const [progress, setProgress] = useState<GroupProgressMap>(new Map())
+
+  // Per-group repo accumulators — kept in a ref to avoid stale-closure issues.
+  const reposRef = useRef<Map<string, Map<string, RepoProgress>>>(new Map())
+
+  // Linger timers for completed / errored groups.
+  const lingerTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map())
+
+  const clearLingerTimer = useCallback((group: string) => {
+    const existing = lingerTimers.current.get(group)
+    if (existing) {
+      clearTimeout(existing)
+      lingerTimers.current.delete(group)
+    }
+  }, [])
+
+  const scheduleRemoval = useCallback(
+    (group: string, delayMs: number) => {
+      clearLingerTimer(group)
+      const id = setTimeout(() => {
+        setProgress((prev) => {
+          if (!prev.has(group)) return prev
+          const next = new Map(prev)
+          next.delete(group)
+          return next
+        })
+        reposRef.current.delete(group)
+        lingerTimers.current.delete(group)
+      }, delayMs)
+      lingerTimers.current.set(group, id)
+    },
+    [clearLingerTimer],
+  )
+
+  const dismiss = useCallback(
+    (group: string) => {
+      clearLingerTimer(group)
+      setProgress((prev) => {
+        if (!prev.has(group)) return prev
+        const next = new Map(prev)
+        next.delete(group)
+        return next
+      })
+      reposRef.current.delete(group)
+    },
+    [clearLingerTimer],
+  )
+
+  useEffect(() => {
+    const url = '/api/index-progress'
+    const es = new EventSource(url)
+
+    // ── connected (one fire per group when the daemon starts streaming) ──────
+    es.addEventListener('connected', (ev: MessageEvent) => {
+      try {
+        const payload = JSON.parse(ev.data as string) as { group: string }
+        const group = payload.group
+        if (!group) return
+        clearLingerTimer(group)
+        if (!reposRef.current.has(group)) {
+          reposRef.current.set(group, new Map())
+        }
+        setProgress((prev) => {
+          const next = new Map(prev)
+          next.set(group, {
+            status: 'indexing',
+            overall_pct: 0,
+            repos: [],
+            last_event_at: new Date().toISOString(),
+          })
+          return next
+        })
+      } catch {
+        // ignore
+      }
+    })
+
+    // ── progress ─────────────────────────────────────────────────────────────
+    es.addEventListener('progress', (ev: MessageEvent) => {
+      try {
+        const payload: SseProgressPayload = JSON.parse(ev.data as string)
+        const { group, repos: incoming } = payload
+        if (!group) return
+
+        let groupRepos = reposRef.current.get(group)
+        if (!groupRepos) {
+          groupRepos = new Map()
+          reposRef.current.set(group, groupRepos)
+        }
+        const merged = mergeRepos(groupRepos, incoming)
+        reposRef.current.set(group, merged)
+
+        const reposList = Array.from(merged.values())
+        const overall_pct = computeOverallPct(reposList)
+
+        setProgress((prev) => {
+          const next = new Map(prev)
+          next.set(group, {
+            status: 'indexing',
+            overall_pct,
+            repos: reposList,
+            last_event_at: new Date().toISOString(),
+          })
+          return next
+        })
+      } catch {
+        // ignore
+      }
+    })
+
+    // ── heartbeat ────────────────────────────────────────────────────────────
+    es.addEventListener('heartbeat', (ev: MessageEvent) => {
+      try {
+        const payload = JSON.parse(ev.data as string) as { group?: string }
+        const group = payload.group
+        if (!group) return
+        setProgress((prev) => {
+          if (!prev.has(group)) return prev
+          const next = new Map(prev)
+          const cur = prev.get(group)!
+          next.set(group, { ...cur, last_event_at: new Date().toISOString() })
+          return next
+        })
+      } catch {
+        // ignore — heartbeat shape may vary
+      }
+    })
+
+    // ── close ────────────────────────────────────────────────────────────────
+    es.addEventListener('close', (ev: MessageEvent) => {
+      try {
+        const payload: SseClosePayload = JSON.parse(ev.data as string)
+        const { group, status, error } = payload
+        if (!group) return
+
+        const groupRepos = reposRef.current.get(group)
+        const repos = groupRepos ? Array.from(groupRepos.values()) : []
+
+        setProgress((prev) => {
+          const next = new Map(prev)
+          next.set(group, {
+            status,
+            overall_pct: status === 'done' ? 100 : computeOverallPct(repos),
+            repos,
+            last_event_at: new Date().toISOString(),
+            error,
+          })
+          return next
+        })
+
+        scheduleRemoval(group, status === 'done' ? DONE_LINGER_MS : ERROR_LINGER_MS)
+      } catch {
+        // ignore
+      }
+    })
+
+    // ── network error ─────────────────────────────────────────────────────────
+    es.onerror = () => {
+      if (es.readyState === EventSource.CLOSED) {
+        // Connection fully lost — mark all in-flight groups as error.
+        setProgress((prev) => {
+          if (prev.size === 0) return prev
+          const next = new Map<string, IndexProgressState>()
+          for (const [group, state] of prev.entries()) {
+            if (state.status === 'indexing' || state.status === 'connecting') {
+              next.set(group, {
+                ...state,
+                status: 'error',
+                error: 'Connection to daemon lost.',
+                last_event_at: new Date().toISOString(),
+              })
+              scheduleRemoval(group, ERROR_LINGER_MS)
+            } else {
+              next.set(group, state)
+            }
+          }
+          return next
+        })
+      }
+    }
+
+    return () => {
+      es.close()
+      // Clear all linger timers on unmount.
+      for (const id of lingerTimers.current.values()) {
+        clearTimeout(id)
+      }
+      lingerTimers.current.clear()
+    }
+  }, [clearLingerTimer, scheduleRemoval])
+
+  return { progress, dismiss }
+}


### PR DESCRIPTION
## Summary

Landing-page group cards now show a live "Indexing X%" badge whenever a group is being rebuilt. Users can see at a glance which groups are busy without clicking into the group view.

**What changed:**

- **`useAllIndexProgress` hook** (`dashboard/src/hooks/shared/useAllIndexProgress.ts`) — opens a single `EventSource` on `/api/index-progress` (wildcard stream), accumulates per-group repo progress, and returns `Map<group, IndexProgressState>`. Completed groups linger for 10 s (done) or 15 s (error) so the finish animation plays before the badge disappears.

- **`IndexingBadge` component** — three visual states:
  - *Indexing*: pulsing sky chip with spinning `Loader2` + live percentage. `animate-pulse` on the chip, `animate-spin` on the icon.
  - *Done*: emerald `CheckCircle2` chip; auto-removed after 10 s linger.
  - *Error*: red `AlertCircle` chip; tooltip shows the error message.
  Each state shows a per-repo phase summary in the native `title` tooltip (e.g. `api: extracting_ast, worker: scanning`).

- **`GroupCard`** accepts an optional `indexProgress` prop. While actively indexing the card dims to `opacity-80`. The badge is rendered in the thumbnail overlay row, left of the existing `GroupOpsMenu`. Clicking the badge opens the existing `IndexingProgressModal` — no new modal surface.

- **`GroupSelector`** calls `useAllIndexProgress()` once at the grid level and passes the relevant slice to each card. Multiple concurrent rebuilds are all visible.

## Closes / Refs

Closes #1235

## Testing

- [ ] All tests pass: `go test ./...`
- [ ] Trigger rebuild via Operations menu → card shows live pulsing badge
- [ ] Multiple concurrent rebuilds visible simultaneously
- [ ] Once done, badge transitions to emerald checkmark then clears after ~10 s
- [ ] Error state shows red chip with error text in tooltip
- [ ] Clicking any badge opens the full `IndexingProgressModal` for that group

## Notes

The `useAllIndexProgress` hook reuses all existing SSE types from `@/types/indexProgress` — no new server-side changes required. The `/api/index-progress` wildcard endpoint already exists from the per-group work (#1207).

The badge is positioned in `absolute top-2 right-2` alongside the existing ops menu using a flex row — the ops kebab always stays rightmost; the badge slides in to its left when active.

`animate-[fadeIn_0.2s_ease-out]` on the done badge uses a Tailwind arbitrary animation value — if the project's Tailwind config does not have a `fadeIn` keyframe defined, it degrades gracefully (no animation, chip still visible).