### PR TITLE
[dashboard] MCP Setup Wizard — one-click install for Claude Code / Cursor / Windsurf

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -19,6 +19,7 @@ import { SettingsRoute } from '@/routes/settings'
 import { QualityRoute } from '@/routes/quality'
 import { MCPActivityRoute } from '@/routes/mcp-activity'
 import { OnboardRoute } from '@/routes/onboard'
+import { MCPSetupRoute } from '@/routes/mcp-setup'
 import { RouterErrorBoundary } from '@/components/RouterErrorBoundary'
 import { EmptyState } from '@/components/shared/EmptyState'
 import { Globe } from 'lucide-react'
@@ -109,6 +110,9 @@ const router = createBrowserRouter([
 
       // Surface 13 — Web onboarding wizard (#1239)
       { path: 'onboard', element: <OnboardRoute /> },
+
+      // Surface 14 — MCP Setup Wizard (#1247)
+      { path: 'mcp-setup', element: <MCPSetupRoute /> },
     ],
   },
 ])

--- a/dashboard/src/api/mcp-setup.ts
+++ b/dashboard/src/api/mcp-setup.ts
@@ -1,0 +1,87 @@
+/**
+ * MCP Setup Wizard API — issue #1247
+ *
+ * GET  /api/mcp-setup/hosts             — detect installed hosts + config state
+ * POST /api/mcp-setup/install?host=X    — idempotent install
+ * POST /api/mcp-setup/uninstall?host=X  — remove archigraph entry
+ * POST /api/mcp-setup/verify?host=X     — test-query the MCP server
+ */
+
+// ── Wire types ────────────────────────────────────────────────────────────────
+
+export type MCPHostID = 'claude' | 'cursor' | 'windsurf'
+
+export type MCPInstallState =
+  | 'installed'     // entry present and well-formed
+  | 'partial'       // entry present but malformed
+  | 'not_installed' // no entry found
+  | 'host_absent'   // config file not found (host may not be installed)
+
+export interface MCPHostInfo {
+  id: MCPHostID
+  label: string
+  config_path: string
+  exists: boolean
+  state: MCPInstallState
+  current_args?: string[]
+  error?: string
+}
+
+export interface MCPHostsReply {
+  hosts: MCPHostInfo[]
+  mcp_port: number
+  server_arg: string
+}
+
+export interface MCPActionReply {
+  ok: boolean
+  message: string
+  latency_ms?: number
+}
+
+// ── Fetch helpers ─────────────────────────────────────────────────────────────
+
+class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    message: string,
+  ) {
+    super(message)
+  }
+}
+
+async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(path, {
+    headers: { 'Content-Type': 'application/json', ...init?.headers },
+    ...init,
+  })
+  if (!res.ok) {
+    const body = await res.text()
+    throw new ApiError(res.status, `API ${res.status} ${path}: ${body}`)
+  }
+  return res.json() as Promise<T>
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export async function fetchMCPHosts(): Promise<MCPHostsReply> {
+  return apiFetch<MCPHostsReply>('/api/mcp-setup/hosts')
+}
+
+export async function installMCPHost(host: MCPHostID): Promise<MCPActionReply> {
+  return apiFetch<MCPActionReply>(`/api/mcp-setup/install?host=${host}`, {
+    method: 'POST',
+  })
+}
+
+export async function uninstallMCPHost(host: MCPHostID): Promise<MCPActionReply> {
+  return apiFetch<MCPActionReply>(`/api/mcp-setup/uninstall?host=${host}`, {
+    method: 'POST',
+  })
+}
+
+export async function verifyMCPHost(host: MCPHostID): Promise<MCPActionReply> {
+  return apiFetch<MCPActionReply>(`/api/mcp-setup/verify?host=${host}`, {
+    method: 'POST',
+  })
+}

--- a/dashboard/src/components/layout/NavMenu.tsx
+++ b/dashboard/src/components/layout/NavMenu.tsx
@@ -14,7 +14,7 @@ import { NavLink, useNavigate } from 'react-router-dom'
 import {
   Network, Workflow, Radio, Globe, BookOpen, Clock,
   Stethoscope, Sparkles, Server, RefreshCw, ChevronDown,
-  BarChart2, Settings, Activity,
+  BarChart2, Settings, Activity, Zap,
 } from 'lucide-react'
 
 /* ── Types ──────────────────────────────────────────────────────────────────── */
@@ -58,6 +58,7 @@ export function operateItems(group: string): NavEntry[] {
     { label: 'System',        to: '/system',            icon: <Server      className="w-4 h-4" /> },
     { label: 'Update',        to: '/update',            icon: <RefreshCw   className="w-4 h-4" /> },
     { label: 'MCP Activity',  to: '/mcp-activity',      icon: <Activity    className="w-4 h-4" /> },
+    { label: 'MCP Setup',     to: '/mcp-setup',         icon: <Zap         className="w-4 h-4" /> },
     { label: 'Settings',      to: '/settings',          icon: <Settings    className="w-4 h-4" /> },
   ]
 }

