### PR TITLE
[export] OpenAPI 3.0 spec export from indexed HTTP endpoints (#1340)

### DIFF
--- a/dashboard/src/routes/paths.tsx
+++ b/dashboard/src/routes/paths.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState, useCallback, useMemo } from 'react'
 import { useParams, Outlet, useNavigate } from 'react-router-dom'
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { ChevronUp, ChevronDown, List, Globe, Columns2 } from 'lucide-react'
+import { ChevronUp, ChevronDown, List, Globe, Columns2, FileDown } from 'lucide-react'
 import { PathRow } from '@/components/paths/PathRow'
 import { PathsGroup } from '@/components/paths/PathsGroup'
 import { BackendGroup, readCollapsed, writeCollapsed } from '@/components/paths/BackendGroup'
@@ -717,6 +717,18 @@ export function PathsRoute() {
               <span className="text-xs text-slate-400 dark:text-slate-500 flex-shrink-0 tabular-nums">
                 {isFetching && !isLoading ? '↻ ' : ''}{totalLabel}
               </span>
+            )}
+            {activeTab === 'endpoints' && (data?.total ?? 0) > 0 && (
+              <a
+                href={`/api/export/${group}/openapi?format=yaml`}
+                download={`${group}-openapi.yaml`}
+                title="Download OpenAPI 3.0 spec (YAML)"
+                className="flex items-center gap-1 text-xs text-slate-400 dark:text-slate-400 hover:text-slate-800 dark:hover:text-slate-200 px-1.5 py-0.5 rounded hover:bg-slate-200 dark:hover:bg-slate-800 transition-colors flex-shrink-0"
+                aria-label="Download OpenAPI spec"
+              >
+                <FileDown className="w-3.5 h-3.5" aria-hidden />
+                OpenAPI
+              </a>
             )}
           </div>
 

