### PR TITLE
fix(hierarchy): fold line-0 class shadows into the real typed node (#1613)

### DIFF
--- a/cmd/archigraph/class_shadow_fold_test.go
+++ b/cmd/archigraph/class_shadow_fold_test.go
@@ -1,0 +1,106 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// TestClassShadowFold_NoLine0Shadows asserts the #1613 fold invariant on the
+// Django fixture: every class resolves to a single node with a real start_line
+// and qualified_name, and NO line-0 INFERRED_FROM_CLASS_HIERARCHY shadow
+// remains. The fixture's models.py declares `Article(models.Model)` and
+// `Author(models.Model)`, each of which the pipeline would otherwise emit as
+// up to three nodes (Model framework node + SCOPE.Component/class AST node +
+// INFERRED class-hierarchy shadow).
+func TestClassShadowFold_NoLine0Shadows(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/django_app", "django_app", nil)
+
+	var inferred, classLikeLine0 int
+	byName := map[string][]graph.Entity{}
+	for _, e := range doc.Entities {
+		byName[e.Name] = append(byName[e.Name], e)
+		if e.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY" {
+			inferred++
+		}
+		if classLikeComponentSubtypes[e.Subtype] && e.StartLine == 0 {
+			classLikeLine0++
+		}
+	}
+
+	if inferred != 0 {
+		t.Errorf("expected 0 INFERRED_FROM_CLASS_HIERARCHY shadows after fold, got %d", inferred)
+	}
+	if classLikeLine0 != 0 {
+		t.Errorf("expected 0 class-like entities at start_line=0 after fold, got %d", classLikeLine0)
+	}
+
+	// Each declared class must resolve to exactly ONE class-declaration node
+	// with a real line span and a qualified_name. The ORM table sentinel
+	// (SCOPE.Component/orm_model_sentinel) is an intentional, search-excluded
+	// edge anchor named after the table — it is NOT a class shadow and is out
+	// of scope for #1613, so we exclude it from the per-class node count.
+	for _, name := range []string{"Article", "Author"} {
+		var decls []graph.Entity
+		for _, e := range byName[name] {
+			if e.Subtype == "orm_model_sentinel" {
+				continue
+			}
+			decls = append(decls, e)
+		}
+		if len(decls) != 1 {
+			t.Errorf("%s: expected exactly 1 class-declaration node after fold, got %d: %+v", name, len(decls), kinds(decls))
+			continue
+		}
+		e := decls[0]
+		if e.StartLine == 0 {
+			t.Errorf("%s: surviving node has start_line=0 (want real line)", name)
+		}
+		if e.QualifiedName == "" {
+			t.Errorf("%s: surviving node has empty qualified_name", name)
+		}
+		if e.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY" {
+			t.Errorf("%s: surviving node still carries the inference provenance", name)
+		}
+	}
+}
+
+// TestClassShadowFold_NoNewDanglingEdges asserts the fold does not introduce
+// dangling hex-id edge endpoints relative to the unfolded graph (folding only
+// re-points endpoints onto a surviving node that is always present).
+func TestClassShadowFold_NoNewDanglingEdges(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DISABLE_1613_FOLD", "1")
+	unfolded := runIndexerOn(t, "testdata/django_app", "django_app", nil)
+	t.Setenv("ARCHIGRAPH_DISABLE_1613_FOLD", "")
+	folded := runIndexerOn(t, "testdata/django_app", "django_app", nil)
+
+	if d := danglingHexEndpoints(folded); d > danglingHexEndpoints(unfolded) {
+		t.Errorf("fold introduced new dangling hex endpoints: folded=%d unfolded=%d",
+			d, danglingHexEndpoints(unfolded))
+	}
+}
+
+func danglingHexEndpoints(doc *graph.Document) int {
+	ids := make(map[string]bool, len(doc.Entities))
+	for _, e := range doc.Entities {
+		ids[e.ID] = true
+	}
+	n := 0
+	for _, r := range doc.Relationships {
+		if isHex16(r.FromID) && !ids[r.FromID] {
+			n++
+		}
+		if isHex16(r.ToID) && !ids[r.ToID] {
+			n++
+		}
+	}
+	return n
+}
+
+func kinds(es []graph.Entity) []string {
+	out := make([]string, len(es))
+	for i, e := range es {
+		out[i] = e.Kind + "/" + e.Subtype
+	}
+	return out
+}

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2093,6 +2093,292 @@ func (i *Indexer) buildPatternContainsRels(records []types.EntityRecord) []types
 	return out
 }
 
