### PR TITLE
feat(webui-v2): Paths "swagger++" v1 — repo→module hierarchy + drill-down + orphan badge

### DIFF
--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -67,6 +67,10 @@ type v2PathTotals struct {
 	Endpoints   int `json:"endpoints"`
 	Controllers int `json:"controllers"`
 	Backends    int `json:"backends"`
+	// Orphans is the count of frontend FETCH calls that resolve to no backend
+	// handler. Surfaced here so the Orphan-callers tab can show a counter badge
+	// without a second round-trip (#1551).
+	Orphans int `json:"orphans"`
 }
 
 // v2PathsListResponse is the payload for GET /api/v2/groups/:id/paths.
@@ -139,22 +143,22 @@ type v2OutboundQueries struct {
 
 // v2PathDetail is the full detail for GET /api/v2/groups/:id/paths/:hash.
 type v2PathDetail struct {
-	PathHash        string              `json:"path_hash"`
-	Path            string              `json:"path"`
-	Verbs           []string            `json:"verbs"`
-	Repos           []string            `json:"repos"`
-	IsWebhook       bool                `json:"is_webhook"`
-	WebhookProvider string              `json:"webhook_provider,omitempty"`
-	Auth            bool                `json:"auth"`
-	AuthScheme      string              `json:"auth_scheme,omitempty"`
-	Description     v2DescriptionBlock  `json:"description"`
-	Parameters      []v2PathParameter   `json:"parameters"`
-	ResponseShapes  []v2ResponseShape   `json:"response_shapes"`
-	Handlers        []v2HandlerDetail   `json:"handlers"`
-	InboundFetches  []v2PathEntity      `json:"inbound_fetches"`
-	Outbound        v2OutboundQueries   `json:"outbound"`
-	SideEffects     []v2PathEntity      `json:"side_effects"`
-	Tests           []v2PathEntity      `json:"tests"`
+	PathHash        string             `json:"path_hash"`
+	Path            string             `json:"path"`
+	Verbs           []string           `json:"verbs"`
+	Repos           []string           `json:"repos"`
+	IsWebhook       bool               `json:"is_webhook"`
+	WebhookProvider string             `json:"webhook_provider,omitempty"`
+	Auth            bool               `json:"auth"`
+	AuthScheme      string             `json:"auth_scheme,omitempty"`
+	Description     v2DescriptionBlock `json:"description"`
+	Parameters      []v2PathParameter  `json:"parameters"`
+	ResponseShapes  []v2ResponseShape  `json:"response_shapes"`
+	Handlers        []v2HandlerDetail  `json:"handlers"`
+	InboundFetches  []v2PathEntity     `json:"inbound_fetches"`
+	Outbound        v2OutboundQueries  `json:"outbound"`
+	SideEffects     []v2PathEntity     `json:"side_effects"`
+	Tests           []v2PathEntity     `json:"tests"`
 }
 
 // v2OrphanCaller is one orphan caller row.
@@ -172,8 +176,8 @@ type v2OrphanCaller struct {
 
 // v2OrphanTotals is the breakdown by severity.
 type v2OrphanTotals struct {
-	NoHandlerFound int `json:"no_handler_found"`
-	DynamicBaseURL int `json:"dynamic_baseurl"`
+	NoHandlerFound  int `json:"no_handler_found"`
+	DynamicBaseURL  int `json:"dynamic_baseurl"`
 	TemplateLiteral int `json:"template_literal"`
 }
 
@@ -211,21 +215,21 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 	// ---- Phase 1: collect raw endpoints (ported from handlePathsList) ----
 
 	type rawEP struct {
-		ID            string
-		Path          string
-		Verb          string
-		Handler       string
-		Framework     string
-		IsWebhook     bool
-		WebhookProv   string
-		Auth          bool
-		Repo          string
-		SourceFile    string
-		StartLine     int
-		OwningBackend string
-		ControllerID  string
+		ID             string
+		Path           string
+		Verb           string
+		Handler        string
+		Framework      string
+		IsWebhook      bool
+		WebhookProv    string
+		Auth           bool
+		Repo           string
+		SourceFile     string
+		StartLine      int
+		OwningBackend  string
+		ControllerID   string
 		ControllerFile string
-		Language      string
+		Language       string
 	}
 
 	var eps []rawEP
@@ -259,33 +263,41 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				continue
 			}
 
-			owningBackend := e.Properties["owning_backend"]
-			if owningBackend == "" {
-				owningBackend = inferOwningBackend(e.Name, repo.Slug)
-			}
+			// Backend = the owning repo. The raw owning_backend property is
+			// almost always the bare entity prefix ("src") which collapses every
+			// service into one node, so the repo slug is the only reliable
+			// top-level grouping key on a real multi-repo platform (#1551).
+			owningBackend := repo.Slug
 
-			// Derive controller name from handler name heuristic.
-			controllerID := e.Properties["controller"]
+			// Controller/module = the source file the handler lives in. For
+			// framework controllers ("orders.controller.ts") and GraphQL
+			// resolver files ("resolvers.ts") this maps directly to the unit a
+			// developer thinks in, which the raw `controller` property
+			// (one-per-endpoint garbage) does not. Fall back to a name heuristic.
+			controllerID := controllerKeyFromFile(e.SourceFile)
+			if controllerID == "" {
+				controllerID = e.Properties["controller"]
+			}
 			if controllerID == "" {
 				controllerID = inferControllerName(e.Name)
 			}
 
 			eps = append(eps, rawEP{
-				ID:            dashPrefixedID(repo.Slug, e.ID),
-				Path:          path,
-				Verb:          verb,
-				Handler:       e.Name,
-				Framework:     e.Properties["framework"],
-				IsWebhook:     e.Properties["is_webhook"] == "true",
-				WebhookProv:   e.Properties["webhook_provider"],
-				Auth:          e.Properties["auth"] == "true" || e.Properties["auth_scheme"] != "",
-				Repo:          repo.Slug,
-				SourceFile:    e.SourceFile,
-				StartLine:     e.StartLine,
-				OwningBackend: owningBackend,
-				ControllerID:  controllerID,
+				ID:             dashPrefixedID(repo.Slug, e.ID),
+				Path:           path,
+				Verb:           verb,
+				Handler:        e.Name,
+				Framework:      e.Properties["framework"],
+				IsWebhook:      e.Properties["is_webhook"] == "true",
+				WebhookProv:    e.Properties["webhook_provider"],
+				Auth:           e.Properties["auth"] == "true" || e.Properties["auth_scheme"] != "",
+				Repo:           repo.Slug,
+				SourceFile:     e.SourceFile,
+				StartLine:      e.StartLine,
+				OwningBackend:  owningBackend,
+				ControllerID:   controllerID,
 				ControllerFile: e.SourceFile,
-				Language:      e.Language,
+				Language:       e.Language,
 			})
 		}
 	}
