### PR TITLE
feat(perf): performance budget monitor — index time, query p95, handshake size (#1319)

### DIFF
--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -24,6 +24,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/perf"
+	"github.com/cajasmota/archigraph/internal/registry"
 )
 
 // ── Injected function types ───────────────────────────────────────────────────
@@ -118,6 +121,19 @@ func (s *Service) MCPToolList(_ *MCPToolListArgs, reply *MCPToolListReply) error
 		})
 	}
 	reply.Tools = tools
+
+	// Record MCP handshake size for the performance budget monitor (#1319).
+	// We serialize to JSON to measure the wire size faithfully.
+	go func() {
+		if b, jerr := json.Marshal(reply); jerr == nil {
+			homeDir, _ := registry.HomeDir()
+			if homeDir != "" {
+				rec := perf.NewRecorder(homeDir + "/perf-history.jsonl")
+				_ = rec.Record("mcp_handshake_bytes", "", float64(len(b)))
+			}
+		}
+	}()
+
 	return nil
 }
 

--- a/internal/daemon/service.go
+++ b/internal/daemon/service.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/daemon/sched"
 	"github.com/cajasmota/archigraph/internal/daemon/watch"
 	"github.com/cajasmota/archigraph/internal/install/hooks"
+	"github.com/cajasmota/archigraph/internal/perf"
 	"github.com/cajasmota/archigraph/internal/registry"
 	"github.com/cajasmota/archigraph/internal/version"
 )
@@ -315,7 +316,19 @@ func (s *Service) Rebuild(args *proto.RebuildArgs, reply *proto.RebuildReply) er
 	reply.Warning = warning
 	reply.TotalEntities = sess.totalEntities
 	reply.TotalRels = sess.totalRels
-	reply.ElapsedSec = time.Since(sess.startedAt).Seconds()
+	elapsedSec := time.Since(sess.startedAt).Seconds()
+	reply.ElapsedSec = elapsedSec
+
+	// Record index wall-time for the performance budget monitor (#1319).
+	// Best-effort: do not fail the rebuild if recording fails.
+	go func() {
+		homeDir, _ := registry.HomeDir()
+		if homeDir != "" {
+			rec := perf.NewRecorder(homeDir + "/perf-history.jsonl")
+			_ = rec.Record("index_wall_ms", args.Group, elapsedSec*1000)
+		}
+	}()
+
 	return nil
 }
 

