### PR TITLE
[#1292] Fix multi-batch DRF ghost suppression: coordinator pre-pass over all Python files

### DIFF
--- a/cmd/archigraph/extract.go
+++ b/cmd/archigraph/extract.go
@@ -81,6 +81,7 @@ func runExtractSubprocess(argv []string) error {
 		batch      = fs.String("batch", "", "path to newline-delimited batch file")
 		batchID    = fs.String("batch-id", "", "label propagated into stats")
 		skipPasses = fs.String("skip-pass", "", "comma-separated pass names to skip")
+		drfNames   = fs.String("drf-names", "", "path to coordinator-written DRF register-name file (#1292)")
 	)
 	if err := fs.Parse(argv); err != nil {
 		return err
@@ -98,11 +99,12 @@ func runExtractSubprocess(argv []string) error {
 	}
 
 	return extract.Run(context.Background(), extract.SubprocessOptions{
-		RepoRoot:   *repo,
-		Language:   *lang,
-		BatchPath:  *batch,
-		BatchID:    *batchID,
-		Output:     os.Stdout,
-		SkipPasses: skipSet,
+		RepoRoot:     *repo,
+		Language:     *lang,
+		BatchPath:    *batch,
+		BatchID:      *batchID,
+		Output:       os.Stdout,
+		SkipPasses:   skipSet,
+		DRFNamesPath: *drfNames,
 	})
 }

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 
 	"github.com/cajasmota/archigraph/internal/classifier"
+	"github.com/cajasmota/archigraph/internal/engine"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -147,6 +148,22 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 		return nil, err
 	}
 
+	// Pre-pass (#1292): build the repo-wide DRF register-name registry by
+	// scanning ALL Python files before any extraction batch spawns. This
+	// ensures every subprocess receives the complete set of router.register()
+	// basenames regardless of which batch those files land in.
+	//
+	// Without this, each subprocess only scanned its own partial batch, so
+	// register() calls in batch N were invisible to batch M — resulting in
+	// ghost bare-prefix Route entities (e.g. /alternate-addresses, /aoc)
+	// surviving suppression and appearing as phantom http_endpoints.
+	drfNamesPath, drfWriteErr := writeDRFNamesFile(batchDir, repoRoot, buckets["python"])
+	if drfWriteErr != nil {
+		// Non-fatal: fall back to per-batch scan (which is correct for single-batch
+		// repos and avoids a hard failure if the pre-pass itself has an I/O error).
+		drfNamesPath = ""
+	}
+
 	skip := strings.Join(cfg.SkipPasses, ",")
 	stderr := cfg.Stderr
 	if stderr == nil {
@@ -189,6 +206,9 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 			}
 			if b.language != "" {
 				args = append(args, "--lang", b.language)
+			}
+			if drfNamesPath != "" {
+				args = append(args, "--drf-names", drfNamesPath)
 			}
 			if skip != "" {
 				args = append(args, "--skip-pass", skip)
@@ -340,6 +360,60 @@ func writeBatches(dir string, buckets map[string][]string, batchSize int) ([]bat
 		}
 	}
 	return batches, nil
