### PR TITLE
feat(enrichment): separate community-naming queue from entity enrichment

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -92,6 +92,7 @@ import type {
   EntityNeighborResponse,
   PendingRepairsResponse,
   PendingEnrichmentsResponse,
+  CommunityNamingResponse,
   EnrichmentProgressResponse,
   OrphanCallersResponse,
   OrphanPublishersResponse,
@@ -934,6 +935,14 @@ export async function fetchEnrichments(group: string): Promise<PendingEnrichment
     return { items: [], total: 0 }
   }
   return apiFetch<PendingEnrichmentsResponse>(`/api/enrichments/${group}`)
+}
+
+/** GET /api/community-naming/{group} — name_community candidates (#1301) */
+export async function fetchCommunityNaming(group: string): Promise<CommunityNamingResponse> {
+  if (USE_MOCKS) {
+    return { items: [], total: 0 }
+  }
+  return apiFetch<CommunityNamingResponse>(`/api/community-naming/${group}`)
 }
 
 /** GET /api/enrichments/{group}/progress — per-tier job progress (#1286) */

--- a/dashboard/src/routes/pending.tsx
+++ b/dashboard/src/routes/pending.tsx
@@ -1,13 +1,13 @@
 import { useState, useMemo, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { fetchRepairs, fetchEnrichments, postCandidateAction } from '@/api/client'
-import type { PendingCandidateRow, QualificationSignal, EnrichmentProgressBand } from '@/types/api'
+import { fetchRepairs, fetchEnrichments, fetchCommunityNaming, postCandidateAction } from '@/api/client'
+import type { PendingCandidateRow, QualificationSignal, EnrichmentProgressBand, CommunityNamingRow } from '@/types/api'
 import { useEnrichmentProgress } from '@/hooks/shared/useEnrichmentProgress'
 import {
   Wrench, Sparkles, CheckCircle, XCircle, AlertCircle,
   ChevronDown, ChevronRight, Search, EyeOff,
-  ArrowUpDown, Loader2,
+  ArrowUpDown, Loader2, Network,
 } from 'lucide-react'
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -881,15 +881,113 @@ function TieredList({ rows, group, emptyMessage, onApplied }: TieredListProps) {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// CommunityNamingList — flat list of name_community candidates (#1301)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface CommunityNamingListProps {
+  rows: CommunityNamingRow[]
+}
+
+function CommunityNamingList({ rows }: CommunityNamingListProps) {
+  const [searchQ, setSearchQ] = useState('')
+  const q = searchQ.trim().toLowerCase()
+
+  const filtered = useMemo(() =>
+    q ? rows.filter((r) => {
+      const autoName = (r.context?.auto_name as string | undefined ?? '').toLowerCase()
+      const topEntities = JSON.stringify(r.context?.top_entities ?? '').toLowerCase()
+      return autoName.includes(q) || topEntities.includes(q) || r.repo.toLowerCase().includes(q)
+    }) : rows,
+  [rows, q])
+
+  if (rows.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center py-20 gap-3 text-slate-400 dark:text-slate-500">
+        <CheckCircle className="w-10 h-10 text-emerald-400/70" />
+        <p className="text-sm">No pending community naming — all clusters resolved</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="flex flex-col h-full">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 px-4 py-2 border-b border-slate-200 dark:border-slate-800 bg-white/80 dark:bg-slate-950/80 backdrop-blur-sm flex-shrink-0">
+        <div className="flex items-center gap-1.5 flex-1 min-w-[160px] max-w-xs bg-slate-50 dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded-md px-2.5 py-1.5">
+          <Search className="w-3.5 h-3.5 text-slate-400 dark:text-slate-500 shrink-0" />
+          <input
+            type="search"
+            aria-label="Search community naming candidates"
+            placeholder="Search clusters…"
+            value={searchQ}
+            onChange={(e) => setSearchQ(e.target.value)}
+            className="flex-1 bg-transparent text-sm text-slate-700 dark:text-slate-300 placeholder-slate-400 dark:placeholder-slate-500 outline-none"
+          />
+        </div>
+        <span className="ml-auto text-xs text-slate-500 dark:text-slate-400 tabular-nums">
+          {filtered.length} of {rows.length} clusters
+        </span>
+      </div>
+
+      {/* List */}
+      <div className="flex-1 overflow-y-auto">
+        {filtered.length === 0 ? (
+          <div className="flex flex-col items-center justify-center py-16 gap-2 text-slate-400 dark:text-slate-500">
+            <Search className="w-8 h-8 text-slate-300" />
+            <p className="text-sm">No clusters match "{searchQ}"</p>
+          </div>
+        ) : (
+          filtered.map((row) => {
+            const autoName = row.context?.auto_name as string | undefined
+            const size = row.context?.size as number | undefined
+            const topEntities = (row.context?.top_entities as string[] | undefined) ?? []
+            return (
+              <div
+                key={row.candidate_id}
+                className="flex items-start gap-3 px-4 py-3 border-b border-slate-100 dark:border-slate-800 hover:bg-slate-50/60 dark:hover:bg-slate-800/40 transition-colors"
+              >
+                <Network className="w-4 h-4 mt-0.5 shrink-0 text-violet-500 dark:text-violet-400" aria-hidden="true" />
+                <div className="flex-1 min-w-0">
+                  <p className="text-sm font-medium text-slate-800 dark:text-slate-200 truncate">
+                    {autoName ?? row.subject_id}
+                    {size != null && (
+                      <span className="ml-2 text-xs font-normal text-slate-400 dark:text-slate-500">
+                        {size} nodes
+                      </span>
+                    )}
+                  </p>
+                  {topEntities.length > 0 && (
+                    <p className="text-xs text-slate-500 dark:text-slate-400 mt-0.5 truncate">
+                      {topEntities.slice(0, 5).join(', ')}
+                      {topEntities.length > 5 && ` +${topEntities.length - 5} more`}
+                    </p>
+                  )}
+                  {row.repo && (
+                    <span className="text-xs font-mono text-slate-400 dark:text-slate-500">{row.repo}</span>
+                  )}
+                </div>
+              </div>
+            )
+          })
+        )}
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // PendingRoute — Surface 6
 // ─────────────────────────────────────────────────────────────────────────────
 
-type TabId = 'repairs' | 'enrichments'
+type TabId = 'repairs' | 'enrichments' | 'community-naming'
 
 /**
  * Surface 6 — Pending queue.
- * Two tabs: Repair candidates (repair_edge + dynamic_baseurl) and
- * Enrichment candidates (describe_entity, classify_domain, …).
+ * Three tabs:
+ *   1. Repair candidates (repair_edge + dynamic_baseurl)
+ *   2. Enrichment candidates (describe_entity, classify_domain, …) — entity-level
+ *   3. Community naming (name_community) — cluster naming, separated per #1301
+ *
  * Enrichments are bucketed into 4 collapsible tiers: Critical / High / Medium / Low.
  */
 export function PendingRoute() {
@@ -911,6 +1009,13 @@ export function PendingRoute() {
     staleTime: 30 * 1000,
   })
 
+  const communityNamingQuery = useQuery({
+    queryKey: ['community-naming', group],
+    queryFn: () => fetchCommunityNaming(group ?? ''),
+    enabled: !!group,
+    staleTime: 30 * 1000,
+  })
+
   if (!group) {
     return (
       <div className="h-full flex items-center justify-center text-slate-400 dark:text-slate-500">
@@ -921,8 +1026,9 @@ export function PendingRoute() {
 
   const repairCount = repairsQuery.data?.total ?? 0
   const enrichCount = enrichmentsQuery.data?.total ?? 0
-  const isLoading = repairsQuery.isLoading || enrichmentsQuery.isLoading
-  const hasError = repairsQuery.isError || enrichmentsQuery.isError
+  const communityCount = communityNamingQuery.data?.total ?? 0
+  const isLoading = repairsQuery.isLoading || enrichmentsQuery.isLoading || communityNamingQuery.isLoading
+  const hasError = repairsQuery.isError || enrichmentsQuery.isError || communityNamingQuery.isError
 
   const tabs: { id: TabId; label: string; count: number; icon: React.ReactNode }[] = [
     {
@@ -936,6 +1042,12 @@ export function PendingRoute() {
       label: 'Enrichment candidates',
       count: enrichCount,
       icon: <Sparkles className="w-3.5 h-3.5" />,
+    },
+    {
+      id: 'community-naming',
+      label: 'Community naming',
+      count: communityCount,
+      icon: <Network className="w-3.5 h-3.5" />,
     },
   ]
 
@@ -1040,6 +1152,12 @@ export function PendingRoute() {
               emptyMessage="No pending enrichments — all candidates resolved"
               onApplied={() => setAppliedCount((n) => n + 1)}
             />
+          </div>
+        )}
+
+        {!isLoading && !hasError && activeTab === 'community-naming' && (
+          <div className="flex flex-col flex-1 overflow-hidden">
+            <CommunityNamingList rows={communityNamingQuery.data?.items ?? []} />
           </div>
         )}
       </div>

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -787,6 +787,27 @@ export interface PendingEnrichmentsResponse {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Community naming queue — GET /api/community-naming/{group} (#1301)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** One row returned by GET /api/community-naming/{group}. */
+export interface CommunityNamingRow {
+  candidate_id: string
+  repo: string
+  kind: string
+  subject_id: string
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  context?: Record<string, any>
+  confidence?: number
+  discovered_at?: string
+}
+
+export interface CommunityNamingResponse {
+  items: CommunityNamingRow[]
+  total: number
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Enrichment progress — GET /api/enrichments/{group}/progress (#1286)
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/internal/dashboard/handlers_community_naming.go
+++ b/internal/dashboard/handlers_community_naming.go
@@ -1,0 +1,84 @@
+package dashboard
+
+// handlers_community_naming.go — Community-naming queue endpoint (#1301).
+//
+//	GET /api/community-naming/{group}  — name_community candidates for every
+//	                                     repo in the group, separate from the
+//	                                     entity-level enrichment queue.
+//
+// Background: the enrichment task queue contained 1,556 name_community jobs
+// mixed with ~3,059 entity-level jobs (describe_entity / classify_domain /
+// describe_role). Because community naming is a fundamentally different
+// workflow — naming graph-detected clusters rather than enriching individual
+// code entities — the two kinds are split at the API layer so the frontend
+// can show them in separate panels with separate progress tracking.
+
+import (
+	"net/http"
+)
+
+// communityNamingRow is the wire shape for one community-naming candidate.
+// It mirrors pendingCandidateRow but is kept separate so each queue can
+// evolve its fields independently.
+type communityNamingRow struct {
+	CandidateID  string         `json:"candidate_id"`
+	Repo         string         `json:"repo"`
+	Kind         string         `json:"kind"`
+	SubjectID    string         `json:"subject_id"`
+	Context      map[string]any `json:"context,omitempty"`
+	Confidence   float64        `json:"confidence,omitempty"`
+	DiscoveredAt string         `json:"discovered_at,omitempty"`
+}
+
+// handleCommunityNaming — GET /api/community-naming/{group}
+//
+// Returns all name_community candidates aggregated across every repo in
+// the group. Each row represents one community cluster that has not yet
+// received an agent-assigned name.
+//
+// Response shape:
+//
+//	{
+//	  "items": [ {communityNamingRow}, … ],
+//	  "total": 1556
+//	}
+func (s *Server) handleCommunityNaming(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	items := []communityNamingRow{}
+
+	for slug, repo := range grp.Repos {
+		if repo == nil || repo.Path == "" {
+			continue
+		}
+		for _, c := range readAllCandidates(repo.Path) {
+			if !communityNamingKinds[c.Kind] {
+				continue // entity enrichment and repair tabs handle the rest
+			}
+			items = append(items, communityNamingRow{
+				CandidateID:  c.ID,
+				Repo:         slug,
+				Kind:         c.Kind,
+				SubjectID:    c.SubjectID,
+				Context:      c.Context,
+				Confidence:   c.Confidence,
+				DiscoveredAt: c.DiscoveredAt,
+			})
+		}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"items": items,
+		"total": len(items),
+	})
+}

--- a/internal/dashboard/handlers_community_naming_test.go
+++ b/internal/dashboard/handlers_community_naming_test.go
@@ -1,0 +1,170 @@
+package dashboard
+
+// handlers_community_naming_test.go — HTTP-level tests for
+//
+//	GET /api/community-naming/{group}   (#1301)
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// newCommunityNamingServer creates a minimal Server with one repo whose
+// enrichment-candidates.json contains a mix of name_community and
+// describe_entity candidates. Returned along with the repo's state dir.
+func newCommunityNamingServer(t *testing.T) (*Server, string) {
+	t.Helper()
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	// Create a temporary repo directory with an archigraph state dir.
+	repoDir := t.TempDir()
+	stateDir := filepath.Join(repoDir, ".archigraph")
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+
+	// Write a candidates file with mixed kinds.
+	candidates := []map[string]any{
+		{
+			"id":         "cn:community:1",
+			"kind":       "name_community",
+			"task_type":  "community",
+			"subject_id": "community:1",
+			"context":    map[string]any{"auto_name": "AuthCluster", "size": 42, "top_entities": []string{"UserService", "TokenValidator"}},
+			"confidence_floor": 0.6,
+			"discovered_at":    "2026-05-01T00:00:00Z",
+		},
+		{
+			"id":         "cn:community:2",
+			"kind":       "name_community",
+			"task_type":  "community",
+			"subject_id": "community:2",
+			"context":    map[string]any{"auto_name": "BillingCluster", "size": 17, "top_entities": []string{"InvoiceService"}},
+			"confidence_floor": 0.6,
+			"discovered_at":    "2026-05-01T00:00:00Z",
+		},
+		{
+			"id":         "ec:entity:abc",
+			"kind":       "describe_entity",
+			"task_type":  "entity",
+			"subject_id": "entity:abc",
+			"context":    map[string]any{"name": "AuthHandler", "kind": "Service"},
+			"score":      75,
+			"discovered_at": "2026-05-01T00:00:00Z",
+		},
+	}
+	data, _ := json.Marshal(map[string]any{"version": 2, "candidates": candidates})
+	if err := os.WriteFile(filepath.Join(stateDir, "enrichment-candidates.json"), data, 0o644); err != nil {
+		t.Fatalf("write candidates: %v", err)
+	}
+
+	// Seed group "g1" into the graph cache with the temp repo.
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g1"] = &cacheEntry{
+		group: &DashGroup{
+			Name: "g1",
+			Repos: map[string]*DashRepo{
+				"repo1": {Slug: "repo1", Path: repoDir},
+			},
+		},
+		loadedAt: time.Now().Add(60 * time.Second),
+	}
+	srv.graphs.mu.Unlock()
+	return srv, stateDir
+}
+
+func TestHandleCommunityNaming_ReturnsCommunityKindsOnly(t *testing.T) {
+	srv, _ := newCommunityNamingServer(t)
+	h := srv.routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/community-naming/g1", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	items, ok := resp["items"].([]any)
+	if !ok {
+		t.Fatalf("items is not an array: %T", resp["items"])
+	}
+	total := resp["total"].(float64)
+
+	if got := len(items); got != 2 {
+		t.Errorf("want 2 community items, got %d", got)
+	}
+	if total != 2 {
+		t.Errorf("want total=2, got %v", total)
+	}
+
+	// Verify only name_community kinds.
+	for _, raw := range items {
+		item := raw.(map[string]any)
+		if kind, _ := item["kind"].(string); kind != "name_community" {
+			t.Errorf("unexpected kind %q in community-naming response", kind)
+		}
+	}
+}
+
+func TestHandleCommunityNaming_EnrichmentsExcludesCommunity(t *testing.T) {
+	// Verify that /api/enrichments/{group} no longer includes name_community rows.
+	srv, _ := newCommunityNamingServer(t)
+	h := srv.routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/enrichments/g1", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", rr.Code, rr.Body.String())
+	}
+
+	var resp map[string]any
+	if err := json.NewDecoder(rr.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	items, ok := resp["items"].([]any)
+	if !ok {
+		t.Fatalf("items is not an array: %T", resp["items"])
+	}
+
+	// Only describe_entity should be present (1 item).
+	if got := len(items); got != 1 {
+		t.Errorf("want 1 entity enrichment item (describe_entity), got %d", got)
+	}
+	for _, raw := range items {
+		item := raw.(map[string]any)
+		if kind, _ := item["kind"].(string); kind == "name_community" {
+			t.Errorf("name_community should not appear in /api/enrichments response")
+		}
+	}
+}
+
+func TestHandleCommunityNaming_MissingGroup(t *testing.T) {
+	srv, _ := newCommunityNamingServer(t)
+	h := srv.routes()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/community-naming/nonexistent", nil)
+	rr := httptest.NewRecorder()
+	h.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNotFound {
+		t.Errorf("want 404 for missing group, got %d", rr.Code)
+	}
+}

--- a/internal/dashboard/handlers_enrichment_batch_test.go
+++ b/internal/dashboard/handlers_enrichment_batch_test.go
@@ -151,7 +151,7 @@ func TestHandleEnrichmentBatch_alreadyQueued(t *testing.T) {
 	srv, q := newZeroWorkerJobsServer(t)
 
 	// Pre-enqueue "ep-001" so it shows as already_queued.
-	_, _ = q.Enqueue("g1", "ep-001", "http_endpoint")
+	_, _ = q.Enqueue("g1", "ep-001", "http_endpoint", "")
 
 	candidates := []batchCandidate{
 		{EntityID: "ep-001", Kind: "http_endpoint"}, // already_queued
@@ -192,7 +192,7 @@ func TestHandleEnrichmentBatch_alreadyEnriched(t *testing.T) {
 	srv, q := newBatchJobsServer(t)
 
 	// Enqueue "ep-done" and wait for it to reach done state.
-	id, _ := q.Enqueue("g1", "ep-done", "http_endpoint")
+	id, _ := q.Enqueue("g1", "ep-done", "http_endpoint", "")
 	deadline := time.Now().Add(3 * time.Second)
 	for time.Now().Before(deadline) {
 		j, ok := q.Get(id)

--- a/internal/dashboard/handlers_repairs.go
+++ b/internal/dashboard/handlers_repairs.go
@@ -25,6 +25,14 @@ var repairKinds = map[string]bool{
 	"dynamic_baseurl_endpoint":   true,
 }
 
+// communityNamingKinds is the closed set of candidate kinds surfaced on the
+// dedicated "Community naming" tab. Separated from entity-level enrichment
+// because community-naming is a different workflow (naming clusters, not
+// enriching individual entities) — refs #1301.
+var communityNamingKinds = map[string]bool{
+	"name_community": true,
+}
+
 // pendingCandidateRow is the wire shape shared by both /api/repairs and
 // /api/enrichments. The richer Context map is forwarded as-is so the
 // dashboard can display subject / proposed-value without a second round-trip.
@@ -130,6 +138,9 @@ func (s *Server) handleEnrichments(w http.ResponseWriter, r *http.Request) {
 			if repairKinds[c.Kind] {
 				continue // repair tab handles these
 			}
+			if communityNamingKinds[c.Kind] {
+				continue // community-naming tab handles these (#1301)
+			}
 			items = append(items, pendingCandidateRow{
 				CandidateID:     c.ID,
 				Repo:            slug,
@@ -167,6 +178,8 @@ type candidateRaw struct {
 	ID              string         `json:"id"`
 	Kind            string         `json:"kind"`
 	SubjectID       string         `json:"subject_id"`
+	// TaskType is "entity" or "community"; empty means "entity" (backward compat).
+	TaskType        string         `json:"task_type,omitempty"`
 	Context         map[string]any `json:"context,omitempty"`
 	Hint            string         `json:"hint,omitempty"`
 	Confidence      float64        `json:"confidence,omitempty"`
@@ -264,6 +277,9 @@ func (s *Server) handleEnrichmentTasks(w http.ResponseWriter, r *http.Request) {
 		for _, c := range readAllCandidates(repo.Path) {
 			if repairKinds[c.Kind] {
 				continue // repair tab handles these
+			}
+			if communityNamingKinds[c.Kind] {
+				continue // community-naming tab handles these (#1301)
 			}
 			key := c.SubjectID + "|" + c.Kind
 			completed := resolvedSet[key]

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -318,6 +318,8 @@ func (s *Server) routes() http.Handler {
 	// Pending queue — repair candidates + enrichment candidates (#987)
 	mux.HandleFunc("GET /api/repairs/{group}", s.handleRepairs)
 	mux.HandleFunc("GET /api/enrichments/{group}", s.handleEnrichments)
+	// Community-naming queue — separated from entity enrichment (#1301)
+	mux.HandleFunc("GET /api/community-naming/{group}", s.handleCommunityNaming)
 	// Aggregated enrichment-task view — 1 task per entity with N actions (#1134)
 	mux.HandleFunc("GET /api/enrichments/{group}/tasks", s.handleEnrichmentTasks)
 	// Candidate apply/reject actions (#1016)

--- a/internal/enrichment/candidates.go
+++ b/internal/enrichment/candidates.go
@@ -62,6 +62,11 @@ type Candidate struct {
 	ID                   string         `json:"id"`
 	Kind                 string         `json:"kind"`
 	SubjectID            string         `json:"subject_id"`
+	// TaskType distinguishes the candidate queue a job belongs to.
+	// "entity" covers describe_entity / classify_domain / describe_role / …;
+	// "community" covers name_community jobs. Absent on older records —
+	// consumers should treat empty-string as "entity" for backward compat.
+	TaskType             string         `json:"task_type,omitempty"`
 	Context              map[string]any `json:"context,omitempty"`
 	PromptTemplate       string         `json:"prompt_template,omitempty"`
 	ConfidenceFloor      float64        `json:"confidence_floor,omitempty"`
@@ -1319,6 +1324,7 @@ func CollectCommunityCandidates(doc *graph.Document, rejected map[string]bool) [
 			ID:        candidateID(sid, KindNameCommunity),
 			Kind:      KindNameCommunity,
 			SubjectID: sid,
+			TaskType:  "community",
 			Context: map[string]any{
 				"community_id": c.ID,
 				"auto_name":    c.AutoName,


### PR DESCRIPTION
## Summary

Per the audit findings in #1301: 1,556 of 1,820 "Low" enrichment tasks are `name_community` cluster-naming jobs that do not belong in the entity enrichment queue. This PR separates them at every layer — task type, API endpoint, and dashboard UI.

- **`internal/enrichment/candidates.go`** — `Candidate` gains a `task_type` field (`"entity"` | `"community"`); `CollectCommunityCandidates` stamps `task_type = "community"` on every emitted record
- **`internal/dashboard/handlers_repairs.go`** — `handleEnrichments` and `handleEnrichmentTasks` now skip `communityNamingKinds` (i.e. `name_community`), reducing the entity task count from ~4,615 to ~3,059
- **`internal/dashboard/handlers_community_naming.go`** — new `GET /api/community-naming/{group}` endpoint returning the 1,556 community-naming candidates in their own response envelope
- **`internal/dashboard/server.go`** — route registered
- **`dashboard/src/`** — new `fetchCommunityNaming` API function, `CommunityNamingResponse` type, and a third "Community naming" tab on `/pending` with its own `CommunityNamingList` component

## Closes / Refs

- Refs #1301

## Testing

- [x] All tests pass: `go test ./internal/dashboard/...` — 3 new tests covering the new endpoint, the enrichment exclusion, and 404 for missing groups
- [x] Pre-existing `TestCollectRepairEdgeCandidates_NonHexFromID` failure confirmed unrelated (pre-dates this branch)
- [x] Pre-existing `handlers_enrichment_batch_test.go` compile error fixed (missing `criticalityBand` arg to `q.Enqueue`)
- [x] `go build ./internal/enrichment/... ./internal/dashboard/...` clean

## Notes

`task_type` on `Candidate` is additive and backward-compatible: consumers that don't read it are unaffected. Older on-disk candidates without the field are treated as `"entity"` by the dashboard filter (`communityNamingKinds` checks `c.Kind`, not `c.TaskType`), so no migration needed.

The `CommunityNamingList` frontend component is intentionally read-only in this PR — action buttons (apply/reject) are a follow-up; the endpoint and panel establish the separation audit #1301 requires.