### PR TITLE
fix(django/signals): emit resolver-bindable topic stub IDs (Fixes #1649)

### DIFF
--- a/internal/engine/django_signal_pubsub_edges.go
+++ b/internal/engine/django_signal_pubsub_edges.go
@@ -245,16 +245,27 @@ func ApplyDjangoSignalPubSub(
 	emittedTopic := map[string]bool{}
 	seenEdge := map[string]bool{}
 
-	signalTopicID := func(name string) string {
-		return "django_signal:" + name
+	// topicStub returns the resolver-friendly stub form used on both the
+	// entity construction-time ID and on edge endpoints: "<kind>:<name>".
+	// The trailing name MUST match EntityRecord.Name verbatim — splitStub
+	// in resolve.Index.LookupStatusHint splits on the first ':' and then
+	// looks up byKind[kind][name] / byName[name]. Using "django_signal:<n>"
+	// as the name segment (as the original #1617 implementation did) broke
+	// the resolver lookup so every PUBLISHES_TO / SUBSCRIBES_TO ToID kept
+	// its stub form on-disk instead of being rewritten to the topic's hex
+	// EntityID, leaving topology queries blind to signal pub/sub at runtime
+	// (#1649). The "django_signal:" disambiguator is now carried only in
+	// Properties["signal"] (still set below).
+	topicStub := func(name string) string {
+		return signalTopicKind + ":" + name
 	}
 
 	emitTopic := func(name, sourceFile string) string {
-		id := signalTopicID(name)
-		if !emittedTopic[id] {
-			emittedTopic[id] = true
+		stub := topicStub(name)
+		if !emittedTopic[stub] {
+			emittedTopic[stub] = true
 			ents = append(ents, types.EntityRecord{
-				ID:         signalTopicKind + ":" + id,
+				ID:         stub,
 				Name:       name,
 				Kind:       signalTopicKind,
 				SourceFile: sourceFile,
@@ -270,21 +281,21 @@ func ApplyDjangoSignalPubSub(
 				QualityScore:       0.8,
 			})
 		}
-		return id
+		return stub
 	}
 
-	emitEdge := func(fromOp, topicID, kind string) {
+	emitEdge := func(fromOp, topicStub, kind string) {
 		if fromOp == "" {
 			return
 		}
-		key := kind + "|" + fromOp + "|" + topicID
+		key := kind + "|" + fromOp + "|" + topicStub
 		if seenEdge[key] {
 			return
 		}
 		seenEdge[key] = true
 		rels = append(rels, types.RelationshipRecord{
 			FromID: "SCOPE.Operation:" + fromOp,
-			ToID:   signalTopicKind + ":" + topicID,
+			ToID:   topicStub,
 			Kind:   kind,
 			Properties: map[string]string{
 				"framework":    "django_signals",

--- a/internal/engine/django_signal_pubsub_edges_test.go
+++ b/internal/engine/django_signal_pubsub_edges_test.go
@@ -3,6 +3,7 @@
 package engine
 
 import (
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/types"
@@ -157,7 +158,7 @@ def update(self, request):
 	foundSub := false
 	for _, r := range subs {
 		if r.FromID == "SCOPE.Operation:handle_inspection_pre_update" &&
-			r.ToID == signalTopicKind+":django_signal:inspection_pre_update" {
+			r.ToID == signalTopicKind+":inspection_pre_update" {
 			foundSub = true
 		}
 	}
@@ -173,6 +174,34 @@ def update(self, request):
 	}
 	if !foundPub {
 		t.Errorf("missing publisher edge from update(); pubs=%v", pubs)
+	}
+
+	// Regression guard for #1649: the topic entity's pre-stamp ID must match
+	// the form used on edge endpoints, AND the suffix after the first ':'
+	// must equal Entity.Name. resolve.splitStub splits on ':' and then looks
+	// up byKind[kind][name] / byName[name] — any mismatch leaves the ToID as
+	// a stub on-disk forever (PUBLISHES_TO/SUBSCRIBES_TO orphaned from their
+	// topic at runtime, even though graph.fb persistence is correct).
+	for _, e := range ents {
+		if e.Kind != signalTopicKind {
+			continue
+		}
+		want := signalTopicKind + ":" + e.Name
+		if e.ID != want {
+			t.Errorf("topic entity ID=%q want=%q (must round-trip splitStub→Name)", e.ID, want)
+		}
+	}
+	for _, r := range append(append([]types.RelationshipRecord(nil), subs...), pubs...) {
+		// ToID must be "<kind>:<bareName>" — never include the historical
+		// "django_signal:" disambiguator in the resolver-visible segment.
+		if !strings.HasPrefix(r.ToID, signalTopicKind+":") {
+			t.Errorf("edge ToID=%q missing %s: prefix", r.ToID, signalTopicKind)
+			continue
+		}
+		suffix := r.ToID[len(signalTopicKind)+1:]
+		if strings.Contains(suffix, ":") {
+			t.Errorf("edge ToID=%q has extra ':' in name segment — resolver will fail to bind to topic Entity.Name (#1649)", r.ToID)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Quality benchmark iter2 (Phase-6 calibration) flagged Django signal pub/sub showing **0 topics / 0 edges at runtime on upvate** despite #1617/#1631 shipping the synthesis pass. Suspected an #1620-family `graph.fb` schema gap. It isn't. Persistence is correct; the resolver was the wrong layer.

Fixes #1649.

## 1. What it does

`engine.ApplyDjangoSignalPubSub` constructs synthetic `SCOPE.MessageTopic` entities for every `sig = Signal()` custom signal plus `SUBSCRIBES_TO` from `@receiver` handlers and `PUBLISHES_TO` from `.send()`/`.send_robust()` callers. The fix rewrites the construction-time stub form from `SCOPE.MessageTopic:django_signal:<name>` to `SCOPE.MessageTopic:<name>` on both the entity ID and edge endpoints so `resolve.Index.LookupStatusHint` can bind them.

The `django_signal:` disambiguator is still preserved on `Properties[\"signal\"]` for downstream topology consumers.

## 2. Why it's needed (root cause)

The .fb writer/reader carry `kind: string` opaquely; round-trip is byte-identical. Persistence was never the bug.

`resolve.Index.LookupStatusHint(stub)` does:

\`\`\`
splitStub on first ':' -> (kind, name)
byKind[kind][name]  -> hex ID, else
byName[name]        -> hex ID, else
keep stub
\`\`\`

`byKind` and `byName` are populated from `Entity.Name` (after `stampEntityIDs` re-computes ID = sha256(repo, kind, name, sourceFile)). The synthesis pass set `Entity.Name = \"inspection_pre_update\"` but the edge ToID was `\"SCOPE.MessageTopic:django_signal:inspection_pre_update\"`. `splitStub` yielded `name = \"django_signal:inspection_pre_update\"` — which matches nothing. Every signal `PUBLISHES_TO` / `SUBSCRIBES_TO` ToID stayed in stub form forever, so MCP topology / find_callees saw a dangling stub instead of the topic node and reported 0 edges.

Celery dispatch edges (`Function:<task>`) bind correctly because the task name segment matches `Entity.Name`.

## 3. Before/after — isolated probe of upvate

|                    | Before (main) | After (this PR) |
|--------------------|--------------:|----------------:|
| Signal PUBLISHES_TO ToID hex   | 0  | 8  |
| Signal PUBLISHES_TO ToID stub  | 8  | 0  |
| Signal SUBSCRIBES_TO ToID hex  | 0  | 6  |
| Signal SUBSCRIBES_TO ToID stub | 6  | 0  |
| Celery CALLS ToID hex          | 12 | 12 |
| `SCOPE.MessageTopic` entities  | 6  | 6  |
| graph.fb round-trip parity     | identical | identical |

Resolver counter delta: `rewrote 14692 → 14706` (+14, exactly the signal edges); `unmatched 16833 → 16819` (-14).

## 4. Tests

Existing `TestApplyDjangoSignalPubSub_PublisherAndSubscriber` is updated to assert the new stub form. A regression guard is added that locks the resolver contract:

- topic `Entity.ID` must equal `\"<kind>:\" + Entity.Name`
- every emitted edge `ToID`'s name segment must not contain `':'` (so `splitStub` lands on `Entity.Name` verbatim)

Any future change that reintroduces a disambiguator into the resolver-visible segment fails the test before it can ship.

All resolver, engine, graph, fbwriter, fbreader, links, mcp, patterns, quality unit suites pass. Pre-existing flakes on main (TestDebounce, TestPhaseB_*, TestYamlScalar, etc.) are unchanged.

## 5. Verification

- `go vet ./cmd/... ./internal/...` clean
- `go build ./cmd/... ./internal/...` clean
- Engine + resolve + graph + fbwriter + fbreader test packages: **all green**
- Targeted probe on real upvate corpus (`/Users/jorgecajas/Documents/Projects/UpVate/upvate_core`): edges survive end-to-end through graph.json → graph.fb → in-process fbreader with all ToIDs resolved to hex (counts above)
- Did **not** touch `internal/mcp` (#1650 owns that), the indexer write paths (#461), or the live :47274 daemon

## 6. Scope / non-goals

- Out of scope: any MCP-side topology query change (the edges now resolve at the graph layer, so MCP gets the right answers without a server change)
- Out of scope: the `archigraph_find_callees` end-to-end MCP round-trip — daemon was deliberately not restarted per task instructions; once landed and re-indexed, `archigraph_topology` and `archigraph_find_callees` on Celery `.delay()` / signal `.send()` call sites will surface the now-resolved edges
- Out of scope: any change to celery dispatch (already resolves correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)