### PR TITLE
feat(api-v2): real REST wrappers over CLI-only ops + async action jobs (Fixes #1512)

### DIFF
--- a/internal/dashboard/API_V2.md
+++ b/internal/dashboard/API_V2.md
@@ -236,6 +236,94 @@ v1 `GET /api/graph/{group}/entity/{id}` (unchanged, raw JSON).
 
 ---
 
+## 6c. Action endpoints + async-job convention (#1512)
+
+The Operations + Settings screens trigger CLI-equivalent mutating actions.
+Every such endpoint is a thin REST wrapper over the SAME internal function the
+corresponding `archigraph` CLI command calls — no logic is duplicated.
+
+### Async jobs (rebuild / reset)
+
+Indexing is long-running and MUST NOT block the HTTP handler — the daemon has
+to keep serving reads while a rebuild runs (the #1487 serving-mutex invariant).
+So rebuild/reset endpoints are **asynchronous**:
+
+1. The handler validates the group, fires the daemon `Rebuild` RPC in a
+   background goroutine (same path as the CLI), and returns **`202 Accepted`**
+   immediately with a job id.
+2. Clients poll **`GET /api/v2/jobs/{id}`** or subscribe to the SSE feed
+   **`GET /api/v2/jobs/{id}/stream`** to track status.
+
+**202 ack body** (`v2OK` envelope):
+
+```json
+{ "ok": true, "data": {
+  "job_id": "aj-1716300000000000000",
+  "op": "rebuild",                   // "rebuild" | "reset"
+  "group": "acme",
+  "repo": "core",                    // omitted for whole-group rebuild
+  "status": "queued",
+  "progress_token": "web-1716300000000",
+  "status_url": "/api/v2/jobs/aj-...",
+  "stream_url": "/api/v2/jobs/aj-.../stream"
+}}
+```
+
+**Job shape** (`GET /api/v2/jobs/{id}`):
+
+```json
+{ "ok": true, "data": {
+  "id": "aj-...", "op": "rebuild", "group": "acme", "repo": "core",
+  "status": "running",               // queued | running | done | failed
+  "progress": 5,                     // 0..100, coarse
+  "message": "indexing started",
+  "error": "",
+  "progress_token": "web-...",
+  "queued_at": 1716300000000,        // unix-ms
+  "started_at": 1716300000050,
+  "finished_at": null
+}}
+```
+
+Jobs are tracked in an in-memory, TTL-pruned registry (finished jobs drop after
+30 min) so a long-lived daemon never accumulates unbounded state. Live per-file
+indexing progress is still on the v1 `/api/index-progress/{group}` SSE stream,
+keyed on `progress_token`.
+
+**Job SSE** (`GET /api/v2/jobs/{id}/stream`) follows §3: `connected` →
+`job` (one per status transition) → `heartbeat` every 15 s → `close` once the
+job reaches a terminal state. The path ends in `/stream` so `withGzip` excludes
+it automatically.
+
+### Action endpoint reference
+
+| Method + path | Wraps | Notes |
+|---|---|---|
+| `POST /api/v2/groups/{group}/rebuild` | `archigraph rebuild <group>` | async → 202 + job id |
+| `POST /api/v2/groups/{group}/repos/{repo}/rebuild` | `archigraph rebuild <group> <repo>` | async → 202 + job id |
+| `POST /api/v2/groups/{group}/repos/{repo}/reset` | `archigraph rebuild --wipe` | async → 202 + job id (destructive) |
+| `GET /api/v2/jobs/{id}` | — | job status/progress |
+| `GET /api/v2/jobs/{id}/stream` | — | job SSE feed |
+| `PATCH /api/v2/groups/{group}/repos/{repo}/monorepo` | module selection | persists to fleet.json **and** triggers a watcher `ForceRescan` so the running daemon re-reconciles (no longer persist-only). Reports `watcher_reloaded`. |
+| `POST /api/v2/maintenance/cleanup` | `archigraph cleanup` | body `{"dry_run":true}` (default) previews orphaned registry entries; `false` removes them |
+| `POST /api/v2/update/apply` | `archigraph update` | runs the updater as a subprocess (so this daemon is not replaced mid-request); returns `{exit_code, output[], applied}`. Version check stays at `GET /api/updates/check`. |
+| `POST /api/v2/patterns/{group}/export` | `archigraph patterns export` | body `{"file"}` or `{"repo"}` → writes approved patterns to CLAUDE.md |
+| `POST /api/v2/patterns/{group}/gc` | `archigraph patterns gc` | body `{"dry_run":true}` (default) previews; `false` prunes decayed candidates |
+
+---
+
+## 10. Intentionally CLI-only (no REST wrapper)
+
+**Daemon install / uninstall** (`archigraph daemon install|uninstall`) are NOT
+exposed over REST. They register/unregister a launchd service (macOS) /
+systemd unit (Linux), which requires elevated privileges and filesystem changes
+outside the daemon's own process — there is no safe in-process REST trigger
+(the daemon would be modifying the very service definition that supervises it).
+These remain CLI-only by design; the Settings screen surfaces them as a CLI
+hint rather than a button.
+
+---
+
 ## 7. Adding a new v2 endpoint — checklist
 
 - [ ] Handler file named `v2_<surface>.go`.

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -94,6 +94,17 @@ type Server struct {
 	// endpoints but does not prevent build or read-only webhook list routes.
 	// Set via SetWebhookDispatcher before Serve.
 	webhookDispatcher webhookDispatcherIface
+
+	// actionJobs tracks async v2 action jobs (rebuild/reset) so the
+	// Operations + Settings screens can poll/stream their status without the
+	// triggering HTTP handler ever blocking on the work (#1512). Always
+	// non-nil; initialised in NewServer.
+	actionJobs *actionJobRegistry
+
+	// rebuildRunner, when non-nil, replaces the default daemon-RPC rebuild path
+	// used by the v2 async rebuild/reset endpoints (#1512). Test-only injection
+	// point so the async job lifecycle can run without a live daemon.
+	rebuildRunner rebuildRunner
 }
 
 // watcherForceRescan is the subset of the watch.Watcher surface used by
@@ -127,11 +138,12 @@ func NewServer(cfg Config, store RegistryStore) (*Server, error) {
 	h := newWSHub()
 	go h.run()
 	srv := &Server{
-		cfg:      cfg,
-		registry: store,
-		graphs:   NewGraphCache(60 * time.Second),
-		hub:      h,
-		rng:      rand.New(rand.NewSource(time.Now().UnixNano())),
+		cfg:        cfg,
+		registry:   store,
+		graphs:     NewGraphCache(60 * time.Second),
+		hub:        h,
+		rng:        rand.New(rand.NewSource(time.Now().UnixNano())),
+		actionJobs: newActionJobRegistry(),
 	}
 	// auditor starts as a no-op writer; replaced when SetAuditLog/SetAuditBroker is called.
 	srv.auditor = audit.NewWriter(nil, nil)
@@ -531,14 +543,25 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups/{group}", s.handleV2GetGroup)
 	mux.HandleFunc("PATCH /api/v2/groups/{group}/features", s.handleV2PatchFeatures)
 	mux.HandleFunc("PATCH /api/v2/groups/{group}/docs", s.handleV2PatchDocs)
-	mux.HandleFunc("POST /api/v2/groups/{group}/rebuild", s.handleV2RebuildGroup)
 	mux.HandleFunc("DELETE /api/v2/groups/{group}", s.handleV2DeleteGroup)
 	mux.HandleFunc("POST /api/v2/groups/{group}/repos", s.handleV2AddRepo)
 	mux.HandleFunc("DELETE /api/v2/groups/{group}/repos/{repo}", s.handleV2RemoveRepo)
-	mux.HandleFunc("POST /api/v2/groups/{group}/repos/{repo}/rebuild", s.handleV2RebuildRepo)
-	mux.HandleFunc("POST /api/v2/groups/{group}/repos/{repo}/reset", s.handleV2ResetRepo)
 	mux.HandleFunc("PATCH /api/v2/groups/{group}/repos/{repo}/monorepo", s.handleV2PatchMonorepo)
 	mux.HandleFunc("POST /api/v2/groups/{group}/doctor", s.handleV2Doctor)
+
+	// --- v2 action endpoints (#1512): real REST wrappers over CLI-only ops. ---
+	// Rebuild/reset are ASYNC: handler returns 202 + a job id immediately and
+	// runs the index in a background goroutine (never blocks the daemon from
+	// serving — the #1487 serving-mutex invariant). Poll/stream via /api/v2/jobs.
+	mux.HandleFunc("POST /api/v2/groups/{group}/rebuild", s.handleV2RebuildGroupAsync)
+	mux.HandleFunc("POST /api/v2/groups/{group}/repos/{repo}/rebuild", s.handleV2RebuildRepoAsync)
+	mux.HandleFunc("POST /api/v2/groups/{group}/repos/{repo}/reset", s.handleV2ResetRepoAsync)
+	mux.HandleFunc("GET /api/v2/jobs/{id}", s.handleV2JobGet)
+	mux.HandleFunc("GET /api/v2/jobs/{id}/stream", s.handleV2JobStream)
+	mux.HandleFunc("POST /api/v2/maintenance/cleanup", s.handleV2Cleanup)
+	mux.HandleFunc("POST /api/v2/update/apply", s.handleV2UpdateApply)
+	mux.HandleFunc("POST /api/v2/patterns/{group}/export", s.handleV2PatternExport)
+	mux.HandleFunc("POST /api/v2/patterns/{group}/gc", s.handleV2PatternGC)
 
 	// Topology screen — WebUI v2 (#1440, epic #1432).
 	// Wraps the v1 collectTopologyResponse + buildTopicDetail in the v2 envelope.

--- a/internal/dashboard/v2_actions.go
+++ b/internal/dashboard/v2_actions.go
@@ -1,0 +1,441 @@
+// v2_actions.go — real REST wrappers over the CLI-only operations (#1512).
+//
+// Before this file, the Operations (#1444) and Settings (#1436) screens left
+// the mutating actions as CLI-hint stubs ("no safe REST trigger"). The owner
+// principle: if the CLI can do it, build a REST wrapper that calls the SAME
+// internal functions the CLI command calls — never duplicate logic.
+//
+// Endpoints added here (all v2; v1 routes are UNCHANGED):
+//
+//	POST  /api/v2/groups/{group}/rebuild                  → async rebuild group
+//	POST  /api/v2/groups/{group}/repos/{repo}/rebuild     → async rebuild repo
+//	POST  /api/v2/groups/{group}/repos/{repo}/reset       → async wipe+rebuild repo
+//	GET   /api/v2/jobs/{id}                               → job status/progress
+//	GET   /api/v2/jobs/{id}/stream                        → job SSE feed
+//	POST  /api/v2/maintenance/cleanup                     → preview/execute cleanup
+//	POST  /api/v2/update/apply                            → run `archigraph update`
+//	POST  /api/v2/patterns/{group}/export                 → export approved patterns
+//	POST  /api/v2/patterns/{group}/gc                     → gc candidate patterns
+//
+// Async-job design (rebuild/reset):
+//
+//	The HTTP handler MUST NOT block on the index — the daemon has to keep
+//	serving reads while a rebuild runs (the #1487 serving-mutex invariant).
+//	So the handler enqueues an actionJob (see v2_jobs.go), fires the daemon
+//	`Rebuild` RPC in a background goroutine (the exact path the CLI `rebuild`
+//	command + the v1 /api/groups/{group}/rebuild handler take), and returns
+//	202 immediately with the job id. The job tracks the RPC lifecycle; live
+//	per-file progress is still available on /api/index-progress/{group}.
+//
+// Daemon install/uninstall is intentionally NOT wrapped here — see API_V2.md
+// §10: it requires launchd privileges that have no safe in-process REST trigger.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/agentpatterns"
+	"github.com/cajasmota/archigraph/internal/daemon/client"
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// v2JobAck is the 202 body returned by every async action endpoint.
+type v2JobAck struct {
+	JobID         string `json:"job_id"`
+	Op            string `json:"op"`
+	Group         string `json:"group"`
+	Repo          string `json:"repo,omitempty"`
+	Status        string `json:"status"`
+	ProgressToken string `json:"progress_token"`
+	// StreamURL / StatusURL are convenience hrefs for the frontend.
+	StatusURL string `json:"status_url"`
+	StreamURL string `json:"stream_url"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Async rebuild / reset
+// ─────────────────────────────────────────────────────────────────────────────
+
+// rebuildRunner runs the actual rebuild for the given args and returns the
+// daemon reply. The default implementation dials the daemon and fires the
+// `Rebuild` RPC (the exact path the CLI `rebuild` command takes). Overridable
+// in tests so the async lifecycle can be exercised without a live daemon.
+type rebuildRunner func(args proto.RebuildArgs) (proto.RebuildReply, error)
+
+// defaultRebuildRunner dials the daemon and fires the Rebuild RPC.
+func defaultRebuildRunner(args proto.RebuildArgs) (proto.RebuildReply, error) {
+	bg, err := client.Dial()
+	if err != nil {
+		return proto.RebuildReply{}, fmt.Errorf("daemon dial failed: %w", err)
+	}
+	defer bg.Close()
+	return bg.Rebuild(args)
+}
+
+// dispatchV2Rebuild is the shared async path for the v2 rebuild/reset
+// endpoints. It mirrors the v1 dispatchRebuild logic (registry validation +
+// daemon probe + background RPC) but wraps the lifecycle in an actionJob so
+// the v2 screens get a pollable/streamable job id.
+func (s *Server) dispatchV2Rebuild(w http.ResponseWriter, group, repo string, wipe bool) {
+	// Validate the group exists — call the same registry func the CLI uses.
+	if _, err := groupConfigPath(group); err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+
+	// Probe the daemon before accepting so we fail fast with a clear 503.
+	// Skipped when a test runner is injected.
+	if s.rebuildRunner == nil {
+		probe, err := client.Dial()
+		if err != nil {
+			writeV2Err(w, http.StatusServiceUnavailable, "unavailable",
+				"daemon not reachable — run 'archigraph start' first")
+			return
+		}
+		probe.Close()
+	}
+
+	op := "rebuild"
+	if wipe {
+		op = "reset"
+	}
+	token := fmt.Sprintf("web-%d", time.Now().UnixMilli())
+	job := s.actionJobs.create(op, group, repo, token)
+
+	args := proto.RebuildArgs{
+		Group:         group,
+		Slug:          repo,
+		Wipe:          wipe,
+		ProgressToken: token,
+	}
+
+	// Fire the RPC asynchronously. The handler returns 202 immediately; this
+	// goroutine owns the job lifecycle and never touches the HTTP response.
+	go s.runRebuildJob(job.ID, args)
+
+	// Audit identically to the v1 handler.
+	s.auditor.OK(op, group, map[string]any{"repo": repo, "wipe": wipe, "progress_token": token, "job_id": job.ID})
+
+	ack := v2JobAck{
+		JobID:         job.ID,
+		Op:            op,
+		Group:         group,
+		Repo:          repo,
+		Status:        actionJobQueued,
+		ProgressToken: token,
+		StatusURL:     "/api/v2/jobs/" + job.ID,
+		StreamURL:     "/api/v2/jobs/" + job.ID + "/stream",
+	}
+	writeV2JSON(w, http.StatusAccepted, v2OK(ack))
+}
+
+// runRebuildJob executes the daemon Rebuild RPC and tracks the actionJob
+// status through its lifecycle. Runs entirely in a background goroutine.
+func (s *Server) runRebuildJob(jobID string, args proto.RebuildArgs) {
+	now := time.Now().UnixMilli()
+	s.actionJobs.update(jobID, func(j *actionJob) {
+		j.Status = actionJobRunning
+		j.StartedAt = &now
+		j.Progress = 5
+		j.Message = "indexing started"
+	})
+
+	runner := s.rebuildRunner
+	if runner == nil {
+		runner = defaultRebuildRunner
+	}
+	reply, err := runner(args)
+	if err != nil {
+		s.markJobFailed(jobID, err.Error())
+		return
+	}
+
+	fin := time.Now().UnixMilli()
+	s.actionJobs.update(jobID, func(j *actionJob) {
+		j.Status = actionJobDone
+		j.Progress = 100
+		j.FinishedAt = &fin
+		j.Message = fmt.Sprintf("rebuilt %d repo(s): %d entities, %d relationships",
+			len(reply.Repos), reply.TotalEntities, reply.TotalRels)
+		if reply.Warning != "" {
+			j.Message += " (warning: " + reply.Warning + ")"
+		}
+	})
+}
+
+func (s *Server) markJobFailed(jobID, msg string) {
+	fin := time.Now().UnixMilli()
+	s.actionJobs.update(jobID, func(j *actionJob) {
+		j.Status = actionJobFailed
+		j.FinishedAt = &fin
+		j.Error = msg
+	})
+}
+
+// handleV2RebuildGroupAsync — POST /api/v2/groups/{group}/rebuild (real).
+func (s *Server) handleV2RebuildGroupAsync(w http.ResponseWriter, r *http.Request) {
+	s.dispatchV2Rebuild(w, r.PathValue("group"), "", false)
+}
+
+// handleV2RebuildRepoAsync — POST /api/v2/groups/{group}/repos/{repo}/rebuild (real).
+func (s *Server) handleV2RebuildRepoAsync(w http.ResponseWriter, r *http.Request) {
+	s.dispatchV2Rebuild(w, r.PathValue("group"), r.PathValue("repo"), false)
+}
+
+// handleV2ResetRepoAsync — POST /api/v2/groups/{group}/repos/{repo}/reset (real).
+func (s *Server) handleV2ResetRepoAsync(w http.ResponseWriter, r *http.Request) {
+	s.dispatchV2Rebuild(w, r.PathValue("group"), r.PathValue("repo"), true)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Maintenance cleanup — wraps `archigraph cleanup`
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2Cleanup — POST /api/v2/maintenance/cleanup
+//
+// Body: { "dry_run": true } previews orphaned registry entries (default);
+// { "dry_run": false } removes them. Wraps the same registry scan the v1
+// /api/cleanup handler and the `archigraph cleanup` command perform.
+func (s *Server) handleV2Cleanup(w http.ResponseWriter, r *http.Request) {
+	req := struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: true}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	reg, err := registry.Load()
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "registry: "+err.Error())
+		return
+	}
+
+	orphaned := []CleanupOrphan{}
+	for _, g := range reg.Groups {
+		if !configExists(g.ConfigPath) {
+			orphaned = append(orphaned, CleanupOrphan{Name: g.Name, ConfigPath: g.ConfigPath})
+		}
+	}
+
+	reply := CleanupReply{DryRun: req.DryRun, Orphaned: orphaned}
+	if len(orphaned) == 0 {
+		reply.Message = "No orphaned registry entries found"
+		writeV2JSON(w, http.StatusOK, v2OK(reply))
+		return
+	}
+	if req.DryRun {
+		reply.Message = fmt.Sprintf("%d orphaned %s found — POST with dry_run:false to remove",
+			len(orphaned), maintenancePluralEntry(len(orphaned)))
+		writeV2JSON(w, http.StatusOK, v2OK(reply))
+		return
+	}
+
+	orphanSet := make(map[string]struct{}, len(orphaned))
+	for _, o := range orphaned {
+		orphanSet[o.Name] = struct{}{}
+	}
+	var kept []registry.GroupRef
+	for _, g := range reg.Groups {
+		if _, bad := orphanSet[g.Name]; !bad {
+			kept = append(kept, g)
+		}
+	}
+	reg.Groups = kept
+	if err := registry.Save(reg); err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "registry save: "+err.Error())
+		return
+	}
+	reply.Removed = len(orphaned)
+	reply.Message = fmt.Sprintf("Removed %d orphaned %s", len(orphaned), maintenancePluralEntry(len(orphaned)))
+	s.auditor.OK("cleanup", "", map[string]any{"removed": len(orphaned)})
+	writeV2JSON(w, http.StatusOK, v2OK(reply))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Update apply — wraps `archigraph update`
+// ─────────────────────────────────────────────────────────────────────────────
+
+// v2UpdateApplyReply is the result of running `archigraph update`.
+type v2UpdateApplyReply struct {
+	ExitCode int      `json:"exit_code"`
+	Output   []string `json:"output"`
+	Applied  bool     `json:"applied"`
+}
+
+// handleV2UpdateApply — POST /api/v2/update/apply
+//
+// Runs `archigraph update` as a subprocess (so this daemon is not replaced
+// mid-request) via the SAME defaultUpdateRunner the v1 SSE handler uses, and
+// returns the captured output in one JSON envelope. The version check is
+// already live at GET /api/updates/check.
+func (s *Server) handleV2UpdateApply(w http.ResponseWriter, r *http.Request) {
+	out, runErr := defaultUpdateRunner(r.Context(), []string{"update"})
+
+	lines := splitLines(string(out))
+	if lines == nil {
+		lines = []string{}
+	}
+	reply := v2UpdateApplyReply{Output: lines}
+	reply.ExitCode, reply.Applied = exitCodeFromErr(runErr)
+	s.auditor.OK("update", "", map[string]any{"exit_code": reply.ExitCode})
+	writeV2JSON(w, http.StatusOK, v2OK(reply))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Patterns export / gc — wraps `archigraph patterns export|gc`
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2PatternExport — POST /api/v2/patterns/{group}/export
+//
+// Body: { "file": "/abs/CLAUDE.md" } or { "repo": "/abs/repo" }. Calls the
+// SAME agentpatterns.UpsertFile path the v1 handler + CLI use.
+func (s *Server) handleV2PatternExport(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+	res, status, errMsg := s.exportPatterns(group, r)
+	if errMsg != "" {
+		code := "internal_error"
+		if status == http.StatusBadRequest {
+			code = "bad_request"
+		}
+		writeV2Err(w, status, code, errMsg)
+		return
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(res))
+}
+
+// handleV2PatternGC — POST /api/v2/patterns/{group}/gc
+//
+// Body: { "dry_run": true } (default) previews; false prunes. Calls the SAME
+// agentpatterns gc path the v1 handler + CLI use.
+func (s *Server) handleV2PatternGC(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+	res, status, errMsg := s.gcPatterns(group, r)
+	if errMsg != "" {
+		writeV2Err(w, status, "internal_error", errMsg)
+		return
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(res))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Small helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// configExists reports whether a group config file is present on disk.
+func configExists(path string) bool {
+	_, err := os.Stat(path)
+	return err == nil
+}
+
+// exitCodeFromErr maps a subprocess error to (exitCode, applied).
+func exitCodeFromErr(err error) (int, bool) {
+	if err == nil {
+		return 0, true
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode(), false
+	}
+	return 1, false
+}
+
+// exportPatterns runs the pattern-export logic (same agentpatterns.UpsertFile
+// path the CLI uses) and returns (result, httpStatus, errMsg).
+func (s *Server) exportPatterns(group string, r *http.Request) (map[string]any, int, string) {
+	var req struct {
+		File string `json:"file"`
+		Repo string `json:"repo"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		return nil, http.StatusBadRequest, "invalid JSON: " + err.Error()
+	}
+	target := req.File
+	if target == "" {
+		if req.Repo == "" {
+			return nil, http.StatusBadRequest, "pass file or repo in request body"
+		}
+		target = filepath.Join(req.Repo, "CLAUDE.md")
+	}
+
+	dir := groupPatternsDir(group)
+	patterns, err := loadAgentPatterns(dir)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "load patterns: " + err.Error()
+	}
+	if err := agentpatterns.UpsertFile(target, patterns, agentpatterns.ExportOptions{}); err != nil {
+		return nil, http.StatusInternalServerError, "export: " + err.Error()
+	}
+	approved := 0
+	for _, p := range patterns {
+		if !p.IsCandidate {
+			approved++
+		}
+	}
+	s.auditor.OK("patterns_export", group, map[string]any{"target": target, "exported": approved})
+	return map[string]any{"exported": approved, "target": target}, http.StatusOK, ""
+}
+
+// gcPatterns runs the candidate-pattern GC (same agentpatterns path as the CLI)
+// and returns (result, httpStatus, errMsg).
+func (s *Server) gcPatterns(group string, r *http.Request) (map[string]any, int, string) {
+	req := struct {
+		DryRun bool `json:"dry_run"`
+	}{DryRun: true}
+	_ = json.NewDecoder(r.Body).Decode(&req)
+
+	dir := groupPatternsDir(group)
+	patterns, err := loadAgentPatterns(dir)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "load patterns: " + err.Error()
+	}
+	cfg, err := agentpatterns.LoadConfig(dir)
+	if err != nil {
+		return nil, http.StatusInternalServerError, "load config: " + err.Error()
+	}
+	cutoff := time.Now().Add(-time.Duration(cfg.CandidateDecayDays) * 24 * time.Hour).Unix()
+
+	var keep, pruned []agentpatterns.Pattern
+	for _, p := range patterns {
+		if p.IsCandidate && p.LastValidated > 0 && p.LastValidated < cutoff {
+			pruned = append(pruned, p)
+		} else {
+			keep = append(keep, p)
+		}
+	}
+	if !req.DryRun && len(pruned) > 0 {
+		if err := agentpatterns.Save(dir, keep); err != nil {
+			return nil, http.StatusInternalServerError, "save patterns: " + err.Error()
+		}
+	}
+	pruneRows := make([]map[string]any, 0, len(pruned))
+	for _, p := range pruned {
+		pruneRows = append(pruneRows, patternToRow(p))
+	}
+	if !req.DryRun {
+		s.auditor.OK("patterns_gc", group, map[string]any{"pruned": len(pruned)})
+	}
+	return map[string]any{
+		"dry_run":              req.DryRun,
+		"pruned_count":         len(pruned),
+		"pruned":               pruneRows,
+		"remaining_count":      len(keep),
+		"candidate_decay_days": cfg.CandidateDecayDays,
+	}, http.StatusOK, ""
+}

