### PR TITLE
fix(detect): polyglot monorepo module detection + real per-repo files count (#1559)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -379,6 +379,7 @@ func Index(repoPath, outPath, repoTag string, skipPasses []string, pretty bool, 
 			side := &graph.GraphStatsSidecar{
 				Version:            1,
 				ComputedAt:         deterministicGeneratedAt(),
+				TotalFiles:         doc.Stats.Files,
 				TotalEntities:      doc.Stats.Entities,
 				TotalRelationships: doc.Stats.Relationships,
 				Communities:        doc.AlgorithmStats.NumCommunities,

--- a/internal/cli/status_stats.go
+++ b/internal/cli/status_stats.go
@@ -74,7 +74,7 @@ func ComputeStatusSummary(group string, repos []registry.Repo) *StatusSummary {
 			if json.Unmarshal(data, &side) == nil {
 				rs.Entities = side.TotalEntities
 				rs.Relationships = side.TotalRelationships
-				rs.Files = side.TotalEntities // Placeholder — graph-stats doesn't track files
+				rs.Files = side.TotalFiles // real indexed file count (#1559)
 				if !side.ComputedAt.IsZero() {
 					rs.LastIndexed = side.ComputedAt
 					rs.LastIndexedAge = formatTimeSince(side.ComputedAt)

--- a/internal/graph/graph.go
+++ b/internal/graph/graph.go
@@ -105,6 +105,7 @@ func RelationshipID(fromID, toID, kind string) string {
 type GraphStatsSidecar struct {
 	Version            int       `json:"version"`
 	ComputedAt         time.Time `json:"computed_at"`
+	TotalFiles         int       `json:"total_files,omitempty"`
 	TotalEntities      int       `json:"total_entities"`
 	TotalRelationships int       `json:"total_relationships"`
 	Communities        int       `json:"communities"`

--- a/internal/install/detect/detect.go
+++ b/internal/install/detect/detect.go
@@ -49,14 +49,56 @@ func Stack(repo string) string {
 type MonorepoKind string
 
 const (
-	KindNone  MonorepoKind = ""
-	KindPNPM  MonorepoKind = "pnpm"
-	KindNPM   MonorepoKind = "npm"
-	KindNx    MonorepoKind = "nx"
-	KindTurbo MonorepoKind = "turbo"
-	KindLerna MonorepoKind = "lerna"
-	KindMulti MonorepoKind = "multi"
+	KindNone     MonorepoKind = ""
+	KindPNPM     MonorepoKind = "pnpm"
+	KindNPM      MonorepoKind = "npm"
+	KindNx       MonorepoKind = "nx"
+	KindTurbo    MonorepoKind = "turbo"
+	KindLerna    MonorepoKind = "lerna"
+	KindMulti    MonorepoKind = "multi"
+	KindPolyglot MonorepoKind = "polyglot"
 )
+
+// containerDirs are the conventional top-level directories that hold service
+// or package modules in a (polyglot) monorepo. Each immediate child that
+// contains source code is treated as a selectable module.
+var containerDirs = []string{"services", "apps", "packages", "libs", "lib", "frontend", "backend", "modules", "cmd", "pkg"}
+
+// ecosystemManifests are per-package manifest filenames across ecosystems. A
+// directory containing any of these is a package root regardless of language.
+var ecosystemManifests = []string{
+	"package.json",                            // npm/pnpm/yarn (Node)
+	"pyproject.toml", "setup.py", "setup.cfg", // Python
+	"requirements.txt", "Pipfile", // Python
+	"go.mod",                            // Go
+	"pom.xml", "build.gradle", "build.gradle.kts", // Maven/Gradle (JVM)
+	"Cargo.toml",    // Rust
+	"composer.json", // PHP
+	"mix.exs",       // Elixir
+	"Gemfile",       // Ruby
+	"*.csproj",      // .NET (matched specially)
+}
+
+// sourceExts is the set of file extensions that count as "source code" for the
+// code-dir fallback. Kept in sync (loosely) with the classifier's language map
+// but inlined here to keep the detect package dependency-free and cheap.
+var sourceExts = map[string]struct{}{
+	".py": {}, ".pyi": {}, ".pyw": {},
+	".go":  {},
+	".js":  {}, ".jsx": {}, ".mjs": {}, ".cjs": {},
+	".ts":  {}, ".tsx": {}, ".mts": {}, ".cts": {},
+	".java": {},
+	".kt":   {}, ".kts": {},
+	".rb": {}, ".rake": {},
+	".php": {},
+	".rs":  {},
+	".cs":  {},
+	".swift": {},
+	".scala": {}, ".sc": {},
+	".ex": {}, ".exs": {},
+	".c": {}, ".h": {}, ".cpp": {}, ".cc": {}, ".cxx": {}, ".hpp": {},
+	".dart": {},
+}
 
 // Monorepo describes a detected monorepo layout.
 type Monorepo struct {
@@ -67,38 +109,310 @@ type Monorepo struct {
 // DetectMonorepo inspects a repo root and returns its kind plus the
 // list of package roots (repo-relative). Returns Monorepo{Kind:KindNone}
 // if no monorepo signal is present.
+//
+// Detection is a HYBRID of two strategies, unioned so a polyglot monorepo
+// surfaces ALL its services (not just the pnpm/Node ones a workspace manifest
+// happens to list):
+//
+//  1. Ecosystem workspace manifests (pnpm-workspace.yaml, package.json
+//     `workspaces`, nx/turbo/lerna) — the JS/TS workspace packages.
+//  2. A polyglot code-dir scan — every immediate child of the conventional
+//     container dirs (services/, apps/, libs/, frontend/, …) plus top-level
+//     module dirs that contain SOURCE CODE in any supported language or an
+//     ecosystem manifest (go.mod, pyproject.toml, pom.xml, Cargo.toml,
+//     composer.json, mix.exs, …).
+//
+// The union means a pure-Node workspace still reports exactly its workspace
+// packages, while a polyglot platform reports its Python/Go/Java/Kotlin/Rust/
+// PHP/Elixir services too. The reported Kind reflects the dominant signal: a
+// workspace manifest's kind when one exists, else KindMulti/KindPolyglot.
 func DetectMonorepo(repo string) (Monorepo, error) {
+	kind := KindNone
+	seen := map[string]struct{}{}
+
+	add := func(pkgs []string) {
+		for _, p := range pkgs {
+			seen[filepath.ToSlash(p)] = struct{}{}
+		}
+	}
+
+	// 1. Ecosystem workspace manifests (Node/JS/TS).
 	switch {
 	case exists(repo, "pnpm-workspace.yaml"):
 		pkgs, err := scanWorkspaces(repo, parseYAMLPackages(filepath.Join(repo, "pnpm-workspace.yaml")))
-		return Monorepo{Kind: KindPNPM, Packages: pkgs}, err
+		if err != nil {
+			return Monorepo{}, err
+		}
+		add(pkgs)
+		kind = KindPNPM
 	case exists(repo, "nx.json"):
 		pkgs, err := scanWorkspaces(repo, parsePackageJSONWorkspaces(repo))
-		return Monorepo{Kind: KindNx, Packages: pkgs}, err
+		if err != nil {
+			return Monorepo{}, err
+		}
+		add(pkgs)
+		kind = KindNx
 	case exists(repo, "turbo.json"):
 		pkgs, err := scanWorkspaces(repo, parsePackageJSONWorkspaces(repo))
-		return Monorepo{Kind: KindTurbo, Packages: pkgs}, err
+		if err != nil {
+			return Monorepo{}, err
+		}
+		add(pkgs)
+		kind = KindTurbo
 	case exists(repo, "lerna.json"):
 		pkgs, err := scanWorkspaces(repo, parseLernaPackages(filepath.Join(repo, "lerna.json")))
-		return Monorepo{Kind: KindLerna, Packages: pkgs}, err
+		if err != nil {
+			return Monorepo{}, err
+		}
+		add(pkgs)
+		kind = KindLerna
 	case exists(repo, "package.json"):
 		ws := parsePackageJSONWorkspaces(repo)
 		if len(ws) > 0 {
 			pkgs, err := scanWorkspaces(repo, ws)
-			return Monorepo{Kind: KindNPM, Packages: pkgs}, err
+			if err != nil {
+				return Monorepo{}, err
+			}
+			add(pkgs)
+			kind = KindNPM
 		}
 	}
-	// Heuristic fallback: presence of a top-level packages/ or apps/ dir
-	// each containing >1 manifest.
-	for _, sub := range []string{"packages", "apps", "services"} {
-		if isDir(filepath.Join(repo, sub)) {
-			pkgs, err := scanGlob(repo, []string{sub + "/*"})
-			if err == nil && len(pkgs) > 1 {
-				return Monorepo{Kind: KindMulti, Packages: pkgs}, nil
+
+	// 2. Polyglot code-dir scan — surfaces non-Node services the workspace
+	//    manifest doesn't list (orders/Python, inventory/Go, notifications/
+	//    Kotlin, pricing/Rust, billing/PHP, realtime-dashboard/Elixir, …).
+	add(scanPolyglotModules(repo))
+
+	// Decide the reported kind. If a workspace manifest set a kind, keep it.
+	// Otherwise label the layout from the code-dir scan: KindPolyglot when the
+	// detected modules span more than one language, else KindMulti.
+	if kind == KindNone && len(seen) > 1 {
+		if len(distinctLanguages(repo, seen)) > 1 {
+			kind = KindPolyglot
+		} else {
+			kind = KindMulti
+		}
+	}
+	if len(seen) == 0 {
+		return Monorepo{Kind: KindNone}, nil
+	}
+
+	out := make([]string, 0, len(seen))
+	for k := range seen {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return Monorepo{Kind: kind, Packages: out}, nil
+}
+
+// scanPolyglotModules returns repo-relative paths to every directory that looks
+// like a service/package module in ANY language. It scans the immediate
+// children of the conventional container dirs plus the top-level dirs of the
+// repo, and includes a directory when it either contains an ecosystem manifest
+// (go.mod, pyproject.toml, pom.xml, Cargo.toml, composer.json, mix.exs,
+// package.json, requirements.txt, build.gradle[.kts], …) OR contains source
+// files in a supported language within its first couple of levels.
+func scanPolyglotModules(repo string) []string {
+	var out []string
+	seen := map[string]struct{}{}
+
+	consider := func(rel string) {
+		if rel == "" || rel == "." {
+			return
+		}
+		rel = filepath.ToSlash(rel)
+		if _, ok := seen[rel]; ok {
+			return
+		}
+		abs := filepath.Join(repo, rel)
+		if !isDir(abs) {
+			return
+		}
+		if isModuleDir(abs) {
+			seen[rel] = struct{}{}
+			out = append(out, rel)
+		}
+	}
+
+	// Immediate children of conventional container dirs.
+	for _, container := range containerDirs {
+		cdir := filepath.Join(repo, container)
+		entries, err := os.ReadDir(cdir)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() || isIgnoredDir(e.Name()) {
+				continue
+			}
+			consider(filepath.Join(container, e.Name()))
+		}
+	}
+
+	// Top-level service/package dirs that aren't themselves containers
+	// (e.g. data-pipeline, py-shared sitting at the repo root).
+	topEntries, err := os.ReadDir(repo)
+	if err == nil {
+		for _, e := range topEntries {
+			if !e.IsDir() || isIgnoredDir(e.Name()) {
+				continue
+			}
+			name := e.Name()
+			// Skip the container dirs themselves; their children were scanned.
+			if isContainer(name) {
+				continue
+			}
+			consider(name)
+		}
+	}
+
+	sort.Strings(out)
+	return out
+}
+
+// distinctLanguages returns the set of source languages across the given
+// repo-relative module paths. Used to decide KindPolyglot vs KindMulti. It
+// probes by source-file extension (shallow) rather than the root-manifest-only
+// Stack(), so a Python service whose only signal is nested *.py files still
+// counts.
+func distinctLanguages(repo string, modules map[string]struct{}) map[string]struct{} {
+	langs := map[string]struct{}{}
+	for rel := range modules {
+		moduleLanguages(filepath.Join(repo, rel), 2, langs)
+	}
+	return langs
+}
+
+// extLanguage maps a (lower-cased) extension to a coarse language label for
+// polyglot classification.
+var extLanguage = map[string]string{
+	".py": "python", ".pyi": "python", ".pyw": "python",
+	".go":  "go",
+	".js":  "node", ".jsx": "node", ".mjs": "node", ".cjs": "node",
+	".ts":  "node", ".tsx": "node", ".mts": "node", ".cts": "node",
+	".java": "jvm", ".kt": "jvm", ".kts": "jvm", ".scala": "jvm",
+	".rb":  "ruby",
+	".php": "php",
+	".rs":  "rust",
+	".cs":  "dotnet",
+	".swift": "swift",
+	".ex": "elixir", ".exs": "elixir",
+	".dart": "dart",
+	".c": "c", ".h": "c", ".cpp": "cpp", ".cc": "cpp", ".cxx": "cpp", ".hpp": "cpp",
+}
+
+// moduleLanguages adds the languages found in dir (up to maxDepth) into langs.
+func moduleLanguages(dir string, maxDepth int, langs map[string]struct{}) {
+	if maxDepth < 0 {
+		return
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			if !isIgnoredDir(e.Name()) {
+				moduleLanguages(filepath.Join(dir, e.Name()), maxDepth-1, langs)
+			}
+			continue
+		}
+		if l, ok := extLanguage[strings.ToLower(filepath.Ext(e.Name()))]; ok {
+			langs[l] = struct{}{}
+		}
+	}
+}
+
+func isContainer(name string) bool {
+	for _, c := range containerDirs {
+		if c == name {
+			return true
+		}
+	}
+	return false
+}
+
+// isIgnoredDir skips dot-dirs and well-known non-source directories so the
+// scan never surfaces node_modules/vendor/.git as "modules".
+func isIgnoredDir(name string) bool {
+	if strings.HasPrefix(name, ".") {
+		return true
+	}
+	switch name {
+	case "node_modules", "vendor", "target", "build", "dist", "out",
+		"__pycache__", ".venv", "venv", "bin", "obj", "tmp",
+		"contracts", "infra", "docs", "deploy", "scripts", "test", "tests",
+		"testdata", "fixtures", "examples", "third_party":
+		return true
+	}
+	return false
+}
+
+// isModuleDir reports whether dir is a source module: it has an ecosystem
+// manifest OR contains source files in a supported language (scanned shallowly,
+// up to ~2 levels deep — enough to catch services/orders/app/db.py).
+func isModuleDir(dir string) bool {
+	if hasEcosystemManifest(dir) {
+		return true
+	}
+	return hasSourceFiles(dir, 2)
+}
+
+// hasEcosystemManifest reports whether dir contains any per-package manifest.
+func hasEcosystemManifest(dir string) bool {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		for _, m := range ecosystemManifests {
+			if m == "*.csproj" {
+				if strings.HasSuffix(name, ".csproj") {
+					return true
+				}
+				continue
+			}
+			if name == m {
+				return true
 			}
 		}
 	}
-	return Monorepo{Kind: KindNone}, nil
+	return false
+}
+
+// hasSourceFiles reports whether dir (or a subdir within maxDepth) contains at
+// least one supported source file. It stops at the first hit and skips ignored
+// directories so it stays cheap on large trees.
+func hasSourceFiles(dir string, maxDepth int) bool {
+	if maxDepth < 0 {
+		return false
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return false
+	}
+	var subdirs []string
+	for _, e := range entries {
+		if e.IsDir() {
+			if !isIgnoredDir(e.Name()) {
+				subdirs = append(subdirs, e.Name())
+			}
+			continue
+		}
+		if _, ok := sourceExts[strings.ToLower(filepath.Ext(e.Name()))]; ok {
+			return true
+		}
+	}
+	for _, sd := range subdirs {
+		if hasSourceFiles(filepath.Join(dir, sd), maxDepth-1) {
+			return true
+		}
+	}
+	return false
 }
 
 func exists(dir, name string) bool {

--- a/internal/install/detect/detect_test.go
+++ b/internal/install/detect/detect_test.go
@@ -88,6 +88,143 @@ func TestDetectMonorepoNx(t *testing.T) {
 	}
 }
 
+// TestDetectMonorepoPolyglot builds a synthetic polyglot monorepo mirroring the
+// polyglot-platform fixture: a pnpm-workspace.yaml that lists ONLY the Node
+// services, plus many non-Node services (Python/Go/Java/Kotlin/Rust/PHP/Elixir)
+// the manifest does not list. Detection must surface ALL of them, not just the
+// pnpm packages (regression for #1559).
+func TestDetectMonorepoPolyglot(t *testing.T) {
+	dir := t.TempDir()
+	// pnpm workspace listing ONLY the Node services + frontends.
+	write(t, filepath.Join(dir, "pnpm-workspace.yaml"),
+		"packages:\n  - 'services/gateway'\n  - 'services/catalog'\n  - 'frontend/*'\n")
+	write(t, filepath.Join(dir, "services/gateway/package.json"), `{"name":"gateway"}`)
+	write(t, filepath.Join(dir, "services/gateway/src/index.ts"), "export const x = 1\n")
+	write(t, filepath.Join(dir, "services/catalog/package.json"), `{"name":"catalog"}`)
+	write(t, filepath.Join(dir, "services/catalog/src/index.ts"), "export const y = 1\n")
+	write(t, filepath.Join(dir, "frontend/web/package.json"), `{"name":"web"}`)
+	write(t, filepath.Join(dir, "frontend/web/src/app.tsx"), "export const A = 1\n")
+
+	// Non-Node services NOT in the workspace manifest.
+	write(t, filepath.Join(dir, "services/orders/requirements.txt"), "fastapi\n")
+	write(t, filepath.Join(dir, "services/orders/app/db.py"), "x = 1\n")
+	write(t, filepath.Join(dir, "services/analytics/analytics/main.py"), "print(1)\n") // no manifest, .py only
+	write(t, filepath.Join(dir, "services/inventory/go.mod"), "module inventory\n")
+	write(t, filepath.Join(dir, "services/inventory/main.go"), "package main\n")
+	write(t, filepath.Join(dir, "services/notifications/build.gradle.kts"), "// kt\n")
+	write(t, filepath.Join(dir, "services/notifications/src/Main.kt"), "fun main(){}\n")
+	write(t, filepath.Join(dir, "services/legacy-erp/pom.xml"), "<project/>\n")
+	write(t, filepath.Join(dir, "services/legacy-erp/src/Main.java"), "class M{}\n")
+	write(t, filepath.Join(dir, "services/pricing/Cargo.toml"), "[package]\n")
+	write(t, filepath.Join(dir, "services/pricing/src/main.rs"), "fn main(){}\n")
+	write(t, filepath.Join(dir, "services/billing/composer.json"), `{}`)
+	write(t, filepath.Join(dir, "services/billing/routes/web.php"), "<?php\n")
+	write(t, filepath.Join(dir, "services/realtime-dashboard/mix.exs"), "defmodule M do end\n")
+	// Top-level non-container module dir.
+	write(t, filepath.Join(dir, "data-pipeline/dags/etl.py"), "x = 1\n")
+	// libs/
+	write(t, filepath.Join(dir, "libs/go-shared/go.mod"), "module shared\n")
+	write(t, filepath.Join(dir, "libs/py-shared/pyproject.toml"), "[project]\n")
+	// Noise that must be ignored.
+	write(t, filepath.Join(dir, "node_modules/junk/index.js"), "//\n")
+	write(t, filepath.Join(dir, "infra/k8s/deploy.yaml"), "kind: x\n")
+	write(t, filepath.Join(dir, "vendor/carrier-sdk/main.go"), "package x\n")
+
+	m, err := DetectMonorepo(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got := map[string]bool{}
+	for _, p := range m.Packages {
+		got[p] = true
+	}
+	// Every polyglot service must be present, not just the Node ones.
+	wantPresent := []string{
+		"services/gateway", "services/catalog", "frontend/web", // Node
+		"services/orders", "services/analytics", "data-pipeline", "libs/py-shared", // Python
+		"services/inventory", "libs/go-shared", // Go
+		"services/notifications",     // Kotlin
+		"services/legacy-erp",        // Java
+		"services/pricing",           // Rust
+		"services/billing",           // PHP
+		"services/realtime-dashboard", // Elixir
+	}
+	for _, w := range wantPresent {
+		if !got[w] {
+			t.Errorf("missing expected module %q; got %v", w, m.Packages)
+		}
+	}
+	// Noise must NOT appear.
+	for _, bad := range []string{"node_modules", "infra", "vendor", "node_modules/junk"} {
+		if got[bad] {
+			t.Errorf("ignored dir leaked as module: %q", bad)
+		}
+	}
+	if m.Kind != KindPNPM {
+		t.Errorf("kind: want pnpm (workspace manifest wins), got %q", m.Kind)
+	}
+	if len(m.Packages) < 14 {
+		t.Errorf("expected >=14 modules across languages, got %d: %v", len(m.Packages), m.Packages)
+	}
+}
+
+// TestDetectMonorepoPolyglotNoManifest covers a polyglot monorepo with NO
+// workspace manifest at all — detection should still find all services via the
+// code-dir scan and report KindPolyglot.
+func TestDetectMonorepoPolyglotNoManifest(t *testing.T) {
+	dir := t.TempDir()
+	write(t, filepath.Join(dir, "services/orders/app/main.py"), "x=1\n")
+	write(t, filepath.Join(dir, "services/inventory/main.go"), "package main\n")
+	write(t, filepath.Join(dir, "services/billing/index.php"), "<?php\n")
+	m, _ := DetectMonorepo(dir)
+	if m.Kind != KindPolyglot {
+		t.Fatalf("kind: want polyglot, got %q (%v)", m.Kind, m.Packages)
+	}
+	if len(m.Packages) != 3 {
+		t.Fatalf("want 3 modules, got %d: %v", len(m.Packages), m.Packages)
+	}
+}
+
+// TestDetectMonorepoRealPolyglotPlatform asserts against the REAL fixture on
+// disk when present. Skipped in CI where the fixture is absent.
+func TestDetectMonorepoRealPolyglotPlatform(t *testing.T) {
+	const fixture = "/Users/jorgecajas/Documents/Projects/polyglot-platform"
+	if _, err := os.Stat(fixture); err != nil {
+		t.Skip("polyglot-platform fixture not present")
+	}
+	m, err := DetectMonorepo(fixture)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := map[string]bool{}
+	for _, p := range m.Packages {
+		got[p] = true
+	}
+	// Non-Node services that the pnpm-workspace.yaml does NOT list.
+	mustHave := []string{
+		"services/orders", "services/analytics", "services/workers", "services/order-saga",
+		"services/semantic-search", "services/ledger", // Python
+		"services/inventory", "services/shipping", "libs/go-shared", // Go
+		"services/notifications",                      // Kotlin
+		"services/legacy-erp", "services/stream-processor", // Java
+		"services/pricing", "services/rate-limiter", // Rust
+		"services/billing",            // PHP
+		"services/realtime-dashboard", // Elixir
+	}
+	missing := 0
+	for _, w := range mustHave {
+		if !got[w] {
+			t.Errorf("real fixture missing polyglot module %q", w)
+			missing++
+		}
+	}
+	if len(m.Packages) < 20 {
+		t.Errorf("expected >=20 modules from polyglot-platform, got %d: %v", len(m.Packages), m.Packages)
+	}
+	t.Logf("polyglot-platform detected %d modules (kind=%s)", len(m.Packages), m.Kind)
+}
+
 func TestDetectMonorepoNone(t *testing.T) {
 	dir := t.TempDir()
 	write(t, filepath.Join(dir, "go.mod"), "module x\n")


### PR DESCRIPTION
## 1. Problem

Pointing the create-group wizard at a polyglot monorepo (`polyglot-platform`) detected only the **11 pnpm/Node packages** read from `pnpm-workspace.yaml` and **missed every non-Node service**: orders/analytics/workers/order-saga/semantic-search/ledger (Python), inventory/shipping/go-shared (Go), notifications (Kotlin), legacy-erp/stream-processor (Java), pricing/rate-limiter (Rust), billing (PHP), realtime-dashboard (Elixir), py-shared, data-pipeline. `DetectMonorepo` short-circuited on the first ecosystem manifest and `scanGlob` only admitted dirs containing `package.json`.

Separately, the per-repo `files` count was **0 everywhere** (Settings repo rows + group detail) even though entities existed: the `graph-stats.json` sidecar had no file-count field, so `repoStats` always read 0 and the CLI used `TotalEntities` as a placeholder.

## 2. Root cause

- `internal/install/detect/detect.go` — `DetectMonorepo` was pnpm/npm/nx/turbo/lerna-only; the heuristic fallback also keyed on `package.json`. No path detected Python/Go/JVM/Rust/PHP/Elixir modules.
- `internal/graph/graph.go` — `GraphStatsSidecar` had no `TotalFiles` field; `cmd/archigraph/index.go` populated `TotalEntities`/`TotalRelationships` but not files, even though `doc.Stats.Files` was already computed.

## 3. Fix

**Detection — hybrid (ecosystem manifests ∪ polyglot code-dir scan):**
- Keep the JS/TS workspace-manifest detection (kind is preserved: pnpm/npm/nx/turbo/lerna).
- Add `scanPolyglotModules`: scan immediate children of conventional container dirs (`services/ apps/ packages/ libs/ frontend/ …`) **plus** top-level module dirs, admitting any dir that has an ecosystem manifest (`go.mod`, `pyproject.toml`/`setup.py`/`requirements.txt`, `pom.xml`/`build.gradle[.kts]`, `Cargo.toml`, `composer.json`, `mix.exs`, `Gemfile`, `*.csproj`, `package.json`) **or** contains source files in any supported language (shallow scan, ≤2 levels).
- Union both sets (dedup), ignore `node_modules/vendor/.git/infra/docs/…`. New `KindPolyglot` when no workspace manifest exists but modules span >1 language; else `KindMulti`.

**Files metric:** add `TotalFiles` to `GraphStatsSidecar`, populate from `doc.Stats.Files` in `index.go`, and replace the CLI placeholder in `status_stats.go`. `v2_group_settings.go`'s `repoStats` already read `total_files`, so the API/UI light up once the sidecar carries it.

## 4. Testing

- `go test ./internal/install/detect/ ./internal/graph/` — pass. New `TestDetectMonorepoPolyglot` (synthetic, asserts all 9-language services present + noise excluded), `TestDetectMonorepoPolyglotNoManifest` (KindPolyglot), and `TestDetectMonorepoRealPolyglotPlatform` (real fixture, ≥20 modules). Existing pnpm/npm/nx tests still pass with unchanged counts.
- **Isolated daemon** (`ARCHIGRAPH_DAEMON_ROOT`/`ARCHIGRAPH_HOME`/`ARCHIGRAPH_DASHBOARD_PORT=47931`, live :47274 untouched): wizard `POST /api/v2/scan/inspect` on `polyglot-platform` → **32 modules** spanning all 9 languages (was 11).
- Indexed 5 non-Node services: orders (Python, 14 files/175 ent), inventory (Go, 6/69), notifications (Kotlin, 14/85), pricing (Rust, 3/34), billing (PHP, 11/113). `total_files` confirmed written to the sidecar; group detail shows non-zero file counts.

## 5. Before / After

| | Before | After |
|---|---|---|
| Modules detected (polyglot-platform) | **11** (Node only) | **32** (all 9 languages) |
| Per-repo `files` metric | **0** everywhere | real indexed file count |

## 6. Risks / follow-ups

- The code-dir scan is shallow (≤2 levels) for cost; deeply-nested-only sources in a module without a manifest at its first 2 levels won't register. Container/ignore lists are heuristic and may need tuning for unusual layouts.
- Two pre-existing dashboard test failures (`TestWriteback_success`, `TestYamlScalar`) are unrelated to this change (files unchanged from `origin/main`).

Fixes #1559

🤖 Generated with [Claude Code](https://claude.com/claude-code)