### PR TITLE
[jarvis] Light up MCP-query glow for real out-of-process tool calls (#1645)

### DIFF
--- a/internal/mcp/activity.go
+++ b/internal/mcp/activity.go
@@ -8,11 +8,85 @@
 package mcp
 
 import (
+	"context"
 	"os"
 	"strconv"
 	"sync"
 	"time"
 )
+
+// ---------------------------------------------------------------------------
+// Per-call ID collector (epic #1157)
+// ---------------------------------------------------------------------------
+//
+// Many archigraph tools render their results as markdown (archigraph_find's
+// per-repo summary, the compact node/edge view) or as JSON whose id field is
+// just "id" rather than "entity_id". In both cases the post-hoc extractIDs
+// text-parser cannot recover the entity ids the call actually touched, so the
+// MCP-activity event reaches the SSE stream with empty returned_node_ids and
+// the WebUI glow has nothing to highlight.
+//
+// idCollector lets a handler (or a shared render helper) record the prefixed
+// ids it surfaced directly, while it still has them in hand. wrap() installs a
+// collector into the request context; emitActivity reads it back. This is a
+// side channel only — collected ids never enter the tool's wire response, so
+// nothing leaks to the calling agent.
+
+type idCollectorKey struct{}
+
+// idCollector accumulates node/edge ids touched during a single tool call.
+// Goroutine-safe so concurrent render helpers can record without coordination.
+type idCollector struct {
+	mu    sync.Mutex
+	nodes []string
+	edges []string
+}
+
+// withIDCollector returns a child context carrying a fresh collector plus the
+// collector itself. emitActivity drains the collector after the handler runs.
+func withIDCollector(ctx context.Context) (context.Context, *idCollector) {
+	c := &idCollector{}
+	return context.WithValue(ctx, idCollectorKey{}, c), c
+}
+
+// collectorFrom returns the collector installed in ctx, or nil when absent
+// (e.g. unit tests that call a handler directly without wrap()).
+func collectorFrom(ctx context.Context) *idCollector {
+	if ctx == nil {
+		return nil
+	}
+	c, _ := ctx.Value(idCollectorKey{}).(*idCollector)
+	return c
+}
+
+// recordNodeIDs adds prefixed node ids to the collector in ctx (no-op when
+// ctx carries no collector). Safe to call from any render path.
+func recordNodeIDs(ctx context.Context, ids ...string) {
+	if c := collectorFrom(ctx); c != nil {
+		c.mu.Lock()
+		c.nodes = append(c.nodes, ids...)
+		c.mu.Unlock()
+	}
+}
+
+// recordEdgeIDs adds edge ids to the collector in ctx (no-op when absent).
+func recordEdgeIDs(ctx context.Context, ids ...string) {
+	if c := collectorFrom(ctx); c != nil {
+		c.mu.Lock()
+		c.edges = append(c.edges, ids...)
+		c.mu.Unlock()
+	}
+}
+
+// drain returns the deduped collected node/edge ids.
+func (c *idCollector) drain() (nodes, edges []string) {
+	if c == nil {
+		return nil, nil
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return dedup(c.nodes), dedup(c.edges)
+}
 
 // ---------------------------------------------------------------------------
 // Event

--- a/internal/mcp/activity_ids_test.go
+++ b/internal/mcp/activity_ids_test.go
@@ -1,0 +1,151 @@
+package mcp
+
+import (
+	"context"
+	"reflect"
+	"sort"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+func sortedCopy(in []string) []string {
+	out := append([]string(nil), in...)
+	sort.Strings(out)
+	return out
+}
+
+// TestExtractIDsBareID verifies that a JSON result whose entity id field is the
+// plain "id" key (as produced by serializeEntity) yields a node id. Before the
+// fix, extractIDs only looked at "entity_id"/"node_id", so archigraph_inspect
+// results glowed nothing.
+func TestExtractIDsBareID(t *testing.T) {
+	res := mcpapi.NewToolResultText(`{"id":"upvate-core::abc123","label":"Foo","kind":"function"}`)
+	nodes, _ := extractIDs(res)
+	if want := []string{"upvate-core::abc123"}; !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("extractIDs nodes = %v, want %v", nodes, want)
+	}
+}
+
+// TestExtractIDsSliceBareID verifies the per-item "id" probe inside arrays.
+func TestExtractIDsSliceBareID(t *testing.T) {
+	res := mcpapi.NewToolResultText(`{"nodes":[{"id":"r::n1"},{"id":"r::n2"}]}`)
+	nodes, _ := extractIDs(res)
+	if want := []string{"r::n1", "r::n2"}; !reflect.DeepEqual(sortedCopy(nodes), want) {
+		t.Fatalf("extractIDs slice nodes = %v, want %v", nodes, want)
+	}
+}
+
+// TestIDCollector verifies that ids recorded through the per-call collector are
+// drained back out, deduped. This is the path markdown-rendering tools use.
+func TestIDCollector(t *testing.T) {
+	ctx, c := withIDCollector(context.Background())
+	recordNodeIDs(ctx, "r::a", "r::b", "r::a")
+	recordEdgeIDs(ctx, "e1")
+	nodes, edges := c.drain()
+	if want := []string{"r::a", "r::b"}; !reflect.DeepEqual(nodes, want) {
+		t.Fatalf("collector nodes = %v, want %v", nodes, want)
+	}
+	if want := []string{"e1"}; !reflect.DeepEqual(edges, want) {
+		t.Fatalf("collector edges = %v, want %v", edges, want)
+	}
+}
+
+// TestRecordNodeIDsNoCollector ensures recording is a safe no-op when the
+// context carries no collector (e.g. direct handler calls in other tests).
+func TestRecordNodeIDsNoCollector(t *testing.T) {
+	recordNodeIDs(context.Background(), "r::x") // must not panic
+	if c := collectorFrom(context.Background()); c != nil {
+		t.Fatalf("expected nil collector, got %v", c)
+	}
+}
+
+// TestIDsFromArgs verifies id-bearing arguments are harvested as a fallback,
+// while free-text fields are excluded and bare (unprefixed) label_or_id values
+// are skipped.
+func TestIDsFromArgs(t *testing.T) {
+	got := idsFromArgs(map[string]any{
+		"node_id":         "r::n",
+		"target_entity_id": "r::t",
+		"question":        "where is auth", // must be ignored
+		"label_or_id":     "PlainLabel",    // bare label → skipped
+	})
+	if want := []string{"r::n", "r::t"}; !reflect.DeepEqual(sortedCopy(got), want) {
+		t.Fatalf("idsFromArgs = %v, want %v", got, want)
+	}
+
+	// Prefixed label_or_id IS an id.
+	got2 := idsFromArgs(map[string]any{"label_or_id": "r::Foo"})
+	if want := []string{"r::Foo"}; !reflect.DeepEqual(got2, want) {
+		t.Fatalf("idsFromArgs prefixed = %v, want %v", got2, want)
+	}
+}
+
+// TestMarkdownToolIDsReachEvent simulates the wire path of archigraph_find:
+// a handler that returns markdown (no ids in the body) records its touched
+// ids via the collector; emitActivity then publishes them. Before the fix,
+// such events arrived with empty returned_node_ids → no WebUI glow.
+func TestMarkdownToolIDsReachEvent(t *testing.T) {
+	broker := NewMCPActivityBroker()
+	ch, cancel := broker.SubscribeAll()
+	defer cancel()
+	s := &Server{activityBroker: broker}
+
+	// Install the collector exactly as wrap() does, then run a markdown
+	// "handler" that records ids the way the per-repo summary call site does.
+	ctx, collector := withIDCollector(context.Background())
+	recordNodeIDs(ctx, "upvate-core::abc", "upvate-core-frontend::def")
+	res := mcpapi.NewToolResultText("# group: upvate — per-repo top hits\n")
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = "archigraph_find"
+	req.Params.Arguments = map[string]any{"question": "auth"}
+
+	s.emitActivity(ctx, "archigraph_find", req, res, collector)
+
+	select {
+	case ev := <-ch:
+		got := sortedCopy(ev.ReturnedNodeIDs)
+		want := []string{"upvate-core-frontend::def", "upvate-core::abc"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("event node ids = %v, want %v", got, want)
+		}
+		if ev.ToolName != "archigraph_find" {
+			t.Fatalf("tool name = %q", ev.ToolName)
+		}
+	default:
+		t.Fatal("no event published")
+	}
+}
+
+// TestEmitActivityMergesSources verifies emitActivity unions collector ids,
+// JSON-extracted ids, and arg-derived ids into the published event.
+func TestEmitActivityMergesSources(t *testing.T) {
+	broker := NewMCPActivityBroker()
+	ch, cancel := broker.SubscribeAll()
+	defer cancel()
+
+	s := &Server{activityBroker: broker}
+
+	ctx, collector := withIDCollector(context.Background())
+	recordNodeIDs(ctx, "r::fromCollector")
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Name = "archigraph_inspect"
+	req.Params.Arguments = map[string]any{"node_id": "r::fromArgs"}
+
+	res := mcpapi.NewToolResultText(`{"id":"r::fromJSON"}`)
+
+	s.emitActivity(ctx, "archigraph_inspect", req, res, collector)
+
+	select {
+	case ev := <-ch:
+		got := sortedCopy(ev.ReturnedNodeIDs)
+		want := []string{"r::fromArgs", "r::fromCollector", "r::fromJSON"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("event node ids = %v, want %v", got, want)
+		}
+	default:
+		t.Fatal("no event published")
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -433,8 +433,12 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 			end(isErr)
 		}()
 		s.reloadBeforeCall()
+		// Install a per-call id collector so render helpers can record the
+		// entity ids they surface (markdown tools have no machine-readable ids
+		// in their wire output). emitActivity drains it afterwards.
+		ctx, collector := withIDCollector(ctx)
 		res, err = fn(ctx, req)
-		s.emitActivity(ctx, name, req, res)
+		s.emitActivity(ctx, name, req, res, collector)
 		return res, err
 	}
 }
@@ -443,7 +447,7 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 // wired). It is called after every tool handler returns. The agent_id is
 // derived from the "archigraph-agent-id" context value when set, or falls
 // back to the User-Agent extracted at session accept time.
-func (s *Server) emitActivity(_ context.Context, toolName string, req mcpapi.CallToolRequest, res *mcpapi.CallToolResult) {
+func (s *Server) emitActivity(_ context.Context, toolName string, req mcpapi.CallToolRequest, res *mcpapi.CallToolResult, collector *idCollector) {
 	if s.activityBroker == nil {
 		return
 	}
@@ -458,11 +462,51 @@ func (s *Server) emitActivity(_ context.Context, toolName string, req mcpapi.Cal
 		QueryArgs: argsCopy,
 		Timestamp: 0, // broker will fill this in
 	}
-	// Extract node/edge IDs from the result content when present.
+
 	if res != nil && !res.IsError {
-		event.ReturnedNodeIDs, event.ReturnedEdgeIDs = extractIDs(res)
+		// Resolve the touched entity ids in priority order:
+		//  1. Ids explicitly recorded by the handler / render helpers (covers
+		//     markdown-formatted tools like archigraph_find whose wire output
+		//     carries no machine-readable ids).
+		//  2. Ids parsed out of a JSON result body (covers structured tools).
+		//  3. The request's own id-bearing arguments (covers single-entity
+		//     tools like inspect / get_source / expand even when neither of the
+		//     above fires).
+		nodeIDs, edgeIDs := collector.drain()
+		jn, je := extractIDs(res)
+		nodeIDs = append(nodeIDs, jn...)
+		edgeIDs = append(edgeIDs, je...)
+		nodeIDs = append(nodeIDs, idsFromArgs(args)...)
+		event.ReturnedNodeIDs = dedup(nodeIDs)
+		event.ReturnedEdgeIDs = dedup(edgeIDs)
 	}
 	s.activityBroker.Publish(event)
+}
+
+// idsFromArgs harvests entity ids that the caller passed in as arguments.
+// These are the exact nodes a single-entity tool (inspect, get_source,
+// expand, impact_radius, …) operated on, so they are a sound fallback when
+// the rendered result exposes no ids of its own. Free-text fields such as
+// "question" or "label" are intentionally excluded — they are not ids.
+func idsFromArgs(args map[string]any) []string {
+	var out []string
+	for _, k := range []string{
+		"node_id", "entity_id", "target_entity_id", "from_id", "to_id",
+	} {
+		if v, ok := args[k]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	// label_or_id is an id only when it carries the "<repo>::<local>" prefix;
+	// a bare label would not match any graph node id, so skip it then.
+	if v, ok := args["label_or_id"].(string); ok && v != "" {
+		if r, _ := splitPrefixed(v); r != "" {
+			out = append(out, v)
+		}
+	}
+	return out
 }
 
 // extractIDs attempts to pull entity IDs and edge IDs out of a tool result's
@@ -484,7 +528,7 @@ func extractIDs(res *mcpapi.CallToolResult) (nodeIDs, edgeIDs []string) {
 			continue
 		}
 		nodeIDs = append(nodeIDs, collectScalarIDs(payload,
-			"entity_id", "node_id", "pattern_id", "topic_id", "process_id")...)
+			"id", "entity_id", "node_id", "pattern_id", "topic_id", "process_id")...)
 		nodeIDs = append(nodeIDs, collectSliceIDs(payload,
 			"results", "nodes", "steps", "orphans", "patterns", "orphan_publishers",
 			"orphan_subscribers", "dead_ends", "truncated_flows", "publishers",
@@ -527,7 +571,7 @@ func collectSliceIDs(m map[string]any, keys ...string) []string {
 			if !ok {
 				continue
 			}
-			for _, field := range []string{"entity_id", "node_id", "from_id", "to_id", "pattern_id", "topic_id", "process_id"} {
+			for _, field := range []string{"id", "entity_id", "node_id", "from_id", "to_id", "pattern_id", "topic_id", "process_id"} {
 				if s, ok := obj[field].(string); ok && s != "" {
 					out = append(out, s)
 				}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -350,7 +350,20 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 
 	// Smart scoping: no filter, multiple repos -> per-repo top 3.
 	if len(repoFilter) == 0 && len(lg.Repos) > 1 {
-		return mcpapi.NewToolResultText(renderPerRepoSummary(all, lg)), nil
+		summary := renderPerRepoSummary(all, lg)
+		// Record the prefixed ids of the top-3-per-repo hits actually shown so
+		// the MCP-activity glow has nodes to highlight (the markdown body
+		// carries no machine-readable ids). Mirrors renderPerRepoSummary's
+		// own per-repo top-3 selection.
+		perRepoShown := map[string]int{}
+		for _, sc := range all {
+			if perRepoShown[sc.repo.Repo] >= 3 {
+				continue
+			}
+			perRepoShown[sc.repo.Repo]++
+			recordNodeIDs(ctx, prefixedID(sc.repo.Repo, sc.hit.Entity.ID))
+		}
+		return mcpapi.NewToolResultText(summary), nil
 	}
 
 	// Otherwise BFS-expand from each top hit and render compact.
@@ -407,6 +420,11 @@ func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolReques
 		Nodes:        visibleNodes,
 		Edges:        visibleEdges,
 		OneRepo:      oneRepo,
+	}
+	// Record the prefixed ids of every visible node so the MCP-activity glow
+	// highlights the compact result set (the rendered markdown has no ids).
+	for _, nw := range visibleNodes {
+		recordNodeIDs(ctx, prefixedID(nw.Repo, nw.Entity.ID))
 	}
 	return mcpapi.NewToolResultText(renderCompact(rr, tokenBudget)), nil
 }

--- a/webui-v2/src/hooks/use-mcp-activity.ts
+++ b/webui-v2/src/hooks/use-mcp-activity.ts
@@ -88,7 +88,10 @@ export function useMCPActivity(enabled = true): UseMCPActivityReturn {
       setState((prev) => ({ ...prev, connected: true }));
     });
 
-    es.addEventListener("activity", (ev: MessageEvent) => {
+    // The Go backend emits this event as "mcp_activity"
+    // (internal/dashboard/handlers_mcp_activity.go). Listening for the wrong
+    // name silently drops every event → "No MCP queries yet" / no glow.
+    es.addEventListener("mcp_activity", (ev: MessageEvent) => {
       try {
         const event: MCPActivityEvent = JSON.parse(ev.data as string);
         setState((prev) => {


### PR DESCRIPTION
# Summary

The live MCP-query glow on the WebUI-v2 cosmos graph never fired for real archigraph MCP queries. Tools like `archigraph_find`, `archigraph_inspect`, `archigraph_stats` ran fine; the overlay sat at "No MCP queries yet". The issue's hypothesis was that out-of-process MCP activity never reached the SSE broker — verifying on the live :47274 daemon disproved that. Real Claude-Code-driven calls route through mcp-bridge → daemon RPC → the shared `*mcp.Server` singleton (cmd/archigraph/daemon_mcp_rpc.go, ADR-0017), which already has the activity broker wired. SSE events were flowing the whole time; I captured them on the live daemon before touching anything.

Two compounding defects were swallowing the glow downstream.

# Root Cause

**Defect 1 — frontend listened for the wrong SSE event name.** `webui-v2/src/hooks/use-mcp-activity.ts` did `es.addEventListener("activity", …)`, but `internal/dashboard/handlers_mcp_activity.go` emits `writeSSEEvent(w, "mcp_activity", …)`. Every event was silently dropped by `EventSource` → `totalCount` stuck at 0 → overlay rendered "No MCP queries yet" → `use-graph-highlight.ts` never received a `latestEvent` → no glow.

**Defect 2 — even after fixing the listener, `returned_node_ids` was empty on nearly every event.** The glow set in `use-graph-highlight.ts:127` is keyed entirely off `returned_node_ids` / `returned_edge_ids`. `emitActivity` calls `extractIDs`, which only:
- parses JSON-formatted result text — but `archigraph_find` returns markdown (`# group: … — per-repo top hits …`), so `json.Unmarshal` failed and no ids were extracted.
- probes scalar keys `entity_id`, `node_id`, etc. — but `serializeEntity` (the JSON shape used by `archigraph_inspect`, `archigraph_expand`, `archigraph_get_source`) emits its id field as `"id"`. So even structured tools yielded zero ids.

# Fix

Three layered changes that work together.

**Frontend (`webui-v2/src/hooks/use-mcp-activity.ts`):** rename the listener from `"activity"` to `"mcp_activity"` to match the backend wire name.

**Backend — per-call id collector (`internal/mcp/activity.go`):** new `idCollector` carried in `context.Context`. `wrap()` installs a fresh collector on every tool call; render helpers and handlers call `recordNodeIDs(ctx, prefixedID(repo, e.ID))` for the entities they actually surface. The collector is goroutine-safe, deduped, and lives only inside the daemon — collected ids never enter the tool's wire response to the calling agent.

**Backend — chokepoint wiring (`internal/mcp/tools.go`):** the two return paths of `handleQueryGraph` now record ids: `renderPerRepoSummary` records the top-3-per-repo hits actually shown, and the compact render records every visible node. Together this covers `archigraph_find` end-to-end with the prefixed-id format the dashboard graph keys on.

**Backend — id resolution upgrade (`internal/mcp/server.go`):** `emitActivity` now unions ids from three sources, deduped:
1. The collector (covers markdown-rendering tools).
2. `extractIDs` of the result body — extended to recognise the bare `"id"` scalar/slice key (covers every `serializeEntity`-shaped JSON result, i.e. inspect / expand / get_source / impact_radius etc.).
3. `idsFromArgs` of the request arguments (`node_id`, `entity_id`, `target_entity_id`, `from_id`, `to_id`, and `label_or_id` only when it carries a `<repo>::<local>` prefix) — a safe fallback for single-entity tools whose body never surfaces ids in either form.

# Files Touched

- `internal/mcp/activity.go` — `idCollector` type, `withIDCollector` / `collectorFrom` / `recordNodeIDs` / `recordEdgeIDs` / `drain`.
- `internal/mcp/server.go` — `wrap` installs the collector; `emitActivity` unions the three id sources; `extractIDs` recognises `"id"`; new `idsFromArgs` helper.
- `internal/mcp/tools.go` — `handleQueryGraph` records prefixed ids at both render exits.
- `internal/mcp/activity_ids_test.go` — new unit tests (extractIDs bare `id`, collector lifecycle, no-collector no-op safety, args harvesting, end-to-end emitActivity merge from markdown-style call).
- `webui-v2/src/hooks/use-mcp-activity.ts` — SSE listener name corrected to `mcp_activity`.

# Verification

`go build ./internal/mcp/...` clean. `go test ./internal/mcp/...` green (1.8s). `go test ./internal/dashboard/...` green for all MCP-activity tests (the only dashboard failure, `TestYamlScalar`, predates this PR on main and is unrelated). `npx tsc --noEmit` in `webui-v2` clean; `npx vite build` produces a usable bundle.

Live verification against an isolated daemon on port 47999 (binary built from this branch, `ARCHIGRAPH_DAEMON_ROOT=/tmp/archigraph-fix-home`, state hashes symlinked from the canonical store — the canonical :47274 daemon was NOT touched and remained HTTP 200 throughout). Captured SSE event from a real `archigraph_find` MCP call routed through `archigraph mcp-bridge`:

```
event: mcp_activity
data: {"tool_name":"archigraph_find","query_args":{"group":"upvate","question":"authentication middleware"},"returned_node_ids":["upvate-core::c84f9b9c0c3a7b18","upvate-core::14d45f8830972c90","upvate-core::f4ad87fa875edbac","upvate-core-frontend::27f8a309f2e8999d","upvate-core-frontend::9491eba3c0178b5b","upvate-core-frontend::a9d1a6e11e681374","core-mobile::ext:expo-local-authentication","core-mobile::ext:supportedAuthenticationTypesAsync"],"timestamp":1779491546595}
```

`archigraph_inspect` (`label_or_id: TokenAuthenticationMiddleware`) emitted `returned_node_ids: ["upvate-core::c84f9b9c0c3a7b18"]` via the new bare-`"id"` extractor path. `archigraph_stats` (no entity result) emitted no ids, as expected.

The prefixed-id format (`<slug>::<local>`) matches `dashPrefixedID` in `internal/dashboard/graphstate.go:115`, which is what the WebUI's `idToIdx` map keys on, so the glow will hit real nodes in the rendered graph.

# Risks & Migration

Low risk. Side channel only — the collector is daemon-internal; tool wire responses are unchanged. JSON `"id"` extraction could in theory pick up unrelated `"id"` keys in nested objects, but archigraph JSON results that carry an `"id"` carry an entity id; deduping makes a stray scalar harmless. The arg-fallback list is restricted to id-typed keys (free-text like `question`, `label`, and bare-label `label_or_id` are excluded).

# Rollout

No deploy steps. `archigraph install` rebuilds the daemon binary, after which the canonical :47274 picks up the change. The frontend listener fix ships with the next webui-v2 build (`make dashboard-build`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
