### PR TITLE
fix(php-client): resolve variable-interpolated and concat URLs in Laravel Http::

### DIFF
--- a/internal/engine/http_endpoint_php_client.go
+++ b/internal/engine/http_endpoint_php_client.go
@@ -218,6 +218,7 @@ var phpLaravelEnvVerbRe = regexp.MustCompile(
 
 // ---------------------------------------------------------------------------
 // PHP variable string table: $url = "/path"; $base = "https://...";
+// Also captures runtime-dynamic base URLs: $x = config(...) / env(...)
 // ---------------------------------------------------------------------------
 
 // phpStringVarRe captures PHP variable string assignments:
@@ -227,6 +228,104 @@ var phpLaravelEnvVerbRe = regexp.MustCompile(
 //	$endpoint = '/api/v1/users';
 var phpStringVarRe = regexp.MustCompile(
 	`(?m)(\$[A-Za-z_][\w]*)\s*=\s*(?:"([^"\n\r]{1,256})"|'([^'\n\r]{1,256})')`,
+)
+
+// phpConfigVarRe captures PHP variable assignments whose value is a runtime
+// config/env call:
+//
+//	$ordersUrl  = config('services.orders.url');
+//	$baseUrl    = env('ORDERS_BASE');
+//	$apiBaseUrl = config("services.notifications.url");
+//
+// Group 1 = variable name, group 2+ = config key (unused by caller — just
+// the presence of the assignment is needed to mark the var as runtime-dynamic).
+var phpConfigVarRe = regexp.MustCompile(
+	`(?m)(\$[A-Za-z_][\w]*)\s*=\s*(?:config|env)\s*\(\s*(?:"[^"\n\r]{1,256}"|'[^'\n\r]{1,256}')\s*\)`,
+)
+
+// phpInterpLeadingVarRe matches a PHP double-quoted string whose FIRST
+// interpolation is a variable: "{$ordersUrl}/orders/{$orderId}".
+// It captures:
+//   - group 1: the leading variable name (without `${}` delimiters), e.g. "ordersUrl"
+//   - group 2: the static path suffix following the first interpolation,
+//     e.g. "/orders/" — further `{$x}` segments inside it are converted to
+//     OpenAPI {x} placeholders by resolvePHPInterpSuffix.
+var phpInterpLeadingVarRe = regexp.MustCompile(
+	`^\{\$([A-Za-z_][\w]*)\}([^"'\n\r]*)$`,
+)
+
+// phpInnerInterpRe replaces `{$varName}` and `{$obj->prop}` segments within a
+// path suffix with the OpenAPI placeholder `{varName}` or `{prop}`.
+// Matches:
+//   - {$orderId}        → {orderId}
+//   - {$this->orderId}  → {orderId}  (last identifier after ->)
+var phpInnerInterpRe = regexp.MustCompile(`\{\$([A-Za-z_][\w]*(?:->[A-Za-z_][\w]*)*)\}`)
+
+// phpConcatLeadingVarRe matches PHP concatenation where a variable prefixes
+// a string literal, as captured by the URL variable group in client regexes
+// AFTER the literal groups have been exhausted. It is applied to the raw
+// URL value when it looks like `$varName . "/path"` — this form is
+// pre-folded into the symbol table (literal part already extracted) so this
+// regex handles the separate concat-detection pass.
+//
+// This regex operates on the CONTENT around the call site, not on the already-
+// extracted raw string. See synthesizePHPClient concat-scan loop below.
+//
+// Pattern: $var . "suffix" or $var . 'suffix'
+var phpConcatLeadingVarRe = regexp.MustCompile(
+	`(\$[A-Za-z_][\w]*)\s*\.\s*(?:"([^"\n\r]{0,256})"|'([^'\n\r]{0,256})')`,
+)
+
+// phpLaravelHttpInterpRe matches Laravel Http:: calls whose URL argument is a
+// double-quoted interpolated PHP string starting with a variable:
+//
+//	Http::get("{$ordersUrl}/orders/{$orderId}")
+//	Http::post("{$notifUrl}/notifications", [...])
+//	Http::withToken(config('x'))->get("{$erpUrl}/api/erp/invoices/{$id}")
+//
+// Capture groups: 1 = verb, 2 = raw interpolated string body (between the
+// outer double-quotes, after the leading `{$`).
+var phpLaravelHttpInterpRe = regexp.MustCompile(
+	`\bHttp\s*(?:::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\((?:[^)(]|\([^)]*\))*\)\s*->\s*)?\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*"\{(\$[A-Za-z_][\w]*[^"]{0,256})`,
+)
+
+// phpLaravelHttpChainedInterpRe matches the chained Laravel form with an
+// interpolated URL:
+//
+//	Http::withToken(config('x'))->post("{$erpUrl}/api/erp/invoices")
+var phpLaravelHttpChainedInterpRe = regexp.MustCompile(
+	`\bHttp\s*::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\((?:[^)(]|\([^)]*\))*\)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*"\{(\$[A-Za-z_][\w]*[^"]{0,256})`,
+)
+
+// phpGuzzleVerbInterpRe matches Guzzle verb methods with an interpolated URL:
+//
+//	$client->get("{$ordersUrl}/orders/{$orderId}")
+//	$http->post("{$notifUrl}/api/notifications")
+var phpGuzzleVerbInterpRe = regexp.MustCompile(
+	`\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*"\{(\$[A-Za-z_][\w]*[^"]{0,256})`,
+)
+
+// phpLaravelHttpConcatRe matches Laravel Http:: calls where the URL is a
+// variable followed by string concatenation:
+//
+//	Http::get($ordersUrl . "/orders/" . $id)
+//	Http::post($notifUrl . '/notifications', $data)
+var phpLaravelHttpConcatRe = regexp.MustCompile(
+	`\bHttp\s*(?:::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\((?:[^)(]|\([^)]*\))*\)\s*->\s*)?\s*::\s*(get|post|put|patch|delete|head|options)\s*\(\s*(\$[A-Za-z_][\w]*)\s*\.`,
+)
+
+// phpLaravelHttpChainedConcatRe is the chained form with concatenation:
+//
+//	Http::withToken(config('x'))->post($erpUrl . "/api/erp/invoices", $data)
+var phpLaravelHttpChainedConcatRe = regexp.MustCompile(
+	`\bHttp\s*::\s*(?:withHeaders|withToken|withBasicAuth|timeout|retry|acceptJson|asJson|asForm|asMultipart|baseUrl|withOptions)\s*\((?:[^)(]|\([^)]*\))*\)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*(\$[A-Za-z_][\w]*)\s*\.`,
+)
+
+// phpGuzzleVerbConcatRe matches Guzzle verb methods with concatenation:
+//
+//	$client->get($ordersUrl . "/orders/" . $id)
+var phpGuzzleVerbConcatRe = regexp.MustCompile(
+	`\$(?:client|http|guzzle|httpClient)\s*->\s*(get|post|put|patch|delete|head|options)\s*\(\s*(\$[A-Za-z_][\w]*)\s*\.`,
 )
 
 // ---------------------------------------------------------------------------
@@ -501,6 +600,126 @@ func synthesizePHPClientWithRuntime(content string, emit phpClientEmitFn) {
 		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, suffix)
 		emit(verb, canonical, "laravel_http", "Function", caller, true)
 	}
+
+	// ----- PHP string interpolation: Http::get("{$ordersUrl}/orders/{$id}") -----
+	for _, m := range phpLaravelHttpInterpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]] // e.g. "$ordersUrl}/orders/{$orderId}"
+		path := resolvePHPInterpURL(raw, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "laravel_http", "Function", caller, true)
+	}
+
+	// ----- PHP string interpolation (chained): Http::withToken()->get("{$url}/path") -----
+	for _, m := range phpLaravelHttpChainedInterpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		path := resolvePHPInterpURL(raw, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "laravel_http", "Function", caller, true)
+	}
+
+	// ----- PHP string interpolation: $client->get("{$ordersUrl}/orders/{$id}") -----
+	for _, m := range phpGuzzleVerbInterpRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		raw := content[m[4]:m[5]]
+		path := resolvePHPInterpURL(raw, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "guzzle", "Function", caller, true)
+	}
+
+	// ----- PHP variable concat: Http::get($ordersUrl . "/orders/" . $id) -----
+	for _, m := range phpLaravelHttpConcatRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		varName := content[m[4]:m[5]]
+		path := resolvePHPConcatURL(content, m[1], varName, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "laravel_http", "Function", caller, true)
+	}
+
+	// ----- PHP variable concat (chained): Http::withToken()->post($url . "/path") -----
+	for _, m := range phpLaravelHttpChainedConcatRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		varName := content[m[4]:m[5]]
+		path := resolvePHPConcatURL(content, m[1], varName, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "laravel_http", "Function", caller, true)
+	}
+
+	// ----- PHP variable concat: $client->get($ordersUrl . "/orders/" . $id) -----
+	for _, m := range phpGuzzleVerbConcatRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 6 {
+			continue
+		}
+		verb := strings.ToUpper(content[m[2]:m[3]])
+		varName := content[m[4]:m[5]]
+		path := resolvePHPConcatURL(content, m[1], varName, syms)
+		if path == "" {
+			continue
+		}
+		normed, ok := normalizeRawClientPath(path)
+		if !ok {
+			continue
+		}
+		caller := enclosingPHPFnAt(funcs, m[0])
+		canonical := httproutes.Canonicalize(httproutes.FrameworkExpress, normed)
+		emit(verb, canonical, "guzzle", "Function", caller, true)
+	}
 }
 
 // ---------------------------------------------------------------------------
