### PR TITLE
feat(http): Kotlin Spring MVC endpoint extraction

### DIFF
--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -245,6 +245,15 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		ctx, file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Spring MVC AST pass for Kotlin: same prefix-composition logic as the
+	// Java pass above, but adapted for the Kotlin tree-sitter CST shape.
+	// Emits http_endpoint_definition entities directly (no intermediate Route
+	// layer) because there is no YAML rule layer for Kotlin Spring controllers.
+	// No-op for non-Kotlin files. Refs #1421.
+	entities, relationships = applySpringRouteCompositionKotlin(
+		ctx, file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// Django REST Framework AST pass: compose the parent `path("api/",
 	// include(<router>.urls))` prefix with each `<router>.register("name",
 	// ViewSet)` call into a single composed Route. The YAML rules above

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -297,6 +297,11 @@ func applyHTTPEndpointSynthesis(
 	case "kotlin":
 		// Consumer side (#721 wave 2a): Ktor, OkHttp-Kotlin, Retrofit-K.
 		synthesizeKotlinClientWithRuntime(string(content), emitClientRuntime)
+		// Consumer side (#1421): Spring RestTemplate / WebClient / FeignClient
+		// are commonly used in Kotlin Spring Boot services. The Java client
+		// synthesizer covers these patterns idiomatically since both JVM
+		// languages share the same Spring APIs.
+		synthesizeJavaClientWithRuntime(string(content), emitClientRuntime)
 	case "ruby":
 		// Consumer side (#721 wave 2b): Net::HTTP, Faraday, HTTParty, RestClient.
 		synthesizeRubyClientWithRuntime(string(content), emitClientRuntime)

--- a/internal/engine/spring_routes_kotlin.go
+++ b/internal/engine/spring_routes_kotlin.go
@@ -1,0 +1,425 @@
+// AST-driven Spring MVC route composition for Kotlin files.
+//
+// Mirrors spring_routes.go (Java) for Kotlin Spring Boot controllers.
+// Kotlin uses a different tree-sitter grammar from Java, so this is a
+// separate pass that understands Kotlin's annotation CST shape:
+//
+//   Marker annotation (no args):
+//     annotation → "@" + user_type → type_identifier
+//
+//   Annotation with args:
+//     annotation → "@" + constructor_invocation → user_type + value_arguments
+//       Positional: value_argument → string_literal
+//       Named:      value_argument → simple_identifier("value"|"path") + "=" + string_literal
+//       Method key: value_argument → simple_identifier("method") + "=" + collection_literal
+//         e.g. [RequestMethod.GET] — extract verb from the collection text.
+//
+// Class and method bodies follow the same composition rules as the Java pass:
+// the class-level @RequestMapping prefix composes with each method-level
+// @GetMapping/@PostMapping/... path to produce the canonical route.
+//
+// Producer-side: emits http_endpoint_definition entities + ROUTES_TO edges.
+// Refs #1421.
+package engine
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/engine/httproutes"
+	"github.com/cajasmota/archigraph/internal/treesitter"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// applySpringRouteCompositionKotlin runs the Kotlin Spring AST pass on a
+// Kotlin file. It is the Kotlin counterpart to applySpringRouteComposition
+// (spring_routes.go). It emits composed http_endpoint_definition entities
+// directly (not via an intermediate Route entity) because there is no YAML
+// rule layer for Kotlin Spring controllers.
+//
+// Returns new entities and relationships appended to the inputs.
+func applySpringRouteCompositionKotlin(
+	ctx context.Context,
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if lang != "kotlin" || len(content) == 0 {
+		return entities, relationships
+	}
+	if !bytesContainsAny(content, "@RestController", "@Controller") {
+		return entities, relationships
+	}
+
+	newEntities, newRels := extractKotlinSpringEndpoints(ctx, path, content)
+	entities = append(entities, newEntities...)
+	relationships = append(relationships, newRels...)
+	return entities, relationships
+}
+
+// extractKotlinSpringEndpoints parses the Kotlin source with tree-sitter and
+// walks all class_declaration nodes looking for Spring controllers. For each
+// controller it emits one http_endpoint_definition per handler method.
+func extractKotlinSpringEndpoints(ctx context.Context, path string, content []byte) ([]types.EntityRecord, []types.RelationshipRecord) {
+	factory := treesitter.NewParserFactory(nil)
+	pr, err := factory.Parse(ctx, content, "kotlin")
+	if err != nil || pr == nil || pr.Tree == nil {
+		return nil, nil
+	}
+
+	var entities []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seen := map[string]bool{}
+
+	root := pr.Tree.RootNode()
+	walkKotlinClasses(root, content, path, &entities, &rels, seen)
+	return entities, rels
+}
+
+// walkKotlinClasses does a depth-first walk looking for class_declaration nodes
+// and delegating to processKotlinSpringClass for each one.
+func walkKotlinClasses(
+	node *sitter.Node,
+	src []byte,
+	path string,
+	entities *[]types.EntityRecord,
+	rels *[]types.RelationshipRecord,
+	seen map[string]bool,
+) {
+	if node == nil {
+		return
+	}
+	if node.Type() == "class_declaration" {
+		processKotlinSpringClass(node, src, path, entities, rels, seen)
+		// recurse: nested classes may also be controllers
+	}
+	for i := 0; i < int(node.ChildCount()); i++ {
+		walkKotlinClasses(node.Child(i), src, path, entities, rels, seen)
+	}
+}
+
+// processKotlinSpringClass inspects a class_declaration. If the class is a
+// Spring controller (carries @RestController or @Controller) AND has a
+// class-level @RequestMapping, each function_declaration inside the class_body
+// that carries a verb annotation is emitted as an http_endpoint_definition.
+func processKotlinSpringClass(
+	class *sitter.Node,
+	src []byte,
+	path string,
+	entities *[]types.EntityRecord,
+	rels *[]types.RelationshipRecord,
+	seen map[string]bool,
+) {
+	classModifiers := kotlinClassModifiers(class)
+	isController := false
+	prefix := ""
+	hasClassMapping := false
+
+	for _, anno := range classModifiers {
+		name, arg := kotlinAnnotationNameAndPath(anno, src)
+		if controllerAnnotations[name] {
+			isController = true
+		}
+		if name == "RequestMapping" {
+			hasClassMapping = true
+			prefix = arg
+		}
+	}
+	if !isController || !hasClassMapping {
+		return
+	}
+
+	// Find the class_body child.
+	var body *sitter.Node
+	for i := 0; i < int(class.ChildCount()); i++ {
+		ch := class.Child(i)
+		if ch.Type() == "class_body" {
+			body = ch
+			break
+		}
+	}
+	if body == nil {
+		return
+	}
+
+	for i := 0; i < int(body.ChildCount()); i++ {
+		ch := body.Child(i)
+		if ch.Type() != "function_declaration" {
+			continue
+		}
+		// Extract function name from simple_identifier child.
+		methodName := ""
+		for j := 0; j < int(ch.ChildCount()); j++ {
+			gc := ch.Child(j)
+			if gc.Type() == "simple_identifier" {
+				methodName = nodeText(gc, src)
+				break
+			}
+		}
+		if methodName == "" {
+			continue
+		}
+
+		// Collect method-level annotations from the function's modifiers.
+		funcModifiers := kotlinClassModifiers(ch)
+		for _, anno := range funcModifiers {
+			aname, apath := kotlinAnnotationNameAndPath(anno, src)
+			if !verbAnnotations[aname] {
+				continue
+			}
+			verb := httpMethodForAnnotation(aname)
+			// For @RequestMapping on a method we also look for an explicit
+			// method key (method = [RequestMethod.GET]) to sharpen the verb.
+			if aname == "RequestMapping" {
+				if mv := kotlinRequestMappingMethod(anno, src); mv != "" {
+					verb = mv
+				}
+			}
+
+			composedPath := joinRoutePaths(prefix, apath)
+			canonical := httproutes.Canonicalize(httproutes.FrameworkSpring, composedPath)
+			if canonical == "" {
+				continue
+			}
+
+			id := httproutes.SyntheticID(verb, canonical)
+			if seen[id] {
+				continue
+			}
+			seen[id] = true
+
+			*entities = append(*entities, types.EntityRecord{
+				ID:       id,
+				Name:     id,
+				Kind:     httpEndpointDefinitionKind,
+				SourceFile: path,
+				Language: "kotlin",
+				Properties: map[string]string{
+					"verb":            verb,
+					"path":            canonical,
+					"framework":       "spring_mvc",
+					"pattern_type":    "ast_driven",
+					"source_handler":  fmt.Sprintf("Controller:%s", methodName),
+					"owning_backend":  deriveOwningBackend(path),
+				},
+				EnrichmentRequired: false,
+				EnrichmentStatus:   types.StatusPending,
+				QualityScore:       0.8,
+			})
+			*rels = append(*rels, types.RelationshipRecord{
+				FromID: id,
+				ToID:   fmt.Sprintf("Controller:%s", methodName),
+				Kind:   "ROUTES_TO",
+				Properties: map[string]string{
+					"framework":    "spring_mvc",
+					"pattern_type": "ast_driven",
+				},
+			})
+		}
+	}
+}
+
+// kotlinClassModifiers returns the annotation children from the modifiers node
+// of a class_declaration or function_declaration.
+func kotlinClassModifiers(node *sitter.Node) []*sitter.Node {
+	if node == nil {
+		return nil
+	}
+	var out []*sitter.Node
+	for i := 0; i < int(node.ChildCount()); i++ {
+		ch := node.Child(i)
+		if ch.Type() == "modifiers" {
+			for j := 0; j < int(ch.ChildCount()); j++ {
+				gc := ch.Child(j)
+				if gc.Type() == "annotation" {
+					out = append(out, gc)
+				}
+			}
+			break // only one modifiers child per declaration
+		}
+	}
+	return out
+}
+
+// kotlinAnnotationNameAndPath returns the annotation name and its first
+// path-like string literal argument (the positional first arg or the value
+// of the `value` or `path` named argument).
+//
+// Kotlin annotation CST shapes:
+//
+//	Marker:          annotation → "@" + user_type → type_identifier
+//	With args:       annotation → "@" + constructor_invocation → user_type + value_arguments
+//	  Positional:    value_argument → string_literal
+//	  Named value=:  value_argument → simple_identifier("value") + "=" + string_literal
+//	  Named path=:   value_argument → simple_identifier("path") + "=" + string_literal
+func kotlinAnnotationNameAndPath(anno *sitter.Node, src []byte) (string, string) {
+	if anno == nil || anno.Type() != "annotation" {
+		return "", ""
+	}
+
+	name := ""
+	path := ""
+
+	for i := 0; i < int(anno.ChildCount()); i++ {
+		ch := anno.Child(i)
+		switch ch.Type() {
+		case "user_type":
+			// Marker annotation: @RestController, @GetMapping (no args).
+			name = kotlinUserTypeName(ch, src)
+
+		case "constructor_invocation":
+			// Annotation with args: @RequestMapping("/prefix") or @GetMapping(value="/x").
+			// First child of constructor_invocation is the user_type (name).
+			for j := 0; j < int(ch.ChildCount()); j++ {
+				gc := ch.Child(j)
+				switch gc.Type() {
+				case "user_type":
+					name = kotlinUserTypeName(gc, src)
+				case "value_arguments":
+					path = kotlinExtractPathFromValueArgs(gc, src)
+				}
+			}
+		}
+	}
+
+	// Strip package qualifier if present (e.g. "annotation.GetMapping").
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		name = name[idx+1:]
+	}
+	return name, path
+}
+
+// kotlinUserTypeName returns the type_identifier text from a user_type node,
+// handling optional package qualification (the last type_identifier segment).
+func kotlinUserTypeName(userType *sitter.Node, src []byte) string {
+	if userType == nil {
+		return ""
+	}
+	// user_type may have multiple type_reference children separated by dots.
+	// We want the last type_identifier.
+	var last string
+	for i := 0; i < int(userType.ChildCount()); i++ {
+		ch := userType.Child(i)
+		if ch.Type() == "type_identifier" {
+			last = nodeText(ch, src)
+		}
+	}
+	return last
+}
+
+// kotlinExtractPathFromValueArgs extracts the path/value string literal from
+// a value_arguments node. Supports:
+//   - positional: value_argument → string_literal
+//   - named value=: value_argument → simple_identifier("value") + "=" + string_literal
+//   - named path=: value_argument → simple_identifier("path") + "=" + string_literal
+func kotlinExtractPathFromValueArgs(args *sitter.Node, src []byte) string {
+	if args == nil {
+		return ""
+	}
+	var positional, byKey string
+	for i := 0; i < int(args.ChildCount()); i++ {
+		va := args.Child(i)
+		if va.Type() != "value_argument" {
+			continue
+		}
+		// Inspect children of value_argument.
+		key := ""
+		var strLit *sitter.Node
+		for j := 0; j < int(va.ChildCount()); j++ {
+			vc := va.Child(j)
+			switch vc.Type() {
+			case "simple_identifier":
+				// This is a named arg key only when followed by "=" — i.e. key comes
+				// before any string_literal. Capture the last identifier before "=".
+				key = nodeText(vc, src)
+			case "string_literal":
+				strLit = vc
+			}
+		}
+		if strLit == nil {
+			continue
+		}
+		val := stripKotlinStringLiteral(nodeText(strLit, src))
+		if key == "" {
+			// Positional argument.
+			if positional == "" {
+				positional = val
+			}
+		} else if key == "value" || key == "path" {
+			// Named value= or path= argument.
+			byKey = val
+		}
+	}
+	if byKey != "" {
+		return byKey
+	}
+	return positional
+}
+
+// kotlinRequestMappingMethod extracts the HTTP verb from a @RequestMapping
+// annotation's `method = [RequestMethod.GET]` (or similar) argument.
+// Returns an empty string when the argument is absent (caller keeps "ANY").
+func kotlinRequestMappingMethod(anno *sitter.Node, src []byte) string {
+	if anno == nil {
+		return ""
+	}
+	// Navigate: annotation → constructor_invocation → value_arguments → value_argument with key "method"
+	for i := 0; i < int(anno.ChildCount()); i++ {
+		ci := anno.Child(i)
+		if ci.Type() != "constructor_invocation" {
+			continue
+		}
+		for j := 0; j < int(ci.ChildCount()); j++ {
+			gc := ci.Child(j)
+			if gc.Type() != "value_arguments" {
+				continue
+			}
+			for k := 0; k < int(gc.ChildCount()); k++ {
+				va := gc.Child(k)
+				if va.Type() != "value_argument" {
+					continue
+				}
+				key := ""
+				for l := 0; l < int(va.ChildCount()); l++ {
+					vc := va.Child(l)
+					if vc.Type() == "simple_identifier" {
+						key = nodeText(vc, src)
+					}
+					if key == "method" && (vc.Type() == "collection_literal" || vc.Type() == "string_literal") {
+						raw := nodeText(vc, src)
+						return extractMethodFromCollectionLiteral(raw)
+					}
+				}
+			}
+		}
+	}
+	return ""
+}
+
+// extractMethodFromCollectionLiteral extracts the HTTP verb from a Kotlin
+// collection_literal like `[RequestMethod.GET]` or `[RequestMethod.POST]`.
+// Returns the verb in uppercase or "" when none is recognized.
+func extractMethodFromCollectionLiteral(raw string) string {
+	verbs := []string{"GET", "POST", "PUT", "DELETE", "PATCH", "HEAD", "OPTIONS"}
+	upper := strings.ToUpper(raw)
+	for _, v := range verbs {
+		if strings.Contains(upper, v) {
+			return v
+		}
+	}
+	return ""
+}
+
+// stripKotlinStringLiteral removes surrounding double quotes from a Kotlin
+// string literal token. Falls back to returning the input unchanged.
+func stripKotlinStringLiteral(s string) string {
+	if len(s) >= 2 && s[0] == '"' && s[len(s)-1] == '"' {
+		return s[1 : len(s)-1]
+	}
+	return s
+}

--- a/internal/engine/spring_routes_kotlin_test.go
+++ b/internal/engine/spring_routes_kotlin_test.go
@@ -1,0 +1,273 @@
+// Tests for Spring MVC route composition in Kotlin files.
+//
+// Refs #1421.
+package engine
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// sampleKotlinSpringController mirrors the Java fixture in spring_routes_test.go.
+const sampleKotlinSpringController = `package io.shipfast.notifications
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/api")
+class OrderController {
+
+    @GetMapping("/orders")
+    fun listOrders(): List<Order> = emptyList()
+
+    @PostMapping("/orders")
+    fun createOrder(@RequestBody o: Order): Order = o
+
+    @PutMapping("/orders/{id}")
+    fun updateOrder(@PathVariable id: Long, @RequestBody o: Order): Order = o
+
+    @DeleteMapping("/orders/{id}")
+    fun deleteOrder(@PathVariable id: Long) {}
+
+    @PatchMapping("/orders/{id}")
+    fun patchOrder(@PathVariable id: Long): Order? = null
+
+    @RequestMapping(value = "/legacy", method = [RequestMethod.GET])
+    fun legacy(): String = "ok"
+}
+`
+
+// sampleKotlinControllerNoClassPrefix exercises the case where the class has
+// NO class-level @RequestMapping. Each method carries its own full path.
+// The pass must NOT emit endpoints for this class (no class mapping → pass skips).
+const sampleKotlinControllerNoClassPrefix = `package io.shipfast.example
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+class NoClassPrefixController {
+
+    @GetMapping("/health")
+    fun health(): String = "ok"
+}
+`
+
+// sampleKotlinControllerWithOutboundCalls exercises RestTemplate / WebClient
+// outbound HTTP client calls emitted as http_endpoint_call entities.
+const sampleKotlinControllerWithOutboundCalls = `package io.shipfast.svc
+
+import org.springframework.web.bind.annotation.*
+import org.springframework.web.client.RestTemplate
+import org.springframework.web.reactive.function.client.WebClient
+
+@RestController
+@RequestMapping("/notifications")
+class NotificationsController(
+    private val restTemplate: RestTemplate,
+    private val webClient: WebClient,
+) {
+    @PostMapping("/email")
+    fun sendEmail(@RequestBody req: Map<String, Any>): Map<String, Boolean> {
+        restTemplate.getForObject("/api/users", String::class.java)
+        return mapOf("sent" to true)
+    }
+}
+`
+
+// TestKotlinSpring_ComposedEndpoints verifies that the Kotlin Spring pass
+// emits http_endpoint_definition entities with composed paths, correct verbs,
+// and ROUTES_TO edges.
+func TestKotlinSpring_ComposedEndpoints(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "services/notifications/src/main/kotlin/io/shipfast/OrderController.kt",
+		Content:  []byte(sampleKotlinSpringController),
+		Language: "kotlin",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+
+	// Collect all http_endpoint_definition IDs.
+	defIDs := map[string]bool{}
+	for _, e := range result.Entities {
+		if e.Kind == httpEndpointDefinitionKind {
+			defIDs[e.ID] = true
+		}
+	}
+
+	wantIDs := []string{
+		"http:GET:/api/orders",
+		"http:POST:/api/orders",
+		"http:PUT:/api/orders/{id}",
+		"http:DELETE:/api/orders/{id}",
+		"http:PATCH:/api/orders/{id}",
+		"http:GET:/api/legacy",
+	}
+	for _, id := range wantIDs {
+		if !defIDs[id] {
+			t.Errorf("missing http_endpoint_definition %q; got: %v", id, keyList(defIDs))
+		}
+	}
+
+	// Verify ROUTES_TO edges exist.
+	type rel struct{ from, to string }
+	wantRels := map[rel]bool{
+		{"http:GET:/api/orders", "Controller:listOrders"}:       false,
+		{"http:POST:/api/orders", "Controller:createOrder"}:     false,
+		{"http:PUT:/api/orders/{id}", "Controller:updateOrder"}: false,
+		{"http:DELETE:/api/orders/{id}", "Controller:deleteOrder"}: false,
+		{"http:PATCH:/api/orders/{id}", "Controller:patchOrder"}: false,
+		{"http:GET:/api/legacy", "Controller:legacy"}:           false,
+	}
+	for _, r := range result.Relationships {
+		if r.Kind != "ROUTES_TO" {
+			continue
+		}
+		key := rel{r.FromID, r.ToID}
+		if _, ok := wantRels[key]; ok {
+			wantRels[key] = true
+		}
+	}
+	for k, seen := range wantRels {
+		if !seen {
+			t.Errorf("expected ROUTES_TO %s -> %s not found", k.from, k.to)
+		}
+	}
+
+	// Verify properties on emitted entities.
+	for _, e := range result.Entities {
+		if e.Kind != httpEndpointDefinitionKind {
+			continue
+		}
+		if e.Language != "kotlin" {
+			t.Errorf("entity %q: Language=%q, want kotlin", e.ID, e.Language)
+		}
+		if e.Properties["pattern_type"] != "ast_driven" {
+			t.Errorf("entity %q: pattern_type=%q, want ast_driven", e.ID, e.Properties["pattern_type"])
+		}
+		if e.Properties["framework"] != "spring_mvc" {
+			t.Errorf("entity %q: framework=%q, want spring_mvc", e.ID, e.Properties["framework"])
+		}
+	}
+}
+
+// TestKotlinSpring_NoClassPrefix verifies that controllers without a class-level
+// @RequestMapping are not processed by the AST pass (the pass requires a class
+// prefix to compose). The ShipFast notifications controller pattern always has
+// a class-level mapping, but a plain @RestController without one must not panic.
+func TestKotlinSpring_NoClassPrefix(t *testing.T) {
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+	result, err := det.Detect(context.Background(), extractor.FileInput{
+		Path:     "src/main/kotlin/NoClassPrefixController.kt",
+		Content:  []byte(sampleKotlinControllerNoClassPrefix),
+		Language: "kotlin",
+	})
+	if err != nil {
+		t.Fatalf("Detect: %v", err)
+	}
+	// The AST pass requires a class-level @RequestMapping, so no endpoints
+	// from our pass. (Other synthesizers may not emit either, but we only
+	// assert that the AST pass does not panic or emit garbage.)
+	for _, e := range result.Entities {
+		if e.Kind == httpEndpointDefinitionKind && e.Properties["pattern_type"] == "ast_driven" {
+			t.Errorf("unexpected ast_driven endpoint %q for no-class-prefix controller", e.ID)
+		}
+	}
+}
+
+// TestKotlinSpring_ShipFastNotifications directly exercises the ShipFast
+// notifications EmailController and DispatchController fixtures.
+func TestKotlinSpring_ShipFastNotifications(t *testing.T) {
+	emailController := `package io.shipfast.notifications
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/notifications")
+class EmailController {
+
+    @PostMapping("/email")
+    fun sendEmail(@RequestBody req: Map<String, Any>): Map<String, Boolean> {
+        return mapOf("sent" to true)
+    }
+}
+`
+	dispatchController := `package io.shipfast.notifications
+
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/notifications")
+class DispatchController {
+
+    @PostMapping("/dispatch")
+    fun dispatch(@RequestBody req: Map<String, Any>): Map<String, Boolean> {
+        return mapOf("sent" to true)
+    }
+}
+`
+	rules, err := LoadAllRules()
+	if err != nil {
+		t.Fatalf("LoadAllRules: %v", err)
+	}
+	det := New(rules)
+
+	for _, tc := range []struct {
+		name    string
+		src     string
+		wantIDs []string
+	}{
+		{
+			name:    "EmailController",
+			src:     emailController,
+			wantIDs: []string{"http:POST:/notifications/email"},
+		},
+		{
+			name:    "DispatchController",
+			src:     dispatchController,
+			wantIDs: []string{"http:POST:/notifications/dispatch"},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			result, err := det.Detect(context.Background(), extractor.FileInput{
+				Path:     "services/notifications/src/main/kotlin/io/shipfast/notifications/" + tc.name + ".kt",
+				Content:  []byte(tc.src),
+				Language: "kotlin",
+			})
+			if err != nil {
+				t.Fatalf("Detect: %v", err)
+			}
+			defIDs := map[string]bool{}
+			for _, e := range result.Entities {
+				if e.Kind == httpEndpointDefinitionKind {
+					defIDs[e.ID] = true
+				}
+			}
+			for _, id := range tc.wantIDs {
+				if !defIDs[id] {
+					t.Errorf("missing %q (got: %v)", id, keyList(defIDs))
+				}
+			}
+		})
+	}
+}
+
+// keyList returns the keys of a bool map as a slice for error messages.
+func keyList(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	return keys
+}


