### PR TITLE
[#1329] Add daily quality-metrics persistence + trend sparklines

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -455,6 +455,18 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 		// Best-effort — surface as a warning, not a hard failure.
 		warning = fmt.Sprintf("link passes failed: %v", err)
 	}
+
+	// Persist a quality-metrics snapshot to health-history.jsonl (#1329).
+	// Best-effort: failure is logged but never blocks the caller.
+	go func() {
+		if layout, lerr := daemon.DefaultLayout(); lerr == nil {
+			if herr := appendRebuildHistory(layout.Root, args.Group, cfg, rebuilt); herr != nil {
+				fmt.Fprintf(os.Stderr, "archigraph: record quality history for %s: %v (non-fatal)\n",
+					args.Group, herr)
+			}
+		}
+	}()
+
 	return rebuilt, warning, nil
 }
 

--- a/cmd/archigraph/rebuild_history.go
+++ b/cmd/archigraph/rebuild_history.go
@@ -1,0 +1,187 @@
+package main
+
+// rebuild_history.go — capture quality metrics after every daemon rebuild
+// and persist them to health-history.jsonl (#1329).
+//
+// All metric collection is best-effort: errors are logged and silently
+// skipped so a failed scan never blocks the rebuild response.
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/quality"
+	"github.com/cajasmota/archigraph/internal/quality/audit"
+	"github.com/cajasmota/archigraph/internal/registry"
+	"github.com/cajasmota/archigraph/internal/secrets"
+)
+
+// appendRebuildHistory measures the current graph quality for a group and
+// appends one HealthEntry to the JSONL history file.
+//
+// root is the daemon layout root (typically ~/.archigraph).
+// group is the archigraph group name.
+// cfg is the already-loaded group configuration.
+// rebuiltPaths is the list of repo paths that were successfully indexed.
+//
+// The function is designed to run in a goroutine: all errors are surfaced
+// via the returned error rather than panicking.
+func appendRebuildHistory(root, group string, cfg *registry.GroupConfig, rebuiltPaths []string) error {
+	entry := quality.HealthEntry{
+		Timestamp: time.Now().UTC(),
+		Group:     group,
+	}
+
+	// ── Core metrics (orphan + bug rate) ─────────────────────────────────────
+	// Re-use the audit machinery that handleQualityComposite uses.
+	totalEntities := 0
+	totalOrphans := 0
+	totalImports := 0
+	goodImports := 0
+
+	for _, repoPath := range rebuiltPaths {
+		rep, err := audit.AuditPath(repoPath, false)
+		if err != nil || len(rep.Repos) == 0 {
+			continue
+		}
+		rr := rep.Repos[0]
+		totalEntities += rr.Entities
+		totalOrphans += rr.Orphans
+		totalImports += rr.ImportsTotal
+		goodImports += rr.ImportsToIDFormat[audit.ImportFormatHex] +
+			rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+	}
+
+	entry.TotalEntities = totalEntities
+	if totalEntities > 0 {
+		entry.OrphanRate = 100.0 * float64(totalOrphans) / float64(totalEntities)
+	}
+	if totalImports > 0 {
+		entry.BugRate = 100.0 * float64(totalImports-goodImports) / float64(totalImports)
+	}
+	entry.HealthScore = quality.ComputeHealthScore(entry.OrphanRate, entry.BugRate)
+
+	// ── Coverage + cycles + entity counts ────────────────────────────────────
+	// Walk all repos in the group and aggregate graph-level stats.
+	totalProduction := 0
+	coveredProduction := 0
+	totalCycles := 0
+	totalFlows := 0
+	totalEndpoints := 0
+	hasCoverage := false
+	hasCycles := false
+
+	for _, repoPath := range rebuiltPaths {
+		stateDir := stateDirForRepoPath(repoPath)
+		doc, err := loadGraphFromStateDir(stateDir)
+		if err != nil || doc == nil {
+			continue
+		}
+
+		// Coverage.
+		cov := graph.ComputeCoverage(doc)
+		hasCoverage = true
+		totalProduction += cov.TotalProduction
+		coveredProduction += cov.CoveredProduction
+
+		// Cycles. Pass nil pagerank — uniform weights are fine for counting.
+		cycles := graph.FindImportCycles(doc.Entities, doc.Relationships, nil)
+		hasCycles = true
+		totalCycles += len(cycles)
+
+		// Entity type counts.
+		for _, e := range doc.Entities {
+			switch e.Kind {
+			case "http_endpoint", "http_endpoint_definition", "http_endpoint_call":
+				totalEndpoints++
+			}
+			if isProcessFlow(e) {
+				totalFlows++
+			}
+		}
+	}
+
+	entry.TotalFlows = totalFlows
+	entry.TotalEndpoints = totalEndpoints
+
+	if hasCoverage && totalProduction > 0 {
+		covPct := 100.0 * float64(coveredProduction) / float64(totalProduction)
+		entry.CoveragePct = &covPct
+	}
+	if hasCycles {
+		entry.Cycles = &totalCycles
+	}
+
+	// ── Auth-uncovered endpoint count ─────────────────────────────────────────
+	// Count endpoints without an auth annotation by scanning relationship kinds.
+	authUncovered := countAuthUncoveredEndpoints(rebuiltPaths)
+	entry.AuthUncovered = &authUncovered
+
+	// ── Secrets ──────────────────────────────────────────────────────────────
+	// Run a quick secret scan across all repos. Cap per-file size at 256 KB to
+	// bound memory; skip on scan error rather than failing the whole snapshot.
+	const maxSecretFileSizeBytes = 256 * 1024
+	totalSecrets := 0
+	for _, repoPath := range rebuiltPaths {
+		findings, err := secrets.ScanPath(repoPath, maxSecretFileSizeBytes)
+		if err != nil {
+			// Non-fatal: log and skip.
+			fmt.Fprintf(os.Stderr, "archigraph: secret scan %s: %v (skipped)\n", repoPath, err)
+			continue
+		}
+		totalSecrets += len(findings)
+	}
+	entry.Secrets = &totalSecrets
+
+	return quality.AppendEntry(root, entry)
+}
+
+// isProcessFlow returns true for entity kinds that represent process flows.
+func isProcessFlow(e graph.Entity) bool {
+	switch e.Kind {
+	case "process", "SCOPE.Process":
+		return true
+	}
+	return len(e.Kind) > 14 && e.Kind[:14] == "SCOPE.Process."
+}
+
+// stateDirForRepoPath returns the daemon state directory for a repo path.
+// Delegates to the same helper used by the daemon indexer.
+func stateDirForRepoPath(repoPath string) string {
+	return daemon.StateDirForRepo(repoPath)
+}
+
+// countAuthUncoveredEndpoints returns the number of http_endpoint entities
+// that have no outgoing HAS_AUTH or REQUIRES_AUTH relationship across all
+// rebuilt repos.
+func countAuthUncoveredEndpoints(repoPaths []string) int {
+	uncovered := 0
+	for _, repoPath := range repoPaths {
+		stateDir := stateDirForRepoPath(repoPath)
+		doc, err := loadGraphFromStateDir(stateDir)
+		if err != nil || doc == nil {
+			continue
+		}
+
+		// Build set of endpoint IDs that have an auth edge.
+		authed := make(map[string]bool, 16)
+		for _, r := range doc.Relationships {
+			if r.Kind == "HAS_AUTH" || r.Kind == "REQUIRES_AUTH" || r.Kind == "auth" {
+				authed[r.FromID] = true
+			}
+		}
+		// Count endpoint entities not in the authed set.
+		for _, e := range doc.Entities {
+			switch e.Kind {
+			case "http_endpoint", "http_endpoint_definition":
+				if !authed[e.ID] {
+					uncovered++
+				}
+			}
+		}
+	}
+	return uncovered
+}

