### PR TITLE
feat(quality): service-level SCC / cycle detection (#1502)

### DIFF
--- a/cmd/archigraph/xrepo_verify.go
+++ b/cmd/archigraph/xrepo_verify.go
@@ -129,7 +129,49 @@ func runXRepoVerify(args []string) int {
 		diagnoseOrphans(tmpGraphs, linkedSources)
 	}
 
+	// Service-level SCC detection over the produced links (#1502). Aggregates
+	// directed cross-repo links into a service graph and reports cycles.
+	reportServiceCycles(linksPath)
+
 	return 0
+}
+
+// reportServiceCycles reads the produced links.json, aggregates directed
+// cross-service links (calls / publishes_to) into a service graph, runs Tarjan
+// SCC, and prints every SCC of size >= 2. Exercises the exact #1502 code path
+// on a real fixture without touching the live daemon.
+func reportServiceCycles(linksPath string) {
+	b, err := os.ReadFile(linksPath)
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "read links for SCC:", err)
+		return
+	}
+	var doc struct {
+		Links []struct {
+			Source   string `json:"source"`
+			Target   string `json:"target"`
+			Relation string `json:"relation"`
+		} `json:"links"`
+	}
+	if err := json.Unmarshal(b, &doc); err != nil {
+		fmt.Fprintln(os.Stderr, "parse links for SCC:", err)
+		return
+	}
+	sl := make([]graph.ServiceLink, 0, len(doc.Links))
+	for _, l := range doc.Links {
+		from := repoOf(l.Source)
+		to := repoOf(l.Target)
+		sl = append(sl, graph.ServiceLink{FromService: from, ToService: to, Relation: l.Relation})
+	}
+	cycles := graph.FindServiceCycles(sl)
+	fmt.Println("\n=== SERVICE-LEVEL SCC / CYCLES (#1502) ===")
+	fmt.Printf("service SCCs (size >= 2): %d\n", len(cycles))
+	for i, c := range cycles {
+		fmt.Printf("[%d] size=%d members=%v\n", i+1, c.Size, c.Members)
+		for _, e := range c.Edges {
+			fmt.Printf("     %s -> %s  (%v)\n", e.From, e.To, e.Relations)
+		}
+	}
 }
 
 type fwkCov struct {
@@ -307,13 +349,13 @@ func stripAPIPrefixDiag(p string) (string, bool) {
 
 // orphanRecord holds information about an orphan consumer call.
 type orphanRecord struct {
-	repo          string
-	verb          string
-	path          string
-	name          string
-	framework     string
-	urlPrefix     string
-	callerEntity  string
+	repo         string
+	verb         string
+	path         string
+	name         string
+	framework    string
+	urlPrefix    string
+	callerEntity string
 }
 
 // diagnoseOrphans dumps orphan consumer calls with nearest producer candidates.
@@ -429,9 +471,9 @@ func diagnoseOrphans(graphsDir string, linkedSources map[string]bool) {
 
 	// Categorise miss reasons.
 	type missReason struct {
-		reason  string
-		consVerb string
-		consPath string
+		reason      string
+		consVerb    string
+		consPath    string
 		prodMatches []string
 	}
 	reasonCounts := map[string]int{}

--- a/internal/graph/service_cycles.go
+++ b/internal/graph/service_cycles.go
@@ -1,0 +1,273 @@
+// Package graph — service_cycles.go implements strongly-connected-component
+// (SCC) detection over a SERVICE-level (repo-level) graph.
+//
+// Per-entity import-cycle detection (cycles.go) cannot see cross-service
+// coupling that flows THROUGH synthetic boundary nodes: an HTTP `FETCHES` edge
+// lands on an endpoint-synthetic node, and a Kafka publish/subscribe pair is
+// mediated by a topic node. As a result two services that mutually depend on
+// each other (orders calls payments over REST while payments calls back over a
+// Kafka topic) never share a direct entity→entity edge, so Tarjan over IMPORTS
+// finds nothing.
+//
+// The cross-repo link passes (internal/links P1-P7) already resolve those
+// boundaries into direct service→service edges (`<repo>::<id>` source/target,
+// relation calls / imports / publishes_to). FindServiceCycles aggregates those
+// resolved links into a directed service graph and runs Tarjan SCC over it,
+// reporting every SCC of size >= 2 as a service-level circular dependency.
+package graph
+
+import "sort"
+
+// ServiceEdge is a directed service→service edge, aggregated from one or more
+// cross-repo links. Relations records the distinct relation labels (calls,
+// imports, publishes_to, ...) that contributed to this edge, for explainability.
+type ServiceEdge struct {
+	From      string   `json:"from"`
+	To        string   `json:"to"`
+	Relations []string `json:"relations,omitempty"`
+}
+
+// ServiceCycle describes one strongly-connected component of size >= 2 in the
+// service-level graph.
+type ServiceCycle struct {
+	// Members lists service (repo) names that form the cycle, sorted.
+	Members []string `json:"members"`
+	// Edges lists the directed service→service edges internal to the cycle,
+	// sorted for determinism.
+	Edges []ServiceEdge `json:"edges"`
+	// Size is len(Members), for fast filtering.
+	Size int `json:"size"`
+}
+
+// ServiceLink is the minimal directed cross-service edge FindServiceCycles
+// consumes. It is decoupled from the MCP CrossRepoLink / links.Link shapes so
+// the graph package stays dependency-free; callers map their link type onto it.
+type ServiceLink struct {
+	FromService string
+	ToService   string
+	Relation    string
+}
+
+// directedRelations is the set of link relations that express a real DIRECTION
+// of RUNTIME service coupling and may therefore participate in a service cycle.
+//
+//   - calls        consumer → producer (HTTP / gRPC FETCHES, resolved through
+//     the endpoint-synthetic boundary node)
+//   - publishes_to publisher → subscriber (Kafka/Redis topic, resolved through
+//     the topic boundary node)
+//
+// Deliberately EXCLUDED:
+//   - imports               cross-repo module imports are build-time coupling
+//     (everything importing a shared lib, or a Python
+//     service "importing" another), not service→service
+//     runtime calls. Including them collapses unrelated
+//     services into one giant SCC.
+//   - shared_label /        UNDIRECTED co-occurrence signals (two services
+//     string_match          merely reference the same label / string). Treating
+//     them as edges manufactures spurious cycles.
+var directedRelations = map[string]bool{
+	"calls":        true,
+	"publishes_to": true,
+}
+
+// IsDirectedServiceRelation reports whether a link relation expresses a
+// directed dependency that may participate in a service-level cycle.
+func IsDirectedServiceRelation(relation string) bool {
+	return directedRelations[relation]
+}
+
+// FindServiceCycles aggregates directed cross-service links into a service
+// graph and returns every strongly-connected component of size >= 2.
+//
+// Only links whose relation is a directed dependency (see directedRelations)
+// are considered; undirected co-occurrence relations (shared_label,
+// string_match) are ignored so they cannot fabricate cycles. Self-edges
+// (FromService == ToService) are dropped.
+//
+// Results are sorted by descending size, then by first member name.
+func FindServiceCycles(links []ServiceLink) []ServiceCycle {
+	// Aggregate links into a deduplicated directed service adjacency map,
+	// tracking the contributing relation labels per edge.
+	type edgeKey struct{ from, to string }
+	adj := make(map[string]map[string]bool)
+	relsByEdge := make(map[edgeKey]map[string]bool)
+
+	for _, l := range links {
+		if !directedRelations[l.Relation] {
+			continue
+		}
+		if l.FromService == "" || l.ToService == "" {
+			continue
+		}
+		if l.FromService == l.ToService {
+			continue // self-coupling is not a cycle
+		}
+		if adj[l.FromService] == nil {
+			adj[l.FromService] = make(map[string]bool)
+		}
+		adj[l.FromService][l.ToService] = true
+
+		k := edgeKey{l.FromService, l.ToService}
+		if relsByEdge[k] == nil {
+			relsByEdge[k] = make(map[string]bool)
+		}
+		relsByEdge[k][l.Relation] = true
+	}
+
+	if len(adj) == 0 {
+		return nil
+	}
+
+	// Build sorted adjacency lists for deterministic traversal.
+	adjList := make(map[string][]string, len(adj))
+	allNodes := make(map[string]bool)
+	for u, vs := range adj {
+		allNodes[u] = true
+		list := make([]string, 0, len(vs))
+		for v := range vs {
+			list = append(list, v)
+			allNodes[v] = true
+		}
+		sort.Strings(list)
+		adjList[u] = list
+	}
+
+	sccs := tarjanSCC(allNodes, adjList)
+
+	var cycles []ServiceCycle
+	for _, scc := range sccs {
+		if len(scc) < 2 {
+			continue
+		}
+		member := make(map[string]bool, len(scc))
+		for _, m := range scc {
+			member[m] = true
+		}
+		var edges []ServiceEdge
+		for _, u := range scc {
+			for _, v := range adjList[u] {
+				if !member[v] {
+					continue
+				}
+				relSet := relsByEdge[edgeKey{u, v}]
+				rels := make([]string, 0, len(relSet))
+				for r := range relSet {
+					rels = append(rels, r)
+				}
+				sort.Strings(rels)
+				edges = append(edges, ServiceEdge{From: u, To: v, Relations: rels})
+			}
+		}
+		sort.Strings(scc)
+		sort.Slice(edges, func(i, j int) bool {
+			if edges[i].From != edges[j].From {
+				return edges[i].From < edges[j].From
+			}
+			return edges[i].To < edges[j].To
+		})
+		cycles = append(cycles, ServiceCycle{
+			Members: scc,
+			Edges:   edges,
+			Size:    len(scc),
+		})
+	}
+
+	sort.SliceStable(cycles, func(i, j int) bool {
+		if cycles[i].Size != cycles[j].Size {
+			return cycles[i].Size > cycles[j].Size
+		}
+		mi, mj := "", ""
+		if len(cycles[i].Members) > 0 {
+			mi = cycles[i].Members[0]
+		}
+		if len(cycles[j].Members) > 0 {
+			mj = cycles[j].Members[0]
+		}
+		return mi < mj
+	})
+	return cycles
+}
+
+// tarjanSCC runs Tarjan's iterative strongly-connected-components algorithm
+// over the directed graph described by nodes + sorted adjacency lists. It
+// returns one slice per SCC. Iteration is deterministic given sorted input.
+func tarjanSCC(nodes map[string]bool, adj map[string][]string) [][]string {
+	type nodeState struct {
+		index   int
+		lowlink int
+		onStack bool
+	}
+	state := make(map[string]*nodeState, len(nodes))
+	var stack []string
+	index := 0
+	var sccs [][]string
+
+	type frame struct {
+		u string
+		i int
+	}
+
+	sorted := make([]string, 0, len(nodes))
+	for n := range nodes {
+		sorted = append(sorted, n)
+	}
+	sort.Strings(sorted)
+
+	var dfs []frame
+	for _, start := range sorted {
+		if state[start] != nil {
+			continue
+		}
+		state[start] = &nodeState{index: index, lowlink: index}
+		index++
+		stack = append(stack, start)
+		state[start].onStack = true
+		dfs = append(dfs, frame{u: start})
+
+		for len(dfs) > 0 {
+			top := &dfs[len(dfs)-1]
+			u := top.u
+			neighbours := adj[u]
+			if top.i < len(neighbours) {
+				v := neighbours[top.i]
+				top.i++
+				if sv := state[v]; sv == nil {
+					state[v] = &nodeState{index: index, lowlink: index}
+					index++
+					stack = append(stack, v)
+					state[v].onStack = true
+					dfs = append(dfs, frame{u: v})
+				} else if sv.onStack {
+					if sv.index < state[u].lowlink {
+						state[u].lowlink = sv.index
+					}
+				}
+				continue
+			}
+
+			dfs = dfs[:len(dfs)-1]
+			su := state[u]
+			if len(dfs) > 0 {
+				parent := dfs[len(dfs)-1].u
+				sp := state[parent]
+				if su.lowlink < sp.lowlink {
+					sp.lowlink = su.lowlink
+				}
+			}
+			if su.lowlink == su.index {
+				var scc []string
+				for {
+					w := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					state[w].onStack = false
+					scc = append(scc, w)
+					if w == u {
+						break
+					}
+				}
+				sccs = append(sccs, scc)
+			}
+		}
+	}
+	return sccs
+}

--- a/internal/graph/service_cycles_test.go
+++ b/internal/graph/service_cycles_test.go
@@ -1,0 +1,120 @@
+package graph
+
+import (
+	"reflect"
+	"testing"
+)
+
+// Test_FindServiceCycles_TwoNodeCycle covers the canonical orders↔payments
+// shape: a directed REST `calls` edge one way and a Kafka `publishes_to` edge
+// back, mediated by no shared entity. The two services must form exactly one
+// SCC of size 2.
+func Test_FindServiceCycles_TwoNodeCycle(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "orders", ToService: "payments", Relation: "calls"},
+		{FromService: "payments", ToService: "orders", Relation: "publishes_to"},
+	}
+	got := FindServiceCycles(links)
+	if len(got) != 1 {
+		t.Fatalf("want 1 SCC, got %d: %+v", len(got), got)
+	}
+	if got[0].Size != 2 {
+		t.Fatalf("want size 2, got %d", got[0].Size)
+	}
+	want := []string{"orders", "payments"}
+	if !reflect.DeepEqual(got[0].Members, want) {
+		t.Fatalf("members = %v, want %v", got[0].Members, want)
+	}
+	if len(got[0].Edges) != 2 {
+		t.Fatalf("want 2 internal edges, got %d: %+v", len(got[0].Edges), got[0].Edges)
+	}
+}
+
+// Test_FindServiceCycles_NoCycle ensures a one-way fan-out produces no SCC.
+func Test_FindServiceCycles_NoCycle(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "a", ToService: "b", Relation: "calls"},
+		{FromService: "a", ToService: "c", Relation: "calls"},
+		{FromService: "b", ToService: "c", Relation: "publishes_to"},
+	}
+	if got := FindServiceCycles(links); len(got) != 0 {
+		t.Fatalf("want 0 SCC, got %d: %+v", len(got), got)
+	}
+}
+
+// Test_FindServiceCycles_OneWaySubscriberNotPulledIn mirrors MANIFEST §11.10:
+// `ledger` only consumes payments.settled (payments → ledger) and never calls
+// back. It must NOT join the orders↔payments SCC.
+func Test_FindServiceCycles_OneWaySubscriberNotPulledIn(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "orders", ToService: "payments", Relation: "calls"},
+		{FromService: "payments", ToService: "orders", Relation: "publishes_to"},
+		{FromService: "payments", ToService: "ledger", Relation: "publishes_to"},
+	}
+	got := FindServiceCycles(links)
+	if len(got) != 1 {
+		t.Fatalf("want 1 SCC, got %d: %+v", len(got), got)
+	}
+	for _, m := range got[0].Members {
+		if m == "ledger" {
+			t.Fatalf("ledger must not be in the SCC: %v", got[0].Members)
+		}
+	}
+	if !reflect.DeepEqual(got[0].Members, []string{"orders", "payments"}) {
+		t.Fatalf("members = %v, want [orders payments]", got[0].Members)
+	}
+}
+
+// Test_FindServiceCycles_UndirectedRelationsExcluded ensures shared_label /
+// string_match co-occurrence links cannot fabricate a cycle even when they form
+// a mutual pair.
+func Test_FindServiceCycles_UndirectedRelationsExcluded(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "x", ToService: "y", Relation: "shared_label"},
+		{FromService: "y", ToService: "x", Relation: "shared_label"},
+		{FromService: "x", ToService: "y", Relation: "string_match"},
+		{FromService: "y", ToService: "x", Relation: "string_match"},
+	}
+	if got := FindServiceCycles(links); len(got) != 0 {
+		t.Fatalf("undirected relations must not form a cycle, got %d: %+v", len(got), got)
+	}
+}
+
+// Test_FindServiceCycles_ImportsExcluded ensures cross-repo module imports
+// (build-time coupling, e.g. two services importing each other's shared lib)
+// do NOT form a runtime service cycle.
+func Test_FindServiceCycles_ImportsExcluded(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "p", ToService: "q", Relation: "imports"},
+		{FromService: "q", ToService: "p", Relation: "imports"},
+	}
+	if got := FindServiceCycles(links); len(got) != 0 {
+		t.Fatalf("imports must not form a service cycle, got %d: %+v", len(got), got)
+	}
+}
+
+// Test_FindServiceCycles_SelfEdgeIgnored confirms a self-loop is not a cycle.
+func Test_FindServiceCycles_SelfEdgeIgnored(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "solo", ToService: "solo", Relation: "calls"},
+	}
+	if got := FindServiceCycles(links); len(got) != 0 {
+		t.Fatalf("self-edge must not form a cycle, got %d", len(got))
+	}
+}
+
+// Test_FindServiceCycles_ThreeNodeCycle covers a larger SCC and edge ordering.
+func Test_FindServiceCycles_ThreeNodeCycle(t *testing.T) {
+	links := []ServiceLink{
+		{FromService: "a", ToService: "b", Relation: "calls"},
+		{FromService: "b", ToService: "c", Relation: "calls"},
+		{FromService: "c", ToService: "a", Relation: "publishes_to"},
+	}
+	got := FindServiceCycles(links)
+	if len(got) != 1 || got[0].Size != 3 {
+		t.Fatalf("want one size-3 SCC, got %+v", got)
+	}
+	if !reflect.DeepEqual(got[0].Members, []string{"a", "b", "c"}) {
+		t.Fatalf("members = %v", got[0].Members)
+	}
+}

