### PR TITLE
fix(engine/python): context-manager alias binding + local variable URL resolution

### DIFF
--- a/internal/engine/http_endpoint_python_client.go
+++ b/internal/engine/http_endpoint_python_client.go
@@ -34,6 +34,7 @@
 package engine
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 
@@ -118,6 +119,41 @@ var pySessionClientRe = regexp.MustCompile(
 		`|` +
 		`([A-Za-z_][\w]*)` + // group 4: bare ident
 		`)`,
+)
+
+// pyContextManagerAliasRe matches `with` / `async with` context-manager
+// forms that bind an httpx or requests client to a user-chosen variable:
+//
+//	async with httpx.AsyncClient() as c:
+//	async with httpx.AsyncClient(base_url="...") as svc:
+//	with httpx.Client(base_url="...") as http:
+//	with requests.Session() as sess:
+//
+// Capture groups:
+//
+//	1 = client type  (AsyncClient | Client | Session)
+//	2 = optional base_url value (may be empty)
+//	3 = alias identifier
+var pyContextManagerAliasRe = regexp.MustCompile(
+	`(?:async\s+)?with\s+(?:httpx\.(?:Async)?Client|requests\.Session)\s*\(` +
+		`[^)]*?(?:base_url\s*=\s*["']([^"'\n\r]*)["'])?[^)]*\)\s+as\s+([A-Za-z_]\w*)`,
+)
+
+// pyLocalVarStringRe captures simple local string assignments inside a
+// function body:
+//
+//	pricing_endpoint = "http://pricing/api/v1/price"
+//	url = f"/items/{item_id}"
+//
+// We deliberately allow both lower and UPPER names (unlike the module-level
+// pyStringConstRe which skips pure-uppercase to avoid re-capturing constants
+// a second time — here all names are equally valid).
+//
+// The indentation prefix is required (at least one whitespace char) to avoid
+// matching module-level constants again; those are already handled by
+// buildPyStringSymbolTable.
+var pyLocalVarStringRe = regexp.MustCompile(
+	`(?m)^[ \t]+([a-zA-Z_][\w]*)\s*=\s*(f?)["']([^"'\n\r]{1,512})["']`,
 )
 
 // pyAiohttpInlineRe matches `aiohttp.ClientSession().<verb>("path", ...)`.
@@ -259,7 +295,17 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 	}
 	funcs := indexPyEnclosingFunctions(content)
 	syms := buildPyStringSymbolTable(content)
+	locals := buildPyLocalVarTable(content)
 	instances := buildPySessionInstanceTable(content)
+	// Merge local variables into syms for URL resolution (locals win on
+	// collision, as they are more specific than module-level constants).
+	mergedSyms := make(map[string]string, len(syms)+len(locals))
+	for k, v := range syms {
+		mergedSyms[k] = v
+	}
+	for k, v := range locals {
+		mergedSyms[k] = v
+	}
 
 	// requests.<verb>(...) / httpx.<verb>(...)
 	for _, m := range pyTopLevelVerbRe.FindAllStringSubmatchIndex(content, -1) {
@@ -268,11 +314,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		}
 		framework := content[m[2]:m[3]]
 		verb := strings.ToUpper(content[m[4]:m[5]])
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -288,11 +334,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		}
 		framework := content[m[2]:m[3]]
 		verb := strings.ToUpper(content[m[4]:m[5]])
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -306,11 +352,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		if len(m) < 6 {
 			continue
 		}
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 2, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 2, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -324,11 +370,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		if len(m) < 8 {
 			continue
 		}
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 2, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 2, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -344,7 +390,7 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		emit(verb, canonical, "urllib", "Function", caller, dynamic)
 	}
 
-	// Session / client instance calls.
+	// Session / client instance calls — static allowlist.
 	for _, m := range pySessionClientRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 10 {
 			continue
@@ -361,11 +407,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		if verb == "REQUEST" {
 			continue
 		}
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 6, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -378,17 +424,51 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 		emit(verb, canonical, "http_client", "Function", caller, dynamic)
 	}
 
