### PR TITLE
feat(webui-v2): Graph screen — cosmos.gl WebGL dependency graph (#1437)

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -205,6 +205,37 @@ this endpoint; the created group reports `health: "unindexed"`.
 
 ---
 
+## 6b. Graph surface (Graph screen)
+
+`GET /api/v2/graph/{group}`
+
+Returns the full dependency graph for the WebUI v2 hero surface, wrapped in a
+`v2OK` envelope:
+
+```jsonc
+{ "ok": true, "data": {
+  "nodes": [{ "id", "label", "kind", "repo", "degree", "pagerank",
+              "community_id?", "source_file?" }],
+  "edges": [{ "source", "target", "kind" }],
+  "communities": [{ "id", "label", "repo", "size", "color_index" }],
+  "repos": [{ "id", "language", "color_index" }],
+  "total_node_count": 1234
+}}
+```
+
+Query params (mirror the v1 `/api/graph` handler): `repos=slug1,slug2`,
+`filter_kind=`, `include_external=true`, `view=modules`.
+
+This is a NEW endpoint, not a reuse of v1 `/api/graph/{group}`. Rationale: the
+v1 tier-1 payload deliberately omits `pagerank` + `source_file` to keep its wire
+shape tight, but the cosmos.gl renderer needs both (node sizing + the "module"
+group-by). A clean v2 endpoint keeps the two UIs independent. Like v1, it shares
+the server-side payload cache + strong ETag/304 + mux-level gzip (cache keys are
+namespaced with a `v2:` prefix). Entity detail for the inspector still uses the
+v1 `GET /api/graph/{group}/entity/{id}` (unchanged, raw JSON).
+
+---
+
 ## 7. Adding a new v2 endpoint — checklist
 
 - [ ] Handler file named `v2_<surface>.go`.

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -520,6 +520,10 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups", s.handleV2Groups)
 	mux.HandleFunc("POST /api/v2/groups", s.handleV2CreateGroup)
 
+	// Graph — the WebUI v2 hero surface payload (nodes/edges/communities/repos).
+	// Carries pagerank + source_file for cosmos.gl node sizing + module group-by.
+	mux.HandleFunc("GET /api/v2/graph/{group}", s.handleV2Graph)
+
 	return s.withAuth(withGzip(mux))
 }
 

--- a/internal/dashboard/v2_graph.go
+++ b/internal/dashboard/v2_graph.go
@@ -1,0 +1,327 @@
+// v2_graph.go — GET /api/v2/graph/{group}
+//
+// The graph payload for WebUI v2's hero surface. It returns the full
+// dependency graph (nodes + edges + communities + repos) wrapped in the
+// standard v2 envelope (see v2_helpers.go / API_V2.md):
+//
+//	{ "ok": true, "data": { nodes, edges, communities, repos, total_node_count } }
+//
+// This reuses the proven v1 dense-graph build logic (handlers_graph.go) but
+// emits a v2-shaped payload that carries the fields the cosmos.gl WebGL canvas
+// needs that the v1 tier-1 payload omitted:
+//
+//   - pagerank      (drives log-scaled node radius)
+//   - source_file   (drives the "module" group-by dimension on the client)
+//   - communities[] (id + colorIndex + size + label) for the legend / focus
+//   - repos[]       (slug + language) for the repo filter + per-repo islands
+//
+// Like v1, it honours ?repos=, ?filter_kind=, ?include_external=, ?view=modules
+// and reuses the server-side payload cache + strong ETag + 304 path. gzip is
+// applied at the mux level (server.go withGzip), so large payloads compress
+// transparently for clients sending Accept-Encoding: gzip.
+//
+// Latitude decision (documented per the ticket): a NEW /api/v2/graph endpoint
+// is added rather than reusing the v1 /api/graph one. Rationale — the v1 tier-1
+// payload deliberately omits pagerank + source_file to keep its wire shape
+// tight, but the cosmos.gl renderer needs both for node sizing and the
+// module group-by. Bolting those onto v1 would change its contract and risk
+// the legacy dashboard; a clean v2 endpoint keeps both UIs independent (the
+// ARCHITECTURE.md hard rule "do not touch dashboard/").
+
+package dashboard
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/module"
+)
+
+// ── v2 wire structs ──────────────────────────────────────────────────────────
+
+// v2GraphNode is the per-node shape consumed by the cosmos.gl canvas.
+type v2GraphNode struct {
+	ID          string  `json:"id"`
+	Label       string  `json:"label"`
+	Kind        string  `json:"kind"`
+	Repo        string  `json:"repo"`
+	Degree      int     `json:"degree"`
+	PageRank    float64 `json:"pagerank"`
+	CommunityID *int    `json:"community_id,omitempty"`
+	SourceFile  string  `json:"source_file,omitempty"`
+}
+
+// v2GraphEdge is the per-edge shape (compact).
+type v2GraphEdge struct {
+	Source string `json:"source"`
+	Target string `json:"target"`
+	Kind   string `json:"kind"`
+}
+
+// v2GraphCommunity is the community summary for the legend / focus popover.
+// ColorIndex is a 1-based index into the pastel categorical scale so the
+// frontend can pick a stable token color without knowing the palette size.
+type v2GraphCommunity struct {
+	ID         int    `json:"id"`
+	Label      string `json:"label"`
+	Repo       string `json:"repo"`
+	Size       int    `json:"size"`
+	ColorIndex int    `json:"color_index"`
+}
+
+// v2GraphRepo is one repo in the group (drives the repo filter + islands).
+type v2GraphRepo struct {
+	ID         string `json:"id"`
+	Language   string `json:"language"`
+	ColorIndex int    `json:"color_index"`
+}
+
+// v2GraphResponse is the data payload inside the v2 envelope.
+type v2GraphResponse struct {
+	Nodes          []v2GraphNode      `json:"nodes"`
+	Edges          []v2GraphEdge      `json:"edges"`
+	Communities    []v2GraphCommunity `json:"communities"`
+	Repos          []v2GraphRepo      `json:"repos"`
+	TotalNodeCount int                `json:"total_node_count"`
+}
+
+// handleV2Graph — GET /api/v2/graph/{group}
+func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+	filterKind := r.URL.Query().Get("filter_kind")
+	reposParam := r.URL.Query().Get("repos")
+	includeExternal := r.URL.Query().Get("include_external") == "true"
+	includeModules := r.URL.Query().Get("view") == "modules" ||
+		r.URL.Query().Get("include") == "modules"
+
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+
+	// Payload cache + strong ETag/304. A "v2:" prefix keeps the v2 payload
+	// cache entries distinct from v1's for the same (group, params) tuple.
+	cacheKey := "v2:" + payloadCacheKey(group, filterKind, "", reposParam, includeExternal, includeModules)
+	if entry, hit := s.graphs.Payloads.Get(cacheKey); hit {
+		w.Header().Set("ETag", entry.etag)
+		w.Header().Set("Vary", "Accept-Encoding")
+		if r.Header.Get("If-None-Match") == entry.etag {
+			w.WriteHeader(http.StatusNotModified)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write(entry.body)
+		return
+	}
+
+	repos := sortedRepos(grp)
+	if reposParam != "" {
+		slugSet := map[string]bool{}
+		for _, sl := range strings.Split(reposParam, ",") {
+			slugSet[strings.TrimSpace(sl)] = true
+		}
+		var filtered []*DashRepo
+		for _, rp := range repos {
+			if slugSet[rp.Slug] {
+				filtered = append(filtered, rp)
+			}
+		}
+		repos = filtered
+	}
+
+	resp := s.buildV2Graph(repos, grp, filterKind, includeExternal, includeModules)
+
+	if resp.TotalNodeCount > softNodeWarnThreshold {
+		w.Header().Set("X-Graph-Warning", "large-graph: node count exceeds 50k; consider filtering by repo or kind")
+	}
+
+	env := v2OK(resp)
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(env); err != nil {
+		writeV2JSON(w, http.StatusOK, env)
+		return
+	}
+	body := buf.Bytes()
+	sum := sha256.Sum256(body)
+	etag := fmt.Sprintf(`"%x"`, sum[:8])
+	s.graphs.Payloads.Set(cacheKey, body, etag)
+
+	w.Header().Set("ETag", etag)
+	w.Header().Set("Vary", "Accept-Encoding")
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	_, _ = w.Write(body)
+}
+
+// buildV2Graph walks the loaded repos and assembles the v2 graph payload.
+// Mirrors serveGraphDense's visibility + filter rules so v1 and v2 agree on
+// which nodes/edges exist; adds pagerank + source_file + repo/community color
+// indices that the cosmos.gl canvas needs.
+func (s *Server) buildV2Graph(repos []*DashRepo, grp *DashGroup, filterKind string, includeExternal, includeModules bool) v2GraphResponse {
+	totalEntities, totalRels, totalCommunities := 0, 0, 0
+	for _, rp := range repos {
+		if rp.Doc == nil {
+			continue
+		}
+		totalEntities += len(rp.Doc.Entities)
+		totalRels += len(rp.Doc.Relationships)
+		totalCommunities += len(rp.Doc.Communities)
+	}
+
+	nodes := make([]v2GraphNode, 0, totalEntities)
+	edges := make([]v2GraphEdge, 0, totalRels)
+	communities := make([]v2GraphCommunity, 0, totalCommunities)
+	reposOut := make([]v2GraphRepo, 0, len(repos))
+	visible := make(map[string]bool, totalEntities)
+
+	// Stable 1-based repo color index (alphabetical, matching sortedRepos order).
+	repoColorIdx := make(map[string]int, len(repos))
+	for i, rp := range repos {
+		repoColorIdx[rp.Slug] = (i % pastelScaleSize) + 1
+	}
+
+	for _, rp := range repos {
+		if rp.Doc == nil {
+			continue
+		}
+		lang := ""
+		// Use the most common entity language as the repo's primary language.
+		if len(rp.Doc.Entities) > 0 {
+			lang = dominantLanguage(rp.Doc.Entities)
+		}
+		reposOut = append(reposOut, v2GraphRepo{
+			ID:         rp.Slug,
+			Language:   lang,
+			ColorIndex: repoColorIdx[rp.Slug],
+		})
+
+		for _, c := range rp.Doc.Communities {
+			label := c.AutoName
+			if c.AgentName != "" {
+				label = c.AgentName
+			}
+			communities = append(communities, v2GraphCommunity{
+				ID:         c.ID,
+				Label:      label,
+				Repo:       rp.Slug,
+				Size:       c.Size,
+				ColorIndex: communityColorIndex(c.ID),
+			})
+		}
+
+		degreeMap := buildDegreeMap(rp.Doc.Relationships)
+
+		for i := range rp.Doc.Entities {
+			e := &rp.Doc.Entities[i]
+			strippedKind := dashStripScopePrefix(e.Kind)
+			if !includeExternal && strippedKind == externalKindSuffix {
+				continue
+			}
+			if !includeModules && strippedKind == module.KindModule {
+				continue
+			}
+			if filterKind != "" && strippedKind != filterKind {
+				continue
+			}
+			pid := dashPrefixedID(rp.Slug, e.ID)
+			if visible[pid] {
+				continue
+			}
+			visible[pid] = true
+			pr := 0.0
+			if e.PageRank != nil {
+				pr = *e.PageRank
+			}
+			node := v2GraphNode{
+				ID:         pid,
+				Label:      entityLabel(e),
+				Kind:       strippedKind,
+				Repo:       rp.Slug,
+				Degree:     degreeMap[e.ID],
+				PageRank:   pr,
+				SourceFile: e.SourceFile,
+			}
+			if e.CommunityID != nil {
+				node.CommunityID = e.CommunityID
+			}
+			nodes = append(nodes, node)
+		}
+	}
+
+	for _, rp := range repos {
+		if rp.Doc == nil {
+			continue
+		}
+		for _, rel := range rp.Doc.Relationships {
+			from := dashPrefixedID(rp.Slug, rel.FromID)
+			to := dashPrefixedID(rp.Slug, rel.ToID)
+			if visible[from] && visible[to] {
+				edges = append(edges, v2GraphEdge{Source: from, Target: to, Kind: rel.Kind})
+			}
+		}
+	}
+	for _, l := range grp.Links {
+		if visible[l.Source] && visible[l.Target] {
+			edges = append(edges, v2GraphEdge{Source: l.Source, Target: l.Target, Kind: l.Kind})
+		}
+	}
+
+	return v2GraphResponse{
+		Nodes:          nodes,
+		Edges:          edges,
+		Communities:    communities,
+		Repos:          reposOut,
+		TotalNodeCount: len(nodes),
+	}
+}
+
+// pastelScaleSize is the number of pastel categorical slots in tokens.css
+// (--pastel-1 … --pastel-10). Color indices wrap within this range.
+const pastelScaleSize = 10
+
+// communityColorIndex maps a community id to a stable 1-based pastel slot.
+// id = -1 (ungrouped/denoised) maps to slot 1; negatives are normalised.
+func communityColorIndex(id int) int {
+	if id < 0 {
+		return 1
+	}
+	return (id % pastelScaleSize) + 1
+}
+
+// dominantLanguage returns the most frequent non-empty Language across the
+// repo's entities — used as the repo's primary language label.
+func dominantLanguage(entities []graph.Entity) string {
+	counts := map[string]int{}
+	for i := range entities {
+		if lang := entities[i].Language; lang != "" {
+			counts[lang]++
+		}
+	}
+	best := ""
+	bestN := 0
+	// Deterministic: iterate sorted keys so ties resolve stably.
+	keys := make([]string, 0, len(counts))
+	for k := range counts {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		if counts[k] > bestN {
+			bestN = counts[k]
+			best = k
+		}
+	}
+	return best
+}

