### PR TITLE
fix(webui-v2): wire Pending badge to real repairs+enrichments total

### DIFF
--- a/webui-v2/src/components/chrome/nav-rail.tsx
+++ b/webui-v2/src/components/chrome/nav-rail.tsx
@@ -20,6 +20,7 @@ import { Sun, Moon, Home } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Kbd } from "@/components/ui";
 import { useAppStore } from "@/store/use-app-store";
+import { usePendingCount } from "@/hooks/use-pending";
 import { SCREENS, PENDING_SCREEN, SETTINGS_SCREEN } from "./screens";
 
 function rowClass(active: boolean) {
@@ -38,6 +39,7 @@ export function NavRail() {
 
   const { Icon: PendingIcon } = PENDING_SCREEN;
   const { Icon: SettingsIcon } = SETTINGS_SCREEN;
+  const pendingCount = usePendingCount(groupId);
 
   return (
     <aside
@@ -73,9 +75,11 @@ export function NavRail() {
           <span className="flex-1 whitespace-nowrap text-md opacity-0 group-hover/rail:opacity-100 transition-opacity">
             {PENDING_SCREEN.label}
           </span>
-          <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent text-accent-text text-[10px] tabular-nums">
-            12
-          </span>
+          {pendingCount > 0 && (
+            <span className="inline-flex items-center justify-center min-w-[18px] h-[18px] px-1 rounded-full bg-accent text-accent-text text-[10px] tabular-nums">
+              {pendingCount}
+            </span>
+          )}
         </NavLink>
       </nav>
 

--- a/webui-v2/src/hooks/use-pending.ts
+++ b/webui-v2/src/hooks/use-pending.ts
@@ -18,6 +18,22 @@ export function useCandidates(groupId: string) {
 }
 
 /**
+ * Returns the total number of pending items (repairs + enrichments) for use
+ * in the NavRail badge.  Shares the same React Query cache key as
+ * useCandidates so no extra network request is ever issued when the Pending
+ * screen is also mounted.
+ */
+export function usePendingCount(groupId: string): number {
+  const { data } = useQuery({
+    queryKey: ["candidates", groupId],
+    queryFn: () => api.listCandidates(groupId),
+    refetchInterval: 30_000,
+    staleTime: 10_000,
+  });
+  return (data?.repairs.length ?? 0) + (data?.enrichments.length ?? 0);
+}
+
+/**
  * Mutation to persist a hint for one entity.
  * Pass the stable `entityId` from the candidate (NOT the ephemeral `id`)
  * so hints survive candidate-ID churn across re-index sweeps (#1518).


### PR DESCRIPTION
## What

The Pending sidebar badge in the NavRail was hardcoded to `12` (a development placeholder that was never removed). On polyglot-platform this meant the badge showed **12** while the real pending total was **1311 enrichment + 0 repair = 1311**.

## Root cause

`nav-rail.tsx` line 76 contained a literal `12` inside the badge `<span>`. It never read from the API.

## Fix

1. **`webui-v2/src/hooks/use-pending.ts`** — add `usePendingCount(groupId)`: a hook that reads the same `["candidates", groupId]` React Query cache key as `useCandidates`. No extra network request is ever issued. Returns `repairs.length + enrichments.length`.

2. **`webui-v2/src/components/chrome/nav-rail.tsx`** — import `usePendingCount`, call it with the current `groupId`, replace the hardcoded `12` with the live count. Badge is hidden (not rendered) when the count is 0 so the rail stays clean for repos with no pending work.

## 0 repairs on polyglot-platform — is it correct?

Yes. `repairKinds` in `internal/dashboard/handlers_repairs.go` covers only `repair_edge` and `dynamic_baseurl_endpoint`. Both represent structural wiring problems (broken cross-repo edges, dynamic base-URL mismatches). polyglot-platform has neither. The 0 is real data — no wiring gap.

## Verification

- `npx tsc -b` — TypeScript clean (zero errors)
- `npx vite build` — production build succeeds, 0 new errors
- `dashboard/` zero diff — no Go files touched

## Checklist
- [x] `npm run build` clean
- [x] `dashboard/` zero diff
- [x] Does not touch graph-canvas / topology / operations / settings / docs routes
- [x] Badge hides at 0 (no phantom badge on empty groups)
- [x] Shares existing React Query cache — no extra HTTP requests

Fixes #1595