--- a/internal/mcp/cycles_tools.go
+++ b/internal/mcp/cycles_tools.go
@@ -25,6 +25,7 @@ func (s *Server) handleQualityCycles(_ context.Context, req mcpapi.CallToolReque
 	}
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
 	limit := argInt(req, "limit", 100)
+	repoFilter := argStringSlice(req, "repo_filter")
 
 	type memberDetail struct {
 		EntityID   string  `json:"entity_id"`
@@ -139,12 +140,66 @@ func (s *Server) handleQualityCycles(_ context.Context, req mcpapi.CallToolReque
 		all = all[:limit]
 	}
 
+	// ── Service-level SCC detection (#1502) ──────────────────────────────────
+	// Per-repo IMPORTS cycles above cannot see cross-service coupling that flows
+	// through HTTP-endpoint / topic synthetic nodes. Aggregate the group's
+	// resolved cross-repo links into a directed service graph and run Tarjan SCC
+	// over it so e.g. orders↔payments (REST one way, Kafka the other) surfaces.
+	serviceCycles := buildServiceCycles(lg, repoFilter)
+
 	return jsonResult(map[string]any{
-		"cycles":    all,
-		"count":     len(all),
-		"total":     total,
-		"truncated": total > len(all),
+		"cycles":         all,
+		"count":          len(all),
+		"total":          total,
+		"truncated":      total > len(all),
+		"service_cycles": serviceCycles,
+		"service_count":  len(serviceCycles),
 	}), nil
+}
+
+// buildServiceCycles aggregates a group's cross-repo links into a directed
+// service graph and returns every strongly-connected component of size >= 2.
+//
+// Only directed-dependency relations (calls / imports / publishes_to) feed the
+// graph; undirected co-occurrence relations (shared_label, string_match) are
+// excluded so they cannot manufacture spurious cycles. When repoFilter is set,
+// the graph is restricted to links whose BOTH endpoints are in the filter.
+func buildServiceCycles(lg *LoadedGroup, repoFilter []string) []graph.ServiceCycle {
+	if lg == nil || len(lg.Links) == 0 {
+		return nil
+	}
+	keep := map[string]bool{}
+	for _, r := range repoFilter {
+		keep[r] = true
+	}
+	inFilter := func(repo string) bool {
+		if len(keep) == 0 {
+			return true
+		}
+		return keep[repo]
+	}
+
+	links := make([]graph.ServiceLink, 0, len(lg.Links))
+	for _, l := range lg.Links {
+		rel := l.EffectiveKind()
+		if !graph.IsDirectedServiceRelation(rel) {
+			continue
+		}
+		fromRepo, _ := splitPrefixed(l.Source)
+		toRepo, _ := splitPrefixed(l.Target)
+		if fromRepo == "" || toRepo == "" {
+			continue
+		}
+		if !inFilter(fromRepo) || !inFilter(toRepo) {
+			continue
+		}
+		links = append(links, graph.ServiceLink{
+			FromService: fromRepo,
+			ToService:   toRepo,
+			Relation:    rel,
+		})
+	}
+	return graph.FindServiceCycles(links)
 }
 
 // buildPageRankMap extracts per-entity PageRank scores from a loaded Document.