+}
+
+// writeDRFNamesFile scans all Python files in pyFiles for router.register()
+// basenames and writes one basename per line to a temp file in dir. Returns
+// the absolute path of the written file, or ("", nil) when no names were
+// found (so subprocesses stay in fallback mode and don't need the flag).
+//
+// This is the coordinator side of the #1292 multi-batch DRF ghost fix. By
+// scanning ALL Python files at once (before any subprocess spawns), we produce
+// a complete, repo-wide set of DRF register basenames. Each subprocess then
+// loads this file via --drf-names instead of scanning only its own partial
+// batch — eliminating the cross-batch visibility gap that caused 124 ghost
+// bare-prefix paths to survive suppression.
+func writeDRFNamesFile(dir, repoRoot string, pyFiles []string) (string, error) {
+	if len(pyFiles) == 0 {
+		return "", nil
+	}
+
+	// Scan all Python files into the engine's global registry temporarily.
+	engine.ClearDRFRegisterNames()
+	for _, rel := range pyFiles {
+		abs := filepath.Join(repoRoot, rel)
+		content, err := os.ReadFile(abs)
+		if err != nil {
+			continue // skip unreadable files; don't fail the whole pre-pass
+		}
+		engine.ScanDRFRegisterNames(content)
+	}
+
+	names := engine.CollectDRFRegisterNames()
+	// Always clear after collecting — we don't want this coordinator-side global
+	// to bleed into any in-process extraction that might follow (tests, etc.).
+	engine.ClearDRFRegisterNames()
+
+	if len(names) == 0 {
+		return "", nil // no register() calls found; subprocesses use fallback
+	}
+
+	f, err := os.CreateTemp(dir, "drf-names-*.txt")
+	if err != nil {
+		return "", fmt.Errorf("create drf-names file: %w", err)
+	}
+	defer f.Close()
+
+	w := bufio.NewWriter(f)
+	for _, n := range names {
+		if _, err := fmt.Fprintln(w, n); err != nil {
+			return "", fmt.Errorf("write drf-names file: %w", err)
+		}
+	}
+	if err := w.Flush(); err != nil {
+		return "", fmt.Errorf("flush drf-names file: %w", err)
+	}
+	return f.Name(), nil
 }
 
 // decodeStream consumes the subprocess's stdout (one JSONL envelope per

--- a/internal/daemon/extract/subproc.go
+++ b/internal/daemon/extract/subproc.go
@@ -53,6 +53,15 @@ type SubprocessOptions struct {
 	// passes (graph-algo, build-document, enrichment) never run inside
 	// the subprocess regardless of this set — the daemon owns those.
 	SkipPasses map[string]bool
+
+	// DRFNamesPath is the absolute path of a newline-delimited file that
+	// contains every DRF router.register() basename collected by the
+	// coordinator's repo-wide pre-pass. When set, the subprocess loads
+	// the global DRF register-name registry from this file instead of
+	// re-scanning only its own (partial) batch — which would miss register
+	// calls in files assigned to other batches. This is the fix for the
+	// multi-batch ghost path regression described in issue #1292.
+	DRFNamesPath string
 }
 
 // Run is the subprocess-side entrypoint. It is invoked from
@@ -143,21 +152,46 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 	// lightweight line-based pass (no AST). ClearPythonClassRegistry resets any
 	// state from a prior batch to avoid bleeding across unrelated index runs.
 	//
