### PR TITLE
feat(extractor/sql): deep DB-schema extraction — PROCEDURE/TRIGGER/trigger_function + Python raw-SQL edges

### DIFF
--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -169,6 +169,16 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		emitReferences(root, file, &entities)
 	}()
 
+	// Issue #1414 — raw SQL procedure call + view read edges.
+	// Scans for cursor.execute("CALL proc(...)") and
+	// cursor.execute("SELECT ... FROM view") patterns and emits
+	// CALLS / READS_FROM edges from the enclosing Python function to
+	// the SQL procedure / view entity. Safe: never removes existing edges.
+	func() {
+		defer func() { _ = recover() }()
+		emitRawSQLDBCallEdges(string(file.Content), file.Path, &entities)
+	}()
+
 	// Track B (analog of #642 for Python) — IMPORTS ToID rewrite.
 	// Rewrites IMPORTS edges whose source_module points at a known
 	// external Python package to an `ext:<module>[:<name>]` ToID so

--- a/internal/extractors/python/raw_sql_db_calls.go
+++ b/internal/extractors/python/raw_sql_db_calls.go
@@ -1,0 +1,186 @@
+// raw_sql_db_calls.go — Issue #1414: raw SQL procedure call + view read extraction.
+//
+// Detects Python patterns that invoke stored procedures via CALL and read from
+// SQL views via raw cursor.execute / db.execute strings. Emits:
+//
+//   - cursor.execute("CALL proc_name(...)")  → enclosing fn CALLS proc_name
+//   - conn.execute("CALL proc_name(...)")    → enclosing fn CALLS proc_name
+//   - cursor.execute("SELECT ... FROM view") → enclosing fn READS_FROM view
+//   - conn.execute("SELECT ... FROM view")   → enclosing fn READS_FROM view
+//
+// These edges bridge the Python application layer to the SQL schema layer,
+// closing the orphan gap for procedure and view entities defined in migration
+// files that are only referenced via raw execute strings.
+//
+// The scanner is intentionally conservative:
+//   - Only fires when "CALL" or "SELECT … FROM" appears literally inside the
+//     string argument of an execute call.
+//   - Procedure names are normalised: schema qualifiers (schema.proc) are
+//     stripped to the leaf name.
+//   - View names are extracted from the first FROM / JOIN clause in the string.
+//   - One edge per (caller, target) pair — deduplication across all call
+//     sites in the same function.
+//
+// The pass appends edges to entities in place; it never removes or modifies
+// existing entities, so regressions on files without raw-SQL calls are
+// impossible.
+package python
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// pyRawSQLCallRE matches:
+//
+//	cursor.execute("CALL proc_name(...)") or
+//	conn.execute("CALL proc_name(...)")   or
+//	db.execute("CALL proc_name(...)")     or
+//	session.execute("CALL proc_name(...)") — any receiver + .execute( + string
+//
+// Capture group 1: the full SQL string content (up to closing quote).
+var pyRawSQLCallRE = regexp.MustCompile(
+	`(?i)\b\w+\.execute\s*\(\s*(?:f?["'])((?:[^"'\\]|\\.)*?)(?:["'])`,
+)
+
+// pyRawSQLCALLProcRE extracts the procedure name from a SQL CALL statement.
+// Capture group 1: proc name (leaf, without schema qualifier).
+var pyRawSQLCALLProcRE = regexp.MustCompile(
+	`(?i)\bCALL\s+(?:\w+\.)?(\w+)\s*\(`,
+)
+
+// pyRawSQLFromRE extracts the first table/view name after FROM in a SQL SELECT.
+// Capture group 1: table/view name.
+var pyRawSQLFromRE = regexp.MustCompile(
+	`(?i)\bFROM\s+(?:\w+\.)?(\w+)\b`,
+)
+
+// enclosingFuncRE extracts enclosing function names from surrounding source
+// context — used to attribute edges when tree-sitter is not available.
+// We use a simple line-scan approach: the nearest preceding "def " line above
+// the call site is the enclosing function.
+
+// rawSQLReservedWords lists identifiers that FROM/JOIN can pick up but that are
+// SQL keywords rather than table/view names.
+var rawSQLReservedWords = map[string]bool{
+	"ONLY": true, "SELECT": true, "WHERE": true, "WITH": true, "AS": true,
+	"JOIN": true, "LATERAL": true, "DUAL": true,
+}
+
+// emitRawSQLDBCallEdges scans src for cursor.execute("CALL ...") and
+// cursor.execute("SELECT ... FROM view") patterns and appends CALLS /
+// READS_FROM edges to the enclosing function entities in entities.
+//
+// filePath is used only to match entities by SourceFile.
+// src is the raw Python source text.
+func emitRawSQLDBCallEdges(src string, filePath string, entities *[]types.EntityRecord) {
+	if entities == nil || len(*entities) == 0 {
+		return
+	}
+
+	lines := strings.Split(src, "\n")
+	// Build a map from line number (1-based) to the enclosing function's
+	// emitted name by scanning "def " declarations. This is intentionally
+	// simple: the most recently declared function at the same or lower
+	// indentation level enclosing the call site.
+	funcByLine := buildFuncLineMap(lines)
+
+	type edgeKey struct {
+		caller string
+		kind   string
+		target string
+	}
+	seen := make(map[edgeKey]bool)
+
+	for _, m := range pyRawSQLCallRE.FindAllStringSubmatchIndex(src, -1) {
+		sqlStr := src[m[2]:m[3]]
+		lineNum := strings.Count(src[:m[0]], "\n") + 1
+		caller := funcByLine[lineNum]
+		if caller == "" {
+			continue
+		}
+
+		// Detect CALL proc_name(...)
+		if cm := pyRawSQLCALLProcRE.FindStringSubmatch(sqlStr); cm != nil {
+			procName := cm[1]
+			k := edgeKey{caller, "CALLS", procName}
+			if !seen[k] {
+				seen[k] = true
+				appendEdgeToFunc(entities, filePath, caller, types.RelationshipRecord{
+					ToID:       procName,
+					Kind:       "CALLS",
+					Properties: map[string]string{"raw_sql": "true", "call_type": "procedure"},
+				})
+			}
+			continue
+		}
+
+		// Detect SELECT ... FROM view_name
+		upperSQL := strings.ToUpper(sqlStr)
+		if strings.Contains(upperSQL, "SELECT") {
+			for _, fm := range pyRawSQLFromRE.FindAllStringSubmatch(sqlStr, -1) {
+				viewName := fm[1]
+				if rawSQLReservedWords[strings.ToUpper(viewName)] {
+					continue
+				}
+				k := edgeKey{caller, "READS_FROM", viewName}
+				if !seen[k] {
+					seen[k] = true
+					appendEdgeToFunc(entities, filePath, caller, types.RelationshipRecord{
+						ToID:       viewName,
+						Kind:       "READS_FROM",
+						Properties: map[string]string{"raw_sql": "true", "dml": "select"},
+					})
+				}
+			}
+		}
+	}
+}
+
+// buildFuncLineMap builds a line→enclosingFunctionName map for src split by
+// lines. The algorithm is a simple indentation-aware "most recent def"
+// tracker: for each line we record the deepest enclosing def name.
+func buildFuncLineMap(lines []string) map[int]string {
+	// Stack entries: (indentLevel, funcEmittedName)
+	type stackEntry struct {
+		indent int
+		name   string
+	}
+	var stack []stackEntry
+	result := make(map[int]string, len(lines))
+
+	defRE := regexp.MustCompile(`^(\s*)def\s+(\w+)\s*\(`)
+
+	for i, line := range lines {
+		lineNum := i + 1
+
+		if m := defRE.FindStringSubmatch(line); m != nil {
+			indent := len(m[1])
+			name := m[2]
+			// Pop entries at same or deeper indent — this def supersedes them.
+			for len(stack) > 0 && stack[len(stack)-1].indent >= indent {
+				stack = stack[:len(stack)-1]
+			}
+			stack = append(stack, stackEntry{indent, name})
+		}
+
+		if len(stack) > 0 {
+			result[lineNum] = stack[len(stack)-1].name
+		}
+	}
+	return result
+}
+
+// appendEdgeToFunc appends rel to the first entity in entities whose
+// SourceFile == filePath and Name == funcName.
+func appendEdgeToFunc(entities *[]types.EntityRecord, filePath, funcName string, rel types.RelationshipRecord) {
+	for i := range *entities {
+		e := &(*entities)[i]
+		if e.SourceFile == filePath && e.Name == funcName {
+			e.Relationships = append(e.Relationships, rel)
+			return
+		}
+	}
+}

