### PR TITLE
fix(P7): dedup key (topicName, repo-pair) — distinct-topic edges no longer collapse (#1474)

### DIFF
--- a/internal/links/topic_pass.go
+++ b/internal/links/topic_pass.go
@@ -23,7 +23,11 @@ package links
 // pass so the same topic Name appears in every repo that touches it. P7
 // joins by Name, exactly like P4 joins http_endpoint synthetics by Name.
 //
-// Emits one link per (publisher-entity, subscriber-entity) cross-repo pair:
+// Emits one link per (topicName, publisherRepo, subscriberRepo) triple — i.e.
+// one edge per distinct topic per repo-pair. Two different topics flowing
+// between the same repo-pair produce two separate edges (#1474). Within a
+// single topic the representative-per-side entity selection still collapses
+// the publisher×subscriber entity cartesian to O(1) per repo-pair (#1453).
 //
 //	relation   = "publishes_to"
 //	method     = "topic"
@@ -265,7 +269,16 @@ func runTopicPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pas
 
 				source := entityKey(pub.repo, srcID)
 				target := entityKey(sub.repo, tgtID)
-				id := MakeID(source, target, MethodTopic)
+				// Dedup key is (topicName, publisherRepo, subscriberRepo): two
+				// distinct topics flowing between the same repo-pair must each emit
+				// their own edge. Before #1474 the key was just (source, target,
+				// method) — which collapsed when the same representative entity was
+				// the minimum publisher/subscriber for two different topic Names,
+				// suppressing the second edge (#1474). Including `name` in the ID
+				// hash produces a unique key per (topic, repo-pair) while keeping
+				// the O(R²) rep-per-side bound intact. Link.Method stays MethodTopic
+				// so replaceByMethod segregation is unchanged.
+				id := MakeID(source, target, MethodTopic+":"+name)
 				if emitted[id] {
 					continue
 				}

--- a/internal/links/topic_pass_test.go
+++ b/internal/links/topic_pass_test.go
@@ -360,3 +360,103 @@ func TestTopicPass_EventBridgeChannel(t *testing.T) {
 		t.Errorf("channel: want eventbridge, got %v", topicLinks[0].Channel)
 	}
 }
