### PR TITLE
fix(pending): key hints by entity ID to survive re-index churn

### DIFF
--- a/internal/dashboard/v2_pending.go
+++ b/internal/dashboard/v2_pending.go
@@ -8,8 +8,11 @@
 //
 // PUT /api/v2/groups/{group}/candidates/{cid}/hint
 //
-//	Persists a hint string on the matching candidate entry. Body: {"hint":"..."}
-//	Empty hint string clears the hint. 404 when candidate not found.
+//	Persists a hint string keyed by the ENTITY ID (SubjectID) of the
+//	candidate. Body: {"hint":"..."}.  Empty hint string clears the hint.
+//	{cid} is treated as an entity ID so hints survive candidate-ID churn
+//	across re-index sweeps (#1518). 404 when no candidate for that entity
+//	is found in any repo of the group.
 package dashboard
 
 import (
@@ -36,21 +39,31 @@ type v2EntityRef struct {
 
 type v2RepairCandidate struct {
 	ID          string      `json:"id"`
+	// EntityID is the stable entity identifier (SubjectID). Clients MUST use
+	// this field — not ID — when calling PUT …/candidates/{cid}/hint.
+	EntityID    string      `json:"entityId"`
 	Severity    string      `json:"severity"`
 	IssueType   string      `json:"issueType"`
 	Entity      v2EntityRef `json:"entity"`
 	Description string      `json:"description"`
 	Confidence  float64     `json:"confidence"`
 	DetectedAt  int64       `json:"detectedAt"` // unix ms
+	// Hint is the team-authored hint currently stored for this entity (may be "").
+	Hint        string      `json:"hint,omitempty"`
 }
 
 type v2EnrichmentCandidate struct {
 	ID             string      `json:"id"`
+	// EntityID is the stable entity identifier (SubjectID). Clients MUST use
+	// this field — not ID — when calling PUT …/candidates/{cid}/hint.
+	EntityID       string      `json:"entityId"`
 	EnrichmentType string      `json:"enrichmentType"`
 	Entity         v2EntityRef `json:"entity"`
 	Description    string      `json:"description"`
 	Confidence     float64     `json:"confidence"`
 	DetectedAt     int64       `json:"detectedAt"` // unix ms
+	// Hint is the team-authored hint currently stored for this entity (may be "").
+	Hint           string      `json:"hint,omitempty"`
 }
 
 type v2CandidatesResponse struct {
@@ -178,7 +191,16 @@ func (s *Server) handleV2Candidates(w http.ResponseWriter, r *http.Request) {
 		if repo == nil || repo.Path == "" {
 			continue
 		}
+		// Load the entity-keyed hint store once per repo.
+		hints := readEntityHints(repo.Path)
 		for _, c := range readAllCandidates(repo.Path) {
+			// Resolve hint: prefer entity-keyed store (#1518); fall back to the
+			// legacy candidate-level Hint field for backward compatibility.
+			hint := hints[c.SubjectID]
+			if hint == "" {
+				hint = c.Hint
+			}
+
 			if repairKinds[c.Kind] {
 				if tab == "enrichments" {
 					continue
@@ -197,12 +219,14 @@ func (s *Server) handleV2Candidates(w http.ResponseWriter, r *http.Request) {
 				}
 				repairs = append(repairs, v2RepairCandidate{
 					ID:          c.ID,
+					EntityID:    c.SubjectID,
 					Severity:    sev,
 					IssueType:   issueType,
 					Entity:      entityRefFromContext(c.Context, slug, c.SubjectID),
 					Description: descriptionFromContext(c.Context, c.Kind),
 					Confidence:  c.Confidence,
 					DetectedAt:  parseDetectedAt(c.DiscoveredAt),
+					Hint:        hint,
 				})
 			} else if !communityNamingKinds[c.Kind] {
 				if tab == "repairs" {
@@ -214,11 +238,13 @@ func (s *Server) handleV2Candidates(w http.ResponseWriter, r *http.Request) {
 				}
 				enrichments = append(enrichments, v2EnrichmentCandidate{
 					ID:             c.ID,
+					EntityID:       c.SubjectID,
 					EnrichmentType: enrichType,
 					Entity:         entityRefFromContext(c.Context, slug, c.SubjectID),
 					Description:    descriptionFromContext(c.Context, c.Kind),
 					Confidence:     c.Confidence,
 					DetectedAt:     parseDetectedAt(c.DiscoveredAt),
+					Hint:           hint,
 				})
 			}
 		}
@@ -244,14 +270,22 @@ type v2HintReq struct {
 
 // handleV2CandidateHint — PUT /api/v2/groups/{group}/candidates/{cid}/hint
 //
-// Persists the hint on the matching candidate in enrichment-candidates.json.
-// Responds 200 { ok:true, data: { hint: "<saved>" } } on success.
-// Responds 404 when the candidate is not found in any repo.
+// Persists a hint keyed by the ENTITY ID (SubjectID) of the candidate.
+// {cid} in the URL path is interpreted as the entity ID, not the ephemeral
+// candidate ID, so hints survive candidate-ID churn across re-index sweeps
+// (#1518).
+//
+// The handler verifies that at least one candidate in the group has the
+// given entity ID (SubjectID) before writing, so callers get a proper 404
+// when the entity is no longer present.
+//
+// Responds 200 { ok:true, data: { hint: "<saved>", entityId: "<eid>" } }.
+// Responds 404 when no candidate with that entity ID is found in any repo.
 func (s *Server) handleV2CandidateHint(w http.ResponseWriter, r *http.Request) {
 	group := r.PathValue("group")
-	cid := r.PathValue("cid")
-	if group == "" || cid == "" {
-		writeV2Err(w, http.StatusBadRequest, "bad_request", "group and cid required")
+	entityID := r.PathValue("cid") // path param name kept for URL compat; value is now entity ID
+	if group == "" || entityID == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group and entityId required")
 		return
 	}
 
@@ -267,50 +301,60 @@ func (s *Server) handleV2CandidateHint(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Find any repo that has a candidate for this entity ID and persist the hint.
 	for _, repo := range grp.Repos {
 		if repo == nil || repo.Path == "" {
 			continue
 		}
-		if updated := updateCandidateHint(repo.Path, cid, req.Hint); updated {
-			writeV2JSON(w, http.StatusOK, v2OK(map[string]string{"hint": req.Hint}))
+		if updated := upsertEntityHint(repo.Path, entityID, req.Hint); updated {
+			writeV2JSON(w, http.StatusOK, v2OK(map[string]string{
+				"hint":     req.Hint,
+				"entityId": entityID,
+			}))
 			return
 		}
 	}
 
-	writeV2Err(w, http.StatusNotFound, "not_found", "candidate not found")
+	writeV2Err(w, http.StatusNotFound, "not_found", "no candidate found for entity")
 }
 
-// updateCandidateHint reads enrichment-candidates.json in repoPath, finds
-// the entry with id == cid, updates its Hint, and writes the file back.
-// Returns true when the candidate was found and the file written successfully.
-func updateCandidateHint(repoPath, cid, hint string) bool {
+// entityHintsFile returns the path to the entity-hints store for a repo.
+// The store is a flat JSON object: { "<entityID>": "<hint>", ... }.
+// It lives next to enrichment-candidates.json in the archigraph state dir.
+func entityHintsFile(repoPath string) string {
+	return filepath.Join(daemon.StateDirForRepo(repoPath), "entity-hints.json")
+}
+
+// readEntityHints loads the entity-keyed hint store from disk.
+// Returns an empty map on any read or parse error (non-fatal).
+func readEntityHints(repoPath string) map[string]string {
 	if repoPath == "" {
-		return false
+		return map[string]string{}
 	}
-	filePath := filepath.Join(daemon.StateDirForRepo(repoPath), "enrichment-candidates.json")
-	data, err := os.ReadFile(filePath)
+	data, err := os.ReadFile(entityHintsFile(repoPath))
 	if err != nil {
+		return map[string]string{}
+	}
+	var m map[string]string
+	if json.Unmarshal(data, &m) != nil {
+		return map[string]string{}
+	}
+	return m
+}
+
+// upsertEntityHint writes (or clears) a hint for entityID in the entity-hints
+// store.  It first confirms that the entity exists among the repo's candidates
+// (so stale entity IDs get a 404 rather than silently creating orphan hints).
+// Returns true when the hint was persisted successfully.
+func upsertEntityHint(repoPath, entityID, hint string) bool {
+	if repoPath == "" || entityID == "" {
 		return false
 	}
 
-	// Support both flat-array and {"candidates":[…]} shapes.
-	var arr []candidateRaw
-	wrapped := false
-	if json.Unmarshal(data, &arr) != nil {
-		var obj struct {
-			Candidates []candidateRaw `json:"candidates"`
-		}
-		if json.Unmarshal(data, &obj) != nil {
-			return false
-		}
-		arr = obj.Candidates
-		wrapped = true
-	}
-
+	// Verify the entity exists in current candidates.
 	found := false
-	for i := range arr {
-		if arr[i].ID == cid {
-			arr[i].Hint = hint
+	for _, c := range readAllCandidates(repoPath) {
+		if c.SubjectID == entityID {
 			found = true
 			break
 		}
@@ -319,17 +363,17 @@ func updateCandidateHint(repoPath, cid, hint string) bool {
 		return false
 	}
 
-	var out []byte
-	var marshalErr error
-	if wrapped {
-		out, marshalErr = json.Marshal(struct {
-			Candidates []candidateRaw `json:"candidates"`
-		}{Candidates: arr})
+	m := readEntityHints(repoPath)
+
+	if hint == "" {
+		delete(m, entityID)
 	} else {
-		out, marshalErr = json.Marshal(arr)
+		m[entityID] = hint
 	}
-	if marshalErr != nil {
+
+	out, err := json.Marshal(m)
+	if err != nil {
 		return false
 	}
-	return os.WriteFile(filePath, out, 0o644) == nil
+	return os.WriteFile(entityHintsFile(repoPath), out, 0o644) == nil
 }

--- a/internal/dashboard/v2_pending_test.go
+++ b/internal/dashboard/v2_pending_test.go
@@ -318,19 +318,24 @@ func TestHandleV2Candidates_communityNamingExcluded(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// PUT /api/v2/groups/{group}/candidates/{cid}/hint
+// PUT /api/v2/groups/{group}/candidates/{cid}/hint  (cid = entity ID, #1518)
 // ---------------------------------------------------------------------------
 
+// TestHandleV2CandidateHint_ok verifies that a hint is stored in the
+// entity-hints store keyed by SubjectID (entity ID) and that a subsequent
+// GET /candidates returns the hint attached to the candidate.
 func TestHandleV2CandidateHint_ok(t *testing.T) {
 	repoPath := t.TempDir()
 	seedPendingCandidates(t, repoPath, []candidateRaw{
-		{ID: "c99", Kind: "repair_edge", SubjectID: "X", Confidence: 0.9},
+		// ID "c99" is the ephemeral candidate ID; "entity:X" is the stable entity ID.
+		{ID: "c99", Kind: "repair_edge", SubjectID: "entity:X", Confidence: 0.9},
 	})
 
 	ts := newPendingServer(t, "grpH", "repo1", repoPath)
 	body := bytes.NewBufferString(`{"hint":"check the migration guide"}`)
+	// URL now uses entity ID, not candidate ID.
 	req, _ := http.NewRequest("PUT",
-		ts.URL+"/api/v2/groups/grpH/candidates/c99/hint", body)
+		ts.URL+"/api/v2/groups/grpH/candidates/entity:X/hint", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -355,27 +360,146 @@ func TestHandleV2CandidateHint_ok(t *testing.T) {
 	if env.Data["hint"] != "check the migration guide" {
 		t.Errorf("want hint in response, got %v", env.Data)
 	}
-
-	// Verify hint was persisted to disk.
-	saved := readAllCandidates(repoPath)
-	if len(saved) == 0 {
-		t.Fatal("no candidates on disk after PUT")
+	if env.Data["entityId"] != "entity:X" {
+		t.Errorf("want entityId in response, got %v", env.Data)
 	}
-	if saved[0].Hint != "check the migration guide" {
-		t.Errorf("hint not persisted; got %q", saved[0].Hint)
+
+	// Verify hint is in the entity-hints store, NOT mutated onto the candidate.
+	hints := readEntityHints(repoPath)
+	if hints["entity:X"] != "check the migration guide" {
+		t.Errorf("hint not in entity-hints store; got %q", hints["entity:X"])
+	}
+	// The raw candidate's Hint field should NOT have been modified.
+	raw := readAllCandidates(repoPath)
+	if len(raw) == 0 {
+		t.Fatal("no candidates on disk")
+	}
+	if raw[0].Hint != "" {
+		t.Errorf("raw candidate Hint should be untouched; got %q", raw[0].Hint)
+	}
+
+	// GET /candidates should return the hint attached to the repair candidate.
+	gresp, err := http.Get(ts.URL + "/api/v2/groups/grpH/candidates")
+	if err != nil {
+		t.Fatalf("GET candidates: %v", err)
+	}
+	defer gresp.Body.Close()
+	var genv struct {
+		Data v2CandidatesResponse `json:"data"`
+	}
+	if err := json.NewDecoder(gresp.Body).Decode(&genv); err != nil {
+		t.Fatalf("decode candidates: %v", err)
+	}
+	if len(genv.Data.Repairs) != 1 {
+		t.Fatalf("want 1 repair, got %d", len(genv.Data.Repairs))
+	}
+	if genv.Data.Repairs[0].Hint != "check the migration guide" {
+		t.Errorf("hint not re-attached on GET; got %q", genv.Data.Repairs[0].Hint)
+	}
+	if genv.Data.Repairs[0].EntityID != "entity:X" {
+		t.Errorf("want entityId entity:X, got %q", genv.Data.Repairs[0].EntityID)
+	}
+}
+
+// TestHandleV2CandidateHint_survivesReindex verifies that the hint survives
+// a simulated re-index that replaces the candidate ID while keeping the same
+// entity ID (SubjectID).  This is the core regression tested by #1518.
+func TestHandleV2CandidateHint_survivesReindex(t *testing.T) {
+	repoPath := t.TempDir()
+	// First index: candidate ID "old-cid", entity "entity:Y".
+	seedPendingCandidates(t, repoPath, []candidateRaw{
+		{ID: "old-cid", Kind: "repair_edge", SubjectID: "entity:Y", Confidence: 0.9},
+	})
+
+	ts := newPendingServer(t, "grpReindex", "repo1", repoPath)
+
+	// Save hint by entity ID.
+	body := bytes.NewBufferString(`{"hint":"important context"}`)
+	req, _ := http.NewRequest("PUT",
+		ts.URL+"/api/v2/groups/grpReindex/candidates/entity:Y/hint", body)
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PUT hint: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("PUT want 200, got %d", resp.StatusCode)
+	}
+
+	// Simulate re-index: same SubjectID but new candidate ID "new-cid".
+	seedPendingCandidates(t, repoPath, []candidateRaw{
+		{ID: "new-cid", Kind: "repair_edge", SubjectID: "entity:Y", Confidence: 0.9},
+	})
+
+	// GET candidates — hint should still be present.
+	gresp, err := http.Get(ts.URL + "/api/v2/groups/grpReindex/candidates")
+	if err != nil {
+		t.Fatalf("GET candidates: %v", err)
+	}
+	defer gresp.Body.Close()
+	var genv struct {
+		Data v2CandidatesResponse `json:"data"`
+	}
+	if err := json.NewDecoder(gresp.Body).Decode(&genv); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(genv.Data.Repairs) != 1 {
+		t.Fatalf("want 1 repair after re-index, got %d", len(genv.Data.Repairs))
+	}
+	rc := genv.Data.Repairs[0]
+	if rc.ID != "new-cid" {
+		t.Errorf("want new-cid after re-index, got %q", rc.ID)
+	}
+	if rc.Hint != "important context" {
+		t.Errorf("hint lost after re-index; got %q", rc.Hint)
+	}
+}
+
+// TestHandleV2CandidateHint_backwardCompatLegacyHintField verifies that
+// candidates whose Hint field is still populated in enrichment-candidates.json
+// (legacy format before #1518) still have their hint returned via GET.
+func TestHandleV2CandidateHint_backwardCompatLegacyHintField(t *testing.T) {
+	repoPath := t.TempDir()
+	seedPendingCandidates(t, repoPath, []candidateRaw{
+		// Legacy: hint baked into the candidate JSON (old format).
+		{ID: "legacy-cid", Kind: "repair_edge", SubjectID: "entity:Z", Confidence: 0.9, Hint: "legacy hint"},
+	})
+
+	ts := newPendingServer(t, "grpLegacy", "repo1", repoPath)
+	gresp, err := http.Get(ts.URL + "/api/v2/groups/grpLegacy/candidates")
+	if err != nil {
+		t.Fatalf("GET candidates: %v", err)
+	}
+	defer gresp.Body.Close()
+	var genv struct {
+		Data v2CandidatesResponse `json:"data"`
+	}
+	if err := json.NewDecoder(gresp.Body).Decode(&genv); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(genv.Data.Repairs) != 1 {
+		t.Fatalf("want 1 repair, got %d", len(genv.Data.Repairs))
+	}
+	if genv.Data.Repairs[0].Hint != "legacy hint" {
+		t.Errorf("legacy hint not returned; got %q", genv.Data.Repairs[0].Hint)
 	}
 }
 
 func TestHandleV2CandidateHint_clearHint(t *testing.T) {
 	repoPath := t.TempDir()
 	seedPendingCandidates(t, repoPath, []candidateRaw{
-		{ID: "c1", Kind: "repair_edge", SubjectID: "X", Confidence: 0.9, Hint: "old hint"},
+		{ID: "c1", Kind: "repair_edge", SubjectID: "entity:ClearMe", Confidence: 0.9},
 	})
+	// Pre-seed a hint in the entity store.
+	if err := os.WriteFile(entityHintsFile(repoPath), []byte(`{"entity:ClearMe":"old hint"}`), 0o644); err != nil {
+		t.Fatalf("seed entity hints: %v", err)
+	}
 
 	ts := newPendingServer(t, "grpH2", "repo1", repoPath)
 	body := bytes.NewBufferString(`{"hint":""}`)
 	req, _ := http.NewRequest("PUT",
-		ts.URL+"/api/v2/groups/grpH2/candidates/c1/hint", body)
+		ts.URL+"/api/v2/groups/grpH2/candidates/entity:ClearMe/hint", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)
@@ -387,25 +511,24 @@ func TestHandleV2CandidateHint_clearHint(t *testing.T) {
 		t.Fatalf("want 200, got %d", resp.StatusCode)
 	}
 
-	saved := readAllCandidates(repoPath)
-	if len(saved) == 0 {
-		t.Fatal("no candidates on disk")
-	}
-	if saved[0].Hint != "" {
-		t.Errorf("hint should be cleared, got %q", saved[0].Hint)
+	// Hint should be gone from the entity store.
+	hints := readEntityHints(repoPath)
+	if h, ok := hints["entity:ClearMe"]; ok {
+		t.Errorf("hint should be removed; got %q", h)
 	}
 }
 
 func TestHandleV2CandidateHint_notFound(t *testing.T) {
 	repoPath := t.TempDir()
 	seedPendingCandidates(t, repoPath, []candidateRaw{
-		{ID: "c1", Kind: "repair_edge", SubjectID: "X", Confidence: 0.9},
+		{ID: "c1", Kind: "repair_edge", SubjectID: "entity:Known", Confidence: 0.9},
 	})
 
 	ts := newPendingServer(t, "grpH3", "repo1", repoPath)
 	body := bytes.NewBufferString(`{"hint":"irrelevant"}`)
+	// Use an entity ID that doesn't exist in candidates.
 	req, _ := http.NewRequest("PUT",
-		ts.URL+"/api/v2/groups/grpH3/candidates/no-such-id/hint", body)
+		ts.URL+"/api/v2/groups/grpH3/candidates/entity:NoSuchEntity/hint", body)
 	req.Header.Set("Content-Type", "application/json")
 
 	resp, err := http.DefaultClient.Do(req)

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -469,6 +469,8 @@ export type Severity = "critical" | "warning" | "info";
 
 export interface RepairCandidate {
   id: string;
+  /** Stable entity identifier (SubjectID). Use this — not id — for hint keying. */
+  entityId: string;
   severity: Severity;
   issueType: RepairIssueType;
   entity: EntityRef;
@@ -477,20 +479,26 @@ export interface RepairCandidate {
   confidence: number;
   /** Unix ms. */
   detectedAt: number;
+  /** Team-authored hint currently stored for this entity (may be absent). */
+  hint?: string;
 }
 
 export interface EnrichmentCandidate {
   id: string;
+  /** Stable entity identifier (SubjectID). Use this — not id — for hint keying. */
+  entityId: string;
   enrichmentType: EnrichmentType;
   entity: EntityRef;
   description: string;
   confidence: number;
   detectedAt: number;
+  /** Team-authored hint currently stored for this entity (may be absent). */
+  hint?: string;
 }
 
 export type Candidate = RepairCandidate | EnrichmentCandidate;
 
-/** Hints stored per-candidate-id in local state and persisted via PUT hint. */
+/** Hints stored per-entity-id in local state and persisted via PUT hint (#1518). */
 export type HintMap = Record<string, string>;
 
 /** Wire shape returned by GET /api/v2/groups/:id/candidates */

--- a/webui-v2/src/hooks/use-pending.ts
+++ b/webui-v2/src/hooks/use-pending.ts
@@ -17,12 +17,17 @@ export function useCandidates(groupId: string) {
   });
 }
 
-/** Mutation to persist a hint for one candidate. Invalidates candidates query on success. */
+/**
+ * Mutation to persist a hint for one entity.
+ * Pass the stable `entityId` from the candidate (NOT the ephemeral `id`)
+ * so hints survive candidate-ID churn across re-index sweeps (#1518).
+ * Invalidates the candidates query on success.
+ */
 export function useSaveHint(groupId: string) {
   const qc = useQueryClient();
   return useMutation({
-    mutationFn: ({ candidateId, hint }: { candidateId: string; hint: string }) =>
-      api.saveHint(groupId, candidateId, hint),
+    mutationFn: ({ entityId, hint }: { entityId: string; hint: string }) =>
+      api.saveHint(groupId, entityId, hint),
     onSuccess: () => {
       // Invalidate so a background refetch picks up the persisted hint value.
       qc.invalidateQueries({ queryKey: ["candidates", groupId] });

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -259,10 +259,14 @@ export const api = {
     requestV2<V2CandidatesResponse>(
       `/groups/${encodeURIComponent(groupId)}/candidates${tab ? `?tab=${tab}` : ""}`,
     ),
-  /** Persist a hint for a candidate. Empty string clears the hint. */
-  saveHint: (groupId: string, candidateId: string, hint: string) =>
-    requestV2<{ ok: true }>(
-      `/groups/${encodeURIComponent(groupId)}/candidates/${encodeURIComponent(candidateId)}/hint`,
+  /**
+   * Persist a hint for an entity.  Pass the stable `entityId` field from the
+   * candidate (NOT the ephemeral `id`) so hints survive candidate-ID churn
+   * across re-index sweeps (#1518).  Empty string clears the hint.
+   */
+  saveHint: (groupId: string, entityId: string, hint: string) =>
+    requestV2<{ hint: string; entityId: string }>(
+      `/groups/${encodeURIComponent(groupId)}/candidates/${encodeURIComponent(entityId)}/hint`,
       { method: "PUT", body: JSON.stringify({ hint }) },
     ),
   // --- Flows (Process Flow Explorer) ---

--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -600,6 +600,7 @@ export default function PendingScreen() {
     toggleGroup,
     setDraft,
     confirmSave,
+    seedServerHints,
   } = usePendingStore();
 
   // All items for the current tab.
@@ -614,6 +615,17 @@ export default function PendingScreen() {
       setFocusedId(allItems[0].id);
     }
   }, [allItems, focusedId, setFocusedId]);
+
+  // Seed server-provided hints into the store so they populate the input on
+  // first render without a separate PUT round-trip (#1518).
+  useEffect(() => {
+    if (!data) return;
+    const hints: Record<string, string> = {};
+    for (const c of [...data.repairs, ...data.enrichments]) {
+      if (c.hint) hints[c.entityId] = c.hint;
+    }
+    seedServerHints(hints);
+  }, [data, seedServerHints]);
 
   // Filter candidates.
   const filtered = useMemo(
@@ -662,18 +674,20 @@ export default function PendingScreen() {
   const focusedItem = focusedId
     ? allItems.find((i) => i.id === focusedId) ?? null
     : null;
-  const focusedDraft = focusedId
-    ? (drafts[focusedId] ?? savedHints[focusedId] ?? "")
+  // Hints are keyed by entityId (stable), not by the ephemeral candidate id (#1518).
+  const focusedEntityId = focusedItem?.entityId ?? null;
+  const focusedDraft = focusedEntityId
+    ? (drafts[focusedEntityId] ?? savedHints[focusedEntityId] ?? "")
     : "";
-  const focusedSaved = focusedId ? (savedHints[focusedId] ?? "") : "";
+  const focusedSaved = focusedEntityId ? (savedHints[focusedEntityId] ?? "") : "";
 
   const handleSaveHint = () => {
     if (!focusedItem) return;
     saveHintMutation.mutate(
-      { candidateId: focusedItem.id, hint: focusedDraft },
+      { entityId: focusedItem.entityId, hint: focusedDraft },
       {
         onSuccess: () => {
-          confirmSave(focusedItem.id, focusedDraft);
+          confirmSave(focusedItem.entityId, focusedDraft);
           toast.success("Hint saved.");
         },
         onError: () => {
@@ -800,7 +814,7 @@ export default function PendingScreen() {
               tab={tab}
               draft={focusedDraft}
               savedHint={focusedSaved}
-              onDraftChange={(v) => focusedId && setDraft(focusedId, v)}
+              onDraftChange={(v) => focusedEntityId && setDraft(focusedEntityId, v)}
               onSave={handleSaveHint}
               saving={saveHintMutation.isPending}
               groupId={groupId}

--- a/webui-v2/src/store/use-pending-store.ts
+++ b/webui-v2/src/store/use-pending-store.ts
@@ -20,9 +20,16 @@ interface PendingState {
   focusedId: string | null;
   /** Map of groupKey → collapsed (false means collapsed; absent/true means open). */
   openMap: Record<string, boolean>;
-  /** Per-candidate-id hint text typed but not yet saved to the server. */
+  /**
+   * Per-ENTITY-ID hint text typed but not yet saved to the server (#1518).
+   * Keyed by candidate.entityId (SubjectID), NOT by candidate.id.
+   */
   drafts: Record<string, string>;
-  /** Per-candidate-id hint text that has been confirmed saved (from PUT response). */
+  /**
+   * Per-ENTITY-ID hint text confirmed saved (from PUT response or seeded from
+   * server-returned hint field) (#1518).
+   * Keyed by candidate.entityId (SubjectID), NOT by candidate.id.
+   */
   savedHints: Record<string, string>;
 
   setTab: (tab: PendingTab) => void;
@@ -30,8 +37,12 @@ interface PendingState {
   setGroupBy: (groupBy: PendingGroupBy) => void;
   setFocusedId: (id: string | null) => void;
   toggleGroup: (key: string) => void;
-  setDraft: (id: string, text: string) => void;
-  confirmSave: (id: string, hint: string) => void;
+  /** Set draft hint text for an entity. Pass candidate.entityId as key. */
+  setDraft: (entityId: string, text: string) => void;
+  /** Confirm that a hint was successfully saved for an entity. */
+  confirmSave: (entityId: string, hint: string) => void;
+  /** Seed server-provided hints (from GET /candidates response) into savedHints. */
+  seedServerHints: (hints: Record<string, string>) => void;
 }
 
 export const usePendingStore = create<PendingState>((set) => ({
@@ -51,11 +62,17 @@ export const usePendingStore = create<PendingState>((set) => ({
     set((s) => ({
       openMap: { ...s.openMap, [key]: s.openMap[key] === false ? true : false },
     })),
-  setDraft: (id, text) => set((s) => ({ drafts: { ...s.drafts, [id]: text } })),
-  confirmSave: (id, hint) =>
+  setDraft: (entityId, text) =>
+    set((s) => ({ drafts: { ...s.drafts, [entityId]: text } })),
+  confirmSave: (entityId, hint) =>
     set((s) => {
       const drafts = { ...s.drafts };
-      delete drafts[id];
-      return { drafts, savedHints: { ...s.savedHints, [id]: hint } };
+      delete drafts[entityId];
+      return { drafts, savedHints: { ...s.savedHints, [entityId]: hint } };
     }),
+  seedServerHints: (hints) =>
+    set((s) => ({
+      // Merge server hints; locally confirmed saves take precedence.
+      savedHints: { ...hints, ...s.savedHints },
+    })),
 }));


### PR DESCRIPTION
## Problem

Pending-screen hints were stored keyed by the ephemeral **candidate ID** (`c.ID`) — a value regenerated on every index sweep. Every re-index silently dropped all user-authored hints, making the feature unreliable. Fixes #1518.

## What changed

### Daemon (`internal/dashboard/v2_pending.go`)

- New `entity-hints.json` store (a flat `map[entityID]string`) lives next to `enrichment-candidates.json` in the archigraph state dir.
- `upsertEntityHint(repoPath, entityID, hint)` — writes or clears the hint; validates the entity still exists in current candidates before writing (so stale entity IDs get a proper 404).
- `readEntityHints(repoPath)` — loads the store (non-fatal on miss).
- `GET /candidates` — re-attaches hints from `entity-hints.json` keyed by `SubjectID`; falls back to the legacy `Hint` field on the raw candidate entry for backward compatibility with existing data.
- Wire shapes `v2RepairCandidate` / `v2EnrichmentCandidate` gain two new fields: `EntityID` (= `SubjectID`, stable) and `Hint`.
- `PUT …/candidates/{cid}/hint` — `{cid}` is now interpreted as **entity ID** (SubjectID), not candidate ID. Response includes `entityId` to let the client confirm the key used.

### Frontend (`webui-v2/`)

| File | Change |
|---|---|
| `src/data/types.ts` | `entityId: string` + `hint?: string` on both candidate interfaces; `HintMap` comment updated |
| `src/lib/api.ts` | `saveHint` param `candidateId` → `entityId`; return type updated |
| `src/hooks/use-pending.ts` | mutation arg `candidateId` → `entityId` |
| `src/store/use-pending-store.ts` | `drafts` + `savedHints` keyed by `entityId`; new `seedServerHints` action |
| `src/routes/pending.tsx` | All hint paths use `focusedItem.entityId`; `useEffect` seeds server-returned hints into the store on load |

## Tests

- `TestHandleV2CandidateHint_ok` — updated to use entity IDs; asserts hint lands in `entity-hints.json`, NOT mutated onto the raw candidate; asserts GET re-attaches the hint; asserts `entityId` echoed in response.
- `TestHandleV2CandidateHint_survivesReindex` (new) — saves hint by entity ID, replaces candidates file with new candidate IDs, confirms hint still appears on GET.
- `TestHandleV2CandidateHint_backwardCompatLegacyHintField` (new) — candidate with `hint` baked into the JSON (legacy format) still returns it on GET.
- `TestHandleV2CandidateHint_clearHint` — updated to pre-seed `entity-hints.json` and verify deletion.
- `TestHandleV2CandidateHint_notFound` — now 404s on unknown entity ID (not candidate ID).

All 14 v2 tests pass. Two pre-existing failures in `TestWriteback_success` / `TestYamlScalar` (unrelated writeback work) are unchanged. `npm run build` (TypeScript + Vite) clean.

## Test plan

- [ ] `go test ./internal/dashboard/... -run TestHandleV2` — all 14 pass
- [ ] `cd webui-v2 && npm run build` — no TS or bundle errors
- [ ] Manual: save a hint on a candidate, re-trigger indexing, confirm hint survives on reload
- [ ] Manual: candidates lacking a hint show empty hint input

🤖 Generated with [Claude Code](https://claude.com/claude-code)