### PR TITLE
fix(mcp): de-noise + re-rank find results, clamp get_source, container-free callers, paged endpoint paths (#1614)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -173,7 +173,15 @@ Previously named `archigraph_search` (renamed in #668).
 | `context_filter` | string[] | no | `[]` | Edge-kind filter (see [Relationship Types](#relationship-types)). |
 | `repo_filter` | string[] | no | `[]` | Repo names to scope. `["*"]` requests a full dump. |
 | `full` | boolean | no | `false` | Return raw JSON instead of compact text. |
+| `include_noise` | boolean | no | `false` | Keep synthetic nodes (file/module container components, inferred class-hierarchy shadows, raw `SCOPE.Pattern` nodes, built-in `Process` nodes). Excluded by default (#1614). |
 | `group`, `cwd` | string | no | — | Common args. |
+
+By default results are **de-noised and re-ranked** (#1614): file/module container
+components, inferred class-hierarchy shadows, raw Pattern nodes and array-built-in
+Process nodes are dropped, and real **lined** entities (`start_line > 0`) rank above
+lineless route/resource entities — both above any retained synthetic node. The same
+filtering applies to the `full=true` JSON dump. Set `include_noise=true` to recover
+the unfiltered list.
 
 **Output** — text (default) or JSON when `full=true`:
 
@@ -655,6 +663,12 @@ writes to. Files that fail to parse as JSON are silently skipped.
 Return the source-file snippet for a node from disk, with `context_lines`
 above and below the entity's recorded `[start_line, end_line]` range.
 
+**Span guard (#1614):** when `end_line <= start_line` or either is `0` (common
+for synthetic / shadow / route entities), the span is clamped to a fixed
+fallback window (`start_line + 60`). A **hard cap of 200 emitted lines** is then
+applied unconditionally, so `get_source` can never dump an entire file no matter
+what span the entity records.
+
 **Inputs**
 
 | Name | Type | Required | Default | Description |
@@ -894,8 +908,12 @@ both `http_endpoint_definition` and `http_endpoint_call`.
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
 | `repo_filter` | string[] | no | [] | Repos to scope. |
-| `limit` | number | no | 200 | Max results. |
+| `limit` | number | no | 200 | Max results in this page (0 = no cap). |
+| `offset` | number | no | 0 | Pagination offset (#1614) — page through every route with `offset`+`limit` to enumerate all paths. |
 | `group` / `cwd` | string | no | — | Standard routing args. |
+
+The response carries `total`, `offset`, and `truncated` so a caller can answer
+"which endpoints exist" by paging until `truncated` is `false`.
 
 **Output** — JSON object:
 
@@ -938,7 +956,8 @@ note.
 |------|------|----------|---------|-------------|
 | `repo_filter` | string[] | no | [] | Repos to scope. |
 | `orphan_only` | boolean | no | false | When true, return only call-sites with no matching definition. |
-| `limit` | number | no | 200 | Max results. |
+| `limit` | number | no | 200 | Max results in this page (0 = no cap). |
+| `offset` | number | no | 0 | Pagination offset (#1614) — page with `offset`+`limit` to enumerate every call-site path. |
 | `group` / `cwd` | string | no | — | Standard routing args. |
 
 **Output** — JSON object:

--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -1,0 +1,165 @@
+// denoise.go — MCP serving-layer result de-noising and re-ranking (#1614).
+//
+// The graph carries many synthetic / structural entities that are useful for
+// traversal but pure noise in a ranked find/search result: file-and-module
+// CONTAINER components, inferred class-hierarchy shadows, raw Pattern nodes, and
+// Process nodes for array built-ins. Worse, because these often share the BM25
+// score of a real match (label substring), they frequently rank ABOVE the real
+// lined entity the agent actually wants.
+//
+// This file classifies entities into noise buckets and provides a stable
+// re-rank comparator so that real, lined, qualified entities sort first. It is
+// purely a serving-layer concern — no extraction state is touched (other grinds
+// own internal/extractors and internal/engine).
+package mcp
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// noiseKind enumerates the de-noise buckets. noiseNone means the entity is a
+// real, surfacable result.
+type noiseKind int
+
+const (
+	noiseNone noiseKind = iota
+	// noiseContainer: a file/module CONTAINER Component — its label is the
+	// source-file path and it has no body (start_line==0). Useful for
+	// traversal, never a useful ranked hit.
+	noiseContainer
+	// noiseShadow: an inferred class-hierarchy / implicit-method shadow. Either
+	// carries provenance==INFERRED_FROM_CLASS_HIERARCHY, or has an empty
+	// qualified_name AND start_line==0 (e.g. drf_viewset_implicit_method
+	// LoginViewSet.list / .retrieve / .update — bodies that don't exist in
+	// source).
+	noiseShadow
+	// noisePattern: a raw structural Pattern node (SCOPE.Pattern), e.g.
+	// error_handling:try_catch:N. Not the agent-learned AgentPattern kind.
+	noisePattern
+	// noiseProcess: a Process node for an array/string built-in call, e.g.
+	// "Login → map", "Foo → trim". Identified by the proc: ID prefix and/or
+	// the "X → builtin" label shape.
+	noiseProcess
+)
+
+// arrayBuiltins is the set of array/string built-in method names whose Process
+// nodes (e.g. "Login → map") are pure noise in a ranked result.
+var arrayBuiltins = map[string]bool{
+	"map": true, "filter": true, "reduce": true, "forEach": true,
+	"some": true, "every": true, "find": true, "findIndex": true,
+	"includes": true, "indexOf": true, "join": true, "split": true,
+	"trim": true, "slice": true, "splice": true, "concat": true,
+	"push": true, "pop": true, "shift": true, "unshift": true,
+	"sort": true, "reverse": true, "flat": true, "flatMap": true,
+	"keys": true, "values": true, "entries": true, "toLowerCase": true,
+	"toUpperCase": true, "replace": true, "padStart": true, "padEnd": true,
+}
+
+// classifyNoise returns the noise bucket for an entity. noiseNone means the
+// entity is a real, surfacable result.
+func classifyNoise(e *graph.Entity) noiseKind {
+	if e == nil {
+		return noiseNone
+	}
+	bareKind := strings.ToLower(stripScopePrefix(e.Kind))
+
+	// Process nodes for built-ins: the local ID carries a "proc:" segment and
+	// the label has the "X → builtin" shape.
+	if bareKind == "process" || strings.Contains(e.ID, "proc:") {
+		if _, builtin := splitProcessBuiltin(e.Name); builtin {
+			return noiseProcess
+		}
+	}
+
+	// Raw structural Pattern nodes (NOT the agent-learned AgentPattern kind,
+	// which has no SCOPE. prefix and is surfaced deliberately).
+	if e.Kind == string(types.EntityKindPattern) {
+		return noisePattern
+	}
+
+	// File/module container Component: label == source-file path, no body.
+	if bareKind == "component" && e.StartLine == 0 {
+		if e.Properties["subtype"] == "file" || e.Properties["subtype"] == "module" {
+			return noiseContainer
+		}
+		// Fallback: label literally equals the source file path.
+		if e.SourceFile != "" && e.Name == e.SourceFile {
+			return noiseContainer
+		}
+	}
+
+	// Inferred class-hierarchy / implicit-method shadows.
+	if prov := e.Properties["provenance"]; prov == "INFERRED_FROM_CLASS_HIERARCHY" {
+		return noiseShadow
+	}
+	if e.StartLine == 0 && e.QualifiedName == "" {
+		// Bodiless, unqualified entity. Endpoint kinds legitimately have
+		// start_line==0 (they are route declarations, not source bodies) — keep
+		// those. Same for external/datastore/queue/event kinds that model
+		// non-source resources.
+		if !isStructuralLineless(bareKind) {
+			return noiseShadow
+		}
+	}
+
+	return noiseNone
+}
+
+// isStructuralLineless reports whether a bare (scope-stripped, lowercased) kind
+// is one that legitimately has start_line==0 and is NOT a shadow — i.e. it
+// models a route/resource rather than a source body.
+func isStructuralLineless(bareKind string) bool {
+	switch bareKind {
+	case "http_endpoint", "http_endpoint_definition", "http_endpoint_call",
+		"endpoint", "route", "externalapi", "datastore", "dataaccess",
+		"queue", "event", "infraresource", "messagetopic", "service",
+		"externalpackage", "external", "config":
+		return true
+	}
+	return false
+}
+
+// splitProcessBuiltin parses a Process label of the form "Caller → builtin" and
+// reports whether the right-hand side is a known array/string built-in.
+func splitProcessBuiltin(label string) (string, bool) {
+	// Labels use a unicode right-arrow; tolerate "->" as well.
+	for _, sep := range []string{" → ", "→", " -> ", "->"} {
+		if i := strings.Index(label, sep); i >= 0 {
+			rhs := strings.TrimSpace(label[i+len(sep):])
+			return rhs, arrayBuiltins[rhs]
+		}
+	}
+	return "", false
+}
+
+// isNoise reports whether the entity is in any noise bucket.
+func isNoise(e *graph.Entity) bool { return classifyNoise(e) != noiseNone }
+
+// rankTier returns a coarse ranking tier for an entity; LOWER is better. Real
+// lined+qualified entities are tier 0, real lined entities tier 1, structural
+// lineless (endpoints/resources) tier 2, and every noise bucket tier 3+. The
+// caller combines tier with BM25 score so that within a tier the BM25 order is
+// preserved, but a real entity always outranks a shadow/container/pattern.
+func rankTier(e *graph.Entity) int {
+	switch classifyNoise(e) {
+	case noiseContainer:
+		return 5
+	case noiseShadow:
+		return 4
+	case noisePattern:
+		return 6
+	case noiseProcess:
+		return 6
+	}
+	// Real entity. Lined entities (whether or not they carry a qualified_name)
+	// share the top tier so that BM25 relevance — not the mere presence of a
+	// qualified_name — orders them. Lineless-but-legitimate entities (routes /
+	// resources, e.g. endpoint definitions) sit just below.
+	if e.StartLine > 0 {
+		return 0
+	}
+	return 1 // lineless but legitimate (endpoint/resource)
+}

--- a/internal/mcp/denoise_test.go
+++ b/internal/mcp/denoise_test.go
@@ -1,0 +1,126 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+func TestClassifyNoise(t *testing.T) {
+	cases := []struct {
+		name string
+		e    graph.Entity
+		want noiseKind
+	}{
+		{
+			name: "file container component",
+			e: graph.Entity{
+				Kind: "SCOPE.Component", Name: "src/features/auth/login/Login.tablet.tsx",
+				SourceFile: "src/features/auth/login/Login.tablet.tsx", StartLine: 0,
+				Properties: map[string]string{"subtype": "file"},
+			},
+			want: noiseContainer,
+		},
+		{
+			name: "container label==path no subtype",
+			e: graph.Entity{
+				Kind: "SCOPE.Component", Name: "app/(public)/login.tsx",
+				SourceFile: "app/(public)/login.tsx", StartLine: 0,
+			},
+			want: noiseContainer,
+		},
+		{
+			name: "drf implicit method shadow (empty qname, line 0)",
+			e: graph.Entity{
+				Kind: "SCOPE.Operation", Name: "LoginViewSet.retrieve",
+				SourceFile: "core/views/auth_viewset.py", StartLine: 0, QualifiedName: "",
+				Properties: map[string]string{"pattern_type": "drf_viewset_implicit_method"},
+			},
+			want: noiseShadow,
+		},
+		{
+			name: "inferred-from-class-hierarchy provenance",
+			e: graph.Entity{
+				Kind: "SCOPE.Operation", Name: "Base.method", StartLine: 12,
+				QualifiedName: "pkg.Base.method",
+				Properties:    map[string]string{"provenance": "INFERRED_FROM_CLASS_HIERARCHY"},
+			},
+			want: noiseShadow,
+		},
+		{
+			name: "raw pattern node",
+			e: graph.Entity{
+				Kind: "SCOPE.Pattern", Name: "error_handling:try_catch:3",
+				SourceFile: "x.py", StartLine: 10,
+			},
+			want: noisePattern,
+		},
+		{
+			name: "process builtin map",
+			e: graph.Entity{
+				ID: "proc:11c264af58999ae9", Kind: "SCOPE.Process", Name: "Login → map",
+				SourceFile: "src/features/auth/login/index.tsx", StartLine: 0,
+			},
+			want: noiseProcess,
+		},
+		{
+			name: "real lined qualified operation",
+			e: graph.Entity{
+				Kind: "SCOPE.Operation", Name: "login", QualifiedName: "auth.login",
+				SourceFile: "src/stores/authentication/authService.js", StartLine: 4,
+			},
+			want: noiseNone,
+		},
+		{
+			name: "endpoint definition (lineless but legit)",
+			e: graph.Entity{
+				Kind: "http_endpoint_definition", Name: "http:POST:/api/v1/auth/login",
+				SourceFile: "core/routers.py", StartLine: 0, QualifiedName: "",
+			},
+			want: noiseNone,
+		},
+		{
+			name: "agent pattern is not raw pattern noise",
+			e: graph.Entity{
+				Kind: "AgentPattern", Name: "retry-policy", StartLine: 5,
+			},
+			want: noiseNone,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyNoise(&c.e); got != c.want {
+				t.Fatalf("classifyNoise = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+func TestRankTierOrdersRealAboveNoise(t *testing.T) {
+	real := &graph.Entity{Kind: "SCOPE.Operation", Name: "login", QualifiedName: "a.login", StartLine: 4}
+	shadow := &graph.Entity{Kind: "SCOPE.Operation", Name: "LoginViewSet.list", StartLine: 0}
+	container := &graph.Entity{Kind: "SCOPE.Component", Name: "x.tsx", SourceFile: "x.tsx", StartLine: 0, Properties: map[string]string{"subtype": "file"}}
+
+	if rankTier(real) >= rankTier(shadow) {
+		t.Fatalf("real (%d) should rank above shadow (%d)", rankTier(real), rankTier(shadow))
+	}
+	if rankTier(shadow) >= rankTier(container) {
+		t.Fatalf("shadow (%d) should rank above container (%d)", rankTier(shadow), rankTier(container))
+	}
+}
+
+func TestPageSlice(t *testing.T) {
+	s := []int{0, 1, 2, 3, 4}
+	if got := pageSlice(s, 0, 2); len(got) != 2 || got[0] != 0 {
+		t.Fatalf("pageSlice(0,2)=%v", got)
+	}
+	if got := pageSlice(s, 2, 2); len(got) != 2 || got[0] != 2 {
+		t.Fatalf("pageSlice(2,2)=%v", got)
+	}
+	if got := pageSlice(s, 10, 2); len(got) != 0 {
+		t.Fatalf("pageSlice(10,2) should be empty, got %v", got)
+	}
+	if got := pageSlice(s, 3, 0); len(got) != 2 {
+		t.Fatalf("pageSlice(3,0) should be 2 items, got %v", got)
+	}
+}

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -18,9 +18,9 @@
 //     and handleSearchEntities. It calls expandKindAlias so those tools gain
 //     alias support without further changes.
 //   - Three new focused tools:
-//       archigraph_endpoint_definitions — list definition-side entities only
-//       archigraph_endpoint_calls       — list call-site entities only
-//       archigraph_endpoint_stats       — counts of each kind + orphan summary
+//     archigraph_endpoint_definitions — list definition-side entities only
+//     archigraph_endpoint_calls       — list call-site entities only
+//     archigraph_endpoint_stats       — counts of each kind + orphan summary
 //
 // Migration path (for agents and external callers)
 //
@@ -212,15 +212,15 @@ func (s *Server) handleEndpointDefinitions(_ context.Context, req mcpapi.CallToo
 		return out[i].Name < out[j].Name
 	})
 	total := len(out)
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
+	offset := argInt(req, "offset", 0)
+	out = pageSlice(out, offset, limit)
 	return jsonResult(map[string]any{
 		"definitions": out,
 		"count":       len(out),
 		"total":       total,
-		"truncated":   total > len(out),
-		"note":        "http_endpoint kind is deprecated; prefer http_endpoint_definition for handler/route entities.",
+		"offset":      offset,
+		"truncated":   offset+len(out) < total,
+		"note":        "http_endpoint kind is deprecated; prefer http_endpoint_definition for handler/route entities. Page with offset+limit to enumerate all paths.",
 	}), nil
 }
 
@@ -260,17 +260,17 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 	}
 
 	type item struct {
-		EntityID         string            `json:"entity_id"`
-		Name             string            `json:"name"`
-		Kind             string            `json:"kind"`
-		Repo             string            `json:"repo"`
-		SourceFile       string            `json:"source_file,omitempty"`
-		StartLine        int               `json:"start_line,omitempty"`
-		Method           string            `json:"method,omitempty"`
-		Path             string            `json:"path,omitempty"`
-		MatchedDefinition string           `json:"matched_definition,omitempty"`
-		OrphanHint       string            `json:"orphan_hint,omitempty"`
-		Properties       map[string]string `json:"properties,omitempty"`
+		EntityID          string            `json:"entity_id"`
+		Name              string            `json:"name"`
+		Kind              string            `json:"kind"`
+		Repo              string            `json:"repo"`
+		SourceFile        string            `json:"source_file,omitempty"`
+		StartLine         int               `json:"start_line,omitempty"`
+		Method            string            `json:"method,omitempty"`
+		Path              string            `json:"path,omitempty"`
+		MatchedDefinition string            `json:"matched_definition,omitempty"`
+		OrphanHint        string            `json:"orphan_hint,omitempty"`
+		Properties        map[string]string `json:"properties,omitempty"`
 	}
 
 	// Build FETCHES edge map: callerID → toID (definition target).
@@ -375,16 +375,32 @@ func (s *Server) handleEndpointCalls(_ context.Context, req mcpapi.CallToolReque
 	})
 
 	total := len(out)
-	if limit > 0 && len(out) > limit {
-		out = out[:limit]
-	}
+	offset := argInt(req, "offset", 0)
+	out = pageSlice(out, offset, limit)
 	return jsonResult(map[string]any{
 		"calls":     out,
 		"count":     len(out),
 		"total":     total,
-		"truncated": total > len(out),
-		"note":      "http_endpoint kind is deprecated; prefer http_endpoint_call for consumer-side call-site entities.",
+		"offset":    offset,
+		"truncated": offset+len(out) < total,
+		"note":      "http_endpoint kind is deprecated; prefer http_endpoint_call for consumer-side call-site entities. Page with offset+limit to enumerate all call-site paths.",
 	}), nil
+}
+
+// pageSlice returns the [offset, offset+limit) window of s, clamped to bounds.
+// A limit<=0 means "no limit" (return everything from offset onward).
+func pageSlice[T any](s []T, offset, limit int) []T {
+	if offset < 0 {
+		offset = 0
+	}
+	if offset >= len(s) {
+		return s[:0]
+	}
+	s = s[offset:]
+	if limit > 0 && len(s) > limit {
+		s = s[:limit]
+	}
+	return s
 }
 
 // ---------------------------------------------------------------------------
@@ -487,8 +503,8 @@ func (s *Server) handleEndpointStats(_ context.Context, req mcpapi.CallToolReque
 			"legacy_kind":  totalLegacy,
 			"orphan_calls": totalOrphans,
 		},
-		"per_repo":  perRepo,
-		"migrated":  migrated,
-		"note":      note,
+		"per_repo": perRepo,
+		"migrated": migrated,
+		"note":     note,
 	}), nil
 }

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -107,6 +107,13 @@ func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest
 			if e == nil {
 				continue
 			}
+			// #1614: drop file/module CONTAINER components and inferred
+			// shadows. Callers should be operation/component-level referencers,
+			// not the synthetic file node that "contains" the call. (q02/q03/q10)
+			switch classifyNoise(e) {
+			case noiseContainer, noiseShadow:
+				continue
+			}
 			callers = append(callers, caller{
 				EntityID:   prefixedID(r.Repo, e.ID),
 				Name:       e.Name,

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -104,12 +104,18 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 // registerTools registers every tool handler on the MCP server.
 // Source of truth: AddTool calls below — keep internal/mcp/SCHEMA.md in sync.
 // Tool count: 28 (#1281: 9→4 bundles; #1293: desc trim; #1312: +quality_cycles; #1314: +auth_coverage;
-//   #1322: +secrets; #1323: +test_coverage; #1333: desc ≤80 chars;
-//   refactor/mcp-real-3k: ≤3k handshake, -license_audit for token ceiling).
+//
+//	#1322: +secrets; #1323: +test_coverage; #1333: desc ≤80 chars;
+//	refactor/mcp-real-3k: ≤3k handshake, -license_audit for token ceiling).
+//
 // Dropped (HTTP-only): archigraph_diagnostics, archigraph_quality_orphans,
-//   archigraph_get_next_enrichment_task, archigraph_get_telemetry.
+//
+//	archigraph_get_next_enrichment_task, archigraph_get_telemetry.
+//
 // Dropped (agent-facing, ≤3k): archigraph_recent_activity (UI), archigraph_save_finding,
-//   archigraph_list_findings (use enrichments), archigraph_cross_links (niche).
+//
+//	archigraph_list_findings (use enrichments), archigraph_cross_links (niche).
+//
 // Dropped (HTTP-only, ≤3k optimization): archigraph_license_audit (#1334, HTTP API still available).
 func (s *Server) registerTools() {
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_whoami",
@@ -127,13 +133,14 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_get_source", s.handleGetNodeSource))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find",
-		mcpapi.WithDescription("BM25 graph query with optional BFS expansion."),
+		mcpapi.WithDescription("BM25 graph query, de-noised; include_noise:true keeps synthetic nodes."),
 		mcpapi.WithString("question", mcpapi.Required()),
 		mcpapi.WithString("mode", mcpapi.DefaultString("bfs")),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(3)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithBoolean("full", mcpapi.DefaultBool(false)),
+		mcpapi.WithBoolean("include_noise", mcpapi.DefaultBool(false)),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_find", s.handleQueryGraph))
@@ -318,6 +325,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("action", mcpapi.Required()),
 		mcpapi.WithBoolean("orphan_only", mcpapi.DefaultBool(false)),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(200)),
+		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0)),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -287,6 +287,7 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 	depth := argInt(req, "depth", 3)
 	tokenBudget := argInt(req, "token_budget", 800)
 	full := argBool(req, "full", false)
+	includeNoise := argBool(req, "include_noise", false)
 	repoFilter := argStringSlice(req, "repo_filter")
 	contextFilter := contextFilterSet(argStringSlice(req, "context_filter"))
 	mode := argString(req, "mode", "bfs")
@@ -304,7 +305,32 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 			all = append(all, scored{repo: r, hit: h})
 		}
 	}
-	sort.SliceStable(all, func(i, j int) bool { return all[i].hit.Score > all[j].hit.Score })
+
+	// De-noise (#1614): drop file/module container components, inferred class
+	// shadows, raw Pattern nodes and Process built-in nodes from the default
+	// ranked list. They remain reachable via include_noise:true. Applied to
+	// BOTH the compact and full (structured) outputs.
+	if !includeNoise {
+		filtered := all[:0]
+		for _, sc := range all {
+			if isNoise(sc.hit.Entity) {
+				continue
+			}
+			filtered = append(filtered, sc)
+		}
+		all = filtered
+	}
+
+	// Re-rank (#1614): real, lined, qualified entities sort above
+	// shadows/containers/patterns. Within a tier, BM25 score order is preserved.
+	// (When include_noise is set, this still floats real hits above the noise.)
+	sort.SliceStable(all, func(i, j int) bool {
+		ti, tj := rankTier(all[i].hit.Entity), rankTier(all[j].hit.Entity)
+		if ti != tj {
+			return ti < tj
+		}
+		return all[i].hit.Score > all[j].hit.Score
+	})
 
 	// "always-1" rule: if nothing matched but repos contain entities, return
 	// the highest-PageRank entity as a single-result fallback so callers see
@@ -913,11 +939,34 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
 	scanner.Buffer(make([]byte, 1024*1024), 64*1024*1024)
-	start := e.StartLine - contextLines
+
+	// Bound the requested span (#1614). Synthetic / shadow / route entities
+	// frequently carry end_line<=start_line or start_line==0, which previously
+	// caused get_source to emit the entire file. Clamp a degenerate span to a
+	// fixed fallback window, and ALWAYS apply a hard max-lines cap so the
+	// returned chunk can never be a whole-file dump regardless of the recorded
+	// span.
+	const fallbackSpan = 60  // lines, when end<=start or either is 0
+	const hardMaxLines = 200 // absolute cap on emitted source lines
+
+	startLine := e.StartLine
+	endLine := e.EndLine
+	if startLine < 1 {
+		startLine = 1
+	}
+	if endLine <= startLine || e.StartLine == 0 || e.EndLine == 0 {
+		endLine = startLine + fallbackSpan
+	}
+
+	start := startLine - contextLines
 	if start < 1 {
 		start = 1
 	}
-	end := e.EndLine + contextLines
+	end := endLine + contextLines
+	// Hard cap: never emit more than hardMaxLines.
+	if end-start+1 > hardMaxLines {
+		end = start + hardMaxLines - 1
+	}
 	var b strings.Builder
 	line := 0
 	for scanner.Scan() {


### PR DESCRIPTION
## 1. What & why
`archigraph_find(full:true)` on the upvate group returned ~140 nodes of which ~100 were synthetic noise — file/module container components, inferred class-hierarchy shadows, raw `SCOPE.Pattern` nodes, and array-built-in `Process` nodes — and the worst of those frequently ranked **above** the real lined entity an agent actually wants. `get_source` could dump an entire file when an entity's span was degenerate (`end<=start` or `0`). `find_callers` returned file-container nodes instead of real referencers, and there was no way to page through the full endpoint surface to answer "which endpoints exist".

This is fixed entirely at the MCP serving layer (no extraction changes — `internal/extractors` / `internal/engine` untouched).

Fixes #1614

## 2. Approach
- New `internal/mcp/denoise.go`: a single `classifyNoise` classifier + `rankTier` comparator, shared across handlers.
- `handleQueryGraph` (find/search/full): filter the noise buckets out of the default ranked list and the `full:true` JSON dump, then re-rank so real lined entities sort first. New `include_noise:true` flag recovers the unfiltered list.
- `handleGetNodeSource`: clamp degenerate spans to a 60-line fallback window and apply an unconditional 200-line hard cap.
- `handleFindCallers`: drop container + shadow nodes so callers are operation/component-level referencers.
- `handleEndpoints` definitions/calls: add `offset` paging (with `total`/`offset`/`truncated`) so agents can enumerate every resolved path.

## 3. De-noise / rank rules
Excluded by default (kept behind `include_noise:true`):
- **Container** — `Component` with `start_line==0` and `subtype in {file,module}` (or label == source-file path).
- **Shadow** — `provenance==INFERRED_FROM_CLASS_HIERARCHY`, OR empty `qualified_name` + `start_line==0` (e.g. `drf_viewset_implicit_method` `LoginViewSet.list/.retrieve/.update`). Lineless route/resource kinds (endpoints, datastores, queues, external APIs…) are explicitly NOT treated as shadows.
- **Pattern** — raw `SCOPE.Pattern` nodes (the agent-learned `AgentPattern` kind is preserved).
- **Process** — `Process` nodes whose label is `Caller → <array/string builtin>` (map/filter/trim/join/some/…).

Re-rank tiers (lower = first): real lined entity (`start_line>0`) → lineless-but-legitimate route/resource → shadow → container → pattern/process. Within a tier, BM25 score order is preserved, so the highest-relevance real hit stays on top.

## 4. get_source guard
`const fallbackSpan = 60`, `const hardMaxLines = 200`. If `end_line<=start_line` or either is `0`, `end = start + 60`; then the emitted window is capped to 200 lines regardless of the recorded span — it can never be a whole-file dump.

## 5. Verification (real upvate, read-only — live :47274 untouched)
- `go build ./internal/mcp`, `go vet ./internal/mcp`, `go test ./internal/mcp` — all green (28-tool handshake stays under the 3k-token / 80-char-desc budgets).
- Loaded the three real upvate graphs (`core-mobile`, `upvate-core`, `upvate-core-frontend`) and ran `find("Login")` through the de-noise pipeline:

| | total | container | shadow | process |
|---|---|---|---|---|
| **before** | 97 | 7 | 16 | 4 |
| **after** | 70 | 0 | 0 | 0 |

  27 noise nodes dropped; the post-fix top-12 are all real lined entities ordered by BM25 (`loginLoader` 8.26 @ L894, `login` 8.01 @ L4, …) — no containers/shadows/processes. Earlier the file-path containers and `LoginViewSet.list/.update` shadows (all `start_line:0`) appeared in the result and ranked among the top.

## 6. Notes / risk
- Serving-layer only; graph data on disk and the live daemon are unchanged. Re-ranking is opt-out via `include_noise`. Pre-existing `go vet ./...` failures (dashboard `dist` embed, fixture source files) are unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)