### PR TITLE
fix(engine/python): detect directly-imported gRPC stub — cross-file client resolution (#1481)

### DIFF
--- a/internal/engine/grpc_edges.go
+++ b/internal/engine/grpc_edges.go
@@ -698,10 +698,24 @@ func findEnclosingGoFuncName(src string, offset int) string {
 var pyAddServicerRe = regexp.MustCompile(
 	`\w+_pb2_grpc\.add_(\w+)Servicer_to_server\s*\(\s*(\w+)\s*[(),]`)
 
-// pyStubRe captures `stub = pb2_grpc.ServiceStub(channel)`.
-// Group 1: variable name. Group 2: service name.
+// pyStubRe captures the module-qualified stub construction form:
+//
+//	stub = inventory_pb2_grpc.InventoryServiceStub(channel)
+//
+// Group 1: variable name. Group 2: service name (prefix before "Stub").
 var pyStubRe = regexp.MustCompile(
 	`(\w+)\s*=\s*\w+_pb2_grpc\.(\w+)Stub\s*\(`)
+
+// pyStubDirectRe captures the directly-imported stub form (cross-file import):
+//
+//	from inventory_pb2_grpc import InventoryServiceStub
+//	stub = InventoryServiceStub(channel)
+//
+// Group 1: variable name. Group 2: service name (prefix before "Stub").
+// Only fires when the file also contains a _pb2_grpc import so we don't
+// false-positive on unrelated "SomethingStub" class names.
+var pyStubDirectRe = regexp.MustCompile(
+	`(\w+)\s*=\s*(\w+)Stub\s*\(`)
 
 // pyMethodCallRe captures `stub.method(req)` call sites.
 // Group 1: stub variable. Group 2: method name.
@@ -793,6 +807,7 @@ func synthesizePythonGRPC(
 	// ---- Client side ----
 	stubRegistry := map[string]string{} // var name → service name
 
+	// Module-qualified form: stub = inventory_pb2_grpc.InventoryServiceStub(ch)
 	for _, m := range pyStubRe.FindAllStringSubmatch(src, -1) {
 		if len(m) < 3 {
 			continue
@@ -801,6 +816,31 @@ func synthesizePythonGRPC(
 		serviceName := m[2]
 		stubRegistry[varName] = serviceName
 		emitService(serviceName, "grpc_python_client", map[string]string{"role": "client"})
+	}
+
+	// Directly-imported form (cross-file): stub = InventoryServiceStub(ch)
+	// Only applies when the file has a _pb2_grpc import (avoids false positives).
+	if strings.Contains(src, "_pb2_grpc") {
+		for _, m := range pyStubDirectRe.FindAllStringSubmatch(src, -1) {
+			if len(m) < 3 {
+				continue
+			}
+			varName := m[1]
+			serviceName := m[2]
+			// Skip if already registered by the module-qualified form.
+			if _, exists := stubRegistry[varName]; exists {
+				continue
+			}
+			// Skip names that don't look like gRPC service stubs (must end
+			// in "Stub" — already guaranteed by the regex — and the prefix
+			// must be non-empty and not a local variable name in lower_snake).
+			// Convention: protoc-generated stub classes are PascalCase.
+			if serviceName == "" || (serviceName[0] >= 'a' && serviceName[0] <= 'z') {
+				continue
+			}
+			stubRegistry[varName] = serviceName
+			emitService(serviceName, "grpc_python_client", map[string]string{"role": "client"})
+		}
 	}
 
 	if len(stubRegistry) == 0 {

--- a/internal/engine/grpc_edges_test.go
+++ b/internal/engine/grpc_edges_test.go
@@ -612,6 +612,67 @@ func main() {
 }
 
 // ---------------------------------------------------------------------------
+// Python — cross-file directly-imported stub (#1481)
+// ---------------------------------------------------------------------------
+
+// TestGRPC_Python_Client_DirectImportStub verifies that a stub created from a
+// directly-imported class (from inventory_pb2_grpc import InventoryServiceStub)
+// emits a GRPC_HANDLES edge.  This is the cross-file case: inventory_client.py
+// imports the stub class and uses it; the call is one file-level import away
+// from the endpoint that calls reserve_stock() in routes.py.
+//
+// Before #1481 the directly-imported form was not detected; only
+// `module_pb2_grpc.ServiceStub(channel)` was matched by pyStubRe.
+func TestGRPC_Python_Client_DirectImportStub(t *testing.T) {
+	src := `import grpc
+import inventory_pb2
+import inventory_pb2_grpc
+from inventory_pb2_grpc import InventoryServiceStub
+
+INVENTORY_ADDR = "inventory:50051"
+
+
+def reserve_stock(order_id: str) -> str:
+    channel = grpc.insecure_channel(INVENTORY_ADDR)
+    stub = InventoryServiceStub(channel)
+    resp = stub.ReserveStock(inventory_pb2.ReserveStockRequest(order_id=order_id))
+    return resp.reservation_id
+`
+	ents, rels := runGRPCDetect(t, "python", "inventory_client.py", src)
+
+	requireGRPCMethod(t, ents, "InventoryService", "ReserveStock", "python-client-direct-import")
+	requireGRPCHandles(t, rels, "InventoryService", "ReserveStock", "python-client-direct-import")
+}
+
+// TestGRPC_Python_Client_ModuleQualifiedStub verifies that the existing
+// module-qualified form (inventory_pb2_grpc.InventoryServiceStub) is still
+// detected after the #1481 refactor.
+func TestGRPC_Python_Client_ModuleQualifiedStub(t *testing.T) {
+	src := `import grpc
+import inventory_pb2
+import inventory_pb2_grpc
+
+INVENTORY_ADDR = "inventory:50051"
+
+
+def reserve_stock(order_id: str) -> str:
+    channel = grpc.insecure_channel(INVENTORY_ADDR)
+    stub = inventory_pb2_grpc.InventoryServiceStub(channel)
+    resp = stub.ReserveStock(inventory_pb2.ReserveStockRequest(order_id=order_id))
+    return resp.reservation_id
+`
+	ents, rels := runGRPCDetect(t, "python", "inventory_client_qualified.py", src)
+
+	requireGRPCMethod(t, ents, "InventoryService", "ReserveStock", "python-client-module-qualified")
+	requireGRPCHandles(t, rels, "InventoryService", "ReserveStock", "python-client-module-qualified")
+
+	if !strings.Contains(ents[0].Language, "") {
+		// Sanity: entities were emitted
+		t.Errorf("expected non-empty entities")
+	}
+}
+
+// ---------------------------------------------------------------------------
 // No-op guard
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## 1. What

Fixes #1481 — gRPC cross-file stub resolution.

The Python gRPC synthesis pass only matched the module-qualified stub construction:
`stub = inventory_pb2_grpc.InventoryServiceStub(channel)`

When the stub class is imported directly (cross-file pattern from inventory_client.py),
the pass emitted no GRPC_HANDLES edge:
`stub = InventoryServiceStub(channel)   # was invisible to the pass`

Result: orders→inventory gRPC cross-repo link never appeared in P6 output.

## 2. Root cause + fix

### Engine fix (internal/engine/grpc_edges.go)
Added pyStubDirectRe — a second stub-construction regex matching the directly-imported form. Guarded by strings.Contains(src, "_pb2_grpc") to avoid false positives on unrelated FooStub(...) patterns. The existing pyStubRe (module-qualified form) is unchanged.

### Fixture fix (polyglot-platform)
Three commented-out lines were preventing the §2 gRPC edge from being real:
- services/orders/app/inventory_client.py: stub creation + stub.ReserveStock call were commented; now uncommented with inventory_pb2_grpc import
- services/inventory/internal/server.go: pb.RegisterInventoryServiceServer was commented; now uncommented so synthesizeGoGRPC emits GRPC_IMPLEMENTS
- MANIFEST.md: added NOTE (#1481) documenting the fixture change

## 3. Test evidence

New tests:
- TestGRPC_Python_Client_DirectImportStub — directly-imported stub emits GRPC_HANDLES
- TestGRPC_Python_Client_ModuleQualifiedStub — existing form still works

xrepo-verify (isolated, non-/tmp build):
- Before: orders→inventory gRPC cross-repo links: 0
- After: orders→inventory gRPC cross-repo links: 1
  orders::reserve_stock (app/inventory_client.py) → inventory::inventoryServer.ReserveStock (internal/server.go)
  identifier: grpc:InventoryService/ReserveStock

go test ./internal/engine/ ./internal/links/ — all pass

## 4. Risk
Low. pyStubDirectRe is strictly additive and requires _pb2_grpc in the file. No existing tests changed.

## 5. What was NOT changed
P6 (internal/links/grpc_pass.go) is unchanged — fix is entirely in the synthesis pass.

## 6. Fixture note
polyglot-platform MANIFEST declared orders→inventory as gRPC but the code had stub calls commented out. This PR makes the fixture match its own MANIFEST spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)