### PR TITLE
[jarvis] Real-time MCP-query glow on the webui-v2 cosmos graph (#1157)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -43,6 +43,8 @@ import {
   pastelAt,
   degreeColor,
   linkPalette,
+  lerpRGBA,
+  JARVIS_GLOW,
 } from "@/lib/graph-colors";
 import { saveLayout, loadLayout, isDegenerateLayout, isLayoutHealthy } from "@/lib/graph-layout-cache";
 import {
@@ -53,6 +55,10 @@ import {
   type NodeSizingConfig,
   type RenderConfig,
 } from "@/store/use-graph-store";
+
+// #1157: a module-stable empty set so an unset highlightedNodeIds prop never
+// creates a new identity each render.
+const EMPTY_HIGHLIGHT: ReadonlySet<string> = new Set();
 
 const SPACE_SIZE = 32768;
 // Fix #1532-3 / #1548-2: a small padding makes the settled graph FILL the
@@ -214,6 +220,19 @@ export interface GraphCanvasProps {
   onNodeClick: (node: GraphNode | null) => void;
   onNodeHover: (node: GraphNode | null) => void;
   onSettled: () => void;
+  /**
+   * #1157 Jarvis: node IDs the most recent MCP tool call touched. The canvas
+   * runs a transient GLOW/PULSE on these nodes (and any edge whose both
+   * endpoints are in the set) that decays to nothing — a real-time view of the
+   * agent working through the graph. Empty set = no glow.
+   */
+  highlightedNodeIds?: ReadonlySet<string>;
+  /**
+   * #1157 Jarvis: monotonic counter bumped on every fresh highlight. A change
+   * (re)starts the glow rAF loop from full intensity, so back-to-back MCP
+   * queries each re-pulse even if the node set overlaps.
+   */
+  highlightEpoch?: number;
   className?: string;
 }
 
@@ -253,6 +272,8 @@ function GraphCanvasInner(
     onNodeClick,
     onNodeHover,
     onSettled,
+    highlightedNodeIds,
+    highlightEpoch = 0,
     className = "",
   }: GraphCanvasProps,
   ref: React.Ref<GraphCanvasHandle>,
@@ -1322,6 +1343,148 @@ function GraphCanvasInner(
   useEffect(() => {
     scheduleLabels();
   }, [hoveredNodeId, scheduleLabels]);
+
+  // ── #1157 Jarvis: transient GLOW/PULSE on MCP-touched nodes + edges ──────────
+  // When the MCP server queries/returns graph entities, the activity SSE stream
+  // (useGraphHighlight) hands us the touched node IDs + a bumped `highlightEpoch`.
+  // We run a short rAF loop that OVERWRITES only the affected entries in the GPU
+  // color/size buffers with a decaying amber pulse, then restores the base
+  // buffers when the pulse ends. This is a pure transient overlay — it never
+  // re-layouts, re-clusters, or moves a single node, so it stays performant on
+  // the 20k-node upvate graph (only the touched indices are rewritten each frame;
+  // a typical MCP result touches a handful to a few dozen nodes).
+  //
+  // Edges: WebUI v2 edges have no synthetic id, so an edge glows when BOTH its
+  // endpoints are in the highlighted node set (resolved against linkData.links,
+  // which is index-based and parallel to the packed link color buffer).
+  const glowRafRef = useRef<number | null>(null);
+  // Stable empty fallback so an undefined prop doesn't thrash the effect deps.
+  const highlightSet = highlightedNodeIds ?? EMPTY_HIGHLIGHT;
+  useEffect(() => {
+    const g = graphRef.current;
+    if (!g) return;
+
+    // Cancel any in-flight glow loop (a new epoch supersedes the previous pulse).
+    if (glowRafRef.current !== null) {
+      cancelAnimationFrame(glowRafRef.current);
+      glowRafRef.current = null;
+    }
+
+    // Resolve the affected NODE indices.
+    const nodeIdxs: number[] = [];
+    for (const id of highlightSet) {
+      const i = idToIdx.get(id);
+      if (i !== undefined) nodeIdxs.push(i);
+    }
+
+    // Resolve the affected EDGE (link) indices: an edge glows when both its
+    // endpoints are highlighted. linkData.links is a flat [src,tgt,...] index
+    // buffer parallel to the per-link color quads.
+    const edgeIdxs: number[] = [];
+    if (nodeIdxs.length > 0) {
+      const hiIdx = new Set(nodeIdxs);
+      const { links } = linkData;
+      for (let li = 0, e = 0; li < links.length; li += 2, e++) {
+        if (hiIdx.has(links[li]) && hiIdx.has(links[li + 1])) edgeIdxs.push(e);
+      }
+    }
+
+    // Nothing to glow (decay finished, or no entity in the current view) →
+    // restore the base buffers so any prior pulse is fully cleared, then stop.
+    if (nodeIdxs.length === 0) {
+      g.setPointColors(packPointColors());
+      g.setPointSizes(packed.sizes);
+      g.setLinkColors(packLinkColors());
+      g.render();
+      return;
+    }
+
+    // Snapshot the BASE buffers once; each frame we re-derive from these so the
+    // pulse blends from the node's real color/size (theme + colorMode aware).
+    const baseColors = packPointColors();
+    const baseSizes = packed.sizes;
+    const baseLinkColors = packLinkColors();
+    const glowColors = new Float32Array(baseColors);
+    const glowSizes = new Float32Array(baseSizes);
+    const glowLinkColors = new Float32Array(baseLinkColors);
+
+    const start = performance.now();
+    // GLOW_MS mirrors useGraphHighlight.DECAY_MS (~1.8s) — kept local so the
+    // canvas has no import cycle with the hook.
+    const GLOW_MS = 1800;
+
+    const frame = (now: number) => {
+      const gg = graphRef.current;
+      if (!gg) return;
+      const t = Math.min(1, (now - start) / GLOW_MS);
+      // Decay envelope: bright instantly, ease out to 0. A gentle 2-beat pulse
+      // rides on top so the glow "breathes" while it fades (the Jarvis feel).
+      const decay = 1 - t * t; // ease-out quadratic → 0 at end
+      const pulse = 0.78 + 0.22 * Math.cos(t * Math.PI * 4); // ~2 beats over the life
+      const intensity = decay * pulse; // 0..1
+
+      // ── nodes: blend base color → amber, and scale size up ──────────────────
+      for (const i of nodeIdxs) {
+        const o = i * 4;
+        const base: RGBA = [
+          baseColors[o] * 255,
+          baseColors[o + 1] * 255,
+          baseColors[o + 2] * 255,
+          baseColors[o + 3],
+        ];
+        // Blend toward amber, force full opacity at the peak so the node pops
+        // even if its base alpha (pointOpacity) is low.
+        const blended = lerpRGBA(base, JARVIS_GLOW, intensity);
+        const a = base[3] + (1 - base[3]) * intensity;
+        writeNormalizedRGBA(glowColors, i, [blended[0], blended[1], blended[2], a]);
+        // Scale the node up to 2.4× at peak for a visible "halo" bloom.
+        glowSizes[i] = baseSizes[i] * (1 + 1.4 * intensity);
+      }
+
+      // ── edges: blend base link color → amber + lift alpha ───────────────────
+      for (const e of edgeIdxs) {
+        const o = e * 4;
+        const base: RGBA = [
+          baseLinkColors[o] * 255,
+          baseLinkColors[o + 1] * 255,
+          baseLinkColors[o + 2] * 255,
+          baseLinkColors[o + 3],
+        ];
+        const blended = lerpRGBA(base, JARVIS_GLOW, intensity);
+        const a = Math.max(base[3], 0.35) + (1 - Math.max(base[3], 0.35)) * intensity;
+        writeNormalizedRGBA(glowLinkColors, e, [blended[0], blended[1], blended[2], a]);
+      }
+
+      gg.setPointColors(glowColors);
+      gg.setPointSizes(glowSizes);
+      if (edgeIdxs.length > 0) gg.setLinkColors(glowLinkColors);
+      gg.render();
+
+      if (t < 1) {
+        glowRafRef.current = requestAnimationFrame(frame);
+      } else {
+        // Pulse done → restore the exact base buffers (clean slate).
+        gg.setPointColors(baseColors);
+        gg.setPointSizes(baseSizes);
+        gg.setLinkColors(baseLinkColors);
+        gg.render();
+        glowRafRef.current = null;
+      }
+    };
+    glowRafRef.current = requestAnimationFrame(frame);
+
+    return () => {
+      if (glowRafRef.current !== null) {
+        cancelAnimationFrame(glowRafRef.current);
+        glowRafRef.current = null;
+      }
+    };
+    // Re-run on each fresh highlight (epoch) — NOT on every set identity churn.
+    // packPointColors/packLinkColors/packed are stable between data/theme pushes;
+    // when those change the data-push / recolor effects re-assert the base
+    // buffers, and the next epoch restarts the glow from the new base.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [highlightEpoch]);
 
   // ── Fix #1548-3: camera snapshot / restore for ego focus enter / exit ─────────
   // cosmos.gl exposes no public pan setter, so we capture (a) the zoom level and

--- a/webui-v2/src/components/graph/mcp-activity-overlay.tsx
+++ b/webui-v2/src/components/graph/mcp-activity-overlay.tsx
@@ -1,0 +1,185 @@
+/* ============================================================
+   components/graph/mcp-activity-overlay.tsx — Jarvis MCP activity surface.
+
+   A subtle, in-canvas affordance for the real-time MCP-query glow (#1157):
+     • A small "pulse badge" (bottom-right of the canvas) showing the SSE
+       connection state, a live-pulsing dot while a query is active, and the
+       running query count. Click it to open the log.
+     • A toggle in the badge menu to turn the whole overlay (and the glow)
+       on/off — default ON.
+     • A slide-out log panel listing the last 50 MCP events (time / tool /
+       node count) with a "replay" button that re-triggers the glow.
+
+   Ported + restyled to WebUI v2 tokens from the deleted v1 dashboard overlay
+   (#1232). Theme-aware via the same surface/border/text tokens the rest of v2
+   uses, so it follows the dark/light toggle automatically.
+   ============================================================ */
+
+import { memo, useCallback, useEffect, useRef, useState } from "react";
+import { Activity, RefreshCw, X } from "lucide-react";
+import type { MCPActivityEvent } from "@/hooks/use-mcp-activity";
+
+function formatTs(ts: number): string {
+  const d = new Date(ts);
+  const p = (n: number) => n.toString().padStart(2, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}:${p(d.getSeconds())}`;
+}
+
+const shortTool = (t: string) => t.replace(/^archigraph_/, "");
+
+function nodeCount(ev: MCPActivityEvent): number {
+  return (ev.returned_node_ids?.length ?? 0) + (ev.returned_edge_ids?.length ?? 0);
+}
+
+export interface MCPActivityOverlayProps {
+  enabled: boolean;
+  connected: boolean;
+  isActive: boolean;
+  totalCount: number;
+  eventLog: MCPActivityEvent[];
+  onToggle: (enabled: boolean) => void;
+  onReplay: (event: MCPActivityEvent) => void;
+}
+
+export const MCPActivityOverlay = memo(function MCPActivityOverlay({
+  enabled,
+  connected,
+  isActive,
+  totalCount,
+  eventLog,
+  onToggle,
+  onReplay,
+}: MCPActivityOverlayProps) {
+  const [panelOpen, setPanelOpen] = useState(false);
+  const logRef = useRef<HTMLDivElement>(null);
+
+  // Escape closes the panel.
+  useEffect(() => {
+    if (!panelOpen) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.stopPropagation();
+        setPanelOpen(false);
+      }
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [panelOpen]);
+
+  // Keep the log scrolled to the newest entry.
+  useEffect(() => {
+    if (panelOpen && logRef.current) logRef.current.scrollTop = logRef.current.scrollHeight;
+  }, [eventLog.length, panelOpen]);
+
+  const toggleEnabled = useCallback(() => onToggle(!enabled), [enabled, onToggle]);
+
+  // ── badge state ──────────────────────────────────────────────────────────
+  const dotClass = !enabled
+    ? "bg-text-4"
+    : isActive
+      ? "bg-amber-400"
+      : connected
+        ? "bg-emerald-400"
+        : "bg-text-4";
+  const label = !enabled
+    ? "MCP activity overlay off"
+    : isActive
+      ? "MCP query active"
+      : connected
+        ? `MCP activity connected — ${totalCount} ${totalCount === 1 ? "query" : "queries"}`
+        : "MCP activity stream disconnected";
+
+  return (
+    <div className="absolute bottom-3 right-24 z-30 flex flex-col items-end gap-1.5">
+      {/* ── slide-out log panel ─────────────────────────────────────────── */}
+      {panelOpen && enabled ? (
+        <div
+          className="mb-1 w-72 overflow-hidden rounded-lg border border-border bg-surface/95 shadow-lg backdrop-blur-sm"
+          data-testid="mcp-activity-panel"
+        >
+          <div className="flex items-center justify-between border-b border-border px-3 py-2">
+            <span className="flex items-center gap-1.5 text-xs font-semibold text-text-2">
+              <Activity size={12} className="text-amber-400" /> MCP activity
+            </span>
+            <button
+              onClick={() => setPanelOpen(false)}
+              aria-label="Close MCP activity log"
+              className="rounded p-0.5 text-text-3 hover:text-text"
+            >
+              <X size={13} />
+            </button>
+          </div>
+          <div ref={logRef} className="max-h-64 overflow-y-auto">
+            {eventLog.length === 0 ? (
+              <p className="px-3 py-4 text-center text-xs text-text-4">
+                No MCP queries yet. Run an archigraph MCP tool and watch the graph glow.
+              </p>
+            ) : (
+              eventLog.map((ev, i) => (
+                <div
+                  key={`${ev.timestamp}-${i}`}
+                  className="flex items-center gap-2 border-b border-border/50 px-3 py-1.5 text-xs last:border-0"
+                  data-testid="mcp-activity-entry"
+                >
+                  <span className="font-mono tabular-nums text-text-4">{formatTs(ev.timestamp)}</span>
+                  <span className="min-w-0 flex-1 truncate font-medium text-text-2">
+                    {shortTool(ev.tool_name)}
+                  </span>
+                  {nodeCount(ev) > 0 ? (
+                    <span className="tabular-nums text-text-3">{nodeCount(ev)}</span>
+                  ) : null}
+                  <button
+                    onClick={() => onReplay(ev)}
+                    aria-label="Replay this query's glow"
+                    title="Replay glow"
+                    className="rounded p-0.5 text-text-3 hover:text-amber-400"
+                    disabled={nodeCount(ev) === 0}
+                  >
+                    <RefreshCw size={11} />
+                  </button>
+                </div>
+              ))
+            )}
+          </div>
+          <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
+            <span className="text-[11px] text-text-4">Glow on MCP query</span>
+            <button
+              onClick={toggleEnabled}
+              role="switch"
+              aria-checked={enabled}
+              aria-label="Toggle MCP activity glow"
+              className={`relative h-4 w-7 rounded-full transition-colors ${
+                enabled ? "bg-accent" : "bg-surface-2"
+              }`}
+            >
+              <span
+                className={`absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform ${
+                  enabled ? "translate-x-3.5" : "translate-x-0.5"
+                }`}
+              />
+            </button>
+          </div>
+        </div>
+      ) : null}
+
+      {/* ── pulse badge ─────────────────────────────────────────────────── */}
+      <button
+        type="button"
+        onClick={() => (enabled ? setPanelOpen((p) => !p) : toggleEnabled())}
+        aria-label={label}
+        title={label}
+        data-testid="mcp-activity-badge"
+        className="flex items-center gap-1.5 rounded-md border border-border bg-surface/85 px-2 py-1 text-[11px] font-semibold tracking-wide text-text-2 backdrop-blur-sm transition-colors hover:bg-surface-2"
+        style={isActive ? { boxShadow: "0 0 8px rgba(255,176,59,0.45)" } : undefined}
+      >
+        <span
+          aria-hidden
+          data-testid="mcp-activity-dot"
+          className={`h-1.5 w-1.5 rounded-full ${dotClass} ${isActive ? "animate-pulse" : ""}`}
+        />
+        <Activity size={11} aria-hidden className={enabled ? "" : "opacity-40"} />
+        <span className="tabular-nums">{enabled ? (totalCount > 0 ? totalCount : "MCP") : "off"}</span>
+      </button>
+    </div>
+  );
+});

--- a/webui-v2/src/hooks/use-graph-highlight.ts
+++ b/webui-v2/src/hooks/use-graph-highlight.ts
@@ -1,0 +1,171 @@
+/* ============================================================
+   hooks/use-graph-highlight.ts — Jarvis MCP-query glow (#1157).
+
+   Subscribes to useMCPActivity and exposes the node IDs the most recent MCP
+   tool call touched, with a decay timer. The graph canvas reads
+   `highlightedNodeIds` (and resolves the incident edges itself, since WebUI v2
+   edges are keyed by endpoint, not by a synthetic edge id) and runs a transient
+   GLOW/PULSE animation that fades over ~DECAY_MS — a "Jarvis" effect showing the
+   agent working through the graph in real time.
+
+   Ported + adapted from the deleted v1 dashboard hook (#1232). Differences:
+     • v2 edges have no `id`; the backend's returned_edge_ids are endpoint IDs,
+       so we fold them into the highlighted NODE set and let the canvas light any
+       edge whose BOTH endpoints are highlighted. This is more robust than
+       matching opaque edge ids and needs no Go change.
+     • Bursts (multiple tools in quick succession) UNION their nodes within a
+       short window so a multi-tool agent step glows as one coherent sweep,
+       rather than each event clobbering the last.
+
+   Interface:
+     • highlightedNodeIds — Set<string> currently glowing (union of recent events)
+     • epoch              — bumps on every new highlight (canvas restarts its rAF)
+     • isActive           — true while a glow is decaying
+     • enabled / setEnabled — toggle the SSE subscription + glow
+     • sseConnected, latestEvent, eventLog, totalCount — activity stream state
+     • replay(event)      — re-trigger the glow for a historical log entry
+   ============================================================ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { useMCPActivity, type MCPActivityEvent } from "./use-mcp-activity";
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/** How long a glow takes to fully fade (ms). Owner spec: ~1–2s. */
+export const DECAY_MS = 1800;
+/** Bursts within this window UNION into one glow rather than replacing it. */
+const BURST_WINDOW_MS = 350;
+const EMPTY_SET: ReadonlySet<string> = new Set();
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+export interface GraphHighlightState {
+  /** Node IDs currently glowing (empty = nothing active). */
+  highlightedNodeIds: ReadonlySet<string>;
+  /**
+   * Monotonic counter bumped on every fresh highlight. The canvas watches this
+   * to (re)start its rAF glow loop without re-subscribing to set identity.
+   */
+  epoch: number;
+  /** Whether a glow is currently decaying. */
+  isActive: boolean;
+  /** agent_id of the latest event (reserved for per-agent tinting). */
+  agentId: string | null;
+  /** Whether the overlay (and SSE subscription) is enabled. */
+  enabled: boolean;
+  /** Whether the SSE stream is connected. */
+  sseConnected: boolean;
+  /** Raw latest event for the activity badge/log. */
+  latestEvent: MCPActivityEvent | null;
+  /** Rolling last-50 event log. */
+  eventLog: MCPActivityEvent[];
+  /** Total MCP queries since mount. */
+  totalCount: number;
+}
+
+export interface GraphHighlightControls {
+  /** Toggle the overlay + SSE subscription on/off. */
+  setEnabled: (enabled: boolean) => void;
+  /** Re-trigger the glow from a historical log entry. */
+  replay: (event: MCPActivityEvent) => void;
+}
+
+export type UseGraphHighlightReturn = GraphHighlightState & GraphHighlightControls;
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+export function useGraphHighlight(): UseGraphHighlightReturn {
+  const [enabled, setEnabledState] = useState(true);
+  const [nodeIds, setNodeIds] = useState<ReadonlySet<string>>(EMPTY_SET);
+  const [epoch, setEpoch] = useState(0);
+  const [agentId, setAgentId] = useState<string | null>(null);
+
+  const decayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const lastTriggerRef = useRef(0);
+
+  const activity = useMCPActivity(enabled);
+
+  const clear = useCallback(() => {
+    if (decayTimerRef.current) {
+      clearTimeout(decayTimerRef.current);
+      decayTimerRef.current = null;
+    }
+    setNodeIds(EMPTY_SET);
+    setAgentId(null);
+  }, []);
+
+  /**
+   * Apply a glow over `ids`. Within BURST_WINDOW_MS of the previous trigger we
+   * UNION (a multi-tool agent step glows as one sweep); otherwise we replace.
+   */
+  const applyGlow = useCallback((ids: string[], agent: string | null) => {
+    if (ids.length === 0) return;
+    const now = Date.now();
+    const burst = now - lastTriggerRef.current < BURST_WINDOW_MS;
+    lastTriggerRef.current = now;
+
+    setNodeIds((prev) => {
+      const next = new Set(burst ? prev : EMPTY_SET);
+      for (const id of ids) next.add(id);
+      return next;
+    });
+    setAgentId(agent);
+    // Bump epoch so the canvas (re)starts the rAF glow from full intensity.
+    setEpoch((e) => e + 1);
+
+    if (decayTimerRef.current) clearTimeout(decayTimerRef.current);
+    decayTimerRef.current = setTimeout(() => {
+      setNodeIds(EMPTY_SET);
+      setAgentId(null);
+      decayTimerRef.current = null;
+    }, DECAY_MS);
+  }, []);
+
+  const replay = useCallback(
+    (event: MCPActivityEvent) => {
+      const ids = [
+        ...(event.returned_node_ids ?? []),
+        // v2: edge ids are endpoint ids — fold into the node set so the canvas
+        // lights any edge whose both endpoints are highlighted.
+        ...(event.returned_edge_ids ?? []),
+      ];
+      applyGlow(ids, event.agent_id ?? null);
+    },
+    [applyGlow],
+  );
+
+  const setEnabled = useCallback(
+    (next: boolean) => {
+      setEnabledState(next);
+      if (!next) clear();
+    },
+    [clear],
+  );
+
+  // React to incoming SSE events (reference-change guarded).
+  const lastEventRef = useRef<MCPActivityEvent | null>(null);
+  useEffect(() => {
+    const ev = activity.latestEvent;
+    if (!ev || ev === lastEventRef.current) return;
+    lastEventRef.current = ev;
+    replay(ev);
+  }, [activity.latestEvent, replay]);
+
+  useEffect(() => () => {
+    if (decayTimerRef.current) clearTimeout(decayTimerRef.current);
+  }, []);
+
+  return {
+    highlightedNodeIds: nodeIds,
+    epoch,
+    isActive: nodeIds.size > 0,
+    agentId,
+    enabled,
+    sseConnected: activity.connected,
+    latestEvent: activity.latestEvent,
+    eventLog: activity.eventLog,
+    totalCount: activity.totalCount,
+    setEnabled,
+    replay,
+  };
+}

--- a/webui-v2/src/hooks/use-mcp-activity.ts
+++ b/webui-v2/src/hooks/use-mcp-activity.ts
@@ -1,0 +1,126 @@
+/* ============================================================
+   hooks/use-mcp-activity.ts — SSE subscription to the MCP activity stream.
+
+   Ported to WebUI v2 from the (deleted) v1 dashboard Jarvis surface
+   (#1157 phases 1+2, originally #1232). The Go backend
+   (internal/dashboard/handlers_mcp_activity.go + internal/mcp/activity*.go)
+   survives unchanged on main, so this hook simply re-subscribes to the same
+   GET /api/mcp-activity/stream SSE endpoint via the Vite /api proxy.
+
+   Lifecycle:
+     • Opens an EventSource when `enabled` is true (default).
+     • Reconnects automatically on transient errors (browser-native ES).
+     • Closes + cleans up on unmount or when toggled off.
+     • Exposes the last event, a rolling log (last MAX_LOG), and a count.
+
+   The graph canvas uses `latestEvent` to drive the Jarvis glow/pulse.
+   ============================================================ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+/**
+ * Wire shape of a single MCP tool-call event from /api/mcp-activity/stream.
+ * Mirrors internal/mcp.MCPActivityEvent in Go.
+ */
+export interface MCPActivityEvent {
+  tool_name: string;
+  query_args?: Record<string, unknown>;
+  returned_node_ids?: string[];
+  returned_edge_ids?: string[];
+  agent_id?: string;
+  timestamp: number;
+}
+
+export interface MCPActivityState {
+  /** Whether the SSE connection is open. */
+  connected: boolean;
+  /** The most recent event received (null = none yet). */
+  latestEvent: MCPActivityEvent | null;
+  /** Rolling log of the last MAX_LOG events, newest last. */
+  eventLog: MCPActivityEvent[];
+  /** Count of events received since mount. */
+  totalCount: number;
+}
+
+export interface UseMCPActivityReturn extends MCPActivityState {
+  /** Clear the event log and reset counters. */
+  clear: () => void;
+}
+
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+const SSE_URL = "/api/mcp-activity/stream";
+const MAX_LOG = 50;
+
+const INITIAL_STATE: MCPActivityState = {
+  connected: false,
+  latestEvent: null,
+  eventLog: [],
+  totalCount: 0,
+};
+
+// ── Hook ──────────────────────────────────────────────────────────────────────
+
+/**
+ * @param enabled - When false, no EventSource is opened (toggle support).
+ *                  Defaults to true so the canvas subscribes when mounted.
+ */
+export function useMCPActivity(enabled = true): UseMCPActivityReturn {
+  const [state, setState] = useState<MCPActivityState>(INITIAL_STATE);
+  const esRef = useRef<EventSource | null>(null);
+
+  const clear = useCallback(() => setState(INITIAL_STATE), []);
+
+  useEffect(() => {
+    if (!enabled) {
+      esRef.current?.close();
+      esRef.current = null;
+      setState((prev) => ({ ...prev, connected: false }));
+      return;
+    }
+
+    const es = new EventSource(SSE_URL);
+    esRef.current = es;
+
+    es.addEventListener("connected", () => {
+      setState((prev) => ({ ...prev, connected: true }));
+    });
+
+    es.addEventListener("activity", (ev: MessageEvent) => {
+      try {
+        const event: MCPActivityEvent = JSON.parse(ev.data as string);
+        setState((prev) => {
+          const log = [...prev.eventLog, event];
+          if (log.length > MAX_LOG) log.splice(0, log.length - MAX_LOG);
+          return {
+            connected: true,
+            latestEvent: event,
+            eventLog: log,
+            totalCount: prev.totalCount + 1,
+          };
+        });
+      } catch {
+        // Malformed JSON — ignore.
+      }
+    });
+
+    es.addEventListener("heartbeat", () => {
+      setState((prev) => (prev.connected ? prev : { ...prev, connected: true }));
+    });
+
+    es.onerror = () => {
+      if (es.readyState === EventSource.CLOSED) {
+        setState((prev) => ({ ...prev, connected: false }));
+      }
+    };
+
+    return () => {
+      es.close();
+      esRef.current = null;
+    };
+  }, [enabled]);
+
+  return { ...state, clear };
+}

--- a/webui-v2/src/lib/graph-colors.ts
+++ b/webui-v2/src/lib/graph-colors.ts
@@ -171,3 +171,26 @@ export function linkPalette(isDark: boolean): LinkPalette {
 export const SAME_REPO_EDGE: RGBA = [71, 85, 105, 1];
 /** Highlighted (focused-neighbor) edge color — amber. */
 export const HIGHLIGHT_EDGE: RGBA = [251, 146, 60, 1];
+
+/**
+ * Jarvis MCP-query glow color (#1157). A warm amber that pops in BOTH themes
+ * against the repo/community pastels and the slate edge mesh, so a node/edge the
+ * MCP agent just touched visibly lights up before fading. Same hue as
+ * HIGHLIGHT_EDGE for consistency, lifted slightly for the additive glow blend.
+ */
+export const JARVIS_GLOW: RGBA = [255, 176, 59, 1];
+
+/**
+ * Linear-interpolate between two RGBA colors. t in [0,1]. Alpha lerps too.
+ * Used by the canvas glow loop to blend a node's base color toward the Jarvis
+ * amber at the current pulse intensity.
+ */
+export function lerpRGBA(a: RGBA, b: RGBA, t: number): RGBA {
+  const x = Math.max(0, Math.min(1, t));
+  return [
+    a[0] + (b[0] - a[0]) * x,
+    a[1] + (b[1] - a[1]) * x,
+    a[2] + (b[2] - a[2]) * x,
+    a[3] + (b[3] - a[3]) * x,
+  ];
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -27,6 +27,8 @@ import type { GraphCanvasHandle } from "@/components/graph/graph-canvas";
 import { NodeInspector } from "@/components/graph/node-inspector";
 import { FiltersDrawer } from "@/components/graph/filters-drawer";
 import { CommunitiesPopover } from "@/components/graph/communities-popover";
+import { MCPActivityOverlay } from "@/components/graph/mcp-activity-overlay";
+import { useGraphHighlight } from "@/hooks/use-graph-highlight";
 
 const COLOR_MODES: { id: ColorMode; label: string }[] = [
   { id: "repo", label: "Repo" },
@@ -46,6 +48,10 @@ export default function GraphScreen() {
 
   const searchRef = useRef<HTMLInputElement>(null);
   const canvasRef = useRef<GraphCanvasHandle>(null);
+
+  // #1157 Jarvis: subscribe to the MCP activity SSE stream and derive the
+  // transient glow set + epoch the canvas animates. Default ON.
+  const jarvis = useGraphHighlight();
 
   // ── ?node= deep-link: restore on mount, persist on selection change ──────────
   // On first render, if the URL carries ?node=<id>, apply it as the selected
@@ -351,8 +357,21 @@ export default function GraphScreen() {
                 onNodeClick={onNodeClick}
                 onNodeHover={(n) => s.setHoveredNode(n?.id ?? null)}
                 onSettled={() => {}}
+                highlightedNodeIds={jarvis.enabled ? jarvis.highlightedNodeIds : undefined}
+                highlightEpoch={jarvis.epoch}
               />
             </Suspense>
+
+            {/* #1157 Jarvis: MCP activity badge + log + on/off toggle. */}
+            <MCPActivityOverlay
+              enabled={jarvis.enabled}
+              connected={jarvis.sseConnected}
+              isActive={jarvis.isActive}
+              totalCount={jarvis.totalCount}
+              eventLog={jarvis.eventLog}
+              onToggle={jarvis.setEnabled}
+              onReplay={jarvis.replay}
+            />
 
             {/* Fix #1548-3: clear "focused on X — exit" affordance. */}
             {focusActive ? (


### PR DESCRIPTION
Fixes #1157

## 1. What & why
The "Jarvis" effect: when the MCP server queries / returns graph entities, those nodes (and their incident edges) **glow/pulse amber for ~1.8s then fade** on the embedded webui-v2 cosmos graph — a real-time view of the agent working through the graph. v1 phases 1+2 (#1222/#1230/#1232) shipped this in the now-deleted v1 `dashboard/`; this re-implements it on the webui-v2 cosmos.gl canvas.

## 2. Approach
**Frontend-only.** The Go backend survived the v1 `dashboard/` deletion intact on `main` — `internal/mcp/activity.go` + `activity_log.go`, `internal/dashboard/handlers_mcp_activity.go`, and the registered `GET /api/mcp-activity/{stream,history}` routes — so **no Go/SSE change was required**. webui-v2 simply re-subscribes to the existing SSE endpoint via the Vite `/api` proxy.

The glow is a **pure transient overlay**: an rAF loop rewrites only the MCP-touched indices in the GPU color/size buffers and restores the base buffers when the pulse ends. It never re-layouts, re-clusters, or moves a node, so it stays performant on the 20k-node upvate graph (a typical MCP result touches a handful to a few dozen nodes).

## 3. Changes
- `webui-v2/src/hooks/use-mcp-activity.ts` (new) — EventSource hook for `/api/mcp-activity/stream` (connected/activity/heartbeat), rolling 50-event log + count. Ported from v1.
- `webui-v2/src/hooks/use-graph-highlight.ts` (new) — derives the glow node set + monotonic `epoch` from the stream, ~1.8s decay, burst-union (a multi-tool agent step glows as one sweep). v2 edges have no synthetic id, so the backend's `returned_edge_ids` (endpoint ids) fold into the node set and the canvas lights any edge whose **both** endpoints are highlighted — robust + no Go change.
- `webui-v2/src/components/graph/graph-canvas.tsx` — new `highlightedNodeIds` + `highlightEpoch` props; rAF glow loop (blend base color → amber, scale node up to 2.4×, lift edge alpha) with an ease-out + 2-beat pulse envelope; restores base buffers on finish.
- `webui-v2/src/components/graph/mcp-activity-overlay.tsx` (new) — subtle pulse badge (connection dot + count) bottom-right, slide-out log panel (time/tool/count + replay), on/off toggle (default ON), theme-aware via v2 tokens, Escape closes.
- `webui-v2/src/lib/graph-colors.ts` — `JARVIS_GLOW` amber + `lerpRGBA` helper.
- `webui-v2/src/routes/graph.tsx` — wires `useGraphHighlight` into the canvas + renders the overlay.

## 4. Verification
Read-only against the **live :47274 daemon** via a dev server on :47299 (`AG_API_TARGET=http://localhost:47274`), group `polyglot-platform` (1320 nodes, LOD HIGH):
- SSE connects to the live broker ("MCP activity connected").
- A real-shaped MCP activity event carrying **real in-view node ids** glows the corresponding nodes/edges then fades. (Delivered via a Playwright SSE mock: the live MCP server process publishes to the on-disk activity log, not this run's in-process SSE broker, so a route mock was the faithful way to feed a real event into the app's `useMCPActivity`.)
- **WebGL `readPixels` amber-pixel probe:** 0 baseline → ~5500 (light) / ~2300 (dark) at peak → back to 0 by ~1.3–2s. Decay curve shows the 2-beat pulse.
- Toggle off→"off", click re-enables; replay re-fires; Escape closes panel.
- `npm run build` + `tsc --noEmit` clean. 0 console errors (both themes).

Screenshots (light peak, dark peak, faded) captured locally; glow bloom clearly visible center-left in both themes with the activity panel open.

## 5. Risk & rollback
Low. Additive frontend only; default-ON but a single toggle disables it (closing the EventSource). If the SSE endpoint is unavailable the badge shows "disconnected" and nothing else changes. Revert = drop this branch.

## 6. Out of scope / follow-ups
- Per-agent color tinting (the `agent_id` field is plumbed but the glow is a single amber hue for now).
- No Go change; if a future need arises to glow from the disk log when the MCP server runs out-of-process, a minimal SSE tail could be added — not needed here.
- `dashboard/` + all Go: **zero diff**. Live :47274 daemon **not restarted/touched**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)