### PR TITLE
fix(links): harden cross-repo HTTP path normalization + framework coverage report (#1409)

### DIFF
--- a/cmd/archigraph/main.go
+++ b/cmd/archigraph/main.go
@@ -15,6 +15,11 @@ import (
 // long-running daemon mode (plus the per-group linker, which both the
 // daemon and `archigraph rebuild` need).
 func main() {
+	// Hidden verification harness for issue #1409 (not part of the public
+	// command surface; intercepted before cobra dispatch).
+	if len(os.Args) >= 2 && os.Args[1] == "xrepo-verify" {
+		os.Exit(runXRepoVerify(os.Args[2:]))
+	}
 	cli.Execute(cli.Hooks{
 		RunDaemon:    runDaemon,
 		RunLinks:     runLinksHook,

--- a/cmd/archigraph/xrepo_verify.go
+++ b/cmd/archigraph/xrepo_verify.go
@@ -1,0 +1,253 @@
+package main
+
+// xrepo_verify.go — isolated verification harness for issue #1409.
+//
+// Indexes a set of repos with THIS binary into a temp graphs dir, runs the
+// cross-repo link passes, and reports HTTP route↔fetch link counts plus a
+// framework endpoint/call extraction coverage table. Never touches the live
+// daemon or ~/.archigraph state (uses an isolated temp ARCHIGRAPH_HOME).
+//
+// Not part of the public command surface; invoked only during verification:
+//
+//	archigraph xrepo-verify <group> <slug>=<path> [<slug>=<path> ...]
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/links"
+)
+
+func runXRepoVerify(args []string) int {
+	if len(args) < 3 {
+		fmt.Fprintln(os.Stderr, "usage: archigraph xrepo-verify <group> <slug>=<path> [<slug>=<path> ...]")
+		return 2
+	}
+	group := args[0]
+	repos := args[1:]
+
+	tmpGraphs, err := os.MkdirTemp("", "ag-xrepo-graphs-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mktemp:", err)
+		return 1
+	}
+	tmpHome, err := os.MkdirTemp("", "ag-xrepo-home-")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "mktemp:", err)
+		return 1
+	}
+	fmt.Printf("graphs dir: %s\nhome dir:   %s\n", tmpGraphs, tmpHome)
+
+	for _, spec := range repos {
+		i := strings.IndexByte(spec, '=')
+		if i < 0 {
+			fmt.Fprintln(os.Stderr, "bad spec (need slug=path):", spec)
+			return 2
+		}
+		slug := spec[:i]
+		path := spec[i+1:]
+		out := filepath.Join(tmpGraphs, slug, "graph.json")
+		if err := os.MkdirAll(filepath.Dir(out), 0o755); err != nil {
+			fmt.Fprintln(os.Stderr, "mkdir:", err)
+			return 1
+		}
+		fmt.Printf("indexing %-22s %s\n", slug, path)
+		if err := Index(path, out, slug, nil, false, false, WithExportJSON(true)); err != nil {
+			fmt.Fprintf(os.Stderr, "index %s: %v\n", slug, err)
+			return 1
+		}
+	}
+
+	res, err := links.RunAllPasses(group, tmpGraphs, tmpHome)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "link passes:", err)
+		return 1
+	}
+
+	// Read back links.json and count HTTP route↔fetch cross-repo links.
+	linksPath := res.OutLinks
+	httpLinks, repoPairs := countHTTPLinks(linksPath)
+	fmt.Println("\n=== CROSS-REPO HTTP ROUTE↔FETCH LINKS ===")
+	fmt.Printf("total http-method links: %d\n", httpLinks)
+	pairs := make([]string, 0, len(repoPairs))
+	for p, n := range repoPairs {
+		pairs = append(pairs, fmt.Sprintf("  %s : %d", p, n))
+	}
+	sort.Strings(pairs)
+	for _, p := range pairs {
+		fmt.Println(p)
+	}
+
+	// Collect the set of link Source endpoints ("repo::entityID") so that
+	// orphans = consumer synthetics whose caller/stamped entity never
+	// appears as the source of an emitted cross-repo HTTP link.
+	linkedSources := linkSourceSet(linksPath)
+
+	// Framework coverage diagnosis + orphan count.
+	coverage, prodTotal, consTotal, orphanConsumers := analyzeCoverage(tmpGraphs, linkedSources)
+	fmt.Println("\n=== ENDPOINT/CALL EXTRACTION COVERAGE (by framework) ===")
+	fmt.Printf("%-22s %12s %12s\n", "framework", "endpoints", "calls")
+	fwks := make([]string, 0, len(coverage))
+	for f := range coverage {
+		fwks = append(fwks, f)
+	}
+	sort.Strings(fwks)
+	for _, f := range fwks {
+		c := coverage[f]
+		fmt.Printf("%-22s %12d %12d\n", f, c.endpoints, c.calls)
+	}
+	fmt.Printf("\nproducer-side endpoint synthetics (total): %d\n", prodTotal)
+	fmt.Printf("consumer-side call synthetics (total):     %d\n", consTotal)
+	fmt.Printf("orphan consumer calls (no cross-repo link): %d\n", orphanConsumers)
+
+	return 0
+}
+
+type fwkCov struct {
+	endpoints int
+	calls     int
+}
+
+func countHTTPLinks(linksPath string) (int, map[string]int) {
+	pairs := map[string]int{}
+	b, err := os.ReadFile(linksPath)
+	if err != nil {
+		return 0, pairs
+	}
+	var doc struct {
+		Links []struct {
+			Source string `json:"source"`
+			Target string `json:"target"`
+			Method string `json:"method"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return 0, pairs
+	}
+	n := 0
+	for _, l := range doc.Links {
+		if l.Method != "http" {
+			continue
+		}
+		n++
+		sr := repoOf(l.Source)
+		tr := repoOf(l.Target)
+		pairs[sr+"→"+tr]++
+	}
+	return n, pairs
+}
+
+// linkSourceSet returns the set of "repo::entityID" source endpoints across
+// all method=http links.
+func linkSourceSet(linksPath string) map[string]bool {
+	out := map[string]bool{}
+	b, err := os.ReadFile(linksPath)
+	if err != nil {
+		return out
+	}
+	var doc struct {
+		Links []struct {
+			Source string `json:"source"`
+			Method string `json:"method"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		return out
+	}
+	for _, l := range doc.Links {
+		if l.Method == "http" {
+			out[l.Source] = true
+		}
+	}
+	return out
+}
+
+func repoOf(endpoint string) string {
+	if i := strings.Index(endpoint, "::"); i >= 0 {
+		return endpoint[:i]
+	}
+	return endpoint
+}
+
+// analyzeCoverage walks each repo's graph.json and counts http_endpoint
+// synthetics by framework + side, plus a rough orphan-consumer estimate.
+func analyzeCoverage(graphsDir string, linkedSources map[string]bool) (map[string]fwkCov, int, int, int) {
+	cov := map[string]fwkCov{}
+	prodTotal, consTotal := 0, 0
+	orphans := 0
+
+	_ = filepath.WalkDir(graphsDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Base(p) != "graph.json" {
+			return nil
+		}
+		doc, err := graph.LoadGraphFromDir(filepath.Dir(p))
+		if err != nil {
+			return nil
+		}
+		repo := doc.Repo
+		if repo == "" {
+			repo = filepath.Base(filepath.Dir(p))
+		}
+		// Index entities by (kind,name,file) so source_caller refs resolve.
+		type entKey struct{ kind, name, file string }
+		entIDByKey := map[entKey]string{}
+		for _, e := range doc.Entities {
+			if isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			k := entKey{e.Kind, e.Name, e.SourceFile}
+			if _, ok := entIDByKey[k]; !ok {
+				entIDByKey[k] = e.ID
+			}
+		}
+		for _, e := range doc.Entities {
+			if !isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			fw := e.Properties["framework"]
+			if fw == "" {
+				fw = "(unknown)"
+			}
+			pt := e.Properties["pattern_type"]
+			c := cov[fw]
+			switch pt {
+			case "http_endpoint_client_synthesis":
+				c.calls++
+				consTotal++
+				// Resolve caller entity ID (source_caller → same-file entity),
+				// else fall back to the synthetic's own stamped ID — matching
+				// http_pass.go srcID resolution.
+				callerID := ""
+				if ref := e.Properties["source_caller"]; ref != "" {
+					if i := strings.IndexByte(ref, ':'); i > 0 {
+						kind, name := ref[:i], ref[i+1:]
+						callerID = entIDByKey[entKey{kind, name, e.SourceFile}]
+					}
+				}
+				if callerID == "" {
+					callerID = e.ID
+				}
+				if !linkedSources[repo+"::"+callerID] {
+					orphans++
+				}
+			default:
+				// http_endpoint_synthesis or missing → producer side.
+				c.endpoints++
+				prodTotal++
+			}
+			cov[fw] = c
+		}
+		return nil
+	})
+	return cov, prodTotal, consTotal, orphans
+}
+
+func isHTTPEndpointKind(kind string) bool {
+	k := strings.ToLower(kind)
+	return strings.Contains(k, "http_endpoint")
+}

