### PR TITLE
feat(quality): architectural fitness functions with CI gates (#1345)

### DIFF
--- a/cmd/archigraph/quality.go
+++ b/cmd/archigraph/quality.go
@@ -40,6 +40,10 @@ func runQuality(argv []string) error {
 	if len(argv) >= 1 && argv[0] == "bug-rate-corpus" {
 		return runBugRateCorpus(argv[1:])
 	}
+	// `quality check [--strict] <group|repo-path>` — architectural fitness functions (#1345).
+	if len(argv) >= 1 && argv[0] == "check" {
+		return runQualityCheck(argv[1:])
+	}
 	fs := flag.NewFlagSet("quality", flag.ContinueOnError)
 	jsonOut := fs.String("json", "", "write JSON report to this path (default: stderr-only human summary)")
 	keepGraph := fs.Bool("keep-graph", false, "preserve the temp graph.json (path printed on stderr)")

--- a/cmd/archigraph/quality_fitness.go
+++ b/cmd/archigraph/quality_fitness.go
@@ -1,0 +1,234 @@
+package main
+
+// quality_fitness.go — `archigraph quality check [--strict] [--json] <group-or-repo-path>`
+//
+// Evaluates the architectural fitness rules defined in
+// <repo>/.archigraph/fitness.yaml against the live graph for the given group
+// (or a single repo path) and prints a human-readable violation report.
+//
+// Exit codes:
+//
+//	0  all rules passed (or only warn/info violations found without --strict)
+//	1  internal error
+//	2  at least one error-severity rule violated
+//
+// With --strict, any violation (including warn/info) causes exit 2.
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/quality/fitness"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// runQualityCheck is the entry point for `archigraph quality check ...`.
+func runQualityCheck(argv []string) error {
+	fs := flag.NewFlagSet("quality check", flag.ContinueOnError)
+	strict := fs.Bool("strict", false, "exit non-zero on any violation (including warn/info)")
+	jsonOut := fs.Bool("json", false, "emit JSON report to stdout instead of human text")
+	outPath := fs.String("output", "", "write output to this file (default: stdout)")
+
+	if err := fs.Parse(argv); err != nil {
+		return err
+	}
+
+	// Collect graph documents to evaluate.
+	type repoDoc struct {
+		slug    string
+		repoDir string
+		doc     *graph.Document
+	}
+	var repoDocs []repoDoc
+
+	if fs.NArg() == 0 {
+		return fmt.Errorf("usage: archigraph quality check [--strict] [--json] <group-name|repo-path>")
+	}
+
+	target := fs.Arg(0)
+
+	// Try to resolve as a group name first.
+	groups, _ := registry.Groups()
+	var resolvedGroup string
+	for _, g := range groups {
+		if g.Name == target {
+			resolvedGroup = g.Name
+			break
+		}
+	}
+
+	if resolvedGroup != "" {
+		// Load every repo in the group.
+		for _, g := range groups {
+			if g.Name != resolvedGroup {
+				continue
+			}
+			cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+			if err != nil {
+				return fmt.Errorf("load group config: %w", err)
+			}
+			for _, r := range cfg.Repos {
+				stateDir := filepath.Join(r.Path, ".archigraph")
+				doc, err := graph.LoadGraphFromDir(stateDir)
+				if err != nil {
+					fmt.Fprintf(os.Stderr, "quality check: skip %s (%v)\n", r.Slug, err)
+					continue
+				}
+				repoDocs = append(repoDocs, repoDoc{slug: r.Slug, repoDir: r.Path, doc: doc})
+			}
+		}
+		if len(repoDocs) == 0 {
+			return fmt.Errorf("group %q has no indexed repos", target)
+		}
+	} else {
+		// Treat as a direct repo path.
+		absPath, err := filepath.Abs(target)
+		if err != nil {
+			return fmt.Errorf("resolve path: %w", err)
+		}
+		stateDir := filepath.Join(absPath, ".archigraph")
+		doc, err := graph.LoadGraphFromDir(stateDir)
+		if err != nil {
+			return fmt.Errorf("load graph from %s: %w", stateDir, err)
+		}
+		repoDocs = append(repoDocs, repoDoc{slug: filepath.Base(absPath), repoDir: absPath, doc: doc})
+	}
+
+	// Evaluate fitness rules for each repo document.
+	type repoResult struct {
+		Slug   string              `json:"slug"`
+		Result *fitness.EvalResult `json:"result"`
+	}
+	var results []repoResult
+	totalErrors, totalWarns, totalInfos := 0, 0, 0
+
+	for _, rd := range repoDocs {
+		stateDir := filepath.Join(rd.repoDir, ".archigraph")
+		fitCfg, err := fitness.LoadConfig(stateDir)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "quality check: %s: %v (skipping)\n", rd.slug, err)
+			continue
+		}
+		if len(fitCfg.Rules) == 0 && len(repoDocs) > 1 {
+			// In multi-repo mode, skip repos without a fitness config silently.
+			continue
+		}
+		evalResult := fitness.Evaluate(fitCfg, rd.doc)
+		results = append(results, repoResult{Slug: rd.slug, Result: evalResult})
+		totalErrors += evalResult.ErrorCount
+		totalWarns += evalResult.WarnCount
+		totalInfos += evalResult.InfoCount
+	}
+
+	if len(results) == 0 {
+		if *jsonOut {
+			fmt.Println(`{"repos":[],"message":"no fitness.yaml found — nothing to check"}`)
+			return nil
+		}
+		fmt.Fprintln(os.Stderr, "quality check: no .archigraph/fitness.yaml found — nothing to check")
+		fmt.Fprintln(os.Stderr, "  Tip: create .archigraph/fitness.yaml in any indexed repo.")
+		return nil
+	}
+
+	// Output.
+	var out *os.File = os.Stdout
+	if *outPath != "" {
+		f, err := os.Create(*outPath)
+		if err != nil {
+			return fmt.Errorf("create output file: %w", err)
+		}
+		defer f.Close()
+		out = f
+	}
+
+	if *jsonOut {
+		type jsonRoot struct {
+			Repos       []repoResult `json:"repos"`
+			TotalErrors int          `json:"total_errors"`
+			TotalWarns  int          `json:"total_warns"`
+			TotalInfos  int          `json:"total_infos"`
+		}
+		enc := json.NewEncoder(out)
+		enc.SetIndent("", "  ")
+		if encErr := enc.Encode(jsonRoot{
+			Repos:       results,
+			TotalErrors: totalErrors,
+			TotalWarns:  totalWarns,
+			TotalInfos:  totalInfos,
+		}); encErr != nil {
+			return encErr
+		}
+	} else {
+		for _, rr := range results {
+			writeCheckHuman(out, rr.Slug, rr.Result)
+		}
+		// Summary line.
+		fmt.Fprintf(out, "\nsummary: %d error(s), %d warn(s), %d info(s)\n", totalErrors, totalWarns, totalInfos)
+		if totalErrors == 0 && totalWarns == 0 {
+			fmt.Fprintln(out, "all fitness rules passed ✓")
+		}
+
+		// Print suggested rules (for repos with no existing rules).
+		for _, rr := range results {
+			if len(rr.Result.SuggestedRules) > 0 && rr.Result.TotalRules == 0 {
+				fmt.Fprintf(out, "\nsuggested rules for %s (add to .archigraph/fitness.yaml):\n", rr.Slug)
+				for _, s := range rr.Result.SuggestedRules {
+					fmt.Fprintf(out, "  # %s\n  # %s\n  %s\n\n", s.Name, s.Reason, indentYAML(s.YAML, "  "))
+				}
+			}
+		}
+	}
+
+	// Exit code.
+	if totalErrors > 0 {
+		os.Exit(2)
+	}
+	if *strict && (totalWarns > 0 || totalInfos > 0) {
+		os.Exit(2)
+	}
+	return nil
+}
+
+func writeCheckHuman(out *os.File, slug string, r *fitness.EvalResult) {
+	fmt.Fprintf(out, "repo: %s  (%d rules, %d passed, %d failed)\n", slug, r.TotalRules, r.PassedRules, r.FailedRules)
+	for _, rr := range r.Results {
+		if rr.Passed {
+			fmt.Fprintf(out, "  [PASS] %s\n", rr.Rule.Name)
+			continue
+		}
+		fmt.Fprintf(out, "  [FAIL] %s\n", rr.Rule.Name)
+		for _, v := range rr.Violations {
+			icon := severityIcon(v.Severity)
+			fmt.Fprintf(out, "         %s %s\n", icon, v.Message)
+			if v.FromEntity != nil && v.FromEntity.SourceFile != "" {
+				fmt.Fprintf(out, "              at %s\n", v.FromEntity.SourceFile)
+			}
+		}
+	}
+}
+
+func severityIcon(sev string) string {
+	switch sev {
+	case "warn":
+		return "WARN"
+	case "info":
+		return "INFO"
+	default:
+		return "ERR "
+	}
+}
+
+func indentYAML(yaml, prefix string) string {
+	lines := strings.Split(yaml, "\n")
+	for i, l := range lines {
+		if i > 0 {
+			lines[i] = prefix + l
+		}
+	}
+	return strings.Join(lines, "\n")
+}