--- a/internal/extractors/python/raw_sql_db_calls_test.go
+++ b/internal/extractors/python/raw_sql_db_calls_test.go
@@ -1,0 +1,138 @@
+package python_test
+
+// Issue #1414: Python raw SQL DB call edge extraction.
+//
+// Verifies that the raw SQL scanner emits:
+//   - cursor.execute("CALL proc_name(...)") → enclosing function CALLS proc_name
+//   - cursor.execute("SELECT ... FROM view_name") → enclosing function READS_FROM view_name
+//
+// These edges bridge the Python application layer (app/db.py, consumer.py)
+// to the SQL schema layer (procedures, views defined in migration files).
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func extractPyContent1414(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+	entities, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Content:  []byte(src),
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("extract: %v", err)
+	}
+	return entities
+}
+
+func findPyEntityByName(entities []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range entities {
+		if entities[i].Name == name {
+			return &entities[i]
+		}
+	}
+	return nil
+}
+
+func hasEdge(rels []types.RelationshipRecord, kind, toID string) bool {
+	for _, r := range rels {
+		if r.Kind == kind && r.ToID == toID {
+			return true
+		}
+	}
+	return false
+}
+
+// Test1414_PyCallsProcedure verifies that cursor.execute("CALL mark_order_paid(...)")
+// produces a CALLS edge from the enclosing Python function to mark_order_paid.
+func Test1414_PyCallsProcedure(t *testing.T) {
+	src := `
+import psycopg2
+
+def mark_order_paid(conn, order_id, amount):
+    cursor = conn.cursor()
+    cursor.execute("CALL mark_order_paid(%s, %s)", (order_id, amount))
+    conn.commit()
+`
+	entities := extractPyContent1414(t, src, "app/db.py")
+	fn := findPyEntityByName(entities, "mark_order_paid")
+	if fn == nil {
+		t.Fatal("[CALLS] expected function mark_order_paid to be extracted")
+	}
+	if !hasEdge(fn.Relationships, "CALLS", "mark_order_paid") {
+		t.Errorf("[CALLS] expected mark_order_paid CALLS mark_order_paid (procedure), got %v", fn.Relationships)
+	}
+}
+
+// Test1414_PyReadsFromView verifies that cursor.execute("SELECT ... FROM order_summary")
+// produces a READS_FROM edge from the enclosing function to order_summary.
+func Test1414_PyReadsFromView(t *testing.T) {
+	src := `
+import psycopg2
+
+def get_user_summary(conn, user_id):
+    cursor = conn.cursor()
+    cursor.execute("SELECT id, user_id, status FROM order_summary WHERE user_id = %s", (user_id,))
+    return cursor.fetchall()
+`
+	entities := extractPyContent1414(t, src, "app/db.py")
+	fn := findPyEntityByName(entities, "get_user_summary")
+	if fn == nil {
+		t.Fatal("[READS_FROM] expected function get_user_summary to be extracted")
+	}
+	if !hasEdge(fn.Relationships, "READS_FROM", "order_summary") {
+		t.Errorf("[READS_FROM] expected get_user_summary READS_FROM order_summary, got %v", fn.Relationships)
+	}
+}
+
+// Test1414_PyNoFalsePositivesOnPlainExecute ensures that cursor.execute() calls
+// without SQL CALL or SELECT ... FROM do NOT emit spurious edges.
+func Test1414_PyNoFalsePositivesOnPlainExecute(t *testing.T) {
+	src := `
+def create_table(conn):
+    cursor = conn.cursor()
+    cursor.execute("CREATE TABLE IF NOT EXISTS foo (id INT)")
+    conn.commit()
+`
+	entities := extractPyContent1414(t, src, "app/schema.py")
+	fn := findPyEntityByName(entities, "create_table")
+	if fn == nil {
+		return // function not emitted — test moot
+	}
+	for _, r := range fn.Relationships {
+		if (r.Kind == "CALLS" || r.Kind == "READS_FROM") && r.Properties["raw_sql"] == "true" {
+			t.Errorf("unexpected raw SQL edge from create_table: %+v", r)
+		}
+	}
+}
+
+// Test1414_PyConsumerCallsProc verifies that a consumer.py pattern calling
+// the procedure on payments.settled event also emits the CALLS edge.
+func Test1414_PyConsumerCallsProc(t *testing.T) {
+	src := `
+import psycopg2
+
+def on_payment_settled(conn, event):
+    order_id = event["order_id"]
+    amount = event["amount"]
+    conn.execute("CALL mark_order_paid(%s, %s)" % (order_id, amount))
+`
+	entities := extractPyContent1414(t, src, "consumer.py")
+	fn := findPyEntityByName(entities, "on_payment_settled")
+	if fn == nil {
+		t.Fatal("expected function on_payment_settled to be extracted")
+	}
+	if !hasEdge(fn.Relationships, "CALLS", "mark_order_paid") {
+		t.Errorf("expected on_payment_settled CALLS mark_order_paid (procedure), got %v", fn.Relationships)
+	}
+}

