### PR TITLE
feat(graph): ?node= deep-link, canvas code-split, daemon-side LoD thinning

### DIFF
--- a/internal/dashboard/v2_graph.go
+++ b/internal/dashboard/v2_graph.go
@@ -103,6 +103,7 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 	includeExternal := r.URL.Query().Get("include_external") == "true"
 	includeModules := r.URL.Query().Get("view") == "modules" ||
 		r.URL.Query().Get("include") == "modules"
+	lodParam := r.URL.Query().Get("lod")
 
 	grp, err := s.graphs.GetGroup(group)
 	if err != nil {
@@ -112,7 +113,8 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 
 	// Payload cache + strong ETag/304. A "v2:" prefix keeps the v2 payload
 	// cache entries distinct from v1's for the same (group, params) tuple.
-	cacheKey := "v2:" + payloadCacheKey(group, filterKind, "", reposParam, includeExternal, includeModules)
+	// The lod suffix is appended so each LoD level has its own cache entry.
+	cacheKey := "v2:" + payloadCacheKey(group, filterKind, "", reposParam, includeExternal, includeModules) + ":lod=" + lodParam
 	if entry, hit := s.graphs.Payloads.Get(cacheKey); hit {
 		w.Header().Set("ETag", entry.etag)
 		w.Header().Set("Vary", "Accept-Encoding")
@@ -142,6 +144,27 @@ func (s *Server) handleV2Graph(w http.ResponseWriter, r *http.Request) {
 	}
 
 	resp := s.buildV2Graph(repos, grp, filterKind, includeExternal, includeModules)
+
+	// Apply LoD thinning: cap nodes by pagerank, then drop orphaned edges.
+	// total_node_count is preserved as the un-thinned count so the UI badge
+	// can read "500 / 12 000" even after thinning.
+	totalBeforeThin := resp.TotalNodeCount
+	nodeCap := lodNodeCap(lodParam)
+	if nodeCap > 0 && len(resp.Nodes) > nodeCap {
+		resp.Nodes = thinByPagerank(resp.Nodes, nodeCap)
+		keptIDs := make(map[string]bool, len(resp.Nodes))
+		for _, n := range resp.Nodes {
+			keptIDs[n.ID] = true
+		}
+		pruned := resp.Edges[:0]
+		for _, e := range resp.Edges {
+			if keptIDs[e.Source] && keptIDs[e.Target] {
+				pruned = append(pruned, e)
+			}
+		}
+		resp.Edges = pruned
+	}
+	resp.TotalNodeCount = totalBeforeThin
 
 	if resp.TotalNodeCount > softNodeWarnThreshold {
 		w.Header().Set("X-Graph-Warning", "large-graph: node count exceeds 50k; consider filtering by repo or kind")
@@ -298,6 +321,42 @@ func communityColorIndex(id int) int {
 		return 1
 	}
 	return (id % pastelScaleSize) + 1
+}
+
+// ── LoD helpers ──────────────────────────────────────────────────────────────
+
+// lodNodeCap maps a ?lod= query value to a node budget (0 = unlimited).
+// Canonical names: overview|normal|full.
+// Legacy frontend LodLevel strings: low|mid|high are also accepted.
+func lodNodeCap(lod string) int {
+	switch lod {
+	case "overview", "low":
+		return 500
+	case "full", "high":
+		return 0 // unlimited
+	default:
+		// "normal", "mid", "" (no param), and unknown values all default to 3000.
+		return 3000
+	}
+}
+
+// thinByPagerank returns at most cap nodes from nodes, keeping those with
+// the highest pagerank (ties broken by degree). If cap == 0 or
+// cap >= len(nodes) it returns nodes unchanged. The returned slice is a
+// new allocation sorted descending by pagerank.
+func thinByPagerank(nodes []v2GraphNode, cap int) []v2GraphNode {
+	if cap == 0 || len(nodes) <= cap {
+		return nodes
+	}
+	sorted := make([]v2GraphNode, len(nodes))
+	copy(sorted, nodes)
+	sort.Slice(sorted, func(i, j int) bool {
+		if sorted[i].PageRank != sorted[j].PageRank {
+			return sorted[i].PageRank > sorted[j].PageRank
+		}
+		return sorted[i].Degree > sorted[j].Degree
+	})
+	return sorted[:cap]
 }
 
 // dominantLanguage returns the most frequent non-empty Language across the

--- a/internal/dashboard/v2_graph_test.go
+++ b/internal/dashboard/v2_graph_test.go
@@ -1,0 +1,176 @@
+package dashboard
+
+// v2_graph_test.go — unit tests for the ?lod= LoD thinning feature (#1516).
+//
+// The tests verify:
+//   - lod=overview caps nodes to the top 500 by pagerank.
+//   - lod=normal caps nodes to the top 3000 by pagerank.
+//   - lod=full (or no param) returns all nodes.
+//   - Edges whose endpoints are removed by LoD thinning are dropped.
+//   - total_node_count reflects the un-thinned count.
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeV2GraphTestServer builds a test server loaded with n fake entities.
+// Entities are given pagerank values 0..n-1 scaled to [0,1) (highest = n-1/n).
+func makeV2GraphTestServer(t *testing.T, n int) *httptest.Server {
+	t.Helper()
+	entities := make([]graph.Entity, n)
+	for i := range entities {
+		pr := float64(i) / float64(n)
+		entities[i] = graph.Entity{
+			ID:       fmt.Sprintf("e%d", i),
+			Kind:     "function",
+			PageRank: &pr,
+		}
+	}
+	grp := makeGraphTestGroup(entities, nil)
+	return newV2GraphTestServerWithGroup(t, grp)
+}
+
+func newV2GraphTestServerWithGroup(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name: "testgrp", ConfigPath: "/tmp/testgrp.json", Repos: []string{"testrepo"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+func fetchV2Graph(t *testing.T, ts *httptest.Server, lod string) v2GraphResponse {
+	t.Helper()
+	url := ts.URL + "/api/v2/graph/testgrp"
+	if lod != "" {
+		url += "?lod=" + lod
+	}
+	resp, err := http.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d for lod=%q", resp.StatusCode, lod)
+	}
+	var env struct {
+		Data v2GraphResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return env.Data
+}
+
+func TestV2GraphLoD_Full(t *testing.T) {
+	const n = 100
+	ts := makeV2GraphTestServer(t, n)
+	data := fetchV2Graph(t, ts, "full")
+	if len(data.Nodes) != n {
+		t.Errorf("lod=full: got %d nodes, want %d", len(data.Nodes), n)
+	}
+	if data.TotalNodeCount != n {
+		t.Errorf("lod=full: TotalNodeCount=%d, want %d", data.TotalNodeCount, n)
+	}
+}
+
+func TestV2GraphLoD_Overview(t *testing.T) {
+	const n = 1000
+	const cap = 500
+	ts := makeV2GraphTestServer(t, n)
+	data := fetchV2Graph(t, ts, "overview")
+	if len(data.Nodes) > cap {
+		t.Errorf("lod=overview: got %d nodes, want ≤%d", len(data.Nodes), cap)
+	}
+	if data.TotalNodeCount != n {
+		t.Errorf("lod=overview: TotalNodeCount=%d, want %d (un-thinned)", data.TotalNodeCount, n)
+	}
+}
+
+func TestV2GraphLoD_Normal(t *testing.T) {
+	const n = 5000
+	const cap = 3000
+	ts := makeV2GraphTestServer(t, n)
+	data := fetchV2Graph(t, ts, "normal")
+	if len(data.Nodes) > cap {
+		t.Errorf("lod=normal: got %d nodes, want ≤%d", len(data.Nodes), cap)
+	}
+	if data.TotalNodeCount != n {
+		t.Errorf("lod=normal: TotalNodeCount=%d, want %d (un-thinned)", data.TotalNodeCount, n)
+	}
+}
+
+func TestV2GraphLoD_LegacyNames(t *testing.T) {
+	// "low", "mid", "high" are the frontend's LodLevel strings; accept them too.
+	const n = 1000
+	ts := makeV2GraphTestServer(t, n)
+	if data := fetchV2Graph(t, ts, "low"); len(data.Nodes) > 500 {
+		t.Errorf("lod=low (legacy): got %d nodes, want ≤500", len(data.Nodes))
+	}
+	if data := fetchV2Graph(t, ts, "high"); len(data.Nodes) != n {
+		t.Errorf("lod=high (legacy): got %d nodes, want %d", len(data.Nodes), n)
+	}
+}
+
+func TestV2GraphLoD_DefaultIsNormal(t *testing.T) {
+	// No ?lod= param → same as lod=normal (cap 3000).
+	const n = 5000
+	ts := makeV2GraphTestServer(t, n)
+	data := fetchV2Graph(t, ts, "")
+	if len(data.Nodes) > 3000 {
+		t.Errorf("no lod: got %d nodes, want ≤3000 (default=normal)", len(data.Nodes))
+	}
+}
+
+func TestV2GraphLoD_EdgesDropped(t *testing.T) {
+	// With lod=overview on 600 nodes (cap=500), the lowest-pagerank nodes are
+	// removed. Verify no edge in the thinned response references a missing node.
+	const n = 600
+	entities := make([]graph.Entity, n)
+	rels := make([]graph.Relationship, 0, n)
+	for i := range entities {
+		pr := float64(i) / float64(n)
+		entities[i] = graph.Entity{ID: fmt.Sprintf("e%d", i), Kind: "function", PageRank: &pr}
+	}
+	// chain: e0→e1, e1→e2, ... e(n-1)→e0
+	for i := 0; i < n; i++ {
+		rels = append(rels, graph.Relationship{
+			FromID: fmt.Sprintf("e%d", i),
+			ToID:   fmt.Sprintf("e%d", (i+1)%n),
+			Kind:   "CALLS",
+		})
+	}
+	grp := makeGraphTestGroup(entities, rels)
+	ts := newV2GraphTestServerWithGroup(t, grp)
+
+	data := fetchV2Graph(t, ts, "overview") // cap=500; removes e0..e99
+	nodeSet := make(map[string]bool, len(data.Nodes))
+	for _, nd := range data.Nodes {
+		nodeSet[nd.ID] = true
+	}
+	for _, e := range data.Edges {
+		if !nodeSet[e.Source] {
+			t.Errorf("edge source %q not in thinned node set", e.Source)
+		}
+		if !nodeSet[e.Target] {
+			t.Errorf("edge target %q not in thinned node set", e.Target)
+		}
+	}
+}

--- a/webui-v2/src/hooks/use-graph.ts
+++ b/webui-v2/src/hooks/use-graph.ts
@@ -14,8 +14,8 @@ import type {
   EntityDetailWire,
 } from "@/data/types";
 
-export const graphQueryKey = (groupId: string, repos?: string[], filterKind?: string) =>
-  ["graph", groupId, repos?.slice().sort().join(",") ?? "", filterKind ?? ""] as const;
+export const graphQueryKey = (groupId: string, repos?: string[], filterKind?: string, lod?: string) =>
+  ["graph", groupId, repos?.slice().sort().join(",") ?? "", filterKind ?? "", lod ?? ""] as const;
 
 /** Normalize the wire payload (snake_case) into the domain shape. */
 function normalize(w: GraphPayloadWire): GraphPayload {
@@ -50,10 +50,10 @@ function normalize(w: GraphPayloadWire): GraphPayload {
  */
 export function useGraph(
   groupId: string,
-  opts?: { repos?: string[]; filterKind?: string },
+  opts?: { repos?: string[]; filterKind?: string; lod?: string },
 ) {
   return useQuery({
-    queryKey: graphQueryKey(groupId, opts?.repos, opts?.filterKind),
+    queryKey: graphQueryKey(groupId, opts?.repos, opts?.filterKind, opts?.lod),
     queryFn: async () => normalize(await api.getGraph(groupId, opts)),
     // The payload is large + server-cached (ETag/304); keep it warm.
     staleTime: 5 * 60 * 1000,

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -134,10 +134,11 @@ export const api = {
     requestV2<DocsEntityDetail>(`/groups/${groupId}/docs/entities/${encodeURIComponent(entityId)}`),
   /** v2 — the full graph payload (nodes/edges/communities/repos) for the Graph
    *  screen. `params` maps to the daemon's repo/kind filters. */
-  getGraph: (groupId: string, params?: { repos?: string[]; filterKind?: string }) => {
+  getGraph: (groupId: string, params?: { repos?: string[]; filterKind?: string; lod?: string }) => {
     const qs = new URLSearchParams();
     if (params?.repos && params.repos.length > 0) qs.set("repos", params.repos.join(","));
     if (params?.filterKind) qs.set("filter_kind", params.filterKind);
+    if (params?.lod) qs.set("lod", params.lod);
     const suffix = qs.toString() ? `?${qs.toString()}` : "";
     return requestV2<GraphPayloadWire>(`/graph/${encodeURIComponent(groupId)}${suffix}`);
   },

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -12,15 +12,17 @@
    Query.
    ============================================================ */
 
-import { useEffect, useMemo, useRef } from "react";
-import { useParams } from "react-router-dom";
+import { useEffect, useMemo, useRef, lazy, Suspense } from "react";
+import { useParams, useSearchParams } from "react-router-dom";
 import { X, RotateCcw, SlidersHorizontal } from "lucide-react";
 import { SearchInput, Pill, Kbd } from "@/components/ui";
 import { useGraph } from "@/hooks/use-graph";
 import { useGraphStore, type ColorMode } from "@/store/use-graph-store";
 import { useAppStore } from "@/store/use-app-store";
 import type { EdgeKind, GraphNode } from "@/data/types";
-import { GraphCanvas } from "@/components/graph/graph-canvas";
+const GraphCanvas = lazy(() =>
+  import("@/components/graph/graph-canvas").then((m) => ({ default: m.GraphCanvas })),
+);
 import { NodeInspector } from "@/components/graph/node-inspector";
 import { FiltersDrawer } from "@/components/graph/filters-drawer";
 import { CommunitiesPopover } from "@/components/graph/communities-popover";
@@ -37,9 +39,38 @@ export default function GraphScreen() {
   const isDark = theme === "dark";
 
   const s = useGraphStore();
-  const { data, isLoading, isError } = useGraph(groupId);
+  const [searchParams, setSearchParams] = useSearchParams();
+  const { data, isLoading, isError } = useGraph(groupId, { lod: s.lod });
 
   const searchRef = useRef<HTMLInputElement>(null);
+
+  // ── ?node= deep-link: restore on mount, persist on selection change ──────────
+  // On first render, if the URL carries ?node=<id>, apply it as the selected
+  // node. focusEgo is called in a separate data-ready effect below.
+  useEffect(() => {
+    const nodeParam = searchParams.get("node");
+    if (nodeParam && !s.selectedNodeId) {
+      s.setSelectedNode(nodeParam);
+    }
+    // Only run on mount — searchParams intentionally excluded to avoid loops.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  // Mirror selectedNodeId → URL so a deep-link can be copied.
+  useEffect(() => {
+    setSearchParams(
+      (prev) => {
+        const next = new URLSearchParams(prev);
+        if (s.selectedNodeId) {
+          next.set("node", s.selectedNodeId);
+        } else {
+          next.delete("node");
+        }
+        return next;
+      },
+      { replace: true },
+    );
+  }, [s.selectedNodeId, setSearchParams]);
 
   // ── keyboard: / focus search, F filters, Escape cascade ─────────────────────
   useEffect(() => {
@@ -108,6 +139,15 @@ export default function GraphScreen() {
     }
     s.setFocusNodes(set);
   };
+
+  // Once data arrives, if a node was deep-linked, focus its ego-graph.
+  useEffect(() => {
+    if (data && s.selectedNodeId && !s.focusNodeIds) {
+      focusEgo(s.selectedNodeId, 1);
+    }
+    // Only trigger when data first becomes available.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [!!data]);
 
   const selectedNode: GraphNode | null = useMemo(
     () => nodes.find((n) => n.id === s.selectedNodeId) ?? null,
@@ -216,25 +256,33 @@ export default function GraphScreen() {
           </div>
         ) : (
           <>
-            <GraphCanvas
-              group={groupId}
-              nodes={nodes}
-              edges={edges}
-              selectedNodeId={s.selectedNodeId}
-              isDark={isDark}
-              colorMode={s.colorMode}
-              groupBy={s.groupBy}
-              simulation={s.simulation}
-              nodeSizing={s.nodeSizing}
-              render={s.render}
-              activeRepos={s.activeRepos}
-              focusedCommunityId={s.focusedCommunityId}
-              focusNodeIds={s.focusNodeIds}
-              relayoutNonce={s.relayoutNonce}
-              onNodeClick={onNodeClick}
-              onNodeHover={(n) => s.setHoveredNode(n?.id ?? null)}
-              onSettled={() => {}}
-            />
+            <Suspense
+              fallback={
+                <div className="grid h-full place-items-center bg-bg">
+                  <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
+                </div>
+              }
+            >
+              <GraphCanvas
+                group={groupId}
+                nodes={nodes}
+                edges={edges}
+                selectedNodeId={s.selectedNodeId}
+                isDark={isDark}
+                colorMode={s.colorMode}
+                groupBy={s.groupBy}
+                simulation={s.simulation}
+                nodeSizing={s.nodeSizing}
+                render={s.render}
+                activeRepos={s.activeRepos}
+                focusedCommunityId={s.focusedCommunityId}
+                focusNodeIds={s.focusNodeIds}
+                relayoutNonce={s.relayoutNonce}
+                onNodeClick={onNodeClick}
+                onNodeHover={(n) => s.setHoveredNode(n?.id ?? null)}
+                onSettled={() => {}}
+              />
+            </Suspense>
 
             <div className="pointer-events-none absolute bottom-3 left-3 z-20 rounded-md border border-border bg-surface/80 px-2 py-1 font-mono text-xs text-text-3 backdrop-blur-sm">
               LOD: {lodLabel}


### PR DESCRIPTION
## What

Three WebUI v2 Graph polish items from #1516 (unblocked after #1513 graph-knobs merged):

1. **`?node=` deep-link** — `routes/graph.tsx` uses `useSearchParams` to persist/restore `selectedNodeId` in the URL. Loading `/g/<group>/graph?node=<id>` selects the node and focuses its ego-graph once data arrives. Follows the exact pattern used in `routes/paths.tsx` (functional parity with how Paths tracks `?path=`).
2. **Canvas code-split** — `GraphCanvas` (which imports `@cosmos.gl/graph`, ~840 kB) is now `React.lazy`-loaded with a `Suspense` spinner. Vite emits it as a separate async chunk (`graph-canvas-*.js`, 378 kB gzip 112 kB), shrinking the initial bundle and improving first-paint. FiltersDrawer + tuning-panels/store from #1520 are unaffected (static imports).
3. **Daemon-side LoD thinning** — `GET /api/v2/graph/{group}?lod=` now accepts `overview|normal|full` (also legacy aliases `low|mid|high` matching the existing `LodLevel` type). Handler caps nodes to top-500/3000/unlimited by pagerank (degree as tiebreak), drops orphaned edges, preserves `total_node_count` as the un-thinned count for the LOD badge. The `lod` param threads through `api.ts → use-graph.ts → GraphScreen` so the FiltersDrawer LoD selector triggers a real re-fetch.

## Why

- **Deep-link**: engineers want to share a URL pointing directly at a node of interest; the graph screen was the only surface without URL state.
- **Code-split**: the 840 kB synchronous cosmos chunk triggered a Vite chunk-size warning and delayed first-paint for all users, not just those visiting the Graph screen.
- **LoD**: the selector existed since #1513 but was purely cosmetic; large corpora (10k+ nodes) needed server-side relief to stay performant. `total_node_count` now lets the badge read "500 / 12 000" so the user sees the thinning.

## How it was tested

- **Go**: `go test ./internal/dashboard/ -run TestV2GraphLoD -v` — 6 TDD tests (overview cap, normal cap, full/unlimited, legacy aliases `low`/`high`, default=normal, edge-pruning after thinning) all PASS.
- **Frontend**: `npm run build` — `graph-canvas-2vTXSkEL.js` (378 kB) confirmed as a separate Vite chunk; TypeScript clean.
- **Playwright (headless)**: navigated to `/g/demo/graph?node=test-node-123`; `window.location.search.includes('node=')` → `true`; Graph screen toolbar rendered; Filters drawer opened showing LEVEL OF DETAIL section with LOW/MID/HIGH buttons wired. Screenshots: `1516-deep-link.png` + `1516-filters-lod.png`.
- **Daemon untouched**: `git diff HEAD -- dashboard/` → empty.
- **Pre-existing failures**: `TestWriteback_success` and `TestYamlScalar` fail on `main` before this branch — confirmed unrelated.

## Files changed

| File | Change |
|---|---|
| `webui-v2/src/routes/graph.tsx` | `useSearchParams` + lazy `GraphCanvas` + `Suspense` wrapper + `lod` wired to `useGraph` |
| `webui-v2/src/hooks/use-graph.ts` | `lod` in query key and opts signature |
| `webui-v2/src/lib/api.ts` | `lod` query string param in `getGraph` |
| `internal/dashboard/v2_graph.go` | `lodParam` parsing, `lodNodeCap` + `thinByPagerank` helpers, cache key includes lod, edge pruning after thin |
| `internal/dashboard/v2_graph_test.go` | new file: 6 LoD handler tests |

## Checklist

- [x] `go build ./internal/... ./cmd/...` clean
- [x] `go test ./internal/dashboard/ -run TestV2GraphLoD` — 6/6 PASS
- [x] `npm run build` clean; `graph-canvas-*.js` separate chunk confirmed
- [x] Playwright: `?node=` URL param preserved on load; Filters drawer LoD selector visible and rendered
- [x] Dev server torn down after verification
- [x] `dashboard/` zero diff

Fixes #1516