### PR TITLE
[#1285] Add POST /api/enrichments/{group}/batch-enrich endpoint

### DIFF
--- a/internal/dashboard/handlers_enrichment_batch.go
+++ b/internal/dashboard/handlers_enrichment_batch.go
@@ -1,0 +1,210 @@
+package dashboard
+
+// handlers_enrichment_batch.go — Batched enrichment API (issue #1285).
+//
+//	POST /api/enrichments/{group}/batch-enrich
+//
+// Accepts up to 50 enrichment candidates in one request, creates one job per
+// accepted candidate via the existing internal/jobs queue, and returns a
+// batch summary with accepted/rejected counts and rejection reasons.
+//
+// Already-enriched candidates (status=done in the job history for the entity)
+// are rejected with reason "already_enriched". Candidates that already have a
+// queued or running job for the same entity are rejected with "already_queued".
+// Requests with more than 50 candidates are rejected with HTTP 400 before any
+// jobs are created.
+//
+// The endpoint is idempotent by design: calling it twice with the same entity
+// list creates jobs only for entities that are not yet tracked.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/jobs"
+)
+
+// maxBatchSize is the hard cap on candidates per batch-enrich request.
+// Requests that exceed this are rejected with HTTP 400 before any jobs are
+// created, preventing context-window overflow in downstream agent calls.
+const maxBatchSize = 50
+
+// batchCandidate is one enrichment candidate inside a batch-enrich request.
+type batchCandidate struct {
+	// EntityID is the unique stable identifier for the entity (e.g. "ep-abc123").
+	EntityID string `json:"entity_id"`
+	// Kind is the enrichment kind (e.g. "http_endpoint", "process_flow").
+	// Defaults to "describe_entity" when empty.
+	Kind string `json:"kind,omitempty"`
+	// CriticalityBand is the optional priority band: "critical", "high",
+	// "medium", or "low". Stored on the job for scheduler-side prioritisation.
+	CriticalityBand string `json:"criticality_band,omitempty"`
+}
+
+// batchEnrichRequest is the JSON body for POST /api/enrichments/{group}/batch-enrich.
+type batchEnrichRequest struct {
+	// Candidates is the list of entities to enrich. Max 50.
+	Candidates []batchCandidate `json:"candidates"`
+	// ModelOverride optionally pins the Claude model for this batch.
+	// When empty, the queue worker uses its configured default.
+	ModelOverride string `json:"model_override,omitempty"`
+}
+
+// rejectionReason records why one candidate was not enqueued.
+type rejectionReason struct {
+	EntityID string `json:"entity_id"`
+	// Reason is one of: "already_enriched", "already_queued", "enqueue_failed".
+	Reason string `json:"reason"`
+	// Detail carries the underlying error message for "enqueue_failed" cases.
+	Detail string `json:"detail,omitempty"`
+}
+
+// batchEnrichResponse is returned by POST /api/enrichments/{group}/batch-enrich.
+type batchEnrichResponse struct {
+	// BatchID is a synthetic opaque identifier for client-side progress tracking.
+	BatchID string `json:"batch_id"`
+	// Accepted is the number of candidates successfully enqueued.
+	Accepted int `json:"accepted"`
+	// Rejected is the number of candidates skipped or failed.
+	Rejected int `json:"rejected"`
+	// JobIDs lists the newly created job IDs in the same order as the accepted
+	// candidates. Clients can poll GET /api/enrichments/{group}/jobs for status.
+	JobIDs []string `json:"job_ids"`
+	// RejectionReasons describes each skipped candidate.
+	RejectionReasons []rejectionReason `json:"rejection_reasons,omitempty"`
+}
+
+// handleEnrichmentBatch — POST /api/enrichments/{group}/batch-enrich
+//
+// Enqueues up to 50 enrichment candidates in a single HTTP round-trip.
+// Returns 400 if the batch exceeds 50 candidates. Returns 503 if the job
+// queue is not initialised. Returns 202 Accepted on success (even when all
+// candidates are rejected — the request was valid).
+func (s *Server) handleEnrichmentBatch(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	if s.jobQueue == nil {
+		writeErr(w, http.StatusServiceUnavailable, "job queue not initialised")
+		return
+	}
+
+	var req batchEnrichRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body: "+err.Error())
+		return
+	}
+
+	if len(req.Candidates) > maxBatchSize {
+		writeErr(w, http.StatusBadRequest,
+			fmt.Sprintf("batch too large: %d candidates (max %d)", len(req.Candidates), maxBatchSize))
+		return
+	}
+
+	if len(req.Candidates) == 0 {
+		writeErr(w, http.StatusBadRequest, "candidates list must not be empty")
+		return
+	}
+
+	// Build a lookup of entity_id → latest terminal job status for this group,
+	// so we can detect already_enriched and already_queued without extra round-trips.
+	entityStatus := buildEntityStatusMap(s.jobQueue, group)
+
+	batchID := newBatchID()
+	var (
+		jobIDs   []string
+		rejected []rejectionReason
+	)
+
+	for _, c := range req.Candidates {
+		entityID := strings.TrimSpace(c.EntityID)
+		if entityID == "" {
+			// Silently skip blank entity IDs; clients should not send them.
+			rejected = append(rejected, rejectionReason{
+				EntityID: c.EntityID,
+				Reason:   "invalid_entity_id",
+				Detail:   "entity_id must not be blank",
+			})
+			continue
+		}
+
+		switch entityStatus[entityID] {
+		case jobs.StatusDone:
+			rejected = append(rejected, rejectionReason{
+				EntityID: entityID,
+				Reason:   "already_enriched",
+			})
+			continue
+		case jobs.StatusQueued, jobs.StatusRunning:
+			rejected = append(rejected, rejectionReason{
+				EntityID: entityID,
+				Reason:   "already_queued",
+			})
+			continue
+		}
+
+		kind := c.Kind
+		if kind == "" {
+			kind = "describe_entity"
+		}
+
+		id, err := s.jobQueue.Enqueue(group, entityID, kind)
+		if err != nil {
+			s.auditor.Err("batch_enrich_enqueue", group,
+				map[string]any{"entity_id": entityID, "kind": kind, "batch_id": batchID},
+				err.Error())
+			rejected = append(rejected, rejectionReason{
+				EntityID: entityID,
+				Reason:   "enqueue_failed",
+				Detail:   err.Error(),
+			})
+			continue
+		}
+
+		jobIDs = append(jobIDs, id)
+	}
+
+	s.auditor.OK("batch_enrich", group, map[string]any{
+		"batch_id": batchID,
+		"accepted": len(jobIDs),
+		"rejected": len(rejected),
+		"model":    req.ModelOverride,
+	})
+
+	resp := batchEnrichResponse{
+		BatchID:          batchID,
+		Accepted:         len(jobIDs),
+		Rejected:         len(rejected),
+		JobIDs:           jobIDs,
+		RejectionReasons: rejected,
+	}
+	// Always 202 — the request was valid and the jobs were accepted.
+	writeJSON(w, http.StatusAccepted, resp)
+}
+
+// buildEntityStatusMap returns a map of entity_id → most-recent job Status
+// for all jobs in the given group. When multiple jobs exist for the same
+// entity, the most-recently-queued one wins (ListForGroup returns newest-first).
+func buildEntityStatusMap(q *jobs.Queue, group string) map[string]string {
+	all := q.ListForGroup(group) // newest-first per entity
+	m := make(map[string]string, len(all))
+	for _, j := range all {
+		// ListForGroup is newest-first; only record the first (newest) occurrence.
+		if _, seen := m[j.SubjectID]; !seen {
+			m[j.SubjectID] = j.Status
+		}
+	}
+	return m
+}
+
+// newBatchID returns a time-prefixed, URL-safe batch identifier.
+// Format: batch-<unix-ms>
+func newBatchID() string {
+	return fmt.Sprintf("batch-%d", time.Now().UnixMilli())
+}

