### PR TITLE
feat(webui-v2): Landing screen — group selector + create-group + empty state (#1435)

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -168,6 +168,43 @@ Called once on app mount by WebUI v2. Response:
 
 ---
 
+## 6a. Group surface (Landing screen)
+
+`/api/v2/meta` returns only group **slugs**. The Landing screen needs richer
+per-group data, so two dedicated endpoints back it.
+
+### `GET /api/v2/groups` (paginated)
+
+Rich group list for the Landing cards grid. Each item:
+
+```json
+{
+  "id": "acme",
+  "name": "acme",
+  "repos": ["core", "web"],
+  "entityCount": 1200,
+  "fidelity": 1.0,        // 0..1, or null when never indexed
+  "indexedAt": 1716300000000, // unix-ms, or null when never indexed
+  "health": "healthy"     // "healthy" | "warning" | "unindexed"
+}
+```
+
+`health` + `fidelity` are derived server-side in `deriveGroupHealth`
+(`v2_groups.go`) so the rules live in one place: a group with no entities and
+no last-indexed time is `unindexed` (fidelity null); otherwise it is indexed.
+**Note:** the daemon does not yet persist a real per-group fidelity score, so
+indexed groups currently report `fidelity: 1.0` / `health: "healthy"`. When a
+real score lands it slots straight into `deriveGroupHealth` with no wire change.
+
+### `POST /api/v2/groups`
+
+Creates an **empty** group (fleet.json + registry entry) from a name. Body:
+`{ "name": "<slug>" }`. Returns `201` with the created group in a `v2OK`
+envelope. Repo discovery / indexing (the full wizard) is **out of scope** for
+this endpoint; the created group reports `health: "unindexed"`.
+
+---
+
 ## 7. Adding a new v2 endpoint — checklist
 
 - [ ] Handler file named `v2_<surface>.go`.

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -516,6 +516,10 @@ func (s *Server) routes() http.Handler {
 	// and registered groups.
 	mux.HandleFunc("GET /api/v2/meta", s.handleV2Meta)
 
+	// Landing screen — rich group list + create-group.
+	mux.HandleFunc("GET /api/v2/groups", s.handleV2Groups)
+	mux.HandleFunc("POST /api/v2/groups", s.handleV2CreateGroup)
+
 	return s.withAuth(withGzip(mux))
 }
 

--- a/internal/dashboard/v2_groups.go
+++ b/internal/dashboard/v2_groups.go
@@ -1,0 +1,144 @@
+// v2_groups.go — Landing-screen group surface for WebUI v2.
+//
+// Endpoints:
+//
+//	GET  /api/v2/groups       → rich Group list (drives the Landing cards grid)
+//	POST /api/v2/groups       → create an (empty) group from a name
+//
+// The Landing screen needs more than the slug list returned by /api/v2/meta:
+// it renders per-group entity counts, repo slugs, fidelity, last-indexed time,
+// and a health state. All of that is already aggregated by the registry store
+// (GroupSummary). This handler maps GroupSummary → the v2 Group wire shape the
+// WebUI v2 api client expects and derives the health/fidelity fields in one
+// place so the rules don't live in the browser.
+//
+// Create-group reuses the v1 registry CreateGroup path (same as the v1 admin
+// and onboard handlers) — it creates the fleet.json + registers the group with
+// no repos. Repo discovery / indexing (the full wizard) is intentionally out of
+// scope for this endpoint; see the Landing PR for the data-decision write-up.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"time"
+)
+
+// v2Group is the wire shape consumed by the WebUI v2 Landing screen. It mirrors
+// the `Group` interface in webui-v2/src/data/types.ts.
+type v2Group struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Repos       []string `json:"repos"`
+	EntityCount int      `json:"entityCount"`
+	// Fidelity is 0..1, or null when the group has never been indexed.
+	Fidelity *float64 `json:"fidelity"`
+	// IndexedAt is unix-ms, or null when never indexed.
+	IndexedAt *int64 `json:"indexedAt"`
+	// Health is one of "healthy" | "warning" | "unindexed", derived server-side.
+	Health string `json:"health"`
+}
+
+const (
+	healthHealthy   = "healthy"
+	healthWarning   = "warning"
+	healthUnindexed = "unindexed"
+)
+
+// deriveGroupHealth computes the health + fidelity for a group from its
+// aggregated stats. The rules live here (one place) per the design doc:
+//   - never indexed (no entities AND no last-indexed) → unindexed, fidelity null
+//   - fidelity ≥ 0.8 → healthy; otherwise → warning
+//
+// Until the daemon persists a real fidelity score per group, we surface a
+// neutral indexed-but-unknown value (1.0 → healthy) so indexed groups don't
+// render as perpetually "low fidelity". This keeps the wire contract stable;
+// when a real score lands it slots straight into this function.
+func deriveGroupHealth(s GroupSummary) (health string, fidelity *float64, indexedAt *int64) {
+	indexed := s.LastIndexed != ""
+	if !indexed && s.EntityCount == 0 {
+		return healthUnindexed, nil, nil
+	}
+	if t, err := time.Parse(time.RFC3339, s.LastIndexed); err == nil {
+		ms := t.UnixMilli()
+		indexedAt = &ms
+	}
+	f := 1.0
+	fidelity = &f
+	if f >= 0.8 {
+		health = healthHealthy
+	} else {
+		health = healthWarning
+	}
+	return health, fidelity, indexedAt
+}
+
+func toV2Group(s GroupSummary) v2Group {
+	health, fidelity, indexedAt := deriveGroupHealth(s)
+	repos := s.Repos
+	if repos == nil {
+		repos = []string{}
+	}
+	return v2Group{
+		ID:          s.Name,
+		Name:        s.Name,
+		Repos:       repos,
+		EntityCount: s.EntityCount,
+		Fidelity:    fidelity,
+		IndexedAt:   indexedAt,
+		Health:      health,
+	}
+}
+
+// handleV2Groups — GET /api/v2/groups
+//
+// Returns the rich, paginated Group list for the Landing screen.
+func (s *Server) handleV2Groups(w http.ResponseWriter, r *http.Request) {
+	groups, err := s.registry.ListGroups()
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	out := make([]v2Group, 0, len(groups))
+	for _, g := range groups {
+		out = append(out, toV2Group(g))
+	}
+	pag := parsePagination(r.URL.Query(), len(out))
+	end := pag.Offset + pag.Limit
+	if pag.Offset > len(out) {
+		pag.Offset = len(out)
+	}
+	if end > len(out) {
+		end = len(out)
+	}
+	writeV2JSON(w, http.StatusOK, v2Page(out[pag.Offset:end], pag))
+}
+
+// v2CreateGroupReq is the request body for POST /api/v2/groups.
+type v2CreateGroupReq struct {
+	Name string `json:"name"`
+}
+
+// handleV2CreateGroup — POST /api/v2/groups
+//
+// Creates an empty group (fleet.json + registry entry) from a name. Repo
+// discovery and indexing remain a separate flow; the returned Group has no
+// repos and reports health=unindexed.
+func (s *Server) handleV2CreateGroup(w http.ResponseWriter, r *http.Request) {
+	var req v2CreateGroupReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "name required")
+		return
+	}
+	created, err := s.registry.CreateGroup(req.Name)
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	writeV2JSON(w, http.StatusCreated, v2OK(toV2Group(created)))
+}