--- a/docs/quality/xrepo-http-coverage-1409.md
+++ b/docs/quality/xrepo-http-coverage-1409.md
@@ -1,0 +1,105 @@
+# Cross-repo HTTP route↔fetch — framework coverage report (#1409)
+
+This report records the framework endpoint/call **extraction** coverage measured
+while fixing the cross-repo HTTP path-normalization bug (#1409). The cross-repo
+matcher in `internal/links/http_pass.go` can only link what the per-language
+extractors emit as `http_endpoint` synthetics; this report identifies which
+frameworks lack endpoint and/or call extraction so they can be filed as
+follow-up issues.
+
+## Method
+
+Each repo was indexed in isolation with a from-source binary into a temp graph
+location (no live daemon), then `RunAllPasses` was run and the resulting
+`http_endpoint` synthetics counted by `pattern_type`:
+
+- `http_endpoint_synthesis` / `*_router_expanded` / `urlconf_nested_include` /
+  `django_admin_synthetic` / `webhook_synthesis` → **producer** (endpoint)
+- `http_endpoint_client_synthesis` → **consumer** (call)
+
+Harness: `archigraph xrepo-verify <group> <slug>=<path>...` (hidden verification
+subcommand, `cmd/archigraph/xrepo_verify.go`).
+
+## ShipFast (polyglot-platform) — per-service extraction
+
+| Service | Language | Framework | endpoints | calls | Endpoint extraction | Call extraction |
+|---|---|---|---:|---:|---|---|
+| gateway | TS | **NestJS** | 0 | 0 | ❌ none | ❌ none |
+| orders | Python | FastAPI | 4 | 2 | ✅ | ✅ |
+| users-auth | Python | Django | 1 | 0 | ✅ | n/a |
+| catalog | TS | **Express** | 0 | 0 | ⚠️ synthesized then **dropped at resolve** | ❌ |
+| payments | TS | Express | 3 | 0 | ✅ | n/a |
+| shipping | Go | gin | 3 | 0 | ✅ | n/a |
+| pricing | Rust | **axum** | 0 | 0 | ❌ none | n/a |
+| billing | PHP | **Laravel** | 0 | 0 | ❌ none | n/a |
+| semantic-search | Python | FastAPI | 2 | 1 | ✅ | ✅ |
+| order-saga | Python | FastAPI | 1 | 0 | ✅ | n/a |
+| search-graphql | TS | **Apollo** | 0 | 0 | ❌ none (GraphQL, not REST) | ❌ |
+| notifications | Kotlin | **Spring Boot** | 0 | 0 | ❌ none | n/a |
+| web | TS | React (axios) | 0 | 3 | n/a | ✅ |
+| mobile | TS | React Native | 0 | 1 | n/a | ✅ |
+| admin | TS | React + Apollo | 0 | 0 | n/a | ⚠️ GraphQL client not extracted |
+| workers | Python | httpx client | 0 | 2 | n/a | ✅ |
+
+## Coverage diagnosis (the 6 frameworks in scope)
+
+| Framework | Endpoint extraction | Call extraction | Verdict |
+|---|---|---|---|
+| **FastAPI** | ✅ extracted | ✅ extracted (httpx/http_client) | covered |
+| **gin** | ✅ extracted | n/a in fixture | endpoint covered |
+| **Express** | ⚠️ inconsistent — works for some handler shapes (payments=3), **drops inline arrow-function handlers** (catalog: `synthetics=3 handler_resolved=0 handler_dropped=3`) | ✅ extracted (axios) | **bug: inline-handler resolve drop** |
+| **NestJS** | ❌ not extracted — `@Controller`/`@Get`/`@Post` decorators are not recognized | ❌ HTTP-service calls (`orders.post(...)`, axios instances) not emitted as client synthetics | **no extractor** |
+| **Laravel** | ❌ not extracted — `Route::get/post(...)` + `Route::prefix()->group()` in `routes/web.php` not recognized | n/a in fixture | **no extractor** |
+| **Apollo** | ❌ not extracted (GraphQL resolvers ≠ REST endpoints; out of HTTP route↔fetch scope) | ❌ GraphQL client queries not extracted | GraphQL is a separate model; track separately |
+
+## Diff vs MANIFEST §2 (~21 expected REST cross-service edges)
+
+MANIFEST §2 documents 21 REST HTTP cross-service edges (excluding the GraphQL
+`admin → search-graphql` row and the gRPC/WebSocket rows). The matcher currently
+links **3** of them:
+
+- `web → orders` (`POST /orders`)
+- `mobile → orders` (`GET /orders/{id}`)
+- `workers → shipping` (`POST /shipments`)
+
+The other ~18 are blocked **upstream of the matcher** by missing/buggy
+extraction — every edge whose producer is NestJS gateway, Laravel billing,
+axum pricing, Spring notifications, Apollo search-graphql, or whose Express
+producer dropped its inline handler (catalog) has nothing for the matcher to
+link to. The path-normalization fix in this PR does not change ShipFast's count
+because none of its gaps are normalization-driven.
+
+## Follow-up issues to file
+
+1. **NestJS endpoint + HTTP-client extraction** — `@Controller`/`@Get`/`@Post`
+   decorator routes and `HttpService`/axios-instance proxy calls.
+2. **Laravel route extraction** — `Route::verb()` and `Route::prefix()->group()`
+   in `routes/*.php`, mapped to controller methods.
+3. **Express inline-handler endpoint drop** — `app.get("/x", async (req,res)=>…)`
+   synthetics are dropped at the resolve stage when the handler is an inline
+   arrow function (`handler_dropped`, `no_handler_prop`); they should survive
+   with the synthetic as fallback handler (as the matcher already tolerates).
+4. **axum (Rust) endpoint extraction** — `Router::new().route("/x", get(handler))`.
+5. **Spring Boot (Kotlin) endpoint extraction** — `@RequestMapping`/`@GetMapping`.
+6. **GraphQL cross-repo linking** (Apollo) — separate model from HTTP
+   route↔fetch; track as its own epic.
+7. **upvate producer-side route gap** — the residual upvate orphans (~157) are
+   dominated by DRF custom `@action` routes / nested sub-routers (e.g.
+   `/groups/companies`, `/sync-logs`, `/note-types`) that the DRF router
+   expansion does not emit as endpoints. Not a normalization problem.
+
+## Path-normalization fix (this PR) — measured impact
+
+| Group | links before | links after | orphan calls before | orphan calls after |
+|---|---:|---:|---:|---:|
+| upvate | 215 | 221 | 163 | 157 |
+| shipfast | 3 | 3 | 6 | 6 |
+
+The fix hardens the matcher's `byPath` index normalization (case-fold, trailing
+slash, `<int:id>` angle-bracket params) and adds a **property-free** generic
+`/api`, `/api/vN`, `/vN` prefix strip on both producer and consumer sides,
+complementing the `url_prefix`-driven strip from #819 (which only fires when the
+producer carries a `url_prefix` property). The bulk of upvate's prefix mismatch
+(`/inspections/{id}` ↔ `/api/v1/inspections/{pk}`) was already reclaimed by
+#819; the generic strip closes the remaining cases where `url_prefix` is absent
+(hand-written routers, `urlconf_nested_include`).

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -68,23 +68,76 @@ import (
 // pathParamRe matches any path-parameter placeholder regardless of origin:
 //   - {pk}, {id}, {param}, {userId}, {branchId}, etc.  (curly-brace style)
 //   - :id, :pk, :userId, etc.                           (Express/Rails colon style)
+//   - <int:id>, <slug>, <uuid:pk>, etc.                 (Django/Flask angle style)
 //
 // All of these are replaced with the canonical token {*} for byPath index
 // lookup only — the original canonicalPath is preserved on the hit object.
-var pathParamRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*`)
+//
+// Producer synthetics are normally canonicalised to {name} form before they
+// reach this pass, but consumer-side synthetics (and a few producer paths that
+// skip canonicalisation) can still arrive with raw `:id` / `<int:id>` shapes;
+// matching all three styles here makes the byPath index resilient regardless
+// of which synthesizer emitted the hit.
+var pathParamRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*|<[^>]+>`)
+
+// apiPrefixRe matches a leading API/version prefix on a path so the byPath
+// index can register a prefix-stripped alias. This complements the
+// url_prefix-driven strip (#819): many producers (urlconf_nested_include,
+// hand-written routers) and consumers carry an `/api`, `/api/v1`, or bare
+// `/v2` prefix WITHOUT a populated url_prefix property, so a property-free
+// generic strip is needed to bucket `/api/v1/inspections/{*}` together with a
+// consumer's `/inspections/{*}`.
+//
+// Only the FIRST segment group is stripped and only the well-known `api` /
+// version forms — we never strip an arbitrary first segment, which would
+// collapse genuinely-distinct routes. Go's RE2 has no lookahead, so the
+// pattern requires either a following `/` (kept out of the match via the
+// trailing optional segment) or end-of-string; stripAPIPrefix anchors on the
+// match end and re-adds the leading slash.
+var apiPrefixRe = regexp.MustCompile(`^/(?:api(?:/v\d+)?|v\d+)(/|$)`)
 
 // normalizePathForIndex canonicalizes all path-parameter placeholders to