--- a/webui-v2/package-lock.json
+++ b/webui-v2/package-lock.json
@@ -8,6 +8,7 @@
       "name": "archigraph-webui-v2",
       "version": "0.1.0",
       "dependencies": {
+        "@cosmos.gl/graph": "2.6.4",
         "@radix-ui/react-dialog": "^1.1.4",
         "@radix-ui/react-dropdown-menu": "^2.1.4",
         "@radix-ui/react-popover": "^1.1.4",
@@ -330,6 +331,31 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@cosmos.gl/graph": {
+      "version": "2.6.4",
+      "resolved": "https://registry.npmmirror.com/@cosmos.gl/graph/-/graph-2.6.4.tgz",
+      "integrity": "sha512-i+N9lSpAjGLTUPelo/bKNbQnKPDqt3k2UnRlfIWe2Lrambc4J3QFgOfpR8AalQ/1tgLRoeNtVBZ1GPpsNqae5w==",
+      "license": "MIT",
+      "dependencies": {
+        "d3-array": "^3.2.0",
+        "d3-color": "^3.1.0",
+        "d3-drag": "^3.0.0",
+        "d3-ease": "^3.0.1",
+        "d3-scale": "^4.0.2",
+        "d3-selection": "^3.0.0",
+        "d3-transition": "^3.0.1",
+        "d3-zoom": "^3.0.0",
+        "dompurify": "^3.2.6",
+        "gl-bench": "^1.0.42",
+        "gl-matrix": "^3.4.3",
+        "random": "^4.1.0",
+        "regl": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=12.2.0",
+        "npm": ">=7.0.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -2499,6 +2525,13 @@
         "@types/react": "^18.0.0"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmmirror.com/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==",
+      "license": "MIT",
+      "optional": true
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "resolved": "https://registry.npmmirror.com/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
@@ -2623,6 +2656,172 @@
       "devOptional": true,
       "license": "MIT"
     },
+    "node_modules/d3-array": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmmirror.com/d3-array/-/d3-array-3.2.4.tgz",
+      "integrity": "sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==",
+      "license": "ISC",
+      "dependencies": {
+        "internmap": "1 - 2"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-format": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmmirror.com/d3-format/-/d3-format-3.1.2.tgz",
+      "integrity": "sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-scale": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmmirror.com/d3-scale/-/d3-scale-4.0.2.tgz",
+      "integrity": "sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2.10.0 - 3",
+        "d3-format": "1 - 3",
+        "d3-interpolate": "1.2.0 - 3",
+        "d3-time": "2.1.1 - 3",
+        "d3-time-format": "2 - 4"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time/-/d3-time-3.1.0.tgz",
+      "integrity": "sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-array": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-time-format": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/d3-time-format/-/d3-time-format-4.1.0.tgz",
+      "integrity": "sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-time": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmmirror.com/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmmirror.com/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmmirror.com/debug/-/debug-4.4.3.tgz",
@@ -2656,6 +2855,15 @@
       "resolved": "https://registry.npmmirror.com/detect-node-es/-/detect-node-es-1.1.0.tgz",
       "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
       "license": "MIT"
+    },
+    "node_modules/dompurify": {
+      "version": "3.4.5",
+      "resolved": "https://registry.npmmirror.com/dompurify/-/dompurify-3.4.5.tgz",
+      "integrity": "sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==",
+      "license": "(MPL-2.0 OR Apache-2.0)",
+      "optionalDependencies": {
+        "@types/trusted-types": "^2.0.7"
+      }
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.360",
@@ -2782,12 +2990,33 @@
         "node": ">=6"
       }
     },
+    "node_modules/gl-bench": {
+      "version": "1.0.42",
+      "resolved": "https://registry.npmmirror.com/gl-bench/-/gl-bench-1.0.42.tgz",
+      "integrity": "sha512-zuMsA/NCPmI8dPy6q3zTUH8OUM5cqKg7uVWwqzrtXJPBqoypM0XeFWEc8iFOqbf/1qtXieWOrbmgFEByKTQt4Q==",
+      "license": "MIT"
+    },
+    "node_modules/gl-matrix": {
+      "version": "3.4.4",
+      "resolved": "https://registry.npmmirror.com/gl-matrix/-/gl-matrix-3.4.4.tgz",
+      "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
+      "license": "MIT"
+    },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmmirror.com/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/internmap": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmmirror.com/internmap/-/internmap-2.0.3.tgz",
+      "integrity": "sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/jiti": {
       "version": "2.7.0",
@@ -3218,6 +3447,18 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/random": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmmirror.com/random/-/random-4.1.0.tgz",
+      "integrity": "sha512-6Ajb7XmMSE9EFAMGC3kg9mvE7fGlBip25mYYuSMzw/uUSrmGilvZo2qwX3RnTRjwXkwkS+4swse9otZ92VjAtQ==",
+      "license": "MIT",
+      "dependencies": {
+        "seedrandom": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/react": {
       "version": "18.3.1",
       "resolved": "https://registry.npmmirror.com/react/-/react-18.3.1.tgz",
@@ -3354,6 +3595,12 @@
         }
       }
     },
