### PR TITLE
feat(topology): IaC SNS→multi-SQS fan-out across CDK/TF/CFN (#1596)

### DIFF
--- a/internal/dashboard/topology_sns_fanout_test.go
+++ b/internal/dashboard/topology_sns_fanout_test.go
@@ -1,0 +1,63 @@
+package dashboard
+
+// topology_sns_fanout_test.go — #1596. Verifies that the IaC-declared
+// SNS→multi-SQS fan-out (one SNS topic with SQS subscribers declared across
+// CDK / Terraform / CloudFormation) renders in the topology surface as a
+// single SNS topic node with 3+ SQS subscribers. Mirrors the entity/edge
+// shape emitted by internal/engine/applyIaCSNSEdges (topic = SCOPE.MessageTopic
+// broker=sns; each SQS subscriber = SUBSCRIBES_TO edge FromID=SQS-queue,
+// ToID=SNS-topic).
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestCollectTopology_SNSMultiIaCFanOut(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "polyglot-platform",
+		Entities: []graph.Entity{
+			{ID: "topic-oe", Name: "sns:order-events", Kind: "SCOPE.MessageTopic",
+				Properties: map[string]string{"broker": "sns", "pattern_type": "iac_sns_fanout"}},
+			{ID: "q-analytics", Name: "sqs:order-events-analytics", Kind: "SCOPE.Queue",
+				Properties: map[string]string{"broker": "sqs", "pattern_type": "iac_sns_fanout", "iac_tool": "cdk"}},
+			{ID: "q-audit", Name: "sqs:order-events-audit", Kind: "SCOPE.Queue",
+				Properties: map[string]string{"broker": "sqs", "pattern_type": "iac_sns_fanout", "iac_tool": "terraform"}},
+			{ID: "q-fraud", Name: "sqs:order-events-fraud", Kind: "SCOPE.Queue",
+				Properties: map[string]string{"broker": "sqs", "pattern_type": "iac_sns_fanout", "iac_tool": "cloudformation"}},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "s1", FromID: "q-analytics", ToID: "topic-oe", Kind: "SUBSCRIBES_TO",
+				Properties: map[string]string{"iac_tool": "cdk"}},
+			{ID: "s2", FromID: "q-audit", ToID: "topic-oe", Kind: "SUBSCRIBES_TO",
+				Properties: map[string]string{"iac_tool": "terraform"}},
+			{ID: "s3", FromID: "q-fraud", ToID: "topic-oe", Kind: "SUBSCRIBES_TO",
+				Properties: map[string]string{"iac_tool": "cloudformation"}},
+		},
+	}
+	grp := &DashGroup{
+		Name:  "g",
+		Repos: map[string]*DashRepo{"polyglot-platform": {Slug: "polyglot-platform", Doc: doc}},
+	}
+
+	topics, _, _, _ := collectTopology(grp)
+
+	var oe map[string]any
+	for _, topic := range topics {
+		if topic["label"] == "sns:order-events" {
+			oe = topic
+			break
+		}
+	}
+	if oe == nil {
+		t.Fatalf("order-events SNS topic not found in topology topics: %+v", topics)
+	}
+	if oe["broker"] != "sns" {
+		t.Errorf("broker = %v, want sns", oe["broker"])
+	}
+	consumers, _ := oe["consumers"].([]string)
+	if len(consumers) != 3 {
+		t.Fatalf("want 3 SQS subscribers on order-events topic, got %d (%v)", len(consumers), consumers)
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -333,6 +333,17 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// IaC-declared SNS → SQS fan-out edges (#1596). Reads SNS→SQS
+	// subscriptions declared in AWS CDK (TS), Terraform (HCL), and
+	// CloudFormation (YAML) and emits a synthetic SNS topic (SCOPE.Queue,
+	// broker=sns) plus a SUBSCRIBES_TO edge per SQS subscriber. Subscriptions
+	// for the same topic name declared across different IaC tools collapse
+	// onto a single SNS topic node, surfacing the fan-out in /topology.
+	// Append-only — cannot regress the surrounding pipeline's bug-rate.
+	entities, relationships = applyIaCSNSEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// Google Cloud Pub/Sub producer/consumer cross-repo edges (wave 3 of #726).
 	// Emits SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
 	// google-cloud-pubsub (Python/Node/Go/Java), Pub/Sub Lite, and

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -101,6 +101,15 @@ func synthesisSupportsLanguage(lang string) bool {
 	// #1483: Elixir Finch / HTTPoison consumer-side extraction.
 	case "elixir":
 		return true
+	// #1596: Infrastructure-as-Code languages have no compiled YAML rule sets
+	// of their own (Terraform rules live under the `hcl` key; CloudFormation
+	// YAML has none), so without this they would short-circuit out of Detect
+	// before the IaC-aware synthesis passes run. Allowing them through lets
+	// applyEventBusEdges (HCL EventBridge / serverless.yml) and applyIaCSNSEdges
+	// (Terraform / CloudFormation SNS→SQS fan-out) scan the raw content. Files
+	// with none of the recognised anchors are no-ops inside those passes.
+	case "terraform", "hcl", "yaml":
+		return true
 	default:
 		return false
 	}

--- a/internal/engine/iac_sns_edges.go
+++ b/internal/engine/iac_sns_edges.go
@@ -1,0 +1,447 @@
+// IaC-declared SNS → SQS fan-out detection — #1596.
+//
+// The application-side SNS→SQS detection (sqs_edges.go) only sees runtime
+// SDK calls (boto3 sns.subscribe, etc.). Fan-out topologies, however, are
+// almost always declared in Infrastructure-as-Code, where ONE SNS topic
+// subscribes several SQS queues. This pass reads the IaC declarations and
+// emits, for each SNS→SQS subscription it can statically recognise:
+//
+//   - a synthetic SNS topic entity  (SCOPE.Queue, broker=sns, id=sns:<name>)
+//   - a synthetic SQS queue entity  (SCOPE.Queue, broker=sqs, id=sqs:<name>)
+//   - a SUBSCRIBES_TO edge  FromID=SCOPE.Queue:sqs:<queue>  ToID=SCOPE.Queue:sns:<topic>
+//
+// The topology view (handlers_topology.go brokerEdges) reads SUBSCRIBES_TO
+// edges whose ToID is a Queue entity as that entity's consumers, so the SNS
+// topic node renders with one SQS subscriber per subscription. Because the
+// topic ID is canonicalised to just the topic name, subscriptions declared
+// across DIFFERENT IaC tools (CDK / Terraform / CloudFormation) for the same
+// topic name collapse onto a single SNS topic node — producing the intended
+// multi-IaC fan-out.
+//
+// IaC tools covered:
+//   - AWS CDK (TypeScript): `new sns.Topic(this, id, {topicName:"x"})` +
+//     `topic.addSubscription(new SqsSubscription(queueVar))`, resolving the
+//     queue var to its `new sqs.Queue(..., {queueName:"y"})` declaration.
+//   - Terraform / HCL: `resource "aws_sns_topic_subscription" "x" { topic_arn=...
+//     protocol="sqs" endpoint=aws_sqs_queue.y.arn }` resolving the queue ref
+//     to its `resource "aws_sqs_queue" "y" { name="..." }` declaration.
+//   - CloudFormation (YAML): `Type: AWS::SNS::Subscription` with `Protocol: sqs`,
+//     `TopicArn` (literal ARN, !Ref, or !GetAtt), and `Endpoint` (!GetAtt of
+//     an AWS::SQS::Queue resource), resolving the queue logical-id to its
+//     QueueName.
+//
+// # Scope guard
+//
+// Append-only — this pass never modifies or removes existing entities or
+// edges, so it cannot regress the surrounding pipeline's bug-rate.
+//
+// Refs #1596.
+package engine
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// iacSNSTopicName extracts the bare topic name from a topic name or ARN,
+// reusing the package-level snsTopicNameFromARN helper. Defensive against
+// stray whitespace.
+func iacSNSTopicName(nameOrARN string) string {
+	return snsTopicNameFromARN(strings.TrimSpace(nameOrARN))
+}
+
+// iacSNSSupportsLanguage reports whether applyIaCSNSEdges scans `lang`.
+// CDK arrives as typescript/javascript, Terraform as hcl/terraform,
+// CloudFormation as yaml.
+func iacSNSSupportsLanguage(lang string) bool {
+	switch lang {
+	case "javascript", "typescript", "hcl", "terraform", "yaml":
+		return true
+	default:
+		return false
+	}
+}
+
+// applyIaCSNSEdges is the entry point. Runs after applySQSEdges and is
+// append-only.
+func applyIaCSNSEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if len(content) == 0 {
+		return entities, relationships
+	}
+	if !iacSNSSupportsLanguage(lang) {
+		return entities, relationships
+	}
+
+	src := string(content)
+	// Cheap guard: file must mention SNS and a subscription idiom.
+	if !strings.Contains(src, "sns") && !strings.Contains(src, "SNS") &&
+		!strings.Contains(src, "Sns") {
+		return entities, relationships
+	}
+
+	seenEnt := map[string]bool{}
+	seenEdge := map[string]bool{}
+
+	// The SNS topic is a MessageTopic so it collapses onto the same node as
+	// any application-side SNS topic of the same name (kafka_wrapper_edges.go
+	// emits SNS topics as messageTopicKind).
+	emitTopic := func(name, iacTool string) string {
+		id := snsTopicID(name)
+		if !seenEnt["topic|"+id] {
+			seenEnt["topic|"+id] = true
+			entities = append(entities, types.EntityRecord{
+				Name:     id,
+				Kind:     messageTopicKind,
+				Language: lang,
+				Properties: map[string]string{
+					"broker":       "sns",
+					"topic_name":   iacSNSTopicName(name),
+					"pattern_type": "iac_sns_fanout",
+					"iac_tool":     iacTool,
+				},
+				EnrichmentStatus: types.StatusPending,
+				QualityScore:     0.8,
+			})
+		}
+		return id
+	}
+
+	emitQueue := func(name, iacTool string) string {
+		id := sqsQueueID(name)
+		if !seenEnt["queue|"+id] {
+			seenEnt["queue|"+id] = true
+			entities = append(entities, types.EntityRecord{
+				Name:     id,
+				Kind:     queueEntityKind,
+				Language: lang,
+				Properties: map[string]string{
+					"broker":       "sqs",
+					"queue_name":   sqsQueueDisplayName(name),
+					"pattern_type": "iac_sns_fanout",
+					"iac_tool":     iacTool,
+				},
+				EnrichmentStatus: types.StatusPending,
+				QualityScore:     0.8,
+			})
+		}
+		return id
+	}
+
+	// emitSubscription records SQS-queue --SUBSCRIBES_TO--> SNS-topic so the
+	// topology renders the SQS queue as a subscriber of the topic.
+	emitSubscription := func(topicName, queueName, iacTool string) {
+		if topicName == "" || queueName == "" {
+			return
+		}
+		topicID := emitTopic(topicName, iacTool)
+		queueID := emitQueue(queueName, iacTool)
+		fromID := fmt.Sprintf("%s:%s", queueEntityKind, queueID)
+		toID := fmt.Sprintf("%s:%s", messageTopicKind, topicID)
+		key := fromID + "|" + toID
+		if seenEdge[key] {
+			return
+		}
+		seenEdge[key] = true
+		relationships = append(relationships, types.RelationshipRecord{
+			FromID: fromID,
+			ToID:   toID,
+			Kind:   subscribesToEdgeKind,
+			Properties: map[string]string{
+				"broker":       "sns_sqs",
+				"pattern_type": "iac_sns_fanout",
+				"sns_fanout":   "true",
+				"iac_tool":     iacTool,
+			},
+		})
+	}
+
+	switch lang {
+	case "javascript", "typescript":
+		applyCDKSNSSubscriptions(src, emitSubscription)
+	case "hcl", "terraform":
+		applyTerraformSNSSubscriptions(src, emitSubscription)
+	case "yaml":
+		applyCloudFormationSNSSubscriptions(src, emitSubscription)
+	}
+
+	return entities, relationships
+}
+
+// ---------------------------------------------------------------------------
+// AWS CDK (TypeScript / JavaScript)
+// ---------------------------------------------------------------------------
+
+// cdkTopicDeclRe captures `const VAR = new sns.Topic(this, "Id", { topicName: "name" })`.
+// Group 1 = JS var name, group 2 = topicName literal.
+var cdkTopicDeclRe = regexp.MustCompile(
+	`(?:const|let|var)\s+(\w+)\s*=\s*new\s+sns\.Topic\s*\([^)]*?topicName\s*:\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]`)
+
+// cdkQueueDeclRe captures `const VAR = new sqs.Queue(this, "Id", { queueName: "name" })`.
+// Group 1 = JS var name, group 2 = queueName literal.
+var cdkQueueDeclRe = regexp.MustCompile(
+	`(?:const|let|var)\s+(\w+)\s*=\s*new\s+sqs\.Queue\s*\([^)]*?queueName\s*:\s*["'` + "`" + `]([^"'` + "`" + `]+)["'` + "`" + `]`)
+
+// cdkSubscribeRe captures `topicVar.addSubscription(new SqsSubscription(queueVar))`.
+// Group 1 = topic var, group 2 = queue var.
+var cdkSubscribeRe = regexp.MustCompile(
+	`(\w+)\s*\.addSubscription\s*\(\s*new\s+SqsSubscription\s*\(\s*(\w+)`)
+
+func applyCDKSNSSubscriptions(src string, emit func(topicName, queueName, iacTool string)) {
+	if !strings.Contains(src, "addSubscription") || !strings.Contains(src, "SqsSubscription") {
+		return
+	}
+	// Build var → name maps for topics and queues.
+	topicNames := map[string]string{}
+	for _, m := range cdkTopicDeclRe.FindAllStringSubmatch(src, -1) {
+		topicNames[m[1]] = m[2]
+	}
+	queueNames := map[string]string{}
+	for _, m := range cdkQueueDeclRe.FindAllStringSubmatch(src, -1) {
+		queueNames[m[1]] = m[2]
+	}
+	for _, m := range cdkSubscribeRe.FindAllStringSubmatch(src, -1) {
+		topicName := topicNames[m[1]]
+		queueName := queueNames[m[2]]
+		if topicName == "" || queueName == "" {
+			continue
+		}
+		emit(topicName, queueName, "cdk")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Terraform / HCL
+// ---------------------------------------------------------------------------
+
+// tfQueueResRe captures `resource "aws_sqs_queue" "ident" { ... name = "x" ... }`.
+// Group 1 = HCL ident, group 2 = block body.
+var tfQueueResRe = regexp.MustCompile(`(?s)resource\s+"aws_sqs_queue"\s+"(\w+)"\s*\{(.*?)\n\}`)
+
+// tfQueueNameRe extracts `name = "x"` from a queue block body.
+var tfQueueNameRe = regexp.MustCompile(`name\s*=\s*"([^"]+)"`)
+
+// tfSubscriptionResRe captures the whole subscription resource block body.
+var tfSubscriptionResRe = regexp.MustCompile(`(?s)resource\s+"aws_sns_topic_subscription"\s+"(\w+)"\s*\{(.*?)\n\}`)
+
+// tfProtocolSQSRe matches `protocol = "sqs"` in a subscription block.
+var tfProtocolSQSRe = regexp.MustCompile(`protocol\s*=\s*"sqs"`)
+
+// tfTopicArnLiteralRe matches `topic_arn = "arn:...:name"`.
+var tfTopicArnLiteralRe = regexp.MustCompile(`topic_arn\s*=\s*"([^"]+)"`)
+
+// tfTopicArnRefRe matches `topic_arn = aws_sns_topic.ident.arn`.
+var tfTopicArnRefRe = regexp.MustCompile(`topic_arn\s*=\s*aws_sns_topic\.(\w+)\.arn`)
+
+// tfTopicResRe captures `resource "aws_sns_topic" "ident" { ... name="x" ... }`.
+var tfTopicResRe = regexp.MustCompile(`(?s)resource\s+"aws_sns_topic"\s+"(\w+)"\s*\{(.*?)\n\}`)
+
+// tfEndpointQueueRefRe matches `endpoint = aws_sqs_queue.ident.arn`.
+var tfEndpointQueueRefRe = regexp.MustCompile(`endpoint\s*=\s*aws_sqs_queue\.(\w+)\.arn`)
+
+// tfEndpointArnLiteralRe matches `endpoint = "arn:aws:sqs:...:queue-name"`.
+var tfEndpointArnLiteralRe = regexp.MustCompile(`endpoint\s*=\s*"([^"]+)"`)
+
+func applyTerraformSNSSubscriptions(src string, emit func(topicName, queueName, iacTool string)) {
+	if !strings.Contains(src, "aws_sns_topic_subscription") {
+		return
+	}
+	// Resolve aws_sqs_queue idents → queue names.
+	queueNames := map[string]string{}
+	for _, m := range tfQueueResRe.FindAllStringSubmatch(src, -1) {
+		if nm := tfQueueNameRe.FindStringSubmatch(m[2]); nm != nil {
+			queueNames[m[1]] = nm[1]
+		}
+	}
+	// Resolve aws_sns_topic idents → topic names.
+	topicNames := map[string]string{}
+	for _, m := range tfTopicResRe.FindAllStringSubmatch(src, -1) {
+		if nm := tfQueueNameRe.FindStringSubmatch(m[2]); nm != nil {
+			topicNames[m[1]] = nm[1]
+		}
+	}
+
+	for _, m := range tfSubscriptionResRe.FindAllStringSubmatch(src, -1) {
+		body := m[2]
+		if !tfProtocolSQSRe.MatchString(body) {
+			continue
+		}
+		// Resolve topic name.
+		topicName := ""
+		if lm := tfTopicArnLiteralRe.FindStringSubmatch(body); lm != nil {
+			topicName = iacSNSTopicName(lm[1])
+		} else if rm := tfTopicArnRefRe.FindStringSubmatch(body); rm != nil {
+			topicName = topicNames[rm[1]]
+		}
+		// Resolve queue name.
+		queueName := ""
+		if qm := tfEndpointQueueRefRe.FindStringSubmatch(body); qm != nil {
+			queueName = queueNames[qm[1]]
+		} else if em := tfEndpointArnLiteralRe.FindStringSubmatch(body); em != nil {
+			queueName = sqsQueueDisplayName(em[1])
+		}
+		if topicName == "" || queueName == "" {
+			continue
+		}
+		emit(topicName, queueName, "terraform")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// CloudFormation (YAML)
+// ---------------------------------------------------------------------------
+
+// cfnResourceBlockRe captures each top-level resource: `  LogicalId:\n    Type: ...`.
+// We split the Resources section into blocks keyed by logical id and scan
+// each block.
+var cfnResourceHeaderRe = regexp.MustCompile(`(?m)^  (\w+):\s*$`)
+
+// cfnTypeRe extracts the `Type:` of a resource block.
+var cfnTypeRe = regexp.MustCompile(`Type:\s*([\w:]+)`)
+
+// cfnQueueNameRe extracts `QueueName: x`.
+var cfnQueueNameRe = regexp.MustCompile(`QueueName:\s*["']?([\w.\-]+)["']?`)
+
+// cfnProtocolSQSRe matches `Protocol: sqs`.
+var cfnProtocolSQSRe = regexp.MustCompile(`Protocol:\s*["']?sqs["']?`)
+
+// cfnTopicArnLiteralRe matches `TopicArn: "arn:...:name"` or `TopicArn: arn:...:name`.
+var cfnTopicArnLiteralRe = regexp.MustCompile(`TopicArn:\s*["']?(arn:aws:sns:[^"'\s]+)["']?`)
+
+// cfnTopicArnRefRe matches `TopicArn: !Ref Logical` or `TopicArn: { "Ref": "Logical" }`.
+var cfnTopicArnRefRe = regexp.MustCompile(`TopicArn:\s*(?:!Ref\s+(\w+)|\{\s*["']?Ref["']?\s*:\s*["'](\w+)["']\s*\})`)
+
+// cfnTopicNamePropRe matches `TopicName: x` inside an AWS::SNS::Topic resource.
+var cfnTopicNamePropRe = regexp.MustCompile(`TopicName:\s*["']?([\w.\-]+)["']?`)
+
+// cfnEndpointGetAttRe matches `Endpoint: !GetAtt Logical.Arn`.
+var cfnEndpointGetAttRe = regexp.MustCompile(`Endpoint:\s*(?:!GetAtt\s+(\w+)\.Arn|\{\s*["']?Fn::GetAtt["']?\s*:\s*\[\s*["'](\w+)["'])`)
+
+// cfnEndpointArnLiteralRe matches `Endpoint: "arn:aws:sqs:...:queue"`.
+var cfnEndpointArnLiteralRe = regexp.MustCompile(`Endpoint:\s*["']?(arn:aws:sqs:[^"'\s]+)["']?`)
+
+// cfnParamDefaultArnRe scans Parameters for `Default: "arn:aws:sns:...:name"`.
+var cfnParamDefaultArnRe = regexp.MustCompile(`Default:\s*["']?(arn:aws:sns:[^"'\s]+)["']?`)
+
+// cfnResourceBlock is a parsed CloudFormation resource block.
+type cfnResourceBlock struct {
+	logicalID string
+	typ       string
+	body      string
+}
+
+// splitCFNResources returns the list of resource blocks under Resources:.
+func splitCFNResources(src string) []cfnResourceBlock {
+	// Find the Resources: section start.
+	idx := strings.Index(src, "\nResources:")
+	if idx < 0 {
+		if strings.HasPrefix(src, "Resources:") {
+			idx = 0
+		} else {
+			return nil
+		}
+	}
+	section := src[idx:]
+	headers := cfnResourceHeaderRe.FindAllStringSubmatchIndex(section, -1)
+	var blocks []cfnResourceBlock
+	for i, h := range headers {
+		id := section[h[2]:h[3]]
+		start := h[1]
+		end := len(section)
+		if i+1 < len(headers) {
+			end = headers[i+1][0]
+		}
+		body := section[start:end]
+		typ := ""
+		if tm := cfnTypeRe.FindStringSubmatch(body); tm != nil {
+			typ = tm[1]
+		}
+		blocks = append(blocks, cfnResourceBlock{logicalID: id, typ: typ, body: body})
+	}
+	return blocks
+}
+
+func applyCloudFormationSNSSubscriptions(src string, emit func(topicName, queueName, iacTool string)) {
+	if !strings.Contains(src, "AWS::SNS::Subscription") {
+		return
+	}
+	blocks := splitCFNResources(src)
+	if len(blocks) == 0 {
+		return
+	}
+
+	// Build logical-id → SQS queue name, logical-id → SNS topic name.
+	queueNames := map[string]string{}
+	topicNames := map[string]string{}
+	for _, b := range blocks {
+		switch b.typ {
+		case "AWS::SQS::Queue":
+			if qm := cfnQueueNameRe.FindStringSubmatch(b.body); qm != nil {
+				queueNames[b.logicalID] = qm[1]
+			} else {
+				// No explicit QueueName — fall back to logical id.
+				queueNames[b.logicalID] = b.logicalID
+			}
+		case "AWS::SNS::Topic":
+			if tm := cfnTopicNamePropRe.FindStringSubmatch(b.body); tm != nil {
+				topicNames[b.logicalID] = tm[1]
+			} else {
+				topicNames[b.logicalID] = b.logicalID
+			}
+		}
+	}
+
+	// A topic ARN may come in via a Parameter default (e.g. OrderEventsTopicArn).
+	paramDefaultTopic := ""
+	if pm := cfnParamDefaultArnRe.FindStringSubmatch(src); pm != nil {
+		paramDefaultTopic = iacSNSTopicName(pm[1])
+	}
+
+	for _, b := range blocks {
+		if b.typ != "AWS::SNS::Subscription" {
+			continue
+		}
+		if !cfnProtocolSQSRe.MatchString(b.body) {
+			continue
+		}
+		// Resolve topic name.
+		topicName := ""
+		if lm := cfnTopicArnLiteralRe.FindStringSubmatch(b.body); lm != nil {
+			topicName = iacSNSTopicName(lm[1])
+		} else if rm := cfnTopicArnRefRe.FindStringSubmatch(b.body); rm != nil {
+			ref := rm[1]
+			if ref == "" {
+				ref = rm[2]
+			}
+			if tn, ok := topicNames[ref]; ok {
+				topicName = tn
+			} else if paramDefaultTopic != "" {
+				// !Ref to a Parameter whose Default is a topic ARN.
+				topicName = paramDefaultTopic
+			}
+		}
+		// Resolve queue name.
+		queueName := ""
+		if gm := cfnEndpointGetAttRe.FindStringSubmatch(b.body); gm != nil {
+			ref := gm[1]
+			if ref == "" {
+				ref = gm[2]
+			}
+			queueName = queueNames[ref]
+		} else if em := cfnEndpointArnLiteralRe.FindStringSubmatch(b.body); em != nil {
+			queueName = sqsQueueDisplayName(em[1])
+		}
+		if topicName == "" || queueName == "" {
+			continue
+		}
+		emit(topicName, queueName, "cloudformation")
+	}
+}

--- a/internal/engine/iac_sns_edges_test.go
+++ b/internal/engine/iac_sns_edges_test.go
@@ -1,0 +1,148 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// countSNSSubscribers returns the number of distinct SUBSCRIBES_TO edges whose
+// ToID is the given SNS topic ID, plus the set of iac_tool values seen.
+func countSNSSubscribers(rels []types.RelationshipRecord, topicID string) (int, map[string]bool) {
+	to := messageTopicKind + ":" + topicID
+	tools := map[string]bool{}
+	n := 0
+	for _, r := range rels {
+		if r.Kind == subscribesToEdgeKind && r.ToID == to {
+			n++
+			tools[r.Properties["iac_tool"]] = true
+		}
+	}
+	return n, tools
+}
+
+func TestIaCSNSEdges_CDK(t *testing.T) {
+	src := `
+import * as sns from "aws-cdk-lib/aws-sns";
+import * as sqs from "aws-cdk-lib/aws-sqs";
+import { SqsSubscription } from "aws-cdk-lib/aws-sns-subscriptions";
+const orderEvents = new sns.Topic(this, "OrderEvents", { topicName: "order-events" });
+const analyticsQueue = new sqs.Queue(this, "AQ", { queueName: "order-events-analytics" });
+orderEvents.addSubscription(new SqsSubscription(analyticsQueue));
+`
+	_, rels := applyIaCSNSEdges("typescript", "infra/cdk/lib/stack.ts", []byte(src), nil, nil)
+	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
+	if n != 1 {
+		t.Fatalf("CDK: want 1 subscriber, got %d (%+v)", n, rels)
+	}
+	if !tools["cdk"] {
+		t.Fatalf("CDK: want iac_tool=cdk, got %v", tools)
+	}
+}
+
+func TestIaCSNSEdges_Terraform(t *testing.T) {
+	src := `
+resource "aws_sqs_queue" "order_events_audit" {
+  name = "order-events-audit"
+}
+resource "aws_sns_topic_subscription" "order_events_audit" {
+  topic_arn = "arn:aws:sns:us-east-1:000000000000:order-events"
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.order_events_audit.arn
+}
+`
+	_, rels := applyIaCSNSEdges("terraform", "infra/terraform/order-events.tf", []byte(src), nil, nil)
+	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
+	if n != 1 {
+		t.Fatalf("TF: want 1 subscriber, got %d (%+v)", n, rels)
+	}
+	if !tools["terraform"] {
+		t.Fatalf("TF: want iac_tool=terraform, got %v", tools)
+	}
+}
+
+func TestIaCSNSEdges_CloudFormation(t *testing.T) {
+	src := `AWSTemplateFormatVersion: "2010-09-09"
+Parameters:
+  OrderEventsTopicArn:
+    Type: String
+    Default: "arn:aws:sns:us-east-1:000000000000:order-events"
+Resources:
+  OrderEventsFraudQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: order-events-fraud
+  OrderEventsFraudSubscription:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: !Ref OrderEventsTopicArn
+      Protocol: sqs
+      Endpoint: !GetAtt OrderEventsFraudQueue.Arn
+`
+	_, rels := applyIaCSNSEdges("yaml", "infra/cloudformation/order-events-fanout.yaml", []byte(src), nil, nil)
+	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
+	if n != 1 {
+		t.Fatalf("CFN: want 1 subscriber, got %d (%+v)", n, rels)
+	}
+	if !tools["cloudformation"] {
+		t.Fatalf("CFN: want iac_tool=cloudformation, got %v", tools)
+	}
+}
+
+// TestIaCSNSEdges_FanOutCollapse verifies that subscriptions for the SAME topic
+// name declared across three IaC tools collapse onto a single topic node with
+// three distinct SQS subscribers.
+func TestIaCSNSEdges_FanOutCollapse(t *testing.T) {
+	cdk := `const t = new sns.Topic(this, "T", { topicName: "order-events" });
+const q = new sqs.Queue(this, "Q", { queueName: "order-events-analytics" });
+t.addSubscription(new SqsSubscription(q));`
+	tf := `resource "aws_sqs_queue" "a" { name = "order-events-audit" }
+resource "aws_sns_topic_subscription" "a" {
+  topic_arn = "arn:aws:sns:us-east-1:0:order-events"
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.a.arn
+}`
+	cfn := `Resources:
+  FraudQ:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: order-events-fraud
+  Sub:
+    Type: AWS::SNS::Subscription
+    Properties:
+      TopicArn: "arn:aws:sns:us-east-1:0:order-events"
+      Protocol: sqs
+      Endpoint: !GetAtt FraudQ.Arn`
+
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	ents, rels = applyIaCSNSEdges("typescript", "stack.ts", []byte(cdk), ents, rels)
+	ents, rels = applyIaCSNSEdges("terraform", "x.tf", []byte(tf), ents, rels)
+	ents, rels = applyIaCSNSEdges("yaml", "x.yaml", []byte(cfn), ents, rels)
+
+	n, tools := countSNSSubscribers(rels, snsTopicID("order-events"))
+	if n != 3 {
+		t.Fatalf("fan-out: want 3 subscribers, got %d", n)
+	}
+	for _, want := range []string{"cdk", "terraform", "cloudformation"} {
+		if !tools[want] {
+			t.Fatalf("fan-out: missing iac_tool=%s (got %v)", want, tools)
+		}
+	}
+	// All SNS topic entities share ONE canonical ID, so they collapse to a
+	// single node at render time (entities are deduped by ID across files /
+	// repos, mirroring kafka_wrapper_edges.go which also emits one topic
+	// entity per file). Assert every emitted SNS topic carries the same ID.
+	topicCount := 0
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			topicCount++
+			if e.Name != snsTopicID("order-events") {
+				t.Fatalf("fan-out: SNS topic entity has unexpected ID %q", e.Name)
+			}
+		}
+	}
+	if topicCount == 0 {
+		t.Fatalf("fan-out: no SNS topic entity emitted")
+	}
+}


### PR DESCRIPTION
## 1. What & why
`Fixes #1596`. Adds a multi-IaC **SNS → multi-SQS fan-out** to the
polyglot-platform fixture and the extractor support to surface it: ONE SNS
topic (`order-events`) that fans out to **3 SQS queues whose subscriptions are
each declared by a different IaC tool** (AWS CDK, Terraform, CloudFormation).
The Topology view now renders the single SNS topic node with 3 SQS subscribers.

## 2. What changed
**Extractor (this PR, `internal/`):**
- New append-only engine pass `applyIaCSNSEdges` (`internal/engine/iac_sns_edges.go`),
  wired after `applySQSEdges` in `detector.go`. Emits a synthetic SNS topic
  (`SCOPE.MessageTopic`, broker=sns) + one `SUBSCRIBES_TO` edge per SQS
  subscriber (FromID = SQS queue, ToID = SNS topic). Same-name topics across
  tools collapse onto one node.
  - CDK (TS): `new sns.Topic{topicName}` + `topic.addSubscription(new SqsSubscription(q))`.
  - Terraform/HCL: `aws_sns_topic_subscription` (protocol=sqs), resolving topic_arn + endpoint.
  - CloudFormation (YAML): `AWS::SNS::Subscription` (Protocol: sqs), resolving TopicArn (!Ref param / literal) + Endpoint (!GetAtt queue).
- Widened `synthesisSupportsLanguage` to admit `terraform`/`hcl`/`yaml`
  (`internal/engine/http_endpoint_synthesis.go`). These IaC languages have no
  compiled YAML rule sets of their own (Terraform rules are keyed under `hcl`;
  CloudFormation YAML has none), so they previously short-circuited out of
  `engine.Detect` **before any IaC-aware synthesis pass ran** — which also
  silently disabled the existing HCL EventBridge / serverless.yml detection in
  `applyEventBusEdges`. This bug-fix re-enables both.

**Fixture (committed separately in polyglot-platform):**
- CDK: `infra/cdk/lib/shipping-stack.ts` — SNS `order-events` topic + SQS
  `order-events-analytics` subscription.
- Terraform: `infra/terraform/order-events.tf` — SQS `order-events-audit` +
  `aws_sns_topic_subscription`.
- CloudFormation: `infra/cloudformation/order-events-fanout.yaml` — SQS
  `order-events-fraud` + `AWS::SNS::Subscription`.
- Consumer code: `services/analytics/analytics/fanout_consumers.py` (boto3
  receive_message on all 3 queues).
- `MANIFEST.md` updated (topics §3 + IaC §5 + a #1596 note).

## 3. How verified
- New unit tests: `internal/engine/iac_sns_edges_test.go` (per-tool extraction
  + 3-tool fan-out collapse) and `internal/dashboard/topology_sns_fanout_test.go`
  (topology renders the topic with 3 consumers).
- **Isolated full-pipeline reindex** of the real fixture (temp graphs dir, no
  live daemon): the `order-events` topic resolves to exactly **3 SQS
  subscribers** — `order-events-analytics` (cdk), `order-events-audit`
  (terraform), `order-events-fraud` (cloudformation).
- Topology layer (`collectTopologyResponse`) renders the single topic node with
  all 3 consumers.
- Live `:47274` daemon untouched; isolated daemon torn down.
- `go test ./internal/engine/ -count=1` green; `go vet ./internal/engine/` clean.

## 4. Extraction results (which IaC tools' SNS→SQS extracted)
| IaC tool | Subscription | Queue | Extracted |
|---|---|---|---|
| AWS CDK | `addSubscription(new SqsSubscription)` | order-events-analytics | ✅ |
| Terraform | `aws_sns_topic_subscription` proto=sqs | order-events-audit | ✅ |
| CloudFormation | `AWS::SNS::Subscription` Proto: sqs | order-events-fraud | ✅ |

All three extract; no gaps.

## 5. Risk / scope
The new pass is append-only (cannot remove/modify existing entities/edges). The
`synthesisSupportsLanguage` widening lets more IaC files reach the synthesis
passes, but each pass has its own content guard and is a no-op without the
relevant anchors. Full engine suite green.

## 6. Out of scope / follow-ups
- HTTP topology endpoint was verified at the `collectTopologyResponse` layer
  (deterministic read of the indexed edges) rather than via a live daemon HTTP
  call, to avoid any risk of the daemon's `ConfigDir` touching real
  `~/.config/archigraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)