-// the uniform token {*} so that route shapes from different extractors can
-// be compared without caring about parameter names.
+// the uniform token {*}, lower-cases the result, and strips a trailing slash
+// so that route shapes from different extractors can be compared without
+// caring about parameter names, case, or trailing-slash convention.
 //
 // Examples:
 //
 //	/users/{pk}             → /users/{*}
 //	/users/:id              → /users/{*}
+//	/users/<int:id>         → /users/{*}
+//	/Users/{userId}/        → /users/{*}
 //	/users/{userId}/posts/{postId} → /users/{*}/posts/{*}
-//	/api/v1/static          → /api/v1/static  (unchanged)
+//	/api/v1/static          → /api/v1/static  (prefix handled separately)
 func normalizePathForIndex(path string) string {
-	return pathParamRe.ReplaceAllString(path, "{*}")
+	path = pathParamRe.ReplaceAllString(path, "{*}")
+	path = strings.ToLower(path)
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+	return path
+}
+
+// stripAPIPrefix removes a leading `/api`, `/api/vN`, or `/vN` segment from an
+// already-index-normalized path. Returns ("", false) when no such prefix is
+// present so callers can avoid registering a duplicate alias. The returned
+// path always keeps a leading slash.
+func stripAPIPrefix(normalizedPath string) (string, bool) {
+	m := apiPrefixRe.FindStringSubmatchIndex(normalizedPath)
+	if m == nil {
+		return "", false
+	}
+	// Group 1 (m[2]:m[3]) captured the boundary `/` or "". Strip everything up
+	// to the start of group 1 so a trailing `/` boundary is preserved as the
+	// new leading slash.
+	stripped := normalizedPath[m[2]:]
+	if stripped == "" {
+		stripped = "/"
+	}
+	return stripped, stripped != normalizedPath
 }
 
 // MethodHTTP identifies this pass's emissions in links.json.
