### PR TITLE
chore(quality-check): add extraction-calibration phase (over/under audit)

### DIFF
--- a/skills/archigraph-quality-check/SKILL.md
+++ b/skills/archigraph-quality-check/SKILL.md
@@ -36,6 +36,7 @@ It runs **before** `/generate-docs` because docgen amplifies whatever bias the M
   - `--focus <category>` - only generate questions from one of the nine categories (see Phase 1). Useful for stress-testing a known weak area.
   - `--question-set <path>` - JSON file with a user-curated question set instead of auto-generated. Schema documented in Phase 1.
   - `--baseline <path>` - prior report markdown to diff against. Surfaces deltas in token/quality/speed.
+  - `--no-calibration` - skip Phase 6 (the extraction over/under audit). By default calibration always runs.
 
 ## Daemon discipline
 
@@ -56,6 +57,9 @@ The skill is a strict pipeline. Each phase has a dedicated prompt under `prompts
 | 3 | `prompts/03-without-mcp-run.md` | Answer the **same** questions using only `rg` / `grep` / `Read` / `Bash`. No archigraph MCP. Same metrics. Persist as `without-mcp.json`. |
 | 4 | `prompts/04-quality-judgment.md` | Determine ground truth by reading source code directly. Judge both runs against ground truth: full / partial / wrong / unknown plus per-question misses. Persist as `judgment.json`. |
 | 5 | `prompts/05-report.md` | Render the markdown report at `--output`. Tables, findings, issues, recommendations, raw-data appendix. |
+| 6 | `prompts/06-extraction-calibration.md` | Evaluate whether archigraph is OVER- or UNDER-extracting on this group. Quantify phantom/duplicate nodes, noise, and missing relationships against grep+read ground truth. Persist as `calibration.json` and append an "Extraction calibration" section to the report. |
+
+Phase 6 runs after Phase 5 (it consumes the same group + ground-truth passes and appends to the report). It is **not** gated on the benchmark questions — it is a structural audit of the graph itself, independent of the head-to-head. Run it whenever the benchmark runs; skip only if the user passes `--no-calibration`.
 
 Each phase reads its predecessor's output from the run directory:
 
@@ -66,6 +70,7 @@ Each phase reads its predecessor's output from the run directory:
   without-mcp.json     # Phase 3
   judgment.json        # Phase 4
   report.md            # Phase 5 (also copied to --output)
+  calibration.json     # Phase 6 (extraction over/under audit; report section appended)
 ```
 
 ## Question categories
@@ -107,6 +112,60 @@ Phase 4 reads source files **directly** to determine ground truth, independent o
 
 This methodology is honest about MCP losses. If MCP confidently returned a wrong answer, the judge marks it wrong even if it sounded authoritative.
 
