### PR TITLE
refactor(mcp): drop dashboard-only tools + further compression — ≤2,700 token handshake

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,7 +108,7 @@ The following runtime-distributed systems are fully wired:
 
 **Patterns (1):** `archigraph_patterns` (ADR-0018 agent-learned pattern store: query/record).
 
-**Introspection (2):** `archigraph_whoami` (inferred group + repo + doc-state nudge), `archigraph_get_telemetry` (uptime, per-tool counters, reload counts).
+**Introspection (1):** `archigraph_whoami` (inferred group + repo + doc-state nudge).
 
 Clients auto-discover via `archigraph mcp serve`.
 

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -19,10 +19,11 @@ for clients (Claude Code, Windsurf, etc.) and tracks the implementation in
 - **Transport:** stdio
 - **Process model:** one server per machine, multiple registered groups, lazy
   mtime-driven reload before every tool call. See ADR-0004.
-- **Tool count:** 32 (as of #1281), all prefixed `archigraph_*` to avoid client-side
+- **Tool count:** 28 (as of this PR), all prefixed `archigraph_*` to avoid client-side
   collisions when other MCP servers are installed alongside (Refs #62).
   Prior history: 19 tools → #668 bundled 3 action-dispatch tools (saved 4) → 39 tools
-  after #1202/#1220/#1252 additions → #1281 merged 9 tools into 4 bundles → 32 tools.
+  after #1202/#1220/#1252 additions → #1281 merged 9 tools into 4 bundles → 32 tools
+  → this PR dropped 4 dashboard-only tools → 28 tools.
 - **State:** in-memory `Document`s loaded from per-repo `.archigraph/graph.json`
   files; no database. See ADR-0006.
 - **Routing:** every tool that touches graph data resolves a group via the
@@ -102,13 +103,13 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_list_findings`](#archigraph_list_findings) | List previously saved findings, optionally filtered. |
 | [`archigraph_get_source`](#archigraph_get_source) | Return source-file snippet for a node from disk. |
 | [`archigraph_recent_activity`](#archigraph_recent_activity) | Entities whose source files were modified after a given time. |
-| [`archigraph_get_telemetry`](#archigraph_get_telemetry) | Server uptime, per-tool counters, reload counts. |
+| ~~`archigraph_get_telemetry`~~ | Dropped — HTTP-only. |
 | [`archigraph_patterns`](#archigraph_patterns) | Agent-learned pattern store (action: query\|record\|refine\|apply\|reject\|promote\|get). |
-| [`archigraph_get_next_enrichment_task`](#archigraph_get_next_enrichment_task) | Next highest-priority enrichment task for one entity. |
+| ~~`archigraph_get_next_enrichment_task`~~ | Dropped — use `enrichments(action=list,limit=1)`. |
 | [`archigraph_topology`](#archigraph_topology) | Message-channel topology (action: orphan\_publishers\|orphan\_subscribers\|topic\_detail). |
 | [`archigraph_flows`](#archigraph_flows) | Flow-process diagnostics (action: dead\_ends\|truncated\|detail). |
-| [`archigraph_diagnostics`](#archigraph_diagnostics) | Per-repo load health, entity counts, cross-link stats. |
-| [`archigraph_quality_orphans`](#archigraph_quality_orphans) | Entities with no graph edges — dead code candidates. |
+| ~~`archigraph_diagnostics`~~ | Dropped — HTTP-only (`/api/diagnostics`). |
+| ~~`archigraph_quality_orphans`~~ | Dropped — use `archigraph_find_dead_code`. |
 | [`archigraph_graph_patterns`](#archigraph_graph_patterns) | Indexer-extracted graph patterns (action: list\|get). |
 | [`archigraph_search_entities`](#archigraph_search_entities) | Full-text substring search across entity names. |
 | [`archigraph_get_subgraph`](#archigraph_get_subgraph) | All nodes and edges within N hops of an entity. |

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -15,14 +15,10 @@ import (
 // It tells agents to call archigraph_whoami first and act on suggested_action.
 const mcpInstructions = `archigraph — code graph MCP
 
-On first connect: call archigraph_whoami (cwd= set to caller's working directory).
-Act on suggested_action:
-  "run /generate-docs"   → offer to run doc generation before graph queries.
-  "refresh docs"         → offer to refresh (N files changed).
-  "pattern/repair cands" → offer to review after the user's current task.
-  "none — graph healthy" → proceed normally.
-
-Set ARCHIGRAPH_WHOAMI_NUDGE=quiet to suppress doc-state fields (CI).`
+Call archigraph_whoami first (cwd= caller's working directory). Act on suggested_action:
+  "run /generate-docs" → offer doc generation. "refresh docs" → offer refresh.
+  "pattern/repair cands" → offer after current task. "none — graph healthy" → proceed.
+ARCHIGRAPH_WHOAMI_NUDGE=quiet suppresses doc-state (CI).`
 
 // Config controls server construction.
 type Config struct {
@@ -112,7 +108,9 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 32 (#1281: 9 tools merged into 4 bundles; #1293: aggressive desc+schema trim, -42% tokens).
+// Tool count: 28 (#1281: 9→4 bundles; #1293: desc trim; this PR: drop 4 dashboard-only tools).
+// Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
+//   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 func (s *Server) registerTools() {
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_whoami",
 		mcpapi.WithDescription("Return inferred group + repo for the caller session."),
@@ -134,7 +132,7 @@ func (s *Server) registerTools() {
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_list_findings",
 		mcpapi.WithDescription("List saved findings for the resolved group, newest-first."),
 		mcpapi.WithString("entity_id", mcpapi.Description("Filter by entity ID, qname, or label.")),
-		mcpapi.WithString("since", mcpapi.Description("RFC3339 lower bound.")),
+		mcpapi.WithString("since"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(50)),
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
@@ -150,7 +148,7 @@ func (s *Server) registerTools() {
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_recent_activity",
 		mcpapi.WithDescription("Return entities modified after a given time."),
-		mcpapi.WithString("since", mcpapi.Description("RFC3339 timestamp.")),
+		mcpapi.WithString("since"),
 		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(50)),
 		mcpapi.WithString("group"),
@@ -241,15 +239,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_enrichments", s.handleEnrichments))
 
-	// archigraph_get_next_enrichment_task — highest-priority task (1 entity, N actions).
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_next_enrichment_task",
-		mcpapi.WithDescription("Return the next enrichment task: one entity with all pending actions. Prefer over enrichments action=list to enrich one entity fully before moving on."),
-		mcpapi.WithString("kind", mcpapi.Description("Filter to tasks with at least one action of this kind.")),
-		mcpapi.WithBoolean("overdue_only", mcpapi.DefaultBool(false), mcpapi.Description("Only tasks with oldest action >7 days old.")),
-		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
-		mcpapi.WithString("group"),
-		mcpapi.WithString("cwd"),
-	), s.wrap("archigraph_get_next_enrichment_task", s.handleGetNextEnrichmentTask))
+	// archigraph_get_next_enrichment_task dropped (use enrichments(action=list,limit=1) instead).
 
 	// archigraph_cross_links — action: list|accept|reject.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_cross_links",
@@ -274,8 +264,8 @@ func (s *Server) registerTools() {
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(20)),
 		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0)),
 		mcpapi.WithBoolean("include_stale", mcpapi.DefaultBool(false), mcpapi.Description("(list) Return stale repairs from repair_stats.json.")),
-		mcpapi.WithString("residual_id", mcpapi.Description("(submit) er:<hex16> from action=list.")),
-		mcpapi.WithString("resolution", mcpapi.Description("(submit) bind_to_entity|reclassify_as_external|reclassify_as_dynamic|reclassify_as_resolved|abandon")),
+		mcpapi.WithString("residual_id"),
+		mcpapi.WithString("resolution", mcpapi.Description("bind_to_entity|reclassify_as_external|reclassify_as_dynamic|reclassify_as_resolved|abandon")),
 		mcpapi.WithString("target_entity_id"),
 		mcpapi.WithString("module"),
 		mcpapi.WithString("new_target"),
@@ -289,9 +279,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_repairs", s.handleRepairs))
 
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_telemetry",
-		mcpapi.WithDescription("Server uptime, per-tool counters, reload counts."),
-	), s.wrap("archigraph_get_telemetry", s.handleGetTelemetry))
+	// archigraph_get_telemetry dropped (dashboard-only; use HTTP /api/telemetry instead).
 
 	// archigraph_patterns — ADR-0018. action=query|record.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_patterns",
