### PR TITLE
links: add P6 gRPC + P7 message-topic cross-repo passes (Fixes #1447)

### DIFF
--- a/internal/links/grpc_pass.go
+++ b/internal/links/grpc_pass.go
@@ -1,0 +1,255 @@
+package links
+
+// grpc_pass.go implements the cross-repo gRPC client-stub → server-impl
+// matcher (P6).
+//
+// Design
+// ------
+// The engine pass (internal/engine/grpc_edges.go, #725) emits for every
+// gRPC service discovered in a repo:
+//
+//	Entity{Kind: "SCOPE.GrpcMethod", Name: "grpc:ServiceName/MethodName"}
+//
+// This entity has the SAME Name on both the client side (emitted when the
+// pass sees a stub call) and the server side (emitted when the pass sees a
+// service registration). However, the on-disk entity ID is distinct per repo
+// because graph.EntityID hashes the repo tag in.
+//
+// P6 joins by .Name across repos, finds the GRPC_HANDLES edge (client →
+// GrpcMethod) to resolve the caller entity ID, and finds the
+// GRPC_IMPLEMENTS edge (handler → GrpcMethod) to resolve the handler entity
+// ID. It emits:
+//
+//	relation   = "calls"
+//	method     = "grpc"
+//	channel    = "grpc"
+//	identifier = "grpc:<ServiceName>/<MethodName>"
+//
+// Idempotency: method-segregated overwrite on MethodGRPC. Re-running P6
+// replaces every entry whose method is "grpc" while leaving P1–P5 intact.
+//
+// Fallback: if no GRPC_HANDLES edge is present for a GrpcMethod entity, the
+// pass falls back to using the GrpcMethod entity ID itself as the link
+// source (so the link still points at something meaningful). Same fallback
+// on the server side for GRPC_IMPLEMENTS. When neither edge is present on
+// either side, no link is emitted for that name (we require at least one
+// GRPC_HANDLES + one GRPC_IMPLEMENTS to produce a cross-repo edge).
+
+import (
+	"sort"
+	"strings"
+)
+
+// MethodGRPC identifies this pass's emissions in links.json.
+const MethodGRPC = "grpc"
+
+// grpcChannel is the channel string written to every emitted link.
+const grpcChannel = "grpc"
+
+// grpcMethodKindLink is the entity kind emitted by the gRPC engine pass.
+// Matches engine.grpcMethodKind = "SCOPE.GrpcMethod".
+const grpcMethodKindLink = "SCOPE.GrpcMethod"
+
+// grpcHandlesEdge / grpcImplementsEdge are the edge kinds emitted by the
+// engine pass; compared case-insensitively to be robust to on-disk variance.
+const grpcHandlesEdgeKindLink    = "GRPC_HANDLES"
+const grpcImplementsEdgeKindLink = "GRPC_IMPLEMENTS"
+
+// grpcHit collects one GrpcMethod appearance in one repo.
+type grpcHit struct {
+	repo       string
+	stampedID  string // the per-repo hashed entity ID
+	name       string // "grpc:ServiceName/MethodName"
+	sourceFile string
+	// callerID is the entity ID of the caller on the client side,
+	// resolved via the GRPC_HANDLES edge (FromID → this entity).
+	callerID string
+	// handlerID is the entity ID of the handler on the server side,
+	// resolved via the GRPC_IMPLEMENTS edge (FromID → this entity).
+	handlerID string
+	// isClient is true when at least one GRPC_HANDLES edge targets this entity.
+	isClient bool
+	// isServer is true when at least one GRPC_IMPLEMENTS edge targets this entity.
+	isServer bool
+}
+
+// runGRPCPass implements P6: cross-repo gRPC client-stub → server-impl linker.
+func runGRPCPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "grpc"}
+
+	if len(graphs) < 2 {
+		// Method-segregated overwrite still runs so a previous group of
+		// ≥ 2 repos that shrunk to 1 cleans up its prior gRPC entries.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodGRPC), nil, rejects)
+		return res, err
+	}
+
+	// Pre-compute per-repo inbound edge index: entity ID → []edges pointing TO it.
+	// We need to find GRPC_HANDLES (client→method) and GRPC_IMPLEMENTS (handler→method)
+	// edges that point AT each GrpcMethod entity.
+	type inboundEdge struct {
+		fromID string
+		kind   string // "GRPC_HANDLES" or "GRPC_IMPLEMENTS"
+	}
+	// repo → toEntityID → []inboundEdge
+	inboundByRepo := map[string]map[string][]inboundEdge{}
+	for _, g := range graphs {
+		m := map[string][]inboundEdge{}
+		inboundByRepo[g.Repo] = m
+		for _, e := range g.Edges {
+			upperKind := strings.ToUpper(e.Kind)
+			if upperKind == grpcHandlesEdgeKindLink || upperKind == grpcImplementsEdgeKindLink {
+				m[e.ToID] = append(m[e.ToID], inboundEdge{fromID: e.FromID, kind: upperKind})
+			}
+		}
+	}
+
+	// Index: method name → repo → hit.
+	// One hit per (repo, name) pair — first occurrence wins (dedup).
+	hitsByName := map[string]map[string]*grpcHit{}
+	for _, g := range graphs {
+		inbound := inboundByRepo[g.Repo]
+		for _, e := range g.Entities {
+			if e.Kind != grpcMethodKindLink {
+				continue
+			}
+			if e.Name == "" {
+				continue
+			}
+			if !strings.HasPrefix(e.Name, "grpc:") {
+				continue
+			}
+			byRepo, ok := hitsByName[e.Name]
+			if !ok {
+				byRepo = map[string]*grpcHit{}
+				hitsByName[e.Name] = byRepo
+			}
+			if _, exists := byRepo[g.Repo]; exists {
+				continue // first-occurrence wins
+			}
+			hit := &grpcHit{
+				repo:       g.Repo,
+				stampedID:  e.ID,
+				name:       e.Name,
+				sourceFile: e.SourceFile,
+			}
+			// Resolve caller / handler from inbound edges.
+			for _, ie := range inbound[e.ID] {
+				switch ie.kind {
+				case grpcHandlesEdgeKindLink:
+					hit.isClient = true
+					if hit.callerID == "" {
+						hit.callerID = ie.fromID
+					}
+				case grpcImplementsEdgeKindLink:
+					hit.isServer = true
+					if hit.handlerID == "" {
+						hit.handlerID = ie.fromID
+					}
+				}
+			}
+			byRepo[g.Repo] = hit
+		}
+	}
+
+	now := discoveredAt()
+	emitted := map[string]bool{}
+	var fresh []Link
+
+	// Sort names for deterministic output.
+	names := make([]string, 0, len(hitsByName))
+	for n := range hitsByName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		byRepo := hitsByName[name]
+		if len(byRepo) < 2 {
+			continue
+		}
+
+		// Split into client repos (have GRPC_HANDLES) and server repos
+		// (have GRPC_IMPLEMENTS). A repo can be both.
+		var clients, servers []*grpcHit
+		for _, h := range byRepo {
+			if h.isClient {
+				clients = append(clients, h)
+			}
+			if h.isServer {
+				servers = append(servers, h)
+			}
+		}
+
+		if len(clients) == 0 || len(servers) == 0 {
+			continue
+		}
+
+		// Sort for deterministic ordering.
+		sort.Slice(clients, func(i, j int) bool {
+			if clients[i].repo != clients[j].repo {
+				return clients[i].repo < clients[j].repo
+			}
+			return clients[i].stampedID < clients[j].stampedID
+		})
+		sort.Slice(servers, func(i, j int) bool {
+			if servers[i].repo != servers[j].repo {
+				return servers[i].repo < servers[j].repo
+			}
+			return servers[i].stampedID < servers[j].stampedID
+		})
+
+		for _, client := range clients {
+			for _, server := range servers {
+				if client.repo == server.repo {
+					continue // never emit a self-pair as a cross-repo edge
+				}
+
+				// Source: caller entity on client side; fall back to synthetic ID.
+				srcID := client.callerID
+				if srcID == "" {
+					srcID = client.stampedID
+				}
+				// Target: handler entity on server side; fall back to synthetic ID.
+				tgtID := server.handlerID
+				if tgtID == "" {
+					tgtID = server.stampedID
+				}
+
+				source := entityKey(client.repo, srcID)
+				target := entityKey(server.repo, tgtID)
+				id := MakeID(source, target, MethodGRPC)
+				if emitted[id] {
+					continue
+				}
+				emitted[id] = true
+
+				ident := name // "grpc:ServiceName/MethodName"
+				ch := grpcChannel
+				fresh = append(fresh, Link{
+					ID:           id,
+					Source:       source,
+					Target:       target,
+					Relation:     RelationCalls,
+					Method:       MethodGRPC,
+					Confidence:   ScoreImport(),
+					Channel:      &ch,
+					Identifier:   &ident,
+					DiscoveredAt: now,
+					SourceLocations: [][]string{
+						{client.sourceFile},
+						{server.sourceFile},
+					},
+				})
+			}
+		}
+	}
+
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodGRPC), fresh, rejects)
+	if err != nil {
+		return res, err
+	}
+	res.LinksAdded = added
+	res.Skipped = skipped
+	return res, nil
+}

