### PR TITLE
feat(wizard): multi-repo parent detection — child git repos as selectable group children (Fixes #1531)

### DIFF
--- a/internal/dashboard/v2_wizard.go
+++ b/internal/dashboard/v2_wizard.go
@@ -69,6 +69,15 @@ type v2ScanInspectReply struct {
 	Monorepo string `json:"monorepo"`
 	// Packages is the list of repo-relative package roots for a monorepo.
 	Packages []string `json:"packages"`
+	// ChildGitRepos is the list of immediate child directory names (relative to
+	// AbsPath) that contain a .git directory. Populated when the parent dir is NOT
+	// itself a git repo but contains N child git repos (the multi-repo-parent
+	// pattern). Takes precedence over Packages when both would be non-empty.
+	ChildGitRepos []string `json:"childGitRepos"`
+	// ChildrenKind is "git-repos" when ChildGitRepos is non-empty, "packages"
+	// when Packages is non-empty, "" when neither. The frontend uses this to
+	// label the checkbox list appropriately.
+	ChildrenKind string `json:"childrenKind"`
 	// HasAgentsMD is true when AGENTS.md / CLAUDE.md / GEMINI.md exists at the root.
 	HasAgentsMD bool `json:"hasAgentsMd"`
 	// AlreadyRegistered is the existing group name if .archigraph/group.json exists.
@@ -98,6 +107,28 @@ type v2ScanReposReq struct {
 // ─────────────────────────────────────────────────────────────────────────────
 // POST /api/v2/scan/inspect — resolve + detect (no writes)
 // ─────────────────────────────────────────────────────────────────────────────
+
+// detectChildGitRepos returns the names of immediate subdirectories of dir
+// that contain a .git entry (file or directory), sorted alphabetically. It
+// does NOT recurse; only depth-1 children are checked. Returns nil (not an
+// empty slice) when no such children exist so callers can test with len().
+func detectChildGitRepos(dir string) []string {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+	var children []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		candidate := filepath.Join(dir, e.Name(), ".git")
+		if _, err := os.Stat(candidate); err == nil {
+			children = append(children, e.Name())
+		}
+	}
+	return children
+}
 
 // handleV2ScanInspect resolves a server-side path and returns a stack +
 // monorepo detection preview. It performs NO registry writes; it is the
@@ -144,6 +175,28 @@ func (s *Server) handleV2ScanInspect(w http.ResponseWriter, r *http.Request) {
 		pkgs = []string{}
 	}
 
+	// Detect child git repos (the multi-repo-parent pattern). A parent directory
+	// containing N sub-repos is NOT itself a monorepo (no workspace manifest), so
+	// DetectMonorepo returns KindNone. We detect it by checking which immediate
+	// subdirs contain a .git entry. If child git repos are found we prefer them
+	// over monorepo packages (a plain parent dir can't meaningfully be both).
+	childGitRepos := detectChildGitRepos(abs)
+	if childGitRepos == nil {
+		childGitRepos = []string{}
+	}
+
+	// Determine childrenKind and resolve precedence: child git repos win over
+	// monorepo packages when both would be present (shouldn't happen in practice
+	// but be explicit and safe).
+	var childrenKind string
+	if len(childGitRepos) > 0 {
+		// Child git repos detected — clear packages to avoid confusion.
+		pkgs = []string{}
+		childrenKind = "git-repos"
+	} else if len(pkgs) > 0 {
+		childrenKind = "packages"
+	}
+
 	reply := v2ScanInspectReply{
 		Valid:          true,
 		AbsPath:        abs,
@@ -152,6 +205,8 @@ func (s *Server) handleV2ScanInspect(w http.ResponseWriter, r *http.Request) {
 		Stack:          detect.Stack(abs),
 		Monorepo:       string(mono.Kind),
 		Packages:       pkgs,
+		ChildGitRepos:  childGitRepos,
+		ChildrenKind:   childrenKind,
 		HasAgentsMD:    fileExists(abs, "AGENTS.md") || fileExists(abs, "CLAUDE.md") || fileExists(abs, "GEMINI.md"),
 	}
 	if fileExists(abs, ".archigraph/group.json") {

--- a/internal/dashboard/v2_wizard_test.go
+++ b/internal/dashboard/v2_wizard_test.go
@@ -49,6 +49,19 @@ func writeMonorepo(t *testing.T, dir string) {
 	}
 }
 
+// writeChildGitRepos creates a parent directory fixture with N named child
+// git repos — each subdirectory contains a real .git dir (empty, just the
+// marker). This simulates the multi-repo-parent pattern.
+func writeChildGitRepos(t *testing.T, parentDir string, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		gitDir := filepath.Join(parentDir, name, ".git")
+		if err := os.MkdirAll(gitDir, 0o755); err != nil {
+			t.Fatalf("writeChildGitRepos mkdir %s: %v", gitDir, err)
+		}
+	}
+}
+
 // TestV2ScanInspect_DetectsMonorepo verifies the scan/detect step resolves a
 // real path and surfaces the stack + monorepo layout without any registry write.
 func TestV2ScanInspect_DetectsMonorepo(t *testing.T) {
@@ -112,6 +125,87 @@ func TestV2ScanInspect_InvalidPath(t *testing.T) {
 	}
 	if env.Data.Error == "" {
 		t.Fatalf("expected error message for missing path")
+	}
+}
+
+// TestV2ScanInspect_DetectsChildGitRepos verifies that pointing at a parent
+// directory whose immediate children are git repos returns childGitRepos + sets
+// childrenKind to "git-repos".
+func TestV2ScanInspect_DetectsChildGitRepos(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	parentDir := t.TempDir()
+	writeChildGitRepos(t, parentDir, "core", "frontend", "mobile")
+
+	body := `{"path":` + jsonQuote(parentDir) + `}`
+	resp, err := http.Post(ts.URL+"/api/v2/scan/inspect", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST scan/inspect: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d; want 200", resp.StatusCode)
+	}
+	var env struct {
+		OK   bool               `json:"ok"`
+		Data v2ScanInspectReply `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK || !env.Data.Valid {
+		t.Fatalf("scan should be valid: %+v", env)
+	}
+	if len(env.Data.ChildGitRepos) != 3 {
+		t.Fatalf("childGitRepos = %v; want 3 entries (core, frontend, mobile)", env.Data.ChildGitRepos)
+	}
+	if env.Data.ChildrenKind != "git-repos" {
+		t.Fatalf("childrenKind = %q; want git-repos", env.Data.ChildrenKind)
+	}
+	// Packages must be empty — child git repos take precedence.
+	if len(env.Data.Packages) != 0 {
+		t.Fatalf("packages = %v; want empty (child git repos take precedence)", env.Data.Packages)
+	}
+}
+
+// TestV2ScanInspect_PrefersChildGitReposOverMonorepo verifies that when a
+// directory has BOTH a pnpm-workspace.yaml (monorepo packages) AND child git
+// repos, child git repos take precedence (childrenKind="git-repos", packages=[]).
+func TestV2ScanInspect_PrefersChildGitReposOverMonorepo(t *testing.T) {
+	ts, _ := newWizardTestServer(t, func(proto.RebuildArgs) (proto.RebuildReply, error) {
+		return proto.RebuildReply{}, nil
+	})
+	parentDir := t.TempDir()
+	// Plant a monorepo marker.
+	writeMonorepo(t, parentDir)
+	// Also plant child git repos (the precedence case).
+	writeChildGitRepos(t, parentDir, "repo-a", "repo-b")
+
+	body := `{"path":` + jsonQuote(parentDir) + `}`
+	resp, err := http.Post(ts.URL+"/api/v2/scan/inspect", "application/json", strings.NewReader(body))
+	if err != nil {
+		t.Fatalf("POST scan/inspect: %v", err)
+	}
+	defer resp.Body.Close()
+	var env struct {
+		OK   bool               `json:"ok"`
+		Data v2ScanInspectReply `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !env.OK || !env.Data.Valid {
+		t.Fatalf("scan should be valid: %+v", env)
+	}
+	if env.Data.ChildrenKind != "git-repos" {
+		t.Fatalf("childrenKind = %q; want git-repos (child git repos take precedence)", env.Data.ChildrenKind)
+	}
+	if len(env.Data.ChildGitRepos) < 2 {
+		t.Fatalf("childGitRepos = %v; want >= 2", env.Data.ChildGitRepos)
+	}
+	if len(env.Data.Packages) != 0 {
+		t.Fatalf("packages = %v; want empty when child git repos present", env.Data.Packages)
 	}
 }
 

--- a/webui-v2/src/components/chrome/scan-wizard.tsx
+++ b/webui-v2/src/components/chrome/scan-wizard.tsx
@@ -54,7 +54,7 @@ import {
 import { useIndexProgress } from "@/hooks/use-index-progress";
 import { IndexProgressFeed } from "@/components/chrome/index-progress-feed";
 import { ApiError } from "@/lib/api";
-import type { ScanInspectReply } from "@/data/types";
+import type { ScanInspectReply, WizardRepo } from "@/data/types";
 import { cn } from "@/lib/utils";
 
 type WizardStep = "pick" | "detect" | "index";
@@ -91,6 +91,10 @@ export function ScanWizard(props: ScanWizardProps) {
   // its own repo (its absolute sub-path), so indexing a subset works and the
   // Index step shows one row per chosen module. Default: all packages checked.
   const [selectedPkgs, setSelectedPkgs] = useState<Set<string>>(new Set());
+  // Multi-repo-parent selection (#1531 follow-up). When Detect finds child git
+  // repos, the user picks WHICH ones to index; each is registered as its own
+  // repo (its absolute sub-path). Default: all children checked.
+  const [selectedChildren, setSelectedChildren] = useState<Set<string>>(new Set());
 
   // Server-side folder browser (#1529). `browseDir` is the directory currently
   // being listed; null defaults to the daemon's home dir. `null` while the
@@ -120,6 +124,7 @@ export function ScanWizard(props: ScanWizardProps) {
     setName("");
     setJobId(null);
     setSelectedPkgs(new Set());
+    setSelectedChildren(new Set());
     setBrowseDir(null);
     inspect.reset();
     createFromScan.reset();
@@ -162,6 +167,8 @@ export function ScanWizard(props: ScanWizardProps) {
         // Default to ALL detected packages checked (#1531). Empty for a single
         // repo — then runIndex registers the whole folder as one repo.
         setSelectedPkgs(new Set(result.packages ?? []));
+        // Default all child git repos checked (#1531 follow-up).
+        setSelectedChildren(new Set(result.childGitRepos ?? []));
         setStep("detect");
       } else {
         toast.error(result.error ?? "That path can't be indexed.");
@@ -174,21 +181,30 @@ export function ScanWizard(props: ScanWizardProps) {
   // --- Step 3: create/register + index ---
   async function runIndex() {
     if (!scan?.valid) return;
-    // Monorepo with a package list → register ONLY the SELECTED package roots,
-    // each as its own repo (its absolute sub-path). The daemon walks each
-    // sub-path independently, so indexing a subset works and the Index step
-    // streams one progress row per chosen module (#1531). A single repo (no
-    // packages) registers the whole folder as one repo, as before.
+    // Build the repo list based on what was detected:
+    //   1. Child git repos (multi-repo-parent, #1531 follow-up): each selected
+    //      child dir as its own repo (absolute sub-path).
+    //   2. Monorepo packages (#1531): each selected package as its own repo.
+    //   3. Single repo: the whole folder, as before.
+    const hasChildGitRepos = (scan.childGitRepos?.length ?? 0) > 0;
     const isMonorepo = (scan.packages?.length ?? 0) > 0;
-    const repos = isMonorepo
-      ? [...selectedPkgs].sort().map((pkg) => ({
-          path: `${scan.absPath}/${pkg}`,
-          slug: slugify(`${scan.suggestedSlug}-${pkg}`),
-          modules: [pkg],
-        }))
-      : [{ path: scan.absPath, slug: scan.suggestedSlug }];
+    let repos: WizardRepo[];
+    if (hasChildGitRepos) {
+      repos = [...selectedChildren].sort().map((child) => ({
+        path: `${scan.absPath}/${child}`,
+        slug: slugify(child),
+      }));
+    } else if (isMonorepo) {
+      repos = [...selectedPkgs].sort().map((pkg) => ({
+        path: `${scan.absPath}/${pkg}`,
+        slug: slugify(`${scan.suggestedSlug}-${pkg}`),
+        modules: [pkg],
+      }));
+    } else {
+      repos = [{ path: scan.absPath, slug: scan.suggestedSlug }];
+    }
     if (repos.length === 0) {
-      toast.error("Select at least one package to index.");
+      toast.error("Select at least one repo to index.");
       return;
     }
     try {
@@ -433,7 +449,11 @@ export function ScanWizard(props: ScanWizardProps) {
                   <div className="flex items-center justify-between py-1">
                     <dt className="text-text-3">Layout</dt>
                     <dd>
-                      {scan.monorepo ? (
+                      {(scan.childGitRepos?.length ?? 0) > 0 ? (
+                        <Badge tone="info">
+                          {scan.childGitRepos.length} repositor{scan.childGitRepos.length === 1 ? "y" : "ies"} detected
+                        </Badge>
+                      ) : scan.monorepo ? (
                         <Badge tone="info">
                           {scan.monorepo} monorepo · {scan.packages.length} package
                           {scan.packages.length === 1 ? "" : "s"}
@@ -452,6 +472,84 @@ export function ScanWizard(props: ScanWizardProps) {
                     </div>
                   )}
                 </dl>
+
+                {/* Child git repos selection (#1531 follow-up): multi-repo-parent
+                    pattern — pick which child repos to index. Each selected child
+                    dir is registered as its own repo. Only shown when childGitRepos
+                    is non-empty (takes precedence over monorepo packages). */}
+                {(scan.childGitRepos?.length ?? 0) > 0 && (
+                  <div data-testid="wizard-child-repos">
+                    <div className="flex items-center justify-between">
+                      <span className="text-sm text-text-2">
+                        Repositories to index
+                        <span className="ml-1.5 text-xs text-text-4">
+                          ({selectedChildren.size}/{scan.childGitRepos.length})
+                        </span>
+                      </span>
+                      <div className="flex gap-2">
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 text-xs"
+                          onClick={() => setSelectedChildren(new Set(scan.childGitRepos))}
+                          data-testid="wizard-child-repos-all"
+                        >
+                          Select all
+                        </Button>
+                        <Button
+                          type="button"
+                          variant="ghost"
+                          size="sm"
+                          className="h-6 text-xs"
+                          onClick={() => setSelectedChildren(new Set())}
+                          data-testid="wizard-child-repos-none"
+                        >
+                          None
+                        </Button>
+                      </div>
+                    </div>
+                    <ul className="mt-1.5 max-h-48 overflow-y-auto rounded-lg border border-border bg-surface divide-y divide-border/60">
+                      {scan.childGitRepos.map((child) => {
+                        const checked = selectedChildren.has(child);
+                        return (
+                          <li key={child}>
+                            <button
+                              type="button"
+                              role="checkbox"
+                              aria-checked={checked}
+                              className={cn(
+                                "flex w-full items-center gap-2 px-3 py-2 text-left text-sm hover:bg-surface-2",
+                                checked ? "text-text-2" : "text-text-4",
+                              )}
+                              onClick={() =>
+                                setSelectedChildren((prev) => {
+                                  const next = new Set(prev);
+                                  if (next.has(child)) next.delete(child);
+                                  else next.add(child);
+                                  return next;
+                                })
+                              }
+                              data-testid="wizard-child-repo"
+                              data-child={child}
+                              data-checked={checked}
+                            >
+                              {checked ? (
+                                <CheckSquare size={15} className="shrink-0 text-accent-strong" />
+                              ) : (
+                                <Square size={15} className="shrink-0 text-text-4" />
+                              )}
+                              <span className="min-w-0 flex-1 truncate font-mono">{child}</span>
+                            </button>
+                          </li>
+                        );
+                      })}
+                    </ul>
+                    {selectedChildren.size === 0 && (
+                      <p className="mt-1 text-xs text-danger">Select at least one repository to index.</p>
+                    )}
+                  </div>
+                )}
 
                 {/* Monorepo module selection (#1531): pick which package roots
                     to index. Default all-checked; only the SELECTED packages are
@@ -557,6 +655,7 @@ export function ScanWizard(props: ScanWizardProps) {
                 disabled={
                   !scan.valid ||
                   indexing ||
+                  ((scan.childGitRepos?.length ?? 0) > 0 && selectedChildren.size === 0) ||
                   (scan.packages.length > 0 && selectedPkgs.size === 0) ||
                   (mode === "create" && (!nameSlug || nameDuplicate))
                 }

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -948,6 +948,18 @@ export interface ScanInspectReply {
   /** "pnpm" | "npm" | "turbo" | "nx" | "lerna" | "multi" | "" */
   monorepo: string;
   packages: string[];
+  /**
+   * Names of immediate child directories that contain a .git entry — the
+   * multi-repo-parent pattern (#1531 follow-up). Non-empty only when the
+   * parent dir is NOT a git repo itself but wraps N child git repos. Takes
+   * precedence over packages when both would be present.
+   */
+  childGitRepos: string[];
+  /**
+   * "git-repos" when childGitRepos is non-empty, "packages" when packages is
+   * non-empty, "" otherwise. The UI uses this to label the checkbox list.
+   */
+  childrenKind: "git-repos" | "packages" | "";
   hasAgentsMd: boolean;
   alreadyRegistered?: string;
   error?: string;


### PR DESCRIPTION
## What
Extend the scan/inspect wizard step to detect **child git repositories** (immediate subdirectories containing a `.git` entry) when pointing at a parent directory that wraps N separate git repos. The detected children are presented in the same checkbox UI introduced in #1541 for monorepo packages. Selecting a subset registers exactly those child repos as the group's repos.

## Why
Pointing the wizard at a multi-repo parent (e.g. the UpVate parent containing `upvate_core` + `upvate_core_frontend` + `core-mobile`) previously indexed the parent as ONE flattened repo ("Repos: 1"). #1541 shipped package selection for monorepos but did NOT address the distinct case of a plain parent dir containing N sibling git repos with no workspace manifest.

## How
1. **Backend** (`v2_wizard.go`): add `detectChildGitRepos(dir)` — reads immediate subdirs, checks for a `.git` entry, returns sorted names. Add `ChildGitRepos []string` + `ChildrenKind string` to `v2ScanInspectReply`. In `handleV2ScanInspect`, call the helper and set `ChildrenKind = "git-repos"` when children are found; clear `Packages` so child git repos take precedence over monorepo detection (edge case).
2. **Backend tests** (`v2_wizard_test.go`): `TestV2ScanInspect_DetectsChildGitRepos` (3-child fixture), `TestV2ScanInspect_PrefersChildGitReposOverMonorepo` (precedence).
3. **Frontend types** (`data/types.ts`): extend `ScanInspectReply` with `childGitRepos: string[]` + `childrenKind: "git-repos" | "packages" | ""`.
4. **Frontend UI** (`scan-wizard.tsx`): new `selectedChildren` state (mirrors `selectedPkgs`); child-repos checkbox list with Select-all/None + count label (e.g. "3/3"); updated Layout badge ("N repositories detected"); extended `runIndex` to map selected children to individual `WizardRepo` entries; Index button disabled when 0 children selected.

## Testing
- `go build ./cmd/...` + `go vet ./internal/dashboard/`: green.
- `go test ./internal/dashboard/ -count=1`: 2 new tests pass; only 2 pre-existing failures on `origin/main` (TestWriteback_success, TestYamlScalar — unrelated to this PR, fail identically without these changes).
- `npm run build` (tsc + vite): green.
- Isolated daemon (port 47299, separate ARCHIGRAPH_HOME=/tmp/archigraph-test-home-multirepo). Did NOT touch live :47274.
- Walked the live flow: pointed wizard at `/Users/jorgecajas/Documents/Projects/UpVate` → Detect step shows "3 repositories detected" layout badge + "Repositories to index (3/3)" checkbox list with `core-mobile`, `upvate_core`, `upvate_core_frontend` all checked. Deselected `core-mobile` → counter shows (2/3). Created group → confirmed group has 2 repos (not 1 flattened).

## Evidence
Screenshot 1 — Detect step with UpVate parent: 3 child repos listed (3/3), "3 repositories detected" badge, all checked.

Screenshot 2 — After deselecting `core-mobile`: counter shows (2/3), `core-mobile` unchecked (greyed out).

API verification:
```
POST /api/v2/scan/inspect {"path":"/Users/jorgecajas/Documents/Projects/UpVate"}
→ childGitRepos: ["core-mobile","upvate_core","upvate_core_frontend"], childrenKind: "git-repos", packages: []

POST /api/v2/groups/from-scan {"name":"upvate-subset","repos":[upvate-core, upvate-core-frontend]}
→ 202 JobAck

GET /api/v2/groups/upvate-subset
→ repos count: 2 (upvate-core + upvate-core-frontend) — NOT 1 flattened
```

## Checklist
- [x] go build/vet green
- [x] go test ./internal/dashboard/ — new tests pass, no regressions
- [x] npm run build green
- [x] Isolated daemon only (live :47274 untouched)
- [x] UpVate parent → 3 child repos listed → select 2 → group.repos = 2
- [x] Fixes #1531