### PR TITLE
fix(graph): guard parseColor + communityColor/-1 + repoColor against undefined (live crash)

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -86,7 +86,9 @@ function buildRepoCenters(
 type RGBA = [number, number, number, number]
 
 /** Parse a #rrggbb / #rgb / rgba(...) string into [r,g,b,a] (rgb 0-255, a 0-1). */
-function parseColor(c: string): RGBA {
+function parseColor(c: string | null | undefined): RGBA {
+  // Guard: if c is not a non-empty string, return the slate-500 fallback immediately
+  if (!c || typeof c !== 'string') return [100, 116, 139, 1]
   if (c.startsWith('#')) {
     let hex = c.slice(1)
     if (hex.length === 3) {
@@ -352,10 +354,11 @@ const GraphCanvasInner = ({
         const t = Math.pow(pct, 0.7)
         rgba = silkRoadColor(t)
       } else if (colorMode === 'community') {
-        rgba = parseColor(communityColor(n.community_id ?? 0))
+        // Pass community_id directly; communityColor handles -1 (ungrouped) and null/undefined
+        rgba = parseColor(communityColor(n.community_id))
       } else {
         // repo mode
-        if (n.is_centroid) rgba = parseColor(communityColor(n.community_id ?? 0))
+        if (n.is_centroid) rgba = parseColor(communityColor(n.community_id))
         else rgba = parseColor(repoColor(n.repo))
       }
       out[i * 4] = rgba[0]

--- a/dashboard/src/hooks/graph/useCommunityColors.ts
+++ b/dashboard/src/hooks/graph/useCommunityColors.ts
@@ -57,10 +57,20 @@ export function useCommunityColors(
   }, [communities])
 }
 
+/** Neutral muted gray used for the denoised/ungrouped bucket (community_id = -1)
+ *  and any other undefined/null community. Slate-500 matches the graph's dark theme.
+ */
+const UNGROUPED_COLOR = '#64748b' // slate-500
+
 /**
  * Returns the hex color for a given communityId, using the palette directly.
  * Use this for one-off lookups without hooks.
+ * community_id = -1 (denoised/ungrouped nodes) and null/undefined both return
+ * a muted gray rather than crashing or producing undefined.
  */
-export function communityColor(communityId: number): string {
-  return COMMUNITY_PALETTE[communityId % COMMUNITY_PALETTE.length]
+export function communityColor(communityId: number | null | undefined): string {
+  if (communityId == null || communityId === -1) return UNGROUPED_COLOR
+  // % on a negative number returns negative in JS — ensure positive index
+  const idx = ((communityId % COMMUNITY_PALETTE.length) + COMMUNITY_PALETTE.length) % COMMUNITY_PALETTE.length
+  return COMMUNITY_PALETTE[idx]
 }

--- a/dashboard/src/lib/colors.ts
+++ b/dashboard/src/lib/colors.ts
@@ -90,7 +90,12 @@ const REPO_COLOR_PALETTE: string[] = [
 const repoColorCache = new Map<string, string>()
 const repoOrder: string[] = []
 
-export function repoColor(slug: string): string {
+/** Fallback for nodes whose repo is unknown/undefined (e.g. Module-kind nodes). */
+const UNKNOWN_REPO_COLOR = '#64748b' // slate-500, matches graph dark theme
+
+export function repoColor(slug: string | null | undefined): string {
+  // Guard: Module-kind nodes and other edge-cases may have no repo slug
+  if (!slug) return UNKNOWN_REPO_COLOR
   if (repoColorCache.has(slug)) return repoColorCache.get(slug)!
   if (!repoOrder.includes(slug)) repoOrder.push(slug)
   const idx = repoOrder.indexOf(slug)


### PR DESCRIPTION
## What & Why

Live crash hitting production: `TypeError: Cannot read properties of undefined (reading 'startsWith')` at `GraphCanvas.tsx:90` (`parseColor`). The color-buffer `useMemo` crashed for two new node populations, rendering the entire graph all-white.

**Root causes:**
- `community_id = -1` (denoised/ungrouped bucket from #1389): `?? 0` did not catch -1, so `communityColor(-1)` used JS's negative modulo returning a negative index → `COMMUNITY_PALETTE[-1]` is `undefined` → `parseColor(undefined)` → crash.
- Module-kind nodes with `repo === undefined`: `repoColor(undefined)` hit `repoColorCache.has(undefined)` then returned `REPO_COLOR_PALETTE[0]` — wait, actually returned a valid color *if* `undefined` was coerced to string. But the strict-mode TypeScript type path could diverge; added guard anyway.

## Changes

### 1. `parseColor` — primary crash guard (`GraphCanvas.tsx`)
- Signature: `string` → `string | null | undefined`
- Added top-of-function guard: if `!c || typeof c !== 'string'` → return `[100, 116, 139, 1]` (slate-500 fallback) before any `.startsWith` call
- Stops the crash even if upstream color fns ever return undefined

### 2. `communityColor` — ungrouped/-1 bucket (`useCommunityColors.ts`)
- Signature: `number` → `number | null | undefined`
- `community_id === -1` (denoised nodes) and `null`/`undefined` → return `#64748b` (slate-500 `UNGROUPED_COLOR`) — muted gray in dark theme
- Fixed JS negative-modulo bug: `idx = ((id % len) + len) % len` so large negative IDs (if they ever exist) also map cleanly
- Removed `?? 0` coercions at call sites so `-1` reaches this function rather than being masked to palette[0]

### 3. `repoColor` — unknown/undefined repo (`colors.ts`)
- Signature: `string` → `string | null | undefined`
- `!slug` → return `#64748b` (`UNKNOWN_REPO_COLOR`) instead of pushing `undefined` into repoOrder/cache

## Verification

- Vite build: `tsc -b` passes with zero errors in the three changed files (pre-existing unrelated TS errors in other files are unchanged)
- Playwright smoke: navigated to `/graph/upvate`, switched **Community** mode → **Repo** mode → console error count remained at 1 (pre-existing 503 on `/api/index-progress/upvate`); zero `startsWith` TypeErrors
- Screenshot: `colors-fixed-community.png` shows graph rendering with colors in Community mode

## Refs

Refs #1378 (EPIC: graph quality hardening)