### PR TITLE
feat(quality): import cycle detector via Tarjan SCC (#1312)

### DIFF
--- a/internal/graph/cycles.go
+++ b/internal/graph/cycles.go
@@ -1,0 +1,289 @@
+// Package graph — cycles.go implements Tarjan's strongly-connected-components
+// (SCC) algorithm over IMPORTS edges between entities. Each SCC of size > 1
+// represents a circular dependency (import cycle).
+//
+// Beyond raw detection, each cycle is annotated with:
+//   - WeakestLinkID: the edge whose source has the lowest PageRank —
+//     severing it causes the least disruption to the rest of the graph.
+//   - SuggestedExtraction: the entity with the highest PageRank inside the
+//     cycle (best candidate to be extracted into a shared module that both
+//     sides can depend on without the cycle).
+package graph
+
+import (
+	"sort"
+)
+
+// ImportCycle describes one strongly-connected component of size > 1 in the
+// IMPORTS sub-graph.
+type ImportCycle struct {
+	// Members lists entity IDs that form the cycle, sorted for determinism.
+	Members []string `json:"members"`
+	// Edges lists the IMPORTS relationships (FromID → ToID) inside the cycle,
+	// sorted for determinism.
+	Edges []CycleEdge `json:"edges"`
+	// WeakestLinkFromID / WeakestLinkToID identify the edge whose source has
+	// the lowest PageRank — the best edge to sever to break the cycle cheaply.
+	WeakestLinkFromID string `json:"weakest_link_from_id"`
+	WeakestLinkToID   string `json:"weakest_link_to_id"`
+	// SuggestedExtractionID is the entity inside the cycle with the highest
+	// PageRank — the best candidate for extraction into a common module.
+	SuggestedExtractionID string `json:"suggested_extraction_id"`
+	// Size is len(Members) for fast filtering.
+	Size int `json:"size"`
+}
+
+// CycleEdge is a directed IMPORTS relationship within a cycle.
+type CycleEdge struct {
+	FromID string `json:"from_id"`
+	ToID   string `json:"to_id"`
+}
+
+// FindImportCycles runs Tarjan SCC on the IMPORTS sub-graph of rels, using
+// pagerank scores to annotate each cycle with a weakest link and suggested
+// extraction target.
+//
+// pagerank may be nil or empty — in that case all nodes are treated as
+// equally weighted (weakest-link = first alphabetical source).
+//
+// Returns cycles sorted by descending size, then ascending first member ID.
+func FindImportCycles(entities []Entity, rels []Relationship, pagerank map[string]float64) []ImportCycle {
+	// Collect entity IDs that actually exist so we skip dangling edges.
+	known := make(map[string]bool, len(entities))
+	for i := range entities {
+		known[entities[i].ID] = true
+	}
+
+	// Build adjacency list of IMPORTS edges (directed: from → to).
+	// importsAdj[u] = list of v where u IMPORTS v.
+	importsAdj := make(map[string][]string)
+	// importsEdge is a lookup set for edges inside cycles.
+	type edgeKey struct{ from, to string }
+	edgeSet := make(map[edgeKey]bool)
+
+	for i := range rels {
+		r := &rels[i]
+		if r.Kind != "IMPORTS" {
+			continue
+		}
+		if !known[r.FromID] || !known[r.ToID] {
+			continue
+		}
+		if r.FromID == r.ToID {
+			continue // self-import: not a cycle
+		}
+		importsAdj[r.FromID] = append(importsAdj[r.FromID], r.ToID)
+		edgeSet[edgeKey{r.FromID, r.ToID}] = true
+	}
+
+	if len(importsAdj) == 0 {
+		return nil
+	}
+
+	// Ensure deterministic iteration by sorting adjacency lists.
+	for id := range importsAdj {
+		sort.Strings(importsAdj[id])
+	}
+
+	// --- Tarjan's iterative SCC ---
+	type nodeState struct {
+		index   int
+		lowlink int
+		onStack bool
+	}
+	state := make(map[string]*nodeState, len(importsAdj))
+	var stack []string
+	index := 0
+	var sccs [][]string
+
+	// Iterative DFS to avoid stack overflows on deep graphs.
+	type frame struct {
+		u    string
+		i    int // next child index in importsAdj[u]
+	}
+
+	// Collect all nodes (sources + any targets that are also sources).
+	allNodes := make(map[string]bool)
+	for u, vs := range importsAdj {
+		allNodes[u] = true
+		for _, v := range vs {
+			allNodes[v] = true
+		}
+	}
+	// Sort for determinism.
+	sortedNodes := make([]string, 0, len(allNodes))
+	for n := range allNodes {
+		sortedNodes = append(sortedNodes, n)
+	}
+	sort.Strings(sortedNodes)
+
+	var dfsStack []frame
+	for _, start := range sortedNodes {
+		if state[start] != nil {
+			continue
+		}
+		state[start] = &nodeState{index: index, lowlink: index}
+		index++
+		stack = append(stack, start)
+		state[start].onStack = true
+		dfsStack = append(dfsStack, frame{u: start, i: 0})
+
+		for len(dfsStack) > 0 {
+			top := &dfsStack[len(dfsStack)-1]
+			u := top.u
+			neighbours := importsAdj[u]
+
+			if top.i < len(neighbours) {
+				v := neighbours[top.i]
+				top.i++
+				if sv := state[v]; sv == nil {
+					// Tree edge: push v.
+					state[v] = &nodeState{index: index, lowlink: index}
+					index++
+					stack = append(stack, v)
+					state[v].onStack = true
+					dfsStack = append(dfsStack, frame{u: v, i: 0})
+				} else if sv.onStack {
+					// Back edge.
+					if sv.index < state[u].lowlink {
+						state[u].lowlink = sv.index
+					}
+				}
+				continue
+			}
+
+			// All neighbours processed — pop u.
+			dfsStack = dfsStack[:len(dfsStack)-1]
+			su := state[u]
+
+			if len(dfsStack) > 0 {
+				parent := dfsStack[len(dfsStack)-1].u
+				sp := state[parent]
+				if su.lowlink < sp.lowlink {
+					sp.lowlink = su.lowlink
+				}
+			}
+
+			// Root of an SCC?
+			if su.lowlink == su.index {
+				var scc []string
+				for {
+					w := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					state[w].onStack = false
+					scc = append(scc, w)
+					if w == u {
+						break
+					}
+				}
+				sccs = append(sccs, scc)
+			}
+		}
+	}
+
+	// Build ImportCycle for each SCC of size > 1.
+	var cycles []ImportCycle
+	for _, scc := range sccs {
+		if len(scc) < 2 {
+			continue
+		}
+		memberSet := make(map[string]bool, len(scc))
+		for _, m := range scc {
+			memberSet[m] = true
+		}
+		// Collect internal edges.
+		var edges []CycleEdge
+		for _, u := range scc {
+			for _, v := range importsAdj[u] {
+				if memberSet[v] {
+					edges = append(edges, CycleEdge{FromID: u, ToID: v})
+				}
+			}
+		}
+		// Sort members and edges for determinism.
+		sort.Strings(scc)
+		sort.Slice(edges, func(i, j int) bool {
+			if edges[i].FromID != edges[j].FromID {
+				return edges[i].FromID < edges[j].FromID
+			}
+			return edges[i].ToID < edges[j].ToID
+		})
+
+		// Weakest link: edge whose source has the lowest PageRank.
+		// If PageRank is unavailable, fall back to alphabetically first source.
+		weakFrom, weakTo := pickWeakestLink(edges, pagerank)
+
+		// Suggested extraction: member with the highest PageRank.
+		bestExtraction := pickBestExtraction(scc, pagerank)
+
+		cycles = append(cycles, ImportCycle{
+			Members:               scc,
+			Edges:                 edges,
+			WeakestLinkFromID:     weakFrom,
+			WeakestLinkToID:       weakTo,
+			SuggestedExtractionID: bestExtraction,
+			Size:                  len(scc),
+		})
+	}
+
+	// Sort: descending size, then ascending first member for determinism.
+	sort.SliceStable(cycles, func(i, j int) bool {
+		if cycles[i].Size != cycles[j].Size {
+			return cycles[i].Size > cycles[j].Size
+		}
+		mi := ""
+		if len(cycles[i].Members) > 0 {
+			mi = cycles[i].Members[0]
+		}
+		mj := ""
+		if len(cycles[j].Members) > 0 {
+			mj = cycles[j].Members[0]
+		}
+		return mi < mj
+	})
+	return cycles
+}
+
+// pickWeakestLink returns the edge whose source has the lowest PageRank.
+// Tie-breaks on source ID alphabetically to stay deterministic.
+func pickWeakestLink(edges []CycleEdge, pr map[string]float64) (fromID, toID string) {
+	if len(edges) == 0 {
+		return "", ""
+	}
+	best := edges[0]
+	bestPR := prScore(best.FromID, pr)
+	for _, e := range edges[1:] {
+		p := prScore(e.FromID, pr)
+		if p < bestPR || (p == bestPR && e.FromID < best.FromID) {
+			best = e
+			bestPR = p
+		}
+	}
+	return best.FromID, best.ToID
+}
+
+// pickBestExtraction returns the member with the highest PageRank (best
+// candidate for extraction into a shared module). Tie-breaks alphabetically.
+func pickBestExtraction(members []string, pr map[string]float64) string {
+	if len(members) == 0 {
+		return ""
+	}
+	best := members[0]
+	bestPR := prScore(best, pr)
+	for _, m := range members[1:] {
+		p := prScore(m, pr)
+		if p > bestPR || (p == bestPR && m < best) {
+			best = m
+			bestPR = p
+		}
+	}
+	return best
+}
+
+// prScore returns the PageRank score for id, or 0.0 if missing.
+func prScore(id string, pr map[string]float64) float64 {
+	if pr == nil {
+		return 0
+	}
+	return pr[id]
+}

--- a/internal/graph/cycles_test.go
+++ b/internal/graph/cycles_test.go
@@ -1,0 +1,241 @@
+package graph
+
+import (
+	"testing"
+)
+
+// relImport constructs an IMPORTS relationship.
+func relImport(from, to string) Relationship {
+	return Relationship{ID: from + "-imports-" + to, FromID: from, ToID: to, Kind: "IMPORTS"}
+}
+
+// relCalls constructs a CALLS relationship (should be ignored by cycle detector).
+func relCalls2(from, to string) Relationship {
+	return Relationship{ID: from + "-calls-" + to, FromID: from, ToID: to, Kind: "CALLS"}
+}
+
+// TestFindImportCycles_SimpleCycle — A imports B, B imports A. Must detect one cycle.
+func TestFindImportCycles_SimpleCycle(t *testing.T) {
+	ents := makeEntities("A", "B")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "A"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d: %v", len(cycles), cycles)
+	}
+	c := cycles[0]
+	if c.Size != 2 {
+		t.Errorf("cycle size = %d, want 2", c.Size)
+	}
+	if len(c.Edges) != 2 {
+		t.Errorf("edge count = %d, want 2", len(c.Edges))
+	}
+	// Members must be sorted.
+	if c.Members[0] != "A" || c.Members[1] != "B" {
+		t.Errorf("members not sorted: %v", c.Members)
+	}
+}
+
+// TestFindImportCycles_ThreeNodeCycle — A→B→C→A. Must detect one 3-member cycle.
+func TestFindImportCycles_ThreeNodeCycle(t *testing.T) {
+	ents := makeEntities("A", "B", "C")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "C"),
+		relImport("C", "A"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d", len(cycles))
+	}
+	if cycles[0].Size != 3 {
+		t.Errorf("want 3-member cycle, got %d members", cycles[0].Size)
+	}
+}
+
+// TestFindImportCycles_Acyclic — A→B, B→C. No cycles.
+func TestFindImportCycles_Acyclic(t *testing.T) {
+	ents := makeEntities("A", "B", "C")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "C"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 0 {
+		t.Errorf("acyclic graph should have no cycles, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_NoImportEdges — Only CALLS edges; cycle detector must ignore them.
+func TestFindImportCycles_NoImportEdges(t *testing.T) {
+	ents := makeEntities("A", "B")
+	rels := []Relationship{
+		relCalls2("A", "B"),
+		relCalls2("B", "A"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 0 {
+		t.Errorf("CALLS edges should not produce import cycles, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_TwoCycles — Two independent 2-cycles.
+func TestFindImportCycles_TwoCycles(t *testing.T) {
+	ents := makeEntities("A", "B", "C", "D")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "A"),
+		relImport("C", "D"),
+		relImport("D", "C"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 2 {
+		t.Fatalf("expected 2 cycles, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_SortedBySize — larger cycle listed first.
+func TestFindImportCycles_SortedBySize(t *testing.T) {
+	ents := makeEntities("A", "B", "C", "D", "E")
+	rels := []Relationship{
+		// 3-cycle: C→D→E→C
+		relImport("C", "D"),
+		relImport("D", "E"),
+		relImport("E", "C"),
+		// 2-cycle: A→B→A
+		relImport("A", "B"),
+		relImport("B", "A"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) < 2 {
+		t.Fatalf("expected at least 2 cycles, got %d", len(cycles))
+	}
+	if cycles[0].Size < cycles[1].Size {
+		t.Errorf("cycles not sorted by descending size: %d < %d", cycles[0].Size, cycles[1].Size)
+	}
+}
+
+// TestFindImportCycles_WeakestLink — the entity with the lowest PageRank
+// should be the weakest-link source.
+func TestFindImportCycles_WeakestLink(t *testing.T) {
+	ents := makeEntities("A", "B", "C")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "C"),
+		relImport("C", "A"),
+	}
+	// Assign C the lowest PageRank.
+	pr := map[string]float64{
+		"A": 0.5,
+		"B": 0.4,
+		"C": 0.1,
+	}
+	cycles := FindImportCycles(ents, rels, pr)
+	if len(cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d", len(cycles))
+	}
+	if cycles[0].WeakestLinkFromID != "C" {
+		t.Errorf("weakest link source = %q, want %q", cycles[0].WeakestLinkFromID, "C")
+	}
+	if cycles[0].WeakestLinkToID != "A" {
+		t.Errorf("weakest link dest = %q, want %q", cycles[0].WeakestLinkToID, "A")
+	}
+}
+
+// TestFindImportCycles_SuggestedExtraction — the entity with the highest
+// PageRank should be the suggested extraction target.
+func TestFindImportCycles_SuggestedExtraction(t *testing.T) {
+	ents := makeEntities("A", "B", "C")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "C"),
+		relImport("C", "A"),
+	}
+	pr := map[string]float64{
+		"A": 0.5,
+		"B": 0.9,
+		"C": 0.1,
+	}
+	cycles := FindImportCycles(ents, rels, pr)
+	if len(cycles) != 1 {
+		t.Fatalf("expected 1 cycle, got %d", len(cycles))
+	}
+	if cycles[0].SuggestedExtractionID != "B" {
+		t.Errorf("suggested extraction = %q, want %q", cycles[0].SuggestedExtractionID, "B")
+	}
+}
+
+// TestFindImportCycles_SelfImport — self-import should not count as a cycle.
+func TestFindImportCycles_SelfImport(t *testing.T) {
+	ents := makeEntities("A")
+	rels := []Relationship{
+		relImport("A", "A"),
+	}
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 0 {
+		t.Errorf("self-import should not produce a cycle, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_DanglingEdge — edge referencing an entity not in the
+// entity list should be silently skipped (no panic, no false positive).
+func TestFindImportCycles_DanglingEdge(t *testing.T) {
+	ents := makeEntities("A", "B")
+	rels := []Relationship{
+		relImport("A", "B"),
+		relImport("B", "UNKNOWN"), // dangling
+		relImport("UNKNOWN", "A"), // dangling
+	}
+	// Without the UNKNOWN node present, there is no complete cycle.
+	cycles := FindImportCycles(ents, rels, nil)
+	if len(cycles) != 0 {
+		t.Errorf("dangling edges should not produce cycles, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_Empty — empty input must not panic.
+func TestFindImportCycles_Empty(t *testing.T) {
+	cycles := FindImportCycles(nil, nil, nil)
+	if len(cycles) != 0 {
+		t.Errorf("empty input: expected 0 cycles, got %d", len(cycles))
+	}
+}
+
+// TestFindImportCycles_Determinism — multiple calls with same input produce
+// identical output (members and edges sorted, cycles in stable order).
+func TestFindImportCycles_Determinism(t *testing.T) {
+	ents := makeEntities("A", "B", "C", "D", "E", "F")
+	rels := []Relationship{
+		relImport("A", "B"), relImport("B", "C"), relImport("C", "A"),
+		relImport("D", "E"), relImport("E", "F"), relImport("F", "D"),
+	}
+	var prev []ImportCycle
+	for i := 0; i < 5; i++ {
+		got := FindImportCycles(ents, rels, nil)
+		if prev == nil {
+			prev = got
+			continue
+		}
+		if len(got) != len(prev) {
+			t.Fatalf("run %d: cycle count changed %d→%d", i, len(prev), len(got))
+		}
+		for j := range got {
+			if got[j].Size != prev[j].Size {
+				t.Errorf("run %d cycle %d: size %d→%d", i, j, prev[j].Size, got[j].Size)
+			}
+			if len(got[j].Members) != len(prev[j].Members) {
+				t.Errorf("run %d cycle %d: member count changed", i, j)
+				continue
+			}
+			for k := range got[j].Members {
+				if got[j].Members[k] != prev[j].Members[k] {
+					t.Errorf("run %d cycle %d member %d: %q→%q",
+						i, j, k, prev[j].Members[k], got[j].Members[k])
+				}
+			}
+		}
+		prev = got
+	}
+}

--- a/internal/mcp/cycles_tools.go
+++ b/internal/mcp/cycles_tools.go
@@ -1,0 +1,170 @@
+// cycles_tools.go — MCP handler for archigraph_quality_cycles (#1312).
+//
+// Exposes import-cycle detection via Tarjan SCC over IMPORTS edges. Each
+// reported cycle includes the participating files/entities, the weakest-link
+// edge (lowest-PageRank source — easiest to sever), and a suggested extraction
+// target (highest-PageRank member — best candidate for a shared module).
+package mcp
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleQualityCycles is the MCP handler for archigraph_quality_cycles.
+// It accepts an optional repo_filter and optional limit, runs Tarjan SCC
+// over the IMPORTS sub-graph of each loaded repo, and returns all detected
+// cycles sorted by descending size.
+func (s *Server) handleQualityCycles(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	limit := argInt(req, "limit", 100)
+
+	type memberDetail struct {
+		EntityID   string  `json:"entity_id"`
+		EntityName string  `json:"name"`
+		Kind       string  `json:"kind"`
+		SourceFile string  `json:"source_file,omitempty"`
+		PageRank   float64 `json:"pagerank,omitempty"`
+	}
+
+	type cycleOut struct {
+		Repo                    string            `json:"repo"`
+		Size                    int               `json:"size"`
+		Members                 []memberDetail    `json:"members"`
+		Edges                   []graph.CycleEdge `json:"edges"`
+		WeakestLinkFromID       string            `json:"weakest_link_from_id"`
+		WeakestLinkFromName     string            `json:"weakest_link_from_name"`
+		WeakestLinkToID         string            `json:"weakest_link_to_id"`
+		WeakestLinkToName       string            `json:"weakest_link_to_name"`
+		SuggestedExtractionID   string            `json:"suggested_extraction_id"`
+		SuggestedExtractionName string            `json:"suggested_extraction_name"`
+	}
+
+	var all []cycleOut
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+
+		// Build PageRank map from entity attributes (Pass 4 output).
+		pr := buildPageRankMap(r.Doc)
+
+		cycles := graph.FindImportCycles(r.Doc.Entities, r.Doc.Relationships, pr)
+		if len(cycles) == 0 {
+			continue
+		}
+
+		// Index entities by ID for name lookup.
+		byID := indexByID(r.Doc)
+
+		for _, c := range cycles {
+			members := make([]memberDetail, 0, len(c.Members))
+			for _, id := range c.Members {
+				e := byID[id]
+				if e == nil {
+					members = append(members, memberDetail{
+						EntityID: prefixedID(r.Repo, id),
+					})
+					continue
+				}
+				mem := memberDetail{
+					EntityID:   prefixedID(r.Repo, e.ID),
+					EntityName: e.Name,
+					Kind:       e.Kind,
+					SourceFile: e.SourceFile,
+				}
+				if e.PageRank != nil {
+					mem.PageRank = *e.PageRank
+				}
+				members = append(members, mem)
+			}
+
+			// Prefix edge IDs.
+			edges := make([]graph.CycleEdge, len(c.Edges))
+			for i, edge := range c.Edges {
+				edges[i] = graph.CycleEdge{
+					FromID: prefixedID(r.Repo, edge.FromID),
+					ToID:   prefixedID(r.Repo, edge.ToID),
+				}
+			}
+
+			weakFromName := entityName(byID, c.WeakestLinkFromID)
+			weakToName := entityName(byID, c.WeakestLinkToID)
+			extractName := entityName(byID, c.SuggestedExtractionID)
+
+			all = append(all, cycleOut{
+				Repo:                    r.Repo,
+				Size:                    c.Size,
+				Members:                 members,
+				Edges:                   edges,
+				WeakestLinkFromID:       prefixedID(r.Repo, c.WeakestLinkFromID),
+				WeakestLinkFromName:     weakFromName,
+				WeakestLinkToID:         prefixedID(r.Repo, c.WeakestLinkToID),
+				WeakestLinkToName:       weakToName,
+				SuggestedExtractionID:   prefixedID(r.Repo, c.SuggestedExtractionID),
+				SuggestedExtractionName: extractName,
+			})
+		}
+	}
+
+	// Sort: descending cycle size, then repo, then first member name.
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].Size != all[j].Size {
+			return all[i].Size > all[j].Size
+		}
+		if all[i].Repo != all[j].Repo {
+			return all[i].Repo < all[j].Repo
+		}
+		mi := ""
+		if len(all[i].Members) > 0 {
+			mi = all[i].Members[0].EntityName
+		}
+		mj := ""
+		if len(all[j].Members) > 0 {
+			mj = all[j].Members[0].EntityName
+		}
+		return mi < mj
+	})
+
+	total := len(all)
+	if limit > 0 && len(all) > limit {
+		all = all[:limit]
+	}
+
+	return jsonResult(map[string]any{
+		"cycles":    all,
+		"count":     len(all),
+		"total":     total,
+		"truncated": total > len(all),
+	}), nil
+}
+
+// buildPageRankMap extracts per-entity PageRank scores from a loaded Document.
+// Entities without a PageRank attribute (pre-Pass-4 graphs) return an empty map.
+func buildPageRankMap(doc *graph.Document) map[string]float64 {
+	pr := make(map[string]float64, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.PageRank != nil {
+			pr[e.ID] = *e.PageRank
+		}
+	}
+	return pr
+}
+
+// entityName returns the Name of the entity with the given local ID, or ""
+// when not found.
+func entityName(byID map[string]*graph.Entity, id string) string {
+	if e := byID[id]; e != nil {
+		return e.Name
+	}
+	return ""
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,7 +103,7 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 28 (#1281: 9→4 bundles; #1293: desc trim; this PR: drop 4 dashboard-only tools).
+// Tool count: 29 (#1281: 9→4 bundles; #1293: desc trim; #1312: +archigraph_quality_cycles).
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
 //   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 func (s *Server) registerTools() {
@@ -414,6 +414,16 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_find_dead_code", s.handleFindDeadCode))
+
+	// archigraph_quality_cycles — import cycle detection (#1312).
+	// Runs Tarjan SCC on IMPORTS edges; each SCC > 1 = circular dependency.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_quality_cycles",
+		mcpapi.WithDescription("Detect import cycles via Tarjan SCC on IMPORTS edges. Returns cycle members, weakest-link edge, and suggested extraction target."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_quality_cycles", s.handleQualityCycles))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -630,9 +630,9 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 28 (32 post-#1281 minus 4 dashboard-only tools dropped here).
-	if got := len(srv.MCP.ListTools()); got != 28 {
-		t.Errorf("expected 28 registered tools, got %d", got)
+	// Total count: 29 (28 pre-#1312 + archigraph_quality_cycles).
+	if got := len(srv.MCP.ListTools()); got != 29 {
+		t.Errorf("expected 29 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## What

Closes #1312. Adds import-cycle detection as a first-class quality signal.

## Why

Circular IMPORTS dependencies (A→B→C→A) cause tight coupling, break compilation ordering, and are the top refactoring smell in large codebases. They were previously invisible in archigraph's quality surface.

## How

**Algorithm — `internal/graph/cycles.go`**

Iterative Tarjan SCC over the IMPORTS sub-graph (all other edge kinds ignored). Each SCC of size > 1 is a cycle. The iterative DFS avoids call-stack overflows on deep graphs. Results are deterministic: adjacency lists and output slices are sorted before use.

Two go-beyond annotations per cycle:
- **Weakest link** — the IMPORTS edge whose source has the lowest PageRank. Severing it costs the least structural disruption to the rest of the graph.
- **Suggested extraction** — the cycle member with the highest PageRank. Best candidate to extract into a shared module that both sides can depend on without the cycle.

**MCP surface — `internal/mcp/cycles_tools.go`**

New tool \`archigraph_quality_cycles\` (registered in \`server.go\`). Accepts \`repo_filter\` and \`limit\`. Returns per-cycle: members (with name, kind, source_file, pagerank), edges, weakest-link with names, suggested extraction with name.

**Tests — `internal/graph/cycles_test.go`**

12 targeted cases covering: simple 2-cycle, 3-node cycle, acyclic graph (no false positives), non-IMPORTS edges ignored, two independent cycles, size ordering, weakest-link selection, suggested extraction, self-import, dangling edges, empty input, and 5-run determinism.

## Verification

\`\`\`
go test ./internal/graph/... ./internal/mcp/... -count=1
# ok  github.com/cajasmota/archigraph/internal/graph    4.7s
# ok  github.com/cajasmota/archigraph/internal/mcp      2.8s
\`\`\`

All 12 new tests pass. No regressions in the existing suite.

## Constraints met

- Backend only (no frontend changes)
- No client names in any output
- 6-section PR body
- Issue #1312 filed before implementation