### PR TITLE
fix(engine+links): close client xrepo links on the REAL polyglot fixture (Fixes #1496)

### DIFF
--- a/internal/engine/http_endpoint_jsts_client_1483.go
+++ b/internal/engine/http_endpoint_jsts_client_1483.go
@@ -260,6 +260,27 @@ var elixirModuleAttrRe = regexp.MustCompile(
 	`(?m)@([a-z_][a-z0-9_]*)\s+"([^"\n\r]+)"`,
 )
 
+// elixirModuleAttrEnvRe matches a module attribute whose value is a
+// `System.get_env/2` call carrying a static default literal, e.g.
+//
+//	@base_url System.get_env("GATEWAY_URL", "http://gateway:3000")
+//
+// This is the idiomatic Elixir config pattern (#1496): the base URL is
+// resolved from an env var at boot with a hard-coded fallback. The fallback
+// literal is the only statically-knowable value, so we register it as the
+// attribute's symbol-table value — exactly mirroring how the JS/TS side
+// treats `process.env.X || "literal"`. Without this the `#{@base_url}`
+// interpolation never resolves and the canonical path keeps a bogus
+// `{@base_url}` segment, so the cross-repo link can never form.
+//
+// Capture groups:
+//
+//	1 = attribute name (without @)
+//	2 = default string literal (2nd arg to System.get_env)
+var elixirModuleAttrEnvRe = regexp.MustCompile(
+	`(?m)@([a-z_][a-z0-9_]*)\s+System\.get_env\(\s*"[^"\n\r]*"\s*,\s*"([^"\n\r]+)"\s*\)`,
+)
+
 // elixirInterpolationRe matches `#{expr}` inside Elixir string interpolations.
 var elixirInterpolationRe = regexp.MustCompile(`#\{([^}]+)\}`)
 
@@ -269,6 +290,17 @@ func buildElixirSymbolTable(content string) map[string]string {
 	syms := make(map[string]string)
 	// Module attributes: @base_url "http://gateway:4000"
 	for _, m := range elixirModuleAttrRe.FindAllStringSubmatch(content, -1) {
+		if len(m) >= 3 {
+			key := "@" + m[1]
+			if _, dup := syms[key]; !dup {
+				syms[key] = m[2]
+			}
+		}
+	}
+	// #1496 — Module attributes resolved from System.get_env/2 with a static
+	// default: @base_url System.get_env("GATEWAY_URL", "http://gateway:3000").
+	// The fallback literal is the statically-knowable value.
+	for _, m := range elixirModuleAttrEnvRe.FindAllStringSubmatch(content, -1) {
 		if len(m) >= 3 {
 			key := "@" + m[1]
 			if _, dup := syms[key]; !dup {

--- a/internal/engine/http_endpoint_jsts_client_1483_test.go
+++ b/internal/engine/http_endpoint_jsts_client_1483_test.go
@@ -6,6 +6,71 @@ import (
 	"testing"
 )
 
+// TestSynth_ProducerConsumerSameFile_BothSurvive covers the #1496 dedup bug.
+// A NestJS gateway can both SERVE a route (@Controller("orders") @Post()) and
+// CALL the same logical path on a downstream service (axios `orders.post(
+// "/orders")`). Both are the canonical id `http:POST:/orders`, so the old
+// side-agnostic dedup collapsed them into a single producer synthetic and the
+// consumer call vanished — leaving the gateway→orders cross-repo link
+// permanently unformed. The dedup is now side-scoped: a producer
+// (http_endpoint_synthesis) and a consumer (http_endpoint_client_synthesis)
+// for the same (verb, path) must both survive.
+func TestSynth_ProducerConsumerSameFile_BothSurvive(t *testing.T) {
+	src := `import { Controller, Get, Post, Param, Body } from "@nestjs/common";
+import { serviceClient } from "@shipfast/js-shared";
+
+const orders = serviceClient(process.env.ORDERS_URL || "http://orders:8000");
+
+@Controller("orders")
+export class OrdersProxyController {
+  @Post()
+  async create(@Body() body: any) {
+    const { data } = await orders.post("/orders", body);
+    return data;
+  }
+
+  @Get(":id")
+  async get(@Param("id") id: string) {
+    const { data } = await orders.get(` + "`/orders/${id}`" + `);
+    return data;
+  }
+}
+`
+	_, res := runDetect(t, "typescript", "orders.controller.ts", src)
+
+	type pp struct{ verb, path, side string }
+	var seen []pp
+	for _, e := range res.Entities {
+		if e.Kind != httpEndpointDefinitionKind && e.Kind != httpEndpointCallKind {
+			continue
+		}
+		seen = append(seen, pp{
+			verb: e.Properties["verb"],
+			path: e.Properties["path"],
+			side: e.Properties["pattern_type"],
+		})
+	}
+
+	want := []pp{
+		{"POST", "/orders", "http_endpoint_synthesis"},        // producer: @Controller("orders") @Post()
+		{"POST", "/orders", "http_endpoint_client_synthesis"}, // consumer: orders.post("/orders")
+		{"GET", "/orders/{id}", "http_endpoint_synthesis"},        // producer: @Get(":id")
+		{"GET", "/orders/{id}", "http_endpoint_client_synthesis"}, // consumer: orders.get(`/orders/${id}`)
+	}
+	for _, w := range want {
+		found := false
+		for _, s := range seen {
+			if s == w {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("missing %s synthetic for %s %s (got: %+v)", w.side, w.verb, w.path, seen)
+		}
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Idiom 1 — NestJS HttpService (RxJS)
 // ---------------------------------------------------------------------------
@@ -245,6 +310,41 @@ end
 		"http:GET:/orders",
 	}
 	requireContains(t, got, want, "elixir-finch-interpolated")
+}
+
+// TestSynth_ElixirFinch_SystemGetEnvBaseURL covers the #1496 real-fixture
+// pattern where the @base_url module attribute is resolved from
+// System.get_env/2 with a static default rather than a bare string literal:
+//
+//	@base_url System.get_env("GATEWAY_URL", "http://gateway:3000")
+//	url = "#{@base_url}/orders/#{order_id}"
+//	Finch.build(:get, url)
+//
+// Before the fix the symbol table never resolved @base_url, so the canonical
+// path kept a bogus `/{@base_url}/orders/{order_id}` segment and the
+// realtime-dashboard→gateway cross-repo link could never form.
+func TestSynth_ElixirFinch_SystemGetEnvBaseURL(t *testing.T) {
+	src := `
+defmodule RealtimeDashboard.GatewayClient do
+  @base_url System.get_env("GATEWAY_URL", "http://gateway:3000")
+
+  def get_order(order_id) do
+    url = "#{@base_url}/orders/#{order_id}"
+    Finch.build(:get, url, [])
+    |> Finch.request(RealtimeDashboard.Finch)
+  end
+end
+`
+	got, _ := runDetect(t, "elixir", "gateway_client.ex", src)
+	want := []string{
+		"http:GET:/orders/{order_id}",
+	}
+	requireContains(t, got, want, "elixir-finch-system-getenv-baseurl")
+	for _, id := range got {
+		if id == "http:GET:/{@base_url}/orders/{order_id}" {
+			t.Errorf("regression: @base_url not resolved, emitted bogus path %q", id)
+		}
+	}
 }
 
 // TestSynth_ElixirHTTPoison_Static covers `HTTPoison.get("url")` and

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -140,10 +140,20 @@ func applyHTTPEndpointSynthesis(
 				return
 			}
 			id := httproutes.SyntheticID(method, canonicalPath)
-			if seen[id] {
+			// #1496 — dedup is SIDE-scoped. A producer-side definition and a
+			// consumer-side call for the same (verb, path) are legitimately
+			// distinct entities and must both survive: a gateway that SERVES
+			// `POST /orders` (NestJS @Controller) while also CALLING a
+			// downstream `POST /orders` (axios proxy) needs both synthetics or
+			// the cross-repo consumer edge can never form. The dedup still
+			// collapses same-side duplicates (e.g. AST-composed Route + YAML
+			// regex both claiming the same producer endpoint) because those
+			// share both the path-ID and the patternType.
+			dedupKey := patternType + "\x00" + id
+			if seen[dedupKey] {
 				return
 			}
-			seen[id] = true
+			seen[dedupKey] = true
 
 			props := map[string]string{
 				"verb":         strings.ToUpper(method),
@@ -209,7 +219,10 @@ func applyHTTPEndpointSynthesis(
 				return
 			}
 			id := httproutes.SyntheticID(method, canonicalPath)
-			alreadySeen := seen[id]
+			// #1496 — mirror the side-scoped dedup key emitClient uses, so the
+			// "did emitClient actually append a new entity?" check below is
+			// correct (it stamps caller_file / url_kind on the appended entity).
+			alreadySeen := seen["http_endpoint_client_synthesis\x00"+id]
 			emitClient(method, canonicalPath, framework, refKind, refName)
 			// Stamp runtime_dynamic on the newly emitted entity if this
 			// is the first time we see this ID and the URL was derived

--- a/internal/links/http_pass.go
+++ b/internal/links/http_pass.go
@@ -384,6 +384,21 @@ func runHTTPPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pass
 				if genericKey, ok := stripAPIPrefix(key); ok {
 					byPath[genericKey] = append(byPath[genericKey], h)
 				}
+
+				// #1496 — GraphQL root aliasing. A GraphQL service exposes one
+				// HTTP endpoint (conventionally `POST /graphql`) that multiplexes
+				// every field resolver. The producer side emits per-field
+				// synthetics with paths like `/graphql/Query/searchProducts`
+				// (verb=GRAPHQL), while a client (Apollo `new ApolloClient({uri:
+				// ".../graphql"})`) only knows the transport root `/graphql`.
+				// Register every GraphQL field-level producer ALSO under the
+				// `/graphql` root so a client pointing at the root matches the
+				// service. We key off the `/graphql/` path prefix (not framework)
+				// so any GraphQL extractor benefits, and only register producer
+				// hits to avoid a consumer-root entry shadowing the producer.
+				if h.side == sideProducer && strings.HasPrefix(key, "/graphql/") {
+					byPath["/graphql"] = append(byPath["/graphql"], h)
+				}
 			}
 		}
 	}

--- a/internal/links/http_pass_test.go
+++ b/internal/links/http_pass_test.go
@@ -3,6 +3,7 @@ package links
 import (
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 )
 
@@ -407,6 +408,87 @@ func TestHTTPPass_GenericPrefixMatch(t *testing.T) {
 	if !found {
 		t.Errorf("expected cross-repo link for /api/v1 prefix mismatch w/o url_prefix; got %+v", doc.Links)
 	}
+}
+
+// TestHTTPPass_GraphQLRootMatch verifies the #1496 fix: an Apollo client that
+// only knows the GraphQL transport root (`new ApolloClient({uri: ".../graphql"})`
+// → consumer synthetic `http:GRAPHQL:/graphql`) links to a GraphQL service whose
+// producer synthetics are emitted per resolver field
+// (`http:GRAPHQL:/graphql/Query/searchProducts`). All GraphQL operations are
+// multiplexed over the one `/graphql` HTTP endpoint, so the field-level
+// producers are aliased under the `/graphql` root in the byPath index.
+func TestHTTPPass_GraphQLRootMatch(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "search-graphql",
+		Entities: []map[string]any{
+			{
+				"id": "ep1", "name": "http:GRAPHQL:/graphql/Query/searchProducts", "kind": "http_endpoint",
+				"source_file": "src/resolvers.ts",
+				"properties": map[string]any{
+					"verb":         "GRAPHQL",
+					"path":         "/graphql/Query/searchProducts",
+					"framework":    "graphql",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+			{
+				"id": "ep2", "name": "http:GRAPHQL:/graphql/Query/order", "kind": "http_endpoint",
+				"source_file": "src/resolvers.ts",
+				"properties": map[string]any{
+					"verb":         "GRAPHQL",
+					"path":         "/graphql/Query/order",
+					"framework":    "graphql",
+					"pattern_type": "http_endpoint_synthesis",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "admin",
+		Entities: []map[string]any{
+			{"id": "fn1", "name": "queries", "kind": "Function", "source_file": "src/queries.ts"},
+			{
+				"id": "ep3", "name": "http:GRAPHQL:/graphql", "kind": "http_endpoint",
+				"source_file": "src/queries.ts",
+				"properties": map[string]any{
+					"verb":          "GRAPHQL",
+					"path":          "/graphql",
+					"framework":     "apollo_client_uri",
+					"pattern_type":  "http_endpoint_client_synthesis",
+					"source_caller": "Function:queries",
+				},
+			},
+		},
+		Edges: []map[string]string{},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g-graphql-root", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g-graphql-root-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	var found bool
+	for _, l := range doc.Links {
+		if l.Method == MethodHTTP && repoOfLink(l.Source) == "admin" && repoOfLink(l.Target) == "search-graphql" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected admin→search-graphql GraphQL-root cross-repo link; got %+v", doc.Links)
+	}
+}
+
+// repoOfLink extracts the repo prefix of a "repo::entityID" endpoint key.
+func repoOfLink(endpoint string) string {
+	if i := strings.Index(endpoint, "::"); i >= 0 {
+		return endpoint[:i]
+	}
+	return endpoint
 }
 
 // TestHTTPPass_PkVsParamMatch verifies that Django {pk} on the producer side


### PR DESCRIPTION
## 1. Problem

#1488 added consumer-side extraction for NestJS HttpService, Elixir Finch/HTTPoison, and Apollo Client URIs, but on the **real** `polyglot-platform` fixture the three target cross-repo links never closed — same class as billing #1490. The consumer synthetics emitted, yet no `method=http` xrepo edge formed.

`xrepo-verify --diagnose shipfast` (full fixture) before this PR:
- `gateway→orders` : **0** (acceptance: required)
- `realtime-dashboard→gateway` : **0** (required)
- `admin→search-graphql` : **0** (required)
- Total HTTP cross-repo links: **28**

## 2. Root cause

Three independent bugs, one per edge — all confirmed by dumping the synthetics + orphan paths on the real graph:

1. **gateway→orders** — `services/gateway/src/orders.controller.ts` both SERVES `POST /orders` (`@Controller("orders")` + `@Post()`) and CALLS `POST /orders` downstream (`orders.post("/orders")` via the `serviceClient()` axios factory). The synthesis dedup in `http_endpoint_synthesis.go` keyed only on `httproutes.SyntheticID(verb, path)`, shared between the producer `emit` and consumer `emitClient` closures. The producer claimed the ID first, so the consumer call was silently dropped — `orphan consumer calls` showed `gateway` emitting calls to other services but never to `/orders`.

2. **realtime-dashboard→gateway** — `gateway_client.ex` declares `@base_url System.get_env("GATEWAY_URL", "http://gateway:3000")`. The Elixir symbol table only recognised `@attr "literal"`, so `@base_url` never resolved and the canonical path came out as the bogus `/{@base_url}/orders/{order_id}` (NO_PATH_MATCH), never matching gateway's `GET /orders/{id}` producer.

3. **admin→search-graphql** — `frontend/admin/src/queries.ts` uses `new ApolloClient({uri})`, emitting a single consumer synthetic `GRAPHQL /graphql` (the transport root). The producer side emits per-resolver-field synthetics `GRAPHQL /graphql/Query/<field>`. The byPath index had no `/graphql` bucket, so the root-only client found no producer (NO_PATH_MATCH).

## 3. Fix

1. **Side-scoped dedup** (`internal/engine/http_endpoint_synthesis.go`): the dedup key is now `patternType + "\x00" + id`, so a producer definition and a consumer call for the same `(verb, path)` both survive. Same-side duplicates (AST-composed Route + YAML regex) still collapse because they share both the path-ID and patternType. The `makeRuntimeEmit` `alreadySeen` check was updated to mirror the consumer-side key so `caller_file`/`url_kind` stamping stays correct.

2. **Elixir `System.get_env/2` base URL** (`internal/engine/http_endpoint_jsts_client_1483.go`): added `elixirModuleAttrEnvRe` + a second pass in `buildElixirSymbolTable` that registers the static default literal (2nd arg of `System.get_env`) as the attribute's value — mirroring how the JS/TS side already treats `process.env.X || "literal"`.

3. **GraphQL root aliasing** (`internal/links/http_pass.go`): in the byPath index build, every **producer** hit whose normalised path begins `/graphql/` is also registered under the `/graphql` root. A GraphQL service multiplexes all field resolvers over the one HTTP endpoint, so a client pointing at the transport root legitimately reaches it. Keyed off the `/graphql/` path prefix (not framework) so any GraphQL extractor benefits.

## 4. Verification (REAL fixture)

`archigraph xrepo-verify shipfast <all 29 polyglot-platform repos>` — before → after:

| edge | before | after |
|---|---|---|
| gateway→orders | 0 | **2** |
| realtime-dashboard→gateway | 0 | **1** |
| admin→search-graphql | 0 | **1** |
| total HTTP xrepo links | 28 | **34** |

No baseline links were removed (pure +6). The extra links beyond the three required (`realtime-dashboard→orders`, `admin→catalog`) are legitimate: both orders and gateway expose `GET /orders/{*}`, and both catalog and search-graphql are real Apollo GraphQL services, so the root-only clients genuinely reach them.

Unit tests added (all pass):
- `TestSynth_ProducerConsumerSameFile_BothSurvive` (engine) — producer + consumer of same path in one NestJS file both survive.
- `TestSynth_ElixirFinch_SystemGetEnvBaseURL` (engine) — `@base_url System.get_env(...)` resolves; no bogus `{@base_url}` segment.
- `TestHTTPPass_GraphQLRootMatch` (links) — Apollo `/graphql` root links to a `/graphql/Query/<field>` producer.

`go test ./internal/engine/ ./internal/links/` — PASS.

## 5. Risk / blast radius

- Side-scoped dedup is the only change to a shared hot path. It can only ADD synthetics that were previously dropped (a producer+consumer collision in the same file); same-side dedup is unchanged. Net effect on the full fixture was +6 links, −0.
- GraphQL aliasing is producer-only and gated on the `/graphql/` prefix, so it cannot collapse REST routes.
- Elixir change only adds a new symbol-table entry; existing `@attr "literal"` resolution is untouched.

## 6. Out of scope / notes

- Pre-existing failures on `main` in `internal/dashboard` (`TestWriteback_success`, `TestYamlScalar`) and `internal/enrichment` (`TestCollectRepairEdgeCandidates_NonHexFromID`) reproduce on a clean checkout and are unrelated to this change.

Fixes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)