--- a/dashboard/src/api/client.ts
+++ b/dashboard/src/api/client.ts
@@ -1386,12 +1386,22 @@ export interface HealthEntry {
   timestamp: string
   group: string
   total_entities: number
+  total_flows?: number
+  total_endpoints?: number
   /** Percentage of entities with no incoming relationship (0–100). */
   orphan_rate: number
   /** Percentage of repair candidates (0–100). */
   bug_rate: number
   /** Composite quality score: max(0, 100 - orphan_rate - bug_rate). */
   health_score: number
+  /** Test coverage % (0–100) when available. */
+  coverage_pct?: number
+  /** Number of import cycles detected. */
+  cycles?: number
+  /** Number of HTTP endpoints with no auth annotation. */
+  auth_uncovered?: number
+  /** Number of hardcoded-secret findings. */
+  secrets?: number
   /** Enrichment recall percentage when available. */
   recall_pct?: number
 }
@@ -1409,6 +1419,47 @@ export async function fetchQualityHistory(
 ): Promise<QualityHistoryReply> {
   return apiFetch<QualityHistoryReply>(
     `/api/quality/history/${encodeURIComponent(group)}?days=${days}`,
+  )
+}
+
+// ── Quality trends — per-metric sparklines (#1329) ───────────────────────────
+
+/** One data point in a metric time series. */
+export interface TrendPoint {
+  /** ISO-8601 timestamp. */
+  ts: string
+  /** Metric value at this timestamp. */
+  v: number
+}
+
+/** Time-series data for a single quality metric. */
+export interface MetricTrend {
+  label: string
+  unit: '%' | 'count'
+  lower_is_better: boolean
+  /** Target threshold (0 when none). */
+  goal: number
+  points: TrendPoint[]
+  latest?: number
+  /** Change vs ~7 days ago (positive = improvement when !lower_is_better). */
+  delta_7d?: number
+  /** Change vs ~30 days ago. */
+  delta_30d?: number
+}
+
+export interface QualityTrendsReply {
+  group: string
+  days: number
+  metrics: MetricTrend[]
+}
+
+/** GET /api/quality/trends/{group}?days=N */
+export async function fetchQualityTrends(
+  group: string,
+  days = 30,
+): Promise<QualityTrendsReply> {
+  return apiFetch<QualityTrendsReply>(
+    `/api/quality/trends/${encodeURIComponent(group)}?days=${days}`,
   )
 }
 

