### PR TITLE
fix(links): load graph.fb-only repos in cross-repo link passes (#1374 item #4)

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -19,7 +19,6 @@ package links
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -27,6 +26,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
 )
 
 // SchemaVersion is the integer version of the links file shape.
@@ -286,26 +287,14 @@ type edgeRef struct {
 	Kind   string // imports, calls, ...
 }
 
-// onDiskGraph is the minimal subset of graph.Document we need.
-type onDiskGraph struct {
-	Repo     string `json:"repo"`
-	Entities []struct {
-		ID         string            `json:"id"`
-		Name       string            `json:"name"`
-		Kind       string            `json:"kind"`
-		Subtype    string            `json:"subtype,omitempty"`
-		SourceFile string            `json:"source_file"`
-		Properties map[string]string `json:"properties,omitempty"`
-	} `json:"entities"`
-	Relationships []struct {
-		FromID string `json:"from_id"`
-		ToID   string `json:"to_id"`
-		Kind   string `json:"kind"`
-	} `json:"relationships"`
-}
-
-// loadAllGraphs walks graphsDir and returns one repoGraph per
-// <slug>/graph.json (or one if graphsDir is itself a graph.json).
+// loadAllGraphs walks graphsDir and returns one repoGraph per slug directory
+// that contains graph.fb or graph.json (graph.fb preferred per ADR-0016).
+//
+// Previously this function only walked for graph.json, which silently skipped
+// repos indexed with the default fb-only mode (ADR-0016 flip-day, issue #808).
+// The fix: collect directories that own either graph file, then load each via
+// graph.LoadGraphFromDir so the same fb-first / json-fallback logic applies
+// throughout the link passes. Fixes #1374 item #4 (cross_repo_links = 0).
 func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 	if graphsDir == "" {
 		return nil, errors.New("graphs dir required")
@@ -314,9 +303,14 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 	if err != nil {
 		return nil, err
 	}
-	var paths []string
+
+	// Collect the set of directories that contain at least one graph file.
+	// Using a set avoids double-loading when both graph.fb and graph.json
+	// are present in the same directory.
+	dirSet := map[string]bool{}
 	if !fi.IsDir() {
-		paths = []string{graphsDir}
+		// Caller passed a graph.json directly — treat its parent as the dir.
+		dirSet[filepath.Dir(graphsDir)] = true
 	} else {
 		err := filepath.WalkDir(graphsDir, func(p string, d os.DirEntry, err error) error {
 			if err != nil {
@@ -325,8 +319,9 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 			if d.IsDir() {
 				return nil
 			}
-			if filepath.Base(p) == "graph.json" {
-				paths = append(paths, p)
+			base := filepath.Base(p)
+			if base == "graph.json" || base == "graph.fb" {
+				dirSet[filepath.Dir(p)] = true
 			}
 			return nil
 		})
@@ -334,39 +329,45 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 			return nil, err
 		}
 	}
-	sort.Strings(paths)
-	graphs := make([]repoGraph, 0, len(paths))
+
+	// Deterministic iteration order.
+	dirs := make([]string, 0, len(dirSet))
+	for d := range dirSet {
+		dirs = append(dirs, d)
+	}
+	sort.Strings(dirs)
+
+	graphs := make([]repoGraph, 0, len(dirs))
 	seen := map[string]bool{}
-	for _, p := range paths {
-		b, err := os.ReadFile(p)
+	for _, dir := range dirs {
+		// Resolve symlinks so FileRoot points at the real repository.
+		realDir := dir
+		if rp, err := filepath.EvalSymlinks(dir); err == nil {
+			realDir = rp
+		}
+
+		doc, err := graph.LoadGraphFromDir(dir)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("load graph in %s: %w", dir, err)
 		}
-		var g onDiskGraph
-		if err := json.Unmarshal(b, &g); err != nil {
-			return nil, fmt.Errorf("parse %s: %w", p, err)
+
+		repoName := doc.Repo
+		if repoName == "" {
+			// Fallback: derive from the slug sub-directory name (one level up
+			// from the staged dir, which has layout <tmp>/<slug>/graph.{fb,json}).
+			repoName = filepath.Base(realDir)
 		}
-		if g.Repo == "" {
-			// Fallback: derive from parent dir name.
-			g.Repo = filepath.Base(filepath.Dir(filepath.Dir(p)))
-		}
-		if seen[g.Repo] {
+		if seen[repoName] {
 			continue
 		}
-		seen[g.Repo] = true
-		// Resolve the on-disk source-file root: if `p` is a symlink, follow
-		// it so FileRoot points at the real repository (where the source
-		// files live), not the staging directory we may have built.
-		realPath := p
-		if rp, err := filepath.EvalSymlinks(p); err == nil {
-			realPath = rp
-		}
+		seen[repoName] = true
+
 		rg := repoGraph{
-			Repo:     g.Repo,
-			Path:     p,
-			FileRoot: filepath.Dir(filepath.Dir(realPath)),
+			Repo:     repoName,
+			Path:     filepath.Join(dir, "graph.json"), // keep for logging/compat
+			FileRoot: filepath.Dir(realDir),
 		}
-		for _, e := range g.Entities {
+		for _, e := range doc.Entities {
 			rg.Entities = append(rg.Entities, entityNode{
 				ID:         e.ID,
 				Name:       e.Name,
@@ -376,7 +377,7 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 				Properties: e.Properties,
 			})
 		}
-		for _, r := range g.Relationships {
+		for _, r := range doc.Relationships {
 			rg.Edges = append(rg.Edges, edgeRef{FromID: r.FromID, ToID: r.ToID, Kind: r.Kind})
 		}
 		graphs = append(graphs, rg)

--- a/internal/links/links_test.go
+++ b/internal/links/links_test.go
@@ -6,6 +6,9 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
 )
 
 // fixtureGraph is a minimal helper to write a per-repo graph.json that
@@ -597,3 +600,127 @@ func itoa(n int) string {
 
 // keep strings import used.
 var _ = strings.HasPrefix
+
+// TestLoadAllGraphs_FBOnly verifies that loadAllGraphs can load repos that
+// have only graph.fb (no graph.json). This is the default ADR-0016 mode.
+// Regression test for #1374 item #4 (cross_repo_links = 0).
+func TestLoadAllGraphs_FBOnly(t *testing.T) {
+	root := t.TempDir()
+
+	// Helper: write a minimal graph.Document as graph.fb into root/<slug>.
+	writeFB := func(slug string, doc *graph.Document) {
+		t.Helper()
+		dir := filepath.Join(root, slug)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+			t.Fatalf("write graph.fb for %s: %v", slug, err)
+		}
+	}
+
+	writeFB("frontend", &graph.Document{
+		Repo: "frontend",
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "callSchedule", Kind: "function", SourceFile: "src/api.ts"},
+		},
+	})
+	writeFB("backend", &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "b1", Name: "ScheduleView", Kind: "class", SourceFile: "api/views.py"},
+		},
+	})
+
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatalf("loadAllGraphs: %v", err)
+	}
+	if len(graphs) != 2 {
+		t.Fatalf("expected 2 graphs, got %d", len(graphs))
+	}
+	byRepo := map[string]repoGraph{}
+	for _, g := range graphs {
+		byRepo[g.Repo] = g
+	}
+	if _, ok := byRepo["frontend"]; !ok {
+		t.Errorf("frontend repo not loaded (fb-only)")
+	}
+	if _, ok := byRepo["backend"]; !ok {
+		t.Errorf("backend repo not loaded (fb-only)")
+	}
+	if len(byRepo["frontend"].Entities) != 1 {
+		t.Errorf("frontend: expected 1 entity, got %d", len(byRepo["frontend"].Entities))
+	}
+	if len(byRepo["backend"].Entities) != 1 {
+		t.Errorf("backend: expected 1 entity, got %d", len(byRepo["backend"].Entities))
+	}
+}
+
+// TestLoadAllGraphs_MixedFBAndJSON verifies that a group where one repo has
+// graph.json and another has only graph.fb loads both repos correctly.
+// This mirrors the real upvate group (upvate_core has json; frontend/mobile are fb-only).
+func TestLoadAllGraphs_MixedFBAndJSON(t *testing.T) {
+	root := t.TempDir()
+
+	// backend: write graph.json only (old-style or explicit --export-json).
+	backendDir := filepath.Join(root, "backend")
+	if err := os.MkdirAll(backendDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	backendDoc := map[string]any{
+		"version": 1,
+		"repo":    "backend",
+		"entities": []map[string]any{
+			{"id": "b1", "name": "schedule", "kind": "function", "source_file": "api.py"},
+		},
+		"relationships": []map[string]string{},
+	}
+	b, _ := json.Marshal(backendDoc)
+	if err := os.WriteFile(filepath.Join(backendDir, "graph.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// frontend: write graph.fb only (default ADR-0016 mode).
+	frontendDir := filepath.Join(root, "frontend")
+	if err := os.MkdirAll(frontendDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	frontendDoc := &graph.Document{
+		Repo: "frontend",
+		Entities: []graph.Entity{
+			{ID: "f1", Name: "fetchSchedule", Kind: "function", SourceFile: "api.ts"},
+		},
+	}
+	if err := fbwriter.WriteAtomic(filepath.Join(frontendDir, "graph.fb"), frontendDoc); err != nil {
+		t.Fatalf("write graph.fb: %v", err)
+	}
+
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatalf("loadAllGraphs: %v", err)
+	}
+	if len(graphs) != 2 {
+		t.Fatalf("expected 2 graphs (mixed fb+json), got %d", len(graphs))
+	}
+	slugs := make([]string, 0, len(graphs))
+	for _, g := range graphs {
+		slugs = append(slugs, g.Repo)
+	}
+	hasBackend := false
+	hasFrontend := false
+	for _, s := range slugs {
+		switch s {
+		case "backend":
+			hasBackend = true
+		case "frontend":
+			hasFrontend = true
+		}
+	}
+	if !hasBackend {
+		t.Errorf("backend (json-only) not loaded; repos found: %v", slugs)
+	}
+	if !hasFrontend {
+		t.Errorf("frontend (fb-only) not loaded; repos found: %v", slugs)
+	}
+}


### PR DESCRIPTION
## Problem

After ADR-0016 flip-day (#808), the indexer defaults to writing graph.fb only. The link loader in \`internal/links/links.go\` still walked only for graph.json, silently skipping fb-only repos — causing cross_repo_links = 0 for any group where the backend has graph.json but frontend/mobile are fb-only.

Confirmed: 3-repo client group produced 0 cross-repo links before this fix, 917 after.

## Root cause

\`internal/links/links.go loadAllGraphs\`: walked graphsDir and only collected files named graph.json. A repo directory with only graph.fb was silently skipped. All link passes (import, label, http, string, OpenAPI) operate on the result, so all passes produced zero output.

## Fix

\`internal/links/links.go\`: loadAllGraphs now collects directories containing graph.fb OR graph.json (using a set to avoid double-loading), then loads each via graph.LoadGraphFromDir (fb-first per ADR-0016). The now-unnecessary onDiskGraph JSON projection struct has been removed.

Note: The companion state.go fix (Reload fb-awareness via daemon.FindGraphFile) was already merged separately as PR #1375 — this PR carries only the links-layer fix.

## Verified result

```
import: 553 links
label:  149 links
http:   215 links
total:  917 cross-repo links (was 0)
```

## Tests

Two regression tests added in \`internal/links/links_test.go\`:
- \`TestLoadAllGraphs_FBOnly\` — all-fb group loads correctly
- \`TestLoadAllGraphs_MixedFBAndJSON\` — mixed group loads both repos

All existing links tests pass.

Fixes #1374 (item 4 — cross-repo edges)