--- a/internal/links/grpc_pass_test.go
+++ b/internal/links/grpc_pass_test.go
@@ -1,0 +1,321 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestGRPCPass_ClientServerMatch verifies the happy path:
+// a Python client (orders repo) calls Inventory.Reserve via stub,
+// and a Go server (inventory repo) implements InventoryServer.Reserve.
+// The pass must emit one cross-repo CALLS link with method=grpc,
+// channel=grpc, identifier=grpc:Inventory/Reserve.
+func TestGRPCPass_ClientServerMatch(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Client side: orders repo — Python stub calls grpc:Inventory/Reserve.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{
+				"id": "caller1", "name": "create_order",
+				"kind": "SCOPE.Operation", "source_file": "orders/service.py",
+			},
+			{
+				"id": "gm1", "name": "grpc:Inventory/Reserve",
+				"kind": "SCOPE.GrpcMethod", "source_file": "",
+				"properties": map[string]any{
+					"service":      "Inventory",
+					"method":       "Reserve",
+					"pattern_type": "grpc_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "caller1", "to_id": "gm1", "kind": "GRPC_HANDLES"},
+		},
+	})
+
+	// Server side: inventory repo — Go handler implements grpc:Inventory/Reserve.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{
+				"id": "handler1", "name": "InventoryServer.Reserve",
+				"kind": "SCOPE.Operation", "source_file": "inventory/server.go",
+			},
+			{
+				"id": "gm2", "name": "grpc:Inventory/Reserve",
+				"kind": "SCOPE.GrpcMethod", "source_file": "",
+				"properties": map[string]any{
+					"service":      "Inventory",
+					"method":       "Reserve",
+					"pattern_type": "grpc_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "handler1", "to_id": "gm2", "kind": "GRPC_IMPLEMENTS"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	result, err := RunAllPasses("g1", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "g1-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var grpcLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC {
+			grpcLinks = append(grpcLinks, l)
+		}
+	}
+
+	if len(grpcLinks) == 0 {
+		t.Fatalf("expected ≥1 grpc link; got 0; total links=%d; pass results=%+v", len(doc.Links), result.Results)
+	}
+
+	hit := grpcLinks[0]
+	if hit.Source != "orders::caller1" {
+		t.Errorf("source: want orders::caller1 (resolved caller), got %s", hit.Source)
+	}
+	if hit.Target != "inventory::handler1" {
+		t.Errorf("target: want inventory::handler1 (resolved handler), got %s", hit.Target)
+	}
+	if hit.Relation != RelationCalls {
+		t.Errorf("relation: want calls, got %s", hit.Relation)
+	}
+	if hit.Channel == nil || *hit.Channel != "grpc" {
+		t.Errorf("channel: want grpc, got %v", hit.Channel)
+	}
+	if hit.Identifier == nil || *hit.Identifier != "grpc:Inventory/Reserve" {
+		t.Errorf("identifier: want grpc:Inventory/Reserve, got %v", hit.Identifier)
+	}
+}
+
+// TestGRPCPass_NoMatchWithoutBothSides verifies that a GrpcMethod entity
+// present in only one repo (server only, no client stub) does NOT produce a link.
+func TestGRPCPass_NoMatchWithoutBothSides(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Only a server — no client stub in any other repo.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{
+				"id": "handler1", "name": "InventoryServer.Reserve",
+				"kind": "SCOPE.Operation", "source_file": "inventory/server.go",
+			},
+			{
+				"id": "gm2", "name": "grpc:Inventory/Reserve",
+				"kind": "SCOPE.GrpcMethod", "source_file": "",
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "handler1", "to_id": "gm2", "kind": "GRPC_IMPLEMENTS"},
+		},
+	})
+	// A second repo that has nothing gRPC-related.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "c1", "name": "App", "kind": "SCOPE.Component", "source_file": "src/App.tsx"},
+		},
+		Edges: nil,
+	})
+
+	home := filepath.Join(root, "ag-home2")
+	if _, err := RunAllPasses("g2", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "g2-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC {
+			t.Errorf("expected no grpc links, got %+v", l)
+		}
+	}
+}
+
+// TestGRPCPass_NoEdgesNoLink verifies that when the Name appears in two
+// repos but neither repo has GRPC_HANDLES nor GRPC_IMPLEMENTS edges, no
+// link is emitted (both sides look like neither client nor server).
+func TestGRPCPass_NoEdgesNoLink(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Two repos both have the GrpcMethod entity, but no edges at all.
+	for _, repo := range []string{"orders", "inventory"} {
+		writeFixture(t, root, fixtureGraph{
+			Repo: repo,
+			Entities: []map[string]any{
+				{
+					"id": "gm1", "name": "grpc:Inventory/Reserve",
+					"kind": "SCOPE.GrpcMethod", "source_file": "",
+					"properties": map[string]any{"pattern_type": "grpc_synthesis"},
+				},
+			},
+			Edges: []map[string]string{}, // no GRPC_HANDLES or GRPC_IMPLEMENTS edges
+		})
+	}
+
+	home := filepath.Join(root, "ag-home3")
+	if _, err := RunAllPasses("g3", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "g3-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC {
+			t.Errorf("expected no grpc links (no edges present), got %+v", l)
+		}
+	}
+}
+
+// TestGRPCPass_MultipleMethodsSameService verifies that multiple RPC methods
+// on the same service each produce their own independent cross-repo link.
+func TestGRPCPass_MultipleMethodsSameService(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "c1", "name": "create_order", "kind": "SCOPE.Operation", "source_file": "orders/service.py"},
+			{"id": "c2", "name": "cancel_order", "kind": "SCOPE.Operation", "source_file": "orders/service.py"},
+			{"id": "gm1", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+			{"id": "gm2", "name": "grpc:Inventory/Release", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "c1", "to_id": "gm1", "kind": "GRPC_HANDLES"},
+			{"from_id": "c2", "to_id": "gm2", "kind": "GRPC_HANDLES"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{"id": "h1", "name": "Server.Reserve", "kind": "SCOPE.Operation", "source_file": "server.go"},
+			{"id": "h2", "name": "Server.Release", "kind": "SCOPE.Operation", "source_file": "server.go"},
+			{"id": "gm3", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+			{"id": "gm4", "name": "grpc:Inventory/Release", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "h1", "to_id": "gm3", "kind": "GRPC_IMPLEMENTS"},
+			{"from_id": "h2", "to_id": "gm4", "kind": "GRPC_IMPLEMENTS"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home4")
+	if _, err := RunAllPasses("g4", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "g4-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var grpcLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC {
+			grpcLinks = append(grpcLinks, l)
+		}
+	}
+
+	if len(grpcLinks) != 2 {
+		t.Fatalf("expected 2 grpc links (one per method), got %d: %+v", len(grpcLinks), grpcLinks)
+	}
+
+	// Both links should go from orders→inventory.
+	for _, l := range grpcLinks {
+		if l.Relation != RelationCalls {
+			t.Errorf("relation: want calls, got %s", l.Relation)
+		}
+		if l.Channel == nil || *l.Channel != "grpc" {
+			t.Errorf("channel: want grpc, got %v", l.Channel)
+		}
+	}
+}
+
+// TestGRPCPass_Idempotent verifies that running P6 twice does not duplicate
+// gRPC links (method-segregated overwrite).
+func TestGRPCPass_Idempotent(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "caller1", "name": "create_order", "kind": "SCOPE.Operation", "source_file": "orders/service.py"},
+			{"id": "gm1", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "caller1", "to_id": "gm1", "kind": "GRPC_HANDLES"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{"id": "handler1", "name": "Server.Reserve", "kind": "SCOPE.Operation", "source_file": "server.go"},
+			{"id": "gm2", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "handler1", "to_id": "gm2", "kind": "GRPC_IMPLEMENTS"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home5")
+
+	run1, err := RunAllPasses("g5", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run2, err := RunAllPasses("g5", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var grpcCount1, grpcCount2 int
+	for _, r := range run1.Results {
+		if r.Pass == "grpc" {
+			grpcCount1 = r.LinksAdded
+		}
+	}
+	for _, r := range run2.Results {
+		if r.Pass == "grpc" {
+			grpcCount2 = r.LinksAdded
+		}
+	}
+
+	if grpcCount1 != 1 {
+		t.Errorf("run1: expected 1 grpc link added, got %d", grpcCount1)
+	}
+	if grpcCount2 != 1 {
+		t.Errorf("run2: expected 1 grpc link added (idempotent replace), got %d", grpcCount2)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "g5-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var grpcLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC {
+			grpcLinks = append(grpcLinks, l)
+		}
+	}
+	if len(grpcLinks) != 1 {
+		t.Errorf("expected exactly 1 grpc link after 2 runs, got %d", len(grpcLinks))
+	}
+}

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -253,6 +253,24 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 	}
 	res.Results = append(res.Results, p5)
 
+	// P6 — cross-repo gRPC client-stub → server-impl linker. Uses
+	// SCOPE.GrpcMethod entities with canonical name grpc:Service/Method
+	// emitted by the gRPC engine pass (#725) as the join key.
+	p6, err := runGRPCPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("grpc pass: %w", err)
+	}
+	res.Results = append(res.Results, p6)
+
+	// P7 — cross-repo message-topic publisher↔subscriber linker. Uses
+	// SCOPE.MessageTopic entities emitted by the Kafka/SNS/SQS/EventBridge
+	// passes as the join key, matched by canonical topic Name.
+	p7, err := runTopicPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("topic pass: %w", err)
+	}
+	res.Results = append(res.Results, p7)
+
 	for _, r := range res.Results {
 		res.TotalLinks += r.LinksAdded
 		res.TotalCandid += r.Candidates

--- a/internal/links/shipfast_grpc_topic_test.go
+++ b/internal/links/shipfast_grpc_topic_test.go
@@ -1,0 +1,208 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestShipFastManifest_GRPCAndTopicLinks is the #1447 acceptance test.
+//
+// It replicates the ShipFast polyglot fixture at the link-pass level:
+//
+//	§2 gRPC:
+//	  orders (Python client) → inventory (Go server)
+//	  via contracts/proto/inventory.proto — Inventory/Reserve
+//
+//	§3 Topics:
+//	  orders.placed   : orders → inventory, notifications, analytics  (3 links)
+//	  payments.settled: payments → orders, billing, ledger             (3 links)
+//	  inventory.reserved (SNS): inventory → shipping                   (1 link)
+//
+// Expected after: ≥1 gRPC link (orders→inventory) + ≥7 topic links.
+// Before running this test both counts would be 0 (issue #1447).
+func TestShipFastManifest_GRPCAndTopicLinks(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// ---- orders service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			// gRPC client stub: calls Inventory.Reserve
+			{"id": "create_order_fn", "name": "create_order", "kind": "SCOPE.Operation", "source_file": "orders/service.py"},
+			{"id": "gm_inv_reserve_client", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+			// Topic publisher: orders.placed
+			{"id": "place_order_fn", "name": "place_order", "kind": "SCOPE.Operation", "source_file": "orders/producer.py"},
+			{"id": "topic_orders_placed_pub", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+			// Topic subscriber: payments.settled
+			{"id": "on_payment_fn", "name": "on_payment_settled", "kind": "SCOPE.Operation", "source_file": "orders/consumer.py"},
+			{"id": "topic_payments_settled_orders_sub", "name": "sns:payments.settled", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "create_order_fn", "to_id": "gm_inv_reserve_client", "kind": "GRPC_HANDLES"},
+			{"from_id": "place_order_fn", "to_id": "topic_orders_placed_pub", "kind": "PUBLISHES_TO"},
+			{"from_id": "on_payment_fn", "to_id": "topic_payments_settled_orders_sub", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// ---- inventory service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			// gRPC server: implements Inventory.Reserve
+			{"id": "inventory_handler", "name": "InventoryServer.Reserve", "kind": "SCOPE.Operation", "source_file": "inventory/server.go"},
+			{"id": "gm_inv_reserve_server", "name": "grpc:Inventory/Reserve", "kind": "SCOPE.GrpcMethod", "source_file": ""},
+			// Topic subscriber: orders.placed
+			{"id": "inv_on_order_fn", "name": "on_order_placed", "kind": "SCOPE.Operation", "source_file": "inventory/consumer.go"},
+			{"id": "topic_orders_placed_inv", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+			// Topic publisher: inventory.reserved (SNS)
+			{"id": "inv_reserve_fn", "name": "reserve_item", "kind": "SCOPE.Operation", "source_file": "inventory/service.go"},
+			{"id": "topic_inv_reserved_pub", "name": "sns:inventory.reserved", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "inventory_handler", "to_id": "gm_inv_reserve_server", "kind": "GRPC_IMPLEMENTS"},
+			{"from_id": "inv_on_order_fn", "to_id": "topic_orders_placed_inv", "kind": "SUBSCRIBES_TO"},
+			{"from_id": "inv_reserve_fn", "to_id": "topic_inv_reserved_pub", "kind": "PUBLISHES_TO"},
+		},
+	})
+
+	// ---- notifications service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "notifications",
+		Entities: []map[string]any{
+			{"id": "notif_fn", "name": "send_confirmation", "kind": "SCOPE.Operation", "source_file": "notifications/handler.js"},
+			{"id": "topic_orders_placed_notif", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "notif_fn", "to_id": "topic_orders_placed_notif", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// ---- analytics service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "analytics",
+		Entities: []map[string]any{
+			{"id": "analytics_fn", "name": "track_order", "kind": "SCOPE.Operation", "source_file": "analytics/handler.go"},
+			{"id": "topic_orders_placed_analytics", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "analytics_fn", "to_id": "topic_orders_placed_analytics", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// ---- payments service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "payments",
+		Entities: []map[string]any{
+			{"id": "settle_fn", "name": "settle_payment", "kind": "SCOPE.Operation", "source_file": "payments/service.py"},
+			{"id": "topic_payments_settled_pub", "name": "sns:payments.settled", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "settle_fn", "to_id": "topic_payments_settled_pub", "kind": "PUBLISHES_TO"},
+		},
+	})
+
+	// ---- billing service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "billing",
+		Entities: []map[string]any{
+			{"id": "billing_fn", "name": "record_payment", "kind": "SCOPE.Operation", "source_file": "billing/consumer.go"},
+			{"id": "topic_payments_settled_billing", "name": "sns:payments.settled", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "billing_fn", "to_id": "topic_payments_settled_billing", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// ---- ledger service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "ledger",
+		Entities: []map[string]any{
+			{"id": "ledger_fn", "name": "post_entry", "kind": "SCOPE.Operation", "source_file": "ledger/consumer.go"},
+			{"id": "topic_payments_settled_ledger", "name": "sns:payments.settled", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "ledger_fn", "to_id": "topic_payments_settled_ledger", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// ---- shipping service ----
+	writeFixture(t, root, fixtureGraph{
+		Repo: "shipping",
+		Entities: []map[string]any{
+			{"id": "shipping_fn", "name": "create_shipment", "kind": "SCOPE.Operation", "source_file": "shipping/consumer.go"},
+			{"id": "topic_inv_reserved_sub", "name": "sns:inventory.reserved", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "shipping_fn", "to_id": "topic_inv_reserved_sub", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-shipfast")
+	result, err := RunAllPasses("shipfast", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "shipfast-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	grpcCount := 0
+	topicCount := 0
+	for _, l := range doc.Links {
+		switch l.Method {
+		case MethodGRPC:
+			grpcCount++
+		case MethodTopic:
+			topicCount++
+		}
+	}
+
+	// §2: At least orders→inventory gRPC link.
+	if grpcCount < 1 {
+		t.Errorf("§2 gRPC: expected ≥1 cross-repo gRPC link, got 0; pass results=%+v", result.Results)
+	}
+
+	// Verify the specific orders→inventory Reserve link exists.
+	grpcFound := false
+	for _, l := range doc.Links {
+		if l.Method == MethodGRPC &&
+			l.Source == "orders::create_order_fn" &&
+			l.Target == "inventory::inventory_handler" {
+			grpcFound = true
+			if l.Identifier == nil || *l.Identifier != "grpc:Inventory/Reserve" {
+				t.Errorf("§2 gRPC: identifier: want grpc:Inventory/Reserve, got %v", l.Identifier)
+			}
+			if l.Channel == nil || *l.Channel != "grpc" {
+				t.Errorf("§2 gRPC: channel: want grpc, got %v", l.Channel)
+			}
+			break
+		}
+	}
+	if !grpcFound {
+		t.Errorf("§2 gRPC: missing orders::create_order_fn → inventory::inventory_handler link")
+		for _, l := range doc.Links {
+			if l.Method == MethodGRPC {
+				t.Logf("  found grpc link: %s → %s", l.Source, l.Target)
+			}
+		}
+	}
+
+	// §3: Expect 7 topic links total:
+	//   orders.placed (kafka): orders→inventory (1), orders→notifications (2), orders→analytics (3)
+	//   payments.settled (sns): payments→orders (4), payments→billing (5), payments→ledger (6)
+	//   inventory.reserved (sns): inventory→shipping (7)
+	if topicCount < 7 {
+		t.Errorf("§3 topics: expected ≥7 cross-repo topic links, got %d; pass results=%+v", topicCount, result.Results)
+		for _, l := range doc.Links {
+			if l.Method == MethodTopic {
+				t.Logf("  found topic link: %s → %s (identifier=%v, channel=%v)", l.Source, l.Target, l.Identifier, l.Channel)
+			}
+		}
+	}
+
+	t.Logf("Before: 0 gRPC links, 0 topic links (issue #1447)")
+	t.Logf("After:  %d gRPC links, %d topic links", grpcCount, topicCount)
+	t.Logf("Total cross-repo links: %d", len(doc.Links))
+}

--- a/internal/links/topic_pass.go
+++ b/internal/links/topic_pass.go
@@ -1,0 +1,259 @@
+package links
+
+// topic_pass.go implements the cross-repo message-topic publisher↔subscriber
+// matcher (P7).
+//
+// Design
+// ------
+// The Kafka/SNS/SQS/EventBridge/Redis engine passes emit synthetic
+// SCOPE.MessageTopic entities keyed by a broker-prefixed topic name:
+//
+//	Entity{Kind: "SCOPE.MessageTopic", Name: "kafka:orders.placed"}
+//	Entity{Kind: "SCOPE.MessageTopic", Name: "sns:payments.settled"}
+//	Entity{Kind: "SCOPE.MessageTopic", Name: "sqs:inventory-reserved-queue"}
+//	Entity{Kind: "SCOPE.MessageTopic", Name: "event:eventbridge:orders:orders.placed"}
+//	Entity{Kind: "SCOPE.MessageTopic", Name: "redis:orders.placed"}
+//
+// On the publisher side, a PUBLISHES_TO edge points from the producer
+// function/method to the MessageTopic entity.
+// On the subscriber side, a SUBSCRIBES_TO edge points from the consumer
+// function/method to the MessageTopic entity.
+//
+// Cross-repo identity: the Name field is already normalised by the engine
+// pass so the same topic Name appears in every repo that touches it. P7
+// joins by Name, exactly like P4 joins http_endpoint synthetics by Name.
+//
+// Emits one link per (publisher-entity, subscriber-entity) cross-repo pair:
+//
+//	relation   = "publishes_to"
+//	method     = "topic"
+//	channel    = broker name (kafka / sns / sqs / eventbridge / redis / ...)
+//	identifier = topic name
+//
+// Idempotency: method-segregated overwrite on MethodTopic. Re-running P7
+// replaces every entry whose method is "topic" while leaving P1–P6 intact.
+
+import (
+	"sort"
+	"strings"
+)
+
+// MethodTopic identifies this pass's emissions in links.json.
+const MethodTopic = "topic"
+
+// RelationPublishesTo is the relation written on publisher→subscriber links.
+// More precise than RelationCalls for message-bus flows.
+const RelationPublishesTo = "publishes_to"
+
+// topicMessageTopicKind is the entity kind emitted by broker engine passes.
+const topicMessageTopicKind = "SCOPE.MessageTopic"
+
+// topicPublishesEdge / topicSubscribesEdge are matched case-insensitively.
+const topicPublishesEdge = "PUBLISHES_TO"
+const topicSubscribesEdge = "SUBSCRIBES_TO"
+
+// topicHit collects one MessageTopic appearance in one repo.
+type topicHit struct {
+	repo       string
+	stampedID  string
+	name       string
+	sourceFile string
+	// publisherIDs are entity IDs of publishers (PUBLISHES_TO edges TO this topic).
+	publisherIDs []string
+	// subscriberIDs are entity IDs of subscribers (SUBSCRIBES_TO edges TO this topic).
+	subscriberIDs []string
+}
+
+// brokerFromTopicName extracts the broker string from a topic Name for the
+// channel field on emitted links. Examples:
+//
+//	"kafka:orders.placed"           → "kafka"
+//	"sns:payments.settled"          → "sns"
+//	"sqs:inventory-queue"           → "sqs"
+//	"event:eventbridge:src:type"    → "eventbridge"
+//	"event:eventgrid:topic:type"    → "eventgrid"
+//	"redis:orders.placed"           → "redis"
+//	"nats:orders.placed"            → "nats"
+func brokerFromTopicName(name string) string {
+	// "event:eventbridge:..." and other event-bus forms: second segment is broker.
+	if strings.HasPrefix(name, "event:") {
+		rest := name[len("event:"):]
+		if i := strings.IndexByte(rest, ':'); i > 0 {
+			return rest[:i] // "eventbridge", "eventgrid", "cloudevents"
+		}
+		return "event"
+	}
+	// Simple "broker:..." form (kafka, sns, sqs, redis, nats, pubsub, etc.).
+	if i := strings.IndexByte(name, ':'); i > 0 {
+		return name[:i]
+	}
+	return "message"
+}
+
+// runTopicPass implements P7: cross-repo message-topic publisher↔subscriber
+// linker.
+func runTopicPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "topic"}
+
+	if len(graphs) < 2 {
+		// Method-segregated overwrite still runs so a previous group of
+		// ≥ 2 repos that shrunk to 1 cleans up its prior topic entries.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodTopic), nil, rejects)
+		return res, err
+	}
+
+	// Pre-compute inbound PUBLISHES_TO / SUBSCRIBES_TO edges per repo,
+	// indexed by the topic entity ID they point at.
+	type inboundTopicEdge struct {
+		fromID string
+		kind   string // "PUBLISHES_TO" or "SUBSCRIBES_TO"
+	}
+	// repo → toEntityID → []inboundTopicEdge
+	inboundByRepo := map[string]map[string][]inboundTopicEdge{}
+	for _, g := range graphs {
+		m := map[string][]inboundTopicEdge{}
+		inboundByRepo[g.Repo] = m
+		for _, e := range g.Edges {
+			upper := strings.ToUpper(e.Kind)
+			if upper == topicPublishesEdge || upper == topicSubscribesEdge {
+				m[e.ToID] = append(m[e.ToID], inboundTopicEdge{fromID: e.FromID, kind: upper})
+			}
+		}
+	}
+
+	// Index: topic name → repo → hit.
+	// One hit per (repo, name) pair — first occurrence wins.
+	hitsByName := map[string]map[string]*topicHit{}
+	for _, g := range graphs {
+		inbound := inboundByRepo[g.Repo]
+		for _, e := range g.Entities {
+			if e.Kind != topicMessageTopicKind {
+				continue
+			}
+			if e.Name == "" {
+				continue
+			}
+			byRepo, ok := hitsByName[e.Name]
+			if !ok {
+				byRepo = map[string]*topicHit{}
+				hitsByName[e.Name] = byRepo
+			}
+			if _, exists := byRepo[g.Repo]; exists {
+				continue // first-occurrence wins
+			}
+			hit := &topicHit{
+				repo:       g.Repo,
+				stampedID:  e.ID,
+				name:       e.Name,
+				sourceFile: e.SourceFile,
+			}
+			for _, ie := range inbound[e.ID] {
+				switch ie.kind {
+				case topicPublishesEdge:
+					hit.publisherIDs = append(hit.publisherIDs, ie.fromID)
+				case topicSubscribesEdge:
+					hit.subscriberIDs = append(hit.subscriberIDs, ie.fromID)
+				}
+			}
+			byRepo[g.Repo] = hit
+		}
+	}
+
+	now := discoveredAt()
+	emitted := map[string]bool{}
+	var fresh []Link
+
+	// Sort names for deterministic output.
+	names := make([]string, 0, len(hitsByName))
+	for n := range hitsByName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+
+	for _, name := range names {
+		byRepo := hitsByName[name]
+		if len(byRepo) < 2 {
+			continue
+		}
+
+		// Collect publisher repos (have PUBLISHES_TO) and subscriber repos
+		// (have SUBSCRIBES_TO). A repo can be both.
+		var publishers, subscribers []*topicHit
+		for _, h := range byRepo {
+			if len(h.publisherIDs) > 0 {
+				publishers = append(publishers, h)
+			}
+			if len(h.subscriberIDs) > 0 {
+				subscribers = append(subscribers, h)
+			}
+		}
+
+		if len(publishers) == 0 || len(subscribers) == 0 {
+			continue
+		}
+
+		sort.Slice(publishers, func(i, j int) bool { return publishers[i].repo < publishers[j].repo })
+		sort.Slice(subscribers, func(i, j int) bool { return subscribers[i].repo < subscribers[j].repo })
+
+		broker := brokerFromTopicName(name)
+
+		for _, pub := range publishers {
+			// Sort publisher IDs for deterministic selection.
+			sortedPubIDs := make([]string, len(pub.publisherIDs))
+			copy(sortedPubIDs, pub.publisherIDs)
+			sort.Strings(sortedPubIDs)
+
+			for _, sub := range subscribers {
+				if pub.repo == sub.repo {
+					continue // never emit a self-pair as a cross-repo edge
+				}
+
+				// Sort subscriber IDs for deterministic selection.
+				sortedSubIDs := make([]string, len(sub.subscriberIDs))
+				copy(sortedSubIDs, sub.subscriberIDs)
+				sort.Strings(sortedSubIDs)
+
+				// Emit one link per (publisher entity, subscriber entity) pair
+				// so that when multiple functions publish/subscribe to the same
+				// topic in one repo, each gets its own cross-repo edge.
+				for _, srcID := range sortedPubIDs {
+					for _, tgtID := range sortedSubIDs {
+						source := entityKey(pub.repo, srcID)
+						target := entityKey(sub.repo, tgtID)
+						id := MakeID(source, target, MethodTopic)
+						if emitted[id] {
+							continue
+						}
+						emitted[id] = true
+
+						ident := name
+						ch := broker
+						fresh = append(fresh, Link{
+							ID:           id,
+							Source:       source,
+							Target:       target,
+							Relation:     RelationPublishesTo,
+							Method:       MethodTopic,
+							Confidence:   ScoreImport(),
+							Channel:      &ch,
+							Identifier:   &ident,
+							DiscoveredAt: now,
+							SourceLocations: [][]string{
+								{pub.sourceFile},
+								{sub.sourceFile},
+							},
+						})
+					}
+				}
+			}
+		}
+	}
+
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodTopic), fresh, rejects)
+	if err != nil {
+		return res, err
+	}
+	res.LinksAdded = added
+	res.Skipped = skipped
+	return res, nil
+}

--- a/internal/links/topic_pass_test.go
+++ b/internal/links/topic_pass_test.go
@@ -1,0 +1,362 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// TestTopicPass_KafkaPublisherSubscriber verifies the happy path:
+// orders repo publishes to kafka:orders.placed; inventory and notifications
+// repos subscribe. Two cross-repo topic links expected.
+func TestTopicPass_KafkaPublisherSubscriber(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Publisher: orders repo.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "pub1", "name": "place_order", "kind": "SCOPE.Operation", "source_file": "orders/handler.py"},
+			{
+				"id": "topic1", "name": "kafka:orders.placed",
+				"kind": "SCOPE.MessageTopic", "source_file": "",
+				"properties": map[string]any{"broker": "kafka", "topic_name": "orders.placed"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "pub1", "to_id": "topic1", "kind": "PUBLISHES_TO"},
+		},
+	})
+
+	// Subscriber: inventory repo.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{"id": "sub1", "name": "on_order_placed", "kind": "SCOPE.Operation", "source_file": "inventory/consumer.go"},
+			{
+				"id": "topic2", "name": "kafka:orders.placed",
+				"kind": "SCOPE.MessageTopic", "source_file": "",
+				"properties": map[string]any{"broker": "kafka", "topic_name": "orders.placed"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "sub1", "to_id": "topic2", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	// Subscriber: notifications repo.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "notifications",
+		Entities: []map[string]any{
+			{"id": "sub2", "name": "send_confirmation", "kind": "SCOPE.Operation", "source_file": "notifications/handler.js"},
+			{
+				"id": "topic3", "name": "kafka:orders.placed",
+				"kind": "SCOPE.MessageTopic", "source_file": "",
+				"properties": map[string]any{"broker": "kafka", "topic_name": "orders.placed"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "sub2", "to_id": "topic3", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-topic1")
+	result, err := RunAllPasses("tg1", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg1-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var topicLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			topicLinks = append(topicLinks, l)
+		}
+	}
+
+	// Expect 2 links: orders→inventory and orders→notifications.
+	if len(topicLinks) != 2 {
+		t.Fatalf("expected 2 topic links, got %d; results=%+v; links=%+v", len(topicLinks), result.Results, topicLinks)
+	}
+
+	for _, l := range topicLinks {
+		if l.Source != "orders::pub1" {
+			t.Errorf("source: want orders::pub1, got %s", l.Source)
+		}
+		if l.Channel == nil || *l.Channel != "kafka" {
+			t.Errorf("channel: want kafka, got %v", l.Channel)
+		}
+		if l.Identifier == nil || *l.Identifier != "kafka:orders.placed" {
+			t.Errorf("identifier: want kafka:orders.placed, got %v", l.Identifier)
+		}
+		if l.Relation != RelationPublishesTo {
+			t.Errorf("relation: want publishes_to, got %s", l.Relation)
+		}
+	}
+
+	// Verify the correct subscriber repos are targeted.
+	targets := map[string]bool{}
+	for _, l := range topicLinks {
+		targets[l.Target] = true
+	}
+	if !targets["inventory::sub1"] {
+		t.Error("expected target inventory::sub1 among topic links")
+	}
+	if !targets["notifications::sub2"] {
+		t.Error("expected target notifications::sub2 among topic links")
+	}
+}
+
+// TestTopicPass_SNStoSQS verifies that an SNS publisher → subscriber
+// cross-repo pair produces a link when the canonical topic Name is shared.
+// Simulates ShipFast §3: payments.settled (payments→billing).
+func TestTopicPass_SNStoSQS(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "payments",
+		Entities: []map[string]any{
+			{"id": "pub1", "name": "settle_payment", "kind": "SCOPE.Operation", "source_file": "payments/service.py"},
+			{
+				"id": "topic1", "name": "sns:payments.settled",
+				"kind": "SCOPE.MessageTopic", "source_file": "",
+				"properties": map[string]any{"broker": "sns", "topic_name": "payments.settled"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "pub1", "to_id": "topic1", "kind": "PUBLISHES_TO"},
+		},
+	})
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "billing",
+		Entities: []map[string]any{
+			{"id": "sub1", "name": "record_payment", "kind": "SCOPE.Operation", "source_file": "billing/consumer.go"},
+			{
+				"id": "topic2", "name": "sns:payments.settled",
+				"kind": "SCOPE.MessageTopic", "source_file": "",
+				"properties": map[string]any{"broker": "sns", "topic_name": "payments.settled"},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "sub1", "to_id": "topic2", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-topic2")
+	if _, err := RunAllPasses("tg2", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg2-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var topicLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			topicLinks = append(topicLinks, l)
+		}
+	}
+
+	if len(topicLinks) != 1 {
+		t.Fatalf("expected 1 topic link, got %d: %+v", len(topicLinks), topicLinks)
+	}
+	if topicLinks[0].Channel == nil || *topicLinks[0].Channel != "sns" {
+		t.Errorf("channel: want sns, got %v", topicLinks[0].Channel)
+	}
+	if topicLinks[0].Source != "payments::pub1" {
+		t.Errorf("source: want payments::pub1, got %s", topicLinks[0].Source)
+	}
+	if topicLinks[0].Target != "billing::sub1" {
+		t.Errorf("target: want billing::sub1, got %s", topicLinks[0].Target)
+	}
+}
+
+// TestTopicPass_NoPublisher verifies that a topic present in two repos but
+// only with subscribers (no publishers) does NOT produce a link.
+func TestTopicPass_NoPublisher(t *testing.T) {
+	root := fixtureRoot(t)
+
+	for _, repo := range []string{"svc-a", "svc-b"} {
+		writeFixture(t, root, fixtureGraph{
+			Repo: repo,
+			Entities: []map[string]any{
+				{"id": "sub1", "name": "handler", "kind": "SCOPE.Operation", "source_file": "handler.go"},
+				{
+					"id": "topic1", "name": "kafka:shared.event",
+					"kind": "SCOPE.MessageTopic", "source_file": "",
+				},
+			},
+			Edges: []map[string]string{
+				{"from_id": "sub1", "to_id": "topic1", "kind": "SUBSCRIBES_TO"},
+			},
+		})
+	}
+
+	home := filepath.Join(root, "ag-home-topic3")
+	if _, err := RunAllPasses("tg3", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg3-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			t.Errorf("expected no topic links, got %+v", l)
+		}
+	}
+}
+
+// TestTopicPass_BrokerFromTopicName checks that channel extraction works
+// for all broker prefixes used by ShipFast §3 and beyond.
+func TestTopicPass_BrokerFromTopicName(t *testing.T) {
+	cases := []struct {
+		name   string
+		expect string
+	}{
+		{"kafka:orders.placed", "kafka"},
+		{"sns:payments.settled", "sns"},
+		{"sqs:inventory-reserved-queue", "sqs"},
+		{"event:eventbridge:orders:orders.placed", "eventbridge"},
+		{"event:eventgrid:topic:event-type", "eventgrid"},
+		{"event:cloudevents:source:type", "cloudevents"},
+		{"redis:orders.placed", "redis"},
+		{"nats:orders.placed", "nats"},
+		{"pubsub:orders.placed", "pubsub"},
+	}
+	for _, tc := range cases {
+		got := brokerFromTopicName(tc.name)
+		if got != tc.expect {
+			t.Errorf("brokerFromTopicName(%q): want %q, got %q", tc.name, tc.expect, got)
+		}
+	}
+}
+
+// TestTopicPass_Idempotent verifies that running P7 twice does not duplicate
+// topic links (method-segregated overwrite guarantees exactly-once semantics).
+func TestTopicPass_Idempotent(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "pub1", "name": "place_order", "kind": "SCOPE.Operation", "source_file": "o.py"},
+			{"id": "topic1", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "pub1", "to_id": "topic1", "kind": "PUBLISHES_TO"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "inventory",
+		Entities: []map[string]any{
+			{"id": "sub1", "name": "on_order", "kind": "SCOPE.Operation", "source_file": "i.go"},
+			{"id": "topic2", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "sub1", "to_id": "topic2", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-topic4")
+
+	run1, err := RunAllPasses("tg4", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+	run2, err := RunAllPasses("tg4", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var topicCount1, topicCount2 int
+	for _, r := range run1.Results {
+		if r.Pass == "topic" {
+			topicCount1 = r.LinksAdded
+		}
+	}
+	for _, r := range run2.Results {
+		if r.Pass == "topic" {
+			topicCount2 = r.LinksAdded
+		}
+	}
+
+	if topicCount1 != 1 {
+		t.Errorf("run1: expected 1 topic link added, got %d", topicCount1)
+	}
+	if topicCount2 != 1 {
+		t.Errorf("run2: expected 1 topic link added (idempotent replace), got %d", topicCount2)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg4-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var topicLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			topicLinks = append(topicLinks, l)
+		}
+	}
+	if len(topicLinks) != 1 {
+		t.Errorf("expected exactly 1 topic link after 2 runs, got %d", len(topicLinks))
+	}
+}
+
+// TestTopicPass_EventBridgeChannel verifies that eventbridge-prefixed topic
+// names produce channel="eventbridge" (not "event").
+func TestTopicPass_EventBridgeChannel(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "pub1", "name": "dispatch_event", "kind": "SCOPE.Operation", "source_file": "orders/events.py"},
+			{"id": "topic1", "name": "event:eventbridge:orders:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "pub1", "to_id": "topic1", "kind": "PUBLISHES_TO"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "analytics",
+		Entities: []map[string]any{
+			{"id": "sub1", "name": "track_order", "kind": "SCOPE.Operation", "source_file": "analytics/handler.go"},
+			{"id": "topic2", "name": "event:eventbridge:orders:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "sub1", "to_id": "topic2", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-topic5")
+	if _, err := RunAllPasses("tg5", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg5-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var topicLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			topicLinks = append(topicLinks, l)
+		}
+	}
+	if len(topicLinks) != 1 {
+		t.Fatalf("expected 1 topic link, got %d: %+v", len(topicLinks), topicLinks)
+	}
+	if topicLinks[0].Channel == nil || *topicLinks[0].Channel != "eventbridge" {
+		t.Errorf("channel: want eventbridge, got %v", topicLinks[0].Channel)
+	}
+}


### PR DESCRIPTION
## What

Fixes #1447. ShipFast polyglot corpus shows 0 gRPC cross-repo links and 0 topic cross-repo links before this PR.

## Why

The gRPC engine pass (#725) emits `SCOPE.GrpcMethod` entities keyed by `grpc:ServiceName/MethodName` with `GRPC_HANDLES` edges on the client side and `GRPC_IMPLEMENTS` edges on the server side. The Kafka/SNS/SQS/EventBridge/Redis engine passes emit `SCOPE.MessageTopic` entities with `PUBLISHES_TO` / `SUBSCRIBES_TO` edges. Neither was wired into the cross-repo link passes in `internal/links/`.

The import pass (P1) cannot join these cross-repo because `graph.EntityID()` hashes the repo tag — the same `grpc:Inventory/Reserve` entity has a **different stamped ID** in the `orders` repo vs the `inventory` repo. The solution (join by `.Name` across repos) already existed for HTTP endpoints in P4; this PR replicates the same pattern for gRPC methods and message topics.

## How

### P6 (`grpc_pass.go`) — gRPC cross-repo linker
- Scans all per-repo graphs for `SCOPE.GrpcMethod` entities whose name starts with `grpc:`
- Groups hits by canonical name (e.g. `grpc:Inventory/Reserve`) across repos
- Classifies each repo as client (has inbound `GRPC_HANDLES` edge) or server (has inbound `GRPC_IMPLEMENTS` edge)
- Emits one `method=grpc, channel=grpc, relation=calls` link per (client-caller → server-handler) cross-repo pair
- Traces edges to resolve real caller/handler entity IDs; falls back to synthetic entity ID when no edge is present

### P7 (`topic_pass.go`) — message-topic cross-repo linker
- Scans for `SCOPE.MessageTopic` entities, groups by broker-prefixed name (`kafka:orders.placed`, `sns:payments.settled`, `event:eventbridge:orders:orders.placed`, etc.)
- Classifies repos as publishers (`PUBLISHES_TO` inbound) or subscribers (`SUBSCRIBES_TO` inbound)
- Emits one `method=topic, channel=<broker>, relation=publishes_to` link per (publisher-entity × subscriber-entity) cross-repo pair
- `brokerFromTopicName()` handles the `event:` prefix hierarchy (`event:eventbridge:*` → channel=`eventbridge`)

Both passes are method-segregated and idempotent (same semantics as P4/P5). Both registered in `RunAllPasses` as P6 and P7.

## Before / After (ShipFast §2/§3 fixture)

| | Before | After |
|---|---|---|
| gRPC links (§2) | 0 | **1** (orders::create_order_fn → inventory::inventory_handler, identifier=`grpc:Inventory/Reserve`) |
| Topic links (§3) | 0 | **7** (orders.placed×3, payments.settled×3, inventory.reserved×1) |

## Test plan

- [x] `go test ./internal/links/ -run TestGRPCPass -v` — 5 P6 unit tests pass
- [x] `go test ./internal/links/ -run TestTopicPass -v` — 6 P7 unit tests pass (incl. `brokerFromTopicName` key extraction)
- [x] `go test ./internal/links/ -run TestShipFastManifest -v` — §2/§3 acceptance test passes (1 gRPC + 7 topic links)
- [x] `go test ./internal/links/ -count=1` — full links suite, zero regressions in P1–P5 tests
- [x] `go build ./internal/links/ ./internal/engine/` — clean build

## Notes

- Live daemon at `:47274` was NOT rebuilt (per instructions — no `index .` in this repo)
- Worktree: `/Users/jorgecajas/Documents/Projects/archigraph-worktrees/fix-grpc-topic`

🤖 Generated with [Claude Code](https://claude.com/claude-code)