### PR TITLE
fix(engine/py): resolve cross-module imported f-string URL constants in local vars

### DIFF
--- a/internal/engine/http_endpoint_python_client.go
+++ b/internal/engine/http_endpoint_python_client.go
@@ -326,7 +326,7 @@ func synthesizePyClientWithRuntime(content string, emit pyClientEmitFn) {
 	}
 	funcs := indexPyEnclosingFunctions(content)
 	syms := buildPyStringSymbolTable(content)
-	locals := buildPyLocalVarTable(content)
+	locals := buildPyLocalVarTable(content, syms)
 	instances := buildPySessionInstanceTable(content)
 	// Merge local variables into syms for URL resolution (locals win on
 	// collision, as they are more specific than module-level constants).
@@ -685,11 +685,25 @@ func buildPySessionInstanceTable(content string) map[string]string {
 // like `pricing_endpoint = "http://..."` are resolved when used as a URL
 // argument later in the same function.
 //
+// moduleSyms is the module-level constant table built by
+// buildPyStringSymbolTable. It is used to eagerly resolve f-string
+// local variables so that patterns like:
+//
+//	PRICING_URL = "http://pricing:8084"        # module level
+//	pricing_endpoint = f"{PRICING_URL}/quote"  # function body
+//	await client.post(pricing_endpoint, ...)
+//
+// produce the resolved value "http://pricing:8084/quote" for
+// pricing_endpoint rather than storing the raw f-string body
+// "{PRICING_URL}/quote". Without this, pyResolveURLArg would return
+// isFString=false for bare-identifier lookups, causing the
+// {PRICING_URL} placeholder to appear in the emitted path. (#1491)
+//
 // Note: this is a file-wide scan — we do not attempt true per-function
 // scoping. False-positive variable capture across function boundaries is
 // extremely rare in practice and the worst outcome is resolving a URL from
 // another function in the same file (which still produces a valid edge).
-func buildPyLocalVarTable(content string) map[string]string {
+func buildPyLocalVarTable(content string, moduleSyms map[string]string) map[string]string {
 	out := make(map[string]string)
 	for _, m := range pyLocalVarStringRe.FindAllStringSubmatch(content, -1) {
 		// m[1]=name, m[2]="f" if f-string, m[3]=body
@@ -697,12 +711,59 @@ func buildPyLocalVarTable(content string) map[string]string {
 			continue
 		}
 		name := m[1]
-		val := m[3]
+		body := m[3]
+		isFString := m[2] == "f" || m[2] == "F"
+
+		var val string
+		if isFString {
+			// Eagerly resolve f-string substitutions using module-level
+			// constants. This turns `f"{PRICING_URL}/quote"` into
+			// "http://pricing:8084/quote" (or "/quote" after stripURLHost)
+			// so that later bare-identifier lookups get the full resolved
+			// value rather than the raw {NAME} body.
+			//
+			// Even when moduleSyms is empty (e.g. PRICING_URL is imported
+			// from another module), pyResolveFStringBody strips URL/host-
+			// shaped identifiers (pyIsURLConstName) so that
+			// `f"{PRICING_URL}/quote"` → "/quote" rather than
+			// "/{PRICING_URL}/quote". (#1491)
+			val = pyResolveFStringBody(body, moduleSyms)
+		} else {
+			val = body
+		}
+
 		if _, dup := out[name]; !dup {
 			out[name] = val
 		}
 	}
 	return out
+}
+
+// pyResolveFStringBody substitutes {identifier} placeholders in an f-string
+// body using the provided symbol table. When a placeholder identifier is
+// present in syms, its value is substituted directly. When it is absent but
+// looks like a URL/host constant (pyIsURLConstName), it is stripped (replaced
+// with empty string), so that `{PRICING_URL}/quote` → `/quote` rather than
+// `/{PRICING_URL}/quote`. Other unknown identifiers are left as-is (they will
+// be treated as path parameters by pyCanonicalize later).
+func pyResolveFStringBody(body string, syms map[string]string) string {
+	return pyFStringSubstRe.ReplaceAllStringFunc(body, func(match string) string {
+		mm := pyFStringSubstRe.FindStringSubmatch(match)
+		if len(mm) < 2 {
+			return match
+		}
+		expr := strings.TrimSpace(mm[1])
+		if pyIdentRe.MatchString(expr) {
+			if val, ok := syms[expr]; ok {
+				return val
+			}
+			// Unknown identifier: strip URL/host constants, keep path params.
+			if pyIsURLConstName(expr) {
+				return ""
+			}
+		}
+		return match
+	})
 }
 
 // pyResolveURLArg picks the URL argument from a match's submatch slice.

--- a/internal/engine/http_endpoint_python_client_test.go
+++ b/internal/engine/http_endpoint_python_client_test.go
@@ -505,3 +505,179 @@ async def get_stock(item_id: str):
 	requireContains(t, ids, want, "imported-const-path-param")
 	requireFetches(t, rels, "http:GET:/items/{item_id}/stock", "imported-const-path-param")
 }
+
+// ---------------------------------------------------------------------------
+// #1491 — cross-MODULE f-string URL resolution via local variable
+// ---------------------------------------------------------------------------
+
+// TestPyClient_XModule_LocalVarFString_SameFile covers the core scenario
+// from #1491: a module-level URL constant is used inside an f-string that is
+// assigned to a local variable, which is then passed to the HTTP client.
+//
+//	PRICING_URL = "http://pricing:8000"    # same file (module-level)
+//	pricing_endpoint = f"{PRICING_URL}/quote"
+//	await client.post(pricing_endpoint, ...)  → POST:/quote
+//
+// Before the fix this emitted `POST:/{PRICING_URL}/quote` because the local
+// variable table stored the raw f-string body without resolving it, and
+// pyResolveURLArg returned isFString=false for bare-identifier lookups.
+func TestPyClient_XModule_LocalVarFString_SameFile(t *testing.T) {
+	src := `
+import httpx
+
+PRICING_URL = "http://pricing:8084"
+
+async def create_order(payload: dict):
+    pricing_endpoint = f"{PRICING_URL}/quote"
+    async with httpx.AsyncClient() as client:
+        quote = await client.post(pricing_endpoint, json={"sku": "abc"})
+    return quote.json()
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	want := []string{"http:POST:/quote"}
+	requireContains(t, ids, want, "xmod-localvar-fstring-samefile")
+	requireFetches(t, rels, "http:POST:/quote", "xmod-localvar-fstring-samefile")
+	for _, id := range ids {
+		if strings.Contains(id, "PRICING_URL") {
+			t.Errorf("xmod-localvar-fstring-samefile: emitted literal placeholder %q", id)
+		}
+	}
+}
+
+// TestPyClient_XModule_LocalVarFString_Imported covers the cross-module case:
+// PRICING_URL is imported from another module and the local variable holds
+// the f-string that references it.
+//
+//	from app.config import PRICING_URL
+//	pricing_endpoint = f"{PRICING_URL}/quote"
+//	await client.post(pricing_endpoint, ...)  → POST:/quote  (not /{PRICING_URL}/quote)
+func TestPyClient_XModule_LocalVarFString_Imported(t *testing.T) {
+	src := `
+from app.config import PRICING_URL
+import httpx
+
+async def create_order(payload: dict):
+    pricing_endpoint = f"{PRICING_URL}/quote"
+    async with httpx.AsyncClient() as client:
+        quote = await client.post(pricing_endpoint, json={"sku": "abc"})
+    return quote.json()
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	want := []string{"http:POST:/quote"}
+	requireContains(t, ids, want, "xmod-localvar-fstring-imported")
+	requireFetches(t, rels, "http:POST:/quote", "xmod-localvar-fstring-imported")
+	for _, id := range ids {
+		if strings.Contains(id, "PRICING_URL") {
+			t.Errorf("xmod-localvar-fstring-imported: emitted literal placeholder %q", id)
+		}
+	}
+}
+
+// TestPyClient_XModule_LocalVarFString_FlagGated covers the polyglot-platform
+// orders/routes.py pattern: an if-branch overwrites pricing_endpoint with a
+// V2 URL, but both branches must resolve to valid paths (not raw f-string
+// bodies).
+func TestPyClient_XModule_LocalVarFString_FlagGated(t *testing.T) {
+	src := `
+import httpx
+
+PRICING_URL = "http://pricing:8084"
+PRICING_V2_URL = "http://pricing:8084/v2"
+
+async def create_order(payload: dict):
+    pricing_endpoint = f"{PRICING_URL}/quote"
+    if payload.get("new_engine"):
+        pricing_endpoint = f"{PRICING_V2_URL}/quote"
+
+    async with httpx.AsyncClient() as client:
+        quote = await client.post(pricing_endpoint, json={"sku": "abc"})
+    return quote.json()
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	// Both /quote and /v2/quote are valid resolved paths.
+	requireContains(t, ids, []string{"http:POST:/quote"}, "flag-gated-v1")
+	requireFetches(t, rels, "http:POST:/quote", "flag-gated-v1")
+	for _, id := range ids {
+		if strings.Contains(id, "PRICING_URL") || strings.Contains(id, "PRICING_V2_URL") {
+			t.Errorf("flag-gated: emitted literal placeholder %q", id)
+		}
+	}
+}
+
+// TestPyClient_XModule_LocalVarFString_OrderSagaInventory covers
+// order-saga→inventory: INVENTORY_URL module const in f-string local var.
+func TestPyClient_XModule_LocalVarFString_OrderSagaInventory(t *testing.T) {
+	src := `
+import httpx
+
+INVENTORY_URL = "http://inventory:50051"
+
+async def reserve_stock(item_id: str, qty: int):
+    url = f"{INVENTORY_URL}/reserve"
+    async with httpx.AsyncClient() as c:
+        await c.post(url, json={"item_id": item_id, "qty": qty})
+`
+	ids, rels := runDetectWithRels(t, "python", "steps.py", src)
+	requireContains(t, ids, []string{"http:POST:/reserve"}, "saga-inventory-localvar")
+	requireFetches(t, rels, "http:POST:/reserve", "saga-inventory-localvar")
+	for _, id := range ids {
+		if strings.Contains(id, "INVENTORY_URL") {
+			t.Errorf("saga-inventory: emitted placeholder %q", id)
+		}
+	}
+}
+
+// TestPyClient_XModule_LocalVarFString_SemanticSearchCatalog covers
+// semantic-search→catalog: CATALOG_URL module const, direct f-string to
+// client.get (no intermediate local var). Uses a simple identifier path
+// param (not a subscript expression like hit['sku'] which is a pre-existing
+// limitation). Verifies that CATALOG_URL is stripped correctly.
+func TestPyClient_XModule_LocalVarFString_SemanticSearchCatalog(t *testing.T) {
+	src := `
+import httpx
+
+CATALOG_URL = "http://catalog:3001"
+
+async def enrich(hits: list) -> list:
+    products = []
+    async with httpx.AsyncClient() as client:
+        for hit in hits:
+            sku = hit["sku"]
+            resp = await client.get(f"{CATALOG_URL}/products/{sku}")
+            products.append(resp.json())
+    return products
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	// CATALOG_URL is a same-file constant, should be resolved via f-string path.
+	requireContains(t, ids, []string{"http:GET:/products/{sku}"}, "semantic-search-catalog-direct-fstring")
+	requireFetches(t, rels, "http:GET:/products/{sku}", "semantic-search-catalog-direct-fstring")
+	for _, id := range ids {
+		if strings.Contains(id, "CATALOG_URL") {
+			t.Errorf("semantic-search-catalog: emitted placeholder %q", id)
+		}
+	}
+}
+
+// TestPyClient_XModule_LocalVarFString_SemanticSearchViaLocalVar covers the
+// case where the URL is built into a local variable using an f-string.
+func TestPyClient_XModule_LocalVarFString_SemanticSearchViaLocalVar(t *testing.T) {
+	src := `
+import httpx
+
+CATALOG_URL = "http://catalog:3001"
+
+async def enrich(sku: str) -> dict:
+    url = f"{CATALOG_URL}/products/{sku}"
+    async with httpx.AsyncClient() as client:
+        resp = await client.get(url)
+    return resp.json()
+`
+	ids, rels := runDetectWithRels(t, "python", "routes.py", src)
+	requireContains(t, ids, []string{"http:GET:/products/{sku}"}, "semantic-search-catalog-localvar")
+	requireFetches(t, rels, "http:GET:/products/{sku}", "semantic-search-catalog-localvar")
+	for _, id := range ids {
+		if strings.Contains(id, "CATALOG_URL") {
+			t.Errorf("semantic-search-catalog: emitted placeholder %q", id)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

`#1479` resolved same-module f-string constants, but `orders→pricing` cross-repo link was still MISSING — orphan path `/{PRICING_URL}/quote`.

**Root cause:** In `routes.py` (orders service):
```python
PRICING_URL = "http://pricing:8084"        # module level

async def create_order(payload: dict):
    pricing_endpoint = f"{PRICING_URL}/quote"   # local var assigned from f-string
    async with httpx.AsyncClient() as client:
        quote = await client.post(pricing_endpoint, ...)  # passed as bare ident
```

Two-layer bug:
1. `buildPyLocalVarTable` stored the raw f-string body `{PRICING_URL}/quote` without resolving the `{NAME}` substitution
2. `pyResolveURLArg` returned `isFString=false` for bare-identifier lookups, so `pyCanonicalize` treated `{PRICING_URL}` as a literal path segment → `/{PRICING_URL}/quote`

## Fix

- Add `pyResolveFStringBody(body, syms)`: resolves `{IDENTIFIER}` placeholders in an f-string body. Substitutes known constants, strips URL/host-shaped names (`pyIsURLConstName`: all-caps or `_URL/_HOST/_ADDR/_ENDPOINT/_BASE/_SVC/_SERVICE` suffix), keeps unknown identifiers as path-param placeholders.
- Change `buildPyLocalVarTable(content, moduleSyms)` to eagerly resolve f-string bodies at table-build time. Works even when `moduleSyms` is empty (cross-module import case): `pyResolveFStringBody` still strips URL-shaped names.
- Scope is safe: only f-string local variables are affected; plain string locals, direct f-string call args, and all other patterns are unchanged.

## Real-fixture before→after (polyglot-platform, 6 services)

```
BEFORE:
  total http-method links: 1
    order-saga→orders : 1
  orphan consumer calls: 11
  [10] CONSUMER POST /{PRICING_URL}/quote  ← the #1491 orphan

AFTER:
  total http-method links: 2  (+1)
    order-saga→orders : 1
    orders→pricing    : 1  ← NEW — resolved by this fix
  orphan consumer calls: 10  (-1)
  /{PRICING_URL}/quote is GONE
```

The remaining 10 orphans are unrelated: missing producer endpoints for gRPC-backed services (inventory) and the pre-existing subscript-expression limitation `{hit['sku']}` in semantic-search.

## Tests

6 new unit tests added in `TestPyClient_XModule_LocalVarFString_*`:
- `SameFile` — module-level const via local var (same file)
- `Imported` — `from app.config import PRICING_URL` then local var  
- `FlagGated` — branching `if ... pricing_endpoint = f"{PRICING_V2_URL}/quote"` pattern
- `OrderSagaInventory` — `INVENTORY_URL` same pattern
- `SemanticSearchCatalog` — `CATALOG_URL` direct f-string (no local var)
- `SemanticSearchViaLocalVar` — `CATALOG_URL` via local var

All 6 pass. Full engine test suite passes with no regressions.

## Checklist

- [x] Root cause identified (not a guess-and-check fix)
- [x] Failing tests written first (TDD)
- [x] Fix implements root cause only — no unrelated changes
- [x] Real fixture `polyglot-platform` before→after verified with `xrepo-verify`
- [x] `orders→pricing` link confirmed resolved post-fix
- [x] Full engine test suite passes (`go test ./internal/engine/`)
- [x] No live daemon touched

Fixes #1491