### PR TITLE
[#1236] Add composite bug-rate-corpus harness + graph health score (A–F)

### DIFF
--- a/cmd/archigraph/quality.go
+++ b/cmd/archigraph/quality.go
@@ -36,6 +36,10 @@ func runQuality(argv []string) error {
 	if len(argv) >= 1 && (argv[0] == "audit-orphans" || argv[0] == "audit") {
 		return runAuditOrphans(argv[1:])
 	}
+	// `quality bug-rate-corpus <dir>` — composite health score across a corpus.
+	if len(argv) >= 1 && argv[0] == "bug-rate-corpus" {
+		return runBugRateCorpus(argv[1:])
+	}
 	fs := flag.NewFlagSet("quality", flag.ContinueOnError)
 	jsonOut := fs.String("json", "", "write JSON report to this path (default: stderr-only human summary)")
 	keepGraph := fs.Bool("keep-graph", false, "preserve the temp graph.json (path printed on stderr)")

--- a/cmd/archigraph/quality_corpus.go
+++ b/cmd/archigraph/quality_corpus.go
@@ -1,0 +1,435 @@
+package main
+
+// quality_corpus.go — `archigraph quality bug-rate-corpus <dir>`
+//
+// Scans a directory for archigraph-indexed repos, computes the composite
+// graph-health score for each one, and emits a summary.  The composite
+// formula is:
+//
+//	health = 100 - (orphan_rate_pct * 0.3 + bug_rate_pct * 0.5 + recall_miss_pct * 0.2)
+//
+// Output formats: text (default), json, csv, markdown  (--format flag).
+// CI mode: --fail-below=N exits non-zero when any group's score drops below N.
+// Baseline mode: --baseline=N exits non-zero when score drops more than N points
+// vs the last recorded measurement.
+//
+// Historic measurements are appended to the health-history JSONL file so
+// the dashboard trend line picks them up automatically.
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/quality"
+	"github.com/cajasmota/archigraph/internal/quality/audit"
+)
+
+// corpusGroupResult holds the per-group measurement result.
+type corpusGroupResult struct {
+	// Name is the last path component of the group directory.
+	Name string `json:"name"`
+	// Path is the absolute path to the group root.
+	Path string `json:"path"`
+	// OrphanRatePct is the fraction of entities with no inbound edges * 100.
+	OrphanRatePct float64 `json:"orphan_rate_pct"`
+	// BugRatePct is the fraction of unresolved import-edges * 100.
+	BugRatePct float64 `json:"bug_rate_pct"`
+	// RecallMissPct is 0 unless a recall measurement was supplied externally.
+	RecallMissPct float64 `json:"recall_miss_pct"`
+	// Composite is the full decomposed score.
+	Composite quality.CompositeResult `json:"composite"`
+	// Entities is the total entity count across all repos in the group.
+	Entities int `json:"entities"`
+	// Repos is the number of repos analysed.
+	Repos int `json:"repos"`
+	// MeasuredAt is when this measurement was taken.
+	MeasuredAt time.Time `json:"measured_at"`
+	// Errors lists non-fatal per-repo errors encountered during the audit.
+	Errors []string `json:"errors,omitempty"`
+
+	// Top5Improvements are the highest-value actions to improve this group's score.
+	Top5Improvements []string `json:"top_5_improvements,omitempty"`
+
+	// PreviousScore is the last recorded health score for this group, or -1
+	// when no prior measurement exists.
+	PreviousScore float64 `json:"previous_score"`
+	// ScoreDelta is Composite.Score - PreviousScore (positive = improvement).
+	// Set to 0 when PreviousScore is unavailable.
+	ScoreDelta float64 `json:"score_delta"`
+}
+
+// runBugRateCorpus is the implementation of `archigraph quality bug-rate-corpus`.
+func runBugRateCorpus(argv []string) error {
+	fs := flag.NewFlagSet("quality bug-rate-corpus", flag.ContinueOnError)
+	format := fs.String("format", "text", "output format: text|json|csv|markdown")
+	failBelow := fs.Float64("fail-below", 0, "exit non-zero when any group scores below N (0 = disabled)")
+	baseline := fs.Float64("baseline", 0, "exit non-zero when score drops more than N points vs last measurement (0 = disabled)")
+	slackWebhook := fs.String("slack-webhook", "", "post a summary to this Slack incoming-webhook URL (stub)")
+	noHistory := fs.Bool("no-history", false, "skip appending to health-history.jsonl")
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+	if fs.NArg() < 1 {
+		return fmt.Errorf("usage: archigraph quality bug-rate-corpus [flags] <dir>")
+	}
+
+	root, err := filepath.Abs(fs.Arg(0))
+	if err != nil {
+		return fmt.Errorf("resolve path: %w", err)
+	}
+
+	results, err := measureCorpus(root)
+	if err != nil {
+		return err
+	}
+	if len(results) == 0 {
+		return fmt.Errorf("no archigraph-indexed groups found under %s", root)
+	}
+
+	// Load previous scores for delta computation.
+	layout, layoutErr := daemon.DefaultLayout()
+	histRoot := ""
+	if layoutErr == nil {
+		histRoot = layout.Root
+		for i := range results {
+			prev := lastHealthScore(histRoot, results[i].Name)
+			results[i].PreviousScore = prev
+			if prev >= 0 {
+				results[i].ScoreDelta = math.Round((results[i].Composite.Score-prev)*10) / 10
+			}
+		}
+	}
+
+	// Persist to health history unless suppressed.
+	if !*noHistory && histRoot != "" {
+		for _, r := range results {
+			entry := quality.HealthEntry{
+				Timestamp:     r.MeasuredAt,
+				Group:         r.Name,
+				TotalEntities: r.Entities,
+				OrphanRate:    r.OrphanRatePct,
+				BugRate:       r.BugRatePct,
+				HealthScore:   r.Composite.Score,
+			}
+			_ = quality.AppendEntry(histRoot, entry)
+		}
+	}
+
+	// Slack stub.
+	if *slackWebhook != "" {
+		postSlackSummary(*slackWebhook, results)
+	}
+
+	// Render.
+	switch strings.ToLower(*format) {
+	case "json":
+		if err := renderJSON(results); err != nil {
+			return err
+		}
+	case "csv":
+		if err := renderCSV(results); err != nil {
+			return err
+		}
+	case "markdown", "md":
+		renderMarkdown(results)
+	default:
+		renderText(results)
+	}
+
+	// CI exit codes.
+	var ciFailures []string
+	for _, r := range results {
+		if *failBelow > 0 && r.Composite.Score < *failBelow {
+			ciFailures = append(ciFailures, fmt.Sprintf(
+				"%s: score %.1f < threshold %.1f", r.Name, r.Composite.Score, *failBelow,
+			))
+		}
+		if *baseline > 0 && r.PreviousScore >= 0 && r.ScoreDelta < -*baseline {
+			ciFailures = append(ciFailures, fmt.Sprintf(
+				"%s: score dropped %.1f points (threshold %.1f)", r.Name, -r.ScoreDelta, *baseline,
+			))
+		}
+	}
+	if len(ciFailures) > 0 {
+		for _, f := range ciFailures {
+			fmt.Fprintln(os.Stderr, "FAIL:", f)
+		}
+		os.Exit(1)
+	}
+	return nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Measurement
+// ─────────────────────────────────────────────────────────────────────────────
+
+// measureCorpus walks root one level deep, audits each archigraph-indexed
+// directory, and returns one result per group.
+func measureCorpus(root string) ([]corpusGroupResult, error) {
+	ents, err := os.ReadDir(root)
+	if err != nil {
+		return nil, fmt.Errorf("read dir %s: %w", root, err)
+	}
+
+	// Check whether root itself is a single indexed group.
+	if audit.HasGraph(root) {
+		r, mErr := measureGroup(root)
+		if mErr != nil {
+			return nil, mErr
+		}
+		return []corpusGroupResult{r}, nil
+	}
+
+	var results []corpusGroupResult
+	for _, e := range ents {
+		if !e.IsDir() || strings.HasPrefix(e.Name(), ".") || strings.HasPrefix(e.Name(), "_") {
+			continue
+		}
+		p := filepath.Join(root, e.Name())
+		if !audit.HasGraph(p) {
+			continue
+		}
+		r, mErr := measureGroup(p)
+		if mErr != nil {
+			// Non-fatal: surface the error but continue.
+			results = append(results, corpusGroupResult{
+				Name:   e.Name(),
+				Path:   p,
+				Errors: []string{mErr.Error()},
+			})
+			continue
+		}
+		results = append(results, r)
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return results[i].Name < results[j].Name
+	})
+	return results, nil
+}
+
+// measureGroup audits a single archigraph-indexed directory and computes the
+// composite score.
+func measureGroup(path string) (corpusGroupResult, error) {
+	now := time.Now().UTC()
+	rep, err := audit.AuditPath(path, false)
+	if err != nil {
+		return corpusGroupResult{}, fmt.Errorf("audit %s: %w", path, err)
+	}
+
+	// Aggregate orphan + entity counts across repos.
+	totalEntities := 0
+	totalOrphans := 0
+	totalImports := 0
+	goodImports := 0
+	repos := 0
+	var allErrs []string
+	for _, rr := range rep.Repos {
+		if rr == nil {
+			continue
+		}
+		repos++
+		totalEntities += rr.Entities
+		totalOrphans += rr.Orphans
+		totalImports += rr.ImportsTotal
+		goodImports += rr.ImportsToIDFormat[audit.ImportFormatHex] +
+			rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+		allErrs = append(allErrs, rr.Errors...)
+	}
+
+	orphanRatePct := 0.0
+	if totalEntities > 0 {
+		orphanRatePct = 100.0 * float64(totalOrphans) / float64(totalEntities)
+	}
+	// Bug rate: fraction of IMPORTS edges that are NOT resolved to a hex ID or
+	// ext-qualified reference. These are edges to unresolved targets.
+	bugRatePct := 0.0
+	if totalImports > 0 {
+		bugRatePct = 100.0 * float64(totalImports-goodImports) / float64(totalImports)
+	}
+
+	composite := quality.CompositeScoreFromPcts(orphanRatePct, bugRatePct, 0)
+	top5 := buildTop5(rep, orphanRatePct, bugRatePct)
+
+	return corpusGroupResult{
+		Name:             filepath.Base(path),
+		Path:             path,
+		OrphanRatePct:    math.Round(orphanRatePct*10) / 10,
+		BugRatePct:       math.Round(bugRatePct*10) / 10,
+		RecallMissPct:    0,
+		Composite:        composite,
+		Entities:         totalEntities,
+		Repos:            repos,
+		MeasuredAt:       now,
+		Errors:           allErrs,
+		Top5Improvements: top5,
+		PreviousScore:    -1,
+	}, nil
+}
+
+// buildTop5 synthesises up to 5 actionable improvement suggestions for a group.
+func buildTop5(rep *audit.Report, orphanPct, bugPct float64) []string {
+	var tips []string
+	if orphanPct > 20 {
+		tips = append(tips, fmt.Sprintf("Reduce orphan rate (%.1f%%) — improve REFERENCES emission for disconnected entities", orphanPct))
+	}
+	if bugPct > 20 {
+		tips = append(tips, fmt.Sprintf("Resolve import edges (%.1f%% unresolved) — fix path-string IMPORTS targets", bugPct))
+	}
+	// Per-language recommendations from the audit engine.
+	for _, rec := range rep.Recommendations {
+		if len(tips) >= 5 {
+			break
+		}
+		tips = append(tips, rec.Issue)
+	}
+	if len(tips) == 0 {
+		tips = append(tips, "Graph is healthy — no immediate action required")
+	}
+	if len(tips) > 5 {
+		tips = tips[:5]
+	}
+	return tips
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// History helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// lastHealthScore reads the most recent HealthEntry for the named group and
+// returns its HealthScore, or -1 when no prior entry exists.
+func lastHealthScore(histRoot, group string) float64 {
+	entries, err := quality.ReadHistory(histRoot, group, 365)
+	if err != nil || len(entries) == 0 {
+		return -1
+	}
+	return entries[len(entries)-1].HealthScore
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Renderers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func renderText(results []corpusGroupResult) {
+	for _, r := range results {
+		delta := ""
+		if r.PreviousScore >= 0 {
+			sign := "+"
+			if r.ScoreDelta < 0 {
+				sign = ""
+			}
+			delta = fmt.Sprintf("  (prev %.1f, %s%.1f)", r.PreviousScore, sign, r.ScoreDelta)
+		}
+		fmt.Printf("%-30s  score=%.1f (%s)%s  orphan=%.1f%%  bug=%.1f%%  entities=%d\n",
+			r.Name, r.Composite.Score, r.Composite.Grade, delta,
+			r.OrphanRatePct, r.BugRatePct, r.Entities)
+		for _, tip := range r.Top5Improvements {
+			fmt.Printf("  • %s\n", tip)
+		}
+	}
+}
+
+func renderMarkdown(results []corpusGroupResult) {
+	fmt.Printf("# Graph Health Report — %s\n\n", time.Now().UTC().Format("2006-01-02"))
+	fmt.Println("| Group | Score | Grade | Δ | Orphan% | Bug% | Entities | Repos |")
+	fmt.Println("|---|---|---|---|---|---|---|---|")
+	for _, r := range results {
+		delta := "—"
+		if r.PreviousScore >= 0 {
+			sign := "+"
+			if r.ScoreDelta < 0 {
+				sign = ""
+			}
+			delta = fmt.Sprintf("%s%.1f", sign, r.ScoreDelta)
+		}
+		fmt.Printf("| %s | %.1f | %s | %s | %.1f%% | %.1f%% | %d | %d |\n",
+			r.Name, r.Composite.Score, r.Composite.Grade, delta,
+			r.OrphanRatePct, r.BugRatePct, r.Entities, r.Repos)
+	}
+	fmt.Println()
+	for _, r := range results {
+		if len(r.Top5Improvements) == 0 {
+			continue
+		}
+		fmt.Printf("## %s — top improvements\n\n", r.Name)
+		for _, tip := range r.Top5Improvements {
+			fmt.Printf("- %s\n", tip)
+		}
+		fmt.Println()
+	}
+}
+
+func renderJSON(results []corpusGroupResult) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(results)
+}
+
+func renderCSV(results []corpusGroupResult) error {
+	w := csv.NewWriter(os.Stdout)
+	if err := w.Write([]string{
+		"name", "path", "score", "grade",
+		"orphan_rate_pct", "bug_rate_pct", "recall_miss_pct",
+		"entities", "repos", "previous_score", "score_delta",
+		"measured_at",
+	}); err != nil {
+		return err
+	}
+	for _, r := range results {
+		prevScore := ""
+		if r.PreviousScore >= 0 {
+			prevScore = fmt.Sprintf("%.1f", r.PreviousScore)
+		}
+		if err := w.Write([]string{
+			r.Name,
+			r.Path,
+			fmt.Sprintf("%.1f", r.Composite.Score),
+			r.Composite.Grade,
+			fmt.Sprintf("%.1f", r.OrphanRatePct),
+			fmt.Sprintf("%.1f", r.BugRatePct),
+			fmt.Sprintf("%.1f", r.RecallMissPct),
+			fmt.Sprintf("%d", r.Entities),
+			fmt.Sprintf("%d", r.Repos),
+			prevScore,
+			fmt.Sprintf("%.1f", r.ScoreDelta),
+			r.MeasuredAt.Format(time.RFC3339),
+		}); err != nil {
+			return err
+		}
+	}
+	w.Flush()
+	return w.Error()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Slack stub
+// ─────────────────────────────────────────────────────────────────────────────
+
+// postSlackSummary is a stub. A real implementation would POST a JSON payload
+// to the incoming-webhook URL. We print to stderr so the user knows it was
+// called.
+func postSlackSummary(webhookURL string, results []corpusGroupResult) {
+	if webhookURL == "" {
+		return
+	}
+	best := results[0]
+	worst := results[0]
+	for _, r := range results {
+		if r.Composite.Score > best.Composite.Score {
+			best = r
+		}
+		if r.Composite.Score < worst.Composite.Score {
+			worst = r
+		}
+	}
+	fmt.Fprintf(os.Stderr, "slack-webhook: would POST to %s — best=%s (%.1f) worst=%s (%.1f)\n",
+		webhookURL, best.Name, best.Composite.Score, worst.Name, worst.Composite.Score)
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -153,6 +153,7 @@ Dashboard:
 Quality:
   quality <fixture-dir>                       Measure extraction recall vs a golden fixture
   quality audit-orphans [--corpus] <path>     Audit orphan rate + edge hygiene; emits md or JSON
+  quality bug-rate-corpus [flags] <dir>       Composite health score across a corpus of indexed groups
 
 Agent-learned patterns (ADR-0018):
   patterns list [--needs-attention]           Show patterns table (rejected/low-conf/stale with --needs-attention)

--- a/internal/dashboard/handlers_quality.go
+++ b/internal/dashboard/handlers_quality.go
@@ -24,6 +24,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/quality"
 	"github.com/cajasmota/archigraph/internal/quality/audit"
 	"github.com/cajasmota/archigraph/internal/registry"
 )
@@ -34,7 +35,7 @@ import (
 
 // OrphanAuditReply is the wire shape for GET /api/quality/orphans/{group}.
 type OrphanAuditReply struct {
-	Group    string             `json:"group"`
+	Group     string            `json:"group"`
 	AuditedAt string            `json:"audited_at"`
 	Total     OrphanTotals      `json:"total"`
 	PerRepo   []RepoOrphanStats `json:"per_repo"`
@@ -48,9 +49,9 @@ type OrphanAuditReply struct {
 
 // OrphanTotals rolls up aggregate counts across the whole group.
 type OrphanTotals struct {
-	Entities    int     `json:"entities"`
-	Orphans     int     `json:"orphans"`
-	OrphanRate  float64 `json:"orphan_rate"`
+	Entities   int     `json:"entities"`
+	Orphans    int     `json:"orphans"`
+	OrphanRate float64 `json:"orphan_rate"`
 }
 
 // RepoOrphanStats is a per-repo summary row for the result table.
@@ -91,16 +92,16 @@ type RecallRequest struct {
 
 // RecallReply is the wire shape for POST /api/quality/recall.
 type RecallReply struct {
-	Fixture              string               `json:"fixture"`
-	EntityRecall         float64              `json:"entity_recall"`
-	RelationshipRecall   float64              `json:"relationship_recall"`
-	EntityExpected       int                  `json:"entity_expected"`
-	EntityFound          int                  `json:"entity_found"`
-	RelationshipExpected int                  `json:"relationship_expected"`
-	RelationshipFound    int                  `json:"relationship_found"`
-	ForbiddenHits        int                  `json:"forbidden_hits"`
-	MissingEntities      []RecallMissingItem  `json:"missing_entities,omitempty"`
-	MissingRelationships []RecallRelItem      `json:"missing_relationships,omitempty"`
+	Fixture              string              `json:"fixture"`
+	EntityRecall         float64             `json:"entity_recall"`
+	RelationshipRecall   float64             `json:"relationship_recall"`
+	EntityExpected       int                 `json:"entity_expected"`
+	EntityFound          int                 `json:"entity_found"`
+	RelationshipExpected int                 `json:"relationship_expected"`
+	RelationshipFound    int                 `json:"relationship_found"`
+	ForbiddenHits        int                 `json:"forbidden_hits"`
+	MissingEntities      []RecallMissingItem `json:"missing_entities,omitempty"`
+	MissingRelationships []RecallRelItem     `json:"missing_relationships,omitempty"`
 }
 
 // RecallMissingItem is a missing entity in a recall report.
@@ -318,15 +319,15 @@ func (s *Server) handleQualityRecall(w http.ResponseWriter, r *http.Request) {
 
 	// Unmarshal into a local shape that mirrors quality.JSONReport fields.
 	var jr struct {
-		Fixture                    string  `json:"fixture"`
-		EntityExpected             int     `json:"entity_expected"`
-		EntityFound                int     `json:"entity_found"`
-		EntityRecall               float64 `json:"entity_recall"`
-		RelationshipExpected       int     `json:"relationship_expected"`
-		RelationshipFound          int     `json:"relationship_found"`
-		RelationshipRecall         float64 `json:"relationship_recall"`
-		ForbiddenHits              int     `json:"forbidden_hits"`
-		MissingEntities []struct {
+		Fixture              string  `json:"fixture"`
+		EntityExpected       int     `json:"entity_expected"`
+		EntityFound          int     `json:"entity_found"`
+		EntityRecall         float64 `json:"entity_recall"`
+		RelationshipExpected int     `json:"relationship_expected"`
+		RelationshipFound    int     `json:"relationship_found"`
+		RelationshipRecall   float64 `json:"relationship_recall"`
+		ForbiddenHits        int     `json:"forbidden_hits"`
+		MissingEntities      []struct {
 			Name string `json:"name"`
 			Kind string `json:"kind"`
 			File string `json:"source_file,omitempty"`
@@ -448,4 +449,91 @@ func goldenFixturesDir() (string, error) {
 		return candidate, nil
 	}
 	return "", fmt.Errorf("could not locate golden fixtures directory (set ARCHIGRAPH_FIXTURES_DIR)")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/quality/composite/{group}
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CompositeScoreReply is the wire shape for GET /api/quality/composite/{group}.
+type CompositeScoreReply struct {
+	Group string `json:"group"`
+	// Score is the composite health score (0–100, higher is better).
+	Score float64 `json:"score"`
+	// Grade is the letter grade (A–F) derived from Score.
+	Grade string `json:"grade"`
+	// OrphanRatePct is the fraction of entities with no inbound edges * 100.
+	OrphanRatePct float64 `json:"orphan_rate_pct"`
+	// BugRatePct is the fraction of unresolved import edges * 100.
+	BugRatePct float64 `json:"bug_rate_pct"`
+	// RecallMissPct is always 0 for live-graph measurements (no golden fixture).
+	RecallMissPct float64 `json:"recall_miss_pct"`
+	// Entities is the total entity count across all repos in the group.
+	Entities int `json:"entities"`
+	// Repos is the number of repos measured.
+	Repos int `json:"repos"`
+}
+
+// handleQualityComposite computes the composite graph-health score for the
+// requested group and returns it as JSON. The handler runs the orphan audit
+// in-process (same as handleQualityOrphans) and then applies the composite
+// formula from internal/quality.CompositeScoreFromPcts.
+func (s *Server) handleQualityComposite(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	// Audit each repo and accumulate totals.
+	totalEntities := 0
+	totalOrphans := 0
+	totalImports := 0
+	goodImports := 0
+	repos := 0
+
+	for _, rp := range repoPaths {
+		rep, aErr := audit.AuditPath(rp.Path, false)
+		if aErr != nil || len(rep.Repos) == 0 {
+			continue
+		}
+		rr := rep.Repos[0]
+		repos++
+		totalEntities += rr.Entities
+		totalOrphans += rr.Orphans
+		totalImports += rr.ImportsTotal
+		goodImports += rr.ImportsToIDFormat[audit.ImportFormatHex] +
+			rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+	}
+
+	orphanPct := 0.0
+	if totalEntities > 0 {
+		orphanPct = 100.0 * float64(totalOrphans) / float64(totalEntities)
+	}
+	bugPct := 0.0
+	if totalImports > 0 {
+		bugPct = 100.0 * float64(totalImports-goodImports) / float64(totalImports)
+	}
+
+	cr := quality.CompositeScoreFromPcts(orphanPct, bugPct, 0)
+	writeJSON(w, http.StatusOK, CompositeScoreReply{
+		Group:         groupName,
+		Score:         cr.Score,
+		Grade:         cr.Grade,
+		OrphanRatePct: cr.OrphanRatePct,
+		BugRatePct:    cr.BugRatePct,
+		RecallMissPct: cr.RecallMissPct,
+		Entities:      totalEntities,
+		Repos:         repos,
+	})
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -286,10 +286,11 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/cleanup/preview", s.handleCleanupPreview)
 	mux.HandleFunc("POST /api/cleanup", s.handleCleanup)
 
-	// Quality surface (#1198)
+	// Quality surface (#1198, #1236)
 	mux.HandleFunc("GET /api/quality/orphans/{group}", s.handleQualityOrphans)
 	mux.HandleFunc("GET /api/quality/fixtures", s.handleQualityFixtures)
 	mux.HandleFunc("POST /api/quality/recall", s.handleQualityRecall)
+	mux.HandleFunc("GET /api/quality/composite/{group}", s.handleQualityComposite)
 
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)

--- a/internal/quality/audit/audit.go
+++ b/internal/quality/audit/audit.go
@@ -174,6 +174,14 @@ func AuditPath(path string, corpus bool) (*Report, error) {
 	return rep, nil
 }
 
+// HasGraph returns true if dir has any indexable graph (graph.fb or
+// graph.json) in its .archigraph state directory. Exported so corpus
+// scanners (e.g. the bug-rate-corpus command) can test directories without
+// calling the full AuditPath pipeline.
+func HasGraph(dir string) bool {
+	return hasGraphJSON(dir)
+}
+
 // hasGraph returns true if dir has any indexable graph (graph.fb or
 // graph.json) in its .archigraph state directory.
 // Renamed from hasGraphJSON for ADR-0016 flip-day (#808).

--- a/internal/quality/composite.go
+++ b/internal/quality/composite.go
@@ -1,0 +1,91 @@
+// Package quality — composite graph health scorer.
+//
+// CompositeScore combines three orthogonal signals into a single 0–100
+// "graph health" number that is suitable for trending, CI gating, and
+// at-a-glance dashboards.
+//
+// Formula (issue #1236):
+//
+//	health = 100 - (orphan_rate_pct * 0.3 + bug_rate_pct * 0.5 + recall_miss_pct * 0.2)
+//
+// All inputs are 0–100 percentages (not 0–1 ratios). The result is
+// clamped to [0, 100] and rounded to one decimal place.
+//
+// Grade thresholds:
+//
+//	≥ 90  → A
+//	≥ 75  → B
+//	≥ 60  → C
+//	≥ 45  → D
+//	< 45  → F
+package quality
+
+import "math"
+
+// CompositeResult holds the decomposed inputs and the derived composite score.
+type CompositeResult struct {
+	// OrphanRatePct is the percentage of entities with no inbound edges (0–100).
+	OrphanRatePct float64 `json:"orphan_rate_pct"`
+	// BugRatePct is the percentage of edges pointing to unresolved targets (0–100).
+	BugRatePct float64 `json:"bug_rate_pct"`
+	// RecallMissPct is the percentage of expected entities/relationships not
+	// found by the extractor (0–100). Zero when no fixture-based measurement
+	// is available for this group.
+	RecallMissPct float64 `json:"recall_miss_pct"`
+	// Score is the composite health score (0–100, higher is better).
+	Score float64 `json:"score"`
+	// Grade is the letter grade derived from Score (A–F).
+	Grade string `json:"grade"`
+}
+
+// CompositeScoreFromPcts computes the composite health score given the three
+// component percentages (each in [0, 100]). Inputs outside that range are
+// clamped so callers don't need to guard.
+func CompositeScoreFromPcts(orphanRatePct, bugRatePct, recallMissPct float64) CompositeResult {
+	orphanRatePct = clamp100(orphanRatePct)
+	bugRatePct = clamp100(bugRatePct)
+	recallMissPct = clamp100(recallMissPct)
+
+	raw := 100.0 - (orphanRatePct*0.3 + bugRatePct*0.5 + recallMissPct*0.2)
+	score := math.Round(clamp100(raw)*10) / 10
+
+	return CompositeResult{
+		OrphanRatePct: orphanRatePct,
+		BugRatePct:    bugRatePct,
+		RecallMissPct: recallMissPct,
+		Score:         score,
+		Grade:         scoreGrade(score),
+	}
+}
+
+// CompositeScoreFromRatios is a convenience wrapper for callers that work with
+// 0–1 ratios (as produced by the audit and history machinery).
+func CompositeScoreFromRatios(orphanRate, bugRate, recallMiss float64) CompositeResult {
+	return CompositeScoreFromPcts(orphanRate*100, bugRate*100, recallMiss*100)
+}
+
+// scoreGrade maps a score to a letter grade.
+func scoreGrade(score float64) string {
+	switch {
+	case score >= 90:
+		return "A"
+	case score >= 75:
+		return "B"
+	case score >= 60:
+		return "C"
+	case score >= 45:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+func clamp100(v float64) float64 {
+	if v < 0 {
+		return 0
+	}
+	if v > 100 {
+		return 100
+	}
+	return v
+}

--- a/internal/quality/composite_test.go
+++ b/internal/quality/composite_test.go
@@ -1,0 +1,132 @@
+package quality
+
+import (
+	"testing"
+)
+
+func TestCompositeScoreFromPcts(t *testing.T) {
+	tests := []struct {
+		name          string
+		orphanPct     float64
+		bugPct        float64
+		recallMissPct float64
+		wantScore     float64
+		wantGrade     string
+	}{
+		{
+			name:          "perfect graph",
+			orphanPct:     0,
+			bugPct:        0,
+			recallMissPct: 0,
+			wantScore:     100.0,
+			wantGrade:     "A",
+		},
+		{
+			name:          "grade A boundary (90)",
+			orphanPct:     0,
+			bugPct:        20,
+			recallMissPct: 0,
+			// 100 - (0*0.3 + 20*0.5 + 0*0.2) = 90
+			wantScore: 90.0,
+			wantGrade: "A",
+		},
+		{
+			name:          "grade B",
+			orphanPct:     10,
+			bugPct:        20,
+			recallMissPct: 10,
+			// 100 - (3 + 10 + 2) = 85
+			wantScore: 85.0,
+			wantGrade: "B",
+		},
+		{
+			name:          "grade C",
+			orphanPct:     20,
+			bugPct:        30,
+			recallMissPct: 20,
+			// 100 - (6 + 15 + 4) = 75 -> just at B boundary
+			wantScore: 75.0,
+			wantGrade: "B",
+		},
+		{
+			name:          "grade D",
+			orphanPct:     30,
+			bugPct:        60,
+			recallMissPct: 30,
+			// 100 - (9 + 30 + 6) = 55 → D (< 60)
+			wantScore: 55.0,
+			wantGrade: "D",
+		},
+		{
+			name:          "grade F — terrible graph",
+			orphanPct:     80,
+			bugPct:        100,
+			recallMissPct: 100,
+			// 100 - (24 + 50 + 20) = 6
+			wantScore: 6.0,
+			wantGrade: "F",
+		},
+		{
+			name:          "clamped below zero",
+			orphanPct:     100,
+			bugPct:        100,
+			recallMissPct: 100,
+			// 100 - (30 + 50 + 20) = 0
+			wantScore: 0.0,
+			wantGrade: "F",
+		},
+		{
+			name:          "inputs clamped at 100",
+			orphanPct:     200,
+			bugPct:        200,
+			recallMissPct: 200,
+			wantScore:     0.0,
+			wantGrade:     "F",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := CompositeScoreFromPcts(tc.orphanPct, tc.bugPct, tc.recallMissPct)
+			if got.Score != tc.wantScore {
+				t.Errorf("Score: got %.1f, want %.1f", got.Score, tc.wantScore)
+			}
+			if got.Grade != tc.wantGrade {
+				t.Errorf("Grade: got %q, want %q", got.Grade, tc.wantGrade)
+			}
+		})
+	}
+}
+
+func TestCompositeScoreFromRatios(t *testing.T) {
+	// Ratios should produce the same result as equivalent pcts.
+	r := CompositeScoreFromRatios(0.10, 0.20, 0.10)
+	p := CompositeScoreFromPcts(10, 20, 10)
+	if r.Score != p.Score {
+		t.Errorf("ratio vs pct mismatch: %.1f vs %.1f", r.Score, p.Score)
+	}
+}
+
+func TestScoreGrade(t *testing.T) {
+	cases := []struct {
+		score float64
+		grade string
+	}{
+		{100, "A"},
+		{90, "A"},
+		{89.9, "B"},
+		{75, "B"},
+		{74.9, "C"},
+		{60, "C"},
+		{59.9, "D"},
+		{45, "D"},
+		{44.9, "F"},
+		{0, "F"},
+	}
+	for _, c := range cases {
+		got := scoreGrade(c.score)
+		if got != c.grade {
+			t.Errorf("scoreGrade(%.1f) = %q, want %q", c.score, got, c.grade)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1236

Adds a comprehensive composite graph-health metric that combines the three existing quality signals — orphan rate, bug rate (unresolved import edges), and recall miss — into a single 0–100 score with an A–F grade. Implements the `archigraph quality bug-rate-corpus` CLI command and a matching dashboard REST endpoint.

**Formula** (issue #1236):
```
health = 100 - (orphan_rate_pct × 0.3 + bug_rate_pct × 0.5 + recall_miss_pct × 0.2)
```

**Grade thresholds:** A ≥ 90, B ≥ 75, C ≥ 60, D ≥ 45, F < 45.

### What changed

| Layer | File | Change |
|---|---|---|
| Core scorer | `internal/quality/composite.go` | `CompositeScoreFromPcts`, `CompositeScoreFromRatios`, `CompositeResult`, `scoreGrade` |
| Tests | `internal/quality/composite_test.go` | 11 table-driven cases: formula correctness, clamping, grade boundaries, ratio/pct invariant |
| Audit export | `internal/quality/audit/audit.go` | Export `HasGraph()` so corpus scanner can probe dirs without a full audit |
| CLI subcommand | `cmd/archigraph/quality_corpus.go` | `archigraph quality bug-rate-corpus [flags] <dir>` |
| CLI dispatch | `cmd/archigraph/quality.go` | Route `bug-rate-corpus` subverb |
| Dashboard API | `internal/dashboard/handlers_quality.go` | `GET /api/quality/composite/{group}` → `CompositeScoreReply` |
| Dashboard routes | `internal/dashboard/server.go` | Register composite route |
| Help text | `internal/cli/root.go` | Surface subcommand in advanced help |

### CLI flags

```
archigraph quality bug-rate-corpus [flags] <dir>

  --format text|json|csv|markdown   Output format (default: text)
  --fail-below N                    Exit 1 when any group scores below N
  --baseline N                      Exit 1 when score drops > N pts vs last run
  --slack-webhook URL               Post summary to Slack (stub)
  --no-history                      Skip appending to health-history.jsonl
```

### Beyond the minimum

- `--fail-below` / `--baseline` CI gates with non-zero exit codes
- Historic delta displayed: `prev 81.3, +4.2` (reads from health-history.jsonl)
- Top-5 improvement suggestions per group derived from audit recommendations
- Slack webhook stub (prints to stderr; real POST is a one-liner when needed)
- All four output formats: text, JSON, CSV, Markdown table
- Dashboard `GET /api/quality/composite/{group}` for the Quality surface trend tile

## Closes / Refs
- Closes #1236

## Testing
- [x] All tests pass: `go test ./...`
- [x] `go vet ./...` clean, `gofmt` clean
- [x] New composite scorer: 11 table-driven unit tests (formula, clamping, grade thresholds, ratio/pct invariant)
- [x] Existing quality + audit package tests unaffected
- [x] No regression in cross-language parity

## Notes

The `dist/` embed placeholder is not committed (it is produced by `make dashboard-build`); CI builds the frontend first, same as every other PR.