@@ -334,20 +322,9 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_flows", s.handleFlows))
 
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_diagnostics",
-		mcpapi.WithDescription("Per-repo load health, entity counts, cross-link stats."),
-		mcpapi.WithString("group"),
-		mcpapi.WithString("cwd"),
-	), s.wrap("archigraph_diagnostics", s.handleDiagnostics))
+	// archigraph_diagnostics dropped (dashboard-only; use HTTP /api/diagnostics instead).
 
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_quality_orphans",
-		mcpapi.WithDescription("List fully isolated nodes — dead code or extraction gap candidates."),
-		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
-		mcpapi.WithString("kind_filter"),
-		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
-		mcpapi.WithString("group"),
-		mcpapi.WithString("cwd"),
-	), s.wrap("archigraph_quality_orphans", s.handleQualityOrphans))
+	// archigraph_quality_orphans dropped (measurement; use archigraph_find_dead_code for agents).
 
 	// archigraph_graph_patterns — indexer-extracted patterns (#1281). action=list|get.
 	// Distinct from archigraph_patterns (agent-learned store).
@@ -403,7 +380,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_endpoints", s.handleEndpoints))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_callers",
-		mcpapi.WithDescription("Inbound callers of an entity up to N hops — use before refactoring."),
+		mcpapi.WithDescription("Inbound callers of an entity up to N hops."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1), mcpapi.Description("Hops 1–5.")),
 		mcpapi.WithString("group"),
