### PR TITLE
feat(module): deterministic module-node aggregation pass (#1383)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -50,11 +50,12 @@ const (
 	PassRenameDetect   = "rename-detect"   // Pass 5.5: detect entity renames across rebuilds (#1344)
 	PassEnrichment     = "enrichment"      // Pass 6: emit enrichment candidates
 	PassProcessFlow    = "process-flow"    // Pass 7: process-flow BFS over CALLS (#724)
+	PassModuleAgg      = "module-agg"      // Pass 8: module-level aggregation (#1383)
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow,
+	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassModuleAgg,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -972,6 +973,22 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 		// process entities into the canonical id ordering.
 		doc.Stats.Entities = len(doc.Entities)
 		doc.Stats.Relationships = len(doc.Relationships)
+	}
+
+	// Pass 8 — module-level aggregation (issue #1383 / EPIC #1380).
+	// Runs AFTER all entity/relationship passes are finalised (Pass 7 process-
+	// flow is the last mutating pass) so the Module→entity CONTAINS edges and
+	// Module→Module DEPENDS_ON edges reflect the final graph topology. Module
+	// nodes are stored IN the main document alongside real entities; callers
+	// that want only the entity-level graph filter by kind != "Module". The
+	// pass is skippable via --skip-pass=module-agg.
+	if !i.skipPasses[PassModuleAgg] {
+		aggStats := module.Aggregate(doc)
+		if verbose() || aggStats.ModuleNodes > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: module-agg modules=%d contains=%d depends_on=%d\n",
+				aggStats.ModuleNodes, aggStats.ContainsEdges, aggStats.DependsOnEdges)
+		}
 	}
 
 	// Pass 6 — enrichment candidate emission (PORT-LLM / issue #15). Runs

