### PR TITLE
feat(wizard): server-side folder browser — picking a folder yields its abs path (Fixes #1529)

### DIFF
--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -559,6 +559,10 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("POST /api/v2/scan/inspect", s.handleV2ScanInspect)
 	mux.HandleFunc("POST /api/v2/groups/from-scan", s.handleV2CreateGroupFromScan)
 	mux.HandleFunc("POST /api/v2/groups/{group}/repos/scan", s.handleV2ScanRepos)
+	// fs/list powers the ScanWizard's server-side folder browser (#1529): the
+	// daemon lists its OWN filesystem so picking a folder yields its absolute
+	// path — no manual paste required.
+	mux.HandleFunc("GET /api/v2/fs/list", s.handleV2FsList)
 
 	// Docs entity browser — WebUI v2 (#1438)
 	mux.HandleFunc("GET /api/v2/groups/{group}/docs/tree", s.handleV2DocsTree)

--- a/internal/dashboard/v2_fs.go
+++ b/internal/dashboard/v2_fs.go
@@ -1,0 +1,186 @@
+// v2_fs.go — server-side filesystem directory browser for the create-group
+// ScanWizard (#1529).
+//
+// The browser File System Access API (showDirectoryPicker) only yields an
+// opaque FileSystemDirectoryHandle with NO real on-disk path, so the wizard
+// could never tell the daemon WHICH directory to index — leaving the user
+// stuck at "paste its full path to continue". Because the daemon runs on the
+// SAME machine as the browser (localhost) and already indexes arbitrary local
+// paths, it can list its OWN filesystem so the UI can present a real folder
+// browser: navigating a folder yields its ABSOLUTE path, and selecting it is
+// sufficient to proceed — no manual typing required.
+//
+//	GET /api/v2/fs/list?path=<abs>  → list the subdirectories of <path>
+//
+// When path is empty we default to a sensible start: the user's home dir,
+// surfacing common project roots ($HOME/Documents, $HOME/Documents/Projects)
+// as shortcuts. We list DIRECTORIES ONLY (never file contents). Errors
+// (nonexistent path, permission denied) are reported gracefully in the
+// envelope rather than as HTTP failures, so the UI can show a message and let
+// the user navigate elsewhere.
+
+package dashboard
+
+import (
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Wire shapes
+// ─────────────────────────────────────────────────────────────────────────────
+
+// v2FsEntry is one subdirectory under the listed path.
+type v2FsEntry struct {
+	// Name is the directory basename (e.g. "Projects").
+	Name string `json:"name"`
+	// Path is the absolute on-disk path (what the daemon will index).
+	Path string `json:"path"`
+	// IsDir is always true (we list directories only) but kept explicit so the
+	// shape is self-describing for the frontend.
+	IsDir bool `json:"isDir"`
+	// Hidden is true for dot-directories (.git, .archigraph, …).
+	Hidden bool `json:"hidden"`
+}
+
+// v2FsShortcut is a convenience jump target (home, Documents, Projects).
+type v2FsShortcut struct {
+	Label string `json:"label"`
+	Path  string `json:"path"`
+}
+
+// v2FsListReply is the response for GET /api/v2/fs/list.
+type v2FsListReply struct {
+	// Path is the resolved absolute path that was listed.
+	Path string `json:"path"`
+	// Parent is the absolute parent path ("" when at the filesystem root).
+	Parent string `json:"parent"`
+	// Entries are the immediate subdirectories of Path, sorted by name.
+	Entries []v2FsEntry `json:"entries"`
+	// Shortcuts are quick-jump targets (only populated for the default/home view).
+	Shortcuts []v2FsShortcut `json:"shortcuts,omitempty"`
+	// Error is a human-readable reason when the path could not be listed
+	// (nonexistent / permission denied). Entries is empty in that case.
+	Error string `json:"error,omitempty"`
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/v2/fs/list — list subdirectories of an absolute path
+// ─────────────────────────────────────────────────────────────────────────────
+
+// handleV2FsList lists the immediate subdirectories of the requested path so
+// the WebUI v2 ScanWizard can present a server-side folder browser. When no
+// path is supplied it defaults to the daemon's home directory and surfaces
+// common project roots as shortcuts. Localhost-only by deployment (the daemon
+// already indexes arbitrary local paths), so no path is out of bounds.
+func (s *Server) handleV2FsList(w http.ResponseWriter, r *http.Request) {
+	raw := strings.TrimSpace(r.URL.Query().Get("path"))
+
+	home, _ := os.UserHomeDir()
+
+	// Default start: the user's home directory.
+	if raw == "" {
+		raw = home
+	}
+
+	abs, err := expandPath(raw)
+	if err != nil {
+		writeV2JSON(w, http.StatusOK, v2OK(v2FsListReply{
+			Path:  raw,
+			Error: "cannot resolve path: " + err.Error(),
+		}))
+		return
+	}
+
+	info, statErr := os.Stat(abs)
+	if statErr != nil || !info.IsDir() {
+		msg := "path does not exist or is not a directory"
+		if statErr != nil {
+			msg = statErr.Error()
+		}
+		writeV2JSON(w, http.StatusOK, v2OK(v2FsListReply{
+			Path:   abs,
+			Parent: parentOrEmpty(abs),
+			Error:  msg,
+		}))
+		return
+	}
+
+	dirEntries, readErr := os.ReadDir(abs)
+	if readErr != nil {
+		writeV2JSON(w, http.StatusOK, v2OK(v2FsListReply{
+			Path:   abs,
+			Parent: parentOrEmpty(abs),
+			Error:  "cannot read directory: " + readErr.Error(),
+		}))
+		return
+	}
+
+	entries := make([]v2FsEntry, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		// Directories only — never file contents. Symlinks that point at a
+		// directory are included via Stat so users can follow them.
+		if !de.IsDir() {
+			if de.Type()&os.ModeSymlink == 0 {
+				continue
+			}
+			target, terr := os.Stat(filepath.Join(abs, de.Name()))
+			if terr != nil || !target.IsDir() {
+				continue
+			}
+		}
+		name := de.Name()
+		entries = append(entries, v2FsEntry{
+			Name:   name,
+			Path:   filepath.Join(abs, name),
+			IsDir:  true,
+			Hidden: strings.HasPrefix(name, "."),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool {
+		return strings.ToLower(entries[i].Name) < strings.ToLower(entries[j].Name)
+	})
+
+	reply := v2FsListReply{
+		Path:    abs,
+		Parent:  parentOrEmpty(abs),
+		Entries: entries,
+	}
+
+	// Surface common project roots only on the home view so the UI can offer
+	// one-click jumps without the user typing.
+	if home != "" && abs == home {
+		reply.Shortcuts = homeShortcuts(home)
+	}
+
+	writeV2JSON(w, http.StatusOK, v2OK(reply))
+}
+
+// parentOrEmpty returns the parent directory of abs, or "" when abs is already
+// the filesystem root (so the UI can disable the "up" control).
+func parentOrEmpty(abs string) string {
+	parent := filepath.Dir(abs)
+	if parent == abs {
+		return ""
+	}
+	return parent
+}
+
+// homeShortcuts returns the quick-jump targets that actually exist on disk.
+func homeShortcuts(home string) []v2FsShortcut {
+	candidates := []v2FsShortcut{
+		{Label: "Home", Path: home},
+		{Label: "Documents", Path: filepath.Join(home, "Documents")},
+		{Label: "Projects", Path: filepath.Join(home, "Documents", "Projects")},
+	}
+	out := make([]v2FsShortcut, 0, len(candidates))
+	for _, c := range candidates {
+		if info, err := os.Stat(c.Path); err == nil && info.IsDir() {
+			out = append(out, c)
+		}
+	}
+	return out
+}

--- a/internal/dashboard/v2_fs_test.go
+++ b/internal/dashboard/v2_fs_test.go
@@ -1,0 +1,149 @@
+package dashboard
+
+import (
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon/proto"
+)
+
+// fsListEnvelope is the decoded GET /api/v2/fs/list response.
+type fsListEnvelope struct {
+	OK   bool          `json:"ok"`
+	Data v2FsListReply `json:"data"`
+}
+
+func getFsList(t *testing.T, baseURL, path string) fsListEnvelope {
+	t.Helper()
+	u := baseURL + "/api/v2/fs/list"
+	if path != "" {
+		req, _ := http.NewRequest(http.MethodGet, u, nil)
+		q := req.URL.Query()
+		q.Set("path", path)
+		req.URL.RawQuery = q.Encode()
+		resp, err := http.DefaultClient.Do(req)
+		if err != nil {
+			t.Fatalf("GET fs/list: %v", err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			t.Fatalf("status = %d; want 200", resp.StatusCode)
+		}
+		var env fsListEnvelope
+		if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		return env
+	}
+	resp, err := http.Get(u)
+	if err != nil {
+		t.Fatalf("GET fs/list: %v", err)
+	}
+	defer resp.Body.Close()
+	var env fsListEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return env
+}
+
+// TestV2FsList_ListsSubdirsWithAbsPaths verifies the folder browser returns
+// subdirectories (not files) with their ABSOLUTE on-disk paths — the key
+// requirement that lets the wizard proceed without a manual paste.
+func TestV2FsList_ListsSubdirsWithAbsPaths(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	root := t.TempDir()
+	for _, d := range []string{"alpha", "beta", ".hidden"} {
+		if err := os.MkdirAll(filepath.Join(root, d), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, "afile.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := getFsList(t, ts.URL, root)
+	if !env.OK {
+		t.Fatalf("ok = false; reply = %+v", env.Data)
+	}
+	if env.Data.Path != root {
+		t.Fatalf("Path = %q; want %q", env.Data.Path, root)
+	}
+	if env.Data.Parent != filepath.Dir(root) {
+		t.Fatalf("Parent = %q; want %q", env.Data.Parent, filepath.Dir(root))
+	}
+
+	byName := map[string]v2FsEntry{}
+	for _, e := range env.Data.Entries {
+		byName[e.Name] = e
+	}
+	// Directories present; file absent.
+	if _, ok := byName["afile.txt"]; ok {
+		t.Fatal("file afile.txt should not be listed")
+	}
+	for _, want := range []string{"alpha", "beta", ".hidden"} {
+		e, ok := byName[want]
+		if !ok {
+			t.Fatalf("missing dir %q", want)
+		}
+		if e.Path != filepath.Join(root, want) {
+			t.Fatalf("%q Path = %q; want absolute %q", want, e.Path, filepath.Join(root, want))
+		}
+		if !e.IsDir {
+			t.Fatalf("%q IsDir = false", want)
+		}
+		if !filepath.IsAbs(e.Path) {
+			t.Fatalf("%q Path %q is not absolute", want, e.Path)
+		}
+	}
+	if !byName[".hidden"].Hidden {
+		t.Fatal(".hidden should be flagged Hidden")
+	}
+	// Sorted ascending case-insensitively: .hidden, alpha, beta.
+	if env.Data.Entries[0].Name != ".hidden" || env.Data.Entries[1].Name != "alpha" {
+		t.Fatalf("entries not sorted: %+v", env.Data.Entries)
+	}
+}
+
+// TestV2FsList_DefaultsToHome verifies that an empty path defaults to the
+// daemon's home directory.
+func TestV2FsList_DefaultsToHome(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	env := getFsList(t, ts.URL, "")
+	if !env.OK {
+		t.Fatalf("ok = false; reply = %+v", env.Data)
+	}
+	if env.Data.Path != home {
+		t.Fatalf("Path = %q; want home %q", env.Data.Path, home)
+	}
+}
+
+// TestV2FsList_NonexistentPathGraceful verifies a bad path returns a graceful
+// error in the envelope (HTTP 200), not a hard failure.
+func TestV2FsList_NonexistentPathGraceful(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	missing := filepath.Join(t.TempDir(), "does-not-exist-xyz")
+	env := getFsList(t, ts.URL, missing)
+	if !env.OK {
+		t.Fatalf("ok should stay true for graceful error; reply = %+v", env.Data)
+	}
+	if env.Data.Error == "" {
+		t.Fatal("expected Error for nonexistent path")
+	}
+	if len(env.Data.Entries) != 0 {
+		t.Fatalf("expected no entries; got %d", len(env.Data.Entries))
+	}
+}

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -4,12 +4,15 @@
    Used by BOTH Landing (mode="create") and Settings (mode="add-repo").
    Three steps:
 
-     1. Pick directory — a server-side PATH the daemon resolves + indexes.
-        showDirectoryPicker() is offered only as a convenience to PREFILL the
-        folder-name hint; the browser File System Access API yields an opaque
-        FileSystemDirectoryHandle with no real on-disk path, so it cannot tell
-        the daemon WHICH directory to index. The path text field is the source
-        of truth. (See v2_wizard.go for the matching backend note.)
+     1. Pick directory — a SERVER-SIDE folder browser (#1529). The daemon
+        runs on this machine, so GET /api/v2/fs/list walks ITS filesystem:
+        the user navigates folders and "Select this folder" yields a real
+        ABSOLUTE path — no manual paste required. (The browser File System
+        Access API only yields an opaque handle with no on-disk path, so it
+        can't tell the daemon WHICH directory to index — that's why the
+        daemon lists its own filesystem instead.) A manual path field is
+        kept as a fallback for users who prefer to paste. (See v2_fs.go /
+        v2_wizard.go for the matching backend notes.)
 
      2. Detect — POST /api/v2/scan/inspect previews the detected stack +
         monorepo layout + suggested group/slug. The user confirms.
@@ -20,7 +23,16 @@
    ============================================================ */
 
 import { useEffect, useState } from "react";
-import { CheckCircle2, FolderSearch, Loader2, AlertTriangle, ArrowRight } from "lucide-react";
+import {
+  CheckCircle2,
+  Folder,
+  ChevronRight,
+  CornerLeftUp,
+  Loader2,
+  AlertTriangle,
+  ArrowRight,
+  Check,
+} from "lucide-react";
 import { toast } from "sonner";
 
 import { Button, Input, Badge } from "@/components/ui";
@@ -35,6 +47,7 @@ import {
   useCreateGroupFromScan,
   useScanReposIntoGroup,
   useWizardJob,
+  useFsList,
 } from "@/hooks/use-wizard";
 import { useIndexProgress } from "@/hooks/use-index-progress";
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
@@ -63,11 +76,6 @@ function slugify(s: string): string {
   return s.toLowerCase().trim().replace(/[^a-z0-9]+/g, "-").replace(/^-+|-+$/g, "");
 }
 
-/** showDirectoryPicker is non-standard; narrow it without `any`. */
-type DirPickerWindow = Window & {
-  showDirectoryPicker?: () => Promise<{ name: string }>;
-};
-
 export function ScanWizard(props: ScanWizardProps) {
   const { open, onOpenChange, mode, groupId, groupName, takenNames = [], existingPaths = [], onIndexed } = props;
 
@@ -76,6 +84,12 @@ export function ScanWizard(props: ScanWizardProps) {
   const [scan, setScan] = useState<ScanInspectReply | null>(null);
   const [name, setName] = useState("");
   const [jobId, setJobId] = useState<string | null>(null);
+
+  // Server-side folder browser (#1529). `browseDir` is the directory currently
+  // being listed; null defaults to the daemon's home dir. `null` while the
+  // dialog is closed avoids a wasted fetch.
+  const [browseDir, setBrowseDir] = useState<string | null>(null);
+  const fs = useFsList(browseDir, open && step === "pick");
 
   const inspect = useScanInspect();
   const createFromScan = useCreateGroupFromScan();
@@ -98,6 +112,7 @@ export function ScanWizard(props: ScanWizardProps) {
     setScan(null);
     setName("");
     setJobId(null);
+    setBrowseDir(null);
     inspect.reset();
     createFromScan.reset();
     scanRepos.reset();
@@ -119,32 +134,26 @@ export function ScanWizard(props: ScanWizardProps) {
   const nameDuplicate = takenNames.includes(nameSlug);
 
   // --- Step 1: pick directory ---
-  async function browse() {
-    const picker = (window as DirPickerWindow).showDirectoryPicker;
-    if (!picker) {
-      toast.info("Your browser can't open a folder picker — type or paste the path.");
-      return;
-    }
-    try {
-      const handle = await picker();
-      // The handle has NO real on-disk path (browser sandbox). We can only use
-      // its name as a hint; the user still confirms the absolute path below.
-      if (handle?.name && path.trim() === "") {
-        toast.info(`Picked “${handle.name}” — paste its full path to continue.`);
-      }
-    } catch {
-      /* user cancelled — no-op */
-    }
-  }
+  // The folder browser's "Select this folder" target — the absolute path the
+  // user has navigated INTO (fs.data.path), which is what gets indexed. Falls
+  // back to the manual-paste field when the user typed a path instead.
+  const browsePath = fs.data?.path ?? "";
 
-  async function runDetect() {
-    if (path.trim() === "" || pathDuplicate) return;
+  // runDetect scans an explicit absolute path. The folder browser passes the
+  // directory the user navigated into; the manual field passes its trimmed
+  // text. Either way a single value drives the Detect step — no typing needed
+  // when browsing.
+  async function runDetect(target: string) {
+    const p = target.trim();
+    if (p === "" || existingPaths.includes(p)) return;
     try {
-      const result = await inspect.mutateAsync(path.trim());
+      const result = await inspect.mutateAsync(p);
       setScan(result);
       if (result.valid) {
         setName((prev) => prev || result.suggestedGroup);
         setStep("detect");
+      } else {
+        toast.error(result.error ?? "That path can't be indexed.");
       }
     } catch (e) {
       toast.error(e instanceof ApiError ? e.message : "Failed to scan path.");
@@ -217,54 +226,153 @@ export function ScanWizard(props: ScanWizardProps) {
           ))}
         </ol>
 
-        {/* Step 1 — pick directory */}
+        {/* Step 1 — pick directory: a server-side folder browser (#1529). The
+            daemon lists ITS OWN filesystem so navigating to a folder and
+            selecting it yields a real absolute path. No typing required. */}
         {step === "pick" && (
-          <form
-            className="mt-4 space-y-3"
-            onSubmit={(e) => {
-              e.preventDefault();
-              void runDetect();
-            }}
-          >
-            <label className="block">
-              <span className="text-sm text-text-2">Repository path</span>
-              <div className="mt-1 flex gap-2">
-                <Input
-                  autoFocus
-                  value={path}
-                  onChange={(e) => setPath(e.target.value)}
-                  placeholder="/Users/you/code/my-repo"
-                  className="flex-1 font-mono text-sm"
-                  data-testid="wizard-path"
-                />
-                <Button type="button" variant="secondary" size="sm" onClick={() => void browse()}>
-                  <FolderSearch size={13} />
-                  Browse…
-                </Button>
+          <div className="mt-4 space-y-3" data-testid="wizard-fsbrowser">
+            {/* Current directory + Up control */}
+            <div className="flex items-center gap-2">
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={!fs.data?.parent}
+                onClick={() => setBrowseDir(fs.data?.parent ?? null)}
+                data-testid="wizard-fs-up"
+                title="Up one level"
+              >
+                <CornerLeftUp size={13} />
+              </Button>
+              <code
+                className="min-w-0 flex-1 truncate rounded-md border border-border bg-surface px-2 py-1.5 font-mono text-xs text-text-2"
+                title={browsePath}
+                data-testid="wizard-fs-cwd"
+              >
+                {browsePath || "…"}
+              </code>
+            </div>
+
+            {/* Shortcuts (home view only) */}
+            {fs.data?.shortcuts && fs.data.shortcuts.length > 0 && (
+              <div className="flex flex-wrap gap-1.5">
+                {fs.data.shortcuts.map((sc) => (
+                  <Button
+                    key={sc.path}
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 text-xs"
+                    onClick={() => setBrowseDir(sc.path)}
+                  >
+                    {sc.label}
+                  </Button>
+                ))}
               </div>
-              {pathDuplicate && (
-                <p className="mt-1 text-xs text-danger">This path is already in the group.</p>
+            )}
+
+            {/* Subfolder list */}
+            <div
+              className="max-h-64 overflow-y-auto rounded-lg border border-border bg-surface"
+              data-testid="wizard-fs-list"
+            >
+              {fs.isLoading ? (
+                <div className="flex items-center gap-2 p-3 text-sm text-text-3">
+                  <Loader2 size={14} className="animate-spin" /> Loading…
+                </div>
+              ) : fs.data?.error ? (
+                <div className="flex items-start gap-2 p-3 text-sm text-danger">
+                  <AlertTriangle size={14} className="mt-0.5 shrink-0" />
+                  <span>{fs.data.error}</span>
+                </div>
+              ) : (fs.data?.entries.length ?? 0) === 0 ? (
+                <div className="p-3 text-sm text-text-4">No subfolders here.</div>
+              ) : (
+                <ul className="divide-y divide-border/60">
+                  {fs.data!.entries.map((e) => (
+                    <li key={e.path}>
+                      <button
+                        type="button"
+                        className={cn(
+                          "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-2",
+                          e.hidden ? "text-text-4" : "text-text-2",
+                        )}
+                        onClick={() => setBrowseDir(e.path)}
+                        data-testid="wizard-fs-entry"
+                        title={e.path}
+                      >
+                        <Folder size={14} className="shrink-0 text-text-3" />
+                        <span className="min-w-0 flex-1 truncate font-mono">{e.name}</span>
+                        <ChevronRight size={14} className="shrink-0 text-text-4" />
+                      </button>
+                    </li>
+                  ))}
+                </ul>
               )}
-            </label>
-            <p className="text-xs text-text-4">
-              archigraph indexes the folder on this machine — paste its absolute path. (Browsers
-              can't hand a real path to the daemon, so the picker only prefills the name.)
-            </p>
-            <div className="flex justify-end gap-2 pt-1">
+            </div>
+
+            {/* Select-this-folder: picking is sufficient to proceed. */}
+            <div className="flex items-center justify-between gap-2">
+              <p className="text-xs text-text-4">
+                Navigate to a repo folder, then select it — no typing needed.
+              </p>
+              <Button
+                type="button"
+                variant="secondary"
+                size="sm"
+                disabled={!browsePath || inspect.isPending}
+                onClick={() => {
+                  setPath(browsePath);
+                  void runDetect(browsePath);
+                }}
+                data-testid="wizard-fs-select"
+              >
+                {inspect.isPending ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}
+                Select this folder
+              </Button>
+            </div>
+
+            {/* Manual-paste fallback. */}
+            <form
+              className="border-t border-border/60 pt-3"
+              onSubmit={(e) => {
+                e.preventDefault();
+                void runDetect(path);
+              }}
+            >
+              <label className="block">
+                <span className="text-xs text-text-3">Or paste an absolute path</span>
+                <div className="mt-1 flex gap-2">
+                  <Input
+                    value={path}
+                    onChange={(e) => setPath(e.target.value)}
+                    placeholder="/Users/you/code/my-repo"
+                    className="flex-1 font-mono text-sm"
+                    data-testid="wizard-path"
+                  />
+                  <Button
+                    type="submit"
+                    variant="ghost"
+                    size="sm"
+                    disabled={path.trim() === "" || pathDuplicate || inspect.isPending}
+                    data-testid="wizard-scan"
+                  >
+                    Scan
+                    <ArrowRight size={13} />
+                  </Button>
+                </div>
+                {pathDuplicate && (
+                  <p className="mt-1 text-xs text-danger">This path is already in the group.</p>
+                )}
+              </label>
+            </form>
+
+            <div className="flex justify-end pt-1">
               <Button type="button" variant="ghost" onClick={() => onOpenChange(false)}>
                 Cancel
               </Button>
-              <Button
-                type="submit"
-                disabled={path.trim() === "" || pathDuplicate || inspect.isPending}
-                data-testid="wizard-scan"
-              >
-                {inspect.isPending ? <Loader2 size={13} className="animate-spin" /> : null}
-                Scan
-                <ArrowRight size={13} />
-              </Button>
             </div>
-          </form>
+          </div>
         )}
 
         {/* Step 2 — detect preview */}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -951,6 +951,40 @@ export interface ScanInspectReply {
   error?: string;
 }
 
+/* ------------------------------------------------------------------ *
+ * Server-side folder browser (#1529). The browser File System Access API
+ * can't hand the daemon a real on-disk path, so the wizard navigates the
+ * daemon's OWN filesystem via GET /api/v2/fs/list. Picking a folder yields
+ * its absolute path — no manual paste required.
+ * ------------------------------------------------------------------ */
+
+/** One subdirectory entry returned by GET /api/v2/fs/list. */
+export interface FsEntry {
+  name: string;
+  /** Absolute on-disk path the daemon will index. */
+  path: string;
+  isDir: boolean;
+  hidden: boolean;
+}
+
+/** A quick-jump shortcut (home / Documents / Projects), only on the home view. */
+export interface FsShortcut {
+  label: string;
+  path: string;
+}
+
+/** GET /api/v2/fs/list — subdirectories of an absolute path. */
+export interface FsListReply {
+  /** The resolved absolute path that was listed. */
+  path: string;
+  /** Absolute parent path, or "" at the filesystem root. */
+  parent: string;
+  entries: FsEntry[];
+  shortcuts?: FsShortcut[];
+  /** Human-readable reason when the path couldn't be listed. */
+  error?: string;
+}
+
 /** One repo the wizard wants registered + indexed. */
 export interface WizardRepo {
   path: string;

--- a/webui-v2/src/hooks/use-wizard.ts
+++ b/webui-v2/src/hooks/use-wizard.ts
@@ -16,6 +16,25 @@ import type { WizardRepo } from "@/data/types";
 import { groupsQueryKey } from "@/hooks/use-groups";
 import { settingsQueryKey } from "@/hooks/use-settings";
 
+/**
+ * Server-side folder browser (#1529): lists the subdirectories of an absolute
+ * path on the daemon's OWN filesystem so the wizard can navigate to a folder
+ * and proceed with its absolute path — no manual paste.
+ *
+ * `path` is the directory to list; null/undefined means "the daemon's home
+ * directory" (the default landing view, which also surfaces shortcuts). Use
+ * `enabled` to gate the fetch to when the browser is actually visible. Path
+ * errors are surfaced in `data.error` (the request itself still succeeds).
+ */
+export function useFsList(path: string | null, enabled: boolean) {
+  return useQuery({
+    queryKey: ["fs-list", path],
+    queryFn: () => api.fsList(path ?? undefined),
+    enabled,
+    staleTime: 5_000,
+  });
+}
+
 /** Detect step: resolve + inspect a server-side path. */
 export function useScanInspect() {
   return useMutation({

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -48,6 +48,7 @@ import type {
   UpdateApplyReply,
   ScanInspectReply,
   WizardRepo,
+  FsListReply,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -137,6 +138,17 @@ export const api = {
   /** v2 — create an empty group from a name (Landing wizard). */
   createGroup: (name: string) =>
     requestV2<Group>("/groups", { method: "POST", body: JSON.stringify({ name }) }),
+
+  /**
+   * GET /api/v2/fs/list — list the subdirectories of an absolute path on the
+   * daemon's own filesystem (#1529). Powers the wizard's server-side folder
+   * browser: navigating a folder yields its absolute path, so picking it is
+   * enough to proceed — no manual paste. Empty path defaults to the daemon's
+   * home directory (with Documents/Projects shortcuts). Path errors are
+   * carried in `error` (HTTP 200), not thrown.
+   */
+  fsList: (path?: string) =>
+    requestV2<FsListReply>(`/fs/list${path ? `?path=${encodeURIComponent(path)}` : ""}`),
 
   // --- v2 create-group / add-repo scan wizard (#1517) ---
   /**


### PR DESCRIPTION
## What & Why
The create-group **ScanWizard** dead-ended. Step 1 relied on the browser `showDirectoryPicker()`, which — by browser sandbox — only yields the folder **name** with no on-disk path. The daemon indexes paths on its OWN filesystem, so it could never know WHICH directory to index, leaving the user stuck at *"paste its full path to continue."*

Since the daemon runs on the same machine as the browser (localhost), it can list its own filesystem. This PR adds a **server-side folder browser**: the user navigates folders and selecting one yields its **absolute path** — picking is sufficient to proceed, no manual typing.

Fixes #1529

## How
**Backend** — `GET /api/v2/fs/list?path=<abs>` (`internal/dashboard/v2_fs.go`, registered in `server.go`):
- Lists **directories only** (never file contents) with `{name, path (absolute), isDir, hidden}`, sorted case-insensitively.
- Empty `path` defaults to `$HOME` and surfaces `Home` / `Documents` / `Documents/Projects` shortcuts (only those that exist).
- Nonexistent / permission-denied paths are reported **gracefully** in the envelope (HTTP 200 + `error`), so the UI shows a message and lets the user navigate elsewhere.
- Symlinks-to-dir are followed; files skipped.

**Frontend** — `scan-wizard.tsx` step 1 is now a folder browser:
- Current dir + **Up** control + shortcut chips + a scrollable subfolder list (each row navigates in).
- **Select this folder** runs Detect on the navigated absolute path (`fs.data.path`).
- Manual-paste field kept as a fallback. The misleading `showDirectoryPicker` "Browse…" is removed.
- New `useFsList` hook + `api.fsList` + `FsListReply`/`FsEntry`/`FsShortcut` types.

## Testing
- `internal/dashboard/v2_fs_test.go`: abs-path listing, dirs-only filtering, hidden flag, sort order, `$HOME` default, graceful nonexistent-path error. **Green.**
- `go build ./internal/... ./cmd/...`, `go vet ./internal/dashboard/` — green.
- `npm run build` + `npm run lint` (tsc --noEmit) — green.
- **E2E (memory-safe, did NOT touch live :47274):** ran an isolated `archigraph dashboard serve --port 47999` with an isolated `ARCHIGRAPH_HOME`, drove the wizard with Playwright: opened create-group → folder browser landed on `$HOME` with shortcuts → Projects → `polyglot-platform` → **Select this folder** → advanced to **Detect** showing `/Users/.../polyglot-platform`, "pnpm monorepo · 11 packages", group name prefilled, **without typing any path**.

## Screenshots
- `1529-01-folder-browser-home.png` — browser on `$HOME`
- `1529-02-navigated-polyglot.png` — navigated into `polyglot-platform`
- `1529-03-detect-proceed.png` — Detect step reached via pick-only

## Risks / Rollback
Additive endpoint + localhost-only deployment (daemon already indexes arbitrary local paths). Manual-paste fallback preserved. Revert the single commit to roll back. `dashboard/` (legacy) untouched — zero diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)