### PR TITLE
[PLT-1646] Paths detail: resolve definition → handler, regroup by viewset

### DIFF
--- a/internal/dashboard/paths_handler_resolve.go
+++ b/internal/dashboard/paths_handler_resolve.go
@@ -1,0 +1,284 @@
+package dashboard
+
+// paths_handler_resolve.go — endpoint-definition → handler resolution (#1646).
+//
+// DRF (and Spring/NestJS) producers emit a synthetic `http_endpoint_definition`
+// entity per (verb, path) at the route-registration site (e.g. `routers.py:0`).
+// That synthetic carries NO body edges: the real CALLS / QUERIES / REFERENCES /
+// ACCESSES_TABLE / TESTS edges all live on the *handler* method (the ViewSet
+// method, controller action, …). The handler is linked to the definition by an
+// inbound `IMPLEMENTS` edge:
+//
+//	handler  --IMPLEMENTS-->  http_endpoint_definition
+//	(also: definition --ROUTES_TO/SERVES--> handler  for some frameworks)
+//
+// Before #1646 the Paths detail traversed edges off the *definition* entity, so
+// Called-by / Downstream / Side-effects / Tests were always empty, and the left
+// tree grouped by the route-definition file (routers.py) instead of the owning
+// viewset/module. This file resolves the handler and classifies its edges so the
+// detail sections and grouping reflect the real handler.
+
+import (
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// repoEntityIndex is a per-repo lookup built once per request so the
+// handler-resolution passes don't re-scan the relationship slice O(n²).
+type repoEntityIndex struct {
+	repo *DashRepo
+	// byID maps local entity ID → entity.
+	byID map[string]*graph.Entity
+	// implementsTo maps a definition's local ID → the handler local IDs that
+	// IMPLEMENT (or ROUTES_TO / SERVES) it.
+	handlerOf map[string][]string
+}
+
+// handlerResolveEdgeKinds are the producer-side edge kinds that link a backend
+// handler to an http_endpoint_definition. IMPLEMENTS is the DRF/Nest shape;
+// ROUTES_TO / SERVES cover Spring and other frameworks where the definition
+// points at the handler directly.
+var handlerResolveEdgeKinds = map[string]bool{
+	"IMPLEMENTS": true,
+	"ROUTES_TO":  true,
+	"SERVES":     true,
+}
+
+// buildRepoEntityIndex builds an entity index + handler-resolution map for a
+// single repo document. The handlerOf map is keyed by the definition entity ID
+// and resolves in BOTH directions:
+//
+//	handler --IMPLEMENTS--> def   (DRF/Nest: FromID is the handler)
+//	def --ROUTES_TO--> handler    (Spring: ToID is the handler)
+//
+// so the caller can ask "who handles this definition?" regardless of framework.
+func buildRepoEntityIndex(repo *DashRepo) *repoEntityIndex {
+	idx := &repoEntityIndex{
+		repo:      repo,
+		byID:      make(map[string]*graph.Entity, len(repo.Doc.Entities)),
+		handlerOf: make(map[string][]string),
+	}
+	for i := range repo.Doc.Entities {
+		e := &repo.Doc.Entities[i]
+		idx.byID[e.ID] = e
+	}
+	isDef := func(id string) bool {
+		e := idx.byID[id]
+		return e != nil && strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointDefinitionKind)
+	}
+	isHandlerKind := func(id string) bool {
+		e := idx.byID[id]
+		if e == nil {
+			return false
+		}
+		// A handler is anything that is NOT itself an endpoint definition: a
+		// viewset method (Operation), controller action, function, etc.
+		return !strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointDefinitionKind)
+	}
+	for i := range repo.Doc.Relationships {
+		r := &repo.Doc.Relationships[i]
+		if !handlerResolveEdgeKinds[r.Kind] {
+			continue
+		}
+		switch {
+		// handler --IMPLEMENTS/SERVES--> definition  (FromID = handler)
+		case isDef(r.ToID) && isHandlerKind(r.FromID):
+			idx.handlerOf[r.ToID] = appendUnique(idx.handlerOf[r.ToID], r.FromID)
+		// definition --ROUTES_TO/SERVES--> handler  (ToID = handler)
+		case isDef(r.FromID) && isHandlerKind(r.ToID):
+			idx.handlerOf[r.FromID] = appendUnique(idx.handlerOf[r.FromID], r.ToID)
+		}
+	}
+	return idx
+}
+
+// resolveHandlers returns the handler entities for a given endpoint-definition
+// entity. If the entity is not a synthetic definition (e.g. a framework that
+// records the route directly on a real function) it is returned as its own
+// handler so callers always get a non-empty handler to traverse.
+func (idx *repoEntityIndex) resolveHandlers(defEntity *graph.Entity) []*graph.Entity {
+	if defEntity == nil {
+		return nil
+	}
+	isDef := strings.EqualFold(dashStripScopePrefix(defEntity.Kind), httpEndpointDefinitionKind)
+	if !isDef {
+		// Already a concrete handler / real route entity.
+		return []*graph.Entity{defEntity}
+	}
+	ids := idx.handlerOf[defEntity.ID]
+	if len(ids) == 0 {
+		// Unresolved — fall back to the definition itself so existing
+		// definition-level edges (e.g. retargeted FETCHES) still surface.
+		return []*graph.Entity{defEntity}
+	}
+	out := make([]*graph.Entity, 0, len(ids))
+	for _, id := range ids {
+		if h := idx.byID[id]; h != nil {
+			out = append(out, h)
+		}
+	}
+	if len(out) == 0 {
+		return []*graph.Entity{defEntity}
+	}
+	return out
+}
+
+// handlerGroupKey derives a stable viewset/module grouping key for a resolved
+// handler. Preference order:
+//
+//  1. The class/viewset the handler belongs to ("RoleViewSet.retrieve" →
+//     "RoleViewSet"; "pkg::OrderViewSet" → "OrderViewSet").
+//  2. The handler's own name when it carries no class scope (a bare function
+//     view, e.g. "health_check").
+//
+// This is the unit a developer thinks in (the viewset/controller), NOT the
+// route-registration file. Returns "" when no handler name is available.
+func handlerGroupKey(handler *graph.Entity) string {
+	if handler == nil {
+		return ""
+	}
+	name := handler.Name
+	// Strip a leading scope prefix kind ("SCOPE.Operation:RoleViewSet.retrieve"
+	// arrives here already as Name="RoleViewSet.retrieve", but be defensive).
+	if i := strings.LastIndex(name, ":"); i >= 0 && i < len(name)-1 {
+		// only strip when the prefix looks like a kind tag, not a package path
+		if !strings.Contains(name[:i], "/") {
+			name = name[i+1:]
+		}
+	}
+	// "RoleViewSet.retrieve" → "RoleViewSet"
+	if dot := strings.LastIndex(name, "."); dot > 0 {
+		return name[:dot]
+	}
+	// "pkg::OrderViewSet" → "OrderViewSet"
+	if sc := strings.LastIndex(name, "::"); sc >= 0 && sc < len(name)-2 {
+		return name[sc+2:]
+	}
+	return name
+}
+
+// classifiedHandlerEdges holds a resolved handler's edges, split into the four
+// Paths-detail sections. IDs are repo-prefixed (dashPrefixedID) so the group
+// resolver can look them up cross-repo.
+type classifiedHandlerEdges struct {
+	calledBy    []string // inbound CALLS + inbound FETCHES (callers)
+	downstream  []string // outbound CALLS to other operations/services
+	sideEffects []string // DB writes / model mutation / pub-sub / external API
+	tests       []string // inbound TESTS edges
+}
+
+// sideEffectEdgeKinds are outbound edge kinds that represent a mutation or
+// external interaction performed by the handler.
+var sideEffectEdgeKinds = map[string]bool{
+	"QUERIES":       true,
+	"ACCESSES_TABLE": true,
+	"EMITS":         true,
+	"PUBLISHES_TO":  true,
+	"SUBSCRIBES_TO": true,
+	"TRIGGERS":      true,
+	"MAPS_TO":       true,
+}
+
+// classifyHandlerEdges walks the repo's relationships once and bucketises every
+// edge touching the given handler IDs. defIDs are the endpoint-definition IDs
+// the handlers implement: inbound FETCHES land on the *definition* (the
+// resolver retargets caller fetches there), so they are collected as callers
+// too. The handler set and definition set are evaluated against local IDs.
+func classifyHandlerEdges(idx *repoEntityIndex, handlerIDs, defIDs []string) classifiedHandlerEdges {
+	handlerSet := make(map[string]bool, len(handlerIDs))
+	for _, id := range handlerIDs {
+		handlerSet[id] = true
+	}
+	defSet := make(map[string]bool, len(defIDs))
+	for _, id := range defIDs {
+		defSet[id] = true
+	}
+	slug := idx.repo.Slug
+	var out classifiedHandlerEdges
+	for i := range idx.repo.Doc.Relationships {
+		r := &idx.repo.Doc.Relationships[i]
+		// Outbound from a handler.
+		if handlerSet[r.FromID] {
+			switch {
+			case r.Kind == "CALLS":
+				// Skip external stubs (Response/save/get…) — they're noise; keep
+				// only edges that resolve to a real intra-graph entity.
+				if t := idx.byID[r.ToID]; t != nil && !isExternalStub(t) {
+					out.downstream = append(out.downstream, dashPrefixedID(slug, r.ToID))
+				}
+			case sideEffectEdgeKinds[r.Kind]:
+				out.sideEffects = append(out.sideEffects, dashPrefixedID(slug, r.ToID))
+			case r.Kind == "REFERENCES":
+				// REFERENCES to a Model/datastore is a DB touch; ignore plain
+				// symbol references to keep the section signal-dense.
+				if t := idx.byID[r.ToID]; t != nil && isDataEntity(t) {
+					out.sideEffects = append(out.sideEffects, dashPrefixedID(slug, r.ToID))
+				}
+			}
+		}
+		// Inbound to a handler.
+		if handlerSet[r.ToID] {
+			switch r.Kind {
+			case "CALLS":
+				out.calledBy = append(out.calledBy, dashPrefixedID(slug, r.FromID))
+			case "TESTS":
+				out.tests = append(out.tests, dashPrefixedID(slug, r.FromID))
+			}
+		}
+		// Inbound to the definition: retargeted caller FETCHES + TESTS.
+		if defSet[r.ToID] {
+			switch r.Kind {
+			case "FETCHES":
+				out.calledBy = append(out.calledBy, dashPrefixedID(slug, r.FromID))
+			case "TESTS":
+				out.tests = append(out.tests, dashPrefixedID(slug, r.FromID))
+			}
+		}
+	}
+	out.calledBy = dedupStrings(out.calledBy)
+	out.downstream = dedupStrings(out.downstream)
+	out.sideEffects = dedupStrings(out.sideEffects)
+	out.tests = dedupStrings(out.tests)
+	return out
+}
+
+// isExternalStub reports whether an entity is a synthetic external-call stub
+// (SCOPE.External:save, builtin Response, etc.) that adds noise rather than
+// signal to the Downstream section.
+func isExternalStub(e *graph.Entity) bool {
+	k := strings.ToLower(dashStripScopePrefix(e.Kind))
+	if strings.Contains(k, "external") {
+		// External *services* (real third-party APIs) are signal; bare external
+		// call stubs with no source file are noise.
+		return e.SourceFile == ""
+	}
+	return false
+}
+
+// isDataEntity reports whether an entity is a persistence target (DB model,
+// table, datastore) — i.e. a REFERENCES/QUERIES to it is a real side effect.
+func isDataEntity(e *graph.Entity) bool {
+	k := strings.ToLower(dashStripScopePrefix(e.Kind))
+	switch {
+	case strings.Contains(k, "model"),
+		strings.Contains(k, "table"),
+		strings.Contains(k, "datastore"),
+		strings.Contains(k, "dataaccess"),
+		strings.Contains(k, "database"),
+		strings.Contains(k, "collection"):
+		return true
+	}
+	return false
+}
+
+// appendUnique appends s to sl only if not already present.
+func appendUnique(sl []string, s string) []string {
+	for _, v := range sl {
+		if v == s {
+			return sl
+		}
+	}
+	return append(sl, s)
+}
+

