### PR TITLE
[graph][ui] Multi-criteria filter panel — kind, community, degree, file, property (#1367)

### DIFF
--- a/dashboard/smoke-filter-panel-1367.mjs
+++ b/dashboard/smoke-filter-panel-1367.mjs
@@ -1,0 +1,262 @@
+/**
+ * Headless smoke test for #1367 — Multi-criteria graph filter panel.
+ *
+ * Tests:
+ *   1. Filter panel toggle button is present in the sidebar
+ *   2. Panel expands and shows all filter controls
+ *   3. Active filter badge shows correct count
+ *   4. Match count badge updates live
+ *   5. Kind filter checkbox marks nodes visible/hidden
+ *   6. Min-degree input narrows the match count
+ *   7. Clear all button resets the panel
+ *   8. No regression: repo filter, color toggle, simulation tunables still present
+ *
+ * Usage: node smoke-filter-panel-1367.mjs <port>
+ */
+
+import { chromium } from '@playwright/test'
+import * as fs from 'fs'
+import * as path from 'path'
+import { fileURLToPath } from 'url'
+
+const PORT = process.argv[2] ?? '5533'
+const BASE = `http://127.0.0.1:${PORT}`
+const GRAPH_URL = `${BASE}/graph/upvate`
+const SCREENSHOTS_DIR = path.join(path.dirname(fileURLToPath(import.meta.url)), 'e2e-screenshots', 'filter-panel-1367')
+
+fs.mkdirSync(SCREENSHOTS_DIR, { recursive: true })
+
+function screenshot(page, name) {
+  const p = path.join(SCREENSHOTS_DIR, name)
+  return page.screenshot({ path: p, fullPage: false }).then(() => {
+    console.log(`  screenshot → ${p}`)
+    return p
+  })
+}
+
+const browser = await chromium.launch({ headless: true })
+const context = await browser.newContext({ viewport: { width: 1400, height: 900 } })
+const page = await context.newPage()
+
+const consoleErrors = []
+page.on('console', (msg) => {
+  if (msg.type() === 'error') consoleErrors.push(msg.text())
+})
+
+const results = []
+
+function assert(name, pass, detail = '') {
+  const status = pass ? 'PASS' : 'FAIL'
+  results.push({ name, pass })
+  console.log(`  [${status}] ${name}${detail ? ' — ' + detail : ''}`)
+  return pass
+}
+
+// ── Step 1: Load graph page ─────────────────────────────────────────────────
+console.log('\n── Step 1: Load graph page ─────────────────────────────────────────')
+console.log(`Navigating to ${GRAPH_URL} ...`)
+await page.goto(GRAPH_URL, { waitUntil: 'networkidle', timeout: 30000 })
+await page.waitForTimeout(2000)
+
+await screenshot(page, 'ss-01-loaded.png')
+
+// Canvas should be present
+const canvas = page.locator('canvas')
+const canvasCount = await canvas.count()
+assert('canvas rendered', canvasCount > 0, `count=${canvasCount}`)
+
+// ── Step 2: Filter panel toggle button exists ────────────────────────────────
+console.log('\n── Step 2: Filter panel toggle button ──────────────────────────────')
+
+const filterToggle = page.locator('[data-testid="filter-panel-toggle"]')
+const filterToggleCount = await filterToggle.count()
+assert('filter panel toggle button present', filterToggleCount > 0, `count=${filterToggleCount}`)
+
+// Panel body should be hidden initially
+const filterBody = page.locator('[data-testid="filter-panel-body"]')
+const bodyInitialCount = await filterBody.count()
+assert('filter panel body hidden initially', bodyInitialCount === 0, `count=${bodyInitialCount}`)
+
+// ── Step 3: Expand the filter panel ─────────────────────────────────────────
+console.log('\n── Step 3: Expand filter panel ─────────────────────────────────────')
+await filterToggle.first().click()
+await page.waitForTimeout(300)
+
+const bodyAfterExpand = await filterBody.count()
+assert('filter panel body visible after click', bodyAfterExpand > 0, `count=${bodyAfterExpand}`)
+
+await screenshot(page, 'ss-02-panel-expanded.png')
+
+// Check all controls are present
+const kindSearch = page.locator('[data-testid="filter-kind-search"]')
+assert('kind search input present', await kindSearch.count() > 0)
+
+const minDegreeInput = page.locator('[data-testid="filter-min-degree"]')
+assert('min-degree input present', await minDegreeInput.count() > 0)
+
+const fileGlobInput = page.locator('[data-testid="filter-file-glob"]')
+assert('file-glob input present', await fileGlobInput.count() > 0)
+
+const hasPropSelect = page.locator('[data-testid="filter-has-property"]')
+assert('has-property select present', await hasPropSelect.count() > 0)
+
+const invertToggle = page.locator('[data-testid="filter-invert"]')
+assert('invert toggle present', await invertToggle.count() > 0)
+
+const clearAllBtn = page.locator('[data-testid="filter-clear-all"]')
+assert('clear-all button present', await clearAllBtn.count() > 0)
+
+const logicAnd = page.locator('[data-testid="filter-logic-and"]')
+const logicOr = page.locator('[data-testid="filter-logic-or"]')
+assert('AND logic button present', await logicAnd.count() > 0)
+assert('OR logic button present', await logicOr.count() > 0)
+
+// ── Step 4: Wait for nodes to load and check initial match count ─────────────
+console.log('\n── Step 4: Match count after load ──────────────────────────────────')
+await page.waitForTimeout(5000) // let graph data load
+
+const matchCountEl = page.locator('[data-testid="filter-match-count"]')
+const matchCountText = await matchCountEl.count() > 0 ? await matchCountEl.first().textContent() : 'n/a'
+console.log(`  Initial match count text: "${matchCountText}"`)
+// Match count may not be shown when no filter is active (matchCount = nodes.length but badge hidden when panel shows it inline)
+// At minimum confirm no error state
+
+// ── Step 5: Select a kind to filter ─────────────────────────────────────────
+console.log('\n── Step 5: Select Function kind filter ─────────────────────────────')
+
+const functionKindBtn = page.locator('[data-testid="filter-kind-Function"]')
+const functionKindCount = await functionKindBtn.count()
+assert('Function kind checkbox present', functionKindCount > 0, `count=${functionKindCount}`)
+
+if (functionKindCount > 0) {
+  await functionKindBtn.first().click()
+  await page.waitForTimeout(400)
+
+  const activeBadge = page.locator('[data-testid="filter-active-badge"]')
+  const activeBadgeCount = await activeBadge.count()
+  assert('active filter badge appears after kind selection', activeBadgeCount > 0, `count=${activeBadgeCount}`)
+
+  const activeBadgeText = activeBadgeCount > 0 ? await activeBadge.first().textContent() : ''
+  assert('active filter badge shows count ≥ 1', parseInt(activeBadgeText ?? '0', 10) >= 1, `badge="${activeBadgeText}"`)
+
+  await screenshot(page, 'ss-03-function-filter.png')
+
+  // Check aria-checked = true
+  const ariaChecked = await functionKindBtn.first().getAttribute('aria-checked')
+  assert('Function kind checkbox aria-checked=true', ariaChecked === 'true', `aria-checked=${ariaChecked}`)
+}
+
+// ── Step 6: Set min-degree filter ────────────────────────────────────────────
+console.log('\n── Step 6: Set min-degree = 5 ──────────────────────────────────────')
+await minDegreeInput.first().fill('5')
+await page.waitForTimeout(400)
+
+const matchCountAfterDegree = page.locator('[data-testid="filter-match-count"]')
+const degreeMatchText = await matchCountAfterDegree.count() > 0 ? await matchCountAfterDegree.first().textContent() : 'n/a'
+console.log(`  Match count after degree filter: "${degreeMatchText}"`)
+
+await screenshot(page, 'ss-04-degree-filter.png')
+
+// Active badge should show 2 or more (kind + degree)
+const badgeAfterDegree = page.locator('[data-testid="filter-active-badge"]')
+const badgeAfterDegreeText = await badgeAfterDegree.count() > 0 ? await badgeAfterDegree.first().textContent() : '0'
+assert('active badge shows ≥ 2 after kind + degree', parseInt(badgeAfterDegreeText ?? '0', 10) >= 2, `badge="${badgeAfterDegreeText}"`)
+
+// ── Step 7: Clear all ─────────────────────────────────────────────────────────
+console.log('\n── Step 7: Clear all filters ────────────────────────────────────────')
+await clearAllBtn.first().click()
+await page.waitForTimeout(300)
+
+// Active badge should disappear
+const badgeAfterClear = page.locator('[data-testid="filter-active-badge"]')
+const badgeAfterClearCount = await badgeAfterClear.count()
+assert('active badge gone after clear all', badgeAfterClearCount === 0, `count=${badgeAfterClearCount}`)
+
+// Kind checkbox should be unchecked
+const functionKindAfterClear = await functionKindBtn.count() > 0 ? await functionKindBtn.first().getAttribute('aria-checked') : 'n/a'
+assert('Function kind unchecked after clear all', functionKindAfterClear === 'false', `aria-checked=${functionKindAfterClear}`)
+
+// Min degree should be 0
+const minDegreeAfterClear = await minDegreeInput.first().inputValue()
+assert('min-degree reset to 0 after clear all', minDegreeAfterClear === '0', `value=${minDegreeAfterClear}`)
+
+await screenshot(page, 'ss-05-cleared.png')
+
+// ── Step 8: File glob filter ──────────────────────────────────────────────────
+console.log('\n── Step 8: File glob filter ─────────────────────────────────────────')
+await fileGlobInput.first().fill('**/*.py')
+await page.waitForTimeout(400)
+
+const badgeGlob = page.locator('[data-testid="filter-active-badge"]')
+const badgeGlobCount = await badgeGlob.count()
+assert('active badge appears for glob filter', badgeGlobCount > 0, `count=${badgeGlobCount}`)
+
+await screenshot(page, 'ss-06-glob-filter.png')
+
+// Clear
+await clearAllBtn.first().click()
+await page.waitForTimeout(200)
+
+// ── Step 9: OR logic toggle ───────────────────────────────────────────────────
+console.log('\n── Step 9: Logic toggle ─────────────────────────────────────────────')
+
+// AND should be active by default
+const andAriaPressed = await logicAnd.first().getAttribute('aria-pressed')
+assert('AND logic pressed by default', andAriaPressed === 'true', `aria-pressed=${andAriaPressed}`)
+
+await logicOr.first().click()
+await page.waitForTimeout(200)
+
+const orAriaPressed = await logicOr.first().getAttribute('aria-pressed')
+const andAriaAfterOr = await logicAnd.first().getAttribute('aria-pressed')
+assert('OR logic becomes pressed', orAriaPressed === 'true', `aria-pressed=${orAriaPressed}`)
+assert('AND logic unpressed after OR click', andAriaAfterOr === 'false', `aria-pressed=${andAriaAfterOr}`)
+
+// Reset to AND
+await logicAnd.first().click()
+await page.waitForTimeout(200)
+
+// ── Step 10: Regression — existing sidebar controls still present ─────────────
+console.log('\n── Step 10: Regression — existing controls still present ────────────')
+
+// Color by radio group
+const colorByRepo = page.locator('button[role="radio"][aria-checked="true"]')
+assert('color mode radio present', await colorByRepo.count() > 0)
+
+// Simulation controls toggle
+const simControls = page.locator('[data-testid="sim-controls-toggle"]')
+assert('simulation controls toggle present', await simControls.count() > 0)
+
+// Cross-repo toggle in toolbar
+const crossRepoToggle = page.locator('[data-testid="cross-repo-toggle"]')
+assert('cross-repo toggle present', await crossRepoToggle.count() > 0)
+
+// Snapshot button
+const snapshotBtn = page.locator('[data-testid="toolbar-snapshot-btn"]')
+assert('snapshot button present', await snapshotBtn.count() > 0)
+
+await screenshot(page, 'ss-07-regression-check.png')
+
+// ── Step 11: Console errors ───────────────────────────────────────────────────
+console.log('\n── Step 11: Console error check ─────────────────────────────────────')
+const relevantErrors = consoleErrors.filter(e =>
+  !e.includes('GPU stall') &&
+  !e.includes('WebGL') &&
+  !e.includes('ReadPixels') &&
+  !e.includes('net::ERR') &&
+  !e.includes('DuckDB') &&
+  !e.includes('Abort') &&
+  !e.includes('favicon')
+)
+assert('no relevant console errors', relevantErrors.length === 0,
+  relevantErrors.length > 0 ? relevantErrors.slice(0, 3).join(' | ') : 'clean')
+
+// ── Summary ──────────────────────────────────────────────────────────────────
+console.log('\n══ SMOKE TEST SUMMARY ══════════════════════════════════════════════')
+const passed = results.filter(r => r.pass).length
+const failed = results.filter(r => !r.pass).length
+results.forEach(r => console.log(`  ${r.pass ? '✓' : '✗'} ${r.name}`))
+console.log(`\n  ${passed}/${results.length} passed — Screenshots in: ${SCREENSHOTS_DIR}`)
+
+await browser.close()
+process.exit(failed === 0 ? 0 : 1)

--- a/dashboard/src/components/graph/FilterPanel.tsx
+++ b/dashboard/src/components/graph/FilterPanel.tsx
@@ -1,0 +1,471 @@
+/**
+ * FilterPanel — multi-criteria graph filter sidebar section (#1367).
+ *
+ * Collapsible section with:
+ *   - Kind: multi-select of EntityKind values
+ *   - Community: multi-select (community IDs)
+ *   - Min degree: number input
+ *   - File path glob: text input
+ *   - Has property: dropdown
+ *   - Logic toggle: AND / OR
+ *   - Invert filter toggle
+ *   - 'Clear all' button
+ *   - Match count badge (live)
+ *
+ * All state is managed externally via the useGraphFilter hook.
+ * The match count is passed in as `matchCount` so the parent controls
+ * when / how the filter is applied to the Cosmograph canvas.
+ */
+
+import { useState, useId } from 'react'
+import { ChevronDown, ChevronRight, X, Filter } from 'lucide-react'
+import type { EntityKind } from '@/types/api'
+import type { GraphFilterState } from '@/hooks/graph/useGraphFilter'
+import type { Community } from '@/types/api'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Stable list of filterable entity kinds (ordered by frequency of use)
+// ────────────────────────────────────────────────────────────────────────────
+
+const ALL_KINDS: EntityKind[] = [
+  'Function', 'Class', 'Component', 'Operation', 'Endpoint', 'Route',
+  'Schema', 'Model', 'DataAccess', 'Datastore', 'Queue', 'Event',
+  'Service', 'View', 'UIComponent', 'JSX', 'Stylesheet',
+  'ExternalAPI', 'InfraResource', 'Config', 'Process',
+  'AgentPattern', 'MessageTopic', 'Document', 'CodeBlock',
+  'Variable', 'Reference', 'Pattern', 'Project', 'External', 'ScopeUnknown',
+]
+
+const HAS_PROPERTY_OPTIONS = [
+  { value: '',            label: '— any —' },
+  { value: 'description', label: 'description' },
+  { value: 'domain',      label: 'domain' },
+  { value: 'summary',     label: 'summary' },
+  { value: 'deprecated',  label: 'deprecated' },
+  { value: 'version',     label: 'version' },
+  { value: 'owner',       label: 'owner' },
+  { value: 'tags',        label: 'tags' },
+]
+
+// ────────────────────────────────────────────────────────────────────────────
+// Props
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface FilterPanelProps {
+  filter:           GraphFilterState
+  /** Number of nodes that currently match the active filter (-1 = not computed) */
+  matchCount:       number
+  /** All communities available for multi-select */
+  communities:      Community[]
+  onSetKinds:       (kinds: Set<EntityKind>) => void
+  onSetCommunities: (ids: Set<number>) => void
+  onSetMinDegree:   (v: number) => void
+  onSetFileGlob:    (v: string) => void
+  onSetHasProperty: (v: string) => void
+  onSetInvert:      (v: boolean) => void
+  onSetLogic:       (v: 'and' | 'or') => void
+  onClearAll:       () => void
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Component
+// ────────────────────────────────────────────────────────────────────────────
+
+export function FilterPanel({
+  filter,
+  matchCount,
+  communities,
+  onSetKinds,
+  onSetCommunities,
+  onSetMinDegree,
+  onSetFileGlob,
+  onSetHasProperty,
+  onSetInvert,
+  onSetLogic,
+  onClearAll,
+}: FilterPanelProps) {
+  const [open, setOpen] = useState(false)
+  const [kindSearchQuery, setKindSearchQuery] = useState('')
+  const id = useId()
+
+  const activeCount =
+    filter.kinds.size +
+    filter.communityIds.size +
+    (filter.minDegree > 0 ? 1 : 0) +
+    (filter.fileGlob ? 1 : 0) +
+    (filter.hasProperty ? 1 : 0)
+
+  const filteredKinds = kindSearchQuery
+    ? ALL_KINDS.filter((k) => k.toLowerCase().includes(kindSearchQuery.toLowerCase()))
+    : ALL_KINDS
+
+  function toggleKind(kind: EntityKind) {
+    const next = new Set(filter.kinds)
+    if (next.has(kind)) next.delete(kind)
+    else next.add(kind)
+    onSetKinds(next)
+  }
+
+  function toggleCommunity(id: number) {
+    const next = new Set(filter.communityIds)
+    if (next.has(id)) next.delete(id)
+    else next.add(id)
+    onSetCommunities(next)
+  }
+
+  const sortedCommunities = [...communities].sort((a, b) => b.size - a.size).slice(0, 40)
+
+  return (
+    <div data-testid="filter-panel">
+      {/* ── Section header ── */}
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-expanded={open}
+        aria-controls={`filter-panel-body-${id}`}
+        className={[
+          'flex items-center justify-between w-full px-2 py-1 rounded',
+          'text-[10px] uppercase tracking-wider text-slate-500 dark:text-slate-600 font-semibold',
+          'hover:bg-slate-200/40 dark:hover:bg-slate-800/40 transition-colors',
+          'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+        ].join(' ')}
+        data-testid="filter-panel-toggle"
+      >
+        <span className="flex items-center gap-1.5">
+          <Filter className="w-3 h-3" aria-hidden />
+          Filter
+          {activeCount > 0 && (
+            <span
+              className="inline-flex items-center justify-center w-4 h-4 rounded-full text-[9px] font-bold bg-sky-500 text-white"
+              aria-label={`${activeCount} active filters`}
+              data-testid="filter-active-badge"
+            >
+              {activeCount}
+            </span>
+          )}
+        </span>
+        <span className="flex items-center gap-1">
+          {matchCount >= 0 && (
+            <span
+              className="text-[9px] font-mono text-slate-400 tabular-nums"
+              aria-live="polite"
+              aria-label={`${matchCount.toLocaleString()} matching nodes`}
+              data-testid="filter-match-count"
+            >
+              {matchCount.toLocaleString()}
+            </span>
+          )}
+          {open
+            ? <ChevronDown className="w-3 h-3 text-slate-400" aria-hidden />
+            : <ChevronRight className="w-3 h-3 text-slate-400" aria-hidden />
+          }
+        </span>
+      </button>
+
+      {open && (
+        <div
+          id={`filter-panel-body-${id}`}
+          className="flex flex-col gap-3 mt-1 px-1"
+          data-testid="filter-panel-body"
+        >
+
+          {/* ── Logic toggle (AND / OR) ── */}
+          <div>
+            <p className="text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1">
+              Match logic
+            </p>
+            <div className="flex gap-1">
+              {(['and', 'or'] as const).map((v) => (
+                <button
+                  key={v}
+                  type="button"
+                  onClick={() => onSetLogic(v)}
+                  aria-pressed={filter.filterLogic === v}
+                  className={[
+                    'flex-1 py-0.5 rounded text-[10px] font-medium transition-colors border',
+                    'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                    filter.filterLogic === v
+                      ? 'bg-sky-900/40 text-sky-300 border-sky-700'
+                      : 'bg-transparent text-slate-500 border-slate-600 hover:border-slate-500 hover:text-slate-300',
+                  ].join(' ')}
+                  data-testid={`filter-logic-${v}`}
+                >
+                  {v.toUpperCase()}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Kind multi-select ── */}
+          <div>
+            <p className="text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1">
+              Kind
+              {filter.kinds.size > 0 && (
+                <span className="ml-1 text-sky-400">({filter.kinds.size})</span>
+              )}
+            </p>
+            <input
+              type="search"
+              placeholder="Search kinds…"
+              value={kindSearchQuery}
+              onChange={(e) => setKindSearchQuery(e.target.value)}
+              className={[
+                'w-full px-2 py-0.5 mb-1 rounded text-[10px]',
+                'bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300',
+                'border border-slate-300 dark:border-slate-700 focus:border-sky-600 focus:outline-none',
+                'placeholder-slate-500',
+              ].join(' ')}
+              aria-label="Search entity kinds"
+              data-testid="filter-kind-search"
+            />
+            <div
+              className="flex flex-col gap-0.5 max-h-[140px] overflow-y-auto scrollbar-thin"
+              role="group"
+              aria-label="Entity kind filter"
+            >
+              {filteredKinds.map((kind) => {
+                const checked = filter.kinds.has(kind)
+                return (
+                  <button
+                    key={kind}
+                    type="button"
+                    role="checkbox"
+                    aria-checked={checked}
+                    onClick={() => toggleKind(kind)}
+                    className={[
+                      'flex items-center gap-1.5 px-2 py-0.5 rounded text-left text-[10px] w-full transition-colors',
+                      'hover:bg-slate-200/60 dark:hover:bg-slate-800/60',
+                      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                      checked ? 'text-sky-300 bg-sky-900/20' : 'text-slate-600 dark:text-slate-400',
+                    ].join(' ')}
+                    data-testid={`filter-kind-${kind}`}
+                  >
+                    <span
+                      className={[
+                        'w-3 h-3 rounded border shrink-0 flex items-center justify-center',
+                        checked
+                          ? 'bg-sky-500 border-sky-500 text-white'
+                          : 'border-slate-500 bg-transparent',
+                      ].join(' ')}
+                      aria-hidden
+                    >
+                      {checked && (
+                        <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+                          <path d="M1.5 4L3.5 6L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                        </svg>
+                      )}
+                    </span>
+                    {kind}
+                  </button>
+                )
+              })}
+              {filteredKinds.length === 0 && (
+                <p className="px-2 py-1 text-[10px] text-slate-500">No matching kinds</p>
+              )}
+            </div>
+          </div>
+
+          {/* ── Community multi-select ── */}
+          {sortedCommunities.length > 0 && (
+            <div>
+              <p className="text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1">
+                Community
+                {filter.communityIds.size > 0 && (
+                  <span className="ml-1 text-sky-400">({filter.communityIds.size})</span>
+                )}
+              </p>
+              <div
+                className="flex flex-col gap-0.5 max-h-[100px] overflow-y-auto scrollbar-thin"
+                role="group"
+                aria-label="Community filter"
+              >
+                {sortedCommunities.map((c) => {
+                  const checked = filter.communityIds.has(c.id)
+                  const name = c.agent_name ?? c.auto_name ?? `Community ${c.id}`
+                  return (
+                    <button
+                      key={`${c.id}-${c.repo}`}
+                      type="button"
+                      role="checkbox"
+                      aria-checked={checked}
+                      onClick={() => toggleCommunity(c.id)}
+                      className={[
+                        'flex items-center gap-1.5 px-2 py-0.5 rounded text-left text-[10px] w-full transition-colors',
+                        'hover:bg-slate-200/60 dark:hover:bg-slate-800/60',
+                        'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                        checked ? 'text-sky-300 bg-sky-900/20' : 'text-slate-600 dark:text-slate-400',
+                      ].join(' ')}
+                      data-testid={`filter-community-${c.id}`}
+                    >
+                      <span
+                        className={[
+                          'w-3 h-3 rounded border shrink-0 flex items-center justify-center',
+                          checked
+                            ? 'bg-sky-500 border-sky-500 text-white'
+                            : 'border-slate-500 bg-transparent',
+                        ].join(' ')}
+                        aria-hidden
+                      >
+                        {checked && (
+                          <svg width="8" height="8" viewBox="0 0 8 8" fill="none">
+                            <path d="M1.5 4L3.5 6L6.5 2" stroke="white" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        )}
+                      </span>
+                      <span className="flex-1 truncate">{name}</span>
+                      <span className="text-slate-500 tabular-nums">{c.size}</span>
+                    </button>
+                  )
+                })}
+              </div>
+            </div>
+          )}
+
+          {/* ── Min degree ── */}
+          <div>
+            <label
+              htmlFor={`filter-min-degree-${id}`}
+              className="block text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1"
+            >
+              Min degree
+            </label>
+            <input
+              id={`filter-min-degree-${id}`}
+              type="number"
+              min={0}
+              max={9999}
+              step={1}
+              value={filter.minDegree}
+              onChange={(e) => {
+                const v = parseInt(e.target.value, 10)
+                onSetMinDegree(isNaN(v) || v < 0 ? 0 : v)
+              }}
+              className={[
+                'w-full px-2 py-0.5 rounded text-[10px]',
+                'bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300',
+                'border border-slate-300 dark:border-slate-700 focus:border-sky-600 focus:outline-none',
+              ].join(' ')}
+              aria-label="Minimum node degree"
+              data-testid="filter-min-degree"
+            />
+          </div>
+
+          {/* ── File path glob ── */}
+          <div>
+            <label
+              htmlFor={`filter-file-glob-${id}`}
+              className="block text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1"
+            >
+              File path glob
+            </label>
+            <input
+              id={`filter-file-glob-${id}`}
+              type="text"
+              value={filter.fileGlob}
+              onChange={(e) => onSetFileGlob(e.target.value)}
+              placeholder="e.g. **/api/*.py"
+              className={[
+                'w-full px-2 py-0.5 rounded text-[10px]',
+                'bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300',
+                'border border-slate-300 dark:border-slate-700 focus:border-sky-600 focus:outline-none',
+                'placeholder-slate-500',
+              ].join(' ')}
+              aria-label="File path glob filter"
+              data-testid="filter-file-glob"
+            />
+          </div>
+
+          {/* ── Has property ── */}
+          <div>
+            <label
+              htmlFor={`filter-has-property-${id}`}
+              className="block text-[9px] uppercase tracking-wider text-slate-500/70 dark:text-slate-600/70 font-semibold px-1 pb-1"
+            >
+              Has property
+            </label>
+            <select
+              id={`filter-has-property-${id}`}
+              value={filter.hasProperty}
+              onChange={(e) => onSetHasProperty(e.target.value)}
+              className={[
+                'w-full px-2 py-0.5 rounded text-[10px]',
+                'bg-slate-200 dark:bg-slate-800 text-slate-700 dark:text-slate-300',
+                'border border-slate-300 dark:border-slate-700 focus:border-sky-600 focus:outline-none',
+              ].join(' ')}
+              aria-label="Filter by presence of property"
+              data-testid="filter-has-property"
+            >
+              {HAS_PROPERTY_OPTIONS.map((opt) => (
+                <option key={opt.value} value={opt.value}>{opt.label}</option>
+              ))}
+            </select>
+          </div>
+
+          {/* ── Invert filter toggle ── */}
+          <div className="flex items-center justify-between px-1">
+            <label
+              htmlFor={`filter-invert-${id}`}
+              className="text-[10px] text-slate-500 dark:text-slate-500 cursor-pointer"
+            >
+              Invert filter
+            </label>
+            <button
+              id={`filter-invert-${id}`}
+              type="button"
+              role="switch"
+              aria-checked={filter.invertFilter}
+              onClick={() => onSetInvert(!filter.invertFilter)}
+              className={[
+                'relative inline-flex h-4 w-7 items-center rounded-full transition-colors',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                filter.invertFilter ? 'bg-sky-500' : 'bg-slate-600',
+              ].join(' ')}
+              aria-label="Invert filter — show non-matching nodes instead"
+              data-testid="filter-invert"
+            >
+              <span
+                className={[
+                  'inline-block h-3 w-3 rounded-full bg-white transition-transform',
+                  filter.invertFilter ? 'translate-x-3.5' : 'translate-x-0.5',
+                ].join(' ')}
+                aria-hidden
+              />
+            </button>
+          </div>
+
+          {/* ── Clear all + match count row ── */}
+          <div className="flex items-center justify-between gap-2 pt-1 border-t border-slate-200 dark:border-slate-700">
+            {matchCount >= 0 ? (
+              <span
+                className="text-[10px] text-slate-400 tabular-nums"
+                aria-live="polite"
+                aria-label={`${matchCount.toLocaleString()} nodes match current filters`}
+              >
+                {matchCount.toLocaleString()} match{matchCount !== 1 ? 'es' : ''}
+              </span>
+            ) : (
+              <span />
+            )}
+            <button
+              type="button"
+              onClick={onClearAll}
+              disabled={activeCount === 0 && !filter.invertFilter}
+              className={[
+                'flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium transition-colors border',
+                'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                activeCount > 0 || filter.invertFilter
+                  ? 'border-rose-700 text-rose-400 hover:bg-rose-900/20'
+                  : 'border-slate-700 text-slate-600 opacity-50 cursor-not-allowed',
+              ].join(' ')}
+              aria-label="Clear all filters"
+              data-testid="filter-clear-all"
+            >
+              <X className="w-3 h-3" aria-hidden />
+              Clear all
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -308,6 +308,12 @@ export interface GraphCanvasProps {
    * Omit to use Silk Road defaults.
    */
   simulationConfig?: SimulationConfig
+  /**
+   * #1367: Multi-criteria filter — pre-computed array of node indices that pass
+   * all active filter criteria. When non-null the canvas shows only these nodes
+   * (intersected with the repo filter and LoD band). null = no filter active.
+   */
+  nodeFilterIndices?: number[] | null
 }
 
 /** Truncate long labels at ~30 chars for layout legibility */
@@ -356,6 +362,7 @@ const GraphCanvasInner = ({
   forceVisibleIds,
   highlightedEdgeIds,
   simulationConfig,
+  nodeFilterIndices,
 }: GraphCanvasProps) => {
   // #1361: merge tunable params with Silk Road defaults so omitted props fall back correctly
   const simCfg: SimulationConfig = useMemo(
@@ -415,18 +422,31 @@ const GraphCanvasInner = ({
   }, [nodes, currentBand, activeRepos, effectiveForceIds])
 
   // Apply LoD visibility via Cosmograph's imperative selection API.
+  // #1367: when nodeFilterIndices is non-null, intersect it with the LoD band result.
   useEffect(() => {
     const cosmo = cosmographRef.current
     if (!cosmo) return
 
     // #1356: all bands are now unfiltered (topN=null, degreeMin=0).
     const isUnfilteredBand = currentBand.topN === null && currentBand.degreeMin === 0
-    if (isUnfilteredBand && !activeRepos && effectiveForceIds.size === 0) {
+    const noOverrides = !activeRepos && effectiveForceIds.size === 0 && !nodeFilterIndices
+
+    if (isUnfilteredBand && noOverrides) {
       cosmo.selectPoints(null)
     } else {
-      cosmo.selectPoints(lodVisibleIndices)
+      // Intersect lod indices with nodeFilterIndices when both are present
+      let effective: number[] | null = lodVisibleIndices
+      if (nodeFilterIndices !== null && nodeFilterIndices !== undefined) {
+        if (effective === null) {
+          effective = nodeFilterIndices
+        } else {
+          const filterSet = new Set(nodeFilterIndices)
+          effective = effective.filter((i) => filterSet.has(i))
+        }
+      }
+      cosmo.selectPoints(effective)
     }
-  }, [lodVisibleIndices, currentBand, activeRepos, effectiveForceIds])
+  }, [lodVisibleIndices, currentBand, activeRepos, effectiveForceIds, nodeFilterIndices])
 
   // Fallback repo-filter application when band is unfiltered (before LoD fires)
   useEffect(() => {
@@ -434,8 +454,18 @@ const GraphCanvasInner = ({
     if (!cosmo) return
     const isUnfilteredBand = currentBand.topN === null && currentBand.degreeMin === 0
     if (!isUnfilteredBand) return
-    cosmo.selectPoints(visibleIndices)
-  }, [visibleIndices, currentBand])
+    // If nodeFilterIndices active, intersect with repo filter
+    if (nodeFilterIndices !== null && nodeFilterIndices !== undefined) {
+      if (visibleIndices !== null) {
+        const filterSet = new Set(nodeFilterIndices)
+        cosmo.selectPoints(visibleIndices.filter((i) => filterSet.has(i)))
+      } else {
+        cosmo.selectPoints(nodeFilterIndices)
+      }
+    } else {
+      cosmo.selectPoints(visibleIndices)
+    }
+  }, [visibleIndices, currentBand, nodeFilterIndices])
 
   // ---------------------------------------------------------------------------
   // Node data with pre-computed cluster + size + position fields
@@ -911,7 +941,7 @@ const GraphCanvasInner = ({
 
         // ── Greyout opacity ────────────────────────────────────────────────
         // #1356: all bands are unfiltered, so greyout only applies when repo filter is active.
-        pointGreyoutOpacity={repoFilterActive ? 0 : 0.15}
+        pointGreyoutOpacity={(repoFilterActive || !!nodeFilterIndices) ? 0 : 0.15}
         linkGreyoutOpacity={repoFilterActive ? 0 : 0.1}
 
         // ── Simulation — #1153 Silk Road defaults, #1361 tunable via sidebar sliders ───

--- a/dashboard/src/hooks/graph/useGraphFilter.ts
+++ b/dashboard/src/hooks/graph/useGraphFilter.ts
@@ -1,0 +1,287 @@
+/**
+ * useGraphFilter — multi-criteria graph filter state (#1367).
+ *
+ * Criteria:
+ *   - kinds:         Set<EntityKind>  (multi-select; empty = all)
+ *   - communityIds:  Set<number>      (multi-select; empty = all)
+ *   - minDegree:     number           (0 = no threshold)
+ *   - fileGlob:      string           (glob against source_file; '' = no filter)
+ *   - hasProperty:   string           ('' = no filter; 'description' | 'domain' | etc.)
+ *
+ * State is persisted to localStorage under the key 'archigraph:graph-filter'.
+ * Exports `filterNodes()` — a pure function that applies all criteria to a
+ * GraphNode[] and returns the array of matching indices (for Cosmograph selectPoints).
+ *
+ * Design notes
+ * ────────────
+ * • `activeFilter` is truthy only when at least one criterion is non-default.
+ *   Callers can short-circuit to null (= show all) when it's false.
+ * • URL-shareable filter hash is exposed via `filterHash` — consumers can
+ *   append it to the page URL with `history.replaceState` if desired.
+ * • `invertFilter` flag is supported: when true, hidden nodes become visible
+ *   and vice versa (applies AFTER the normal criteria pass).
+ * • `filterLogic` = 'and' | 'or' switches between intersection and union.
+ *   Default is 'and' (all criteria must match).
+ */
+
+import { useState, useCallback, useMemo } from 'react'
+import type { GraphNode, EntityKind } from '@/types/api'
+
+// ────────────────────────────────────────────────────────────────────────────
+// Types
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface GraphFilterState {
+  kinds:        Set<EntityKind>
+  communityIds: Set<number>
+  minDegree:    number
+  fileGlob:     string
+  hasProperty:  string
+  invertFilter: boolean
+  filterLogic:  'and' | 'or'
+}
+
+const DEFAULT_FILTER: GraphFilterState = {
+  kinds:        new Set(),
+  communityIds: new Set(),
+  minDegree:    0,
+  fileGlob:     '',
+  hasProperty:  '',
+  invertFilter: false,
+  filterLogic:  'and',
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// localStorage serialise / deserialise
+// ────────────────────────────────────────────────────────────────────────────
+
+const LS_KEY = 'archigraph:graph-filter'
+
+function serialise(f: GraphFilterState): string {
+  return JSON.stringify({
+    kinds:        [...f.kinds],
+    communityIds: [...f.communityIds],
+    minDegree:    f.minDegree,
+    fileGlob:     f.fileGlob,
+    hasProperty:  f.hasProperty,
+    invertFilter: f.invertFilter,
+    filterLogic:  f.filterLogic,
+  })
+}
+
+function deserialise(raw: string): GraphFilterState {
+  try {
+    const obj = JSON.parse(raw)
+    return {
+      kinds:        new Set<EntityKind>(obj.kinds ?? []),
+      communityIds: new Set<number>((obj.communityIds ?? []).map(Number)),
+      minDegree:    typeof obj.minDegree === 'number' ? obj.minDegree : 0,
+      fileGlob:     typeof obj.fileGlob   === 'string' ? obj.fileGlob  : '',
+      hasProperty:  typeof obj.hasProperty === 'string' ? obj.hasProperty : '',
+      invertFilter: obj.invertFilter === true,
+      filterLogic:  obj.filterLogic === 'or' ? 'or' : 'and',
+    }
+  } catch {
+    return { ...DEFAULT_FILTER }
+  }
+}
+
+function loadFromStorage(): GraphFilterState {
+  try {
+    const raw = typeof localStorage !== 'undefined' ? localStorage.getItem(LS_KEY) : null
+    return raw ? deserialise(raw) : { ...DEFAULT_FILTER }
+  } catch {
+    return { ...DEFAULT_FILTER }
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Glob matcher (path matching only — no full picomatch)
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Simple glob match: supports `*` (any chars within segment) and `**` (any path).
+ * Case-insensitive. Returns true when `glob` is empty.
+ */
+export function matchGlob(path: string | undefined, glob: string): boolean {
+  if (!glob) return true
+  if (!path) return false
+  // Convert glob to regex: ** → .*, * → [^/]*
+  const escaped = glob
+    .replace(/[.+^${}()|[\]\\]/g, '\\$&')  // escape regex specials (not * or ?)
+    .replace(/\*\*/g, '\x00')               // placeholder for **
+    .replace(/\*/g,   '[^/]*')              // * → match within segment
+    .replace(/\x00/g, '.*')                 // ** → match across segments
+  try {
+    return new RegExp('^' + escaped + '$', 'i').test(path)
+  } catch {
+    return path.toLowerCase().includes(glob.toLowerCase())
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// filterNodes — pure function
+// ────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Returns the array of indices in `nodes` that pass all active criteria.
+ * Returns null when no criteria are active (callers should pass null to selectPoints).
+ */
+export function filterNodes(
+  nodes: GraphNode[],
+  filter: GraphFilterState,
+): number[] | null {
+  const isDefault =
+    filter.kinds.size === 0 &&
+    filter.communityIds.size === 0 &&
+    filter.minDegree === 0 &&
+    !filter.fileGlob &&
+    !filter.hasProperty
+
+  if (isDefault && !filter.invertFilter) return null
+
+  const isAnd = filter.filterLogic === 'and'
+
+  const result: number[] = []
+  for (let i = 0; i < nodes.length; i++) {
+    const n = nodes[i]
+    const checks: boolean[] = []
+
+    if (filter.kinds.size > 0) {
+      checks.push(filter.kinds.has(n.kind))
+    }
+    if (filter.communityIds.size > 0) {
+      checks.push(n.community_id !== undefined && filter.communityIds.has(n.community_id))
+    }
+    if (filter.minDegree > 0) {
+      checks.push((n.degree ?? 0) >= filter.minDegree)
+    }
+    if (filter.fileGlob) {
+      checks.push(matchGlob(n.source_file, filter.fileGlob))
+    }
+    if (filter.hasProperty) {
+      checks.push(
+        !!n.properties && filter.hasProperty in n.properties && n.properties[filter.hasProperty] !== null && n.properties[filter.hasProperty] !== '',
+      )
+    }
+
+    if (checks.length === 0) {
+      // No active criteria — node passes by default
+      result.push(i)
+      continue
+    }
+
+    const passes = isAnd ? checks.every(Boolean) : checks.some(Boolean)
+    const effective = filter.invertFilter ? !passes : passes
+    if (effective) result.push(i)
+  }
+
+  return result
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// URL hash serialiser (for #filter= sharing)
+// ────────────────────────────────────────────────────────────────────────────
+
+export function filterToHash(f: GraphFilterState): string {
+  const isDefault =
+    f.kinds.size === 0 &&
+    f.communityIds.size === 0 &&
+    f.minDegree === 0 &&
+    !f.fileGlob &&
+    !f.hasProperty &&
+    !f.invertFilter &&
+    f.filterLogic === 'and'
+  if (isDefault) return ''
+  try {
+    return '#filter=' + encodeURIComponent(serialise(f))
+  } catch {
+    return ''
+  }
+}
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hook
+// ────────────────────────────────────────────────────────────────────────────
+
+export interface UseGraphFilterReturn {
+  filter:           GraphFilterState
+  activeFilter:     boolean
+  filterHash:       string
+  setKinds:         (kinds: Set<EntityKind>) => void
+  setCommunityIds:  (ids: Set<number>) => void
+  setMinDegree:     (v: number) => void
+  setFileGlob:      (v: string) => void
+  setHasProperty:   (v: string) => void
+  setInvert:        (v: boolean) => void
+  setLogic:         (v: 'and' | 'or') => void
+  clearAll:         () => void
+}
+
+export function useGraphFilter(): UseGraphFilterReturn {
+  const [filter, setFilter] = useState<GraphFilterState>(() => loadFromStorage())
+
+  const persist = useCallback((next: GraphFilterState) => {
+    setFilter(next)
+    try {
+      localStorage.setItem(LS_KEY, serialise(next))
+    } catch { /* quota exceeded — ignore */ }
+  }, [])
+
+  const setKinds = useCallback((kinds: Set<EntityKind>) => {
+    setFilter((f) => { const next = { ...f, kinds }; persist(next); return next })
+  }, [persist])
+
+  const setCommunityIds = useCallback((ids: Set<number>) => {
+    setFilter((f) => { const next = { ...f, communityIds: ids }; persist(next); return next })
+  }, [persist])
+
+  const setMinDegree = useCallback((v: number) => {
+    setFilter((f) => { const next = { ...f, minDegree: v }; persist(next); return next })
+  }, [persist])
+
+  const setFileGlob = useCallback((v: string) => {
+    setFilter((f) => { const next = { ...f, fileGlob: v }; persist(next); return next })
+  }, [persist])
+
+  const setHasProperty = useCallback((v: string) => {
+    setFilter((f) => { const next = { ...f, hasProperty: v }; persist(next); return next })
+  }, [persist])
+
+  const setInvert = useCallback((v: boolean) => {
+    setFilter((f) => { const next = { ...f, invertFilter: v }; persist(next); return next })
+  }, [persist])
+
+  const setLogic = useCallback((v: 'and' | 'or') => {
+    setFilter((f) => { const next = { ...f, filterLogic: v }; persist(next); return next })
+  }, [persist])
+
+  const clearAll = useCallback(() => {
+    const next = { ...DEFAULT_FILTER }
+    persist(next)
+  }, [persist])
+
+  const activeFilter = useMemo(() => (
+    filter.kinds.size > 0 ||
+    filter.communityIds.size > 0 ||
+    filter.minDegree > 0 ||
+    !!filter.fileGlob ||
+    !!filter.hasProperty
+  ), [filter])
+
+  const filterHash = useMemo(() => filterToHash(filter), [filter])
+
+  return {
+    filter,
+    activeFilter,
+    filterHash,
+    setKinds,
+    setCommunityIds,
+    setMinDegree,
+    setFileGlob,
+    setHasProperty,
+    setInvert,
+    setLogic,
+    clearAll,
+  }
+}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -10,10 +10,12 @@ import { useHoverLabel } from '@/hooks/graph/useHoverLabel'
 import { useColorMode } from '@/hooks/graph/useColorMode'
 import { useSimulationConfig } from '@/hooks/graph/useSimulationConfig'
 import { useGraphHighlight } from '@/hooks/graph/useGraphHighlight'
+import { useGraphFilter, filterNodes } from '@/hooks/graph/useGraphFilter'
 import { useGraphCameraStore, useSimulationRunning } from '@/store/graphCameraStore'
 import { useThemeContext } from '@/context/ThemeContext'
 import { GraphCanvas } from '@/components/graph/GraphCanvas'
 import { SimulationControls } from '@/components/graph/SimulationControls'
+import { FilterPanel } from '@/components/graph/FilterPanel'
 import { GraphToolbar } from '@/components/graph/GraphToolbar'
 import { EdgeKindFilters } from '@/components/graph/EdgeKindFilters'
 import { CommunityLegend } from '@/components/graph/CommunityLegend'
@@ -64,6 +66,20 @@ export function GraphRoute() {
   // ── Simulation config (#1361 — tunable params persisted to localStorage) ──
   const { config: simConfig, setParam: setSimParam, applyPreset: applySimPreset, shareHash: simShareHash } = useSimulationConfig()
 
+  // ── Multi-criteria graph filter (#1367) ────────────────────────────────────
+  const {
+    filter: graphFilter,
+    activeFilter: graphFilterActive,
+    setKinds: setFilterKinds,
+    setCommunityIds: setFilterCommunities,
+    setMinDegree: setFilterMinDegree,
+    setFileGlob: setFilterFileGlob,
+    setHasProperty: setFilterHasProperty,
+    setInvert: setFilterInvert,
+    setLogic: setFilterLogic,
+    clearAll: clearGraphFilter,
+  } = useGraphFilter()
+
   // ── View state ─────────────────────────────────────────────────────────────
   const [searchQuery, setSearchQuery] = useState('')
   const [showSearchResults, setShowSearchResults] = useState(false)
@@ -109,6 +125,8 @@ export function GraphRoute() {
     ? (activeRepos.size === allRepoSlugs.length ? null : activeRepos)
     : null
 
+  // #1367: multi-criteria filter indices — computed after useGraphData returns nodes.
+
   const { nodes, edges, communities, allEdgeKinds, totalNodeCount, isLoading, error, refetch } =
     useGraphData(
       group ?? '',
@@ -124,6 +142,17 @@ export function GraphRoute() {
     )
 
   const colorMap = useCommunityColors(communities)
+
+  // ── #1367: multi-criteria filter — compute matching indices + match count ──
+  const filterIndices = useMemo<number[] | null>(() => {
+    if (!graphFilterActive) return null
+    return filterNodes(nodes, graphFilter)
+  }, [nodes, graphFilter, graphFilterActive])
+
+  const filterMatchCount = useMemo(() => {
+    if (!graphFilterActive) return nodes.length
+    return filterIndices?.length ?? 0
+  }, [nodes.length, graphFilterActive, filterIndices])
 
   // ── Hover neighbor counts (#1060) ──────────────────────────────────────────
   // Pre-index edges by source and target so neighbor lookup is O(1) per query.
@@ -534,6 +563,23 @@ export function GraphRoute() {
 
           <div className="border-t border-slate-200 dark:border-slate-700" />
 
+          {/* Multi-criteria filter panel (#1367) */}
+          <FilterPanel
+            filter={graphFilter}
+            matchCount={isLoading ? -1 : filterMatchCount}
+            communities={communities}
+            onSetKinds={setFilterKinds}
+            onSetCommunities={setFilterCommunities}
+            onSetMinDegree={setFilterMinDegree}
+            onSetFileGlob={setFilterFileGlob}
+            onSetHasProperty={setFilterHasProperty}
+            onSetInvert={setFilterInvert}
+            onSetLogic={setFilterLogic}
+            onClearAll={clearGraphFilter}
+          />
+
+          <div className="border-t border-slate-200 dark:border-slate-700" />
+
           {/* Repo filter */}
           {allRepoSlugs.length > 0 && (
             <div>
@@ -657,6 +703,7 @@ export function GraphRoute() {
               forceVisibleIds={highlightedNodeIds}
               highlightedEdgeIds={highlightedEdgeIds}
               simulationConfig={simConfig}
+              nodeFilterIndices={filterIndices}
             />
           )}
 


### PR DESCRIPTION
## Summary

- New collapsible **Filter** section in the graph sidebar with five orthogonal criteria: kind multi-select, community multi-select, min-degree threshold, file path glob, and has-property dropdown
- AND/OR logic toggle and invert filter toggle for power users
- Live match-count badge and active-filter count badge on the toggle header
- State persisted to localStorage; filterHash exposes #filter= URL-shareable state
- Filter indices intersected with the existing repo filter + LoD band in GraphCanvas via new nodeFilterIndices prop — no re-fetch, no layout restart, no regression to existing controls

## Closes / Refs
- Closes #1367

## Architecture

New hook useGraphFilter exports pure filterNodes() fn. FilterPanel component manages all UI state externally. GraphCanvas.nodeFilterIndices is intersected with LoD band + repo filter inside the existing selectPoints effects.

Existing controls untouched: repo filter, color mode, sim tunables, edge-kind chips, cross-repo toggle, MCP overlay, snapshot export.

## Testing

Run the headless smoke test: node dashboard/smoke-filter-panel-1367.mjs <port>
23 assertions, 7 screenshots in dashboard/e2e-screenshots/filter-panel-1367/

## Go-beyond
- Invert filter toggle (show non-matching nodes)
- AND / OR logic toggle
- filterHash URL-shareable state (#filter= hash)

🤖 Generated with [Claude Code](https://claude.com/claude-code)