### PR TITLE
fix(graph): merge cross-repo links into served v2 graph (Fixes #1582)

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -382,11 +382,72 @@ func (c *GraphCache) loadGroup(groupName string) (*DashGroup, error) {
 	lf := defaultLinksFile(groupName)
 	if data, err := os.ReadFile(lf); err == nil {
 		if links, err2 := readCrossRepoLinks(data); err2 == nil {
-			grp.Links = links
+			grp.Links = normalizeLinkEndpoints(links, grp.Repos)
 		}
 	}
 
 	return grp, nil
+}
+
+// normalizeLinkEndpoints rewrites the "<repo-slug>::<entity-id>" endpoints of
+// cross-repo links so each one matches the canonical prefixed node ID used by
+// the served graph (built with dashPrefixedID(rp.Slug, entity.ID)). Without
+// this rewrite the merge guard `visible[l.Source] && visible[l.Target]` in
+// buildV2Graph / serveGraphDense never matches and every cross-repo edge is
+// silently dropped from the served graph — the #1582 symptom (0 of 37,104
+// served edges were cross-repo).
+//
+// The repo-slug PREFIX written by the link pass diverges from the dashboard
+// repo slugs in (at least) two ways observed in the corpus:
+//
+//   - underscore vs dash:   "upvate_core"  vs  "upvate-core"
+//   - short name vs full:   "catalog"      vs  "polyglot-platform-services-catalog"
+//
+// Because the <entity-id> suffix is globally unique within a group (verified:
+// 0 collisions across upvate's 19,613 and polyglot-platform's 1,316 nodes),
+// the most reliable resolution is by that suffix: we index every entity ID ->
+// its canonical prefixed node ID and rewrite each endpoint to the canonical
+// form of the entity it points at. Endpoints whose entity ID is unknown (or
+// whose suffix collides — a defensive guard) are left untouched, so the merge
+// guard drops them exactly as before.
+func normalizeLinkEndpoints(links []CrossRepoLink, repos map[string]*DashRepo) []CrossRepoLink {
+	if len(repos) == 0 || len(links) == 0 {
+		return links
+	}
+	// entity-ID suffix -> canonical prefixed node ID. Suffixes seen more than
+	// once are recorded as ambiguous and never used for rewriting.
+	canonical := make(map[string]string)
+	ambiguous := make(map[string]bool)
+	for _, rp := range repos {
+		if rp == nil || rp.Doc == nil {
+			continue
+		}
+		for i := range rp.Doc.Entities {
+			id := rp.Doc.Entities[i].ID
+			if _, seen := canonical[id]; seen {
+				ambiguous[id] = true
+				continue
+			}
+			canonical[id] = dashPrefixedID(rp.Slug, id)
+		}
+	}
+	rewrite := func(endpoint string) string {
+		_, local := dashSplitPrefixed(endpoint)
+		if local == "" || ambiguous[local] {
+			return endpoint
+		}
+		if cid, ok := canonical[local]; ok {
+			return cid
+		}
+		return endpoint // unknown entity; leave as-is (merge guard drops it)
+	}
+	out := make([]CrossRepoLink, len(links))
+	for i, l := range links {
+		l.Source = rewrite(l.Source)
+		l.Target = rewrite(l.Target)
+		out[i] = l
+	}
+	return out
 }
 
 // attachAlgorithmResults re-derives community, pagerank, and god-node data

--- a/internal/dashboard/v2_graph_xrepo_test.go
+++ b/internal/dashboard/v2_graph_xrepo_test.go
@@ -96,3 +96,74 @@ func TestBuildV2Graph_CrossRepoEdge_SlugMismatchDrops(t *testing.T) {
 		t.Fatalf("cross-repo edges = %d; want 0 for the divergent-slug bug condition — guards the #1576 contract", got)
 	}
 }