+
+// TestTopicPass_TwoDistinctTopicsSameRepoPair is the #1474 regression guard.
+//
+// When two DIFFERENT topic names both flow from the same publisher repo to the
+// same subscriber repo, the pre-#1474 code collapsed them into a single edge
+// because the dedup key was (source-entity, target-entity, method). If the same
+// representative entity (lexicographic minimum) was chosen for BOTH topics on
+// each side, MakeID produced an identical hash and the second edge was dropped.
+//
+// After the fix the dedup key is (topicName, source-entity, target-entity), so
+// each distinct topic between a given repo-pair emits its own edge.
+func TestTopicPass_TwoDistinctTopicsSameRepoPair(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// orders repo: one function publishes BOTH topics.
+	// Using the SAME entity ID ("shared_pub") as the publisher for both ensures
+	// the pre-fix code would choose the same representative and produce a
+	// colliding MakeID → dropping the second topic edge.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			// shared_pub is the lex-minimum publisher entity for both topics.
+			{"id": "shared_pub", "name": "publish_events", "kind": "SCOPE.Operation", "source_file": "orders/producer.py"},
+			{"id": "topic_placed", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+			{"id": "topic_shipped", "name": "kafka:orders.shipped", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "shared_pub", "to_id": "topic_placed", "kind": "PUBLISHES_TO"},
+			{"from_id": "shared_pub", "to_id": "topic_shipped", "kind": "PUBLISHES_TO"},
+		},
+	})
+
+	// notifications repo: one function subscribes to BOTH topics.
+	// Same pattern: shared_sub is the lex-minimum subscriber for both topics.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "notifications",
+		Entities: []map[string]any{
+			{"id": "shared_sub", "name": "handle_order_event", "kind": "SCOPE.Operation", "source_file": "notifications/handler.js"},
+			{"id": "topic_placed_n", "name": "kafka:orders.placed", "kind": "SCOPE.MessageTopic", "source_file": ""},
+			{"id": "topic_shipped_n", "name": "kafka:orders.shipped", "kind": "SCOPE.MessageTopic", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "shared_sub", "to_id": "topic_placed_n", "kind": "SUBSCRIBES_TO"},
+			{"from_id": "shared_sub", "to_id": "topic_shipped_n", "kind": "SUBSCRIBES_TO"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-topic-1474")
+	result, err := RunAllPasses("tg1474", root, home)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, err := readDoc(filepath.Join(home, "groups", "tg1474-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var topicLinks []Link
+	for _, l := range doc.Links {
+		if l.Method == MethodTopic {
+			topicLinks = append(topicLinks, l)
+		}
+	}
+
+	// Must emit 2 edges: one per distinct topic, not 1 (the pre-#1474 collapse).
+	if len(topicLinks) != 2 {
+		t.Fatalf("#1474 regression: expected 2 topic links (one per distinct topic), got %d; "+
+			"pass results=%+v; links=%+v", len(topicLinks), result.Results, topicLinks)
+	}
+
+	// Both edges must share the same source and target (same rep entities).
+	for _, l := range topicLinks {
+		if l.Source != "orders::shared_pub" {
+			t.Errorf("source: want orders::shared_pub, got %s", l.Source)
+		}
+		if l.Target != "notifications::shared_sub" {
+			t.Errorf("target: want notifications::shared_sub, got %s", l.Target)
+		}
+	}
+
+	// Verify both topic identifiers are present.
+	identifiers := map[string]bool{}
+	for _, l := range topicLinks {
+		if l.Identifier != nil {
+			identifiers[*l.Identifier] = true
+		}
+	}
+	if !identifiers["kafka:orders.placed"] {
+		t.Error("expected kafka:orders.placed identifier among topic links")
+	}
+	if !identifiers["kafka:orders.shipped"] {
+		t.Error("expected kafka:orders.shipped identifier among topic links")
+	}
+
+	// Both link IDs must be distinct.
+	if topicLinks[0].ID == topicLinks[1].ID {
+		t.Errorf("link IDs must be distinct per topic; both got %s", topicLinks[0].ID)
+	}
+}


### PR DESCRIPTION
## What

P7 (topic pass) was silently dropping cross-repo edges when two **different** topic Names flowed between the **same** repo-pair. Only one of the two edges was emitted; the second was suppressed by the global `emitted` dedup map.

## Why it broke

The dedup key was `MakeID(source, target, MethodTopic)` — `sha8(sourceEntity + "→" + targetEntity + ":topic")`. The representative entity per side is chosen as `minString(ids)` (lex-minimum entity ID in the repo for that topic). If the same entity was the lex-minimum publisher for **both** `kafka:orders.placed` and `kafka:orders.shipped`, and the same entity was the lex-minimum subscriber on the other side, both iterations produced an identical hash. The `emitted[id]` guard treated the second as a duplicate and dropped it (#1474 regression, introduced in the #1454/#1459 hang-fix).

## Fix

Include the topic Name in the ID hash: `MakeID(source, target, MethodTopic+":"+name)`. This makes the dedup key effectively `(topicName, sourceEntity, targetEntity)` — i.e. one edge per distinct topic per repo-pair.

- `Link.Method` stays `"topic"` — `replaceByMethod` segregation unchanged.
- The `representative-per-side` selection from #1453/#1454 is untouched (still O(1) entities per repo).
- `topicEmissionCapPerName` guard from #1459 is retained.
- Emission is now O(distinct-topics × publisher-repos × subscriber-repos), which is the correct bound.

## Tests

| Test | Before | After |
|---|---|---|
| `TestTopicPass_TwoDistinctTopicsSameRepoPair` (**new, #1474 guard**) | would FAIL (1 link emitted, 2 expected) | PASS (2 links, distinct IDs) |
| `TestTopicPass_RealSkewedShape_BoundedEmission` (#1456 scale guard) | 8 links | 8 links — unchanged |
| `TestTopicGRPCPass_ScaleCompletes` (#1453 scale guard) | 702 topic links | 702 topic links — unchanged |
| `TestShipFastManifest_GRPCAndTopicLinks` (#1447 acceptance) | 7 topic links | 7 topic links — unchanged |
| All other `TestTopicPass_*` | PASS | PASS |

Full package: `go test ./internal/links/... -timeout 120s` — OK.

## Before / After (fixture measure)

The ShipFast manifest fixture has no same-entity multi-topic scenario today, so its count stays at 7. The new test (`TestTopicPass_TwoDistinctTopicsSameRepoPair`) is the direct #1474 repro: 1 shared publisher entity, 1 shared subscriber entity, 2 distinct topic Names → was 1 edge, now 2.

## Scope

`internal/links/topic_pass.go` + `internal/links/topic_pass_test.go` only. No schema changes, no daemon changes, no API changes.

Fixes #1474

🤖 Generated with [Claude Code](https://claude.com/claude-code)