### PR TITLE
fix(paths): actually eliminate DRF ghosts — verified against real corpus

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -28,6 +28,8 @@
 package engine
 
 import (
+	"fmt"
+	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
@@ -35,6 +37,10 @@ import (
 	"github.com/cajasmota/archigraph/internal/engine/httproutes"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// drfDbgEnabled gates the diagnostic stderr tracing for the DRF ghost-path
+// investigation. Set ARCHIGRAPH_DRF_DBG=1 to enable.
+var drfDbgEnabled = os.Getenv("ARCHIGRAPH_DRF_DBG") == "1"
 
 // drfRouterRegisterDetailedRe captures the (routerVar, prefix, ViewSet identifier)
 // triple of every `router.register(r"prefix", ViewSetClass, ...)` call in a
@@ -311,9 +317,15 @@ func ApplyDjangoDRFRoutes(
 		// valid, and required so routes still land somewhere rather than being
 		// silently dropped).
 		parentPrefixes := findParentIncludePrefixes(relPath, parentFiles, fileReader)
+		if drfDbgEnabled {
+			fmt.Fprintf(os.Stderr, "DRF: file=%s parentPrefixes=%v\n", relPath, parentPrefixes)
+		}
 		if len(parentPrefixes) == 0 {
 			// File is not included from anywhere — emit at bare prefix.
 			parentPrefixes = []string{""}
+			if drfDbgEnabled {
+				fmt.Fprintf(os.Stderr, "DRF: file=%s NO parent found → bare prefix fallback\n", relPath)
+			}
 		}
 
 		// Find every router.register() call. Each yields (routerVar, prefix, ViewSet).
@@ -615,13 +627,24 @@ func findParentIncludePrefixes(
 		}
 		src := string(content)
 
+		if drfDbgEnabled {
+			fmt.Fprintf(os.Stderr, "DRF: scanning candidate=%s for target=%s\n", candidate, targetRelPath)
+		}
+
 		// String-form include: path("prefix", include("module.path"))
 		for _, m := range djangoIncludeStringRe.FindAllStringSubmatch(src, -1) {
 			parentPrefix := m[1]
 			modulePath := m[2]
 			resolved := modulePathToFilePath(modulePath)
+			if drfDbgEnabled {
+				fmt.Fprintf(os.Stderr, "DRF:   include match prefix=%q module=%q resolved=%q target=%q\n",
+					parentPrefix, modulePath, resolved, targetRelPath)
+			}
 			if resolved != targetRelPath {
 				alt := modulePathToFilePath_relToParent(modulePath, candidate)
+				if drfDbgEnabled {
+					fmt.Fprintf(os.Stderr, "DRF:   alt=%q\n", alt)
+				}
 				if alt != targetRelPath {
 					continue
 				}
@@ -629,6 +652,10 @@ func findParentIncludePrefixes(
 			if !seen[parentPrefix] {
 				prefixes = append(prefixes, parentPrefix)
 				seen[parentPrefix] = true
+				if drfDbgEnabled {
+					fmt.Fprintf(os.Stderr, "DRF:   FOUND prefix=%q for target=%s from candidate=%s\n",
+						parentPrefix, targetRelPath, candidate)
+				}
 			}
 		}
 

--- a/internal/engine/django_routes.go
+++ b/internal/engine/django_routes.go
@@ -29,6 +29,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"os"
 	"regexp"
 	"strings"
 	"sync"
@@ -38,6 +39,13 @@ import (
 	"github.com/cajasmota/archigraph/internal/treesitter"
 	"github.com/cajasmota/archigraph/internal/types"
 )
+
+// drfDbgEnabled in django_routes.go mirrors the one in django_drf_actions.go.
+// Both are gated on the same ARCHIGRAPH_DRF_DBG env var. Since Go evaluates
+// package-level vars at init time, the value is fixed for the process lifetime.
+// Use "var" (not "const") so the linker can dead-code-eliminate the blocks when
+// the env var is absent in production.
+var drfRoutesDbgEnabled = os.Getenv("ARCHIGRAPH_DRF_DBG") == "1"
 
 // ---------------------------------------------------------------------------
 // Cross-file DRF register-name registry (#1278)
@@ -224,7 +232,41 @@ func applyDjangoRouteComposition(
 		}
 		filteredEntities = append(filteredEntities, e)
 	}
-	filteredEntities = append(filteredEntities, composed.entities...)
+
+	// #1297 — suppress bare-prefix AST-composed Route entities when they
+	// duplicate a DRF register name. This handles the case where a
+	// routers.py file mounts its router locally via path("",
+	// include(router.urls)) — the local empty prefix produces a composed
+	// Route:/alternate-addresses — but the file is ALSO included from a
+	// parent urls.py via path("api/v1/", include("core.routers")). The
+	// ApplyDjangoDRFRoutes pass (which sees the parent include) correctly
+	// emits /api/v1/alternate-addresses; the locally-composed
+	// Route:/alternate-addresses is a ghost that must be suppressed.
+	//
+	// We suppress a composed entity when:
+	//   - Its kind is Route and SourceFile is the current file.
+	//   - Its bare name (TrimLeft("/")) appears in drfGlobalRegisterNames,
+	//     meaning a router.register() call with that basename exists somewhere
+	//     in the repo.
+	// This is safe because isDRFGlobalRegisterName only matches single-segment
+	// basenames (e.g. "alternate-addresses"), never multi-segment composed
+	// paths like "api/v1/alternate-addresses". If the local prefix were
+	// non-empty, the composed entity name would include the prefix and would
+	// NOT match a bare register name.
+	var composedFiltered []types.EntityRecord
+	for _, e := range composed.entities {
+		if e.Kind == "Route" && e.SourceFile == path {
+			bare := strings.TrimLeft(e.Name, "/")
+			if isDRFGlobalRegisterName(bare) {
+				if drfRoutesDbgEnabled {
+					fmt.Fprintf(os.Stderr, "DRF: suppressing bare ast_driven Route %q (global register name match)\n", e.Name)
+				}
+				continue
+			}
+		}
+		composedFiltered = append(composedFiltered, e)
+	}
+	filteredEntities = append(filteredEntities, composedFiltered...)
 
 	// Drop YAML ROUTES_TO edges whose source Route is one of the bare
 	// register names we just replaced. The YAML edge is


### PR DESCRIPTION
## Summary

Eliminates the 124 ghost DRF paths that persisted after three previous PRs (#1278/#1290, #1292/#1295). The root cause was identified through end-to-end tracing (Phase 1) before any code was changed.

**Root cause (Phase 1):**
- `core/routers.py` mounts its DRF router with an empty local prefix: `path("", include(router.urls))`
- `extractDjangoComposedRoutes` (Phase 2 of `applyDjangoRouteComposition`) composed `ast_driven` Route entities at the bare name — `"" + "alternate-addresses"` → `Route:/alternate-addresses`
- Phase 1 global suppression (added in #1290) only filtered `yaml_driven` entities. Phase 2 composed entities bypassed it entirely.
- `synthesizeDjangoFromComposed` then converted these bare `ast_driven` Routes into `http_endpoint_definition` nodes → 124 ghost paths in the paths API
- #1295 fixed the coordinator pre-pass for the subprocess path (`ARCHIGRAPH_SUBPROC_EXTRACT=1`) only; the default in-process path was unaffected

**Why previous fixes missed it:**
| PR | What it fixed | Why ghosts survived |
|----|--------------|---------------------|
| #1290 | Cross-file yaml_driven Route suppression (Phase 1) | Phase 2 composed entities not touched |
| #1295 | Coordinator pre-pass for subprocess extraction | In-process path (default) unaffected |

**The fix:**
In `applyDjangoRouteComposition`, after Phase 2 appends composed entities, filter out any composed `Route` whose bare name (`strings.TrimLeft(e.Name, "/")`) appears in `drfGlobalRegisterNames` before adding to `filteredEntities`. This is safe: `isDRFGlobalRegisterName` only matches single-segment register basenames (e.g. `"alternate-addresses"`), never multi-segment prefixed paths like `"api/v1/alternate-addresses"`.

Also adds `ARCHIGRAPH_DRF_DBG=1` stderr tracing (env-gated, zero cost in production) in both `django_routes.go` and `django_drf_actions.go`.

## Closes / Refs
- Closes #1297

## Phase 3 verification (real corpus)

```
Before fix:  total:494, api:311, admin:59, other:124
After fix:   total:370, api:311, admin:59, other:0
```

`other` went from 124 → 0 (requirement was ≤5). `api` and `admin` counts unchanged — no signal was pruned.

## Testing
- [x] All tests pass: `go test ./internal/engine/... → ok (8.7s)`
- [x] Verified on real corpus: other:0
- [x] No regression in cross-language parity

## Notes

The `ARCHIGRAPH_DRF_DBG=1` debug tracing was instrumental in Phase 1. Key finding: `DRF: file=core/routers.py parentPrefixes=[api/v1/]` confirmed `ApplyDjangoDRFRoutes` was already finding the correct parent prefix — the ghosts were originating entirely in `extractDjangoComposedRoutes` Phase 2, not from the cross-file pass.