### PR TITLE
fix(webui-v2): skeleton contrast + shimmer — app-wide loading placeholders now clearly visible

### DIFF
--- a/webui-v2/src/components/docs/docs-skeleton.tsx
+++ b/webui-v2/src/components/docs/docs-skeleton.tsx
@@ -3,14 +3,7 @@
    Rendered while useDocsEntity is pending.
    ============================================================ */
 
-function SkeletonLine({ w = "100%" }: { w?: string }) {
-  return (
-    <div
-      className="h-3 rounded bg-surface-2 animate-pulse"
-      style={{ width: w }}
-    />
-  );
-}
+import { Skeleton } from "@/components/ui/skeleton";
 
 export function DocsEntitySkeleton() {
   return (
@@ -18,26 +11,26 @@ export function DocsEntitySkeleton() {
       {/* Head */}
       <div className="flex flex-col gap-3">
         <div className="flex items-center gap-2">
-          <SkeletonLine w="56px" />
-          <SkeletonLine w="240px" />
+          <Skeleton w="w-14" />
+          <Skeleton w="w-60" />
         </div>
-        <SkeletonLine w="320px" />
+        <Skeleton w="w-80" />
         <div className="flex gap-2">
-          <SkeletonLine w="72px" />
-          <SkeletonLine w="72px" />
+          <Skeleton w="w-18" />
+          <Skeleton w="w-18" />
         </div>
       </div>
       {/* Signature block */}
       <div className="flex flex-col gap-2">
-        <SkeletonLine w="80px" />
-        <div className="h-20 rounded-md bg-surface-2 animate-pulse" />
+        <Skeleton w="w-20" />
+        <Skeleton h="h-20" className="rounded-md" />
       </div>
       {/* Description */}
       <div className="flex flex-col gap-2">
-        <SkeletonLine w="80px" />
-        <SkeletonLine w="100%" />
-        <SkeletonLine w="90%" />
-        <SkeletonLine w="60%" />
+        <Skeleton w="w-20" />
+        <Skeleton w="w-full" />
+        <Skeleton w="w-[90%]" />
+        <Skeleton w="w-[60%]" />
       </div>
     </article>
   );

--- a/webui-v2/src/components/ui/index.ts
+++ b/webui-v2/src/components/ui/index.ts
@@ -22,3 +22,4 @@ export {
   DialogDescription,
 } from "./dialog";
 export { Tabs, TabsList, TabsTrigger, TabsContent } from "./tabs";
+export { Skeleton } from "./skeleton";

--- a/webui-v2/src/components/ui/skeleton.tsx
+++ b/webui-v2/src/components/ui/skeleton.tsx
@@ -1,0 +1,36 @@
+/* ============================================================
+   skeleton.tsx — Shared loading-placeholder primitive.
+
+   Usage:
+     <Skeleton />                       — full-width line, default height
+     <Skeleton w="w-48" h="h-4" />     — Tailwind width/height classes
+     <Skeleton className="h-20 w-full rounded-md" />
+
+   The shimmer is driven by the ag-skeleton CSS class (app.css) which
+   uses --skeleton-base / --skeleton-highlight tokens.  Those tokens are
+   defined for light, dark, warm-light, and warm-dark in tokens.css, so
+   every palette looks correct automatically.
+
+   Motion: the animation is suppressed via @media (prefers-reduced-motion)
+   in app.css — no extra work needed here.
+   ============================================================ */
+
+import { cn } from "@/lib/utils";
+
+interface SkeletonProps {
+  /** Tailwind width class, e.g. "w-48" or "w-full" (default: "w-full") */
+  w?: string;
+  /** Tailwind height class, e.g. "h-3" or "h-6" (default: "h-3") */
+  h?: string;
+  /** Extra Tailwind classes — merged last so they can override w/h */
+  className?: string;
+}
+
+export function Skeleton({ w = "w-full", h = "h-3", className }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={cn("rounded ag-skeleton", w, h, className)}
+    />
+  );
+}

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -34,6 +34,7 @@ import type {
 } from "@/data/types";
 import { cn } from "@/lib/utils";
 import { api } from "@/lib/api";
+import { Skeleton } from "@/components/ui/skeleton";
 
 // ─── Step-kind metadata ───────────────────────────────────────────────────────
 
@@ -191,10 +192,10 @@ function AIChip() {
 function SkeletonRow() {
   return (
     <div className="flex gap-2.5 px-3.5 py-2.5 border-b border-border-soft">
-      <div className="w-[22px] h-[22px] rounded-xs bg-surface-2 animate-pulse flex-none" />
+      <Skeleton w="w-[22px]" h="h-[22px]" className="rounded-xs flex-none" />
       <div className="flex-1 flex flex-col gap-1.5">
-        <div className="h-3 w-3/4 rounded bg-surface-2 animate-pulse" />
-        <div className="h-2.5 w-1/2 rounded bg-surface-2 animate-pulse" />
+        <Skeleton w="w-3/4" />
+        <Skeleton w="w-1/2" h="h-2.5" />
       </div>
     </div>
   );

--- a/webui-v2/src/routes/landing.tsx
+++ b/webui-v2/src/routes/landing.tsx
@@ -14,7 +14,7 @@ import { useNavigate } from "react-router-dom";
 import { ArrowRight, Plus, MoreHorizontal } from "lucide-react";
 import { toast } from "sonner";
 
-import { Button, Card, InfoLabel, Kbd } from "@/components/ui";
+import { Button, Card, InfoLabel, Kbd, Skeleton } from "@/components/ui";
 import { LandingTopBar } from "@/components/chrome/landing-top-bar";
 import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { Constellation, seedFromString } from "@/components/viz/constellation";
@@ -307,7 +307,7 @@ export default function Landing() {
           ) : isLoading ? (
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
               {[0, 1, 2].map((i) => (
-                <Card key={i} className="h-[200px] animate-pulse bg-surface-2" />
+                <Skeleton key={i} h="h-[200px]" className="rounded-lg" />
               ))}
             </div>
           ) : list.length === 0 ? (

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -80,6 +80,7 @@ import {
 import { useRunDoctor } from "@/hooks/use-settings";
 import { useIndexProgress } from "@/hooks/use-index-progress";
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import type { DoctorCheck, LogLine, PatternRow, SystemStatus } from "@/data/types";
 
@@ -444,7 +445,7 @@ function SystemTab({ groupId }: { groupId: string }) {
       {/* Daemon status */}
       <Section title="Daemon" sub="Live process state. Auto-refreshes every 5 seconds.">
         {isLoading ? (
-          <div className="h-28 rounded-lg bg-surface-2 animate-pulse" />
+          <Skeleton h="h-28" className="rounded-lg" />
         ) : isError || !status ? (
           <div className="flex items-center gap-2 text-sm text-text-3 py-4">
             <AlertTriangle size={14} className="text-warning" />
@@ -917,7 +918,7 @@ function PatternsTab({ groupId }: { groupId: string }) {
       {isLoading ? (
         <div className="space-y-2">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-12 rounded-lg bg-surface-2 animate-pulse" />
+            <Skeleton key={i} h="h-12" className="rounded-lg" />
           ))}
         </div>
       ) : isError ? (
@@ -1053,7 +1054,7 @@ function OrphanAuditPane({ groupId }: { groupId: string }) {
       {isLoading ? (
         <div className="space-y-3">
           {[0, 1, 2].map((i) => (
-            <div key={i} className="h-16 rounded-lg bg-surface-2 animate-pulse" />
+            <Skeleton key={i} h="h-16" className="rounded-lg" />
           ))}
         </div>
       ) : !data ? (
@@ -1215,7 +1216,7 @@ function RecallPane({ groupId }: { groupId: string }) {
         <div className="flex-1">
           <label className="block text-sm text-text-2 mb-1">Golden fixture</label>
           {fixturesLoading ? (
-            <div className="h-8 rounded-md bg-surface-2 animate-pulse" />
+            <Skeleton h="h-8" className="rounded-md" />
           ) : fixtures.length === 0 ? (
             <p className="text-sm text-text-3">
               No fixtures found. Add test fixtures to{" "}
@@ -1402,7 +1403,7 @@ function UpdatesTab() {
         }
       >
         {isLoading ? (
-          <div className="h-20 rounded-lg bg-surface-2 animate-pulse" />
+          <Skeleton h="h-20" className="rounded-lg" />
         ) : isError || !data ? (
           <div className="flex items-center gap-2 text-sm text-text-3 py-4">
             <AlertTriangle size={14} className="text-warning" />

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -17,7 +17,7 @@ import {
   Layers, Box, List, Maximize2,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
-import { Badge, Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui";
+import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Skeleton } from "@/components/ui";
 import { usePaths, usePathDetail, useOrphans } from "@/hooks/use-paths";
 import type {
   PathBackend, ControllerGroupShape, PathRoute, PathDetail,
@@ -133,25 +133,14 @@ function kindIcon(kind: string): React.ReactNode {
 }
 
 /* ============================================================
-   Skeleton primitives
+   Skeleton primitives — use shared Skeleton from UI layer
    ============================================================ */
-
-function SkeletonLine({ w = "w-full", h = "h-3" }: { w?: string; h?: string }) {
-  return (
-    <div
-      className={cn(
-        "rounded bg-surface-2 animate-pulse motion-reduce:animate-none",
-        w, h,
-      )}
-    />
-  );
-}
 
 function ListSkeleton() {
   return (
     <div className="p-3 space-y-2">
       {[80, 60, 70, 50, 65].map((w, i) => (
-        <SkeletonLine key={i} w={`w-[${w}%]`} />
+        <Skeleton key={i} w={`w-[${w}%]`} />
       ))}
     </div>
   );
@@ -160,11 +149,11 @@ function ListSkeleton() {
 function DetailSkeleton() {
   return (
     <div className="p-6 space-y-4">
-      <SkeletonLine w="w-48" h="h-4" />
-      <SkeletonLine w="w-72" h="h-6" />
-      <SkeletonLine w="w-full" />
-      <SkeletonLine w="w-4/5" />
-      <SkeletonLine w="w-3/4" />
+      <Skeleton w="w-48" h="h-4" />
+      <Skeleton w="w-72" h="h-6" />
+      <Skeleton w="w-full" />
+      <Skeleton w="w-4/5" />
+      <Skeleton w="w-3/4" />
     </div>
   );
 }
@@ -1008,7 +997,7 @@ function OrphansPanel({ groupId }: { groupId: string }) {
     return (
       <div className="p-4 space-y-2">
         {[1, 2, 3].map((i) => (
-          <div key={i} className="h-14 rounded bg-surface-2 animate-pulse motion-reduce:animate-none" />
+          <Skeleton key={i} h="h-14" />
         ))}
       </div>
     );
@@ -1229,8 +1218,8 @@ export default function PathsScreen() {
           </>
         ) : isLoading ? (
           <div className="flex items-center gap-3">
-            <SkeletonLine w="w-20" h="h-2.5" />
-            <SkeletonLine w="w-20" h="h-2.5" />
+            <Skeleton w="w-20" h="h-2.5" />
+            <Skeleton w="w-20" h="h-2.5" />
           </div>
         ) : null}
       </div>

--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -16,7 +16,7 @@ import { toast } from "sonner";
 
 import { useCandidates, useSaveHint } from "@/hooks/use-pending";
 import { usePendingStore } from "@/store/use-pending-store";
-import { Badge, Button, Tabs, TabsList, TabsTrigger } from "@/components/ui";
+import { Badge, Button, Tabs, TabsList, TabsTrigger, Skeleton } from "@/components/ui";
 import { cn } from "@/lib/utils";
 
 import type {
@@ -562,10 +562,10 @@ function PendingSkeleton() {
         {Array.from({ length: 6 }).map((_, i) => (
           <div
             key={i}
-            className="px-3 py-2 border-b border-border-soft animate-pulse"
+            className="px-3 py-2 border-b border-border-soft flex flex-col gap-1.5"
           >
-            <div className="h-3 bg-surface-3 rounded w-3/4 mb-1.5" />
-            <div className="h-2.5 bg-surface-3 rounded w-1/2" />
+            <Skeleton w="w-3/4" />
+            <Skeleton w="w-1/2" h="h-2.5" />
           </div>
         ))}
       </aside>

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -58,6 +58,7 @@ import {
 import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { ApiError } from "@/lib/api";
 import type { SettingsRepo, SettingsGroup, DoctorCheck, MonorepoPkg } from "@/data/types";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 
 // ---------------------------------------------------------------------------
@@ -1204,7 +1205,7 @@ export default function SettingsScreen() {
     return (
       <div className="mx-auto w-full max-w-[880px] px-6 py-10 space-y-4">
         {[0, 1, 2, 3].map((i) => (
-          <div key={i} className="h-24 rounded-xl bg-surface-2 animate-pulse" />
+          <Skeleton key={i} h="h-24" className="rounded-xl" />
         ))}
       </div>
     );

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -28,6 +28,7 @@ import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/input";
 import { Pill } from "@/components/ui/pill";
+import { Skeleton } from "@/components/ui/skeleton";
 import { cn } from "@/lib/utils";
 import {
   useTopology,
@@ -204,11 +205,11 @@ function BrokerShapeIcon({
 
 function SkeletonFlowUnit() {
   return (
-    <div className="flex items-center gap-3 h-16 px-4 rounded-lg bg-surface-2 animate-pulse border border-border">
-      <div className="size-6 rounded-full bg-surface-3 shrink-0" />
+    <div className="flex items-center gap-3 h-16 px-4 rounded-lg border border-border">
+      <Skeleton w="w-6" h="h-6" className="rounded-full shrink-0" />
       <div className="flex-1 space-y-2">
-        <div className="h-3 bg-surface-3 rounded w-1/3" />
-        <div className="h-2 bg-surface-3 rounded w-1/4" />
+        <Skeleton w="w-1/3" />
+        <Skeleton w="w-1/4" h="h-2" />
       </div>
     </div>
   );

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -23,6 +23,10 @@
   --color-surface-2: var(--surface-2);
   --color-surface-3: var(--surface-3);
 
+  /* -- Skeleton -- */
+  --color-skeleton-base: var(--skeleton-base);
+  --color-skeleton-highlight: var(--skeleton-highlight);
+
   /* -- Borders -- */
   --color-border: var(--border);
   --color-border-strong: var(--border-strong);
@@ -99,6 +103,35 @@
    on standalone pages (the showcase) without fighting the tokens reset. */
 .ag-scroll {
   overflow: auto;
+}
+
+/* ── Skeleton shimmer ────────────────────────────────────────────────────────
+   Used by the shared <Skeleton> primitive (components/ui/skeleton.tsx).
+   Uses token-driven colours so light/dark/warm palettes all look correct.
+   The shimmer gradient travels 200% so the bright band fully crosses the bar.
+   ──────────────────────────────────────────────────────────────────────── */
+@keyframes ag-shimmer {
+  0%   { background-position: 200% center; }
+  100% { background-position: -200% center; }
+}
+
+.ag-skeleton {
+  background: linear-gradient(
+    90deg,
+    var(--skeleton-base)      0%,
+    var(--skeleton-base)      35%,
+    var(--skeleton-highlight) 50%,
+    var(--skeleton-base)      65%,
+    var(--skeleton-base)      100%
+  );
+  background-size: 200% auto;
+  animation: ag-shimmer 1.6s ease-in-out infinite;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .ag-skeleton {
+    animation: none;
+  }
 }
 
 /* Honor reduced-motion globally (per handoff motion rules). */

--- a/webui-v2/src/styles/tokens.css
+++ b/webui-v2/src/styles/tokens.css
@@ -66,6 +66,10 @@
   --pastel-9-ink:  #6573b3;
   --pastel-10-ink: #c08741;
 
+  /* -- Skeleton / loading placeholders -- */
+  --skeleton-base:      #e2e6ed;   /* noticeably darker than surface-2 (#f3f5f8) */
+  --skeleton-highlight: #edf0f5;   /* shimmer highlight — lighter band */
+
   /* -- Graph canvas -- */
   --canvas-bg:        #f7f8fa;
   --canvas-grid:      rgba(15, 23, 42, 0.045);
@@ -142,6 +146,8 @@
   --text-2:        #4a4843;
   --text-3:        #76736b;
   --text-4:        #a5a299;
+  --skeleton-base:      #e4dfd6;   /* warm light skeleton base */
+  --skeleton-highlight: #eeece6;   /* warm light shimmer highlight */
   --canvas-bg:     #fbfaf7;
   --canvas-grid:   rgba(28, 27, 24, 0.04);
   --edge-color:    rgba(28, 27, 24, 0.14);
@@ -206,6 +212,10 @@
   --pastel-9-ink:  #b1b8d9;
   --pastel-10-ink: #e8be93;
 
+  /* -- Skeleton / loading placeholders -- */
+  --skeleton-base:      #2a3140;   /* clearly lighter than surface (#1a1f2b) */
+  --skeleton-highlight: #333d4e;   /* shimmer highlight — lighter band */
+
   --canvas-bg:        #0b0e15;
   --canvas-grid:      rgba(211, 216, 224, 0.04);
   --edge-color:       rgba(211, 216, 224, 0.10);
@@ -232,6 +242,8 @@
   --text-2:        #cbc7be;
   --text-3:        #908b80;
   --text-4:        #5e5a52;
+  --skeleton-base:      #312e29;   /* warm dark skeleton base */
+  --skeleton-highlight: #3b3731;   /* warm dark shimmer highlight */
   --canvas-bg:     #131210;
   --canvas-grid:   rgba(245, 242, 236, 0.04);
   --edge-color:    rgba(245, 242, 236, 0.12);


### PR DESCRIPTION
## What

Fixes #1533 — WebUI v2 skeleton/loading placeholders were nearly invisible because `bg-surface-2` is only 2–4% luminance away from `--surface` in both light and dark themes.

## Why it was invisible

| Theme | surface | surface-2 | delta |
|---|---|---|---|
| light | `#ffffff` | `#f3f5f8` | ~2% |
| dark  | `#1a1f2b` | `#20262f` | ~2% |

## Solution

- **New design tokens** — `--skeleton-base` and `--skeleton-highlight` added in `tokens.css` for all four palette variants (light, dark, warm-light, warm-dark), tuned to be noticeably distinct from the card surface while remaining tasteful.
- **Shimmer animation** — `@keyframes ag-shimmer` + `.ag-skeleton` utility class in `app.css`: a 90° gradient shimmer that travels 200% so the bright band fully crosses each bar. `prefers-reduced-motion` stops the animation.
- **Shared `Skeleton` primitive** — `webui-v2/src/components/ui/skeleton.tsx`, exported from the UI barrel, accepts `w`, `h`, and `className` Tailwind props. Every usage site now uses this instead of ad-hoc `bg-surface-2 animate-pulse` divs.
- **App-wide migration** — All inline skeleton divs in `flows.tsx`, `paths.tsx`, `topology.tsx`, `operations.tsx`, `pending.tsx`, `settings.tsx`, `landing.tsx`, and `docs-skeleton.tsx` updated to the shared primitive.
- **`dashboard/` untouched** — zero diff on the old dashboard.

## Verification

- `npm run build` → clean (`tsc -b && vite build`, no TS errors)
- Playwright screenshots confirm bars are clearly visible in both light and dark mode (see below)

### Light mode
Bars read as clearly distinct mid-gray lines against white card surfaces, with a subtle shimmer sweep.

### Dark mode
Bars lift off the dark card surface with sufficient contrast and the same shimmer.

## Files changed

| File | Change |
|---|---|
| `webui-v2/src/styles/tokens.css` | +`--skeleton-base` / `--skeleton-highlight` tokens (all palette variants) |
| `webui-v2/src/styles/app.css` | +`@keyframes ag-shimmer` + `.ag-skeleton` class + token bridge |
| `webui-v2/src/components/ui/skeleton.tsx` | NEW — shared Skeleton primitive |
| `webui-v2/src/components/ui/index.ts` | +export Skeleton |
| `webui-v2/src/components/docs/docs-skeleton.tsx` | migrated to Skeleton |
| `webui-v2/src/routes/flows.tsx` | migrated SkeletonRow |
| `webui-v2/src/routes/paths.tsx` | migrated SkeletonLine + inline divs |
| `webui-v2/src/routes/topology.tsx` | migrated SkeletonFlowUnit |
| `webui-v2/src/routes/operations.tsx` | migrated 5 inline skeleton divs |
| `webui-v2/src/routes/pending.tsx` | migrated PendingSkeleton |
| `webui-v2/src/routes/settings.tsx` | migrated 4 inline skeleton divs |
| `webui-v2/src/routes/landing.tsx` | migrated skeleton cards |

🤖 Generated with [Claude Code](https://claude.com/claude-code)