### PR TITLE
feat(graph): auto-settle on load + zoom-aware sizing + label tooltip + fill-viewport + click-to-focus N-hop

### DIFF
--- a/dashboard/src/components/graph/GraphCanvas.tsx
+++ b/dashboard/src/components/graph/GraphCanvas.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect, useCallback, memo, useMemo, useState } from 'react'
 import { Graph } from '@cosmos.gl/graph'
 import { communityColor } from '@/hooks/graph/useCommunityColors'
 import { repoColor } from '@/lib/colors'
+import { nodeDisplayLabel } from '@/lib/utils'
 import type { GraphNode, GraphEdge } from '@/types/api'
 import { useGraphCameraStore } from '@/store/graphCameraStore'
 import type { ColorMode } from '@/hooks/graph/useColorMode'
@@ -126,6 +127,12 @@ function buildGroupCenters(
   )
 }
 
+// #1392-refine (item 4) — Fit padding as a fraction of the node bounding box.
+// cosmos.gl's default fitView padding leaves large empty margins; a small
+// padding makes the settled graph FILL the viewport. Used for both the fresh
+// settle fit and the cached-layout fit.
+const FIT_PADDING = 0.1
+
 // ---------------------------------------------------------------------------
 // Color helpers — cosmos.gl wants packed RGBA Float32Array
 //   format: [r, g, b, a, ...] where r/g/b are 0–255 and a is 0–1.
