### PR TITLE
feat(webui-v2): create-group / add-repo scan→detect→index wizard (Fixes #1517)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -551,6 +551,15 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups", s.handleV2Groups)
 	mux.HandleFunc("POST /api/v2/groups", s.handleV2CreateGroup)
 
+	// Create-group / add-repo scan→detect→index wizard (#1517).
+	// scan/inspect detects stack + monorepo (no writes); from-scan creates a
+	// group + registers repos + enqueues an async index job; repos/scan does
+	// the same for an existing group. All index steps return a 202 JobAck the
+	// wizard streams via /api/v2/jobs/{id}/stream.
+	mux.HandleFunc("POST /api/v2/scan/inspect", s.handleV2ScanInspect)
+	mux.HandleFunc("POST /api/v2/groups/from-scan", s.handleV2CreateGroupFromScan)
+	mux.HandleFunc("POST /api/v2/groups/{group}/repos/scan", s.handleV2ScanRepos)
+
 	// Docs entity browser — WebUI v2 (#1438)
 	mux.HandleFunc("GET /api/v2/groups/{group}/docs/tree", s.handleV2DocsTree)
 	mux.HandleFunc("GET /api/v2/groups/{group}/docs/entities/{entityId}", s.handleV2DocsEntityDetail)

--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -1,0 +1,291 @@
+// v2_wizard.go — shared create-group / add-repo scan→detect→index wizard (#1517).
+//
+// Today create-group (#1451) makes an EMPTY group and Settings add-repo (#1455)
+// only registers a repo without indexing. This file adds the thin v2 endpoints
+// the shared WebUI v2 wizard drives:
+//
+//	POST /api/v2/scan/inspect            → resolve + validate a path, detect
+//	                                       stack + monorepo layout (no writes)
+//	POST /api/v2/groups/from-scan        → create group + register repos +
+//	                                       enqueue an async index job (JobAck)
+//	POST /api/v2/groups/{group}/repos/scan → register repos into an existing
+//	                                       group + enqueue an async index job
+//
+// Directory input — server-side path, NOT a browser File handle:
+//
+//	The daemon indexes paths on its OWN filesystem (the Rebuild RPC, the
+//	registry, and detect.* all take an absolute path the daemon resolves).
+//	The browser File System Access API (showDirectoryPicker) only yields an
+//	opaque FileSystemDirectoryHandle with no real on-disk path, so it cannot
+//	tell the daemon WHICH directory to index. The wizard therefore sends a
+//	PATH STRING that the daemon resolves with the SAME expandPath() the v1
+//	onboard endpoints use. showDirectoryPicker is used in the UI only as an
+//	optional convenience to prefill the folder *name* hint; the path field is
+//	the source of truth. This mirrors how #1512's rebuild endpoint targets a
+//	group whose repos are already absolute server paths.
+//
+// Reuse: scan/inspect wraps the SAME detect.Stack + detect.DetectMonorepo the
+// v1 /api/onboard endpoints use; the index step reuses the #1512 actionJob
+// infra (s.actionJobs + runRebuildJob) so progress is pollable/streamable via
+// /api/v2/jobs/{id} + /api/v2/jobs/{id}/stream.
+
+package dashboard
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+	"github.com/cajasmota/archigraph/internal/install/detect"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// v2ScanInspectReq is the request body for POST /api/v2/scan/inspect.
+type v2ScanInspectReq struct {
+	Path string `json:"path"`
+}
+
+// v2ScanInspectReply is the detection preview returned by the scan step.
+type v2ScanInspectReply struct {
+	// Valid reports whether the path resolved to an existing directory.
+	Valid bool `json:"valid"`
+	// AbsPath is the resolved absolute path (~ + relative refs expanded).
+	AbsPath string `json:"absPath"`
+	// SuggestedGroup is derived from the directory basename (slugified).
+	SuggestedGroup string `json:"suggestedGroup"`
+	// SuggestedSlug is the URL-safe repo slug (basename, lower-cased).
+	SuggestedSlug string `json:"suggestedSlug"`
+	// Stack is the detected dominant stack ("go", "node", "python", …).
+	Stack string `json:"stack"`
+	// Monorepo is the detected layout kind ("pnpm","npm","turbo","nx","lerna","multi") or "".
+	Monorepo string `json:"monorepo"`
+	// Packages is the list of repo-relative package roots for a monorepo.
+	Packages []string `json:"packages"`
+	// HasAgentsMD is true when AGENTS.md / CLAUDE.md / GEMINI.md exists at the root.
+	HasAgentsMD bool `json:"hasAgentsMd"`
+	// AlreadyRegistered is the existing group name if .archigraph/group.json exists.
+	AlreadyRegistered string `json:"alreadyRegistered,omitempty"`
+	// Error is a human-readable reason when Valid is false.
+	Error string `json:"error,omitempty"`
+}
+
+// v2WizardRepo is one repo the wizard wants registered + indexed.
+type v2WizardRepo struct {
+	Path    string   `json:"path"`
+	Slug    string   `json:"slug,omitempty"`
+	Modules []string `json:"modules,omitempty"`
+}
+
+// v2FromScanReq is the body for POST /api/v2/groups/from-scan.
+type v2FromScanReq struct {
+	Name  string         `json:"name"`
+	Repos []v2WizardRepo `json:"repos"`
+}
+
+// v2ScanReposReq is the body for POST /api/v2/groups/{group}/repos/scan.
+type v2ScanReposReq struct {
+	Repos []v2WizardRepo `json:"repos"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/v2/scan/inspect — resolve + detect (no writes)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2ScanInspect resolves a server-side path and returns a stack +
+// monorepo detection preview. It performs NO registry writes; it is the
+// "detect" step of the wizard. Wraps the same detect.* helpers the v1 onboard
+// endpoints use.
+func (s *Server) handleV2ScanInspect(w http.ResponseWriter, r *http.Request) {
+	var req v2ScanInspectReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if req.Path == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "path required")
+		return
+	}
+
+	abs, err := expandPath(req.Path)
+	if err != nil {
+		writeV2JSON(w, http.StatusOK, v2OK(v2ScanInspectReply{
+			Valid: false,
+			Error: fmt.Sprintf("cannot resolve path: %v", err),
+		}))
+		return
+	}
+
+	info, statErr := os.Stat(abs)
+	if statErr != nil || !info.IsDir() {
+		msg := "path does not exist or is not a directory"
+		if statErr != nil {
+			msg = statErr.Error()
+		}
+		writeV2JSON(w, http.StatusOK, v2OK(v2ScanInspectReply{
+			Valid:   false,
+			AbsPath: abs,
+			Error:   msg,
+		}))
+		return
+	}
+
+	base := filepath.Base(abs)
+	mono, _ := detect.DetectMonorepo(abs)
+	pkgs := mono.Packages
+	if pkgs == nil {
+		pkgs = []string{}
+	}
+
+	reply := v2ScanInspectReply{
+		Valid:          true,
+		AbsPath:        abs,
+		SuggestedGroup: slugify(base),
+		SuggestedSlug:  slugify(base),
+		Stack:          detect.Stack(abs),
+		Monorepo:       string(mono.Kind),
+		Packages:       pkgs,
+		HasAgentsMD:    fileExists(abs, "AGENTS.md") || fileExists(abs, "CLAUDE.md") || fileExists(abs, "GEMINI.md"),
+	}
+	if fileExists(abs, ".archigraph/group.json") {
+		reply.AlreadyRegistered = readManifestGroup(filepath.Join(abs, ".archigraph", "group.json"))
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(reply))
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/v2/groups/from-scan — create group + register repos + index
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2CreateGroupFromScan creates a NEW group from a scanned path, registers
+// the chosen repos, and enqueues an async index job. It returns a 202 JobAck
+// (identical shape to the rebuild endpoints) so the wizard can stream progress
+// via /api/v2/jobs/{id}/stream. The group + repos are created synchronously
+// before the ack so a failure surfaces immediately; only the indexing is async.
+func (s *Server) handleV2CreateGroupFromScan(w http.ResponseWriter, r *http.Request) {
+	var req v2FromScanReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if req.Name == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "name required")
+		return
+	}
+	if len(req.Repos) == 0 {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "at least one repo required")
+		return
+	}
+
+	// 1. Create the group registry entry (same path the v1 onboard handler uses).
+	if _, err := s.registry.CreateGroup(req.Name); err != nil {
+		writeV2Err(w, http.StatusConflict, "conflict", "create group: "+err.Error())
+		return
+	}
+
+	// 2. Register each repo, resolving the server-side path + detecting stack.
+	if status, code, msg := s.registerWizardRepos(req.Name, req.Repos); msg != "" {
+		writeV2Err(w, status, code, msg)
+		return
+	}
+
+	// 3. Enqueue the async index job (reuses the #1512 actionJob infra).
+	s.enqueueWizardIndex(w, req.Name)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// POST /api/v2/groups/{group}/repos/scan — add repos to existing group + index
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2ScanRepos registers one or more scanned repos into an EXISTING group
+// and enqueues an async index job. Returns 202 JobAck. This is the Settings
+// "add repo" path of the shared wizard.
+func (s *Server) handleV2ScanRepos(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if _, err := groupConfigPath(group); err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+	var req v2ScanReposReq
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "invalid JSON body")
+		return
+	}
+	if len(req.Repos) == 0 {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "at least one repo required")
+		return
+	}
+	if status, code, msg := s.registerWizardRepos(group, req.Repos); msg != "" {
+		writeV2Err(w, status, code, msg)
+		return
+	}
+	s.enqueueWizardIndex(w, group)
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// registerWizardRepos resolves + registers each wizard repo into the group.
+// Returns ("", "", "") on success or (httpStatus, errCode, message) on failure.
+func (s *Server) registerWizardRepos(group string, repos []v2WizardRepo) (int, string, string) {
+	for _, spec := range repos {
+		if spec.Path == "" {
+			return http.StatusBadRequest, "bad_request", "repo path required"
+		}
+		abs, err := expandPath(spec.Path)
+		if err != nil {
+			return http.StatusBadRequest, "bad_request", fmt.Sprintf("bad path %q: %v", spec.Path, err)
+		}
+		if info, statErr := os.Stat(abs); statErr != nil || !info.IsDir() {
+			return http.StatusBadRequest, "bad_request", fmt.Sprintf("path %q is not a directory", abs)
+		}
+		slug := spec.Slug
+		if slug == "" {
+			slug = slugify(filepath.Base(abs))
+		}
+		repo := registry.Repo{
+			Slug:    slug,
+			Path:    abs,
+			Stack:   detect.Stack(abs),
+			Modules: spec.Modules,
+		}
+		if err := s.registry.AddRepo(group, repo); err != nil {
+			return http.StatusConflict, "conflict", fmt.Sprintf("add repo %q: %v", slug, err)
+		}
+	}
+	return 0, "", ""
+}
+
+// enqueueWizardIndex enqueues a rebuild actionJob for the group and writes the
+// 202 JobAck. It mirrors dispatchV2Rebuild but is the wizard's index step.
+func (s *Server) enqueueWizardIndex(w http.ResponseWriter, group string) {
+	token := fmt.Sprintf("wizard-%d", time.Now().UnixMilli())
+	job := s.actionJobs.create("rebuild", group, "", token)
+
+	args := proto.RebuildArgs{
+		Group:         group,
+		ProgressToken: token,
+	}
+	go s.runRebuildJob(job.ID, args)
+
+	s.auditor.OK("wizard_index", group, map[string]any{"progress_token": token, "job_id": job.ID})
+
+	ack := v2JobAck{
+		JobID:         job.ID,
+		Op:            "rebuild",
+		Group:         group,
+		Status:        actionJobQueued,
+		ProgressToken: token,
+		StatusURL:     "/api/v2/jobs/" + job.ID,
+		StreamURL:     "/api/v2/jobs/" + job.ID + "/stream",
+	}
+	writeV2JSON(w, http.StatusAccepted, v2OK(ack))
+}

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -1,0 +1,197 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+)
+
+// newWizardTestServer builds a Server with an isolated ARCHIGRAPH_HOME, the
+// in-memory fakeStore (so CreateGroup/AddRepo don't touch ~/.archigraph), and
+// an injected rebuildRunner so the index job completes without a live daemon.
+func newWizardTestServer(t *testing.T, runner rebuildRunner) (*httptest.Server, *Server) {
+	t.Helper()
+	t.Setenv("ARCHIGRAPH_HOME", t.TempDir())
+	s, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	s.rebuildRunner = runner
+	ts := httptest.NewServer(s.routes())
+	t.Cleanup(ts.Close)
+	return ts, s
+}
+
+// writeMonorepo lays down a tiny pnpm monorepo fixture under dir.
+func writeMonorepo(t *testing.T, dir string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, "pnpm-workspace.yaml"), []byte("packages:\n  - packages/*\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range []string{"a", "b"} {
+		pkgDir := filepath.Join(dir, "packages", p)
+		if err := os.MkdirAll(pkgDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(pkgDir, "package.json"), []byte(`{"name":"`+p+`"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(dir, "package.json"), []byte(`{"name":"root"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestV2ScanInspect_DetectsMonorepo verifies the scan/detect step resolves a
+// real path and surfaces the stack + monorepo layout without any registry write.
+func TestV2ScanInspect_DetectsMonorepo(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	repoDir := t.TempDir()
+	writeMonorepo(t, repoDir)
+
+	body := `{"path":` + jsonQuote(repoDir) + `}`
+	resp, err := http.Post(ts.URL+"/api/v2/scan/inspect", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST scan/inspect: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	var env struct {
+		OK   bool               `json:"ok"`
+		Data v2ScanInspectReply `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK || !env.Data.Valid {
+		t.Fatalf("scan should be valid: %+v", env)
+	}
+	if env.Data.Stack != "node" {
+		t.Fatalf("stack = %q; want node", env.Data.Stack)
+	}
+	if env.Data.Monorepo != "pnpm" {
+		t.Fatalf("monorepo = %q; want pnpm", env.Data.Monorepo)
+	}
+	if len(env.Data.Packages) != 2 {
+		t.Fatalf("packages = %v; want 2", env.Data.Packages)
+	}
+	if env.Data.SuggestedGroup == "" || env.Data.SuggestedSlug == "" {
+		t.Fatalf("missing suggestions: %+v", env.Data)
+	}
+}
+
+// TestV2ScanInspect_InvalidPath verifies a non-existent path returns valid:false
+// (200 with an error message, not an HTTP error — the wizard renders inline).
+func TestV2ScanInspect_InvalidPath(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	body := `{"path":"/no/such/dir/archigraph-test-xyz"}`
+	resp, err := http.Post(ts.URL+"/api/v2/scan/inspect", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	var env struct {
+		Data v2ScanInspectReply `json:"data"`
+	}
+	json.NewDecoder(resp.Body).Decode(&env)
+	if env.Data.Valid {
+		t.Fatalf("expected invalid for missing path: %+v", env.Data)
+	}
+	if env.Data.Error == "" {
+		t.Fatalf("expected error message for missing path")
+	}
+}
+
+// TestV2CreateGroupFromScan_CreatesAndIndexes verifies the full wizard create
+// path: it creates the group, registers the repo, and enqueues an index job
+// that the runner drives to done.
+func TestV2CreateGroupFromScan_CreatesAndIndexes(t *testing.T) {
+	done := make(chan struct{}, 1)
+	runner := func(args proto.RebuildArgs) (proto.RebuildReply, error) {
+		if args.Group != "wiz" {
+			t.Errorf("runner group = %q; want wiz", args.Group)
+		}
+		done <- struct{}{}
+		return proto.RebuildReply{Repos: []string{"core"}, TotalEntities: 10, TotalRels: 3}, nil
+	}
+	ts, _ := newWizardTestServer(t, runner)
+	repoDir := t.TempDir()
+
+	body := `{"name":"wiz","repos":[{"path":` + jsonQuote(repoDir) + `,"slug":"core"}]}`
+	resp, err := http.Post(ts.URL+"/api/v2/groups/from-scan", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST from-scan: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d; want 202", resp.StatusCode)
+	}
+	var env struct {
+		OK   bool     `json:"ok"`
+		Data v2JobAck `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK || env.Data.JobID == "" || env.Data.Group != "wiz" {
+		t.Fatalf("bad ack: %+v", env)
+	}
+
+	select {
+	case <-done:
+	case <-time.After(3 * time.Second):
+		t.Fatal("index runner never fired")
+	}
+
+	// Poll the job to done.
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		r, _ := http.Get(ts.URL + "/api/v2/jobs/" + env.Data.JobID)
+		var je struct {
+			Data struct {
+				Status string `json:"status"`
+			} `json:"data"`
+		}
+		json.NewDecoder(r.Body).Decode(&je)
+		r.Body.Close()
+		if je.Data.Status == actionJobDone {
+			return
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatal("job never reached done")
+}
+
+// TestV2CreateGroupFromScan_RequiresRepos verifies an empty repo list is rejected.
+func TestV2CreateGroupFromScan_RequiresRepos(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	resp, err := http.Post(ts.URL+"/api/v2/groups/from-scan", "application/json", strings.NewReader(`{"name":"x","repos":[]}`))
+	if err != nil {
+		t.Fatalf("POST: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("status = %d; want 400", resp.StatusCode)
+	}
+}
+
+// jsonQuote quotes a string for safe embedding in a JSON literal.
+func jsonQuote(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -1,0 +1,388 @@
+/* ============================================================
+   ScanWizard — shared create-group / add-repo scan→detect→index wizard (#1517).
+
+   Used by BOTH Landing (mode="create") and Settings (mode="add-repo").
+   Three steps:
+
+     1. Pick directory — a server-side PATH the daemon resolves + indexes.
+        showDirectoryPicker() is offered only as a convenience to PREFILL the
+        folder-name hint; the browser File System Access API yields an opaque
+        FileSystemDirectoryHandle with no real on-disk path, so it cannot tell
+        the daemon WHICH directory to index. The path text field is the source
+        of truth. (See v2_wizard.go for the matching backend note.)
+
+     2. Detect — POST /api/v2/scan/inspect previews the detected stack +
+        monorepo layout + suggested group/slug. The user confirms.
+
+     3. Index — POST /api/v2/groups/from-scan (create) or
+        /api/v2/groups/{g}/repos/scan (add-repo) enqueues an async job; the
+        wizard streams queued→running→done via the job poller (#1522 pattern).
+   ============================================================ */
+
+import { useEffect, useState } from "react";
+import { CheckCircle2, FolderSearch, Loader2, AlertTriangle, ArrowRight } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button, Input, Badge } from "@/components/ui";
+import {
+  Dialog,
+  DialogContent,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui";
+import {
+  useScanInspect,
+  useCreateGroupFromScan,
+  useScanReposIntoGroup,
+  useWizardJob,
+} from "@/hooks/use-wizard";
+import { ApiError } from "@/lib/api";
+import type { ScanInspectReply } from "@/data/types";
+import { cn } from "@/lib/utils";
+
+type WizardStep = "pick" | "detect" | "index";
+
+export interface ScanWizardProps {
+  open: boolean;
+  onOpenChange: (v: boolean) => void;
+  /** "create" → ask for a group name + create it. "add-repo" → add into groupId. */
+  mode: "create" | "add-repo";
+  /** Required when mode==="add-repo". */
+  groupId?: string;
+  groupName?: string;
+  /** Slugs/paths already taken so we can warn on duplicates. */
+  takenNames?: string[];
+  existingPaths?: string[];
+  /** Fired once the index job reaches "done" (e.g. navigate into the group). */
+  onIndexed?: (group: string) => void;
+}
+
+function slugify(s: string): string {
+  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
+}
+
+/** showDirectoryPicker is non-standard; narrow it without `any`. */
+type DirPickerWindow = Window & {
+  showDirectoryPicker?: () => Promise<{ name: string }>;
+};
+
+export function ScanWizard(props: ScanWizardProps) {
+  const { open, onOpenChange, mode, groupId, groupName, takenNames = [], existingPaths = [], onIndexed } = props;
+
+  const [step, setStep] = useState<WizardStep>("pick");
+  const [path, setPath] = useState("");
+  const [scan, setScan] = useState<ScanInspectReply | null>(null);
+  const [name, setName] = useState("");
+  const [jobId, setJobId] = useState<string | null>(null);
+
+  const inspect = useScanInspect();
+  const createFromScan = useCreateGroupFromScan();
+  const scanRepos = useScanReposIntoGroup(groupId ?? "");
+  const job = useWizardJob(jobId, mode === "create" ? scan?.suggestedGroup : groupId);
+
+  // Reset everything when the dialog closes.
+  function reset() {
+    setStep("pick");
+    setPath("");
+    setScan(null);
+    setName("");
+    setJobId(null);
+    inspect.reset();
+    createFromScan.reset();
+    scanRepos.reset();
+  }
+
+  // Drive completion toasts off the job poller.
+  useEffect(() => {
+    if (!job.data) return;
+    if (job.data.status === "done") {
+      toast.success(job.data.message ?? "Indexing complete.");
+      onIndexed?.(job.data.group);
+    } else if (job.data.status === "failed") {
+      toast.error(job.data.error ?? "Indexing failed.");
+    }
+  }, [job.data, onIndexed]);
+
+  const pathDuplicate = path.trim() !== "" && existingPaths.includes(path.trim());
+  const nameSlug = slugify(name || scan?.suggestedGroup || "");
+  const nameDuplicate = takenNames.includes(nameSlug);
+
+  // --- Step 1: pick directory ---
+  async function browse() {
+    const picker = (window as DirPickerWindow).showDirectoryPicker;
+    if (!picker) {
+      toast.info("Your browser can't open a folder picker — type or paste the path.");
+      return;
+    }
+    try {
+      const handle = await picker();
+      // The handle has NO real on-disk path (browser sandbox). We can only use
+      // its name as a hint; the user still confirms the absolute path below.
+      if (handle?.name && path.trim() === "") {
+        toast.info(`Picked “${handle.name}” — paste its full path to continue.`);
+      }
+    } catch {
+      /* user cancelled — no-op */
+    }
+  }
+
+  async function runDetect() {
+    if (path.trim() === "" || pathDuplicate) return;
+    try {
+      const result = await inspect.mutateAsync(path.trim());
+      setScan(result);
+      if (result.valid) {
+        setName((prev) => prev || result.suggestedGroup);
+        setStep("detect");
+      }
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to scan path.");
+    }
+  }
+
+  // --- Step 3: create/register + index ---
+  async function runIndex() {
+    if (!scan?.valid) return;
+    const repos = [{ path: scan.absPath, slug: scan.suggestedSlug }];
+    try {
+      if (mode === "create") {
+        if (!nameSlug || nameDuplicate) return;
+        const ack = await createFromScan.mutateAsync({ name: nameSlug, repos });
+        setJobId(ack.job_id);
+      } else {
+        const ack = await scanRepos.mutateAsync(repos);
+        setJobId(ack.job_id);
+      }
+      setStep("index");
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to start indexing.");
+    }
+  }
+
+  const indexing = createFromScan.isPending || scanRepos.isPending;
+  const jobStatus = job.data?.status;
+  const jobProgress = job.data?.progress ?? 0;
+  const terminal = jobStatus === "done" || jobStatus === "failed";
+
+  return (
+    <Dialog
+      open={open}
+      onOpenChange={(v) => {
+        // Don't allow closing mid-index unless terminal.
+        if (!v && step === "index" && !terminal) return;
+        if (!v) reset();
+        onOpenChange(v);
+      }}
+    >
+      <DialogContent>
+        <DialogTitle>
+          {mode === "create" ? "Index a new group" : <>Add a repo to <span className="font-mono">{groupName}</span></>}
+        </DialogTitle>
+        <DialogDescription>
+          {step === "pick" && "Point archigraph at a repository folder on this machine."}
+          {step === "detect" && "Review what we detected, then start indexing."}
+          {step === "index" && "Indexing in progress — you can leave this open."}
+        </DialogDescription>
+
+        {/* Stepper */}
+        <ol className="mt-3 flex items-center gap-2 text-xs text-text-3" data-testid="wizard-stepper">
+          {(["pick", "detect", "index"] as WizardStep[]).map((s, i) => (
+            <li key={s} className="flex items-center gap-2">
+              <span
+                className={cn(
+                  "inline-flex size-5 items-center justify-center rounded-full border font-mono",
+                  step === s
+                    ? "border-accent bg-accent-soft text-accent-strong"
+                    : "border-border text-text-4",
+                )}
+              >
+                {i + 1}
+              </span>
+              <span className={cn(step === s ? "text-text-2" : "text-text-4")}>
+                {s === "pick" ? "Pick" : s === "detect" ? "Detect" : "Index"}
+              </span>
+              {i < 2 && <span className="text-border">/</span>}
+            </li>
+          ))}
+        </ol>
+
+        {/* Step 1 — pick directory */}
+        {step === "pick" && (
+          <form
+            className="mt-4 space-y-3"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void runDetect();
+            }}
+          >
+            <label className="block">
+              <span className="text-sm text-text-2">Repository path</span>
+              <div className="mt-1 flex gap-2">
+                <Input
+                  autoFocus
+                  value={path}
+                  onChange={(e) => setPath(e.target.value)}
+                  placeholder="/Users/you/code/my-repo"
+                  className="flex-1 font-mono text-sm"
+                  data-testid="wizard-path"
+                />
+                <Button type="button" variant="secondary" size="sm" onClick={() => void browse()}>
+                  <FolderSearch size={13} />
+                  Browse…
+                </Button>
+              </div>
+              {pathDuplicate && (
+                <p className="mt-1 text-xs text-danger">This path is already in the group.</p>
+              )}
+            </label>
+            <p className="text-xs text-text-4">
+              archigraph indexes the folder on this machine — paste its absolute path. (Browsers
+              can't hand a real path to the daemon, so the picker only prefills the name.)
+            </p>
+            <div className="flex justify-end gap-2 pt-1">
+              <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
+                Cancel
+              </Button>
+              <Button
+                type="submit"
+                disabled={path.trim() === "" || pathDuplicate || inspect.isPending}
+                data-testid="wizard-scan"
+              >
+                {inspect.isPending ? <Loader2 size={13} className="animate-spin" /> : null}
+                Scan
+                <ArrowRight size={13} />
+              </Button>
+            </div>
+          </form>
+        )}
+
+        {/* Step 2 — detect preview */}
+        {step === "detect" && scan && (
+          <div className="mt-4 space-y-4">
+            {!scan.valid ? (
+              <div className="flex items-start gap-2 rounded-lg border border-danger/40 bg-danger-soft/40 p-3 text-sm text-danger">
+                <AlertTriangle size={15} className="mt-0.5 shrink-0" />
+                <span>{scan.error ?? "That path can't be indexed."}</span>
+              </div>
+            ) : (
+              <>
+                <dl className="rounded-lg border border-border bg-surface p-3 text-sm" data-testid="wizard-detect">
+                  <div className="flex items-center justify-between py-1">
+                    <dt className="text-text-3">Path</dt>
+                    <dd className="font-mono text-text-2 truncate max-w-[60%]" title={scan.absPath}>
+                      {scan.absPath}
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between py-1">
+                    <dt className="text-text-3">Stack</dt>
+                    <dd>
+                      <Badge tone="accent">{scan.stack}</Badge>
+                    </dd>
+                  </div>
+                  <div className="flex items-center justify-between py-1">
+                    <dt className="text-text-3">Layout</dt>
+                    <dd>
+                      {scan.monorepo ? (
+                        <Badge tone="info">
+                          {scan.monorepo} monorepo · {scan.packages.length} package
+                          {scan.packages.length === 1 ? "" : "s"}
+                        </Badge>
+                      ) : (
+                        <Badge tone="neutral">single repo</Badge>
+                      )}
+                    </dd>
+                  </div>
+                  {scan.alreadyRegistered && (
+                    <div className="flex items-center justify-between py-1">
+                      <dt className="text-text-3">Note</dt>
+                      <dd className="text-warning text-xs">
+                        already in group “{scan.alreadyRegistered}”
+                      </dd>
+                    </div>
+                  )}
+                </dl>
+
+                {mode === "create" && (
+                  <label className="block">
+                    <span className="text-sm text-text-2">Group name</span>
+                    <Input
+                      value={name}
+                      onChange={(e) => setName(e.target.value)}
+                      placeholder={scan.suggestedGroup}
+                      className="mt-1 font-mono text-sm"
+                      data-testid="wizard-group-name"
+                    />
+                    {nameDuplicate && (
+                      <p className="mt-1 text-xs text-danger">A group “{nameSlug}” already exists.</p>
+                    )}
+                  </label>
+                )}
+              </>
+            )}
+
+            <div className="flex justify-between gap-2 pt-1">
+              <Button type="button" variant="ghost" onClick={() => setStep("pick")}>
+                Back
+              </Button>
+              <Button
+                type="button"
+                disabled={!scan.valid || indexing || (mode === "create" && (!nameSlug || nameDuplicate))}
+                onClick={() => void runIndex()}
+                data-testid="wizard-index"
+              >
+                {indexing ? <Loader2 size={13} className="animate-spin" /> : null}
+                {mode === "create" ? "Create & index" : "Add & index"}
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {/* Step 3 — index progress */}
+        {step === "index" && (
+          <div className="mt-4 space-y-4" data-testid="wizard-progress">
+            <div className="flex items-center gap-2">
+              {jobStatus === "done" ? (
+                <CheckCircle2 size={16} className="text-success" />
+              ) : jobStatus === "failed" ? (
+                <AlertTriangle size={16} className="text-danger" />
+              ) : (
+                <Loader2 size={16} className="animate-spin text-accent-strong" />
+              )}
+              <span className="text-sm text-text-2" data-testid="wizard-status">
+                {jobStatus === "queued" && "Queued…"}
+                {jobStatus === "running" && (job.data?.message || "Indexing…")}
+                {jobStatus === "done" && (job.data?.message || "Indexing complete.")}
+                {jobStatus === "failed" && (job.data?.error || "Indexing failed.")}
+                {!jobStatus && "Starting…"}
+              </span>
+            </div>
+
+            <div className="h-2 w-full overflow-hidden rounded-full bg-surface-2">
+              <div
+                className={cn(
+                  "h-full rounded-full transition-all duration-500",
+                  jobStatus === "failed" ? "bg-danger" : jobStatus === "done" ? "bg-success" : "bg-accent",
+                )}
+                style={{ width: `${jobStatus === "done" ? 100 : jobProgress}%` }}
+              />
+            </div>
+
+            <div className="flex justify-end gap-2 pt-1">
+              <Button
+                type="button"
+                disabled={!terminal}
+                onClick={() => {
+                  reset();
+                  onOpenChange(false);
+                }}
+                data-testid="wizard-done"
+              >
+                {terminal ? "Done" : "Indexing…"}
+              </Button>
+            </div>
+          </div>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -930,6 +930,34 @@ export interface ActionJob {
   finished_at?: number;
 }
 
+/* ------------------------------------------------------------------ *
+ * Create-group / add-repo scan wizard (#1517). The wizard sends a
+ * server-side PATH string (the daemon resolves + indexes it); see
+ * v2_wizard.go for the browser-File-handle limitation note.
+ * ------------------------------------------------------------------ */
+
+/** POST /api/v2/scan/inspect — stack + monorepo detection preview (no writes). */
+export interface ScanInspectReply {
+  valid: boolean;
+  absPath: string;
+  suggestedGroup: string;
+  suggestedSlug: string;
+  stack: string;
+  /** "pnpm" | "npm" | "turbo" | "nx" | "lerna" | "multi" | "" */
+  monorepo: string;
+  packages: string[];
+  hasAgentsMd: boolean;
+  alreadyRegistered?: string;
+  error?: string;
+}
+
+/** One repo the wizard wants registered + indexed. */
+export interface WizardRepo {
+  path: string;
+  slug?: string;
+  modules?: string[];
+}
+
 /** POST /api/v2/maintenance/cleanup result. */
 export interface CleanupReply {
   dry_run: boolean;

--- a/webui-v2/src/hooks/use-wizard.ts
+++ b/webui-v2/src/hooks/use-wizard.ts
@@ -1,0 +1,68 @@
+/* ============================================================
+   hooks/use-wizard.ts — shared create-group / add-repo scan wizard (#1517).
+
+   The wizard is used by BOTH Landing (create-group) and Settings
+   (add-repo). It scans a server-side path, previews the detected
+   stack + monorepo layout, then creates/registers + indexes with
+   live job progress.
+
+   Per the Lego layering, screens go through these hooks; they never
+   call api.* directly.
+   ============================================================ */
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { WizardRepo } from "@/data/types";
+import { groupsQueryKey } from "@/hooks/use-groups";
+import { settingsQueryKey } from "@/hooks/use-settings";
+
+/** Detect step: resolve + inspect a server-side path. */
+export function useScanInspect() {
+  return useMutation({
+    mutationFn: (path: string) => api.scanInspect(path),
+  });
+}
+
+/** Create-group-from-scan: create + register + enqueue index job. Returns a JobAck. */
+export function useCreateGroupFromScan() {
+  return useMutation({
+    mutationFn: ({ name, repos }: { name: string; repos: WizardRepo[] }) =>
+      api.createGroupFromScan(name, repos),
+  });
+}
+
+/** Add-repo-from-scan: register repos into an existing group + index. Returns a JobAck. */
+export function useScanReposIntoGroup(groupId: string) {
+  return useMutation({
+    mutationFn: (repos: WizardRepo[]) => api.scanReposIntoGroup(groupId, repos),
+  });
+}
+
+/**
+ * Polls a wizard index job until it reaches a terminal state. Pass null to
+ * disable. On completion, invalidates BOTH the Landing groups list and the
+ * group's Settings detail so freshly-indexed counts appear everywhere.
+ *
+ * The backend also exposes an SSE stream at the job's stream_url; this hook
+ * uses 1 s polling (the same proven pattern as Settings' useActionJob) to keep
+ * the wizard resilient when the EventSource connection is interrupted.
+ */
+export function useWizardJob(jobId: string | null, groupId?: string) {
+  const qc = useQueryClient();
+  return useQuery({
+    queryKey: ["wizard-job", jobId],
+    queryFn: async () => {
+      const job = await api.getJob(jobId as string);
+      if (job.status === "done" || job.status === "failed") {
+        void qc.invalidateQueries({ queryKey: groupsQueryKey });
+        if (groupId) void qc.invalidateQueries({ queryKey: settingsQueryKey(groupId) });
+      }
+      return job;
+    },
+    enabled: !!jobId,
+    refetchInterval: (query) => {
+      const s = query.state.data?.status;
+      return s === "done" || s === "failed" ? false : 1000;
+    },
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -46,6 +46,8 @@ import type {
   ActionJob,
   CleanupReply,
   UpdateApplyReply,
+  ScanInspectReply,
+  WizardRepo,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -126,6 +128,37 @@ export const api = {
   /** v2 — create an empty group from a name (Landing wizard). */
   createGroup: (name: string) =>
     requestV2<Group>("/groups", { method: "POST", body: JSON.stringify({ name }) }),
+
+  // --- v2 create-group / add-repo scan wizard (#1517) ---
+  /**
+   * POST /api/v2/scan/inspect — resolve a server-side path and detect its
+   * stack + monorepo layout. No registry writes; the "detect" wizard step.
+   */
+  scanInspect: (path: string) =>
+    requestV2<ScanInspectReply>("/scan/inspect", {
+      method: "POST",
+      body: JSON.stringify({ path }),
+    }),
+
+  /**
+   * POST /api/v2/groups/from-scan — create a group, register the scanned repos,
+   * and enqueue an async index job. Returns a 202 JobAck the wizard streams.
+   */
+  createGroupFromScan: (name: string, repos: WizardRepo[]) =>
+    requestV2<JobAck>("/groups/from-scan", {
+      method: "POST",
+      body: JSON.stringify({ name, repos }),
+    }),
+
+  /**
+   * POST /api/v2/groups/:id/repos/scan — register scanned repos into an
+   * existing group + enqueue an async index job (Settings add-repo). 202 JobAck.
+   */
+  scanReposIntoGroup: (groupId: string, repos: WizardRepo[]) =>
+    requestV2<JobAck>(`/groups/${encodeURIComponent(groupId)}/repos/scan`, {
+      method: "POST",
+      body: JSON.stringify({ repos }),
+    }),
 
   // --- v2 Docs entity browser (#1438) ---
   getDocsTree: (groupId: string) =>

--- a/webui-v2/src/routes/landing.tsx
+++ b/webui-v2/src/routes/landing.tsx
@@ -14,18 +14,12 @@ import { useNavigate } from "react-router-dom";
 import { ArrowRight, Plus, MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
-import { Button, Card, Input, InfoLabel, Kbd } from "@/components/ui";
-import {
-  Dialog,
-  DialogContent,
-  DialogTitle,
-  DialogDescription,
-} from "@/components/ui";
+import { Button, Card, InfoLabel, Kbd } from "@/components/ui";
 import { LandingTopBar } from "@/components/chrome/landing-top-bar";
+import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { Constellation, seedFromString } from "@/components/viz/constellation";
-import { useGroups, useCreateGroup } from "@/hooks/use-groups";
+import { useGroups } from "@/hooks/use-groups";
 import { useMeta } from "@/hooks/use-meta";
-import { ApiError } from "@/lib/api";
 import type { Group, GroupHealth } from "@/data/types";
 import { cn } from "@/lib/utils";
 
@@ -56,10 +50,6 @@ function relativeTime(ms: number | null): string {
   const day = Math.floor(hr / 24);
   if (day < 7) return `${day}d ago`;
   return `${Math.floor(day / 7)}w ago`;
-}
-
-function slugify(s: string): string {
-  return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
 /* ---------- info tips ---------- */
@@ -282,97 +272,6 @@ function EmptyState({ onCreate }: { onCreate: () => void }) {
   );
 }
 
-/* ---------- create-group modal ---------- */
-
-function CreateGroupModal({
-  open,
-  onOpenChange,
-  takenNames,
-}: {
-  open: boolean;
-  onOpenChange: (v: boolean) => void;
-  takenNames: string[];
-}) {
-  const [name, setName] = useState("");
-  const create = useCreateGroup();
-  const slug = slugify(name);
-  const duplicate = takenNames.includes(slug);
-  const valid = slug.length > 0 && !duplicate;
-
-  function reset() {
-    setName("");
-    create.reset();
-  }
-
-  async function submit() {
-    if (!valid) return;
-    try {
-      const g = await create.mutateAsync(slug);
-      toast.success(`Group “${g.name}” created.`);
-      reset();
-      onOpenChange(false);
-    } catch (e) {
-      const msg = e instanceof ApiError ? e.message : "Failed to create group.";
-      toast.error(msg);
-    }
-  }
-
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(v) => {
-        if (!v) reset();
-        onOpenChange(v);
-      }}
-    >
-      <DialogContent>
-        <DialogTitle>New group</DialogTitle>
-        <DialogDescription>
-          Name your group. You can add repositories to it afterwards.
-        </DialogDescription>
-
-        <form
-          className="mt-4 space-y-3"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void submit();
-          }}
-        >
-          <label className="block">
-            <span className="text-sm text-text-2">Group name</span>
-            <Input
-              autoFocus
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              placeholder="e.g. platform"
-              className="mt-1.5"
-            />
-          </label>
-
-          {slug && (
-            <p className="text-sm text-text-3">
-              Config:{" "}
-              <span className="font-mono text-text-2">~/.config/archigraph/{slug}.fleet.json</span>
-            </p>
-          )}
-          {duplicate && (
-            <p className="text-sm text-danger">A group named “{slug}” already exists.</p>
-          )}
-
-          <div className="flex justify-end gap-2 pt-2">
-            <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!valid || create.isPending}>
-              {create.isPending ? "Creating…" : "Create group"}
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 /* ---------- screen ---------- */
 
 export default function Landing() {
@@ -445,7 +344,13 @@ export default function Landing() {
         </div>
       </main>
 
-      <CreateGroupModal open={wizardOpen} onOpenChange={setWizardOpen} takenNames={takenNames} />
+      <ScanWizard
+        open={wizardOpen}
+        onOpenChange={setWizardOpen}
+        mode="create"
+        takenNames={takenNames}
+        onIndexed={(group) => navigate(`/g/${group}/graph`)}
+      />
     </div>
   );
 }

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -48,7 +48,6 @@ import {
   usePatchDocs,
   useRebuildGroup,
   useDeleteGroup,
-  useAddRepo,
   useRemoveRepo,
   useRebuildRepo,
   useResetRepo,
@@ -56,6 +55,7 @@ import {
   useRunDoctor,
   useActionJob,
 } from "@/hooks/use-settings";
+import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { ApiError } from "@/lib/api";
 import type { SettingsRepo, SettingsGroup, DoctorCheck, MonorepoPkg } from "@/data/types";
 import { cn } from "@/lib/utils";
@@ -1067,102 +1067,6 @@ function RemoveRepoModal({
   );
 }
 
-function AddRepoModal({
-  open,
-  groupId,
-  groupName,
-  existingPaths,
-  onClose,
-}: {
-  open: boolean;
-  groupId: string;
-  groupName: string;
-  existingPaths: string[];
-  onClose: () => void;
-}) {
-  const addRepo = useAddRepo(groupId);
-  const [slug, setSlug] = useState("");
-  const [path, setPath] = useState("");
-  const pathError = path && existingPaths.includes(path) ? "This path is already in the group." : "";
-
-  const valid = path.trim() !== "" && !pathError;
-
-  const handleAdd = async () => {
-    if (!valid) return;
-    try {
-      await addRepo.mutateAsync({ slug: slug.trim() || undefined as unknown as string, path: path.trim() });
-      toast.success(`Repo added to ${groupName}.`);
-      setSlug("");
-      setPath("");
-      onClose();
-    } catch (e) {
-      const msg = e instanceof ApiError ? e.message : "Failed to add repo.";
-      toast.error(msg);
-    }
-  };
-
-  return (
-    <Dialog
-      open={open}
-      onOpenChange={(v) => {
-        if (!v && !addRepo.isPending) {
-          setSlug("");
-          setPath("");
-          onClose();
-        }
-      }}
-    >
-      <DialogContent>
-        <DialogTitle>
-          Add repos to <span className="font-mono">{groupName}</span>
-        </DialogTitle>
-        <DialogDescription>
-          New repos inherit this group's features (watchers + git hooks).
-        </DialogDescription>
-
-        <form
-          className="mt-4 space-y-3"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void handleAdd();
-          }}
-        >
-          <label className="block">
-            <span className="text-sm text-text-2">Repository path</span>
-            <Input
-              autoFocus
-              value={path}
-              onChange={(e) => setPath(e.target.value)}
-              placeholder="/path/to/repo"
-              className="mt-1 font-mono text-sm"
-            />
-            {pathError && <p className="mt-1 text-xs text-danger">{pathError}</p>}
-          </label>
-          <label className="block">
-            <span className="text-sm text-text-2">Slug (optional — derived from folder name)</span>
-            <Input
-              value={slug}
-              onChange={(e) => setSlug(e.target.value)}
-              placeholder="my-repo"
-              className="mt-1 font-mono text-sm"
-            />
-          </label>
-
-          <div className="flex justify-end gap-2 pt-1">
-            <Button type="button" variant="ghost" onClick={onClose} disabled={addRepo.isPending}>
-              Cancel
-            </Button>
-            <Button type="submit" disabled={!valid || addRepo.isPending}>
-              {addRepo.isPending ? <Loader2 size={13} className="animate-spin" /> : null}
-              Add repo
-            </Button>
-          </div>
-        </form>
-      </DialogContent>
-    </Dialog>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // Rebuild confirm specs (single source of truth per design doc)
 // ---------------------------------------------------------------------------
@@ -1361,12 +1265,13 @@ export default function SettingsScreen() {
         onClose={() => setRemoveRepo(null)}
       />
 
-      <AddRepoModal
+      <ScanWizard
         open={addRepoOpen}
+        onOpenChange={setAddRepoOpen}
+        mode="add-repo"
         groupId={groupId}
         groupName={group.name}
         existingPaths={group.repos.map((r) => r.path)}
-        onClose={() => setAddRepoOpen(false)}
       />
 
       {confirmSpec && (


### PR DESCRIPTION
## 1. What & why
Today create-group (#1451) makes an **empty** group + an info-toast, and Settings add-repo (#1455) only **registers** a repo without indexing or progress. This PR builds the real shared **scan → detect → index** wizard and wires it into **both** Landing (create-group) and Settings (add-repo) as one component. Unblocked by #1512 (async-job + SSE endpoints) and #1511 (fidelity), both already on main.

`Fixes #1517`

## 2. How it works
**Three steps, one shared `ScanWizard` component:**
1. **Pick directory** — a path text field (source of truth) + a `showDirectoryPicker()` convenience button.
2. **Detect** — `POST /api/v2/scan/inspect` previews stack + monorepo layout + suggested group/slug (no writes); user confirms.
3. **Index** — create/register + enqueue an async job, then stream `queued → running → done` via the job poller (the #1522 `useActionJob` pattern, applied as `useWizardJob`).

**New thin v2 endpoints** (reuse existing `detect.*` + the #1512 `actionJob` infra — no logic duplicated):
- `POST /api/v2/scan/inspect` → resolve + detect (wraps `detect.Stack` + `detect.DetectMonorepo`, the same helpers the v1 onboard endpoints use).
- `POST /api/v2/groups/from-scan` → `registry.CreateGroup` + register repos + `runRebuildJob` → **202 JobAck** (same shape as rebuild).
- `POST /api/v2/groups/{group}/repos/scan` → register repos into an existing group + index job.

The group + repos are created **synchronously** before the 202 (so failures surface immediately); only the indexing is async, consistent with the #1487 serving-mutex invariant.

## 3. Directory / path input — browser-API limitation (documented)
The daemon indexes paths on **its own filesystem** (the Rebuild RPC, the registry, and `detect.*` all take an absolute path the daemon resolves). The browser **File System Access API** (`showDirectoryPicker()`) only yields an opaque `FileSystemDirectoryHandle` with **no real on-disk path**, so it cannot tell the daemon *which* directory to index. The wizard therefore sends a **PATH STRING** the daemon resolves with the same `expandPath()` the v1 onboard endpoints use; `showDirectoryPicker()` is offered only to prefill the folder-name hint. This mirrors how #1512's rebuild endpoint targets a group whose repos are already absolute server paths. The limitation is documented inline in both `v2_wizard.go` and `scan-wizard.tsx`, and surfaced to the user in the wizard ("Browsers can't hand a real path to the daemon…").

## 4. Testing
- `go build ./cmd/... ./internal/...` clean; `gofmt -l` clean; `go vet ./internal/dashboard/` clean.
- New handler tests `internal/dashboard/v2_wizard_test.go`: scan/inspect detects a pnpm monorepo + suggestions; invalid path returns `valid:false`; from-scan creates + registers + drives an index job to `done`; empty-repo list → 400. All pass.
- `npm run build` (tsc -b + vite) clean; `tsc --noEmit` clean.
- **Playwright E2E against an ISOLATED test daemon** (separate `ARCHIGRAPH_HOME` + `ARCHIGRAPH_DAEMON_ROOT`, dashboard on :47999, Vite on :47282 — the live :47274 daemon was never touched) over a **small temp repo**:
  - **Landing create:** Pick → Detect (stack=go, single repo) → Create & index → job done → navigated to the new group's graph; registry confirmed group `wizdemo` with 8 entities, healthy.
  - **Settings add-repo:** same shared wizard ("Add a repo to wizdemo") → scan repo2 → Add & index → progress step → "rebuilt 2 repo(s)" + Done; Settings live-refreshed to 2 repos / 11 entities.
  - Dev server + isolated daemon torn down after; `dashboard/` zero diff.

Pre-existing unrelated failures (`TestWriteback_success`, `TestYamlScalar`) confirmed to fail on clean `main` too — not touched by this PR.

## 5. Risk & rollback
Low. All new routes are additive `/api/v2/...`; v1 + existing v2 endpoints unchanged. The old `createGroup` (empty) + `addRepo` (register-only) endpoints remain for backward compat — the UI just no longer calls the empty-create path from Landing. Rollback = revert the branch; no data migration.

## 6. Screenshots
Wizard steps captured during E2E (Pick / Detect / Index-progress) against the isolated daemon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)