@@ -331,11 +343,11 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 
 		if _, ok := cm.paths[ep.Path]; !ok {
 			cm.paths[ep.Path] = &v2PathRoute{
-				PathHash:  hashStr(ep.Path),
-				Path:      ep.Path,
-				Verbs:     []string{},
+				PathHash:   hashStr(ep.Path),
+				Path:       ep.Path,
+				Verbs:      []string{},
 				Frameworks: []string{},
-				Repos:     []string{},
+				Repos:      []string{},
 				Controller: cID,
 			}
 			cm.order = append(cm.order, ep.Path)
@@ -383,11 +395,12 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 		}
 		sort.Strings(repos)
 
-		// Detect cross-backend refs (endpoint's repos include a repo not
-		// owned by this backend — heuristic: any repo outside this set).
+		// Detect cross-backend refs: a route owned here whose repo set spans
+		// beyond this backend's own repo (the backend id is the repo slug).
 		crossBackendRefs := false
 		anyRate := 0
 		var language, framework string
+		verbSet := map[string]bool{}
 
 		groups := make([]v2ControllerGroup, 0, len(bm.order))
 		for _, cID := range bm.order {
@@ -397,8 +410,14 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				pr := cm.paths[path]
 				sort.Strings(pr.Verbs)
 				for _, v := range pr.Verbs {
+					verbSet[v] = true
 					if v == "ANY" {
 						anyRate++
+					}
+				}
+				for _, rr := range pr.Repos {
+					if rr != bID {
+						crossBackendRefs = true
 					}
 				}
 				routes = append(routes, *pr)
@@ -415,7 +434,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			}
 			groups = append(groups, v2ControllerGroup{
 				ID:        cID,
-				Label:     cID,
+				Label:     controllerLabelFromFile(cm.file),
 				File:      cm.file,
 				IsWebhook: isWebhookCtrl,
 				Routes:    routes,
@@ -430,11 +449,11 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			}
 		}
 
