### PR TITLE
feat(php): Laravel HTTP endpoint extraction (#1419)

### DIFF
--- a/fixtures/sources/php/billing_client.php
+++ b/fixtures/sources/php/billing_client.php
@@ -1,0 +1,29 @@
+<?php
+
+use GuzzleHttp\Client;
+use Illuminate\Support\Facades\Http;
+
+class BillingService
+{
+    public function createOrder(array $data): array
+    {
+        $client = new Client();
+        $response = $client->post('http://orders-service/api/orders', ['json' => $data]);
+        return json_decode($response->getBody(), true);
+    }
+
+    public function sendNotification(string $userId, string $event): void
+    {
+        Http::post('http://notifications-service/api/notifications', [
+            'user_id' => $userId,
+            'event'   => $event,
+        ]);
+    }
+
+    public function getOrder(string $id): array
+    {
+        $client = new Client();
+        $response = $client->get('http://orders-service/api/orders/' . $id);
+        return json_decode($response->getBody(), true);
+    }
+}

--- a/fixtures/sources/php/billing_routes.php
+++ b/fixtures/sources/php/billing_routes.php
@@ -1,0 +1,14 @@
+<?php
+
+use App\Http\Controllers\InvoiceController;
+use App\Http\Controllers\SubscriptionController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/invoices', [InvoiceController::class, 'index']);
+Route::post('/invoices', [InvoiceController::class, 'store']);
+Route::get('/invoices/{id}', [InvoiceController::class, 'show']);
+Route::put('/invoices/{id}', [InvoiceController::class, 'update']);
+Route::delete('/invoices/{id}', [InvoiceController::class, 'destroy']);
+
+Route::resource('subscriptions', SubscriptionController::class);
+Route::apiResource('payments', PaymentController::class);

--- a/internal/engine/http_endpoint_php_producer.go
+++ b/internal/engine/http_endpoint_php_producer.go
@@ -1,0 +1,219 @@
+// http_endpoint_php_producer.go — Laravel route → http_endpoint_definition synthesis.
+//
+// Covers:
+//   - Route::get/post/put/patch/delete/options/any('/path', ...)
+//   - Route::resource('name', Controller::class) → 7 standard CRUD endpoints
+//   - Route::apiResource('name', Controller::class) → 5 API CRUD endpoints
+//     (excludes the two browser form routes /create and /{id}/edit)
+//
+// Handler extraction:
+//   - Array syntax:  [Controller::class, 'method']   → "Controller@method"
+//   - String syntax: 'ControllerName@method'         → "ControllerName@method"
+//   - Closure:       function($request){...}         → "" (no static handler ref)
+//
+// The canonical path uses httproutes.FrameworkExpress (Express-style {param})
+// because Laravel path parameters use the {param} syntax natively.
+//
+// Refs #1419.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// ---------------------------------------------------------------------------
+// Compiled regexps
+// ---------------------------------------------------------------------------
+
+// laravelVerbRouteRe matches:
+//
+//	Route::get('/path', [Controller::class, 'method'])
+//	Route::post('/path', 'ControllerName@method')
+//	Route::get('/path', function() { ... })
+//
+// Capture groups: 1=verb, 2=path (double-quoted), 3=path (single-quoted),
+// 4=controller class (array form), 5=method name (array form),
+// 6=controller@method string (single-quoted), 7=controller@method string (double-quoted).
+var laravelVerbRouteRe = regexp.MustCompile(
+	`(?m)Route::(get|post|put|patch|delete|options|any)\s*\(\s*` +
+		`(?:"([^"]{1,500})"|'([^']{1,500})')` + // path: groups 2, 3
+		`\s*,\s*` +
+		`(?:` +
+		`\[\s*([\w\\]+)::class\s*,\s*'(\w+)'\s*\]` + // array form: groups 4, 5
+		`|` +
+		`'([\w\\@]+)'` + // string @method form (single-quoted): group 6
+		`|` +
+		`"([\w\\@]+)"` + // double-quoted @method form: group 7
+		`)?`,
+)
+
+// laravelResourceRe matches:
+//
+//	Route::resource('name', Controller::class)
+//	Route::resource('name', 'ControllerName')
+//
+// Capture groups: 1=resource name.
+var laravelResourceRe = regexp.MustCompile(
+	`(?m)Route::resource\s*\(\s*['"]([^'"]{1,200})['"]`,
+)
+
+// laravelApiResourceRe matches:
+//
+//	Route::apiResource('name', Controller::class)
+//
+// Capture groups: 1=resource name.
+var laravelApiResourceRe = regexp.MustCompile(
+	`(?m)Route::apiResource\s*\(\s*['"]([^'"]{1,200})['"]`,
+)
+
+// ---------------------------------------------------------------------------
+// CRUD route tables
+// ---------------------------------------------------------------------------
+
+// laravelResourceRoutes are the 7 standard routes emitted by Route::resource.
+var laravelResourceRoutes = []struct{ method, suffix string }{
+	{"GET", ""},           // index
+	{"POST", ""},          // store
+	{"GET", "/create"},    // create (form)
+	{"GET", "/{id}"},      // show
+	{"GET", "/{id}/edit"}, // edit (form)
+	{"PUT", "/{id}"},      // update
+	{"DELETE", "/{id}"},   // destroy
+}
+
+// laravelApiResourceRoutes are the 5 routes emitted by Route::apiResource
+// (excludes /create and /{id}/edit — no form views in API mode).
+var laravelApiResourceRoutes = []struct{ method, suffix string }{
+	{"GET", ""},         // index
+	{"POST", ""},        // store
+	{"GET", "/{id}"},    // show
+	{"PUT", "/{id}"},    // update
+	{"DELETE", "/{id}"}, // destroy
+}
+
+// ---------------------------------------------------------------------------
+// Fast-path gate
+// ---------------------------------------------------------------------------
+
+func phpHasAnyLaravelRoute(content string) bool {
+	return strings.Contains(content, "Route::get") ||
+		strings.Contains(content, "Route::post") ||
+		strings.Contains(content, "Route::put") ||
+		strings.Contains(content, "Route::patch") ||
+		strings.Contains(content, "Route::delete") ||
+		strings.Contains(content, "Route::options") ||
+		strings.Contains(content, "Route::any") ||
+		strings.Contains(content, "Route::resource") ||
+		strings.Contains(content, "Route::apiResource")
+}
+
+// ---------------------------------------------------------------------------
+// Handler extraction helpers
+// ---------------------------------------------------------------------------
+
+// laravelHandlerFromMatch returns a "Controller@method" string from a regex
+// match of laravelVerbRouteRe. Returns "" when the handler is a closure or
+// cannot be statically determined.
+//
+// laravelVerbRouteRe capture groups (indices into FindAllStringSubmatchIndex output):
+//
+//	m[0..1]   = full match
+//	m[2..3]   = group 1 (verb)
+//	m[4..5]   = group 2 (path double-quoted)
+//	m[6..7]   = group 3 (path single-quoted)
+//	m[8..9]   = group 4 (controller class, array form)
+//	m[10..11] = group 5 (method name, array form)
+//	m[12..13] = group 6 (string @method, single-quoted)
+//	m[14..15] = group 7 (string @method, double-quoted)
+func laravelHandlerFromMatch(src string, m []int) string {
+	// Array form: [ControllerClass::class, 'method'] — groups 4+5.
+	if len(m) >= 12 && m[8] >= 0 && m[10] >= 0 {
+		cls := src[m[8]:m[9]]
+		// Strip leading namespace backslashes to get bare class name.
+		if i := strings.LastIndex(cls, "\\"); i >= 0 {
+			cls = cls[i+1:]
+		}
+		method := src[m[10]:m[11]]
+		return cls + "@" + method
+	}
+	// String form (single-quoted): 'Controller@method' — group 6.
+	if len(m) >= 14 && m[12] >= 0 {
+		return src[m[12]:m[13]]
+	}
+	// Double-quoted string form — group 7.
+	if len(m) >= 16 && m[14] >= 0 {
+		return src[m[14]:m[15]]
+	}
+	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Public entry point
+// ---------------------------------------------------------------------------
+
+// synthesizeLaravel scans a PHP source file for Laravel route registrations
+// and calls emit for each (verb, canonical-path, framework, handlerKind, handlerName)
+// tuple discovered. It is the producer-side counterpart to synthesizePHPClient.
+func synthesizeLaravel(content string, emit emitFn) {
+	if !phpHasAnyLaravelRoute(content) {
+		return
+	}
+
+	// --- Explicit verb routes: Route::get/post/... ---
+	for _, m := range laravelVerbRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+
+		// Extract raw path from double-quoted (group 2) or single-quoted (group 3).
+		raw := ""
+		if m[4] >= 0 {
+			raw = content[m[4]:m[5]]
+		} else if m[6] >= 0 {
+			raw = content[m[6]:m[7]]
+		}
+		if raw == "" {
+			continue
+		}
+
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
+		handler := laravelHandlerFromMatch(content, m)
+		handlerKind := "Controller"
+		if handler == "" {
+			handlerKind = ""
+		}
+		emit(verb, canonical, "laravel", handlerKind, handler)
+	}
+
+	// --- Route::resource → 7 CRUD endpoints ---
+	for _, m := range laravelResourceRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		base := "/" + strings.Trim(name, "/")
+		for _, r := range laravelResourceRoutes {
+			path := base + r.suffix
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			emit(r.method, canonical, "laravel_resource", "", "")
+		}
+	}
+
+	// --- Route::apiResource → 5 API CRUD endpoints ---
+	for _, m := range laravelApiResourceRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		base := "/" + strings.Trim(name, "/")
+		for _, r := range laravelApiResourceRoutes {
+			path := base + r.suffix
+			canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, path)
+			emit(r.method, canonical, "laravel_api_resource", "", "")
+		}
+	}
+}

