### PR TITLE
docs: README refresh + CHANGELOG + SSE/settings docs for v1.0-rc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,165 @@
+# Changelog
+
+All notable changes are documented here. Entries are grouped by the session
+or release they landed in. PR numbers link to
+https://github.com/cajasmota/archigraph/pull/<N>.
+
+---
+
+## [Unreleased] — v1.0-rc (2026-05-21, overnight session)
+
+### Dashboard — new surfaces and nav
+
+- **Cmd+K command palette** — fuzzy search all surfaces and actions from
+  anywhere in the dashboard. (#1234, #1237)
+- **Nav redesign** — 9 surfaces reorganised into Explore / Operate dropdown
+  menus. (#1210, #1213)
+- **MCP Activity surface (Jarvis)** — live log of every MCP tool call at
+  `/mcp-activity`. (#1226, #1230)
+- **Graph canvas Jarvis integration** — graph nodes pulse in real time when
+  returned by an MCP tool. (#1225, #1232)
+- **Quality surface** — orphan audit + recall measurement + health-score
+  history trend line. (#1198, #1205, #1214, #1223)
+- **Patterns surface** — list, edit, delete, and export agent-learned
+  patterns. (#1189, #1197)
+- **Settings surface** — theme, auto-update, telemetry, MCP config, log
+  level, all persisted to `~/.archigraph/settings.json`. (#1206, #1211)
+- **System surface** — daemon control panel with restart, stop, and live
+  log tail. (#1195, #1203)
+- **Update surface** — version check, apply, and refresh-rules-lite. (#1199,
+  #1208)
+- **Diagnostics surface** — daemon + per-group health checks. (#1187, #1193)
+- **Maintenance ops** — rebuild, reset, and cleanup actions per group or
+  per repo in the dashboard. (#1200, #1204)
+- **Graph thumbnail** — group cards on the landing page show a preview of the
+  indexed graph. (#983, #1194)
+- **Pending surface tiers** — tiered enrichment queue buckets
+  (Critical / High / Medium / Low). (#1133, #1185)
+
+### Paths v2
+
+- `/api/paths/{group}` returns endpoint definitions grouped by
+  `owning_backend`. (#1218, #1227)
+- Orphan-caller detection at `/api/paths/{group}/orphan-callers`. (#1225)
+- Duplicate path elimination (105 dupes removed, same endpoint with and
+  without prefix). (#1124, #1163)
+- XPath / XML namespace strings filtered from the Paths list. (#1125, #1160)
+- DRF `ANY`-verb paths deduplicated via `http_endpoint_synthesis` entries.
+  (#1126, #1158)
+
+### Topology v2
+
+- Rich per-topic detail panel v2 at
+  `/api/topology/{group}/topic/{topicId}`. (#1141, #1178)
+- `broker_canonical` + `owning_service` + `broker_groups` metadata. (#1139,
+  #1175)
+- Orphan publisher detector at `/api/topology/{group}/orphan-publishers`.
+  (#1136, #1155)
+- Orphan subscriber detector at `/api/topology/{group}/orphan-subscribers`.
+  (#1137, #1159)
+- Broker + service grouping headers in the list view. (#1142, #1176)
+- Four-tab structure: All / Orphan Publishers / Orphan Subscribers /
+  Scheduled Jobs. (#1140, #1168)
+- `message_topic` YAML frontmatter wired into detail endpoint. (#1143, #1182)
+- `Task`/`ScheduledJob` entity kinds bucketed into the Topology queue view.
+  (#1116, #1122)
+
+### Flows v2
+
+- Per-flow React Flow DAG detail panel. (#1150, #1177)
+- `process_flow` frontmatter wired into the flow detail panel. (#1152, #1181)
+- Four-tab structure for Flows v2. (#1149, #1170)
+- Entry-kind grouping headers in the flow list. (#1151, #1171)
+- Entry-kind grouping metadata on `/api/flows/{group}` list endpoint. (#1148,
+  #1167)
+- Step-kind annotation and side-effect classification. (#1147, #1166)
+- Truncated flow detector at `/api/flows/{group}/truncated`. (#1146, #1161)
+- Dead-end flow classifier at `/api/flows/{group}/dead-ends`. (#1145, #1156)
+
+### Real-time indexing progress (SSE)
+
+- In-memory pub/sub broker for indexer progress events. (#1183, #1184)
+- Internal `progress` package instruments the full indexer pipeline. (#1188)
+- SSE endpoint `/api/index-progress` (all groups) and
+  `/api/index-progress/{group}`. (#1186, #1190)
+- `rebuild` CLI subscribes to broker for real-time terminal progress. (#1196,
+  #1201)
+- Dashboard `useIndexProgress` hook + `IndexingProgressModal`. (#1191, #1207)
+
+### MCP — new tools and Jarvis broker
+
+- MCP event broker + SSE endpoint `/api/mcp-activity/stream` (Phase 1).
+  (#1215, #1222)
+- 3 new HTTP endpoint tools: `archigraph_endpoint_definitions`,
+  `archigraph_endpoint_calls`, `archigraph_endpoint_stats`. (#1220, #1229)
+- 13 additional tools for Topology v2, Flows v2, Quality, and graph
+  traversal. (#1202, #1209)
+
+### Entity model
+
+- **`http_endpoint_definition` + `http_endpoint_call`** — `http_endpoint`
+  split into two distinct entity kinds at the extractor layer. Legacy
+  `http_endpoint` remains readable via compatibility helper. (#1217, #1233)
+- Confidence score (0–100) added to every enrichment `Candidate`. (#1131,
+  #1179)
+- Enrichment model: 1 `EnrichmentTask` per entity with N pending actions.
+  (#1134, #1165)
+- Rebuild summary includes per-kind breakdown + color-coded percentage. (#1132,
+  #1174)
+- `describe_entity` emitter switched to research-driven positive selection;
+  noise kinds excluded. (#1130, #1154, #1162, #1173)
+
+### AGENTS.md auto-injection
+
+- After every `archigraph rebuild`, an Architecture Map block is written into
+  `AGENTS.md` in each indexed repo. (#1216, #1221)
+
+### Graph rendering
+
+- 6-band zoom LoD (expanded from 3) for smoother level-of-detail
+  progression. (#1108, #1192)
+- Four rendering pathologies fixed: LoD threshold, Process pile-up, sizing,
+  and hash labels. (#1121, #1127)
+- Galaxy tune + 3-way color mode + Jarvis hook. (#1153, #1172)
+
+### Extractors
+
+- Stdlib placeholder elimination extended to PHP, Elixir, Clojure, and
+  Erlang. (#1085, #1224)
+
+### Docs / skills
+
+- `generate-docs` skill: Topology v2 + Flows v2 frontmatter schemas and Pass
+  14 validation. (#1212)
+
+### Bug fixes
+
+- Resolve leftover conflict marker from earlier rebase (build). (#1231)
+- Merge conflict markers in `daemon.go` resolved. (#1228)
+- `inferEntryKind` helper rename to resolve collision. (#1169)
+- `actionEntry` field name consistency fix. (standalone commit)
+- Unblock `npm run build` — fix tsc errors in test files. (#1180)
+
+---
+
+## Earlier sessions (2026-05-19 – 2026-05-20)
+
+Covered by the session checkpoints in `MEMORY.md`. Key highlights:
+
+- Daemon install-and-forget architecture (ADR-0017).
+- `-81%` RSS via profile-driven fix (#637).
+- Patterns chain: agent-learned patterns via ADR-0018.
+- Cosmograph migration + tuning.
+- 25+ new language extractors.
+- Custom-extractor pipeline wiring (#1086).
+- Lifecycle CLI (#1090).
+- Near-zero Python orphans.
+- Cross-repo functional testing.
+- Paths v2 shipped (#1099, #1098, #1100, #1104).
+- Unified enrichment schema (#1105).
+- Graph hard-stop (#1101).
+- Repo-first layout (#1106, not yet landed at session end).
+
+---
+
+_Older history is tracked in the [GitHub releases](https://github.com/cajasmota/archigraph/releases)._

--- a/README.md
+++ b/README.md
@@ -10,6 +10,27 @@ decisions are in [`docs/adrs/`](docs/adrs/). Track progress and roadmap
 via the [issue tracker](https://github.com/cajasmota/archigraph/issues)
 and [milestones](https://github.com/cajasmota/archigraph/milestones).
 
+## What's new (v0.9 → v1.0-rc)
+
+- **Paths v2, Topology v2, Flows v2** — rich list + detail panel surfaces
+  for HTTP endpoints, message-bus topics, and process flows.
+- **12 dashboard surfaces** — see [Surfaces map](#surfaces-map) below.
+- **Explore / Operate nav** — grouped dropdown menus replace the flat nav bar.
+- **Cmd+K command palette** — fuzzy search all surfaces and actions from
+  anywhere in the dashboard.
+- **Real-time indexing progress** — SSE stream at `/api/index-progress`
+  drives an in-dashboard progress modal during `archigraph rebuild`.
+- **MCP Activity surface (Jarvis)** — live view of every MCP tool call,
+  with real-time graph node highlighting for the returned entities.
+- **AGENTS.md auto-injection** — after each rebuild, archigraph writes an
+  Architecture Map block directly into `AGENTS.md` in every indexed repo.
+- **`http_endpoint_definition` + `http_endpoint_call`** — the legacy
+  `http_endpoint` kind is split into two distinct entity kinds for
+  precise orphan-caller detection (#1217).
+- **13 new MCP tools** — Topology v2, Flows v2, Quality, and graph
+  traversal surfaces exposed to agents. See
+  [`internal/mcp/SCHEMA.md`](internal/mcp/SCHEMA.md).
+
 ## Install
 
 ### macOS / Linux
@@ -114,6 +135,155 @@ archigraph patterns config           # show / set pattern thresholds
 
 `archigraph help advanced` lists the full set.
 
+## Surfaces map
+
+The dashboard at http://127.0.0.1:47274/ has 12 surfaces grouped into two
+menus.
+
+```
+Dashboard (http://127.0.0.1:47274/)
+│
+├── Explore
+│   ├── Graph        /graph          — Cosmograph node-link canvas + 6-band LoD
+│   ├── Flows        /flows          — Process-flow DAG list + per-flow detail panel
+│   ├── Topology     /topology       — Message-bus topics + broker/service grouping
+│   ├── Pending      /pending        — Tiered enrichment queue (Critical/High/Med/Low)
+│   ├── Paths        /paths          — HTTP endpoint definitions grouped by backend
+│   └── Docs         /docs           — Indexed markdown document tree
+│
+└── Operate
+    ├── Diagnostics  /diagnostics    — Daemon + per-group health checks
+    ├── Quality      /quality        — Orphan audit + recall measurement + history trend
+    ├── Patterns     /patterns       — Agent-learned patterns list/edit/delete/export
+    ├── System       /system         — Daemon control panel (restart, stop, logs)
+    ├── Update       /update         — Version check + apply + refresh-rules-lite
+    └── Settings     /settings       — Theme, auto-update, telemetry, MCP config, log level
+
+Special
+    └── MCP Activity /mcp-activity   — Live Jarvis view of MCP tool calls + graph highlighting
+```
+
+### Keyboard shortcuts
+
+| Shortcut | Action |
+|----------|--------|
+| `Cmd+K` (macOS) / `Ctrl+K` (Linux/Win) | Open command palette |
+| `Esc` | Close command palette / close detail panel |
+| `↑` / `↓` | Navigate palette results |
+| `Enter` | Activate selected result |
+
+## How agents use archigraph
+
+archigraph exposes a Model Context Protocol (MCP) server that AI agents
+connect to over stdio. The daemon registers one MCP server per machine;
+multiple groups can be active simultaneously.
+
+### MCP setup
+
+After `archigraph install <group>`, the daemon writes an MCP server entry
+to your Claude Code `~/.claude/claude.json` (or equivalent for other
+clients). No manual configuration is needed.
+
+To verify the wiring:
+
+```sh
+archigraph status <group>     # shows MCP: connected / disconnected
+```
+
+### What agents can do
+
+The MCP server exposes 19 tools prefixed `archigraph_`. Common workflows:
+
+| Goal | Tool |
+|------|------|
+| Orient to codebase | `archigraph_whoami` → `archigraph_stats` |
+| Find a symbol | `archigraph_find` (BM25 + BFS) |
+| Inspect an entity | `archigraph_inspect` |
+| Walk the call graph | `archigraph_expand` |
+| Trace a data path | `archigraph_trace` |
+| Understand flows | `archigraph_traces` |
+| Find HTTP endpoints | `archigraph_endpoint_definitions` |
+| Find orphan callers | `archigraph_endpoint_calls` |
+| Save a finding | `archigraph_save_finding` |
+
+Full tool reference: [`internal/mcp/SCHEMA.md`](internal/mcp/SCHEMA.md).
+
+### Real-time MCP activity
+
+The Jarvis MCP Activity surface (`/mcp-activity`) shows every tool call in
+real time. The graph canvas subscribes to the SSE stream at
+`/api/mcp-activity/stream` and pulses the returned nodes — so you can watch
+the agent's graph exploration as it happens.
+
+### AGENTS.md auto-injection
+
+After every `archigraph rebuild`, archigraph writes a fenced Architecture
+Map block into `AGENTS.md` (or creates the file if absent) in each indexed
+repo. Agents reading `AGENTS.md` at session start automatically receive the
+latest structure without any manual step.
+
+## Real-time indexing progress
+
+During `archigraph rebuild`, the indexer emits progress events to an
+in-process pub/sub broker. The dashboard subscribes via:
+
+```
+GET /api/index-progress           — progress across all groups (SSE)
+GET /api/index-progress/{group}   — progress for a specific group (SSE)
+```
+
+Each SSE event is a JSON object:
+
+```json
+{
+  "group": "my-group",
+  "repo": "api-server",
+  "phase": "resolve",
+  "pct": 62,
+  "elapsed_ms": 4210
+}
+```
+
+The dashboard shows a live `IndexingProgressModal` while any rebuild is
+running.
+
+## Settings file
+
+User preferences are persisted to `~/.archigraph/settings.json`. All
+fields are optional; missing keys fall back to defaults.
+
+```json
+{
+  "theme": "light",
+  "default_group": "",
+  "auto_check_updates": true,
+  "update_channel": "stable",
+  "refresh_schedule": "",
+  "telemetry_enabled": false,
+  "daemon_rss_budget_mb": 512,
+  "watcher_debounce_secs": 2,
+  "indexer_parallelism": 4,
+  "log_level": "info"
+}
+```
+
+| Field | Values | Default | Notes |
+|-------|--------|---------|-------|
+| `theme` | `light` \| `dark` \| `auto` | `light` | |
+| `default_group` | group slug | `""` | Shown on first dashboard load |
+| `auto_check_updates` | bool | `true` | |
+| `update_channel` | `stable` \| `dev` | `stable` | |
+| `refresh_schedule` | cron or `""` | `""` | Empty = manual only |
+| `telemetry_enabled` | bool | `false` | |
+| `daemon_rss_budget_mb` | 100–2000 | `512` | Requires daemon restart |
+| `watcher_debounce_secs` | 1–60 | `2` | |
+| `indexer_parallelism` | 1–32 | `4` | Requires daemon restart |
+| `log_level` | `debug` \| `info` \| `warn` \| `error` | `info` | |
+
+The Settings surface (`/settings`) in the dashboard edits this file
+through `GET/PUT /api/settings`. A `POST /api/settings/reset` restores
+factory defaults.
+
 ## Contributing
 
 If you're an AI agent contributing to archigraph, see [AGENTS.md](AGENTS.md) for conventions.
@@ -140,6 +310,26 @@ sample applications, one per supported language family. Framework
 internals are deliberately excluded as primary fixtures — see
 [ADR-0014](docs/adrs/0014-corpus-expansion-strategy.md). New language
 support lands together with the sample apps that exercise it.
+
+## Roadmap
+
+### v1.0 ship-gate
+
+- [ ] Bug-rate below 10% on the full validation corpus
+- [ ] Daemon determinism (#481) resolved — reliable measurement across runs
+- [ ] HTTP overhaul — unified HTTP client/server pairing
+- [ ] Per-language quality pass (residual orphan elimination)
+
+Track the v1.0 milestone: https://github.com/cajasmota/archigraph/milestone/1
+
+### v1.1 plan
+
+- **Paths v2 epic** — cross-repo endpoint stitching, prefix-aware dedup
+  (#1082, not yet dispatched)
+- **Embedding strategy** — bundled MiniLM (`hugot` + `simplego`) + BYO
+  endpoint for semantic search
+- **BYO extractor pipeline** — custom-extractor registration without a
+  daemon restart
 
 ## License
 

--- a/docs/settings.md
+++ b/docs/settings.md
@@ -1,0 +1,73 @@
+# Settings file reference
+
+archigraph persists user preferences in `~/.archigraph/settings.json`.
+The file is created automatically on first write (via the Settings surface
+or the `PUT /api/settings` endpoint). All fields are optional; missing keys
+fall back to the defaults below.
+
+## Schema
+
+```json
+{
+  "theme": "light",
+  "default_group": "",
+  "auto_check_updates": true,
+  "update_channel": "stable",
+  "refresh_schedule": "",
+  "telemetry_enabled": false,
+  "daemon_rss_budget_mb": 512,
+  "watcher_debounce_secs": 2,
+  "indexer_parallelism": 4,
+  "log_level": "info"
+}
+```
+
+## Field reference
+
+| Field | Type | Default | Allowed values | Notes |
+|-------|------|---------|----------------|-------|
+| `theme` | string | `"light"` | `"light"` \| `"dark"` \| `"auto"` | `"auto"` follows the OS dark-mode preference |
+| `default_group` | string | `""` | Any registered group slug | Group shown on first dashboard load; empty = most recently used |
+| `auto_check_updates` | bool | `true` | `true` \| `false` | Polls GitHub releases on daemon start |
+| `update_channel` | string | `"stable"` | `"stable"` \| `"dev"` | `"dev"` includes release candidates |
+| `refresh_schedule` | string | `""` | cron expression or `""` | Empty = manual-only refresh; e.g. `"0 3 * * *"` for 03:00 daily |
+| `telemetry_enabled` | bool | `false` | `true` \| `false` | Opt-in anonymous usage metrics |
+| `daemon_rss_budget_mb` | int | `512` | 100–2000 | Maximum RSS the daemon may use before it sheds loaded graphs. **Requires daemon restart.** |
+| `watcher_debounce_secs` | int | `2` | 1–60 | How long to wait after a file change before triggering a re-index |
+| `indexer_parallelism` | int | `4` | 1–32 | Number of parallel goroutines used during indexing. **Requires daemon restart.** |
+| `log_level` | string | `"info"` | `"debug"` \| `"info"` \| `"warn"` \| `"error"` | Daemon log verbosity |
+
+## API endpoints
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/api/settings` | Return current settings + defaults |
+| `PUT` | `/api/settings` | Partial or full update; returns which fields require a restart |
+| `POST` | `/api/settings/reset` | Restore factory defaults |
+
+### `GET /api/settings` response
+
+```json
+{
+  "settings": { ... },
+  "defaults": { ... }
+}
+```
+
+### `PUT /api/settings` response
+
+The server merges the request body onto the current settings (partial PUT is
+safe). Fields that require a daemon restart are listed in `restart_required`:
+
+```json
+{
+  "settings": { ... },
+  "defaults": { ... },
+  "restart_required": ["daemon_rss_budget_mb"]
+}
+```
+
+## Dashboard
+
+The Settings surface at `/settings` in the dashboard provides a GUI for all
+fields above and displays a "restart required" banner when applicable.

--- a/docs/sse-endpoints.md
+++ b/docs/sse-endpoints.md
@@ -1,0 +1,106 @@
+# Server-Sent Events (SSE) endpoints
+
+archigraph exposes two SSE endpoints for real-time streaming. Both are served
+by the embedded dashboard server on http://127.0.0.1:47274/.
+
+---
+
+## `/api/index-progress` — indexer progress stream
+
+Streams progress events for all groups currently being indexed.
+
+```
+GET /api/index-progress
+GET /api/index-progress/{group}
+```
+
+### Event shape
+
+Each event is a JSON object sent as an `event: progress` SSE line:
+
+```json
+{
+  "group":      "my-group",
+  "repo":       "api-server",
+  "phase":      "resolve",
+  "pct":        62,
+  "elapsed_ms": 4210,
+  "done":       false
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `group` | string | Group slug |
+| `repo` | string | Repo slug being processed |
+| `phase` | string | Current pipeline phase (`parse`, `extract`, `resolve`, `write`) |
+| `pct` | int | 0–100 completion percentage within the current phase |
+| `elapsed_ms` | int | Milliseconds since the rebuild started |
+| `done` | bool | `true` on the final event; client should close the connection |
+
+### Notes
+
+- Events are emitted by the in-process pub/sub broker (`internal/progress`).
+- The dashboard `IndexingProgressModal` subscribes to this stream during
+  `archigraph rebuild` and shows a live progress bar.
+- The `archigraph rebuild` CLI also subscribes via the broker so the terminal
+  can show real-time progress.
+- If no rebuild is in progress, the connection is held open but no events are
+  sent until a rebuild starts.
+
+---
+
+## `/api/mcp-activity/stream` — MCP activity stream (Jarvis)
+
+Streams a notification for every MCP tool call the daemon processes.
+
+```
+GET /api/mcp-activity/stream
+```
+
+### Event shape
+
+Each event is a JSON object sent as an `event: mcp-activity` SSE line:
+
+```json
+{
+  "id":           "01HX4B8GQN5CMQRK",
+  "tool":         "archigraph_find",
+  "group":        "my-group",
+  "repo_filter":  ["api-server"],
+  "elapsed_ms":   31,
+  "entity_ids":   ["a1b2c3d4e5f60718", "b2c3d4e5f6071829"],
+  "ts":           "2026-05-21T07:42:01.234Z"
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | string | Unique call ID (ULID) |
+| `tool` | string | Tool name (e.g. `archigraph_find`) |
+| `group` | string | Resolved group slug |
+| `repo_filter` | string[] | Repos in scope for this call |
+| `elapsed_ms` | int | Server-side latency |
+| `entity_ids` | string[] | Entity IDs returned by the tool, if any |
+| `ts` | string | RFC 3339 timestamp |
+
+### Notes
+
+- The MCP Activity surface (`/mcp-activity`) subscribes to this stream and
+  renders a live event log.
+- The Graph canvas (`/graph`) also subscribes: nodes whose IDs appear in
+  `entity_ids` are highlighted ("pulsed") in real time — Jarvis-style visual
+  feedback while an agent explores the graph.
+- History (last 500 events) is available at `GET /api/mcp-activity/history`.
+
+---
+
+## Client example (curl)
+
+```bash
+# Watch indexing progress for a group
+curl -N http://127.0.0.1:47274/api/index-progress/my-group
+
+# Stream MCP activity
+curl -N http://127.0.0.1:47274/api/mcp-activity/stream
+```


### PR DESCRIPTION
## Summary

- **README.md** rewritten to reflect the full v1.0-rc scope: 12 dashboard surfaces, Cmd+K palette, Explore/Operate nav, real-time indexing SSE, Jarvis MCP activity, AGENTS.md auto-injection, `http_endpoint_definition`/`http_endpoint_call` split, 19 MCP tools, and a Settings file reference. Adds: ASCII Surfaces map, keyboard shortcuts table, 'How agents use archigraph' section, and Roadmap (v1.0 ship-gate + v1.1 epic links).
- **CHANGELOG.md** (new): overnight session highlights with one-line summaries per PR number, grouped by subsystem.
- **docs/sse-endpoints.md** (new): full reference for `/api/index-progress` and `/api/mcp-activity/stream` — event shape, field descriptions, and curl examples.
- **docs/settings.md** (new): `~/.archigraph/settings.json` field reference with types, defaults, and the `GET/PUT/POST /api/settings` API contract.

No code changes in this PR — docs only.

## Changed files

| File | Change |
|------|--------|
| `README.md` | Full rewrite — feature list, surfaces map, agent section, settings, roadmap |
| `CHANGELOG.md` | New — 50+ PRs from overnight session, grouped by subsystem |
| `docs/sse-endpoints.md` | New — SSE endpoint reference |
| `docs/settings.md` | New — settings.json field reference + API |

## Links verified

All internal doc links checked against the worktree filesystem. No broken anchors.

## Test plan

- [ ] Read README.md top to bottom — confirm every surface, shortcut, and tool name matches what's in `internal/mcp/SCHEMA.md` and `internal/dashboard/server.go`
- [ ] Confirm `docs/settings.md` field table matches `AppSettings` struct in `internal/dashboard/handlers_settings.go`
- [ ] Confirm SSE event shapes in `docs/sse-endpoints.md` match `internal/progress/event.go` and `internal/mcp/activity.go`
- [ ] Verify no client names leak in any of the new docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)