### PR TITLE
fix(webui-v2): reload === Reset — version the layout cache + unify the settle path (#1581)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -44,7 +44,7 @@ import {
   degreeColor,
   linkPalette,
 } from "@/lib/graph-colors";
-import { saveLayout, loadLayout, isDegenerateLayout } from "@/lib/graph-layout-cache";
+import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
 import {
   baseSizeForCount,
   DEFAULT_NODE_SIZING,
@@ -96,14 +96,6 @@ function sanitizePositions(
     out[i] = v;
   }
   return { array: out, repaired };
-}
-
-/** Fix #1562: true only if EVERY coordinate is a finite number. */
-function allFinite(positions: ArrayLike<number> | null | undefined): boolean {
-  const len = positions?.length ?? 0;
-  if (len === 0) return false;
-  for (let i = 0; i < len; i++) if (!Number.isFinite(positions![i])) return false;
-  return true;
 }
 
 // ── group / cluster helpers ──────────────────────────────────────────────────
@@ -794,6 +786,64 @@ function GraphCanvasInner(
   const doSettleRef = useRef(doSettle);
   doSettleRef.current = doSettle;
 
+  // Fix #1581: keep the latest packed buffers in a ref so the UNIFIED settle
+  // routine below can be a stable (dep-free) callback shared by every fresh-settle
+  // entry point (first load, Reset/Re-layout, group / group-by change, ego
+  // re-layout) without each one re-deriving the kick logic.
+  const packedRef = useRef(packed);
+  packedRef.current = packed;
+
+  // Fix #1581: THE single source of truth for "run a fresh settle". Previously the
+  // first-load no-cache path (mount effect) and the Reset/Re-layout path used
+  // DIFFERENT kick routines: the mount path scheduled a mid-settle re-heat (a
+  // second alpha pass partway through the window) gated by reheatedRef +
+  // onSimulationEnd, while Reset just did `g.start(1)` + a lone cap timer with NO
+  // re-heat. So a fresh page LOAD converged via the re-heat to the good spread,
+  // but a Reset (and the diverging older logic) could freeze before the islands
+  // finished pulling in — reload and Reset did not match. We now route BOTH
+  // through this one function so a fresh load is byte-for-byte the SAME settle the
+  // Reset button runs: reseed from packed.positions → start → mid-settle re-heat →
+  // hard cap → doSettle (fit + cache). Reload === Reset by construction.
+  const kickFreshSettle = useCallback(() => {
+    const g = graphRef.current;
+    if (!g) return;
+    const p = packedRef.current;
+    hasSettledRef.current = false;
+    didAutoStartRef.current = true;
+    reheatedRef.current = false;
+    mountTimeRef.current = Date.now();
+    if (capTimerRef.current) {
+      clearTimeout(capTimerRef.current);
+      capTimerRef.current = null;
+    }
+    if (reheatTimerRef.current) {
+      clearTimeout(reheatTimerRef.current);
+      reheatTimerRef.current = null;
+    }
+    g.setPointPositions(p.positions);
+    g.setPointClusters(p.clusters);
+    g.setPointClusterStrength(p.clusterStrength);
+    g.render();
+    g.create();
+    g.start(1);
+    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
+    // Mid-settle re-heat: a single alpha pass partway through cools down before the
+    // strong center/gravity finish pulling the islands inward (the hollow-ring
+    // failure). Re-heat once at ~45% so it keeps converging to the canvas-filling
+    // spread, then the cap is the hard backstop. onSimulationEnd ignores the first
+    // (pre-re-heat) cool-down via reheatedRef so it never freezes a half-spread.
+    reheatTimerRef.current = setTimeout(() => {
+      const gg = graphRef.current;
+      reheatedRef.current = true;
+      if (gg && !hasSettledRef.current) gg.start(1);
+    }, Math.round(capMs * 0.45));
+    capTimerRef.current = setTimeout(() => {
+      if (!hasSettledRef.current) doSettleRef.current();
+    }, capMs);
+  }, []);
+  const kickFreshSettleRef = useRef(kickFreshSettle);
+  kickFreshSettleRef.current = kickFreshSettle;
+
   // ── mount the engine ONCE ─────────────────────────────────────────────────
   useEffect(() => {
     const container = containerRef.current;
@@ -908,10 +958,12 @@ function GraphCanvasInner(
     // Fix #1562: a layout cached BEFORE this fix could contain NaN/Infinity from
     // a diverged settle; loading it would crash on the first fit. Only trust a
     // fully-finite cache; otherwise fall through to a fresh (now-stable) layout.
-    // Fix #1567-2: ALSO reject a degenerate (over-contracted / collapsed) cache so
-    // a reload re-settles to the good spread instead of restoring a bad blob — the
-    // reload now matches Reset.
-    if (saved && allFinite(saved.positions) && !isDegenerateLayout(saved.positions)) {
+    // Fix #1567-2 / #1581: ALSO reject a degenerate (collapsed) OR over-contracted
+    // cache via isLayoutHealthy, and the cache is now version-scoped so a layout
+    // baked by retired force defaults is a guaranteed MISS. On any reject we run
+    // the EXACT same fresh settle the Reset button runs (kickFreshSettle) so the
+    // reload converges to the good spread — reload === Reset.
+    if (saved && isLayoutHealthy(saved.positions, nodeIds.length * 2)) {
       requestAnimationFrame(() => {
         const gg = graphRef.current;
         if (!gg) return;
@@ -919,23 +971,13 @@ function GraphCanvasInner(
         doSettleRef.current();
       });
     } else {
-      const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
-      // Fix #1558-2: a single alpha=1 pass from the (spread) seed cools down
-      // before the strong center/gravity finish pulling the islands inward — the
-      // graph froze as a hollow ring. Re-heat the simulation once partway through
-      // the settle window so it keeps converging on the now-partially-collapsed
-      // positions, reliably reaching the canvas-filling layout (this mirrors the
-      // manual second `start()` that was needed to converge). Still bounded by the
-      // settleTime cap below.
-      reheatedRef.current = false;
-      reheatTimerRef.current = setTimeout(() => {
-        const gg = graphRef.current;
-        reheatedRef.current = true;
-        if (gg && !hasSettledRef.current) gg.start(1);
-      }, Math.round(capMs * 0.45));
-      capTimerRef.current = setTimeout(() => {
-        if (!hasSettledRef.current) doSettleRef.current();
-      }, capMs);
+      // No valid cache → fresh settle, identical to Reset/Re-layout. Claim the
+      // auto-start synchronously so the data-push effect (which runs right after
+      // this mount effect in the same commit) doesn't kick its own competing
+      // g.start(1); the unified kick (deferred a frame so buffers are uploaded)
+      // owns the settle.
+      didAutoStartRef.current = true;
+      requestAnimationFrame(() => kickFreshSettleRef.current());
     }
 
     return () => {
@@ -974,11 +1016,14 @@ function GraphCanvasInner(
     g.create();
     if (!didAutoStartRef.current && !hasSettledRef.current) {
       const saved = loadLayout(group, nodeIds);
-      // Fix #1567-2: a degenerate cache is treated as a miss → kick a fresh
-      // settle (the mount handler also ignores it), so we don't render a blob.
-      if (!saved || isDegenerateLayout(saved.positions)) {
-        didAutoStartRef.current = true;
-        g.start(1);
+      // Fix #1581: an unhealthy/missing cache → run the UNIFIED fresh settle (the
+      // same routine Reset uses) instead of a bare g.start(1) here. This is a
+      // safety net: the mount effect normally claims the auto-start, but if the
+      // first data push beat it (or arrived after a node-set change), route through
+      // kickFreshSettle so reload still === Reset. A healthy cache is left to the
+      // mount/group handlers to pin + settle.
+      if (!saved || !isLayoutHealthy(saved.positions, nodeIds.length * 2)) {
+        kickFreshSettleRef.current();
       }
     }
     if (hasSettledRef.current) g.pause();
@@ -1020,24 +1065,13 @@ function GraphCanvasInner(
   }, [render, simulation, packLinkColors, packLinkWidths]);
 
   // ── re-layout request (Reset / re-layout) ───────────────────────────────────
+  // Fix #1581: this IS the canonical fresh-settle now; it (and first load) both
+  // call kickFreshSettle so the two paths are identical.
   useEffect(() => {
     if (relayoutRef.current === relayoutNonce) return;
     relayoutRef.current = relayoutNonce;
-    const g = graphRef.current;
-    if (!g) return;
-    hasSettledRef.current = false;
-    mountTimeRef.current = Date.now();
-    g.setPointPositions(packed.positions);
-    g.setPointClusters(packed.clusters);
-    g.setPointClusterStrength(packed.clusterStrength);
-    g.render();
-    g.create();
-    g.start(1);
-    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
-    if (capTimerRef.current) clearTimeout(capTimerRef.current);
-    capTimerRef.current = setTimeout(() => {
-      if (!hasSettledRef.current) doSettleRef.current();
-    }, capMs);
+    if (!graphRef.current) return;
+    kickFreshSettleRef.current();
   }, [relayoutNonce, packed]);
 
   // ── re-layout when the node SET changes (Fix #1548-3 ego enter/exit) ─────────
@@ -1054,31 +1088,17 @@ function GraphCanvasInner(
     didAutoStartRef.current = true;
     mountTimeRef.current = Date.now();
     const saved = loadLayout(group, nodeIds);
-    // Fix #1562: ignore a non-finite cached layout (see mount handler).
-    // Fix #1567-2: also ignore a degenerate (collapsed) cache → re-settle.
-    if (
-      saved &&
-      saved.positions.length === packed.positions.length &&
-      allFinite(saved.positions) &&
-      !isDegenerateLayout(saved.positions)
-    ) {
+    // Fix #1562/#1567-2/#1581: reuse the cache only when it's HEALTHY (finite, not
+    // collapsed, not over-contracted) AND version-current; otherwise run the
+    // unified fresh settle (== Reset).
+    if (saved && isLayoutHealthy(saved.positions, packed.positions.length)) {
       g.setPointPositions(saved.positions, true);
       g.render();
       g.create();
       doSettleRef.current();
       return;
     }
-    g.setPointPositions(packed.positions);
-    g.setPointClusters(packed.clusters);
-    g.setPointClusterStrength(packed.clusterStrength);
-    g.render();
-    g.create();
-    g.start(1);
-    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
-    if (capTimerRef.current) clearTimeout(capTimerRef.current);
-    capTimerRef.current = setTimeout(() => {
-      if (!hasSettledRef.current) doSettleRef.current();
-    }, capMs);
+    kickFreshSettleRef.current();
   }, [group, packed, nodeIds]);
 
   // ── re-cluster on group-by change ───────────────────────────────────────────
@@ -1086,21 +1106,9 @@ function GraphCanvasInner(
   useEffect(() => {
     if (prevGroupByRef.current === groupBy) return;
     prevGroupByRef.current = groupBy;
-    const g = graphRef.current;
-    if (!g) return;
-    hasSettledRef.current = false;
-    mountTimeRef.current = Date.now();
-    g.setPointPositions(packed.positions);
-    g.setPointClusters(packed.clusters);
-    g.setPointClusterStrength(packed.clusterStrength);
-    g.render();
-    g.create();
-    g.start(1);
-    const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
-    if (capTimerRef.current) clearTimeout(capTimerRef.current);
-    capTimerRef.current = setTimeout(() => {
-      if (!hasSettledRef.current) doSettleRef.current();
-    }, capMs);
+    if (!graphRef.current) return;
+    // Fix #1581: a group-by change re-clusters → run the unified fresh settle.
+    kickFreshSettleRef.current();
   }, [groupBy, packed]);
 
   // ── visibility / hover spotlight + repo + community selection ─────────────────
@@ -1297,20 +1305,9 @@ function GraphCanvasInner(
     if (!isFocusView || !changed) return;
     const g = graphRef.current;
     if (!g) return;
-    hasSettledRef.current = false;
-    didAutoStartRef.current = true;
-    mountTimeRef.current = Date.now();
-    g.setPointPositions(packed.positions);
-    g.setPointClusters(packed.clusters);
-    g.setPointClusterStrength(packed.clusterStrength);
-    g.render();
-    g.create();
-    g.start(1);
+    // Fix #1581: unified fresh settle for the new ego node set.
+    kickFreshSettleRef.current();
     const capMs = Math.max(500, Math.min(6000, (simRef.current.settleTime ?? 2.0) * 1000));
-    if (capTimerRef.current) clearTimeout(capTimerRef.current);
-    capTimerRef.current = setTimeout(() => {
-      if (!hasSettledRef.current) doSettleRef.current();
-    }, capMs);
     const fit = () => {
       fitNowRef.current();
       refreshLabelsRef.current();

--- a/webui-v2/src/lib/graph-layout-cache.ts
+++ b/webui-v2/src/lib/graph-layout-cache.ts
@@ -5,16 +5,37 @@
    localStorage lets a return visit skip the explode/settle animation
    entirely and render the laid-out graph INSTANTLY.
 
-   Key:   archigraph.v2.layout.<group>.<nodesetHash>
+   Key:   archigraph.v2.layout.<layoutVersion>.<group>.<nodesetHash>
    Value: base64-encoded Float32Array of [x0, y0, x1, y1, ...]
 
    The node-set hash (FNV-1a over sorted node IDs) keys the cache so a graph
    whose nodes changed (re-index) misses and re-lays-out. A 2 MB guard avoids
    blowing the localStorage quota on huge graphs.
+
+   Fix #1581: the cache key is ALSO scoped by a LAYOUT_VERSION. The settled
+   positions are a product of the simulation / force defaults; when we ship new
+   force defaults (#1566/#1569/#1586/…) the OLD cached positions are stale — a
+   reload restored a layout produced by forces that no longer exist (the
+   over-contracted blob), while Reset re-ran the sim with the new forces and
+   produced the good spread. Bumping LAYOUT_VERSION whenever the layout-producing
+   defaults change makes every key under the old version a guaranteed MISS, so a
+   ship of new forces always re-settles. (Keep this in lock-step with the store's
+   DEFAULTS_VERSION — bump both when DEFAULT_SIMULATION changes.)
    ============================================================ */
 
 const MAX_BYTES = 2 * 1024 * 1024;
 const PREFIX = "archigraph.v2.layout";
+
+/**
+ * Fix #1581: version stamp baked into every layout-cache key. Bump this whenever
+ * a change can alter the SETTLED GEOMETRY for the same node set — i.e. any change
+ * to the simulation / force defaults (DEFAULT_SIMULATION), the cluster-seeding, or
+ * the settle routine. Old-version entries become unreachable keys (a miss), so the
+ * graph re-settles with the current forces on next load instead of restoring a
+ * layout baked by retired forces. Tracks the store's DEFAULTS_VERSION (=4 at the
+ * time of #1581).
+ */
+export const LAYOUT_VERSION = 4;
 
 function fnv1a32(s: string): string {
   let h = 0x811c9dc5 >>> 0;
@@ -27,7 +48,8 @@ function fnv1a32(s: string): string {
 
 function layoutKey(group: string, nodeIds: string[]): string {
   const hash = fnv1a32([...nodeIds].sort().join(","));
-  return `${PREFIX}.${group}.${hash}`;
+  // Fix #1581: scope by LAYOUT_VERSION so a defaults bump invalidates old caches.
+  return `${PREFIX}.${LAYOUT_VERSION}.${group}.${hash}`;
 }
 
 function float32ToBase64(arr: Float32Array): string {
@@ -56,9 +78,29 @@ export function saveLayout(group: string, nodeIds: string[], positions: Float32A
   try {
     const encoded = float32ToBase64(positions);
     if (encoded.length > MAX_BYTES) return;
+    // Fix #1581: drop any layout entries from an OLDER version for this group +
+    // node set so stale blobs can never be read back and don't accumulate in
+    // localStorage. (We can only namespace-scan the keys we know how to rebuild.)
+    pruneOldVersions(group, nodeIds);
     localStorage.setItem(layoutKey(group, nodeIds), encoded);
   } catch {
     /* ignore quota / private-mode */
+  }
+}
+
+/**
+ * Fix #1581: remove layout-cache entries written under a PREVIOUS LAYOUT_VERSION
+ * for this exact group + node set, so a reload can never fall back to a layout
+ * baked by retired forces and localStorage doesn't grow unbounded across ships.
+ */
+function pruneOldVersions(group: string, nodeIds: string[]): void {
+  try {
+    const hash = fnv1a32([...nodeIds].sort().join(","));
+    for (let v = 0; v < LAYOUT_VERSION; v++) {
+      localStorage.removeItem(`${PREFIX}.${v}.${group}.${hash}`);
+    }
+  } catch {
+    /* ignore */
   }
 }
 
@@ -106,15 +148,32 @@ export function isDegenerateLayout(positions: Float32Array): boolean {
   const spanX = maxX - minX;
   const spanY = maxY - minY;
   const span = Math.max(spanX, spanY);
-  // Degenerate = the cloud has COLLAPSED toward a point — its span is tiny
-  // relative to the node count. A healthy cosmos.gl settle spreads roughly
-  // sqrt(n) × ~10 units of span (empirically ~584 for 3000 nodes); a contracted /
-  // mid-collapse snapshot is many times smaller. We threshold well BELOW the
-  // healthy span (sqrt(n) × 3, ≈164 for 3000) so a good spread is never rejected,
-  // while a true collapse (all nodes piled together) still trips it. The floor
-  // (40) catches the fully-collapsed case on tiny graphs.
-  const minHealthySpan = Math.max(40, Math.sqrt(n) * 3);
+  // Fix #1581: reject both a COLLAPSED layout (all nodes piled near a point) AND
+  // an OVER-CONTRACTED one (a tight ball / mushed clusters — the bug). A healthy
+  // cosmos.gl settle under the current forces spreads roughly sqrt(n) × ~10 units
+  // (empirically ~584 for 3000 nodes); the over-contracted reload blob is several
+  // times smaller. The earlier threshold (sqrt(n) × 3) only caught a near-total
+  // collapse, so the tight-ball reload slipped through and looked wrong vs Reset.
+  // Raise the healthy floor to sqrt(n) × 6 (≈329 for 3000) — still comfortably
+  // below a real spread so a good layout is never rejected, but now a contracted
+  // ball trips it and the caller re-settles (matching Reset). The absolute floor
+  // (60) catches the fully-collapsed case on tiny graphs.
+  const minHealthySpan = Math.max(60, Math.sqrt(n) * 6);
   return span < minHealthySpan;
+}
+
+/**
+ * Fix #1581: convenience predicate — a cached layout is GOOD (reusable on load)
+ * when every coordinate is finite AND the bounding-box spread is healthy for the
+ * node count (not collapsed, not an over-contracted ball). Callers reuse the cache
+ * only when this passes; otherwise they re-settle (== Reset).
+ */
+export function isLayoutHealthy(positions: Float32Array, expectedLen: number): boolean {
+  if (positions.length !== expectedLen) return false;
+  for (let i = 0; i < positions.length; i++) {
+    if (!Number.isFinite(positions[i])) return false;
+  }
+  return !isDegenerateLayout(positions);
 }
 
 export function clearLayout(group: string, nodeIds: string[]): void {

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -153,7 +153,12 @@ const ALL_EDGE_KINDS: EdgeKind[] = [
 // the change actually lands on next load with no manual Reset.
 // Fix #1580: bump so the lowered base-size floor + auto-scale defaults reach
 // users who already have a stored sizing blob (e.g. baseSize 90 from v2).
-const DEFAULTS_VERSION = 3;
+// Fix #1581: bump again — the recurring "reload restores a contracted layout"
+// bug is rooted in stale CACHED LAYOUTS produced by retired force defaults. We
+// scope the layout cache by graph-layout-cache.LAYOUT_VERSION (kept in lock-step
+// with this constant); bumping here also discards stale persisted TUNING so the
+// current force defaults (which produce the good spread) actually apply on load.
+const DEFAULTS_VERSION = 4;
 const VERSION_KEY = "ag.v2.graph.defaultsVersion";
 
 function readStoredVersion(): number {


### PR DESCRIPTION
## 1. Problem

On a big WebUI v2 graph (upvate ~19.8k, polyglot-platform), **reloading** the page restored an over-contracted / degenerate cached layout (a tight ball / mushed clusters), while pressing **Reset / Re-layout** re-ran the simulation and produced the good separated spread. Recurring bug (hit 3+ times); #1567's attempt only caught a *fully-collapsed* layout, so the tight-ball reload slipped through.

## 2. Root cause

Three compounding causes:
- **Stale layout cache vs. new forces.** The cached node positions are a product of the simulation/force defaults. We changed forces in #1566/#1569/#1586, but the cached positions baked by the OLD forces persisted — reload restored a layout produced by forces that no longer exist.
- **First-load settle ≠ Reset settle.** The no-cache first-load path ran a mid-settle re-heat (a second alpha pass at ~45%) gated by `reheatedRef` + `onSimulationEnd`; the Reset path just did `g.start(1)` + a lone cap timer with **no** re-heat. The two paths converged differently.
- **Weak quality gate.** `isDegenerateLayout` only rejected a near-total collapse (`span < sqrt(n)*3`), so an over-contracted (but not fully collapsed) cache was reused.

## 3. Fix

1. **Version the layout cache.** New `LAYOUT_VERSION` (=4) is baked into every cache key (`archigraph.v2.layout.<ver>.<group>.<hash>`), kept in lock-step with the store's `DEFAULTS_VERSION` (also bumped 3→4). A defaults change makes every old-version key a guaranteed MISS → re-settle. `saveLayout` prunes old-version entries for the same group + node set.
2. **Unified settle path.** Factored the fresh-settle routine into one `kickFreshSettle()` (reseed → `start` → mid-settle re-heat → hard cap → `doSettle`/fit/cache) called by **every** fresh-settle entry point: first load, Reset/Re-layout, group change, group-by change, ego re-layout. A fresh load is now byte-for-byte the same settle Reset runs.
3. **Health gate on reuse.** New `isLayoutHealthy()` (finite + not collapsed + not over-contracted; healthy-span floor raised `sqrt(n)*3` → `sqrt(n)*6`) gates cache reuse on every load path. `doSettle` still snapshots the cache only after a non-degenerate settle.

`allFinite` (now unused) removed; `isDegenerateLayout` retained for the save-time guard.

## 4. Files

- `webui-v2/src/lib/graph-layout-cache.ts` — `LAYOUT_VERSION`, version-scoped key, `pruneOldVersions`, `isLayoutHealthy`, stricter degenerate floor.
- `webui-v2/src/components/graph/graph-canvas.tsx` — `kickFreshSettle` unified routine wired into all settle entry points; load paths use `isLayoutHealthy`.
- `webui-v2/src/store/use-graph-store.ts` — `DEFAULTS_VERSION` 3→4.

## 5. Verification (real big graphs, isolated dev server + Playwright)

`npm run build` clean, `npm run lint` (tsc) clean. Isolated Vite dev (`:47280`, `AG_API_TARGET` read-only proxy to the daemon; live `:47274` untouched). dashboard/ zero diff.

**upvate (rendered 3000-node LoD subset of 19.8k):**
- (a) Fresh load (cache cleared) auto-settled to a good spread — span **3277**, 0 non-finite, no Reset needed. v4 cache key written.
- (b) Reload → span **3277** (byte-identical to fresh; cache restored the good layout). Reset (Re-layout button) → healthy spread (raw span 584 > healthy floor 329; differs in raw units only because cosmos `rescalePositions` rescales each `start()` — both fit-fill the viewport identically). Screenshots fresh/reload/reset all show the same separated repo islands.
- (c) Seeded a stale **v3** contracted blob (span ~5) + removed the v4 key → reload IGNORED it (version-scoped miss), re-settled to span **589** (> floor 329), and PRUNED the stale v3 key.

**polyglot-platform (1316 nodes):**
- Fresh load span **3277**, 0 non-finite, healthy (floor 218). Reload span **3277** — identical. Screenshots match.

## 6. Risk / rollout

Low-risk, WebUI v2 graph only. The version bump silently discards stale cached layouts + persisted tuning on first load (intended). No backend / orphan / topology / operations changes. Not merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)