-	// Pre-pass (#1278): build cross-file DRF register-name registry. Scans
-	// every Python file for router.register() basenames so that
-	// applyDjangoRouteComposition can suppress bare Route entities even when
-	// the matching include(router.urls) call lives in a different file.
+	// Pre-pass (#1278 / #1292): load cross-file DRF register-name registry.
+	//
+	// When the coordinator provides a DRFNamesPath file (multi-batch mode), we
+	// load the globally-collected register names from it — those names span ALL
+	// Python files in the repo, not just the files in this batch. This is the
+	// fix for #1292: the original per-batch scan only saw the files in each
+	// individual batch, so register names from other batches were invisible,
+	// allowing ghost bare-prefix Route entities to survive suppression.
+	//
+	// When DRFNamesPath is empty (single-batch mode or tests), we fall back to
+	// scanning the files in this batch (the original #1278 behaviour).
 	if runExtract {
 		pyextr.ClearPythonClassRegistry()
 		engine.ClearDRFRegisterNames()
-		for _, rel := range files {
-			abs := filepath.Join(opts.RepoRoot, rel)
-			if !strings.HasSuffix(strings.ToLower(rel), ".py") {
-				continue
+		if opts.DRFNamesPath != "" {
+			// Multi-batch path (#1292): load the coordinator-written global set.
+			if names, err := readDRFNamesFile(opts.DRFNamesPath); err == nil {
+				engine.LoadDRFRegisterNames(names)
 			}
-			if pyContent, err := os.ReadFile(abs); err == nil {
-				pyextr.ScanPythonClassRegistry(rel, string(pyContent))
-				engine.ScanDRFRegisterNames(pyContent)
+			// Still scan the batch for the Python class registry (unrelated to DRF).
+			for _, rel := range files {
+				abs := filepath.Join(opts.RepoRoot, rel)
+				if !strings.HasSuffix(strings.ToLower(rel), ".py") {
+					continue
+				}
+				if pyContent, err := os.ReadFile(abs); err == nil {
+					pyextr.ScanPythonClassRegistry(rel, string(pyContent))
+				}
+			}
+		} else {
+			// Single-batch / fallback path (#1278): scan only the files in this batch.
+			for _, rel := range files {
+				abs := filepath.Join(opts.RepoRoot, rel)
+				if !strings.HasSuffix(strings.ToLower(rel), ".py") {
+					continue
+				}
+				if pyContent, err := os.ReadFile(abs); err == nil {
+					pyextr.ScanPythonClassRegistry(rel, string(pyContent))
+					engine.ScanDRFRegisterNames(pyContent)
+				}
 			}
 		}
 	}
@@ -308,6 +342,29 @@ func Run(ctx context.Context, opts SubprocessOptions) error {
 }
 
 // readBatch reads a newline-delimited file of repo-relative paths.
+// readDRFNamesFile reads the coordinator-written DRF register-name file and
+// returns the list of basenames. The file format is one basename per line;
+// blank lines are skipped. This is part of the #1292 multi-batch fix: the
+// coordinator writes ALL repo-wide DRF register names before spawning any
+// subprocesses, and each subprocess loads from this file rather than scanning
+// only its own partial batch.
+func readDRFNamesFile(path string) ([]string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	sc := bufio.NewScanner(f)
+	var out []string
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line != "" {
+			out = append(out, line)
+		}
+	}
+	return out, sc.Err()
+}
+
 // Blank lines and lines beginning with '#' are skipped so the batch
 // files are inspectable by hand when debugging.
 func readBatch(path string) ([]string, error) {

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -97,12 +97,46 @@ func ClearDRFRegisterNames() {
 	drfGlobalRegisterNames = map[string]bool{}
 }
 
+// LoadDRFRegisterNames populates the global DRF register-name registry from
+// a pre-collected slice of basenames. This is the subprocess entry point for
+// the multi-batch coordinator path: the coordinator scans ALL Python files
+// once, writes the collected names to a temp file, and each subprocess loads
+// them here instead of re-scanning its own (partial) batch.
+//
+// Calling this replaces any names currently in the registry; call
+// ClearDRFRegisterNames first if you want a clean slate.
+func LoadDRFRegisterNames(names []string) {
+	if len(names) == 0 {
+		return
+	}
+	drfGlobalMu.Lock()
+	defer drfGlobalMu.Unlock()
+	for _, n := range names {
+		if n != "" {
+			drfGlobalRegisterNames[n] = true
+		}
+	}
+}
+
 // isDRFGlobalRegisterName reports whether name appears in the cross-file
 // DRF register-name registry populated by the ScanDRFRegisterNames pre-pass.
 func isDRFGlobalRegisterName(name string) bool {
 	drfGlobalMu.RLock()
 	defer drfGlobalMu.RUnlock()
 	return drfGlobalRegisterNames[name]
+}
+
+// CollectDRFRegisterNames returns a snapshot of all currently-registered DRF
+// register basenames. Used by the coordinator to write the global name set to a
+// temp file before spawning subprocesses.
+func CollectDRFRegisterNames() []string {
+	drfGlobalMu.RLock()
+	defer drfGlobalMu.RUnlock()
+	out := make([]string, 0, len(drfGlobalRegisterNames))
+	for n := range drfGlobalRegisterNames {
+		out = append(out, n)
+	}
+	return out
 }
 
 // composedDjangoRoutes holds the output of the Django AST pass.

--- a/internal/engine/drf_cross_file_1278_test.go
+++ b/internal/engine/drf_cross_file_1278_test.go
@@ -231,6 +231,128 @@ urlpatterns = [
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Multi-batch ghost regression (#1292)
+// ---------------------------------------------------------------------------
+//
+// This test reproduces the exact failure mode that caused 124 ghost bare-prefix
+// paths to survive after #1290 merged:
+//
+// The coordinator partitions Python files into batches of ~80. Each batch
+// previously ran ClearDRFRegisterNames + ScanDRFRegisterNames on only its OWN
+// files. When router.register() calls lived in batch-0 files and the consuming
+// file (with include(router.urls)) lived in batch-1, the batch-1 subprocess
+// had an empty global registry and never suppressed the ghost Route entities.
+//
+// The fix (coordinator side): scan ALL Python files once → write names file →
+// each subprocess loads the file via LoadDRFRegisterNames.
+//
+// This test simulates that two-batch scenario at the engine level:
+// batch-0 has router_test.py (register-only), batch-1 has urls_test.py
+// (include-only). We verify that:
+//  1. Loading names via LoadDRFRegisterNames (the new path) suppresses ghosts.
+//  2. Route entities composed by the AST pass (with /api/v1/ prefix) survive.
+
+// TestDRFMultiBatch_GhostsSuppressedViaLoadedNames verifies that bare
+// Route entities from a router.register()-only file are suppressed even when
+// LoadDRFRegisterNames is used to populate the global set (coordinator path).
+//
+// Regression test for #1292.
+func TestDRFMultiBatch_GhostsSuppressedViaLoadedNames(t *testing.T) {
+	// Simulate coordinator pre-pass: scan batch-0 (router_test.py) and collect names.
+	// In production the coordinator writes these to a file; here we directly call
+	// ScanDRFRegisterNames then CollectDRFRegisterNames to get the slice.
+	ClearDRFRegisterNames()
+	ScanDRFRegisterNames([]byte(crossFileRoutersFile)) // batch-0 files only
+	collectedNames := CollectDRFRegisterNames()
+	ClearDRFRegisterNames() // simulate subprocess starting with empty state
+
+	// Simulate batch-1 subprocess: load names from the coordinator file.
+	LoadDRFRegisterNames(collectedNames) // <-- the new path introduced in #1292
+	t.Cleanup(ClearDRFRegisterNames)
+
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	ctx := context.Background()
+
+	// Detect router_test.py (the batch-0 file with only register() calls).
+	// In multi-batch mode, batch-0 subprocess ALSO receives the names file, so
+	// it suppresses its own YAML Route entities via LoadDRFRegisterNames.
+	routersResult, err := det.Detect(ctx, extractor.FileInput{
+		Path:     "router_test/routers.py",
+		Content:  []byte(crossFileRoutersFile),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("Detect(routers.py): %v", err)
+	}
+
+	// Bare ghost Route entities must be absent.
+	ghostNames := map[string]bool{"users": true, "orders": true}
+	for _, e := range routersResult.Entities {
+		if e.Kind == "Route" && ghostNames[e.Name] {
+			t.Errorf("[#1292] ghost Route %q survived multi-batch suppression; "+
+				"LoadDRFRegisterNames not consulted by applyDjangoRouteComposition", e.Name)
+		}
+	}
+	// Ghost ROUTES_TO edges must also be absent.
+	for _, r := range routersResult.Relationships {
+		if r.Kind == "ROUTES_TO" && len(r.FromID) > 6 {
+			bare := r.FromID[6:] // strip "Route:"
+			if ghostNames[bare] {
+				t.Errorf("[#1292] ghost ROUTES_TO Route:%s survived multi-batch suppression", bare)
+			}
+		}
+	}
+
+	// Ghost http_endpoint entities must also be absent (synthesizeDjangoFromComposed
+	// consumes ast_driven Route entities; there should be none for bare names).
+	for _, e := range routersResult.Entities {
+		if e.Kind == "http_endpoint" {
+			// Paths like /users, /orders, /users/{pk}, /orders/{pk} are ghosts.
+			for ghost := range ghostNames {
+				if e.Name == "/"+ghost || e.Name == "/"+ghost+"/{pk}" {
+					t.Errorf("[#1292] ghost http_endpoint %q must not appear after multi-batch suppression", e.Name)
+				}
+			}
+		}
+	}
+}
+
+// TestDRFMultiBatch_CollectAndLoadRoundTrip verifies that the
+// CollectDRFRegisterNames→clear→LoadDRFRegisterNames round-trip correctly
+// transfers all names. This tests the coordinator↔subprocess boundary.
+func TestDRFMultiBatch_CollectAndLoadRoundTrip(t *testing.T) {
+	content := []byte(`
+from rest_framework.routers import DefaultRouter
+router = DefaultRouter()
+router.register(r'alternate-addresses', AlternateAddressViewSet)
+router.register(r'aoc', AocViewSet)
+router.register(r'auth/login', AuthLoginViewSet)
+`)
+	ClearDRFRegisterNames()
+	ScanDRFRegisterNames(content)
+	collected := CollectDRFRegisterNames()
+	ClearDRFRegisterNames()
+
+	if len(collected) != 3 {
+		t.Fatalf("expected 3 names collected, got %d: %v", len(collected), collected)
+	}
+
+	// Load into fresh state (subprocess side).
+	LoadDRFRegisterNames(collected)
+	t.Cleanup(ClearDRFRegisterNames)
+
+	for _, name := range []string{"alternate-addresses", "aoc", "auth/login"} {
+		if !isDRFGlobalRegisterName(name) {
+			t.Errorf("name %q missing after LoadDRFRegisterNames round-trip", name)
+		}
+	}
+}
+
 // TestDRFCrossFile_ApplyDRFRoutes_AttributeFormInclude verifies that
 // ApplyDjangoDRFRoutes correctly emits prefixed routes when the parent file
 // uses attribute-form include(router.urls) to mount a routers file.


### PR DESCRIPTION
## Summary

**Root cause of #1292 (why #1290 didn't actually fix the 124 ghosts):**

The coordinator partitions Python files into batches of ~80. Each subprocess previously ran `ClearDRFRegisterNames` + `ScanDRFRegisterNames` on only its **own batch files**. When `router.register()` calls were in batch-0 files and the `include(router.urls)` call was in a batch-1 file, the batch-1 subprocess had an **empty global register-name set** and never suppressed the ghost bare-prefix Route entities — exactly the 124 ghosts (`/alternate-addresses`, `/aoc`, `/auth/login`, etc.) that survived despite #1290.

**Fix:**

The coordinator now runs a single repo-wide DRF pre-pass **before spawning any subprocess** (`writeDRFNamesFile`). It scans ALL Python files, collects the complete set of `router.register()` basenames, writes them to a temp file, and passes `--drf-names <file>` to every subproc. Each subprocess loads the names via the new `engine.LoadDRFRegisterNames()` instead of re-scanning its partial batch.

**New engine API (2 functions):**
- `LoadDRFRegisterNames(names []string)` — subprocess entry point: populates registry from coordinator-written slice
- `CollectDRFRegisterNames() []string` — coordinator entry point: snapshot current registry for serialization

**Fallback safety:** if `writeDRFNamesFile` fails (I/O error), `drfNamesPath` is empty and each subprocess falls back to the original per-batch scan. Single-batch repos (≤80 Python files) are unaffected.

## Closes / Refs
- Closes #1292
- Fixes the regression introduced by #1290 (which was correct in concept but broke under multi-batch execution)

## Testing
- [x] All tests pass: `go test ./...` (engine + extract packages)
- [x] `TestDRFMultiBatch_GhostsSuppressedViaLoadedNames` — new test simulating two-batch scenario: verifies ghost Routes suppressed when registry loaded via `LoadDRFRegisterNames`
- [x] `TestDRFMultiBatch_CollectAndLoadRoundTrip` — new test verifying collect→clear→load round-trip preserves all names across the coordinator↔subprocess boundary
- [x] All 4 existing `TestDRFCrossFile_*` tests still pass unchanged
- [x] `TestCoordinate_EndToEnd` passes (extract package integration test)

## Notes

**Why #1290 appeared to work in unit tests:** The `TestDRFCrossFile_*` tests call `ScanDRFRegisterNames` directly in-process — they never go through the coordinator/subprocess split. The bug only manifests when `ARCHIGRAPH_SUBPROC_EXTRACT=1` and the repo has >80 Python files. client-fixture-X has hundreds of Python files, so it always produces multiple Python batches.

**Verify after deploy:**
```bash
curl http://127.0.0.1:47274/api/paths/upvate | jq '[.paths[]|select(.path|startswith("/api/")|not)|select(.path|startswith("/admin/")|not)]|length'
# should return 0 (was 124)
```