### PR TITLE
fix(flows): WebUI v2 zoom buttons, list scroll, and floating step card (Fixes #1587)

### DIFF
--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -521,7 +521,7 @@ function ListRail({
 
   return (
     <aside
-      className="flex flex-col border-r border-border bg-bg-soft min-h-0 min-w-0"
+      className="flex flex-col h-full border-r border-border bg-bg-soft min-h-0 min-w-0"
       style={{ overflow: "hidden" }}
     >
       {/* Toolbar */}
@@ -799,7 +799,10 @@ function FlowDag({
   const viewportRef = useRef<HTMLDivElement>(null);
   const [zoom, setZoom] = useState(1);
   const [pan, setPan] = useState({ x: 0, y: 0 });
-  const dragRef = useRef<{ x: number; y: number; px: number; py: number; moved: boolean } | null>(null);
+  const dragRef = useRef<{
+    x: number; y: number; px: number; py: number;
+    moved: boolean; captured: boolean; pointerId: number;
+  } | null>(null);
   const [dragging, setDragging] = useState(false);
 
   const { positions, totalHeight, totalWidth, perLane } = useMemo(
@@ -878,37 +881,63 @@ function FlowDag({
   };
 
   // Drag-to-pan.
+  //
+  // CRITICAL: we must NOT call setPointerCapture on pointerdown. Capturing the
+  // pointer on the viewport retargets the subsequent `click` event to the
+  // viewport instead of the element actually under the cursor — which is why
+  // the zoom/fit buttons AND the step nodes were dead (#1554 regressed):
+  // their native onClick never fired because the click was stolen by the
+  // captured viewport. Instead we only capture once a real drag begins (after
+  // the movement threshold) so plain clicks dispatch normally to their target.
   const onPointerDown = (e: React.PointerEvent) => {
     if (e.button !== 0) return;
-    dragRef.current = { x: e.clientX, y: e.clientY, px: pan.x, py: pan.y, moved: false };
+    // Don't start a pan when the press lands on an interactive control
+    // (step node, zoom button, etc.) — let the click reach it.
+    const t = e.target as HTMLElement;
+    if (t?.closest?.("button, a, input, [data-no-pan]")) return;
+    dragRef.current = {
+      x: e.clientX, y: e.clientY, px: pan.x, py: pan.y,
+      moved: false, captured: false, pointerId: e.pointerId,
+    };
     setDragging(true);
-    (e.currentTarget as HTMLElement).setPointerCapture(e.pointerId);
   };
   const onPointerMove = (e: React.PointerEvent) => {
     const d = dragRef.current;
     if (!d) return;
     const dx = e.clientX - d.x;
     const dy = e.clientY - d.y;
-    if (!d.moved && Math.abs(dx) + Math.abs(dy) > 3) d.moved = true;
-    setPan({ x: d.px + dx, y: d.py + dy });
+    if (!d.moved && Math.abs(dx) + Math.abs(dy) > 3) {
+      d.moved = true;
+      // Capture only now that we're actually panning, so wheel/move stay
+      // tracked even if the cursor leaves the viewport mid-drag.
+      try {
+        (e.currentTarget as HTMLElement).setPointerCapture(d.pointerId);
+        d.captured = true;
+      } catch {
+        /* capture may be unavailable */
+      }
+    }
+    if (d.moved) setPan({ x: d.px + dx, y: d.py + dy });
   };
   const endDrag = (e: React.PointerEvent) => {
     const d = dragRef.current;
     if (d) {
-      // A click on empty canvas (no drag, target is not a step node) deselects
-      // the current step. Node buttons are <button> elements, so a click that
-      // did not land on/inside a button is an empty-canvas click.
+      // A click on empty canvas (no drag) deselects the current step. Because
+      // we never capture on a plain click, clicks on step nodes reach their
+      // own onClick; here we only handle the empty-canvas deselect.
       if (!d.moved && e.type === "pointerup") {
         const onNode = (e.target as HTMLElement)?.closest?.("button[data-step-node]");
         if (!onNode) onPickStep(null);
       }
+      if (d.captured) {
+        try {
+          (e.currentTarget as HTMLElement).releasePointerCapture(d.pointerId);
+        } catch {
+          /* pointer may already be released */
+        }
+      }
       dragRef.current = null;
       setDragging(false);
-      try {
-        (e.currentTarget as HTMLElement).releasePointerCapture(e.pointerId);
-      } catch {
-        /* pointer may already be released */
-      }
     }
   };
 
@@ -2081,12 +2110,17 @@ export default function FlowsScreen() {
         style={{
           display: "grid",
           gridTemplateColumns: showDetail ? "400px 1fr" : "400px 1fr",
+          // Constrain the single grid row to the workspace height. Without an
+          // explicit row track the implicit row is `auto` and grows to fit the
+          // (tall) flow list, so the inner overflow-y-auto never activates and
+          // the list can't scroll. minmax(0,1fr) lets children shrink + scroll.
+          gridTemplateRows: "minmax(0, 1fr)",
         }}
       >
         {/* List rail — always rendered (hidden on narrow when detail is open) */}
         <div
           className={cn(
-            "min-h-0 overflow-hidden",
+            "min-h-0 h-full overflow-hidden",
             showDetail ? "max-[1180px]:hidden" : "",
           )}
         >
@@ -2101,7 +2135,7 @@ export default function FlowsScreen() {
         </div>
 
         {/* Detail panel */}
-        <div className="min-h-0 overflow-hidden">
+        <div className="min-h-0 h-full overflow-hidden">
           <DetailPanel
             selection={selection}
             groupId={groupId}


### PR DESCRIPTION
## 1. Problem
WebUI v2 Flows (`webui-v2/src/routes/flows.tsx`) had three interaction failures that #1554 claimed to fix but which regressed/were incomplete in real use on the polyglot-platform flows:
1. **Zoom +/−/fit buttons did nothing** (mouse-wheel zoom worked).
2. **The left flow list could not scroll** to items below the fold.
3. **Clicking a step node showed no floating detail card** — selection never happened.

## 2. Root cause
- **Buttons + step card (one shared cause):** `onPointerDown` on the DAG viewport called `setPointerCapture` immediately. Per the Pointer Events spec, while an element has pointer capture the subsequent `click` is dispatched to the **capturing element** (the viewport), not the element actually under the cursor. So the zoom/fit `<button>`s and the step `<button data-step-node>`s never received their own `onClick` — they were dead. Wheel-zoom worked because it doesn't depend on `click`.
- **List scroll:** the workspace `display:grid` container defined only `gridTemplateColumns`; its implicit grid row was `auto`, so the row grew to the full height of the (very tall) flow list and the inner `overflow-y-auto` never had a bounded height to scroll against. The list rail also lacked an explicit height.

## 3. Fix
- Do **not** capture the pointer on `pointerdown`. Capture only once a real pan starts (after the 3px move threshold). Also bail out of pan-start when the press lands on a `button, a, input, [data-no-pan]` so plain clicks dispatch normally to their target. Zoom in/out/fit and step selection now fire on real clicks.
- Constrain the workspace grid to a single `gridTemplateRows: minmax(0, 1fr)` row and add `h-full` to the list-rail `<aside>` and both grid cells, so the inner `overflow-y-auto` activates and the full list scrolls.
- Step click selects the node and renders the floating `StepInspector` card over the canvas; close button and empty-canvas click both dismiss it (empty-canvas deselect handled in `endDrag` only for non-drag pointerups that didn't land on a node).

## 4. Files changed
- `webui-v2/src/routes/flows.tsx` (+50 / −16). `dashboard/` untouched (zero diff).

## 5. Verification (real pointer interactions)
Isolated standalone API (`archigraph dashboard serve --port 47291`, polyglot-platform group, **live :47274 never touched**) + Vite dev (`:47294`) + Playwright on `/g/polyglot-platform/flows`:
- `npm run build` clean; `tsc --noEmit` clean.
- **Zoom buttons:** read 57% (fit) → real click "Zoom in" → **68%** → real click "Zoom out" → **57%**; Fit clicked. Measurable change each time.
- **List scroll:** list scroller `clientHeight 658 < scrollHeight 9440`, `canScroll: true`, 142 rows. A below-the-fold flow (`GlController.postSale → JournalEntry.setMemo`, `beforeTop 950`, off-screen) became visible after scroll (`afterTop 541`, visible). 
- **Step card:** clicked step node #3 → node selected (border-accent, 1 selected) and floating card appeared with real info ("LedgerService.postSale", "Step 3 of 6", `LedgerService.java:22`, repo). Close button → card gone + selection cleared. Re-opened, then empty-canvas click → card gone + selection cleared.
- Only console error is a pre-existing favicon 404 (unrelated).

## 6. Risk / rollout
Low. Single-file frontend change scoped to the Flows DAG interactions. No API/schema changes, no graph/topology/paths touched, `dashboard/` zero diff. Behavior is additive (clicks now reach their targets); pan/wheel-zoom unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)