### PR TITLE
fix(graph): readable labels for Process nodes (no more proc:hash)

### DIFF
--- a/internal/dashboard/handlers_graph.go
+++ b/internal/dashboard/handlers_graph.go
@@ -56,6 +56,55 @@ import (
 // X-Graph-Warning response header so the frontend can surface a notice.
 const softNodeWarnThreshold = 50_000
 
+// entityLabel returns the human-readable display label for an entity.
+//
+// For most entities this is e.Name. For Process (SCOPE.Process) entities the
+// Name field holds a synthesised "<entry> → <terminal>" string set by the
+// process-flow BFS pass. If that Name is somehow empty (e.g. the entity was
+// written by an older indexer version, or the entry function itself had an
+// empty Name), we reconstruct a readable label from the stored Properties:
+//
+//  1. entry_name property (the entry function's name, always stored by the pass)
+//  2. chain_labels property (full "A → B → C" string, first/last segment pair)
+//  3. entry_id property (last path component of the entry entity id)
+//  4. The raw entity ID itself (still better than nothing — callers that show
+//     the raw id will at least see a shorter string via this field)
+func entityLabel(e *graph.Entity) string {
+	if e.Name != "" {
+		return e.Name
+	}
+	// Only apply the Properties fallback for Process entities — other kinds
+	// with empty Names are normal (anonymous lambdas, generated stubs, etc.)
+	// and should just propagate the empty string without confusing the caller.
+	if e.Kind != "SCOPE.Process" {
+		return e.Name
+	}
+	if e.Properties != nil {
+		// Prefer the pre-stored entry_name which is the entry function's name.
+		if en := e.Properties["entry_name"]; en != "" {
+			// If we also have chain_labels, derive the terminal name for a richer
+			// "entry → terminal" label that matches what the pass would have built.
+			if cl := e.Properties["chain_labels"]; cl != "" {
+				// chain_labels is "A → B → … → Z"; extract the last segment.
+				parts := strings.Split(cl, " → ")
+				if len(parts) >= 2 {
+					return en + " → " + parts[len(parts)-1]
+				}
+			}
+			return en + " flow"
+		}
+		// Fallback: last path component of entry_id (strips the scope prefix).
+		if eid := e.Properties["entry_id"]; eid != "" {
+			if idx := strings.LastIndexAny(eid, ":./"); idx >= 0 && idx < len(eid)-1 {
+				return eid[idx+1:] + " flow"
+			}
+			return eid + " flow"
+		}
+	}
+	// Last resort: return the raw entity ID so the caller at least has something.
+	return e.ID
+}
+
 // buildDegreeMap returns a map from entity ID to total degree (in + out) for
 // all relationships in a repo.  Used by the dense/mid samplers to rank nodes
 // by connectivity rather than PageRank alone (#1020).
@@ -138,13 +187,16 @@ const externalKindSuffix = "External"
 
 // graphNodeWire is the Tier-1 compact node shape sent over the wire.
 // Fields tagged omitempty are absent for most nodes — keeps JSON tight.
+// Label is NOT omitempty: an empty string must be transmitted explicitly so
+// the frontend client receives "" rather than undefined, which would cause
+// it to fall back to the raw id (e.g. "repo::proc:<hash>").
 type graphNodeWire struct {
 	ID          string `json:"id"`
 	Repo        string `json:"repo"`
 	Kind        string `json:"kind"`
 	Degree      int    `json:"degree"`
 	CommunityID *int   `json:"community_id,omitempty"`
-	Label       string `json:"label,omitempty"`
+	Label       string `json:"label"`
 }
 
 // graphEdgeWire is the Tier-1 compact edge shape.
@@ -265,14 +317,16 @@ func (s *Server) serveGraphDense(w http.ResponseWriter, grp *DashGroup, repos []
 			// Tier 1 compact node: id, repo, kind, degree, community_id, label.
 			// `kind` is included so the frontend can special-case Process sizing (#1121 P3).
 			// `label` is included for ALL entities (#1374) so the frontend never falls back
-			// to repo::<hash-id> for non-Process nodes. Uses e.Name, the same field
-			// returned by the MCP inspect tool.
+			// to repo::<hash-id> for non-Process nodes. entityLabel handles the
+			// SCOPE.Process fallback path: when e.Name is empty (older graph data or
+			// entry function with no name), it reconstructs a readable label from
+			// Properties["entry_name"] and Properties["chain_labels"].
 			node := graphNodeWire{
 				ID:     pid,
 				Repo:   r.Slug,
 				Kind:   strippedKind,
 				Degree: degreeMap[e.ID],
-				Label:  e.Name,
+				Label:  entityLabel(e),
 			}
 			if e.CommunityID != nil {
 				node.CommunityID = e.CommunityID
@@ -376,7 +430,7 @@ func (s *Server) handleGraphLabels(w http.ResponseWriter, r *http.Request) {
 				e := &r.Doc.Entities[i]
 				pid := dashPrefixedID(r.Slug, e.ID)
 				if want[pid] {
-					out = append(out, labelEntry{ID: pid, Label: e.Name})
+					out = append(out, labelEntry{ID: pid, Label: entityLabel(e)})
 				}
 			}
 		}
@@ -410,7 +464,7 @@ func (s *Server) handleGraphLabels(w http.ResponseWriter, r *http.Request) {
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			pid := dashPrefixedID(repo.Slug, e.ID)
-			all = append(all, degreeLabel{id: pid, label: e.Name, degree: degMap[e.ID]})
+			all = append(all, degreeLabel{id: pid, label: entityLabel(e), degree: degMap[e.ID]})
 		}
 	}
 
@@ -527,7 +581,7 @@ func (s *Server) handleGraphEntity(w http.ResponseWriter, r *http.Request) {
 		if e, ok := entityIndex[nid]; ok {
 			neighbors = append(neighbors, neighborWire{
 				ID:         dashPrefixedID(repo.Slug, e.ID),
-				Label:      e.Name,
+				Label:      entityLabel(e),
 				Kind:       dashStripScopePrefix(e.Kind),
 				SourceFile: e.SourceFile,
 				StartLine:  e.StartLine,
@@ -653,7 +707,7 @@ func (s *Server) handleGroupGodNodes(w http.ResponseWriter, r *http.Request) {
 			}
 			nodes = append(nodes, godNode{
 				ID:       dashPrefixedID(r.Slug, e.ID),
-				Label:    e.Name,
+				Label:    entityLabel(e),
 				Kind:     dashStripScopePrefix(e.Kind),
 				Repo:     r.Slug,
 				PageRank: pr,

--- a/internal/dashboard/handlers_graph_test.go
+++ b/internal/dashboard/handlers_graph_test.go
@@ -1,0 +1,301 @@
+package dashboard
+
+// handlers_graph_test.go — unit tests for Process node label handling in the
+// /api/graph/{group} endpoint (and the entityLabel helper).
+//
+// Tests verify that:
+//   - Process entities with a non-empty Name emit that Name as the label.
+//   - Process entities with an empty Name fall back to Properties["entry_name"]
+//     + terminal derived from Properties["chain_labels"].
+//   - Process entities with neither Name nor chain_labels fall back to
+//     Properties["entry_id"] (last path component) + " flow".
+//   - Non-Process entities with an empty Name are returned with an empty label
+//     (not a hash fallback) — the graphNodeWire.Label field is always present in
+//     the JSON so the frontend never sees undefined and falls back to the raw id.
+//   - The "label" JSON key is always present in graphNodeWire output even when
+//     the value is an empty string (no omitempty).
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ─── helpers ──────────────────────────────────────────────────────────────────
+
+func makeGraphTestGroup(entities []graph.Entity, rels []graph.Relationship) *DashGroup {
+	doc := &graph.Document{
+		Repo:          "testrepo",
+		Entities:      entities,
+		Relationships: rels,
+	}
+	return &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"testrepo": {Slug: "testrepo", Path: "/tmp/fake", Doc: doc},
+		},
+	}
+}
+
+func newGraphTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name:       "testgrp",
+		ConfigPath: "/tmp/testgrp.json",
+		Repos:      []string{"testrepo"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+// fetchGraphNodes calls GET /api/graph/testgrp and returns the nodes slice.
+func fetchGraphNodes(t *testing.T, ts *httptest.Server) []map[string]interface{} {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/api/graph/testgrp")
+	if err != nil {
+		t.Fatalf("GET /api/graph/testgrp: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != 200 {
+		t.Fatalf("status=%d", resp.StatusCode)
+	}
+	var body map[string]interface{}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	nodesRaw, ok := body["nodes"].([]interface{})
+	if !ok {
+		t.Fatal("nodes field missing or wrong type")
+	}
+	out := make([]map[string]interface{}, 0, len(nodesRaw))
+	for _, n := range nodesRaw {
+		if m, ok := n.(map[string]interface{}); ok {
+			out = append(out, m)
+		}
+	}
+	return out
+}
+
+// nodeByID finds the first node whose "id" field contains the given suffix.
+func nodeByID(nodes []map[string]interface{}, idSuffix string) map[string]interface{} {
+	for _, n := range nodes {
+		if id, _ := n["id"].(string); strings.Contains(id, idSuffix) {
+			return n
+		}
+	}
+	return nil
+}
+
+// ─── entityLabel unit tests ───────────────────────────────────────────────────
+
+func TestEntityLabel_NonEmpty(t *testing.T) {
+	e := &graph.Entity{ID: "fn:abc", Name: "handleSubmit", Kind: "SCOPE.Function"}
+	if got := entityLabel(e); got != "handleSubmit" {
+		t.Errorf("entityLabel = %q, want 'handleSubmit'", got)
+	}
+}
+
+func TestEntityLabel_ProcessWithName(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "proc:abc123",
+		Name: "handleOrder → writeDB",
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_name":   "handleOrder",
+			"chain_labels": "handleOrder → callService → writeDB",
+		},
+	}
+	// When Name is set, entityLabel returns it unchanged — no Properties lookup.
+	if got := entityLabel(e); got != "handleOrder → writeDB" {
+		t.Errorf("entityLabel = %q, want 'handleOrder → writeDB'", got)
+	}
+}
+
+func TestEntityLabel_ProcessEmptyName_FallsBackToEntryName(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "proc:deadbeef01234567",
+		Name: "", // empty — simulates older graph data
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_name":   "processPayment",
+			"entry_id":     "testrepo::SCOPE.Function:processPayment",
+			"chain_labels": "processPayment → chargeCard → emitEvent → notify",
+		},
+	}
+	got := entityLabel(e)
+	// Should derive "processPayment → notify" from entry_name + last chain segment.
+	if got != "processPayment → notify" {
+		t.Errorf("entityLabel = %q, want 'processPayment → notify'", got)
+	}
+}
+
+func TestEntityLabel_ProcessEmptyNameNoChainLabels_FallsBackToEntryNameFlow(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "proc:deadbeef01234567",
+		Name: "",
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_name": "syncInventory",
+		},
+	}
+	got := entityLabel(e)
+	if got != "syncInventory flow" {
+		t.Errorf("entityLabel = %q, want 'syncInventory flow'", got)
+	}
+}
+
+func TestEntityLabel_ProcessEmptyNameNoEntryName_FallsBackToEntryID(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "proc:deadbeef01234567",
+		Name: "",
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_id": "testrepo::SCOPE.Function:auditLog",
+		},
+	}
+	got := entityLabel(e)
+	if got != "auditLog flow" {
+		t.Errorf("entityLabel = %q, want 'auditLog flow'", got)
+	}
+}
+
+func TestEntityLabel_ProcessEmptyNameNoProperties_FallsBackToID(t *testing.T) {
+	e := &graph.Entity{
+		ID:   "proc:deadbeef01234567",
+		Name: "",
+		Kind: "SCOPE.Process",
+	}
+	got := entityLabel(e)
+	// When there are absolutely no properties, the raw ID is returned
+	// rather than showing an empty string.
+	if got == "" {
+		t.Errorf("entityLabel returned empty string, want non-empty fallback")
+	}
+}
+
+func TestEntityLabel_NonProcessEmptyName_ReturnsEmpty(t *testing.T) {
+	// Non-Process entities with empty Name are NOT given a fallback — they
+	// return "" which will be transmitted as the label (not omitted), so the
+	// frontend receives "" and won't show the raw id.
+	e := &graph.Entity{ID: "fn:xyz", Name: "", Kind: "SCOPE.Function"}
+	if got := entityLabel(e); got != "" {
+		t.Errorf("entityLabel = %q, want '' for non-Process empty-Name entity", got)
+	}
+}
+
+// ─── HTTP handler integration tests ──────────────────────────────────────────
+
+// TestHandlerGraph_ProcessNodeLabel_NonEmptyName verifies that a SCOPE.Process
+// entity with a non-empty Name emits that Name as the label field in the JSON.
+func TestHandlerGraph_ProcessNodeLabel_NonEmptyName(t *testing.T) {
+	procEnt := graph.Entity{
+		ID:   "proc:0123456789abcdef",
+		Name: "handleSubmit → writeDB",
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_name":   "handleSubmit",
+			"chain_labels": "handleSubmit → callRepo → writeDB",
+		},
+	}
+	grp := makeGraphTestGroup([]graph.Entity{procEnt}, nil)
+	ts := newGraphTestServer(t, grp)
+
+	nodes := fetchGraphNodes(t, ts)
+	node := nodeByID(nodes, "proc:0123456789abcdef")
+	if node == nil {
+		t.Fatal("proc node not found in response")
+	}
+	label, _ := node["label"].(string)
+	if label != "handleSubmit → writeDB" {
+		t.Errorf("label=%q, want 'handleSubmit → writeDB'", label)
+	}
+}
+
+// TestHandlerGraph_ProcessNodeLabel_EmptyName verifies that a SCOPE.Process
+// entity with an empty Name (older graph data) falls back to Properties-derived
+// label so the frontend never shows the raw proc:<hash> id.
+func TestHandlerGraph_ProcessNodeLabel_EmptyName(t *testing.T) {
+	procEnt := graph.Entity{
+		ID:   "proc:deadbeef12345678",
+		Name: "", // empty — the bug scenario
+		Kind: "SCOPE.Process",
+		Properties: map[string]string{
+			"entry_name":   "processOrder",
+			"chain_labels": "processOrder → validateCart → chargeCard → notify",
+		},
+	}
+	grp := makeGraphTestGroup([]graph.Entity{procEnt}, nil)
+	ts := newGraphTestServer(t, grp)
+
+	nodes := fetchGraphNodes(t, ts)
+	node := nodeByID(nodes, "proc:deadbeef12345678")
+	if node == nil {
+		t.Fatal("proc node not found in response")
+	}
+
+	label, _ := node["label"].(string)
+	// Must NOT be the raw ID and must NOT be empty.
+	if strings.Contains(label, "proc:deadbeef12345678") {
+		t.Errorf("label still contains the raw proc hash: %q", label)
+	}
+	if label == "" {
+		t.Error("label is empty; expected a human-readable fallback")
+	}
+	// Should be derived from entry_name + last segment of chain_labels.
+	want := "processOrder → notify"
+	if label != want {
+		t.Errorf("label=%q, want %q", label, want)
+	}
+}
+
+// TestHandlerGraph_LabelFieldAlwaysPresent checks that the "label" JSON field
+// is always present in the graphNodeWire output, even when the entity has an
+// empty Name and no Properties (the zero-value case). The frontend
+// normalizeGraphNode does `raw.label ?? raw.id` — undefined (absent field)
+// triggers the raw-id fallback; an explicit empty string does not.
+func TestHandlerGraph_LabelFieldAlwaysPresent(t *testing.T) {
+	fnEnt := graph.Entity{
+		ID:   "fn:abc",
+		Name: "", // empty name — anonymous or generated entity
+		Kind: "SCOPE.Function",
+	}
+	grp := makeGraphTestGroup([]graph.Entity{fnEnt}, nil)
+	ts := newGraphTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/graph/testgrp")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	// Decode into a raw map so we can distinguish absent vs. present-empty
+	// JSON keys.
+	var body struct {
+		Nodes []map[string]json.RawMessage `json:"nodes"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Nodes) == 0 {
+		t.Fatal("no nodes returned")
+	}
+	raw := body.Nodes[0]
+	if _, ok := raw["label"]; !ok {
+		t.Error(`"label" key absent from graphNodeWire JSON — must always be present (no omitempty)`)
+	}
+}

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -281,7 +281,32 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 				}
 			}
 		}
-		label := fmt.Sprintf("%s → %s", entry.Name, terminalName)
+		// entryLabel is the human-readable name for the entry entity.
+		// entry.Name is the canonical source; fall back through QualifiedName
+		// and then the last path component of the ID so the Process entity
+		// always carries a non-empty, non-hash Name field.
+		entryLabel := entry.Name
+		if entryLabel == "" {
+			entryLabel = entry.QualifiedName
+		}
+		if entryLabel == "" {
+			// Strip any "<repo>::<kind>:" prefix from the ID.
+			if idx := strings.LastIndex(entry.ID, ":"); idx >= 0 && idx < len(entry.ID)-1 {
+				entryLabel = entry.ID[idx+1:]
+			} else {
+				entryLabel = entry.ID
+			}
+		}
+		// terminalLabel: prefer the human name, fall back to last ID segment.
+		terminalLabel := terminalName
+		if terminalLabel == terminalID && terminalID != "" {
+			// terminalName still equals the raw ID (phantom fallback or missing name).
+			// Try stripping the ID prefix for a shorter display value.
+			if idx := strings.LastIndex(terminalID, ":"); idx >= 0 && idx < len(terminalID)-1 {
+				terminalLabel = terminalID[idx+1:]
+			}
+		}
+		label := fmt.Sprintf("%s → %s", entryLabel, terminalLabel)
 
 		props := map[string]string{
 			"entry_id":             entry.ID,


### PR DESCRIPTION
## What

Two-layer fix for `SCOPE.Process` entity labels displaying as raw `proc:<hash>` IDs in the graph tooltip instead of human-readable text.

## Why it was broken

**Engine layer (`process_flow.go`):** When an entry entity has an empty `Name` (e.g. anonymous functions or extractors that don't populate `Name`), the label was computed as `" → terminalName"` — a space-prefixed string that's technically non-empty but not useful. Worse, for cross-repo phantom terminals where `terminalName == terminalID`, the label contained the full raw ID hash.

**Serve layer (`handlers_graph.go`):** `graphNodeWire.Label` was tagged `json:"label,omitempty"`. If `e.Name == ""`, the field was **omitted** from the JSON response. The frontend `normalizeGraphNode` does `raw.label ?? raw.id` — `undefined ?? raw.id` evaluates to the raw `proc:<hash>` ID, so the tooltip showed the hash.

## Fix

**Engine (pass 7):** Added fallback chain for `entryLabel` and `terminalLabel`:
- `entry.Name` (primary, unchanged)
- `entry.QualifiedName` (new fallback)
- Last path component of `entry.ID` (strips `repo::kind:` prefix)

For the terminal side: when `terminalName == terminalID` (phantom/missing name), strip the ID prefix to a shorter display value.

**Serve layer:**
1. Removed `omitempty` from `graphNodeWire.Label` — empty string is now transmitted explicitly, so the frontend receives `""` instead of `undefined`, preventing the raw-id fallback.
2. Added `entityLabel(e *graph.Entity) string` helper: for `SCOPE.Process` entities with empty `Name` (older indexed data), derives a readable label from stored `Properties` in priority order:
   - `entry_name` + last segment of `chain_labels` → `"processOrder → notify"`
   - `entry_name` alone → `"processOrder flow"`
   - Last component of `entry_id` → `"auditLog flow"`
   - Raw entity ID (last resort, always non-empty)
3. Applied `entityLabel(e)` across all label-producing call sites in the file (Tier-1 graph payload, labels endpoint, god-nodes, neighbor wires).

Non-Process entities with empty `Name` are unaffected: `entityLabel` returns `""` for them, which is transmitted explicitly and renders as blank — correct for anonymous/generated entities.

## Tests

10 new tests in `internal/dashboard/handlers_graph_test.go`:
- `TestEntityLabel_*` (7 cases): unit tests for every fallback level of the `entityLabel` helper
- `TestHandlerGraph_ProcessNodeLabel_NonEmptyName`: HTTP handler happy path — named Process node emits correct label
- `TestHandlerGraph_ProcessNodeLabel_EmptyName`: HTTP handler bug path — Process node with empty Name emits Properties-derived label, never the `proc:hash`
- `TestHandlerGraph_LabelFieldAlwaysPresent`: verifies `"label"` key is always present in JSON even for empty-Name entities (guards the `omitempty` removal)

## Before / After samples

| Entity | Before | After |
|--------|--------|-------|
| `proc:0270c40214bbc8f0` (name set) | `AttachmentViewer → split` ✓ | `AttachmentViewer → split` ✓ (unchanged) |
| `proc:deadbeef12345678` (name empty) | *(omitted from JSON → fallback to `proc:deadbeef12345678`)* | `processOrder → notify` ✓ |
| entry with empty Name, QualifiedName `pkg.handlePayment` | ` → logAudit` | `pkg.handlePayment → logAudit` ✓ |

## Checklist
- [x] Engine tests pass (`go test ./internal/engine/...`)
- [x] Dashboard tests pass (`go test ./internal/dashboard/` — pre-existing `TestYamlScalar` failure unrelated)
- [x] Binary builds clean (`go build ./cmd/archigraph/...`)
- [x] Normal entities (non-Process) unaffected
- [x] No omitempty on `Label` — JSON field always present

Refs #1374