### PR TITLE
fix(webui-v2): default LoD = HIGH + repo-aware cross-repo emphasis with real data (#1599)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -481,8 +481,6 @@ function GraphCanvasInner(
     // a distinct bright bridge color in BOTH themes. Re-packed on theme change
     // (isDark is a dep), so the dark/light toggle flows through live.
     const pal = linkPalette(isDark);
-    // Fix #1566: keep emphasis muted + thin (no violet/sky spaghetti) — cross
-    // edges read as a slightly distinct thread, not a dominating rope.
     // Fix #1567-1: make the emphasis tier REPO-AWARE. We compute three opacity
     // tiers — faded / subtle / emphasized — then map each edge STATE onto a tier
     // depending on whether the group is multi-repo:
@@ -491,10 +489,40 @@ function GraphCanvasInner(
     //                  island↔island bridges light up, NOT the in-repo wiring.
     //   • single-repo: no st-2 edges; cross-MODULE (st 1) = emphasized,
     //                  intra-module (st 0) = faded (the #1569 behavior).
+    //
+    // Fix #1599: the #1566/#1567 emphasis was tuned with ZERO real cross-repo
+    // edges present, so the "make cross-repo pop" path was never exercised against
+    // live data. Now upvate serves 376 cross-repo edges out of 37k — but the old
+    // tier gaps were so tight (faded≈0.36 / subtle≈0.51 / emph≈0.63) that those
+    // 376 bridges were lost in the 37k-edge mesh. Because the cross-repo bridges
+    // are RARE (376 of 37k), they can safely be near-opaque + bright WITHOUT
+    // becoming spaghetti — there simply aren't enough of them to dominate. So when
+    // the group is MULTI-REPO we open the gap hard: the emphasized (cross-repo)
+    // tier goes near-full opacity while intra-repo (cross-module + intra-module)
+    // edges fade well back, so the inter-cluster connections visibly stand out.
+    // For a single-repo monorepo the cross-MODULE tier is the rare/structural one,
+    // so it gets the emphasized treatment but with a gentler gap (cross-module is
+    // far more common than cross-repo, so over-brightening it would re-introduce
+    // spaghetti).
     const base = render.linkOpacity;
-    const fadedA = Math.min(0.5, base * 0.6);
-    const subtleA = Math.min(0.7, Math.max(0.5, base * 0.85));
-    const emphA = Math.min(0.8, Math.max(0.6, base * 1.05));
+    let fadedA: number;
+    let subtleA: number;
+    let emphA: number;
+    if (isMultiRepo) {
+      // Wide gap: bridges pop, intra-repo recedes. The rare cross-repo edges
+      // (376 of 37k on upvate) get a high — but not fully opaque — alpha so they
+      // clearly own the foreground while staying tasteful even when a denser
+      // layout packs them through the center (not a solid cyan mat).
+      fadedA = Math.min(0.32, base * 0.5);
+      subtleA = Math.min(0.42, Math.max(0.3, base * 0.62));
+      emphA = 0.85;
+    } else {
+      // Single-repo: cross-module is the (more common) emphasized tier — a
+      // tasteful gap that still keeps it readable, not blaring.
+      fadedA = Math.min(0.5, base * 0.6);
+      subtleA = Math.min(0.7, Math.max(0.5, base * 0.85));
+      emphA = Math.min(0.85, Math.max(0.65, base * 1.15));
+    }
     for (let i = 0; i < states.length; i++) {
       const st = states[i];
       // tier: 0 faded, 1 subtle, 2 emphasized — repo-aware.
@@ -532,12 +560,18 @@ function GraphCanvasInner(
     // repo) gets the thickest hair; the subtle tier sits between; intra is
     // thinnest. So upvate's island bridges read as the distinct tier, not the
     // in-repo wiring.
-    const W_FADED = 0.8;
-    const W_SUBTLE = 1.0;
-    const W_EMPH = 1.3;
-    const FLOOR_FADED = 0.8;
-    const FLOOR_SUBTLE = 1.0;
-    const FLOOR_EMPH = 1.2;
+    // Fix #1599: on a MULTI-REPO group the rare cross-repo bridges (376 of 37k on
+    // upvate) get a distinctly thicker hair so they read as the structural tier,
+    // while intra-repo edges stay thin. There are few enough bridges that a
+    // noticeably thicker line stays tasteful (no rope). On a single-repo monorepo
+    // the cross-module emphasized tier is far more common, so keep the original
+    // gentle width gap to avoid spaghetti.
+    const W_FADED = isMultiRepo ? 0.6 : 0.8;
+    const W_SUBTLE = isMultiRepo ? 0.7 : 1.0;
+    const W_EMPH = isMultiRepo ? 1.8 : 1.3;
+    const FLOOR_FADED = isMultiRepo ? 0.6 : 0.8;
+    const FLOOR_SUBTLE = isMultiRepo ? 0.7 : 1.0;
+    const FLOOR_EMPH = isMultiRepo ? 1.7 : 1.2;
     for (let i = 0; i < states.length; i++) {
       const st = states[i];
       let tier: 0 | 1 | 2;

--- a/webui-v2/src/lib/graph-colors.ts
+++ b/webui-v2/src/lib/graph-colors.ts
@@ -140,23 +140,29 @@ export function linkPalette(isDark: boolean): LinkPalette {
   // are now only a SLIGHTLY-distinct, more muted tone than intra (a soft
   // sky / lavender-ish slate) so the user can TRACE them on inspection rather
   // than be overwhelmed. Still theme-aware (#1564) + dark-visible.
+  // Fix #1599: with real cross-repo edges now present (and rare — 376 of 37k on
+  // upvate), the bridge color is the KEY signal and can be a vivid, fully-
+  // saturated cyan in both themes without becoming spaghetti. The intra tiers are
+  // pushed quieter (lower contrast vs the bg) so the bright bridges clearly own
+  // the foreground. This is the chromatic half of the multi-repo emphasis (the
+  // opacity/width gaps live in graph-canvas).
   if (isDark) {
     return {
-      // muted sky — distinct but not blaring on the near-black bg.
-      crossRepo: [125, 211, 252, 1],
+      // vivid sky/cyan — the bridge signal, pops on the near-black bg.
+      crossRepo: [56, 211, 255, 1],
       // soft periwinkle — only slightly distinct from intra slate.
-      crossModule: [165, 180, 252, 1],
-      // light slate — visible on dark but quiet, so it recedes.
-      intraModule: [148, 163, 184, 1],
+      crossModule: [148, 163, 220, 1],
+      // dim slate — quiet, recedes well into the dark bg.
+      intraModule: [120, 134, 156, 1],
     };
   }
   return {
-    // medium sky — distinct but not saturated against the light bg.
-    crossRepo: [56, 154, 214, 1],
+    // saturated sky/cyan — the bridge signal, pops on the light bg.
+    crossRepo: [14, 144, 210, 1],
     // muted indigo — only slightly distinct from the slate intra edges.
-    crossModule: [99, 102, 180, 1],
-    // dark slate — quiet, recedes into the light bg.
-    intraModule: [71, 85, 105, 1],
+    crossModule: [110, 116, 170, 1],
+    // light slate — quiet, recedes into the light bg.
+    intraModule: [120, 134, 156, 1],
   };
 }
 

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -302,7 +302,15 @@ export const useGraphStore = create<GraphState>((set) => ({
 
   enabledEdgeKinds: new Set(ALL_EDGE_KINDS),
   activeRepos: null,
-  lod: "mid",
+  // Fix #1599: DEFAULT to HIGH so the FULL graph renders out of the box (no
+  // node/edge thinning). MID/overview previously capped the daemon payload to
+  // ~3000 nodes, which silently dropped most of a large graph (upvate: 3000 of
+  // 19.6k nodes) AND nearly all cross-repo edges (10 of 376) — so the inter-repo
+  // structure the emphasis tier exists to surface was never even served. HIGH
+  // serves the complete corpus (19,613 nodes / 37,418 edges on upvate); cosmos.gl
+  // renders it fine (verified #1562/#1580). MID/LOW stay selectable as lighter
+  // tiers via the LOD control.
+  lod: "high",
 
   colorMode: "repo",
   groupBy: "repo",
@@ -382,7 +390,8 @@ export const useGraphStore = create<GraphState>((set) => ({
     set({
       enabledEdgeKinds: new Set(ALL_EDGE_KINDS),
       activeRepos: null,
-      lod: "mid",
+      // Fix #1599: clearing filters returns to the full-graph default (HIGH).
+      lod: "high",
     }),
   resetView: () =>
     set({


### PR DESCRIPTION
## 1. What & why

WebUI v2 graph defaulted to **MID** LoD, which capped the daemon payload to ~3000 nodes. On a large group like upvate that silently dropped most of the graph (3000 of 19.8k nodes) **and** nearly all the cross-repo structure (the daemon served only ~18 of 376 cross-repo edges at MID, 0 at LOW). So the out-of-box graph was both incomplete and missing the very inter-repo links the emphasis tier exists to surface.

Separately, the repo-aware emphasis (#1567) was implemented when **zero** real cross-repo edges existed, so the "emphasize cross-REPO, fade intra" branch was never exercised against live data. With its tight tier gaps (faded≈0.36 / subtle≈0.51 / emph≈0.63, widths 0.8/1.0/1.3) the 376 real bridges were lost in the 37k-edge mesh.

This PR (a) makes **HIGH** the default LoD so the full corpus renders with no node/edge thinning, and (b) opens the emphasis gap hard for multi-repo groups so the rare cross-repo bridges visibly stand out. Fixes #1599.

## 2. Changes

- **`store/use-graph-store.ts`** — default `lod: "mid"` → `"high"` (initial state + `clearAllFilters`). LoD is a server-side parameter (the daemon does all thinning); HIGH requests the complete graph. MID/LOW stay selectable as lighter tiers. LoD is not persisted, so no defaults-version bump needed.
- **`components/graph/graph-canvas.tsx`** — `packLinkColors` / `packLinkWidths` now branch on `isMultiRepo`:
  - **Multi-repo** (e.g. upvate = 3 repos): cross-repo (emphasized) tier gets high opacity (0.85) + a distinctly thicker hair (width 1.8, floor 1.7); intra-repo (cross-module + intra-module) fade well back (≤0.42 opacity, 0.6–0.7 width). Because cross-repo edges are rare (376 of 37k), this stays tasteful — there aren't enough to become spaghetti.
  - **Single-repo monorepo**: cross-MODULE stays the emphasized tier, but with the original gentler gap (cross-module is far more common, so over-brightening would re-introduce spaghetti).
- **`lib/graph-colors.ts`** — `linkPalette` bridge color is now a vivid saturated cyan in both themes (the chromatic half of the emphasis); intra tiers pushed quieter so the bright bridges own the foreground.

## 3. How it was verified

`npm run build` clean. Isolated Vite dev server (port 47286, never the live :47274), Playwright on real data, both themes:

- **upvate HIGH default**: LOD badge `HIGH 19,613/19,613`, `getPointPositions().length/2 === 19613` — full graph, no thinning. The 376 cross-repo bridges render as the bright/thick tier spanning the 3 repo clusters; intra edges faded.
- **polyglot-platform HIGH default**: `1,323/1,323`, renders fine.
- **Reload === Reset (#1602 not broken)**: reload re-settles to a healthy spread (bbox ≈3030×3277, not collapsed) at the full 19,613 nodes.
- Daemon payload audit confirming the premise: `lod=high` → 19,613 nodes / 37,418 edges / 376 cross-repo; `lod=mid` → 3000 / 7039 / 18; `lod=low` → 500 / 751 / 0.

## 4. Screenshots

(attached in the PR thread comment)
- upvate HIGH light — cross-repo bridges stand out between clusters
- upvate HIGH dark — same, vivid cyan bridges
- polyglot HIGH light — full multi-repo graph

## 5. Risk / blast radius

Frontend-only, scoped to the graph canvas + its store/colors. No backend / topology / operations / dashboard changes (dashboard/ diff is empty). HIGH was already verified renderable on upvate at #1562/#1580; cosmos.gl handles the full set fine. Lower tiers remain available via the LoD control for memory-constrained sessions.

## 6. Follow-ups

- On a *cache-reused* reload of a very dense graph the layout can contract into a tighter ball (a pre-existing settle/cache-quality behavior, not introduced here); a fresh settle separates the clusters cleanly. The tuned emphasis (0.85 opacity / 1.8 width) was chosen to stay tasteful even in the contracted state. Worth a separate look at large-graph cache-reload settle quality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
