### PR TITLE
feat(generate-docs): Business documentation tier + audit skill fixes (#1623, #1621)

### DIFF
--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -1,6 +1,49 @@
 # generate-docs
 
-Generate module-organized markdown documentation for every repo in a registered archigraph group, then stitch it into a group-level synthesis with cross-repo links.
+Generate documentation for a registered archigraph group in two independent
+**tiers**:
+
+- **Technical tier** — module-organized markdown for every repo, stitched into a
+  group-level synthesis with cross-repo links. For engineers. (Passes 0–14.)
+- **Business tier** — a separate, group-synthesised `business/` doc set written
+  for PMs / non-engineers: product capabilities, a business domain glossary,
+  user journeys as plain-language narratives, and business rules reverse-
+  engineered from the code. (Passes 15–19.) The webui surfaces this under its
+  Business chooser tab (#1634).
+
+The user picks one or both tiers. The two tiers are produced by separate pass
+ranges and can run independently.
+
+## Documentation tiers
+
+Before planning, the orchestrator asks **which tier(s)** to generate:
+
+> Generate **Technical** docs (per-repo engineering reference), **Business** docs
+> (PM-facing product capabilities / journeys / rules synthesised across the
+> group), or **both**?
+
+The choice is recorded in `plan.json` `tiers: ["technical", "business"]`.
+
+- **Technical only** → run Passes 0–8 (+10–14 as applicable). Skip 15–19.
+- **Business only** → run Pass 0 (domain interview) and Pass 1 (inventory) for
+  the graph signals the business passes need, then Passes 15–19. Skip 2–14
+  except where a business pass reads a technical-tier file that does not exist —
+  in that case the business writer falls back to graph queries (each business
+  prompt names its fallback).
+- **Both** → run the technical tier first (Passes 0–14), then the business tier
+  (15–19); the business passes can reuse the just-written technical docs as
+  input, which produces higher-fidelity business translation.
+
+The tiers write to **disjoint locations** (technical: `<repo>/docs/{overview,
+modules,reference,…}`; business: `<primary-repo>/docs/business/…`), so they
+never overwrite each other and the webui keeps them in separate views.
+
+The **business tier is NOT per-repo.** It is synthesised across every repo in
+the group and organised by business domain/capability. It is written into one
+anchor repo's `docs/business/` directory (the `primary_repo` chosen in Pass 2 —
+default the repo with the most entities). The webui aggregates every repo's
+`business/` tree into a single Business view, so a single location reads as one
+group-level set.
 
 ## When to use this skill
 
@@ -49,6 +92,22 @@ Time estimates assume typical small-to-medium codebases (1k–10k source entitie
 | 12 | `prompts/12-pattern-prose.md` | Emit `docs/patterns/<category>/<id>.md` per approved pattern (ADR-0018 Phase 6). | 2–4 min |
 | 13 | `prompts/13-enrichment.md` | LLM enrichment pass: emit unified YAML frontmatter for `http_endpoint`, `process_flow`, and `message_topic` entities (merge, disqualify, rank, group, summarise, detect gaps). Dashboard surfaces consume this data. | 5–15 min |
 | 14 | `prompts/14-frontmatter-validation.md` | Frontmatter validation pass: re-read every enriched doc file, parse its YAML frontmatter, and verify each field against the backend parser's expectations. Catches schema drift between the skill and the dashboard consumers. | 2–5 min |
+
+### Business-tier passes (Pass 15 through Pass 19)
+
+These run only when `"business"` is in `plan.tiers`. They are **group-synthesised**
+(not per-repo) and write to `<primary-repo>/docs/business/`. Every business
+writer reads `snippets/business-voice.md` first (PM audience, zero internal
+symbols, no code mermaid). Pass 15 runs first (later passes link into the
+glossary); Pass 19 runs last (it indexes the rest).
+
+| Pass | Prompt | Purpose | Est. time |
+|------|--------|---------|-----------|
+| 15 | `prompts/15-business-domain.md` | Business domain model + glossary: business nouns (Inspection, Deficiency, Jurisdiction) defined in plain language, code collapsed to one term per concept. | 5–10 min |
+| 16 | `prompts/16-business-capabilities.md` | Product capabilities: what the system does + why, derived from endpoints/flows/topics grouped by business outcome (a few capabilities, not one-per-endpoint). | 8–20 min |
+| 17 | `prompts/17-business-journeys.md` | User journeys as plain-language narratives — a user accomplishing a goal end-to-end across the product. Replaces the audit's symbol-heavy mermaid "journey". | 5–15 min |
+| 18 | `prompts/18-business-rules.md` | Business rules / requirements reverse-engineered from validation/permission/conditional logic, stated as product requirements. | 5–15 min |
+| 19 | `prompts/19-business-overview.md` | Business landing page: pitch + indexes into capabilities, journeys, glossary, rules. Runs last. | 3–5 min |
 
 **Total wall time:** typically **25–65 minutes** for small repos (1k entities), **1–2 hours** for medium repos (10k entities), **2–4 hours** for large repos (100k+ entities). Pass 4 parallelizes across module clusters, so the critical path is dominated by Pass 0 (user interaction), Passes 1–2 (discovery), and Passes 4–5 (content generation).
 
@@ -522,6 +581,31 @@ docs/
   cross-links.md               # Pass 8 summary
 ```
 
+### Business tier layout
+
+The business tier (Passes 15–19) is group-synthesised and written into the
+`primary_repo`'s `docs/business/` directory. The webui (#1634) reads the
+`business/` set and surfaces it under its Business chooser tab.
+
+```
+<primary-repo>/docs/business/
+  overview.md                  # Pass 19 — landing page + indexes (template: business-overview.md)
+  capabilities/
+    <capability-slug>.md       # Pass 16 — one per product capability (template: business-capability.md)
+  domain-glossary.md           # Pass 15 — business vocabulary (template: business-domain-glossary.md)
+  journeys/
+    <journey-slug>.md          # Pass 17 — plain-language user journeys (template: business-journey.md)
+  rules/
+    index.md                   # Pass 18 — business rules / requirements (template: business-rules.md)
+    <area>.md                  # optional — only if one area's rules outgrow index.md
+```
+
+Every business page is reverse-engineered from code, so each carries a collapsed
+`<details>` provenance block at the bottom (the ONLY place a symbol/file path may
+appear in a business page) so an engineer can audit it without polluting the PM
+reading. All other content is plain business language with zero internal symbol
+names per `snippets/business-voice.md`.
+
 > **Note:** A doc-site (formerly Pass 9 VitePress config) is out of scope for this skill. It is planned for a separate milestone-2 effort. Pass 9 is intentionally reserved in the pass table.
 
 ## Conventions
@@ -532,7 +616,12 @@ If the agent encounters a stack with no matching convention, it should stop and 
 
 ## Quality gates (snippets/verification-checklist.md)
 
-Before any pass commits its output, the writer subagent runs the checks in `snippets/verification-checklist.md`. The orchestrator re-runs the same checklist before declaring the pass complete.
+Before any pass commits its output, the writer subagent runs the checks in `snippets/verification-checklist.md`. The orchestrator re-runs the same checklist before declaring the pass complete. The checklist incorporates three contracts that fix the 2026-05-23 docgen audit defects:
+
+- **`snippets/anchor-contract.md`** — emitted `anchors:` frontmatter is *derived from* the headings the writer actually produced, never hand-authored. Fixes the 17 anchor-slug mismatches (`summary` declared vs `## Where it lives` written). Enforced per-file in the checklist and group-wide in Pass 8.
+- **`snippets/link-hygiene.md`** — link targets must be real generated doc files; never link into source-code directories; bare-directory links need a real index target; relative paths use the filesystem dirname (not the registry slug) to avoid the `upvate-core`/`upvate_core` 404 class. Fixes the 37 broken links.
+- **Volume control** (`prompts/02-plan.md` § Step 1b) — merge thin dir-derived modules, cap module count by LOC, and never schedule empty stub pages (`flows/index.md`). With archigraph #1620 communities now persisting, the plan prefers real graph communities over directory fallback. Fixes the 122-module over-fragmentation.
+- **`snippets/business-voice.md`** — the business-tier style contract (PM audience, zero symbols, no code mermaid). Fixes the symbol-heavy "user-journeys.md" that read as technical, not business.
 
 ## Related
 

--- a/skills/generate-docs/output-templates/business-capability.md
+++ b/skills/generate-docs/output-templates/business-capability.md
@@ -1,0 +1,47 @@
+---
+tier: business
+doc_type: business-capability
+capability: <slug>
+anchors: []   # derive from headings per snippets/anchor-contract.md after writing
+---
+
+# <Capability name>
+
+> One sentence: what business outcome this capability delivers.
+
+## What it does
+
+> One or two plain-language paragraphs. The business behaviour, end to end, in
+> the reader's terms. No component names, no API paths.
+
+## Why it exists
+
+> The business reason. What would break, or who would be unhappy, without it.
+
+## Who uses it and when
+
+> The user types and the situations that trigger this capability.
+
+## What it produces
+
+> The business artifacts/outcomes (a submitted report, a notified customer, a
+> recorded deficiency). Link to the relevant domain terms in the glossary.
+
+## Rules that govern it
+
+> Bullet list of the business rules that constrain this capability, each linking
+> to the rule in `rules/`. Plain language.
+
+- <rule in business language> — see [rules/index.md#<anchor>](../rules/index.md#<anchor>).
+
+## Related journeys
+
+- [<Journey name>](../journeys/<slug>.md)
+
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Reverse-engineered from the endpoints/flows documented in the technical tier
+and graph evidence (endpoints, process flows, message topics tied to this
+capability). Last regenerated: <date>.
+</details>

--- a/skills/generate-docs/output-templates/business-domain-glossary.md
+++ b/skills/generate-docs/output-templates/business-domain-glossary.md
@@ -1,0 +1,34 @@
+---
+tier: business
+doc_type: business-domain-glossary
+anchors: []   # derive from headings per snippets/anchor-contract.md after writing
+---
+
+# Domain glossary
+
+> The business vocabulary of the product. One entry per business concept
+> (Inspection, Deficiency, Jurisdiction, Witnessing Company …). These are the
+> nouns a PM uses, NOT class names. Each term is defined in plain language and,
+> where useful, related to other terms. Alphabetical.
+
+## <Business Term>
+
+> One-paragraph plain-language definition. What it is in the business, not in
+> the code.
+
+- **Relates to:** <other terms>, linked: [<Term>](#<anchor>).
+- **Lifecycle:** <if the term has states, name them in business words —
+  e.g. "An inspection is *scheduled*, then *in progress*, then *submitted*,
+  then *closed*.">
+
+## <Business Term>
+
+> …
+
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Domain terms were derived from the entities/data model documented in the
+technical tier across all repos and grouped by business meaning rather than by
+class. Last regenerated: <date>.
+</details>

--- a/skills/generate-docs/output-templates/business-journey.md
+++ b/skills/generate-docs/output-templates/business-journey.md
@@ -1,0 +1,57 @@
+---
+tier: business
+doc_type: business-journey
+journey: <slug>
+anchors: []   # derive from headings per snippets/anchor-contract.md after writing
+---
+
+# <Journey name>
+
+> One sentence: the goal the user accomplishes, end to end, across the product.
+> Example: "A field inspector completes a building inspection and the office
+> receives the report."
+
+## Who and why
+
+> The user type and the business goal. One short paragraph.
+
+## The journey, step by step
+
+> A NUMBERED list in plain language. Each step is something the *user* or *the
+> system* does, described as a business action — never a function call. This is
+> the heart of the page; a PM should follow it without help.
+
+1. <Plain-language step — what the user does / sees / decides>.
+2. <Next step>.
+3. …
+
+> If a simple business-step diagram helps, add one (≤ 8 boxes, business labels
+> only). It must NOT be a sequence diagram of code. Otherwise omit it.
+
+```mermaid
+flowchart LR
+  A[Inspection scheduled] --> B[Inspector arrives on site]
+  B --> C[Deficiencies recorded]
+  C --> D[Report submitted]
+  D --> E[Office reviews & issues]
+```
+
+## What can go wrong
+
+> Plain-language exceptions and edge cases the product handles (offline, missing
+> data, rejected submission). No stack traces, no error class names.
+
+## Where it touches the business
+
+> Which capabilities and domain terms this journey exercises, each linked.
+
+- Uses the [<Capability>](../capabilities/<slug>.md) capability.
+- Involves [<Domain term>](../domain-glossary.md#<anchor>).
+
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Assembled from the process flows / call chains documented in the technical tier
+(possibly spanning multiple repos) and translated to a business narrative.
+Last regenerated: <date>.
+</details>

--- a/skills/generate-docs/output-templates/business-overview.md
+++ b/skills/generate-docs/output-templates/business-overview.md
@@ -1,0 +1,56 @@
+---
+tier: business
+doc_type: business-overview
+anchors: []   # derive from headings per snippets/anchor-contract.md after writing
+---
+
+# What <Product> does
+
+> Two or three plain-language paragraphs a PM could paste into a Confluence
+> landing page. What is this product, who uses it, what problem does it solve.
+> No component names. Lift the domain framing from `domain.md` and the technical
+> overviews, translated to business voice (`snippets/business-voice.md`).
+
+## Who uses it
+
+| User type | What they do with it |
+| --------- | -------------------- |
+| <e.g. Office staff> | <plain-language goal> |
+| <e.g. Field inspectors> | <plain-language goal> |
+
+## What it does (capabilities)
+
+> One bullet per capability, each linking to its capability page. This is the
+> capability index — keep each line to a single business sentence.
+
+- [<Capability name>](capabilities/<slug>.md) — <one business sentence>.
+
+## Core ideas (domain)
+
+> One paragraph pointing readers at the glossary for the business vocabulary
+> (Inspection, Deficiency, Jurisdiction, …).
+
+See the [domain glossary](domain-glossary.md) for the business terms used
+throughout these docs.
+
+## How a typical job flows (journeys)
+
+> One bullet per end-to-end journey, each linking to its journey page.
+
+- [<Journey name>](journeys/<slug>.md) — <one business sentence describing the
+  goal a user accomplishes>.
+
+## Rules the product enforces
+
+> One paragraph pointing at the business-rules section, with 2–3 headline rules
+> in plain language.
+
+See [business rules](rules/index.md) for the constraints and requirements the
+product enforces.
+
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Synthesised across all repos in the `<group>` group from the technical doc set
+and the archigraph graph. Last regenerated: <date>.
+</details>

--- a/skills/generate-docs/output-templates/business-rules.md
+++ b/skills/generate-docs/output-templates/business-rules.md
@@ -1,0 +1,45 @@
+---
+tier: business
+doc_type: business-rules
+anchors: []   # derive from headings per snippets/anchor-contract.md after writing
+---
+
+# Business rules
+
+> The constraints, requirements, and policies the product enforces, reverse-
+> engineered from the implementation and stated as PRODUCT requirements — the
+> kind a team lead would lift into a spec. Each rule is plain language and
+> testable in business terms. Group by business area, one `##` per area.
+>
+> A rule reads like a requirement, not like code:
+>   GOOD: "An inspection cannot be submitted until every device on the building
+>          checklist has an outcome recorded."
+>   BAD:  "`InspectionSerializer.validate()` raises if `devices` is empty."
+
+## <Business area, e.g. Inspections>
+
+### <Rule title in business language>
+
+- **Rule:** <the requirement, one sentence>.
+- **Why:** <the business reason / what it protects>.
+- **Applies when:** <the situation that triggers it>.
+- **If violated:** <what the product does — rejects, warns, blocks — in
+  business terms>.
+
+### <Next rule>
+
+> …
+
+## <Next business area, e.g. Access & permissions>
+
+> Rules about who can do what, in business terms ("only office staff may close
+> an inspection"; "field inspectors cannot edit a submitted report").
+
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Rules were inferred from validation logic, conditional branches, permission
+checks, and required fields surfaced via `archigraph_find` and the technical
+tier. Each rule should be verifiable against that logic. Last regenerated:
+<date>.
+</details>

--- a/skills/generate-docs/prompts/02-plan.md
+++ b/skills/generate-docs/prompts/02-plan.md
@@ -16,6 +16,17 @@ A Louvain community from `archigraph_clusters` is a graph cluster, not necessari
 - Merge two communities if they share more than 30% of their bridge-doc nodes or if their top-entity names share a clear prefix (e.g., `users.views`, `users.serializers` -> module `users`).
 - Split a community if it contains entities from two unrelated layers (e.g., HTTP handlers + DB migrations); rare, but the convention file for the stack tells you when to expect it.
 
+**Prefer real graph communities over directory fallback.** Call `archigraph_clusters(repo_filter=["<r>"])` first. As of archigraph #1620 communities persist through the daemon load path, so a non-empty cluster list is the norm. Only fall back to directory-derived modules when `archigraph_clusters` genuinely returns `[]` for a repo.
+
+#### Step 1b — Volume control (fragmentation guard)
+
+This step fixes the audit finding where a single-app backend exploded into 122 directory-derived modules with empty `flows/index.md` stub triplets. Apply it whether modules came from communities or directory fallback, but it is **mandatory** on the directory-fallback path:
+
+- **Merge thin modules.** A module with fewer than `min_module_entities` (default **8**) in-module entities is too thin to stand alone. Merge it into its nearest sibling — same parent directory, or the module whose top entities share its prefix. Only keep a sub-`min_module_entities` module standalone if it is a genuinely distinct public surface (e.g. a small but externally-consumed API module); note the exception in the plan entry.
+- **Cap module count relative to size.** As a sanity check, target roughly one module per ~1.5–3k LOC. If the candidate module count exceeds `loc / 1500`, you are over-fragmenting — merge more aggressively. Record the final count and the merge decisions in `plan.json` under `volume_control`.
+- **Never schedule empty stub pages.** A module gets a `flows.md` / `api.md` page in its plan entry ONLY if it has real content for it: `flows.md` only if the module owns ≥1 process flow or dynamic edge; `api.md` only if it is the primary owner of a public API. A module page (`README.md`) is always scheduled, but `flows`/`api` are conditional. Set `"pages": ["readme"]` (or add `"flows"`, `"api"`) per module so Pass 4 never emits an empty `flows/index.md`.
+- **Index pages only when non-empty.** Only schedule a `modules/README.md` / section index if the section will have ≥1 child page. Pass 8 link-hygiene forbids linking to a directory whose index was never generated.
+
 ### Step 2 — Name modules
 
 Each module gets a kebab-case slug used as a directory name under `docs/modules/`. Pull the slug from the dominant package/import path when one exists; otherwise, pick the most central entity's parent.
@@ -34,6 +45,15 @@ Write `~/.archigraph/groups/<group>/plan.json`:
 ```json
 {
   "group": "<group>",
+  "tiers": ["technical", "business"],
+  "primary_repo": "<slug>",
+  "volume_control": {
+    "min_module_entities": 8,
+    "modules_before_merge": 122,
+    "modules_after_merge": 46,
+    "module_source": "communities",
+    "merge_notes": ["merged sync/import/report dir-stubs into data-pipeline"]
+  },
   "passes": {
     "3_overview": { "repos": ["<slug>", "..."] },
     "4_cluster": {
@@ -46,6 +66,7 @@ Write `~/.archigraph/groups/<group>/plan.json`:
           "communities": ["c1", "c4"],
           "token_budget": 6500,
           "source_snippets": 10,
+          "pages": ["readme", "flows"],
           "depends_on": []
         }
       ]
@@ -59,10 +80,23 @@ Write `~/.archigraph/groups/<group>/plan.json`:
       "topics": ["auth", "logging", "errors", "observability"]
     },
     "7_synthesis": { "scope": "group" },
-    "8_cross_link": { "candidates_to_review": 0 }
+    "8_cross_link": { "candidates_to_review": 0 },
+    "business": {
+      "enabled": true,
+      "primary_repo": "<slug>",
+      "capabilities_estimate": 10,
+      "journeys_estimate": 5
+    }
   }
 }
 ```
+
+The `tiers` field records which documentation tiers the user selected (see
+SKILL.md § Documentation tiers). `business` passes (15–19) are only scheduled if
+`"business"` is in `tiers`; technical passes (3–8, 10–14) only if `"technical"`
+is in `tiers`. `primary_repo` is the anchor repo the business tier writes its
+group-synthesised `docs/business/` set into (default: the repo with the most
+entities — usually the backend/service).
 
 ### Step 5 — Show the plan to the user
 

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -64,6 +64,16 @@ Use whichever output template fits, or write freeform if no template applies (cr
 - A "Where this is enforced" section listing file paths.
 - A "Where this is bypassed" section if the convention's `cross_cutting_pitfalls` lists known gotchas (e.g., management commands that skip middleware).
 
+**Anchor contract (`snippets/anchor-contract.md`).** Cross-cutting pages are
+where the 2026-05-23 audit found the 17 anchor mismatches: stubs declared
+`anchors: [summary, primary-implementation, patterns, consumers, gotchas]` but
+the prose used `## Where it lives`, `## How it's used`. If you emit an
+`anchors:` frontmatter list, **write the headings first, then derive `anchors:`
+from those exact headings** — never the reverse. A declared anchor with no
+matching heading in the same file is a hard failure. Apply
+`snippets/link-hygiene.md` to every link you emit (no source-dir links, no bare
+directory links).
+
 ### Step 5 — Aggregate to group level
 
 After all per-repo files for the topic are written, write the group-level aggregator at `~/.archigraph/groups/<group>/cross-cutting/<topic>.md`. The aggregator is short — it points to each repo's page and calls out repo-to-repo divergence.

--- a/skills/generate-docs/prompts/08-cross-link.md
+++ b/skills/generate-docs/prompts/08-cross-link.md
@@ -7,12 +7,39 @@ Two responsibilities:
 
 ## Step 1 — Static link check
 
-For each generated markdown file, parse every `[text](path)` and confirm:
+Apply `snippets/link-hygiene.md` and `snippets/anchor-contract.md` — they are the
+source of truth for what a valid link/anchor is. This pass enforces them across
+the whole tree (technical + business). For each generated markdown file, parse
+every `[text](path)` and confirm:
 
-- The path resolves to an existing file (relative paths) or a known anchor (`#section-slug`).
-- The anchor matches the heading slug exactly. The slugification rule: lowercase, spaces → hyphens, drop non-alphanumeric except `-`; your anchor check must match that.
+- The path resolves to an existing file under a `docs/` tree (relative paths) or
+  a known anchor (`#section-slug`).
+- **No link points into a source-code directory** (`src/`, `core/`,
+  `dockerfile`, etc.). Those must be backticked paths, not links — rewrite any
+  that slipped through (link-hygiene rule 2).
+- **No bare-directory link** (`](modules/)`, `](reference/)`) without a real
+  index file target. Either repoint to a concrete page or to a generated
+  `<dir>/README.md` that exists; if neither exists, drop the link and leave the
+  text in backticks (link-hygiene rule 3).
+- **Relative paths use the filesystem dirname, prose uses the slug.** The
+  registry slug (`upvate-core`) and the on-disk dir (`upvate_core`) can differ.
+  A link path with the slug where the directory uses an underscore is the
+  `core-mobile → ../../upvate-core/docs/` 404 from the audit. Resolve the real
+  dirname from `inventory.json` `repo.path` and rewrite (link-hygiene rule 4).
+- The anchor matches the heading slug exactly per `snippets/anchor-contract.md`
+  slugification. Additionally verify each file's declared `anchors:` frontmatter
+  list: every declared anchor MUST have a matching heading in that same file
+  (the 17-mismatch bug). If a file declares anchors with no matching heading,
+  the writer built the list by hand — re-derive `anchors:` from the actual
+  headings (anchor-contract procedure) and fix in place.
+- **Don't keep links to optional pages that were never generated**
+  (`how-to/local-dev.md`, a missing `reference/` index): drop them
+  (link-hygiene rule 6).
 
-Broken links are auto-fixed where the target is unambiguous; otherwise log them and report at the end.
+Broken links are auto-fixed where the target is unambiguous; otherwise log them
+and report at the end. The report's "Broken intra-doc links" section must be
+empty for the run to be considered clean — every broken link is either repaired
+or downgraded to a backticked identifier.
 
 ## Step 2 — Cross-repo link candidates
 

--- a/skills/generate-docs/prompts/15-business-domain.md
+++ b/skills/generate-docs/prompts/15-business-domain.md
@@ -1,0 +1,87 @@
+# Pass 15 — Business domain model + glossary (BUSINESS tier)
+
+The first business pass. Produce the product's business vocabulary: the nouns a
+PM uses (Inspection, Deficiency, Jurisdiction, Customer, Order), each defined in
+plain language. Later business passes (capabilities, journeys, rules) link into
+this glossary, so it runs first.
+
+> **READ FIRST:** `snippets/business-voice.md`. Every rule there is binding for
+> this pass. Zero internal symbol names; PM audience; provenance only in the
+> collapsed `<details>` block.
+
+The business tier is **synthesised across the whole group**, not per repo. Even
+though the file is written under one repo's `docs/business/` (see Output), its
+content spans every repo's domain.
+
+## Inputs
+
+- `~/.archigraph/groups/<group>/domain.md` — owner-supplied domain framing (Pass 0).
+- Every `<repo>/docs/overview.md` and `<repo>/docs/glossary.md` from the
+  technical tier, if it was generated (the technical glossary is symbol-anchored;
+  translate it to business voice — do not copy it).
+- The graph (entities / data model) via the MCP tools below.
+
+## Output
+
+Write a single group-synthesised file:
+
+```
+<primary-repo>/docs/business/domain-glossary.md
+```
+
+`<primary-repo>` is the group's anchor repo — the one the orchestrator selected
+in the tier-selection step (default: the backend/service repo with the most
+entities; the webui aggregates all repos' `business/` trees into one Business
+view, so a single location reads as one set). Use
+`output-templates/business-domain-glossary.md`.
+
+## Procedure
+
+### Step 1 — Gather candidate domain concepts
+
+Find the business entities (data model), not the code structure:
+
+```
+archigraph_find(question="core data model and domain entities", repo_filter=null, depth=2, token_budget=1500)
+archigraph_find(question="what are the main business records the system stores", repo_filter=null, depth=2, token_budget=1200)
+```
+
+Also read each technical-tier `glossary.md` and `overview.md`. These already
+name the domain; your job is to lift the **business** terms and drop the code.
+
+### Step 2 — Group by business meaning
+
+Multiple classes/tables often back ONE business concept (e.g. `Inspection`,
+`InspectionItem`, `InspectionSerializer`, `inspection` table → the single
+business term **Inspection**). Collapse them. The reader sees one term, not
+four code artifacts.
+
+Discard pure-plumbing entities (serializers, view-sets, repositories, DTOs) —
+they are not domain concepts.
+
+### Step 3 — Define each term in business language
+
+For each business term: a plain-language definition, what it relates to (linked
+to other glossary terms), and its lifecycle in business words if it has states.
+Order alphabetically. Follow `output-templates/business-domain-glossary.md`.
+
+### Step 4 — Anchors + provenance
+
+Write headings first, then derive the `anchors:` frontmatter list per
+`snippets/anchor-contract.md`. Put any code/file references ONLY inside the
+collapsed `<details>` provenance block at the bottom.
+
+### Step 5 — Verify + save
+
+Run `snippets/verification-checklist.md` (business-voice section applies).
+
+```
+archigraph_save_finding(
+  question="What is the business domain glossary for the <group> group?",
+  answer="<file: <primary-repo>/docs/business/domain-glossary.md>",
+  type="business_domain",
+)
+```
+
+Hand back to the orchestrator. Pass 16 (capabilities) and Pass 17 (journeys)
+both link into this glossary, so they run after it.

--- a/skills/generate-docs/prompts/16-business-capabilities.md
+++ b/skills/generate-docs/prompts/16-business-capabilities.md
@@ -1,0 +1,82 @@
+# Pass 16 — Product capabilities (BUSINESS tier)
+
+Produce one page per product capability: what the system does and why, in
+business language. Capabilities are derived from the system's externally-visible
+behaviour — HTTP endpoints, process flows, message topics, scheduled jobs —
+grouped by business meaning, NOT one-per-endpoint.
+
+> **READ FIRST:** `snippets/business-voice.md`. Binding. No symbol names, no API
+> paths, no code mermaid. PM audience.
+
+Synthesised across the whole group.
+
+## Inputs
+
+- `<primary-repo>/docs/business/domain-glossary.md` (Pass 15) — link into it.
+- Technical-tier `reference/api.md`, module `flows.md`, and `overview.md` for
+  every repo (where generated) — these enumerate the behaviour; translate it.
+- The graph via the MCP tools below.
+
+## Output
+
+```
+<primary-repo>/docs/business/capabilities/<capability-slug>.md   # one per capability
+```
+
+Use `output-templates/business-capability.md`. `<capability-slug>` is a
+kebab-case business name (e.g. `schedule-inspection`, `submit-report`,
+`manage-deficiencies`) — not a module or endpoint name.
+
+## Procedure
+
+### Step 1 — Enumerate behaviour
+
+```
+archigraph_endpoints(repo_filter=null, limit=500)        # what the product exposes
+archigraph_flows(repo_filter=null, limit=200)            # process flows / call chains
+archigraph_find(question="scheduled jobs and background processing", repo_filter=null, depth=2, token_budget=1000)
+archigraph_find(question="message topics and events the system emits", repo_filter=null, depth=2, token_budget=1000)
+```
+
+If `archigraph_endpoints` / `archigraph_flows` are unavailable, fall back to
+reading the technical-tier `reference/api.md` and module `flows.md`.
+
+### Step 2 — Cluster into capabilities
+
+Group the raw behaviour by **business outcome**. Many endpoints + a flow + a
+topic often constitute ONE capability:
+
+> `POST /inspections`, `PATCH /inspections/{id}`, `POST /inspections/{id}/submit`,
+> the `inspection.submitted` topic, and the submit flow →
+> capability **"Conduct and submit an inspection."**
+
+Aim for a SMALL number of capabilities (typically 5–15 for a product), each
+genuinely distinct. Do not emit a capability page per endpoint — that is the
+over-fragmentation the audit warned about, in business clothing.
+
+### Step 3 — Write each capability page
+
+Fill `output-templates/business-capability.md`: what it does, why it exists, who
+uses it and when, what it produces, the rules that govern it (forward-link to
+`rules/` — Pass 18 fills those), related journeys (forward-link to `journeys/` —
+Pass 17). Plain language throughout.
+
+### Step 4 — Anchors + provenance
+
+Headings first, then derive `anchors:` per `snippets/anchor-contract.md`. Code
+references only in the collapsed `<details>` block.
+
+### Step 5 — Verify + save
+
+Run `snippets/verification-checklist.md`. Then once, for the capability set:
+
+```
+archigraph_save_finding(
+  question="What product capabilities does the <group> group provide?",
+  answer="<files: <primary-repo>/docs/business/capabilities/*.md>",
+  type="business_capabilities",
+)
+```
+
+Hand back. Pass 19 (business overview) will index every capability page you
+wrote, so report the list of capability slugs to the orchestrator.

--- a/skills/generate-docs/prompts/17-business-journeys.md
+++ b/skills/generate-docs/prompts/17-business-journeys.md
@@ -1,0 +1,84 @@
+# Pass 17 — User journeys as business narrative (BUSINESS tier)
+
+Produce end-to-end user journeys written as PLAIN-LANGUAGE narratives — a user
+accomplishing a goal across the whole product. This pass exists specifically to
+fix the audit finding that the old `user-journeys.md` was a 60-step mermaid
+sequence diagram naming internal symbols. That artifact belongs in the technical
+tier; here we write the business version.
+
+> **READ FIRST:** `snippets/business-voice.md`. Binding. The hard rule: NO code
+> sequence diagrams, NO internal symbols, NO API paths. A simple business-step
+> `flowchart` (≤ 8 business-labelled boxes) is the ONLY diagram allowed, and only
+> if it adds something the prose doesn't.
+
+Synthesised across the whole group — a journey typically crosses repos (mobile
+app → backend → office web).
+
+## Inputs
+
+- `<primary-repo>/docs/business/domain-glossary.md` (Pass 15).
+- `<primary-repo>/docs/business/capabilities/*.md` (Pass 16) — link into them.
+- Process flows / call chains and cross-repo links from the graph.
+- Any technical-tier journey/flow pages — translate to business voice, do not
+  copy. Demote their mermaid sequence diagrams; they stay in the technical tier.
+
+## Output
+
+```
+<primary-repo>/docs/business/journeys/<journey-slug>.md   # one per journey
+```
+
+Use `output-templates/business-journey.md`. A journey-slug is a goal in
+kebab-case (e.g. `field-inspection-day`, `customer-places-order`,
+`onboard-new-building`).
+
+## Procedure
+
+### Step 1 — Identify the goals
+
+A journey is a goal a real user accomplishes, end to end. Find them from:
+
+```
+archigraph_flows(repo_filter=null, limit=200)
+archigraph_traces(action=list, repo_filter=null, limit=50)
+archigraph_cross_links(action=list, limit=200)   # cross-repo legs of a journey
+```
+
+Plus the capability set from Pass 16 (a journey usually chains several
+capabilities). Pick the handful of journeys that matter to the business
+(typically 3–8). Do not enumerate every code path.
+
+### Step 2 — Write the narrative
+
+A NUMBERED list of plain-language steps: what the user does, sees, decides; what
+the system does for them — in business terms. Cross-repo legs become natural
+sentences ("the inspection syncs to the office when the device is back online"),
+never "`core-mobile` calls `upvate_core` `/api/v1/sync`".
+
+Then "What can go wrong" (business exceptions: offline, rejected, missing data)
+and "Where it touches the business" (link to the capabilities and domain terms
+it exercises).
+
+### Step 3 — Optional business diagram
+
+If a ≤8-box business `flowchart` clarifies the sequence, add it with
+business-only labels. Otherwise omit. NEVER a `sequenceDiagram`.
+
+### Step 4 — Anchors + provenance
+
+Headings first, derive `anchors:` per `snippets/anchor-contract.md`. Symbols and
+file paths ONLY in the collapsed `<details>` block.
+
+### Step 5 — Verify + save
+
+Run `snippets/verification-checklist.md`. Then:
+
+```
+archigraph_save_finding(
+  question="What are the business user journeys for the <group> group?",
+  answer="<files: <primary-repo>/docs/business/journeys/*.md>",
+  type="business_journeys",
+)
+```
+
+Hand back; report the list of journey slugs for Pass 19's index.

--- a/skills/generate-docs/prompts/18-business-rules.md
+++ b/skills/generate-docs/prompts/18-business-rules.md
@@ -1,0 +1,81 @@
+# Pass 18 — Business rules / requirements (BUSINESS tier)
+
+Reverse-engineer the product's business rules — constraints, requirements,
+policies — from the implementation, and state them as PRODUCT REQUIREMENTS. This
+is the layer a team lead extracts engineering requirements from; here we
+generate it backwards (code → requirement). This is the inverse of the normal
+workflow and is the owner's headline reason for the business tier.
+
+> **READ FIRST:** `snippets/business-voice.md`. Binding. A rule reads like a
+> requirement, not like code:
+>   GOOD: "An inspection cannot be submitted until every device on the checklist
+>          has an outcome recorded."
+>   BAD:  "`InspectionSerializer.validate()` raises when `devices` is empty."
+
+Synthesised across the whole group.
+
+## Inputs
+
+- `<primary-repo>/docs/business/domain-glossary.md` (Pass 15).
+- `<primary-repo>/docs/business/capabilities/*.md` (Pass 16) — rules attach to
+  capabilities.
+- The graph: validation logic, conditional branches, permission checks,
+  required fields.
+
+## Output
+
+```
+<primary-repo>/docs/business/rules/index.md   # grouped by business area
+```
+
+Use `output-templates/business-rules.md`. One file is usually enough; split into
+`rules/<area>.md` only if a single area has many rules and the index grows
+unwieldy. If you split, `rules/index.md` must still exist and link to each area
+file (link-hygiene: no bare-directory links).
+
+## Procedure
+
+### Step 1 — Mine the implementation for rules
+
+```
+archigraph_find(question="validation rules and required fields", repo_filter=null, depth=2, token_budget=1500)
+archigraph_find(question="permission and authorization checks — who can do what", repo_filter=null, depth=2, token_budget=1500)
+archigraph_find(question="state transitions and status constraints", repo_filter=null, depth=2, token_budget=1200)
+archigraph_find(question="business invariants and conditional logic that rejects input", repo_filter=null, depth=2, token_budget=1200)
+```
+
+Also fold in any latent-bug / security findings the run produced (e.g. an
+endpoint missing a permission check) — surface those as a rule that SHOULD hold
+plus a flagged gap, in business terms ("Only authorised staff should be able to
+clear inspections; today this is not enforced for one action — flagged for
+engineering").
+
+### Step 2 — Translate each into a requirement
+
+Each rule: the requirement (one sentence), why it exists, when it applies, and
+what the product does if violated — all in business language. Group by business
+area (Inspections, Access & permissions, Reporting, …). Attach rules to
+capabilities by linking back to `capabilities/<slug>.md`.
+
+Discard pure-technical guards (null checks, type coercions) — they are not
+business rules.
+
+### Step 3 — Anchors + provenance
+
+Headings first, derive `anchors:` per `snippets/anchor-contract.md`. The
+capability pages forward-link to specific rule anchors, so name your rule
+headings clearly and stably. File/symbol references ONLY in `<details>`.
+
+### Step 4 — Verify + save
+
+Run `snippets/verification-checklist.md`. Then:
+
+```
+archigraph_save_finding(
+  question="What business rules does the <group> group enforce?",
+  answer="<file: <primary-repo>/docs/business/rules/index.md>",
+  type="business_rules",
+)
+```
+
+Hand back to the orchestrator.

--- a/skills/generate-docs/prompts/19-business-overview.md
+++ b/skills/generate-docs/prompts/19-business-overview.md
@@ -1,0 +1,70 @@
+# Pass 19 — Business overview / landing page (BUSINESS tier)
+
+The last business pass. Produce the single landing page a PM opens first: what
+the product does, who uses it, and an index into the capabilities, journeys,
+domain glossary, and rules written by Passes 15–18. It runs last because it
+links to everything those passes produced.
+
+> **READ FIRST:** `snippets/business-voice.md`. Binding.
+
+Synthesised across the whole group.
+
+## Inputs
+
+- `~/.archigraph/groups/<group>/domain.md`.
+- The business pages written by Passes 15–18 (glossary, capabilities/*,
+  journeys/*, rules/index.md) — you index all of them.
+
+## Output
+
+```
+<primary-repo>/docs/business/overview.md
+```
+
+Use `output-templates/business-overview.md`. This is the root of the Business
+view the webui surfaces (#1634): the chooser's "Business" tab lands here.
+
+## Procedure
+
+### Step 1 — Write the pitch
+
+Two or three plain-language paragraphs: what the product is, the problem it
+solves, who it serves. Lift the framing from `domain.md`, translated to business
+voice. No component names.
+
+### Step 2 — Build the indexes
+
+- **Who uses it** — table of user types and their goals.
+- **What it does** — one bullet per capability page from Pass 16, each a
+  business sentence linking to `capabilities/<slug>.md`.
+- **Core ideas** — point at `domain-glossary.md`.
+- **How a typical job flows** — one bullet per journey from Pass 17 linking to
+  `journeys/<slug>.md`.
+- **Rules the product enforces** — 2–3 headline rules + link to `rules/index.md`.
+
+Every link must resolve (the page must already exist from Passes 15–18) — apply
+`snippets/link-hygiene.md`. Do not link to a capability/journey that was not
+written.
+
+### Step 3 — Anchors + provenance
+
+Headings first, derive `anchors:` per `snippets/anchor-contract.md`. Provenance
+in the collapsed `<details>` block.
+
+### Step 4 — Verify + save
+
+Run `snippets/verification-checklist.md`, then run the business-tier link check:
+confirm every link from `overview.md` resolves to a file that exists under
+`business/`.
+
+```
+archigraph_save_finding(
+  question="What is the business overview of the <group> group?",
+  answer="<file: <primary-repo>/docs/business/overview.md>",
+  type="business_overview",
+)
+```
+
+Hand back to the orchestrator. The business tier is complete:
+`business/overview.md`, `business/capabilities/*`, `business/domain-glossary.md`,
+`business/journeys/*`, `business/rules/index.md`.

--- a/skills/generate-docs/snippets/anchor-contract.md
+++ b/skills/generate-docs/snippets/anchor-contract.md
@@ -1,0 +1,61 @@
+# Anchor contract (shared slug vocabulary)
+
+Fixes the class of bug where a page declares `anchors:` in its frontmatter but
+the prose uses different headings, so the declared anchor slugs do not resolve
+(the "17 anchor mismatches" found in the 2026-05-23 docgen audit). The root
+cause was that the anchor generator and the heading writer used **different
+vocabularies** (`summary` declared, `## Where it lives` written).
+
+There is exactly one rule and it has no exceptions.
+
+## Rule: derive `anchors:` from headings, never the other way around
+
+A writer subagent must **write the prose headings first, then derive the
+`anchors:` list from those headings.** Never hand-author an `anchors:` list and
+hope the headings match it.
+
+### Slugification (must match the backend + Pass 8 checker exactly)
+
+```
+slug(heading) =
+  1. take the heading text AFTER the leading `#`+space
+  2. strip surrounding backticks but KEEP the inner text
+       "## How `JWTAuthMiddleware` validates" → "How JWTAuthMiddleware validates"
+  3. lowercase
+  4. replace every run of non-alphanumeric characters with a single "-"
+  5. trim leading/trailing "-"
+```
+
+Worked examples:
+
+| Heading | Slug |
+|---------|------|
+| `## Summary` | `summary` |
+| `## Where it lives` | `where-it-lives` |
+| `## How it's used` | `how-it-s-used` |
+| ``## How `JWTAuthMiddleware` validates tokens`` | `how-jwtauthmiddleware-validates-tokens` |
+| `## Business rules` | `business-rules` |
+
+### Procedure for any writer that emits `anchors:` frontmatter
+
+```
+1. Write the full markdown body (all `##`/`###` headings + prose).
+2. Collect every heading line.
+3. anchors = [ slug(h) for h in headings ]   # in document order, deduped
+4. Write the frontmatter `anchors:` list to exactly that derived set.
+5. Self-check: for each declared anchor, grep the body for a heading whose
+   slug() equals it. If any anchor has no matching heading → STOP, you built
+   the list by hand. Re-derive from step 2.
+```
+
+### Do NOT
+
+- Do **not** copy an `anchors:` template list (`[summary, primary-implementation,
+  patterns, consumers, gotchas]`) and then write whatever headings feel natural.
+  If you use a template heading set, you must write **those exact headings**.
+- Do **not** include an anchor for a heading you did not write.
+- Do **not** emit `anchors:` at all if the page has no headings worth anchoring —
+  an empty/absent list is valid; a wrong list is a hard failure.
+
+Pass 8 (`prompts/08-cross-link.md`) re-runs this check across all pages and the
+verification checklist (`snippets/verification-checklist.md`) gates it per file.

--- a/skills/generate-docs/snippets/business-voice.md
+++ b/skills/generate-docs/snippets/business-voice.md
@@ -1,0 +1,75 @@
+# Business-voice rules
+
+The single style contract for every page in the BUSINESS tier (`business/`).
+A writer subagent in any business pass (15–19) MUST read this first and obey it
+without exception. The audience is a Product Manager, a business analyst, or a
+non-engineer team lead reading on Confluence — **not** an engineer.
+
+The 2026-05-23 docgen audit found `user-journeys.md` was *labeled* a narrative
+but was a 60-step mermaid `sequenceDiagram` naming `useAuthStore`,
+`syncEngine.ts`, `/api/v1/mobile/*`. That is a technical-tier artifact. It must
+never appear in the business tier.
+
+## Hard rules (a violation is a hard stop — rewrite, do not ship)
+
+1. **Zero internal symbol names.** No class names, function names, file names,
+   module slugs, env vars, table names, API paths, or package names. If you
+   would write `OrderViewSet`, `syncEngine.ts`, `/api/v1/mobile`, or
+   `useAuthStore`, instead name the *business thing* it implements ("the order
+   submission step", "the offline sync that runs when the device reconnects").
+2. **No code mermaid.** No `sequenceDiagram`, no `classDiagram`, no
+   call-graph/flow-of-functions. A simple business-narrative `flowchart`
+   diagram of *business steps* (boxes a PM would recognise: "Inspection
+   created" → "Deficiency recorded" → "Report issued") is allowed, max ~8 nodes,
+   and must duplicate nothing the prose already says clearly.
+3. **No code blocks of source.** No quoted source. A small illustrative
+   payload-in-business-terms table is fine ("an inspection record carries: who,
+   where, when, outcome"); a JSON/Python/TS block is not.
+4. **Plain language.** Short sentences. Define any unavoidable jargon inline or
+   link to the domain glossary. Prefer "the system" / "the field app" /
+   "office staff" over component names.
+5. **Business framing, always.** Every capability/rule/journey answers *what the
+   business gets* and *why*, then *what the user does*. Never *how the code
+   does it*.
+
+## What to write instead of symbols
+
+| Tempting (technical) | Write this (business) |
+|----------------------|-----------------------|
+| `InspectionViewSet.create()` | "An inspector starts a new inspection" |
+| `permission_classes = [...]` | "Only authorised office staff can do this" |
+| `order.created` topic | "An order-placed notification fans out to fulfilment and billing" |
+| `if status == 'OVERDUE'` | "When an inspection passes its due date it becomes overdue" |
+| `core-mobile` repo | "the field inspection app" |
+
+## Provenance, kept out of the reader's way
+
+A business page is reverse-engineered from code, so it can be wrong if the code
+changes. Each business page carries a hidden-by-default provenance note at the
+bottom so an engineer can audit it without polluting the PM reading:
+
+```markdown
+<details>
+<summary>Where this came from (for engineers)</summary>
+
+Derived from the technical docs and graph evidence:
+- capability backed by the endpoints documented in `<repo>/docs/reference/api.md`
+- rule observed in validation logic surfaced by `archigraph_find`
+- last regenerated: <date>
+
+</details>
+```
+
+The `<summary>` block is the **only** place a file path or symbol may appear in
+a business page, and it is collapsed by default so a PM never has to read it.
+
+## Translating evidence → business language
+
+You will be handed graph evidence and technical-tier docs full of symbols.
+Your job is translation, not transcription:
+
+1. Read the evidence (endpoints, flows, entities, validation logic, the
+   already-written technical docs).
+2. Group it by *business meaning*, not by code structure.
+3. Write the business meaning in the reader's language.
+4. Drop the provenance trail into the collapsed `<details>` block.

--- a/skills/generate-docs/snippets/link-hygiene.md
+++ b/skills/generate-docs/snippets/link-hygiene.md
@@ -1,0 +1,68 @@
+# Link hygiene
+
+Fixes the "37 broken links" class from the 2026-05-23 docgen audit. Every
+markdown link a writer emits must satisfy these rules. Pass 8
+(`prompts/08-cross-link.md`) validates them across the whole tree; the
+verification checklist gates them per file as they are written.
+
+## 1. A link target must be a real, generated doc file
+
+Before emitting `[text](path)`, the producer must be able to point at the doc
+file that `path` resolves to. If you cannot, do not emit a link — write the
+identifier in backticks instead (the ADR-0007 bridge), which is clickable-free
+but graph-valid.
+
+## 2. Never link into source-code directories
+
+`../../src/network/hooks/`, `../../core/...`, `../../dockerfile` are **not doc
+pages**. The audit found these emitted as if they were links. A source file is
+referenced in **backticks as a path**, never as a markdown link:
+
+```markdown
+Defined in `core/views/report_viewset.py`.        ✅
+See [report viewset](../../core/views/report_viewset.py).   ❌
+```
+
+The only links allowed are to files under a `docs/` tree.
+
+## 3. Directory links must target an index file that exists
+
+A bare-directory link (`[modules](modules/)`, `[reference](reference/)`) 404s
+unless that directory has an `index.md` / `README.md`. Two options, in order:
+
+1. Link to a concrete page inside the directory
+   (`[API reference](reference/api.md)`), OR
+2. If you genuinely mean "the section", link to a generated index file
+   (`[modules](modules/README.md)`) **and ensure that index file is in the
+   plan**. Pass 2 only schedules an index page for a section that has ≥ 1 child
+   page; do not link to an index that was never generated.
+
+Never emit `](modules/)` with a trailing slash and no file.
+
+## 4. Use the filesystem dirname for paths, the slug for prose
+
+The registry slug (`upvate-core`, hyphenated) and the on-disk directory
+(`upvate_core`, underscored) can differ. This caused
+`core-mobile/docs/overview.md` → `../../upvate-core/docs/` (404, dir is
+`upvate_core`).
+
+- **Relative link paths** (`../../<dir>/docs/...`) MUST use the actual
+  filesystem directory name. Resolve it from `archigraph_whoami` /
+  `inventory.json` `repo.path` (the last path segment), not from the slug.
+- **Prose / display text** may use the human slug.
+
+```markdown
+See the [billing overview](../../upvate_core/docs/overview.md) in `upvate-core`.
+                              └ filesystem dirname ┘            └ slug in prose ┘
+```
+
+## 5. Anchors must satisfy the anchor contract
+
+A link `path#anchor` must point at a heading whose slug (per
+`snippets/anchor-contract.md`) equals `anchor`. Same slugification rule on both
+sides.
+
+## 6. Don't link to optional pages that were not generated
+
+`how-to/local-dev.md`, a `reference/` index, etc. are optional. Only link to one
+after confirming the plan scheduled it. If it was skipped, drop the link.

--- a/skills/generate-docs/snippets/verification-checklist.md
+++ b/skills/generate-docs/snippets/verification-checklist.md
@@ -24,9 +24,18 @@ False positives are possible (acronyms, capitalized prose words) — review each
 ## Structural
 
 - [ ] No empty sections — either fill them or delete them.
+- [ ] No empty stub pages — never emit a `flows/index.md` (or any page) that contains only a heading or a placeholder table with no rows. If a module has no flows, do not write a `flows` page at all (see `prompts/02-plan.md` § Volume control).
 - [ ] No placeholder text remaining (`<one line>`, `<entity>`, `TODO`, `FIXME`).
 - [ ] Tables have a header row + alignment row.
 - [ ] Internal links use relative paths and resolve to existing files.
+
+## Links + anchors (`snippets/link-hygiene.md`, `snippets/anchor-contract.md`)
+
+- [ ] No link points into a source-code directory (`src/`, `core/`, `dockerfile`, …). Source paths are backticked, not linked.
+- [ ] No bare-directory link (`](modules/)`) without a real index-file target that exists.
+- [ ] Relative link PATHS use the filesystem dirname; prose may use the slug. (Catches the `upvate-core` vs `upvate_core` 404.)
+- [ ] No link to an optional page the plan did not schedule.
+- [ ] If the file declares `anchors:` in frontmatter, every declared anchor has a matching heading IN THIS FILE whose slug equals it. The list was derived FROM the headings, not hand-authored.
 
 ## Forbidden terms
 
@@ -47,3 +56,13 @@ False positives are possible (acronyms, capitalized prose words) — review each
 
 - [ ] The file's section headings match the relevant `output-templates/*.md`.
 - [ ] No drive-by additions of sections the template did not include.
+
+## Business tier only (`snippets/business-voice.md`)
+
+Apply these checks to any file under a `business/` directory. A violation is a hard stop — rewrite, do not ship.
+
+- [ ] Zero internal symbol names in the visible body (no class/function/file names, no API paths, no env vars, no table names, no module slugs, no repo dir names). The ONLY place a symbol/path may appear is inside the collapsed `<details>` provenance block.
+- [ ] No `sequenceDiagram` / `classDiagram` / call-graph mermaid. Any mermaid is a business-step `flowchart` with ≤ 8 business-labelled boxes.
+- [ ] No quoted source code blocks.
+- [ ] A non-engineer could read the page top to bottom and understand it without help.
+- [ ] Every link resolves to another `business/` page or the domain glossary (run after the page's siblings exist).


### PR DESCRIPTION
## 1. What & why
Adds a distinct **BUSINESS documentation tier** to the `generate-docs` skill (the owner priority, #1623) and fixes the skill-side defects found in the 2026-05-23 docgen audit (#1621). The technical per-repo tier is unchanged and fully separable — the user now picks Technical and/or Business.

The business tier is what a product team owns on Confluence — the layer team-leads extract engineering requirements from. Here we generate it **backwards (code → business)**: PM-readable, synthesised across all repos by business domain/capability, with zero internal symbol names and no code-mermaid.

## 2. Business tier design (#1623)
**Selection:** new `tiers: ["technical","business"]` in `plan.json`; SKILL.md "Documentation tiers" section drives the chooser. Technical-only runs 0–14; business-only runs 0,1 then 15–19; both runs technical first so business passes reuse the technical docs as higher-fidelity input.

**Layout** (group-synthesised into the `primary_repo`, read by the webui #1634 `business/` aggregator):
```
<primary-repo>/docs/business/
  overview.md          # Pass 19 — landing page + indexes
  capabilities/*.md    # Pass 16 — product capabilities (what + why)
  domain-glossary.md   # Pass 15 — business vocabulary (Inspection, Deficiency…)
  journeys/*.md        # Pass 17 — plain-language user journeys
  rules/index.md       # Pass 18 — business rules / requirements
```

**Generation passes** (each reads `snippets/business-voice.md` first):
- **15 domain** — business nouns from entities/data-model, collapsed to one term per concept (drop serializers/viewsets/DTOs).
- **16 capabilities** — from `archigraph_endpoints`/`archigraph_flows`/topics, grouped by business outcome (5–15 capabilities, not one-per-endpoint).
- **17 journeys** — end-to-end goals from flows/traces/cross-links as numbered plain-language narratives; ≤8-box business `flowchart` only, never a `sequenceDiagram`. Directly replaces the audit's symbol-heavy "user-journeys.md".
- **18 rules** — requirements reverse-engineered from validation/permission/conditional logic; folds in the latent-bug/security findings as flagged gaps.
- **19 overview** — pitch + indexes into the above (runs last).

**PM-readability enforced by `snippets/business-voice.md`:** zero internal symbols/paths/API routes/env vars in the visible body; the only place a symbol may appear is a collapsed `<details>` provenance block at the bottom (so engineers can audit without polluting the PM reading). Gated by a new business-tier section in the verification checklist.

## 3. Audit skill fixes (#1621)
- **Anchor contract** (`snippets/anchor-contract.md`): `anchors:` frontmatter must be *derived from* the headings actually written, never hand-authored — fixes the 17 mismatches (`summary` declared vs `## Where it lives` written). Enforced in Pass 6 (where they originated), per-file in the checklist, and group-wide in Pass 8.
- **Broken links** (`snippets/link-hygiene.md`): no links into source-code dirs; bare-directory links need a real index target; relative paths use the **filesystem dirname** not the registry slug (fixes the `upvate-core`/`upvate_core` 404); drop links to ungenerated optional pages. Pass 8 now requires the broken-links report to be empty.
- **Volume control** (Pass 2 § Step 1b): prefer real graph communities (now persisting via #1620) over dir-fallback; merge thin modules (`min_module_entities` default 8); cap module count by LOC; conditional `pages:` so empty `flows/index.md` stubs are never scheduled. Fixes the 122-module over-fragmentation.

## 4. Files
New: `prompts/15-19-business-*.md`, `output-templates/business-{overview,capability,domain-glossary,journey,rules}.md`, `snippets/{anchor-contract,link-hygiene,business-voice}.md`. Edited: `SKILL.md`, `prompts/{02-plan,06-cross-cutting,08-cross-link}.md`, `snippets/verification-checklist.md`. No Go/internal/webui changes.

## 5. Testing
Daemon is intentionally stopped (live :47274 untouched), so no full doc run. Validated:
- Structure: all 5 prompts, 5 templates, 3 snippets present; templates open with valid frontmatter; no symbol leaks in template bodies.
- A hand-authored sample business journey (UpVate domain from the audit) passed all contracts: zero symbol leaks in the visible body, no `sequenceDiagram`, 6-node business flowchart (≤8), and `anchors:` frontmatter slugs all match real headings (anchor contract satisfied). Sample was scratch-only, not committed.

## 6. Risk & rollout
Skill-content only — no code, no daemon dependency at merge time. Technical tier behaviour is unchanged (business passes are additive and gated on `tiers`). Business tier needs a real run against a live group to fully exercise; recommend a follow-up dry run once :47274 is back up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)