### PR TITLE
fix(enrichment): tune ComputeScore — http_endpoint_definition, critical-band, utility-fn penalty, line-span

### DIFF
--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -86,7 +86,11 @@ type Candidate struct {
 func kindBaseScore(kind string) (int, string) {
 	switch kind {
 	// Public API surface — always highest priority.
-	case "http_endpoint", "HTTPEndpoint", "SCOPE.HTTPEndpoint", "Route", "SCOPE.Route":
+	// http_endpoint_definition is the canonical post-#1217 kind for
+	// handler/route entities; the legacy http_endpoint alias is kept for
+	// graphs produced before the split.
+	case "http_endpoint", "http_endpoint_definition",
+		"HTTPEndpoint", "SCOPE.HTTPEndpoint", "Route", "SCOPE.Route":
 		return 80, "base_http_endpoint:80"
 	// Named architectural roles.
 	case "Service", "SCOPE.Service", "Controller", "SCOPE.Controller",
@@ -132,36 +136,66 @@ func criticalityBand(score int) string {
 	}
 }
 
+// ScoreHints carries per-entity graph-level signals that require access to the
+// full Document (relationship index, cross-repo adjacency). These are computed
+// once per entity at emit time and passed into ComputeScore so the function
+// itself remains pure (no Document traversal at score time).
+type ScoreHints struct {
+	// OutboundEdges is the number of outgoing relationships from this entity
+	// in the indexed graph. Used to differentiate high-degree hub nodes within
+	// the critical band.
+	OutboundEdges int
+	// HasCrossRepoInbound is true when at least one inbound relationship
+	// originates from a different repository (cross-repo dependency signal).
+	HasCrossRepoInbound bool
+}
+
 // ComputeScore calculates the 0–100 confidence score for a candidate, together
 // with a human-readable breakdown and a criticality band. The entity e must be
 // the same entity whose ID is c.SubjectID; passing nil produces a safe zero.
 //
-// Scoring formula (from issue #1131 spec):
+// hints is optional — pass nil (or omit) when no Document context is available.
+// When provided, graph-level signals (outbound degree, cross-repo inbound) are
+// incorporated into the score.
+//
+// Scoring formula (from issue #1131 spec, updated in #1301):
 //
 //	Base by kind:
-//	  http_endpoint / Route              → 80
-//	  Service / Controller / View / Route → 65
-//	  Schema / Model                     → 60
-//	  DataAccess                         → 55
-//	  Process / Task / ScheduledJob      → 45
-//	  Operation                          → 40
-//	  Component                          → 35 (default)
+//	  http_endpoint / http_endpoint_definition / Route → 80
+//	  Service / Controller / View                      → 65
+//	  Schema / Model                                   → 60
+//	  DataAccess                                       → 55
+//	  Process / Task / ScheduledJob                    → 45
+//	  Operation                                        → 40
+//	  Component                                        → 35 (default)
 //
 //	Positive modifiers:
 //	  +20  is_god_node
 //	  +15  is_articulation_point
 //	  +10  pagerank >= 0.01
 //	  +15  name in {process, handle, run, make, do, main, init, setup, update, execute}
+//	  +10  line_span > 30 (complex function body)
+//	  +5   outbound_edges > 20 (high-degree hub — critical-band differentiator)
+//	  +5   pagerank > 0.05 (top ~1% by pagerank — critical-band differentiator)
+//	  +5   cross-repo inbound dependency (cross-repo critical-band differentiator)
 //
 //	Negative modifiers:
+//	  -15  self-descriptive Operation name matching selfDescriptiveOperationRE
+//	       (applies even to articulation points; god nodes are exempt)
 //	  -15  len(name) <= 4
 //	  -10  source_file empty
 //	  -20  all-lowercase-underscore name with len < 10 (private helper heuristic)
+//	  -15  line_span <= 5 (trivial body — single-line or near-trivial)
 //
 // The result is clamped to [0, 100].
-func ComputeScore(e *graph.Entity) (score int, breakdown string, band string) {
+func ComputeScore(e *graph.Entity, hints ...*ScoreHints) (score int, breakdown string, band string) {
 	if e == nil {
 		return 0, "nil_entity", "low"
+	}
+
+	var h *ScoreHints
+	if len(hints) > 0 {
+		h = hints[0]
 	}
 
 	base, baseLabel := kindBaseScore(e.Kind)
@@ -178,7 +212,7 @@ func ComputeScore(e *graph.Entity) (score int, breakdown string, band string) {
 		total += 15
 		parts = append(parts, "+articulation:15")
 	}
-	// +10 high pagerank.
+	// +10 high pagerank (broad threshold — any entity in the top ~10%).
 	if e.PageRank != nil && *e.PageRank >= 0.01 {
 		total += 10
 		parts = append(parts, "+pagerank:10")
@@ -188,6 +222,48 @@ func ComputeScore(e *graph.Entity) (score int, breakdown string, band string) {
 	if ambiguousNames[nameLower] {
 		total += 15
 		parts = append(parts, "+ambiguous_name:15")
+	}
+
+	// Line-span modifiers: derived from StartLine/EndLine. These fire when
+	// the entity has non-zero line information (avoids penalising synthetic
+	// or cross-repo placeholder nodes that have no source location).
+	if e.EndLine > 0 && e.StartLine > 0 {
+		lineSpan := e.EndLine - e.StartLine
+		if lineSpan > 30 {
+			total += 10
+			parts = append(parts, "+complex_body:10")
+		} else if lineSpan <= 5 {
+			total -= 15
+			parts = append(parts, "-trivial_body:15")
+		}
+	}
+
+	// Critical-band differentiators (require ScoreHints from Document context).
+	// These break ties within the 80–100 range so god nodes and HTTP hubs
+	// score differently from plain critical entities.
+	if h != nil {
+		if h.OutboundEdges > 20 {
+			total += 5
+			parts = append(parts, "+high_degree:5")
+		}
+		if e.PageRank != nil && *e.PageRank > 0.05 {
+			total += 5
+			parts = append(parts, "+top_pagerank:5")
+		}
+		if h.HasCrossRepoInbound {
+			total += 5
+			parts = append(parts, "+cross_repo:5")
+		}
+	}
+
+	// Utility-function penalty: self-descriptive Operation names get -15 even
+	// when they are articulation points. God nodes are exempt because their hub
+	// status makes the description valuable even when the name is self-evident.
+	if !e.IsGodNode &&
+		(e.Kind == "SCOPE.Operation" || e.Kind == "Operation") &&
+		selfDescriptiveOperationRE.MatchString(e.Name) {
+		total -= 15
+		parts = append(parts, "-self_descriptive:15")
 	}
 
 	// -15 very short name (≤4 chars, hard to describe meaningfully).
@@ -344,12 +420,15 @@ var schemaSimpleFieldRE = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*\.[a-z_][a-
 // qualifyHTTPKinds is the set of entity kinds that represent public API
 // surface — HTTP endpoints and route definitions — that always qualify for
 // enrichment because their intent and contract must be documented.
+// http_endpoint_definition is the post-#1217 canonical kind; http_endpoint
+// is the legacy alias emitted by older indexer versions.
 var qualifyHTTPKinds = map[string]bool{
-	"http_endpoint":      true,
-	"HTTPEndpoint":       true,
-	"Route":              true,
-	"SCOPE.Route":        true,
-	"SCOPE.HTTPEndpoint": true,
+	"http_endpoint":            true,
+	"http_endpoint_definition": true,
+	"HTTPEndpoint":             true,
+	"Route":                    true,
+	"SCOPE.Route":              true,
+	"SCOPE.HTTPEndpoint":       true,
 }
 
 // qualifyHighArchKinds is the set of entity kinds that represent named
@@ -652,6 +731,47 @@ var commonProgrammingTerms = map[string]bool{
 }
 
 // ---------------------------------------------------------------------------
+// ScoreHints index helpers
+// ---------------------------------------------------------------------------
+
+// scoreHintsIndex pre-computes ScoreHints for every entity in doc from its
+// relationship list. Call once per Document and reuse the returned map across
+// all entities in that document to avoid O(E×N) traversal.
+//
+// Cross-repo inbound detection: a relationship's FromID is considered
+// cross-repo when it does not appear in the entity ID set of doc. This is a
+// conservative heuristic — true cross-repo resolution requires the multi-repo
+// corpus index — but it correctly identifies entities that are referenced from
+// external graphs merged into this document via the links pass.
+func scoreHintsIndex(doc *graph.Document) map[string]*ScoreHints {
+	if doc == nil {
+		return nil
+	}
+	// Build a set of entity IDs that belong to this document.
+	localIDs := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Entities {
+		localIDs[doc.Entities[i].ID] = true
+	}
+	idx := make(map[string]*ScoreHints, len(doc.Entities))
+	for i := range doc.Entities {
+		idx[doc.Entities[i].ID] = &ScoreHints{}
+	}
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if h, ok := idx[r.FromID]; ok {
+			h.OutboundEdges++
+		}
+		if h, ok := idx[r.ToID]; ok {
+			// Inbound from a non-local entity → cross-repo signal.
+			if !localIDs[r.FromID] {
+				h.HasCrossRepoInbound = true
+			}
+		}
+	}
+	return idx
+}
+
+// ---------------------------------------------------------------------------
 // Built-in emitters
 // ---------------------------------------------------------------------------
 
@@ -663,11 +783,28 @@ var commonProgrammingTerms = map[string]bool{
 // graph nothing has a description, so everything qualified (22,427 candidates
 // ≈ 100% of entities). The new rule inverts this: default policy is NOT to
 // enrich; an entity qualifies only when it hits a positive signal.
-type describeEntityEmitter struct{}
+//
+// The emitter caches the scoreHintsIndex for the current document so the
+// relationship table is only traversed once per CollectCandidates call.
+type describeEntityEmitter struct {
+	cachedDoc   *graph.Document
+	cachedHints map[string]*ScoreHints
+}
 
-func (describeEntityEmitter) Name() string { return KindDescribeEntity }
+func (em *describeEntityEmitter) Name() string { return KindDescribeEntity }
 
-func (describeEntityEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candidate {
+func (em *describeEntityEmitter) hintsFor(e *graph.Entity, doc *graph.Document) *ScoreHints {
+	if doc != em.cachedDoc {
+		em.cachedDoc = doc
+		em.cachedHints = scoreHintsIndex(doc)
+	}
+	if em.cachedHints == nil {
+		return nil
+	}
+	return em.cachedHints[e.ID]
+}
+
+func (em *describeEntityEmitter) EmitFor(e *graph.Entity, doc *graph.Document) []Candidate {
 	if e == nil || e.Name == "" {
 		return nil
 	}
@@ -684,7 +821,8 @@ func (describeEntityEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 	if !ok {
 		return nil
 	}
-	sc, bd, band := ComputeScore(e)
+	hints := em.hintsFor(e, doc)
+	sc, bd, band := ComputeScore(e, hints)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindDescribeEntity),
 		Kind:      KindDescribeEntity,
@@ -709,11 +847,25 @@ func (describeEntityEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 // classifyDomainEmitter emits a candidate for entities that look
 // architecturally significant — high pagerank or god-node flag — so the
 // agent assigns a domain (auth, billing, search, ...).
-type classifyDomainEmitter struct{}
+type classifyDomainEmitter struct {
+	cachedDoc   *graph.Document
+	cachedHints map[string]*ScoreHints
+}
 
-func (classifyDomainEmitter) Name() string { return KindClassifyDomain }
+func (em *classifyDomainEmitter) Name() string { return KindClassifyDomain }
 
-func (classifyDomainEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candidate {
+func (em *classifyDomainEmitter) hintsFor(e *graph.Entity, doc *graph.Document) *ScoreHints {
+	if doc != em.cachedDoc {
+		em.cachedDoc = doc
+		em.cachedHints = scoreHintsIndex(doc)
+	}
+	if em.cachedHints == nil {
+		return nil
+	}
+	return em.cachedHints[e.ID]
+}
+
+func (em *classifyDomainEmitter) EmitFor(e *graph.Entity, doc *graph.Document) []Candidate {
 	if e == nil || e.Name == "" {
 		return nil
 	}
@@ -742,7 +894,8 @@ func (classifyDomainEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 	if len(sigs) == 0 {
 		return nil
 	}
-	sc, bd, band := ComputeScore(e)
+	hints := em.hintsFor(e, doc)
+	sc, bd, band := ComputeScore(e, hints)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindClassifyDomain),
 		Kind:      KindClassifyDomain,
@@ -765,11 +918,25 @@ func (classifyDomainEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candi
 // describeRoleEmitter emits a candidate for clearly architectural nodes
 // (god nodes, articulation points) so the agent assigns a role label
 // (controller / adapter / policy / orchestrator / ...).
-type describeRoleEmitter struct{}
+type describeRoleEmitter struct {
+	cachedDoc   *graph.Document
+	cachedHints map[string]*ScoreHints
+}
 
-func (describeRoleEmitter) Name() string { return KindDescribeRole }
+func (em *describeRoleEmitter) Name() string { return KindDescribeRole }
 
-func (describeRoleEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candidate {
+func (em *describeRoleEmitter) hintsFor(e *graph.Entity, doc *graph.Document) *ScoreHints {
+	if doc != em.cachedDoc {
+		em.cachedDoc = doc
+		em.cachedHints = scoreHintsIndex(doc)
+	}
+	if em.cachedHints == nil {
+		return nil
+	}
+	return em.cachedHints[e.ID]
+}
+
+func (em *describeRoleEmitter) EmitFor(e *graph.Entity, doc *graph.Document) []Candidate {
 	if e == nil || e.Name == "" {
 		return nil
 	}
@@ -798,7 +965,8 @@ func (describeRoleEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candida
 	if e.IsArticulationPt {
 		sigs = append(sigs, "articulation_point")
 	}
-	sc, bd, band := ComputeScore(e)
+	hints := em.hintsFor(e, doc)
+	sc, bd, band := ComputeScore(e, hints)
 	return []Candidate{{
 		ID:        candidateID(e.ID, KindDescribeRole),
 		Kind:      KindDescribeRole,
@@ -821,11 +989,13 @@ func (describeRoleEmitter) EmitFor(e *graph.Entity, _ *graph.Document) []Candida
 
 // DefaultEmitters returns the built-in emitter set. Callers are free to
 // extend this slice; CollectCandidates accepts any []CandidateEmitter.
+// Each emitter is returned as a pointer so its internal ScoreHints cache
+// is shared across all EmitFor calls within a single CollectCandidates run.
 func DefaultEmitters() []CandidateEmitter {
 	return []CandidateEmitter{
-		describeEntityEmitter{},
-		classifyDomainEmitter{},
-		describeRoleEmitter{},
+		&describeEntityEmitter{},
+		&classifyDomainEmitter{},
+		&describeRoleEmitter{},
 	}
 }
 

--- a/internal/enrichment/candidates_test.go
+++ b/internal/enrichment/candidates_test.go
@@ -26,7 +26,7 @@ func mkDoc(es ...graph.Entity) *graph.Document {
 func TestEmitFor_DescribeEntity_NoDescription(t *testing.T) {
 	// http_endpoint qualifies (public API surface — always signal 1).
 	doc := mkDoc(graph.Entity{ID: "e1", Name: "http:GET:/api/users", Kind: "http_endpoint"})
-	cands := CollectCandidates(doc, []CandidateEmitter{describeEntityEmitter{}}, nil)
+	cands := CollectCandidates(doc, []CandidateEmitter{&describeEntityEmitter{}}, nil)
 	if len(cands) != 1 {
 		t.Fatalf("expected 1 candidate, got %d", len(cands))
 	}
@@ -45,13 +45,13 @@ func TestEmitFor_DescribeEntity_NoDescription(t *testing.T) {
 		ID: "e2", Name: "http:POST:/api/orders", Kind: "http_endpoint",
 		Properties: map[string]string{"description": "already set"},
 	})
-	if got := CollectCandidates(doc2, []CandidateEmitter{describeEntityEmitter{}}, nil); len(got) != 0 {
+	if got := CollectCandidates(doc2, []CandidateEmitter{&describeEntityEmitter{}}, nil); len(got) != 0 {
 		t.Fatalf("expected 0 candidates for described entity, got %d", len(got))
 	}
 
 	// Generic "class" kind does NOT qualify under positive selection.
 	doc3 := mkDoc(graph.Entity{ID: "e3", Name: "AuthService", Kind: "class"})
-	if got := CollectCandidates(doc3, []CandidateEmitter{describeEntityEmitter{}}, nil); len(got) != 0 {
+	if got := CollectCandidates(doc3, []CandidateEmitter{&describeEntityEmitter{}}, nil); len(got) != 0 {
 		t.Fatalf("expected 0 candidates for non-qualifying kind, got %d", len(got))
 	}
 }
@@ -59,7 +59,7 @@ func TestEmitFor_DescribeEntity_NoDescription(t *testing.T) {
 // Test 2: a god node triggers a describe_role candidate.
 func TestEmitFor_DescribeRole_GodNode(t *testing.T) {
 	doc := mkDoc(graph.Entity{ID: "g1", Name: "Coordinator", Kind: "class", IsGodNode: true})
-	cands := CollectCandidates(doc, []CandidateEmitter{describeRoleEmitter{}}, nil)
+	cands := CollectCandidates(doc, []CandidateEmitter{&describeRoleEmitter{}}, nil)
 	if len(cands) != 1 {
 		t.Fatalf("expected 1 describe_role candidate, got %d", len(cands))
 	}
@@ -69,13 +69,13 @@ func TestEmitFor_DescribeRole_GodNode(t *testing.T) {
 
 	// Articulation-point also qualifies.
 	doc2 := mkDoc(graph.Entity{ID: "a1", Name: "Bridge", Kind: "class", IsArticulationPt: true})
-	if got := CollectCandidates(doc2, []CandidateEmitter{describeRoleEmitter{}}, nil); len(got) != 1 {
+	if got := CollectCandidates(doc2, []CandidateEmitter{&describeRoleEmitter{}}, nil); len(got) != 1 {
 		t.Fatalf("articulation point: expected 1 candidate, got %d", len(got))
 	}
 
 	// A vanilla entity should NOT trigger describe_role.
 	doc3 := mkDoc(graph.Entity{ID: "v1", Name: "Plain", Kind: "function"})
-	if got := CollectCandidates(doc3, []CandidateEmitter{describeRoleEmitter{}}, nil); len(got) != 0 {
+	if got := CollectCandidates(doc3, []CandidateEmitter{&describeRoleEmitter{}}, nil); len(got) != 0 {
 		t.Fatalf("vanilla entity: expected 0, got %d", len(got))
 	}
 }
@@ -125,7 +125,7 @@ func TestEmit_SkipsRejected(t *testing.T) {
 		graph.Entity{ID: "e1", Name: "http:GET:/api/rejected", Kind: "http_endpoint"},
 		graph.Entity{ID: "e2", Name: "http:GET:/api/allowed", Kind: "http_endpoint"},
 	)
-	cands := CollectCandidatesSkippingRejected(doc, []CandidateEmitter{describeEntityEmitter{}}, dir)
+	cands := CollectCandidatesSkippingRejected(doc, []CandidateEmitter{&describeEntityEmitter{}}, dir)
 	if len(cands) != 1 {
 		t.Fatalf("expected 1 candidate after rejection filter, got %d", len(cands))
 	}
@@ -310,7 +310,7 @@ func TestEmitFor_NoiseKinds(t *testing.T) {
 		"SCOPE.CodeBlock",
 		"SCOPE.Document",
 	}
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	for _, kind := range noiseKinds {
 		doc := mkDoc(graph.Entity{ID: "n1", Name: "SomeName", Kind: kind})
 		got := CollectCandidates(doc, emitter, nil)
@@ -343,7 +343,7 @@ func TestEmitFor_SelfDescriptiveOperation(t *testing.T) {
 		"onClick",
 		"useEffect",
 	}
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	for _, name := range selfDescriptive {
 		doc := mkDoc(graph.Entity{ID: "op1", Name: name, Kind: "SCOPE.Operation"})
 		got := CollectCandidates(doc, emitter, nil)
@@ -367,7 +367,7 @@ func TestEmitFor_AmbiguousOperation(t *testing.T) {
 		"apply",     // 5 chars, all-lowercase
 		"transform", // 9 chars, all-lowercase
 	}
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	for _, name := range ambiguous {
 		doc := mkDoc(graph.Entity{ID: "op2", Name: name, Kind: "SCOPE.Operation"})
 		got := CollectCandidates(doc, emitter, nil)
@@ -388,7 +388,7 @@ func TestEmitFor_OperationWithDescription(t *testing.T) {
 			"description": "Processes the incoming payload through the validation pipeline.",
 		},
 	})
-	got := CollectCandidates(doc, []CandidateEmitter{describeEntityEmitter{}}, nil)
+	got := CollectCandidates(doc, []CandidateEmitter{&describeEntityEmitter{}}, nil)
 	if len(got) != 0 {
 		t.Fatalf("Operation with description: expected 0 candidates, got %d", len(got))
 	}
@@ -398,7 +398,7 @@ func TestEmitFor_OperationWithDescription(t *testing.T) {
 // and non-qualifying kinds do not. Under positive selection (issue #1162) the
 // default policy is NOT to enrich; an entity must hit a positive signal.
 func TestEmitFor_PositiveSelection(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	// Qualifying kinds: must produce a candidate.
 	qualifying := []struct {
@@ -450,7 +450,7 @@ func TestEmitFor_PositiveSelection(t *testing.T) {
 // described in issue #1162: 1 HTTPEndpoint, 1 god node, 1 ambiguous-name Op,
 // 1 trivial helper → exactly 3 candidates (helper not selected).
 func TestQualifiesForEnrichment_Scenario(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	doc := mkDoc(
 		// Signal 1 — HTTP endpoint: qualifies
 		graph.Entity{ID: "ep1", Name: "http:POST:/api/orders", Kind: "http_endpoint"},
@@ -477,7 +477,7 @@ func TestQualifiesForEnrichment_Scenario(t *testing.T) {
 // TestQualifiesForEnrichment_Signals checks that QualificationSignals is
 // populated and contains the correct signal name for each qualifying trigger.
 func TestQualifiesForEnrichment_Signals(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	cases := []struct {
 		entity graph.Entity
@@ -514,7 +514,7 @@ func TestQualifiesForEnrichment_Signals(t *testing.T) {
 // TestQualifiesForEnrichment_NoiseKindDefaultsOut verifies that entities in
 // the noise kind set are excluded even if they are god nodes.
 func TestQualifiesForEnrichment_NoiseKindDefaultsOut(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	noiseGodNode := graph.Entity{
 		ID: "n1", Name: "SomePattern", Kind: "SCOPE.Pattern", IsGodNode: true,
 	}
@@ -529,7 +529,7 @@ func TestQualifiesForEnrichment_NoiseKindDefaultsOut(t *testing.T) {
 // for the ambiguous-name signal: exactly at 9 chars (qualifies), 10 chars
 // (does not), camelCase (does not, has uppercase).
 func TestQualifiesForEnrichment_AmbiguousNameBoundary(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	// 9 chars all-lowercase → qualifies
 	doc9 := mkDoc(graph.Entity{ID: "o1", Name: "transform", Kind: "SCOPE.Operation"}) // exactly 9
@@ -559,7 +559,7 @@ func TestQualifiesForEnrichment_AmbiguousNameBoundary(t *testing.T) {
 // selfDescriptiveOperationRE correctly filters articulation-point operations
 // whose names are trivially paraphraseable (make/handle/list/… prefixes).
 func TestDeepTightening_SelfDescriptiveREExtension(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	// These names should NOT produce a describe_entity candidate — each encodes
 	// its own action+subject and an agent description would be a tautology.
 	selfDesc := []string{
@@ -599,7 +599,7 @@ func TestDeepTightening_SelfDescriptiveREExtension(t *testing.T) {
 // TestDeepTightening_DjangoMetaAttrs verifies that SCOPE.Schema entities whose
 // names contain ".Meta." (Django Meta class attributes) are excluded.
 func TestDeepTightening_DjangoMetaAttrs(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	metaEntities := []struct {
 		id   string
 		name string
@@ -621,7 +621,7 @@ func TestDeepTightening_DjangoMetaAttrs(t *testing.T) {
 // TestDeepTightening_ModelFieldDeclarations verifies that SCOPE.Schema entities
 // matching the "ModelName.field_name" pattern are excluded.
 func TestDeepTightening_ModelFieldDeclarations(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	fieldEntities := []struct {
 		id   string
 		name string
@@ -648,7 +648,7 @@ func TestDeepTightening_ModelFieldDeclarations(t *testing.T) {
 // TestDeepTightening_PrivateHelperOperations verifies that underscore-prefixed
 // private helpers are excluded from the ambiguous-name signal.
 func TestDeepTightening_PrivateHelperOperations(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	privateHelpers := []string{"_s", "_m", "_mask_key", "_norm", "_norm_str"}
 	for _, name := range privateHelpers {
 		doc := mkDoc(graph.Entity{ID: "ph", Name: name, Kind: "SCOPE.Operation"})
@@ -662,7 +662,7 @@ func TestDeepTightening_PrivateHelperOperations(t *testing.T) {
 // TestDeepTightening_ShortComponentVariables verifies that SCOPE.Component
 // names of 1–3 characters (local variable captures) are excluded.
 func TestDeepTightening_ShortComponentVariables(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 	shortVars := []string{"cx", "db", "bg", "mo", "mx"}
 	for _, name := range shortVars {
 		doc := mkDoc(graph.Entity{ID: "sv", Name: name, Kind: "SCOPE.Component"})
@@ -959,7 +959,7 @@ func TestComputeScore_ScoreOnEmittedCandidate(t *testing.T) {
 		PageRank:   &pr,
 		SourceFile: "handlers.go",
 	})
-	cands := CollectCandidates(doc, []CandidateEmitter{describeEntityEmitter{}}, nil)
+	cands := CollectCandidates(doc, []CandidateEmitter{&describeEntityEmitter{}}, nil)
 	if len(cands) != 1 {
 		t.Fatalf("expected 1 candidate, got %d", len(cands))
 	}
@@ -1016,7 +1016,7 @@ func TestComputeScore_NilEntity(t *testing.T) {
 // entity that is an articulation point but has a self-descriptive name does NOT
 // qualify for describe_entity (Signal 2 guard, fix #1279).
 func TestSignal2_SelfDescriptiveOpArticulationPoint(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	selfDescriptiveNames := []string{
 		"setFilters",
@@ -1058,7 +1058,7 @@ func TestSignal2_SelfDescriptiveOpArticulationPoint(t *testing.T) {
 // it also matches selfDescriptiveOperationRE. God nodes are architectural hubs
 // that need description regardless of name pattern (fix #1279).
 func TestSignal2_GodNodeSelfDescriptiveOpStillQualifies(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	doc := mkDoc(graph.Entity{
 		ID:        "gn1",
@@ -1087,7 +1087,7 @@ func TestSignal2_GodNodeSelfDescriptiveOpStillQualifies(t *testing.T) {
 // The self-descriptive guard in Signal 2 targets only SCOPE.Operation / Operation
 // kinds (fix #1279).
 func TestSignal2_ArticulationPtNonOpStillQualifies(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	doc := mkDoc(graph.Entity{
 		ID:               "svc1",
@@ -1106,7 +1106,7 @@ func TestSignal2_ArticulationPtNonOpStillQualifies(t *testing.T) {
 // operation with a self-descriptive name. The describe_entity guard must
 // not affect describeRoleEmitter (fix #1279 — preserving describe_role).
 func TestDescribeRoleEmitter_ArticulationPtSelfDescriptiveOp(t *testing.T) {
-	emitter := []CandidateEmitter{describeRoleEmitter{}}
+	emitter := []CandidateEmitter{&describeRoleEmitter{}}
 
 	// describeRoleEmitter already has its own selfDescriptiveOperationRE check
 	// that filters self-descriptive names. Verify that a non-self-descriptive
@@ -1130,7 +1130,7 @@ func TestDescribeRoleEmitter_ArticulationPtSelfDescriptiveOp(t *testing.T) {
 // containing "${" are excluded from describe_entity enrichment entirely
 // (template-literal URL guard, fix #1279).
 func TestTemplateLiteralName_SkipsDescribeEntity(t *testing.T) {
-	emitter := []CandidateEmitter{describeEntityEmitter{}}
+	emitter := []CandidateEmitter{&describeEntityEmitter{}}
 
 	templateLiteralNames := []string{
 		"${import.meta.env.VITE_CORE_API}/devices/?${queryParams.toString()}",
@@ -1300,7 +1300,7 @@ func TestFilter_HttpEndpointCall(t *testing.T) {
 // trivial-prop terms in commonProgrammingTerms suppress the ambiguous-name
 // signal and produce no candidates.
 func TestFilter_ExtendedCommonTerms(t *testing.T) {
-	emitters := []CandidateEmitter{describeEntityEmitter{}}
+	emitters := []CandidateEmitter{&describeEntityEmitter{}}
 	trivialNames := []string{
 		"variant", "height", "width", "color", "speed",
 		"gap", "align", "sticky", "sync", "year", "month",
@@ -1326,4 +1326,243 @@ func candidateKinds(cs []Candidate) []string {
 		kinds[i] = c.Kind
 	}
 	return kinds
+}
+
+// ---------------------------------------------------------------------------
+// Tests for issue #1301: score-function fixes
+// ---------------------------------------------------------------------------
+
+// TestComputeScore_HTTPEndpointDefinition verifies that the post-#1217 kind
+// "http_endpoint_definition" receives base score 80 (not the default 35).
+func TestComputeScore_HTTPEndpointDefinition(t *testing.T) {
+	e := &graph.Entity{
+		ID:         "ep1",
+		Name:       "http:GET:/api/v1/users",
+		Kind:       "http_endpoint_definition",
+		SourceFile: "handlers/users.go",
+	}
+	score, breakdown, band := ComputeScore(e)
+	if score < 80 {
+		t.Errorf("http_endpoint_definition: score = %d, want >= 80; breakdown: %s", score, breakdown)
+	}
+	if band != "critical" {
+		t.Errorf("http_endpoint_definition: band = %q, want \"critical\"; breakdown: %s", band, breakdown)
+	}
+}
+
+// TestComputeScore_HTTPEndpointDefinitionQualifies verifies that
+// http_endpoint_definition entities are emitted by describeEntityEmitter
+// (qualifyHTTPKinds guard added in #1301).
+func TestComputeScore_HTTPEndpointDefinitionQualifies(t *testing.T) {
+	doc := mkDoc(graph.Entity{
+		ID:         "ep2",
+		Name:       "http:POST:/api/v1/orders",
+		Kind:       "http_endpoint_definition",
+		SourceFile: "handlers/orders.go",
+	})
+	got := CollectCandidates(doc, []CandidateEmitter{&describeEntityEmitter{}}, nil)
+	if len(got) != 1 {
+		t.Fatalf("http_endpoint_definition: expected 1 candidate, got %d", len(got))
+	}
+	if got[0].CriticalityBand != "critical" {
+		t.Errorf("http_endpoint_definition: band = %q, want \"critical\"; breakdown: %s",
+			got[0].CriticalityBand, got[0].ScoreBreakdown)
+	}
+}
+
+// TestComputeScore_CriticalBandDifferentiation verifies that the three
+// critical-band differentiators (+5 each for outbound degree, top pagerank,
+// cross-repo inbound) break ties within 80–100 and that scores are not
+// uniformly 80.
+func TestComputeScore_CriticalBandDifferentiation(t *testing.T) {
+	pr := 0.06 // above the 0.05 top-pagerank threshold
+	tests := []struct {
+		name      string
+		entity    graph.Entity
+		hints     *ScoreHints
+		wantScore int
+		wantBand  string
+	}{
+		{
+			name: "god-node + high-degree + top-pagerank + cross-repo breaks plain critical tie",
+			// class base 35 + god 20 + pagerank 10 + high_degree 5 + top_pagerank 5 + cross_repo 5 = 80
+			entity: graph.Entity{
+				ID:         "g1",
+				Name:       "Notification",
+				Kind:       "class",
+				SourceFile: "core/notification.go",
+				IsGodNode:  true,
+				PageRank:   &pr,
+			},
+			hints:     &ScoreHints{OutboundEdges: 25, HasCrossRepoInbound: true},
+			wantScore: 80,
+			wantBand:  "critical",
+		},
+		{
+			name: "http_endpoint_definition god-node = at least 100",
+			entity: graph.Entity{
+				ID:         "ep3",
+				Name:       "http:GET:/api/v1/users",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "handlers/users.go",
+				IsGodNode:  true,
+				PageRank:   &pr,
+			},
+			hints:     &ScoreHints{OutboundEdges: 25, HasCrossRepoInbound: true},
+			wantScore: 100, // 80+20+5+5+5 = 115 → clamped to 100
+			wantBand:  "critical",
+		},
+		{
+			name: "plain http_endpoint_definition no hints = 80",
+			entity: graph.Entity{
+				ID:         "ep4",
+				Name:       "http:DELETE:/api/v1/orders",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "handlers/orders.go",
+			},
+			hints:     nil,
+			wantScore: 80,
+			wantBand:  "critical",
+		},
+		{
+			name: "plain Route with high-degree = 85",
+			entity: graph.Entity{
+				ID:         "rt1",
+				Name:       "/blog/",
+				Kind:       "Route",
+				SourceFile: "routes/blog.go",
+			},
+			hints:     &ScoreHints{OutboundEdges: 25},
+			wantScore: 85, // 80 + 5 high-degree
+			wantBand:  "critical",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			score, bd, band := ComputeScore(&tc.entity, tc.hints)
+			if score != tc.wantScore {
+				t.Errorf("score = %d, want %d; breakdown: %s", score, tc.wantScore, bd)
+			}
+			if band != tc.wantBand {
+				t.Errorf("band = %q, want %q; breakdown: %s", band, tc.wantBand, bd)
+			}
+		})
+	}
+}
+
+// TestComputeScore_UtilityFunctionPenalty verifies that self-descriptive
+// Operation names are penalised -15 even when they are articulation points,
+// but god nodes remain exempt.
+func TestComputeScore_UtilityFunctionPenalty(t *testing.T) {
+	// Articulation-point setLoading: 40 base + 15 articulation - 15 self_descriptive = 40 (Medium)
+	e := &graph.Entity{
+		ID:               "op1",
+		Name:             "setLoading",
+		Kind:             "SCOPE.Operation",
+		SourceFile:       "src/hooks/useData.ts",
+		IsArticulationPt: true,
+	}
+	score, bd, band := ComputeScore(e)
+	if score >= 60 {
+		t.Errorf("setLoading articulation-pt: score = %d, want < 60 (High or Critical); breakdown: %s", score, bd)
+	}
+	if band == "high" || band == "critical" {
+		t.Errorf("setLoading articulation-pt: band = %q, want medium or low; breakdown: %s", band, bd)
+	}
+
+	// God-node getUser: 40 base + 20 god — penalty exempt — = 60 (High)
+	eGod := &graph.Entity{
+		ID:         "op2",
+		Name:       "getUser",
+		Kind:       "SCOPE.Operation",
+		SourceFile: "src/api/user.ts",
+		IsGodNode:  true,
+	}
+	scoreGod, bdGod, bandGod := ComputeScore(eGod)
+	if scoreGod < 55 {
+		t.Errorf("getUser god-node: score = %d, want >= 55 (god exempt from penalty); breakdown: %s", scoreGod, bdGod)
+	}
+	_ = bandGod
+}
+
+// TestComputeScore_LineSpanModifiers verifies that line-span affects the score:
+// +10 for large functions (>30 lines), -15 for trivial bodies (<=5 lines).
+func TestComputeScore_LineSpanModifiers(t *testing.T) {
+	// Complex function: name "authorize" does not match selfDescriptiveOperationRE
+	// (no uppercase after verb prefix), so no -15 penalty.
+	// 40 base + 10 complex_body = 50 (Medium).
+	complex := &graph.Entity{
+		ID:         "fn1",
+		Name:       "authorize",
+		Kind:       "SCOPE.Operation",
+		SourceFile: "auth/authorize.go",
+		StartLine:  10,
+		EndLine:    55, // span = 45 > 30
+	}
+	scoreComplex, bdComplex, _ := ComputeScore(complex)
+	if scoreComplex != 50 {
+		t.Errorf("complex function: score = %d, want 50; breakdown: %s", scoreComplex, bdComplex)
+	}
+
+	// Trivial function: name "adapter" (7 chars, not short, not self-descriptive).
+	// 40 base - 15 trivial_body = 25 (Low).
+	trivial := &graph.Entity{
+		ID:         "fn2",
+		Name:       "adapter",
+		Kind:       "SCOPE.Operation",
+		SourceFile: "util/adapter.go",
+		StartLine:  1,
+		EndLine:    3, // span = 2 <= 5
+	}
+	scoreTrivial, bdTrivial, bandTrivial := ComputeScore(trivial)
+	if scoreTrivial != 25 {
+		t.Errorf("trivial function: score = %d, want 25; breakdown: %s", scoreTrivial, bdTrivial)
+	}
+	if bandTrivial != "low" {
+		t.Errorf("trivial function: band = %q, want \"low\"; breakdown: %s", bandTrivial, bdTrivial)
+	}
+}
+
+// TestComputeScore_ScoreHintsFromDocument verifies that scoreHintsIndex
+// correctly counts outbound edges and detects cross-repo inbound.
+func TestComputeScore_ScoreHintsFromDocument(t *testing.T) {
+	doc := &graph.Document{
+		Version: graph.SchemaVersion,
+		Repo:    "testrepo",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "AuthService", Kind: "Service", SourceFile: "auth.go"},
+			{ID: "b", Name: "UserRepo", Kind: "SCOPE.DataAccess", SourceFile: "repo.go"},
+		},
+		Relationships: []graph.Relationship{
+			// a → b (outbound for a, inbound for b from a local entity)
+			{ID: "r1", FromID: "a", ToID: "b", Kind: "calls"},
+			// external → b (cross-repo inbound for b)
+			{ID: "r2", FromID: "external-repo-entity", ToID: "b", Kind: "imports"},
+			// a → c (non-existent target is fine, still counts as outbound for a)
+			{ID: "r3", FromID: "a", ToID: "c", Kind: "imports"},
+		},
+	}
+	idx := scoreHintsIndex(doc)
+	hA := idx["a"]
+	if hA == nil {
+		t.Fatal("no hints for entity a")
+	}
+	if hA.OutboundEdges != 2 {
+		t.Errorf("entity a: OutboundEdges = %d, want 2", hA.OutboundEdges)
+	}
+	if hA.HasCrossRepoInbound {
+		t.Errorf("entity a: HasCrossRepoInbound = true, want false (all inbound from local)")
+	}
+
+	hB := idx["b"]
+	if hB == nil {
+		t.Fatal("no hints for entity b")
+	}
+	if hB.OutboundEdges != 0 {
+		t.Errorf("entity b: OutboundEdges = %d, want 0", hB.OutboundEdges)
+	}
+	if !hB.HasCrossRepoInbound {
+		t.Errorf("entity b: HasCrossRepoInbound = false, want true (inbound from external-repo-entity)")
+	}
 }


### PR DESCRIPTION
## What changed

Four scoring flaws from the #1301 audit, all in `internal/enrichment/candidates.go` `ComputeScore`.

## Why

| Issue | Root cause | Fix |
|---|---|---|
| 54 `http_endpoint_definition` entities stuck at 55 | `kindBaseScore` switch only covered `"http_endpoint"` (legacy alias); the post-#1217 canonical kind was missing | Added `"http_endpoint_definition"` to the 80-base case and to `qualifyHTTPKinds` |
| God nodes all at 80 — `Notification` ties `/blog/` route | No differentiation within the 80–100 band | Three +5 differentiators via new `ScoreHints`: `OutboundEdges>20`, `PageRank>0.05`, `HasCrossRepoInbound` |
| `setX`/`getX`/`useX` ops scoring ~70 via articulation-point signal | No penalty for self-descriptive names even at articulation points | `-15 self_descriptive` for `SCOPE.Operation` matching `selfDescriptiveOperationRE`; god nodes remain exempt |
| Only 15 discrete scores across 5,000 entities (bimodal) | Scoring formula had no continuous signal | Added line-span modifiers: `+10` if `EndLine-StartLine>30`, `-15` if `≤5`; derived from existing fields |

## How

- `ScoreHints` struct carries per-entity graph signals requiring Document traversal (`OutboundEdges int`, `HasCrossRepoInbound bool`).
- `scoreHintsIndex(doc)` builds a `map[entityID]*ScoreHints` in one pass over `doc.Relationships`.
- Each emitter struct now has a `cachedDoc / cachedHints` pair so the index is built **once per CollectCandidates call**, not once per entity.
- `ComputeScore(e, hints...)` — variadic, fully backward-compatible; nil hints skip the graph-level differentiators.
- `DefaultEmitters()` returns pointers (`&describeEntityEmitter{}`) so the cache state is shared within a run.

## Tests

6 new table-driven cases in `candidates_test.go`:
- `TestComputeScore_HTTPEndpointDefinition` — base 80, band critical
- `TestComputeScore_HTTPEndpointDefinitionQualifies` — emitter produces critical candidate
- `TestComputeScore_CriticalBandDifferentiation` — Route+high_degree=85, god HTTP endpoint=100
- `TestComputeScore_UtilityFunctionPenalty` — setLoading articulationPt stays Medium; getUser godNode exempt
- `TestComputeScore_LineSpanModifiers` — span>30 +10, span≤5 -15
- `TestComputeScore_ScoreHintsFromDocument` — outbound count, cross-repo inbound detection

Pre-existing failure `TestCollectRepairEdgeCandidates_NonHexFromID` is **not** caused by this PR (fails on `main` too).

## Acceptance checklist

- [ ] Rebuild target codebase; dump score histogram — confirm Critical band > 5% of scored entities
- [ ] Confirm `http_endpoint_definition` entities all at ≥ 80 (was 55)
- [ ] Confirm score spread 80–100 (no longer flat at 80)

Closes #1301 (partial — scoring; histogram verification deferred to follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)