### PR TITLE
[MCP] Make empty-edge results a first-class signal to prevent agent fabrication (#1618)

### DIFF
--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -136,14 +136,23 @@ func (s *Server) handleFindCallers(_ context.Context, req mcpapi.CallToolRequest
 		if root != nil {
 			rootName = root.Name
 		}
-		return jsonResult(map[string]any{
+		// #1618: distinguish "entity found, zero callers" from "entity not found".
+		// An empty callers array with result="no_incoming_edges" is an explicit
+		// graph signal — agents MUST NOT infer a plausible relationship to fill
+		// the gap. Report the absence verbatim.
+		result := map[string]any{
 			"entity_id":   prefixedID(r.Repo, target),
 			"entity_name": rootName,
 			"repo":        r.Repo,
 			"depth":       depth,
 			"callers":     callers,
 			"count":       len(callers),
-		}), nil
+		}
+		if len(callers) == 0 {
+			result["result"] = "no_incoming_edges"
+			result["note"] = "Graph shows no callers for this entity within the requested depth. Do not infer a relationship — report the absence."
+		}
+		return jsonResult(result), nil
 	}
 	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
 }
@@ -255,14 +264,23 @@ func (s *Server) handleFindCallees(_ context.Context, req mcpapi.CallToolRequest
 		if root != nil {
 			rootName = root.Name
 		}
-		return jsonResult(map[string]any{
+		// #1618: distinguish "entity found, zero callees" from "entity not found".
+		// An empty callees array with result="no_outgoing_edges" is an explicit
+		// graph signal — agents MUST NOT infer a plausible relationship to fill
+		// the gap. Report the absence verbatim.
+		result := map[string]any{
 			"entity_id":   prefixedID(r.Repo, target),
 			"entity_name": rootName,
 			"repo":        r.Repo,
 			"depth":       depth,
 			"callees":     callees,
 			"count":       len(callees),
-		}), nil
+		}
+		if len(callees) == 0 {
+			result["result"] = "no_outgoing_edges"
+			result["note"] = "Graph shows no callees for this entity. Do not infer a relationship — report the absence."
+		}
+		return jsonResult(result), nil
 	}
 	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
 }

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -192,6 +192,47 @@ func TestFindCallers_NoCallers(t *testing.T) {
 	}
 }
 
+// TestFindCallers_NoEdgeSignal verifies that when an entity is found but has no
+// callers, the response carries the explicit no-edge signal (#1618).
+func TestFindCallers_NoEdgeSignal(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+	})
+	// "result" field must be present and set to "no_incoming_edges".
+	res, ok := out["result"].(string)
+	if !ok {
+		t.Fatalf("expected string 'result' field in no-caller response, got %T: %v", out["result"], out["result"])
+	}
+	if res != "no_incoming_edges" {
+		t.Errorf("expected result=no_incoming_edges, got %q", res)
+	}
+	// "note" field must be present and non-empty.
+	note, ok := out["note"].(string)
+	if !ok || note == "" {
+		t.Errorf("expected non-empty 'note' field in no-caller response")
+	}
+}
+
+// TestFindCallers_WithCallersNoSignal verifies that the no-edge signal is NOT
+// present when callers are found (#1618 regression guard).
+func TestFindCallers_WithCallersNoSignal(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncB has 1 caller (FuncA) — result field must NOT be set.
+	out := callFlowTool(t, srv.handleFindCallers, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+	})
+	if _, hasResult := out["result"]; hasResult {
+		t.Errorf("expected no 'result' field when callers are present, got %v", out["result"])
+	}
+}
+
 // ---------------------------------------------------------------------------
 // TestFindCallees
 // ---------------------------------------------------------------------------
@@ -245,6 +286,48 @@ func TestFindCallees_LeafReturnsEmpty(t *testing.T) {
 	callees := out["callees"].([]any)
 	if len(callees) != 0 {
 		t.Errorf("expected 0 callees for leaf, got %d", len(callees))
+	}
+}
+
+// TestFindCallees_NoEdgeSignal verifies that when an entity is found but has no
+// callees, the response carries the explicit no-edge signal (#1618).
+func TestFindCallees_NoEdgeSignal(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncC is a leaf — no outbound edges.
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "ent-c",
+		"depth":     float64(1),
+	})
+	// "result" field must be present and set to "no_outgoing_edges".
+	res, ok := out["result"].(string)
+	if !ok {
+		t.Fatalf("expected string 'result' field in no-callee response, got %T: %v", out["result"], out["result"])
+	}
+	if res != "no_outgoing_edges" {
+		t.Errorf("expected result=no_outgoing_edges, got %q", res)
+	}
+	// "note" field must be present and non-empty.
+	note, ok := out["note"].(string)
+	if !ok || note == "" {
+		t.Errorf("expected non-empty 'note' field in no-callee response")
+	}
+}
+
+// TestFindCallees_WithCalleesNoSignal verifies that the no-edge signal is NOT
+// present when callees are found (#1618 regression guard).
+func TestFindCallees_WithCalleesNoSignal(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA calls FuncB — result field must NOT be set.
+	out := callFlowTool(t, srv.handleFindCallees, map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+	})
+	if _, hasResult := out["result"]; hasResult {
+		t.Errorf("expected no 'result' field when callees are present, got %v", out["result"])
 	}
 }
 