+## Extraction calibration (Phase 6)
+
+The benchmark answers "does the MCP beat grep on real questions?" Phase 6 answers a different, complementary question: **is the graph itself the right size?** A graph can win the head-to-head while still being miscalibrated — too many junk nodes (over-extraction) or too few real edges (under-extraction). Both degrade docgen and erode trust in counts. Phase 6 quantifies each direction against grep+read ground truth and emits an "Extraction calibration" table.
+
+### Over-extraction (noise / false positives)
+
+Things in the graph that should NOT be there, or that inflate counts:
+
+- **Duplicate-kind nodes** - one source symbol emitted as multiple kind-tagged nodes (e.g. a Django `ViewSet` appearing as both a `Component` and a `View`; a Celery task appearing as `ScheduledJob` + `Task` + `Operation`). Detect by grouping search results on `(name, source_file)` and counting distinct `entity_id`/`kind`. Report the duplication factor (nodes per real symbol).
+- **Statement-level noise** - expressions, assignments, or f-strings extracted as standalone entities (e.g. `error_message = f"..."` as kind `Operation`). Detect by sampling entity names that contain `=`, `f"`, `return`, operators, or are not valid identifiers.
+- **Framework scaffolding** - auto-generated routes/handlers that are not hand-written app surface (e.g. Django admin `/admin/...` CRUD endpoints, migration files). Count them as a share of the relevant kind and flag for optional pruning.
+- **Generated / vendored pollution** - nodes from `node_modules`, `dist/`, `build/`, `migrations/`, `*.generated.*`, protobuf/openapi output. Detect by `source_file` path patterns.
+- **Phantom edges** - relationships that grep proves do not exist (rare; sample-verify a handful of high-degree edges).
+- **Trivial entities** - getters/setters/`__init__`-only stubs counted as first-class operations when they carry no graph value.
+
+Quantify each as a count and a rate (share of the affected kind or of total entities). Give 1-3 concrete examples per category with `path:line`.
+
+### Under-extraction (gaps / false negatives)
+
+Things that SHOULD be in the graph but are missing:
+
+- **Missing relationships that should exist** - e.g. test entities present but **zero** `TESTS` edges; Celery/pub-sub topics with null publishers or subscribers; cross-repo HTTP calls left as orphans because the client path (`/inspections/{id}`) doesn't match the server route (`/api/v1/inspections/{pk}`) — a prefix/param-name normalization gap, not a real missing endpoint. Quantify orphan-call rate and cross-repo link coverage (linked ÷ linkable).
+- **Missing entities** - real symbols grep finds that `archigraph_search` / `archigraph_inspect` cannot. Sample a few known classes/functions from each repo and confirm presence.
+- **Empty qualified_names** - entities whose `qualified_name` is `""`. These break path-finding and cross-repo joins. Report the rate by kind.
+- **Unlinked framework patterns** - DI bindings, signal/event handlers, route→handler wiring that exist in source but produce no edge.
+- **Missing kinds** - structurally important kinds that are absent or near-empty (e.g. a `Process` label expected but unpopulated).
+
+For each gap, establish ground truth with grep/read on the real repos before claiming a miss, so the audit doesn't blame the graph for something that genuinely isn't in the code.
+
+### Output: the calibration table
+
+```markdown
+## Extraction calibration
+
+| Direction | Issue | Count | Rate | Example (path:line) |
+|---|---|---:|---:|---|
+| Over | Duplicate-kind nodes (ViewSet=Component+View) | ... | ...× per symbol | ... |
+| Over | Statement-level noise (f-strings as Operation) | ... | ...% of Operation | ... |
+| Over | Django admin scaffolding endpoints | ... | ...% of endpoints | ... |
+| Under | Test entities with 0 TESTS edges | ... | ...% | ... |
+| Under | Orphan cross-repo HTTP calls | ... | ...% of calls | ... |
+| Under | Empty qualified_names | ... | ...% | ... |
+
+**Calibration verdict:** `<over-biased / under-biased / balanced>` — one-line justification.
+
+### Prune recommendations (over-extraction)
+- ...
+
+### Add recommendations (under-extraction)
+- ...
+```
+
+The verdict and recommendations feed the archigraph coordinator directly: "prune X" and "wire up Y" are actionable indexer changes. Recommendations must cite the count/rate that motivates them.
+
 ## Privacy
 
 The skill **never logs file content** in the report or in any intermediate JSON. It logs:
@@ -134,6 +193,7 @@ Source snippets are referenced by path+line, not embedded. The raw-data appendix
 - Ground truth is established by an independent grep+read pass before scoring either answer.
 - The report is written to `--output` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`).
 - The skill never spawns a daemon and never names real competitor tools in any artifact.
+- Phase 6 runs by default (unless `--no-calibration`), writes `calibration.json`, and appends an "Extraction calibration" table with quantified over- and under-extraction rows plus prune/add recommendations, each citing a count or rate established against grep+read ground truth.
 
 ## Outputs
 
@@ -141,7 +201,8 @@ Source snippets are referenced by path+line, not embedded. The raw-data appendix
 - `~/.archigraph/quality-check/<timestamp>/with-mcp.json` - Phase 2 results.
 - `~/.archigraph/quality-check/<timestamp>/without-mcp.json` - Phase 3 results.
 - `~/.archigraph/quality-check/<timestamp>/judgment.json` - Phase 4 scoring.
-- `<--output>` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`) - final shareable report.
+- `~/.archigraph/quality-check/<timestamp>/calibration.json` - Phase 6 over/under-extraction audit.
+- `<--output>` (default `~/private/benchmarks/mcp-quality-bench-<date>.md`) - final shareable report (includes the "Extraction calibration" section).
 
 ## Related
 

--- a/skills/archigraph-quality-check/prompts/05-report.md
+++ b/skills/archigraph-quality-check/prompts/05-report.md
@@ -96,6 +96,10 @@ Concrete tuning ideas for the archigraph coordinator. Each recommendation cites 
 ### Anti-patterns to avoid
 - `<X>` - observed in q04, costs N tokens per occurrence.
 