+// foldShadowStats reports the result of foldClassHierarchyShadows for the
+// stderr log line.
+type foldShadowStats struct {
+	// ShadowsFolded is the number of INFERRED_FROM_CLASS_HIERARCHY shadows
+	// dropped because a real typed node existed for the same source+symbol.
+	ShadowsFolded int
+	// EdgesRepointed is the number of edge endpoints (FromID/ToID, embedded
+	// or standalone) rewritten from a folded shadow's ID to its survivor.
+	EdgesRepointed int
+	// ShadowsBackfilled is the number of shadows that survived (no real typed
+	// node) and now carry a real start_line (>0) from the extractor.
+	ShadowsBackfilled int
+	// ShadowsStillLine0 is the residual count of surviving shadows that still
+	// have start_line==0 (regex could not anchor a line — should be ~0).
+	ShadowsStillLine0 int
+}
+
+// frameworkClassKindPriority ranks framework-typed node kinds by how strongly
+// they represent a class/type *declaration* (vs a nested artifact that merely
+// shares the class name, e.g. a Django Meta `Constraint`). These are the only
+// kinds eligible to be a fold *survivor*. When several share a fold source's
+// source_file+name, the highest-priority kind wins. Higher value = stronger
+// class signal. SCOPE.Component is intentionally absent: it is the generic AST
+// node we fold AWAY into a framework-typed survivor (so a class with a View
+// resolves to ONE node), and it is itself the survivor only when no
+// framework-typed node exists (handled separately, never as a candidate here).
+var frameworkClassKindPriority = map[string]int{
+	"Model":          100,
+	"View":           100,
+	"Controller":     100,
+	"Service":        100,
+	"Middleware":     100,
+	"Repository":     100,
+	"TestClass":      90,
+	"Schema":         80,
+	"Plugin":         80,
+	"Implementation": 80,
+	"Interface":      80,
+	"Task":           70,
+}
+
+func isShadowRecord(r *types.EntityRecord) bool {
+	return r.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY"
+}
+
+// classLikeComponentSubtypes are the SCOPE.Component subtypes that denote a
+// class/type declaration (as opposed to subtype="file"/"import"/"module").
+var classLikeComponentSubtypes = map[string]bool{
+	"class": true, "struct": true, "interface": true,
+	"protocol": true, "trait": true, "behaviour": true,
+}
+
+// isFoldSource reports whether r is a class-representation node that should be
+// folded into a framework-typed node when one exists for the same symbol:
+//   - the INFERRED_FROM_CLASS_HIERARCHY shadow emitted by the hierarchy pass, OR
+//   - the generic SCOPE.Component class node emitted by the per-language AST
+//     extractor (these two share an EntityID and pre-merge at assembly).
+//
+// When NO framework-typed node exists, a fold source is kept as the single
+// node for that class (it already carries a real line from its extractor).
+func isFoldSource(r *types.EntityRecord) bool {
+	if r.Name == "" {
+		return false
+	}
+	if isShadowRecord(r) {
+		return true
+	}
+	return r.Kind == "SCOPE.Component" && classLikeComponentSubtypes[r.Subtype]
+}
+
+// foldClassHierarchyShadows folds line-less / generic class nodes into the real
+// framework-typed node (View/Model/Controller/…) for the same source_file +
+// symbol when one exists, so every class resolves to ONE node with a real line
+// span + qualified_name. Issue #1613.
+//
+// Fold sources (see isFoldSource): the INFERRED_FROM_CLASS_HIERARCHY shadow and
+// the generic SCOPE.Component/class AST node. For each:
+//   - If a framework-typed node (see frameworkClassKindPriority) exists for the
+//     same (SourceFile, Name): DROP the source and remap its stamped ID to the
+//     survivor. The survivor keeps its real start_line/end_line/qualified_name/
+//     language; any property the source carried that the survivor lacks (e.g.
+//     is_abstract) is copied over.
+//   - Otherwise the source SURVIVES as the single node for that class — the
+//     extractor already stamped a real start_line (+ qualified_name for Python).
+//
+// After deciding folds, every edge endpoint (embedded EntityRecord.Relationships
+// across ALL records, plus the standalone pass2Rels stream) that points at a
+// folded source's ID is rewritten to the survivor's ID. Embedded edges OWNED by
+// a folded source (those it emitted) are re-homed onto the survivor record so
+// they are still surfaced at assembly time. Edges are never dropped.
+//
+// Runs after stampEntityIDs + the resolver passes so r.ID is populated and
+// embedded rel endpoints are already in hex-ID form where resolvable.
+func (i *Indexer) foldClassHierarchyShadows(
+	merged []types.EntityRecord,
+	pass2Rels []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord, foldShadowStats) {
+	var stats foldShadowStats
+
+	// Index framework-typed survivor candidates by (SourceFile, Name).
+	type cand struct {
+		idx int
+		id  string
+		pri int
+		ln  int
+	}
+	bySymbol := make(map[[2]string][]cand)
+	for k := range merged {
+		r := &merged[k]
+		if r.Name == "" {
+			continue
+		}
+		pri, ok := frameworkClassKindPriority[r.Kind]
+		if !ok {
+			continue
+		}
+		key := [2]string{r.SourceFile, r.Name}
+		bySymbol[key] = append(bySymbol[key], cand{idx: k, id: r.ID, pri: pri, ln: r.StartLine})
+	}
+
+	// Index non-shadow records by stamped ID so a surviving shadow can detect a
+	// sibling AST SCOPE.Component node (same ID) to defer to (#1613): the shadow
+	// and the per-language AST class node share an EntityID, so only one is
+	// emitted at assembly. We want the AST node (real coordinates, no inference
+	// provenance) to win, and we strip the now-misleading shadow provenance from
+	// any shadow that survives with real coordinates.
+	nonShadowByID := make(map[string]bool)
+	for k := range merged {
+		r := &merged[k]
+		if r.ID != "" && !isShadowRecord(r) {
+			nonShadowByID[r.ID] = true
+		}
+	}
+
+	// remap: folded source ID -> survivor ID.
+	remap := make(map[string]string)
+	drop := make(map[int]bool)
+
+	for k := range merged {
+		r := &merged[k]
+		if !isFoldSource(r) {
+			continue
+		}
+		cands := bySymbol[[2]string{r.SourceFile, r.Name}]
+		if len(cands) == 0 {
+			// No framework-typed survivor — this node IS the single class node.
+			if isShadowRecord(r) {
+				// If a sibling AST SCOPE.Component node (same ID) exists, drop
+				// the shadow and let the AST node carry the class (it has real
+				// coordinates and no inference provenance). Otherwise the shadow
+				// is the only node: keep it, but strip the now-misleading
+				// INFERRED_FROM_CLASS_HIERARCHY provenance since it points at
+				// real source (start_line>0). Record residual stats.
+				if nonShadowByID[r.ID] {
+					drop[k] = true
+					stats.ShadowsFolded++
+					// Re-home edges the shadow owns onto the standalone stream
+					// with an explicit FromID (== the shared ID the AST sibling
+					// also uses) so they are not lost when this record is dropped.
+					for ri := range r.Relationships {
+						rel := r.Relationships[ri]
+						if rel.FromID == "" {
+							rel.FromID = r.ID
+						}
+						pass2Rels = append(pass2Rels, rel)
+					}
+					r.Relationships = nil
+					continue
+				}
+				if r.StartLine > 0 {
+					stats.ShadowsBackfilled++
+					delete(r.Properties, "provenance")
+				} else {
+					stats.ShadowsStillLine0++
+				}
+			}
+			continue
+		}
+		// Pick the strongest class-like candidate: highest priority, then
+		// smallest start_line (the declaration), then smallest id for stability.
+		best := cands[0]
+		for _, c := range cands[1:] {
+			if c.pri != best.pri {
+				if c.pri > best.pri {
+					best = c
+				}
+				continue
+			}
+			if c.ln != best.ln {
+				// Prefer a real (>0) smaller line; treat 0 as "no line" (worst).
+				switch {
+				case best.ln == 0 && c.ln > 0:
+					best = c
+				case c.ln > 0 && c.ln < best.ln:
+					best = c
+				}
+				continue
+			}
+			if c.id < best.id {
+				best = c
+			}
+		}
+		if best.id == r.ID {
+			// Degenerate (same ID) — leave as-is.
+			continue
+		}
+		drop[k] = true
+		remap[r.ID] = best.id
+		stats.ShadowsFolded++
+
+		// Copy useful properties the survivor lacks (e.g. is_abstract, role).
+		sv := &merged[best.idx]
+		if sv.Properties == nil {
+			sv.Properties = map[string]string{}
+		}
+		for pk, pv := range r.Properties {
+			if pk == "provenance" || pk == "ref" {
+				continue
+			}
+			if _, exists := sv.Properties[pk]; !exists {
+				sv.Properties[pk] = pv
+			}
+		}
+		// Re-home edges the shadow OWNS (emitted on its own record). Their
+		// FromID may be "" (meaning the owner's ID) — bind it to the survivor.
+		for ri := range r.Relationships {
+			rel := r.Relationships[ri]
+			if rel.FromID == "" || rel.FromID == r.ID {
+				rel.FromID = best.id
+			}
+			sv.Relationships = append(sv.Relationships, rel)
+		}
+		r.Relationships = nil
+	}
+
+	if len(remap) == 0 && len(drop) == 0 {
+		return merged, pass2Rels, stats
+	}
+
+	// Re-point every edge endpoint that targets a folded shadow.
+	rewrite := func(id string) (string, bool) {
+		if nv, ok := remap[id]; ok {
+			return nv, true
+		}
+		return id, false
+	}
+	for k := range merged {
+		if drop[k] {
+			continue
+		}
+		r := &merged[k]
+		for ri := range r.Relationships {
+			rel := &r.Relationships[ri]
+			if nv, ok := rewrite(rel.FromID); ok {
+				rel.FromID = nv
+				stats.EdgesRepointed++
+			}
+			if nv, ok := rewrite(rel.ToID); ok {
+				rel.ToID = nv
+				stats.EdgesRepointed++
+			}
+		}
+	}
+	for ri := range pass2Rels {
+		rel := &pass2Rels[ri]
+		if nv, ok := rewrite(rel.FromID); ok {
+			rel.FromID = nv
+			stats.EdgesRepointed++
+		}
+		if nv, ok := rewrite(rel.ToID); ok {
+			rel.ToID = nv
+			stats.EdgesRepointed++
+		}
+	}
+
+	// Compact: drop the folded shadow records.
+	out := merged[:0]
+	for k := range merged {
+		if drop[k] {
+			continue
+		}
+		out = append(out, merged[k])
+	}
+	return out, pass2Rels, stats
+}
+
 // buildDocument merges entity records from every pass, dedupes by stable
 // graph-entity ID, resolves cross-file CALLS edges, then assembles the
 // final on-disk document.