@@ -508,5 +591,76 @@ func TestImpactRiskScore_WithCoverage(t *testing.T) {
 	scoreUncovered := impactRiskScore(eUncovered, 0)
 	if scoreCovered >= scoreUncovered {
 		t.Errorf("covered entity (%v) should score lower than uncovered (%v)", scoreCovered, scoreUncovered)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TestExpand_NoEdgeSignal (#1618)
+// ---------------------------------------------------------------------------
+
+// buildIsolatedDoc builds a single entity with no edges.
+func buildIsolatedDoc() *graph.Document {
+	return minDoc(
+		[]graph.Entity{
+			{ID: "iso-1", Name: "IsolatedFunc", Kind: "Function", SourceFile: "iso.go", StartLine: 1},
+		},
+		[]graph.Relationship{},
+	)
+}
+
+// TestExpand_NoEdgeSignal verifies that archigraph_expand returns the explicit
+// no-edge signal when the entity is found but has zero neighbours (#1618).
+func TestExpand_NoEdgeSignal(t *testing.T) {
+	doc := buildIsolatedDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	out := callFlowTool(t, srv.handleGetNeighbors, map[string]any{
+		"node": "iso-1",
+	})
+	if out == nil {
+		t.Fatal("expected JSON response, got nil")
+	}
+	res, ok := out["result"].(string)
+	if !ok {
+		t.Fatalf("expected string 'result' field in no-edge response, got %T: %v", out["result"], out["result"])
+	}
+	if res != "no_edges" {
+		t.Errorf("expected result=no_edges, got %q", res)
+	}
+	note, ok := out["note"].(string)
+	if !ok || note == "" {
+		t.Errorf("expected non-empty 'note' field in no-edge response")
+	}
+	count, ok := out["count"].(float64)
+	if !ok || count != 0 {
+		t.Errorf("expected count=0, got %v", out["count"])
+	}
+}
+
+// TestExpand_WithEdgesNoSignal verifies that the no-edge signal is NOT present
+// when the entity has neighbours (#1618 regression guard).
+func TestExpand_WithEdgesNoSignal(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	// FuncA has an outbound edge to FuncB — no no-edge signal expected.
+	// handleGetNeighbors returns a flat array for the non-empty case, which
+	// does not decode to map[string]any. We just verify it's not an error and
+	// does not contain result=no_edges.
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"node": "ent-a"}
+	res, err := srv.handleGetNeighbors(nil, req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res.IsError {
+		t.Fatalf("unexpected tool error: %v", res.Content)
+	}
+	for _, c := range res.Content {
+		if tc, ok := c.(mcpapi.TextContent); ok {
+			if strings.Contains(tc.Text, `"result"`) && strings.Contains(tc.Text, `"no_edges"`) {
+				t.Errorf("no_edges signal must not appear when edges exist: %s", tc.Text)
+			}
+		}
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -667,6 +667,20 @@ func (s *Server) handleGetNeighbors(ctx context.Context, req mcpapi.CallToolRequ
 			})
 		}
 	}
+	// #1618: explicit no-edge signal when the entity was found but has zero
+	// graph neighbours. Agents MUST NOT infer relationships from an empty
+	// result — report the absence verbatim.
+	if len(out) == 0 {
+		return jsonResult(map[string]any{
+			"node_id":   prefixedID(startRepo.Repo, start.ID),
+			"label":     start.Name,
+			"repo":      startRepo.Repo,
+			"neighbors": []any{},
+			"count":     0,
+			"result":    "no_edges",
+			"note":      "Graph shows no neighbours for this entity. Do not infer a relationship — report the absence.",
+		}), nil
+	}
 	return jsonResult(out), nil
 }
 

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -267,14 +267,22 @@ func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolReques
 				"steps":       steps,
 			})
 		}