--- a/internal/extractors/sql/sql.go
+++ b/internal/extractors/sql/sql.go
@@ -1,21 +1,29 @@
 // Package sql implements the tree-sitter–based extractor for SQL source files.
 //
 // Extracted entities:
-//   - CREATE TABLE  → Kind="SCOPE.Datastore", Subtype="table"
-//   - column        → Kind="SCOPE.Schema",    Subtype="column" (one per column inside a CREATE TABLE)
-//   - CREATE VIEW   → Kind="SCOPE.Datastore", Subtype="view"
-//   - CREATE INDEX  → Kind="SCOPE.Datastore", Subtype="index"
+//   - CREATE TABLE        → Kind="SCOPE.Datastore", Subtype="table"
+//   - column              → Kind="SCOPE.Schema",    Subtype="column" (one per column inside a CREATE TABLE)
+//   - CREATE VIEW         → Kind="SCOPE.Datastore", Subtype="view"
+//   - CREATE INDEX        → Kind="SCOPE.Datastore", Subtype="index"
+//   - CREATE FUNCTION     → Kind="SCOPE.Datastore", Subtype="function"
+//   - CREATE PROCEDURE    → Kind="SCOPE.Datastore", Subtype="procedure"
+//   - RETURNS TRIGGER fn  → Kind="SCOPE.Datastore", Subtype="trigger_function"
+//   - CREATE TRIGGER      → Kind="SCOPE.Datastore", Subtype="trigger"
 //   - dbt {{ ref('model') }}    → Kind="SCOPE.Component",  Subtype="dbt_ref"
 //   - dbt {{ source('s','t') }} → Kind="SCOPE.Datastore",  Subtype="dbt_source"
 //   - dbt {{ config(...) }}     → Kind="SCOPE.Component",  Subtype="dbt_config"
 //
 // Relationships emitted:
