### PR TITLE
fix(jsts): qualified_name, per-binding line attribution, drop builtin-method CALLS (#1616)

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -99,6 +99,9 @@ func (e *JSExtractor) Extract(ctx context.Context, file extreg.FileInput) ([]typ
 		// considering the repo-root tsconfig.
 		aliases:  AliasMapForFile(file.RepoRoot, file.Path),
 		repoRoot: file.RepoRoot,
+		// Issue #1616 — derive the dotted module path once so emit() can
+		// stamp QualifiedName on every entity.
+		module: dottedModuleFromPath(file.Path),
 	}
 
 	// Issue #570 — emit a file-level SCOPE.Component (subtype="file")
@@ -253,6 +256,13 @@ type extractor struct {
 	entities      []types.EntityRecord
 	relationships []types.RelationshipRecord
 
+	// module — Issue #1616. The dotted module path derived from filePath
+	// (e.g. "src/stores/authReducer.js" → "src.stores.authReducer"). Set
+	// once in Extract before walk() runs. Used to populate every emitted
+	// entity's QualifiedName ("<module>.<name>"), mirroring the Python
+	// extractor (#1413). Empty when filePath is empty.
+	module string
+
 	// imports / importByLocal — issue #421. Populated once per file
 	// before walk() runs. Receiver-typed CALLS emission consults
 	// importByLocal[<typeName>] to resolve a typed receiver to the
@@ -356,6 +366,18 @@ func lines(n *sitter.Node) (int, int) {
 	return start, end
 }
 
+// qualify returns the module-path-qualified name for an emitted entity
+// (Issue #1616). Mirrors the Python extractor (#1413): "<module>.<name>",
+// falling back to the bare name when the module is empty. name may already
+// carry a dotted class path for methods (e.g. "Foo.bar"), in which case the
+// result is "<module>.Foo.bar".
+func (x *extractor) qualify(name string) string {
+	if x.module == "" {
+		return name
+	}
+	return x.module + "." + name
+}
+
 // emit appends an entity to the extraction results.
 func (x *extractor) emit(name, kind string, n *sitter.Node, subtype string, sig string) {
 	if name == "" || name == "?" {
@@ -372,14 +394,15 @@ func (x *extractor) emitWithRels(name, kind string, n *sitter.Node, subtype stri
 	}
 	start, end := lines(n)
 	e := types.EntityRecord{
-		Name:       name,
-		Kind:       kind,
-		SourceFile: x.filePath,
-		StartLine:  start,
-		EndLine:    end,
-		Language:   x.language,
-		Subtype:    subtype,
-		Signature:  sig,
+		Name:          name,
+		QualifiedName: x.qualify(name),
+		Kind:          kind,
+		SourceFile:    x.filePath,
+		StartLine:     start,
+		EndLine:       end,
+		Language:      x.language,
+		Subtype:       subtype,
+		Signature:     sig,
 		Properties: map[string]string{
 			"kind":    kind,
 			"subtype": subtype,
@@ -402,6 +425,7 @@ func (x *extractor) emitWithProps(name, kind string, n *sitter.Node, subtype str
 	start, end := lines(n)
 	e := types.EntityRecord{
 		Name:             name,
+		QualifiedName:    x.qualify(name),
 		Kind:             kind,
 		SourceFile:       x.filePath,
 		StartLine:        start,
@@ -789,6 +813,7 @@ func (x *extractor) handleInterfaceDeclaration(n *sitter.Node) {
 	start, end := lines(n)
 	e := types.EntityRecord{
 		Name:             name,
+		QualifiedName:    x.qualify(name),
 		Kind:             "SCOPE.Schema",
 		SourceFile:       x.filePath,
 		StartLine:        start,
@@ -859,6 +884,7 @@ func (x *extractor) handleTypeAliasDeclaration(n *sitter.Node) {
 	start, end := lines(n)
 	e := types.EntityRecord{
 		Name:             name,
+		QualifiedName:    x.qualify(name),
 		Kind:             "SCOPE.Schema",
 		SourceFile:       x.filePath,
 		StartLine:        start,
@@ -1225,15 +1251,31 @@ func (x *extractor) findInnerFunctionBody(n *sitter.Node) *sitter.Node {
 //   - stateHook=true (issue #513) → array elements at index≥1 get subtype
 //     "state_setter" so setX() calls resolve to a real entity
 //
-// Each emit is anchored to valueNode for line numbers (the LHS doesn't
-// carry useful position info beyond what's already on the declarator).
+// Issue #1616 — each binding is anchored to ITS OWN identifier node for
+// line numbers, not the shared valueNode. Previously every binding in a
+// multi-line destructure (e.g. `export const { setToken, getToken, ... } =
+// authSlice.actions;`) was pinned to the single line of the RHS member
+// expression, producing a cluster of entities all reporting the same
+// start_line. Anchoring on the bound identifier attributes each entity to
+// its real declaration line.
 func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, opLift bool, stateHook bool, parentClass string, cb *classBindings) {
 	if pattern == nil {
 		return
 	}
-	anchor := valueNode
-	if anchor == nil {
-		anchor = pattern
+	// fallbackAnchor is used only when a binding node is somehow nil; the
+	// per-binding identifier node is preferred for line attribution (#1616).
+	fallbackAnchor := valueNode
+	if fallbackAnchor == nil {
+		fallbackAnchor = pattern
+	}
+	// anchorFor returns the node to use for line numbers for a given
+	// binding: the binding's own identifier node when available, else the
+	// shared fallback (#1616).
+	anchorFor := func(bind *sitter.Node) *sitter.Node {
+		if bind != nil {
+			return bind
+		}
+		return fallbackAnchor
 	}
 	kind := "SCOPE.Component"
 	subtype := "const_destructure"
@@ -1271,7 +1313,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 					if stateHook && elemIdx >= 1 {
 						elemSubtype = "state_setter"
 					}
-					x.emit(name, kind, anchor, elemSubtype, fmt.Sprintf("%s [%s, ...]", sigPrefix, name))
+					x.emit(name, kind, anchorFor(ch), elemSubtype, fmt.Sprintf("%s [%s, ...]", sigPrefix, name))
 					elemIdx++
 				case "object_pattern", "array_pattern":
 					walk(ch, elemIdx)
@@ -1279,7 +1321,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 				case "rest_pattern":
 					if id := firstIdentifierChild(ch); id != nil {
 						name := x.nodeText(id)
-						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [...%s]", sigPrefix, name))
+						x.emit(name, kind, anchorFor(id), subtype, fmt.Sprintf("%s [...%s]", sigPrefix, name))
 					}
 					elemIdx++
 				case "assignment_pattern":
@@ -1287,7 +1329,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 					if left := ch.ChildByFieldName("left"); left != nil {
 						if left.Type() == "identifier" {
 							name := x.nodeText(left)
-							x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s [%s = ...]", sigPrefix, name))
+							x.emit(name, kind, anchorFor(left), subtype, fmt.Sprintf("%s [%s = ...]", sigPrefix, name))
 						} else {
 							walk(left, -1)
 						}
@@ -1297,7 +1339,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 			}
 		case "shorthand_property_identifier_pattern":
 			name := x.nodeText(p)
-			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s }", sigPrefix, name))
+			x.emit(name, kind, anchorFor(p), subtype, fmt.Sprintf("%s { %s }", sigPrefix, name))
 		case "object_assignment_pattern":
 			// `{ foo = defaultValue }` — tree-sitter wraps the
 			// shorthand identifier in an object_assignment_pattern when
@@ -1308,7 +1350,7 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 				switch left.Type() {
 				case "shorthand_property_identifier_pattern", "identifier":
 					name := x.nodeText(left)
-					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { %s = ... }", sigPrefix, name))
+					x.emit(name, kind, anchorFor(left), subtype, fmt.Sprintf("%s { %s = ... }", sigPrefix, name))
 				default:
 					walk(left, -1)
 				}
@@ -1323,14 +1365,14 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 			switch value.Type() {
 			case "identifier":
 				name := x.nodeText(value)
-				x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s }", sigPrefix, name))
+				x.emit(name, kind, anchorFor(value), subtype, fmt.Sprintf("%s { ...: %s }", sigPrefix, name))
 			case "object_pattern", "array_pattern":
 				walk(value, -1)
 			case "assignment_pattern":
 				if left := value.ChildByFieldName("left"); left != nil {
 					if left.Type() == "identifier" {
 						name := x.nodeText(left)
-						x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...: %s = ... }", sigPrefix, name))
+						x.emit(name, kind, anchorFor(left), subtype, fmt.Sprintf("%s { ...: %s = ... }", sigPrefix, name))
 					} else {
 						walk(left, -1)
 					}
@@ -1339,20 +1381,20 @@ func (x *extractor) emitDestructuredEntities(pattern, valueNode *sitter.Node, op
 		case "rest_pattern":
 			if id := firstIdentifierChild(p); id != nil {
 				name := x.nodeText(id)
-				x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s { ...%s }", sigPrefix, name))
+				x.emit(name, kind, anchorFor(id), subtype, fmt.Sprintf("%s { ...%s }", sigPrefix, name))
 			}
 		case "assignment_pattern":
 			if left := p.ChildByFieldName("left"); left != nil {
 				if left.Type() == "identifier" {
 					name := x.nodeText(left)
-					x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s = ...", sigPrefix, name))
+					x.emit(name, kind, anchorFor(left), subtype, fmt.Sprintf("%s %s = ...", sigPrefix, name))
 				} else {
 					walk(left, -1)
 				}
 			}
 		case "identifier":
 			name := x.nodeText(p)
-			x.emit(name, kind, anchor, subtype, fmt.Sprintf("%s %s", sigPrefix, name))
+			x.emit(name, kind, anchorFor(p), subtype, fmt.Sprintf("%s %s", sigPrefix, name))
 		}
 	}
 	walk(pattern, -1)
@@ -1571,6 +1613,47 @@ func (x *extractor) extractCallRelationships(body *sitter.Node, callerName strin
 	return rels
 }
 
+// builtinMethodNames is the set of JS/TS built-in prototype methods on
+// Array, String, Object, Promise, Map, Set, and Number that the extractor
+// must NOT emit as user-defined CALLS targets (Issue #1616). A bare
+// `<expr>.map(...)` whose receiver did not type-resolve to a user class is
+// almost always a built-in iteration/transform, not a call into the user's
+// own code; emitting it produces unresolvable bug-extractor edges and
+// spurious SCOPE.Process flow steps. The list is deliberately limited to
+// unambiguous, high-frequency built-ins.
+var builtinMethodNames = map[string]bool{
+	// Array iteration / transformation
+	"map": true, "filter": true, "reduce": true, "reduceRight": true,
+	"forEach": true, "some": true, "every": true, "find": true,
+	"findIndex": true, "findLast": true, "findLastIndex": true,
+	"flat": true, "flatMap": true, "sort": true, "reverse": true,
+	"fill": true, "copyWithin": true, "entries": true, "keys": true,
+	"values": true, "indexOf": true, "lastIndexOf": true,
+	"includes": true, "push": true, "pop": true, "shift": true,
+	"unshift": true, "splice": true,
+	// Array + String shared
+	"slice": true, "concat": true, "join": true,
+	// String
+	"trim": true, "trimStart": true, "trimEnd": true, "split": true,
+	"replace": true, "replaceAll": true, "toLowerCase": true,
+	"toUpperCase": true, "padStart": true, "padEnd": true,
+	"startsWith": true, "endsWith": true, "charAt": true,
+	"charCodeAt": true, "codePointAt": true, "substring": true,
+	"substr": true, "repeat": true, "match": true, "matchAll": true,
+	"search": true, "normalize": true, "localeCompare": true,
+	// Promise instance
+	"then": true, "catch": true, "finally": true,
+	// Number / common formatting
+	"toFixed": true, "toString": true, "toPrecision": true,
+	"valueOf": true, "hasOwnProperty": true,
+}
+
+// isBuiltinMethodName reports whether method is a JS/TS built-in prototype
+// method that should not be modeled as a user-defined CALLS target (#1616).
+func isBuiltinMethodName(method string) bool {
+	return builtinMethodNames[method]
+}
+
 // callTarget resolves the callee name from a call_expression / new_expression.
 // Returns the trailing identifier of the function expression, or "" when the
 // callee is an unsupported expression form (numeric literal, complex
@@ -1633,6 +1716,21 @@ func (x *extractor) callTarget(call *sitter.Node, frame *classBindings) string {
 		// to the bare method name (existing behaviour preserved).
 		if id := x.receiverNodeStdlibTarget(fn, method); id != "" {
 			return id
+		}
+		// Issue #1616 — drop CALLS edges to JS/TS built-in array, string,
+		// Object, and Promise prototype methods (.map/.filter/.reduce/
+		// .forEach/.some/.every/.find/.join/.split/.trim/.slice/...). These
+		// are language built-ins, not user-defined operations: emitting a
+		// bare-name CALLS edge to them produces unresolvable targets that
+		// the resolver dumps into bug-extractor AND, downstream, causes the
+		// process-flow builder to synthesise spurious SCOPE.Process steps
+		// (e.g. `Login → map`, `Login → trim`). We only filter when the
+		// receiver did NOT type-resolve to a user class and is NOT a Node
+		// stdlib namespace (both handled above), so a genuine user method
+		// that happens to share a built-in name (resolved via typing) is
+		// preserved.
+		if isBuiltinMethodName(method) {
+			return ""
 		}
 		return method
 	case "parenthesized_expression":

--- a/internal/extractors/javascript/issue1616_jsts_extract_test.go
+++ b/internal/extractors/javascript/issue1616_jsts_extract_test.go
@@ -1,0 +1,154 @@
+package javascript_test
+
+import (
+	"context"
+	"testing"
+
+	extreg "github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/extractors/javascript"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractAtPath runs the JS/TS extractor for content at a specific repo-relative
+// path (Issue #1616 — qualified_name derivation depends on the file path).
+func extractAtPath(t *testing.T, content []byte, language, path string) []types.EntityRecord {
+	t.Helper()
+	var tree = parseJS(t, content)
+	if language == "typescript" {
+		tree = parseTS(t, content)
+	}
+	e := javascript.New()
+	got, err := e.Extract(context.Background(), extreg.FileInput{
+		Path:     path,
+		Content:  content,
+		Language: language,
+		Tree:     tree,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return got
+}
+
+// TestIssue1616_QualifiedNamePopulated verifies that function, arrow, class,
+// interface, and type-alias entities carry a module-path-qualified
+// QualifiedName ("<dotted-module>.<name>") instead of an empty string.
+func TestIssue1616_QualifiedNamePopulated(t *testing.T) {
+	src := []byte(`
+export function createOrder(x) { return x; }
+export const handleClick = () => 42;
+export class Widget {}
+`)
+	ents := extractAtPath(t, src, "javascript", "src/orders/handlers.js")
+
+	wantQN := map[string]string{
+		"createOrder": "src.orders.handlers.createOrder",
+		"handleClick": "src.orders.handlers.handleClick",
+		"Widget":      "src.orders.handlers.Widget",
+	}
+	for name, qn := range wantQN {
+		e := findByName(ents, name)
+		if e == nil {
+			t.Fatalf("entity %q not emitted", name)
+		}
+		if e.QualifiedName != qn {
+			t.Errorf("%q QualifiedName = %q, want %q", name, e.QualifiedName, qn)
+		}
+	}
+}
+
+func TestIssue1616_QualifiedNameTypeScript(t *testing.T) {
+	src := []byte(`
+export interface User { id: number }
+export type ID = string | number;
+`)
+	ents := extractAtPath(t, src, "typescript", "src/models/user.ts")
+	for name, qn := range map[string]string{
+		"User": "src.models.user.User",
+		"ID":   "src.models.user.ID",
+	} {
+		e := findByName(ents, name)
+		if e == nil {
+			t.Fatalf("entity %q not emitted", name)
+		}
+		if e.QualifiedName != qn {
+			t.Errorf("%q QualifiedName = %q, want %q", name, e.QualifiedName, qn)
+		}
+	}
+}
+
+// TestIssue1616_DestructureLineAttribution verifies that each binding in a
+// multi-line object-destructure is attributed to ITS OWN declaration line,
+// not the single line of the RHS expression (the authReducer.js line-420
+// cluster bug).
+func TestIssue1616_DestructureLineAttribution(t *testing.T) {
+	src := []byte(`const slice = { actions: {} };
+export const {
+    setToken,
+    getToken,
+    destroyToken,
+} = slice.actions;
+`)
+	ents := extractAtPath(t, src, "javascript", "src/stores/authReducer.js")
+
+	want := map[string]int{
+		"setToken":     3,
+		"getToken":     4,
+		"destroyToken": 5,
+	}
+	seenLines := map[int]bool{}
+	for name, line := range want {
+		e := findByName(ents, name)
+		if e == nil {
+			t.Fatalf("destructured binding %q not emitted", name)
+		}
+		if e.StartLine != line {
+			t.Errorf("%q StartLine = %d, want %d", name, e.StartLine, line)
+		}
+		seenLines[e.StartLine] = true
+	}
+	if len(seenLines) < 3 {
+		t.Errorf("expected 3 distinct start lines, got %d (bindings still pinned to one line)", len(seenLines))
+	}
+}
+
+// TestIssue1616_NoBuiltinMethodCalls verifies that calls to JS built-in
+// array/string prototype methods (.map/.filter/.trim/.join/.some/...) do NOT
+// produce CALLS edges to a bare built-in name (which downstream synthesises
+// spurious Process flow steps like `Login -> map`).
+func TestIssue1616_NoBuiltinMethodCalls(t *testing.T) {
+	src := []byte(`
+export function Login(items) {
+  const a = items.map(x => x);
+  const b = a.filter(Boolean);
+  const c = "  hi  ".trim();
+  const d = [1, 2].join(",");
+  const e = items.some(Boolean);
+  doRealWork(a);
+  return c + d + e + b;
+}
+`)
+	ents := extractAtPath(t, src, "javascript", "src/auth/Login.jsx")
+	login := findByName(ents, "Login")
+	if login == nil {
+		t.Fatal("Login entity not emitted")
+	}
+	builtins := map[string]bool{
+		"map": true, "filter": true, "trim": true, "join": true, "some": true,
+	}
+	sawReal := false
+	for _, r := range login.Relationships {
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if builtins[r.ToID] {
+			t.Errorf("CALLS edge to built-in method %q should be filtered", r.ToID)
+		}
+		if r.ToID == "doRealWork" {
+			sawReal = true
+		}
+	}
+	if !sawReal {
+		t.Error("expected the user-defined call doRealWork to still produce a CALLS edge")
+	}
+}


### PR DESCRIPTION
Fixes #1616

## 1. What & why
Three JS/TS extraction defects were producing graph noise and unresolvable edges, validated on the upvate frontend (650 source files):

1. **~65% empty `qualified_name`** — the JS extractor never populated `QualifiedName`, so most TS/JS entities had an empty qualified name (calibration ~13,441). Resolution paths and cross-repo linking that key on qualified names had nothing to match.
2. **Local destructure bindings all pinned to one line** — e.g. `authReducer.js`'s `export const { setToken, getToken, destroyToken, ... } = authSlice.actions;` emitted every action with `start_line=420` (the line of the RHS member expression).
3. **JS built-in array/string methods modeled as call targets** — `arr.map(...)`, `s.trim()`, `a.join()`, `xs.some()` produced bare-name `CALLS` edges that the resolver could not bind and that the process-flow builder turned into spurious `SCOPE.Process` steps (`Login -> map`, `Login -> trim`).

## 2. How
All changes are confined to `internal/extractors/javascript/extractor.go`:

- **Defect 1:** Added an `extractor.module` field derived once per file via the existing `dottedModuleFromPath`, plus a `qualify(name)` helper. `QualifiedName` is now stamped in the three emit helpers (`emitWithRels`, `emitWithProps`) and on the directly-constructed interface / type-alias entities. Method names already carry their dotted class path, so `module + "." + name` is correct for them too (same encoding as the Python extractor, #1413).
- **Defect 2:** `emitDestructuredEntities` now anchors each binding's line numbers to its **own** identifier node (`anchorFor(bindNode)`) instead of the shared RHS `anchor`. Genuinely same-line destructures still collapse to one line; multi-line ones spread across their real lines.
- **Defect 3:** Added `isBuiltinMethodName` (Array / String / Object / Promise / Number prototype methods). In `callTarget`'s `member_expression` branch, after receiver-typing and Node-stdlib resolution both miss, a built-in method name returns `""` so no `CALLS` edge is emitted. User methods that share a built-in name but type-resolve to a user class are preserved (the filter runs only on the unresolved fall-through).

## 3. Testing
- New `internal/extractors/javascript/issue1616_jsts_extract_test.go`: qualified_name for JS + TS entities, per-binding line attribution for a multi-line destructure, and built-in-method CALLS suppression (asserting the real user call survives).
- `go build ./internal/extractors/...`, `go vet`, and `go test` green for `internal/extractors/javascript`, `internal/engine`, `internal/resolve`.
- One pre-existing failure remains in `cmd/archigraph` (`TestDaemonMCPListTools_Returns14Canonical`, missing `archigraph_recent_activity` / `archigraph_get_telemetry`); confirmed it fails identically with these changes stashed — unrelated to this issue.

## 4. Verification (isolated, real upvate)
A pruned copy of the upvate frontend was indexed offline in-process (no daemon, no live `:47274`) with both the base commit (10b723a) and this branch, using an identical pipeline so only the extractor differs.

| Metric (jsts, non-file entities) | BEFORE | AFTER |
|---|---|---|
| empty `qualified_name` | 7991 / 7991 = **100%** | 1088 / 7919 = **13.7%** |
| `CALLS` edges to a built-in-named entity | **1649** | **0** |
| `SCOPE.Process` nodes | **247** | **175** (-72 spurious flows) |
| local-const Components in >=4-share-one-line clusters | **551** | **262** |
| authReducer action `start_line`s | `{420: 11}` (all pinned) | `409..419` (each on its own line) |

The residual 13.7% empty qualified_name are **not** JS-extractor user entities — they are nodes synthesized by other passes/extractors (`http_endpoint_call`, `SCOPE.Pattern`, `SCOPE.Process`, and `react_component` from `internal/extractors/cross/react_props`), out of scope for this issue. Every entity emitted by the JS extractor itself now carries a qualified name.

## 5. Risks / trade-offs
- The built-in-method filter is intentionally conservative: it only fires on the unresolved fall-through, so a user method named e.g. `find` that type-resolves via the receiver binder (#421) or Node-stdlib path is untouched. A user object literal with a method also named `map` called via an untyped receiver would be dropped — acceptable, as such edges are unresolvable today anyway and the cost is graph noise removal.
- Destructured reducer actions (e.g. `setToken`) are still emitted (not dropped) because they are re-exported and called cross-file; dropping them would regress resolution. The fix corrects their line attribution rather than removing the signal.

## 6. Out of scope / coordination
- No changes to `internal/extractors/python`, `internal/resolve`, or `internal/mcp` (other grinds).
- Did not touch `internal/engine/cross` (class-shadows grind). The built-in filter was applied at the JS extractor source (`callTarget`) rather than in `internal/engine/process_flow.go`, which removes the spurious Process steps at the root without editing the shared flow builder.
- Did not touch the live `:47274` daemon; all verification used an isolated in-process index of an upvate copy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)