### PR TITLE
feat(graph): tunable node sizing — base + per-tier multipliers in sidebar

### DIFF
--- a/dashboard/smoke-node-sizing-1360.mjs
+++ b/dashboard/smoke-node-sizing-1360.mjs
@@ -1,0 +1,211 @@
+/**
+ * Headless smoke test for #1360 — Tunable node sizing.
+ *
+ *   - Sidebar shows "Node sizing" collapsible section
+ *   - Expanding it shows base size input + 6 tier multiplier rows
+ *   - Editing base size persists to localStorage
+ *   - Editing tier multiplier persists to localStorage
+ *   - Reset to defaults button appears when values are custom
+ *   - Reset restores original values
+ *   - 0 relevant console errors
+ *
+ * Usage: node smoke-node-sizing-1360.mjs <port>
+ */
+
+import { chromium } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const PORT = process.argv[2] ?? '5533'
+const BASE = `http://127.0.0.1:${PORT}`
+const GRAPH_URL = `${BASE}/graph/upvate`
+const SCREENSHOTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'smoke-screenshots-node-sizing-1360')
+
+fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true })
+
+function screenshot(page, name) {
+  const p = path.join(SCREENSHOTS_DIR, name)
+  return page.screenshot({ path: p, fullPage: false }).then(() => {
+    console.log(`  screenshot → ${p}`)
+    return p
+  })
+}
+
+const results = []
+function assert(name, condition, detail = '') {
+  results.push({ name, pass: !!condition })
+  if (condition) {
+    console.log(`  ✓ ${name}`)
+  } else {
+    console.log(`  ✗ ${name}${detail ? ` — ${detail}` : ''}`)
+  }
+}
+
+const browser = await chromium.launch({ headless: true })
+const page = await browser.newPage()
+
+const consoleErrors = []
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text())
+})
+
+// ── Step 1: Navigate to /graph/upvate ────────────────────────────────────────
+console.log('\n── Step 1: Navigate ─────────────────────────────────────────────────')
+await page.goto(GRAPH_URL, { waitUntil: 'domcontentloaded', timeout: 30000 })
+await page.waitForTimeout(5000)
+await screenshot(page, 'ss-01-initial.png')
+
+// ── Step 2: Sidebar visible and Node sizing section present ───────────────────
+console.log('\n── Step 2: Node sizing section in sidebar ───────────────────────────')
+
+const sidebar = page.locator('[aria-label="Graph filters sidebar"]')
+const sidebarVisible = await sidebar.isVisible()
+assert('sidebar is visible', sidebarVisible)
+
+const nodeSizingToggle = page.locator('[aria-controls="node-sizing-body"]')
+const sizingToggleVisible = await nodeSizingToggle.isVisible()
+assert('Node sizing collapsible button is visible', sizingToggleVisible)
+
+await screenshot(page, 'ss-02-sidebar-collapsed.png')
+
+// ── Step 3: Expand the Node sizing section ────────────────────────────────────
+console.log('\n── Step 3: Expand Node sizing ────────────────────────────────────────')
+await nodeSizingToggle.click()
+await page.waitForTimeout(300)
+
+const sizingBody = page.locator('[data-testid="node-sizing-body"]')
+const bodyVisible = await sizingBody.isVisible()
+assert('Node sizing body expands on click', bodyVisible)
+
+await screenshot(page, 'ss-03-expanded.png')
+
+// ── Step 4: Verify base size input ────────────────────────────────────────────
+console.log('\n── Step 4: Base size input ───────────────────────────────────────────')
+const baseSizeInput = page.locator('[aria-label="Base node size in pixels"]')
+const baseSizeVisible = await baseSizeInput.isVisible()
+assert('Base size input is visible', baseSizeVisible)
+
+const baseSizeValue = await baseSizeInput.inputValue()
+assert(`Base size default is 10 (got ${baseSizeValue})`, baseSizeValue === '10')
+
+// ── Step 5: Verify 6 tier multiplier inputs ───────────────────────────────────
+console.log('\n── Step 5: Tier multiplier inputs ────────────────────────────────────')
+const tierInputs = page.locator('[aria-label^="Tier "][aria-label$="size multiplier"]')
+const tierCount = await tierInputs.count()
+assert(`6 tier multiplier inputs visible (found ${tierCount})`, tierCount === 6)
+
+// Check defaults
+const expectedDefaults = ['1', '1.5', '2', '3', '5', '10']
+for (let i = 0; i < 6; i++) {
+  const val = await tierInputs.nth(i).inputValue()
+  assert(`Tier ${i + 1} default multiplier = ${expectedDefaults[i]} (got ${val})`, val === expectedDefaults[i])
+}
+
+// ── Step 6: Edit base size (10 → 5) ──────────────────────────────────────────
+console.log('\n── Step 6: Edit base size 10 → 5 ────────────────────────────────────')
+await baseSizeInput.click({ clickCount: 3 })
+await baseSizeInput.fill('5')
+await baseSizeInput.press('Enter')
+await page.waitForTimeout(500)
+
+// Verify localStorage persisted
+const storedAfterBaseEdit = await page.evaluate(() => {
+  try { return localStorage.getItem('archigraph:graph:sizing') } catch { return null }
+})
+let parsed = null
+try { parsed = JSON.parse(storedAfterBaseEdit ?? 'null') } catch { /* empty */ }
+assert('localStorage updated after base size edit', !!parsed)
+assert(`localStorage.baseSize = 5 (got ${parsed?.baseSize})`, parsed?.baseSize === 5)
+
+await screenshot(page, 'ss-04-base-edited.png')
+
+// Reset-to-defaults button should now be active
+const resetBtn = page.locator('[aria-label="Reset node sizing to defaults"]')
+const resetBtnEnabled = !(await resetBtn.isDisabled())
+assert('Reset button enabled when values differ from defaults', resetBtnEnabled)
+
+// ── Step 7: Edit tier 6 multiplier (10 → 20) ─────────────────────────────────
+console.log('\n── Step 7: Edit tier 6 multiplier 10 → 20 ───────────────────────────')
+const tier6Input = tierInputs.nth(5)
+await tier6Input.click({ clickCount: 3 })
+await tier6Input.fill('20')
+await tier6Input.press('Enter')
+await page.waitForTimeout(500)
+
+const storedAfterTierEdit = await page.evaluate(() => {
+  try { return localStorage.getItem('archigraph:graph:sizing') } catch { return null }
+})
+let parsed2 = null
+try { parsed2 = JSON.parse(storedAfterTierEdit ?? 'null') } catch { /* empty */ }
+assert('localStorage updated after tier 6 edit', !!parsed2)
+assert(`localStorage.multipliers[5] = 20 (got ${parsed2?.multipliers?.[5]})`, parsed2?.multipliers?.[5] === 20)
+
+await screenshot(page, 'ss-05-tier-edited.png')
+
+// ── Step 8: Reset to defaults ─────────────────────────────────────────────────
+console.log('\n── Step 8: Reset to defaults ────────────────────────────────────────')
+await resetBtn.click()
+await page.waitForTimeout(500)
+
+const baseSizeAfterReset = await baseSizeInput.inputValue()
+assert(`Base size restored to 10 after reset (got ${baseSizeAfterReset})`, baseSizeAfterReset === '10')
+
+const tier6AfterReset = await tier6Input.inputValue()
+assert(`Tier 6 multiplier restored to 10 after reset (got ${tier6AfterReset})`, tier6AfterReset === '10')
+
+const storedAfterReset = await page.evaluate(() => {
+  try { return localStorage.getItem('archigraph:graph:sizing') } catch { return null }
+})
+let parsed3 = null
+try { parsed3 = JSON.parse(storedAfterReset ?? 'null') } catch { /* empty */ }
+assert('localStorage updated to defaults after reset', parsed3?.baseSize === 10 && parsed3?.multipliers?.[5] === 10)
+
+await screenshot(page, 'ss-06-after-reset.png')
+
+// ── Step 9: Reload — values persist ───────────────────────────────────────────
+console.log('\n── Step 9: Persistence across reload ────────────────────────────────')
+// Set a custom value, reload, verify it survives
+await baseSizeInput.click({ clickCount: 3 })
+await baseSizeInput.fill('15')
+await baseSizeInput.press('Enter')
+await page.waitForTimeout(400)
+
+await page.reload({ waitUntil: 'domcontentloaded', timeout: 30000 })
+await page.waitForTimeout(2000)
+
+// Re-expand sidebar section after reload
+const nodeSizingToggleAfterReload = page.locator('[aria-controls="node-sizing-body"]')
+await nodeSizingToggleAfterReload.click()
+await page.waitForTimeout(300)
+
+const baseSizeAfterReload = await page.locator('[aria-label="Base node size in pixels"]').inputValue()
+assert(`Base size survives reload (got ${baseSizeAfterReload})`, baseSizeAfterReload === '15')
+
+await screenshot(page, 'ss-07-after-reload.png')
+
+// ── Step 10: Console errors ───────────────────────────────────────────────────
+console.log('\n── Step 10: Console error check ─────────────────────────────────────')
+const relevantErrors = consoleErrors.filter(e =>
+  !e.includes('GPU stall') &&
+  !e.includes('WebGL') &&
+  !e.includes('ReadPixels') &&
+  !e.includes('net::ERR') &&
+  !e.includes('DuckDB') &&
+  !e.includes('Abort') &&
+  !e.includes('503') &&
+  !e.includes('Failed to load resource') &&
+  !e.includes('Service Unavailable')
+)
+assert('no relevant console errors', relevantErrors.length === 0,
+  relevantErrors.length > 0 ? relevantErrors.slice(0, 3).join(' | ') : 'clean')
+
+// ── Summary ───────────────────────────────────────────────────────────────────
+console.log('\n══ SMOKE TEST SUMMARY ══════════════════════════════════════════════')
+const passed = results.filter(r => r.pass).length
+const failed = results.filter(r => !r.pass).length
+results.forEach(r => console.log(`  ${r.pass ? '✓' : '✗'} ${r.name}`))
+console.log(`\n  ${passed}/${results.length} passed — Screenshots in: ${SCREENSHOTS_DIR}`)
+
+await browser.close()
+process.exit(failed === 0 ? 0 : 1)