@@ -319,6 +372,18 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 						byPath[strippedKey] = append(byPath[strippedKey], h)
 					}
 				}
+
+				// #1409 — property-free generic API/version prefix strip.
+				// Many producers (urlconf_nested_include, hand-written
+				// routers, Express/gin Routers) and consumers carry an
+				// `/api`, `/api/vN`, or bare `/vN` prefix WITHOUT a populated
+				// url_prefix property; register a stripped alias so the two
+				// sides bucket together regardless. Registering this on BOTH
+				// sides means a `/api/v1/x` producer and a `/api/x` consumer
+				// both also appear under `/x`.
+				if genericKey, ok := stripAPIPrefix(key); ok {
+					byPath[genericKey] = append(byPath[genericKey], h)
+				}
 			}
 		}
 	}
@@ -345,18 +410,29 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 		// path. The wildcarded counterpart contributes producer /
 		// consumer hits keyed by ITS own repo set.
 		if verb, p, ok := parseHTTPName(name); ok {
-			for _, h := range byPath[normalizePathForIndex(p)] {
-				if h.name == name {
-					continue
-				}
-				hVerb, _, _ := parseHTTPName(h.name)
-				if !verbsCompatible(verb, hVerb) {
-					continue
-				}
-				if h.side == sideProducer {
-					producers = appendUnique(producers, h)
-				} else if h.side == sideConsumer {
-					consumers = appendUnique(consumers, h)
+			// Probe the byPath index under the normalized path AND its
+			// generic API/version-stripped form (#1409), so a name carrying
+			// `/api/v1/...` finds the `/...` bucket and vice versa. The
+			// stripped alias was registered on both sides during index build.
+			normKey := normalizePathForIndex(p)
+			probeKeys := []string{normKey}
+			if strippedKey, sok := stripAPIPrefix(normKey); sok {
+				probeKeys = append(probeKeys, strippedKey)
+			}
+			for _, pk := range probeKeys {
+				for _, h := range byPath[pk] {
+					if h.name == name {
+						continue
+					}
+					hVerb, _, _ := parseHTTPName(h.name)
+					if !verbsCompatible(verb, hVerb) {
+						continue
+					}
+					if h.side == sideProducer {
+						producers = appendUnique(producers, h)
+					} else if h.side == sideConsumer {
+						consumers = appendUnique(consumers, h)
+					}
 				}
 			}
 		}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -297,12 +297,115 @@ func TestHTTPPass_NormalizePathForIndex(t *testing.T) {
 		{"", ""},
 		// version numbers should NOT be collapsed — v1, v2 are literal
 		{"/api/v1/users/{pk}", "/api/v1/users/{*}"},
+		// #1409 — Django/Flask angle-bracket params collapse too.
+		{"/users/<int:id>", "/users/{*}"},
+		{"/users/<slug>", "/users/{*}"},
+		{"/users/<uuid:pk>/posts/<int:post_id>", "/users/{*}/posts/{*}"},
+		// #1409 — case-insensitive normalization.
+		{"/Users/{Id}", "/users/{*}"},
+		{"/API/V1/Users", "/api/v1/users"},
+		// #1409 — trailing slash stripped (Django convention).
+		{"/users/{pk}/", "/users/{*}"},
+		{"/contracts/", "/contracts"},
 	}
 	for _, c := range cases {
 		got := normalizePathForIndex(c.in)
 		if got != c.want {
 			t.Errorf("normalizePathForIndex(%q) = %q, want %q", c.in, got, c.want)
 		}
+	}
+}
+
+// TestStripAPIPrefix covers the property-free generic API/version prefix strip
+// added in #1409. Only well-known api/version segments are stripped; arbitrary
+// first segments and non-prefix paths are left alone.
+func TestStripAPIPrefix(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     string
+		stripped bool
+	}{
+		{"/api/v1/inspections/{*}", "/inspections/{*}", true},
+		{"/api/users", "/users", true},
+		{"/v2/x", "/x", true},
+		{"/v1", "/", true},
+		{"/api", "/", true},
+		{"/api/v1", "/", true},
+		// no false positives
+		{"/apixyz/foo", "", false},
+		{"/users/{*}", "", false},
+		{"/version/foo", "", false},
+		{"/", "", false},
+	}
+	for _, c := range cases {
+		got, ok := stripAPIPrefix(c.in)
+		if ok != c.stripped || (ok && got != c.want) {
+			t.Errorf("stripAPIPrefix(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.stripped)
+		}
+	}
+}
+
+// TestHTTPPass_GenericPrefixMatch verifies that a producer serving
+// `/api/v1/inspections/{pk}` links to a consumer calling `/inspections/{id}`
+// even when the producer carries NO url_prefix property — the concrete upvate
+// case from issue #1409 (#819 only handled the property-driven strip).
+func TestHTTPPass_GenericPrefixMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "InspectionView", "kind": "Controller", "source_file": "app/views.py"},
+			{
+				"id": "ep1", "name": "http:GET:/api/v1/inspections/{pk}", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/api/v1/inspections/{pk}",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+					// NOTE: deliberately NO url_prefix — exercises the generic strip.
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "getInspection", "kind": "Function", "source_file": "src/api.ts"},
+			{
+				"id": "ep2", "name": "http:GET:/inspections/{id}", "kind": "http_endpoint",
+				"source_file": "src/api.ts",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/inspections/{id}",
+					"framework":     "axios",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:getInspection",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g-generic-prefix", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g-generic-prefix-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected cross-repo link for /api/v1 prefix mismatch w/o url_prefix; got %+v", doc.Links)
 	}
 }
 


