### PR TITLE
feat(engine): aio-pika RabbitMQ extraction + multi-broker ETL fixture (#1638)

### DIFF
--- a/internal/engine/etl_pipeline_1638_test.go
+++ b/internal/engine/etl_pipeline_1638_test.go
@@ -1,0 +1,136 @@
+// End-to-end verification for the polyglot-platform multi-broker ETL pipeline
+// fixture (#1638). Drives every broker pass over the actual fixture source and
+// asserts the pipeline is connected stage->stage: each hop's producer emits a
+// synthetic channel/topic/queue whose ID is matched by the next stage's
+// consumer (cross-repo linking is pure shared-ID matching, so equal IDs ⇒ a
+// connected edge in Topology + a traceable Flow).
+//
+// Brokers exercised: SQS, SNS, Redis Streams, Google Pub/Sub, RabbitMQ
+// (aio-pika — the NEW extractor added by this change).
+package engine
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+const etlFixtureDir = "/Users/jorgecajas/Documents/Projects/polyglot-platform/data-pipeline/etl"
+
+// brokerPass is the shared signature of every per-file broker synthesis pass.
+type brokerPass func(lang, path string, content []byte,
+	ents []types.EntityRecord, rels []types.RelationshipRecord) (
+	[]types.EntityRecord, []types.RelationshipRecord)
+
+// allBrokerPasses runs every broker pass over a file and returns the union of
+// emitted entities + relationships, mirroring detector.go's pass ordering.
+func allBrokerPasses(t *testing.T, path string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	content, err := os.ReadFile(path)
+	if err != nil {
+		t.Skipf("fixture not present (%v) — skipping e2e", err)
+	}
+	var ents []types.EntityRecord
+	var rels []types.RelationshipRecord
+	for _, pass := range []brokerPass{
+		applyKafkaWrapperEdges, // SNS code-level publish
+		applyRabbitMQEdges,     // pika + aio-pika
+		applySQSEdges,
+		applyPubSubEdges,
+		applyRedisPubSubEdges,
+	} {
+		ents, rels = pass("python", path, content, ents, rels)
+	}
+	return ents, rels
+}
+
+// hasEntity reports whether an emitted synthetic channel entity carries sub in
+// its ID or Name. Broker passes key synthetic queues/topics on the Name field
+// (SourceFile left empty for cross-repo collapse), so check both.
+func hasEntityID(ents []types.EntityRecord, sub string) bool {
+	for _, e := range ents {
+		if containsStr(e.ID, sub) || containsStr(e.Name, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// hasEdgeTo reports whether a relationship of kind targets an ID containing sub.
+func hasEdgeTo(rels []types.RelationshipRecord, kind, sub string) bool {
+	for _, r := range rels {
+		if r.Kind == kind && containsStr(r.ToID, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsStr(s, sub string) bool {
+	return len(sub) == 0 || (len(s) >= len(sub) && indexStr(s, sub) >= 0)
+}
+
+func indexStr(s, sub string) int {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+func TestETLPipeline1638_EndToEnd(t *testing.T) {
+	stage := func(name string) ([]types.EntityRecord, []types.RelationshipRecord) {
+		return allBrokerPasses(t, filepath.Join(etlFixtureDir, name))
+	}
+
+	// Hop 1: ingest -> SQS etl-ingest-queue (producer).
+	e1, r1 := stage("stage1_ingest.py")
+	if !hasEntityID(e1, "etl-ingest-queue") || !hasEdgeTo(r1, publishesToEdgeKind, "etl-ingest-queue") {
+		t.Errorf("stage1: missing SQS producer for etl-ingest-queue")
+	}
+
+	// Hop 2: SQS consumer + SNS etl-transformed-topic producer.
+	e2, r2 := stage("stage2_transform.py")
+	if !hasEdgeTo(r2, subscribesToEdgeKind, "etl-ingest-queue") {
+		t.Errorf("stage2: missing SQS consumer for etl-ingest-queue")
+	}
+	if !hasEntityID(e2, "etl-transformed-topic") || !hasEdgeTo(r2, publishesToEdgeKind, "etl-transformed-topic") {
+		t.Errorf("stage2: missing SNS producer for etl-transformed-topic")
+	}
+
+	// Hop 3: SNS consumer (subscribe) + Redis stream producer.
+	_, r3 := stage("stage3_enrich.py")
+	if !hasEdgeTo(r3, subscribesToEdgeKind, "etl-transformed-topic") {
+		t.Errorf("stage3: missing SNS consumer for etl-transformed-topic")
+	}
+	if !hasEdgeTo(r3, publishesToEdgeKind, "etl-enriched-stream") {
+		t.Errorf("stage3: missing Redis-stream producer for etl-enriched-stream")
+	}
+
+	// Hop 4: Redis stream consumer + Google Pub/Sub producer.
+	_, r4 := stage("stage4_dedup.py")
+	if !hasEdgeTo(r4, subscribesToEdgeKind, "etl-enriched-stream") {
+		t.Errorf("stage4: missing Redis-stream consumer for etl-enriched-stream")
+	}
+	if !hasEdgeTo(r4, publishesToEdgeKind, "etl-deduped-topic") {
+		t.Errorf("stage4: missing Pub/Sub producer for etl-deduped-topic")
+	}
+
+	// Hop 5: Pub/Sub consumer + RabbitMQ (aio-pika) producer.
+	_, r5 := stage("stage5_aggregate.py")
+	if !hasEdgeTo(r5, subscribesToEdgeKind, "etl-deduped-topic") {
+		t.Errorf("stage5: missing Pub/Sub consumer for etl-deduped-topic")
+	}
+	if !hasEdgeTo(r5, publishesToEdgeKind, "etl-load-queue") {
+		t.Errorf("stage5: missing aio-pika producer for etl-load-queue")
+	}
+
+	// Hop 6: RabbitMQ (aio-pika) consumer = sink.
+	_, r6 := stage("stage6_load.py")
+	if !hasEdgeTo(r6, subscribesToEdgeKind, "etl-load-queue") {
+		t.Errorf("stage6: missing aio-pika consumer for etl-load-queue")
+	}
+}

--- a/internal/engine/rabbitmq_edges.go
+++ b/internal/engine/rabbitmq_edges.go
@@ -139,6 +139,7 @@ func applyRabbitMQEdges(
 	switch lang {
 	case "python":
 		synthesizePyRabbitMQ(src, emitQueue, emitEdge)
+		synthesizePyAioPika(src, emitQueue, emitEdge)
 	case "javascript", "typescript":
 		synthesizeNodeRabbitMQ(src, emitQueue, emitEdge)
 	case "java", "kotlin":
@@ -207,6 +208,147 @@ var pikaQueueDeclareKwRe = regexp.MustCompile(`\.queue_declare\s*\(\s*queue\s*=\
 // pikaQueueDeclarePosRe captures channel.queue_declare(name).
 // Group 1 = queue name.
 var pikaQueueDeclarePosRe = regexp.MustCompile(`\.queue_declare\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// ---------------------------------------------------------------------------
+// Python — aio-pika (async RabbitMQ) — #1638
+//
+// aio-pika is the de-facto async RabbitMQ client. Unlike pika it routes
+// through an exchange object, so publishes look like:
+//
+//	await channel.default_exchange.publish(Message(...), routing_key="q")
+//	await exchange.publish(msg, routing_key=QUEUE_CONST)
+//
+// and consumers / declarations look like:
+//
+//	queue = await channel.declare_queue("q", durable=True)
+//	await queue.consume(handler)
+//
+// We resolve the queue name from the publish routing_key and from
+// declare_queue, then attach consume() edges to the most recently declared
+// queue in the same file (single-queue ETL workers are the common case).
+// ---------------------------------------------------------------------------
+
+// aioPikaPublishLitRe captures a routing_key="q" kwarg. aio-pika publishes
+// pass a Message(...) positional arg whose own parens defeat a `.publish(...`
+// anchored match, so we key on the routing_key kwarg directly. Presence of a
+// `.publish(` somewhere in the file is verified by the caller guard.
+// Group 1 = routing key (literal queue name).
+var aioPikaPublishLitRe = regexp.MustCompile(`routing_key\s*=\s*["']([^"'\n\r]+)["']`)
+
+// aioPikaPublishVarRe captures routing_key=QUEUE_CONST (resolved via consts).
+// Group 1 = constant name.
+var aioPikaPublishVarRe = regexp.MustCompile(`routing_key\s*=\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+// aioPikaDeclareQueueLitRe captures await channel.declare_queue("q", ...).
+// Group 1 = queue name (literal).
+var aioPikaDeclareQueueLitRe = regexp.MustCompile(`\.declare_queue\s*\(\s*["']([^"'\n\r]+)["']`)
+
+// aioPikaDeclareQueueVarRe captures await channel.declare_queue(QUEUE_CONST, ...).
+// Group 1 = constant name.
+var aioPikaDeclareQueueVarRe = regexp.MustCompile(`\.declare_queue\s*\(\s*([A-Za-z_][A-Za-z0-9_]*)`)
+
+// aioPikaConsumeRe captures queue.consume(handler) — async consumer side.
+var aioPikaConsumeRe = regexp.MustCompile(`\.consume\s*\(`)
+
+// pyConstAssignRe captures module-level NAME = "value" string constants used
+// to resolve queue-name references in aio-pika calls.
+var pyConstAssignRe = regexp.MustCompile(`(?m)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*=\s*["']([^"'\n\r]+)["']`)
+
+// synthesizePyAioPika emits RabbitMQ producer/consumer edges for aio-pika.
+func synthesizePyAioPika(
+	src string,
+	emitQueue func(queueID, queueName, exchange, routingKey string, props map[string]string),
+	emitEdge func(callerKind, callerName, queueID, edgeKind string, props map[string]string),
+) {
+	isAioPika := strings.Contains(src, "aio_pika") || strings.Contains(src, "aio-pika")
+	// declare_queue + consume without an aio_pika import is still aio-pika
+	// (re-exported names), but plain pika never calls declare_queue/consume —
+	// it uses queue_declare/basic_consume — so this is safe.
+	if !isAioPika && !strings.Contains(src, "declare_queue") {
+		return
+	}
+
+	// Build a module-level string-constant table for routing_key/queue refs.
+	consts := map[string]string{}
+	for _, m := range pyConstAssignRe.FindAllStringSubmatch(src, -1) {
+		if len(m) >= 3 {
+			consts[m[1]] = m[2]
+		}
+	}
+	resolve := func(tok string) string {
+		if v, ok := consts[tok]; ok {
+			return v
+		}
+		return tok
+	}
+
+	enclosing := func(offset int) string { return findEnclosingPyName(src, offset) }
+
+	// Track the last declared queue name so consume() can bind to it when the
+	// consume call does not name a queue (aio-pika consumes on a queue object).
+	lastDeclared := ""
+
+	// declare_queue (literal + const) — emit the queue entity.
+	declareNames := map[int]string{}
+	for _, m := range aioPikaDeclareQueueLitRe.FindAllStringSubmatchIndex(src, -1) {
+		declareNames[m[0]] = src[m[2]:m[3]]
+	}
+	for _, m := range aioPikaDeclareQueueVarRe.FindAllStringSubmatchIndex(src, -1) {
+		if _, seen := declareNames[m[0]]; seen {
+			continue
+		}
+		declareNames[m[0]] = resolve(src[m[2]:m[3]])
+	}
+	for off, name := range declareNames {
+		if !looksLikeQueueName(name) {
+			continue
+		}
+		_ = off
+		lastDeclared = name
+		emitQueue(rabbitmqQueueID(name), name, "", "", map[string]string{
+			"declared":        "true",
+			"messaging_layer": "aio-pika",
+		})
+	}
+
+	// publish via routing_key (literal + const) — producer side. Only for
+	// genuine aio-pika files: pika also uses routing_key= on basic_publish,
+	// which is already handled by synthesizePyRabbitMQ — avoid double-counting.
+	pubOffsets := map[int]string{}
+	if isAioPika && strings.Contains(src, ".publish(") {
+		for _, m := range aioPikaPublishLitRe.FindAllStringSubmatchIndex(src, -1) {
+			pubOffsets[m[0]] = src[m[2]:m[3]]
+		}
+		for _, m := range aioPikaPublishVarRe.FindAllStringSubmatchIndex(src, -1) {
+			if _, seen := pubOffsets[m[0]]; seen {
+				continue
+			}
+			pubOffsets[m[0]] = resolve(src[m[2]:m[3]])
+		}
+	}
+	for off, name := range pubOffsets {
+		if !looksLikeQueueName(name) {
+			continue
+		}
+		qID := rabbitmqQueueID(name)
+		emitQueue(qID, name, "", name, map[string]string{"messaging_layer": "aio-pika"})
+		emitEdge("Function", enclosing(off), qID, publishesToEdgeKind, map[string]string{
+			"messaging_layer": "aio-pika",
+			"routing_key":     name,
+		})
+	}
+
+	// consume — consumer side, bound to the last declared queue in the file.
+	if lastDeclared != "" {
+		for _, m := range aioPikaConsumeRe.FindAllStringSubmatchIndex(src, -1) {
+			// Skip the declare_queue/publish offsets already handled.
+			qID := rabbitmqQueueID(lastDeclared)
+			emitEdge("Function", enclosing(m[0]), qID, subscribesToEdgeKind, map[string]string{
+				"messaging_layer": "aio-pika",
+			})
+		}
+	}
+}
 
 // celeryTaskRe captures @app.task or @celery.task decorated functions.
 // Group 1 = function name.

--- a/internal/engine/rabbitmq_edges_test.go
+++ b/internal/engine/rabbitmq_edges_test.go
@@ -342,3 +342,50 @@ func TestRabbitMQ_LooksLikeQueueName(t *testing.T) {
 		}
 	}
 }
+
+// #1638 — aio-pika async RabbitMQ producer/consumer detection.
+func TestRabbitMQ_Python_AioPikaPublishConstRoutingKey(t *testing.T) {
+	src := `import aio_pika
+
+LOAD_QUEUE = "etl-load-queue"
+
+async def publish_aggregate(channel, aggregate):
+    await channel.default_exchange.publish(
+        aio_pika.Message(body=b"x"),
+        routing_key=LOAD_QUEUE,
+    )
+`
+	ents, rels := runRabbitMQDetect(t, "python", "stage5.py", src)
+	qID := rabbitmqQueueID("etl-load-queue")
+	if queueByName(ents, qID) == nil {
+		t.Fatalf("expected SCOPE.Queue for etl-load-queue, ents=%v", ents)
+	}
+	pubs := relsByKind(rels, publishesToEdgeKind)
+	if len(pubs) == 0 || !strings.Contains(pubs[0].to, qID) {
+		t.Fatalf("expected aio-pika PUBLISHES_TO to %q, got %v", qID, pubs)
+	}
+	if pubs[0].props["messaging_layer"] != "aio-pika" {
+		t.Fatalf("messaging_layer = %q, want aio-pika", pubs[0].props["messaging_layer"])
+	}
+}
+
+func TestRabbitMQ_Python_AioPikaDeclareAndConsume(t *testing.T) {
+	src := `import aio_pika
+
+LOAD_QUEUE = "etl-load-queue"
+
+async def consume(connection):
+    channel = await connection.channel()
+    queue = await channel.declare_queue(LOAD_QUEUE, durable=True)
+    await queue.consume(on_message)
+`
+	ents, rels := runRabbitMQDetect(t, "python", "stage6.py", src)
+	qID := rabbitmqQueueID("etl-load-queue")
+	if queueByName(ents, qID) == nil {
+		t.Fatalf("expected SCOPE.Queue for etl-load-queue, ents=%v", ents)
+	}
+	subs := relsByKind(rels, subscribesToEdgeKind)
+	if len(subs) == 0 || !strings.Contains(subs[0].to, qID) {
+		t.Fatalf("expected aio-pika SUBSCRIBES_TO to %q, got %v", qID, subs)
+	}
+}


### PR DESCRIPTION
## 1. Problem
Issue #1638 asks for a realistic multi-broker ETL pipeline in the polyglot-platform fixture that flows across **multiple** messaging systems, and for the topology/flows engine to detect every hop — including brokers "not yet supported". The pipeline must form a connected stage→stage chain in Topology and a single traceable Flow.

## 2. Investigation
archigraph already ships extractors for Kafka, SNS, SQS, EventBridge, Redis pub/sub + Streams, Celery, NATS, Pulsar, **Google Cloud Pub/Sub** (`pubsub_edges.go`) and **RabbitMQ** (`rabbitmq_edges.go`). So Pub/Sub and RabbitMQ are *not* missing wholesale, contrary to the issue's framing. Auditing the RabbitMQ pass revealed the real gap: it covers **pika** (sync), **amqplib** (Node), **amqp091-go** (Go) and **Spring AMQP** — but **not aio-pika**, the de-facto *async* Python RabbitMQ client. aio-pika routes through an exchange object (`channel.default_exchange.publish(..., routing_key=)`) and declares/consumes on queue objects (`await channel.declare_queue(...)`, `await queue.consume(...)`), none of which the existing regexes matched.

## 3. Solution
- **Fixture** (`polyglot-platform`, committed separately — `3138deb`): 6-stage ETL in `data-pipeline/etl/` crossing five brokers end to end, each hop a real producer + consumer:
  `ingest →(SQS)→ transform →(SNS)→ enrich →(Redis stream)→ dedup →(Google Pub/Sub)→ aggregate →(RabbitMQ/aio-pika)→ load`. MANIFEST.md §3 documents channels + per-stage producers/consumers as ground truth.
- **New extractor** (`internal/engine/rabbitmq_edges.go`): `synthesizePyAioPika` — emits `rabbitmq:<queue>` SCOPE.Queue + PUBLISHES_TO (routing_key, literal + module-const resolved) and SUBSCRIBES_TO (declare_queue + queue.consume). Guarded to `aio_pika` files so it never double-counts pika's `basic_publish` routing_key kwarg.

## 4. Verification (isolated — live :47274 untouched)
- `go build ./internal/... ./cmd/...` clean; `go vet ./internal/engine/` clean.
- Full `go test ./internal/engine/` and `./internal/links/` green.
- New `TestRabbitMQ_Python_AioPika*` unit tests (publish via const routing_key; declare_queue + consume).
- New `etl_pipeline_1638_test.go` drives all five broker passes over the **actual fixture files** and asserts the pipeline connects stage→stage (each hop's producer topic ID == next stage's consumer topic ID). PASS.
- All six fixture stages `python -m py_compile` clean.
- The live daemon on :47274 was left STOPPED throughout; verification is purely in-process.

**Detected end-to-end pipeline:**
| Hop | Channel | Broker | Producer → Consumer |
|---|---|---|---|
| 1→2 | etl-ingest-queue | SQS | stage1.ingest → stage2.transform |
| 2→3 | etl-transformed-topic | SNS | stage2.transform → stage3.register_subscription |
| 3→4 | etl-enriched-stream | Redis Streams | stage3.handle_sns_event → stage4.dedup |
| 4→5 | etl-deduped-topic | Google Pub/Sub | stage4.dedup → stage5.aggregate |
| 5→6 | etl-load-queue | RabbitMQ (aio-pika) | stage5.publish_aggregate → stage6.consume |

**Brokers needing NEW extraction:** only **RabbitMQ aio-pika** (async). SQS, SNS, Redis Streams and Google Pub/Sub already extracted with no code change.

## 5. Risks / Trade-offs
- aio-pika `consume()` binds to the last `declare_queue` in the same file (single-queue worker is the common case); multi-queue async consumers in one file would bind all consumes to the last declared queue. Acceptable for the fixture and typical worker layout.
- The aio-pika publish path keys on the `routing_key=` kwarg + presence of `.publish(` (the `Message(...)` positional arg defeats a `.publish(...`-anchored match). Scoped to `aio_pika`-importing files to avoid colliding with pika.

## 6. Follow-ups
- Node aio-style / Go async RabbitMQ wrappers are out of scope here.
- Coordinated minimally: did not touch `internal/graph/load.go` or `cmd/archigraph/{index,daemon}.go` (owned by the #1626 relocation grind).

Fixes #1638

🤖 Generated with [Claude Code](https://claude.com/claude-code)