### PR TITLE
fix(daemon): subscribe watchers off boot critical path — live group-load hang (Fixes #1456)

### DIFF
--- a/internal/daemon/boot_watcher_async_test.go
+++ b/internal/daemon/boot_watcher_async_test.go
@@ -1,0 +1,121 @@
+package daemon_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+)
+
+// TestBoot_WatcherSubscriptionDoesNotBlockBind is the regression guard
+// for #1456: a stalled watcher subscription (ReposToWatch returning slowly,
+// or a per-repo AddRepo walk hanging on a slow mount / FD pressure / kqueue
+// contention) must NOT prevent the daemon from binding its RPC socket and
+// becoming ready.
+//
+// Before the fix the watcher subscription ran synchronously on Run()'s
+// critical path, between the scheduler start and the RPC accept loop, so any
+// stall there left the daemon at 0% CPU never serving — exactly what the
+// live :47274 daemon exhibited on shipfast group-load (10/328 boots stalled
+// in the watcher phase per the daemon.log forensics).
+//
+// We simulate the stall by making ReposToWatch block for far longer than the
+// readiness deadline. With the async fix the socket binds well within the
+// deadline; with the old synchronous code Dial would never succeed until the
+// stall cleared.
+func TestBoot_WatcherSubscriptionDoesNotBlockBind(t *testing.T) {
+	root := shortTempRoot(t)
+	t.Setenv(daemon.EnvRoot, root)
+	layout, err := daemon.DefaultLayout()
+	if err != nil {
+		t.Fatalf("layout: %v", err)
+	}
+	if err := daemon.EnsureLayout(layout); err != nil {
+		t.Fatalf("ensure: %v", err)
+	}
+
+	// ReposToWatch blocks for 5s, simulating a stalled filesystem walk
+	// during watcher subscription. released is closed when it returns so
+	// the test can confirm the goroutine actually ran (and is off the
+	// critical path).
+	const stall = 5 * time.Second
+	released := make(chan struct{})
+	cfg := daemon.Config{
+		Layout: layout,
+		ReposToWatch: func() []string {
+			defer close(released)
+			time.Sleep(stall)
+			return nil
+		},
+		GroupsForRepo:  func(_ string) []string { return nil },
+		SchedulerIndex: func(_ context.Context, _ string) error { return nil },
+		SchedulerLinks: func(_ context.Context, _ string) error { return nil },
+		SchedulerAlgo:  func(_ context.Context, _ string) error { return nil },
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() { done <- daemon.Run(ctx, cfg) }()
+
+	// The daemon must SERVE RPC promptly — far sooner than the 5s stall.
+	// We assert a real Ping round-trip completes, not merely that the socket
+	// file exists: the socket is created early (transport.Listen) but the
+	// accept loop, dashboard goroutine, and "ready" log all sit AFTER the
+	// watcher subscription on the boot path. A synchronous stall there means
+	// the daemon binds the fd but never answers — exactly the live symptom
+	// (0% CPU, :47274 never serving). We give a generous 2s budget; the boot
+	// path itself is sub-100ms.
+	// pingOnce dials and Pings with a hard per-attempt timeout. net/rpc's
+	// Call blocks until the server's accept loop reads the request, so a
+	// blocked daemon would otherwise hang this attempt indefinitely and
+	// silently outlast the deadline. The timeout converts that into a
+	// failed attempt we can retry / time out cleanly.
+	pingOnce := func(timeout time.Duration) bool {
+		c, derr := client.Dial()
+		if derr != nil {
+			return false
+		}
+		defer c.Close()
+		res := make(chan error, 1)
+		go func() { _, perr := c.Ping(); res <- perr }()
+		select {
+		case err := <-res:
+			return err == nil
+		case <-time.After(timeout):
+			return false
+		}
+	}
+
+	servedDeadline := time.Now().Add(2 * time.Second)
+	served := false
+	for time.Now().Before(servedDeadline) {
+		if pingOnce(200 * time.Millisecond) {
+			served = true
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if !served {
+		t.Fatalf("daemon did not answer an RPC within 2s while the watcher "+
+			"subscription was stalled for %s — watcher setup is blocking the "+
+			"boot critical path (#1456 regression)", stall)
+	}
+
+	// Sanity: the stalled subscription really was running concurrently and
+	// eventually returns (it is not silently skipped).
+	select {
+	case <-released:
+	case <-time.After(stall + 2*time.Second):
+		t.Fatalf("ReposToWatch never released — watcher goroutine not started")
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Log("daemon did not exit within 3s of cancel")
+	}
+}

--- a/internal/daemon/server.go
+++ b/internal/daemon/server.go
@@ -213,12 +213,33 @@ func Run(ctx context.Context, cfg Config) error {
 		} else {
 			svc.watcher = watcher
 			defer watcher.Stop()
+			// #1456: subscribe repos OFF the critical boot path. Each
+			// AddRepo recursively walks the repo tree and issues an
+			// fsnotify (kqueue/inotify) Add per directory. On a grown
+			// multi-repo fixture this is thousands of filesystem syscalls,
+			// and a single stalled stat/Add (slow mount, FD pressure,
+			// firmlink/snapshot dir, kqueue contention from sibling watch
+			// processes) used to block Run() before it ever bound the RPC
+			// socket or dashboard — the daemon would sit at 0% CPU and
+			// never serve. Live boot logs showed 10/328 boots stalling here
+			// between "scheduler: RSS-budget" and "pattern decay started",
+			// having registered 0–3 of 27 repos. Doing the walk in a
+			// goroutine lets boot reach "ready" + acceptLoop promptly; the
+			// graph is served from the on-disk .fb regardless, and reactive
+			// reindex simply becomes live once each repo finishes
+			// subscribing.
 			if cfg.ReposToWatch != nil {
-				for _, r := range cfg.ReposToWatch() {
-					if _, err := watcher.AddRepo(r); err != nil {
-						logger.Printf("watcher: add repo %s: %v", r, err)
+				go func() {
+					t0 := time.Now()
+					repos := cfg.ReposToWatch()
+					for _, r := range repos {
+						if _, err := watcher.AddRepo(r); err != nil {
+							logger.Printf("watcher: add repo %s: %v", r, err)
+						}
 					}
-				}
+					logger.Printf("watcher: subscription complete repos=%d took=%s",
+						len(repos), time.Since(t0).Truncate(time.Millisecond))
+				}()
 			}
 			if cfg.OnWatcherReady != nil {
 				cfg.OnWatcherReady(watcher)


### PR DESCRIPTION
## 1. Problem
The live archigraph daemon intermittently **hung on `shipfast` group-load**: 0% CPU, never binding `:47274`, never reaching `ready`, for 60s+. Booted fine with an empty registry. The capped binary (#1459) and deleting `shipfast-links.json` didn't help, and a clean alt-root state copy did not reliably reproduce — the trigger lived in the full live setup.

## 2. Investigation / Root Cause
Forensics on `~/.archigraph/logs/daemon.log` were decisive. Across **328 historical boots**:
- 328 logged `graph format`
- 302 reached `scheduler: RSS-budget`
- only **294** reached `pattern decay scheduler started` / `ready`

So **10 boots stalled in the watcher-setup phase** — between the scheduler-config log and pattern-decay — having registered **0–3 of the 27 repos** (`watcher: registered` count per hung boot: 3, 1, 1, then 0×7 in the shipfast-grown era).

In `daemon.Run` (`internal/daemon/server.go`) the watcher repo-subscription loop — `ReposToWatch()` + per-repo `watcher.AddRepo()`, where each `AddRepo` does a recursive `filepath.WalkDir` issuing an fsnotify/kqueue `Add` per directory (thousands of syscalls on the grown 27-repo fixture) — ran **synchronously on the boot critical path, before** the RPC accept loop (`go acceptLoop`) and the dashboard goroutine were started. A single stalled walk (slow mount, FD/kqueue pressure from the machine's sibling `archigraph watch` processes, an APFS firmlink/snapshot dir) blocks `Run()` before it ever binds and serves — precisely the observed symptom. The grown fixture widened the synchronous window enough to hit ~2–3% of boots.

## 3. Fix
Run the `ReposToWatch()` + `AddRepo` loop in a **goroutine**. The watcher object is still created synchronously (cheap — one fsnotify handle), but the heavy filesystem walk happens in the background, so `Run()` reaches `ready` + `acceptLoop` + dashboard-listen promptly. The graph is served from the on-disk `.fb` regardless; reactive reindex goes live per-repo as each finishes subscribing (logged via `watcher: subscription complete repos=N took=…`).

## 4. Goroutine / Blocking Evidence
The regression test injects a `ReposToWatch` that stalls 5s and asserts a real `Ping` RPC round-trips within 2s:
- **Old synchronous code:** `FAIL` in 2.05s — daemon binds the socket fd but never answers (parked in the watcher loop before `go acceptLoop`). This is the live symptom: bound-but-not-serving, 0% CPU.
- **With the fix:** `PASS` — `ready` logs immediately; `watcher: subscription complete` logs 5s later.

E2E with a copy of the live `~/.archigraph` + shipfast on an isolated alt root/port: `ready` + `dashboard ready` now log **first** (06:13:24.315), and watcher subscription completes **721ms later** (06:13:25.035) instead of blocking the bind.

## 5. Tests
- New `internal/daemon/boot_watcher_async_test.go` — `TestBoot_WatcherSubscriptionDoesNotBlockBind`. Verified red-on-old / green-on-fix.
- `go vet` + `gofmt` clean. (Two pre-existing `TestPhaseB_*` fsnotify-timing failures reproduce on `origin/main` unchanged and are unrelated to this fix.)

## 6. Safety / Teardown
- The alt instance ran on an isolated `ARCHIGRAPH_DAEMON_ROOT`/`ARCHIGRAPH_HOME` copy, port 47994, own socket. It and its root copy were torn down completely; no rogue daemons remain.
- The live `:47274` daemon (PID 34545) was never touched and is confirmed still UP (`http 200`).

Fixes #1456

🤖 Generated with [Claude Code](https://claude.com/claude-code)