### PR TITLE
fix(django): eliminate phantom orphan entities for signals and admin (#1374)

### DIFF
--- a/internal/custom/python/django.go
+++ b/internal/custom/python/django.go
@@ -2,6 +2,7 @@ package python
 
 import (
 	"context"
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -116,18 +117,38 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 	}
 
 	// 3. Signal receivers
+	// The handler function is the entity; the sender model becomes the TARGET
+	// of a HANDLES_SIGNAL edge — not a new entity.  This avoids the
+	// Service:<ModelName> phantom orphans introduced by the old YAML pattern
+	// (issue #1374 item 3).
 	for _, idx := range allMatchesIndex(djangoReceiverRe, source) {
 		signalType := source[idx[2]:idx[3]]
 		handlerName := source[idx[6]:idx[7]]
 		line := lineOf(source, idx[0])
 		props := map[string]string{"framework": "django", "pattern_type": "signal", "signal_type": signalType}
+		var senderModel string
 		if idx[4] != -1 {
-			props["sender"] = source[idx[4]:idx[5]]
+			senderModel = source[idx[4]:idx[5]]
+			props["sender"] = senderModel
 		}
-		out = append(out, entity(handlerName, "SCOPE.Operation", "function", file.Path, line, props))
+		ent := entity(handlerName, "SCOPE.Operation", "function", file.Path, line, props)
+		// Emit HANDLES_SIGNAL → sender model so the handler is connected to
+		// the existing model entity instead of leaving it as an orphan.
+		if senderModel != "" {
+			ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+				ToID:       djangoModelRef(senderModel),
+				Kind:       string(types.RelationshipKindHandlesSignal),
+				Properties: map[string]string{"signal_type": signalType, "framework": "django"},
+			})
+		}
+		out = append(out, ent)
 	}
 
 	// 4. Admin registrations
+	// Each registration emits an admin-class entity plus a REGISTERS edge to
+	// the existing model entity.  The old YAML pattern emitted a phantom
+	// Controller:<ModelName> entity with no edges; that has been removed
+	// (issue #1374 item 3).
 	for _, idx := range allMatchesIndex(djangoAdminRegRe, source) {
 		modelName := source[idx[2]:idx[3]]
 		adminClass := modelName + "Admin"
@@ -135,15 +156,27 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 			adminClass = source[idx[4]:idx[5]]
 		}
 		line := lineOf(source, idx[0])
-		out = append(out, entity(adminClass, "SCOPE.Component", "admin_class", file.Path, line,
-			map[string]string{"framework": "django", "pattern_type": "admin_register", "model": modelName}))
+		ent := entity(adminClass, "SCOPE.Component", "admin_class", file.Path, line,
+			map[string]string{"framework": "django", "pattern_type": "admin_register", "model": modelName})
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID:       djangoModelRef(modelName),
+			Kind:       string(types.RelationshipKindRegisters),
+			Properties: map[string]string{"framework": "django", "model": modelName},
+		})
+		out = append(out, ent)
 	}
 	for _, idx := range allMatchesIndex(djangoAdminDecorRe, source) {
 		modelName := source[idx[2]:idx[3]]
 		adminClass := source[idx[4]:idx[5]]
 		line := lineOf(source, idx[0])
-		out = append(out, entity(adminClass, "SCOPE.Component", "admin_class", file.Path, line,
-			map[string]string{"framework": "django", "pattern_type": "admin_decorator", "model": modelName}))
+		ent := entity(adminClass, "SCOPE.Component", "admin_class", file.Path, line,
+			map[string]string{"framework": "django", "pattern_type": "admin_decorator", "model": modelName})
+		ent.Relationships = append(ent.Relationships, types.RelationshipRecord{
+			ToID:       djangoModelRef(modelName),
+			Kind:       string(types.RelationshipKindRegisters),
+			Properties: map[string]string{"framework": "django", "model": modelName},
+		})
+		out = append(out, ent)
 	}
 
 	// 5. DRF serializers
@@ -274,6 +307,18 @@ func (e *DjangoExtractor) Extract(ctx context.Context, file extractor.FileInput)
 
 	span.SetAttributes(attribute.Int("entity_count", len(out)))
 	return out, nil
