### PR TITLE
fix(mcp): use FindGraphFile in Reload so .fb-only repos are no longer dropped (#1374)

### DIFF
--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -2054,5 +2055,96 @@ func TestPatterns_ConcurrentRefineApply(t *testing.T) {
 	// Confidence must be within valid bounds.
 	if conf, _ := out["confidence"].(float64); conf < 0.0 || conf > 1.0 {
 		t.Errorf("confidence out of bounds after concurrent ops: %v", conf)
+	}
+}
+
+// writeGraphFB writes a graph.Document to <repoDir>/.archigraph/graph.fb
+// (FlatBuffers format). Used to verify fix for issue #1374 item #1.
+func writeGraphFB(t *testing.T, repoDir string, doc *graph.Document) string {
+	t.Helper()
+	dir := filepath.Join(repoDir, ".archigraph")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(path, doc); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// TestReloadFBOnlyRepo verifies fix for issue #1374 item #1:
+// State.Reload() must load repos that have only graph.fb (no graph.json).
+// Previously the stat-guard pointed at graph.json → ENOENT → repo silently dropped.
+func TestReloadFBOnlyRepo(t *testing.T) {
+	dir := t.TempDir()
+
+	// Three repos: one with graph.json only, one with graph.fb only, one with both.
+	repoJSON := filepath.Join(dir, "repo-json")
+	repoFB := filepath.Join(dir, "repo-fb")
+	repoBoth := filepath.Join(dir, "repo-both")
+	for _, p := range []string{repoJSON, repoFB, repoBoth} {
+		if err := os.MkdirAll(p, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	docJSON := fixtureDoc("repo-json")
+	docFB := fixtureDoc("repo-fb")
+	docBoth := fixtureDoc("repo-both")
+
+	writeGraph(t, repoJSON, docJSON)   // graph.json only
+	writeGraphFB(t, repoFB, docFB)    // graph.fb only
+	writeGraph(t, repoBoth, docBoth)  // graph.json
+	writeGraphFB(t, repoBoth, docBoth) // + graph.fb
+
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"test-group": {
+				Repos: map[string]RegistryRepo{
+					"repo-json": {Path: repoJSON},
+					"repo-fb":   {Path: repoFB},
+					"repo-both": {Path: repoBoth},
+				},
+			},
+		},
+	}
+	state := NewState(reg)
+	n, err := state.Reload()
+	if err != nil {
+		t.Fatalf("Reload error: %v", err)
+	}
+	if n != 3 {
+		t.Errorf("expected 3 repos reloaded, got %d", n)
+	}
+
+	grp := state.Group("test-group")
+	if grp == nil {
+		t.Fatal("group not found after Reload")
+	}
+
+	for _, rName := range []string{"repo-json", "repo-fb", "repo-both"} {
+		lr := grp.Repos[rName]
+		if lr == nil {
+			t.Errorf("repo %q missing from loaded group", rName)
+			continue
+		}
+		if lr.Doc == nil {
+			t.Errorf("repo %q: Doc is nil (loadErr=%q)", rName, lr.loadErr)
+			continue
+		}
+		if lr.loadErr != "" {
+			t.Errorf("repo %q: unexpected loadErr=%q", rName, lr.loadErr)
+		}
+		if len(lr.Doc.Entities) != 4 {
+			t.Errorf("repo %q: expected 4 entities, got %d", rName, len(lr.Doc.Entities))
+		}
+	}
+
+	// repo-both: GraphFile should point at graph.fb (fb is preferred when both exist).
+	if lr := grp.Repos["repo-both"]; lr != nil {
+		if !strings.HasSuffix(lr.GraphFile, "graph.fb") {
+			t.Errorf("repo-both: expected GraphFile to end in graph.fb, got %q", lr.GraphFile)
+		}
 	}
 }

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -262,27 +262,39 @@ func (s *State) Reload() (int, error) {
 		seen := map[string]bool{}
 		for rName, rEntry := range gEntry.Repos {
 			seen[rName] = true
-			gf := rEntry.graphFile()
+			// Use FindGraphFile to discover graph.fb (preferred) or graph.json,
+			// fixing issue #1374 item #1: repos that only have graph.fb were
+			// silently dropped because the old os.Stat always targeted graph.json.
+			graphPath, modtimeNs := daemon.FindGraphFile(rEntry.Path)
+			if graphPath == "" {
+				// Neither graph.fb nor graph.json exists yet; skip without error.
+				lr, exists := grp.Repos[rName]
+				if !exists {
+					lr = &LoadedRepo{Repo: rName, Path: rEntry.Path}
+					grp.Repos[rName] = lr
+				}
+				lr.loadErr = "no graph file found (graph.fb or graph.json)"
+				continue
+			}
 			lr, ok := grp.Repos[rName]
 			if !ok {
-				lr = &LoadedRepo{Repo: rName, Path: rEntry.Path, GraphFile: gf}
+				lr = &LoadedRepo{Repo: rName, Path: rEntry.Path, GraphFile: graphPath}
 				grp.Repos[rName] = lr
 			}
-			info, err := os.Stat(gf)
-			if err != nil {
-				lr.loadErr = err.Error()
+			// Update GraphFile in case .fb appeared after initial load.
+			lr.GraphFile = graphPath
+			fileMtime := time.Unix(0, modtimeNs)
+			if fileMtime.Equal(lr.mtime) && lr.Doc != nil {
 				continue
 			}
-			if info.ModTime().Equal(lr.mtime) && lr.Doc != nil {
-				continue
-			}
-			doc, err := readDocument(gf)
+			stateDir := daemon.StateDirForRepo(rEntry.Path)
+			doc, err := readDocumentFromDir(stateDir)
 			if err != nil {
 				lr.loadErr = err.Error()
 				continue
 			}
 			lr.Doc = doc
-			lr.mtime = info.ModTime()
+			lr.mtime = fileMtime
 			lr.loadErr = ""
 			lr.LabelIndex = BuildLabelIndex(doc)
 			lr.BM25 = BuildBM25(doc)
@@ -333,11 +345,20 @@ func (s *State) SnapshotGroups() []*LoadedGroup {
 	return out
 }
 
+// readDocumentFromDir loads a graph document from a state directory.
+// Delegates to graph.LoadGraphFromDir which prefers graph.fb over graph.json
+// (ADR-0016, issue #808).
+func readDocumentFromDir(stateDir string) (*graph.Document, error) {
+	return graph.LoadGraphFromDir(stateDir)
+}
+
 // readDocument loads a graph document from disk. It receives the
 // graph.json path for back-compat with the registry's graphFile()
 // helper, derives the state directory, then delegates to
 // graph.LoadGraphFromDir which prefers graph.fb when present (ADR-0016
 // flip-day, issue #808).
+//
+// Deprecated: callers should prefer readDocumentFromDir.
 func readDocument(graphJSONPath string) (*graph.Document, error) {
 	stateDir := filepath.Dir(graphJSONPath)
 	return graph.LoadGraphFromDir(stateDir)


### PR DESCRIPTION
## What

`State.Reload()` in `internal/mcp/state.go` used `os.Stat` against the hard-coded `graph.json` path from `GraphPathForRepo`. Repos that only have `graph.fb` hit `ENOENT` and were silently skipped via `continue`, dropping their entire entity set from every MCP query.

Affected repos in the upvate group: `core-mobile` (4,251 entities) and `upvate_core_frontend` (9,090 entities) — 13,341 entities total were invisible to the MCP layer.

## Root Cause

`graphFile()` (line 166) → `daemon.GraphPathForRepo()` → always returns `.../graph.json`. The `os.Stat(gf)` call on line 271 fails with ENOENT for `.fb`-only repos. `readDocument` (line 341) already uses `graph.LoadGraphFromDir` which handles `.fb` correctly — the stat guard was the only broken piece.

## Fix

Replace the `graphFile()` + `os.Stat()` pair in `Reload()` with `daemon.FindGraphFile(rEntry.Path)`, which:
- stats both `graph.fb` and `graph.json`
- returns the preferred path (`.fb` first; falls back to `.json`; empty string if neither exists)
- returns the mtime as `int64` nanoseconds for the staleness check

The mtime comparison and the `readDocument` call are updated to use the result. Also introduces `readDocumentFromDir(stateDir)` as the canonical call site (takes a directory, not a `.json` path) and marks `readDocument` deprecated.

## Test

Added `TestReloadFBOnlyRepo` in `server_test.go`:
- **repo-json**: `graph.json` only → loads 4 entities ✓
- **repo-fb**: `graph.fb` only → loads 4 entities ✓ (was 0 / nil Doc before fix)
- **repo-both**: both files → loads 4 entities, `GraphFile` points at `.fb` ✓

## Verification

```
Before (main HEAD, MCP layer):
  upvate group → 7,081 entities (upvate_core only; core-mobile + upvate_core_frontend dropped)

After (this branch, State.Reload against live registry):
  group=upvate repo=core-mobile          entities=4251  graphFile=…/graph.fb
  group=upvate repo=upvate_core          entities=7081  graphFile=…/graph.fb
  group=upvate repo=upvate_core_frontend entities=9090  graphFile=…/graph.fb
  group=upvate TOTAL entities=20422
```

Full mcp package test suite passes: `go test ./internal/mcp/... → ok (1.490s)`.

## Checklist

- [x] Root cause confirmed (`.fb`-only repos → ENOENT on stat → silently skipped)
- [x] Fix uses existing `daemon.FindGraphFile` (already handles fb-first + fallback)
- [x] Mtime staleness optimization preserved (now uses nanosecond mtime from `FindGraphFile`)
- [x] New unit test covers fb-only, json-only, and both-present cases
- [x] All existing mcp tests pass
- [x] No shared daemon touched

Fixes #1374 item #1.