### PR TITLE
feat(coverage): test-coverage graph layer — link Test entities to production code (#1323)

### DIFF
--- a/internal/dashboard/handlers_coverage.go
+++ b/internal/dashboard/handlers_coverage.go
@@ -1,0 +1,212 @@
+package dashboard
+
+// handlers_coverage.go — Test-coverage HTTP surface (issue #1323).
+//
+// Route registered in server.go:
+//
+//	GET  /api/quality/coverage/{group}
+//
+// The handler loads each repo's indexed graph document, runs
+// graph.ComputeCoverage, and aggregates the per-repo results into a
+// single GroupCoverageReport.
+//
+// Query params:
+//
+//	dir=<path>     — filter ByDirectory entries by directory prefix
+//	module=<name>  — filter ByModule entries by module name substring
+//	severity=high|medium|low — filter UncoveredEntities by minimum severity
+//	limit=<n>      — cap UncoveredEntities to n items (default 200)
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// GroupCoverageReport is the wire shape for GET /api/quality/coverage/{group}.
+type GroupCoverageReport struct {
+	Group             string                `json:"group"`
+	TotalProduction   int                   `json:"total_production"`
+	CoveredProduction int                   `json:"covered_production"`
+	CoveragePct       float64               `json:"coverage_pct"`
+	TotalTests        int                   `json:"total_tests"`
+	TotalTestsEdges   int                   `json:"total_tests_edges"`
+	Repos             int                   `json:"repos"`
+	// UncoveredEntities is sorted by severity (high first) and capped by
+	// the ?limit query parameter (default 200).
+	UncoveredEntities []graph.UncoveredEntity  `json:"uncovered_entities"`
+	ByDirectory       []graph.DirCoverage      `json:"by_directory"`
+	ByModule          []graph.ModuleCoverage   `json:"by_module"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleQualityCoverage serves GET /api/quality/coverage/{group}.
+func (s *Server) handleQualityCoverage(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	// Resolve repo paths using the shared helper in handlers_quality.go.
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	// ── query-string options ──────────────────────────────────────────────────
+	q := r.URL.Query()
+	filterDir := q.Get("dir")
+	filterModule := q.Get("module")
+	filterSeverity := strings.ToLower(q.Get("severity"))
+	limit := 200
+	if lStr := q.Get("limit"); lStr != "" {
+		if n, pErr := strconv.Atoi(lStr); pErr == nil && n > 0 {
+			limit = n
+		}
+	}
+
+	// ── aggregate across repos ────────────────────────────────────────────────
+	result := GroupCoverageReport{Group: groupName}
+
+	// Accumulate per-directory and per-module maps for aggregation.
+	type dirAccum struct{ total, covered int }
+	type modAccum struct{ total, covered int }
+	dirAcc := make(map[string]*dirAccum)
+	modAcc := make(map[string]*modAccum)
+
+	for _, rp := range repoPaths {
+		stateDir := filepath.Join(rp.Path, ".archigraph")
+		doc, loadErr := graph.LoadGraphFromDir(stateDir)
+		if loadErr != nil {
+			// Repo not yet indexed — skip silently.
+			continue
+		}
+
+		report := graph.ComputeCoverage(doc)
+		result.Repos++
+		result.TotalProduction += report.TotalProduction
+		result.CoveredProduction += report.CoveredProduction
+		result.TotalTests += report.TotalTests
+		result.TotalTestsEdges += report.TotalTestsEdges
+
+		// Merge uncovered entities.
+		result.UncoveredEntities = append(result.UncoveredEntities, report.UncoveredEntities...)
+
+		// Merge per-directory stats.
+		for _, d := range report.ByDirectory {
+			if _, ok := dirAcc[d.Dir]; !ok {
+				dirAcc[d.Dir] = &dirAccum{}
+			}
+			dirAcc[d.Dir].total += d.Total
+			dirAcc[d.Dir].covered += d.Covered
+		}
+
+		// Merge per-module stats.
+		for _, m := range report.ByModule {
+			if _, ok := modAcc[m.Module]; !ok {
+				modAcc[m.Module] = &modAccum{}
+			}
+			modAcc[m.Module].total += m.Total
+			modAcc[m.Module].covered += m.Covered
+		}
+	}
+
+	// ── compute group-level coverage % ───────────────────────────────────────
+	if result.TotalProduction > 0 {
+		result.CoveragePct = 100.0 * float64(result.CoveredProduction) / float64(result.TotalProduction)
+	}
+
+	// ── apply severity filter and cap UncoveredEntities ──────────────────────
+	severityOrder := map[string]int{"high": 0, "medium": 1, "low": 2}
+	minSev := 2 // default: include all
+	if v, ok := severityOrder[filterSeverity]; ok {
+		minSev = v
+	}
+
+	filtered := result.UncoveredEntities[:0]
+	for _, u := range result.UncoveredEntities {
+		if severityOrder[u.Severity] <= minSev {
+			filtered = append(filtered, u)
+		}
+	}
+	// Re-sort: severity then file then name.
+	sort.SliceStable(filtered, func(i, j int) bool {
+		si := severityOrder[filtered[i].Severity]
+		sj := severityOrder[filtered[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		if filtered[i].SourceFile != filtered[j].SourceFile {
+			return filtered[i].SourceFile < filtered[j].SourceFile
+		}
+		return filtered[i].Name < filtered[j].Name
+	})
+	if len(filtered) > limit {
+		filtered = filtered[:limit]
+	}
+	result.UncoveredEntities = filtered
+
+	// ── build ByDirectory with optional prefix filter ─────────────────────────
+	for d, acc := range dirAcc {
+		if filterDir != "" && !strings.HasPrefix(d, filterDir) {
+			continue
+		}
+		covPct := 0.0
+		if acc.total > 0 {
+			covPct = 100.0 * float64(acc.covered) / float64(acc.total)
+		}
+		result.ByDirectory = append(result.ByDirectory, graph.DirCoverage{
+			Dir:         d,
+			Total:       acc.total,
+			Covered:     acc.covered,
+			CoveragePct: covPct,
+		})
+	}
+	sort.Slice(result.ByDirectory, func(i, j int) bool {
+		return result.ByDirectory[i].Dir < result.ByDirectory[j].Dir
+	})
+
+	// ── build ByModule with optional name filter ──────────────────────────────
+	for m, acc := range modAcc {
+		if filterModule != "" && !strings.Contains(m, filterModule) {
+			continue
+		}
+		covPct := 0.0
+		if acc.total > 0 {
+			covPct = 100.0 * float64(acc.covered) / float64(acc.total)
+		}
+		result.ByModule = append(result.ByModule, graph.ModuleCoverage{
+			Module:      m,
+			Total:       acc.total,
+			Covered:     acc.covered,
+			CoveragePct: covPct,
+		})
+	}
+	sort.Slice(result.ByModule, func(i, j int) bool {
+		return result.ByModule[i].Module < result.ByModule[j].Module
+	})
+
+	w.Header().Set("Content-Type", "application/json")
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(result)
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -377,6 +377,8 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/quality/composite/{group}", s.handleQualityComposite)
 	// #1313: N+1 query anti-pattern detector.
 	mux.HandleFunc("GET /api/quality/anti-patterns/{group}", s.handleNPlusOne)
+	// #1323: test-coverage graph — link Test entities to production code.
+	mux.HandleFunc("GET /api/quality/coverage/{group}", s.handleQualityCoverage)
 
 	// Supporting endpoints
 	mux.HandleFunc("GET /api/groups/{group}/communities", s.handleGroupCommunities)

--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -1,0 +1,416 @@
+// Package graph — coverage.go implements the test-coverage graph algorithm.
+//
+// ComputeCoverage walks all TESTS and CALLS relationships in a graph.Document
+// to build a CoverageReport that answers three questions:
+//
+//  1. Which production entities have at least one incoming TESTS edge?
+//     (covered = true)
+//  2. Which production entities are untested (no TESTS inbound)?
+//     (untested list, severity-ranked)
+//  3. What is the coverage percentage per directory / module?
+//
+// # Definitions
+//
+// "Test entity" — an entity whose SourceFile matches a test-file pattern
+// (_test.go, .test.ts, .spec.ts, test_*.py, *_test.py, *_spec.rb,
+// *Test.java, *Tests.java, *Spec.java, *Test.kt).
+//
+// "Production entity" — any non-test entity whose kind is in the coverage
+// scope: Function, Method, Class, Interface, Struct.
+//
+// "TESTS edge" — a graph relationship with Kind == "TESTS".  The testmap
+// extractor (internal/extractors/cross/testmap) emits these edges directly.
+// When none are present, ComputeCoverage falls back to a synthetic pass:
+// for every test entity it walks its CALLS edges and emits a virtual TESTS
+// link for each call target that is a production entity.
+//
+// # Severity rules for untested entities
+//
+//	"high"   — http_endpoint_definition or http_endpoint without TESTS
+//	"medium" — exported Function / Method (capitalised name, no leading _)
+//	"low"    — everything else in scope
+//
+// OTel span: graph.ComputeCoverage
+// Issue #1323.
+package graph
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public types
+// ─────────────────────────────────────────────────────────────────────────────
+
+// CoverageReport is the output of ComputeCoverage.
+type CoverageReport struct {
+	// TotalProduction is the count of in-scope production entities.
+	TotalProduction int `json:"total_production"`
+	// CoveredProduction is the count of production entities with ≥1 TESTS edge.
+	CoveredProduction int `json:"covered_production"`
+	// CoveragePct is CoveredProduction/TotalProduction*100 (0 when no
+	// production entities exist).
+	CoveragePct float64 `json:"coverage_pct"`
+
+	// TotalTests is the number of test entities found.
+	TotalTests int `json:"total_tests"`
+	// TotalTestsEdges is the number of TESTS relationship edges (real or
+	// synthetic) that contributed to coverage.
+	TotalTestsEdges int `json:"total_tests_edges"`
+
+	// UncoveredEntities lists production entities without any TESTS edge,
+	// sorted by severity (high → medium → low) then by file+name.
+	UncoveredEntities []UncoveredEntity `json:"uncovered_entities"`
+
+	// ByDirectory contains per-directory coverage statistics, sorted by
+	// directory path. Only directories with ≥1 production entity are included.
+	ByDirectory []DirCoverage `json:"by_directory"`
+
+	// ByModule contains per-module (Properties["module"]) coverage statistics.
+	// Only populated when entities carry the "module" property.
+	ByModule []ModuleCoverage `json:"by_module"`
+
+	// EntitiesScanned is the total number of entities examined.
+	EntitiesScanned int `json:"entities_scanned"`
+	// RelationshipsScanned is the total number of relationships examined.
+	RelationshipsScanned int `json:"relationships_scanned"`
+}
+
+// UncoveredEntity is one production entity that has no TESTS inbound.
+type UncoveredEntity struct {
+	EntityID   string `json:"entity_id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file"`
+	StartLine  int    `json:"start_line"`
+	Language   string `json:"language"`
+	Module     string `json:"module,omitempty"`
+	// Severity is "high" | "medium" | "low".
+	Severity string `json:"severity"`
+}
+
+// DirCoverage is per-directory coverage statistics.
+type DirCoverage struct {
+	Dir         string  `json:"dir"`
+	Total       int     `json:"total"`
+	Covered     int     `json:"covered"`
+	CoveragePct float64 `json:"coverage_pct"`
+}
+
+// ModuleCoverage is per-module coverage statistics.
+type ModuleCoverage struct {
+	Module      string  `json:"module"`
+	Total       int     `json:"total"`
+	Covered     int     `json:"covered"`
+	CoveragePct float64 `json:"coverage_pct"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Kind / file helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// coverageEntityKinds is the set of entity kinds that count as "production
+// entities" for coverage purposes.
+var coverageEntityKinds = map[string]bool{
+	"Function":                   true,
+	"Method":                     true,
+	"Class":                      true,
+	"Interface":                  true,
+	"Struct":                     true,
+	"http_endpoint":              true,
+	"http_endpoint_definition":   true,
+}
+
+// isTestFile returns true when the source file path matches a recognised test
+// file convention.
+func isTestFile(path string) bool {
+	// Path-segment check first: /test/, /tests/, /__tests__/, /spec/
+	// Prefix the path with "/" so that a leading path segment like "spec/foo.rb"
+	// also matches "/spec/".
+	slashed := "/" + filepath.ToSlash(strings.ToLower(path))
+	for _, seg := range []string{"/test/", "/tests/", "/__tests__/", "/spec/"} {
+		if strings.Contains(slashed, seg) {
+			return true
+		}
+	}
+
+	base := filepath.Base(path)
+	lower := strings.ToLower(base)
+	ext := filepath.Ext(base)
+	stem := strings.TrimSuffix(lower, ext)
+
+	switch ext {
+	case ".go":
+		return strings.HasSuffix(stem, "_test")
+	case ".py":
+		return strings.HasPrefix(stem, "test_") || strings.HasSuffix(stem, "_test")
+	case ".ts", ".tsx", ".js", ".jsx":
+		return strings.HasSuffix(stem, ".test") ||
+			strings.HasSuffix(stem, ".spec") ||
+			strings.Contains(lower, ".test.") ||
+			strings.Contains(lower, ".spec.")
+	case ".rb":
+		return strings.HasSuffix(stem, "_spec")
+	case ".java":
+		return strings.HasSuffix(stem, "test") ||
+			strings.HasSuffix(stem, "tests") ||
+			strings.HasSuffix(stem, "spec")
+	case ".kt":
+		return strings.HasSuffix(stem, "test") ||
+			strings.HasSuffix(stem, "tests") ||
+			strings.HasSuffix(stem, "spec")
+	case ".cs":
+		return strings.HasSuffix(stem, "test") ||
+			strings.HasSuffix(stem, "tests") ||
+			strings.HasSuffix(stem, "spec")
+	}
+	// No match found for the file's naming convention.
+	return false
+}
+
+// isProductionEntity returns true when e is a production entity in scope.
+func isProductionEntity(e *Entity) bool {
+	return coverageEntityKinds[e.Kind] && !isTestFile(e.SourceFile)
+}
+
+// isTestEntity returns true when e is a test entity.
+func isTestEntity(e *Entity) bool {
+	return isTestFile(e.SourceFile)
+}
+
+// entitySeverity classifies the coverage importance of a production entity.
+func entitySeverity(e *Entity) string {
+	switch e.Kind {
+	case "http_endpoint", "http_endpoint_definition":
+		return "high"
+	case "Function", "Method":
+		// Exported (capitalised, not leading underscore) → medium.
+		if isExported(e.Name) {
+			return "medium"
+		}
+		return "low"
+	}
+	return "low"
+}
+
+// isExported returns true for names that appear exported/public.
+func isExported(name string) bool {
+	if name == "" {
+		return false
+	}
+	first := rune(name[0])
+	return first >= 'A' && first <= 'Z'
+}
+
+// dirOf returns the directory portion of a source file path, normalised to
+// forward slashes and with a trailing slash stripped.
+func dirOf(path string) string {
+	d := filepath.ToSlash(filepath.Dir(path))
+	if d == "." {
+		return ""
+	}
+	return d
+}
+
+// pct computes a percentage clamped to [0,100].
+func pct(covered, total int) float64 {
+	if total == 0 {
+		return 0
+	}
+	v := 100.0 * float64(covered) / float64(total)
+	if v > 100 {
+		return 100
+	}
+	return v
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core algorithm
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ComputeCoverage analyses doc and returns a CoverageReport.
+//
+// It runs in two phases:
+//
+//  1. Collect existing TESTS edges (emitted by the testmap extractor or a
+//     previous run of ComputeCoverage). Build a covered-entity set.
+//
+//  2. Synthetic fallback: for test entities with CALLS edges to production
+//     entities that are not yet covered, emit a virtual TESTS edge (recorded
+//     in the report totals but NOT written back to the document).
+//
+// The caller is responsible for writing TESTS edges back to the document if
+// persistence is desired.
+func ComputeCoverage(doc *Document) *CoverageReport {
+	report := &CoverageReport{}
+	report.EntitiesScanned = len(doc.Entities)
+	report.RelationshipsScanned = len(doc.Relationships)
+
+	// ── index entities ────────────────────────────────────────────────────────
+	entByID := make(map[string]*Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		entByID[e.ID] = e
+	}
+
+	// Classify entities.
+	prodIDs := make(map[string]bool)  // production entity IDs
+	testIDs := make(map[string]bool)  // test entity IDs
+
+	for id, e := range entByID {
+		switch {
+		case isProductionEntity(e):
+			prodIDs[id] = true
+		case isTestEntity(e):
+			testIDs[id] = true
+		}
+	}
+	report.TotalProduction = len(prodIDs)
+	report.TotalTests = len(testIDs)
+
+	// ── phase 1: collect TESTS edges ─────────────────────────────────────────
+	// covered maps production-entity-ID → count of TESTS inbound.
+	covered := make(map[string]int, len(prodIDs))
+	// testCallsTo: per test-entity-ID, the set of CALLS target IDs.
+	testCallsTo := make(map[string][]string)
+
+	const kindTests = "TESTS"
+	const kindCalls = "CALLS"
+
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		switch strings.ToUpper(rel.Kind) {
+		case kindTests:
+			if prodIDs[rel.ToID] {
+				covered[rel.ToID]++
+				report.TotalTestsEdges++
+			}
+		case kindCalls:
+			if testIDs[rel.FromID] {
+				testCallsTo[rel.FromID] = append(testCallsTo[rel.FromID], rel.ToID)
+			}
+		}
+	}
+
+	// ── phase 2: synthetic TESTS from CALLS ──────────────────────────────────
+	for testID, targets := range testCallsTo {
+		_ = testID
+		for _, toID := range targets {
+			if prodIDs[toID] && covered[toID] == 0 {
+				// Virtual TESTS edge: count it but do not add a duplicate.
+				covered[toID]++
+				report.TotalTestsEdges++
+			}
+		}
+	}
+
+	// ── compute totals ────────────────────────────────────────────────────────
+	report.CoveredProduction = len(covered)
+	report.CoveragePct = pct(report.CoveredProduction, report.TotalProduction)
+
+	// ── build uncovered list ──────────────────────────────────────────────────
+	for id := range prodIDs {
+		if covered[id] > 0 {
+			continue
+		}
+		e := entByID[id]
+		mod := ""
+		if e.Properties != nil {
+			mod = e.Properties["module"]
+		}
+		report.UncoveredEntities = append(report.UncoveredEntities, UncoveredEntity{
+			EntityID:   id,
+			Name:       e.Name,
+			Kind:       e.Kind,
+			SourceFile: e.SourceFile,
+			StartLine:  e.StartLine,
+			Language:   e.Language,
+			Module:     mod,
+			Severity:   entitySeverity(e),
+		})
+	}
+
+	// Sort: severity (high < medium < low) then file then name.
+	severityOrder := map[string]int{"high": 0, "medium": 1, "low": 2}
+	sort.SliceStable(report.UncoveredEntities, func(i, j int) bool {
+		si := severityOrder[report.UncoveredEntities[i].Severity]
+		sj := severityOrder[report.UncoveredEntities[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		if report.UncoveredEntities[i].SourceFile != report.UncoveredEntities[j].SourceFile {
+			return report.UncoveredEntities[i].SourceFile < report.UncoveredEntities[j].SourceFile
+		}
+		return report.UncoveredEntities[i].Name < report.UncoveredEntities[j].Name
+	})
+
+	// ── per-directory breakdown ───────────────────────────────────────────────
+	type dirStat struct{ total, covered int }
+	dirStats := make(map[string]*dirStat)
+
+	for id, e := range entByID {
+		if !prodIDs[id] {
+			continue
+		}
+		d := dirOf(e.SourceFile)
+		if _, ok := dirStats[d]; !ok {
+			dirStats[d] = &dirStat{}
+		}
+		dirStats[d].total++
+		if covered[id] > 0 {
+			dirStats[d].covered++
+		}
+	}
+
+	for d, s := range dirStats {
+		report.ByDirectory = append(report.ByDirectory, DirCoverage{
+			Dir:         d,
+			Total:       s.total,
+			Covered:     s.covered,
+			CoveragePct: pct(s.covered, s.total),
+		})
+	}
+	sort.Slice(report.ByDirectory, func(i, j int) bool {
+		return report.ByDirectory[i].Dir < report.ByDirectory[j].Dir
+	})
+
+	// ── per-module breakdown ──────────────────────────────────────────────────
+	type modStat struct{ total, covered int }
+	modStats := make(map[string]*modStat)
+
+	for id, e := range entByID {
+		if !prodIDs[id] {
+			continue
+		}
+		mod := ""
+		if e.Properties != nil {
+			mod = e.Properties["module"]
+		}
+		if mod == "" {
+			continue // skip entities without a module tag
+		}
+		if _, ok := modStats[mod]; !ok {
+			modStats[mod] = &modStat{}
+		}
+		modStats[mod].total++
+		if covered[id] > 0 {
+			modStats[mod].covered++
+		}
+	}
+
+	for m, s := range modStats {
+		report.ByModule = append(report.ByModule, ModuleCoverage{
+			Module:      m,
+			Total:       s.total,
+			Covered:     s.covered,
+			CoveragePct: pct(s.covered, s.total),
+		})
+	}
+	sort.Slice(report.ByModule, func(i, j int) bool {
+		return report.ByModule[i].Module < report.ByModule[j].Module
+	})
+
+	return report
+}

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -1,0 +1,310 @@
+package graph
+
+import (
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isTestFile unit tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestIsTestFile(t *testing.T) {
+	cases := []struct {
+		path string
+		want bool
+	}{
+		// Go
+		{"foo_test.go", true},
+		{"foo.go", false},
+		// Python
+		{"test_user.py", true},
+		{"user_test.py", true},
+		{"user.py", false},
+		// TypeScript / JS
+		{"user.test.ts", true},
+		{"user.spec.ts", true},
+		{"user.ts", false},
+		{"UserSpec.js", false},
+		{"user.test.js", true},
+		// Ruby
+		{"user_spec.rb", true},
+		{"user.rb", false},
+		// Java
+		{"UserTest.java", true},
+		{"UserTests.java", true},
+		{"UserSpec.java", true},
+		{"User.java", false},
+		// Kotlin
+		{"UserTest.kt", true},
+		// Path-segment
+		{"src/__tests__/user.ts", true},
+		{"src/test/User.java", true},
+		{"src/spec/user.rb", true},
+		{"src/main/User.java", false},
+	}
+	for _, tc := range cases {
+		got := isTestFile(tc.path)
+		if got != tc.want {
+			t.Errorf("isTestFile(%q) = %v, want %v", tc.path, got, tc.want)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ComputeCoverage tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+// makeDoc is a helper to construct a minimal graph.Document for tests.
+func makeDoc(entities []Entity, rels []Relationship) *Document {
+	return &Document{
+		Version:       SchemaVersion,
+		Entities:      entities,
+		Relationships: rels,
+	}
+}
+
+// TestComputeCoverage_Empty checks that an empty document returns zeroes.
+func TestComputeCoverage_Empty(t *testing.T) {
+	report := ComputeCoverage(makeDoc(nil, nil))
+	if report.TotalProduction != 0 {
+		t.Errorf("TotalProduction want 0, got %d", report.TotalProduction)
+	}
+	if report.CoveragePct != 0 {
+		t.Errorf("CoveragePct want 0, got %f", report.CoveragePct)
+	}
+}
+
+// TestComputeCoverage_DirectTESTSEdge verifies that an explicit TESTS edge
+// marks the target entity as covered.
+func TestComputeCoverage_DirectTESTSEdge(t *testing.T) {
+	entities := []Entity{
+		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
+		{ID: "test1", Name: "TestHandleUser", Kind: "Function", SourceFile: "handler_test.go"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "test1", ToID: "prod1", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.TotalProduction != 1 {
+		t.Errorf("TotalProduction want 1, got %d", report.TotalProduction)
+	}
+	if report.CoveredProduction != 1 {
+		t.Errorf("CoveredProduction want 1, got %d", report.CoveredProduction)
+	}
+	if report.CoveragePct != 100.0 {
+		t.Errorf("CoveragePct want 100, got %f", report.CoveragePct)
+	}
+	if len(report.UncoveredEntities) != 0 {
+		t.Errorf("UncoveredEntities want 0, got %d", len(report.UncoveredEntities))
+	}
+}
+
+// TestComputeCoverage_FiveTESTSEdges verifies that a test calling 5 production
+// entities generates 5 TESTS edges and marks all 5 as covered.
+func TestComputeCoverage_FiveTESTSEdges(t *testing.T) {
+	entities := []Entity{
+		{ID: "t1", Name: "TestAll", Kind: "Function", SourceFile: "all_test.go"},
+	}
+	for i := 0; i < 5; i++ {
+		entities = append(entities, Entity{
+			ID:         "p" + string(rune('1'+i)),
+			Name:       "Prod" + string(rune('A'+i)),
+			Kind:       "Function",
+			SourceFile: "prod.go",
+		})
+	}
+	// Build explicit TESTS edges (as if emitted by the testmap extractor).
+	rels := []Relationship{
+		{ID: "r1", FromID: "t1", ToID: "p1", Kind: "TESTS"},
+		{ID: "r2", FromID: "t1", ToID: "p2", Kind: "TESTS"},
+		{ID: "r3", FromID: "t1", ToID: "p3", Kind: "TESTS"},
+		{ID: "r4", FromID: "t1", ToID: "p4", Kind: "TESTS"},
+		{ID: "r5", FromID: "t1", ToID: "p5", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.TotalProduction != 5 {
+		t.Errorf("TotalProduction want 5, got %d", report.TotalProduction)
+	}
+	if report.CoveredProduction != 5 {
+		t.Errorf("CoveredProduction want 5, got %d", report.CoveredProduction)
+	}
+	if report.TotalTestsEdges != 5 {
+		t.Errorf("TotalTestsEdges want 5, got %d", report.TotalTestsEdges)
+	}
+	if len(report.UncoveredEntities) != 0 {
+		t.Errorf("UncoveredEntities want 0, got %d", len(report.UncoveredEntities))
+	}
+}
+
+// TestComputeCoverage_SyntheticFromCALLS verifies the synthetic fallback:
+// a test entity with CALLS edges to production entities gets virtual TESTS edges.
+func TestComputeCoverage_SyntheticFromCALLS(t *testing.T) {
+	entities := []Entity{
+		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "foo_test.go"},
+		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "foo.go"},
+		{ID: "p2", Name: "Bar", Kind: "Function", SourceFile: "bar.go"},
+	}
+	// No TESTS edges — only CALLS from test to prod.
+	rels := []Relationship{
+		{ID: "c1", FromID: "t1", ToID: "p1", Kind: "CALLS"},
+		{ID: "c2", FromID: "t1", ToID: "p2", Kind: "CALLS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	if report.CoveredProduction != 2 {
+		t.Errorf("CoveredProduction want 2 (synthetic), got %d", report.CoveredProduction)
+	}
+	if report.TotalTestsEdges != 2 {
+		t.Errorf("TotalTestsEdges want 2 (synthetic), got %d", report.TotalTestsEdges)
+	}
+	if len(report.UncoveredEntities) != 0 {
+		t.Errorf("UncoveredEntities want 0, got %d", len(report.UncoveredEntities))
+	}
+}
+
+// TestComputeCoverage_UntestedFlagged verifies that entities without any
+// TESTS inbound appear in UncoveredEntities.
+func TestComputeCoverage_UntestedFlagged(t *testing.T) {
+	entities := []Entity{
+		{ID: "p1", Name: "HandleUser", Kind: "http_endpoint_definition", SourceFile: "handler.go"},
+		{ID: "p2", Name: "ExportedFn", Kind: "Function", SourceFile: "lib.go"},
+		{ID: "p3", Name: "internalFn", Kind: "Function", SourceFile: "lib.go"},
+	}
+	// No test entities at all.
+	report := ComputeCoverage(makeDoc(entities, nil))
+	if report.TotalProduction != 3 {
+		t.Errorf("TotalProduction want 3, got %d", report.TotalProduction)
+	}
+	if report.CoveredProduction != 0 {
+		t.Errorf("CoveredProduction want 0, got %d", report.CoveredProduction)
+	}
+	if len(report.UncoveredEntities) != 3 {
+		t.Errorf("UncoveredEntities want 3, got %d", len(report.UncoveredEntities))
+	}
+	// The http_endpoint_definition should appear first (high severity).
+	if report.UncoveredEntities[0].Severity != "high" {
+		t.Errorf("first uncovered entity severity want high, got %s", report.UncoveredEntities[0].Severity)
+	}
+}
+
+// TestComputeCoverage_SeverityOrder checks high < medium < low ordering.
+func TestComputeCoverage_SeverityOrder(t *testing.T) {
+	entities := []Entity{
+		{ID: "e1", Name: "internalFn", Kind: "Function", SourceFile: "a.go"},
+		{ID: "e2", Name: "ExportedFn", Kind: "Function", SourceFile: "b.go"},
+		{ID: "e3", Name: "PostUser", Kind: "http_endpoint_definition", SourceFile: "c.go"},
+	}
+	report := ComputeCoverage(makeDoc(entities, nil))
+	sev := []string{}
+	for _, u := range report.UncoveredEntities {
+		sev = append(sev, u.Severity)
+	}
+	// high must come before medium must come before low.
+	sawHigh, sawMedium := false, false
+	for _, s := range sev {
+		switch s {
+		case "high":
+			if sawMedium {
+				t.Errorf("high after medium in severity ordering: %v", sev)
+			}
+			sawHigh = true
+		case "medium":
+			if !sawHigh && containsSeverity(sev, "high") {
+				t.Errorf("medium before high in severity ordering: %v", sev)
+			}
+			sawMedium = true
+		case "low":
+			_ = sawMedium // low must come last; already enforced by sortStable
+		}
+	}
+}
+
+func containsSeverity(sev []string, target string) bool {
+	for _, s := range sev {
+		if s == target {
+			return true
+		}
+	}
+	return false
+}
+
+// TestComputeCoverage_ByDirectory checks per-directory aggregation.
+func TestComputeCoverage_ByDirectory(t *testing.T) {
+	entities := []Entity{
+		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "pkg/foo/foo.go"},
+		{ID: "p2", Name: "Bar", Kind: "Function", SourceFile: "pkg/foo/bar.go"},
+		{ID: "p3", Name: "Baz", Kind: "Function", SourceFile: "pkg/baz/baz.go"},
+		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "pkg/foo/foo_test.go"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "t1", ToID: "p1", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	dirMap := make(map[string]DirCoverage)
+	for _, d := range report.ByDirectory {
+		dirMap[d.Dir] = d
+	}
+	fooDir := dirMap["pkg/foo"]
+	if fooDir.Total != 2 {
+		t.Errorf("pkg/foo total want 2, got %d", fooDir.Total)
+	}
+	if fooDir.Covered != 1 {
+		t.Errorf("pkg/foo covered want 1, got %d", fooDir.Covered)
+	}
+	bazDir := dirMap["pkg/baz"]
+	if bazDir.Total != 1 {
+		t.Errorf("pkg/baz total want 1, got %d", bazDir.Total)
+	}
+	if bazDir.Covered != 0 {
+		t.Errorf("pkg/baz covered want 0, got %d", bazDir.Covered)
+	}
+}
+
+// TestComputeCoverage_ByModule checks per-module aggregation.
+func TestComputeCoverage_ByModule(t *testing.T) {
+	entities := []Entity{
+		{ID: "p1", Name: "A", Kind: "Function", SourceFile: "a.go",
+			Properties: map[string]string{"module": "auth"}},
+		{ID: "p2", Name: "B", Kind: "Function", SourceFile: "b.go",
+			Properties: map[string]string{"module": "auth"}},
+		{ID: "p3", Name: "C", Kind: "Function", SourceFile: "c.go",
+			Properties: map[string]string{"module": "payments"}},
+		{ID: "t1", Name: "TestA", Kind: "Function", SourceFile: "a_test.go"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "t1", ToID: "p1", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	modMap := make(map[string]ModuleCoverage)
+	for _, m := range report.ByModule {
+		modMap[m.Module] = m
+	}
+	authMod := modMap["auth"]
+	if authMod.Total != 2 {
+		t.Errorf("auth.Total want 2, got %d", authMod.Total)
+	}
+	if authMod.Covered != 1 {
+		t.Errorf("auth.Covered want 1, got %d", authMod.Covered)
+	}
+	payMod := modMap["payments"]
+	if payMod.Total != 1 {
+		t.Errorf("payments.Total want 1, got %d", payMod.Total)
+	}
+	if payMod.Covered != 0 {
+		t.Errorf("payments.Covered want 0, got %d", payMod.Covered)
+	}
+}
+
+// TestComputeCoverage_HTTPEndpointHighSeverity ensures HTTP endpoints without
+// tests are surfaced with "high" severity.
+func TestComputeCoverage_HTTPEndpointHighSeverity(t *testing.T) {
+	entities := []Entity{
+		{ID: "ep1", Name: "POST /users", Kind: "http_endpoint", SourceFile: "routes.go"},
+	}
+	report := ComputeCoverage(makeDoc(entities, nil))
+	if len(report.UncoveredEntities) != 1 {
+		t.Fatalf("want 1 uncovered, got %d", len(report.UncoveredEntities))
+	}
+	if report.UncoveredEntities[0].Severity != "high" {
+		t.Errorf("HTTP endpoint severity want high, got %s", report.UncoveredEntities[0].Severity)
+	}
+}

--- a/internal/mcp/coverage_tools.go
+++ b/internal/mcp/coverage_tools.go
@@ -1,0 +1,186 @@
+// coverage_tools.go — MCP tool for test-coverage analysis (issue #1323).
+//
+// Tool: archigraph_test_coverage
+//
+//	Returns per-entity and per-directory test coverage statistics for the
+//	resolved group. Identifies production entities that have no TESTS edge
+//	inbound (untested) and ranks them by severity.
+//
+// Severity rules:
+//
+//	high   — HTTP endpoint without tests (unprotected surface area)
+//	medium — exported Function / Method without tests
+//	low    — other in-scope entities without tests
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleTestCoverage implements archigraph_test_coverage.
+func (s *Server) handleTestCoverage(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, toolErr := s.resolveAndGroup(req)
+	if toolErr != nil {
+		return toolErr, nil
+	}
+
+	repoFilter := argStringSlice(req, "repo_filter")
+	severityFilter := argString(req, "severity", "") // high | medium | low | ""
+	limit := argInt(req, "limit", 100)
+	topDir := argBool(req, "top_directories", false)
+
+	// ── accumulate across repos ───────────────────────────────────────────────
+	type dirAccum struct{ total, covered int }
+	dirAcc := make(map[string]*dirAccum)
+
+	totalProd := 0
+	coveredProd := 0
+	totalTests := 0
+	totalEdges := 0
+	var allUncovered []graph.UncoveredEntity
+
+	severityOrder := map[string]int{"high": 0, "medium": 1, "low": 2}
+
+	// Iterate over repos in sorted order for deterministic output.
+	repoNames := make([]string, 0, len(lg.Repos))
+	for name := range lg.Repos {
+		repoNames = append(repoNames, name)
+	}
+	sort.Strings(repoNames)
+
+	for _, name := range repoNames {
+		rd := lg.Repos[name]
+		if rd == nil || rd.Doc == nil {
+			continue
+		}
+		if len(repoFilter) > 0 && !repoMatchesSlice(rd.Repo, repoFilter) {
+			continue
+		}
+
+		report := graph.ComputeCoverage(rd.Doc)
+		totalProd += report.TotalProduction
+		coveredProd += report.CoveredProduction
+		totalTests += report.TotalTests
+		totalEdges += report.TotalTestsEdges
+
+		for _, u := range report.UncoveredEntities {
+			if severityFilter != "" && u.Severity != severityFilter {
+				continue
+			}
+			allUncovered = append(allUncovered, u)
+		}
+
+		for _, d := range report.ByDirectory {
+			if _, ok := dirAcc[d.Dir]; !ok {
+				dirAcc[d.Dir] = &dirAccum{}
+			}
+			dirAcc[d.Dir].total += d.Total
+			dirAcc[d.Dir].covered += d.Covered
+		}
+	}
+
+	// ── compute group-level percentage ────────────────────────────────────────
+	covPct := 0.0
+	if totalProd > 0 {
+		covPct = 100.0 * float64(coveredProd) / float64(totalProd)
+	}
+
+	// ── sort + cap uncovered list ─────────────────────────────────────────────
+	sort.SliceStable(allUncovered, func(i, j int) bool {
+		si := severityOrder[allUncovered[i].Severity]
+		sj := severityOrder[allUncovered[j].Severity]
+		if si != sj {
+			return si < sj
+		}
+		if allUncovered[i].SourceFile != allUncovered[j].SourceFile {
+			return allUncovered[i].SourceFile < allUncovered[j].SourceFile
+		}
+		return allUncovered[i].Name < allUncovered[j].Name
+	})
+	if len(allUncovered) > limit {
+		allUncovered = allUncovered[:limit]
+	}
+
+	// ── build top-directory breakdown ─────────────────────────────────────────
+	type dirRow struct {
+		dir         string
+		total       int
+		covered     int
+		coveragePct float64
+	}
+	var dirRows []dirRow
+	if topDir {
+		for d, acc := range dirAcc {
+			p := 0.0
+			if acc.total > 0 {
+				p = 100.0 * float64(acc.covered) / float64(acc.total)
+			}
+			dirRows = append(dirRows, dirRow{
+				dir:         d,
+				total:       acc.total,
+				covered:     acc.covered,
+				coveragePct: p,
+			})
+		}
+		// Sort least-covered first for actionability.
+		sort.Slice(dirRows, func(i, j int) bool {
+			if dirRows[i].coveragePct != dirRows[j].coveragePct {
+				return dirRows[i].coveragePct < dirRows[j].coveragePct
+			}
+			return dirRows[i].dir < dirRows[j].dir
+		})
+		if len(dirRows) > 20 {
+			dirRows = dirRows[:20]
+		}
+	}
+
+	// ── render text output ────────────────────────────────────────────────────
+	out := fmt.Sprintf(
+		"## Test Coverage — group %q\n\n"+
+			"Production entities : %d\n"+
+			"Covered             : %d (%.1f%%)\n"+
+			"Test entities       : %d\n"+
+			"TESTS edges (total) : %d\n",
+		lg.Name,
+		totalProd, coveredProd, covPct,
+		totalTests, totalEdges,
+	)
+
+	out += fmt.Sprintf("\n### Untested entities (%d shown", len(allUncovered))
+	if severityFilter != "" {
+		out += ", severity=" + severityFilter
+	}
+	out += ")\n\n"
+	if len(allUncovered) == 0 {
+		out += "_No untested entities found._\n"
+	}
+	for _, u := range allUncovered {
+		out += fmt.Sprintf("- [%s] %s  %s:%d\n",
+			u.Severity, u.Name, u.SourceFile, u.StartLine)
+	}
+
+	if topDir && len(dirRows) > 0 {
+		out += "\n### Directories by coverage (lowest first)\n\n"
+		out += fmt.Sprintf("%-8s %-6s %-6s  %s\n", "Covered%", "Cvrd", "Total", "Dir")
+		for _, d := range dirRows {
+			out += fmt.Sprintf("%-8.1f %-6d %-6d  %s\n", d.coveragePct, d.covered, d.total, d.dir)
+		}
+	}
+
+	return mcpapi.NewToolResultText(out), nil
+}
+
+// repoMatchesSlice returns true when slug matches any entry in filter.
+func repoMatchesSlice(slug string, filter []string) bool {
+	for _, f := range filter {
+		if f == slug {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -438,6 +438,21 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 	), s.wrap("archigraph_auth_coverage", s.handleAuthCoverage))
+
+	// #1323: test-coverage graph — link Test entities to the code they exercise.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_test_coverage",
+		mcpapi.WithDescription("Test-coverage analysis: identifies production entities (Function, Method, Class, "+
+			"http_endpoint) that have no incoming TESTS edge. "+
+			"Ranks untested code by severity: high=HTTP endpoints, medium=exported functions, low=other. "+
+			"Use top_directories=true to see which directories have the worst coverage gaps. "+
+			"severity filter: high|medium|low (empty = all)."),
+		mcpapi.WithArray("repo_filter", mcpapi.WithStringItems()),
+		mcpapi.WithString("severity", mcpapi.Description("Filter uncovered list: high|medium|low (empty=all)")),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),
+		mcpapi.WithBoolean("top_directories", mcpapi.DefaultBool(false)),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+	), s.wrap("archigraph_test_coverage", s.handleTestCoverage))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard


### PR DESCRIPTION
## What

Implements the test-coverage graph layer requested in #1323. Agents and the dashboard can now answer **"which production entities lack tests?"** without any external coverage tooling — the signal is derived entirely from the indexed graph.

## Why

The testmap extractor already emits TESTS edges (test fn → prod fn). Before this PR there was no way to invert that signal (prod fn → "has tests?") or surface coverage gaps per directory/module. This fills that gap.

## How

**Algorithm (`internal/graph/coverage.go` — `ComputeCoverage`)**

- Phase 1: collect explicit TESTS edges (emitted by `_cross_testmap` extractor).
- Phase 2 (synthetic fallback): for any test entity with CALLS edges to uncovered production entities, emit a virtual TESTS link (counted in totals, not written back).
- Severity ranking for untested entities: `high`=HTTP endpoints, `medium`=exported fns, `low`=everything else.
- Per-directory and per-module breakdown in `CoverageReport`.

**HTTP surface (`internal/dashboard/handlers_coverage.go`)**

Route: `GET /api/quality/coverage/{group}`
Query params: `?dir=`, `?module=`, `?severity=high|medium|low`, `?limit=N` (default 200).

**MCP tool (`internal/mcp/coverage_tools.go`)**

Tool: `archigraph_test_coverage` — reads from already-loaded in-memory `LoadedGroup` docs (zero extra I/O). Supports `repo_filter`, `severity`, `limit`, `top_directories` params. Returns ranked untested-entity list + optional directory breakdown sorted by least-covered first.

## Tests

10 table-driven tests in `internal/graph/coverage_test.go` covering: empty doc, direct TESTS edge, 5-edge acceptance case, synthetic CALLS fallback, untested flagging, severity ordering, per-dir and per-module aggregation, HTTP endpoint high-severity.

All pass. `go build` and `go vet` clean on all three touched packages.

## Checklist

- [x] Route registered: `GET /api/quality/coverage/{group}`
- [x] MCP tool registered: `archigraph_test_coverage`
- [x] 10 tests pass
- [x] `go build ./internal/graph ./internal/mcp ./internal/dashboard` clean
- [x] No client names in any artifact
- [x] Issue #1323 filed before implementation

🤖 Generated with [Claude Code](https://claude.com/claude-code)