### PR TITLE
WebUI v2 Operations: memory over-budget alert + unresolved-references breakdown + plain-language Fidelity copy (Fixes #1588)

### DIFF
--- a/internal/dashboard/handlers_quality.go
+++ b/internal/dashboard/handlers_quality.go
@@ -58,8 +58,45 @@ type OrphanAuditReply struct {
 	Fidelity *float64 `json:"fidelity"`
 	// BugRatePct is the unresolved-import rate (0–100); fidelity = 100 − this.
 	BugRatePct float64 `json:"bug_rate_pct"`
+	// References is the unresolved-references breakdown — the real driver of
+	// Fidelity. It explains, in plain-language reason buckets, why a fraction of
+	// the import/reference edges could NOT be linked to a real target.
+	References UnresolvedReferences `json:"references"`
 	// Recommendations is the punch list from the audit engine.
 	Recommendations []RecommendationItem `json:"recommendations"`
+}
+
+// UnresolvedReferences is the Fidelity story: of all the import/reference edges
+// archigraph extracted, how many it resolved to a real target and — for the
+// rest — the reason it could not. This is the PRIMARY quality view because the
+// orphan audit reads "perfect" (0 orphans) on graphs whose Fidelity is held
+// down entirely by unresolved references.
+type UnresolvedReferences struct {
+	// Total is every import/reference edge considered.
+	Total int `json:"total"`
+	// Resolved is the count linked to a real target (hex id or ext-qualified).
+	Resolved int `json:"resolved"`
+	// Unresolved is Total − Resolved.
+	Unresolved int `json:"unresolved"`
+	// ResolvedRate is Resolved/Total (0–1); equals Fidelity as a ratio.
+	ResolvedRate float64 `json:"resolved_rate"`
+	// Reasons breaks the UNRESOLVED edges into plain-language buckets.
+	Reasons []UnresolvedReason `json:"reasons"`
+}
+
+// UnresolvedReason is one plain-language bucket of unresolved references.
+type UnresolvedReason struct {
+	// Reason is the machine key (external_library, unresolved_import, etc.).
+	Reason string `json:"reason"`
+	// Label is the human-readable name shown in the UI.
+	Label string `json:"label"`
+	// Description explains, for a non-technical user, what this bucket means.
+	Description string `json:"description"`
+	// Count is the number of unresolved edges in this bucket.
+	Count int `json:"count"`
+	// Pct is this bucket's share of the TOTAL edges (0–1), so the buckets plus
+	// the resolved share add up to 1.
+	Pct float64 `json:"pct"`
 }
 
 // OrphanTotals rolls up aggregate counts across the whole group.
@@ -246,6 +283,7 @@ func buildOrphanAuditReply(group string, repos []*audit.RepoReport) OrphanAuditR
 	kindOrphans := map[string]int{}
 	totalImports := 0
 	goodImports := 0
+	formatCounts := map[audit.ImportFormat]int{}
 
 	for _, rr := range repos {
 		if rr == nil {
@@ -257,6 +295,9 @@ func buildOrphanAuditReply(group string, repos []*audit.RepoReport) OrphanAuditR
 		totalImports += rr.ImportsTotal
 		goodImports += rr.ImportsToIDFormat[audit.ImportFormatHex] +
 			rr.ImportsToIDFormat[audit.ImportFormatExtQualified]
+		for f, c := range rr.ImportsToIDFormat {
+			formatCounts[f] += c
+		}
 
 		slug := filepath.Base(rr.Path)
 		rate := 0.0
@@ -326,7 +367,69 @@ func buildOrphanAuditReply(group string, repos []*audit.RepoReport) OrphanAuditR
 	fid := fidelityFromBugRate(bugPct)
 	reply.Fidelity = &fid
 
+	reply.References = buildUnresolvedReferences(totalImports, goodImports, formatCounts)
+
 	return reply
+}
+
+// buildUnresolvedReferences turns the raw import-format histogram into the
+// plain-language unresolved-references breakdown that drives Fidelity.
+//
+// Resolved = hex (linked to a real entity id) + ext_qualified (linked to a
+// named symbol in an external module). Everything else is unresolved, bucketed
+// by the reason archigraph could not pin it to a target:
+//
+//	ext_bare    → external_library  (a third-party package, no specific symbol)
+//	path_string → unresolved_import (a relative/absolute path the resolver did
+//	                                 not attach to an extracted file)
+//	other       → extraction_gap    (a bare name with no prefix — dynamic
+//	                                 dispatch, generated code, or a parser gap)
+func buildUnresolvedReferences(total, resolved int, formats map[audit.ImportFormat]int) UnresolvedReferences {
+	ur := UnresolvedReferences{
+		Total:      total,
+		Resolved:   resolved,
+		Unresolved: total - resolved,
+		Reasons:    []UnresolvedReason{},
+	}
+	if total > 0 {
+		ur.ResolvedRate = float64(resolved) / float64(total)
+	}
+
+	type spec struct {
+		format      audit.ImportFormat
+		reason      string
+		label       string
+		description string
+	}
+	specs := []spec{
+		{audit.ImportFormatExtBare, "external_library", "External library",
+			"Points at a third-party package archigraph does not index, so there is no target inside your code to link to."},
+		{audit.ImportFormatPathString, "unresolved_import", "Unresolved import",
+			"References a file by path that archigraph could not match to an extracted file — often a build alias, generated file, or a path outside the indexed repos."},
+		{audit.ImportFormatOther, "extraction_gap", "Dynamic or not-yet-extracted",
+			"A bare reference with no resolvable target — dynamically-loaded code, runtime dispatch, or a gap in extraction for that language."},
+	}
+	for _, sp := range specs {
+		c := formats[sp.format]
+		if c == 0 {
+			continue
+		}
+		p := 0.0
+		if total > 0 {
+			p = float64(c) / float64(total)
+		}
+		ur.Reasons = append(ur.Reasons, UnresolvedReason{
+			Reason:      sp.reason,
+			Label:       sp.label,
+			Description: sp.description,
+			Count:       c,
+			Pct:         p,
+		})
+	}
+	sort.Slice(ur.Reasons, func(i, j int) bool {
+		return ur.Reasons[i].Count > ur.Reasons[j].Count
+	})
+	return ur
 }
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/webui-v2/src/components/showcase/primitives-showcase.tsx
+++ b/webui-v2/src/components/showcase/primitives-showcase.tsx
@@ -120,7 +120,7 @@ export default function PrimitivesShowcase() {
             <TooltipContent>A token-styled Radix tooltip.</TooltipContent>
           </Tooltip>
           <span className="text-md text-text-2">
-            <InfoLabel label="Fidelity" hint="Group health, 0–100. High = good. Replaces legacy bug-rate." />
+            <InfoLabel label="Fidelity" hint="How complete archigraph's map of your code is — the percentage of your code's references it linked to a real target. Higher is better." />
           </span>
         </Section>
 

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1127,6 +1127,38 @@ export interface KindStat {
   orphan_rate: number;
 }
 
+/** One plain-language bucket of unresolved references. */
+export interface UnresolvedReason {
+  /** Machine key: external_library | unresolved_import | extraction_gap. */
+  reason: string;
+  /** Human-readable name shown in the UI. */
+  label: string;
+  /** Plain-language explanation of what this bucket means. */
+  description: string;
+  /** Number of unresolved edges in this bucket. */
+  count: number;
+  /** Share of the TOTAL edges (0–1). */
+  pct: number;
+}
+
+/**
+ * Unresolved-references breakdown — the real driver of Fidelity. Of every
+ * import/reference edge archigraph extracted, how many it linked to a real
+ * target and, for the rest, the reason it could not.
+ */
+export interface UnresolvedReferences {
+  /** Every import/reference edge considered. */
+  total: number;
+  /** Linked to a real target. */
+  resolved: number;
+  /** total − resolved. */
+  unresolved: number;
+  /** resolved/total (0–1); equals Fidelity as a ratio. */
+  resolved_rate: number;
+  /** The unresolved edges, bucketed by reason. */
+  reasons: UnresolvedReason[];
+}
+
 /** Recommendation item from orphan audit */
 export interface RecommendationItem {
   priority: number;
@@ -1145,12 +1177,14 @@ export interface OrphanAuditReply {
   total: OrphanAuditTotals;
   per_repo: RepoOrphanStats[];
   per_kind: KindStat[];
-  /** Composite graph-health score (0–100): orphans + bug-rate + recall. */
+  /** Composite graph-health score (0–100): orphans + unresolved refs + recall. */
   health_score: number;
-  /** Fidelity = 100 − bug_rate, as a 0–1 ratio (null when unknown). */
+  /** Fidelity = resolved-reference share, as a 0–1 ratio (null when unknown). */
   fidelity: number | null;
-  /** Unresolved-import rate (0–100); fidelity = 100 − this. */
+  /** @deprecated internal field; the unresolved-reference rate (0–100). */
   bug_rate_pct: number;
+  /** Unresolved-references breakdown — the real Fidelity story. */
+  references: UnresolvedReferences;
   recommendations: RecommendationItem[];
 }
 

--- a/webui-v2/src/routes/operations.tsx
+++ b/webui-v2/src/routes/operations.tsx
@@ -331,6 +331,27 @@ function DaemonStatusCard({
   const dot = STATUS_DOT[status.status] ?? "bg-text-4";
   const label = STATUS_LABEL[status.status] ?? status.status;
 
+  // Memory budget state. When RSS exceeds the configured budget the daemon is
+  // running over its intended footprint — surface a clear warning rather than a
+  // bare "987 / 500 MB" number that reads as fine.
+  const overBudget =
+    status.rss_budget_mb != null &&
+    status.rss_budget_mb > 0 &&
+    status.rss_mb > status.rss_budget_mb;
+  const memRatio =
+    status.rss_budget_mb && status.rss_budget_mb > 0
+      ? status.rss_mb / status.rss_budget_mb
+      : 0;
+  // Hard warning (red) once ~1.5× over; amber for anything above budget.
+  const memSeverity = overBudget ? (memRatio >= 1.5 ? "danger" : "warning") : null;
+  const memTooltip = overBudget
+    ? `Over memory budget — using ${status.rss_mb.toFixed(0)} MB against a ${status.rss_budget_mb!.toFixed(
+        0,
+      )} MB budget (${Math.round(memRatio * 100)}%). Consider restarting the daemon or indexing fewer repositories.`
+    : status.rss_budget_mb
+    ? `Within budget — ${status.rss_mb.toFixed(0)} MB of ${status.rss_budget_mb.toFixed(0)} MB.`
+    : undefined;
+
   return (
     <Card className="p-5">
       <div className="flex items-start justify-between gap-4">
@@ -366,15 +387,30 @@ function DaemonStatusCard({
               : `${status.rss_mb.toFixed(0)} MB`,
             mono: true,
             truncate: false,
+            memory: true,
           },
           { label: "Socket", value: status.socket_path ?? "—", mono: true, truncate: true },
           { label: "Dashboard URL", value: status.dashboard_url ?? "—", mono: true, truncate: true },
-        ].map(({ label, value, mono, truncate }) => (
+        ].map(({ label, value, mono, truncate, memory }) => (
           <div key={label}>
-            <dt className="text-xs text-text-3">{label}</dt>
+            <dt className="text-xs text-text-3 flex items-center gap-1.5">
+              {label}
+              {memory && memSeverity && (
+                <Badge tone={memSeverity} className="text-[10px] px-1.5 py-0" title={memTooltip}>
+                  <AlertTriangle size={9} className="mr-0.5" />
+                  Over budget
+                </Badge>
+              )}
+            </dt>
             <dd
-              className={cn("text-sm mt-0.5", mono && "font-mono", truncate && "truncate")}
-              title={value}
+              className={cn(
+                "text-sm mt-0.5",
+                mono && "font-mono",
+                truncate && "truncate",
+                memory && memSeverity === "danger" && "text-danger",
+                memory && memSeverity === "warning" && "text-warning",
+              )}
+              title={memory ? memTooltip ?? value : value}
             >
               {value}
             </dd>
@@ -1008,9 +1044,200 @@ function PatternsTab({ groupId }: { groupId: string }) {
 // ---------------------------------------------------------------------------
 
 const FIDELITY_TIP_OPS =
-  "Fidelity = 100 − bug-rate: the share of import/reference edges that resolve to a real target. This is the owner-defined primary quality number, shown the same way on the Home cards.";
+  "Fidelity — how complete archigraph's map of your code is. Whenever your code points at something (calls a function, imports a module, calls an API), archigraph links it to where that's defined. Fidelity is the percentage of those links it resolved. The rest point at things it couldn't locate yet — external libraries, dynamically-loaded code, or extraction gaps.";
 const HEALTH_TIP_OPS =
-  "Health is a composite score (0–100) that ALSO factors in orphan rate and recall miss — not just extraction correctness. It is computed only from a real audit run, so it can differ from Fidelity: a graph can extract correctly (high fidelity) yet still have many orphaned entities (lower health).";
+  "Health is a composite score (0–100) that ALSO factors in orphan rate and recall miss — not just how many references resolved. It is computed only from a real audit run, so it can differ from Fidelity: a graph can resolve most references (high fidelity) yet still have many orphaned entities (lower health).";
+
+// Honest banner shown above the Quality views: Fidelity measures extraction
+// completeness, which is a DIFFERENT axis from documentation coverage.
+function FidelityBanner() {
+  return (
+    <div className="flex items-start gap-2.5 rounded-lg border border-border-soft bg-surface-2 p-3 text-xs text-text-3">
+      <Info size={14} className="text-accent-strong shrink-0 mt-0.5" />
+      <p>
+        <span className="text-text-2 font-medium">Fidelity measures extraction completeness</span>{" "}
+        — the share of your code's references that archigraph linked to a real target. Running the
+        docs skill improves <span className="text-text-2">documentation</span> coverage, which is a
+        different axis and does not change Fidelity.
+      </p>
+    </div>
+  );
+}
+
+// PRIMARY quality view: the unresolved-references breakdown that actually
+// drives Fidelity. On graphs with zero orphans the orphan audit reads
+// "perfect" while Fidelity is held down entirely by these unresolved edges, so
+// this is the view that explains the number.
+function UnresolvedReferencesPane({ groupId }: { groupId: string }) {
+  const { data, isLoading } = useOrphanAudit(groupId);
+  const runAudit = useRunOrphanAudit(groupId);
+
+  const hasRun = !!data?.has_run;
+  const refs = data?.references;
+  const resolvedPct = refs && refs.total > 0 ? Math.round(refs.resolved_rate * 100) : null;
+  const resolvedColor =
+    resolvedPct == null
+      ? "text-text-3"
+      : resolvedPct >= 90
+      ? "text-success"
+      : resolvedPct >= 75
+      ? "text-warning"
+      : "text-danger";
+
+  const reasonColor = (i: number) =>
+    ["bg-danger", "bg-warning", "bg-accent-strong", "bg-info"][i % 4];
+
+  return (
+    <div className="space-y-5">
+      <FidelityBanner />
+
+      <div className="flex items-center justify-between">
+        {hasRun ? (
+          <p className="text-xs text-text-4">Last measured {relativeTime(data!.audited_at)}</p>
+        ) : (
+          <span />
+        )}
+        <Button
+          variant="primary"
+          size="sm"
+          onClick={() =>
+            runAudit.mutate(undefined, {
+              onSuccess: () => toast.success("Audit complete."),
+              onError: () => toast.error("Audit failed."),
+            })
+          }
+          disabled={runAudit.isPending}
+        >
+          {runAudit.isPending ? (
+            <>
+              <Loader2 size={12} className="animate-spin" />
+              Running…
+            </>
+          ) : (
+            <>
+              <Activity size={12} />
+              Run audit
+            </>
+          )}
+        </Button>
+      </div>
+
+      {isLoading ? (
+        <div className="space-y-3">
+          {[0, 1, 2].map((i) => (
+            <Skeleton key={i} h="h-16" className="rounded-lg" />
+          ))}
+        </div>
+      ) : !hasRun || !refs ? (
+        <div className="flex flex-col items-center justify-center py-16 text-center text-text-3">
+          <Activity size={28} className="text-text-4 mb-3" />
+          <p className="text-sm font-medium">Not measured yet</p>
+          <p className="text-xs mt-1">
+            Run audit to see which of your code's references archigraph could resolve.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Headline numbers */}
+          <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+            <Card className="p-4 text-center">
+              <p className={cn("text-xl font-mono font-semibold tabular-nums", resolvedColor)}>
+                {resolvedPct == null ? "—" : `${resolvedPct}%`}
+              </p>
+              <div className="mt-1 flex justify-center">
+                <InfoLabel label="Fidelity" hint={FIDELITY_TIP_OPS} />
+              </div>
+            </Card>
+            <Card className="p-4 text-center">
+              <p className="text-xl font-mono font-semibold tabular-nums text-text">
+                {refs.total.toLocaleString()}
+              </p>
+              <p className="text-xs text-text-3 mt-1">References</p>
+            </Card>
+            <Card className="p-4 text-center">
+              <p className="text-xl font-mono font-semibold tabular-nums text-success">
+                {refs.resolved.toLocaleString()}
+              </p>
+              <p className="text-xs text-text-3 mt-1">Resolved</p>
+            </Card>
+            <Card className="p-4 text-center">
+              <p className="text-xl font-mono font-semibold tabular-nums text-warning">
+                {refs.unresolved.toLocaleString()}
+              </p>
+              <p className="text-xs text-text-3 mt-1">Unresolved</p>
+            </Card>
+          </div>
+
+          {/* Stacked resolved/unresolved bar */}
+          <div className="space-y-1.5">
+            <div className="flex h-2.5 w-full overflow-hidden rounded-full bg-surface-3">
+              <div
+                className="h-full bg-success"
+                style={{ width: `${refs.resolved_rate * 100}%` }}
+                title={`Resolved — ${refs.resolved.toLocaleString()} (${Math.round(
+                  refs.resolved_rate * 100,
+                )}%)`}
+              />
+              {refs.reasons.map((r, i) => (
+                <div
+                  key={r.reason}
+                  className={cn("h-full", reasonColor(i))}
+                  style={{ width: `${r.pct * 100}%` }}
+                  title={`${r.label} — ${r.count.toLocaleString()} (${Math.round(r.pct * 100)}%)`}
+                />
+              ))}
+            </div>
+            <div className="flex items-center gap-3 text-[11px] text-text-3">
+              <span className="flex items-center gap-1">
+                <span className="size-2 rounded-full bg-success" /> Resolved
+              </span>
+              {refs.reasons.map((r, i) => (
+                <span key={r.reason} className="flex items-center gap-1">
+                  <span className={cn("size-2 rounded-full", reasonColor(i))} /> {r.label}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          {/* Unresolved by reason */}
+          {refs.reasons.length > 0 ? (
+            <Section
+              title="Unresolved references"
+              sub="What stops archigraph from linking the rest of your code's references — the reasons that drive Fidelity below 100%."
+            >
+              <div className="space-y-2.5">
+                {refs.reasons.map((r, i) => (
+                  <div
+                    key={r.reason}
+                    className="rounded-lg border border-border-soft bg-surface-2 p-3"
+                  >
+                    <div className="flex items-center gap-3">
+                      <span className={cn("size-2.5 rounded-full shrink-0", reasonColor(i))} />
+                      <span className="text-sm text-text-2 font-medium flex-1">{r.label}</span>
+                      <span className="text-xs font-mono tabular-nums text-text-3 w-12 text-right">
+                        {(r.pct * 100).toFixed(1)}%
+                      </span>
+                      <span className="text-xs text-text-4 font-mono w-20 text-right">
+                        {r.count.toLocaleString()}
+                      </span>
+                    </div>
+                    <p className="text-xs text-text-3 mt-1.5 ml-[22px]">{r.description}</p>
+                  </div>
+                ))}
+              </div>
+            </Section>
+          ) : (
+            <div className="flex flex-col items-center justify-center py-10 text-center text-text-3">
+              <CheckCircle size={24} className="text-success mb-2" />
+              <p className="text-sm font-medium">All references resolved</p>
+              <p className="text-xs mt-1">Every import/reference edge links to a real target.</p>
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
 
 function OrphanAuditPane({ groupId }: { groupId: string }) {
   const { data, isLoading } = useOrphanAudit(groupId);
@@ -1399,11 +1626,15 @@ function RecallPane({ groupId }: { groupId: string }) {
 
 function QualityTab({ groupId }: { groupId: string }) {
   return (
-    <Tabs defaultValue="orphans">
+    <Tabs defaultValue="references">
       <TabsList className="mb-5">
+        <TabsTrigger value="references">Unresolved references</TabsTrigger>
         <TabsTrigger value="orphans">Orphan audit</TabsTrigger>
         <TabsTrigger value="recall">Recall measurement</TabsTrigger>
       </TabsList>
+      <TabsContent value="references">
+        <UnresolvedReferencesPane groupId={groupId} />
+      </TabsContent>
       <TabsContent value="orphans">
         <OrphanAuditPane groupId={groupId} />
       </TabsContent>


### PR DESCRIPTION
Fixes #1588

## 1. Problem
The Operations screen had three honesty gaps:
- The **System** card showed memory like `987 / 500 MB` with no warning, even at ~2x over the 500 MB budget.
- The **Quality** tab only showed the orphan audit. On upvate (0 orphans) it read "perfect" while Fidelity sat at ~56%, with nothing explaining the gap. The 56% comes entirely from unresolved import/reference edges, which were never surfaced.
- User-facing copy still said **"bug rate"** ("Fidelity = 100 − bug-rate…"), the exact term the owner renamed away from.

## 2. Approach
- **Memory alert (frontend-only):** compute over-budget state from `rss_mb` vs `rss_budget_mb`; render an amber "Over budget" chip (red ≥1.5×) plus a plain-language tooltip suggesting a restart or fewer repos. Stays subtle when under budget.
- **Unresolved-references breakdown (backend + frontend):** the data already existed in the audit engine's import-format histogram (`ImportsToIDFormat`). Added an `UnresolvedReferences` block to `OrphanAuditReply` that aggregates resolved (hex + ext_qualified) vs unresolved, bucketed into plain-language reasons: External library (ext_bare), Unresolved import (path_string), Dynamic/not-yet-extracted (other), each with count, share, and a non-technical description. New **"Unresolved references"** sub-tab is now the PRIMARY Quality view; Orphan audit and Recall demoted to secondary tabs.
- **Plain-language copy:** replaced the "bug-rate" Fidelity tooltip with a non-technical explanation; relabeled the breakdown "Unresolved references"; added an honest banner clarifying Fidelity = extraction completeness (the docs skill improves documentation coverage, a different axis). Also fixed the leftover "bug-rate" string in the primitives showcase.

## 3. Files changed
- `internal/dashboard/handlers_quality.go` — `UnresolvedReferences`/`UnresolvedReason` wire types + `buildUnresolvedReferences()` aggregation.
- `webui-v2/src/data/types.ts` — matching TS types; `references` on `OrphanAuditReply`; `bug_rate_pct` marked deprecated/internal.
- `webui-v2/src/routes/operations.tsx` — memory over-budget chip + tooltip; new `UnresolvedReferencesPane` + `FidelityBanner`; Quality tab reordered (references primary); plain-language tooltips.
- `webui-v2/src/components/showcase/primitives-showcase.tsx` — Fidelity InfoLabel copy.

## 4. Verification
- `go vet ./internal/dashboard ./internal/quality/...` clean; `go test ./internal/dashboard -run Quality` passes.
- `npm run build` (tsc + vite) clean.
- Isolated daemon (`dashboard serve --port 47350`) + Vite dev server (47390) against real data, NOT live :47274.
- **upvate:** Fidelity 56.5% explained — Resolved 5,055 / 8,941; External library 37.1%, Dynamic 6.2%, Unresolved import 0.2%.
- **polyglot-platform:** Fidelity 51.4% — Dynamic 28.4%, External library 20.2%.
- Memory chip verified by simulating 987/500 MB → red "Over budget" chip + 197% tooltip.
- Playwright DOM check: zero "bug" in rendered text or any tooltip on both Quality sub-tabs and System, both light and dark themes.

## 5. Risk / rollback
Low. Backend change is additive (new JSON fields; existing fields untouched, `bug_rate_pct` retained for back-compat). Frontend is the Operations route only. Revert the commit to roll back.

## 6. Out of scope / follow-ups
- Internal field name `bug_rate_pct` (API + Go) intentionally kept; only UI strings changed per the issue.
- Cached audits persisted before this change lack `references` until a fresh "Run audit"; the pane shows the empty state until then (expected).
- Did NOT touch graph/flows/topology/paths/docs, the embedded `dashboard/` SPA (zero diff), or live :47274.
- Pre-existing unrelated failure `TestYamlScalar` (enrichment writeback) exists on origin/main and is untouched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)