### PR TITLE
feat(settings): watcher ON by default + monorepo groups show modules count

### DIFF
--- a/internal/dashboard/store.go
+++ b/internal/dashboard/store.go
@@ -212,6 +212,7 @@ func (liveStore) CreateGroup(name string) (GroupSummary, error) {
 		return GroupSummary{}, fmt.Errorf("group %q already exists", name)
 	}
 	cfg := &registry.GroupConfig{Name: name}
+	cfg.Features.Watchers = true // new groups default to watcher ON (debounced partial reindex)
 	if err := registry.SaveGroupConfig(configPath, cfg); err != nil {
 		return GroupSummary{}, err
 	}

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -65,6 +65,30 @@ import { cn } from "@/lib/utils";
 // Helpers
 // ---------------------------------------------------------------------------
 
+/**
+ * Determine whether a group is a monorepo group (a single git root split into
+ * N module paths, each registered as a Repo entry with a non-null .monorepo
+ * field) vs a true multi-repo group (N separate git roots, each without
+ * per-repo monorepo metadata).
+ *
+ * Detection heuristic (client-only, no extra API field needed):
+ *   • Monorepo group  — every repo in the group has a non-null .monorepo
+ *     field (i.e. was registered with detected modules). Noun = "module",
+ *     count = group.repos.length (each entry IS a module).
+ *   • Multi-repo group — at least one repo has .monorepo == null (separate
+ *     git roots). Noun = "repo", count = group.repos.length.
+ *
+ * Edge case: empty group → defaults to "repo".
+ */
+function groupRepoNoun(group: SettingsGroup): { count: number; noun: string; nounPlural: string } {
+  const isMonorepoGroup =
+    group.repos.length > 0 && group.repos.every((r) => r.monorepo != null);
+  if (isMonorepoGroup) {
+    return { count: group.repos.length, noun: "module", nounPlural: "modules" };
+  }
+  return { count: group.repos.length, noun: "repo", nounPlural: "repos" };
+}
+
 function relativeTime(ms: number | null): string {
   if (!ms) return "never";
   const diff = Date.now() - ms;
@@ -165,6 +189,12 @@ const HEALTH_CONFIG = {
 
 function HeaderCard({ group, onRebuild }: { group: SettingsGroup; onRebuild: () => void }) {
   const h = HEALTH_CONFIG[group.health];
+  const { count: repoCount, noun: repoNoun } = groupRepoNoun(group);
+  const repoLabel = repoNoun === "module" ? "Modules" : "Repositories";
+  const repoHint =
+    repoNoun === "module"
+      ? "Detected sub-modules within this monorepo. Each module is indexed independently."
+      : "Top-level git repos indexed in this group.";
 
   return (
     <Card className="p-5">
@@ -189,9 +219,9 @@ function HeaderCard({ group, onRebuild }: { group: SettingsGroup; onRebuild: () 
         {[
           {
             key: "repos",
-            label: "Repositories",
-            hint: "Top-level git repos indexed here. Monorepos count as one.",
-            value: group.repos.length,
+            label: repoLabel,
+            hint: repoHint,
+            value: repoCount,
             mono: true,
           },
           {
@@ -532,11 +562,15 @@ function RepositoriesSection({
     );
   };
 
+  const { count: repoCount, noun: repoNoun, nounPlural: repoNounPlural } = groupRepoNoun(group);
+  const sectionTitle = repoNoun === "module" ? "Modules" : "Repositories";
+  const sectionSub = `${repoCount} ${repoNounPlural} indexed in this group.`;
+
   return (
     <Section
       id="repositories"
-      title="Repositories"
-      sub={`${group.repos.length} repos indexed in this group.`}
+      title={sectionTitle}
+      sub={sectionSub}
       action={
         <Button variant="ghost" size="sm" onClick={onAddRepo}>
           <Plus size={13} />


### PR DESCRIPTION
## What changed

Two targeted fixes to the WebUI v2 Settings screen (`#1589`).

### 1. Filesystem watchers ON by default

**Problem:** New groups had `watchers: false` because `GroupConfig` zero-value is `false`. Users had to manually enable an important feature every time they created a group.

**Fix:** `internal/dashboard/store.go` — `CreateGroup()` now sets `cfg.Features.Watchers = true` before persisting the fleet.json. The Settings toggle still exists for opt-out. Existing groups are unaffected (stored value is preserved on every read/write cycle). The watcher already does debounced partial reindex on file change ("Low overhead; keeps the graph fresh." is the existing description).

Scope: only `liveStore.CreateGroup`. All three create-group paths (`POST /api/v2/groups`, `POST /api/v2/groups/from-scan`, `POST /api/admin/groups`) route through this single function.

### 2. Monorepo groups label count as "modules" not "repos"

**Problem:** The helper text "Top-level git repos indexed here. Monorepos count as one." was wrong for monorepo groups — a group like polyglot-platform has 32 registered `Repo` entries (one per module path) all with `monorepo != null`. Showing "32 repos" is misleading; they are modules.

**Fix:** `webui-v2/src/routes/settings.tsx` — new `groupRepoNoun()` helper detects the group type client-side using the existing wire data:
- **Monorepo group**: every `repo.monorepo != null` → noun = "module", header stat label = "Modules", section title = "Modules", sub = "N modules indexed in this group.", header hint = "Detected sub-modules within this monorepo. Each module is indexed independently."
- **Multi-repo group**: at least one `repo.monorepo == null` → noun = "repo", all existing labels preserved.

No backend change required; the `monorepo` field is already populated for module-registered repos.

## Verification (isolated daemon :47399, live daemon :47274 untouched)

| Group | Before | After |
|---|---|---|
| polyglot-platform (32 module paths, all `monorepo != null`) | "32 repos indexed" | "32 modules indexed" |
| upvate (3 separate git roots, all `monorepo == null`) | "3 repos indexed" | "3 repos indexed" (unchanged) |
| new group (created via `POST /api/v2/groups`) | `watchers: false` | `watchers: true` |

### Screenshots
- `1589-polyglot-platform-light.png` — polyglot-platform, light: "Modules / 32 modules indexed"
- `1589-polyglot-platform-dark.png` — polyglot-platform, dark: same
- `1589-upvate-light.png` — upvate, light: "Repositories / 3 repos indexed"
- `1589-new-group-watcher-on-light.png` — new group, light: Filesystem watchers toggle ON
- `1589-new-group-watcher-on-dark.png` — new group, dark: Filesystem watchers toggle ON

### Build verification
- `go build ./internal/dashboard/... ./internal/registry/... ./internal/cli/...` — clean
- `go vet ./internal/dashboard/... ./internal/registry/... ./internal/cli/...` — clean
- `tsc -b` (webui-v2) — clean, zero TS errors
- `vite build` (webui-v2) — clean, 746 kB bundle (same as baseline)
- `dashboard/` zero diff (untouched)

## Files changed
- `internal/dashboard/store.go` — +1 line: `cfg.Features.Watchers = true` in `CreateGroup`
- `webui-v2/src/routes/settings.tsx` — +35 lines: `groupRepoNoun()` helper + consume in `HeaderCard` + `RepositoriesSection`

Fixes #1589