--- a/internal/mcp/cycles_tools_test.go
+++ b/internal/mcp/cycles_tools_test.go
@@ -1,0 +1,75 @@
+package mcp
+
+import "testing"
+
+// Test_buildServiceCycles_RelationFieldAlias verifies that service-level SCC
+// detection (#1502) reads the on-disk links-pass "relation" field (not just the
+// MCP-candidate "kind" field) so cross-repo links emitted by internal/links
+// surface their direction. The canonical orders↔payments cycle uses
+// relation=calls one way and relation=publishes_to the other.
+func Test_buildServiceCycles_RelationFieldAlias(t *testing.T) {
+	lg := &LoadedGroup{
+		Name: "g",
+		Links: []CrossRepoLink{
+			{Source: "orders::a", Target: "payments::b", Relation: "calls"},
+			{Source: "payments::c", Target: "orders::d", Relation: "publishes_to"},
+		},
+	}
+	cycles := buildServiceCycles(lg, nil)
+	if len(cycles) != 1 || cycles[0].Size != 2 {
+		t.Fatalf("want one size-2 SCC, got %+v", cycles)
+	}
+	if cycles[0].Members[0] != "orders" || cycles[0].Members[1] != "payments" {
+		t.Fatalf("members = %v, want [orders payments]", cycles[0].Members)
+	}
+}
+
+// Test_buildServiceCycles_SharedLabelExcluded confirms undirected shared_label
+// links cannot fabricate a service cycle even as a mutual pair.
+func Test_buildServiceCycles_SharedLabelExcluded(t *testing.T) {
+	lg := &LoadedGroup{
+		Links: []CrossRepoLink{
+			{Source: "a::1", Target: "b::2", Relation: "shared_label"},
+			{Source: "b::3", Target: "a::4", Relation: "shared_label"},
+		},
+	}
+	if got := buildServiceCycles(lg, nil); len(got) != 0 {
+		t.Fatalf("shared_label must not form a cycle, got %+v", got)
+	}
+}
+
+// Test_buildServiceCycles_RepoFilter restricts the service graph to links whose
+// both endpoints fall inside the filter.
+func Test_buildServiceCycles_RepoFilter(t *testing.T) {
+	lg := &LoadedGroup{
+		Links: []CrossRepoLink{
+			{Source: "orders::a", Target: "payments::b", Relation: "calls"},
+			{Source: "payments::c", Target: "orders::d", Relation: "publishes_to"},
+			{Source: "payments::e", Target: "ledger::f", Relation: "publishes_to"},
+		},
+	}
+	// Filter excludes ledger; orders↔payments still cycles, ledger never appears.
+	cycles := buildServiceCycles(lg, []string{"orders", "payments"})
+	if len(cycles) != 1 || cycles[0].Size != 2 {
+		t.Fatalf("want one size-2 SCC, got %+v", cycles)
+	}
+	for _, m := range cycles[0].Members {
+		if m == "ledger" {
+			t.Fatalf("ledger leaked into filtered SCC: %v", cycles[0].Members)
+		}
+	}
+}
+
+// Test_buildServiceCycles_KindFieldStillWorks verifies the legacy "kind" field
+// (MCP-appended candidates) is still honoured.
+func Test_buildServiceCycles_KindFieldStillWorks(t *testing.T) {
+	lg := &LoadedGroup{
+		Links: []CrossRepoLink{
+			{Source: "a::1", Target: "b::2", Kind: "calls"},
+			{Source: "b::3", Target: "a::4", Kind: "publishes_to"},
+		},
+	}
+	if got := buildServiceCycles(lg, nil); len(got) != 1 {
+		t.Fatalf("kind field must still work, got %+v", got)
+	}
+}

