### PR TITLE
feat(wizard): monorepo module selection + per-module progress + single-border button (Fixes #1531)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -24,11 +24,20 @@ import (
 	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/jobs"
 	"github.com/cajasmota/archigraph/internal/mcp"
+	"github.com/cajasmota/archigraph/internal/progress"
 	"github.com/cajasmota/archigraph/internal/quality"
 	"github.com/cajasmota/archigraph/internal/quality/audit"
 	"github.com/cajasmota/archigraph/internal/registry"
 	"github.com/cajasmota/archigraph/internal/resolve"
 )
+
+// daemonProgressBroker is the process-wide indexer progress bus. The Rebuild
+// path publishes granular per-repo progress.Event records into it (via the
+// indexer's WithPublisher option) and the dashboard's /api/index-progress SSE
+// endpoints subscribe to it, so the WebUI Index step renders live per-repo /
+// per-module rows with file counters instead of a generic bar (#1531). It is
+// created once in runDaemon before the RPC + dashboard servers start.
+var daemonProgressBroker = progress.NewBroker()
 
 // defaultDashboardPort is the default TCP port for the embedded dashboard.
 const defaultDashboardPort = 47274
@@ -381,6 +390,11 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 			if args.Incremental && !args.Wipe {
 				opts = append(opts, WithIncremental(daemon.StateDirForRepo(w.r.Path)))
 			}
