### PR TITLE
fix(webui-v2): graph links visible at all zooms + kill hollow-ring layout (#1558)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -106,10 +106,13 @@ function buildGroupCenters(
   const keys = Array.from(new Set(nodes.map((n) => groupKeyFor(n, mode)))).sort();
   const N = keys.length;
   if (N === 0) return new Map();
-  // Fix #1548-2: the prior ring radius (N*700, sqrt(n)*50) flung clusters far
-  // apart, leaving the canvas mostly empty. Tighten it so clusters sit in a
-  // compact ring and the stronger center force pulls the whole graph together.
-  const R = Math.max(900, Math.sqrt(nodes.length) * 20, N * 150);
+  // Fix #1558-2: the ring radius still scaled with the GROUP COUNT (N*150) which,
+  // on a many-module monorepo, flung the clusters into a wide hollow ring with an
+  // empty middle. The ring is now only a SEEDING hint — keep it tight so the
+  // initial spokes start close to center, then let the link-spring + center
+  // gravity pull connected modules inward to fill the canvas. Scale with node
+  // count (not group count), so adding more groups no longer expands the ring.
+  const R = Math.min(1400, Math.max(450, Math.sqrt(nodes.length) * 28));
   return new Map(
     keys.map((key, i) => {
       const angle = (i / N) * 2 * Math.PI;
@@ -199,6 +202,11 @@ function GraphCanvasInner(
   const graphRef = useRef<Graph | null>(null);
   const hasSettledRef = useRef(false);
   const capTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Fix #1558-2: timer for the mid-settle re-heat (see mount effect) + a flag so
+  // the first early onSimulationEnd doesn't freeze a still-spread hollow ring
+  // before the re-heat has had a chance to finish converging.
+  const reheatTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reheatedRef = useRef(false);
   const didAutoStartRef = useRef(false);
   const mountTimeRef = useRef(Date.now());
 
@@ -285,7 +293,10 @@ function GraphCanvasInner(
       const repoIdx = repoToIdx.get(n.repo ?? "") ?? 0;
       clusters[i] = clusterIdFor(n, repoIdx, groupBy);
       const normPR = (n.pageRank ?? 0) / maxPR;
-      clusterStrength[i] = grouping ? 0.45 + normPR * 0.25 : 0.04 + normPR * 0.06;
+      // Fix #1558-2: lower the per-node cluster pull so it nudges (rather than
+      // pins) nodes to their group center; the cross-module link-spring then wins
+      // where it matters, drawing connected modules together (was 0.45 + .25).
+      clusterStrength[i] = grouping ? 0.22 + normPR * 0.15 : 0.04 + normPR * 0.06;
 
       // log-scaled size by degree (graph.md: radius scales with PageRank/degree),
       // hard-capped at maxMultiplier × base so high-degree hubs never bloom into
@@ -296,13 +307,17 @@ function GraphCanvasInner(
 
       const gkey = groupKeyFor(n, groupBy);
       const center = grouping ? groupCenters.get(gkey) : undefined;
-      const jitterR = Math.max(600, Math.sqrt(groupCount.get(gkey) ?? 1) * 40);
+      // Fix #1558-2: seed nodes TIGHTLY around their group center (and seed the
+      // ungrouped fallback near the middle, not across a 4000-wide field). Within
+      // the ≤2s settle cap the strong center/gravity + link-spring then pull the
+      // already-compact start into a canvas-filling mass — no hollow ring.
+      const jitterR = Math.max(280, Math.sqrt(groupCount.get(gkey) ?? 1) * 26);
       const angle = Math.random() * 2 * Math.PI;
       const r = Math.random() * jitterR;
-      positions[i * 2] = center ? center.x + r * Math.cos(angle) : (Math.random() - 0.5) * 4000;
+      positions[i * 2] = center ? center.x + r * Math.cos(angle) : (Math.random() - 0.5) * 1600;
       positions[i * 2 + 1] = center
         ? center.y + r * Math.sin(angle)
-        : (Math.random() - 0.5) * 4000;
+        : (Math.random() - 0.5) * 1600;
     });
 
     return { positions, sizes, clusters, clusterStrength };
@@ -371,8 +386,19 @@ function GraphCanvasInner(
     const { states } = linkData;
     const out = new Float32Array(states.length);
     if (!render.showLinks) return out;
+    // Fix #1558-1: links must stay visible at EVERY zoom level — especially the
+    // long cross-module "bridge" links between islands, which previously thinned
+    // to sub-pixel and vanished when zoomed out. `scaleLinksOnZoom` is off so the
+    // width is a constant on-screen pixel value; we floor every link at a
+    // perceptible minimum (cross-module links a touch heavier so the bridges read
+    // first) and never let linkWidthScale push them below that floor.
+    const MIN_SAME = 1.1;
+    const MIN_CROSS = 2.4;
     for (let i = 0; i < states.length; i++) {
-      out[i] = (states[i] === 1 ? 2.2 : 0.6) * render.linkWidthScale;
+      const cross = states[i] === 1;
+      const base = cross ? 2.6 : 1.0;
+      const floor = cross ? MIN_CROSS : MIN_SAME;
+      out[i] = Math.max(floor, base * render.linkWidthScale);
     }
     return out;
   }, [linkData, render.showLinks, render.linkWidthScale]);
@@ -591,6 +617,11 @@ function GraphCanvasInner(
       pointGreyoutOpacity: 0.15,
       linkGreyoutOpacity: render.linkOpacity * 0.5,
       linkWidthScale: render.showLinks ? render.linkWidthScale : 0,
+      // Fix #1558-1: keep links at a CONSTANT on-screen pixel width regardless of
+      // zoom. With this off, the floored widths from packLinkWidths hold at every
+      // zoom level, so the long inter-island bridge links never thin out and
+      // disappear when the user zooms all the way out.
+      scaleLinksOnZoom: false,
       // Fix #1548-2: cosmos.gl fades links by their ON-SCREEN length
       // (linkVisibilityDistanceRange, in px) and caps far-link alpha at
       // linkVisibilityMinTransparency. The defaults ([50,150] / 0.25) made
@@ -606,18 +637,37 @@ function GraphCanvasInner(
       enableSimulation: true,
       simulationLinkSpring: simulation.linkSpring,
       simulationLinkDistance: Math.max(simulation.linkDistance, 8),
-      simulationGravity: 0.02,
+      // Fix #1558-2: more gravity (was 0.02) reinforces the center pull so
+      // disconnected islands drift inward instead of sitting on the rim, filling
+      // the canvas rather than leaving an empty middle.
+      simulationGravity: 0.35,
       simulationFriction: simulation.friction,
-      simulationDecay: 1500,
-      simulationCluster: 0.5,
+      // Fix #1558-2: a slower cool-down (was 1500) keeps the simulation active
+      // long enough for the strong center + gravity to pull the islands inward
+      // before it freezes — otherwise it ended early at the spread state and the
+      // graph settled as a hollow ring. The ≤settleTime wall-clock cap still
+      // bounds total settle time.
+      simulationDecay: 3000,
+      // Fix #1558-2: the cluster force pinned every node hard to its ring center,
+      // overriding the cross-module link-spring and locking in the hollow ring.
+      // Soften it so groups still coalesce locally but connected modules are free
+      // to be pulled together by their shared edges (was 0.5).
+      simulationCluster: 0.2,
       simulationRepulsion: simulation.repulsion,
       simulationCenter: simulation.center,
       rescalePositions: true,
-      fitViewOnInit: true,
-      fitViewDelay: 3500,
+      // Fix #1558-2: let OUR doSettle own the final fit (after the mid-settle
+      // re-heat has converged). cosmos's own fitViewOnInit fired at a fixed delay
+      // mid-reheat and captured the still-spread layout, so the graph looked like
+      // it floated/ringed even though it later converged. Disable it here.
+      fitViewOnInit: false,
       fitViewPadding: FIT_PADDING,
       onSimulationEnd: () => {
-        if (!hasSettledRef.current) doSettleRef.current();
+        // Fix #1558-2: ignore the FIRST early cool-down (before the mid-settle
+        // re-heat) so we don't freeze a still-spread hollow ring. After the
+        // re-heat has run, the second cool-down settles the converged layout. The
+        // cap timer is the hard backstop either way.
+        if (!hasSettledRef.current && reheatedRef.current) doSettleRef.current();
       },
       onSimulationTick: scheduleLabelsLive,
       onClick: (index?: number) => {
@@ -668,6 +718,19 @@ function GraphCanvasInner(
       });
     } else {
       const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
+      // Fix #1558-2: a single alpha=1 pass from the (spread) seed cools down
+      // before the strong center/gravity finish pulling the islands inward — the
+      // graph froze as a hollow ring. Re-heat the simulation once partway through
+      // the settle window so it keeps converging on the now-partially-collapsed
+      // positions, reliably reaching the canvas-filling layout (this mirrors the
+      // manual second `start()` that was needed to converge). Still bounded by the
+      // settleTime cap below.
+      reheatedRef.current = false;
+      reheatTimerRef.current = setTimeout(() => {
+        const gg = graphRef.current;
+        reheatedRef.current = true;
+        if (gg && !hasSettledRef.current) gg.start(1);
+      }, Math.round(capMs * 0.45));
       capTimerRef.current = setTimeout(() => {
         if (!hasSettledRef.current) doSettleRef.current();
       }, capMs);
@@ -675,6 +738,7 @@ function GraphCanvasInner(
 
     return () => {
       if (capTimerRef.current) clearTimeout(capTimerRef.current);
+      if (reheatTimerRef.current) clearTimeout(reheatTimerRef.current);
       if (labelTimerRef.current !== null) clearTimeout(labelTimerRef.current);
       if (rafRef.current !== null) cancelAnimationFrame(rafRef.current);
       interactingRef.current = false;

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -46,16 +46,23 @@ export interface RenderConfig {
 }
 
 export const DEFAULT_SIMULATION: SimulationConfig = {
-  // Fix #1548-2: the layout was over-spread (clusters flung far apart, mostly
-  // empty canvas). A firmer center pull + slightly lower repulsion pulls the
-  // clusters together so the graph uses space sensibly (was center 0.4 /
-  // repulsion 1.2). Kept moderate so clusters stay legible, not collapsed.
-  linkSpring: 1.0,
-  linkDistance: 10,
+  // Fix #1558-2: the graph showed a HOLLOW RING of islands with an empty middle —
+  // the cluster force pinned each module to a wide ring while the cross-module
+  // links were too weak to pull connected modules together. Raise link-spring so
+  // edges (esp. the 36 cross-module bridges) contract, raise center gravity so
+  // the whole graph collapses inward and FILLS the canvas, and drop repulsion so
+  // unconnected islands stop shoving each other to the rim. Balanced — clusters
+  // still read as clusters, the graph is not a single blob.
+  // (was linkSpring 1.0 / repulsion 1.0 / center 0.55)
+  linkSpring: 2.2,
+  linkDistance: 8,
   friction: 0.85,
-  repulsion: 1.0,
-  center: 0.55,
-  settleTime: 2.0,
+  repulsion: 0.12,
+  center: 1.6,
+  // A slightly longer settle (still ≤ the 6s hard cap) lets the strong center +
+  // gravity converge from the seed into the canvas-filling mass — the 2s cap
+  // stopped it while the islands were still spread. (Fix #1558-2)
+  settleTime: 4.5,
 };
 
 export const DEFAULT_NODE_SIZING: NodeSizingConfig = {
@@ -74,7 +81,11 @@ export const DEFAULT_RENDER: RenderConfig = {
   // Fix #1532-4: cap the on-screen pixel size so no node becomes a giant blob
   // even when zoomed in (was 60).
   maxPointSize: 34,
-  linkWidthScale: 1.0,
+  // Fix #1558-1: the long cross-module links between islands vanished when
+  // zoomed OUT. Raise the default width scale so even the thin same-repo links
+  // clear the visible-pixel floor at every zoom level (see packLinkWidths,
+  // which now also enforces a hard minimum on-screen width).
+  linkWidthScale: 1.4,
   // Fix #1548-2: edges must read clearly from the FIRST paint (not just after
   // settle). Raise the default same-repo link opacity further so relationships
   // are visible immediately on a light background.


### PR DESCRIPTION
Fixes #1558

## 1. What & why
The WebUI v2 graph had two related defects on the real polyglot-platform graph (232 nodes / 134 edges / 36 cross-module):

1. **Links vanished when zoomed OUT.** Despite #1550 widening the visibility range, the long cross-module "bridge" links between islands disappeared at low zoom — their on-screen width thinned below a perceptible pixel and they were lost.
2. **Hollow ring / empty middle.** The 36 cross-module edges existed but the layout settled as a ring of islands around the rim with an empty center, because the cluster force pinned each module hard to a wide ring while the link-spring + center gravity were too weak to pull connected modules together.

## 2. How — link visibility (Fix #1558-1)
- `packLinkWidths` now floors every link at a perceptible constant on-screen width (same-module ≥1.1px, cross-module ≥2.4px) so `linkWidthScale` can never push them sub-pixel.
- Set `scaleLinksOnZoom: false` explicitly so those floored widths are constant on-screen pixels at **every** zoom — the long inter-island bridges stay visible when zoomed all the way out.
- Raised the default `linkWidthScale` 1.0 → 1.4.

## 3. How — cohesion / kill the hollow ring (Fix #1558-2)
Tuned the simulation defaults so connected modules contract toward each other and the graph **fills** the canvas, balanced so clusters stay legible (not one blob):
- Sim defaults: `linkSpring` 1.0→2.2, `repulsion` 1.0→0.12, `center` 0.55→1.6, `linkDistance` 10→8, `settleTime` 2.0→4.5s.
- Engine: `simulationGravity` 0.02→0.35, `simulationCluster` 0.5→0.2, `simulationDecay` 1500→3000 (slower cool-down), per-node `clusterStrength` 0.45→0.22 base.
- Ring radius no longer scales with **group count** (`N*150` flung clusters wide); it now scales gently with node count and is only a tight seeding hint. Seed jitter tightened so nodes start compact.
- The single alpha-1 settle cooled before the strong center pull finished, freezing a hollow ring. Added a **mid-settle re-heat** (`g.start(1)` at 45% of the settle window) gated so the first early `onSimulationEnd` doesn't freeze the still-spread state; disabled cosmos's own `fitViewOnInit` (it fired mid-reheat and captured the spread layout) so our `doSettle` owns the final fit. Everything stays bounded by the `settleTime` cap.

Prior-PR features kept intact: per-module colors, node-blob size cap, zoom-gated labels, ego-focus camera snapshot/restore.

## 4. Files changed
- `webui-v2/src/store/use-graph-store.ts` — DEFAULT_SIMULATION + DEFAULT_RENDER tuning.
- `webui-v2/src/components/graph/graph-canvas.tsx` — link-width floor, `scaleLinksOnZoom`, ring radius + seed jitter, gravity/cluster/decay, mid-settle re-heat, fit ownership.

No other files touched: dashboard/, flows.tsx, paths.tsx, topology.tsx unchanged.

## 5. Verification (real data, memory-safe)
- `npm run build` clean; `tsc --noEmit` clean.
- Isolated Vite dev server (:47290) proxying read-only GETs to the polyglot-platform daemon — live :47274 never mutated/restarted.
- Playwright on the real 232/134 graph, fresh localStorage (no cached layout/tuning):
  - **Zoom fully out → links stay visible** (before: links completely gone).
  - **Fitted → cohesive colored mass filling the canvas**, no hollow ring / empty middle, per-module colors intact, clusters still distinct (not over-collapsed).
- Before/after screenshots attached in the PR thread.

## 6. Risk / rollback
Low. Changes are confined to graph simulation/render defaults + the settle sequence; all knobs remain live-tunable and localStorage-persisted, so users can override. Revert = revert this commit. The re-heat is bounded by the existing settleTime hard cap, so no risk of an unbounded simulation.