--- a/internal/mcp/state.go
+++ b/internal/mcp/state.go
@@ -178,12 +178,27 @@ func (r RegistryRepo) graphFile() string {
 // Per ADR-0009, source/target are written as "<repo>::<localId>". Confidence
 // in [0,1]. Channel/method are free-form labels carried for filtering.
 type CrossRepoLink struct {
-	Source     string  `json:"source"`
-	Target     string  `json:"target"`
+	Source string `json:"source"`
+	Target string `json:"target"`
+	// Kind holds the edge relation. The MCP-appended candidate format writes
+	// "kind"; the links-pass on-disk format (internal/links) writes "relation".
+	// Accept both so service-level SCC detection (#1502) sees pass-emitted
+	// links (calls / imports / publishes_to). Relation is the on-disk alias;
+	// EffectiveKind() collapses them.
 	Kind       string  `json:"kind"`
+	Relation   string  `json:"relation,omitempty"`
 	Confidence float64 `json:"confidence,omitempty"`
 	Channel    string  `json:"channel,omitempty"`
 	Method     string  `json:"method,omitempty"`
+}
+
+// EffectiveKind returns the link's relation, preferring the explicit "kind"
+// field and falling back to the links-pass "relation" field.
+func (l CrossRepoLink) EffectiveKind() string {
+	if l.Kind != "" {
+		return l.Kind
+	}
+	return l.Relation
 }
 
 // LoadedRepo is one repo's graph plus index plus mtime tracking.


### PR DESCRIPTION
## 1. What & why
`archigraph_quality_cycles` runs Tarjan SCC over **IMPORTS** edges per repo. It cannot see cross-service circular dependencies, because cross-service coupling flows through **synthetic boundary nodes**, not direct entity→entity edges:

- `orders → payments` via HTTP `FETCHES` → `http:POST:/charges` endpoint synthetic
- `payments → orders` via Kafka `payments.settled` (payments publishes, orders' `consumer.py` subscribes) → topic node

There are **zero** direct orders-entity → payments-entity edges, so the existing pass reports no SCC even though `polyglot-platform` MANIFEST §11.1 expects exactly one: `orders ↔ payments`.

## 2. What changed
- **`internal/graph/service_cycles.go`** (new): `FindServiceCycles([]ServiceLink) []ServiceCycle` — aggregates directed cross-service links into a repo/service-level graph and runs an iterative Tarjan SCC, returning every SCC of size ≥ 2 with its internal edges (annotated with contributing relations). Decoupled `ServiceLink` input keeps the graph package dependency-free.
- **`internal/mcp/cycles_tools.go`**: `handleQualityCycles` now also builds a service graph from the group's resolved cross-repo links (`lg.Links`, the P1–P7 link-pass output — reused rather than re-aggregated) and reports `service_cycles` / `service_count` alongside the existing import cycles. Honors `repo_filter`.
- **`internal/mcp/state.go`**: `CrossRepoLink` now reads the on-disk links-pass `relation` field (it previously only read `kind`, which the links files don't write) via `EffectiveKind()`; `kind` still wins when present.
- **`cmd/archigraph/xrepo_verify.go`**: prints a service-SCC section so the isolated harness exercises the exact #1502 path on a real fixture.

## 3. Relation selection (avoiding spurious cycles)
Only **directed runtime** relations feed the service graph: `calls` (HTTP/gRPC) and `publishes_to` (topic publisher→subscriber). Excluded:
- `imports` — cross-repo module imports are build-time coupling (shared libs, etc.); including them collapses unrelated services into one giant SCC.
- `shared_label` / `string_match` — undirected co-occurrence; would manufacture cycles.

Self-edges are dropped. Output is fully deterministic (sorted members/edges, descending size).

## 4. Verification (real fixture, isolated, memory-safe)
Built a non-`/tmp` binary and ran `archigraph xrepo-verify` (isolated temp `ARCHIGRAPH_HOME`, never touches the live daemon / `:47274`) over `polyglot-platform`:

- **§11.1 canonical** (`orders` + `payments`): **1 SCC — `[orders payments]`**, edges `orders→payments (calls)` + `payments→orders (publishes_to)`. ✅ matches expected.
- **§11.10 ledger exclusion** (`orders` + `payments` + `ledger`): still **1 SCC — `[orders payments]`**; `ledger` (pure consumer of `payments.settled`, no callback) correctly **NOT** pulled in. ✅

(Note: indexing the entire 26-service platform yields a larger SCC — but every closing edge is MANIFEST-confirmed real coupling, e.g. `billing` is a documented "NEW subscriber of payments.settled" with a real `billing→orders` HTTP call. That is genuine signal, not a false positive of this pass.)

## 5. Tests
- `internal/graph/service_cycles_test.go`: 2-node cycle (orders↔payments shape), 3-node cycle, no-cycle fan-out, one-way subscriber not pulled in (§11.10), undirected relations excluded, imports excluded, self-edge ignored.
- `internal/mcp/cycles_tools_test.go`: `relation`-field aliasing, `kind`-field back-compat, `shared_label` exclusion, repo-filter scoping.
- `go test ./internal/graph/ ./internal/mcp/` green; `go vet` + `gofmt` clean.

## 6. Risk & rollout
Additive: existing `cycles` output unchanged; new keys `service_cycles`/`service_count` appended. The `CrossRepoLink.Relation` alias is backward-compatible (`kind` still honored). No daemon/live-state changes. Do **not** merge — for review.

Fixes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)