+			// Publish granular per-repo progress into the shared broker so the
+			// WebUI Index step renders live rows + file counters (#1531).
+			opts = append(opts,
+				WithPublisher(daemonProgressBroker),
+				WithProgressSlugs(args.Group, w.r.Slug))
 			indexErr := rebuildIndexFunc(w.r.Path, "", "", nil, false, false, opts...)
 			results[i] = repoResult{
 				path: w.r.Path,
@@ -408,6 +422,11 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 				if args.Incremental && !args.Wipe {
 					opts = append(opts, WithIncremental(daemon.StateDirForRepo(rw.r.Path)))
 				}
+				// Publish granular per-repo progress into the shared broker so
+				// the WebUI Index step renders live rows + file counters (#1531).
+				opts = append(opts,
+					WithPublisher(daemonProgressBroker),
+					WithProgressSlugs(args.Group, rw.r.Slug))
 				indexErr := rebuildIndexFunc(rw.r.Path, "", "", nil, false, false, opts...)
 				results[idx] = repoResult{
 					path: rw.r.Path,
@@ -686,6 +705,12 @@ func makeDaemonDashboardServe(daemonStartedAt time.Time) func(ctx context.Contex
 		// Tell the dashboard server when the daemon started so /api/info
 		// can compute and report uptime (#991).
 		srv.SetDaemonStartedAt(daemonStartedAt)
+
+		// Wire the shared indexer progress broker (#1531) so the
+		// /api/index-progress SSE endpoints can fan granular per-repo /
+		// per-module progress.Event records to the WebUI Index step. The
+		// Rebuild path publishes into this same broker (see daemonRebuildFunc).
+		srv.SetProgressBroker(daemonProgressBroker)
 
 		// Wire MCP activity broker (epic #1157, Phase 1: Jarvis).
 		// The same broker is injected into the shared MCP server so tool

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -32,6 +32,8 @@ import {
   AlertTriangle,
   ArrowRight,
   Check,
+  CheckSquare,
+  Square,
 } from "lucide-react";
 import { toast } from "sonner";
 
@@ -84,6 +86,11 @@ export function ScanWizard(props: ScanWizardProps) {
   const [scan, setScan] = useState<ScanInspectReply | null>(null);
   const [name, setName] = useState("");
   const [jobId, setJobId] = useState<string | null>(null);
+  // Monorepo module selection (#1531). When Detect finds a monorepo, the user
+  // picks WHICH package roots to index; each selected package is registered as
+  // its own repo (its absolute sub-path), so indexing a subset works and the
+  // Index step shows one row per chosen module. Default: all packages checked.
+  const [selectedPkgs, setSelectedPkgs] = useState<Set<string>>(new Set());
 
   // Server-side folder browser (#1529). `browseDir` is the directory currently
   // being listed; null defaults to the daemon's home dir. `null` while the
@@ -112,6 +119,7 @@ export function ScanWizard(props: ScanWizardProps) {
     setScan(null);
     setName("");
     setJobId(null);
+    setSelectedPkgs(new Set());
     setBrowseDir(null);
     inspect.reset();
     createFromScan.reset();
@@ -151,6 +159,9 @@ export function ScanWizard(props: ScanWizardProps) {
       setScan(result);
       if (result.valid) {
         setName((prev) => prev || result.suggestedGroup);
+        // Default to ALL detected packages checked (#1531). Empty for a single
+        // repo — then runIndex registers the whole folder as one repo.
+        setSelectedPkgs(new Set(result.packages ?? []));
         setStep("detect");
       } else {
         toast.error(result.error ?? "That path can't be indexed.");
@@ -163,7 +174,23 @@ export function ScanWizard(props: ScanWizardProps) {
   // --- Step 3: create/register + index ---
   async function runIndex() {
     if (!scan?.valid) return;
-    const repos = [{ path: scan.absPath, slug: scan.suggestedSlug }];
+    // Monorepo with a package list → register ONLY the SELECTED package roots,
+    // each as its own repo (its absolute sub-path). The daemon walks each
+    // sub-path independently, so indexing a subset works and the Index step
+    // streams one progress row per chosen module (#1531). A single repo (no
+    // packages) registers the whole folder as one repo, as before.
+    const isMonorepo = (scan.packages?.length ?? 0) > 0;
+    const repos = isMonorepo
+      ? [...selectedPkgs].sort().map((pkg) => ({
+          path: `${scan.absPath}/${pkg}`,
+          slug: slugify(`${scan.suggestedSlug}-${pkg}`),
+          modules: [pkg],
+        }))
+      : [{ path: scan.absPath, slug: scan.suggestedSlug }];
+    if (repos.length === 0) {
+      toast.error("Select at least one package to index.");
+      return;
+    }
     try {
       if (mode === "create") {
         if (!nameSlug || nameDuplicate) return;
@@ -320,6 +347,11 @@ export function ScanWizard(props: ScanWizardProps) {
                 type="button"
                 variant="secondary"
                 size="sm"
+                // shrink-0 + whitespace-nowrap: the flex parent was squeezing the
+                // button so its label wrapped to two lines, and the wrapped text
+                // overflowed the fixed-height border box — reading as a double
+                // border. Keep it a single-line pill with one clean border (#1531).
+                className="shrink-0 whitespace-nowrap"
                 disabled={!browsePath || inspect.isPending}
                 onClick={() => {
                   setPath(browsePath);
@@ -421,6 +453,83 @@ export function ScanWizard(props: ScanWizardProps) {
                   )}
                 </dl>
 
+                {/* Monorepo module selection (#1531): pick which package roots
+                    to index. Default all-checked; only the SELECTED packages are
+                    registered + indexed. */}
+                {scan.packages.length > 0 && (
+                  <div data-testid="wizard-modules">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-text-2">
+                        Packages to index
+                        <span className="ml-1.5 text-xs text-text-4">
+                          ({selectedPkgs.size}/{scan.packages.length})
+                        </span>
+                      </span>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 text-xs"
+                          onClick={() => setSelectedPkgs(new Set(scan.packages))}
+                          data-testid="wizard-modules-all"
+                        >
+                          Select all
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 text-xs"
+                          onClick={() => setSelectedPkgs(new Set())}
+                          data-testid="wizard-modules-none"
+                        >
+                          None
+                        </Button>
+                      </div>
+                    </div>
+                    <ul className="mt-1.5 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface divide-y divide-border/60">
+                      {scan.packages.map((pkg) => {
+                        const checked = selectedPkgs.has(pkg);
+                        return (
+                          <li key={pkg}>
+                            <button
+                              type="button"
+                              role="checkbox"
+                              aria-checked={checked}
+                              className={cn(
+                                "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-2",
+                                checked ? "text-text-2" : "text-text-4",
+                              )}
+                              onClick={() =>
+                                setSelectedPkgs((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(pkg)) next.delete(pkg);
+                                  else next.add(pkg);
+                                  return next;
+                                })
+                              }
+                              data-testid="wizard-module"
+                              data-pkg={pkg}
+                              data-checked={checked}
+                            >
+                              {checked ? (
+                                <CheckSquare size={15} className="shrink-0 text-accent-strong" />
+                              ) : (
+                                <Square size={15} className="shrink-0 text-text-4" />
+                              )}
+                              <span className="min-w-0 flex-1 truncate font-mono">{pkg}</span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {selectedPkgs.size === 0 && (
+                      <p className="mt-1 text-xs text-danger">Select at least one package to index.</p>
+                    )}
+                  </div>
+                )}
+
                 {mode === "create" && (
                   <label className="block">
                     <span className="text-sm text-text-2">Group name</span>
@@ -445,7 +554,12 @@ export function ScanWizard(props: ScanWizardProps) {
               </Button>
               <Button
                 type="button"
-                disabled={!scan.valid || indexing || (mode === "create" && (!nameSlug || nameDuplicate))}
+                disabled={
+                  !scan.valid ||
+                  indexing ||
+                  (scan.packages.length > 0 && selectedPkgs.size === 0) ||
+                  (mode === "create" && (!nameSlug || nameDuplicate))
+                }
                 onClick={() => void runIndex()}
                 data-testid="wizard-index"
               >


### PR DESCRIPTION
## Summary
WebUI v2 create-group / add-repo wizard now lets you **pick which packages of a monorepo to index**, shows **live per-module progress with file counters**, and the **"Select this folder" button renders with a single clean border**. Also wires the previously-dormant indexer→broker→SSE progress pipeline so the granular stream actually flows.

`Fixes #1531`

## What changed
- `webui-v2/src/components/chrome/scan-wizard.tsx`
- `cmd/archigraph/daemon.go`

`dashboard/` (legacy SPA): **zero diff**.

## 1. Problem
- Detect recognised a monorepo ("pnpm · 11 packages") but offered no way to choose **which** packages — it always registered the whole root.
- The Index step showed a single coarse bar stuck on "Waiting for the first files…": the granular `progress.Event` pipeline (Tracker + Broker + `SetProgressBroker`, built in #1118/#1527) was **never wired** into the daemon's Rebuild path, so the `/api/index-progress/{group}` SSE endpoint always returned `progress broker not available`.
- The "Select this folder" button label wrapped to two lines inside its fixed-height border box, reading as a double border.

## 2. Root cause
- `SetProgressBroker` existed on the dashboard server but was never called in `cmd/archigraph/daemon.go`, and `daemonRebuildFunc` never passed `WithPublisher`/`WithProgressSlugs` to the indexer — so no `progress.Event` ever reached a subscriber.
- The select button used `variant="secondary"` (one border) but the flex parent squeezed it, wrapping the label and overflowing the 28px `h-7` box.

## 3. Fix
1. **Single-border button** — added `shrink-0 whitespace-nowrap` so it stays a one-line pill with one border.
2. **Monorepo module selection** — Detect renders a checkbox list of detected package roots (default all-checked, Select-all / None). `runIndex` registers **only the selected packages**, each as its own repo (absolute sub-path), so the daemon walks just those subtrees → subset indexing works. Index button disabled until ≥1 chosen.
3. **Per-module progress + file counters** — created a process-wide `progress.Broker` in `runDaemon`, wired it via `SetProgressBroker`, and threaded `WithPublisher` + `WithProgressSlugs(group, repo.Slug)` into both `rebuildIndexFunc` call sites (serial + parallel). The existing `IndexProgressFeed` now receives events and renders one row per package with "N/M files", a per-module bar, and a done state.

## 4. Testing
- `go build ./cmd/...` + `go vet ./cmd/archigraph`: green.
- `go test ./internal/dashboard` (wizard/scan/progress/SSE), `./internal/progress`, `./internal/install/detect`: pass. Two pre-existing `enrichment-writeback` failures are unrelated and fail identically on `origin/main`.
- `npm run build` (tsc + vite): green.
- Walked the live flow against an **isolated daemon** (separate `ARCHIGRAPH_HOME`/`ARCHIGRAPH_DAEMON_ROOT`, dashboard `:47299`, dev server `:47285`) + the `polyglot-platform` pnpm fixture. **Did NOT touch live :47274.**

## 5. Evidence
- Detect shows the 11-package checkbox list, all checked (11/11).
- Deselected 3 packages (8/11) → only the 8 selected repos indexed; the 3 `frontend/*` packages absent from the group. **Subset index works.**
- Index step renders **8 per-module rows**, each with N/M file counters (9/9, 7/7, 6/6 files · NN entities) + per-module bar.
- Granular SSE verified directly: distinct `repo_slug` rows progressing scanning→extracting_ast→…→done with real `files_done`/`files_total`.
- "Select this folder" is a single-line 28px pill, one border.

## 6. Risk / rollout
Low. Backend change is additive (publisher wiring; no behaviour change when no subscriber). Frontend change is scoped to the wizard. No DB/registry schema change — selected packages register as ordinary repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)