### PR TITLE
feat(graph/mcp/dashboard): module-level GDS — SCC + PageRank + betweenness on the aggregated module graph (#1384)

### DIFF
--- a/cmd/mcp-audit/main.go
+++ b/cmd/mcp-audit/main.go
@@ -40,7 +40,15 @@ import (
 // Empirical baseline: 2,963 tokens (28 tools, measured 2026-05-21 with 4-chars/token,
 // after refactor/mcp-real-3k schema compression). Ceiling = 3,000 (hard spec target).
 // Bump this constant when intentionally adding new tools (with justification comment).
-const defaultCeiling = 3000
+//
+// 2026-05-23 (#1384, epic #1380): bumped 3000 → 3100 to seat the new
+// archigraph_module_analysis tool. Module-level GDS (SCC + PageRank + betweenness
+// on the aggregated module graph) is a strategic addition — the bird's-eye-view
+// counterpart to the entity-level surface. Bundled into one action-dispatched
+// tool (cycles|centrality|all) to minimise footprint; measured at 3085 tokens
+// (+85 above the previous ceiling, +122 above baseline). +100-token bump is the
+// smallest round number that fits with a safety margin.
+const defaultCeiling = 3100
 
 // maxDescLen is the per-tool description character limit.
 const maxDescLen = 80

--- a/internal/dashboard/server.go
+++ b/internal/dashboard/server.go
@@ -626,6 +626,9 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths", s.handleV2PathsList)
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/orphans", s.handleV2PathsOrphans)
 	mux.HandleFunc("GET /api/v2/groups/{id}/paths/{hash}", s.handleV2PathDetail)
+	// Module-level GDS analysis (#1384, epic #1380) — SCC + PageRank +
+	// betweenness over the aggregated module graph.
+	mux.HandleFunc("GET /api/v2/groups/{group}/modules/analysis", s.handleV2ModulesAnalysis)
 
 	return s.withAuth(withGzip(mux))
 }

--- a/internal/dashboard/v2_modules.go
+++ b/internal/dashboard/v2_modules.go
@@ -1,0 +1,179 @@
+// v2_modules.go — v2 endpoint for the module-level GDS analysis (#1384,
+// part of epic #1380).
+//
+// Surfaces SCC / PageRank / betweenness over the aggregated module graph so
+// the dashboard can render a collapsed-view "modules at a glance" UI (the UI
+// work itself lives under #1386).
+//
+// Route registered in server.go:
+//
+//	GET /api/v2/groups/{group}/modules/analysis
+//	    ?repo_filter=slug1,slug2
+//	    &top_n=10            (default 10)
+//	    &min_scc_size=2      (default 2)
+//
+// Response (v2 envelope):
+//
+//	{
+//	  "ok": true,
+//	  "data": {
+//	    "repos": [
+//	      {
+//	        "repo": "...",
+//	        "num_modules": N,
+//	        "num_module_edges": N,
+//	        "num_sccs": N,
+//	        "largest_scc_size": N,
+//	        "modules_in_cycle": N,
+//	        "top_pagerank": [...],
+//	        "top_betweenness": [...],
+//	        "sccs": [...]
+//	      }, ...
+//	    ],
+//	    "count": N
+//	  }
+//	}
+package dashboard
+
+import (
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// handleV2ModulesAnalysis — GET /api/v2/groups/{group}/modules/analysis
+func (s *Server) handleV2ModulesAnalysis(w http.ResponseWriter, r *http.Request) {
+	group := r.PathValue("group")
+	if group == "" {
+		writeV2Err(w, http.StatusBadRequest, "bad_request", "group required")
+		return
+	}
+	grp, err := s.graphs.GetGroup(group)
+	if err != nil {
+		writeV2Err(w, http.StatusNotFound, "not_found", err.Error())
+		return
+	}
+
+	q := r.URL.Query()
+	topN := 10
+	if v := q.Get("top_n"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			topN = n
+		}
+	}
+	minSCC := 2
+	if v := q.Get("min_scc_size"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 2 {
+			minSCC = n
+		}
+	}
+	var repoFilter map[string]bool
+	if v := q.Get("repo_filter"); v != "" {
+		repoFilter = map[string]bool{}
+		for _, s := range strings.Split(v, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				repoFilter[s] = true
+			}
+		}
+	}
+
+	type centOut struct {
+		ModuleID    string  `json:"module_id"`
+		ModuleName  string  `json:"module_name"`
+		PageRank    float64 `json:"pagerank"`
+		Betweenness float64 `json:"betweenness"`
+		InDegree    int     `json:"in_degree"`
+		OutDegree   int     `json:"out_degree"`
+		InCycle     bool    `json:"in_cycle"`
+	}
+	type sccOut struct {
+		ID          int                `json:"id"`
+		Size        int                `json:"size"`
+		Members     []string           `json:"members"`
+		MemberNames []string           `json:"member_names"`
+		Edges       []graph.ModuleEdge `json:"edges"`
+	}
+	type repoOut struct {
+		Repo           string    `json:"repo"`
+		NumModules     int       `json:"num_modules"`
+		NumModuleEdges int       `json:"num_module_edges"`
+		NumSCCs        int       `json:"num_sccs"`
+		LargestSCCSize int       `json:"largest_scc_size"`
+		ModulesInCycle int       `json:"modules_in_cycle"`
+		TopPageRank    []centOut `json:"top_pagerank"`
+		TopBetweenness []centOut `json:"top_betweenness"`
+		SCCs           []sccOut  `json:"sccs"`
+	}
+
+	out := make([]repoOut, 0)
+	for _, repo := range sortedRepos(grp) {
+		if repo.Doc == nil {
+			continue
+		}
+		if repoFilter != nil && !repoFilter[repo.Slug] {
+			continue
+		}
+		res := graph.RunModuleAlgorithms(repo.Doc.Entities, repo.Doc.Relationships)
+		ro := repoOut{
+			Repo:           repo.Slug,
+			NumModules:     res.Stats.NumModules,
+			NumModuleEdges: res.Stats.NumModuleEdges,
+			NumSCCs:        res.Stats.NumSCCs,
+			LargestSCCSize: res.Stats.LargestSCCSize,
+			ModulesInCycle: res.Stats.NumModulesInCycle,
+		}
+		toCent := func(c graph.ModuleCentrality) centOut {
+			return centOut{
+				ModuleID:    dashPrefixedID(repo.Slug, c.ModuleID),
+				ModuleName:  c.ModuleName,
+				PageRank:    c.PageRank,
+				Betweenness: c.Betweenness,
+				InDegree:    c.InDegree,
+				OutDegree:   c.OutDegree,
+				InCycle:     res.SCCOf[c.ModuleID] >= 0,
+			}
+		}
+		for _, c := range graph.TopByPageRank(res.Centrality, topN) {
+			ro.TopPageRank = append(ro.TopPageRank, toCent(c))
+		}
+		for _, c := range graph.TopByBetweenness(res.Centrality, topN) {
+			ro.TopBetweenness = append(ro.TopBetweenness, toCent(c))
+		}
+		for _, c := range res.SCCs {
+			if c.Size < minSCC {
+				continue
+			}
+			prefixedMembers := make([]string, len(c.Members))
+			for i, m := range c.Members {
+				prefixedMembers[i] = dashPrefixedID(repo.Slug, m)
+			}
+			prefixedEdges := make([]graph.ModuleEdge, len(c.Edges))
+			for i, e := range c.Edges {
+				prefixedEdges[i] = graph.ModuleEdge{
+					FromModule: dashPrefixedID(repo.Slug, e.FromModule),
+					ToModule:   dashPrefixedID(repo.Slug, e.ToModule),
+					Weight:     e.Weight,
+				}
+			}
+			ro.SCCs = append(ro.SCCs, sccOut{
+				ID:          c.ID,
+				Size:        c.Size,
+				Members:     prefixedMembers,
+				MemberNames: append([]string{}, c.MemberNames...),
+				Edges:       prefixedEdges,
+			})
+		}
+		out = append(out, ro)
+	}
+
+	sort.Slice(out, func(i, j int) bool { return out[i].Repo < out[j].Repo })
+
+	writeV2JSON(w, http.StatusOK, v2OK(map[string]any{
+		"repos": out,
+		"count": len(out),
+	}))
+}

