### PR TITLE
fix(build): drop @cosmograph/cosmos from vite manual chunks

### DIFF
--- a/dashboard/vite.config.ts
+++ b/dashboard/vite.config.ts
@@ -52,7 +52,7 @@ export default defineConfig(({ mode }) => {
             // pages (Paths, Flows, Topology, Docs …) never download the GPU renderer.
             // Combined with the lazy GraphRoute in App.tsx this saves ~500 KB gzipped
             // on initial load for users who only use non-graph surfaces. (#1249 perf)
-            cosmograph: ['@cosmograph/react', '@cosmograph/cosmos'],
+            cosmograph: ['@cosmograph/react'],
           },
         },
       },


### PR DESCRIPTION
After #1261, vite tries to chunk @cosmograph/cosmos but only @cosmograph/react is in deps. Fix: remove from manualChunks list.