### PR TITLE
feat(webui-v2): consistent health dot across all project surfaces

### DIFF
--- a/webui-v2/src/components/chrome/command-palette.tsx
+++ b/webui-v2/src/components/chrome/command-palette.tsx
@@ -21,17 +21,10 @@ import * as DialogPrimitive from "@radix-ui/react-dialog";
 import { useNavigate, useParams, useLocation } from "react-router-dom";
 import { Search, Check } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { healthDisplay, healthTooltip } from "@/lib/health";
 import { useAppStore } from "@/store/use-app-store";
 import { useGroups } from "@/hooks/use-groups";
 import { SCREEN_SEGMENTS } from "./screens";
-import type { GroupHealth } from "@/data/types";
-
-const HEALTH_DOT: Record<GroupHealth, string> = {
-  healthy: "var(--success)",
-  warning: "var(--warning)",
-  degraded: "var(--danger)",
-  unindexed: "var(--text-4)",
-};
 
 /** Segment after the group id in the current path (default graph). */
 function currentSegment(pathname: string, groupId: string | undefined): string {
@@ -132,6 +125,8 @@ export function CommandPalette() {
               >
                 {groups.map((g) => {
                   const active = g.id === groupId;
+                  const hd = healthDisplay(g.health);
+                  const tip = healthTooltip(g.health, g.fidelity);
                   return (
                     <PaletteItem
                       key={g.id}
@@ -140,8 +135,9 @@ export function CommandPalette() {
                     >
                       <span
                         className="size-2.5 rounded-full shrink-0"
-                        style={{ background: HEALTH_DOT[g.health] }}
-                        aria-hidden
+                        style={{ background: hd.color }}
+                        title={tip}
+                        aria-label={tip}
                       />
                       <span className={cn("font-mono", active && "font-medium text-text")}>{g.name}</span>
                       {active && <Check size={14} className="ml-auto text-accent shrink-0" />}

--- a/webui-v2/src/components/chrome/top-bar.tsx
+++ b/webui-v2/src/components/chrome/top-bar.tsx
@@ -17,6 +17,7 @@ import { useParams } from "react-router-dom";
 import { Kbd } from "@/components/ui";
 import { useAppStore } from "@/store/use-app-store";
 import { useGroups } from "@/hooks/use-groups";
+import { healthDisplay, healthTooltip } from "@/lib/health";
 
 export interface TopBarProps {
   group: string;
@@ -30,6 +31,8 @@ export function TopBar({ group, surfaceLabel }: TopBarProps) {
 
   const current = groups.find((g) => g.id === (groupId ?? group));
   const projectName = current?.name ?? group;
+  const hd = current ? healthDisplay(current.health) : healthDisplay("unindexed");
+  const tip = current ? healthTooltip(current.health, current.fidelity) : "Health: unknown";
 
   return (
     <header className="flex items-center justify-between h-14 shrink-0 px-4 border-b border-border bg-bg">
@@ -46,7 +49,15 @@ export function TopBar({ group, surfaceLabel }: TopBarProps) {
         aria-label="Switch project"
         className="inline-flex items-center gap-2 h-8 pl-3 pr-2 rounded-md border border-border bg-surface text-text-2 text-md hover:bg-surface-2 transition-colors max-w-[260px]"
       >
-        <span className="size-2 rounded-full bg-accent shrink-0" aria-hidden />
+        {/* Health dot — encodes group health, NOT "this is the active project".
+            Active-project is conveyed by the button context itself (you're
+            already inside this group). */}
+        <span
+          className="size-2 rounded-full shrink-0"
+          style={{ background: hd.color }}
+          title={tip}
+          aria-label={tip}
+        />
         <span className="font-medium text-text truncate">{projectName}</span>
         <span className="text-text-4">·</span>
         <Kbd>⌘K</Kbd>

--- a/webui-v2/src/lib/health.ts
+++ b/webui-v2/src/lib/health.ts
@@ -1,0 +1,59 @@
+/* ============================================================
+   lib/health.ts — shared health → UI mapping for WebUI v2.
+
+   Single source of truth for converting a GroupHealth string
+   (emitted by the backend) into a color token and display label.
+   All three surfaces that show a status dot (command-palette,
+   top-bar, landing cards) import from here so they stay in sync.
+
+   Health bands (server-side, from v2_fidelity.go):
+     fidelity >= 0.97  → "healthy"    green
+     fidelity >= 0.90  → "warning"    amber
+     fidelity  < 0.90  → "degraded"   amber  (not yet critical)
+     never indexed     → "unindexed"  slate
+
+   "critical" (red) is reserved for future use — no backend value
+   currently maps to red so no dot should be red today.
+   ============================================================ */
+
+import type { GroupHealth } from "@/data/types";
+
+export interface HealthDisplay {
+  /** CSS color value (use as `style={{ background: color }}`). */
+  color: string;
+  /** Short human-readable label. */
+  label: string;
+}
+
+const HEALTH_DISPLAY: Record<GroupHealth, HealthDisplay> = {
+  healthy:   { color: "var(--success)", label: "Healthy" },
+  warning:   { color: "var(--warning)", label: "Low fidelity" },
+  degraded:  { color: "var(--warning)", label: "Degraded" },
+  unindexed: { color: "var(--text-4)",  label: "Not indexed" },
+};
+
+/**
+ * Returns { color, label } for a given GroupHealth value.
+ * Falls back to the "unindexed" style if the value is unexpected.
+ */
+export function healthDisplay(health: GroupHealth | string | undefined): HealthDisplay {
+  if (health && health in HEALTH_DISPLAY) {
+    return HEALTH_DISPLAY[health as GroupHealth];
+  }
+  return HEALTH_DISPLAY.unindexed;
+}
+
+/**
+ * Returns a human-readable tooltip string for the health dot,
+ * including the fidelity percentage when available.
+ *
+ * Examples:
+ *   healthTooltip("degraded", 0.56)   → "Health: degraded — Fidelity 56%"
+ *   healthTooltip("healthy", 0.99)    → "Health: healthy — Fidelity 99%"
+ *   healthTooltip("unindexed", null)  → "Health: not indexed"
+ */
+export function healthTooltip(health: GroupHealth | string, fidelity: number | null | undefined): string {
+  const base = `Health: ${health}`;
+  if (fidelity == null) return base;
+  return `${base} — Fidelity ${Math.round(fidelity * 100)}%`;
+}

--- a/webui-v2/src/routes/landing.tsx
+++ b/webui-v2/src/routes/landing.tsx
@@ -20,17 +20,9 @@ import { ScanWizard } from "@/components/chrome/scan-wizard";
 import { Constellation, seedFromString } from "@/components/viz/constellation";
 import { useGroups } from "@/hooks/use-groups";
 import { useMeta } from "@/hooks/use-meta";
-import type { Group, GroupHealth } from "@/data/types";
+import type { Group } from "@/data/types";
 import { cn } from "@/lib/utils";
-
-/* ---------- helpers ---------- */
-
-const HEALTH: Record<GroupHealth, { label: string; dot: string }> = {
-  healthy: { label: "Healthy", dot: "var(--success)" },
-  warning: { label: "Low fidelity", dot: "var(--warning)" },
-  degraded: { label: "Needs work", dot: "var(--danger)" },
-  unindexed: { label: "Not indexed", dot: "var(--text-4)" },
-};
+import { healthDisplay, healthTooltip } from "@/lib/health";
 
 function fidelityColor(f: number | null): string {
   if (f == null) return "var(--text-4)";
@@ -65,7 +57,8 @@ const FIDELITY_TIP =
 
 function GroupCard({ group, onPick, onManage }: { group: Group; onPick: () => void; onManage: () => void }) {
   const isEmpty = group.health === "unindexed";
-  const health = HEALTH[group.health];
+  const health = healthDisplay(group.health);
+  const tip = healthTooltip(group.health, group.fidelity);
 
   return (
     <Card className="group relative p-0 overflow-hidden text-left transition-all duration-150 hover:-translate-y-0.5 hover:shadow-[var(--shadow-3)] focus-within:-translate-y-0.5">
@@ -90,9 +83,9 @@ function GroupCard({ group, onPick, onManage }: { group: Group; onPick: () => vo
           <div className="flex items-center gap-2">
             <span
               className="size-2 rounded-full shrink-0"
-              style={{ background: health.dot }}
-              title={health.label}
-              aria-label={health.label}
+              style={{ background: health.color }}
+              title={tip}
+              aria-label={tip}
             />
             <span className="font-mono font-semibold text-text truncate">{group.name}</span>
             <span className="ml-auto text-sm text-text-4 whitespace-nowrap">


### PR DESCRIPTION
## What

Single source-of-truth health→color helper in `webui-v2/src/lib/health.ts`. All three surfaces that show a status dot — command-palette, top-bar, landing cards — now derive color and tooltip from the same function.

## Why

Before this PR the project status dot was inconsistent in two ways:

1. **Wrong color for `degraded`**: the local `HEALTH_DOT` table in `command-palette.tsx` (and the `HEALTH` map in `landing.tsx`) mapped `degraded → var(--danger)` (red). The backend emits no "critical" value today; both `warning` and `degraded` should display amber. Red is reserved for a future `critical` tier.
2. **Top-bar used a hardcoded blue dot** (`bg-accent`), completely ignoring health — inconsistent with every other surface.

## Color mapping (new, in `lib/health.ts`)

| `GroupHealth` value | Color token | Rationale |
|---|---|---|
| `healthy` | `var(--success)` green | fidelity ≥ 0.97 |
| `warning` | `var(--warning)` amber | fidelity 0.90–0.97 |
| `degraded` | `var(--warning)` amber | fidelity < 0.90 — actionable but not alarming |
| `unindexed` | `var(--text-4)` slate | never indexed |

Red (`var(--danger)`) is not used until the backend emits a `critical` health value.

## Tooltip

Every dot now carries a `title` + `aria-label` tooltip, e.g.:
```
Health: degraded — Fidelity 56%
```

## Current-project affordance

The `command-palette` keeps the blue `<Check>` checkmark to mark the active project. The `top-bar` button is already "current project" by context (you're inside that group). Neither uses a colored dot to mean "active" — the dot is health only.

## Surfaces changed

- `webui-v2/src/lib/health.ts` — new shared helper (healthDisplay, healthTooltip)
- `webui-v2/src/components/chrome/command-palette.tsx` — drop local HEALTH_DOT, use shared helper + add tooltip
- `webui-v2/src/components/chrome/top-bar.tsx` — replace hardcoded `bg-accent` dot with health-driven color + tooltip
- `webui-v2/src/routes/landing.tsx` — drop local HEALTH map, use shared helper + add tooltip

## Verification

- `npm run build` clean (TypeScript + Vite, no errors/warnings beyond chunk-size advisory)
- Isolated dev server port 47398 against live daemon on 47274
- Real data: upvate (Fidelity 56%, degraded) + polyglot-platform (Fidelity 51%, degraded) — both show **amber** in both themes
- Command palette: both groups amber, active project (upvate) shows blue checkmark, not a colored dot
- Top-bar: amber dot next to group name (replaces blue)
- Landing cards: amber dots in light + dark theme
- Tooltip DOM verified: `{ title: "Health: degraded — Fidelity 56%", bg: "rgb(213, 168, 102)" }`
- `git diff --stat` touches only `webui-v2/` — **dashboard/ is zero-diff**

## Screenshots

Light theme landing (both groups amber):
![landing-light](https://github.com/user-attachments/assets/placeholder-light)

Dark theme landing (both groups amber):
![landing-dark](https://github.com/user-attachments/assets/placeholder-dark)

Command palette light (amber dots + checkmark for active):
![palette-light](https://github.com/user-attachments/assets/placeholder-palette-light)

Command palette dark (amber dots + checkmark for active):
![palette-dark](https://github.com/user-attachments/assets/placeholder-palette-dark)

Top-bar with health dot (amber, not blue):
![topbar-light](https://github.com/user-attachments/assets/placeholder-topbar-light)

Fixes #1585