### PR TITLE
feat(graph): layout cache + load-perf pass (#1399)

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/hooks/graph/useNodeSizingConfig'
 import type { RenderConfig } from '@/hooks/graph/useRenderConfig'
 import { DEFAULT_RENDER_CONFIG } from '@/hooks/graph/useRenderConfig'
+import type { LayoutCacheEntry } from '@/hooks/graph/useLayoutCache'
 
 // ---------------------------------------------------------------------------
 // cosmos.gl (MIT) engine wrapper — replaces @cosmograph/react (#1373)
@@ -178,6 +179,14 @@ export interface GraphCanvasProps {
   nodeFilterIndices?: number[] | null
   nodeSizingConfig?: NodeSizingConfig
   renderConfig?: RenderConfig
+  /** Group slug — used as cache key namespace for position persistence. */
+  group?: string
+  /** Pre-loaded settled positions from localStorage (null = cold load). */
+  savedLayout?: LayoutCacheEntry | null
+  /** Called once when the simulation settles, with the final Float32 positions. */
+  onLayoutSaved?: (positions: Float32Array) => void
+  /** When true, ignore savedLayout and run a fresh simulation (Re-layout). */
+  relayoutRequested?: boolean
 }
 
 /** Truncate long labels at ~30 chars for layout legibility */
@@ -218,12 +227,20 @@ const GraphCanvasInner = ({
   nodeFilterIndices,
   nodeSizingConfig,
   renderConfig,
+  savedLayout,
+  onLayoutSaved,
+  relayoutRequested,
 }: GraphCanvasProps) => {
   // #1361: merge tunable params with Silk Road defaults
   const simCfg: SimulationConfig = useMemo(
     () => simulationConfig ? { ...SILK_ROAD_DEFAULTS, ...simulationConfig } : SILK_ROAD_DEFAULTS,
     [simulationConfig],
   )
+
+  // Live ref so the mount-only settle-time cap timer reads the current
+  // settleTime slider value without re-running the mount effect.
+  const simCfgRef = useRef(simCfg)
+  simCfgRef.current = simCfg
 
   // #1380: merge tunable render params with defaults so nothing changes if
   // renderConfig is not supplied (maintains backward compat with all callers).
@@ -500,6 +517,15 @@ const GraphCanvasInner = ({
   const hasSettledRef = useRef(false)
   hasSettledRef.current = hasSettled
 
+  // Stable refs for layout-cache props so the mount-only effect + settle
+  // callback can read live values without re-running.
+  const onLayoutSavedRef = useRef(onLayoutSaved)
+  onLayoutSavedRef.current = onLayoutSaved
+  const savedLayoutRef = useRef(savedLayout)
+  savedLayoutRef.current = savedLayout
+  const relayoutRequestedRef = useRef(relayoutRequested)
+  relayoutRequestedRef.current = relayoutRequested
+
   const doSettle = useCallback(() => {
     if (hardStopTimerRef.current) {
       clearTimeout(hardStopTimerRef.current)
@@ -510,6 +536,11 @@ const GraphCanvasInner = ({
     onSimulationRunningChange?.(false)
     labelDirtyRef.current = true
     refreshLabels()
+    // Persist settled positions so the next load can skip the simulation.
+    const positions = graphRef.current?.getPointPositions()
+    if (positions && positions.length > 0 && onLayoutSavedRef.current) {
+      onLayoutSavedRef.current(new Float32Array(positions))
+    }
   }, [onSimulationRunningChange, refreshLabels])
 
   const doSettleRef = useRef(doSettle)
@@ -569,8 +600,12 @@ const GraphCanvasInner = ({
       if (!node) return
       // selectAdjacentPoints=true highlights node + 1-degree neighbors; others
       // are greyed out GPU-side via pointGreyoutOpacity (no buffer re-upload).
-      graphRef.current?.selectPointByIndex(index, true)
-      if (hasSettledRef.current) graphRef.current?.pause()
+      // Gate BOTH select + pause on hasSettledRef: touching the sim mid-settle
+      // interrupts the tick loop and freezes a half-laid-out graph.
+      if (hasSettledRef.current) {
+        graphRef.current?.selectPointByIndex(index, true)
+        graphRef.current?.pause()
+      }
       onNodeHoverRef.current(node)
     }, 50)
   }, [])
@@ -635,9 +670,12 @@ const GraphCanvasInner = ({
       // Cosmograph product layer, so any meaningful value fuses the islands.
       simulationGravity: 0.02,
       simulationFriction: simCfg.friction,
-      // Slower decay so repulsion + cluster forces have time to pull the
-      // communities into separated islands before the simulation cools.
-      simulationDecay: 6000,
+      // Faster decay (was 6000) so a FRESH layout cools quickly. The actual
+      // ceiling on the explode/settle animation is the wall-clock settle-time
+      // cap below (simCfg.settleTime), which force-calls doSettle() regardless
+      // of decay. Decay 1500 lets the sim mostly settle on its own well within
+      // the ~2s cap while still giving islands time to separate.
+      simulationDecay: 1500,
       // Moderate cluster force pulls each repo/community toward its own island
       // center — strong enough to form distinct islands, but NOT so strong it
       // collapses every island into a single overplotted dot (which re-creates
@@ -648,9 +686,10 @@ const GraphCanvasInner = ({
       // APART from each other and (b) spreads nodes WITHIN each island so the
       // core isn't a single saturated point — local density drops and the
       // purple→pink→yellow degree gradient becomes legible across the island.
-      simulationRepulsion: 4.0,
-      // No center pull — center gravity re-fuses islands into a single mass.
-      simulationCenter: 0.0,
+      simulationRepulsion: simCfg.repulsion,
+      // Center pull keeps the settled layout centered in the viewport instead
+      // of drifting to the edges. Driven by the live "Center Force" slider.
+      simulationCenter: simCfg.center,
 
       // rescalePositions: true — let cosmos.gl rescale the seeded ring positions
       // into the canvas space at init. Phase 2 had this false which, combined
@@ -695,6 +734,23 @@ const GraphCanvasInner = ({
 
     graphRef.current = graph
 
+    // If a saved layout exists and no re-layout was requested, pre-seed the
+    // engine with the cached positions and settle immediately — the explode/
+    // settle animation is SKIPPED entirely (the wall-clock cap below only
+    // applies to fresh layouts). Use rAF so cosmos.gl finishes GL init before
+    // we feed position data in.
+    const hasSavedLayout =
+      !relayoutRequestedRef.current && savedLayoutRef.current?.positions != null
+    if (hasSavedLayout) {
+      requestAnimationFrame(() => {
+        const g = graphRef.current
+        const entry = savedLayoutRef.current
+        if (!g || !entry) return
+        g.setPointPositions(entry.positions, true)
+        doSettleRef.current()
+      })
+    }
+
     // Publish a CosmographRef-shaped shim so the camera store / toolbar /
     // keyboard nav / inspector consume the engine without code changes.
     const shim = {
@@ -719,11 +775,20 @@ const GraphCanvasInner = ({
     }
     setGraphRef(shim as unknown as Parameters<typeof setGraphRef>[0])
 
-    // Hard-stop in case onSimulationEnd never fires (#1153). Raised to 16s to
-    // give the slower decay time to settle into separated islands first.
-    hardStopTimerRef.current = setTimeout(() => {
-      if (!hasSettledRef.current) doSettleRef.current()
-    }, 16000)
+    // Wall-clock settle-time CAP for a FRESH layout: force doSettle() after
+    // simCfg.settleTime seconds (default 2.0s, owner-tunable via the "Settle
+    // time (s)" slider) even if onSimulationEnd never fired. This is a hard
+    // ceiling on the initial → explode → settle animation so it is reliably
+    // ≤ the configured time and never drags on. Skipped when a saved layout is
+    // restored (that path settles immediately above). The cap is read live
+    // from simCfgRef so a fresh re-layout uses the current slider value.
+    if (!hasSavedLayout) {
+      const capSeconds = simCfgRef.current.settleTime ?? 2.0
+      const capMs = Math.max(500, Math.min(6000, capSeconds * 1000))
+      hardStopTimerRef.current = setTimeout(() => {
+        if (!hasSettledRef.current) doSettleRef.current()
+      }, capMs)
+    }
 
     return () => {
       if (hardStopTimerRef.current) clearTimeout(hardStopTimerRef.current)
@@ -796,8 +861,54 @@ const GraphCanvasInner = ({
       simulationLinkSpring: simCfg.linkSpring,
       simulationLinkDistance: simCfg.linkDistance,
       simulationFriction: simCfg.friction,
+      simulationRepulsion: simCfg.repulsion,
+      simulationCenter: simCfg.center,
     })
   }, [isDark, repoFilterActive, nodeFilterIndices, simCfg])
+
+  // Live settle-time cap: when the "Settle time (s)" slider changes WHILE a
+  // fresh layout is still settling, re-arm the wall-clock cap to the new value
+  // (relative to mount). If the new cap has already elapsed, settle now. Skips
+  // entirely once the layout has settled. settleTime changes never touch the
+  // cosmos.gl config (it has no such knob) — they only move this JS timer.
+  const mountTimeRef = useRef<number>(Date.now())
+  useEffect(() => {
+    if (hasSettled) return
+    if (savedLayoutRef.current?.positions != null && !relayoutRequestedRef.current) return
+    const capMs = Math.max(500, Math.min(6000, (simCfg.settleTime ?? 2.0) * 1000))
+    const elapsed = Date.now() - mountTimeRef.current
+    if (hardStopTimerRef.current) clearTimeout(hardStopTimerRef.current)
+    if (elapsed >= capMs) {
+      if (!hasSettledRef.current) doSettleRef.current()
+      return
+    }
+    hardStopTimerRef.current = setTimeout(() => {
+      if (!hasSettledRef.current) doSettleRef.current()
+    }, capMs - elapsed)
+  }, [simCfg.settleTime, hasSettled])
+
+  // Re-layout: when relayoutRequested flips true, restart the force sim from
+  // the current positions, reset the settle state + mount clock, and re-arm
+  // the wall-clock cap so the fresh explode/settle is bounded by settleTime.
+  const prevRelayoutRef = useRef(false)
+  useEffect(() => {
+    if (relayoutRequested && !prevRelayoutRef.current) {
+      const g = graphRef.current
+      if (g) {
+        mountTimeRef.current = Date.now()
+        setHasSettled(false)
+        hasSettledRef.current = false
+        onSimulationRunningChange?.(true)
+        g.start(1)
+        const capMs = Math.max(500, Math.min(6000, (simCfgRef.current.settleTime ?? 2.0) * 1000))
+        if (hardStopTimerRef.current) clearTimeout(hardStopTimerRef.current)
+        hardStopTimerRef.current = setTimeout(() => {
+          if (!hasSettledRef.current) doSettleRef.current()
+        }, capMs)
+      }
+    }
+    prevRelayoutRef.current = !!relayoutRequested
+  }, [relayoutRequested, onSimulationRunningChange])
 
   // ---------------------------------------------------------------------------
   // #1380: Live render config — apply immediately via setConfig (no re-init).

--- a/dashboard/src/components/graph/SimulationControls.tsx
+++ b/dashboard/src/components/graph/SimulationControls.tsx
@@ -28,6 +28,8 @@ export interface SimulationControlsProps {
   setParam:    (key: keyof SimulationConfig, value: number) => void
   applyPreset: (preset: SimulationPreset) => void
   shareHash:   string
+  /** Called when user requests a fresh layout (clears cached positions + re-runs sim). */
+  onRelayout?: () => void
 }
 
 // ---------------------------------------------------------------------------
@@ -39,6 +41,7 @@ export function SimulationControls({
   setParam,
   applyPreset,
   shareHash,
+  onRelayout,
 }: SimulationControlsProps) {
   const [open, setOpen] = useState(false)
   const [copied, setCopied] = useState(false)
@@ -165,6 +168,26 @@ export function SimulationControls({
                 Dense
               </button>
             </div>
+
+            {/* Re-layout button — clears cached positions and re-runs force sim */}
+            {onRelayout && (
+              <button
+                type="button"
+                onClick={onRelayout}
+                className={[
+                  'flex items-center justify-center gap-1 w-full px-1.5 py-1 rounded text-[10px] font-medium transition-colors',
+                  'bg-slate-200/40 dark:bg-slate-800/40 text-slate-500 dark:text-slate-500',
+                  'hover:text-amber-400 hover:border-amber-600',
+                  'border border-slate-300 dark:border-slate-700',
+                  'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                ].join(' ')}
+                aria-label="Recompute layout from scratch"
+                data-testid="sim-relayout-btn"
+                title="Clears cached positions and runs a fresh force simulation"
+              >
+                Re-layout
+              </button>
+            )}
 
             {/* Share link button */}
             <button

--- a/dashboard/src/hooks/graph/useLayoutCache.ts
+++ b/dashboard/src/hooks/graph/useLayoutCache.ts
@@ -1,0 +1,84 @@
+/**
+ * useLayoutCache — persist / restore settled graph positions to localStorage.
+ *
+ * Key: `archigraph.layout.<group>.<nodesetHash>`
+ * Value: base64-encoded Float32Array of [x0, y0, x1, y1, ...]
+ *
+ * Size limit: skip persist if encoded string > 2 MB (localStorage quota guard).
+ * Node-set hash: deterministic 32-bit FNV-1a over sorted node IDs joined by ','.
+ */
+
+const MAX_BYTES = 2 * 1024 * 1024 // 2 MB guard
+
+/** FNV-1a 32-bit hash of a string. Returns unsigned decimal string for use in keys. */
+function fnv1a32(s: string): string {
+  let h = 0x811c9dc5 >>> 0
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i)
+    h = Math.imul(h, 0x01000193) >>> 0
+  }
+  return String(h)
+}
+
+function layoutKey(group: string, nodeIds: string[]): string {
+  const sorted = [...nodeIds].sort()
+  const hash = fnv1a32(sorted.join(','))
+  return `archigraph.layout.${group}.${hash}`
+}
+
+function float32ToBase64(arr: Float32Array): string {
+  const bytes = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength)
+  let s = ''
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i])
+  return btoa(s)
+}
+
+function base64ToFloat32(b64: string): Float32Array | null {
+  try {
+    const s = atob(b64)
+    const bytes = new Uint8Array(s.length)
+    for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i)
+    return new Float32Array(bytes.buffer)
+  } catch {
+    return null
+  }
+}
+
+export interface LayoutCacheEntry {
+  positions: Float32Array
+}
+
+export function saveLayout(group: string, nodeIds: string[], positions: Float32Array): void {
+  try {
+    const encoded = float32ToBase64(positions)
+    if (encoded.length > MAX_BYTES) return // too large — skip silently
+    const key = layoutKey(group, nodeIds)
+    localStorage.setItem(key, encoded)
+  } catch {
+    // Ignore quota / private-mode errors
+  }
+}
+
+export function loadLayout(group: string, nodeIds: string[]): LayoutCacheEntry | null {
+  try {
+    const key = layoutKey(group, nodeIds)
+    const encoded = localStorage.getItem(key)
+    if (!encoded) return null
+    const positions = base64ToFloat32(encoded)
+    if (!positions || positions.length !== nodeIds.length * 2) {
+      localStorage.removeItem(key) // stale / corrupt
+      return null
+    }
+    return { positions }
+  } catch {
+    return null
+  }
+}
+
+export function clearLayout(group: string, nodeIds: string[]): void {
+  try {
+    localStorage.removeItem(layoutKey(group, nodeIds))
+  } catch {
+    // ignore
+  }
+}

--- a/dashboard/src/hooks/graph/useSimulationConfig.ts
+++ b/dashboard/src/hooks/graph/useSimulationConfig.ts
@@ -23,6 +23,8 @@ export interface SimulationConfig {
   linkSpring:   number   // 0.0–2.0
   linkDistance: number   // 1–50
   friction:     number   // 0.5–0.95
+  repulsion:    number   // 0.1–10.0
+  center:       number   // 0.0–1.0
 }
 
 export type SimulationPreset = 'silk-road' | 'dense'
@@ -45,6 +47,8 @@ export const SILK_ROAD_DEFAULTS: SimulationConfig = {
   linkSpring:   0.08,
   linkDistance: 2,
   friction:     0.77,
+  repulsion:    4.0,
+  center:       0.15,
 }
 
 export const DENSE_DEFAULTS: SimulationConfig = {
@@ -53,6 +57,8 @@ export const DENSE_DEFAULTS: SimulationConfig = {
   linkSpring:   0.5,
   linkDistance: 1,
   friction:     0.88,
+  repulsion:    2.0,
+  center:       0.3,
 }
 
 export const PRESET_CONFIGS: Record<SimulationPreset, SimulationConfig> = {
@@ -67,6 +73,8 @@ export const PRESET_CONFIGS: Record<SimulationPreset, SimulationConfig> = {
 export const SLIDER_META: SliderMeta[] = [
   { key: 'spaceSize',    label: 'Space Size',     min: 1024,  max: 16384, step: 256  },
   { key: 'gravity',      label: 'Gravity',        min: 0.0,   max: 1.0,   step: 0.01 },
+  { key: 'repulsion',    label: 'Repulsion',      min: 0.1,   max: 10.0,  step: 0.1  },
+  { key: 'center',       label: 'Center Force',   min: 0.0,   max: 1.0,   step: 0.01 },
   { key: 'linkSpring',   label: 'Link Spring',    min: 0.0,   max: 2.0,   step: 0.01 },
   { key: 'linkDistance', label: 'Link Distance',  min: 1,     max: 50,    step: 1    },
   { key: 'friction',     label: 'Friction',       min: 0.50,  max: 0.95,  step: 0.01 },
@@ -86,6 +94,8 @@ function encodeToHash(cfg: SimulationConfig): string {
     ls:  String(cfg.linkSpring),
     ld:  String(cfg.linkDistance),
     fr:  String(cfg.friction),
+    rp:  String(cfg.repulsion),
+    ct:  String(cfg.center),
   })
   return params.toString()
 }
@@ -99,6 +109,8 @@ function decodeFromHash(hash: string): Partial<SimulationConfig> {
     const ls = Number(params.get('ls'));  if (isFinite(ls))            out.linkSpring   = ls
     const ld = Number(params.get('ld'));  if (isFinite(ld) && ld > 0) out.linkDistance = ld
     const fr = Number(params.get('fr'));  if (isFinite(fr))            out.friction     = fr
+    const rp = Number(params.get('rp'));  if (isFinite(rp) && rp > 0) out.repulsion    = rp
+    const ct = Number(params.get('ct'));  if (isFinite(ct))            out.center       = ct
     return out
   } catch {
     return {}

--- a/dashboard/src/hooks/graph/useSimulationConfig.ts
+++ b/dashboard/src/hooks/graph/useSimulationConfig.ts
@@ -25,6 +25,15 @@ export interface SimulationConfig {
   friction:     number   // 0.5–0.95
   repulsion:    number   // 0.1–10.0
   center:       number   // 0.0–1.0
+  /**
+   * settleTime — wall-clock cap (seconds) for the explode/settle animation on
+   * a FRESH layout (no cached positions). GraphCanvas force-calls doSettle()
+   * after this many seconds even if onSimulationEnd never fired, so the
+   * initial → explode → settle animation never runs longer than this.
+   * Default 2.0s, range 0.5–6s. Ignored when a saved layout is restored
+   * (the simulation is skipped entirely in that case).
+   */
+  settleTime:   number   // 0.5–6.0 (seconds)
 }
 
 export type SimulationPreset = 'silk-road' | 'dense'
@@ -49,6 +58,7 @@ export const SILK_ROAD_DEFAULTS: SimulationConfig = {
   friction:     0.77,
   repulsion:    4.0,
   center:       0.15,
+  settleTime:   2.0,
 }
 
 export const DENSE_DEFAULTS: SimulationConfig = {
@@ -59,6 +69,7 @@ export const DENSE_DEFAULTS: SimulationConfig = {
   friction:     0.88,
   repulsion:    2.0,
   center:       0.3,
+  settleTime:   2.0,
 }
 
 export const PRESET_CONFIGS: Record<SimulationPreset, SimulationConfig> = {
@@ -78,6 +89,7 @@ export const SLIDER_META: SliderMeta[] = [
   { key: 'linkSpring',   label: 'Link Spring',    min: 0.0,   max: 2.0,   step: 0.01 },
   { key: 'linkDistance', label: 'Link Distance',  min: 1,     max: 50,    step: 1    },
   { key: 'friction',     label: 'Friction',       min: 0.50,  max: 0.95,  step: 0.01 },
+  { key: 'settleTime',   label: 'Settle time (s)', min: 0.5,  max: 6.0,   step: 0.1  },
 ]
 
 // ---------------------------------------------------------------------------
@@ -96,6 +108,7 @@ function encodeToHash(cfg: SimulationConfig): string {
     fr:  String(cfg.friction),
     rp:  String(cfg.repulsion),
     ct:  String(cfg.center),
+    st:  String(cfg.settleTime),
   })
   return params.toString()
 }
@@ -111,6 +124,7 @@ function decodeFromHash(hash: string): Partial<SimulationConfig> {
     const fr = Number(params.get('fr'));  if (isFinite(fr))            out.friction     = fr
     const rp = Number(params.get('rp'));  if (isFinite(rp) && rp > 0) out.repulsion    = rp
     const ct = Number(params.get('ct'));  if (isFinite(ct))            out.center       = ct
+    const st = Number(params.get('st'));  if (isFinite(st) && st > 0) out.settleTime   = st
     return out
   } catch {
     return {}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -9,6 +9,8 @@ import { useGraphSearch } from '@/hooks/graph/useGraphSearch'
 import { useHoverLabel } from '@/hooks/graph/useHoverLabel'
 import { useColorMode } from '@/hooks/graph/useColorMode'
 import { useSimulationConfig } from '@/hooks/graph/useSimulationConfig'
+import { saveLayout, loadLayout, clearLayout } from '@/hooks/graph/useLayoutCache'
+import type { LayoutCacheEntry } from '@/hooks/graph/useLayoutCache'
 import { useGraphHighlight } from '@/hooks/graph/useGraphHighlight'
 import { useGraphFilter, filterNodes } from '@/hooks/graph/useGraphFilter'
 import { useGraphKeyboardNav } from '@/hooks/graph/useGraphKeyboardNav'
@@ -169,6 +171,32 @@ export function GraphRoute() {
       effectiveActiveRepos,
       showExternal,
     )
+
+  // ── Layout position cache (#1399) ──────────────────────────────────────────
+  // Persist settled positions so a reload skips the explode/settle animation.
+  const [cachedLayout, setCachedLayout] = useState<LayoutCacheEntry | null>(null)
+  const [relayoutRequested, setRelayoutRequested] = useState(false)
+
+  const layoutNodeIds = useMemo(() => nodes.map((n) => String(n.id)), [nodes])
+
+  useEffect(() => {
+    if (!group || nodes.length === 0) return
+    if (relayoutRequested) return // fresh sim requested — ignore cache
+    setCachedLayout(loadLayout(group, layoutNodeIds))
+  }, [group, layoutNodeIds, relayoutRequested, nodes.length])
+
+  const handleLayoutSaved = useCallback((positions: Float32Array) => {
+    if (!group || layoutNodeIds.length === 0) return
+    saveLayout(group, layoutNodeIds, positions)
+    setRelayoutRequested(false)
+  }, [group, layoutNodeIds])
+
+  const handleRelayout = useCallback(() => {
+    if (!group || layoutNodeIds.length === 0) return
+    clearLayout(group, layoutNodeIds)
+    setCachedLayout(null)
+    setRelayoutRequested(true)
+  }, [group, layoutNodeIds])
 
   const colorMap = useCommunityColors(communities)
 
@@ -637,6 +665,7 @@ export function GraphRoute() {
             setParam={setSimParam}
             applyPreset={applySimPreset}
             shareHash={simShareHash}
+            onRelayout={handleRelayout}
           />
 
           <div className="border-t border-slate-200 dark:border-slate-700" />
@@ -805,6 +834,10 @@ export function GraphRoute() {
               nodeFilterIndices={filterIndices}
               nodeSizingConfig={nodeSizingConfig}
               renderConfig={renderConfig}
+              group={group}
+              savedLayout={cachedLayout}
+              onLayoutSaved={handleLayoutSaved}
+              relayoutRequested={relayoutRequested}
             />
           )}
 


### PR DESCRIPTION
## What changed

Five interrelated graph load-performance and UX improvements:

1. **Layout cache** — after the force simulation settles, node positions are serialised as `Float32Array` (base64, ≤2 MB guard) to localStorage keyed by `group + FNV-1a hash of sorted nodeIds`. On the next load the saved positions are pre-seeded into cosmos.gl via `setPointPositions()` and `doSettle()` is called immediately, skipping the simulation entirely.
2. **Faster settle** — `simulationDecay` lowered from 6000 → 1500, so a fresh layout completes in ~1–2 s instead of ~5 s.
3. **Mouse-freeze fix** — `handleMouseMove`'s `selectPointByIndex` + `pause()` calls are now gated on `hasSettledRef.current`, so dragging/hovering mid-settle no longer interrupts the force simulation.
4. **Stronger center gravity** — `simulationCenter` default raised from 0.0 → 0.15 (Silk Road preset) to prevent edge-node drift.
5. **Live simulation knobs** — `repulsion`, `center` (and `settleTime`) added to `SimulationConfig` + `SLIDER_META` + the Simulation panel, plus a "Re-layout" button that clears the cached positions and forces a fresh run.

## Why

Issue #1399 / EPIC #1380. The graph was slow to load on every page visit because the force simulation ran from scratch each time, freezing on mouse hover mid-settle. Users on large graphs (e.g. 400+ nodes) saw 5–8 s of animation before the graph was usable.

## How it works

- **New file** `dashboard/src/hooks/graph/useLayoutCache.ts` — pure utility (`saveLayout` / `loadLayout` / `clearLayout`). No React dependency; usable in tests.
- **`GraphCanvas.tsx`** receives `savedLayout`, `onLayoutSaved`, `relayoutRequested` props. On mount, if a saved layout is present and a relayout was not requested, a single `requestAnimationFrame` pre-seeds positions and calls `doSettle()`. `onSimulationEnd` / the hard-stop timer now both call `onLayoutSaved` with the captured `Float32Array`.
- **`graph.tsx`** owns the cache state (`cachedLayout`, `relayoutRequested`), loads from localStorage on `group + nodeIds` change, and passes handlers down.
- **`useSimulationConfig.ts`** extended with `repulsion`, `center`, `settleTime`; both presets (Silk Road / Dense) updated accordingly.
- **`SimulationControls.tsx`** gains an `onRelayout` prop and renders the "Re-layout" button when provided.

## Verification

Manual smoke test against the shared :47274 daemon via Vite dev server:

- **First load** (`load-first-settled.png`): Canvas renders, simulation runs ~1.5 s, layout key `archigraph.layout.<group>.<hash>` appears in localStorage after settle.
- **Second load** (`load-second-instant.png`): Same group — graph appears within ~2 s with no simulation animation; positions match first load.
- **Centered layout** (`centered-layout.png`): Nodes cluster at center rather than drifting to canvas edges.
- `make build` passes (TypeScript compilation + Go binary).

## Checklist

- [x] `make build` green
- [x] Layout key saved to localStorage after first settle
- [x] Second load instant (no simulation animation)
- [x] Mouse hover no longer freezes mid-settle
- [x] `repulsion` / `center` / `settleTime` sliders live in Simulation panel
- [x] "Re-layout" button clears cache and triggers fresh simulation
- [x] No changes to daemon / Go code
- [x] No changes to unrelated dashboard routes

Fixes #1399
EPIC #1380