--- a/internal/engine/http_endpoint_php_producer.go
+++ b/internal/engine/http_endpoint_php_producer.go
@@ -181,12 +181,17 @@ func synthesizeLaravel(content string, emit emitFn) {
 		}
 
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, raw)
-		handler := laravelHandlerFromMatch(content, m)
-		handlerKind := "Controller"
-		if handler == "" {
-			handlerKind = ""
-		}
-		emit(verb, canonical, "laravel", handlerKind, handler)
+		// Laravel routes are always in a separate file from their controller
+		// classes (PSR-4 autoloading). Emitting the controller reference as
+		// source_handler causes the resolve pass to drop the synthetic when
+		// the controller entity is not in the same file (which is the normal
+		// case for routes/*.php files). We pass empty handler so the
+		// synthetic gets NoHandlerProp treatment (kept unconditionally) and
+		// survives as an http_endpoint_definition for cross-repo linking.
+		// The controller reference is captured by laravelHandlerFromMatch but
+		// intentionally not forwarded here — it can be added as a plain
+		// property in a follow-up when the cross-file resolver supports it.
+		emit(verb, canonical, "laravel", "", "")
 	}
 
 	// --- Route::resource → 7 CRUD endpoints ---

--- a/internal/engine/http_endpoint_php_producer_test.go
+++ b/internal/engine/http_endpoint_php_producer_test.go
@@ -1,0 +1,266 @@
+package engine
+
+import (
+	"sort"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func collectLaravelSynthetics(content string) []string {
+	var ids []string
+	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
+		id := "http:" + method + ":" + canonicalPath
+		ids = append(ids, id)
+	}
+	synthesizeLaravel(content, emit)
+	sort.Strings(ids)
+	return ids
+}
+
+type laravelMatch struct {
+	method, path, framework, handlerKind, handlerName string
+}
+
+func collectLaravelMatches(content string) []laravelMatch {
+	var out []laravelMatch
+	emit := func(method, canonicalPath, framework, handlerKind, handlerName string) {
+		out = append(out, laravelMatch{method, canonicalPath, framework, handlerKind, handlerName})
+	}
+	synthesizeLaravel(content, emit)
+	return out
+}
+
+// ---------------------------------------------------------------------------
+// Fast-path gate: no Route:: → no output
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_EmptyFile(t *testing.T) {
+	ids := collectLaravelSynthetics("")
+	if len(ids) != 0 {
+		t.Errorf("expected 0 synthetics from empty file, got %v", ids)
+	}
+}
+
+func TestSynthLaravel_NoRoutes(t *testing.T) {
+	src := `<?php
+echo "hello world";
+$x = new Foo();
+`
+	ids := collectLaravelSynthetics(src)
+	if len(ids) != 0 {
+		t.Errorf("expected 0 synthetics, got %v", ids)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Explicit verb routes — array controller syntax
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_VerbRoutes_ArraySyntax(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Route;
+
+Route::get('/invoices', [InvoiceController::class, 'index']);
+Route::post('/invoices', [InvoiceController::class, 'store']);
+Route::get('/invoices/{id}', [InvoiceController::class, 'show']);
+Route::put('/invoices/{id}', [InvoiceController::class, 'update']);
+Route::delete('/invoices/{id}', [InvoiceController::class, 'destroy']);
+`
+	matches := collectLaravelMatches(src)
+	// Check count
+	if len(matches) != 5 {
+		t.Fatalf("expected 5 matches, got %d: %+v", len(matches), matches)
+	}
+	// Check one entry in detail
+	found := false
+	for _, m := range matches {
+		if m.method == "GET" && m.path == "/invoices" && m.framework == "laravel" &&
+			m.handlerKind == "Controller" && m.handlerName == "InvoiceController@index" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("missing GET /invoices → InvoiceController@index; got: %+v", matches)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Explicit verb routes — string @method syntax
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_VerbRoutes_StringSyntax(t *testing.T) {
+	src := `<?php
+Route::get('/users', 'UserController@index');
+Route::post('/users', 'UserController@store');
+`
+	matches := collectLaravelMatches(src)
+	if len(matches) != 2 {
+		t.Fatalf("expected 2, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].handlerName != "UserController@index" {
+		t.Errorf("handler=%q, want UserController@index", matches[0].handlerName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route::resource expansion
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_Resource(t *testing.T) {
+	src := `<?php
+Route::resource('subscriptions', SubscriptionController::class);
+`
+	ids := collectLaravelSynthetics(src)
+	// Route::resource emits 7 routes
+	if len(ids) != 7 {
+		t.Fatalf("expected 7 resource routes, got %d: %v", len(ids), ids)
+	}
+	want := []string{
+		"http:DELETE:/subscriptions/{id}",
+		"http:GET:/subscriptions",
+		"http:GET:/subscriptions/create",
+		"http:GET:/subscriptions/{id}",
+		"http:GET:/subscriptions/{id}/edit",
+		"http:POST:/subscriptions",
+		"http:PUT:/subscriptions/{id}",
+	}
+	for _, w := range want {
+		found := false
+		for _, id := range ids {
+			if id == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing %q in resource expansion; got: %v", w, ids)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route::apiResource expansion
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_ApiResource(t *testing.T) {
+	src := `<?php
+Route::apiResource('payments', PaymentController::class);
+`
+	ids := collectLaravelSynthetics(src)
+	// Route::apiResource emits 5 routes (no /create, no /{id}/edit)
+	if len(ids) != 5 {
+		t.Fatalf("expected 5 api-resource routes, got %d: %v", len(ids), ids)
+	}
+	// Ensure /create and /{id}/edit are NOT emitted
+	for _, id := range ids {
+		if id == "http:GET:/payments/create" || id == "http:GET:/payments/{id}/edit" {
+			t.Errorf("apiResource should NOT emit %q (that's resource-only)", id)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Path parameter normalisation
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_PathParamNormalization(t *testing.T) {
+	src := `<?php
+Route::get('/orders/{orderId}/items/{itemId}', [OrderController::class, 'show']);
+`
+	ids := collectLaravelSynthetics(src)
+	want := "http:GET:/orders/{orderId}/items/{itemId}"
+	found := false
+	for _, id := range ids {
+		if id == want {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("path param normalisation: missing %q; got: %v", want, ids)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Route::any → ANY verb
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_AnyVerb(t *testing.T) {
+	src := `<?php
+Route::any('/health', [HealthController::class, 'check']);
+`
+	matches := collectLaravelMatches(src)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].method != "ANY" {
+		t.Errorf("method=%q, want ANY", matches[0].method)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Closure handler → empty handler name
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_ClosureHandler(t *testing.T) {
+	src := `<?php
+Route::get('/ping', function() { return 'pong'; });
+`
+	matches := collectLaravelMatches(src)
+	if len(matches) != 1 {
+		t.Fatalf("expected 1 match, got %d: %+v", len(matches), matches)
+	}
+	if matches[0].handlerName != "" {
+		t.Errorf("closure handler should yield empty handler name, got %q", matches[0].handlerName)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full billing fixture
+// ---------------------------------------------------------------------------
+
+func TestSynthLaravel_BillingFixture(t *testing.T) {
+	src := `<?php
+use App\Http\Controllers\InvoiceController;
+use App\Http\Controllers\SubscriptionController;
+use Illuminate\Support\Facades\Route;
+
+Route::get('/invoices', [InvoiceController::class, 'index']);
+Route::post('/invoices', [InvoiceController::class, 'store']);
+Route::get('/invoices/{id}', [InvoiceController::class, 'show']);
+Route::put('/invoices/{id}', [InvoiceController::class, 'update']);
+Route::delete('/invoices/{id}', [InvoiceController::class, 'destroy']);
+
+Route::resource('subscriptions', SubscriptionController::class);
+Route::apiResource('payments', PaymentController::class);
+`
+	ids := collectLaravelSynthetics(src)
+	// 5 explicit + 7 resource + 5 apiResource = 17 (minus any dedup overlap)
+	// subscriptions and payments share no paths, so expect 17
+	if len(ids) < 17 {
+		t.Errorf("billing fixture: expected ≥17 synthetics, got %d: %v", len(ids), ids)
+	}
+	wantSample := []string{
+		"http:GET:/invoices",
+		"http:POST:/invoices",
+		"http:GET:/invoices/{id}",
+		"http:PUT:/invoices/{id}",
+		"http:DELETE:/invoices/{id}",
+		"http:GET:/subscriptions",
+		"http:GET:/payments",
+	}
+	for _, w := range wantSample {
+		found := false
+		for _, id := range ids {
+			if id == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("billing fixture: missing %q; got: %v", w, ids)
+		}
+	}
+}

--- a/internal/engine/http_endpoint_php_producer_test.go
+++ b/internal/engine/http_endpoint_php_producer_test.go
@@ -74,16 +74,18 @@ Route::delete('/invoices/{id}', [InvoiceController::class, 'destroy']);
 	if len(matches) != 5 {
 		t.Fatalf("expected 5 matches, got %d: %+v", len(matches), matches)
 	}
-	// Check one entry in detail
+	// Check one entry in detail — handler is intentionally empty so the
+	// resolve pass keeps the synthetic (NoHandlerProp path) even when the
+	// controller class lives in a different file (normal PSR-4 layout).
 	found := false
 	for _, m := range matches {
 		if m.method == "GET" && m.path == "/invoices" && m.framework == "laravel" &&
-			m.handlerKind == "Controller" && m.handlerName == "InvoiceController@index" {
+			m.handlerKind == "" && m.handlerName == "" {
 			found = true
 		}
 	}
 	if !found {
-		t.Errorf("missing GET /invoices → InvoiceController@index; got: %+v", matches)
+		t.Errorf("missing GET /invoices with empty handler; got: %+v", matches)
 	}
 }
 
@@ -100,8 +102,9 @@ Route::post('/users', 'UserController@store');
 	if len(matches) != 2 {
 		t.Fatalf("expected 2, got %d: %+v", len(matches), matches)
 	}
-	if matches[0].handlerName != "UserController@index" {
-		t.Errorf("handler=%q, want UserController@index", matches[0].handlerName)
+	// Handler is intentionally empty — controllers live in separate files.
+	if matches[0].handlerName != "" {
+		t.Errorf("handler=%q, want empty (PSR-4 cross-file convention)", matches[0].handlerName)
 	}
 }
 

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -96,7 +96,7 @@ func synthesisSupportsLanguage(lang string) bool {
 	// rules are compiled for them so the per-protocol synthesizers can
 	// run. Files in these languages that contain none of the recognised
 	// anchors are no-ops in the synthesizers themselves.
-	case "kotlin", "go", "csharp", "ruby":
+	case "kotlin", "go", "csharp", "ruby", "php":
 		return true
 	default:
 		return false
@@ -301,6 +301,8 @@ func applyHTTPEndpointSynthesis(
 		// Consumer side (#721 wave 2c): reqwest, hyper, ureq, surf.
 		synthesizeRustClientWithRuntime(string(content), emitClientRuntime)
 	case "php":
+		// Producer side (#1419): Laravel Route::verb/resource/apiResource.
+		synthesizeLaravel(string(content), emit)
 		// Consumer side (#721 wave 2c): Guzzle, Symfony HttpClient, cURL, file_get_contents,
 		// WordPress HTTP API, Laravel Http facade.
 		synthesizePHPClientWithRuntime(string(content), emitClientRuntime)

--- a/internal/extractors/cross/httpclient/extractor.go
+++ b/internal/extractors/cross/httpclient/extractor.go
@@ -100,6 +100,33 @@ var javaURICreateRE = regexp.MustCompile(
 	`(?m)\bURI\.create\s*\(\s*"([^"]{1,500})"`,
 )
 
+// PHP: Guzzle $client->METHOD('url') — double and single quoted
+var phpGuzzleVerbDoubleRE = regexp.MustCompile(
+	`(?im)\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*"([^"\n\r]{1,500})"`,
+)
+var phpGuzzleVerbSingleRE = regexp.MustCompile(
+	`(?im)\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*'([^'\n\r]{1,500})'`,
+)
+
+// PHP: Guzzle $client->request('METHOD', 'url') — verb/url quote combinations
+var phpGuzzleRequestDoubleRE = regexp.MustCompile(
+	`(?im)\$(?:client|http|guzzle|httpClient)\s*->\s*request\s*\(\s*"([A-Za-z]+)"\s*,\s*"([^"\n\r]{1,500})"`,
+)
+var phpGuzzleRequestSingleRE = regexp.MustCompile(
+	`(?im)\$(?:client|http|guzzle|httpClient)\s*->\s*request\s*\(\s*'([A-Za-z]+)'\s*,\s*'([^'\n\r]{1,500})'`,
+)
+var phpGuzzleRequestMixedRE = regexp.MustCompile(
+	`(?im)\$(?:client|http|guzzle|httpClient)\s*->\s*request\s*\(\s*'([A-Za-z]+)'\s*,\s*"([^"\n\r]{1,500})"`,
+)
+
+// PHP: Laravel Http::METHOD('url') facade
+var phpLaravelHttpDoubleRE = regexp.MustCompile(
+	`(?im)\bHttp\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*"([^"\n\r]{1,500})"`,
+)
+var phpLaravelHttpSingleRE = regexp.MustCompile(
+	`(?im)\bHttp\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*'([^'\n\r]{1,500})'`,
+)
+
 // ---------------------------------------------------------------------------
 // Language gate
 // ---------------------------------------------------------------------------
@@ -272,6 +299,48 @@ func extractJava(source string) []call {
 	return out
 }
 
+func extractPHP(source string) []call {
+	var out []call
+
+	for _, m := range phpGuzzleVerbDoubleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpGuzzleVerbSingleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpGuzzleRequestDoubleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpGuzzleRequestSingleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpGuzzleRequestMixedRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpLaravelHttpDoubleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+	for _, m := range phpLaravelHttpSingleRE.FindAllStringSubmatch(source, -1) {
+		if len(m) >= 3 {
+			out = append(out, call{url: m[2], method: strings.ToUpper(m[1])})
+		}
+	}
+
+	return out
+}
+
 // ---------------------------------------------------------------------------
 // All-language scan (when language is empty)
 // ---------------------------------------------------------------------------
@@ -282,6 +351,7 @@ func extractAll(source string) []call {
 	out = append(out, extractPython(source)...)
 	out = append(out, extractGo(source)...)
 	out = append(out, extractJava(source)...)
+	out = append(out, extractPHP(source)...)
 	return out
 }
 
@@ -380,6 +450,8 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		calls = extractGo(source)
 	case "java":
 		calls = extractJava(source)
+	case "php":
+		calls = extractPHP(source)
 	default:
 		// Empty language: evaluate all patterns (cross-language fallback).
 		calls = extractAll(source)

--- a/internal/extractors/cross/httpclient/extractor_test.go
+++ b/internal/extractors/cross/httpclient/extractor_test.go
@@ -388,3 +388,84 @@ requests.get("https://py.example.com/api")
 		t.Errorf("expected at least 2 API entities with empty language, got %d", len(apis))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PHP: Guzzle + Laravel Http facade
+// ---------------------------------------------------------------------------
+
+func TestPHP_GuzzleGet(t *testing.T) {
+	src := `<?php
+use GuzzleHttp\Client;
+function fetchOrders() {
+    $client = new Client();
+    return $client->get('http://orders-service/api/orders');
+}
+`
+	apis := apiEntities(runExtract(t, "php", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+	if apis[0].Name != "http://orders-service/api/orders" {
+		t.Errorf("url=%q", apis[0].Name)
+	}
+}
+
+func TestPHP_GuzzlePost(t *testing.T) {
+	src := `<?php
+use GuzzleHttp\Client;
+function createOrder($data) {
+    $client = new Client();
+    $response = $client->post('http://orders-service/api/orders', ['json' => $data]);
+    return $response;
+}
+`
+	apis := apiEntities(runExtract(t, "php", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+}
+
+func TestPHP_LaravelHttpFacade(t *testing.T) {
+	src := `<?php
+use Illuminate\Support\Facades\Http;
+function notify($userId) {
+    Http::post('http://notifications-service/api/notifications', ['user_id' => $userId]);
+}
+`
+	apis := apiEntities(runExtract(t, "php", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+	if apis[0].Name != "http://notifications-service/api/notifications" {
+		t.Errorf("url=%q", apis[0].Name)
+	}
+	rels := callRels(apis)
+	if len(rels) != 1 {
+		t.Errorf("expected 1 CALLS relationship, got %d", len(rels))
+	}
+}
+
+func TestPHP_GuzzleRequest(t *testing.T) {
+	src := `<?php
+use GuzzleHttp\Client;
+function patchOrder($id, $data) {
+    $client = new Client();
+    $client->request('PATCH', 'http://orders-service/api/orders/123', ['json' => $data]);
+}
+`
+	apis := apiEntities(runExtract(t, "php", src))
+	if len(apis) != 1 {
+		t.Fatalf("expected 1 API entity, got %d", len(apis))
+	}
+}
+
+func TestPHP_NoPHPNoResults(t *testing.T) {
+	// Go file that happens to contain "->get(" should not trigger PHP extraction.
+	// Language is "go", not "php" — PHP patterns should not fire.
+	src := `package main
+func main() { _ = "http://example.com" }
+`
+	apis := apiEntities(runExtract(t, "go", src))
+	// just verify no panic; Go extractor won't match $client->get
+	_ = apis
+}


### PR DESCRIPTION
## What

Adds producer-side `http_endpoint_definition` synthesis for Laravel routes (`Route::get/post/put/patch/delete/options/any`, `Route::resource`, `Route::apiResource`) and consumer-side PHP HTTP client extraction (Guzzle, Laravel `Http::` facade) to the `cross/httpclient` extractor.

## Why

Cross-repo HTTP linking (#1409) is coverage-bound: billing's Laravel routes emitted zero `http_endpoint_definition` synthetics before this PR, so the HTTP pass had nothing to match against outbound calls from other services. MANIFEST §2 documents 2 billing-originating cross-repo edges (billing→orders, billing→notifications) that were invisible to the linker.

## How

- **New `internal/engine/http_endpoint_php_producer.go`**: `synthesizeLaravel(content, emit)` — regex-based producer-side scanner covering `Route::verb()` (with array/string handler extraction), `Route::resource` (7 CRUD routes), and `Route::apiResource` (5 API routes). Routes emit with empty handler ref so the resolve pass takes the `NoHandlerProp` path (unconditionally kept) — necessary because Laravel route files always reference controllers in separate PSR-4 files, making same-file handler resolution impossible.
- **Wired** into `applyHTTPEndpointSynthesis` `case "php":` alongside the existing `synthesizePHPClientWithRuntime`. PHP added to `synthesisSupportsLanguage`.
- **New `extractPHP`** in `cross/httpclient/extractor.go`: Guzzle `$client->METHOD(url)`, `$client->request('VERB', url)`, and Laravel `Http::METHOD(url)`. Wired into the language switch and `extractAll`.

## Verification (isolated — never touches :47274)

Binary built from this branch (`go build -o /tmp/ag-laravel ./cmd/archigraph/`), indexed ShipFast billing + orders + notifications into isolated temp dir:

| Metric | Before | After |
|---|---:|---:|
| billing endpoint synthetics | 0 | 15 (10 laravel + 5 laravel_api_resource) |
| orders endpoint synthetics | 0 | 3 |
| notifications endpoint synthetics | 0 | 2 |
| billing→orders cross-repo links | 0 | **2** |
| billing→notifications cross-repo links | 0 | **1** |
| orphan consumer calls | 3 | **0** |
| handler_dropped | n/a | **0** (all synthetics survive) |

Worktree: `/Users/jorgecajas/Documents/Projects/archigraph-worktrees/cov-laravel`

## Tests

- 10 new `TestSynthLaravel_*` unit tests in `internal/engine/http_endpoint_php_producer_test.go`
- 5 new `TestPHP_*` tests in `internal/extractors/cross/httpclient/extractor_test.go`
- Full `internal/engine/...` and `internal/extractors/cross/httpclient/...` test suites pass with no regressions

Fixes #1419

🤖 Generated with [Claude Code](https://claude.com/claude-code)