@@ -2274,6 +2560,27 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 		// Migrate to the standalone pass2Rels stream so the
 		// assembly loop below still surfaces them on the document.
 		pass2Rels = append(pass2Rels, pruneOrphanRels...)
+	}
+
+	// #1613 — fold class-hierarchy Component shadows into their real typed
+	// node. The class-hierarchy pass emits every class as a SCOPE.Component
+	// (provenance=INFERRED_FROM_CLASS_HIERARCHY). When a real typed node
+	// (View/Model/Controller/struct/…) already exists for the same
+	// source_file+symbol, that shadow is a line-less duplicate: drop it and
+	// re-point its edges onto the surviving typed node. Shadows with no real
+	// typed node keep their (now real, from the extractor) line span +
+	// qualified_name and survive as the single node for that class.
+	var foldStats foldShadowStats
+	// ARCHIGRAPH_DISABLE_1613_FOLD is a verification escape hatch (compare
+	// folded vs unfolded graphs on the same binary); unset in production.
+	if os.Getenv("ARCHIGRAPH_DISABLE_1613_FOLD") == "" {
+		merged, pass2Rels, foldStats = i.foldClassHierarchyShadows(merged, pass2Rels)
+	}
+	if foldStats.ShadowsFolded > 0 || foldStats.ShadowsBackfilled > 0 {
+		fmt.Fprintf(os.Stderr,
+			"class-shadow-fold: folded=%d (edges_repointed=%d) survived_with_real_lines=%d still_line0=%d\n",
+			foldStats.ShadowsFolded, foldStats.EdgesRepointed,
+			foldStats.ShadowsBackfilled, foldStats.ShadowsStillLine0)
 	}
 
 	entities := make([]graph.Entity, 0, len(merged))

