### PR TITLE
fix(graph): lower node base-size floor + auto-scale on dense graphs, dim links on hover (Fixes #1580)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -45,12 +45,14 @@ import {
   linkPalette,
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout } from "@/lib/graph-layout-cache";
-import type {
-  ColorMode,
-  GroupByMode,
-  SimulationConfig,
-  NodeSizingConfig,
-  RenderConfig,
+import {
+  baseSizeForCount,
+  DEFAULT_NODE_SIZING,
+  type ColorMode,
+  type GroupByMode,
+  type SimulationConfig,
+  type NodeSizingConfig,
+  type RenderConfig,
 } from "@/store/use-graph-store";
 
 const SPACE_SIZE = 32768;
@@ -356,6 +358,17 @@ function GraphCanvasInner(
     for (const n of nodes) if ((n.pageRank ?? 0) > maxPR) maxPR = n.pageRank ?? 0;
     if (maxPR === 0) maxPR = 1;
 
+    // Fix #1580: AUTO-SCALE the base size DOWN as the graph grows. The knob's
+    // value is tuned for a ~1.5k-node reference graph; on a ≈19k-node graph that
+    // base produces overlapping colored blobs when zoomed out. We scale the
+    // EFFECTIVE base inversely with sqrt(nodeCount) so a huge graph renders as
+    // fine points out of the box. The knob still works: we scale it by the same
+    // count-derived ratio as the default, so turning the slider down further
+    // shrinks points proportionally (and it now reaches single digits).
+    const countScale =
+      baseSizeForCount(count) / DEFAULT_NODE_SIZING.baseSize; // ≤1, →small for big graphs
+    const effectiveBase = Math.max(1, nodeSizing.baseSize * countScale);
+
     const grouping = groupBy !== "none";
     const groupCount = new Map<string, number>();
     for (const n of nodes) {
@@ -395,8 +408,8 @@ function GraphCanvasInner(
       // hard-capped at maxMultiplier × base so high-degree hubs never bloom into
       // overlapping blobs. (Fix #1532-4)
       const raw =
-        nodeSizing.baseSize + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale;
-      sizes[i] = Math.min(raw, nodeSizing.baseSize * nodeSizing.maxMultiplier);
+        effectiveBase + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale * countScale;
+      sizes[i] = Math.min(raw, effectiveBase * nodeSizing.maxMultiplier);
 
       const gkey = groupKeyFor(n, groupBy);
       const center = grouping ? groupCenters.get(gkey) : undefined;
@@ -1115,18 +1128,31 @@ function GraphCanvasInner(
       const sel = new Set<number>([hovIdx]);
       for (const nb of neighborIdx.get(hovIdx) ?? []) sel.add(nb);
       g.selectPointsByIndices(Array.from(sel));
-      // Dim the rest hard so the neighborhood reads as a spotlight (but still
-      // faintly visible for context).
-      g.setConfig({ pointGreyoutOpacity: isDark ? 0.08 : 0.1 });
+      // Fix #1567-3: dim non-neighbor NODES hard so the neighborhood reads as a
+      // spotlight (still faintly visible for context).
+      // Fix #1580: also FADE the non-neighbor LINKS to near-zero. cosmos.gl keeps a
+      // link bright only when BOTH endpoints are selected, and greys every other
+      // link to linkGreyoutOpacity. The default greyout (linkOpacity*0.5) left the
+      // whole link mesh visible — the dimmed graph looked like a skeleton of
+      // threads. Drop linkGreyoutOpacity to ~0 so only the hovered node + its
+      // direct neighbors AND the links AMONG them stay bright; everything else
+      // recedes, cleanly isolating the neighborhood. Restored on un-hover below.
+      g.setConfig({
+        pointGreyoutOpacity: isDark ? 0.08 : 0.1,
+        linkGreyoutOpacity: 0,
+      });
       g.render();
       return;
     }
 
+    // Fix #1580: not hovering → restore the default link greyout so the
+    // repo/community selection (and the un-hovered full graph) shows links again.
+    const restoredLinkGreyout = render.linkOpacity * 0.5;
     const repoActive = activeRepos != null;
     const communityActive = focusedCommunityId != null;
     if (!repoActive && !communityActive) {
       g.selectPointsByIndices(null);
-      g.setConfig({ pointGreyoutOpacity: 0.15 });
+      g.setConfig({ pointGreyoutOpacity: 0.15, linkGreyoutOpacity: restoredLinkGreyout });
       g.render();
       return;
     }
@@ -1138,9 +1164,21 @@ function GraphCanvasInner(
       })
       .filter((i) => i !== -1);
     g.selectPointsByIndices(effective);
-    g.setConfig({ pointGreyoutOpacity: repoActive ? 0 : 0.18 });
+    g.setConfig({
+      pointGreyoutOpacity: repoActive ? 0 : 0.18,
+      linkGreyoutOpacity: restoredLinkGreyout,
+    });
     g.render();
-  }, [nodes, activeRepos, focusedCommunityId, hoveredNodeId, idToIdx, neighborIdx, isDark]);
+  }, [
+    nodes,
+    activeRepos,
+    focusedCommunityId,
+    hoveredNodeId,
+    idToIdx,
+    neighborIdx,
+    isDark,
+    render.linkOpacity,
+  ]);
 
   useEffect(() => {
     applySelection();

--- a/webui-v2/src/components/graph/tuning-panels.tsx
+++ b/webui-v2/src/components/graph/tuning-panels.tsx
@@ -31,6 +31,8 @@ import {
   DEFAULT_SIMULATION,
   DEFAULT_NODE_SIZING,
   DEFAULT_RENDER,
+  NODE_BASE_SIZE_MIN,
+  NODE_BASE_SIZE_MAX,
 } from "@/store/use-graph-store";
 import { Button } from "@/components/ui";
 
@@ -233,9 +235,9 @@ export function TuningPanels() {
         <Slider
           label="Base size"
           value={nodeSizing.baseSize}
-          min={40}
-          max={320}
-          step={10}
+          min={NODE_BASE_SIZE_MIN}
+          max={NODE_BASE_SIZE_MAX}
+          step={2}
           onChange={(v) => setNodeSizing({ baseSize: v })}
         />
         <Slider

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -83,10 +83,36 @@ export const DEFAULT_NODE_SIZING: NodeSizingConfig = {
   // Fix #1532-4: out-of-box defaults must not produce overlapping "blobs".
   // Lower base + gentler degree scale + a tight max multiplier so a high-degree
   // hub stays at most ~1.8× the base size (was 3× of a much larger base).
+  //
+  // Fix #1580: this is the REFERENCE base size for a small/mid graph. On a large
+  // (≈19k-node) graph that fixed 90 is far too big — nodes overlap into colored
+  // blobs when zoomed out. The graph-canvas now AUTO-SCALES this down inversely
+  // with sqrt(nodeCount) (see baseSizeForCount), so the user-facing default knob
+  // can stay readable on a small graph while a huge graph renders as fine points.
   baseSize: 90,
   degreeScale: 18,
   maxMultiplier: 1.8,
 };
+
+// Fix #1580: the base-size slider/clamp floor. Lowered from 40 to 4 so a very
+// dense (≈19k-node) graph can be tuned down to fine points instead of blobs.
+export const NODE_BASE_SIZE_MIN = 4;
+export const NODE_BASE_SIZE_MAX = 320;
+
+/**
+ * Fix #1580: node-count-aware DEFAULT base size. A 19k-node graph needs a much
+ * smaller base than a 200-node one, so scale the reference default DOWN inversely
+ * with sqrt(nodeCount), normalized to a ~1.5k-node reference graph, and floor it
+ * at NODE_BASE_SIZE_MIN. This is applied in graph-canvas to the EFFECTIVE base
+ * size whenever the user hasn't overridden the knob, so a freshly-loaded huge
+ * graph renders as points, not blobs, with no manual tuning.
+ */
+export function baseSizeForCount(count: number, reference = DEFAULT_NODE_SIZING.baseSize): number {
+  if (!Number.isFinite(count) || count <= 0) return reference;
+  const REF_NODES = 1500; // graph size the reference baseSize was tuned for
+  const scaled = reference * Math.sqrt(REF_NODES / count);
+  return Math.max(NODE_BASE_SIZE_MIN, Math.min(reference, scaled));
+}
 
 export const DEFAULT_RENDER: RenderConfig = {
   pointOpacity: 0.92,
@@ -125,7 +151,9 @@ const ALL_EDGE_KINDS: EdgeKind[] = [
 // the stale stored tuning and adopt the new code defaults. Bump this whenever a
 // default in DEFAULT_SIMULATION / DEFAULT_NODE_SIZING / DEFAULT_RENDER changes so
 // the change actually lands on next load with no manual Reset.
-const DEFAULTS_VERSION = 2;
+// Fix #1580: bump so the lowered base-size floor + auto-scale defaults reach
+// users who already have a stored sizing blob (e.g. baseSize 90 from v2).
+const DEFAULTS_VERSION = 3;
 const VERSION_KEY = "ag.v2.graph.defaultsVersion";
 
 function readStoredVersion(): number {
@@ -326,6 +354,14 @@ export const useGraphStore = create<GraphState>((set) => ({
   setNodeSizing: (patch) =>
     set((s) => {
       const nodeSizing = { ...s.nodeSizing, ...patch };
+      // Fix #1580: clamp baseSize to the lowered floor so the knob can go to
+      // single digits (fine points on a dense graph) but never below 4 / above max.
+      if (patch.baseSize !== undefined) {
+        nodeSizing.baseSize = Math.max(
+          NODE_BASE_SIZE_MIN,
+          Math.min(NODE_BASE_SIZE_MAX, nodeSizing.baseSize),
+        );
+      }
       persist("ag.v2.graph.sizing", nodeSizing);
       return { nodeSizing };
     }),


### PR DESCRIPTION
## What

WebUI-v2 graph screen, two fixes on top of the center-filled layout + hover-spotlight (#1567/#1569/#1575), verified against the real **upvate** graph (19,613 nodes) in both themes.

## Why

On the 19k-node upvate graph the nodes overlapped into solid colored **blobs** when zoomed out (the base-size knob floored at 40 and the fixed default of 90 was far too big), and the hover spotlight greyed non-neighbor **nodes** but left every **link** bright — so the dimmed graph read as a skeleton of link threads rather than an isolated neighborhood.

## How

**1. Base-size floor + count-aware auto-scale (`use-graph-store.ts`, `tuning-panels.tsx`, `graph-canvas.tsx`)**
- Slider + store clamp floor lowered `40 → 4` (`NODE_BASE_SIZE_MIN`), step `10 → 2`, so the knob reaches single digits.
- New `baseSizeForCount(count)` scales the reference base **down** inversely with `sqrt(nodeCount)` (normalized to a ~1.5k-node reference, floored at 4). `graph-canvas` applies this `countScale` to the effective base (and the degree term), so a 19k graph renders as fine points out of the box; the knob still works proportionally.
- `maxMultiplier` blob-cap preserved (now relative to the scaled base). `scalePointsOnZoom` (already on) shrinks points when zoomed out.
- `DEFAULTS_VERSION` bumped `2 → 3` so the lowered floor reaches users with a stored sizing blob.

**2. Hover dims LINKS too (`graph-canvas.tsx`)**
- In `applySelection`, on node hover also set `linkGreyoutOpacity: 0` (was `linkOpacity*0.5` mesh). cosmos keeps a link bright only when both endpoints are selected, so only the hovered node + direct neighbors AND the links among them stay bright; everything else recedes.
- Restored to `linkOpacity*0.5` on un-hover and on the repo/community-selection paths.

## Testing

- `npm run build` + `npm run lint` (tsc --noEmit) clean.
- Isolated dev server (`AG_DEV_PORT=47286`) proxied read-only to the live daemon API; Playwright on the real upvate graph at `lod=high` (19,613 nodes).
  - Zoomed-out 19k graph renders as fine points, **no blobs**, at default base 90; base-size knob reaches **4** (verified `min=4` on the range input) → wispy single points.
  - Hover any node → engine reports `linkGreyoutOpacity:0` + `pointGreyoutOpacity:0.08`; both non-neighbor **nodes and links** dim, neighborhood isolated. Un-hover restores `linkGreyoutOpacity:0.3`.
  - Verified in **light and dark** themes.
- Live `:47274` not touched (read-only API proxy only).

## Risk / Rollout

- Scoped to 3 files; **zero diff** to `dashboard/` and no changes to flows/paths/topology/nav.
- The `DEFAULTS_VERSION` bump discards stale stored graph tuning once on next load (existing migration mechanism) so the new floor/scale lands without a manual Reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)