### PR TITLE
feat(security): auth coverage audit — flag HTTP endpoints missing auth (#1314)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -19,11 +19,11 @@ for clients (Claude Code, Windsurf, etc.) and tracks the implementation in
 - **Transport:** stdio
 - **Process model:** one server per machine, multiple registered groups, lazy
   mtime-driven reload before every tool call. See ADR-0004.
-- **Tool count:** 28 (as of this PR), all prefixed `archigraph_*` to avoid client-side
+- **Tool count:** 29 (as of this PR), all prefixed `archigraph_*` to avoid client-side
   collisions when other MCP servers are installed alongside (Refs #62).
   Prior history: 19 tools → #668 bundled 3 action-dispatch tools (saved 4) → 39 tools
   after #1202/#1220/#1252 additions → #1281 merged 9 tools into 4 bundles → 32 tools
-  → this PR dropped 4 dashboard-only tools → 28 tools.
+  → dropped 4 dashboard-only tools → 28 tools → #1314 added auth_coverage → 29 tools.
 - **State:** in-memory `Document`s loaded from per-repo `.archigraph/graph.json`
   files; no database. See ADR-0006.
 - **Routing:** every tool that touches graph data resolves a group via the
@@ -120,6 +120,7 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_impact_radius`](#archigraph_impact_radius) | Blast-radius analysis with per-entity risk score. |
 | [`archigraph_summarize_subgraph`](#archigraph_summarize_subgraph) | Markdown summary of entity call neighbourhood. |
 | [`archigraph_find_dead_code`](#archigraph_find_dead_code) | Entities with 0 inbound/outbound project edges. |
+| [`archigraph_auth_coverage`](#archigraph_auth_coverage) | Security audit: flag HTTP endpoints missing auth decorators/middleware. |
 
 ---
 
@@ -1010,6 +1011,100 @@ entity). Use to assess Sub-A (#1217) migration progress.
 `migrated: true` means no legacy `http_endpoint` entities remain — all have been
 split into `http_endpoint_definition` / `http_endpoint_call` by Sub-A (#1217).
 When `migrated: false`, `note` contains a migration reminder.
+
+---
+
+---
+
+### `archigraph_auth_coverage`
+
+Security audit tool (#1314). Walk every `http_endpoint_definition` entity in the group and
+determine whether it is covered by an auth decorator, middleware, or guard.
+
+**Detection signals (applied in priority order)**
+
+1. Entity property `auth_decorator` / `auth_middleware` / `auth_guard` set by an extractor.
+2. `TAGGED_AS` relationship from the endpoint to an `auth_policy` entity.
+3. An `auth_policy` entity (emitted by the pattern extractor) shares the same source file.
+
+**Auth annotations recognised (per framework)**
+
+| Framework | Recognised markers |
+|-----------|-------------------|
+| Django | `@login_required`, `@permission_required`, `@user_passes_test` |
+| DRF | `permission_classes = [IsAuthenticated]` |
+| Flask | `@login_required`, `@jwt_required`, `@roles_required` |
+| FastAPI | `Depends(get_current_user)`, `Depends(oauth2_scheme)` |
+| Express | `requireAuth`, `authMiddleware`, `verifyToken`, `passport.authenticate` |
+| NestJS | `@UseGuards(JwtAuthGuard)` |
+| Spring | `@PreAuthorize`, `@Secured`, `@RolesAllowed` |
+| ASP.NET | `[Authorize]`, `[Authorize(Roles=...)]`, `[Authorize(Policy=...)]` |
+| Rails | `before_action :authenticate_user!` |
+
+**Severity rules**
+
+| Condition | Severity |
+|-----------|----------|
+| Auth present | `info` |
+| No auth + sensitive operation (payment/delete/admin/…) | `error` |
+| No auth + IDOR-risk path (`{user_id}`, `:account_id`, …) | `error` |
+| No auth + anything else | `warn` |
+
+**Default-allow vs default-deny**
+
+If ≥ 80 % of endpoints in a repo are covered, the repo is classified as `default-deny`
+(auth is the norm). Otherwise `default-allow` (auth is the exception — higher risk posture).
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `group` | string | no | inferred | Group name (registry key). |
+| `cwd` | string | no | — | CWD for group inference. |
+| `repo_filter` | string[] | no | all | Limit to specific repos. |
+| `only_missing` | bool | no | `false` | When true, return only endpoints where `has_auth=false`. |
+| `limit` | int | no | `200` | Max endpoints returned. |
+
+**Output**
+
+```json
+{
+  "endpoints": [
+    {
+      "entity_id": "myrepo::a1b2c3d4e5f6a7b8",
+      "name": "delete_user",
+      "repo": "myrepo",
+      "source_file": "api/users.py",
+      "start_line": 42,
+      "method": "DELETE",
+      "path": "/api/users/{user_id}",
+      "has_auth": false,
+      "auth_evidence": "",
+      "severity": "error",
+      "sensitive_op": true,
+      "idor_risk": true,
+      "sensitive_terms": "delete, user_id"
+    }
+  ],
+  "count": 1,
+  "total": 1,
+  "truncated": false,
+  "repo_summaries": [
+    {
+      "repo": "myrepo",
+      "total": 12,
+      "covered": 10,
+      "uncovered": 2,
+      "coverage_rate": 0.833,
+      "default_policy": "default-deny",
+      "error_count": 1,
+      "warn_count": 1
+    }
+  ],
+  "overall_coverage": 0.833,
+  "note": "..."
+}
+```
 
 ---
 

--- a/internal/mcp/auth_coverage.go
+++ b/internal/mcp/auth_coverage.go
@@ -1,0 +1,514 @@
+// auth_coverage.go — archigraph_auth_coverage MCP tool (#1314).
+//
+// # Purpose
+//
+// Walk every http_endpoint_definition entity in a group and determine whether
+// it is covered by an auth decorator / middleware.  Endpoints without auth are
+// surfaced as potential security vulnerabilities.
+//
+// # Detection strategy
+//
+// Auth coverage is determined by three complementary signals, evaluated in
+// order of decreasing reliability:
+//
+//  1. Graph edge — an auth_policy entity (emitted by the patterns/
+//     auth_endpoint_linker) shares the same source file as the endpoint.
+//     This is the strongest signal because the indexer explicitly linked the
+//     two via a common-file relationship.
+//
+//  2. Entity property — the endpoint entity itself carries an "auth_decorator"
+//     or "auth_middleware" property set by an extractor (future extractors may
+//     populate these directly).
+//
+//  3. TAGGED_AS edge — a TAGGED_AS relationship from the endpoint to an entity
+//     whose subtype or kind is "auth_policy".
+//
+// # Severity
+//
+// | Condition                                   | Severity |
+// |---------------------------------------------|----------|
+// | No auth + sensitive operation (write/pay)   | error    |
+// | No auth + accepts user_id param             | error    |
+// | No auth + any other endpoint                | warn     |
+// | Auth present                                | info     |
+//
+// Sensitive operation heuristics: endpoint name or path contains
+// "payment", "checkout", "password", "delete", "admin", "write", "create",
+// "update", "register", "reset".
+//
+// IDOR heuristic: HTTP verb is GET/POST/PUT/PATCH/DELETE and path contains
+// "{user_id}", ":user_id", or the endpoint properties contain "param:user_id".
+//
+// # Default-allow vs default-deny
+//
+// If ≥80 % of endpoints in a repo are covered, the repo is classified as
+// "default-deny" (auth is the norm).  Otherwise "default-allow" (auth is the
+// exception — higher risk posture).
+package mcp
+
+import (
+	"context"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Auth-pattern tables — per-framework annotation/middleware names considered
+// proof of authentication/authorisation protection.
+// ---------------------------------------------------------------------------
+
+// authAnnotationNames is the set of decorator / annotation names that, when
+// attached to an endpoint, constitute auth coverage.  Lookup is
+// case-insensitive.
+var authAnnotationNames = map[string]bool{
+	// Django
+	"login_required":       true,
+	"permission_required":  true,
+	"user_passes_test":     true,
+	"staff_member_required": true,
+	"superuser_required":   true,
+	// DRF
+	"permission_classes":   true,
+	"isauthenticated":      true,
+	"isadminuser":          true,
+	"isauthorizedorreadonly": true,
+	// Flask / Flask-Login / Flask-JWT-Extended
+	"jwt_required":      true,
+	"fresh_jwt_required": true,
+	"roles_required":    true,
+	"roles_accepted":    true,
+	// FastAPI
+	"get_current_user":        true,
+	"get_current_active_user": true,
+	"oauth2_scheme":           true,
+	"verify_token":            true,
+	"get_current_superuser":   true,
+	"authenticate":            true,
+	"require_auth":            true,
+	// Express / Node
+	"requireauth":     true,
+	"authmiddleware":  true,
+	"verifyjwt":       true,
+	"verifytoken":     true,
+	"jwtauthguard":    true,
+	"authguard":       true,
+	// NestJS
+	"useguards":       true,
+	// Spring
+	"preauthorize":    true,
+	"secured":         true,
+	"rolesallowed":    true,
+	// ASP.NET
+	"authorize":       true,
+	// Rails
+	"before_action":   true, // commonly used with authenticate_user!
+	"authenticate_user!": true,
+	// Generic
+	"auth":            true,
+	"authenticated":   true,
+	"authorized":      true,
+}
+
+// authPropertyKeys are entity property keys whose presence indicates auth.
+var authPropertyKeys = []string{
+	"auth_decorator",
+	"auth_middleware",
+	"auth_guard",
+	"annotation_name", // set by decorator_extractor
+}
+
+// authPropertyValues — for annotation_name property, these values signal auth.
+var authPropertyValues = authAnnotationNames
+
+// sensitiveTerms — endpoint name or path tokens that raise severity to error
+// when auth is absent.
+var sensitiveTerms = []string{
+	"payment", "checkout", "billing", "invoice",
+	"password", "passwd", "credential",
+	"admin", "superuser", "staff",
+	"delete", "remove", "destroy",
+	"register", "signup", "create",
+	"update", "write", "modify", "edit",
+	"reset", "token", "secret", "key",
+}
+
+// idorParams — path or param tokens that indicate user-scoped data, triggering
+// IDOR risk when auth is absent.
+var idorParams = []string{
+	"{user_id}", ":user_id", "user_id",
+	"{account_id}", ":account_id", "account_id",
+	"{owner_id}", ":owner_id", "owner_id",
+	"{member_id}", ":member_id",
+}
+
+// ---------------------------------------------------------------------------
+// handleAuthCoverage — the MCP tool handler
+// ---------------------------------------------------------------------------
+
+// handleAuthCoverage implements the archigraph_auth_coverage tool.
+func (s *Server) handleAuthCoverage(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	limit := argInt(req, "limit", 200)
+	onlyMissing := argBool(req, "only_missing", false)
+
+	type EndpointRecord struct {
+		EntityID       string `json:"entity_id"`
+		Name           string `json:"name"`
+		Repo           string `json:"repo"`
+		SourceFile     string `json:"source_file,omitempty"`
+		StartLine      int    `json:"start_line,omitempty"`
+		Method         string `json:"method,omitempty"`
+		Path           string `json:"path,omitempty"`
+		HasAuth        bool   `json:"has_auth"`
+		AuthEvidence   string `json:"auth_evidence,omitempty"`
+		Severity       string `json:"severity"`
+		SensitiveOp    bool   `json:"sensitive_op,omitempty"`
+		IDORRisk       bool   `json:"idor_risk,omitempty"`
+		SensitiveTerms string `json:"sensitive_terms,omitempty"`
+	}
+
+	type RepoSummary struct {
+		Repo           string `json:"repo"`
+		Total          int    `json:"total"`
+		Covered        int    `json:"covered"`
+		Uncovered      int    `json:"uncovered"`
+		CoverageRate   float64 `json:"coverage_rate"`
+		DefaultPolicy  string `json:"default_policy"` // "default-deny" or "default-allow"
+		ErrorCount     int    `json:"error_count"`
+		WarnCount      int    `json:"warn_count"`
+	}
+
+	var endpoints []EndpointRecord
+	var summaries []RepoSummary
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+
+		// Build a file -> []auth_policy_entity index for this repo.
+		// auth_policy entities are emitted by the patterns/auth_endpoint_linker
+		// as SCOPE.Config entities with subtype "auth_policy".
+		authPoliciesByFile := buildAuthPoliciesByFile(r.Doc)
+
+		// Build set of entity IDs reachable via TAGGED_AS edges to auth_policy.
+		taggedAuthIDs := buildTaggedAuthIDs(r.Doc)
+
+		repoTotal := 0
+		repoCovered := 0
+		repoErrors := 0
+		repoWarns := 0
+
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if !isDefinitionKind(e.Kind) {
+				continue
+			}
+			// Exclude client-synthesis call-side entries.
+			if e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+				continue
+			}
+
+			repoTotal++
+
+			hasAuth, evidence := determineAuthCoverage(e, authPoliciesByFile, taggedAuthIDs)
+
+			method := e.Properties["verb"]
+			path := e.Properties["path"]
+			sensitiveOp, sensitiveMatch := isSensitiveOperation(e.Name, path)
+			idorRisk := hasIDORRisk(path, e.Properties)
+
+			var severity string
+			switch {
+			case hasAuth:
+				severity = "info"
+			case sensitiveOp || idorRisk:
+				severity = "error"
+			default:
+				severity = "warn"
+			}
+
+			if hasAuth {
+				repoCovered++
+			} else {
+				switch severity {
+				case "error":
+					repoErrors++
+				case "warn":
+					repoWarns++
+				}
+			}
+
+			if onlyMissing && hasAuth {
+				continue
+			}
+
+			endpoints = append(endpoints, EndpointRecord{
+				EntityID:       prefixedID(r.Repo, e.ID),
+				Name:           e.Name,
+				Repo:           r.Repo,
+				SourceFile:     e.SourceFile,
+				StartLine:      e.StartLine,
+				Method:         method,
+				Path:           path,
+				HasAuth:        hasAuth,
+				AuthEvidence:   evidence,
+				Severity:       severity,
+				SensitiveOp:    sensitiveOp,
+				IDORRisk:       idorRisk,
+				SensitiveTerms: sensitiveMatch,
+			})
+		}
+
+		if repoTotal == 0 {
+			continue
+		}
+
+		coverageRate := float64(repoCovered) / float64(repoTotal)
+		defaultPolicy := "default-allow"
+		if coverageRate >= 0.80 {
+			defaultPolicy = "default-deny"
+		}
+
+		summaries = append(summaries, RepoSummary{
+			Repo:          r.Repo,
+			Total:         repoTotal,
+			Covered:       repoCovered,
+			Uncovered:     repoTotal - repoCovered,
+			CoverageRate:  coverageRate,
+			DefaultPolicy: defaultPolicy,
+			ErrorCount:    repoErrors,
+			WarnCount:     repoWarns,
+		})
+	}
+
+	// Sort endpoints: errors first, then warns, then info; within same severity
+	// sort by repo then source file then line.
+	sort.SliceStable(endpoints, func(i, j int) bool {
+		si := severityRank(endpoints[i].Severity)
+		sj := severityRank(endpoints[j].Severity)
+		if si != sj {
+			return si < sj
+		}
+		if endpoints[i].Repo != endpoints[j].Repo {
+			return endpoints[i].Repo < endpoints[j].Repo
+		}
+		if endpoints[i].SourceFile != endpoints[j].SourceFile {
+			return endpoints[i].SourceFile < endpoints[j].SourceFile
+		}
+		return endpoints[i].StartLine < endpoints[j].StartLine
+	})
+
+	total := len(endpoints)
+	if limit > 0 && len(endpoints) > limit {
+		endpoints = endpoints[:limit]
+	}
+
+	totalEndpoints := 0
+	totalCovered := 0
+	for _, s := range summaries {
+		totalEndpoints += s.Total
+		totalCovered += s.Covered
+	}
+
+	overallRate := 0.0
+	if totalEndpoints > 0 {
+		overallRate = float64(totalCovered) / float64(totalEndpoints)
+	}
+
+	return jsonResult(map[string]any{
+		"endpoints":        endpoints,
+		"count":            len(endpoints),
+		"total":            total,
+		"truncated":        total > len(endpoints),
+		"repo_summaries":   summaries,
+		"overall_coverage": overallRate,
+		"note": "has_auth=false with severity=error indicates an unprotected endpoint " +
+			"performing a sensitive operation or accepting user-scoped parameters (IDOR risk). " +
+			"has_auth=false with severity=warn indicates a potentially public endpoint — " +
+			"verify intentional exposure.",
+	}), nil
+}
+
+// ---------------------------------------------------------------------------
+// Auth detection helpers
+// ---------------------------------------------------------------------------
+
+// buildAuthPoliciesByFile builds a map from source file path → set of auth
+// evidence strings for auth_policy entities found in that file.
+func buildAuthPoliciesByFile(doc *graph.Document) map[string][]string {
+	result := make(map[string][]string)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if !isAuthPolicyEntity(e) {
+			continue
+		}
+		evidence := authEntityEvidence(e)
+		result[e.SourceFile] = append(result[e.SourceFile], evidence)
+	}
+	return result
+}
+
+// isAuthPolicyEntity reports whether an entity was emitted by the auth pattern
+// extractor (subtype == "auth_policy" or kind is SCOPE.Config with auth props).
+func isAuthPolicyEntity(e *graph.Entity) bool {
+	if e.Subtype == "auth_policy" {
+		return true
+	}
+	// Entities created by decorator_extractor for auth decorators have
+	// decorator_name set to a known auth annotation.
+	if dn := e.Properties["decorator_name"]; dn != "" {
+		if authAnnotationNames[strings.ToLower(dn)] {
+			return true
+		}
+	}
+	// annotation_name property set by auth_endpoint_linker
+	if an := e.Properties["annotation_name"]; an != "" {
+		return true
+	}
+	// middleware_name property set by auth_endpoint_linker
+	if mn := e.Properties["middleware_name"]; mn != "" {
+		return true
+	}
+	return false
+}
+
+// authEntityEvidence returns a human-readable evidence string for an auth
+// policy entity (e.g. "@login_required", "verifyToken").
+func authEntityEvidence(e *graph.Entity) string {
+	if an := e.Properties["annotation_name"]; an != "" {
+		return an
+	}
+	if mn := e.Properties["middleware_name"]; mn != "" {
+		return mn
+	}
+	if dn := e.Properties["decorator_name"]; dn != "" {
+		return "@" + dn
+	}
+	return e.Name
+}
+
+// buildTaggedAuthIDs returns the set of entity IDs that have a TAGGED_AS
+// relationship pointing to an auth_policy entity.
+func buildTaggedAuthIDs(doc *graph.Document) map[string]bool {
+	// Collect auth-policy entity IDs first.
+	authIDs := map[string]bool{}
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if isAuthPolicyEntity(e) {
+			authIDs[e.ID] = true
+		}
+	}
+
+	tagged := map[string]bool{}
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		if rel.Kind == "TAGGED_AS" && authIDs[rel.ToID] {
+			tagged[rel.FromID] = true
+		}
+	}
+	return tagged
+}
+
+// determineAuthCoverage checks three signals (in priority order) and returns
+// (hasAuth, evidenceDescription).
+func determineAuthCoverage(
+	e *graph.Entity,
+	authByFile map[string][]string,
+	taggedAuthIDs map[string]bool,
+) (bool, string) {
+	// Signal 1: entity property directly on the endpoint.
+	for _, k := range authPropertyKeys {
+		if v := e.Properties[k]; v != "" {
+			vl := strings.ToLower(v)
+			if k == "annotation_name" || k == "auth_decorator" || k == "auth_middleware" || k == "auth_guard" {
+				if authPropertyValues[vl] || k != "annotation_name" {
+					return true, k + "=" + v
+				}
+			}
+		}
+	}
+
+	// Signal 2: TAGGED_AS edge to auth_policy entity.
+	if taggedAuthIDs[e.ID] {
+		return true, "TAGGED_AS auth_policy"
+	}
+
+	// Signal 3: an auth_policy entity shares the same source file.
+	if evidences, ok := authByFile[e.SourceFile]; ok && len(evidences) > 0 {
+		return true, "file-level: " + strings.Join(deduplicateStrings(evidences), ", ")
+	}
+
+	return false, ""
+}
+
+// isSensitiveOperation reports whether an endpoint name or path suggests a
+// sensitive operation (payment, password change, admin, destructive write).
+// Returns (isSensitive, matchedTerms).
+func isSensitiveOperation(name, path string) (bool, string) {
+	haystack := strings.ToLower(name + " " + path)
+	var matches []string
+	seen := map[string]bool{}
+	for _, term := range sensitiveTerms {
+		if strings.Contains(haystack, term) && !seen[term] {
+			seen[term] = true
+			matches = append(matches, term)
+		}
+	}
+	if len(matches) > 0 {
+		return true, strings.Join(matches, ", ")
+	}
+	return false, ""
+}
+
+// hasIDORRisk returns true when the path or properties suggest a user-scoped
+// parameter that could be exploited for insecure direct object reference.
+func hasIDORRisk(path string, props map[string]string) bool {
+	pathLower := strings.ToLower(path)
+	for _, param := range idorParams {
+		if strings.Contains(pathLower, strings.ToLower(param)) {
+			return true
+		}
+	}
+	// Check properties for param markers
+	for k, v := range props {
+		if strings.Contains(strings.ToLower(k), "param") &&
+			strings.Contains(strings.ToLower(v), "user_id") {
+			return true
+		}
+	}
+	return false
+}
+
+// severityRank maps severity strings to an integer for sort ordering
+// (lower = higher priority / shown first).
+func severityRank(s string) int {
+	switch s {
+	case "error":
+		return 0
+	case "warn":
+		return 1
+	default:
+		return 2
+	}
+}
+
+// deduplicateStrings returns a deduplicated copy of ss preserving order.
+func deduplicateStrings(ss []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/mcp/auth_coverage_test.go
+++ b/internal/mcp/auth_coverage_test.go
@@ -1,0 +1,486 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+// buildAuthCoverageDoc builds a Document with a mix of protected and unprotected
+// HTTP endpoints plus auth_policy entities.
+//
+//	Endpoints
+//	  ep_login_required   — protected by file-level auth_policy (login_required)
+//	  ep_tagged_auth      — protected via TAGGED_AS edge to auth_policy
+//	  ep_prop_auth        — protected via auth_decorator property
+//	  ep_public           — no auth (severity: warn)
+//	  ep_delete_no_auth   — DELETE on /users/{user_id}, no auth (severity: error, IDOR+sensitive)
+//	  ep_payment_no_auth  — POST /checkout, no auth (severity: error, sensitive)
+//	  ep_call_site        — http_endpoint_call — should be excluded
+//
+//	Auth entities
+//	  auth_login_required  — subtype=auth_policy in same file as ep_login_required
+//	  auth_policy_tagged   — subtype=auth_policy, TAGGED_AS from ep_tagged_auth
+func buildAuthCoverageDoc() *graph.Document {
+	return &graph.Document{
+		Entities: []graph.Entity{
+			// Protected: shares source file with auth_policy entity.
+			{
+				ID: "ep_login_required", Name: "get_dashboard",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "views/dashboard.py", StartLine: 10,
+				Properties: map[string]string{"verb": "GET", "path": "/dashboard"},
+			},
+			// Protected: TAGGED_AS edge to auth_policy.
+			{
+				ID: "ep_tagged_auth", Name: "list_orders",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "routes/orders.py", StartLine: 20,
+				Properties: map[string]string{"verb": "GET", "path": "/orders"},
+			},
+			// Protected: auth_decorator property on entity itself.
+			{
+				ID: "ep_prop_auth", Name: "create_post",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "routes/posts.py", StartLine: 30,
+				Properties: map[string]string{
+					"verb":           "POST",
+					"path":           "/posts",
+					"auth_decorator": "jwt_required",
+				},
+			},
+			// Unprotected: no auth signal → severity warn.
+			{
+				ID: "ep_public", Name: "list_articles",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "routes/public.py", StartLine: 5,
+				Properties: map[string]string{"verb": "GET", "path": "/articles"},
+			},
+			// Unprotected: sensitive (delete) + IDOR ({user_id}) → severity error.
+			{
+				ID: "ep_delete_no_auth", Name: "delete_user",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "routes/users.py", StartLine: 42,
+				Properties: map[string]string{"verb": "DELETE", "path": "/users/{user_id}"},
+			},
+			// Unprotected: sensitive (payment/checkout) → severity error.
+			{
+				ID: "ep_payment_no_auth", Name: "checkout",
+				Kind:       "http_endpoint_definition",
+				SourceFile: "routes/billing.py", StartLine: 15,
+				Properties: map[string]string{"verb": "POST", "path": "/checkout"},
+			},
+			// Call-site — must NOT appear in auth coverage results.
+			{
+				ID: "ep_call_site", Name: "fetchOrders",
+				Kind:       "http_endpoint_call",
+				SourceFile: "services/order_service.py", StartLine: 8,
+				Properties: map[string]string{"verb": "GET", "path": "/orders"},
+			},
+			// Auth policy entity: shares file with ep_login_required.
+			{
+				ID: "auth_login_required", Name: "login_required@views/dashboard.py:9",
+				Kind:    "SCOPE.Config",
+				Subtype: "auth_policy",
+				SourceFile: "views/dashboard.py", StartLine: 9,
+				Properties: map[string]string{
+					"kind":           "auth_policy",
+					"annotation_name": "@login_required",
+					"middleware_name": "login_required",
+				},
+			},
+			// Auth policy entity: linked to ep_tagged_auth via TAGGED_AS.
+			{
+				ID: "auth_policy_tagged", Name: "auth_policy_nestjs_JwtAuthGuard",
+				Kind:    "SCOPE.Config",
+				Subtype: "auth_policy",
+				SourceFile: "routes/orders.py", StartLine: 18,
+				Properties: map[string]string{
+					"kind":           "auth_policy",
+					"annotation_name": "@UseGuards",
+					"middleware_name": "JwtAuthGuard",
+				},
+			},
+		},
+		Relationships: []graph.Relationship{
+			// TAGGED_AS: ep_tagged_auth → auth_policy_tagged (but ep_tagged_auth and
+			// auth_policy_tagged are in the same file anyway — test TAGGED_AS path too
+			// by using a separate file; file-level signal won't help here because
+			// ep_tagged_auth SourceFile != auth_policy_tagged SourceFile below — wait,
+			// they ARE equal in the fixture. Override by using a relationship only
+			// (TAGGED_AS detection runs before file-level detection, but file-level
+			// would also fire here). The TAGGED_AS path is exercised in TestAuthCoverage_TaggedAS.
+			{ID: "rel_tagged", FromID: "ep_tagged_auth", ToID: "auth_policy_tagged", Kind: "TAGGED_AS"},
+		},
+	}
+}
+
+func callAuthCoverageTool(t *testing.T, s *Server, args map[string]any) map[string]any {
+	t.Helper()
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = args
+	res, err := s.handleAuthCoverage(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil {
+		t.Fatal("nil result")
+	}
+	if res.IsError {
+		t.Fatalf("tool error: %v", res.Content)
+	}
+	var out map[string]any
+	for _, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		if err := json.Unmarshal([]byte(tc.Text), &out); err != nil {
+			t.Fatalf("unmarshal: %v", err)
+		}
+	}
+	return out
+}
+
+// endpointsByID extracts the endpoints array and indexes by entity_id suffix
+// (after "::" separator) for easy lookup in tests.
+func endpointsByID(t *testing.T, out map[string]any) map[string]map[string]any {
+	t.Helper()
+	eps, ok := out["endpoints"].([]any)
+	if !ok {
+		t.Fatalf("endpoints is %T, want []any", out["endpoints"])
+	}
+	result := make(map[string]map[string]any, len(eps))
+	for _, raw := range eps {
+		ep, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("endpoint entry is %T", raw)
+		}
+		id, _ := ep["entity_id"].(string)
+		// Strip the "repo1::" prefix.
+		if idx := len("repo1::"); len(id) > idx {
+			id = id[idx:]
+		}
+		result[id] = ep
+	}
+	return result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+func TestAuthCoverage_CallSitesExcluded(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+	if _, found := eps["ep_call_site"]; found {
+		t.Error("http_endpoint_call should not appear in auth coverage results")
+	}
+}
+
+func TestAuthCoverage_FileLevel_HasAuth(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+
+	ep, ok := eps["ep_login_required"]
+	if !ok {
+		t.Fatal("ep_login_required not found in results")
+	}
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("ep_login_required should have has_auth=true (file-level auth_policy)")
+	}
+	if sev, _ := ep["severity"].(string); sev != "info" {
+		t.Errorf("ep_login_required: want severity=info, got %q", sev)
+	}
+}
+
+func TestAuthCoverage_PropertyLevel_HasAuth(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+
+	ep, ok := eps["ep_prop_auth"]
+	if !ok {
+		t.Fatal("ep_prop_auth not found in results")
+	}
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("ep_prop_auth should have has_auth=true (auth_decorator property)")
+	}
+	if sev, _ := ep["severity"].(string); sev != "info" {
+		t.Errorf("ep_prop_auth: want severity=info, got %q", sev)
+	}
+}
+
+func TestAuthCoverage_Public_SeverityWarn(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+
+	ep, ok := eps["ep_public"]
+	if !ok {
+		t.Fatal("ep_public not found in results")
+	}
+	if hasAuth, _ := ep["has_auth"].(bool); hasAuth {
+		t.Errorf("ep_public should have has_auth=false")
+	}
+	if sev, _ := ep["severity"].(string); sev != "warn" {
+		t.Errorf("ep_public: want severity=warn, got %q", sev)
+	}
+}
+
+func TestAuthCoverage_DeleteWithIDOR_SeverityError(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+
+	ep, ok := eps["ep_delete_no_auth"]
+	if !ok {
+		t.Fatal("ep_delete_no_auth not found in results")
+	}
+	if hasAuth, _ := ep["has_auth"].(bool); hasAuth {
+		t.Errorf("ep_delete_no_auth should have has_auth=false")
+	}
+	if sev, _ := ep["severity"].(string); sev != "error" {
+		t.Errorf("ep_delete_no_auth: want severity=error, got %q", sev)
+	}
+	if idorRisk, _ := ep["idor_risk"].(bool); !idorRisk {
+		t.Errorf("ep_delete_no_auth: want idor_risk=true")
+	}
+	if sensitiveOp, _ := ep["sensitive_op"].(bool); !sensitiveOp {
+		t.Errorf("ep_delete_no_auth: want sensitive_op=true")
+	}
+}
+
+func TestAuthCoverage_PaymentEndpoint_SeverityError(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+
+	ep, ok := eps["ep_payment_no_auth"]
+	if !ok {
+		t.Fatal("ep_payment_no_auth not found in results")
+	}
+	if sev, _ := ep["severity"].(string); sev != "error" {
+		t.Errorf("ep_payment_no_auth: want severity=error, got %q", sev)
+	}
+	if sensitiveOp, _ := ep["sensitive_op"].(bool); !sensitiveOp {
+		t.Errorf("ep_payment_no_auth: want sensitive_op=true (checkout matches payment/checkout terms)")
+	}
+}
+
+func TestAuthCoverage_OnlyMissing(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{
+		"group":        "test",
+		"only_missing": true,
+	})
+	eps := endpointsByID(t, out)
+
+	// Protected endpoints must not appear.
+	for _, id := range []string{"ep_login_required", "ep_tagged_auth", "ep_prop_auth"} {
+		if _, found := eps[id]; found {
+			t.Errorf("only_missing=true: protected endpoint %q should be excluded", id)
+		}
+	}
+	// Unprotected endpoints must appear.
+	for _, id := range []string{"ep_public", "ep_delete_no_auth", "ep_payment_no_auth"} {
+		if _, found := eps[id]; !found {
+			t.Errorf("only_missing=true: unprotected endpoint %q should be present", id)
+		}
+	}
+}
+
+func TestAuthCoverage_RepoSummary(t *testing.T) {
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+
+	summaries, ok := out["repo_summaries"].([]any)
+	if !ok || len(summaries) == 0 {
+		t.Fatal("expected non-empty repo_summaries")
+	}
+	summary := summaries[0].(map[string]any)
+
+	total := int(summary["total"].(float64))
+	covered := int(summary["covered"].(float64))
+	uncovered := int(summary["uncovered"].(float64))
+
+	// 6 definition endpoints (ep_call_site excluded), 3 covered, 3 uncovered.
+	if total != 6 {
+		t.Errorf("total: want 6, got %d", total)
+	}
+	if covered != 3 {
+		t.Errorf("covered: want 3, got %d", covered)
+	}
+	if uncovered != 3 {
+		t.Errorf("uncovered: want 3, got %d", uncovered)
+	}
+
+	// 3/6 = 50% < 80% → default-allow
+	policy, _ := summary["default_policy"].(string)
+	if policy != "default-allow" {
+		t.Errorf("default_policy: want default-allow, got %q", policy)
+	}
+
+	errorCount := int(summary["error_count"].(float64))
+	warnCount := int(summary["warn_count"].(float64))
+	if errorCount != 2 {
+		t.Errorf("error_count: want 2, got %d", errorCount)
+	}
+	if warnCount != 1 {
+		t.Errorf("warn_count: want 1, got %d", warnCount)
+	}
+}
+
+func TestAuthCoverage_DefaultDeny(t *testing.T) {
+	// Build a repo where ≥80% of endpoints are protected.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			// 4 protected (via file-level auth_policy), 1 unprotected → 80% → default-deny.
+			{
+				ID: "e1", Kind: "http_endpoint_definition",
+				SourceFile: "views/a.py", Name: "view_a",
+				Properties: map[string]string{"verb": "GET", "path": "/a"},
+			},
+			{
+				ID: "e2", Kind: "http_endpoint_definition",
+				SourceFile: "views/a.py", Name: "view_b",
+				Properties: map[string]string{"verb": "GET", "path": "/b"},
+			},
+			{
+				ID: "e3", Kind: "http_endpoint_definition",
+				SourceFile: "views/a.py", Name: "view_c",
+				Properties: map[string]string{"verb": "GET", "path": "/c"},
+			},
+			{
+				ID: "e4", Kind: "http_endpoint_definition",
+				SourceFile: "views/a.py", Name: "view_d",
+				Properties: map[string]string{"verb": "GET", "path": "/d"},
+			},
+			{
+				ID: "e5", Kind: "http_endpoint_definition",
+				SourceFile: "views/public.py", Name: "public_view",
+				Properties: map[string]string{"verb": "GET", "path": "/public"},
+			},
+			// auth_policy in views/a.py covers e1-e4.
+			{
+				ID: "auth1", Kind: "SCOPE.Config", Subtype: "auth_policy",
+				SourceFile: "views/a.py", Name: "login_required@views/a.py:1",
+				Properties: map[string]string{"middleware_name": "login_required"},
+			},
+		},
+	}
+	s := newTestServerWithDoc(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+
+	summaries, _ := out["repo_summaries"].([]any)
+	if len(summaries) == 0 {
+		t.Fatal("expected non-empty repo_summaries")
+	}
+	policy, _ := summaries[0].(map[string]any)["default_policy"].(string)
+	if policy != "default-deny" {
+		t.Errorf("want default-deny (80%% coverage), got %q", policy)
+	}
+}
+
+func TestAuthCoverage_TaggedAS(t *testing.T) {
+	// Endpoint in a DIFFERENT file than the auth_policy entity, but linked via TAGGED_AS.
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{
+				ID: "ep1", Kind: "http_endpoint_definition",
+				SourceFile: "routes/api.py", Name: "protected_endpoint",
+				Properties: map[string]string{"verb": "GET", "path": "/protected"},
+			},
+			{
+				ID: "auth1", Kind: "SCOPE.Config", Subtype: "auth_policy",
+				SourceFile: "middleware/auth.py", Name: "JwtAuthGuard",
+				Properties: map[string]string{"middleware_name": "JwtAuthGuard"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel1", FromID: "ep1", ToID: "auth1", Kind: "TAGGED_AS"},
+		},
+	}
+	s := newTestServerWithDoc(t, doc)
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps := endpointsByID(t, out)
+	ep, ok := eps["ep1"]
+	if !ok {
+		t.Fatal("ep1 not found in results")
+	}
+	if hasAuth, _ := ep["has_auth"].(bool); !hasAuth {
+		t.Errorf("ep1 should have has_auth=true (TAGGED_AS auth_policy)")
+	}
+}
+
+func TestAuthCoverage_SensitiveTermDetection(t *testing.T) {
+	cases := []struct {
+		name, path string
+		wantSens   bool
+		wantTerm   string
+	}{
+		{"checkout", "/api/checkout", true, "checkout"},
+		{"change_password", "/api/password/change", true, "password"},
+		{"admin_panel", "/admin/users", true, "admin"},
+		{"list_articles", "/articles", false, ""},
+		{"delete_comment", "/comments/123", true, "delete"},
+	}
+
+	for _, tc := range cases {
+		got, match := isSensitiveOperation(tc.name, tc.path)
+		if got != tc.wantSens {
+			t.Errorf("isSensitiveOperation(%q, %q) = %v, want %v", tc.name, tc.path, got, tc.wantSens)
+		}
+		if tc.wantSens && tc.wantTerm != "" && match == "" {
+			t.Errorf("isSensitiveOperation(%q, %q): expected match containing %q, got %q",
+				tc.name, tc.path, tc.wantTerm, match)
+		}
+	}
+}
+
+func TestAuthCoverage_IDORRiskDetection(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		{"/api/users/{user_id}", true},
+		{"/api/users/:user_id", true},
+		{"/api/accounts/{account_id}", true},
+		{"/api/posts/123", false},
+		{"/api/items", false},
+	}
+
+	for _, tc := range cases {
+		got := hasIDORRisk(tc.path, nil)
+		if got != tc.want {
+			t.Errorf("hasIDORRisk(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestAuthCoverage_SeverityOrdering(t *testing.T) {
+	// Errors must appear before warns, warns before infos.
+	s := newTestServerWithDoc(t, buildAuthCoverageDoc())
+	out := callAuthCoverageTool(t, s, map[string]any{"group": "test"})
+	eps, _ := out["endpoints"].([]any)
+
+	lastRank := -1
+	for _, raw := range eps {
+		ep := raw.(map[string]any)
+		sev, _ := ep["severity"].(string)
+		rank := severityRank(sev)
+		if rank < lastRank {
+			t.Errorf("severity ordering violated: %q (rank %d) came after rank %d", sev, rank, lastRank)
+		}
+		lastRank = rank
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,7 +103,7 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 29 (#1281: 9→4 bundles; #1293: desc trim; #1312: +archigraph_quality_cycles).
+// Tool count: 30 (#1281: 9→4 bundles; #1293: desc trim; #1312: +archigraph_quality_cycles; #1314: +archigraph_auth_coverage).
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
 //   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 func (s *Server) registerTools() {
@@ -424,6 +424,20 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_quality_cycles", s.handleQualityCycles))
+
+	// archigraph_auth_coverage — security audit (#1314).
+	// Walk all http_endpoint_definition entities and flag those without auth
+	// decorators/middleware.  Severity: error (sensitive/IDOR), warn (public), info (covered).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_auth_coverage",
+		mcpapi.WithDescription("Security audit: list HTTP endpoints and flag those missing auth decorators or middleware. "+
+			"Returns has_auth, severity (error/warn/info), IDOR risk, and sensitive-operation flags per endpoint. "+
+			"error = unprotected sensitive operation or IDOR risk; warn = potentially public endpoint; info = auth present."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithBoolean("only_missing", mcpapi.DefaultBool(false)),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_auth_coverage", s.handleAuthCoverage))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -582,6 +582,7 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_impact_radius",
 		"archigraph_summarize_subgraph",
 		"archigraph_find_dead_code",
+		"archigraph_auth_coverage",
 		// recent activity
 		"archigraph_recent_activity",
 	}
@@ -630,9 +631,9 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 29 (28 pre-#1312 + archigraph_quality_cycles).
-	if got := len(srv.MCP.ListTools()); got != 29 {
-		t.Errorf("expected 29 registered tools, got %d", got)
+	// Total count: 30 (28 pre-#1312 + archigraph_quality_cycles + archigraph_auth_coverage).
+	if got := len(srv.MCP.ListTools()); got != 30 {
+		t.Errorf("expected 30 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Adds `archigraph_auth_coverage`, a new MCP security-audit tool that walks every `http_endpoint_definition` in a group and flags those not covered by auth decorators or middleware.

**Three detection signals** (evaluated in priority order):
1. Entity property — `auth_decorator` / `auth_middleware` / `auth_guard` on the endpoint itself
2. `TAGGED_AS` edge — relationship from the endpoint to an `auth_policy` entity
3. File-level co-location — an `auth_policy` entity (emitted by `patterns/auth_endpoint_linker`) shares the same source file

**Per-framework auth patterns recognised:** Django (`@login_required`, `@permission_required`), DRF (`permission_classes = [IsAuthenticated]`), Flask (`@login_required`, `@jwt_required`), FastAPI (`Depends(get_current_user)`), Express (`verifyToken`, `passport.authenticate`), NestJS (`@UseGuards`), Spring (`@PreAuthorize`, `@Secured`, `@RolesAllowed`), ASP.NET (`[Authorize]`), Rails (`before_action :authenticate_user!`)

**Severity rules:**
| Condition | Severity |
|-----------|----------|
| Auth present | `info` |
| No auth + sensitive op (payment / delete / admin / password) | `error` |
| No auth + IDOR-risk path ({user_id}, :account_id, ...) | `error` |
| No auth + anything else | `warn` |

**Default-allow vs default-deny classification:** repos where 80%+ of endpoints are covered are `default-deny`; others are `default-allow` (higher risk, surfaced in `repo_summaries`).

**Files changed:**
- `internal/mcp/auth_coverage.go` — new tool handler + all detection helpers
- `internal/mcp/auth_coverage_test.go` — 13 tests covering all detection signals, severity rules, IDOR/sensitive detection, `only_missing` filter, repo summary, ordering
- `internal/mcp/server.go` — register `archigraph_auth_coverage`
- `internal/mcp/server_test.go` — update tool count (28 to 29) and `wantPresent` list
- `internal/mcp/SCHEMA.md` — full schema documentation for the new tool

## Closes / Refs
- Closes #1314

## Testing
- [x] All tests pass: `go test ./internal/mcp/... -count=1` — ok (13 new, 0 regressions)
- [x] Relevant fixtures verified (file-level, TAGGED_AS, property, only_missing, repo summary)
- [x] No regression in cross-language parity

## Notes
- Auth detection is conservative: the file-level signal (auth_policy entity in same file as endpoint) fires correctly for the common pattern where decorators live adjacent to routes, but may produce false positives in large mixed files. A future issue can refine to line-range proximity.
- Recommended agent workflow: `archigraph_auth_coverage(group=..., only_missing=true)` to enumerate `error` entries and prioritise for immediate remediation.