--- a/dashboard/src/routes/_layout.tsx
+++ b/dashboard/src/routes/_layout.tsx
@@ -17,7 +17,7 @@ import {
 const GROUP_DEFAULT = 'fixture-a'
 
 const EXPLORE_PREFIXES = ['/graph/', '/flows/', '/topology/', '/paths/', '/docs/', '/pending/']
-const OPERATE_PREFIXES = ['/diagnostics', '/quality', '/patterns/', '/system', '/update', '/mcp-activity', '/settings']
+const OPERATE_PREFIXES = ['/diagnostics', '/quality', '/patterns/', '/system', '/update', '/mcp-activity', '/mcp-setup', '/settings']
 
 export function AppLayout() {
   const { group = GROUP_DEFAULT } = useParams()

--- a/dashboard/src/routes/mcp-setup.tsx
+++ b/dashboard/src/routes/mcp-setup.tsx
@@ -1,0 +1,531 @@
+/**
+ * MCP Setup Wizard — Surface 13 (issue #1247)
+ *
+ * Detects which MCP hosts are installed (Claude Code, Cursor, Windsurf),
+ * shows the current config state, and allows one-click install / uninstall
+ * / verify without manual copy-paste.
+ */
+
+import { useState } from 'react'
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
+import {
+  Zap, CheckCircle, AlertTriangle, XCircle, RefreshCw,
+  Download, Trash2, Activity, ChevronDown, ChevronRight,
+  FileText,
+} from 'lucide-react'
+import {
+  fetchMCPHosts,
+  installMCPHost,
+  uninstallMCPHost,
+  verifyMCPHost,
+  type MCPHostInfo,
+  type MCPInstallState,
+  type MCPHostsReply,
+} from '@/api/mcp-setup'
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function cls(...parts: (string | boolean | undefined)[]) {
+  return parts.filter(Boolean).join(' ')
+}
+
+// ── State chip ────────────────────────────────────────────────────────────────
+
+interface StateChipProps {
+  state: MCPInstallState
+}
+
+const STATE_META: Record<
+  MCPInstallState,
+  { label: string; icon: React.ReactNode; className: string }
+> = {
+  installed: {
+    label: 'Installed',
+    icon: <CheckCircle className="w-3.5 h-3.5" />,
+    className:
+      'bg-emerald-50 dark:bg-emerald-950/40 text-emerald-700 dark:text-emerald-400 border-emerald-200 dark:border-emerald-800',
+  },
+  partial: {
+    label: 'Partial',
+    icon: <AlertTriangle className="w-3.5 h-3.5" />,
+    className:
+      'bg-amber-50 dark:bg-amber-950/40 text-amber-700 dark:text-amber-400 border-amber-200 dark:border-amber-800',
+  },
+  not_installed: {
+    label: 'Not installed',
+    icon: <XCircle className="w-3.5 h-3.5" />,
+    className:
+      'bg-slate-50 dark:bg-slate-900 text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700',
+  },
+  host_absent: {
+    label: 'Host not found',
+    icon: <XCircle className="w-3.5 h-3.5" />,
+    className:
+      'bg-slate-50 dark:bg-slate-900 text-slate-400 dark:text-slate-500 border-slate-200 dark:border-slate-700',
+  },
+}
+
+function StateChip({ state }: StateChipProps) {
+  const { label, icon, className } = STATE_META[state]
+  return (
+    <span
+      className={cls(
+        'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full text-xs font-medium border',
+        className,
+      )}
+    >
+      {icon}
+      {label}
+    </span>
+  )
+}
+
+// ── Result banner ─────────────────────────────────────────────────────────────
+
+interface ResultBannerProps {
+  ok: boolean
+  message: string
+  latencyMs?: number
+  onDismiss: () => void
+}
+
+function ResultBanner({ ok, message, latencyMs, onDismiss }: ResultBannerProps) {
+  return (
+    <div
+      className={cls(
+        'flex items-start gap-2 px-3 py-2 rounded text-xs border',
+        ok
+          ? 'bg-emerald-50 dark:bg-emerald-950/30 border-emerald-200 dark:border-emerald-800 text-emerald-700 dark:text-emerald-400'
+          : 'bg-red-50 dark:bg-red-950/30 border-red-200 dark:border-red-800 text-red-700 dark:text-red-400',
+      )}
+    >
+      {ok ? (
+        <CheckCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+      ) : (
+        <XCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+      )}
+      <span className="flex-1">
+        {message}
+        {latencyMs !== undefined && (
+          <span className="ml-1 opacity-60">({latencyMs}ms)</span>
+        )}
+      </span>
+      <button
+        type="button"
+        onClick={onDismiss}
+        className="opacity-50 hover:opacity-100 transition-opacity flex-shrink-0"
+        aria-label="Dismiss"
+      >
+        ×
+      </button>
+    </div>
+  )
+}
+
+// ── Config path display ───────────────────────────────────────────────────────
+
+interface ConfigPathRowProps {
+  path: string
+  exists: boolean
+  currentArgs?: string[]
+}
+
+function ConfigPathRow({ path, exists, currentArgs }: ConfigPathRowProps) {
+  const [open, setOpen] = useState(false)
+  return (
+    <div className="space-y-1">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 transition-colors"
+      >
+        {open ? (
+          <ChevronDown className="w-3 h-3" />
+        ) : (
+          <ChevronRight className="w-3 h-3" />
+        )}
+        <FileText className="w-3 h-3" />
+        <span className="font-mono truncate max-w-xs">{path}</span>
+        {!exists && (
+          <span className="text-slate-300 dark:text-slate-600">(not found)</span>
+        )}
+      </button>
+      {open && (
+        <div className="ml-5 text-xs text-slate-400 dark:text-slate-500 space-y-0.5">
+          <p>
+            <strong>Status:</strong> {exists ? 'file exists' : 'file not found'}
+          </p>
+          {currentArgs && currentArgs.length > 0 && (
+            <p>
+              <strong>Current args:</strong>{' '}
+              <code className="font-mono">{currentArgs.join(' ')}</code>
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ── Host card ─────────────────────────────────────────────────────────────────
+
+interface HostCardProps {
+  host: MCPHostInfo
+  onRefresh: () => void
+}
+
+interface ActionResult {
+  ok: boolean
+  message: string
+  latencyMs?: number
+}
+
+function HostCard({ host, onRefresh }: HostCardProps) {
+  const [result, setResult] = useState<ActionResult | null>(null)
+
+  const installMutation = useMutation({
+    mutationFn: () => installMCPHost(host.id),
+    onSuccess: (r) => {
+      setResult({ ok: r.ok, message: r.message })
+      onRefresh()
+    },
+    onError: (e: Error) => setResult({ ok: false, message: e.message }),
+  })
+
+  const uninstallMutation = useMutation({
+    mutationFn: () => uninstallMCPHost(host.id),
+    onSuccess: (r) => {
+      setResult({ ok: r.ok, message: r.message })
+      onRefresh()
+    },
+    onError: (e: Error) => setResult({ ok: false, message: e.message }),
+  })
+
+  const verifyMutation = useMutation({
+    mutationFn: () => verifyMCPHost(host.id),
+    onSuccess: (r) =>
+      setResult({ ok: r.ok, message: r.message, latencyMs: r.latency_ms }),
+    onError: (e: Error) => setResult({ ok: false, message: e.message }),
+  })
+
+  const busy =
+    installMutation.isPending ||
+    uninstallMutation.isPending ||
+    verifyMutation.isPending
+
+  const isInstalled = host.state === 'installed'
+  const isAbsent = host.state === 'host_absent'
+
+  return (
+    <div className="border border-slate-200 dark:border-slate-800 rounded-lg overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center gap-3 px-4 py-3 bg-slate-50 dark:bg-slate-900">
+        <Zap className="w-4 h-4 text-sky-400 flex-shrink-0" />
+        <span className="flex-1 font-medium text-sm text-slate-800 dark:text-slate-200">
+          {host.label}
+        </span>
+        <StateChip state={host.state} />
+      </div>
+
+      {/* Body */}
+      <div className="px-4 py-3 bg-white dark:bg-slate-950 space-y-3">
+        {/* Config path */}
+        {host.config_path && (
+          <ConfigPathRow
+            path={host.config_path}
+            exists={host.exists}
+            currentArgs={host.current_args}
+          />
+        )}
+
+        {/* Error from detection */}
+        {host.error && (
+          <p className="text-xs text-amber-500 dark:text-amber-400">
+            Detection note: {host.error}
+          </p>
+        )}
+
+        {/* Action result */}
+        {result && (
+          <ResultBanner
+            ok={result.ok}
+            message={result.message}
+            latencyMs={result.latencyMs}
+            onDismiss={() => setResult(null)}
+          />
+        )}
+
+        {/* Buttons */}
+        {!isAbsent && (
+          <div className="flex items-center gap-2 flex-wrap">
+            {!isInstalled ? (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => installMutation.mutate()}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium
+                  bg-sky-500 text-white hover:bg-sky-600 disabled:opacity-40
+                  disabled:cursor-not-allowed transition-colors"
+              >
+                {installMutation.isPending ? (
+                  <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Download className="w-3.5 h-3.5" />
+                )}
+                Install
+              </button>
+            ) : (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={() => {
+                  if (
+                    window.confirm(
+                      `Remove archigraph from ${host.label}'s MCP config?`,
+                    )
+                  ) {
+                    uninstallMutation.mutate()
+                  }
+                }}
+                className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium
+                  border border-red-300 dark:border-red-800 text-red-600 dark:text-red-400
+                  hover:bg-red-50 dark:hover:bg-red-950/30 disabled:opacity-40
+                  disabled:cursor-not-allowed transition-colors"
+              >
+                {uninstallMutation.isPending ? (
+                  <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+                ) : (
+                  <Trash2 className="w-3.5 h-3.5" />
+                )}
+                Uninstall
+              </button>
+            )}
+
+            <button
+              type="button"
+              disabled={busy}
+              onClick={() => verifyMutation.mutate()}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium
+                border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-400
+                hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40
+                disabled:cursor-not-allowed transition-colors"
+            >
+              {verifyMutation.isPending ? (
+                <RefreshCw className="w-3.5 h-3.5 animate-spin" />
+              ) : (
+                <Activity className="w-3.5 h-3.5" />
+              )}
+              Verify
+            </button>
+          </div>
+        )}
+
+        {/* Reinstall option for partial state */}
+        {host.state === 'partial' && (
+          <p className="text-xs text-amber-500 dark:text-amber-400">
+            The archigraph entry exists but may be misconfigured. Click Install to
+            overwrite with the correct settings.
+          </p>
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ── Welcome banner (no hosts detected) ───────────────────────────────────────
+
+function NoHostsBanner() {
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-800 bg-slate-50 dark:bg-slate-900 px-5 py-6 text-center space-y-2">
+      <Zap className="w-8 h-8 text-sky-300 mx-auto" />
+      <p className="text-sm font-medium text-slate-700 dark:text-slate-300">
+        No MCP hosts found
+      </p>
+      <p className="text-xs text-slate-500 dark:text-slate-500 max-w-sm mx-auto">
+        Install{' '}
+        <a
+          href="https://claude.ai/download"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-slate-700 dark:hover:text-slate-300"
+        >
+          Claude Code
+        </a>
+        ,{' '}
+        <a
+          href="https://cursor.com"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-slate-700 dark:hover:text-slate-300"
+        >
+          Cursor
+        </a>
+        , or{' '}
+        <a
+          href="https://codeium.com/windsurf"
+          target="_blank"
+          rel="noopener noreferrer"
+          className="underline hover:text-slate-700 dark:hover:text-slate-300"
+        >
+          Windsurf
+        </a>{' '}
+        to use archigraph as an MCP server.
+      </p>
+    </div>
+  )
+}
+
+// ── Main route ────────────────────────────────────────────────────────────────
+
+const QUERY_KEY = ['mcp-setup', 'hosts'] as const
+
+export function MCPSetupRoute() {
+  const qc = useQueryClient()
+
+  const { data, isLoading, error, refetch } = useQuery<MCPHostsReply>({
+    queryKey: QUERY_KEY,
+    queryFn: fetchMCPHosts,
+    staleTime: 10_000,
+  })
+
+  const refresh = () => {
+    qc.invalidateQueries({ queryKey: QUERY_KEY })
+    void refetch()
+  }
+
+  const allAbsent =
+    data?.hosts.every((h) => h.state === 'host_absent') ?? false
+
+  return (
+    <div className="h-full overflow-y-auto">
+      <div className="max-w-2xl mx-auto px-4 py-8 space-y-5">
+        {/* Header */}
+        <div className="flex items-center justify-between">
+          <div className="flex items-center gap-3">
+            <Zap className="w-6 h-6 text-sky-400" />
+            <div>
+              <h1 className="text-xl font-semibold text-slate-800 dark:text-slate-200">
+                MCP Setup
+              </h1>
+              <p className="text-xs text-slate-400 dark:text-slate-500 mt-0.5">
+                One-click install for Claude Code, Cursor, and Windsurf
+              </p>
+            </div>
+          </div>
+
+          <button
+            type="button"
+            onClick={refresh}
+            disabled={isLoading}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded text-sm font-medium
+              border border-slate-300 dark:border-slate-700 text-slate-600 dark:text-slate-400
+              hover:bg-slate-50 dark:hover:bg-slate-800 disabled:opacity-40 transition-colors"
+            aria-label="Refresh host detection"
+          >
+            <RefreshCw className={cls('w-3.5 h-3.5', isLoading && 'animate-spin')} />
+            Refresh
+          </button>
+        </div>
+
+        {/* MCP port info */}
+        {data?.mcp_port !== undefined && data.mcp_port > 0 && (
+          <p className="text-xs text-slate-400 dark:text-slate-500">
+            Daemon MCP port:{' '}
+            <code className="font-mono text-slate-600 dark:text-slate-300">
+              {data.mcp_port}
+            </code>
+          </p>
+        )}
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="flex items-center justify-center py-12 text-slate-400">
+            <RefreshCw className="w-5 h-5 animate-spin mr-2" />
+            Detecting hosts…
+          </div>
+        )}
+
+        {/* Error */}
+        {error && (
+          <div className="rounded border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-950/30 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+            Failed to detect hosts: {String(error)}
+          </div>
+        )}
+
+        {/* No hosts welcome banner */}
+        {!isLoading && !error && allAbsent && <NoHostsBanner />}
+
+        {/* Host cards */}
+        {!isLoading &&
+          !error &&
+          data?.hosts
+            .filter((h) => h.state !== 'host_absent')
+            .map((host) => (
+              <HostCard key={host.id} host={host} onRefresh={refresh} />
+            ))}
+
+        {/* Show absent hosts collapsed */}
+        {!isLoading && !error && data && (
+          <AbsentHostsCollapsed
+            hosts={data.hosts.filter((h) => h.state === 'host_absent')}
+          />
+        )}
+
+        {/* How it works */}
+        <div className="border border-slate-200 dark:border-slate-800 rounded-lg px-4 py-4 text-xs text-slate-400 dark:text-slate-500 space-y-1.5">
+          <p className="font-medium text-slate-500 dark:text-slate-400">How it works</p>
+          <ul className="list-disc list-inside space-y-1">
+            <li>
+              <strong>Install</strong> — merges <code className="font-mono">archigraph mcp</code>{' '}
+              into your host's MCP config file (idempotent).
+            </li>
+            <li>
+              <strong>Uninstall</strong> — removes only the archigraph entry; other servers are
+              preserved.
+            </li>
+            <li>
+              <strong>Verify</strong> — pings the local MCP server to confirm it's reachable.
+            </li>
+            <li>A <code className="font-mono">.bak</code> backup is created before any write.</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Collapsed absent hosts section ────────────────────────────────────────────
+
+function AbsentHostsCollapsed({ hosts }: { hosts: MCPHostInfo[] }) {
+  const [open, setOpen] = useState(false)
+  if (hosts.length === 0) return null
+  return (
+    <div className="border border-slate-100 dark:border-slate-900 rounded-lg overflow-hidden">
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-left text-xs
+          text-slate-400 dark:text-slate-600 hover:text-slate-500 dark:hover:text-slate-500
+          bg-slate-50 dark:bg-slate-900/50 transition-colors"
+      >
+        {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        {hosts.length} host{hosts.length > 1 ? 's' : ''} not detected on this machine
+      </button>
+      {open && (
+        <div className="px-4 pb-3 pt-1 space-y-1 bg-white dark:bg-slate-950">
+          {hosts.map((h) => (
+            <div key={h.id} className="flex items-center gap-2 text-xs text-slate-400">
+              <XCircle className="w-3 h-3 flex-shrink-0" />
+              <span>{h.label}</span>
+              {h.config_path && (
+                <span className="font-mono text-slate-300 dark:text-slate-700 truncate">
+                  {h.config_path}
+                </span>
+              )}
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/internal/dashboard/handlers_mcp_setup.go
+++ b/internal/dashboard/handlers_mcp_setup.go
@@ -1,0 +1,491 @@
+package dashboard
+
+// handlers_mcp_setup.go — MCP Setup Wizard backend (issue #1247)
+//
+// Endpoints:
+//   GET  /api/mcp-setup/hosts             — detect installed hosts + current config state
+//   POST /api/mcp-setup/install?host=X    — idempotent merge of archigraph entry
+//   POST /api/mcp-setup/uninstall?host=X  — remove archigraph entry
+//   POST /api/mcp-setup/verify?host=X     — test-query against the local MCP server
+//
+// Supported hosts: claude, cursor, windsurf
+// All config mutations create a backup before writing. No mutation happens
+// without an explicit user action (POST).
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+// MCPHostID is the canonical identifier for a supported MCP host.
+type MCPHostID string
+
+const (
+	HostClaude   MCPHostID = "claude"
+	HostCursor   MCPHostID = "cursor"
+	HostWindsurf MCPHostID = "windsurf"
+)
+
+// MCPInstallState describes the current installation state of the archigraph
+// MCP server entry within a host's configuration file.
+type MCPInstallState string
+
+const (
+	StateInstalled   MCPInstallState = "installed"   // entry present and well-formed
+	StatePartial     MCPInstallState = "partial"      // entry present but malformed / wrong args
+	StateNotInstalled MCPInstallState = "not_installed" // no entry found
+	StateHostAbsent  MCPInstallState = "host_absent"  // host config file not found (host may not be installed)
+)
+
+// MCPHostInfo is the per-host response payload.
+type MCPHostInfo struct {
+	ID          MCPHostID       `json:"id"`
+	Label       string          `json:"label"`
+	ConfigPath  string          `json:"config_path"`
+	Exists      bool            `json:"exists"`
+	State       MCPInstallState `json:"state"`
+	CurrentArgs []string        `json:"current_args,omitempty"` // args from existing entry, if any
+	Error       string          `json:"error,omitempty"`
+}
+
+// mcpHostsReply is the GET /api/mcp-setup/hosts response.
+type mcpHostsReply struct {
+	Hosts     []MCPHostInfo `json:"hosts"`
+	MCPPort   int           `json:"mcp_port"`
+	ServerArg string        `json:"server_arg"` // "archigraph" — for display
+}
+
+// mcpActionReply is returned by install / uninstall / verify.
+type mcpActionReply struct {
+	OK      bool   `json:"ok"`
+	Message string `json:"message"`
+	// For verify: latency in milliseconds
+	LatencyMs *int64 `json:"latency_ms,omitempty"`
+}
+
+// ── Config path resolution ────────────────────────────────────────────────────
+
+// configPathFor returns the canonical MCP config file path for a host on
+// the current OS. Returns ("", false) when the host is not supported on
+// this OS (e.g. Windows-only paths on macOS).
+func configPathFor(host MCPHostID) string {
+	home, _ := os.UserHomeDir()
+	if home == "" {
+		return ""
+	}
+
+	switch host {
+	case HostClaude:
+		// Claude Code: ~/.claude/mcp.json  (all platforms)
+		return filepath.Join(home, ".claude", "mcp.json")
+
+	case HostCursor:
+		switch runtime.GOOS {
+		case "darwin":
+			return filepath.Join(home, "Library", "Application Support", "Cursor", "User", "mcp.json")
+		case "linux":
+			xdg := os.Getenv("XDG_CONFIG_HOME")
+			if xdg == "" {
+				xdg = filepath.Join(home, ".config")
+			}
+			return filepath.Join(xdg, "Cursor", "User", "mcp.json")
+		case "windows":
+			appdata := os.Getenv("APPDATA")
+			if appdata == "" {
+				appdata = filepath.Join(home, "AppData", "Roaming")
+			}
+			return filepath.Join(appdata, "Cursor", "User", "mcp.json")
+		}
+
+	case HostWindsurf:
+		switch runtime.GOOS {
+		case "darwin":
+			return filepath.Join(home, "Library", "Application Support", "Windsurf", "User", "mcp.json")
+		case "linux":
+			xdg := os.Getenv("XDG_CONFIG_HOME")
+			if xdg == "" {
+				xdg = filepath.Join(home, ".config")
+			}
+			return filepath.Join(xdg, "Windsurf", "User", "mcp.json")
+		case "windows":
+			appdata := os.Getenv("APPDATA")
+			if appdata == "" {
+				appdata = filepath.Join(home, "AppData", "Roaming")
+			}
+			return filepath.Join(appdata, "Windsurf", "User", "mcp.json")
+		}
+	}
+	return ""
+}
+
+// hostLabel returns a human-readable name for the host.
+func hostLabel(h MCPHostID) string {
+	switch h {
+	case HostClaude:
+		return "Claude Code"
+	case HostCursor:
+		return "Cursor"
+	case HostWindsurf:
+		return "Windsurf"
+	}
+	return string(h)
+}
+
+// ── MCP JSON config shape ─────────────────────────────────────────────────────
+//
+// All three hosts use a compatible mcpServers / mcp.servers envelope. We
+// target the Claude Code shape (mcpServers) since Cursor and Windsurf also
+// accept it via their compatibility mode. If the file already contains
+// the alternate shape we preserve it.
+
+// mcpServerEntry is the per-server definition inside any host's MCP config.
+type mcpServerEntry struct {
+	Command string   `json:"command"`
+	Args    []string `json:"args"`
+}
+
+// readMCPConfig reads and parses the host's MCP config file. Returns a nil
+// map and no error when the file does not exist.
+func readMCPConfig(path string) (map[string]any, error) {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	var out map[string]any
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, fmt.Errorf("parse %s: %w", path, err)
+	}
+	return out, nil
+}
+
+// writeMCPConfig atomically writes cfg to path, creating parent directories.
+// The original file is backed up to <path>.bak before overwriting.
+func writeMCPConfig(path string, cfg map[string]any) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	// Backup original.
+	if _, err := os.Stat(path); err == nil {
+		if err2 := copyFile(path, path+".bak"); err2 != nil {
+			return fmt.Errorf("backup: %w", err2)
+		}
+	}
+	b, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, b, 0o644); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+func copyFile(src, dst string) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+	_, err = io.Copy(out, in)
+	return err
+}
+
+// mcpServersMap extracts or creates the mcpServers sub-object from a config
+// map, normalising both "mcpServers" (Claude Code) and "mcp.servers" (Cursor/
+// Windsurf) shapes. Returns the servers map and a setter that writes it back.
+func mcpServersMap(cfg map[string]any) (servers map[string]any, commit func()) {
+	// Prefer "mcpServers" (Claude Code canonical form).
+	if raw, ok := cfg["mcpServers"]; ok {
+		if m, ok := raw.(map[string]any); ok {
+			return m, func() { cfg["mcpServers"] = m }
+		}
+	}
+	// Try "mcp" → "servers" (Cursor/Windsurf).
+	if raw, ok := cfg["mcp"]; ok {
+		if mcpObj, ok := raw.(map[string]any); ok {
+			if srvRaw, ok := mcpObj["servers"]; ok {
+				if m, ok := srvRaw.(map[string]any); ok {
+					return m, func() { mcpObj["servers"] = m; cfg["mcp"] = mcpObj }
+				}
+			}
+		}
+	}
+	// Neither present — create mcpServers.
+	m := map[string]any{}
+	return m, func() { cfg["mcpServers"] = m }
+}
+
+// detectState inspects a loaded config map (nil = file not found) and returns
+// the installation state for the archigraph entry together with any current args.
+func detectState(cfg map[string]any) (MCPInstallState, []string) {
+	if cfg == nil {
+		return StateHostAbsent, nil
+	}
+	servers, _ := mcpServersMap(cfg)
+	raw, ok := servers["archigraph"]
+	if !ok {
+		return StateNotInstalled, nil
+	}
+	// Marshal/unmarshal to convert map[string]any → mcpServerEntry.
+	b, _ := json.Marshal(raw)
+	var entry mcpServerEntry
+	if err := json.Unmarshal(b, &entry); err != nil {
+		return StatePartial, nil
+	}
+	if entry.Command != "archigraph" {
+		return StatePartial, entry.Args
+	}
+	// Check that "mcp" is among the args.
+	hasMCP := false
+	for _, a := range entry.Args {
+		if a == "mcp" {
+			hasMCP = true
+			break
+		}
+	}
+	if !hasMCP {
+		return StatePartial, entry.Args
+	}
+	return StateInstalled, entry.Args
+}
+
+// ── Handler: GET /api/mcp-setup/hosts ────────────────────────────────────────
+
+// boundPort returns the TCP port the server is listening on, or 0 if the
+// listener has not been set (e.g. during unit tests).
+func (s *Server) boundPort() int {
+	if s.listener == nil {
+		return 0
+	}
+	_, portStr, err := net.SplitHostPort(s.listener.Addr().String())
+	if err != nil {
+		return 0
+	}
+	p, _ := strconv.Atoi(portStr)
+	return p
+}
+
+func (s *Server) handleMCPSetupHosts(w http.ResponseWriter, _ *http.Request) {
+	port := s.boundPort()
+	hosts := []MCPHostID{HostClaude, HostCursor, HostWindsurf}
+	infos := make([]MCPHostInfo, 0, len(hosts))
+
+	for _, h := range hosts {
+		info := MCPHostInfo{
+			ID:    h,
+			Label: hostLabel(h),
+		}
+		path := configPathFor(h)
+		info.ConfigPath = path
+		if path == "" {
+			info.State = StateHostAbsent
+			info.Error = "unsupported OS for this host"
+			infos = append(infos, info)
+			continue
+		}
+		_, statErr := os.Stat(path)
+		info.Exists = statErr == nil
+
+		cfg, err := readMCPConfig(path)
+		if err != nil {
+			info.State = StatePartial
+			info.Error = err.Error()
+		} else {
+			info.State, info.CurrentArgs = detectState(cfg)
+		}
+		infos = append(infos, info)
+	}
+
+	writeJSON(w, http.StatusOK, mcpHostsReply{
+		Hosts:     infos,
+		MCPPort:   port,
+		ServerArg: "archigraph",
+	})
+}
+
+// ── Handler: POST /api/mcp-setup/install?host=X ──────────────────────────────
+
+func (s *Server) handleMCPSetupInstall(w http.ResponseWriter, r *http.Request) {
+	host, ok := parseHostParam(w, r)
+	if !ok {
+		return
+	}
+	path := configPathFor(host)
+	if path == "" {
+		writeErr(w, http.StatusBadRequest, "host not supported on this OS")
+		return
+	}
+
+	cfg, err := readMCPConfig(path)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "read config: "+err.Error())
+		return
+	}
+	if cfg == nil {
+		cfg = map[string]any{}
+	}
+
+	servers, commit := mcpServersMap(cfg)
+	servers["archigraph"] = mcpServerEntry{
+		Command: "archigraph",
+		Args:    []string{"mcp"},
+	}
+	commit()
+
+	if err := writeMCPConfig(path, cfg); err != nil {
+		writeErr(w, http.StatusInternalServerError, "write config: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpActionReply{
+		OK:      true,
+		Message: fmt.Sprintf("archigraph MCP entry installed in %s", path),
+	})
+}
+
+// ── Handler: POST /api/mcp-setup/uninstall?host=X ────────────────────────────
+
+func (s *Server) handleMCPSetupUninstall(w http.ResponseWriter, r *http.Request) {
+	host, ok := parseHostParam(w, r)
+	if !ok {
+		return
+	}
+	path := configPathFor(host)
+	if path == "" {
+		writeErr(w, http.StatusBadRequest, "host not supported on this OS")
+		return
+	}
+
+	cfg, err := readMCPConfig(path)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "read config: "+err.Error())
+		return
+	}
+	if cfg == nil {
+		// Nothing to uninstall.
+		writeJSON(w, http.StatusOK, mcpActionReply{OK: true, Message: "config not found — nothing to remove"})
+		return
+	}
+
+	servers, commit := mcpServersMap(cfg)
+	if _, exists := servers["archigraph"]; !exists {
+		writeJSON(w, http.StatusOK, mcpActionReply{OK: true, Message: "archigraph entry not present"})
+		return
+	}
+	delete(servers, "archigraph")
+	commit()
+
+	if err := writeMCPConfig(path, cfg); err != nil {
+		writeErr(w, http.StatusInternalServerError, "write config: "+err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpActionReply{
+		OK:      true,
+		Message: fmt.Sprintf("archigraph MCP entry removed from %s", path),
+	})
+}
+
+// ── Handler: POST /api/mcp-setup/verify?host=X ───────────────────────────────
+//
+// Sends a lightweight JSON-RPC initialize request to the MCP server on
+// localhost and reports success or failure + latency.
+
+func (s *Server) handleMCPSetupVerify(w http.ResponseWriter, r *http.Request) {
+	_, ok := parseHostParam(w, r)
+	if !ok {
+		return
+	}
+
+	port := s.boundPort()
+	url := fmt.Sprintf("http://127.0.0.1:%d/mcp", port)
+
+	// We use a minimal MCP initialize probe — a JSON body that any compliant
+	// server will respond to with 200 or a recognisable error.
+	probe := map[string]any{
+		"jsonrpc": "2.0",
+		"id":      1,
+		"method":  "initialize",
+		"params": map[string]any{
+			"protocolVersion": "2024-11-05",
+			"capabilities":    map[string]any{},
+			"clientInfo":      map[string]any{"name": "archigraph-setup-wizard", "version": "1"},
+		},
+	}
+	body, _ := json.Marshal(probe)
+
+	client := &http.Client{Timeout: 5 * time.Second}
+	start := time.Now()
+	resp, err := client.Post(url, "application/json", bytes.NewReader(body))
+	latencyMs := time.Since(start).Milliseconds()
+
+	if err != nil {
+		// If the MCP endpoint is not exposed over HTTP (it may be stdio-only),
+		// fall back to a simple health check on the dashboard port.
+		url2 := fmt.Sprintf("http://127.0.0.1:%d/api/info", port)
+		start2 := time.Now()
+		resp2, err2 := client.Get(url2)
+		latencyMs = time.Since(start2).Milliseconds()
+		if err2 != nil {
+			writeJSON(w, http.StatusOK, mcpActionReply{
+				OK:        false,
+				Message:   fmt.Sprintf("MCP server unreachable: %v", err),
+				LatencyMs: &latencyMs,
+			})
+			return
+		}
+		resp2.Body.Close()
+		writeJSON(w, http.StatusOK, mcpActionReply{
+			OK:        true,
+			Message:   fmt.Sprintf("daemon reachable on port %d (MCP over stdio — no HTTP probe)", port),
+			LatencyMs: &latencyMs,
+		})
+		return
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
+		writeJSON(w, http.StatusOK, mcpActionReply{
+			OK:        true,
+			Message:   fmt.Sprintf("MCP server responded %d in %dms", resp.StatusCode, latencyMs),
+			LatencyMs: &latencyMs,
+		})
+		return
+	}
+	writeJSON(w, http.StatusOK, mcpActionReply{
+		OK:        false,
+		Message:   fmt.Sprintf("MCP server returned status %d", resp.StatusCode),
+		LatencyMs: &latencyMs,
+	})
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+func parseHostParam(w http.ResponseWriter, r *http.Request) (MCPHostID, bool) {
+	h := strings.TrimSpace(r.URL.Query().Get("host"))
+	switch MCPHostID(h) {
+	case HostClaude, HostCursor, HostWindsurf:
+		return MCPHostID(h), true
+	}
+	writeErr(w, http.StatusBadRequest, fmt.Sprintf("unknown host %q; valid: claude, cursor, windsurf", h))
+	return "", false
+}

--- a/internal/dashboard/handlers_mcp_setup_test.go
+++ b/internal/dashboard/handlers_mcp_setup_test.go
@@ -1,0 +1,246 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// newMCPSetupTestServer returns a *Server suitable for MCP setup handler tests.
+func newMCPSetupTestServer(t *testing.T) *Server {
+	t.Helper()
+	s, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return s
+}
+
+// writeTempMCPConfig writes a JSON config to a temp file and returns the path.
+func writeTempMCPConfig(t *testing.T, content map[string]any) string {
+	t.Helper()
+	tmp := t.TempDir()
+	path := filepath.Join(tmp, "mcp.json")
+	b, _ := json.MarshalIndent(content, "", "  ")
+	if err := os.WriteFile(path, b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// ── detectState ───────────────────────────────────────────────────────────────
+
+func TestDetectState_NilConfig(t *testing.T) {
+	state, args := detectState(nil)
+	if state != StateHostAbsent {
+		t.Errorf("expected host_absent, got %q", state)
+	}
+	if len(args) != 0 {
+		t.Errorf("expected no args, got %v", args)
+	}
+}
+
+func TestDetectState_NoEntry(t *testing.T) {
+	cfg := map[string]any{"mcpServers": map[string]any{"other-tool": map[string]any{}}}
+	state, _ := detectState(cfg)
+	if state != StateNotInstalled {
+		t.Errorf("expected not_installed, got %q", state)
+	}
+}
+
+func TestDetectState_ValidEntry(t *testing.T) {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"archigraph": map[string]any{
+				"command": "archigraph",
+				"args":    []any{"mcp"},
+			},
+		},
+	}
+	state, args := detectState(cfg)
+	if state != StateInstalled {
+		t.Errorf("expected installed, got %q", state)
+	}
+	if len(args) == 0 || args[0] != "mcp" {
+		t.Errorf("expected args=[mcp], got %v", args)
+	}
+}
+
+func TestDetectState_WrongCommand(t *testing.T) {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"archigraph": map[string]any{
+				"command": "wrong",
+				"args":    []any{"mcp"},
+			},
+		},
+	}
+	state, _ := detectState(cfg)
+	if state != StatePartial {
+		t.Errorf("expected partial, got %q", state)
+	}
+}
+
+func TestDetectState_MissingMCPArg(t *testing.T) {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{
+			"archigraph": map[string]any{
+				"command": "archigraph",
+				"args":    []any{"serve"},
+			},
+		},
+	}
+	state, _ := detectState(cfg)
+	if state != StatePartial {
+		t.Errorf("expected partial, got %q", state)
+	}
+}
+
+// ── writeMCPConfig + readMCPConfig round-trip ─────────────────────────────────
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	in := map[string]any{
+		"mcpServers": map[string]any{
+			"archigraph": map[string]any{"command": "archigraph", "args": []any{"mcp"}},
+		},
+	}
+	if err := writeMCPConfig(path, in); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	out, err := readMCPConfig(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	b1, _ := json.Marshal(in)
+	b2, _ := json.Marshal(out)
+	if string(b1) != string(b2) {
+		t.Errorf("round-trip mismatch:\n got  %s\n want %s", b2, b1)
+	}
+}
+
+func TestWriteCreatesBackup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "mcp.json")
+
+	original := map[string]any{"mcpServers": map[string]any{}}
+	if err := writeMCPConfig(path, original); err != nil {
+		t.Fatal(err)
+	}
+	updated := map[string]any{"mcpServers": map[string]any{"archigraph": "x"}}
+	if err := writeMCPConfig(path, updated); err != nil {
+		t.Fatal(err)
+	}
+	// backup should exist
+	if _, err := os.Stat(path + ".bak"); err != nil {
+		t.Errorf("backup not created: %v", err)
+	}
+}
+
+// ── HTTP handlers ─────────────────────────────────────────────────────────────
+
+func TestHandleMCPSetupHosts(t *testing.T) {
+	s := newMCPSetupTestServer(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/mcp-setup/hosts", nil)
+	s.handleMCPSetupHosts(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rr.Code)
+	}
+	var reply mcpHostsReply
+	if err := json.NewDecoder(rr.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(reply.Hosts) != 3 {
+		t.Errorf("expected 3 hosts, got %d", len(reply.Hosts))
+	}
+	if reply.ServerArg != "archigraph" {
+		t.Errorf("expected server_arg=archigraph, got %q", reply.ServerArg)
+	}
+}
+
+func TestHandleMCPSetupInstallUninstall(t *testing.T) {
+	s := newMCPSetupTestServer(t)
+
+	// Redirect the config path to a temp dir by monkey-patching via env.
+	// We can't call the real configPathFor without home dir manipulation,
+	// so we test the logic via the exported helper functions directly and
+	// only hit the HTTP layer for the error paths here.
+
+	// --- bad host param ---
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-setup/install?host=unknown", nil)
+	s.handleMCPSetupInstall(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("bad host: expected 400, got %d", rr.Code)
+	}
+
+	rr2 := httptest.NewRecorder()
+	req2 := httptest.NewRequest(http.MethodPost, "/api/mcp-setup/uninstall?host=bad", nil)
+	s.handleMCPSetupUninstall(rr2, req2)
+	if rr2.Code != http.StatusBadRequest {
+		t.Errorf("bad host uninstall: expected 400, got %d", rr2.Code)
+	}
+}
+
+func TestHandleMCPSetupVerifyBadHost(t *testing.T) {
+	s := newMCPSetupTestServer(t)
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, "/api/mcp-setup/verify?host=nope", nil)
+	s.handleMCPSetupVerify(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", rr.Code)
+	}
+}
+
+// ── mcpServersMap ─────────────────────────────────────────────────────────────
+
+func TestMCPServersMapClaudeShape(t *testing.T) {
+	cfg := map[string]any{
+		"mcpServers": map[string]any{"x": 1},
+	}
+	m, commit := mcpServersMap(cfg)
+	m["archigraph"] = "new"
+	commit()
+	servers := cfg["mcpServers"].(map[string]any)
+	if _, ok := servers["archigraph"]; !ok {
+		t.Error("archigraph key not committed to mcpServers")
+	}
+}
+
+func TestMCPServersMapCursorShape(t *testing.T) {
+	cfg := map[string]any{
+		"mcp": map[string]any{
+			"servers": map[string]any{"y": 2},
+		},
+	}
+	m, commit := mcpServersMap(cfg)
+	m["archigraph"] = "new"
+	commit()
+	mcp := cfg["mcp"].(map[string]any)
+	servers := mcp["servers"].(map[string]any)
+	if _, ok := servers["archigraph"]; !ok {
+		t.Error("archigraph key not committed to mcp.servers")
+	}
+}
+
+func TestMCPServersMapEmpty(t *testing.T) {
+	cfg := map[string]any{}
+	m, commit := mcpServersMap(cfg)
+	m["archigraph"] = "new"
+	commit()
+	servers, ok := cfg["mcpServers"]
+	if !ok {
+		t.Fatal("mcpServers not created")
+	}
+	sm := servers.(map[string]any)
+	if _, ok := sm["archigraph"]; !ok {
+		t.Error("archigraph not present after commit")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -337,6 +337,12 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/onboard/detect-monorepo", s.handleOnboardDetectMonorepo)
 	mux.HandleFunc("POST /api/onboard/create-group", s.handleOnboardCreateGroup)
 
+	// MCP Setup Wizard (#1247) — one-click install / uninstall / verify
+	mux.HandleFunc("GET /api/mcp-setup/hosts", s.handleMCPSetupHosts)
+	mux.HandleFunc("POST /api/mcp-setup/install", s.handleMCPSetupInstall)
+	mux.HandleFunc("POST /api/mcp-setup/uninstall", s.handleMCPSetupUninstall)
+	mux.HandleFunc("POST /api/mcp-setup/verify", s.handleMCPSetupVerify)
+
 	return s.withAuth(mux)
 }
 


### PR DESCRIPTION
## Summary

Closes #1247

Adds an MCP Setup Wizard to the dashboard that removes the manual config copy-paste step. Users can now install, uninstall, and verify the archigraph MCP entry in Claude Code, Cursor, or Windsurf with a single button click.

- **Backend** — 4 new REST endpoints in \`internal/dashboard/handlers_mcp_setup.go\`
- **Frontend** — new \`/mcp-setup\` route (Surface 13) with per-host cards, state chips, and one-click actions
- **Config detection** — reads the correct path per host and OS (macOS/Linux/Windows)
- **Safety** — backup written to \`<path>.bak\` before any mutation; no write without explicit click

## Closes / Refs
- \`Closes #1247\`

## Testing
- [x] All tests pass: \`go test ./internal/dashboard/...\` (13 new tests, 0 failures)
- [x] TypeScript: zero errors in new files
- [x] No regression in existing tests

## Notes
Backup is created before every write. Idempotent install (merges, does not duplicate). Verify falls back to \`/api/info\` health check when MCP is stdio-only.