### PR TITLE
fix(resolve): structural HTTP call→definition matching + caller-edge retarget (#1615)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2118,7 +2118,7 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 	merged, httpEndpointStats = engine.ResolveHTTPEndpointHandlers(merged)
 	if httpEndpointStats.Synthetics > 0 {
 		fmt.Fprintf(os.Stderr,
-			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d caller_resolved=%d caller_unresolved=%d calls_linked=%d calls_unresolved=%d\n",
+			"http-endpoint-resolve: synthetics=%d handler_resolved=%d handler_dropped=%d no_handler_prop=%d caller_resolved=%d caller_unresolved=%d calls_linked=%d calls_unresolved=%d caller_edges_retargeted=%d\n",
 			httpEndpointStats.Synthetics,
 			httpEndpointStats.HandlerResolved,
 			httpEndpointStats.HandlerDropped,
@@ -2126,7 +2126,8 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 			httpEndpointStats.CallerResolved,
 			httpEndpointStats.CallerUnresolved,
 			httpEndpointStats.CallsLinked,
-			httpEndpointStats.CallsUnresolved)
+			httpEndpointStats.CallsUnresolved,
+			httpEndpointStats.CallerEdgesRetargeted)
 	}
 	// #1217 migration hints: log how many legacy http_endpoint entities were
 	// rewritten to the split kinds. These lines appear only when a graph

