### PR TITLE
fix(dashboard): clean per-repo state + invalidate groups cache on group delete

### DIFF
--- a/internal/dashboard/v2_group_settings.go
+++ b/internal/dashboard/v2_group_settings.go
@@ -349,6 +349,16 @@ func (s *Server) handleV2DeleteGroup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Load the config so we can clean up per-repo state before de-registering.
+	// Best-effort: if the config can't be read we still proceed with removal.
+	if cfg, cfgErr := registry.LoadGroupConfig(configPath); cfgErr == nil {
+		for _, rep := range cfg.Repos {
+			stateDir := daemon.StateDirForRepo(rep.Path)
+			// Best-effort: non-fatal per repo — do NOT touch source code.
+			_ = os.RemoveAll(stateDir)
+		}
+	}
+
 	// Remove group from registry.
 	if err := registry.RemoveGroup(groupName); err != nil {
 		writeV2Err(w, http.StatusInternalServerError, "internal_error", "remove group: "+err.Error())

--- a/internal/dashboard/v2_group_settings_test.go
+++ b/internal/dashboard/v2_group_settings_test.go
@@ -6,10 +6,14 @@ import (
 	"math"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/quality"
+	"github.com/cajasmota/archigraph/internal/registry"
 )
 
 // ---------------------------------------------------------------------------
@@ -359,5 +363,121 @@ func TestV2GetGroup_RealFidelityViaServer(t *testing.T) {
 	}
 	if hlth != healthWarning {
 		t.Errorf("health: want %q, got %q", healthWarning, hlth)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DELETE /api/v2/groups/{group} — per-repo state cleanup (#1635)
+// ---------------------------------------------------------------------------
+
+// TestV2DeleteGroup_CleansRepoState verifies that deleting a group removes the
+// per-repo state directories for every repo in the group (#1635), in addition
+// to de-registering the group and removing the fleet config.
+func TestV2DeleteGroup_CleansRepoState(t *testing.T) {
+	// Isolate registry + daemon state to temp dirs so this test is hermetic
+	// and parallel-safe.
+	archHome := t.TempDir()
+	daemonRoot := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", archHome)
+	t.Setenv("ARCHIGRAPH_DAEMON_ROOT", daemonRoot)
+
+	// Write a minimal fleet config with two repos.
+	configDir := filepath.Join(archHome, "configs")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir configs: %v", err)
+	}
+	configPath := filepath.Join(configDir, "testgroup.fleet.json")
+	cfg := registry.GroupConfig{Name: "testgroup"}
+	cfg.Repos = []registry.Repo{
+		{Slug: "repo-a", Path: "/repos/alpha"},
+		{Slug: "repo-b", Path: "/repos/beta"},
+	}
+	cfgBytes, err := json.Marshal(cfg)
+	if err != nil {
+		t.Fatalf("marshal cfg: %v", err)
+	}
+	if err := os.WriteFile(configPath, cfgBytes, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// Register the group so registry.Groups() can find it.
+	if err := registry.AddGroup("testgroup", configPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	// Create synthetic per-repo state dirs with a marker file inside each.
+	// With ARCHIGRAPH_DAEMON_ROOT set, daemon.StateDirForRepo returns
+	// $ARCHIGRAPH_DAEMON_ROOT/state/<hash>/. We use the same helper the
+	// handler uses so the paths are guaranteed to match.
+	repoPaths := []string{"/repos/alpha", "/repos/beta"}
+	for _, rp := range repoPaths {
+		stateDir := daemon.StateDirForRepo(rp)
+		if err := os.MkdirAll(stateDir, 0o755); err != nil {
+			t.Fatalf("mkdir state %s: %v", stateDir, err)
+		}
+		// Write a dummy graph-stats.json to represent indexed state.
+		if err := os.WriteFile(filepath.Join(stateDir, "graph-stats.json"), []byte(`{}`), 0o644); err != nil {
+			t.Fatalf("write marker: %v", err)
+		}
+	}
+
+	// Build a test server backed by fakeStore. The handler reads the on-disk
+	// registry via registry.Groups(); the fakeStore only backs the unrelated
+	// list/graph endpoints.
+	st := newFakeStore()
+	srv, err := NewServer(DefaultConfig(), st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	ts := httptest.NewServer(srv.routes())
+	defer ts.Close()
+
+	// Issue DELETE /api/v2/groups/testgroup.
+	req, _ := http.NewRequest("DELETE", ts.URL+"/api/v2/groups/testgroup", nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("DELETE: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("want 200, got %d", resp.StatusCode)
+	}
+	var body struct {
+		OK   bool              `json:"ok"`
+		Data map[string]string `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if !body.OK {
+		t.Fatalf("want ok=true")
+	}
+	if body.Data["deleted"] != "testgroup" {
+		t.Errorf("deleted: want %q, got %q", "testgroup", body.Data["deleted"])
+	}
+
+	// Assert: both per-repo state dirs have been removed.
+	for _, rp := range repoPaths {
+		stateDir := daemon.StateDirForRepo(rp)
+		if _, err := os.Stat(stateDir); !os.IsNotExist(err) {
+			t.Errorf("state dir for %s should be removed, but still exists at %s", rp, stateDir)
+		}
+	}
+
+	// Assert: the fleet config file is removed.
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Errorf("fleet config should be removed, but still exists at %s", configPath)
+	}
+
+	// Assert: group is no longer in the registry.
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatalf("registry.Groups: %v", err)
+	}
+	for _, g := range groups {
+		if g.Name == "testgroup" {
+			t.Errorf("group %q should be de-registered but was found in registry", "testgroup")
+		}
 	}
 }

--- a/webui-v2/src/hooks/use-settings.ts
+++ b/webui-v2/src/hooks/use-settings.ts
@@ -9,6 +9,7 @@
 
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { api } from "@/lib/api";
+import { groupsQueryKey } from "@/hooks/use-groups";
 import type { SettingsFeatures } from "@/data/types";
 
 /** Query key for the settings detail of a group. */
@@ -60,10 +61,20 @@ export function useRebuildGroup(groupId: string) {
   });
 }
 
-/** Deletes the group. Does NOT invalidate — caller navigates away. */
+/** Deletes the group. Invalidates the groups list so Landing + project switcher
+ *  refresh immediately; caller is also responsible for navigating away. */
 export function useDeleteGroup(groupId: string) {
+  const qc = useQueryClient();
   return useMutation({
     mutationFn: () => api.deleteGroup(groupId),
+    onSuccess: () => {
+      // Remove the deleted group from the landing cache immediately so no
+      // stale card lingers, then invalidate to trigger a fresh fetch.
+      void qc.invalidateQueries({ queryKey: groupsQueryKey });
+      // Also remove any cached settings for this group so stale :groupId routes
+      // cannot serve data for a group that no longer exists.
+      void qc.removeQueries({ queryKey: settingsQueryKey(groupId) });
+    },
   });
 }
 


### PR DESCRIPTION
## What changed and why

**Fixes #1635** — deleting a group left every member repo's graph state on disk, and the Landing / project-switcher did not refresh until a manual page reload.

### 1 · Backend: `handleV2DeleteGroup` (internal/dashboard/v2_group_settings.go ~line 344)

Previously the handler only called `registry.RemoveGroup` + `os.Remove(configPath)`, leaving every per-repo state dir untouched.

**Fix:** before de-registering the group, load the fleet config and for each repo call `os.RemoveAll(daemon.StateDirForRepo(rep.Path))`. Mirrors exactly what `handleV2RemoveRepo` already does for the single-repo path. Uses the same exported helper so the cleanup automatically stays correct after the `#1626` store-relocation lands. Errors are best-effort/non-fatal per repo. Execution order: clean repo state → RemoveGroup → remove config file.

### 2 · Frontend: `useDeleteGroup` (webui-v2/src/hooks/use-settings.ts)

Previously the hook had no `onSuccess` — the comment read "Does NOT invalidate — caller navigates away." This meant the Landing card grid and the project switcher kept showing the deleted group until a hard reload.

**Fix:** added an `onSuccess` that:
1. `invalidateQueries({ queryKey: groupsQueryKey })` — triggers an immediate re-fetch of the Landing groups list and project-switcher.
2. `removeQueries({ queryKey: settingsQueryKey(groupId) })` — evicts the now-stale settings cache for the deleted group so any stale `:groupId` route cannot serve data for a group that no longer exists.

The modal caller (`DeleteGroupModal` in routes/settings.tsx) already navigates to `/` on success — that redirect is unchanged.

## How it was tested

- `go test ./internal/dashboard -run Delete` — new test `TestV2DeleteGroup_CleansRepoState` green (also existing `TestV2DeleteGroup_NotFound`).
- New test sets `ARCHIGRAPH_HOME` + `ARCHIGRAPH_DAEMON_ROOT` to temp dirs for hermeticity, seeds two per-repo state dirs, issues DELETE, and asserts: both state dirs removed, fleet config removed, group de-registered.
- `go build ./internal/...` + `go vet ./internal/...` — clean.
- `npm run build` inside `webui-v2/` — clean (TypeScript + Vite, zero new errors).
- Pre-existing failures (`TestWriteback_success`, `TestYamlScalar` in handlers_enrichment_writeback_test.go) confirmed on `main` before this branch — not introduced here.
- Daemon intentionally left stopped; no live :47274 touched.

## Files changed

| File | Change |
|---|---|
| `internal/dashboard/v2_group_settings.go` | Load config + best-effort `RemoveAll` per repo before de-register |
| `internal/dashboard/v2_group_settings_test.go` | `TestV2DeleteGroup_CleansRepoState` + `daemon`/`registry` imports |
| `webui-v2/src/hooks/use-settings.ts` | `useDeleteGroup` invalidates `groupsQueryKey` + removes settings cache |

## Scope / non-goals

- `internal/graph/load.go` and `cmd/archigraph/{index,daemon}.go` are untouched (owned by #1626).
- `internal/dashboard/` has zero diff outside the settings handler + its test file.
- Source code on disk is never touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)