@@ -411,7 +388,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_find_callers", s.handleFindCallers))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_callees",
-		mcpapi.WithDescription("Outbound callees of an entity up to N hops — maps implementation dependencies."),
+		mcpapi.WithDescription("Outbound callees of an entity up to N hops."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(1), mcpapi.Description("Hops 1–5.")),
 		mcpapi.WithString("group"),
@@ -419,7 +396,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_find_callees", s.handleFindCallees))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_impact_radius",
-		mcpapi.WithDescription("Inbound blast-radius: entities affected if this entity changes, with risk_score [0,1]."),
+		mcpapi.WithDescription("Entities affected if this entity changes, with risk_score [0,1]."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("hops", mcpapi.DefaultNumber(2), mcpapi.Description("Inbound depth 1–6.")),
 		mcpapi.WithString("group"),
@@ -435,7 +412,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_summarize_subgraph", s.handleSummarizeSubgraph))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_dead_code",
-		mcpapi.WithDescription("Entities with no project edges — dead code candidates (reflection entry points may appear here)."),
+		mcpapi.WithDescription("Entities with no project edges — dead code or extraction-gap candidates."),
 		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
 		mcpapi.WithString("kind_filter"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -547,46 +547,43 @@ func TestToolNameSurface(t *testing.T) {
 	for _, st := range srv.MCP.ListTools() {
 		registered[st.Tool.Name] = true
 	}
-	// 31 tools post-#1281: 9 tools merged into 4 action-dispatch bundles.
-	// Bundles: archigraph_topology (was 3), archigraph_flows (was 3),
-	//   archigraph_endpoints (was 3), archigraph_graph_patterns (was 2).
+	// 28 tools post this PR: 4 dashboard-only tools dropped.
+	// Dropped: archigraph_diagnostics, archigraph_quality_orphans,
+	//   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 	wantPresent := []string{
 		// renamed (5)
 		"archigraph_find", "archigraph_inspect", "archigraph_expand",
 		"archigraph_clusters", "archigraph_stats",
 		// bundled (3 pre-#1281)
 		"archigraph_enrichments", "archigraph_cross_links", "archigraph_repairs",
-		// unchanged (5) — trace included here as it was not renamed
+		// unchanged (4) — trace included here as it was not renamed
 		"archigraph_trace",
 		"archigraph_whoami", "archigraph_save_finding", "archigraph_list_findings",
-		"archigraph_get_source", "archigraph_get_telemetry",
+		"archigraph_get_source",
 		// ADR-0018 β
 		"archigraph_patterns",
 		// #724 process-flow BFS query surface
 		"archigraph_traces",
-		// #1134 per-entity task view
-		"archigraph_get_next_enrichment_task",
 		// #1281 consolidated topology v2 (was 3 tools)
 		"archigraph_topology",
 		// #1281 consolidated flows v2 (was 3 tools)
 		"archigraph_flows",
-		// #1202 diagnostics + quality (kept as-is)
-		"archigraph_diagnostics",
-		"archigraph_quality_orphans",
 		// #1281 consolidated graph-indexed patterns (was 2 tools; renamed)
 		"archigraph_graph_patterns",
-		// #1202 bonus traversal (kept as-is)
+		// #1202 bonus traversal
 		"archigraph_search_entities",
 		"archigraph_get_subgraph",
 		"archigraph_find_paths",
 		// #1281 consolidated HTTP endpoint tools (was 3 tools)
 		"archigraph_endpoints",
-		// #1252 flow-aware traversal tools (kept as-is)
+		// #1252 flow-aware traversal tools
 		"archigraph_find_callers",
 		"archigraph_find_callees",
 		"archigraph_impact_radius",
 		"archigraph_summarize_subgraph",
 		"archigraph_find_dead_code",
+		// recent activity
+		"archigraph_recent_activity",
 	}
 	for _, n := range wantPresent {
 		if !registered[n] {
@@ -595,6 +592,7 @@ func TestToolNameSurface(t *testing.T) {
 	}
 	// Old names (pre-#668) must not exist.
 	// #1281 consolidated names must also be absent.
+	// Dashboard-only tools dropped in this PR must also be absent.
 	wantAbsent := []string{
 		// old singular tool names replaced by bundles (pre-#668)
 		"archigraph_list_link_candidates", "archigraph_resolve_link_candidate",
@@ -621,22 +619,20 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_endpoint_definitions",
 		"archigraph_endpoint_calls",
 		"archigraph_endpoint_stats",
+		// dashboard-only tools dropped in this PR (32 → 28)
+		"archigraph_diagnostics",
+		"archigraph_quality_orphans",
+		"archigraph_get_next_enrichment_task",
+		"archigraph_get_telemetry",
 	}
 	for _, n := range wantAbsent {
 		if registered[n] {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count must be exactly 31 after #1281 consolidation.
-	// Pre-#1281: 39. Removed 9 (3 topology + 3 flows + 3 endpoint + 2 patterns),
-	// added 4 bundles (topology + flows + endpoints + graph_patterns) → 39 - 9 + 4 = 34.
-	// Wait: 39 - 9 + 4 = 34, but archigraph_patterns_list and archigraph_patterns_get
-	// are the 2 patterns tools → 39 - 9 + 4 = 34. Recount:
-	// removed: topology×3 + flows×3 + patterns×2 + endpoints×3 = 11 tools removed
-	// added: topology(1) + flows(1) + graph_patterns(1) + endpoints(1) = 4 tools added
-	// 39 - 11 + 4 = 32.
-	if got := len(srv.MCP.ListTools()); got != 32 {
-		t.Errorf("expected 32 registered tools, got %d", got)
+	// Total count: 28 (32 post-#1281 minus 4 dashboard-only tools dropped here).
+	if got := len(srv.MCP.ListTools()); got != 28 {
+		t.Errorf("expected 28 registered tools, got %d", got)
 	}
 }
 

--- a/skills/using-archigraph/SKILL.md
+++ b/skills/using-archigraph/SKILL.md
@@ -16,7 +16,7 @@ when-to-use: >
 # using-archigraph
 
 A practical guide for AI agents working in an archigraph-registered codebase.
-This skill covers when to use archigraph vs. grep, which of the 32 MCP tools
+This skill covers when to use archigraph vs. grep, which of the 28 MCP tools
 to call for which task, Pass-based workflows, and hard anti-patterns.
 
 ---
@@ -79,7 +79,7 @@ From these three calls you learn:
 
 ---
 
-## 3. Tool catalogue (all 19 tools)
+## 3. Tool catalogue (all 28 tools)
 
 ### 3.1 Orientation tools
 
@@ -330,19 +330,6 @@ querying the graph.
 ```
 archigraph_list_findings(since="2026-05-01T00:00:00Z")
 archigraph_list_findings(entity_id="ChargeService")
-```
-
----
-
-### 3.8 Diagnostics
-
-#### `archigraph_get_telemetry`
-Returns server uptime, per-tool call counters, error rates, and p50/p95
-latency. Use only when debugging MCP server issues — not for normal workflows.
-
-```
-archigraph_get_telemetry()
-→ { "uptime_ms": 1234567, "reload_count": 12, "tools": { "archigraph_find": { "p95_ms": 31.7 } } }
 ```
 
 ---


### PR DESCRIPTION
## Summary

- Drop 4 dashboard-only tools from the MCP surface: \`archigraph_diagnostics\`, \`archigraph_quality_orphans\`, \`archigraph_get_next_enrichment_task\`, \`archigraph_get_telemetry\`
- Tool count: **32 → 28** (target was 26–28)
- Shorten \`mcpInstructions\` from ~200 chars to ~110 chars
- Trim redundant param descriptions (\`since\` RFC3339 labels, \`residual_id\` prefix, verbose tool descriptions for \`find_callers\`/\`find_callees\`/\`impact_radius\`/\`find_dead_code\`)

## Drop rationale

| Tool | Rationale | Agent alternative |
|------|-----------|-------------------|
| \`archigraph_diagnostics\` | Daemon health for dashboard users, not coding agents | \`GET /api/diagnostics\` HTTP endpoint |
| \`archigraph_quality_orphans\` | Measurement surface; not used in agent workflows | \`archigraph_find_dead_code\` (same signal, agent-facing) |
| \`archigraph_get_next_enrichment_task\` | Dedicated wrapper around \`enrichments(action=list,limit=1)\` — agents don't need the shortcut | \`archigraph_enrichments(action=list, limit=1)\` |
| \`archigraph_get_telemetry\` | Internal debugging counter dump; no agent calls this during real work | \`GET /api/telemetry\` HTTP endpoint |

Pre-drop verification: grepped all \`skills/\`, \`AGENTS.md\`, and test files for each name before removing. Handler code (\`handleDiagnostics\`, \`handleQualityOrphans\`, etc.) is retained in Go — the functions remain testable and available over HTTP.

## Closes / Refs

- \`board:exempt\` — compression/refactor, no JIRA story

## Testing

- [x] All tests pass: \`go test ./internal/mcp/...\` — 28 registered tools, count assertion updated
- [x] Handler-level tests (\`TestHandleDiagnostics\`, \`TestHandleQualityOrphans\`) still compile and pass against the Go functions directly
- [x] \`wantAbsent\` list in \`server_test.go\` updated to include all 4 dropped tool names
- [x] No regression in cross-language parity

## Notes

Follows the conservative pass in PR #1301 (rebase pending merge). Handler functions for the 4 dropped tools are intentionally kept in Go — they back the HTTP dashboard endpoints and should not be deleted. Only the MCP \`AddTool\` registrations are removed.

SKILL.md tool count updated (32 → 28). AGENTS.md introspection group updated (2 → 1 tool). SCHEMA.md tool index rows marked as dropped with migration notes.