### PR TITLE
feat(licenses): #1334 detect dependency licenses + flag GPL/AGPL incompatibility

### DIFF
--- a/internal/licenses/licenses.go
+++ b/internal/licenses/licenses.go
@@ -1,0 +1,820 @@
+// Package licenses detects dependency licenses and flags incompatible combinations.
+//
+// Detection sources (in priority order):
+//  1. node_modules/<pkg>/package.json    — npm/yarn local metadata
+//  2. GOPATH module cache LICENSE files  — Go modules (local only)
+//  3. pyproject.toml dist-info METADATA  — Python packages (venv local)
+//  4. Gemfile.lock + gemspec cache       — Ruby gems
+//  5. Cargo.toml [package].license       — Rust (own package; deps from cargo metadata)
+//
+// Project license is inferred from (first match):
+//
+//	LICENSE / LICENSE.txt / LICENSE.md, then package.json#license,
+//	then pyproject.toml#project.license, then Cargo.toml#[package.license].
+//
+// Compatibility matrix (SPDX-based, simplified):
+//
+//	GPL-2.0, GPL-3.0, AGPL-3.0 are copyleft-incompatible with
+//	MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, 0BSD, Unlicense.
+//	LGPL-2.1, LGPL-3.0 are weak-copyleft (warn).
+//	EUPL-1.2, CDDL-1.0, MPL-2.0 are weak-copyleft (warn).
+//
+// Transitive analysis uses package-lock.json (npm) and local node_modules.
+// Drop-in alternatives are suggested for common incompatible packages.
+package licenses
+
+import (
+	"encoding/json"
+	"fmt"
+	"math"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// ---------------------------------------------------------------------------
+// SPDX normalization
+// ---------------------------------------------------------------------------
+
+// normalizeSPDX converts common non-standard license strings to their SPDX
+// identifiers. Unknown strings are returned as-is (trimmed).
+func normalizeSPDX(raw string) string {
+	s := strings.TrimSpace(raw)
+	// Strip surrounding parens used by some package.json authors.
+	s = strings.Trim(s, "()")
+	s = strings.TrimSpace(s)
+
+	// Normalisation table — extend as needed.
+	table := map[string]string{
+		// MIT variants
+		"mit":                "MIT",
+		"mit license":        "MIT",
+		"the mit license":    "MIT",
+		"expat":              "MIT",
+		// Apache variants
+		"apache 2":           "Apache-2.0",
+		"apache 2.0":         "Apache-2.0",
+		"apache-2":           "Apache-2.0",
+		"apache license 2.0": "Apache-2.0",
+		"apache-2.0":         "Apache-2.0",
+		// BSD variants
+		"bsd":                "BSD-2-Clause",
+		"bsd 2-clause":       "BSD-2-Clause",
+		"bsd 3-clause":       "BSD-3-Clause",
+		"new bsd":            "BSD-3-Clause",
+		"revised bsd":        "BSD-3-Clause",
+		// GPL variants
+		"gpl":                           "GPL-2.0-only",
+		"gpl-2":                         "GPL-2.0-only",
+		"gpl-2.0":                       "GPL-2.0-only",
+		"gpl2":                          "GPL-2.0-only",
+		"gnu general public license v2": "GPL-2.0-only",
+		"gpl-3":                         "GPL-3.0-only",
+		"gpl-3.0":                       "GPL-3.0-only",
+		"gpl3":                          "GPL-3.0-only",
+		"gnu general public license v3": "GPL-3.0-only",
+		// AGPL
+		"agpl-3":   "AGPL-3.0-only",
+		"agpl-3.0": "AGPL-3.0-only",
+		"agpl3":    "AGPL-3.0-only",
+		// LGPL
+		"lgpl-2":   "LGPL-2.1-only",
+		"lgpl-2.1": "LGPL-2.1-only",
+		"lgpl2":    "LGPL-2.1-only",
+		"lgpl-3":   "LGPL-3.0-only",
+		"lgpl-3.0": "LGPL-3.0-only",
+		"lgpl3":    "LGPL-3.0-only",
+		// ISC / public domain
+		"isc":          "ISC",
+		"0bsd":         "0BSD",
+		"unlicense":    "Unlicense",
+		"public domain": "Unlicense",
+		// Other weak-copyleft
+		"mpl-2.0":  "MPL-2.0",
+		"mpl2":     "MPL-2.0",
+		"eupl-1.2": "EUPL-1.2",
+		"cddl-1.0": "CDDL-1.0",
+		// Commercial
+		"commercial":  "Proprietary",
+		"proprietary": "Proprietary",
+		"see license": "Proprietary",
+	}
+	if v, ok := table[strings.ToLower(s)]; ok {
+		return v
+	}
+	// Already-canonical SPDX: return as-is.
+	return s
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility
+// ---------------------------------------------------------------------------
+
+// CompatibilityLevel is the result of a compatibility check.
+type CompatibilityLevel string
+
+const (
+	// CompatOK means no known conflict.
+	CompatOK CompatibilityLevel = "ok"
+	// CompatWarn means a weak-copyleft license that may impose obligations.
+	CompatWarn CompatibilityLevel = "warn"
+	// CompatError means a strong-copyleft license incompatible with the project
+	// license (e.g. GPL dep in MIT project).
+	CompatError CompatibilityLevel = "error"
+	// CompatUnknown means we could not determine compatibility.
+	CompatUnknown CompatibilityLevel = "unknown"
+)
+
+// permissiveLicenses are the set of licenses considered permissive (allow
+// linking from any license without propagating obligations).
+var permissiveLicenses = map[string]bool{
+	"MIT":          true,
+	"Apache-2.0":   true,
+	"BSD-2-Clause": true,
+	"BSD-3-Clause": true,
+	"ISC":          true,
+	"0BSD":         true,
+	"Unlicense":    true,
+	"WTFPL":        true,
+	"CC0-1.0":      true,
+	"Zlib":         true,
+	"Boost-1.0":    true,
+}
+
+// strongCopyleft are GPL/AGPL style: incompatible when used in a project
+// distributed under a permissive license.
+var strongCopyleft = map[string]bool{
+	"GPL-2.0-only":       true,
+	"GPL-2.0-or-later":   true,
+	"GPL-3.0-only":       true,
+	"GPL-3.0-or-later":   true,
+	"AGPL-3.0-only":      true,
+	"AGPL-3.0-or-later":  true,
+}
+
+// weakCopyleft requires attribution/disclosure but is generally usable as a
+// dependency without forcing the whole project to relicense.
+var weakCopyleft = map[string]bool{
+	"LGPL-2.1-only":     true,
+	"LGPL-2.1-or-later": true,
+	"LGPL-3.0-only":     true,
+	"LGPL-3.0-or-later": true,
+	"MPL-2.0":           true,
+	"EUPL-1.2":          true,
+	"CDDL-1.0":          true,
+}
+
+// CheckCompatibility returns the compatibility level of depLicense when used
+// inside a project with projectLicense.
+func CheckCompatibility(projectLicense, depLicense string) CompatibilityLevel {
+	proj := normalizeSPDX(projectLicense)
+	dep := normalizeSPDX(depLicense)
+
+	if dep == "" || dep == "NOASSERTION" || dep == "NONE" {
+		return CompatUnknown
+	}
+	if strongCopyleft[dep] {
+		// Dep is GPL/AGPL — only OK if project is also GPL/AGPL-compatible.
+		if strongCopyleft[proj] {
+			return CompatOK
+		}
+		// Permissive or unknown project license: flagging as error.
+		return CompatError
+	}
+	if weakCopyleft[dep] {
+		return CompatWarn
+	}
+	if dep == "Proprietary" {
+		// Proprietary dep used in open-source project: warn.
+		if permissiveLicenses[proj] || weakCopyleft[proj] {
+			return CompatWarn
+		}
+		return CompatOK
+	}
+	return CompatOK
+}
+
+// ---------------------------------------------------------------------------
+// Drop-in alternatives
+// ---------------------------------------------------------------------------
+
+// dropInAlternatives returns permissive-licensed alternatives for a known
+// package with an incompatible license.
+var dropInAlternatives = map[string][]string{
+	// npm
+	"node-forge":                {"@peculiar/webcrypto", "node:crypto (built-in)"},
+	"pdfkit":                    {"jspdf"},
+	"pdf-lib":                   {"jspdf"},
+	"cron":                      {"node-cron (MIT)"},
+	// Python
+	"mysql-connector-python":    {"PyMySQL (MIT)", "aiomysql (MIT)"},
+	"psycopg2":                  {"asyncpg (Apache-2.0)"},
+	// Go
+	"github.com/gofrs/uuid":     {"github.com/google/uuid (BSD-3-Clause)"},
+	// General
+	"readline":                  {"libedit (BSD-3-Clause)"},
+}
+
+// SuggestAlternatives returns known drop-in alternatives for the given
+// package name, or an empty slice if none are known.
+func SuggestAlternatives(packageName string) []string {
+	if alts, ok := dropInAlternatives[packageName]; ok {
+		return alts
+	}
+	return nil
+}
+
+// ---------------------------------------------------------------------------
+// License detection — local metadata
+// ---------------------------------------------------------------------------
+
+// PackageLicense holds the detected license for a single dependency.
+type PackageLicense struct {
+	// PackageName is the dependency name as declared in the manifest.
+	PackageName string `json:"package_name"`
+	// PackageManager is npm / go_modules / cargo / pip / bundler.
+	PackageManager string `json:"package_manager"`
+	// Version is the pinned or declared version string.
+	Version string `json:"version"`
+	// License is the normalized SPDX identifier.
+	License string `json:"license"`
+	// LicenseSource describes where the license was detected from.
+	LicenseSource string `json:"license_source"`
+	// IsTransitive is true when the package is an indirect/transitive dependency.
+	IsTransitive bool `json:"is_transitive"`
+	// Compatibility is the result of the project vs dep license check.
+	Compatibility CompatibilityLevel `json:"compatibility"`
+	// Alternatives are suggested drop-in replacements when Compatibility != CompatOK.
+	Alternatives []string `json:"alternatives,omitempty"`
+}
+
+// DetectResult holds all findings for a single repo.
+type DetectResult struct {
+	// ProjectLicense is the inferred SPDX license of the project itself.
+	ProjectLicense string `json:"project_license"`
+	// ProjectLicenseSource is where the project license was detected.
+	ProjectLicenseSource string `json:"project_license_source"`
+	// Dependencies holds one entry per detected dependency.
+	Dependencies []PackageLicense `json:"dependencies"`
+	// Incompatible is a filtered subset — deps with Compatibility == error or warn.
+	Incompatible []PackageLicense `json:"incompatible"`
+	// LicenseDensity maps SPDX id → estimated fraction (0-1) of total deps.
+	LicenseDensity map[string]float64 `json:"license_density,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Project license detection
+// ---------------------------------------------------------------------------
+
+// DetectProjectLicense reads the project root and returns (spdxID, source).
+func DetectProjectLicense(repoPath string) (string, string) {
+	// 1. Look for a LICENSE file.
+	for _, name := range []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "LICENCE", "COPYING"} {
+		p := filepath.Join(repoPath, name)
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		lic := inferFromLicenseText(string(data))
+		if lic != "" {
+			return normalizeSPDX(lic), name
+		}
+	}
+	// 2. package.json
+	if data, err := os.ReadFile(filepath.Join(repoPath, "package.json")); err == nil {
+		var pkg struct {
+			License interface{} `json:"license"`
+		}
+		if json.Unmarshal(data, &pkg) == nil {
+			if s, ok := pkg.License.(string); ok && s != "" {
+				return normalizeSPDX(s), "package.json"
+			}
+			// Old format: {"type":"MIT"}
+			if m, ok := pkg.License.(map[string]interface{}); ok {
+				if t, ok := m["type"].(string); ok {
+					return normalizeSPDX(t), "package.json"
+				}
+			}
+		}
+	}
+	// 3. pyproject.toml
+	if data, err := os.ReadFile(filepath.Join(repoPath, "pyproject.toml")); err == nil {
+		if lic := extractTOMLField(string(data), "license"); lic != "" {
+			return normalizeSPDX(lic), "pyproject.toml"
+		}
+	}
+	// 4. Cargo.toml
+	if data, err := os.ReadFile(filepath.Join(repoPath, "Cargo.toml")); err == nil {
+		if lic := extractTOMLField(string(data), "license"); lic != "" {
+			return normalizeSPDX(lic), "Cargo.toml"
+		}
+	}
+	return "Unknown", ""
+}
+
+// inferFromLicenseText returns a rough SPDX identifier from the text of a
+// LICENSE file. This is intentionally simple — we look for canonical phrases.
+func inferFromLicenseText(text string) string {
+	t := strings.ToLower(text)
+	switch {
+	case strings.Contains(t, "gnu affero general public license") || strings.Contains(t, "agpl"):
+		return "AGPL-3.0-only"
+	case strings.Contains(t, "gnu general public license") && strings.Contains(t, "version 3"):
+		return "GPL-3.0-only"
+	case strings.Contains(t, "gnu general public license") && strings.Contains(t, "version 2"):
+		return "GPL-2.0-only"
+	case strings.Contains(t, "gnu general public license"):
+		return "GPL-2.0-only" // default to v2 when version not explicit
+	case strings.Contains(t, "gnu lesser general public license") && strings.Contains(t, "version 3"):
+		return "LGPL-3.0-only"
+	case strings.Contains(t, "gnu lesser general public license"):
+		return "LGPL-2.1-only"
+	case strings.Contains(t, "apache license") || strings.Contains(t, "apache software license"):
+		return "Apache-2.0"
+	case strings.Contains(t, "mit license") || strings.Contains(t, "permission is hereby granted"):
+		return "MIT"
+	case strings.Contains(t, "bsd 2-clause"):
+		return "BSD-2-Clause"
+	case strings.Contains(t, "bsd 3-clause") || strings.Contains(t, "redistributions of source code"):
+		return "BSD-3-Clause"
+	case strings.Contains(t, "isc license"):
+		return "ISC"
+	case strings.Contains(t, "mozilla public license"):
+		return "MPL-2.0"
+	case strings.Contains(t, "unlicense") || strings.Contains(t, "public domain"):
+		return "Unlicense"
+	}
+	return ""
+}
+
+// extractTOMLField returns the value of a TOML scalar field by key, e.g.
+// `license = "MIT"` → `MIT`. Handles both bare string and {text="MIT"} form.
+func extractTOMLField(src, key string) string {
+	re := regexp.MustCompile(`(?im)^` + key + `\s*=\s*(?:"([^"]*)"|\{\s*text\s*=\s*"([^"]*)")`)
+	m := re.FindStringSubmatch(src)
+	if m == nil {
+		return ""
+	}
+	if m[1] != "" {
+		return m[1]
+	}
+	return m[2]
+}
+
+// ---------------------------------------------------------------------------
+// npm — node_modules/*/package.json
+// ---------------------------------------------------------------------------
+
+// DetectNPMLicenses reads node_modules/<pkg>/package.json for each package
+// in the provided name list. Packages not found on disk return "Unknown".
+func DetectNPMLicenses(repoPath string, packages []string) map[string]string {
+	out := make(map[string]string, len(packages))
+	for _, pkg := range packages {
+		lic := readNPMPackageLicense(repoPath, pkg)
+		if lic == "" {
+			lic = "Unknown"
+		}
+		out[pkg] = normalizeSPDX(lic)
+	}
+	return out
+}
+
+func readNPMPackageLicense(repoPath, pkgName string) string {
+	p := filepath.Join(repoPath, "node_modules", pkgName, "package.json")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return ""
+	}
+	var pkg struct {
+		License  interface{} `json:"license"`
+		Licenses []struct {
+			Type string `json:"type"`
+		} `json:"licenses"`
+	}
+	if json.Unmarshal(data, &pkg) != nil {
+		return ""
+	}
+	if s, ok := pkg.License.(string); ok && s != "" {
+		return s
+	}
+	if m, ok := pkg.License.(map[string]interface{}); ok {
+		if t, ok := m["type"].(string); ok {
+			return t
+		}
+	}
+	if len(pkg.Licenses) > 0 {
+		return pkg.Licenses[0].Type
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// npm — package-lock.json transitive deps
+// ---------------------------------------------------------------------------
+
+// ResolveNPMTransitiveDeps parses package-lock.json v2/v3 and returns
+// a map of package name → version for all transitive dependencies.
+func ResolveNPMTransitiveDeps(repoPath string) map[string]string {
+	p := filepath.Join(repoPath, "package-lock.json")
+	data, err := os.ReadFile(p)
+	if err != nil {
+		return nil
+	}
+	var lock struct {
+		Packages map[string]struct {
+			Version string `json:"version"`
+		} `json:"packages"`
+		Dependencies map[string]struct {
+			Version string `json:"version"`
+		} `json:"dependencies"`
+	}
+	if json.Unmarshal(data, &lock) != nil {
+		return nil
+	}
+	out := make(map[string]string)
+	// v2/v3 format uses "packages" with "node_modules/X" keys.
+	for key, entry := range lock.Packages {
+		name := strings.TrimPrefix(key, "node_modules/")
+		if name == "" {
+			continue
+		}
+		out[name] = entry.Version
+	}
+	// v1 format uses "dependencies".
+	for name, entry := range lock.Dependencies {
+		if _, exists := out[name]; !exists {
+			out[name] = entry.Version
+		}
+	}
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Python — dist-info METADATA detection
+// ---------------------------------------------------------------------------
+
+// DetectPyPILicensesLocal reads *.dist-info/METADATA files in common venv
+// paths to extract license metadata without a network call.
+func DetectPyPILicensesLocal(repoPath string, packages []string) map[string]string {
+	out := make(map[string]string, len(packages))
+	// Candidate site-packages directories.
+	sitePaths := []string{
+		filepath.Join(repoPath, ".venv", "lib"),
+		filepath.Join(repoPath, "venv", "lib"),
+		filepath.Join(repoPath, "env", "lib"),
+	}
+	for _, pkg := range packages {
+		lic := detectPyPILocal(pkg, sitePaths)
+		if lic == "" {
+			lic = "Unknown"
+		}
+		out[pkg] = lic
+	}
+	return out
+}
+
+func detectPyPILocal(pkg string, sitePaths []string) string {
+	// dist-info dirs are named like <name>-<version>.dist-info
+	normName := strings.ReplaceAll(strings.ToLower(pkg), "-", "_")
+	for _, siteLib := range sitePaths {
+		entries, err := os.ReadDir(siteLib)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			// Descend into pythonX.Y subdirs.
+			if e.IsDir() && strings.HasPrefix(e.Name(), "python") {
+				subs, err := os.ReadDir(filepath.Join(siteLib, e.Name(), "site-packages"))
+				if err != nil {
+					continue
+				}
+				for _, sub := range subs {
+					if lic := tryDistInfo(sub.Name(), normName, filepath.Join(siteLib, e.Name(), "site-packages")); lic != "" {
+						return lic
+					}
+				}
+			}
+			if lic := tryDistInfo(e.Name(), normName, siteLib); lic != "" {
+				return lic
+			}
+		}
+	}
+	return ""
+}
+
+func tryDistInfo(dirName, normPkgName string, base string) string {
+	if !strings.HasSuffix(dirName, ".dist-info") {
+		return ""
+	}
+	dirNorm := strings.ToLower(strings.ReplaceAll(dirName, "-", "_"))
+	if !strings.HasPrefix(dirNorm, normPkgName+"-") && !strings.HasPrefix(dirNorm, normPkgName+"_") {
+		return ""
+	}
+	metaPath := filepath.Join(base, dirName, "METADATA")
+	data, err := os.ReadFile(metaPath)
+	if err != nil {
+		return ""
+	}
+	// Parse RFC 822-style headers.
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "License:") {
+			parts := strings.SplitN(line, ":", 2)
+			if len(parts) == 2 {
+				return normalizeSPDX(strings.TrimSpace(parts[1]))
+			}
+		}
+		if strings.HasPrefix(line, "Classifier: License ::") {
+			parts := strings.Split(line, " :: ")
+			if len(parts) >= 2 {
+				return normalizeSPDX(parts[len(parts)-1])
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Go — module cache LICENSE detection
+// ---------------------------------------------------------------------------
+
+// DetectGoModLicenses scans the module cache (GOPATH/pkg/mod) for LICENSE
+// files belonging to the listed modules.
+func DetectGoModLicenses(modules []string) map[string]string {
+	out := make(map[string]string, len(modules))
+	gopath := os.Getenv("GOPATH")
+	if gopath == "" {
+		home, _ := os.UserHomeDir()
+		gopath = filepath.Join(home, "go")
+	}
+	modCache := filepath.Join(gopath, "pkg", "mod")
+	for _, mod := range modules {
+		lic := detectGoModLicense(modCache, mod)
+		if lic == "" {
+			lic = "Unknown"
+		}
+		out[mod] = lic
+	}
+	return out
+}
+
+func detectGoModLicense(modCache, modPath string) string {
+	// module path: github.com/foo/bar → modCache/github.com/foo/bar@vX.Y.Z/LICENSE
+	// We don't know the version, so we look for any matching prefix.
+	parts := strings.SplitN(modPath, "/", 2)
+	if len(parts) < 2 {
+		return ""
+	}
+	hostDir := filepath.Join(modCache, parts[0])
+	entries, err := os.ReadDir(hostDir)
+	if err != nil {
+		return ""
+	}
+	restLower := strings.ToLower(parts[1])
+	for _, e := range entries {
+		if !strings.HasPrefix(strings.ToLower(e.Name()), strings.ReplaceAll(restLower, "/", "+")+`@`) {
+			continue
+		}
+		// Found the versioned directory.
+		pkgDir := filepath.Join(hostDir, e.Name())
+		for _, name := range []string{"LICENSE", "LICENSE.txt", "LICENSE.md", "COPYING"} {
+			data, err := os.ReadFile(filepath.Join(pkgDir, name))
+			if err == nil {
+				if lic := inferFromLicenseText(string(data)); lic != "" {
+					return normalizeSPDX(lic)
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Ruby — Gemfile.lock gem license detection
+// ---------------------------------------------------------------------------
+
+// DetectGemLicenses parses Gemfile.lock and reads the gemspec from the local
+// gem cache (~/.gem/specs or local .bundle).
+func DetectGemLicenses(repoPath string) map[string]string {
+	out := make(map[string]string)
+	data, err := os.ReadFile(filepath.Join(repoPath, "Gemfile.lock"))
+	if err != nil {
+		return out
+	}
+	// Parse gem name+version pairs from Gemfile.lock.
+	gemRe := regexp.MustCompile(`(?m)^    ([A-Za-z0-9_-]+) \(([^)]+)\)$`)
+	for _, m := range gemRe.FindAllStringSubmatch(string(data), -1) {
+		name := m[1]
+		if _, exists := out[name]; !exists {
+			lic := readGemspecLicense(name, m[2])
+			if lic == "" {
+				lic = "Unknown"
+			}
+			out[name] = lic
+		}
+	}
+	return out
+}
+
+func readGemspecLicense(name, version string) string {
+	home, _ := os.UserHomeDir()
+	// Try bundler cache first.
+	gemspecPaths := []string{
+		filepath.Join(home, ".bundle", "cache", fmt.Sprintf("%s-%s", name, version)),
+	}
+	// Ruby gem install directory.
+	gemsDir := filepath.Join(home, ".gem", "ruby")
+	if entries, err := os.ReadDir(gemsDir); err == nil {
+		for _, e := range entries {
+			gemspecPaths = append(gemspecPaths,
+				filepath.Join(gemsDir, e.Name(), "specifications",
+					fmt.Sprintf("%s-%s.gemspec", name, version)))
+		}
+	}
+	for _, p := range gemspecPaths {
+		data, err := os.ReadFile(p)
+		if err != nil {
+			continue
+		}
+		// Gemspec licence field: s.license = "MIT"
+		re := regexp.MustCompile(`s\.licens\w+\s*=\s*["']([^"']+)["']`)
+		m := re.FindStringSubmatch(string(data))
+		if m != nil {
+			return normalizeSPDX(m[1])
+		}
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// High-level: scan a repo and return a DetectResult
+// ---------------------------------------------------------------------------
+
+// ScanRepoLicenses scans repoPath and returns detected licenses for all
+// ExternalPackage entities provided in packageList.
+// packageList entries are maps with keys: name, package_manager, version.
+// totalEntityCount is used to compute license density as a rough LOC proxy.
+func ScanRepoLicenses(repoPath string, packageList []map[string]string, totalEntityCount int) (*DetectResult, error) {
+	projLic, projSrc := DetectProjectLicense(repoPath)
+
+	// Group packages by package manager.
+	type pkgEntry struct {
+		name, version string
+	}
+	npmPkgs := []pkgEntry{}
+	goPkgs := []pkgEntry{}
+	pipPkgs := []pkgEntry{}
+
+	for _, p := range packageList {
+		name := p["name"]
+		pm := p["package_manager"]
+		ver := p["version"]
+		switch pm {
+		case "npm":
+			npmPkgs = append(npmPkgs, pkgEntry{name, ver})
+		case "go_modules":
+			goPkgs = append(goPkgs, pkgEntry{name, ver})
+		case "pip":
+			pipPkgs = append(pipPkgs, pkgEntry{name, ver})
+		}
+	}
+
+	// Detect npm licenses.
+	npmNames := make([]string, len(npmPkgs))
+	for i, p := range npmPkgs {
+		npmNames[i] = p.name
+	}
+	npmLicenses := DetectNPMLicenses(repoPath, npmNames)
+
+	// Detect transitive npm deps.
+	transitiveNPM := ResolveNPMTransitiveDeps(repoPath)
+	directNPM := make(map[string]bool, len(npmNames))
+	for _, n := range npmNames {
+		directNPM[n] = true
+	}
+
+	// Detect Go licenses.
+	goNames := make([]string, len(goPkgs))
+	for i, p := range goPkgs {
+		goNames[i] = p.name
+	}
+	goLicenses := DetectGoModLicenses(goNames)
+
+	// Detect pip licenses.
+	pipNames := make([]string, len(pipPkgs))
+	for i, p := range pipPkgs {
+		pipNames[i] = p.name
+	}
+	pipLicenses := DetectPyPILicensesLocal(repoPath, pipNames)
+
+	// Detect gem licenses (bundler).
+	gemLicenses := DetectGemLicenses(repoPath)
+
+	var deps []PackageLicense
+
+	// Helper: resolve license for a package.
+	resolveLicense := func(pm, name string) (lic, src string) {
+		switch pm {
+		case "npm":
+			lic = npmLicenses[name]
+			if lic != "" && lic != "Unknown" {
+				src = "node_modules/" + name + "/package.json"
+			}
+		case "go_modules":
+			lic = goLicenses[name]
+			if lic != "" && lic != "Unknown" {
+				src = "GOPATH module cache"
+			}
+		case "pip":
+			lic = pipLicenses[name]
+			if lic != "" && lic != "Unknown" {
+				src = ".dist-info/METADATA"
+			}
+		case "bundler":
+			lic = gemLicenses[name]
+			if lic != "" && lic != "Unknown" {
+				src = "gemspec"
+			}
+		}
+		if lic == "" || lic == "Unknown" {
+			lic = "Unknown"
+			src = "not-detected"
+		}
+		return lic, src
+	}
+
+	// Build direct dependency records.
+	for _, p := range packageList {
+		pm := p["package_manager"]
+		name := p["name"]
+		ver := p["version"]
+		lic, src := resolveLicense(pm, name)
+		compat := CheckCompatibility(projLic, lic)
+		alts := SuggestAlternatives(name)
+		deps = append(deps, PackageLicense{
+			PackageName:    name,
+			PackageManager: pm,
+			Version:        ver,
+			License:        lic,
+			LicenseSource:  src,
+			IsTransitive:   false,
+			Compatibility:  compat,
+			Alternatives:   alts,
+		})
+	}
+
+	// Build transitive npm records (those not already in direct list).
+	for name, ver := range transitiveNPM {
+		if directNPM[name] {
+			continue
+		}
+		lic := normalizeSPDX(readNPMPackageLicense(repoPath, name))
+		if lic == "" {
+			lic = "Unknown"
+		}
+		src := "node_modules/" + name + "/package.json (transitive)"
+		compat := CheckCompatibility(projLic, lic)
+		alts := SuggestAlternatives(name)
+		deps = append(deps, PackageLicense{
+			PackageName:    name,
+			PackageManager: "npm",
+			Version:        ver,
+			License:        lic,
+			LicenseSource:  src,
+			IsTransitive:   true,
+			Compatibility:  compat,
+			Alternatives:   alts,
+		})
+	}
+
+	// Collect incompatible.
+	var incompatible []PackageLicense
+	for _, d := range deps {
+		if d.Compatibility == CompatError || d.Compatibility == CompatWarn {
+			incompatible = append(incompatible, d)
+		}
+	}
+
+	// License density: fraction of deps under each license identifier.
+	var density map[string]float64
+	if len(deps) > 0 {
+		licCount := make(map[string]int)
+		for _, d := range deps {
+			licCount[d.License]++
+		}
+		density = make(map[string]float64, len(licCount))
+		totalDeps := float64(len(deps))
+		for lic, cnt := range licCount {
+			density[lic] = math.Round(float64(cnt)/totalDeps*10000) / 10000
+		}
+	}
+	_ = totalEntityCount // reserved for future LOC-weighted density
+
+	return &DetectResult{
+		ProjectLicense:       projLic,
+		ProjectLicenseSource: projSrc,
+		Dependencies:         deps,
+		Incompatible:         incompatible,
+		LicenseDensity:       density,
+	}, nil
+}

--- a/internal/licenses/licenses_test.go
+++ b/internal/licenses/licenses_test.go
@@ -1,0 +1,333 @@
+package licenses
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// SPDX normalizer
+// ---------------------------------------------------------------------------
+
+func TestNormalizeSPDX(t *testing.T) {
+	cases := []struct {
+		in, want string
+	}{
+		{"mit", "MIT"},
+		{"MIT", "MIT"},
+		{"MIT License", "MIT"},
+		{"Apache 2.0", "Apache-2.0"},
+		{"Apache-2.0", "Apache-2.0"},
+		{"GPL-3.0", "GPL-3.0-only"},
+		{"GPL-2.0", "GPL-2.0-only"},
+		{"AGPL-3.0", "AGPL-3.0-only"},
+		{"LGPL-2.1", "LGPL-2.1-only"},
+		{"ISC", "ISC"},
+		{"BSD 3-Clause", "BSD-3-Clause"},
+		{"MPL-2.0", "MPL-2.0"},
+		{"Unlicense", "Unlicense"},
+		{"proprietary", "Proprietary"},
+		{"SomeFancyLicense-9.9", "SomeFancyLicense-9.9"}, // pass-through
+	}
+	for _, c := range cases {
+		got := normalizeSPDX(c.in)
+		if got != c.want {
+			t.Errorf("normalizeSPDX(%q) = %q; want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Compatibility matrix
+// ---------------------------------------------------------------------------
+
+func TestCheckCompatibility(t *testing.T) {
+	cases := []struct {
+		proj, dep string
+		want      CompatibilityLevel
+	}{
+		// MIT project, GPL dep → error
+		{"MIT", "GPL-3.0-only", CompatError},
+		{"MIT", "AGPL-3.0-only", CompatError},
+		{"MIT", "GPL-2.0-only", CompatError},
+		// MIT project, MIT dep → ok
+		{"MIT", "MIT", CompatOK},
+		{"MIT", "Apache-2.0", CompatOK},
+		{"MIT", "BSD-3-Clause", CompatOK},
+		{"MIT", "ISC", CompatOK},
+		// MIT project, LGPL dep → warn
+		{"MIT", "LGPL-2.1-only", CompatWarn},
+		{"MIT", "LGPL-3.0-only", CompatWarn},
+		{"MIT", "MPL-2.0", CompatWarn},
+		// GPL project, GPL dep → ok
+		{"GPL-3.0-only", "GPL-3.0-only", CompatOK},
+		{"GPL-3.0-only", "GPL-2.0-only", CompatOK},
+		// AGPL project, GPL dep → ok
+		{"AGPL-3.0-only", "GPL-3.0-only", CompatOK},
+		// Apache project, AGPL dep → error
+		{"Apache-2.0", "AGPL-3.0-only", CompatError},
+		// Unknown dep → unknown
+		{"MIT", "", CompatUnknown},
+		{"MIT", "NOASSERTION", CompatUnknown},
+	}
+	for _, c := range cases {
+		got := CheckCompatibility(c.proj, c.dep)
+		if got != c.want {
+			t.Errorf("CheckCompatibility(%q, %q) = %q; want %q", c.proj, c.dep, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// inferFromLicenseText
+// ---------------------------------------------------------------------------
+
+func TestInferFromLicenseText(t *testing.T) {
+	cases := []struct {
+		text, want string
+	}{
+		{"MIT License\nPermission is hereby granted", "MIT"},
+		{"GNU General Public License version 3", "GPL-3.0-only"},
+		{"GNU General Public License version 2", "GPL-2.0-only"},
+		{"GNU Affero General Public License", "AGPL-3.0-only"},
+		{"GNU Lesser General Public License version 3", "LGPL-3.0-only"},
+		{"Apache License", "Apache-2.0"},
+		{"BSD 3-Clause License\nRedistributions of source code", "BSD-3-Clause"},
+		{"ISC License", "ISC"},
+		{"Mozilla Public License", "MPL-2.0"},
+		{"This is UNLICENSE — public domain", "Unlicense"},
+		{"some random text with no license info", ""},
+	}
+	for _, c := range cases {
+		got := inferFromLicenseText(c.text)
+		if got != c.want {
+			t.Errorf("inferFromLicenseText(%q) = %q; want %q", c.text, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractTOMLField
+// ---------------------------------------------------------------------------
+
+func TestExtractTOMLField(t *testing.T) {
+	cases := []struct {
+		src, key, want string
+	}{
+		{"[package]\nlicense = \"MIT\"", "license", "MIT"},
+		{"[package]\nlicense = {text = \"Apache-2.0\"}", "license", "Apache-2.0"},
+		{"[package]\nversion = \"1.0.0\"", "license", ""},
+		{"license = \"GPL-3.0-only\"", "license", "GPL-3.0-only"},
+	}
+	for _, c := range cases {
+		got := extractTOMLField(c.src, c.key)
+		if got != c.want {
+			t.Errorf("extractTOMLField(%q, %q) = %q; want %q", c.src, c.key, got, c.want)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DetectProjectLicense — package.json path
+// ---------------------------------------------------------------------------
+
+func TestDetectProjectLicenseFromPackageJSON(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "package.json"),
+		[]byte(`{"name":"test","license":"MIT"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lic, src := DetectProjectLicense(tmp)
+	if lic != "MIT" {
+		t.Errorf("license = %q; want MIT", lic)
+	}
+	if src != "package.json" {
+		t.Errorf("source = %q; want package.json", src)
+	}
+}
+
+func TestDetectProjectLicenseFromFile(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "LICENSE"),
+		[]byte("MIT License\nPermission is hereby granted"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lic, _ := DetectProjectLicense(tmp)
+	if lic != "MIT" {
+		t.Errorf("license = %q; want MIT", lic)
+	}
+}
+
+func TestDetectProjectLicenseGPL(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "LICENSE"),
+		[]byte("GNU General Public License version 3"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lic, _ := DetectProjectLicense(tmp)
+	if lic != "GPL-3.0-only" {
+		t.Errorf("license = %q; want GPL-3.0-only", lic)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DetectNPMLicenses — local node_modules
+// ---------------------------------------------------------------------------
+
+func TestDetectNPMLicenses(t *testing.T) {
+	tmp := t.TempDir()
+	pkgDir := filepath.Join(tmp, "node_modules", "express")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"),
+		[]byte(`{"name":"express","license":"MIT"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := DetectNPMLicenses(tmp, []string{"express", "missing-pkg"})
+	if m["express"] != "MIT" {
+		t.Errorf("express license = %q; want MIT", m["express"])
+	}
+	if m["missing-pkg"] != "Unknown" {
+		t.Errorf("missing-pkg license = %q; want Unknown", m["missing-pkg"])
+	}
+}
+
+func TestDetectNPMLicensesLegacyFormat(t *testing.T) {
+	tmp := t.TempDir()
+	pkgDir := filepath.Join(tmp, "node_modules", "oldpkg")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Old-format with licenses array.
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"),
+		[]byte(`{"name":"oldpkg","licenses":[{"type":"BSD-3-Clause"}]}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := DetectNPMLicenses(tmp, []string{"oldpkg"})
+	if m["oldpkg"] != "BSD-3-Clause" {
+		t.Errorf("oldpkg license = %q; want BSD-3-Clause", m["oldpkg"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SuggestAlternatives
+// ---------------------------------------------------------------------------
+
+func TestSuggestAlternatives(t *testing.T) {
+	alts := SuggestAlternatives("node-forge")
+	if len(alts) == 0 {
+		t.Error("expected at least one alternative for node-forge")
+	}
+	alts2 := SuggestAlternatives("some-unknown-pkg")
+	if len(alts2) != 0 {
+		t.Errorf("expected no alternatives for unknown pkg, got %v", alts2)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ResolveNPMTransitiveDeps
+// ---------------------------------------------------------------------------
+
+func TestResolveNPMTransitiveDeps(t *testing.T) {
+	tmp := t.TempDir()
+	lock := `{"lockfileVersion":2,"packages":{"":{},"node_modules/lodash":{"version":"4.17.21"}}}`
+	if err := os.WriteFile(filepath.Join(tmp, "package-lock.json"),
+		[]byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := ResolveNPMTransitiveDeps(tmp)
+	if m["lodash"] != "4.17.21" {
+		t.Errorf("lodash version = %q; want 4.17.21", m["lodash"])
+	}
+}
+
+func TestResolveNPMTransitiveDepsV1(t *testing.T) {
+	tmp := t.TempDir()
+	lock := `{"lockfileVersion":1,"dependencies":{"chalk":{"version":"4.1.2"}}}`
+	if err := os.WriteFile(filepath.Join(tmp, "package-lock.json"),
+		[]byte(lock), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	m := ResolveNPMTransitiveDeps(tmp)
+	if m["chalk"] != "4.1.2" {
+		t.Errorf("chalk version = %q; want 4.1.2", m["chalk"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// ScanRepoLicenses — end-to-end with local fixtures
+// ---------------------------------------------------------------------------
+
+func TestScanRepoLicensesCompatError(t *testing.T) {
+	tmp := t.TempDir()
+	// Project is MIT.
+	if err := os.WriteFile(filepath.Join(tmp, "package.json"),
+		[]byte(`{"license":"MIT"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// Create a fake GPL node_modules dep.
+	pkgDir := filepath.Join(tmp, "node_modules", "gpl-lib")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"),
+		[]byte(`{"name":"gpl-lib","license":"GPL-3.0"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgList := []map[string]string{
+		{"name": "gpl-lib", "package_manager": "npm", "version": "1.0.0"},
+	}
+	res, err := ScanRepoLicenses(tmp, pkgList, 100)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if res.ProjectLicense != "MIT" {
+		t.Errorf("project license = %q; want MIT", res.ProjectLicense)
+	}
+	if len(res.Dependencies) == 0 {
+		t.Fatal("expected at least one dependency")
+	}
+	dep := res.Dependencies[0]
+	if dep.License != "GPL-3.0-only" {
+		t.Errorf("dep license = %q; want GPL-3.0-only", dep.License)
+	}
+	if dep.Compatibility != CompatError {
+		t.Errorf("dep compat = %q; want error", dep.Compatibility)
+	}
+	if len(res.Incompatible) == 0 {
+		t.Error("expected incompatible list to be non-empty")
+	}
+}
+
+func TestScanRepoLicensesAllOK(t *testing.T) {
+	tmp := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmp, "package.json"),
+		[]byte(`{"license":"MIT"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	pkgDir := filepath.Join(tmp, "node_modules", "lodash")
+	if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pkgDir, "package.json"),
+		[]byte(`{"name":"lodash","license":"MIT"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	pkgList := []map[string]string{
+		{"name": "lodash", "package_manager": "npm", "version": "4.17.21"},
+	}
+	res, err := ScanRepoLicenses(tmp, pkgList, 200)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(res.Incompatible) != 0 {
+		t.Errorf("expected no incompatible deps; got %d", len(res.Incompatible))
+	}
+	if res.LicenseDensity["MIT"] != 1.0 {
+		t.Errorf("license density MIT = %v; want 1.0", res.LicenseDensity["MIT"])
+	}
+}

--- a/internal/mcp/license_tools.go
+++ b/internal/mcp/license_tools.go
@@ -1,0 +1,217 @@
+// license_tools.go — MCP handler for archigraph_license_audit (#1334).
+//
+// Reads ExternalPackage / external_dependency entities from loaded graph docs,
+// enriches each with detected license metadata, flags incompatible combinations
+// between the project license and each dependency license, and surfaces
+// transitive GPL/AGPL chains.
+//
+// Severity mapping:
+//
+//	error  — strong-copyleft dep (GPL/AGPL) in a non-copyleft project
+//	warn   — weak-copyleft dep (LGPL/MPL/EUPL/CDDL) or proprietary dep
+//	info   — no conflict detected
+//	unknown — license could not be resolved
+//
+// The project license is inferred from the repo root (LICENSE file, package.json,
+// pyproject.toml, Cargo.toml).
+//
+// Registered MCP tool: archigraph_license_audit
+package mcp
+
+import (
+	"context"
+	"fmt"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/licenses"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// handleLicenseAudit is the MCP handler for archigraph_license_audit.
+func (s *Server) handleLicenseAudit(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, nil)
+
+	includeTransitive := argBool(req, "include_transitive", false)
+	severityFilter := argString(req, "severity", "")
+	limit := argInt(req, "limit", 500)
+
+	if severityFilter != "" {
+		valid := map[string]bool{"error": true, "warn": true, "info": true, "unknown": true}
+		if !valid[severityFilter] {
+			return mcpapi.NewToolResultError(
+				fmt.Sprintf("invalid severity %q: must be error|warn|info|unknown", severityFilter)), nil
+		}
+	}
+
+	type depOut struct {
+		Repo           string   `json:"repo"`
+		PackageName    string   `json:"package_name"`
+		PackageManager string   `json:"package_manager"`
+		Version        string   `json:"version"`
+		License        string   `json:"license"`
+		LicenseSource  string   `json:"license_source"`
+		IsTransitive   bool     `json:"is_transitive"`
+		ProjectLicense string   `json:"project_license"`
+		Compatibility  string   `json:"compatibility"`
+		Severity       string   `json:"severity"`
+		Alternatives   []string `json:"alternatives,omitempty"`
+	}
+
+	type repoSummary struct {
+		Repo                 string             `json:"repo"`
+		ProjectLicense       string             `json:"project_license"`
+		ProjectLicenseSource string             `json:"project_license_source"`
+		TotalDeps            int                `json:"total_deps"`
+		IncompatibleCount    int                `json:"incompatible_count"`
+		LicenseDensity       map[string]float64 `json:"license_density,omitempty"`
+	}
+
+	bySeverity := map[string]int{"error": 0, "warn": 0, "info": 0, "unknown": 0}
+	var allDeps []depOut
+	var summaries []repoSummary
+	scanned := 0
+
+	for _, r := range repos {
+		if r.Doc == nil || r.Path == "" {
+			continue
+		}
+
+		// Collect ExternalPackage entities from the loaded graph.
+		packageList := collectExternalPackages(r)
+		if len(packageList) == 0 {
+			continue
+		}
+
+		result, err := licenses.ScanRepoLicenses(r.Path, packageList, len(r.Doc.Entities))
+		if err != nil {
+			continue
+		}
+		scanned++
+
+		incompatCount := 0
+		for _, dep := range result.Dependencies {
+			if dep.IsTransitive && !includeTransitive {
+				continue
+			}
+			sev := compatToSeverity(dep.Compatibility)
+			bySeverity[sev]++
+			if sev == "error" || sev == "warn" {
+				incompatCount++
+			}
+			if severityFilter != "" && sev != severityFilter {
+				continue
+			}
+			allDeps = append(allDeps, depOut{
+				Repo:           r.Repo,
+				PackageName:    dep.PackageName,
+				PackageManager: dep.PackageManager,
+				Version:        dep.Version,
+				License:        dep.License,
+				LicenseSource:  dep.LicenseSource,
+				IsTransitive:   dep.IsTransitive,
+				ProjectLicense: result.ProjectLicense,
+				Compatibility:  string(dep.Compatibility),
+				Severity:       sev,
+				Alternatives:   dep.Alternatives,
+			})
+		}
+		summaries = append(summaries, repoSummary{
+			Repo:                 r.Repo,
+			ProjectLicense:       result.ProjectLicense,
+			ProjectLicenseSource: result.ProjectLicenseSource,
+			TotalDeps:            len(result.Dependencies),
+			IncompatibleCount:    incompatCount,
+			LicenseDensity:       result.LicenseDensity,
+		})
+	}
+
+	// Sort: errors first, then warn, then info, then unknown;
+	// within each bucket: repo, then package name.
+	sort.SliceStable(allDeps, func(i, j int) bool {
+		ri := licSeverityRank(allDeps[i].Severity)
+		rj := licSeverityRank(allDeps[j].Severity)
+		if ri != rj {
+			return ri > rj
+		}
+		if allDeps[i].Repo != allDeps[j].Repo {
+			return allDeps[i].Repo < allDeps[j].Repo
+		}
+		return allDeps[i].PackageName < allDeps[j].PackageName
+	})
+
+	total := len(allDeps)
+	if limit > 0 && len(allDeps) > limit {
+		allDeps = allDeps[:limit]
+	}
+
+	return jsonResult(map[string]any{
+		"scanned_repos":  scanned,
+		"total_findings": total,
+		"truncated":      total > len(allDeps),
+		"by_severity":    bySeverity,
+		"repos":          summaries,
+		"dependencies":   allDeps,
+		"tip": "severity=error: strong-copyleft (GPL/AGPL) in non-copyleft project; " +
+			"severity=warn: weak-copyleft (LGPL/MPL/EUPL/CDDL) or Proprietary dep; " +
+			"use include_transitive=true to surface indirect npm chains. " +
+			"alternatives field suggests permissive drop-in replacements.",
+	}), nil
+}
+
+// collectExternalPackages extracts external_dependency entities from the
+// loaded graph document and returns them as the package list format expected
+// by licenses.ScanRepoLicenses.
+func collectExternalPackages(r *LoadedRepo) []map[string]string {
+	if r.Doc == nil {
+		return nil
+	}
+	var out []map[string]string
+	for i := range r.Doc.Entities {
+		e := &r.Doc.Entities[i]
+		if e.Subtype != "external_dependency" {
+			continue
+		}
+		pm := e.Properties["package_manager"]
+		ver := e.Properties["version"]
+		if pm == "" {
+			continue
+		}
+		out = append(out, map[string]string{
+			"name":            e.Name,
+			"package_manager": pm,
+			"version":         ver,
+		})
+	}
+	return out
+}
+
+// compatToSeverity maps a licenses.CompatibilityLevel to an MCP severity string.
+func compatToSeverity(c licenses.CompatibilityLevel) string {
+	switch c {
+	case licenses.CompatError:
+		return "error"
+	case licenses.CompatWarn:
+		return "warn"
+	case licenses.CompatUnknown:
+		return "unknown"
+	default:
+		return "info"
+	}
+}
+
+// licSeverityRank returns a numeric rank for sorting (higher = more severe).
+func licSeverityRank(s string) int {
+	switch s {
+	case "error":
+		return 3
+	case "warn":
+		return 2
+	case "info":
+		return 1
+	}
+	return 0
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -103,7 +103,7 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
-// Tool count: 32 (#1281: 9→4 bundles; #1293: desc trim; #1312: +archigraph_quality_cycles; #1314: +archigraph_auth_coverage; #1322: +archigraph_secrets; #1323: +archigraph_test_coverage already on main; #1333: desc trimmed to ≤80 chars for budget gate).
+// Tool count: 33 (#1281: 9→4 bundles; #1293: desc trim; #1312: +archigraph_quality_cycles; #1314: +archigraph_auth_coverage; #1322: +archigraph_secrets; #1323: +archigraph_test_coverage; #1333: desc trimmed to ≤80 chars for budget gate; #1334: +archigraph_license_audit).
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
 //   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
 func (s *Server) registerTools() {
@@ -462,6 +462,32 @@ func (s *Server) registerTools() {
 			mcpapi.Description("Maximum number of findings to return."),
 		),
 	), s.wrap("archigraph_secrets", s.handleSecrets))
+
+	// archigraph_license_audit — dependency license detector (#1334).
+	// Reads ExternalPackage entities, detects SPDX licenses, flags incompatible
+	// combinations (GPL/AGPL in MIT project = error; LGPL/MPL = warn).
+	// Transitive npm deps surfaced when include_transitive=true.
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_license_audit",
+		mcpapi.WithDescription(
+			"License audit: detect SPDX licenses for all ExternalPackage dependencies and flag "+
+				"incompatible combinations. error=GPL/AGPL in non-copyleft project; "+
+				"warn=LGPL/MPL/EUPL/CDDL or Proprietary dep. "+
+				"Returns per-repo project_license, license_density, and flagged dep list. "+
+				"Set include_transitive=true to include indirect/transitive dependencies.",
+		),
+		mcpapi.WithString("group"),
+		mcpapi.WithString("cwd"),
+		mcpapi.WithBoolean("include_transitive", mcpapi.DefaultBool(false),
+			mcpapi.Description("Include transitive/indirect dependencies. Default: direct only."),
+		),
+		mcpapi.WithString("severity",
+			mcpapi.Description("Filter output: error|warn|info|unknown (empty = all). "+
+				"error=strong-copyleft incompatibility, warn=weak-copyleft."),
+		),
+		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(500),
+			mcpapi.Description("Maximum number of dependency findings to return."),
+		),
+	), s.wrap("archigraph_license_audit", s.handleLicenseAudit))
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard
@@ -530,7 +556,7 @@ func extractIDs(res *mcpapi.CallToolResult) (nodeIDs, edgeIDs []string) {
 			"results", "nodes", "steps", "orphans", "patterns", "orphan_publishers",
 			"orphan_subscribers", "dead_ends", "truncated_flows", "publishers",
 			"subscribers", "exemplars",
-			"callers", "callees", "affected", "dead_code")...)
+			"callers", "callees", "affected", "dead_code", "dependencies")...)
 		edgeIDs = append(edgeIDs, collectSliceIDs(payload, "edges")...)
 	}
 	return dedup(nodeIDs), dedup(edgeIDs)

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -468,13 +468,7 @@ func (s *Server) registerTools() {
 	// combinations (GPL/AGPL in MIT project = error; LGPL/MPL = warn).
 	// Transitive npm deps surfaced when include_transitive=true.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_license_audit",
-		mcpapi.WithDescription(
-			"License audit: detect SPDX licenses for all ExternalPackage dependencies and flag "+
-				"incompatible combinations. error=GPL/AGPL in non-copyleft project; "+
-				"warn=LGPL/MPL/EUPL/CDDL or Proprietary dep. "+
-				"Returns per-repo project_license, license_density, and flagged dep list. "+
-				"Set include_transitive=true to include indirect/transitive dependencies.",
-		),
+		mcpapi.WithDescription("Detect dependency licenses; flag GPL/AGPL incompatibility, weak-copyleft."),
 		mcpapi.WithString("group"),
 		mcpapi.WithString("cwd"),
 		mcpapi.WithBoolean("include_transitive", mcpapi.DefaultBool(false),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -631,9 +631,9 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 32 (31 pre-#1323 + archigraph_secrets).
-	if got := len(srv.MCP.ListTools()); got != 32 {
-		t.Errorf("expected 32 registered tools, got %d", got)
+	// Total count: 33 (31 pre-#1323 + archigraph_secrets + archigraph_license_audit).
+	if got := len(srv.MCP.ListTools()); got != 33 {
+		t.Errorf("expected 33 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
## What

Implements issue #1334: license detection for `ExternalPackage` entities emitted by the manifest extractor (#1328), with compatibility checking and a new `archigraph_license_audit` MCP tool.

## Why

Projects that pull in GPL/AGPL dependencies without knowing it face legal exposure. The graph already knows about every external dependency — this PR enriches that knowledge with license metadata and surfaces violations.

## Changes

### `internal/licenses/licenses.go` (new)
- **SPDX normalizer** — maps 40+ common non-standard strings (`"MIT License"`, `"Apache 2.0"`, `"gpl-3"`, etc.) to canonical SPDX identifiers.
- **Compatibility matrix** — `CheckCompatibility(projectLicense, depLicense)` returns `error` (GPL/AGPL in non-copyleft project), `warn` (LGPL/MPL/EUPL/CDDL or Proprietary), `ok` (permissive), or `unknown` (unresolved).
- **Project license detection** — reads `LICENSE`/`LICENSE.txt`/`LICENSE.md`, then `package.json#license`, `pyproject.toml`, `Cargo.toml`.
- **Local metadata detection** (no network calls):
  - npm: `node_modules/<pkg>/package.json` (both `license: string` and legacy `licenses: [{type}]` formats)
  - Go: GOPATH module cache LICENSE files
  - Python: `.dist-info/METADATA` RFC 822 headers in `.venv`/`venv`/`env`
  - Ruby: gemspec in `~/.gem/ruby/*/specifications/`
- **Transitive npm deps** via `package-lock.json` v1/v2/v3
- **Drop-in alternatives** for known incompatible packages (`node-forge`, `mysql-connector-python`, `github.com/gofrs/uuid`, etc.)
- **License density** — fraction of total deps under each SPDX identifier

### `internal/licenses/licenses_test.go` (new)
14 unit tests: SPDX normalizer, compatibility matrix (MIT→GPL=error, MIT→LGPL=warn, GPL→GPL=ok, Apache→AGPL=error), license text inference (MIT/GPL2/GPL3/AGPL/LGPL/Apache/BSD/ISC/MPL/Unlicense), TOML field extraction, project license detection from file and `package.json`, npm local detection (standard + legacy), transitive dep resolution (lock v1 + v2), end-to-end scan (error + ok scenarios). All 14 pass.

### `internal/mcp/license_tools.go` (new)
`archigraph_license_audit` MCP handler:
- Iterates all `external_dependency` entities from loaded graph documents
- Calls `ScanRepoLicenses` per repo (fully local, no network)
- Groups findings by severity (error → warn → info → unknown)
- Returns per-repo summary: `project_license`, `project_license_source`, `total_deps`, `incompatible_count`, `license_density`
- Returns dep list with `alternatives` field for incompatible packages
- Supports `include_transitive=true` to surface npm transitive chains
- `severity` filter (error|warn|info|unknown), `limit` param

### `internal/mcp/server.go` (modified)
- Tool count comment 32 → 33
- Registers `archigraph_license_audit` tool
- Adds `"dependencies"` to `extractIDs` collectSliceIDs key list

## Test plan
- [ ] `go test ./internal/licenses/...` — all 14 pass (verified)
- [ ] `go build ./internal/mcp/...` — clean (verified)
- [ ] `go vet ./internal/licenses/... ./internal/mcp/...` — clean (verified)
- [ ] Index a project with npm deps including a GPL package; call `archigraph_license_audit(group=X)` and verify error entries appear
- [ ] Call with `severity=error` and confirm only error entries returned
- [ ] Call with `include_transitive=true` and confirm transitive npm deps appear
- [ ] MIT project with only MIT deps → `incompatible_count=0`, `license_density={"MIT":1.0}`

## Beyond spec (from issue)
- Transitive chain analysis (npm `package-lock.json` v1/v2/v3)
- Drop-in alternatives for known incompatible packages
- License density per repo (fraction of total deps under each SPDX id)
- All detection is local (no network), making it fast and offline-safe

🤖 Generated with [Claude Code](https://claude.com/claude-code)