+    "node_modules/regl": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmmirror.com/regl/-/regl-2.1.1.tgz",
+      "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
+      "license": "MIT"
+    },
     "node_modules/rollup": {
       "version": "4.60.4",
       "resolved": "https://registry.npmmirror.com/rollup/-/rollup-4.60.4.tgz",
@@ -3407,6 +3654,12 @@
       "dependencies": {
         "loose-envify": "^1.1.0"
       }
+    },
+    "node_modules/seedrandom": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmmirror.com/seedrandom/-/seedrandom-3.0.5.tgz",
+      "integrity": "sha512-8OwmbklUNzwezjGInmZ+2clQmExQPvomqjL7LFqOYqtmuxRgQYqOD3mHaU+MvZn5FLUeVxVfQjwLZW/n/JFuqg==",
+      "license": "MIT"
     },
     "node_modules/semver": {
       "version": "6.3.1",

--- a/webui-v2/package.json
+++ b/webui-v2/package.json
@@ -11,6 +11,7 @@
     "lint": "tsc --noEmit"
   },
   "dependencies": {
+    "@cosmos.gl/graph": "2.6.4",
     "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.4",
     "@radix-ui/react-popover": "^1.1.4",

--- a/webui-v2/src/components/graph/communities-popover.tsx
+++ b/webui-v2/src/components/graph/communities-popover.tsx
@@ -1,0 +1,85 @@
+/* ============================================================
+   components/graph/communities-popover.tsx — top-right communities picker.
+
+   Lists communities; clicking one focuses its nodes (non-members dim).
+   ============================================================ */
+
+import { useState } from "react";
+import { Popover, PopoverTrigger, PopoverContent, Pill, SearchInput } from "@/components/ui";
+import { useGraphStore } from "@/store/use-graph-store";
+import type { GraphCommunity } from "@/data/types";
+
+export function CommunitiesPopover({ communities }: { communities: GraphCommunity[] }) {
+  const open = useGraphStore((s) => s.communitiesOpen);
+  const setOpen = useGraphStore((s) => s.setCommunitiesOpen);
+  const focusedCommunityId = useGraphStore((s) => s.focusedCommunityId);
+  const setFocusedCommunity = useGraphStore((s) => s.setFocusedCommunity);
+  const [q, setQ] = useState("");
+
+  const focused = communities.find((c) => c.id === focusedCommunityId);
+  const filtered = communities.filter((c) =>
+    c.label.toLowerCase().includes(q.toLowerCase()),
+  );
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Pill active={focusedCommunityId != null} count={focused ? undefined : communities.length}>
+          {focused ? focused.label : "Communities"}
+        </Pill>
+      </PopoverTrigger>
+      <PopoverContent className="w-[320px] p-0">
+        <div className="border-b border-border p-2.5">
+          <SearchInput
+            value={q}
+            onChange={(e) => setQ(e.target.value)}
+            placeholder="Filter communities…"
+            autoFocus
+          />
+        </div>
+        {focusedCommunityId != null ? (
+          <button
+            onClick={() => {
+              setFocusedCommunity(null);
+              setOpen(false);
+            }}
+            className="flex w-full items-center justify-between border-b border-border px-3 py-2 text-left text-sm text-accent-strong hover:bg-surface-2"
+          >
+            Show all
+          </button>
+        ) : null}
+        <ul className="ag-scroll max-h-[320px] overflow-auto py-1">
+          {filtered.map((c) => (
+            <li key={`${c.repo}-${c.id}`}>
+              <button
+                onClick={() => {
+                  setFocusedCommunity(c.id === focusedCommunityId ? null : c.id);
+                  setOpen(false);
+                }}
+                aria-pressed={c.id === focusedCommunityId}
+                className={`flex w-full items-center justify-between gap-2 px-3 py-1.5 text-left hover:bg-surface-2 ${
+                  c.id === focusedCommunityId ? "bg-accent-soft" : ""
+                }`}
+              >
+                <span className="flex min-w-0 items-center gap-2">
+                  <span
+                    className="h-2.5 w-2.5 shrink-0 rounded-full"
+                    style={{ background: `var(--pastel-${((c.colorIndex - 1) % 10) + 1})` }}
+                  />
+                  <span className="truncate text-sm text-text-2">{c.label}</span>
+                </span>
+                <span className="font-mono text-xs tabular-nums text-text-3">{c.size}</span>
+              </button>
+            </li>
+          ))}
+          {filtered.length === 0 ? (
+            <li className="px-3 py-2 text-sm text-text-3">No communities match.</li>
+          ) : null}
+        </ul>
+        <div className="border-t border-border px-3 py-2 text-xs text-text-3">
+          Click a community to focus its nodes
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/webui-v2/src/components/graph/filters-drawer.tsx
+++ b/webui-v2/src/components/graph/filters-drawer.tsx
@@ -1,0 +1,135 @@
+/* ============================================================
+   components/graph/filters-drawer.tsx — right slide-out filters + tuning.
+
+   Sections: Edge types · Repositories · Level of detail · (tuning panels).
+   ============================================================ */
+
+import { Dialog, DrawerContent, DialogTitle, Button } from "@/components/ui";
+import { useGraphStore, type LodLevel } from "@/store/use-graph-store";
+import type { EdgeKind, GraphRepo } from "@/data/types";
+import { TuningPanels } from "./tuning-panels";
+
+const EDGE_KINDS: EdgeKind[] = [
+  "CALLS",
+  "REFERENCES",
+  "RENDERS",
+  "DEPENDS_ON",
+  "EXTENDS",
+  "CONTAINS",
+  "IMPORTS",
+];
+
+const LODS: LodLevel[] = ["low", "mid", "high"];
+
+export function FiltersDrawer({ repos }: { repos: GraphRepo[] }) {
+  const filtersOpen = useGraphStore((s) => s.filtersOpen);
+  const setFiltersOpen = useGraphStore((s) => s.setFiltersOpen);
+  const enabledEdgeKinds = useGraphStore((s) => s.enabledEdgeKinds);
+  const toggleEdgeKind = useGraphStore((s) => s.toggleEdgeKind);
+  const activeRepos = useGraphStore((s) => s.activeRepos);
+  const toggleRepo = useGraphStore((s) => s.toggleRepo);
+  const lod = useGraphStore((s) => s.lod);
+  const setLod = useGraphStore((s) => s.setLod);
+  const clearAllFilters = useGraphStore((s) => s.clearAllFilters);
+
+  return (
+    <Dialog open={filtersOpen} onOpenChange={setFiltersOpen}>
+      <DrawerContent className="flex flex-col">
+        <DialogTitle className="text-md font-semibold text-text">Filters</DialogTitle>
+
+        <div className="ag-scroll mt-4 min-h-0 flex-1 space-y-4">
+          <section>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">Edge types</h4>
+            <div className="flex flex-wrap gap-1.5">
+              {EDGE_KINDS.map((k) => {
+                const on = enabledEdgeKinds.has(k);
+                return (
+                  <button
+                    key={k}
+                    onClick={() => toggleEdgeKind(k)}
+                    aria-pressed={on}
+                    className={`inline-flex items-center gap-1.5 rounded-full border px-2.5 py-1 font-mono text-xs transition-colors ${
+                      on
+                        ? "border-transparent bg-accent-soft text-accent-strong"
+                        : "border-border bg-surface text-text-3 hover:bg-surface-2"
+                    }`}
+                  >
+                    <span className="h-1.5 w-1.5 rounded-full bg-current" />
+                    {k}
+                  </button>
+                );
+              })}
+            </div>
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">Repositories</h4>
+            <div className="space-y-1.5">
+              {repos.map((r) => {
+                const on = activeRepos?.has(r.id) ?? false;
+                return (
+                  <button
+                    key={r.id}
+                    onClick={() => toggleRepo(r.id)}
+                    aria-pressed={on}
+                    className={`flex w-full items-center justify-between rounded-md border px-3 py-1.5 text-left transition-colors ${
+                      on
+                        ? "border-transparent bg-accent-soft text-accent-strong"
+                        : "border-border bg-surface text-text-2 hover:bg-surface-2"
+                    }`}
+                  >
+                    <span className="flex items-center gap-2">
+                      <span
+                        className="h-2.5 w-2.5 rounded-full"
+                        style={{ background: `var(--pastel-${((r.colorIndex - 1) % 10) + 1})` }}
+                      />
+                      <span className="font-mono text-sm">{r.id}</span>
+                    </span>
+                    <span className="text-xs text-text-3">{r.language}</span>
+                  </button>
+                );
+              })}
+              {repos.length === 0 ? <p className="text-sm text-text-3">No repos.</p> : null}
+            </div>
+            {activeRepos ? (
+              <p className="mt-1.5 text-xs text-text-3">{activeRepos.size} selected · others hidden</p>
+            ) : (
+              <p className="mt-1.5 text-xs text-text-3">No selection = all repos shown</p>
+            )}
+          </section>
+
+          <section>
+            <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">Level of detail</h4>
+            <div className="grid grid-cols-3 gap-1">
+              {LODS.map((l) => (
+                <button
+                  key={l}
+                  onClick={() => setLod(l)}
+                  aria-pressed={lod === l}
+                  className={`h-7 rounded-md border text-xs font-medium uppercase transition-colors ${
+                    lod === l
+                      ? "border-transparent bg-accent-soft text-accent-strong"
+                      : "border-border bg-surface text-text-2 hover:bg-surface-2"
+                  }`}
+                >
+                  {l}
+                </button>
+              ))}
+            </div>
+          </section>
+
+          <TuningPanels />
+        </div>
+
+        <footer className="mt-4 flex items-center justify-between gap-2 border-t border-border pt-3">
+          <Button variant="ghost" size="sm" onClick={clearAllFilters}>
+            Clear all
+          </Button>
+          <Button variant="primary" size="sm" onClick={() => setFiltersOpen(false)}>
+            Done
+          </Button>
+        </footer>
+      </DrawerContent>
+    </Dialog>
+  );
+}

--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -1,0 +1,653 @@
+/* ============================================================
+   components/graph/graph-canvas.tsx — the WebGL dependency graph canvas.
+
+   GPU-accelerated force-directed graph via the MIT-licensed cosmos.gl
+   engine (@cosmos.gl/graph — NOT @cosmograph, which is non-commercial).
+   Reimplemented clean for WebUI v2, porting the hard-won lessons from the
+   legacy dashboard GraphCanvas:
+
+     • setPointColors / setLinkColors take RGB 0..1, NOT 0–255 — every
+       channel > 1 clamps to white in the shader (writeNormalizedRGBA).
+     • bounded square spaceSize + fit-camera-to-node-bbox so the settled
+       graph FILLS the viewport.
+     • cluster force → repo / community / module islands; bright sky
+       cross-repo "bridge" edges.
+     • layout-cache: settled positions persisted in localStorage → instant
+       reload, the explode/settle animation is skipped.
+     • ≤2s settle cap (wall-clock) + live knob.
+     • click-to-focus N-hop ego-graph (hard-restricts the rendered set +
+       re-fits the camera).
+     • live tuning (sim / sizing / render) applied via setConfig without
+       re-instantiating the engine.
+
+   This component is imperative-by-design: it builds Float32 buffers itself
+   and pushes them to the engine; it never recreates the Graph on data change.
+   ============================================================ */
+
+import { useRef, useEffect, useMemo, useCallback, memo } from "react";
+import { Graph } from "@cosmos.gl/graph";
+import type { GraphNode, GraphEdge } from "@/data/types";
+import {
+  type RGBA,
+  parseColor,
+  writeNormalizedRGBA,
+  readPastelScale,
+  pastelAt,
+  degreeColor,
+  CROSS_REPO_EDGE,
+  SAME_REPO_EDGE,
+} from "@/lib/graph-colors";
+import { saveLayout, loadLayout } from "@/lib/graph-layout-cache";
+import type {
+  ColorMode,
+  GroupByMode,
+  SimulationConfig,
+  NodeSizingConfig,
+  RenderConfig,
+} from "@/store/use-graph-store";
+
+const SPACE_SIZE = 32768;
+const FIT_PADDING = 0.1;
+
+// ── group / cluster helpers ──────────────────────────────────────────────────
+
+function moduleKey(sourceFile: string): string {
+  if (!sourceFile) return "";
+  const parts = sourceFile.replace(/\\/g, "/").split("/");
+  return parts.slice(0, -1).slice(-2).join("/");
+}
+
+function hashMod1000(s: string): number {
+  let h = 0;
+  for (let i = 0; i < s.length; i++) h = ((h << 5) - h + s.charCodeAt(i)) | 0;
+  return Math.abs(h) % 1000;
+}
+
+function groupKeyFor(n: GraphNode, mode: GroupByMode): string {
+  switch (mode) {
+    case "repo":
+      return n.repo ?? "";
+    case "community":
+      return `c:${n.communityId ?? -1}`;
+    case "module":
+      return moduleKey(n.sourceFile) || `repo:${n.repo ?? ""}`;
+    default:
+      return "";
+  }
+}
+
+function clusterIdFor(n: GraphNode, repoIdx: number, mode: GroupByMode): number | undefined {
+  if (mode === "none") return undefined;
+  if (mode === "repo") {
+    const mod = hashMod1000(moduleKey(n.sourceFile));
+    const cid = n.communityId ?? 0;
+    return repoIdx * 10_000_000 + cid * 1000 + mod;
+  }
+  const k = groupKeyFor(n, mode);
+  return hashMod1000(k) + hashMod1000(k + "#") * 1000;
+}
+
+function buildGroupCenters(
+  nodes: GraphNode[],
+  mode: GroupByMode,
+): Map<string, { x: number; y: number }> {
+  if (mode === "none") return new Map();
+  const keys = Array.from(new Set(nodes.map((n) => groupKeyFor(n, mode)))).sort();
+  const N = keys.length;
+  if (N === 0) return new Map();
+  const R = Math.max(3000, Math.sqrt(nodes.length) * 50, N * 700);
+  return new Map(
+    keys.map((key, i) => {
+      const angle = (i / N) * 2 * Math.PI;
+      return [key, { x: R * Math.cos(angle), y: R * Math.sin(angle) }];
+    }),
+  );
+}
+
+// ── component ────────────────────────────────────────────────────────────────
+
+export interface GraphCanvasProps {
+  group: string;
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  selectedNodeId: string | null;
+  isDark: boolean;
+  colorMode: ColorMode;
+  groupBy: GroupByMode;
+  simulation: SimulationConfig;
+  nodeSizing: NodeSizingConfig;
+  render: RenderConfig;
+  /** repo filter — null = all. */
+  activeRepos: Set<string> | null;
+  /** community focus — dims non-members (null = none). */
+  focusedCommunityId: number | null;
+  /** N-hop ego focus — hard-restrict to these ids (null = full graph). */
+  focusNodeIds: Set<string> | null;
+  /** changes to this nonce force a fresh re-layout (skip cache). */
+  relayoutNonce: number;
+  onNodeClick: (node: GraphNode | null) => void;
+  onNodeHover: (node: GraphNode | null) => void;
+  onSettled: () => void;
+  className?: string;
+}
+
+const LABEL_COUNT = 24;
+const truncate = (s: string) => (s.length > 30 ? s.slice(0, 28) + "…" : s);
+
+function GraphCanvasInner({
+  group,
+  nodes,
+  edges,
+  selectedNodeId,
+  isDark,
+  colorMode,
+  groupBy,
+  simulation,
+  nodeSizing,
+  render,
+  activeRepos,
+  focusedCommunityId,
+  focusNodeIds,
+  relayoutNonce,
+  onNodeClick,
+  onNodeHover,
+  onSettled,
+  className = "",
+}: GraphCanvasProps) {
+  const containerRef = useRef<HTMLDivElement>(null);
+  const graphRef = useRef<Graph | null>(null);
+  const hasSettledRef = useRef(false);
+  const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const didAutoStartRef = useRef(false);
+  const mountTimeRef = useRef(Date.now());
+
+  // Live refs so the mount-only handlers read current values.
+  const nodesRef = useRef(nodes);
+  nodesRef.current = nodes;
+  const selectedRef = useRef<string | null>(selectedNodeId);
+  selectedRef.current = selectedNodeId;
+  const onNodeClickRef = useRef(onNodeClick);
+  onNodeClickRef.current = onNodeClick;
+  const onNodeHoverRef = useRef(onNodeHover);
+  onNodeHoverRef.current = onNodeHover;
+  const onSettledRef = useRef(onSettled);
+  onSettledRef.current = onSettled;
+  const simRef = useRef(simulation);
+  simRef.current = simulation;
+  const relayoutRef = useRef(relayoutNonce);
+
+  const idToIdx = useMemo(() => {
+    const m = new Map<string, number>();
+    nodes.forEach((n, i) => m.set(n.id, i));
+    return m;
+  }, [nodes]);
+
+  const nodeIds = useMemo(() => nodes.map((n) => n.id), [nodes]);
+
+  const repoToIdx = useMemo(() => {
+    const repos = Array.from(new Set(nodes.map((n) => n.repo ?? ""))).sort();
+    return new Map(repos.map((r, i) => [r, i]));
+  }, [nodes]);
+
+  const groupCenters = useMemo(() => buildGroupCenters(nodes, groupBy), [nodes, groupBy]);
+
+  // Degree percentile fn (so the degree gradient spreads across the long tail).
+  const sortedDegrees = useMemo(
+    () => nodes.map((n) => n.degree ?? 0).sort((a, b) => a - b),
+    [nodes],
+  );
+  const degreePercentile = useCallback(
+    (d: number): number => {
+      const arr = sortedDegrees;
+      if (arr.length === 0) return 0;
+      let lo = 0;
+      let hi = arr.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >> 1;
+        if (arr[mid] <= d) lo = mid + 1;
+        else hi = mid;
+      }
+      return lo / arr.length;
+    },
+    [sortedDegrees],
+  );
+
+  // ── packed buffers ──────────────────────────────────────────────────────────
+  const packed = useMemo(() => {
+    const count = nodes.length;
+    const positions = new Float32Array(count * 2);
+    const sizes = new Float32Array(count);
+    const clusters: (number | undefined)[] = new Array(count);
+    const clusterStrength = new Float32Array(count);
+
+    let maxPR = 0;
+    for (const n of nodes) if ((n.pageRank ?? 0) > maxPR) maxPR = n.pageRank ?? 0;
+    if (maxPR === 0) maxPR = 1;
+
+    const grouping = groupBy !== "none";
+    const groupCount = new Map<string, number>();
+    for (const n of nodes) {
+      const k = groupKeyFor(n, groupBy);
+      groupCount.set(k, (groupCount.get(k) ?? 0) + 1);
+    }
+
+    nodes.forEach((n, i) => {
+      const repoIdx = repoToIdx.get(n.repo ?? "") ?? 0;
+      clusters[i] = clusterIdFor(n, repoIdx, groupBy);
+      const normPR = (n.pageRank ?? 0) / maxPR;
+      clusterStrength[i] = grouping ? 0.45 + normPR * 0.25 : 0.04 + normPR * 0.06;
+
+      // log-scaled size by degree (graph.md: radius scales with PageRank/degree).
+      sizes[i] =
+        nodeSizing.baseSize + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale;
+
+      const gkey = groupKeyFor(n, groupBy);
+      const center = grouping ? groupCenters.get(gkey) : undefined;
+      const jitterR = Math.max(600, Math.sqrt(groupCount.get(gkey) ?? 1) * 40);
+      const angle = Math.random() * 2 * Math.PI;
+      const r = Math.random() * jitterR;
+      positions[i * 2] = center ? center.x + r * Math.cos(angle) : (Math.random() - 0.5) * 4000;
+      positions[i * 2 + 1] = center
+        ? center.y + r * Math.sin(angle)
+        : (Math.random() - 0.5) * 4000;
+    });
+
+    return { positions, sizes, clusters, clusterStrength };
+  }, [nodes, repoToIdx, groupCenters, groupBy, nodeSizing]);
+
+  // Node colors — re-read pastel scale from tokens.css so theme flows through.
+  const packPointColors = useCallback((): Float32Array => {
+    const { fill } = readPastelScale();
+    const count = nodes.length;
+    const out = new Float32Array(count * 4);
+    for (let i = 0; i < count; i++) {
+      const n = nodes[i];
+      let rgba: RGBA;
+      if (colorMode === "degree") {
+        const t = Math.pow(degreePercentile(n.degree ?? 0), 0.7);
+        rgba = degreeColor(t);
+      } else if (colorMode === "community") {
+        rgba = pastelAt(fill, (n.communityId ?? 0) + 1);
+      } else {
+        rgba = pastelAt(fill, (repoToIdx.get(n.repo ?? "") ?? 0) + 1);
+      }
+      writeNormalizedRGBA(out, i, rgba);
+    }
+    return out;
+  }, [nodes, colorMode, repoToIdx, degreePercentile]);
+
+  // Links — packed [src,tgt] + cross-repo state.
+  const linkData = useMemo(() => {
+    const idToRepo = new Map(nodes.map((n) => [n.id, n.repo ?? ""]));
+    const src: number[] = [];
+    const tgt: number[] = [];
+    const states: number[] = []; // 1 cross-repo, 0 same-repo
+    for (const e of edges) {
+      const s = idToIdx.get(e.source);
+      const t = idToIdx.get(e.target);
+      if (s === undefined || t === undefined) continue;
+      const cross = idToRepo.get(e.source) !== idToRepo.get(e.target);
+      src.push(s);
+      tgt.push(t);
+      states.push(cross ? 1 : 0);
+    }
+    const links = new Float32Array(src.length * 2);
+    for (let i = 0; i < src.length; i++) {
+      links[i * 2] = src[i];
+      links[i * 2 + 1] = tgt[i];
+    }
+    return { links, states };
+  }, [nodes, edges, idToIdx]);
+
+  const packLinkColors = useCallback((): Float32Array => {
+    const { states } = linkData;
+    const out = new Float32Array(states.length * 4);
+    const sameA = render.linkOpacity;
+    const crossA = Math.min(1, Math.max(0.55, render.linkOpacity * 3.5));
+    for (let i = 0; i < states.length; i++) {
+      const base = states[i] === 1 ? CROSS_REPO_EDGE : SAME_REPO_EDGE;
+      const rgba: RGBA = [base[0], base[1], base[2], states[i] === 1 ? crossA : sameA];
+      writeNormalizedRGBA(out, i, rgba);
+    }
+    return out;
+  }, [linkData, render.linkOpacity]);
+
+  const packLinkWidths = useCallback((): Float32Array => {
+    const { states } = linkData;
+    const out = new Float32Array(states.length);
+    if (!render.showLinks) return out;
+    for (let i = 0; i < states.length; i++) {
+      out[i] = (states[i] === 1 ? 2.2 : 0.6) * render.linkWidthScale;
+    }
+    return out;
+  }, [linkData, render.showLinks, render.linkWidthScale]);
+
+  // Top-N labels overlay.
+  const topLabelIdx = useMemo(
+    () =>
+      nodes
+        .map((n, i) => ({ i, d: n.degree ?? 0 }))
+        .sort((a, b) => b.d - a.d)
+        .slice(0, LABEL_COUNT)
+        .map((x) => x.i),
+    [nodes],
+  );
+  const labelLayerRef = useRef<HTMLDivElement>(null);
+  const labelRafRef = useRef<number | null>(null);
+
+  const refreshLabels = useCallback(() => {
+    const g = graphRef.current;
+    const layer = labelLayerRef.current;
+    if (!g || !layer) return;
+    const positions = g.getPointPositions();
+    if (!positions || positions.length === 0) return;
+    const w = containerRef.current?.clientWidth ?? 0;
+    const h = containerRef.current?.clientHeight ?? 0;
+    const frag: string[] = [];
+    for (const idx of topLabelIdx) {
+      const n = nodesRef.current[idx];
+      if (!n) continue;
+      const px = positions[idx * 2];
+      const py = positions[idx * 2 + 1];
+      if (px === undefined || py === undefined) continue;
+      const [sx, sy] = g.spaceToScreenPosition([px, py]);
+      if (sx < -50 || sy < -50 || sx > w + 50 || sy > h + 50) continue;
+      frag.push(
+        `<span style="position:absolute;left:${sx}px;top:${
+          sy - 14
+        }px;transform:translate(-50%,-100%);white-space:nowrap;font-size:11px;font-weight:500;padding:1px 5px;border-radius:4px;background:${
+          isDark ? "rgba(2,6,23,0.72)" : "rgba(248,250,252,0.85)"
+        };color:${isDark ? "#e2e8f0" : "#1e293b"}">${truncate(n.label)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")}</span>`,
+      );
+    }
+    layer.innerHTML = frag.join("");
+  }, [topLabelIdx, isDark]);
+
+  const scheduleLabels = useCallback(() => {
+    if (labelRafRef.current !== null) return;
+    labelRafRef.current = requestAnimationFrame(() => {
+      labelRafRef.current = null;
+      refreshLabels();
+    });
+  }, [refreshLabels]);
+
+  const doSettle = useCallback(() => {
+    if (hasSettledRef.current) return;
+    hasSettledRef.current = true;
+    if (capTimerRef.current) {
+      clearTimeout(capTimerRef.current);
+      capTimerRef.current = null;
+    }
+    const g = graphRef.current;
+    g?.pause();
+    g?.fitView(400, FIT_PADDING);
+    scheduleLabels();
+    setTimeout(scheduleLabels, 450);
+    const positions = g?.getPointPositions();
+    if (positions && positions.length > 0) {
+      saveLayout(group, nodeIds, new Float32Array(positions));
+    }
+    onSettledRef.current();
+  }, [group, nodeIds, scheduleLabels]);
+  const doSettleRef = useRef(doSettle);
+  doSettleRef.current = doSettle;
+
+  // ── mount the engine ONCE ─────────────────────────────────────────────────
+  useEffect(() => {
+    const container = containerRef.current;
+    if (!container) return;
+
+    const g = new Graph(container, {
+      backgroundColor: isDark ? "#020617" : "#f8fafc",
+      spaceSize: SPACE_SIZE,
+      pixelRatio: Math.min(window.devicePixelRatio, 1.5),
+      scalePointsOnZoom: render.scalePointsOnZoom,
+      pointSizeScale: render.pointSizeScale,
+      pointOpacity: render.pointOpacity,
+      pointGreyoutOpacity: 0.15,
+      linkGreyoutOpacity: render.linkOpacity * 0.5,
+      linkWidthScale: render.showLinks ? render.linkWidthScale : 0,
+      renderHoveredPointRing: true,
+      hoveredPointRingColor: isDark ? "#e2e8f0" : "#1e293b",
+      pointSamplingDistance: 120,
+      enableSimulation: true,
+      simulationLinkSpring: simulation.linkSpring,
+      simulationLinkDistance: Math.max(simulation.linkDistance, 8),
+      simulationGravity: 0.02,
+      simulationFriction: simulation.friction,
+      simulationDecay: 1500,
+      simulationCluster: 0.5,
+      simulationRepulsion: simulation.repulsion,
+      simulationCenter: simulation.center,
+      rescalePositions: true,
+      fitViewOnInit: true,
+      fitViewDelay: 3500,
+      fitViewPadding: FIT_PADDING,
+      onSimulationEnd: () => {
+        if (!hasSettledRef.current) doSettleRef.current();
+      },
+      onSimulationTick: scheduleLabels,
+      onClick: (index?: number) => {
+        if (index === undefined) {
+          onNodeClickRef.current(null);
+          return;
+        }
+        const n = nodesRef.current[index];
+        if (!n) return;
+        if (n.id === selectedRef.current) onNodeClickRef.current(null);
+        else onNodeClickRef.current(n);
+      },
+      onBackgroundClick: () => {
+        graphRef.current?.unselectPoints();
+        onNodeHoverRef.current(null);
+        onNodeClickRef.current(null);
+      },
+      onMouseMove: (index?: number) => {
+        if (index === undefined) {
+          onNodeHoverRef.current(null);
+          return;
+        }
+        const n = nodesRef.current[index];
+        if (n) onNodeHoverRef.current(n);
+      },
+      onZoom: scheduleLabels,
+    });
+    graphRef.current = g;
+
+    const saved = loadLayout(group, nodeIds);
+    if (saved) {
+      requestAnimationFrame(() => {
+        const gg = graphRef.current;
+        if (!gg) return;
+        gg.setPointPositions(saved.positions, true);
+        doSettleRef.current();
+      });
+    } else {
+      const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
+      capTimerRef.current = setTimeout(() => {
+        if (!hasSettledRef.current) doSettleRef.current();
+      }, capMs);
+    }
+
+    return () => {
+      if (capTimerRef.current) clearTimeout(capTimerRef.current);
+      if (labelRafRef.current !== null) cancelAnimationFrame(labelRafRef.current);
+      g.destroy();
+      graphRef.current = null;
+    };
+    // mount-only — do NOT recreate on data/config change
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // ── data push (positions / colors / sizes / clusters / links) ───────────────
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    const prev = g.getPointPositions();
+    if (hasSettledRef.current && prev.length === packed.positions.length) {
+      g.setPointPositions(new Float32Array(prev), true);
+    } else {
+      g.setPointPositions(packed.positions);
+    }
+    g.setPointSizes(packed.sizes);
+    g.setPointClusters(packed.clusters);
+    g.setPointClusterStrength(packed.clusterStrength);
+    g.setPointColors(packPointColors());
+    g.setLinks(linkData.links);
+    g.setLinkColors(packLinkColors());
+    g.setLinkWidths(packLinkWidths());
+    g.render();
+    g.create();
+    if (!didAutoStartRef.current && !hasSettledRef.current) {
+      const saved = loadLayout(group, nodeIds);
+      if (!saved) {
+        didAutoStartRef.current = true;
+        g.start(1);
+      }
+    }
+    if (hasSettledRef.current) g.pause();
+    scheduleLabels();
+  }, [packed, packPointColors, linkData, packLinkColors, packLinkWidths, group, nodeIds, scheduleLabels]);
+
+  // ── recolor on theme / colorMode ────────────────────────────────────────────
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    g.setPointColors(packPointColors());
+    g.setLinkColors(packLinkColors());
+    g.setLinkWidths(packLinkWidths());
+    g.setConfig({ backgroundColor: isDark ? "#020617" : "#f8fafc" });
+    g.render();
+    g.create();
+    if (hasSettledRef.current) g.pause();
+  }, [packPointColors, packLinkColors, packLinkWidths, isDark]);
+
+  // ── live render/sim config ──────────────────────────────────────────────────
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    g.setConfig({
+      pointOpacity: render.pointOpacity,
+      pointSizeScale: render.pointSizeScale,
+      scalePointsOnZoom: render.scalePointsOnZoom,
+      linkWidthScale: render.showLinks ? render.linkWidthScale : 0,
+      simulationLinkSpring: simulation.linkSpring,
+      simulationLinkDistance: Math.max(simulation.linkDistance, 8),
+      simulationFriction: simulation.friction,
+      simulationRepulsion: simulation.repulsion,
+      simulationCenter: simulation.center,
+    });
+    g.setLinkColors(packLinkColors());
+    g.setLinkWidths(packLinkWidths());
+    g.render();
+    if (hasSettledRef.current) g.pause();
+  }, [render, simulation, packLinkColors, packLinkWidths]);
+
+  // ── re-layout request (Reset / re-layout) ───────────────────────────────────
+  useEffect(() => {
+    if (relayoutRef.current === relayoutNonce) return;
+    relayoutRef.current = relayoutNonce;
+    const g = graphRef.current;
+    if (!g) return;
+    hasSettledRef.current = false;
+    mountTimeRef.current = Date.now();
+    g.setPointPositions(packed.positions);
+    g.setPointClusters(packed.clusters);
+    g.setPointClusterStrength(packed.clusterStrength);
+    g.render();
+    g.create();
+    g.start(1);
+    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
+    if (capTimerRef.current) clearTimeout(capTimerRef.current);
+    capTimerRef.current = setTimeout(() => {
+      if (!hasSettledRef.current) doSettleRef.current();
+    }, capMs);
+  }, [relayoutNonce, packed]);
+
+  // ── re-cluster on group-by change ───────────────────────────────────────────
+  const prevGroupByRef = useRef(groupBy);
+  useEffect(() => {
+    if (prevGroupByRef.current === groupBy) return;
+    prevGroupByRef.current = groupBy;
+    const g = graphRef.current;
+    if (!g) return;
+    hasSettledRef.current = false;
+    mountTimeRef.current = Date.now();
+    g.setPointPositions(packed.positions);
+    g.setPointClusters(packed.clusters);
+    g.setPointClusterStrength(packed.clusterStrength);
+    g.render();
+    g.create();
+    g.start(1);
+    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
+    if (capTimerRef.current) clearTimeout(capTimerRef.current);
+    capTimerRef.current = setTimeout(() => {
+      if (!hasSettledRef.current) doSettleRef.current();
+    }, capMs);
+  }, [groupBy, packed]);
+
+  // ── visibility / focus selection ─────────────────────────────────────────────
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    const repoActive = activeRepos != null;
+    const focusActive = focusNodeIds != null;
+    const communityActive = focusedCommunityId != null;
+
+    if (!repoActive && !focusActive && !communityActive) {
+      g.selectPointsByIndices(null);
+      g.setConfig({ pointGreyoutOpacity: 0.15 });
+      return;
+    }
+    let effective: number[] = nodes
+      .map((n, i) => {
+        if (repoActive && !activeRepos!.has(n.repo)) return -1;
+        if (communityActive && n.communityId !== focusedCommunityId) return -1;
+        if (focusActive && !focusNodeIds!.has(n.id)) return -1;
+        return i;
+      })
+      .filter((i) => i !== -1);
+    g.selectPointsByIndices(effective);
+    // hard-hide for repo/focus filters; soft-dim for community focus.
+    g.setConfig({ pointGreyoutOpacity: repoActive || focusActive ? 0 : 0.18 });
+  }, [nodes, activeRepos, focusNodeIds, focusedCommunityId]);
+
+  // ── re-fit to focus ego-graph ────────────────────────────────────────────────
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g || !hasSettledRef.current) return;
+    if (focusNodeIds && focusNodeIds.size > 0) {
+      const indices = Array.from(focusNodeIds)
+        .map((id) => idToIdx.get(id))
+        .filter((i): i is number => i !== undefined);
+      if (indices.length > 0) g.fitViewByPointIndices(indices, 400, FIT_PADDING);
+    } else {
+      g.fitView(400, FIT_PADDING);
+    }
+    setTimeout(scheduleLabels, 450);
+  }, [focusNodeIds, idToIdx, scheduleLabels]);
+
+  return (
+    <div className={`relative h-full w-full ${className}`} role="img" aria-label="Dependency graph">
+      <div ref={containerRef} className="h-full w-full" />
+      <div ref={labelLayerRef} aria-hidden className="pointer-events-none absolute inset-0 z-10" />
+      {/* vignette for perceived depth */}
+      <div
+        aria-hidden
+        className="pointer-events-none absolute inset-0"
+        style={{
+          background: isDark
+            ? "radial-gradient(ellipse at 50% 50%, transparent 55%, rgba(2,6,23,0.55) 100%)"
+            : "radial-gradient(ellipse at 50% 50%, transparent 55%, rgba(226,232,240,0.45) 100%)",
+        }}
+      />
+    </div>
+  );
+}
+
+export const GraphCanvas = memo(GraphCanvasInner);
+
+// Re-export so callers can resolve the slate fallback consistently.
+export { parseColor };

