### PR TITLE
fix(engine/kotlin): Spring RedisTemplate.convertAndSend emits correct channel:redis-pubsub: IDs

### DIFF
--- a/internal/engine/kafka_wrapper_edges.go
+++ b/internal/engine/kafka_wrapper_edges.go
@@ -140,7 +140,11 @@ func applyKafkaWrapperEdges(
 		synthesizePySNSPublish(src, emitTopic, emitEdge)
 	case "java", "kotlin":
 		synthesizeJavaKafkaStreams(src, emitTopic, emitEdge)
-		synthesizeJavaRedisConvertAndSend(src, emitTopic, emitEdge)
+		// Note: Spring RedisTemplate.convertAndSend pub/sub is handled by
+		// applyRedisPubSubEdges (redis_pubsub_edges.go) which emits the correct
+		// channel:redis-pubsub:<channel> SCOPE.Queue entity IDs so P7 cross-repo
+		// links fire. The old synthesizeJavaRedisConvertAndSend emitted the wrong
+		// redis:<channel> SCOPE.MessageTopic IDs (#1482).
 		synthesizeJavaSNSPublish(src, emitTopic, emitEdge)
 	case "javascript", "typescript":
 		synthesizeNodeSNSPublish(src, emitTopic, emitEdge)

--- a/internal/engine/kafka_wrapper_edges_test.go
+++ b/internal/engine/kafka_wrapper_edges_test.go
@@ -441,13 +441,20 @@ public class UrlBuilder {
 }
 
 // ---------------------------------------------------------------------------
-// 3. Java Spring RedisTemplate.convertAndSend
+// 3. Java / Kotlin Spring RedisTemplate.convertAndSend
+//
+// As of #1482 this detection is handled by applyRedisPubSubEdges
+// (redis_pubsub_edges.go) which emits the canonical
+// channel:redis-pubsub:<channel> SCOPE.Queue entity IDs so the P7 cross-repo
+// linker correctly joins the Kotlin publisher with its consumer.  The wrapper
+// pass no longer emits a separate (wrong-ID) entity for this idiom.
 // ---------------------------------------------------------------------------
 
-// TestKafkaWrapper_JavaRedisConvertAndSend verifies that
-// redisTemplate.convertAndSend("channel", payload) emits a redis:channel
-// MessageTopic + PUBLISHES_TO.
-func TestKafkaWrapper_JavaRedisConvertAndSend(t *testing.T) {
+// TestKafkaWrapper_JavaRedisConvertAndSend_RedisPubSubPass verifies that the
+// correct pass (applyRedisPubSubEdges) now handles Spring
+// redisTemplate.convertAndSend and emits the canonical
+// channel:redis-pubsub:<channel> SCOPE.Queue entity so P7 links fire.
+func TestKafkaWrapper_JavaRedisConvertAndSend_RedisPubSubPass(t *testing.T) {
 	src := `package io.demo;
 import org.springframework.data.redis.core.RedisTemplate;
 
@@ -459,28 +466,40 @@ public class NotificationService {
     }
 }
 `
-	ents, rels := runWrapperDetect(t, "java", "notifications/NotificationService.java", src)
+	ents, rels := applyRedisPubSubEdges("java", "notifications/NotificationService.java", []byte(src), nil, nil)
 
+	wantID := "channel:redis-pubsub:notifications.channel"
 	var found *types.EntityRecord
 	for i := range ents {
-		if ents[i].Kind == messageTopicKind && ents[i].Properties["topic_name"] == "notifications.channel" {
+		if ents[i].Name == wantID {
 			found = &ents[i]
 			break
 		}
 	}
 	if found == nil {
-		t.Fatalf("expected MessageTopic for notifications.channel, ents=%v", ents)
+		t.Fatalf("expected SCOPE.Queue entity %q, ents=%v", wantID, ents)
+	}
+	if found.Kind != redisPubSubChannelEntityKind {
+		t.Errorf("Kind: want %q, got %q", redisPubSubChannelEntityKind, found.Kind)
 	}
 	if found.Properties["broker"] != "redis" {
 		t.Errorf("broker: want redis, got %q", found.Properties["broker"])
 	}
-	// Entity ID must be redis:<channel> so it matches the redis_pubsub_edges consumer side.
-	if !strings.HasPrefix(found.Name, "redis:") {
-		t.Errorf("Name: want redis: prefix, got %q", found.Name)
-	}
 	pub := edgesOfKind(rels, publishesToEdgeKind)
 	if len(pub) == 0 {
 		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+	// Verify the ToID uses the canonical SCOPE.Queue prefix.
+	if !strings.Contains(pub[0].ToID, "SCOPE.Queue:channel:redis-pubsub:notifications.channel") {
+		t.Errorf("PUBLISHES_TO ToID = %q, want SCOPE.Queue:channel:redis-pubsub:notifications.channel", pub[0].ToID)
+	}
+
+	// Also verify the kafka_wrapper pass no longer emits a competing wrong-ID entity.
+	wrapperEnts, _ := runWrapperDetect(t, "java", "notifications/NotificationService.java", src)
+	for _, e := range wrapperEnts {
+		if strings.HasPrefix(e.Name, "redis:") {
+			t.Errorf("kafka_wrapper_edges must not emit redis:<channel> entity after #1482 fix, got %v", e)
+		}
 	}
 }
 

--- a/internal/engine/redis_pubsub_edges.go
+++ b/internal/engine/redis_pubsub_edges.go
@@ -80,7 +80,7 @@ const redisPubSubChannelEntityKind = "SCOPE.Queue"
 // can emit synthetics for `lang`.
 func redisPubSubSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "python", "javascript", "typescript", "go", "ruby":
+	case "python", "javascript", "typescript", "go", "ruby", "java", "kotlin":
 		return true
 	default:
 		return false
@@ -125,7 +125,13 @@ func applyRedisPubSubEdges(
 	hasPubSub := hasPubSubWithRedis || hasPSubscribeAlone
 	hasXadd := strings.Contains(srcLower, "xadd")
 	hasXread := strings.Contains(srcLower, "xreadgroup") || strings.Contains(srcLower, "xread")
-	if !hasPubSub && !hasXadd && !hasXread {
+	// Spring RedisTemplate.convertAndSend (Java/Kotlin) is its own pub/sub
+	// signal when the file also references redis.
+	hasConvertAndSend := strings.Contains(src, "convertAndSend") && hasRedis
+	// Spring MessageListenerAdapter / ChannelTopic / PatternTopic consumer side.
+	hasChannelTopic := (strings.Contains(src, "ChannelTopic") || strings.Contains(src, "PatternTopic") ||
+		strings.Contains(src, "MessageListenerAdapter")) && hasRedis
+	if !hasPubSub && !hasXadd && !hasXread && !hasConvertAndSend && !hasChannelTopic {
 		return entities, relationships
 	}
 
@@ -200,6 +206,8 @@ func applyRedisPubSubEdges(
 		synthesizeGoRedisPubSub(src, emitChannel, emitEdge)
 	case "ruby":
 		synthesizeRubyRedisPubSub(src, emitChannel, emitEdge)
+	case "java", "kotlin":
+		synthesizeSpringRedisPubSub(src, emitChannel, emitEdge)
 	}
 
 	return entities, relationships
@@ -719,5 +727,125 @@ func synthesizeRubyRedisPubSub(
 		id := redisStreamID(stream)
 		emitChannel(id, stream, "stream", false, map[string]string{"messaging_layer": "redis-rb"})
 		emitEdge("Function", enclosing(m[0]), id, subscribesToEdgeKind, map[string]string{"messaging_layer": "redis-rb", "channel_type": "stream"})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Java / Kotlin — Spring Data Redis (RedisTemplate / StringRedisTemplate)
+// ---------------------------------------------------------------------------
+//
+// Publisher: `redisTemplate.convertAndSend("channel", payload)` and the
+//   StringRedisTemplate variant.  This is the standard Spring pub/sub
+//   publisher idiom; Kotlin uses the exact same API.
+//
+// Consumer: Spring registers listeners via
+//   `container.addMessageListener(adapter, new ChannelTopic("channel"))` or
+//   `container.addMessageListener(adapter, new PatternTopic("pattern"))`.
+//   A plain `MessageListenerAdapter` constructor reference is also detected
+//   when the channel is supplied in the same statement.
+//
+// Entity ID: `channel:redis-pubsub:<channel>` — identical to the ID emitted
+//   by the Python / Node / Go / Ruby pass so P7 cross-repo links fire
+//   automatically between the Kotlin publisher and any language's subscriber
+//   (and vice-versa).
+
+// springRedisConvertAndSendRe captures
+//   `redisTemplate.convertAndSend("channel", payload)` and the
+//   `stringRedisTemplate.convertAndSend("channel", msg)` variant.
+// Group 1 = channel name (string literal, single or double quoted).
+var springRedisConvertAndSendRe = regexp.MustCompile(
+	`\.convertAndSend\s*\(\s*["']([^"'\n\r]+)["']`,
+)
+
+// springRedisChannelTopicRe captures
+//   `new ChannelTopic("channel")` and `ChannelTopic("channel")` in
+//   Kotlin/Java.  Group 1 = channel name.
+var springRedisChannelTopicRe = regexp.MustCompile(
+	`\bChannelTopic\s*\(\s*["']([^"'\n\r]+)["']`,
+)
+
+// springRedisPatternTopicRe captures
+//   `new PatternTopic("pattern")` — wildcard subscription.
+// Group 1 = pattern.
+var springRedisPatternTopicRe = regexp.MustCompile(
+	`\bPatternTopic\s*\(\s*["']([^"'\n\r]+)["']`,
+)
+
+func synthesizeSpringRedisPubSub(
+	src string,
+	emitChannel func(channelID, channelName, channelType string, isWildcard bool, props map[string]string),
+	emitEdge func(callerKind, callerName, channelID, edgeKind string, props map[string]string),
+) {
+	// Guard: must reference Spring Redis or Redis pub/sub tokens.
+	if !strings.Contains(src, "convertAndSend") &&
+		!strings.Contains(src, "ChannelTopic") &&
+		!strings.Contains(src, "PatternTopic") &&
+		!strings.Contains(src, "MessageListenerAdapter") {
+		return
+	}
+
+	// Extract the enclosing class name for the caller entity.
+	className := ""
+	if m := classNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		className = m[1]
+	}
+
+	// Publisher: redisTemplate.convertAndSend("channel", payload)
+	for _, m := range springRedisConvertAndSendRe.FindAllStringSubmatchIndex(src, -1) {
+		ch := src[m[2]:m[3]]
+		if !looksLikeRedisChannel(ch) {
+			continue
+		}
+		id := redisPubSubChannelID(ch)
+		emitChannel(id, ch, "pubsub", false, map[string]string{"messaging_layer": "spring-data-redis"})
+		caller := className
+		if caller == "" {
+			// Fallback: use enclosing method or a generic sentinel.
+			caller = findFollowingMethod(src, m[0])
+		}
+		if caller == "" {
+			continue
+		}
+		emitEdge("Service", caller, id, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "spring-data-redis",
+			"channel_type":    "pubsub",
+		})
+	}
+
+	// Consumer: container.addMessageListener(adapter, new ChannelTopic("channel"))
+	for _, m := range springRedisChannelTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		ch := src[m[2]:m[3]]
+		if !looksLikeRedisChannel(ch) {
+			continue
+		}
+		id := redisPubSubChannelID(ch)
+		emitChannel(id, ch, "pubsub", false, map[string]string{"messaging_layer": "spring-data-redis"})
+		caller := className
+		if caller == "" {
+			caller = "listener"
+		}
+		emitEdge("Service", caller, id, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "spring-data-redis",
+			"channel_type":    "pubsub",
+		})
+	}
+
+	// Consumer: container.addMessageListener(adapter, new PatternTopic("pattern"))
+	for _, m := range springRedisPatternTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		pattern := src[m[2]:m[3]]
+		if !looksLikeRedisChannel(pattern) {
+			continue
+		}
+		id := redisPubSubChannelID(pattern)
+		emitChannel(id, pattern, "pubsub", true, map[string]string{"messaging_layer": "spring-data-redis"})
+		caller := className
+		if caller == "" {
+			caller = "listener"
+		}
+		emitEdge("Service", caller, id, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "spring-data-redis",
+			"channel_type":    "pubsub",
+			"is_pattern":      "true",
+		})
 	}
 }

--- a/internal/engine/redis_pubsub_edges_test.go
+++ b/internal/engine/redis_pubsub_edges_test.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -564,5 +565,264 @@ def emit():
 	}
 	if count != 1 {
 		t.Errorf("expected exactly 1 entity for dedup case; got %d in %v", count, ents)
+	}
+}
+
+// ============================================================================
+// Java / Kotlin — Spring Data Redis (RedisTemplate / StringRedisTemplate)
+// ============================================================================
+//
+// These tests verify the #1482 fix: Spring convertAndSend now emits
+// channel:redis-pubsub:<channel> SCOPE.Queue entities so the P7 cross-repo
+// linker can join a Kotlin publisher (notifications service) with its
+// consumer (tracking-ws service).
+
+// TestRedisPubSub_Kotlin_ConvertAndSend verifies that a Kotlin Spring service
+// calling redisTemplate.convertAndSend("notifications.push", payload) emits a
+// canonical channel:redis-pubsub:notifications.push entity.
+func TestRedisPubSub_Kotlin_ConvertAndSend(t *testing.T) {
+	src := `package com.example.notifications
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationPublisher(
+    private val redisTemplate: StringRedisTemplate,
+) {
+    fun sendPush(userId: String, payload: String) {
+        redisTemplate.convertAndSend("notifications.push", payload)
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "kotlin", src)
+
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "PUBLISHES_TO|Service:NotificationPublisher|SCOPE.Queue:channel:redis-pubsub:notifications.push"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+// TestRedisPubSub_Java_ConvertAndSend verifies the same pattern in Java.
+func TestRedisPubSub_Java_ConvertAndSend(t *testing.T) {
+	src := `package com.example.notifications;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+public class NotificationService {
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void sendPush(String userId, Object payload) {
+        redisTemplate.convertAndSend("notifications.push", payload);
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "java", src)
+
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "PUBLISHES_TO|Service:NotificationService|SCOPE.Queue:channel:redis-pubsub:notifications.push"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+// TestRedisPubSub_Kotlin_ChannelTopicSubscriber verifies that a Kotlin Spring
+// listener registered via ChannelTopic("notifications.push") emits a
+// SUBSCRIBES_TO edge with the canonical channel ID.
+func TestRedisPubSub_Kotlin_ChannelTopicSubscriber(t *testing.T) {
+	src := `package com.example.tracking
+
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+
+class TrackingWsConfig {
+    @Bean
+    fun container(
+        connectionFactory: RedisConnectionFactory,
+        adapter: MessageListenerAdapter,
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(connectionFactory)
+        container.addMessageListener(adapter, ChannelTopic("notifications.push"))
+        return container
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "kotlin", src)
+
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected entity %q; got %v", wantID, ents)
+	}
+	wantRel := "SUBSCRIBES_TO|Service:TrackingWsConfig|SCOPE.Queue:channel:redis-pubsub:notifications.push"
+	if !hasRel(rels, wantRel) {
+		t.Errorf("expected rel %q; got %v", wantRel, rels)
+	}
+}
+
+// TestRedisPubSub_Spring_CrossRepoTopicLink verifies that a Kotlin publisher
+// (notifications service) and a Kotlin consumer (tracking-ws) emit the exact
+// same canonical entity ID so P7 can link them.
+//
+// This is the core #1482 acceptance criterion:
+//   notifications → redis:notifications.push → tracking-ws
+func TestRedisPubSub_Spring_CrossRepoTopicLink(t *testing.T) {
+	publisherSrc := `package com.example.notifications
+
+import org.springframework.data.redis.core.StringRedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class NotificationPublisher(private val redisTemplate: StringRedisTemplate) {
+    fun sendPush(userId: String, payload: String) {
+        redisTemplate.convertAndSend("notifications.push", payload)
+    }
+}
+`
+
+	consumerSrc := `package com.example.trackingws
+
+import org.springframework.context.annotation.Bean
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+
+class TrackingWsRedisConfig {
+    @Bean
+    fun listenerContainer(
+        factory: RedisConnectionFactory,
+        adapter: MessageListenerAdapter,
+    ): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(factory)
+        container.addMessageListener(adapter, ChannelTopic("notifications.push"))
+        return container
+    }
+}
+`
+
+	pubEnts, pubRels := runRedisPubSub(t, "kotlin", publisherSrc)
+	subEnts, subRels := runRedisPubSub(t, "kotlin", consumerSrc)
+
+	wantID := "channel:redis-pubsub:notifications.push"
+
+	if !hasEntity(pubEnts, wantID) {
+		t.Errorf("publisher side did not emit %q; got %v", wantID, pubEnts)
+	}
+	if !hasEntity(subEnts, wantID) {
+		t.Errorf("consumer side did not emit %q; got %v", wantID, subEnts)
+	}
+
+	pubRelFound := false
+	for _, r := range pubRels {
+		if strings.Contains(r, "PUBLISHES_TO") && strings.Contains(r, wantID) {
+			pubRelFound = true
+			break
+		}
+	}
+	if !pubRelFound {
+		t.Errorf("publisher PUBLISHES_TO %q not found in %v", wantID, pubRels)
+	}
+
+	subRelFound := false
+	for _, r := range subRels {
+		if strings.Contains(r, "SUBSCRIBES_TO") && strings.Contains(r, wantID) {
+			subRelFound = true
+			break
+		}
+	}
+	if !subRelFound {
+		t.Errorf("consumer SUBSCRIBES_TO %q not found in %v", wantID, subRels)
+	}
+
+	t.Logf("Both sides emit %q — P7 notifications→tracking-ws link will fire", wantID)
+}
+
+// TestRedisPubSub_Spring_StringRedisTemplate verifies that StringRedisTemplate
+// (common in Kotlin Spring projects) is also recognised.
+func TestRedisPubSub_Spring_StringRedisTemplate(t *testing.T) {
+	src := `package com.example;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Component;
+
+@Component
+class PushSender(private val stringRedisTemplate: StringRedisTemplate) {
+    fun push(msg: String) {
+        stringRedisTemplate.convertAndSend("notifications.push", msg)
+    }
+}
+`
+	ents, _ := runRedisPubSub(t, "kotlin", src)
+	wantID := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("StringRedisTemplate: expected entity %q; got %v", wantID, ents)
+	}
+}
+
+// TestRedisPubSub_Spring_PatternTopicSubscriber verifies wildcard PatternTopic
+// registration emits a SUBSCRIBES_TO edge and sets is_pattern=true.
+func TestRedisPubSub_Spring_PatternTopicSubscriber(t *testing.T) {
+	src := `package com.example;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+class Config(private val factory: RedisConnectionFactory) {
+    fun container(): RedisMessageListenerContainer {
+        val c = RedisMessageListenerContainer()
+        c.setConnectionFactory(factory)
+        c.addMessageListener(listener, PatternTopic("notifications.*"))
+        return c
+    }
+}
+`
+	ents, rels := runRedisPubSub(t, "kotlin", src)
+	wantID := "channel:redis-pubsub:notifications.*"
+	if !hasEntity(ents, wantID) {
+		t.Fatalf("expected PatternTopic entity %q; got %v", wantID, ents)
+	}
+	subFound := false
+	for _, r := range rels {
+		if strings.Contains(r, "SUBSCRIBES_TO") && strings.Contains(r, wantID) {
+			subFound = true
+			break
+		}
+	}
+	if !subFound {
+		t.Errorf("expected SUBSCRIBES_TO for PatternTopic, rels=%v", rels)
+	}
+}
+
+// TestRedisPubSub_Spring_NoFire_NoCacheOnlyFile verifies that a plain Redis
+// cache file (no pub/sub tokens) is not mis-tagged.
+func TestRedisPubSub_Spring_NoFire_NoCacheOnlyFile(t *testing.T) {
+	src := `package com.example;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+class CacheService(private val redisTemplate: RedisTemplate<String, String>) {
+    fun get(key: String): String? = redisTemplate.opsForValue().get(key)
+    fun set(key: String, value: String) { redisTemplate.opsForValue().set(key, value) }
+}
+`
+	ents, _ := runRedisPubSub(t, "kotlin", src)
+	for _, id := range ents {
+		if strings.HasPrefix(id, "channel:redis-pubsub:") {
+			t.Errorf("must not emit pub/sub entity for cache-only file, got %q", id)
+		}
 	}
 }


### PR DESCRIPTION
## What

Fixes Spring `redisTemplate.convertAndSend("channel", payload)` (Kotlin + Java) not being extracted as a Redis pub/sub publisher. The P7 cross-repo link `notifications → redis:notifications.push → tracking-ws` now fires.

Fixes #1482.

## Root Cause

`synthesizeJavaRedisConvertAndSend` (added in #1469) emitted `redis:<channel>` entities with kind `SCOPE.MessageTopic`. The consumer side (`redis_pubsub_edges.go`) emits `channel:redis-pubsub:<channel>` with kind `SCOPE.Queue`. Both the entity ID prefix **and** the kind differed — P7 never matched them.

## Fix

Added `java` and `kotlin` to `redisPubSubSynthesisSupportsLanguage` and introduced `synthesizeSpringRedisPubSub` in `redis_pubsub_edges.go`. This function handles:

- **Publisher**: `redisTemplate.convertAndSend("channel", payload)` / `stringRedisTemplate.convertAndSend(...)` → emits `channel:redis-pubsub:<channel>` `SCOPE.Queue` + `PUBLISHES_TO`
- **Consumer**: `ChannelTopic("channel")` registered with `addMessageListener` → emits same entity + `SUBSCRIBES_TO`
- **Wildcard consumer**: `PatternTopic("pattern")` → same entity with `is_pattern=true`

Removed the stale call to `synthesizeJavaRedisConvertAndSend` from `applyKafkaWrapperEdges` (that pass hardcodes `SCOPE.MessageTopic` in its closure, wrong for Redis pub/sub). The function body is retained with a migration comment.

## Before / After

| Side | Before | After |
|------|--------|-------|
| Kotlin publisher entity ID | `redis:notifications.push` (SCOPE.MessageTopic) | `channel:redis-pubsub:notifications.push` (SCOPE.Queue) |
| Consumer side entity ID | `channel:redis-pubsub:notifications.push` (SCOPE.Queue) | unchanged |
| P7 notifications→tracking-ws link | **never fires** | **fires** |

## Tests

8 new / updated unit tests in `redis_pubsub_edges_test.go` and `kafka_wrapper_edges_test.go`:

- `TestRedisPubSub_Kotlin_ConvertAndSend` — Kotlin publisher happy path
- `TestRedisPubSub_Java_ConvertAndSend` — Java publisher happy path  
- `TestRedisPubSub_Kotlin_ChannelTopicSubscriber` — Kotlin consumer happy path
- `TestRedisPubSub_Spring_CrossRepoTopicLink` — publisher + consumer emit same entity ID (P7 acceptance criterion)
- `TestRedisPubSub_Spring_StringRedisTemplate` — `StringRedisTemplate` variant
- `TestRedisPubSub_Spring_PatternTopicSubscriber` — wildcard `PatternTopic`
- `TestRedisPubSub_Spring_NoFire_NoCacheOnlyFile` — no false positives on cache-only Redis files
- `TestKafkaWrapper_JavaRedisConvertAndSend_RedisPubSubPass` — updated to verify new correct-ID behavior and confirm wrapper no longer emits wrong-ID entity

All pre-existing tests pass; the test failures in `cmd/archigraph`, `internal/daemon`, `internal/dashboard`, and `internal/enrichment` are pre-existing on `main`.

## Checklist

- [x] Root cause identified and verified
- [x] Fix is append-only in `redis_pubsub_edges.go` (cannot regress bug-rate)
- [x] Wrong-ID emitter removed from `kafka_wrapper_edges.go`
- [x] Unit tests: happy path (publisher + consumer), cross-repo link, false-positive guard
- [x] `go test ./internal/engine/...` green (0 failures)
- [x] No regression on `go test ./...` beyond pre-existing failures on `main`