-//   - Table    → Column          : CONTAINS
-//   - Column   → ReferencedTable  : REFERENCES (foreign key)
-//   - Index    → Table            : INDEXES
-//   - View     → Table            : READS_FROM   (Issue #389)
-//   - Function → Table            : READS_FROM   (Issue #389; SELECT in body)
-//   - Function → Table            : WRITES_TO    (Issue #389; INSERT/UPDATE/DELETE in body)
+//   - Table            → Column              : CONTAINS
+//   - Column           → ReferencedTable     : REFERENCES (foreign key)
+//   - Index            → Table              : INDEXES
+//   - View             → Table              : READS_FROM   (Issue #389)
+//   - Function         → Table              : READS_FROM   (Issue #389; SELECT in body)
+//   - Function         → Table              : WRITES_TO    (Issue #389; INSERT/UPDATE/DELETE in body)
+//   - Procedure        → Table              : READS_FROM / WRITES_TO (same as function)
+//   - Trigger          → TriggerFunction    : FIRES        (Issue #1414)
+//   - Trigger          → Table              : DEFINED_ON   (Issue #1414)
+//   - TriggerFunction  → Table              : READS_FROM / WRITES_TO (body DML)
 //
 // Migration metadata (Issue #1275):
 //   When a .sql file lives under a migrations/ directory, every emitted table
@@ -66,8 +74,27 @@ var (
 	indexRE = regexp.MustCompile(
 		`(?i)(?m)^\s*CREATE\s+(?:UNIQUE\s+)?(?:CONCURRENTLY\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?(\w+)\s+ON\s+(?:\w+\.)?(\w+)`,
 	)
+	// funcRE matches CREATE [OR REPLACE] FUNCTION (but NOT PROCEDURE — handled separately).
 	funcRE = regexp.MustCompile(
-		`(?i)(?m)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:AGGREGATE\s+|PROCEDURE\s+|FUNCTION\s+)(\w+)\s*\(`,
+		`(?i)(?m)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?(?:AGGREGATE\s+|FUNCTION\s+)(\w+)\s*\(`,
+	)
+
+	// procRE matches CREATE [OR REPLACE] PROCEDURE name(
+	procRE = regexp.MustCompile(
+		`(?i)(?m)^\s*CREATE\s+(?:OR\s+REPLACE\s+)?PROCEDURE\s+(?:\w+\.)?(\w+)\s*\(`,
+	)
+
+	// triggerFuncBodyRE detects "RETURNS TRIGGER" in a function body —
+	// used to reclassify FUNCTION entities that are PostgreSQL trigger
+	// handler functions (Subtype="trigger_function").
+	triggerFuncBodyRE = regexp.MustCompile(`(?i)\bRETURNS\s+TRIGGER\b`)
+
+	// triggerRE matches CREATE [CONSTRAINT] TRIGGER name ... ON table ...
+	// EXECUTE {FUNCTION|PROCEDURE} func_name
+	// Captures: (1) trigger_name, (2) event (BEFORE|AFTER|INSTEAD OF),
+	//           (3) table_name, (4) func_name
+	triggerRE = regexp.MustCompile(
+		`(?is)CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\s+(\w+)\s+(?:(BEFORE|AFTER|INSTEAD\s+OF)\s+)?(?:\w+\s+(?:OR\s+\w+\s+)*)?ON\s+(?:\w+\.)?(\w+)\s+.*?EXECUTE\s+(?:FUNCTION|PROCEDURE)\s+(?:\w+\.)?(\w+)\s*\(`,
 	)
 
 	// dbt Jinja patterns.
@@ -424,7 +451,12 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		})
 	}
 
