### PR TITLE
feat(engine): PHP ext-rdkafka consumer/producer extraction

### DIFF
--- a/internal/engine/kafka_edges.go
+++ b/internal/engine/kafka_edges.go
@@ -58,7 +58,7 @@ const transformsEdgeKind = "TRANSFORMS"
 // and Go — the languages with non-trivial Kafka adoption in the corpora.
 func kafkaSynthesisSupportsLanguage(lang string) bool {
 	switch lang {
-	case "java", "kotlin", "javascript", "typescript", "python", "go":
+	case "java", "kotlin", "javascript", "typescript", "python", "go", "php":
 		return true
 	default:
 		return false
@@ -179,6 +179,8 @@ func applyKafkaEdges(
 		synthesizePyKafka(src, emitTopic, emitEdge)
 	case "go":
 		synthesizeGoKafka(src, emitTopic, emitEdge)
+	case "php":
+		synthesizePHPRdKafka(src, emitTopic, emitEdge)
 	}
 
 	return entities, relationships
@@ -963,4 +965,189 @@ func surroundingText(src string, offset, radius int) string {
 		end = len(src)
 	}
 	return src[start:end]
+}
+
+// ---------------------------------------------------------------------------
+// PHP — ext-rdkafka (RdKafka\KafkaConsumer + RdKafka\Producer)
+// ---------------------------------------------------------------------------
+//
+// Covers the two dominant RdKafka idioms found in PHP codebases:
+//
+//   Consumer (high-level):
+//     $consumer = new KafkaConsumer($conf);
+//     $consumer->subscribe(['payments.settled', 'orders.placed']);
+//
+//   Consumer (partition-assign):
+//     $consumer->assign([new TopicPartition('payments.settled', 0)]);
+//
+//   Producer (high-level):
+//     $producer->newTopic('payments.settled')->produce(...);
+//
+//   Producer (low-level):
+//     $topic = $producer->newTopic('payments.settled');
+//     $topic->produce(RD_KAFKA_PARTITION_UA, 0, $msg);
+//
+// Caller attribution: the PHP extractor emits SCOPE.Operation entities
+// with Name="ClassName.methodName" for class methods and "functionName"
+// for top-level functions.  We walk backward from the call site to find
+// the nearest `function` or `public function` declaration and use
+// "ClassName.methodName" when a class name is also discoverable.
+// Falls back to "module" when no enclosing function is found.
+
+// phpRdKafkaSubscribeRe captures `->subscribe([...])` with one or more
+// string literals as topic names.  Matches both single and double-quoted
+// strings inside the array argument.
+// Group 1 = the full comma-separated list body (between the [ ]).
+var phpRdKafkaSubscribeRe = regexp.MustCompile(
+	`->\s*subscribe\s*\(\s*\[([^\]]+)\]`,
+)
+
+// phpRdKafkaAssignRe captures `->assign([new TopicPartition('topic', ...)])`.
+// Group 1 = first string argument (the topic name) of each TopicPartition call.
+var phpRdKafkaAssignRe = regexp.MustCompile(
+	`new\s+(?:RdKafka\\)?TopicPartition\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// phpRdKafkaNewTopicRe captures `->newTopic('topic')` — used by both
+// RdKafka\Producer and the high-level RdKafka\KafkaProducer to obtain a
+// topic handle before calling ->produce().
+// Group 1 = topic name string literal.
+var phpRdKafkaNewTopicRe = regexp.MustCompile(
+	`->\s*newTopic\s*\(\s*['"]([^'"]+)['"]`,
+)
+
+// phpClassNameRe captures the nearest `class Foo` declaration.
+var phpClassNameRe = regexp.MustCompile(`(?m)\bclass\s+(\w+)`)
+
+// phpMethodRe captures PHP method / function declarations.
+// Group 1 = method name (for class methods), group 2 = function name.
+var phpMethodRe = regexp.MustCompile(
+	`(?m)(?:public|protected|private|static|abstract|final|\s)+function\s+(\w+)\s*\(|(?:^|\s)function\s+(\w+)\s*\(`,
+)
+
+// synthesizePHPRdKafka extracts Kafka topic subscriptions and publications
+// from PHP files that use ext-rdkafka (RdKafka\KafkaConsumer,
+// RdKafka\Producer).  Emits SUBSCRIBES_TO and PUBLISHES_TO edges toward
+// the canonical `kafka:<topic>` MessageTopic entities.
+func synthesizePHPRdKafka(
+	src string,
+	emitTopic func(topicID, topicName, broker string, dynamic bool, props map[string]string),
+	emitEdge func(callerKind, callerName, topicID, edgeKind string, props map[string]string),
+) {
+	// Fast pre-filter: only process files that reference RdKafka or subscribe.
+	if !strings.Contains(src, "RdKafka") && !strings.Contains(src, "rdkafka") &&
+		!strings.Contains(src, "KafkaConsumer") && !strings.Contains(src, "KafkaProducer") {
+		return
+	}
+
+	// Resolve the first class name in the file for caller attribution.
+	className := ""
+	if m := phpClassNameRe.FindStringSubmatch(src); len(m) >= 2 {
+		className = m[1]
+	}
+
+	enclosing := func(offset int) string {
+		return findEnclosingPHPName(src, offset, className)
+	}
+
+	// Consumer: ->subscribe(['topic1', 'topic2', ...])
+	for _, m := range phpRdKafkaSubscribeRe.FindAllStringSubmatchIndex(src, -1) {
+		body := src[m[2]:m[3]]
+		caller := enclosing(m[0])
+		for _, tok := range strings.Split(body, ",") {
+			tok = strings.TrimSpace(tok)
+			if tok == "" {
+				continue
+			}
+			// Strip surrounding single or double quotes.
+			tok = strings.Trim(tok, `'"`)
+			tok = strings.TrimSpace(tok)
+			if !looksLikeKafkaTopic(tok) {
+				continue
+			}
+			id := kafkaTopicID(tok)
+			emitTopic(id, tok, "kafka", false, map[string]string{
+				"messaging_layer": "rdkafka",
+			})
+			emitEdge("SCOPE.Operation", caller, id, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "rdkafka",
+			})
+			// Class-level fallback so the consumer class itself is linked.
+			if className != "" {
+				emitEdge("SCOPE.Component", className, id, subscribesToEdgeKind, map[string]string{
+					"messaging_layer": "rdkafka",
+				})
+			}
+		}
+	}
+
+	// Consumer: ->assign([new TopicPartition('topic', partition)])
+	for _, m := range phpRdKafkaAssignRe.FindAllStringSubmatchIndex(src, -1) {
+		topic := src[m[2]:m[3]]
+		if !looksLikeKafkaTopic(topic) {
+			continue
+		}
+		caller := enclosing(m[0])
+		id := kafkaTopicID(topic)
+		emitTopic(id, topic, "kafka", false, map[string]string{
+			"messaging_layer": "rdkafka",
+		})
+		emitEdge("SCOPE.Operation", caller, id, subscribesToEdgeKind, map[string]string{
+			"messaging_layer": "rdkafka",
+		})
+		if className != "" {
+			emitEdge("SCOPE.Component", className, id, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "rdkafka",
+			})
+		}
+	}
+
+	// Producer: ->newTopic('topic-name') — the returned handle is used to
+	// call ->produce(...), so the topic-handle creation is the publish point.
+	for _, m := range phpRdKafkaNewTopicRe.FindAllStringSubmatchIndex(src, -1) {
+		topic := src[m[2]:m[3]]
+		if !looksLikeKafkaTopic(topic) {
+			continue
+		}
+		caller := enclosing(m[0])
+		id := kafkaTopicID(topic)
+		emitTopic(id, topic, "kafka", false, map[string]string{
+			"messaging_layer": "rdkafka",
+		})
+		emitEdge("SCOPE.Operation", caller, id, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "rdkafka",
+		})
+		if className != "" {
+			emitEdge("SCOPE.Component", className, id, publishesToEdgeKind, map[string]string{
+				"messaging_layer": "rdkafka",
+			})
+		}
+	}
+}
+
+// findEnclosingPHPName returns the "ClassName.methodName" or "functionName"
+// for the nearest enclosing function declaration before `offset` in `src`.
+// Falls back to "module" when no function declaration is found.
+func findEnclosingPHPName(src string, offset int, className string) string {
+	start := offset - 4000
+	if start < 0 {
+		start = 0
+	}
+	window := src[start:offset]
+	matches := phpMethodRe.FindAllStringSubmatch(window, -1)
+	if len(matches) == 0 {
+		return "module"
+	}
+	last := matches[len(matches)-1]
+	methodName := last[1]
+	if methodName == "" {
+		methodName = last[2]
+	}
+	if methodName == "" {
+		return "module"
+	}
+	if className != "" {
+		return className + "." + methodName
+	}
+	return methodName
 }