--- a/internal/module/aggregate.go
+++ b/internal/module/aggregate.go
@@ -1,0 +1,299 @@
+// Package module — deterministic module-level graph aggregation (issue #1383).
+//
+// # Summary
+//
+// Aggregate materialises a module-level view of the entity graph. It reads
+// Properties["module"] from every entity in the document and produces:
+//
+//  1. Module container nodes  — one synthetic Entity per distinct (repo, module)
+//     pair.  Kind = "Module", Name = module path (e.g. "core/views").
+//     Stable 16-char hex IDs derived from (repo, "Module", moduleName, "").
+//
+//  2. CONTAINS edges — Module → entity for every entity whose module matches.
+//     FromID = module node ID, ToID = entity ID.
+//
+//  3. Aggregated DEPENDS_ON edges — for every entity-level relationship whose
+//     source entity and target entity live in DIFFERENT modules, a weighted
+//     edge is emitted between the two Module nodes.  The weight (stored as
+//     Properties["weight"]) equals the number of distinct underlying entity
+//     edges.  Self-edges (same module on both sides) are suppressed.
+//
+// # Storage strategy
+//
+// Module nodes and their edges are appended INTO the existing graph.Document
+// so they are queryable via the standard loader, MCP, and API without any new
+// format overhead.  All Module entities carry:
+//
+//	Properties["synthetic"] = "true"
+//	Kind                     = "Module"
+//
+// Consumers that want only the entity-level graph can filter by
+// entity.Kind != "Module".  The existing entity/relationship counts in
+// Stats are updated to include the new nodes and edges.
+//
+// # Determinism
+//
+// Same input always produces the same output:
+//   - Module IDs: graph.EntityID(repo, "Module", name, "").
+//   - CONTAINS IDs: graph.RelationshipID(moduleID, entityID, "CONTAINS").
+//   - DEPENDS_ON IDs: graph.RelationshipID(fromModuleID, toModuleID, "DEPENDS_ON").
+//   - Entity iteration order is normalised by sorting before emitting.
+//
+// # Cross-repo edges
+//
+// Module IDs encode the repo tag so modules from different repos never
+// collide.  A cross-repo entity relationship (fromEntity.Repo != toEntity.Repo)
+// maps to a cross-repo Module→Module DEPENDS_ON edge, which is both valid and
+// useful for multi-repo group views.
+package module
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// KindModule is the entity Kind used for synthetic module container nodes.
+const KindModule = "Module"
+
+// KindContains is the relationship kind used for Module→entity edges.
+const KindContains = "CONTAINS"
+
+// KindDependsOn is the relationship kind used for Module→Module edges.
+const KindDependsOn = "DEPENDS_ON"
+
+// AggregateResult holds the counts produced by Aggregate.
+type AggregateResult struct {
+	// ModuleNodes is the number of synthetic Module entities created.
+	ModuleNodes int
+	// ContainsEdges is the number of Module→entity CONTAINS edges emitted.
+	ContainsEdges int
+	// DependsOnEdges is the number of Module→Module DEPENDS_ON edges emitted.
+	DependsOnEdges int
+}
+
+// moduleKey uniquely identifies a module node within the document.  Each
+// entity carries a repo tag and a module label; cross-repo module nodes are
+// fully distinct.
+type moduleKey struct {
+	repo string
+	name string
+}
+
+// Aggregate runs the module-level aggregation pass over doc.  It appends
+// Module entities and their edges to doc.Entities / doc.Relationships and
+// updates doc.Stats to reflect the additions.
+//
+// The pass is safe to call on any Document that has been produced by the
+// standard indexer pipeline (all entities must have Properties["module"] set;
+// entities without the key receive an implicit "_external" treatment and are
+// placed in a module node named "_external").
+//
+// Aggregate is deterministic: calling it twice on the same Document (without
+// re-running the indexer) is idempotent — duplicate Module nodes are skipped
+// by the seenEntity gate in the caller, but for safety the function also
+// checks for pre-existing Module entities and skips re-emitting them.
+func Aggregate(doc *graph.Document) AggregateResult {
+	if doc == nil {
+		return AggregateResult{}
+	}
+
+	// ── Step 1: build entity-id → module key lookup ─────────────────────────
+	// We need to know which module each entity belongs to so that we can
+	// resolve both endpoints of every relationship.
+	entityModule := make(map[string]moduleKey, len(doc.Entities))
+	// Use Document.Repo for same-repo entities. Cross-repo entity IDs
+	// in a multi-repo group document carry a per-entity repo tag in
+	// Properties["repo"]; single-repo documents use doc.Repo for all.
+	for k := range doc.Entities {
+		e := &doc.Entities[k]
+		if e.Kind == KindModule {
+			continue
+		}
+		mod := "_external"
+		if e.Properties != nil {
+			if v, ok := e.Properties["module"]; ok && v != "" {
+				mod = v
+			}
+		}
+		repo := doc.Repo
+		if e.Properties != nil {
+			if v, ok := e.Properties["repo"]; ok && v != "" {
+				repo = v
+			}
+		}
+		entityModule[e.ID] = moduleKey{repo: repo, name: mod}
+	}
+
+	// ── Step 2: collect distinct module keys ────────────────────────────────
+	// Use a sorted slice for deterministic iteration order later.
+	moduleSet := make(map[moduleKey]struct{})
+	for _, mk := range entityModule {
+		moduleSet[mk] = struct{}{}
+	}
+
+	// ── Step 3: build module-key → stable module node ID ────────────────────
+	moduleNodeID := make(map[moduleKey]string, len(moduleSet))
+	for mk := range moduleSet {
+		moduleNodeID[mk] = moduleNodeEntityID(mk.repo, mk.name)
+	}
+
+	// ── Step 4: check which Module nodes already exist (idempotency) ────────
+	existingModuleIDs := make(map[string]bool, len(doc.Entities))
+	for k := range doc.Entities {
+		if doc.Entities[k].Kind == KindModule {
+			existingModuleIDs[doc.Entities[k].ID] = true
+		}
+	}
+
+	// ── Step 5: emit Module container entities ───────────────────────────────
+	// Collect and sort for stable output.
+	sortedModuleKeys := make([]moduleKey, 0, len(moduleSet))
+	for mk := range moduleSet {
+		sortedModuleKeys = append(sortedModuleKeys, mk)
+	}
+	sort.Slice(sortedModuleKeys, func(i, j int) bool {
+		if sortedModuleKeys[i].repo != sortedModuleKeys[j].repo {
+			return sortedModuleKeys[i].repo < sortedModuleKeys[j].repo
+		}
+		return sortedModuleKeys[i].name < sortedModuleKeys[j].name
+	})
+
+	newModuleCount := 0
+	for _, mk := range sortedModuleKeys {
+		mid := moduleNodeID[mk]
+		if existingModuleIDs[mid] {
+			continue
+		}
+		existingModuleIDs[mid] = true
+		props := map[string]string{
+			"module":    mk.name,
+			"repo":      mk.repo,
+			"synthetic": "true",
+		}
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         mid,
+			Name:       mk.name,
+			Kind:       KindModule,
+			Properties: props,
+		})
+		newModuleCount++
+	}
+
+	// ── Step 6: emit CONTAINS edges (Module → entity) ────────────────────────
+	// Build a dedup set seeded with existing CONTAINS edges so re-runs are
+	// idempotent.
+	existingRels := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		existingRels[doc.Relationships[k].ID] = true
+	}
+
+	// Sort entity IDs for stable CONTAINS emission order.
+	sortedEntityIDs := make([]string, 0, len(entityModule))
+	for eid := range entityModule {
+		sortedEntityIDs = append(sortedEntityIDs, eid)
+	}
+	sort.Strings(sortedEntityIDs)
+
+	containsCount := 0
+	for _, eid := range sortedEntityIDs {
+		mk := entityModule[eid]
+		mid := moduleNodeID[mk]
+		rid := graph.RelationshipID(mid, eid, KindContains)
+		if existingRels[rid] {
+			continue
+		}
+		existingRels[rid] = true
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     rid,
+			FromID: mid,
+			ToID:   eid,
+			Kind:   KindContains,
+		})
+		containsCount++
+	}
+
+	// ── Step 7: aggregate Module→Module DEPENDS_ON edges ─────────────────────
+	// Walk every entity-level relationship; if the from/to entities are in
+	// different modules, accumulate the count into a from-module→to-module
+	// pair.
+	type modPair struct{ from, to moduleKey }
+	edgeWeight := make(map[modPair]int)
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == KindContains || r.Kind == KindDependsOn {
+			// Skip meta-edges we are generating ourselves.
+			continue
+		}
+		fromMK, fromOK := entityModule[r.FromID]
+		toMK, toOK := entityModule[r.ToID]
+		if !fromOK || !toOK {
+			continue
+		}
+		if fromMK == toMK {
+			// Same module — self-edge: skip.
+			continue
+		}
+		edgeWeight[modPair{from: fromMK, to: toMK}]++
+	}
+
+	// Sort pairs for deterministic emission.
+	sortedPairs := make([]modPair, 0, len(edgeWeight))
+	for p := range edgeWeight {
+		sortedPairs = append(sortedPairs, p)
+	}
+	sort.Slice(sortedPairs, func(i, j int) bool {
+		pi, pj := sortedPairs[i], sortedPairs[j]
+		if pi.from.repo != pj.from.repo {
+			return pi.from.repo < pj.from.repo
+		}
+		if pi.from.name != pj.from.name {
+			return pi.from.name < pj.from.name
+		}
+		if pi.to.repo != pj.to.repo {
+			return pi.to.repo < pj.to.repo
+		}
+		return pi.to.name < pj.to.name
+	})
+
+	dependsOnCount := 0
+	for _, p := range sortedPairs {
+		fromMID := moduleNodeID[p.from]
+		toMID := moduleNodeID[p.to]
+		rid := graph.RelationshipID(fromMID, toMID, KindDependsOn)
+		if existingRels[rid] {
+			continue
+		}
+		existingRels[rid] = true
+		w := edgeWeight[p]
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     rid,
+			FromID: fromMID,
+			ToID:   toMID,
+			Kind:   KindDependsOn,
+			Properties: map[string]string{
+				"weight": fmt.Sprintf("%d", w),
+			},
+		})
+		dependsOnCount++
+	}
+
+	// ── Step 8: update document stats ────────────────────────────────────────
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+
+	return AggregateResult{
+		ModuleNodes:    newModuleCount,
+		ContainsEdges:  containsCount,
+		DependsOnEdges: dependsOnCount,
+	}
+}
+
+// moduleNodeEntityID returns the stable 16-char hex entity ID for a Module
+// container node.  The ID encodes (repo, "Module", name, "") to guarantee
+// uniqueness across repos and avoid collisions with real entities (which
+// always have a non-empty sourceFile).
+func moduleNodeEntityID(repo, name string) string {
+	return graph.EntityID(repo, KindModule, name, "")
+}