--- a/internal/dashboard/v2_actions_test.go
+++ b/internal/dashboard/v2_actions_test.go
@@ -1,0 +1,211 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// newActionTestServer builds a Server with an isolated ARCHIGRAPH_HOME, an
+// injected rebuildRunner, and a registered group "demo" with one repo. It
+// returns the wired *httptest.Server.
+func newActionTestServer(t *testing.T, runner rebuildRunner) (*httptest.Server, *Server) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+
+	// Persist a group config + register it so groupConfigPath finds it.
+	cfgPath := filepath.Join(home, "demo.fleet.json")
+	gc := &registry.GroupConfig{Name: "demo", Repos: []registry.Repo{{Slug: "core", Path: filepath.Join(home, "core")}}}
+	if err := registry.SaveGroupConfig(cfgPath, gc); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+	if err := registry.AddGroup("demo", cfgPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	s, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	s.rebuildRunner = runner
+	ts := httptest.NewServer(s.routes())
+	t.Cleanup(ts.Close)
+	return ts, s
+}
+
+// TestV2Rebuild_Returns202Immediately verifies the handler does not block on
+// the index: even with a slow runner, the POST returns 202 + a job id at once,
+// and a concurrent read request is served while the rebuild is in flight
+// (the #1487 serving-mutex invariant).
+func TestV2Rebuild_Returns202Immediately(t *testing.T) {
+	release := make(chan struct{})
+	var started sync.WaitGroup
+	started.Add(1)
+	runner := func(args proto.RebuildArgs) (proto.RebuildReply, error) {
+		started.Done()
+		<-release // block until the test lets the job finish
+		return proto.RebuildReply{Repos: []string{"core"}, TotalEntities: 42, TotalRels: 7}, nil
+	}
+	ts, _ := newActionTestServer(t, runner)
+
+	start := time.Now()
+	resp, err := http.Post(ts.URL+"/api/v2/groups/demo/rebuild", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST rebuild: %v", err)
+	}
+	elapsed := time.Since(start)
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d; want 202", resp.StatusCode)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("handler blocked %v; should return immediately", elapsed)
+	}
+
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			JobID  string `json:"job_id"`
+			Status string `json:"status"`
+		} `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	resp.Body.Close()
+	if !env.OK || env.Data.JobID == "" {
+		t.Fatalf("bad ack: %+v", env)
+	}
+
+	// The job goroutine should be running (blocked in runner) — prove a
+	// concurrent read is served while the rebuild is in flight.
+	started.Wait()
+	jr, err := http.Get(ts.URL + "/api/v2/jobs/" + env.Data.JobID)
+	if err != nil {
+		t.Fatalf("GET job during rebuild: %v", err)
+	}
+	if jr.StatusCode != http.StatusOK {
+		t.Fatalf("concurrent job status = %d; want 200", jr.StatusCode)
+	}
+	jr.Body.Close()
+
+	// Let the job finish and confirm it transitions to done.
+	close(release)
+	jobID := env.Data.JobID
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, _ := http.Get(ts.URL + "/api/v2/jobs/" + jobID)
+		var je struct {
+			Data struct {
+				Status   string `json:"status"`
+				Progress int    `json:"progress"`
+			} `json:"data"`
+		}
+		json.NewDecoder(r.Body).Decode(&je)
+		r.Body.Close()
+		if je.Data.Status == actionJobDone {
+			if je.Data.Progress != 100 {
+				t.Fatalf("done job progress = %d; want 100", je.Data.Progress)
+			}
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("job never reached done")
+}
+
+// TestV2Rebuild_UnknownGroup404 verifies registry validation.
+func TestV2Rebuild_UnknownGroup404(t *testing.T) {
+	ts, _ := newActionTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	resp, err := http.Post(ts.URL+"/api/v2/groups/nope/rebuild", "application/json", nil)
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404", resp.StatusCode)
+	}
+}
+
+// TestV2Job_NotFound verifies the job poller 404s for an unknown id.
+func TestV2Job_NotFound(t *testing.T) {
+	ts, _ := newActionTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	resp, err := http.Get(ts.URL + "/api/v2/jobs/aj-does-not-exist")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("status = %d; want 404", resp.StatusCode)
+	}
+}
+
+// TestV2JobStream_TerminatesOnDone verifies the SSE stream emits a job event
+// and closes once the job reaches a terminal state.
+func TestV2JobStream_TerminatesOnDone(t *testing.T) {
+	ts, _ := newActionTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{Repos: []string{"core"}}, nil
+	})
+	// Trigger a rebuild.
+	resp, _ := http.Post(ts.URL+"/api/v2/groups/demo/repos/core/rebuild", "application/json", nil)
+	var env struct {
+		Data struct {
+			JobID string `json:"job_id"`
+		} `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&env)
+	resp.Body.Close()
+
+	sr, err := http.Get(ts.URL + "/api/v2/jobs/" + env.Data.JobID + "/stream")
+	if err != nil {
+		t.Fatalf("GET stream: %v", err)
+	}
+	defer sr.Body.Close()
+	if ct := sr.Header.Get("Content-Type"); !strings.HasPrefix(ct, "text/event-stream") {
+		t.Fatalf("content-type = %q; want SSE", ct)
+	}
+	buf := make([]byte, 4096)
+	n, _ := sr.Body.Read(buf)
+	body := string(buf[:n])
+	if !strings.Contains(body, "event: connected") {
+		t.Fatalf("stream missing connected event: %q", body)
+	}
+}
+
+// TestV2Cleanup_DryRunPreview verifies the cleanup wrapper previews orphans.
+func TestV2Cleanup_DryRunPreview(t *testing.T) {
+	ts, _ := newActionTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	resp, err := http.Post(ts.URL+"/api/v2/maintenance/cleanup", "application/json", strings.NewReader(`{"dry_run":true}`))
+	if err != nil {
+		t.Fatalf("POST cleanup: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	var env struct {
+		OK   bool `json:"ok"`
+		Data struct {
+			DryRun  bool `json:"dry_run"`
+			Removed int  `json:"removed"`
+		} `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&env)
+	if !env.OK || !env.Data.DryRun || env.Data.Removed != 0 {
+		t.Fatalf("dry-run cleanup should not remove: %+v", env)
+	}
+}

--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -72,13 +72,13 @@ type v2GroupFeatures struct {
 
 // v2SettingsRepo matches the SettingsRepo interface.
 type v2SettingsRepo struct {
-	Slug      string           `json:"slug"`
-	Path      string           `json:"path"`
-	Stack     string           `json:"stack"`
-	Files     int              `json:"files"`
-	Entities  int              `json:"entities"`
-	IndexedAt *int64           `json:"indexedAt"`
-	Monorepo  *v2MonorepoInfo  `json:"monorepo"`
+	Slug      string          `json:"slug"`
+	Path      string          `json:"path"`
+	Stack     string          `json:"stack"`
+	Files     int             `json:"files"`
+	Entities  int             `json:"entities"`
+	IndexedAt *int64          `json:"indexedAt"`
+	Monorepo  *v2MonorepoInfo `json:"monorepo"`
 }
 
 // v2MonorepoInfo matches the SettingsRepo.monorepo shape.
@@ -327,21 +327,8 @@ func (s *Server) handleV2PatchDocs(w http.ResponseWriter, r *http.Request) {
 	writeV2JSON(w, http.StatusOK, v2OK(map[string]string{"docsPath": cfg.GroupDocs}))
 }
 
-// handleV2RebuildGroup — POST /api/v2/groups/{group}/rebuild
-//
-// STUB: the real indexer trigger is not yet wired via REST. Returns 202 Accepted.
-func (s *Server) handleV2RebuildGroup(w http.ResponseWriter, r *http.Request) {
-	groupName := r.PathValue("group")
-	if _, err := groupConfigPath(groupName); err != nil {
-		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
-		return
-	}
-	writeV2JSON(w, http.StatusAccepted, v2OK(map[string]string{
-		"status":  "queued",
-		"message": "Rebuild queued. Use the CLI: archigraph rebuild " + groupName,
-		"note":    "REST-triggered rebuild wiring is tracked in epic #1432.",
-	}))
-}
+// NOTE: the former handleV2RebuildGroup / handleV2RebuildRepo / handleV2ResetRepo
+// stubs were replaced by the real async wrappers in v2_actions.go (#1512).
 
 // handleV2DeleteGroup — DELETE /api/v2/groups/{group}
 func (s *Server) handleV2DeleteGroup(w http.ResponseWriter, r *http.Request) {
@@ -459,45 +446,12 @@ func (s *Server) handleV2RemoveRepo(w http.ResponseWriter, r *http.Request) {
 	writeV2JSON(w, http.StatusOK, v2OK(map[string]string{"removed": repoSlug}))
 }
 
-// handleV2RebuildRepo — POST /api/v2/groups/{group}/repos/{repo}/rebuild
-//
-// STUB: see rebuild-group note above.
-func (s *Server) handleV2RebuildRepo(w http.ResponseWriter, r *http.Request) {
-	groupName := r.PathValue("group")
-	repoSlug := r.PathValue("repo")
-	if _, err := groupConfigPath(groupName); err != nil {
-		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
-		return
-	}
-	writeV2JSON(w, http.StatusAccepted, v2OK(map[string]string{
-		"status":  "queued",
-		"message": "Rebuild queued. Use the CLI: archigraph rebuild " + groupName + " " + repoSlug,
-		"note":    "REST-triggered rebuild wiring is tracked in epic #1432.",
-	}))
-}
-
-// handleV2ResetRepo — POST /api/v2/groups/{group}/repos/{repo}/reset
-//
-// STUB: see rebuild-group note above.
-func (s *Server) handleV2ResetRepo(w http.ResponseWriter, r *http.Request) {
-	groupName := r.PathValue("group")
-	repoSlug := r.PathValue("repo")
-	if _, err := groupConfigPath(groupName); err != nil {
-		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
-		return
-	}
-	writeV2JSON(w, http.StatusAccepted, v2OK(map[string]string{
-		"status":  "queued",
-		"message": "Cache reset + rebuild queued for " + repoSlug + " in " + groupName,
-		"note":    "REST-triggered rebuild wiring is tracked in epic #1432.",
-	}))
-}
-
 // handleV2PatchMonorepo — PATCH /api/v2/groups/{group}/repos/{repo}/monorepo
 //
-// Persists the module selection to fleet.json. The running watcher/indexer
-// is NOT hot-reloaded — a manual rebuild is needed (or the next watch event).
-// This is documented as a stub in the PR body.
+// Persists the module selection to fleet.json AND triggers a watcher rescan so
+// the running daemon re-reconciles the repo against the updated config (#1512).
+// When no watcher is wired into this server, it falls back to persist-only and
+// reports watcher_reloaded:false.
 func (s *Server) handleV2PatchMonorepo(w http.ResponseWriter, r *http.Request) {
 	groupName := r.PathValue("group")
 	repoSlug := r.PathValue("repo")
@@ -532,11 +486,24 @@ func (s *Server) handleV2PatchMonorepo(w http.ResponseWriter, r *http.Request) {
 		writeV2Err(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
+
+	// Trigger a watcher rescan so the running daemon re-reconciles every repo
+	// against the updated module selection. ForceRescan queues a full diff for
+	// all registered repos; the next index picks up the changed Modules.
+	reloaded := false
+	if s.watcher != nil {
+		s.watcher.ForceRescan()
+		reloaded = true
+	}
+	note := "Watcher rescan triggered; the changed module selection is picked up on the next reconcile."
+	if !reloaded {
+		note = "No watcher wired in this server; rebuild the repo to apply."
+	}
 	writeV2JSON(w, http.StatusOK, v2OK(map[string]any{
 		"saved":            true,
 		"packages":         req.Packages,
-		"watcher_reloaded": false,
-		"note":             "Watcher hot-reload not yet wired; rebuild the repo to apply.",
+		"watcher_reloaded": reloaded,
+		"note":             note,
 	}))
 }
 

--- a/internal/dashboard/v2_jobs.go
+++ b/internal/dashboard/v2_jobs.go
@@ -1,0 +1,257 @@
+// v2_jobs.go — async action-job registry for WebUI v2 (#1512).
+//
+// The v2 Operations + Settings screens trigger long-running actions
+// (rebuild, reset). Per the backend-v2 async convention these handlers MUST
+// NOT block the HTTP request on the work itself: the daemon must keep serving
+// reads while a rebuild runs (consistent with the #1487 serving-mutex fix).
+//
+// Design:
+//
+//   - POST .../rebuild | .../reset enqueues an actionJob, kicks off the work
+//     in a background goroutine, and returns 202 immediately with a job id.
+//   - GET  /api/v2/jobs/{id}        polls the job status/progress.
+//   - GET  /api/v2/jobs/{id}/stream is the SSE feed of status transitions.
+//
+// The actual indexing is NOT performed in this process. We dial the daemon
+// and fire the existing `Rebuild` RPC (the same path the CLI `archigraph
+// rebuild` command and the v1 /api/groups/{group}/rebuild handler use). The
+// goroutine simply tracks the RPC lifecycle so the job surfaces a clean
+// status. Live indexing progress is still available via the existing
+// /api/index-progress/{group} SSE stream, keyed on the progress token we
+// embed in the job.
+//
+// This registry is in-memory + bounded; jobs are pruned after a TTL so a
+// long-lived daemon does not accumulate unbounded state (memory-safe per the
+// repo's memory discipline).
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// Action-job status values.
+const (
+	actionJobQueued  = "queued"
+	actionJobRunning = "running"
+	actionJobDone    = "done"
+	actionJobFailed  = "failed"
+)
+
+// actionJobTTL is how long a finished job is retained for polling before it is
+// pruned from the registry.
+const actionJobTTL = 30 * time.Minute
+
+// actionJob is one async action (rebuild/reset) tracked by the daemon.
+type actionJob struct {
+	ID            string `json:"id"`
+	Op            string `json:"op"` // "rebuild" | "reset"
+	Group         string `json:"group"`
+	Repo          string `json:"repo,omitempty"`
+	Status        string `json:"status"`
+	Progress      int    `json:"progress"` // 0..100, coarse
+	Message       string `json:"message,omitempty"`
+	Error         string `json:"error,omitempty"`
+	ProgressToken string `json:"progress_token"`
+	QueuedAt      int64  `json:"queued_at"` // unix-ms
+	StartedAt     *int64 `json:"started_at,omitempty"`
+	FinishedAt    *int64 `json:"finished_at,omitempty"`
+}
+
+// actionJobRegistry is a concurrent, TTL-pruned store of action jobs plus a
+// per-job subscriber set for SSE streaming.
+type actionJobRegistry struct {
+	mu   sync.RWMutex
+	jobs map[string]*actionJob
+	subs map[string]map[chan actionJob]struct{}
+}
+
+func newActionJobRegistry() *actionJobRegistry {
+	return &actionJobRegistry{
+		jobs: make(map[string]*actionJob),
+		subs: make(map[string]map[chan actionJob]struct{}),
+	}
+}
+
+// create inserts a new queued job and returns a copy.
+func (r *actionJobRegistry) create(op, group, repo, token string) actionJob {
+	id := fmt.Sprintf("aj-%d", time.Now().UnixNano())
+	j := &actionJob{
+		ID:            id,
+		Op:            op,
+		Group:         group,
+		Repo:          repo,
+		Status:        actionJobQueued,
+		ProgressToken: token,
+		QueuedAt:      time.Now().UnixMilli(),
+	}
+	r.mu.Lock()
+	r.pruneLocked()
+	r.jobs[id] = j
+	r.mu.Unlock()
+	return *j
+}
+
+// update applies a mutation to the job under lock, then notifies subscribers
+// with a copy. mutate runs while holding the lock; keep it cheap.
+func (r *actionJobRegistry) update(id string, mutate func(*actionJob)) {
+	r.mu.Lock()
+	j, ok := r.jobs[id]
+	if !ok {
+		r.mu.Unlock()
+		return
+	}
+	mutate(j)
+	snapshot := *j
+	subs := r.subs[id]
+	chans := make([]chan actionJob, 0, len(subs))
+	for ch := range subs {
+		chans = append(chans, ch)
+	}
+	r.mu.Unlock()
+
+	for _, ch := range chans {
+		// Non-blocking send: drop on a slow consumer rather than stall the worker.
+		select {
+		case ch <- snapshot:
+		default:
+		}
+	}
+}
+
+// get returns a copy of the job, or false.
+func (r *actionJobRegistry) get(id string) (actionJob, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	j, ok := r.jobs[id]
+	if !ok {
+		return actionJob{}, false
+	}
+	return *j, true
+}
+
+// subscribe registers a channel for job updates. The returned cancel func
+// removes and closes it. The current snapshot is delivered immediately.
+func (r *actionJobRegistry) subscribe(id string) (<-chan actionJob, func(), bool) {
+	r.mu.Lock()
+	j, ok := r.jobs[id]
+	if !ok {
+		r.mu.Unlock()
+		return nil, nil, false
+	}
+	ch := make(chan actionJob, 8)
+	if r.subs[id] == nil {
+		r.subs[id] = make(map[chan actionJob]struct{})
+	}
+	r.subs[id][ch] = struct{}{}
+	snapshot := *j
+	r.mu.Unlock()
+
+	// Deliver the current state first so a late subscriber is not stuck.
+	ch <- snapshot
+
+	cancel := func() {
+		r.mu.Lock()
+		if set, ok := r.subs[id]; ok {
+			delete(set, ch)
+			if len(set) == 0 {
+				delete(r.subs, id)
+			}
+		}
+		r.mu.Unlock()
+		close(ch)
+	}
+	return ch, cancel, true
+}
+
+// pruneLocked drops finished jobs older than the TTL. Caller holds r.mu.
+func (r *actionJobRegistry) pruneLocked() {
+	cutoff := time.Now().Add(-actionJobTTL).UnixMilli()
+	for id, j := range r.jobs {
+		if j.FinishedAt != nil && *j.FinishedAt < cutoff {
+			if _, streaming := r.subs[id]; !streaming {
+				delete(r.jobs, id)
+			}
+		}
+	}
+}
+
+// terminal returns true once a job has stopped transitioning.
+func (j actionJob) terminal() bool {
+	return j.Status == actionJobDone || j.Status == actionJobFailed
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Job query handlers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2JobGet — GET /api/v2/jobs/{id}
+func (s *Server) handleV2JobGet(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	j, ok := s.actionJobs.get(id)
+	if !ok {
+		writeV2Err(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+		return
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(j))
+}
+
+// handleV2JobStream — GET /api/v2/jobs/{id}/stream (SSE).
+//
+// Emits the standard v2 SSE lifecycle: a `connected` event, one `job` event
+// per status transition (and immediately for the current state), `heartbeat`
+// every 15s, and a final `close` once the job reaches a terminal state.
+func (s *Server) handleV2JobStream(w http.ResponseWriter, r *http.Request) {
+	id := r.PathValue("id")
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "streaming not supported")
+		return
+	}
+
+	ch, cancel, ok := s.actionJobs.subscribe(id)
+	if !ok {
+		writeV2Err(w, http.StatusNotFound, "not_found", fmt.Sprintf("job %q not found", id))
+		return
+	}
+	defer cancel()
+
+	setV2SSEHeaders(w)
+	w.WriteHeader(http.StatusOK)
+
+	connected, _ := json.Marshal(map[string]int64{"subscribed_at": time.Now().UnixMilli()})
+	writeV2SSEEvent(w, "connected", string(connected))
+	flusher.Flush()
+
+	heartbeat := time.NewTicker(15 * time.Second)
+	defer heartbeat.Stop()
+
+	ctx := r.Context()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-heartbeat.C:
+			writeV2SSEEvent(w, "heartbeat", "{}")
+			flusher.Flush()
+		case j, open := <-ch:
+			if !open {
+				writeV2SSEEvent(w, "close", "{}")
+				flusher.Flush()
+				return
+			}
+			data, _ := json.Marshal(j)
+			writeV2SSEEvent(w, "job", string(data))
+			flusher.Flush()
+			if j.terminal() {
+				writeV2SSEEvent(w, "close", "{}")
+				flusher.Flush()
+				return
+			}
+		}
+	}
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -889,6 +889,54 @@ export interface PatternGCReply {
   candidate_decay_days: number;
 }
 
+/* ------------------------------------------------------------------ *
+ * Async action jobs (#1512) — rebuild / reset return a JobAck (202) and
+ * the frontend polls ActionJob via GET /api/v2/jobs/:id. See API_V2.md §6c.
+ * ------------------------------------------------------------------ */
+
+/** 202 ack returned by an async action endpoint. */
+export interface JobAck {
+  job_id: string;
+  op: "rebuild" | "reset";
+  group: string;
+  repo?: string;
+  status: string;
+  progress_token: string;
+  status_url: string;
+  stream_url: string;
+}
+
+/** Live status of an async action job. */
+export interface ActionJob {
+  id: string;
+  op: "rebuild" | "reset";
+  group: string;
+  repo?: string;
+  status: "queued" | "running" | "done" | "failed";
+  progress: number;
+  message?: string;
+  error?: string;
+  progress_token: string;
+  queued_at: number;
+  started_at?: number;
+  finished_at?: number;
+}
+
+/** POST /api/v2/maintenance/cleanup result. */
+export interface CleanupReply {
+  dry_run: boolean;
+  orphaned: { name: string; config_path: string }[];
+  removed: number;
+  message: string;
+}
+
+/** POST /api/v2/update/apply result. */
+export interface UpdateApplyReply {
+  exit_code: number;
+  output: string[];
+  applied: boolean;
+}
+
 /** Orphan audit totals */
 export interface OrphanAuditTotals {
   entities: number;

--- a/webui-v2/src/hooks/use-operations.ts
+++ b/webui-v2/src/hooks/use-operations.ts
@@ -70,6 +70,29 @@ export function useUpdateCheck() {
   });
 }
 
+/** Runs `archigraph update` (#1512). Re-checks the version on success. */
+export function useApplyUpdate() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: () => api.applyUpdate(),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: updateCheckKey() }),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Maintenance — cleanup orphaned registry entries (#1512)
+// ---------------------------------------------------------------------------
+
+/**
+ * Previews (dryRun:true, default) or executes (false) registry cleanup.
+ * Wraps POST /api/v2/maintenance/cleanup.
+ */
+export function useCleanup() {
+  return useMutation({
+    mutationFn: (dryRun: boolean) => api.runCleanup(dryRun),
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Patterns
 // ---------------------------------------------------------------------------

--- a/webui-v2/src/hooks/use-settings.ts
+++ b/webui-v2/src/hooks/use-settings.ts
@@ -50,7 +50,10 @@ export function usePatchDocs(groupId: string) {
   });
 }
 
-/** Enqueues a full group rebuild (stub → 202 Accepted). */
+/**
+ * Triggers an async full-group rebuild (#1512). Resolves to a JobAck (202) —
+ * the caller feeds job_id into useActionJob to track progress.
+ */
 export function useRebuildGroup(groupId: string) {
   return useMutation({
     mutationFn: () => api.rebuildGroup(groupId),
@@ -84,17 +87,42 @@ export function useRemoveRepo(groupId: string) {
   });
 }
 
-/** Enqueues a single-repo rebuild (stub). */
+/** Triggers an async single-repo rebuild (#1512). Resolves to a JobAck. */
 export function useRebuildRepo(groupId: string) {
   return useMutation({
     mutationFn: (repoSlug: string) => api.rebuildRepo(groupId, repoSlug),
   });
 }
 
-/** Resets repo cache + rebuild (stub). */
+/** Triggers an async repo cache-wipe + rebuild (#1512). Resolves to a JobAck. */
 export function useResetRepo(groupId: string) {
   return useMutation({
     mutationFn: (repoSlug: string) => api.resetRepo(groupId, repoSlug),
+  });
+}
+
+/**
+ * Polls an async action job (#1512) until it reaches a terminal state.
+ * Pass null to disable. On completion, invalidates the settings query so the
+ * screen reflects the freshly-indexed entity counts.
+ */
+export function useActionJob(groupId: string, jobId: string | null) {
+  const qc = useQueryClient();
+  return useQuery({
+    queryKey: ["action-job", jobId],
+    queryFn: async () => {
+      const job = await api.getJob(jobId as string);
+      if (job.status === "done" || job.status === "failed") {
+        void qc.invalidateQueries({ queryKey: settingsQueryKey(groupId) });
+      }
+      return job;
+    },
+    enabled: !!jobId,
+    // Poll every second while running; stop once terminal.
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === "done" || s === "failed" ? false : 1000;
+    },
   });
 }
 

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -42,6 +42,10 @@ import type {
   OrphanAuditReply,
   FixturesReply,
   RecallReply,
+  JobAck,
+  ActionJob,
+  CleanupReply,
+  UpdateApplyReply,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -202,9 +206,12 @@ export const api = {
       body: JSON.stringify({ docsPath }),
     }),
 
-  /** POST /api/v2/groups/:id/rebuild — enqueue group rebuild (stub → 202). */
+  /**
+   * POST /api/v2/groups/:id/rebuild — trigger an ASYNC group rebuild (#1512).
+   * Returns 202 + a job id immediately; poll getJob / stream pollJob.
+   */
   rebuildGroup: (groupId: string) =>
-    requestV2<{ status: string; message: string }>(`/groups/${encodeURIComponent(groupId)}/rebuild`, {
+    requestV2<JobAck>(`/groups/${encodeURIComponent(groupId)}/rebuild`, {
       method: "POST",
     }),
 
@@ -228,17 +235,20 @@ export const api = {
       { method: "DELETE" },
     ),
 
-  /** POST /api/v2/groups/:id/repos/:slug/rebuild — enqueue repo rebuild (stub). */
+  /** POST /api/v2/groups/:id/repos/:slug/rebuild — ASYNC repo rebuild → 202 + job id (#1512). */
   rebuildRepo: (groupId: string, repoSlug: string) =>
-    requestV2<{ status: string; message: string }>(`/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repoSlug)}/rebuild`, {
+    requestV2<JobAck>(`/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repoSlug)}/rebuild`, {
       method: "POST",
     }),
 
-  /** POST /api/v2/groups/:id/repos/:slug/reset — reset cache + rebuild (stub). */
+  /** POST /api/v2/groups/:id/repos/:slug/reset — ASYNC wipe + rebuild → 202 + job id (#1512). */
   resetRepo: (groupId: string, repoSlug: string) =>
-    requestV2<{ status: string; message: string }>(`/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repoSlug)}/reset`, {
+    requestV2<JobAck>(`/groups/${encodeURIComponent(groupId)}/repos/${encodeURIComponent(repoSlug)}/reset`, {
       method: "POST",
     }),
+
+  /** GET /api/v2/jobs/:id — poll the status/progress of an async action job (#1512). */
+  getJob: (jobId: string) => requestV2<ActionJob>(`/jobs/${encodeURIComponent(jobId)}`),
 
   /** PATCH /api/v2/groups/:id/repos/:slug/monorepo — update package selection. */
   patchMonorepo: (groupId: string, repoSlug: string, packages: string[]) =>
@@ -357,6 +367,24 @@ export const api = {
       method: "POST",
       body: JSON.stringify(target),
     }),
+
+  /**
+   * POST /api/v2/maintenance/cleanup — preview/execute orphaned-registry cleanup (#1512).
+   * dryRun:true (default) previews; false removes.
+   */
+  runCleanup: (dryRun = true) =>
+    requestV2<CleanupReply>(`/maintenance/cleanup`, {
+      method: "POST",
+      body: JSON.stringify({ dry_run: dryRun }),
+    }),
+
+  /**
+   * POST /api/v2/update/apply — run `archigraph update` (#1512).
+   * Subprocess-based, so the daemon is not replaced mid-request. The version
+   * check stays on GET /api/updates/check (checkForUpdates above).
+   */
+  applyUpdate: () =>
+    requestV2<UpdateApplyReply>(`/update/apply`, { method: "POST" }),
 
   /** GET /api/quality/orphans/{group} — orphan audit for a group. */
   getOrphanAudit: (groupId: string) =>

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -66,9 +66,12 @@ import {
   useStopDaemon,
   useSystemLogs,
   useUpdateCheck,
+  useApplyUpdate,
+  useCleanup,
   usePatterns,
   useDeletePattern,
   usePatternGC,
+  useExportPatterns,
   useOrphanAudit,
   useRunOrphanAudit,
   useQualityFixtures,
@@ -413,6 +416,7 @@ function SystemTab({ groupId }: { groupId: string }) {
   const restartDaemon = useRestartDaemon();
   const stopDaemon = useStopDaemon();
   const runDoctor = useRunDoctor(groupId);
+  const cleanup = useCleanup();
   const [logsOpen, setLogsOpen] = useState(false);
   const [confirmRestart, setConfirmRestart] = useState(false);
   const [confirmStop, setConfirmStop] = useState(false);
@@ -458,12 +462,38 @@ function SystemTab({ groupId }: { groupId: string }) {
               </a>.
             </p>
             <p>
-              <span className="text-text-2 font-medium">Cleanup</span> — removes orphaned registry
-              entries. Run from terminal:
+              <span className="text-text-2 font-medium">Cleanup</span> — removes registry entries
+              whose config file no longer exists. Preview first, then remove.
             </p>
-            <code className="block font-mono text-text-2 bg-bg-soft border border-border-soft rounded px-2 py-1 text-xs">
-              archigraph cleanup
-            </code>
+            <div className="flex items-center gap-2">
+              <Button
+                variant="secondary"
+                size="sm"
+                disabled={cleanup.isPending}
+                onClick={() => {
+                  cleanup.mutate(true, {
+                    onSuccess: (res) => toast.info(res.message),
+                    onError: () => toast.error("Cleanup preview failed."),
+                  });
+                }}
+              >
+                Preview orphans
+              </Button>
+              <Button
+                variant="danger"
+                size="sm"
+                disabled={cleanup.isPending}
+                onClick={() => {
+                  cleanup.mutate(false, {
+                    onSuccess: (res) =>
+                      res.removed > 0 ? toast.success(res.message) : toast.info(res.message),
+                    onError: () => toast.error("Cleanup failed."),
+                  });
+                }}
+              >
+                Remove orphans
+              </Button>
+            </div>
           </div>
         </div>
       </Section>
@@ -698,6 +728,7 @@ function PatternsTab({ groupId }: { groupId: string }) {
   const [exportTarget, setExportTarget] = useState("");
 
   const patternGC = usePatternGC(groupId);
+  const exportPatterns = useExportPatterns(groupId);
 
   const { data, isLoading, isError } = usePatterns(groupId, {
     needs_attention: needsAttentionOnly || undefined,
@@ -828,28 +859,34 @@ function PatternsTab({ groupId }: { groupId: string }) {
         <div className="rounded-lg border border-border bg-surface p-4 text-sm space-y-3">
           <p className="font-medium text-text">Export patterns to CLAUDE.md</p>
           <p className="text-text-3">
-            Writes the approved pattern block to a file. Use the CLI for full control:
+            Writes the approved pattern block to the given CLAUDE.md (or a repo
+            path, in which case it targets &lt;repo&gt;/CLAUDE.md).
           </p>
-          <code className="block font-mono text-text-2 bg-bg-soft border border-border-soft rounded px-2 py-1 text-xs">
-            archigraph patterns export --repo /path/to/repo
-          </code>
           <div className="flex gap-2 pt-1">
             <Input
               value={exportTarget}
               onChange={(e) => setExportTarget(e.target.value)}
-              placeholder="/path/to/CLAUDE.md"
+              placeholder="/path/to/CLAUDE.md or /path/to/repo"
               className="flex-1 font-mono text-sm"
             />
             <Button
               variant="secondary"
               size="sm"
-              disabled={!exportTarget}
+              disabled={!exportTarget || exportPatterns.isPending}
               onClick={() => {
-                toast.info("Export via REST is coming. Use the CLI for now.");
-                setExportOpen(false);
+                const t = exportTarget.trim();
+                // Treat a path ending in .md as a file; otherwise a repo dir.
+                const target = t.endsWith(".md") ? { file: t } : { repo: t };
+                exportPatterns.mutate(target, {
+                  onSuccess: (res) => {
+                    toast.success(`Exported ${res.exported} pattern(s) to ${res.target}`);
+                    setExportOpen(false);
+                  },
+                  onError: () => toast.error("Pattern export failed."),
+                });
               }}
             >
-              Export
+              {exportPatterns.isPending ? "Exporting…" : "Export"}
             </Button>
             <Button variant="ghost" size="sm" onClick={() => setExportOpen(false)}>
               Cancel
@@ -1327,6 +1364,7 @@ function QualityTab({ groupId }: { groupId: string }) {
 
 function UpdatesTab() {
   const { data, isLoading, isError, refetch, isFetching } = useUpdateCheck();
+  const applyUpdate = useApplyUpdate();
 
   return (
     <div className="space-y-5">
@@ -1410,14 +1448,23 @@ function UpdatesTab() {
                     <Button
                       variant="primary"
                       size="sm"
+                      disabled={applyUpdate.isPending}
                       onClick={() => {
-                        toast.info(
-                          "Run `archigraph update` from your terminal. SSE streaming is planned for a follow-up PR.",
-                        );
+                        toast.info("Applying update…");
+                        applyUpdate.mutate(undefined, {
+                          onSuccess: (res) => {
+                            if (res.exit_code === 0) {
+                              toast.success("Update applied. Restart the daemon to run the new version.");
+                            } else {
+                              toast.error(`Update exited ${res.exit_code}. Check the output.`);
+                            }
+                          },
+                          onError: () => toast.error("Failed to apply update."),
+                        });
                       }}
                     >
                       <Download size={12} />
-                      Update now
+                      {applyUpdate.isPending ? "Updating…" : "Update now"}
                     </Button>
                   </div>
                 </div>

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -54,6 +54,7 @@ import {
   useResetRepo,
   usePatchMonorepo,
   useRunDoctor,
+  useActionJob,
 } from "@/hooks/use-settings";
 import { ApiError } from "@/lib/api";
 import type { SettingsRepo, SettingsGroup, DoctorCheck, MonorepoPkg } from "@/data/types";
@@ -503,6 +504,20 @@ function RepositoriesSection({
   const resetRepo = useResetRepo(groupId);
   const patchMonorepo = usePatchMonorepo(groupId);
 
+  // Track the in-flight async repo job (#1512): poll until terminal, then toast.
+  const [repoJobId, setRepoJobId] = useState<string | null>(null);
+  const repoJob = useActionJob(groupId, repoJobId);
+  useEffect(() => {
+    if (!repoJob.data) return;
+    if (repoJob.data.status === "done") {
+      toast.success(repoJob.data.message ?? "Rebuild complete.");
+      setRepoJobId(null);
+    } else if (repoJob.data.status === "failed") {
+      toast.error(repoJob.data.error ?? "Rebuild failed.");
+      setRepoJobId(null);
+    }
+  }, [repoJob.data]);
+
   const handleTogglePackage = (repo: SettingsRepo, pkg: MonorepoPkg) => {
     if (!repo.monorepo) return;
     const current = repo.monorepo.packages.map((p) =>
@@ -543,13 +558,19 @@ function RepositoriesSection({
             onRemove={() => onRemove(repo)}
             onRebuild={() =>
               rebuildRepo.mutate(repo.slug, {
-                onSuccess: (d) => toast.info(d.message ?? "Rebuild queued."),
+                onSuccess: (d) => {
+                  toast.info("Rebuild queued.");
+                  setRepoJobId(d.job_id);
+                },
                 onError: () => toast.error("Failed to queue rebuild."),
               })
             }
             onReset={() =>
               resetRepo.mutate(repo.slug, {
-                onSuccess: (d) => toast.info(d.message ?? "Reset queued."),
+                onSuccess: (d) => {
+                  toast.info("Reset queued.");
+                  setRepoJobId(d.job_id);
+                },
                 onError: () => toast.error("Failed to queue reset."),
               })
             }
@@ -1249,6 +1270,20 @@ export default function SettingsScreen() {
   const { data: group, isLoading, isError, error } = useSettingsGroup(groupId);
   const rebuildGroup = useRebuildGroup(groupId);
 
+  // Track the in-flight async group-rebuild job (#1512) and toast on completion.
+  const [groupJobId, setGroupJobId] = useState<string | null>(null);
+  const groupJob = useActionJob(groupId, groupJobId);
+  useEffect(() => {
+    if (!groupJob.data) return;
+    if (groupJob.data.status === "done") {
+      toast.success(groupJob.data.message ?? "Rebuild complete.");
+      setGroupJobId(null);
+    } else if (groupJob.data.status === "failed") {
+      toast.error(groupJob.data.error ?? "Rebuild failed.");
+      setGroupJobId(null);
+    }
+  }, [groupJob.data]);
+
   const [removeRepo, setRemoveRepo] = useState<SettingsRepo | null>(null);
   const [addRepoOpen, setAddRepoOpen] = useState(false);
   const [confirm, setConfirm] = useState<{ kind: ConfirmKind; repo?: SettingsRepo } | null>(null);
@@ -1347,7 +1382,8 @@ export default function SettingsScreen() {
             if (confirm?.kind === "rebuild-group") {
               rebuildGroup.mutate(undefined, {
                 onSuccess: (d) => {
-                  toast.info(d.message ?? "Rebuild queued.");
+                  toast.info("Rebuild queued.");
+                  setGroupJobId(d.job_id);
                   setConfirm(null);
                 },
                 onError: () => {


### PR DESCRIPTION
## What
Unstub the Operations (#1444) + Settings (#1436) actions that were left as CLI-hint stubs ("no safe REST trigger"). Every new v2 endpoint is a thin REST wrapper over the **same internal function the corresponding `archigraph` CLI command calls** — no logic is duplicated. v1 routes are UNCHANGED.

## Why
The screens shipped with rebuild / reset / cleanup / update / pattern-export buttons that only printed a CLI hint. The real logic already exists (v1 maintenance handlers, the daemon `Rebuild` RPC, the agentpatterns package, the updater subprocess); it just needed a v2 surface. The original stub note pointed at this epic.

## How
**New `internal/dashboard/v2_actions.go` + `v2_jobs.go`:**
- `POST /api/v2/groups/{g}/rebuild`, `/repos/{r}/rebuild`, `/repos/{r}/reset` — **async**: validate the group, fire the daemon `Rebuild` RPC in a background goroutine (the exact path the CLI `rebuild` command + the v1 `/api/groups/{g}/rebuild` handler take), and return **202 + a job id** immediately. The handler **never blocks on the index**, so the daemon keeps serving reads while a rebuild runs (the #1487 serving-mutex invariant).
- `GET /api/v2/jobs/{id}` (status/progress) + `GET /api/v2/jobs/{id}/stream` (SSE: `connected` → `job` → `heartbeat` → `close`). In-memory, TTL-pruned (30 min) registry so a long-lived daemon never accumulates unbounded job state. Live per-file progress still flows on v1 `/api/index-progress/{g}` via the embedded progress token.
- `POST /api/v2/maintenance/cleanup` — dry-run preview (default) + execute.
- `POST /api/v2/update/apply` — runs `archigraph update` as a subprocess (so the daemon is not replaced mid-request); the version check stays on `GET /api/updates/check`.
- `POST /api/v2/patterns/{g}/export` + `/gc` — wrap the same agentpatterns path the CLI uses.

**`PATCH /api/v2/groups/{g}/repos/{r}/monorepo`** now triggers a watcher `ForceRescan` after persisting (was persist-only), so the running daemon re-reconciles against the new module selection (`watcher_reloaded` reported).

**Intentionally CLI-only:** daemon install/uninstall (launchd privileges, no safe in-process REST trigger) — documented in `API_V2.md` §10.

**Frontend:** re-pointed the Operations + Settings stubs at the real endpoints (`lib/api.ts`, `hooks/use-settings.ts`, `hooks/use-operations.ts`, `routes/settings.tsx`, `routes/operations.tsx`). Rebuild/reset now poll the async job to completion via a new `useActionJob` hook and toast on done/failed; cleanup + update-apply + pattern-export buttons are live.

**`API_V2.md`** updated with §6c (action endpoints + async-job convention) and §10 (CLI-only ops).

## Async-job design
1. Handler validates the group, creates an `actionJob` (queued), spawns a goroutine, returns 202 with `{ job_id, status_url, stream_url, progress_token }`.
2. Goroutine sets the job → running, calls the daemon RPC (overridable runner for tests), then → done/failed with a coarse progress + summary message.
3. Clients poll `GET /api/v2/jobs/{id}` or subscribe to the `/stream` SSE feed. The path ends in `/stream`, so the existing `withGzip` SSE exclusion applies automatically.

## Testing
- `go build ./...` + `go vet ./internal/dashboard/` clean.
- Handler tests, **race-tested like #1487**: rebuild returns 202 immediately, the job runs async without blocking a concurrent `GET /api/v2/jobs/{id}`, and transitions to done with progress 100; unknown group → 404; unknown job → 404; SSE stream emits `connected` and closes on terminal; cleanup dry-run previews without removing.
- `npm run build` clean (tsc -b + vite).
- v1 routes UNCHANGED — the only removed registrations are the 3 v2 stub handlers, swapped for the real async ones.
- Two pre-existing failures in `handlers_enrichment_writeback_test.go` (`TestWriteback_success`, `TestYamlScalar`) reproduce on clean `origin/main` and are unrelated to this change.

## Risks / rollback
Additive v2 surface; v1 untouched. The job registry is bounded + pruned. Revert the new files + the route block to roll back.

Fixes #1512

🤖 Generated with [Claude Code](https://claude.com/claude-code)