@@ -244,6 +251,12 @@ export interface GraphCanvasProps {
   highlightedEdgeIds?: ReadonlySet<string>
   simulationConfig?: SimulationConfig
   nodeFilterIndices?: number[] | null
+  /**
+   * #1392-refine (item 5) — click-to-focus N-hop ego graph. When non-null, only
+   * these node indices are rendered (everything else hard-hidden) and the camera
+   * re-fits to them so it reads as a fresh subgraph of just the related nodes.
+   */
+  focusedNodeIndices?: number[] | null
   nodeSizingConfig?: NodeSizingConfig
   renderConfig?: RenderConfig
   /** #1392 — clustering dimension: repo (default) / community / module / none. */
@@ -294,6 +307,7 @@ const GraphCanvasInner = ({
   highlightedEdgeIds,
   simulationConfig,
   nodeFilterIndices,
+  focusedNodeIndices,
   nodeSizingConfig,
   renderConfig,
   groupBy = 'repo',
@@ -325,6 +339,10 @@ const GraphCanvasInner = ({
 
   const [hasSettled, setHasSettled] = useState(false)
   const hardStopTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  // #1392-refine: ensures we auto-start the fresh-load simulation exactly once
+  // (no manual Play needed). Stays false on the cached-layout path (that path
+  // settles instantly without animating).
+  const didAutoStartRef = useRef(false)
 
   // Mirror of nodes so click handler can resolve index → GraphNode synchronously
   const nodesRef = useRef<GraphNode[]>(nodes)
@@ -340,6 +358,36 @@ const GraphCanvasInner = ({
 
   const stableEmptySet = useMemo(() => new Set<string>(), [])
   const effectiveForceIds = forceVisibleIds ?? stableEmptySet
+
+  // #1392-refine (item 2) — base point-size scaling constants. Largest tier node
+  // = BASE * MAX_MULT (matches the tier-5 multiplier in useNodeSizingConfig).
+  const SIZE_BASE = 120
+  const SIZE_MAX_MULT = 3.0
+
+  // Live render-config ref so the zoom handler can read maxPointSize /
+  // pointSizeScale / scalePointsOnZoom without re-binding the mount-only handler.
+  const rcRef = useRef(rc)
+  rcRef.current = rc
+
+  /**
+   * #1392-refine (item 2) — compute the effective pointSizeScale so the LARGEST
+   * node never exceeds maxPointSize on screen, accounting for zoom.
+   *
+   * With scalePointsOnZoom:true, rendered_px = size * pointSizeScale * zoom.
+   * Without a zoom-aware cap, zooming in inflates EVERY node into a giant
+   * overlapping blob (degree differentiation lost in a wall of identical
+   * circles). We cap the scale so size_max * scale * zoom <= maxPointSize:
+   *   effScale = min(pointSizeScale, maxPointSize / (SIZE_BASE*SIZE_MAX_MULT*zoom))
+   * Because the cap multiplies ALL sizes uniformly, the per-degree size buffer
+   * still differentiates hubs from leaves — they just stop ballooning together.
+   */
+  const effectiveScaleForZoom = useCallback((zoom: number): number => {
+    const cfg = rcRef.current
+    const z = cfg.scalePointsOnZoom ? Math.max(zoom, 0.0001) : 1
+    const sizeMax = SIZE_BASE * SIZE_MAX_MULT
+    const zoomCap = cfg.maxPointSize / (sizeMax * z)
+    return Math.min(cfg.pointSizeScale, zoomCap)
+  }, [])
 
   const repoFilterActive = activeRepos != null
 
@@ -588,7 +636,7 @@ const GraphCanvasInner = ({
         idx,
         x: sx,
         y: sy - (radius ?? 4) - 6,
-        text: truncateLabel(n.label ?? String(n.id)),
+        text: truncateLabel(nodeDisplayLabel(n)),
       })
     }
     setLabelPositions(out)
@@ -597,8 +645,14 @@ const GraphCanvasInner = ({
   // ---------------------------------------------------------------------------
   // Simulation settle / hard-stop
   // ---------------------------------------------------------------------------
+  // #1392-refine — hasSettledRef is AUTHORITATIVE and mutated only by doSettle
+  // (→true) and the re-layout / group-by effects (→false). It is intentionally
+  // NOT auto-mirrored from the `hasSettled` state on every render: that mirror
+  // could transiently reset the ref to a stale `false` between doSettle()'s
+  // synchronous ref-set and the state commit, letting a second doSettle slip
+  // past the idempotency guard and double-toggle the Play/Pause store (which
+  // left the cached/settled graph drifting with the button stuck on "running").
   const hasSettledRef = useRef(false)
-  hasSettledRef.current = hasSettled
 
   // Stable refs for layout-cache props so the mount-only effect + settle
   // callback can read live values without re-running.
@@ -610,6 +664,15 @@ const GraphCanvasInner = ({
   relayoutRequestedRef.current = relayoutRequested
 
   const doSettle = useCallback(() => {
+    // #1392-refine — idempotency guard. doSettle can be reached from multiple
+    // sources (cached-layout rAF, onSimulationEnd, the wall-clock cap, re-layout
+    // cap). hasSettledRef is mirrored from state and lags a render, so two of
+    // these can fire before the re-render and BOTH run — double-toggling the
+    // Play/Pause store (onSimulationRunningChange is a flip, not a setter) and
+    // leaving the sim visibly running after settle. Set the ref synchronously
+    // and bail if we've already settled so the body runs exactly once.
+    if (hasSettledRef.current) return
+    hasSettledRef.current = true
     if (hardStopTimerRef.current) {
       clearTimeout(hardStopTimerRef.current)
       hardStopTimerRef.current = null
@@ -620,8 +683,10 @@ const GraphCanvasInner = ({
     // #1392 — Fit the camera to the actual NODE bounding box (cosmos.gl fitView
     // frames the points, not the square simulation space) so the settled graph
     // FILLS the 16:9 viewport instead of sitting tiny inside the square space.
-    // A short animation feels intentional; runs once on settle.
-    graphRef.current?.fitView(400)
+    // A short animation feels intentional; runs once on settle. #1392-refine
+    // (item 4) — explicit small padding so the graph FILLS the viewport instead
+    // of sitting tiny inside large empty margins.
+    graphRef.current?.fitView(400, FIT_PADDING)
     labelDirtyRef.current = true
     // refresh labels after the fit animation positions are applied
     refreshLabels()
@@ -635,6 +700,24 @@ const GraphCanvasInner = ({
 
   const doSettleRef = useRef(doSettle)
   doSettleRef.current = doSettle
+
+  // Live mirror of the user's run/pause intent so post-settle buffer pushes
+  // (render()/create() restart cosmos's sim loop when enableSimulation:true)
+  // can re-assert the paused state instead of letting the graph drift forever.
+  const simulationRunningRef = useRef(simulationRunning)
+  simulationRunningRef.current = simulationRunning
+
+  /**
+   * #1392-refine — re-assert the settled/paused state after an imperative
+   * render()/create(). cosmos.gl restarts its simulation loop on create() when
+   * enableSimulation is true; once we've settled (and the user hasn't pressed
+   * Play) we must pause again or the cached/settled graph keeps drifting.
+   */
+  const reassertPauseIfSettled = useCallback(() => {
+    if (hasSettledRef.current && simulationRunningRef.current !== true) {
+      graphRef.current?.pause()
+    }
+  }, [])
 
   // ---------------------------------------------------------------------------
   // Event handlers (stable — read live values from refs)
@@ -736,7 +819,7 @@ const GraphCanvasInner = ({
       scalePointsOnZoom: rc.scalePointsOnZoom,
       pointSizeScale: rc.pointSizeScale,
       pointOpacity: rc.pointOpacity,
-      pointGreyoutOpacity: (repoFilterActive || !!nodeFilterIndices) ? 0 : 0.18,
+      pointGreyoutOpacity: (repoFilterActive || !!nodeFilterIndices || !!focusedNodeIndices) ? 0 : 0.18,
       linkGreyoutOpacity: repoFilterActive ? 0 : rc.linkOpacity * 0.5,
       linkWidthScale: rc.showLinks ? rc.linkWidthScale : 0,
       renderHoveredPointRing: true,
@@ -792,6 +875,9 @@ const GraphCanvasInner = ({
       rescalePositions: true,
       fitViewOnInit: true,
       fitViewDelay: 3500,
+      // #1392-refine (item 4) — fill the viewport with a small bounding-box
+      // padding instead of cosmos.gl's larger default margins.
+      fitViewPadding: FIT_PADDING,
 
       onSimulationEnd: () => {
         if (!hasSettledRef.current) doSettleRef.current()
@@ -812,6 +898,13 @@ const GraphCanvasInner = ({
         const k = t?.k ?? 1
         setZoomLevel(k)
         onZoomChangeRef.current?.(k)
+        // #1392-refine (item 2) — zoom-aware size cap. Re-apply the effective
+        // pointSizeScale so the largest node stays <= maxPointSize at this zoom,
+        // preventing the "uniform giant overlapping blobs" the owner reported.
+        const g = graphRef.current
+        if (g && rcRef.current.scalePointsOnZoom) {
+          g.setConfig({ pointSizeScale: effectiveScaleForZoom(k) })
+        }
         // Reposition labels on pan/zoom
         if (labelRafRef.current === null) {
           labelRafRef.current = requestAnimationFrame(() => {
@@ -923,9 +1016,33 @@ const GraphCanvasInner = ({
     // create() throws "missing buffer pointIndices" (verified in 2.6.4 dist).
     g.render()
     g.create()
+    // #1392-refine — AUTO-SETTLE ON LOAD (item 1). On the first data upload for a
+    // FRESH layout (no cached positions, no re-layout pending) start the force
+    // simulation immediately so the graph settles WITHOUT the user pressing Play.
+    // The wall-clock settle-time cap (mount effect) auto-pauses + saves positions
+    // once it settles. The cached-layout path is skipped here — it settled
+    // instantly in the mount effect. start() is also a no-op once hasSettled.
+    if (!didAutoStartRef.current && !hasSettledRef.current) {
+      const hasSavedLayout =
+        !relayoutRequestedRef.current && savedLayoutRef.current?.positions != null
+      if (!hasSavedLayout) {
+        didAutoStartRef.current = true
+        // Kick the force sim. We do NOT notify onSimulationRunningChange here:
+        // the camera store already initialises simulationRunning=true and the
+        // toolbar treats the callback as a flip (toggleSimulation), not a
+        // setter. doSettle() flips it to paused once the layout settles, so
+        // calling it here too would double-toggle and desync the Play/Pause
+        // button (leaving it stuck showing "running" after settle).
+        g.start(1)
+      }
+    }
+    // If we've already settled (e.g. cached-layout load, or a recolor-triggered
+    // re-push), create() above restarted cosmos's sim loop — re-pause so the
+    // settled graph stays put instead of drifting.
+    reassertPauseIfSettled()
     labelDirtyRef.current = true
     if (usePrev) refreshLabels()
-  }, [packed, packPointColors, linkData, packLinkColors, packLinkWidths, topLabelIndices, refreshLabels])
+  }, [packed, packPointColors, linkData, packLinkColors, packLinkWidths, topLabelIndices, refreshLabels, reassertPauseIfSettled])
 
   // Recolor when colorMode / theme / hover-selection styling changes.
   useEffect(() => {
@@ -936,7 +1053,8 @@ const GraphCanvasInner = ({
     g.setLinkWidths(packLinkWidths())
     g.render()
     g.create()
-  }, [packPointColors, packLinkColors, packLinkWidths])
+    reassertPauseIfSettled()
+  }, [packPointColors, packLinkColors, packLinkWidths, reassertPauseIfSettled])
 
   // ---------------------------------------------------------------------------
   // Config updates — sim sliders / theme / greyout (setConfig merges in 2.6.4)
@@ -949,7 +1067,7 @@ const GraphCanvasInner = ({
     // spaceSize at runtime forces a costly resize + re-layout.
     g.setConfig({
       backgroundColor: isDark ? '#020617' : '#f8fafc',
-      pointGreyoutOpacity: (repoFilterActive || !!nodeFilterIndices) ? 0 : 0.18,
+      pointGreyoutOpacity: (repoFilterActive || !!nodeFilterIndices || !!focusedNodeIndices) ? 0 : 0.18,
       linkGreyoutOpacity: repoFilterActive ? 0 : 0.1,
       simulationLinkSpring: simCfg.linkSpring,
       simulationLinkDistance: simCfg.linkDistance,
@@ -957,7 +1075,7 @@ const GraphCanvasInner = ({
       simulationRepulsion: simCfg.repulsion,
       simulationCenter: simCfg.center,
     })
-  }, [isDark, repoFilterActive, nodeFilterIndices, simCfg])
+  }, [isDark, repoFilterActive, nodeFilterIndices, focusedNodeIndices, simCfg])
 
   // Live settle-time cap: when the "Settle time (s)" slider changes WHILE a
   // fresh layout is still settling, re-arm the wall-clock cap to the new value
@@ -1046,9 +1164,12 @@ const GraphCanvasInner = ({
     renderDebounceRef.current = setTimeout(() => {
       const g = graphRef.current
       if (!g) return
-      const BASE = 120
-      const MAX_MULT = 3.0
-      const clampedScale = Math.min(rc.pointSizeScale, rc.maxPointSize / (BASE * MAX_MULT))
+      // #1392-refine (item 2) — zoom-aware clamp: cap pointSizeScale so the
+      // largest node stays <= maxPointSize at the CURRENT zoom (not just zoom=1).
+      // This keeps the Rendering panel's maxPointSize/sizeScale knobs working
+      // while preventing zoomed-in nodes from ballooning into uniform blobs.
+      const currentZoom = g.getZoomLevel?.() ?? 1
+      const clampedScale = effectiveScaleForZoom(currentZoom)
       g.setConfig({
         pointOpacity: rc.pointOpacity,
         pointSizeScale: clampedScale,
@@ -1059,6 +1180,7 @@ const GraphCanvasInner = ({
       g.setLinkColors(packLinkColors())
       g.setLinkWidths(packLinkWidths())
       g.render()
+      reassertPauseIfSettled()
     }, 16)
     return () => {
       if (renderDebounceRef.current) clearTimeout(renderDebounceRef.current)
@@ -1079,7 +1201,8 @@ const GraphCanvasInner = ({
   useEffect(() => {
     const g = graphRef.current
     if (!g) return
-    const noOverrides = !activeRepos && effectiveForceIds.size === 0 && !nodeFilterIndices
+    const noOverrides =
+      !activeRepos && effectiveForceIds.size === 0 && !nodeFilterIndices && !focusedNodeIndices
     if (noOverrides) {
       g.selectPointsByIndices(null)
       return
@@ -1100,8 +1223,43 @@ const GraphCanvasInner = ({
       nodes.forEach((n, i) => { if (effectiveForceIds.has(n.id)) set.add(i) })
       effective = Array.from(set)
     }
+    // #1392-refine (item 5) — focus is a HARD restriction applied LAST: the
+    // rendered set becomes exactly the N-hop neighborhood, intersected with any
+    // active repo/criteria filter so focus never re-reveals filtered-out nodes.
+    if (focusedNodeIndices != null) {
+      if (effective === null) {
+        effective = focusedNodeIndices
+      } else {
+        const fs = new Set(effective)
+        effective = focusedNodeIndices.filter((i) => fs.has(i))
+      }
+    }
     g.selectPointsByIndices(effective)
-  }, [visibleIndices, activeRepos, effectiveForceIds, nodeFilterIndices, nodes])
+  }, [visibleIndices, activeRepos, effectiveForceIds, nodeFilterIndices, focusedNodeIndices, nodes])
+
+  // ---------------------------------------------------------------------------
+  // #1392-refine (item 5) — re-fit the camera to the focused subgraph so it
+  // FILLS the viewport (reads as a fresh, smaller graph). When focus clears,
+  // re-fit back to the full node bounding box. Gated on hasSettled so we never
+  // fight the initial settle fit. A short animation makes the transition read.
+  // ---------------------------------------------------------------------------
+  const prevFocusKeyRef = useRef<string | null>(null)
+  useEffect(() => {
+    if (!hasSettled) return
+    const g = graphRef.current
+    if (!g) return
+    // Cheap structural key so we only re-fit when the focus set actually changes.
+    const key = focusedNodeIndices ? focusedNodeIndices.join(',') : null
+    if (prevFocusKeyRef.current === key) return
+    prevFocusKeyRef.current = key
+    if (focusedNodeIndices && focusedNodeIndices.length > 0) {
+      g.fitViewByPointIndices(focusedNodeIndices, 400, FIT_PADDING)
+    } else {
+      g.fitView(400, FIT_PADDING)
+    }
+    labelDirtyRef.current = true
+    setTimeout(() => { labelDirtyRef.current = true; refreshLabels() }, 450)
+  }, [focusedNodeIndices, hasSettled, refreshLabels])
 
   // ---------------------------------------------------------------------------
   // Simulation run/pause (resume layout)

--- a/dashboard/src/hooks/graph/useFocusNeighborhood.ts
+++ b/dashboard/src/hooks/graph/useFocusNeighborhood.ts
@@ -1,0 +1,129 @@
+/**
+ * useFocusNeighborhood — click-to-focus N-hop ego graph (#1392-refine item 5).
+ *
+ * When the user clicks a node we "focus" on its neighborhood: only that node
+ * plus every node within N hops (BFS over the loaded edge list) stays visible;
+ * everything else is hidden. This reads as a fresh, smaller graph of just the
+ * related nodes, with the camera re-fit to it.
+ *
+ * State:
+ *   focusNodeId — the clicked node id (null = no focus, full graph shown)
+ *   hopDepth    — neighborhood radius in hops (default 2, clamped 1–3)
+ *
+ * The neighborhood itself is computed by the caller via `computeNeighborhood`
+ * from the edges already present in the payload — NO backend call is made.
+ *
+ * hopDepth is persisted to localStorage so the user's preferred radius sticks.
+ */
+import { useState, useCallback } from 'react'
+import type { GraphEdge } from '@/types/api'
+
+const HOP_STORAGE_KEY = 'archigraph.graph.focusHopDepth'
+export const MIN_HOP_DEPTH = 1
+export const MAX_HOP_DEPTH = 3
+export const DEFAULT_HOP_DEPTH = 2
+
+function clampHop(v: number): number {
+  if (!isFinite(v)) return DEFAULT_HOP_DEPTH
+  return Math.max(MIN_HOP_DEPTH, Math.min(MAX_HOP_DEPTH, Math.round(v)))
+}
+
+function readStoredHop(): number {
+  try {
+    const raw = localStorage.getItem(HOP_STORAGE_KEY)
+    if (raw) return clampHop(Number(raw))
+  } catch {
+    // private mode — fall through
+  }
+  return DEFAULT_HOP_DEPTH
+}
+
+export interface UseFocusNeighborhoodReturn {
+  focusNodeId: string | null
+  hopDepth: number
+  setFocus: (id: string | null) => void
+  clearFocus: () => void
+  setHopDepth: (n: number) => void
+  isFocused: boolean
+}
+
+export function useFocusNeighborhood(): UseFocusNeighborhoodReturn {
+  const [focusNodeId, setFocusNodeId] = useState<string | null>(null)
+  const [hopDepth, setHopDepthState] = useState<number>(readStoredHop)
+
+  const setFocus = useCallback((id: string | null) => {
+    setFocusNodeId(id)
+  }, [])
+
+  const clearFocus = useCallback(() => setFocusNodeId(null), [])
+
+  const setHopDepth = useCallback((n: number) => {
+    const clamped = clampHop(n)
+    setHopDepthState(clamped)
+    try {
+      localStorage.setItem(HOP_STORAGE_KEY, String(clamped))
+    } catch {
+      // ignore
+    }
+  }, [])
+
+  return {
+    focusNodeId,
+    hopDepth,
+    setFocus,
+    clearFocus,
+    setHopDepth,
+    isFocused: focusNodeId !== null,
+  }
+}
+
+/**
+ * Build an undirected adjacency map from the edge list. Memoise this in the
+ * caller against `edges` so a focus toggle / hop change doesn't rebuild it.
+ */
+export function buildAdjacency(edges: GraphEdge[]): Map<string, string[]> {
+  const adj = new Map<string, string[]>()
+  const push = (a: string, b: string) => {
+    const list = adj.get(a)
+    if (list) list.push(b)
+    else adj.set(a, [b])
+  }
+  for (const e of edges) {
+    const s = String(e.source)
+    const t = String(e.target)
+    push(s, t)
+    push(t, s)
+  }
+  return adj
+}
+
+/**
+ * BFS the N-hop neighborhood of `startId` over an undirected adjacency map.
+ * Returns the set of node ids within `hopDepth` hops, INCLUDING startId.
+ * Treated as undirected so both callers and callees are pulled in.
+ */
+export function computeNeighborhood(
+  adj: Map<string, string[]>,
+  startId: string,
+  hopDepth: number,
+): Set<string> {
+  const result = new Set<string>([startId])
+  let frontier: string[] = [startId]
+  const depth = Math.max(MIN_HOP_DEPTH, Math.min(MAX_HOP_DEPTH, hopDepth))
+  for (let hop = 0; hop < depth; hop++) {
+    const next: string[] = []
+    for (const id of frontier) {
+      const neighbors = adj.get(id)
+      if (!neighbors) continue
+      for (const n of neighbors) {
+        if (!result.has(n)) {
+          result.add(n)
+          next.push(n)
+        }
+      }
+    }
+    if (next.length === 0) break
+    frontier = next
+  }
+  return result
+}

--- a/dashboard/src/lib/utils.ts
+++ b/dashboard/src/lib/utils.ts
@@ -8,3 +8,20 @@ import { twMerge } from 'tailwind-merge'
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+/**
+ * Human-readable label for a graph node. Returns the node's `label` when it is
+ * a non-empty / non-whitespace string, otherwise falls back to its raw id.
+ *
+ * The `label ?? id` pattern is NOT sufficient because some payload nodes carry
+ * an empty-string label (which `??` does not catch), making the hover tooltip
+ * render the raw id (e.g. `upvate_core::proc:8288cd4a88`) instead of a real
+ * name like `AttachmentViewer → split`.
+ */
+export function nodeDisplayLabel(
+  node: { label?: string | null; id: string },
+): string {
+  const label = node.label
+  if (typeof label === 'string' && label.trim().length > 0) return label
+  return node.id
+}

--- a/dashboard/src/routes/graph.tsx
+++ b/dashboard/src/routes/graph.tsx
@@ -9,6 +9,13 @@ import { useGraphSearch } from '@/hooks/graph/useGraphSearch'
 import { useHoverLabel } from '@/hooks/graph/useHoverLabel'
 import { useColorMode } from '@/hooks/graph/useColorMode'
 import { useGroupByConfig } from '@/hooks/graph/useGroupByConfig'
+import {
+  useFocusNeighborhood,
+  buildAdjacency,
+  computeNeighborhood,
+  MIN_HOP_DEPTH,
+  MAX_HOP_DEPTH,
+} from '@/hooks/graph/useFocusNeighborhood'
 import { useSimulationConfig } from '@/hooks/graph/useSimulationConfig'
 import { saveLayout, loadLayout, clearLayout } from '@/hooks/graph/useLayoutCache'
 import type { LayoutCacheEntry } from '@/hooks/graph/useLayoutCache'
@@ -45,6 +52,7 @@ import { IndexingProgressModal } from '@/components/indexing/IndexingProgressMod
 import { SnapshotModal } from '@/components/graph/SnapshotModal'
 import { useSnapshotExport } from '@/hooks/graph/useSnapshotExport'
 import { repoColor } from '@/lib/colors'
+import { nodeDisplayLabel } from '@/lib/utils'
 import { RefreshCw } from 'lucide-react'
 import type { GraphNode, RelationshipKind } from '@/types/api'
 
@@ -79,6 +87,16 @@ export function GraphRoute() {
 
   // ── Group by — clustering dimension (#1392, persisted to localStorage) ─────
   const { groupBy, setGroupBy } = useGroupByConfig()
+
+  // ── Click-to-focus N-hop ego graph (#1392-refine item 5) ───────────────────
+  const {
+    focusNodeId,
+    hopDepth,
+    setFocus,
+    clearFocus,
+    setHopDepth,
+    isFocused,
+  } = useFocusNeighborhood()
 
   // ── Simulation config (#1361 — tunable params persisted to localStorage) ──
   const { config: simConfig, setParam: setSimParam, applyPreset: applySimPreset, shareHash: simShareHash } = useSimulationConfig()
@@ -178,15 +196,20 @@ export function GraphRoute() {
 
   // ── Layout position cache (#1399) ──────────────────────────────────────────
   // Persist settled positions so a reload skips the explode/settle animation.
-  const [cachedLayout, setCachedLayout] = useState<LayoutCacheEntry | null>(null)
   const [relayoutRequested, setRelayoutRequested] = useState(false)
 
   const layoutNodeIds = useMemo(() => nodes.map((n) => String(n.id)), [nodes])
 
-  useEffect(() => {
-    if (!group || nodes.length === 0) return
-    if (relayoutRequested) return // fresh sim requested — ignore cache
-    setCachedLayout(loadLayout(group, layoutNodeIds))
+  // #1392-refine (item 1) — load the cached layout SYNCHRONOUSLY via useMemo so
+  // it is available on the SAME render that GraphCanvas first mounts. Previously
+  // this lived in a useEffect, so cachedLayout was null on the mount render and
+  // GraphCanvas (mount-only init) always took the fresh-simulation path even
+  // when a cache existed. With the synchronous read, a cached layout renders
+  // settled INSTANTLY (no animation). loadLayout is a cheap localStorage read.
+  // A null result (no cache / cleared / re-layout requested) → fresh auto-settle.
+  const cachedLayout = useMemo<LayoutCacheEntry | null>(() => {
+    if (!group || nodes.length === 0 || relayoutRequested) return null
+    return loadLayout(group, layoutNodeIds)
   }, [group, layoutNodeIds, relayoutRequested, nodes.length])
 
   const handleLayoutSaved = useCallback((positions: Float32Array) => {
@@ -198,7 +221,6 @@ export function GraphRoute() {
   const handleRelayout = useCallback(() => {
     if (!group || layoutNodeIds.length === 0) return
     clearLayout(group, layoutNodeIds)
-    setCachedLayout(null)
     setRelayoutRequested(true)
   }, [group, layoutNodeIds])
 
@@ -214,6 +236,32 @@ export function GraphRoute() {
     if (!graphFilterActive) return nodes.length
     return filterIndices?.length ?? 0
   }, [nodes.length, graphFilterActive, filterIndices])
+
+  // ── Focus N-hop neighborhood → node-array indices (#1392-refine item 5) ─────
+  // Adjacency is built once per edge set; the BFS + index mapping recompute only
+  // when the focused node or hop depth changes. All client-side from the loaded
+  // edge list — no backend call.
+  const focusAdjacency = useMemo(() => buildAdjacency(edges), [edges])
+
+  const focusNeighborhood = useMemo<Set<string> | null>(() => {
+    if (!focusNodeId) return null
+    // Guard: focused node must still be present in the current node set.
+    if (!nodes.some((n) => n.id === focusNodeId)) return null
+    return computeNeighborhood(focusAdjacency, focusNodeId, hopDepth)
+  }, [focusNodeId, hopDepth, focusAdjacency, nodes])
+
+  const focusedNodeIndices = useMemo<number[] | null>(() => {
+    if (!focusNeighborhood) return null
+    const out: number[] = []
+    nodes.forEach((n, i) => { if (focusNeighborhood.has(n.id)) out.push(i) })
+    return out
+  }, [focusNeighborhood, nodes])
+
+  const focusNodeLabel = useMemo(() => {
+    if (!focusNodeId) return null
+    const n = nodes.find((nn) => nn.id === focusNodeId)
+    return n ? nodeDisplayLabel(n) : focusNodeId
+  }, [focusNodeId, nodes])
 
   // ── Node sizing tier counts (#1360) — histogram for NodeSizingControls ──────
   // Count how many non-Process nodes fall in each degree-percentile tier so the
@@ -308,15 +356,25 @@ export function GraphRoute() {
   })
 
   // ── Handlers ───────────────────────────────────────────────────────────────
+  // #1392-refine (item 5) — clicking a node BOTH opens the inspector AND focuses
+  // the camera/render on its N-hop ego graph (only the neighborhood stays
+  // visible, camera re-fits to it).
   const handleNodeClick = useCallback((node: GraphNode) => {
     selectNode(node.id)
-  }, [selectNode])
+    setFocus(node.id)
+  }, [selectNode, setFocus])
 
-  /** Clears node selection: removes URL param + signals Cosmograph to unhighlight. */
+  /** Clears node selection + focus: removes URL param + unhighlights + restores full graph. */
   const handleDeselect = useCallback(() => {
     clearSelection()
+    clearFocus()
     graphRef?.unselectPoints?.()
-  }, [clearSelection, graphRef])
+  }, [clearSelection, clearFocus, graphRef])
+
+  /** Clears only the focus (back to full graph) while keeping the inspector. */
+  const handleClearFocus = useCallback(() => {
+    clearFocus()
+  }, [clearFocus])
 
   // ── Keyboard shortcuts ─────────────────────────────────────────────────────
   // Note: '/' (search focus), arrow-nav, Tab, F, 0, n, p, Cmd+[/] are handled
@@ -881,6 +939,7 @@ export function GraphRoute() {
               highlightedEdgeIds={highlightedEdgeIds}
               simulationConfig={simConfig}
               nodeFilterIndices={filterIndices}
+              focusedNodeIndices={focusedNodeIndices}
               nodeSizingConfig={nodeSizingConfig}
               renderConfig={renderConfig}
               group={group}
@@ -888,6 +947,55 @@ export function GraphRoute() {
               onLayoutSaved={handleLayoutSaved}
               relayoutRequested={relayoutRequested}
             />
+          )}
+
+          {/* #1392-refine (item 5): focus ego-graph control bar — hop depth +
+              clear-focus affordance. Shown only while a node is focused. Esc and
+              clicking empty background also clear focus. */}
+          {isFocused && (
+            <div
+              className="absolute top-3 left-3 z-20 flex items-center gap-2 px-2.5 py-1.5 rounded-md border border-sky-700 bg-slate-900/95 text-xs text-slate-200 shadow-lg"
+              data-testid="graph-focus-bar"
+            >
+              <span className="text-sky-300 font-medium">Focused</span>
+              {focusNodeLabel && (
+                <span className="max-w-[180px] truncate text-slate-300" title={focusNodeLabel}>
+                  {focusNodeLabel}
+                </span>
+              )}
+              <span className="text-slate-500" aria-hidden>·</span>
+              <span className="text-slate-400">hops</span>
+              <div className="flex items-center gap-0.5" role="group" aria-label="Focus hop depth">
+                {Array.from({ length: MAX_HOP_DEPTH - MIN_HOP_DEPTH + 1 }, (_, k) => MIN_HOP_DEPTH + k).map((n) => (
+                  <button
+                    key={n}
+                    type="button"
+                    onClick={() => setHopDepth(n)}
+                    aria-pressed={hopDepth === n}
+                    className={[
+                      'w-5 h-5 rounded text-[11px] font-mono transition-colors',
+                      'focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400',
+                      hopDepth === n
+                        ? 'bg-sky-600 text-white'
+                        : 'bg-slate-800 text-slate-400 hover:bg-slate-700',
+                    ].join(' ')}
+                    title={`${n}-hop neighborhood`}
+                  >
+                    {n}
+                  </button>
+                ))}
+              </div>
+              <button
+                type="button"
+                onClick={handleClearFocus}
+                className="ml-1 px-1.5 py-0.5 rounded border border-slate-700 text-slate-400 hover:text-slate-200 hover:border-slate-500 transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-sky-400"
+                aria-label="Clear focus — back to full graph"
+                title="Clear focus (Esc)"
+                data-testid="graph-clear-focus"
+              >
+                ✕ full graph
+              </button>
+            </div>
           )}
 
           {/* #1157 Phase 2: Jarvis MCP activity overlay — pulse badge + log panel */}
@@ -917,7 +1025,7 @@ export function GraphRoute() {
                 style={{ left: tx, top: ty }}
                 aria-hidden="true"
               >
-                <div className="font-medium truncate">{hovNode.label ?? hovNode.id}</div>
+                <div className="font-medium truncate">{nodeDisplayLabel(hovNode)}</div>
                 {(callerCount > 0 || calleeCount > 0) && (
                   <div className="mt-0.5 text-slate-400 flex gap-2">
                     {callerCount > 0 && <span>{callerCount} caller{callerCount !== 1 ? 's' : ''}</span>}


### PR DESCRIPTION
## What & why
Five owner-requested refinements to the now-working graph view (color white-out / Group-by islands / cross-repo bridges already shipped in #1403). All changes are in `dashboard/src`; no backend changes. Everything previously working is preserved: colors (RGB normalized 0–1, no white-out), Group-by islands, cross-repo bridges, layout cache, settle cap, all panels, FPS.

## How (per item)
1. **Auto-settle on load (no manual Play, ≤2s).** Fresh load explicitly kicks the force sim once (`g.start`) in the data-push effect so it settles with no Play click, bounded by the existing wall-clock cap which auto-pauses + persists positions. Cached load now reads `cachedLayout` synchronously via `useMemo` (was a `useEffect` → null on the mount render → always took the fresh-sim path), so a cached layout renders settled **instantly**. Fixed a settle/Play-button desync: `doSettle` is idempotent (synchronous ref guard), `hasSettledRef` is authoritative (no per-render mirror), and `reassertPauseIfSettled()` re-pauses after post-settle `render()/create()` calls that restart cosmos's loop.
2. **Zoom-aware sizing.** Degree size buffer was already correct; the blob regression was `scalePointsOnZoom` inflating all nodes uniformly. Added `effectiveScaleForZoom` cap (applied on every `onZoom` + in the render-config effect) so the largest node never exceeds `maxPointSize` on screen — caps uniformly so hubs stay bigger than leaves at all zoom levels. Rendering-panel knobs still work.
3. **Tooltip shows label, not id.** New `nodeDisplayLabel()` returns `label` only when non-empty/non-whitespace, else `id` (`label ?? id` missed empty-string labels). Used by the hover tooltip + on-canvas overlay.
4. **Fill the viewport.** Explicit small `FIT_PADDING` (0.1) on the settle fit, cached-load fit, and `fitViewPadding` config.
5. **NEW: click-to-focus N-hop ego graph.** `useFocusNeighborhood` hook (focus id + persisted hopDepth 1–3, default 2) + client-side undirected BFS over the loaded edge list (no backend call). Clicking a node filters the rendered set to its N-hop neighborhood (hard hide, intersected with active filters) and re-fits the camera to it. Return via Esc, empty-background click, and a "✕ full graph" button; compact 1/2/3 hop control in the focus bar. Inspector + hover still work inside focus.

## Files
- `dashboard/src/components/graph/GraphCanvas.tsx` — auto-start, idempotent settle, fit padding, zoom-aware size cap, focus filter + re-fit
- `dashboard/src/routes/graph.tsx` — sync cached layout, focus wiring (click→focus, Esc/background/button→clear), neighborhood BFS, focus bar UI
- `dashboard/src/hooks/graph/useFocusNeighborhood.ts` — new hook + `buildAdjacency` + `computeNeighborhood`
- `dashboard/src/lib/utils.ts` — `nodeDisplayLabel`

## Testing
Playwright on an **isolated Vite port** (5219, did not touch shared :47274) against the real `upvate` group (19,652 nodes):
- Fresh load (cleared cache) auto-settles ~0.3s, no click, button shows paused, layout persisted.
- Cached reload renders settled instantly (no drift; button paused).
- Zoomed-in nodes degree-sized + distinct; largest clamped to ~150px instead of ballooning to ~2000px.
- Tooltip + overlay render real labels (0 `proc:hash`).
- Graph fills the viewport.
- Node click → only ~2-hop neighborhood + camera re-fit; Esc / background / button return to full.
- No graph console errors (only an unrelated pre-existing `/api/index-progress` 503). Colors correct.
- `vite build` passes. Unit test suite shows 16 failed / 90 passed **identical** to clean `main` (pre-existing, unrelated) — zero new regressions.

Verification screenshots: `refine-autosettle.png`, `refine-zoom-sizing.png`, `refine-fit.png`, `refine-focus.png`, `refine-focus-cleared.png` (in `.verification-screenshots/`).

## Risk / rollback
Frontend-only, scoped to the graph surface. Cleanly revertable. The settle/pause refactor is the only behavioral change to existing flow and is covered by the auto-settle + cached-load verifications above.

Refs #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)