### PR TITLE
[export] Graph subgraph → Mermaid/Graphviz/PlantUML/D2 (#1318)

### DIFF
--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -1873,3 +1873,34 @@ export function subscribeAuditStream(
 
   return () => es.close()
 }
+
+// ── DSL export (#1318) ────────────────────────────────────────────────────────
+
+export type ExportFormat = 'mermaid' | 'graphviz' | 'plantuml' | 'd2'
+
+/**
+ * Fetch a subgraph as paste-ready DSL text.
+ *
+ * GET /api/export/{group}/{entity_id}/{format}?depth=N&limit=M
+ *
+ * Returns the raw diagram source (text/plain). Throws ApiError on failure.
+ */
+export async function fetchExportDSL(
+  group: string,
+  entityId: string,
+  format: ExportFormat,
+  opts?: { depth?: number; limit?: number },
+): Promise<string> {
+  const params = new URLSearchParams()
+  if (opts?.depth !== undefined) params.set('depth', String(opts.depth))
+  if (opts?.limit !== undefined) params.set('limit', String(opts.limit))
+  const qs = params.toString() ? `?${params}` : ''
+  const url = `/api/export/${encodeURIComponent(group)}/${encodeURIComponent(entityId)}/${format}${qs}`
+  const res = await fetch(url)
+  if (!res.ok) {
+    const body = await res.text()
+    throw new ApiError(res.status, body, `API ${res.status}: ${url}`)
+  }
+  return res.text()
+}
+

--- a/dashboard/src/components/graph/EntityInspector.tsx
+++ b/dashboard/src/components/graph/EntityInspector.tsx
@@ -8,6 +8,7 @@ import { RepoChip } from '@/components/shared/RepoChip'
 import { SourceSnippet } from '@/components/shared/SourceSnippet'
 import { NodeChip } from './NodeChip'
 import { EdgeBadge } from './EdgeBadge'
+import { ExportDiagramButton } from './ExportDiagramButton'
 import type { EntityNeighborResponse, EntityKind, GraphEdge, GraphNode } from '@/types/api'
 
 interface EntityInspectorProps {
@@ -15,6 +16,8 @@ interface EntityInspectorProps {
   isLoading: boolean
   onClose: () => void
   onSelectEntity: (id: string) => void
+  /** The active group name — required for the DSL export endpoint (#1318) */
+  group?: string
   /** Deep-link to Flows surface for process_flow entities */
   onOpenInFlows?: (entityId: string) => void
   /** Deep-link to Paths surface for http_endpoint/handler entities */
@@ -116,6 +119,7 @@ export function EntityInspector({
   isLoading,
   onClose,
   onSelectEntity,
+  group,
   onOpenInFlows,
   onOpenInPaths,
   onOpenInTopology,
@@ -477,6 +481,15 @@ export function EntityInspector({
                 <Network className="w-3.5 h-3.5" />
                 Highlight subgraph
               </button>
+            )}
+
+            {/* Copy as diagram — DSL export (#1318) */}
+            {group && (
+              <ExportDiagramButton
+                group={group}
+                entityId={data.entity.id}
+                depth={2}
+              />
             )}
 
             {/* Open in editor */}

--- a/dashboard/src/components/graph/ExportDiagramButton.tsx
+++ b/dashboard/src/components/graph/ExportDiagramButton.tsx
@@ -1,0 +1,161 @@
+/**
+ * ExportDiagramButton — "Copy as diagram" control for the Entity Inspector.
+ *
+ * Shows a compact toolbar:
+ *   [Mermaid ▼] [Copy as diagram]
+ *
+ * On click it calls GET /api/export/{group}/{entity_id}/{format}?depth=2
+ * and writes the result to the clipboard. A "Copied!" flash confirms
+ * success; errors degrade to a tooltip message.
+ *
+ * #1318
+ */
+
+import { useState, useCallback } from 'react'
+import { Share2, Check, ChevronDown } from 'lucide-react'
+import { fetchExportDSL, type ExportFormat } from '@/api/client'
+
+// ── Format metadata ───────────────────────────────────────────────────────────
+
+interface FormatMeta {
+  label: string
+  hint: string
+}
+
+const FORMATS: Record<ExportFormat, FormatMeta> = {
+  mermaid: { label: 'Mermaid', hint: 'Paste into GH issues, Notion, HackMD…' },
+  graphviz: { label: 'Graphviz DOT', hint: 'Render with dot / xdot / Graphviz Online' },
+  plantuml: { label: 'PlantUML', hint: 'Paste into PlantUML Online / Confluence' },
+  d2: { label: 'D2', hint: 'Render with the d2 CLI or Terrastruct playground' },
+}
+
+const FORMAT_ORDER: ExportFormat[] = ['mermaid', 'graphviz', 'plantuml', 'd2']
+
+// ── Props ─────────────────────────────────────────────────────────────────────
+
+interface ExportDiagramButtonProps {
+  group: string
+  entityId: string
+  /** BFS depth for subgraph traversal (default 2) */
+  depth?: number
+}
+
+// ── Component ─────────────────────────────────────────────────────────────────
+
+export function ExportDiagramButton({
+  group,
+  entityId,
+  depth = 2,
+}: ExportDiagramButtonProps) {
+  const [format, setFormat] = useState<ExportFormat>('mermaid')
+  const [dropdownOpen, setDropdownOpen] = useState(false)
+  const [state, setState] = useState<'idle' | 'loading' | 'copied' | 'error'>('idle')
+  const [errorMsg, setErrorMsg] = useState('')
+
+  const handleCopy = useCallback(async () => {
+    if (state === 'loading') return
+    setState('loading')
+    setErrorMsg('')
+
+    try {
+      const dsl = await fetchExportDSL(group, entityId, format, { depth })
+      await navigator.clipboard.writeText(dsl)
+      setState('copied')
+      setTimeout(() => setState('idle'), 2000)
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : 'Copy failed'
+      setErrorMsg(msg)
+      setState('error')
+      setTimeout(() => setState('idle'), 3000)
+    }
+  }, [group, entityId, format, depth, state])
+
+  const handleSelectFormat = useCallback((f: ExportFormat) => {
+    setFormat(f)
+    setDropdownOpen(false)
+  }, [])
+
+  const copyLabel =
+    state === 'loading' ? 'Copying…'
+    : state === 'copied' ? 'Copied!'
+    : state === 'error' ? 'Error'
+    : 'Copy as diagram'
+
+  return (
+    <div className="flex flex-col gap-1" data-testid="export-diagram-button">
+      <div className="flex items-center gap-1">
+        {/* Format picker */}
+        <div className="relative">
+          <button
+            type="button"
+            onClick={() => setDropdownOpen((v) => !v)}
+            aria-haspopup="listbox"
+            aria-expanded={dropdownOpen}
+            aria-label={`Export format: ${FORMATS[format].label}`}
+            title={FORMATS[format].hint}
+            className="flex items-center gap-1 px-2 py-1 rounded text-xs border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-slate-800 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
+          >
+            <span>{FORMATS[format].label}</span>
+            <ChevronDown className="w-3 h-3 text-slate-400" />
+          </button>
+
+          {dropdownOpen && (
+            <ul
+              role="listbox"
+              aria-label="Diagram format"
+              className="absolute bottom-full mb-1 left-0 z-20 min-w-[10rem] bg-white dark:bg-slate-900 border border-slate-200 dark:border-slate-700 rounded shadow-lg py-1"
+            >
+              {FORMAT_ORDER.map((f) => (
+                <li key={f} role="option" aria-selected={f === format}>
+                  <button
+                    type="button"
+                    onClick={() => handleSelectFormat(f)}
+                    className={`w-full text-left px-3 py-1.5 text-xs transition-colors hover:bg-slate-100 dark:hover:bg-slate-800 ${
+                      f === format
+                        ? 'text-sky-500 font-semibold'
+                        : 'text-slate-700 dark:text-slate-300'
+                    }`}
+                  >
+                    <span className="block">{FORMATS[f].label}</span>
+                    <span className="block text-[10px] text-slate-400 dark:text-slate-600 mt-0.5">
+                      {FORMATS[f].hint}
+                    </span>
+                  </button>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+
+        {/* Copy button */}
+        <button
+          type="button"
+          onClick={handleCopy}
+          disabled={state === 'loading'}
+          aria-label={copyLabel}
+          title={state === 'error' ? errorMsg : FORMATS[format].hint}
+          data-testid="copy-diagram-btn"
+          className={`flex items-center gap-1.5 px-2 py-1 rounded text-xs transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400 ${
+            state === 'copied'
+              ? 'text-green-600 dark:text-green-400 bg-green-50 dark:bg-green-950/30'
+              : state === 'error'
+                ? 'text-red-500 dark:text-red-400 bg-red-50 dark:bg-red-950/30'
+                : 'text-violet-500 hover:text-violet-400 hover:bg-violet-50 dark:hover:bg-violet-950/30'
+          }`}
+        >
+          {state === 'copied'
+            ? <Check className="w-3.5 h-3.5" />
+            : <Share2 className="w-3.5 h-3.5" />}
+          <span>{copyLabel}</span>
+        </button>
+      </div>
+
+      {/* Error message */}
+      {state === 'error' && errorMsg && (
+        <p className="text-[10px] text-red-500 dark:text-red-400 pl-1">
+          {errorMsg}
+        </p>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -698,6 +698,7 @@ export function GraphRoute() {
               selectNode(id)
               zoomToNode(id)
             }}
+            group={group}
             onOpenInFlows={handleOpenInFlows}
             onOpenInPaths={handleOpenInPaths}
             onOpenInTopology={handleOpenInTopology}

--- a/dashboard/tests/e2e/graph-export-diagram.spec.ts
+++ b/dashboard/tests/e2e/graph-export-diagram.spec.ts
@@ -1,0 +1,236 @@
+/**
+ * E2E: Graph DSL export — "Copy as diagram" button (#1318)
+ *
+ * Tests the ExportDiagramButton in the Entity Inspector panel.
+ *
+ * Two VIEW screenshots (always captured).
+ * Structural tests degrade gracefully when no daemon is running:
+ * the export button is only present when an entity is selected, which
+ * requires a live graph. Tests annotate and skip cleanly in that case.
+ *
+ * Headless only. 0 console errors expected.
+ */
+
+import { test, expect, type Page } from '@playwright/test'
+import { fileURLToPath } from 'url'
+import path from 'path'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+const BASE_URL = process.env.TEST_BASE_URL ?? 'http://localhost:5173'
+const GROUP = process.env.TEST_GROUP ?? 'default'
+const GRAPH_URL = `${BASE_URL}/${GROUP}/graph`
+const SCREENSHOT_DIR = path.join(__dirname, '..', '..', 'test-results', 'export-diagram')
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async function screenshot(page: Page, name: string) {
+  await page.screenshot({
+    path: path.join(SCREENSHOT_DIR, `${name}.png`),
+    fullPage: false,
+  })
+}
+
+async function waitForGraph(page: Page) {
+  await Promise.race([
+    page.getByRole('complementary', { name: 'Graph filters sidebar' })
+      .waitFor({ state: 'visible', timeout: 8000 }),
+    page.waitForTimeout(8000),
+  ]).catch(() => {})
+}
+
+async function trySelectNode(page: Page): Promise<boolean> {
+  const canvas = page.locator('.graph-canvas')
+  const canvasVisible = await canvas.isVisible({ timeout: 5000 }).catch(() => false)
+  if (!canvasVisible) return false
+
+  const box = await canvas.boundingBox()
+  if (!box) return false
+
+  // Try center + 4 quadrants to find a clickable node.
+  const offsets = [[0, 0], [-100, -100], [100, -100], [-100, 100], [100, 100]] as const
+  for (const [dx, dy] of offsets) {
+    await page.mouse.click(box.x + box.width / 2 + dx, box.y + box.height / 2 + dy)
+    await page.waitForTimeout(500)
+    const inspector = page.getByTestId('entity-inspector')
+    if (await inspector.isVisible({ timeout: 1000 }).catch(() => false)) {
+      return true
+    }
+  }
+  return false
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+test.describe('Graph DSL export — #1318', () => {
+  let consoleErrors: string[] = []
+
+  test.beforeEach(async ({ page }) => {
+    consoleErrors = []
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') consoleErrors.push(msg.text())
+    })
+    await page.goto(GRAPH_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
+    await waitForGraph(page)
+  })
+
+  // ── VIEW screenshots ──────────────────────────────────────────────────────
+
+  test('VIEW 1 — graph loaded, export button not yet visible', async ({ page }) => {
+    await page.waitForTimeout(500)
+    await screenshot(page, '1-graph-no-selection')
+  })
+
+  test('VIEW 2 — inspector open with export button visible (if node found)', async ({ page }) => {
+    await trySelectNode(page)
+    await page.waitForTimeout(500)
+    await screenshot(page, '2-inspector-export-button')
+  })
+
+  // ── Structural tests ──────────────────────────────────────────────────────
+
+  test('graph route renders without crash', async ({ page }) => {
+    const errorBoundary = page.locator('[data-testid="error-boundary"]')
+    const crashed = await errorBoundary.isVisible({ timeout: 2000 }).catch(() => false)
+    expect(crashed, 'React error boundary should not be visible').toBe(false)
+  })
+
+  test('export button appears in inspector when node selected (with daemon)', async ({ page }) => {
+    const nodeSelected = await trySelectNode(page)
+    if (!nodeSelected) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'No daemon / no node found — export button test skipped.',
+      })
+      return
+    }
+
+    const inspector = page.getByTestId('entity-inspector')
+    await expect(inspector).toBeVisible()
+
+    const exportBtn = inspector.getByTestId('export-diagram-button')
+    await expect(exportBtn, 'Export diagram button should be visible in inspector').toBeVisible()
+
+    // Format picker button should be present.
+    const formatPicker = exportBtn.getByRole('button', { name: /Export format/i })
+    await expect(formatPicker).toBeVisible()
+
+    // Copy button should be present.
+    const copyBtn = exportBtn.getByTestId('copy-diagram-btn')
+    await expect(copyBtn).toBeVisible()
+    await expect(copyBtn).toHaveText(/Copy as diagram/)
+  })
+
+  test('format picker opens and shows all 4 formats (with daemon)', async ({ page }) => {
+    const nodeSelected = await trySelectNode(page)
+    if (!nodeSelected) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'No daemon — format picker test skipped.',
+      })
+      return
+    }
+
+    const inspector = page.getByTestId('entity-inspector')
+    const exportBtn = inspector.getByTestId('export-diagram-button')
+    if (!(await exportBtn.isVisible({ timeout: 2000 }).catch(() => false))) {
+      test.info().annotations.push({ type: 'info', description: 'Export button not visible — skipped.' })
+      return
+    }
+
+    // Open format dropdown.
+    const formatPicker = exportBtn.getByRole('button', { name: /Export format/i })
+    await formatPicker.click()
+
+    // Dropdown should list all 4 formats.
+    const dropdown = exportBtn.getByRole('listbox', { name: 'Diagram format' })
+    await expect(dropdown).toBeVisible()
+
+    for (const format of ['Mermaid', 'Graphviz DOT', 'PlantUML', 'D2']) {
+      await expect(dropdown.getByRole('option', { name: new RegExp(format) })).toBeVisible()
+    }
+
+    // Close by clicking elsewhere.
+    await page.keyboard.press('Escape')
+  })
+
+  test('copy-to-clipboard writes DSL text (with daemon)', async ({ page, context }) => {
+    // Grant clipboard permissions.
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    const nodeSelected = await trySelectNode(page)
+    if (!nodeSelected) {
+      test.info().annotations.push({
+        type: 'info',
+        description: 'No daemon — clipboard test skipped.',
+      })
+      return
+    }
+
+    const inspector = page.getByTestId('entity-inspector')
+    const exportBtn = inspector.getByTestId('export-diagram-button')
+    if (!(await exportBtn.isVisible({ timeout: 2000 }).catch(() => false))) {
+      test.info().annotations.push({ type: 'info', description: 'Export button not visible — skipped.' })
+      return
+    }
+
+    const copyBtn = exportBtn.getByTestId('copy-diagram-btn')
+    await copyBtn.click()
+
+    // Button should show "Copied!" flash.
+    await expect(copyBtn).toHaveText(/Copied!/, { timeout: 5000 })
+
+    // Clipboard should contain non-empty text starting with Mermaid header.
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText.length, 'Clipboard should contain DSL text').toBeGreaterThan(0)
+    expect(clipboardText, 'Default format should be Mermaid').toMatch(/flowchart LR/)
+  })
+
+  test('switching to Graphviz format and copying (with daemon)', async ({ page, context }) => {
+    await context.grantPermissions(['clipboard-read', 'clipboard-write'])
+
+    const nodeSelected = await trySelectNode(page)
+    if (!nodeSelected) {
+      test.info().annotations.push({ type: 'info', description: 'No daemon — skipped.' })
+      return
+    }
+
+    const inspector = page.getByTestId('entity-inspector')
+    const exportBtn = inspector.getByTestId('export-diagram-button')
+    if (!(await exportBtn.isVisible({ timeout: 2000 }).catch(() => false))) {
+      test.info().annotations.push({ type: 'info', description: 'Export button not visible — skipped.' })
+      return
+    }
+
+    // Switch to Graphviz.
+    const formatPicker = exportBtn.getByRole('button', { name: /Export format/i })
+    await formatPicker.click()
+    const dropdown = exportBtn.getByRole('listbox', { name: 'Diagram format' })
+    await dropdown.getByRole('option', { name: /Graphviz/ }).click()
+
+    // Format label should update.
+    await expect(formatPicker).toContainText('Graphviz DOT')
+
+    // Copy.
+    const copyBtn = exportBtn.getByTestId('copy-diagram-btn')
+    await copyBtn.click()
+    await expect(copyBtn).toHaveText(/Copied!/, { timeout: 5000 })
+
+    const clipboardText = await page.evaluate(() => navigator.clipboard.readText())
+    expect(clipboardText, 'Graphviz DOT format should contain digraph').toMatch(/digraph subgraph/)
+  })
+
+  test('0 console errors on load', async ({ page }) => {
+    await page.waitForTimeout(1000)
+    const realErrors = consoleErrors.filter(
+      (e) =>
+        !e.includes('Download the React DevTools') &&
+        !e.includes('ReactDOM.render is no longer supported') &&
+        !e.includes('net::ERR_CONNECTION_REFUSED'),
+    )
+    expect(realErrors, `Unexpected console errors:\n${realErrors.join('\n')}`).toHaveLength(0)
+  })
+})

--- a/internal/dashboard/handlers_export_dsl.go
+++ b/internal/dashboard/handlers_export_dsl.go
@@ -1,0 +1,444 @@
+package dashboard
+
+// handlers_export_dsl.go — DSL export endpoint (#1318)
+//
+//	GET /api/export/{group}/{entity_id}/{format}?depth=N&limit=M
+//
+// Exports a subgraph (one entity + N-hop BFS neighbors) as paste-ready
+// diagram source in one of four formats:
+//
+//	mermaid   — Mermaid flowchart LR
+//	graphviz  — DOT language (digraph)
+//	plantuml  — PlantUML component diagram
+//	d2        — D2 language
+//
+// The subgraph is limited to `limit` nodes (default 15, max 50) for
+// inline-doc usability. Nodes are color-coded by kind using tokens that
+// match the graph canvas palette.
+//
+// Response: Content-Type text/plain; the DSL text is returned as-is so
+// callers can copy it into a GH issue, Notion block, or README code fence.
+
+import (
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// defaultExportDepth is the default BFS depth when ?depth= is omitted.
+const defaultExportDepth = 2
+
+// defaultExportLimit is the default node cap for export subgraphs.
+const defaultExportLimit = 15
+
+// maxExportLimit caps how many nodes a single export request can return.
+const maxExportLimit = 50
+
+// handleExportDSL — GET /api/export/{group}/{entity_id}/{format}
+func (s *Server) handleExportDSL(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	entityID := r.PathValue("entity_id")
+	format := strings.ToLower(r.PathValue("format"))
+
+	if group == "" || entityID == "" || format == "" {
+		writeErr(w, http.StatusBadRequest, "group, entity_id, and format are required")
+		return
+	}
+
+	switch format {
+	case "mermaid", "graphviz", "plantuml", "d2":
+	default:
+		writeErr(w, http.StatusBadRequest, "format must be one of: mermaid, graphviz, plantuml, d2")
+		return
+	}
+
+	depth := defaultExportDepth
+	if d := r.URL.Query().Get("depth"); d != "" {
+		if n, err := strconv.Atoi(d); err == nil && n >= 0 {
+			depth = n
+			if depth > 5 {
+				depth = 5 // cap to prevent runaway traversal
+			}
+		}
+	}
+
+	limit := defaultExportLimit
+	if l := r.URL.Query().Get("limit"); l != "" {
+		if n, err := strconv.Atoi(l); err == nil && n > 0 {
+			limit = n
+			if limit > maxExportLimit {
+				limit = maxExportLimit
+			}
+		}
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	repo, root := findEntity(grp, entityID)
+	if root == nil {
+		writeErr(w, http.StatusNotFound, "entity not found: "+entityID)
+		return
+	}
+
+	nodes, edges := bfsSubgraph(repo, root, depth, limit)
+
+	var dsl string
+	switch format {
+	case "mermaid":
+		dsl = renderMermaid(nodes, edges)
+	case "graphviz":
+		dsl = renderGraphviz(nodes, edges)
+	case "plantuml":
+		dsl = renderPlantUML(nodes, edges)
+	case "d2":
+		dsl = renderD2(nodes, edges)
+	}
+
+	w.Header().Set("Content-Type", "text/plain; charset=utf-8")
+	w.Header().Set("X-Export-Format", format)
+	w.Header().Set("X-Export-NodeCount", strconv.Itoa(len(nodes)))
+	w.WriteHeader(http.StatusOK)
+	_, _ = fmt.Fprint(w, dsl)
+}
+
+// ── Subgraph BFS ──────────────────────────────────────────────────────────────
+
+// exportNode is the flattened representation used by all renderers.
+type exportNode struct {
+	ID    string // prefixed "repo::local"
+	Label string
+	Kind  string
+	Repo  string
+}
+
+// exportEdge connects two exportNode.ID values.
+type exportEdge struct {
+	FromID string
+	ToID   string
+	Kind   string
+}
+
+// bfsSubgraph performs a BFS from root up to depth hops, collecting at most
+// limit nodes. Cross-repo links from grp.Links are not followed (too noisy
+// for inline doc snippets); only same-repo relationships are traversed.
+func bfsSubgraph(repo *DashRepo, root *graph.Entity, depth, limit int) ([]exportNode, []exportEdge) {
+	if repo.Doc == nil {
+		return nil, nil
+	}
+
+	// Build an adjacency index: localID → []Relationship
+	adj := make(map[string][]graph.Relationship, len(repo.Doc.Relationships))
+	for _, rel := range repo.Doc.Relationships {
+		adj[rel.FromID] = append(adj[rel.FromID], rel)
+		// Add reverse too so BFS walks in both directions.
+		adj[rel.ToID] = append(adj[rel.ToID], graph.Relationship{
+			FromID: rel.ToID,
+			ToID:   rel.FromID,
+			Kind:   rel.Kind,
+		})
+	}
+
+	// Entity index for O(1) lookup.
+	entityIdx := make(map[string]*graph.Entity, len(repo.Doc.Entities))
+	for i := range repo.Doc.Entities {
+		entityIdx[repo.Doc.Entities[i].ID] = &repo.Doc.Entities[i]
+	}
+
+	type frontier struct {
+		id    string
+		depth int
+	}
+
+	visited := map[string]bool{root.ID: true}
+	queue := []frontier{{id: root.ID, depth: 0}}
+	var nodeOrder []string
+	nodeOrder = append(nodeOrder, root.ID)
+
+	// Track which directed edges we've seen (original direction, not BFS reverse).
+	edgeSet := map[string]exportEdge{}
+
+	for len(queue) > 0 && len(nodeOrder) < limit {
+		cur := queue[0]
+		queue = queue[1:]
+
+		if cur.depth >= depth {
+			continue
+		}
+
+		for _, rel := range adj[cur.id] {
+			neighbor := rel.ToID
+			// Record the original-direction edge (not the reverse we added).
+			ekey := rel.FromID + "->" + rel.ToID + ":" + rel.Kind
+			if _, seen := edgeSet[ekey]; !seen {
+				edgeSet[ekey] = exportEdge{
+					FromID: dashPrefixedID(repo.Slug, rel.FromID),
+					ToID:   dashPrefixedID(repo.Slug, rel.ToID),
+					Kind:   rel.Kind,
+				}
+			}
+
+			if !visited[neighbor] && len(nodeOrder) < limit {
+				visited[neighbor] = true
+				nodeOrder = append(nodeOrder, neighbor)
+				queue = append(queue, frontier{id: neighbor, depth: cur.depth + 1})
+			}
+		}
+	}
+
+	// Build nodes slice (root first, then BFS order).
+	nodes := make([]exportNode, 0, len(nodeOrder))
+	for _, id := range nodeOrder {
+		e := entityIdx[id]
+		if e == nil {
+			continue
+		}
+		nodes = append(nodes, exportNode{
+			ID:    dashPrefixedID(repo.Slug, e.ID),
+			Label: e.Name,
+			Kind:  dashStripScopePrefix(e.Kind),
+			Repo:  repo.Slug,
+		})
+	}
+
+	// Collect only edges whose both endpoints are in the visited set.
+	edges := make([]exportEdge, 0, len(edgeSet))
+	for _, e := range edgeSet {
+		fromLocal := strings.TrimPrefix(e.FromID, repo.Slug+"::")
+		toLocal := strings.TrimPrefix(e.ToID, repo.Slug+"::")
+		if visited[fromLocal] && visited[toLocal] {
+			edges = append(edges, e)
+		}
+	}
+
+	// Stable sort for deterministic output.
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].FromID != edges[j].FromID {
+			return edges[i].FromID < edges[j].FromID
+		}
+		return edges[i].ToID < edges[j].ToID
+	})
+
+	return nodes, edges
+}
+
+// ── Color tokens per kind ─────────────────────────────────────────────────────
+// These match the graph canvas palette used in the React SPA.
+
+type kindStyle struct {
+	mermaidFill    string // hex background
+	mermaidStroke  string // hex border
+	dotFillcolor   string // for graphviz
+	dotFontcolor   string
+	pumlStereo     string // PlantUML stereotype color
+	d2StyleFill    string
+	d2StyleStroke  string
+}
+
+var kindStyles = map[string]kindStyle{
+	"Function":     {mermaidFill: "#bfdbfe", mermaidStroke: "#3b82f6", dotFillcolor: "#bfdbfe", dotFontcolor: "#1e40af", pumlStereo: "#bfdbfe", d2StyleFill: "#bfdbfe", d2StyleStroke: "#3b82f6"},
+	"Class":        {mermaidFill: "#a5f3fc", mermaidStroke: "#06b6d4", dotFillcolor: "#a5f3fc", dotFontcolor: "#155e75", pumlStereo: "#a5f3fc", d2StyleFill: "#a5f3fc", d2StyleStroke: "#06b6d4"},
+	"Interface":    {mermaidFill: "#a5f3fc", mermaidStroke: "#06b6d4", dotFillcolor: "#a5f3fc", dotFontcolor: "#155e75", pumlStereo: "#a5f3fc", d2StyleFill: "#a5f3fc", d2StyleStroke: "#06b6d4"},
+	"Endpoint":     {mermaidFill: "#bbf7d0", mermaidStroke: "#22c55e", dotFillcolor: "#bbf7d0", dotFontcolor: "#14532d", pumlStereo: "#bbf7d0", d2StyleFill: "#bbf7d0", d2StyleStroke: "#22c55e"},
+	"Route":        {mermaidFill: "#bbf7d0", mermaidStroke: "#22c55e", dotFillcolor: "#bbf7d0", dotFontcolor: "#14532d", pumlStereo: "#bbf7d0", d2StyleFill: "#bbf7d0", d2StyleStroke: "#22c55e"},
+	"MessageTopic": {mermaidFill: "#e9d5ff", mermaidStroke: "#a855f7", dotFillcolor: "#e9d5ff", dotFontcolor: "#581c87", pumlStereo: "#e9d5ff", d2StyleFill: "#e9d5ff", d2StyleStroke: "#a855f7"},
+	"Queue":        {mermaidFill: "#e9d5ff", mermaidStroke: "#a855f7", dotFillcolor: "#e9d5ff", dotFontcolor: "#581c87", pumlStereo: "#e9d5ff", d2StyleFill: "#e9d5ff", d2StyleStroke: "#a855f7"},
+	"Process":      {mermaidFill: "#fed7aa", mermaidStroke: "#f97316", dotFillcolor: "#fed7aa", dotFontcolor: "#7c2d12", pumlStereo: "#fed7aa", d2StyleFill: "#fed7aa", d2StyleStroke: "#f97316"},
+	"Component":    {mermaidFill: "#99f6e4", mermaidStroke: "#14b8a6", dotFillcolor: "#99f6e4", dotFontcolor: "#134e4a", pumlStereo: "#99f6e4", d2StyleFill: "#99f6e4", d2StyleStroke: "#14b8a6"},
+	"Service":      {mermaidFill: "#99f6e4", mermaidStroke: "#14b8a6", dotFillcolor: "#99f6e4", dotFontcolor: "#134e4a", pumlStereo: "#99f6e4", d2StyleFill: "#99f6e4", d2StyleStroke: "#14b8a6"},
+	"Variable":     {mermaidFill: "#fef08a", mermaidStroke: "#ca8a04", dotFillcolor: "#fef08a", dotFontcolor: "#713f12", pumlStereo: "#fef08a", d2StyleFill: "#fef08a", d2StyleStroke: "#ca8a04"},
+	"Struct":       {mermaidFill: "#fce7f3", mermaidStroke: "#ec4899", dotFillcolor: "#fce7f3", dotFontcolor: "#831843", pumlStereo: "#fce7f3", d2StyleFill: "#fce7f3", d2StyleStroke: "#ec4899"},
+}
+
+var defaultStyle = kindStyle{
+	mermaidFill: "#f1f5f9", mermaidStroke: "#94a3b8",
+	dotFillcolor: "#f1f5f9", dotFontcolor: "#334155",
+	pumlStereo: "#f1f5f9",
+	d2StyleFill: "#f1f5f9", d2StyleStroke: "#94a3b8",
+}
+
+func styleFor(kind string) kindStyle {
+	if s, ok := kindStyles[kind]; ok {
+		return s
+	}
+	return defaultStyle
+}
+
+// ── Mermaid renderer ──────────────────────────────────────────────────────────
+
+// mermaidID returns a safe Mermaid node identifier. Mermaid does not allow
+// "::" in node IDs, so we hash the prefixed ID.
+func mermaidID(prefixedID string) string {
+	return "n" + hashStr(prefixedID)
+}
+
+// mermaidLabel truncates a label to 40 chars for readability.
+func mermaidLabel(label, kind string) string {
+	if len(label) > 40 {
+		label = label[:37] + "…"
+	}
+	return label + "\\n[" + kind + "]"
+}
+
+func renderMermaid(nodes []exportNode, edges []exportEdge) string {
+	var sb strings.Builder
+	sb.WriteString("flowchart LR\n")
+
+	// Collect unique kinds for style declarations.
+	kindNodes := map[string][]string{} // kind → []mermaidID
+	for _, n := range nodes {
+		id := mermaidID(n.ID)
+		label := mermaidLabel(n.Label, n.Kind)
+		sb.WriteString(fmt.Sprintf("  %s[\"%s\"]\n", id, label))
+		kindNodes[n.Kind] = append(kindNodes[n.Kind], id)
+	}
+
+	sb.WriteString("\n")
+
+	for _, e := range edges {
+		fromID := mermaidID(e.FromID)
+		toID := mermaidID(e.ToID)
+		label := e.Kind
+		sb.WriteString(fmt.Sprintf("  %s -->|%s| %s\n", fromID, label, toID))
+	}
+
+	sb.WriteString("\n")
+
+	// Emit style per kind.
+	for kind, ids := range kindNodes {
+		s := styleFor(kind)
+		for _, id := range ids {
+			sb.WriteString(fmt.Sprintf("  style %s fill:%s,stroke:%s\n", id, s.mermaidFill, s.mermaidStroke))
+		}
+	}
+
+	return sb.String()
+}
+
+// ── Graphviz renderer ─────────────────────────────────────────────────────────
+
+// dotID returns a safe DOT identifier by replacing non-alphanumeric chars.
+func dotID(prefixedID string) string {
+	r := strings.NewReplacer("::", "_", "-", "_", "/", "_", ".", "_", " ", "_")
+	return "n_" + r.Replace(prefixedID)
+}
+
+func renderGraphviz(nodes []exportNode, edges []exportEdge) string {
+	var sb strings.Builder
+	sb.WriteString("digraph subgraph {\n")
+	sb.WriteString("  rankdir=LR;\n")
+	sb.WriteString("  node [shape=box, style=filled, fontname=\"Helvetica\", fontsize=11];\n")
+	sb.WriteString("  edge [fontname=\"Helvetica\", fontsize=9];\n\n")
+
+	for _, n := range nodes {
+		s := styleFor(n.Kind)
+		label := n.Label
+		if len(label) > 40 {
+			label = label[:37] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("  %s [label=\"%s\\n[%s]\", fillcolor=\"%s\", fontcolor=\"%s\"];\n",
+			dotID(n.ID), dotEscape(label), n.Kind, s.dotFillcolor, s.dotFontcolor))
+	}
+
+	sb.WriteString("\n")
+
+	for _, e := range edges {
+		sb.WriteString(fmt.Sprintf("  %s -> %s [label=\"%s\"];\n",
+			dotID(e.FromID), dotID(e.ToID), e.Kind))
+	}
+
+	sb.WriteString("}\n")
+	return sb.String()
+}
+
+func dotEscape(s string) string {
+	return strings.NewReplacer(`"`, `\"`, `\`, `\\`).Replace(s)
+}
+
+// ── PlantUML renderer ─────────────────────────────────────────────────────────
+
+func renderPlantUML(nodes []exportNode, edges []exportEdge) string {
+	var sb strings.Builder
+	sb.WriteString("@startuml\n")
+	sb.WriteString("' Generated by archigraph export\n")
+	sb.WriteString("left to right direction\n")
+	sb.WriteString("skinparam componentStyle rectangle\n\n")
+
+	// Build id → alias map.
+	aliases := make(map[string]string, len(nodes))
+	for _, n := range nodes {
+		alias := "p" + hashStr(n.ID)
+		aliases[n.ID] = alias
+		s := styleFor(n.Kind)
+		label := n.Label
+		if len(label) > 40 {
+			label = label[:37] + "..."
+		}
+		sb.WriteString(fmt.Sprintf("component \"%s\\n[%s]\" as %s #%s\n",
+			pumlEscape(label), n.Kind, alias, strings.TrimPrefix(s.pumlStereo, "#")))
+	}
+
+	sb.WriteString("\n")
+
+	for _, e := range edges {
+		fromAlias := aliases[e.FromID]
+		toAlias := aliases[e.ToID]
+		if fromAlias == "" || toAlias == "" {
+			continue
+		}
+		sb.WriteString(fmt.Sprintf("%s --> %s : %s\n", fromAlias, toAlias, e.Kind))
+	}
+
+	sb.WriteString("@enduml\n")
+	return sb.String()
+}
+
+func pumlEscape(s string) string {
+	return strings.NewReplacer(`"`, `'`, `\n`, ` `).Replace(s)
+}
+
+// ── D2 renderer ───────────────────────────────────────────────────────────────
+
+// d2ID returns a safe D2 identifier.
+func d2ID(prefixedID string) string {
+	r := strings.NewReplacer("::", "_", "-", "_", "/", "_", ".", "_", " ", "_")
+	return r.Replace(prefixedID)
+}
+
+func renderD2(nodes []exportNode, edges []exportEdge) string {
+	var sb strings.Builder
+	sb.WriteString("# Generated by archigraph export\n")
+	sb.WriteString("direction: right\n\n")
+
+	for _, n := range nodes {
+		id := d2ID(n.ID)
+		s := styleFor(n.Kind)
+		label := n.Label
+		if len(label) > 40 {
+			label = label[:37] + "…"
+		}
+		sb.WriteString(fmt.Sprintf("%s: \"%s [%s]\" {\n  style.fill: \"%s\"\n  style.stroke: \"%s\"\n}\n",
+			id, d2Escape(label), n.Kind, s.d2StyleFill, s.d2StyleStroke))
+	}
+
+	sb.WriteString("\n")
+
+	for _, e := range edges {
+		fromID := d2ID(e.FromID)
+		toID := d2ID(e.ToID)
+		sb.WriteString(fmt.Sprintf("%s -> %s: %s\n", fromID, toID, e.Kind))
+	}
+
+	return sb.String()
+}
+
+func d2Escape(s string) string {
+	return strings.NewReplacer(`"`, `'`).Replace(s)
+}

--- a/internal/dashboard/handlers_export_dsl_test.go
+++ b/internal/dashboard/handlers_export_dsl_test.go
@@ -1,0 +1,405 @@
+package dashboard
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ── Renderer unit tests ───────────────────────────────────────────────────────
+
+func TestRenderMermaid_basic(t *testing.T) {
+	nodes := []exportNode{
+		{ID: "repo::funcA", Label: "funcA", Kind: "Function", Repo: "repo"},
+		{ID: "repo::funcB", Label: "funcB", Kind: "Class", Repo: "repo"},
+	}
+	edges := []exportEdge{
+		{FromID: "repo::funcA", ToID: "repo::funcB", Kind: "calls"},
+	}
+
+	out := renderMermaid(nodes, edges)
+
+	if !strings.Contains(out, "flowchart LR") {
+		t.Error("mermaid output should start with flowchart LR")
+	}
+	if !strings.Contains(out, "funcA") {
+		t.Error("mermaid output should contain funcA label")
+	}
+	if !strings.Contains(out, "calls") {
+		t.Error("mermaid output should contain edge kind 'calls'")
+	}
+	if !strings.Contains(out, "fill:") {
+		t.Error("mermaid output should contain style fill declarations")
+	}
+	// Color tokens: Function → blue
+	if !strings.Contains(out, "#bfdbfe") {
+		t.Errorf("Function nodes should use blue fill #bfdbfe; got:\n%s", out)
+	}
+}
+
+func TestRenderGraphviz_basic(t *testing.T) {
+	nodes := []exportNode{
+		{ID: "repo::ep1", Label: "GET /users", Kind: "Endpoint", Repo: "repo"},
+		{ID: "repo::svc1", Label: "UserService", Kind: "Service", Repo: "repo"},
+	}
+	edges := []exportEdge{
+		{FromID: "repo::ep1", ToID: "repo::svc1", Kind: "invokes"},
+	}
+
+	out := renderGraphviz(nodes, edges)
+
+	if !strings.Contains(out, "digraph subgraph") {
+		t.Error("graphviz output should contain 'digraph subgraph'")
+	}
+	if !strings.Contains(out, "rankdir=LR") {
+		t.Error("graphviz output should set rankdir=LR")
+	}
+	if !strings.Contains(out, "invokes") {
+		t.Error("graphviz output should contain edge kind")
+	}
+	// Endpoint → green
+	if !strings.Contains(out, "#bbf7d0") {
+		t.Errorf("Endpoint nodes should use green fill; got:\n%s", out)
+	}
+}
+
+func TestRenderPlantUML_basic(t *testing.T) {
+	nodes := []exportNode{
+		{ID: "repo::topic1", Label: "user.created", Kind: "MessageTopic", Repo: "repo"},
+		{ID: "repo::svc1", Label: "NotifSvc", Kind: "Service", Repo: "repo"},
+	}
+	edges := []exportEdge{
+		{FromID: "repo::svc1", ToID: "repo::topic1", Kind: "publishes"},
+	}
+
+	out := renderPlantUML(nodes, edges)
+
+	if !strings.Contains(out, "@startuml") {
+		t.Error("plantuml output should start with @startuml")
+	}
+	if !strings.Contains(out, "@enduml") {
+		t.Error("plantuml output should end with @enduml")
+	}
+	if !strings.Contains(out, "publishes") {
+		t.Error("plantuml output should contain edge kind")
+	}
+	// MessageTopic → purple e9d5ff
+	if !strings.Contains(out, "e9d5ff") {
+		t.Errorf("MessageTopic nodes should use purple; got:\n%s", out)
+	}
+}
+
+func TestRenderD2_basic(t *testing.T) {
+	nodes := []exportNode{
+		{ID: "repo::proc1", Label: "OrderProcess", Kind: "Process", Repo: "repo"},
+		{ID: "repo::comp1", Label: "PaymentComp", Kind: "Component", Repo: "repo"},
+	}
+	edges := []exportEdge{
+		{FromID: "repo::proc1", ToID: "repo::comp1", Kind: "uses"},
+	}
+
+	out := renderD2(nodes, edges)
+
+	if !strings.Contains(out, "direction: right") {
+		t.Error("d2 output should set direction")
+	}
+	if !strings.Contains(out, "uses") {
+		t.Error("d2 output should contain edge kind")
+	}
+	// Process → orange fed7aa
+	if !strings.Contains(out, "fed7aa") {
+		t.Errorf("Process nodes should use orange fill; got:\n%s", out)
+	}
+}
+
+func TestRenderMermaid_labelTruncation(t *testing.T) {
+	long := strings.Repeat("x", 60)
+	nodes := []exportNode{
+		{ID: "repo::n1", Label: long, Kind: "Function", Repo: "repo"},
+	}
+	out := renderMermaid(nodes, nil)
+	// Should contain truncated label ending in …
+	if !strings.Contains(out, "…") {
+		t.Error("long labels should be truncated with ellipsis in mermaid")
+	}
+}
+
+func TestRenderGraphviz_labelTruncation(t *testing.T) {
+	long := strings.Repeat("y", 50)
+	nodes := []exportNode{
+		{ID: "repo::n1", Label: long, Kind: "Class", Repo: "repo"},
+	}
+	out := renderGraphviz(nodes, nil)
+	if !strings.Contains(out, "...") {
+		t.Error("long labels should be truncated with ... in graphviz")
+	}
+}
+
+func TestRenderMermaid_defaultStyleFallback(t *testing.T) {
+	nodes := []exportNode{
+		{ID: "repo::n1", Label: "Unknown", Kind: "WeirdKind", Repo: "repo"},
+	}
+	out := renderMermaid(nodes, nil)
+	// Should use default grey fill
+	if !strings.Contains(out, "#f1f5f9") {
+		t.Errorf("unknown kind should fall back to default fill; got:\n%s", out)
+	}
+}
+
+// ── BFS subgraph tests ────────────────────────────────────────────────────────
+
+func makeBFSTestRepo() *DashRepo {
+	entities := []graph.Entity{
+		{ID: "e1", Name: "Entry", Kind: "Function"},
+		{ID: "e2", Name: "Middle", Kind: "Class"},
+		{ID: "e3", Name: "Leaf", Kind: "Function"},
+		{ID: "e4", Name: "DeepLeaf", Kind: "Function"},
+		{ID: "e5", Name: "Unconnected", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{FromID: "e1", ToID: "e2", Kind: "calls"},
+		{FromID: "e2", ToID: "e3", Kind: "calls"},
+		{FromID: "e3", ToID: "e4", Kind: "calls"},
+	}
+	return &DashRepo{
+		Slug: "testrepo",
+		Doc: &graph.Document{
+			Entities:      entities,
+			Relationships: rels,
+		},
+	}
+}
+
+func TestBFSSubgraph_depth1(t *testing.T) {
+	repo := makeBFSTestRepo()
+	root := &repo.Doc.Entities[0] // e1
+	nodes, _ := bfsSubgraph(repo, root, 1, 50)
+
+	ids := nodeIDs(nodes)
+	if !ids["testrepo::e1"] {
+		t.Error("root should be in nodes")
+	}
+	if !ids["testrepo::e2"] {
+		t.Error("depth-1 neighbor e2 should be in nodes")
+	}
+	if ids["testrepo::e3"] {
+		t.Error("depth-2 node e3 should NOT be in nodes at depth=1")
+	}
+}
+
+func TestBFSSubgraph_depth2(t *testing.T) {
+	repo := makeBFSTestRepo()
+	root := &repo.Doc.Entities[0] // e1
+	nodes, edges := bfsSubgraph(repo, root, 2, 50)
+
+	ids := nodeIDs(nodes)
+	if !ids["testrepo::e1"] || !ids["testrepo::e2"] || !ids["testrepo::e3"] {
+		t.Error("depth-2 traversal should include e1, e2, e3")
+	}
+	if ids["testrepo::e4"] {
+		t.Error("depth-3 node e4 should NOT appear at depth=2")
+	}
+	if ids["testrepo::e5"] {
+		t.Error("unconnected node e5 should never appear")
+	}
+
+	if len(edges) == 0 {
+		t.Error("edges should be non-empty")
+	}
+}
+
+func TestBFSSubgraph_limit(t *testing.T) {
+	repo := makeBFSTestRepo()
+	root := &repo.Doc.Entities[0]
+	nodes, _ := bfsSubgraph(repo, root, 10, 2) // limit=2
+
+	if len(nodes) > 2 {
+		t.Errorf("limit=2 should produce at most 2 nodes, got %d", len(nodes))
+	}
+}
+
+func TestBFSSubgraph_nilDoc(t *testing.T) {
+	repo := &DashRepo{Slug: "empty", Doc: nil}
+	nodes, edges := bfsSubgraph(repo, &graph.Entity{ID: "x"}, 2, 50)
+	if len(nodes) != 0 || len(edges) != 0 {
+		t.Error("nil doc should return empty results")
+	}
+}
+
+func nodeIDs(nodes []exportNode) map[string]bool {
+	m := map[string]bool{}
+	for _, n := range nodes {
+		m[n.ID] = true
+	}
+	return m
+}
+
+// ── HTTP handler tests ────────────────────────────────────────────────────────
+
+func newExportTestServer(t *testing.T) *Server {
+	t.Helper()
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv
+}
+
+func TestHandleExportDSL_missingFormat(t *testing.T) {
+	srv := newExportTestServer(t)
+	// path variable "format" will be empty → 400
+	req := httptest.NewRequest(http.MethodGet, "/api/export/mygroup/myentity/", nil)
+	req.SetPathValue("group", "mygroup")
+	req.SetPathValue("entity_id", "myentity")
+	req.SetPathValue("format", "")
+	w := httptest.NewRecorder()
+	srv.handleExportDSL(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleExportDSL_invalidFormat(t *testing.T) {
+	srv := newExportTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/e/svg", nil)
+	req.SetPathValue("group", "g")
+	req.SetPathValue("entity_id", "e")
+	req.SetPathValue("format", "svg")
+	w := httptest.NewRecorder()
+	srv.handleExportDSL(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for unknown format, got %d", w.Code)
+	}
+}
+
+func TestHandleExportDSL_groupNotFound(t *testing.T) {
+	srv := newExportTestServer(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/nogroup/eid/mermaid", nil)
+	req.SetPathValue("group", "nogroup")
+	req.SetPathValue("entity_id", "eid")
+	req.SetPathValue("format", "mermaid")
+	w := httptest.NewRecorder()
+	srv.handleExportDSL(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404 for unknown group, got %d", w.Code)
+	}
+}
+
+func TestHandleExportDSL_allFormats(t *testing.T) {
+	// Wire a fake store with a live group+entity.
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	// Inject a graph group with a real entity so handler reaches renderers.
+	grp := &DashGroup{
+		Name: "testgroup",
+		Repos: map[string]*DashRepo{
+			"repo1": {
+				Slug: "repo1",
+				Doc: &graph.Document{
+					Entities: []graph.Entity{
+						{ID: "fn1", Name: "MyFunc", Kind: "Function"},
+						{ID: "fn2", Name: "Helper", Kind: "Function"},
+					},
+					Relationships: []graph.Relationship{
+						{FromID: "fn1", ToID: "fn2", Kind: "calls"},
+					},
+				},
+			},
+		},
+	}
+	// Inject into cache directly.
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgroup"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	for _, fmt := range []string{"mermaid", "graphviz", "plantuml", "d2"} {
+		t.Run(fmt, func(t *testing.T) {
+			req := httptest.NewRequest(http.MethodGet,
+				"/api/export/testgroup/repo1::fn1/"+fmt+"?depth=1", nil)
+			req.SetPathValue("group", "testgroup")
+			req.SetPathValue("entity_id", "repo1::fn1")
+			req.SetPathValue("format", fmt)
+			w := httptest.NewRecorder()
+			srv.handleExportDSL(w, req)
+
+			if w.Code != http.StatusOK {
+				t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+			}
+			ct := w.Header().Get("Content-Type")
+			if !strings.HasPrefix(ct, "text/plain") {
+				t.Errorf("want text/plain content-type, got %q", ct)
+			}
+			body := w.Body.String()
+			if len(body) == 0 {
+				t.Error("expected non-empty DSL body")
+			}
+			// Verify node count header.
+			nc := w.Header().Get("X-Export-NodeCount")
+			if nc == "" {
+				t.Error("X-Export-NodeCount header should be present")
+			}
+		})
+	}
+}
+
+func TestHandleExportDSL_entityNotFound(t *testing.T) {
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	grp := &DashGroup{
+		Name: "testgroup",
+		Repos: map[string]*DashRepo{
+			"repo1": {
+				Slug: "repo1",
+				Doc: &graph.Document{
+					Entities: []graph.Entity{{ID: "fn1", Name: "MyFunc", Kind: "Function"}},
+				},
+			},
+		},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgroup"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/export/testgroup/repo1::doesnotexist/mermaid", nil)
+	req.SetPathValue("group", "testgroup")
+	req.SetPathValue("entity_id", "repo1::doesnotexist")
+	req.SetPathValue("format", "mermaid")
+	w := httptest.NewRecorder()
+	srv.handleExportDSL(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404 for unknown entity, got %d", w.Code)
+	}
+}
+
+func TestHandleExportDSL_depthCap(t *testing.T) {
+	// depth=99 should be capped to 5.
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	grp := &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			"r": {
+				Slug: "r",
+				Doc: &graph.Document{
+					Entities: []graph.Entity{{ID: "e1", Name: "Root", Kind: "Function"}},
+				},
+			},
+		},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["g"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/r::e1/mermaid?depth=99", nil)
+	req.SetPathValue("group", "g")
+	req.SetPathValue("entity_id", "r::e1")
+	req.SetPathValue("format", "mermaid")
+	w := httptest.NewRecorder()
+	// Must not hang or blow the stack.
+	srv.handleExportDSL(w, req)
+	if w.Code != http.StatusOK {
+		t.Errorf("want 200, got %d", w.Code)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -433,6 +433,9 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/perf/budgets", s.handlePerfBudgets)
 	mux.HandleFunc("POST /api/perf/record", s.handlePerfRecord)
 
+	// DSL export — Graph subgraph → Mermaid / Graphviz / PlantUML / D2 (#1318)
+	mux.HandleFunc("GET /api/export/{group}/{entity_id}/{format}", s.handleExportDSL)
+
 	return s.withAuth(withGzip(mux))
 }
 


### PR DESCRIPTION
## Summary

- New \`GET /api/export/{group}/{entity_id}/{format}?depth=N&limit=M\` endpoint: BFS from any entity, renders the subgraph as paste-ready diagram DSL in \`mermaid\` | \`graphviz\` | \`plantuml\` | \`d2\` formats
- Color tokens per kind (Endpoint=green, MessageTopic=purple, Process=orange, Component=teal, Function=blue, …) match the graph canvas palette
- Node cap defaults to 15 (max 50), depth defaults to 2 (max 5) — keeps inline-doc snippets readable
- Frontend: \`ExportDiagramButton\` in the Entity Inspector Actions section — format dropdown (Mermaid default) + copy-to-clipboard with "Copied!" flash feedback
- \`group\` prop threaded through \`EntityInspector\` → \`graph.tsx\`

## Closes / Refs

Closes #1318

## Testing

- [x] 19 new Go unit tests pass (\`TestRender*\`, \`TestBFSSubgraph_*\`, \`TestHandleExportDSL_*\`)
- [x] Pre-existing failures (\`TestWriteback_success\`, \`TestYamlScalar\`) are on \`main\` too — not introduced here
- [x] TypeScript: zero new errors in modified/new files (pre-existing TS errors unchanged)
- [x] Headless Playwright e2e spec \`graph-export-diagram.spec.ts\` — degrades gracefully without daemon, full assertions when live graph present
- [x] \`go test ./internal/dashboard/... -run "TestRender|TestBFS|TestHandleExport"\` → PASS (19/19)

## Notes

- Endpoint returns \`text/plain\` with \`X-Export-Format\` and \`X-Export-NodeCount\` response headers
- BFS traverses same-repo relationships only (cross-repo links are too noisy for inline snippets)
- D2 and Graphviz identifiers are sanitized to remove \`::\` / \`-\` / \`.\` / \`/\` that would break parsers
- \`ExportDiagramButton\` is tree-shaken out if \`group\` prop is absent (backward compatible)