--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -8,6 +8,11 @@ import { useGraphCameraStore } from '@/store/graphCameraStore'
 import type { ColorMode } from '@/hooks/graph/useColorMode'
 import type { SimulationConfig } from '@/hooks/graph/useSimulationConfig'
 import { SILK_ROAD_DEFAULTS } from '@/hooks/graph/useSimulationConfig'
+import type { NodeSizingConfig } from '@/hooks/graph/useNodeSizingConfig'
+import {
+  buildDegreePercentileFn,
+  computeTunedSize,
+} from '@/hooks/graph/useNodeSizingConfig'
 
 // ---------------------------------------------------------------------------
 // Semantic layout helpers (#1072 / #1106 repo-first layout)
@@ -324,6 +329,11 @@ export interface GraphCanvasProps {
    * to pass the flat [x0,y0,x1,y1,...] node positions to the minimap.
    */
   onNodePositions?: (positions: Float32Array | number[]) => void
+  /**
+   * #1360: Tunable node sizing config — base size + per-tier multipliers.
+   * When omitted, falls back to the legacy log-scale formula.
+   */
+  nodeSizingConfig?: NodeSizingConfig
 }
 
 /** Truncate long labels at ~30 chars for layout legibility */
@@ -375,6 +385,7 @@ const GraphCanvasInner = ({
   nodeFilterIndices,
   onZoomTransform,
   onNodePositions,
+  nodeSizingConfig,
 }: GraphCanvasProps) => {
   // #1361: merge tunable params with Silk Road defaults so omitted props fall back correctly
   const simCfg: SimulationConfig = useMemo(
@@ -483,8 +494,15 @@ const GraphCanvasInner = ({
   // Node data with pre-computed cluster + size + position fields
   // ---------------------------------------------------------------------------
 
+  // Legacy log-scale formula — used as fallback when no nodeSizingConfig is provided.
   const computeSize = (d: number): number =>
     2 + Math.log10(d + 1) * 12
+
+  // #1360: Tunable sizing — pre-sort degrees for percentile lookup.
+  const sortedDegrees = useMemo(
+    () => nodes.map((n) => n.degree ?? 0).sort((a, b) => a - b),
+    [nodes],
+  )
 
   const repoToIdx = useMemo(() => {
     const repos = Array.from(new Set(nodes.map((n) => n.repo ?? ''))).sort()
@@ -504,15 +522,21 @@ const GraphCanvasInner = ({
       repoEntityCount.set(repo, (repoEntityCount.get(repo) ?? 0) + 1)
     }
 
+    // #1360: build percentile lookup once per node set
+    const getPercentile = buildDegreePercentileFn(sortedDegrees)
+
     return nodes.map((n, i) => {
       const repoIdx = repoToIdx.get(n.repo ?? '') ?? 0
       const cid = clusterIdFor(n, repoIdx)
       const normalizedPR = (n.pagerank ?? 0) / maxPR
       const strength = 0.10 + normalizedPR * 0.08
-      // #1127 P3: Process entities use a flat small range
+      // #1127 P3: Process entities keep flat small range (sizing config doesn't apply)
+      // #1360: all other kinds use tunable sizing when config is provided
       const __size = n.kind === 'Process'
         ? 4 + Math.min((n.degree ?? 0) * 0.005, 6)
-        : computeSize(n.degree ?? 0)
+        : nodeSizingConfig
+          ? computeTunedSize(n.degree ?? 0, getPercentile, nodeSizingConfig)
+          : computeSize(n.degree ?? 0)
       const center = repoCenters.get(n.repo ?? '')
       const jitterR = Math.sqrt(repoEntityCount.get(n.repo ?? '') ?? 1) * 8
       const angle = Math.random() * 2 * Math.PI
@@ -522,7 +546,7 @@ const GraphCanvasInner = ({
       return { ...n, __idx: i, __cluster_id: cid, __cluster_strength: strength, __size, __x, __y }
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [nodes, repoToIdx, repoCenters])
+  }, [nodes, repoToIdx, repoCenters, sortedDegrees, nodeSizingConfig])
 
   const cosmographLinks = useMemo(() => {
     const idToIdx = new Map(nodes.map((n, i) => [String(n.id), i]))

--- a/dashboard/src/components/graph/NodeSizingControls.tsx
+++ b/dashboard/src/components/graph/NodeSizingControls.tsx
@@ -1,0 +1,210 @@
+/**
+ * NodeSizingControls — collapsible sidebar section for tunable node sizing.
+ *
+ * Issue #1360: expose live tuning controls so the user can dial in graph node
+ * sizes without guessing.
+ *
+ * - Base size input (2–50 px)
+ * - 6 tier multiplier inputs (one per degree-percentile band)
+ * - Tier count and percentile range shown per row
+ * - Reset to defaults button
+ * - Values persisted via useNodeSizingConfig (localStorage)
+ */
+import { memo, useState, useCallback } from 'react'
+import type { NodeSizingConfig } from '@/hooks/graph/useNodeSizingConfig'
+import {
+  TIER_COUNT,
+  TIER_UPPER_PERCENTILES,
+  DEFAULT_BASE_SIZE,
+  DEFAULT_MULTIPLIERS,
+} from '@/hooks/graph/useNodeSizingConfig'
+import { ChevronDown, ChevronRight, RotateCcw } from 'lucide-react'
+
+/** Label for each tier's percentile band */
+function tierLabel(index: number): string {
+  const lo = index === 0 ? 0 : TIER_UPPER_PERCENTILES[index - 1]
+  const hi = TIER_UPPER_PERCENTILES[index]
+  return `p${lo}–p${hi}`
+}
+
+interface NodeSizingControlsProps {
+  config: NodeSizingConfig
+  /** Tier node counts — optional histogram hint (length === TIER_COUNT). */
+  tierCounts?: number[]
+  onBaseSizeChange: (v: number) => void
+  onMultiplierChange: (tierIndex: number, v: number) => void
+  onReset: () => void
+}
+
+/**
+ * Tiny numeric input that defers onChange until blur or Enter,
+ * so the user can type freely without intermediate NaN states.
+ */
+const TierInput = memo(function TierInput({
+  value,
+  min,
+  max,
+  step,
+  ariaLabel,
+  onChange,
+}: {
+  value: number
+  min: number
+  max: number
+  step: number
+  ariaLabel: string
+  onChange: (v: number) => void
+}) {
+  const [raw, setRaw] = useState<string>(String(value))
+  const [focused, setFocused] = useState(false)
+
+  // Sync external value when not focused (e.g. after reset)
+  const displayValue = focused ? raw : String(value)
+
+  const commit = useCallback(
+    (s: string) => {
+      const parsed = parseFloat(s)
+      if (!isNaN(parsed)) onChange(parsed)
+      setRaw(String(isNaN(parsed) ? value : parsed))
+      setFocused(false)
+    },
+    [onChange, value],
+  )
+
+  return (
+    <input
+      type="number"
+      min={min}
+      max={max}
+      step={step}
+      value={displayValue}
+      aria-label={ariaLabel}
+      onChange={(e) => setRaw(e.target.value)}
+      onFocus={() => { setFocused(true); setRaw(String(value)) }}
+      onBlur={(e) => commit(e.target.value)}
+      onKeyDown={(e) => { if (e.key === 'Enter') (e.target as HTMLInputElement).blur() }}
+      className={[
+        'w-14 text-right text-[11px] px-1 py-0.5 rounded border',
+        'bg-slate-800 text-slate-200 border-slate-600',
+        'focus:outline-none focus:ring-1 focus:ring-sky-400 focus:border-sky-500',
+        'transition-colors',
+      ].join(' ')}
+    />
+  )
+})
+
+export const NodeSizingControls = memo(function NodeSizingControls({
+  config,
+  tierCounts,
+  onBaseSizeChange,
+  onMultiplierChange,
+  onReset,
+}: NodeSizingControlsProps) {
+  const [open, setOpen] = useState(false)
+
+  const isDefault =
+    config.baseSize === DEFAULT_BASE_SIZE &&
+    config.multipliers.every((m, i) => m === DEFAULT_MULTIPLIERS[i])
+
+  return (
+    <div data-testid="node-sizing-controls">
+      {/* Section header — click to expand/collapse */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        className={[
+          'flex items-center gap-1.5 w-full px-2 py-1 text-left rounded transition-colors',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+          'hover:bg-slate-200/40 dark:hover:bg-slate-800/40',
+        ].join(' ')}
+        aria-expanded={open}
+        aria-controls="node-sizing-body"
+      >
+        <span className="shrink-0 text-slate-500">
+          {open ? <ChevronDown className="w-3 h-3" /> : <ChevronRight className="w-3 h-3" />}
+        </span>
+        <span className="text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-600 font-semibold flex-1">
+          Node sizing
+        </span>
+        {!isDefault && (
+          <span
+            className="w-1.5 h-1.5 rounded-full bg-sky-400 shrink-0"
+            title="Custom sizing active"
+            aria-label="Custom sizing active"
+          />
+        )}
+      </button>
+
+      {open && (
+        <div
+          id="node-sizing-body"
+          className="px-2 pb-2 flex flex-col gap-1"
+          data-testid="node-sizing-body"
+        >
+          {/* Base size row */}
+          <div className="flex items-center justify-between gap-1 mt-1">
+            <span className="text-[11px] text-slate-400 flex-1">Base (px)</span>
+            <TierInput
+              value={config.baseSize}
+              min={2}
+              max={50}
+              step={1}
+              ariaLabel="Base node size in pixels"
+              onChange={onBaseSizeChange}
+            />
+          </div>
+
+          {/* Tier multiplier rows */}
+          <div className="mt-1 flex flex-col gap-0.5">
+            <div className="flex items-center justify-between mb-0.5">
+              <span className="text-[9px] uppercase tracking-wider text-slate-600">Tier</span>
+              <span className="text-[9px] uppercase tracking-wider text-slate-600">×</span>
+            </div>
+            {Array.from({ length: TIER_COUNT }, (_, i) => {
+              const count = tierCounts?.[i] ?? 0
+              return (
+                <div key={i} className="flex items-center gap-1">
+                  <span
+                    className="text-[10px] text-slate-500 tabular-nums flex-1 truncate"
+                    title={tierLabel(i)}
+                  >
+                    {tierLabel(i)}
+                    {tierCounts != null && (
+                      <span className="ml-1 text-slate-600">({count})</span>
+                    )}
+                  </span>
+                  <TierInput
+                    value={config.multipliers[i]}
+                    min={0.1}
+                    max={100}
+                    step={0.5}
+                    ariaLabel={`Tier ${i + 1} size multiplier`}
+                    onChange={(v) => onMultiplierChange(i, v)}
+                  />
+                </div>
+              )
+            })}
+          </div>
+
+          {/* Reset button */}
+          <button
+            type="button"
+            onClick={onReset}
+            disabled={isDefault}
+            className={[
+              'mt-1.5 flex items-center justify-center gap-1 w-full px-2 py-1 rounded text-[10px] border transition-colors',
+              'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+              isDefault
+                ? 'opacity-40 cursor-default border-slate-700 text-slate-500'
+                : 'border-slate-600 text-slate-400 hover:border-sky-600 hover:text-sky-400',
+            ].join(' ')}
+            aria-label="Reset node sizing to defaults"
+          >
+            <RotateCcw className="w-2.5 h-2.5" />
+            Reset to defaults
+          </button>
+        </div>
+      )}
+    </div>
+  )
+})

--- a/dashboard/src/hooks/graph/useNodeSizingConfig.ts
+++ b/dashboard/src/hooks/graph/useNodeSizingConfig.ts
@@ -1,0 +1,166 @@
+/**
+ * useNodeSizingConfig — persisted tunable node sizing config.
+ *
+ * Issue #1360: expose live tuning controls so the user can dial in graph node
+ * sizes without guessing.
+ *
+ * State:
+ *   baseSize    — numeric (px), default 10
+ *   multipliers — 6-element array, one per degree-percentile tier
+ *
+ * Tiers (degree percentile bands):
+ *   0 → lowest 50%        → 1.0×
+ *   1 → 50–75%            → 1.5×
+ *   2 → 75–90%            → 2.0×
+ *   3 → 90–97%            → 3.0×
+ *   4 → 97–99.5%          → 5.0×
+ *   5 → top 0.5%          → 10.0×
+ *
+ * All values are persisted to localStorage under key `archigraph:graph:sizing`.
+ */
+import { useState, useCallback } from 'react'
+
+export const TIER_COUNT = 6
+
+export const DEFAULT_BASE_SIZE = 10
+
+export const DEFAULT_MULTIPLIERS: readonly number[] = [1.0, 1.5, 2.0, 3.0, 5.0, 10.0]
+
+/**
+ * Percentile upper-bounds per tier (inclusive, 0-100).
+ * Tier 0: [0, 50], Tier 1: (50, 75], ..., Tier 5: (99.5, 100]
+ */
+export const TIER_UPPER_PERCENTILES: readonly number[] = [50, 75, 90, 97, 99.5, 100]
+
+export interface NodeSizingConfig {
+  baseSize: number
+  multipliers: number[]
+}
+
+export interface UseNodeSizingConfigReturn {
+  config: NodeSizingConfig
+  setBaseSize: (v: number) => void
+  setMultiplier: (tierIndex: number, v: number) => void
+  resetToDefaults: () => void
+}
+
+const STORAGE_KEY = 'archigraph:graph:sizing'
+
+function loadFromStorage(): NodeSizingConfig | null {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return null
+    const parsed = JSON.parse(raw) as Partial<NodeSizingConfig>
+    const baseSize = typeof parsed.baseSize === 'number' && isFinite(parsed.baseSize)
+      ? Math.max(2, Math.min(50, parsed.baseSize))
+      : DEFAULT_BASE_SIZE
+    const multipliers = Array.isArray(parsed.multipliers) && parsed.multipliers.length === TIER_COUNT
+      ? (parsed.multipliers as number[]).map((m) =>
+          typeof m === 'number' && isFinite(m) ? Math.max(0.1, Math.min(100, m)) : 1.0,
+        )
+      : [...DEFAULT_MULTIPLIERS]
+    return { baseSize, multipliers }
+  } catch {
+    return null
+  }
+}
+
+function saveToStorage(cfg: NodeSizingConfig): void {
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(cfg))
+  } catch {
+    // localStorage may be unavailable in some environments — fail silently
+  }
+}
+
+function defaultConfig(): NodeSizingConfig {
+  return { baseSize: DEFAULT_BASE_SIZE, multipliers: [...DEFAULT_MULTIPLIERS] }
+}
+
+export function useNodeSizingConfig(): UseNodeSizingConfigReturn {
+  const [config, setConfig] = useState<NodeSizingConfig>(() => loadFromStorage() ?? defaultConfig())
+
+  const update = useCallback((next: NodeSizingConfig) => {
+    setConfig(next)
+    saveToStorage(next)
+  }, [])
+
+  const setBaseSize = useCallback((v: number) => {
+    const clamped = Math.max(2, Math.min(50, isFinite(v) ? v : DEFAULT_BASE_SIZE))
+    setConfig((prev) => {
+      const next = { ...prev, baseSize: clamped }
+      saveToStorage(next)
+      return next
+    })
+  }, [])
+
+  const setMultiplier = useCallback((tierIndex: number, v: number) => {
+    const clamped = Math.max(0.1, Math.min(100, isFinite(v) ? v : 1.0))
+    setConfig((prev) => {
+      const multipliers = [...prev.multipliers]
+      multipliers[tierIndex] = clamped
+      const next = { ...prev, multipliers }
+      saveToStorage(next)
+      return next
+    })
+  }, [])
+
+  const resetToDefaults = useCallback(() => {
+    update(defaultConfig())
+  }, [update])
+
+  return { config, setBaseSize, setMultiplier, resetToDefaults }
+}
+
+// ---------------------------------------------------------------------------
+// Tier assignment helpers (used by GraphCanvas to compute __size per node)
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute a per-node degree percentile rank (0–100).
+ *
+ * Accepts the full sorted-ascending degree array and returns a function
+ * that maps any degree value to its percentile.
+ */
+export function buildDegreePercentileFn(
+  sortedDegrees: number[],
+): (degree: number) => number {
+  const n = sortedDegrees.length
+  if (n === 0) return () => 0
+
+  return (degree: number): number => {
+    // Binary search for leftmost index where sortedDegrees[i] >= degree
+    let lo = 0
+    let hi = n
+    while (lo < hi) {
+      const mid = (lo + hi) >> 1
+      if (sortedDegrees[mid] < degree) lo = mid + 1
+      else hi = mid
+    }
+    // lo = count of elements strictly less than degree
+    return (lo / n) * 100
+  }
+}
+
+/**
+ * Map a percentile (0–100) to a tier index (0–5).
+ */
+export function percentileToTier(percentile: number): number {
+  for (let i = 0; i < TIER_UPPER_PERCENTILES.length; i++) {
+    if (percentile <= TIER_UPPER_PERCENTILES[i]) return i
+  }
+  return TIER_COUNT - 1
+}
+
+/**
+ * Compute the final node size: base × multipliers[tier].
+ */
+export function computeTunedSize(
+  degree: number,
+  getPercentile: (degree: number) => number,
+  config: NodeSizingConfig,
+): number {
+  const pct = getPercentile(degree)
+  const tier = percentileToTier(pct)
+  return config.baseSize * (config.multipliers[tier] ?? 1.0)
+}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -16,6 +16,12 @@ import { useGraphFilter, filterNodes } from '@/hooks/graph/useGraphFilter'
 import { useGraphKeyboardNav } from '@/hooks/graph/useGraphKeyboardNav'
 import { useGraphCameraStore, useSimulationRunning } from '@/store/graphCameraStore'
 import { useThemeContext } from '@/context/ThemeContext'
+import {
+  useNodeSizingConfig,
+  buildDegreePercentileFn,
+  percentileToTier,
+  TIER_COUNT,
+} from '@/hooks/graph/useNodeSizingConfig'
 import { GraphCanvas } from '@/components/graph/GraphCanvas'
 import { SimulationControls } from '@/components/graph/SimulationControls'
 import { FilterPanel } from '@/components/graph/FilterPanel'
@@ -31,6 +37,7 @@ import {
   GraphErrorState,
 } from '@/components/graph/GraphEmptyState'
 import { MCPActivityOverlay } from '@/components/graph/MCPActivityOverlay'
+import { NodeSizingControls } from '@/components/graph/NodeSizingControls'
 import { IndexingProgressModal } from '@/components/indexing/IndexingProgressModal'
 import { SnapshotModal } from '@/components/graph/SnapshotModal'
 import { useSnapshotExport } from '@/hooks/graph/useSnapshotExport'
@@ -83,6 +90,14 @@ export function GraphRoute() {
     setLogic: setFilterLogic,
     clearAll: clearGraphFilter,
   } = useGraphFilter()
+
+  // ── Node sizing config (#1360 — persisted to localStorage) ────────────────
+  const {
+    config: nodeSizingConfig,
+    setBaseSize: setNodeSizingBaseSize,
+    setMultiplier: setNodeSizingMultiplier,
+    resetToDefaults: resetNodeSizing,
+  } = useNodeSizingConfig()
 
   // ── View state ─────────────────────────────────────────────────────────────
   const [searchQuery, setSearchQuery] = useState('')
@@ -178,6 +193,26 @@ export function GraphRoute() {
     if (!graphFilterActive) return nodes.length
     return filterIndices?.length ?? 0
   }, [nodes.length, graphFilterActive, filterIndices])
+
+  // ── Node sizing tier counts (#1360) — histogram for NodeSizingControls ──────
+  // Count how many non-Process nodes fall in each degree-percentile tier so the
+  // sidebar can show e.g. "Tier 1 (3847)" next to the multiplier input.
+  const nodeSizingTierCounts = useMemo<number[]>(() => {
+    const counts = new Array<number>(TIER_COUNT).fill(0)
+    if (nodes.length === 0) return counts
+    const sortedDegrees = nodes
+      .filter((n) => n.kind !== 'Process')
+      .map((n) => n.degree ?? 0)
+      .sort((a, b) => a - b)
+    const getPercentile = buildDegreePercentileFn(sortedDegrees)
+    for (const n of nodes) {
+      if (n.kind === 'Process') continue
+      const pct = getPercentile(n.degree ?? 0)
+      const tier = percentileToTier(pct)
+      counts[tier]++
+    }
+    return counts
+  }, [nodes])
 
   // ── Hover neighbor counts (#1060) ──────────────────────────────────────────
   // Pre-index edges by source and target so neighbor lookup is O(1) per query.
@@ -671,6 +706,17 @@ export function GraphRoute() {
 
           <div className="border-t border-slate-200 dark:border-slate-700" />
 
+          {/* Node sizing controls (#1360) */}
+          <NodeSizingControls
+            config={nodeSizingConfig}
+            tierCounts={nodeSizingTierCounts}
+            onBaseSizeChange={setNodeSizingBaseSize}
+            onMultiplierChange={setNodeSizingMultiplier}
+            onReset={resetNodeSizing}
+          />
+
+          <div className="border-t border-slate-200 dark:border-slate-700" />
+
           {/* Repo filter */}
           {allRepoSlugs.length > 0 && (
             <div>
@@ -797,6 +843,7 @@ export function GraphRoute() {
               nodeFilterIndices={filterIndices}
               onZoomTransform={setMinimapZoom}
               onNodePositions={setMinimapPositions}
+              nodeSizingConfig={nodeSizingConfig}
             />
           )}
 


### PR DESCRIPTION
## Summary

Stop guessing graph node sizes. Adds live tuning controls to the graph sidebar so the user can dial in the right look and persist it.

**What changed:**
- New hook `useNodeSizingConfig` — `baseSize` (default 10 px) + 6 tier multipliers `[1.0, 1.5, 2.0, 3.0, 5.0, 10.0]`, persisted to `localStorage` under `archigraph:graph:sizing`
- New component `NodeSizingControls` — collapsible "Node sizing" section in the left sidebar with: base size input (2–50 px range), 6 tier multiplier inputs (each labeled with its percentile band + node count), a custom-value indicator dot, and a "Reset to defaults" button
- `GraphCanvas`: accepts optional `nodeSizingConfig` prop; replaces the fixed log-scale formula with degree-percentile bucketing (`buildDegreePercentileFn` + `percentileToTier` + `computeTunedSize`). Process nodes retain their existing flat-size override (#1127). Falls back to legacy formula when no config passed.
- `graph.tsx` route: wires the hook, computes per-tier node counts (shown as histogram hints), and renders `NodeSizingControls` between Overlays and Repos in the sidebar

**Tier assignment (degree percentile → tier):**

| Tier | Percentile band | Default multiplier |
|------|-----------------|-------------------|
| 1    | p0–p50          | 1.0×              |
| 2    | p50–p75         | 1.5×              |
| 3    | p75–p90         | 2.0×              |
| 4    | p90–p97         | 3.0×              |
| 5    | p97–p99.5       | 5.0×              |
| 6    | p99.5–p100      | 10.0×             |

Final size = `baseSize × multipliers[tier]`. Cosmograph picks it up via `pointSizeBy='__size'`.

## Closes / Refs
- Closes #1360

## Testing
- Headless Playwright smoke test `smoke-node-sizing-1360.mjs`: **22/22 pass**
  - Sidebar "Node sizing" collapsible section visible and expands/collapses
  - Base size input shows default 10; 6 tier inputs show defaults 1/1.5/2/3/5/10
  - Editing base size (10→5) → localStorage persists correctly
  - Editing tier 6 multiplier (10→20) → localStorage persists correctly
  - Reset to defaults → inputs and localStorage both restored
  - Values survive page reload (localStorage round-trip)
  - 0 relevant console errors

## Notes
- Color toggle, LoD bands, hub pulse, and cross-repo filter are all unaffected
- Process node sizing unchanged (flat 4–10 px per #1127)
- No backend changes; pure frontend localStorage state