### PR TITLE
feat(links): cross-language SAME_AS linker for shared-lib domain models (P8)

### DIFF
--- a/internal/graph/service_cycles.go
+++ b/internal/graph/service_cycles.go
@@ -62,9 +62,10 @@ type ServiceLink struct {
 //     service "importing" another), not service→service
 //     runtime calls. Including them collapses unrelated
 //     services into one giant SCC.
-//   - shared_label /        UNDIRECTED co-occurrence signals (two services
-//     string_match          merely reference the same label / string). Treating
-//     them as edges manufactures spurious cycles.
+//   - shared_label /        UNDIRECTED co-occurrence / identity signals (two
+//     string_match /         services merely reference the same label / string,
+//     same_as                or two shared-lib models are the same concept).
+//     Treating them as edges manufactures spurious cycles.
 var directedRelations = map[string]bool{
 	"calls":        true,
 	"publishes_to": true,

--- a/internal/links/confidence.go
+++ b/internal/links/confidence.go
@@ -40,7 +40,40 @@ const (
 	// stringBandLow / stringBandHigh bracket the P3 low band.
 	stringBandLow  = 0.3
 	stringBandHigh = 0.6
+
+	// sameAsBandLow / sameAsBandHigh bracket the P8 cross-language
+	// SAME_AS band. The pass is heavily gated (shared-lib location +
+	// canonical name + structural field overlap), so even the floor
+	// represents a high-signal identity match. The confidence scales
+	// with the Jaccard field overlap between the two models.
+	sameAsBandLow  = 0.7
+	sameAsBandHigh = 0.98
 )
+
+// ScoreSameAs maps a field-overlap ratio in [0, 1] (Jaccard over
+// normalized field-name sets) to the P8 SAME_AS band. A perfect field
+// match lands near the top; the configured minimum overlap maps to the
+// floor of the band.
+func ScoreSameAs(overlap, minOverlap float64) float64 {
+	if overlap >= 1.0 {
+		return sameAsBandHigh
+	}
+	if minOverlap >= 1.0 {
+		minOverlap = 0.0
+	}
+	span := 1.0 - minOverlap
+	if span <= 0 {
+		return sameAsBandLow
+	}
+	scaled := sameAsBandLow + (overlap-minOverlap)/span*(sameAsBandHigh-sameAsBandLow)
+	if scaled < sameAsBandLow {
+		scaled = sameAsBandLow
+	}
+	if scaled > sameAsBandHigh {
+		scaled = sameAsBandHigh
+	}
+	return scaled
+}
 
 // ScoreImport returns the confidence for a P1 (import/calls) link.
 func ScoreImport() float64 { return ImportConfidence }

--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -5,11 +5,17 @@
 // candidates.json sidecar for mid-confidence matches and a
 // rejections.json file used to suppress already-rejected candidates.
 //
-// Three pass kinds:
+// Pass kinds:
 //
 //   - P1 (import_pass.go) — structural cross-repo imports/calls edges
 //   - P2 (label_pass.go) — TF-IDF + kind-compat shared-label match
 //   - P3 (string_pass.go) — string-pattern catalog (HTTP routes, ARNs, etc.)
+//   - P4 (http_pass.go) — HTTP route ↔ fetch matcher
+//   - P5 (openapi_pass.go) — OpenAPI spec → HTTP route linker
+//   - P6 (grpc_pass.go) — gRPC client-stub → server-impl linker
+//   - P7 (topic_pass.go) — message-topic publisher ↔ subscriber linker
+//   - P8 (sameas_pass.go) — cross-language SAME_AS linker for shared-lib
+//     domain models
 //
 // All passes are idempotent and method-segregated: re-running a pass only
 // rewrites the entries whose `method` matches that pass; entries from
@@ -39,6 +45,10 @@ const (
 	RelationImports     = "imports"
 	RelationSharedLabel = "shared_label"
 	RelationStringMatch = "string_match"
+	// RelationSameAs marks an undirected cross-language identity edge
+	// between two shared-library domain models that represent the same
+	// concept (emitted by the P8 same-as pass — see sameas_pass.go).
+	RelationSameAs = "same_as"
 )
 
 // Method values identify which pass produced an entry. Method-segregated
@@ -270,6 +280,17 @@ func RunAllPasses(group, graphsDir, archigraphHome string) (*RunResult, error) {
 		return nil, fmt.Errorf("topic pass: %w", err)
 	}
 	res.Results = append(res.Results, p7)
+
+	// P8 — cross-language SAME_AS linker for shared-library domain models.
+	// Conservatively links same-named domain models (Component/Model/Schema
+	// kinds) that live in shared-lib repos and share enough field names to
+	// be the same concept across languages (e.g. py-shared Order ↔
+	// js-shared Order). See sameas_pass.go.
+	p8, err := runSameAsPass(graphs, paths, rejects)
+	if err != nil {
+		return nil, fmt.Errorf("same-as pass: %w", err)
+	}
+	res.Results = append(res.Results, p8)
 
 	for _, r := range res.Results {
 		res.TotalLinks += r.LinksAdded

--- a/internal/links/sameas_pass.go
+++ b/internal/links/sameas_pass.go
@@ -1,0 +1,395 @@
+package links
+
+import (
+	"sort"
+	"strings"
+)
+
+// sameas_pass.go implements P8 — the cross-language SAME_AS linker for
+// shared-library domain models.
+//
+// Problem (deferred from #1501): a domain model defined once per language
+// in the shared libs — e.g. `Order` in libs/py-shared/py_shared/models.py
+// and `Order` in libs/js-shared/src/types.ts — represents ONE concept but
+// has no edge connecting the two. Cross-language entity resolution (and
+// any "where is this model used across the platform" query) therefore
+// can't see that they are the same thing.
+//
+// This pass emits an undirected, symmetric `SAME_AS` edge (method=same_as,
+// relation=same_as) between such models. It is intentionally CONSERVATIVE:
+// a same-named `Config` struct living in two unrelated services must NOT
+// be merged. Three gates must all pass:
+//
+//	(a) Domain-model kind — the entity is a class/struct/interface-like
+//	    type (kind in Component/Model/Schema; see isDomainModelKind).
+//	(b) Shared-lib location — the owning repo is a shared contract / model
+//	    library (py-shared, js-shared, go-shared, contracts, *-common, …;
+//	    see isSharedLibRepo).
+//	(c) Structural overlap — the two models share at least
+//	    sameAsMinFieldOverlap of their normalized field names (Jaccard),
+//	    so two coincidentally same-named shells don't link.
+//
+// Both endpoints must be in DIFFERENT repos (cross-language is the whole
+// point) and share the same canonical (normalized) name.
+//
+// Idempotency: method-segregated on MethodSameAs. Re-running P8 rewrites
+// only same_as entries; output from P1–P7 is preserved.
+
+// MethodSameAs identifies this pass's emissions in links.json.
+const MethodSameAs = "same_as"
+
+const (
+	// sameAsMinFieldOverlap is the minimum Jaccard overlap of normalized
+	// field-name sets required to emit a SAME_AS link. Below this (but
+	// above zero) the pair is recorded as a candidate, not a link.
+	sameAsMinFieldOverlap = 0.5
+
+	// sameAsCandidateFloor is the field-overlap floor below which a pair
+	// is dropped entirely (not even a candidate). A name-only match with
+	// no structural support is too weak to surface.
+	sameAsCandidateFloor = 0.25
+)
+
+// sharedLibRepoMarkers are substrings (lowercased) that identify a repo as
+// a shared contract / domain-model library. Matched against the repo slug.
+var sharedLibRepoMarkers = []string{
+	"shared",
+	"contracts",
+	"contract",
+	"common",
+	"commons",
+	"proto",
+	"protos",
+	"schemas",
+	"domain-models",
+	"models-shared",
+}
+
+// isSharedLibRepo reports whether a repo slug looks like a shared
+// contract / domain-model library. Gate (b).
+func isSharedLibRepo(repo string) bool {
+	r := strings.ToLower(repo)
+	for _, m := range sharedLibRepoMarkers {
+		if r == m || strings.Contains(r, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// domainModelKinds are the entity kinds that represent a structured
+// domain type eligible for SAME_AS linking. Compared case-insensitively
+// against both the bare kind ("Model") and the SCOPE.* form
+// ("SCOPE.Component", "SCOPE.Schema"). Gate (a).
+var domainModelKinds = map[string]bool{
+	"component": true,
+	"model":     true,
+	"schema":    true,
+}
+
+// modelSubtypes are the entity subtypes that confirm a structured type
+// (vs. a field, enum-member, or other leaf). When an entity carries one
+// of these subtypes it is treated as a model regardless of kind; when it
+// carries a leaf subtype (field/member/...) it is rejected.
+var modelSubtypes = map[string]bool{
+	"class":     true,
+	"struct":    true,
+	"interface": true,
+	"type":      true,
+	"record":    true,
+	"protocol":  true,
+	"trait":     true,
+	"dataclass": true,
+	"":          true, // bare Model entities have no subtype
+}
+
+// leafSubtypes are subtypes that mark a leaf member (a field of a model,
+// an enum value, …) and must never be linked as a model in their own
+// right — this is what stops `Order.id` ↔ `Order.id` false links.
+var leafSubtypes = map[string]bool{
+	"field":       true,
+	"member":      true,
+	"value":       true,
+	"enum_member": true,
+	"property":    true,
+	"attribute":   true,
+	"constant":    true,
+}
+
+// isDomainModelKind applies gate (a): the entity must be a structured
+// model type, not a field / enum member / function. It accepts the bare
+// kind, the SCOPE.* kind tail, and the subtype.
+func isDomainModelKind(kind, subtype string) bool {
+	sub := strings.ToLower(strings.TrimSpace(subtype))
+	if leafSubtypes[sub] {
+		return false
+	}
+	k := strings.ToLower(strings.TrimSpace(kind))
+	// Strip a leading "scope." namespace ("SCOPE.Component" → "component").
+	if i := strings.LastIndex(k, "."); i >= 0 {
+		k = k[i+1:]
+	}
+	if !domainModelKinds[k] {
+		return false
+	}
+	// A recognised model kind plus a non-leaf subtype passes. Reject odd
+	// subtypes that aren't in modelSubtypes to stay conservative.
+	return modelSubtypes[sub]
+}
+
+// canonicalModelName normalizes a model's type name for cross-language
+// matching: case-folded, whitespace-trimmed, with line-number artefacts
+// dropped (see #511). Unlike normalizeLabel (P2) it deliberately does NOT
+// apply the generic-noise stoplist — legitimate shared domain models are
+// frequently named `User`, `Config`, `Item`, `Order`, etc., and the P8
+// pass relies on the shared-lib-location and structural-field-overlap
+// gates (not a name blocklist) to avoid false merges. Suffix-stripping
+// (`OrderDTO` ↔ `Order`) is intentionally omitted too: it would let
+// structurally-different shells collide on a coincidental stem.
+func canonicalModelName(name string) string {
+	s := strings.TrimSpace(name)
+	if s == "" {
+		return ""
+	}
+	if lineNumberSuffix.MatchString(s) {
+		return ""
+	}
+	return strings.ToLower(s)
+}
+
+// normalizeFieldName lowercases and strips non-alphanumerics so that
+// snake_case and camelCase variants of the same field collapse together
+// (`user_id` and `userId` → `userid`). This is what lets a Python model
+// and its TypeScript twin be recognised as structurally identical.
+func normalizeFieldName(name string) string {
+	// Drop any "Owner." prefix (field entities are named "Order.user_id").
+	if i := strings.LastIndex(name, "."); i >= 0 {
+		name = name[i+1:]
+	}
+	var b strings.Builder
+	for _, r := range strings.ToLower(name) {
+		if (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') {
+			b.WriteByte(byte(r))
+		}
+	}
+	return b.String()
+}
+
+// modelEntity is a chosen representative model for a (repo, canonicalName)
+// plus its derived normalized field-name set.
+type modelEntity struct {
+	repo   string
+	node   entityNode
+	fields map[string]bool
+}
+
+// fieldsForModel derives the normalized field-name set for a model from
+// two possible representations the extractors emit:
+//
+//   - a `fields` property holding a comma-separated list (TypeScript
+//     interfaces, some schema extractors); or
+//   - child field entities reachable via CONTAINS edges whose name is
+//     "<Model>.<field>" and whose subtype is a leaf (Python classes, Go
+//     structs).
+//
+// The union of both is returned (a model may use either or both).
+func fieldsForModel(g repoGraph, model entityNode, childrenByParent map[string][]entityNode) map[string]bool {
+	out := map[string]bool{}
+
+	// Representation 1: comma-separated `fields` property.
+	if model.Properties != nil {
+		if raw, ok := model.Properties["fields"]; ok && raw != "" {
+			for _, f := range strings.Split(raw, ",") {
+				if n := normalizeFieldName(f); n != "" {
+					out[n] = true
+				}
+			}
+		}
+	}
+
+	// Representation 2: child field entities (CONTAINS → leaf).
+	for _, child := range childrenByParent[model.ID] {
+		sub := strings.ToLower(strings.TrimSpace(child.Subtype))
+		if !leafSubtypes[sub] {
+			continue
+		}
+		// Only count children that belong to this model: their name is
+		// "<ModelName>.<field>" (defensive — the CONTAINS edge already
+		// scopes this, but module-level containers also use CONTAINS).
+		if !strings.HasPrefix(child.Name, model.Name+".") {
+			continue
+		}
+		if n := normalizeFieldName(child.Name); n != "" {
+			out[n] = true
+		}
+	}
+	return out
+}
+
+// jaccard returns |a ∩ b| / |a ∪ b| for two string sets. Empty/empty → 0.
+func jaccard(a, b map[string]bool) float64 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	inter := 0
+	for k := range a {
+		if b[k] {
+			inter++
+		}
+	}
+	union := len(a) + len(b) - inter
+	if union == 0 {
+		return 0
+	}
+	return float64(inter) / float64(union)
+}
+
+// runSameAsPass implements P8.
+func runSameAsPass(graphs []repoGraph, paths Paths, rejects map[string]bool) (PassResult, error) {
+	res := PassResult{Pass: "same_as"}
+
+	if len(graphs) < 2 {
+		// Keep idempotency clean even with nothing to do.
+		_, _, err := replaceByMethod(paths.Links, newMethodSet(MethodSameAs), nil, rejects)
+		if err != nil {
+			return res, err
+		}
+		_, _, err = replaceByMethod(paths.Candidates, newMethodSet(MethodSameAs), nil, rejects)
+		return res, err
+	}
+
+	// Collect candidate model entities per shared-lib repo, indexed by
+	// canonical name. Only entities passing gates (a) + (b) are kept.
+	// byName: canonicalName → []modelEntity.
+	byName := map[string][]modelEntity{}
+
+	for _, g := range graphs {
+		if !isSharedLibRepo(g.Repo) {
+			continue // gate (b)
+		}
+
+		// Build CONTAINS child index for this repo (parent ID → children).
+		childrenByParent := map[string][]entityNode{}
+		nodeByID := map[string]entityNode{}
+		for _, e := range g.Entities {
+			nodeByID[e.ID] = e
+		}
+		for _, edge := range g.Edges {
+			if !strings.EqualFold(edge.Kind, "CONTAINS") {
+				continue
+			}
+			if child, ok := nodeByID[edge.ToID]; ok {
+				childrenByParent[edge.FromID] = append(childrenByParent[edge.FromID], child)
+			}
+		}
+
+		// One representative per (canonicalName) in this repo. Several
+		// entities may describe the same model (a bare `Model` plus a
+		// `SCOPE.Component`); prefer the one that yields the most fields,
+		// breaking ties by entity-ID for determinism.
+		repByName := map[string]modelEntity{}
+		for _, e := range g.Entities {
+			if !isDomainModelKind(e.Kind, e.Subtype) { // gate (a)
+				continue
+			}
+			canon := canonicalModelName(e.Name)
+			if canon == "" {
+				continue
+			}
+			fields := fieldsForModel(g, e, childrenByParent)
+			cand := modelEntity{repo: g.Repo, node: e, fields: fields}
+			cur, ok := repByName[canon]
+			if !ok ||
+				len(cand.fields) > len(cur.fields) ||
+				(len(cand.fields) == len(cur.fields) && cand.node.ID < cur.node.ID) {
+				repByName[canon] = cand
+			}
+		}
+		for canon, m := range repByName {
+			byName[canon] = append(byName[canon], m)
+		}
+	}
+
+	now := discoveredAt()
+	var freshLinks, freshCands []Link
+
+	// Stable iteration over canonical names.
+	names := make([]string, 0, len(byName))
+	for k := range byName {
+		names = append(names, k)
+	}
+	sort.Strings(names)
+
+	seenPair := map[string]bool{}
+
+	for _, canon := range names {
+		models := byName[canon]
+		if len(models) < 2 {
+			continue // need the same model in ≥2 shared-lib repos
+		}
+		// Stable order across repos.
+		sort.Slice(models, func(i, j int) bool {
+			if models[i].repo != models[j].repo {
+				return models[i].repo < models[j].repo
+			}
+			return models[i].node.ID < models[j].node.ID
+		})
+
+		for i := 0; i < len(models); i++ {
+			for j := i + 1; j < len(models); j++ {
+				a, b := models[i], models[j]
+				if a.repo == b.repo {
+					continue // intra-repo same-name is not cross-language
+				}
+
+				// Gate (c): structural field overlap.
+				overlap := jaccard(a.fields, b.fields)
+				if overlap < sameAsCandidateFloor {
+					continue // too weak — drop entirely (false-merge guard)
+				}
+
+				sa := entityKey(a.repo, a.node.ID)
+				sb := entityKey(b.repo, b.node.ID)
+				src, tgt := orderEndpoints(sa, sb)
+				pairKey := src + "|" + tgt
+				if seenPair[pairKey] {
+					continue
+				}
+				seenPair[pairKey] = true
+
+				ident := canon
+				link := Link{
+					ID:           MakeID(src, tgt, MethodSameAs),
+					Source:       src,
+					Target:       tgt,
+					Relation:     RelationSameAs,
+					Method:       MethodSameAs,
+					Confidence:   ScoreSameAs(overlap, sameAsMinFieldOverlap),
+					Channel:      nil,
+					Identifier:   &ident,
+					DiscoveredAt: now,
+				}
+				if overlap >= sameAsMinFieldOverlap {
+					freshLinks = append(freshLinks, link)
+				} else {
+					link.Reason = "same_as field overlap below link threshold"
+					freshCands = append(freshCands, link)
+				}
+			}
+		}
+	}
+
+	added, skipped, err := replaceByMethod(paths.Links, newMethodSet(MethodSameAs), freshLinks, rejects)
+	if err != nil {
+		return res, err
+	}
+	cAdded, cSkipped, err := replaceByMethod(paths.Candidates, newMethodSet(MethodSameAs), freshCands, rejects)
+	if err != nil {
+		return res, err
+	}
+
+	res.LinksAdded = added
+	res.Candidates = cAdded
+	res.Skipped = skipped + cSkipped
+	return res, nil
+}

--- a/internal/links/sameas_pass_test.go
+++ b/internal/links/sameas_pass_test.go
@@ -1,0 +1,245 @@
+package links
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+// sameAsLinks returns every SAME_AS (method=same_as) link in the group's
+// links.json, keyed by ordered "source|target".
+func sameAsLinks(t *testing.T, home, group string) map[string]Link {
+	t.Helper()
+	doc, err := readDoc(filepath.Join(home, "groups", group+"-links.json"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	out := map[string]Link{}
+	for _, l := range doc.Links {
+		if l.Method == MethodSameAs {
+			out[l.Source+"|"+l.Target] = l
+		}
+	}
+	return out
+}
+
+// TestSameAsPass_SharedDomainModelLinks (positive) — the same domain model
+// defined in two shared-lib repos (Python class + TypeScript interface)
+// with overlapping field names must be linked with a single SAME_AS edge.
+func TestSameAsPass_SharedDomainModelLinks(t *testing.T) {
+	root := fixtureRoot(t)
+
+	// Python shared lib: Order class with field children via CONTAINS.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "py-shared",
+		Entities: []map[string]any{
+			{"id": "o", "name": "Order", "kind": "SCOPE.Component", "subtype": "class", "source_file": "py_shared/models.py"},
+			{"id": "f1", "name": "Order.id", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "py_shared/models.py"},
+			{"id": "f2", "name": "Order.user_id", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "py_shared/models.py"},
+			{"id": "f3", "name": "Order.total_cents", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "py_shared/models.py"},
+		},
+		Edges: []map[string]string{
+			{"from_id": "o", "to_id": "f1", "kind": "CONTAINS"},
+			{"from_id": "o", "to_id": "f2", "kind": "CONTAINS"},
+			{"from_id": "o", "to_id": "f3", "kind": "CONTAINS"},
+		},
+	})
+
+	// JS shared lib: Order interface with comma-separated `fields` property.
+	// camelCase variants must normalize to the snake_case Python ones.
+	writeFixture(t, root, fixtureGraph{
+		Repo: "js-shared",
+		Entities: []map[string]any{
+			{
+				"id":          "o",
+				"name":        "Order",
+				"kind":        "SCOPE.Schema",
+				"subtype":     "interface",
+				"source_file": "src/types.ts",
+				"properties":  map[string]any{"fields": "id, userId, totalCents"},
+			},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-sa-pos")
+	if _, err := RunAllPasses("sapos", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	links := sameAsLinks(t, home, "sapos")
+	if len(links) != 1 {
+		t.Fatalf("expected exactly 1 SAME_AS link, got %d: %+v", len(links), links)
+	}
+	for _, l := range links {
+		if l.Relation != RelationSameAs {
+			t.Errorf("relation = %q, want %q", l.Relation, RelationSameAs)
+		}
+		if l.Identifier == nil || *l.Identifier != "order" {
+			t.Errorf("identifier = %v, want \"order\"", l.Identifier)
+		}
+		// Perfect field overlap → top of the band.
+		if l.Confidence < sameAsBandHigh-1e-9 {
+			t.Errorf("confidence = %v, want ~%v (full overlap)", l.Confidence, sameAsBandHigh)
+		}
+		// Endpoints must be ordered and cross-repo.
+		if l.Source >= l.Target {
+			t.Errorf("endpoints not ordered: %s !< %s", l.Source, l.Target)
+		}
+	}
+}
+
+// TestSameAsPass_UnrelatedConfigNotMerged (negative) — two same-named
+// `Config` types in two NON-shared service repos must NOT be linked, even
+// though they share a name. The shared-lib gate alone excludes them.
+func TestSameAsPass_UnrelatedConfigNotMerged(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "orders", // a service, not a shared lib
+		Entities: []map[string]any{
+			{"id": "c", "name": "Config", "kind": "SCOPE.Component", "subtype": "class", "source_file": "orders/config.py"},
+			{"id": "f1", "name": "Config.db_url", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "orders/config.py"},
+			{"id": "f2", "name": "Config.timeout", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "orders/config.py"},
+		},
+		Edges: []map[string]string{
+			{"from_id": "c", "to_id": "f1", "kind": "CONTAINS"},
+			{"from_id": "c", "to_id": "f2", "kind": "CONTAINS"},
+		},
+	})
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "billing", // another service, identical type name
+		Entities: []map[string]any{
+			{"id": "c", "name": "Config", "kind": "SCOPE.Component", "subtype": "class", "source_file": "billing/config.go"},
+			{"id": "f1", "name": "Config.db_url", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "billing/config.go"},
+			{"id": "f2", "name": "Config.timeout", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "billing/config.go"},
+		},
+		Edges: []map[string]string{
+			{"from_id": "c", "to_id": "f1", "kind": "CONTAINS"},
+			{"from_id": "c", "to_id": "f2", "kind": "CONTAINS"},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-sa-neg1")
+	if _, err := RunAllPasses("saneg1", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	if links := sameAsLinks(t, home, "saneg1"); len(links) != 0 {
+		t.Fatalf("expected 0 SAME_AS links for unrelated service Configs, got %d: %+v", len(links), links)
+	}
+}
+
+// TestSameAsPass_SharedButStructurallyDisjointNotMerged (negative) — two
+// same-named types living in shared-lib repos but with NO overlapping
+// field names must NOT be merged: passing the location + name gates is not
+// enough; the structural-overlap gate must fail them.
+func TestSameAsPass_SharedButStructurallyDisjointNotMerged(t *testing.T) {
+	root := fixtureRoot(t)
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "py-shared",
+		Entities: []map[string]any{
+			{"id": "s", "name": "Settings", "kind": "SCOPE.Component", "subtype": "class", "source_file": "py_shared/settings.py"},
+			{"id": "f1", "name": "Settings.alpha", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "py_shared/settings.py"},
+			{"id": "f2", "name": "Settings.beta", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "py_shared/settings.py"},
+		},
+		Edges: []map[string]string{
+			{"from_id": "s", "to_id": "f1", "kind": "CONTAINS"},
+			{"from_id": "s", "to_id": "f2", "kind": "CONTAINS"},
+		},
+	})
+
+	writeFixture(t, root, fixtureGraph{
+		Repo: "js-shared",
+		Entities: []map[string]any{
+			{
+				"id":          "s",
+				"name":        "Settings",
+				"kind":        "SCOPE.Schema",
+				"subtype":     "interface",
+				"source_file": "src/settings.ts",
+				"properties":  map[string]any{"fields": "gamma, delta, epsilon"},
+			},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-sa-neg2")
+	if _, err := RunAllPasses("saneg2", root, home); err != nil {
+		t.Fatal(err)
+	}
+
+	if links := sameAsLinks(t, home, "saneg2"); len(links) != 0 {
+		t.Fatalf("expected 0 SAME_AS links for structurally-disjoint shared types, got %d: %+v", len(links), links)
+	}
+}
+
+// TestSameAsPass_FieldEntitiesNeverLinked (negative) — leaf field entities
+// (Order.id in two repos) must never themselves be linked as models.
+func TestSameAsPass_FieldEntitiesNeverLinked(t *testing.T) {
+	root := fixtureRoot(t)
+
+	for _, repo := range []string{"py-shared", "js-shared"} {
+		writeFixture(t, root, fixtureGraph{
+			Repo: repo,
+			Entities: []map[string]any{
+				{"id": "f", "name": "Order.id", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "models"},
+			},
+		})
+	}
+
+	home := filepath.Join(root, "ag-home-sa-neg3")
+	if _, err := RunAllPasses("saneg3", root, home); err != nil {
+		t.Fatal(err)
+	}
+	if links := sameAsLinks(t, home, "saneg3"); len(links) != 0 {
+		t.Fatalf("expected 0 SAME_AS links for bare field entities, got %d: %+v", len(links), links)
+	}
+}
+
+// TestSameAsPass_Idempotent — re-running the pass yields a stable set of
+// links (method-segregated overwrite, deterministic ids).
+func TestSameAsPass_Idempotent(t *testing.T) {
+	root := fixtureRoot(t)
+	writeFixture(t, root, fixtureGraph{
+		Repo: "py-shared",
+		Entities: []map[string]any{
+			{"id": "o", "name": "Money", "kind": "SCOPE.Component", "subtype": "class", "source_file": "m.py"},
+			{"id": "f1", "name": "Money.amount", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "m.py"},
+			{"id": "f2", "name": "Money.currency", "kind": "SCOPE.Schema", "subtype": "field", "source_file": "m.py"},
+		},
+		Edges: []map[string]string{
+			{"from_id": "o", "to_id": "f1", "kind": "CONTAINS"},
+			{"from_id": "o", "to_id": "f2", "kind": "CONTAINS"},
+		},
+	})
+	writeFixture(t, root, fixtureGraph{
+		Repo: "contracts",
+		Entities: []map[string]any{
+			{
+				"id": "o", "name": "Money", "kind": "SCOPE.Schema", "subtype": "interface",
+				"source_file": "money.ts", "properties": map[string]any{"fields": "amount, currency"},
+			},
+		},
+	})
+
+	home := filepath.Join(root, "ag-home-sa-idem")
+	if _, err := RunAllPasses("saidem", root, home); err != nil {
+		t.Fatal(err)
+	}
+	first := sameAsLinks(t, home, "saidem")
+	if len(first) != 1 {
+		t.Fatalf("first run: expected 1 link, got %d", len(first))
+	}
+	if _, err := RunAllPasses("saidem", root, home); err != nil {
+		t.Fatal(err)
+	}
+	second := sameAsLinks(t, home, "saidem")
+	if len(second) != 1 {
+		t.Fatalf("second run: expected 1 link, got %d", len(second))
+	}
+	for k, l := range first {
+		if l2, ok := second[k]; !ok || l2.ID != l.ID {
+			t.Errorf("link %s not stable across runs", k)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1509

## 1. What & why
Same-named domain models defined once per language in the shared libs — `Order` in `libs/py-shared/py_shared/models.py` and `Order` in `libs/js-shared/src/types.ts`, plus `User`, `OrderItem`, `Money`, etc. — represent ONE concept but had no edge connecting them, so cross-language entity resolution (and "where is this model used across the platform" queries) couldn't see they are the same thing. This adds **P8**, a conservative cross-repo link pass that emits an undirected, symmetric `SAME_AS` edge between such models.

## 2. Approach
A new pass `internal/links/sameas_pass.go` (`runSameAsPass`) wired into `RunAllPasses` after P7, method-segregated on `MethodSameAs` (`same_as`) for idempotency — exactly like the existing P1–P7 passes. A pair is linked only if **all three gates** pass:

- **(a) domain-model kind** — entity kind in Component/Model/Schema with a non-leaf subtype (`isDomainModelKind`); leaf subtypes (`field`/`member`/`value`/…) are rejected so `Order.id` can never link to `Order.id`.
- **(b) shared-lib location** — owning repo slug matches a shared-lib marker (`shared`/`contracts`/`common`/`proto`/`schemas`/…) via `isSharedLibRepo`. A local `Config` in two services is never even considered.
- **(c) structural field overlap** — Jaccard overlap of normalized field-name sets ≥ 0.5. Field names are folded (`user_id` ≡ `userId` → `userid`) and derived from either a comma-separated `fields` property (TS interfaces) **or** child field-entities via `CONTAINS` edges (Python classes / Go structs).

Endpoints must be in **different** repos and share the same canonical name. Confidence scales with field overlap into a high band [0.7, 0.98] (`ScoreSameAs`). Crucially, P8 uses its own `canonicalModelName` (not P2's `normalizeLabel`) so legitimate generic-but-real domain names like `User`/`Config`/`Item` are NOT stoplisted — the structural + location gates, not a name blocklist, are what prevent false merges.

## 3. Files changed
- `internal/links/sameas_pass.go` — new pass (gates, field derivation, Jaccard, emission).
- `internal/links/links.go` — `RelationSameAs` const, P8 wired into `RunAllPasses`, package doc updated.
- `internal/links/confidence.go` — `ScoreSameAs` + SAME_AS band.
- `internal/graph/service_cycles.go` — doc note: `same_as` is undirected (already excluded from cycle detection via the directed-relation allowlist).
- `internal/links/sameas_pass_test.go` — unit tests.

## 4. Verification (real fixture, isolated, memory-safe)
Isolated index of `polyglot-platform` (all 22 repos staged via symlink into a temp dir, temp `$HOME`, no `/tmp` build, live :47274 untouched). Result — exactly **3 SAME_AS edges, zero false merges**:

| edge | identifier | confidence |
|---|---|---|
| js-shared:User ↔ py-shared:User | user | 0.98 |
| js-shared:OrderItem ↔ py-shared:OrderItem | orderitem | 0.98 |
| js-shared:Order ↔ py-shared:Order | order | 0.98 |

**Near-misses deliberately excluded:** go-shared `OrderRef` (different canonical name → no link to `Order`). No same-named domain model recurs across any non-shared service repos in this fixture, so the shared-lib gate had nothing to wrongly merge.

## 5. Tests
`go test ./internal/links/ ./internal/graph/` — all green. New tests:
- positive: shared `Order` (py class + JS interface, camel/snake folded) → one SAME_AS link at top-of-band confidence.
- negative: two unrelated service `Config` types → no link (shared-lib gate).
- negative: two shared-lib `Settings` with disjoint fields → no link (structural gate).
- negative: bare `Order.id` field entities → never linked.
- idempotency: re-running yields stable ids/links.

## 6. Risk & rollout
Low risk: additive, method-segregated pass; no change to P1–P7 output. Conservative-by-design (three AND-gates) — biased toward missing a link rather than fabricating one. `same_as` is undirected and excluded from service-cycle detection. Re-running is idempotent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)