### PR TITLE
feat(engine/java): extend Kafka Streams DSL topic extraction — .through() + chained sinks (Fixes #1480)

### DIFF
--- a/fixtures/sources/java/stream-processor/src/main/java/io/streamprocessor/OrderEnrichmentTopology.java
+++ b/fixtures/sources/java/stream-processor/src/main/java/io/streamprocessor/OrderEnrichmentTopology.java
@@ -1,0 +1,45 @@
+package io.streamprocessor;
+
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Order enrichment topology — #1480 fixture.
+ *
+ * Consumes orders.placed and payments.settled (source topics),
+ * enriches each order record and routes it:
+ *   - All enriched orders → orders.enriched (PUBLISHES_TO)
+ *   - High-value orders (total > 1000) → orders.high_value (PUBLISHES_TO)
+ *
+ * analytics, search-os, and notifications services subscribe to these
+ * output topics so cross-repo P7 topic links must resolve.
+ */
+public class OrderEnrichmentTopology {
+
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        // Consume source topics.
+        KStream<String, Order> ordersStream = builder.stream("orders.placed");
+        KStream<String, Payment> paymentsStream = builder.stream("payments.settled");
+
+        // Enrich orders with payment status and publish to orders.enriched.
+        KStream<String, EnrichedOrder> enriched = ordersStream
+                .mapValues(order -> enrich(order));
+        enriched.to("orders.enriched");
+
+        // Branch high-value orders to a dedicated sink.
+        enriched
+                .filter((key, value) -> value != null && value.total > 1000)
+                .to("orders.high_value");
+
+        return builder.build();
+    }
+
+    private EnrichedOrder enrich(Order order) {
+        // Enrichment logic omitted for fixture brevity.
+        return new EnrichedOrder(order);
+    }
+}

--- a/fixtures/sources/java/stream-processor/src/main/java/io/streamprocessor/PaymentRoutingTopology.java
+++ b/fixtures/sources/java/stream-processor/src/main/java/io/streamprocessor/PaymentRoutingTopology.java
@@ -1,0 +1,38 @@
+package io.streamprocessor;
+
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.Topology;
+
+/**
+ * Payment routing topology — #1480 fixture.
+ *
+ * Consumes payments.settled (source topic).
+ * Uses .through("payments.normalised") to route records through an intermediate
+ * repartition topic before writing final output.
+ *
+ * Demonstrates the full Streams DSL surface extracted by #1480:
+ *   builder.stream(...)      → SUBSCRIBES_TO
+ *   kStream.through(...)     → PUBLISHES_TO + SUBSCRIBES_TO  (repartition)
+ *   kStream.filter().to(...) → PUBLISHES_TO  (chained sink)
+ */
+public class PaymentRoutingTopology {
+
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+
+        KStream<String, Payment> payments = builder.stream("payments.settled");
+
+        // Repartition through an intermediate topic.
+        KStream<String, Payment> repartitioned = payments
+                .through("payments.normalised");
+
+        // Route normalised payments to the final output topic.
+        repartitioned
+                .filter((key, value) -> value != null && value.amount > 0)
+                .to("orders.enriched");
+
+        return builder.build();
+    }
+}

--- a/internal/engine/kafka_wrapper_edges.go
+++ b/internal/engine/kafka_wrapper_edges.go
@@ -294,7 +294,8 @@ func synthesizeJavaRedisConvertAndSend(
 }
 
 // ---------------------------------------------------------------------------
-// 3. Java Kafka Streams: builder.stream("topic") / kStream.to("topic")
+// 3. Java Kafka Streams: builder.stream("topic") / kStream.to("topic") /
+//    kStream.through("topic") / chained .filter().to() / .branch()[n].to()
 // ---------------------------------------------------------------------------
 
 // javaKafkaStreamBuilderRe captures `builder.stream("topic")` and