--- a/internal/graph/module_gds.go
+++ b/internal/graph/module_gds.go
@@ -1,0 +1,665 @@
+// Package graph — module_gds.go implements module-LEVEL graph data-science
+// algorithms (issue #1384, part of epic #1380).
+//
+// # Why
+//
+// algorithms.go runs SCC / PageRank / betweenness over the ENTITY graph
+// (one node per function / class / file). On a real-world codebase that
+// produces tens of thousands of nodes and the high-centrality picture is
+// dominated by widely-shared utility entities. The strategic question the
+// user actually has — "which MODULES form a cycle? which MODULE is the
+// blast-radius hub?" — needs a bird's-eye view at module granularity.
+//
+// # Aggregated module graph
+//
+// We collapse the entity graph onto modules:
+//
+//	for each entity-level edge A → B with kind ∈ realKinds:
+//	    let mA = module(A), mB = module(B)
+//	    if mA == mB:           skip (intra-module: not a module-edge)
+//	    if mA == "" || mB == "": skip (untagged: would pollute results)
+//	    accumulate edgeWeight[mA → mB] += 1
+//
+// "module" is read from Entity.Properties["module"] when present; if the
+// document also carries pre-baked synthetic Module containers (the post-#1383
+// shape — Kind="Module", DEPENDS_ON edges between them with weight) we use
+// those directly to avoid recomputing. realKinds excludes the synthetic
+// scaffolding kinds (CONTAINS, STEP_IN_PROCESS, ENTRY_POINT_OF, DEPENDS_ON
+// when between module nodes — those are themselves the aggregated edges).
+//
+// # Outputs
+//
+//   - ModuleSCC: strongly-connected components of size >= 2 in the module
+//     graph. These are the circular module dependencies. Tarjan iterative.
+//   - PageRank + betweenness: module-level centrality scores. The top-N are
+//     the modules everything else depends on (PageRank) and the modules that
+//     sit on the most shortest paths (betweenness — bottlenecks).
+//
+// # Determinism
+//
+// Same input ⇒ same output. Adjacency lists are sorted, Tarjan walks nodes
+// in sorted order, ties in score-ranked output are tiebroken on module ID.
+// Scores are rounded to 4 decimal places (same policy as algorithms.go) so
+// minor solver-tolerance noise does not flip the top-N membership across runs.
+package graph
+
+import (
+	"sort"
+
+	"gonum.org/v1/gonum/graph/network"
+	"gonum.org/v1/gonum/graph/path"
+	"gonum.org/v1/gonum/graph/simple"
+)
+
+// Module-graph synthetic kinds that must NOT be re-aggregated. See package
+// doc for the rationale.
+const (
+	kindModule     = "Module"
+	relContains    = "CONTAINS"
+	relDependsOn   = "DEPENDS_ON"
+	relStepIn      = "STEP_IN_PROCESS"
+	relEntryPoint  = "ENTRY_POINT_OF"
+	moduleExternal = "_external" // synthetic catch-all from internal/module aggregator
+)
+
+// ModuleEdge is a directed aggregated edge between two module IDs.
+type ModuleEdge struct {
+	FromModule string `json:"from_module"`
+	ToModule   string `json:"to_module"`
+	// Weight is the count of underlying entity-edges that collapsed onto
+	// this module-pair (or, when DEPENDS_ON edges already carry a weight
+	// property, that pre-baked count).
+	Weight int `json:"weight"`
+}
+
+// ModuleSCC is one strongly-connected component of size >= 2 in the
+// aggregated module graph.
+type ModuleSCC struct {
+	// ID is a deterministic integer assigned to the SCC for cross-reference.
+	// Stable across runs of the same input (Tarjan-discovery order over the
+	// sorted node set).
+	ID int `json:"id"`
+	// Members lists module IDs participating in the cycle, sorted.
+	Members []string `json:"members"`
+	// MemberNames mirrors Members but carries the human-readable module name
+	// (Module entity.Name when available; falls back to the ID).
+	MemberNames []string `json:"member_names"`
+	// Edges are the directed module→module edges INTERNAL to the SCC, sorted.
+	Edges []ModuleEdge `json:"edges"`
+	// Size is len(Members), for fast filtering.
+	Size int `json:"size"`
+}
+
+// ModuleCentrality is one module's score pair.
+type ModuleCentrality struct {
+	ModuleID    string  `json:"module_id"`
+	ModuleName  string  `json:"module_name"`
+	PageRank    float64 `json:"pagerank"`
+	Betweenness float64 `json:"betweenness"`
+	// InDegree / OutDegree are the unweighted node-degrees in the module
+	// graph — cheap sanity-check metrics that often correlate with PageRank
+	// but with very different units, useful for hub vs. fan-out distinction.
+	InDegree  int `json:"in_degree"`
+	OutDegree int `json:"out_degree"`
+}
+
+// ModuleAlgorithmResults bundles every output of RunModuleAlgorithms.
+type ModuleAlgorithmResults struct {
+	// ModuleIDs is the deterministic sorted list of all module IDs present
+	// in the aggregated graph (including singletons with no inbound/outbound
+	// edges, when they're present in the input as Module entities).
+	ModuleIDs []string `json:"module_ids"`
+	// ModuleNames maps module ID → human-readable name. Always populated.
+	ModuleNames map[string]string `json:"module_names"`
+	// Edges is the full set of aggregated module→module edges, sorted.
+	Edges []ModuleEdge `json:"edges"`
+	// SCCs are the strongly-connected components of size >= 2.
+	SCCs []ModuleSCC `json:"sccs"`
+	// SCCOf maps module ID → SCC ID; -1 when the module is not in any
+	// non-trivial SCC. Always populated for every module ID.
+	SCCOf map[string]int `json:"scc_of"`
+	// Centrality is per-module PageRank + betweenness, sorted by ID.
+	Centrality []ModuleCentrality `json:"centrality"`
+	// Stats are corpus-level summaries.
+	Stats ModuleAlgorithmStats `json:"stats"`
+}
+
+// ModuleAlgorithmStats are the corpus-level summary numbers.
+type ModuleAlgorithmStats struct {
+	NumModules        int `json:"num_modules"`
+	NumModuleEdges    int `json:"num_module_edges"`
+	NumSCCs           int `json:"num_sccs"`
+	LargestSCCSize    int `json:"largest_scc_size"`
+	NumModulesInCycle int `json:"num_modules_in_cycle"`
+}
+
+// RunModuleAlgorithms is the top-level entry point. It builds the aggregated
+// module graph from (entities, rels) and runs SCC + PageRank + betweenness
+// over it.
+//
+// Inputs:
+//
+//   - entities: the full Document.Entities slice. Both Module container
+//     entities (Kind="Module") and regular entities (carrying
+//     Properties["module"]) are accepted; the function reconciles them.
+//   - rels:     the full Document.Relationships slice. CONTAINS, STEP_IN_PROCESS
+//     and ENTRY_POINT_OF edges are dropped (they are scaffolding, not real
+//     dependencies). DEPENDS_ON edges BETWEEN two Module nodes are taken as
+//     pre-aggregated module-level edges (with their "weight" property when
+//     present); all other edges are aggregated by collapsing their endpoints
+//     onto their respective modules.
+//
+// Returns a populated *ModuleAlgorithmResults. Never returns nil — an empty
+// graph produces a zero-stats result with empty slices.
+func RunModuleAlgorithms(entities []Entity, rels []Relationship) *ModuleAlgorithmResults {
+	moduleIDs, moduleNames, entityToModule := collectModules(entities)
+	edges := aggregateModuleEdges(entities, rels, entityToModule, moduleIDs)
+
+	res := &ModuleAlgorithmResults{
+		ModuleIDs:   moduleIDs,
+		ModuleNames: moduleNames,
+		Edges:       edges,
+		SCCOf:       make(map[string]int, len(moduleIDs)),
+	}
+
+	if len(moduleIDs) == 0 {
+		return res
+	}
+
+	// Initialise SCCOf to -1 for every module before SCC pass.
+	for _, m := range moduleIDs {
+		res.SCCOf[m] = -1
+	}
+
+	// SCC pass (size >= 2). Returns SCCs sorted by descending size.
+	sccs := findModuleSCCs(moduleIDs, edges)
+	for _, c := range sccs {
+		for _, m := range c.Members {
+			res.SCCOf[m] = c.ID
+		}
+	}
+	// Enrich SCCs with names.
+	for i := range sccs {
+		sccs[i].MemberNames = lookupNames(sccs[i].Members, moduleNames)
+	}
+	res.SCCs = sccs
+
+	// Centrality pass via gonum on the same aggregated graph.
+	res.Centrality = computeModuleCentrality(moduleIDs, edges, moduleNames)
+
+	// Stats summary.
+	res.Stats = ModuleAlgorithmStats{
+		NumModules:     len(moduleIDs),
+		NumModuleEdges: len(edges),
+		NumSCCs:        len(sccs),
+	}
+	for _, c := range sccs {
+		if c.Size > res.Stats.LargestSCCSize {
+			res.Stats.LargestSCCSize = c.Size
+		}
+		res.Stats.NumModulesInCycle += c.Size
+	}
+	return res
+}
+
+// collectModules walks the entity set and returns:
+//
+//   - the sorted deduplicated list of module IDs;
+//   - module ID → display name map;
+//   - per-entity-ID → module ID map (for entities that are not themselves
+//     Module containers).
+//
+// Module identity strategy: if a Module-kind container exists for a given
+// (repo, module) pair, its entity ID is used as the module ID and its Name
+// is used as the display name. Otherwise the module name itself (e.g.
+// "core/views") doubles as the module ID. This keeps post-#1383 documents
+// (with pre-baked Module containers) and pre-aggregation documents working
+// from the same surface.
+func collectModules(entities []Entity) (ids []string, names map[string]string, entityToModule map[string]string) {
+	names = map[string]string{}
+	entityToModule = map[string]string{}
+
+	// First pass: pick up Module containers (Kind="Module").
+	// We build two indexes so we can match real entities back to their
+	// container even when only the module name is on Properties["module"]:
+	//
+	//   - containerByLabel:   "(repo)|(name)" → ID (precise, used when both
+	//                         endpoints carry a repo tag — the multi-repo
+	//                         group document case).
+	//   - containerByName:    "name" → ID (fallback, used when the real
+	//                         entity has no Properties["repo"] — single-repo
+	//                         documents written by the indexer, where the
+	//                         module-aggregator stamps "repo" on Module
+	//                         entities only).
+	//
+	// containerByName collides when two repos have a module with the same
+	// name; in that case we still prefer the precise label match, and only
+	// fall back to the name-only index when nothing else matches.
+	containerByLabel := map[string]string{}
+	containerByName := map[string]string{}
+	containerByNameAmbiguous := map[string]bool{}
+	idSet := map[string]bool{}
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind != kindModule {
+			continue
+		}
+		mid := e.ID
+		idSet[mid] = true
+		names[mid] = e.Name
+		repo := ""
+		modName := e.Name
+		if e.Properties != nil {
+			if r, ok := e.Properties["repo"]; ok {
+				repo = r
+			}
+			if m, ok := e.Properties["module"]; ok && m != "" {
+				modName = m
+			}
+		}
+		containerByLabel[repo+"|"+modName] = mid
+		if existing, ok := containerByName[modName]; ok && existing != mid {
+			containerByNameAmbiguous[modName] = true
+		}
+		containerByName[modName] = mid
+	}
+
+	// Second pass: real entities. Resolve each to its module ID.
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == kindModule {
+			continue
+		}
+		modName := ""
+		repo := ""
+		if e.Properties != nil {
+			modName = e.Properties["module"]
+			repo = e.Properties["repo"]
+		}
+		if modName == "" {
+			// Untagged entity — skip from aggregation. Including it would
+			// pollute the synthetic "_external" bucket with everything that
+			// happens to lack a module label, which is not signal.
+			continue
+		}
+		// Three-tier lookup:
+		//   1. Exact (repo, name) match — multi-repo group documents.
+		//   2. Name-only match when the name is unambiguous — single-repo
+		//      documents (real entities have no "repo" property; containers do).
+		//   3. Synthesised string-ID fallback — pre-#1383 documents with no
+		//      Module containers at all.
+		mid, ok := containerByLabel[repo+"|"+modName]
+		if !ok && !containerByNameAmbiguous[modName] {
+			if v, ok2 := containerByName[modName]; ok2 {
+				mid = v
+				ok = true
+			}
+		}
+		if !ok {
+			mid = modName
+			if !idSet[mid] {
+				idSet[mid] = true
+				names[mid] = modName
+			}
+		}
+		entityToModule[e.ID] = mid
+	}
+
+	// Drop the synthetic "_external" bucket — it aggregates "everything we
+	// failed to label" and is never useful signal for SCC / centrality.
+	for mid, name := range names {
+		if name == moduleExternal {
+			delete(idSet, mid)
+			delete(names, mid)
+		}
+	}
+	for eid, mid := range entityToModule {
+		if names[mid] == "" && idSet[mid] == false {
+			delete(entityToModule, eid)
+		}
+	}
+
+	ids = make([]string, 0, len(idSet))
+	for id := range idSet {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids, names, entityToModule
+}
+
+// aggregateModuleEdges produces the directed module-level edge multiset.
+//
+// Pre-aggregated DEPENDS_ON edges (when both endpoints are Module containers)
+// are taken at face value: their "weight" property is parsed if present, else
+// defaults to 1. All other relationships are collapsed by looking up each
+// endpoint's module; self-loops (intra-module) are dropped.
+//
+// Excluded relationship kinds: CONTAINS (Module→entity scaffolding),
+// STEP_IN_PROCESS / ENTRY_POINT_OF (process-flow scaffolding). They have no
+// dependency semantics at module granularity.
+func aggregateModuleEdges(_ []Entity, rels []Relationship, entityToModule map[string]string, moduleIDs []string) []ModuleEdge {
+	moduleSet := make(map[string]bool, len(moduleIDs))
+	for _, m := range moduleIDs {
+		moduleSet[m] = true
+	}
+
+	type edgeKey struct{ from, to string }
+	weight := map[edgeKey]int{}
+
+	for i := range rels {
+		r := &rels[i]
+		switch r.Kind {
+		case relContains, relStepIn, relEntryPoint:
+			continue
+		}
+		if r.FromID == "" || r.ToID == "" || r.FromID == r.ToID {
+			continue
+		}
+
+		// Pre-aggregated module→module edge?
+		if r.Kind == relDependsOn && moduleSet[r.FromID] && moduleSet[r.ToID] {
+			w := 1
+			if r.Properties != nil {
+				if v, ok := r.Properties["weight"]; ok {
+					if n := atoiSafe(v); n > 0 {
+						w = n
+					}
+				}
+			}
+			weight[edgeKey{r.FromID, r.ToID}] += w
+			continue
+		}
+
+		// Regular entity-level edge — collapse onto module pair.
+		fromMod, okF := entityToModule[r.FromID]
+		toMod, okT := entityToModule[r.ToID]
+		if !okF || !okT {
+			continue
+		}
+		if fromMod == toMod {
+			continue
+		}
+		weight[edgeKey{fromMod, toMod}]++
+	}
+
+	edges := make([]ModuleEdge, 0, len(weight))
+	for k, w := range weight {
+		edges = append(edges, ModuleEdge{FromModule: k.from, ToModule: k.to, Weight: w})
+	}
+	sort.Slice(edges, func(i, j int) bool {
+		if edges[i].FromModule != edges[j].FromModule {
+			return edges[i].FromModule < edges[j].FromModule
+		}
+		return edges[i].ToModule < edges[j].ToModule
+	})
+	return edges
+}
+
+// findModuleSCCs runs an iterative Tarjan SCC over the directed module graph
+// described by (moduleIDs, edges) and returns every SCC of size >= 2, sorted
+// by descending size with ID-tiebreak.
+func findModuleSCCs(moduleIDs []string, edges []ModuleEdge) []ModuleSCC {
+	if len(moduleIDs) == 0 || len(edges) == 0 {
+		return nil
+	}
+
+	adj := make(map[string][]string, len(moduleIDs))
+	for _, m := range moduleIDs {
+		adj[m] = nil
+	}
+	for _, e := range edges {
+		adj[e.FromModule] = append(adj[e.FromModule], e.ToModule)
+	}
+	// Sort adjacency lists for deterministic DFS.
+	for k := range adj {
+		sort.Strings(adj[k])
+	}
+
+	type nodeState struct {
+		index   int
+		lowlink int
+		onStack bool
+	}
+	state := make(map[string]*nodeState, len(moduleIDs))
+	var stack []string
+	index := 0
+	var rawSCCs [][]string
+
+	type frame struct {
+		u string
+		i int
+	}
+	var dfsStack []frame
+
+	// Iterate in sorted order — determinism, and ensures every node is touched.
+	for _, start := range moduleIDs {
+		if state[start] != nil {
+			continue
+		}
+		state[start] = &nodeState{index: index, lowlink: index, onStack: true}
+		index++
+		stack = append(stack, start)
+		dfsStack = append(dfsStack, frame{u: start})
+
+		for len(dfsStack) > 0 {
+			top := &dfsStack[len(dfsStack)-1]
+			u := top.u
+			neighbours := adj[u]
+
+			if top.i < len(neighbours) {
+				v := neighbours[top.i]
+				top.i++
+				sv := state[v]
+				if sv == nil {
+					state[v] = &nodeState{index: index, lowlink: index, onStack: true}
+					index++
+					stack = append(stack, v)
+					dfsStack = append(dfsStack, frame{u: v})
+				} else if sv.onStack {
+					if sv.index < state[u].lowlink {
+						state[u].lowlink = sv.index
+					}
+				}
+				continue
+			}
+
+			// All neighbours processed — pop u.
+			dfsStack = dfsStack[:len(dfsStack)-1]
+			su := state[u]
+			if len(dfsStack) > 0 {
+				parent := dfsStack[len(dfsStack)-1].u
+				sp := state[parent]
+				if su.lowlink < sp.lowlink {
+					sp.lowlink = su.lowlink
+				}
+			}
+			if su.lowlink == su.index {
+				var scc []string
+				for {
+					w := stack[len(stack)-1]
+					stack = stack[:len(stack)-1]
+					state[w].onStack = false
+					scc = append(scc, w)
+					if w == u {
+						break
+					}
+				}
+				rawSCCs = append(rawSCCs, scc)
+			}
+		}
+	}
+
+	// Filter to size >= 2 and build ModuleSCC with internal edges + names.
+	memberSetFor := func(members []string) map[string]bool {
+		s := make(map[string]bool, len(members))
+		for _, m := range members {
+			s[m] = true
+		}
+		return s
+	}
+	weightOf := make(map[string]int, len(edges))
+	for _, e := range edges {
+		weightOf[e.FromModule+"\x00"+e.ToModule] = e.Weight
+	}
+
+	out := make([]ModuleSCC, 0)
+	for _, members := range rawSCCs {
+		if len(members) < 2 {
+			continue
+		}
+		sort.Strings(members)
+		set := memberSetFor(members)
+		var internal []ModuleEdge
+		for _, u := range members {
+			for _, v := range adj[u] {
+				if set[v] {
+					internal = append(internal, ModuleEdge{
+						FromModule: u,
+						ToModule:   v,
+						Weight:     weightOf[u+"\x00"+v],
+					})
+				}
+			}
+		}
+		sort.Slice(internal, func(i, j int) bool {
+			if internal[i].FromModule != internal[j].FromModule {
+				return internal[i].FromModule < internal[j].FromModule
+			}
+			return internal[i].ToModule < internal[j].ToModule
+		})
+		out = append(out, ModuleSCC{
+			Members: members,
+			Edges:   internal,
+			Size:    len(members),
+		})
+	}
+
+	// Sort by descending size, then by first member ID ascending.
+	sort.SliceStable(out, func(i, j int) bool {
+		if out[i].Size != out[j].Size {
+			return out[i].Size > out[j].Size
+		}
+		return out[i].Members[0] < out[j].Members[0]
+	})
+	// Assign deterministic IDs after sorting.
+	for i := range out {
+		out[i].ID = i
+	}
+	return out
+}
+
+// computeModuleCentrality returns per-module PageRank + betweenness scores
+// over the aggregated module graph. The graph is built on the fly as a
+// gonum simple.WeightedDirectedGraph so we can reuse the same algorithms as
+// the entity-level pass.
+func computeModuleCentrality(moduleIDs []string, edges []ModuleEdge, names map[string]string) []ModuleCentrality {
+	if len(moduleIDs) == 0 {
+		return nil
+	}
+	// Build a stable string→int64 index.
+	toInt := make(map[string]int64, len(moduleIDs))
+	fromInt := make(map[int64]string, len(moduleIDs))
+	g := simple.NewWeightedDirectedGraph(0, 0)
+	for i, m := range moduleIDs {
+		id := int64(i)
+		toInt[m] = id
+		fromInt[id] = m
+		g.AddNode(simple.Node(id))
+	}
+	inDeg := make(map[string]int, len(moduleIDs))
+	outDeg := make(map[string]int, len(moduleIDs))
+	for _, e := range edges {
+		from, okF := toInt[e.FromModule]
+		to, okT := toInt[e.ToModule]
+		if !okF || !okT || from == to {
+			continue
+		}
+		w := float64(e.Weight)
+		if w <= 0 {
+			w = 1
+		}
+		if existing := g.WeightedEdge(from, to); existing != nil {
+			w += existing.Weight()
+			g.RemoveEdge(from, to)
+		}
+		g.SetWeightedEdge(g.NewWeightedEdge(simple.Node(from), simple.Node(to), w))
+		outDeg[e.FromModule]++
+		inDeg[e.ToModule]++
+	}
+
+	// Betweenness — modules are O(hundreds), so exact weighted is cheap.
+	betw := map[int64]float64{}
+	if shortest, ok := path.FloydWarshall(g); ok {
+		betw = network.BetweennessWeighted(g, shortest)
+	} else {
+		betw = network.Betweenness(g)
+	}
+	// PageRank — sparse variant matches algorithms.go policy (#633).
+	pr := network.PageRankSparse(g, 0.85, 1e-6)
+
+	out := make([]ModuleCentrality, 0, len(moduleIDs))
+	for _, m := range moduleIDs {
+		nid := toInt[m]
+		out = append(out, ModuleCentrality{
+			ModuleID:    m,
+			ModuleName:  fallbackName(m, names),
+			PageRank:    roundForDeterminism(sanitizeFloat(pr[nid])),
+			Betweenness: roundForDeterminism(sanitizeFloat(betw[nid])),
+			InDegree:    inDeg[m],
+			OutDegree:   outDeg[m],
+		})
+	}
+	// Sort by module ID for stable enumeration; rank-ordered views are a
+	// projection of this list (see TopByPageRank / TopByBetweenness).
+	sort.Slice(out, func(i, j int) bool { return out[i].ModuleID < out[j].ModuleID })
+	return out
+}
+
+// TopByPageRank returns the top-N centrality entries by PageRank, ties
+// broken by ascending module ID. n<=0 returns the full list.
+func TopByPageRank(cents []ModuleCentrality, n int) []ModuleCentrality {
+	cp := make([]ModuleCentrality, len(cents))
+	copy(cp, cents)
+	sort.SliceStable(cp, func(i, j int) bool {
+		if cp[i].PageRank != cp[j].PageRank {
+			return cp[i].PageRank > cp[j].PageRank
+		}
+		return cp[i].ModuleID < cp[j].ModuleID
+	})
+	if n > 0 && n < len(cp) {
+		cp = cp[:n]
+	}
+	return cp
+}
+
+// TopByBetweenness returns the top-N centrality entries by betweenness, ties
+// broken by ascending module ID. n<=0 returns the full list.
+func TopByBetweenness(cents []ModuleCentrality, n int) []ModuleCentrality {
+	cp := make([]ModuleCentrality, len(cents))
+	copy(cp, cents)
+	sort.SliceStable(cp, func(i, j int) bool {
+		if cp[i].Betweenness != cp[j].Betweenness {
+			return cp[i].Betweenness > cp[j].Betweenness
+		}
+		return cp[i].ModuleID < cp[j].ModuleID
+	})
+	if n > 0 && n < len(cp) {
+		cp = cp[:n]
+	}
+	return cp
+}
+
+func lookupNames(ids []string, names map[string]string) []string {
+	out := make([]string, len(ids))
+	for i, id := range ids {
+		out[i] = fallbackName(id, names)
+	}
+	return out
+}
+
+func fallbackName(id string, names map[string]string) string {
+	if n, ok := names[id]; ok && n != "" {
+		return n
+	}
+	return id
+}

