### PR TITLE
feat(graph): node-count + zoom aware node sizing that holds at all zooms/sizes (#1607)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -46,8 +46,7 @@ import {
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
 import {
-  baseSizeForCount,
-  DEFAULT_NODE_SIZING,
+  autoBasePx,
   type ColorMode,
   type GroupByMode,
   type SimulationConfig,
@@ -283,6 +282,10 @@ function GraphCanvasInner(
   onSettledRef.current = onSettled;
   const simRef = useRef(simulation);
   simRef.current = simulation;
+  // Fix #1607: live render config in a ref so the mount-only zoom handler reads
+  // the current pointSizeScale / maxPointSize when computing the zoom response.
+  const renderRef = useRef(render);
+  renderRef.current = render;
   const hoveredRef = useRef<string | null>(hoveredNodeId);
   hoveredRef.current = hoveredNodeId;
   const relayoutRef = useRef(relayoutNonce);
@@ -350,16 +353,16 @@ function GraphCanvasInner(
     for (const n of nodes) if ((n.pageRank ?? 0) > maxPR) maxPR = n.pageRank ?? 0;
     if (maxPR === 0) maxPR = 1;
 
-    // Fix #1580: AUTO-SCALE the base size DOWN as the graph grows. The knob's
-    // value is tuned for a ~1.5k-node reference graph; on a ≈19k-node graph that
-    // base produces overlapping colored blobs when zoomed out. We scale the
-    // EFFECTIVE base inversely with sqrt(nodeCount) so a huge graph renders as
-    // fine points out of the box. The knob still works: we scale it by the same
-    // count-derived ratio as the default, so turning the slider down further
-    // shrinks points proportionally (and it now reaches single digits).
-    const countScale =
-      baseSizeForCount(count) / DEFAULT_NODE_SIZING.baseSize; // ≤1, →small for big graphs
-    const effectiveBase = Math.max(1, nodeSizing.baseSize * countScale);
+    // Fix #1607: the per-node SIZE buffer is now authored directly in SCREEN
+    // PIXELS at neutral zoom (pointSizeScale is 1.0). The base pixel size is
+    // computed AUTOMATICALLY from the node count (autoBasePx: big graph → small
+    // dots, small graph → bigger discs) so the defaults look right on both 19k and
+    // 1.3k graphs with no tuning. The user baseSize knob is a MULTIPLIER around
+    // that auto base (1.0 = auto). The zoom RESPONSE (sublinear growth on zoom-in +
+    // a px cap) is applied separately by the zoom-driven pointSizeScale updater, so
+    // these are the base px at zoom = 1.
+    const autoBase = autoBasePx(count);
+    const effectiveBase = Math.max(0.5, autoBase * nodeSizing.baseSize);
 
     const grouping = groupBy !== "none";
     const groupCount = new Map<string, number>();
@@ -396,12 +399,13 @@ function GraphCanvasInner(
       // wins and connected groups migrate adjacent. (was 0.22 + normPR*0.15)
       clusterStrength[i] = grouping ? 0.06 + normPR * 0.06 : 0.03 + normPR * 0.04;
 
-      // log-scaled size by degree (graph.md: radius scales with PageRank/degree),
-      // hard-capped at maxMultiplier × base so high-degree hubs never bloom into
-      // overlapping blobs. (Fix #1532-4)
-      const raw =
-        effectiveBase + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale * countScale;
-      sizes[i] = Math.min(raw, effectiveBase * nodeSizing.maxMultiplier);
+      // Fix #1607: gentle log-scaled degree boost in MULTIPLES of the base px,
+      // hard-capped at maxMultiplier × base so a high-degree hub is at most ~2.2×
+      // a regular node — slightly larger, never a blob. degreeScale is a small
+      // unitless factor on log10(degree+1).
+      const degBoost = 1 + Math.log10((n.degree ?? 0) + 1) * nodeSizing.degreeScale;
+      const mult = Math.min(degBoost, nodeSizing.maxMultiplier);
+      sizes[i] = effectiveBase * mult;
 
       const gkey = groupKeyFor(n, groupBy);
       const center = grouping ? groupCenters.get(gkey) : undefined;
@@ -418,7 +422,14 @@ function GraphCanvasInner(
         : (Math.random() - 0.5) * 1600;
     });
 
-    return { positions, sizes, clusters, clusterStrength };
+    // Fix #1607: the largest base-px size in the buffer (a hub). The zoom-driven
+    // size updater uses this to set pointSizeScale so the LARGEST node is exactly
+    // capped at render.maxPointSize px when zoomed in — preventing any blob.
+    let maxSizePx = 0;
+    for (let i = 0; i < count; i++) if (sizes[i] > maxSizePx) maxSizePx = sizes[i];
+    if (maxSizePx <= 0) maxSizePx = 1;
+
+    return { positions, sizes, clusters, clusterStrength, maxSizePx };
   }, [nodes, repoToIdx, groupCenters, groupBy, nodeSizing]);
 
   // Node colors — re-read pastel scale from tokens.css so theme flows through.
@@ -694,6 +705,9 @@ function GraphCanvasInner(
     // Fix #1564-3: only the hovered node + neighbors are ever labelled, so the
     // per-frame work is tiny — the hover label tracks smoothly during pan/zoom.
     refreshLabelsRef.current();
+    // Fix #1607: keep point sizing in lock-step with the zoom every frame during
+    // a continuous pinch/wheel/drag so the sublinear growth + cap track smoothly.
+    applyZoomSizingRef.current();
     rafRef.current = requestAnimationFrame(motionLoop);
   }, []);
   const startInteraction = useCallback(() => {
@@ -809,10 +823,15 @@ function GraphCanvasInner(
     }
 
     fitNowRef.current();
+    // Fix #1607: the fit sets the fitted zoom level → recompute the zoom-driven
+    // point size so the very first painted (fitted) frame already has perceptible,
+    // non-overlapping nodes with no manual tuning.
+    applyZoomSizingRef.current(true);
     scheduleLabels();
     // One more fit on the next frames in case the canvas size settled late.
     setTimeout(() => {
       fitNowRef.current();
+      applyZoomSizingRef.current(true);
       scheduleLabels();
     }, 200);
     onSettledRef.current();
@@ -826,6 +845,63 @@ function GraphCanvasInner(
   // re-layout) without each one re-deriving the kick logic.
   const packedRef = useRef(packed);
   packedRef.current = packed;
+
+  // ── Fix #1607: SUBLINEAR, capped zoom-driven point sizing ────────────────────
+  // cosmos's built-in scalePointsOnZoom is LINEAR: zoom in → size×zoom (blobs that
+  // overlap), zoom out → tiny dots. That single linear law can't be perceptible
+  // when zoomed out AND non-overlapping when zoomed in. We turn cosmos's law OFF
+  // and drive `pointSizeScale` ourselves from the LIVE zoom level with a SUBLINEAR
+  // response and a hard pixel cap:
+  //
+  //   factor(z) = clamp( z^ZOOM_EXP , MIN_FACTOR , capFactor )
+  //
+  //   • z^0.5 (sqrt) grows nodes GENTLY as you zoom in — they get bigger so they
+  //     read as discs, but far slower than the geometry spreads apart, so they
+  //     never catch up and overlap into blobs.
+  //   • MIN_FACTOR keeps nodes a perceptible fraction of their base size when
+  //     zoomed all the way OUT (visible dots, not invisible lines).
+  //   • capFactor is derived from render.maxPointSize: it's the factor at which
+  //     the LARGEST node (packed.maxSizePx, a hub) hits exactly maxPointSize px, so
+  //     no node ever blobs past the cap no matter how far the user zooms in.
+  //
+  // The on-screen px of a node ≈ baseSizePx × pointSizeScale (scalePointsOnZoom is
+  // off, so cosmos does NOT multiply by zoom again — we own the whole zoom curve).
+  const ZOOM_EXP = 0.5; // sqrt → sublinear growth
+  const MIN_FACTOR = 0.62; // floor: zoomed-out dots stay perceptible
+  const lastZoomScaleRef = useRef(-1);
+  const applyZoomSizing = useCallback((force = false) => {
+    const g = graphRef.current;
+    if (!g) return;
+    let z = 1;
+    try {
+      z = g.getZoomLevel() || 1;
+    } catch {
+      z = 1;
+    }
+    if (!Number.isFinite(z) || z <= 0) z = 1;
+    const r = renderRef.current;
+    const baseScale = r.pointSizeScale; // user "Point size scale" knob (default 1.0)
+    const maxPx = Math.max(2, r.maxPointSize);
+    const maxBasePx = packedRef.current.maxSizePx; // largest hub base px @ zoom 1
+    // capFactor: the scale at which the largest node reaches maxPx on screen.
+    const capFactor = maxPx / (maxBasePx * baseScale);
+    // Fix #1607: the "Grow nodes on zoom" toggle (render.scalePointsOnZoom) chooses
+    // the zoom law. ON (default) = sublinear growth z^0.5 so nodes read as discs
+    // when zoomed in without overlapping; OFF = constant on-screen size (factor 1),
+    // i.e. nodes keep a fixed pixel size at every zoom. Both stay px-capped.
+    const raw = renderRef.current.scalePointsOnZoom ? Math.pow(z, ZOOM_EXP) : 1;
+    const factor = Math.max(MIN_FACTOR, Math.min(capFactor, raw));
+    const next = baseScale * factor;
+    // Skip redundant setConfig churn if the scale hasn't meaningfully moved.
+    if (!force && Math.abs(next - lastZoomScaleRef.current) < 1e-3) return;
+    lastZoomScaleRef.current = next;
+    g.setConfig({ pointSizeScale: next });
+    // While settled the loop is paused; nudge a single repaint so the new size
+    // lands without re-running the simulation.
+    if (hasSettledRef.current) g.render();
+  }, []);
+  const applyZoomSizingRef = useRef(applyZoomSizing);
+  applyZoomSizingRef.current = applyZoomSizing;
 
   // Fix #1581: THE single source of truth for "run a fresh settle". Previously the
   // first-load no-cache path (mount effect) and the Reset/Re-layout path used
@@ -887,7 +963,9 @@ function GraphCanvasInner(
       backgroundColor: isDark ? "#020617" : "#f8fafc",
       spaceSize: SPACE_SIZE,
       pixelRatio: Math.min(window.devicePixelRatio, 1.5),
-      scalePointsOnZoom: render.scalePointsOnZoom,
+      // Fix #1607: ALWAYS off — our applyZoomSizing updater is the sole zoom→size
+      // law (sublinear + px-capped). cosmos's built-in linear law must not stack.
+      scalePointsOnZoom: false,
       pointSizeScale: render.pointSizeScale,
       pointOpacity: render.pointOpacity,
       pointGreyoutOpacity: 0.15,
@@ -979,6 +1057,10 @@ function GraphCanvasInner(
       // for the (rare) single-shot zoom that doesn't emit start/end.
       onZoomStart: () => startInteractionRef.current(),
       onZoom: () => {
+        // Fix #1607: drive the sublinear, capped point size off every zoom event
+        // (covers the single-shot wheel zoom that doesn't bracket start/end). The
+        // rAF motion loop handles continuous zoom/pan; this catches the rest.
+        applyZoomSizingRef.current();
         if (!interactingRef.current) scheduleLabelsLive();
       },
       onZoomEnd: () => endInteractionRef.current(),
@@ -1083,8 +1165,12 @@ function GraphCanvasInner(
     if (!g) return;
     g.setConfig({
       pointOpacity: render.pointOpacity,
-      pointSizeScale: render.pointSizeScale,
-      scalePointsOnZoom: render.scalePointsOnZoom,
+      // Fix #1607: do NOT set pointSizeScale here — the zoom-driven updater owns it
+      // (base scale × sublinear-capped zoom factor). We re-run that updater below so
+      // a knob change (Point size scale / Max point size) re-derives the live scale
+      // at the current zoom. We also force scalePointsOnZoom OFF: our updater is the
+      // single source of the zoom→size law, and cosmos's linear law must not stack.
+      scalePointsOnZoom: false,
       linkWidthScale: render.showLinks ? render.linkWidthScale : 0,
       simulationLinkSpring: simulation.linkSpring,
       simulationLinkDistance: Math.max(simulation.linkDistance, 8),
@@ -1092,6 +1178,9 @@ function GraphCanvasInner(
       simulationRepulsion: simulation.repulsion,
       simulationCenter: simulation.center,
     });
+    // Fix #1607: re-derive pointSizeScale from the live zoom (force, since the knob
+    // may have changed maxPointSize / base scale).
+    applyZoomSizingRef.current(true);
     g.setLinkColors(packLinkColors());
     g.setLinkWidths(packLinkWidths());
     g.render();

--- a/webui-v2/src/components/graph/tuning-panels.tsx
+++ b/webui-v2/src/components/graph/tuning-panels.tsx
@@ -233,19 +233,23 @@ export function TuningPanels() {
         onReset={() => setNodeSizing(DEFAULT_NODE_SIZING)}
       >
         <Slider
-          label="Base size"
+          // Fix #1607: baseSize is now a MULTIPLIER around the auto count-derived
+          // size (1.0 = auto). 0.2..4× nudges all nodes proportionally on any graph.
+          label="Base size (×auto)"
           value={nodeSizing.baseSize}
           min={NODE_BASE_SIZE_MIN}
           max={NODE_BASE_SIZE_MAX}
-          step={2}
+          step={0.1}
           onChange={(v) => setNodeSizing({ baseSize: v })}
         />
         <Slider
+          // Fix #1607: degreeScale is now a small unitless hub-emphasis factor
+          // (log10(degree+1) × this), capped by Max multiplier. 0..3 is plenty.
           label="Degree scale"
           value={nodeSizing.degreeScale}
           min={0}
-          max={120}
-          step={5}
+          max={3}
+          step={0.1}
           onChange={(v) => setNodeSizing({ degreeScale: v })}
         />
         <Slider
@@ -364,7 +368,9 @@ export function TuningPanels() {
           onChange={(v) => setRender({ linkWidthScale: v })}
         />
         <Toggle
-          label="Scale on zoom"
+          // Fix #1607: ON = nodes grow gently (sublinear, px-capped) as you zoom
+          // in; OFF = constant on-screen pixel size at every zoom.
+          label="Grow nodes on zoom"
           checked={render.scalePointsOnZoom}
           onChange={(v) => setRender({ scalePointsOnZoom: v })}
         />

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -29,8 +29,16 @@ export interface SimulationConfig {
 }
 
 export interface NodeSizingConfig {
+  /**
+   * Fix #1607: baseSize is now a USER MULTIPLIER (≈1.0 = "leave it auto"), NOT an
+   * absolute pixel/size value. The graph-canvas computes an AUTOMATIC base size in
+   * screen-pixels from the node count (big graph → smaller dots, small graph →
+   * bigger nodes; see autoBasePx) and multiplies it by this knob. So 1.0 gives the
+   * tuned auto size for any graph; 0.5 halves it, 2.0 doubles it — proportional on
+   * every graph instead of an absolute that only suited one node count.
+   */
   baseSize: number;
-  /** log10(degree) multiplier. */
+  /** log10(degree) multiplier — hub emphasis, capped by maxMultiplier. */
   degreeScale: number;
   maxMultiplier: number;
 }
@@ -80,47 +88,67 @@ export const DEFAULT_SIMULATION: SimulationConfig = {
 };
 
 export const DEFAULT_NODE_SIZING: NodeSizingConfig = {
-  // Fix #1532-4: out-of-box defaults must not produce overlapping "blobs".
-  // Lower base + gentler degree scale + a tight max multiplier so a high-degree
-  // hub stays at most ~1.8× the base size (was 3× of a much larger base).
-  //
-  // Fix #1580: this is the REFERENCE base size for a small/mid graph. On a large
-  // (≈19k-node) graph that fixed 90 is far too big — nodes overlap into colored
-  // blobs when zoomed out. The graph-canvas now AUTO-SCALES this down inversely
-  // with sqrt(nodeCount) (see baseSizeForCount), so the user-facing default knob
-  // can stay readable on a small graph while a huge graph renders as fine points.
-  baseSize: 90,
-  degreeScale: 18,
-  maxMultiplier: 1.8,
+  // Fix #1607: baseSize is a MULTIPLIER around the auto (count-derived) base, so
+  // the out-of-box default is 1.0 ("use the computed auto size"). The auto base in
+  // screen-pixels is computed by autoBasePx() from the node count, so 19k and 1.3k
+  // graphs both get a sensible default with no manual tuning. degreeScale/maxMult
+  // give hubs a gentle, hard-capped boost so no node ever blobs.
+  baseSize: 1.0,
+  degreeScale: 0.5,
+  maxMultiplier: 2.2,
 };
 
-// Fix #1580: the base-size slider/clamp floor. Lowered from 40 to 4 so a very
-// dense (≈19k-node) graph can be tuned down to fine points instead of blobs.
-export const NODE_BASE_SIZE_MIN = 4;
-export const NODE_BASE_SIZE_MAX = 320;
+// Fix #1607: baseSize is now a unitless MULTIPLIER, so the slider runs 0.2..4×.
+export const NODE_BASE_SIZE_MIN = 0.2;
+export const NODE_BASE_SIZE_MAX = 4;
 
 /**
- * Fix #1580: node-count-aware DEFAULT base size. A 19k-node graph needs a much
- * smaller base than a 200-node one, so scale the reference default DOWN inversely
- * with sqrt(nodeCount), normalized to a ~1.5k-node reference graph, and floor it
- * at NODE_BASE_SIZE_MIN. This is applied in graph-canvas to the EFFECTIVE base
- * size whenever the user hasn't overridden the knob, so a freshly-loaded huge
- * graph renders as points, not blobs, with no manual tuning.
+ * Fix #1607: AUTOMATIC base node size in SCREEN PIXELS (at neutral zoom = 1),
+ * derived purely from the node count. The whole point of this fix is that the
+ * defaults look right on BOTH a 19,613-node graph and a 1,320-node graph without
+ * touching any knob, so the base must adapt to density.
+ *
+ * Model: nodes share the viewport area, so per-node "breathing room" scales like
+ * 1/sqrt(count). We anchor that to a comfortable on-screen diameter and clamp to a
+ * perceptible-but-non-overlapping pixel band:
+ *
+ *   px = clamp( K / sqrt(count), MIN_PX, MAX_PX )
+ *
+ * Tuned so:
+ *   • count ≈ 1,320  → ~9.5px   (small graph: clearly visible discs)
+ *   • count ≈ 19,613 → ~2.8px   (huge graph: fine perceptible points, no blobs)
+ *   • count ≈ 200    → capped at MAX_PX (tiny graph stays tasteful, not giant)
+ *
+ * This is the BASE at zoom=1; graph-canvas multiplies by the user baseSize knob
+ * and then applies a SUBLINEAR, capped zoom response on top (see zoomSizeFactor).
  */
-export function baseSizeForCount(count: number, reference = DEFAULT_NODE_SIZING.baseSize): number {
-  if (!Number.isFinite(count) || count <= 0) return reference;
-  const REF_NODES = 1500; // graph size the reference baseSize was tuned for
-  const scaled = reference * Math.sqrt(REF_NODES / count);
-  return Math.max(NODE_BASE_SIZE_MIN, Math.min(reference, scaled));
+export const NODE_MIN_PX = 2.0;
+export const NODE_MAX_PX = 14;
+export function autoBasePx(count: number): number {
+  if (!Number.isFinite(count) || count <= 0) return 8;
+  const K = 350; // K/sqrt(count): 1320→9.6px, 19613→2.5px, 200→24.7px(→clamped)
+  const px = K / Math.sqrt(count);
+  return Math.max(NODE_MIN_PX, Math.min(NODE_MAX_PX, px));
 }
 
 export const DEFAULT_RENDER: RenderConfig = {
   pointOpacity: 0.92,
-  pointSizeScale: 0.22,
+  // Fix #1607: the per-node SIZE buffer is now authored directly in screen-pixels
+  // (autoBasePx × knobs), so the global scale is a neutral 1.0 — the px values map
+  // 1:1 on screen at zoom=1. (Was 0.22, which only made sense against the old
+  // ~90-unit absolute base.)
+  pointSizeScale: 1.0,
+  // Fix #1607: this flag now means "GROW nodes on zoom" and is driven by OUR
+  // sublinear, px-capped updater (NOT cosmos's built-in linear law, which is
+  // forced off in graph-canvas). DEFAULT ON: nodes grow gently (z^0.5) as you zoom
+  // in so they read as discs — but the px cap stops them blobbing — and a floor
+  // keeps them perceptible when zoomed out. OFF = constant on-screen pixel size.
   scalePointsOnZoom: true,
-  // Fix #1532-4: cap the on-screen pixel size so no node becomes a giant blob
-  // even when zoomed in (was 60).
-  maxPointSize: 34,
+  // Fix #1607: this is now a REAL on-screen pixel CAP, enforced by the zoom-driven
+  // size updater so the largest (hub) node can never blob past this many px no
+  // matter how far the user zooms in. (Previously cosmos had no maxPointSize at
+  // all, so this knob was inert — a root cause of the "big blobs zoomed in" bug.)
+  maxPointSize: 26,
   // Fix #1558-1: the long cross-module links between islands vanished when
   // zoomed OUT. Raise the default width scale so even the thin same-repo links
   // clear the visible-pixel floor at every zoom level (see packLinkWidths,
@@ -158,7 +186,12 @@ const ALL_EDGE_KINDS: EdgeKind[] = [
 // scope the layout cache by graph-layout-cache.LAYOUT_VERSION (kept in lock-step
 // with this constant); bumping here also discards stale persisted TUNING so the
 // current force defaults (which produce the good spread) actually apply on load.
-const DEFAULTS_VERSION = 4;
+// Fix #1607: bump to 5 — the sizing model changed shape entirely (baseSize is now
+// a unitless multiplier, pointSizeScale is 1.0, scalePointsOnZoom is off, defaults
+// retuned). A stored v4 sizing/render blob (baseSize 90, pointSizeScale 0.22,
+// scalePointsOnZoom true) would be catastrophically wrong under the new model, so
+// discard it and adopt the new code defaults on next load — no manual Reset.
+const DEFAULTS_VERSION = 5;
 const VERSION_KEY = "ag.v2.graph.defaultsVersion";
 
 function readStoredVersion(): number {
@@ -367,8 +400,8 @@ export const useGraphStore = create<GraphState>((set) => ({
   setNodeSizing: (patch) =>
     set((s) => {
       const nodeSizing = { ...s.nodeSizing, ...patch };
-      // Fix #1580: clamp baseSize to the lowered floor so the knob can go to
-      // single digits (fine points on a dense graph) but never below 4 / above max.
+      // Fix #1607: clamp the baseSize MULTIPLIER to 0.2..4× so the knob nudges the
+      // auto (count-derived) base proportionally without ever going to zero/absurd.
       if (patch.baseSize !== undefined) {
         nodeSizing.baseSize = Math.max(
           NODE_BASE_SIZE_MIN,


### PR DESCRIPTION
## What
Redo the WebUI v2 graph dynamic node sizing so nodes look right at **all zoom levels** and **all graph sizes** — out of the box, with no manual tuning. Verified on real **upvate** (19,613 nodes) and **polyglot-platform** (1,320 nodes) at fitted / zoomed-in / zoomed-out.

Fixes #1607.

## Why
The owner's manual-config testing showed the old model couldn't satisfy all cases:
- `scalePointsOnZoom` OFF → tiny dots / just lines when zoomed in.
- `scalePointsOnZoom` ON → big overlapping blobs when zoomed in, bad zoomed out (cosmos's law is **linear**).
- The same config looked completely different on a 19k vs a 1.3k graph.
- Root cause found: the `maxPointSize` knob was **inert** — cosmos.gl has no `maxPointSize`, so nothing ever capped the on-screen pixel size; "blobs when zoomed in" was unbounded.

A single linear law can't be perceptible-when-out AND non-overlapping-when-in. The fix is an automatic, node-count-aware base plus a **sublinear, px-capped** zoom response we drive ourselves.

## How
**Automatic base size (node-count aware)** — `autoBasePx(count) = clamp(350/sqrt(count), 2px, 14px)`. Big graph → fine ~2.5px dots (19.6k), small graph → ~9.6px discs (1.3k). The `baseSize` knob becomes a unitless **multiplier** (1.0 = auto) around this, so it scales proportionally on any graph instead of being an absolute that only suited one count. Degree adds a gentle `log10` hub boost, hard-capped at `maxMultiplier` so no node blobs.

**Sublinear, capped zoom response** — cosmos's linear `scalePointsOnZoom` is forced OFF; we drive `pointSizeScale` from the live zoom in the existing rAF zoom hook: `factor = clamp(zoom^0.5, 0.62, capFactor)`. The `^0.5` (sqrt) grows nodes **gently** so they read as discs when zoomed in but never catch up to the spreading geometry (no blobs); the `0.62` floor keeps zoomed-out dots perceptible; `capFactor` pins the largest (hub) node to exactly `render.maxPointSize` px — a now-**real** on-screen cap. The "Scale on zoom" toggle is repurposed to "Grow nodes on zoom" (on = sublinear growth, off = constant px).

**Good defaults for both regimes** — retuned `DEFAULT_NODE_SIZING` (baseSize 1.0×, degreeScale 0.5, maxMult 2.2) and `DEFAULT_RENDER` (pointSizeScale 1.0, scalePointsOnZoom on, maxPointSize 26). Bumped `DEFAULTS_VERSION` 4 → 5 so they apply on next load (stale v4 blobs discarded) with no manual Reset.

## Testing
Isolated Vite dev server (port 47291) with a **read-only** proxy to the existing daemon; live `:47274` not touched (confirmed still serving 200 after). `npm run build` clean. localStorage cleared so v5 defaults apply fresh (verified `defaultsVersion=5`, stored sizing/render = null = code defaults).

Sublinear+cap proven by instrumentation:
- polyglot: zoom 1.78→13.1 (7.4×) → scale 1.335→1.546 (1.16×). Zoomed-out floor at 0.62.
- upvate: zoom 0.45→6.5 (14×) → scale 0.67→2.55 (sublinear). Zoomed-out floor at 0.62.

6 screenshots captured (perceptible + non-overlapping at every one):
- `1607-poly-1-fitted.png`, `1607-poly-2-zoomed-in.png`, `1607-poly-3-zoomed-out.png`
- `1607-upvate-1-fitted.png`, `1607-upvate-2-zoomed-in.png`, `1607-upvate-3-zoomed-out.png`

**Reload === Reset** (bbox span, after settle):
- polyglot: reload [375,375] vs re-layout [386,404] — within force-sim jitter.
- upvate: reload [1443,1474] vs re-layout [1460,1544] — within force-sim jitter.
No contracted-layout regression on either graph; both fit/fill identically.

## Risk / Rollout
Scoped to 3 files in `webui-v2/` (graph-canvas, store, tuning-panels). **dashboard/ zero diff.** No backend/topology/flows/paths changes. `scalePointsOnZoom` plumbing kept (repurposed), so no type/API breakage. Worst case a user with a stale store: the v5 bump discards it on next load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)