+## Extraction calibration
+
+(Appended by Phase 6 - `prompts/06-extraction-calibration.md`. Leave this heading as the insertion point; Phase 6 fills the over/under table, calibration verdict, and prune/add recommendations. Omit only if `--no-calibration`.)
+
 ## Regression diff (if --baseline provided)
 
 | Question | Prior with-MCP tokens | Current | Δ | Prior quality | Current | Δ |

--- a/skills/archigraph-quality-check/prompts/06-extraction-calibration.md
+++ b/skills/archigraph-quality-check/prompts/06-extraction-calibration.md
@@ -1,0 +1,92 @@
+# Phase 6 - Extraction calibration (over / under audit)
+
+Audit whether archigraph is **over-extracting** (noise, phantoms, duplicates polluting the graph) or **under-extracting** (real relationships and entities missing). This is a structural audit of the graph itself, independent of the Phase 2/3 head-to-head. Your output is `calibration.json` plus an "Extraction calibration" section appended to the report from Phase 5.
+
+Skip this phase only if the user passed `--no-calibration`.
+
+## Inputs
+
+- The resolved group (confirm with `archigraph_whoami` if not already known).
+- `archigraph_stats` for the entity/relationship/cross-repo totals (the denominators).
+- The real repos on disk for grep+read ground truth (the judge uses `rg`/`Read`, never the MCP, so the audit is honest).
+
+## Protocol
+
+### Step A - Establish the denominators
+
+Call `archigraph_stats`. Record total entities, total relationships, cross-repo links, and per-repo counts. Every rate you report is `count ÷ one of these denominators` (or ÷ the affected kind's count) — always state which.
+
+### Step B - Over-extraction probes
+
+For each category, gather counts via MCP, then confirm with grep+read that the flagged nodes really are noise/dupes.
+
+1. **Duplicate-kind nodes.** Pick several representative symbols (a Django ViewSet/Model, a Celery task, a serializer). For each, `archigraph_search_entities query=<name>` and group results by `(name, source_file)`. Count distinct `entity_id` and the set of `kind` values per group. If one source symbol yields >1 node, that is duplication. Report the duplication factor (nodes per real symbol) and the kind-pairs observed (e.g. `Component`+`View`, `ScheduledJob`+`Task`+`Operation`).
+2. **Statement-level noise.** Search for entity names that are clearly not declarations: contains `= f"`, `= {`, `return `, ` == `, leading whitespace, or is not a valid identifier. Each hit is an expression mis-extracted as an entity. Estimate the rate within the affected kind (usually `Operation`).
+3. **Framework scaffolding.** `archigraph_endpoints action=definitions`. Count auto-generated routes (Django `/admin/...`, DRF browsable-API, framework health routes) vs hand-written app routes. Report scaffolding share of total endpoints.
+4. **Generated / vendored pollution.** Sample `source_file` paths for `node_modules/`, `dist/`, `build/`, `migrations/`, `*.generated.*`, `*_pb2.py`, openapi output. Count nodes from such paths.
+5. **Phantom edges (spot check).** Take 3-5 high-confidence edges (`archigraph_find_callers`/`find_callees`) and grep the source to confirm the call really exists. Note any that don't.
+
+### Step C - Under-extraction probes
+
+1. **Missing relationships.**
+   - `archigraph_test_coverage` - if test entities exist but `TESTS edges (total) = 0`, that is total under-extraction of test linkage. Report covered% and edge count.
+   - `archigraph_topology action=orphan_publishers` / `orphan_subscribers` - count pub/sub topics with null counterpart. Cross-check Celery `@shared_task` / `.delay()` / `.apply_async()` call sites in source that produce no edge.
+   - `archigraph_endpoints action=calls orphan_only=true` - count orphan cross-repo HTTP calls. Then check WHY: compare a client path (e.g. `/inspections/{id}`) to the server route (`/api/v1/inspections/{pk}`). If the endpoint genuinely exists server-side, the orphan is a **normalization gap** (prefix/param-name), not a real missing endpoint — say so. Report cross-repo link coverage as `linked ÷ linkable`.
+2. **Missing entities.** Pick 3-5 classes/functions per repo you can see with `rg`. Confirm each via `archigraph_inspect` / `archigraph_search_entities`. Any grep-visible symbol the MCP can't find is a miss.
+3. **Empty qualified_names.** `archigraph_inspect` a sample of entities across kinds; count those with `qualified_name == ""`. Report rate by kind. Empty qnames break path-finding and cross-repo joins.
+4. **Unlinked framework patterns.** Look for DI bindings, Django signals (`@receiver`), route→handler wiring in source; check whether the graph has the corresponding edge.
+5. **Missing kinds.** Note any structurally important kind that is absent or near-empty when source clearly contains instances.
+
+### Honesty rule
+
+Before claiming a miss, grep the real repo to prove the thing exists in source. Before claiming noise, grep to prove the node has no real referent. The audit blames the graph only for genuine mismatches.
+
+## Output schema (`calibration.json`)
+
+```json
+{
+  "version": 1,
+  "audited_at": "<RFC3339>",
+  "denominators": {"entities": 0, "relationships": 0, "cross_repo_links": 0},
+  "over_extraction": [
+    {"issue": "duplicate-kind nodes", "count": 0, "rate": "Nx per symbol", "kinds": ["Component","View"], "examples": [{"path": "", "line": 0}]}
+  ],
+  "under_extraction": [
+    {"issue": "test entities with 0 TESTS edges", "count": 0, "rate": "0%", "examples": [{"path": "", "line": 0}]}
+  ],
+  "verdict": "over-biased | under-biased | balanced",
+  "verdict_rationale": "...",
+  "prune_recommendations": ["..."],
+  "add_recommendations": ["..."]
+}
+```
+
+## Report section to append
+
+Append to the Phase 5 report (and copy into `<run-dir>/report.md`):
+
+```markdown
+## Extraction calibration
+
+| Direction | Issue | Count | Rate | Example (path:line) |
+|---|---|---:|---:|---|
+| Over | ... | ... | ... | ... |
+| Under | ... | ... | ... | ... |
+
+**Calibration verdict:** `<over-biased / under-biased / balanced>` — `<one-line justification>`.
+
+### Prune recommendations (over-extraction)
+- `<what to drop>` — cites `<count/rate>`.
+
+### Add recommendations (under-extraction)
+- `<what to wire up>` — cites `<count/rate>`.
+```
+
+## Privacy
+
+- Log entity kinds, counts, rates, paths, and line numbers only — never source-code snippets.
+- Do not name competitor tools.
+
+## Output
+
+Write `calibration.json`, append the "Extraction calibration" section to the report at `--output` and `<run-dir>/report.md`, print the calibration verdict and the top over/under issue, and return to the orchestrator.


### PR DESCRIPTION
## What

Adds **Phase 6 — Extraction calibration** to the `archigraph-quality-check` skill. The existing skill benchmarks MCP vs grep+read on ~10-15 questions and judges quality vs ground truth, but it never reported whether archigraph is OVER- or UNDER-extracting. This adds that dimension as a structural audit of the graph itself (independent of the head-to-head).

## Why

A graph can win the benchmark while still being miscalibrated — too many junk nodes (over-extraction) inflate counts and pollute docgen; too few real edges (under-extraction) hide architecture. Both erode trust. Phase 6 quantifies each direction and feeds prune/add recommendations straight to the coordinator.

## Changes

- **`prompts/06-extraction-calibration.md`** (new): grep+read ground-truth protocol covering
  - Over: duplicate-kind nodes (Django ViewSet = Component+View; Celery task = ScheduledJob+Task+Operation), statement-level noise (f-strings as `Operation`), framework scaffolding (Django admin routes), generated/vendored pollution, phantom edges, trivial entities.
  - Under: missing TESTS/pub-sub/cross-repo edges, missing entities, empty qualified_names, unlinked framework patterns, missing kinds.
  - `calibration.json` schema + "Extraction calibration" table (over vs under, counts + rates + examples) + prune/add recommendations + verdict.
- **`SKILL.md`**: Phase 6 pipeline row, `--no-calibration` flag, calibration concept section, run-dir/outputs/acceptance entries.
- **`prompts/05-report.md`**: reserves the "Extraction calibration" heading as the Phase 6 insertion point.

Benchmark phases 1-5 are unchanged. Validated live against the `upvate` group; report shows duplicate-kind dupes, statement noise, 873 orphan cross-repo HTTP calls, and 0 TESTS edges.

Refs #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)