+
+// TestNormalizeLinkEndpoints_UnderscoreSlugRewrite is the #1582 fix: the link
+// pass still writes <group>-links.json with underscore-normalised repo slugs
+// ("upvate_core_frontend", "upvate_core") even after #1576/#1579, while the
+// dashboard repos / served node IDs use the dash form. normalizeLinkEndpoints
+// (called from loadGroup at link-load time) rewrites the slug prefix to the
+// canonical config slug, so buildV2Graph's visibility guard then matches and
+// the cross-repo edge IS served. Without the rewrite the edge is silently
+// dropped (the symptom: 0 of 37,104 served edges were cross-repo).
+func TestNormalizeLinkEndpoints_UnderscoreSlugRewrite(t *testing.T) {
+	grp := twoRepoGroup("upvate-core-frontend", "upvate-core", "upvate_core_frontend", "upvate_core")
+	grp.Links = normalizeLinkEndpoints(grp.Links, grp.Repos)
+
+	if got := grp.Links[0].Source; got != "upvate-core-frontend::aaaa000000000000" {
+		t.Fatalf("Source not normalised: got %q", got)
+	}
+	if got := grp.Links[0].Target; got != "upvate-core::bbbb000000000000" {
+		t.Fatalf("Target not normalised: got %q", got)
+	}
+
+	var s Server
+	resp := s.buildV2Graph(sortedRepos(grp), grp, "", false, false)
+	if got := countCrossRepoEdges(resp); got != 1 {
+		t.Fatalf("cross-repo edges = %d; want 1 after slug normalisation — #1582", got)
+	}
+}
+
+// TestNormalizeLinkEndpoints_UnknownRepoLeftAsIs verifies an endpoint whose
+// slug resolves to no known repo is left untouched (and therefore dropped by
+// the merge guard, the prior behaviour) rather than corrupted.
+func TestNormalizeLinkEndpoints_UnknownEntityLeftAsIs(t *testing.T) {
+	repos := map[string]*DashRepo{"upvate-core": {
+		Slug: "upvate-core",
+		Doc:  &graph.Document{Repo: "upvate-core", Entities: []graph.Entity{{ID: "yyyy"}}},
+	}}
+	// "x" is not a known entity ID; "y" is (under upvate-core), but the link
+	// uses the divergent "upvate_core" prefix — suffix resolution rewrites it.
+	links := []CrossRepoLink{{Source: "ghost_repo::x", Target: "upvate_core::yyyy", Kind: "calls"}}
+	out := normalizeLinkEndpoints(links, repos)
+	if out[0].Source != "ghost_repo::x" {
+		t.Fatalf("unknown-entity Source mutated: %q", out[0].Source)
+	}
+	if out[0].Target != "upvate-core::yyyy" {
+		t.Fatalf("known-entity Target not normalised: %q", out[0].Target)
+	}
+}
+
+// TestNormalizeLinkEndpoints_ShortSlugRewrite covers the polyglot-platform
+// shape: the link slug is a short service name ("catalog") while the dashboard
+// repo slug is the full monorepo path. Suffix-based resolution still rewrites
+// the endpoint to the canonical node ID.
+func TestNormalizeLinkEndpoints_ShortSlugRewrite(t *testing.T) {
+	repos := map[string]*DashRepo{
+		"polyglot-platform-services-catalog": {
+			Slug: "polyglot-platform-services-catalog",
+			Doc:  &graph.Document{Repo: "polyglot-platform-services-catalog", Entities: []graph.Entity{{ID: "cccc"}}},
+		},
+		"polyglot-platform-frontend-admin": {
+			Slug: "polyglot-platform-frontend-admin",
+			Doc:  &graph.Document{Repo: "polyglot-platform-frontend-admin", Entities: []graph.Entity{{ID: "aaaa"}}},
+		},
+	}
+	links := []CrossRepoLink{{Source: "admin::aaaa", Target: "catalog::cccc", Kind: "calls"}}
+	out := normalizeLinkEndpoints(links, repos)
+	if out[0].Source != "polyglot-platform-frontend-admin::aaaa" {
+		t.Fatalf("short-slug Source not normalised: %q", out[0].Source)
+	}
+	if out[0].Target != "polyglot-platform-services-catalog::cccc" {
+		t.Fatalf("short-slug Target not normalised: %q", out[0].Target)
+	}
+}


### PR DESCRIPTION
## Summary
The served `/api/v2/graph/{group}` showed **0 cross-repo edges** despite the link pass extracting hundreds of cross-repo links into `~/.archigraph/groups/<group>-links.json` (397 for upvate, 243 for polyglot-platform). The links were loaded into `grp.Links` but their endpoints never matched the served node IDs, so `buildV2Graph`'s `visible[l.Source] && visible[l.Target]` guard silently dropped every one.

## Root cause
The merge logic was present (v2_graph.go:298, and the v1 twin handlers_graph.go:412) — the bug was a **slug-prefix divergence** between link endpoints and served node IDs (`dashPrefixedID(rp.Slug, entity.ID)`):

- **underscore vs dash**: links wrote `upvate_core` / `upvate_core_frontend`; nodes use `upvate-core` / `upvate-core-frontend`.
- **short name vs full monorepo path** (polyglot): links wrote `catalog` / `admin`; nodes use `polyglot-platform-services-catalog` / `polyglot-platform-frontend-admin`.

#1576/#1579 fixed the slug at index time for some endpoints but the on-disk links artifact still carries divergent prefixes. The `<entity-id>` suffix after `::`, however, is globally unique within a group (verified: 0 collisions across upvate's 19,613 and polyglot's 1,316 nodes).

## What changed
- `internal/dashboard/graphstate.go`: new `normalizeLinkEndpoints`, called from `loadGroup` right after the links file is read. It indexes every entity ID → its canonical prefixed node ID and rewrites each link endpoint to that canonical form. Unknown or ambiguous-suffix endpoints are left untouched (merge guard drops them, as before). Because it normalises `grp.Links` at load, **both** the v1 dense graph and the v2 graph are fixed with no change to either merge site. Edges keep their semantic relation kind (`calls`/`imports`/`shared_label`) — the frontend already styles cross-repo edges by comparing node repos, not edge kind, so no kind rewrite was needed.
- `internal/dashboard/v2_graph_xrepo_test.go`: added 3 tests — underscore-slug rewrite, short-slug (polyglot) rewrite, and unknown-entity-left-as-is.

## Testing
- `go build ./...` clean (pre-existing `dist`/`fixtures` infra errors unrelated).
- `go vet ./internal/dashboard/...` clean.
- New + existing xrepo tests pass. The only two failing dashboard tests (`TestWriteback_success`, `TestYamlScalar`) were confirmed **pre-existing on clean origin/main**, unrelated to this change.
- Isolated daemon (port 47932, never touched live :47274) against the real indexed data — served cross-repo edge counts **before → after**:
  - upvate `lod=full`: **0 → 376**; `lod=mid`: 0 → 10
  - polyglot-platform `lod=full`: **0 → 194**; `lod=mid`: 0 → 194
  - Spot-checked a real edge: `core-mobile::http:GET:/checklist-catalogs` (mobile, `checklist-catalogs.api.ts`) → `upvate-core::ChecklistCatalogViewSet.list` (Django, `core/views/checklist_viewset.py`).

## Risk
Low. Pure load-time normalisation of link endpoints; unresolvable links behave exactly as before (dropped). `dashboard/` and `webui-v2/` have zero diff.

Fixes #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)