--- a/dashboard/src/routes/quality.tsx
+++ b/dashboard/src/routes/quality.tsx
@@ -3,10 +3,11 @@ import { useParams } from 'react-router-dom'
 import { useQuery, useMutation } from '@tanstack/react-query'
 import {
   fetchQualityOrphans, fetchQualityFixtures, postQualityRecall,
-  fetchQualityHistory,
+  fetchQualityHistory, fetchQualityTrends,
   type OrphanAuditReply, type RecallReply, type KindStat, type RepoOrphanStats,
   type HealthEntry,
   type QualityHistoryReply,
+  type MetricTrend, type TrendPoint,
 } from '@/api/client'
 import {
   ShieldCheck, ShieldAlert, PlayCircle, RefreshCw,
@@ -392,7 +393,7 @@ function downloadCSV(entries: HealthEntry[], group: string) {
 // Tab type
 // ─────────────────────────────────────────────────────────────────────────────
 
-type Tab = 'history' | 'orphans' | 'recall'
+type Tab = 'history' | 'trends' | 'orphans' | 'recall'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // History tab (#1214)
@@ -1070,6 +1071,264 @@ function SummaryCard({
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
+// Inline SVG Sparkline (no external chart dependency)
+// ─────────────────────────────────────────────────────────────────────────────
+
+interface SparklineProps {
+  points: TrendPoint[]
+  /** When true, lower values are better (colours inverted). */
+  lowerIsBetter?: boolean
+  goal?: number
+  width?: number
+  height?: number
+}
+
+/** Tiny inline SVG sparkline — one per metric in the Trends grid. */
+function Sparkline({ points, lowerIsBetter = false, goal, width = 120, height = 36 }: SparklineProps) {
+  if (points.length === 0) return <span className="text-xs text-slate-400 italic">no data</span>
+  if (points.length === 1) {
+    return (
+      <svg viewBox={`0 0 ${width} ${height}`} style={{ width, height }}>
+        <circle cx={width / 2} cy={height / 2} r={3} className="fill-sky-500" />
+      </svg>
+    )
+  }
+
+  const vals = points.map((p) => p.v)
+  const minV = Math.min(...vals)
+  const maxV = Math.max(...vals)
+  const range = Math.max(maxV - minV, 1)
+
+  const PAD = { x: 4, y: 4 }
+  const innerW = width - PAD.x * 2
+  const innerH = height - PAD.y * 2
+
+  const toX = (i: number) => PAD.x + (i / (points.length - 1)) * innerW
+  const toY = (v: number) => PAD.y + innerH - ((v - minV) / range) * innerH
+
+  const polyline = points.map((p, i) => `${toX(i)},${toY(p.v)}`).join(' ')
+
+  const last = vals[vals.length - 1]
+  const first = vals[0]
+  const improved = lowerIsBetter ? last <= first : last >= first
+  const lineColor = improved ? '#10b981' /* emerald-500 */ : '#ef4444' /* red-500 */
+
+  return (
+    <svg viewBox={`0 0 ${width} ${height}`} style={{ width, height }} className="overflow-visible">
+      {/* Goal line when within view range */}
+      {goal !== undefined && goal >= minV && goal <= maxV && (
+        <line
+          x1={PAD.x} y1={toY(goal)}
+          x2={PAD.x + innerW} y2={toY(goal)}
+          stroke="#94a3b8"
+          strokeWidth={0.8}
+          strokeDasharray="3 2"
+        />
+      )}
+      <polyline
+        points={polyline}
+        fill="none"
+        stroke={lineColor}
+        strokeWidth={1.5}
+        strokeLinejoin="round"
+        strokeLinecap="round"
+      />
+      {/* Last-point dot */}
+      <circle
+        cx={toX(points.length - 1)}
+        cy={toY(last)}
+        r={2.5}
+        fill={lineColor}
+      />
+    </svg>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Metric card (one per metric in the Trends grid)
+// ─────────────────────────────────────────────────────────────────────────────
+
+function TrendArrow({ delta, lowerIsBetter }: { delta: number; lowerIsBetter: boolean }) {
+  const improved = lowerIsBetter ? delta <= 0 : delta >= 0
+  const sign = delta > 0 ? '+' : ''
+  if (Math.abs(delta) < 0.1) {
+    return <span className="inline-flex items-center gap-0.5 text-xs text-slate-400"><Minus className="w-3 h-3" />stable</span>
+  }
+  return (
+    <span className={`inline-flex items-center gap-0.5 text-xs font-medium ${improved ? 'text-emerald-500' : 'text-red-500'}`}>
+      {improved ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+      {sign}{delta.toFixed(1)}
+    </span>
+  )
+}
+
+function MetricCard({ mt }: { mt: MetricTrend }) {
+  const hasGoal = mt.goal > 0
+  const onTarget = mt.latest !== undefined && hasGoal && (
+    mt.lower_is_better ? mt.latest <= mt.goal : mt.latest >= mt.goal
+  )
+
+  return (
+    <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-white dark:bg-slate-900 p-3 flex flex-col gap-2">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-2">
+        <span className="text-xs font-medium text-slate-600 dark:text-slate-300 leading-tight">{mt.label}</span>
+        {hasGoal && (
+          <span className={`text-xs px-1.5 py-0.5 rounded-full font-mono shrink-0 ${
+            onTarget
+              ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300'
+              : 'bg-slate-100 dark:bg-slate-800 text-slate-500 dark:text-slate-400'
+          }`}>
+            goal {mt.goal}{mt.unit === '%' ? '%' : ''}
+          </span>
+        )}
+      </div>
+
+      {/* Sparkline */}
+      <div className="flex items-end justify-center py-1">
+        <Sparkline points={mt.points} lowerIsBetter={mt.lower_is_better} goal={mt.goal} width={140} height={40} />
+      </div>
+
+      {/* Latest value + deltas */}
+      <div className="flex items-end justify-between gap-2">
+        <div>
+          <span className="font-mono text-lg font-bold text-slate-800 dark:text-slate-100">
+            {mt.latest !== undefined ? mt.latest.toFixed(mt.unit === '%' ? 1 : 0) : '—'}
+          </span>
+          <span className="text-xs text-slate-400 dark:text-slate-500 ml-1">{mt.unit}</span>
+        </div>
+        <div className="flex flex-col items-end gap-0.5">
+          {mt.delta_7d !== undefined && (
+            <div className="flex items-center gap-1">
+              <span className="text-[10px] text-slate-400">7d</span>
+              <TrendArrow delta={mt.delta_7d} lowerIsBetter={mt.lower_is_better} />
+            </div>
+          )}
+          {mt.delta_30d !== undefined && (
+            <div className="flex items-center gap-1">
+              <span className="text-[10px] text-slate-400">30d</span>
+              <TrendArrow delta={mt.delta_30d} lowerIsBetter={mt.lower_is_better} />
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Trends tab (#1329) — per-metric sparklines
+// ─────────────────────────────────────────────────────────────────────────────
+
+function TrendsTab({ group }: { group: string }) {
+  const [days, setDays] = useState<number>(30)
+
+  const { data, isLoading, isError, refetch, isFetching } = useQuery({
+    queryKey: ['quality-trends', group, days],
+    queryFn: () => fetchQualityTrends(group, days),
+    staleTime: 60_000,
+  })
+
+  const metrics = data?.metrics ?? []
+
+  return (
+    <div className="space-y-5">
+      {/* Controls */}
+      <div className="flex items-center justify-between">
+        <div className="flex rounded-md border border-slate-200 dark:border-slate-700 overflow-hidden text-xs">
+          {([7, 30, 90] as const).map((d) => (
+            <button
+              key={d}
+              onClick={() => setDays(d)}
+              className={[
+                'px-3 py-1.5 transition-colors',
+                days === d
+                  ? 'bg-sky-50 dark:bg-sky-900/30 text-sky-600 dark:text-sky-400 font-semibold'
+                  : 'text-slate-500 hover:bg-slate-50 dark:hover:bg-slate-800',
+              ].join(' ')}
+            >
+              {d}d
+            </button>
+          ))}
+        </div>
+        <button
+          onClick={() => refetch()}
+          disabled={isFetching}
+          className="p-1.5 rounded text-slate-400 hover:text-slate-700 dark:hover:text-slate-200 hover:bg-slate-100 dark:hover:bg-slate-800 transition-colors disabled:opacity-40"
+          aria-label="Refresh"
+        >
+          <RefreshCw className={`w-4 h-4 ${isFetching ? 'animate-spin' : ''}`} />
+        </button>
+      </div>
+
+      {isLoading && (
+        <div className="flex items-center justify-center py-16 text-slate-400">
+          <RefreshCw className="w-5 h-5 animate-spin mr-2" />
+          Loading trends…
+        </div>
+      )}
+
+      {isError && (
+        <div className="rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          Failed to load quality trends. Make sure the daemon is running and the group exists.
+        </div>
+      )}
+
+      {!isLoading && !isError && metrics.length === 0 && (
+        <div className="rounded-lg border border-slate-200 dark:border-slate-700 bg-slate-50 dark:bg-slate-900 px-6 py-10 text-center">
+          <Activity className="w-8 h-8 mx-auto mb-3 text-slate-300 dark:text-slate-600" />
+          <p className="text-sm font-medium text-slate-600 dark:text-slate-400">No trend data yet</p>
+          <p className="text-xs text-slate-400 dark:text-slate-500 mt-1">
+            Run{' '}
+            <code className="font-mono bg-slate-100 dark:bg-slate-800 px-1 rounded">
+              archigraph rebuild {group}
+            </code>{' '}
+            a few times to start accumulating metrics.
+          </p>
+        </div>
+      )}
+
+      {!isLoading && !isError && metrics.length > 0 && (
+        <>
+          <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-3">
+            {metrics.map((mt) => (
+              <MetricCard key={mt.label} mt={mt} />
+            ))}
+          </div>
+
+          {/* Regression alert: any metric that degraded significantly vs 7d */}
+          {(() => {
+            const regressions = metrics.filter((mt) => {
+              if (mt.delta_7d === undefined) return false
+              const worsened = mt.lower_is_better ? mt.delta_7d > 0 : mt.delta_7d < 0
+              return worsened && Math.abs(mt.delta_7d) >= 5
+            })
+            if (regressions.length === 0) return null
+            return (
+              <div className="rounded-lg border border-amber-200 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 px-4 py-3">
+                <div className="flex items-center gap-2 mb-1">
+                  <AlertTriangle className="w-4 h-4 text-amber-500 shrink-0" />
+                  <span className="text-sm font-semibold text-amber-800 dark:text-amber-200">
+                    Regression detected (vs 7 days ago)
+                  </span>
+                </div>
+                <ul className="text-xs text-amber-700 dark:text-amber-300 space-y-0.5 ml-6 list-disc">
+                  {regressions.map((mt) => (
+                    <li key={mt.label}>
+                      <strong>{mt.label}</strong>: {mt.delta_7d! > 0 ? '+' : ''}{mt.delta_7d!.toFixed(1)}{mt.unit === '%' ? '%' : ''} change
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            )
+          })()}
+        </>
+      )}
+    </div>
+  )
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
 // Root route component
 // ─────────────────────────────────────────────────────────────────────────────
 
@@ -1086,14 +1345,14 @@ export function QualityRoute() {
           <div>
             <h1 className="text-lg font-bold text-slate-800 dark:text-slate-200">Quality</h1>
             <p className="text-sm text-slate-500 dark:text-slate-400">
-              Health-score history, orphan audit, and recall measurement for <strong>{group}</strong>
+              Per-metric trend sparklines, history, orphan audit, and recall for <strong>{group}</strong>
             </p>
           </div>
         </div>
 
         {/* Tabs */}
         <div className="flex gap-1 border-b border-slate-200 dark:border-slate-800">
-          {(['history', 'orphans', 'recall'] as const).map(tab => (
+          {(['trends', 'history', 'orphans', 'recall'] as const).map(tab => (
             <button
               key={tab}
               type="button"
@@ -1105,13 +1364,20 @@ export function QualityRoute() {
                   : 'border-transparent text-slate-500 hover:text-slate-700 dark:hover:text-slate-300',
               ].join(' ')}
             >
-              {tab === 'history' ? 'History' : tab === 'orphans' ? 'Orphan audit' : 'Recall measurement'}
+              {tab === 'trends'
+                ? 'Trends'
+                : tab === 'history'
+                ? 'History'
+                : tab === 'orphans'
+                ? 'Orphan audit'
+                : 'Recall measurement'}
             </button>
           ))}
         </div>
 
         {/* Tab content */}
         <div className="min-h-64">
+          {activeTab === 'trends' && <TrendsTab group={group} />}
           {activeTab === 'history' && <HistoryTab group={group} />}
           {activeTab === 'orphans' && <OrphanTab group={group} />}
           {activeTab === 'recall' && <RecallTab />}

--- a/internal/dashboard/handlers_quality_trends.go
+++ b/internal/dashboard/handlers_quality_trends.go
@@ -1,0 +1,278 @@
+package dashboard
+
+// handlers_quality_trends.go — GET /api/quality/trends/{group}
+//
+// Returns per-metric time-series data for a group so the Quality surface
+// can render inline sparklines. Each metric is returned as a separate
+// series so the frontend can render individual mini-charts without
+// having to fan-out multiple requests.
+//
+// Route registered in server.go:
+//
+//	GET /api/quality/trends/{group}?days=N
+
+import (
+	"net/http"
+	"strconv"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/quality"
+)
+
+// TrendPoint is a single data point in a metric series.
+type TrendPoint struct {
+	// Timestamp is the ISO-8601 rebuild timestamp.
+	Timestamp string `json:"ts"`
+	// Value is the metric value at this point.
+	Value float64 `json:"v"`
+}
+
+// MetricTrend holds the time series for one metric together with the
+// goal threshold and the current-vs-reference delta.
+type MetricTrend struct {
+	// Label is the human-readable metric name.
+	Label string `json:"label"`
+	// Unit is the display unit ("%" or "count").
+	Unit string `json:"unit"`
+	// LowerIsBetter marks metrics where improvement means going down.
+	LowerIsBetter bool `json:"lower_is_better"`
+	// Goal is the target value (0 when no goal is set).
+	Goal float64 `json:"goal,omitempty"`
+	// Points is the time series, oldest first.
+	Points []TrendPoint `json:"points"`
+	// Latest is the most-recent value, or nil when no data.
+	Latest *float64 `json:"latest,omitempty"`
+	// Delta7d is the change vs. the point closest to 7 days ago.
+	// Nil when insufficient history.
+	Delta7d *float64 `json:"delta_7d,omitempty"`
+	// Delta30d is the change vs. the point closest to 30 days ago.
+	// Nil when insufficient history.
+	Delta30d *float64 `json:"delta_30d,omitempty"`
+}
+
+// QualityTrendsReply is the wire shape for GET /api/quality/trends/{group}.
+type QualityTrendsReply struct {
+	Group   string        `json:"group"`
+	Days    int           `json:"days"`
+	Metrics []MetricTrend `json:"metrics"`
+}
+
+// handleQualityTrends serves GET /api/quality/trends/{group}?days=N.
+//
+// It reads the health-history.jsonl file and builds one MetricTrend per
+// trackable metric. All metrics with at least one non-nil data point are
+// included; sparse metrics (e.g. coverage, cycles) simply have fewer points.
+func (s *Server) handleQualityTrends(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	days := 30
+	if raw := r.URL.Query().Get("days"); raw != "" {
+		n, err := strconv.Atoi(raw)
+		if err != nil || n < 1 {
+			writeErr(w, http.StatusBadRequest, "days must be a positive integer")
+			return
+		}
+		if n > 365 {
+			n = 365
+		}
+		days = n
+	}
+
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "cannot locate daemon root: "+err.Error())
+		return
+	}
+
+	entries, err := quality.ReadHistory(layout.Root, group, days)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "reading history: "+err.Error())
+		return
+	}
+	if entries == nil {
+		entries = []quality.HealthEntry{}
+	}
+
+	reply := buildTrendsReply(group, days, entries)
+	writeJSON(w, http.StatusOK, reply)
+}
+
+// buildTrendsReply constructs the full trends payload from a slice of
+// HealthEntry values. The caller must pass entries sorted oldest-first.
+func buildTrendsReply(group string, days int, entries []quality.HealthEntry) QualityTrendsReply {
+	if len(entries) == 0 {
+		return QualityTrendsReply{Group: group, Days: days, Metrics: []MetricTrend{}}
+	}
+
+	// Build per-metric point lists. We always emit the core metrics
+	// (health_score, orphan_rate, bug_rate). Extended metrics are only
+	// emitted when at least one entry has a non-nil value.
+
+	type extractor struct {
+		label         string
+		unit          string
+		lowerIsBetter bool
+		goal          float64
+		fn            func(e quality.HealthEntry) *float64
+	}
+
+	ptrF := func(v float64) *float64 { return &v }
+
+	extractors := []extractor{
+		{
+			label:         "Health score",
+			unit:          "%",
+			lowerIsBetter: false,
+			goal:          90,
+			fn:            func(e quality.HealthEntry) *float64 { return ptrF(e.HealthScore) },
+		},
+		{
+			label:         "Orphan rate",
+			unit:          "%",
+			lowerIsBetter: true,
+			goal:          5,
+			fn:            func(e quality.HealthEntry) *float64 { return ptrF(e.OrphanRate) },
+		},
+		{
+			label:         "Bug rate",
+			unit:          "%",
+			lowerIsBetter: true,
+			goal:          3,
+			fn:            func(e quality.HealthEntry) *float64 { return ptrF(e.BugRate) },
+		},
+		{
+			label:         "Test coverage",
+			unit:          "%",
+			lowerIsBetter: false,
+			goal:          80,
+			fn:            func(e quality.HealthEntry) *float64 { return e.CoveragePct },
+		},
+		{
+			label:         "Import cycles",
+			unit:          "count",
+			lowerIsBetter: true,
+			goal:          0,
+			fn: func(e quality.HealthEntry) *float64 {
+				if e.Cycles == nil {
+					return nil
+				}
+				v := float64(*e.Cycles)
+				return &v
+			},
+		},
+		{
+			label:         "Auth-uncovered endpoints",
+			unit:          "count",
+			lowerIsBetter: true,
+			goal:          0,
+			fn: func(e quality.HealthEntry) *float64 {
+				if e.AuthUncovered == nil {
+					return nil
+				}
+				v := float64(*e.AuthUncovered)
+				return &v
+			},
+		},
+		{
+			label:         "Secret findings",
+			unit:          "count",
+			lowerIsBetter: true,
+			goal:          0,
+			fn: func(e quality.HealthEntry) *float64 {
+				if e.Secrets == nil {
+					return nil
+				}
+				v := float64(*e.Secrets)
+				return &v
+			},
+		},
+	}
+
+	var metrics []MetricTrend
+	for _, ex := range extractors {
+		var points []TrendPoint
+		for _, e := range entries {
+			v := ex.fn(e)
+			if v == nil {
+				continue
+			}
+			points = append(points, TrendPoint{
+				Timestamp: e.Timestamp.UTC().Format("2006-01-02T15:04:05Z"),
+				Value:     *v,
+			})
+		}
+		// Skip metrics that have no data at all.
+		if len(points) == 0 {
+			continue
+		}
+
+		mt := MetricTrend{
+			Label:         ex.label,
+			Unit:          ex.unit,
+			LowerIsBetter: ex.lowerIsBetter,
+			Goal:          ex.goal,
+			Points:        points,
+		}
+
+		latest := points[len(points)-1].Value
+		mt.Latest = &latest
+
+		// Compute deltas vs ~7d and ~30d reference windows.
+		if d := refDelta(entries, ex.fn, 7); d != nil {
+			mt.Delta7d = d
+		}
+		if d := refDelta(entries, ex.fn, 30); d != nil {
+			mt.Delta30d = d
+		}
+
+		metrics = append(metrics, mt)
+	}
+	if metrics == nil {
+		metrics = []MetricTrend{}
+	}
+
+	return QualityTrendsReply{Group: group, Days: days, Metrics: metrics}
+}
+
+// refDelta returns (latest − reference) for a metric, where reference is
+// the entry closest to daysAgo days before the most-recent timestamp.
+// Returns nil when there are fewer than 2 data points or when the metric
+// has no value at the reference point.
+func refDelta(entries []quality.HealthEntry, fn func(quality.HealthEntry) *float64, daysAgo int) *float64 {
+	// Find the latest entry that has a value.
+	var latestVal *float64
+	for i := len(entries) - 1; i >= 0; i-- {
+		if v := fn(entries[i]); v != nil {
+			latestVal = v
+			break
+		}
+	}
+	if latestVal == nil {
+		return nil
+	}
+
+	// Reference: find last entry older than daysAgo.
+	windowMS := int64(daysAgo) * 24 * 60 * 60 * 1000
+	latestTs := entries[len(entries)-1].Timestamp.UnixMilli()
+	cutoff := latestTs - windowMS
+
+	var refVal *float64
+	for i := len(entries) - 1; i >= 0; i-- {
+		if entries[i].Timestamp.UnixMilli() <= cutoff {
+			if v := fn(entries[i]); v != nil {
+				refVal = v
+			}
+			break
+		}
+	}
+	if refVal == nil {
+		return nil
+	}
+
+	delta := *latestVal - *refVal
+	return &delta
+}

--- a/internal/dashboard/handlers_quality_trends_test.go
+++ b/internal/dashboard/handlers_quality_trends_test.go
@@ -1,0 +1,237 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/quality"
+)
+
+// TestBuildTrendsReply_empty verifies that an empty entry slice yields
+// an empty metrics slice (not nil) so the frontend can handle it uniformly.
+func TestBuildTrendsReply_empty(t *testing.T) {
+	reply := buildTrendsReply("mygroup", 30, nil)
+	if reply.Group != "mygroup" {
+		t.Errorf("group: got %q, want %q", reply.Group, "mygroup")
+	}
+	if len(reply.Metrics) != 0 {
+		t.Errorf("expected 0 metrics for empty input, got %d", len(reply.Metrics))
+	}
+}
+
+// TestBuildTrendsReply_coreMetrics verifies that the three always-present
+// metrics (health_score, orphan_rate, bug_rate) are present and correct.
+func TestBuildTrendsReply_coreMetrics(t *testing.T) {
+	now := time.Now().UTC()
+	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now.Add(-48 * time.Hour),
+			Group:         "g",
+			TotalEntities: 1000,
+			OrphanRate:    20.0,
+			BugRate:       5.0,
+			HealthScore:   75.0,
+		},
+		{
+			Timestamp:     now.Add(-24 * time.Hour),
+			Group:         "g",
+			TotalEntities: 1050,
+			OrphanRate:    18.0,
+			BugRate:       4.5,
+			HealthScore:   77.5,
+		},
+	}
+
+	reply := buildTrendsReply("g", 30, entries)
+
+	// At minimum the three core metrics must be present.
+	if len(reply.Metrics) < 3 {
+		t.Fatalf("expected at least 3 metrics, got %d", len(reply.Metrics))
+	}
+
+	// Find health_score metric.
+	var hsMt *MetricTrend
+	for i := range reply.Metrics {
+		if reply.Metrics[i].Label == "Health score" {
+			hsMt = &reply.Metrics[i]
+			break
+		}
+	}
+	if hsMt == nil {
+		t.Fatal("Health score metric not found")
+	}
+	if len(hsMt.Points) != 2 {
+		t.Errorf("expected 2 points for Health score, got %d", len(hsMt.Points))
+	}
+	if hsMt.Latest == nil || *hsMt.Latest != 77.5 {
+		t.Errorf("latest health score: got %v, want 77.5", hsMt.Latest)
+	}
+	if hsMt.LowerIsBetter {
+		t.Errorf("health score should have LowerIsBetter=false")
+	}
+}
+
+// TestBuildTrendsReply_extendedMetrics verifies that sparse extended metrics
+// (coverage, cycles, secrets) are included only when data exists.
+func TestBuildTrendsReply_extendedMetrics(t *testing.T) {
+	now := time.Now().UTC()
+	covPct := 65.0
+	cycles := 3
+	secrets := 2
+
+	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now.Add(-24 * time.Hour),
+			Group:         "g",
+			TotalEntities: 500,
+			OrphanRate:    10.0,
+			BugRate:       2.0,
+			HealthScore:   88.0,
+			CoveragePct:   &covPct,
+			Cycles:        &cycles,
+			Secrets:       &secrets,
+		},
+	}
+
+	reply := buildTrendsReply("g", 30, entries)
+
+	metricsMap := make(map[string]*MetricTrend, len(reply.Metrics))
+	for i := range reply.Metrics {
+		metricsMap[reply.Metrics[i].Label] = &reply.Metrics[i]
+	}
+
+	if mt, ok := metricsMap["Test coverage"]; !ok {
+		t.Error("Test coverage metric missing")
+	} else if mt.Latest == nil || *mt.Latest != 65.0 {
+		t.Errorf("coverage latest: got %v, want 65.0", mt.Latest)
+	}
+
+	if mt, ok := metricsMap["Import cycles"]; !ok {
+		t.Error("Import cycles metric missing")
+	} else if mt.Latest == nil || *mt.Latest != 3 {
+		t.Errorf("cycles latest: got %v, want 3", mt.Latest)
+	}
+
+	if mt, ok := metricsMap["Secret findings"]; !ok {
+		t.Error("Secret findings metric missing")
+	} else if mt.Latest == nil || *mt.Latest != 2 {
+		t.Errorf("secrets latest: got %v, want 2", mt.Latest)
+	}
+}
+
+// TestBuildTrendsReply_sparseMetricExcluded verifies that a metric is not
+// included in the reply when all entries have nil for that metric.
+func TestBuildTrendsReply_sparseMetricExcluded(t *testing.T) {
+	now := time.Now().UTC()
+	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now,
+			Group:         "g",
+			TotalEntities: 500,
+			OrphanRate:    10.0,
+			BugRate:       2.0,
+			HealthScore:   88.0,
+			// CoveragePct, Cycles, Secrets all nil → should be excluded.
+		},
+	}
+
+	reply := buildTrendsReply("g", 30, entries)
+
+	for _, mt := range reply.Metrics {
+		switch mt.Label {
+		case "Test coverage", "Import cycles", "Auth-uncovered endpoints", "Secret findings":
+			t.Errorf("metric %q should be absent when all values are nil, but was included", mt.Label)
+		}
+	}
+}
+
+// TestBuildTrendsReply_delta verifies that the 7d and 30d deltas are computed
+// correctly.
+func TestBuildTrendsReply_delta(t *testing.T) {
+	now := time.Now().UTC()
+	entries := []quality.HealthEntry{
+		{
+			Timestamp:     now.AddDate(0, 0, -35),
+			Group:         "g",
+			TotalEntities: 900,
+			OrphanRate:    25.0,
+			BugRate:       6.0,
+			HealthScore:   69.0, // old entry (>30d ago)
+		},
+		{
+			Timestamp:     now.AddDate(0, 0, -8),
+			Group:         "g",
+			TotalEntities: 950,
+			OrphanRate:    22.0,
+			BugRate:       5.0,
+			HealthScore:   73.0, // ~7-30d ago
+		},
+		{
+			Timestamp:     now,
+			Group:         "g",
+			TotalEntities: 1000,
+			OrphanRate:    20.0,
+			BugRate:       4.5,
+			HealthScore:   80.0, // latest
+		},
+	}
+
+	reply := buildTrendsReply("g", 60, entries)
+
+	var hsMt *MetricTrend
+	for i := range reply.Metrics {
+		if reply.Metrics[i].Label == "Health score" {
+			hsMt = &reply.Metrics[i]
+			break
+		}
+	}
+	if hsMt == nil {
+		t.Fatal("Health score metric missing")
+	}
+
+	// delta30d should be 80 - 69 = 11
+	if hsMt.Delta30d == nil {
+		t.Fatal("Delta30d is nil, want 11.0")
+	}
+	if *hsMt.Delta30d != 11.0 {
+		t.Errorf("Delta30d: got %v, want 11.0", *hsMt.Delta30d)
+	}
+
+	// delta7d: the entry at -8d is the closest entry older than 7d from now
+	// (cutoff = now - 7d; -8d <= cutoff), so delta7d = 80 - 73 = 7
+	if hsMt.Delta7d == nil {
+		t.Fatal("Delta7d is nil, want 7.0")
+	}
+	if *hsMt.Delta7d != 7.0 {
+		t.Errorf("Delta7d: got %v, want 7.0", *hsMt.Delta7d)
+	}
+}
+
+// TestHandleQualityTrends_daysValidation checks that the handler returns 400
+// for an invalid ?days value.
+func TestHandleQualityTrends_daysValidation(t *testing.T) {
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/quality/trends/mygroup?days=bad", nil)
+	req.SetPathValue("group", "mygroup")
+	rr := httptest.NewRecorder()
+
+	srv.handleQualityTrends(rr, req)
+
+	if rr.Code != http.StatusBadRequest {
+		t.Errorf("status: got %d, want 400", rr.Code)
+	}
+	var body map[string]string
+	if err := json.NewDecoder(rr.Body).Decode(&body); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if body["error"] == "" {
+		t.Error("expected non-empty error message")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -409,8 +409,9 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/mcp-activity/stream", s.handleMCPActivityStream)
 	mux.HandleFunc("GET /api/mcp-activity/history", s.handleMCPActivityHistory)
 
-	// Surface 11 — Quality history (#1214)
+	// Surface 11 — Quality history (#1214) + per-metric trends (#1329)
 	mux.HandleFunc("GET /api/quality/history/{group}", s.handleQualityHistory)
+	mux.HandleFunc("GET /api/quality/trends/{group}", s.handleQualityTrends)
 
 	// Surface 12 — Web onboarding wizard (#1239)
 	mux.HandleFunc("POST /api/onboard/check-path", s.handleOnboardCheckPath)

--- a/internal/quality/history.go
+++ b/internal/quality/history.go
@@ -25,6 +25,10 @@ type HealthEntry struct {
 	Group string `json:"group"`
 	// TotalEntities is the total entity count across all repos in the group.
 	TotalEntities int `json:"total_entities"`
+	// TotalFlows is the number of process-flow entities in the group.
+	TotalFlows int `json:"total_flows,omitempty"`
+	// TotalEndpoints is the number of http_endpoint entities in the group.
+	TotalEndpoints int `json:"total_endpoints,omitempty"`
 	// OrphanRate is the percentage of entities with no incoming relationship (0–100).
 	OrphanRate float64 `json:"orphan_rate"`
 	// BugRate is the percentage of entities that are repair candidates (0–100).
@@ -33,6 +37,18 @@ type HealthEntry struct {
 	// HealthScore is a composite quality score (0–100, higher is better).
 	// Computed as max(0, 100 - OrphanRate - BugRate).
 	HealthScore float64 `json:"health_score"`
+	// CoveragePct is the test-coverage percentage (0–100) measured from
+	// Test-entity → production-entity edges. Omitted when not available.
+	CoveragePct *float64 `json:"coverage_pct,omitempty"`
+	// Cycles is the total number of import cycles detected. Omitted when
+	// cycle detection was not run.
+	Cycles *int `json:"cycles,omitempty"`
+	// AuthUncovered is the number of HTTP endpoints with no auth annotation.
+	// Omitted when not available.
+	AuthUncovered *int `json:"auth_uncovered,omitempty"`
+	// Secrets is the total number of hardcoded-secret findings. Omitted when
+	// the secret scan was not run.
+	Secrets *int `json:"secrets,omitempty"`
 	// RecallPct is the enrichment recall percentage when available (0–100).
 	// Omitted (null) when not measured.
 	RecallPct *float64 `json:"recall_pct,omitempty"`

--- a/internal/quality/history_test.go
+++ b/internal/quality/history_test.go
@@ -132,3 +132,63 @@ func TestReadHistory_DayFilter(t *testing.T) {
 		t.Errorf("wrong entry returned: orphan_rate=%v", got[0].OrphanRate)
 	}
 }
+
+// TestAppendAndReadHistory_ExtendedFields verifies that the new fields added
+// in #1329 (coverage_pct, cycles, auth_uncovered, secrets, total_flows,
+// total_endpoints) round-trip correctly through JSONL.
+func TestAppendAndReadHistory_ExtendedFields(t *testing.T) {
+	root := t.TempDir()
+	now := time.Now().UTC().Truncate(time.Second)
+
+	covPct := 72.5
+	cycles := 4
+	authUncov := 2
+	secrets := 1
+
+	entry := quality.HealthEntry{
+		Timestamp:      now,
+		Group:          "ext-group",
+		TotalEntities:  500,
+		TotalFlows:     12,
+		TotalEndpoints: 30,
+		OrphanRate:     8.0,
+		BugRate:        2.5,
+		HealthScore:    quality.ComputeHealthScore(8.0, 2.5),
+		CoveragePct:    &covPct,
+		Cycles:         &cycles,
+		AuthUncovered:  &authUncov,
+		Secrets:        &secrets,
+	}
+
+	if err := quality.AppendEntry(root, entry); err != nil {
+		t.Fatalf("AppendEntry: %v", err)
+	}
+
+	got, err := quality.ReadHistory(root, "ext-group", 7)
+	if err != nil {
+		t.Fatalf("ReadHistory: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(got))
+	}
+
+	e := got[0]
+	if e.TotalFlows != 12 {
+		t.Errorf("total_flows: got %d, want 12", e.TotalFlows)
+	}
+	if e.TotalEndpoints != 30 {
+		t.Errorf("total_endpoints: got %d, want 30", e.TotalEndpoints)
+	}
+	if e.CoveragePct == nil || *e.CoveragePct != 72.5 {
+		t.Errorf("coverage_pct: got %v, want 72.5", e.CoveragePct)
+	}
+	if e.Cycles == nil || *e.Cycles != 4 {
+		t.Errorf("cycles: got %v, want 4", e.Cycles)
+	}
+	if e.AuthUncovered == nil || *e.AuthUncovered != 2 {
+		t.Errorf("auth_uncovered: got %v, want 2", e.AuthUncovered)
+	}
+	if e.Secrets == nil || *e.Secrets != 1 {
+		t.Errorf("secrets: got %v, want 1", e.Secrets)
+	}
+}


### PR DESCRIPTION
## Summary

Closes #1329

Persists extended quality metrics after every daemon rebuild and surfaces them as per-metric sparklines on the /quality page.

**Backend changes:**
- \`internal/quality/history.go\`: Extended \`HealthEntry\` with 7 new optional fields: \`coverage_pct\`, \`cycles\`, \`auth_uncovered\`, \`secrets\`, \`total_flows\`, \`total_endpoints\`.
- \`cmd/archigraph/rebuild_history.go\`: New \`appendRebuildHistory\` helper. After every successful daemon rebuild, a goroutine collects coverage (via \`graph.ComputeCoverage\`), import cycles (via \`graph.FindImportCycles\`), auth-uncovered endpoint count, and secret findings (via \`secrets.ScanPath\`), then appends a \`HealthEntry\` to \`~/.archigraph/health-history.jsonl\`.
- \`cmd/archigraph/daemon.go\`: Hooks the goroutine into \`daemonRebuildFunc\` (best-effort, non-blocking).
- \`internal/dashboard/handlers_quality_trends.go\`: New handler for \`GET /api/quality/trends/{group}?days=N\`. Returns per-metric \`MetricTrend\` objects with \`points[]\`, \`latest\`, \`delta_7d\`, \`delta_30d\`, \`goal\`, and \`lower_is_better\`. Sparse metrics are omitted when no data exists.
- \`internal/dashboard/server.go\`: Registers the new route alongside \`/api/quality/history/{group}\`.

**Frontend changes (dashboard/):**
- \`src/api/client.ts\`: Extended \`HealthEntry\` type; new \`MetricTrend\`, \`TrendPoint\`, \`QualityTrendsReply\` types; new \`fetchQualityTrends()\` function.
- \`src/routes/quality.tsx\`: Added a **Trends** tab (now default) with inline SVG \`Sparkline\` component (no external chart dep), \`MetricCard\` grid (2-4 columns responsive), \`TrendArrow\` badges, goal-threshold line on sparklines, regression-alert banner when any metric degrades ≥5 units vs 7 days ago.

## Beyond the minimum

- Goal thresholds per metric (e.g. orphan rate < 5%, coverage ≥ 80%) shown as dashed line on sparkline and goal badge.
- Regression alert band surfaces quality regressions automatically.
- \`lower_is_better\` aware colouring — green/red inverted correctly for rate/count metrics vs score metrics.

## Testing
- [x] All tests pass: \`go test ./internal/quality/... ./internal/dashboard/...\`
- [x] \`go build ./cmd/... ./internal/...\` — clean
- [x] Backward-compat: existing health-history.jsonl entries without new fields deserialise cleanly (nil/zero)
- [x] 7 new tests: \`TestAppendAndReadHistory_ExtendedFields\`, \`TestBuildTrendsReply_*\` (5), \`TestHandleQualityTrends_daysValidation\`

## Notes

Secret scan runs at 256 KB/file cap in the background goroutine (non-blocking to rebuild response). Auth-uncovered count uses HAS_AUTH / REQUIRES_AUTH / auth relationship kinds.