### PR TITLE
fix(webui-v2): monorepo-aware Graph defaults (Fixes #1532)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -47,7 +47,9 @@ import type {
 } from "@/store/use-graph-store";
 
 const SPACE_SIZE = 32768;
-const FIT_PADDING = 0.1;
+// Fix #1532-3: a smaller padding makes the settled graph FILL the canvas
+// instead of floating small in the middle at LOD HIGH (was 0.1).
+const FIT_PADDING = 0.04;
 
 // ── group / cluster helpers ──────────────────────────────────────────────────
 
@@ -111,6 +113,7 @@ export interface GraphCanvasProps {
   nodes: GraphNode[];
   edges: GraphEdge[];
   selectedNodeId: string | null;
+  hoveredNodeId: string | null;
   isDark: boolean;
   colorMode: ColorMode;
   groupBy: GroupByMode;
@@ -131,7 +134,11 @@ export interface GraphCanvasProps {
   className?: string;
 }
 
-const LABEL_COUNT = 24;
+// Labels (Fix #1532-5) are zoom/LOD-gated: a small always-on set of the
+// highest-degree hubs (plus the hovered node), with progressively more labels
+// revealed as the user zooms in — readable, not cluttered.
+const LABEL_BASE_COUNT = 12; // shown at the default (zoomed-out) level
+const LABEL_MAX_COUNT = 160; // ceiling once fully zoomed in
 const truncate = (s: string) => (s.length > 30 ? s.slice(0, 28) + "…" : s);
 
 function GraphCanvasInner({
@@ -139,6 +146,7 @@ function GraphCanvasInner({
   nodes,
   edges,
   selectedNodeId,
+  hoveredNodeId,
   isDark,
   colorMode,
   groupBy,
@@ -174,6 +182,8 @@ function GraphCanvasInner({
   onSettledRef.current = onSettled;
   const simRef = useRef(simulation);
   simRef.current = simulation;
+  const hoveredRef = useRef<string | null>(hoveredNodeId);
+  hoveredRef.current = hoveredNodeId;
   const relayoutRef = useRef(relayoutNonce);
 
   const idToIdx = useMemo(() => {
@@ -190,6 +200,13 @@ function GraphCanvasInner({
   }, [nodes]);
 
   const groupCenters = useMemo(() => buildGroupCenters(nodes, groupBy), [nodes, groupBy]);
+
+  // Stable 1-based module color index (alphabetical) for the "module" color
+  // mode — gives a monorepo's packages distinct colors. (Fix #1532-1)
+  const moduleToIdx = useMemo(() => {
+    const mods = Array.from(new Set(nodes.map((n) => moduleKey(n.sourceFile)))).sort();
+    return new Map(mods.map((m, i) => [m, i]));
+  }, [nodes]);
 
   // Degree percentile fn (so the degree gradient spreads across the long tail).
   const sortedDegrees = useMemo(
@@ -237,9 +254,12 @@ function GraphCanvasInner({
       const normPR = (n.pageRank ?? 0) / maxPR;
       clusterStrength[i] = grouping ? 0.45 + normPR * 0.25 : 0.04 + normPR * 0.06;
 
-      // log-scaled size by degree (graph.md: radius scales with PageRank/degree).
-      sizes[i] =
+      // log-scaled size by degree (graph.md: radius scales with PageRank/degree),
+      // hard-capped at maxMultiplier × base so high-degree hubs never bloom into
+      // overlapping blobs. (Fix #1532-4)
+      const raw =
         nodeSizing.baseSize + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale;
+      sizes[i] = Math.min(raw, nodeSizing.baseSize * nodeSizing.maxMultiplier);
 
       const gkey = groupKeyFor(n, groupBy);
       const center = grouping ? groupCenters.get(gkey) : undefined;
@@ -268,13 +288,15 @@ function GraphCanvasInner({
         rgba = degreeColor(t);
       } else if (colorMode === "community") {
         rgba = pastelAt(fill, (n.communityId ?? 0) + 1);
+      } else if (colorMode === "module") {
+        rgba = pastelAt(fill, (moduleToIdx.get(moduleKey(n.sourceFile)) ?? 0) + 1);
       } else {
         rgba = pastelAt(fill, (repoToIdx.get(n.repo ?? "") ?? 0) + 1);
       }
       writeNormalizedRGBA(out, i, rgba);
     }
     return out;
-  }, [nodes, colorMode, repoToIdx, degreePercentile]);
+  }, [nodes, colorMode, repoToIdx, moduleToIdx, degreePercentile]);
 
   // Links — packed [src,tgt] + cross-repo state.
   const linkData = useMemo(() => {
@@ -322,18 +344,31 @@ function GraphCanvasInner({
     return out;
   }, [linkData, render.showLinks, render.linkWidthScale]);
 
-  // Top-N labels overlay.
-  const topLabelIdx = useMemo(
+  // Nodes ranked by degree (descending) — the highest-degree hubs are labelled
+  // first; the count revealed grows with zoom level. (Fix #1532-5)
+  const rankedByDegree = useMemo(
     () =>
       nodes
         .map((n, i) => ({ i, d: n.degree ?? 0 }))
         .sort((a, b) => b.d - a.d)
-        .slice(0, LABEL_COUNT)
         .map((x) => x.i),
     [nodes],
   );
   const labelLayerRef = useRef<HTMLDivElement>(null);
-  const labelRafRef = useRef<number | null>(null);
+
+  const escapeLabel = (s: string) =>
+    truncate(s).replace(/&/g, "&amp;").replace(/</g, "&lt;");
+
+  const labelSpan = (sx: number, sy: number, text: string, strong: boolean) =>
+    `<span style="position:absolute;left:${sx}px;top:${
+      sy - 14
+    }px;transform:translate(-50%,-100%);white-space:nowrap;font-size:${
+      strong ? 12 : 11
+    }px;font-weight:${strong ? 600 : 500};padding:1px 5px;border-radius:4px;background:${
+      isDark ? "rgba(2,6,23,0.72)" : "rgba(248,250,252,0.9)"
+    };color:${isDark ? "#e2e8f0" : "#1e293b"}${
+      strong ? `;outline:1px solid ${isDark ? "#38bdf8" : "#0284c7"}` : ""
+    }">${escapeLabel(text)}</span>`;
 
   const refreshLabels = useCallback(() => {
     const g = graphRef.current;
@@ -343,8 +378,30 @@ function GraphCanvasInner({
     if (!positions || positions.length === 0) return;
     const w = containerRef.current?.clientWidth ?? 0;
     const h = containerRef.current?.clientHeight ?? 0;
+
+    // Zoom-gated count: at the fitted level show only the top hubs; reveal more
+    // (up to a ceiling) the further the user zooms in.
+    let zoom = 1;
+    try {
+      zoom = g.getZoomLevel() || 1;
+    } catch {
+      /* engine not ready */
+    }
+    const factor = Math.max(1, Math.pow(Math.max(zoom, 0.0001) * 3.2, 1.4));
+    const count = Math.min(
+      LABEL_MAX_COUNT,
+      rankedByDegree.length,
+      Math.round(LABEL_BASE_COUNT * factor),
+    );
+
+    const shown = new Set<number>(rankedByDegree.slice(0, count));
+    // Always include the hovered node, even if it's a low-degree leaf.
+    const hovId = hoveredRef.current;
+    const hovIdx = hovId != null ? idToIdx.get(hovId) : undefined;
+    if (hovIdx !== undefined) shown.add(hovIdx);
+
     const frag: string[] = [];
-    for (const idx of topLabelIdx) {
+    for (const idx of shown) {
       const n = nodesRef.current[idx];
       if (!n) continue;
       const px = positions[idx * 2];
@@ -352,26 +409,33 @@ function GraphCanvasInner({
       if (px === undefined || py === undefined) continue;
       const [sx, sy] = g.spaceToScreenPosition([px, py]);
       if (sx < -50 || sy < -50 || sx > w + 50 || sy > h + 50) continue;
-      frag.push(
-        `<span style="position:absolute;left:${sx}px;top:${
-          sy - 14
-        }px;transform:translate(-50%,-100%);white-space:nowrap;font-size:11px;font-weight:500;padding:1px 5px;border-radius:4px;background:${
-          isDark ? "rgba(2,6,23,0.72)" : "rgba(248,250,252,0.85)"
-        };color:${isDark ? "#e2e8f0" : "#1e293b"}">${truncate(n.label)
-          .replace(/&/g, "&amp;")
-          .replace(/</g, "&lt;")}</span>`,
-      );
+      frag.push(labelSpan(sx, sy, n.label, idx === hovIdx));
     }
     layer.innerHTML = frag.join("");
-  }, [topLabelIdx, isDark]);
+  }, [rankedByDegree, idToIdx, isDark]);
 
+  // Always invoke the LATEST refreshLabels via a ref: the mount-only engine
+  // handlers (onZoom / onSimulationTick) and a stable scheduleLabels would
+  // otherwise capture the FIRST-render closure, whose node list was still empty
+  // — so labels never rendered. (Fix #1532-5)
+  const refreshLabelsRef = useRef(refreshLabels);
+  refreshLabelsRef.current = refreshLabels;
+
+  // Schedule a debounced label refresh on a short timeout. We deliberately do
+  // NOT use requestAnimationFrame: once the engine is paused (settled) it stops
+  // painting, so rAF gets starved and never fires — labels would never appear.
+  // A stable single-timer (clear-then-set) guarantees the refresh runs and is
+  // coalesced across the many tick/zoom events. (Fix #1532-5)
+  const labelTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const scheduleLabels = useCallback(() => {
-    if (labelRafRef.current !== null) return;
-    labelRafRef.current = requestAnimationFrame(() => {
-      labelRafRef.current = null;
-      refreshLabels();
-    });
-  }, [refreshLabels]);
+    if (labelTimerRef.current !== null) clearTimeout(labelTimerRef.current);
+    labelTimerRef.current = setTimeout(() => {
+      labelTimerRef.current = null;
+      refreshLabelsRef.current();
+    }, 48);
+  }, []);
+  // scheduleLabels is stable (no deps), so engine handlers can use it directly.
+  const scheduleLabelsLive = scheduleLabels;
 
   const doSettle = useCallback(() => {
     if (hasSettledRef.current) return;
@@ -384,7 +448,12 @@ function GraphCanvasInner({
     g?.pause();
     g?.fitView(400, FIT_PADDING);
     scheduleLabels();
-    setTimeout(scheduleLabels, 450);
+    // Re-fit once layout has fully painted so the graph reliably FILLS the
+    // viewport at LOD HIGH (the first fit can run before final positions land).
+    setTimeout(() => {
+      graphRef.current?.fitView(300, FIT_PADDING);
+      scheduleLabels();
+    }, 450);
     const positions = g?.getPointPositions();
     if (positions && positions.length > 0) {
       saveLayout(group, nodeIds, new Float32Array(positions));
@@ -428,7 +497,7 @@ function GraphCanvasInner({
       onSimulationEnd: () => {
         if (!hasSettledRef.current) doSettleRef.current();
       },
-      onSimulationTick: scheduleLabels,
+      onSimulationTick: scheduleLabelsLive,
       onClick: (index?: number) => {
         if (index === undefined) {
           onNodeClickRef.current(null);
@@ -452,7 +521,7 @@ function GraphCanvasInner({
         const n = nodesRef.current[index];
         if (n) onNodeHoverRef.current(n);
       },
-      onZoom: scheduleLabels,
+      onZoom: scheduleLabelsLive,
     });
     graphRef.current = g;
 
@@ -473,7 +542,7 @@ function GraphCanvasInner({
 
     return () => {
       if (capTimerRef.current) clearTimeout(capTimerRef.current);
-      if (labelRafRef.current !== null) cancelAnimationFrame(labelRafRef.current);
+      if (labelTimerRef.current !== null) clearTimeout(labelTimerRef.current);
       g.destroy();
       graphRef.current = null;
     };
@@ -613,6 +682,26 @@ function GraphCanvasInner({
     // hard-hide for repo/focus filters; soft-dim for community focus.
     g.setConfig({ pointGreyoutOpacity: repoActive || focusActive ? 0 : 0.18 });
   }, [nodes, activeRepos, focusNodeIds, focusedCommunityId]);
+
+  // ── refresh labels when the hovered node changes (Fix #1532-5) ───────────────
+  useEffect(() => {
+    scheduleLabels();
+  }, [hoveredNodeId, scheduleLabels]);
+
+  // Once node data is available, kick a few delayed label refreshes so the
+  // labels appear after the engine has positions — the mount-time settle may
+  // have scheduled a refresh while the node list was still empty. (Fix #1532-5)
+  useEffect(() => {
+    if (rankedByDegree.length === 0) return;
+    const t1 = setTimeout(scheduleLabels, 300);
+    const t2 = setTimeout(scheduleLabels, 1200);
+    const t3 = setTimeout(scheduleLabels, 2600);
+    return () => {
+      clearTimeout(t1);
+      clearTimeout(t2);
+      clearTimeout(t3);
+    };
+  }, [rankedByDegree, scheduleLabels]);
 
   // ── re-fit to focus ego-graph ────────────────────────────────────────────────
   useEffect(() => {

--- a/webui-v2/src/lib/graph-colors.ts
+++ b/webui-v2/src/lib/graph-colors.ts
@@ -110,7 +110,8 @@ export function degreeColor(t: number): RGBA {
 
 /** Cross-repo "bridge" edge color — bright sky so integration points pop. */
 export const CROSS_REPO_EDGE: RGBA = [56, 189, 248, 1];
-/** Same-repo edge color — subtle slate. */
-export const SAME_REPO_EDGE: RGBA = [100, 116, 139, 1];
+/** Same-repo edge color — slate, lifted brighter (#1532-2) so edges read on
+ *  the light background instead of fading into it. */
+export const SAME_REPO_EDGE: RGBA = [71, 85, 105, 1];
 /** Highlighted (focused-neighbor) edge color — amber. */
 export const HIGHLIGHT_EDGE: RGBA = [251, 146, 60, 1];

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -29,6 +29,7 @@ import { CommunitiesPopover } from "@/components/graph/communities-popover";
 
 const COLOR_MODES: { id: ColorMode; label: string }[] = [
   { id: "repo", label: "Repo" },
+  { id: "module", label: "Module" },
   { id: "community", label: "Community" },
   { id: "degree", label: "Degree" },
 ];
@@ -103,6 +104,23 @@ export default function GraphScreen() {
   }, [data, s.enabledEdgeKinds]);
 
   const nodes = data?.nodes ?? [];
+
+  // ── monorepo-aware default coloring/grouping (Fix #1532-1) ───────────────────
+  // A monorepo is a single repo split into many modules. Repo grouping there is
+  // one flat color = useless; default to per-MODULE color + module grouping.
+  // Multi-repo groups keep Repo. Applied ONCE per group, before the user touches
+  // the controls (applyMonorepoDefaults no-ops once groupingTouched is true).
+  useEffect(() => {
+    if (!data || nodes.length === 0) return;
+    const repos = new Set(nodes.map((n) => n.repo));
+    const moduleOf = (sf: string) =>
+      sf ? sf.replace(/\\/g, "/").split("/").slice(0, -1).slice(-2).join("/") : "";
+    const modules = new Set(nodes.map((n) => moduleOf(n.sourceFile)).filter(Boolean));
+    const isMonorepo = repos.size <= 1 && modules.size >= 3;
+    s.applyMonorepoDefaults(isMonorepo);
+    // Run once per group when data first becomes available.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [groupId, !!data]);
 
   const searchMatches = useMemo(() => {
     if (!s.search.trim()) return [];
@@ -268,6 +286,7 @@ export default function GraphScreen() {
                 nodes={nodes}
                 edges={edges}
                 selectedNodeId={s.selectedNodeId}
+                hoveredNodeId={s.hoveredNodeId}
                 isDark={isDark}
                 colorMode={s.colorMode}
                 groupBy={s.groupBy}

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -14,7 +14,7 @@
 import { create } from "zustand";
 import type { EdgeKind } from "@/data/types";
 
-export type ColorMode = "repo" | "community" | "degree";
+export type ColorMode = "repo" | "module" | "community" | "degree";
 export type GroupByMode = "repo" | "community" | "module" | "none";
 export type LodLevel = "low" | "mid" | "high";
 
@@ -55,18 +55,25 @@ export const DEFAULT_SIMULATION: SimulationConfig = {
 };
 
 export const DEFAULT_NODE_SIZING: NodeSizingConfig = {
-  baseSize: 120,
-  degreeScale: 30,
-  maxMultiplier: 3.0,
+  // Fix #1532-4: out-of-box defaults must not produce overlapping "blobs".
+  // Lower base + gentler degree scale + a tight max multiplier so a high-degree
+  // hub stays at most ~1.8× the base size (was 3× of a much larger base).
+  baseSize: 90,
+  degreeScale: 18,
+  maxMultiplier: 1.8,
 };
 
 export const DEFAULT_RENDER: RenderConfig = {
   pointOpacity: 0.92,
   pointSizeScale: 0.22,
   scalePointsOnZoom: true,
-  maxPointSize: 60,
+  // Fix #1532-4: cap the on-screen pixel size so no node becomes a giant blob
+  // even when zoomed in (was 60).
+  maxPointSize: 34,
   linkWidthScale: 1.0,
-  linkOpacity: 0.18,
+  // Fix #1532-2: edges were nearly invisible on the light background at 0.18.
+  // Raise the default same-repo link opacity so relationships read clearly.
+  linkOpacity: 0.42,
   showLinks: true,
 };
 
@@ -117,6 +124,12 @@ interface GraphState {
   // View knobs
   colorMode: ColorMode;
   groupBy: GroupByMode;
+  /**
+   * Whether the user has explicitly chosen a color/group mode this session.
+   * Until then, the screen is free to pick monorepo-aware defaults once the
+   * graph data arrives (Fix #1532-1). Set true by setColorMode/setGroupBy.
+   */
+  groupingTouched: boolean;
 
   // Tuning (persisted)
   simulation: SimulationConfig;
@@ -140,6 +153,13 @@ interface GraphState {
   setLod: (lod: LodLevel) => void;
   setColorMode: (m: ColorMode) => void;
   setGroupBy: (m: GroupByMode) => void;
+  /**
+   * Pick monorepo-aware default coloring/grouping ONCE per group, before the
+   * user touches the controls. A monorepo (one repo, many modules) defaults to
+   * per-MODULE color + module grouping (repo coloring would be one flat color);
+   * a multi-repo group keeps Repo. (Fix #1532-1)
+   */
+  applyMonorepoDefaults: (isMonorepo: boolean) => void;
   setSimulation: (patch: Partial<SimulationConfig>) => void;
   setNodeSizing: (patch: Partial<NodeSizingConfig>) => void;
   setRender: (patch: Partial<RenderConfig>) => void;
@@ -163,6 +183,7 @@ export const useGraphStore = create<GraphState>((set) => ({
 
   colorMode: "repo",
   groupBy: "repo",
+  groupingTouched: false,
 
   simulation: persistedJSON("ag.v2.graph.sim", DEFAULT_SIMULATION),
   nodeSizing: persistedJSON("ag.v2.graph.sizing", DEFAULT_NODE_SIZING),
@@ -194,8 +215,15 @@ export const useGraphStore = create<GraphState>((set) => ({
     }),
   clearRepos: () => set({ activeRepos: null }),
   setLod: (lod) => set({ lod }),
-  setColorMode: (colorMode) => set({ colorMode }),
-  setGroupBy: (groupBy) => set({ groupBy }),
+  setColorMode: (colorMode) => set({ colorMode, groupingTouched: true }),
+  setGroupBy: (groupBy) => set({ groupBy, groupingTouched: true }),
+  applyMonorepoDefaults: (isMonorepo) =>
+    set((s) => {
+      if (s.groupingTouched) return {}; // never override an explicit choice
+      return isMonorepo
+        ? { colorMode: "module" as ColorMode, groupBy: "module" as GroupByMode }
+        : { colorMode: "repo" as ColorMode, groupBy: "repo" as GroupByMode };
+    }),
 
   setSimulation: (patch) =>
     set((s) => {


### PR DESCRIPTION
## 1. What & why
The WebUI v2 Graph shipped with **bad out-of-box defaults** that made a monorepo graph nearly unusable on first load: one flat color (Repo grouping), barely-visible edges, the graph floating small in the canvas, high-degree nodes ballooning into overlapping blobs, and no node labels at all. This PR fixes all five as **defaults** (kept in `use-graph-store.ts` so they remain easy to re-tune), with monorepo auto-detection.

`Fixes #1532`

## 2. The five fixes
1. **Per-MODULE coloring for monorepos.** Added a `module` color mode (distinct pastel per module, derived from `source_file`). On data load the screen auto-detects a monorepo (single repo with ≥3 modules) and defaults color + group-by to **Module**; multi-repo groups keep **Repo**. The choice no-ops once the user touches a control (`groupingTouched`).
2. **Brighter links.** Default `linkOpacity` raised `0.18 → 0.42` and the same-repo edge color lifted (`slate-500 → slate-600`) so relationships read on the light background.
3. **Fit-to-viewport.** Tightened fit padding `0.1 → 0.04` and added a second `fitView` ~450ms after settle (the first fit can run before final positions land) so the graph fills the canvas at LOD HIGH.
4. **Node-size blob cap.** Lowered defaults (`baseSize 120→90`, `degreeScale 30→18`, `maxMultiplier 3.0→1.8`, `maxPointSize 60→34`) and, critically, **enforced** the `maxMultiplier` ceiling in the size buffer (`size = min(raw, baseSize × maxMultiplier)`) which was previously ignored — so a high-degree hub stays ≤1.8× base and never blooms into a blob, even when zoomed.
5. **Node labels (zoom/LOD-gated).** Wired the label layer to render entity names: an always-on set of the highest-degree hubs plus the hovered node, with the count scaling up as you zoom in (`LABEL_BASE_COUNT 12 → LABEL_MAX_COUNT 160`), viewport-culled so it stays readable.

## 3. Root-cause note (labels never rendered)
Two latent bugs blocked labels entirely on origin/main:
- The mount-only engine callbacks (`onZoom`/`onSimulationTick`) captured the **first-render** `scheduleLabels`, whose `refreshLabels` closed over an **empty** node list. Routed through a live ref to the latest `refreshLabels`.
- `scheduleLabels` relied on `requestAnimationFrame`, which is **starved after the engine pauses** (settled → no painting), so the final refresh never fired. Switched to a coalesced single-`setTimeout` (clear-then-set); the prior guard had also left a stale non-null timer ref that permanently blocked rescheduling.

## 4. Testing
- `npm run build` (tsc -b + vite) green; `npm run lint` (tsc --noEmit) clean.
- Verified on the **real indexed `polyglot-platform`** monorepo group (1 repo, 111 modules, 1,612 nodes) via an isolated headless Playwright run against a dev server on an isolated port (proxying read-only `/api` to the live daemon — **:47274 untouched**):
  - Module color mode auto-selected; **multiple distinct module colors** visible.
  - **Links clearly visible** on the light background.
  - Graph **fills the canvas** at load.
  - **No blob nodes**, even when zoomed into the dense cluster.
  - **Labels render** (e.g. `publishDerived`, `LedgerService.postSale`, `OrderEnrichmentTopology.build`) and reveal more granular names (`post`, `get`, `append_event`, `refund`) on zoom.
- Monorepo detection verified against live payload: `repos=1, modules=111 → monorepo=true`.

## 5. Risk & rollback
Low risk — changes are confined to `webui-v2/` (graph store defaults, canvas rendering, graph route, edge colors). No Go/backend changes; **`dashboard/` has zero diff**; the v2 graph endpoint already carried `pagerank` + `source_file`. All five values live in `DEFAULT_*` configs and are exposed in the existing tuning panels, so any default can be re-tuned without a code change. Revert = revert the branch.

## 6. Scope
4 files, +178/-41: `store/use-graph-store.ts`, `components/graph/graph-canvas.tsx`, `routes/graph.tsx`, `lib/graph-colors.ts`. Did not merge; did not touch the live daemon (:47274).

🤖 Generated with [Claude Code](https://claude.com/claude-code)