@@ -305,14 +306,20 @@ var javaKafkaStreamBuilderRe = regexp.MustCompile(
 )
 
 // javaKafkaStreamToRe captures `kStream.to("topic")` — the sink topic written
-// by a Kafka Streams topology. Group 1 = topic name.
+// by a Kafka Streams topology. Also fires for chained forms like
+// `.filter(...).to("topic")`, `.mapValues(...).to("topic")`, and
+// `.branch(...)[n].to("topic")`. Group 1 = topic name.
 var javaKafkaStreamToRe = regexp.MustCompile(
 	`\.to\s*\(\s*"([^"\n\r]+)"`,
 )
 
-// javaKafkaStreamBranchToRe captures `.branch(...)` followed by `.to("topic")`
-// for branched topologies. Same regex as javaKafkaStreamToRe — handled by the
-// same scan.
+// javaKafkaStreamThroughRe captures `kStream.through("topic")` — the
+// rerouting operator that both consumes from and produces to an intermediate
+// topic, acting as both source and sink in the topology.
+// Group 1 = topic name.
+var javaKafkaStreamThroughRe = regexp.MustCompile(
+	`\.through\s*\(\s*"([^"\n\r]+)"`,
+)
 
 func synthesizeJavaKafkaStreams(
 	src string,
@@ -352,6 +359,8 @@ func synthesizeJavaKafkaStreams(
 	}
 
 	// Sink topics: kStream.to("topic") — producer side.
+	// Also fires for chained DSL forms: .filter(...).to("x"),
+	// .mapValues(...).to("x"), .branch(...)[n].to("x").
 	for _, m := range javaKafkaStreamToRe.FindAllStringSubmatchIndex(src, -1) {
 		topic := src[m[2]:m[3]]
 		if !looksLikeKafkaTopic(topic) {
@@ -359,7 +368,7 @@ func synthesizeJavaKafkaStreams(
 		}
 		// Avoid matching Java method calls that happen to look like .to("…")
 		// but are not Kafka Streams topology calls. Heuristic: if the
-		// surrounding ~200 chars contain KStream / KTable / topology tokens,
+		// surrounding ~300 chars contain KStream / KTable / topology tokens,
 		// it's safe to claim this.
 		ctx := surroundingText(src, m[0], 300)
 		if !strings.Contains(ctx, "KStream") &&
@@ -368,6 +377,7 @@ func synthesizeJavaKafkaStreams(
 			!strings.Contains(ctx, ".through(") &&
 			!strings.Contains(ctx, ".branch(") &&
 			!strings.Contains(ctx, ".filter(") &&
+			!strings.Contains(ctx, ".mapValues(") &&
 			!strings.Contains(ctx, "topology") &&
 			!strings.Contains(src, "KafkaStreams") {
 			continue
@@ -378,6 +388,30 @@ func synthesizeJavaKafkaStreams(
 			"broker":          "kafka",
 			"messaging_layer": "kafka_streams",
 			"stream_role":     "sink",
+		})
+	}
+
+	// Through topics: kStream.through("topic") — intermediate rerouting.
+	// The topology PUBLISHES_TO the through-topic AND SUBSCRIBES_TO it
+	// (Kafka Streams writes records to the through-topic and then reads them
+	// back internally). Emit both edges so cross-repo linkers can match either
+	// side of the through-topic connection.
+	for _, m := range javaKafkaStreamThroughRe.FindAllStringSubmatchIndex(src, -1) {
+		topic := src[m[2]:m[3]]
+		if !looksLikeKafkaTopic(topic) {
+			continue
+		}
+		id := kafkaTopicID(topic)
+		emitTopic(id, topic, "kafka", map[string]string{"messaging_layer": "kafka_streams", "stream_role": "through"})
+		emitEdge("Service", caller, id, publishesToEdgeKind, map[string]string{
+			"broker":          "kafka",
+			"messaging_layer": "kafka_streams",
+			"stream_role":     "through",
+		})
+		emitEdge("Service", caller, id, subscribesToEdgeKind, map[string]string{
+			"broker":          "kafka",
+			"messaging_layer": "kafka_streams",
+			"stream_role":     "through",
 		})
 	}
 }

--- a/internal/engine/kafka_wrapper_edges_test.go
+++ b/internal/engine/kafka_wrapper_edges_test.go
@@ -258,6 +258,188 @@ public class Utils {
 	}
 }
 
+// TestKafkaWrapper_JavaKafkaStreams_Through verifies that kStream.through("topic")
+// emits a MessageTopic with BOTH PUBLISHES_TO and SUBSCRIBES_TO edges, since
+// Kafka Streams writes to the through-topic and reads it back internally
+// (repartition / intermediate routing).
+func TestKafkaWrapper_JavaKafkaStreams_Through(t *testing.T) {
+	src := `package io.demo;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+
+public class PaymentRouter {
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, Payment> payments = builder.stream("payments.settled");
+        KStream<String, Payment> repartitioned = payments.through("payments.normalised");
+        repartitioned.filter((k, v) -> v != null)
+                     .to("orders.enriched");
+        return builder.build();
+    }
+}
+`
+	ents, rels := runWrapperDetect(t, "java", "stream-processor/PaymentRouter.java", src)
+
+	// through-topic must be present as a MessageTopic entity.
+	throughTopic := topicByName(ents, "payments.normalised")
+	if throughTopic == nil {
+		t.Fatalf("expected MessageTopic for payments.normalised (through), ents=%v", ents)
+	}
+	if throughTopic.Properties["stream_role"] != "through" {
+		t.Errorf("stream_role: want through, got %q", throughTopic.Properties["stream_role"])
+	}
+
+	// through-topic must have BOTH PUBLISHES_TO and SUBSCRIBES_TO edges.
+	var pubToThrough, subToThrough bool
+	for _, r := range rels {
+		if strings.Contains(r.ToID, "kafka:payments.normalised") {
+			switch r.Kind {
+			case publishesToEdgeKind:
+				pubToThrough = true
+			case subscribesToEdgeKind:
+				subToThrough = true
+			}
+		}
+	}
+	if !pubToThrough {
+		t.Errorf("expected PUBLISHES_TO edge for through-topic payments.normalised, rels=%v", rels)
+	}
+	if !subToThrough {
+		t.Errorf("expected SUBSCRIBES_TO edge for through-topic payments.normalised, rels=%v", rels)
+	}
+
+	// Source + final sink must also be present.
+	if topicByName(ents, "payments.settled") == nil {
+		t.Fatalf("expected MessageTopic for payments.settled (source), ents=%v", ents)
+	}
+	if topicByName(ents, "orders.enriched") == nil {
+		t.Fatalf("expected MessageTopic for orders.enriched (sink), ents=%v", ents)
+	}
+}
+
+// TestKafkaWrapper_JavaKafkaStreams_MapValuesThenTo verifies that a chained
+// .mapValues(...).to("topic") form produces a PUBLISHES_TO edge for the sink.
+func TestKafkaWrapper_JavaKafkaStreams_MapValuesThenTo(t *testing.T) {
+	src := `package io.demo;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+
+public class OrderEnricher {
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, Order> orders = builder.stream("orders.placed");
+        orders.mapValues(order -> enrich(order))
+              .to("orders.enriched");
+        return builder.build();
+    }
+}
+`
+	ents, rels := runWrapperDetect(t, "java", "stream-processor/OrderEnricher.java", src)
+
+	if topicByName(ents, "orders.placed") == nil {
+		t.Fatalf("expected MessageTopic for orders.placed, ents=%v", ents)
+	}
+	if topicByName(ents, "orders.enriched") == nil {
+		t.Fatalf("expected MessageTopic for orders.enriched, ents=%v", ents)
+	}
+	if len(edgesOfKind(rels, publishesToEdgeKind)) == 0 {
+		t.Errorf("expected PUBLISHES_TO edge for orders.enriched, rels=%v", rels)
+	}
+}
+
+// TestKafkaWrapper_JavaKafkaStreams_StreamProcessorFixture verifies the full
+// stream-processor fixture: consumes orders.placed + payments.settled,
+// produces orders.enriched + orders.high_value.
+// This is the fixture-level recall test for #1480 — equivalent of
+// TestKafkaWrapper_ShipFastTopicRecall but for the Kafka Streams DSL.
+func TestKafkaWrapper_JavaKafkaStreams_StreamProcessorFixture(t *testing.T) {
+	// OrderEnrichmentTopology: source=orders.placed + payments.settled,
+	// sink=orders.enriched + orders.high_value.
+	enrichmentSrc := `package io.streamprocessor;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+
+public class OrderEnrichmentTopology {
+    public Topology buildTopology() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, Order> ordersStream = builder.stream("orders.placed");
+        KStream<String, Payment> paymentsStream = builder.stream("payments.settled");
+        KStream<String, EnrichedOrder> enriched = ordersStream.mapValues(order -> enrich(order));
+        enriched.to("orders.enriched");
+        enriched.filter((key, value) -> value != null && value.total > 1000)
+                .to("orders.high_value");
+        return builder.build();
+    }
+}
+`
+	ents, rels := runWrapperDetect(t, "java",
+		"stream-processor/src/main/java/io/streamprocessor/OrderEnrichmentTopology.java",
+		enrichmentSrc)
+
+	// All four expected topics must be present.
+	for _, want := range []string{"orders.placed", "payments.settled", "orders.enriched", "orders.high_value"} {
+		if topicByName(ents, want) == nil {
+			t.Errorf("expected MessageTopic for %q, ents=%v", want, ents)
+		}
+	}
+
+	// Two SUBSCRIBES_TO edges (source topics).
+	subs := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(subs) < 2 {
+		t.Errorf("expected ≥2 SUBSCRIBES_TO edges (source topics), got %d; rels=%v", len(subs), rels)
+	}
+
+	// Two PUBLISHES_TO edges (sink topics).
+	pubs := edgesOfKind(rels, publishesToEdgeKind)
+	if len(pubs) < 2 {
+		t.Errorf("expected ≥2 PUBLISHES_TO edges (sink topics), got %d; rels=%v", len(pubs), rels)
+	}
+
+	// Canonical IDs must match what P7 will join on.
+	wantIDs := map[string]bool{
+		"kafka:orders.placed":    false,
+		"kafka:payments.settled": false,
+		"kafka:orders.enriched":  false,
+		"kafka:orders.high_value": false,
+	}
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			wantIDs[e.Name] = true
+		}
+	}
+	for id, seen := range wantIDs {
+		if !seen {
+			t.Errorf("canonical MessageTopic %q not emitted — P7 cross-repo link will miss it", id)
+		}
+	}
+
+	t.Logf("stream-processor fixture: %d topics, %d SUBSCRIBES_TO, %d PUBLISHES_TO",
+		len(ents), len(subs), len(pubs))
+}
+
+// TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava verifies
+// that .through() on a plain Java non-Streams file does not emit any topic.
+func TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava(t *testing.T) {
+	src := `package io.demo;
+
+public class UrlBuilder {
+    // through() here is a path-component helper, not Kafka Streams.
+    public String buildUrl(String base) {
+        return base.through("normalised");
+    }
+}
+`
+	ents, _ := runWrapperDetect(t, "java", "UrlBuilder.java", src)
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			t.Errorf("must not emit MessageTopic from plain through() call, got %v", e)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // 3. Java Spring RedisTemplate.convertAndSend
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Extends Kafka Streams DSL topic extraction (built on `kafka_wrapper_edges.go` from #1469) to cover the full DSL surface needed for the `stream-processor` service fixture.

## Changes

**`internal/engine/kafka_wrapper_edges.go`** — `synthesizeJavaKafkaStreams`

- Adds `javaKafkaStreamThroughRe` regex to capture `.through("topic")` calls.
- `.through("topic")` emits **both** `PUBLISHES_TO` and `SUBSCRIBES_TO` edges for the through-topic (`stream_role: "through"`), because Kafka Streams writes records to the through-topic and reads them back internally.
- Adds `.mapValues(` to the surrounding-context guard on the `.to()` scan, so chained `.mapValues(...).to("topic")` forms are correctly attributed as Kafka Streams sinks.
- Updates guard comment to document all covered chained forms (`.filter().to()`, `.mapValues().to()`, `.branch()[n].to()`).

**`internal/engine/kafka_wrapper_edges_test.go`** — 4 new unit tests

| Test | What it proves |
|------|---------------|
| `TestKafkaWrapper_JavaKafkaStreams_Through` | `.through()` emits MessageTopic + both PUBLISHES_TO + SUBSCRIBES_TO; `stream_role=through` |
| `TestKafkaWrapper_JavaKafkaStreams_MapValuesThenTo` | `.mapValues(...).to("topic")` emits correct PUBLISHES_TO |
| `TestKafkaWrapper_JavaKafkaStreams_StreamProcessorFixture` | Full fixture recall: 4 canonical `kafka:*` topic IDs, ≥2 SUBSCRIBES_TO, ≥2 PUBLISHES_TO |
| `TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava` | Guard blocks false positives on non-Streams `.through()` calls |

**`fixtures/sources/java/stream-processor/`** — new fixture service

- `OrderEnrichmentTopology.java`: consumes `orders.placed` + `payments.settled`, produces `orders.enriched` + `orders.high_value` via `.mapValues().to()` + `.filter().to()`.
- `PaymentRoutingTopology.java`: consumes `payments.settled`, reroutes via `.through("payments.normalised")`, sinks to `orders.enriched`.

## Before / After topic links

| Scenario | Before #1480 | After #1480 |
|----------|-------------|------------|
| `stream-processor` → `analytics` (on `kafka:orders.enriched`) | ✗ not extracted | ✓ +1 link |
| `stream-processor` → `search-os` (on `kafka:orders.enriched`) | ✗ not extracted | ✓ +1 link |
| `stream-processor` → `notifications` (on `kafka:orders.high_value`) | ✗ not extracted | ✓ +1 link |
| **Total new cross-repo topic links** | **0** | **+3** |

The canonical IDs `kafka:orders.enriched` and `kafka:orders.high_value` match what the existing analytics / search-os / notifications subscriber services emit, so P7 joins without any change to the link pass.

## Test results

```
--- PASS: TestKafkaWrapper_JavaKafkaStreams_Through (0.00s)
--- PASS: TestKafkaWrapper_JavaKafkaStreams_MapValuesThenTo (0.00s)
--- PASS: TestKafkaWrapper_JavaKafkaStreams_StreamProcessorFixture (0.00s)
--- PASS: TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava (0.00s)
ok  github.com/cajasmota/archigraph/internal/engine   7.8s  (21 TestKafkaWrapper_* pass)
ok  github.com/cajasmota/archigraph/internal/links    3.9s  (all topic pass + scale tests pass)
```

## Guard / no-regression proof

- `synthesizeJavaKafkaStreams` guard unchanged: still requires `KafkaStreams`, `StreamsBuilder`, `KStream`, or `kafka_streams` token in the file — prevents false positives on plain Java `Stream<T>` or unrelated `.through()` calls.
- Append-only: no existing entities or edges modified.
- `TestKafkaWrapper_JavaKafkaStreams_NoFire_WithoutGuard` and `TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava` both pass.
- P7 scale tests (`TestTopicGRPCPass_ScaleCompletes`, `TestTopicPass_RealSkewedShape_BoundedEmission`) pass unchanged.

Fixes #1480

🤖 Generated with [Claude Code](https://claude.com/claude-code)