### PR DESCRIPTION
## What

Add AST-driven `http_endpoint_definition` extraction for Kotlin Spring Boot controllers. A new pass (`spring_routes_kotlin.go`) mirrors the existing Java Spring route composition pass but understands the Kotlin tree-sitter CST shape. Also wires `synthesizeJavaClientWithRuntime` into the Kotlin synthesis path for outbound Spring client calls.

Fixes #1421.

## Why

Cross-repo HTTP link coverage (#1409) is blocked on extracting server-side endpoints from every framework. ShipFast `services/notifications` is Kotlin/Spring Boot — without this pass its controllers emit no `http_endpoint_definition` entities and no cross-repo links can be established to them.

## How

- `internal/engine/spring_routes_kotlin.go` (new): walks `class_declaration` nodes in the Kotlin CST. For each `@RestController`/`@Controller` class that carries a class-level `@RequestMapping`, it composes the prefix with each method-level verb annotation (`@GetMapping`, `@PostMapping`, `@PutMapping`, `@DeleteMapping`, `@PatchMapping`, `@RequestMapping(method=[…])`) and emits:
  - `http_endpoint_definition` entity with canonical `http:VERB:/path` ID, `framework=spring_mvc`, `pattern_type=ast_driven`, `source_handler=Controller:methodName`
  - `ROUTES_TO` relationship from the endpoint to the handler
- `internal/engine/detector.go`: calls `applySpringRouteCompositionKotlin` after the Java Spring pass
- `internal/engine/http_endpoint_synthesis.go`: adds `synthesizeJavaClientWithRuntime` to the `case "kotlin":` block for RestTemplate/WebClient/FeignClient outbound call detection

## Verification

**Before:** 0 `http_endpoint_definition` entities for Kotlin Spring controllers in ShipFast `services/notifications`

**After (unit tests):**
- `http:POST:/notifications/email` (EmailController)
- `http:POST:/notifications/dispatch` (DispatchController)
- Full verb matrix verified: `GET`, `POST`, `PUT`, `DELETE`, `PATCH` on composed paths
- No panic/garbage for controllers without class-level `@RequestMapping`

All 3 new tests pass (`TestKotlinSpring_ComposedEndpoints`, `TestKotlinSpring_NoClassPrefix`, `TestKotlinSpring_ShipFastNotifications`). Full engine test suite green.

**Note:** `archigraph index` is a daemon RPC client (ADR-0017). The live daemon at :47274 was NOT touched per instructions.

## Test plan

- [ ] `go test ./internal/engine/ -run TestKotlinSpring` — all 3 subtests pass
- [ ] `go test ./internal/engine/` — full suite green (no regressions)
- [ ] Verify 2 new endpoints appear in ShipFast notifications after daemon rebuild (post-merge step)

## Impact

- +2 `http_endpoint_definition` entities per Kotlin Spring Boot controller (EmailController + DispatchController in notifications service)
- Enables cross-repo HTTP link resolution from any caller that references `POST /notifications/email` or `POST /notifications/dispatch`
- Zero change to Java extraction, Python, JS/TS paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)