--- a/internal/dashboard/paths_handler_resolve_test.go
+++ b/internal/dashboard/paths_handler_resolve_test.go
@@ -1,0 +1,232 @@
+package dashboard
+
+// paths_handler_resolve_test.go — #1646 unit tests for endpoint-definition →
+// handler resolution and the v2 detail / list re-grouping.
+
+import (
+	"encoding/json"
+	"net/http"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// drfRoleFixture mirrors the upvate shape: a synthetic http_endpoint_definition
+// at routers.py:0 + the RoleViewSet.retrieve handler linked by IMPLEMENTS, plus
+// a real CALLS edge into a downstream helper and a model REFERENCES edge that
+// must surface as a Side-effect.
+func drfRoleFixture() ([]graph.Entity, []graph.Relationship) {
+	entities := []graph.Entity{
+		// Synthetic endpoint definition produced by the DRF router expansion.
+		{
+			ID:         "ep_get_roles_pk",
+			Name:       "http:GET:/api/v1/roles/{pk}",
+			Kind:       "http_endpoint_definition",
+			SourceFile: "core/routers.py",
+			StartLine:  0,
+			Properties: map[string]string{"path": "/api/v1/roles/{pk}", "verb": "GET", "framework": "drf"},
+		},
+		// Real handler — a viewset method.
+		{
+			ID:            "op_retrieve",
+			Name:          "RoleViewSet.retrieve",
+			QualifiedName: "core.views.role_viewset.RoleViewSet.retrieve",
+			Kind:          "SCOPE.Operation",
+			SourceFile:    "core/views/role_viewset.py",
+			StartLine:     42,
+			Language:      "python",
+		},
+		// A downstream operation the handler CALLS.
+		{
+			ID: "op_helper", Name: "find_role_by_pk", Kind: "SCOPE.Operation",
+			SourceFile: "core/services/role_service.py", StartLine: 10,
+		},
+		// A Model the handler REFERENCES (a DB touch → Side-effect).
+		{
+			ID: "model_role", Name: "Role", Kind: "Model",
+			SourceFile: "core/models/role.py", StartLine: 5,
+		},
+		// A test method that TESTS the handler.
+		{
+			ID: "op_test", Name: "RoleViewSetTests.test_retrieve", Kind: "SCOPE.Operation",
+			SourceFile: "core/tests/test_role_viewset.py", StartLine: 12,
+		},
+		// A frontend FETCH call site retargeted to the definition.
+		{
+			ID: "fe_caller", Name: "useRoleDetail", Kind: "SCOPE.Operation",
+			SourceFile: "src/hooks/useRoleDetail.ts", StartLine: 7,
+		},
+	}
+	rels := []graph.Relationship{
+		// Handler IMPLEMENTS the definition — this is what the resolver follows.
+		{FromID: "op_retrieve", ToID: "ep_get_roles_pk", Kind: "IMPLEMENTS"},
+		// Handler's outbound edges (downstream + side-effects).
+		{FromID: "op_retrieve", ToID: "op_helper", Kind: "CALLS"},
+		{FromID: "op_retrieve", ToID: "model_role", Kind: "REFERENCES"},
+		// Test → handler.
+		{FromID: "op_test", ToID: "op_retrieve", Kind: "TESTS"},
+		// Retargeted frontend FETCHES → definition.
+		{FromID: "fe_caller", ToID: "ep_get_roles_pk", Kind: "FETCHES"},
+	}
+	return entities, rels
+}
+
+// TestV2PathDetail_PopulatesSectionsViaIMPLEMENTS verifies #1646: the detail
+// pane resolves the definition to its IMPLEMENTS-linked handler and traverses
+// the handler's edges to populate Called-by, Downstream, Side-effects, Tests.
+func TestV2PathDetail_PopulatesSectionsViaIMPLEMENTS(t *testing.T) {
+	entities, rels := drfRoleFixture()
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	hash := hashStr("/api/v1/roles/{pk}")
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths/" + hash)
+	if err != nil {
+		t.Fatalf("GET detail: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status: want 200 got %d", resp.StatusCode)
+	}
+	var body struct {
+		Data v2PathDetail `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	d := body.Data
+
+	// Handler card must point at the resolved viewset method, not the
+	// routers.py:0 synthetic.
+	if len(d.Handlers) != 1 {
+		t.Fatalf("handlers: want 1 got %d", len(d.Handlers))
+	}
+	h := d.Handlers[0]
+	if h.SourceFile != "core/views/role_viewset.py" || h.StartLine != 42 {
+		t.Errorf("handler source: want core/views/role_viewset.py:42, got %s:%d", h.SourceFile, h.StartLine)
+	}
+	if h.QualifiedName != "core.views.role_viewset.RoleViewSet.retrieve" {
+		t.Errorf("handler qualified_name: got %q", h.QualifiedName)
+	}
+
+	// Called-by must include the frontend fetch caller.
+	if len(d.InboundFetches) != 1 || d.InboundFetches[0].QualifiedName == "" && d.InboundFetches[0].Label != "useRoleDetail" {
+		t.Errorf("called-by: want useRoleDetail, got %+v", d.InboundFetches)
+	}
+	// Downstream must include the helper operation the handler CALLS.
+	allDown := append(append(append(append([]v2PathEntity{}, d.Outbound.DB...), d.Outbound.Event...),
+		d.Outbound.Queue...), d.Outbound.External...)
+	allDown = append(allDown, d.Outbound.GRPC...)
+	found := false
+	for _, x := range allDown {
+		if x.Label == "find_role_by_pk" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("downstream: missing find_role_by_pk, got %+v", allDown)
+	}
+	// Side-effects must include the Role model REFERENCES.
+	foundSE := false
+	for _, x := range d.SideEffects {
+		if x.Label == "Role" {
+			foundSE = true
+		}
+	}
+	if !foundSE {
+		t.Errorf("side_effects: missing Role model, got %+v", d.SideEffects)
+	}
+	// Tests must include the test method that TESTS the handler.
+	if len(d.Tests) != 1 || d.Tests[0].Label != "RoleViewSetTests.test_retrieve" {
+		t.Errorf("tests: want RoleViewSetTests.test_retrieve, got %+v", d.Tests)
+	}
+}
+
+// TestV2PathsList_GroupsByViewSet_NotRouterFile verifies #1646: when endpoint
+// definitions are router-expanded synthetics all sharing routers.py, the list
+// must group routes by their IMPLEMENTS-resolved viewset, not by the shared
+// router file.
+func TestV2PathsList_GroupsByViewSet_NotRouterFile(t *testing.T) {
+	entities := []graph.Entity{
+		// Two router-expanded definitions — both at routers.py:0.
+		{ID: "ep_roles_get", Name: "http:GET:/api/v1/roles", Kind: "http_endpoint_definition",
+			SourceFile: "core/routers.py", StartLine: 0,
+			Properties: map[string]string{"path": "/api/v1/roles", "verb": "GET"}},
+		{ID: "ep_buildings_get", Name: "http:GET:/api/v1/buildings", Kind: "http_endpoint_definition",
+			SourceFile: "core/routers.py", StartLine: 0,
+			Properties: map[string]string{"path": "/api/v1/buildings", "verb": "GET"}},
+		// Two viewset handlers in different files.
+		{ID: "op_role_list", Name: "RoleViewSet.list", Kind: "SCOPE.Operation",
+			SourceFile: "core/views/role_viewset.py", StartLine: 10},
+		{ID: "op_bldg_list", Name: "BuildingViewSet.list", Kind: "SCOPE.Operation",
+			SourceFile: "core/views/building_viewset.py", StartLine: 12},
+	}
+	rels := []graph.Relationship{
+		{FromID: "op_role_list", ToID: "ep_roles_get", Kind: "IMPLEMENTS"},
+		{FromID: "op_bldg_list", ToID: "ep_buildings_get", Kind: "IMPLEMENTS"},
+	}
+	grp := makePathsTestGroup(entities, rels)
+	ts := newPathsTestServer(t, grp)
+	defer ts.Close()
+
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/paths")
+	if err != nil {
+		t.Fatalf("GET paths: %v", err)
+	}
+	defer resp.Body.Close()
+	var body struct {
+		Data v2PathsListResponse `json:"data"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(body.Data.Backends) != 1 {
+		t.Fatalf("backends: want 1, got %d", len(body.Data.Backends))
+	}
+	groups := body.Data.Backends[0].Groups
+	if len(groups) != 2 {
+		t.Fatalf("controllers: want 2 (one per viewset), got %d (labels=%v)",
+			len(groups), groupLabels(groups))
+	}
+	labels := map[string]bool{}
+	for _, g := range groups {
+		labels[g.Label] = true
+	}
+	if !labels["RoleViewSet"] || !labels["BuildingViewSet"] {
+		t.Errorf("controller labels: want {RoleViewSet, BuildingViewSet}, got %v", labels)
+	}
+	if body.Data.Totals.Controllers != 2 {
+		t.Errorf("totals.controllers: want 2, got %d", body.Data.Totals.Controllers)
+	}
+}
+
+func groupLabels(gs []v2ControllerGroup) []string {
+	out := make([]string, 0, len(gs))
+	for _, g := range gs {
+		out = append(out, g.Label)
+	}
+	return out
+}
+
+// TestHandlerGroupKey covers the name → grouping-key heuristic.
+func TestHandlerGroupKey(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"viewset method", "RoleViewSet.retrieve", "RoleViewSet"},
+		{"nested method", "auth.RoleViewSet.create", "auth.RoleViewSet"},
+		{"bare function view", "health_check", "health_check"},
+		{"scope-separated", "pkg::OrderViewSet", "OrderViewSet"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := handlerGroupKey(&graph.Entity{Name: tc.in})
+			if got != tc.want {
+				t.Errorf("handlerGroupKey(%q) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -235,6 +235,10 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 	var eps []rawEP
 
 	for _, repo := range sortedRepos(grp) {
+		// #1646 — per-repo handler-resolution index so each endpoint definition
+		// can be grouped by its owning viewset/module rather than the shared
+		// route-registration file (routers.py / urls.py).
+		idx := buildRepoEntityIndex(repo)
 		for i := range repo.Doc.Entities {
 			e := &repo.Doc.Entities[i]
 			kind := dashStripScopePrefix(e.Kind)
@@ -269,12 +273,38 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			// top-level grouping key on a real multi-repo platform (#1551).
 			owningBackend := repo.Slug
 
-			// Controller/module = the source file the handler lives in. For
-			// framework controllers ("orders.controller.ts") and GraphQL
-			// resolver files ("resolvers.ts") this maps directly to the unit a
-			// developer thinks in, which the raw `controller` property
-			// (one-per-endpoint garbage) does not. Fall back to a name heuristic.
-			controllerID := controllerKeyFromFile(e.SourceFile)
+			// Controller/module — resolve the endpoint definition to its handler
+			// (the viewset method that IMPLEMENTS it) and group by the OWNING
+			// VIEWSET/CLASS ("RoleViewSet"), which is the unit a developer thinks
+			// in. DRF router-expanded definitions all share routers.py:0, so
+			// grouping by the definition's own file collapses dozens of viewsets
+			// into a single "routers" node — the #1646 bug. The handler's source
+			// file is the real controller file. We fall back to the framework
+			// controller-file convention (NestJS/GraphQL) and then a name
+			// heuristic when no handler resolves. (#1646)
+			controllerID := ""
+			controllerFile := e.SourceFile
+			// Only re-key by the resolved handler when the endpoint entity is a
+			// synthetic definition that resolved to a DISTINCT handler (the DRF
+			// router-expanded case). Endpoint entities that are themselves the
+			// route (NestJS/GraphQL/Go) keep the file-based grouping below.
+			if strings.EqualFold(dashStripScopePrefix(e.Kind), httpEndpointDefinitionKind) {
+				if handlerEnts := idx.resolveHandlers(e); len(handlerEnts) > 0 {
+					h := handlerEnts[0]
+					if h.ID != e.ID &&
+						!strings.EqualFold(dashStripScopePrefix(h.Kind), httpEndpointDefinitionKind) {
+						controllerID = handlerGroupKey(h)
+						if h.SourceFile != "" {
+							controllerFile = h.SourceFile
+						}
+					}
+				}
+			}
+			if controllerID == "" {
+				// Framework controllers ("orders.controller.ts") / GraphQL
+				// resolver files map cleanly to a developer unit by file.
+				controllerID = controllerKeyFromFile(e.SourceFile)
+			}
 			if controllerID == "" {
 				controllerID = e.Properties["controller"]
 			}
@@ -296,7 +326,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 				StartLine:      e.StartLine,
 				OwningBackend:  owningBackend,
 				ControllerID:   controllerID,
-				ControllerFile: e.SourceFile,
+				ControllerFile: controllerFile,
 				Language:       e.Language,
 			})
 		}
@@ -434,7 +464,7 @@ func (s *Server) handleV2PathsList(w http.ResponseWriter, r *http.Request) {
 			}
 			groups = append(groups, v2ControllerGroup{
 				ID:        cID,
-				Label:     controllerLabelFromFile(cm.file),
+				Label:     controllerLabel(cID, cm.file),
 				File:      cm.file,
 				IsWebhook: isWebhookCtrl,
 				Routes:    routes,
@@ -529,7 +559,10 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		DocsPath      string
 		ResponseKeys  []string
 		StatusCodes   []int
-		InboundIDs    []string
+		// CalledByIDs / OutboundIDs / SideEffectIDs / TestIDs are collected from
+		// the RESOLVED handler (the viewset method that IMPLEMENTS this endpoint
+		// definition), not the synthetic definition entity itself (#1646).
+		CalledByIDs   []string
 		OutboundIDs   []string
 		SideEffectIDs []string
 		TestIDs       []string
@@ -539,6 +572,10 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	var pathStr string
 	var isWebhook bool
 	var webhookProv string
+
+	// Per-repo entity index + handler-resolution map, built lazily and reused
+	// across all matched endpoint definitions in the same repo (#1646).
+	repoIdx := map[string]*repoEntityIndex{}
 
 	docgenState, _ := mcp.LoadDocgenState(id)
 
@@ -600,49 +637,68 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				}
 			}
 
-			// Collect edge IDs.
-			inbound := []string{}
-			outbound := []string{}
-			sideEffects := []string{}
-			tests := []string{}
-			for _, rel := range repo.Doc.Relationships {
-				if rel.ToID == e.ID && rel.Kind == "FETCHES" {
-					inbound = append(inbound, dashPrefixedID(repo.Slug, rel.FromID))
-				}
-				if rel.FromID == e.ID {
-					switch rel.Kind {
-					case "QUERIES", "ACCESSES_TABLE":
-						outbound = append(outbound, dashPrefixedID(repo.Slug, rel.ToID))
-					case "EMITS", "PUBLISHES_TO":
-						sideEffects = append(sideEffects, dashPrefixedID(repo.Slug, rel.ToID))
-					case "TESTS":
-						tests = append(tests, dashPrefixedID(repo.Slug, rel.ToID))
+			// #1646 — resolve this endpoint definition to its real handler(s)
+			// (the viewset method that IMPLEMENTS it) and collect the section
+			// edges from the HANDLER, not the synthetic definition (which carries
+			// no body edges). The definition ID is still passed so retargeted
+			// inbound FETCHES (caller → definition) surface as Called-by.
+			idx := repoIdx[repo.Slug]
+			if idx == nil {
+				idx = buildRepoEntityIndex(repo)
+				repoIdx[repo.Slug] = idx
+			}
+			handlerEnts := idx.resolveHandlers(e)
+			handlerIDs := make([]string, 0, len(handlerEnts))
+			for _, h := range handlerEnts {
+				handlerIDs = append(handlerIDs, h.ID)
+			}
+			classified := classifyHandlerEdges(idx, handlerIDs, []string{e.ID})
+
+			// Prefer the resolved handler's identity for the handler card so the
+			// detail shows the real viewset method + its source location, not the
+			// routers.py:0 synthetic. Fall back to the definition when unresolved.
+			handlerName := e.Name
+			handlerQN := e.Properties["qualified_name"]
+			handlerFile := e.SourceFile
+			handlerLine := e.StartLine
+			handlerLang := e.Language
+			if len(handlerEnts) > 0 {
+				h := handlerEnts[0]
+				if !strings.EqualFold(dashStripScopePrefix(h.Kind), httpEndpointDefinitionKind) {
+					handlerName = h.Name
+					if h.QualifiedName != "" {
+						handlerQN = h.QualifiedName
+					}
+					handlerFile = h.SourceFile
+					handlerLine = h.StartLine
+					if h.Language != "" {
+						handlerLang = h.Language
 					}
 				}
 			}
 
 			hits = append(hits, matched{
 				Verb:          verb,
-				Handler:       e.Name,
-				QualifiedName: e.Properties["qualified_name"],
+				Handler:       handlerName,
+				QualifiedName: handlerQN,
 				Framework:     e.Properties["framework"],
 				IsWebhook:     e.Properties["is_webhook"] == "true",
 				WebhookProv:   e.Properties["webhook_provider"],
 				Auth:          e.Properties["auth"] == "true" || e.Properties["auth_scheme"] != "",
 				AuthScheme:    e.Properties["auth_scheme"],
 				Repo:          repo.Slug,
-				SourceFile:    e.SourceFile,
-				StartLine:     e.StartLine,
-				Language:      e.Language,
+				SourceFile:    handlerFile,
+				StartLine:     handlerLine,
+				Language:      handlerLang,
 				HasDocs:       hasDocs,
 				DocsSummary:   docsSummary,
 				DocsPath:      docsPath,
 				ResponseKeys:  respKeys,
 				StatusCodes:   statusCodes,
-				InboundIDs:    inbound,
-				OutboundIDs:   outbound,
-				SideEffectIDs: sideEffects,
-				TestIDs:       tests,
+				CalledByIDs:   classified.calledBy,
+				OutboundIDs:   classified.downstream,
+				SideEffectIDs: classified.sideEffects,
+				TestIDs:       classified.tests,
 			})
 		}
 	}
@@ -748,18 +804,22 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	// Extract parameters from path segments (dynamic path params).
 	params := extractPathParameters(pathStr, verbs)
 
-	// Resolve entity IDs.
-	inboundIDs := collectUniqueIDs(hits, func(h matched) []string { return h.InboundIDs })
+	// Resolve entity IDs (#1646: all collected from the resolved handler).
+	calledByIDs := collectUniqueIDs(hits, func(h matched) []string { return h.CalledByIDs })
 	outboundIDs := collectUniqueIDs(hits, func(h matched) []string { return h.OutboundIDs })
 	sideEffectIDs := collectUniqueIDs(hits, func(h matched) []string { return h.SideEffectIDs })
 	testIDs := collectUniqueIDs(hits, func(h matched) []string { return h.TestIDs })
 
-	inboundFetches := resolveEntitySlice(grp, inboundIDs, "FETCHES")
-	outboundAll := resolveEntitySlice(grp, outboundIDs, "QUERIES")
-	sideEffectEntities := resolveEntitySlice(grp, sideEffectIDs, "EMITS")
+	// Called-by: inbound callers resolved to this endpoint (frontend FETCHES
+	// retargeted to the definition + intra-repo CALLS into the handler).
+	inboundFetches := resolveEntitySlice(grp, calledByIDs, "CALLED_BY")
+	// Downstream: the handler's outbound CALLS (services, helpers, DB-access fns).
+	outboundAll := resolveEntitySlice(grp, outboundIDs, "CALLS")
+	// Side effects: DB writes / model mutation / pub-sub the handler performs.
+	sideEffectEntities := resolveEntitySlice(grp, sideEffectIDs, "SIDE_EFFECT")
 	testEntities := resolveEntitySlice(grp, testIDs, "TESTS")
 
-	// Split outbound by kind.
+	// Split downstream callees by kind for the structured Outbound section.
 	outbound := v2OutboundQueries{
 		DB:       []v2PathEntity{},
 		Event:    []v2PathEntity{},
@@ -769,7 +829,7 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	}
 	for _, e := range outboundAll {
 		switch strings.ToLower(e.Kind) {
-		case "datastore", "table", "db", "database":
+		case "datastore", "table", "db", "database", "model", "dataaccess", "collection":
 			outbound.DB = append(outbound.DB, e)
 		case "event", "topic":
 			outbound.Event = append(outbound.Event, e)
@@ -906,6 +966,18 @@ func inferControllerName(handlerName string) string {
 		return handlerName[sc+2:]
 	}
 	return handlerName
+}
+
+// controllerLabel produces the display label for a controller group. When the
+// group id is a resolved viewset/class name (the #1646 path — it is not a file
+// path), it is used verbatim ("RoleViewSet"). Otherwise the group was keyed by
+// source file (NestJS/GraphQL/fallback) and we derive a friendly label from the
+// file convention.
+func controllerLabel(controllerID, file string) string {
+	if controllerID != "" && !strings.ContainsAny(controllerID, "/.") {
+		return controllerID
+	}
+	return controllerLabelFromFile(file)
 }
 
 // controllerKeyFromFile derives a stable controller/module grouping key from a


### PR DESCRIPTION
Fixes #1646

## What changed
- `internal/dashboard/paths_handler_resolve.go` (new) — per-repo entity index that resolves `http_endpoint_definition` → handler via the inbound `IMPLEMENTS` edge (and `ROUTES_TO` / `SERVES` for Spring/Nest), classifies the handler's edges into Called-by / Downstream / Side-effects / Tests, and derives a viewset/class grouping key from the handler name.
- `internal/dashboard/v2_paths.go` — `handleV2PathDetail` now traverses the **resolved handler's** edges (the four detail sections were empty before because they read off the synthetic definition, which carries no body edges). `handleV2PathsList` re-keys controller groups by the resolved viewset for router-expanded definitions while leaving NestJS / GraphQL / Go-net-http file-based grouping intact. Handler card now reports the real viewset method source file / line / qualified name.
- `internal/dashboard/paths_handler_resolve_test.go` (new) — DRF fixture covering handler resolution, populated detail sections, and viewset-based grouping invariant (`RoleViewSet` / `BuildingViewSet` instead of `routers.py` / `urls.py`).

## Why
DRF (and Spring / NestJS) emit a synthetic `http_endpoint_definition` per route at the registration site (`core/routers.py:0` for every DRF endpoint). The real CALLS / QUERIES / REFERENCES / ACCESSES_TABLE / TESTS edges live on the handler viewset method, linked by `handler --IMPLEMENTS--> definition`. The Paths detail and the list grouping both read off the definition entity, so every endpoint detail was 0/0/0/0 and the entire backend collapsed into two controllers.

## Verify
Live `:47274` was kept up read-only throughout. Built the daemon from this branch under an isolated `ARCHIGRAPH_DAEMON_ROOT` with `$ROOT/state/<hash>` symlinks pointing at the existing `~/.archigraph/store/<slug>-<hash>` dirs and served on `:47900` against the upvate corpus.

**Grouping — `/api/v2/groups/upvate/paths`** (before → after):
- Controllers: **2 → 60**. Before: `routers.py` (292 routes) + `urls.py` (19). After: BuildingViewSet 22, InspectionViewSet 20, GroupViewSet 16, DeviceViewSet 16, ContractViewSet 14, UserViewSet 14, ScheduleViewset 12, ClientViewSet 11, ProposalViewSet 10, ImportViewSet 8, JurisdictionViewSet 8, … (60 total). Two residual `routers` / `urls` groups remain for definitions still missing an `IMPLEMENTS` link.

**Detail — `/api/v1/roles/{pk}`** (before → after):
- Handlers: `http:PUT:/api/v1/roles/{pk}` @ `core/routers.py:0` (×5)  →  `RoleViewSet.update` / `.destroy` / `.retrieve` / `.partial_update` @ `core/views/role_viewset.py`.
- (RoleViewSet methods are thin CRUD, so the four sections legitimately stay empty for this one — see endpoints below for populated examples.)

**Detail — endpoints with real body edges**:
- `POST /api/v1/users/groups/roles` → handler `UserViewSet.groups_roles` @ `core/views/user_viewset.py:676`; downstream 2 (`GroupViewSet.filter`, `NoteDetailView.delete`); side_effects 2 (Model `UserGroupRole`, Model `UserGroup`).
- `POST /api/v1/inspections/update-deficiency` → handler `InspectionViewSet.update_deficiency` @ `core/views/inspection_viewset.py:2528`; downstream 3 (`MongoDBConnection.get_collection`, `MongoDBConnection.update_one`, `GroupViewSet.filter`); side_effects 1 (Model `Checklist`).
- `GET|POST /api/v1/buildings` → handlers `BuildingViewSet.list` (line 132), `BuildingViewSet.create` (line 208); downstream 5 (serializer, queryset, `create_building_and_devices`, `create_mass_building_and_devices`, `BuildingSerializer`).

`go vet ./internal/dashboard/` clean. Full dashboard tests pass except the pre-existing `TestYamlScalar` failure (same on `origin/main`, unrelated to this change).

## Scope notes
- The corpus-wide TESTS-edge thinness flagged in #1646 still applies: most TESTS edges in upvate point at helper Operations rather than viewset methods directly, so the Tests section is empty for most endpoints. The resolver correctly surfaces TESTS edges whenever they exist (covered by unit test). Walking from helper TESTS up into the viewset would need a second hop and is out of scope.
- Called-by surfaces retargeted frontend FETCHES via the #1615 matcher; the 702 orphan callers remain in the Orphans tab until they resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)