--- a/internal/dashboard/handlers_export_openapi.go
+++ b/internal/dashboard/handlers_export_openapi.go
@@ -1,0 +1,483 @@
+package dashboard
+
+// handlers_export_openapi.go — OpenAPI 3.0 export from indexed HTTP endpoints (#1340)
+//
+//	GET /api/export/{group}/openapi?format=yaml|json
+//
+// Reads all http_endpoint_definition entities in the group and emits a
+// standards-compliant OpenAPI 3.0 document.  The spec includes:
+//
+//   - paths/methods from endpoint Properties["method"] + Properties["path"]
+//   - path parameters extracted from canonical {param} placeholders
+//   - response shapes (status codes + field keys) from enrichment data
+//   - operation summaries from AI enrichment when available
+//   - tags derived from owning_backend grouping
+//
+// The output validates against the OpenAPI 3.0 schema and loads without
+// errors in Swagger UI / Redoc.
+//
+// format=yaml (default) → application/x-yaml + Content-Disposition download
+// format=json          → application/json   + Content-Disposition download
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// ---------------------------------------------------------------------------
+// OpenAPI 3.0 data structures
+// ---------------------------------------------------------------------------
+
+// openAPIDoc is the top-level OpenAPI 3.0 document.
+type openAPIDoc struct {
+	OpenAPI    string                        `json:"openapi" yaml:"openapi"`
+	Info       openAPIInfo                   `json:"info" yaml:"info"`
+	Paths      map[string]openAPIPathItem    `json:"paths" yaml:"paths"`
+	Tags       []openAPITag                  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Components openAPIComponents             `json:"components,omitempty" yaml:"components,omitempty"`
+}
+
+type openAPIInfo struct {
+	Title       string `json:"title" yaml:"title"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+	Version     string `json:"version" yaml:"version"`
+}
+
+// openAPIPathItem maps HTTP methods to their operations.
+// We keep the fields explicit (no dynamic map) so yaml/json marshal order is
+// deterministic and swagger-cli validates cleanly.
+type openAPIPathItem struct {
+	Get     *openAPIOperation `json:"get,omitempty" yaml:"get,omitempty"`
+	Post    *openAPIOperation `json:"post,omitempty" yaml:"post,omitempty"`
+	Put     *openAPIOperation `json:"put,omitempty" yaml:"put,omitempty"`
+	Patch   *openAPIOperation `json:"patch,omitempty" yaml:"patch,omitempty"`
+	Delete  *openAPIOperation `json:"delete,omitempty" yaml:"delete,omitempty"`
+	Head    *openAPIOperation `json:"head,omitempty" yaml:"head,omitempty"`
+	Options *openAPIOperation `json:"options,omitempty" yaml:"options,omitempty"`
+}
+
+// setOperation assigns an operation to the correct method field.
+func (pi *openAPIPathItem) setOperation(method string, op *openAPIOperation) {
+	switch strings.ToUpper(method) {
+	case "GET":
+		pi.Get = op
+	case "POST":
+		pi.Post = op
+	case "PUT":
+		pi.Put = op
+	case "PATCH":
+		pi.Patch = op
+	case "DELETE":
+		pi.Delete = op
+	case "HEAD":
+		pi.Head = op
+	case "OPTIONS":
+		pi.Options = op
+	}
+}
+
+type openAPIOperation struct {
+	OperationID string                    `json:"operationId,omitempty" yaml:"operationId,omitempty"`
+	Summary     string                    `json:"summary,omitempty" yaml:"summary,omitempty"`
+	Description string                    `json:"description,omitempty" yaml:"description,omitempty"`
+	Tags        []string                  `json:"tags,omitempty" yaml:"tags,omitempty"`
+	Parameters  []openAPIParameter        `json:"parameters,omitempty" yaml:"parameters,omitempty"`
+	Responses   map[string]openAPIResponse `json:"responses" yaml:"responses"`
+}
+
+type openAPIParameter struct {
+	Name     string        `json:"name" yaml:"name"`
+	In       string        `json:"in" yaml:"in"`
+	Required bool          `json:"required" yaml:"required"`
+	Schema   openAPISchema `json:"schema" yaml:"schema"`
+}
+
+type openAPIResponse struct {
+	Description string                    `json:"description" yaml:"description"`
+	Content     map[string]openAPIMedia   `json:"content,omitempty" yaml:"content,omitempty"`
+}
+
+type openAPIMedia struct {
+	Schema openAPISchema `json:"schema" yaml:"schema"`
+}
+
+type openAPISchema struct {
+	Type       string                   `json:"type,omitempty" yaml:"type,omitempty"`
+	Properties map[string]openAPISchema `json:"properties,omitempty" yaml:"properties,omitempty"`
+}
+
+type openAPITag struct {
+	Name        string `json:"name" yaml:"name"`
+	Description string `json:"description,omitempty" yaml:"description,omitempty"`
+}
+
+type openAPIComponents struct {
+	Schemas map[string]openAPISchema `json:"schemas,omitempty" yaml:"schemas,omitempty"`
+}
+
+// ---------------------------------------------------------------------------
+// Path-parameter regex
+// ---------------------------------------------------------------------------
+
+var rePathParam = regexp.MustCompile(`\{([A-Za-z_]\w*)\}`)
+
+// ---------------------------------------------------------------------------
+// Handler
+// ---------------------------------------------------------------------------
+
+// handleExportOpenAPI — GET /api/export/{group}/openapi?format=yaml|json
+func (s *Server) handleExportOpenAPI(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	format := strings.ToLower(r.URL.Query().Get("format"))
+	if format == "" {
+		format = "yaml"
+	}
+	if format != "yaml" && format != "json" {
+		writeErr(w, http.StatusBadRequest, "format must be yaml or json")
+		return
+	}
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	// -----------------------------------------------------------------------
+	// Collect all http_endpoint_definition entities across repos.
+	// -----------------------------------------------------------------------
+
+	type rawEP struct {
+		method        string
+		path          string
+		handlerName   string
+		framework     string
+		owningBackend string
+		description   string   // AI summary when available
+		responseKeys  []string // from enrichment
+		statusCodes   []int
+		repo          string
+	}
+
+	var eps []rawEP
+
+	for _, repo := range sortedRepos(grp) {
+		for i := range repo.Doc.Entities {
+			e := &repo.Doc.Entities[i]
+
+			// Accept http_endpoint_definition and backward-compat kinds.
+			kind := dashStripScopePrefix(e.Kind)
+			if !types.IsHTTPEndpointDefinitionKind(kind) &&
+				kind != httpEndpointKind &&
+				e.Kind != "Endpoint" && e.Kind != "Route" {
+				continue
+			}
+			// Exclude call-site synthetics.
+			if e.Kind == "http_endpoint_call" ||
+				e.Properties["pattern_type"] == "http_endpoint_client_synthesis" {
+				continue
+			}
+
+			path := e.Properties["path"]
+			if path == "" {
+				path = e.Name
+			}
+			if !isHTTPEndpointPath(path) {
+				continue
+			}
+
+			method := strings.ToUpper(e.Properties["method"])
+			if method == "" {
+				method = strings.ToUpper(e.Properties["verb"])
+			}
+			if method == "" {
+				method = "ANY"
+			}
+			// Skip DRF urlconf_nested_include ANY placeholders.
+			if method == "ANY" && e.Properties["urlconf_nested_include"] == "true" {
+				continue
+			}
+
+			owningBackend := e.Properties["owning_backend"]
+			if owningBackend == "" {
+				owningBackend = inferOwningBackend(e.Name, repo.Slug)
+			}
+
+			// AI enrichment description — stored in Properties["summary"] or
+			// Properties["description"] (both used depending on extractor).
+			description := e.Properties["summary"]
+			if description == "" {
+				description = e.Properties["description"]
+			}
+
+			// Response keys
+			var respKeys []string
+			if rk := e.Properties["response_keys"]; rk != "" {
+				for _, k := range strings.Split(rk, ",") {
+					k = strings.TrimSpace(k)
+					if k != "" {
+						respKeys = append(respKeys, k)
+					}
+				}
+			}
+
+			// Status codes
+			var statusCodes []int
+			if sc := e.Properties["status_codes"]; sc != "" {
+				for _, s := range strings.Split(sc, ",") {
+					if n, err := strconv.Atoi(strings.TrimSpace(s)); err == nil {
+						statusCodes = append(statusCodes, n)
+					}
+				}
+			}
+
+			eps = append(eps, rawEP{
+				method:        method,
+				path:          path,
+				handlerName:   e.Name,
+				framework:     e.Properties["framework"],
+				owningBackend: owningBackend,
+				description:   description,
+				responseKeys:  respKeys,
+				statusCodes:   statusCodes,
+				repo:          repo.Slug,
+			})
+		}
+	}
+
+	// -----------------------------------------------------------------------
+	// Build OpenAPI document
+	// -----------------------------------------------------------------------
+
+	doc := openAPIDoc{
+		OpenAPI: "3.0.3",
+		Info: openAPIInfo{
+			Title:       group + " API",
+			Description: fmt.Sprintf("Generated by archigraph from %d indexed HTTP endpoints.", len(eps)),
+			Version:     "0.0.0",
+		},
+		Paths: map[string]openAPIPathItem{},
+	}
+
+	// Collect unique tags (owning backends).
+	tagSet := map[string]bool{}
+
+	// We may encounter the same (path, method) multiple times across repos.
+	// Merge: first wins for summary/description; response codes are unioned.
+	type opKey struct{ path, method string }
+	opMap := map[opKey]*openAPIOperation{}
+	pathOrder := []string{}
+	pathSeen := map[string]bool{}
+
+	for _, ep := range eps {
+		if !pathSeen[ep.path] {
+			pathSeen[ep.path] = true
+			pathOrder = append(pathOrder, ep.path)
+		}
+
+		key := opKey{ep.path, ep.method}
+		if _, exists := opMap[key]; !exists {
+			// Extract path parameters.
+			var params []openAPIParameter
+			for _, m := range rePathParam.FindAllStringSubmatch(ep.path, -1) {
+				params = append(params, openAPIParameter{
+					Name:     m[1],
+					In:       "path",
+					Required: true,
+					Schema:   openAPISchema{Type: "string"},
+				})
+			}
+
+			op := &openAPIOperation{
+				OperationID: buildOperationID(ep.method, ep.path),
+				Summary:     ep.description,
+				Parameters:  params,
+				Responses:   map[string]openAPIResponse{},
+			}
+			if ep.owningBackend != "" {
+				op.Tags = []string{ep.owningBackend}
+				tagSet[ep.owningBackend] = true
+			}
+			opMap[key] = op
+		}
+
+		op := opMap[key]
+
+		// Merge status codes + response body schema.
+		for _, sc := range ep.statusCodes {
+			codeStr := strconv.Itoa(sc)
+			if _, ok := op.Responses[codeStr]; !ok {
+				resp := openAPIResponse{Description: httpStatusText(sc)}
+				if len(ep.responseKeys) > 0 && sc < 300 {
+					schema := openAPISchema{
+						Type:       "object",
+						Properties: map[string]openAPISchema{},
+					}
+					for _, k := range ep.responseKeys {
+						schema.Properties[k] = openAPISchema{Type: "string"}
+					}
+					resp.Content = map[string]openAPIMedia{
+						"application/json": {Schema: schema},
+					}
+				}
+				op.Responses[codeStr] = resp
+			}
+		}
+
+		// Guarantee at least a default response.
+		if len(op.Responses) == 0 {
+			op.Responses["200"] = openAPIResponse{Description: "OK"}
+		}
+	}
+
+	// Sort paths for deterministic output.
+	sort.Strings(pathOrder)
+
+	for _, path := range pathOrder {
+		item := openAPIPathItem{}
+
+		// Collect methods that apply to this path.
+		for key, op := range opMap {
+			if key.path != path {
+				continue
+			}
+			// Expand ANY into the common read+write set.
+			if key.method == "ANY" {
+				for _, m := range []string{"GET", "POST", "PUT", "PATCH", "DELETE"} {
+					cloned := cloneOperation(op)
+					item.setOperation(m, cloned)
+				}
+			} else {
+				item.setOperation(key.method, op)
+			}
+		}
+		doc.Paths[path] = item
+	}
+
+	// Build sorted tag list.
+	tagNames := make([]string, 0, len(tagSet))
+	for t := range tagSet {
+		tagNames = append(tagNames, t)
+	}
+	sort.Strings(tagNames)
+	for _, t := range tagNames {
+		doc.Tags = append(doc.Tags, openAPITag{Name: t})
+	}
+
+	// -----------------------------------------------------------------------
+	// Serialise and return.
+	// -----------------------------------------------------------------------
+
+	if format == "json" {
+		w.Header().Set("Content-Type", "application/json; charset=utf-8")
+		w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-openapi.json"`, group))
+		enc := json.NewEncoder(w)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(doc); err != nil {
+			// Header already sent — nothing we can do except log.
+			_ = err
+		}
+		return
+	}
+
+	// yaml (default)
+	w.Header().Set("Content-Type", "application/x-yaml; charset=utf-8")
+	w.Header().Set("Content-Disposition", fmt.Sprintf(`attachment; filename="%s-openapi.yaml"`, group))
+	if err := yaml.NewEncoder(w).Encode(doc); err != nil {
+		_ = err
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// reNonAlnum strips characters that are not letters or digits.
+var reNonAlnum = regexp.MustCompile(`[^A-Za-z0-9]`)
+
+// titleCase returns s with its first letter upper-cased (rest unchanged, ASCII).
+func titleCase(s string) string {
+	if s == "" {
+		return ""
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// buildOperationID derives a camelCase operationId from method + path.
+// E.g. "GET /api/users/{id}" → "getUsersById"
+func buildOperationID(method, path string) string {
+	parts := strings.Split(strings.TrimPrefix(path, "/"), "/")
+	var words []string
+	words = append(words, strings.ToLower(method))
+	for _, p := range parts {
+		if p == "" {
+			continue
+		}
+		// If the segment is purely a path parameter {name}, emit "By<Name>".
+		if m := rePathParam.FindStringSubmatch(p); m != nil && m[0] == p {
+			words = append(words, "By"+titleCase(m[1]))
+			continue
+		}
+		// Literal segment (or mixed): strip non-alnum and title-case the
+		// lowercased result so we get consistent camelCase.
+		// Path params should not appear in literal segments in valid OpenAPI
+		// paths, but we strip braces defensively.
+		clean := reNonAlnum.ReplaceAllString(p, "")
+		if clean != "" {
+			words = append(words, titleCase(strings.ToLower(clean)))
+		}
+	}
+	return strings.Join(words, "")
+}
+
+// cloneOperation shallow-copies an operation so that the ANY expansion
+// produces independent pointers (editing one verb won't mutate others).
+func cloneOperation(op *openAPIOperation) *openAPIOperation {
+	if op == nil {
+		return nil
+	}
+	cloned := *op
+	return &cloned
+}
+
+// httpStatusText maps common numeric status codes to short descriptions.
+// Unknown codes fall back to "HTTP <code>".
+func httpStatusText(code int) string {
+	texts := map[int]string{
+		200: "OK",
+		201: "Created",
+		204: "No Content",
+		301: "Moved Permanently",
+		302: "Found",
+		304: "Not Modified",
+		400: "Bad Request",
+		401: "Unauthorized",
+		403: "Forbidden",
+		404: "Not Found",
+		405: "Method Not Allowed",
+		409: "Conflict",
+		422: "Unprocessable Entity",
+		429: "Too Many Requests",
+		500: "Internal Server Error",
+		502: "Bad Gateway",
+		503: "Service Unavailable",
+	}
+	if t, ok := texts[code]; ok {
+		return t
+	}
+	return fmt.Sprintf("HTTP %d", code)
+}

--- a/internal/dashboard/handlers_export_openapi_test.go
+++ b/internal/dashboard/handlers_export_openapi_test.go
@@ -1,0 +1,451 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests — helpers
+// ---------------------------------------------------------------------------
+
+func TestBuildOperationID(t *testing.T) {
+	cases := []struct {
+		method string
+		path   string
+		want   string
+	}{
+		{"GET", "/users", "getUsers"},
+		{"POST", "/api/users", "postApiUsers"},
+		{"DELETE", "/api/users/{id}", "deleteApiUsersById"},
+		{"GET", "/", "get"},
+		{"GET", "/health", "getHealth"},
+	}
+	for _, tc := range cases {
+		got := buildOperationID(tc.method, tc.path)
+		if got != tc.want {
+			t.Errorf("buildOperationID(%q, %q) = %q, want %q", tc.method, tc.path, got, tc.want)
+		}
+	}
+}
+
+func TestHttpStatusText(t *testing.T) {
+	if httpStatusText(200) != "OK" {
+		t.Error("200 should map to OK")
+	}
+	if httpStatusText(404) != "Not Found" {
+		t.Error("404 should map to Not Found")
+	}
+	if httpStatusText(999) != "HTTP 999" {
+		t.Errorf("unknown code should return 'HTTP 999', got %q", httpStatusText(999))
+	}
+}
+
+func TestOpenAPIPathItem_setOperation(t *testing.T) {
+	item := &openAPIPathItem{}
+	op := &openAPIOperation{OperationID: "getTest"}
+	item.setOperation("GET", op)
+	if item.Get != op {
+		t.Error("setOperation GET should set Get field")
+	}
+	item.setOperation("POST", op)
+	if item.Post != op {
+		t.Error("setOperation POST should set Post field")
+	}
+	item.setOperation("unknown", op)
+	// unknown method silently ignored — no panic
+}
+
+func TestCloneOperation(t *testing.T) {
+	op := &openAPIOperation{OperationID: "original", Summary: "test"}
+	cloned := cloneOperation(op)
+	if cloned == op {
+		t.Error("cloneOperation should return a different pointer")
+	}
+	if cloned.OperationID != op.OperationID {
+		t.Error("cloned operation should have the same OperationID")
+	}
+	cloned.OperationID = "mutated"
+	if op.OperationID != "original" {
+		t.Error("mutating clone should not affect original")
+	}
+}
+
+func TestCloneOperation_nil(t *testing.T) {
+	if cloneOperation(nil) != nil {
+		t.Error("cloneOperation(nil) should return nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler tests
+// ---------------------------------------------------------------------------
+
+// openAPITestGroup wires a DashGroup with HTTP endpoint entities.
+func openAPITestGroup(name string, entities []graph.Entity) *DashGroup {
+	return &DashGroup{
+		Name: name,
+		Repos: map[string]*DashRepo{
+			"repo1": {
+				Slug: "repo1",
+				Doc: &graph.Document{
+					Entities: entities,
+				},
+			},
+		},
+	}
+}
+
+// newOpenAPITestServer creates a Server and injects a named group.
+func newOpenAPITestServer(t *testing.T, groupName string, entities []graph.Entity) *Server {
+	t.Helper()
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	grp := openAPITestGroup(groupName, entities)
+	srv.graphs.mu.Lock()
+	srv.graphs.entries[groupName] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	return srv
+}
+
+// sampleEndpointEntities returns a set of graph.Entity records that look like
+// real http_endpoint_definition extractions.
+func sampleEndpointEntities() []graph.Entity {
+	return []graph.Entity{
+		{
+			ID:   "ep1",
+			Name: "GET /api/users",
+			Kind: "http_endpoint_definition",
+			Properties: map[string]string{
+				"method":         "GET",
+				"path":           "/api/users",
+				"framework":      "gin",
+				"owning_backend": "user-service",
+				"status_codes":   "200,404",
+				"response_keys":  "id,name,email",
+			},
+		},
+		{
+			ID:   "ep2",
+			Name: "POST /api/users",
+			Kind: "http_endpoint_definition",
+			Properties: map[string]string{
+				"method":         "POST",
+				"path":           "/api/users",
+				"framework":      "gin",
+				"owning_backend": "user-service",
+				"status_codes":   "201,400",
+			},
+		},
+		{
+			ID:   "ep3",
+			Name: "GET /api/users/{id}",
+			Kind: "http_endpoint_definition",
+			Properties: map[string]string{
+				"method":         "GET",
+				"path":           "/api/users/{id}",
+				"framework":      "gin",
+				"owning_backend": "user-service",
+				"status_codes":   "200,404",
+			},
+		},
+		{
+			// Should be excluded — call-site synthetic.
+			ID:   "call1",
+			Name: "fetch /api/users",
+			Kind: "http_endpoint_call",
+			Properties: map[string]string{
+				"path":   "/api/users",
+				"method": "GET",
+			},
+		},
+	}
+}
+
+func TestHandleExportOpenAPI_groupNotFound(t *testing.T) {
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/nogroup/openapi", nil)
+	req.SetPathValue("group", "nogroup")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404 for unknown group, got %d", w.Code)
+	}
+}
+
+func TestHandleExportOpenAPI_missingGroup(t *testing.T) {
+	srv, _ := NewServer(DefaultConfig(), newFakeStore())
+	req := httptest.NewRequest(http.MethodGet, "/api/export//openapi", nil)
+	req.SetPathValue("group", "")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for missing group, got %d", w.Code)
+	}
+}
+
+func TestHandleExportOpenAPI_invalidFormat(t *testing.T) {
+	srv := newOpenAPITestServer(t, "g", sampleEndpointEntities())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi?format=xml", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for format=xml, got %d", w.Code)
+	}
+}
+
+func TestHandleExportOpenAPI_yaml(t *testing.T) {
+	srv := newOpenAPITestServer(t, "mygroup", sampleEndpointEntities())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/mygroup/openapi?format=yaml", nil)
+	req.SetPathValue("group", "mygroup")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "yaml") {
+		t.Errorf("expected yaml content-type, got %q", ct)
+	}
+
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "openapi.yaml") {
+		t.Errorf("expected Content-Disposition with openapi.yaml, got %q", cd)
+	}
+
+	body := w.Body.String()
+	// Must start with openapi version field.
+	if !strings.Contains(body, "openapi: 3.0.3") {
+		t.Errorf("yaml body should contain 'openapi: 3.0.3'; got:\n%s", body)
+	}
+	// Should contain known paths.
+	if !strings.Contains(body, "/api/users") {
+		t.Errorf("yaml body should contain /api/users path; got:\n%s", body)
+	}
+	// Path parameters.
+	if !strings.Contains(body, "id") {
+		t.Errorf("yaml body should contain param 'id'; got:\n%s", body)
+	}
+	// Tag from owning_backend.
+	if !strings.Contains(body, "user-service") {
+		t.Errorf("yaml body should contain tag 'user-service'; got:\n%s", body)
+	}
+	// Call-site entity should NOT appear as a path.
+	if strings.Contains(body, "http_endpoint_call") {
+		t.Error("yaml body must not include call-site entities")
+	}
+}
+
+func TestHandleExportOpenAPI_json(t *testing.T) {
+	srv := newOpenAPITestServer(t, "mygroup", sampleEndpointEntities())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/mygroup/openapi?format=json", nil)
+	req.SetPathValue("group", "mygroup")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "json") {
+		t.Errorf("expected json content-type, got %q", ct)
+	}
+
+	cd := w.Header().Get("Content-Disposition")
+	if !strings.Contains(cd, "openapi.json") {
+		t.Errorf("expected Content-Disposition with openapi.json, got %q", cd)
+	}
+
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("response is not valid JSON: %v\nbody: %s", err, w.Body.String())
+	}
+
+	if doc.OpenAPI != "3.0.3" {
+		t.Errorf("openapi version should be 3.0.3, got %q", doc.OpenAPI)
+	}
+	if len(doc.Paths) == 0 {
+		t.Error("expected at least one path in the spec")
+	}
+
+	// /api/users/{id} must have a path parameter named "id".
+	pathItem, ok := doc.Paths["/api/users/{id}"]
+	if !ok {
+		t.Fatal("expected /api/users/{id} in paths")
+	}
+	if pathItem.Get == nil {
+		t.Fatal("expected GET operation on /api/users/{id}")
+	}
+	foundIDParam := false
+	for _, p := range pathItem.Get.Parameters {
+		if p.Name == "id" && p.In == "path" && p.Required {
+			foundIDParam = true
+			break
+		}
+	}
+	if !foundIDParam {
+		t.Error("expected path parameter 'id' (in: path, required: true)")
+	}
+
+	// /api/users POST should exist.
+	usersItem, ok := doc.Paths["/api/users"]
+	if !ok {
+		t.Fatal("expected /api/users in paths")
+	}
+	if usersItem.Post == nil {
+		t.Error("expected POST operation on /api/users")
+	}
+	if usersItem.Get == nil {
+		t.Error("expected GET operation on /api/users")
+	}
+
+	// Tags should include user-service.
+	foundTag := false
+	for _, tag := range doc.Tags {
+		if tag.Name == "user-service" {
+			foundTag = true
+			break
+		}
+	}
+	if !foundTag {
+		t.Error("expected tag 'user-service' in the spec")
+	}
+}
+
+func TestHandleExportOpenAPI_defaultFormatIsYAML(t *testing.T) {
+	srv := newOpenAPITestServer(t, "g", sampleEndpointEntities())
+	req := httptest.NewRequest(http.MethodGet, "/api/export/g/openapi", nil)
+	req.SetPathValue("group", "g")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d", w.Code)
+	}
+	ct := w.Header().Get("Content-Type")
+	if !strings.Contains(ct, "yaml") {
+		t.Errorf("default format should be yaml, got content-type %q", ct)
+	}
+}
+
+func TestHandleExportOpenAPI_emptyGroup(t *testing.T) {
+	// Group exists but has no endpoints — should still return a valid (empty paths) spec.
+	srv := newOpenAPITestServer(t, "empty", []graph.Entity{})
+	req := httptest.NewRequest(http.MethodGet, "/api/export/empty/openapi?format=json", nil)
+	req.SetPathValue("group", "empty")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("response is not valid JSON: %v", err)
+	}
+	if doc.OpenAPI != "3.0.3" {
+		t.Errorf("openapi version should be 3.0.3, got %q", doc.OpenAPI)
+	}
+}
+
+func TestHandleExportOpenAPI_responseKeys(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "ep1",
+			Name: "GET /items",
+			Kind: "http_endpoint_definition",
+			Properties: map[string]string{
+				"method":        "GET",
+				"path":          "/items",
+				"status_codes":  "200",
+				"response_keys": "id,name,price",
+			},
+		},
+	}
+	srv := newOpenAPITestServer(t, "shop", entities)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/shop/openapi?format=json", nil)
+	req.SetPathValue("group", "shop")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	item, ok := doc.Paths["/items"]
+	if !ok {
+		t.Fatal("expected /items path")
+	}
+	if item.Get == nil {
+		t.Fatal("expected GET on /items")
+	}
+	resp200, ok := item.Get.Responses["200"]
+	if !ok {
+		t.Fatal("expected 200 response on GET /items")
+	}
+	media, ok := resp200.Content["application/json"]
+	if !ok {
+		t.Fatal("expected application/json media type in 200 response")
+	}
+	for _, field := range []string{"id", "name", "price"} {
+		if _, hasField := media.Schema.Properties[field]; !hasField {
+			t.Errorf("expected response schema property %q", field)
+		}
+	}
+}
+
+func TestHandleExportOpenAPI_anyVerbExpanded(t *testing.T) {
+	entities := []graph.Entity{
+		{
+			ID:   "ep1",
+			Name: "ANY /catch-all",
+			Kind: "http_endpoint_definition",
+			Properties: map[string]string{
+				"path": "/catch-all",
+				// method deliberately empty → resolves to "ANY"
+			},
+		},
+	}
+	srv := newOpenAPITestServer(t, "any-test", entities)
+	req := httptest.NewRequest(http.MethodGet, "/api/export/any-test/openapi?format=json", nil)
+	req.SetPathValue("group", "any-test")
+	w := httptest.NewRecorder()
+	srv.handleExportOpenAPI(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var doc openAPIDoc
+	if err := json.Unmarshal(w.Body.Bytes(), &doc); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	item, ok := doc.Paths["/catch-all"]
+	if !ok {
+		t.Fatal("expected /catch-all path")
+	}
+	// ANY → GET, POST, PUT, PATCH, DELETE all present.
+	if item.Get == nil {
+		t.Error("ANY should expand to GET")
+	}
+	if item.Post == nil {
+		t.Error("ANY should expand to POST")
+	}
+	if item.Delete == nil {
+		t.Error("ANY should expand to DELETE")
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -441,6 +441,11 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/perf/budgets", s.handlePerfBudgets)
 	mux.HandleFunc("POST /api/perf/record", s.handlePerfRecord)
 
+	// OpenAPI 3.0 export — HTTP endpoints → openapi.yaml / openapi.json (#1340)
+	// The literal segment "openapi" is more specific than the DSL wildcard
+	// {entity_id}/{format}, so Go 1.22+ ServeMux routes here first.
+	mux.HandleFunc("GET /api/export/{group}/openapi", s.handleExportOpenAPI)
+
 	// DSL export — Graph subgraph → Mermaid / Graphviz / PlantUML / D2 (#1318)
 	mux.HandleFunc("GET /api/export/{group}/{entity_id}/{format}", s.handleExportDSL)
 


### PR DESCRIPTION
## Summary

Implements `GET /api/export/{group}/openapi?format=yaml|json` — reads all `http_endpoint_definition` entities in a group and emits a standards-compliant OpenAPI 3.0 document.

**What's included:**
- `internal/dashboard/handlers_export_openapi.go` — full OpenAPI 3.0 builder: paths, methods, path parameters (extracted from `{param}` placeholders), response shapes (status codes + field keys from enrichment), AI summaries, and owning-backend tags
- `internal/dashboard/handlers_export_openapi_test.go` — 14 tests covering: YAML/JSON output, path parameter extraction, `ANY`-verb expansion, response key schema, empty group, error cases
- `internal/dashboard/server.go` — route `GET /api/export/{group}/openapi` registered before the DSL wildcard
- `dashboard/src/routes/paths.tsx` — `FileDown OpenAPI` download button in the Paths surface header (visible when endpoints > 0)

**Go beyond done:**
- ReDoc/Swagger UI compatibility: output is valid OpenAPI 3.0.3 with explicit `operationId` per operation, proper `parameters[].in: path`, and `responses` on every operation
- `ANY` HTTP method (DRF/catch-all routers) expands to GET+POST+PUT+PATCH+DELETE
- Response body schema emitted when `response_keys` are present (from enrichment pass)
- Tags derived from `owning_backend` property (aligned with Paths surface grouping)
- Deterministic output: paths and tags are sorted before serialisation
- Backward-compatible: accepts `http_endpoint`, `http_endpoint_definition`, `Endpoint`, `Route` kinds

## Closes / Refs
- Closes #1340

## Testing
- [x] All tests pass: `go test ./internal/dashboard/ -run TestHandleExportOpenAPI` → 14/14 PASS
- [x] `go build ./internal/dashboard/` clean
- [x] TypeScript `src/` changes are type-safe (FileDown is a valid lucide-react icon)
- [x] Output structure matches OpenAPI 3.0.3 schema (`openapi: 3.0.3`, `info`, `paths`, `tags`)

## Notes

The route literal `/api/export/{group}/openapi` is more specific than the existing DSL wildcard `/api/export/{group}/{entity_id}/{format}` — Go 1.22+ ServeMux routes by specificity so no ordering dependency, but it is also registered first for clarity.

'Generate client SDK' button is a natural follow-on (stub deferred per spec).