### PR TITLE
fix(links): suppress spurious cross-repo imports via shared ext:* placeholders

### DIFF
--- a/internal/links/import_pass.go
+++ b/internal/links/import_pass.go
@@ -138,13 +138,70 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	// the JS repo's `local → ext:log` consults the JS repo's subtype
 	// (function) and the bare-name filter rejects it correctly.
 	subtypeByRepo := map[string]map[string]string{}
+
+	// Issue #1507 — spurious cross-repo imports via shared ext:* placeholders.
+	//
+	// `ext:*` entity IDs are NOT repo-scoped: every repo that references the
+	// same external package emits an entity with the SAME literal ID string.
+	// The first-write-wins assignment of entRepo[extID] = firstRepo produces
+	// an ARBITRARY repo attribution. A subsequent repo whose edge references
+	// the same `ext:*` ID finds a DIFFERENT repo in entRepo, making the edge
+	// look like a cross-repo import when it is an intra-repo reference.
+	//
+	// Concrete failure mode: if orders, analytics, order-saga, and workers all
+	// import `py_shared`, each emits an `ext:py_shared` entity. entRepo assigns
+	// ext:py_shared to whichever repo loaded first (say, analytics). Then every
+	// orders/order-saga/workers edge `local_fn → ext:py_shared` resolves as
+	// fromRepo=X, toRepo=analytics → spurious orders→analytics,
+	// order-saga→analytics, workers→analytics cross-repo links are emitted.
+	//
+	// Fix (two complementary guards):
+	//
+	//  Guard A — repo-name collision: if the base name of the ext:* ID
+	//   (everything after "ext:") exactly matches (case-folded, hyphen/
+	//   underscore normalised) a slug in the indexed group, the external
+	//   placeholder is a proxy for that repo's code. Remove it from entRepo
+	//   entirely so the fromRepo/toRepo guard below treats it as unresolved.
+	//   Example: ext:py_shared with group containing "py-shared" → removed.
+	//   This ensures imports of a grouped library don't produce cross-repo
+	//   links between the consuming services (orders, analytics, etc.) instead
+	//   of to the library itself.
+	//
+	//  Guard B — multi-origin collision: if the same ext:* ID appears in
+	//   MORE THAN ONE distinct repo, its entRepo attribution is arbitrary
+	//   (first-write-wins) and the resulting directional link (e.g.
+	//   orders::create_order → analytics::ext:opentelemetry) is misleading:
+	//   it looks like orders imports from analytics, when both repos simply
+	//   share the same external monitoring lib. Remove any such ext:* ID from
+	//   entRepo. This supersedes the original #566 "two repos share
+	//   ext:axios" behaviour: #566 links were informative but created false
+	//   service-level import edges that confuse the topology view. Issue
+	//   #1507 establishes that cross-repo import edges must represent actual
+	//   code-level dependencies, not shared external-package usage.
+
+	// Build the normalised repo-slug set for Guard A.
+	repoSlugs := make(map[string]struct{}, len(graphs))
+	for _, g := range graphs {
+		repoSlugs[normalizeSlug(g.Repo)] = struct{}{}
+	}
+
+	// extRepos[id] tracks the distinct repos that contain each ext:* entity.
+	extRepos := map[string]map[string]struct{}{}
+
 	for _, g := range graphs {
 		for _, e := range g.Entities {
-			// First write wins on repo: structural ids are stable per
+			// First write wins on repo: structural IDs are stable per
 			// (repo, kind, name, file) so collision across repos is
-			// already disambiguated by the per-repo seed.
+			// already disambiguated by the per-repo seed. The exception
+			// is ext:* IDs — handled by the guards below.
 			if _, ok := entRepo[e.ID]; !ok {
 				entRepo[e.ID] = g.Repo
+			}
+			if strings.HasPrefix(e.ID, "ext:") {
+				if extRepos[e.ID] == nil {
+					extRepos[e.ID] = map[string]struct{}{}
+				}
+				extRepos[e.ID][g.Repo] = struct{}{}
 			}
 			st, ok := subtypeByRepo[g.Repo]
 			if !ok {
@@ -154,6 +211,26 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 			if existing := st[e.ID]; existing == "" && e.Subtype != "" {
 				st[e.ID] = e.Subtype
 			}
+		}
+	}
+
+	// Apply Guard A and Guard B: remove ext:* IDs whose entRepo attribution
+	// would produce spurious cross-repo links.
+	for id, repos := range extRepos {
+		// Guard A: ext:* name matches a repo slug in this group.
+		baseName := id[len("ext:"):]
+		// Strip a qualifier suffix (ext:module:name → base is "module").
+		if colon := strings.IndexByte(baseName, ':'); colon > 0 {
+			baseName = baseName[:colon]
+		}
+		if _, isRepo := repoSlugs[normalizeSlug(baseName)]; isRepo {
+			delete(entRepo, id)
+			continue
+		}
+		// Guard B: same ext:* ID in more than one repo — arbitrary attribution
+		// and misleading directional link (issue #1507).
+		if len(repos) > 1 {
+			delete(entRepo, id)
 		}
 	}
 
@@ -292,6 +369,16 @@ func runImportPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (Pa
 	res.LinksAdded = added
 	res.Skipped = skipped
 	return res, nil
+}
+
+// normalizeSlug folds a repo slug or ext:* base name to a canonical form
+// for comparison. Lowercases and replaces hyphens with underscores so that
+// "py-shared" and "py_shared" are treated as the same slug.
+// Used by runImportPass Guard A (issue #1507).
+func normalizeSlug(s string) string {
+	s = strings.ToLower(s)
+	s = strings.ReplaceAll(s, "-", "_")
+	return s
 }
 
 // normalizedRelation maps a graph relationship Kind to one of the

--- a/internal/links/import_pass_test.go
+++ b/internal/links/import_pass_test.go
@@ -2,6 +2,7 @@ package links
 
 import (
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -47,10 +48,17 @@ func TestImportPass_SkipsBareNameExt(t *testing.T) {
 	}
 }
 
-// TestImportPass_EmitsQualifiedExt verifies the converse: qualified
-// "ext:<module>:<name>" placeholders (e.g. `ext:react:useState`) DO
-// carry real module identity and remain eligible for cross-repo
-// linking when two repos point at the same qualified ID.
+// TestImportPass_EmitsQualifiedExt was the converse of #509: qualified
+// "ext:<module>:<name>" placeholders (e.g. `ext:react:useState`) were
+// eligible for cross-repo linking when two repos referenced the same ID.
+//
+// Issue #1507 supersedes this: any ext:* ID that appears in more than one
+// repo is a shared external placeholder with no stable repo owner; emitting
+// a directional cross-repo link between the two consuming repos (e.g.
+// beta::b_comp → alpha::ext:react:useState) implies beta imports from alpha
+// when in reality both repos independently depend on the react library.
+// Guard B in runImportPass removes all multi-repo ext:* IDs from entRepo,
+// so zero import-method links are emitted in this scenario.
 func TestImportPass_EmitsQualifiedExt(t *testing.T) {
 	root := fixtureRoot(t)
 	writeFixture(t, root, fixtureGraph{
@@ -81,22 +89,29 @@ func TestImportPass_EmitsQualifiedExt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var count int
+	// Guard B (#1507): ext:react:useState appears in both repos → removed
+	// from entRepo → no import-method link is emitted between the two repos.
 	for _, l := range doc.Links {
 		if l.Method == MethodImport {
-			count++
+			t.Errorf("expected zero import-method links for shared ext:react:useState (#1507 Guard B); got %+v", l)
 		}
-	}
-	if count != 1 {
-		t.Fatalf("expected exactly 1 import-method link for ext:react:useState, got %d (%+v)", count, doc.Links)
 	}
 }
 
-// TestImportPass_EmitsSharedPackageExt is the issue #566 fix:
+// TestImportPass_EmitsSharedPackageExt was the issue #566 fix:
 // real npm packages emitted by external-synth as `ext:<package>`
-// (single colon, subtype="package") MUST produce cross-repo links when
-// two repos share the placeholder. #509 was over-aggressive and
-// dropped these alongside true bare-name built-ins.
+// (single colon, subtype="package") produced cross-repo links when two
+// repos shared the placeholder.
+//
+// Issue #1507 supersedes this: the directional cross-repo link
+// (beta::b_local → alpha::ext:axios) was misleading — it implied beta
+// imports from alpha when both repos independently depend on axios.
+// Guard B in runImportPass removes all multi-repo ext:* IDs from entRepo,
+// so zero import-method links are emitted for shared external packages.
+//
+// The isBuiltinExt gate (#509 fix) remains: bare-name ext:* with no
+// subtype=package is still filtered. This test now documents that
+// subtype=package shared ext:* links are also suppressed by Guard B.
 func TestImportPass_EmitsSharedPackageExt(t *testing.T) {
 	root := fixtureRoot(t)
 	writeFixture(t, root, fixtureGraph{
@@ -127,14 +142,12 @@ func TestImportPass_EmitsSharedPackageExt(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var imports []Link
+	// Guard B (#1507): ext:axios appears in both repos → removed from
+	// entRepo → no import-method link is emitted between alpha and beta.
 	for _, l := range doc.Links {
 		if l.Method == MethodImport {
-			imports = append(imports, l)
+			t.Errorf("expected zero import-method links for shared ext:axios (#1507 Guard B); got %+v", l)
 		}
-	}
-	if len(imports) == 0 {
-		t.Fatalf("expected ≥1 import-method links for shared ext:axios (subtype=package), got 0; links=%+v", doc.Links)
 	}
 }
 
@@ -249,11 +262,13 @@ func TestImportPass_SameModuleDifferentName(t *testing.T) {
 	}
 }
 
-// TestImportPass_ScopedNpmPackage covers case (e) of #566:
-// scoped npm packages like `@tanstack/react-query` are emitted as
-// `ext:@tanstack/react-query` — a single-colon ID containing a slash.
-// Pre-#566 the second-colon test dropped these; the subtype="package"
-// admission restores them.
+// TestImportPass_ScopedNpmPackage covers scoped npm packages like
+// `@tanstack/react-query` emitted as `ext:@tanstack/react-query`.
+// Pre-#566 the second-colon test dropped these. Post-#1507 Guard B
+// suppresses the cross-repo link when both repos share the placeholder,
+// because the directional link was misleading (implies alpha imports from
+// beta when both independently depend on the package). Guard B removes any
+// ext:* ID that appears in more than one repo from entRepo.
 func TestImportPass_ScopedNpmPackage(t *testing.T) {
 	root := fixtureRoot(t)
 	writeFixture(t, root, fixtureGraph{
@@ -280,14 +295,12 @@ func TestImportPass_ScopedNpmPackage(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	var imports int
+	// Guard B (#1507): ext:@tanstack/react-query appears in both repos →
+	// removed from entRepo → no import-method link is emitted.
 	for _, l := range doc.Links {
 		if l.Method == MethodImport {
-			imports++
+			t.Errorf("expected zero import-method links for shared scoped npm package (#1507 Guard B); got %+v", l)
 		}
-	}
-	if imports == 0 {
-		t.Fatalf("expected ≥1 import-method links for shared scoped npm package, got 0; links=%+v", doc.Links)
 	}
 }
 
@@ -425,6 +438,173 @@ func TestImportPass_HTTPEndpointDoesNotMatchAcrossDifferentNames(t *testing.T) {
 	for _, l := range doc.Links {
 		if l.Method == MethodImport {
 			t.Errorf("expected no import links for mismatched http_endpoint Names; got %+v", l)
+		}
+	}
+}
+
+// TestImportPass_NoSpuriousLinksViaSharedExtPlaceholder is the regression
+// test for issue #1507. Four repos all import the same Python shared-lib
+// (`py_shared`), producing `ext:py_shared` entities in each. The linker
+// must NOT emit cross-repo links between the consuming services (orders,
+// analytics, order-saga, workers) — those services don't import each other.
+//
+// Guard B (multi-origin): ext:py_shared appears in 4 repos → removed from
+// entRepo → no spurious import links are emitted.
+func TestImportPass_NoSpuriousLinksViaSharedExtPlaceholder(t *testing.T) {
+	root := fixtureRoot(t)
+	services := []string{"orders", "analytics", "order-saga", "workers"}
+	for _, svc := range services {
+		writeFixture(t, root, fixtureGraph{
+			Repo: svc,
+			Entities: []map[string]any{
+				{"id": svc + "_local", "name": "handler", "kind": "function", "source_file": "app/main.py"},
+				// Each service emits an ext:py_shared entity (subtype=package)
+				// when it resolves `import py_shared` through the external synth.
+				{"id": "ext:py_shared", "name": "py_shared", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+			},
+			Edges: []map[string]string{
+				{"from_id": svc + "_local", "to_id": "ext:py_shared", "kind": "imports"},
+			},
+		})
+	}
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g1507-multiservice", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g1507-multiservice-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method != MethodImport {
+			continue
+		}
+		srcRepo := l.Source
+		if i := strings.Index(srcRepo, "::"); i >= 0 {
+			srcRepo = srcRepo[:i]
+		}
+		tgtRepo := l.Target
+		if i := strings.Index(tgtRepo, "::"); i >= 0 {
+			tgtRepo = tgtRepo[:i]
+		}
+		// None of the services import each other — any import link between
+		// two service repos is spurious.
+		for _, s1 := range services {
+			for _, s2 := range services {
+				if s1 != s2 && srcRepo == s1 && tgtRepo == s2 {
+					t.Errorf("spurious import link %s → %s (should be zero); link=%+v", s1, s2, l)
+				}
+			}
+		}
+	}
+}
+
+// TestImportPass_NoSpuriousLinkWhenExtNameMatchesGroupedRepo verifies Guard A
+// (issue #1507): when the base name of an ext:* ID matches a repo slug in the
+// indexed group, the entity is removed from entRepo and no spurious cross-repo
+// import links are produced between the consuming services.
+//
+// Scenario: "py-shared" is an indexed repo. "orders" and "analytics" both
+// emit `ext:py_shared` (guard A normalises hyphens to underscores). The
+// linker must not create orders→analytics or analytics→orders links.
+func TestImportPass_NoSpuriousLinkWhenExtNameMatchesGroupedRepo(t *testing.T) {
+	root := fixtureRoot(t)
+	// The actual shared-lib repo (no edges pointing at ext:py_shared).
+	writeFixture(t, root, fixtureGraph{
+		Repo: "py-shared",
+		Entities: []map[string]any{
+			{"id": "pyshared_order_model", "name": "Order", "kind": "SCOPE.Component", "source_file": "py_shared/models.py"},
+		},
+		Edges: []map[string]string{},
+	})
+	// Consuming services — both emit ext:py_shared as an external placeholder.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders",
+		Entities: []map[string]any{
+			{"id": "orders_handler", "name": "create_order", "kind": "function", "source_file": "app/routes.py"},
+			{"id": "ext:py_shared", "name": "py_shared", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "orders_handler", "to_id": "ext:py_shared", "kind": "imports"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "analytics",
+		Entities: []map[string]any{
+			{"id": "analytics_main", "name": "process", "kind": "function", "source_file": "analytics/main.py"},
+			{"id": "ext:py_shared", "name": "py_shared", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "analytics_main", "to_id": "ext:py_shared", "kind": "imports"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g1507-reponame", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g1507-reponame-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, l := range doc.Links {
+		if l.Method != MethodImport {
+			continue
+		}
+		// No import-method links should exist between the consuming services.
+		srcRepo := l.Source
+		if i := strings.Index(srcRepo, "::"); i >= 0 {
+			srcRepo = srcRepo[:i]
+		}
+		tgtRepo := l.Target
+		if i := strings.Index(tgtRepo, "::"); i >= 0 {
+			tgtRepo = tgtRepo[:i]
+		}
+		if (srcRepo == "orders" && tgtRepo == "analytics") ||
+			(srcRepo == "analytics" && tgtRepo == "orders") {
+			t.Errorf("spurious import link between consuming services %s→%s; link=%+v", srcRepo, tgtRepo, l)
+		}
+	}
+}
+
+// TestImportPass_NoSpuriousLinkTwoReposSharedExt verifies that Guard B
+// suppresses cross-repo links even for the two-repo shared-external case.
+// Previously #566 emitted a link when exactly two repos shared ext:axios;
+// issue #1507 removes this: the directional link (bff::fn → frontend::ext:axios)
+// implies bff imports from frontend when both simply depend on the axios library.
+func TestImportPass_NoSpuriousLinkTwoReposSharedExt(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "frontend",
+		Entities: []map[string]any{
+			{"id": "fe_comp", "name": "FetchUser", "kind": "function", "source_file": "src/api.ts"},
+			{"id": "ext:axios", "name": "axios", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "fe_comp", "to_id": "ext:axios", "kind": "imports"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "bff",
+		Entities: []map[string]any{
+			{"id": "bff_comp", "name": "ProxyRequest", "kind": "function", "source_file": "src/proxy.ts"},
+			{"id": "ext:axios", "name": "axios", "kind": "SCOPE.External", "subtype": "package", "source_file": ""},
+		},
+		Edges: []map[string]string{
+			{"from_id": "bff_comp", "to_id": "ext:axios", "kind": "imports"},
+		},
+	})
+	home := filepath.Join(root, "ag-home")
+	if _, err := RunAllPasses("g1507-twoaxios", root, home); err != nil {
+		t.Fatal(err)
+	}
+	doc, err := readDoc(filepath.Join(home, "groups", "g1507-twoaxios-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Guard B (#1507): ext:axios in both repos → no cross-repo import link.
+	for _, l := range doc.Links {
+		if l.Method == MethodImport {
+			t.Errorf("expected zero import-method links for two-repo shared ext:axios; got %+v", l)
 		}
 	}
 }


### PR DESCRIPTION
## 1. What the bug was

The P1 import pass (`runImportPass`) builds an `entRepo` map (entity ID → repo) using first-write-wins. `ext:*` entity IDs are **not repo-scoped** — every repo that references the same external package emits the same literal ID string (e.g. `ext:py_shared`, `ext:opentelemetry`, `ext:os`). The first-write-wins assignment attributed these IDs to whichever repo happened to load first, producing false directional cross-repo import edges:

- `orders → analytics` (via `ext:opentelemetry` — both repos use OTel, analytics owned it first)
- `py-shared → orders` ×2 (via `ext:os` — orders owned it, py-shared's imports looked like cross-repo calls)
- `order-saga → workers`, `orders → order-saga` (via `ext:json` in 3 repos)

These created misleading topology: orders appeared to import from analytics, py-shared appeared to import from orders, etc.

## 2. Root cause

`ext:*` external placeholder IDs are synthesised by the external synth pass after indexing. They are keyed by package name (`ext:py_shared`, `ext:os`) not by repo. Multiple services sharing the same external dependency each get an entity with the identical ID. The `entRepo` map's first-write-wins logic assigns the ID to a random repo (load-order dependent).

## 3. Fix

Two complementary guards applied after the `entRepo` map is built:

**Guard A — repo-name collision**: If the base name of an `ext:*` ID (normalised, hyphens→underscores) matches a repo slug in the indexed group, the placeholder is a proxy for that library. `ext:py_shared` with "py-shared" in the group → removed from `entRepo`. Services importing the library no longer produce spurious cross-service links.

**Guard B — multi-origin collision**: Any `ext:*` ID that appears in more than one repo is removed from `entRepo`. The first-write-wins attribution was arbitrary; the resulting directional link (`orders::fn → analytics::ext:opentelemetry`) implied a code dependency that doesn't exist. This supersedes the #566 shared-external-package links: those were informative but created misleading topology edges that the #1507 contract explicitly forbids.

## 4. Verification (polyglot-platform, Python services)

Fixture: `orders`, `analytics`, `order-saga`, `workers`, `py-shared`

| | Import links | Details |
|---|---|---|
| **BEFORE** | 7 | 4 spurious: orders→analytics, py-shared→orders×2, orders→order-saga (ext:json), order-saga→workers (unknown) |
| **AFTER** | 3 | All legitimate: order-saga→orders×2 (http_endpoint), order-saga→workers (http_endpoint) |

Spurious removed:
- `orders → analytics` via `ext:opentelemetry` — GONE
- `py-shared → orders` ×2 via `ext:os` — GONE
- `orders → order-saga` via `ext:json` — GONE

Legitimate preserved:
- `order-saga → orders` (http:POST:/orders, http:POST:/charges) — KEPT
- `order-saga → workers` (http:POST:/shipments) — KEPT

## 5. Tests

3 new regression tests:
- `TestImportPass_NoSpuriousLinksViaSharedExtPlaceholder` — Guard B: 4 services share `ext:py_shared`, no cross-service links
- `TestImportPass_NoSpuriousLinkWhenExtNameMatchesGroupedRepo` — Guard A: `ext:py_shared` with "py-shared" as indexed repo
- `TestImportPass_NoSpuriousLinkTwoReposSharedExt` — Guard B: 2-repo shared ext:axios now also suppressed

3 updated #566 tests documenting new behaviour (shared-ext links are now suppressed by Guard B with rationale).

## 6. Behaviour change note

The #566 "two repos share `ext:axios`" feature is intentionally superseded. Those links showed shared external dependencies but used directional edges that implied one service imports from another — confusing in topology view. Guard B removes them. The `isBuiltinExt` gate (#509) remains unchanged.

Fixes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)