### PR DESCRIPTION
Addresses #1409 (normalization lands here; framework-coverage gaps reported separately as follow-up issues).

## 1. Problem
Cross-repo HTTP route↔fetch linking under-matched producer endpoints against consumer call URLs. upvate frontends call `/inspections/{id}` while the Django backend serves `/api/v1/inspections/{pk}`; ShipFast (22-repo polyglot fixture) linked only 3 of ~21 documented REST cross-service edges. Two distinct root causes: a path-normalization gap in the matcher, and upstream extraction gaps in several frameworks.

## 2. What changed (normalization — `internal/links/http_pass.go`)
The byPath index that buckets route shapes is now robust to cosmetic differences:
- `pathParamRe` also collapses Django/Flask angle-bracket params (`<int:id>`, `<slug>`) alongside `{pk}`/`:id`.
- `normalizePathForIndex` lower-cases + strips trailing slashes.
- New `stripAPIPrefix` registers a **property-free** generic alias stripping a leading `/api`, `/api/vN`, or bare `/vN` segment on **both** producer and consumer sides — complementing the `url_prefix`-driven strip from #819 (which only fired when the producer carried a `url_prefix` property). The wildcard pull-in probes both the normalized key and its stripped form. Only well-known api/version segments are stripped (`/apixyz/foo`, `/version/foo` untouched).