+	// Session / client instance calls — dynamic aliases from context managers
+	// and explicit constructor assignments (e.g. `c = httpx.AsyncClient()`).
+	// Only fires for aliases NOT already covered by the static allowlist above
+	// to avoid double-emitting.
+	if dynRe := pyBuildDynamicAliasRe(instances); dynRe != nil {
+		for _, m := range dynRe.FindAllStringSubmatchIndex(content, -1) {
+			if len(m) < 10 {
+				continue
+			}
+			if m[0] > 0 && content[m[0]-1] == '@' {
+				continue
+			}
+			receiver := content[m[2]:m[3]]
+			verb := strings.ToUpper(content[m[4]:m[5]])
+			if verb == "REQUEST" {
+				continue
+			}
+			raw, isFString, dynamic := pyResolveURLArg(content, m, 6, mergedSyms)
+			if raw == "" {
+				continue
+			}
+			path, ok := pyCanonicalize(raw, isFString, mergedSyms)
+			if !ok {
+				continue
+			}
+			if base, ok := instances[receiver]; ok && base != "" {
+				path = composeBaseURL(base, path)
+			}
+			caller := enclosingPyFuncAt(funcs, m[0])
+			canonical := httproutes.Canonicalize(httproutes.FrameworkFastAPI, path)
+			emit(verb, canonical, "http_client", "Function", caller, dynamic)
+		}
+	}
+
 	// aiohttp inline form.
 	for _, m := range pyAiohttpInlineRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 8 {
 			continue
 		}
 		verb := strings.ToUpper(content[m[2]:m[3]])
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 4, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 4, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -403,11 +483,11 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 			continue
 		}
 		verb := strings.ToUpper(content[m[2]:m[3]])
-		raw, isFString, dynamic := pyResolveURLArg(content, m, 4, syms)
+		raw, isFString, dynamic := pyResolveURLArg(content, m, 4, mergedSyms)
 		if raw == "" {
 			continue
 		}
-		path, ok := pyCanonicalize(raw, isFString, syms)
+		path, ok := pyCanonicalize(raw, isFString, mergedSyms)
 		if !ok {
 			continue
 		}
@@ -454,6 +534,42 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 	}
 }
 
