### PR TITLE
fix(graph): emit label for all nodes in Tier-1 payload (#1374)

### DIFF
--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -10,7 +10,7 @@ package dashboard
 // Three-tier graph data model:
 //
 //	Tier 1 (default): Compact render payload — nodes carry id, repo, kind,
-//	  degree, community_id, and label (Process nodes only). Edges carry source, target, kind.
+//	  degree, community_id, and label (all nodes, #1374). Edges carry source, target, kind.
 //	  This is the only shape; there is no ?full= opt-in.
 //
 //	Tier 2: Labels endpoint — GET /api/graph/{group}/labels?top=200 returns
@@ -169,9 +169,10 @@ type graphDenseResponse struct {
 // A soft X-Graph-Warning header is added when node count exceeds
 // softNodeWarnThreshold so the frontend can optionally surface a notice.
 //
-// Tier 1 compact payload: nodes carry only id, repo, kind, degree, community_id.
+// Tier 1 compact payload: nodes carry id, repo, kind, degree, community_id, label.
 // Full entity detail is available via GET /api/graph/{group}/entity/{id} (Tier 3).
-// Labels for the top-N nodes are available via GET /api/graph/{group}/labels (Tier 2).
+// The Tier 2 labels endpoint (GET /api/graph/{group}/labels) remains available for
+// backward compatibility but is no longer the sole source of human-readable names.
 //
 // includeExternal controls whether SCOPE.External placeholder entities are
 // emitted. Default (false) hides stdlib/builtin nodes from the graph view.
@@ -242,23 +243,20 @@ func (s *Server) serveGraphDense(w http.ResponseWriter, group string, repos []*D
 				continue
 			}
 			visible[pid] = true
-			// Tier 1 compact node: id, repo, kind, degree, community_id.
-			// `kind` is included so the frontend can special-case Process sizing (#1121 P3)
-			// and `label` is included for Process entities so they never fall back to
-			// their hash ID in the Tier-2 top-200 labels window (#1121 P4).
+			// Tier 1 compact node: id, repo, kind, degree, community_id, label.
+			// `kind` is included so the frontend can special-case Process sizing (#1121 P3).
+			// `label` is included for ALL entities (#1374) so the frontend never falls back
+			// to repo::<hash-id> for non-Process nodes. Uses e.Name, the same field
+			// returned by the MCP inspect tool.
 			node := graphNodeWire{
 				ID:     pid,
 				Repo:   r.Slug,
 				Kind:   strippedKind,
 				Degree: degreeMap[e.ID],
+				Label:  e.Name,
 			}
 			if e.CommunityID != nil {
 				node.CommunityID = e.CommunityID
-			}
-			// Process entities carry their human label (entry → terminal) in e.Name.
-			// Include it inline so the frontend never falls back to the proc:<hash> ID.
-			if strippedKind == "Process" {
-				node.Label = e.Name
 			}
 			nodes = append(nodes, node)
 		}

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -377,7 +377,7 @@ func TestGraphLabels_UnknownGroup_404(t *testing.T) {
 	}
 }
 
-func TestGraph_LitePayload_KindAlwaysLabelForProcess(t *testing.T) {
+func TestGraph_LitePayload_LabelOnAllNodes(t *testing.T) {
 	ts, _ := newPhase1Server(t)
 	code, body := getJSON(t, ts.URL, "/api/graph/testgroup")
 	if code != 200 {
@@ -387,21 +387,19 @@ func TestGraph_LitePayload_KindAlwaysLabelForProcess(t *testing.T) {
 	if len(nodes) == 0 {
 		t.Fatalf("expected nodes")
 	}
-	// #1121: Tier 1 compact nodes now include `kind` for every node and `label`
-	// for Process nodes only. source_file and pagerank remain excluded.
+	// #1374: Tier 1 compact nodes include `kind` and `label` for every node.
+	// Previously only Process nodes carried label, causing other nodes to render
+	// as repo::<hash-id> in the graph view. Now all nodes carry their human name.
+	// source_file and pagerank remain excluded.
 	for _, n := range nodes {
 		nm, _ := n.(map[string]any)
 		// kind is always present (#1121 P3 — frontend needs it for Process sizing)
 		if nm["kind"] == nil {
 			t.Errorf("Tier 1 node missing kind field; id=%v", nm["id"])
 		}
-		// Process nodes carry label inline (#1121 P4 — avoid proc:<hash> fallback)
-		if nm["kind"] == "Process" && nm["label"] == nil {
-			t.Errorf("Tier 1 Process node missing label field; id=%v", nm["id"])
-		}
-		// Non-Process nodes must NOT carry label (kept compact)
-		if nm["kind"] != "Process" && nm["label"] != nil {
-			t.Errorf("Tier 1 non-Process node should not carry label field; kind=%v got label=%v", nm["kind"], nm["label"])
+		// label is now always present (#1374 — all nodes must carry human-readable name)
+		if nm["label"] == nil {
+			t.Errorf("Tier 1 node missing label field; kind=%v id=%v", nm["kind"], nm["id"])
 		}
 		// source_file stays excluded
 		if nm["source_file"] != nil {


### PR DESCRIPTION
## What

The Tier-1 graph-render API endpoint (`GET /api/graph/{group}`) was emitting nodes **without a `label` field** for every entity except `Process`-kind nodes. The frontend fell back to `repo::<hash-id>` as the display string for all non-Process nodes (Functions, Classes, Methods, Endpoints, etc.).

## Root Cause

In `serveGraphDense` (`internal/dashboard/handlers_graph.go`), `node.Label = e.Name` was guarded behind `if strippedKind == "Process"`. All other entity kinds were serialized with an empty `Label`, which `json:",omitempty"` then dropped entirely from the wire payload.

## Fix

Remove the `Process`-only guard. Unconditionally set `node.Label = e.Name` for all entities. This matches the same `e.Name` field that the MCP `inspect` tool returns as `"label"` (confirmed via `internal/mcp/tools.go:554`). The `graphNodeWire` struct already carried the `label omitempty` field — no struct changes needed.

## Before / After (sample node JSON)

**Before** (Function node — label absent, frontend falls back):
```json
{"id": "svc::a1b2c3d4", "repo": "svc", "kind": "Function", "degree": 3}
```

**After** (same node — label populated):
```json
{"id": "svc::a1b2c3d4", "repo": "svc", "kind": "Function", "degree": 3, "label": "AuthHandler"}
```

Process nodes were already correct and remain correct.

## Scope

- Only `internal/dashboard/handlers_graph.go` (`serveGraphDense`) — **no frontend files touched**.
- `GraphCanvas.tsx` and `graph.tsx` are **not modified** (parallel cosmos.gl migration owns those).
- `graphNodeWire` struct unchanged — `Label string \`json:"label,omitempty"\`` already existed.

## Tests

- Updated `TestGraph_LitePayload_KindAlwaysLabelForProcess` → `TestGraph_LitePayload_LabelOnAllNodes` to assert all nodes carry a non-nil `label`.
- All 13 graph handler tests pass (`go test ./internal/dashboard/ -run TestGraph`).
- Two pre-existing unrelated failures in `TestWriteback_success` / `TestYamlScalar` also fail on `main` unchanged.

## Refs

Fixes #1374 item #2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)