### PR TITLE
fix(graph): merge cross-repo links into GET /api/graph/{group} edge payload

### DIFF
--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -116,7 +116,7 @@ func (s *Server) handleGraph(w http.ResponseWriter, r *http.Request) {
 		repos = filtered
 	}
 
-	s.serveGraphDense(w, group, repos, filterKind, includeExternal)
+	s.serveGraphDense(w, grp, repos, filterKind, includeExternal)
 }
 
 // externalKindSuffix is the trailing portion of the SCOPE.External kind after
@@ -180,7 +180,7 @@ type graphDenseResponse struct {
 // Perf (#1249): uses typed structs (graphNodeWire, graphEdgeWire) to eliminate
 // per-node map allocations.  Pre-sizes slices from entity/relationship counts
 // to avoid slice growth copies.
-func (s *Server) serveGraphDense(w http.ResponseWriter, group string, repos []*DashRepo, filterKind string, includeExternal bool) {
+func (s *Server) serveGraphDense(w http.ResponseWriter, grp *DashGroup, repos []*DashRepo, filterKind string, includeExternal bool) {
 	// Pre-size: count total entities + relationships across repos to avoid
 	// repeated slice growth under GC pressure.
 	totalEntities, totalRels, totalCommunities := 0, 0, 0
@@ -276,6 +276,20 @@ func (s *Server) serveGraphDense(w http.ResponseWriter, group string, repos []*D
 					Kind:   rel.Kind,
 				})
 			}
+		}
+	}
+
+	// Merge cross-repo links (group-level edges produced by the link pass).
+	// Only emit a cross-repo edge when BOTH endpoints are in the visible set so
+	// that single-repo filtered views don't reference nodes that weren't returned.
+	// See issue #1388.
+	for _, l := range grp.Links {
+		if visible[l.Source] && visible[l.Target] {
+			edges = append(edges, graphEdgeWire{
+				FromID: l.Source,
+				ToID:   l.Target,
+				Kind:   l.Kind,
+			})
 		}
 	}
 

--- a/internal/dashboard/handlers_phase1_test.go
+++ b/internal/dashboard/handlers_phase1_test.go
@@ -1313,6 +1313,166 @@ func TestGraph_Dense_EdgeConnectivity(t *testing.T) {
 	}
 }
 