--- a/internal/module/aggregate_test.go
+++ b/internal/module/aggregate_test.go
@@ -1,0 +1,429 @@
+package module_test
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/module"
+)
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+// makeEntity builds a minimal graph.Entity for test fixtures.
+func makeEntity(id, kind, name, sourceFile, mod, repo string) graph.Entity {
+	props := map[string]string{"module": mod}
+	if repo != "" {
+		props["repo"] = repo
+	}
+	return graph.Entity{
+		ID:         id,
+		Kind:       kind,
+		Name:       name,
+		SourceFile: sourceFile,
+		Properties: props,
+	}
+}
+
+// makeRel builds a minimal graph.Relationship for test fixtures.
+func makeRel(fromID, toID, kind string) graph.Relationship {
+	return graph.Relationship{
+		ID:     graph.RelationshipID(fromID, toID, kind),
+		FromID: fromID,
+		ToID:   toID,
+		Kind:   kind,
+	}
+}
+
+// moduleNodeID returns the expected ID for a synthetic Module node.
+func moduleNodeID(repo, name string) string {
+	return graph.EntityID(repo, module.KindModule, name, "")
+}
+
+// countKind counts entities/relationships of a given kind in a document.
+func countEntityKind(doc *graph.Document, kind string) int {
+	n := 0
+	for k := range doc.Entities {
+		if doc.Entities[k].Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+func countRelKind(doc *graph.Document, kind string) int {
+	n := 0
+	for k := range doc.Relationships {
+		if doc.Relationships[k].Kind == kind {
+			n++
+		}
+	}
+	return n
+}
+
+// findRelWeight returns the integer weight of a DEPENDS_ON edge between two
+// module names, or -1 if the edge is absent.
+func findRelWeight(doc *graph.Document, repo, fromMod, toMod string) int {
+	fmid := moduleNodeID(repo, fromMod)
+	tmid := moduleNodeID(repo, toMod)
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == module.KindDependsOn && r.FromID == fmid && r.ToID == tmid {
+			if r.Properties == nil {
+				return 0
+			}
+			if w, err := strconv.Atoi(r.Properties["weight"]); err == nil {
+				return w
+			}
+			return 0
+		}
+	}
+	return -1
+}
+
+// ─── TestAggregate_NilDoc ─────────────────────────────────────────────────────
+
+func TestAggregate_NilDoc(t *testing.T) {
+	res := module.Aggregate(nil)
+	if res.ModuleNodes != 0 || res.ContainsEdges != 0 || res.DependsOnEdges != 0 {
+		t.Errorf("expected zero result on nil doc, got %+v", res)
+	}
+}
+
+// ─── TestAggregate_EmptyDoc ───────────────────────────────────────────────────
+
+func TestAggregate_EmptyDoc(t *testing.T) {
+	doc := &graph.Document{Repo: "myrepo"}
+	res := module.Aggregate(doc)
+	if res.ModuleNodes != 0 {
+		t.Errorf("empty doc: want 0 module nodes, got %d", res.ModuleNodes)
+	}
+}
+
+// ─── TestAggregate_ModuleNodeCount ───────────────────────────────────────────
+//
+// Two distinct modules (core/views, core/models) → exactly 2 Module nodes.
+
+func TestAggregate_ModuleNodeCount(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "myrepo",
+		Entities: []graph.Entity{
+			makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", ""),
+			makeEntity("e2", "Function", "view_b", "core/views/b.py", "core/views", ""),
+			makeEntity("e3", "Function", "model_a", "core/models/a.py", "core/models", ""),
+		},
+	}
+	res := module.Aggregate(doc)
+	if res.ModuleNodes != 2 {
+		t.Errorf("want 2 module nodes, got %d", res.ModuleNodes)
+	}
+	if countEntityKind(doc, module.KindModule) != 2 {
+		t.Errorf("want 2 Module entities in doc, got %d", countEntityKind(doc, module.KindModule))
+	}
+}
+
+// ─── TestAggregate_ContainsCoverage ──────────────────────────────────────────
+//
+// Every non-Module entity must have exactly one CONTAINS edge pointing to it.
+
+func TestAggregate_ContainsCoverage(t *testing.T) {
+	e1 := makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", "")
+	e2 := makeEntity("e2", "Function", "view_b", "core/views/b.py", "core/views", "")
+	e3 := makeEntity("e3", "Function", "model_a", "core/models/a.py", "core/models", "")
+
+	doc := &graph.Document{
+		Repo:     "myrepo",
+		Entities: []graph.Entity{e1, e2, e3},
+	}
+	res := module.Aggregate(doc)
+	if res.ContainsEdges != 3 {
+		t.Errorf("want 3 CONTAINS edges, got %d", res.ContainsEdges)
+	}
+	if countRelKind(doc, module.KindContains) != 3 {
+		t.Errorf("want 3 CONTAINS rels in doc, got %d", countRelKind(doc, module.KindContains))
+	}
+
+	// Each entity should appear exactly once as ToID in a CONTAINS edge.
+	containsTarget := make(map[string]int)
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == module.KindContains {
+			containsTarget[r.ToID]++
+		}
+	}
+	for _, e := range []graph.Entity{e1, e2, e3} {
+		if containsTarget[e.ID] != 1 {
+			t.Errorf("entity %q: want 1 CONTAINS edge, got %d", e.ID, containsTarget[e.ID])
+		}
+	}
+}
+
+// ─── TestAggregate_DependsOnWeight ───────────────────────────────────────────
+//
+// 14 entity-level CALLS from core/views to core/models → one DEPENDS_ON with
+// weight=14.
+
+func TestAggregate_DependsOnWeight(t *testing.T) {
+	const nCalls = 14
+	var ents []graph.Entity
+	var rels []graph.Relationship
+
+	// 14 distinct view entities each call one model entity.
+	modelID := fmt.Sprintf("model%04d", 0)
+	ents = append(ents, makeEntity(modelID, "Function", fmt.Sprintf("model_%d", 0),
+		"core/models/a.py", "core/models", ""))
+	for i := 0; i < nCalls; i++ {
+		viewID := fmt.Sprintf("view%04d", i)
+		ents = append(ents, makeEntity(viewID, "Function", fmt.Sprintf("view_%d", i),
+			"core/views/a.py", "core/views", ""))
+		rels = append(rels, makeRel(viewID, modelID, "CALLS"))
+	}
+
+	doc := &graph.Document{
+		Repo:          "myrepo",
+		Entities:      ents,
+		Relationships: rels,
+	}
+	module.Aggregate(doc)
+
+	w := findRelWeight(doc, "myrepo", "core/views", "core/models")
+	if w != nCalls {
+		t.Errorf("want DEPENDS_ON weight=%d, got %d", nCalls, w)
+	}
+}
+
+// ─── TestAggregate_NoSelfEdge ─────────────────────────────────────────────────
+//
+// Relationships between entities in the SAME module must not produce a
+// Module→Module DEPENDS_ON self-edge.
+
+func TestAggregate_NoSelfEdge(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "myrepo",
+		Entities: []graph.Entity{
+			makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", ""),
+			makeEntity("e2", "Function", "view_b", "core/views/b.py", "core/views", ""),
+		},
+		Relationships: []graph.Relationship{
+			makeRel("e1", "e2", "CALLS"),
+		},
+	}
+	module.Aggregate(doc)
+
+	if countRelKind(doc, module.KindDependsOn) != 0 {
+		t.Errorf("expected 0 DEPENDS_ON edges (same-module), got %d",
+			countRelKind(doc, module.KindDependsOn))
+	}
+}
+
+// ─── TestAggregate_CrossRepo ──────────────────────────────────────────────────
+//
+// Entity from repo-A calls entity from repo-B in different modules → cross-repo
+// DEPENDS_ON edge is emitted.
+
+func TestAggregate_CrossRepo(t *testing.T) {
+	// e1 is from repo-a, e2 from repo-b (simulated via Properties["repo"]).
+	e1 := makeEntity("ea1", "Function", "svc_call", "svc/client.py", "svc", "repo-a")
+	e2 := makeEntity("eb1", "Function", "handler", "api/handler.py", "api", "repo-b")
+	// Manually set doc.Repo to repo-a; e2 has Properties["repo"] = "repo-b".
+	doc := &graph.Document{
+		Repo:          "repo-a",
+		Entities:      []graph.Entity{e1, e2},
+		Relationships: []graph.Relationship{makeRel("ea1", "eb1", "CALLS")},
+	}
+	module.Aggregate(doc)
+
+	found := false
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == module.KindDependsOn {
+			fromMID := moduleNodeID("repo-a", "svc")
+			toMID := moduleNodeID("repo-b", "api")
+			if r.FromID == fromMID && r.ToID == toMID {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Error("expected cross-repo DEPENDS_ON edge (repo-a:svc → repo-b:api) not found")
+	}
+}
+
+// ─── TestAggregate_StableIDs ──────────────────────────────────────────────────
+//
+// Running Aggregate twice on the same document must not duplicate nodes/edges.
+
+func TestAggregate_Idempotent(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "myrepo",
+		Entities: []graph.Entity{
+			makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", ""),
+			makeEntity("e2", "Function", "model_a", "core/models/a.py", "core/models", ""),
+		},
+		Relationships: []graph.Relationship{makeRel("e1", "e2", "CALLS")},
+	}
+	r1 := module.Aggregate(doc)
+	entities1 := len(doc.Entities)
+	rels1 := len(doc.Relationships)
+
+	// Second call — all nodes/edges already exist; nothing should be added.
+	r2 := module.Aggregate(doc)
+	if len(doc.Entities) != entities1 {
+		t.Errorf("idempotency: entity count changed from %d to %d on second call", entities1, len(doc.Entities))
+	}
+	if len(doc.Relationships) != rels1 {
+		t.Errorf("idempotency: relationship count changed from %d to %d on second call", rels1, len(doc.Relationships))
+	}
+	if r2.ModuleNodes != 0 || r2.ContainsEdges != 0 || r2.DependsOnEdges != 0 {
+		t.Errorf("idempotency: expected zero new artifacts on second run, got %+v", r2)
+	}
+	_ = r1
+}
+
+// ─── TestAggregate_DeterministicEdgeIDs ───────────────────────────────────────
+//
+// Module node IDs and edge IDs must be the same across two independent Aggregate
+// calls on independently constructed but identical documents.
+
+func TestAggregate_DeterministicEdgeIDs(t *testing.T) {
+	build := func() *graph.Document {
+		return &graph.Document{
+			Repo: "myrepo",
+			Entities: []graph.Entity{
+				makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", ""),
+				makeEntity("e2", "Function", "model_a", "core/models/a.py", "core/models", ""),
+			},
+			Relationships: []graph.Relationship{makeRel("e1", "e2", "CALLS")},
+		}
+	}
+
+	doc1 := build()
+	doc2 := build()
+	module.Aggregate(doc1)
+	module.Aggregate(doc2)
+
+	// Collect IDs from both and compare.
+	ids := func(doc *graph.Document) map[string]bool {
+		m := make(map[string]bool)
+		for _, e := range doc.Entities {
+			m[e.ID] = true
+		}
+		for _, r := range doc.Relationships {
+			m[r.ID] = true
+		}
+		return m
+	}
+
+	ids1, ids2 := ids(doc1), ids(doc2)
+	for id := range ids1 {
+		if !ids2[id] {
+			t.Errorf("determinism: ID %q in run-1 but not run-2", id)
+		}
+	}
+	for id := range ids2 {
+		if !ids1[id] {
+			t.Errorf("determinism: ID %q in run-2 but not run-1", id)
+		}
+	}
+}
+
+// ─── TestAggregate_StatsUpdated ───────────────────────────────────────────────
+
+func TestAggregate_StatsUpdated(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "myrepo",
+		Entities: []graph.Entity{
+			makeEntity("e1", "Function", "view_a", "core/views/a.py", "core/views", ""),
+			makeEntity("e2", "Function", "model_a", "core/models/a.py", "core/models", ""),
+		},
+		Relationships: []graph.Relationship{makeRel("e1", "e2", "CALLS")},
+		Stats:         graph.Stats{Entities: 2, Relationships: 1},
+	}
+	module.Aggregate(doc)
+
+	if doc.Stats.Entities != len(doc.Entities) {
+		t.Errorf("Stats.Entities not updated: got %d, want %d", doc.Stats.Entities, len(doc.Entities))
+	}
+	if doc.Stats.Relationships != len(doc.Relationships) {
+		t.Errorf("Stats.Relationships not updated: got %d, want %d", doc.Stats.Relationships, len(doc.Relationships))
+	}
+}
+
+// ─── TestAggregate_ThreeModulesFixture ────────────────────────────────────────
+//
+// Comprehensive fixture: 3 modules, multiple cross-module edges.
+//   - core/views  → core/models  (3 CALLS)
+//   - core/views  → core/utils   (1 CALLS)
+//   - core/models → core/utils   (2 CALLS)
+//   - core/views  → core/views   (5 CALLS, intra — should NOT produce DEPENDS_ON)
+
+func TestAggregate_ThreeModulesFixture(t *testing.T) {
+	entities := []graph.Entity{
+		makeEntity("v1", "Function", "v1", "core/views/a.py", "core/views", ""),
+		makeEntity("v2", "Function", "v2", "core/views/b.py", "core/views", ""),
+		makeEntity("m1", "Function", "m1", "core/models/a.py", "core/models", ""),
+		makeEntity("m2", "Function", "m2", "core/models/b.py", "core/models", ""),
+		makeEntity("m3", "Function", "m3", "core/models/c.py", "core/models", ""),
+		makeEntity("u1", "Function", "u1", "core/utils/a.py", "core/utils", ""),
+		makeEntity("u2", "Function", "u2", "core/utils/b.py", "core/utils", ""),
+	}
+	rels := []graph.Relationship{
+		// core/views → core/models (3)
+		makeRel("v1", "m1", "CALLS"),
+		makeRel("v1", "m2", "CALLS"),
+		makeRel("v2", "m3", "CALLS"),
+		// core/views → core/utils (1)
+		makeRel("v1", "u1", "CALLS"),
+		// core/models → core/utils (2)
+		makeRel("m1", "u1", "CALLS"),
+		makeRel("m2", "u2", "CALLS"),
+		// intra-module (should NOT produce DEPENDS_ON)
+		makeRel("v1", "v2", "CALLS"),
+		makeRel("v1", "v2", "IMPORTS"),
+		makeRel("m1", "m2", "CALLS"),
+		makeRel("m1", "m3", "CALLS"),
+		makeRel("m2", "m3", "CALLS"),
+	}
+	doc := &graph.Document{
+		Repo:          "myrepo",
+		Entities:      entities,
+		Relationships: rels,
+	}
+	res := module.Aggregate(doc)
+
+	// 3 distinct modules → 3 Module nodes.
+	if res.ModuleNodes != 3 {
+		t.Errorf("want 3 Module nodes, got %d", res.ModuleNodes)
+	}
+
+	// Every entity should have exactly 1 CONTAINS edge.
+	if res.ContainsEdges != len(entities) {
+		t.Errorf("want %d CONTAINS edges, got %d", len(entities), res.ContainsEdges)
+	}
+
+	// 3 cross-module pairs → 3 DEPENDS_ON edges.
+	if res.DependsOnEdges != 3 {
+		t.Errorf("want 3 DEPENDS_ON edges, got %d", res.DependsOnEdges)
+	}
+
+	// Validate weights.
+	if w := findRelWeight(doc, "myrepo", "core/views", "core/models"); w != 3 {
+		t.Errorf("core/views→core/models: want weight 3, got %d", w)
+	}
+	if w := findRelWeight(doc, "myrepo", "core/views", "core/utils"); w != 1 {
+		t.Errorf("core/views→core/utils: want weight 1, got %d", w)
+	}
+	if w := findRelWeight(doc, "myrepo", "core/models", "core/utils"); w != 2 {
+		t.Errorf("core/models→core/utils: want weight 2, got %d", w)
+	}
+
+	// No self-edges.
+	for k := range doc.Relationships {
+		r := &doc.Relationships[k]
+		if r.Kind == module.KindDependsOn && r.FromID == r.ToID {
+			t.Errorf("unexpected DEPENDS_ON self-edge: %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
## What & Why

Implements issue #1383 (EPIC #1380): a new deterministic Pass 8 (`module-agg`) that materialises a module-level rollup of the entity graph. Every entity already carries `Properties["module"]` from the existing path-rollup pass (#1381). This pass aggregates those values into a queryable module graph.

## What is emitted

Three kinds of artifacts are appended **in-place** to `graph.Document` (no new file format):

| Artifact | Kind | Notes |
|---|---|---|
| Module container nodes | `"Module"` | One per distinct `(repo, module)` pair. Stable 16-char hex ID via `graph.EntityID(repo, "Module", name, "")`. Carries `Properties["synthetic"]="true"` so callers can filter. |
| Module→entity edges | `"CONTAINS"` | One per entity. FromID = module node, ToID = entity. |
| Module→module edges | `"DEPENDS_ON"` | One per cross-module relationship pair. `Properties["weight"]` = count of underlying entity edges. Same-module self-edges are suppressed. Cross-repo edges work correctly (module IDs are repo-scoped). |

Consumers that want only the entity-level graph filter by `entity.Kind != "Module"`.

## Implementation

- `internal/module/aggregate.go` — new `Aggregate(doc *graph.Document) AggregateResult` function.
- `internal/module/aggregate_test.go` — 11 unit tests (see below).
- `cmd/archigraph/index.go` — added `PassModuleAgg = "module-agg"` pass constant; wired after Pass 7 (process-flow) before enrichment emission. Skippable via `--skip-pass=module-agg`. Logs `archigraph: module-agg modules=N contains=N depends_on=N` under `ARCHIGRAPH_VERBOSE=1`.

## Tests (all pass)

| Test | Asserts |
|---|---|
| `TestAggregate_NilDoc` | no panic / zero result on nil |
| `TestAggregate_EmptyDoc` | no modules on empty document |
| `TestAggregate_ModuleNodeCount` | 2 entities in 2 modules → 2 Module nodes |
| `TestAggregate_ContainsCoverage` | every entity has exactly 1 CONTAINS edge |
| `TestAggregate_DependsOnWeight` | 14 CALLS across modules → `weight=14` |
| `TestAggregate_NoSelfEdge` | intra-module edges produce no DEPENDS_ON |
| `TestAggregate_CrossRepo` | cross-repo entity call → cross-repo Module→Module edge |
| `TestAggregate_Idempotent` | second `Aggregate()` call adds nothing new |
| `TestAggregate_DeterministicEdgeIDs` | two independent runs produce identical IDs |
| `TestAggregate_StatsUpdated` | `doc.Stats` reflects added nodes/edges |
| `TestAggregate_ThreeModulesFixture` | 3 modules, 3 correct weighted DEPENDS_ON edges, 0 self-edges |

## Test plan

- [ ] `go test ./internal/module/... -count=1` — all 30 tests pass (11 new + 19 existing rollup tests)
- [ ] `go build github.com/cajasmota/archigraph/cmd/archigraph` — compiles clean
- [ ] `archigraph index <repo> --skip-pass=graph-algo,enrichment` — stderr shows `module-agg modules=N contains=N depends_on=N`
- [ ] Graph entity count increases by N module nodes; relationship count increases by (CONTAINS + DEPENDS_ON) edges
- [ ] `archigraph index <repo> --skip-pass=module-agg` — pass is skippable, entity/rel counts unchanged vs pre-#1383 baseline

## Non-goals / scope guard

- Frontend changes are out-of-scope (separate agent owns `GraphCanvas.tsx`).
- Community/clustering code is untouched.
- This pass reads `Properties["module"]` — does NOT recompute path rollup.

Fixes #1383
Part of EPIC #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)