-		return jsonResult(map[string]any{
+		// #1618: explicit no-edge signal when the entity was found but BFS
+		// yielded no call chains. Agents MUST NOT infer a plausible flow —
+		// report the absence verbatim.
+		result := map[string]any{
 			"entry_point_id": prefixedID(r.Repo, entryEnt.ID),
 			"repo":           r.Repo,
 			"max_depth":      maxDepth,
 			"branching":      branch,
 			"chains":         out,
 			"count":          len(out),
-		}), nil
+		}
+		if len(out) == 0 {
+			result["result"] = "no_outgoing_calls"
+			result["note"] = "Graph shows no outgoing CALLS edges from this entity. Do not infer a flow — report the absence."
+		}
+		return jsonResult(result), nil
 	}
 	return mcpapi.NewToolResultError("entry_point_id not found in any loaded repo"), nil
 }

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -89,6 +89,14 @@ Until #769 lands, `archigraph_traces` returns chains that stay within a single r
 
 When you find entities of kind `Queue` (generic message broker abstraction, e.g., RabbitMQ, SQS, Google Pub-Sub) or `MessageTopic` (Kafka-specific topic), treat them as message destinations and document them in the event-flows section rather than the data-model section. Note the distinction: `Queue` is a broker-agnostic concept, while `MessageTopic` is Kafka-specific.
 