--- a/internal/cli/root.go
+++ b/internal/cli/root.go
@@ -154,6 +154,7 @@ Quality:
   quality <fixture-dir>                       Measure extraction recall vs a golden fixture
   quality audit-orphans [--corpus] <path>     Audit orphan rate + edge hygiene; emits md or JSON
   quality bug-rate-corpus [flags] <dir>       Composite health score across a corpus of indexed groups
+  quality check [--strict] <group|path>       Evaluate architectural fitness rules (.archigraph/fitness.yaml)
 
 Agent-learned patterns (ADR-0018):
   patterns list [--needs-attention]           Show patterns table (rejected/low-conf/stale with --needs-attention)

--- a/internal/dashboard/handlers_fitness.go
+++ b/internal/dashboard/handlers_fitness.go
@@ -1,0 +1,143 @@
+package dashboard
+
+// handlers_fitness.go — Architectural fitness functions HTTP surface (#1345).
+//
+// Route:
+//
+//	GET /api/fitness/{group}
+//	    Evaluates .archigraph/fitness.yaml rules for every repo in the group
+//	    and returns per-repo results plus aggregate violation counts.
+//
+// Query parameters:
+//
+//	repo   — (optional) restrict evaluation to a single slug within the group
+//
+// Response shape: FitnessGroupReport (JSON)
+
+import (
+	"fmt"
+	"net/http"
+	"path/filepath"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/quality/fitness"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// FitnessRepoResult is the per-repo evaluation result returned by the API.
+type FitnessRepoResult struct {
+	Slug        string              `json:"slug"`
+	Path        string              `json:"path"`
+	HasConfig   bool                `json:"has_config"`
+	TotalRules  int                 `json:"total_rules"`
+	PassedRules int                 `json:"passed_rules"`
+	FailedRules int                 `json:"failed_rules"`
+	ErrorCount  int                 `json:"error_count"`
+	WarnCount   int                 `json:"warn_count"`
+	InfoCount   int                 `json:"info_count"`
+	Results     []fitness.RuleResult `json:"results"`
+	Suggested   []fitness.SuggestedRule `json:"suggested_rules,omitempty"`
+}
+
+// FitnessGroupReport is the wire shape for GET /api/fitness/{group}.
+type FitnessGroupReport struct {
+	Group       string               `json:"group"`
+	TotalErrors int                  `json:"total_errors"`
+	TotalWarns  int                  `json:"total_warns"`
+	TotalInfos  int                  `json:"total_infos"`
+	Repos       []FitnessRepoResult  `json:"repos"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Handler
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleFitness(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	repoPaths, err := repoPathsForGroup(groupName)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q: %v", groupName, err))
+		return
+	}
+	if len(repoPaths) == 0 {
+		writeErr(w, http.StatusNotFound, fmt.Sprintf("group %q has no repos", groupName))
+		return
+	}
+
+	// Optional single-repo filter.
+	filterSlug := r.URL.Query().Get("repo")
+
+	report := FitnessGroupReport{Group: groupName}
+
+	for _, rp := range repoPaths {
+		if filterSlug != "" && rp.Slug != filterSlug {
+			continue
+		}
+
+		stateDir := filepath.Join(rp.Path, ".archigraph")
+
+		// Load fitness config (empty config if file absent).
+		fitCfg, cfgErr := fitness.LoadConfig(stateDir)
+		if cfgErr != nil {
+			// Config parse error: surface as a single error finding.
+			report.Repos = append(report.Repos, FitnessRepoResult{
+				Slug:      rp.Slug,
+				Path:      rp.Path,
+				HasConfig: true,
+				Results: []fitness.RuleResult{{
+					Passed: false,
+					Violations: []fitness.Violation{{
+						RuleName: "__config_parse_error__",
+						Severity: "error",
+						Kind:     "parse",
+						Message:  cfgErr.Error(),
+					}},
+				}},
+				ErrorCount: 1,
+				FailedRules: 1,
+			})
+			report.TotalErrors++
+			continue
+		}
+
+		hasConfig := len(fitCfg.Rules) > 0
+
+		// Load the graph document.
+		doc, docErr := graph.LoadGraphFromDir(stateDir)
+		if docErr != nil {
+			// Graph not indexed yet — skip silently (consistent with other handlers).
+			continue
+		}
+
+		evalResult := fitness.Evaluate(fitCfg, doc)
+
+		repoResult := FitnessRepoResult{
+			Slug:        rp.Slug,
+			Path:        rp.Path,
+			HasConfig:   hasConfig,
+			TotalRules:  evalResult.TotalRules,
+			PassedRules: evalResult.PassedRules,
+			FailedRules: evalResult.FailedRules,
+			ErrorCount:  evalResult.ErrorCount,
+			WarnCount:   evalResult.WarnCount,
+			InfoCount:   evalResult.InfoCount,
+			Results:     evalResult.Results,
+			Suggested:   evalResult.SuggestedRules,
+		}
+
+		report.Repos = append(report.Repos, repoResult)
+		report.TotalErrors += evalResult.ErrorCount
+		report.TotalWarns += evalResult.WarnCount
+		report.TotalInfos += evalResult.InfoCount
+	}
+
+	writeJSON(w, http.StatusOK, report)
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -448,6 +448,9 @@ func (s *Server) routes() http.Handler {
 	// GET /api/dependencies/{group}  — declared + used/unused/phantom classification
 	mux.HandleFunc("GET /api/dependencies/{group}", s.handleDependencies)
 
+	// #1345: Architectural fitness functions — user-defined rules with CI gates.
+	mux.HandleFunc("GET /api/fitness/{group}", s.handleFitness)
+
 	return s.withAuth(withGzip(mux))
 }
 

--- a/internal/quality/fitness/rule.go
+++ b/internal/quality/fitness/rule.go
@@ -1,0 +1,637 @@
+// Package fitness implements architectural fitness functions: user-defined
+// rules loaded from .archigraph/fitness.yaml that are evaluated against a
+// live graph and can gate CI builds.
+//
+// # Rule grammar
+//
+// Three rule kinds are supported:
+//
+//  1. forbid — a directed-edge pattern that must NOT appear:
+//     forbid: 'SourceKind -> TargetKind'
+//     forbid: 'SourceKind -[EDGE_KIND]-> TargetKind'
+//
+//  2. require — a structural invariant that must hold for every entity of
+//     a given kind:
+//     require: 'Kind has-no-outbound-IMPORTS'
+//     require: 'Kind has-no-inbound-CALLS'
+//
+//  3. threshold — a numeric metric assertion:
+//     threshold: 'import_cycles.max_size <= 3'
+//     threshold: 'orphan_rate_pct < 20'
+//     threshold: 'import_cycles.count == 0'
+//
+// # Severity
+//
+// Every rule carries an optional severity (error | warn | info). Default is
+// "error". CI uses --strict to exit non-zero on any violation.
+//
+// # Exception list
+//
+// A rule may list entity IDs or kind:name patterns in an "except" list. Any
+// entity matching an exception entry is excluded from that rule's evaluation.
+package fitness
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Config types (parsed from .archigraph/fitness.yaml)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Config is the root structure of .archigraph/fitness.yaml.
+type Config struct {
+	Rules []RuleConfig `yaml:"rules"`
+}
+
+// RuleConfig is a single rule definition as it appears in YAML.
+type RuleConfig struct {
+	// Name is a human-readable label shown in violation messages.
+	Name string `yaml:"name"`
+
+	// Forbid is a directed-edge pattern that must not exist in the graph.
+	// Format: 'SourceKind -> TargetKind'  or
+	//         'SourceKind -[EDGE_KIND]-> TargetKind'
+	Forbid string `yaml:"forbid,omitempty"`
+
+	// Require is a structural invariant that every entity of a given kind
+	// must satisfy.
+	// Format: 'Kind has-no-outbound-EDGE_KIND'  or
+	//         'Kind has-no-inbound-EDGE_KIND'
+	Require string `yaml:"require,omitempty"`
+
+	// Threshold is a metric-comparison assertion.
+	// Format: 'metric op value'  (e.g. 'import_cycles.max_size <= 3')
+	Threshold string `yaml:"threshold,omitempty"`
+
+	// Severity is the impact level of a violation: error | warn | info.
+	// Defaults to "error".
+	Severity string `yaml:"severity,omitempty"`
+
+	// Except is a list of patterns exempted from this rule.
+	// Each entry may be a bare entity ID or 'kind:name' glob.
+	Except []string `yaml:"except,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Public result types
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Violation is a single rule breach.
+type Violation struct {
+	// RuleName is the human-readable name of the violated rule.
+	RuleName string `json:"rule_name"`
+	// Severity is "error" | "warn" | "info".
+	Severity string `json:"severity"`
+	// Kind is "forbid" | "require" | "threshold".
+	Kind string `json:"kind"`
+	// Message describes the specific violation instance.
+	Message string `json:"message"`
+	// FromEntity / ToEntity are populated for edge-level violations.
+	FromEntity *EntityRef `json:"from_entity,omitempty"`
+	ToEntity   *EntityRef `json:"to_entity,omitempty"`
+}
+
+// EntityRef is a lightweight entity descriptor used inside Violation.
+type EntityRef struct {
+	ID         string `json:"id"`
+	Name       string `json:"name"`
+	Kind       string `json:"kind"`
+	SourceFile string `json:"source_file,omitempty"`
+}
+
+// RuleResult is the evaluation outcome for a single rule.
+type RuleResult struct {
+	Rule       RuleConfig  `json:"rule"`
+	Violations []Violation `json:"violations"`
+	// Passed is true when len(Violations) == 0.
+	Passed bool `json:"passed"`
+}
+
+// EvalResult holds the full evaluation of a fitness config against one graph.
+type EvalResult struct {
+	// TotalRules is the number of rules evaluated.
+	TotalRules int `json:"total_rules"`
+	// PassedRules / FailedRules are counts.
+	PassedRules  int `json:"passed_rules"`
+	FailedRules  int `json:"failed_rules"`
+	// ErrorCount / WarnCount / InfoCount count violations by severity.
+	ErrorCount int `json:"error_count"`
+	WarnCount  int `json:"warn_count"`
+	InfoCount  int `json:"info_count"`
+	// Results contains one entry per rule.
+	Results []RuleResult `json:"results"`
+	// SuggestedRules contains auto-detected rules the user might want to adopt.
+	SuggestedRules []SuggestedRule `json:"suggested_rules,omitempty"`
+}
+
+// SuggestedRule is an auto-detected architectural pattern the user might
+// want to codify as an explicit fitness rule.
+type SuggestedRule struct {
+	// Name is a short description of the suggested rule.
+	Name string `json:"name"`
+	// YAML is the ready-to-paste YAML snippet.
+	YAML string `json:"yaml"`
+	// Reason explains why the pattern was detected.
+	Reason string `json:"reason"`
+}
+
+// HasFailures returns true when any error-severity rule failed.
+func (r *EvalResult) HasFailures() bool {
+	return r.ErrorCount > 0
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Loading
+// ─────────────────────────────────────────────────────────────────────────────
+
+// DefaultConfigName is the conventional config file name.
+const DefaultConfigName = "fitness.yaml"
+
+// LoadConfig reads .archigraph/fitness.yaml from stateDir (the
+// <repo>/.archigraph directory) and returns the parsed Config.
+// Returns an empty Config (no rules) when the file does not exist.
+func LoadConfig(stateDir string) (*Config, error) {
+	path := stateDir + "/" + DefaultConfigName
+	raw, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &Config{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("fitness: read %s: %w", path, err)
+	}
+	var cfg Config
+	if err := yaml.Unmarshal(raw, &cfg); err != nil {
+		return nil, fmt.Errorf("fitness: parse %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+// Evaluate runs all rules in cfg against doc and returns an EvalResult.
+// It never returns an error; parse/eval problems are surfaced as violations
+// with severity "error".
+func Evaluate(cfg *Config, doc *graph.Document) *EvalResult {
+	res := &EvalResult{TotalRules: len(cfg.Rules)}
+
+	// Build fast-lookup indexes.
+	entityByID := make(map[string]*graph.Entity, len(doc.Entities))
+	for i := range doc.Entities {
+		entityByID[doc.Entities[i].ID] = &doc.Entities[i]
+	}
+
+	for _, rc := range cfg.Rules {
+		rr := evaluateRule(rc, doc, entityByID)
+		res.Results = append(res.Results, rr)
+		if rr.Passed {
+			res.PassedRules++
+		} else {
+			res.FailedRules++
+			for _, v := range rr.Violations {
+				switch v.Severity {
+				case "warn":
+					res.WarnCount++
+				case "info":
+					res.InfoCount++
+				default:
+					res.ErrorCount++
+				}
+			}
+		}
+	}
+
+	res.SuggestedRules = suggestRules(doc, entityByID)
+	return res
+}
+
+func evaluateRule(rc RuleConfig, doc *graph.Document, entityByID map[string]*graph.Entity) RuleResult {
+	sev := rc.Severity
+	if sev == "" {
+		sev = "error"
+	}
+	rr := RuleResult{Rule: rc, Passed: true}
+
+	switch {
+	case rc.Forbid != "":
+		rr.Violations = evalForbid(rc, doc, entityByID, sev)
+	case rc.Require != "":
+		rr.Violations = evalRequire(rc, doc, entityByID, sev)
+	case rc.Threshold != "":
+		rr.Violations = evalThreshold(rc, doc, sev)
+	default:
+		rr.Violations = []Violation{{
+			RuleName: rc.Name,
+			Severity: "error",
+			Kind:     "parse",
+			Message:  "rule has no forbid / require / threshold clause",
+		}}
+	}
+
+	if len(rr.Violations) > 0 {
+		rr.Passed = false
+	}
+	return rr
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// forbid evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+// forbidPattern captures the parsed forbid expression.
+type forbidPattern struct {
+	fromKindGlob string // may be "*"
+	edgeKind     string // may be "" (any)
+	toKindGlob   string // may be "*"
+}
+
+// parseForbid parses expressions like:
+//
+//	'SourceKind -> TargetKind'
+//	'SourceKind -[EDGE]-> TargetKind'
+//	'* -> DatabaseTable'
+var reForbidWithEdge = regexp.MustCompile(`^(\S+)\s+-\[([^\]]+)\]->\s+(\S+)$`)
+var reForbidSimple = regexp.MustCompile(`^(\S+)\s+->\s+(\S+)$`)
+
+func parseForbid(expr string) (forbidPattern, error) {
+	expr = strings.TrimSpace(expr)
+	if m := reForbidWithEdge.FindStringSubmatch(expr); m != nil {
+		return forbidPattern{fromKindGlob: m[1], edgeKind: strings.ToUpper(m[2]), toKindGlob: m[3]}, nil
+	}
+	if m := reForbidSimple.FindStringSubmatch(expr); m != nil {
+		return forbidPattern{fromKindGlob: m[1], toKindGlob: m[2]}, nil
+	}
+	return forbidPattern{}, fmt.Errorf("cannot parse forbid expression %q; expected 'SourceKind -> TargetKind' or 'SourceKind -[EDGE]-> TargetKind'", expr)
+}
+
+func kindMatches(entityKind, glob string) bool {
+	if glob == "*" {
+		return true
+	}
+	// Case-insensitive substring/prefix match: 'Model' matches 'DataModel', etc.
+	return strings.EqualFold(entityKind, glob) ||
+		strings.HasSuffix(strings.ToLower(entityKind), strings.ToLower("."+glob)) ||
+		strings.HasPrefix(strings.ToLower(entityKind), strings.ToLower(glob+"."))
+}
+
+func evalForbid(rc RuleConfig, doc *graph.Document, entityByID map[string]*graph.Entity, sev string) []Violation {
+	pat, err := parseForbid(rc.Forbid)
+	if err != nil {
+		return []Violation{{RuleName: rc.Name, Severity: "error", Kind: "parse", Message: err.Error()}}
+	}
+
+	var violations []Violation
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		if pat.edgeKind != "" && !strings.EqualFold(rel.Kind, pat.edgeKind) {
+			continue
+		}
+		fromEnt := entityByID[rel.FromID]
+		toEnt := entityByID[rel.ToID]
+		if fromEnt == nil || toEnt == nil {
+			continue
+		}
+		if !kindMatches(fromEnt.Kind, pat.fromKindGlob) {
+			continue
+		}
+		if !kindMatches(toEnt.Kind, pat.toKindGlob) {
+			continue
+		}
+		if isExcepted(fromEnt, rc.Except) || isExcepted(toEnt, rc.Except) {
+			continue
+		}
+		violations = append(violations, Violation{
+			RuleName:   rc.Name,
+			Severity:   sev,
+			Kind:       "forbid",
+			Message:    fmt.Sprintf("forbidden edge: %s(%s) -[%s]-> %s(%s)", fromEnt.Name, fromEnt.Kind, rel.Kind, toEnt.Name, toEnt.Kind),
+			FromEntity: entRef(fromEnt),
+			ToEntity:   entRef(toEnt),
+		})
+	}
+	return violations
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// require evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+// requirePattern captures the parsed require expression.
+type requirePattern struct {
+	kindGlob  string
+	direction string // "outbound" | "inbound"
+	edgeKind  string
+}
+
+// parseRequire parses expressions like:
+//
+//	'Kind has-no-outbound-IMPORTS'
+//	'Kind has-no-inbound-CALLS'
+var reRequire = regexp.MustCompile(`^(\S+)\s+has-no-(outbound|inbound)-(\S+)$`)
+
+func parseRequire(expr string) (requirePattern, error) {
+	expr = strings.TrimSpace(expr)
+	m := reRequire.FindStringSubmatch(expr)
+	if m == nil {
+		return requirePattern{}, fmt.Errorf("cannot parse require expression %q; expected 'Kind has-no-outbound-EDGE_KIND' or 'Kind has-no-inbound-EDGE_KIND'", expr)
+	}
+	return requirePattern{kindGlob: m[1], direction: m[2], edgeKind: strings.ToUpper(m[3])}, nil
+}
+
+func evalRequire(rc RuleConfig, doc *graph.Document, entityByID map[string]*graph.Entity, sev string) []Violation {
+	pat, err := parseRequire(rc.Require)
+	if err != nil {
+		return []Violation{{RuleName: rc.Name, Severity: "error", Kind: "parse", Message: err.Error()}}
+	}
+
+	// Build a set of entity IDs that match the kind glob.
+	matchedIDs := make(map[string]bool)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if kindMatches(e.Kind, pat.kindGlob) && !isExcepted(e, rc.Except) {
+			matchedIDs[e.ID] = true
+		}
+	}
+
+	var violations []Violation
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		if !strings.EqualFold(rel.Kind, pat.edgeKind) {
+			continue
+		}
+		var subjectID, peerID string
+		if pat.direction == "outbound" {
+			subjectID = rel.FromID
+			peerID = rel.ToID
+		} else {
+			subjectID = rel.ToID
+			peerID = rel.FromID
+		}
+		if !matchedIDs[subjectID] {
+			continue
+		}
+		subjectEnt := entityByID[subjectID]
+		peerEnt := entityByID[peerID]
+		if subjectEnt == nil {
+			continue
+		}
+		peerName := peerID
+		if peerEnt != nil {
+			peerName = fmt.Sprintf("%s(%s)", peerEnt.Name, peerEnt.Kind)
+		}
+		var msg string
+		if pat.direction == "outbound" {
+			msg = fmt.Sprintf("%s(%s) must have no outbound %s edges, but found -> %s", subjectEnt.Name, subjectEnt.Kind, pat.edgeKind, peerName)
+		} else {
+			msg = fmt.Sprintf("%s(%s) must have no inbound %s edges, but found %s ->", subjectEnt.Name, subjectEnt.Kind, pat.edgeKind, peerName)
+		}
+		violations = append(violations, Violation{
+			RuleName:   rc.Name,
+			Severity:   sev,
+			Kind:       "require",
+			Message:    msg,
+			FromEntity: entRef(subjectEnt),
+		})
+	}
+	return violations
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// threshold evaluation
+// ─────────────────────────────────────────────────────────────────────────────
+
+var reThreshold = regexp.MustCompile(`^(\S+)\s*(<=|>=|<|>|==|!=)\s*(\S+)$`)
+
+func evalThreshold(rc RuleConfig, doc *graph.Document, sev string) []Violation {
+	expr := strings.TrimSpace(rc.Threshold)
+	m := reThreshold.FindStringSubmatch(expr)
+	if m == nil {
+		return []Violation{{
+			RuleName: rc.Name,
+			Severity: "error",
+			Kind:     "parse",
+			Message:  fmt.Sprintf("cannot parse threshold %q; expected 'metric op value' (e.g. 'import_cycles.max_size <= 3')", expr),
+		}}
+	}
+	metric, op, rawTarget := m[1], m[2], m[3]
+
+	target, err := strconv.ParseFloat(rawTarget, 64)
+	if err != nil {
+		return []Violation{{
+			RuleName: rc.Name,
+			Severity: "error",
+			Kind:     "parse",
+			Message:  fmt.Sprintf("threshold target %q is not a number", rawTarget),
+		}}
+	}
+
+	value, resolveErr := resolveMetric(metric, doc)
+	if resolveErr != nil {
+		return []Violation{{
+			RuleName: rc.Name,
+			Severity: "error",
+			Kind:     "threshold",
+			Message:  resolveErr.Error(),
+		}}
+	}
+
+	if !evalOp(value, op, target) {
+		return []Violation{{
+			RuleName: rc.Name,
+			Severity: sev,
+			Kind:     "threshold",
+			Message:  fmt.Sprintf("threshold violated: %s = %.4g %s %.4g is false", metric, value, op, target),
+		}}
+	}
+	return nil
+}
+
+// resolveMetric returns the current numeric value of a named metric.
+// Supported metrics:
+//
+//	import_cycles.count       — number of distinct import cycles
+//	import_cycles.max_size    — size of the largest cycle
+//	orphan_rate_pct           — % of entities with no inbound edges
+//	entity_count              — total number of entities
+//	relationship_count        — total number of relationships
+func resolveMetric(metric string, doc *graph.Document) (float64, error) {
+	switch metric {
+	case "entity_count":
+		return float64(len(doc.Entities)), nil
+	case "relationship_count":
+		return float64(len(doc.Relationships)), nil
+	case "orphan_rate_pct":
+		return computeOrphanRatePct(doc), nil
+	case "import_cycles.count", "import_cycles.max_size":
+		cycles := graph.FindImportCycles(doc.Entities, doc.Relationships, nil)
+		if metric == "import_cycles.count" {
+			return float64(len(cycles)), nil
+		}
+		max := 0
+		for _, c := range cycles {
+			if c.Size > max {
+				max = c.Size
+			}
+		}
+		return float64(max), nil
+	}
+	return 0, fmt.Errorf("unknown metric %q; supported: import_cycles.count, import_cycles.max_size, orphan_rate_pct, entity_count, relationship_count", metric)
+}
+
+func evalOp(v float64, op string, target float64) bool {
+	switch op {
+	case "<=":
+		return v <= target
+	case ">=":
+		return v >= target
+	case "<":
+		return v < target
+	case ">":
+		return v > target
+	case "==":
+		return v == target
+	case "!=":
+		return v != target
+	}
+	return false
+}
+
+func computeOrphanRatePct(doc *graph.Document) float64 {
+	if len(doc.Entities) == 0 {
+		return 0
+	}
+	hasInbound := make(map[string]bool, len(doc.Entities))
+	for i := range doc.Relationships {
+		hasInbound[doc.Relationships[i].ToID] = true
+	}
+	orphans := 0
+	for i := range doc.Entities {
+		if !hasInbound[doc.Entities[i].ID] {
+			orphans++
+		}
+	}
+	return float64(orphans) / float64(len(doc.Entities)) * 100
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func entRef(e *graph.Entity) *EntityRef {
+	if e == nil {
+		return nil
+	}
+	return &EntityRef{ID: e.ID, Name: e.Name, Kind: e.Kind, SourceFile: e.SourceFile}
+}
+
+// isExcepted returns true when e matches any entry in the exception list.
+// An exception entry can be:
+//   - a bare entity ID (exact match)
+//   - 'kind:name' where kind / name may each be '*' for wildcard
+func isExcepted(e *graph.Entity, except []string) bool {
+	for _, exc := range except {
+		if exc == e.ID {
+			return true
+		}
+		if strings.Contains(exc, ":") {
+			parts := strings.SplitN(exc, ":", 2)
+			kindPat, namePat := parts[0], parts[1]
+			kindOK := kindPat == "*" || strings.EqualFold(kindPat, e.Kind)
+			nameOK := namePat == "*" || strings.EqualFold(namePat, e.Name) || strings.Contains(strings.ToLower(e.Name), strings.ToLower(namePat))
+			if kindOK && nameOK {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Auto-suggestion engine
+// ─────────────────────────────────────────────────────────────────────────────
+
+// suggestRules looks for common architectural anti-patterns in the graph and
+// returns suggested fitness rules the user might want to adopt.
+func suggestRules(doc *graph.Document, entityByID map[string]*graph.Entity) []SuggestedRule {
+	var suggestions []SuggestedRule
+
+	// Suggestion 1: if any http_endpoint_definition entity directly imports a
+	// DatabaseTable or Model entity, suggest a "no DB in handlers" rule.
+	handlerHitsDB := false
+	for i := range doc.Relationships {
+		r := &doc.Relationships[i]
+		if r.Kind != "IMPORTS" && r.Kind != "CALLS" && r.Kind != "USES" {
+			continue
+		}
+		from := entityByID[r.FromID]
+		to := entityByID[r.ToID]
+		if from == nil || to == nil {
+			continue
+		}
+		if isEndpointOrHandler(from.Kind) && isDatabaseKind(to.Kind) {
+			handlerHitsDB = true
+			break
+		}
+	}
+	if handlerHitsDB {
+		suggestions = append(suggestions, SuggestedRule{
+			Name:   "No DB access from HTTP handlers",
+			YAML:   "- name: 'No DB access from HTTP handlers'\n  forbid: 'http_endpoint_definition -> DatabaseTable'\n  severity: error",
+			Reason: "Detected direct edges from HTTP handler entities to database entities — consider adding a service/repository layer.",
+		})
+	}
+
+	// Suggestion 2: if import cycles exist, suggest a threshold rule.
+	cycles := graph.FindImportCycles(doc.Entities, doc.Relationships, nil)
+	if len(cycles) > 0 {
+		maxSize := 0
+		for _, c := range cycles {
+			if c.Size > maxSize {
+				maxSize = c.Size
+			}
+		}
+		suggestions = append(suggestions, SuggestedRule{
+			Name: "No import cycles",
+			YAML: fmt.Sprintf("- name: 'No import cycles'\n  threshold: 'import_cycles.count == 0'\n  severity: error"),
+			Reason: fmt.Sprintf("Found %d import cycle(s) (largest: %d members). Consider banning new cycles via a threshold rule.", len(cycles), maxSize),
+		})
+		if maxSize > 3 {
+			suggestions = append(suggestions, SuggestedRule{
+				Name: "Cap cycle size at 3",
+				YAML: "- name: 'Max cycle size 3'\n  threshold: 'import_cycles.max_size <= 3'\n  severity: warn",
+				Reason: fmt.Sprintf("Largest import cycle has %d members — smaller cycles are easier to break.", maxSize),
+			})
+		}
+	}
+
+	return suggestions
+}
+
+func isEndpointOrHandler(kind string) bool {
+	lower := strings.ToLower(kind)
+	return strings.Contains(lower, "endpoint") ||
+		strings.Contains(lower, "handler") ||
+		strings.Contains(lower, "controller") ||
+		strings.Contains(lower, "view") ||
+		strings.Contains(lower, "route")
+}
+
+func isDatabaseKind(kind string) bool {
+	lower := strings.ToLower(kind)
+	return strings.Contains(lower, "database") ||
+		strings.Contains(lower, "table") ||
+		strings.Contains(lower, "repository") ||
+		strings.Contains(lower, "dao") ||
+		strings.Contains(lower, "model") ||
+		strings.Contains(lower, "entity")
+}

--- a/internal/quality/fitness/rule_test.go
+++ b/internal/quality/fitness/rule_test.go
@@ -1,0 +1,300 @@
+package fitness_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/quality/fitness"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func makeDoc(entities []graph.Entity, rels []graph.Relationship) *graph.Document {
+	return &graph.Document{
+		Entities:      entities,
+		Relationships: rels,
+	}
+}
+
+func entity(id, name, kind, file string) graph.Entity {
+	return graph.Entity{ID: id, Name: name, Kind: kind, SourceFile: file}
+}
+
+func rel(id, fromID, toID, kind string) graph.Relationship {
+	return graph.Relationship{ID: id, FromID: fromID, ToID: toID, Kind: kind}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// forbid
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEvaluate_Forbid_Triggers(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserHandler", "http_endpoint_definition", "handler.go"),
+			entity("e2", "users_table", "DatabaseTable", "db.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:   "No DB in handlers",
+			Forbid: "http_endpoint_definition -> DatabaseTable",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Fatalf("expected 1 failed rule, got %d", result.FailedRules)
+	}
+	if len(result.Results[0].Violations) != 1 {
+		t.Fatalf("expected 1 violation, got %d", len(result.Results[0].Violations))
+	}
+	v := result.Results[0].Violations[0]
+	if v.Kind != "forbid" {
+		t.Errorf("expected kind=forbid, got %s", v.Kind)
+	}
+	if v.FromEntity == nil || v.FromEntity.ID != "e1" {
+		t.Errorf("expected from entity e1")
+	}
+}
+
+func TestEvaluate_Forbid_NoViolation(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserService", "Service", "svc.go"),
+			entity("e2", "users_table", "DatabaseTable", "db.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:   "No DB in handlers",
+			Forbid: "http_endpoint_definition -> DatabaseTable",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 0 {
+		t.Errorf("expected 0 failed rules, got %d", result.FailedRules)
+	}
+}
+
+func TestEvaluate_Forbid_WithEdgeKind(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserHandler", "http_endpoint_definition", "handler.go"),
+			entity("e2", "users_table", "DatabaseTable", "db.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "CALLS"),
+		},
+	)
+	// Pattern with specific edge kind: only flag CALLS edges.
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:   "No direct CALLS from handler to DB",
+			Forbid: "http_endpoint_definition -[CALLS]-> DatabaseTable",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Errorf("expected 1 failed rule, got %d", result.FailedRules)
+	}
+}
+
+func TestEvaluate_Forbid_ExceptionByID(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserHandler", "http_endpoint_definition", "handler.go"),
+			entity("e2", "users_table", "DatabaseTable", "db.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:   "No DB in handlers",
+			Forbid: "http_endpoint_definition -> DatabaseTable",
+			Except: []string{"e1"}, // except the specific entity
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 0 {
+		t.Errorf("expected 0 failed rules (exception applies), got %d", result.FailedRules)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// require
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEvaluate_Require_HasNoOutbound_Triggers(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserModel", "Model", "model.go"),
+			entity("e2", "OrderService", "Service", "svc.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:    "Models depend on nothing",
+			Require: "Model has-no-outbound-IMPORTS",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Fatalf("expected 1 failed rule, got %d", result.FailedRules)
+	}
+}
+
+func TestEvaluate_Require_HasNoOutbound_Passes(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserModel", "Model", "model.go"),
+			entity("e2", "OrderService", "Service", "svc.go"),
+		},
+		[]graph.Relationship{
+			// Only CALLS, not IMPORTS — rule is about IMPORTS.
+			rel("r1", "e1", "e2", "CALLS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:    "Models depend on nothing",
+			Require: "Model has-no-outbound-IMPORTS",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 0 {
+		t.Errorf("expected 0 failed rules, got %d", result.FailedRules)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// threshold
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEvaluate_Threshold_OrphanRate(t *testing.T) {
+	// 3 entities, 1 inbound edge → 2/3 orphans = 66.7%
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "A", "Service", "a.go"),
+			entity("e2", "B", "Service", "b.go"),
+			entity("e3", "C", "Service", "c.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"), // e2 has inbound; e1 and e3 are orphans
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:      "Low orphan rate",
+			Threshold: "orphan_rate_pct < 30",
+			Severity:  "warn",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Fatalf("expected 1 failed rule (orphan rate 66.7%% > 30%%), got %d", result.FailedRules)
+	}
+	if result.WarnCount != 1 {
+		t.Errorf("expected warn_count=1, got %d", result.WarnCount)
+	}
+}
+
+func TestEvaluate_Threshold_EntityCount(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "A", "Service", "a.go"),
+			entity("e2", "B", "Service", "b.go"),
+		},
+		nil,
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:      "Entity count check",
+			Threshold: "entity_count >= 2",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 0 {
+		t.Errorf("expected 0 failed rules (entity_count=2 >= 2), got %d", result.FailedRules)
+	}
+}
+
+func TestEvaluate_Threshold_UnknownMetric(t *testing.T) {
+	doc := makeDoc(nil, nil)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:      "Unknown metric",
+			Threshold: "nonexistent_metric <= 5",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Errorf("expected 1 failed rule (unknown metric), got %d", result.FailedRules)
+	}
+	v := result.Results[0].Violations[0]
+	if v.Severity != "error" {
+		t.Errorf("expected severity error for unknown metric, got %s", v.Severity)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// severity
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEvaluate_SeverityWarn_NotError(t *testing.T) {
+	doc := makeDoc(
+		[]graph.Entity{
+			entity("e1", "UserHandler", "http_endpoint_definition", "handler.go"),
+			entity("e2", "users_table", "DatabaseTable", "db.go"),
+		},
+		[]graph.Relationship{
+			rel("r1", "e1", "e2", "IMPORTS"),
+		},
+	)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name:     "Soft: No DB in handlers",
+			Forbid:   "http_endpoint_definition -> DatabaseTable",
+			Severity: "warn",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.ErrorCount != 0 {
+		t.Errorf("expected 0 errors (severity=warn), got %d", result.ErrorCount)
+	}
+	if result.WarnCount != 1 {
+		t.Errorf("expected 1 warn, got %d", result.WarnCount)
+	}
+	if result.HasFailures() {
+		t.Errorf("HasFailures() should be false for warn-only violations")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// parse errors
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestEvaluate_NoClause_IsParseError(t *testing.T) {
+	doc := makeDoc(nil, nil)
+	cfg := &fitness.Config{
+		Rules: []fitness.RuleConfig{{
+			Name: "Empty rule",
+		}},
+	}
+	result := fitness.Evaluate(cfg, doc)
+	if result.FailedRules != 1 {
+		t.Errorf("expected 1 failed rule for empty clause, got %d", result.FailedRules)
+	}
+}


### PR DESCRIPTION
## What

Closes #1345. Introduces user-defined architectural fitness functions: rules declared in `.archigraph/fitness.yaml` evaluated against the live graph, surfaced via API and CLI with optional CI gating.

## Why

Teams need a lightweight, code-driven way to enforce architectural invariants — "no DB access from HTTP handlers", "models have no outbound imports", "zero import cycles" — without a full policy framework.

## How

### New package: `internal/quality/fitness`

DSL parser + evaluator with three rule kinds:

| Kind | Grammar | Example |
|------|---------|---------|
| `forbid` | `SourceKind -> TargetKind` or `SourceKind -[EDGE]-> TargetKind` | `http_endpoint_definition -> DatabaseTable` |
| `require` | `Kind has-no-outbound-EDGE_KIND` | `Model has-no-outbound-IMPORTS` |
| `threshold` | `metric op value` | `import_cycles.max_size <= 3` |

Per-rule severity (error/warn/info), exception lists, and an auto-suggestion engine that detects common anti-patterns.

Supported metrics: `import_cycles.count`, `import_cycles.max_size`, `orphan_rate_pct`, `entity_count`, `relationship_count`.

### New CLI subcommand: `archigraph quality check`

```
archigraph quality check [--strict] [--json] [--output FILE] <group|repo-path>
```

Exit codes: `0` all passed · `2` error-severity violations (or any violation with `--strict`).

### New API endpoint: `GET /api/fitness/{group}`

Returns `FitnessGroupReport` — per-repo rule results with violation details and suggested rules. Optional `?repo=slug` filter.

### Wiring

- `cmd/archigraph/quality.go` — dispatches `quality check` subverb
- `internal/dashboard/server.go` — registers `GET /api/fitness/{group}`
- `internal/cli/root.go` — adds `quality check` to the advanced help text

## Test plan

- [ ] `go test ./internal/quality/fitness/...` — 11 tests covering all three rule kinds, severity levels, exceptions, parse errors
- [ ] `go build ./internal/quality/fitness/... ./internal/dashboard/... ./cmd/archigraph/...` — clean
- [ ] Create `.archigraph/fitness.yaml` in any indexed repo, run `archigraph quality check <group>` — violations appear
- [ ] `--strict` flag causes exit 2 on warn violations
- [ ] `GET /api/fitness/<group>` returns JSON with `total_errors` and per-repo results
- [ ] Repo with no `fitness.yaml` — skipped silently; suggested rules appear when auto-patterns detected

## Example config

```yaml
# .archigraph/fitness.yaml
rules:
  - name: 'No DB access from handlers'
    forbid: 'http_endpoint_definition -> DatabaseTable'
  - name: 'Models depend on nothing'
    require: 'Model has-no-outbound-IMPORTS'
    except: ['Model:BaseModel']
  - name: 'Max cycle size 3'
    threshold: 'import_cycles.max_size <= 3'
    severity: warn
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)