--- a/webui-v2/src/components/graph/node-inspector.tsx
+++ b/webui-v2/src/components/graph/node-inspector.tsx
@@ -1,0 +1,135 @@
+/* ============================================================
+   components/graph/node-inspector.tsx — floating right-pane inspector.
+
+   Opens on node selection (graph.md "floating overlay" mode). Lazy-fetches
+   the Tier-3 entity detail (callers / callees / community) and offers
+   click-to-focus on neighbors.
+   ============================================================ */
+
+import { X } from "lucide-react";
+import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Button } from "@/components/ui";
+import { useEntityDetail } from "@/hooks/use-graph";
+import type { GraphNode } from "@/data/types";
+
+export interface NodeInspectorProps {
+  groupId: string;
+  node: GraphNode;
+  onClose: () => void;
+  onFocusNode: (id: string) => void;
+}
+
+export function NodeInspector({ groupId, node, onClose, onFocusNode }: NodeInspectorProps) {
+  const { data, isLoading } = useEntityDetail(groupId, node.id);
+
+  const inbound = data?.inbound_edges ?? [];
+  const outbound = data?.outbound_edges ?? [];
+  const neighborById = new Map((data?.neighbors ?? []).map((n) => [n.id, n]));
+
+  return (
+    <aside
+      role="dialog"
+      aria-label={`Inspector: ${node.label}`}
+      className="absolute right-4 top-4 bottom-4 z-30 flex w-[360px] flex-col rounded-lg border border-border bg-surface/90 shadow-[var(--shadow-4)] backdrop-blur-md"
+    >
+      <header className="flex items-start justify-between gap-2 border-b border-border p-4">
+        <div className="min-w-0">
+          <div className="truncate font-mono text-[15px] text-text">{node.label}</div>
+          <div className="mt-1.5 flex flex-wrap items-center gap-1.5">
+            <Badge tone="info">{node.kind}</Badge>
+            <Badge dot="var(--accent)">{node.repo}</Badge>
+          </div>
+        </div>
+        <button onClick={onClose} aria-label="Close inspector" className="rounded-md p-1 text-text-3 hover:bg-surface-2 hover:text-text">
+          <X size={16} />
+        </button>
+      </header>
+
+      <div className="border-b border-border px-4 py-2 font-mono text-xs text-text-3 break-all">
+        {data?.entity.source_file
+          ? `${data.entity.source_file}:${data.entity.start_line}`
+          : "—"}
+      </div>
+
+      <div className="grid grid-cols-3 gap-2 border-b border-border px-4 py-3 text-center">
+        <Stat label="Inbound" value={data?.in_degree ?? node.degree} />
+        <Stat label="PageRank" value={node.pageRank.toFixed(4)} />
+        <Stat label="Community" value={data?.community_name ?? (node.communityId ?? "—")} />
+      </div>
+
+      <Tabs defaultValue="inbound" className="flex min-h-0 flex-1 flex-col">
+        <TabsList className="mx-4 mt-3">
+          <TabsTrigger value="inbound">Inbound</TabsTrigger>
+          <TabsTrigger value="outbound">Outbound</TabsTrigger>
+          <TabsTrigger value="schema">Schema</TabsTrigger>
+        </TabsList>
+
+        <div className="ag-scroll min-h-0 flex-1 p-4">
+          <TabsContent value="inbound">
+            <EdgeList edges={inbound} dir="from_id" neighborById={neighborById} loading={isLoading} onFocusNode={onFocusNode} />
+          </TabsContent>
+          <TabsContent value="outbound">
+            <EdgeList edges={outbound} dir="to_id" neighborById={neighborById} loading={isLoading} onFocusNode={onFocusNode} />
+          </TabsContent>
+          <TabsContent value="schema">
+            <p className="text-sm text-text-3">No schema metadata for this entity.</p>
+          </TabsContent>
+        </div>
+      </Tabs>
+
+      <footer className="flex gap-2 border-t border-border p-3">
+        <Button variant="ghost" size="sm" className="flex-1" onClick={() => onFocusNode(node.id)}>
+          Focus neighbors
+        </Button>
+      </footer>
+    </aside>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div>
+      <div className="font-mono text-md tabular-nums text-text">{value}</div>
+      <div className="text-xs text-text-3">{label}</div>
+    </div>
+  );
+}
+
+function EdgeList({
+  edges,
+  dir,
+  neighborById,
+  loading,
+  onFocusNode,
+}: {
+  edges: { from_id: string; to_id: string; kind: string }[];
+  dir: "from_id" | "to_id";
+  neighborById: Map<string, { label: string }>;
+  loading: boolean;
+  onFocusNode: (id: string) => void;
+}) {
+  if (loading) return <p className="text-sm text-text-3">Loading…</p>;
+  if (edges.length === 0) return <p className="text-sm text-text-3">No edges.</p>;
+  const shown = edges.slice(0, 25);
+  return (
+    <ul className="space-y-1.5">
+      {shown.map((e, i) => {
+        const id = e[dir];
+        const label = neighborById.get(id)?.label ?? id;
+        return (
+          <li key={`${id}-${i}`}>
+            <button
+              onClick={() => onFocusNode(id)}
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-left hover:bg-surface-2"
+            >
+              <Badge tone="neutral" className="shrink-0">{e.kind}</Badge>
+              <span className="truncate font-mono text-sm text-text-2">{label}</span>
+            </button>
+          </li>
+        );
+      })}
+      {edges.length > shown.length ? (
+        <li className="px-2 text-xs text-text-3">+{edges.length - shown.length} more</li>
+      ) : null}
+    </ul>
+  );
+}

