### PR TITLE
docs(enrichment): add docs/agent-hosts.md — per-host Haiku config for Pass 13

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ archigraph dashboard
 
 The `/generate-docs` skill produces per-repo documentation (overview, module guides, API reference, patterns) and a cross-repo synthesis. It runs a 12-pass pipeline that typically takes 25–60 minutes for small repos, 1–2 hours for medium repos, and 2–4 hours for large repos. Estimates and pass details are in the [generate-docs skill docs](skills/generate-docs/SKILL.md).
 
+Pass 13 (LLM enrichment) should run with Haiku to avoid high costs. See
+[`docs/agent-hosts.md`](docs/agent-hosts.md) for per-host setup instructions
+(Claude Code, Cursor, Windsurf, Continue, Aider, Cline).
+
 ## Usage
 
 archigraph is a CLI plus a unified daemon process that manages indexing,

--- a/docs/agent-hosts.md
+++ b/docs/agent-hosts.md
@@ -1,0 +1,344 @@
+# Agent host configuration — Haiku for Pass 13 enrichment
+
+Pass 13 (LLM enrichment) runs hundreds to thousands of LLM calls in batches.
+Using the wrong model (Sonnet or Opus) inflates cost by 10–20× without
+meaningfully improving enrichment quality for most entities.
+This page shows how to set `claude-3-haiku-20240307` as the active model in
+each supported agent host **before** starting Pass 13.
+
+> **Model selection rule** (from [`skills/generate-docs/SKILL.md`](../skills/generate-docs/SKILL.md)):
+> Haiku for `high`, `medium`, and `low` criticality bands (the vast majority
+> of a corpus). Sonnet only for the small `critical` tier (score ≥ 80).
+> The skill enforces this automatically — but only when the host allows
+> per-call model overrides (see the comparison table below).
+
+---
+
+## Host comparison table
+
+| Host | Can set model? | Supports MCP? | Per-call override? | Notes |
+|------|---------------|--------------|-------------------|-------|
+| [Claude Code](#claude-code) | Yes — CLI flag, slash command, or `settings.json` | Yes (native) | Yes — skill drives model selection per batch | Full support; recommended |
+| [Cursor](#cursor) | Yes — model picker per session | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/generate-docs` |
+| [Windsurf](#windsurf-codeium) | Yes — Cascade model picker | Yes (via MCP JSON config) | No — one model for the whole session | Switch to Haiku before invoking `/generate-docs` |
+| [Continue](#continue) | Yes — `config.json` or inline picker | Yes (via MCP JSON config) | No | Set `defaultModel` to Haiku in config |
+| [Aider](#aider) | Yes — `--model` CLI flag or `.aider.conf.yml` | No (no MCP client) | No | Run Pass 13 outside Aider; use Claude Code instead |
+| [Cline](#cline) | Yes — model picker in VS Code sidebar | Yes (via MCP JSON config) | No — one model per task | Switch to Haiku before starting the task |
+
+---
+
+## Claude Code
+
+Pass 13 runs inside Claude Code and the `/generate-docs` skill drives model
+selection automatically (Haiku for non-critical batches, Sonnet for the
+critical tier). You can still lock the session to Haiku to prevent accidental
+Sonnet fallback.
+
+### Set model at session start (recommended)
+
+```sh
+claude --model claude-3-haiku-20240307
+```
+
+Then invoke:
+
+```
+/generate-docs
+```
+
+The skill's Pass 13 will use Haiku for all non-critical batches and will
+prompt you before switching to Sonnet for the critical tier.
+
+### Switch model mid-session
+
+In the Claude Code chat:
+
+```
+/model claude-3-haiku-20240307
+```
+
+### Per-project default
+
+Add to `.claude/settings.json` in your repo (or `~/.claude/settings.json`
+for a machine-wide default):
+
+```json
+{
+  "model": "claude-3-haiku-20240307"
+}
+```
+
+The project-level file takes precedence over the machine-wide file.
+
+### Confirm the active model
+
+The model name appears in the Claude Code status bar and in the `/model`
+command output. You can also check at any time:
+
+```
+/model
+```
+
+Expected output: `Current model: claude-3-haiku-20240307`
+
+### Recommended workflow for Pass 13
+
+1. `claude --model claude-3-haiku-20240307` — start the session locked to Haiku.
+2. Run `archigraph status <group>` to confirm the daemon is up and MCP is connected.
+3. Invoke `/generate-docs` — the skill runs Passes 0–12 at whatever model is set,
+   then reaches Pass 13.
+4. At Pass 13, the skill prints a cost estimate and asks for confirmation before
+   dispatching batches. The non-critical batches go to Haiku; the skill will ask
+   you to confirm the model switch to Sonnet for the critical tier before sending
+   those batches.
+5. After Pass 13 completes, run `/model claude-3-5-sonnet-20241022` (or whichever
+   model you prefer for interactive coding) to restore your normal session model.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Pass 13 cost far higher than expected | Session model was Sonnet or Opus | Verify with `/model`; restart with `--model claude-3-haiku-20240307` and re-run |
+| `/model` command not found | Claude Code version too old | Upgrade: `npm i -g @anthropic-ai/claude-code@latest` |
+| Skill ignores `/model` change mid-run | Session model is advisory; the skill's per-batch override still applies | No action needed — the skill manages model selection per batch |
+| `settings.json` model ignored | Project file path wrong | Must be `.claude/settings.json` relative to the repo root you opened |
+
+---
+
+## Cursor
+
+Cursor selects the model per chat session. It does not support mid-run model
+switching inside a single task.
+
+### Set model before starting Pass 13
+
+1. Open the AI panel: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
+2. Click the **model selector** at the top of the panel.
+3. Choose **claude-3-haiku-20240307** (or the display name "Claude 3 Haiku").
+
+### Confirm the active model
+
+The model name is shown in the panel header while a request is in flight.
+There is no CLI command to query it.
+
+### Recommended workflow for Pass 13
+
+Because Cursor does not allow mid-run model switching, all batches — including
+the critical tier — will use the model active when you invoke `/generate-docs`.
+Choose one of:
+
+- **Option A (preferred):** use Claude Code for Pass 13 (supports per-batch
+  model selection).
+- **Option B:** set Haiku in Cursor, accept that the critical tier also runs
+  Haiku, and re-run critical-tier entities in a Claude Code session afterward
+  if deeper analysis is needed.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Claude 3 Haiku" not in model list | Anthropic API key not set in Cursor settings | Add key under **Cursor → Settings → Models → Anthropic** |
+| Model resets after closing the panel | Expected — Cursor does not persist per-chat model | Re-select before each Pass 13 run |
+
+---
+
+## Windsurf (Codeium)
+
+Windsurf uses Cascade for AI interactions. Model selection is per-session
+and does not persist across sessions.
+
+### Set model before starting Pass 13
+
+1. Open Cascade: `Cmd+L` (macOS) / `Ctrl+L` (Linux/Windows).
+2. Click the **model picker** (usually a small label near the top-right of
+   the Cascade panel).
+3. Select **Claude 3 Haiku** (maps to `claude-3-haiku-20240307`).
+
+### Confirm the active model
+
+The model name is shown in the Cascade panel header.
+
+### Recommended workflow for Pass 13
+
+Same constraint as Cursor — no per-batch model switching. Prefer Claude Code
+for Pass 13 if your corpus has a significant critical tier. If you must use
+Windsurf, set Haiku before invoking the skill and accept that the critical
+tier runs at Haiku quality.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| "Claude 3 Haiku" missing from picker | Codeium account plan does not include Haiku | Check your Codeium plan; Claude models require Codeium Pro or API key mode |
+| Cascade panel not opening | Windsurf extension needs restart | `Cmd+Shift+P` → "Reload Window" |
+
+---
+
+## Continue
+
+Continue (VS Code / JetBrains extension) reads its model config from
+`~/.continue/config.json`.
+
+### Set Haiku as default model
+
+Edit `~/.continue/config.json`:
+
+```json
+{
+  "models": [
+    {
+      "title": "Claude 3 Haiku",
+      "provider": "anthropic",
+      "model": "claude-3-haiku-20240307",
+      "apiKey": "<your-anthropic-api-key>"
+    }
+  ],
+  "defaultModel": "Claude 3 Haiku"
+}
+```
+
+Reload the Continue extension after saving (`Cmd+Shift+P` → "Continue: Reload").
+
+### Switch model inline
+
+Click the model label at the bottom of the Continue chat panel and choose
+**Claude 3 Haiku** from the dropdown.
+
+### Confirm the active model
+
+The current model is shown in the Continue chat panel footer.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Model not listed | API key missing or wrong | Verify `apiKey` in `config.json`; check for trailing spaces |
+| `defaultModel` ignored | Title mismatch | `defaultModel` must exactly match the `title` field in `models` |
+
+---
+
+## Aider
+
+Aider is a terminal-based AI coding tool. It does not have an MCP client, so
+it cannot call `archigraph_*` MCP tools directly. **Pass 13 cannot run inside
+Aider.** Use Claude Code for Pass 13.
+
+If you use Aider for your normal coding sessions but want to run enrichment,
+the recommended workflow is:
+
+1. Finish your Aider session and commit your work.
+2. Open Claude Code in the same directory.
+3. Run Pass 13 inside Claude Code as described in the [Claude Code](#claude-code) section.
+4. Return to Aider after enrichment is complete.
+
+### Setting the model in Aider (for reference)
+
+If you do use Aider for any Claude work:
+
+```sh
+aider --model claude-3-haiku-20240307
+```
+
+Or add to `.aider.conf.yml`:
+
+```yaml
+model: claude-3-haiku-20240307
+```
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `archigraph_*` tools not found in Aider | Aider has no MCP client | Use Claude Code for Pass 13 |
+| Aider rejects the model name | Aider version too old | `pip install --upgrade aider-chat` |
+
+---
+
+## Cline
+
+Cline is a VS Code extension with MCP client support. Model selection is
+per-task (set before starting the task).
+
+### Set model before starting Pass 13
+
+1. Open the Cline sidebar in VS Code.
+2. Click the **model selector** (gear icon or model name label near the top).
+3. Choose **claude-3-haiku-20240307**.
+
+### Wire up MCP (required for `archigraph_*` tools)
+
+Cline reads MCP server config from its VS Code extension settings.
+`archigraph install <group>` writes the server entry to `~/.claude/claude.json`,
+but Cline uses its own config file. Copy the server entry:
+
+```sh
+# After archigraph install, inspect the generated entry:
+cat ~/.claude/claude.json | grep -A 10 '"archigraph"'
+```
+
+Then add the equivalent entry to the Cline MCP config (VS Code settings →
+**Cline → MCP Servers**):
+
+```json
+{
+  "archigraph": {
+    "command": "archigraph",
+    "args": ["mcp"],
+    "type": "stdio"
+  }
+}
+```
+
+### Confirm the active model
+
+The model is shown in the Cline task panel header before each task run.
+
+### Recommended workflow for Pass 13
+
+Set Haiku before clicking "Start Task". The same no-per-batch-switching
+constraint applies as for Cursor and Windsurf — prefer Claude Code for full
+tier-aware enrichment.
+
+### Troubleshooting
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| `archigraph_*` tools not available | MCP entry not in Cline's config | Add the server entry as shown above |
+| Model selector not showing Haiku | Anthropic API key not configured in Cline | VS Code settings → **Cline → API Provider** → set Anthropic key |
+| Task spins with no progress | MCP server not started | Run `archigraph start` and verify `archigraph status` shows "running" |
+
+---
+
+## Recommended minimal setup
+
+If you are onboarding to archigraph enrichment for the first time, this is
+the fastest path to a working, cost-safe Pass 13 environment:
+
+```sh
+# 1. Install archigraph
+curl -fsSL https://raw.githubusercontent.com/cajasmota/archigraph/main/install.sh | bash
+
+# 2. Register your repos and start the daemon
+archigraph wizard          # creates group config
+archigraph install <group> # starts daemon, wires MCP, writes ~/.claude/claude.json
+
+# 3. Confirm MCP is connected
+archigraph status <group>  # should show "MCP: connected"
+
+# 4. Open Claude Code locked to Haiku
+claude --model claude-3-haiku-20240307
+
+# 5. Run the full doc + enrichment pipeline
+/generate-docs
+```
+
+Total setup time: ~5 minutes. Pass 13 will then run at Haiku rates for most
+entities, with a cost-estimate confirmation gate before any Sonnet batches.
+
+---
+
+## Related
+
+- [`skills/generate-docs/SKILL.md`](../skills/generate-docs/SKILL.md) — full Pass 13 procedure, model selection table, batching rules, and resume semantics.
+- [`docs/settings.md`](settings.md) — archigraph daemon settings reference.
+- [MCP Activity surface (`/mcp-activity`)](http://127.0.0.1:47274/mcp-activity) — live view of MCP tool calls; useful to confirm the daemon is receiving archigraph calls from your agent host.


### PR DESCRIPTION
## Summary

Creates `docs/agent-hosts.md` so users know exactly how to configure `claude-3-haiku-20240307` in their agent host before running Pass 13, preventing accidental \$70+ enrichment runs at Sonnet/Opus rates.

Closes #1288

## What changed

- **`docs/agent-hosts.md`** (new) — six host sections (Claude Code, Cursor, Windsurf, Continue, Aider, Cline), each with: how to set the model, how to confirm it is active, a recommended Pass 13 workflow, and a troubleshooting table. Also includes a host comparison table (can-set-model, MCP support, per-call override) and a "Recommended minimal setup" section covering the full onboarding path from install to first enrichment run.
- **`README.md`** — three-line blurb added below the `/generate-docs` paragraph linking to `docs/agent-hosts.md`.

## How to verify

1. Read `docs/agent-hosts.md` and confirm all six host sections are present with model-setting steps, confirmation steps, and troubleshooting tables.
2. Confirm `README.md` links `docs/agent-hosts.md` from the Quick start section.
3. Confirm no Go/backend files changed — documentation only.
4. Confirm `skills/generate-docs/SKILL.md` already cross-references `docs/agent-hosts.md` (added by #1289, already merged) — the link resolves correctly with this PR.

## Testing

- [ ] All tests pass: `go test ./...`
- [ ] Relevant fixtures verified
- [ ] No regression in cross-language parity

## Notes

- No client names appear in the doc.
- The Aider section explicitly notes MCP is not supported and redirects users to Claude Code for Pass 13.
- The comparison table's "Per-call override?" column clarifies why Claude Code is the recommended host for enrichment runs with mixed criticality tiers.

Parent epic: #1282