### PR TITLE
fix(webui-v2): remove duplicate TopBar from topology and docs screens

### DIFF
--- a/webui-v2/src/routes/docs.tsx
+++ b/webui-v2/src/routes/docs.tsx
@@ -25,62 +25,6 @@ import { DocsTree } from "@/components/docs/docs-tree";
 import { DocsReader } from "@/components/docs/docs-reader";
 import { DocsNotGenerated, DocsPickDocument } from "@/components/docs/docs-empty";
 
-// ── Inline DocsTopBar ─────────────────────────────────────────────────────────
-
-function DocsTopBar({
-  group,
-  search,
-  onSearch,
-}: {
-  group: string;
-  search: string;
-  onSearch: (v: string) => void;
-}) {
-  const inputRef = useRef<HTMLInputElement>(null);
-
-  useEffect(() => {
-    const handler = (e: KeyboardEvent) => {
-      if (e.key === "/" && document.activeElement?.tagName !== "INPUT") {
-        e.preventDefault();
-        inputRef.current?.focus();
-      }
-    };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, []);
-
-  return (
-    <div className="flex items-center justify-between h-11 shrink-0 px-4 gap-4 border-b border-border bg-bg">
-      <span className="text-sm text-text-3 font-mono shrink-0">{group} / Docs</span>
-
-      <div className="relative flex items-center flex-1 max-w-xs">
-        <Search size={13} className="absolute left-2.5 text-text-4 pointer-events-none" />
-        <input
-          ref={inputRef}
-          type="text"
-          className="w-full pl-8 pr-8 h-7 rounded-md bg-surface border border-border text-sm text-text placeholder:text-text-4 focus:outline-none focus:ring-1 focus:ring-[var(--accent)] focus:border-[var(--accent)]"
-          placeholder="Search documents…"
-          value={search}
-          onChange={(e) => onSearch(e.target.value)}
-        />
-        {search ? (
-          <button
-            className="absolute right-2 text-text-4 hover:text-text-2"
-            onClick={() => onSearch("")}
-            aria-label="Clear"
-          >
-            <X size={11} />
-          </button>
-        ) : (
-          <Kbd className="absolute right-2 text-[10px]">/</Kbd>
-        )}
-      </div>
-
-      <span className="text-xs text-text-3 shrink-0">Generated docs</span>
-    </div>
-  );
-}
-
 // ── DocsScreen ────────────────────────────────────────────────────────────────
 
 export default function DocsScreen() {
@@ -130,9 +74,47 @@ export default function DocsScreen() {
 
   const hasDocs = tree.length > 0;
 
+  // Keyboard: "/" focuses search input
+  const searchRef = useRef<HTMLInputElement>(null);
+  useEffect(() => {
+    const handler = (e: KeyboardEvent) => {
+      if (e.key === "/" && document.activeElement?.tagName !== "INPUT") {
+        e.preventDefault();
+        searchRef.current?.focus();
+      }
+    };
+    window.addEventListener("keydown", handler);
+    return () => window.removeEventListener("keydown", handler);
+  }, []);
+
   return (
     <div className="flex flex-col h-full">
-      <DocsTopBar group={groupId} search={search} onSearch={setSearch} />
+      {/* Controls row: search for the document tree */}
+      <div className="flex items-center gap-3 h-10 shrink-0 px-4 border-b border-border bg-bg">
+        <div className="relative flex items-center flex-1 max-w-xs">
+          <Search size={13} className="absolute left-2.5 text-text-4 pointer-events-none" />
+          <input
+            ref={searchRef}
+            type="text"
+            className="w-full pl-8 pr-8 h-7 rounded-md bg-surface border border-border text-sm text-text placeholder:text-text-4 focus:outline-none focus:ring-1 focus:ring-[var(--accent)] focus:border-[var(--accent)]"
+            placeholder="Search documents…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+          />
+          {search ? (
+            <button
+              className="absolute right-2 text-text-4 hover:text-text-2"
+              onClick={() => setSearch("")}
+              aria-label="Clear"
+            >
+              <X size={11} />
+            </button>
+          ) : (
+            <Kbd className="absolute right-2 text-[10px]">/</Kbd>
+          )}
+        </div>
+        <span className="text-xs text-text-3 ml-auto shrink-0">Generated docs</span>
+      </div>
 
       {/* No documents generated yet → whole-screen agent-skill empty state. */}
       {!treeLoading && !hasDocs ? (

--- a/webui-v2/src/routes/topology.tsx
+++ b/webui-v2/src/routes/topology.tsx
@@ -23,7 +23,6 @@ import {
   LayoutList,
 } from "lucide-react";
 
-import { TopBar } from "@/components/chrome/top-bar";
 import { Tabs, TabsList, TabsTrigger, TabsContent } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { SearchInput } from "@/components/ui/input";
@@ -1286,7 +1285,6 @@ export default function TopologyScreen() {
   if (!isLoading && !isError && channels.length === 0) {
     return (
       <div className="flex flex-col h-full bg-bg">
-        <TopBar group={groupId} surfaceLabel="Topology" />
         <div className="flex flex-col items-center justify-center flex-1 text-center gap-4 px-6">
           <p className="text-xl font-semibold text-text">No async channels indexed</p>
           <p className="text-md text-text-3 max-w-sm">
@@ -1300,8 +1298,6 @@ export default function TopologyScreen() {
 
   return (
     <div className="flex flex-col h-full bg-bg">
-      <TopBar group={groupId} surfaceLabel="Topology" />
-
       <Tabs value={tab} onValueChange={setTab} className="flex flex-col flex-1 min-h-0">
         {/* Tab strip */}
         <div className="border-b border-border shrink-0 px-4">


### PR DESCRIPTION
## What

After #1570 moved the TopBar (breadcrumb + screen-tab strip) into the AppShell, `topology.tsx` and `docs.tsx` were still rendering their own `<TopBar>` inside the Outlet. This caused a duplicated header on those two screens — two breadcrumbs and two tab strips stacked on top of each other.

## Changes

**`webui-v2/src/routes/topology.tsx`**
- Removed `import { TopBar }` from `@/components/chrome/top-bar`
- Removed the `<TopBar group={groupId} surfaceLabel="Topology" />` call from the empty-state path
- Removed the `<TopBar group={groupId} surfaceLabel="Topology" />` call from the main return
- All topology-specific controls preserved in-screen: the "All / Orphan pub / Orphan sub / Scheduled" sub-tabs, broker filter chips, channel search input (`/` shortcut), and Map/List toggle button pair

**`webui-v2/src/routes/docs.tsx`**
- Removed the inline `DocsTopBar` function component (header rendering + breadcrumb label)
- Removed `<DocsTopBar ... />` usage from `DocsScreen`
- Preserved the document search functionality (input, `ref`, `useEffect` keyboard handler for `/`, clear button, `Kbd` shortcut hint, "Generated docs" label) as a `h-10 shrink-0` controls row in the screen body, directly below the AppShell header

## Verification

- `npm run build` → clean, zero TypeScript errors, zero new warnings
- Isolated dev server on `:5175` (never touched `:47274`)
- **Topology** screenshot: single breadcrumb `archigraph › demo › Topology` + single screen-tabs row; topology sub-tabs + search + Map/List toggle all present below
- **Docs** screenshot: single breadcrumb `archigraph › demo › Docs` + single screen-tabs row; document search with `/ ` shortcut and "Generated docs" label present below
- No changes to `graph.tsx`, `flows.tsx`, `paths.tsx`, `app-shell.tsx`, `top-bar.tsx`, or any `dashboard/` file

Fixes #1571