### PR TITLE
[#1627] Graph export/import — back up + restore an indexed group as a zip

### DIFF
--- a/internal/dashboard/handlers_v2_graph_export.go
+++ b/internal/dashboard/handlers_v2_graph_export.go
@@ -1,0 +1,617 @@
+// handlers_v2_graph_export.go — WebUI v2 GRAPH export + import endpoints.
+//
+// Parallel to handlers_v2_docs.go (#1658) which exports generated markdown
+// docs, these endpoints export/import the GRAPH data — the indexed store
+// contents (graph.fb, graph.json, enrichments, links, metadata, embeddings)
+// plus the fleet config — so a group can be backed up, transferred
+// machine-to-machine, or shared.
+//
+// Routes (registered in server.go):
+//
+//	GET  /api/v2/groups/{group}/export?format=zip&kind=graph|all  → handleV2GraphExport
+//	POST /api/v2/groups/import?force=true&name=<override>         → handleV2GraphImport
+//
+// Archive layout (extensible — see ExportManifest.Version):
+//
+//	<group>/manifest.json                — ExportManifest (version + group + repos)
+//	<group>/fleet.json                   — copy of the per-group config
+//	<group>/store/<repoSlug>/...         — entire daemon store dir for each repo
+//	                                       (graph.fb, graph.json, enrichments,
+//	                                       links, metadata, embeddings.bin, ...)
+//	<group>/docs/<repoSlug>/...          — generated technical docs   (kind=all only)
+//	<group>/docs/business/...            — generated business docs    (kind=all only)
+//
+// On import the daemon:
+//   1. unpacks the archive into a temp dir,
+//   2. validates the manifest + required layout,
+//   3. relocates each store payload into the local daemon's store dir
+//      (`$ARCHIGRAPH_HOME/store/<slug>-<hash>`), keyed by repo path,
+//   4. writes the fleet config to its canonical path,
+//   5. registers the group with the registry,
+//   6. (optionally) copies generated docs into the docs store.
+//
+// The endpoint refuses if the target group is already registered unless
+// `force=true` is set. `name=<override>` lets a caller import the archive
+// under a different group slug — useful when comparing a backup against the
+// live group without overwriting it.
+//
+// The graph cache is invalidated for the imported group so the next read
+// re-loads from the freshly restored store.
+
+package dashboard
+
+import (
+	"archive/zip"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// exportManifestVersion is the current archive format version. Bump when
+// the on-disk layout changes in a way an old importer cannot handle.
+const exportManifestVersion = 1
+
+// maxImportArchiveBytes caps the body size accepted by the import endpoint
+// (1 GiB). Big graphs are real — embeddings + flatbuffer + JSON sidecars
+// for a polyglot platform can be hundreds of MB — so the cap is generous
+// but bounded to keep the daemon from being trivially DoS-ed.
+const maxImportArchiveBytes = 1 << 30
+
+// ExportManifest is the small json sidecar packed at the top of every
+// graph archive. It lets the importer validate compatibility without
+// having to parse the fleet config first, and records useful provenance.
+type ExportManifest struct {
+	Version    int               `json:"version"`
+	Kind       string            `json:"kind"` // "graph" or "all"
+	Group      string            `json:"group"`
+	ExportedAt string            `json:"exported_at"` // RFC3339 UTC
+	Repos      []ExportRepoEntry `json:"repos"`
+}
+
+// ExportRepoEntry records one repo's identity inside the archive so the
+// importer can map archive paths back to a registry.Repo entry without
+// re-deriving slug hashes.
+type ExportRepoEntry struct {
+	Slug     string `json:"slug"`
+	Path     string `json:"path"`      // original absolute path on the exporting host
+	Stack    string `json:"stack,omitempty"`
+	CloneURL string `json:"clone_url,omitempty"`
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Export
+// ──────────────────────────────────────────────────────────────────────────
+
+// handleV2GraphExport — GET /api/v2/groups/{group}/export?format=zip&kind=graph|all
+//
+// Streams a zip archive of the graph store for every repo in the group
+// plus the fleet config. With kind=all the generated docs (technical +
+// business) are bundled too. Designed to be extensible: additional kinds
+// or formats can be added without breaking the existing contract.
+func (s *Server) handleV2GraphExport(w http.ResponseWriter, r *http.Request) {
+	groupName := r.PathValue("group")
+	if groupName == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+	configPath, err := groupConfigPath(groupName)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", "group not found: "+groupName)
+		return
+	}
+	cfg, err := registry.LoadGroupConfig(configPath)
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error", "load fleet: "+err.Error())
+		return
+	}
+
+	format := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("format")))
+	if format == "" {
+		format = "zip"
+	}
+	if format != "zip" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request",
+			"unsupported format: "+format+" (supported: zip)")
+		return
+	}
+
+	kind := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("kind")))
+	if kind == "" {
+		kind = "graph"
+	}
+	switch kind {
+	case "graph", "all":
+	default:
+		writeV2Err(w, http.StatusBadRequest, "bad_request",
+			"unsupported kind: "+kind+" (supported: graph, all)")
+		return
+	}
+
+	// Build the manifest from the live fleet config so import doesn't have
+	// to recompute slugs.
+	manifest := ExportManifest{
+		Version:    exportManifestVersion,
+		Kind:       kind,
+		Group:      groupName,
+		ExportedAt: time.Now().UTC().Format(time.RFC3339),
+		Repos:      make([]ExportRepoEntry, 0, len(cfg.Repos)),
+	}
+	for _, rp := range cfg.Repos {
+		manifest.Repos = append(manifest.Repos, ExportRepoEntry{
+			Slug:     rp.Slug,
+			Path:     rp.Path,
+			Stack:    rp.Stack,
+			CloneURL: rp.CloneURL,
+		})
+	}
+
+	filename := fmt.Sprintf("%s-graph-%s.zip", groupName,
+		time.Now().UTC().Format("20060102-150405"))
+	w.Header().Set("Content-Type", "application/zip")
+	w.Header().Set("Content-Disposition", `attachment; filename="`+filename+`"`)
+
+	zw := zip.NewWriter(w)
+	defer zw.Close()
+
+	// 1) Manifest at the archive top.
+	manifestBytes, _ := json.MarshalIndent(manifest, "", "  ")
+	if err := writeZipFile(zw, groupName+"/manifest.json", manifestBytes); err != nil {
+		return
+	}
+
+	// 2) Fleet config copy.
+	if raw, ferr := os.ReadFile(configPath); ferr == nil {
+		if err := writeZipFile(zw, groupName+"/fleet.json", raw); err != nil {
+			return
+		}
+	}
+
+	// 3) Per-repo store directories.
+	// Sort repos by slug for deterministic archives (helps test snapshots).
+	repos := append([]registry.Repo(nil), cfg.Repos...)
+	sort.Slice(repos, func(i, j int) bool { return repos[i].Slug < repos[j].Slug })
+	for _, rp := range repos {
+		stateDir := daemon.StateDirForRepo(rp.Path)
+		if !dirHasContent(stateDir) {
+			// Skip repos that have never been indexed — keep the archive clean.
+			continue
+		}
+		prefix := groupName + "/store/" + rp.Slug
+		if err := zipAddTree(zw, stateDir, prefix); err != nil {
+			// Best-effort: response already streaming; abort.
+			return
+		}
+	}
+
+	// 4) kind=all also bundles generated docs (mirrors #1658 docs export).
+	if kind == "all" {
+		// Technical docs per repo (only the store layout — pre-#1624 in-repo
+		// docs are out of scope; the canonical store wins).
+		for _, rp := range repos {
+			docsDir := daemon.RepoDocsDir(groupName, rp.Slug)
+			if !dirHasContent(docsDir) {
+				continue
+			}
+			if err := zipAddTree(zw, docsDir,
+				groupName+"/docs/"+rp.Slug); err != nil {
+				return
+			}
+		}
+		// Business docs (group-level).
+		if bizDir := daemon.BusinessDocsDir(groupName); dirHasContent(bizDir) {
+			if err := zipAddTree(zw, bizDir,
+				groupName+"/docs/business"); err != nil {
+				return
+			}
+		}
+	}
+}
+
+// writeZipFile is a tiny helper for stuffing in-memory bytes (manifest +
+// fleet copy) into the archive. Uses Deflate to match zipAddTree.
+func writeZipFile(zw *zip.Writer, name string, data []byte) error {
+	fh := &zip.FileHeader{
+		Name:     name,
+		Method:   zip.Deflate,
+		Modified: time.Now(),
+	}
+	w, err := zw.CreateHeader(fh)
+	if err != nil {
+		return err
+	}
+	_, err = w.Write(data)
+	return err
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Import
+// ──────────────────────────────────────────────────────────────────────────
+
+// v2GraphImportReply is the success envelope payload.
+type v2GraphImportReply struct {
+	Group  string   `json:"group"`
+	Repos  []string `json:"repos"`
+	Forced bool     `json:"forced"`
+}
+
+// handleV2GraphImport — POST /api/v2/groups/import
+//
+// Body: a zip archive produced by handleV2GraphExport (any kind).
+// Content-Type may be application/zip OR multipart/form-data with a `file`
+// field (the WebUI uses the latter so a file picker can attach the upload).
+//
+// Query params:
+//   - force=true        — overwrite an existing group of the same name.
+//   - name=<override>   — register the archive under a different group slug.
+//
+// On success the daemon: writes the fleet config to its canonical path,
+// restores each repo's store dir under the local daemon's store root,
+// registers the group with the registry, and (when present) restores the
+// docs trees. The graph cache for the imported group is invalidated so the
+// next read loads fresh state.
+func (s *Server) handleV2GraphImport(w http.ResponseWriter, r *http.Request) {
+	force := strings.EqualFold(r.URL.Query().Get("force"), "true")
+	nameOverride := strings.TrimSpace(r.URL.Query().Get("name"))
+
+	body, cleanup, err := readImportBody(r)
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	defer cleanup()
+
+	zr, err := zip.NewReader(body, body.Size())
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request",
+			"invalid zip archive: "+err.Error())
+		return
+	}
+
+	// Validate layout: locate manifest.json under a single top-level group
+	// directory.
+	manifest, archiveGroup, err := readManifestFromZip(zr)
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", err.Error())
+		return
+	}
+	if manifest.Version > exportManifestVersion {
+		writeV2Err(w, http.StatusBadRequest, "unsupported_version",
+			fmt.Sprintf("manifest version %d is newer than this daemon supports (%d)",
+				manifest.Version, exportManifestVersion))
+		return
+	}
+
+	// Decide on the final group name.
+	finalGroup := manifest.Group
+	if nameOverride != "" {
+		finalGroup = nameOverride
+	}
+	if finalGroup == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "manifest is missing group name")
+		return
+	}
+
+	// Conflict check.
+	existingPath, _ := groupConfigPath(finalGroup)
+	if existingPath != "" && !force {
+		writeV2Err(w, http.StatusConflict, "conflict",
+			fmt.Sprintf("group %q already exists; pass force=true to overwrite", finalGroup))
+		return
+	}
+
+	// Load the bundled fleet config and apply the group-name override + any
+	// slug-keyed restore mapping.
+	bundledFleetPath := archiveGroup + "/fleet.json"
+	cfg, err := readFleetFromZip(zr, bundledFleetPath)
+	if err != nil {
+		writeV2Err(w, http.StatusBadRequest, "bad_request",
+			"missing or invalid fleet.json in archive: "+err.Error())
+		return
+	}
+	cfg.Name = finalGroup
+
+	// Restore each repo's store dir into the local daemon's store layout.
+	// We key the destination by the ORIGINAL absolute path recorded in the
+	// manifest (and stored on the fleet's Repo.Path). This preserves the
+	// install-local layout: re-importing onto the same host hits the same
+	// store dir; importing onto a different host keeps repos addressable
+	// via their original paths (and the user can rebind via the Settings
+	// "Add repo" flow if the path differs on the new host).
+	for _, rp := range cfg.Repos {
+		archivePrefix := archiveGroup + "/store/" + rp.Slug + "/"
+		destStateDir := daemon.StateDirForRepo(rp.Path)
+		if destStateDir == "" {
+			continue
+		}
+		if err := os.MkdirAll(destStateDir, 0o755); err != nil {
+			writeV2Err(w, http.StatusInternalServerError, "internal_error",
+				"mkdir state dir: "+err.Error())
+			return
+		}
+		if err := extractZipPrefix(zr, archivePrefix, destStateDir); err != nil {
+			writeV2Err(w, http.StatusInternalServerError, "internal_error",
+				"restore store for "+rp.Slug+": "+err.Error())
+			return
+		}
+	}
+
+	// Restore docs trees if the archive contained them (kind=all export).
+	if manifest.Kind == "all" {
+		for _, rp := range cfg.Repos {
+			archivePrefix := archiveGroup + "/docs/" + rp.Slug + "/"
+			destDocsDir := daemon.RepoDocsDir(finalGroup, rp.Slug)
+			if destDocsDir == "" || !zipPrefixExists(zr, archivePrefix) {
+				continue
+			}
+			if err := os.MkdirAll(destDocsDir, 0o755); err != nil {
+				writeV2Err(w, http.StatusInternalServerError, "internal_error",
+					"mkdir docs dir: "+err.Error())
+				return
+			}
+			if err := extractZipPrefix(zr, archivePrefix, destDocsDir); err != nil {
+				writeV2Err(w, http.StatusInternalServerError, "internal_error",
+					"restore docs for "+rp.Slug+": "+err.Error())
+				return
+			}
+		}
+		bizPrefix := archiveGroup + "/docs/business/"
+		if zipPrefixExists(zr, bizPrefix) {
+			destBiz := daemon.BusinessDocsDir(finalGroup)
+			if destBiz != "" {
+				_ = os.MkdirAll(destBiz, 0o755)
+				if err := extractZipPrefix(zr, bizPrefix, destBiz); err != nil {
+					writeV2Err(w, http.StatusInternalServerError, "internal_error",
+						"restore business docs: "+err.Error())
+					return
+				}
+			}
+		}
+	}
+
+	// Persist the fleet config + register the group.
+	finalConfigPath, err := registry.ConfigPathFor(finalGroup)
+	if err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error",
+			"resolve config path: "+err.Error())
+		return
+	}
+	if err := registry.SaveGroupConfig(finalConfigPath, cfg); err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error",
+			"save fleet: "+err.Error())
+		return
+	}
+	if err := registry.AddGroup(finalGroup, finalConfigPath); err != nil {
+		writeV2Err(w, http.StatusInternalServerError, "internal_error",
+			"register group: "+err.Error())
+		return
+	}
+
+	// Bust the cached graph for this group so the next read picks up the
+	// freshly restored store. Non-fatal if the cache layer is absent
+	// (e.g. fresh import for a never-loaded group).
+	if s.graphs != nil {
+		s.graphs.Invalidate(finalGroup)
+	}
+
+	repos := make([]string, 0, len(cfg.Repos))
+	for _, rp := range cfg.Repos {
+		repos = append(repos, rp.Slug)
+	}
+	writeV2JSON(w, http.StatusOK, v2OK(v2GraphImportReply{
+		Group:  finalGroup,
+		Repos:  repos,
+		Forced: existingPath != "" && force,
+	}))
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Import helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+// sizedReaderAt is the zip.NewReader contract: a ReaderAt with known size.
+type sizedReaderAt struct {
+	io.ReaderAt
+	size int64
+}
+
+func (s *sizedReaderAt) Size() int64 { return s.size }
+
+// readImportBody pulls the zip bytes out of either a raw application/zip
+// body or a multipart/form-data upload (the WebUI uses the multipart form).
+// Returns a sized ReaderAt over the bytes + a cleanup callback.
+//
+// The body is bounded by maxImportArchiveBytes — anything bigger is
+// rejected to keep the daemon from being trivially DoS-ed.
+func readImportBody(r *http.Request) (*sizedReaderAt, func(), error) {
+	ct := r.Header.Get("Content-Type")
+	noop := func() {}
+
+	if strings.HasPrefix(ct, "multipart/form-data") {
+		// Up to maxImportArchiveBytes — multipart parses lazily so cap reader.
+		r.Body = http.MaxBytesReader(nil, r.Body, maxImportArchiveBytes)
+		if err := r.ParseMultipartForm(32 << 20); err != nil {
+			return nil, noop, fmt.Errorf("parse multipart: %w", err)
+		}
+		file, _, err := r.FormFile("file")
+		if err != nil {
+			return nil, noop, fmt.Errorf("missing 'file' form field: %w", err)
+		}
+		defer file.Close()
+		tmp, err := os.CreateTemp("", "archigraph-import-*.zip")
+		if err != nil {
+			return nil, noop, err
+		}
+		if _, err := io.Copy(tmp, file); err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, noop, err
+		}
+		fi, err := tmp.Stat()
+		if err != nil {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+			return nil, noop, err
+		}
+		cleanup := func() {
+			_ = tmp.Close()
+			_ = os.Remove(tmp.Name())
+		}
+		return &sizedReaderAt{ReaderAt: tmp, size: fi.Size()}, cleanup, nil
+	}
+
+	// Default path: treat the body as raw zip bytes.
+	r.Body = http.MaxBytesReader(nil, r.Body, maxImportArchiveBytes)
+	tmp, err := os.CreateTemp("", "archigraph-import-*.zip")
+	if err != nil {
+		return nil, noop, err
+	}
+	if _, err := io.Copy(tmp, r.Body); err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return nil, noop, err
+	}
+	fi, err := tmp.Stat()
+	if err != nil {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+		return nil, noop, err
+	}
+	cleanup := func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmp.Name())
+	}
+	return &sizedReaderAt{ReaderAt: tmp, size: fi.Size()}, cleanup, nil
+}
+
+// readManifestFromZip locates the top-level <group>/manifest.json entry
+// and returns the parsed manifest plus the archive's top-level group dir
+// (which may differ from the eventual register-as group name).
+func readManifestFromZip(zr *zip.Reader) (ExportManifest, string, error) {
+	var manifestEntry *zip.File
+	for _, f := range zr.File {
+		// Look for exactly one "<X>/manifest.json" at depth 1.
+		name := filepath.ToSlash(f.Name)
+		parts := strings.SplitN(name, "/", 2)
+		if len(parts) == 2 && parts[1] == "manifest.json" {
+			if manifestEntry != nil {
+				return ExportManifest{}, "",
+					errors.New("archive contains multiple manifest.json files")
+			}
+			manifestEntry = f
+		}
+	}
+	if manifestEntry == nil {
+		return ExportManifest{}, "",
+			errors.New("archive is missing <group>/manifest.json")
+	}
+	rc, err := manifestEntry.Open()
+	if err != nil {
+		return ExportManifest{}, "", err
+	}
+	defer rc.Close()
+	raw, err := io.ReadAll(rc)
+	if err != nil {
+		return ExportManifest{}, "", err
+	}
+	var m ExportManifest
+	if err := json.Unmarshal(raw, &m); err != nil {
+		return ExportManifest{}, "", fmt.Errorf("manifest.json: %w", err)
+	}
+	archiveGroup := strings.SplitN(filepath.ToSlash(manifestEntry.Name), "/", 2)[0]
+	return m, archiveGroup, nil
+}
+
+// readFleetFromZip reads the bundled fleet.json from the archive and
+// returns the parsed config. Used to restore the per-group config on
+// import.
+func readFleetFromZip(zr *zip.Reader, path string) (*registry.GroupConfig, error) {
+	for _, f := range zr.File {
+		if filepath.ToSlash(f.Name) != path {
+			continue
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return nil, err
+		}
+		defer rc.Close()
+		raw, err := io.ReadAll(rc)
+		if err != nil {
+			return nil, err
+		}
+		cfg := &registry.GroupConfig{}
+		if err := json.Unmarshal(raw, cfg); err != nil {
+			return nil, err
+		}
+		return cfg, nil
+	}
+	return nil, fmt.Errorf("missing %s", path)
+}
+
+// zipPrefixExists reports whether any file in the zip has a name starting
+// with prefix. Used to skip docs restoration when none was bundled.
+func zipPrefixExists(zr *zip.Reader, prefix string) bool {
+	for _, f := range zr.File {
+		if strings.HasPrefix(filepath.ToSlash(f.Name), prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// extractZipPrefix copies every file under `prefix` in zr into destRoot,
+// preserving the suffix path. Skips directory entries and refuses paths
+// that escape destRoot (defence in depth against zip-slip).
+func extractZipPrefix(zr *zip.Reader, prefix, destRoot string) error {
+	absRoot, err := filepath.Abs(destRoot)
+	if err != nil {
+		return err
+	}
+	for _, f := range zr.File {
+		name := filepath.ToSlash(f.Name)
+		if !strings.HasPrefix(name, prefix) {
+			continue
+		}
+		rel := strings.TrimPrefix(name, prefix)
+		if rel == "" || strings.HasSuffix(rel, "/") {
+			continue
+		}
+		// zip-slip guard.
+		destPath := filepath.Join(absRoot, filepath.FromSlash(rel))
+		if !strings.HasPrefix(destPath+string(os.PathSeparator), absRoot+string(os.PathSeparator)) &&
+			destPath != absRoot {
+			return fmt.Errorf("archive entry escapes destination: %s", name)
+		}
+		if err := os.MkdirAll(filepath.Dir(destPath), 0o755); err != nil {
+			return err
+		}
+		rc, err := f.Open()
+		if err != nil {
+			return err
+		}
+		out, err := os.Create(destPath)
+		if err != nil {
+			rc.Close()
+			return err
+		}
+		if _, err := io.Copy(out, rc); err != nil {
+			rc.Close()
+			out.Close()
+			return err
+		}
+		rc.Close()
+		if err := out.Close(); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/dashboard/handlers_v2_graph_export_test.go
+++ b/internal/dashboard/handlers_v2_graph_export_test.go
@@ -1,0 +1,364 @@
+// handlers_v2_graph_export_test.go — round-trip tests for #1627.
+//
+// Builds a small fake graph store on disk for a group, exports it via the
+// HTTP handler, then imports the resulting archive as a DIFFERENT group on
+// the same daemon and asserts the restored store is byte-for-byte equal
+// to the original. Also covers the conflict / force / format / kind paths.
+
+package dashboard
+
+import (
+	"archive/zip"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"mime/multipart"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// buildGraphExportTestServer seeds a fake archigraph home with one group
+// "alpha" containing one repo whose store dir is populated with the
+// canonical files that ship in a real graph (graph.fb / graph.json /
+// enrichments / links / metadata / embeddings.bin).
+func buildGraphExportTestServer(t *testing.T) (*Server, *registry.GroupConfig, string) {
+	t.Helper()
+
+	home := t.TempDir()
+	t.Setenv("ARCHIGRAPH_HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(home, "xdg"))
+
+	repoPath := filepath.Join(home, "repos", "alpha-repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Seed the store layout for the repo with the files that a real index
+	// would produce. Content is deterministic so hash compares are stable.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mustWrite(t, filepath.Join(stateDir, "graph.fb"), "FLATBUF-bytes")
+	mustWrite(t, filepath.Join(stateDir, "graph.json"), `{"entities":[]}`)
+	mustWrite(t, filepath.Join(stateDir, "enrichments", "http_endpoint.json"), `[{"id":"ep-1"}]`)
+	mustWrite(t, filepath.Join(stateDir, "links.json"), `{"links":[]}`)
+	mustWrite(t, filepath.Join(stateDir, "metadata.json"), `{"computed_at":"2026-05-23T00:00:00Z"}`)
+	mustWrite(t, filepath.Join(stateDir, "embeddings.bin"), "EMBED-binary-bytes")
+
+	// Persist the fleet + register the group via the production helpers so
+	// the import path exercises the real registry plumbing.
+	cfgPath := filepath.Join(home, "alpha.fleet.json")
+	cfg := &registry.GroupConfig{
+		Name:  "alpha",
+		Repos: []registry.Repo{{Slug: "alpha-repo", Path: repoPath, Stack: "go"}},
+	}
+	cfg.Features.Watchers = true
+	if err := registry.SaveGroupConfig(cfgPath, cfg); err != nil {
+		t.Fatalf("SaveGroupConfig: %v", err)
+	}
+	if err := registry.AddGroup("alpha", cfgPath); err != nil {
+		t.Fatalf("AddGroup: %v", err)
+	}
+
+	srv, err := NewServer(DefaultConfig(), newFakeStore())
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	return srv, cfg, repoPath
+}
+
+// hashTree fingerprints every regular file under root as a map of
+// relpath → sha256-hex. Used to compare a freshly-imported store to the
+// original byte-for-byte without caring about mod-times.
+func hashTree(t *testing.T, root string) map[string]string {
+	t.Helper()
+	out := map[string]string{}
+	err := filepath.Walk(root, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return err
+		}
+		rel, _ := filepath.Rel(root, path)
+		rel = filepath.ToSlash(rel)
+		b, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		sum := sha256.Sum256(b)
+		out[rel] = hex.EncodeToString(sum[:])
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("hashTree %s: %v", root, err)
+	}
+	return out
+}
+
+// TestGraphExportImport_RoundTrip is the headline round-trip: export the
+// alpha group's store, import it as alpha-copy on the same daemon, and
+// assert (a) the import succeeded, (b) the new group is registered, and
+// (c) the restored store matches the original byte-for-byte.
+func TestGraphExportImport_RoundTrip(t *testing.T) {
+	srv, origCfg, origRepoPath := buildGraphExportTestServer(t)
+	origStateDir := daemon.StateDirForRepo(origRepoPath)
+	origHashes := hashTree(t, origStateDir)
+	if len(origHashes) == 0 {
+		t.Fatal("expected non-empty store before export")
+	}
+
+	// 1) Export.
+	er := httptest.NewRequest("GET",
+		"/api/v2/groups/alpha/export?format=zip&kind=graph", nil)
+	ew := httptest.NewRecorder()
+	srv.routes().ServeHTTP(ew, er)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("export: expected 200, got %d: %s", ew.Code, ew.Body.String())
+	}
+	if got := ew.Header().Get("Content-Type"); got != "application/zip" {
+		t.Fatalf("Content-Type = %q, want application/zip", got)
+	}
+	archive := ew.Body.Bytes()
+	if len(archive) < 100 {
+		t.Fatalf("archive suspiciously small: %d bytes", len(archive))
+	}
+
+	// Quick sanity-check: the manifest + at least one store file are present.
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		t.Fatalf("zip parse: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	for _, want := range []string{
+		"alpha/manifest.json",
+		"alpha/fleet.json",
+		"alpha/store/alpha-repo/graph.fb",
+		"alpha/store/alpha-repo/graph.json",
+		"alpha/store/alpha-repo/enrichments/http_endpoint.json",
+		"alpha/store/alpha-repo/links.json",
+		"alpha/store/alpha-repo/metadata.json",
+		"alpha/store/alpha-repo/embeddings.bin",
+	} {
+		if !names[want] {
+			t.Errorf("missing %s in archive; names = %v", want,
+				sortedKeys(names))
+		}
+	}
+
+	// 2) Import as a different group name on the same daemon.
+	body, contentType := multipartZip(t, archive)
+	ir := httptest.NewRequest("POST",
+		"/api/v2/groups/import?name=alpha-copy", body)
+	ir.Header.Set("Content-Type", contentType)
+	iw := httptest.NewRecorder()
+	srv.routes().ServeHTTP(iw, ir)
+	if iw.Code != http.StatusOK {
+		t.Fatalf("import: expected 200, got %d: %s", iw.Code, iw.Body.String())
+	}
+	var env v2Envelope
+	if err := json.Unmarshal(iw.Body.Bytes(), &env); err != nil {
+		t.Fatalf("decode envelope: %v", err)
+	}
+	if !env.OK {
+		t.Fatalf("envelope.ok=false: %s", iw.Body.String())
+	}
+	reply, _ := env.Data.(map[string]interface{})
+	if reply["group"] != "alpha-copy" {
+		t.Errorf("expected group=alpha-copy, got %v", reply["group"])
+	}
+
+	// 3) Assert the imported group is registered.
+	groups, err := registry.Groups()
+	if err != nil {
+		t.Fatalf("registry.Groups: %v", err)
+	}
+	hasCopy := false
+	for _, g := range groups {
+		if g.Name == "alpha-copy" {
+			hasCopy = true
+			// Fleet contents should match the original (modulo name override).
+			cfg, err := registry.LoadGroupConfig(g.ConfigPath)
+			if err != nil {
+				t.Fatalf("LoadGroupConfig: %v", err)
+			}
+			if cfg.Name != "alpha-copy" {
+				t.Errorf("imported fleet.Name = %q, want alpha-copy", cfg.Name)
+			}
+			if len(cfg.Repos) != len(origCfg.Repos) {
+				t.Errorf("imported repos = %d, want %d", len(cfg.Repos), len(origCfg.Repos))
+			}
+			if cfg.Repos[0].Path != origCfg.Repos[0].Path {
+				t.Errorf("imported repo path mismatch: %q vs %q",
+					cfg.Repos[0].Path, origCfg.Repos[0].Path)
+			}
+			break
+		}
+	}
+	if !hasCopy {
+		t.Fatalf("alpha-copy not registered; have %v", groups)
+	}
+
+	// 4) The restored store directory should be byte-equal to the original.
+	// We restored under the same repo path because the manifest preserves it,
+	// so the destination is the same StateDirForRepo. Hash-compare what's on
+	// disk after the round-trip to confirm no file was dropped or corrupted.
+	newHashes := hashTree(t, origStateDir)
+	if len(newHashes) != len(origHashes) {
+		t.Fatalf("round-trip file count differs: orig=%d new=%d",
+			len(origHashes), len(newHashes))
+	}
+	for rel, want := range origHashes {
+		if got := newHashes[rel]; got != want {
+			t.Errorf("file %s hash mismatch after round-trip: want=%s got=%s",
+				rel, want, got)
+		}
+	}
+}
+
+// TestGraphExport_KindAll_BundlesDocs verifies that kind=all includes the
+// docs trees in the archive alongside the store.
+func TestGraphExport_KindAll_BundlesDocs(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+
+	// Seed technical + business docs.
+	techDir := daemon.RepoDocsDir("alpha", "alpha-repo")
+	mustWrite(t, filepath.Join(techDir, "overview.md"), "# Alpha\n")
+	bizDir := daemon.BusinessDocsDir("alpha")
+	mustWrite(t, filepath.Join(bizDir, "capabilities.md"), "# Caps\n")
+
+	r := httptest.NewRequest("GET",
+		"/api/v2/groups/alpha/export?format=zip&kind=all", nil)
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	zr, err := zip.NewReader(bytes.NewReader(w.Body.Bytes()), int64(w.Body.Len()))
+	if err != nil {
+		t.Fatalf("zip parse: %v", err)
+	}
+	names := map[string]bool{}
+	for _, f := range zr.File {
+		names[f.Name] = true
+	}
+	if !names["alpha/docs/alpha-repo/overview.md"] {
+		t.Errorf("missing technical doc in kind=all export: %v", sortedKeys(names))
+	}
+	if !names["alpha/docs/business/capabilities.md"] {
+		t.Errorf("missing business doc in kind=all export: %v", sortedKeys(names))
+	}
+}
+
+// TestGraphExport_UnknownGroup_404 verifies the not-found branch.
+func TestGraphExport_UnknownGroup_404(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+	r := httptest.NewRequest("GET",
+		"/api/v2/groups/ghost/export?format=zip", nil)
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, r)
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+// TestGraphExport_UnsupportedFormat verifies the bad-format branch.
+func TestGraphExport_UnsupportedFormat(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+	r := httptest.NewRequest("GET",
+		"/api/v2/groups/alpha/export?format=tar", nil)
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// TestGraphImport_Conflict refuses to overwrite an existing group unless
+// force=true is set.
+func TestGraphImport_Conflict(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+
+	// First, export.
+	er := httptest.NewRequest("GET", "/api/v2/groups/alpha/export", nil)
+	ew := httptest.NewRecorder()
+	srv.routes().ServeHTTP(ew, er)
+	if ew.Code != http.StatusOK {
+		t.Fatalf("export prep failed: %d", ew.Code)
+	}
+	archive := ew.Body.Bytes()
+
+	// Import-without-rename hits the existing "alpha" → must be a 409.
+	body, ct := multipartZip(t, archive)
+	r := httptest.NewRequest("POST", "/api/v2/groups/import", body)
+	r.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, r)
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409 conflict, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Same archive with force=true → succeeds.
+	body2, ct2 := multipartZip(t, archive)
+	r2 := httptest.NewRequest("POST",
+		"/api/v2/groups/import?force=true", body2)
+	r2.Header.Set("Content-Type", ct2)
+	w2 := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w2, r2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("force-import: expected 200, got %d: %s", w2.Code, w2.Body.String())
+	}
+}
+
+// TestGraphImport_InvalidArchive rejects non-zip bodies cleanly.
+func TestGraphImport_InvalidArchive(t *testing.T) {
+	srv, _, _ := buildGraphExportTestServer(t)
+	body, ct := multipartZip(t, []byte("not a zip"))
+	r := httptest.NewRequest("POST", "/api/v2/groups/import", body)
+	r.Header.Set("Content-Type", ct)
+	w := httptest.NewRecorder()
+	srv.routes().ServeHTTP(w, r)
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+// multipartZip wraps a zip body in a multipart/form-data envelope keyed
+// `file` — the same shape the WebUI's <input type="file"> uploader sends.
+func multipartZip(t *testing.T, archive []byte) (io.Reader, string) {
+	t.Helper()
+	var buf bytes.Buffer
+	mw := multipart.NewWriter(&buf)
+	part, err := mw.CreateFormFile("file", "graph.zip")
+	if err != nil {
+		t.Fatalf("CreateFormFile: %v", err)
+	}
+	if _, err := part.Write(archive); err != nil {
+		t.Fatalf("write part: %v", err)
+	}
+	if err := mw.Close(); err != nil {
+		t.Fatalf("close mw: %v", err)
+	}
+	return &buf, mw.FormDataContentType()
+}
+
+func sortedKeys(m map[string]bool) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -571,6 +571,13 @@ func (s *Server) routes() http.Handler {
 	// Docs export (#1624): streams an archive of a group's generated docs.
 	// Extensible by format (zip first) + kind (all|technical|business).
 	mux.HandleFunc("GET /api/v2/groups/{group}/docs/export", s.handleV2DocsExport)
+	// Graph export + import (#1627): streams an archive of the indexed store
+	// (graph.fb, enrichments, links, embeddings, fleet config); import accepts
+	// such an archive and restores the group. Extensible by format + kind.
+	// NOTE: registered BEFORE the wildcard /api/v2/groups/{group} GET below so
+	// Go 1.22 ServeMux picks the more-specific path first.
+	mux.HandleFunc("POST /api/v2/groups/import", s.handleV2GraphImport)
+	mux.HandleFunc("GET /api/v2/groups/{group}/export", s.handleV2GraphExport)
 	// Graph — the WebUI v2 hero surface payload (nodes/edges/communities/repos).
 	// Carries pagerank + source_file for cosmos.gl node sizing + module group-by.
 	mux.HandleFunc("GET /api/v2/graph/{group}", s.handleV2Graph)

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -204,6 +204,57 @@ export const api = {
     qs.set("kind", opts?.kind ?? "all");
     return `/api/v2/groups/${encodeURIComponent(groupId)}/docs/export?${qs.toString()}`;
   },
+  /**
+   * Graph export URL (#1627) — parallel to docsExportUrl. Streams an archive
+   * of the indexed store (graph.fb, enrichments, links, embeddings, fleet
+   * config) for the entire group. `kind=all` also bundles the generated docs
+   * so a single archive backs up the whole group surface. Returns a plain
+   * URL string for use as an anchor `href` so the browser handles the
+   * download lifecycle.
+   */
+  graphExportUrl: (
+    groupId: string,
+    opts?: { format?: "zip"; kind?: "graph" | "all" },
+  ) => {
+    const qs = new URLSearchParams();
+    qs.set("format", opts?.format ?? "zip");
+    qs.set("kind", opts?.kind ?? "graph");
+    return `/api/v2/groups/${encodeURIComponent(groupId)}/export?${qs.toString()}`;
+  },
+  /**
+   * POST /api/v2/groups/import (#1627) — restore a group from a zip archive
+   * previously produced by graphExportUrl. The browser uploads the zip as a
+   * multipart/form-data body keyed `file`. `force=true` overwrites an
+   * existing group of the same name; `name` registers the archive under a
+   * different group slug.
+   */
+  graphImport: async (
+    file: File,
+    opts?: { force?: boolean; name?: string },
+  ): Promise<{ group: string; repos: string[]; forced: boolean }> => {
+    const qs = new URLSearchParams();
+    if (opts?.force) qs.set("force", "true");
+    if (opts?.name) qs.set("name", opts.name);
+    const fd = new FormData();
+    fd.append("file", file);
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    const res = await fetch(`${BASE_V2}/groups/import${suffix}`, {
+      method: "POST",
+      body: fd,
+    });
+    let body: V2Ok<{ group: string; repos: string[]; forced: boolean }> | V2Err;
+    try {
+      body = (await res.json()) as
+        | V2Ok<{ group: string; repos: string[]; forced: boolean }>
+        | V2Err;
+    } catch {
+      throw new ApiError(res.status, `POST /groups/import failed: ${res.status}`);
+    }
+    if (!body.ok) {
+      throw new ApiError(res.status, body.error.message, body.error.code);
+    }
+    return body.data;
+  },
   /** v2 — the full graph payload (nodes/edges/communities/repos) for the Graph
    *  screen. `params` maps to the daemon's repo/kind filters. */
   getGraph: (groupId: string, params?: { repos?: string[]; filterKind?: string; lod?: string }) => {

--- a/webui-v2/src/routes/settings.tsx
+++ b/webui-v2/src/routes/settings.tsx
@@ -29,8 +29,13 @@ import {
   AlertTriangle,
   CheckCircle,
   Loader2,
+  Download,
+  Upload,
 } from "lucide-react";
 import { toast } from "sonner";
+
+import { api } from "@/lib/api";
+import { useQueryClient } from "@tanstack/react-query";
 
 import {
   Button,
@@ -822,7 +827,235 @@ function HealthSection({ groupId }: { groupId: string }) {
 }
 
 // ---------------------------------------------------------------------------
-// 6. Danger zone
+// 6. Export / Import (#1627)
+//
+// Parallel to the docs export shipped in #1658, this section lets users
+// archive the entire indexed graph + fleet config for a group (or download
+// the graph + docs together) and import an archive back to recreate the
+// group. Designed extensibly: today supports zip + (graph|all); future
+// formats slot into the same UI.
+// ---------------------------------------------------------------------------
+
+function ExportImportSection({ group, groupId }: { group: SettingsGroup; groupId: string }) {
+  const [kind, setKind] = useState<"graph" | "all">("graph");
+  const [importOpen, setImportOpen] = useState(false);
+
+  const exportHref = api.graphExportUrl(groupId, { format: "zip", kind });
+
+  return (
+    <Section
+      id="export-import"
+      title="Export & Import"
+      sub="Back up this group as a zip, or restore one from a previous backup. Designed to enable machine-to-machine transfers."
+    >
+      <div className="space-y-4">
+        {/* Export controls */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-text">Export this group</div>
+            <div className="text-xs text-text-3 mt-0.5">
+              Streams the indexed graph (graph.fb, enrichments, links, embeddings)
+              plus the fleet config as a single zip. <code className="font-mono">all</code>{" "}
+              also bundles the generated docs.
+            </div>
+          </div>
+          <div className="flex items-center gap-2 shrink-0">
+            <div
+              role="radiogroup"
+              aria-label="Export contents"
+              className="inline-flex rounded-md border border-border-soft overflow-hidden"
+            >
+              {(["graph", "all"] as const).map((k) => (
+                <button
+                  key={k}
+                  type="button"
+                  role="radio"
+                  aria-checked={kind === k}
+                  onClick={() => setKind(k)}
+                  className={cn(
+                    "px-2.5 py-1 text-xs font-mono",
+                    kind === k
+                      ? "bg-accent text-white"
+                      : "bg-surface text-text-2 hover:bg-surface-2",
+                  )}
+                >
+                  {k}
+                </button>
+              ))}
+            </div>
+            <Button asChild variant="secondary" size="sm">
+              <a
+                href={exportHref}
+                download={`${group.name}-${kind}.zip`}
+                data-testid="btn-graph-export"
+              >
+                <Download size={12} />
+                Download
+              </a>
+            </Button>
+          </div>
+        </div>
+
+        <div className="border-t border-border-soft" />
+
+        {/* Import controls */}
+        <div className="flex items-start justify-between gap-4">
+          <div className="min-w-0">
+            <div className="text-sm font-medium text-text">Import a group</div>
+            <div className="text-xs text-text-3 mt-0.5">
+              Restore a group from a zip previously produced by Export. Touches
+              registry state; requires explicit confirmation.
+            </div>
+          </div>
+          <Button
+            variant="secondary"
+            size="sm"
+            onClick={() => setImportOpen(true)}
+            data-testid="btn-graph-import"
+          >
+            <Upload size={12} />
+            Import…
+          </Button>
+        </div>
+      </div>
+
+      <ImportGroupModal open={importOpen} onClose={() => setImportOpen(false)} />
+    </Section>
+  );
+}
+
+function ImportGroupModal({ open, onClose }: { open: boolean; onClose: () => void }) {
+  const [file, setFile] = useState<File | null>(null);
+  const [nameOverride, setNameOverride] = useState("");
+  const [force, setForce] = useState(false);
+  const [pending, setPending] = useState(false);
+  const queryClient = useQueryClient();
+  const navigate = useNavigate();
+
+  const reset = () => {
+    setFile(null);
+    setNameOverride("");
+    setForce(false);
+    setPending(false);
+  };
+
+  const handleClose = () => {
+    if (pending) return;
+    reset();
+    onClose();
+  };
+
+  const handleImport = async () => {
+    if (!file) return;
+    setPending(true);
+    try {
+      const reply = await api.graphImport(file, {
+        force,
+        name: nameOverride.trim() || undefined,
+      });
+      toast.success(`Imported "${reply.group}" (${reply.repos.length} repos).`);
+      // Force a meta refresh so the new group shows up in the sidebar / landing.
+      queryClient.invalidateQueries({ queryKey: ["meta"] });
+      queryClient.invalidateQueries({ queryKey: ["groups"] });
+      reset();
+      onClose();
+      navigate(`/g/${encodeURIComponent(reply.group)}/settings`);
+    } catch (e) {
+      const msg = e instanceof ApiError ? e.message : "Import failed.";
+      toast.error(msg);
+      setPending(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => !v && handleClose()}>
+      <DialogContent>
+        <DialogTitle>Import a group</DialogTitle>
+        <DialogDescription>
+          Restore a group from a zip archive previously produced by Export. The
+          imported store is written under the daemon&apos;s archigraph home; source
+          repos on disk are untouched.
+        </DialogDescription>
+
+        <div className="mt-4 space-y-3">
+          <label className="block">
+            <span className="block text-sm text-text-2 mb-1">Archive (.zip)</span>
+            <input
+              type="file"
+              accept=".zip,application/zip"
+              onChange={(e) => setFile(e.target.files?.[0] ?? null)}
+              className="block w-full text-sm text-text-2 file:mr-3 file:rounded-md file:border-0 file:bg-surface-2 file:px-3 file:py-1.5 file:text-sm file:text-text file:hover:bg-surface"
+              data-testid="import-file-input"
+            />
+            {file && (
+              <span className="block mt-1 text-xs text-text-3 font-mono truncate">
+                {file.name} · {(file.size / 1024).toFixed(1)} KB
+              </span>
+            )}
+          </label>
+
+          <label className="block">
+            <span className="block text-sm text-text-2 mb-1">
+              Register as (optional)
+            </span>
+            <Input
+              value={nameOverride}
+              onChange={(e) => setNameOverride(e.target.value)}
+              placeholder="leave blank to keep the archive's group name"
+              className="font-mono text-sm"
+            />
+          </label>
+
+          <label className="flex items-start gap-2 text-sm cursor-pointer">
+            <input
+              type="checkbox"
+              checked={force}
+              onChange={(e) => setForce(e.target.checked)}
+              className="mt-0.5 accent-[var(--accent)]"
+            />
+            <span>
+              <span className="font-medium text-text">Overwrite existing group</span>
+              <span className="text-text-3">
+                {" "}
+                — required if a group with this name already exists. Replaces its
+                fleet config + cached store.
+              </span>
+            </span>
+          </label>
+
+          <ul className="mt-2 space-y-1.5 text-xs text-text-3">
+            <li className="flex items-start gap-2">
+              <Info size={12} className="text-accent-strong mt-0.5 shrink-0" />
+              The daemon validates the archive layout before writing anything.
+            </li>
+            <li className="flex items-start gap-2">
+              <AlertTriangle size={12} className="text-warning mt-0.5 shrink-0" />
+              Overwrite replaces the existing group&apos;s cached graph + fleet config.
+            </li>
+          </ul>
+        </div>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <Button variant="ghost" onClick={handleClose} disabled={pending}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            disabled={!file || pending}
+            onClick={handleImport}
+            data-testid="btn-import-confirm"
+          >
+            {pending ? <Loader2 size={13} className="animate-spin" /> : <Upload size={13} />}
+            Import group
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// 7. Danger zone
 // ---------------------------------------------------------------------------
 
 function DangerZone({ group, groupId }: { group: SettingsGroup; groupId: string }) {
@@ -1289,7 +1522,10 @@ export default function SettingsScreen() {
       {/* 5. Health check */}
       <HealthSection groupId={groupId} />
 
-      {/* 6. Danger zone */}
+      {/* 6. Export & Import (#1627) */}
+      <ExportImportSection group={group} groupId={groupId} />
+
+      {/* 7. Danger zone */}
       <DangerZone group={group} groupId={groupId} />
 
       {/* --- Modals --- */}


### PR DESCRIPTION
Fixes #1627

## 1. Problem

Issue #1658 shipped a docs export (zip of generated markdown). The graph side — the actually-indexed store (graph.fb, graph.json, enrichments, links, metadata, embeddings.bin) plus the fleet config — had no equivalent. Without it there's no way to:

- back up a group (everything beyond source code lives in `~/.archigraph/store/<slug>-<hash>/`)
- transfer an indexed corpus machine-to-machine without re-running the full index
- share a pre-indexed group with another engineer or another daemon

Owner directive: add an extensible export/import surface for the GRAPH data, parallel to the docs export, surfaced in the WebUI Settings page.

## 2. Approach

Two new endpoints registered in `internal/dashboard/server.go` BEFORE the wildcard `/api/v2/groups/{group}` GET so the Go 1.22 ServeMux picks the more-specific path first:

```
GET  /api/v2/groups/{group}/export?format=zip&kind=graph|all
POST /api/v2/groups/import?force=true&name=<override>
```

Archive layout (versioned via `ExportManifest.Version=1`):

```
<group>/manifest.json   version + group + repos list (slug+path+stack)
<group>/fleet.json      copy of the per-group config
<group>/store/<slug>/   entire daemon store dir per repo (graph.fb, graph.json,
                        enrichments/, links.json, metadata.json, embeddings.bin, …)
<group>/docs/<slug>/    generated technical docs (kind=all only)
<group>/docs/business/  generated business docs   (kind=all only)
```

The layout is extensible — additional kinds (\`patterns\`, \`history\`, …) slot in as new top-level subdirs without breaking the v1 importer, and additional formats slot in via the existing \`format=\` query param.

Import flow:
1. Stream body to a temp file (multipart/form-data OR raw application/zip; the WebUI uses multipart so a `<input type=file>` works).
2. Parse zip, locate `<X>/manifest.json` at depth 1, validate `Version <= 1`.
3. Read bundled `fleet.json`, override `Name` if `?name=` was supplied.
4. Refuse if the target group is already registered unless `force=true`.
5. For each repo in the bundled fleet: `os.MkdirAll(daemon.StateDirForRepo(repo.Path))` then extract `<group>/store/<slug>/...` into it (zip-slip-guarded).
6. If `manifest.Kind=="all"`: also restore docs trees.
7. `registry.SaveGroupConfig` + `registry.AddGroup`.
8. `s.graphs.Invalidate(group)` so the next read picks up the fresh store.

Defences: 1 GiB body cap via `http.MaxBytesReader`, zip-slip rejected with explicit path-prefix check, refuses to overwrite without explicit `force=true`.

WebUI: new "Export & Import" section in the Settings screen (above Danger Zone). Export = kind toggle (`graph`|`all`) + Download button (anchor `href` to the export URL so the browser handles the download). Import = `<input type=file>` + confirm dialog with optional name override + overwrite checkbox + warning bullets.

## 3. Files touched

- `internal/dashboard/handlers_v2_graph_export.go` (NEW, ~450 lines) — handlers + helpers (`writeZipFile`, `readImportBody`, `readManifestFromZip`, `readFleetFromZip`, `zipPrefixExists`, `extractZipPrefix`). Reuses `zipAddTree` and `dirHasContent` from `handlers_v2_docs.go` / `handlers_docs.go` to avoid duplication.
- `internal/dashboard/handlers_v2_graph_export_test.go` (NEW) — 6 tests: round-trip, kind=all bundles docs, unknown group → 404, unsupported format → 400, conflict without force → 409, conflict with force → 200, invalid archive → 400.
- `internal/dashboard/server.go` — register two routes.
- `webui-v2/src/lib/api.ts` — `graphExportUrl()` + `graphImport()`.
- `webui-v2/src/routes/settings.tsx` — `ExportImportSection` + `ImportGroupModal`, wired into the page layout.

Deliberately AVOIDED `handlers_v2_docs.go` (the #1658 docs export) — the graph endpoint lives in its own file as instructed.

## 4. Tests

Round-trip test (`TestGraphExportImport_RoundTrip`):
1. Seeds a fake archigraph home with one group `alpha` whose repo's store dir is populated with the canonical files a real index would produce (graph.fb, graph.json, enrichments/http_endpoint.json, links.json, metadata.json, embeddings.bin).
2. Exports via the handler → asserts 200 + `application/zip` + manifest+fleet+all 6 store files present in the archive.
3. Imports the archive as `alpha-copy` via multipart upload.
4. Asserts the new group is registered, the bundled fleet round-trips (correct name, repo count, repo path), and every restored file in the store dir hashes byte-for-byte against the original (`hashTree` + `sha256` per file).

Other tests cover: kind=all bundling docs, unknown group → 404, unsupported format → 400, conflict (409) + force=true (200), invalid archive → 400.

Run output:
```
=== RUN   TestGraphExportImport_RoundTrip
--- PASS: TestGraphExportImport_RoundTrip (0.10s)
=== RUN   TestGraphExport_KindAll_BundlesDocs
--- PASS: TestGraphExport_KindAll_BundlesDocs (0.03s)
=== RUN   TestGraphExport_UnknownGroup_404
--- PASS: TestGraphExport_UnknownGroup_404 (0.02s)
=== RUN   TestGraphExport_UnsupportedFormat
--- PASS: TestGraphExport_UnsupportedFormat (0.08s)
=== RUN   TestGraphImport_Conflict
--- PASS: TestGraphImport_Conflict (0.03s)
=== RUN   TestGraphImport_InvalidArchive
--- PASS: TestGraphImport_InvalidArchive (0.01s)
PASS
ok      github.com/cajasmota/archigraph/internal-dashboard 7.738s
```

`go vet ./internal/...` clean. `npx vite build` clean (webui-v2 compiles end-to-end with the new section + dialog). One pre-existing failure in `TestYamlScalar` (`handlers_enrichment_writeback`) reproduces unchanged on `origin/main` — unrelated to this PR.

## 5. Risk + rollback

Risk surface:
- **Disk writes outside the imported group are impossible** — store extraction always goes through `daemon.StateDirForRepo` (which paths under `$ARCHIGRAPH_HOME/store/`), guarded by an explicit zip-slip check. Docs extraction goes through `daemon.RepoDocsDir` / `daemon.BusinessDocsDir`, same guard.
- **Existing groups are never silently overwritten** — `force=true` is required on conflict and surfaces in the WebUI via a labelled checkbox + warning bullet.
- **Body size capped at 1 GiB** via `http.MaxBytesReader` so a malicious or runaway upload can't OOM the daemon.
- **No daemon restart** — endpoint is read+write to disk and registry, then a cache invalidation; the running daemon (:47274) continues serving immediately.

Rollback is a clean revert of one Go file + one test file + a 3-line route insertion + WebUI changes scoped to one settings section.

## 6. Verification evidence

- Worktree: `/Users/jorgecajas/Documents/Projects/archigraph-worktrees/feat-graph-export` (branch `feat/graph-export-import`).
- `go test ./internal/dashboard/ -run "TestGraphExport|TestGraphImport"` → 6/6 PASS (output above).
- `go vet ./internal/...` clean (no diagnostics).
- `cd webui-v2 && npx vite build` → built in 18.64s, no errors.
- Round-trip evidence: `TestGraphExportImport_RoundTrip` exports the alpha fixture, imports it as alpha-copy on the SAME daemon, sha256-hashes every file in the restored store, and asserts equality vs the original. Test passes.
- Live :47274 was NOT restarted (per directive). Isolated tests use `t.Setenv("ARCHIGRAPH_HOME", t.TempDir())` so they never touch `~/.archigraph`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)