+// pyStaticAliasSet is the set of receiver names already matched by the
+// compiled pySessionClientRe. Used by pyBuildDynamicAliasRe to avoid
+// emitting duplicates.
+var pyStaticAliasSet = map[string]bool{
+	"session": true, "client": true, "http_client": true,
+	"api_client": true, "http": true, "api": true,
+}
+
+// pyBuildDynamicAliasRe builds a regex that matches `<alias>.<verb>(url)`
+// for every alias in `instances` that is NOT already covered by the static
+// pySessionClientRe allowlist. Returns nil when there are no new aliases.
+func pyBuildDynamicAliasRe(instances map[string]string) *regexp.Regexp {
+	var extras []string
+	for name := range instances {
+		if !pyStaticAliasSet[name] {
+			extras = append(extras, regexp.QuoteMeta(name))
+		}
+	}
+	if len(extras) == 0 {
+		return nil
+	}
+	pattern := fmt.Sprintf(
+		`\b(%s)\s*\.\s*(get|post|put|patch|delete|head|options|request)\s*\(\s*(?:`+
+			`f?["']([^"'\n\r]+)["']`+
+			`|`+
+			`([A-Za-z_][\w]*)`+
+			`)`,
+		strings.Join(extras, "|"),
+	)
+	re, err := regexp.Compile(pattern)
+	if err != nil {
+		return nil
+	}
+	return re
+}
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -495,6 +611,12 @@ func buildPyStringSymbolTable(content string) map[string]string {
 // name → base URL. Sources:
 //   - `<n> = httpx.Client(base_url="...")` and AsyncClient
 //   - `<n>.base_url = "..."` mutation
+//   - `with/async with httpx.AsyncClient(...) as <alias>` context managers
+//   - `with/async with requests.Session() as <alias>` context managers
+//
+// The empty-string value "" is used when no base_url is known; the
+// caller in synthesizePyClientWithRuntime only composes a prefix when the
+// base is non-empty.
 func buildPySessionInstanceTable(content string) map[string]string {
 	out := make(map[string]string)
 	for _, m := range pyHttpxClientCtorRe.FindAllStringSubmatch(content, -1) {
@@ -505,6 +627,48 @@ func buildPySessionInstanceTable(content string) map[string]string {
 	for _, m := range pySessionBaseURLRe.FindAllStringSubmatch(content, -1) {
 		if len(m) >= 3 {
 			out[m[1]] = stripURLHost(m[2])
+		}
+	}
+	// Context-manager alias bindings: `with httpx.AsyncClient() as c` etc.
+	// Register every alias so it is recognised as a client receiver even when
+	// the name is not in the pySessionClientRe allowlist.
+	for _, m := range pyContextManagerAliasRe.FindAllStringSubmatch(content, -1) {
+		// m[1] = optional base_url, m[2] = alias
+		if len(m) >= 3 {
+			alias := m[2]
+			base := ""
+			if m[1] != "" {
+				base = stripURLHost(m[1])
+			}
+			if _, exists := out[alias]; !exists {
+				out[alias] = base
+			}
+		}
+	}
+	return out
+}
+
+// buildPyLocalVarTable returns a map from local-variable name → string value
+// for every indented (function-body-level) string assignment in the file.
+// It intentionally includes all names regardless of case so that patterns
+// like `pricing_endpoint = "http://..."` are resolved when used as a URL
+// argument later in the same function.
+//
+// Note: this is a file-wide scan — we do not attempt true per-function
+// scoping. False-positive variable capture across function boundaries is
+// extremely rare in practice and the worst outcome is resolving a URL from
+// another function in the same file (which still produces a valid edge).
+func buildPyLocalVarTable(content string) map[string]string {
+	out := make(map[string]string)
+	for _, m := range pyLocalVarStringRe.FindAllStringSubmatch(content, -1) {
+		// m[1]=name, m[2]="f" if f-string, m[3]=body
+		if len(m) < 4 {
+			continue
+		}
+		name := m[1]
+		val := m[3]
+		if _, dup := out[name]; !dup {
+			out[name] = val
 		}
 	}
 	return out

--- a/internal/engine/http_endpoint_python_client_test.go
+++ b/internal/engine/http_endpoint_python_client_test.go
@@ -175,3 +175,163 @@ def fetch_health():
 	requireContains(t, ids, want, "urllib-urlopen")
 	requireFetches(t, rels, "http:GET:/health", "urllib-urlopen")
 }
+
+// ---------------------------------------------------------------------------
+// #1465 regression tests
+// ---------------------------------------------------------------------------
+
+// TestPyClient_ContextManagerAlias_Short covers the saga fixture pattern:
+//
+//	async with httpx.AsyncClient() as c:
+//	    await c.post("/orders/confirm", ...)
+//
+// The alias "c" is not in the static allowlist, so prior to the fix these
+// calls produced zero http_endpoint synthetics.
+func TestPyClient_ContextManagerAlias_Short(t *testing.T) {
+	src := `
+import httpx
+
+async def confirm_order(order_id: str):
+    async with httpx.AsyncClient() as c:
+        r = await c.post("/orders/confirm", json={"order_id": order_id})
+    return r
+
+async def reserve_inventory(item_id: str):
+    async with httpx.AsyncClient() as c:
+        r = await c.post("/inventory/reserve", json={"item_id": item_id})
+    return r
+
+async def charge_payment(amount: float):
+    async with httpx.AsyncClient() as c:
+        r = await c.post("/payments/charge", json={"amount": amount})
+    return r
+`
+	ids, rels := runDetectWithRels(t, "python", "steps.py", src)
+	want := []string{
+		"http:POST:/orders/confirm",
+		"http:POST:/inventory/reserve",
+		"http:POST:/payments/charge",
+	}
+	requireContains(t, ids, want, "context-manager-alias-short")
+	requireFetches(t, rels, "http:POST:/orders/confirm", "context-manager-alias-short")
+	requireFetches(t, rels, "http:POST:/inventory/reserve", "context-manager-alias-short")
+	requireFetches(t, rels, "http:POST:/payments/charge", "context-manager-alias-short")
+}
+
+// TestPyClient_ContextManagerAlias_WithBaseURL covers the case where the
+// context-manager binding includes a base_url:
+//
+//	async with httpx.AsyncClient(base_url="http://orders-svc") as svc:
+//	    await svc.get("/items")
+func TestPyClient_ContextManagerAlias_WithBaseURL(t *testing.T) {
+	src := `
+import httpx
+
+async def list_items():
+    async with httpx.AsyncClient(base_url="http://items-svc") as svc:
+        return await svc.get("/items")
+`
+	ids, rels := runDetectWithRels(t, "python", "items_client.py", src)
+	want := []string{"http:GET:/items"}
+	requireContains(t, ids, want, "context-manager-alias-base-url")
+	requireFetches(t, rels, "http:GET:/items", "context-manager-alias-base-url")
+}
+
+// TestPyClient_ContextManagerAlias_SyncClient covers `with httpx.Client() as http_svc`.
+func TestPyClient_ContextManagerAlias_SyncClient(t *testing.T) {
+	src := `
+import httpx
+
+def get_price(sku: str):
+    with httpx.Client() as http_svc:
+        return http_svc.get(f"/pricing/{sku}")
+`
+	ids, rels := runDetectWithRels(t, "python", "pricing.py", src)
+	want := []string{"http:GET:/pricing/{sku}"}
+	requireContains(t, ids, want, "context-manager-sync-client")
+	requireFetches(t, rels, "http:GET:/pricing/{sku}", "context-manager-sync-client")
+}
+
+// TestPyClient_ContextManagerAlias_RequestsSession covers
+// `with requests.Session() as sess`.
+func TestPyClient_ContextManagerAlias_RequestsSession(t *testing.T) {
+	src := `
+import requests
+
+def fetch_users():
+    with requests.Session() as sess:
+        return sess.get("/api/users")
+`
+	ids, rels := runDetectWithRels(t, "python", "session_client.py", src)
+	want := []string{"http:GET:/api/users"}
+	requireContains(t, ids, want, "context-manager-requests-session")
+	requireFetches(t, rels, "http:GET:/api/users", "context-manager-requests-session")
+}
+
+// TestPyClient_VariableURL covers the orders→pricing fixture pattern:
+//
+//	pricing_endpoint = "http://pricing-svc/api/v1/price"
+//	...
+//	async with httpx.AsyncClient() as c:
+//	    r = await c.get(pricing_endpoint)
+//
+// The URL is held in a local variable, not an inline string. Prior to the
+// fix this produced zero http_endpoint synthetics because the bare
+// identifier was not in the module-level symbol table.
+func TestPyClient_VariableURL(t *testing.T) {
+	src := `
+import httpx
+
+async def get_price(sku: str):
+    pricing_endpoint = "http://pricing-svc/api/v1/price"
+    async with httpx.AsyncClient() as c:
+        r = await c.get(pricing_endpoint)
+    return r
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	want := []string{"http:GET:/api/v1/price"}
+	requireContains(t, ids, want, "variable-url")
+	requireFetches(t, rels, "http:GET:/api/v1/price", "variable-url")
+}
+
+// TestPyClient_VariableURL_AllowlistReceiver verifies that variable-URL
+// resolution also works for receivers that ARE in the static allowlist
+// (regression guard — the mergedSyms path must cover both cases).
+func TestPyClient_VariableURL_AllowlistReceiver(t *testing.T) {
+	src := `
+import httpx
+
+async def get_price(sku: str):
+    pricing_endpoint = "http://pricing-svc/api/v1/price"
+    async with httpx.AsyncClient() as client:
+        r = await client.get(pricing_endpoint)
+    return r
+`
+	ids, rels := runDetectWithRels(t, "python", "routes2.py", src)
+	want := []string{"http:GET:/api/v1/price"}
+	requireContains(t, ids, want, "variable-url-allowlist-receiver")
+	requireFetches(t, rels, "http:GET:/api/v1/price", "variable-url-allowlist-receiver")
+}
+
+// TestPyClient_NoRegression_StaticAllowlist verifies that the pre-existing
+// static allowlist names still work and emit exactly one edge (not doubled
+// by the dynamic alias pass).
+func TestPyClient_NoRegression_StaticAllowlist(t *testing.T) {
+	src := `
+import httpx
+
+async def list_orders():
+    async with httpx.AsyncClient() as client:
+        r = await client.get("/api/orders")
+    return r
+`
+	ids, rels := runDetectWithRels(t, "python", "no_regression.py", src)
+	want := []string{"http:GET:/api/orders"}
+	requireContains(t, ids, want, "no-regression-static-allowlist")
+
+	// Exactly one FETCHES edge — not doubled.
+	hits := fetchesEdgesFor(rels, "http:GET:/api/orders")
+	if len(hits) != 1 {
+		t.Errorf("no-regression-static-allowlist: expected exactly 1 FETCHES edge to http:GET:/api/orders, got %d", len(hits))
+	}
+}


### PR DESCRIPTION
## What

Fixes two extraction gaps that silently dropped cross-repo HTTP edges in Python services using httpx/requests context-manager patterns (Fixes #1465).

## Root cause

`http_endpoint_python_client.go` matched client receivers against a **fixed allowlist** (`session|client|http_client|api_client|http|api`) and never parsed `async with httpx.AsyncClient() as <alias>` / `with httpx.Client() as <alias>` / `with requests.Session() as <alias>` to learn the bound receiver name. Additionally, bare-identifier URL arguments (e.g. `c.get(pricing_endpoint)`) were only resolved from the module-level string symbol table, not from function-local variable assignments.

**Fixture proof (before fix):**
- `services/order-saga/app/steps.py` uses `as c` → 5 saga cross-repo edges emitted **zero** http_endpoint_call synthetics
- `services/orders/app/routes.py` pricing call uses `as client` + `pricing_endpoint` variable → **zero** resolved edges (variable not in module-level syms)

## Fix

### 1. Context-manager alias binding (`pyContextManagerAliasRe` + `buildPySessionInstanceTable`)
Added `pyContextManagerAliasRe` that matches:
```python
async with httpx.AsyncClient() as c:
async with httpx.AsyncClient(base_url="...") as svc:
with httpx.Client() as http_svc:
with requests.Session() as sess:
```
All bound aliases (including `base_url` when present) are registered in `buildPySessionInstanceTable`. A new `pyBuildDynamicAliasRe` helper builds a per-file dynamic regex from aliases NOT already in the static allowlist and runs a second scan pass — static-allowlist receivers are NOT processed again (no double-emit).

### 2. Function-local variable URL resolution (`pyLocalVarStringRe` + `buildPyLocalVarTable`)
Added `pyLocalVarStringRe` that captures indented (function-body-level) string assignments:
```python
    pricing_endpoint = "http://pricing-svc/api/v1/price"
    url = f"/items/{item_id}"
```
`buildPyLocalVarTable` scans the file for these and merges results into `mergedSyms` (locals win on collision). All call-site resolvers now use `mergedSyms` instead of the module-level `syms` map.

## Before / after (synthetic edge count on saga fixture pattern)

| Pattern | Before | After |
|---|---|---|
| `async with httpx.AsyncClient() as c: await c.post("/orders/confirm")` | 0 edges | 1 edge |
| `async with httpx.AsyncClient() as c: await c.post("/inventory/reserve")` | 0 edges | 1 edge |
| `async with httpx.AsyncClient() as c: await c.post("/payments/charge")` | 0 edges | 1 edge |
| `client.get(pricing_endpoint)` where `pricing_endpoint = "http://svc/..."` | 0 edges | 1 edge |
| `client.get("/api/orders")` (static allowlist, no regression) | 1 edge | 1 edge (no double-emit) |

**Net new edges from #1465 fix: ≥5 saga cross-repo edges + orders→pricing edge.**

## Tests

7 new unit tests added to `http_endpoint_python_client_test.go`:
- `TestPyClient_ContextManagerAlias_Short` — saga `as c` pattern, 3 services
- `TestPyClient_ContextManagerAlias_WithBaseURL` — `as svc` with base_url
- `TestPyClient_ContextManagerAlias_SyncClient` — `with httpx.Client() as http_svc`
- `TestPyClient_ContextManagerAlias_RequestsSession` — `with requests.Session() as sess`
- `TestPyClient_VariableURL` — local variable URL + non-allowlist alias
- `TestPyClient_VariableURL_AllowlistReceiver` — local variable URL + allowlist alias (regression guard)
- `TestPyClient_NoRegression_StaticAllowlist` — exactly 1 FETCHES edge for `as client` (anti-double-emit)

All 13 `TestPyClient_*` pass. Full `./internal/engine/...` suite clean. Pre-existing daemon/verify failures are unrelated to this change.

## Checklist
- [x] All existing tests pass
- [x] 7 new targeted regression tests
- [x] No double-emit for static allowlist names
- [x] `buildPySessionInstanceTable` extended (not replaced)
- [x] `mergedSyms` used throughout `synthesizePyClientWithRuntime` 
- [x] `fmt` import added (needed for `pyBuildDynamicAliasRe`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)