-	// Functions / Procedures.
+	// Functions (including trigger-handler functions reclassified to trigger_function).
+	//
+	// Issue #1414: a FUNCTION whose body contains "RETURNS TRIGGER" is a
+	// PostgreSQL trigger handler. Emit it with Subtype="trigger_function" so
+	// downstream graph queries can distinguish it from plain functions and so
+	// TRIGGER entities can reference it via a typed FIRES edge.
 	for _, m := range funcRE.FindAllStringSubmatchIndex(src, -1) {
 		name := src[m[2]:m[3]]
 		key := "function:" + name
@@ -443,13 +475,6 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 		body := sliceFuncBody(src, m[1])
 		reads, writes := extractDMLTargets(body)
 		var rels []types.RelationshipRecord
-		dmlKindFor := func(table string, isWrite bool) string {
-			if isWrite {
-				return "write"
-			}
-			_ = table
-			return "select"
-		}
 		for _, t := range reads {
 			if t == name {
 				continue
@@ -458,7 +483,7 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 				FromID:     name,
 				ToID:       t,
 				Kind:       "READS_FROM",
-				Properties: map[string]string{"dml": dmlKindFor(t, false)},
+				Properties: map[string]string{"dml": "select"},
 			})
 		}
 		for _, t := range writes {
@@ -469,19 +494,139 @@ func extractSQL(src, filePath string) []types.EntityRecord {
 				FromID:     name,
 				ToID:       t,
 				Kind:       "WRITES_TO",
-				Properties: map[string]string{"dml": dmlKindFor(t, true)},
+				Properties: map[string]string{"dml": "write"},
+			})
+		}
+
+		// Determine whether this is a trigger handler function.
+		// RETURNS TRIGGER appears between the parameter list close-paren and
+		// the AS $$ body start. We build a "declaration region" that covers
+		// from the CREATE keyword through the first $$ (or first semicolon for
+		// non-dollar-quoted bodies) so the triggerFuncBodyRE can find it.
+		subtype := "function"
+		signature := fmt.Sprintf("CREATE FUNCTION %s", name)
+		declRegion := sliceFuncDecl(src, m[0], m[1])
+		if triggerFuncBodyRE.MatchString(declRegion) {
+			subtype = "trigger_function"
+			signature = fmt.Sprintf("CREATE FUNCTION %s RETURNS TRIGGER", name)
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:               name,
+			Kind:               "SCOPE.Datastore",
+			Subtype:            subtype,
+			SourceFile:         filePath,
+			Language:           "sql",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          signature,
+			EnrichmentRequired: false,
+			Relationships:      rels,
+		})
+	}
+
+	// Procedures (Issue #1414): CREATE [OR REPLACE] PROCEDURE name(...)
+	// Distinct from FUNCTION — emitted with Subtype="procedure" and a
+	// correct "CREATE PROCEDURE" signature.
+	for _, m := range procRE.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		key := "procedure:" + name
+		if seen[key] {
+			continue
+		}
+		// Also guard against a name that was already claimed by the funcRE pass
+		// (shouldn't happen given the split regex, but be defensive).
+		if seen["function:"+name] {
+			continue
+		}
+		seen[key] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		endLine := findBlockEnd(src, m[1]-1)
+
+		body := sliceFuncBody(src, m[1])
+		reads, writes := extractDMLTargets(body)
+		var rels []types.RelationshipRecord
+		for _, t := range reads {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "READS_FROM",
+				Properties: map[string]string{"dml": "select"},
+			})
+		}
+		for _, t := range writes {
+			if t == name {
+				continue
+			}
+			rels = append(rels, types.RelationshipRecord{
+				FromID:     name,
+				ToID:       t,
+				Kind:       "WRITES_TO",
+				Properties: map[string]string{"dml": "write"},
 			})
 		}
 
 		entities = append(entities, types.EntityRecord{
 			Name:               name,
 			Kind:               "SCOPE.Datastore",
-			Subtype:            "function",
+			Subtype:            "procedure",
 			SourceFile:         filePath,
 			Language:           "sql",
 			StartLine:          startLine,
 			EndLine:            endLine,
-			Signature:          fmt.Sprintf("CREATE FUNCTION %s", name),
+			Signature:          fmt.Sprintf("CREATE PROCEDURE %s", name),
+			EnrichmentRequired: false,
+			Relationships:      rels,
+		})
+	}
+
+	// Triggers (Issue #1414): CREATE [CONSTRAINT] TRIGGER name ... ON table
+	// EXECUTE FUNCTION|PROCEDURE func_name(...)
+	//
+	// Emits two edges from the trigger entity:
+	//   - FIRES      → trigger function (the EXECUTE FUNCTION target)
+	//   - DEFINED_ON → table            (the ON <table> target)
+	for _, m := range triggerRE.FindAllStringSubmatchIndex(src, -1) {
+		triggerName := src[m[2]:m[3]]
+		// m[4]:m[5] is the event (BEFORE/AFTER/INSTEAD OF) — optional
+		tableName := src[m[6]:m[7]]
+		funcName := src[m[8]:m[9]]
+
+		key := "trigger:" + triggerName
+		if seen[key] {
+			continue
+		}
+		seen[key] = true
+		startLine := strings.Count(src[:m[0]], "\n") + 1
+		endLine := findStmtEnd(src, m[0])
+
+		rels := []types.RelationshipRecord{
+			{
+				FromID:     triggerName,
+				ToID:       funcName,
+				Kind:       "FIRES",
+				Properties: map[string]string{"trigger_target": "function"},
+			},
+			{
+				FromID:     triggerName,
+				ToID:       tableName,
+				Kind:       "DEFINED_ON",
+				Properties: map[string]string{"trigger_table": tableName},
+			},
+		}
+
+		entities = append(entities, types.EntityRecord{
+			Name:               triggerName,
+			Kind:               "SCOPE.Datastore",
+			Subtype:            "trigger",
+			SourceFile:         filePath,
+			Language:           "sql",
+			StartLine:          startLine,
+			EndLine:            endLine,
+			Signature:          fmt.Sprintf("CREATE TRIGGER %s ON %s EXECUTE FUNCTION %s", triggerName, tableName, funcName),
 			EnrichmentRequired: false,
 			Relationships:      rels,
 		})
@@ -931,4 +1076,41 @@ func findStmtEnd(src string, startPos int) int {
 		return strings.Count(src, "\n") + 1
 	}
 	return strings.Count(src[:startPos+idx], "\n") + 1
+}
+
+// sliceFuncDecl returns the "declaration region" of a CREATE FUNCTION statement:
+// the text from createStart up to (but not including) the start of the $$ body
+// or the first semicolon.
+//
+// This region contains the function header including the RETURNS clause (e.g.
+// "RETURNS TRIGGER") that sits between the parameter list close-paren and the
+// body marker. It is used by the trigger_function reclassification to find
+// "RETURNS TRIGGER" without scanning the full dollar-quoted body.
+//
+// createStart is the byte offset of "CREATE" in src.
+// headerEnd is the byte offset immediately AFTER the opening "(" of the
+// parameter list (i.e. m[1] from the funcRE match).
+func sliceFuncDecl(src string, createStart, headerEnd int) string {
+	if createStart < 0 || headerEnd < 0 || headerEnd > len(src) {
+		return ""
+	}
+	// Find the close-paren of the parameter list.
+	paramCloseIdx := findBlockEndOffset(src, headerEnd-1)
+	scanFrom := headerEnd
+	if paramCloseIdx > 0 && paramCloseIdx < len(src) {
+		scanFrom = paramCloseIdx + 1
+	}
+	if scanFrom >= len(src) {
+		return src[createStart:]
+	}
+	rest := src[scanFrom:]
+	// Stop at the first $$ (dollar-quote body start).
+	if i := strings.Index(rest, "$$"); i >= 0 {
+		return src[createStart : scanFrom+i]
+	}
+	// No dollar-quote — stop at the first semicolon.
+	if i := strings.Index(rest, ";"); i >= 0 {
+		return src[createStart : scanFrom+i]
+	}
+	return src[createStart:]
 }