@@ -528,9 +747,14 @@ func phpHasAnyHTTPClient(content string) bool {
 }
 
 // buildPHPStringSymbolTable returns a map from $variable → string value
-// for simple PHP variable string assignments.
+// for simple PHP variable string assignments and config/env calls.
+//
+// Config/env calls ($x = config(...) / $x = env(...)) are stored with the
+// sentinel value phpRuntimeDynamicSentinel so that interpolation/concat
+// resolvers know the variable is a runtime-dynamic base URL.
 func buildPHPStringSymbolTable(content string) map[string]string {
 	syms := make(map[string]string)
+	// Literal string assignments: $url = "http://..." or $url = '/path'
 	for _, m := range phpStringVarRe.FindAllStringSubmatchIndex(content, -1) {
 		if len(m) < 8 {
 			continue
@@ -549,7 +773,189 @@ func buildPHPStringSymbolTable(content string) map[string]string {
 			syms[name] = val
 		}
 	}
+	// config(...) / env(...) assignments — runtime-dynamic base URLs (#1473).
+	for _, m := range phpConfigVarRe.FindAllStringSubmatchIndex(content, -1) {
+		if len(m) < 4 || m[2] < 0 {
+			continue
+		}
+		name := content[m[2]:m[3]]
+		if _, dup := syms[name]; !dup {
+			syms[name] = phpRuntimeDynamicSentinel
+		}
+	}
 	return syms
+}
+
+// phpRuntimeDynamicSentinel is stored in the symbol table for variables whose
+// value comes from config(...) or env(...). It signals that the variable is a
+// runtime-dynamic base URL prefix, not a literal path component.
+const phpRuntimeDynamicSentinel = "\x00runtime_dynamic\x00"
+
+// resolvePHPInterpURL resolves a PHP double-quoted interpolated string body
+// that starts immediately after the opening `"` and the leading `{$`.
+//
+// Input raw is the content AFTER the regex has consumed `Http::get("{`, so it
+// looks like: `$ordersUrl}/orders/{$orderId}"` (the closing `"` may or may
+// not be present — we stop at the first `"`).
+//
+// Resolution:
+//  1. Recover the full body: prepend `{$`, take up to (not including) `"`.
+//  2. Match phpInterpLeadingVarRe: leading variable + static suffix.
+//  3. If the leading variable is runtime-dynamic (config/env assigned), return
+//     the static suffix with `{$inner}` → `{inner}` expansion.
+//  4. If the leading variable has a literal value in the symbol table, try to
+//     resolve via normalizeRawClientPath (returns a host-stripped path).
+func resolvePHPInterpURL(raw string, syms map[string]string) string {
+	// raw starts after `"{` — prepend `{` to reconstruct the interpolation
+	body := "{" + raw
+	// Trim at first double-quote (end of the string literal).
+	if idx := strings.Index(body, `"`); idx >= 0 {
+		body = body[:idx]
+	}
+	// Also strip trailing `)` or `,` that may appear if the closing quote was
+	// not in the regex capture window.
+	body = strings.TrimRight(body, ");, \t\n\r")
+
+	m := phpInterpLeadingVarRe.FindStringSubmatch(body)
+	if len(m) < 3 {
+		return ""
+	}
+	varName := "$" + m[1]
+	suffix := m[2] // static path fragment, may contain more {$x} segments
+
+	val, known := syms[varName]
+	if !known {
+		// Unknown variable — cannot resolve.
+		return ""
+	}
+
+	if val == phpRuntimeDynamicSentinel {
+		// Variable is runtime-dynamic (config/env). Extract the path suffix.
+		path := phpExpandInnerInterp(suffix)
+		return path
+	}
+
+	// Literal base URL: strip host, then append suffix with inner params expanded.
+	base, ok := normalizeRawClientPath(val)
+	if !ok {
+		// Probably a relative path; use it directly and append suffix.
+		base = val
+	}
+	path := base + phpExpandInnerInterp(suffix)
+	return path
+}
+
+// resolvePHPConcatURL resolves a PHP variable-concatenation URL like:
+//
+//	$ordersUrl . "/orders/" . $orderId
+//
+// contentAfterDot is the content immediately after the first `.` operator.
+// We scan forward to collect all consecutive string-literal and variable
+// segments in the concat chain and assemble the static path.
+//
+// varName is the leading variable (already past the opening `$var .` part
+// captured by phpLaravelHttpConcatRe). We look up its value in syms and then
+// scan forward from afterDotOffset in content for more segments.
+func resolvePHPConcatURL(content string, afterDotOffset int, varName string, syms map[string]string) string {
+	val, known := syms[varName]
+	if !known {
+		return ""
+	}
+
+	// Only runtime-dynamic and literal-path bases are handled.
+	// For literal bases that start with http(s)://, strip the host.
+	var base string
+	isDynamic := val == phpRuntimeDynamicSentinel
+	if isDynamic {
+		base = ""
+	} else {
+		stripped, ok := normalizeRawClientPath(val)
+		if !ok {
+			base = val // may be relative path
+		} else {
+			base = stripped
+		}
+	}
+
+	// Scan forward from afterDotOffset to collect path segments.
+	window := content[afterDotOffset:]
+	if len(window) > 512 {
+		window = window[:512]
+	}
+	path := base + phpCollectConcatSuffix(window)
+	return path
+}
+
+// phpCollectConcatSuffix scans a PHP concat expression tail, collecting
+// string literals and converting `$var` segments to `{var}` OpenAPI
+// path-param placeholders.
+//
+// window starts immediately after the first `.` operator.
+// Example window: ` "/orders/" . $orderId . "/status")`
+// Returns:        `/orders/{orderId}/status`
+func phpCollectConcatSuffix(window string) string {
+	var buf strings.Builder
+	rest := strings.TrimLeft(window, " \t")
+
+	// phpConcatSegRe matches one segment: a string literal or a variable.
+	// We process iteratively.
+	segRe := regexp.MustCompile(
+		`^(?:` +
+			`"([^"\n\r]{0,256})"` + // group 1: double-quoted literal
+			`|` +
+			`'([^'\n\r]{0,256})'` + // group 2: single-quoted literal
+			`|` +
+			`(\$[A-Za-z_][\w]*)` + // group 3: variable
+			`)`,
+	)
+	dotRe := regexp.MustCompile(`^\s*\.\s*`)
+
+	for rest != "" {
+		m := segRe.FindStringSubmatch(rest)
+		if m == nil {
+			break
+		}
+		if m[1] != "" {
+			buf.WriteString(m[1])
+		} else if m[2] != "" {
+			buf.WriteString(m[2])
+		} else if m[3] != "" {
+			// $varName → {varName}
+			vn := m[3][1:] // strip leading $
+			buf.WriteString("{")
+			buf.WriteString(vn)
+			buf.WriteString("}")
+		}
+		rest = rest[len(m[0]):]
+		// Consume optional `.` separator.
+		dm := dotRe.FindString(rest)
+		if dm == "" {
+			break
+		}
+		rest = rest[len(dm):]
+	}
+	return buf.String()
+}
+
+// phpExpandInnerInterp replaces `{$varName}` and `{$this->prop}` segments in a
+// path suffix with the OpenAPI path-parameter form `{varName}` / `{prop}`.
+// For property accesses like `{$this->orderId}` the last segment after `->` is used.
+func phpExpandInnerInterp(suffix string) string {
+	return phpInnerInterpRe.ReplaceAllStringFunc(suffix, func(match string) string {
+		inner := phpInnerInterpRe.FindStringSubmatch(match)
+		if len(inner) < 2 {
+			return "{param}"
+		}
+		expr := inner[1]
+		// Take the last identifier segment after `->` (e.g. "this->orderId" → "orderId").
+		if idx := strings.LastIndex(expr, "->"); idx >= 0 {
+			expr = expr[idx+2:]
+		}
+		if expr == "" {
+			return "{param}"
+		}
+		return "{" + expr + "}"
+	})
 }
 
 // phpPickURLArg extracts the URL string from a match's double-quoted /

--- a/internal/engine/http_endpoint_php_client_1473_test.go
+++ b/internal/engine/http_endpoint_php_client_1473_test.go
@@ -1,0 +1,441 @@
+package engine
+
+// Tests for issue #1473 — PHP Laravel Http:: variable-interpolated URL resolution.
+//
+// Context: #1470 added Laravel Http:: client extraction, but when the URL is
+// constructed via double-quoted string interpolation or concatenation with a
+// variable assigned from config()/env(), the extractor emitted nothing because
+// the variable's value was not a literal string in the symbol table.
+//
+// Patterns fixed:
+//   - Interpolation:  Http::get("{$ordersUrl}/orders/{$orderId}")
+//     where $ordersUrl = config('services.orders.url')
+//   - Concatenation:  Http::post($notifUrl . '/notifications', $data)
+//     where $notifUrl  = config('services.notifications.url')
+//   - Guzzle variant: $client->get("{$erpUrl}/api/erp/invoices/{$id}")
+//   - Chained:        Http::withToken(config('x'))->post("{$erpUrl}/api/erp/invoices")
+//
+// Fixture mirrors services/billing — InvoiceController.php + GenerateInvoicePdf.php
+//
+// Before fix (#1473 open): 0 billing→{orders,notifications,legacy-erp} edges for
+// variable-interpolated/concat URL forms.
+//
+// After fix: all three services resolve correctly.
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// InvoiceController — interpolated URLs
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_InterpolatedURL verifies that Http:: calls with
+// double-quoted interpolated URLs where the base var is assigned via config()
+// produce the correct http_endpoint_call entities and FETCHES edges.
+func TestPHP1473_InterpolatedURL(t *testing.T) {
+	src := `<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Http;
+
+class InvoiceController extends Controller
+{
+    public function store(Request $request)
+    {
+        $ordersUrl = config('services.orders.url');
+        $notifUrl  = config('services.notifications.url');
+        $erpUrl    = config('services.erp.url');
+
+        // interpolated base + static path
+        $orderResponse = Http::post("{$ordersUrl}/api/orders", [
+            'customer_id' => $request->customer_id,
+        ]);
+        $orderId = $orderResponse->json('id');
+
+        // interpolated base + static path (notifications)
+        Http::post("{$notifUrl}/api/notifications", [
+            'user_id' => $request->customer_id,
+            'event'   => 'invoice.created',
+        ]);
+
+        // chained withToken + interpolated URL (legacy-erp)
+        Http::withToken(config('services.erp.token'))
+            ->post("{$erpUrl}/api/erp/invoices", [
+                'order_id' => $orderId,
+            ]);
+
+        return response()->json(['order_id' => $orderId]);
+    }
+
+    public function show(Request $request, string $id)
+    {
+        $ordersUrl = config('services.orders.url');
+        // interpolated base + path + param
+        $response = Http::get("{$ordersUrl}/api/orders/{$id}");
+        return response()->json($response->json());
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "InvoiceController.php", src)
+
+	// billing → orders (POST via interpolated URL)
+	requireContains(t, ids, []string{"http:POST:/api/orders"}, "#1473 billing→orders POST interpolated")
+	requireFetches(t, rels, "http:POST:/api/orders", "#1473 billing→orders POST interpolated")
+
+	// billing → notifications (POST via interpolated URL)
+	requireContains(t, ids, []string{"http:POST:/api/notifications"}, "#1473 billing→notifications POST interpolated")
+	requireFetches(t, rels, "http:POST:/api/notifications", "#1473 billing→notifications POST interpolated")
+
+	// billing → legacy-erp (POST via withToken chained + interpolated URL)
+	requireContains(t, ids, []string{"http:POST:/api/erp/invoices"}, "#1473 billing→legacy-erp POST interpolated chained")
+	requireFetches(t, rels, "http:POST:/api/erp/invoices", "#1473 billing→legacy-erp POST interpolated chained")
+
+	// billing → orders (GET with path param via interpolated URL — canonicalized with {id})
+	requireContains(t, ids, []string{"http:GET:/api/orders/{id}"}, "#1473 billing→orders GET interpolated with param")
+}
+
+// ---------------------------------------------------------------------------
+// InvoiceController — concatenation URLs
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_ConcatenationURL verifies that Http:: calls where the URL is
+// assembled via PHP dot-concatenation (`$var . "/path"`) are resolved when the
+// leading variable is a config()/env() assignment.
+func TestPHP1473_ConcatenationURL(t *testing.T) {
+	src := `<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Http;
+
+class InvoiceController extends Controller
+{
+    public function store(Request $request)
+    {
+        $ordersUrl = config('services.orders.url');
+        $notifUrl  = config('services.notifications.url');
+        $erpUrl    = config('services.erp.url');
+
+        // concatenation form — base var . static path
+        Http::post($ordersUrl . '/api/orders', ['items' => []]);
+
+        Http::post($notifUrl . '/api/notifications', [
+            'event' => 'invoice.created',
+        ]);
+
+        Http::withToken(config('services.erp.token'))
+            ->post($erpUrl . '/api/erp/invoices', ['sync' => true]);
+
+        return response()->json([]);
+    }
+
+    public function show(string $id)
+    {
+        $ordersUrl = config('services.orders.url');
+        // concat with additional param segment
+        Http::get($ordersUrl . '/api/orders/' . $id);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "InvoiceController.php", src)
+
+	requireContains(t, ids, []string{"http:POST:/api/orders"}, "#1473 billing→orders POST concat")
+	requireFetches(t, rels, "http:POST:/api/orders", "#1473 billing→orders POST concat")
+
+	requireContains(t, ids, []string{"http:POST:/api/notifications"}, "#1473 billing→notifications POST concat")
+	requireFetches(t, rels, "http:POST:/api/notifications", "#1473 billing→notifications POST concat")
+
+	requireContains(t, ids, []string{"http:POST:/api/erp/invoices"}, "#1473 billing→legacy-erp POST concat chained")
+	requireFetches(t, rels, "http:POST:/api/erp/invoices", "#1473 billing→legacy-erp POST concat chained")
+
+	// GET with path param — canonicalized as {id}
+	requireContains(t, ids, []string{"http:GET:/api/orders/{id}"}, "#1473 billing→orders GET concat with param")
+}
+
+// ---------------------------------------------------------------------------
+// GenerateInvoicePdf — interpolated + concatenation mix
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_GenerateInvoicePdf verifies the GenerateInvoicePdf job
+// class fixture which mixes interpolated and concatenation URL forms.
+func TestPHP1473_GenerateInvoicePdf(t *testing.T) {
+	src := `<?php
+
+namespace App\Jobs;
+
+use Illuminate\Support\Facades\Http;
+
+class GenerateInvoicePdf
+{
+    public function __construct(
+        private readonly int    $invoiceId,
+        private readonly string $orderId,
+    ) {}
+
+    public function handle(): void
+    {
+        $ordersUrl = config('services.orders.url');
+        $erpUrl    = config('services.erp.url');
+        $notifUrl  = config('services.notifications.url');
+
+        // Fetch order details — interpolated URL with path param
+        $order = Http::get("{$ordersUrl}/api/orders/{$this->orderId}")->json();
+
+        // Push PDF metadata to legacy ERP — withHeaders chained + interpolated
+        Http::withHeaders([
+            'X-Api-Key' => config('services.erp.api_key'),
+        ])->post("{$erpUrl}/api/erp/pdf-uploads", [
+            'invoice_id' => $this->invoiceId,
+        ]);
+
+        // Notify user — concatenation form
+        Http::withToken(config('services.notifications.token'))
+            ->post($notifUrl . '/api/notifications', [
+                'event' => 'invoice.pdf_ready',
+            ]);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "GenerateInvoicePdf.php", src)
+
+	// billing → orders GET (interpolated with $this->orderId — canonicalized to {orderId})
+	requireContains(t, ids, []string{"http:GET:/api/orders/{orderId}"}, "#1473 pdf billing→orders GET interpolated")
+	requireFetches(t, rels, "http:GET:/api/orders/{orderId}", "#1473 pdf billing→orders GET interpolated")
+
+	// billing → legacy-erp POST (withHeaders chained + interpolated)
+	requireContains(t, ids, []string{"http:POST:/api/erp/pdf-uploads"}, "#1473 pdf billing→legacy-erp POST interpolated chained")
+	requireFetches(t, rels, "http:POST:/api/erp/pdf-uploads", "#1473 pdf billing→legacy-erp POST interpolated chained")
+
+	// billing → notifications POST (withToken chained + concat)
+	requireContains(t, ids, []string{"http:POST:/api/notifications"}, "#1473 pdf billing→notifications POST concat chained")
+	requireFetches(t, rels, "http:POST:/api/notifications", "#1473 pdf billing→notifications POST concat chained")
+}
+
+// ---------------------------------------------------------------------------
+// Guzzle variant
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_GuzzleInterpolated verifies that Guzzle $client->get() /
+// $client->post() calls with interpolated URLs are also resolved.
+func TestPHP1473_GuzzleInterpolated(t *testing.T) {
+	src := `<?php
+
+use GuzzleHttp\Client;
+
+class BillingService
+{
+    public function getOrder(string $id): array
+    {
+        $ordersUrl = config('services.orders.url');
+        $client = new Client();
+        $response = $client->get("{$ordersUrl}/api/orders/{$id}");
+        return json_decode($response->getBody(), true);
+    }
+
+    public function createOrder(array $data): array
+    {
+        $ordersUrl = config('services.orders.url');
+        $client = new Client();
+        $response = $client->post("{$ordersUrl}/api/orders", ['json' => $data]);
+        return json_decode($response->getBody(), true);
+    }
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "BillingService.php", src)
+
+	requireContains(t, ids, []string{"http:GET:/api/orders/{id}", "http:POST:/api/orders"}, "#1473 guzzle interpolated")
+	requireFetches(t, rels, "http:GET:/api/orders/{id}", "#1473 guzzle interpolated GET")
+	requireFetches(t, rels, "http:POST:/api/orders", "#1473 guzzle interpolated POST")
+}
+
+// ---------------------------------------------------------------------------
+// Before/After measurement — fixture mirrors billing service
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_BillingServiceLinkCount is the primary before/after measurement.
+//
+// BEFORE (#1473 open): 0 edges for variable-interpolated/concat URL forms.
+// AFTER (this fix): all three billing→{orders,notifications,legacy-erp} edges
+// emit correctly regardless of whether the URL is a literal, interpolated, or
+// concatenated from a config() variable.
+//
+// Expected AFTER counts across two billing files combined:
+//
+//	billing → orders        : ≥ 2 edges (POST + GET from InvoiceController)
+//	billing → notifications : ≥ 2 edges (POST from InvoiceController + GenerateInvoicePdf)
+//	billing → legacy-erp   : ≥ 2 edges (POST /erp/invoices + POST /erp/pdf-uploads)
+func TestPHP1473_BillingServiceLinkCount(t *testing.T) {
+	invoiceControllerSrc := `<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Support\Facades\Http;
+
+class InvoiceController extends Controller
+{
+    public function store()
+    {
+        $ordersUrl = config('services.orders.url');
+        $notifUrl  = config('services.notifications.url');
+        $erpUrl    = config('services.erp.url');
+
+        Http::post("{$ordersUrl}/api/orders", ['items' => []]);
+        Http::post("{$notifUrl}/api/notifications", ['event' => 'invoice.created']);
+        Http::withToken(config('services.erp.token'))
+            ->post("{$erpUrl}/api/erp/invoices", ['sync' => true]);
+    }
+
+    public function show(string $id)
+    {
+        $ordersUrl = config('services.orders.url');
+        Http::get("{$ordersUrl}/api/orders/{$id}");
+    }
+}
+`
+
+	generateInvoicePdfSrc := `<?php
+
+namespace App\Jobs;
+
+use Illuminate\Support\Facades\Http;
+
+class GenerateInvoicePdf
+{
+    public function handle(): void
+    {
+        $ordersUrl = config('services.orders.url');
+        $erpUrl    = config('services.erp.url');
+        $notifUrl  = config('services.notifications.url');
+
+        Http::get($ordersUrl . '/api/orders/123');
+        Http::withHeaders(['X-Api-Key' => 'key'])
+            ->post("{$erpUrl}/api/erp/pdf-uploads", []);
+        Http::withToken('token')
+            ->post($notifUrl . '/api/notifications', ['event' => 'pdf_ready']);
+    }
+}
+`
+
+	idsIC, relsIC := runDetectWithRels(t, "php", "InvoiceController.php", invoiceControllerSrc)
+	idsPDF, relsPDF := runDetectWithRels(t, "php", "GenerateInvoicePdf.php", generateInvoicePdfSrc)
+
+	// Deduplicate http: entity IDs across both files.
+	allIDs := make(map[string]bool)
+	for _, id := range append(idsIC, idsPDF...) {
+		if strings.HasPrefix(id, "http:") {
+			allIDs[id] = true
+		}
+	}
+
+	// Count FETCHES edges by target.
+	fetchesByTarget := make(map[string]int)
+	totalFetches := 0
+	for _, r := range append(relsIC, relsPDF...) {
+		if r.Kind == fetchesEdgeKind {
+			totalFetches++
+			fetchesByTarget[r.ToID]++
+		}
+	}
+
+	// Before/after report.
+	t.Logf("=== #1473 before/after link count (variable-interpolated URLs) ===")
+	t.Logf("BEFORE: 0 edges for interpolated/concat URL forms (config() base vars unresolved)")
+	t.Logf("AFTER:  %d distinct http_endpoint_call entities, %d FETCHES edges across 2 billing files",
+		len(allIDs), totalFetches)
+	// Count all orders edges regardless of path-param variant
+	// (e.g. http:GET:/api/orders/{id} and http:GET:/api/orders both count).
+	ordersEdges := 0
+	notifEdges := 0
+	erpEdges := 0
+	for target, count := range fetchesByTarget {
+		switch {
+		case strings.HasPrefix(target, "http:POST:/api/orders") ||
+			strings.HasPrefix(target, "http:GET:/api/orders") ||
+			strings.HasPrefix(target, "http:PUT:/api/orders") ||
+			strings.HasPrefix(target, "http:PATCH:/api/orders"):
+			ordersEdges += count
+		case strings.HasPrefix(target, "http:POST:/api/notifications") ||
+			strings.HasPrefix(target, "http:GET:/api/notifications"):
+			notifEdges += count
+		case strings.HasPrefix(target, "http:POST:/api/erp/") ||
+			strings.HasPrefix(target, "http:PATCH:/api/erp/") ||
+			strings.HasPrefix(target, "http:PUT:/api/erp/"):
+			erpEdges += count
+		}
+	}
+
+	t.Logf("  billing→orders        : %d edge(s)", ordersEdges)
+	t.Logf("  billing→notifications : %d edge(s)", notifEdges)
+	t.Logf("  billing→legacy-erp   : %d edge(s)", erpEdges)
+
+	// Assert minimum AFTER counts.
+	if ordersEdges < 2 {
+		t.Errorf("#1473 billing→orders: expected ≥2 FETCHES edges, got %d", ordersEdges)
+	}
+	if notifEdges < 2 {
+		t.Errorf("#1473 billing→notifications: expected ≥2 FETCHES edges, got %d", notifEdges)
+	}
+	if erpEdges < 2 {
+		t.Errorf("#1473 billing→legacy-erp: expected ≥2 FETCHES edges, got %d", erpEdges)
+	}
+	if len(allIDs) < 4 {
+		t.Errorf("#1473 expected ≥4 distinct http_endpoint_call entities, got %d: %v", len(allIDs), allIDs)
+	}
+	if totalFetches < 6 {
+		t.Errorf("#1473 expected ≥6 total FETCHES edges, got %d", totalFetches)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Negative / no-regression
+// ---------------------------------------------------------------------------
+
+// TestPHP1473_NegativeNoFalsePositives confirms that plain variables without
+// a known config/env assignment are NOT emitted (prevents false positives).
+func TestPHP1473_NegativeNoFalsePositives(t *testing.T) {
+	src := `<?php
+
+use Illuminate\Support\Facades\Http;
+
+function callUnknownBase(): void
+{
+    // $unknownVar has no prior assignment in this file — should NOT emit.
+    Http::get("{$unknownVar}/api/things");
+    Http::post($anotherUnknownVar . '/api/stuff', []);
+}
+`
+	ids, _ := runDetectWithRels(t, "php", "unknown.php", src)
+
+	for _, id := range ids {
+		if strings.HasPrefix(id, "http:") {
+			if strings.Contains(id, "/api/things") || strings.Contains(id, "/api/stuff") {
+				t.Errorf("#1473 negative: unexpectedly emitted entity %q for unknown base var", id)
+			}
+		}
+	}
+}
+
+// TestPHP1473_EnvAssignmentInterpolated verifies that env() assignments (not
+// just config()) are also tracked as runtime-dynamic base URLs.
+func TestPHP1473_EnvAssignmentInterpolated(t *testing.T) {
+	src := `<?php
+
+use Illuminate\Support\Facades\Http;
+
+function callOrders(): void
+{
+    $baseUrl = env('ORDERS_SERVICE_URL');
+    Http::get("{$baseUrl}/api/orders");
+    Http::post($baseUrl . '/api/orders', []);
+}
+`
+	ids, rels := runDetectWithRels(t, "php", "caller.php", src)
+
+	requireContains(t, ids, []string{"http:GET:/api/orders", "http:POST:/api/orders"}, "#1473 env() interpolated")
+	requireFetches(t, rels, "http:GET:/api/orders", "#1473 env() interpolated GET")
+	requireFetches(t, rels, "http:POST:/api/orders", "#1473 env() interpolated POST")
+}


### PR DESCRIPTION
## What

PHP `Http::get("{$ordersUrl}/orders/{$orderId}")` — where `$ordersUrl = config('services.orders.url')` — was silently emitting **zero** FETCHES edges because the symbol table only tracked literal string assignments. Variables set via `config()` or `env()` were unknown, so the entire URL was discarded.

This fix teaches the extractor to fold config/env-assigned base-URL variables into the path, resolving all three missing billing service edges: **billing→orders**, **billing→notifications**, **billing→legacy-erp**.

## Root Cause

`buildPHPStringSymbolTable` only matched `$x = "literal"` patterns. `$ordersUrl = config('services.orders.url')` produced no symbol table entry, so `phpPickURLArg` returned `""` and the call site was skipped.

## Solution

1. **`phpConfigVarRe`** — new regex capturing `$x = config(...)` / `$x = env(...)` assignments, stored with a `phpRuntimeDynamicSentinel` value.
2. **`resolvePHPInterpURL`** — resolves `"{$baseVar}/path/{$param}"` double-quoted interpolated strings. Strips the leading `{$var}` (which is the dynamic base), expands remaining `{$inner}` / `{$this->prop}` segments to OpenAPI `{prop}` placeholders.
3. **`resolvePHPConcatURL` + `phpCollectConcatSuffix`** — resolves `$baseVar . "/path" . $param` concat chains, converting `$var` segments to `{var}` placeholders.
4. **`phpExpandInnerInterp`** — updated to handle `{$this->prop}` by taking the last `->` segment.
5. **6 new scan loops** in `synthesizePHPClientWithRuntime` covering:
   - Interpolated + chained interpolated forms for Laravel Http::
   - Interpolated form for Guzzle verb methods
   - Concat + chained concat forms for Laravel Http::
   - Concat form for Guzzle verb methods

## Before / After (billing service fixture, 2 files)

| Direction | Before | After |
|-----------|--------|-------|
| billing → orders | 0 edges (interpolated/concat) | 3 FETCHES edges |
| billing → notifications | 0 edges | 2 FETCHES edges |
| billing → legacy-erp | 0 edges (interpolated/concat) | 2 FETCHES edges |

## Tests

New file `http_endpoint_php_client_1473_test.go` (7 tests):
- `TestPHP1473_InterpolatedURL` — Http:: direct + chained with `{$var}/path` forms
- `TestPHP1473_ConcatenationURL` — Http:: direct + chained with `$var . "/path"` forms
- `TestPHP1473_GenerateInvoicePdf` — job class fixture mixing both forms
- `TestPHP1473_GuzzleInterpolated` — Guzzle `$client->get("{$var}/path")` coverage
- `TestPHP1473_BillingServiceLinkCount` — before/after measurement (≥2 edges per service)
- `TestPHP1473_NegativeNoFalsePositives` — unknown vars not emitted
- `TestPHP1473_EnvAssignmentInterpolated` — `env()` assignments also tracked

All 27 PHP tests pass (20 pre-existing + 7 new). Full `./internal/engine/` suite clean.

## Test Plan

- [ ] `go test ./internal/engine/ -run TestPHP` — 27/27 pass
- [ ] `go test ./internal/engine/` — full suite passes
- [ ] `go build ./internal/engine/` — clean compile

Fixes #1473
🤖 Generated with [Claude Code](https://claude.com/claude-code)