### PR TITLE
fix(coverage): TESTS edges missing + test-entity count inflated

### DIFF
--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -113,14 +113,38 @@ type ModuleCoverage struct {
 
 // coverageEntityKinds is the set of entity kinds that count as "production
 // entities" for coverage purposes.
+//
+// "SCOPE.Operation" is the canonical kind emitted by every language extractor
+// for functions and methods (Go, Python, JS/TS, Java, Rust, Ruby, …). The
+// bare "Function" / "Method" keys are kept for forward compatibility with any
+// third-party or future extractors that emit those kinds directly.
 var coverageEntityKinds = map[string]bool{
-	"Function":                   true,
-	"Method":                     true,
+	"SCOPE.Operation":            true, // canonical: all language extractors
+	"Function":                   true, // compat / future
+	"Method":                     true, // compat / future
 	"Class":                      true,
 	"Interface":                  true,
 	"Struct":                     true,
 	"http_endpoint":              true,
 	"http_endpoint_definition":   true,
+}
+
+// testEntityKinds is the set of entity kinds that count as "test entities"
+// for coverage purposes. Only callable kinds (SCOPE.Operation, Function,
+// Method) are counted — not every entity that happens to live in a test file
+// (imports, constants, class declarations, SCOPE.Pattern wrappers, etc.).
+//
+// The previous behaviour of counting every entity from a test file inflated
+// TotalTests because the Python / JS / Go extractors emit an entity per
+// symbol, so a 3-file test suite could report 500+ "test entities" when only
+// ~10 test functions exist (issue #1410).
+//
+// "SCOPE.Operation" is the canonical kind emitted by every language extractor;
+// the bare "Function" / "Method" keys are kept for forward compatibility.
+var testEntityKinds = map[string]bool{
+	"SCOPE.Operation": true, // canonical: all language extractors
+	"Function":        true, // compat / future
+	"Method":          true, // compat / future
 }
 
 // isTestFile returns true when the source file path matches a recognised test
@@ -175,9 +199,11 @@ func isProductionEntity(e *Entity) bool {
 	return coverageEntityKinds[e.Kind] && !isTestFile(e.SourceFile)
 }
 
-// isTestEntity returns true when e is a test entity.
+// isTestEntity returns true when e is a test entity.  Only Function and
+// Method entities inside test files are counted — not every symbol extracted
+// from a test file (see testEntityKinds for rationale).
 func isTestEntity(e *Entity) bool {
-	return isTestFile(e.SourceFile)
+	return isTestFile(e.SourceFile) && testEntityKinds[e.Kind]
 }
 
 // entitySeverity classifies the coverage importance of a production entity.
@@ -185,7 +211,7 @@ func entitySeverity(e *Entity) string {
 	switch e.Kind {
 	case "http_endpoint", "http_endpoint_definition":
 		return "high"
-	case "Function", "Method":
+	case "SCOPE.Operation", "Function", "Method":
 		// Exported (capitalised, not leading underscore) → medium.
 		if isExported(e.Name) {
 			return "medium"

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -308,3 +308,43 @@ func TestComputeCoverage_HTTPEndpointHighSeverity(t *testing.T) {
 		t.Errorf("HTTP endpoint severity want high, got %s", report.UncoveredEntities[0].Severity)
 	}
 }
+
+// TestComputeCoverage_TotalTestsCountsOnlyCallables verifies that TotalTests
+// counts only SCOPE.Operation / Function / Method entities from test files —
+// not every symbol that happens to live in a test file (imports, constants,
+// class declarations, SCOPE.Pattern wrapper entities, etc.).
+//
+// This exercises issue #1410 where 593 test entities were reported for ~3
+// test files because every Python / Go symbol was counted, including imports,
+// module-level constants, and testmap's SCOPE.Pattern wrapper records.
+func TestComputeCoverage_TotalTestsCountsOnlyCallables(t *testing.T) {
+	entities := []Entity{
+		// Test file — the actual test function emitted as SCOPE.Operation (counts).
+		{ID: "t1", Name: "test_create_order", Kind: "SCOPE.Operation", SourceFile: "tests/test_orders.py"},
+		// Test file — a helper class (must NOT count).
+		{ID: "t2", Name: "OrderTestHelper", Kind: "Class", SourceFile: "tests/test_orders.py"},
+		// Test file — a SCOPE.Component (file node, must NOT count).
+		{ID: "t3", Name: "tests/test_orders.py", Kind: "SCOPE.Component", SourceFile: "tests/test_orders.py"},
+		// Test file — a SCOPE.Pattern wrapper emitted by testmap (must NOT count).
+		{ID: "t4", Name: "test_create_order -> create_order", Kind: "SCOPE.Pattern",
+			SourceFile: "tests/test_orders.py",
+			Properties: map[string]string{"pattern_kind": "test_coverage"}},
+		// Production entity — SCOPE.Operation as emitted by Go/Python/JS extractors.
+		{ID: "p1", Name: "create_order", Kind: "SCOPE.Operation", SourceFile: "orders/service.py"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "t1", ToID: "p1", Kind: "TESTS"},
+	}
+	report := ComputeCoverage(makeDoc(entities, rels))
+	// Only the SCOPE.Operation from the test file (t1) counts as a test entity.
+	if report.TotalTests != 1 {
+		t.Errorf("TotalTests want 1 (only callable test entities), got %d", report.TotalTests)
+	}
+	// The production SCOPE.Operation is covered.
+	if report.TotalProduction != 1 {
+		t.Errorf("TotalProduction want 1 (SCOPE.Operation now in scope), got %d", report.TotalProduction)
+	}
+	if report.CoveredProduction != 1 {
+		t.Errorf("CoveredProduction want 1, got %d", report.CoveredProduction)
+	}
+}

--- a/internal/resolve/refs.go
+++ b/internal/resolve/refs.go
@@ -1333,21 +1333,46 @@ func (idx Index) lookupStructural(stub string) (id string, status int, handled b
 	// cross-language test→production extractor emits this 3-segment shape
 	// when the production file cannot be inferred (high/medium confidence
 	// calls inside a test body). The standard 6-segment structural-ref
-	// path can't match it. Try a QualifiedName lookup first; failing that
-	// hand off to isHeuristicScopeStub (Dynamic) via the parts-length
-	// guard below. The minority of these stubs whose qname is a unique
-	// graph entity (test bodies that reference symbols by full path —
-	// e.g. `requests.get` when only one entity has that qname) earn a
-	// resolution credit instead of being silently dropped to Dynamic.
+	// path can't match it.
+	//
+	// Resolution ladder (issue #1410):
+	//  1. byQualifiedName — resolves fully-qualified stubs like "pkg.Func".
+	//  2. byName — resolves bare names that are unique across the entire
+	//     graph (e.g. "create_order" when only one entity has that name).
+	//     This is the common case for same-package Python/Go calls.
+	//  3. nameKinds under "Function" / "Method" — a tighter probe when
+	//     byName is ambiguous across kinds but unique within the callable
+	//     family; avoids false-positive matches on same-name Classes.
+	// If all three fail the stub is left as Dynamic / Unmatched.
 	if strings.HasPrefix(stub, "scope:operation:?#") {
 		qname := stub[len("scope:operation:?#"):]
 		if qname != "" {
+			// Tier 1: fully-qualified name (e.g. "pkg.Func" or "module.func")
 			if qid, ok := idx.byQualifiedName[qname]; ok {
 				if qid == "" {
-					// QualifiedName collision — fall through to Dynamic.
-					return "", statusUnmatched, true
+					return "", statusUnmatched, true // collision
 				}
 				return qid, statusRewritten, true
+			}
+			// Tier 2: bare name unique across the whole graph
+			if qid, ok := idx.byName[qname]; ok && qid != "" {
+				return qid, statusRewritten, true
+			}
+			// Tier 3: unique within the callable (Function/Method) kind family
+			if bucket := idx.nameKinds[qname]; len(bucket) > 0 {
+				var hit string
+				for _, knd := range []string{"Function", "Method"} {
+					if id, ok := bucket[knd]; ok && id != "" {
+						if hit != "" && hit != id {
+							hit = "" // ambiguous across function/method
+							break
+						}
+						hit = id
+					}
+				}
+				if hit != "" {
+					return hit, statusRewritten, true
+				}
 			}
 		}
 		return "", statusUnmatched, true

--- a/internal/resolve/refs_test.go
+++ b/internal/resolve/refs_test.go
@@ -1532,6 +1532,66 @@ func TestReferences_TestmapUnknownProdFile_QnameRewrite(t *testing.T) {
 	}
 }
 
+// Issue #1410 — testmap "?" form resolves via byName when the qname is a
+// unique entity name across the whole graph (common for small Python services
+// where each domain function has a unique name).
+func TestReferences_TestmapUnknownProdFile_ByNameRewrite(t *testing.T) {
+	entities := []types.EntityRecord{{
+		ID:         "cccccccccccccccc",
+		Kind:       "Function",
+		Name:       "create_order",
+		SourceFile: "services/orders/orders.py",
+	}}
+	rels := []types.RelationshipRecord{{
+		FromID:     "0000000000000000",
+		ToID:       "scope:operation:?#create_order",
+		Kind:       "TESTS",
+		Properties: map[string]string{"language": "python"},
+	}}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "cccccccccccccccc" {
+		t.Fatalf("expected byName rewrite to cccccccccccccccc, ToID=%s", rels[0].ToID)
+	}
+	if stats.ToRewritten != 1 {
+		t.Fatalf("expected ToRewritten=1, got %+v", stats)
+	}
+}
+
+// Issue #1410 — testmap "?" form resolves via nameKinds[Function] when byName
+// is ambiguous across kinds (e.g. a Function and a Class share the name) but
+// the name is unique within the Function kind.
+func TestReferences_TestmapUnknownProdFile_NameKindsFunctionRewrite(t *testing.T) {
+	entities := []types.EntityRecord{
+		{
+			ID:         "dddddddddddddddd",
+			Kind:       "Function",
+			Name:       "process_payment",
+			SourceFile: "payments/service.py",
+		},
+		{
+			ID:         "eeeeeeeeeeeeeeee",
+			Kind:       "Class",
+			Name:       "process_payment",
+			SourceFile: "payments/model.py",
+		},
+	}
+	rels := []types.RelationshipRecord{{
+		FromID:     "0000000000000000",
+		ToID:       "scope:operation:?#process_payment",
+		Kind:       "TESTS",
+		Properties: map[string]string{"language": "python"},
+	}}
+	idx := BuildIndex(entities)
+	stats := References(rels, idx)
+	if rels[0].ToID != "dddddddddddddddd" {
+		t.Fatalf("expected nameKinds[Function] rewrite to dddddddddddddddd, ToID=%s", rels[0].ToID)
+	}
+	if stats.ToRewritten != 1 {
+		t.Fatalf("expected ToRewritten=1, got %+v", stats)
+	}
+}
+
 // Issue #432 — Python `from .compat import urlparse` reaches the resolver
 // as a bare ToID `.compat.urlparse` (the leading dot is preserved by the
 // extractor so the resolver sees the relative form). These are intra-package


### PR DESCRIPTION
## Problem

Two compounding bugs caused `archigraph_test_coverage` to report **0 TESTS edges / 0% test coverage** alongside **593 'test entities'** on upvate, even though ~3 real test files existed.

## Root Causes

### 1. `coverageEntityKinds` missing `SCOPE.Operation`
Every language extractor (Go, Python, JS/TS, Java, Rust, Ruby, …) emits functions as `SCOPE.Operation`. `coverageEntityKinds` only had bare `"Function"` / `"Method"` keys — kinds that no extractor actually emits. This caused `TotalProduction = 0` and `CoveragePct = 0%` universally, regardless of how many TESTS edges existed.

**Fix:** Added `"SCOPE.Operation"` to `coverageEntityKinds`, `testEntityKinds`, and `entitySeverity`. Kept legacy bare-name keys for forward compatibility.

### 2. `isTestEntity` counted every symbol from a test file
With `isTestEntity` returning `true` for any entity whose `SourceFile` matches a test-file pattern, all symbols (imports, constants, class bodies, SCOPE.Pattern wrappers from testmap) were counted as test entities. A 3-file Python test suite had 593 entities because each `from x import y` and each class-level constant produced an entity.

**Fix:** Restricted `isTestEntity` to callable kinds (`SCOPE.Operation`, `Function`, `Method`). Only entities that represent actual test functions contribute to `TotalTests`.

### 3. `scope:operation:?#<qname>` resolver only tried `byQualifiedName`
For high/medium confidence TESTS edges where the production file cannot be inferred, testmap emits `"scope:operation:?#<qname>"`. The resolver only tried `byQualifiedName`. Added two new tiers:
- **Tier 2:** `byName` — resolves bare names unique across the entire graph (common for small services)
- **Tier 3:** `nameKinds[Function/Method]` — resolves names unique within the callable kind family

## Verification

Tested on a ShipFast-style fixture (`services/orders/orders.py` + `tests/test_orders.py`, 3 test functions):

| Metric | Before | After |
|---|---|---|
| TotalTests | 7 (all symbols from test file) | 3 (test functions only) |
| TotalProduction | 0 (SCOPE.Operation not in scope) | 2 |
| TESTS edges | 0 | 3 |
| CoveragePct | 0% | 100% |

TESTS edges emitted:
- `test_create_order_success → create_order`
- `test_create_order_empty_items → create_order`
- `test_cancel_order → cancel_order`

## Changes

- `internal/graph/coverage.go` — `coverageEntityKinds`, `testEntityKinds`, `entitySeverity` updated
- `internal/graph/coverage_test.go` — `TestComputeCoverage_TotalTestsCountsOnlyCallables` added
- `internal/resolve/refs.go` — `?#<qname>` resolution extended with byName + nameKinds tiers
- `internal/resolve/refs_test.go` — 2 new tests for byName and nameKinds resolution paths

All tests pass: `internal/graph`, `internal/resolve`, `internal/extractors/cross/testmap` and the full extractor suite (50+ packages).

Fixes #1410

🤖 Generated with [Claude Code](https://claude.com/claude-code)