### PR TITLE
fix(links): skip cross-bucket consumer collision in byPath expansion

### DIFF
--- a/cmd/archigraph/xrepo_verify.go
+++ b/cmd/archigraph/xrepo_verify.go
@@ -10,12 +10,16 @@ package main
 // Not part of the public command surface; invoked only during verification:
 //
 //	archigraph xrepo-verify <group> <slug>=<path> [<slug>=<path> ...]
+//
+// Extended in #1445 to also accept --diagnose which dumps sample orphan
+// consumer call → nearest producer-endpoint pairs for gap analysis.
 
 import (
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 
@@ -23,9 +27,25 @@ import (
 	"github.com/cajasmota/archigraph/internal/links"
 )
 
+// pathParamDiagRe normalises path-param placeholders to {*} for diagnostic
+// output only — mirrors the normalisation done inside http_pass.go.
+var pathParamDiagRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*|<[^>]+>`)
+
 func runXRepoVerify(args []string) int {
+	// Check for --diagnose flag.
+	diagnose := false
+	filtered := args[:0]
+	for _, a := range args {
+		if a == "--diagnose" {
+			diagnose = true
+		} else {
+			filtered = append(filtered, a)
+		}
+	}
+	args = filtered
+
 	if len(args) < 3 {
-		fmt.Fprintln(os.Stderr, "usage: archigraph xrepo-verify <group> <slug>=<path> [<slug>=<path> ...]")
+		fmt.Fprintln(os.Stderr, "usage: archigraph xrepo-verify [--diagnose] <group> <slug>=<path> [<slug>=<path> ...]")
 		return 2
 	}
 	group := args[0]
@@ -104,6 +124,10 @@ func runXRepoVerify(args []string) int {
 	fmt.Printf("\nproducer-side endpoint synthetics (total): %d\n", prodTotal)
 	fmt.Printf("consumer-side call synthetics (total):     %d\n", consTotal)
 	fmt.Printf("orphan consumer calls (no cross-repo link): %d\n", orphanConsumers)
+
+	if diagnose {
+		diagnoseOrphans(tmpGraphs, linkedSources)
+	}
 
 	return 0
 }
@@ -250,4 +274,334 @@ func analyzeCoverage(graphsDir string, linkedSources map[string]bool) (map[strin
 func isHTTPEndpointKind(kind string) bool {
 	k := strings.ToLower(kind)
 	return strings.Contains(k, "http_endpoint")
+}
+
+// normPathDiag mirrors the normalisation in http_pass.go for diagnostic purposes.
+func normPathDiag(path string) string {
+	path = pathParamDiagRe.ReplaceAllString(path, "{*}")
+	path = strings.ToLower(path)
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+	return path
+}
+
+// apiPrefixDiagRe matches the well-known /api[/vN] or /vN prefix (diagnostic).
+var apiPrefixDiagRe = regexp.MustCompile(`^/(?:api(?:/v\d+)?|v\d+)(/|$)`)
+
+// stripAPIPrefixDiag removes a leading API/version prefix (diagnostic mirror of http_pass).
+func stripAPIPrefixDiag(p string) (string, bool) {
+	m := apiPrefixDiagRe.FindStringSubmatchIndex(p)
+	if m == nil {
+		return "", false
+	}
+	s := p[m[2]:]
+	if s == "" {
+		s = "/"
+	}
+	return s, s != p
+}
+
+// orphanRecord holds information about an orphan consumer call.
+type orphanRecord struct {
+	repo          string
+	verb          string
+	path          string
+	name          string
+	framework     string
+	urlPrefix     string
+	callerEntity  string
+}
+
+// diagnoseOrphans dumps orphan consumer calls with nearest producer candidates.
+// It shows the normalised path of the consumer and the closest producer paths
+// so we can see exactly what form of mismatch is causing the miss.
+func diagnoseOrphans(graphsDir string, linkedSources map[string]bool) {
+	// Collect all producer endpoints keyed by repo.
+	type producerEp struct {
+		repo      string
+		verb      string
+		path      string
+		normPath  string
+		name      string
+		urlPrefix string
+	}
+	var producers []producerEp
+	var orphans []orphanRecord
+
+	_ = filepath.WalkDir(graphsDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Base(p) != "graph.json" {
+			return nil
+		}
+		doc, err := graph.LoadGraphFromDir(filepath.Dir(p))
+		if err != nil {
+			return nil
+		}
+		repo := doc.Repo
+		if repo == "" {
+			repo = filepath.Base(filepath.Dir(p))
+		}
+
+		type entKey struct{ kind, name, file string }
+		entIDByKey := map[entKey]string{}
+		for _, e := range doc.Entities {
+			if isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			k := entKey{e.Kind, e.Name, e.SourceFile}
+			if _, ok := entIDByKey[k]; !ok {
+				entIDByKey[k] = e.ID
+			}
+		}
+
+		for _, e := range doc.Entities {
+			if !isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			pt := e.Properties["pattern_type"]
+			verb := e.Properties["verb"]
+			path := e.Properties["path"]
+			urlPrefix := e.Properties["url_prefix"]
+			framework := e.Properties["framework"]
+
+			if pt == "http_endpoint_client_synthesis" {
+				// Consumer side — check if orphan.
+				callerID := ""
+				callerName := ""
+				if ref := e.Properties["source_caller"]; ref != "" {
+					if i := strings.IndexByte(ref, ':'); i > 0 {
+						kind, name := ref[:i], ref[i+1:]
+						callerID = entIDByKey[entKey{kind, name, e.SourceFile}]
+						callerName = name
+					}
+				}
+				if callerID == "" {
+					callerID = e.ID
+					callerName = e.Name
+				}
+				if !linkedSources[repo+"::"+callerID] {
+					orphans = append(orphans, orphanRecord{
+						repo:         repo,
+						verb:         verb,
+						path:         path,
+						name:         e.Name,
+						framework:    framework,
+						urlPrefix:    urlPrefix,
+						callerEntity: callerName,
+					})
+				}
+			} else {
+				// Producer side.
+				producers = append(producers, producerEp{
+					repo:      repo,
+					verb:      verb,
+					path:      path,
+					normPath:  normPathDiag(path),
+					name:      e.Name,
+					urlPrefix: urlPrefix,
+				})
+			}
+		}
+		return nil
+	})
+
+	// Build byNorm index for producers: normPath → []producerEp
+	byNorm := map[string][]producerEp{}
+	for _, p := range producers {
+		byNorm[p.normPath] = append(byNorm[p.normPath], p)
+		if s, ok := stripAPIPrefixDiag(p.normPath); ok {
+			byNorm[s] = append(byNorm[s], p)
+		}
+		if p.urlPrefix != "" && strings.HasPrefix(p.path, p.urlPrefix) {
+			stripped := p.path[len(p.urlPrefix):]
+			if stripped == "" {
+				stripped = "/"
+			}
+			sn := normPathDiag(stripped)
+			if sn != p.normPath {
+				byNorm[sn] = append(byNorm[sn], p)
+			}
+		}
+	}
+
+	// Categorise miss reasons.
+	type missReason struct {
+		reason  string
+		consVerb string
+		consPath string
+		prodMatches []string
+	}
+	reasonCounts := map[string]int{}
+	var samples []missReason
+	const maxSamples = 40
+
+	for _, o := range orphans {
+		normCons := normPathDiag(o.path)
+		normStripped, hasStripped := stripAPIPrefixDiag(normCons)
+
+		var matches []producerEp
+		seen := map[string]bool{}
+		for _, n := range []string{normCons, normStripped} {
+			if n == "" {
+				continue
+			}
+			for _, p := range byNorm[n] {
+				k := p.repo + "::" + p.name
+				if !seen[k] {
+					seen[k] = true
+					matches = append(matches, p)
+				}
+			}
+		}
+		_ = hasStripped
+
+		reason := ""
+		var matchDescs []string
+		if len(matches) == 0 {
+			reason = "NO_PATH_MATCH"
+		} else {
+			// Path matches exist — check verb.
+			consVerbUp := strings.ToUpper(o.verb)
+			hasCompatVerb := false
+			for _, m := range matches {
+				mv := strings.ToUpper(m.verb)
+				if mv == consVerbUp || mv == "ANY" || consVerbUp == "ANY" || consVerbUp == "" {
+					hasCompatVerb = true
+				}
+				matchDescs = append(matchDescs, fmt.Sprintf("%s %s:%s", m.repo, m.verb, m.path))
+			}
+			if hasCompatVerb {
+				reason = "PATH_AND_VERB_MATCH_BUT_UNLINKED"
+			} else {
+				reason = "VERB_MISMATCH"
+			}
+		}
+		reasonCounts[reason]++
+		if len(samples) < maxSamples && (reason != "PATH_AND_VERB_MATCH_BUT_UNLINKED" || len(samples) < 10) {
+			samples = append(samples, missReason{
+				reason:      reason,
+				consVerb:    o.verb,
+				consPath:    o.path,
+				prodMatches: matchDescs,
+			})
+		}
+	}
+
+	fmt.Println("\n=== ORPHAN MISS REASON BREAKDOWN ===")
+	reasons := make([]string, 0, len(reasonCounts))
+	for r := range reasonCounts {
+		reasons = append(reasons, r)
+	}
+	sort.Strings(reasons)
+	for _, r := range reasons {
+		fmt.Printf("  %-45s : %d\n", r, reasonCounts[r])
+	}
+
+	fmt.Printf("\n=== SAMPLE ORPHAN CALLS (first %d) ===\n", maxSamples)
+	for i, s := range samples {
+		fmt.Printf("[%d] CONSUMER %s %s (reason=%s)\n", i+1, s.consVerb, s.consPath, s.reason)
+		if len(s.prodMatches) == 0 {
+			fmt.Println("     -> no producer path matches found")
+		} else {
+			for _, m := range s.prodMatches {
+				fmt.Printf("     -> PRODUCER %s\n", m)
+			}
+		}
+	}
+
+	// --- Phase 2: dump all PATH_AND_VERB_MATCH_BUT_UNLINKED with their
+	// consumer properties to understand why the link pass misses them. ---
+	fmt.Println("\n=== PATH_AND_VERB_MATCH_BUT_UNLINKED — full detail ===")
+	_ = filepath.WalkDir(graphsDir, func(p string, d os.DirEntry, err error) error {
+		if err != nil || d.IsDir() || filepath.Base(p) != "graph.json" {
+			return nil
+		}
+		doc, err := graph.LoadGraphFromDir(filepath.Dir(p))
+		if err != nil {
+			return nil
+		}
+		repo := doc.Repo
+		if repo == "" {
+			repo = filepath.Base(filepath.Dir(p))
+		}
+		type entKey struct{ kind, name, file string }
+		entIDByKey := map[entKey]string{}
+		for _, e := range doc.Entities {
+			if isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			k := entKey{e.Kind, e.Name, e.SourceFile}
+			if _, ok := entIDByKey[k]; !ok {
+				entIDByKey[k] = e.ID
+			}
+		}
+		for _, e := range doc.Entities {
+			if !isHTTPEndpointKind(e.Kind) {
+				continue
+			}
+			pt := e.Properties["pattern_type"]
+			if pt != "http_endpoint_client_synthesis" {
+				continue
+			}
+			verb := e.Properties["verb"]
+			path := e.Properties["path"]
+			framework := e.Properties["framework"]
+			urlPrefix := e.Properties["url_prefix"]
+			sourceCaller := e.Properties["source_caller"]
+			callerID := ""
+			if ref := sourceCaller; ref != "" {
+				if i := strings.IndexByte(ref, ':'); i > 0 {
+					kind, name := ref[:i], ref[i+1:]
+					callerID = entIDByKey[entKey{kind, name, e.SourceFile}]
+				}
+			}
+			if callerID == "" {
+				callerID = e.ID
+			}
+			if linkedSources[repo+"::"+callerID] {
+				continue // already linked — skip
+			}
+			// Check if it's a path match but unlinked.
+			normCons := normPathDiag(path)
+			normStripped, _ := stripAPIPrefixDiag(normCons)
+			var matches []producerEp
+			seen2 := map[string]bool{}
+			for _, n := range []string{normCons, normStripped} {
+				if n == "" {
+					continue
+				}
+				for _, prod := range byNorm[n] {
+					k := prod.repo + "::" + prod.name
+					if !seen2[k] {
+						seen2[k] = true
+						matches = append(matches, prod)
+					}
+				}
+			}
+			if len(matches) == 0 {
+				continue
+			}
+			consVerbUp := strings.ToUpper(verb)
+			hasCompatVerb := false
+			for _, m := range matches {
+				mv := strings.ToUpper(m.verb)
+				if mv == consVerbUp || mv == "ANY" || consVerbUp == "ANY" || consVerbUp == "" {
+					hasCompatVerb = true
+				}
+			}
+			if !hasCompatVerb {
+				continue
+			}
+			fmt.Printf("ORPHAN consumer: name=%q verb=%q path=%q framework=%q url_prefix=%q source_caller=%q\n",
+				e.Name, verb, path, framework, urlPrefix, sourceCaller)
+			for _, m := range matches {
+				fmt.Printf("  MATCH  producer: name=%q verb=%q path=%q url_prefix=%q\n",
+					m.name, m.verb, m.path, m.urlPrefix)
+			}
+		}
+		return nil
+	})
 }

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -431,6 +431,17 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 					if h.side == sideProducer {
 						producers = appendUnique(producers, h)
 					} else if h.side == sideConsumer {
+						// #1445: skip consumer hits whose canonical name has its
+						// own entry in the top-level hits map. That consumer will
+						// be linked (or not) in its own name-bucket iteration.
+						// Pulling it into the current bucket via byPath causes
+						// cross-bucket deduplication: consumerRepos picks it as
+						// the first consumer for its repo, which may already have
+						// a link from its own bucket, leaving the current
+						// bucket's real consumers permanently unlinked.
+						if _, hasOwnBucket := hits[h.name]; hasOwnBucket {
+							continue
+						}
 						consumers = appendUnique(consumers, h)
 					}
 				}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -1479,3 +1479,124 @@ func TestHTTPPass_URLPrefixStrip_Idempotence(t *testing.T) {
 		t.Errorf("match_quality: want exact_verb for same-name match, got %q", httpLinks[0].MatchQuality)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Cross-bucket consumer collision regression test (issue #1445)
+// ---------------------------------------------------------------------------
+
+// TestHTTPPass_CrossBucketConsumerCollision reproduces the root cause of
+// issue #1445: two frontend consumer synthetics exist —
+//
+//   consumerA: http:GET:/roles        (a direct call to /roles)
+//   consumerB: http:GET:/api/v1/roles (a call to the versioned path)
+//
+// The backend has one producer: http:GET:/api/v1/roles (DRF router-expanded,
+// url_prefix=/api/v1, so byPath also registers the stripped alias /roles).
+//
+// Before the fix, when processing the "http:GET:/api/v1/roles" name bucket
+// the byPath expansion probed "/roles" and pulled in consumerA.  Because
+// consumerA's canonical name ("http:GET:/roles") already had its own entry in
+// the hits map, consumerRepos deduplication picked consumerA first (it sorts
+// lower), causing the link for consumerA to be blocked by the emitted-map
+// after the "/roles" bucket ran.  consumerB (the real caller) was never
+// linked.
+//
+// After the fix consumerA is skipped in the "/api/v1/roles" bucket (it has
+// its own bucket), so consumerB gets linked correctly and both consumers
+// receive their links.
+func TestHTTPPass_CrossBucketConsumerCollision(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Backend: one producer, DRF-router-expanded with url_prefix=/api/v1.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "backend",
+		Entities: []map[string]any{
+			{
+				"id": "handler1", "name": "RoleViewSet", "kind": "Controller",
+				"source_file": "app/views.py",
+			},
+			{
+				"id": "ep1", "name": "http:GET:/api/v1/roles", "kind": "http_endpoint",
+				"source_file": "app/views.py",
+				"properties": map[string]any{
+					"verb":         "GET",
+					"path":         "/api/v1/roles",
+					"framework":    "django",
+					"pattern_type": "http_endpoint_synthesis",
+					"url_prefix":   "/api/v1",
+				},
+			},
+		},
+		Edges: []map[string]string{
+			{"from_id": "handler1", "to_id": "ep1", "kind": "IMPLEMENTS"},
+		},
+	})
+
+	// Frontend: two distinct consumers.
+	//   consumerA calls /roles directly (its own name bucket in hits map).
+	//   consumerB calls /api/v1/roles (exact-name match to the producer).
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{
+				"id": "callerA", "name": "useRoles", "kind": "Function",
+				"source_file": "src/network/hooks/roles.js",
+			},
+			{
+				"id": "consumerA", "name": "http:GET:/roles", "kind": "http_endpoint",
+				"source_file": "src/network/hooks/roles.js",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/roles",
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:useRoles",
+				},
+			},
+			{
+				"id": "callerB", "name": "ContactForm", "kind": "Function",
+				"source_file": "src/pages/contacts/ContactForm.jsx",
+			},
+			{
+				"id": "consumerB", "name": "http:GET:/api/v1/roles", "kind": "http_endpoint",
+				"source_file": "src/pages/contacts/ContactForm.jsx",
+				"properties": map[string]any{
+					"verb":          "GET",
+					"path":          "/api/v1/roles",
+					"framework":     "fetch",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:ContactForm",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g1445-collision", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g1445-collision-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a set of (source, target) pairs for all HTTP links.
+	type pair struct{ src, tgt string }
+	linked := map[pair]bool{}
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP {
+			linked[pair{l.Source, l.Target}] = true
+		}
+	}
+
+	// consumerB (exact-name match) MUST produce a link: frontend::callerB → backend::handler1.
+	if !linked[pair{"frontend::callerB", "backend::handler1"}] {
+		t.Errorf("#1445 regression: consumerB (http:GET:/api/v1/roles) not linked to handler1; links=%+v", doc.Links)
+	}
+
+	// consumerA (prefix-strip match via /roles → /api/v1/roles) MUST also be linked.
+	if !linked[pair{"frontend::callerA", "backend::handler1"}] {
+		t.Errorf("#1445 regression: consumerA (http:GET:/roles) not linked to handler1 via prefix-strip; links=%+v", doc.Links)
+	}
+}


### PR DESCRIPTION
## Problem

`#1445`: cross-repo HTTP matcher leaves orphan consumer calls unresolved even when matching endpoints ARE emitted.

**Root cause**: `byPath` expansion could import a consumer hit whose canonical name (e.g. `http:GET:/roles`) already had its own entry in the top-level `hits` map. The `consumerRepos` deduplication picked that imported consumer first (lower sort order by `less()`), while the `emitted` map then blocked the duplicate link when the consumer's own bucket ran — permanently leaving the real callers of `http:GET:/api/v1/roles` unlinked.

Concrete example from the upvate corpus:
- Consumer A: `http:GET:/roles` (entity `19b7e8de`, `src/network/hooks/user.js`) — its own bucket
- Consumer B: `http:GET:/api/v1/roles` (entity `259550`, `src/pages/.../ContactForm.jsx`) — versioned path
- Producer: `http:GET:/api/v1/roles` (`url_prefix=/api/v1`, DRF router-expanded)

When processing the `/api/v1/roles` bucket, byPath probed `/roles` (prefix-stripped alias), found consumer A, deduplication elected it, and the `/roles` bucket's link for it was already in `emitted` — consumer B was never linked.

## Fix

In `internal/links/http_pass.go`, inside the byPath expansion loop, skip any consumer hit whose canonical name already has its own bucket in the `hits` map. Those consumers are served correctly in their own name-bucket iteration; borrowing them into a foreign bucket via a path alias is the only source of the collision.

```go
} else if h.side == sideConsumer {
    // #1445: skip consumer hits whose canonical name has its
    // own entry in the top-level hits map. That consumer will
    // be linked (or not) in its own name-bucket iteration.
    if _, hasOwnBucket := hits[h.name]; hasOwnBucket {
        continue
    }
    consumers = appendUnique(consumers, h)
}
```

## Tests

`TestHTTPPass_CrossBucketConsumerCollision` in `internal/links/http_pass_test.go` reproduces the exact scenario — DRF producer with `url_prefix=/api/v1`, a direct `/roles` consumer (its own bucket), and a versioned `/api/v1/roles` consumer — and asserts that BOTH consumers receive cross-repo `CALLS` links to the backend handler.

All existing `TestHTTPPass_*` tests continue to pass.

## Verification (upvate corpus — isolated worktree, daemon untouched)

```
before: orphan consumer calls = 149, total HTTP links = 185
after:  orphan consumer calls = 148, total HTTP links = 186
```

The remaining 148 orphans are expected: the `consumerRepos` deduplication intentionally keeps one link per (consumer-repo, producer-repo) pair, and many frontend repos have multiple synthetic entities for the same endpoint path/verb in the same repo. These are not bugs.

## Tooling

Added `--diagnose` flag to `archigraph xrepo-verify` that dumps orphan consumer → nearest producer pairs. Useful for future gap analysis without touching the live daemon.

## Scope

- `internal/links/http_pass.go` — matcher fix (7 lines)
- `internal/links/http_pass_test.go` — regression test (121 lines)
- `cmd/archigraph/xrepo_verify.go` — `--diagnose` flag + `diagnoseOrphans()` helper

Fixes #1445