### PR TITLE
[#1278] Fix cross-file DRF router suppression: eliminate 124 ghost bare-prefix paths

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -1465,7 +1465,13 @@ func (i *Indexer) runPass1ExtractWithProgress(ctx context.Context, absRepo strin
 	// This allows extractBaseClasses in the Python extractor to resolve
 	// cross-file `class Foo(Bar):` shapes to the correct source file when
 	// exactly one project file declares `Bar`.
+	//
+	// Pre-pass (#1278): build the cross-file DRF register-name registry.
+	// Scans every Python file for router.register() basenames so that
+	// applyDjangoRouteComposition can suppress bare Route entities produced by
+	// the YAML rules even when include(router.urls) lives in a different file.
 	pyextr.ClearPythonClassRegistry()
+	engine.ClearDRFRegisterNames()
 	for _, rel := range files {
 		abs := filepath.Join(absRepo, rel)
 		if !strings.HasSuffix(strings.ToLower(rel), ".py") {
@@ -1473,6 +1479,7 @@ func (i *Indexer) runPass1ExtractWithProgress(ctx context.Context, absRepo strin
 		}
 		if content, err := os.ReadFile(abs); err == nil {
 			pyextr.ScanPythonClassRegistry(rel, string(content))
+			engine.ScanDRFRegisterNames(content)
 		}
 	}
 

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -142,8 +142,14 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 	// `class Foo(Bar):` shapes to the correct source file. Scanning is a
 	// lightweight line-based pass (no AST). ClearPythonClassRegistry resets any
 	// state from a prior batch to avoid bleeding across unrelated index runs.
+	//
+	// Pre-pass (#1278): build cross-file DRF register-name registry. Scans
+	// every Python file for router.register() basenames so that
+	// applyDjangoRouteComposition can suppress bare Route entities even when
+	// the matching include(router.urls) call lives in a different file.
 	if runExtract {
 		pyextr.ClearPythonClassRegistry()
+		engine.ClearDRFRegisterNames()
 		for _, rel := range files {
 			abs := filepath.Join(opts.RepoRoot, rel)
 			if !strings.HasSuffix(strings.ToLower(rel), ".py") {
@@ -151,6 +157,7 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 			}
 			if pyContent, err := os.ReadFile(abs); err == nil {
 				pyextr.ScanPythonClassRegistry(rel, string(pyContent))
+				engine.ScanDRFRegisterNames(pyContent)
 			}
 		}
 	}

--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -594,6 +594,14 @@ func findParentIncludePrefixes(
 ) []string {
 	var prefixes []string
 	seen := map[string]bool{}
+
+	// Determine whether the target file contains any router.register() calls.
+	// Used to gate the attribute-form include heuristic below (#1278).
+	var targetHasRegister bool
+	if targetContent := fileReader(targetRelPath); len(targetContent) > 0 {
+		targetHasRegister = drfRouterRegisterDetailedRe.Match(targetContent)
+	}
+
 	for _, candidate := range parentFiles {
 		if candidate == targetRelPath {
 			continue
@@ -606,6 +614,8 @@ func findParentIncludePrefixes(
 			continue
 		}
 		src := string(content)
+
+		// String-form include: path("prefix", include("module.path"))
 		for _, m := range djangoIncludeStringRe.FindAllStringSubmatch(src, -1) {
 			parentPrefix := m[1]
 			modulePath := m[2]
@@ -619,6 +629,37 @@ func findParentIncludePrefixes(
 			if !seen[parentPrefix] {
 				prefixes = append(prefixes, parentPrefix)
 				seen[parentPrefix] = true
+			}
+		}
+
+		// #1278 — Attribute-form include: path("prefix", include(routerVar.urls)).
+		// When the parent file mounts a router variable via attribute-form include
+		// rather than a string module path, djangoIncludeStringRe doesn't match.
+		// Heuristic: if the candidate parent file has `path("prefix",
+		// include(someVar.urls))` AND the target file contains router.register()
+		// calls, treat this as a parent-include relationship and use the prefix.
+		//
+		// This heuristic is safe because:
+		// - We only fire it when the target file actually defines router registrations.
+		// - In the vast majority of DRF projects, each urlconf file is mounted at
+		//   most one attribute-form router, so false-positive prefix collisions are
+		//   extremely unlikely.
+		// - If the heuristic over-fires (two router files in same project with same
+		//   parent), the worst case is a duplicate http_endpoint at the correct
+		//   prefix — the dedup pass removes it.
+		if targetHasRegister {
+			flatSrc := flattenParenthesised(src)
+			for _, m := range drfRouterAttrIncludeRe.FindAllStringSubmatch(flatSrc, -1) {
+				parentPrefix := m[1]
+				if parentPrefix == "" {
+					continue
+				}
+				// Only apply when the string-form include did NOT already find a
+				// prefix for this file — avoid double-adding the same prefix.
+				if !seen[parentPrefix] {
+					prefixes = append(prefixes, parentPrefix)
+					seen[parentPrefix] = true
+				}
 			}
 		}
 	}

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -15,19 +15,95 @@
 // include-prefix paths it "claimed" so the surrounding engine can suppress
 // the duplicate flat Routes the YAML rules would otherwise emit.
 //
-// Refs #64.
+// Cross-file suppression (#1278): when router.register() calls live in one
+// file and path("api/v1/", include(router.urls)) lives in another file, the
+// per-file claimedRegisterNames set is empty during the register-file pass and
+// cannot suppress the bare YAML Route entities. A global pre-pass registry
+// (drfGlobalRegisterNames) is populated by ScanDRFRegisterNames before
+// per-file extraction begins. The suppression gate in applyDjangoRouteComposition
+// now also consults this global set so cross-file bare Routes are correctly dropped.
+//
+// Refs #64, #1278.
 package engine
 
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
+	"sync"
 
 	sitter "github.com/smacker/go-tree-sitter"
 
 	"github.com/cajasmota/archigraph/internal/treesitter"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// ---------------------------------------------------------------------------
+// Cross-file DRF register-name registry (#1278)
+// ---------------------------------------------------------------------------
+
+// drfRegisterScanRe is a lightweight line-based regex that captures every
+// router.register() basename from a Python file without an AST parse. Used
+// in the cross-file pre-pass (ScanDRFRegisterNames) to build a global set
+// of claimed register names before per-file extraction runs.
+//
+// Accepts both raw-string (r"name") and plain-string ("name" / 'name') forms.
+// Anchors the receiver to router-like identifiers (same pattern as the YAML
+// rule) to avoid false positives from unrelated .register() calls.
+var drfRegisterScanRe = regexp.MustCompile(
+	`(?:[\w]*[Rr]outer|api_router|v\d+_router|router_v\d+)\.register\s*\(\s*r?["']([^"']+)["']`,
+)
+
+// drfGlobalMu guards drfGlobalRegisterNames for concurrent pre-pass callers.
+var drfGlobalMu sync.RWMutex
+
+// drfGlobalRegisterNames is the cross-repo set of all router.register()
+// basenames found during the ScanDRFRegisterNames pre-pass. It is consulted
+// by applyDjangoRouteComposition when the per-file claimedRegisterNames set
+// is empty (cross-file scenario). Reset by ClearDRFRegisterNames at the
+// start of each index run.
+var drfGlobalRegisterNames = map[string]bool{}
+
+// ScanDRFRegisterNames scans a single Python file's content and merges every
+// router.register() basename into the global cross-file registry. Safe for
+// concurrent calls from parallel file-walkers.
+//
+// Call this for every .py file BEFORE per-file extraction begins (same
+// lifecycle as pyextr.ScanPythonClassRegistry). The global set is then
+// available to applyDjangoRouteComposition when suppressing cross-file ghosts.
+func ScanDRFRegisterNames(content []byte) {
+	if len(content) == 0 {
+		return
+	}
+	matches := drfRegisterScanRe.FindAllSubmatch(content, -1)
+	if len(matches) == 0 {
+		return
+	}
+	drfGlobalMu.Lock()
+	defer drfGlobalMu.Unlock()
+	for _, m := range matches {
+		if len(m) >= 2 && len(m[1]) > 0 {
+			drfGlobalRegisterNames[string(m[1])] = true
+		}
+	}
+}
+
+// ClearDRFRegisterNames resets the global DRF register-name registry.
+// Call at the start of each index run and in test teardowns.
+func ClearDRFRegisterNames() {
+	drfGlobalMu.Lock()
+	defer drfGlobalMu.Unlock()
+	drfGlobalRegisterNames = map[string]bool{}
+}
+
+// isDRFGlobalRegisterName reports whether name appears in the cross-file
+// DRF register-name registry populated by the ScanDRFRegisterNames pre-pass.
+func isDRFGlobalRegisterName(name string) bool {
+	drfGlobalMu.RLock()
+	defer drfGlobalMu.RUnlock()
+	return drfGlobalRegisterNames[name]
+}
 
 // composedDjangoRoutes holds the output of the Django AST pass.
 type composedDjangoRoutes struct {
@@ -52,6 +128,18 @@ type composedDjangoRoutes struct {
 // dropping the now-redundant flat Routes and the orphan parent-path Route.
 //
 // `lang` lets the engine no-op cleanly for non-Python files.
+//
+// #1278 — two-phase suppression:
+//
+//  1. Global cross-file suppression: always applied for any Python file. Drops
+//     YAML Route entities and ROUTES_TO edges whose bare name appears in the
+//     cross-file DRF register-name registry (built by the ScanDRFRegisterNames
+//     pre-pass). This handles the case where router.register() calls live in
+//     one file but the include(router.urls) call lives in another file.
+//
+//  2. Per-file composed suppression: applied only when the file contains both
+//     include() and .register() calls (same-file composition). Replaces the
+//     bare Route entities with the AST-composed prefixed routes.
 func applyDjangoRouteComposition(
 	ctx context.Context,
 	lang string,
@@ -63,6 +151,22 @@ func applyDjangoRouteComposition(
 	if lang != "python" || len(content) == 0 {
 		return rawEntities, rawRels
 	}
+
+	// Phase 1 — global cross-file suppression (#1278): drop bare YAML Route
+	// entities (and their ROUTES_TO edges) whose name is in the global
+	// register-name set, regardless of whether this file contains an include()
+	// binding. This handles register-only files (no include() in this file)
+	// where the per-file claimedRegisterNames set would be empty.
+	//
+	// We apply this even for files that will also go through Phase 2 (the
+	// same-file composition path) to keep the logic uniform; Phase 2's
+	// claimedRegisterNames set is a strict subset of the global set.
+	entities := suppressGlobalDRFOrphans(path, rawEntities, rawRels)
+	rawEntities = entities.ents
+	rawRels = entities.rels
+
+	// Phase 2 — per-file AST-driven composed suppression (original #64 logic):
+	// only fires when the file contains both include() and .register() calls.
 	// Cheap pre-filter: a DRF-composing urls.py has at minimum a `path(`
 	// and an `include(` somewhere, plus a `.register(` for the router.
 	if !bytesContainsAll(content, "path(", "include(", ".register(") {
@@ -104,6 +208,81 @@ func applyDjangoRouteComposition(
 	filteredRels = append(filteredRels, composed.relationships...)
 
 	return filteredEntities, filteredRels
+}
+
+// suppressedEntities bundles filtered entity + relationship slices.
+type suppressedEntities struct {
+	ents []types.EntityRecord
+	rels []types.RelationshipRecord
+}
+
+// suppressGlobalDRFOrphans drops bare YAML Route entities and their ROUTES_TO
+// edges from rawEntities/rawRels when the entity name appears in the global
+// cross-file DRF register-name registry. This is Phase 1 of the #1278 fix.
+//
+// Returns a new suppressedEntities with the filtered results. When the global
+// registry is empty (no router.register() found anywhere in the repo, or the
+// pre-pass hasn't run yet), the inputs are returned unchanged.
+func suppressGlobalDRFOrphans(
+	filePath string,
+	rawEntities []types.EntityRecord,
+	rawRels []types.RelationshipRecord,
+) suppressedEntities {
+	// Fast path: if the global set is empty nothing to do.
+	drfGlobalMu.RLock()
+	globalEmpty := len(drfGlobalRegisterNames) == 0
+	drfGlobalMu.RUnlock()
+	if globalEmpty {
+		return suppressedEntities{ents: rawEntities, rels: rawRels}
+	}
+
+	// Check whether any entity in this file is a candidate for suppression
+	// before allocating new slices. This keeps the hot path allocation-free
+	// for files with no YAML Route entities.
+	hasCandidates := false
+	for _, e := range rawEntities {
+		if e.Kind == "Route" && e.SourceFile == filePath && isDRFGlobalRegisterName(e.Name) {
+			hasCandidates = true
+			break
+		}
+	}
+	if !hasCandidates {
+		// Also check rels in case an orphan edge slipped through without a
+		// corresponding entity (unusual but possible with out-of-order processing).
+		for _, r := range rawRels {
+			if r.Kind == "ROUTES_TO" && strings.HasPrefix(r.FromID, "Route:") {
+				bare := strings.TrimPrefix(r.FromID, "Route:")
+				if isDRFGlobalRegisterName(bare) {
+					hasCandidates = true
+					break
+				}
+			}
+		}
+	}
+	if !hasCandidates {
+		return suppressedEntities{ents: rawEntities, rels: rawRels}
+	}
+
+	filteredEnts := rawEntities[:0:0]
+	for _, e := range rawEntities {
+		if e.Kind == "Route" && e.SourceFile == filePath && isDRFGlobalRegisterName(e.Name) {
+			continue // suppress cross-file ghost
+		}
+		filteredEnts = append(filteredEnts, e)
+	}
+
+	filteredRels := rawRels[:0:0]
+	for _, r := range rawRels {
+		if r.Kind == "ROUTES_TO" && strings.HasPrefix(r.FromID, "Route:") {
+			bare := strings.TrimPrefix(r.FromID, "Route:")
+			if isDRFGlobalRegisterName(bare) {
+				continue // suppress orphan ROUTES_TO edge
+			}
+		}
+		filteredRels = append(filteredRels, r)
+	}
+
+	return suppressedEntities{ents: filteredEnts, rels: filteredRels}
 }
 
 // bytesContainsAll returns true iff every needle is present in content.

--- a/internal/engine/drf_cross_file_1278_test.go
+++ b/internal/engine/drf_cross_file_1278_test.go
@@ -1,0 +1,290 @@
+// Tests for issue #1278: cross-file DRF router suppression.
+//
+// When router.register() calls live in one file and path("api/v1/",
+// include(router.urls)) lives in another file, the per-file
+// claimedRegisterNames set is empty during the register-file pass and bare
+// YAML Route entities (and their ROUTES_TO edges) survive suppression,
+// producing ghost http:ANY:/X endpoints with no /api/ prefix.
+//
+// The fix: a global cross-file registry (drfGlobalRegisterNames) is populated
+// by ScanDRFRegisterNames before per-file extraction begins. The suppression
+// gate in applyDjangoRouteComposition now also consults this global set.
+//
+// Additionally, findParentIncludePrefixes is extended to detect attribute-form
+// include(routerVar.urls) in parent files so ApplyDjangoDRFRoutes correctly
+// emits prefixed routes when the parent uses attribute-form include.
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture A: register in file A, include in file B (cross-file)
+// ---------------------------------------------------------------------------
+//
+// routers.py has only router.register() calls.
+// urls.py has path("api/v1/", include(router.urls)).
+// Without the fix: bare Route:users and Route:orders survive in routers.py and
+// ApplyDjangoDRFRoutes emits ghost http:ANY:/users endpoints.
+// With the fix: bare Route entities are suppressed; only /api/v1/* paths land.
+
+const crossFileRoutersFile = `from rest_framework.routers import DefaultRouter
+from .views import UserViewSet, OrderViewSet
+
+router = DefaultRouter()
+router.register(r'users', UserViewSet, basename='user')
+router.register(r'orders', OrderViewSet, basename='order')
+`
+
+const crossFileURLsFile = `from django.urls import path, include
+from .routers import router
+
+urlpatterns = [
+    path('api/v1/', include(router.urls)),
+]
+`
+
+// TestDRFCrossFile_SuppressesOrphanRouteEntities verifies that when
+// router.register() is in routers.py and include(router.urls) is in urls.py,
+// bare Route entities ("users", "orders") are suppressed by the global
+// register-name registry and do not appear in the Detect output.
+//
+// Regression test for #1278.
+func TestDRFCrossFile_SuppressesOrphanRouteEntities(t *testing.T) {
+	// Set up the global register-name registry as the pre-pass would.
+	ClearDRFRegisterNames()
+	ScanDRFRegisterNames([]byte(crossFileRoutersFile))
+	ScanDRFRegisterNames([]byte(crossFileURLsFile))
+	t.Cleanup(ClearDRFRegisterNames)
+
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	ctx := context.Background()
+
+	// Detect routers.py — should suppress bare Route:users and Route:orders.
+	routersResult, err := det.Detect(ctx, extractor.FileInput{
+		Path:     "myapp/routers.py",
+		Content:  []byte(crossFileRoutersFile),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect(routers.py): %v", err)
+	}
+
+	// Bare Route entities must be absent from routers.py output.
+	orphanNames := map[string]bool{"users": true, "orders": true}
+	for _, e := range routersResult.Entities {
+		if e.Kind == "Route" && orphanNames[e.Name] {
+			t.Errorf("orphan Route %q survived cross-file suppression in routers.py output", e.Name)
+		}
+	}
+	// Bare ROUTES_TO edges must also be absent.
+	for _, r := range routersResult.Relationships {
+		if r.Kind == "ROUTES_TO" {
+			bare := ""
+			if len(r.FromID) > len("Route:") && r.FromID[:6] == "Route:" {
+				bare = r.FromID[6:]
+			}
+			if orphanNames[bare] {
+				t.Errorf("orphan ROUTES_TO from Route:%s survived cross-file suppression in routers.py", bare)
+			}
+		}
+	}
+}
+
+// TestDRFCrossFile_SameFileCompositionUnaffected verifies that the existing
+// same-file composition path (#64) still works correctly when the global
+// register-name registry is populated (i.e., we don't over-suppress composed
+// Route entities that have a real prefix).
+//
+// This is the regression guard for the #64 fix against the #1278 fix.
+func TestDRFCrossFile_SameFileCompositionUnaffected(t *testing.T) {
+	// Same-file content: both register() and include(router.urls) in one file.
+	sameFile := `from rest_framework.routers import DefaultRouter
+from django.urls import path, include
+from myapp.views import UserViewSet, OrderViewSet
+
+router = DefaultRouter()
+router.register(r'users', UserViewSet)
+router.register(r'orders', OrderViewSet)
+
+urlpatterns = [
+    path('api/v1/', include(router.urls)),
+]
+`
+	// Populate global registry as the pre-pass would.
+	ClearDRFRegisterNames()
+	ScanDRFRegisterNames([]byte(sameFile))
+	t.Cleanup(ClearDRFRegisterNames)
+
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	ctx := context.Background()
+
+	result, err := det.Detect(ctx, extractor.FileInput{
+		Path:     "myapp/urls.py",
+		Content:  []byte(sameFile),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	// Composed Route entities must be present.
+	got := map[string]bool{}
+	for _, e := range result.Entities {
+		if e.Kind == "Route" {
+			got[e.Name] = true
+		}
+	}
+	wantComposed := []string{"/api/v1/users", "/api/v1/orders"}
+	for _, p := range wantComposed {
+		if !got[p] {
+			t.Errorf("missing composed Route %q after global registry suppression (got %v)", p, got)
+		}
+	}
+	// Bare names must NOT be present.
+	for _, bare := range []string{"users", "orders", "api/v1/"} {
+		if got[bare] {
+			t.Errorf("orphan bare Route %q must not be present after same-file composition", bare)
+		}
+	}
+
+	// Verify ROUTES_TO edges from composed routes exist.
+	type rel struct{ from, to string }
+	wantRels := map[rel]bool{
+		{"Route:/api/v1/users", "View:UserViewSet"}:   false,
+		{"Route:/api/v1/orders", "View:OrderViewSet"}: false,
+	}
+	for _, r := range result.Relationships {
+		if r.Kind != "ROUTES_TO" {
+			continue
+		}
+		k := rel{r.FromID, r.ToID}
+		if _, ok := wantRels[k]; ok {
+			wantRels[k] = true
+		}
+	}
+	for k, seen := range wantRels {
+		if !seen {
+			t.Errorf("missing composed ROUTES_TO %s -> %s", k.from, k.to)
+		}
+	}
+}
+
+// TestDRFCrossFile_BarePlainPathPreserved verifies that a bare path() in one
+// file, with no router.register() anywhere, produces a Route entity that is
+// NOT suppressed by the global registry (which would be empty).
+//
+// Fixture: a plain Django urls.py with non-DRF paths only.
+func TestDRFCrossFile_BarePlainPathPreserved(t *testing.T) {
+	plainURLs := `from django.urls import path
+from myapp import views
+
+urlpatterns = [
+    path('about/', views.about),
+    path('contact/', views.contact),
+]
+`
+	// Reset global registry — no register() calls in the repo.
+	ClearDRFRegisterNames()
+	ScanDRFRegisterNames([]byte(plainURLs))
+	t.Cleanup(ClearDRFRegisterNames)
+
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	ctx := context.Background()
+
+	result, err := det.Detect(ctx, extractor.FileInput{
+		Path:     "myapp/urls.py",
+		Content:  []byte(plainURLs),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	// Plain path-based routes must still be present (not suppressed).
+	got := map[string]bool{}
+	for _, e := range result.Entities {
+		if e.Kind == "Route" {
+			got[e.Name] = true
+		}
+	}
+	for _, want := range []string{"about/", "contact/"} {
+		if !got[want] {
+			t.Errorf("plain Route %q was incorrectly suppressed (got %v)", want, got)
+		}
+	}
+}
+
+// TestDRFCrossFile_ApplyDRFRoutes_AttributeFormInclude verifies that
+// ApplyDjangoDRFRoutes correctly emits prefixed routes when the parent file
+// uses attribute-form include(router.urls) to mount a routers file.
+//
+// Fixture: client-fixture-X layout where routers.py is included via
+// path("api/v1/", include(router.urls)) in urls.py (attribute form, not
+// string form).
+func TestDRFCrossFile_ApplyDRFRoutes_AttributeFormInclude(t *testing.T) {
+	routersPy := `from rest_framework.routers import DefaultRouter
+from .views import UserViewSet, OrderViewSet
+
+router = DefaultRouter()
+router.register(r'users', UserViewSet, basename='user')
+router.register(r'orders', OrderViewSet, basename='order')
+`
+	urlsPy := `from django.urls import path, include
+from .routers import router
+
+urlpatterns = [
+    path('api/v1/', include(router.urls)),
+]
+`
+	files := []string{"myapp/routers.py", "myapp/urls.py"}
+	contentMap := map[string][]byte{
+		"myapp/routers.py": []byte(routersPy),
+		"myapp/urls.py":    []byte(urlsPy),
+	}
+	reader := func(p string) []byte { return contentMap[p] }
+
+	out := ApplyDjangoDRFRoutes(files, reader)
+
+	// Collect all http_endpoint IDs.
+	ids := map[string]bool{}
+	for _, e := range out {
+		ids[e.ID] = true
+	}
+
+	// Expect prefixed routes (from the cross-file attribute-form include heuristic).
+	wantPrefixed := []string{
+		"http:GET:/api/v1/users",
+		"http:POST:/api/v1/users",
+		"http:GET:/api/v1/users/{pk}",
+	}
+	for _, want := range wantPrefixed {
+		if !ids[want] {
+			t.Errorf("expected prefixed route %q to be emitted; got %v", want, ids)
+		}
+	}
+
+	// Ghost bare-prefix routes must NOT be emitted.
+	ghostBare := []string{"http:GET:/users", "http:GET:/users/{pk}", "http:POST:/users"}
+	for _, ghost := range ghostBare {
+		if ids[ghost] {
+			t.Errorf("ghost bare-prefix route %q must not be emitted when parent uses attribute-form include", ghost)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the cross-file DRF router suppression bug that produced 124 ghost `http:ANY:/X` endpoints (no `/api/` prefix) for client-fixture-X, inflating the path count from ~370 to 494 (+33%).

**Root cause:** `claimedRegisterNames` was built per-file in `applyDjangoRouteComposition`. When `router.register()` calls live in one file (e.g. `routers.py`) and `path("api/v1/", include(router.urls))` lives in another file (e.g. `urls.py`), the suppression set is empty during the register-file pass — bare YAML `Route:users` entities escape, and `ApplyDjangoDRFRoutes` falls back to bare-prefix route emission (`/users` instead of `/api/v1/users`).

**Two complementary fixes:**

**1. Global cross-file register-name registry (`django_routes.go`)**
- Add `ScanDRFRegisterNames` / `ClearDRFRegisterNames` (same lifecycle as `ScanPythonClassRegistry` pre-pass) to build a repo-wide set of all `router.register()` basenames before per-file extraction begins.
- Restructure `applyDjangoRouteComposition` into two phases:
  - **Phase 1** (always, for every Python file): suppress bare YAML `Route` entities and `ROUTES_TO` edges whose name appears in the global set — even on register-only files where the pre-filter would have returned early.
  - **Phase 2** (same-file only): the original #64 AST-driven composed suppression.
- Add `suppressGlobalDRFOrphans` helper with a fast-path when the global registry is empty (no-op for non-DRF repos).

**2. Attribute-form parent include detection (`django_drf_actions.go`)**
- Extend `findParentIncludePrefixes` to also detect `path("prefix", include(routerVar.urls))` (attribute-form) in parent `urls.py` files, not only string-form `include("module.path")`.
- Heuristic: only fires when the target file contains `router.register()` calls (low false-positive risk).
- Prevents `ApplyDjangoDRFRoutes` from falling back to bare-prefix `[""]` and emitting ghost `http:ANY:/resource` endpoints.

**3. Pre-pass registration (`subproc.go`, `index.go`)**
- Calls `ClearDRFRegisterNames` + `ScanDRFRegisterNames` for every `.py` file in the same pre-pass loop as `ScanPythonClassRegistry`.

## Closes / Refs

- Closes #1278
- Refs #1115 (path count accuracy epic)

## Testing

- [x] 4 new tests in `drf_cross_file_1278_test.go`:
  - `TestDRFCrossFile_SuppressesOrphanRouteEntities` — cross-file: register in A, include in B → orphan Route entities suppressed
  - `TestDRFCrossFile_SameFileCompositionUnaffected` — same-file: #64 composition path unaffected by global registry (no regression)
  - `TestDRFCrossFile_BarePlainPathPreserved` — no-register: plain `path()` routes preserved when global registry is empty
  - `TestDRFCrossFile_ApplyDRFRoutes_AttributeFormInclude` — `ApplyDjangoDRFRoutes`: attribute-form parent include → prefixed routes only, no bare ghosts
- [x] All existing engine tests pass (`go test ./internal/engine/ -count=1`)
- [x] `go vet ./internal/engine/... ./internal/daemon/extract/...` passes

## Notes

The `suppressGlobalDRFOrphans` fast-path ensures zero allocation overhead for non-Python files and for Python files with no DRF route registrations anywhere in the repo. The attribute-form parent include heuristic in `findParentIncludePrefixes` is conservative: it only fires when the target file has `router.register()` calls, reducing false-positive risk. In the rare case of over-firing, the downstream dedup pass removes duplicate http_endpoint entities.

Expected outcome after merge + daemon restart + reindex of client-fixture-X: path count drops from 494 → ~370 (within 9% of ground truth ~405).