## 3. Coverage diagnosis (`docs/quality/xrepo-http-coverage-1409.md`)
Per-framework endpoint/call extraction on ShipFast:
- **Extracted:** FastAPI (endpoint+call), gin (endpoint), Express (endpoint — but drops inline arrow-function handlers, see catalog), axios/httpx clients.
- **NOT extracted:** NestJS (`@Controller`/`@Get`), Laravel (`Route::get`), axum (Rust), Spring Boot (Kotlin), Apollo/GraphQL.

Filed as follow-up issues rather than building new extractors in this PR.

## 4. Verification (isolated; live :47274 daemon untouched)
Indexed each repo from-source into a temp graph location via a hidden `xrepo-verify` harness, then ran the link pass:

| Group | links before | links after | orphan calls before | orphan calls after |
|---|---:|---:|---:|---:|
| upvate | 215 | 221 | 163 | 157 |
| shipfast | 3 | 3 | 6 | 6 |

ShipFast count is unchanged because every remaining edge is blocked by extraction (NestJS/Laravel/axum/Spring/Apollo/Express-inline-drop), not normalization. The bulk of upvate's `/inspections/{id}` ↔ `/api/v1/inspections/{pk}` mismatch was already reclaimed by #819; the generic strip closes the residual cases where `url_prefix` is absent. The remaining ~157 upvate orphans are DRF custom-action / nested-router producer endpoints not emitted by extraction (documented as follow-up #7).

## 5. Tests
- `TestHTTPPass_NormalizePathForIndex`: + angle-bracket / case / trailing-slash cases
- `TestStripAPIPrefix`: strip + no-false-positive coverage
- `TestHTTPPass_GenericPrefixMatch`: links `/api/v1/inspections/{pk}` ↔ `/inspections/{id}` with NO url_prefix property
- All `internal/links` + `httproutes` tests pass.

## 6. Notes
`cmd/archigraph/xrepo_verify.go` is a hidden verification-only subcommand (intercepted before cobra dispatch); not part of the public command surface. Did not rebuild/restart the live daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Addresses #1409.