--- a/internal/engine/http_endpoint_match.go
+++ b/internal/engine/http_endpoint_match.go
@@ -1,0 +1,153 @@
+// http_endpoint_match.go — structural path normalization for matching
+// http_endpoint_call synthetics to http_endpoint_definition synthetics
+// (issue #1615).
+//
+// Background
+// ----------
+// The Phase-2 resolve pass (http_endpoint_resolve.go) links a call synthetic to
+// a definition synthetic by an EXACT match on the canonical synthetic Name
+// (`http:<VERB>:<path>`). On real polyglot codebases that exact match is far too
+// strict: a frontend/mobile client calls `/inspections/{id}/create-deficiencies/`
+// while the backend mounts the route at `/api/v1/inspections/{pk}/create-deficiencies`.
+// The two Names differ on three independent axes —
+//
+//	(a) the configurable API mount prefix (`/api`, `/api/vN`, `/vN`),
+//	(b) the path-parameter token name (`{id}` vs `{pk}` vs `{slug}` …),
+//	(c) the trailing slash + letter case,
+//
+// — so the exact match misses and the call-site is counted as an orphan even
+// though it clearly targets the backend route. On the upvate corpus this
+// accounted for the bulk of intra-repo HTTP orphans (143 of 144 unresolved
+// call synthetics in the backend repo become resolvable once these three axes
+// are normalized away).
+//
+// Strategy
+// --------
+// normalizeEndpointPath collapses (b) and (c): every path-parameter placeholder
+// — `{pk}`, `{id}`, `{userId}`, `:id`, `<int:id>`, … — becomes the uniform
+// token `{*}`, the result is lower-cased and the trailing slash is stripped.
+// stripEndpointAPIPrefix collapses (a): a leading `/api`, `/api/vN` or bare
+// `/vN` segment is removed so a prefixed producer and an unprefixed consumer
+// bucket together.
+//
+// This is intentionally CONSERVATIVE to avoid false matches:
+//   - Only the well-known `api` / `vN` first segments are stripped — never an
+//     arbitrary first segment, which would collapse genuinely-distinct routes.
+//   - The verb must still be compatible (verbsMatchCompat): `ANY` matches any
+//     specific verb (Django ViewSets emit ANY), but two DIFFERENT specific
+//     verbs never match (DELETE/{*} must not resolve to PATCH/{*}).
+//   - The exact-Name match in the resolve pass always runs FIRST; this
+//     normalized match is a fallback used only when the exact match misses.
+package engine
+
+import (
+	"regexp"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// endpointPathParamRe matches a path-parameter placeholder in any of the three
+// notations the various extractors emit:
+//   - {pk}, {id}, {userId}            (OpenAPI / Django / Express curly form)
+//   - :id, :pk, :userId              (Express / Rails colon form)
+//   - <int:id>, <slug>, <uuid:pk>    (Django / Flask angle form)
+//
+// Each is replaced with the canonical token {*} so matching is on path
+// STRUCTURE, not parameter name. Mirrors internal/links/http_pass.go.
+var endpointPathParamRe = regexp.MustCompile(`\{[^}]+\}|:[a-zA-Z][a-zA-Z0-9_]*|<[^>]+>`)
+
+// endpointAPIPrefixRe matches a leading API/version mount prefix. Only the
+// FIRST segment group is matched and only the well-known `api` / `vN` forms —
+// an arbitrary first segment is never stripped. Go's RE2 has no lookahead so
+// group 1 captures the boundary `/` (kept out of the strip) or end-of-string.
+// Mirrors internal/links/http_pass.go.
+var endpointAPIPrefixRe = regexp.MustCompile(`^/(?:api(?:/v\d+)?|v\d+)(/|$)`)
+
+// normalizeEndpointPath canonicalizes every path-parameter placeholder to the
+// uniform token {*}, lower-cases the result and strips a trailing slash so that
+// route shapes from different extractors compare without caring about parameter
+// name, case or trailing-slash convention.
+//
+//	/users/{pk}                    → /users/{*}
+//	/Users/{userId}/               → /users/{*}
+//	/users/<int:id>                → /users/{*}
+//	/users/{userId}/posts/{postId} → /users/{*}/posts/{*}
+func normalizeEndpointPath(path string) string {
+	path = endpointPathParamRe.ReplaceAllString(path, "{*}")
+	path = strings.ToLower(path)
+	if len(path) > 1 {
+		path = strings.TrimRight(path, "/")
+		if path == "" {
+			path = "/"
+		}
+	}
+	return path
+}
+
+// stripEndpointAPIPrefix removes a leading `/api`, `/api/vN`, or `/vN` segment
+// from an already-normalized path. Returns ("", false) when no such prefix is
+// present. The returned path always keeps a leading slash.
+func stripEndpointAPIPrefix(normalizedPath string) (string, bool) {
+	m := endpointAPIPrefixRe.FindStringSubmatchIndex(normalizedPath)
+	if m == nil {
+		return "", false
+	}
+	stripped := normalizedPath[m[2]:]
+	if stripped == "" {
+		stripped = "/"
+	}
+	return stripped, stripped != normalizedPath
+}
+
+// endpointMatchKeys returns the set of normalized keys under which a synthetic
+// with the given canonical path should be registered / probed: the normalized
+// path, plus its API/version-prefix-stripped form when one is present. Keys are
+// deduplicated.
+func endpointMatchKeys(path string) []string {
+	if path == "" {
+		return nil
+	}
+	nk := normalizeEndpointPath(path)
+	keys := []string{nk}
+	if stripped, ok := stripEndpointAPIPrefix(nk); ok && stripped != nk {
+		keys = append(keys, stripped)
+	}
+	return keys
+}
+
+// resolveCallByPath is the structural fallback used by the Phase-2 resolve pass
+// when the exact-Name match for an http_endpoint_call synthetic misses. It
+// looks the call's normalized path keys up in definitionByPath and returns the
+// first definition (in merged order, for determinism) whose verb is compatible.
+//
+// Determinism: definitionByPath slices are appended in `merged` iteration
+// order, which is canonical by contract of ResolveHTTPEndpointHandlers, so the
+// first compatible candidate is stable across runs.
+//
+// Returns (index, true) on a match, (0, false) otherwise.
+func resolveCallByPath(call *types.EntityRecord, merged []types.EntityRecord, definitionByPath map[string][]int) (int, bool) {
+	callVerb := propOr(call, "verb", "")
+	for _, key := range endpointMatchKeys(propOr(call, "path", "")) {
+		for _, idx := range definitionByPath[key] {
+			if verbsMatchCompat(callVerb, propOr(&merged[idx], "verb", "")) {
+				return idx, true
+			}
+		}
+	}
+	return 0, false
+}
+
+// verbsMatchCompat reports whether a call verb and a definition verb may refer
+// to the same logical endpoint. ANY (case-insensitive) on either side matches
+// everything — Django ViewSets wire HTTP methods at the View level and emit
+// ANY-verb route synthetics. An empty verb is treated as ANY. Two different
+// specific verbs never match.
+func verbsMatchCompat(callVerb, defVerb string) bool {
+	c := strings.ToUpper(strings.TrimSpace(callVerb))
+	d := strings.ToUpper(strings.TrimSpace(defVerb))
+	if c == "" || c == "ANY" || d == "" || d == "ANY" {
+		return true
+	}
+	return c == d
+}

--- a/internal/engine/http_endpoint_match_test.go
+++ b/internal/engine/http_endpoint_match_test.go
@@ -1,0 +1,151 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+func TestNormalizeEndpointPath(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"/users/{pk}", "/users/{*}"},
+		{"/users/:id", "/users/{*}"},
+		{"/users/<int:id>", "/users/{*}"},
+		{"/Users/{userId}/", "/users/{*}"},
+		{"/users/{userId}/posts/{postId}", "/users/{*}/posts/{*}"},
+		{"/api/v1/inspections/{pk}/create-deficiencies", "/api/v1/inspections/{*}/create-deficiencies"},
+		{"/inspections/{id}/create-deficiencies/", "/inspections/{*}/create-deficiencies"},
+		{"/", "/"},
+	}
+	for _, c := range cases {
+		if got := normalizeEndpointPath(c.in); got != c.want {
+			t.Errorf("normalizeEndpointPath(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+func TestStripEndpointAPIPrefix(t *testing.T) {
+	cases := []struct {
+		in       string
+		want     string
+		stripped bool
+	}{
+		{"/api/v1/inspections/{*}/create-deficiencies", "/inspections/{*}/create-deficiencies", true},
+		{"/api/users", "/users", true},
+		{"/v2/things", "/things", true},
+		{"/api", "/", true},
+		{"/inspections/{*}/create-deficiencies", "", false}, // no prefix
+		{"/apiary/bees", "", false},                          // not a real api prefix segment
+	}
+	for _, c := range cases {
+		got, ok := stripEndpointAPIPrefix(c.in)
+		if ok != c.stripped || (ok && got != c.want) {
+			t.Errorf("stripEndpointAPIPrefix(%q) = (%q,%v), want (%q,%v)", c.in, got, ok, c.want, c.stripped)
+		}
+	}
+}
+
+func TestVerbsMatchCompat(t *testing.T) {
+	yes := [][2]string{{"POST", "ANY"}, {"ANY", "GET"}, {"GET", "GET"}, {"", "POST"}, {"delete", "DELETE"}}
+	no := [][2]string{{"DELETE", "PATCH"}, {"GET", "POST"}, {"PUT", "GET"}}
+	for _, c := range yes {
+		if !verbsMatchCompat(c[0], c[1]) {
+			t.Errorf("verbsMatchCompat(%q,%q) = false, want true", c[0], c[1])
+		}
+	}
+	for _, c := range no {
+		if verbsMatchCompat(c[0], c[1]) {
+			t.Errorf("verbsMatchCompat(%q,%q) = true, want false", c[0], c[1])
+		}
+	}
+}
+
+// TestResolveStructuralFallbackAndRetarget exercises the #1615 path: a call
+// synthetic that differs from its definition on API prefix + param-token name +
+// trailing slash + verb (ANY) must (a) resolve via the structural fallback and
+// (b) have its inbound caller→call-synthetic FETCHES edge retargeted at the
+// definition so it stops counting as an orphan.
+func TestResolveStructuralFallbackAndRetarget(t *testing.T) {
+	merged := []types.EntityRecord{
+		// Producer handler + its definition synthetic (mounted under /api/v1, {pk}, ANY verb).
+		{
+			Kind: "SCOPE.Operation", Name: "InspectionViewSet.create_deficiency", SourceFile: "views.py",
+		},
+		{
+			Kind: httpEndpointDefinitionKind,
+			Name: "http:ANY:/api/v1/inspections/{pk}/create-deficiencies",
+			Properties: map[string]string{
+				"path": "/api/v1/inspections/{pk}/create-deficiencies", "verb": "ANY",
+				"source_handler": "SCOPE.Operation:InspectionViewSet.create_deficiency",
+			},
+			SourceFile: "views.py",
+		},
+		// Consumer caller + its call synthetic (no prefix, {id}, trailing slash, POST verb).
+		{
+			Kind: "SCOPE.Operation", Name: "createDeficiencies", SourceFile: "api.ts",
+		},
+		{
+			Kind: httpEndpointCallKind,
+			Name: "http:POST:/inspections/{id}/create-deficiencies/",
+			Properties: map[string]string{
+				"path": "/inspections/{id}/create-deficiencies/", "verb": "POST",
+				"source_caller": "SCOPE.Operation:createDeficiencies",
+			},
+			SourceFile: "api.ts",
+		},
+	}
+
+	out, stats := ResolveHTTPEndpointHandlers(merged)
+
+	if stats.CallsLinked < 1 {
+		t.Fatalf("expected the call synthetic to resolve via structural fallback, calls_linked=%d", stats.CallsLinked)
+	}
+	if stats.CallerEdgesRetargeted < 1 {
+		t.Fatalf("expected the inbound caller FETCHES edge to be retargeted, caller_edges_retargeted=%d", stats.CallerEdgesRetargeted)
+	}
+
+	// The caller entity's FETCHES edge must now point at the DEFINITION stub,
+	// not the call-synthetic stub.
+	defStub := httpEndpointDefinitionKind + ":http:ANY:/api/v1/inspections/{pk}/create-deficiencies"
+	found := false
+	for _, e := range out {
+		if e.Name != "createDeficiencies" {
+			continue
+		}
+		for _, rel := range e.Relationships {
+			if string(rel.Kind) == fetchesEdgeKind && rel.ToID == defStub {
+				found = true
+			}
+		}
+	}
+	if !found {
+		t.Errorf("caller createDeficiencies has no FETCHES edge retargeted to %q", defStub)
+	}
+}
+
+// TestResolveStructuralFallbackVerbGuard ensures a call with an incompatible
+// specific verb does NOT resolve to a definition of a different specific verb
+// (false-match guard).
+func TestResolveStructuralFallbackVerbGuard(t *testing.T) {
+	merged := []types.EntityRecord{
+		{
+			Kind: httpEndpointDefinitionKind,
+			Name: "http:GET:/me-email-templates",
+			Properties: map[string]string{"path": "/me-email-templates", "verb": "GET"},
+			SourceFile: "views.py",
+		},
+		{
+			Kind: httpEndpointCallKind,
+			Name: "http:DELETE:/me-email-templates",
+			Properties: map[string]string{"path": "/me-email-templates", "verb": "DELETE"},
+			SourceFile: "api.ts",
+		},
+	}
+	_, stats := ResolveHTTPEndpointHandlers(merged)
+	if stats.CallsLinked != 0 {
+		t.Errorf("DELETE call must not resolve to a GET-only definition, calls_linked=%d", stats.CallsLinked)
+	}
+	if stats.CallsUnresolved != 1 {
+		t.Errorf("expected the DELETE call to stay unresolved, calls_unresolved=%d", stats.CallsUnresolved)
+	}
+}

--- a/internal/engine/http_endpoint_resolve.go
+++ b/internal/engine/http_endpoint_resolve.go
@@ -88,6 +88,9 @@ type ResolveHTTPEndpointStats struct {
 	// #1217 cross-link counters.
 	CallsLinked      int // call → definition FETCHES edges emitted
 	CallsUnresolved  int // call entities with no matching definition (UNRESOLVED_FETCH)
+	// #1615 — caller→call-synthetic FETCHES edges retargeted at the resolved
+	// definition so the call-site is no longer an orphan.
+	CallerEdgesRetargeted int
 }
 
 // ResolveHTTPEndpointHandlers runs the Phase-2 post-pass over `merged`.
@@ -158,17 +161,38 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 	// http_endpoint_definition via a FETCHES edge (#1217).
 	// Key: synthetic ID (e.g. "http:GET:/api/users") → merged index.
 	definitionByName := make(map[string]int, len(merged))
+	// #1615 — structural fallback index: normalized-path-key → []merged index.
+	// When the exact-Name match misses (because the call and the definition
+	// differ on API prefix / param-token name / trailing slash / case) we look
+	// the call's normalized path keys up here and accept any definition with a
+	// compatible verb. Conservative: only well-known API/version prefixes are
+	// stripped and ANY-verb is the only cross-verb match (see
+	// http_endpoint_match.go).
+	definitionByPath := make(map[string][]int, len(merged))
 	for i := range merged {
 		r := &merged[i]
 		if r.Kind == httpEndpointDefinitionKind {
 			if _, ok := definitionByName[r.Name]; !ok {
 				definitionByName[r.Name] = i
 			}
+			for _, k := range endpointMatchKeys(propOr(r, "path", "")) {
+				definitionByPath[k] = append(definitionByPath[k], i)
+			}
 		}
 	}
 
 	// Collect indices of synthetics to drop (unresolved handlers).
 	drop := map[int]bool{}
+
+	// #1615 — records, for every call synthetic that resolves to a definition,
+	// the rewrite from its FETCHES stub (http_endpoint_call:<name>) to the
+	// definition stub (http_endpoint_definition:<name>). After the main loop we
+	// sweep every caller→call-synthetic FETCHES edge and retarget it at the
+	// definition so the call-site is no longer counted as an orphan. Without
+	// this retarget, the structural call→definition match links the synthetic
+	// pair but the inbound caller edge still points at the (non-definition)
+	// call synthetic and keeps inflating the orphan-call metric.
+	callStubToDefStub := map[string]string{}
 
 	for i := range merged {
 		r := &merged[i]
@@ -198,7 +222,13 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		// so a simple name lookup is sufficient. Emit FETCHES on success;
 		// emit UNRESOLVED_FETCH when no definition is found in the merged set.
 		if r.Kind == httpEndpointCallKind {
-			if defIdx, found := definitionByName[r.Name]; found {
+			defIdx, found := definitionByName[r.Name]
+			if !found {
+				// #1615 — structural fallback: match by normalized path shape
+				// + compatible verb when the exact Name missed.
+				defIdx, found = resolveCallByPath(r, merged, definitionByPath)
+			}
+			if found {
 				def := &merged[defIdx]
 				callStub := r.Kind + ":" + r.Name
 				defStub := def.Kind + ":" + def.Name
@@ -211,6 +241,10 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 						"resolved":     "true",
 					},
 				})
+				// #1615 — remember the stub rewrite so the post-loop sweep can
+				// retarget inbound caller→call-synthetic FETCHES edges at the
+				// definition.
+				callStubToDefStub[callStub] = defStub
 				stats.CallsLinked++
 			} else {
 				// No matching definition found — emit UNRESOLVED_FETCH so the
@@ -322,6 +356,37 @@ func ResolveHTTPEndpointHandlers(merged []types.EntityRecord) ([]types.EntityRec
 		// Clear the now-redundant property.
 		delete(r.Properties, "source_handler")
 		stats.HandlerResolved++
+	}
+
+	// #1615 — retarget caller→call-synthetic FETCHES edges at the resolved
+	// definition. The caller edges were emitted by resolveCallerToFetchesEdge
+	// with ToID = "http_endpoint_call:<name>"; once that call synthetic has been
+	// matched (exact or structural) to a definition we point the caller straight
+	// at the definition so the call-site stops counting as an orphan. Only
+	// http_endpoint_client_synthesis_resolved edges are touched; all other
+	// FETCHES edges (including the call→def edges we just emitted) are left
+	// intact. No-op when callStubToDefStub is empty.
+	if len(callStubToDefStub) > 0 {
+		for i := range merged {
+			rels := merged[i].Relationships
+			for j := range rels {
+				rel := &rels[j]
+				if rel.Kind != fetchesEdgeKind {
+					continue
+				}
+				if rel.Properties["pattern_type"] != "http_endpoint_client_synthesis_resolved" {
+					continue
+				}
+				if defStub, ok := callStubToDefStub[rel.ToID]; ok {
+					rel.ToID = defStub
+					if rel.Properties == nil {
+						rel.Properties = map[string]string{}
+					}
+					rel.Properties["retargeted"] = "http_endpoint_call_to_definition"
+					stats.CallerEdgesRetargeted++
+				}
+			}
+		}
 	}
 
 	if len(drop) == 0 {


### PR DESCRIPTION
## 1. What & why
Cross-stack HTTP call-sites were counted as orphans whenever the client path differed from the backend route on any of three independent axes:
- the API mount prefix (`/api/v1/`),
- the path-parameter token name (`{id}` vs `{pk}` vs `{slug}`),
- the trailing slash + letter case.

The Phase-2 resolve pass (`http_endpoint_resolve.go`) matched `http_endpoint_call` synthetics to `http_endpoint_definition` synthetics by an **exact canonical-Name** match only. So a client calling `/inspections/{id}/create-deficiencies/` never resolved to the backend route `/api/v1/inspections/{pk}/create-deficiencies` (verb `ANY`), and every such call-site inflated the orphan-call metric. This is the same path-normalization gap behind the historical upvate 873-orphan issue and benchmark q05/q11/q12.

## 2. How
- **New `internal/engine/http_endpoint_match.go`** — a conservative structural normalizer:
  - `normalizeEndpointPath`: `{pk}` / `{id}` / `:id` / `<int:id>` → uniform `{*}`, lowercase, trailing-slash strip.
  - `stripEndpointAPIPrefix`: removes a leading `/api`, `/api/vN`, or bare `/vN` segment — **well-known segments only**.
  - `verbsMatchCompat`: `ANY` (Django ViewSets) matches any specific verb; two different specific verbs never match.
- **`http_endpoint_resolve.go`** — when the exact-Name match misses, fall back to a verb-aware normalized path-key index of definitions. When a call resolves, **retarget its inbound `caller → call-synthetic` FETCHES edge at the definition** so the call-site stops counting as an orphan (a new `caller_edges_retargeted` stat is logged).

## 3. Testing
- `go build` / `go vet` clean; `internal/engine` + `internal/links` suites green.
- New unit tests: the three normalization axes, the structural-fallback resolution + caller-edge retarget, and the verb false-match guard.
- **Isolated re-index of the real upvate group** (separate temp dir — the live daemon on :47274 was never touched): backend intra-repo `orphan_calls` **394 → 251** (143 caller edges retargeted), group total **1115 → 972**, resolved FETCHES **2 → 145** (0.2% → 13.0%). Spot-check `/inspections/{id}/create-deficiencies/` resolves to `InspectionViewSet.create_deficiency`.

## 4. False-match guard
Only well-known `api`/`vN` first segments are stripped (never an arbitrary first segment, which would collapse distinct routes); `ANY` is the only cross-verb match (DELETE/{*} never resolves to PATCH/{*}); the exact-Name match always runs first and the normalized match is a strict fallback. A verb-guard test asserts a DELETE call does not bind to a GET-only definition.

## 5. Risks / rollback
Low: the normalized match is fallback-only and verb-gated, so existing exact matches are unchanged. Revert is a clean single-commit rollback.

## 6. Follow-up (out of this grind's scope)
The remaining ~721 orphans are **cross-repo** (mobile/frontend → backend). Per-repo resolve cannot see another repo's definitions, and the `orphan_calls` metric (`internal/mcp/endpoint_tools.go`) is computed from single-hop graph FETCHES and **never consults the cross-repo `links.json`** that `internal/links/http_pass.go` already produces — that pass's normalization is complete and resolves 222/222 linkable consumer call-sites at the link level. Closing the cross-repo metric gap requires `endpoint_stats` to follow the cross-repo links, a one-file change in `internal/mcp` (owned by another grind).

Fixes #1615

🤖 Generated with [Claude Code](https://claude.com/claude-code)