### PR TITLE
fix(build): consolidate duplicate SecretFinding struct definitions

### DIFF
--- a/internal/dashboard/handlers_secrets.go
+++ b/internal/dashboard/handlers_secrets.go
@@ -29,8 +29,9 @@ import (
 // Wire shapes
 // ─────────────────────────────────────────────────────────────────────────────
 
-// SecretFinding is the API-level representation of one detected secret.
-type SecretFinding struct {
+// QualitySecretFinding is the API-level representation of one detected secret
+// returned by GET /api/quality/secrets/{group}.
+type QualitySecretFinding struct {
 	File            string `json:"file"`
 	Line            int    `json:"line"`
 	Kind            string `json:"kind"`
@@ -45,7 +46,7 @@ type SecretFileRollup struct {
 	Repo     string          `json:"repo"`
 	Count    int             `json:"count"`
 	Severity string          `json:"severity"`
-	Findings []SecretFinding `json:"findings"`
+	Findings []QualitySecretFinding `json:"findings"`
 }
 
 // SecretScanReply is the wire shape returned by GET /api/quality/secrets/{group}.
@@ -116,12 +117,12 @@ func (s *Server) handleQualitySecrets(w http.ResponseWriter, r *http.Request) {
 			if !passesSeverityFilter(secrets.Severity(fr.Severity), severityFilter) {
 				continue
 			}
-			var apiFindings []SecretFinding
+			var apiFindings []QualitySecretFinding
 			for _, f := range fr.Findings {
 				if !passesSeverityFilter(f.Severity, severityFilter) {
 					continue
 				}
-				apiFindings = append(apiFindings, SecretFinding{
+				apiFindings = append(apiFindings, QualitySecretFinding{
 					File:            f.File,
 					Line:            f.Line,
 					Kind:            f.Kind,

--- a/internal/dashboard/handlers_security.go
+++ b/internal/dashboard/handlers_security.go
@@ -59,8 +59,9 @@ type GroupAuthCoverageReport struct {
 // Secrets wire shapes
 // ─────────────────────────────────────────────────────────────────────────────
 
-// SecretFinding is a single secret-related finding.
-type SecretFinding struct {
+// SecuritySecretFinding is a single secret-related finding returned by
+// GET /api/security/secrets/{group}.
+type SecuritySecretFinding struct {
 	EntityID   string `json:"entity_id"`
 	Name       string `json:"name"`
 	Repo       string `json:"repo"`
@@ -68,11 +69,11 @@ type SecretFinding struct {
 	StartLine  int    `json:"start_line,omitempty"`
 	Language   string `json:"language,omitempty"`
 	// Category: "hardcoded_credential" | "secrets_management"
-	Category     string `json:"category"`
+	Category string `json:"category"`
 	// Provider is set for secrets_management findings (e.g. "vault", "aws_secrets_manager")
-	Provider     string `json:"provider,omitempty"`
-	Severity     string `json:"severity"` // "error" | "warn" | "info"
-	Remediation  string `json:"remediation,omitempty"`
+	Provider    string `json:"provider,omitempty"`
+	Severity    string `json:"severity"` // "error" | "warn" | "info"
+	Remediation string `json:"remediation,omitempty"`
 }
 
 // GroupSecretsReport is the wire shape for GET /api/security/secrets/{group}.
@@ -83,7 +84,7 @@ type GroupSecretsReport struct {
 	WarnCount      int             `json:"warn_count"`
 	InfoCount      int             `json:"info_count"`
 	ByCategory     map[string]int  `json:"by_category"`
-	Findings       []SecretFinding `json:"findings"`
+	Findings       []SecuritySecretFinding `json:"findings"`
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -405,7 +406,7 @@ func (s *Server) handleSecuritySecrets(w http.ResponseWriter, r *http.Request) {
 			}
 			result.ByCategory[category]++
 
-			result.Findings = append(result.Findings, SecretFinding{
+			result.Findings = append(result.Findings, SecuritySecretFinding{
 				EntityID:    rp.Slug + "/" + e.ID,
 				Name:        e.Name,
 				Repo:        rp.Slug,


### PR DESCRIPTION
## Summary

- Build was broken by concurrent PRs #1322 + #1331 each declaring \`SecretFinding\` in \`internal/dashboard\` — Go does not allow duplicate type names in the same package.
- The two structs serve completely different endpoints with different fields, so the fix is a rename rather than a union merge:
  - \`handlers_secrets.go\` → \`QualitySecretFinding\` (used by \`GET /api/quality/secrets/{group}\`)
  - \`handlers_security.go\` → \`SecuritySecretFinding\` (used by \`GET /api/security/secrets/{group}\`)
- JSON wire field names are **unchanged** — only the Go type identifiers differ.

## Test plan

- [ ] \`go build ./internal/dashboard/...\` passes clean (verified locally)
- [ ] \`go test ./internal/dashboard/...\` — all pre-existing tests pass; two unrelated writeback/YAML failures (\`TestWriteback_success\`, \`TestYamlScalar\`) were already failing on \`main\` before this branch and are out of scope
- [ ] Confirm no other files in the repo reference the bare \`SecretFinding\` name

🤖 Generated with [Claude Code](https://claude.com/claude-code)