--- a/internal/extractors/cross/hierarchy/extractor.go
+++ b/internal/extractors/cross/hierarchy/extractor.go
@@ -101,6 +101,87 @@ var swiftProtocolRE = regexp.MustCompile(`(?m)^protocol\s+(\w+)`)
 var genericRE = regexp.MustCompile(`<[^>]*>`)
 
 // ---------------------------------------------------------------------------
+// Source-span helpers (issue #1613)
+//
+// The class-hierarchy pass historically emitted every class as a line-less
+// SCOPE.Component "shadow" (start_line=0, qualified_name=""). When a real
+// typed node (View/Model/struct/…) exists for the same source_file+name the
+// shadow is folded away in buildDocument; but for classes the typed-node pass
+// never produces (plain serializers, middleware, helper classes), the shadow
+// is the ONLY node and must carry real coordinates. These helpers give the
+// primary declared class a real start_line + a best-effort qualified_name so
+// the surviving node points at real source instead of :0.
+// ---------------------------------------------------------------------------
+
+// lineAtOffset returns the 1-based line number for byteOffset within source.
+func lineAtOffset(source string, byteOffset int) int {
+	if byteOffset <= 0 {
+		return 1
+	}
+	line := 1
+	for i := 0; i < byteOffset && i < len(source); i++ {
+		if source[i] == '\n' {
+			line++
+		}
+	}
+	return line
+}
+
+// pyModulePath converts a repo-relative .py path to its dotted module path.
+// Mirrors detectorFilePathToModule in internal/engine so the qualified_name we
+// stamp on a folded Python class matches the typed-node convention exactly
+// (so a future typed node and this shadow agree on qualified_name).
+func pyModulePath(filePath string) string {
+	s := strings.TrimSuffix(filePath, ".py")
+	if strings.HasSuffix(s, "/__init__") {
+		s = strings.TrimSuffix(s, "/__init__")
+	}
+	for _, prefix := range []string{"src/", "lib/", "app/"} {
+		if strings.HasPrefix(s, prefix) {
+			s = strings.TrimPrefix(s, prefix)
+			break
+		}
+	}
+	return strings.ReplaceAll(s, "/", ".")
+}
+
+// pyQualifiedName builds module.Class for a Python class declaration.
+func pyQualifiedName(filePath, clsName string) string {
+	if mod := pyModulePath(filePath); mod != "" {
+		return mod + "." + clsName
+	}
+	return clsName
+}
+
+// groupStrings materialises submatch group text from a FindAllStringSubmatchIndex
+// match. idx layout: [fullStart, fullEnd, g1Start, g1End, …]. n is the number
+// of groups including group 0 (the full match). Out-of-range / unmatched groups
+// (-1 offsets) yield "".
+func groupStrings(source string, idx []int, n int) []string {
+	out := make([]string, n)
+	for g := 0; g < n; g++ {
+		s, e := idx[2*g], idx[2*g+1]
+		if s < 0 || e < 0 || s > e || e > len(source) {
+			out[g] = ""
+			continue
+		}
+		out[g] = source[s:e]
+	}
+	return out
+}
+
+// classKeywordOffset returns the byte offset to anchor a class declaration's
+// start line on. We use the name group (group 2) start when present so the
+// reported line is the line of the declaration regardless of any leading
+// delimiter the full match consumed; fall back to the full-match start.
+func classKeywordOffset(idx []int) int {
+	if len(idx) >= 6 && idx[4] >= 0 {
+		return idx[4]
+	}
+	return idx[0]
+}
+
+// ---------------------------------------------------------------------------
 // Ref builders
 // ---------------------------------------------------------------------------
 