--- a/internal/extractors/sql/sql_1414_test.go
+++ b/internal/extractors/sql/sql_1414_test.go
@@ -1,0 +1,211 @@
+package sql_test
+
+// Issue #1414: VIEW / PROCEDURE / TRIGGER deep DB-schema extraction.
+//
+// Acceptance criteria (mirrors ShipFast D23 MANIFEST §12):
+//
+//   Entity extraction:
+//   [E1]  VIEW  order_summary         → SCOPE.Datastore / view
+//   [E2]  PROCEDURE mark_order_paid   → SCOPE.Datastore / procedure
+//   [E3]  FUNCTION log_order_status_change → SCOPE.Datastore / trigger_function
+//   [E4]  TRIGGER trg_order_status_change  → SCOPE.Datastore / trigger
+//   [E5]  TABLE orders                → SCOPE.Datastore / table (regression guard)
+//   [E6]  TABLE order_status_audit    → SCOPE.Datastore / table
+//   [E7]  TABLE daily_revenue         → SCOPE.Datastore / table
+//
+//   Edge extraction:
+//   [R1]  order_summary  READS_FROM orders            (view body SELECT FROM orders)
+//   [R2]  mark_order_paid WRITES_TO orders             (procedure body UPDATE orders)
+//   [R3]  mark_order_paid WRITES_TO daily_revenue      (procedure body INSERT daily_revenue)
+//   [R4]  log_order_status_change WRITES_TO order_status_audit (trigger fn body INSERT)
+//   [R5]  trg_order_status_change FIRES log_order_status_change
+//   [R6]  trg_order_status_change DEFINED_ON orders
+
+import (
+	"testing"
+)
+
+// loadFixture1414 reads the §12 migration fixture.
+func loadFixture1414(t *testing.T) []byte {
+	t.Helper()
+	return loadFixture(t, "migration_006_views_procs_triggers.sql")
+}
+
+// ---- E1: VIEW order_summary ------------------------------------------------
+
+func Test1414_E1_ViewExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "order_summary")
+	if e == nil {
+		t.Fatal("[E1] expected VIEW order_summary entity (SCOPE.Datastore/view)")
+	}
+	if e.Subtype != "view" {
+		t.Errorf("[E1] expected Subtype=view, got %q", e.Subtype)
+	}
+}
+
+// ---- E2: PROCEDURE mark_order_paid -----------------------------------------
+
+func Test1414_E2_ProcedureExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "mark_order_paid")
+	if e == nil {
+		t.Fatal("[E2] expected PROCEDURE mark_order_paid entity (SCOPE.Datastore/procedure)")
+	}
+	if e.Subtype != "procedure" {
+		t.Errorf("[E2] expected Subtype=procedure, got %q", e.Subtype)
+	}
+	if e.Signature == "" {
+		t.Error("[E2] expected non-empty Signature")
+	}
+}
+
+// ---- E3: TRIGGER FUNCTION log_order_status_change --------------------------
+
+func Test1414_E3_TriggerFunctionExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "log_order_status_change")
+	if e == nil {
+		t.Fatal("[E3] expected FUNCTION log_order_status_change entity")
+	}
+	if e.Subtype != "trigger_function" {
+		t.Errorf("[E3] expected Subtype=trigger_function (RETURNS TRIGGER), got %q", e.Subtype)
+	}
+}
+
+// ---- E4: TRIGGER trg_order_status_change -----------------------------------
+
+func Test1414_E4_TriggerExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("[E4] expected TRIGGER trg_order_status_change entity (SCOPE.Datastore/trigger)")
+	}
+	if e.Subtype != "trigger" {
+		t.Errorf("[E4] expected Subtype=trigger, got %q", e.Subtype)
+	}
+}
+
+// ---- E5-E7: Tables are still extracted (regression guard) ------------------
+
+func Test1414_E5E6E7_TablesRegressionGuard(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	for _, want := range []string{"orders", "order_status_audit", "daily_revenue"} {
+		e := findEntity(entities, "SCOPE.Datastore", want)
+		if e == nil {
+			t.Errorf("[E5-E7] expected TABLE %q entity", want)
+		} else if e.Subtype != "table" {
+			t.Errorf("[E5-E7] TABLE %q Subtype=%q, want table", want, e.Subtype)
+		}
+	}
+}
+
+// ---- R1: order_summary READS_FROM orders -----------------------------------
+
+func Test1414_R1_ViewReadsFromOrders(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "order_summary")
+	if e == nil {
+		t.Fatal("[R1] order_summary entity not found")
+	}
+	reads := collectEdges(e.Relationships, "READS_FROM")
+	if !reads["orders"] {
+		t.Errorf("[R1] expected order_summary READS_FROM orders, got %v", reads)
+	}
+}
+
+// ---- R2: mark_order_paid WRITES_TO orders ----------------------------------
+
+func Test1414_R2_ProcedureWritesToOrders(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "mark_order_paid")
+	if e == nil {
+		t.Fatal("[R2] mark_order_paid entity not found")
+	}
+	writes := collectEdges(e.Relationships, "WRITES_TO")
+	if !writes["orders"] {
+		t.Errorf("[R2] expected mark_order_paid WRITES_TO orders, got %v", writes)
+	}
+}
+
+// ---- R3: mark_order_paid WRITES_TO daily_revenue ---------------------------
+
+func Test1414_R3_ProcedureWritesToDailyRevenue(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "mark_order_paid")
+	if e == nil {
+		t.Fatal("[R3] mark_order_paid entity not found")
+	}
+	writes := collectEdges(e.Relationships, "WRITES_TO")
+	if !writes["daily_revenue"] {
+		t.Errorf("[R3] expected mark_order_paid WRITES_TO daily_revenue, got %v", writes)
+	}
+}
+
+// ---- R4: log_order_status_change WRITES_TO order_status_audit --------------
+
+func Test1414_R4_TriggerFnWritesToAudit(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "log_order_status_change")
+	if e == nil {
+		t.Fatal("[R4] log_order_status_change entity not found")
+	}
+	writes := collectEdges(e.Relationships, "WRITES_TO")
+	if !writes["order_status_audit"] {
+		t.Errorf("[R4] expected log_order_status_change WRITES_TO order_status_audit, got %v", writes)
+	}
+}
+
+// ---- R5: trg_order_status_change FIRES log_order_status_change -------------
+
+func Test1414_R5_TriggerFiresTriggerFn(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("[R5] trg_order_status_change entity not found")
+	}
+	fires := collectEdges(e.Relationships, "FIRES")
+	if !fires["log_order_status_change"] {
+		t.Errorf("[R5] expected trg_order_status_change FIRES log_order_status_change, got %v", fires)
+	}
+}
+
+// ---- R6: trg_order_status_change DEFINED_ON orders -------------------------
+
+func Test1414_R6_TriggerDefinedOnOrders(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("[R6] trg_order_status_change entity not found")
+	}
+	definedOn := collectEdges(e.Relationships, "DEFINED_ON")
+	if !definedOn["orders"] {
+		t.Errorf("[R6] expected trg_order_status_change DEFINED_ON orders, got %v", definedOn)
+	}
+}
+
+// ---- ProcedureSignature: Signature field says CREATE PROCEDURE --------------
+
+func Test1414_ProcedureSignature(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "mark_order_paid")
+	if e == nil {
+		t.Fatal("mark_order_paid not found")
+	}
+	if e.Signature != "CREATE PROCEDURE mark_order_paid" {
+		t.Errorf("expected Signature='CREATE PROCEDURE mark_order_paid', got %q", e.Signature)
+	}
+}
+
+// ---- TriggerSignature: Signature contains table and function ----------------
+
+func Test1414_TriggerSignature(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1414(t), "migrations/006_views_procs_triggers.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("trg_order_status_change not found")
+	}
+	if e.Signature == "" {
+		t.Error("expected non-empty trigger Signature")
+	}
+}

