### PR TITLE
fix(engine+links): topic recall on the REAL polyglot fixture (8→16) (Fixes #1489)

### DIFF
--- a/internal/engine/kafka_edges.go
+++ b/internal/engine/kafka_edges.go
@@ -199,9 +199,15 @@ var quarkusIncomingRe = regexp.MustCompile(`@Incoming\s*\(\s*"([^"\n\r]+)"\s*\)`
 // annotations. These typically decorate `Emitter<T>` producer fields.
 var quarkusChannelRe = regexp.MustCompile(`@Channel\s*\(\s*"([^"\n\r]+)"\s*\)`)
 
-// springKafkaListenerRe captures `@KafkaListener(topics = "topic")` and
-// `@KafkaListener(topics = {"a", "b"})`. The topic list is in group 1.
-var springKafkaListenerRe = regexp.MustCompile(`@KafkaListener\s*\(\s*[^)]*?topics\s*=\s*(?:\{([^}]+)\}|"([^"\n\r]+)")`)
+// springKafkaListenerRe captures `@KafkaListener(topics = "topic")`, the Java
+// brace-array form `@KafkaListener(topics = {"a", "b"})`, and the KOTLIN
+// bracket-array form `@KafkaListener(topics = ["a", "b"])`. Kotlin annotation
+// arrays use `[...]` rather than Java's `{...}`, so the notifications service's
+// `@KafkaListener(topics = ["orders.high_value"])` subscriber was previously
+// dropped, severing the stream-processor→notifications high_value link (#1489).
+// The list body (brace OR bracket) is captured into group 1 and parsed by the
+// same comma-split/quote-trim logic; a bare single literal is group 2.
+var springKafkaListenerRe = regexp.MustCompile(`@KafkaListener\s*\(\s*[^)]*?topics\s*=\s*(?:[\{\[]([^}\]]+)[\}\]]|"([^"\n\r]+)")`)
 
 // directKafkaSendRe captures `KafkaTemplate.send("topic", ...)` and
 // `producer.send(new ProducerRecord<>("topic", ...))` style calls.

--- a/internal/engine/kafka_edges_test.go
+++ b/internal/engine/kafka_edges_test.go
@@ -383,6 +383,35 @@ public class OrderConsumer {
 	}
 }
 
+// TestKafka_Kotlin_SpringKafkaListenerBracketArray is the #1489 regression
+// test: Kotlin annotation arrays use `[...]`, not Java's `{...}`. The real
+// fixture's notifications service declares
+// `@KafkaListener(topics = ["orders.high_value"])`; before #1489 the regex
+// only matched braces, so the stream-processor→notifications high_value link
+// was severed even though the synthetic Java brace test passed.
+func TestKafka_Kotlin_SpringKafkaListenerBracketArray(t *testing.T) {
+	src := `package io.shipfast.notifications
+import org.springframework.kafka.annotation.KafkaListener
+
+class Listeners {
+    @KafkaListener(topics = ["orders.placed"], groupId = "notifications")
+    fun onOrderPlaced(payload: String) {}
+
+    @KafkaListener(topics = ["orders.high_value"], groupId = "notifications-vip")
+    fun onHighValue(payload: String) {}
+}
+`
+	ents, rels := runKafkaDetect(t, "kotlin", "Listeners.kt", src)
+	for _, want := range []string{"orders.placed", "orders.high_value"} {
+		if topicByName(ents, want) == nil {
+			t.Errorf("expected MessageTopic for bracket-array topic %q, ents=%v", want, ents)
+		}
+	}
+	if subs := edgesOfKind(rels, subscribesToEdgeKind); len(subs) < 2 {
+		t.Errorf("expected ≥2 SUBSCRIBES_TO edges, got %d; rels=%v", len(subs), rels)
+	}
+}
+
 // TestKafka_Java_TransformDetected covers the @Incoming + @Outgoing on the
 // same method shape — the pass must emit a TRANSFORMS edge between the
 // input topic and the output topic.

--- a/internal/engine/kafka_wrapper_edges.go
+++ b/internal/engine/kafka_wrapper_edges.go
@@ -304,26 +304,79 @@ func synthesizeJavaRedisConvertAndSend(
 
 // javaKafkaStreamBuilderRe captures `builder.stream("topic")` and
 // `streams.builder().stream("topic")` — the source topic read by a topology.
-// Group 1 = topic name.
+// Also matches a CONSTANT identifier arg (`builder.stream(SRC_ORDERS)`),
+// resolved against the file's `static final String` table (#1489).
+// Group 1 = string-literal topic name (may be empty), Group 2 = identifier.
 var javaKafkaStreamBuilderRe = regexp.MustCompile(
-	`\.stream\s*\(\s*"([^"\n\r]+)"`,
+	`\.stream\s*\(\s*(?:"([^"\n\r]+)"|([A-Za-z_][A-Za-z0-9_.]*))`,
 )
 
 // javaKafkaStreamToRe captures `kStream.to("topic")` — the sink topic written
 // by a Kafka Streams topology. Also fires for chained forms like
 // `.filter(...).to("topic")`, `.mapValues(...).to("topic")`, and
-// `.branch(...)[n].to("topic")`. Group 1 = topic name.
+// `.branch(...)[n].to("topic")`. Group 1 = literal, Group 2 = identifier
+// constant arg (`enriched.to(OUT_ENRICHED)`), resolved via the const table.
 var javaKafkaStreamToRe = regexp.MustCompile(
-	`\.to\s*\(\s*"([^"\n\r]+)"`,
+	`\.to\s*\(\s*(?:"([^"\n\r]+)"|([A-Za-z_][A-Za-z0-9_.]*))`,
 )
 
 // javaKafkaStreamThroughRe captures `kStream.through("topic")` — the
 // rerouting operator that both consumes from and produces to an intermediate
 // topic, acting as both source and sink in the topology.
-// Group 1 = topic name.
+// Group 1 = literal, Group 2 = identifier constant arg.
 var javaKafkaStreamThroughRe = regexp.MustCompile(
-	`\.through\s*\(\s*"([^"\n\r]+)"`,
+	`\.through\s*\(\s*(?:"([^"\n\r]+)"|([A-Za-z_][A-Za-z0-9_.]*))`,
 )
+
+// kafkaKotlinStringConstRe captures Kotlin string constants
+// (`const val NAME = "value"` / `val NAME: String = "value"`), which the
+// Java-oriented javaStringConstRe (requires `String` keyword + trailing `;`)
+// does not match. Used alongside javaStringConstRe so Kafka Streams topology
+// calls written with named constants resolve in either language. Group 1 =
+// constant name, Group 2 = string value (#1489).
+var kafkaKotlinStringConstRe = regexp.MustCompile(
+	`(?m)\b(?:const\s+)?val\s+([A-Za-z_][A-Za-z0-9_]*)\s*(?::\s*String)?\s*=\s*"([^"\n\r]+)"`,
+)
+
+// javaStringConstTable builds name→value for Java `static final String NAME =
+// "value";` constants (reusing javaStringConstRe from http_endpoint_java_client.go)
+// plus Kotlin `val`/`const val` constants. Used to resolve constant-arg Kafka
+// Streams topic references such as `enriched.to(OUT_ENRICHED)` (#1489).
+func javaStringConstTable(src string) map[string]string {
+	table := map[string]string{}
+	for _, m := range javaStringConstRe.FindAllStringSubmatch(src, -1) {
+		table[m[1]] = m[2]
+	}
+	for _, m := range kafkaKotlinStringConstRe.FindAllStringSubmatch(src, -1) {
+		if _, ok := table[m[1]]; !ok {
+			table[m[1]] = m[2]
+		}
+	}
+	return table
+}
+
+// resolveJavaTopicArg returns the topic name for a Kafka Streams call match,
+// where group 1 is a string literal and group 2 is an identifier. A bare
+// identifier is resolved against the const table; an unresolved identifier
+// (e.g. a runtime variable) yields "" so the caller skips it. A possibly
+// qualified identifier (`Topics.OUT_ENRICHED`) is resolved on its last
+// segment. Returns ("", false) when nothing usable was captured.
+func resolveJavaTopicArg(lit, ident string, table map[string]string) (string, bool) {
+	if lit != "" {
+		return lit, true
+	}
+	if ident == "" {
+		return "", false
+	}
+	key := ident
+	if i := strings.LastIndexByte(key, '.'); i >= 0 {
+		key = key[i+1:]
+	}
+	if v, ok := table[key]; ok {
+		return v, true
+	}
+	return "", false
+}
 
 func synthesizeJavaKafkaStreams(
 	src string,
@@ -347,10 +400,28 @@ func synthesizeJavaKafkaStreams(
 		caller = "streams"
 	}
 
+	// Resolve named topic constants (`static final String OUT = "x"`) so
+	// constant-arg topology calls like `.to(OUT_ENRICHED)` resolve (#1489).
+	constTable := javaStringConstTable(src)
+
+	// captureTopic pulls the literal (group 1 = idx 2/3) or constant identifier
+	// (group 2 = idx 4/5) from a FindAllStringSubmatchIndex match.
+	captureTopic := func(m []int) (string, bool) {
+		lit := ""
+		if m[2] >= 0 {
+			lit = src[m[2]:m[3]]
+		}
+		ident := ""
+		if m[4] >= 0 {
+			ident = src[m[4]:m[5]]
+		}
+		return resolveJavaTopicArg(lit, ident, constTable)
+	}
+
 	// Source topics: builder.stream("topic") — consumer side.
 	for _, m := range javaKafkaStreamBuilderRe.FindAllStringSubmatchIndex(src, -1) {
-		topic := src[m[2]:m[3]]
-		if !looksLikeKafkaTopic(topic) {
+		topic, ok := captureTopic(m)
+		if !ok || !looksLikeKafkaTopic(topic) {
 			continue
 		}
 		id := kafkaTopicID(topic)
@@ -366,8 +437,8 @@ func synthesizeJavaKafkaStreams(
 	// Also fires for chained DSL forms: .filter(...).to("x"),
 	// .mapValues(...).to("x"), .branch(...)[n].to("x").
 	for _, m := range javaKafkaStreamToRe.FindAllStringSubmatchIndex(src, -1) {
-		topic := src[m[2]:m[3]]
-		if !looksLikeKafkaTopic(topic) {
+		topic, ok := captureTopic(m)
+		if !ok || !looksLikeKafkaTopic(topic) {
 			continue
 		}
 		// Avoid matching Java method calls that happen to look like .to("…")
@@ -401,8 +472,8 @@ func synthesizeJavaKafkaStreams(
 	// back internally). Emit both edges so cross-repo linkers can match either
 	// side of the through-topic connection.
 	for _, m := range javaKafkaStreamThroughRe.FindAllStringSubmatchIndex(src, -1) {
-		topic := src[m[2]:m[3]]
-		if !looksLikeKafkaTopic(topic) {
+		topic, ok := captureTopic(m)
+		if !ok || !looksLikeKafkaTopic(topic) {
 			continue
 		}
 		id := kafkaTopicID(topic)

--- a/internal/engine/kafka_wrapper_edges_test.go
+++ b/internal/engine/kafka_wrapper_edges_test.go
@@ -420,6 +420,91 @@ public class OrderEnrichmentTopology {
 		len(ents), len(subs), len(pubs))
 }
 
+// TestKafkaWrapper_JavaKafkaStreams_ConstantTopicArgs is the #1489 regression
+// test: the REAL polyglot fixture's OrderEnrichmentTopology uses named
+// `static final String` constants for every topic, not inline literals:
+//
+//	public static final String OUT_ENRICHED = "orders.enriched";
+//	builder.stream(SRC_ORDERS, ...); enriched.to(OUT_ENRICHED, ...);
+//
+// Before #1489 the `.stream(...)` / `.to(...)` regexes only matched string
+// literals, so stream-processor emitted ZERO topic entities on the real graph
+// (verified) and the stream-processor→{analytics,search-os,notifications}
+// cross-repo links never fired despite the synthetic literal test passing.
+func TestKafkaWrapper_JavaKafkaStreams_ConstantTopicArgs(t *testing.T) {
+	src := `package io.shipfast.streams;
+import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+
+public class OrderEnrichmentTopology {
+    public static final String SRC_ORDERS = "orders.placed";
+    public static final String SRC_PAYMENTS = "payments.settled";
+    public static final String OUT_ENRICHED = "orders.enriched";
+    public static final String OUT_HIGH_VALUE = "orders.high_value";
+
+    public Topology build() {
+        StreamsBuilder builder = new StreamsBuilder();
+        KStream<String, String> orders = builder.stream(SRC_ORDERS, Consumed.with());
+        KStream<String, String> payments = builder.stream(SRC_PAYMENTS, Consumed.with());
+        KStream<String, String> enriched = orders.join(payments, OrderEnricher::merge);
+        enriched.to(OUT_ENRICHED, Produced.with());
+        enriched.filter((k, v) -> total(v) >= 100000L).to(OUT_HIGH_VALUE, Produced.with());
+        return builder.build();
+    }
+}
+`
+	ents, rels := runWrapperDetect(t, "java",
+		"stream-processor/src/main/java/io/shipfast/streams/OrderEnrichmentTopology.java", src)
+
+	wantIDs := map[string]bool{
+		"kafka:orders.placed":     false,
+		"kafka:payments.settled":  false,
+		"kafka:orders.enriched":   false,
+		"kafka:orders.high_value": false,
+	}
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			if _, ok := wantIDs[e.Name]; ok {
+				wantIDs[e.Name] = true
+			}
+		}
+	}
+	for id, seen := range wantIDs {
+		if !seen {
+			t.Errorf("constant-arg topology: MessageTopic %q not emitted; ents=%v", id, ents)
+		}
+	}
+
+	if subs := edgesOfKind(rels, subscribesToEdgeKind); len(subs) < 2 {
+		t.Errorf("expected ≥2 SUBSCRIBES_TO (constant source topics), got %d", len(subs))
+	}
+	if pubs := edgesOfKind(rels, publishesToEdgeKind); len(pubs) < 2 {
+		t.Errorf("expected ≥2 PUBLISHES_TO (constant sink topics), got %d", len(pubs))
+	}
+}
+
+// TestKafkaWrapper_JavaKafkaStreams_UnresolvedConstantSkipped verifies that a
+// `.to(SOME_VAR)` whose identifier is NOT a known string constant is skipped
+// rather than emitting a topic named after the variable.
+func TestKafkaWrapper_JavaKafkaStreams_UnresolvedConstantSkipped(t *testing.T) {
+	src := `package io.demo;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.KafkaStreams;
+public class T {
+    void build(KStream<String,String> enriched, String runtimeTopic) {
+        enriched.to(runtimeTopic);
+    }
+}
+`
+	ents, _ := runWrapperDetect(t, "java", "demo/T.java", src)
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			t.Errorf("unresolved identifier should emit no topic, got %q", e.Name)
+		}
+	}
+}
+
 // TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava verifies
 // that .through() on a plain Java non-Streams file does not emit any topic.
 func TestKafkaWrapper_JavaKafkaStreams_ThroughTopicNoFireOnPlainJava(t *testing.T) {

--- a/internal/engine/redis_pubsub_edges.go
+++ b/internal/engine/redis_pubsub_edges.go
@@ -80,7 +80,7 @@ const redisPubSubChannelEntityKind = "SCOPE.Queue"
 // can emit synthetics for `lang`.
 func redisPubSubSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "python", "javascript", "typescript", "go", "ruby", "java", "kotlin":
+	case "python", "javascript", "typescript", "go", "ruby", "java", "kotlin", "elixir":
 		return true
 	default:
 		return false
@@ -115,7 +115,10 @@ func applyRedisPubSubEdges(
 	srcLower := strings.ToLower(src)
 	hasPublish := strings.Contains(srcLower, "publish")
 	hasSubscribe := strings.Contains(srcLower, "subscribe") // covers subscribe, psubscribe, PSubscribe, Subscribe
-	hasRedis := strings.Contains(srcLower, "redis")
+	// "redis" matches the client/import; "redix" is the Elixir client lib
+	// (Redix / Redix.PubSub) — note "redix" does NOT contain "redis", so it
+	// must be checked explicitly or Elixir files would be filtered out (#1489).
+	hasRedis := strings.Contains(srcLower, "redis") || strings.Contains(srcLower, "redix")
 	// A publish or subscribe call is only a pub/sub signal when the file also
 	// references redis — UNLESS the call is PSubscribe/psubscribe which is
 	// Redis-specific and can appear without an explicit "redis" import when
@@ -208,6 +211,8 @@ func applyRedisPubSubEdges(
 		synthesizeRubyRedisPubSub(src, emitChannel, emitEdge)
 	case "java", "kotlin":
 		synthesizeSpringRedisPubSub(src, emitChannel, emitEdge)
+	case "elixir":
+		synthesizeElixirRedisPubSub(src, emitChannel, emitEdge)
 	}
 
 	return entities, relationships
@@ -846,6 +851,108 @@ func synthesizeSpringRedisPubSub(
 			"messaging_layer": "spring-data-redis",
 			"channel_type":    "pubsub",
 			"is_pattern":      "true",
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Elixir — Redix.PubSub (#1489)
+// ---------------------------------------------------------------------------
+//
+// The real polyglot fixture's realtime-dashboard (Phoenix/Elixir) consumes the
+// `notifications.push` Redis channel via:
+//
+//	@redis_channel "notifications.push"
+//	{:ok, pubsub} = Redix.PubSub.start_link(...)
+//	{:ok, _ref} = Redix.PubSub.subscribe(pubsub, @redis_channel, self())
+//
+// and may also publish via Redix.command(conn, ["PUBLISH", "chan", msg]).
+// Before #1489 Elixir was unsupported, so realtime-dashboard emitted no
+// SCOPE.Queue entity and never paired with the Kotlin notifications publisher.
+// This synthesizer resolves module-attribute channel constants
+// (`@name "value"`) and string literals on Redix.PubSub.subscribe /
+// .psubscribe and Redix PUBLISH commands, emitting the SAME canonical
+// `channel:redis-pubsub:<name>` SCOPE.Queue ID so P7 joins it cross-repo.
+
+// Note: module-attribute constants (`@name "value"`) are parsed with
+// elixirModuleAttrRe, defined in http_endpoint_jsts_client_1483.go.
+
+// elixirRedixSubscribeRe captures Redix.PubSub.subscribe / .psubscribe with a
+// string-literal or @module-attribute channel argument (after the pubsub conn
+// arg). Group 1 = "" or method suffix, Group 2 = literal, Group 3 = @attr.
+var elixirRedixSubscribeRe = regexp.MustCompile(
+	`Redix\.PubSub\.(p?subscribe)\s*\(\s*[^,]+,\s*(?:"([^"\n\r]+)"|@([a-z_][a-zA-Z0-9_]*))`,
+)
+
+// elixirRedixPublishRe captures Redix.command/Redix.noreply_command with a
+// PUBLISH verb: `Redix.command(conn, ["PUBLISH", "chan", msg])` where the
+// channel is a literal (group 1) or @attr (group 2).
+var elixirRedixPublishRe = regexp.MustCompile(
+	`(?i)Redix\.[a-z_]*command[a-z_!]*\s*\([^,]+,\s*\[\s*"PUBLISH"\s*,\s*(?:"([^"\n\r]+)"|@([a-z_][a-zA-Z0-9_]*))`,
+)
+
+// elixirModuleNameRe captures the enclosing `defmodule Foo.Bar do` so subscribe
+// edges carry a stable per-file caller name.
+var elixirModuleNameRe = regexp.MustCompile(`defmodule\s+([A-Za-z0-9_.]+)\s+do`)
+
+func synthesizeElixirRedisPubSub(
+	src string,
+	emitChannel func(channelID, channelName, channelType string, isWildcard bool, props map[string]string),
+	emitEdge func(callerKind, callerName, channelID, edgeKind string, props map[string]string),
+) {
+	if !strings.Contains(src, "Redix") {
+		return
+	}
+
+	// Build the module-attribute constant table (@redis_channel "x").
+	attrs := map[string]string{}
+	for _, m := range elixirModuleAttrRe.FindAllStringSubmatch(src, -1) {
+		attrs[m[1]] = m[2]
+	}
+
+	caller := "module"
+	if m := elixirModuleNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		caller = m[1]
+	}
+
+	resolve := func(lit, attr string) (string, bool) {
+		if lit != "" {
+			return lit, true
+		}
+		if attr == "" {
+			return "", false
+		}
+		v, ok := attrs[attr]
+		return v, ok
+	}
+
+	// Subscribers: Redix.PubSub.subscribe / psubscribe.
+	for _, m := range elixirRedixSubscribeRe.FindAllStringSubmatch(src, -1) {
+		isPattern := m[1] == "psubscribe"
+		ch, ok := resolve(m[2], m[3])
+		if !ok || !looksLikeRedisChannel(ch) {
+			continue
+		}
+		id := redisPubSubChannelID(ch)
+		emitChannel(id, ch, "pubsub", isPattern, map[string]string{"messaging_layer": "redix"})
+		emitEdge("Service", caller, id, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "redix",
+			"channel_type":    "pubsub",
+			"is_pattern":      boolStr(isPattern),
+		})
+	}
+
+	// Publishers: Redix.command(conn, ["PUBLISH", chan, msg]).
+	for _, m := range elixirRedixPublishRe.FindAllStringSubmatch(src, -1) {
+		ch, ok := resolve(m[1], m[2])
+		if !ok || !looksLikeRedisChannel(ch) {
+			continue
+		}
+		id := redisPubSubChannelID(ch)
+		emitChannel(id, ch, "pubsub", false, map[string]string{"messaging_layer": "redix"})
+		emitEdge("Service", caller, id, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "redix",
+			"channel_type":    "pubsub",
 		})
 	}
 }

--- a/internal/engine/redis_pubsub_edges_test.go
+++ b/internal/engine/redis_pubsub_edges_test.go
@@ -826,3 +826,45 @@ class CacheService(private val redisTemplate: RedisTemplate<String, String>) {
 		}
 	}
 }
+
+// TestRedisPubSub_ElixirRedixSubscribe is the #1489 regression test: the real
+// polyglot fixture's realtime-dashboard (Elixir) consumes notifications.push
+// via Redix.PubSub with the channel held in a @module attribute. Before #1489
+// Elixir was unsupported, so realtime-dashboard emitted no SCOPE.Queue entity
+// and never paired with the Kotlin notifications publisher.
+func TestRedisPubSub_ElixirRedixSubscribe(t *testing.T) {
+	src := `defmodule RealtimeDashboard.NotificationsSubscriber do
+  use GenServer
+  @redis_channel "notifications.push"
+
+  def init(_state) do
+    {:ok, pubsub} = Redix.PubSub.start_link(host: "redis", port: 6379)
+    {:ok, _ref} = Redix.PubSub.subscribe(pubsub, @redis_channel, self())
+    {:ok, %{pubsub: pubsub}}
+  end
+end
+`
+	ents, rels := runRedisPubSub(t, "elixir", src)
+	want := "channel:redis-pubsub:notifications.push"
+	if !hasEntity(ents, want) {
+		t.Fatalf("expected SCOPE.Queue %q (canonical cross-repo ID), ents=%v", want, ents)
+	}
+	if !hasRel(rels, "SUBSCRIBES_TO|Service:RealtimeDashboard.NotificationsSubscriber|SCOPE.Queue:"+want) {
+		t.Fatalf("expected SUBSCRIBES_TO edge to %q, rels=%v", want, rels)
+	}
+}
+
+// TestRedisPubSub_ElixirRedixSubscribeLiteral covers the inline string-literal
+// form (no module attribute).
+func TestRedisPubSub_ElixirRedixSubscribeLiteral(t *testing.T) {
+	src := `defmodule Foo do
+  def go(pubsub) do
+    Redix.PubSub.subscribe(pubsub, "tracking.location", self())
+  end
+end
+`
+	ents, _ := runRedisPubSub(t, "elixir", src)
+	if !hasEntity(ents, "channel:redis-pubsub:tracking.location") {
+		t.Fatalf("expected literal-channel SCOPE.Queue, ents=%v", ents)
+	}
+}

--- a/internal/links/topic_pass.go
+++ b/internal/links/topic_pass.go
@@ -49,8 +49,29 @@ const MethodTopic = "topic"
 // More precise than RelationCalls for message-bus flows.
 const RelationPublishesTo = "publishes_to"
 
-// topicMessageTopicKind is the entity kind emitted by broker engine passes.
+// topicMessageTopicKind is the entity kind emitted by the Kafka/SNS/SQS/
+// EventBridge engine passes.
 const topicMessageTopicKind = "SCOPE.MessageTopic"
+
+// topicQueueKind is the entity kind emitted by the Redis pub/sub + Streams
+// engine pass (redis_pubsub_edges.go). These carry a broker-prefixed Name
+// (`channel:redis-pubsub:<name>` / `stream:redis:<name>`) plus PUBLISHES_TO /
+// SUBSCRIBES_TO edges, exactly like SCOPE.MessageTopic, but use a distinct
+// kind. Before #1489 P7 ignored them entirely, so a Redis publisher and
+// subscriber in different repos sharing an identical channel Name were never
+// paired — the real polyglot fixture's
+// notifications→{tracking-ws,realtime-dashboard}
+// `channel:redis-pubsub:notifications.push` links silently dropped. P7 now
+// treats SCOPE.Queue identically: the canonical Name already matches across
+// repos, so it joins on Name with no new matching logic (#1489).
+const topicQueueKind = "SCOPE.Queue"
+
+// isTopicEntityKind reports whether a graph entity participates in the P7
+// publisher↔subscriber join. Both the broker MessageTopic synthetics and the
+// Redis pub/sub Queue synthetics qualify (#1489).
+func isTopicEntityKind(kind string) bool {
+	return kind == topicMessageTopicKind || kind == topicQueueKind
+}
 
 // topicEmissionCapPerName bounds the number of cross-repo edges a single
 // topic Name may emit. #1454 already collapsed the per-repo-pair entity
@@ -102,6 +123,21 @@ func brokerFromTopicName(name string) string {
 			return rest[:i] // "eventbridge", "eventgrid", "cloudevents"
 		}
 		return "event"
+	}
+	// Redis pub/sub queue synthetics: "channel:redis-pubsub:<name>" and Redis
+	// Streams "stream:redis:<name>". The second segment carries the transport
+	// (redis-pubsub / redis); normalise both to the "redis" channel so emitted
+	// links read consistently with the rest of the topic pass (#1489).
+	if strings.HasPrefix(name, "channel:") || strings.HasPrefix(name, "stream:") {
+		rest := name[strings.IndexByte(name, ':')+1:]
+		if i := strings.IndexByte(rest, ':'); i > 0 {
+			transport := rest[:i]
+			if strings.HasPrefix(transport, "redis") {
+				return "redis"
+			}
+			return transport
+		}
+		return "redis"
 	}
 	// Simple "broker:..." form (kafka, sns, sqs, redis, nats, pubsub, etc.).
 	if i := strings.IndexByte(name, ':'); i > 0 {
@@ -164,7 +200,7 @@ func runTopicPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pas
 	for _, g := range graphs {
 		inbound := inboundByRepo[g.Repo]
 		for _, e := range g.Entities {
-			if e.Kind != topicMessageTopicKind {
+			if !isTopicEntityKind(e.Kind) {
 				continue
 			}
 			if e.Name == "" {

--- a/internal/links/topic_pass_test.go
+++ b/internal/links/topic_pass_test.go
@@ -460,3 +460,66 @@ func TestTopicPass_TwoDistinctTopicsSameRepoPair(t *testing.T) {
 		t.Errorf("link IDs must be distinct per topic; both got %s", topicLinks[0].ID)
 	}
 }
+
+// TestTopicPass_RedisPubSubQueueJoin is the #1489 regression test: the Redis
+// pub/sub engine pass emits SCOPE.Queue entities (Name
+// `channel:redis-pubsub:<name>`), NOT SCOPE.MessageTopic. Before #1489 P7
+// only scanned SCOPE.MessageTopic, so a redis publisher and subscriber in
+// different repos sharing the identical channel Name were never paired. This
+// mirrors the real fixture: notifications (Kotlin) publishes
+// notifications.push; tracking-ws (Node) and realtime-dashboard (Elixir)
+// subscribe.
+func TestTopicPass_RedisPubSubQueueJoin(t *testing.T) {
+	root := fixtureRoot(t)
+
+	q := func(repo, entID, opName, file, edge string) {
+		writeFixture(t, root, fixtureGraph{
+			Repo: repo,
+			Entities: []map[string]any{
+				{"id": opName, "name": opName, "kind": "SCOPE.Operation", "source_file": file},
+				{
+					"id": entID, "name": "channel:redis-pubsub:notifications.push",
+					"kind": "SCOPE.Queue", "source_file": "",
+					"properties": map[string]any{"broker": "redis", "channel_type": "pubsub"},
+				},
+			},
+			Edges: []map[string]string{
+				{"from_id": opName, "to_id": entID, "kind": edge},
+			},
+		})
+	}
+	q("notifications", "q_pub", "publishPush", "Listeners.kt", "PUBLISHES_TO")
+	q("tracking-ws", "q_sub1", "module", "index.ts", "SUBSCRIBES_TO")
+	q("realtime-dashboard", "q_sub2", "Subscriber", "subscriber.ex", "SUBSCRIBES_TO")
+
+	home := filepath.Join(root, "ag-home-redisq")
+	if _, err := RunAllPasses("tgredis", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "tgredis-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	targets := map[string]bool{}
+	for _, l := range doc.Links {
+		if l.Method != MethodTopic {
+			continue
+		}
+		// P7 links from the publisher OPERATION (edge from_id), not the queue
+		// entity id.
+		if l.Source != "notifications::publishPush" {
+			t.Errorf("source: want notifications::publishPush, got %s", l.Source)
+		}
+		if l.Channel == nil || *l.Channel != "redis" {
+			t.Errorf("channel: want redis, got %v", l.Channel)
+		}
+		targets[l.Target] = true
+	}
+	if !targets["tracking-ws::module"] {
+		t.Error("expected notifications→tracking-ws redis link")
+	}
+	if !targets["realtime-dashboard::Subscriber"] {
+		t.Error("expected notifications→realtime-dashboard redis link")
+	}
+}


### PR DESCRIPTION
## 1. What & why
Prior topic-recall fixes (#1484/#1486) passed synthetic unit tests but fired **zero** new links on the real fixture. This PR fixes three defects found by measuring against the REAL fixture `/polyglot-platform` with the `xrepo-verify` harness. Cross-repo topic links rise **8 → 16** (ticket target: ~13).

`Fixes #1489`

## 2. Root causes (real fixture, not synthetic)
1. **Kafka Streams constant args** — `services/stream-processor` (Java) declares `public static final String OUT_ENRICHED = "orders.enriched"` then calls `enriched.to(OUT_ENRICHED)` / `builder.stream(SRC_ORDERS)`. The `.stream`/`.to`/`.through` regexes only matched string **literals**, so stream-processor emitted **zero** topic entities on the real graph (dumped + verified) and the producer side of `orders.enriched`/`orders.high_value` never existed.
2. **P7 ignored Redis pub/sub** — `redis_pubsub_edges.go` emits `SCOPE.Queue` (`channel:redis-pubsub:<name>`), but P7 (`topic_pass.go`) only scanned `SCOPE.MessageTopic`. Both sides emitted the identical channel Name yet were never paired.
3. **Elixir unsupported + Kotlin annotation arrays** — `realtime-dashboard` (Elixir `Redix.PubSub`) emitted nothing; `notifications`' Kotlin `@KafkaListener(topics = ["orders.high_value"])` uses `[...]` arrays (regex only matched Java `{...}`), severing two more links.

## 3. Solution
- `internal/engine/kafka_wrapper_edges.go`: per-file `static final String` (Java) + `val`/`const val` (Kotlin) constant table; resolve constant-identifier args in Kafka Streams `.stream`/`.to`/`.through`.
- `internal/links/topic_pass.go`: P7 joins `SCOPE.Queue` (redis pub/sub) alongside `SCOPE.MessageTopic`; `brokerFromTopicName` maps `channel:`/`stream:` → `redis`.
- `internal/engine/redis_pubsub_edges.go`: Elixir `Redix.PubSub` subscribe/publish extraction (module-attribute + literal channels) emitting the canonical `channel:redis-pubsub:<name>` ID; pre-filter widened to accept the `redix` token.
- `internal/engine/kafka_edges.go`: `@KafkaListener` regex accepts Kotlin `[...]` arrays.

## 4. Verification (REAL fixture)
`archigraph xrepo-verify polyglot <all services>` on `/polyglot-platform`:

| | before | after |
|---|---|---|
| topic links | **8** | **16** |

New edges resolved:
- `stream-processor → analytics`, `stream-processor → search-os` (orders.enriched)
- `stream-processor → notifications` (orders.high_value)
- `orders → stream-processor`, `payments → stream-processor` (constant source topics)
- `orders → notifications` (Kotlin bracket-array listener)
- `notifications → tracking-ws`, `notifications → realtime-dashboard` (redis pub/sub)

All MANIFEST §3 cross-repo topic edges now link. No regression in other methods (http 18, grpc 1 unchanged; import/label unaffected).

## 5. Tests
Added regression tests built from the **exact real-fixture idioms** (not synthetic literals): constant-arg topology, unresolved-identifier skip, Elixir `Redix.PubSub`, Kotlin bracket-array `@KafkaListener`, and P7 `SCOPE.Queue` cross-repo join. `go test ./internal/engine/ ./internal/links/` passes; `go vet` clean.

## 6. Risk & rollback
Engine passes are append-only (cannot remove existing entities/edges); P7 changes only widen the entity-kind scan and add a broker mapping. Did NOT touch the live daemon (:47274). Revert = drop this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)