### PR TITLE
fix(extractors): dedup within-file Order nodes — FastAPI + SQLAlchemy false positives (Fixes #1501)

### DIFF
--- a/internal/custom/python/extractors_test.go
+++ b/internal/custom/python/extractors_test.go
@@ -653,6 +653,11 @@ async def get_items(db = Depends(get_db)):
 }
 
 func TestFastAPI_PydanticModel(t *testing.T) {
+	// Issue #1501 — the FastAPI extractor must NOT emit standalone SCOPE.Schema
+	// entities for Pydantic model classes. The base Python extractor already
+	// emits a SCOPE.Component/class entity for every class definition; a second
+	// SCOPE.Schema from this extractor creates within-file duplicates that inflate
+	// node counts (e.g. "Order" appearing 3× instead of 1×).
 	src := `class UserCreate(BaseModel):
     name: str
     email: str
@@ -661,14 +666,11 @@ class AppConfig(BaseSettings):
     debug: bool = False
 `
 	ents := extract(t, "python_fastapi", src)
-	schemaCount := 0
 	for _, e := range ents {
-		if e.Kind == "SCOPE.Schema" {
-			schemaCount++
+		if e.Kind == "SCOPE.Schema" && (e.Name == "UserCreate" || e.Name == "AppConfig") {
+			t.Fatalf("python_fastapi must not emit SCOPE.Schema entity for Pydantic class %q (issue #1501): "+
+				"the base Python extractor already emits SCOPE.Component/class for it", e.Name)
 		}
-	}
-	if schemaCount != 2 {
-		t.Fatalf("expected 2 Pydantic schemas, got %d", schemaCount)
 	}
 }
 
@@ -1426,6 +1428,31 @@ func TestSQLAlchemy_NoMatch(t *testing.T) {
 	ents := extract(t, "python_sqlalchemy", src)
 	if len(ents) != 0 {
 		t.Fatalf("expected 0 entities, got %d", len(ents))
+	}
+}
+
+// TestSQLAlchemy_NoFalsePositiveOnPydantic verifies that Pydantic BaseModel
+// subclasses are NOT emitted as SQLAlchemy model entities. "BaseModel" contains
+// the word "Model" (which was previously in saBaseIndicators as a bare substring
+// match), causing false-positive SCOPE.Schema duplicates for shared domain
+// classes (issue #1501 — within-extractor dedup fix 2/2).
+func TestSQLAlchemy_NoFalsePositiveOnPydantic(t *testing.T) {
+	src := `from pydantic import BaseModel, BaseSettings
+
+class Order(BaseModel):
+    id: str
+    status: str
+    total_cents: int
+
+class AppConfig(BaseSettings):
+    db_url: str
+`
+	ents := extract(t, "python_sqlalchemy", src)
+	for _, e := range ents {
+		if e.Name == "Order" || e.Name == "AppConfig" {
+			t.Fatalf("python_sqlalchemy must not emit entity for Pydantic class %q (issue #1501): "+
+				"'BaseModel' was falsely matched by the 'Model' substring in saBaseIndicators", e.Name)
+		}
 	}
 }
 

--- a/internal/custom/python/fastapi.go
+++ b/internal/custom/python/fastapi.go
@@ -17,8 +17,19 @@ func init() {
 }
 
 // FastAPIExtractor extracts FastAPI framework patterns: route decorators,
-// Depends(), Pydantic models, APIRouter, WebSocket, middleware,
-// BackgroundTasks, and lifecycle events.
+// Depends(), APIRouter, WebSocket, middleware, BackgroundTasks, and lifecycle
+// events.
+//
+// Pydantic model classes (BaseModel / BaseSettings / RootModel subclasses) are
+// intentionally NOT emitted as separate entities here. The base Python extractor
+// already emits a canonical SCOPE.Component/class entity for every class
+// definition in the same file, including Pydantic models. Emitting a second
+// SCOPE.Schema entity for the same class from this extractor created within-file
+// duplicates (one node per extractor) for names like "Order", inflating node
+// counts without adding structural information. Framework properties for Pydantic
+// models (orm_mode, env_prefix, alias_generator) are captured by the base Python
+// extractor's applyFrameworkInnerClassProperties logic on the Config inner class.
+// Issue #1501 — within-extractor dedup, fix 1/2.
 type FastAPIExtractor struct{}
 
 func (e *FastAPIExtractor) Language() string { return "python_fastapi" }
@@ -29,12 +40,7 @@ var (
 			`\(\s*(?:r)?["']([^"']*)["'][^)]*\)\s*\n` +
 			`(?:\s*(?:#[^\n]*)?\n)*` +
 			`\s*(?:async\s+)?def\s+(\w+)\s*\(`)
-	faDependsParamRe  = regexp.MustCompile(`=\s*Depends\s*\(\s*(\w+)\s*\)`)
-	faPydanticClassRe = regexp.MustCompile(
-		`(?m)^class\s+([A-Z][A-Za-z0-9_]*)\s*\([^)]*` +
-			`(?:(?:pydantic\.)?(?:BaseModel|BaseSettings|RootModel|GenericModel|` +
-			`ConstrainedStr|ConstrainedInt|ConstrainedFloat|ConstrainedBytes|` +
-			`ConstrainedDate|ConstrainedDecimal))[^)]*\)\s*:`)
+	faDependsParamRe = regexp.MustCompile(`=\s*Depends\s*\(\s*(\w+)\s*\)`)
 	faAPIRouterRe    = regexp.MustCompile(`(?m)(\w+)\s*=\s*APIRouter\s*\(([^)]*)\)`)
 	faRouterPrefixRe = regexp.MustCompile(`prefix\s*=\s*["']([^"']*)["']`)
 	faRouterTagsRe   = regexp.MustCompile(`tags\s*=\s*\[\s*["']([^"']*)["']`)
@@ -88,15 +94,12 @@ func (e *FastAPIExtractor) Extract(ctx context.Context, file extractor.FileInput
 			map[string]string{"framework": "fastapi", "pattern_type": "depends", "dependency_fn": depFn}))
 	}
 