+// TestGraph_CrossRepoEdges_MergedIntoPayload verifies that cross-repo links
+// (grp.Links) are included in the GET /api/graph/{group} edge list when both
+// endpoints are present in the returned node set. Regression test for #1388:
+// before the fix serveGraphDense only iterated per-repo Relationships and
+// never emitted grp.Links, so the unified multi-repo graph showed 0 cross-repo
+// edges even though the link pass had computed them.
+func TestGraph_CrossRepoEdges_MergedIntoPayload(t *testing.T) {
+	st := newFakeStore()
+	st.groups["xrepogrp"] = GroupSummary{
+		Name:       "xrepogrp",
+		ConfigPath: "/tmp/xrepogrp.json",
+		Repos:      []string{"frontend", "backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	frontendDoc := &graph.Document{
+		Repo: "frontend",
+		Entities: []graph.Entity{
+			{ID: "fe1", Name: "FetchUsers", Kind: "SCOPE.Function", SourceFile: "src/api.ts", Language: "typescript"},
+		},
+	}
+	backendDoc := &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "be1", Name: "GET /api/users", Kind: "http_endpoint_definition", SourceFile: "routes.go", Language: "go"},
+		},
+	}
+
+	grp := &DashGroup{
+		Name: "xrepogrp",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Path: "/tmp/frontend", Doc: frontendDoc},
+			"backend":  {Slug: "backend", Path: "/tmp/backend", Doc: backendDoc},
+		},
+		// Cross-repo link: frontend FetchUsers → backend GET /api/users
+		Links: []CrossRepoLink{
+			{
+				Source:     "frontend::fe1",
+				Target:     "backend::be1",
+				Kind:       "HTTP_FETCH",
+				Confidence: 0.95,
+			},
+		},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["xrepogrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	code, body := getJSON(t, ts.URL, "/api/graph/xrepogrp")
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	edges, _ := body["edges"].([]interface{})
+	// Must contain the cross-repo edge.
+	var xrepoEdgeCount int
+	for _, e := range edges {
+		em, _ := e.(map[string]any)
+		from, _ := em["from_id"].(string)
+		to, _ := em["to_id"].(string)
+		if from == "frontend::fe1" && to == "backend::be1" {
+			xrepoEdgeCount++
+		}
+	}
+	if xrepoEdgeCount == 0 {
+		t.Errorf("cross-repo edge frontend::fe1 → backend::be1 missing from /api/graph payload (edges=%d); fix #1388", len(edges))
+	}
+
+	// Verify the cross-repo edge connects nodes from different repos.
+	nodes, _ := body["nodes"].([]interface{})
+	nodeRepos := map[string]string{}
+	for _, n := range nodes {
+		nm, _ := n.(map[string]any)
+		id, _ := nm["id"].(string)
+		repo, _ := nm["repo"].(string)
+		nodeRepos[id] = repo
+	}
+	for _, e := range edges {
+		em, _ := e.(map[string]any)
+		from, _ := em["from_id"].(string)
+		to, _ := em["to_id"].(string)
+		if from == "frontend::fe1" && to == "backend::be1" {
+			if nodeRepos[from] == nodeRepos[to] {
+				t.Errorf("cross-repo edge endpoints are in the same repo %q; expected different repos", nodeRepos[from])
+			}
+		}
+	}
+}
+
+// TestGraph_CrossRepoEdges_ExcludedWhenRepoFiltered verifies that cross-repo
+// edges are excluded from the response when one endpoint is filtered out by
+// a repo filter. This prevents dangling edge references (#1388 filter guard).
+func TestGraph_CrossRepoEdges_ExcludedWhenRepoFiltered(t *testing.T) {
+	st := newFakeStore()
+	st.groups["xrepofilter"] = GroupSummary{
+		Name:       "xrepofilter",
+		ConfigPath: "/tmp/xrepofilter.json",
+		Repos:      []string{"frontend", "backend"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+
+	frontendDoc := &graph.Document{
+		Repo: "frontend",
+		Entities: []graph.Entity{
+			{ID: "fe1", Name: "FetchUsers", Kind: "SCOPE.Function", SourceFile: "src/api.ts", Language: "typescript"},
+		},
+	}
+	backendDoc := &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "be1", Name: "GET /api/users", Kind: "http_endpoint_definition", SourceFile: "routes.go", Language: "go"},
+		},
+	}
+
+	grp := &DashGroup{
+		Name: "xrepofilter",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Path: "/tmp/frontend", Doc: frontendDoc},
+			"backend":  {Slug: "backend", Path: "/tmp/backend", Doc: backendDoc},
+		},
+		Links: []CrossRepoLink{
+			{Source: "frontend::fe1", Target: "backend::be1", Kind: "HTTP_FETCH"},
+		},
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["xrepofilter"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+
+	// Filter to only the frontend repo — backend node is absent, so the
+	// cross-repo edge must not appear (would dangle to an unknown target).
+	code, body := getJSON(t, ts.URL, "/api/graph/xrepofilter?filter_repo=frontend")
+	if code != 200 {
+		t.Fatalf("status=%d body=%v", code, body)
+	}
+
+	edges, _ := body["edges"].([]interface{})
+	for _, e := range edges {
+		em, _ := e.(map[string]any)
+		from, _ := em["from_id"].(string)
+		to, _ := em["to_id"].(string)
+		if from == "frontend::fe1" && to == "backend::be1" {
+			t.Errorf("cross-repo edge must be excluded when target repo (backend) is filtered out")
+		}
+	}
+}
+
 // TestGraph_Dense_TotalNodeCount verifies the dense response includes total_node_count
 // (replacing the old lod_level field removed in #1023).
 func TestGraph_Dense_TotalNodeCount(t *testing.T) {


### PR DESCRIPTION
## Problem

`GET /api/graph/{group}` returns 0 cross-repo edges for a multi-repo group even though the link pass computed them (917 edges confirmed in the `archigraph rebuild upvate` log). The unified graph never shows frontend/mobile→backend connections.

## Root cause

`serveGraphDense` in `internal/dashboard/handlers_graph.go` iterated only `r.Doc.Relationships` (per-repo intra edges) and never touched `grp.Links` (the group-level cross-repo edges stored in `~/.archigraph/groups/<group>-links.json`). The `handleGraphEntity` handler (Tier 3 entity detail) already read `grp.Links` correctly; the Tier 1 graph payload did not.

## Fix

- Refactored `serveGraphDense` to accept `*DashGroup` directly instead of `group string`, eliminating a redundant `GetGroup` cache lookup.
- After collecting intra-repo edges, iterate `grp.Links` and emit each cross-repo link as a `graphEdgeWire` **only when both endpoints are in the `visible` set**. The guard handles single-repo filtered views — a cross-repo edge is suppressed when the peer node isn't in the returned node set, preventing dangling references in the cosmos.gl renderer.
- No frontend changes needed: `GraphCanvas.tsx` renders whatever edges the payload contains.

## Tests

Two new regression tests in `handlers_phase1_test.go`:
- `TestGraph_CrossRepoEdges_MergedIntoPayload` — unfiltered group returns the cross-repo edge; verifies endpoints are in different repos.
- `TestGraph_CrossRepoEdges_ExcludedWhenRepoFiltered` — single-repo `filter_repo=frontend` suppresses a cross-repo edge whose peer (backend) is absent from the node set.

## Before / After (expected for upvate group)

| Metric | Before | After |
|--------|--------|-------|
| Cross-repo edges in `/api/graph/upvate` payload | 0 | ~917 |
| Intra-repo edges | unchanged | unchanged |

## Verification checklist

- [x] `go build ./cmd/...` — clean
- [x] `go test ./internal/dashboard/ -run TestGraph_CrossRepoEdges` — both new tests pass
- [x] All pre-existing graph handler tests pass (`TestGraph_*`, `TestGroupLinks_200`, `TestBuildDegreeMap`, etc.)
- [x] Pre-existing `TestWriteback_success` / `TestYamlScalar` failures confirmed pre-existing on `main` (unrelated to this PR)

Fixes #1388
Related: #1379, EPIC #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)