### PR TITLE
[#1258] Audit log surface — track all state-changing operations

### DIFF
--- a/dashboard/src/App.tsx
+++ b/dashboard/src/App.tsx
@@ -24,6 +24,7 @@ import { UpdateRoute } from '@/routes/update'
 import { SettingsRoute } from '@/routes/settings'
 import { QualityRoute } from '@/routes/quality'
 import { MCPActivityRoute } from '@/routes/mcp-activity'
+import { AuditLogRoute } from '@/routes/audit-log'
 import { OnboardRoute } from '@/routes/onboard'
 import { MCPSetupRoute } from '@/routes/mcp-setup'
 import { HelpRoute } from '@/routes/help'
@@ -134,10 +135,13 @@ const router = createBrowserRouter([
       // Surface 13 — Web onboarding wizard (#1239)
       { path: 'onboard', element: <OnboardRoute /> },
 
-      // Surface 14 — MCP Setup Wizard (#1247)
+      // Surface 14 — Audit Log (#1258)
+      { path: 'audit-log', element: <AuditLogRoute /> },
+
+      // Surface 15 — MCP Setup Wizard (#1247)
       { path: 'mcp-setup', element: <MCPSetupRoute /> },
 
-      // Surface 15 — Help & About (#1253)
+      // Surface 16 — Help & About (#1253)
       { path: 'help', element: <HelpRoute /> },
     ],
   },

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -1756,3 +1756,46 @@ export async function onboardCreateGroup(
     body: JSON.stringify({ group_name: groupName, repos }),
   })
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit Log (#1258)
+// ─────────────────────────────────────────────────────────────────────────────
+
+import type { AuditEntry, AuditHistoryResponse } from '@/types/api'
+
+/** GET /api/audit?limit=N&filter=op — last N audit entries, newest-first. */
+export async function fetchAuditHistory(
+  limit = 100,
+  filter?: string,
+): Promise<AuditHistoryResponse> {
+  const params = new URLSearchParams({ limit: String(limit) })
+  if (filter) params.set('filter', filter)
+  return apiFetch<AuditHistoryResponse>(`/api/audit?${params}`)
+}
+
+/**
+ * Subscribe to /api/audit/stream (SSE) for real-time audit entries.
+ * Returns a cleanup function — call it on component unmount.
+ */
+export function subscribeAuditStream(
+  onEvent: (entry: AuditEntry) => void,
+  onError?: () => void,
+): () => void {
+  const es = new EventSource('/api/audit/stream')
+
+  es.addEventListener('audit', (e: MessageEvent) => {
+    try {
+      const entry = JSON.parse(e.data) as AuditEntry
+      onEvent(entry)
+    } catch {
+      // ignore parse errors
+    }
+  })
+
+  es.onerror = () => {
+    onError?.()
+    es.close()
+  }
+
+  return () => es.close()
+}

--- a/dashboard/src/components/layout/NavMenu.tsx
+++ b/dashboard/src/components/layout/NavMenu.tsx
@@ -20,7 +20,7 @@ import { useRef } from 'react'
 import {
   Network, Workflow, Radio, Globe, BookOpen, Clock,
   Stethoscope, Sparkles, Server, RefreshCw, ChevronDown,
-  BarChart2, Settings, Activity, Zap, HelpCircle,
+  BarChart2, Settings, Activity, ClipboardList, Zap, HelpCircle,
 } from 'lucide-react'
 import {
   prefetchSurface,
@@ -70,7 +70,8 @@ export function operateItems(group: string): NavEntry[] {
     { label: 'Patterns',      to: `/patterns/${group}`,  icon: <Sparkles    className="w-4 h-4" /> },
     { label: 'System',        to: '/system',            icon: <Server      className="w-4 h-4" /> },
     { label: 'Update',        to: '/update',            icon: <RefreshCw   className="w-4 h-4" /> },
-    { label: 'MCP Activity',  to: '/mcp-activity',      icon: <Activity    className="w-4 h-4" /> },
+    { label: 'MCP Activity',  to: '/mcp-activity',      icon: <Activity       className="w-4 h-4" /> },
+    { label: 'Audit Log',     to: '/audit-log',         icon: <ClipboardList  className="w-4 h-4" /> },
     { label: 'MCP Setup',     to: '/mcp-setup',         icon: <Zap         className="w-4 h-4" /> },
     { label: 'Settings',      to: '/settings',          icon: <Settings    className="w-4 h-4" /> },
     { label: 'Help & About',  to: '/help',              icon: <HelpCircle  className="w-4 h-4" /> },

--- a/dashboard/src/routes/audit-log.tsx
+++ b/dashboard/src/routes/audit-log.tsx
@@ -1,0 +1,558 @@
+/**
+ * Audit Log — /audit-log
+ *
+ * Surface 14: Timeline of all state-changing operations (rebuild, reset,
+ * settings update, pattern edit, enrichment trigger…).
+ *
+ * Backend:
+ *   GET  /api/audit?limit=N&filter=op  — history from ~/.archigraph/audit.jsonl
+ *   GET  /api/audit/stream             — SSE live tail
+ *   GET  /api/audit/export?format=csv  — download
+ *
+ * Closes #1258.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
+import { useQuery } from '@tanstack/react-query'
+import {
+  fetchAuditHistory,
+  subscribeAuditStream,
+} from '@/api/client'
+import type { AuditEntry } from '@/types/api'
+import {
+  ClipboardList, Download, RefreshCw, X, Search,
+  CheckCircle2, XCircle, Clock, ChevronDown, ChevronRight,
+} from 'lucide-react'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fmtTimestamp(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString(undefined, {
+      month: 'short', day: 'numeric',
+      hour: '2-digit', minute: '2-digit', second: '2-digit',
+    })
+  } catch {
+    return ts
+  }
+}
+
+function relTime(ts: string): string {
+  try {
+    const diff = Date.now() - new Date(ts).getTime()
+    if (diff < 5_000) return 'just now'
+    if (diff < 60_000) return `${Math.floor(diff / 1000)}s ago`
+    if (diff < 3_600_000) return `${Math.floor(diff / 60_000)}m ago`
+    if (diff < 86_400_000) return `${Math.floor(diff / 3_600_000)}h ago`
+    return `${Math.floor(diff / 86_400_000)}d ago`
+  } catch {
+    return ''
+  }
+}
+
+/** Label for an operation — converts snake_case to Title Case words. */
+function opLabel(op: string): string {
+  return op.replace(/_/g, ' ').replace(/\b\w/g, (c) => c.toUpperCase())
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Filter chip
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface ChipProps {
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+function FilterChip({ label, active, onClick }: ChipProps) {
+  const base = 'inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full border text-xs font-medium transition-colors cursor-pointer select-none'
+  const cls = active
+    ? `${base} bg-violet-100 dark:bg-violet-950/50 text-violet-700 dark:text-violet-300 border-violet-300 dark:border-violet-700`
+    : `${base} bg-transparent text-slate-500 dark:text-slate-400 border-slate-200 dark:border-slate-700 hover:border-slate-400 dark:hover:border-slate-500`
+  return (
+    <button type="button" className={cls} onClick={onClick} aria-pressed={active}>
+      {label}
+    </button>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Stats sidebar
+// ─────────────────────────────────────────────────────────────────────────────
+
+function OpStats({ entries }: { entries: AuditEntry[] }) {
+  const stats = useMemo(() => {
+    const counts: Record<string, { total: number; errors: number }> = {}
+    for (const e of entries) {
+      if (!counts[e.operation]) counts[e.operation] = { total: 0, errors: 0 }
+      counts[e.operation].total++
+      if (e.result === 'error') counts[e.operation].errors++
+    }
+    return Object.entries(counts)
+      .map(([op, v]) => ({ op, ...v }))
+      .sort((a, b) => b.total - a.total)
+      .slice(0, 8)
+  }, [entries])
+
+  if (stats.length === 0) return null
+  const maxTotal = stats[0]?.total ?? 1
+
+  return (
+    <section
+      className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4"
+      data-testid="op-stats-panel"
+    >
+      <h2 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-3">
+        Operation counts
+      </h2>
+      <div className="space-y-2">
+        {stats.map(({ op, total, errors }) => (
+          <div key={op}>
+            <div className="flex items-center justify-between text-xs mb-0.5">
+              <span className="font-mono text-slate-700 dark:text-slate-300 truncate max-w-[60%]" title={op}>
+                {opLabel(op)}
+              </span>
+              <span className="text-slate-400 tabular-nums">
+                {total}{errors > 0 ? ` · ${errors} err` : ''}
+              </span>
+            </div>
+            <div className="h-1 rounded-full bg-slate-100 dark:bg-slate-800 overflow-hidden">
+              <div
+                className={[
+                  'h-full rounded-full transition-all',
+                  errors > 0
+                    ? 'bg-rose-400 dark:bg-rose-500'
+                    : 'bg-violet-400 dark:bg-violet-500',
+                ].join(' ')}
+                style={{ width: `${(total / maxTotal) * 100}%` }}
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Entry row
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface EntryRowProps {
+  entry: AuditEntry
+  isNew?: boolean
+}
+
+function EntryRow({ entry, isNew }: EntryRowProps) {
+  const [expanded, setExpanded] = useState(false)
+  const isError = entry.result === 'error'
+  const hasParams = entry.params && Object.keys(entry.params).length > 0
+
+  return (
+    <div
+      className={[
+        'rounded-lg border transition-all',
+        isNew
+          ? 'border-violet-300 dark:border-violet-600 bg-violet-50/60 dark:bg-violet-950/30'
+          : isError
+          ? 'border-rose-200 dark:border-rose-800 bg-rose-50/40 dark:bg-rose-950/20'
+          : 'border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900',
+      ].join(' ')}
+      data-testid="audit-row"
+    >
+      {/* Main row */}
+      <div className="flex items-start gap-3 px-4 py-3">
+        {/* Status icon */}
+        <div className="mt-0.5 flex-shrink-0">
+          {isError
+            ? <XCircle className="w-4 h-4 text-rose-500" aria-label="error" />
+            : <CheckCircle2 className="w-4 h-4 text-emerald-500" aria-label="ok" />
+          }
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center gap-2 flex-wrap">
+            <span
+              className="text-sm font-mono font-medium text-slate-900 dark:text-slate-100"
+              data-testid="audit-op"
+            >
+              {entry.operation}
+            </span>
+            {entry.target && (
+              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400">
+                {entry.target}
+              </span>
+            )}
+            {isError && entry.error && (
+              <span className="text-xs text-rose-600 dark:text-rose-400 truncate max-w-xs" title={entry.error}>
+                {entry.error}
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Timestamp + expand */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <time
+            className="text-xs text-slate-400 tabular-nums"
+            dateTime={entry.timestamp}
+            title={fmtTimestamp(entry.timestamp)}
+          >
+            {relTime(entry.timestamp)}
+          </time>
+          {(hasParams || isError) && (
+            <button
+              type="button"
+              aria-label={expanded ? 'Collapse details' : 'Expand details'}
+              className="p-0.5 rounded text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              onClick={() => setExpanded((v) => !v)}
+            >
+              {expanded ? <ChevronDown className="w-3.5 h-3.5" /> : <ChevronRight className="w-3.5 h-3.5" />}
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Expanded detail */}
+      {expanded && (
+        <div
+          className="px-4 pb-3 border-t border-slate-100 dark:border-slate-800 pt-3 space-y-2"
+          data-testid="audit-row-detail"
+        >
+          <div className="flex items-center gap-4 text-xs text-slate-500 dark:text-slate-400">
+            <Clock className="w-3.5 h-3.5" />
+            <span>{fmtTimestamp(entry.timestamp)}</span>
+          </div>
+          {hasParams && (
+            <div>
+              <p className="text-xs font-semibold text-slate-500 dark:text-slate-400 mb-1">Parameters</p>
+              <pre className="text-xs font-mono bg-slate-50 dark:bg-slate-950 rounded p-2 overflow-x-auto text-slate-700 dark:text-slate-300">
+                {JSON.stringify(entry.params, null, 2)}
+              </pre>
+            </div>
+          )}
+          {isError && entry.error && (
+            <div>
+              <p className="text-xs font-semibold text-rose-500 dark:text-rose-400 mb-1">Error</p>
+              <p className="text-xs font-mono text-rose-600 dark:text-rose-400">{entry.error}</p>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Main route
+// ─────────────────────────────────────────────────────────────────────────────
+
+export function AuditLogRoute() {
+  const [liveEntries, setLiveEntries] = useState<AuditEntry[]>([])
+  const [newTimestamps, setNewTimestamps] = useState<Set<string>>(new Set())
+  const [liveTail, setLiveTail] = useState(true)
+  const [filterOp, setFilterOp] = useState<string | null>(null)
+  const [filterResult, setFilterResult] = useState<'ok' | 'error' | null>(null)
+  const [searchQ, setSearchQ] = useState('')
+  const cleanupRef = useRef<(() => void) | null>(null)
+
+  // ── History query ──────────────────────────────────────────────────────────
+  const { data: historyData, isLoading, refetch } = useQuery({
+    queryKey: ['audit-history'],
+    queryFn: () => fetchAuditHistory(200),
+    staleTime: 0,
+  })
+
+  const historyEntries: AuditEntry[] = historyData?.entries ?? []
+
+  // ── Merge history + live (deduplicate by timestamp+operation) ─────────────
+  const allEntries = useMemo(() => {
+    const combined = [...historyEntries]
+    for (const e of liveEntries) {
+      const dup = combined.some(
+        (h) => h.timestamp === e.timestamp && h.operation === e.operation,
+      )
+      if (!dup) combined.push(e)
+    }
+    // newest-first (timestamps are RFC3339 strings, lexicographic sort works)
+    return combined.sort((a, b) => b.timestamp.localeCompare(a.timestamp))
+  }, [historyEntries, liveEntries])
+
+  // ── Live SSE subscription ──────────────────────────────────────────────────
+  useEffect(() => {
+    if (!liveTail) {
+      cleanupRef.current?.()
+      cleanupRef.current = null
+      return
+    }
+    const cleanup = subscribeAuditStream(
+      (entry) => {
+        setLiveEntries((prev) => [entry, ...prev])
+        setNewTimestamps((prev) => {
+          const next = new Set(prev)
+          next.add(entry.timestamp)
+          setTimeout(
+            () => setNewTimestamps((s) => { const n = new Set(s); n.delete(entry.timestamp); return n }),
+            2_000,
+          )
+          return next
+        })
+      },
+    )
+    cleanupRef.current = cleanup
+    return () => { cleanup(); cleanupRef.current = null }
+  }, [liveTail])
+
+  // ── Derived operation list for filter chips ────────────────────────────────
+  const operations = useMemo(() => {
+    const s = new Set(allEntries.map((e) => e.operation))
+    return [...s].sort()
+  }, [allEntries])
+
+  // ── Filtered entries ───────────────────────────────────────────────────────
+  const filteredEntries = useMemo(() => {
+    let entries = allEntries
+    if (filterOp) entries = entries.filter((e) => e.operation === filterOp)
+    if (filterResult) entries = entries.filter((e) => e.result === filterResult)
+    if (searchQ.trim()) {
+      const q = searchQ.toLowerCase()
+      entries = entries.filter((e) =>
+        e.operation.includes(q) ||
+        (e.target ?? '').toLowerCase().includes(q) ||
+        (e.error ?? '').toLowerCase().includes(q),
+      )
+    }
+    return entries
+  }, [allEntries, filterOp, filterResult, searchQ])
+
+  // ── Export ─────────────────────────────────────────────────────────────────
+  const handleExportJSON = useCallback(() => {
+    const blob = new Blob([JSON.stringify(filteredEntries, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = `audit-${Date.now()}.json`
+    a.click()
+    URL.revokeObjectURL(url)
+  }, [filteredEntries])
+
+  const handleExportCSV = useCallback(() => {
+    window.open('/api/audit/export?format=csv', '_blank')
+  }, [])
+
+  const clearFilters = () => { setFilterOp(null); setFilterResult(null); setSearchQ('') }
+
+  // ─────────────────────────────────────────────────────────────────────────
+  return (
+    <div className="h-full overflow-y-auto" data-testid="audit-log-page">
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-6 space-y-4">
+
+        {/* ── Header ─────────────────────────────────────────────────────── */}
+        <div className="flex items-center gap-3 flex-wrap">
+          <ClipboardList className="w-5 h-5 text-slate-500 flex-shrink-0" />
+          <h1 className="text-lg font-semibold text-slate-900 dark:text-slate-100">
+            Audit Log
+          </h1>
+          <span className="text-xs text-slate-400 tabular-nums">
+            {filteredEntries.length} event{filteredEntries.length !== 1 ? 's' : ''}
+          </span>
+
+          <div className="ml-auto flex items-center gap-2">
+            {/* Live tail toggle */}
+            <button
+              type="button"
+              onClick={() => setLiveTail((v) => !v)}
+              title={liveTail ? 'Pause live tail' : 'Resume live tail'}
+              className={[
+                'inline-flex items-center gap-1.5 px-2.5 py-1.5 rounded-lg text-xs font-medium transition-colors',
+                liveTail
+                  ? 'bg-emerald-100 dark:bg-emerald-950/50 text-emerald-700 dark:text-emerald-300 border border-emerald-300 dark:border-emerald-700'
+                  : 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-slate-700',
+              ].join(' ')}
+              data-testid="live-tail-toggle"
+            >
+              <span className={`w-1.5 h-1.5 rounded-full flex-shrink-0 ${liveTail ? 'bg-emerald-500 animate-pulse' : 'bg-slate-400'}`} />
+              {liveTail ? 'Live' : 'Paused'}
+            </button>
+
+            {/* Refresh */}
+            <button
+              type="button"
+              onClick={() => refetch()}
+              title="Refresh history"
+              className="p-1.5 rounded text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+              data-testid="refresh-btn"
+            >
+              <RefreshCw className="w-4 h-4" />
+            </button>
+
+            {/* Export */}
+            <div className="relative group">
+              <button
+                type="button"
+                title="Export"
+                className="p-1.5 rounded text-slate-500 hover:text-slate-700 dark:hover:text-slate-300 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors"
+                data-testid="export-btn"
+                onClick={handleExportJSON}
+              >
+                <Download className="w-4 h-4" />
+              </button>
+              {/* CSV alt */}
+              <button
+                type="button"
+                onClick={handleExportCSV}
+                className="hidden group-hover:block absolute right-0 top-8 z-10 px-3 py-1.5 bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-lg shadow-lg text-xs whitespace-nowrap text-slate-700 dark:text-slate-300"
+              >
+                Export as CSV
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* ── Filters row ────────────────────────────────────────────────── */}
+        <div className="flex flex-wrap items-center gap-2">
+          {/* Search */}
+          <div className="relative flex-1 min-w-[160px] max-w-xs">
+            <Search className="absolute left-2.5 top-1/2 -translate-y-1/2 w-3.5 h-3.5 text-slate-400 pointer-events-none" />
+            <input
+              type="text"
+              value={searchQ}
+              onChange={(e) => setSearchQ(e.target.value)}
+              placeholder="Search operation, target, error…"
+              className="w-full pl-8 pr-3 py-1.5 rounded-lg bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 text-sm text-slate-900 dark:text-slate-100 placeholder-slate-400 outline-none focus:ring-2 focus:ring-violet-400/50"
+              data-testid="search-input"
+            />
+            {searchQ && (
+              <button
+                type="button"
+                onClick={() => setSearchQ('')}
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-slate-400 hover:text-slate-600 dark:hover:text-slate-300"
+              >
+                <X className="w-3.5 h-3.5" />
+              </button>
+            )}
+          </div>
+
+          {/* Result filter */}
+          <FilterChip
+            label="Errors only"
+            active={filterResult === 'error'}
+            onClick={() => setFilterResult((v) => v === 'error' ? null : 'error')}
+          />
+
+          {operations.length > 0 && (
+            <span className="text-slate-300 dark:text-slate-700">|</span>
+          )}
+
+          {/* Operation chips */}
+          {operations.map((op) => (
+            <FilterChip
+              key={op}
+              label={opLabel(op)}
+              active={filterOp === op}
+              onClick={() => setFilterOp((v) => v === op ? null : op)}
+            />
+          ))}
+
+          {/* Clear all */}
+          {(filterOp || filterResult || searchQ) && (
+            <button
+              type="button"
+              onClick={clearFilters}
+              className="text-xs text-slate-400 hover:text-slate-600 dark:hover:text-slate-300 flex items-center gap-1"
+              data-testid="clear-filters-btn"
+            >
+              <X className="w-3 h-3" />
+              Clear
+            </button>
+          )}
+        </div>
+
+        {/* ── Main content ───────────────────────────────────────────────── */}
+        <div className="grid grid-cols-1 xl:grid-cols-[1fr_240px] gap-4 items-start">
+
+          {/* Entry list */}
+          <div className="space-y-2" data-testid="audit-list">
+            {isLoading && (
+              <div className="space-y-2">
+                {[...Array(5)].map((_, i) => (
+                  <div key={i} className="h-12 rounded-lg bg-slate-100 dark:bg-slate-800 animate-pulse" />
+                ))}
+              </div>
+            )}
+
+            {!isLoading && filteredEntries.length === 0 && (
+              <div className="flex flex-col items-center justify-center py-16 text-center">
+                <ClipboardList className="w-10 h-10 text-slate-300 dark:text-slate-600 mb-3" />
+                <p className="text-sm font-medium text-slate-500 dark:text-slate-400">
+                  {allEntries.length === 0
+                    ? 'No audit entries yet'
+                    : 'No entries match the current filters'}
+                </p>
+                <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+                  {allEntries.length === 0
+                    ? 'State-changing operations will appear here.'
+                    : 'Try clearing the search or filter chips above.'}
+                </p>
+                {(filterOp || filterResult || searchQ) && (
+                  <button
+                    type="button"
+                    onClick={clearFilters}
+                    className="mt-3 text-xs text-violet-500 hover:text-violet-600 dark:text-violet-400"
+                  >
+                    Clear filters
+                  </button>
+                )}
+              </div>
+            )}
+
+            {!isLoading && filteredEntries.map((entry, idx) => (
+              <EntryRow
+                key={`${entry.timestamp}-${entry.operation}-${idx}`}
+                entry={entry}
+                isNew={newTimestamps.has(entry.timestamp)}
+              />
+            ))}
+          </div>
+
+          {/* Sidebar: stats */}
+          <div className="space-y-4">
+            <OpStats entries={allEntries} />
+
+            {/* Legend */}
+            <div className="rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-4">
+              <h2 className="text-xs font-semibold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-2">
+                Logged operations
+              </h2>
+              <ul className="text-xs text-slate-500 dark:text-slate-400 space-y-1 leading-relaxed">
+                {[
+                  'rebuild / reset',
+                  'cleanup',
+                  'settings_update / reset',
+                  'pattern_update / delete',
+                  'enrichment_trigger',
+                ].map((op) => (
+                  <li key={op} className="font-mono">{op}</li>
+                ))}
+              </ul>
+            </div>
+          </div>
+        </div>
+
+        {/* Live tail footer */}
+        {liveTail && (
+          <div className="flex items-center gap-2 text-xs text-slate-400 pt-2">
+            <Clock className="w-3.5 h-3.5" />
+            <span>Live tail active — new operations appear automatically</span>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -994,3 +994,33 @@ export interface MCPActivityHistoryResponse {
   count: number
   note?: string
 }
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Audit Log (#1258)
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * One audit log entry — mirrors internal/audit.Entry.
+ * Returned by GET /api/audit and streamed via SSE /api/audit/stream.
+ */
+export interface AuditEntry {
+  /** RFC 3339 with milliseconds */
+  timestamp: string
+  /** Short snake_case verb: rebuild, settings_update, pattern_delete, … */
+  operation: string
+  /** Group slug, repo slug, setting key, or other target identifier */
+  target?: string
+  /** Optional structured context (request body fields, job IDs, etc.) */
+  params?: Record<string, unknown>
+  /** "ok" or "error" */
+  result: 'ok' | 'error'
+  /** Error message when result === "error" */
+  error?: string
+}
+
+/** Wire shape of GET /api/audit?limit=N&filter=op */
+export interface AuditHistoryResponse {
+  entries: AuditEntry[]
+  count: number
+  note?: string
+}

--- a/dashboard/tests/e2e/audit-log-surface.spec.ts
+++ b/dashboard/tests/e2e/audit-log-surface.spec.ts
@@ -1,0 +1,130 @@
+/**
+ * E2E: Audit Log surface — headless smoke (#1258)
+ *
+ * Verifies:
+ *   1. /audit-log route loads without JS console errors
+ *   2. Page heading "Audit Log" is present
+ *   3. "Audit Log" entry appears in the Operate nav menu
+ *   4. Filters row (search input) is present
+ *   5. Export button is present
+ *   6. Live tail toggle is present and labelled "Live"
+ *   7. Screenshot captured for VIEW review
+ */
+
+import { test, expect } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:5173'
+const AUDIT_URL = `${BASE_URL}/audit-log`
+const SCREENSHOT_DIR = path.join(__dirname, '..', '..', 'test-results', 'audit-log')
+
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Audit Log surface — #1258', () => {
+  let consoleErrors: string[] = []
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        const text = msg.text()
+        // Ignore network errors expected in CI (no live daemon)
+        if (
+          !text.includes('Failed to load resource') &&
+          !text.includes('ERR_CONNECTION') &&
+          !text.includes('net::ERR')
+        ) {
+          consoleErrors.push(text)
+        }
+      }
+    })
+  })
+
+  test('audit-log route loads without JS errors', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    // Allow time for React to hydrate
+    await page.waitForTimeout(1500)
+    expect(consoleErrors, `JS console errors: ${consoleErrors.join('\n')}`).toHaveLength(0)
+  })
+
+  test('page heading is present', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    await page.getByRole('heading', { level: 1, name: /audit log/i }).waitFor({
+      state: 'visible',
+      timeout: 10_000,
+    })
+  })
+
+  test('audit-log page has data-testid root element', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('audit-log-page')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('search input is present', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    const searchInput = page.getByTestId('search-input')
+    await expect(searchInput).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('live tail toggle is present and shows Live state', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    const toggle = page.getByTestId('live-tail-toggle')
+    await expect(toggle).toBeVisible({ timeout: 10_000 })
+    await expect(toggle).toContainText('Live')
+  })
+
+  test('refresh and export buttons are present', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    await expect(page.getByTestId('refresh-btn')).toBeVisible({ timeout: 10_000 })
+    await expect(page.getByTestId('export-btn')).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('Audit Log appears in Operate nav menu', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+
+    // Open the Operate menu
+    const operateBtn = page.getByTestId('operate-menu')
+    await operateBtn.waitFor({ state: 'visible', timeout: 10_000 })
+    await operateBtn.click()
+
+    const auditItem = page.getByRole('menuitem', { name: /audit log/i })
+    await expect(auditItem).toBeVisible({ timeout: 5_000 })
+  })
+
+  test('empty state renders when no entries exist', async ({ page }) => {
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+
+    // Wait for loading to complete — either audit-list renders or empty state
+    await page.waitForTimeout(2_000)
+
+    const list = page.getByTestId('audit-list')
+    await expect(list).toBeVisible({ timeout: 10_000 })
+  })
+
+  test('screenshot — audit-log light mode', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(1_500)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'audit-log-light.png'),
+      fullPage: true,
+    })
+  })
+
+  test('screenshot — audit-log dark mode', async ({ page }) => {
+    await page.setViewportSize({ width: 1280, height: 900 })
+    await page.emulateMedia({ colorScheme: 'dark' })
+    await page.goto(AUDIT_URL, { waitUntil: 'domcontentloaded' })
+    await page.waitForTimeout(1_500)
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'audit-log-dark.png'),
+      fullPage: true,
+    })
+  })
+})

--- a/internal/audit/broker.go
+++ b/internal/audit/broker.go
@@ -1,0 +1,77 @@
+package audit
+
+import "sync"
+
+const brokerBuffer = 64
+
+type sub struct {
+	ch chan Entry
+}
+
+// Broker fans out audit entries to SSE subscribers in real time.
+// It is wired into the dashboard server and called by the audit.Log
+// wrapper whenever an entry is appended.
+//
+// Publish is non-blocking: if a subscriber's buffer is full the event
+// is dropped rather than blocking the caller.
+type Broker struct {
+	mu   sync.RWMutex
+	subs []*sub
+}
+
+// NewBroker constructs an empty Broker.
+func NewBroker() *Broker {
+	return &Broker{}
+}
+
+// Publish fans e out to every current subscriber.
+func (b *Broker) Publish(e Entry) {
+	b.mu.RLock()
+	targets := make([]*sub, len(b.subs))
+	copy(targets, b.subs)
+	b.mu.RUnlock()
+
+	for _, s := range targets {
+		select {
+		case s.ch <- e:
+		default:
+			// subscriber buffer full — drop
+		}
+	}
+}
+
+// Subscribe returns a receive-only channel that receives every entry
+// published after the call. The caller must invoke the returned cancel
+// function (e.g. on HTTP disconnect) to clean up.
+func (b *Broker) Subscribe() (<-chan Entry, func()) {
+	s := &sub{ch: make(chan Entry, brokerBuffer)}
+
+	b.mu.Lock()
+	b.subs = append(b.subs, s)
+	b.mu.Unlock()
+
+	var once sync.Once
+	cancel := func() {
+		once.Do(func() {
+			b.mu.Lock()
+			defer b.mu.Unlock()
+			for i, cur := range b.subs {
+				if cur == s {
+					b.subs[i] = b.subs[len(b.subs)-1]
+					b.subs[len(b.subs)-1] = nil
+					b.subs = b.subs[:len(b.subs)-1]
+					break
+				}
+			}
+			close(s.ch)
+		})
+	}
+	return s.ch, cancel
+}
+
+// SubscriberCount returns the number of live SSE subscribers.
+func (b *Broker) SubscriberCount() int {
+	b.mu.RLock()
+	defer b.mu.RUnlock()
+	return len(b.subs)
+}

--- a/internal/audit/log.go
+++ b/internal/audit/log.go
@@ -1,0 +1,231 @@
+// Package audit — append-only audit log for Archigraph state-changing operations.
+//
+// Every mutation that changes daemon or registry state (rebuild, reset, settings
+// update, pattern edit, group create/delete, enrichment trigger…) appends one
+// JSON line to ~/.archigraph/audit.jsonl.
+//
+// Schema of each line:
+//
+//	{
+//	  "timestamp":  "2026-05-21T12:34:56.789Z",   // RFC 3339 with ms
+//	  "operation":  "rebuild",                      // short snake_case verb
+//	  "target":     "fixture-a",                    // group / repo / setting key / …
+//	  "params":     { … },                          // optional extra context
+//	  "result":     "ok" | "error",
+//	  "error":      "message"                       // only present when result=="error"
+//	}
+//
+// The file is rotated at 10 MiB (old file renamed to audit.jsonl.1, capping
+// total disk use to ~20 MiB).  All I/O is non-blocking: Append enqueues to
+// an internal channel; a single goroutine drains it.
+package audit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+const (
+	// maxLogBytes is the rotation threshold.
+	maxLogBytes = 10 * 1024 * 1024 // 10 MiB
+
+	// auditLogFile is the base file name inside ~/.archigraph/.
+	auditLogFile = "audit.jsonl"
+
+	// logQueueDepth is the channel buffer size. Overflow events are dropped
+	// rather than blocking the caller.
+	logQueueDepth = 512
+)
+
+// Entry is one audit log record.
+type Entry struct {
+	// Timestamp is the RFC 3339 (with milliseconds) time of the operation.
+	Timestamp string `json:"timestamp"`
+	// Operation is a short snake_case verb, e.g. "rebuild", "settings_update".
+	Operation string `json:"operation"`
+	// Target identifies what was acted upon: group slug, repo slug, setting key, etc.
+	Target string `json:"target,omitempty"`
+	// Params holds optional structured context (request body fields, etc.).
+	Params map[string]any `json:"params,omitempty"`
+	// Result is "ok" or "error".
+	Result string `json:"result"`
+	// Error is the error message when Result == "error".
+	Error string `json:"error,omitempty"`
+}
+
+// Log is a goroutine-safe, non-blocking, rotating JSONL sink.
+type Log struct {
+	path  string
+	queue chan Entry
+	once  sync.Once
+	done  chan struct{}
+}
+
+// New constructs a Log that writes to path.  The background goroutine is
+// started lazily on the first Append call.
+func New(path string) *Log {
+	return &Log{
+		path:  path,
+		queue: make(chan Entry, logQueueDepth),
+		done:  make(chan struct{}),
+	}
+}
+
+// DefaultLogPath returns ~/.archigraph/audit.jsonl.
+// Returns an empty string when the home directory cannot be determined;
+// callers should treat that as "disk logging disabled".
+func DefaultLogPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".archigraph", auditLogFile)
+}
+
+// Append enqueues e for disk write.  Returns immediately; never blocks.
+// The background goroutine (started on first call) performs the actual I/O.
+func (l *Log) Append(e Entry) {
+	if e.Timestamp == "" {
+		e.Timestamp = time.Now().UTC().Format("2006-01-02T15:04:05.000Z")
+	}
+	if e.Result == "" {
+		e.Result = "ok"
+	}
+	l.once.Do(l.startWorker)
+	select {
+	case l.queue <- e:
+	default:
+		// queue full — drop rather than block
+	}
+}
+
+// AppendOK is a convenience wrapper for successful operations.
+func (l *Log) AppendOK(operation, target string, params map[string]any) {
+	l.Append(Entry{
+		Operation: operation,
+		Target:    target,
+		Params:    params,
+		Result:    "ok",
+	})
+}
+
+// AppendErr is a convenience wrapper for failed operations.
+func (l *Log) AppendErr(operation, target string, params map[string]any, errMsg string) {
+	l.Append(Entry{
+		Operation: operation,
+		Target:    target,
+		Params:    params,
+		Result:    "error",
+		Error:     errMsg,
+	})
+}
+
+// Close flushes the remaining queue and stops the background goroutine.
+// After Close returns, further Append calls are silently dropped.
+// Safe to call even when no Append has occurred (no-op).
+func (l *Log) Close() {
+	// Start the worker if it hasn't been started yet, so we can close
+	// the queue and wait for the done signal.
+	l.once.Do(l.startWorker)
+	close(l.queue)
+	<-l.done
+}
+
+// Path returns the on-disk path this log writes to.
+func (l *Log) Path() string { return l.path }
+
+func (l *Log) startWorker() {
+	go l.worker()
+}
+
+func (l *Log) worker() {
+	defer close(l.done)
+
+	dir := filepath.Dir(l.path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		for range l.queue {
+		}
+		return
+	}
+
+	f, err := os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+	if err != nil {
+		for range l.queue {
+		}
+		return
+	}
+
+	written := fileSize(l.path)
+
+	for e := range l.queue {
+		line, err2 := json.Marshal(e)
+		if err2 != nil {
+			continue
+		}
+		n, _ := f.Write(append(line, '\n'))
+		written += int64(n)
+
+		if written >= maxLogBytes {
+			f.Close()
+			_ = os.Rename(l.path, l.path+".1")
+			f, err = os.OpenFile(l.path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o644)
+			if err != nil {
+				for range l.queue {
+				}
+				return
+			}
+			written = 0
+		}
+	}
+	f.Close()
+}
+
+// fileSize returns the current byte size of path, or 0 on error.
+func fileSize(path string) int64 {
+	if fi, err := os.Stat(path); err == nil {
+		return fi.Size()
+	}
+	return 0
+}
+
+// ---------------------------------------------------------------------------
+// History reader
+// ---------------------------------------------------------------------------
+
+// ReadHistory reads the last n entries from the JSONL log file at path.
+// Supports optional filter by operation. Reads the entire file up to 50 MiB.
+func ReadHistory(path string, n int, filterOp string) ([]Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var entries []Entry
+	start := 0
+	for i := 0; i <= len(data); i++ {
+		if i == len(data) || data[i] == '\n' {
+			line := data[start:i]
+			start = i + 1
+			if len(line) == 0 {
+				continue
+			}
+			var e Entry
+			if err2 := json.Unmarshal(line, &e); err2 == nil {
+				if filterOp == "" || e.Operation == filterOp {
+					entries = append(entries, e)
+				}
+			}
+		}
+	}
+
+	if n > 0 && len(entries) > n {
+		entries = entries[len(entries)-n:]
+	}
+	return entries, nil
+}

--- a/internal/audit/log_test.go
+++ b/internal/audit/log_test.go
@@ -1,0 +1,132 @@
+package audit
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestAppend_writesToDisk(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	l := New(path)
+
+	l.AppendOK("rebuild", "fixture-a", map[string]any{"wipe": false})
+	l.AppendErr("settings_update", "", nil, "invalid theme")
+
+	// Give the background worker time to flush.
+	l.Close()
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+
+	lines := splitLines(data)
+	if len(lines) != 2 {
+		t.Fatalf("want 2 lines, got %d: %s", len(lines), data)
+	}
+
+	var e1 Entry
+	if err := json.Unmarshal([]byte(lines[0]), &e1); err != nil {
+		t.Fatalf("decode line 1: %v", err)
+	}
+	if e1.Operation != "rebuild" {
+		t.Errorf("want operation=rebuild, got %q", e1.Operation)
+	}
+	if e1.Target != "fixture-a" {
+		t.Errorf("want target=fixture-a, got %q", e1.Target)
+	}
+	if e1.Result != "ok" {
+		t.Errorf("want result=ok, got %q", e1.Result)
+	}
+	if e1.Timestamp == "" {
+		t.Error("want non-empty timestamp")
+	}
+
+	var e2 Entry
+	if err := json.Unmarshal([]byte(lines[1]), &e2); err != nil {
+		t.Fatalf("decode line 2: %v", err)
+	}
+	if e2.Result != "error" {
+		t.Errorf("want result=error, got %q", e2.Result)
+	}
+	if e2.Error == "" {
+		t.Error("want non-empty error field")
+	}
+}
+
+func TestReadHistory_basic(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	l := New(path)
+
+	for i := 0; i < 10; i++ {
+		l.AppendOK("rebuild", "g", nil)
+	}
+	l.AppendOK("settings_update", "theme", nil)
+	l.Close()
+
+	// Read last 5
+	entries, err := ReadHistory(path, 5, "")
+	if err != nil {
+		t.Fatalf("ReadHistory: %v", err)
+	}
+	if len(entries) != 5 {
+		t.Errorf("want 5 entries, got %d", len(entries))
+	}
+
+	// Filter by operation
+	entries, err = ReadHistory(path, 100, "settings_update")
+	if err != nil {
+		t.Fatalf("ReadHistory filtered: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want 1 settings_update entry, got %d", len(entries))
+	}
+}
+
+func TestReadHistory_missingFile(t *testing.T) {
+	entries, err := ReadHistory("/nonexistent/audit.jsonl", 50, "")
+	if err != nil {
+		t.Fatalf("expected nil error for missing file, got %v", err)
+	}
+	if entries != nil {
+		t.Errorf("expected nil entries for missing file")
+	}
+}
+
+func TestAppend_timestampAutoSet(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	l := New(path)
+
+	before := time.Now().UTC()
+	l.Append(Entry{Operation: "test", Result: "ok"})
+	l.Close()
+
+	entries, err := ReadHistory(path, 1, "")
+	if err != nil || len(entries) != 1 {
+		t.Fatalf("read: %v, len=%d", err, len(entries))
+	}
+	if entries[0].Timestamp == "" {
+		t.Error("timestamp should be auto-set")
+	}
+	_ = before
+}
+
+func splitLines(data []byte) []string {
+	var lines []string
+	start := 0
+	for i := 0; i <= len(data); i++ {
+		if i == len(data) || data[i] == '\n' {
+			if i > start {
+				lines = append(lines, string(data[start:i]))
+			}
+			start = i + 1
+		}
+	}
+	return lines
+}

--- a/internal/audit/writer.go
+++ b/internal/audit/writer.go
@@ -1,0 +1,37 @@
+package audit
+
+// Writer combines a Log (disk) and a Broker (SSE fan-out) into a single
+// call site. Handlers call writer.OK / writer.Err and both disk persistence
+// and live streaming happen automatically.
+type Writer struct {
+	log    *Log
+	broker *Broker
+}
+
+// NewWriter wraps log and broker. Either may be nil (the respective path is
+// skipped). Passing nil for both is valid but produces a no-op writer.
+func NewWriter(log *Log, broker *Broker) *Writer {
+	return &Writer{log: log, broker: broker}
+}
+
+// OK records a successful operation.
+func (w *Writer) OK(operation, target string, params map[string]any) {
+	e := Entry{Operation: operation, Target: target, Params: params, Result: "ok"}
+	if w.log != nil {
+		w.log.Append(e)
+	}
+	if w.broker != nil {
+		w.broker.Publish(e)
+	}
+}
+
+// Err records a failed operation.
+func (w *Writer) Err(operation, target string, params map[string]any, errMsg string) {
+	e := Entry{Operation: operation, Target: target, Params: params, Result: "error", Error: errMsg}
+	if w.log != nil {
+		w.log.Append(e)
+	}
+	if w.broker != nil {
+		w.broker.Publish(e)
+	}
+}

--- a/internal/dashboard/handlers_audit.go
+++ b/internal/dashboard/handlers_audit.go
@@ -1,0 +1,202 @@
+package dashboard
+
+// handlers_audit.go — Audit log REST + SSE surface (#1258)
+//
+// Routes registered in server.go:
+//
+//	GET /api/audit             — last N entries, filterable by operation
+//	GET /api/audit/stream      — SSE tail; real-time entries as they are written
+//	GET /api/audit/export      — download full log as JSON or CSV
+//
+// The backend writes ~/.archigraph/audit.jsonl; this handler reads it back.
+
+import (
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/audit"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// auditHistoryReply is returned by GET /api/audit.
+type auditHistoryReply struct {
+	Entries []audit.Entry `json:"entries"`
+	Count   int           `json:"count"`
+	Note    string        `json:"note,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/audit
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleAuditHistory returns the last N audit entries from disk.
+// Query params:
+//
+//	limit=N      (default 100, max 1000)
+//	filter=op    (exact match on Entry.Operation)
+func (s *Server) handleAuditHistory(w http.ResponseWriter, r *http.Request) {
+	if s.auditLog == nil {
+		writeJSON(w, http.StatusOK, auditHistoryReply{
+			Entries: []audit.Entry{},
+			Note:    "audit log not configured",
+		})
+		return
+	}
+
+	limit := 100
+	if v := r.URL.Query().Get("limit"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			limit = n
+		}
+	}
+	if limit > 1000 {
+		limit = 1000
+	}
+	filterOp := r.URL.Query().Get("filter")
+
+	entries, err := audit.ReadHistory(s.auditLog.Path(), limit, filterOp)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "reading audit log: "+err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []audit.Entry{}
+	}
+
+	// Return newest-first so the frontend default view shows recent actions.
+	reverseEntries(entries)
+
+	writeJSON(w, http.StatusOK, auditHistoryReply{
+		Entries: entries,
+		Count:   len(entries),
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/audit/stream  — SSE real-time tail
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleAuditStream fans out new audit entries to SSE subscribers in real time.
+// The broker is optional; when nil the endpoint returns 503.
+//
+// SSE events:
+//
+//	event: connected  data: {"subscribed_at": <unix-ms>}
+//	event: audit      data: <JSON Entry>
+//	event: heartbeat  data: {}
+//	event: close      data: {}
+func (s *Server) handleAuditStream(w http.ResponseWriter, r *http.Request) {
+	if s.auditBroker == nil {
+		writeErr(w, http.StatusServiceUnavailable, "audit stream broker not available")
+		return
+	}
+
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeErr(w, http.StatusInternalServerError, "streaming not supported")
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache, no-transform")
+	w.Header().Set("X-Accel-Buffering", "no")
+	w.Header().Set("Connection", "keep-alive")
+	w.WriteHeader(http.StatusOK)
+
+	ch, cancel := s.auditBroker.Subscribe()
+	defer cancel()
+
+	subscribedAt := time.Now().UnixMilli()
+	writeSSEEvent(w, "connected", fmt.Sprintf(`{"subscribed_at":%d}`, subscribedAt))
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(heartbeatInterval)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			writeSSEEvent(w, "close", "{}")
+			flusher.Flush()
+			return
+
+		case e, ok := <-ch:
+			if !ok {
+				writeSSEEvent(w, "close", "{}")
+				flusher.Flush()
+				return
+			}
+			data, err := json.Marshal(e)
+			if err != nil {
+				continue
+			}
+			writeSSEEvent(w, "audit", string(data))
+			flusher.Flush()
+
+		case <-heartbeat.C:
+			writeSSEEvent(w, "heartbeat", "{}")
+			flusher.Flush()
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/audit/export
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleAuditExport downloads the audit log as JSON or CSV.
+// Query param: format=json (default) | csv
+func (s *Server) handleAuditExport(w http.ResponseWriter, r *http.Request) {
+	if s.auditLog == nil {
+		writeErr(w, http.StatusServiceUnavailable, "audit log not configured")
+		return
+	}
+
+	entries, err := audit.ReadHistory(s.auditLog.Path(), 0, "")
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "reading audit log: "+err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []audit.Entry{}
+	}
+	reverseEntries(entries)
+
+	format := r.URL.Query().Get("format")
+	if format == "csv" {
+		w.Header().Set("Content-Type", "text/csv")
+		w.Header().Set("Content-Disposition", `attachment; filename="audit.csv"`)
+		cw := csv.NewWriter(w)
+		_ = cw.Write([]string{"timestamp", "operation", "target", "result", "error"})
+		for _, e := range entries {
+			_ = cw.Write([]string{e.Timestamp, e.Operation, e.Target, e.Result, e.Error})
+		}
+		cw.Flush()
+		return
+	}
+
+	// Default: JSON
+	w.Header().Set("Content-Type", "application/json")
+	w.Header().Set("Content-Disposition", `attachment; filename="audit.json"`)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(entries)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func reverseEntries(entries []audit.Entry) {
+	for i, j := 0, len(entries)-1; i < j; i, j = i+1, j-1 {
+		entries[i], entries[j] = entries[j], entries[i]
+	}
+}

--- a/internal/dashboard/handlers_audit_test.go
+++ b/internal/dashboard/handlers_audit_test.go
@@ -1,0 +1,234 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/audit"
+)
+
+// setupAuditServer returns a test server with a temp audit log and broker wired in.
+func setupAuditServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	logPath := filepath.Join(tmp, "audit.jsonl")
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	l := audit.New(logPath)
+	b := audit.NewBroker()
+	srv.SetAuditLog(l)
+	srv.SetAuditBroker(b)
+	t.Cleanup(func() { l.Close() })
+	return srv, logPath
+}
+
+func TestHandleAuditHistory_empty(t *testing.T) {
+	srv, _ := setupAuditServer(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var reply auditHistoryReply
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if reply.Count != 0 {
+		t.Errorf("want count=0, got %d", reply.Count)
+	}
+	if reply.Entries == nil {
+		t.Error("entries should be non-nil empty slice")
+	}
+}
+
+func TestHandleAuditHistory_withEntries(t *testing.T) {
+	srv, logPath := setupAuditServer(t)
+
+	// Write some entries directly.
+	l := audit.New(logPath)
+	l.AppendOK("rebuild", "fixture-a", nil)
+	l.AppendOK("settings_update", "", nil)
+	l.AppendErr("rebuild", "fixture-b", nil, "daemon unreachable")
+	l.Close()
+
+	// Give worker time to flush.
+	time.Sleep(50 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit?limit=10", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var reply auditHistoryReply
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if reply.Count != 3 {
+		t.Errorf("want count=3, got %d", reply.Count)
+	}
+	// Should be newest-first: last written = rebuild-fixture-b
+	if reply.Entries[0].Target != "fixture-b" {
+		t.Errorf("want newest entry first (fixture-b), got %q", reply.Entries[0].Target)
+	}
+}
+
+func TestHandleAuditHistory_filter(t *testing.T) {
+	srv, logPath := setupAuditServer(t)
+
+	l := audit.New(logPath)
+	l.AppendOK("rebuild", "fixture-a", nil)
+	l.AppendOK("settings_update", "", nil)
+	l.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit?filter=rebuild", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditHistory(w, req)
+
+	var reply auditHistoryReply
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if reply.Count != 1 {
+		t.Errorf("want count=1 after filter, got %d", reply.Count)
+	}
+	if reply.Entries[0].Operation != "rebuild" {
+		t.Errorf("want operation=rebuild, got %q", reply.Entries[0].Operation)
+	}
+}
+
+func TestHandleAuditHistory_noLog(t *testing.T) {
+	// Server with no audit log configured.
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditHistory(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+
+	var reply auditHistoryReply
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if reply.Note == "" {
+		t.Error("want non-empty note when log not configured")
+	}
+}
+
+func TestHandleAuditExport_json(t *testing.T) {
+	srv, logPath := setupAuditServer(t)
+
+	l := audit.New(logPath)
+	l.AppendOK("rebuild", "g", nil)
+	l.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit/export", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditExport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "application/json" {
+		t.Errorf("want application/json, got %q", ct)
+	}
+
+	var entries []audit.Entry
+	if err := json.NewDecoder(w.Body).Decode(&entries); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want 1 entry, got %d", len(entries))
+	}
+}
+
+func TestHandleAuditExport_csv(t *testing.T) {
+	srv, logPath := setupAuditServer(t)
+
+	l := audit.New(logPath)
+	l.AppendOK("rebuild", "g", nil)
+	l.Close()
+	time.Sleep(50 * time.Millisecond)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit/export?format=csv", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditExport(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if ct := w.Header().Get("Content-Type"); ct != "text/csv" {
+		t.Errorf("want text/csv, got %q", ct)
+	}
+	if len(w.Body.Bytes()) == 0 {
+		t.Error("expected non-empty CSV body")
+	}
+
+	// Verify at least header row + 1 data row
+	body := w.Body.String()
+	if body[:9] != "timestamp" {
+		t.Errorf("expected CSV to start with header, got: %q", body[:min(30, len(body))])
+	}
+}
+
+func TestHandleAuditStream_noBroker(t *testing.T) {
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+
+	req := httptest.NewRequest(http.MethodGet, "/api/audit/stream", nil)
+	w := httptest.NewRecorder()
+	srv.handleAuditStream(w, req)
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503, got %d", w.Code)
+	}
+}
+
+func TestAuditorCalledOnMaintenance(t *testing.T) {
+	srv, logPath := setupAuditServer(t)
+
+	// Ensure the auditor writes to logPath by checking the log after a settings_reset.
+	tmp := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", tmp)
+	defer os.Unsetenv("ARCHIGRAPH_HOME")
+
+	req := httptest.NewRequest(http.MethodPost, "/api/settings/reset", nil)
+	w := httptest.NewRecorder()
+	srv.handleResetSettings(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("reset settings: want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Allow background goroutine to flush.
+	time.Sleep(80 * time.Millisecond)
+
+	entries, err := audit.ReadHistory(logPath, 10, "settings_reset")
+	if err != nil {
+		t.Fatalf("read audit log: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Errorf("want 1 settings_reset audit entry, got %d", len(entries))
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}

--- a/internal/dashboard/handlers_enrichment_jobs.go
+++ b/internal/dashboard/handlers_enrichment_jobs.go
@@ -50,9 +50,11 @@ func (s *Server) handleEnrichmentTrigger(w http.ResponseWriter, r *http.Request)
 
 	id, err := s.jobQueue.Enqueue(group, subjectID, kind)
 	if err != nil {
+		s.auditor.Err("enrichment_trigger", group, map[string]any{"subject_id": subjectID, "kind": kind}, err.Error())
 		writeErr(w, http.StatusTooManyRequests, "job queue full: "+err.Error())
 		return
 	}
+	s.auditor.OK("enrichment_trigger", group, map[string]any{"subject_id": subjectID, "kind": kind, "job_id": id})
 
 	job, _ := s.jobQueue.Get(id)
 	writeJSON(w, http.StatusAccepted, jobToWire(job))

--- a/internal/dashboard/handlers_maintenance.go
+++ b/internal/dashboard/handlers_maintenance.go
@@ -191,6 +191,10 @@ func (s *Server) dispatchRebuild(w http.ResponseWriter, group, repo string, wipe
 		_, _ = bgClient.Rebuild(args)
 	}()
 
+	// Audit the dispatched operation.
+	auditParams := map[string]any{"repo": repo, "wipe": wipe, "progress_token": token}
+	s.auditor.OK(op, group, auditParams)
+
 	reply := MaintenanceAckReply{
 		Op:            op,
 		Group:         group,
@@ -263,6 +267,7 @@ func (s *Server) runCleanup(w http.ResponseWriter, dryRun bool) {
 	reply.Removed = len(orphaned)
 	reply.Message = fmt.Sprintf("Removed %d orphaned %s",
 		len(orphaned), maintenancePluralEntry(len(orphaned)))
+	s.auditor.OK("cleanup", "", map[string]any{"removed": len(orphaned)})
 	writeJSON(w, http.StatusOK, reply)
 }
 

--- a/internal/dashboard/handlers_patterns.go
+++ b/internal/dashboard/handlers_patterns.go
@@ -218,9 +218,11 @@ func (s *Server) handlePatternUpdate(w http.ResponseWriter, r *http.Request) {
 
 	patterns = agentpatterns.Upsert(patterns, updated)
 	if err := agentpatterns.Save(dir, patterns); err != nil {
+		s.auditor.Err("pattern_update", group+"/"+id, nil, err.Error())
 		writeErr(w, http.StatusInternalServerError, "save patterns: "+err.Error())
 		return
 	}
+	s.auditor.OK("pattern_update", group+"/"+id, nil)
 
 	writeJSON(w, http.StatusOK, &updated)
 }
@@ -257,9 +259,11 @@ func (s *Server) handlePatternDelete(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if err := agentpatterns.Save(dir, out); err != nil {
+		s.auditor.Err("pattern_delete", group+"/"+id, nil, err.Error())
 		writeErr(w, http.StatusInternalServerError, "save patterns: "+err.Error())
 		return
 	}
+	s.auditor.OK("pattern_delete", group+"/"+id, nil)
 
 	writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
 }

--- a/internal/dashboard/handlers_settings.go
+++ b/internal/dashboard/handlers_settings.go
@@ -200,9 +200,11 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 	}
 
 	if err := saveSettings(current); err != nil {
+		s.auditor.Err("settings_update", "", nil, err.Error())
 		writeErr(w, http.StatusInternalServerError, "failed to save settings: "+err.Error())
 		return
 	}
+	s.auditor.OK("settings_update", "", map[string]any{"restart_required": restartKeys})
 
 	writeJSON(w, http.StatusOK, settingsReply{
 		Settings:        current,
@@ -216,9 +218,11 @@ func (s *Server) handlePutSettings(w http.ResponseWriter, r *http.Request) {
 func (s *Server) handleResetSettings(w http.ResponseWriter, _ *http.Request) {
 	d := DefaultAppSettings()
 	if err := saveSettings(d); err != nil {
+		s.auditor.Err("settings_reset", "", nil, err.Error())
 		writeErr(w, http.StatusInternalServerError, "failed to reset settings: "+err.Error())
 		return
 	}
+	s.auditor.OK("settings_reset", "", nil)
 	writeJSON(w, http.StatusOK, settingsReply{
 		Settings: d,
 		Defaults: d,

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/audit"
 	"github.com/cajasmota/archigraph/internal/jobs"
 	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/progress"
@@ -59,6 +60,20 @@ type Server struct {
 	// POST /api/enrichments/{group}/trigger returns 503 and the jobs list is empty.
 	// Set via SetJobQueue before calling Serve.
 	jobQueue *jobs.Queue
+
+	// auditLog is the append-only disk sink for audit entries (#1258).
+	// Optional: nil disables disk logging; the in-memory broker still works.
+	// Set via SetAuditLog before calling Serve.
+	auditLog *audit.Log
+
+	// auditBroker fans audit entries to SSE subscribers (#1258).
+	// Optional: nil disables /api/audit/stream (returns 503).
+	// Set via SetAuditBroker before calling Serve.
+	auditBroker *audit.Broker
+
+	// auditor is the combined writer (disk + broker). Mutation handlers call
+	// s.auditor.OK / s.auditor.Err. Initialised by SetAuditLog / SetAuditBroker.
+	auditor *audit.Writer
 }
 
 // NewServer wires a server against the given config and registry-store
@@ -73,13 +88,16 @@ func NewServer(cfg Config, store RegistryStore) (*Server, error) {
 	}
 	h := newWSHub()
 	go h.run()
-	return &Server{
+	srv := &Server{
 		cfg:      cfg,
 		registry: store,
 		graphs:   NewGraphCache(60 * time.Second),
 		hub:      h,
 		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
-	}, nil
+	}
+	// auditor starts as a no-op writer; replaced when SetAuditLog/SetAuditBroker is called.
+	srv.auditor = audit.NewWriter(nil, nil)
+	return srv, nil
 }
 
 // SetDaemonStartedAt records when the parent daemon process started so
@@ -122,6 +140,20 @@ func (s *Server) SetRecallRunner(fn func(fixtureName string) ([]byte, error)) {
 // Call this from cmd/archigraph (or any daemon entrypoint) before Serve.
 func (s *Server) SetJobQueue(q *jobs.Queue) {
 	s.jobQueue = q
+}
+
+// SetAuditLog wires the audit disk log into the dashboard server.
+// Call from the daemon entrypoint before Serve (#1258).
+func (s *Server) SetAuditLog(l *audit.Log) {
+	s.auditLog = l
+	s.auditor = audit.NewWriter(s.auditLog, s.auditBroker)
+}
+
+// SetAuditBroker wires the audit SSE broker into the dashboard server.
+// Call from the daemon entrypoint before Serve (#1258).
+func (s *Server) SetAuditBroker(b *audit.Broker) {
+	s.auditBroker = b
+	s.auditor = audit.NewWriter(s.auditLog, s.auditBroker)
 }
 
 // Listen binds to a random free port within cfg.PortRange. It is
@@ -337,6 +369,11 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/onboard/check-path", s.handleOnboardCheckPath)
 	mux.HandleFunc("POST /api/onboard/detect-monorepo", s.handleOnboardDetectMonorepo)
 	mux.HandleFunc("POST /api/onboard/create-group", s.handleOnboardCreateGroup)
+
+	// Surface 13 — Audit log (#1258)
+	mux.HandleFunc("GET /api/audit", s.handleAuditHistory)
+	mux.HandleFunc("GET /api/audit/stream", s.handleAuditStream)
+	mux.HandleFunc("GET /api/audit/export", s.handleAuditExport)
 
 	// MCP Setup Wizard (#1247) — one-click install / uninstall / verify
 	mux.HandleFunc("GET /api/mcp-setup/hosts", s.handleMCPSetupHosts)


### PR DESCRIPTION
## Summary

Adds a full audit trail for all state-changing dashboard operations backed by an append-only \`~/.archigraph/audit.jsonl\` log with real-time SSE streaming and a new \`/audit-log\` surface (Surface 14) under the Operate menu.

**Backend — new \`internal/audit\` package:**
- \`log.go\` — rotating append-only JSONL writer (10 MiB cap, \`.1\` rotation), non-blocking channel queue
- \`broker.go\` — SSE fan-out pub/sub broker (non-blocking, subscriber drop-on-full)
- \`writer.go\` — \`Writer\` combines disk log + broker into a single \`OK\`/\`Err\` call for handlers
- \`handlers_audit.go\` — three new endpoints:
  - \`GET /api/audit?limit=N&filter=op\` — history, newest-first, filterable
  - \`GET /api/audit/stream\` — SSE real-time tail
  - \`GET /api/audit/export?format=json|csv\` — download

**Wired into mutation handlers:**
- Rebuild / reset / cleanup (\`handlers_maintenance.go\`)
- Settings update / reset (\`handlers_settings.go\`)
- Pattern update / delete (\`handlers_patterns.go\`)
- Enrichment trigger (\`handlers_enrichment_jobs.go\`)

**Frontend:**
- \`routes/audit-log.tsx\` — filterable timeline with SSE live tail, operation chips, error-only toggle, export, stats sidebar
- API client: \`fetchAuditHistory\` + \`subscribeAuditStream\`
- Types: \`AuditEntry\`, \`AuditHistoryResponse\`
- NavMenu: "Audit Log" entry under Operate (\`ClipboardList\` icon)
- App.tsx: \`/audit-log\` route registered as Surface 14

## Closes / Refs
- Closes #1258

## Testing
- [x] All tests pass: \`go test ./internal/audit/... ./internal/dashboard/...\` — 12 tests, 0 failures
- [x] \`go build ./...\` clean
- [x] TypeScript: 30 errors before → 30 errors after (zero regressions, all pre-existing)
- [x] Playwright E2E smoke: \`dashboard/tests/e2e/audit-log-surface.spec.ts\` (headless, light + dark screenshots)
- [x] Mutation handlers (maintenance, settings, patterns, enrichment) all audited

## Notes

The \`Server.auditor\` field is always non-nil (initialized to a no-op \`Writer\` in \`NewServer\`), so mutation handlers never need a nil check. \`SetAuditLog\` / \`SetAuditBroker\` replace it with the live writer; daemon entrypoints call both before \`Serve\`.

The \`audit.Log.Close()\` is safe to call even when no \`Append\` has occurred (it lazily starts the worker goroutine if needed before draining).

Schema: \`{timestamp, operation, target, params, result, error?}\` — matches spec in #1258.