--- a/internal/extractors/sql/testdata/migration_006_views_procs_triggers.sql
+++ b/internal/extractors/sql/testdata/migration_006_views_procs_triggers.sql
@@ -1,0 +1,63 @@
+-- Fixture for Issue #1414: VIEW / PROCEDURE / TRIGGER extraction.
+-- Mirrors services/orders/migrations/002_views_procs_triggers.sql
+-- from the ShipFast D23 corpus (MANIFEST §12).
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    user_id INTEGER NOT NULL,
+    status VARCHAR(50) DEFAULT 'pending',
+    total_amount NUMERIC(12,2) DEFAULT 0
+);
+
+CREATE TABLE daily_revenue (
+    day DATE PRIMARY KEY,
+    revenue NUMERIC(14,2) DEFAULT 0
+);
+
+CREATE TABLE order_status_audit (
+    id BIGSERIAL PRIMARY KEY,
+    order_id INTEGER NOT NULL,
+    old_status VARCHAR(50),
+    new_status VARCHAR(50),
+    changed_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- VIEW: order_summary → reads from orders
+CREATE OR REPLACE VIEW order_summary AS
+SELECT
+    o.id,
+    o.user_id,
+    o.status,
+    o.total_amount
+FROM orders o
+WHERE o.status != 'cancelled';
+
+-- PROCEDURE: mark_order_paid(order_id, amount) — writes orders + daily_revenue
+CREATE OR REPLACE PROCEDURE mark_order_paid(p_order_id TEXT, p_amount INT)
+LANGUAGE plpgsql AS $$
+BEGIN
+    UPDATE orders SET status = 'paid', total_amount = p_amount WHERE id = p_order_id::INT;
+    INSERT INTO daily_revenue (day, revenue)
+        VALUES (CURRENT_DATE, p_amount)
+        ON CONFLICT (day) DO UPDATE SET revenue = daily_revenue.revenue + p_amount;
+END;
+$$;
+
+-- TRIGGER FUNCTION: log_order_status_change() RETURNS TRIGGER
+-- Writes to order_status_audit; reads from orders (implicit via NEW/OLD).
+CREATE OR REPLACE FUNCTION log_order_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+    IF NEW.status IS DISTINCT FROM OLD.status THEN
+        INSERT INTO order_status_audit (order_id, old_status, new_status)
+        VALUES (NEW.id, OLD.status, NEW.status);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- TRIGGER: trg_order_status_change AFTER UPDATE ON orders
+CREATE TRIGGER trg_order_status_change
+AFTER UPDATE ON orders
+FOR EACH ROW
+EXECUTE FUNCTION log_order_status_change();


### PR DESCRIPTION
## Summary

Extends SQL migration extraction to correctly emit PROCEDURE, TRIGGER, and trigger_function entities (previously all collapsed to `function` or silently dropped), and adds a Python raw-SQL pass that bridges `cursor.execute("CALL proc()")` and `cursor.execute("SELECT … FROM view")` back to those SQL entities.

Fixes #1414

## What changed

**`internal/extractors/sql/sql.go`**
- Split `funcRE` into `funcRE` (FUNCTION only) and `procRE` (PROCEDURE only). Procedures now emit `Subtype="procedure"` with the correct `"CREATE PROCEDURE name"` signature.
- `trigger_function` reclassification: after a FUNCTION match, `sliceFuncDecl()` scans the declaration header (between the param-list close-paren and `$$`) for `RETURNS TRIGGER`; when present the entity is emitted as `Subtype="trigger_function"`.
- New `triggerRE` regex extracts `CREATE [CONSTRAINT] TRIGGER name … ON table … EXECUTE FUNCTION func`. Emits `Subtype="trigger"` with two typed edges: `FIRES → trigger_function` and `DEFINED_ON → table`.
- New helper `sliceFuncDecl()` to extract the CREATE-through-RETURNS region (before the dollar-quote body) for trigger-function detection.
- Updated package-level doc comment to enumerate all new entity subtypes and edges.

**`internal/extractors/python/raw_sql_db_calls.go`** (new)
- Regex pass over Python source that detects `<receiver>.execute("<SQL>")` strings.
- `CALL proc_name(…)` → emits `CALLS` edge from the enclosing Python function to `proc_name`.
- `SELECT … FROM view_name` → emits `READS_FROM` edge from the enclosing function to `view_name`.
- Indentation-aware `buildFuncLineMap()` helper associates each call site with its enclosing `def`.

**`internal/extractors/python/extractor.go`**
- One additional deferred call to `emitRawSQLDBCallEdges()` after the existing `emitReferences` pass.

## Test plan

- [ ] `go test ./internal/extractors/sql/... -run Test1414` — 13 new tests covering all MANIFEST §12 entities (E1–E7) and edges (R1–R6); all pass.
- [ ] `go test ./internal/extractors/python/... -run Test1414` — 4 new Python tests (CALLS via CALL, READS_FROM via SELECT, no-false-positive on DDL, consumer.py pattern); all pass.
- [ ] `go test ./internal/extractors/...` — zero regressions across the full extractor suite (all languages).

## MANIFEST §12 coverage verdict

| Object | Expected | Extracted | Status |
|--------|----------|-----------|--------|
| VIEW `order_summary` | SCOPE.Datastore/view | ✓ | PASS |
| PROCEDURE `mark_order_paid` | SCOPE.Datastore/procedure | ✓ | PASS |
| TRIGGER FUNCTION `log_order_status_change` | SCOPE.Datastore/trigger_function | ✓ | PASS |
| TRIGGER `trg_order_status_change` | SCOPE.Datastore/trigger | ✓ | PASS |
| TABLE `orders` | SCOPE.Datastore/table (regression) | ✓ | PASS |
| TABLE `order_status_audit` | SCOPE.Datastore/table | ✓ | PASS |
| TABLE `daily_revenue` | SCOPE.Datastore/table | ✓ | PASS |
| `order_summary` READS_FROM `orders` | edge | ✓ | PASS |
| `mark_order_paid` WRITES_TO `orders` | edge | ✓ | PASS |
| `mark_order_paid` WRITES_TO `daily_revenue` | edge | ✓ | PASS |
| `log_order_status_change` WRITES_TO `order_status_audit` | edge | ✓ | PASS |
| `trg_order_status_change` FIRES `log_order_status_change` | edge | ✓ | PASS |
| `trg_order_status_change` DEFINED_ON `orders` | edge | ✓ | PASS |
| Python `mark_order_paid` fn CALLS proc | edge | ✓ | PASS |
| Python `get_user_summary` fn READS_FROM view | edge | ✓ | PASS |

All §12 objects and edges extracted. 0 objects/edges still missing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)