### PR TITLE
fix(webui-v2): null-safety crash sweep on real polyglot-platform data (Fixes #1537, #1535, #1536)

### DIFF
--- a/webui-v2/src/hooks/use-topology.ts
+++ b/webui-v2/src/hooks/use-topology.ts
@@ -45,7 +45,7 @@ export function flattenChannels(
   if (!data) return [];
 
   const crossRepoIds = new Set<string>();
-  for (const bg of data.broker_groups) {
+  for (const bg of data.broker_groups ?? []) {
     // cross_repo_topic_count > 0 doesn't tell us which IDs, so we derive from
     // broker_groups health.  Exact per-channel cross_repo flag would need the v2
     // detail endpoint; for the list we approximate by broker.
@@ -57,8 +57,8 @@ export function flattenChannels(
   function annotate(
     ch: TopologyChannel,
   ): TopologyChannel & { lifecycle_state: ChannelLifecycle } {
-    const hasP = ch.producers.length > 0;
-    const hasC = ch.consumers.length > 0;
+    const hasP = (ch.producers?.length ?? 0) > 0;
+    const hasC = (ch.consumers?.length ?? 0) > 0;
     let lifecycle_state: ChannelLifecycle;
     if (hasP && hasC) lifecycle_state = "active";
     else if (hasP && !hasC) lifecycle_state = "orphan_subscriber";
@@ -67,12 +67,12 @@ export function flattenChannels(
     return { ...ch, lifecycle_state };
   }
 
-  for (const ch of data.topics) all.push(annotate(ch));
-  for (const ch of data.queues) all.push(annotate(ch));
-  for (const ch of data.nats_subjects) all.push(annotate(ch));
-  for (const ch of data.graphql_subscriptions)
+  for (const ch of data.topics ?? []) all.push(annotate(ch));
+  for (const ch of data.queues ?? []) all.push(annotate(ch));
+  for (const ch of data.nats_subjects ?? []) all.push(annotate(ch));
+  for (const ch of data.graphql_subscriptions ?? [])
     all.push(annotate({ ...ch, broker_canonical: "graphql_subscription" as BrokerCanonical }));
-  for (const ch of data.channels) all.push(annotate(ch));
+  for (const ch of data.channels ?? []) all.push(annotate(ch));
 
   // Mark cross_repo for any channel whose id appears in any broker_group with
   // cross_repo_topic_count > 0. Since we don't have per-id flags here, we use
@@ -100,10 +100,10 @@ export function deriveCounts(
     if (ch.scheduled) scheduled++;
   }
   let active = 0;
-  for (const bg of brokerGroups) {
-    active += bg.health_summary.active;
+  for (const bg of brokerGroups ?? []) {
+    active += bg.health_summary?.active ?? 0;
   }
-  return { total: channels.length, orphanPub, orphanSub, scheduled, active };
+  return { total: channels?.length ?? 0, orphanPub, orphanSub, scheduled, active };
 }
 
 // ---------------------------------------------------------------------------

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -754,7 +754,7 @@ function PatternsTab({ groupId }: { groupId: string }) {
   });
 
   const filtered =
-    data?.patterns.filter((p) =>
+    data?.patterns?.filter((p) =>
       searchQ
         ? p.id.includes(searchQ) ||
           p.kind?.toLowerCase().includes(searchQ.toLowerCase()) ||
@@ -1067,24 +1067,24 @@ function OrphanAuditPane({ groupId }: { groupId: string }) {
           {/* Score + totals */}
           <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
             {[
-              { label: "Health score", value: String(data.health_score), color: healthColor },
+              { label: "Health score", value: String(data.health_score ?? "—"), color: healthColor },
               {
                 label: "Total entities",
-                value: data.total.entities.toLocaleString(),
+                value: (data.total?.entities ?? 0).toLocaleString(),
                 color: "text-text",
               },
               {
                 label: "Orphans",
-                value: data.total.orphans.toLocaleString(),
+                value: (data.total?.orphans ?? 0).toLocaleString(),
                 color: "text-warning",
               },
               {
                 label: "Orphan rate",
-                value: pct(data.total.orphan_rate),
+                value: pct(data.total?.orphan_rate ?? 0),
                 color:
-                  data.total.orphan_rate > 0.2
+                  (data.total?.orphan_rate ?? 0) > 0.2
                     ? "text-danger"
-                    : data.total.orphan_rate > 0.1
+                    : (data.total?.orphan_rate ?? 0) > 0.1
                     ? "text-warning"
                     : "text-success",
               },
@@ -1097,7 +1097,7 @@ function OrphanAuditPane({ groupId }: { groupId: string }) {
           </div>
 
           {/* Per-kind */}
-          {data.per_kind.length > 0 && (
+          {(data.per_kind?.length ?? 0) > 0 && (
             <Section title="By entity kind">
               <div className="space-y-2">
                 {data.per_kind.map((k) => (
@@ -1125,7 +1125,7 @@ function OrphanAuditPane({ groupId }: { groupId: string }) {
           )}
 
           {/* Per-repo */}
-          {data.per_repo.length > 0 && (
+          {(data.per_repo?.length ?? 0) > 0 && (
             <Section title="By repository">
               <div className="rounded-lg border border-border overflow-hidden">
                 <table className="w-full text-sm">
@@ -1174,7 +1174,7 @@ function OrphanAuditPane({ groupId }: { groupId: string }) {
           )}
 
           {/* Recommendations */}
-          {data.recommendations.length > 0 && (
+          {(data.recommendations?.length ?? 0) > 0 && (
             <Section title="Recommendations">
               <div className="space-y-2">
                 {data.recommendations.map((rec, i) => (
@@ -1304,10 +1304,10 @@ function RecallPane({ groupId }: { groupId: string }) {
                 ))}
               </div>
 
-              {r.missing_relationships.length > 0 && (
+              {(r.missing_relationships?.length ?? 0) > 0 && (
                 <Section
                   title="Missing relationships"
-                  sub={`${r.missing_relationships.length} relationships not found in this fixture`}
+                  sub={`${r.missing_relationships?.length ?? 0} relationships not found in this fixture`}
                 >
                   <div className="rounded-lg border border-border overflow-hidden">
                     <table className="w-full text-xs">
@@ -1321,7 +1321,7 @@ function RecallPane({ groupId }: { groupId: string }) {
                         </tr>
                       </thead>
                       <tbody className="divide-y divide-border-soft font-mono">
-                        {r.missing_relationships.slice(0, 50).map((rel, i) => (
+                        {(r.missing_relationships ?? []).slice(0, 50).map((rel, i) => (
                           <tr key={i} className="hover:bg-surface-2">
                             <td
                               className="px-3 py-1.5 text-text-3 truncate max-w-[200px]"

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -89,6 +89,7 @@ function VerbChip({ verb, lg = false }: { verb: string; lg?: boolean }) {
 
 /** Monospace path with dynamic {segments} and ${var} highlighted amber. */
 function PathString({ path, className }: { path: string; className?: string }) {
+  path = path ?? "";
   const parts: React.ReactNode[] = [];
   let i = 0;
   const re = /(\{[\w]+\}|\$\{[\w]+\})/g;
@@ -118,7 +119,7 @@ function statusCodeClass(code: number): string {
 }
 
 function kindIcon(kind: string): React.ReactNode {
-  switch (kind.toLowerCase()) {
+  switch ((kind ?? "").toLowerCase()) {
     case "component": return <Box size={12} />;
     case "datastore":
     case "db":        return <Database size={12} />;
@@ -199,7 +200,7 @@ function RouteRow({
       {/* Verbs + path */}
       <div className="flex-1 min-w-0">
         <div className="flex flex-wrap items-center gap-1 mb-0.5">
-          {route.verbs.map((v) => <VerbChip key={v} verb={v} />)}
+          {(route.verbs ?? []).map((v) => <VerbChip key={v} verb={v} />)}
           {route.is_webhook && (
             <span className="inline-flex items-center gap-1 h-5 px-1.5 rounded text-[10px] font-medium bg-[var(--info-soft)] text-[var(--info)] border border-[var(--info-soft)]">
               🪝 {route.webhook_provider ?? "webhook"}
@@ -210,7 +211,7 @@ function RouteRow({
       </div>
       {/* Right meta */}
       <div className="flex items-center gap-1 shrink-0 mt-0.5">
-        {route.multiplicity > route.verbs.length && (
+        {route.multiplicity > (route.verbs?.length ?? 0) && (
           <span className="text-[10px] text-text-4 tabular-nums">×{route.multiplicity}</span>
         )}
         {route.auth && (
@@ -218,9 +219,9 @@ function RouteRow({
             <Lock size={10} className="text-success" />
           </span>
         )}
-        {route.repos.length > 1 ? (
-          <span className="text-[10px] text-text-4 font-mono">+{route.repos.length}</span>
-        ) : route.repos[0] ? (
+        {(route.repos?.length ?? 0) > 1 ? (
+          <span className="text-[10px] text-text-4 font-mono">+{route.repos?.length}</span>
+        ) : route.repos?.[0] ? (
           <span className="text-[10px] text-text-4 font-mono truncate max-w-[64px]">{route.repos[0]}</span>
         ) : null}
       </div>
@@ -248,9 +249,10 @@ function ControllerSection({
   const key = `${backend.id}::${group.id}`;
   const open = openMap[key] !== false;
 
+  const groupRoutes = group.routes ?? [];
   const matches = search
-    ? group.routes.filter((r) => r.path.toLowerCase().includes(search.toLowerCase()))
-    : group.routes;
+    ? groupRoutes.filter((r) => (r.path ?? "").toLowerCase().includes(search.toLowerCase()))
+    : groupRoutes;
 
   if (search && matches.length === 0) return null;
 
@@ -309,16 +311,19 @@ function BackendSection({
   const key = `be::${backend.id}`;
   const open = openMap[key] !== false;
 
+  const backendGroups = backend.groups ?? [];
   const filteredGroups = search
-    ? backend.groups.filter((g) =>
-        g.routes.some((r) => r.path.toLowerCase().includes(search.toLowerCase())),
+    ? backendGroups.filter((g) =>
+        (g.routes ?? []).some((r) => (r.path ?? "").toLowerCase().includes(search.toLowerCase())),
       )
-    : backend.groups;
+    : backendGroups;
 
   if (search && filteredGroups.length === 0) return null;
 
-  const totalEndpoints = backend.groups.reduce(
-    (sum, g) => sum + g.routes.reduce((s, r) => s + (r.handlers_count || r.verbs.length), 0),
+  const totalEndpoints = backendGroups.reduce(
+    (sum, g) =>
+      sum +
+      (g.routes ?? []).reduce((s, r) => s + (r.handlers_count || (r.verbs?.length ?? 0)), 0),
     0,
   );
 
@@ -411,9 +416,9 @@ function FlatRouteList({
 }) {
   const allRoutes = useMemo(() => {
     const out: PathRoute[] = [];
-    for (const b of backends) {
-      for (const g of b.groups) {
-        for (const r of g.routes) {
+    for (const b of backends ?? []) {
+      for (const g of b.groups ?? []) {
+        for (const r of g.routes ?? []) {
           out.push(r);
         }
       }
@@ -422,7 +427,7 @@ function FlatRouteList({
   }, [backends]);
 
   const filtered = search
-    ? allRoutes.filter((r) => r.path.toLowerCase().includes(search.toLowerCase()))
+    ? allRoutes.filter((r) => (r.path ?? "").toLowerCase().includes(search.toLowerCase()))
     : allRoutes;
 
   if (filtered.length === 0) return null;
@@ -505,7 +510,23 @@ function EntityRow({ entity }: { entity: PathEntity }) {
   );
 }
 
-function DetailPane({ detail }: { detail: PathDetail }) {
+function DetailPane({ detail: rawDetail }: { detail: PathDetail }) {
+  // Real polyglot data can omit array/object fields entirely. Normalize once so
+  // every downstream access is null-safe (#1536).
+  const detail = {
+    ...rawDetail,
+    verbs: rawDetail.verbs ?? [],
+    repos: rawDetail.repos ?? [],
+    parameters: rawDetail.parameters ?? [],
+    response_shapes: rawDetail.response_shapes ?? [],
+    handlers: rawDetail.handlers ?? [],
+    inbound_fetches: rawDetail.inbound_fetches ?? [],
+    side_effects: rawDetail.side_effects ?? [],
+    tests: rawDetail.tests ?? [],
+    path_hash: rawDetail.path_hash ?? "",
+    path: rawDetail.path ?? "",
+    outbound: rawDetail.outbound ?? {},
+  } as PathDetail;
   const [verbFilter, setVerbFilter] = useState<string>("all");
   const [openSections, setOpenSections] = useState<Record<string, boolean>>({
     description: true,
@@ -745,7 +766,7 @@ function DetailPane({ detail }: { detail: PathDetail }) {
                     <div className="flex items-center gap-2 px-3 py-2 bg-bg-soft border-b border-border">
                       <VerbChip verb={shape.verb} />
                       <div className="flex flex-wrap gap-1">
-                        {shape.status_codes.map((sc) => (
+                        {(shape.status_codes ?? []).map((sc) => (
                           <span key={sc} className={cn("text-xs font-mono font-semibold", statusCodeClass(sc))}>
                             {sc}
                           </span>
@@ -815,7 +836,7 @@ function DetailPane({ detail }: { detail: PathDetail }) {
                           className="text-[10px] font-mono text-text-4 shrink-0"
                           title={`${h.source_file}:${h.start_line}`}
                         >
-                          {h.source_file.split("/").slice(-1)[0]}:{h.start_line}
+                          {(h.source_file ?? "").split("/").slice(-1)[0]}:{h.start_line}
                         </span>
                       </div>
                       <div className="px-3 py-2">
@@ -1181,7 +1202,7 @@ export default function PathsScreen() {
     const next: Record<string, boolean> = {};
     for (const b of backends) {
       next[`be::${b.id}`] = true;
-      for (const g of b.groups) {
+      for (const g of b.groups ?? []) {
         next[`${b.id}::${g.id}`] = true;
       }
     }
@@ -1192,7 +1213,7 @@ export default function PathsScreen() {
     const next: Record<string, boolean> = {};
     for (const b of backends) {
       next[`be::${b.id}`] = false;
-      for (const g of b.groups) {
+      for (const g of b.groups ?? []) {
         next[`${b.id}::${g.id}`] = false;
       }
     }
@@ -1204,9 +1225,12 @@ export default function PathsScreen() {
     return backends.reduce(
       (sum, b) =>
         sum +
-        b.groups.reduce(
+        (b.groups ?? []).reduce(
           (gs, g) =>
-            gs + g.routes.filter((r) => r.path.toLowerCase().includes(search.toLowerCase())).length,
+            gs +
+            (g.routes ?? []).filter((r) =>
+              (r.path ?? "").toLowerCase().includes(search.toLowerCase()),
+            ).length,
           0,
         ),
       0,

--- a/webui-v2/src/routes/pending.tsx
+++ b/webui-v2/src/routes/pending.tsx
@@ -606,7 +606,7 @@ export default function PendingScreen() {
   // All items for the current tab.
   const allItems: Candidate[] = useMemo(() => {
     if (!data) return [];
-    return tab === "repairs" ? data.repairs : data.enrichments;
+    return (tab === "repairs" ? data.repairs : data.enrichments) ?? [];
   }, [data, tab]);
 
   // Auto-select first row when tab switches or data loads (nothing focused yet).
@@ -621,7 +621,7 @@ export default function PendingScreen() {
   useEffect(() => {
     if (!data) return;
     const hints: Record<string, string> = {};
-    for (const c of [...data.repairs, ...data.enrichments]) {
+    for (const c of [...(data.repairs ?? []), ...(data.enrichments ?? [])]) {
       if (c.hint) hints[c.entityId] = c.hint;
     }
     seedServerHints(hints);
@@ -657,8 +657,8 @@ export default function PendingScreen() {
         key = item.severity;
         label = SEVERITY_META[item.severity].label;
       } else if (groupBy === "repo") {
-        key = item.entity.repo;
-        label = item.entity.repo;
+        key = item.entity?.repo ?? "unknown";
+        label = item.entity?.repo ?? "unknown";
       } else {
         key = "_all";
         label = "All";

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -395,7 +395,7 @@ function RepoRow({
 }) {
   const isMono = !!repo.monorepo;
   const [expanded, setExpanded] = useState(isMono);
-  const indexedPkgs = repo.monorepo?.packages.filter((p) => p.indexed).length ?? 0;
+  const indexedPkgs = repo.monorepo?.packages?.filter((p) => p.indexed).length ?? 0;
 
   return (
     <div className="border border-border-soft rounded-lg overflow-hidden">

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -281,8 +281,8 @@ function EntityChip({
   id: string;
   crossRepo?: boolean;
 }) {
-  const parts = id.split("::");
-  const name = parts[parts.length - 1].split(":").pop() ?? id;
+  const parts = (id ?? "").split("::");
+  const name = (parts[parts.length - 1] ?? "").split(":").pop() || id;
   const repo = parts.length > 1 ? parts[0] : null;
   return (
     <span
@@ -347,12 +347,14 @@ function FlowUnit({
   onClick: () => void;
 }) {
   const m = brokerMeta(channel.broker_canonical);
-  const producers = channel.producers.slice(0, 3);
-  const producerOverflow = channel.producers.length - 3;
-  const consumers = channel.consumers.slice(0, 3);
-  const consumerOverflow = channel.consumers.length - 3;
-  const hasProducers = channel.producers.length > 0;
-  const hasConsumers = channel.consumers.length > 0;
+  const producerList = channel.producers ?? [];
+  const consumerList = channel.consumers ?? [];
+  const producers = producerList.slice(0, 3);
+  const producerOverflow = producerList.length - 3;
+  const consumers = consumerList.slice(0, 3);
+  const consumerOverflow = consumerList.length - 3;
+  const hasProducers = producerList.length > 0;
+  const hasConsumers = consumerList.length > 0;
 
   const leftEdge = hasProducers ? "solid" : "dashed";
   const rightEdge = hasConsumers ? "solid" : "dashed";
@@ -486,10 +488,16 @@ function BrokerBand({
 
   const isDegradedCelery =
     brokerGroup.broker === "celery" &&
-    channels.every((ch) => ch.producers.length === 0 && ch.consumers.length === 0);
+    channels.every(
+      (ch) => (ch.producers?.length ?? 0) === 0 && (ch.consumers?.length ?? 0) === 0,
+    );
 
   const ts = relativeTime(brokerGroup.last_index_timestamp);
-  const hs = brokerGroup.health_summary;
+  const hs = brokerGroup.health_summary ?? {
+    active: 0,
+    orphan_publisher: 0,
+    orphan_subscriber: 0,
+  };
 
   return (
     <div className="border border-border rounded-lg overflow-hidden">
@@ -564,10 +572,10 @@ function MapView({
   selectedId: string | null;
   onSelect: (ch: FlatChannel) => void;
 }) {
-  const totalCrossRepo = brokerGroups.reduce((n, bg) => n + bg.cross_repo_topic_count, 0);
-  const totalOrphanPub = brokerGroups.reduce((n, bg) => n + bg.orphan_publishers, 0);
-  const totalOrphanSub = brokerGroups.reduce((n, bg) => n + bg.orphan_subscribers, 0);
-  const totalActive = brokerGroups.reduce((n, bg) => n + bg.health_summary.active, 0);
+  const totalCrossRepo = brokerGroups.reduce((n, bg) => n + (bg.cross_repo_topic_count ?? 0), 0);
+  const totalOrphanPub = brokerGroups.reduce((n, bg) => n + (bg.orphan_publishers ?? 0), 0);
+  const totalOrphanSub = brokerGroups.reduce((n, bg) => n + (bg.orphan_subscribers ?? 0), 0);
+  const totalActive = brokerGroups.reduce((n, bg) => n + (bg.health_summary?.active ?? 0), 0);
 
   const summaryItems = [
     { label: `${channels.length} channels` },
@@ -636,11 +644,11 @@ function ListRow({
       <BrokerShapeIcon canonical={channel.broker_canonical} size={18} />
       <span className="font-mono text-md text-text truncate flex-1">{channel.label}</span>
       <span className="text-xs text-text-3 shrink-0 hidden sm:flex items-center gap-1">
-        <span>{channel.producers.length}</span>
+        <span>{channel.producers?.length ?? 0}</span>
         <span className="text-text-4">→</span>
         <BrokerShapeIcon canonical={channel.broker_canonical} size={12} />
         <span className="text-text-4">→</span>
-        <span>{channel.consumers.length}</span>
+        <span>{channel.consumers?.length ?? 0}</span>
       </span>
       <LifecycleChip state={channel.lifecycle_state} className="shrink-0" />
       <RepoChip repo={channel.repo} className="shrink-0" />
@@ -717,12 +725,12 @@ function DetailSection({
 }
 
 function EntityList({ ids }: { ids: string[] }) {
-  if (ids.length === 0) return null;
+  if (!ids || ids.length === 0) return null;
   return (
     <div className="space-y-1">
       {ids.map((id) => {
-        const parts = id.split("::");
-        const name = parts[parts.length - 1].split(":").pop() ?? id;
+        const parts = (id ?? "").split("::");
+        const name = (parts[parts.length - 1] ?? "").split(":").pop() || id;
         const repo = parts.length > 1 ? parts[0] : null;
         return (
           <div key={id} className="flex items-center gap-2 text-sm">
@@ -753,11 +761,11 @@ function DetailPanel({
   }
 
   const producerIds = d
-    ? d.producers.map((p) => (typeof p === "string" ? p : String(p)))
-    : channel.producers;
+    ? (d.producers ?? []).map((p) => (typeof p === "string" ? p : String(p)))
+    : channel.producers ?? [];
   const consumerIds = d
-    ? d.consumers.map((c) => (typeof c === "string" ? c : String(c)))
-    : channel.consumers;
+    ? (d.consumers ?? []).map((c) => (typeof c === "string" ? c : String(c)))
+    : channel.consumers ?? [];
 
   return (
     <aside
@@ -962,7 +970,13 @@ function OrphanPublisherTab({ groupId }: { groupId: string }) {
       </div>
     );
   }
-  const entries = (data ?? []) as OrphanPublisherEntry[];
+  // Real daemon returns { orphan_publishers: [...] }, not a bare array (#1535).
+  const entries = (
+    Array.isArray(data)
+      ? data
+      : ((data as { orphan_publishers?: OrphanPublisherEntry[] } | undefined)
+          ?.orphan_publishers ?? [])
+  ) as OrphanPublisherEntry[];
   if (entries.length === 0) {
     return (
       <div className="flex flex-col items-center py-16 text-center gap-3">
@@ -982,11 +996,11 @@ function OrphanPublisherTab({ groupId }: { groupId: string }) {
           <BrokerShapeIcon canonical={e.broker_canonical} size={18} />
           <span className="font-mono text-md text-text truncate flex-1">{e.label}</span>
           <div className="flex gap-1 flex-wrap">
-            {e.producers.slice(0, 3).map((p) => (
+            {(e.producers ?? []).slice(0, 3).map((p) => (
               <EntityChip key={p} id={p} />
             ))}
-            {e.producers.length > 3 && (
-              <span className="text-xs text-text-3">+{e.producers.length - 3}</span>
+            {(e.producers?.length ?? 0) > 3 && (
+              <span className="text-xs text-text-3">+{(e.producers?.length ?? 0) - 3}</span>
             )}
           </div>
           <span className="text-xs px-2 py-0.5 rounded-full bg-amber-950/30 text-amber-300 border border-amber-700/40 shrink-0">
@@ -1010,7 +1024,13 @@ function OrphanSubscriberTab({ groupId }: { groupId: string }) {
       </div>
     );
   }
-  const entries = (data ?? []) as OrphanSubscriberEntry[];
+  // Real daemon returns { orphan_subscribers: [...] }, not a bare array (#1535).
+  const entries = (
+    Array.isArray(data)
+      ? data
+      : ((data as { orphan_subscribers?: OrphanSubscriberEntry[] } | undefined)
+          ?.orphan_subscribers ?? [])
+  ) as OrphanSubscriberEntry[];
   if (entries.length === 0) {
     return (
       <div className="flex flex-col items-center py-16 text-center gap-3">
@@ -1032,11 +1052,11 @@ function OrphanSubscriberTab({ groupId }: { groupId: string }) {
           <BrokerShapeIcon canonical={e.broker_canonical} size={18} />
           <span className="font-mono text-md text-text truncate flex-1">{e.label}</span>
           <div className="flex gap-1 flex-wrap">
-            {e.consumers.slice(0, 3).map((c) => (
+            {(e.consumers ?? []).slice(0, 3).map((c) => (
               <EntityChip key={c} id={c} />
             ))}
-            {e.consumers.length > 3 && (
-              <span className="text-xs text-text-3">+{e.consumers.length - 3}</span>
+            {(e.consumers?.length ?? 0) > 3 && (
+              <span className="text-xs text-text-3">+{(e.consumers?.length ?? 0) - 3}</span>
             )}
           </div>
           <span
@@ -1076,7 +1096,7 @@ function ScheduledTab({ channels }: { channels: FlatChannel[] }) {
     );
   }
   const sorted = [...scheduled].sort((a, b) =>
-    a.broker_canonical.localeCompare(b.broker_canonical),
+    (a.broker_canonical ?? "").localeCompare(b.broker_canonical ?? ""),
   );
   return (
     <div className="p-4 space-y-2">
@@ -1157,7 +1177,7 @@ export default function TopologyScreen() {
   }, [setSearchParams]);
 
   const filteredChannels = channels.filter((ch) => {
-    if (search && !ch.label.toLowerCase().includes(search.toLowerCase())) return false;
+    if (search && !(ch.label ?? "").toLowerCase().includes(search.toLowerCase())) return false;
     if (activeBrokers.size > 0 && !activeBrokers.has(ch.broker_canonical)) return false;
     return true;
   });


### PR DESCRIPTION
## 1. What & why
WebUI v2 screens were verified on synthetic/small data and threw React error-boundary crashes ("Unexpected Application Error") when run against the **real `polyglot-platform` fixture** (1871 entities). Root cause: unguarded null/undefined field access where the real, sparser data omits array/object fields the synthetic data always populated. This PR sweeps every screen + tab + detail pane on the real data and guards every crash site.

Fixes #1537
Fixes #1535
Fixes #1536

## 2. Crashes found + fixed (all reproduced on real data)
| # | Screen | Crash | Real-data cause | Fix |
|---|--------|-------|-----------------|-----|
| #1535 | Topology (load) | `Cannot read properties of undefined (reading 'length')` in `annotate`/`flattenChannels` | real `channels` have `producers`/`consumers` **null/missing** | `ch.producers?.length ?? 0`, default all bucket arrays + `broker_groups` to `[]`, guard `health_summary` |
| #1535 | Topology → Orphan pub/sub tabs | `entries.map is not a function` | endpoint returns `{ orphan_publishers: [...] }` / `{ orphan_subscribers: [...] }`, **not a bare array** | unwrap envelope: `Array.isArray(data) ? data : data?.orphan_publishers ?? []` |
| #1536 | Paths → DetailPane | `Cannot read properties of null (reading 'length')` | real path detail has `parameters` **null/missing** | normalize `detail` once at top of `DetailPane` (all arrays → `[]`, `outbound` → `{}`, hashes/path → `""`) |

Additional defensive guards added in the same sweep (no live crash hit but same sparse-data risk): topology `FlowUnit`/`BrokerBand`/`MapView`/`ListRow`/`EntityChip`/`EntityList`/`ScheduledTab`; paths `PathString`/`RouteRow`/`ControllerSection`/`BackendSection`/`FlatRouteList`/`filteredCount`/response-shape `status_codes`/handler `source_file`; operations Quality `data.total?.*` + `per_kind`/`per_repo`/`recommendations` length + Patterns `data?.patterns?.filter`; pending `data.repairs/enrichments ?? []` + `item.entity?.repo`; settings `repo.monorepo?.packages?.filter`.

## 3. Files changed
- `webui-v2/src/hooks/use-topology.ts` — `flattenChannels`, `annotate`, `deriveCounts`
- `webui-v2/src/routes/topology.tsx` — orphan-tab envelope unwrap + component guards
- `webui-v2/src/routes/paths.tsx` — `DetailPane` normalization + list-rail guards
- `webui-v2/src/routes/operations.tsx` — Quality + Patterns guards
- `webui-v2/src/routes/pending.tsx` — repairs/enrichments + entity guards
- `webui-v2/src/routes/settings.tsx` — monorepo packages optional-chain

Excluded per scope: `flows.tsx` (parallel grind), `graph.tsx` (parallel grind), `dashboard/` (zero diff).

## 4. How verified
- `npm run build` clean (`tsc -b && vite build`, 1776 modules, no type errors).
- Isolated Vite dev server on an isolated port proxying `/api` → daemon :47274 (live :47274 UI untouched).
- Playwright walkthrough on the real `polyglot-platform` group: Landing, Topology (All/Orphan-pub/Orphan-sub/Scheduled + channel detail pane), Paths (Endpoints + Orphans + open path detail), Docs (tree + entity detail), Pending (repairs + enrichments), Operations (System/Patterns/Quality/Updates), Settings.
- Asserted **zero** React error-boundary crashes ("Unexpected Application Error" / "is not a function" / "Cannot read prop") on every screen after the fix. Captured the three previously-crashing surfaces (topology load, topology orphan-pub, paths-detail) now rendering real data (e.g. "Orphan pub 5", path detail with "Defined in"/"Downstream").

## 5. Risk & scope
Low risk — purely additive null-guards / array defaults / envelope-unwrap; no behavior change on well-formed data. No backend, no dashboard, no flows/graph. Type-safe (build passes).

## 6. Follow-ups (out of scope, noted)
- Orphan-tab entries carry `broker` (not `broker_canonical`) and path-detail producers/consumers are objects rendering as `[object Object]` — both are **data-contract / display** mismatches, not crashes. Worth a separate ticket to align the wire shape with the TS types (`OrphanPublisherEntry.broker_canonical`, `TopologyChannelDetail.producers`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)