### PR TITLE
[#1287] Pre-run cost estimator dialog for enrichment

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -94,6 +94,7 @@ import type {
   PendingEnrichmentsResponse,
   CommunityNamingResponse,
   EnrichmentProgressResponse,
+  EnrichmentEstimateResponse,
   OrphanCallersResponse,
   OrphanPublishersResponse,
   OrphanSubscribersResponse,
@@ -962,6 +963,25 @@ export async function fetchEnrichmentProgress(group: string): Promise<Enrichment
   return apiFetch<EnrichmentProgressResponse>(`/api/enrichments/${group}/progress`)
 }
 
+/** GET /api/enrichments/{group}/estimate — pre-run cost estimate (#1287) */
+export async function fetchEnrichmentEstimate(group: string): Promise<EnrichmentEstimateResponse> {
+  if (USE_MOCKS) {
+    return {
+      tiers: [
+        { band: 'critical', model: 'sonnet', count: 0, est_tokens: 0, est_usd: 0 },
+        { band: 'high',     model: 'haiku',  count: 0, est_tokens: 0, est_usd: 0 },
+        { band: 'medium',   model: 'haiku',  count: 0, est_tokens: 0, est_usd: 0 },
+        { band: 'low',      model: 'haiku',  count: 0, est_tokens: 0, est_usd: 0 },
+      ],
+      already_enriched: 0,
+      total_est_tokens: 0,
+      total_est_usd: 0,
+      est_minutes: 0,
+    }
+  }
+  return apiFetch<EnrichmentEstimateResponse>(`/api/enrichments/${group}/estimate`)
+}
+
 /**
  * POST a resolution (apply) or rejection for a single candidate.
  * The daemon MCP RPC handles the actual write; this just POSTs to the
@@ -980,6 +1000,33 @@ export async function postCandidateAction(
   await apiFetch<unknown>(`/api/enrichments/${group}/action`, {
     method: 'POST',
     body: JSON.stringify({ candidate_id: candidateId, action, value }),
+  })
+}
+
+/** POST /api/enrichments/{group}/batch-enrich — enqueue all pending candidates (#1285) */
+export interface BatchEnrichCandidate {
+  entity_id: string
+  kind?: string
+  criticality_band?: string
+}
+
+export interface BatchEnrichResponse {
+  batch_id: string
+  accepted: number
+  rejected: number
+  job_ids: string[]
+}
+
+export async function postBatchEnrich(
+  group: string,
+  candidates: BatchEnrichCandidate[],
+): Promise<BatchEnrichResponse> {
+  if (USE_MOCKS) {
+    return { batch_id: 'batch-mock', accepted: candidates.length, rejected: 0, job_ids: [] }
+  }
+  return apiFetch<BatchEnrichResponse>(`/api/enrichments/${group}/batch-enrich`, {
+    method: 'POST',
+    body: JSON.stringify({ candidates }),
   })
 }
 

--- a/dashboard/src/components/indexing/EnrichmentCostModal.tsx
+++ b/dashboard/src/components/indexing/EnrichmentCostModal.tsx
@@ -1,0 +1,328 @@
+/**
+ * EnrichmentCostModal — pre-run cost estimator dialog (#1287).
+ *
+ * Shows a per-tier breakdown of estimated token counts and USD cost before
+ * the user triggers a batched enrichment run. The user must confirm before
+ * any LLM calls are dispatched.
+ *
+ * Layout:
+ *   ┌──────────────────────────────────────────────────────┐
+ *   │  Enrichment cost estimate                   [×]      │
+ *   │  ──────────────────────────────────────────────────  │
+ *   │  Critical  Sonnet   110 entities  88,000 tok  $0.26  │
+ *   │  High      Haiku    890 entities  445,000 tok $0.27  │
+ *   │  ...                                                  │
+ *   │  ──────────────────────────────────────────────────  │
+ *   │  Total              5,850         2,615,000   ~$1.79 │
+ *   │  Est. time: ~12 min · 380 already enriched (skipped) │
+ *   │                                                       │
+ *   │  [Cancel]                 [Run enrichment  ~$1.79]   │
+ *   └──────────────────────────────────────────────────────┘
+ *
+ * Pricing constants are defined server-side in internal/enrichment/pricing.go.
+ * The frontend only displays what the backend returns.
+ */
+
+import { useEffect, useRef } from 'react'
+import { X, DollarSign, Clock, Sparkles, AlertTriangle } from 'lucide-react'
+import type { EnrichmentEstimateResponse, EnrichmentEstimateTier } from '@/types/api'
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function fmtTokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(2)}M`
+  if (n >= 1_000)     return `${(n / 1_000).toFixed(0)}k`
+  return String(n)
+}
+
+function fmtUSD(n: number): string {
+  if (n === 0) return '$0.00'
+  if (n < 0.01) return '<$0.01'
+  return `$${n.toFixed(2)}`
+}
+
+function fmtMinutes(n: number): string {
+  if (n < 1) return '<1 min'
+  return `~${Math.round(n)} min`
+}
+
+const BAND_META: Record<string, { label: string; color: string; badgeColor: string }> = {
+  critical: {
+    label: 'Critical',
+    color: 'text-red-600 dark:text-red-400',
+    badgeColor: 'bg-red-100 dark:bg-red-900/40 text-red-700 dark:text-red-300 border-red-200 dark:border-red-700',
+  },
+  high: {
+    label: 'High',
+    color: 'text-orange-600 dark:text-orange-400',
+    badgeColor: 'bg-orange-100 dark:bg-orange-900/40 text-orange-700 dark:text-orange-300 border-orange-200 dark:border-orange-700',
+  },
+  medium: {
+    label: 'Medium',
+    color: 'text-yellow-600 dark:text-yellow-500',
+    badgeColor: 'bg-yellow-100 dark:bg-yellow-900/40 text-yellow-700 dark:text-yellow-300 border-yellow-200 dark:border-yellow-700',
+  },
+  low: {
+    label: 'Low',
+    color: 'text-slate-500 dark:text-slate-400',
+    badgeColor: 'bg-slate-100 dark:bg-slate-800 text-slate-600 dark:text-slate-300 border-slate-200 dark:border-slate-700',
+  },
+}
+
+const MODEL_LABEL: Record<string, string> = {
+  sonnet: 'Sonnet',
+  haiku:  'Haiku',
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TierRow
+// ─────────────────────────────────────────────────────────────────────────────
+
+function TierRow({ tier }: { tier: EnrichmentEstimateTier }) {
+  const meta = BAND_META[tier.band] ?? BAND_META.low
+  return (
+    <tr className="border-t border-slate-700/40">
+      <td className="py-2 pr-4">
+        <span className={`text-sm font-semibold ${meta.color}`}>{meta.label}</span>
+      </td>
+      <td className="py-2 pr-4">
+        <span className={`inline-flex items-center px-2 py-0.5 rounded text-[10px] font-mono font-bold border ${meta.badgeColor}`}>
+          {MODEL_LABEL[tier.model] ?? tier.model}
+        </span>
+      </td>
+      <td className="py-2 pr-4 text-right tabular-nums text-sm text-slate-300">
+        {tier.count.toLocaleString()}
+      </td>
+      <td className="py-2 pr-4 text-right tabular-nums text-sm text-slate-400 font-mono">
+        {fmtTokens(tier.est_tokens)}
+      </td>
+      <td className="py-2 text-right tabular-nums text-sm text-slate-200 font-semibold">
+        {fmtUSD(tier.est_usd)}
+      </td>
+    </tr>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// EnrichmentCostModal
+// ─────────────────────────────────────────────────────────────────────────────
+
+export interface EnrichmentCostModalProps {
+  /** The fetched estimate. Pass null to show a loading state. */
+  estimate: EnrichmentEstimateResponse | null
+  /** Whether the estimate is being fetched. */
+  isLoading: boolean
+  /** Whether the fetch failed. */
+  isError: boolean
+  /** Called when the user dismisses without confirming. */
+  onClose: () => void
+  /** Called when the user confirms the cost and wants to proceed. */
+  onConfirm: () => void
+  /** Whether the confirm action is in progress (disables the button). */
+  isConfirming?: boolean
+}
+
+/**
+ * EnrichmentCostModal renders the pre-run cost estimate in a modal overlay.
+ * The confirm button is disabled when there are no pending candidates.
+ */
+export function EnrichmentCostModal({
+  estimate,
+  isLoading,
+  isError,
+  onClose,
+  onConfirm,
+  isConfirming = false,
+}: EnrichmentCostModalProps) {
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Trap focus inside the modal and close on Escape.
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', onKey)
+    dialogRef.current?.focus()
+    return () => document.removeEventListener('keydown', onKey)
+  }, [onClose])
+
+  const hasData = estimate != null
+  const totalPending = hasData ? estimate.tiers.reduce((s, t) => s + t.count, 0) : 0
+  const canConfirm = hasData && totalPending > 0 && !isConfirming
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm"
+        aria-hidden
+        onClick={onClose}
+        data-testid="cost-modal-backdrop"
+      />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Enrichment cost estimate"
+        tabIndex={-1}
+        data-testid="enrichment-cost-modal"
+        className={[
+          'fixed inset-x-4 top-[10vh] z-50 mx-auto max-w-2xl',
+          'flex flex-col rounded-2xl shadow-2xl outline-none',
+          'bg-slate-900 border border-slate-700',
+          'max-h-[85vh]',
+        ].join(' ')}
+      >
+        {/* ── Header ──────────────────────────────────────────────────────── */}
+        <div className="flex items-start justify-between px-6 pt-5 pb-4 border-b border-slate-700/60 shrink-0">
+          <div className="flex items-center gap-2">
+            <DollarSign className="w-5 h-5 text-sky-400 shrink-0" />
+            <h2 className="text-lg font-semibold text-slate-100">
+              Enrichment cost estimate
+            </h2>
+          </div>
+          <button
+            type="button"
+            aria-label="Close"
+            onClick={onClose}
+            className="p-1.5 rounded-lg text-slate-400 hover:text-slate-200 hover:bg-slate-800 transition-colors shrink-0"
+            data-testid="cost-modal-close"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </div>
+
+        {/* ── Body ────────────────────────────────────────────────────────── */}
+        <div className="flex-1 overflow-y-auto px-6 py-5">
+          {isLoading && (
+            <div className="flex items-center justify-center py-12 text-slate-400 text-sm gap-2">
+              <Sparkles className="w-4 h-4 animate-pulse" />
+              Calculating estimate…
+            </div>
+          )}
+
+          {isError && !isLoading && (
+            <div className="flex items-center gap-2 px-4 py-3 rounded-lg bg-red-900/20 border border-red-800 text-sm text-red-400">
+              <AlertTriangle className="w-4 h-4 shrink-0" />
+              Failed to load cost estimate. Is the daemon running?
+            </div>
+          )}
+
+          {hasData && !isLoading && (
+            <>
+              {/* ── Tier breakdown table ─────────────────────────────────── */}
+              <div className="overflow-x-auto">
+                <table
+                  className="w-full text-left"
+                  aria-label="Cost breakdown by tier"
+                  data-testid="cost-breakdown-table"
+                >
+                  <thead>
+                    <tr className="text-xs text-slate-500 uppercase tracking-wide">
+                      <th className="pb-2 pr-4 font-medium">Tier</th>
+                      <th className="pb-2 pr-4 font-medium">Model</th>
+                      <th className="pb-2 pr-4 text-right font-medium">Entities</th>
+                      <th className="pb-2 pr-4 text-right font-medium">Tokens</th>
+                      <th className="pb-2 text-right font-medium">Est. cost</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {estimate.tiers
+                      .filter((t) => t.count > 0)
+                      .map((tier) => <TierRow key={tier.band} tier={tier} />)
+                    }
+                    {totalPending === 0 && (
+                      <tr>
+                        <td colSpan={5} className="py-6 text-center text-sm text-slate-500">
+                          No pending candidates — nothing to enrich.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                  {totalPending > 0 && (
+                    <tfoot>
+                      <tr className="border-t-2 border-slate-600">
+                        <td className="pt-3 pr-4 text-sm font-bold text-slate-200">Total</td>
+                        <td className="pt-3 pr-4" />
+                        <td className="pt-3 pr-4 text-right tabular-nums text-sm font-bold text-slate-200">
+                          {totalPending.toLocaleString()}
+                        </td>
+                        <td className="pt-3 pr-4 text-right tabular-nums text-sm font-mono text-slate-300">
+                          {fmtTokens(estimate.total_est_tokens)}
+                        </td>
+                        <td className="pt-3 text-right tabular-nums text-base font-bold text-sky-300">
+                          {fmtUSD(estimate.total_est_usd)}
+                        </td>
+                      </tr>
+                    </tfoot>
+                  )}
+                </table>
+              </div>
+
+              {/* ── Meta row ─────────────────────────────────────────────── */}
+              {totalPending > 0 && (
+                <div className="mt-4 flex flex-wrap items-center gap-x-4 gap-y-1 text-xs text-slate-400">
+                  <span className="flex items-center gap-1">
+                    <Clock className="w-3.5 h-3.5 shrink-0" />
+                    Est. run time: {fmtMinutes(estimate.est_minutes)}
+                  </span>
+                  {estimate.already_enriched > 0 && (
+                    <span>
+                      {estimate.already_enriched.toLocaleString()} already enriched — skipped
+                    </span>
+                  )}
+                </div>
+              )}
+
+              {/* ── Budget warning ───────────────────────────────────────── */}
+              {estimate.total_est_usd >= 10 && (
+                <div className="mt-4 flex items-start gap-2 px-4 py-3 rounded-lg bg-amber-900/20 border border-amber-700/60 text-sm text-amber-300">
+                  <AlertTriangle className="w-4 h-4 shrink-0 mt-0.5" />
+                  <span>
+                    This run costs <strong>{fmtUSD(estimate.total_est_usd)}</strong> — confirm you want to proceed.
+                  </span>
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* ── Footer ──────────────────────────────────────────────────────── */}
+        <div className="flex items-center justify-end gap-3 px-6 py-4 border-t border-slate-700/60 shrink-0">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-4 py-2 rounded-lg text-sm font-medium text-slate-300 hover:text-slate-100 hover:bg-slate-800 transition-colors"
+            data-testid="cost-modal-cancel"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            disabled={!canConfirm}
+            onClick={canConfirm ? onConfirm : undefined}
+            data-testid="cost-modal-confirm"
+            className={[
+              'flex items-center gap-2 px-5 py-2 rounded-lg text-sm font-semibold transition-colors',
+              canConfirm
+                ? 'bg-sky-600 hover:bg-sky-500 text-white shadow-sm'
+                : 'bg-slate-700 text-slate-500 cursor-not-allowed',
+            ].join(' ')}
+          >
+            <Sparkles className="w-4 h-4 shrink-0" />
+            {isConfirming
+              ? 'Queuing…'
+              : hasData && totalPending > 0
+                ? `Run enrichment  ${fmtUSD(estimate.total_est_usd)}`
+                : 'Run enrichment'
+            }
+          </button>
+        </div>
+      </div>
+    </>
+  )
+}

--- a/dashboard/src/routes/pending.tsx
+++ b/dashboard/src/routes/pending.tsx
@@ -1,9 +1,13 @@
 import { useState, useMemo, useCallback } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
-import { fetchRepairs, fetchEnrichments, fetchCommunityNaming, postCandidateAction } from '@/api/client'
+import {
+  fetchRepairs, fetchEnrichments, fetchCommunityNaming, postCandidateAction,
+  fetchEnrichmentEstimate, postBatchEnrich,
+} from '@/api/client'
 import type { PendingCandidateRow, QualificationSignal, EnrichmentProgressBand, CommunityNamingRow } from '@/types/api'
 import { useEnrichmentProgress } from '@/hooks/shared/useEnrichmentProgress'
+import { EnrichmentCostModal } from '@/components/indexing/EnrichmentCostModal'
 import {
   Wrench, Sparkles, CheckCircle, XCircle, AlertCircle,
   ChevronDown, ChevronRight, Search, EyeOff,
@@ -710,6 +714,48 @@ function TieredList({ rows, group, emptyMessage, onApplied }: TieredListProps) {
   // Hide-forever stubs (flag only — no backend action yet)
   const [hiddenTiers, setHiddenTiers] = useState<Set<TierId>>(new Set())
 
+  // ── Cost estimator modal (#1287) ─────────────────────────────────────────
+  const [showCostModal, setShowCostModal] = useState(false)
+  const qc = useQueryClient()
+
+  const estimateQuery = useQuery({
+    queryKey: ['enrichment-estimate', group],
+    queryFn: () => fetchEnrichmentEstimate(group),
+    enabled: showCostModal, // only fetch when modal is open
+    staleTime: 30 * 1000,
+  })
+
+  const batchMutation = useMutation({
+    mutationFn: () => {
+      // Build candidates list from all visible rows (the backend deduplicates
+      // already-enriched entities, but we keep it simple here).
+      const candidates = rows.map((r) => ({
+        entity_id: r.subject_id,
+        kind: r.entity_kind ?? r.kind,
+        criticality_band: r.criticality_band ?? '',
+      }))
+      return postBatchEnrich(group, candidates)
+    },
+    onSuccess: () => {
+      setShowCostModal(false)
+      void qc.invalidateQueries({ queryKey: ['enrichments', group] })
+      void qc.invalidateQueries({ queryKey: ['enrichment-progress', group] })
+    },
+  })
+
+  const handleRunClick = useCallback(() => {
+    setShowCostModal(true)
+  }, [])
+
+  const handleModalClose = useCallback(() => {
+    setShowCostModal(false)
+    batchMutation.reset()
+  }, [batchMutation])
+
+  const handleModalConfirm = useCallback(() => {
+    batchMutation.mutate()
+  }, [batchMutation])
+
   const toggleExpanded = useCallback((tierId: TierId) => {
     setExpandedTiers((prev) => {
       const next = { ...prev, [tierId]: !prev[tierId] }
@@ -834,6 +880,19 @@ function TieredList({ rows, group, emptyMessage, onApplied }: TieredListProps) {
           </select>
         </div>
 
+        {/* Run enrichment button — opens cost estimator dialog (#1287) */}
+        {rows.length > 0 && (
+          <button
+            type="button"
+            onClick={handleRunClick}
+            data-testid="run-enrichment-btn"
+            className="shrink-0 flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-semibold bg-sky-600 hover:bg-sky-500 text-white shadow-sm transition-colors"
+          >
+            <Sparkles className="w-3.5 h-3.5" />
+            Run enrichment
+          </button>
+        )}
+
         {/* Bulk selection feedback */}
         {totalSelected > 0 && (
           <span className="text-xs text-sky-600 dark:text-sky-400 font-medium tabular-nums">
@@ -841,6 +900,18 @@ function TieredList({ rows, group, emptyMessage, onApplied }: TieredListProps) {
           </span>
         )}
       </div>
+
+      {/* ── Cost estimator modal (#1287) ──────────────────────────────────────── */}
+      {showCostModal && (
+        <EnrichmentCostModal
+          estimate={estimateQuery.data ?? null}
+          isLoading={estimateQuery.isLoading}
+          isError={estimateQuery.isError}
+          onClose={handleModalClose}
+          onConfirm={handleModalConfirm}
+          isConfirming={batchMutation.isPending}
+        />
+      )}
 
       {/* ── Tier sections ─────────────────────────────────────────────────── */}
       <div className="flex-1 overflow-y-auto p-4 space-y-0">

--- a/dashboard/src/types/api.ts
+++ b/dashboard/src/types/api.ts
@@ -840,6 +840,35 @@ export interface EnrichmentProgressResponse {
 }
 
 // ────────────────────────────────────────────────────────────────────────────
+// Enrichment cost estimator — GET /api/enrichments/{group}/estimate (#1287)
+// ────────────────────────────────────────────────────────────────────────────
+
+/** Per-band cost breakdown in the estimate response. */
+export interface EnrichmentEstimateTier {
+  /** "critical" | "high" | "medium" | "low" */
+  band: string
+  /** "sonnet" (critical) or "haiku" (all other bands) */
+  model: string
+  /** Number of pending candidates in this band. */
+  count: number
+  /** Total estimated tokens for all candidates in this band. */
+  est_tokens: number
+  /** Estimated USD cost at Anthropic published rates. */
+  est_usd: number
+}
+
+/** Response from GET /api/enrichments/{group}/estimate. */
+export interface EnrichmentEstimateResponse {
+  tiers: EnrichmentEstimateTier[]
+  /** Number of entities with a completed job — excluded from the estimate. */
+  already_enriched: number
+  total_est_tokens: number
+  total_est_usd: number
+  /** Rough wall-clock estimate in minutes. */
+  est_minutes: number
+}
+
+// ────────────────────────────────────────────────────────────────────────────
 // Surface 1 — Graph Viewer
 // ────────────────────────────────────────────────────────────────────────────
 

--- a/dashboard/tests/e2e/enrichment-cost-modal.spec.ts
+++ b/dashboard/tests/e2e/enrichment-cost-modal.spec.ts
@@ -1,0 +1,203 @@
+/**
+ * E2E: Enrichment cost estimator dialog (#1287)
+ *
+ * Tests run HEADLESS against the Vite dev server (port 5173).
+ * Without a live daemon, the /api/enrichments/.../estimate endpoint returns
+ * 404. The test mocks the API response so the dialog can be tested in isolation.
+ *
+ * Deliverables:
+ *   - Screenshot of the cost estimate dialog (test-results/cost-modal/*.png)
+ *   - Structural assertions: dialog renders with tiers table + confirm button
+ */
+
+import { test, expect, type Page, type Route } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+import fs from 'fs'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname  = path.dirname(__filename)
+
+const BASE_URL    = process.env.TEST_BASE_URL ?? 'http://localhost:5173'
+const PENDING_URL = `${BASE_URL}/pending/fixture-a`
+const SHOT_DIR    = path.join(__dirname, '..', '..', 'test-results', 'cost-modal')
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Mock data
+// ─────────────────────────────────────────────────────────────────────────────
+
+const MOCK_ESTIMATE = {
+  tiers: [
+    { band: 'critical', model: 'sonnet', count: 110, est_tokens: 88_000,    est_usd: 0.26 },
+    { band: 'high',     model: 'haiku',  count: 890, est_tokens: 445_000,   est_usd: 0.27 },
+    { band: 'medium',   model: 'haiku',  count: 1420, est_tokens: 710_000,  est_usd: 0.43 },
+    { band: 'low',      model: 'haiku',  count: 3430, est_tokens: 1_372_000, est_usd: 0.83 },
+  ],
+  already_enriched: 380,
+  total_est_tokens: 2_615_000,
+  total_est_usd:    1.79,
+  est_minutes:      12,
+}
+
+const MOCK_ENRICHMENTS = {
+  items: [
+    {
+      candidate_id: 'cand-001',
+      subject_id:   'ep-001',
+      kind:         'describe_entity',
+      entity_kind:  'http_endpoint',
+      score:        90,
+      criticality_band: 'critical',
+    },
+    {
+      candidate_id: 'cand-002',
+      subject_id:   'svc-001',
+      kind:         'describe_entity',
+      entity_kind:  'Service',
+      score:        65,
+      criticality_band: 'high',
+    },
+  ],
+  total: 2,
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+function mkdirShot() {
+  fs.mkdirSync(SHOT_DIR, { recursive: true })
+}
+
+async function screenshot(page: Page, name: string) {
+  mkdirShot()
+  await page.screenshot({
+    path: path.join(SHOT_DIR, `${name}.png`),
+    fullPage: false,
+  })
+}
+
+async function interceptAPIs(page: Page) {
+  // Mock enrichments list so the toolbar "Run enrichment" button appears.
+  await page.route('**/api/enrichments/fixture-a', (route: Route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_ENRICHMENTS),
+    })
+  })
+  // Mock the estimate endpoint.
+  await page.route('**/api/enrichments/fixture-a/estimate', (route: Route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(MOCK_ESTIMATE),
+    })
+  })
+  // Mock repairs (empty) to avoid 404 noise.
+  await page.route('**/api/repairs/fixture-a', (route: Route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items: [], total: 0 }),
+    })
+  })
+  // Mock progress (empty) to suppress progress panel.
+  await page.route('**/api/enrichments/fixture-a/progress', (route: Route) => {
+    void route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        tiers: [],
+        overall_done: 0,
+        overall_total: 0,
+      }),
+    })
+  })
+}
+
+async function navigateToEnrichments(page: Page) {
+  await page.goto(PENDING_URL, { waitUntil: 'domcontentloaded', timeout: 30_000 })
+  // Switch to the Enrichment candidates tab.
+  await page.getByRole('tab', { name: /Enrichment candidates/i }).waitFor({ state: 'visible', timeout: 10_000 })
+  await page.getByRole('tab', { name: /Enrichment candidates/i }).click()
+  await page.waitForTimeout(400)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+test.describe('Enrichment cost estimator dialog — #1287', () => {
+  test.beforeEach(async ({ page }) => {
+    await interceptAPIs(page)
+    await navigateToEnrichments(page)
+  })
+
+  test('VIEW — cost estimator dialog renders with tier breakdown', async ({ page }) => {
+    // Click "Run enrichment" button.
+    const runBtn = page.getByTestId('run-enrichment-btn')
+    await runBtn.waitFor({ state: 'visible', timeout: 8_000 })
+    await runBtn.click()
+
+    // Wait for the modal to appear.
+    const modal = page.getByTestId('enrichment-cost-modal')
+    await modal.waitFor({ state: 'visible', timeout: 5_000 })
+
+    // Take the primary screenshot (deliverable).
+    await page.waitForTimeout(300) // let animations settle
+    await screenshot(page, '1-cost-estimator-dialog')
+  })
+
+  test('dialog shows cost breakdown table', async ({ page }) => {
+    await page.getByTestId('run-enrichment-btn').click()
+    const modal = page.getByTestId('enrichment-cost-modal')
+    await modal.waitFor({ state: 'visible', timeout: 5_000 })
+
+    // Breakdown table must be present.
+    await expect(modal.getByTestId('cost-breakdown-table')).toBeVisible()
+
+    // Critical tier row (110 entities).
+    await expect(modal.getByText('Critical')).toBeVisible()
+    // Total cost cell (tfoot row, not the button).
+    await expect(modal.getByRole('cell', { name: '$1.79' })).toBeVisible()
+  })
+
+  test('dialog cancel closes the modal', async ({ page }) => {
+    await page.getByTestId('run-enrichment-btn').click()
+    await page.getByTestId('enrichment-cost-modal').waitFor({ state: 'visible', timeout: 5_000 })
+
+    await page.getByTestId('cost-modal-cancel').click()
+    await expect(page.getByTestId('enrichment-cost-modal')).not.toBeVisible()
+
+    await screenshot(page, '2-after-cancel')
+  })
+
+  test('Escape key closes the modal', async ({ page }) => {
+    await page.getByTestId('run-enrichment-btn').click()
+    await page.getByTestId('enrichment-cost-modal').waitFor({ state: 'visible', timeout: 5_000 })
+
+    await page.keyboard.press('Escape')
+    await expect(page.getByTestId('enrichment-cost-modal')).not.toBeVisible()
+  })
+
+  test('confirm button shows total cost', async ({ page }) => {
+    await page.getByTestId('run-enrichment-btn').click()
+    const modal = page.getByTestId('enrichment-cost-modal')
+    await modal.waitFor({ state: 'visible', timeout: 5_000 })
+
+    const confirmBtn = page.getByTestId('cost-modal-confirm')
+    await expect(confirmBtn).toBeVisible()
+    // Should include cost in button text.
+    await expect(confirmBtn).toContainText('$1.79')
+  })
+
+  test('backdrop click closes the modal', async ({ page }) => {
+    await page.getByTestId('run-enrichment-btn').click()
+    await page.getByTestId('enrichment-cost-modal').waitFor({ state: 'visible', timeout: 5_000 })
+
+    // Click outside the dialog (top-left corner of backdrop).
+    await page.getByTestId('cost-modal-backdrop').click({ position: { x: 10, y: 10 } })
+    await expect(page.getByTestId('enrichment-cost-modal')).not.toBeVisible()
+  })
+})

--- a/internal/dashboard/handlers_enrichment_estimate.go
+++ b/internal/dashboard/handlers_enrichment_estimate.go
@@ -1,0 +1,167 @@
+package dashboard
+
+// handlers_enrichment_estimate.go — Pre-run cost estimator endpoint (#1287).
+//
+//	GET /api/enrichments/{group}/estimate
+//
+// Returns a cost breakdown per criticality tier before the user triggers a
+// batch enrichment run, so they can make an informed decision about the cost.
+//
+// Pricing constants live in internal/enrichment/pricing.go — update them
+// there when Anthropic publishes new rates.
+//
+// Token estimation formula (per entity):
+//
+//	tokens = TokensPerEntity(kind) + promptOverheadTokens
+//
+// where TokensPerEntity returns a conservative upper-bound per entity kind
+// and promptOverheadTokens = 200 covers system prompt + JSON scaffolding.
+//
+// The estimate excludes entities that already have a completed job (status=done)
+// so users who are doing incremental enrichment see only the remaining cost.
+
+import (
+	"net/http"
+
+	"github.com/cajasmota/archigraph/internal/enrichment"
+	"github.com/cajasmota/archigraph/internal/jobs"
+)
+
+// estimateTier is the per-band breakdown in the estimate response.
+type estimateTier struct {
+	// Band is the criticality band: "critical" | "high" | "medium" | "low".
+	Band string `json:"band"`
+	// Model is the Claude model this band uses: "sonnet" (critical) or "haiku" (others).
+	Model string `json:"model"`
+	// Count is the number of candidate entities pending enrichment in this band.
+	Count int `json:"count"`
+	// EstTokens is the total estimated token count for all entities in this band.
+	EstTokens int `json:"est_tokens"`
+	// EstUSD is the estimated cost in USD at published Anthropic rates.
+	EstUSD float64 `json:"est_usd"`
+}
+
+// enrichmentEstimateResponse is the wire type for GET /api/enrichments/{group}/estimate.
+type enrichmentEstimateResponse struct {
+	// Tiers is the per-band breakdown.
+	Tiers []estimateTier `json:"tiers"`
+	// AlreadyEnriched is the number of entities with a completed job — excluded from the estimate.
+	AlreadyEnriched int `json:"already_enriched"`
+	// TotalEstTokens is the sum of est_tokens across all tiers.
+	TotalEstTokens int `json:"total_est_tokens"`
+	// TotalEstUSD is the sum of est_usd across all tiers.
+	TotalEstUSD float64 `json:"total_est_usd"`
+	// EstMinutes is the rough wall-clock estimate for the full run.
+	EstMinutes float64 `json:"est_minutes"`
+}
+
+// handleEnrichmentEstimate — GET /api/enrichments/{group}/estimate
+//
+// Reads the pending enrichment candidates from disk, groups them by
+// criticality band, computes per-band token and USD estimates, and returns
+// the breakdown. Already-enriched entities (job status=done) are excluded.
+//
+// Returns 200 with an empty breakdown (not 404) when the group has no
+// pending candidates — this lets the frontend differentiate "no cost"
+// from "not found".
+func (s *Server) handleEnrichmentEstimate(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// Build a set of already-enriched entity IDs so we can exclude them.
+	alreadyDone := make(map[string]bool)
+	if s.jobQueue != nil {
+		entityStatus := buildEntityStatusMap(s.jobQueue, group)
+		for entityID, status := range entityStatus {
+			if status == jobs.StatusDone {
+				alreadyDone[entityID] = true
+			}
+		}
+	}
+
+	// Collect all pending (non-repair) candidates across all repos in the group.
+	// band → slice of candidates
+	byBand := make(map[string][]candidateRaw)
+	for _, repo := range grp.Repos {
+		if repo == nil || repo.Path == "" {
+			continue
+		}
+		for _, c := range readAllCandidates(repo.Path) {
+			if repairKinds[c.Kind] {
+				continue // repair tab handles these
+			}
+			if alreadyDone[c.SubjectID] {
+				continue // already enriched — skip from estimate
+			}
+			band := c.CriticalityBand
+			if band == "" {
+				band = "low"
+			}
+			byBand[band] = append(byBand[band], c)
+		}
+	}
+
+	// Build tier rows in canonical order.
+	bandOrder := []string{"critical", "high", "medium", "low"}
+	var tiers []estimateTier
+	totalTokens := 0
+	totalUSD := 0.0
+
+	for _, band := range bandOrder {
+		candidates := byBand[band]
+		model := modelForBand(band)
+
+		bandTokens := 0
+		for _, c := range candidates {
+			bandTokens += enrichment.EstimateEntityTokens(c.Kind)
+		}
+
+		bandUSD := enrichment.USDForTokens(bandTokens, model)
+		tiers = append(tiers, estimateTier{
+			Band:      band,
+			Model:     model,
+			Count:     len(candidates),
+			EstTokens: bandTokens,
+			EstUSD:    roundUSD(bandUSD),
+		})
+		totalTokens += bandTokens
+		totalUSD += bandUSD
+	}
+
+	resp := enrichmentEstimateResponse{
+		Tiers:           tiers,
+		AlreadyEnriched: len(alreadyDone),
+		TotalEstTokens:  totalTokens,
+		TotalEstUSD:     roundUSD(totalUSD),
+		EstMinutes:      roundMinutes(enrichment.EstimateWallMinutes(totalTokens)),
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// modelForBand returns the Claude model tier for a given criticality band.
+// Exported for test use.
+func modelForBand(band string) string {
+	if band == "critical" {
+		return "sonnet"
+	}
+	return "haiku"
+}
+
+// roundUSD rounds a USD value to 2 decimal places for clean display.
+func roundUSD(v float64) float64 {
+	return float64(int(v*100+0.5)) / 100
+}
+
+// roundMinutes rounds a minute value to 1 decimal place.
+func roundMinutes(v float64) float64 {
+	return float64(int(v*10+0.5)) / 10
+}

--- a/internal/dashboard/handlers_enrichment_estimate_test.go
+++ b/internal/dashboard/handlers_enrichment_estimate_test.go
@@ -1,0 +1,235 @@
+package dashboard
+
+// handlers_enrichment_estimate_test.go — HTTP-level tests for
+// GET /api/enrichments/{group}/estimate (#1287).
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+)
+
+// seedCandidates writes a minimal enrichment-candidates.json under the
+// per-repo state dir determined by ARCHIGRAPH_DAEMON_ROOT, using the same
+// path logic as StateDirForRepo so readAllCandidates picks them up.
+func seedCandidates(t *testing.T, repoPath string, candidates []map[string]any) {
+	t.Helper()
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll state dir: %v", err)
+	}
+	data, err := json.Marshal(candidates)
+	if err != nil {
+		t.Fatalf("marshal candidates: %v", err)
+	}
+	path := filepath.Join(stateDir, "enrichment-candidates.json")
+	if err := os.WriteFile(path, data, 0o644); err != nil {
+		t.Fatalf("write candidates: %v", err)
+	}
+}
+
+// newEstimateServer creates a test server with group "g1" and a repo at repoPath.
+// ARCHIGRAPH_DAEMON_ROOT must be set before calling so StateDirForRepo is hermetic.
+func newEstimateServer(t *testing.T, repoPath string) *Server {
+	t.Helper()
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g1"] = &cacheEntry{
+		group: &DashGroup{
+			Name: "g1",
+			Repos: map[string]*DashRepo{
+				"repo-a": {Path: repoPath},
+			},
+		},
+		loadedAt: time.Now().Add(60 * time.Second),
+	}
+	srv.graphs.mu.Unlock()
+	return srv
+}
+
+// TestHandleEnrichmentEstimate_noGroup returns 400 when group is empty.
+func TestHandleEnrichmentEstimate_noGroup(t *testing.T) {
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	// The route pattern requires {group} so we hit the missing-group guard
+	// by using an invalid path that maps to a non-existent group.
+	w := doRequest(t, srv, "GET", "/api/enrichments/nonexistent/estimate")
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// TestHandleEnrichmentEstimate_emptyCandidates returns 200 with zero totals
+// when there are no pending candidates.
+func TestHandleEnrichmentEstimate_emptyCandidates(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := filepath.Join(tmp, "repo-a")
+	srv := newEstimateServer(t, repoPath)
+	// No candidate file seeded.
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/estimate")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp enrichmentEstimateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if resp.TotalEstTokens != 0 {
+		t.Errorf("want 0 total tokens, got %d", resp.TotalEstTokens)
+	}
+	if resp.TotalEstUSD != 0 {
+		t.Errorf("want 0 total USD, got %f", resp.TotalEstUSD)
+	}
+	if len(resp.Tiers) != 4 {
+		t.Errorf("want 4 tiers, got %d", len(resp.Tiers))
+	}
+}
+
+// TestHandleEnrichmentEstimate_withCandidates validates token/USD breakdown.
+func TestHandleEnrichmentEstimate_withCandidates(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := filepath.Join(tmp, "repo-a")
+	srv := newEstimateServer(t, repoPath)
+
+	// Seed 2 critical (http_endpoint → 900 tok+200 overhead = 1100) and
+	// 3 high (Service → 600+200 = 800) candidates.
+	candidates := []map[string]any{
+		{"id": "c1", "kind": "http_endpoint", "subject_id": "ep-001", "criticality_band": "critical"},
+		{"id": "c2", "kind": "http_endpoint", "subject_id": "ep-002", "criticality_band": "critical"},
+		{"id": "c3", "kind": "Service",       "subject_id": "svc-001", "criticality_band": "high"},
+		{"id": "c4", "kind": "Service",       "subject_id": "svc-002", "criticality_band": "high"},
+		{"id": "c5", "kind": "Service",       "subject_id": "svc-003", "criticality_band": "high"},
+	}
+	seedCandidates(t, repoPath, candidates)
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/estimate")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp enrichmentEstimateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// Locate tiers by band.
+	tierMap := make(map[string]estimateTier)
+	for _, tier := range resp.Tiers {
+		tierMap[tier.Band] = tier
+	}
+
+	// Critical: 2 entities × 1100 tokens = 2200 tokens.
+	crit := tierMap["critical"]
+	if crit.Count != 2 {
+		t.Errorf("critical: want count=2, got %d", crit.Count)
+	}
+	if crit.EstTokens != 2200 {
+		t.Errorf("critical: want est_tokens=2200, got %d", crit.EstTokens)
+	}
+	if crit.Model != "sonnet" {
+		t.Errorf("critical: want model=sonnet, got %q", crit.Model)
+	}
+
+	// High: 3 entities × 800 tokens = 2400 tokens.
+	high := tierMap["high"]
+	if high.Count != 3 {
+		t.Errorf("high: want count=3, got %d", high.Count)
+	}
+	if high.EstTokens != 2400 {
+		t.Errorf("high: want est_tokens=2400, got %d", high.EstTokens)
+	}
+	if high.Model != "haiku" {
+		t.Errorf("high: want model=haiku, got %q", high.Model)
+	}
+
+	// Total tokens = 2200 + 2400 = 4600.
+	if resp.TotalEstTokens != 4600 {
+		t.Errorf("want total_est_tokens=4600, got %d", resp.TotalEstTokens)
+	}
+	if resp.TotalEstUSD <= 0 {
+		t.Errorf("want positive total_est_usd, got %f", resp.TotalEstUSD)
+	}
+	if resp.EstMinutes < 0 {
+		t.Errorf("want non-negative est_minutes, got %f", resp.EstMinutes)
+	}
+}
+
+// TestHandleEnrichmentEstimate_excludesAlreadyEnriched checks that entities
+// with completed jobs are excluded from the estimate.
+func TestHandleEnrichmentEstimate_excludesAlreadyEnriched(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv(daemon.EnvRoot, tmp)
+
+	repoPath := filepath.Join(tmp, "repo-a")
+	srv, q := newJobsServer(t)
+
+	// Wire the repo into the server's group.
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g1"].group.Repos["repo-a"] = &DashRepo{Path: repoPath}
+	srv.graphs.mu.Unlock()
+
+	// Seed 3 candidates — two are "critical", one "medium".
+	candidates := []map[string]any{
+		{"id": "c1", "kind": "http_endpoint", "subject_id": "ep-001", "criticality_band": "critical"},
+		{"id": "c2", "kind": "http_endpoint", "subject_id": "ep-002", "criticality_band": "critical"},
+		{"id": "c3", "kind": "Service",       "subject_id": "svc-001", "criticality_band": "medium"},
+	}
+	seedCandidates(t, repoPath, candidates)
+
+	// Enqueue and complete a job for ep-001 so it counts as "already enriched".
+	id, err := q.Enqueue("g1", "ep-001", "describe_entity", "critical")
+	if err != nil {
+		t.Fatalf("Enqueue: %v", err)
+	}
+	// Wait for the stub worker to finish the job.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		j, _ := q.Get(id)
+		if j.Status == "done" || j.Status == "failed" {
+			break
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+
+	w := doRequest(t, srv, "GET", "/api/enrichments/g1/estimate")
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp enrichmentEstimateResponse
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// 1 entity already enriched — excluded.
+	if resp.AlreadyEnriched != 1 {
+		t.Errorf("want already_enriched=1, got %d", resp.AlreadyEnriched)
+	}
+
+	// Only 2 candidates remain (ep-002 critical + svc-001 medium).
+	total := 0
+	for _, tier := range resp.Tiers {
+		total += tier.Count
+	}
+	if total != 2 {
+		t.Errorf("want 2 total pending candidates, got %d", total)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -335,6 +335,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/enrichments/{group}/progress", s.handleEnrichmentProgress)
 	// Agent description write-back — persists generated descriptions to graph + frontmatter (#1304)
 	mux.HandleFunc("POST /api/enrichments/{group}/write", s.handleEnrichmentWriteback)
+	// Pre-run cost estimator — shows token/USD estimate before batch enrichment (#1287)
+	mux.HandleFunc("GET /api/enrichments/{group}/estimate", s.handleEnrichmentEstimate)
 
 	// Settings surface (#1206)
 	mux.HandleFunc("GET /api/settings", s.handleGetSettings)

--- a/internal/enrichment/pricing.go
+++ b/internal/enrichment/pricing.go
@@ -1,0 +1,96 @@
+package enrichment
+
+// pricing.go — Anthropic model pricing constants used by the cost estimator.
+//
+// Update these constants when Anthropic publishes new pricing.
+// All values are in USD per million tokens.
+//
+// Source: Anthropic pricing page (last updated 2025-Q2).
+
+// Input pricing (USD per million tokens).
+const (
+	HaikuInputPerMTok  = 0.80
+	HaikuOutputPerMTok = 4.00
+	SonnetInputPerMTok = 3.00
+	SonnetOutputPerMTok = 15.00
+)
+
+// inputRatio is the fraction of total tokens that are input tokens.
+// Based on the enrichment task profile: ~70% input, 30% output.
+const inputRatio = 0.70
+
+// outputRatio is the complementary output fraction.
+const outputRatio = 1.0 - inputRatio
+
+// tokensPerSecondPerWorker is the assumed throughput for wall-time estimation.
+// Calibrated against observed batch runs with 30 parallel workers.
+const tokensPerSecondPerWorker = 500
+
+// parallelWorkers is the assumed concurrency level for wall-time estimation.
+const parallelWorkers = 30
+
+// TokensPerEntity returns the conservative (upper-bound) token estimate for a
+// single entity of the given kind. The estimate covers both prompt (input) and
+// generated output (output) combined — the pricing helpers split it by ratio.
+func TokensPerEntity(kind string) int {
+	switch kind {
+	// API surface — most context-heavy: path, params, response shapes.
+	case "http_endpoint", "HTTPEndpoint", "SCOPE.HTTPEndpoint", "Route", "SCOPE.Route":
+		return 900
+	// Process flows — steps + preconditions.
+	case "process_flow", "Process", "SCOPE.ScheduledJob":
+		return 700
+	// Message topics — schema + consumers.
+	case "message_topic", "Task":
+		return 500
+	// Services, controllers, views.
+	case "Service", "SCOPE.Service", "Controller", "SCOPE.Controller",
+		"View", "SCOPE.View":
+		return 600
+	// Data layer.
+	case "Schema", "Model", "DataAccess", "SCOPE.DataAccess":
+		return 550
+	// Generic operations / components.
+	default:
+		return 500
+	}
+}
+
+// promptOverheadTokens is added once per entity call to account for the fixed
+// system prompt, instruction preamble, and JSON scaffolding.
+const promptOverheadTokens = 200
+
+// EstimateEntityTokens returns the total estimated tokens for one entity,
+// including prompt overhead.
+func EstimateEntityTokens(kind string) int {
+	return TokensPerEntity(kind) + promptOverheadTokens
+}
+
+// USDForTokens computes the estimated cost in USD for the given total token
+// count at the given model's rates. The input/output split is 70/30.
+func USDForTokens(totalTokens int, model string) float64 {
+	input := float64(totalTokens) * inputRatio
+	output := float64(totalTokens) * outputRatio
+
+	var inRate, outRate float64
+	switch model {
+	case "sonnet":
+		inRate, outRate = SonnetInputPerMTok, SonnetOutputPerMTok
+	default: // haiku
+		inRate, outRate = HaikuInputPerMTok, HaikuOutputPerMTok
+	}
+
+	// Rates are per million tokens.
+	return (input*inRate + output*outRate) / 1_000_000
+}
+
+// EstimateWallMinutes returns a rough wall-clock estimate in minutes for
+// processing the given total token count with parallelWorkers concurrent
+// workers at tokensPerSecondPerWorker throughput.
+func EstimateWallMinutes(totalTokens int) float64 {
+	if totalTokens == 0 {
+		return 0
+	}
+	totalSeconds := float64(totalTokens) / float64(tokensPerSecondPerWorker*parallelWorkers)
+	return totalSeconds / 60.0
+}

--- a/internal/enrichment/pricing_test.go
+++ b/internal/enrichment/pricing_test.go
@@ -1,0 +1,93 @@
+package enrichment
+
+// pricing_test.go — Unit tests for the cost-estimator pricing helpers (#1287).
+
+import (
+	"math"
+	"testing"
+)
+
+func TestTokensPerEntity_knownKinds(t *testing.T) {
+	cases := []struct {
+		kind string
+		want int
+	}{
+		{"http_endpoint", 900},
+		{"HTTPEndpoint", 900},
+		{"Route", 900},
+		{"process_flow", 700},
+		{"Process", 700},
+		{"message_topic", 500},
+		{"Service", 600},
+		{"Controller", 600},
+		{"Schema", 550},
+		{"Model", 550},
+		{"DataAccess", 550},
+		{"unknown_kind", 500}, // default
+	}
+	for _, tc := range cases {
+		got := TokensPerEntity(tc.kind)
+		if got != tc.want {
+			t.Errorf("TokensPerEntity(%q) = %d, want %d", tc.kind, got, tc.want)
+		}
+	}
+}
+
+func TestEstimateEntityTokens_includesOverhead(t *testing.T) {
+	// EstimateEntityTokens must always add at least promptOverheadTokens (200).
+	for _, kind := range []string{"http_endpoint", "Service", "unknown"} {
+		base := TokensPerEntity(kind)
+		got  := EstimateEntityTokens(kind)
+		want := base + promptOverheadTokens
+		if got != want {
+			t.Errorf("EstimateEntityTokens(%q) = %d, want %d", kind, got, want)
+		}
+	}
+}
+
+func TestUSDForTokens_haiku(t *testing.T) {
+	// 1M tokens at haiku rates:
+	//   input  = 700k → 700k * $0.80/M  = $0.56
+	//   output = 300k → 300k * $4.00/M  = $1.20
+	//   total  = $1.76
+	total := 1_000_000
+	got   := USDForTokens(total, "haiku")
+	want  := 1.76 // precomputed
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("USDForTokens(1M, haiku) = %.4f, want %.4f", got, want)
+	}
+}
+
+func TestUSDForTokens_sonnet(t *testing.T) {
+	// 1M tokens at sonnet rates:
+	//   input  = 700k → 700k * $3.00/M  = $2.10
+	//   output = 300k → 300k * $15.00/M = $4.50
+	//   total  = $6.60
+	total := 1_000_000
+	got   := USDForTokens(total, "sonnet")
+	want  := 6.60
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("USDForTokens(1M, sonnet) = %.4f, want %.4f", got, want)
+	}
+}
+
+func TestUSDForTokens_zeroTokens(t *testing.T) {
+	if got := USDForTokens(0, "haiku"); got != 0 {
+		t.Errorf("USDForTokens(0, haiku) = %v, want 0", got)
+	}
+}
+
+func TestEstimateWallMinutes(t *testing.T) {
+	// 0 tokens → 0 minutes.
+	if got := EstimateWallMinutes(0); got != 0 {
+		t.Errorf("EstimateWallMinutes(0) = %v, want 0", got)
+	}
+
+	// parallelWorkers=30, tokensPerSecondPerWorker=500 → 15000 tok/s.
+	// 900_000 tokens → 60 s → 1 minute.
+	got := EstimateWallMinutes(900_000)
+	want := 1.0
+	if math.Abs(got-want) > 0.01 {
+		t.Errorf("EstimateWallMinutes(900k) = %.3f, want %.3f", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Before dispatching a batched enrichment run, users now see a cost estimate dialog showing per-tier token counts, USD costs, and wall-time before any LLM call is made. A "Run enrichment" button in the \`/pending\` toolbar triggers the dialog; the user must confirm before any API calls are dispatched.

**Per-tier breakdown (Critical=Sonnet, High/Medium/Low=Haiku):**
- Entity count per band
- Conservative token estimate (\`TokensPerEntity(kind) + 200\` overhead)
- USD cost at Anthropic published rates
- Already-enriched entities excluded from estimate

**Pricing constants** live in a single file (\`internal/enrichment/pricing.go\`) — update once when rates change.

**"Run enrichment \$X.XX" confirm button** shows cost prominently so the user cannot miss it before confirming.

**Budget warning** displayed when estimated cost ≥ \$10.

Also fixes a pre-existing compile error in \`handlers_enrichment_batch_test.go\` (missing 4th argument to \`Enqueue\` after #1300 added \`criticality_band\`).

## Closes / Refs

Closes #1287

## What changed

### Backend
- \`internal/enrichment/pricing.go\` — pricing constants (\`HaikuInputPerMTok=\$0.80\`, \`HaikuOutputPerMTok=\$4.00\`, \`SonnetInputPerMTok=\$3.00\`, \`SonnetOutputPerMTok=\$15.00\`), \`TokensPerEntity(kind)\` (conservative upper bound per kind), \`EstimateEntityTokens\`, \`USDForTokens\`, \`EstimateWallMinutes\`
- \`internal/enrichment/pricing_test.go\` — 6 unit tests covering token estimates, USD math at both model tiers, wall-time
- \`internal/dashboard/handlers_enrichment_estimate.go\` — \`GET /api/enrichments/{group}/estimate\` handler; reads candidates from disk, excludes already-enriched (job status=done), returns per-band breakdown
- \`internal/dashboard/handlers_enrichment_estimate_test.go\` — 4 HTTP-level tests: no-group 404, empty candidates, with candidates (token/USD math), excludes-already-enriched
- \`internal/dashboard/server.go\` — route registration

### Frontend
- \`dashboard/src/types/api.ts\` — \`EnrichmentEstimateTier\` + \`EnrichmentEstimateResponse\` types
- \`dashboard/src/api/client.ts\` — \`fetchEnrichmentEstimate\`, \`postBatchEnrich\`, \`BatchEnrichCandidate\`/\`BatchEnrichResponse\` types
- \`dashboard/src/components/indexing/EnrichmentCostModal.tsx\` — modal with per-tier table, meta row (time + skipped count), budget warning, "Run enrichment \$X.XX" confirm button
- \`dashboard/src/routes/pending.tsx\` — "Run enrichment" toolbar button, estimate query, batch-enrich mutation wired to modal

### E2E
- \`dashboard/tests/e2e/enrichment-cost-modal.spec.ts\` — 6 headless Playwright tests with API mocking; screenshot at \`test-results/cost-modal/1-cost-estimator-dialog.png\`

## Testing

- [x] Go unit tests: \`go test ./internal/enrichment/... -run "TestTokens|TestUSD|TestWall|TestEstimate"\` — 6 pass
- [x] Go HTTP tests: \`go test ./internal/dashboard/... -run "TestHandleEnrichmentEstimate"\` — 4 pass
- [x] 6 Playwright E2E tests pass headless; screenshot captured at \`test-results/cost-modal/\`
- [x] No new TypeScript errors (same 36 pre-existing errors as main)

## Notes

Token estimate formula: \`TokensPerEntity(kind) + 200\` where \`TokensPerEntity\` returns a conservative upper-bound calibrated against the issue spec (http_endpoint=900, process_flow=700, message_topic=500, Service/Controller=600, Schema/Model/DataAccess=550, default=500). The 70/30 input/output ratio matches observed enrichment task profiles.