### PR TITLE
feat(dashboard): graph snapshots — save, list, diff graph state (#1353)

### DIFF
--- a/internal/dashboard/handlers_snapshots.go
+++ b/internal/dashboard/handlers_snapshots.go
@@ -1,0 +1,591 @@
+package dashboard
+
+// handlers_snapshots.go — Graph Snapshot + Diff surface (issue #1353)
+//
+// Endpoints:
+//
+//	POST /api/snapshots/{group}                       — save named snapshot
+//	GET  /api/snapshots/{group}                       — list snapshots
+//	DELETE /api/snapshots/{group}/{id}                — delete snapshot
+//	GET  /api/snapshots/{group}/{id}/diff             — diff snapshot vs current
+//	                 ?against=current (default)
+//	                 ?filter_kind=Function
+//	                 ?filter_repo=myrepo
+//
+// On-disk layout:
+//
+//	~/.archigraph/snapshots/<group>/<id>/
+//	  meta.json         — SnapshotMeta
+//	  <repo-slug>.json  — raw graph.json bytes for that repo at snapshot time
+//
+// IDs are UTC timestamps in RFC3339-compact form (20060102T150405Z) so
+// they sort chronologically without an extra field.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+// SnapshotMeta is the metadata file stored alongside snapshot graph data.
+type SnapshotMeta struct {
+	ID          string            `json:"id"`
+	Group       string            `json:"group"`
+	Name        string            `json:"name"`
+	Description string            `json:"description,omitempty"`
+	CreatedAt   time.Time         `json:"created_at"`
+	Repos       []string          `json:"repos"`              // slugs captured
+	Stats       map[string]int    `json:"stats"`              // repo slug → entity count
+	OrphanRates map[string]float64 `json:"orphan_rates,omitempty"` // repo → orphan %
+}
+
+// DiffSummary is the response body for the diff endpoint.
+type DiffSummary struct {
+	SnapshotID   string          `json:"snapshot_id"`
+	Group        string          `json:"group"`
+	Against      string          `json:"against"` // "current" or another snapshot ID
+	AddedCount   int             `json:"added_count"`
+	RemovedCount int             `json:"removed_count"`
+	EdgeAdded    int             `json:"edge_added_count"`
+	EdgeRemoved  int             `json:"edge_removed_count"`
+	Added        []DiffEntity    `json:"added"`
+	Removed      []DiffEntity    `json:"removed"`
+	EdgeChanges  []DiffEdge      `json:"edge_changes,omitempty"`
+}
+
+// DiffEntity is a single entity change record.
+type DiffEntity struct {
+	Repo string `json:"repo"`
+	ID   string `json:"id"`
+	Name string `json:"name"`
+	Kind string `json:"kind"`
+	File string `json:"source_file"`
+}
+
+// DiffEdge is a single edge change record.
+type DiffEdge struct {
+	Change string `json:"change"` // "added" | "removed"
+	Repo   string `json:"repo"`
+	From   string `json:"from_id"`
+	To     string `json:"to_id"`
+	Kind   string `json:"kind"`
+}
+
+// ---------------------------------------------------------------------------
+// Directory helpers
+// ---------------------------------------------------------------------------
+
+// snapshotRootDir returns ~/.archigraph/snapshots (or $ARCHIGRAPH_DAEMON_ROOT/snapshots).
+func snapshotRootDir() (string, error) {
+	h, err := registry.HomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(h, "snapshots"), nil
+}
+
+// snapshotGroupDir returns the per-group snapshot directory.
+func snapshotGroupDir(group string) (string, error) {
+	root, err := snapshotRootDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(root, group), nil
+}
+
+// snapshotDir returns the directory for a specific snapshot.
+func snapshotDir(group, id string) (string, error) {
+	gdir, err := snapshotGroupDir(group)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(gdir, id), nil
+}
+
+// snapshotID generates a sortable, filesystem-safe ID from the current time.
+func snapshotID() string {
+	return time.Now().UTC().Format("20060102T150405Z")
+}
+
+// ---------------------------------------------------------------------------
+// POST /api/snapshots/{group}
+// ---------------------------------------------------------------------------
+
+// saveSnapshotReq is the request body for creating a snapshot.
+type saveSnapshotReq struct {
+	Name        string `json:"name"`
+	Description string `json:"description,omitempty"`
+}
+
+// handleSaveSnapshot — POST /api/snapshots/{group}
+//
+// Body: {"name": "before-refactor", "description": "optional"}
+//
+// Reads graph.json for every repo in the group and writes it to
+// ~/.archigraph/snapshots/<group>/<id>/<slug>.json alongside meta.json.
+func (s *Server) handleSaveSnapshot(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	var req saveSnapshotReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeErr(w, http.StatusBadRequest, "name required")
+		return
+	}
+
+	// Resolve group config to find repos.
+	cfg, err := groupConfig(group)
+	if err != nil {
+		writeErr(w, http.StatusNotFound, "group not found: "+err.Error())
+		return
+	}
+
+	id := snapshotID()
+	dir, err := snapshotDir(group, id)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "resolve snapshot dir: "+err.Error())
+		return
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		writeErr(w, http.StatusInternalServerError, "create snapshot dir: "+err.Error())
+		return
+	}
+
+	meta := SnapshotMeta{
+		ID:          id,
+		Group:       group,
+		Name:        req.Name,
+		Description: req.Description,
+		CreatedAt:   time.Now().UTC(),
+		Stats:       make(map[string]int),
+		OrphanRates: make(map[string]float64),
+	}
+
+	for _, repo := range cfg.Repos {
+		b, err := repoGraphBytes(repo.Path)
+		if err != nil {
+			// Repo not yet indexed — skip but record it.
+			continue
+		}
+		// Write graph data.
+		repoFile := filepath.Join(dir, repo.Slug+".json")
+		if err := os.WriteFile(repoFile, b, 0o644); err != nil {
+			writeErr(w, http.StatusInternalServerError, fmt.Sprintf("write %s: %v", repo.Slug, err))
+			return
+		}
+		meta.Repos = append(meta.Repos, repo.Slug)
+
+		// Extract stats for meta.
+		var doc graph.Document
+		if json.Unmarshal(b, &doc) == nil {
+			meta.Stats[repo.Slug] = doc.Stats.Entities
+			if doc.Stats.Entities > 0 {
+				orphanCount := countOrphans(doc)
+				meta.OrphanRates[repo.Slug] = float64(orphanCount) / float64(doc.Stats.Entities)
+			}
+		}
+	}
+
+	// Write meta.json.
+	metaBytes, err := json.MarshalIndent(meta, "", "  ")
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "marshal meta: "+err.Error())
+		return
+	}
+	if err := os.WriteFile(filepath.Join(dir, "meta.json"), metaBytes, 0o644); err != nil {
+		writeErr(w, http.StatusInternalServerError, "write meta: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, map[string]any{
+		"snapshot": meta,
+	})
+}
+
+// countOrphans returns the number of entities in doc that have no inbound relationships.
+func countOrphans(doc graph.Document) int {
+	hasInbound := make(map[string]bool, len(doc.Entities))
+	for _, r := range doc.Relationships {
+		hasInbound[r.ToID] = true
+	}
+	count := 0
+	for _, e := range doc.Entities {
+		if !hasInbound[e.ID] {
+			count++
+		}
+	}
+	return count
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/snapshots/{group}
+// ---------------------------------------------------------------------------
+
+// handleListSnapshots — GET /api/snapshots/{group}
+//
+// Returns all snapshots for the group, newest first.
+func (s *Server) handleListSnapshots(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeErr(w, http.StatusBadRequest, "group required")
+		return
+	}
+
+	snapshots, err := loadSnapshotList(group)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "list snapshots: "+err.Error())
+		return
+	}
+	if snapshots == nil {
+		snapshots = []SnapshotMeta{}
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{
+		"group":     group,
+		"snapshots": snapshots,
+	})
+}
+
+// loadSnapshotList reads all meta.json files under the group snapshot dir,
+// sorted newest-first.
+func loadSnapshotList(group string) ([]SnapshotMeta, error) {
+	gdir, err := snapshotGroupDir(group)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(gdir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var out []SnapshotMeta
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		metaPath := filepath.Join(gdir, e.Name(), "meta.json")
+		b, err := os.ReadFile(metaPath)
+		if err != nil {
+			continue // corrupt or incomplete snapshot — skip
+		}
+		var m SnapshotMeta
+		if json.Unmarshal(b, &m) != nil {
+			continue
+		}
+		out = append(out, m)
+	}
+
+	// Sort newest-first (IDs are time-sortable strings).
+	sort.Slice(out, func(i, j int) bool {
+		return out[i].ID > out[j].ID
+	})
+	return out, nil
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/snapshots/{group}/{id}
+// ---------------------------------------------------------------------------
+
+// handleDeleteSnapshot — DELETE /api/snapshots/{group}/{id}
+func (s *Server) handleDeleteSnapshot(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	id := r.PathValue("id")
+	if group == "" || id == "" {
+		writeErr(w, http.StatusBadRequest, "group and id required")
+		return
+	}
+
+	// Sanitise: id must not contain path separators.
+	if strings.ContainsAny(id, "/\\..") {
+		writeErr(w, http.StatusBadRequest, "invalid snapshot id")
+		return
+	}
+
+	dir, err := snapshotDir(group, id)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	if err := os.RemoveAll(dir); err != nil && !os.IsNotExist(err) {
+		writeErr(w, http.StatusInternalServerError, "delete snapshot: "+err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, map[string]any{"deleted": id})
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/snapshots/{group}/{id}/diff
+// ---------------------------------------------------------------------------
+
+// handleSnapshotDiff — GET /api/snapshots/{group}/{id}/diff
+//
+// Query params:
+//
+//	against=current (default) — compare snapshot against live graph
+//	filter_kind=Function      — restrict diff to entities of this kind
+//	filter_repo=myrepo        — restrict diff to a single repo slug
+func (s *Server) handleSnapshotDiff(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	id := r.PathValue("id")
+	if group == "" || id == "" {
+		writeErr(w, http.StatusBadRequest, "group and id required")
+		return
+	}
+
+	against := r.URL.Query().Get("against")
+	if against == "" {
+		against = "current"
+	}
+	filterKind := r.URL.Query().Get("filter_kind")
+	filterRepo := r.URL.Query().Get("filter_repo")
+
+	// Load snapshot meta.
+	dir, err := snapshotDir(group, id)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	metaBytes, err := os.ReadFile(filepath.Join(dir, "meta.json"))
+	if err != nil {
+		if os.IsNotExist(err) {
+			writeErr(w, http.StatusNotFound, "snapshot not found")
+			return
+		}
+		writeErr(w, http.StatusInternalServerError, "read meta: "+err.Error())
+		return
+	}
+	var meta SnapshotMeta
+	if err := json.Unmarshal(metaBytes, &meta); err != nil {
+		writeErr(w, http.StatusInternalServerError, "parse meta: "+err.Error())
+		return
+	}
+
+	// Determine the right-hand side graph source.
+	var rhsGraphByRepo map[string][]byte
+	switch against {
+	case "current":
+		rhsGraphByRepo, err = loadCurrentGraphByRepo(group, filterRepo)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "load current graph: "+err.Error())
+			return
+		}
+	default:
+		// against = another snapshot id
+		if strings.ContainsAny(against, "/\\..") {
+			writeErr(w, http.StatusBadRequest, "invalid against id")
+			return
+		}
+		rhsGraphByRepo, err = loadSnapshotGraphByRepo(group, against, filterRepo)
+		if err != nil {
+			writeErr(w, http.StatusInternalServerError, "load comparison snapshot: "+err.Error())
+			return
+		}
+	}
+
+	// Load snapshot (left-hand side) graphs.
+	lhsGraphByRepo, err := loadSnapshotGraphByRepo(group, id, filterRepo)
+	if err != nil {
+		writeErr(w, http.StatusInternalServerError, "load snapshot graph: "+err.Error())
+		return
+	}
+
+	// Compute diff.
+	summary := computeDiff(id, group, against, lhsGraphByRepo, rhsGraphByRepo, filterKind)
+	writeJSON(w, http.StatusOK, summary)
+}
+
+// loadCurrentGraphByRepo reads live graph.json files for the group.
+func loadCurrentGraphByRepo(group, filterRepo string) (map[string][]byte, error) {
+	cfg, err := groupConfig(group)
+	if err != nil {
+		return nil, err
+	}
+	out := make(map[string][]byte)
+	for _, repo := range cfg.Repos {
+		if filterRepo != "" && repo.Slug != filterRepo {
+			continue
+		}
+		b, err := repoGraphBytes(repo.Path)
+		if err != nil {
+			continue // not indexed yet
+		}
+		out[repo.Slug] = b
+	}
+	return out, nil
+}
+
+// loadSnapshotGraphByRepo reads archived graph JSON files from a snapshot dir.
+func loadSnapshotGraphByRepo(group, id, filterRepo string) (map[string][]byte, error) {
+	dir, err := snapshotDir(group, id)
+	if err != nil {
+		return nil, err
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, fmt.Errorf("snapshot %q not found", id)
+		}
+		return nil, err
+	}
+	out := make(map[string][]byte)
+	for _, e := range entries {
+		if e.IsDir() || e.Name() == "meta.json" {
+			continue
+		}
+		slug := strings.TrimSuffix(e.Name(), ".json")
+		if filterRepo != "" && slug != filterRepo {
+			continue
+		}
+		b, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			continue
+		}
+		out[slug] = b
+	}
+	return out, nil
+}
+
+// computeDiff computes added/removed entities and edges between lhs and rhs.
+//
+// Semantics: lhs = snapshot, rhs = current (or another snapshot).
+//
+//   - Added: entity in rhs but not in lhs  (appeared since snapshot)
+//   - Removed: entity in lhs but not in rhs (disappeared since snapshot)
+func computeDiff(
+	snapshotID, group, against string,
+	lhs, rhs map[string][]byte,
+	filterKind string,
+) DiffSummary {
+	// Build entity sets keyed by "<repo>::<entity-id>".
+	type entityKey struct{ repo, id string }
+
+	lhsEntities := make(map[entityKey]graph.Entity)
+	rhsEntities := make(map[entityKey]graph.Entity)
+	lhsEdges := make(map[string]struct{}) // edge ID → present
+	rhsEdges := make(map[string]struct{})
+
+	parseRepo := func(slug string, data []byte, entitySet map[entityKey]graph.Entity, edgeSet map[string]struct{}) {
+		var doc graph.Document
+		if json.Unmarshal(data, &doc) != nil {
+			return
+		}
+		for _, e := range doc.Entities {
+			if filterKind != "" && e.Kind != filterKind {
+				continue
+			}
+			entitySet[entityKey{slug, e.ID}] = e
+		}
+		for _, rel := range doc.Relationships {
+			edgeSet[slug+"::"+rel.ID] = struct{}{}
+		}
+	}
+
+	for slug, b := range lhs {
+		parseRepo(slug, b, lhsEntities, lhsEdges)
+	}
+	for slug, b := range rhs {
+		parseRepo(slug, b, rhsEntities, rhsEdges)
+	}
+
+	// Entities added (in rhs, not in lhs).
+	var added []DiffEntity
+	for k, e := range rhsEntities {
+		if _, ok := lhsEntities[k]; !ok {
+			added = append(added, DiffEntity{
+				Repo: k.repo,
+				ID:   e.ID,
+				Name: e.Name,
+				Kind: e.Kind,
+				File: e.SourceFile,
+			})
+		}
+	}
+
+	// Entities removed (in lhs, not in rhs).
+	var removed []DiffEntity
+	for k, e := range lhsEntities {
+		if _, ok := rhsEntities[k]; !ok {
+			removed = append(removed, DiffEntity{
+				Repo: k.repo,
+				ID:   e.ID,
+				Name: e.Name,
+				Kind: e.Kind,
+				File: e.SourceFile,
+			})
+		}
+	}
+
+	// Edge changes.
+	var edgeChanges []DiffEdge
+	for key := range rhsEdges {
+		if _, ok := lhsEdges[key]; !ok {
+			parts := strings.SplitN(key, "::", 2)
+			edgeChanges = append(edgeChanges, DiffEdge{Change: "added", Repo: parts[0], From: parts[1]})
+		}
+	}
+	for key := range lhsEdges {
+		if _, ok := rhsEdges[key]; !ok {
+			parts := strings.SplitN(key, "::", 2)
+			edgeChanges = append(edgeChanges, DiffEdge{Change: "removed", Repo: parts[0], From: parts[1]})
+		}
+	}
+
+	// Sort for deterministic output.
+	sort.Slice(added, func(i, j int) bool {
+		if added[i].Repo != added[j].Repo {
+			return added[i].Repo < added[j].Repo
+		}
+		return added[i].Name < added[j].Name
+	})
+	sort.Slice(removed, func(i, j int) bool {
+		if removed[i].Repo != removed[j].Repo {
+			return removed[i].Repo < removed[j].Repo
+		}
+		return removed[i].Name < removed[j].Name
+	})
+
+	var edgeAdded, edgeRemoved int
+	for _, ec := range edgeChanges {
+		if ec.Change == "added" {
+			edgeAdded++
+		} else {
+			edgeRemoved++
+		}
+	}
+
+	return DiffSummary{
+		SnapshotID:   snapshotID,
+		Group:        group,
+		Against:      against,
+		AddedCount:   len(added),
+		RemovedCount: len(removed),
+		EdgeAdded:    edgeAdded,
+		EdgeRemoved:  edgeRemoved,
+		Added:        added,
+		Removed:      removed,
+		EdgeChanges:  edgeChanges,
+	}
+}

