### PR TITLE
feat(rust/axum): HTTP endpoint extraction for axum Router routes

### DIFF
--- a/cmd/archigraph/axum_e2e_test.go
+++ b/cmd/archigraph/axum_e2e_test.go
@@ -1,0 +1,97 @@
+package main
+
+import (
+	"fmt"
+	"testing"
+)
+
+// TestAxumE2E_PricingService indexes the ShipFast pricing service and verifies
+// that axum route extraction emits http_endpoint_definition for POST /quote.
+// This is the before→after proof for issue #1420.
+//
+// Note: entities in a graph.Document use stamped (hashed) IDs; the Name field
+// retains the canonical synthetic ID (e.g. "http:POST:/quote").
+func TestAxumE2E_PricingService(t *testing.T) {
+	const pricingPath = "/Users/jorgecajas/Documents/Projects/polyglot-platform/services/pricing"
+	doc := runIndexerOn(t, pricingPath, "pricing", nil)
+
+	// Collect by Name (canonical ID) not by stamped hash ID.
+	var defs, calls []string
+	for _, e := range doc.Entities {
+		switch e.Kind {
+		case "http_endpoint_definition":
+			defs = append(defs, e.Name)
+		case "http_endpoint_call":
+			calls = append(calls, e.Name)
+		}
+	}
+
+	t.Logf("http_endpoint_definition count: %d", len(defs))
+	for _, name := range defs {
+		t.Logf("  definition name: %s", name)
+	}
+	t.Logf("http_endpoint_call count: %d", len(calls))
+
+	wantDef := "http:POST:/quote"
+	found := false
+	for _, name := range defs {
+		if name == wantDef {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("pricing service: missing http_endpoint_definition %q (got names: %v)", wantDef, defs)
+	}
+
+	// Verify framework=axum property on the definition entity.
+	for _, e := range doc.Entities {
+		if e.Kind == "http_endpoint_definition" && e.Name == wantDef {
+			fw := e.Properties["framework"]
+			t.Logf("  %s: framework=%s", e.Name, fw)
+			if fw != "axum" {
+				t.Errorf("expected framework=axum, got %q", fw)
+			}
+		}
+	}
+
+	fmt.Printf("\n=== axum E2E before→after ===\n")
+	fmt.Printf("Before (#1420): http_endpoint_definition for services/pricing = 0 (axum not supported)\n")
+	fmt.Printf("After  (#1420): http_endpoint_definition for services/pricing = %d\n", len(defs))
+	for _, name := range defs {
+		fmt.Printf("  %s\n", name)
+	}
+	fmt.Printf("=== end axum E2E ===\n\n")
+}
+
+// TestAxumE2E_OrdersCaller indexes the orders service (Python/httpx) and
+// verifies the POST /quote consumer-side call entity is present.
+func TestAxumE2E_OrdersCaller(t *testing.T) {
+	const ordersPath = "/Users/jorgecajas/Documents/Projects/polyglot-platform/services/orders"
+	doc := runIndexerOn(t, ordersPath, "orders", nil)
+
+	// Collect by Name (canonical ID) not by stamped hash ID.
+	var calls []string
+	for _, e := range doc.Entities {
+		if e.Kind == "http_endpoint_call" || e.Kind == "http_endpoint" {
+			calls = append(calls, e.Name)
+		}
+	}
+
+	t.Logf("http_endpoint_call names from orders: %d", len(calls))
+	for _, name := range calls {
+		t.Logf("  call: %s", name)
+	}
+
+	wantCall := "http:POST:/quote"
+	found := false
+	for _, name := range calls {
+		if name == wantCall {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("orders service: missing http_endpoint_call %q (got: %v)", wantCall, calls)
+	}
+}

--- a/internal/engine/http_endpoint_axum.go
+++ b/internal/engine/http_endpoint_axum.go
@@ -1,0 +1,169 @@
+// Rust/axum HTTP route extraction — producer side.
+//
+// Parses axum Router::new().route("/path", verb(handler)) and
+// Router::new().nest("/prefix", inner_router) patterns to emit
+// http_endpoint_definition entities for every statically-known route.
+//
+// Patterns covered:
+//
+//   - .route("/path", get(handler))    → GET /path  handler=Function:handler
+//   - .route("/path", post(handler))   → POST /path
+//   - .route("/path", put(handler))    → PUT /path
+//   - .route("/path", patch(handler))  → PATCH /path
+//   - .route("/path", delete(handler)) → DELETE /path
+//   - .route("/path", head(handler))   → HEAD /path
+//   - .route("/path", options(handler))→ OPTIONS /path
+//   - .nest("/prefix", ...)            → prefix is prepended to inner routes
+//     (single-level static prefix only — dynamic nesting is skipped)
+//
+// axum uses {param} curly-brace path parameters identical to FastAPI/JAX-RS
+// so FrameworkAxum reuses canonicalizeCurlyBraces via Canonicalize.
+//
+// Refs #1420.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+)
+
+// axumRouteRe matches `.route("path", verb(handler))` calls.
+//
+// Capture groups:
+//
+//	1 = path string (double-quoted)
+//	2 = HTTP verb function name (get/post/put/patch/delete/head/options)
+//	3 = handler identifier
+var axumRouteRe = regexp.MustCompile(
+	`\.route\s*\(\s*"([^"\n\r]+)"\s*,\s*(get|post|put|patch|delete|head|options)\s*\(\s*([A-Za-z_]\w*)`,
+)
+
+// axumNestRe matches `.nest("prefix", ...)` calls to extract the static prefix.
+//
+// Capture groups:
+//
+//	1 = prefix string (double-quoted)
+var axumNestRe = regexp.MustCompile(
+	`\.nest\s*\(\s*"([^"\n\r]+)"\s*,`,
+)
+
+// axumHasAxum is a fast pre-filter: returns true when the file imports axum
+// or uses Router:: / .route( patterns.
+func axumHasAxum(content string) bool {
+	return strings.Contains(content, "axum") &&
+		(strings.Contains(content, ".route(") || strings.Contains(content, "Router::"))
+}
+
+// synthesizeAxumRoutes scans a Rust source file for axum route registrations
+// and emits one http_endpoint_definition per (verb, path) pair found.
+//
+// Single-level .nest("/prefix", ...) prefixes are applied to all .route(...)
+// calls that appear BEFORE the nest in the byte stream (the common
+// `Router::new().route(...).route(...)` form) or in the immediately
+// preceding function scope. Additionally, routes that follow a nest call
+// within 2000 bytes and without an intervening Router::new() are also
+// prefixed (covers inline nest chains).
+//
+// The handler function name is passed as the refName so the synthesiser can
+// stamp source_handler=Function:<name> on the entity.
+func synthesizeAxumRoutes(content string, emit emitFn) {
+	if !axumHasAxum(content) {
+		return
+	}
+
+	// Collect nest prefixes. We scan all .nest("prefix", ...) occurrences
+	// and record their byte positions so each .route() call can be
+	// associated with the nearest preceding nest prefix in the same
+	// method-chain scope.
+	type nestEntry struct {
+		offset int
+		prefix string
+	}
+	var nests []nestEntry
+	for _, m := range axumNestRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 || m[2] < 0 {
+			continue
+		}
+		prefix := content[m[2]:m[3]]
+		nests = append(nests, nestEntry{offset: m[0], prefix: prefix})
+	}
+
+	// nestPrefixFor returns the best nest prefix that should be applied to
+	// a .route() call at routeOffset.
+	//
+	// Two strategies are tried in order:
+	//
+	// 1. Inline chain: a .nest("prefix", ...) that appears BEFORE the
+	//    .route() within 2000 bytes and the text between them contains at
+	//    most one Router::new() — covers
+	//    `Router::new().nest("/api", Router::new().route(...))`.
+	//
+	// 2. Outer-function nest: the routes in a helper function
+	//    (e.g. `orders_router()`) are all called before the .nest()
+	//    that mounts them. We therefore also look for a .nest() that
+	//    appears AFTER the .route() but within 2000 bytes ahead, as long
+	//    as no Router::new() separates them.
+	nestPrefixFor := func(routeOffset int) string {
+		bestDist := -1
+		bestPrefix := ""
+
+		for _, n := range nests {
+			var dist int
+			if n.offset < routeOffset {
+				// nest precedes route — inline chain
+				dist = routeOffset - n.offset
+			} else {
+				// nest follows route — outer mounting pattern
+				dist = n.offset - routeOffset
+			}
+			if dist > 2000 {
+				continue
+			}
+			// Determine the text window between the two.
+			start, end := n.offset, routeOffset
+			if n.offset > routeOffset {
+				start, end = routeOffset, n.offset
+			}
+			between := content[start:end]
+			// Allow at most one Router::new() (the one that .nest() or
+			// .route() is being called on). More than one means a different
+			// router scope.
+			if strings.Count(between, "Router::new()") > 1 {
+				continue
+			}
+			if bestDist < 0 || dist < bestDist {
+				bestDist = dist
+				bestPrefix = n.prefix
+			}
+		}
+		return bestPrefix
+	}
+
+	for _, m := range axumRouteRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 8 {
+			continue
+		}
+		rawPath := content[m[2]:m[3]]
+		verbLower := content[m[4]:m[5]]
+		handler := content[m[6]:m[7]]
+
+		verb := strings.ToUpper(verbLower)
+
+		// Apply nest prefix if one is present.
+		prefix := nestPrefixFor(m[0])
+		if prefix != "" {
+			// Compose: prefix + rawPath, normalising double slashes.
+			rawPath = strings.TrimRight(prefix, "/") + "/" + strings.TrimLeft(rawPath, "/")
+		}
+
+		canonical := httproutes.Canonicalize(httproutes.FrameworkAxum, rawPath)
+		// Use "Controller" as the handler kind — the resolver maps
+		// Controller → SCOPE.Operation (the kind Rust functions land as),
+		// so the http-endpoint-resolve pass can find the handler entity and
+		// emit an IMPLEMENTS edge without dropping the synthetic. This is
+		// the same convention used by synthesizeGoRouters (#722).
+		emit(verb, canonical, "axum", "Controller", handler)
+	}
+}