@@ -173,7 +254,9 @@ func (r *result) addRel(from, to, kind string, props map[string]string) {
 // ---------------------------------------------------------------------------
 
 func extractJTCSharp(source, filePath, language string, res *result) {
-	for _, m := range jtcClassRE.FindAllStringSubmatch(source, -1) {
+	idxMatches := jtcClassRE.FindAllStringSubmatchIndex(source, -1)
+	for _, im := range idxMatches {
+		m := groupStrings(source, im, 5)
 		abstract := m[1] != ""
 		clsName := m[2]
 		extendsRaw := strings.TrimSpace(m[3])
@@ -187,6 +270,9 @@ func extractJTCSharp(source, filePath, language string, res *result) {
 		if abstract {
 			res.abstractFound++
 		}
+		// #1613 — anchor the line at the `class` keyword (group 2 is the name;
+		// the full match may start a few bytes earlier on a leading delimiter).
+		startLine := lineAtOffset(source, classKeywordOffset(im))
 		clsID := classRef(filePath, clsName, language)
 		res.addEntity(types.EntityRecord{
 			Name:       clsName,
@@ -194,6 +280,8 @@ func extractJTCSharp(source, filePath, language string, res *result) {
 			Subtype:    "class",
 			SourceFile: filePath,
 			Language:   language,
+			StartLine:  startLine,
+			EndLine:    startLine,
 			Properties: map[string]string{
 				"role":        "class",
 				"is_abstract": boolStr(abstract),
@@ -254,7 +342,8 @@ func extractJTCSharp(source, filePath, language string, res *result) {
 // C# / Kotlin (and other JTC-family langs). Emits EXTENDS edges from the
 // declared interface to each parent interface. Issue #612.
 func extractJTCInterface(source, filePath, language string, res *result) {
-	for _, m := range jtcInterfaceRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range jtcInterfaceRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
 		ifaceName := m[1]
 		extendsRaw := strings.TrimSpace(m[2])
 		if extendsRaw == "" {
@@ -262,6 +351,7 @@ func extractJTCInterface(source, filePath, language string, res *result) {
 		}
 
 		res.classesFound++
+		startLine := lineAtOffset(source, classKeywordOffset(im))
 		ifaceID := ifaceRef(ifaceName, language)
 		res.addEntity(types.EntityRecord{
 			Name:       ifaceName,
@@ -269,6 +359,8 @@ func extractJTCInterface(source, filePath, language string, res *result) {
 			Subtype:    "interface",
 			SourceFile: filePath,
 			Language:   language,
+			StartLine:  startLine,
+			EndLine:    startLine,
 			Properties: map[string]string{
 				"role":       "interface",
 				"ref":        ifaceID,
@@ -295,7 +387,8 @@ func extractJTCInterface(source, filePath, language string, res *result) {
 }
 
 func extractPython(source, filePath string, res *result) {
-	for _, m := range pyClassRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range pyClassRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
 		clsName := m[1]
 		basesRaw := strings.TrimSpace(m[2])
 		if basesRaw == "" {
@@ -319,13 +412,19 @@ func extractPython(source, filePath string, res *result) {
 		if isAbstract {
 			res.abstractFound++
 		}
+		// #1613 — anchor at the `class` keyword (full-match start; pyClassRE is
+		// line-anchored with ^class so the full match begins at the keyword).
+		startLine := lineAtOffset(source, im[0])
 		clsID := classRef(filePath, clsName, "python")
 		res.addEntity(types.EntityRecord{
-			Name:       clsName,
-			Kind:       "SCOPE.Component",
-			Subtype:    "class",
-			SourceFile: filePath,
-			Language:   "python",
+			Name:          clsName,
+			Kind:          "SCOPE.Component",
+			Subtype:       "class",
+			SourceFile:    filePath,
+			Language:      "python",
+			StartLine:     startLine,
+			EndLine:       startLine,
+			QualifiedName: pyQualifiedName(filePath, clsName),
 			Properties: map[string]string{
 				"role":        "class",
 				"is_abstract": boolStr(isAbstract),
@@ -378,17 +477,20 @@ func extractPython(source, filePath string, res *result) {
 }
 
 func extractRuby(source, filePath string, res *result) {
-	for _, m := range rubyClassRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range rubyClassRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
 		clsName := m[1]
 		parentName := strings.TrimSpace(m[2])
 
 		res.classesFound++
+		startLine := lineAtOffset(source, im[0])
 		clsID := classRef(filePath, clsName, "ruby")
 		parentID := classRef(filePath, parentName, "ruby")
 
 		res.addEntity(types.EntityRecord{
 			Name: clsName, Kind: "SCOPE.Component", Subtype: "class",
 			SourceFile: filePath, Language: "ruby",
+			StartLine: startLine, EndLine: startLine,
 			Properties: map[string]string{
 				"role": "class", "ref": clsID,
 				"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
@@ -410,7 +512,8 @@ func extractRuby(source, filePath string, res *result) {
 }
 
 func extractGo(source, filePath string, res *result) {
-	for _, sm := range goStructRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range goStructRE.FindAllStringSubmatchIndex(source, -1) {
+		sm := groupStrings(source, im, 3)
 		clsName := sm[1]
 		body := sm[2]
 
@@ -423,10 +526,13 @@ func extractGo(source, filePath string, res *result) {
 		}
 
 		res.classesFound++
+		startLine := lineAtOffset(source, im[0])
+		endLine := lineAtOffset(source, im[1])
 		clsID := classRef(filePath, clsName, "go")
 		res.addEntity(types.EntityRecord{
 			Name: clsName, Kind: "SCOPE.Component", Subtype: "struct",
 			SourceFile: filePath, Language: "go",
+			StartLine: startLine, EndLine: endLine,
 			Properties: map[string]string{
 				"role": "struct", "ref": clsID,
 				"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
@@ -453,17 +559,20 @@ func extractGo(source, filePath string, res *result) {
 }
 
 func extractRust(source, filePath string, res *result) {
-	for _, m := range rustImplRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range rustImplRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 3)
 		traitName := strings.TrimSpace(m[1])
 		structName := strings.TrimSpace(m[2])
 
 		res.classesFound++
+		startLine := lineAtOffset(source, im[0])
 		structID := classRef(filePath, structName, "rust")
 		traitID := ifaceRef(traitName, "rust")
 
 		res.addEntity(types.EntityRecord{
 			Name: structName, Kind: "SCOPE.Component", Subtype: "struct",
 			SourceFile: filePath, Language: "rust",
+			StartLine: startLine, EndLine: startLine,
 			Properties: map[string]string{
 				"role": "struct", "ref": structID,
 				"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
@@ -514,12 +623,14 @@ func extractElixir(source, filePath string, res *result) {
 		}
 
 		res.classesFound++
+		startLine := lineAtOffset(source, bm[0])
 		modID := classRef(filePath, moduleName, "elixir")
 		behID := ifaceRef(behaviourName, "elixir")
 
 		res.addEntity(types.EntityRecord{
 			Name: moduleName, Kind: "SCOPE.Component", Subtype: "module",
 			SourceFile: filePath, Language: "elixir",
+			StartLine: startLine, EndLine: startLine,
 			Properties: map[string]string{
 				"role": "module", "ref": modID,
 				"provenance": "INFERRED_FROM_CLASS_HIERARCHY",
@@ -542,14 +653,17 @@ func extractElixir(source, filePath string, res *result) {
 }
 
 func extractSwift(source, filePath string, res *result) {
-	for _, m := range swiftProtocolRE.FindAllStringSubmatch(source, -1) {
+	for _, im := range swiftProtocolRE.FindAllStringSubmatchIndex(source, -1) {
+		m := groupStrings(source, im, 2)
 		protoName := m[1]
 		res.classesFound++
 		res.abstractFound++
+		startLine := lineAtOffset(source, im[0])
 		protoID := classRef(filePath, protoName, "swift")
 		res.addEntity(types.EntityRecord{
 			Name: protoName, Kind: "SCOPE.Component", Subtype: "protocol",
 			SourceFile: filePath, Language: "swift",
+			StartLine: startLine, EndLine: startLine,
 			Properties: map[string]string{
 				"role":        "protocol",
 				"is_abstract": "true",


### PR DESCRIPTION
## 1. Problem

Every class was emitted as a **line-less `SCOPE.Component` shadow** (provenance `INFERRED_FROM_CLASS_HIERARCHY`, `start_line=0`, `end_line=0`, `qualified_name=""`, `language=""`) that **duplicated the real typed node**. On a real Django corpus, `LoginViewSet` was BOTH `Component`(line 0) AND `View`(line 22); same for `RegistrationViewSet`/`RefreshViewSet`/`LoginSerializer`/`TokenAuthenticationMiddleware`. Net effect: useless `:0` source pointers, unbounded `get_source` on classes, and ~2x duplicate class nodes.

Root cause: the class-hierarchy inference pass (`internal/extractors/cross/hierarchy`) emits a `SCOPE.Component` entity for every class with no line span and no qualified_name, while the per-language AST extractor and the framework detector independently emit a `SCOPE.Component/class` node and a typed node (`View`/`Model`/…). The shadow and the AST node share an `EntityID` (same Kind+Name+SourceFile) and pre-merge at assembly — and first-writer-wins kept the `:0` shadow over the real AST node.

## 2. Approach

Two-part fix:

**(a) Extractor — give the shadow real coordinates.** `internal/extractors/cross/hierarchy/extractor.go` now uses `FindAllStringSubmatchIndex` to compute a real `start_line`/`end_line` (and, for Python, a `qualified_name` matching the detector convention) for the primary declared class/struct/interface/protocol/module of every supported language. So even a class with **no** framework-typed node now points at real source.

**(b) buildDocument — fold to ONE node.** New `foldClassHierarchyShadows` pass (runs after `stampEntityIDs` + the resolver, so IDs are stamped and embedded edges are in hex-ID form). Fold sources = the INFERRED shadow **and** the generic `SCOPE.Component/class` AST node. When a framework-typed survivor (`View`/`Model`/`Controller`/`Service`/`Middleware`/`Repository`/`TestClass`/`Schema`/`Plugin`/`Implementation`/`Interface`/`Task`) exists for the same `source_file+symbol`, drop the source and re-point its edges onto the survivor. When no framework node exists, the AST/shadow node survives as the single class node with its real line span; a surviving shadow drops its now-misleading inference provenance, and a shadow with an AST sibling defers to it (the AST node carries the class). A priority + smallest-real-line tiebreak prevents folding into nested artifacts that merely share the class name (e.g. a Django Meta `Constraint`).

## 3. Edge re-pointing

No edge is ever dropped. Every edge endpoint (`FromID`/`ToID`) — across all embedded `EntityRecord.Relationships` and the standalone `pass2Rels` stream — that targeted a folded source's ID is rewritten to the survivor's ID. Edges **owned** by a folded source (FromID empty or self) are re-homed onto the survivor record (framework-fold) or onto the standalone stream with an explicit FromID (sibling-drop), so they still surface at assembly.

## 4. Verification (isolated, real Django corpus)

Built + ran in an **isolated daemon root** (`ARCHIGRAPH_DAEMON_ROOT`), indexing a **copy** of the corpus via the in-process `Index()` path — the live `:47274` daemon was never touched. `go build`/`go vet` clean.

Before → after (group-wide):
| metric | before | after |
|---|---|---|
| `INFERRED_FROM_CLASS_HIERARCHY` nodes | 411 | **0** |
| `INFERRED` & `start_line=0` nodes | 411 | **0** |
| class-like entities at `start_line=0` | (all 411 shadows) | **0** |
| total entities | 7014 | 6943 |
| dangling hex edge endpoints | 458 | **458** (unchanged — no edge loss) |
| edge total | 32907 | 32698 (duplicate-edge collapse onto survivor) |

Per-class result:
- `LoginViewSet` / `RegistrationViewSet` / `RefreshViewSet` → **single `View` node**, real line (22/94/116), real `qualified_name`.
- `TokenAuthenticationMiddleware` / `LoginSerializer` → **single `SCOPE.Component/class` node**, real line (10/18), real `qualified_name`, no inference provenance.
- Folded 536 sources, re-pointed edges, survivor connectivity preserved (`LoginViewSet` View node: edges_in=2, edges_out=5).

The 458 dangling endpoints are pre-existing synthetic/external/pattern endpoints — confirmed identical with the fold disabled (`ARCHIGRAPH_DISABLE_1613_FOLD=1`) on the same binary.

## 5. Tests

- New `cmd/archigraph/class_shadow_fold_test.go` on the `django_app` fixture: asserts 0 INFERRED shadows, 0 line-0 class nodes, exactly one declaration node per class with real line + qualified_name, and no new dangling hex endpoints vs the unfolded graph (`ARCHIGRAPH_DISABLE_1613_FOLD`).
- Full `go test ./internal/... ./cmd/...`: **zero new failures vs `origin/main`** — the 32 pre-existing failures (stubbed dashboard `dist` embed, daemon socket/timing, MCP env) are identical with and without this change.

## 6. Risk / scope

Low. The fold is gated to class-representation nodes and framework-typed survivors via an explicit priority map; nested artifacts (`Constraint`/`Config`/etc.) and the intentional `orm_model_sentinel` anchor are never folded. The escape hatch `ARCHIGRAPH_DISABLE_1613_FOLD` exists for A/B verification (unset in production). Determinism preserved (fold operates on the already-sorted merged set; tiebreaks are stable by priority → real line → id).

Fixes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)