### PR TITLE
feat(module): populate Properties["module"] on every entity via path rollup (#1381)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -32,6 +32,7 @@ import (
 	pyextr "github.com/cajasmota/archigraph/internal/extractors/python"
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/graph/fbwriter"
+	"github.com/cajasmota/archigraph/internal/module"
 	"github.com/cajasmota/archigraph/internal/progress"
 	"github.com/cajasmota/archigraph/internal/resolve"
 	"github.com/cajasmota/archigraph/internal/treesitter"
@@ -142,6 +143,11 @@ type Indexer struct {
 	resolveIdx        *resolve.Index
 	resolveStats      resolve.Stats
 	finalDispositions resolve.Stats
+
+	// moduleMarkers is built from the walked file list before extraction and
+	// used by buildDocument to derive Properties["module"] for every entity.
+	// Issue #1381 — module extraction via path rollup.
+	moduleMarkers module.MarkerSet
 }
 
 // IndexOption configures optional behaviour on the Indexer. Used as a
@@ -523,6 +529,13 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 	trk.Tick(progress.PhaseScan, len(files), 0, "", 0)
 	fmt.Fprintf(os.Stderr, "archigraph: discovered %d candidate files in %s\n", len(files), absRepo)
 
+	// Issue #1381 — build package-boundary marker set from the full walked
+	// file list.  This is a single O(N) pass over the already-allocated
+	// slice; it costs no additional I/O.  The result is stored on the
+	// Indexer and consumed by buildDocument to stamp Properties["module"]
+	// on every entity.
+	i.moduleMarkers = module.BuildMarkerSet(files)
+
 	// Incremental mode (issue #1339): filter files down to those whose
 	// content hash changed since the last successful index. The manifest is
 	// loaded once before filtering; it is written back in saveGraph below
@@ -788,6 +801,22 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			extStats.Synthesized, extStats.RelationshipsResolved, extStats.UniqueExternals)
 	}
 	i.stats.extSynth = extStats
+
+	// Issue #1381 — stamp module="_external" on synthesised placeholder
+	// entities that have no source_file (ext:* nodes from external.Synthesize,
+	// and any other synthetic entities that buildDocument could not tag because
+	// they were appended after the assembly loop).  EnsureModule skips entities
+	// that already carry a "module" key, so well-sourced entities are unaffected.
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.SourceFile == "" {
+			if e.Properties == nil {
+				e.Properties = map[string]string{"module": "_external"}
+			} else if _, ok := e.Properties["module"]; !ok {
+				e.Properties["module"] = "_external"
+			}
+		}
+	}
 
 	// ADR-0015 phase-1 (#545) — repair.json apply path. Runs BEFORE the
 	// final reclassification so the bug-rate measurement that follows
@@ -2196,6 +2225,11 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		id := graph.EntityID(i.repoTag, r.Kind, r.Name, r.SourceFile)
 		if !seenEntity[id] {
 			seenEntity[id] = true
+			// Issue #1381 — stamp Properties["module"] on every entity at
+			// assembly time using the deterministic path-rollup algorithm.
+			// EnsureModule is a no-op when the key is already set (extractor
+			// overrides are preserved).
+			r.Properties = module.EnsureModule(r.Properties, r.SourceFile, i.moduleMarkers)
 			entities = append(entities, graph.Entity{
 				ID:            id,
 				Name:          r.Name,

--- a/cmd/archigraph/index_test.go
+++ b/cmd/archigraph/index_test.go
@@ -825,3 +825,55 @@ func TestRustTokioMiniChannelRecvDynamic(t *testing.T) {
 		t.Errorf("dynamic count = 0, expected > 0 after Rust channel/recv fix")
 	}
 }
+
+// TestModuleCoverage_AllEntitiesTagged verifies that every entity produced by
+// the indexer carries a non-empty Properties["module"] value after issue #1381.
+// It also confirms the distinct module count is much smaller than the entity
+// count (many entities share the same module), which validates that rollup —
+// not identity — is happening.
+func TestModuleCoverage_AllEntitiesTagged(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		repo string
+	}{
+		{"django_app", "testdata/django_app"},
+		{"spring_app", "testdata/spring_app"},
+		{"crossfile_go", "testdata/crossfile_go"},
+		{"crossfile_python", "testdata/crossfile_python"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc := runIndexerOn(t, tc.repo, tc.name,
+				[]string{"graph-algo", "process-flow", "enrichment"})
+
+			total := len(doc.Entities)
+			if total == 0 {
+				t.Fatalf("%s: no entities produced", tc.name)
+			}
+
+			modules := map[string]int{}
+			missing := 0
+			for _, e := range doc.Entities {
+				m := e.Properties["module"]
+				if m == "" {
+					missing++
+				} else {
+					modules[m]++
+				}
+			}
+
+			if missing > 0 {
+				t.Errorf("%s: %d/%d entities missing Properties[\"module\"]",
+					tc.name, missing, total)
+			}
+
+			t.Logf("%s: entities=%d distinct_modules=%d", tc.name, total, len(modules))
+
+			// Rollup sanity: distinct modules should be strictly fewer than entities
+			// (unless every entity is in a unique module, which would be a bug).
+			if total > 1 && len(modules) >= total {
+				t.Errorf("%s: distinct_modules=%d >= entities=%d; rollup is not collapsing paths",
+					tc.name, len(modules), total)
+			}
+		})
+	}
+}

