### PR TITLE
feat(ui): project status dot encodes HEALTH consistently in all 3 surfaces

### DIFF
--- a/dashboard/src/components/landing/GroupSelector.tsx
+++ b/dashboard/src/components/landing/GroupSelector.tsx
@@ -20,6 +20,7 @@ import { GroupOpsMenu } from '@/components/landing/GroupOpsMenu'
 import { IndexingProgressModal } from '@/components/indexing/IndexingProgressModal'
 import type { GroupMeta } from '@/types/api'
 import type { IndexProgressState } from '@/types/indexProgress'
+import { deriveHealthBucket, HEALTH_DOT_CLASS, healthTooltip } from '@/lib/groupHealth'
 
 // ─────────────────────────────────────────────────────────────────────────────
 // Helpers
@@ -421,13 +422,23 @@ function GroupCard({ group, onClick, onNavigateToNode, indexProgress }: GroupCar
       >
         {/* Main content — grows to fill available space */}
         <div className="flex-1 flex flex-col justify-between min-h-0">
-          {/* Header: group name + sparkline */}
+          {/* Header: group name + health dot + sparkline */}
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-center gap-2 min-w-0">
               <GitBranch className="w-4 h-4 text-sky-400 shrink-0" aria-hidden />
               <span className="text-xl font-semibold text-slate-100 truncate">
                 {group.display_name}
               </span>
+              {/* Health status dot — same encoding as project switcher + top-bar */}
+              <span
+                title={healthTooltip(group)}
+                aria-label={healthTooltip(group)}
+                data-testid="landing-health-dot"
+                className={[
+                  'w-2.5 h-2.5 rounded-full flex-shrink-0 mt-0.5',
+                  HEALTH_DOT_CLASS[deriveHealthBucket(group)],
+                ].join(' ')}
+              />
             </div>
             <div className="shrink-0 pt-0.5">
               <Sparkline history={group.bug_rate_history} bugRate={group.bug_rate} />

--- a/dashboard/src/components/layout/GroupSelector.tsx
+++ b/dashboard/src/components/layout/GroupSelector.tsx
@@ -5,13 +5,14 @@
  * Mobile (≤640 px): full-screen sheet from the top.
  *
  * Features:
- *  - Trigger: current group display name + ChevronDown
+ *  - Trigger: health dot for the current group + display name + ChevronDown
  *  - Search input at top of panel
  *  - Pinned groups section (max 3, star toggle per row)
  *  - Other groups section
- *  - Unresolved edges status dot: green ≤5% / amber 5–15% / red >15%
- *  - Entity-count tooltip
- *  - Selected row visually highlighted
+ *  - Health status dot: green = healthy (≤5% unresolved), amber = degraded
+ *    (5–15%), red = critical (>15%), grey = not yet indexed.
+ *    Driven by GroupMeta.bug_rate via shared deriveHealthBucket / healthTooltip.
+ *  - Active row highlighted with checkmark (separate affordance from health colour)
  *  - Closes on outside-click or Escape
  *  - Switching preserves the current surface (path replacement)
  */
@@ -25,33 +26,13 @@ import {
   KeyboardEvent as ReactKeyboardEvent,
 } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
-import { Search, Pin, PinOff, ChevronDown, X } from 'lucide-react'
+import { Search, Pin, PinOff, ChevronDown, X, Check } from 'lucide-react'
 import type { GroupMeta } from '@/types/api'
 import { getPinnedGroups, togglePin } from '@/lib/groupPins'
+import { deriveHealthBucket, HEALTH_DOT_CLASS, healthTooltip } from '@/lib/groupHealth'
 
 interface GroupSelectorProps {
   groups: GroupMeta[]
-}
-
-/** Derive a synthetic unresolved edges bucket from entity_count for mock data. */
-function bugRateBucket(g: GroupMeta): 'green' | 'amber' | 'red' {
-  const sum = g.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
-  const pct = sum % 30
-  if (pct <= 5) return 'green'
-  if (pct <= 15) return 'amber'
-  return 'red'
-}
-
-const bucketClass: Record<'green' | 'amber' | 'red', string> = {
-  green: 'bg-emerald-500',
-  amber: 'bg-amber-400',
-  red: 'bg-red-500',
-}
-
-const bucketLabel: Record<'green' | 'amber' | 'red', string> = {
-  green: '≤5% unresolved edges',
-  amber: '5–15% unresolved edges',
-  red: '>15% unresolved edges',
 }
 
 /** Extracts the current surface prefix from a pathname like "/flows/fixture-a" → "flows" */
@@ -74,10 +55,16 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
 
   const surface = surfaceFromPath(location.pathname)
 
-  // Find display name for the active group
-  const activeDisplay = useMemo(() => {
-    return groups.find((g) => g.id === activeGroup)?.display_name ?? activeGroup
+  // Find the active group meta (for display name + health dot in trigger)
+  const activeGroupMeta = useMemo(() => {
+    return groups.find((g) => g.id === activeGroup)
   }, [groups, activeGroup])
+
+  const activeDisplay = activeGroupMeta?.display_name ?? activeGroup
+
+  // Health dot for the trigger button (current project)
+  const activeBucket = activeGroupMeta ? deriveHealthBucket(activeGroupMeta) : 'unknown'
+  const activeTip = activeGroupMeta ? healthTooltip(activeGroupMeta) : 'Health: unknown'
 
   // Filter groups by search query
   const filtered = useMemo(() => {
@@ -170,6 +157,16 @@ export function GroupSelector({ groups }: GroupSelectorProps) {
         ].join(' ')}
         data-testid="group-selector-trigger"
       >
+        {/* Health dot for the current project in the trigger */}
+        <span
+          title={activeTip}
+          aria-label={activeTip}
+          data-testid="group-selector-health-dot"
+          className={[
+            'w-2 h-2 rounded-full flex-shrink-0',
+            HEALTH_DOT_CLASS[activeBucket],
+          ].join(' ')}
+        />
         <span className="font-mono max-w-[12rem] truncate" data-testid="group-selector-label">
           {activeDisplay || 'Select group'}
         </span>
@@ -282,7 +279,8 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
         {groups.map((g) => {
           const isActive = g.id === activeGroup
           const isPinned = pinnedIds.includes(g.id)
-          const bucket = bugRateBucket(g)
+          const bucket = deriveHealthBucket(g)
+          const tip = healthTooltip(g)
 
           return (
             <li key={g.id}>
@@ -299,6 +297,17 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
                     : 'border-transparent text-slate-600 dark:text-slate-400 hover:bg-slate-100/60 dark:hover:bg-slate-800/60 hover:text-slate-800 dark:hover:text-slate-300',
                 ].join(' ')}
               >
+                {/* Current-project checkmark (separate affordance from health colour) */}
+                <span
+                  aria-hidden
+                  className={[
+                    'w-3 h-3 flex-shrink-0',
+                    isActive ? 'text-sky-400' : 'invisible',
+                  ].join(' ')}
+                >
+                  {isActive && <Check className="w-3 h-3" />}
+                </span>
+
                 {/* Group name */}
                 <span className="flex-1 font-mono truncate" title={g.display_name}>
                   {g.display_name}
@@ -328,11 +337,11 @@ function GroupSection({ label, groups, activeGroup, pinnedIds, onSelect, onToggl
                   {isPinned ? <PinOff className="w-3 h-3" /> : <Pin className="w-3 h-3" />}
                 </span>
 
-                {/* Unresolved edges dot */}
+                {/* Health status dot — encodes fidelity, NOT active state */}
                 <span
-                  title={`${bucketLabel[bucket]} — ${g.entity_count.toLocaleString()} entities`}
-                  aria-label={bucketLabel[bucket]}
-                  className={['w-2 h-2 rounded-full flex-shrink-0', bucketClass[bucket]].join(' ')}
+                  title={tip}
+                  aria-label={tip}
+                  className={['w-2 h-2 rounded-full flex-shrink-0', HEALTH_DOT_CLASS[bucket]].join(' ')}
                 />
               </button>
             </li>

--- a/dashboard/src/components/layout/GroupSwitcher.tsx
+++ b/dashboard/src/components/layout/GroupSwitcher.tsx
@@ -4,46 +4,24 @@
  * Features:
  *  - Search/filter input
  *  - Pinned groups float to top (localStorage, max 3)
- *  - Unresolved edges status dot: green ≤5% / amber 5-15% / red >15%
- *    (uses entity_count as proxy until a real unresolved_edges field ships)
- *  - Entity count in tooltip
- *  - Active group: bg-slate-200 dark:bg-slate-800 + sky-500 left border
+ *  - Health status dot: green = healthy (≤5% unresolved), amber = degraded
+ *    (5–15%), red = critical (>15%), grey = not yet indexed.
+ *    Driven by GroupMeta.bug_rate via shared deriveHealthBucket / healthTooltip.
+ *  - Active group: bg-slate-200 dark:bg-slate-800 + sky-500 left border +
+ *    checkmark icon (separate from health colour)
  *  - Switching preserves current surface (e.g. /flows/A → /flows/B)
  */
 
 import { useState, useMemo, useCallback } from 'react'
 import { useNavigate, useParams, useLocation } from 'react-router-dom'
-import { Search, Pin, PinOff } from 'lucide-react'
+import { Search, Pin, PinOff, Check } from 'lucide-react'
 import type { GroupMeta } from '@/types/api'
 import { getPinnedGroups, togglePin } from '@/lib/groupPins'
+import { deriveHealthBucket, HEALTH_DOT_CLASS, healthTooltip } from '@/lib/groupHealth'
 
 interface GroupSwitcherProps {
   groups: GroupMeta[]
   onNavigate?: () => void   // called after navigation (e.g. close mobile drawer)
-}
-
-/** Derive a synthetic unresolved edges bucket from entity_count for mock data. */
-function bugRateBucket(g: GroupMeta): 'green' | 'amber' | 'red' {
-  // Real API will eventually carry a `unresolved_edges` field.
-  // Until then we use a deterministic hash of the id so fixture groups get
-  // stable (but varied) colours in the UI.
-  const sum = g.id.split('').reduce((acc, c) => acc + c.charCodeAt(0), 0)
-  const pct = sum % 30   // 0-29
-  if (pct <= 5) return 'green'
-  if (pct <= 15) return 'amber'
-  return 'red'
-}
-
-const bucketClass: Record<'green' | 'amber' | 'red', string> = {
-  green: 'bg-emerald-500',
-  amber: 'bg-amber-400',
-  red: 'bg-red-500',
-}
-
-const bucketLabel: Record<'green' | 'amber' | 'red', string> = {
-  green: '≤5% unresolved edges',
-  amber: '5–15% unresolved edges',
-  red: '>15% unresolved edges',
 }
 
 /** Extracts the current surface prefix from a pathname like "/flows/fixture-a" → "flows" */
@@ -141,7 +119,8 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
         {sorted.map((g) => {
           const isActive = g.id === activeGroup
           const isPinned = pinnedIds.includes(g.id)
-          const bucket = bugRateBucket(g)
+          const bucket = deriveHealthBucket(g)
+          const tip = healthTooltip(g)
 
           return (
             <li key={g.id}>
@@ -158,6 +137,17 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
                     : 'border-transparent text-slate-400 dark:text-slate-400 hover:bg-slate-200/60 dark:hover:bg-slate-800/60 hover:text-slate-700 dark:hover:text-slate-300',
                 ].join(' ')}
               >
+                {/* Current-project checkmark (separate affordance from health colour) */}
+                <span
+                  aria-hidden
+                  className={[
+                    'w-3 h-3 flex-shrink-0',
+                    isActive ? 'text-sky-400' : 'invisible',
+                  ].join(' ')}
+                >
+                  {isActive && <Check className="w-3 h-3" />}
+                </span>
+
                 {/* Group name */}
                 <span className="flex-1 font-mono truncate" title={g.display_name}>
                   {g.display_name}
@@ -192,13 +182,13 @@ export function GroupSwitcher({ groups, onNavigate }: GroupSwitcherProps) {
                   )}
                 </span>
 
-                {/* Unresolved edges status dot */}
+                {/* Health status dot — encodes fidelity, NOT active state */}
                 <span
-                  title={`${bucketLabel[bucket]} — ${g.entity_count.toLocaleString()} entities`}
-                  aria-label={bucketLabel[bucket]}
+                  title={tip}
+                  aria-label={tip}
                   className={[
                     'w-2 h-2 rounded-full flex-shrink-0',
-                    bucketClass[bucket],
+                    HEALTH_DOT_CLASS[bucket],
                   ].join(' ')}
                 />
               </button>

--- a/dashboard/src/lib/groupHealth.ts
+++ b/dashboard/src/lib/groupHealth.ts
@@ -1,0 +1,56 @@
+/**
+ * groupHealth — shared health/fidelity helpers for the project status dot.
+ *
+ * The dot encodes health via the group's unresolved-edges rate (bug_rate):
+ *   green  — healthy   ≤5%   unresolved edges
+ *   amber  — degraded  5–15% unresolved edges
+ *   red    — critical  >15%  unresolved edges
+ *   grey   — unknown   bug_rate absent (group not yet indexed)
+ *
+ * This module is the single source of truth. All three surfaces that show the
+ * dot (landing cards, project-switcher list, top-bar breadcrumb dropdown) import
+ * from here so the colour logic is never duplicated.
+ */
+
+import type { GroupMeta } from '@/types/api'
+
+export type HealthBucket = 'healthy' | 'degraded' | 'critical' | 'unknown'
+
+/**
+ * Derive the health bucket from a GroupMeta object.
+ * Uses the real bug_rate field; falls back to 'unknown' when absent.
+ */
+export function deriveHealthBucket(g: GroupMeta): HealthBucket {
+  if (g.bug_rate === undefined) return 'unknown'
+  if (g.bug_rate <= 5) return 'healthy'
+  if (g.bug_rate <= 15) return 'degraded'
+  return 'critical'
+}
+
+/** Tailwind bg class for the dot, per bucket. */
+export const HEALTH_DOT_CLASS: Record<HealthBucket, string> = {
+  healthy:  'bg-emerald-500',
+  degraded: 'bg-amber-400',
+  critical: 'bg-red-500',
+  unknown:  'bg-slate-400 dark:bg-slate-600',
+}
+
+/** Human-readable label shown in tooltips. */
+export function healthTooltip(g: GroupMeta): string {
+  const bucket = deriveHealthBucket(g)
+  const fidelityPct =
+    g.bug_rate !== undefined
+      ? ` — Fidelity ${(100 - g.bug_rate).toFixed(0)}%`
+      : ''
+
+  switch (bucket) {
+    case 'healthy':
+      return `Health: healthy${fidelityPct}`
+    case 'degraded':
+      return `Health: degraded${fidelityPct}`
+    case 'critical':
+      return `Health: critical${fidelityPct}`
+    default:
+      return 'Health: unknown — not yet indexed'
+  }
+}

--- a/dashboard/tests/components/GroupSelector.test.tsx
+++ b/dashboard/tests/components/GroupSelector.test.tsx
@@ -11,6 +11,7 @@ const mockGroups: GroupMeta[] = [
     repos: [],
     entity_count: 6916,
     indexed_at: '2026-05-20T10:05:00Z',
+    bug_rate: 3,   // healthy — green
   },
   {
     id: 'fixture-b',
@@ -18,6 +19,7 @@ const mockGroups: GroupMeta[] = [
     repos: [],
     entity_count: 4557,
     indexed_at: '2026-05-20T09:05:00Z',
+    bug_rate: 10,  // degraded — amber
   },
 ]
 
@@ -78,13 +80,22 @@ describe('GroupSelector', () => {
     expect(options[0].textContent).toContain('Fixture B')
   })
 
-  it('renders status dots for all groups', () => {
+  it('renders health status dots for all groups', () => {
     renderWithRouter('/graph/fixture-a')
     fireEvent.click(screen.getByTestId('group-selector-trigger'))
+    // Each group option row should have a health dot with aria-label starting with "Health:"
     const dots = screen.getAllByRole('option').flatMap(
-      (o) => Array.from(o.querySelectorAll('[aria-label*="bug rate"]')),
+      (o) => Array.from(o.querySelectorAll('[aria-label^="Health:"]')),
     )
     expect(dots.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('shows correct health tooltip on trigger dot', () => {
+    renderWithRouter('/graph/fixture-a')
+    const triggerDot = screen.getByTestId('group-selector-health-dot')
+    // fixture-a has bug_rate=3 → healthy, fidelity 97%
+    expect(triggerDot.getAttribute('title')).toContain('healthy')
+    expect(triggerDot.getAttribute('title')).toContain('97')
   })
 
   it('shows "No groups match" when filter has no results', () => {

--- a/dashboard/tests/components/GroupSwitcher.test.tsx
+++ b/dashboard/tests/components/GroupSwitcher.test.tsx
@@ -11,6 +11,7 @@ const mockGroups: GroupMeta[] = [
     repos: [],
     entity_count: 6916,
     indexed_at: '2026-05-20T10:05:00Z',
+    bug_rate: 3,   // healthy — green
   },
   {
     id: 'fixture-b',
@@ -18,6 +19,7 @@ const mockGroups: GroupMeta[] = [
     repos: [],
     entity_count: 4557,
     indexed_at: '2026-05-20T09:05:00Z',
+    bug_rate: 10,  // degraded — amber
   },
 ]
 
@@ -61,13 +63,26 @@ describe('GroupSwitcher', () => {
     expect(options[0].textContent).toContain('Fixture B')
   })
 
-  it('renders status dots for all groups', () => {
+  it('renders health status dots for all groups', () => {
     renderWithRouter('/graph/fixture-a')
-    // Each group option should have a status dot (role=none span with aria-label)
+    // Each group option should have a health status dot with aria-label starting with "Health:"
     const dots = screen.getAllByRole('option').flatMap(
-      (o) => Array.from(o.querySelectorAll('[aria-label*="bug rate"]')),
+      (o) => Array.from(o.querySelectorAll('[aria-label^="Health:"]')),
     )
     expect(dots.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('active group has checkmark and health dot independently', () => {
+    renderWithRouter('/graph/fixture-a')
+    const activeOption = screen.getAllByRole('option').find(
+      (o) => o.getAttribute('aria-selected') === 'true',
+    )!
+    // Checkmark icon should be present (not invisible)
+    const checkSpan = activeOption.querySelector('[aria-hidden]')
+    expect(checkSpan).not.toBeNull()
+    // Health dot should carry "Health:" tooltip
+    const healthDot = activeOption.querySelector('[aria-label^="Health:"]')
+    expect(healthDot).not.toBeNull()
   })
 
   it('calls onNavigate when a group is selected', () => {


### PR DESCRIPTION
## What

Fixes #1585

The project status dot was inconsistent and meaningless:
- **Left sidebar** (`GroupSwitcher`): used a fake deterministic hash of the group ID — completely unrelated to real fidelity
- **Top-bar dropdown** (`GroupSelector`): same fake hash, same problem
- **Landing cards**: no standalone status dot at all
- **Trigger button** (current-project breadcrumb): no dot, so you couldn't see health without opening the panel

## How

### New shared module: `dashboard/src/lib/groupHealth.ts`

Single source of truth. Uses `GroupMeta.bug_rate` (unresolved-edges %):

| Bucket | Condition | Dot colour |
|--------|-----------|------------|
| `healthy` | bug_rate ≤ 5% | emerald-500 |
| `degraded` | 5% < bug_rate ≤ 15% | amber-400 |
| `critical` | bug_rate > 15% | red-500 |
| `unknown` | bug_rate absent | slate-400 |

`healthTooltip(g)` → `"Health: degraded — Fidelity 56%"`

### `GroupSwitcher` (left sidebar)
- Replaced `bugRateBucket` fake hash with `deriveHealthBucket` + `healthTooltip`
- Added sky-400 checkmark icon as a **separate** "current project" affordance so active state never overrides health colour

### `GroupSelector` (top-bar dropdown)
- Same replacement for list rows
- Added health dot to the **trigger button** (`data-testid="group-selector-health-dot"`) — current project health now visible without opening the panel
- Same checkmark affordance for active row in the list

### Landing cards
- Added `w-2.5 h-2.5` health dot next to the group name in the card header (`data-testid="landing-health-dot"`), consistent tooltip

### Tests
- Added `bug_rate` to mock groups (`fixture-a: 3` = healthy, `fixture-b: 10` = degraded)
- Updated dot assertions: `aria-label*="bug rate"` → `aria-label^="Health:"`
- Added test for trigger-dot tooltip content ("healthy", fidelity %)
- Added test verifying checkmark and health dot are independent

## Verification

```
# build
cd dashboard && npm run build   # ✓ built in 26s, zero new errors

# unit tests (our files)
vitest run tests/components/GroupSelector.test.tsx tests/components/GroupSwitcher.test.tsx
# ✓ 17 tests pass (10 + 7)
```

Both themes (light/dark) handled via `dark:bg-slate-600` on the unknown bucket. All other buckets use theme-invariant emerald/amber/red that read correctly in both modes.

## Test plan

- [ ] Open landing page — all cards show a dot next to the group name; hover shows "Health: healthy — Fidelity 97%"
- [ ] Top-bar trigger shows a coloured dot before the group name, matching the card dot for the same group
- [ ] Open the top-bar dropdown — each row shows a dot + checkmark for the active row; dot colour matches the trigger and the card
- [ ] Switch to a group with a different health bucket (e.g. `polyglot-platform` ~degraded) — amber dot appears in all 3 places simultaneously
- [ ] Verify in both light and dark theme
- [ ] `npm run build` passes clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)