### PR TITLE
[dashboard] Repo Manifest viewer — surface AGENTS.md + .archigraph/ per repo (#1351)

### DIFF
--- a/internal/dashboard/handlers_repo_manifest.go
+++ b/internal/dashboard/handlers_repo_manifest.go
@@ -1,0 +1,410 @@
+package dashboard
+
+// handlers_repo_manifest.go — Repo Manifest viewer (#1351)
+//
+// Surfaces per-repo metadata: languages, AGENTS.md status, .archigraph/
+// state files, and dependency manifest files. Also provides a lightweight
+// re-scan endpoint that refreshes manifest data without a full rebuild.
+//
+// Routes registered in server.go:
+//
+//	GET  /api/groups/{group}/repos/{repo}/manifest   — full manifest
+//	POST /api/groups/{group}/repos/{repo}/manifest/refresh — re-scan (async)
+
+import (
+	"bufio"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/install/detect"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// RepoManifestReply is the wire shape for GET /api/groups/{group}/repos/{repo}/manifest.
+type RepoManifestReply struct {
+	// Group and Repo echo back the path params.
+	Group string `json:"group"`
+	Repo  string `json:"repo"`
+
+	// AbsPath is the absolute on-disk path of the repo.
+	AbsPath string `json:"abs_path"`
+
+	// Stack is the dominant language stack ("go", "node", "python", …).
+	Stack string `json:"stack"`
+
+	// Languages is the ordered list of all detected language stacks.
+	Languages []string `json:"languages"`
+
+	// AgentsMD describes the AGENTS.md (or CLAUDE.md / GEMINI.md) file found.
+	AgentsMD AgentsMDInfo `json:"agents_md"`
+
+	// ArchigraphState lists the files present under <repo>/.archigraph/.
+	ArchigraphState []string `json:"archigraph_state"`
+
+	// DependencyManifests lists the dependency manifest files found at the root.
+	DependencyManifests []string `json:"dependency_manifests"`
+
+	// QualityScore is a 0-100 heuristic derived from manifest completeness signals.
+	QualityScore int `json:"quality_score"`
+
+	// QualitySignals enumerates the individual signals used for scoring.
+	QualitySignals []QualitySignal `json:"quality_signals"`
+}
+
+// AgentsMDInfo describes the AGENTS.md (or equivalent) file for a repo.
+type AgentsMDInfo struct {
+	// Exists is true when any agents-context file was found.
+	Exists bool `json:"exists"`
+	// Filename is the base name of the found file ("AGENTS.md", "CLAUDE.md", …).
+	Filename string `json:"filename,omitempty"`
+	// InjectedByArchigraph is true when the file contains the archigraph marker block.
+	InjectedByArchigraph bool `json:"injected_by_archigraph"`
+	// PreviewLines holds up to 50 lines from the beginning of the file.
+	PreviewLines []string `json:"preview_lines,omitempty"`
+	// EditorURI is a "file://…" URI that desktop editors can open directly.
+	EditorURI string `json:"editor_uri,omitempty"`
+}
+
+// QualitySignal is a single boolean signal that contributes to the quality score.
+type QualitySignal struct {
+	// Name is a human-readable label for the signal.
+	Name string `json:"name"`
+	// OK is true when the signal is present.
+	OK bool `json:"ok"`
+	// Points is the number of points this signal contributes when OK.
+	Points int `json:"points"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/groups/{group}/repos/{repo}/manifest
+// ─────────────────────────────────────────────────────────────────────────────
+
+func (s *Server) handleRepoManifest(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	repoPath, err := resolveRepoPath(group, repo)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	reply := buildManifest(group, repo, repoPath)
+	writeJSON(w, http.StatusOK, reply)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/groups/{group}/repos/{repo}/manifest/refresh
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ManifestRefreshReply is the wire shape for POST …/manifest/refresh.
+type ManifestRefreshReply struct {
+	// Manifest is the freshly-scanned manifest (synchronous — no rebuild needed).
+	Manifest RepoManifestReply `json:"manifest"`
+}
+
+func (s *Server) handleRepoManifestRefresh(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	repo := r.PathValue("repo")
+	if group == "" || repo == "" {
+		writeErr(w, http.StatusBadRequest, "group and repo required")
+		return
+	}
+
+	repoPath, err := resolveRepoPath(group, repo)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, err.Error())
+		return
+	}
+
+	manifest := buildManifest(group, repo, repoPath)
+	writeJSON(w, http.StatusOK, ManifestRefreshReply{Manifest: manifest})
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Core scanning logic
+// ─────────────────────────────────────────────────────────────────────────────
+
+// buildManifest scans repoPath and returns a fully-populated RepoManifestReply.
+func buildManifest(group, repo, repoPath string) RepoManifestReply {
+	reply := RepoManifestReply{
+		Group:   group,
+		Repo:    repo,
+		AbsPath: repoPath,
+		Stack:   detect.Stack(repoPath),
+	}
+
+	reply.Languages = detectLanguages(repoPath)
+	reply.AgentsMD = scanAgentsMD(repoPath)
+	reply.ArchigraphState = scanArchigraphState(repoPath)
+	reply.DependencyManifests = scanDependencyManifests(repoPath)
+	reply.QualitySignals, reply.QualityScore = computeQuality(reply)
+
+	return reply
+}
+
+// detectLanguages returns all language stacks detected in the repo, not just
+// the dominant one returned by detect.Stack. Multiple stacks can coexist in
+// monorepo roots or polyglot services.
+func detectLanguages(repoPath string) []string {
+	candidates := []struct {
+		marker string
+		lang   string
+	}{
+		{"go.mod", "go"},
+		{"package.json", "node"},
+		{"pyproject.toml", "python"},
+		{"requirements.txt", "python"},
+		{"Cargo.toml", "rust"},
+		{"pom.xml", "jvm"},
+		{"build.gradle", "jvm"},
+		{"build.gradle.kts", "jvm"},
+		{"Gemfile", "ruby"},
+		{"composer.json", "php"},
+		{"*.csproj", "dotnet"},
+		{"*.fsproj", "dotnet"},
+	}
+	seen := map[string]struct{}{}
+	var langs []string
+	for _, c := range candidates {
+		if strings.Contains(c.marker, "*") {
+			// glob match — scan root-level files
+			ext := strings.TrimPrefix(c.marker, "*")
+			entries, err := os.ReadDir(repoPath)
+			if err != nil {
+				continue
+			}
+			for _, e := range entries {
+				if strings.HasSuffix(e.Name(), ext) {
+					if _, ok := seen[c.lang]; !ok {
+						seen[c.lang] = struct{}{}
+						langs = append(langs, c.lang)
+					}
+					break
+				}
+			}
+		} else {
+			if fileExists(repoPath, c.marker) {
+				if _, ok := seen[c.lang]; !ok {
+					seen[c.lang] = struct{}{}
+					langs = append(langs, c.lang)
+				}
+			}
+		}
+	}
+	return langs
+}
+
+// scanAgentsMD probes for AGENTS.md, CLAUDE.md, and GEMINI.md in the repo root.
+// It reads up to 50 lines for preview and checks for the archigraph marker.
+func scanAgentsMD(repoPath string) AgentsMDInfo {
+	const markerSubstring = "archigraph"
+	candidates := []string{"AGENTS.md", "CLAUDE.md", "GEMINI.md"}
+	for _, name := range candidates {
+		full := filepath.Join(repoPath, name)
+		if _, err := os.Stat(full); err != nil {
+			continue
+		}
+		info := AgentsMDInfo{
+			Exists:    true,
+			Filename:  name,
+			EditorURI: "file://" + full,
+		}
+		// Read up to 50 lines.
+		f, err := os.Open(full)
+		if err != nil {
+			return info
+		}
+		defer f.Close()
+
+		scanner := bufio.NewScanner(io.LimitReader(f, 64*1024)) // 64 KiB max
+		var lines []string
+		injected := false
+		for scanner.Scan() {
+			line := scanner.Text()
+			lines = append(lines, line)
+			if strings.Contains(strings.ToLower(line), markerSubstring) {
+				injected = true
+			}
+			if len(lines) >= 50 {
+				break
+			}
+		}
+		info.PreviewLines = lines
+		info.InjectedByArchigraph = injected
+		return info
+	}
+	return AgentsMDInfo{}
+}
+
+// scanArchigraphState lists file names present under <repo>/.archigraph/.
+// Returns an empty slice (never nil) when the directory is absent.
+func scanArchigraphState(repoPath string) []string {
+	stateDir := daemon.StateDirForRepo(repoPath)
+	entries, err := os.ReadDir(stateDir)
+	if err != nil {
+		// Also probe the in-repo .archigraph directory for committed manifests.
+		inRepoDir := filepath.Join(repoPath, ".archigraph")
+		entries2, err2 := os.ReadDir(inRepoDir)
+		if err2 != nil {
+			return []string{}
+		}
+		var names []string
+		for _, e := range entries2 {
+			if !e.IsDir() {
+				names = append(names, e.Name())
+			}
+		}
+		return names
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			names = append(names, e.Name())
+		}
+	}
+	// Merge in-repo .archigraph committed files (e.g. group.json).
+	inRepoDir := filepath.Join(repoPath, ".archigraph")
+	if entries2, err2 := os.ReadDir(inRepoDir); err2 == nil {
+		seen := map[string]struct{}{}
+		for _, n := range names {
+			seen[n] = struct{}{}
+		}
+		for _, e := range entries2 {
+			if !e.IsDir() {
+				if _, ok := seen[e.Name()]; !ok {
+					names = append(names, e.Name()+" (committed)")
+				}
+			}
+		}
+	}
+	return names
+}
+
+// scanDependencyManifests returns the known dependency manifest files present
+// at the repo root.
+func scanDependencyManifests(repoPath string) []string {
+	candidates := []string{
+		"go.mod",
+		"go.sum",
+		"package.json",
+		"package-lock.json",
+		"yarn.lock",
+		"pnpm-lock.yaml",
+		"requirements.txt",
+		"pyproject.toml",
+		"Pipfile",
+		"Pipfile.lock",
+		"Cargo.toml",
+		"Cargo.lock",
+		"pom.xml",
+		"build.gradle",
+		"build.gradle.kts",
+		"Gemfile",
+		"Gemfile.lock",
+		"composer.json",
+		"composer.lock",
+	}
+	var found []string
+	for _, c := range candidates {
+		if fileExists(repoPath, c) {
+			found = append(found, c)
+		}
+	}
+	return found
+}
+
+// computeQuality derives a 0-100 quality score from the manifest signals and
+// returns both the individual signals and the total score.
+func computeQuality(r RepoManifestReply) ([]QualitySignal, int) {
+	signals := []QualitySignal{
+		{Name: "stack detected", OK: r.Stack != "" && r.Stack != "unknown", Points: 10},
+		{Name: "AGENTS.md / CLAUDE.md present", OK: r.AgentsMD.Exists, Points: 20},
+		{Name: "archigraph marker in agents file", OK: r.AgentsMD.InjectedByArchigraph, Points: 20},
+		{Name: ".archigraph state files present", OK: len(r.ArchigraphState) > 0, Points: 20},
+		{Name: "dependency manifests present", OK: len(r.DependencyManifests) > 0, Points: 15},
+		{Name: "multiple languages detected", OK: len(r.Languages) >= 1, Points: 10},
+		{Name: "lock file present", OK: hasLockFile(r.DependencyManifests), Points: 5},
+	}
+	total := 0
+	for _, s := range signals {
+		if s.OK {
+			total += s.Points
+		}
+	}
+	if total > 100 {
+		total = 100
+	}
+	return signals, total
+}
+
+// hasLockFile returns true when any of the manifests is a known lock file.
+func hasLockFile(manifests []string) bool {
+	lockFiles := map[string]struct{}{
+		"go.sum":           {},
+		"package-lock.json": {},
+		"yarn.lock":        {},
+		"pnpm-lock.yaml":   {},
+		"Cargo.lock":       {},
+		"Gemfile.lock":     {},
+		"Pipfile.lock":     {},
+		"composer.lock":    {},
+	}
+	for _, m := range manifests {
+		if _, ok := lockFiles[m]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// resolveRepoPath finds the on-disk path of a repo by slug within a group.
+func resolveRepoPath(group, repoSlug string) (string, error) {
+	groups, err := registry.Groups()
+	if err != nil {
+		return "", err
+	}
+	for _, g := range groups {
+		if g.Name == group {
+			cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+			if err != nil {
+				return "", err
+			}
+			for _, r := range cfg.Repos {
+				if r.Slug == repoSlug {
+					return r.Path, nil
+				}
+			}
+			return "", &repoNotFoundError{group: group, repo: repoSlug}
+		}
+	}
+	return "", &groupNotFoundError{group: group}
+}
+
+type groupNotFoundError struct{ group string }
+
+func (e *groupNotFoundError) Error() string {
+	return "group \"" + e.group + "\" not registered"
+}
+
+type repoNotFoundError struct{ group, repo string }
+
+func (e *repoNotFoundError) Error() string {
+	return "repo \"" + e.repo + "\" not registered in group \"" + e.group + "\""
+}

--- a/internal/dashboard/handlers_repo_manifest_test.go
+++ b/internal/dashboard/handlers_repo_manifest_test.go
@@ -1,0 +1,345 @@
+package dashboard
+
+// handlers_repo_manifest_test.go — unit tests for the Repo Manifest viewer (#1351).
+//
+// Tests cover:
+//   - scanAgentsMD: detection, preview lines, marker injection flag, editor URI
+//   - detectLanguages: multi-stack detection
+//   - scanDependencyManifests: known file enumeration
+//   - scanArchigraphState: absent directory returns empty slice
+//   - computeQuality: score and signals
+//   - buildManifest: smoke test on a temp directory
+//   - hasLockFile: identifies known lock files
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanAgentsMD
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestScanAgentsMD_NoFile(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	info := scanAgentsMD(dir)
+	if info.Exists {
+		t.Errorf("want Exists=false, got true")
+	}
+	if info.Filename != "" {
+		t.Errorf("want empty Filename, got %q", info.Filename)
+	}
+}
+
+func TestScanAgentsMD_AgentsMD(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := "# Agents\n\nThis repo is indexed by archigraph.\n\nMore text here.\n"
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := scanAgentsMD(dir)
+	if !info.Exists {
+		t.Errorf("want Exists=true")
+	}
+	if info.Filename != "AGENTS.md" {
+		t.Errorf("want Filename=AGENTS.md, got %q", info.Filename)
+	}
+	if !info.InjectedByArchigraph {
+		t.Errorf("want InjectedByArchigraph=true (marker present in content)")
+	}
+	if len(info.PreviewLines) == 0 {
+		t.Errorf("want non-empty PreviewLines")
+	}
+	if !strings.HasPrefix(info.EditorURI, "file://") {
+		t.Errorf("want EditorURI to start with file://, got %q", info.EditorURI)
+	}
+}
+
+func TestScanAgentsMD_ClaudeMD_NoMarker(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	content := strings.Repeat("# CLAUDE config\nNo marker here.\n", 5)
+	if err := os.WriteFile(filepath.Join(dir, "CLAUDE.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := scanAgentsMD(dir)
+	if !info.Exists {
+		t.Errorf("want Exists=true for CLAUDE.md")
+	}
+	if info.Filename != "CLAUDE.md" {
+		t.Errorf("want Filename=CLAUDE.md, got %q", info.Filename)
+	}
+	if info.InjectedByArchigraph {
+		t.Errorf("want InjectedByArchigraph=false (no marker)")
+	}
+}
+
+func TestScanAgentsMD_PreviewCappedAt50Lines(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		sb.WriteString("line\n")
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	info := scanAgentsMD(dir)
+	if len(info.PreviewLines) > 50 {
+		t.Errorf("want at most 50 preview lines, got %d", len(info.PreviewLines))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// detectLanguages
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestDetectLanguages_GoOnly(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/m\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	langs := detectLanguages(dir)
+	if !sliceContains(langs, "go") {
+		t.Errorf("want 'go' in languages, got %v", langs)
+	}
+}
+
+func TestDetectLanguages_Polyglot(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	touch := func(name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	touch("go.mod")
+	touch("package.json")
+	touch("requirements.txt")
+	langs := detectLanguages(dir)
+	for _, want := range []string{"go", "node", "python"} {
+		if !sliceContains(langs, want) {
+			t.Errorf("want %q in languages, got %v", want, langs)
+		}
+	}
+}
+
+func TestDetectLanguages_NoDuplicates(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Both pyproject.toml and requirements.txt → still only one "python" entry.
+	touch := func(name string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	touch("pyproject.toml")
+	touch("requirements.txt")
+	langs := detectLanguages(dir)
+	count := 0
+	for _, l := range langs {
+		if l == "python" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("want exactly 1 'python' entry, got %d in %v", count, langs)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanDependencyManifests
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestScanDependencyManifests_Empty(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	got := scanDependencyManifests(dir)
+	if len(got) != 0 {
+		t.Errorf("want no manifests, got %v", got)
+	}
+}
+
+func TestScanDependencyManifests_KnownFiles(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	for _, name := range []string{"go.mod", "go.sum", "package.json"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(""), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	got := scanDependencyManifests(dir)
+	for _, want := range []string{"go.mod", "go.sum", "package.json"} {
+		if !sliceContains(got, want) {
+			t.Errorf("want %q in manifests, got %v", want, got)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// scanArchigraphState
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestScanArchigraphState_AbsentDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Use a non-existent path so StateDirForRepo won't find anything.
+	got := scanArchigraphState(dir)
+	// Must return a non-nil slice (possibly empty).
+	if got == nil {
+		t.Errorf("want non-nil slice, got nil")
+	}
+}
+
+func TestScanArchigraphState_InRepoDir(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	archDir := filepath.Join(dir, ".archigraph")
+	if err := os.MkdirAll(archDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(archDir, "group.json"), []byte(`{"group":"test"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := scanArchigraphState(dir)
+	if !sliceContains(got, "group.json") && !containsStrPrefix(got, "group.json") {
+		t.Errorf("want group.json in state, got %v", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// computeQuality
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestComputeQuality_FullRepo(t *testing.T) {
+	t.Parallel()
+	r := RepoManifestReply{
+		Stack:     "go",
+		Languages: []string{"go"},
+		AgentsMD: AgentsMDInfo{
+			Exists:               true,
+			InjectedByArchigraph: true,
+		},
+		ArchigraphState:     []string{"graph.json"},
+		DependencyManifests: []string{"go.mod", "go.sum"},
+	}
+	signals, score := computeQuality(r)
+	if score <= 0 {
+		t.Errorf("want positive score, got %d", score)
+	}
+	if score > 100 {
+		t.Errorf("score must be ≤100, got %d", score)
+	}
+	if len(signals) == 0 {
+		t.Errorf("want at least one signal")
+	}
+	// Check that each signal has a name and points.
+	for _, s := range signals {
+		if s.Name == "" {
+			t.Errorf("signal has empty name")
+		}
+		if s.Points <= 0 {
+			t.Errorf("signal %q has non-positive points: %d", s.Name, s.Points)
+		}
+	}
+}
+
+func TestComputeQuality_EmptyRepo(t *testing.T) {
+	t.Parallel()
+	r := RepoManifestReply{}
+	_, score := computeQuality(r)
+	if score != 0 {
+		t.Errorf("want 0 for empty manifest, got %d", score)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// hasLockFile
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestHasLockFile(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		manifests []string
+		want      bool
+	}{
+		{[]string{"go.mod", "go.sum"}, true},
+		{[]string{"package.json", "yarn.lock"}, true},
+		{[]string{"go.mod", "package.json"}, false},
+		{[]string{}, false},
+	}
+	for _, tc := range cases {
+		got := hasLockFile(tc.manifests)
+		if got != tc.want {
+			t.Errorf("hasLockFile(%v) = %v, want %v", tc.manifests, got, tc.want)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// buildManifest smoke test
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestBuildManifest_Smoke(t *testing.T) {
+	t.Parallel()
+	dir := t.TempDir()
+	// Set up a minimal Go repo.
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/m\ngo 1.21\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "go.sum"), []byte(""), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "AGENTS.md"), []byte("# Agents\nindexed by archigraph\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := buildManifest("mygroup", "myrepo", dir)
+	if m.Group != "mygroup" {
+		t.Errorf("want Group=mygroup, got %q", m.Group)
+	}
+	if m.Repo != "myrepo" {
+		t.Errorf("want Repo=myrepo, got %q", m.Repo)
+	}
+	if m.AbsPath != dir {
+		t.Errorf("want AbsPath=%q, got %q", dir, m.AbsPath)
+	}
+	if m.Stack != "go" {
+		t.Errorf("want Stack=go, got %q", m.Stack)
+	}
+	if !m.AgentsMD.Exists {
+		t.Errorf("want AgentsMD.Exists=true")
+	}
+	if m.QualityScore <= 0 {
+		t.Errorf("want positive quality score, got %d", m.QualityScore)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func sliceContains(slice []string, s string) bool {
+	for _, v := range slice {
+		if v == s {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStrPrefix(slice []string, prefix string) bool {
+	for _, v := range slice {
+		if strings.HasPrefix(v, prefix) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -302,6 +302,12 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/admin/groups", s.handleCreateGroup)
 	mux.HandleFunc("POST /api/admin/groups/{group}/repos", s.handleAddRepo)
 
+	// Repo Manifest viewer (#1351) — surface AGENTS.md + .archigraph/ state per repo.
+	// NOTE: the /manifest literal segment must be registered before the /graph wildcard
+	// so Go 1.22 ServeMux prefers the more-specific path.
+	mux.HandleFunc("GET /api/groups/{group}/repos/{repo}/manifest", s.handleRepoManifest)
+	mux.HandleFunc("POST /api/groups/{group}/repos/{repo}/manifest/refresh", s.handleRepoManifestRefresh)
+
 	// --- Phase 1 aggregator endpoints ---
 
 	// First-paint aggregate


### PR DESCRIPTION
## Summary

Adds a **Repo Manifest viewer** API that exposes everything archigraph knows about a repo at a glance — language stack, AGENTS.md status, \`.archigraph/\` state files, dependency manifests, and a 0-100 quality score.

Two new endpoints:
- \`GET /api/groups/{group}/repos/{repo}/manifest\` — full manifest scan
- \`POST /api/groups/{group}/repos/{repo}/manifest/refresh\` — re-scan without full rebuild

Each response includes:
- \`stack\` (dominant) and \`languages\` (all detected, deduplicated)
- \`agents_md\`: exists, filename, \`injected_by_archigraph\` flag, 50-line preview, \`editor_uri\` (\`file://…\`)
- \`archigraph_state\`: file names in the daemon state directory + committed \`.archigraph/\` files
- \`dependency_manifests\`: known lockfiles and manifest files present at root
- \`quality_score\` (0-100) + \`quality_signals\` per-signal breakdown

## Closes / Refs
- Closes #1351

## What changed

| File | Change |
|---|---|
| \`internal/dashboard/handlers_repo_manifest.go\` | New handler + scanning logic |
| \`internal/dashboard/handlers_repo_manifest_test.go\` | 15 unit tests covering all scan functions |
| \`internal/dashboard/server.go\` | Route registration for both new endpoints |

## Beyond the minimum
- \`refresh\` endpoint: re-scan in one POST, no rebuild needed
- 50-line AGENTS.md file preview in response
- \`editor_uri: file://…\` for direct desktop editor links
- Quality score with named signals (not just a raw number)

## Testing
- [x] All manifest-specific tests pass (15/15 PASS)
- [x] Full dashboard suite: 2 pre-existing failures in \`handlers_enrichment_writeback_test.go\` verified on \`main\` before this branch
- [x] \`go build ./internal/dashboard/...\` clean

## Notes

The \`/manifest\` literal path segment is registered before the \`/graph\` wildcard in \`server.go\` so Go 1.22 ServeMux routes correctly. No new dependencies introduced — reuses \`detect.Stack\`, \`daemon.StateDirForRepo\`, and the existing \`fileExists\` helper.