--- a/internal/dashboard/v2_groups_test.go
+++ b/internal/dashboard/v2_groups_test.go
@@ -1,0 +1,221 @@
+package dashboard
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// decodeV2Group is the wire shape returned by the v2 group endpoints.
+type decodeV2Group struct {
+	ID          string   `json:"id"`
+	Name        string   `json:"name"`
+	Repos       []string `json:"repos"`
+	EntityCount int      `json:"entityCount"`
+	Fidelity    *float64 `json:"fidelity"`
+	IndexedAt   *int64   `json:"indexedAt"`
+	Health      string   `json:"health"`
+}
+
+// TestV2Groups_RichShape verifies GET /api/v2/groups returns the paginated
+// rich Group list with derived health fields.
+func TestV2Groups_RichShape(t *testing.T) {
+	st := newFakeStore()
+	st.groups["indexed"] = GroupSummary{
+		Name:        "indexed",
+		ConfigPath:  "/i.json",
+		Repos:       []string{"a", "b"},
+		EntityCount: 1200,
+		LastIndexed: time.Now().UTC().Format(time.RFC3339),
+	}
+	st.groups["fresh"] = GroupSummary{
+		Name:       "fresh",
+		ConfigPath: "/f.json",
+		Repos:      []string{},
+	}
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups")
+	if err != nil {
+		t.Fatalf("GET /api/v2/groups: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		OK         bool            `json:"ok"`
+		Data       []decodeV2Group `json:"data"`
+		Pagination V2Pagination    `json:"pagination"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Error("ok: want true")
+	}
+	if body.Pagination.Total != 2 {
+		t.Errorf("pagination.total: want 2, got %d", body.Pagination.Total)
+	}
+	if len(body.Data) != 2 {
+		t.Fatalf("data: want 2 groups, got %d", len(body.Data))
+	}
+
+	byID := map[string]decodeV2Group{}
+	for _, g := range body.Data {
+		byID[g.ID] = g
+	}
+
+	indexed, ok := byID["indexed"]
+	if !ok {
+		t.Fatal("missing 'indexed' group")
+	}
+	if indexed.Health != healthHealthy {
+		t.Errorf("indexed.health: want healthy, got %q", indexed.Health)
+	}
+	if indexed.EntityCount != 1200 {
+		t.Errorf("indexed.entityCount: want 1200, got %d", indexed.EntityCount)
+	}
+	if indexed.Fidelity == nil {
+		t.Error("indexed.fidelity: want non-null")
+	}
+	if indexed.IndexedAt == nil {
+		t.Error("indexed.indexedAt: want non-null")
+	}
+	if len(indexed.Repos) != 2 {
+		t.Errorf("indexed.repos: want 2, got %v", indexed.Repos)
+	}
+
+	fresh, ok := byID["fresh"]
+	if !ok {
+		t.Fatal("missing 'fresh' group")
+	}
+	if fresh.Health != healthUnindexed {
+		t.Errorf("fresh.health: want unindexed, got %q", fresh.Health)
+	}
+	if fresh.Fidelity != nil {
+		t.Errorf("fresh.fidelity: want null, got %v", *fresh.Fidelity)
+	}
+	if fresh.IndexedAt != nil {
+		t.Errorf("fresh.indexedAt: want null, got %v", *fresh.IndexedAt)
+	}
+	if fresh.Repos == nil {
+		t.Error("fresh.repos: want [] not null")
+	}
+}
+
+// TestV2Groups_EmptyRegistry verifies an empty registry returns an empty data
+// array (not null), so the Landing empty state renders.
+func TestV2Groups_EmptyRegistry(t *testing.T) {
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	var body struct {
+		OK   bool            `json:"ok"`
+		Data []decodeV2Group `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Error("ok: want true")
+	}
+	if body.Data == nil {
+		t.Error("data: want [] not null")
+	}
+	if len(body.Data) != 0 {
+		t.Errorf("data: want empty, got %d", len(body.Data))
+	}
+}
+
+// TestV2CreateGroup creates a group via POST /api/v2/groups and confirms the
+// returned envelope + that it then appears in the list.
+func TestV2CreateGroup(t *testing.T) {
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	reqBody := bytes.NewBufferString(`{"name":"newgroup"}`)
+	resp, err := http.Post(ts.URL+"/api/v2/groups", "application/json", reqBody)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		t.Fatalf("want 201, got %d", resp.StatusCode)
+	}
+
+	var body struct {
+		OK   bool          `json:"ok"`
+		Data decodeV2Group `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Error("ok: want true")
+	}
+	if body.Data.Name != "newgroup" {
+		t.Errorf("name: want newgroup, got %q", body.Data.Name)
+	}
+	if body.Data.Health != healthUnindexed {
+		t.Errorf("health: want unindexed, got %q", body.Data.Health)
+	}
+}
+
+// TestV2CreateGroup_BadRequest verifies an empty name yields a v2 error.
+func TestV2CreateGroup_BadRequest(t *testing.T) {
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	resp, err := http.Post(ts.URL+"/api/v2/groups", "application/json", bytes.NewBufferString(`{"name":""}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("want 400, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK    bool `json:"ok"`
+		Error struct {
+			Code string `json:"code"`
+		} `json:"error"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body.OK {
+		t.Error("ok: want false")
+	}
+	if body.Error.Code != "bad_request" {
+		t.Errorf("error.code: want bad_request, got %q", body.Error.Code)
+	}
+}

--- a/webui-v2/src/components/chrome/landing-top-bar.tsx
+++ b/webui-v2/src/components/chrome/landing-top-bar.tsx
@@ -1,0 +1,92 @@
+/* ============================================================
+   LandingTopBar — minimal top bar for the Landing screen (no group
+   context, so no breadcrumb / NavRail). Logo + wordmark on the left;
+   theme toggle + info popover on the right.
+
+   Built from primitives (Popover, Button) + the appearance store.
+   ============================================================ */
+
+import { Moon, Sun, Info, ExternalLink } from "lucide-react";
+import { Popover, PopoverTrigger, PopoverContent } from "@/components/ui";
+import { useAppStore } from "@/store/use-app-store";
+
+function Wordmark() {
+  return (
+    <div className="flex items-center gap-2">
+      <svg viewBox="0 0 24 24" width="22" height="22" aria-hidden>
+        <defs>
+          <linearGradient id="ag-lp-mark" x1="0" x2="1" y1="0" y2="1">
+            <stop offset="0" stopColor="var(--accent)" />
+            <stop offset="1" stopColor="var(--accent-strong)" />
+          </linearGradient>
+        </defs>
+        <circle cx="6" cy="6" r="2.6" fill="url(#ag-lp-mark)" />
+        <circle cx="18" cy="6" r="2.0" fill="var(--accent)" opacity=".7" />
+        <circle cx="12" cy="18" r="2.6" fill="var(--accent-strong)" />
+        <path d="M7.6 7.6l3 8M16 7.6l-3 8M8 6h8" stroke="var(--accent)" strokeWidth="1.4" fill="none" />
+      </svg>
+      <span className="font-mono text-md font-semibold text-text">archigraph</span>
+    </div>
+  );
+}
+
+const iconBtn =
+  "inline-flex items-center justify-center size-8 rounded-md text-text-3 " +
+  "hover:bg-surface-2 hover:text-text transition-colors " +
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]";
+
+export interface LandingTopBarProps {
+  /** Daemon version string for the info popover (from /api/v2/meta). */
+  version?: string;
+}
+
+export function LandingTopBar({ version }: LandingTopBarProps) {
+  const theme = useAppStore((s) => s.theme);
+  const toggleTheme = useAppStore((s) => s.toggleTheme);
+
+  return (
+    <header className="flex items-center justify-between h-16 shrink-0 px-6 border-b border-border bg-bg">
+      <Wordmark />
+      <div className="flex items-center gap-1">
+        <button
+          type="button"
+          className={iconBtn}
+          onClick={toggleTheme}
+          title={theme === "dark" ? "Light mode" : "Dark mode"}
+          aria-label={theme === "dark" ? "Switch to light mode" : "Switch to dark mode"}
+        >
+          {theme === "dark" ? <Sun size={15} /> : <Moon size={15} />}
+        </button>
+
+        <Popover>
+          <PopoverTrigger asChild>
+            <button type="button" className={iconBtn} title="About archigraph" aria-label="About archigraph">
+              <Info size={15} />
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="end" className="w-64">
+            <div className="flex items-center justify-between">
+              <span className="font-semibold text-text">archigraph</span>
+              <span className="font-mono text-sm text-text-3">{version ?? "—"}</span>
+            </div>
+            <dl className="mt-3 space-y-1.5 text-sm">
+              <div className="flex items-center justify-between">
+                <dt className="text-text-3">Dashboard</dt>
+                <dd className="font-mono text-text-2">{window.location.host}</dd>
+              </div>
+            </dl>
+            <a
+              href="https://github.com/cajasmota/archigraph"
+              target="_blank"
+              rel="noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 text-sm text-accent-strong hover:underline"
+            >
+              <ExternalLink size={12} />
+              View on GitHub
+            </a>
+          </PopoverContent>
+        </Popover>
+      </div>
+    </header>
+  );
+}

--- a/webui-v2/src/components/viz/constellation.tsx
+++ b/webui-v2/src/components/viz/constellation.tsx
@@ -1,0 +1,123 @@
+/* ============================================================
+   Constellation — deterministic mini star-field that hints at a
+   group's graph structure. Pure presentational; seeded so the same
+   group always renders the same dots. Tokens only (pastel scale).
+
+   Lives in the component lib (viz layer) so any screen that wants a
+   decorative graph thumbnail can reuse it. No business logic.
+   ============================================================ */
+
+const PASTELS = [
+  "--pastel-1",
+  "--pastel-2",
+  "--pastel-3",
+  "--pastel-5",
+  "--pastel-7",
+  "--pastel-9",
+];
+
+/** Deterministic LCG so a seed always yields the same field. */
+function seededRand(seed: number): () => number {
+  let s = seed || 1;
+  return () => {
+    s = (s * 9301 + 49297) % 233280;
+    return s / 233280;
+  };
+}
+
+interface Node {
+  x: number;
+  y: number;
+  r: number;
+  color: string;
+}
+
+function generate(seed: number, paletteSize: number, count = 38) {
+  const rng = seededRand(seed);
+  const clusters = Math.max(1, paletteSize);
+  const nodes: Node[] = [];
+  for (let c = 0; c < clusters; c++) {
+    const cx = 0.18 + rng() * 0.64;
+    const cy = 0.18 + rng() * 0.64;
+    const nPer = Math.floor(count / clusters) + (c === 0 ? count % clusters : 0);
+    for (let i = 0; i < nPer; i++) {
+      const ang = rng() * Math.PI * 2;
+      const rad = rng() ** 1.5 * 0.13;
+      nodes.push({
+        x: cx + Math.cos(ang) * rad,
+        y: cy + Math.sin(ang) * rad,
+        r: 1.5 + rng() * 2,
+        color: PASTELS[c % PASTELS.length],
+      });
+    }
+  }
+  const edges: Array<[number, number]> = [];
+  for (let i = 0; i < nodes.length; i++) {
+    if (rng() < 0.55) {
+      const j = Math.floor(rng() * nodes.length);
+      if (j !== i) {
+        const dx = nodes[i].x - nodes[j].x;
+        const dy = nodes[i].y - nodes[j].y;
+        if (Math.sqrt(dx * dx + dy * dy) < 0.18) edges.push([i, j]);
+      }
+    }
+  }
+  return { nodes, edges };
+}
+
+export interface ConstellationProps {
+  /** Stable seed — same seed → same field. */
+  seed: number;
+  /** Number of pastel clusters (1–6). */
+  clusters?: number;
+  /** Render the "nothing indexed yet" dashed-circle variant. */
+  empty?: boolean;
+  className?: string;
+}
+
+export function Constellation({ seed, clusters = 4, empty, className }: ConstellationProps) {
+  if (empty) {
+    return (
+      <svg
+        viewBox="0 0 100 100"
+        preserveAspectRatio="none"
+        className={className}
+        aria-hidden
+      >
+        <g stroke="var(--text-4)" strokeDasharray="2 3" fill="none" opacity="0.5">
+          <circle cx="50" cy="50" r="22" />
+        </g>
+        <circle cx="50" cy="50" r="2.4" fill="var(--text-4)" />
+      </svg>
+    );
+  }
+
+  const { nodes, edges } = generate(seed, clusters);
+  return (
+    <svg viewBox="0 0 100 100" preserveAspectRatio="none" className={className} aria-hidden>
+      <g stroke="var(--border-strong)" strokeWidth="0.3" fill="none" opacity="0.6">
+        {edges.map(([i, j], k) => (
+          <line
+            key={k}
+            x1={nodes[i].x * 100}
+            y1={nodes[i].y * 100}
+            x2={nodes[j].x * 100}
+            y2={nodes[j].y * 100}
+          />
+        ))}
+      </g>
+      <g>
+        {nodes.map((n, k) => (
+          <circle key={k} cx={n.x * 100} cy={n.y * 100} r={n.r * 0.7} fill={`var(${n.color})`} />
+        ))}
+      </g>
+    </svg>
+  );
+}
+
+/** Stable seed from a group slug (so backend needn't return a seed field). */
+export function seedFromString(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = (h * 31 + s.charCodeAt(i)) % 233280;
+  return h || 7;
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -41,11 +41,22 @@ export interface Entity {
   outbound: number;
 }
 
+/** Derived health state for a group (computed server-side in v2_groups.go). */
+export type GroupHealth = "healthy" | "warning" | "unindexed";
+
 export interface Group {
+  /** Slug — also the route param. */
   id: string;
   name: string;
-  repoCount: number;
+  /** Top-level repo slugs. */
+  repos: string[];
   entityCount: number;
-  /** Health metric, 0–100. High = good (replaces legacy "bug-rate"). */
-  fidelity: number;
+  /**
+   * Confidence the graph matches the codebase, 0–1. `null` when the group
+   * has never been indexed. (Replaces the legacy "bug-rate".)
+   */
+  fidelity: number | null;
+  /** ms epoch of the most-recent index across repos; `null` when never indexed. */
+  indexedAt: number | null;
+  health: GroupHealth;
 }

--- a/webui-v2/src/hooks/use-groups.ts
+++ b/webui-v2/src/hooks/use-groups.ts
@@ -1,0 +1,34 @@
+/* ============================================================
+   hooks/use-groups.ts — Landing-screen data hooks.
+
+   Wraps the typed api client (the only network door) in TanStack
+   Query. Screens never call api.* directly outside hooks.
+   ============================================================ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { Group } from "@/data/types";
+
+export const groupsQueryKey = ["groups"] as const;
+
+/** The rich group list that drives the Landing cards grid. */
+export function useGroups() {
+  return useQuery({
+    queryKey: groupsQueryKey,
+    queryFn: () => api.listGroups(),
+  });
+}
+
+/** Create-group mutation; invalidates the list so the new card appears. */
+export function useCreateGroup() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (name: string) => api.createGroup(name),
+    onSuccess: (created: Group) => {
+      qc.setQueryData<Group[]>(groupsQueryKey, (prev) =>
+        prev ? [...prev, created] : [created],
+      );
+      void qc.invalidateQueries({ queryKey: groupsQueryKey });
+    },
+  });
+}

--- a/webui-v2/src/hooks/use-meta.ts
+++ b/webui-v2/src/hooks/use-meta.ts
@@ -1,0 +1,17 @@
+/* ============================================================
+   hooks/use-meta.ts — daemon bootstrap (/api/v2/meta).
+
+   Fetched once on mount; supplies the daemon version for the Landing
+   info popover. staleTime: Infinity per the API_V2 contract.
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+
+export function useMeta() {
+  return useQuery({
+    queryKey: ["meta"],
+    staleTime: Infinity,
+    queryFn: () => api.getMeta(),
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -12,11 +12,14 @@
 import type { Group, Entity, Community } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
+const BASE_V2 = import.meta.env.VITE_AG_API_BASE_V2 ?? "/api/v2";
 
 export class ApiError extends Error {
   constructor(
     public status: number,
     message: string,
+    /** Machine-readable code from a v2 error envelope, when present. */
+    public code?: string,
   ) {
     super(message);
     this.name = "ApiError";
@@ -34,12 +37,60 @@ async function request<T>(path: string, init?: RequestInit): Promise<T> {
   return (await res.json()) as T;
 }
 
+/* ------------------------------------------------------------------ *
+ * v2 envelope helpers — every /api/v2 response is wrapped in
+ *   { ok: true, data, pagination? } | { ok: false, error: { code, message } }
+ * (see internal/dashboard/API_V2.md). requestV2 unwraps `data` or throws
+ * a typed ApiError carrying the canonical error code.
+ * ------------------------------------------------------------------ */
+
+interface V2Ok<T> {
+  ok: true;
+  data: T;
+  pagination?: { limit: number; offset: number; total: number };
+}
+interface V2Err {
+  ok: false;
+  error: { code: string; message: string };
+}
+
+async function requestV2<T>(path: string, init?: RequestInit): Promise<T> {
+  const res = await fetch(`${BASE_V2}${path}`, {
+    headers: { "Content-Type": "application/json", ...init?.headers },
+    ...init,
+  });
+  let body: V2Ok<T> | V2Err;
+  try {
+    body = (await res.json()) as V2Ok<T> | V2Err;
+  } catch {
+    throw new ApiError(res.status, `${init?.method ?? "GET"} ${path} failed: ${res.status}`);
+  }
+  if (!body.ok) {
+    throw new ApiError(res.status, body.error.message, body.error.code);
+  }
+  return body.data;
+}
+
 /**
  * The typed surface of the daemon. Screen tickets add methods here as
  * they need them; nothing else in the app issues network calls.
  */
+export interface Meta {
+  version: string;
+  api_versions: string[];
+  groups: string[];
+}
+
 export const api = {
-  listGroups: () => request<Group[]>("/groups"),
+  /** v2 — daemon bootstrap: version, supported surfaces, group slugs. */
+  getMeta: () => requestV2<Meta>("/meta"),
+  /** v2 — rich group list for the Landing screen. */
+  listGroups: () => requestV2<Group[]>("/groups"),
+  /** v2 — create an empty group from a name (Landing wizard). */
+  createGroup: (name: string) =>
+    requestV2<Group>("/groups", { method: "POST", body: JSON.stringify({ name }) }),
+
+  // --- v1 surfaces still used by other (placeholder) screens ---
   getGroup: (groupId: string) => request<Group>(`/groups/${groupId}`),
   listCommunities: (groupId: string) => request<Community[]>(`/groups/${groupId}/communities`),
   searchEntities: (groupId: string, q: string) =>

--- a/webui-v2/src/routes/landing.tsx
+++ b/webui-v2/src/routes/landing.tsx
@@ -1,48 +1,450 @@
 /* ============================================================
-   Landing — group selector + create-group wizard + empty state.
-   The entry point; renders WITHOUT the in-group chrome.
-   Scaffold only — real group cards + wizard land in the landing ticket.
+   Landing — group selector + create-group + empty state.
+
+   The entry point at `/`. Renders WITHOUT the in-group chrome
+   (no NavRail / breadcrumb): there's no group context yet. Per
+   docs/screens/landing.md.
+
+   Data: useGroups() (GET /api/v2/groups), useCreateGroup()
+   (POST /api/v2/groups), useMeta() (daemon version for the popover).
    ============================================================ */
 
-import { Link } from "react-router-dom";
-import { Card, CardBody, Button, Badge } from "@/components/ui";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { ArrowRight, Plus, MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
 
-const DEMO_GROUPS = [
-  { id: "demo", name: "demo", repos: 3, entities: 20717, fidelity: 88 },
-];
+import { Button, Card, Input, InfoLabel, Kbd } from "@/components/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui";
+import { LandingTopBar } from "@/components/chrome/landing-top-bar";
+import { Constellation, seedFromString } from "@/components/viz/constellation";
+import { useGroups, useCreateGroup } from "@/hooks/use-groups";
+import { useMeta } from "@/hooks/use-meta";
+import { ApiError } from "@/lib/api";
+import type { Group, GroupHealth } from "@/data/types";
+import { cn } from "@/lib/utils";
+
+/* ---------- helpers ---------- */
+
+const HEALTH: Record<GroupHealth, { label: string; dot: string }> = {
+  healthy: { label: "Healthy", dot: "var(--success)" },
+  warning: { label: "Low fidelity", dot: "var(--warning)" },
+  unindexed: { label: "Not indexed", dot: "var(--text-4)" },
+};
+
+function fidelityColor(f: number | null): string {
+  if (f == null) return "var(--text-4)";
+  if (f >= 0.8) return "var(--success)";
+  if (f >= 0.5) return "var(--warning)";
+  return "var(--danger)";
+}
+
+function relativeTime(ms: number | null): string {
+  if (!ms) return "never indexed";
+  const diff = Date.now() - ms;
+  const min = Math.floor(diff / 60000);
+  if (min < 1) return "just now";
+  if (min < 60) return `${min}m ago`;
+  const hr = Math.floor(min / 60);
+  if (hr < 24) return `${hr}h ago`;
+  const day = Math.floor(hr / 24);
+  if (day < 7) return `${day}d ago`;
+  return `${Math.floor(day / 7)}w ago`;
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/* ---------- info tips ---------- */
+
+const ENTITIES_TIP =
+  "Every function, class, hook, component, endpoint and module archigraph extracted — the nodes of the graph.";
+const REPOS_TIP =
+  "Top-level git repositories in this group. Monorepos count as one; open the group to see sub-packages.";
+const FIDELITY_TIP =
+  "Confidence that the graph matches your codebase. Drops with stale, orphaned, or low-confidence entities.";
+
+/* ---------- group card ---------- */
+
+function GroupCard({ group, onPick, onManage }: { group: Group; onPick: () => void; onManage: () => void }) {
+  const isEmpty = group.health === "unindexed";
+  const health = HEALTH[group.health];
+
+  return (
+    <Card className="group relative p-0 overflow-hidden text-left transition-all duration-150 hover:-translate-y-0.5 hover:shadow-[var(--shadow-3)] focus-within:-translate-y-0.5">
+      <button
+        type="button"
+        onClick={onPick}
+        className="block w-full text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] rounded-lg"
+        data-testid={`group-card-${group.id}`}
+      >
+        {/* viz band */}
+        <div className="relative h-[92px] bg-bg-soft border-b border-border-soft">
+          <Constellation
+            seed={seedFromString(group.id)}
+            clusters={Math.min(6, Math.max(2, group.repos.length || 2))}
+            empty={isEmpty}
+            className="h-full w-full"
+          />
+        </div>
+
+        {/* body */}
+        <div className="p-4">
+          <div className="flex items-center gap-2">
+            <span
+              className="size-2 rounded-full shrink-0"
+              style={{ background: health.dot }}
+              title={health.label}
+              aria-label={health.label}
+            />
+            <span className="font-mono font-semibold text-text truncate">{group.name}</span>
+            <span className="ml-auto text-sm text-text-4 whitespace-nowrap">
+              {relativeTime(group.indexedAt)}
+            </span>
+          </div>
+
+          {isEmpty ? (
+            <div className="mt-3">
+              <p className="text-sm text-text-3">No entities indexed yet.</p>
+              <span className="mt-2 inline-flex items-center gap-1 text-md font-medium text-accent-strong">
+                Index this group
+                <ArrowRight size={12} />
+              </span>
+            </div>
+          ) : (
+            <>
+              <dl className="mt-3 grid grid-cols-3 gap-2">
+                <div>
+                  <dt className="text-xs text-text-3">
+                    <InfoLabel label="Entities" hint={ENTITIES_TIP} />
+                  </dt>
+                  <dd className="font-mono text-lg font-semibold text-text tabular-nums">
+                    {group.entityCount.toLocaleString()}
+                  </dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-text-3">
+                    <InfoLabel label="Repos" hint={REPOS_TIP} />
+                  </dt>
+                  <dd className="font-mono text-lg text-text-2 tabular-nums">{group.repos.length}</dd>
+                </div>
+                <div>
+                  <dt className="text-xs text-text-3">
+                    <InfoLabel label="Fidelity" hint={FIDELITY_TIP} />
+                  </dt>
+                  <dd
+                    className="font-mono text-lg tabular-nums"
+                    style={{ color: fidelityColor(group.fidelity) }}
+                  >
+                    {group.fidelity == null ? "—" : `${Math.round(group.fidelity * 100)}%`}
+                  </dd>
+                </div>
+              </dl>
+
+              {group.repos.length > 0 && (
+                <div className="mt-3 flex flex-wrap gap-1.5">
+                  {group.repos.slice(0, 3).map((r) => (
+                    <span
+                      key={r}
+                      className="inline-flex items-center h-5 px-2 rounded-full bg-surface-2 border border-border text-xs font-mono text-text-2"
+                    >
+                      {r}
+                    </span>
+                  ))}
+                  {group.repos.length > 3 && (
+                    <span className="inline-flex items-center h-5 px-2 rounded-full bg-surface-2 border border-border text-xs text-text-3">
+                      +{group.repos.length - 3}
+                    </span>
+                  )}
+                </div>
+              )}
+            </>
+          )}
+        </div>
+      </button>
+
+      {/* manage kebab — focusable for keyboard users, not just hover */}
+      {!isEmpty && (
+        <button
+          type="button"
+          onClick={onManage}
+          title="Group settings"
+          aria-label={`Settings for ${group.name}`}
+          className={cn(
+            "absolute right-2 top-2 inline-flex items-center justify-center size-7 rounded-md",
+            "bg-overlay text-text-3 opacity-0 transition-opacity",
+            "hover:bg-surface-2 hover:text-text",
+            "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)] focus-visible:opacity-100",
+            "group-hover:opacity-100",
+          )}
+          style={{ background: "var(--overlay)" }}
+        >
+          <MoreHorizontal size={15} />
+        </button>
+      )}
+    </Card>
+  );
+}
+
+/* ---------- add-group tile ---------- */
+
+function AddGroupCard({ onClick }: { onClick: () => void }) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid="add-group"
+      className={cn(
+        "min-h-[200px] rounded-lg border border-dashed border-border-strong bg-transparent",
+        "grid place-items-center text-center transition-colors",
+        "hover:border-accent hover:bg-accent-soft/30",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]",
+      )}
+    >
+      <div className="flex flex-col items-center gap-2 px-4">
+        <span className="inline-flex items-center justify-center size-10 rounded-full border border-border-strong text-text-3">
+          <Plus size={22} />
+        </span>
+        <span className="text-md font-medium text-text-2">Add a group</span>
+        <span className="text-sm text-text-4">Point archigraph at one or more repos</span>
+      </div>
+    </button>
+  );
+}
+
+/* ---------- empty state ---------- */
+
+function EmptyArt() {
+  return (
+    <svg viewBox="0 0 200 120" width="200" height="120" aria-hidden>
+      <defs>
+        <linearGradient id="ag-empty" x1="0" x2="1" y1="0" y2="1">
+          <stop offset="0" stopColor="var(--accent)" stopOpacity="0.6" />
+          <stop offset="1" stopColor="var(--accent-strong)" stopOpacity="0.95" />
+        </linearGradient>
+      </defs>
+      <g stroke="var(--border)" strokeWidth="0.6" fill="none">
+        <line x1="60" y1="40" x2="80" y2="60" />
+        <line x1="80" y1="60" x2="100" y2="46" />
+        <line x1="100" y1="46" x2="118" y2="62" />
+        <line x1="118" y1="62" x2="138" y2="50" />
+        <line x1="80" y1="60" x2="98" y2="82" />
+        <line x1="98" y1="82" x2="118" y2="62" />
+      </g>
+      <g>
+        <circle cx="60" cy="40" r="3" fill="var(--pastel-1)" />
+        <circle cx="80" cy="60" r="3.4" fill="var(--pastel-5)" />
+        <circle cx="100" cy="46" r="3" fill="var(--pastel-2)" />
+        <circle cx="118" cy="62" r="3.8" fill="url(#ag-empty)" />
+        <circle cx="138" cy="50" r="3" fill="var(--pastel-3)" />
+        <circle cx="98" cy="82" r="3" fill="var(--pastel-7)" />
+      </g>
+    </svg>
+  );
+}
+
+function EmptyState({ onCreate }: { onCreate: () => void }) {
+  return (
+    <section className="flex flex-col items-center text-center py-20">
+      <EmptyArt />
+      <h1 className="mt-6 text-2xl font-semibold text-text">Index your first group.</h1>
+      <p className="mt-2 max-w-md text-md text-text-3">
+        Point archigraph at one or more repositories to build a queryable graph of every function,
+        class, endpoint, and the edges between them.
+      </p>
+      <div className="mt-6 flex flex-wrap items-center justify-center gap-3">
+        <Button onClick={onCreate} className="gap-2">
+          Create your first group
+          <ArrowRight size={14} />
+        </Button>
+        <Button
+          variant="ghost"
+          onClick={() => toast.info("Joining a teammate's group isn't wired yet.")}
+        >
+          Join a teammate's group
+        </Button>
+      </div>
+      <button
+        type="button"
+        onClick={() => toast.info("Re-scanning ~/.config/archigraph isn't wired yet.")}
+        className="mt-5 text-sm text-text-4 hover:text-text-2"
+      >
+        Already configured via CLI? Re-scan local groups →
+      </button>
+    </section>
+  );
+}
+
+/* ---------- create-group modal ---------- */
+
+function CreateGroupModal({
+  open,
+  onOpenChange,
+  takenNames,
+}: {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  takenNames: string[];
+}) {
+  const [name, setName] = useState("");
+  const create = useCreateGroup();
+  const slug = slugify(name);
+  const duplicate = takenNames.includes(slug);
+  const valid = slug.length > 0 && !duplicate;
+
+  function reset() {
+    setName("");
+    create.reset();
+  }
+
+  async function submit() {
+    if (!valid) return;
+    try {
+      const g = await create.mutateAsync(slug);
+      toast.success(`Group “${g.name}” created.`);
+      reset();
+      onOpenChange(false);
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : "Failed to create group.";
+      toast.error(msg);
+    }
+  }
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        if (!v) reset();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent>
+        <DialogTitle>New group</DialogTitle>
+        <DialogDescription>
+          Name your group. You can add repositories to it afterwards.
+        </DialogDescription>
+
+        <form
+          className="mt-4 space-y-3"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void submit();
+          }}
+        >
+          <label className="block">
+            <span className="text-sm text-text-2">Group name</span>
+            <Input
+              autoFocus
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. platform"
+              className="mt-1.5"
+            />
+          </label>
+
+          {slug && (
+            <p className="text-sm text-text-3">
+              Config:{" "}
+              <span className="font-mono text-text-2">~/.config/archigraph/{slug}.fleet.json</span>
+            </p>
+          )}
+          {duplicate && (
+            <p className="text-sm text-danger">A group named “{slug}” already exists.</p>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button type="submit" disabled={!valid || create.isPending}>
+              {create.isPending ? "Creating…" : "Create group"}
+            </Button>
+          </div>
+        </form>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+/* ---------- screen ---------- */
 
 export default function Landing() {
+  const navigate = useNavigate();
+  const { data: groups, isLoading, isError } = useGroups();
+  const { data: meta } = useMeta();
+  const [wizardOpen, setWizardOpen] = useState(false);
+
+  const list = groups ?? [];
+  const takenNames = list.map((g) => g.id);
+
+  function pick(g: Group) {
+    if (g.health === "unindexed") {
+      toast.info(`“${g.name}” has no indexed entities yet — onboarding flow is not wired.`);
+      return;
+    }
+    navigate(`/g/${g.id}/graph`);
+  }
+
   return (
-    <div className="h-full ag-scroll bg-bg">
-      <div className="mx-auto max-w-4xl px-6 py-12">
-        <h1 className="text-3xl font-semibold text-text">Your groups</h1>
-        <p className="mt-1 text-md text-text-3">Pick a group to explore its knowledge graph, or create a new one.</p>
+    <div className="flex flex-col h-full bg-bg">
+      <LandingTopBar version={meta?.version} />
 
-        <div className="mt-8 grid grid-cols-1 sm:grid-cols-2 gap-4">
-          {DEMO_GROUPS.map((g) => (
-            <Link key={g.id} to={`/g/${g.id}/graph`} className="block">
-              <Card className="hover:shadow-[var(--shadow-2)] transition-shadow">
-                <CardBody>
-                  <div className="flex items-center justify-between">
-                    <span className="font-mono text-md text-text">{g.name}</span>
-                    <Badge tone={g.fidelity >= 80 ? "success" : g.fidelity >= 50 ? "warning" : "danger"}>
-                      {g.fidelity}% fidelity
-                    </Badge>
-                  </div>
-                  <div className="mt-3 flex gap-4 text-sm text-text-3 tabular-nums">
-                    <span>{g.repos} repos</span>
-                    <span>{g.entities.toLocaleString()} entities</span>
-                  </div>
-                </CardBody>
-              </Card>
-            </Link>
-          ))}
+      <main className="flex-1 min-h-0 ag-scroll">
+        <div className="mx-auto w-full max-w-[1080px] px-6 py-12">
+          {isError ? (
+            <div className="py-20 text-center">
+              <h1 className="text-xl font-semibold text-text">Couldn't reach the daemon.</h1>
+              <p className="mt-2 text-md text-text-3">
+                Make sure archigraph is running, then reload.
+              </p>
+            </div>
+          ) : isLoading ? (
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+              {[0, 1, 2].map((i) => (
+                <Card key={i} className="h-[200px] animate-pulse bg-surface-2" />
+              ))}
+            </div>
+          ) : list.length === 0 ? (
+            <EmptyState onCreate={() => setWizardOpen(true)} />
+          ) : (
+            <>
+              <header className="mb-8">
+                <h1 className="text-2xl font-semibold text-text">Pick a group to explore.</h1>
+                <p className="mt-1 text-md text-text-3">
+                  Each group is a constellation of repos indexed into a single dependency graph.
+                </p>
+              </header>
 
-          <Card className="border-dashed grid place-items-center min-h-[120px]">
-            <Button variant="secondary">+ Create group</Button>
-          </Card>
+              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+                {list.map((g) => (
+                  <GroupCard
+                    key={g.id}
+                    group={g}
+                    onPick={() => pick(g)}
+                    onManage={() => navigate(`/g/${g.id}/settings`)}
+                  />
+                ))}
+                <AddGroupCard onClick={() => setWizardOpen(true)} />
+              </div>
+
+              <footer className="mt-10 flex items-center justify-center gap-1.5 text-sm text-text-4">
+                <span>Tip: press</span>
+                <Kbd>⌘</Kbd>
+                <Kbd>K</Kbd>
+                <span>to open the command palette anywhere in archigraph.</span>
+              </footer>
+            </>
+          )}
         </div>
-      </div>
+      </main>
+
+      <CreateGroupModal open={wizardOpen} onOpenChange={setWizardOpen} takenNames={takenNames} />
     </div>
   );
 }


### PR DESCRIPTION
Fixes #1435 · part of EPIC #1432.

## 1. What & why
Implements the WebUI v2 **Landing** screen (route `/`) per `docs/screens/landing.md`, built inside the merged `webui-v2/` app following `ARCHITECTURE.md`'s Lego layering. Landing is the entry point: pick a group to explore, create a new one, or see the empty/fresh-install state. It renders without the in-group chrome (no NavRail/breadcrumb) since there's no group context yet.

## 2. Data decision (per the contract's "agent latitude")
`/api/v2/meta` returns only group **slugs** — not enough for the Landing cards (entity counts, repos, fidelity, last-indexed, health). **I added a v2 endpoint** rather than stub, because the registry store already aggregates the rich data:

- `GET /api/v2/groups` — paginated rich `Group` list. `health` + `fidelity` are derived **server-side** in `deriveGroupHealth` (one place for the rules) from the existing `GroupSummary` aggregation (entity counts + last-indexed sidecars).
- `POST /api/v2/groups` — create an **empty** group from a name; ports the v1 registry `CreateGroup` path (same logic the v1 admin/onboard handlers use).

**Documented gaps** (intentionally out of scope, all surface a toast/info rather than silently failing):
- Full repo-scan wizard (`POST /api/scan-dir`, monorepo detection, indexing SSE) — create-group makes the group; repo discovery is a separate flow. New group reports `health: "unindexed"`.
- "Join a teammate's group", "Re-scan local groups", and the unindexed-group onboarding route are not yet designed (landing.md open questions) → info toasts.
- The daemon does not yet persist a real per-group fidelity score, so indexed groups currently report `fidelity: 1.0` / `healthy`. The wire contract is stable; a real score slots straight into `deriveGroupHealth`. (Mock data in screenshots shows the warning/danger color coding the UI supports.)

## 3. How (implementation)
**Backend** (`internal/dashboard/`): `v2_groups.go` (handlers + health derivation), `v2_groups_test.go`, routes registered in `server.go` under the v2 block, contract documented in `API_V2.md` §6a. Uses `v2OK`/`v2Page`/`writeV2Err` per the v2 envelope.

**Frontend** (`webui-v2/` only):
- `routes/landing.tsx` — hero, 3-up cards grid (breakpoints per spec), GroupCard (constellation viz, status dot, Entities/Repos/Fidelity stats w/ `InfoLabel` tooltips, repo chips +N, focusable manage kebab → settings), unindexed card variant, AddGroupCard, EmptyState, ⌘K footer, create-group modal (Dialog primitive).
- New reusable primitives: `components/viz/constellation.tsx` (seeded deterministic SVG field) and `components/chrome/landing-top-bar.tsx`.
- Hooks layer: `use-groups.ts` (list + create mutation w/ optimistic update + invalidation), `use-meta.ts`. `lib/api.ts` gains a v2-envelope unwrapper (`requestV2`, typed `ApiError.code`); `data/types.ts` `Group` extended (repos[], fidelity\|null, indexedAt\|null, health).

## 4. Testing / verification
- `npm run build` (tsc strict + vite) — clean.
- `go test ./internal/dashboard -run V2` — green (new tests cover rich shape, empty registry → `[]`, create, bad-request). Note: a pre-existing unrelated `TestYamlScalar` fails on clean `origin/main` too; not touched here.
- Playwright screenshots (isolated dev port 47280 against a mock daemon — live `:47274` untouched): populated light+dark, empty light+dark, create-group modal. Create flow verified end-to-end (POST → new card appears).

## 5. Scope / safety
- `dashboard/` is **completely untouched** (zero diff). Changes are confined to `webui-v2/` + the new v2 backend files.
- v1 routes unchanged; v2 additions coexist.

## 6. Follow-ups
- Fix the shared `Button` primitive: `bg-accent` renders transparent for primary buttons app-wide (reproduces on `/showcase`'s own Primary button — pre-existing scaffold bug, not introduced here). Landing uses the `<Button>` primitive, so it corrects itself once fixed.
- Wire the full create-group wizard (repo scan + indexing SSE), unindexed-group onboarding, and the "join/re-scan" flows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)