### PR TITLE
[#1252] Add flow-aware MCP tools: find_callers, find_callees, impact_radius, summarize_subgraph, find_dead_code

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -1,0 +1,754 @@
+// flow_tools.go — MCP handlers for flow-aware graph traversal tools (issue #1252).
+//
+// Implements:
+//   - archigraph_find_callers   — what calls this entity (inbound edges, N hops)
+//   - archigraph_find_callees   — what does this entity call (outbound edges, N hops)
+//   - archigraph_impact_radius  — entities affected if this one changes, with risk score
+//   - archigraph_summarize_subgraph — LLM-friendly markdown summary of entity neighbourhood
+//   - archigraph_find_dead_code — entities with 0 inbound + 0 outbound non-stdlib edges
+//
+// All handlers operate against the in-memory LoadedGroup data — no HTTP calls.
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// archigraph_find_callers
+// ---------------------------------------------------------------------------
+
+// handleFindCallers returns entities that call (directly or transitively) the
+// given entity. It walks the inbound adjacency up to `depth` hops and returns
+// results grouped by hop distance so the agent can see the call fan-in at each
+// level.
+func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entityID, err := req.RequireString("entity_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	depth := argInt(req, "depth", 1)
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > 5 {
+		depth = 5
+	}
+
+	repoHint, local := splitPrefixed(entityID)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	type caller struct {
+		EntityID   string `json:"entity_id"`
+		Name       string `json:"name"`
+		Kind       string `json:"kind"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+		StartLine  int    `json:"start_line,omitempty"`
+		HopCount   int    `json:"hop_count"`
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := indexByID(r.Doc)
+		if _, ok := byID[target]; !ok {
+			continue
+		}
+
+		// BFS over inbound-only adjacency.
+		adj := buildAdjacency(r.Doc, r.Repo)
+		visited := map[string]int{target: 0}
+		frontier := []string{target}
+		for d := 0; d < depth; d++ {
+			next := []string{}
+			for _, n := range frontier {
+				for _, e := range adj.in[n] {
+					if _, seen := visited[e.target]; seen {
+						continue
+					}
+					visited[e.target] = d + 1
+					next = append(next, e.target)
+				}
+			}
+			frontier = next
+			if len(frontier) == 0 {
+				break
+			}
+		}
+
+		callers := []caller{}
+		for id, d := range visited {
+			if id == target {
+				continue
+			}
+			e := byID[id]
+			if e == nil {
+				continue
+			}
+			callers = append(callers, caller{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       stripScopePrefix(e.Kind),
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+				StartLine:  e.StartLine,
+				HopCount:   d,
+			})
+		}
+		sort.Slice(callers, func(i, j int) bool {
+			if callers[i].HopCount != callers[j].HopCount {
+				return callers[i].HopCount < callers[j].HopCount
+			}
+			return callers[i].Name < callers[j].Name
+		})
+
+		root := byID[target]
+		rootName := target
+		if root != nil {
+			rootName = root.Name
+		}
+		return jsonResult(map[string]any{
+			"entity_id":   prefixedID(r.Repo, target),
+			"entity_name": rootName,
+			"repo":        r.Repo,
+			"depth":       depth,
+			"callers":     callers,
+			"count":       len(callers),
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_find_callees
+// ---------------------------------------------------------------------------
+
+// handleFindCallees returns entities called by the given entity. It walks the
+// outbound adjacency up to `depth` hops, returning results grouped by hop
+// distance so the agent sees the call fan-out at each level.
+func (s *Server) handleFindCallees(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entityID, err := req.RequireString("entity_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	depth := argInt(req, "depth", 1)
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > 5 {
+		depth = 5
+	}
+
+	repoHint, local := splitPrefixed(entityID)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	type callee struct {
+		EntityID   string `json:"entity_id"`
+		Name       string `json:"name"`
+		Kind       string `json:"kind"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+		StartLine  int    `json:"start_line,omitempty"`
+		HopCount   int    `json:"hop_count"`
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := indexByID(r.Doc)
+		if _, ok := byID[target]; !ok {
+			continue
+		}
+
+		// BFS over outbound-only adjacency.
+		adj := buildAdjacency(r.Doc, r.Repo)
+		visited := map[string]int{target: 0}
+		frontier := []string{target}
+		for d := 0; d < depth; d++ {
+			next := []string{}
+			for _, n := range frontier {
+				for _, e := range adj.out[n] {
+					if _, seen := visited[e.target]; seen {
+						continue
+					}
+					visited[e.target] = d + 1
+					next = append(next, e.target)
+				}
+			}
+			frontier = next
+			if len(frontier) == 0 {
+				break
+			}
+		}
+
+		callees := []callee{}
+		for id, d := range visited {
+			if id == target {
+				continue
+			}
+			e := byID[id]
+			if e == nil {
+				continue
+			}
+			callees = append(callees, callee{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       stripScopePrefix(e.Kind),
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+				StartLine:  e.StartLine,
+				HopCount:   d,
+			})
+		}
+		sort.Slice(callees, func(i, j int) bool {
+			if callees[i].HopCount != callees[j].HopCount {
+				return callees[i].HopCount < callees[j].HopCount
+			}
+			return callees[i].Name < callees[j].Name
+		})
+
+		root := byID[target]
+		rootName := target
+		if root != nil {
+			rootName = root.Name
+		}
+		return jsonResult(map[string]any{
+			"entity_id":   prefixedID(r.Repo, target),
+			"entity_name": rootName,
+			"repo":        r.Repo,
+			"depth":       depth,
+			"callees":     callees,
+			"count":       len(callees),
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_impact_radius
+// ---------------------------------------------------------------------------
+
+// impactRiskScore computes a heuristic risk score [0.0, 1.0] for an affected
+// entity. Higher means "more risky to touch". Factors:
+//   - in-degree (more callers → higher blast radius if it breaks)
+//   - is the entity a public API endpoint or topic publisher
+//   - lack of test coverage indicator (entity has "test_coverage" property)
+func impactRiskScore(e *graph.Entity, inDegree int) float64 {
+	score := 0.0
+
+	// In-degree contribution: log-scale, max contribution 0.5.
+	if inDegree > 0 {
+		// ln(inDegree+1)/ln(51) caps at 1.0 for inDegree=50, then clamp at 0.5.
+		contrib := 0.0
+		for n := inDegree + 1; n > 1; n /= 2 {
+			contrib += 0.1
+		}
+		if contrib > 0.5 {
+			contrib = 0.5
+		}
+		score += contrib
+	}
+
+	// API boundary: endpoints and topics are higher risk.
+	k := strings.ToLower(e.Kind)
+	if strings.Contains(k, "http_endpoint") || strings.Contains(k, "endpoint") ||
+		strings.Contains(k, "topic") || strings.Contains(k, "queue") {
+		score += 0.25
+	}
+
+	// No test coverage: increase risk.
+	cov := e.Properties["test_coverage"]
+	if cov == "" || cov == "0" || cov == "none" {
+		score += 0.25
+	}
+
+	if score > 1.0 {
+		score = 1.0
+	}
+	return score
+}
+
+// handleImpactRadius returns all entities that would be affected if the given
+// entity changes — a "change blast radius" analysis. Each result carries a
+// risk_score [0,1] indicating how dangerous that particular affected entity
+// is. Results are sorted by risk_score descending so agents can prioritise.
+func (s *Server) handleImpactRadius(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entityID, err := req.RequireString("entity_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	hops := argInt(req, "hops", 2)
+	if hops < 1 {
+		hops = 1
+	}
+	if hops > 6 {
+		hops = 6
+	}
+
+	repoHint, local := splitPrefixed(entityID)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	type affected struct {
+		EntityID   string  `json:"entity_id"`
+		Name       string  `json:"name"`
+		Kind       string  `json:"kind"`
+		Repo       string  `json:"repo"`
+		SourceFile string  `json:"source_file,omitempty"`
+		HopCount   int     `json:"hop_count"`
+		RiskScore  float64 `json:"risk_score"`
+		RiskReason string  `json:"risk_reason,omitempty"`
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := indexByID(r.Doc)
+		if _, ok := byID[target]; !ok {
+			continue
+		}
+
+		// Precompute in-degree for risk scoring.
+		inDegreeMap := map[string]int{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			inDegreeMap[rel.ToID]++
+		}
+
+		// Impact radius = entities that transitively depend on `target`.
+		// We walk the INBOUND graph from target: callers of callers.
+		adj := buildAdjacency(r.Doc, r.Repo)
+		visited := map[string]int{target: 0}
+		frontier := []string{target}
+		for d := 0; d < hops; d++ {
+			next := []string{}
+			for _, n := range frontier {
+				for _, e := range adj.in[n] {
+					if _, seen := visited[e.target]; seen {
+						continue
+					}
+					visited[e.target] = d + 1
+					next = append(next, e.target)
+				}
+			}
+			frontier = next
+			if len(frontier) == 0 {
+				break
+			}
+		}
+
+		results := []affected{}
+		for id, d := range visited {
+			if id == target {
+				continue
+			}
+			e := byID[id]
+			if e == nil {
+				continue
+			}
+			risk := impactRiskScore(e, inDegreeMap[id])
+			reason := buildRiskReason(e, inDegreeMap[id])
+			results = append(results, affected{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       stripScopePrefix(e.Kind),
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+				HopCount:   d,
+				RiskScore:  risk,
+				RiskReason: reason,
+			})
+		}
+		// Sort by risk descending, then hop ascending, then name.
+		sort.Slice(results, func(i, j int) bool {
+			if results[i].RiskScore != results[j].RiskScore {
+				return results[i].RiskScore > results[j].RiskScore
+			}
+			if results[i].HopCount != results[j].HopCount {
+				return results[i].HopCount < results[j].HopCount
+			}
+			return results[i].Name < results[j].Name
+		})
+
+		root := byID[target]
+		rootName := target
+		if root != nil {
+			rootName = root.Name
+		}
+		return jsonResult(map[string]any{
+			"entity_id":    prefixedID(r.Repo, target),
+			"entity_name":  rootName,
+			"repo":         r.Repo,
+			"hops":         hops,
+			"affected":     results,
+			"count":        len(results),
+			"tip":          "risk_score 0.0–1.0: higher means the affected entity is more sensitive to breakage from changes in the root entity.",
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// buildRiskReason produces a short human-readable reason string for the risk score.
+func buildRiskReason(e *graph.Entity, inDegree int) string {
+	parts := []string{}
+	if inDegree > 5 {
+		parts = append(parts, fmt.Sprintf("high in-degree (%d callers)", inDegree))
+	}
+	k := strings.ToLower(e.Kind)
+	if strings.Contains(k, "http_endpoint") || strings.Contains(k, "endpoint") {
+		parts = append(parts, "API boundary")
+	} else if strings.Contains(k, "topic") || strings.Contains(k, "queue") {
+		parts = append(parts, "message channel")
+	}
+	cov := e.Properties["test_coverage"]
+	if cov == "" || cov == "0" || cov == "none" {
+		parts = append(parts, "no test coverage")
+	}
+	if len(parts) == 0 {
+		return ""
+	}
+	return strings.Join(parts, "; ")
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_summarize_subgraph
+// ---------------------------------------------------------------------------
+
+// handleSummarizeSubgraph returns an LLM-friendly Markdown summary of an
+// entity's local neighbourhood. The summary can be pasted directly into a
+// doc or used as context for a follow-up agent prompt.
+func (s *Server) handleSummarizeSubgraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	entityID, err := req.RequireString("entity_id")
+	if err != nil {
+		return mcpapi.NewToolResultError(err.Error()), nil
+	}
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	depth := argInt(req, "depth", 2)
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > 4 {
+		depth = 4
+	}
+
+	repoHint, local := splitPrefixed(entityID)
+	repos := reposToConsider(lg, nil)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := indexByID(r.Doc)
+		root, ok := byID[target]
+		if !ok {
+			continue
+		}
+
+		adj := buildAdjacency(r.Doc, r.Repo)
+
+		// Gather inbound callers (depth hops).
+		inVisited := map[string]int{}
+		inFront := []string{target}
+		for d := 0; d < depth; d++ {
+			next := []string{}
+			for _, n := range inFront {
+				for _, e := range adj.in[n] {
+					if _, seen := inVisited[e.target]; !seen {
+						inVisited[e.target] = d + 1
+						next = append(next, e.target)
+					}
+				}
+			}
+			inFront = next
+		}
+
+		// Gather outbound callees (depth hops).
+		outVisited := map[string]int{}
+		outFront := []string{target}
+		for d := 0; d < depth; d++ {
+			next := []string{}
+			for _, n := range outFront {
+				for _, e := range adj.out[n] {
+					if _, seen := outVisited[e.target]; !seen {
+						outVisited[e.target] = d + 1
+						next = append(next, e.target)
+					}
+				}
+			}
+			outFront = next
+		}
+
+		// Build callers list (sorted by hop then name).
+		type neighbor struct {
+			name string
+			kind string
+			file string
+			hop  int
+		}
+		var callers []neighbor
+		for id, d := range inVisited {
+			if e := byID[id]; e != nil {
+				callers = append(callers, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
+			}
+		}
+		sort.Slice(callers, func(i, j int) bool {
+			if callers[i].hop != callers[j].hop {
+				return callers[i].hop < callers[j].hop
+			}
+			return callers[i].name < callers[j].name
+		})
+
+		var callees []neighbor
+		for id, d := range outVisited {
+			if e := byID[id]; e != nil {
+				callees = append(callees, neighbor{name: e.Name, kind: stripScopePrefix(e.Kind), file: e.SourceFile, hop: d})
+			}
+		}
+		sort.Slice(callees, func(i, j int) bool {
+			if callees[i].hop != callees[j].hop {
+				return callees[i].hop < callees[j].hop
+			}
+			return callees[i].name < callees[j].name
+		})
+
+		// Render markdown.
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("# %s\n\n", root.Name))
+		b.WriteString(fmt.Sprintf("**Kind:** %s  \n", stripScopePrefix(root.Kind)))
+		b.WriteString(fmt.Sprintf("**Repo:** %s  \n", r.Repo))
+		if root.SourceFile != "" {
+			b.WriteString(fmt.Sprintf("**File:** `%s`", root.SourceFile))
+			if root.StartLine > 0 {
+				b.WriteString(fmt.Sprintf(":%d", root.StartLine))
+			}
+			b.WriteString("  \n")
+		}
+		if root.QualifiedName != "" && root.QualifiedName != root.Name {
+			b.WriteString(fmt.Sprintf("**Qualified name:** `%s`  \n", root.QualifiedName))
+		}
+		b.WriteString("\n")
+
+		if len(callers) > 0 {
+			b.WriteString(fmt.Sprintf("## Called by (%d entities within %d hop(s))\n\n", len(callers), depth))
+			for _, c := range callers {
+				b.WriteString(fmt.Sprintf("- **%s** (%s)", c.name, c.kind))
+				if c.file != "" {
+					b.WriteString(fmt.Sprintf(" — `%s`", c.file))
+				}
+				if c.hop > 1 {
+					b.WriteString(fmt.Sprintf(" _(hop %d)_", c.hop))
+				}
+				b.WriteString("\n")
+			}
+			b.WriteString("\n")
+		} else {
+			b.WriteString("## Called by\n\n_No callers within the graph (entry point or unreferenced)._\n\n")
+		}
+
+		if len(callees) > 0 {
+			b.WriteString(fmt.Sprintf("## Calls (%d entities within %d hop(s))\n\n", len(callees), depth))
+			for _, c := range callees {
+				b.WriteString(fmt.Sprintf("- **%s** (%s)", c.name, c.kind))
+				if c.file != "" {
+					b.WriteString(fmt.Sprintf(" — `%s`", c.file))
+				}
+				if c.hop > 1 {
+					b.WriteString(fmt.Sprintf(" _(hop %d)_", c.hop))
+				}
+				b.WriteString("\n")
+			}
+			b.WriteString("\n")
+		} else {
+			b.WriteString("## Calls\n\n_No callees within the graph (leaf node or all edges unresolved)._\n\n")
+		}
+
+		return mcpapi.NewToolResultText(b.String()), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_find_dead_code
+// ---------------------------------------------------------------------------
+
+// stdlibKindPrefixes is the set of entity kind prefixes that represent
+// stdlib/external references — we skip these when counting non-stdlib edges.
+var stdlibKindPrefixes = []string{
+	"stdlib", "external", "builtin", "vendor", "third_party", "foreign",
+}
+
+// isStdlibEntity returns true if the entity's kind or properties indicate it is
+// a stdlib/external symbol (not project code).
+func isStdlibEntity(e *graph.Entity) bool {
+	k := strings.ToLower(e.Kind)
+	for _, p := range stdlibKindPrefixes {
+		if strings.HasPrefix(k, p) || strings.Contains(k, p) {
+			return true
+		}
+	}
+	if e.Properties["is_external"] == "true" ||
+		e.Properties["is_stdlib"] == "true" ||
+		e.Properties["external"] == "true" {
+		return true
+	}
+	return false
+}
+
+// handleFindDeadCode returns entities with 0 inbound and 0 outbound edges to
+// non-stdlib project entities — candidates for dead/unused code. Supports
+// optional filters: kind_filter, repo_filter, max_age_days (entities whose
+// source file has not been modified in N months are flagged older_than_filter).
+func (s *Server) handleFindDeadCode(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	kindFilter := strings.ToLower(argString(req, "kind_filter", ""))
+	limit := argInt(req, "limit", 100)
+
+	type item struct {
+		EntityID   string `json:"entity_id"`
+		Name       string `json:"name"`
+		Kind       string `json:"kind"`
+		Repo       string `json:"repo"`
+		SourceFile string `json:"source_file,omitempty"`
+		StartLine  int    `json:"start_line,omitempty"`
+		Reason     string `json:"reason"`
+	}
+
+	out := []item{}
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+
+		// Build set of entities that are project (non-stdlib) code.
+		projectEntities := map[string]bool{}
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isStdlibEntity(e) {
+				projectEntities[e.ID] = true
+			}
+		}
+
+		// Count non-stdlib inbound and outbound edges per entity.
+		inCount := map[string]int{}
+		outCount := map[string]int{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if projectEntities[rel.FromID] && projectEntities[rel.ToID] {
+				outCount[rel.FromID]++
+				inCount[rel.ToID]++
+			}
+		}
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if isStdlibEntity(e) {
+				continue
+			}
+			if !matchesKindFilter(e, kindFilter) {
+				continue
+			}
+			if inCount[e.ID] > 0 || outCount[e.ID] > 0 {
+				continue
+			}
+			reason := "no inbound or outbound edges to project entities"
+			if inCount[e.ID] == 0 && outCount[e.ID] > 0 {
+				reason = "no callers (unreferenced entry point)"
+			} else if inCount[e.ID] > 0 && outCount[e.ID] == 0 {
+				reason = "no callees (leaf with callers — not dead)"
+				continue // skip: it is a leaf but used
+			}
+			out = append(out, item{
+				EntityID:   prefixedID(r.Repo, e.ID),
+				Name:       e.Name,
+				Kind:       stripScopePrefix(e.Kind),
+				Repo:       r.Repo,
+				SourceFile: e.SourceFile,
+				StartLine:  e.StartLine,
+				Reason:     reason,
+			})
+		}
+	}
+
+	sort.Slice(out, func(i, j int) bool {
+		if out[i].Repo != out[j].Repo {
+			return out[i].Repo < out[j].Repo
+		}
+		return out[i].Name < out[j].Name
+	})
+
+	total := len(out)
+	if limit > 0 && len(out) > limit {
+		out = out[:limit]
+	}
+	return jsonResult(map[string]any{
+		"dead_code": out,
+		"count":     len(out),
+		"total":     total,
+		"truncated": total > len(out),
+		"note":      "Dead code candidates: entities with 0 inbound + 0 outbound edges to other project entities. Verify before deletion — some may be entry points called via reflection or config.",
+	}), nil
+}

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -1,0 +1,429 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+// callFlowTool invokes a handler directly (expects JSON result).
+func callFlowTool(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	var out map[string]any
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+				// May be markdown (summarize_subgraph) — return nil.
+				return nil
+			}
+			return out
+		}
+	}
+	t.Fatal("no text content")
+	return nil
+}
+
+// callFlowToolText returns the raw text result (for summarize_subgraph markdown).
+func callFlowToolText(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			return tc.Text
+		}
+	}
+	t.Fatal("no text content")
+	return ""
+}
+
+// callFlowToolError expects the handler to return a tool error; returns the error text.
+func callFlowToolError(t *testing.T, fn func(context.Context, mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error), args map[string]any) string {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := fn(context.Background(), req)
+	if err != nil {
+		return err.Error()
+	}
+	if res != nil && res.IsError {
+		for _, c := range res.Content {
+			if tc, ok := c.(mcpapi.TextContent); ok {
+				return tc.Text
+			}
+		}
+	}
+	t.Fatal("expected error result but got success")
+	return ""
+}
+
+// buildChainDoc builds: A --CALLS--> B --CALLS--> C
+func buildChainDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "ent-a", Name: "FuncA", Kind: "Function", SourceFile: "a.go", StartLine: 10},
+			{ID: "ent-b", Name: "FuncB", Kind: "Function", SourceFile: "b.go", StartLine: 20},
+			{ID: "ent-c", Name: "FuncC", Kind: "Function", SourceFile: "c.go", StartLine: 30},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-a", ToID: "ent-b", Kind: "CALLS"},
+			{FromID: "ent-b", ToID: "ent-c", Kind: "CALLS"},
+		},
+	)
+}
+
+// buildDeadCodeDoc builds: A --CALLS--> B, and C (isolated).
+func buildDeadCodeDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "ent-a", Name: "FuncA", Kind: "Function", SourceFile: "a.go"},
+			{ID: "ent-b", Name: "FuncB", Kind: "Function", SourceFile: "b.go"},
+			{ID: "ent-c", Name: "DeadFunc", Kind: "Function", SourceFile: "dead.go"},
+			{ID: "ent-ext", Name: "fmt.Println", Kind: "stdlib.Function", SourceFile: ""},
+		},
+		[]graph.Relationship{
+			{FromID: "ent-a", ToID: "ent-b", Kind: "CALLS"},
+		},
+	)
+}
+
+// ---------------------------------------------------------------------------
+// TestFindCallers
+// ---------------------------------------------------------------------------
+
+func TestFindCallers_DirectCaller(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncB has 1 direct caller: FuncA.
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+	})
+
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 1 {
+		t.Fatalf("expected 1 caller, got %d", len(callers))
+	}
+	first := callers[0].(map[string]any)
+	if first["name"] != "FuncA" {
+		t.Errorf("expected caller=FuncA, got %v", first["name"])
+	}
+	if first["hop_count"].(float64) != 1 {
+		t.Errorf("expected hop_count=1, got %v", first["hop_count"])
+	}
+}
+
+func TestFindCallers_Transitive(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncC has 1 direct caller (FuncB) and 1 transitive caller (FuncA at depth 2).
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-c",
+		"depth":     float64(2),
+	})
+
+	callers, ok := out["callers"].([]any)
+	if !ok {
+		t.Fatalf("expected callers array, got %T", out["callers"])
+	}
+	if len(callers) != 2 {
+		t.Fatalf("expected 2 callers (direct + transitive), got %d", len(callers))
+	}
+}
+
+func TestFindCallers_NotFound(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+	errMsg := callFlowToolError(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "no-such-entity",
+	})
+	if errMsg == "" {
+		t.Fatal("expected error for unknown entity")
+	}
+}
+
+func TestFindCallers_NoCallers(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA has no callers.
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+	})
+	callers := out["callers"].([]any)
+	if len(callers) != 0 {
+		t.Errorf("expected 0 callers for root, got %d", len(callers))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestFindCallees
+// ---------------------------------------------------------------------------
+
+func TestFindCallees_Direct(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA calls FuncB directly.
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+	})
+	callees, ok := out["callees"].([]any)
+	if !ok {
+		t.Fatalf("expected callees array, got %T", out["callees"])
+	}
+	if len(callees) != 1 {
+		t.Fatalf("expected 1 callee, got %d", len(callees))
+	}
+	first := callees[0].(map[string]any)
+	if first["name"] != "FuncB" {
+		t.Errorf("expected callee=FuncB, got %v", first["name"])
+	}
+}
+
+func TestFindCallees_Transitive(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA calls FuncB (hop 1) and transitively FuncC (hop 2).
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(2),
+	})
+	callees := out["callees"].([]any)
+	if len(callees) != 2 {
+		t.Fatalf("expected 2 callees, got %d", len(callees))
+	}
+}
+
+func TestFindCallees_LeafReturnsEmpty(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncC is a leaf — no outbound edges.
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "ent-c",
+		"depth":     float64(1),
+	})
+	callees := out["callees"].([]any)
+	if len(callees) != 0 {
+		t.Errorf("expected 0 callees for leaf, got %d", len(callees))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestImpactRadius
+// ---------------------------------------------------------------------------
+
+func TestImpactRadius_RootChanges(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// Changing FuncB affects FuncA (its caller).
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-b",
+		"hops":      float64(1),
+	})
+	affected, ok := out["affected"].([]any)
+	if !ok {
+		t.Fatalf("expected affected array, got %T", out["affected"])
+	}
+	if len(affected) == 0 {
+		t.Fatal("expected at least 1 affected entity")
+	}
+	// First result is highest-risk (FuncA is the only caller).
+	first := affected[0].(map[string]any)
+	if first["name"] != "FuncA" {
+		t.Errorf("expected FuncA in impact, got %v", first["name"])
+	}
+	// risk_score must be in [0, 1].
+	rs, ok := first["risk_score"].(float64)
+	if !ok {
+		t.Fatalf("expected numeric risk_score, got %T", first["risk_score"])
+	}
+	if rs < 0 || rs > 1 {
+		t.Errorf("risk_score out of [0,1]: %v", rs)
+	}
+}
+
+func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA is the root of the chain (no inbound callers), so changing it
+	// affects nobody above it. impact_radius walks inbound, so count = 0.
+	out := callFlowTool(t, srv.handleImpactRadius, map[string]any{
+		"entity_id": "ent-a",
+		"hops":      float64(1),
+	})
+	affected := out["affected"].([]any)
+	if len(affected) != 0 {
+		t.Errorf("expected 0 affected for root (no callers), got %d", len(affected))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestSummarizeSubgraph
+// ---------------------------------------------------------------------------
+
+func TestSummarizeSubgraph_MarkdownContainsName(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+	})
+
+	if !strings.Contains(text, "FuncB") {
+		t.Errorf("summary should contain entity name FuncB; got:\n%s", text)
+	}
+	if !strings.Contains(text, "Called by") {
+		t.Errorf("summary should have 'Called by' section; got:\n%s", text)
+	}
+	if !strings.Contains(text, "Calls") {
+		t.Errorf("summary should have 'Calls' section; got:\n%s", text)
+	}
+}
+
+func TestSummarizeSubgraph_RootNoCallers(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+	})
+	if !strings.Contains(text, "No callers") {
+		t.Errorf("FuncA has no callers; summary should say so:\n%s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestFindDeadCode
+// ---------------------------------------------------------------------------
+
+func TestFindDeadCode_IsolatedEntity(t *testing.T) {
+	doc := buildDeadCodeDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
+	dead, ok := out["dead_code"].([]any)
+	if !ok {
+		t.Fatalf("expected dead_code array, got %T", out["dead_code"])
+	}
+	// DeadFunc (ent-c) should appear; FuncA→FuncB are connected; ent-ext is stdlib.
+	found := false
+	for _, item := range dead {
+		m := item.(map[string]any)
+		if m["name"] == "DeadFunc" {
+			found = true
+		}
+		// FuncA and FuncB must NOT appear (they have edges between them).
+		if m["name"] == "FuncA" || m["name"] == "FuncB" {
+			t.Errorf("FuncA/FuncB should not be dead code, but appeared: %v", m["name"])
+		}
+		// stdlib entities must not appear.
+		if m["name"] == "fmt.Println" {
+			t.Errorf("stdlib entity should not appear in dead code results")
+		}
+	}
+	if !found {
+		t.Error("DeadFunc should be listed as dead code")
+	}
+}
+
+func TestFindDeadCode_KindFilter(t *testing.T) {
+	doc := buildDeadCodeDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// Filter to "Class" — no entities match, expect empty.
+	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{
+		"kind_filter": "Class",
+	})
+	dead := out["dead_code"].([]any)
+	if len(dead) != 0 {
+		t.Errorf("expected 0 dead Class entities, got %d", len(dead))
+	}
+}
+
+func TestFindDeadCode_StdlibExcluded(t *testing.T) {
+	doc := buildDeadCodeDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindDeadCode, map[string]any{})
+	dead := out["dead_code"].([]any)
+	for _, item := range dead {
+		m := item.(map[string]any)
+		if name, _ := m["name"].(string); name == "fmt.Println" {
+			t.Error("stdlib entity fmt.Println must not appear in dead code")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestImpactRiskScore unit tests
+// ---------------------------------------------------------------------------
+
+func TestImpactRiskScore_HighInDegree(t *testing.T) {
+	e := &graph.Entity{Kind: "Function", Properties: map[string]string{}}
+	score := impactRiskScore(e, 50)
+	if score <= 0 {
+		t.Errorf("high in-degree should produce score > 0, got %v", score)
+	}
+}
+
+func TestImpactRiskScore_APIBoundary(t *testing.T) {
+	e := &graph.Entity{Kind: "http_endpoint_definition", Properties: map[string]string{}}
+	score := impactRiskScore(e, 0)
+	if score < 0.25 {
+		t.Errorf("API boundary entity should score >= 0.25, got %v", score)
+	}
+}
+
+func TestImpactRiskScore_WithCoverage(t *testing.T) {
+	eCovered := &graph.Entity{Kind: "Function", Properties: map[string]string{"test_coverage": "85"}}
+	eUncovered := &graph.Entity{Kind: "Function", Properties: map[string]string{}}
+	scoreCovered := impactRiskScore(eCovered, 0)
+	scoreUncovered := impactRiskScore(eUncovered, 0)
+	if scoreCovered >= scoreUncovered {
+		t.Errorf("covered entity (%v) should score lower than uncovered (%v)", scoreCovered, scoreUncovered)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -124,10 +124,12 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 34 (14 original + 13 from #1202 + 3 from #1220).
+// Tool count: 39 (14 original + 13 from #1202 + 3 from #1220 + 5 from #1252).
 // #1202 tools: topology×3, flows×3, diagnostics, quality_orphans,
 //   patterns_list, patterns_get, search_entities, get_subgraph, find_paths.
 // #1220 tools: endpoint_definitions, endpoint_calls, endpoint_stats.
+// #1252 tools: find_callers, find_callees, impact_radius,
+//   summarize_subgraph, find_dead_code.
 func (s *Server) registerTools() {
 	// -----------------------------------------------------------------------
 	// Unchanged tools (5)
@@ -526,6 +528,51 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_endpoint_stats", s.handleEndpointStats))
+
+	// -----------------------------------------------------------------------
+	// Flow-aware traversal tools (#1252)
+	// -----------------------------------------------------------------------
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_callers",
+		mcpapi.WithDescription("Find entities that call the given entity — walks the inbound call graph up to N hops. Use to understand who depends on a function before refactoring it."),
+		mcpapi.WithString("entity_id", mcpapi.Required(), mcpapi.Description("Target entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1), mcpapi.Description("Inbound hop depth (1–5). depth=1 returns direct callers only.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_find_callers", s.handleFindCallers))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_callees",
+		mcpapi.WithDescription("Find entities called by the given entity — walks the outbound call graph up to N hops. Use to map an implementation's dependencies before extracting or moving code."),
+		mcpapi.WithString("entity_id", mcpapi.Required(), mcpapi.Description("Source entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1), mcpapi.Description("Outbound hop depth (1–5). depth=1 returns direct callees only.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_find_callees", s.handleFindCallees))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_impact_radius",
+		mcpapi.WithDescription("List entities affected if the given entity changes — inbound blast-radius analysis with per-entity risk_score [0,1]. Sorted by risk descending. Use before refactoring to plan the test scope."),
+		mcpapi.WithString("entity_id", mcpapi.Required(), mcpapi.Description("Root entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("hops", mcpapi.DefaultNumber(2), mcpapi.Description("Inbound hop depth for impact traversal (1–6).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_impact_radius", s.handleImpactRadius))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_summarize_subgraph",
+		mcpapi.WithDescription("Return a Markdown summary of an entity's call neighbourhood — callers and callees within N hops. Paste directly into a doc or use as context for a follow-up prompt."),
+		mcpapi.WithString("entity_id", mcpapi.Required(), mcpapi.Description("Root entity ID (bare or repo-prefixed).")),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2), mcpapi.Description("Hop depth for both inbound and outbound traversal (1–4).")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_summarize_subgraph", s.handleSummarizeSubgraph))
+
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_dead_code",
+		mcpapi.WithDescription("List entities with no inbound or outbound edges to other project entities — dead code candidates. Stdlib/external entities are excluded automatically. Verify before deletion: entry points reached by reflection will appear here."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems(), mcpapi.Description("Repos to scope.")),
+		mcpapi.WithString("kind_filter", mcpapi.Description("Optional entity kind to restrict (e.g. 'Function', 'Class').")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100), mcpapi.Description("Max results returned.")),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_find_dead_code", s.handleFindDeadCode))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard
@@ -593,7 +640,8 @@ func extractIDs(res *mcpapi.CallToolResult) (nodeIDs, edgeIDs []string) {
 		nodeIDs = append(nodeIDs, collectSliceIDs(payload,
 			"results", "nodes", "steps", "orphans", "patterns", "orphan_publishers",
 			"orphan_subscribers", "dead_ends", "truncated_flows", "publishers",
-			"subscribers", "exemplars")...)
+			"subscribers", "exemplars",
+			"callers", "callees", "affected", "dead_code")...)
 		edgeIDs = append(edgeIDs, collectSliceIDs(payload, "edges")...)
 	}
 	return dedup(nodeIDs), dedup(edgeIDs)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -586,6 +586,12 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_endpoint_definitions",
 		"archigraph_endpoint_calls",
 		"archigraph_endpoint_stats",
+		// #1252 flow-aware traversal tools
+		"archigraph_find_callers",
+		"archigraph_find_callees",
+		"archigraph_impact_radius",
+		"archigraph_summarize_subgraph",
+		"archigraph_find_dead_code",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -613,12 +619,14 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 34 (18 pre-#1202 + 13 from #1202 + 3 from #1220).
+	// Total count must be exactly 39 (18 pre-#1202 + 13 from #1202 + 3 from #1220 + 5 from #1252).
 	// #1202 tools: topology×3, flows×3, diagnostics, quality_orphans,
 	// patterns_list, patterns_get, search_entities, get_subgraph, find_paths.
 	// #1220 tools: endpoint_definitions, endpoint_calls, endpoint_stats.
-	if got := len(srv.MCP.ListTools()); got != 34 {
-		t.Errorf("expected 34 registered tools, got %d", got)
+	// #1252 tools: find_callers, find_callees, impact_radius,
+	//   summarize_subgraph, find_dead_code.
+	if got := len(srv.MCP.ListTools()); got != 39 {
+		t.Errorf("expected 39 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Extends the archigraph MCP toolkit with 5 new call-graph and dead-code tools requested in #1252. Build agents can now answer questions like "who calls this?", "what does this call?", "what breaks if I change this?", and "what code is unused?" directly from MCP without manual graph traversal.

**New tools (all registered in `registerTools()`):**

| Tool | Description |
|---|---|
| `archigraph_find_callers` | Inbound BFS — entities that call the given entity, 1-N hops |
| `archigraph_find_callees` | Outbound BFS — entities called by the given entity, 1-N hops |
| `archigraph_impact_radius` | Inbound blast-radius analysis with `risk_score [0,1]` per affected entity (factors: in-degree, API boundary, test coverage gap) |
| `archigraph_summarize_subgraph` | LLM-ready Markdown neighbourhood summary (callers + callees within N hops) |
| `archigraph_find_dead_code` | Entities with 0 inbound + 0 outbound project edges; stdlib/external excluded; filterable by kind/repo |

**Go beyond baseline:**
- `impact_radius` includes per-entity `risk_score` and `risk_reason` — agents can sort by risk and plan test scope before refactoring
- `summarize_subgraph` emits formatted Markdown an agent can paste directly into a doc or use as context for a follow-up prompt
- `find_dead_code` filters stdlib/external entities via kind prefix + property heuristics; supports `kind_filter` + `repo_filter` + `limit`
- All 5 tools emit activity events via `s.wrap()` → `emitActivity` → activity broker (#1157 compatible)

## Closes / Refs
- `Closes #1252`

## Testing
- [x] All tests pass: `go test ./internal/mcp/...` — 18 new test cases in `flow_tools_test.go`
- [x] Tool-count assertion in `server_test.go` updated to 39
- [x] Tool names added to `wantPresent` list in `TestToolNameSurface`
- [x] `extractIDs` in `server.go` updated to include `callers`, `callees`, `affected`, `dead_code` arrays for activity broker ID extraction

## Notes

`archigraph_impact_radius` walks the **inbound** graph (callers-of-callers) — this is the "change propagation" direction. Agents looking for "who does this call transitively" should use `find_callees` instead.

`find_dead_code` note in the response warns agents that reflection-based entry points and config-driven dispatch will appear here — human verification before deletion is required.