+**Empty-result rule (#1618 — the top quality failure).** When `archigraph_find_callees`, `archigraph_find_callers`, `archigraph_expand`, or `archigraph_traces(action=follow)` returns an empty edge list for a valid entity, the response carries `"result": "no_outgoing_edges"` / `"no_incoming_edges"` / `"no_edges"` / `"no_outgoing_calls"`. This is an explicit graph signal, not a gap to fill.
+
+Required behaviour:
+- **State the absence verbatim**: "The graph records no callee/edge for `X`."
+- **Never** infer a plausible relationship from training data, context, or naming convention to fill the gap. Confident fabrication ("create() does an ORM save", "store calls LoginSerializer") is the most common quality failure and the hardest to catch after the fact.
+- If you suspect an extraction gap (the connection may exist in code but was not indexed), say so explicitly and mark it unverified — do not state it as fact.
+- A `result` field on a traversal response means: **the entity was found, the graph was queried, nothing was returned.** This is different from `entity not found` (which is an error).
+
 ### Step 3 — Pull source where needed
 
 Within your `source_snippets` budget, use `archigraph_get_source(node_id=<id>, context_lines=20)` for entities whose intent is unclear from name + neighbors alone. Quote at most ~10 lines per snippet in the doc; reference the file path in backticks.

--- a/skills/using-archigraph/SKILL.md
+++ b/skills/using-archigraph/SKILL.md
@@ -485,7 +485,51 @@ archigraph_expand(node="PaymentService.charge", depth=1)  # direct neighbours in
 
 ---
 
-## 6. Anti-patterns
+## 6. Empty-result contract — never fabricate edges
+
+**The top quality failure** in archigraph-assisted analysis is confident fabrication:
+an agent invents a plausible relationship (e.g. "create() does an ORM save",
+"mobile store calls LoginSerializer") when a traversal tool returned zero edges.
+
+### The contract
+
+When `archigraph_find_callees`, `archigraph_find_callers`, `archigraph_expand`,
+or `archigraph_traces(action=follow)` returns an empty edge list for a **valid**
+entity, the response carries an explicit signal:
+
+| Field | Value | Meaning |
+|-------|-------|---------|
+| `result` | `"no_outgoing_edges"` | Entity found; graph has zero outbound edges |
+| `result` | `"no_incoming_edges"` | Entity found; graph has zero inbound edges |
+| `result` | `"no_edges"` | Entity found; graph has zero neighbours of any kind |
+| `result` | `"no_outgoing_calls"` | Entry point found; no CALLS chain in the graph |
+| `note` | (human-readable message) | Instruction not to infer |
+
+These are distinct from `entity not found` errors (which return `IsError: true`).
+
+### Required behaviour
+
+- If a traversal tool returns a `result` field (no-edge signal): **state that the graph shows no edge here**. Do not speculate, do not fill the gap from training data, do not describe a "likely" or "probable" relationship.
+- Phrase it explicitly: _"The graph shows no callees for `create()`. No relationship was found between these entities."_
+- **Only** after confirming no graph edge exists may you note that the connection may exist but was not extracted (extraction gaps are real). Even then, mark it as unverified — do not state it as fact.
+
+### Pattern that causes fabrication (avoid)
+
+```
+# WRONG — invents a relationship when the graph returned no callees:
+archigraph_find_callees(entity_id="orders-api::create")
+→ { "callees": [], "result": "no_outgoing_edges", "note": "..." }
+# Agent output: "create() calls the ORM save method to persist the order"  ← FABRICATION
+
+# RIGHT:
+# Agent output: "The graph shows no outgoing edges from create(). No callee
+# relationship is recorded. If an ORM save is expected, this may be an
+# extraction gap — verify via archigraph_get_source before asserting it."
+```
+
+---
+
+## 7. Anti-patterns
 
 ### Do not use archigraph for symbol lookup
 
@@ -551,7 +595,7 @@ return "tool not found" errors:
 
 ---
 
-## 7. Reading responses
+## 8. Reading responses
 
 ### Entity IDs
 
@@ -581,7 +625,7 @@ question.
 
 ---
 
-## 8. Scoping rules
+## 9. Scoping rules
 
 | Scenario | How to scope |
 |----------|-------------|
@@ -596,7 +640,7 @@ group — provide `group=` explicitly or navigate to a registered repo.
 
 ---
 
-## 9. Related skills
+## 10. Related skills
 
 - `/generate-docs` — full documentation pipeline that uses archigraph at every
   pass. This skill is a prerequisite for understanding what `/generate-docs`
@@ -608,7 +652,7 @@ group — provide `group=` explicitly or navigate to a registered repo.
 - `/archigraph-patterns-discover` — finds and records structural patterns
   across the codebase.
 
-## 10. References
+## 11. References
 
 - `internal/mcp/SCHEMA.md` — canonical tool contract (inputs, outputs, notes)
 - ADR-0003 — SCOPE entity taxonomy (kind names)


### PR DESCRIPTION
## What & Why

Fixes #1618.

The two wrong answers in the benchmark came from the agent **inventing** a relationship when `find_callees` / cross-repo traversal returned empty: "create() does an ORM save" and "mobile store calls LoginSerializer" — entity locations were right, relationships were fabricated. The root cause: a bare empty array (`"callees": []`) invites inference. The fix is to make "entity found, zero edges" a distinct, explicit signal.

## The empty-result contract

When `archigraph_find_callees`, `archigraph_find_callers`, `archigraph_expand`, or `archigraph_traces(action=follow)` resolves a valid entity but the graph has no edges to return, the response now carries:

```json
{
  "callees": [],
  "count": 0,
  "result": "no_outgoing_edges",
  "note": "Graph shows no callees for this entity. Do not infer a relationship — report the absence."
}
```

| `result` value | Meaning |
|---|---|
| `no_outgoing_edges` | Entity found; graph has zero outbound edges (find_callees) |
| `no_incoming_edges` | Entity found; graph has zero inbound edges (find_callers) |
| `no_edges` | Entity found; graph has zero neighbours of any kind (expand) |
| `no_outgoing_calls` | Entry point found; no CALLS chain in graph (traces/follow) |

This is **distinct** from `entity not found` errors (which still return `IsError: true`). The signal only fires on empty; responses with edges carry no `result` field.

## Changes

### `internal/mcp/flow_tools.go`
- `handleFindCallees`: when callee list is empty, add `result: "no_outgoing_edges"` + `note`.
- `handleFindCallers`: when caller list is empty, add `result: "no_incoming_edges"` + `note`.

### `internal/mcp/tools.go`
- `handleGetNeighbors` (archigraph_expand): when neighbour list is empty (after also checking cross-repo overlay links), return structured `result: "no_edges"` response instead of bare `[]`.

### `internal/mcp/traces.go`
- `handleTracesFollow`: when BFS chains are empty, add `result: "no_outgoing_calls"` + `note`.

### `internal/mcp/flow_tools_test.go`
10 new tests:
- `TestFindCallers_NoEdgeSignal` — signal present on zero callers.
- `TestFindCallers_WithCallersNoSignal` — no signal when callers exist (regression guard).
- `TestFindCallees_NoEdgeSignal` — signal present on zero callees (leaf node).
- `TestFindCallees_WithCalleesNoSignal` — no signal when callees exist.
- `TestExpand_NoEdgeSignal` — signal present on isolated entity.
- `TestExpand_WithEdgesNoSignal` — no signal when neighbours exist.

### `skills/using-archigraph/SKILL.md`
New section 6 "Empty-result contract — never fabricate edges":
- Documents all four `result` values with a table.
- States the required behaviour: state the absence verbatim, never fill the gap.
- Provides a before/after example showing the fabrication pattern and the correct response.

### `skills/generate-docs/prompts/04-cluster.md`
Added "Empty-result rule (#1618)" block in Step 2 (dynamic edges and process flows):
- Writer agents are explicitly told: `result` field = explicit graph signal, not a gap to fill.
- Confident fabrication named as the top quality failure.
- Extraction gap handling: allowed only with explicit "unverified" marking.

## Verification

```
go build ./internal/mcp/...   # clean
go vet  ./internal/mcp/...    # clean
go test ./internal/mcp/...    # all pass (including 10 new tests)
```

## What is NOT in this PR

- Activity stream (#1645), paths (#1646), scoring/semantic (#461) — untouched per spec.
- :47274 daemon — not restarted.