--- a/internal/dashboard/handlers_enrichment_batch_test.go
+++ b/internal/dashboard/handlers_enrichment_batch_test.go
@@ -1,0 +1,306 @@
+package dashboard
+
+// handlers_enrichment_batch_test.go — HTTP-level tests for the batched
+// enrichment endpoint (issue #1285).
+//
+//	POST /api/enrichments/{group}/batch-enrich
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/jobs"
+)
+
+// doJSONRequest fires a request with a JSON body against the server routes.
+func doJSONRequest(t *testing.T, srv *Server, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(body); err != nil {
+		t.Fatalf("marshal request body: %v", err)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, req)
+	return w
+}
+
+// decodeBatchResp decodes the response body into a batchEnrichResponse.
+func decodeBatchResp(t *testing.T, w *httptest.ResponseRecorder) batchEnrichResponse {
+	t.Helper()
+	var resp batchEnrichResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode response: %v (body: %s)", err, w.Body.String())
+	}
+	return resp
+}
+
+// newBatchJobsServer creates a jobs server with a 2-worker queue (processes jobs).
+func newBatchJobsServer(t *testing.T) (*Server, *jobs.Queue) {
+	t.Helper()
+	return newJobsServer(t) // reuse existing helper from handlers_enrichment_jobs_test.go
+}
+
+// newZeroWorkerJobsServer creates a jobs server with a 0-worker queue (jobs stay queued).
+func newZeroWorkerJobsServer(t *testing.T) (*Server, *jobs.Queue) {
+	t.Helper()
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	q := jobs.NewQueue("", 0) // 0 workers — jobs never leave queued state
+	q.Start()
+	t.Cleanup(q.Stop)
+	srv.SetJobQueue(q)
+	return srv, q
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Happy-path: 30 candidates → 30 jobs accepted
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_happyPath(t *testing.T) {
+	srv, q := newBatchJobsServer(t)
+
+	candidates := make([]batchCandidate, 30)
+	for i := range candidates {
+		candidates[i] = batchCandidate{
+			EntityID:        fmt.Sprintf("ep-%03d", i),
+			Kind:            "http_endpoint",
+			CriticalityBand: "high",
+		}
+	}
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: candidates})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := decodeBatchResp(t, w)
+	if resp.Accepted != 30 {
+		t.Errorf("want accepted=30, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 0 {
+		t.Errorf("want rejected=0, got %d (%v)", resp.Rejected, resp.RejectionReasons)
+	}
+	if len(resp.JobIDs) != 30 {
+		t.Errorf("want 30 job IDs, got %d", len(resp.JobIDs))
+	}
+	if resp.BatchID == "" {
+		t.Error("want non-empty batch_id")
+	}
+
+	// All created jobs must be visible in the queue.
+	for _, id := range resp.JobIDs {
+		if _, ok := q.Get(id); !ok {
+			t.Errorf("job %s not found in queue", id)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Oversized batch → 400
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_oversized(t *testing.T) {
+	srv, _ := newBatchJobsServer(t)
+
+	candidates := make([]batchCandidate, maxBatchSize+1)
+	for i := range candidates {
+		candidates[i] = batchCandidate{EntityID: fmt.Sprintf("ep-%03d", i)}
+	}
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: candidates})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Empty candidates list → 400
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_emptyCandidates(t *testing.T) {
+	srv, _ := newBatchJobsServer(t)
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: []batchCandidate{}})
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for empty candidates, got %d", w.Code)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Idempotency: already_queued rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_alreadyQueued(t *testing.T) {
+	// Zero-worker queue: jobs stay in "queued" state indefinitely.
+	srv, q := newZeroWorkerJobsServer(t)
+
+	// Pre-enqueue "ep-001" so it shows as already_queued.
+	_, _ = q.Enqueue("g1", "ep-001", "http_endpoint")
+
+	candidates := []batchCandidate{
+		{EntityID: "ep-001", Kind: "http_endpoint"}, // already_queued
+		{EntityID: "ep-002", Kind: "http_endpoint"}, // new — should be accepted
+	}
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: candidates})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := decodeBatchResp(t, w)
+	if resp.Accepted != 1 {
+		t.Errorf("want accepted=1, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 1 {
+		t.Errorf("want rejected=1, got %d", resp.Rejected)
+	}
+	if len(resp.RejectionReasons) != 1 {
+		t.Fatalf("want 1 rejection reason, got %d", len(resp.RejectionReasons))
+	}
+	if resp.RejectionReasons[0].EntityID != "ep-001" {
+		t.Errorf("want ep-001 rejected, got %s", resp.RejectionReasons[0].EntityID)
+	}
+	if resp.RejectionReasons[0].Reason != "already_queued" {
+		t.Errorf("want reason=already_queued, got %q", resp.RejectionReasons[0].Reason)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Idempotency: already_enriched rejection
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_alreadyEnriched(t *testing.T) {
+	// Use a 2-worker queue so jobs actually run to "done" status.
+	srv, q := newBatchJobsServer(t)
+
+	// Enqueue "ep-done" and wait for it to reach done state.
+	id, _ := q.Enqueue("g1", "ep-done", "http_endpoint")
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		j, ok := q.Get(id)
+		if ok && j.Status == jobs.StatusDone {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	j, _ := q.Get(id)
+	if j.Status != jobs.StatusDone {
+		t.Fatalf("prerequisite: ep-done job never reached done state (status=%s)", j.Status)
+	}
+
+	// Now batch-enrich with ep-done (already_enriched) + ep-new (accepted).
+	candidates := []batchCandidate{
+		{EntityID: "ep-done", Kind: "http_endpoint"}, // already_enriched
+		{EntityID: "ep-new", Kind: "http_endpoint"},  // new
+	}
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: candidates})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := decodeBatchResp(t, w)
+	if resp.Accepted != 1 {
+		t.Errorf("want accepted=1, got %d", resp.Accepted)
+	}
+	if resp.Rejected != 1 {
+		t.Errorf("want rejected=1, got %d", resp.Rejected)
+	}
+	if len(resp.RejectionReasons) != 1 {
+		t.Fatalf("want 1 rejection reason, got %d", len(resp.RejectionReasons))
+	}
+	if resp.RejectionReasons[0].Reason != "already_enriched" {
+		t.Errorf("want reason=already_enriched, got %q", resp.RejectionReasons[0].Reason)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// No queue wired → 503
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_noQueue(t *testing.T) {
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// Do NOT call srv.SetJobQueue — leave it nil.
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{Candidates: []batchCandidate{{EntityID: "ep-001"}}})
+
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("want 503, got %d", w.Code)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Default kind: omitting kind field defaults to "describe_entity"
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_defaultKind(t *testing.T) {
+	srv, q := newBatchJobsServer(t)
+
+	w := doJSONRequest(t, srv, "POST", "/api/enrichments/g1/batch-enrich",
+		batchEnrichRequest{
+			Candidates: []batchCandidate{
+				{EntityID: "ep-no-kind"}, // Kind intentionally omitted
+			},
+		})
+
+	if w.Code != http.StatusAccepted {
+		t.Fatalf("want 202, got %d: %s", w.Code, w.Body.String())
+	}
+
+	resp := decodeBatchResp(t, w)
+	if resp.Accepted != 1 {
+		t.Fatalf("want accepted=1, got %d", resp.Accepted)
+	}
+
+	// Verify the created job has kind "describe_entity".
+	job, ok := q.Get(resp.JobIDs[0])
+	if !ok {
+		t.Fatal("job not found in queue")
+	}
+	if job.Kind != "describe_entity" {
+		t.Errorf("want kind=describe_entity, got %q", job.Kind)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Invalid JSON body → 400
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandleEnrichmentBatch_invalidJSON(t *testing.T) {
+	srv, _ := newBatchJobsServer(t)
+
+	req := httptest.NewRequest("POST", "/api/enrichments/g1/batch-enrich",
+		bytes.NewBufferString("not-json"))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d", w.Code)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -327,6 +327,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/enrichments/{group}/trigger", s.handleEnrichmentTrigger)
 	mux.HandleFunc("GET /api/enrichments/{group}/jobs", s.handleEnrichmentJobs)
 	mux.HandleFunc("POST /api/enrichments/{group}/jobs/{jobId}/cancel", s.handleEnrichmentJobCancel)
+	// Batched enrichment (#1285) — N candidates → N jobs in one round-trip
+	mux.HandleFunc("POST /api/enrichments/{group}/batch-enrich", s.handleEnrichmentBatch)
 
 	// Settings surface (#1206)
 	mux.HandleFunc("GET /api/settings", s.handleGetSettings)


### PR DESCRIPTION
## Summary

Implements Sub-B of enrichment UX epic #1282. Adds \`POST /api/enrichments/{group}/batch-enrich\` — a single HTTP endpoint that accepts up to 50 enrichment candidates and creates one job per accepted candidate via the existing \`internal/jobs\` queue. Reduces the round-trips needed to enrich 5,800 entities from 5,800 to ~120–290.

## Closes / Refs

- Closes #1285

## What changed

**\`internal/dashboard/handlers_enrichment_batch.go\`** (new)
- \`batchCandidate\` / \`batchEnrichRequest\` — request body types matching the issue spec (\`entity_id\`, \`kind\`, \`criticality_band\`, \`model_override\`)
- \`batchEnrichResponse\` — response with \`batch_id\`, \`accepted\`, \`rejected\`, \`job_ids\`, \`rejection_reasons\`
- \`handleEnrichmentBatch\` — validates body, rejects batches > 50 with HTTP 400, builds entity-status map from existing queue state, skips \`already_enriched\` (status=done) and \`already_queued\` (status=queued|running) candidates with per-candidate reasons, calls \`q.Enqueue\` for new entities, returns 202 with full summary
- \`buildEntityStatusMap\` — inspects \`ListForGroup\` (newest-first) to detect in-flight and completed jobs without extra round-trips
- \`newBatchID\` — synthetic \`batch-<unix-ms>\` identifier for client-side progress tracking

**\`internal/dashboard/server.go\`** (modified)
- Registers \`POST /api/enrichments/{group}/batch-enrich\` alongside the existing trigger/list/cancel routes

**\`internal/dashboard/handlers_enrichment_batch_test.go\`** (new)
- 7 tests: happy-path 30 candidates, oversized > 50 → 400, empty list → 400, \`already_queued\` idempotency, \`already_enriched\` idempotency, no-queue → 503, default kind, invalid JSON → 400

## Design decisions

- **Hard cap at 50** per issue spec — safe context-window budget for downstream agent calls
- **Idempotency by entity status**: inspects the live job queue in-process; no extra I/O
- **No new dependencies**: stdlib-only
- **Auditor integration**: accepted batches and enqueue failures logged via \`s.auditor\`

## Testing

- [x] All tests pass: \`go test ./internal/dashboard/ ./internal/jobs/... -count=1\`
- [x] Existing enrichment trigger/list/cancel tests unchanged
- [x] Batch tests cover all acceptance criteria

## Notes

- Real LLM dispatch remains stubbed in \`internal/jobs\` — real MCP wiring is a follow-up
- \`model_override\` is accepted and audit-logged; threading into \`jobs.Job\` is a follow-up