-		serviceType := inferServiceTypeV2(bID, repos)
+		serviceType := serviceTypeFromVerbs(verbSet, bID, repos)
 
 		result = append(result, v2PathBackend{
 			ID:               bID,
-			Label:            bID,
+			Label:            backendLabelFromRepo(bID, backendOrder),
 			ServiceType:      serviceType,
 			Framework:        framework,
 			Language:         language,
@@ -457,6 +476,10 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
+	// Orphan count for the tab badge — reuse the same v1 scan the Orphans tab
+	// uses so the number is authoritative, not an estimate (#1551).
+	orphanCount := len(collectOrphanCallers(grp))
+
 	writeV2JSON(w, http.StatusOK, v2OK(v2PathsListResponse{
 		Backends: result,
 		Totals: v2PathTotals{
@@ -464,6 +487,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			Endpoints:   totalEndpoints,
 			Controllers: totalControllers,
 			Backends:    len(result),
+			Orphans:     orphanCount,
 		},
 	}))
 }
@@ -884,6 +908,121 @@ func inferControllerName(handlerName string) string {
 	return handlerName
 }
 
+// controllerKeyFromFile derives a stable controller/module grouping key from a
+// handler's source file. The full repo-relative path is used so two files with
+// the same basename in different directories never collide.
+func controllerKeyFromFile(sourceFile string) string {
+	return strings.TrimSpace(sourceFile)
+}
+
+// controllerLabelFromFile produces a human-friendly controller/module label
+// from a source file path. "src/orders.controller.ts" → "OrdersController";
+// "src/resolvers.ts" → "resolvers"; "src/index.ts" → "index". Falls back to the
+// basename when no recognisable convention applies.
+func controllerLabelFromFile(sourceFile string) string {
+	base := sourceFile
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	// Strip a single trailing extension.
+	if dot := strings.LastIndex(base, "."); dot > 0 {
+		base = base[:dot]
+	}
+	// "orders.controller" / "saga.controller" → "OrdersController".
+	for _, suf := range []string{".controller", ".resolver", ".router", ".service", ".handler"} {
+		if strings.HasSuffix(base, suf) {
+			stem := strings.TrimSuffix(base, suf)
+			kind := strings.TrimPrefix(suf, ".")
+			return titleFirst(stem) + titleFirst(kind)
+		}
+	}
+	return base
+}
+
+func titleFirst(s string) string {
+	if s == "" {
+		return s
+	}
+	return strings.ToUpper(s[:1]) + s[1:]
+}
+
+// backendLabelFromRepo trims the longest common slash/dash-delimited prefix
+// shared by all repo backends so labels read as "gateway" / "payments" rather
+// than "polyglot-platform-services-gateway". Falls back to the raw slug.
+func backendLabelFromRepo(repo string, allRepos []string) string {
+	if len(allRepos) < 2 {
+		return repo
+	}
+	prefix := commonDashPrefix(allRepos)
+	if prefix != "" && strings.HasPrefix(repo, prefix) {
+		trimmed := strings.TrimPrefix(repo, prefix)
+		if trimmed != "" {
+			return trimmed
+		}
+	}
+	return repo
+}
+
+// commonDashPrefix returns the longest shared prefix of dash-delimited segments,
+// including the trailing dash (e.g. "polyglot-platform-services-").
+func commonDashPrefix(items []string) string {
+	if len(items) == 0 {
+		return ""
+	}
+	segs := strings.Split(items[0], "-")
+	commonN := len(segs)
+	for _, it := range items[1:] {
+		other := strings.Split(it, "-")
+		n := 0
+		for n < commonN && n < len(other) && segs[n] == other[n] {
+			n++
+		}
+		commonN = n
+		if commonN == 0 {
+			return ""
+		}
+	}
+	// Never consume every segment (would leave an empty label).
+	if commonN >= len(segs) {
+		commonN = len(segs) - 1
+	}
+	if commonN <= 0 {
+		return ""
+	}
+	return strings.Join(segs[:commonN], "-") + "-"
+}
+
+// serviceTypeFromVerbs derives the display service_type from the set of verbs a
+// backend actually serves, falling back to a name/repo heuristic for ambiguous
+// REST cases. GRAPHQL → "GraphQL", GRPC → "gRPC", otherwise "REST".
+func serviceTypeFromVerbs(verbSet map[string]bool, backendName string, repos []string) string {
+	graphql, grpc, rest := false, false, false
+	for v := range verbSet {
+		switch strings.ToUpper(v) {
+		case "GRAPHQL":
+			graphql = true
+		case "GRPC":
+			grpc = true
+		default:
+			rest = true
+		}
+	}
+	// Mixed backends are labelled by their dominant non-REST protocol so the
+	// section colour is meaningful; pure-REST stays REST.
+	switch {
+	case grpc && !rest && !graphql:
+		return "gRPC"
+	case graphql && !rest:
+		return "GraphQL"
+	case graphql:
+		return "GraphQL"
+	case grpc:
+		return "gRPC"
+	default:
+		return inferServiceTypeV2(backendName, repos)
+	}
+}
+
 // inferServiceTypeV2 maps a backend name + repo list to one of the display
 // service_type values used by the UI: "REST" | "gRPC" | "GraphQL".
 func inferServiceTypeV2(backendName string, repos []string) string {
@@ -904,7 +1043,7 @@ func inferServiceTypeV2(backendName string, repos []string) string {
 // dynamic segments. Real parameter metadata would come from annotations /
 // OpenAPI schema; this synthesises a fallback for paths without it.
 func extractPathParameters(path string, verbs []string) []v2PathParameter {
-	var params []v2PathParameter
+	params := []v2PathParameter{}
 	re := strings.Split(strings.TrimPrefix(path, "/"), "/")
 	for _, seg := range re {
 		if strings.HasPrefix(seg, "{") && strings.HasSuffix(seg, "}") {

--- a/internal/dashboard/v2_paths_test.go
+++ b/internal/dashboard/v2_paths_test.go
@@ -347,8 +347,8 @@ func TestV2PathsOrphans_Empty(t *testing.T) {
 	}
 
 	var body struct {
-		OK   bool               `json:"ok"`
-		Data v2OrphansResponse  `json:"data"`
+		OK   bool              `json:"ok"`
+		Data v2OrphansResponse `json:"data"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
 		t.Fatalf("decode: %v", err)
@@ -383,6 +383,113 @@ func TestV2PathsOrphans_RouteRegistration(t *testing.T) {
 	// handler (not a 200 orphans list).
 	if resp.StatusCode != http.StatusOK {
 		t.Errorf("want 200 from orphans handler, got %d (route precedence bug?)", resp.StatusCode)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Grouping + label helpers (#1551)
+// ---------------------------------------------------------------------------
+
+func TestControllerLabelFromFile(t *testing.T) {
+	cases := map[string]string{
+		"src/orders.controller.ts": "OrdersController",
+		"src/saga.controller.ts":   "SagaController",
+		"src/resolvers.ts":         "resolvers",
+		"src/index.ts":             "index",
+		"app/orders/views.py":      "views",
+		"":                         "",
+	}
+	for in, want := range cases {
+		if got := controllerLabelFromFile(in); got != want {
+			t.Errorf("controllerLabelFromFile(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBackendLabelFromRepo(t *testing.T) {
+	all := []string{
+		"polyglot-platform-services-gateway",
+		"polyglot-platform-services-payments",
+		"polyglot-platform-services-catalog",
+	}
+	if got := backendLabelFromRepo("polyglot-platform-services-gateway", all); got != "gateway" {
+		t.Errorf("backendLabelFromRepo gateway = %q, want gateway", got)
+	}
+	// Single repo: no trimming.
+	if got := backendLabelFromRepo("solo-repo", []string{"solo-repo"}); got != "solo-repo" {
+		t.Errorf("backendLabelFromRepo solo = %q, want solo-repo", got)
+	}
+}
+
+func TestServiceTypeFromVerbs(t *testing.T) {
+	cases := []struct {
+		verbs map[string]bool
+		want  string
+	}{
+		{map[string]bool{"GRAPHQL": true}, "GraphQL"},
+		{map[string]bool{"GRPC": true}, "gRPC"},
+		{map[string]bool{"GET": true, "POST": true}, "REST"},
+		{map[string]bool{"GET": true, "GRAPHQL": true}, "GraphQL"},
+	}
+	for _, c := range cases {
+		if got := serviceTypeFromVerbs(c.verbs, "svc", nil); got != c.want {
+			t.Errorf("serviceTypeFromVerbs(%v) = %q, want %q", c.verbs, got, c.want)
+		}
+	}
+}
+
+// TestV2PathsList_GroupsByFile verifies endpoints in the same source file are
+// grouped into one controller, while different files become separate controllers
+// — the real multi-module grouping behaviour (#1551).
+func TestV2PathsList_GroupsByFile(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "a", Name: "list", Kind: "http_endpoint", SourceFile: "src/orders.controller.ts",
+			Properties: map[string]string{"path": "/orders", "verb": "GET", "owning_backend": "src"}},
+		{ID: "b", Name: "create", Kind: "http_endpoint", SourceFile: "src/orders.controller.ts",
+			Properties: map[string]string{"path": "/orders/new", "verb": "POST", "owning_backend": "src"}},
+		{ID: "c", Name: "checkout", Kind: "http_endpoint", SourceFile: "src/saga.controller.ts",
+			Properties: map[string]string{"path": "/checkout", "verb": "POST", "owning_backend": "src"}},
+	}
+	grp := makePathsTestGroup(entities, nil)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths")
+	if err != nil {
+		t.Fatalf("GET paths: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data v2PathsListResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+
+	if len(body.Data.Backends) != 1 {
+		t.Fatalf("backends: want 1 (repo), got %d", len(body.Data.Backends))
+	}
+	if got := len(body.Data.Backends[0].Groups); got != 2 {
+		t.Fatalf("controllers: want 2 (by file), got %d", got)
+	}
+	if body.Data.Totals.Controllers != 2 {
+		t.Errorf("totals.controllers: want 2, got %d", body.Data.Totals.Controllers)
+	}
+	// Parameters must never serialise as null (#1551).
+	hash := hashStr("/orders")
+	dr, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer dr.Body.Close()
+	var detail struct {
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(dr.Body).Decode(&detail); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if detail.Data.Parameters == nil {
+		t.Error("parameters: want [] (non-nil), got nil")
 	}
 }
 

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -714,6 +714,8 @@ export interface PathTotals {
   endpoints: number;
   controllers: number;
   backends: number;
+  /** Orphan-caller count, surfaced for the tab badge (#1551). Optional for back-compat. */
+  orphans?: number;
 }
 
 /** Response from GET /api/v2/groups/:id/paths. */

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -12,9 +12,9 @@
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
-  Search, X, ChevronRight, Lock, ExternalLink, Copy,
+  Search, X, ChevronRight, ChevronLeft, Lock, ExternalLink, Copy,
   Database, Zap, Globe, FlaskConical, TestTube, Server,
-  Layers, Box, List, Maximize2,
+  Layers, Box, List, Maximize2, FolderTree, Boxes, AlertTriangle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Skeleton } from "@/components/ui";
@@ -1120,6 +1120,231 @@ function StatItem({ label, value }: { label: string; value: number }) {
 }
 
 /* ============================================================
+   Backends overview — drill-down screen 1
+   ============================================================ */
+
+/** Accent color for a service type, used on overview cards + section borders. */
+function serviceAccent(type: string): string {
+  return type === "gRPC"
+    ? "var(--pastel-9-ink)"
+    : type === "GraphQL"
+      ? "var(--pastel-5-ink)"
+      : "var(--pastel-1-ink)";
+}
+
+function backendStats(b: PathBackend) {
+  const groups = b.groups ?? [];
+  let routes = 0;
+  let endpoints = 0;
+  const verbCounts: Record<string, number> = {};
+  const repoSet = new Set<string>();
+  for (const g of groups) {
+    for (const r of g.routes ?? []) {
+      routes += 1;
+      endpoints += r.handlers_count || (r.verbs?.length ?? 0);
+      for (const v of r.verbs ?? []) verbCounts[v] = (verbCounts[v] ?? 0) + 1;
+      for (const rp of r.repos ?? []) repoSet.add(rp);
+    }
+  }
+  return { controllers: groups.length, routes, endpoints, verbCounts, repos: [...repoSet] };
+}
+
+function BackendCard({
+  backend,
+  onOpen,
+}: {
+  backend: PathBackend;
+  onOpen: () => void;
+}) {
+  const { controllers, routes, endpoints, verbCounts } = backendStats(backend);
+  const accent = serviceAccent(backend.service_type);
+  const svcClass = SERVICE_TYPE_COLORS[backend.service_type] ?? "bg-surface-2 text-text-3";
+  const verbs = Object.entries(verbCounts).sort((a, b) => b[1] - a[1]);
+
+  return (
+    <button
+      type="button"
+      onClick={onOpen}
+      data-testid={`backend-card-${backend.id}`}
+      className={cn(
+        "group text-left rounded-lg border border-border bg-surface overflow-hidden",
+        "hover:border-border-strong hover:shadow-sm transition-all duration-100",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[var(--accent-ring)]",
+      )}
+      style={{ borderTop: `3px solid ${accent}` }}
+    >
+      <div className="p-4">
+        <div className="flex items-start gap-2">
+          <Boxes size={16} className="text-text-3 mt-0.5 shrink-0" />
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="font-mono text-sm font-semibold text-text truncate">{backend.label}</span>
+              <span className={cn("text-[10px] font-semibold px-1.5 py-0.5 rounded", svcClass)}>
+                {backend.service_type}
+              </span>
+            </div>
+            {backend.id !== backend.label && (
+              <span className="block text-[11px] text-text-4 font-mono truncate mt-0.5">{backend.id}</span>
+            )}
+          </div>
+          <ChevronRight
+            size={16}
+            className="text-text-4 shrink-0 group-hover:translate-x-0.5 transition-transform"
+          />
+        </div>
+
+        {/* Counts */}
+        <div className="mt-3 flex items-center gap-4">
+          <div className="flex flex-col">
+            <span className="text-lg font-semibold text-text tabular-nums leading-none">{routes}</span>
+            <span className="text-[10px] text-text-4 mt-0.5">paths</span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-lg font-semibold text-text tabular-nums leading-none">{endpoints}</span>
+            <span className="text-[10px] text-text-4 mt-0.5">endpoints</span>
+          </div>
+          <div className="flex flex-col">
+            <span className="text-lg font-semibold text-text tabular-nums leading-none">{controllers}</span>
+            <span className="text-[10px] text-text-4 mt-0.5">controllers</span>
+          </div>
+        </div>
+
+        {/* Verb breakdown */}
+        {verbs.length > 0 && (
+          <div className="mt-3 flex flex-wrap items-center gap-1">
+            {verbs.map(([v, n]) => (
+              <span key={v} className="inline-flex items-center gap-1">
+                <VerbChip verb={v} />
+                <span className="text-[10px] text-text-4 tabular-nums">{n}</span>
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Footer chips */}
+        <div className="mt-3 flex flex-wrap items-center gap-1.5">
+          {backend.language && (
+            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-2 text-text-3">
+              {backend.language}
+            </span>
+          )}
+          {backend.framework && (
+            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-2 text-text-3">
+              {backend.framework}
+            </span>
+          )}
+          {backend.cross_backend_refs && (
+            <span className="inline-flex items-center gap-1 text-[10px] text-text-3 border border-dashed border-border-strong px-1 rounded">
+              <ExternalLink size={9} /> cross-refs
+            </span>
+          )}
+          {backend.any_rate > 0 && (
+            <span className="text-[10px] text-warning">ANY {backend.any_rate}</span>
+          )}
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function BackendsOverview({
+  backends,
+  search,
+  onOpenBackend,
+}: {
+  backends: PathBackend[];
+  search: string;
+  onOpenBackend: (id: string) => void;
+}) {
+  const filtered = useMemo(() => {
+    if (!search) return backends;
+    const q = search.toLowerCase();
+    return backends.filter(
+      (b) =>
+        b.label.toLowerCase().includes(q) ||
+        b.id.toLowerCase().includes(q) ||
+        (b.groups ?? []).some((g) =>
+          (g.routes ?? []).some((r) => (r.path ?? "").toLowerCase().includes(q)),
+        ),
+    );
+  }, [backends, search]);
+
+  if (filtered.length === 0) {
+    return (
+      <div className="p-10 text-center flex flex-col items-center gap-3">
+        <Search size={22} className="text-text-4" />
+        <p className="text-sm text-text-2">No backends match "{search}"</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4 overflow-y-auto ag-scroll h-full">
+      <div className="grid gap-3 [grid-template-columns:repeat(auto-fill,minmax(260px,1fr))]">
+        {filtered.map((b) => (
+          <BackendCard key={b.id} backend={b} onOpen={() => onOpenBackend(b.id)} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+/* ============================================================
+   Breadcrumb — drill-down navigation
+   ============================================================ */
+
+function Breadcrumb({
+  backend,
+  pathLabel,
+  onAll,
+  onBackend,
+}: {
+  backend: PathBackend | null;
+  pathLabel: string | null;
+  onAll: () => void;
+  onBackend: () => void;
+}) {
+  return (
+    <nav className="flex items-center gap-1 text-xs min-w-0" aria-label="Breadcrumb">
+      <button
+        type="button"
+        onClick={onAll}
+        className={cn(
+          "inline-flex items-center gap-1 px-1.5 h-6 rounded hover:bg-surface-2 transition-colors shrink-0",
+          backend ? "text-text-3" : "text-text font-medium",
+        )}
+      >
+        <FolderTree size={12} /> All backends
+      </button>
+      {backend && (
+        <>
+          <ChevronRight size={11} className="text-text-4 shrink-0" />
+          <button
+            type="button"
+            onClick={onBackend}
+            className={cn(
+              "inline-flex items-center gap-1 px-1.5 h-6 rounded hover:bg-surface-2 transition-colors min-w-0",
+              pathLabel ? "text-text-3" : "text-text font-medium",
+            )}
+          >
+            <Boxes size={12} className="shrink-0" />
+            <span className="font-mono truncate max-w-[180px]">{backend.label}</span>
+          </button>
+        </>
+      )}
+      {backend && pathLabel && (
+        <>
+          <ChevronRight size={11} className="text-text-4 shrink-0" />
+          <span className="inline-flex items-center px-1.5 h-6 text-text font-mono font-medium truncate max-w-[220px]">
+            {pathLabel}
+          </span>
+        </>
+      )}
+    </nav>
+  );
+}
+
+/* ============================================================
    Main screen
    ============================================================ */
 
@@ -1127,9 +1352,10 @@ export default function PathsScreen() {
   const { groupId = "" } = useParams<{ groupId: string }>();
   const [searchParams, setSearchParams] = useSearchParams();
 
-  // URL state
+  // URL state — backend drives the drill-down level.
   const activeTab = (searchParams.get("tab") ?? "endpoints") as "endpoints" | "orphans";
   const selectedHash = searchParams.get("path");
+  const selectedBackendId = searchParams.get("backend");
 
   // Local list state
   const [search, setSearch] = useState("");
@@ -1141,8 +1367,33 @@ export default function PathsScreen() {
   const { data: pathsData, isLoading, isError } = usePaths(groupId);
   const { data: detail, isLoading: isDetailLoading } = usePathDetail(groupId, selectedHash);
 
-  const backends = pathsData?.backends ?? [];
+  const allBackends = pathsData?.backends ?? [];
   const totals = pathsData?.totals;
+  const orphanCount = totals?.orphans;
+
+  // Selected backend (drill-down level 2). When set, the rail scopes to it.
+  const selectedBackend = useMemo(
+    () => allBackends.find((b) => b.id === selectedBackendId) ?? null,
+    [allBackends, selectedBackendId],
+  );
+  // Backends rendered in the rail/tree: just the selected one, or all (legacy).
+  const backends = selectedBackend ? [selectedBackend] : allBackends;
+
+  // Auto-enter the single backend so a one-service platform skips the overview.
+  useEffect(() => {
+    if (
+      activeTab === "endpoints" &&
+      !selectedBackendId &&
+      !selectedHash &&
+      allBackends.length === 1
+    ) {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("backend", allBackends[0].id);
+        return next;
+      });
+    }
+  }, [activeTab, selectedBackendId, selectedHash, allBackends, setSearchParams]);
 
   // "/" key focuses search
   useEffect(() => {
@@ -1161,16 +1412,48 @@ export default function PathsScreen() {
   }, []);
 
   const selectRoute = useCallback(
-    (hash: string) => {
+    (hash: string, backendId?: string) => {
       setSearchParams((prev) => {
         const next = new URLSearchParams(prev);
         next.set("path", hash);
         next.set("tab", "endpoints");
+        if (backendId) next.set("backend", backendId);
         return next;
       });
     },
     [setSearchParams],
   );
+
+  const openBackend = useCallback(
+    (id: string) => {
+      setSearchParams((prev) => {
+        const next = new URLSearchParams(prev);
+        next.set("backend", id);
+        next.delete("path");
+        return next;
+      });
+      setSearch("");
+    },
+    [setSearchParams],
+  );
+
+  const goAllBackends = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("backend");
+      next.delete("path");
+      return next;
+    });
+    setSearch("");
+  }, [setSearchParams]);
+
+  const goBackendRoot = useCallback(() => {
+    setSearchParams((prev) => {
+      const next = new URLSearchParams(prev);
+      next.delete("path");
+      return next;
+    });
+  }, [setSearchParams]);
 
   const setTab = useCallback(
     (tab: string) => {
@@ -1209,8 +1492,19 @@ export default function PathsScreen() {
     setOpenMap(next);
   }, [backends]);
 
+  // Routes within the scoped (selected) backend — drives the rail labels so the
+  // count reflects the backend you drilled into, not the whole platform.
+  const scopedRouteCount = useMemo(
+    () =>
+      backends.reduce(
+        (sum, b) => sum + (b.groups ?? []).reduce((gs, g) => gs + (g.routes ?? []).length, 0),
+        0,
+      ),
+    [backends],
+  );
+
   const filteredCount = useMemo(() => {
-    if (!search) return totals?.routes ?? 0;
+    if (!search) return scopedRouteCount;
     return backends.reduce(
       (sum, b) =>
         sum +
@@ -1224,7 +1518,7 @@ export default function PathsScreen() {
         ),
       0,
     );
-  }, [search, backends, totals]);
+  }, [search, backends, scopedRouteCount]);
 
   return (
     <div className="flex flex-col h-full overflow-hidden bg-bg" data-testid="paths-screen">
@@ -1263,11 +1557,82 @@ export default function PathsScreen() {
           </TabsTrigger>
           <TabsTrigger value="orphans">
             Orphan callers
+            {orphanCount !== undefined && orphanCount > 0 ? (
+              <span
+                className="ml-1.5 inline-flex items-center gap-0.5 text-xs tabular-nums text-warning"
+                data-testid="orphan-count-badge"
+              >
+                <AlertTriangle size={11} className="shrink-0" />
+                {orphanCount}
+              </span>
+            ) : orphanCount !== undefined ? (
+              <span className="ml-1.5 text-text-4 text-xs tabular-nums" data-testid="orphan-count-badge">
+                {orphanCount}
+              </span>
+            ) : null}
           </TabsTrigger>
         </TabsList>
 
         {/* Endpoints tab */}
         <TabsContent value="endpoints" className="flex-1 min-h-0 flex flex-col mt-0">
+          {/* Breadcrumb bar */}
+          <div className="flex items-center gap-2 px-3 h-9 border-b border-border bg-surface shrink-0">
+            {selectedBackend && (
+              <button
+                type="button"
+                onClick={selectedHash ? goBackendRoot : goAllBackends}
+                aria-label="Back"
+                title="Back"
+                className="h-6 w-6 flex items-center justify-center rounded text-text-3 hover:bg-surface-2 shrink-0 transition-colors"
+              >
+                <ChevronLeft size={14} />
+              </button>
+            )}
+            <Breadcrumb
+              backend={selectedBackend}
+              pathLabel={selectedHash ? (detail?.path ?? "endpoint") : null}
+              onAll={goAllBackends}
+              onBackend={goBackendRoot}
+            />
+            {/* Overview-level search */}
+            {!selectedBackend && allBackends.length > 1 && (
+              <div className="ml-auto flex items-center gap-1.5 h-7 rounded-md border border-border bg-bg-soft px-2 w-64 focus-within:ring-2 focus-within:ring-[var(--accent-ring)] focus-within:border-accent transition-all">
+                <Search size={12} className="text-text-4 shrink-0" />
+                <input
+                  ref={searchRef}
+                  type="text"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  onKeyDown={(e) => e.key === "Escape" && setSearch("")}
+                  placeholder="Filter backends…"
+                  aria-label="Filter backends"
+                  className="flex-1 bg-transparent text-xs text-text placeholder-text-4 outline-none min-w-0"
+                />
+              </div>
+            )}
+          </div>
+
+          {/* Overview (no backend selected) */}
+          {!selectedBackend ? (
+            isLoading ? (
+              <ListSkeleton />
+            ) : isError ? (
+              <div className="p-6 text-center">
+                <p className="text-sm text-text-3">Couldn't load paths.</p>
+              </div>
+            ) : allBackends.length === 0 ? (
+              <div className="p-8 text-center">
+                <p className="text-sm text-text-3">No endpoints indexed yet.</p>
+                <p className="mt-1 text-xs text-text-4">Run the indexer, then reload.</p>
+              </div>
+            ) : (
+              <BackendsOverview
+                backends={allBackends}
+                search={search}
+                onOpenBackend={openBackend}
+              />
+            )
+          ) : (
           <div className="flex flex-1 min-h-0">
             {/* List rail — 520px */}
             <aside
@@ -1292,7 +1657,7 @@ export default function PathsScreen() {
                   {search ? (
                     <>
                       <span className="text-[10px] text-text-4 tabular-nums shrink-0">
-                        {filteredCount} of {totals?.routes ?? "…"}
+                        {filteredCount} of {scopedRouteCount}
                       </span>
                       <button
                         type="button"
@@ -1305,7 +1670,7 @@ export default function PathsScreen() {
                     </>
                   ) : (
                     <span className="text-[10px] text-text-4 shrink-0">
-                      {totals?.routes ?? "…"} routes
+                      {scopedRouteCount} routes
                     </span>
                   )}
                 </div>
@@ -1379,7 +1744,7 @@ export default function PathsScreen() {
                     <Search size={20} className="text-text-4" />
                     <p className="text-sm text-text-2">No routes match "{search}"</p>
                     <p className="text-xs text-text-4">
-                      Clear the search to see all {totals?.routes ?? ""} routes.
+                      Clear the search to see all {scopedRouteCount} routes.
                     </p>
                     <button
                       type="button"
@@ -1397,7 +1762,7 @@ export default function PathsScreen() {
                       openMap={openMap}
                       toggle={toggleOpen}
                       selectedHash={selectedHash}
-                      onSelect={(r) => selectRoute(r.path_hash)}
+                      onSelect={(r) => selectRoute(r.path_hash, b.id)}
                       search={search}
                     />
                   ))
@@ -1406,7 +1771,7 @@ export default function PathsScreen() {
                     backends={backends}
                     search={search}
                     selectedHash={selectedHash}
-                    onSelect={(r) => selectRoute(r.path_hash)}
+                    onSelect={(r) => selectRoute(r.path_hash, selectedBackend?.id)}
                   />
                 )}
               </div>
@@ -1436,6 +1801,7 @@ export default function PathsScreen() {
               )}
             </div>
           </div>
+          )}
         </TabsContent>
 
         {/* Orphans tab */}

--- a/webui-v2/vite.config.ts
+++ b/webui-v2/vite.config.ts
@@ -12,11 +12,12 @@ export default defineConfig({
     },
   },
   server: {
-    port: 47280,
+    port: Number(process.env.AG_DEV_PORT) || 47280,
     strictPort: true,
     proxy: {
       // Proxy /api/* to the archigraph daemon during dev so the SPA can talk to a real dataset.
-      "/api": { target: "http://localhost:47274", changeOrigin: false },
+      // AG_API_TARGET lets you point at an isolated daemon (never the live :47274) for verification.
+      "/api": { target: process.env.AG_API_TARGET || "http://localhost:47274", changeOrigin: false },
     },
   },
   preview: { port: 47281, strictPort: true },


### PR DESCRIPTION
## Summary
Reworks the **Paths / API & Endpoints** explorer into a navigable multi-screen "Swagger with steroids" surface, fixes the degenerate grouping on real multi-repo data, and adds the missing **orphan-callers counter badge**.

## Problem
- The flat endpoint list didn't scale.
- On real polyglot data the hierarchy was meaningless: a single fake `src` backend containing 17 one-route "controllers" — because the `owning_backend` and `controller` entity properties are unreliable.
- The Orphan-callers tab had data (13) but **no count**, unlike Endpoints (17).

## What changed
### Backend — `internal/dashboard/v2_paths.go`
- **Group by repo → source-file** instead of `owning_backend`/`controller`. Repo slug is the only reliable top-level key; the source file is the unit developers think in (`OrdersController`, `resolvers`, `index`). Backend labels trim the common repo prefix; controller labels humanize the filename.
- **service_type from actual verbs** (`GRAPHQL→GraphQL`, `GRPC→gRPC`, else `REST`); `cross_backend_refs` detected from route repo spans.
- **`totals.orphans`** added (reuses the v1 orphan scan) so the tab badge needs no extra round-trip.
- Fixed `parameters` serialising as `null` → always `[]`.

### Frontend — `webui-v2/`
- **Multi-screen drill-down** via a `?backend=` URL param: backends overview (card grid) → backend detail (rail scoped to one backend; controller→route tree, grouped/flat, expand/collapse) → endpoint detail. Breadcrumb + back at every level; single-backend platforms auto-enter.
- **Orphan-callers tab counter badge** (warning-toned w/ icon when > 0).
- Rich endpoint detail (params, response shapes, handlers/defined-in, called-by, downstream, side-effects, tests) preserved.
- `vite.config`: dev-only `AG_API_TARGET`/`AG_DEV_PORT` env overrides so verification can target an isolated daemon (never live :47274).

## Testing
- `go build` + `go vet` + `gofmt` clean. New unit tests: `controllerLabelFromFile`, `backendLabelFromRepo`, `serviceTypeFromVerbs`, file-based grouping, and the parameters-never-null invariant. All path/orphan tests pass. (A pre-existing, unrelated `yamlScalar` enrichment test fails on `origin/main` as well.)
- `npm run build` clean (`tsc -b && vite build`).
- Verified against **real polyglot-platform** (5 backends, 8 controllers, 17 paths / 18 endpoints, 13 orphans) on an isolated daemon: overview cards, drill-down, multi-verb endpoint detail (`GET+PUT /products/{sku}`), orphan tab with **13** badge, and mobile (390px) all render. `dashboard/` zero-diff.

## Risk
Low. v1 routes untouched; v2 wire shapes unchanged except additive optional `totals.orphans`. Grouping change is display-only.

## Companion
A full-redesign Claude Design handoff prompt was written alongside this v1 (documents the complete endpoint data contract + the v1 baseline). It lives outside the repo at `archigraph-design-handoff-2026-05-22/PATHS_V2_PROMPT.md`.

Fixes #1551

🤖 Generated with [Claude Code](https://claude.com/claude-code)