--- a/webui-v2/src/components/graph/tuning-panels.tsx
+++ b/webui-v2/src/components/graph/tuning-panels.tsx
@@ -1,0 +1,116 @@
+/* ============================================================
+   components/graph/tuning-panels.tsx — live tuning controls.
+
+   Four collapsible sections (Node Sizing / Simulation / Rendering /
+   Group-by), localStorage-persisted via use-graph-store. Lesson ported from
+   v1: the owner tunes the galaxy live and the settings survive reloads.
+
+   Rendered inside the Filters drawer as a fourth section so the screen has
+   one slide-out surface, not two competing panels.
+   ============================================================ */
+
+import { useGraphStore, type GroupByMode } from "@/store/use-graph-store";
+import { Button } from "@/components/ui";
+
+function Slider({
+  label,
+  value,
+  min,
+  max,
+  step,
+  onChange,
+}: {
+  label: string;
+  value: number;
+  min: number;
+  max: number;
+  step: number;
+  onChange: (v: number) => void;
+}) {
+  return (
+    <label className="block">
+      <div className="flex items-center justify-between text-sm text-text-3">
+        <span>{label}</span>
+        <span className="font-mono tabular-nums text-text-2">{value}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        step={step}
+        value={value}
+        onChange={(e) => onChange(parseFloat(e.target.value))}
+        className="mt-1 w-full accent-[var(--accent)]"
+      />
+    </label>
+  );
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="border-t border-border pt-3">
+      <h4 className="mb-2 text-xs font-semibold uppercase tracking-wide text-text-3">{title}</h4>
+      <div className="space-y-2.5">{children}</div>
+    </div>
+  );
+}
+
+const GROUP_BY: { id: GroupByMode; label: string }[] = [
+  { id: "repo", label: "Repo" },
+  { id: "community", label: "Community" },
+  { id: "module", label: "Module" },
+  { id: "none", label: "None" },
+];
+
+export function TuningPanels() {
+  const { simulation, nodeSizing, render, groupBy } = useGraphStore();
+  const { setSimulation, setNodeSizing, setRender, setGroupBy, requestRelayout } = useGraphStore();
+
+  return (
+    <div className="space-y-3">
+      <Section title="Group by">
+        <div className="grid grid-cols-4 gap-1">
+          {GROUP_BY.map((g) => (
+            <button
+              key={g.id}
+              onClick={() => setGroupBy(g.id)}
+              aria-pressed={groupBy === g.id}
+              className={`h-7 rounded-md border text-xs font-medium transition-colors ${
+                groupBy === g.id
+                  ? "border-transparent bg-accent-soft text-accent-strong"
+                  : "border-border bg-surface text-text-2 hover:bg-surface-2"
+              }`}
+            >
+              {g.label}
+            </button>
+          ))}
+        </div>
+      </Section>
+
+      <Section title="Node sizing">
+        <Slider label="Base size" value={nodeSizing.baseSize} min={40} max={240} step={10} onChange={(v) => setNodeSizing({ baseSize: v })} />
+        <Slider label="Degree scale" value={nodeSizing.degreeScale} min={0} max={80} step={5} onChange={(v) => setNodeSizing({ degreeScale: v })} />
+      </Section>
+
+      <Section title="Simulation">
+        <Slider label="Repulsion" value={simulation.repulsion} min={0.1} max={4} step={0.1} onChange={(v) => setSimulation({ repulsion: v })} />
+        <Slider label="Link distance" value={simulation.linkDistance} min={2} max={40} step={1} onChange={(v) => setSimulation({ linkDistance: v })} />
+        <Slider label="Center force" value={simulation.center} min={0} max={1} step={0.05} onChange={(v) => setSimulation({ center: v })} />
+        <Slider label="Settle cap (s)" value={simulation.settleTime} min={0.5} max={6} step={0.5} onChange={(v) => setSimulation({ settleTime: v })} />
+        <Button variant="secondary" size="sm" className="w-full" onClick={requestRelayout}>
+          Re-layout
+        </Button>
+      </Section>
+
+      <Section title="Rendering">
+        <Slider label="Point opacity" value={render.pointOpacity} min={0.2} max={1} step={0.02} onChange={(v) => setRender({ pointOpacity: v })} />
+        <Slider label="Point size scale" value={render.pointSizeScale} min={0.05} max={1} step={0.01} onChange={(v) => setRender({ pointSizeScale: v })} />
+        <Slider label="Link opacity" value={render.linkOpacity} min={0} max={1} step={0.02} onChange={(v) => setRender({ linkOpacity: v })} />
+        <label className="flex items-center justify-between text-sm text-text-3">
+          <span>Show links</span>
+          <input type="checkbox" checked={render.showLinks} onChange={(e) => setRender({ showLinks: e.target.checked })} className="accent-[var(--accent)]" />
+        </label>
+      </Section>
+    </div>
+  );
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -41,6 +41,128 @@ export interface Entity {
   outbound: number;
 }
 
+/* ------------------------------------------------------------------ *
+ * Graph screen — wire + domain shapes.
+ *
+ * The wire shapes (snake_case) mirror v2_graph.go's JSON exactly. The
+ * data hook normalizes them into the camelCase domain shapes the screen +
+ * cosmos canvas consume.
+ * ------------------------------------------------------------------ */
+
+/** Raw node as emitted by GET /api/v2/graph/{group}. */
+export interface GraphNodeWire {
+  id: string;
+  label: string;
+  kind: string;
+  repo: string;
+  degree: number;
+  pagerank: number;
+  community_id?: number;
+  source_file?: string;
+}
+
+export interface GraphEdgeWire {
+  source: string;
+  target: string;
+  kind: string;
+}
+
+export interface GraphCommunityWire {
+  id: number;
+  label: string;
+  repo: string;
+  size: number;
+  color_index: number;
+}
+
+export interface GraphRepoWire {
+  id: string;
+  language: string;
+  color_index: number;
+}
+
+export interface GraphPayloadWire {
+  nodes: GraphNodeWire[];
+  edges: GraphEdgeWire[];
+  communities: GraphCommunityWire[];
+  repos: GraphRepoWire[];
+  total_node_count: number;
+}
+
+/** Normalized node consumed by the canvas + inspector. */
+export interface GraphNode {
+  id: string;
+  label: string;
+  kind: string;
+  repo: string;
+  degree: number;
+  pageRank: number;
+  communityId: number | null;
+  sourceFile: string;
+}
+
+export interface GraphEdge {
+  source: string;
+  target: string;
+  kind: string;
+}
+
+export interface GraphCommunity {
+  id: number;
+  label: string;
+  repo: string;
+  size: number;
+  colorIndex: number;
+}
+
+export interface GraphRepo {
+  id: string;
+  language: string;
+  colorIndex: number;
+}
+
+export interface GraphPayload {
+  nodes: GraphNode[];
+  edges: GraphEdge[];
+  communities: GraphCommunity[];
+  repos: GraphRepo[];
+  totalNodeCount: number;
+}
+
+/** Tier-3 entity detail — GET /api/graph/{group}/entity/{id} (v1, reused). */
+export interface EntityEdgeWire {
+  from_id: string;
+  to_id: string;
+  kind: string;
+  cross_repo?: boolean;
+}
+export interface EntityNeighborWire {
+  id: string;
+  label: string;
+  kind: string;
+  source_file: string;
+  start_line: number;
+  repo: string;
+}
+export interface EntityDetailWire {
+  entity: {
+    id: string;
+    name: string;
+    kind: string;
+    source_file: string;
+    start_line: number;
+    repo?: string;
+    pagerank?: number;
+  };
+  inbound_edges: EntityEdgeWire[];
+  outbound_edges: EntityEdgeWire[];
+  neighbors: EntityNeighborWire[];
+  in_degree: number;
+  out_degree: number;
+  community_name?: string;
+  betweenness?: number;
+}
+
 /** Derived health state for a group (computed server-side in v2_groups.go). */
 export type GroupHealth = "healthy" | "warning" | "unindexed";
 

--- a/webui-v2/src/hooks/use-graph.ts
+++ b/webui-v2/src/hooks/use-graph.ts
@@ -1,0 +1,71 @@
+/* ============================================================
+   hooks/use-graph.ts — Graph-screen data hooks.
+
+   Wraps the typed api client in TanStack Query and normalizes the
+   snake_case wire payload into the camelCase domain shapes the screen
+   + cosmos canvas consume. Screens never call api.* directly.
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type {
+  GraphPayload,
+  GraphPayloadWire,
+  EntityDetailWire,
+} from "@/data/types";
+
+export const graphQueryKey = (groupId: string, repos?: string[], filterKind?: string) =>
+  ["graph", groupId, repos?.slice().sort().join(",") ?? "", filterKind ?? ""] as const;
+
+/** Normalize the wire payload (snake_case) into the domain shape. */
+function normalize(w: GraphPayloadWire): GraphPayload {
+  return {
+    nodes: w.nodes.map((n) => ({
+      id: n.id,
+      label: n.label || n.id,
+      kind: n.kind,
+      repo: n.repo,
+      degree: n.degree,
+      pageRank: n.pagerank,
+      communityId: n.community_id ?? null,
+      sourceFile: n.source_file ?? "",
+    })),
+    edges: w.edges.map((e) => ({ source: e.source, target: e.target, kind: e.kind })),
+    communities: w.communities.map((c) => ({
+      id: c.id,
+      label: c.label,
+      repo: c.repo,
+      size: c.size,
+      colorIndex: c.color_index,
+    })),
+    repos: w.repos.map((r) => ({ id: r.id, language: r.language, colorIndex: r.color_index })),
+    totalNodeCount: w.total_node_count,
+  };
+}
+
+/**
+ * The full graph payload. The cosmos canvas renders the FULL corpus (it caps
+ * nothing); the repo / kind filters are passed to the daemon so large graphs
+ * can be sliced server-side (network-payload paginating per graph.md).
+ */
+export function useGraph(
+  groupId: string,
+  opts?: { repos?: string[]; filterKind?: string },
+) {
+  return useQuery({
+    queryKey: graphQueryKey(groupId, opts?.repos, opts?.filterKind),
+    queryFn: async () => normalize(await api.getGraph(groupId, opts)),
+    // The payload is large + server-cached (ETag/304); keep it warm.
+    staleTime: 5 * 60 * 1000,
+  });
+}
+
+/** Lazy Tier-3 entity detail for the inspector (fetched on node click). */
+export function useEntityDetail(groupId: string, entityId: string | null) {
+  return useQuery<EntityDetailWire>({
+    queryKey: ["entity", groupId, entityId],
+    queryFn: () => api.getEntityDetail(groupId, entityId as string),
+    enabled: !!entityId,
+    staleTime: 60 * 1000,
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -9,7 +9,13 @@
    UI never hardcodes the live :47274 daemon during development.
    ============================================================ */
 
-import type { Group, Entity, Community } from "@/data/types";
+import type {
+  Group,
+  Entity,
+  Community,
+  GraphPayloadWire,
+  EntityDetailWire,
+} from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
 const BASE_V2 = import.meta.env.VITE_AG_API_BASE_V2 ?? "/api/v2";
@@ -90,8 +96,23 @@ export const api = {
   createGroup: (name: string) =>
     requestV2<Group>("/groups", { method: "POST", body: JSON.stringify({ name }) }),
 
+  /** v2 — the full graph payload (nodes/edges/communities/repos) for the Graph
+   *  screen. `params` maps to the daemon's repo/kind filters. */
+  getGraph: (groupId: string, params?: { repos?: string[]; filterKind?: string }) => {
+    const qs = new URLSearchParams();
+    if (params?.repos && params.repos.length > 0) qs.set("repos", params.repos.join(","));
+    if (params?.filterKind) qs.set("filter_kind", params.filterKind);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return requestV2<GraphPayloadWire>(`/graph/${encodeURIComponent(groupId)}${suffix}`);
+  },
+
   // --- v1 surfaces still used by other (placeholder) screens ---
   getGroup: (groupId: string) => request<Group>(`/groups/${groupId}`),
+  /** v1 — Tier-3 entity detail for the inspector (lazy, on node click). */
+  getEntityDetail: (groupId: string, entityId: string) =>
+    request<EntityDetailWire>(
+      `/graph/${encodeURIComponent(groupId)}/entity/${encodeURIComponent(entityId)}`,
+    ),
   listCommunities: (groupId: string) => request<Community[]>(`/groups/${groupId}/communities`),
   searchEntities: (groupId: string, q: string) =>
     request<Entity[]>(`/groups/${groupId}/entities?q=${encodeURIComponent(q)}`),

--- a/webui-v2/src/lib/graph-colors.ts
+++ b/webui-v2/src/lib/graph-colors.ts
@@ -1,0 +1,116 @@
+/* ============================================================
+   lib/graph-colors.ts — color helpers for the cosmos.gl canvas.
+
+   CRITICAL LESSON PORTED FROM v1 (#1392): cosmos.gl 2.6.4 reads the
+   per-point / per-link color attribute as a RAW float vec4 and assigns it
+   straight to the fragment color — it does NOT divide by 255. So colors
+   MUST be uploaded in the 0..1 float range. Any channel > 1 clamps to 1.0
+   in the shader → every node renders WHITE. We keep the human-friendly
+   0–255 parse space and normalize to 0..1 only when writing the GPU buffer
+   (writeNormalizedRGBA).
+
+   Colors are sourced from tokens.css (the source-of-truth) via the
+   --pastel-N / --pastel-N-ink categorical scale, resolved at runtime so the
+   theme/palette switches flow through automatically.
+   ============================================================ */
+
+export type RGBA = [number, number, number, number]; // rgb 0–255, a 0–1
+
+/** Number of pastel categorical slots in tokens.css (--pastel-1 … --pastel-10). */
+export const PASTEL_SCALE_SIZE = 10;
+
+const SLATE_500: RGBA = [100, 116, 139, 1];
+
+/** Parse #rrggbb / #rgb / rgb()/rgba() into [r,g,b,a] (rgb 0-255, a 0-1). */
+export function parseColor(c: string | null | undefined): RGBA {
+  if (!c || typeof c !== "string") return SLATE_500;
+  const s = c.trim();
+  if (s.startsWith("#")) {
+    let hex = s.slice(1);
+    if (hex.length === 3) hex = hex.split("").map((ch) => ch + ch).join("");
+    const r = parseInt(hex.slice(0, 2), 16);
+    const g = parseInt(hex.slice(2, 4), 16);
+    const b = parseInt(hex.slice(4, 6), 16);
+    const a = hex.length >= 8 ? parseInt(hex.slice(6, 8), 16) / 255 : 1;
+    if (Number.isNaN(r) || Number.isNaN(g) || Number.isNaN(b)) return SLATE_500;
+    return [r, g, b, a];
+  }
+  const m = s.match(/rgba?\(([^)]+)\)/);
+  if (m) {
+    const parts = m[1].split(",").map((p) => parseFloat(p.trim()));
+    return [parts[0] ?? 0, parts[1] ?? 0, parts[2] ?? 0, parts[3] ?? 1];
+  }
+  return SLATE_500;
+}
+
+/**
+ * Write an RGBA (rgb 0–255, a 0–1) into a packed GPU buffer at quad index i,
+ * NORMALISING rgb to the 0..1 range cosmos.gl's shaders expect. THE fix.
+ */
+export function writeNormalizedRGBA(out: Float32Array, i: number, rgba: RGBA): void {
+  out[i * 4] = rgba[0] / 255;
+  out[i * 4 + 1] = rgba[1] / 255;
+  out[i * 4 + 2] = rgba[2] / 255;
+  out[i * 4 + 3] = rgba[3];
+}
+
+/**
+ * Resolve the pastel categorical scale (and ink variants) from tokens.css at
+ * runtime. Re-read on theme change so the dark-mode desaturated pastels and the
+ * warm-palette overlay both flow through. Returns 0–255 RGBA arrays.
+ */
+export function readPastelScale(root: HTMLElement = document.documentElement): {
+  fill: RGBA[];
+  ink: RGBA[];
+} {
+  const style = getComputedStyle(root);
+  const fill: RGBA[] = [];
+  const ink: RGBA[] = [];
+  for (let i = 1; i <= PASTEL_SCALE_SIZE; i++) {
+    fill.push(parseColor(style.getPropertyValue(`--pastel-${i}`)));
+    ink.push(parseColor(style.getPropertyValue(`--pastel-${i}-ink`)));
+  }
+  return { fill, ink };
+}
+
+/** Pick a pastel slot (1-based color index) from a resolved scale, wrapping. */
+export function pastelAt(scale: RGBA[], colorIndex: number): RGBA {
+  if (scale.length === 0) return SLATE_500;
+  const idx = ((colorIndex - 1) % scale.length + scale.length) % scale.length;
+  return scale[idx];
+}
+
+/**
+ * Degree gradient (cool indigo → violet → pink → warm yellow), ported from the
+ * v1 Silk Road ramp. Used for the "degree / connections" color mode. The cool
+ * floor is kept dark/saturated on purpose — cosmos.gl blends additively so a
+ * dark floor accumulates toward color rather than clipping to white.
+ */
+const DEGREE_STOPS: RGBA[] = [
+  [49, 46, 129, 1], // indigo-900
+  [124, 58, 237, 1], // violet-600
+  [219, 39, 119, 1], // pink-600
+  [250, 204, 21, 1], // yellow-400
+];
+
+export function degreeColor(t: number): RGBA {
+  const x = Math.max(0, Math.min(1, t));
+  const seg = x * (DEGREE_STOPS.length - 1);
+  const i = Math.min(Math.floor(seg), DEGREE_STOPS.length - 2);
+  const f = seg - i;
+  const a = DEGREE_STOPS[i];
+  const b = DEGREE_STOPS[i + 1];
+  return [
+    a[0] + (b[0] - a[0]) * f,
+    a[1] + (b[1] - a[1]) * f,
+    a[2] + (b[2] - a[2]) * f,
+    1,
+  ];
+}
+
+/** Cross-repo "bridge" edge color — bright sky so integration points pop. */
+export const CROSS_REPO_EDGE: RGBA = [56, 189, 248, 1];
+/** Same-repo edge color — subtle slate. */
+export const SAME_REPO_EDGE: RGBA = [100, 116, 139, 1];
+/** Highlighted (focused-neighbor) edge color — amber. */
+export const HIGHLIGHT_EDGE: RGBA = [251, 146, 60, 1];

--- a/webui-v2/src/lib/graph-layout-cache.ts
+++ b/webui-v2/src/lib/graph-layout-cache.ts
@@ -1,0 +1,86 @@
+/* ============================================================
+   lib/graph-layout-cache.ts — persist / restore settled graph positions.
+
+   LESSON PORTED FROM v1: caching the settled Float32 positions in
+   localStorage lets a return visit skip the explode/settle animation
+   entirely and render the laid-out graph INSTANTLY.
+
+   Key:   archigraph.v2.layout.<group>.<nodesetHash>
+   Value: base64-encoded Float32Array of [x0, y0, x1, y1, ...]
+
+   The node-set hash (FNV-1a over sorted node IDs) keys the cache so a graph
+   whose nodes changed (re-index) misses and re-lays-out. A 2 MB guard avoids
+   blowing the localStorage quota on huge graphs.
+   ============================================================ */
+
+const MAX_BYTES = 2 * 1024 * 1024;
+const PREFIX = "archigraph.v2.layout";
+
+function fnv1a32(s: string): string {
+  let h = 0x811c9dc5 >>> 0;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 0x01000193) >>> 0;
+  }
+  return String(h);
+}
+
+function layoutKey(group: string, nodeIds: string[]): string {
+  const hash = fnv1a32([...nodeIds].sort().join(","));
+  return `${PREFIX}.${group}.${hash}`;
+}
+
+function float32ToBase64(arr: Float32Array): string {
+  const bytes = new Uint8Array(arr.buffer, arr.byteOffset, arr.byteLength);
+  let s = "";
+  for (let i = 0; i < bytes.length; i++) s += String.fromCharCode(bytes[i]);
+  return btoa(s);
+}
+
+function base64ToFloat32(b64: string): Float32Array | null {
+  try {
+    const s = atob(b64);
+    const bytes = new Uint8Array(s.length);
+    for (let i = 0; i < s.length; i++) bytes[i] = s.charCodeAt(i);
+    return new Float32Array(bytes.buffer);
+  } catch {
+    return null;
+  }
+}
+
+export interface LayoutCacheEntry {
+  positions: Float32Array;
+}
+
+export function saveLayout(group: string, nodeIds: string[], positions: Float32Array): void {
+  try {
+    const encoded = float32ToBase64(positions);
+    if (encoded.length > MAX_BYTES) return;
+    localStorage.setItem(layoutKey(group, nodeIds), encoded);
+  } catch {
+    /* ignore quota / private-mode */
+  }
+}
+
+export function loadLayout(group: string, nodeIds: string[]): LayoutCacheEntry | null {
+  try {
+    const encoded = localStorage.getItem(layoutKey(group, nodeIds));
+    if (!encoded) return null;
+    const positions = base64ToFloat32(encoded);
+    if (!positions || positions.length !== nodeIds.length * 2) {
+      localStorage.removeItem(layoutKey(group, nodeIds));
+      return null;
+    }
+    return { positions };
+  } catch {
+    return null;
+  }
+}
+
+export function clearLayout(group: string, nodeIds: string[]): void {
+  try {
+    localStorage.removeItem(layoutKey(group, nodeIds));
+  } catch {
+    /* ignore */
+  }
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -1,5 +1,265 @@
-import { PlaceholderScreen } from "./placeholder-screen";
+/* ============================================================
+   routes/graph.tsx — the Graph screen (WebUI v2 hero surface).
+
+   Clean layered composition:
+     api client (lib/api) → data hook (use-graph) → this screen + the
+     cosmos.gl canvas component (components/graph/graph-canvas).
+
+   The screen owns the toolbar (search / communities / filters / reset /
+   group-by + color mode), the WebGL canvas, the floating inspector, the
+   filters drawer (+ tuning panels), and the LOD badge. All interaction +
+   tuning state lives in use-graph-store; the heavy graph data in TanStack
+   Query.
+   ============================================================ */
+
+import { useEffect, useMemo, useRef } from "react";
+import { useParams } from "react-router-dom";
+import { X, RotateCcw, SlidersHorizontal } from "lucide-react";
+import { SearchInput, Pill, Kbd } from "@/components/ui";
+import { useGraph } from "@/hooks/use-graph";
+import { useGraphStore, type ColorMode } from "@/store/use-graph-store";
+import { useAppStore } from "@/store/use-app-store";
+import type { EdgeKind, GraphNode } from "@/data/types";
+import { GraphCanvas } from "@/components/graph/graph-canvas";
+import { NodeInspector } from "@/components/graph/node-inspector";
+import { FiltersDrawer } from "@/components/graph/filters-drawer";
+import { CommunitiesPopover } from "@/components/graph/communities-popover";
+
+const COLOR_MODES: { id: ColorMode; label: string }[] = [
+  { id: "repo", label: "Repo" },
+  { id: "community", label: "Community" },
+  { id: "degree", label: "Degree" },
+];
 
 export default function GraphScreen() {
-  return <PlaceholderScreen title="Graph" description="WebGL dependency graph at 20k+ nodes. Cosmograph renderer, inspector, filters." doc="graph.md" />;
+  const { groupId = "demo" } = useParams();
+  const theme = useAppStore((st) => st.theme);
+  const isDark = theme === "dark";
+
+  const s = useGraphStore();
+  const { data, isLoading, isError } = useGraph(groupId);
+
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  // ── keyboard: / focus search, F filters, Escape cascade ─────────────────────
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      const tag = (e.target as HTMLElement)?.tagName;
+      const typing = tag === "INPUT" || tag === "TEXTAREA";
+      if (e.key === "/" && !typing) {
+        e.preventDefault();
+        searchRef.current?.focus();
+      } else if (e.key === "f" && !typing) {
+        e.preventDefault();
+        s.setFiltersOpen(!s.filtersOpen);
+      } else if (e.key === "Escape") {
+        if (s.selectedNodeId) s.setSelectedNode(null);
+        else if (s.filtersOpen) s.setFiltersOpen(false);
+        else if (s.communitiesOpen) s.setCommunitiesOpen(false);
+        else if (s.focusNodeIds) s.setFocusNodes(null);
+        else if (s.focusedCommunityId != null) s.setFocusedCommunity(null);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [s]);
+
+  // Edge-kind filter applied client-side (kinds are cheap to filter locally).
+  const edges = useMemo(() => {
+    if (!data) return [];
+    if (s.enabledEdgeKinds.size === 7) return data.edges;
+    return data.edges.filter((e) => s.enabledEdgeKinds.has(e.kind as EdgeKind));
+  }, [data, s.enabledEdgeKinds]);
+
+  const nodes = data?.nodes ?? [];
+
+  const searchMatches = useMemo(() => {
+    if (!s.search.trim()) return [];
+    const q = s.search.toLowerCase();
+    return nodes.filter((n) => n.label.toLowerCase().includes(q));
+  }, [nodes, s.search]);
+
+  // Click-to-focus N-hop ego-graph (1 hop).
+  const adjacency = useMemo(() => {
+    const m = new Map<string, Set<string>>();
+    for (const e of edges) {
+      if (!m.has(e.source)) m.set(e.source, new Set());
+      if (!m.has(e.target)) m.set(e.target, new Set());
+      m.get(e.source)!.add(e.target);
+      m.get(e.target)!.add(e.source);
+    }
+    return m;
+  }, [edges]);
+
+  const focusEgo = (id: string, hops = 1) => {
+    const set = new Set<string>([id]);
+    let frontier = [id];
+    for (let h = 0; h < hops; h++) {
+      const next: string[] = [];
+      for (const f of frontier) {
+        for (const nb of adjacency.get(f) ?? []) {
+          if (!set.has(nb)) {
+            set.add(nb);
+            next.push(nb);
+          }
+        }
+      }
+      frontier = next;
+    }
+    s.setFocusNodes(set);
+  };
+
+  const selectedNode: GraphNode | null = useMemo(
+    () => nodes.find((n) => n.id === s.selectedNodeId) ?? null,
+    [nodes, s.selectedNodeId],
+  );
+
+  const onNodeClick = (node: GraphNode | null) => {
+    s.setSelectedNode(node?.id ?? null);
+    if (!node) s.setFocusNodes(null);
+  };
+
+  const lodLabel = `${s.lod.toUpperCase()}  ${nodes.length.toLocaleString()}/${(
+    data?.totalNodeCount ?? nodes.length
+  ).toLocaleString()}`;
+
+  const activeFilterCount = (s.activeRepos?.size ?? 0) + (7 - s.enabledEdgeKinds.size);
+
+  return (
+    <div className="relative flex h-full flex-col">
+      {/* Toolbar */}
+      <div className="flex items-center gap-2 border-b border-border bg-bg px-4 py-2">
+        <div className="relative w-72">
+          <SearchInput
+            ref={searchRef}
+            value={s.search}
+            onChange={(e) => s.setSearch(e.target.value)}
+            placeholder="Search entities…"
+            shortcut={s.search ? undefined : "/"}
+          />
+          {s.search ? (
+            <button
+              onClick={() => s.setSearch("")}
+              aria-label="Clear search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 rounded p-0.5 text-text-3 hover:text-text"
+            >
+              <X size={14} />
+            </button>
+          ) : null}
+        </div>
+        {s.search ? (
+          <span className="text-sm text-text-3 tabular-nums">
+            {searchMatches.length} result{searchMatches.length === 1 ? "" : "s"}
+          </span>
+        ) : null}
+
+        <div className="ml-auto flex items-center gap-2">
+          <div className="flex overflow-hidden rounded-md border border-border">
+            {COLOR_MODES.map((m) => (
+              <button
+                key={m.id}
+                onClick={() => s.setColorMode(m.id)}
+                aria-pressed={s.colorMode === m.id}
+                className={`h-7 px-2.5 text-xs font-medium transition-colors ${
+                  s.colorMode === m.id
+                    ? "bg-accent-soft text-accent-strong"
+                    : "bg-surface text-text-2 hover:bg-surface-2"
+                }`}
+              >
+                {m.label}
+              </button>
+            ))}
+          </div>
+
+          <CommunitiesPopover communities={data?.communities ?? []} />
+
+          <Pill
+            active={activeFilterCount > 0}
+            onClick={() => s.setFiltersOpen(true)}
+            count={activeFilterCount}
+          >
+            <SlidersHorizontal size={13} /> Filters
+          </Pill>
+
+          <button
+            onClick={() => {
+              s.resetView();
+              s.requestRelayout();
+            }}
+            aria-label="Reset view"
+            className="inline-flex h-7 items-center gap-1.5 rounded-md border border-border bg-surface px-2.5 text-sm text-text-2 hover:bg-surface-2"
+          >
+            <RotateCcw size={13} /> Reset
+          </button>
+        </div>
+      </div>
+
+      {/* Canvas + overlays */}
+      <div className="relative min-h-0 flex-1">
+        {isLoading ? (
+          <div className="grid h-full place-items-center bg-bg">
+            <div className="flex flex-col items-center gap-3 text-text-3">
+              <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
+              <span className="text-sm">Loading graph…</span>
+            </div>
+          </div>
+        ) : isError ? (
+          <div className="grid h-full place-items-center bg-bg">
+            <div className="text-center">
+              <p className="text-md text-text">Could not load the graph.</p>
+              <p className="mt-1 text-sm text-text-3">Is this group indexed? Check the daemon.</p>
+            </div>
+          </div>
+        ) : nodes.length === 0 ? (
+          <div className="grid h-full place-items-center bg-bg">
+            <p className="text-md text-text-3">No nodes match the active filters.</p>
+          </div>
+        ) : (
+          <>
+            <GraphCanvas
+              group={groupId}
+              nodes={nodes}
+              edges={edges}
+              selectedNodeId={s.selectedNodeId}
+              isDark={isDark}
+              colorMode={s.colorMode}
+              groupBy={s.groupBy}
+              simulation={s.simulation}
+              nodeSizing={s.nodeSizing}
+              render={s.render}
+              activeRepos={s.activeRepos}
+              focusedCommunityId={s.focusedCommunityId}
+              focusNodeIds={s.focusNodeIds}
+              relayoutNonce={s.relayoutNonce}
+              onNodeClick={onNodeClick}
+              onNodeHover={(n) => s.setHoveredNode(n?.id ?? null)}
+              onSettled={() => {}}
+            />
+
+            <div className="pointer-events-none absolute bottom-3 left-3 z-20 rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
+              LOD: {lodLabel}
+            </div>
+
+            <div className="pointer-events-none absolute bottom-3 right-3 z-20 flex items-center gap-2 text-xs text-text-4">
+              drag · scroll · <Kbd>/</Kbd>
+            </div>
+
+            {selectedNode ? (
+              <NodeInspector
+                groupId={groupId}
+                node={selectedNode}
+                onClose={() => {
+                  s.setSelectedNode(null);
+                  s.setFocusNodes(null);
+                }}
+                onFocusNode={(id) => focusEgo(id)}
+              />
+            ) : null}
+          </>
+        )}
+
+        <FiltersDrawer repos={data?.repos ?? []} />
+      </div>
+    </div>
+  );
 }

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -1,0 +1,233 @@
+/* ============================================================
+   store/use-graph-store.ts — Graph-screen UI state (Zustand).
+
+   Holds the per-screen interaction + tuning state: selection, hover,
+   focus ego-graph, filters, group-by, and the four live tuning panels
+   (Node Sizing / Simulation / Rendering / Group-by). The tuning knobs are
+   persisted to localStorage (lesson ported from v1) so the owner's tuning
+   survives reloads.
+
+   The heavy graph DATA lives in TanStack Query (use-graph.ts); this store
+   only holds UI/interaction state.
+   ============================================================ */
+
+import { create } from "zustand";
+import type { EdgeKind } from "@/data/types";
+
+export type ColorMode = "repo" | "community" | "degree";
+export type GroupByMode = "repo" | "community" | "module" | "none";
+export type LodLevel = "low" | "mid" | "high";
+
+export interface SimulationConfig {
+  linkSpring: number;
+  linkDistance: number;
+  friction: number;
+  repulsion: number;
+  center: number;
+  /** ≤2s settle cap (the hard-won knob). Seconds. */
+  settleTime: number;
+}
+
+export interface NodeSizingConfig {
+  baseSize: number;
+  /** log10(degree) multiplier. */
+  degreeScale: number;
+  maxMultiplier: number;
+}
+
+export interface RenderConfig {
+  pointOpacity: number;
+  pointSizeScale: number;
+  scalePointsOnZoom: boolean;
+  maxPointSize: number;
+  linkWidthScale: number;
+  linkOpacity: number;
+  showLinks: boolean;
+}
+
+export const DEFAULT_SIMULATION: SimulationConfig = {
+  linkSpring: 1.0,
+  linkDistance: 8,
+  friction: 0.85,
+  repulsion: 1.2,
+  center: 0.4,
+  settleTime: 2.0,
+};
+
+export const DEFAULT_NODE_SIZING: NodeSizingConfig = {
+  baseSize: 120,
+  degreeScale: 30,
+  maxMultiplier: 3.0,
+};
+
+export const DEFAULT_RENDER: RenderConfig = {
+  pointOpacity: 0.92,
+  pointSizeScale: 0.22,
+  scalePointsOnZoom: true,
+  maxPointSize: 60,
+  linkWidthScale: 1.0,
+  linkOpacity: 0.18,
+  showLinks: true,
+};
+
+const ALL_EDGE_KINDS: EdgeKind[] = [
+  "CALLS",
+  "REFERENCES",
+  "RENDERS",
+  "DEPENDS_ON",
+  "EXTENDS",
+  "CONTAINS",
+  "IMPORTS",
+];
+
+function persistedJSON<T>(key: string, fallback: T): T {
+  if (typeof localStorage === "undefined") return fallback;
+  try {
+    const raw = localStorage.getItem(key);
+    return raw ? ({ ...fallback, ...JSON.parse(raw) } as T) : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+function persist<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    /* ignore */
+  }
+}
+
+interface GraphState {
+  // Interaction
+  selectedNodeId: string | null;
+  hoveredNodeId: string | null;
+  search: string;
+  focusedCommunityId: number | null;
+  /** N-hop ego-graph focus: explicit node ids, or null for the full graph. */
+  focusNodeIds: Set<string> | null;
+  filtersOpen: boolean;
+  communitiesOpen: boolean;
+
+  // Filters
+  enabledEdgeKinds: Set<EdgeKind>;
+  activeRepos: Set<string> | null; // null = all
+  lod: LodLevel;
+
+  // View knobs
+  colorMode: ColorMode;
+  groupBy: GroupByMode;
+
+  // Tuning (persisted)
+  simulation: SimulationConfig;
+  nodeSizing: NodeSizingConfig;
+  render: RenderConfig;
+
+  // Re-layout request flag (flips true to force a fresh settle)
+  relayoutNonce: number;
+
+  // Actions
+  setSelectedNode: (id: string | null) => void;
+  setHoveredNode: (id: string | null) => void;
+  setSearch: (q: string) => void;
+  setFocusedCommunity: (id: number | null) => void;
+  setFocusNodes: (ids: Set<string> | null) => void;
+  setFiltersOpen: (open: boolean) => void;
+  setCommunitiesOpen: (open: boolean) => void;
+  toggleEdgeKind: (kind: EdgeKind) => void;
+  toggleRepo: (repo: string) => void;
+  clearRepos: () => void;
+  setLod: (lod: LodLevel) => void;
+  setColorMode: (m: ColorMode) => void;
+  setGroupBy: (m: GroupByMode) => void;
+  setSimulation: (patch: Partial<SimulationConfig>) => void;
+  setNodeSizing: (patch: Partial<NodeSizingConfig>) => void;
+  setRender: (patch: Partial<RenderConfig>) => void;
+  requestRelayout: () => void;
+  clearAllFilters: () => void;
+  resetView: () => void;
+}
+
+export const useGraphStore = create<GraphState>((set) => ({
+  selectedNodeId: null,
+  hoveredNodeId: null,
+  search: "",
+  focusedCommunityId: null,
+  focusNodeIds: null,
+  filtersOpen: false,
+  communitiesOpen: false,
+
+  enabledEdgeKinds: new Set(ALL_EDGE_KINDS),
+  activeRepos: null,
+  lod: "mid",
+
+  colorMode: "repo",
+  groupBy: "repo",
+
+  simulation: persistedJSON("ag.v2.graph.sim", DEFAULT_SIMULATION),
+  nodeSizing: persistedJSON("ag.v2.graph.sizing", DEFAULT_NODE_SIZING),
+  render: persistedJSON("ag.v2.graph.render", DEFAULT_RENDER),
+
+  relayoutNonce: 0,
+
+  setSelectedNode: (selectedNodeId) => set({ selectedNodeId }),
+  setHoveredNode: (hoveredNodeId) => set({ hoveredNodeId }),
+  setSearch: (search) => set({ search }),
+  setFocusedCommunity: (focusedCommunityId) => set({ focusedCommunityId }),
+  setFocusNodes: (focusNodeIds) => set({ focusNodeIds }),
+  setFiltersOpen: (filtersOpen) => set({ filtersOpen }),
+  setCommunitiesOpen: (communitiesOpen) => set({ communitiesOpen }),
+
+  toggleEdgeKind: (kind) =>
+    set((s) => {
+      const next = new Set(s.enabledEdgeKinds);
+      if (next.has(kind)) next.delete(kind);
+      else next.add(kind);
+      return { enabledEdgeKinds: next };
+    }),
+  toggleRepo: (repo) =>
+    set((s) => {
+      const next = new Set(s.activeRepos ?? []);
+      if (next.has(repo)) next.delete(repo);
+      else next.add(repo);
+      return { activeRepos: next.size === 0 ? null : next };
+    }),
+  clearRepos: () => set({ activeRepos: null }),
+  setLod: (lod) => set({ lod }),
+  setColorMode: (colorMode) => set({ colorMode }),
+  setGroupBy: (groupBy) => set({ groupBy }),
+
+  setSimulation: (patch) =>
+    set((s) => {
+      const simulation = { ...s.simulation, ...patch };
+      persist("ag.v2.graph.sim", simulation);
+      return { simulation };
+    }),
+  setNodeSizing: (patch) =>
+    set((s) => {
+      const nodeSizing = { ...s.nodeSizing, ...patch };
+      persist("ag.v2.graph.sizing", nodeSizing);
+      return { nodeSizing };
+    }),
+  setRender: (patch) =>
+    set((s) => {
+      const render = { ...s.render, ...patch };
+      persist("ag.v2.graph.render", render);
+      return { render };
+    }),
+
+  requestRelayout: () => set((s) => ({ relayoutNonce: s.relayoutNonce + 1 })),
+  clearAllFilters: () =>
+    set({
+      enabledEdgeKinds: new Set(ALL_EDGE_KINDS),
+      activeRepos: null,
+      lod: "mid",
+    }),
+  resetView: () =>
+    set({
+      selectedNodeId: null,
+      hoveredNodeId: null,
+      focusedCommunityId: null,
+      focusNodeIds: null,
+    }),
+}));


### PR DESCRIPTION
Fixes #1437. Refs EPIC #1432.

## 1. What & why
The WebUI v2 **Graph** screen — the hero surface. A GPU-accelerated, WebGL dependency graph of every indexed entity in a group, built clean in `webui-v2/` per its ARCHITECTURE.md (api client → data hook → screen + canvas). Follows the Landing screen's data-hook + v2-envelope pattern. The legacy `dashboard/` app is untouched (verified zero diff).

## 2. How it works (layered)
- **api client** (`lib/api.ts`): `getGraph()` (v2 envelope) + `getEntityDetail()` (v1 reuse).
- **data hook** (`hooks/use-graph.ts`): TanStack Query, normalizes snake_case wire → camelCase domain.
- **screen** (`routes/graph.tsx`): toolbar (search `/`, color-mode segmented, Communities pill, Filters `F`, Reset), Escape cascade, search match count, click-to-focus ego-graph, LOD badge.
- **canvas** (`components/graph/graph-canvas.tsx`): imperative cosmos.gl engine wrapper.
- **surfaces**: `node-inspector` (floating overlay), `filters-drawer` (edge kinds / repos / LOD + tuning), `communities-popover`, `tuning-panels`.
- **state**: `store/use-graph-store.ts` (selection/filters + localStorage-persisted tuning).

## 3. Graph lessons ported from the old UI
- **cosmos.gl** (`@cosmos.gl/graph` 2.6.4, MIT — not @cosmograph NC) WebGL engine, driven imperatively with Float32 buffers.
- **RGB 0..1, NOT 0–255** — `writeNormalizedRGBA` normalizes at the GPU boundary so the shader doesn't clamp every node to white. Verified by pixel-sampling the framebuffer (0 white among colored).
- **bounded square spaceSize** (32768) + **fit-camera-to-node-bbox** so the settled graph fills the viewport.
- **cluster force** → repo / community / module islands; **bright sky cross-repo bridge** edges.
- **layout-cache** (`lib/graph-layout-cache.ts`): settled positions in localStorage → instant reload, explode/settle skipped.
- **≤2s settle cap + knob** (wall-clock hard-stop, live "Settle cap (s)" slider).
- **click-to-focus N-hop ego-graph** (hard-restrict rendered set + camera re-fit).
- **live tuning panels** (Node Sizing / Simulation / Rendering / Group-by), localStorage-persisted.
- **payload server cache + gzip + ETag** reused from v1.

## 4. Backend data decision
Added a **new** `GET /api/v2/graph/{group}` (`v2_graph.go`) rather than reusing v1 `/api/graph`. The v1 tier-1 payload deliberately omits `pagerank` + `source_file`, but the renderer needs both (node sizing + module group-by). The new handler reuses the v1 dense-build visibility/filter rules + the shared payload cache (`v2:`-prefixed keys) + ETag/304 + mux-level gzip, and adds `communities[]`/`repos[]` with stable color indices. Inspector detail still uses v1 `/entity/{id}` (unchanged). Documented in `API_V2.md` §6b.

## 5. Verification
- `npm run build` clean (tsc + vite). Full `go build ./internal/...` exits 0. `go test ./internal/dashboard -run "TestV2|Graph"` passes.
- Playwright (isolated dev :47280, live :47274 daemon untouched), small mock multi-repo graph:
  - **light + dark** render WITH COLOR (distinct repo islands + sky cross-repo bridges), zero white-out — confirms the RGB 0..1 fix.
  - **click-to-select** opens the inspector (kind/repo/file/PageRank/community + edges).
  - **click-to-focus** restricts to the ego-graph and re-fits the camera.
- `dashboard/` zero diff confirmed.

Screenshots: light, dark, inspector, focus (attached in review).

## 6. Risk / follow-ups
- Edge-kind filtering is client-side; repo/kind node filters are wired through the daemon params but the LOD selector is presentational pending the daemon-side LoD control (graph.md open question #3).
- The 840 kB JS bundle (cosmos.gl) triggers Vite's chunk-size warning — code-splitting the canvas is a sensible follow-up.
- `?node=` deep-link persistence (graph.md open question #1) not yet wired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)