-	// 3. Pydantic models
-	for _, idx := range allMatchesIndex(faPydanticClassRe, source) {
-		className := source[idx[2]:idx[3]]
-		line := lineOf(source, idx[0])
-		out = append(out, entity(className, "SCOPE.Schema", "", file.Path, line,
-			map[string]string{"framework": "fastapi", "pattern_type": "pydantic_model", "class_name": className}))
-	}
+	// Note: Pydantic model classes (BaseModel subclasses) are not emitted here.
+	// The base Python extractor already emits SCOPE.Component/class for every
+	// class definition. Emitting a second SCOPE.Schema entity for the same class
+	// creates within-file duplicates that inflate node counts (issue #1501).
 
-	// 4. APIRouter instantiation
+	// 3. APIRouter instantiation
 	for _, idx := range allMatchesIndex(faAPIRouterRe, source) {
 		varName := source[idx[2]:idx[3]]
 		args := source[idx[4]:idx[5]]

--- a/internal/custom/python/order_dedup_test.go
+++ b/internal/custom/python/order_dedup_test.go
@@ -1,0 +1,203 @@
+package python_test
+
+// Order-dedup regression tests for issue #1501.
+//
+// The polyglot-platform fixture has:
+//   - libs/py-shared/py_shared/models.py  — class Order(BaseModel) [Pydantic]
+//   - services/search-graphql/src/schema.graphql — type Order { … }
+//
+// Before the fix, running all three Python-side extractors produced 3 canonical
+// "Order" nodes (SCOPE.Component/class from base Python + SCOPE.Schema from
+// FastAPI + SCOPE.Schema from SQLAlchemy). The GraphQL extractor produced 1
+// more (SCOPE.Schema/type), totalling 4 canonical "Order" entities — reported
+// as 6 when GraphQL field sub-entities (Order.id, Order.status, Order.totalCents)
+// are counted as well.
+//
+// After the fix, only 2 canonical "Order" entities exist (one per language):
+//   - SCOPE.Component/class "Order" from the base Python extractor
+//   - SCOPE.Schema/type     "Order" from the GraphQL extractor
+//
+// The 3 GraphQL field sub-entities (Order.*) are legitimate and are preserved.
+
+import (
+	"context"
+	"os"
+	"testing"
+
+	_ "github.com/cajasmota/archigraph/internal/custom/python"
+	_ "github.com/cajasmota/archigraph/internal/extractors/graphql"
+	_ "github.com/cajasmota/archigraph/internal/extractors/python"
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+const polyglotPlatformBase = "/Users/jorgecajas/Documents/Projects/polyglot-platform"
+
+// TestOrderDedup_PythonNoFastAPIOrSQLAlchemyDuplicate asserts that the
+// python_fastapi and python_sqlalchemy extractors do NOT emit standalone
+// "Order" entities for the shared Pydantic models.py file.
+// Issue #1501 — within-extractor dedup, fixes 1 and 2.
+func TestOrderDedup_PythonNoFastAPIOrSQLAlchemyDuplicate(t *testing.T) {
+	pyContent, err := os.ReadFile(polyglotPlatformBase + "/libs/py-shared/py_shared/models.py")
+	if err != nil {
+		t.Skip("polyglot-platform not found:", err)
+	}
+
+	fileInput := extractor.FileInput{
+		Path:     "libs/py-shared/py_shared/models.py",
+		Content:  pyContent,
+		Language: "python",
+	}
+
+	for _, key := range []string{"python_fastapi", "python_sqlalchemy"} {
+		ext, ok := extractor.Get(key)
+		if !ok {
+			t.Fatalf("extractor %q not registered", key)
+		}
+		ents, err := ext.Extract(context.Background(), fileInput)
+		if err != nil {
+			t.Fatalf("%s.Extract: %v", key, err)
+		}
+		for _, e := range ents {
+			if e.Name == "Order" {
+				t.Errorf("extractor %q must not emit entity for Pydantic class Order (issue #1501): "+
+					"got Kind=%q Subtype=%q; the base Python extractor already emits SCOPE.Component/class",
+					key, e.Kind, e.Subtype)
+			}
+			if e.Name == "OrderItem" {
+				t.Errorf("extractor %q must not emit entity for Pydantic class OrderItem (issue #1501): "+
+					"got Kind=%q Subtype=%q", key, e.Kind, e.Subtype)
+			}
+		}
+	}
+}
+
+// TestOrderDedup_PythonBaseEmitsOneCanonicalOrder asserts that the base Python
+// extractor emits exactly one SCOPE.Component/class entity named "Order" from
+// models.py, with no SCOPE.Schema duplicate alongside it.
+func TestOrderDedup_PythonBaseEmitsOneCanonicalOrder(t *testing.T) {
+	pyContent, err := os.ReadFile(polyglotPlatformBase + "/libs/py-shared/py_shared/models.py")
+	if err != nil {
+		t.Skip("polyglot-platform not found:", err)
+	}
+
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "libs/py-shared/py_shared/models.py",
+		Content:  pyContent,
+		Language: "python",
+	})
+	if err != nil {
+		t.Fatalf("python.Extract: %v", err)
+	}
+
+	var componentCount, schemaCount int
+	for _, e := range ents {
+		if e.Name == "Order" {
+			switch e.Kind {
+			case "SCOPE.Component":
+				componentCount++
+			case "SCOPE.Schema":
+				schemaCount++
+			}
+		}
+	}
+	if componentCount != 1 {
+		t.Errorf("expected exactly 1 SCOPE.Component/class entity for Order, got %d", componentCount)
+	}
+	if schemaCount != 0 {
+		t.Errorf("expected 0 SCOPE.Schema entities for Order from base Python extractor, got %d", schemaCount)
+	}
+}
+
+// TestOrderDedup_GraphQLStillEmitsOrderType asserts that the GraphQL extractor
+// still emits the canonical SCOPE.Schema/type "Order" entity from schema.graphql.
+// This is a DIFFERENT source language from the Python model and must be preserved.
+func TestOrderDedup_GraphQLStillEmitsOrderType(t *testing.T) {
+	gqlContent, err := os.ReadFile(polyglotPlatformBase + "/services/search-graphql/src/schema.graphql")
+	if err != nil {
+		t.Skip("polyglot-platform not found:", err)
+	}
+
+	ext, ok := extractor.Get("graphql")
+	if !ok {
+		t.Fatal("graphql extractor not registered")
+	}
+	ents, err := ext.Extract(context.Background(), extractor.FileInput{
+		Path:     "services/search-graphql/src/schema.graphql",
+		Content:  gqlContent,
+		Language: "graphql",
+	})
+	if err != nil {
+		t.Fatalf("graphql.Extract: %v", err)
+	}
+
+	found := false
+	for _, e := range ents {
+		if e.Name == "Order" && e.Kind == "SCOPE.Schema" && e.Subtype == "type" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("graphql extractor must still emit SCOPE.Schema/type Order from schema.graphql (legitimate cross-language instance)")
+	}
+}
+
+// TestOrderDedup_TotalCanonicalOrderCount verifies the end-to-end canonical
+// "Order" entity count across all extractors applied to the polyglot-platform
+// fixture. The target is 2: one per language (Python + GraphQL).
+// GraphQL field sub-entities (Order.id, Order.status, Order.totalCents) are
+// NOT counted here as they have names like "Order.id", not "Order".
+func TestOrderDedup_TotalCanonicalOrderCount(t *testing.T) {
+	pyContent, err := os.ReadFile(polyglotPlatformBase + "/libs/py-shared/py_shared/models.py")
+	if err != nil {
+		t.Skip("polyglot-platform not found:", err)
+	}
+	gqlContent, err := os.ReadFile(polyglotPlatformBase + "/services/search-graphql/src/schema.graphql")
+	if err != nil {
+		t.Skip("polyglot-platform not found:", err)
+	}
+
+	type extractorCase struct {
+		key     string
+		lang    string
+		content []byte
+		path    string
+	}
+	cases := []extractorCase{
+		{"python", "python", pyContent, "libs/py-shared/py_shared/models.py"},
+		{"python_fastapi", "python", pyContent, "libs/py-shared/py_shared/models.py"},
+		{"python_sqlalchemy", "python", pyContent, "libs/py-shared/py_shared/models.py"},
+		{"graphql", "graphql", gqlContent, "services/search-graphql/src/schema.graphql"},
+	}
+
+	var canonicalOrder int
+	for _, tc := range cases {
+		ext, ok := extractor.Get(tc.key)
+		if !ok {
+			t.Fatalf("extractor %q not registered", tc.key)
+		}
+		ents, err := ext.Extract(context.Background(), extractor.FileInput{
+			Path:     tc.path,
+			Content:  tc.content,
+			Language: tc.lang,
+		})
+		if err != nil {
+			t.Fatalf("%s.Extract: %v", tc.key, err)
+		}
+		for _, e := range ents {
+			if e.Name == "Order" {
+				canonicalOrder++
+			}
+		}
+	}
+
+	// Expected: 2 canonical "Order" nodes (Python SCOPE.Component/class + GraphQL SCOPE.Schema/type).
+	// Before fix: 4 (Python + FastAPI + SQLAlchemy + GraphQL).
+	if canonicalOrder != 2 {
+		t.Errorf("expected 2 canonical Order entities across all extractors (issue #1501), got %d", canonicalOrder)
+	}
+}