--- a/internal/graph/module_gds_test.go
+++ b/internal/graph/module_gds_test.go
@@ -1,0 +1,288 @@
+package graph
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// makeModEntity builds a regular entity with a module tag.
+func makeModEntity(id, name, mod, repo string) Entity {
+	return Entity{
+		ID:   id,
+		Name: name,
+		Kind: "Function",
+		Properties: map[string]string{
+			"module": mod,
+			"repo":   repo,
+		},
+	}
+}
+
+// makeModContainer builds a synthetic Module container entity (post-#1383 shape).
+func makeModContainer(id, name, repo string) Entity {
+	return Entity{
+		ID:   id,
+		Name: name,
+		Kind: kindModule,
+		Properties: map[string]string{
+			"module":    name,
+			"repo":      repo,
+			"synthetic": "true",
+		},
+	}
+}
+
+// TestRunModuleAlgorithms_EmptyInputs ensures the API never returns nil.
+func TestRunModuleAlgorithms_EmptyInputs(t *testing.T) {
+	got := RunModuleAlgorithms(nil, nil)
+	if got == nil {
+		t.Fatal("expected non-nil results for empty input")
+	}
+	if got.Stats.NumModules != 0 || len(got.SCCs) != 0 || len(got.Centrality) != 0 {
+		t.Fatalf("expected empty result, got %+v", got)
+	}
+}
+
+// TestAggregation_EntityEdgesCollapseToModules verifies that entity edges in
+// different modules collapse into module edges and intra-module ones are dropped.
+func TestAggregation_EntityEdgesCollapseToModules(t *testing.T) {
+	entities := []Entity{
+		makeModEntity("e1", "A", "mod_a", "r"),
+		makeModEntity("e2", "B", "mod_a", "r"),
+		makeModEntity("e3", "C", "mod_b", "r"),
+		makeModEntity("e4", "D", "mod_c", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "e1", ToID: "e2", Kind: "CALLS"}, // intra-module — drop
+		{ID: "r2", FromID: "e1", ToID: "e3", Kind: "CALLS"}, // mod_a → mod_b
+		{ID: "r3", FromID: "e2", ToID: "e3", Kind: "CALLS"}, // mod_a → mod_b (weight++)
+		{ID: "r4", FromID: "e3", ToID: "e4", Kind: "IMPORTS"}, // mod_b → mod_c
+	}
+	res := RunModuleAlgorithms(entities, rels)
+
+	wantMods := []string{"mod_a", "mod_b", "mod_c"}
+	if !reflect.DeepEqual(res.ModuleIDs, wantMods) {
+		t.Fatalf("ModuleIDs: want %v, got %v", wantMods, res.ModuleIDs)
+	}
+	if len(res.Edges) != 2 {
+		t.Fatalf("expected 2 module edges, got %d: %+v", len(res.Edges), res.Edges)
+	}
+	// mod_a→mod_b should have weight 2, mod_b→mod_c weight 1.
+	got := map[string]int{}
+	for _, e := range res.Edges {
+		got[e.FromModule+"→"+e.ToModule] = e.Weight
+	}
+	if got["mod_a→mod_b"] != 2 || got["mod_b→mod_c"] != 1 {
+		t.Fatalf("weights wrong: %+v", got)
+	}
+}
+
+// TestAggregation_PrebakedModuleNodes verifies that when Module containers and
+// DEPENDS_ON edges already exist (post-#1383 documents), they are used and
+// their stored weight is respected.
+func TestAggregation_PrebakedModuleNodes(t *testing.T) {
+	entities := []Entity{
+		makeModContainer("M_A", "mod_a", "r"),
+		makeModContainer("M_B", "mod_b", "r"),
+		makeModEntity("e1", "A", "mod_a", "r"),
+		makeModEntity("e2", "B", "mod_b", "r"),
+	}
+	rels := []Relationship{
+		{ID: "rd", FromID: "M_A", ToID: "M_B", Kind: relDependsOn, Properties: map[string]string{"weight": "7"}},
+		// CONTAINS edges should be ignored.
+		{ID: "rc1", FromID: "M_A", ToID: "e1", Kind: relContains},
+		{ID: "rc2", FromID: "M_B", ToID: "e2", Kind: relContains},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	if len(res.Edges) != 1 {
+		t.Fatalf("expected 1 module edge, got %d", len(res.Edges))
+	}
+	e := res.Edges[0]
+	if e.FromModule != "M_A" || e.ToModule != "M_B" || e.Weight != 7 {
+		t.Fatalf("bad edge: %+v", e)
+	}
+	if res.ModuleNames["M_A"] != "mod_a" {
+		t.Fatalf("expected name lookup, got %v", res.ModuleNames)
+	}
+}
+
+// TestExternalBucketDropped — entities without a module label do not get
+// collapsed into the synthetic "_external" bucket as a result.
+func TestExternalBucketDropped(t *testing.T) {
+	entities := []Entity{
+		makeModContainer("M_EXT", moduleExternal, "r"),
+		makeModContainer("M_A", "mod_a", "r"),
+		makeModEntity("e1", "A", "mod_a", "r"),
+		{ID: "e2", Name: "Untagged", Kind: "Function"}, // no module
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "e1", ToID: "e2", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	for _, m := range res.ModuleIDs {
+		if m == "M_EXT" {
+			t.Fatalf("_external module should be dropped, got %v", res.ModuleIDs)
+		}
+	}
+	if len(res.Edges) != 0 {
+		t.Fatalf("expected no edges (untagged endpoint), got %d", len(res.Edges))
+	}
+}
+
+// TestSCCDetection_TwoModuleCycle — a 2-module cycle is detected.
+func TestSCCDetection_TwoModuleCycle(t *testing.T) {
+	entities := []Entity{
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "r2", FromID: "b", ToID: "a", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	if len(res.SCCs) != 1 {
+		t.Fatalf("expected 1 SCC, got %d", len(res.SCCs))
+	}
+	scc := res.SCCs[0]
+	if scc.Size != 2 {
+		t.Fatalf("expected size 2, got %d", scc.Size)
+	}
+	want := []string{"mod_a", "mod_b"}
+	got := append([]string{}, scc.Members...)
+	sort.Strings(got)
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("members: want %v, got %v", want, got)
+	}
+	if len(scc.Edges) != 2 {
+		t.Fatalf("expected 2 internal edges, got %+v", scc.Edges)
+	}
+	if res.SCCOf["mod_a"] != scc.ID || res.SCCOf["mod_b"] != scc.ID {
+		t.Fatalf("SCCOf not populated: %+v", res.SCCOf)
+	}
+	if res.Stats.NumSCCs != 1 || res.Stats.LargestSCCSize != 2 || res.Stats.NumModulesInCycle != 2 {
+		t.Fatalf("stats wrong: %+v", res.Stats)
+	}
+}
+
+// TestSCCDetection_NoCycle — a DAG produces no SCC and all SCCOf are -1.
+func TestSCCDetection_NoCycle(t *testing.T) {
+	entities := []Entity{
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+		makeModEntity("c", "C", "mod_c", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	if len(res.SCCs) != 0 {
+		t.Fatalf("expected no SCCs in a DAG, got %d", len(res.SCCs))
+	}
+	for m, s := range res.SCCOf {
+		if s != -1 {
+			t.Fatalf("module %s should have SCCOf=-1, got %d", m, s)
+		}
+	}
+}
+
+// TestSCCDetection_ThreeModuleCycle — directed triangle a→b→c→a.
+func TestSCCDetection_ThreeModuleCycle(t *testing.T) {
+	entities := []Entity{
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+		makeModEntity("c", "C", "mod_c", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "r2", FromID: "b", ToID: "c", Kind: "CALLS"},
+		{ID: "r3", FromID: "c", ToID: "a", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	if len(res.SCCs) != 1 || res.SCCs[0].Size != 3 {
+		t.Fatalf("expected 1 SCC of size 3, got %+v", res.SCCs)
+	}
+}
+
+// TestCentrality_HubHasHighestPageRank — a hub module that everything
+// depends on should sit at the top of the PageRank ranking.
+func TestCentrality_HubHasHighestPageRank(t *testing.T) {
+	// hub is depended on by all four other modules.
+	entities := []Entity{
+		makeModEntity("h", "H", "hub", "r"),
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+		makeModEntity("c", "C", "mod_c", "r"),
+		makeModEntity("d", "D", "mod_d", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "a", ToID: "h", Kind: "CALLS"},
+		{ID: "r2", FromID: "b", ToID: "h", Kind: "CALLS"},
+		{ID: "r3", FromID: "c", ToID: "h", Kind: "CALLS"},
+		{ID: "r4", FromID: "d", ToID: "h", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	top := TopByPageRank(res.Centrality, 1)
+	if len(top) != 1 || top[0].ModuleID != "hub" {
+		t.Fatalf("expected hub at the top of PageRank, got %+v", top)
+	}
+	// Hub should also have InDegree = 4.
+	for _, c := range res.Centrality {
+		if c.ModuleID == "hub" {
+			if c.InDegree != 4 {
+				t.Fatalf("hub InDegree: want 4, got %d", c.InDegree)
+			}
+		}
+	}
+}
+
+// TestCentrality_BottleneckHasHighestBetweenness — a module that sits on
+// every shortest path between two clusters has the highest betweenness.
+func TestCentrality_BottleneckHasHighestBetweenness(t *testing.T) {
+	// Topology: a → mid → b ; c → mid → d.  mid is the only path.
+	entities := []Entity{
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+		makeModEntity("c", "C", "mod_c", "r"),
+		makeModEntity("d", "D", "mod_d", "r"),
+		makeModEntity("m", "M", "mid", "r"),
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "a", ToID: "m", Kind: "CALLS"},
+		{ID: "r2", FromID: "m", ToID: "b", Kind: "CALLS"},
+		{ID: "r3", FromID: "c", ToID: "m", Kind: "CALLS"},
+		{ID: "r4", FromID: "m", ToID: "d", Kind: "CALLS"},
+	}
+	res := RunModuleAlgorithms(entities, rels)
+	top := TopByBetweenness(res.Centrality, 1)
+	if len(top) != 1 || top[0].ModuleID != "mid" {
+		t.Fatalf("expected mid at top of betweenness, got %+v", top)
+	}
+}
+
+// TestDeterminism — running twice on the same input must produce identical
+// SCC IDs / member orders / score values. This is a regression guard against
+// gonum's map-iteration noise leaking through (cf. issue #481).
+func TestDeterminism(t *testing.T) {
+	entities := []Entity{
+		makeModEntity("a", "A", "mod_a", "r"),
+		makeModEntity("b", "B", "mod_b", "r"),
+		makeModEntity("c", "C", "mod_c", "r"),
+		makeModEntity("d", "D", "mod_d", "r"),
+	}
+	rels := []Relationship{
+		{ID: "1", FromID: "a", ToID: "b", Kind: "CALLS"},
+		{ID: "2", FromID: "b", ToID: "a", Kind: "CALLS"},
+		{ID: "3", FromID: "b", ToID: "c", Kind: "CALLS"},
+		{ID: "4", FromID: "c", ToID: "d", Kind: "CALLS"},
+		{ID: "5", FromID: "d", ToID: "a", Kind: "CALLS"},
+	}
+	for i := 0; i < 5; i++ {
+		r1 := RunModuleAlgorithms(entities, rels)
+		r2 := RunModuleAlgorithms(entities, rels)
+		if !reflect.DeepEqual(r1, r2) {
+			t.Fatalf("non-deterministic results on iteration %d:\n%+v\n---\n%+v", i, r1, r2)
+		}
+	}
+}

--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -23,7 +23,11 @@ for clients (Claude Code, Windsurf, etc.) and tracks the implementation in
   collisions when other MCP servers are installed alongside (Refs #62).
   Prior history: 19 tools → #668 bundled 3 action-dispatch tools (saved 4) → 39 tools
   after #1202/#1220/#1252 additions → #1281 merged 9 tools into 4 bundles → 32 tools
-  → dropped 4 dashboard-only tools → 28 tools → #1314 added auth_coverage → 29 tools.
+  → dropped 4 dashboard-only tools → 28 tools → #1314 added auth_coverage → 29 tools
+  → #1384 (epic #1380) added `archigraph_module_analysis` (action-dispatched
+  cycles|centrality|all over the aggregated module graph).
+- **Handshake token ceiling:** 3,100 (bumped from 3,000 in #1384 to seat
+  `archigraph_module_analysis`; current measurement 3,085 tokens).
 - **State:** in-memory `Document`s loaded from per-repo `.archigraph/graph.json`
   files; no database. See ADR-0006.
 - **Routing:** every tool that touches graph data resolves a group via the
@@ -122,6 +126,73 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_find_dead_code`](#archigraph_find_dead_code) | Entities with 0 inbound/outbound project edges. |
 | [`archigraph_auth_coverage`](#archigraph_auth_coverage) | Security audit: flag HTTP endpoints missing auth decorators/middleware. |
 | [`archigraph_secrets`](#archigraph_secrets) | Security scan: detect hardcoded API keys, passwords, JWT tokens, and other credentials in source files. |
+| [`archigraph_module_analysis`](#archigraph_module_analysis) | Module-level SCC + PageRank + betweenness over the aggregated module graph (action: cycles\|centrality\|all). |
+
+---
+
+### `archigraph_module_analysis`
+
+Module-level graph data-science (#1384, part of epic #1380). Runs SCC,
+PageRank, and betweenness over the **aggregated module graph** — the
+bird's-eye-view counterpart to the entity-level tools.
+
+The module graph is computed by collapsing every entity-level edge `A → B`
+onto the pair `(module(A), module(B))`, dropping intra-module self-edges,
+and accumulating per-pair weight = count. When the input document already
+contains synthetic `Module` containers and `DEPENDS_ON` edges between them
+(post-#1383 documents), those pre-aggregated edges are used directly
+(honouring their `weight` property).
+
+**Args:**
+
+| Field | Type | Required | Default | Notes |
+|-------|------|----------|---------|-------|
+| `action` | string | no | `all` | `cycles` / `centrality` / `all`. |
+| `repo_filter` | string\[\] | no | all | Restrict to listed repo slugs (read from args even though omitted from schema for handshake-token economy). |
+| `top_n` | int | no | 10 | Top-N for centrality rankings. |
+| `limit` | int | no | 50 | Max SCCs returned. |
+| `min_size` | int | no | 2 | Minimum SCC size to report (cycles action only). |
+| `group` | string | no | inferred | See routing rules above. |
+| `cwd` | string | no | inferred | See routing rules above. |
+
+**Returns (action=all):**
+
+```jsonc
+{
+  "sccs": [                       // module-level cycles, ≥ min_size
+    {
+      "repo": "...",
+      "id": 0,                    // deterministic per repo
+      "size": 3,
+      "members": ["repo::M_A", "repo::M_B", "repo::M_C"],
+      "member_names": ["mod_a", "mod_b", "mod_c"],
+      "edges": [ { "from_module": "repo::M_A", "to_module": "repo::M_B", "weight": 12 } ]
+    }
+  ],
+  "top_pagerank": [               // top-N modules by PageRank, across repos
+    { "repo": "...", "module_id": "repo::M_X", "module_name": "...",
+      "pagerank": 0.0421, "betweenness": 0.0117,
+      "in_degree": 8, "out_degree": 2, "in_cycle": false }
+  ],
+  "top_betweenness": [ /* same shape, sorted by betweenness */ ],
+  "summaries": [                  // per-repo aggregate counts
+    { "repo": "...", "num_modules": N, "num_module_edges": N,
+      "num_sccs": N, "largest_scc_size": N, "modules_in_cycle": N }
+  ]
+}
+```
+
+**Returns (action=cycles):** `{ "cycles": [...], "count": N, "total": N, "truncated": bool, "repos_scanned": N }`.
+
+**Returns (action=centrality):** `{ "repos": [ { "repo": "...", "top_pagerank": [...], "top_betweenness": [...], ... } ], "count": N }`.
+
+Scores are rounded to 4 decimal places (same determinism policy as entity-level
+algorithms, see issue #481). The synthetic `_external` bucket (entities that
+lack a `module` property) is excluded from the module graph — including it
+would pollute SCC and centrality with noise.
+
+The HTTP equivalent is `GET /api/v2/groups/{group}/modules/analysis` on the
+dashboard server (same payload shape, v2 envelope).
 
 ---
 

--- a/internal/mcp/budget_test.go
+++ b/internal/mcp/budget_test.go
@@ -27,8 +27,11 @@ import (
 func TestMCPHandshakeBudget(t *testing.T) {
 	const (
 		// tokenCeiling matches cmd/mcp-audit defaultCeiling.
-		// Baseline: 2,963 tokens (28 tools, measured 2026-05-21 post refactor/mcp-real-3k). Ceiling = 3,000.
-		tokenCeiling  = 3000
+		// Baseline: 2,963 tokens (28 tools, measured 2026-05-21 post refactor/mcp-real-3k).
+		// 2026-05-23 (#1384, epic #1380): ceiling bumped to 3,100 to seat the new
+		// archigraph_module_analysis tool (module-level SCC/PageRank/betweenness).
+		// Current measurement at 29 tools: 3,085 tokens. See cmd/mcp-audit/main.go.
+		tokenCeiling  = 3100
 		charsPerToken = 4
 		envelopeBytes = 512 // initEnvelopeBytes constant from cmd/mcp-audit
 		maxDescLen    = 80

--- a/internal/mcp/module_gds_tools.go
+++ b/internal/mcp/module_gds_tools.go
@@ -1,0 +1,369 @@
+// module_gds_tools.go — MCP handler for the module-LEVEL graph data-science
+// surface (issue #1384, part of epic #1380).
+//
+// Single tool with action=cycles|centrality|all over the aggregated module
+// graph. Bundled (rather than split into two tools as initially planned) to
+// stay under the ≤3k handshake-token ceiling (#1639) — splitting added +196
+// tokens; the action-bundle pattern is already used by patterns/topology/flows.
+//
+// Outputs mirror the entity-level surfaces:
+//
+//   - cycles      ↔ archigraph_quality_cycles (entity-level IMPORTS SCC)
+//   - centrality  ↔ inline PageRank/centrality in archigraph_stats
+//   - all         returns both in one envelope (default; useful for the
+//                 dashboard / docgen consumer).
+package mcp
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// moduleAnalysisResult is the shared per-repo computation cache for both
+// tools. The MCP layer caches per request; the graph algorithm package
+// (RunModuleAlgorithms) is pure and fast on real corpora (≤ thousands of
+// module nodes), so we recompute rather than memoise across requests — this
+// keeps the surface trivially correct under daemon reload.
+type moduleAnalysisResult struct {
+	Repo string
+	Res  *graph.ModuleAlgorithmResults
+}
+
+// computeModuleAnalysis runs RunModuleAlgorithms over every repo in `repos`
+// and returns the per-repo results. Empty repos (no graph loaded) are skipped.
+func computeModuleAnalysis(repos []*LoadedRepo) []moduleAnalysisResult {
+	out := make([]moduleAnalysisResult, 0, len(repos))
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		res := graph.RunModuleAlgorithms(r.Doc.Entities, r.Doc.Relationships)
+		out = append(out, moduleAnalysisResult{Repo: r.Repo, Res: res})
+	}
+	return out
+}
+
+// handleModuleAnalysis dispatches on action=cycles|centrality|all.
+func (s *Server) handleModuleAnalysis(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	action := argString(req, "action", "all")
+	switch action {
+	case "cycles":
+		return s.handleModuleCycles(ctx, req)
+	case "centrality":
+		return s.handleModuleCentrality(ctx, req)
+	case "all", "":
+		return s.handleModuleCombined(ctx, req)
+	}
+	return jsonResult(map[string]any{
+		"error":      "unknown action",
+		"action":     action,
+		"valid":      []string{"cycles", "centrality", "all"},
+	}), nil
+}
+
+// handleModuleCombined returns both cycles and centrality in one envelope.
+func (s *Server) handleModuleCombined(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	topN := argInt(req, "top_n", 10)
+	if topN <= 0 {
+		topN = 10
+	}
+	limit := argInt(req, "limit", 50)
+
+	type centOut struct {
+		Repo        string  `json:"repo"`
+		ModuleID    string  `json:"module_id"`
+		ModuleName  string  `json:"module_name"`
+		PageRank    float64 `json:"pagerank"`
+		Betweenness float64 `json:"betweenness"`
+		InDegree    int     `json:"in_degree"`
+		OutDegree   int     `json:"out_degree"`
+		InCycle     bool    `json:"in_cycle"`
+	}
+	type sccOut struct {
+		Repo        string             `json:"repo"`
+		ID          int                `json:"id"`
+		Size        int                `json:"size"`
+		Members     []string           `json:"members"`
+		MemberNames []string           `json:"member_names"`
+		Edges       []graph.ModuleEdge `json:"edges"`
+	}
+	type repoSummary struct {
+		Repo           string `json:"repo"`
+		NumModules     int    `json:"num_modules"`
+		NumModuleEdges int    `json:"num_module_edges"`
+		NumSCCs        int    `json:"num_sccs"`
+		LargestSCCSize int    `json:"largest_scc_size"`
+		ModulesInCycle int    `json:"modules_in_cycle"`
+	}
+
+	var sccs []sccOut
+	var topPR []centOut
+	var topBet []centOut
+	var summaries []repoSummary
+
+	for _, ra := range computeModuleAnalysis(repos) {
+		summaries = append(summaries, repoSummary{
+			Repo:           ra.Repo,
+			NumModules:     ra.Res.Stats.NumModules,
+			NumModuleEdges: ra.Res.Stats.NumModuleEdges,
+			NumSCCs:        ra.Res.Stats.NumSCCs,
+			LargestSCCSize: ra.Res.Stats.LargestSCCSize,
+			ModulesInCycle: ra.Res.Stats.NumModulesInCycle,
+		})
+		for _, c := range ra.Res.SCCs {
+			members := make([]string, len(c.Members))
+			for i, m := range c.Members {
+				members[i] = prefixedID(ra.Repo, m)
+			}
+			edges := make([]graph.ModuleEdge, len(c.Edges))
+			for i, e := range c.Edges {
+				edges[i] = graph.ModuleEdge{
+					FromModule: prefixedID(ra.Repo, e.FromModule),
+					ToModule:   prefixedID(ra.Repo, e.ToModule),
+					Weight:     e.Weight,
+				}
+			}
+			sccs = append(sccs, sccOut{
+				Repo:        ra.Repo,
+				ID:          c.ID,
+				Size:        c.Size,
+				Members:     members,
+				MemberNames: append([]string{}, c.MemberNames...),
+				Edges:       edges,
+			})
+		}
+		toCent := func(c graph.ModuleCentrality) centOut {
+			return centOut{
+				Repo:        ra.Repo,
+				ModuleID:    prefixedID(ra.Repo, c.ModuleID),
+				ModuleName:  c.ModuleName,
+				PageRank:    c.PageRank,
+				Betweenness: c.Betweenness,
+				InDegree:    c.InDegree,
+				OutDegree:   c.OutDegree,
+				InCycle:     ra.Res.SCCOf[c.ModuleID] >= 0,
+			}
+		}
+		for _, c := range graph.TopByPageRank(ra.Res.Centrality, topN) {
+			topPR = append(topPR, toCent(c))
+		}
+		for _, c := range graph.TopByBetweenness(ra.Res.Centrality, topN) {
+			topBet = append(topBet, toCent(c))
+		}
+	}
+
+	sort.SliceStable(sccs, func(i, j int) bool {
+		if sccs[i].Size != sccs[j].Size {
+			return sccs[i].Size > sccs[j].Size
+		}
+		return sccs[i].Repo < sccs[j].Repo
+	})
+	if limit > 0 && len(sccs) > limit {
+		sccs = sccs[:limit]
+	}
+	sort.SliceStable(topPR, func(i, j int) bool {
+		if topPR[i].PageRank != topPR[j].PageRank {
+			return topPR[i].PageRank > topPR[j].PageRank
+		}
+		return topPR[i].ModuleID < topPR[j].ModuleID
+	})
+	sort.SliceStable(topBet, func(i, j int) bool {
+		if topBet[i].Betweenness != topBet[j].Betweenness {
+			return topBet[i].Betweenness > topBet[j].Betweenness
+		}
+		return topBet[i].ModuleID < topBet[j].ModuleID
+	})
+	sort.Slice(summaries, func(i, j int) bool { return summaries[i].Repo < summaries[j].Repo })
+
+	return jsonResult(map[string]any{
+		"sccs":            sccs,
+		"top_pagerank":    topPR,
+		"top_betweenness": topBet,
+		"summaries":       summaries,
+	}), nil
+}
+
+// handleModuleCycles is the cycles-only response. Returns every module-level
+// SCC of size >= min_size (default 2) in the resolved group.
+func (s *Server) handleModuleCycles(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	limit := argInt(req, "limit", 50)
+	minSize := argInt(req, "min_size", 2)
+	if minSize < 2 {
+		minSize = 2
+	}
+
+	type memberOut struct {
+		ModuleID   string `json:"module_id"`
+		ModuleName string `json:"module_name"`
+	}
+	type cycleOut struct {
+		Repo        string             `json:"repo"`
+		Size        int                `json:"size"`
+		Members     []memberOut        `json:"members"`
+		Edges       []graph.ModuleEdge `json:"edges"`
+		MemberNames []string           `json:"member_names"`
+	}
+
+	var all []cycleOut
+	totalRepos := 0
+	totalSCCs := 0
+
+	for _, ra := range computeModuleAnalysis(repos) {
+		totalRepos++
+		for _, c := range ra.Res.SCCs {
+			if c.Size < minSize {
+				continue
+			}
+			totalSCCs++
+			members := make([]memberOut, 0, len(c.Members))
+			for i, mid := range c.Members {
+				name := mid
+				if i < len(c.MemberNames) {
+					name = c.MemberNames[i]
+				}
+				members = append(members, memberOut{
+					ModuleID:   prefixedID(ra.Repo, mid),
+					ModuleName: name,
+				})
+			}
+			// Prefix edge IDs too — module IDs are scoped per repo.
+			edges := make([]graph.ModuleEdge, len(c.Edges))
+			for i, e := range c.Edges {
+				edges[i] = graph.ModuleEdge{
+					FromModule: prefixedID(ra.Repo, e.FromModule),
+					ToModule:   prefixedID(ra.Repo, e.ToModule),
+					Weight:     e.Weight,
+				}
+			}
+			all = append(all, cycleOut{
+				Repo:        ra.Repo,
+				Size:        c.Size,
+				Members:     members,
+				Edges:       edges,
+				MemberNames: append([]string{}, c.MemberNames...),
+			})
+		}
+	}
+
+	// Sort: descending size, ascending repo, ascending first member name.
+	sort.SliceStable(all, func(i, j int) bool {
+		if all[i].Size != all[j].Size {
+			return all[i].Size > all[j].Size
+		}
+		if all[i].Repo != all[j].Repo {
+			return all[i].Repo < all[j].Repo
+		}
+		mi := ""
+		if len(all[i].Members) > 0 {
+			mi = all[i].Members[0].ModuleName
+		}
+		mj := ""
+		if len(all[j].Members) > 0 {
+			mj = all[j].Members[0].ModuleName
+		}
+		return mi < mj
+	})
+	total := len(all)
+	if limit > 0 && len(all) > limit {
+		all = all[:limit]
+	}
+	return jsonResult(map[string]any{
+		"cycles":      all,
+		"count":       len(all),
+		"total":       total,
+		"truncated":   total > len(all),
+		"repos_scanned": totalRepos,
+	}), nil
+}
+
+// handleModuleCentrality is the MCP handler for archigraph_module_centrality.
+// Returns top-N modules by PageRank and top-N by betweenness, per repo.
+func (s *Server) handleModuleCentrality(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
+	topN := argInt(req, "top_n", 10)
+	if topN <= 0 {
+		topN = 10
+	}
+
+	type centOut struct {
+		Repo        string  `json:"repo"`
+		ModuleID    string  `json:"module_id"`
+		ModuleName  string  `json:"module_name"`
+		PageRank    float64 `json:"pagerank"`
+		Betweenness float64 `json:"betweenness"`
+		InDegree    int     `json:"in_degree"`
+		OutDegree   int     `json:"out_degree"`
+		InCycle     bool    `json:"in_cycle"`
+	}
+	type repoOut struct {
+		Repo             string                     `json:"repo"`
+		NumModules       int                        `json:"num_modules"`
+		NumModuleEdges   int                        `json:"num_module_edges"`
+		NumSCCs          int                        `json:"num_sccs"`
+		LargestSCCSize   int                        `json:"largest_scc_size"`
+		ModulesInCycle   int                        `json:"modules_in_cycle"`
+		TopPageRank      []centOut                  `json:"top_pagerank"`
+		TopBetweenness   []centOut                  `json:"top_betweenness"`
+	}
+
+	out := make([]repoOut, 0, len(repos))
+
+	for _, ra := range computeModuleAnalysis(repos) {
+		toCent := func(c graph.ModuleCentrality) centOut {
+			return centOut{
+				Repo:        ra.Repo,
+				ModuleID:    prefixedID(ra.Repo, c.ModuleID),
+				ModuleName:  c.ModuleName,
+				PageRank:    c.PageRank,
+				Betweenness: c.Betweenness,
+				InDegree:    c.InDegree,
+				OutDegree:   c.OutDegree,
+				InCycle:     ra.Res.SCCOf[c.ModuleID] >= 0,
+			}
+		}
+		topPR := graph.TopByPageRank(ra.Res.Centrality, topN)
+		topBet := graph.TopByBetweenness(ra.Res.Centrality, topN)
+		ro := repoOut{
+			Repo:           ra.Repo,
+			NumModules:     ra.Res.Stats.NumModules,
+			NumModuleEdges: ra.Res.Stats.NumModuleEdges,
+			NumSCCs:        ra.Res.Stats.NumSCCs,
+			LargestSCCSize: ra.Res.Stats.LargestSCCSize,
+			ModulesInCycle: ra.Res.Stats.NumModulesInCycle,
+			TopPageRank:    make([]centOut, 0, len(topPR)),
+			TopBetweenness: make([]centOut, 0, len(topBet)),
+		}
+		for _, c := range topPR {
+			ro.TopPageRank = append(ro.TopPageRank, toCent(c))
+		}
+		for _, c := range topBet {
+			ro.TopBetweenness = append(ro.TopBetweenness, toCent(c))
+		}
+		out = append(out, ro)
+	}
+
+	// Sort repos alphabetically for stable output.
+	sort.Slice(out, func(i, j int) bool { return out[i].Repo < out[j].Repo })
+
+	return jsonResult(map[string]any{
+		"repos": out,
+		"count": len(out),
+	}), nil
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -415,6 +415,19 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_test_coverage", s.handleTestCoverage))
 
+	// archigraph_module_analysis — module-level GDS (#1384, epic #1380).
+	// action=cycles|centrality|all over the aggregated module graph: SCCs,
+	// PageRank, betweenness. Bird's-eye view alongside entity-level tools.
+	// Optional args read from request map but undeclared in schema to keep
+	// the handshake token budget under its ceiling (#1639 pattern): top_n,
+	// limit, min_size, repo_filter (slice form).
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_module_analysis",
+		mcpapi.WithDescription("Module-level SCC+PageRank+betweenness: cycles|centrality|all."),
+		mcpapi.WithString("action", mcpapi.DefaultString("all")),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_module_analysis", s.handleModuleAnalysis))
+
 	// archigraph_secrets — hardcoded secret detector (#1322).
 	// Walks source files; flags API keys, passwords, JWT tokens, and other
 	// high-entropy credentials. Test fixtures and opt-out comments are suppressed.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -603,11 +603,12 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 28 (33 pre-refactor/mcp-real-3k minus 5 dropped for ≤3k budget:
-	// -archigraph_save_finding, -archigraph_list_findings, -archigraph_recent_activity,
-	// -archigraph_cross_links, -archigraph_license_audit [HTTP API still available]).
-	if got := len(srv.MCP.ListTools()); got != 28 {
-		t.Errorf("expected 28 registered tools, got %d", got)
+	// Total count: 29 (28 baseline + 1 new archigraph_module_analysis from #1384,
+	// part of epic #1380 module-level GDS — SCC/PageRank/betweenness on the
+	// aggregated module graph; bundled into one action-dispatched tool to stay
+	// under the ≤3k handshake-token ceiling, mirroring patterns/topology/flows).
+	if got := len(srv.MCP.ListTools()); got != 29 {
+		t.Errorf("expected 29 registered tools, got %d", got)
 	}
 }
 


### PR DESCRIPTION
Fixes #1384 (part of epic #1380; epic stays open).

## 1. What changed

Three layers gain a **module-level** counterpart to the entity-level graph
data-science already living in `internal/graph/algorithms.go`:

- **`internal/graph/module_gds.go`** — `RunModuleAlgorithms` collapses entity
  edges to module edges, then runs Tarjan SCC (iterative) + gonum PageRank
  (sparse) + gonum betweenness (Floyd–Warshall, weighted) over the resulting
  module-level directed weighted graph. Outputs SCCs ≥ 2, per-module
  centrality, and corpus summaries. Honours pre-baked Module containers +
  DEPENDS_ON edges from #1383 when present; falls back to
  `Properties["module"]` otherwise. Drops the synthetic `_external` bucket.
- **`internal/mcp/module_gds_tools.go`** — one action-dispatched tool
  `archigraph_module_analysis(action=cycles|centrality|all)`. Bundled
  (rather than split) to stay within the handshake-token ceiling.
- **`internal/dashboard/v2_modules.go`** — `GET /api/v2/groups/{group}/modules/analysis`
  returning the same payload in v2-envelope form for the future collapsed-view
  UI (#1386 will consume this).

## 2. Why

The entity-level surface in `algorithms.go` produces tens of thousands of
nodes on a real repo, and high-centrality is dominated by widely-shared
utility entities. The strategic question users actually have — *which
modules form a cycle? which module is the blast-radius hub?* — needs a
bird's-eye view at module granularity. Epic #1380 calls for exactly this.

## 3. Design choices

- **One action-bundled MCP tool, not two.** Splitting into
  `archigraph_module_cycles` + `archigraph_module_centrality` measured at
  3,196 handshake tokens (+196 over the 3,000 ceiling). Bundled is 3,085
  (+85). Action-dispatched bundles already exist for patterns / topology /
  flows; the mental model is consistent.
- **Handshake ceiling bumped 3,000 → 3,100** with full justification
  comments in `cmd/mcp-audit/main.go`, `budget_test.go`, and `SCHEMA.md`.
  This is a strategic addition (epic deliverable) — the smallest round
  bump that fits with safety margin.
- **Three-tier container lookup** in `collectModules`: exact `(repo,name)`,
  unambiguous-name-only fallback, then synthesised-string fallback. Real
  entities in single-repo documents lack a `repo` property (containers
  carry it but ordinary entities do not) — without the name-only fallback,
  the module graph **double-counted every node**, producing the wrong SCC
  count on real data. Caught by smoke run, fixed before commit.
- **Determinism policy** matches `algorithms.go`: scores rounded to 1e-4,
  Tarjan walks nodes in sorted order, ties tiebroken on module ID. A
  dedicated `TestDeterminism` runs 5 iterations and `reflect.DeepEqual`s
  the results.

## 4. Test coverage

`go test ./internal/graph/ ./internal/mcp/ ./internal/module/` all green
(including `TestToolNameSurface` updated from 28→29 and
`TestMCPHandshakeBudget` at the new 3,100 ceiling).

`internal/graph/module_gds_test.go` (11 cases):
- `TestRunModuleAlgorithms_EmptyInputs` — empty input, non-nil result.
- `TestAggregation_EntityEdgesCollapseToModules` — entity edges → module
  edges, intra-module edges dropped, weights accumulate.
- `TestAggregation_PrebakedModuleNodes` — pre-#1383 DEPENDS_ON edges used
  directly with their `weight` property; CONTAINS edges ignored.
- `TestExternalBucketDropped` — `_external` module never surfaces.
- `TestSCCDetection_TwoModuleCycle` / `_ThreeModuleCycle` / `_NoCycle`.
- `TestCentrality_HubHasHighestPageRank` — 4 modules → hub topology
  identifies the hub at PageRank rank 1 and InDegree 4.
- `TestCentrality_BottleneckHasHighestBetweenness` — 2 clusters via a
  single bridge module identifies the bridge at betweenness rank 1.
- `TestDeterminism` — 5×`reflect.DeepEqual` on full result struct.

## 5. Verify (isolated reindex of upvate + polyglot)

`go build ./...` + `go vet` clean. The `dist:` pattern error on
`internal/dashboard/static.go` is the pre-existing frontend-embed
artifact, unrelated to this PR.

Smoke run against `~/.archigraph/store/upvate_core-361d39df95e5fa5c`
(7,023 entities, 32,847 relationships, post-#1633 module aggregation):

```
modules=12  module_edges=29  sccs=1  largest_scc=6  modules_in_cycle=6
SCC[0]: { core, core/tasks, core/views, core/serializers,
          core/models, upvate_core }
Top-5 PageRank:    core (0.4036), core/models (0.3705),
                   core/serializers (0.0479), core/tasks (0.0333),
                   core/views (0.0241)
Top-5 betweenness: core (35.0), core/views (12.0),
                   core/management/commands (8.0),
                   core/tasks (5.0), upvate_core (4.0)
```

Reads correctly: the classic Django tangle lights up as a 6-module SCC,
`core` and `core/models` dominate PageRank (everything imports them),
`core` is the bottleneck on betweenness (35.0 — every shortest path
between leaf modules crosses it), `core/views` second (the routing hub).
Leaf utility modules (`core/filters`, `core/signals`, `core/migrations`,
`core/tests`, `_root`) sit cleanly outside the cycle with low scores.

`polyglot-platform` (per-repo): orders / payments / inventory /
users-auth / notifications / realtime-dashboard / search-graphql / web /
admin / core-mobile / upvate_core_frontend all return `sccs=0`. Each
polyglot service is currently tagged with only 1–5 modules per repo
(stack-dependent module-tagging maturity), so per-repo cycles do not
exist to surface. Cross-service cycles between polyglot repos are still
covered by the existing `archigraph_quality_cycles` service-cycle pass
(#1502); collapsing all group repos into one mega-module-graph is a
separate enhancement that belongs with the #1386 collapsed-view UI.

Daemon at `:47274` was **not** restarted (per task instructions). All
smoke runs operated on disk-resident graph documents via a throwaway
in-tree binary that was removed before commit.

## 6. Out of scope / handoffs

- **#1386 collapsed-view UI** — the dashboard UI that consumes the new
  `/api/v2/groups/{group}/modules/analysis` endpoint is a separate grind
  and is not touched here.
- **#1648 verb-collapse / HTTP route extraction in `internal/engine`** —
  untouched, as instructed.
- **#1656 + #1663 payload renderers** — untouched, as instructed.
- **Epic #1380** stays open; this PR closes only the #1384 sub-issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)