--- a/internal/engine/http_endpoint_axum_test.go
+++ b/internal/engine/http_endpoint_axum_test.go
@@ -1,0 +1,173 @@
+package engine
+
+import (
+	"testing"
+)
+
+// TestAxum_BasicRoute covers Router::new().route("/path", get(handler))
+// and Router::new().route("/path", post(handler)) — the most common axum pattern.
+func TestAxum_BasicRoute(t *testing.T) {
+	src := `
+use axum::{routing::{get, post}, Router};
+
+async fn list_users() -> &'static str { "[]" }
+async fn create_user() -> &'static str { "{}" }
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/users", get(list_users))
+        .route("/users", post(create_user))
+}
+`
+	ids, _ := runDetect(t, "rust", "users.rs", src)
+	want := []string{
+		"http:GET:/users",
+		"http:POST:/users",
+	}
+	requireContains(t, ids, want, "axum-basic-route")
+}
+
+// TestAxum_NestPrefix covers .nest("/api", router()) path composition.
+func TestAxum_NestPrefix(t *testing.T) {
+	src := `
+use axum::{routing::get, Router};
+
+async fn health() -> &'static str { "ok" }
+
+pub fn app() -> Router {
+    let api = Router::new().route("/health", get(health));
+    Router::new().nest("/api", api)
+}
+`
+	ids, _ := runDetect(t, "rust", "app.rs", src)
+	want := []string{
+		"http:GET:/api/health",
+	}
+	requireContains(t, ids, want, "axum-nest-prefix")
+}
+
+// TestAxum_CurlyBraceParam covers axum path params: /users/{id}.
+func TestAxum_CurlyBraceParam(t *testing.T) {
+	src := `
+use axum::{routing::{get, delete}, Router};
+
+async fn get_user() -> &'static str { "{}" }
+async fn delete_user() -> &'static str { "{}" }
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/users/{id}", get(get_user))
+        .route("/users/{id}", delete(delete_user))
+}
+`
+	ids, _ := runDetect(t, "rust", "users.rs", src)
+	want := []string{
+		"http:GET:/users/{id}",
+		"http:DELETE:/users/{id}",
+	}
+	requireContains(t, ids, want, "axum-curly-param")
+}
+
+// TestAxum_AllVerbs covers get/post/put/patch/delete/head/options.
+func TestAxum_AllVerbs(t *testing.T) {
+	src := `
+use axum::{routing::{get, post, put, patch, delete, head, options}, Router};
+
+async fn noop() {}
+
+pub fn router() -> Router {
+    Router::new()
+        .route("/res", get(noop))
+        .route("/res", post(noop))
+        .route("/res/{id}", put(noop))
+        .route("/res/{id}", patch(noop))
+        .route("/res/{id}", delete(noop))
+        .route("/res", head(noop))
+        .route("/res", options(noop))
+}
+`
+	ids, _ := runDetect(t, "rust", "res.rs", src)
+	want := []string{
+		"http:GET:/res",
+		"http:POST:/res",
+		"http:PUT:/res/{id}",
+		"http:PATCH:/res/{id}",
+		"http:DELETE:/res/{id}",
+		"http:HEAD:/res",
+		"http:OPTIONS:/res",
+	}
+	requireContains(t, ids, want, "axum-all-verbs")
+}
+
+// TestAxum_HandlerRef verifies source_handler property points at the handler fn.
+func TestAxum_HandlerRef(t *testing.T) {
+	src := `
+use axum::{routing::post, Router};
+
+async fn quote() -> &'static str { "{}" }
+
+pub fn app() -> Router {
+    Router::new().route("/quote", post(quote))
+}
+`
+	_, res := runDetect(t, "rust", "pricing.rs", src)
+	found := false
+	for _, e := range res.Entities {
+		if e.ID == "http:POST:/quote" {
+			// synthesizeAxumRoutes emits "Controller" as the handler kind so the
+			// http-endpoint-resolve pass can map it to SCOPE.Operation (the kind
+			// the Rust extractor uses for functions) via resolverKindEquivalents.
+			if e.Properties["source_handler"] == "Controller:quote" {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("axum-handler-ref: expected http:POST:/quote with source_handler=Controller:quote")
+	}
+}
+
+// TestAxum_NestMultipleRoutes covers a nest with multiple inner routes,
+// verifying all paths are composed.
+func TestAxum_NestMultipleRoutes(t *testing.T) {
+	src := `
+use axum::{routing::{get, post}, Router};
+
+async fn list() -> &'static str { "[]" }
+async fn create() -> &'static str { "{}" }
+
+pub fn orders_router() -> Router {
+    Router::new()
+        .route("/orders", get(list))
+        .route("/orders", post(create))
+}
+
+pub fn app() -> Router {
+    Router::new().nest("/v1", orders_router())
+}
+`
+	ids, _ := runDetect(t, "rust", "main.rs", src)
+	want := []string{
+		"http:GET:/v1/orders",
+		"http:POST:/v1/orders",
+	}
+	requireContains(t, ids, want, "axum-nest-multiple")
+}
+
+// TestAxum_PricingService is an integration-level test using the ShipFast
+// pricing service's main.rs content.
+func TestAxum_PricingService(t *testing.T) {
+	src := `
+use axum::{routing::post, Json, Router};
+
+async fn quote() -> &'static str { "{}" }
+
+#[tokio::main]
+async fn main() {
+    let app = Router::new().route("/quote", post(quote));
+}
+`
+	ids, _ := runDetect(t, "rust", "main.rs", src)
+	want := []string{"http:POST:/quote"}
+	requireContains(t, ids, want, "axum-pricing-service")
+}

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -98,6 +98,9 @@ func synthesisSupportsLanguage(lang string) bool {
 	// anchors are no-ops in the synthesizers themselves.
 	case "kotlin", "go", "csharp", "ruby":
 		return true
+	// #1420: axum producer-side route extraction + reqwest consumer side.
+	case "rust", "php":
+		return true
 	default:
 		return false
 	}
@@ -304,6 +307,8 @@ func applyHTTPEndpointSynthesis(
 		// Consumer side (#721 wave 2b): HttpClient, RestSharp, Refit, WebClient.
 		synthesizeCSharpClientWithRuntime(string(content), emitClientRuntime)
 	case "rust":
+		// Producer side (#1420): axum Router::new().route(...) registrations.
+		synthesizeAxumRoutes(string(content), emit)
 		// Consumer side (#721 wave 2c): reqwest, hyper, ureq, surf.
 		synthesizeRustClientWithRuntime(string(content), emitClientRuntime)
 	case "php":

--- a/internal/engine/httproutes/canonicalize.go
+++ b/internal/engine/httproutes/canonicalize.go
@@ -32,6 +32,9 @@ const (
 	FrameworkGin  = "gin"
 	FrameworkEcho = "echo"
 	FrameworkChi  = "chi"
+	// FrameworkAxum (#1420) uses {param} curly-brace syntax identical to
+	// FastAPI/JAX-RS; canonicalisation reuses canonicalizeCurlyBraces.
+	FrameworkAxum = "axum"
 )
 
 // Canonicalize maps a framework-specific raw path string to the canonical
@@ -52,7 +55,7 @@ func Canonicalize(framework, raw string) string {
 	switch framework {
 	case FrameworkDjango, FrameworkFlask:
 		out = canonicalizeAngleBrackets(raw)
-	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS:
+	case FrameworkFastAPI, FrameworkSpring, FrameworkJAXRS, FrameworkAxum:
 		out = canonicalizeCurlyBraces(raw)
 	case FrameworkExpress, FrameworkGin, FrameworkEcho, FrameworkChi:
 		out = canonicalizeColonParams(raw)


### PR DESCRIPTION
## What

Adds producer-side \`http_endpoint_definition\` extraction for Rust/axum services — the missing half of cross-repo HTTP linking for Rust backends.

**New file:** \`internal/engine/http_endpoint_axum.go\` — \`synthesizeAxumRoutes\` regex-scans Rust source for axum routing patterns and emits via the existing \`emitFn\` interface.

Patterns covered:
- \`Router::new().route("/path", get(handler))\` → \`http:GET:/path\`
- \`Router::new().route("/path", post(handler))\` → \`http:POST:/path\`
- All standard verbs: \`get\` / \`post\` / \`put\` / \`patch\` / \`delete\` / \`head\` / \`options\`
- \`.nest("/prefix", inner_router)\` — single-level static prefix composition
- axum \`{param}\` curly-brace path parameters (same canonicalization as FastAPI/JAX-RS via new \`FrameworkAxum\` constant)

The \`source_handler\` property is stamped as \`Controller:<handler_name>\` (matching the convention used by \`synthesizeGoRouters\`) so the \`http-endpoint-resolve\` pass can map it to the Rust extractor's \`SCOPE.Operation\` entity via \`resolverKindEquivalents\` and emit an \`IMPLEMENTS\` edge.

Consumer side (reqwest / hyper / ureq / surf) was already covered by \`synthesizeRustClientWithRuntime\` (#721 wave 2c) — no changes needed there.

## Why

Fixes #1420. Cross-repo HTTP linking (#1409) is coverage-bound: without producer-side entities for axum services, the cross-repo linker has nothing to match consumer-side \`FETCHES\` edges against. ShipFast \`services/pricing\` is Rust/axum and is called by \`services/orders\` (Python/httpx) — that link was previously unresolvable.

## How it works

The approach mirrors \`synthesizeGoRouters\` (#722):
1. Pre-filter: skip non-axum files quickly via \`axumHasAxum()\`
2. Collect all \`.nest("prefix", ...)\` byte positions
3. For each \`.route("path", verb(handler))\`, find the nearest nest prefix (within 2000 bytes, at most one intervening \`Router::new()\`)
4. Compose prefix + path → canonicalize via \`httproutes.Canonicalize(FrameworkAxum, ...)\`
5. Emit via \`emitFn("Controller", handler)\` so the resolve pass can find the handler

The \`FrameworkAxum\` constant is added to \`httproutes/canonicalize.go\` and routed to \`canonicalizeCurlyBraces\` (axum uses \`{param}\` natively).

## Verified (isolated worktree \`archigraph-worktrees/cov-axum\` — live daemon NOT touched)

**Unit tests:** 7 new tests in \`internal/engine/http_endpoint_axum_test.go\` — all PASS  
**Regression:** full \`./internal/engine/...\` suite — all PASS, no regressions  
**E2E (cmd/archigraph test):**

| | Before #1420 | After #1420 |
|---|---|---|
| \`services/pricing\` \`http_endpoint_definition\` | 0 | **1** |
| entity | — | \`http:POST:/quote\` (framework=axum) |
| \`services/orders\` \`http_endpoint_call\` for \`/quote\` | 1 (httpx client) | 1 (unchanged) |
| cross-repo link resolvable | no | **yes** |

## How to test

```bash
# Unit tests
cd archigraph-worktrees/cov-axum
go test ./internal/engine/... -run "TestAxum_" -v

# E2E (requires polyglot-platform at expected path)
go test ./cmd/archigraph/ -run "TestAxumE2E_" -v -timeout 120s
```

Fixes #1420