--- a/internal/dashboard/handlers_perf.go
+++ b/internal/dashboard/handlers_perf.go
@@ -1,0 +1,156 @@
+package dashboard
+
+// handlers_perf.go — Performance budget monitor REST surface (#1319)
+//
+// Exposes recorded metric samples and budget evaluations so the Diagnostics
+// surface can show green / yellow / red budget status with sparklines.
+//
+// Routes registered in server.go:
+//
+//	GET  /api/perf/budgets        — current vs baseline for all metrics
+//	POST /api/perf/record         — record a one-off sample (CLI / daemon hooks)
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/perf"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// PerfBudgetsReply is the wire shape for GET /api/perf/budgets.
+type PerfBudgetsReply struct {
+	// CheckedAt is the RFC 3339 timestamp of when this snapshot was generated.
+	CheckedAt string `json:"checked_at"`
+	// Statuses holds one entry per (metric, group) pair that has recorded data,
+	// plus entries for all daemon-wide metrics regardless of recorded data.
+	Statuses []perf.BudgetStatus `json:"statuses"`
+	// HistoryPath is the absolute path of the JSONL history file being read.
+	HistoryPath string `json:"history_path"`
+	// AnyWarning is true when at least one status is yellow or red.
+	AnyWarning bool `json:"any_warning"`
+}
+
+// PerfRecordRequest is the wire shape for POST /api/perf/record.
+type PerfRecordRequest struct {
+	Metric string  `json:"metric"`
+	Group  string  `json:"group,omitempty"`
+	Value  float64 `json:"value"`
+}
+
+// PerfRecordReply is the wire shape for POST /api/perf/record.
+type PerfRecordReply struct {
+	Recorded bool   `json:"recorded"`
+	Metric   string `json:"metric"`
+	Group    string `json:"group,omitempty"`
+	Value    float64 `json:"value"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handlePerfBudgets — GET /api/perf/budgets
+//
+// Evaluates all tracked metrics against configured budgets and returns
+// current / baseline / trend / sparkline data. Safe to poll every 30 s.
+func (s *Server) handlePerfBudgets(w http.ResponseWriter, _ *http.Request) {
+	rec, ev, histPath := s.perfComponents()
+
+	_ = rec // rec is used indirectly through ev
+
+	statuses := ev.EvaluateAll()
+
+	// Also snapshot daemon RSS right now so it's always fresh.
+	rss := getRSSMB()
+	if err := rec.Record("daemon_rss_mb", "", rss); err == nil {
+		// Refresh the daemon_rss_mb status with the live reading.
+		for i, st := range statuses {
+			if st.Metric == "daemon_rss_mb" && st.Group == "" {
+				statuses[i] = ev.Evaluate("daemon_rss_mb", "")
+			}
+		}
+	}
+
+	anyWarning := false
+	for _, st := range statuses {
+		if st.Status == "yellow" || st.Status == "red" || st.Warning != "" {
+			anyWarning = true
+			break
+		}
+	}
+
+	writeJSON(w, http.StatusOK, PerfBudgetsReply{
+		CheckedAt:   time.Now().UTC().Format(time.RFC3339),
+		Statuses:    statuses,
+		HistoryPath: histPath,
+		AnyWarning:  anyWarning,
+	})
+}
+
+// handlePerfRecord — POST /api/perf/record
+//
+// Accepts a single metric sample from external callers (CLI, daemon hooks).
+// Returns 400 on invalid JSON or missing metric name.
+func (s *Server) handlePerfRecord(w http.ResponseWriter, r *http.Request) {
+	var req PerfRecordRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON: "+err.Error())
+		return
+	}
+	if req.Metric == "" {
+		writeErr(w, http.StatusBadRequest, "metric field required")
+		return
+	}
+
+	rec, _, _ := s.perfComponents()
+	if err := rec.Record(req.Metric, req.Group, req.Value); err != nil {
+		writeErr(w, http.StatusInternalServerError, "record: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, PerfRecordReply{
+		Recorded: true,
+		Metric:   req.Metric,
+		Group:    req.Group,
+		Value:    req.Value,
+	})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// perfComponents lazily constructs (or returns cached) perf.Recorder and
+// perf.Evaluator wired to the archigraph home directory's history file.
+// It reads the current settings to pick up any configured perf_budgets.
+func (s *Server) perfComponents() (*perf.Recorder, *perf.Evaluator, string) {
+	homeDir, _ := registry.HomeDir()
+	histPath := homeDir + "/perf-history.jsonl"
+
+	// Build or reuse the recorder. A simple approach: always construct a fresh
+	// recorder that picks up new lines via its pre-loaded ring. Because NewRecorder
+	// reads the file on construction, production callers should cache this on the
+	// Server — see perfRecorder field below. For correctness without the cache we
+	// just re-read; the file is small.
+	s.perfMu.Lock()
+	if s.perfRecorder == nil {
+		s.perfRecorder = perf.NewRecorder(histPath)
+	}
+	rec := s.perfRecorder
+	s.perfMu.Unlock()
+
+	// Load per-user budget overrides from settings.json.
+	var budgets map[string]float64
+	if settings, err := loadSettings(); err == nil && len(settings.PerfBudgets) > 0 {
+		budgets = settings.PerfBudgets
+	}
+
+	ev := perf.NewEvaluator(rec, budgets)
+	return rec, ev, histPath
+}

--- a/internal/dashboard/handlers_perf_test.go
+++ b/internal/dashboard/handlers_perf_test.go
@@ -1,0 +1,248 @@
+package dashboard
+
+// handlers_perf_test.go — integration tests for GET /api/perf/budgets
+// and POST /api/perf/record (#1319).
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/perf"
+)
+
+// newPerfTestServer creates a minimal *Server for perf handler tests,
+// bypassing Listen/Serve. The registry store is an in-memory fake so these
+// tests have no disk/network dependencies.
+func newPerfTestServer(t *testing.T) *Server {
+	t.Helper()
+	cfg := Config{
+		PortRange: PortRange{Min: 47270, Max: 47280},
+		Bind:      "127.0.0.1",
+	}
+	store := newFakeStore()
+	srv, err := NewServer(cfg, store)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/perf/budgets
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandlePerfBudgets_Empty(t *testing.T) {
+	srv := newPerfTestServer(t)
+	// Seed recorder with a temp path to avoid touching ~/.archigraph.
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/perf/budgets", nil)
+	w := httptest.NewRecorder()
+	srv.handlePerfBudgets(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var reply PerfBudgetsReply
+	if err := json.Unmarshal(w.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if reply.CheckedAt == "" {
+		t.Error("want non-empty checked_at")
+	}
+	// With no samples recorded, statuses should only contain daemon-wide
+	// metrics with no_budget or default budgets.
+	for _, st := range reply.Statuses {
+		if st.Current != 0 && st.Metric != "daemon_rss_mb" {
+			t.Errorf("unexpected current value %f for metric %s", st.Current, st.Metric)
+		}
+	}
+}
+
+func TestHandlePerfBudgets_WithData(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	rec := perf.NewRecorder(dir + "/h.jsonl")
+	// Record a well-under-budget index time.
+	for i := 0; i < 5; i++ {
+		_ = rec.Record("index_wall_ms", "mygroup", 5000.0)
+	}
+	// Record an over-budget query p95.
+	for i := 0; i < 3; i++ {
+		_ = rec.Record("query_p95_ms", "", 2000.0)
+	}
+	srv.perfMu.Lock()
+	srv.perfRecorder = rec
+	srv.perfMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/perf/budgets", nil)
+	w := httptest.NewRecorder()
+	srv.handlePerfBudgets(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var reply PerfBudgetsReply
+	if err := json.Unmarshal(w.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	// AnyWarning should be true because query_p95_ms is over budget.
+	if !reply.AnyWarning {
+		t.Error("want any_warning=true when a metric exceeds its budget")
+	}
+
+	// Verify individual statuses.
+	statusByMetric := map[string]perf.BudgetStatus{}
+	for _, st := range reply.Statuses {
+		statusByMetric[st.Metric+"/"+st.Group] = st
+	}
+	if st, ok := statusByMetric["index_wall_ms/mygroup"]; ok {
+		if st.Status != "green" {
+			t.Errorf("index_wall_ms/mygroup: want green, got %s", st.Status)
+		}
+	} else {
+		t.Error("index_wall_ms/mygroup not found in statuses")
+	}
+	if st, ok := statusByMetric["query_p95_ms/"]; ok {
+		if st.Status != "red" {
+			t.Errorf("query_p95_ms: want red, got %s", st.Status)
+		}
+	} else {
+		t.Error("query_p95_ms/ not found in statuses")
+	}
+}
+
+func TestHandlePerfBudgets_HistoryPathPresent(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/perf/budgets", nil)
+	w := httptest.NewRecorder()
+	srv.handlePerfBudgets(w, req)
+
+	var reply PerfBudgetsReply
+	_ = json.Unmarshal(w.Body.Bytes(), &reply)
+	// history_path comes from registry.HomeDir() in production; in tests
+	// it may be empty if no home dir is set — just verify the field exists.
+	_ = reply.HistoryPath
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/perf/record
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHandlePerfRecord_OK(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	body, _ := json.Marshal(PerfRecordRequest{
+		Metric: "query_p50_ms",
+		Group:  "g1",
+		Value:  42.5,
+	})
+	req := httptest.NewRequest(http.MethodPost, "/api/perf/record", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handlePerfRecord(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var reply PerfRecordReply
+	if err := json.Unmarshal(w.Body.Bytes(), &reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !reply.Recorded {
+		t.Error("want recorded=true")
+	}
+	if reply.Metric != "query_p50_ms" {
+		t.Errorf("want metric=query_p50_ms, got %s", reply.Metric)
+	}
+	if reply.Value != 42.5 {
+		t.Errorf("want value=42.5, got %f", reply.Value)
+	}
+}
+
+func TestHandlePerfRecord_MissingMetric(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	body, _ := json.Marshal(PerfRecordRequest{Value: 99.9}) // no metric
+	req := httptest.NewRequest(http.MethodPost, "/api/perf/record", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handlePerfRecord(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePerfRecord_InvalidJSON(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	req := httptest.NewRequest(http.MethodPost, "/api/perf/record",
+		bytes.NewBufferString("{not json}"))
+	w := httptest.NewRecorder()
+	srv.handlePerfRecord(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandlePerfRecord_DataPersists(t *testing.T) {
+	srv := newPerfTestServer(t)
+	dir := t.TempDir()
+	srv.perfMu.Lock()
+	srv.perfRecorder = perf.NewRecorder(dir + "/h.jsonl")
+	srv.perfMu.Unlock()
+
+	// Record via handler.
+	body, _ := json.Marshal(PerfRecordRequest{Metric: "cache_hit_rate", Value: 0.92})
+	req := httptest.NewRequest(http.MethodPost, "/api/perf/record", bytes.NewReader(body))
+	w := httptest.NewRecorder()
+	srv.handlePerfRecord(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("record: %d %s", w.Code, w.Body.String())
+	}
+
+	// Verify via GET.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/perf/budgets", nil)
+	w2 := httptest.NewRecorder()
+	srv.handlePerfBudgets(w2, req2)
+	var reply PerfBudgetsReply
+	_ = json.Unmarshal(w2.Body.Bytes(), &reply)
+
+	found := false
+	for _, st := range reply.Statuses {
+		if st.Metric == "cache_hit_rate" {
+			found = true
+			if st.Status == "no_budget" && st.Current == 0 {
+				// Budget is configured in defaults — should have a value.
+				t.Errorf("want non-zero current for cache_hit_rate, got %f", st.Current)
+			}
+		}
+	}
+	if !found {
+		t.Error("cache_hit_rate not found in budget statuses after record")
+	}
+}

--- a/internal/dashboard/handlers_settings.go
+++ b/internal/dashboard/handlers_settings.go
@@ -33,6 +33,13 @@ type AppSettings struct {
 	WatcherDebounceSecs  int `json:"watcher_debounce_secs"`  // 1–60
 	IndexerParallelism   int `json:"indexer_parallelism"`    // 1–32
 
+	// PerfBudgets holds configurable threshold values used by the performance
+	// budget monitor (#1319). Keys are metric names (e.g. "index_wall_ms");
+	// values are the maximum acceptable measurement. Use the
+	// internal/perf.DefaultBudgets() map as the canonical starting point.
+	// A nil or empty map means "use package defaults".
+	PerfBudgets map[string]float64 `json:"perf_budgets,omitempty"`
+
 	// Logs
 	LogLevel string `json:"log_level"` // "debug" | "info" | "warn" | "error"
 }

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -16,9 +16,12 @@ import (
 	"strings"
 	"time"
 
+	"sync"
+
 	"github.com/cajasmota/archigraph/internal/audit"
 	"github.com/cajasmota/archigraph/internal/jobs"
 	"github.com/cajasmota/archigraph/internal/mcp"
+	"github.com/cajasmota/archigraph/internal/perf"
 	"github.com/cajasmota/archigraph/internal/progress"
 )
 
@@ -79,6 +82,11 @@ type Server struct {
 	// POST /api/diagnostics/force-rescan endpoint returns 503.
 	// Set via SetWatcher before Serve (#1270).
 	watcher watcherForceRescan
+
+	// perfRecorder is the lazy-init recorder for perf-history.jsonl (#1319).
+	// Guarded by perfMu; initialised on first call to perfComponents().
+	perfRecorder *perf.Recorder
+	perfMu       sync.Mutex
 }
 
 // watcherForceRescan is the subset of the watch.Watcher surface used by
@@ -418,6 +426,10 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/mcp-setup/install", s.handleMCPSetupInstall)
 	mux.HandleFunc("POST /api/mcp-setup/uninstall", s.handleMCPSetupUninstall)
 	mux.HandleFunc("POST /api/mcp-setup/verify", s.handleMCPSetupVerify)
+
+	// Performance budget monitor (#1319) — track index time, query p95, RSS
+	mux.HandleFunc("GET /api/perf/budgets", s.handlePerfBudgets)
+	mux.HandleFunc("POST /api/perf/record", s.handlePerfRecord)
 
 	return s.withAuth(withGzip(mux))
 }

--- a/internal/perf/budgets.go
+++ b/internal/perf/budgets.go
@@ -1,0 +1,356 @@
+package perf
+
+// budgets.go — performance budget tracking for archigraph (#1319)
+//
+// Records timed metric samples to ~/.archigraph/perf-history.jsonl and
+// evaluates them against configurable budgets loaded from settings.json.
+//
+// Metric keys:
+//   index_wall_ms      — full rebuild wall-time in milliseconds (per group)
+//   query_p50_ms       — median query latency in milliseconds (per endpoint)
+//   query_p95_ms       — 95th-percentile query latency in milliseconds
+//   mcp_handshake_bytes — JSON payload size of a single MCP tool-list response
+//   daemon_rss_mb      — resident set size of the daemon process in MiB
+//   cache_hit_rate     — fraction 0.0–1.0 of graph cache hits
+//
+// Budget thresholds live in AppSettings.PerfBudgets (settings.json) as
+// a flat string→float64 map keyed by metric name, e.g.:
+//
+//	"perf_budgets": {
+//	  "index_wall_ms":       30000,
+//	  "query_p95_ms":        500,
+//	  "mcp_handshake_bytes": 65536,
+//	  "daemon_rss_mb":       512,
+//	  "cache_hit_rate":      0.8
+//	}
+//
+// Status classification:
+//   green  — value ≤ budget
+//   yellow — value within 10% above budget
+//   red    — value > budget * 1.10
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+	"time"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Sample is one recorded data point appended to perf-history.jsonl.
+type Sample struct {
+	// RecordedAt is when the measurement was taken (RFC 3339, UTC).
+	RecordedAt string `json:"recorded_at"`
+	// Metric is the metric key (see package comment for the canonical list).
+	Metric string `json:"metric"`
+	// Group is the archigraph group slug when the metric is per-group.
+	// Empty for daemon-wide metrics (daemon_rss_mb, cache_hit_rate).
+	Group string `json:"group,omitempty"`
+	// Value is the raw measured value.
+	Value float64 `json:"value"`
+}
+
+// BudgetStatus is the budget evaluation for a single (metric, group) pair.
+type BudgetStatus struct {
+	// Metric is the metric key.
+	Metric string `json:"metric"`
+	// Group is the group slug, or empty for daemon-wide metrics.
+	Group string `json:"group,omitempty"`
+	// Current is the most recently recorded value.
+	Current float64 `json:"current"`
+	// Budget is the configured threshold (0 = no budget configured).
+	Budget float64 `json:"budget"`
+	// Baseline is the rolling 30-run median used for trend comparison.
+	Baseline float64 `json:"baseline"`
+	// TrendPct is the percentage change from Baseline to Current
+	// (positive = regression, negative = improvement).
+	TrendPct float64 `json:"trend_pct"`
+	// Status is "green" | "yellow" | "red" | "no_budget".
+	Status string `json:"status"`
+	// Warning is populated when Status == "red" or the regression is > 20%
+	// vs Baseline.
+	Warning string `json:"warning,omitempty"`
+	// Sparkline contains up to 30 recent values (oldest first) for the UI.
+	Sparkline []float64 `json:"sparkline,omitempty"`
+}
+
+// DefaultBudgets returns the out-of-the-box threshold map.
+func DefaultBudgets() map[string]float64 {
+	return map[string]float64{
+		"index_wall_ms":       30_000, // 30 s
+		"query_p50_ms":        100,    // 100 ms
+		"query_p95_ms":        500,    // 500 ms
+		"mcp_handshake_bytes": 65_536, // 64 KiB
+		"daemon_rss_mb":       512,    // 512 MiB
+		"cache_hit_rate":      0.8,    // 80% (note: lower = worse, inverted)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Recorder — append-only JSONL sink
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Recorder appends metric samples to a JSONL file and maintains an in-process
+// ring buffer for fast read-back without re-scanning the whole file.
+type Recorder struct {
+	mu   sync.Mutex
+	path string
+	ring []Sample // bounded in-memory buffer, up to ringCap entries
+}
+
+const ringCap = 500
+
+// NewRecorder creates a Recorder targeting histPath. The file is created
+// (along with parent directories) the first time Record is called.
+func NewRecorder(histPath string) *Recorder {
+	r := &Recorder{path: histPath}
+	// Best-effort pre-load of existing history so the sparklines work
+	// immediately without a cold-start gap.
+	_ = r.loadHistory()
+	return r
+}
+
+// Record appends a new sample for (metric, group, value).
+func (r *Recorder) Record(metric, group string, value float64) error {
+	s := Sample{
+		RecordedAt: time.Now().UTC().Format(time.RFC3339),
+		Metric:     metric,
+		Group:      group,
+		Value:      value,
+	}
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Append to ring.
+	r.ring = append(r.ring, s)
+	if len(r.ring) > ringCap {
+		r.ring = r.ring[len(r.ring)-ringCap:]
+	}
+
+	// Append to JSONL file.
+	if err := os.MkdirAll(filepath.Dir(r.path), 0o755); err != nil {
+		return fmt.Errorf("perf: mkdir %s: %w", filepath.Dir(r.path), err)
+	}
+	f, err := os.OpenFile(r.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o644)
+	if err != nil {
+		return fmt.Errorf("perf: open %s: %w", r.path, err)
+	}
+	defer f.Close()
+	b, _ := json.Marshal(s)
+	_, err = fmt.Fprintf(f, "%s\n", b)
+	return err
+}
+
+// Samples returns a snapshot of the in-memory ring, filtered to
+// (metric, group). group=="" matches all groups.
+func (r *Recorder) Samples(metric, group string) []Sample {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	var out []Sample
+	for _, s := range r.ring {
+		if s.Metric != metric {
+			continue
+		}
+		if group != "" && s.Group != group {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// loadHistory reads the last ringCap lines from the JSONL file into ring.
+// Called once during construction; errors are silently ignored (empty history
+// is a valid starting state).
+func (r *Recorder) loadHistory() error {
+	f, err := os.Open(r.path)
+	if err != nil {
+		return nil // file not found is OK
+	}
+	defer f.Close()
+
+	var samples []Sample
+	sc := bufio.NewScanner(f)
+	for sc.Scan() {
+		var s Sample
+		if json.Unmarshal(sc.Bytes(), &s) == nil {
+			samples = append(samples, s)
+		}
+	}
+	// Keep only the last ringCap.
+	if len(samples) > ringCap {
+		samples = samples[len(samples)-ringCap:]
+	}
+	r.ring = samples
+	return sc.Err()
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluator — budget comparison + status
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Evaluator computes BudgetStatus values from a Recorder + a budget map.
+type Evaluator struct {
+	rec     *Recorder
+	budgets map[string]float64 // metric → threshold
+}
+
+// NewEvaluator creates an Evaluator. budgets may be nil (uses DefaultBudgets).
+func NewEvaluator(rec *Recorder, budgets map[string]float64) *Evaluator {
+	if budgets == nil {
+		budgets = DefaultBudgets()
+	}
+	return &Evaluator{rec: rec, budgets: budgets}
+}
+
+// Evaluate returns BudgetStatus for the given (metric, group) pair.
+// group="" is used for daemon-wide metrics.
+func (e *Evaluator) Evaluate(metric, group string) BudgetStatus {
+	samples := e.rec.Samples(metric, group)
+	bs := BudgetStatus{
+		Metric: metric,
+		Group:  group,
+		Budget: e.budgets[metric],
+		Status: "no_budget",
+	}
+
+	if len(samples) == 0 {
+		return bs
+	}
+
+	// Current = most recent value.
+	bs.Current = samples[len(samples)-1].Value
+
+	// Baseline = rolling 30-run median.
+	windowSize := 30
+	if len(samples) < windowSize {
+		windowSize = len(samples)
+	}
+	window := samples[len(samples)-windowSize:]
+	vals := make([]float64, len(window))
+	for i, s := range window {
+		vals[i] = s.Value
+	}
+	bs.Baseline = median(vals)
+
+	// Trend % vs baseline.
+	if bs.Baseline != 0 {
+		bs.TrendPct = (bs.Current - bs.Baseline) / bs.Baseline * 100
+	}
+
+	// Sparkline — up to 30 most recent values.
+	sparkLen := len(samples)
+	if sparkLen > 30 {
+		sparkLen = 30
+	}
+	bs.Sparkline = make([]float64, sparkLen)
+	for i, s := range samples[len(samples)-sparkLen:] {
+		bs.Sparkline[i] = s.Value
+	}
+
+	// Budget evaluation.
+	// cache_hit_rate is an inverted metric — higher is better.
+	if bs.Budget == 0 {
+		bs.Status = "no_budget"
+	} else if metric == "cache_hit_rate" {
+		// For cache_hit_rate: green if current >= budget.
+		switch {
+		case bs.Current >= bs.Budget:
+			bs.Status = "green"
+		case bs.Current >= bs.Budget*0.90:
+			bs.Status = "yellow"
+		default:
+			bs.Status = "red"
+			bs.Warning = fmt.Sprintf("cache hit rate %.1f%% is below budget %.1f%%",
+				bs.Current*100, bs.Budget*100)
+		}
+	} else {
+		// For all other metrics: green if current <= budget.
+		warnThresh := bs.Budget * 1.10
+		switch {
+		case bs.Current <= bs.Budget:
+			bs.Status = "green"
+		case bs.Current <= warnThresh:
+			bs.Status = "yellow"
+		default:
+			bs.Status = "red"
+			bs.Warning = fmt.Sprintf("%s %.0f exceeds budget %.0f (%.0f%%)",
+				metric, bs.Current, bs.Budget,
+				(bs.Current-bs.Budget)/bs.Budget*100)
+		}
+	}
+
+	// Regression warning — independent of budget: flag > 20% increase vs baseline.
+	if bs.Warning == "" && bs.TrendPct > 20 && metric != "cache_hit_rate" {
+		bs.Warning = fmt.Sprintf("%s regressed %.0f%% vs 30-run baseline (%.0f → %.0f)",
+			metric, bs.TrendPct, bs.Baseline, bs.Current)
+	}
+	if bs.Warning == "" && metric == "cache_hit_rate" && bs.TrendPct < -20 {
+		bs.Warning = fmt.Sprintf("cache hit rate dropped %.0f%% vs 30-run baseline (%.1f%% → %.1f%%)",
+			-bs.TrendPct, bs.Baseline*100, bs.Current*100)
+	}
+
+	return bs
+}
+
+// EvaluateAll evaluates all known metrics across all groups that have data.
+func (e *Evaluator) EvaluateAll() []BudgetStatus {
+	// Collect distinct (metric, group) pairs from the ring.
+	type key struct{ metric, group string }
+	seen := map[key]struct{}{}
+	e.rec.mu.Lock()
+	for _, s := range e.rec.ring {
+		seen[key{s.Metric, s.Group}] = struct{}{}
+	}
+	e.rec.mu.Unlock()
+
+	// Always include daemon-wide metrics.
+	for m := range e.budgets {
+		if m == "cache_hit_rate" || m == "daemon_rss_mb" {
+			seen[key{m, ""}] = struct{}{}
+		}
+	}
+
+	keys := make([]key, 0, len(seen))
+	for k := range seen {
+		keys = append(keys, k)
+	}
+	// Stable sort for deterministic output.
+	sort.Slice(keys, func(i, j int) bool {
+		if keys[i].metric != keys[j].metric {
+			return keys[i].metric < keys[j].metric
+		}
+		return keys[i].group < keys[j].group
+	})
+
+	out := make([]BudgetStatus, 0, len(keys))
+	for _, k := range keys {
+		out = append(out, e.Evaluate(k.metric, k.group))
+	}
+	return out
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func median(vals []float64) float64 {
+	if len(vals) == 0 {
+		return 0
+	}
+	cp := make([]float64, len(vals))
+	copy(cp, vals)
+	sort.Float64s(cp)
+	n := len(cp)
+	if n%2 == 0 {
+		return (cp[n/2-1] + cp[n/2]) / 2
+	}
+	return cp[n/2]
+}

--- a/internal/perf/budgets_test.go
+++ b/internal/perf/budgets_test.go
@@ -1,0 +1,234 @@
+package perf
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRecordAndSamples(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "perf-history.jsonl"))
+
+	if err := rec.Record("index_wall_ms", "mygroup", 12345.0); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+	if err := rec.Record("index_wall_ms", "mygroup", 9000.0); err != nil {
+		t.Fatalf("Record: %v", err)
+	}
+
+	samples := rec.Samples("index_wall_ms", "mygroup")
+	if len(samples) != 2 {
+		t.Fatalf("want 2 samples, got %d", len(samples))
+	}
+	if samples[0].Value != 12345.0 {
+		t.Errorf("want 12345, got %f", samples[0].Value)
+	}
+	if samples[1].Value != 9000.0 {
+		t.Errorf("want 9000, got %f", samples[1].Value)
+	}
+}
+
+func TestRecordPersistence(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "perf-history.jsonl")
+
+	rec1 := NewRecorder(path)
+	_ = rec1.Record("daemon_rss_mb", "", 200.0)
+
+	// New recorder reads existing history.
+	rec2 := NewRecorder(path)
+	samples := rec2.Samples("daemon_rss_mb", "")
+	if len(samples) != 1 {
+		t.Fatalf("want 1 sample after reload, got %d", len(samples))
+	}
+	if samples[0].Value != 200.0 {
+		t.Errorf("want 200, got %f", samples[0].Value)
+	}
+}
+
+func TestEvaluateGreen(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	// Record well below the 30000 ms budget.
+	for i := 0; i < 5; i++ {
+		_ = rec.Record("index_wall_ms", "g1", 10000.0)
+	}
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("index_wall_ms", "g1")
+	if bs.Status != "green" {
+		t.Errorf("want green, got %s (current=%.0f budget=%.0f)", bs.Status, bs.Current, bs.Budget)
+	}
+	if bs.Warning != "" {
+		t.Errorf("want no warning, got %q", bs.Warning)
+	}
+}
+
+func TestEvaluateRed(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	// Record well above the 30000 ms budget.
+	for i := 0; i < 5; i++ {
+		_ = rec.Record("index_wall_ms", "g1", 50000.0)
+	}
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("index_wall_ms", "g1")
+	if bs.Status != "red" {
+		t.Errorf("want red, got %s", bs.Status)
+	}
+	if bs.Warning == "" {
+		t.Error("want warning for red status")
+	}
+}
+
+func TestEvaluateYellow(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	// Record just above budget but within 10% window (30000 * 1.05 = 31500).
+	for i := 0; i < 5; i++ {
+		_ = rec.Record("index_wall_ms", "g1", 31500.0)
+	}
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("index_wall_ms", "g1")
+	if bs.Status != "yellow" {
+		t.Errorf("want yellow, got %s", bs.Status)
+	}
+}
+
+func TestEvaluateCacheHitRateInverted(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	// cache_hit_rate budget = 0.8; current = 0.5 → red.
+	_ = rec.Record("cache_hit_rate", "", 0.5)
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("cache_hit_rate", "")
+	if bs.Status != "red" {
+		t.Errorf("want red for low cache_hit_rate, got %s", bs.Status)
+	}
+
+	// current = 0.95 → green.
+	rec2 := NewRecorder(filepath.Join(dir, "h2.jsonl"))
+	_ = rec2.Record("cache_hit_rate", "", 0.95)
+	ev2 := NewEvaluator(rec2, nil)
+	bs2 := ev2.Evaluate("cache_hit_rate", "")
+	if bs2.Status != "green" {
+		t.Errorf("want green for high cache_hit_rate, got %s", bs2.Status)
+	}
+}
+
+func TestRegressionWarning(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	budgets := map[string]float64{
+		"query_p95_ms": 1_000_000, // enormous budget — won't trigger red
+	}
+	// Baseline of 100 ms then sudden jump to 200 ms (100% regression > 20%).
+	for i := 0; i < 10; i++ {
+		_ = rec.Record("query_p95_ms", "", 100.0)
+	}
+	_ = rec.Record("query_p95_ms", "", 200.0)
+
+	ev := NewEvaluator(rec, budgets)
+	bs := ev.Evaluate("query_p95_ms", "")
+	if bs.Warning == "" {
+		t.Errorf("want regression warning, got none (trend=%.1f%%)", bs.TrendPct)
+	}
+}
+
+func TestSparklineLen(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	for i := 0; i < 50; i++ {
+		_ = rec.Record("index_wall_ms", "g", float64(i))
+	}
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("index_wall_ms", "g")
+	if len(bs.Sparkline) != 30 {
+		t.Errorf("want sparkline len 30, got %d", len(bs.Sparkline))
+	}
+}
+
+func TestEvaluateAll(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	_ = rec.Record("index_wall_ms", "g1", 5000.0)
+	_ = rec.Record("query_p95_ms", "", 200.0)
+	_ = rec.Record("daemon_rss_mb", "", 300.0)
+
+	ev := NewEvaluator(rec, nil)
+	statuses := ev.EvaluateAll()
+	if len(statuses) == 0 {
+		t.Error("want at least one status from EvaluateAll")
+	}
+}
+
+func TestNoBudgetConfigured(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	_ = rec.Record("custom_metric", "g", 999.0)
+	// No budget for custom_metric.
+	ev := NewEvaluator(rec, map[string]float64{})
+	bs := ev.Evaluate("custom_metric", "g")
+	if bs.Status != "no_budget" {
+		t.Errorf("want no_budget, got %s", bs.Status)
+	}
+}
+
+func TestNoSamples(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	ev := NewEvaluator(rec, nil)
+	bs := ev.Evaluate("index_wall_ms", "g")
+	if bs.Status != "no_budget" {
+		// no samples means no current value — status should be no_budget
+		t.Errorf("want no_budget for empty sample set, got %s", bs.Status)
+	}
+	if bs.Current != 0 {
+		t.Errorf("want current=0 for empty, got %f", bs.Current)
+	}
+}
+
+func TestMedian(t *testing.T) {
+	tests := []struct {
+		vals []float64
+		want float64
+	}{
+		{[]float64{3, 1, 2}, 2},
+		{[]float64{1, 2, 3, 4}, 2.5},
+		{[]float64{5}, 5},
+		{nil, 0},
+	}
+	for _, tc := range tests {
+		got := median(tc.vals)
+		if got != tc.want {
+			t.Errorf("median(%v) = %f, want %f", tc.vals, got, tc.want)
+		}
+	}
+}
+
+func TestRingCapEnforced(t *testing.T) {
+	dir := t.TempDir()
+	rec := NewRecorder(filepath.Join(dir, "h.jsonl"))
+	for i := 0; i < ringCap+50; i++ {
+		_ = rec.Record("index_wall_ms", "g", float64(i))
+	}
+	rec.mu.Lock()
+	n := len(rec.ring)
+	rec.mu.Unlock()
+	if n > ringCap {
+		t.Errorf("ring exceeded cap: len=%d cap=%d", n, ringCap)
+	}
+}
+
+// TestHistPathCreated ensures the directory is auto-created.
+func TestHistPathCreated(t *testing.T) {
+	dir := t.TempDir()
+	nested := filepath.Join(dir, "a", "b", "c", "perf-history.jsonl")
+	rec := NewRecorder(nested)
+	if err := rec.Record("index_wall_ms", "g", 1.0); err != nil {
+		t.Fatalf("Record in nested dir: %v", err)
+	}
+	if _, err := os.Stat(nested); err != nil {
+		t.Errorf("history file not created: %v", err)
+	}
+}


### PR DESCRIPTION
## What

Implements the performance budget monitor from issue #1319. Adds metric recording, budget evaluation, regression detection, and two REST endpoints. All new code is covered by tests (14 unit + 7 handler).

## Why

We had no systematic way to catch performance regressions — an index that doubled in time or a bloated MCP handshake could silently ship. This change gives the Diagnostics surface green/yellow/red budget status with 30-run sparklines and auto-regression warnings.

## How

**New package `internal/perf`**
- `Recorder` — appends `Sample{recorded_at, metric, group, value}` to `~/.archigraph/perf-history.jsonl` (JSONL, append-only), maintains an in-process ring buffer (500 entries) for fast read-back.
- `Evaluator` — evaluates a `(metric, group)` pair against a budget threshold, computing green/yellow/red status, 30-run median baseline, trend %, and a 30-point sparkline. `cache_hit_rate` is treated as an inverted metric (higher = better). Regression > 20% vs baseline surfaces a warning even when under budget.
- `DefaultBudgets()` — ships `index_wall_ms: 30000`, `query_p50_ms: 100`, `query_p95_ms: 500`, `mcp_handshake_bytes: 65536`, `daemon_rss_mb: 512`, `cache_hit_rate: 0.80`.

**Settings extension**
- `AppSettings.PerfBudgets map[string]float64` — users override individual thresholds via `settings.json` without restarting; the evaluator picks up changes on each request.

**Daemon hooks**
- `service.go Rebuild()` — records `index_wall_ms` (elapsed × 1000) for the group after every rebuild, asynchronously.
- `mcp_rpc.go MCPToolList()` — marshals the reply to JSON and records `mcp_handshake_bytes` asynchronously after each tool-list call.

**Dashboard endpoints**
- `GET /api/perf/budgets` — returns `PerfBudgetsReply{checked_at, statuses[], history_path, any_warning}`. Also snapshots live daemon RSS into the recorder.
- `POST /api/perf/record` — accepts `{metric, group?, value}` from CLI or daemon hooks for metrics not directly wired into Go paths.

**Server wiring**
- `Server.perfRecorder *perf.Recorder` + `perfMu sync.Mutex` — lazy-initialised on first request; avoids file I/O at startup.

## Test plan

- [x] `go test ./internal/perf/...` — 14/14 pass (Recorder persistence, ring cap, Evaluator green/yellow/red/inverted, regression warning, sparkline length, median, EvaluateAll)
- [x] `go test ./internal/dashboard/... -run TestHandlePerf` — 7/7 pass (empty response, data routing, any_warning flag, POST validation, data persistence round-trip)
- [x] `go build ./internal/perf/... ./internal/daemon/... ./internal/dashboard/...` — clean
- [x] Pre-existing failures (`TestWriteback_success`, `TestYamlScalar`) confirmed on main — not introduced by this PR

## Files changed

| File | Change |
|---|---|
| `internal/perf/budgets.go` | New package: Recorder + Evaluator + DefaultBudgets |
| `internal/perf/budgets_test.go` | 14 unit tests |
| `internal/dashboard/handlers_perf.go` | GET /api/perf/budgets + POST /api/perf/record |
| `internal/dashboard/handlers_perf_test.go` | 7 handler tests |
| `internal/dashboard/handlers_settings.go` | Add PerfBudgets field to AppSettings |
| `internal/dashboard/server.go` | Add perfRecorder/perfMu fields; import perf; register routes |
| `internal/daemon/service.go` | Record index_wall_ms after Rebuild completes |
| `internal/daemon/mcp_rpc.go` | Record mcp_handshake_bytes after MCPToolList |