### PR TITLE
feat(engine): populate empty endpoint sections + non-Kafka topology channels (#1553)

### DIFF
--- a/internal/engine/kafka_wrapper_edges.go
+++ b/internal/engine/kafka_wrapper_edges.go
@@ -747,13 +747,24 @@ func synthesizeNodeSNSPublish(
 	}
 }
 
-// goAWSSNSPublishRe captures Go AWS SDK v2:
+// goAWSSNSPublishRe captures Go AWS SDK v2 with a literal ARN:
 //
 //	snsClient.Publish(ctx, &sns.PublishInput{TopicArn: aws.String("arn:..."), ...})
 //
 // Group 1 = TopicArn value.
 var goAWSSNSPublishRe = regexp.MustCompile(
 	`TopicArn\s*:\s*(?:aws\.String\s*\(\s*)?["` + "`" + `]([^"` + "`" + `\n\r]+)["` + "`" + `]`,
+)
+
+// goAWSSNSPublishVarRe captures the constant-resolved form where the ARN is a
+// package-level identifier rather than an inline string literal:
+//
+//	TopicArn: aws.String(inventoryReservedTopicARN)
+//	TopicArn: &topicARNConst
+//
+// Group 1 = identifier name (resolved against the Go const/var table).
+var goAWSSNSPublishVarRe = regexp.MustCompile(
+	`TopicArn\s*:\s*(?:aws\.String\s*\(\s*&?|&)([A-Za-z_][A-Za-z0-9_]*)\s*\)?`,
 )
 
 func synthesizeGoSNSPublish(
@@ -773,20 +784,40 @@ func synthesizeGoSNSPublish(
 		return findEnclosingGoName(src, offset)
 	}
 
-	for _, m := range goAWSSNSPublishRe.FindAllStringSubmatchIndex(src, -1) {
-		arn := src[m[2]:m[3]]
+	emit := func(offset int, arn string) {
 		topicName := snsTopicNameFromARN(arn)
 		if !looksLikeKafkaTopic(topicName) {
-			continue
+			return
 		}
 		id := snsTopicID(topicName)
 		emitTopic(id, topicName, "sns", map[string]string{
 			"messaging_layer": "aws-sdk-go-v2",
 			"arn":             arn,
 		})
-		emitEdge("Function", enclosing(m[0]), id, publishesToEdgeKind, map[string]string{
+		emitEdge("Function", enclosing(offset), id, publishesToEdgeKind, map[string]string{
 			"broker":          "sns",
 			"messaging_layer": "aws-sdk-go-v2",
 		})
+	}
+
+	// Literal ARN form.
+	litSpans := map[int]bool{}
+	for _, m := range goAWSSNSPublishRe.FindAllStringSubmatchIndex(src, -1) {
+		litSpans[m[0]] = true
+		emit(m[0], src[m[2]:m[3]])
+	}
+
+	// Constant-resolved form: TopicArn: aws.String(NAME) / &NAME.
+	consts := buildGoStringSymbolTable(src)
+	for _, m := range goAWSSNSPublishVarRe.FindAllStringSubmatchIndex(src, -1) {
+		if litSpans[m[0]] {
+			continue // already handled as a literal
+		}
+		name := src[m[2]:m[3]]
+		arn, ok := consts[name]
+		if !ok {
+			continue
+		}
+		emit(m[0], arn)
 	}
 }

--- a/internal/engine/kafka_wrapper_edges_test.go
+++ b/internal/engine/kafka_wrapper_edges_test.go
@@ -702,6 +702,38 @@ func PublishOrdersPlaced(ctx context.Context, client *sns.Client, msg string) er
 	}
 }
 
+// TestKafkaWrapper_GoSNSPublish_ConstResolved verifies that a TopicArn that
+// references a package-level string const (rather than an inline literal) is
+// resolved via the Go const table. Regression for #1553 — the ShipFast
+// inventory service publishes inventory.reserved with a named ARN const.
+func TestKafkaWrapper_GoSNSPublish_ConstResolved(t *testing.T) {
+	src := `package internal
+
+import (
+    "context"
+    "github.com/aws/aws-sdk-go-v2/aws"
+    "github.com/aws/aws-sdk-go-v2/service/sns"
+)
+
+const inventoryReservedTopicARN = "arn:aws:sns:us-east-1:000000000000:inventory.reserved"
+
+func publishReserved(ctx context.Context, c *sns.Client, msg string) {
+    c.Publish(ctx, &sns.PublishInput{
+        TopicArn: aws.String(inventoryReservedTopicARN),
+        Message:  aws.String(msg),
+    })
+}
+`
+	ents, rels := runWrapperDetect(t, "go", "inventory/consumer.go", src)
+
+	if topicByName(ents, "inventory.reserved") == nil {
+		t.Fatalf("expected MessageTopic for inventory.reserved (const-resolved), ents=%v", ents)
+	}
+	if len(edgesOfKind(rels, publishesToEdgeKind)) == 0 {
+		t.Fatalf("expected PUBLISHES_TO edge, rels=%v", rels)
+	}
+}
+
 // TestKafkaWrapper_SNSTopicNameFromARN exercises the ARN-to-name extractor.
 func TestKafkaWrapper_SNSTopicNameFromARN(t *testing.T) {
 	cases := []struct {

--- a/internal/engine/response_shape_corpus.go
+++ b/internal/engine/response_shape_corpus.go
@@ -51,6 +51,19 @@ import (
 // for cross-file resolution in the corpus-wide response-shape pass.
 type handlerKey struct{ kind, name string }
 
+// isHTTPEndpointKind reports whether a kind is one of the three http
+// endpoint synthetic kinds. Post-#1217 the synthesizer splits endpoints
+// into http_endpoint_definition / http_endpoint_call alongside the legacy
+// http_endpoint kind; the corpus-wide response-shape pass must consider all
+// three (it previously only matched the legacy kind, leaving cross-file
+// definitions — e.g. Go gin routes whose handlers live in a sibling file —
+// with empty response shapes).
+func isHTTPEndpointKind(kind string) bool {
+	return kind == httpEndpointKind ||
+		kind == httpEndpointDefinitionKind ||
+		kind == httpEndpointCallKind
+}
+
 // CorpusFileReader returns the source bytes for a repo-relative file
 // path, or nil if not available. The corpus-wide post-pass uses this
 // to read handler source from a different file than the route
@@ -108,7 +121,7 @@ func ApplyResponseShapesCorpus(
 	byName := make(map[string][]*types.EntityRecord, len(entities))
 	for i := range entities {
 		e := &entities[i]
-		if e.Kind == httpEndpointKind {
+		if isHTTPEndpointKind(e.Kind) {
 			continue
 		}
 		k := handlerKey{e.Kind, e.Name}
@@ -152,7 +165,7 @@ func ApplyResponseShapesCorpus(
 
 	for i := range entities {
 		e := &entities[i]
-		if e.Kind != httpEndpointKind {
+		if !isHTTPEndpointKind(e.Kind) {
 			continue
 		}
 		if e.Properties == nil {

--- a/internal/engine/response_shape_corpus_test.go
+++ b/internal/engine/response_shape_corpus_test.go
@@ -289,6 +289,73 @@ class UserDto {
 	}
 }
 
+// TestCorpusResponseShape_GoDefinitionKindCrossFile is a regression for
+// #1553: the corpus pass previously only matched the legacy http_endpoint
+// kind, so post-#1217 http_endpoint_definition entities (e.g. a Go gin route
+// whose handler + struct live in a sibling file) never had their response
+// shapes resolved cross-file. This exercises the http_endpoint_definition
+// path end-to-end.
+func TestCorpusResponseShape_GoDefinitionKindCrossFile(t *testing.T) {
+	handlerContent := []byte(`package internal
+
+import "github.com/gin-gonic/gin"
+import "net/http"
+
+type Shipment struct {
+    OrderID  string ` + "`json:\"order_id\"`" + `
+    Carrier  string ` + "`json:\"carrier\"`" + `
+    Status   string ` + "`json:\"status\"`" + `
+}
+
+func GetShipment(c *gin.Context) {
+    c.JSON(http.StatusOK, Shipment{OrderID: "x", Status: "IN_TRANSIT"})
+}
+`)
+
+	entities := []types.EntityRecord{
+		{
+			Kind:       "Function",
+			Name:       "GetShipment",
+			SourceFile: "shipping/internal/handlers.go",
+			Language:   "go",
+		},
+		{
+			Kind:       httpEndpointDefinitionKind,
+			Name:       "http:GET:/shipments/{orderId}",
+			SourceFile: "shipping/main.go",
+			Language:   "go",
+			Properties: map[string]string{
+				"framework":      "gin",
+				"verb":           "GET",
+				"path":           "/shipments/{orderId}",
+				"pattern_type":   "http_endpoint_synthesis",
+				"source_handler": "Function:GetShipment",
+			},
+		},
+	}
+
+	reader := func(p string) []byte {
+		if p == "shipping/internal/handlers.go" {
+			return handlerContent
+		}
+		return nil
+	}
+
+	stats := ApplyResponseShapesCorpus(entities, nil, reader)
+	if stats.Endpoints != 1 {
+		t.Fatalf("Endpoints=%d want 1 (definition kind must be considered); stats=%+v", stats.Endpoints, stats)
+	}
+	if stats.ShapeExtracted != 1 {
+		t.Fatalf("ShapeExtracted=%d want 1; stats=%+v", stats.ShapeExtracted, stats)
+	}
+	got := entities[1].Properties["response_keys"]
+	for _, k := range []string{"order_id", "carrier", "status"} {
+		if !csvContains(got, k) {
+			t.Errorf("response_keys=%q missing %q", got, k)
+		}
+	}
+}
+
 // csvContains is a tiny helper that checks if a comma-joined string
 // contains a value (used to keep test assertions readable).
 func csvContains(csv, want string) bool {

--- a/internal/engine/sqs_edges.go
+++ b/internal/engine/sqs_edges.go
@@ -544,6 +544,14 @@ var goSQSQueueURLFieldRe = regexp.MustCompile(`QueueUrl\s*:\s*aws\.String\s*\(\s
 // Group 1 = queue name.
 var goSQSCreateRe = regexp.MustCompile(`CreateQueueInput\s*\{[^}]*?QueueName\s*:\s*aws\.String\s*\(\s*"([^"\n\r]+)"`)
 
+// goSQSQueueURLVarFieldRe captures the constant-resolved struct-field form:
+//
+//	QueueUrl: aws.String(inventoryReservedQueueURL)
+//	QueueUrl: &queueURLConst
+//
+// Group 1 = identifier name (resolved against the Go string-const table).
+var goSQSQueueURLVarFieldRe = regexp.MustCompile(`QueueUrl\s*:\s*(?:aws\.String\s*\(\s*&?|&)([A-Za-z_][A-Za-z0-9_]*)\s*\)?`)
+
 func synthesizeGoSQS(
 	src string,
 	emitQueue func(queueID, queueName string, props map[string]string),
@@ -597,6 +605,36 @@ func synthesizeGoSQS(
 	for _, m := range goSQSQueueURLFieldRe.FindAllStringSubmatchIndex(src, -1) {
 		queueURL := src[m[2]:m[3]]
 		if !looksLikeSQSQueue(queueURL) {
+			continue
+		}
+		qID := sqsQueueID(queueURL)
+		qName := sqsQueueDisplayName(queueURL)
+		ctx := surroundingText(src, m[0], 300)
+		isSend := strings.Contains(ctx, "SendMessage") || strings.Contains(ctx, "SendMessageInput")
+		isReceive := strings.Contains(ctx, "ReceiveMessage") || strings.Contains(ctx, "ReceiveMessageInput")
+		if !isSend && !isReceive {
+			continue
+		}
+		emitQueue(qID, qName, nil)
+		caller := enclosing(m[0])
+		edgeKind := subscribesToEdgeKind
+		if isSend {
+			edgeKind = publishesToEdgeKind
+		}
+		emitEdge("Function", caller, qID, edgeKind, map[string]string{
+			"messaging_layer": "aws-sdk-go-v2",
+			"queue_url":       queueURL,
+		})
+	}
+
+	// Struct-literal QueueUrl field referencing a named string constant —
+	// covers `QueueUrl: aws.String(queueURLConst)` where the URL is a
+	// package-level const rather than an inline literal.
+	consts := buildGoStringSymbolTable(src)
+	for _, m := range goSQSQueueURLVarFieldRe.FindAllStringSubmatchIndex(src, -1) {
+		name := src[m[2]:m[3]]
+		queueURL, ok := consts[name]
+		if !ok || !looksLikeSQSQueue(queueURL) {
 			continue
 		}
 		qID := sqsQueueID(queueURL)

--- a/internal/engine/sqs_edges_test.go
+++ b/internal/engine/sqs_edges_test.go
@@ -258,6 +258,38 @@ func Poll(ctx context.Context, client *sqs.Client) {
 	}
 }
 
+// TestSQS_Go_ReceiveMessage_ConstResolved verifies that a QueueUrl referencing
+// a package-level const (rather than an inline literal) is resolved via the Go
+// const table. Regression for #1553 — the ShipFast shipping service receives
+// from the inventory-reserved queue using a named queue-URL const.
+func TestSQS_Go_ReceiveMessage_ConstResolved(t *testing.T) {
+	src := `package internal
+
+import (
+    "context"
+    "github.com/aws/aws-sdk-go-v2/service/sqs"
+    "github.com/aws/aws-sdk-go-v2/aws"
+)
+
+const inventoryReservedQueueURL = "https://sqs.us-east-1.amazonaws.com/000000000000/inventory-reserved"
+
+func pollOnce(ctx context.Context, c *sqs.Client) {
+    out, _ := c.ReceiveMessage(ctx, &sqs.ReceiveMessageInput{
+        QueueUrl: aws.String(inventoryReservedQueueURL),
+    })
+    _ = out
+}
+`
+	ents, rels := runSQSDetect(t, "go", "consumer.go", src)
+	qID := sqsQueueID("inventory-reserved")
+	if queueByName(ents, qID) == nil {
+		t.Fatalf("expected SCOPE.Queue for inventory-reserved (const-resolved), ents=%v", ents)
+	}
+	if len(relsByKind(rels, subscribesToEdgeKind)) == 0 {
+		t.Fatalf("expected SUBSCRIBES_TO edge, rels=%v", rels)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Helpers and guards
 // ---------------------------------------------------------------------------

--- a/internal/extractors/cross/testmap/extractor_test.go
+++ b/internal/extractors/cross/testmap/extractor_test.go
@@ -244,6 +244,30 @@ def test_get_user():
 	}
 }
 
+// TestPytest_AsyncDef is a regression for #1553: async test functions
+// (`async def test_*`) were not detected because the pytest function regex
+// only matched a leading `def`. The ShipFast orders integration test is an
+// `async def`, so no TESTS edge formed and the endpoint Tests section stayed
+// empty.
+func TestPytest_AsyncDef(t *testing.T) {
+	src := `import pytest
+from app.routes import create_order
+
+@pytest.mark.asyncio
+async def test_create_order_publishes_event(monkeypatch):
+    result = await create_order({"user_id": "u1"}, _claims={})
+    assert result["status"] == "PENDING"
+`
+	recs := runExtract(t, "tests/test_orders.py", "python", src)
+	rec := findByTested(t, recs, "test_create_order_publishes_event", "create_order")
+	if rec.Properties["test_framework"] != "pytest" {
+		t.Errorf("framework=%q", rec.Properties["test_framework"])
+	}
+	if rec.Properties["confidence"] != "high" {
+		t.Errorf("confidence=%q, want high", rec.Properties["confidence"])
+	}
+}
+
 func TestPytest_MockerPatchMedium(t *testing.T) {
 	src := `import pytest
 def test_mocked(mocker):

--- a/internal/extractors/cross/testmap/frameworks.go
+++ b/internal/extractors/cross/testmap/frameworks.go
@@ -228,7 +228,7 @@ func detectGoTest(source string) []testFunction {
 // ---------------------------------------------------------------------------
 
 var pytestFuncRE = regexp.MustCompile(
-	`(?m)^([ \t]*)def\s+(test_\w+)\s*\([^)]*\)\s*(?:->\s*[\w\[\], ]+)?\s*:`,
+	`(?m)^([ \t]*)(?:async\s+)?def\s+(test_\w+)\s*\([^)]*\)\s*(?:->\s*[\w\[\], ]+)?\s*:`,
 )
 
 func detectPytest(source string) []testFunction {


### PR DESCRIPTION
## 1. What & why
Fixes #1553. On the ShipFast (`polyglot-platform`) fixture the webui-v2 endpoint-detail panels and the Topology screen were rendering empty sections: every endpoint showed no **response shapes**, no **tests**, no **side effects**, and Topology only showed **Kafka** despite the owner expecting SNS/SQS/EventBridge. Root cause was a mix of (a) fixture publish/receive calls that were commented out, and (b) four genuine extraction gaps. This PR fixes both halves and adds regression tests; the fixture changes ship in a companion commit on the `polyglot-platform` repo.

## 2. Changes
**Extraction (this PR):**
- `internal/engine/kafka_wrapper_edges.go` — `synthesizeGoSNSPublish` resolves `TopicArn: aws.String(NAME)` / `&NAME` against the Go string-const table (reusing `buildGoStringSymbolTable`), mirroring the existing Python const path. Was literal-only before.
- `internal/engine/sqs_edges.go` — `synthesizeGoSQS` resolves `QueueUrl: aws.String(NAME)` against the same const table, send/receive direction inferred from surrounding tokens.
- `internal/engine/response_shape_corpus.go` — added `isHTTPEndpointKind` and applied it so the corpus cross-file response-shape pass considers `http_endpoint_definition` / `http_endpoint_call`, not just the legacy `http_endpoint`. This pass was effectively dead for split-kind endpoints since #1217.
- `internal/extractors/cross/testmap/frameworks.go` — `pytestFuncRE` now matches `async def test_*` (not just `def test_*`).

**Regression tests:** `TestKafkaWrapper_GoSNSPublish_ConstResolved`, `TestSQS_Go_ReceiveMessage_ConstResolved`, `TestCorpusResponseShape_GoDefinitionKindCrossFile`, `TestPytest_AsyncDef`.

**Fixture (companion commit on polyglot-platform, `db3b598`):** uncomment the SNS publish (inventory `inventory.reserved`), the SQS receive (shipping `inventory-reserved`), and the EventBridge publish (shipping `shipping.shipment_created`); add typed FastAPI `response_model` Pydantic classes on orders + typed `Shipment{}` returns on shipping gin handlers; add DynamoDB write + EventBridge publish side effects in `CreateShipment`. MANIFEST updated.

## 3. How it was tested
Fully isolated, never touched live `:47274`:
- Built a binary outside `/tmp` and ran the `xrepo-verify` harness (same engine + link passes the daemon uses, writes graph.json to a temp dir) against the fixture services before/after each change.
- `go test ./internal/engine/ ./internal/extractors/cross/testmap/ ./internal/links/` — all green.
- Confirmed the isolated daemon path (`ARCHIGRAPH_DAEMON_ROOT` + `ARCHIGRAPH_DASHBOARD_PORT=47991`) then tore it down; verified live `:47274` and `polyglot-platform.fleet.json` untouched.

## 4. Before / after (graph-level evidence, isolated index)
| Gap | Before | After |
|---|---|---|
| Response shapes | 1 endpoint (a dict-literal return) | 7 endpoints with typed `response_schema` (4 orders FastAPI + 3 shipping Go gin cross-file) |
| Tests (TESTS edges) | 0 | 1 (orders `test_create_order_publishes_event` → `create_order`) |
| Topology channels | Kafka + Redis only | + `sns:inventory.reserved` (PUBLISHES_TO), `sqs:inventory-reserved` (SUBSCRIBES_TO), `event:eventbridge:shipping:shipping.shipment_created` (PUBLISHES_TO) |
| Side effects | none derivable | handler edges now present: FETCHES×6, PUBLISHES_TO, QUERIES, WRITES_TO×4, READS_FROM×2 |

## 5. Risk & rollout
Low. All extractor changes are additive (const-resolution paths run only when an inline literal didn't already match; the corpus-kind filter only widens what's considered). No edge/entity is removed. Existing engine/testmap/links suites pass unchanged.

## 6. Follow-ups
- DynamoDB `PutItem` is not yet recognised as a DB-write edge (the EventBridge publish already covers the CreateShipment side-effect signal); a dedicated DynamoDB write detector could enrich the Side-effects section further.
- The daemon group↔graph binding via shared `~/.config/.../*.fleet.json` makes ad-hoc isolated-daemon API verification awkward; `xrepo-verify` remains the reliable isolated harness.

Fixes #1553

🤖 Generated with [Claude Code](https://claude.com/claude-code)