--- a/internal/custom/python/sqlalchemy.go
+++ b/internal/custom/python/sqlalchemy.go
@@ -41,7 +41,18 @@ var (
 )
 
 // saBaseIndicators are common base classes for SQLAlchemy declarative models.
-var saBaseIndicators = []string{"Base", "DeclarativeBase", "db.Model", "Model"}
+// "Model" is intentionally absent: it is too broad a substring and matches
+// Pydantic's "BaseModel" as well as Flask-Login's "UserMixin", causing false
+// positives. Use "db.Model" (Flask-SQLAlchemy) or rely on the __tablename__/
+// Mapped[] body scan below instead. Issue #1501 — within-extractor dedup fix 2/2.
+var saBaseIndicators = []string{"Base", "DeclarativeBase", "db.Model"}
+
+// saPydanticBases lists Pydantic base class names that, when present in a
+// class's base list, conclusively identify the class as a Pydantic model and
+// NOT a SQLAlchemy declarative model. This guard prevents false positives when
+// a file imports both sqlalchemy and pydantic (e.g. a shared models.py with
+// Pydantic DTOs next to ORM classes).
+var saPydanticBases = []string{"BaseModel", "BaseSettings", "RootModel", "GenericModel"}
 
 func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileInput) ([]types.EntityRecord, error) {
 	tracer := otel.Tracer("custom.python_sqlalchemy")
@@ -60,6 +71,21 @@ func (e *SQLAlchemyExtractor) Extract(ctx context.Context, file extractor.FileIn
 	for _, idx := range allMatchesIndex(saDeclarativeModelRe, source) {
 		className := source[idx[2]:idx[3]]
 		bases := source[idx[4]:idx[5]]
+
+		// Exclude Pydantic models: if any Pydantic base class appears in the
+		// base list, the class is definitely NOT a SQLAlchemy model, even if the
+		// body contains SQLAlchemy-like patterns (e.g. a shared models.py with
+		// Pydantic DTOs). Issue #1501 — prevents BaseModel false positives.
+		isPydantic := false
+		for _, pb := range saPydanticBases {
+			if strings.Contains(bases, pb) {
+				isPydantic = true
+				break
+			}
+		}
+		if isPydantic {
+			continue
+		}
 
 		// Check if this looks like a SQLAlchemy model
 		isModel := false


### PR DESCRIPTION
## What & Why

`Order` was appearing as 6 nodes in the graph (target: ≤2 canonical). Root cause: two custom Python extractors were emitting standalone entities for classes the base Python extractor already owns.

## Root Cause Analysis

Running all extractors against `libs/py-shared/py_shared/models.py` (which has `class Order(BaseModel)`):

| Extractor | Entity emitted | Kind |
|---|---|---|
| `python` (base) | `Order` | `SCOPE.Component/class` ✓ canonical |
| `python_fastapi` | `Order` | `SCOPE.Schema` ✗ **duplicate** |
| `python_sqlalchemy` | `Order` | `SCOPE.Schema` ✗ **false positive** |
| `graphql` | `Order` | `SCOPE.Schema/type` ✓ canonical (different language) |

Plus 3 GraphQL field sub-entities (`Order.id`, `Order.status`, `Order.totalCents`) = 6 total containing "Order".

## Fix 1 — FastAPI extractor (`internal/custom/python/fastapi.go`)

Removed Pydantic model class emission (section 3 in `Extract()`). The base Python extractor already emits `SCOPE.Component/class` for every class definition. The FastAPI extractor's `SCOPE.Schema` entity for the same class was a pure duplicate with no downstream consumers.

- Removed `faPydanticClassRe` variable (no longer needed)
- Updated docstring to document the intentional omission

## Fix 2 — SQLAlchemy extractor (`internal/custom/python/sqlalchemy.go`)

Two sub-fixes:
1. Removed `"Model"` from `saBaseIndicators` — it was a bare substring match that triggered on `BaseModel`, `UserMixin`, any class with `Model` in a base name
2. Added `saPydanticBases` exclusion guard — if a class inherits from `BaseModel`, `BaseSettings`, `RootModel`, or `GenericModel`, it is conclusively NOT a SQLAlchemy model and is skipped before the body-content scan

## Node count: before → after

```
polyglot-platform/libs/py-shared/py_shared/models.py, class Order(BaseModel):
  BEFORE: python=1, fastapi=1, sqlalchemy=1, graphql=1 = 4 canonical "Order" nodes
  AFTER:  python=1, fastapi=0, sqlalchemy=0, graphql=1 = 2 canonical "Order" nodes
```

Target was ≤2 canonical. ✓ Achieved exactly 2.

GraphQL field sub-entities (`Order.id`, `Order.status`, `Order.totalCents`) are unaffected — they are legitimate.

## Tests

- Updated `TestFastAPI_PydanticModel` — now asserts NO `SCOPE.Schema` entity is emitted for `UserCreate(BaseModel)` or `AppConfig(BaseSettings)`
- Added `TestSQLAlchemy_NoFalsePositiveOnPydantic` — asserts neither `Order(BaseModel)` nor `AppConfig(BaseSettings)` triggers the SQLAlchemy extractor
- New file `order_dedup_test.go` with 4 regression tests:
  - `TestOrderDedup_PythonNoFastAPIOrSQLAlchemyDuplicate`
  - `TestOrderDedup_PythonBaseEmitsOneCanonicalOrder`
  - `TestOrderDedup_GraphQLStillEmitsOrderType`
  - `TestOrderDedup_TotalCanonicalOrderCount` (asserts exactly 2 canonical nodes)

All 3 affected packages pass (`internal/custom/python`, `internal/extractors/python`, `internal/extractors/graphql`).

## What's deferred (sub-problem #2)

Cross-language `SAME_AS` edges between `py-shared::Order` and `js-shared::Order` are not addressed here. This is a harder problem requiring a new cross-language linker pass and belongs in a follow-up issue. The within-file dedup (sub-problem #1) is the more tractable fix and reduces canonical Order count from 4→2 on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)