--- a/internal/module/rollup.go
+++ b/internal/module/rollup.go
@@ -1,0 +1,177 @@
+// Package module derives a stable "module" label for every entity from its
+// source_file path relative to the repository root.
+//
+// The derivation is a deterministic path rollup — same input always produces
+// the same module string.  No clustering or randomness is involved.
+//
+// # Algorithm
+//
+//  1. Strip the repo root prefix from source_file to get a repo-relative path.
+//  2. Scan the path bottom-up for package-boundary markers:
+//     - Go: presence of a go.mod sibling OR same directory as the file (package
+//       declarations are per-directory in Go).
+//     - Python: __init__.py in the same directory.
+//     - JS/TS: package.json OR index.ts / index.js / index.tsx in the same dir.
+//  3. If a marker boundary is found at depth D, use the first D path segments
+//     as the module label (capped at MaxDepth).
+//  4. Fall back to the first DefaultDepth path segments when no marker is found.
+//  5. Files at the repo root (no directory component) → label "_root".
+//
+// # Thread safety
+//
+// Derive is stateless and safe for concurrent use.
+package module
+
+import (
+	"path"
+	"strings"
+)
+
+const (
+	// DefaultDepth is the fallback number of path segments used when no
+	// package-boundary marker is detected.  Two segments gives labels like
+	// "core/views" or "src/features" rather than either the top-level dir
+	// alone or the full file path.
+	DefaultDepth = 2
+
+	// MaxDepth caps the label depth even when a marker is detected deeper
+	// in the tree, preventing excessively granular labels on deeply nested
+	// packages.
+	MaxDepth = 3
+
+	// RootLabel is the module label used for files that live directly at
+	// the repository root (e.g. "main.go", "setup.py").
+	RootLabel = "_root"
+)
+
+// markerFileNames is the set of file names that indicate a package boundary
+// directory when present.  Exported as MarkerFileNames for test access.
+var MarkerFileNames = map[string]bool{
+	"package.json": true,
+	"index.ts":     true,
+	"index.js":     true,
+	"index.tsx":    true,
+	"index.jsx":    true,
+	"__init__.py":  true,
+	"go.mod":       true,
+	"Cargo.toml":   true,
+	"pom.xml":      true,
+	"build.gradle": true,
+}
+
+// MarkerSet is a pre-scanned set of repo-relative directory paths that contain
+// at least one package-boundary marker file.  Built once per index run from
+// the walked file list via BuildMarkerSet.  Nil is safe — Derive falls back to
+// depth-N without marker awareness when ms is nil.
+type MarkerSet map[string]struct{}
+
+// BuildMarkerSet scans a list of repo-relative file paths and returns a
+// MarkerSet of every directory that contains at least one boundary-marker file.
+//
+// repoRelPaths should use forward slashes and be relative to the repo root —
+// the same slice produced by walk.WalkRepo.  Call this once per index run and
+// reuse the result across all Derive calls.
+func BuildMarkerSet(repoRelPaths []string) MarkerSet {
+	ms := make(MarkerSet)
+	for _, p := range repoRelPaths {
+		base := path.Base(p)
+		if !MarkerFileNames[base] {
+			continue
+		}
+		dir := path.Dir(p)
+		if dir == "." {
+			dir = "" // repo root sentinel
+		}
+		ms[dir] = struct{}{}
+	}
+	return ms
+}
+
+// Derive returns the module label for an entity given its repo-relative source
+// file path.
+//
+// sourceFile must be slash-separated and relative to the repo root (the value
+// stored in graph.Entity.SourceFile after the repo-root prefix is stripped).
+// ms may be nil; when non-nil it is consulted for package-boundary hints.
+//
+// The function is pure and deterministic: identical inputs always return the
+// same label.
+func Derive(sourceFile string, ms MarkerSet) string {
+	// Normalise: convert backslashes and strip leading "./".
+	sourceFile = strings.ReplaceAll(sourceFile, "\\", "/")
+	sourceFile = strings.TrimPrefix(sourceFile, "./")
+
+	dir := path.Dir(sourceFile)
+	if dir == "." {
+		// File lives at the repo root.
+		return RootLabel
+	}
+
+	segments := splitSegments(dir)
+	if len(segments) == 0 {
+		return RootLabel
+	}
+
+	// Walk ancestor paths from shallowest to deepest (up to MaxDepth),
+	// recording the deepest marker boundary found.  Walking shallow-first
+	// ensures a top-level marker doesn't collapse sub-packages; we keep
+	// updating bestDepth so the deepest marker within MaxDepth wins.
+	bestDepth := 0
+	if ms != nil {
+		for d := 1; d <= len(segments) && d <= MaxDepth; d++ {
+			ancestor := strings.Join(segments[:d], "/")
+			if _, ok := ms[ancestor]; ok {
+				bestDepth = d
+			}
+		}
+		// Also check the repo root (empty string) — this handles the case
+		// where the root itself has a marker (single-module repos).
+		if _, ok := ms[""]; ok && bestDepth == 0 {
+			// Root marker found: use DefaultDepth so we still get
+			// meaningful labels rather than collapsing everything to "_root".
+			bestDepth = 0 // intentionally leave 0 → fall through to DefaultDepth
+		}
+	}
+
+	depth := DefaultDepth
+	if bestDepth > 0 {
+		depth = bestDepth
+	}
+	// Hard cap and clamp to available segments.
+	if depth > MaxDepth {
+		depth = MaxDepth
+	}
+	if depth > len(segments) {
+		depth = len(segments)
+	}
+
+	return strings.Join(segments[:depth], "/")
+}
+
+// EnsureModule stamps the "module" key into props if it is absent, computing
+// the value from sourceFile and ms.  If props is nil a new map is allocated
+// and returned.  If "module" is already set, props is returned unchanged.
+//
+//	props = module.EnsureModule(props, sourceFile, ms)
+func EnsureModule(props map[string]string, sourceFile string, ms MarkerSet) map[string]string {
+	if props == nil {
+		return map[string]string{"module": Derive(sourceFile, ms)}
+	}
+	if _, ok := props["module"]; !ok {
+		props["module"] = Derive(sourceFile, ms)
+	}
+	return props
+}
+
+// splitSegments splits a slash-separated path into non-empty segments,
+// dropping "." components.
+func splitSegments(p string) []string {
+	parts := strings.Split(p, "/")
+	out := parts[:0]
+	for _, s := range parts {
+		if s != "" && s != "." {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/internal/module/rollup_test.go
+++ b/internal/module/rollup_test.go
@@ -1,0 +1,297 @@
+package module_test
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/module"
+)
+
+// ─── Derive ──────────────────────────────────────────────────────────────────
+
+func TestDerive_RootFiles(t *testing.T) {
+	for _, sf := range []string{
+		"main.go",
+		"setup.py",
+		"index.js",
+		"README.md",
+		"./main.go",
+	} {
+		got := module.Derive(sf, nil)
+		if got != module.RootLabel {
+			t.Errorf("Derive(%q, nil) = %q, want %q", sf, got, module.RootLabel)
+		}
+	}
+}
+
+func TestDerive_DefaultDepthFallback(t *testing.T) {
+	// No markers: should take first 2 segments.
+	cases := []struct {
+		sf   string
+		want string
+	}{
+		{"src/features/auth/login.ts", "src/features"},
+		{"src/features/auth/deep/nested/file.ts", "src/features"},
+		{"core/views/accounts.py", "core/views"},
+		{"core/models/user.py", "core/models"},
+		{"internal/graph/graph.go", "internal/graph"},
+		{"cmd/archigraph/index.go", "cmd/archigraph"},
+		{"a/b/c/d/e/f.go", "a/b"},
+		// Single-segment directory
+		{"pkg/foo.go", "pkg"},
+	}
+	for _, tc := range cases {
+		got := module.Derive(tc.sf, nil)
+		if got != tc.want {
+			t.Errorf("Derive(%q, nil) = %q, want %q", tc.sf, got, tc.want)
+		}
+	}
+}
+
+func TestDerive_MarkerBoundaryPython(t *testing.T) {
+	// core/views has __init__.py → boundary at depth 2
+	ms := module.BuildMarkerSet([]string{
+		"core/__init__.py",
+		"core/views/__init__.py",
+		"core/models/__init__.py",
+	})
+
+	cases := []struct {
+		sf   string
+		want string
+	}{
+		{"core/views/accounts.py", "core/views"},
+		{"core/views/deep/nested.py", "core/views"}, // capped at marker depth 2
+		{"core/models/user.py", "core/models"},
+		{"core/utils.py", "core"},        // file in 'core' dir with __init__.py
+		{"other/stuff/file.py", "other/stuff"}, // no marker → DefaultDepth = 2 → two segments
+	}
+	for _, tc := range cases {
+		got := module.Derive(tc.sf, ms)
+		if got != tc.want {
+			t.Errorf("Derive(%q, ms) = %q, want %q", tc.sf, got, tc.want)
+		}
+	}
+}
+
+func TestDerive_MarkerBoundaryJS(t *testing.T) {
+	ms := module.BuildMarkerSet([]string{
+		"src/features/auth/package.json",
+		"src/features/dashboard/index.ts",
+	})
+
+	cases := []struct {
+		sf   string
+		want string
+	}{
+		{"src/features/auth/login.ts", "src/features/auth"},
+		{"src/features/auth/components/Button.tsx", "src/features/auth"}, // MaxDepth cap
+		{"src/features/dashboard/App.tsx", "src/features/dashboard"},
+		{"src/shared/utils.ts", "src/shared"}, // no marker → DefaultDepth
+	}
+	for _, tc := range cases {
+		got := module.Derive(tc.sf, ms)
+		if got != tc.want {
+			t.Errorf("Derive(%q, ms) = %q, want %q", tc.sf, got, tc.want)
+		}
+	}
+}
+
+func TestDerive_MarkerBoundaryGo(t *testing.T) {
+	ms := module.BuildMarkerSet([]string{
+		"go.mod",
+		"internal/graph/go.mod", // hypothetical nested module
+	})
+
+	cases := []struct {
+		sf   string
+		want string
+	}{
+		// internal/graph has a nested go.mod → boundary at depth 2
+		{"internal/graph/graph.go", "internal/graph"},
+		{"internal/graph/coverage.go", "internal/graph"},
+		// no nested go.mod deeper than 2 → DefaultDepth
+		{"internal/extractor/extractor.go", "internal/extractor"},
+		{"cmd/archigraph/index.go", "cmd/archigraph"},
+	}
+	for _, tc := range cases {
+		got := module.Derive(tc.sf, ms)
+		if got != tc.want {
+			t.Errorf("Derive(%q, ms) = %q, want %q", tc.sf, got, tc.want)
+		}
+	}
+}
+
+func TestDerive_MaxDepthCap(t *testing.T) {
+	// Marker at depth 3 — MaxDepth=3 so boundary is used exactly.
+	ms := module.BuildMarkerSet([]string{
+		"a/b/c/__init__.py",
+	})
+	got := module.Derive("a/b/c/d/e/file.py", ms)
+	// Marker is at depth 3, which equals MaxDepth → label is "a/b/c".
+	want := "a/b/c"
+	if got != want {
+		t.Errorf("Derive cap at MaxDepth=3: got %q, want %q", got, want)
+	}
+
+	// Marker at depth 4 is beyond MaxDepth=3 → scan never sees it → DefaultDepth=2.
+	ms2 := module.BuildMarkerSet([]string{
+		"a/b/c/d/__init__.py",
+	})
+	got2 := module.Derive("a/b/c/d/e/file.py", ms2)
+	want2 := "a/b" // marker beyond MaxDepth → falls back to DefaultDepth
+	if got2 != want2 {
+		t.Errorf("Derive beyond MaxDepth: got %q, want %q", got2, want2)
+	}
+}
+
+func TestDerive_SingleSegmentDirectory(t *testing.T) {
+	// File is one level deep — label is just that segment.
+	got := module.Derive("pkg/foo.go", nil)
+	if got != "pkg" {
+		t.Errorf("got %q, want %q", got, "pkg")
+	}
+}
+
+func TestDerive_Deterministic(t *testing.T) {
+	// Same input must always produce the same output (no randomness).
+	ms := module.BuildMarkerSet([]string{"core/__init__.py"})
+	for i := 0; i < 100; i++ {
+		a := module.Derive("core/views/accounts.py", ms)
+		b := module.Derive("core/views/accounts.py", ms)
+		if a != b {
+			t.Fatalf("non-deterministic: %q vs %q", a, b)
+		}
+	}
+}
+
+func TestDerive_WindowsBackslash(t *testing.T) {
+	got := module.Derive("src\\features\\auth\\login.ts", nil)
+	want := "src/features"
+	if got != want {
+		t.Errorf("backslash normalisation: got %q, want %q", got, want)
+	}
+}
+
+func TestDerive_LeadingDotSlash(t *testing.T) {
+	got := module.Derive("./src/features/login.ts", nil)
+	want := "src/features"
+	if got != want {
+		t.Errorf("leading ./ strip: got %q, want %q", got, want)
+	}
+}
+
+func TestDerive_EmptyAndDotOnly(t *testing.T) {
+	for _, sf := range []string{"", ".", "./"} {
+		got := module.Derive(sf, nil)
+		if got != module.RootLabel {
+			t.Errorf("Derive(%q) = %q, want %q", sf, got, module.RootLabel)
+		}
+	}
+}
+
+// ─── BuildMarkerSet ───────────────────────────────────────────────────────────
+
+func TestBuildMarkerSet_Empty(t *testing.T) {
+	ms := module.BuildMarkerSet(nil)
+	if len(ms) != 0 {
+		t.Fatalf("expected empty MarkerSet, got %d entries", len(ms))
+	}
+}
+
+func TestBuildMarkerSet_IgnoresNonMarkers(t *testing.T) {
+	ms := module.BuildMarkerSet([]string{
+		"core/views/accounts.py",
+		"core/models/user.py",
+		"README.md",
+	})
+	if len(ms) != 0 {
+		t.Fatalf("expected empty MarkerSet, got %v", ms)
+	}
+}
+
+func TestBuildMarkerSet_RootMarker(t *testing.T) {
+	ms := module.BuildMarkerSet([]string{
+		"package.json",
+		"go.mod",
+	})
+	// Root is stored as ""
+	if _, ok := ms[""]; !ok {
+		t.Error("expected root marker (empty string key) to be present")
+	}
+}
+
+func TestBuildMarkerSet_CorrectDirs(t *testing.T) {
+	ms := module.BuildMarkerSet([]string{
+		"core/__init__.py",
+		"core/views/__init__.py",
+		"src/features/auth/package.json",
+	})
+	want := []string{"core", "core/views", "src/features/auth"}
+	for _, w := range want {
+		if _, ok := ms[w]; !ok {
+			t.Errorf("expected marker at dir %q, not found; markers: %v", w, ms)
+		}
+	}
+	if len(ms) != len(want) {
+		t.Errorf("expected %d markers, got %d: %v", len(want), len(ms), ms)
+	}
+}
+
+// ─── EnsureModule ─────────────────────────────────────────────────────────────
+
+func TestEnsureModule_NilProps(t *testing.T) {
+	got := module.EnsureModule(nil, "core/views/accounts.py", nil)
+	if got == nil {
+		t.Fatal("expected non-nil map")
+	}
+	if got["module"] == "" {
+		t.Error("expected module key to be set")
+	}
+}
+
+func TestEnsureModule_AlreadySet(t *testing.T) {
+	props := map[string]string{"module": "custom/label"}
+	got := module.EnsureModule(props, "core/views/accounts.py", nil)
+	if got["module"] != "custom/label" {
+		t.Errorf("expected existing value preserved, got %q", got["module"])
+	}
+}
+
+func TestEnsureModule_SetsWhenAbsent(t *testing.T) {
+	props := map[string]string{"language": "python"}
+	got := module.EnsureModule(props, "core/views/accounts.py", nil)
+	if got["language"] != "python" {
+		t.Error("expected language key preserved")
+	}
+	if got["module"] == "" {
+		t.Error("expected module key to be set")
+	}
+	if got["module"] != "core/views" {
+		t.Errorf("got %q, want %q", got["module"], "core/views")
+	}
+}
+
+// ─── Coverage: every entity gets a non-empty module ───────────────────────────
+
+func TestDerive_NeverEmpty(t *testing.T) {
+	paths := []string{
+		"main.go",
+		"setup.py",
+		"src/index.ts",
+		"src/features/auth/login.ts",
+		"src/features/auth/components/Button.tsx",
+		"internal/graph/coverage.go",
+		"cmd/archigraph/index.go",
+		"a/b/c/d/e/f/g.go",
+	}
+	ms := module.BuildMarkerSet([]string{
+		"src/features/auth/package.json",
+		"internal/graph/__init__.py", // unusual but valid test
+	})
+	for _, p := range paths {
+		got := module.Derive(p, ms)
+		if got == "" {
+			t.Errorf("Derive(%q) returned empty string, want non-empty label", p)
+		}
+	}
+}


### PR DESCRIPTION
## What this PR does

Implements issue #1381 (part of EPIC #1380): populate `Properties["module"]` on **every** entity at index time via a deterministic path-rollup algorithm. This is not clustering — it is a pure derivation from `source_file`.

## Why

`coverage.go`'s `ByModule` rollup already consumes `Properties["module"]`, but that key was never populated. This PR fills it for 100% of entities, enabling module-level coverage breakdowns and providing a stable grouping dimension for downstream tooling.

## How it works

New package `internal/module` implements:

- **`Derive(sourceFile, markerSet)`** — pure function, deterministic, no randomness. Strips repo root, scans ancestor directories for package-boundary markers (`__init__.py`, `package.json`, `index.ts`, `go.mod`, `Cargo.toml`, …), uses the deepest marker boundary up to `MaxDepth=3`. Falls back to `DefaultDepth=2` segments when no marker is found. Root files → `"_root"`.
- **`BuildMarkerSet(paths)`** — single O(N) pass over the walked file list to identify marker directories; called once per index run.
- **`EnsureModule(props, sourceFile, ms)`** — stamps `Properties["module"]` if absent; no-op when the key is already set (allows extractor overrides).

Integration points in `cmd/archigraph/index.go`:

1. `BuildMarkerSet` is called right after `walk.WalkRepo` — zero extra I/O.
2. `EnsureModule` is called in `buildDocument`'s entity assembly loop.
3. After `external.Synthesize`, `ext:*` entities with empty `SourceFile` are stamped `"_external"` to ensure 100% coverage.

## Test coverage

- 19 unit tests in `internal/module/rollup_test.go` covering: root files, default-depth fallback, Python `__init__.py`, JS/TS `package.json`/`index.ts`, Go `go.mod`, MaxDepth cap, determinism, backslash normalisation, leading `./`, empty/`.`-only paths, and a "never empty" coverage sweep.
- Integration test `TestModuleCoverage_AllEntitiesTagged` in `cmd/archigraph/index_test.go` verifies 100% module coverage and rollup-sanity (distinct modules < entity count) across 4 fixtures: `django_app`, `spring_app`, `crossfile_go`, `crossfile_python`.

## Scope constraints

- No changes to entity edges or topology.
- No frontend changes (`dashboard/src` untouched).
- No community/clustering code touched (that is #1382).

## Pre-existing test failures (not introduced by this PR)

`TestIssue820_FixtureF_OrphanRate` (48.27% on main → 48.22% here, slightly improved) and `TestDaemonMCPListTools_Returns14Canonical` both fail on `main` before this PR.

Fixes #1381 — refs #1380