### PR TITLE
fix(daemon): tag rebuilt graphs with config slug — restore cross-repo edges (Fixes #1576)

### DIFF
--- a/cmd/archigraph/daemon.go
+++ b/cmd/archigraph/daemon.go
@@ -280,9 +280,39 @@ func daemonSchedulerLinks(_ context.Context, group string) error {
 // writes, so this is allowed to be slow.
 func daemonSchedulerAlgo(_ context.Context, repoPath string) error {
 	// ADR-0016 flip-day (#808): graph.fb is always written by default now.
-	err := Index(repoPath, "", "", nil, false, false)
+	// #1576: tag with the registered CONFIG slug when this path is known to a
+	// group, so a watcher-triggered re-index keeps doc.Repo aligned with the
+	// dashboard's node slugs and the cross-repo link endpoints. An empty
+	// repoTag would fall back to the dir basename and diverge from a slugified
+	// config slug (e.g. upvate_core vs upvate-core), dropping cross-repo edges.
+	err := Index(repoPath, "", configSlugForPath(repoPath), nil, false, false)
 	invalidateAfterIndex(repoPath)
 	return err
+}
+
+// configSlugForPath returns the registered config slug for repoPath by
+// scanning all group configs, or "" when the path is not registered (in which
+// case Index falls back to the directory basename). Paths are compared after
+// filepath.Clean so trailing-slash / relative differences do not defeat the
+// match.
+func configSlugForPath(repoPath string) string {
+	want := filepath.Clean(repoPath)
+	groups, err := registry.Groups()
+	if err != nil {
+		return ""
+	}
+	for _, g := range groups {
+		cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+		if err != nil {
+			continue
+		}
+		for _, r := range cfg.Repos {
+			if filepath.Clean(r.Path) == want {
+				return r.Slug
+			}
+		}
+	}
+	return ""
 }
 
 // daemonIndexFunc is the IndexFunc handed to daemon.Run. It bridges the
@@ -395,7 +425,13 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 			opts = append(opts,
 				WithPublisher(daemonProgressBroker),
 				WithProgressSlugs(args.Group, w.r.Slug))
-			indexErr := rebuildIndexFunc(w.r.Path, "", "", nil, false, false, opts...)
+			// #1576: tag the graph with the CONFIG slug (not the on-disk
+			// directory basename) so doc.Repo matches the slug the dashboard
+			// keys nodes by and the slug the cross-repo link pass emits as the
+			// link endpoint prefix. When the wizard slugifies a repo name
+			// (e.g. upvate_core → upvate-core) an empty repoTag would fall back
+			// to the dir basename and diverge, dropping every cross-repo edge.
+			indexErr := rebuildIndexFunc(w.r.Path, "", w.r.Slug, nil, false, false, opts...)
 			results[i] = repoResult{
 				path: w.r.Path,
 				slug: w.r.Slug,
@@ -427,7 +463,8 @@ func daemonRebuildFunc(args proto.RebuildArgs) ([]string, string, error) {
 				opts = append(opts,
 					WithPublisher(daemonProgressBroker),
 					WithProgressSlugs(args.Group, rw.r.Slug))
-				indexErr := rebuildIndexFunc(rw.r.Path, "", "", nil, false, false, opts...)
+				// #1576: tag with the CONFIG slug — see serial path above.
+				indexErr := rebuildIndexFunc(rw.r.Path, "", rw.r.Slug, nil, false, false, opts...)
 				results[idx] = repoResult{
 					path: rw.r.Path,
 					slug: rw.r.Slug,

--- a/internal/dashboard/v2_graph_xrepo_test.go
+++ b/internal/dashboard/v2_graph_xrepo_test.go
@@ -1,0 +1,98 @@
+package dashboard
+
+// v2_graph_xrepo_test.go — regression coverage for #1576.
+//
+// #1576: the served multi-repo graph showed ZERO cross-repo edges. Root cause
+// was a slug divergence: the dashboard keys graph NODES by the registry config
+// slug (rp.Slug, e.g. "upvate-core") while cross-repo LINK endpoints are
+// "<repo>::<id>" where <repo> is doc.Repo — the value stamped at index time.
+// The daemon rebuild indexed each repo with an EMPTY repoTag, so doc.Repo fell
+// back to the on-disk directory basename ("upvate_core", with an underscore).
+// When the wizard slugified the config slug ("upvate_core" -> "upvate-core")
+// the two no longer matched, so buildV2Graph's `visible[l.Source] &&
+// visible[l.Target]` guard dropped every cross-repo edge.
+//
+// These tests pin the serving-layer invariant: a cross-repo link whose
+// endpoint slugs match the configured repo slugs is emitted as an edge; a link
+// whose endpoint slugs DIVERGE from the configured slugs is the bug condition
+// and produces no edge. The production fix makes the rebuild stamp doc.Repo
+// with the config slug so the matching case is what actually occurs on disk.
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// twoRepoGroup builds a DashGroup with two single-entity repos under the given
+// config slugs, plus one cross-repo link using the supplied endpoint slugs.
+func twoRepoGroup(cfgSlugA, cfgSlugB, linkSrcSlug, linkDstSlug string) *DashGroup {
+	docA := &graph.Document{
+		Repo:     cfgSlugA,
+		Entities: []graph.Entity{{ID: "aaaa000000000000", Name: "fetchThing", Kind: "Operation", SourceFile: "client.ts"}},
+	}
+	docB := &graph.Document{
+		Repo:     cfgSlugB,
+		Entities: []graph.Entity{{ID: "bbbb000000000000", Name: "ThingRoute", Kind: "Operation", SourceFile: "routes.py"}},
+	}
+	return &DashGroup{
+		Name: "g",
+		Repos: map[string]*DashRepo{
+			cfgSlugA: {Slug: cfgSlugA, Doc: docA},
+			cfgSlugB: {Slug: cfgSlugB, Doc: docB},
+		},
+		Links: []CrossRepoLink{{
+			Source: linkSrcSlug + "::aaaa000000000000",
+			Target: linkDstSlug + "::bbbb000000000000",
+			Kind:   "calls",
+			Method: "http",
+		}},
+	}
+}
+
+func countCrossRepoEdges(resp v2GraphResponse) int {
+	n := 0
+	for _, e := range resp.Edges {
+		sr := repoOfPrefixed(e.Source)
+		tr := repoOfPrefixed(e.Target)
+		if sr != tr {
+			n++
+		}
+	}
+	return n
+}
+
+func repoOfPrefixed(id string) string {
+	for i := 0; i+1 < len(id); i++ {
+		if id[i] == ':' && id[i+1] == ':' {
+			return id[:i]
+		}
+	}
+	return id
+}
+
+// TestBuildV2Graph_CrossRepoEdge_SlugsMatch is the post-fix invariant: when the
+// link endpoint slugs equal the configured repo slugs, the cross-repo edge is
+// served. This is the shape the fixed rebuild produces (doc.Repo == config slug).
+func TestBuildV2Graph_CrossRepoEdge_SlugsMatch(t *testing.T) {
+	var s Server
+	grp := twoRepoGroup("upvate-core-frontend", "upvate-core", "upvate-core-frontend", "upvate-core")
+	resp := s.buildV2Graph(sortedRepos(grp), grp, "", false, false)
+	if got := countCrossRepoEdges(resp); got != 1 {
+		t.Fatalf("cross-repo edges = %d; want 1 (slugs match, edge must be served) — #1576", got)
+	}
+}
+
+// TestBuildV2Graph_CrossRepoEdge_SlugMismatchDrops reproduces the #1576 bug
+// condition: link endpoints use the dir-basename slug (underscores) while the
+// config slug is slugified (dashes). The mismatch drops the edge — which is
+// exactly what the production fix prevents by stamping doc.Repo with the
+// config slug at index time.
+func TestBuildV2Graph_CrossRepoEdge_SlugMismatchDrops(t *testing.T) {
+	var s Server
+	grp := twoRepoGroup("upvate-core-frontend", "upvate-core", "upvate_core_frontend", "upvate_core")
+	resp := s.buildV2Graph(sortedRepos(grp), grp, "", false, false)
+	if got := countCrossRepoEdges(resp); got != 0 {
+		t.Fatalf("cross-repo edges = %d; want 0 for the divergent-slug bug condition — guards the #1576 contract", got)
+	}
+}


### PR DESCRIPTION
## What
Restores cross-repo edges on real multi-repo groups. Rebuilds now stamp each repo's graph identity (`doc.Repo`) with the **registry config slug** instead of letting it fall back to the on-disk directory basename.

## Why (root cause + when it regressed)
The served graph showed **zero** cross-repo edges on `upvate` and `polyglot-platform` — repos rendered as disconnected islands.

Two keying schemes diverged:
- The dashboard keys graph **nodes** by the config slug (`rp.Slug`), e.g. `upvate-core`.
- Cross-repo **link** endpoints are `"<repo>::<id>"` where `<repo>` is `doc.Repo` — the value stamped at index time.

`daemonRebuildFunc` indexed each repo with an **empty repoTag**, so `doc.Repo` fell back to `filepath.Base(repoPath)` = the directory basename (`upvate_core`, underscore). The webui-v2 create-group wizard (#1517/#1526/#1546) **slugifies** repo names (`upvate_core` → `upvate-core`, `_`→`-`), so config slug ≠ indexed `doc.Repo`. `buildV2Graph`'s `visible[l.Source] && visible[l.Target]` guard then dropped every cross-repo edge.

This regressed when multi-repo groups started being created via the slugifying wizard. Pre-wizard CLI-installed groups were immune (config slug == dir name) — hence "worked before". The link **passes** were never broken: the `xrepo-verify` harness produced 222 cross-repo HTTP links on upvate.

## How
- Pass `w.r.Slug` as `repoTag` in both the serial and parallel rebuild paths in `daemonRebuildFunc`.
- Add `configSlugForPath` and use it in `daemonSchedulerAlgo` so watcher-triggered re-indexes also stay aligned.

## Testing
- `go build` / `go vet` clean. `internal/links` + `internal/dashboard` graph tests pass. (Two pre-existing `internal/dashboard` enrichment-writeback failures — `TestWriteback_success`, `TestYamlScalar` — also fail on clean `origin/main`; unrelated.)
- New serving-layer regression tests (`v2_graph_xrepo_test.go`): matched slugs emit the edge; divergent-slug bug condition drops it.

## xrepo-verify before/after (upvate, isolated daemon — NOT live :47274)
| metric | before | after |
| --- | --- | --- |
| xrepo-verify cross-repo HTTP links | 222 (186 fe→core, 36 mobile→core) | 222 |
| links-file slugs | `upvate_core` / `upvate_core_frontend` (underscore) | `upvate-core` / `upvate-core-frontend` (config slug) |
| **served graph cross-repo edges** | **0** | **381** (fe→core 209, mobile→core 45) |

Spot-checked a real edge: frontend `src/stores/permits/permitsService.js` POST `/permits/scan-ips-cart` → core `core/routers.py`.

## Risk
Low. Behavior change is confined to the repoTag passed at rebuild time; node IDs now match link endpoints. Old graphs are corrected on the next rebuild.

Fixes #1576

🤖 Generated with [Claude Code](https://claude.com/claude-code)