### PR TITLE
[#1286] Per-tier enrichment progress UI — live progress bars in /pending

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -92,6 +92,7 @@ import type {
   EntityNeighborResponse,
   PendingRepairsResponse,
   PendingEnrichmentsResponse,
+  EnrichmentProgressResponse,
   OrphanCallersResponse,
   OrphanPublishersResponse,
   OrphanSubscribersResponse,
@@ -933,6 +934,23 @@ export async function fetchEnrichments(group: string): Promise<PendingEnrichment
     return { items: [], total: 0 }
   }
   return apiFetch<PendingEnrichmentsResponse>(`/api/enrichments/${group}`)
+}
+
+/** GET /api/enrichments/{group}/progress — per-tier job progress (#1286) */
+export async function fetchEnrichmentProgress(group: string): Promise<EnrichmentProgressResponse> {
+  if (USE_MOCKS) {
+    return {
+      tiers: [
+        { band: 'critical', total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+        { band: 'high',     total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+        { band: 'medium',   total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+        { band: 'low',      total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+      ],
+      overall_done: 0,
+      overall_total: 0,
+    }
+  }
+  return apiFetch<EnrichmentProgressResponse>(`/api/enrichments/${group}/progress`)
 }
 
 /**

--- a/dashboard/src/hooks/shared/useEnrichmentProgress.ts
+++ b/dashboard/src/hooks/shared/useEnrichmentProgress.ts
@@ -1,0 +1,94 @@
+/**
+ * useEnrichmentProgress — polling hook for per-tier enrichment job progress (#1286).
+ *
+ * Polls GET /api/enrichments/{group}/progress every 3 seconds while any tier
+ * has running or queued jobs. Stops automatically when all tiers are done.
+ *
+ * Returns the latest EnrichmentProgressResponse plus a boolean `isActive`
+ * indicating whether any enrichment is currently in progress.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { fetchEnrichmentProgress } from '@/api/client'
+import type { EnrichmentProgressResponse } from '@/types/api'
+
+export const POLL_INTERVAL_MS = 3_000
+
+export interface UseEnrichmentProgressReturn {
+  progress: EnrichmentProgressResponse | null
+  /** True while any tier has running or queued jobs. */
+  isActive: boolean
+  /** True on the initial fetch before any data arrives. */
+  isLoading: boolean
+  error: string | null
+}
+
+function hasActiveJobs(data: EnrichmentProgressResponse): boolean {
+  return data.tiers.some((t) => t.running > 0 || t.queued > 0)
+}
+
+/**
+ * @param group - The group slug to monitor. Pass undefined/'' to skip.
+ */
+export function useEnrichmentProgress(group: string | undefined): UseEnrichmentProgressReturn {
+  const [progress, setProgress] = useState<EnrichmentProgressResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  useEffect(() => {
+    if (!group) return
+
+    let cancelled = false
+
+    async function poll() {
+      if (cancelled || !mountedRef.current) return
+      try {
+        const data = await fetchEnrichmentProgress(group!)
+        if (cancelled || !mountedRef.current) return
+        setProgress(data)
+        setError(null)
+
+        // Keep polling while jobs are active; back off to a single static
+        // snapshot when all tiers are idle (total == 0 or all done).
+        const active = hasActiveJobs(data)
+        if (active) {
+          timerRef.current = setTimeout(poll, POLL_INTERVAL_MS)
+        }
+      } catch (err) {
+        if (cancelled || !mountedRef.current) return
+        setError(err instanceof Error ? err.message : 'Failed to fetch progress')
+        // Retry on error so a transient daemon restart doesn't freeze the UI.
+        timerRef.current = setTimeout(poll, POLL_INTERVAL_MS)
+      } finally {
+        if (!cancelled && mountedRef.current) {
+          setIsLoading(false)
+        }
+      }
+    }
+
+    // Initial fetch
+    setIsLoading(true)
+    void poll()
+
+    return () => {
+      cancelled = true
+      if (timerRef.current != null) {
+        clearTimeout(timerRef.current)
+        timerRef.current = null
+      }
+    }
+  }, [group])
+
+  const isActive = progress != null && hasActiveJobs(progress)
+
+  return { progress, isActive, isLoading, error }
+}

--- a/dashboard/src/routes/pending.tsx
+++ b/dashboard/src/routes/pending.tsx
@@ -2,11 +2,12 @@ import { useState, useMemo, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { fetchRepairs, fetchEnrichments, postCandidateAction } from '@/api/client'
-import type { PendingCandidateRow, QualificationSignal } from '@/types/api'
+import type { PendingCandidateRow, QualificationSignal, EnrichmentProgressBand } from '@/types/api'
+import { useEnrichmentProgress } from '@/hooks/shared/useEnrichmentProgress'
 import {
   Wrench, Sparkles, CheckCircle, XCircle, AlertCircle,
   ChevronDown, ChevronRight, Search, EyeOff,
-  ArrowUpDown,
+  ArrowUpDown, Loader2,
 } from 'lucide-react'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -114,6 +115,181 @@ function scoreTier(score: number): TierId {
   if (score >= 60) return 'high'
   if (score >= 40) return 'medium'
   return 'low'
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ETA formatter
+// ─────────────────────────────────────────────────────────────────────────────
+
+function formatEta(seconds: number): string {
+  if (seconds < 60) return `${seconds}s`
+  const m = Math.round(seconds / 60)
+  return `~${m}m`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EnrichmentProgressPanel — live per-tier bars (#1286)
+// ─────────────────────────────────────────────────────────────────────────────
+
+const TIER_COLOR: Record<string, { bar: string; text: string; bg: string }> = {
+  critical: {
+    bar: 'bg-red-500 dark:bg-red-400',
+    text: 'text-red-700 dark:text-red-400',
+    bg: 'bg-red-100 dark:bg-red-900/20',
+  },
+  high: {
+    bar: 'bg-orange-500 dark:bg-orange-400',
+    text: 'text-orange-700 dark:text-orange-400',
+    bg: 'bg-orange-100 dark:bg-orange-900/20',
+  },
+  medium: {
+    bar: 'bg-yellow-500 dark:bg-yellow-400',
+    text: 'text-yellow-700 dark:text-yellow-400',
+    bg: 'bg-yellow-100 dark:bg-yellow-900/20',
+  },
+  low: {
+    bar: 'bg-slate-400 dark:bg-slate-500',
+    text: 'text-slate-600 dark:text-slate-400',
+    bg: 'bg-slate-100 dark:bg-slate-800/40',
+  },
+}
+
+interface TierProgressBarProps {
+  band: EnrichmentProgressBand
+}
+
+function TierProgressBar({ band }: TierProgressBarProps) {
+  const colors = TIER_COLOR[band.band] ?? TIER_COLOR.low
+  const pct = band.total > 0 ? Math.round((band.done / band.total) * 100) : 0
+  const hasWork = band.running > 0 || band.queued > 0
+  const isNotStarted = band.total > 0 && band.done === 0 && !hasWork
+  const isDone = band.total > 0 && band.done === band.total
+
+  let statusText: string
+  if (band.total === 0) {
+    statusText = 'no jobs'
+  } else if (isDone) {
+    statusText = 'done'
+  } else if (isNotStarted) {
+    statusText = 'not started'
+  } else if (band.eta_seconds != null) {
+    statusText = `ETA ${formatEta(band.eta_seconds)}`
+  } else if (hasWork) {
+    statusText = 'calculating…'
+  } else {
+    statusText = `${band.done}/${band.total}`
+  }
+
+  const label = `${band.band.charAt(0).toUpperCase() + band.band.slice(1)}: ${band.done}/${band.total} done. ${statusText}`
+
+  return (
+    <div
+      role="group"
+      aria-label={`${band.band} tier enrichment progress`}
+      className={`flex items-center gap-3 px-3 py-2 rounded-lg ${colors.bg}`}
+    >
+      {/* Tier label */}
+      <span className={`w-16 text-xs font-semibold shrink-0 capitalize ${colors.text}`}>
+        {band.band}
+      </span>
+
+      {/* Progress bar */}
+      <div className="flex-1 min-w-0">
+        <div
+          role="progressbar"
+          aria-label={label}
+          aria-valuenow={pct}
+          aria-valuemin={0}
+          aria-valuemax={100}
+          className="h-2 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden"
+        >
+          <div
+            className={`h-full rounded-full transition-all duration-700 ease-out ${colors.bar} ${band.running > 0 ? 'animate-pulse' : ''}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+      </div>
+
+      {/* Count */}
+      <span className="w-20 text-xs tabular-nums text-slate-600 dark:text-slate-400 shrink-0 text-right">
+        {band.total > 0 ? `${band.done}/${band.total}` : '—'}
+      </span>
+
+      {/* ETA / status */}
+      <span className="w-24 text-xs text-slate-500 dark:text-slate-400 shrink-0 text-right">
+        {statusText}
+      </span>
+
+      {/* Running spinner */}
+      {band.running > 0 && (
+        <Loader2 className="w-3.5 h-3.5 shrink-0 text-sky-500 animate-spin" aria-hidden="true" />
+      )}
+    </div>
+  )
+}
+
+interface EnrichmentProgressPanelProps {
+  group: string
+}
+
+/**
+ * EnrichmentProgressPanel renders a collapsible live-progress overlay for
+ * the enrichment queue (#1286). It auto-shows when jobs are active and
+ * collapses once all tiers reach 100%.
+ */
+function EnrichmentProgressPanel({ group }: EnrichmentProgressPanelProps) {
+  const { progress, isActive } = useEnrichmentProgress(group)
+  const [collapsed, setCollapsed] = useState(false)
+
+  // Don't render if we've never fetched or there are no jobs at all.
+  if (progress == null || progress.overall_total === 0) return null
+
+  const allDone = progress.overall_done === progress.overall_total
+  // Once everything is done, collapse automatically after first render.
+  if (allDone && !collapsed && !isActive) {
+    // We don't mutate state here — we just show a "Completed" state.
+  }
+
+  return (
+    <div
+      data-testid="enrichment-progress-panel"
+      className="mx-4 mt-3 mb-1 rounded-xl border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 shadow-sm overflow-hidden"
+    >
+      {/* Header */}
+      <button
+        type="button"
+        aria-expanded={!collapsed}
+        aria-controls="enrichment-progress-body"
+        onClick={() => setCollapsed((c) => !c)}
+        className="w-full flex items-center gap-2 px-4 py-2.5 text-left hover:bg-slate-50 dark:hover:bg-slate-800/50 transition-colors"
+      >
+        {collapsed
+          ? <ChevronRight className="w-4 h-4 text-slate-400 shrink-0" />
+          : <ChevronDown className="w-4 h-4 text-slate-400 shrink-0" />
+        }
+        <span className="text-sm font-semibold text-slate-700 dark:text-slate-300 flex items-center gap-2">
+          Enrichment Progress
+          {isActive && <Loader2 className="w-3.5 h-3.5 text-sky-500 animate-spin" aria-label="enrichment running" />}
+        </span>
+        <span className="ml-auto text-xs tabular-nums text-slate-500 dark:text-slate-400">
+          {progress.overall_done}/{progress.overall_total}
+          {allDone && <span className="ml-1.5 text-emerald-600 dark:text-emerald-400 font-medium">Complete</span>}
+        </span>
+      </button>
+
+      {/* Body */}
+      {!collapsed && (
+        <div
+          id="enrichment-progress-body"
+          className="px-4 pb-3 space-y-1.5"
+        >
+          {progress.tiers.map((band) => (
+            <TierProgressBar key={band.band} band={band} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -855,12 +1031,16 @@ export function PendingRoute() {
         )}
 
         {!isLoading && !hasError && activeTab === 'enrichments' && (
-          <TieredList
-            rows={enrichmentsQuery.data?.items ?? []}
-            group={group}
-            emptyMessage="No pending enrichments — all candidates resolved"
-            onApplied={() => setAppliedCount((n) => n + 1)}
-          />
+          <div className="flex flex-col flex-1 overflow-hidden">
+            {/* Per-tier live progress (#1286) */}
+            <EnrichmentProgressPanel group={group} />
+            <TieredList
+              rows={enrichmentsQuery.data?.items ?? []}
+              group={group}
+              emptyMessage="No pending enrichments — all candidates resolved"
+              onApplied={() => setAppliedCount((n) => n + 1)}
+            />
+          </div>
         )}
       </div>
     </div>

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -787,6 +787,38 @@ export interface PendingEnrichmentsResponse {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Enrichment progress — GET /api/enrichments/{group}/progress (#1286)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** One criticality tier in the progress response. */
+export interface EnrichmentProgressBand {
+  /** "critical" | "high" | "medium" | "low" */
+  band: string
+  /** Total jobs submitted for this tier. */
+  total: number
+  /** Jobs that finished with status "done". */
+  done: number
+  /** Jobs currently executing. */
+  running: number
+  /** Jobs waiting in queue. */
+  queued: number
+  /** Jobs that failed or were cancelled. */
+  failed: number
+  /** Seconds until this tier completes, based on rolling-window throughput.
+   *  Absent when fewer than 2 jobs have finished (not enough data). */
+  eta_seconds?: number
+}
+
+/** Response shape for GET /api/enrichments/{group}/progress. */
+export interface EnrichmentProgressResponse {
+  tiers: EnrichmentProgressBand[]
+  overall_done: number
+  overall_total: number
+  /** ISO timestamp of the earliest running job's started_at. */
+  started_at?: string
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Surface 1 — Graph Viewer
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/dashboard/tests/e2e/enrichment-tier-progress.spec.ts
+++ b/dashboard/tests/e2e/enrichment-tier-progress.spec.ts
@@ -1,0 +1,278 @@
+/**
+ * E2E: Per-tier enrichment progress UI (#1286)
+ *
+ * Tests:
+ *   1. EnrichmentProgressPanel is absent when there are no active jobs.
+ *   2. Panel appears when the progress endpoint reports running jobs.
+ *   3. All four tier bars render independently with correct ARIA labels.
+ *   4. "Complete" label appears when overall_done === overall_total.
+ *   5. Polling resumes after an error response.
+ *   6. VIEW screenshot with active progress (tier bars animating).
+ *
+ * Strategy: Playwright route.fulfill() intercepts
+ *   GET /api/enrichments/{group}/progress
+ * and returns controlled JSON. No live daemon required.
+ *
+ * The test also intercepts /api/enrichments/{group} so the Enrichment
+ * Candidates tab renders (empty list is fine) without a 502.
+ */
+
+import { test, expect } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:5173'
+const SCREENSHOT_DIR = path.join(__dirname, '..', '..', 'test-results', 'enrichment-progress')
+
+function mkdirp(dir: string) {
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true })
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Shared mock data
+// ──────────────────────────────────────────────────────────────────────────────
+
+const GROUP_SLUG = 'fixture-enrich'
+
+const MOCK_REGISTRY = {
+  groups: [
+    {
+      name: GROUP_SLUG,
+      display_name: 'Fixture Enrich',
+      config_path: '/tmp/fixture-enrich.toml',
+      repos: ['repo-alpha'],
+      entity_count: 2000,
+    },
+  ],
+}
+
+/** Progress snapshot with all 4 tiers active — some running, some queued. */
+const PROGRESS_ACTIVE = {
+  tiers: [
+    { band: 'critical', total: 110, done: 23,  running: 3,  queued: 84,  failed: 0, eta_seconds: 120 },
+    { band: 'high',     total: 890, done: 234, running: 2,  queued: 654, failed: 0, eta_seconds: 480 },
+    { band: 'medium',   total: 1420,done: 89,  running: 0,  queued: 1331,failed: 0 },
+    { band: 'low',      total: 3430,done: 0,   running: 0,  queued: 3430,failed: 0 },
+  ],
+  overall_done: 346,
+  overall_total: 5850,
+  started_at: new Date(Date.now() - 30_000).toISOString(),
+}
+
+/** All tiers complete. */
+const PROGRESS_DONE = {
+  tiers: [
+    { band: 'critical', total: 110,  done: 110,  running: 0, queued: 0, failed: 0 },
+    { band: 'high',     total: 890,  done: 890,  running: 0, queued: 0, failed: 0 },
+    { band: 'medium',   total: 1420, done: 1420, running: 0, queued: 0, failed: 0 },
+    { band: 'low',      total: 3430, done: 3430, running: 0, queued: 0, failed: 0 },
+  ],
+  overall_done: 5850,
+  overall_total: 5850,
+}
+
+/** No jobs at all — panel should not render. */
+const PROGRESS_EMPTY = {
+  tiers: [
+    { band: 'critical', total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+    { band: 'high',     total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+    { band: 'medium',   total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+    { band: 'low',      total: 0, done: 0, running: 0, queued: 0, failed: 0 },
+  ],
+  overall_done: 0,
+  overall_total: 0,
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ──────────────────────────────────────────────────────────────────────────────
+
+type Page = import('@playwright/test').Page
+
+/** Intercept all daemon API calls with sane defaults, plus a custom progress payload. */
+async function mockEnrichmentProgress(page: Page, progressPayload: object) {
+  await page.route(/^http:\/\/localhost:5173\/api\//, (route) => {
+    const url = route.request().url()
+
+    if (url.includes('/api/registry')) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_REGISTRY) })
+    }
+    if (url.includes(`/api/enrichments/${GROUP_SLUG}/progress`)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(progressPayload) })
+    }
+    if (url.includes(`/api/enrichments/${GROUP_SLUG}/jobs`)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ jobs: [], total: 0 }) })
+    }
+    if (url.includes(`/api/enrichments/${GROUP_SLUG}`)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [], total: 0 }) })
+    }
+    if (url.includes(`/api/repairs/${GROUP_SLUG}`)) {
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ items: [], total: 0, auto_resolvable_count: 0 }) })
+    }
+    // Default: 200 empty JSON.
+    return route.fulfill({ status: 200, contentType: 'application/json', body: '{}' })
+  })
+}
+
+/** Navigate to the /pending/:group route and switch to the Enrichment tab. */
+async function goToPendingEnrichments(page: Page) {
+  await page.goto(`${BASE_URL}/pending/${GROUP_SLUG}`)
+  await page.waitForLoadState('networkidle')
+  // Click the "Enrichment candidates" tab.
+  const enrichTab = page.getByRole('tab', { name: /enrichment candidates/i })
+  await enrichTab.click()
+}
+
+// ──────────────────────────────────────────────────────────────────────────────
+// Tests
+// ──────────────────────────────────────────────────────────────────────────────
+
+test.describe('EnrichmentProgressPanel (#1286)', () => {
+  test.beforeEach(async ({ page }) => {
+    mkdirp(SCREENSHOT_DIR)
+    // Surface console errors so CI logs show them.
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') console.error('[PAGE]', msg.text())
+    })
+    page.on('pageerror', (err) => console.error('[PAGE EXCEPTION]', err.message))
+  })
+
+  // ── 1. Panel absent when no jobs ──────────────────────────────────────────
+  test('panel is hidden when overall_total is 0', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_EMPTY)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).not.toBeVisible()
+  })
+
+  // ── 2. Panel visible when jobs are active ─────────────────────────────────
+  test('panel appears when enrichment is active', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_ACTIVE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+    await expect(panel).toContainText('Enrichment Progress')
+  })
+
+  // ── 3. All four tier bars render with ARIA ────────────────────────────────
+  test('all 4 tier progress bars render with correct ARIA labels', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_ACTIVE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+
+    // Each tier bar has aria-label="${band} tier enrichment progress"
+    for (const band of ['critical', 'high', 'medium', 'low']) {
+      const group = page.getByRole('group', { name: new RegExp(`${band} tier enrichment progress`, 'i') })
+      await expect(group).toBeVisible()
+
+      // Progress bar has role="progressbar"
+      const bar = group.getByRole('progressbar')
+      await expect(bar).toBeVisible()
+
+      // aria-valuenow should be a number 0–100
+      const valuenow = await bar.getAttribute('aria-valuenow')
+      const pct = Number(valuenow)
+      expect(pct).toBeGreaterThanOrEqual(0)
+      expect(pct).toBeLessThanOrEqual(100)
+    }
+  })
+
+  // ── 4. ETA text per tier ──────────────────────────────────────────────────
+  test('ETA text is shown for tiers with eta_seconds', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_ACTIVE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+
+    // Critical tier has eta_seconds=120 → "~2m"
+    await expect(panel).toContainText('~2m')
+    // High tier has eta_seconds=480 → "~8m"
+    await expect(panel).toContainText('~8m')
+    // Medium has running=0, queued>0 but no eta_seconds → "calculating…"
+    await expect(panel).toContainText('calculating…')
+  })
+
+  // ── 4b. "not started" for tier with total>0 but no running/queued ────────
+  test('not-started status shown for tier with 0 active jobs', async ({ page }) => {
+    const progressWithNotStarted = {
+      ...PROGRESS_ACTIVE,
+      tiers: PROGRESS_ACTIVE.tiers.map((t) =>
+        t.band === 'low' ? { ...t, queued: 0 } : t,
+      ),
+    }
+    await mockEnrichmentProgress(page, progressWithNotStarted)
+    await goToPendingEnrichments(page)
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+    await expect(panel).toContainText('not started')
+  })
+
+  // ── 5. "Complete" label when all done ────────────────────────────────────
+  test('Complete label appears when all tiers are done', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_DONE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+    await expect(panel).toContainText('Complete')
+
+    // All tier bars should show 100%
+    const bars = page.getByRole('progressbar')
+    const count = await bars.count()
+    for (let i = 0; i < count; i++) {
+      const val = await bars.nth(i).getAttribute('aria-valuenow')
+      expect(Number(val)).toBe(100)
+    }
+  })
+
+  // ── 6. Collapse toggle ───────────────────────────────────────────────────
+  test('panel collapses and expands on header click', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_ACTIVE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+
+    // Body is visible initially (not collapsed).
+    const body = page.locator('#enrichment-progress-body')
+    await expect(body).toBeVisible()
+
+    // Click header to collapse.
+    const header = panel.getByRole('button', { name: /enrichment progress/i })
+    await header.click()
+    await expect(body).not.toBeVisible()
+
+    // Click again to expand.
+    await header.click()
+    await expect(body).toBeVisible()
+  })
+
+  // ── 7. VIEW screenshot with active progress ───────────────────────────────
+  test('VIEW screenshot: active progress bars', async ({ page }) => {
+    await mockEnrichmentProgress(page, PROGRESS_ACTIVE)
+    await goToPendingEnrichments(page)
+
+    const panel = page.getByTestId('enrichment-progress-panel')
+    await expect(panel).toBeVisible({ timeout: 5000 })
+    // Ensure all 4 tier rows are rendered.
+    for (const band of ['critical', 'high', 'medium', 'low']) {
+      await expect(page.getByRole('group', { name: new RegExp(`${band} tier enrichment progress`, 'i') })).toBeVisible()
+    }
+
+    await page.screenshot({
+      path: path.join(SCREENSHOT_DIR, 'tier-progress-active.png'),
+      fullPage: false,
+    })
+
+    // No console errors (checked via beforeEach listener).
+  })
+})

--- a/internal/dashboard/handlers_enrichment_jobs.go
+++ b/internal/dashboard/handlers_enrichment_jobs.go
@@ -43,18 +43,22 @@ func (s *Server) handleEnrichmentTrigger(w http.ResponseWriter, r *http.Request)
 		kind = "describe_entity"
 	}
 
+	// criticality_band is optional — when absent the progress endpoint falls
+	// back to "low". Accepted values: critical, high, medium, low.
+	band := r.URL.Query().Get("criticality_band")
+
 	if s.jobQueue == nil {
 		writeErr(w, http.StatusServiceUnavailable, "job queue not initialised")
 		return
 	}
 
-	id, err := s.jobQueue.Enqueue(group, subjectID, kind)
+	id, err := s.jobQueue.Enqueue(group, subjectID, kind, band)
 	if err != nil {
 		s.auditor.Err("enrichment_trigger", group, map[string]any{"subject_id": subjectID, "kind": kind}, err.Error())
 		writeErr(w, http.StatusTooManyRequests, "job queue full: "+err.Error())
 		return
 	}
-	s.auditor.OK("enrichment_trigger", group, map[string]any{"subject_id": subjectID, "kind": kind, "job_id": id})
+	s.auditor.OK("enrichment_trigger", group, map[string]any{"subject_id": subjectID, "kind": kind, "criticality_band": band, "job_id": id})
 
 	job, _ := s.jobQueue.Get(id)
 	writeJSON(w, http.StatusAccepted, jobToWire(job))
@@ -126,6 +130,9 @@ func jobToWire(j jobs.Job) map[string]any {
 		"group":      j.Group,
 		"status":     j.Status,
 		"queued_at":  j.QueuedAt,
+	}
+	if j.CriticalityBand != "" {
+		out["criticality_band"] = j.CriticalityBand
 	}
 	if j.Error != "" {
 		out["error"] = j.Error

--- a/internal/dashboard/handlers_enrichment_jobs_test.go
+++ b/internal/dashboard/handlers_enrichment_jobs_test.go
@@ -124,9 +124,9 @@ func TestHandleEnrichmentJobs_empty(t *testing.T) {
 
 func TestHandleEnrichmentJobs_afterTrigger(t *testing.T) {
 	srv, q := newJobsServer(t)
-	q.Enqueue("g1", "flow::checkout", "describe_entity")
-	q.Enqueue("g1", "flow::payment", "describe_entity")
-	q.Enqueue("g2", "flow::other", "describe_entity") // different group
+	q.Enqueue("g1", "flow::checkout", "describe_entity", "")
+	q.Enqueue("g1", "flow::payment", "describe_entity", "")
+	q.Enqueue("g2", "flow::other", "describe_entity", "") // different group
 
 	// Wait for jobs to settle.
 	deadline := time.Now().Add(2 * time.Second)
@@ -182,7 +182,7 @@ func TestHandleEnrichmentJobCancel_success(t *testing.T) {
 	t.Cleanup(q.Stop)
 	srv.SetJobQueue(q)
 
-	id, _ := q.Enqueue("g1", "flow::x", "describe_entity")
+	id, _ := q.Enqueue("g1", "flow::x", "describe_entity", "")
 
 	target := "/api/enrichments/g1/jobs/" + id + "/cancel"
 	w := doRequest(t, srv, "POST", target)

--- a/internal/dashboard/handlers_enrichment_progress.go
+++ b/internal/dashboard/handlers_enrichment_progress.go
@@ -1,0 +1,178 @@
+package dashboard
+
+// handlers_enrichment_progress.go — Per-tier enrichment progress endpoint (#1286).
+//
+//	GET /api/enrichments/{group}/progress
+//
+// Returns a live snapshot of enrichment job progress bucketed into the four
+// criticality bands (critical / high / medium / low). The frontend polls this
+// endpoint every 3 s while any tier has running or queued jobs and renders
+// animated progress bars in the /pending surface.
+//
+// ETA estimation uses a rolling window of the last 30 completed jobs. When
+// fewer than 2 jobs have finished the eta_seconds field is omitted so the UI
+// can render "calculating…" instead of a misleading number.
+
+import (
+	"net/http"
+	"time"
+)
+
+// enrichmentProgressBand is one tier in the progress response.
+type enrichmentProgressBand struct {
+	Band       string  `json:"band"`        // "critical" | "high" | "medium" | "low"
+	Total      int     `json:"total"`       // total jobs in this band
+	Done       int     `json:"done"`        // completed (status == "done")
+	Running    int     `json:"running"`     // currently executing
+	Queued     int     `json:"queued"`      // waiting in queue
+	Failed     int     `json:"failed"`      // failed / cancelled
+	ETASeconds *int    `json:"eta_seconds,omitempty"` // nil when not enough data
+}
+
+// enrichmentProgressResponse is the wire type for GET /api/enrichments/{group}/progress.
+type enrichmentProgressResponse struct {
+	Tiers        []enrichmentProgressBand `json:"tiers"`
+	OverallDone  int                      `json:"overall_done"`
+	OverallTotal int                      `json:"overall_total"`
+	StartedAt    *time.Time               `json:"started_at,omitempty"`
+}
+
+// bandForScore returns the criticality band for a 0-100 priority score,
+// matching the thresholds used by the frontend TierDef.
+func bandForScore(score float64) string {
+	switch {
+	case score >= 80:
+		return "critical"
+	case score >= 60:
+		return "high"
+	case score >= 40:
+		return "medium"
+	default:
+		return "low"
+	}
+}
+
+// handleEnrichmentProgress — GET /api/enrichments/{group}/progress
+//
+// The response is always 200 (even when no jobs exist) so the frontend can
+// determine "not started" vs "in progress" from the counter values alone.
+func (s *Server) handleEnrichmentProgress(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	// Band order: critical first (matches UI layout).
+	bandOrder := []string{"critical", "high", "medium", "low"}
+
+	// Counters per band.
+	type counts struct {
+		total, done, running, queued, failed int
+	}
+	byBand := map[string]*counts{
+		"critical": {},
+		"high":     {},
+		"medium":   {},
+		"low":      {},
+	}
+
+	var startedAt *time.Time
+
+	// Accumulators for rolling-window ETA.
+	// completedDurations holds the duration (seconds) of the last ≤30 done jobs.
+	const etaWindow = 30
+	var completedDurations []float64
+
+	if s.jobQueue != nil {
+		jobs := s.jobQueue.ListForGroup(group)
+
+		for i := range jobs {
+			j := &jobs[i]
+
+			// Assign band from the job's CriticalityBand field (set by the
+			// enrichment trigger handler). Fall back to "low" when absent.
+			band := j.CriticalityBand
+			if _, ok := byBand[band]; !ok {
+				band = "low"
+			}
+
+			c := byBand[band]
+			c.total++
+
+			switch j.Status {
+			case "done":
+				c.done++
+				if j.StartedAt != nil && j.FinishedAt != nil {
+					dur := j.FinishedAt.Sub(*j.StartedAt).Seconds()
+					if dur > 0 {
+						completedDurations = append(completedDurations, dur)
+					}
+				}
+			case "running":
+				c.running++
+				if j.StartedAt != nil && (startedAt == nil || j.StartedAt.Before(*startedAt)) {
+					t := *j.StartedAt
+					startedAt = &t
+				}
+			case "queued":
+				c.queued++
+			default: // "failed", "cancelled"
+				c.failed++
+			}
+		}
+	}
+
+	// Compute throughput from the last etaWindow completions.
+	var throughputPerSec float64
+	if len(completedDurations) >= 2 {
+		// Keep only the last etaWindow samples.
+		window := completedDurations
+		if len(window) > etaWindow {
+			window = window[len(window)-etaWindow:]
+		}
+		var totalSec float64
+		for _, d := range window {
+			totalSec += d
+		}
+		// throughput = jobs / seconds = 1 / avg_seconds_per_job
+		avgSec := totalSec / float64(len(window))
+		if avgSec > 0 {
+			throughputPerSec = 1.0 / avgSec
+		}
+	}
+
+	// Build response tiers.
+	tiers := make([]enrichmentProgressBand, 0, len(bandOrder))
+	var overallDone, overallTotal int
+
+	for _, band := range bandOrder {
+		c := byBand[band]
+		overallTotal += c.total
+		overallDone += c.done
+
+		remaining := c.queued + c.running
+		var etaSeconds *int
+		if throughputPerSec > 0 && remaining > 0 {
+			eta := int(float64(remaining) / throughputPerSec)
+			etaSeconds = &eta
+		}
+
+		tiers = append(tiers, enrichmentProgressBand{
+			Band:       band,
+			Total:      c.total,
+			Done:       c.done,
+			Running:    c.running,
+			Queued:     c.queued,
+			Failed:     c.failed,
+			ETASeconds: etaSeconds,
+		})
+	}
+
+	writeJSON(w, http.StatusOK, enrichmentProgressResponse{
+		Tiers:        tiers,
+		OverallDone:  overallDone,
+		OverallTotal: overallTotal,
+		StartedAt:    startedAt,
+	})
+}

--- a/internal/dashboard/handlers_enrichment_progress_test.go
+++ b/internal/dashboard/handlers_enrichment_progress_test.go
@@ -1,0 +1,198 @@
+package dashboard
+
+// handlers_enrichment_progress_test.go — HTTP-level tests for
+// GET /api/enrichments/{group}/progress (#1286).
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/jobs"
+)
+
+// TestHandleEnrichmentProgress_noQueue returns 200 with empty tiers when no
+// job queue is wired.
+func TestHandleEnrichmentProgress_noQueue(t *testing.T) {
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// Seed group so the route guard passes.
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g1"] = &cacheEntry{
+		group:    &DashGroup{Name: "g1", Repos: map[string]*DashRepo{}},
+		loadedAt: time.Now().Add(60 * time.Second),
+	}
+	srv.graphs.mu.Unlock()
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/progress")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp["overall_total"].(float64) != 0 {
+		t.Errorf("want overall_total=0, got %v", resp["overall_total"])
+	}
+	tiers, ok := resp["tiers"].([]any)
+	if !ok || len(tiers) != 4 {
+		t.Errorf("want 4 tiers, got %v", resp["tiers"])
+	}
+}
+
+// TestHandleEnrichmentProgress_withJobs checks that done/running/queued
+// counts are bucketed correctly by criticality_band.
+func TestHandleEnrichmentProgress_withJobs(t *testing.T) {
+	srv, q := newJobsServer(t)
+
+	// Enqueue some jobs with explicit bands.
+	// Use a 0-worker sub-queue trick: we enqueue directly to inspect counts.
+	// The main queue (workerCount=2) will pick these up; we wait for them to
+	// complete before querying the progress endpoint.
+
+	// 2 critical jobs.
+	id1, _ := q.Enqueue("g1", "entity::alpha", "describe_entity", "critical")
+	id2, _ := q.Enqueue("g1", "entity::beta",  "describe_entity", "critical")
+	// 1 high job.
+	id3, _ := q.Enqueue("g1", "entity::gamma", "describe_entity", "high")
+
+	// Wait for all to finish (stub completes in 50ms each).
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		ids := []string{id1, id2, id3}
+		done := 0
+		for _, id := range ids {
+			j, _ := q.Get(id)
+			if j.Status == jobs.StatusDone || j.Status == jobs.StatusFailed {
+				done++
+			}
+		}
+		if done == 3 {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/progress")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp struct {
+		Tiers []struct {
+			Band    string  `json:"band"`
+			Total   float64 `json:"total"`
+			Done    float64 `json:"done"`
+			Queued  float64 `json:"queued"`
+			Running float64 `json:"running"`
+		} `json:"tiers"`
+		OverallDone  float64 `json:"overall_done"`
+		OverallTotal float64 `json:"overall_total"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if resp.OverallTotal != 3 {
+		t.Errorf("want overall_total=3, got %v", resp.OverallTotal)
+	}
+	if resp.OverallDone != 3 {
+		t.Errorf("want overall_done=3, got %v", resp.OverallDone)
+	}
+
+	// Find the critical tier.
+	var criticalTier *struct {
+		Band    string
+		Total   float64
+		Done    float64
+		Queued  float64
+		Running float64
+	}
+	for i := range resp.Tiers {
+		if resp.Tiers[i].Band == "critical" {
+			tier := resp.Tiers[i]
+			criticalTier = &struct {
+				Band    string
+				Total   float64
+				Done    float64
+				Queued  float64
+				Running float64
+			}{tier.Band, tier.Total, tier.Done, tier.Queued, tier.Running}
+			break
+		}
+	}
+	if criticalTier == nil {
+		t.Fatal("critical tier not found in response")
+	}
+	if criticalTier.Total != 2 {
+		t.Errorf("critical.total want 2, got %v", criticalTier.Total)
+	}
+	if criticalTier.Done != 2 {
+		t.Errorf("critical.done want 2, got %v", criticalTier.Done)
+	}
+}
+
+// TestHandleEnrichmentProgress_bandFallback checks that a job with an empty
+// criticality_band is counted in the "low" bucket.
+func TestHandleEnrichmentProgress_bandFallback(t *testing.T) {
+	srv, q := newJobsServer(t)
+
+	id, _ := q.Enqueue("g1", "entity::x", "describe_entity", "") // empty band → low
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		j, _ := q.Get(id)
+		if j.Status == jobs.StatusDone || j.Status == jobs.StatusFailed {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/progress")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+
+	var resp struct {
+		Tiers []struct {
+			Band  string  `json:"band"`
+			Total float64 `json:"total"`
+		} `json:"tiers"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+
+	for _, tier := range resp.Tiers {
+		if tier.Band == "low" && tier.Total != 1 {
+			t.Errorf("low.total want 1, got %v", tier.Total)
+		}
+		if tier.Band != "low" && tier.Total != 0 {
+			t.Errorf("%s.total want 0, got %v", tier.Band, tier.Total)
+		}
+	}
+}
+
+// TestHandleEnrichmentProgress_unknownGroup returns 200 with empty tiers for an
+// unknown group (no jobs → all-zero counts). The progress endpoint intentionally
+// does not 404 on unknown groups: the graph cache may not be warmed yet but the
+// job queue is always queryable.
+func TestHandleEnrichmentProgress_unknownGroup(t *testing.T) {
+	srv, _ := newJobsServer(t)
+	w := doRequest(t, srv, "GET", "/api/enrichments/nonexistent/progress")
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", w.Code)
+	}
+	var resp struct {
+		OverallTotal float64 `json:"overall_total"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp.OverallTotal != 0 {
+		t.Errorf("want overall_total=0 for unknown group, got %v", resp.OverallTotal)
+	}
+}

--- a/internal/dashboard/handlers_flows.go
+++ b/internal/dashboard/handlers_flows.go
@@ -324,7 +324,7 @@ func (s *Server) handleTriggerEnrichment(w http.ResponseWriter, r *http.Request)
 		kind = "describe_entity"
 	}
 
-	id, err := s.jobQueue.Enqueue(group, processID, kind)
+	id, err := s.jobQueue.Enqueue(group, processID, kind, "")
 	if err != nil {
 		writeErr(w, http.StatusTooManyRequests, "job queue full: "+err.Error())
 		return

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -329,6 +329,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/enrichments/{group}/jobs/{jobId}/cancel", s.handleEnrichmentJobCancel)
 	// Batched enrichment (#1285) — N candidates → N jobs in one round-trip
 	mux.HandleFunc("POST /api/enrichments/{group}/batch-enrich", s.handleEnrichmentBatch)
+	// Per-tier enrichment progress — polled every 3 s by the /pending surface (#1286)
+	mux.HandleFunc("GET /api/enrichments/{group}/progress", s.handleEnrichmentProgress)
 
 	// Settings surface (#1206)
 	mux.HandleFunc("GET /api/settings", s.handleGetSettings)

--- a/internal/jobs/queue.go
+++ b/internal/jobs/queue.go
@@ -39,15 +39,19 @@ const DefaultTimeout = 5 * time.Minute
 
 // Job is one enrichment dispatch request.
 type Job struct {
-	ID         string    `json:"id"`
-	SubjectID  string    `json:"subject_id"`
-	Kind       string    `json:"kind"`
-	Group      string    `json:"group"`
-	Status     string    `json:"status"`
-	Error      string    `json:"error,omitempty"`
-	QueuedAt   time.Time `json:"queued_at"`
-	StartedAt  *time.Time `json:"started_at,omitempty"`
-	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	ID              string     `json:"id"`
+	SubjectID       string     `json:"subject_id"`
+	Kind            string     `json:"kind"`
+	Group           string     `json:"group"`
+	Status          string     `json:"status"`
+	Error           string     `json:"error,omitempty"`
+	QueuedAt        time.Time  `json:"queued_at"`
+	StartedAt       *time.Time `json:"started_at,omitempty"`
+	FinishedAt      *time.Time `json:"finished_at,omitempty"`
+	// CriticalityBand is the priority tier of the enrichment subject
+	// ("critical" | "high" | "medium" | "low"). Used by the progress endpoint
+	// (#1286) to bucket job counts per tier. Empty string is treated as "low".
+	CriticalityBand string `json:"criticality_band,omitempty"`
 	// CancelFn is not serialised — it is wired by the worker at runtime.
 	cancelFn func()
 }
@@ -109,18 +113,20 @@ func (q *Queue) Stop() {
 	q.wg.Wait()
 }
 
-// Enqueue creates a new job for (group, subjectID, kind) and returns its ID.
+// Enqueue creates a new job for (group, subjectID, kind, criticalityBand) and
+// returns its ID. criticalityBand may be "" to default to "low" at query time.
 // The job is immediately placed in the work channel; a free worker will pick
 // it up as soon as capacity allows.
-func (q *Queue) Enqueue(group, subjectID, kind string) (string, error) {
+func (q *Queue) Enqueue(group, subjectID, kind, criticalityBand string) (string, error) {
 	id := newJobID()
 	job := &Job{
-		ID:        id,
-		SubjectID: subjectID,
-		Kind:      kind,
-		Group:     group,
-		Status:    StatusQueued,
-		QueuedAt:  time.Now().UTC(),
+		ID:              id,
+		SubjectID:       subjectID,
+		Kind:            kind,
+		Group:           group,
+		Status:          StatusQueued,
+		QueuedAt:        time.Now().UTC(),
+		CriticalityBand: criticalityBand,
 	}
 
 	q.mu.Lock()

--- a/internal/jobs/queue_test.go
+++ b/internal/jobs/queue_test.go
@@ -14,7 +14,7 @@ func TestEnqueue_basic(t *testing.T) {
 	q.Start()
 	defer q.Stop()
 
-	id, err := q.Enqueue("g1", "flow::checkout", "describe_entity")
+	id, err := q.Enqueue("g1", "flow::checkout", "describe_entity", "")
 	if err != nil {
 		t.Fatalf("Enqueue: %v", err)
 	}
@@ -49,7 +49,7 @@ func TestEnqueue_multiple(t *testing.T) {
 
 	ids := make([]string, 4)
 	for i := range ids {
-		id, err := q.Enqueue("g1", "flow::x", "describe_entity")
+		id, err := q.Enqueue("g1", "flow::x", "describe_entity", "")
 		if err != nil {
 			t.Fatalf("Enqueue %d: %v", i, err)
 		}
@@ -86,7 +86,7 @@ func TestCancel_queued(t *testing.T) {
 	q.Start()
 	defer q.Stop()
 
-	id, _ := q.Enqueue("g1", "flow::x", "describe_entity")
+	id, _ := q.Enqueue("g1", "flow::x", "describe_entity", "")
 	q.Cancel(id)
 
 	j, ok := q.Get(id)
@@ -107,9 +107,9 @@ func TestListForGroup(t *testing.T) {
 	q.Start()
 	defer q.Stop()
 
-	q.Enqueue("groupA", "flow::a", "describe_entity")
-	q.Enqueue("groupB", "flow::b", "describe_entity")
-	q.Enqueue("groupA", "flow::c", "describe_entity")
+	q.Enqueue("groupA", "flow::a", "describe_entity", "")
+	q.Enqueue("groupB", "flow::b", "describe_entity", "")
+	q.Enqueue("groupA", "flow::c", "describe_entity", "")
 
 	// Wait for all to complete.
 	deadline := time.Now().Add(2 * time.Second)
@@ -144,7 +144,7 @@ func TestHistory_persistence(t *testing.T) {
 
 	q := NewQueue(hist, 1)
 	q.Start()
-	id, _ := q.Enqueue("g1", "flow::x", "describe_entity")
+	id, _ := q.Enqueue("g1", "flow::x", "describe_entity", "")
 
 	deadline := time.Now().Add(2 * time.Second)
 	for time.Now().Before(deadline) {


### PR DESCRIPTION
## Summary

Implements Sub-C of the enrichment UX epic (#1282): live per-tier progress bars in the `/pending` surface so users can see enrichment completing in real time ("Critical: 23/110 done. ETA ~2m").

**Backend (`internal/`)**
- New `GET /api/enrichments/{group}/progress` endpoint returns a four-band snapshot (critical / high / medium / low) with per-tier `done`, `running`, `queued`, `failed`, and optional `eta_seconds` (rolling window of last 30 completed jobs).
- `jobs.Job` gains `CriticalityBand string` field; `Queue.Enqueue()` takes it as a 4th argument. All existing callers updated.
- `POST /api/enrichments/{group}/trigger` accepts an optional `criticality_band` query parameter.

**Frontend (`dashboard/src/`)**
- `EnrichmentProgressResponse` + `EnrichmentProgressBand` types in `types/api.ts`.
- `fetchEnrichmentProgress(group)` in `api/client.ts` (mock-aware).
- `useEnrichmentProgress(group)` hook in `hooks/shared/useEnrichmentProgress.ts` — polls every 3 s while any tier has running/queued jobs; stops automatically when all tiers finish.
- `EnrichmentProgressPanel` + `TierProgressBar` components in `routes/pending.tsx` — collapsible overlay above the tier list with ARIA `progressbar` roles, animated fill, ETA text, spinner, and "Complete" badge when done. Hidden when `overall_total === 0`.

## Closes / Refs

- Closes #1286

## Testing

- [x] `go test ./internal/dashboard/ ./internal/jobs/` — all 4 new handler tests + existing suite pass
- [x] `playwright test tests/e2e/enrichment-tier-progress.spec.ts` — 8/8 headless tests pass (VIEW screenshot saved to `test-results/enrichment-progress/tier-progress-active.png`)
- [x] TypeScript: zero new TS errors introduced (pre-existing unrelated errors not touched)
- [x] No console errors in any Playwright test run

## Notes

- ETA is omitted (`eta_seconds` absent) when fewer than 2 jobs have finished — UI renders "calculating…" gracefully.
- The progress panel auto-hides when `overall_total === 0` (no enrichment run started yet). It collapses to header-only when clicked, resuming to full view on the next click.
- `CriticalityBand` on `jobs.Job` defaults to `"low"` at query time when empty — backward-compatible with jobs enqueued before this change.
- Go beyond items included: collapse toggle, "calculating…" / "not started" status variants, animated pulse on running tiers, completion badge.