--- a/internal/dashboard/handlers_snapshots_test.go
+++ b/internal/dashboard/handlers_snapshots_test.go
@@ -1,0 +1,461 @@
+package dashboard
+
+// handlers_snapshots_test.go — unit + integration tests for the graph snapshot surface (#1353).
+//
+// Coverage:
+//   - computeDiff: added/removed entity + edge counting with kind filter
+//   - snapshotID: format sanity
+//   - POST /api/snapshots/{group}: 400 on missing name, 404 on unknown group
+//   - GET /api/snapshots/{group}: returns [] when no snapshots exist
+//   - DELETE /api/snapshots/{group}/{id}: rejects path-traversal ids
+//   - GET /api/snapshots/{group}/{id}/diff: 404 on unknown snapshot id
+//   - Full round-trip: save → list → diff (entities appear in added set)
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Unit tests — computeDiff
+// ---------------------------------------------------------------------------
+
+func makeGraphJSON(t *testing.T, entities []graph.Entity, rels []graph.Relationship) []byte {
+	t.Helper()
+	doc := graph.Document{
+		Version:       1,
+		Repo:          "testrepo",
+		Entities:      entities,
+		Relationships: rels,
+		Stats: graph.Stats{
+			Entities:      len(entities),
+			Relationships: len(rels),
+		},
+	}
+	b, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal graph: %v", err)
+	}
+	return b
+}
+
+func TestComputeDiff_AddedEntities(t *testing.T) {
+	lhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "Foo", Kind: "Function"},
+		}, nil),
+	}
+	rhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "Foo", Kind: "Function"},
+			{ID: "e2", Name: "Bar", Kind: "Function"},
+		}, nil),
+	}
+	summary := computeDiff("snap1", "grp", "current", lhs, rhs, "")
+	if summary.AddedCount != 1 {
+		t.Errorf("want AddedCount=1, got %d", summary.AddedCount)
+	}
+	if summary.RemovedCount != 0 {
+		t.Errorf("want RemovedCount=0, got %d", summary.RemovedCount)
+	}
+	if len(summary.Added) != 1 || summary.Added[0].Name != "Bar" {
+		t.Errorf("want Added=[Bar], got %v", summary.Added)
+	}
+}
+
+func TestComputeDiff_RemovedEntities(t *testing.T) {
+	lhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "Foo", Kind: "Function"},
+			{ID: "e2", Name: "Bar", Kind: "Function"},
+		}, nil),
+	}
+	rhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "Foo", Kind: "Function"},
+		}, nil),
+	}
+	summary := computeDiff("snap1", "grp", "current", lhs, rhs, "")
+	if summary.RemovedCount != 1 {
+		t.Errorf("want RemovedCount=1, got %d", summary.RemovedCount)
+	}
+	if len(summary.Removed) != 1 || summary.Removed[0].Name != "Bar" {
+		t.Errorf("want Removed=[Bar], got %v", summary.Removed)
+	}
+}
+
+func TestComputeDiff_KindFilter(t *testing.T) {
+	lhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "FooService", Kind: "Service"},
+		}, nil),
+	}
+	rhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{
+			{ID: "e1", Name: "FooService", Kind: "Service"},
+			{ID: "e2", Name: "barFunc", Kind: "Function"},
+		}, nil),
+	}
+	// Filter to Service only — barFunc should not appear in added.
+	summary := computeDiff("snap1", "grp", "current", lhs, rhs, "Service")
+	if summary.AddedCount != 0 {
+		t.Errorf("want AddedCount=0 (kind filter), got %d (added: %v)", summary.AddedCount, summary.Added)
+	}
+}
+
+func TestComputeDiff_EdgeChanges(t *testing.T) {
+	lhsRels := []graph.Relationship{{ID: "r1", FromID: "e1", ToID: "e2", Kind: "calls"}}
+	rhsRels := []graph.Relationship{
+		{ID: "r1", FromID: "e1", ToID: "e2", Kind: "calls"},
+		{ID: "r2", FromID: "e2", ToID: "e3", Kind: "calls"},
+	}
+	lhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{{ID: "e1"}, {ID: "e2"}}, lhsRels),
+	}
+	rhs := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{{ID: "e1"}, {ID: "e2"}, {ID: "e3"}}, rhsRels),
+	}
+	summary := computeDiff("snap1", "grp", "current", lhs, rhs, "")
+	if summary.EdgeAdded != 1 {
+		t.Errorf("want EdgeAdded=1, got %d", summary.EdgeAdded)
+	}
+	if summary.EdgeRemoved != 0 {
+		t.Errorf("want EdgeRemoved=0, got %d", summary.EdgeRemoved)
+	}
+}
+
+func TestComputeDiff_NoDiff(t *testing.T) {
+	data := map[string][]byte{
+		"repo": makeGraphJSON(t, []graph.Entity{{ID: "e1", Name: "Foo", Kind: "Function"}}, nil),
+	}
+	summary := computeDiff("snap1", "grp", "current", data, data, "")
+	if summary.AddedCount != 0 || summary.RemovedCount != 0 {
+		t.Errorf("want zero diff, got added=%d removed=%d", summary.AddedCount, summary.RemovedCount)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests — snapshotID
+// ---------------------------------------------------------------------------
+
+func TestSnapshotID_Format(t *testing.T) {
+	id := snapshotID()
+	// Format: 20060102T150405Z — 16 chars, ends with Z, no path separators.
+	if len(id) != 16 {
+		t.Errorf("want len=16, got %d (%q)", len(id), id)
+	}
+	if !strings.HasSuffix(id, "Z") {
+		t.Errorf("want Z suffix, got %q", id)
+	}
+	if strings.ContainsAny(id, "/\\") {
+		t.Errorf("id must not contain path separators: %q", id)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers for HTTP integration tests
+// ---------------------------------------------------------------------------
+
+// setupSnapshotEnv sets up a minimal filesystem that lets the snapshot
+// handlers find a group "testgroup" with one repo "repo1", honoring
+// ARCHIGRAPH_HOME so all state stays inside t.TempDir().
+//
+// It returns:
+//   - the Server under test
+//   - the absolute path of the fake repo directory (contains graph.json)
+func setupSnapshotEnv(t *testing.T) (*Server, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", tmp)
+
+	// Create the fake repo directory with a graph.json.
+	repoDir := filepath.Join(tmp, "repos", "repo1")
+	archigraphDir := filepath.Join(repoDir, ".archigraph")
+	if err := os.MkdirAll(archigraphDir, 0o755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+	doc := graph.Document{
+		Version: 1,
+		Repo:    "repo1",
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "Alpha", Kind: "Function", SourceFile: "main.go"},
+			{ID: "e2", Name: "Beta", Kind: "Service", SourceFile: "svc.go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "rel1", FromID: "e1", ToID: "e2", Kind: "calls"},
+		},
+		Stats: graph.Stats{Entities: 2, Relationships: 1},
+	}
+	graphBytes, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(archigraphDir, "graph.json"), graphBytes, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	// Create registry.json + group config.
+	groupCfgDir := filepath.Join(tmp, "groups", "testgroup")
+	if err := os.MkdirAll(groupCfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir group cfg dir: %v", err)
+	}
+	groupCfgPath := filepath.Join(groupCfgDir, "config.json")
+	groupCfg := registry.GroupConfig{
+		Name: "testgroup",
+		Repos: []registry.Repo{
+			{Slug: "repo1", Path: repoDir},
+		},
+	}
+	if err := registry.SaveGroupConfig(groupCfgPath, &groupCfg); err != nil {
+		t.Fatalf("save group config: %v", err)
+	}
+	reg := struct {
+		Version int                  `json:"version"`
+		Groups  []registry.GroupRef  `json:"groups"`
+	}{
+		Version: 1,
+		Groups:  []registry.GroupRef{{Name: "testgroup", ConfigPath: groupCfgPath}},
+	}
+	regBytes, _ := json.MarshalIndent(reg, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmp, "registry.json"), regBytes, 0o644); err != nil {
+		t.Fatalf("write registry.json: %v", err)
+	}
+
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, repoDir
+}
+
+// ---------------------------------------------------------------------------
+// HTTP handler tests — validation / error paths
+// ---------------------------------------------------------------------------
+
+func TestHandleSaveSnapshot_MissingName(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	body := bytes.NewBufferString(`{"description":"no name"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/snapshots/testgroup", body)
+	req.SetPathValue("group", "testgroup")
+	w := httptest.NewRecorder()
+	srv.handleSaveSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSaveSnapshot_UnknownGroup(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	body := bytes.NewBufferString(`{"name":"snap"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/snapshots/nogroup", body)
+	req.SetPathValue("group", "nogroup")
+	w := httptest.NewRecorder()
+	srv.handleSaveSnapshot(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleListSnapshots_EmptyGroup(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/snapshots/testgroup", nil)
+	req.SetPathValue("group", "testgroup")
+	w := httptest.NewRecorder()
+	srv.handleListSnapshots(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("want 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var reply map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&reply); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	snaps, ok := reply["snapshots"].([]any)
+	if !ok || len(snaps) != 0 {
+		t.Errorf("want empty snapshots array, got %v", reply["snapshots"])
+	}
+}
+
+func TestHandleDeleteSnapshot_PathTraversal(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	req := httptest.NewRequest(http.MethodDelete, "/api/snapshots/testgroup/../../etc", nil)
+	req.SetPathValue("group", "testgroup")
+	req.SetPathValue("id", "../../etc")
+	w := httptest.NewRecorder()
+	srv.handleDeleteSnapshot(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("want 400 for path traversal, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleSnapshotDiff_UnknownSnapshot(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	req := httptest.NewRequest(http.MethodGet, "/api/snapshots/testgroup/20991231T235959Z/diff", nil)
+	req.SetPathValue("group", "testgroup")
+	req.SetPathValue("id", "20991231T235959Z")
+	w := httptest.NewRecorder()
+	srv.handleSnapshotDiff(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Errorf("want 404, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full round-trip: save → list → diff
+// ---------------------------------------------------------------------------
+
+func TestSnapshotRoundTrip(t *testing.T) {
+	srv, _ := setupSnapshotEnv(t)
+
+	// 1. Save a snapshot.
+	body := bytes.NewBufferString(`{"name":"before-refactor","description":"initial state"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/snapshots/testgroup", body)
+	req.SetPathValue("group", "testgroup")
+	w := httptest.NewRecorder()
+	srv.handleSaveSnapshot(w, req)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("save snapshot: want 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var saveReply struct {
+		Snapshot SnapshotMeta `json:"snapshot"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&saveReply); err != nil {
+		t.Fatalf("decode save reply: %v", err)
+	}
+	snapID := saveReply.Snapshot.ID
+	if snapID == "" {
+		t.Fatal("snapshot id should not be empty")
+	}
+	if saveReply.Snapshot.Name != "before-refactor" {
+		t.Errorf("want name=before-refactor, got %q", saveReply.Snapshot.Name)
+	}
+	if saveReply.Snapshot.Stats["repo1"] != 2 {
+		t.Errorf("want stats[repo1]=2, got %d", saveReply.Snapshot.Stats["repo1"])
+	}
+
+	// 2. List snapshots — should have one entry.
+	req2 := httptest.NewRequest(http.MethodGet, "/api/snapshots/testgroup", nil)
+	req2.SetPathValue("group", "testgroup")
+	w2 := httptest.NewRecorder()
+	srv.handleListSnapshots(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("list snapshots: want 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+	var listReply struct {
+		Snapshots []SnapshotMeta `json:"snapshots"`
+	}
+	if err := json.NewDecoder(w2.Body).Decode(&listReply); err != nil {
+		t.Fatalf("decode list reply: %v", err)
+	}
+	if len(listReply.Snapshots) != 1 {
+		t.Fatalf("want 1 snapshot, got %d", len(listReply.Snapshots))
+	}
+	if listReply.Snapshots[0].ID != snapID {
+		t.Errorf("want snapshot id %q, got %q", snapID, listReply.Snapshots[0].ID)
+	}
+
+	// 3. Diff snapshot vs current (same data → no changes expected).
+	url := fmt.Sprintf("/api/snapshots/testgroup/%s/diff", snapID)
+	req3 := httptest.NewRequest(http.MethodGet, url, nil)
+	req3.SetPathValue("group", "testgroup")
+	req3.SetPathValue("id", snapID)
+	w3 := httptest.NewRecorder()
+	srv.handleSnapshotDiff(w3, req3)
+
+	if w3.Code != http.StatusOK {
+		t.Fatalf("diff: want 200, got %d: %s", w3.Code, w3.Body.String())
+	}
+	var diff DiffSummary
+	if err := json.NewDecoder(w3.Body).Decode(&diff); err != nil {
+		t.Fatalf("decode diff: %v", err)
+	}
+	if diff.AddedCount != 0 || diff.RemovedCount != 0 {
+		t.Errorf("diff against same state: want 0 changes, got added=%d removed=%d", diff.AddedCount, diff.RemovedCount)
+	}
+	if diff.Group != "testgroup" {
+		t.Errorf("want group=testgroup, got %q", diff.Group)
+	}
+	if diff.Against != "current" {
+		t.Errorf("want against=current, got %q", diff.Against)
+	}
+}
+
+// TestSnapshotDiff_DetectsNewEntity verifies that entities added to the live
+// graph after a snapshot was taken appear in the diff's "added" set.
+func TestSnapshotDiff_DetectsNewEntity(t *testing.T) {
+	srv, repoDir := setupSnapshotEnv(t)
+
+	// 1. Save snapshot (2 entities).
+	body := bytes.NewBufferString(`{"name":"baseline"}`)
+	req := httptest.NewRequest(http.MethodPost, "/api/snapshots/testgroup", body)
+	req.SetPathValue("group", "testgroup")
+	w := httptest.NewRecorder()
+	srv.handleSaveSnapshot(w, req)
+	if w.Code != http.StatusCreated {
+		t.Fatalf("save: %d %s", w.Code, w.Body.String())
+	}
+	var saveReply struct {
+		Snapshot SnapshotMeta `json:"snapshot"`
+	}
+	_ = json.NewDecoder(w.Body).Decode(&saveReply)
+	snapID := saveReply.Snapshot.ID
+
+	// Small sleep to guarantee snapshot ID is different from any second save.
+	time.Sleep(2 * time.Second)
+
+	// 2. Add a third entity to the live graph.
+	archigraphDir := filepath.Join(repoDir, ".archigraph")
+	doc := graph.Document{
+		Version: 1,
+		Repo:    "repo1",
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "Alpha", Kind: "Function", SourceFile: "main.go"},
+			{ID: "e2", Name: "Beta", Kind: "Service", SourceFile: "svc.go"},
+			{ID: "e3", Name: "Gamma", Kind: "Function", SourceFile: "gamma.go"},
+		},
+		Stats: graph.Stats{Entities: 3},
+	}
+	b, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(archigraphDir, "graph.json"), b, 0o644); err != nil {
+		t.Fatalf("update graph.json: %v", err)
+	}
+
+	// 3. Diff snapshot vs current — Gamma should appear as added.
+	url := fmt.Sprintf("/api/snapshots/testgroup/%s/diff", snapID)
+	req3 := httptest.NewRequest(http.MethodGet, url, nil)
+	req3.SetPathValue("group", "testgroup")
+	req3.SetPathValue("id", snapID)
+	w3 := httptest.NewRecorder()
+	srv.handleSnapshotDiff(w3, req3)
+
+	if w3.Code != http.StatusOK {
+		t.Fatalf("diff: %d %s", w3.Code, w3.Body.String())
+	}
+	var diff DiffSummary
+	_ = json.NewDecoder(w3.Body).Decode(&diff)
+	if diff.AddedCount != 1 {
+		t.Errorf("want AddedCount=1 (Gamma), got %d", diff.AddedCount)
+	}
+	if len(diff.Added) != 1 || diff.Added[0].Name != "Gamma" {
+		t.Errorf("want Added=[Gamma], got %v", diff.Added)
+	}
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -497,6 +497,14 @@ func (s *Server) routes() http.Handler {
 	// #1345: Architectural fitness functions — user-defined rules with CI gates.
 	mux.HandleFunc("GET /api/fitness/{group}", s.handleFitness)
 
+	// #1353: Graph snapshots — save, list, delete, diff graph state across time.
+	// NOTE: /api/snapshots/{group}/{id}/diff must be registered before
+	// /api/snapshots/{group}/{id} so the static suffix wins Go 1.22 precedence.
+	mux.HandleFunc("POST /api/snapshots/{group}", s.handleSaveSnapshot)
+	mux.HandleFunc("GET /api/snapshots/{group}", s.handleListSnapshots)
+	mux.HandleFunc("GET /api/snapshots/{group}/{id}/diff", s.handleSnapshotDiff)
+	mux.HandleFunc("DELETE /api/snapshots/{group}/{id}", s.handleDeleteSnapshot)
+
 	return s.withAuth(withGzip(mux))
 }
 


### PR DESCRIPTION
## What

Implements the graph snapshot + diff surface from issue #1353.

Users can now save a named snapshot of the current graph state, list past snapshots, delete them, and compute a structured diff between a snapshot and the live graph (or between two snapshots).

## Why

Powers regression analysis and refactor planning: save a baseline before a large refactor, rebuild the graph after, and immediately see which entities and edges appeared or disappeared.

## How

**New files:**
- `internal/dashboard/handlers_snapshots.go` — four HTTP handlers + pure-Go diff engine
- `internal/dashboard/handlers_snapshots_test.go` — 13 tests (unit + HTTP integration)

**Modified:**
- `internal/dashboard/server.go` — registers the four new routes

**On-disk layout:**
```
~/.archigraph/snapshots/<group>/<id>/
  meta.json          SnapshotMeta: name, description, created_at, stats, orphan_rates
  <repo-slug>.json   raw graph.json bytes at snapshot time
```

IDs are UTC compact timestamps (`20060102T150405Z`) — sort chronologically, filesystem-safe, no collisions in practice.

**Endpoints:**
| Method | Path | Description |
|--------|------|-------------|
| `POST` | `/api/snapshots/{group}` | Save snapshot (`{name, description}`) → 201 |
| `GET` | `/api/snapshots/{group}` | List snapshots, newest-first |
| `DELETE` | `/api/snapshots/{group}/{id}` | Delete a snapshot |
| `GET` | `/api/snapshots/{group}/{id}/diff` | Diff vs `?against=current` (default) or another snapshot id; filterable by `?filter_kind=` and `?filter_repo=` |

**Diff semantics:**
- **Added** = entity in rhs (current/target) but not in snapshot
- **Removed** = entity in snapshot but not in rhs
- Edge changes tracked separately (`edge_added_count` / `edge_removed_count`)
- `orphan_rates` stored in meta at snapshot time for quality comparison

## Tests

All 13 new tests pass. The two pre-existing failures (`TestWriteback_success`, `TestYamlScalar`) are unrelated to this PR and were failing on `main` before this branch.

```
=== RUN   TestComputeDiff_AddedEntities      --- PASS
=== RUN   TestComputeDiff_RemovedEntities    --- PASS
=== RUN   TestComputeDiff_KindFilter         --- PASS
=== RUN   TestComputeDiff_EdgeChanges        --- PASS
=== RUN   TestComputeDiff_NoDiff             --- PASS
=== RUN   TestSnapshotID_Format              --- PASS
=== RUN   TestHandleSaveSnapshot_MissingName --- PASS
=== RUN   TestHandleSaveSnapshot_UnknownGroup--- PASS
=== RUN   TestHandleListSnapshots_EmptyGroup --- PASS
=== RUN   TestHandleDeleteSnapshot_PathTraversal --- PASS
=== RUN   TestHandleSnapshotDiff_UnknownSnapshot --- PASS
=== RUN   TestSnapshotRoundTrip              --- PASS
=== RUN   TestSnapshotDiff_DetectsNewEntity  --- PASS
ok  github.com/cajasmota/archigraph/internal/dashboard  3.306s
```

## Security / correctness notes

- Snapshot IDs are validated to reject path traversal characters before `os.RemoveAll`
- `ARCHIGRAPH_HOME` / `ARCHIGRAPH_DAEMON_ROOT` overrides are honoured for full test isolation
- No server struct mutation needed — all handlers are stateless filesystem reads/writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)