+}
+
+// djangoModelRef returns the structural reference ID used as the ToID for
+// REGISTERS and HANDLES_SIGNAL edges targeting a Django model class.
+//
+// The "Class:<Name>" format matches the intra-repo resolver's byName lookup
+// against SCOPE.Component/class and SCOPE.Schema entities emitted by the
+// Python extractor for `class <Name>(models.Model)`.  This is identical to
+// the convention used by applyORMQueries (engine/orm_queries.go) so both
+// passes connect to the same canonical model node.
+func djangoModelRef(modelName string) string {
+	return fmt.Sprintf("Class:%s", modelName)
 }
 
 // extractClassBody returns the class body text from class_start to the next

--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -9,14 +9,24 @@ import (
 	"github.com/cajasmota/archigraph/internal/extractor"
 )
 
-// extract returns extracted entities with fields for assertion.
-func extract(t *testing.T, key, content string) []struct {
+// extractResult holds extracted entity fields for assertion.
+type extractResult struct {
 	Name      string
 	Kind      string
 	Subtype   string
 	StartLine int
 	Props     map[string]string
-} {
+	Rels      []relResult
+}
+
+// relResult holds a relationship's ToID and Kind for assertion.
+type relResult struct {
+	ToID string
+	Kind string
+}
+
+// extract returns extracted entities with fields for assertion.
+func extract(t *testing.T, key, content string) []extractResult {
 	t.Helper()
 	ext, ok := extractor.Get(key)
 	if !ok {
@@ -30,21 +40,20 @@ func extract(t *testing.T, key, content string) []struct {
 	if err != nil {
 		t.Fatalf("Extract(%s): %v", key, err)
 	}
-	var result []struct {
-		Name      string
-		Kind      string
-		Subtype   string
-		StartLine int
-		Props     map[string]string
-	}
+	var result []extractResult
 	for _, e := range entities {
-		result = append(result, struct {
-			Name      string
-			Kind      string
-			Subtype   string
-			StartLine int
-			Props     map[string]string
-		}{e.Name, e.Kind, e.Subtype, e.StartLine, e.Properties})
+		var rels []relResult
+		for _, r := range e.Relationships {
+			rels = append(rels, relResult{ToID: r.ToID, Kind: r.Kind})
+		}
+		result = append(result, extractResult{
+			Name:      e.Name,
+			Kind:      e.Kind,
+			Subtype:   e.Subtype,
+			StartLine: e.StartLine,
+			Props:     e.Properties,
+			Rels:      rels,
+		})
 	}
 	return result
 }
@@ -263,6 +272,231 @@ class RegularClass:
 	ents := extract(t, "python_django", src)
 	if len(ents) != 0 {
 		t.Fatalf("expected 0 entities for non-Django code, got %d", len(ents))
+	}
+}
+
+// ---- #1374 item 3: phantom-orphan regression tests ----
+
+// TestDjango_SignalReceiver_HandlesSignalEdge verifies that the signal handler
+// function is the emitted entity (not the sender model) and that a
+// HANDLES_SIGNAL edge targets the sender model via "Class:<Model>" ref.
+func TestDjango_SignalReceiver_HandlesSignalEdge(t *testing.T) {
+	src := `@receiver(post_save, sender=Contract)
+def replicate_contract(sender, instance, created, **kwargs):
+    pass
+`
+	ents := extract(t, "python_django", src)
+
+	// Entity name must be the HANDLER function, not the sender model.
+	var handler *extractResult
+	for i := range ents {
+		if ents[i].Name == "replicate_contract" {
+			handler = &ents[i]
+		}
+	}
+	if handler == nil {
+		t.Fatal("expected entity named 'replicate_contract' (handler function), not found")
+	}
+
+	// The sender model must NOT be emitted as a new entity.
+	for _, e := range ents {
+		if e.Name == "Contract" {
+			t.Fatalf("phantom entity emitted for sender model 'Contract' — should only be a relationship target")
+		}
+	}
+
+	// The handler entity must carry a HANDLES_SIGNAL edge to Class:Contract.
+	found := false
+	for _, r := range handler.Rels {
+		if r.Kind == "HANDLES_SIGNAL" && r.ToID == "Class:Contract" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected HANDLES_SIGNAL → Class:Contract edge on handler entity; got rels: %+v", handler.Rels)
+	}
+
+	// Signal type captured in properties.
+	if handler.Props["signal_type"] != "post_save" {
+		t.Errorf("expected signal_type=post_save, got %q", handler.Props["signal_type"])
+	}
+}
+
+// TestDjango_SignalReceiver_NoSender verifies that a @receiver without a
+// sender= kwarg still emits the handler entity (with no phantom orphan).
+func TestDjango_SignalReceiver_NoSender(t *testing.T) {
+	src := `@receiver(request_finished)
+def flush_cache(sender, **kwargs):
+    pass
+`
+	ents := extract(t, "python_django", src)
+	var handler *extractResult
+	for i := range ents {
+		if ents[i].Name == "flush_cache" {
+			handler = &ents[i]
+		}
+	}
+	if handler == nil {
+		t.Fatal("expected entity named 'flush_cache'")
+	}
+	// No HANDLES_SIGNAL edge when there is no sender.
+	for _, r := range handler.Rels {
+		if r.Kind == "HANDLES_SIGNAL" {
+			t.Errorf("unexpected HANDLES_SIGNAL edge without sender= kwarg: %+v", r)
+		}
+	}
+}
+
+// TestDjango_AdminRegister_RegistersEdge verifies that admin.site.register
+// emits the admin-class entity (not a phantom Controller:<Model>) plus a
+// REGISTERS edge targeting the model via "Class:<Model>".
+func TestDjango_AdminRegister_RegistersEdge(t *testing.T) {
+	src := `admin.site.register(Contract, ContractAdmin)
+`
+	ents := extract(t, "python_django", src)
+
+	// Must find the admin-class entity by the ADMIN CLASS name, not the model name.
+	var adminEnt *extractResult
+	for i := range ents {
+		if ents[i].Name == "ContractAdmin" && ents[i].Subtype == "admin_class" {
+			adminEnt = &ents[i]
+		}
+	}
+	if adminEnt == nil {
+		t.Fatal("expected entity named 'ContractAdmin' with subtype=admin_class")
+	}
+
+	// The model name must NOT appear as a new phantom entity.
+	for _, e := range ents {
+		if e.Name == "Contract" {
+			t.Fatalf("phantom entity emitted for model 'Contract' — should only be a relationship target")
+		}
+	}
+
+	// The admin entity must carry a REGISTERS edge to Class:Contract.
+	found := false
+	for _, r := range adminEnt.Rels {
+		if r.Kind == "REGISTERS" && r.ToID == "Class:Contract" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected REGISTERS → Class:Contract edge on ContractAdmin; got rels: %+v", adminEnt.Rels)
+	}
+}
+
+// TestDjango_AdminRegister_ImpliedAdminClass verifies the synthesised
+// "<Model>Admin" name when admin.site.register is called with only the model.
+func TestDjango_AdminRegister_ImpliedAdminClass(t *testing.T) {
+	src := `admin.site.register(Invoice)
+`
+	ents := extract(t, "python_django", src)
+
+	var adminEnt *extractResult
+	for i := range ents {
+		if ents[i].Name == "InvoiceAdmin" && ents[i].Subtype == "admin_class" {
+			adminEnt = &ents[i]
+		}
+	}
+	if adminEnt == nil {
+		t.Fatal("expected synthesised entity named 'InvoiceAdmin'")
+	}
+	found := false
+	for _, r := range adminEnt.Rels {
+		if r.Kind == "REGISTERS" && r.ToID == "Class:Invoice" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected REGISTERS → Class:Invoice edge; got rels: %+v", adminEnt.Rels)
+	}
+}
+
+// TestDjango_AdminDecorator_RegistersEdge verifies that @admin.register(Model)
+// emits the decorated admin class with a REGISTERS edge.
+func TestDjango_AdminDecorator_RegistersEdge(t *testing.T) {
+	src := `@admin.register(Payment)
+class PaymentAdmin(admin.ModelAdmin):
+    pass
+`
+	ents := extract(t, "python_django", src)
+
+	var adminEnt *extractResult
+	for i := range ents {
+		if ents[i].Name == "PaymentAdmin" && ents[i].Subtype == "admin_class" {
+			adminEnt = &ents[i]
+		}
+	}
+	if adminEnt == nil {
+		t.Fatal("expected entity named 'PaymentAdmin' with subtype=admin_class")
+	}
+	for _, e := range ents {
+		if e.Name == "Payment" {
+			t.Fatalf("phantom entity emitted for model 'Payment'")
+		}
+	}
+	found := false
+	for _, r := range adminEnt.Rels {
+		if r.Kind == "REGISTERS" && r.ToID == "Class:Payment" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected REGISTERS → Class:Payment edge on PaymentAdmin; got rels: %+v", adminEnt.Rels)
+	}
+}
+
+// TestDjango_MultipleSignals_NoPhantoms is the regression fixture for the
+// "Contract appears as 5 disconnected nodes" symptom: multiple @receiver
+// handlers on the same model must produce one handler entity each (with
+// HANDLES_SIGNAL edges) and zero phantom model entities.
+func TestDjango_MultipleSignals_NoPhantoms(t *testing.T) {
+	src := `@receiver(post_save, sender=Contract)
+def replicate_on_save(sender, instance, **kwargs):
+    pass
+
+@receiver(post_delete, sender=Contract)
+def replicate_on_delete(sender, instance, **kwargs):
+    pass
+
+@receiver(post_save, sender=Invoice)
+def replicate_invoice(sender, instance, **kwargs):
+    pass
+`
+	ents := extract(t, "python_django", src)
+
+	// Count handler entities.
+	handlerCount := 0
+	for _, e := range ents {
+		if e.Props["pattern_type"] == "signal" {
+			handlerCount++
+		}
+	}
+	if handlerCount != 3 {
+		t.Fatalf("expected 3 signal handler entities, got %d", handlerCount)
+	}
+
+	// No phantom model entities (Service or Controller named after models).
+	for _, e := range ents {
+		if e.Name == "Contract" || e.Name == "Invoice" {
+			t.Fatalf("phantom entity emitted for model name %q (kind=%s)", e.Name, e.Kind)
+		}
+	}
+
+	// Each handler must have a HANDLES_SIGNAL edge.
+	for _, e := range ents {
+		if e.Props["pattern_type"] != "signal" {
+			continue
+		}
+		hasEdge := false
+		for _, r := range e.Rels {
+			if r.Kind == "HANDLES_SIGNAL" {
+				hasEdge = true
+			}
+		}
+		if !hasEdge {
+			t.Errorf("handler %q missing HANDLES_SIGNAL edge", e.Name)
+		}
 	}
 }
 

--- a/internal/engine/rules/python/frameworks/django.yaml
+++ b/internal/engine/rules/python/frameworks/django.yaml
@@ -111,16 +111,13 @@ source_patterns:
     entity_type: Config
     name_group: 1
     scope: class
-  # Admin registration: admin.site.register(MyModel)
-  - pattern: "admin\\.site\\.register\\s*\\(\\s*(\\w+)"
-    entity_type: Controller
-    name_group: 1
-    scope: file
-  # Signal handler: @receiver(post_save, sender=...)
-  - pattern: "@receiver\\s*\\([^)]*sender\\s*=\\s*(\\w+)"
-    entity_type: Service
-    name_group: 1
-    scope: function
+  # Admin registrations and signal receivers are handled by the Go-side
+  # DjangoExtractor (internal/custom/python/django.go) which emits the
+  # correct handler/admin-class entities together with REGISTERS and
+  # HANDLES_SIGNAL edges to the existing model entity.  The YAML patterns
+  # that used to be here emitted phantom Controller:<ModelName> and
+  # Service:<ModelName> entities (capturing the sender/model name instead
+  # of the handler name) with no edges — removed by #1374.
 
 # relationship_rules: regex patterns that produce edges between entities.
 relationship_rules:

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -358,6 +358,18 @@ const (
 	// (name_exact+same_file, name_fuzzy+neighborhood, moved, split, …).
 	// The edge is append-only and never modifies existing entities or edges.
 	RelationshipKindRenamedFrom RelationshipKind = "RENAMED_FROM"
+
+	// #1374: Django signal/admin connectivity edges.
+	//   HANDLES_SIGNAL : signal-handler function entity → sender model entity
+	//                    (emitted for every @receiver(signal, sender=Model) handler).
+	//   REGISTERS      : admin class entity → registered model entity
+	//                    (emitted for admin.site.register(Model[, AdminClass]) and
+	//                    @admin.register(Model) class AdminClass(…)).
+	// Both edges use the model's bare name as the ToID structural-ref
+	// ("Class:<ModelName>") so the intra-repo resolver matches the existing
+	// SCOPE.Component/class or SCOPE.Schema model entity without new linker code.
+	RelationshipKindHandlesSignal RelationshipKind = "HANDLES_SIGNAL"
+	RelationshipKindRegisters     RelationshipKind = "REGISTERS"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -427,6 +439,9 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindHasType,
 		// #1344 rename detection:
 		RelationshipKindRenamedFrom,
+		// #1374 Django signal/admin connectivity:
+		RelationshipKindHandlesSignal,
+		RelationshipKindRegisters,
 	}
 }
 


### PR DESCRIPTION
## What

Fixes #1374 (item 3 — Django phantom entities): Django signal handlers and admin registrations were emitting phantom orphaned entities (the sender model name / registered model name as a new node) instead of connecting the real handler/admin-class entity back to the existing model.

## Root cause

Two `source_patterns` in `django.yaml` captured group 1 = the **model name** (sender= kwarg for `@receiver`, model argument for `admin.site.register`) and emitted:
- `Service:Contract` (from every `@receiver(..., sender=Contract)`)
- `Controller:Contract` (from every `admin.site.register(Contract, ...)`)

These were disconnected clones of the model — the "Contract appears as 5 disconnected nodes" symptom. The real handler function and admin class entities were separately emitted by the Go extractor with no edges back to the model.

## Fix

**1. Remove phantom-emitting YAML patterns** (`django.yaml` lines 115–123)
The two broken `source_patterns` are replaced by a comment explaining that the Go extractor handles both constructs correctly.

**2. Add `HANDLES_SIGNAL` and `REGISTERS` to `kinds.go`**
New typed `RelationshipKind` constants added to `AllRelationshipKinds()`.

**3. Emit connectivity edges from the Go `DjangoExtractor`**
- `@receiver(signal, sender=Model)` → emits `HANDLES_SIGNAL` edge from the handler function entity to `Class:Model` (structural ref matching the intra-repo resolver, same convention as `applyORMQueries`)
- `admin.site.register(Model[, AdminClass])` and `@admin.register(Model)` → emits `REGISTERS` edge from the admin-class entity to `Class:Model`

## Verification

Synthetic fixture (3 signal handlers × 2 models + 2 admin registrations):

| Metric | Before | After |
|---|---|---|
| Phantom `Service:Contract` / `Controller:Contract` orphans | 5+ | **0** |
| Signal handler entities with HANDLES_SIGNAL edges | 0 | **3** |
| Admin class entities with REGISTERS edges | 0 | **2** |

## Tests

6 new unit tests covering all cases:
- `TestDjango_SignalReceiver_HandlesSignalEdge` — handler entity emitted (not sender), HANDLES_SIGNAL edge present
- `TestDjango_SignalReceiver_NoSender` — no edge when sender= absent (no crash)
- `TestDjango_AdminRegister_RegistersEdge` — explicit admin class, REGISTERS edge
- `TestDjango_AdminRegister_ImpliedAdminClass` — synthesised `<Model>Admin` name, REGISTERS edge
- `TestDjango_AdminDecorator_RegistersEdge` — `@admin.register` decorator form
- `TestDjango_MultipleSignals_NoPhantoms` — regression fixture for the 5-node symptom

All 17 Django extractor tests pass; full python custom suite green; types tests green (0 regressions).

## Checklist

- [x] YAML phantom patterns removed
- [x] `HANDLES_SIGNAL` + `REGISTERS` added to `kinds.go` + `AllRelationshipKinds()`
- [x] Go extractor emits edges for signal handlers and admin registrations
- [x] Edge target uses `Class:<Name>` structural ref (same as ORM pass)
- [x] 6 new unit tests with zero-phantom assertion
- [x] No client/fixture names in committed artifacts

Part of the #1374 indexer-quality cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