--- a/internal/engine/kafka_edges_test.go
+++ b/internal/engine/kafka_edges_test.go
@@ -488,3 +488,212 @@ func TestKafka_NoOpForUnsupportedLanguage(t *testing.T) {
 		t.Fatalf("expected no-op for unsupported language, got ents=%v rels=%v", ents, rels)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// PHP — ext-rdkafka (RdKafka\KafkaConsumer + RdKafka\Producer) — Fixes #1495
+// ---------------------------------------------------------------------------
+
+// TestKafka_PHPRdKafkaConsumerSubscribe verifies that
+// `$consumer->subscribe(['payments.settled'])` emits a canonical
+// kafka:payments.settled MessageTopic + SUBSCRIBES_TO edge.
+// This is the exact pattern used by billing/app/Console/Commands/ConsumePaymentsSettled.php.
+func TestKafka_PHPRdKafkaConsumerSubscribe(t *testing.T) {
+	src := `<?php
+namespace App\Console\Commands;
+
+use RdKafka\Conf;
+use RdKafka\KafkaConsumer;
+
+class ConsumePaymentsSettled extends Command
+{
+    public function handle(): int
+    {
+        $conf = new Conf();
+        $conf->set('group.id', 'billing-invoicing');
+        $consumer = new KafkaConsumer($conf);
+        $consumer->subscribe(['payments.settled']);
+
+        while (true) {
+            $message = $consumer->consume(120 * 1000);
+        }
+        return self::SUCCESS;
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "php", "app/Console/Commands/ConsumePaymentsSettled.php", src)
+
+	// Must emit a MessageTopic for payments.settled.
+	tp := topicByName(ents, "payments.settled")
+	if tp == nil {
+		t.Fatalf("expected MessageTopic for payments.settled, ents=%v", ents)
+	}
+	if tp.Properties["broker"] != "kafka" {
+		t.Errorf("broker: want kafka, got %q", tp.Properties["broker"])
+	}
+	if tp.Name != "kafka:payments.settled" {
+		t.Errorf("topic entity Name: want kafka:payments.settled, got %q", tp.Name)
+	}
+
+	// Must emit a SUBSCRIBES_TO edge.
+	subs := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	// One of the edges must target kafka:payments.settled.
+	found := false
+	for _, s := range subs {
+		if strings.Contains(s.ToID, "kafka:payments.settled") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("no SUBSCRIBES_TO edge targeting kafka:payments.settled in %v", subs)
+	}
+}
+
+// TestKafka_PHPRdKafkaConsumerSubscribeMulti verifies multi-topic subscribe.
+func TestKafka_PHPRdKafkaConsumerSubscribeMulti(t *testing.T) {
+	src := `<?php
+use RdKafka\KafkaConsumer;
+class OrderConsumer {
+    public function run() {
+        $consumer = new KafkaConsumer($conf);
+        $consumer->subscribe(['orders.placed', 'orders.cancelled']);
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "php", "app/OrderConsumer.php", src)
+
+	for _, topic := range []string{"orders.placed", "orders.cancelled"} {
+		tp := topicByName(ents, topic)
+		if tp == nil {
+			t.Errorf("expected MessageTopic for %s, ents=%v", topic, ents)
+		}
+	}
+	subs := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(subs) < 2 {
+		t.Errorf("expected at least 2 SUBSCRIBES_TO edges for 2 topics, got %d: %v", len(subs), subs)
+	}
+}
+
+// TestKafka_PHPRdKafkaConsumerAssign verifies partition-assign consumer pattern.
+func TestKafka_PHPRdKafkaConsumerAssign(t *testing.T) {
+	src := `<?php
+use RdKafka\KafkaConsumer;
+use RdKafka\TopicPartition;
+
+class PartitionConsumer {
+    public function handle() {
+        $consumer = new KafkaConsumer($conf);
+        $consumer->assign([new TopicPartition('inventory.reserved', 0)]);
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "php", "app/PartitionConsumer.php", src)
+
+	tp := topicByName(ents, "inventory.reserved")
+	if tp == nil {
+		t.Fatalf("expected MessageTopic for inventory.reserved, ents=%v", ents)
+	}
+	subs := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge from assign pattern, rels=%v", rels)
+	}
+	found := false
+	for _, s := range subs {
+		if strings.Contains(s.ToID, "kafka:inventory.reserved") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no SUBSCRIBES_TO targeting inventory.reserved in %v", subs)
+	}
+}
+
+// TestKafka_PHPRdKafkaProducerNewTopic verifies ->newTopic('topic') producer.
+func TestKafka_PHPRdKafkaProducerNewTopic(t *testing.T) {
+	src := `<?php
+use RdKafka\Producer;
+
+class PaymentProducer {
+    public function publish(array $event): void {
+        $producer = new Producer();
+        $topic = $producer->newTopic('payments.settled');
+        $topic->produce(RD_KAFKA_PARTITION_UA, 0, json_encode($event));
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "php", "app/PaymentProducer.php", src)
+
+	tp := topicByName(ents, "payments.settled")
+	if tp == nil {
+		t.Fatalf("expected MessageTopic for payments.settled, ents=%v", ents)
+	}
+	pubs := edgesOfKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge from newTopic, rels=%v", rels)
+	}
+	found := false
+	for _, p := range pubs {
+		if strings.Contains(p.ToID, "kafka:payments.settled") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("no PUBLISHES_TO targeting payments.settled in %v", pubs)
+	}
+}
+
+// TestKafka_PHPNoOpWithoutRdKafka verifies that plain PHP without RdKafka
+// import does not cause false positives.
+func TestKafka_PHPNoOpWithoutRdKafka(t *testing.T) {
+	src := `<?php
+class OrderController {
+    public function subscribe(array $topics): void {
+        // generic subscribe, no kafka
+        foreach ($topics as $t) {
+            $this->eventBus->register($t);
+        }
+    }
+}
+`
+	ents, rels := runKafkaDetect(t, "php", "app/OrderController.php", src)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Fatalf("expected no-op for PHP without RdKafka import, got ents=%v rels=%v", ents, rels)
+	}
+}
+
+// TestKafka_PHPCallerAttribution verifies that the caller entity name is
+// "ClassName.methodName" matching the PHP extractor's SCOPE.Operation naming.
+func TestKafka_PHPCallerAttribution(t *testing.T) {
+	src := `<?php
+use RdKafka\KafkaConsumer;
+
+class ConsumePaymentsSettled {
+    public function handle(): int {
+        $consumer = new KafkaConsumer($conf);
+        $consumer->subscribe(['payments.settled']);
+        return 0;
+    }
+}
+`
+	_, rels := runKafkaDetect(t, "php", "app/ConsumePaymentsSettled.php", src)
+	subs := edgesOfKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+	// Find the SCOPE.Operation edge (not the class-level fallback).
+	found := false
+	for _, s := range subs {
+		if strings.HasPrefix(s.FromID, "SCOPE.Operation:") &&
+			strings.Contains(s.FromID, "ConsumePaymentsSettled.handle") &&
+			strings.Contains(s.ToID, "kafka:payments.settled") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected SCOPE.Operation:ConsumePaymentsSettled.handle → kafka:payments.settled edge, got %v", subs)
+	}
+}


### PR DESCRIPTION
## What

Adds PHP `ext-rdkafka` (`RdKafka\KafkaConsumer` / `RdKafka\Producer`) recognition to the Kafka synthesis pass so the `billing` service's `ConsumePaymentsSettled` command produces a `SUBSCRIBES_TO kafka:payments.settled` edge, resolving the missing `payments→billing` P7 cross-repo link.

Fixes #1495.

## Root cause

`kafkaSynthesisSupportsLanguage` did not include `"php"`, so `applyKafkaEdges` was a no-op for all PHP files. No PHP RdKafka detection logic existed anywhere.

## Changes

**`internal/engine/kafka_edges.go`**
- Added `"php"` to `kafkaSynthesisSupportsLanguage`.
- Added `"php"` dispatch branch in `applyKafkaEdges` switch.
- New `synthesizePHPRdKafka` function covering three idioms:
  - Consumer (high-level): `$consumer->subscribe(['topic', ...])`
  - Consumer (partition-assign): `$consumer->assign([new TopicPartition('topic', ...)])`
  - Producer: `$producer->newTopic('topic-name')`
- New `findEnclosingPHPName` helper — returns `ClassName.methodName` matching PHP extractor's `SCOPE.Operation` naming, with `module` fallback.
- Guard: only fires on files containing `RdKafka`, `rdkafka`, `KafkaConsumer`, or `KafkaProducer`.

**`internal/engine/kafka_edges_test.go`**
Six new tests:
- `TestKafka_PHPRdKafkaConsumerSubscribe` — single-topic subscribe (exact ConsumePaymentsSettled fixture)
- `TestKafka_PHPRdKafkaConsumerSubscribeMulti` — multi-topic subscribe
- `TestKafka_PHPRdKafkaConsumerAssign` — partition-assign pattern
- `TestKafka_PHPRdKafkaProducerNewTopic` — `->newTopic()` producer
- `TestKafka_PHPNoOpWithoutRdKafka` — guard: no false positives on plain PHP
- `TestKafka_PHPCallerAttribution` — verifies `SCOPE.Operation:ConsumePaymentsSettled.handle` caller

## Real-fixture verification (polyglot-platform, 14 services)

```
BEFORE  P7 topic links: 11   (no payments→billing edge)
AFTER   P7 topic links: 12   (payments→billing via kafka:payments.settled ✓)
```

New P7 link: `payments::0f9bd86abd20cc55 → billing::46d6cf4e1bf6c9b7`

## Test results

```
ok  github.com/cajasmota/archigraph/internal/engine   8.275s
ok  github.com/cajasmota/archigraph/internal/links    5.545s
```

All 6 new PHP tests pass. No regressions in engine or links suites.

## Append-only guarantee

`synthesizePHPRdKafka` only appends MessageTopic entities and SUBSCRIBES_TO / PUBLISHES_TO edges. It never modifies or removes existing entities or edges. The guard (fast pre-filter on RdKafka string presence) ensures no extra work on non-Kafka PHP files.