### PR TITLE
perf(mcp): minify JSON responses, save 24% session tokens (#1663)

### DIFF
--- a/docs/verify2/mcp-payload-after.json
+++ b/docs/verify2/mcp-payload-after.json
@@ -1,0 +1,127 @@
+{
+  "group": "upvate",
+  "runs": 5,
+  "timestamp": "2026-05-23T05:43:56.703003+05:45",
+  "samples": [
+    {
+      "name": "find: authentication middleware",
+      "tool": "archigraph_find",
+      "runs": 5,
+      "median_ms": 0.913,
+      "p95_ms": 0.966,
+      "min_ms": 0.687,
+      "max_ms": 0.976,
+      "bytes_out": 558
+    },
+    {
+      "name": "inspect: TokenAuthenticationMiddleware",
+      "tool": "archigraph_inspect",
+      "runs": 5,
+      "median_ms": 0.318,
+      "p95_ms": 0.332,
+      "min_ms": 0.299,
+      "max_ms": 0.345,
+      "bytes_out": 407
+    },
+    {
+      "name": "get_source: TokenAuthenticationMiddleware.process_request",
+      "tool": "archigraph_get_source",
+      "runs": 5,
+      "median_ms": 0.453,
+      "p95_ms": 0.667,
+      "min_ms": 0.384,
+      "max_ms": 13.314,
+      "bytes_out": 2935
+    },
+    {
+      "name": "find_callers: TokenAuthenticationMiddleware (label-resolve)",
+      "tool": "archigraph_find_callers",
+      "runs": 5,
+      "median_ms": 0.201,
+      "p95_ms": 0.211,
+      "min_ms": 0.193,
+      "max_ms": 0.216,
+      "bytes_out": 317
+    },
+    {
+      "name": "find_callers: depth=3 (heavier BFS)",
+      "tool": "archigraph_find_callers",
+      "runs": 5,
+      "median_ms": 0.219,
+      "p95_ms": 0.233,
+      "min_ms": 0.193,
+      "max_ms": 0.282,
+      "bytes_out": 317
+    },
+    {
+      "name": "traces: list",
+      "tool": "archigraph_traces",
+      "runs": 5,
+      "median_ms": 0.682,
+      "p95_ms": 0.711,
+      "min_ms": 0.663,
+      "max_ms": 0.757,
+      "bytes_out": 15411
+    },
+    {
+      "name": "traces: follow (deep BFS)",
+      "tool": "archigraph_traces",
+      "runs": 5,
+      "median_ms": 0.209,
+      "p95_ms": 0.209,
+      "min_ms": 0.206,
+      "max_ms": 0.21,
+      "bytes_out": 781
+    },
+    {
+      "name": "expand: depth=2 (neighbors)",
+      "tool": "archigraph_expand",
+      "runs": 5,
+      "median_ms": 19.242,
+      "p95_ms": 19.606,
+      "min_ms": 18.976,
+      "max_ms": 29.722,
+      "bytes_out": 1006391
+    },
+    {
+      "name": "impact_radius: depth=2",
+      "tool": "archigraph_impact_radius",
+      "runs": 5,
+      "median_ms": 1.65,
+      "p95_ms": 1.678,
+      "min_ms": 1.621,
+      "max_ms": 1.691,
+      "bytes_out": 877
+    },
+    {
+      "name": "endpoints: definitions path=proposal",
+      "tool": "archigraph_endpoints",
+      "runs": 5,
+      "median_ms": 1.047,
+      "p95_ms": 1.052,
+      "min_ms": 1.025,
+      "max_ms": 1.062,
+      "bytes_out": 3461
+    },
+    {
+      "name": "endpoints: definitions all",
+      "tool": "archigraph_endpoints",
+      "runs": 5,
+      "median_ms": 1.713,
+      "p95_ms": 1.791,
+      "min_ms": 1.631,
+      "max_ms": 2.281,
+      "bytes_out": 44237
+    },
+    {
+      "name": "stats: corpus",
+      "tool": "archigraph_stats",
+      "runs": 5,
+      "median_ms": 0.192,
+      "p95_ms": 0.193,
+      "min_ms": 0.189,
+      "max_ms": 0.195,
+      "bytes_out": 332
+    }
+  ]
+}

--- a/docs/verify2/mcp-payload-after.md
+++ b/docs/verify2/mcp-payload-after.md
@@ -1,0 +1,130 @@
+# MCP payload-size optimisation (#1663) — before/after
+
+**Corpus:** upvate group — three repos (`upvate-core`, `upvate-core-frontend`,
+`core-mobile`), live `~/.archigraph/registry.json`.
+
+**Method:** `cmd/bench-mcp` boots `*mcp.Server` in-process, calls each tool
+handler 5×, records `bytes_out` from the last run (sum of all `TextContent`
+text on the result). Bytes are converted to tokens via the conventional
+chars/4 estimate.
+
+Note: the bench bypasses `Server.wrap`, so the measured bytes are pre-envelope
+(no `elapsed_ms` injection). The wrap layer also calls `MarshalIndent` →
+`Marshal` in this PR, so live wire payloads benefit by the same percentage on
+the envelope itself plus the per-tool savings shown below.
+
+## Per-tool bytes (median of 5 runs, last sample)
+
+| Tool / query                                          | Before     | After      | Δ %      |
+|-------------------------------------------------------|-----------:|-----------:|---------:|
+| `archigraph_find` (BM25, depth=3, token_budget=800)   |        558 |        558 |    +0.0% |
+| `archigraph_inspect` (label resolve)                  |        473 |        407 |   −14.0% |
+| `archigraph_get_source` (incl. source body)           |      2,936 |      2,935 |    −0.0% |
+| `archigraph_find_callers` depth=2                     |        354 |        317 |   −10.5% |
+| `archigraph_find_callers` depth=3                     |        354 |        317 |   −10.5% |
+| `archigraph_traces` action=list                       |     19,769 |     15,411 |   −22.0% |
+| `archigraph_traces` action=follow                     |      1,159 |        781 |   −32.6% |
+| `archigraph_expand` depth=2                           |  1,326,608 |  1,006,391 |   −24.1% |
+| `archigraph_impact_radius` depth=2                    |      1,119 |        877 |   −21.6% |
+| `archigraph_endpoints` definitions path=proposal      |      4,337 |      3,461 |   −20.2% |
+| `archigraph_endpoints` definitions (all)              |     55,256 |     44,237 |   −19.9% |
+| `archigraph_stats`                                    |        482 |        332 |   −31.1% |
+| **TOTAL session**                                     |**1,413,405** | **1,076,024** | **−23.9%** |
+| Estimated tokens (chars/4)                            |    353,351 |    269,006 |   −23.9% |
+
+**Target met: 20%+ across the session.** A session running this query set saves
+~84,000 tokens (~23.9%) at zero schema cost.
+
+## Why some tools didn't move
+
+- **`archigraph_find`**: handler returns the compact text format from
+  `renderCompact()` (graph header + node/edge lines), not JSON. It was never
+  paying the pretty-print tax. No regression, no win.
+- **`archigraph_get_source`**: payload is dominated by the literal source-code
+  body. The JSON envelope is a few hundred bytes; minifying it shaves ~10
+  bytes on a 2.9 KB response.
+
+The tools that DO move are all the JSON-shape responses: `inspect`, `traces`,
+`expand`, `impact_radius`, `endpoints`, `stats`, `find_callers`. Wins range
+from −10% (small objects, lots of structural overhead per byte) to −33%
+(`stats`, `traces:follow` — dense flat objects where every key-value pair was
+followed by `,\n  `).
+
+## Format decisions
+
+| Payload shape | Format | Why |
+|---|---|---|
+| Single-entity / nested object (`inspect`, `find_paths`, `whoami`, `stats`) | **Minified JSON** | Schema preserved, callers `json.Unmarshal` as before. TOON would hurt nested shapes. |
+| List-of-record (`endpoints`, `traces:list`, `find_callers`, search results) | **Minified JSON** | Same caller contract. Tabular gives more, but breaks every existing `json.Unmarshal` consumer. Kept as a future opt-in via `tabularEncode`. |
+| Compact text graph (`find`, `expand`'s `renderCompact` path) | **Unchanged** | Already a compact text format, not JSON. |
+| Source-body responses (`get_source`) | **Minified JSON envelope** | Body dominates size; minifying the envelope is a few bytes. |
+| Disk artefacts (repair findings, patterns, candidates, docstate, memory notes) | **Indented JSON (unchanged)** | These files are read by humans on disk; pretty-printing is the right default. |
+
+The brief offered TOON as a possible upgrade for list-of-record. A spot-check
+test (`TestTabularEncode_SavesTokensVsJSON`) shows tabular IS shorter than
+minified JSON for homogeneous lists. But the schema contract MCP callers
+already depend on is `json.Unmarshal`-able JSON — every test in this package
+and the field-report consumers parse the response as JSON. Switching even a
+single tool to tabular requires caller-side updates. The `tabularEncode`
+helper is shipped and tested here so future PRs can opt individual list
+endpoints into it once a caller-side decoder lands.
+
+## Implementation
+
+Two-line behavioural change:
+
+- `internal/mcp/tools.go::jsonResult` — `json.MarshalIndent(v, "", "  ")` →
+  `json.Marshal(v)`. Used by 79 call sites; benefits every JSON-shape tool.
+- `internal/mcp/server.go::wrap` (the `elapsed_ms` envelope, #1650) —
+  `MarshalIndent` → `Marshal` for both object and array envelopes. Same
+  schema: `items` / `count` / `elapsed_ms` keys preserved.
+
+New helpers in `internal/mcp/render.go`:
+
+- `compactJSON(v any) string` — exported-ish minified JSON helper that returns
+  `"null"` on marshal failure. Available for future tool writers.
+- `tabularEncode(schema []string, rows [][]any) string` — TOON-style
+  list-of-record encoder. Header line `[!schema {f1,f2,...}]` then one
+  `{v1,v2,...}` row per record, with `,` `{` `}` `\` escaped via backslash.
+  NOT used by any tool yet — see "Format decisions" above.
+
+New test file `internal/mcp/compact_test.go`:
+
+- `TestCompactJSON_Minified` — no `\n` / `  ` in output, round-trips.
+- `TestJSONResult_NoIndent` — guards against re-introducing pretty-print.
+- `TestTabularEncode_Shape` — schema/row format and escaping.
+- `TestTabularEncode_SavesTokensVsJSON` — tabular is shorter than minified
+  JSON for homogeneous list-of-record payloads.
+
+## Schema preservation
+
+Verified by the existing test suite (`go test ./internal/mcp/...`). Every test
+that parses tool output via `json.Unmarshal` still passes. Three tests in
+`traces_test.go` and one in `server_test.go` had string-matched against the
+pretty-print form (`"count": 2` with the space); updated to match the
+minified form (`"count":2`). No semantic changes.
+
+## Disk artefacts deliberately NOT minified
+
+- `internal/mcp/repair.go` (`repair.json`)
+- `internal/mcp/candidates.go` (`patterns/candidates/*.json`, links)
+- `internal/mcp/docstate.go` (`.archigraph/docstate.json`)
+- `internal/mcp/tools.go::handleSaveFinding` (memory note files)
+- `internal/mcp/telemetry.go::SnapshotJSON` (admin telemetry text)
+
+These are read by humans (on disk, in the dashboard, via `cat`). The
+pretty-print cost is paid once per write and they aren't on the MCP wire.
+
+## Targets vs. result
+
+The brief asked for **20-30%+** reduction. The session-wide result is **23.9%**
+— inside the target band with the higher-volume endpoints (`expand`, `traces`,
+`endpoints`) landing at 20-25% and the flat-object handlers (`stats`,
+`traces:follow`) doing even better at 31-33%.
+
+## Coordination with #1656
+
+#1656 (cached adjacency + byID at reload) was a CPU/alloc win on hot paths.
+This PR (#1663) is a payload-bytes win on response serialisation. They are
+orthogonal — no shared state, no test interaction. Verified by running both
+sets of tests green from origin/main + this branch.

--- a/docs/verify2/mcp-payload-baseline.json
+++ b/docs/verify2/mcp-payload-baseline.json
@@ -1,0 +1,127 @@
+{
+  "group": "upvate",
+  "runs": 5,
+  "timestamp": "2026-05-23T05:37:14.240514+05:45",
+  "samples": [
+    {
+      "name": "find: authentication middleware",
+      "tool": "archigraph_find",
+      "runs": 5,
+      "median_ms": 2.511,
+      "p95_ms": 3.542,
+      "min_ms": 0.749,
+      "max_ms": 3.644,
+      "bytes_out": 558
+    },
+    {
+      "name": "inspect: TokenAuthenticationMiddleware",
+      "tool": "archigraph_inspect",
+      "runs": 5,
+      "median_ms": 0.335,
+      "p95_ms": 0.362,
+      "min_ms": 0.316,
+      "max_ms": 0.366,
+      "bytes_out": 473
+    },
+    {
+      "name": "get_source: TokenAuthenticationMiddleware.process_request",
+      "tool": "archigraph_get_source",
+      "runs": 5,
+      "median_ms": 2.745,
+      "p95_ms": 3.498,
+      "min_ms": 1.348,
+      "max_ms": 32.697,
+      "bytes_out": 2936
+    },
+    {
+      "name": "find_callers: TokenAuthenticationMiddleware (label-resolve)",
+      "tool": "archigraph_find_callers",
+      "runs": 5,
+      "median_ms": 0.455,
+      "p95_ms": 0.477,
+      "min_ms": 0.447,
+      "max_ms": 0.487,
+      "bytes_out": 354
+    },
+    {
+      "name": "find_callers: depth=3 (heavier BFS)",
+      "tool": "archigraph_find_callers",
+      "runs": 5,
+      "median_ms": 0.467,
+      "p95_ms": 0.5,
+      "min_ms": 0.447,
+      "max_ms": 0.554,
+      "bytes_out": 354
+    },
+    {
+      "name": "traces: list",
+      "tool": "archigraph_traces",
+      "runs": 5,
+      "median_ms": 0.839,
+      "p95_ms": 0.969,
+      "min_ms": 0.813,
+      "max_ms": 1.704,
+      "bytes_out": 19769
+    },
+    {
+      "name": "traces: follow (deep BFS)",
+      "tool": "archigraph_traces",
+      "runs": 5,
+      "median_ms": 0.215,
+      "p95_ms": 0.215,
+      "min_ms": 0.209,
+      "max_ms": 0.249,
+      "bytes_out": 1159
+    },
+    {
+      "name": "expand: depth=2 (neighbors)",
+      "tool": "archigraph_expand",
+      "runs": 5,
+      "median_ms": 36.628,
+      "p95_ms": 38.746,
+      "min_ms": 31.025,
+      "max_ms": 46.159,
+      "bytes_out": 1326608
+    },
+    {
+      "name": "impact_radius: depth=2",
+      "tool": "archigraph_impact_radius",
+      "runs": 5,
+      "median_ms": 1.927,
+      "p95_ms": 2.071,
+      "min_ms": 1.721,
+      "max_ms": 4.227,
+      "bytes_out": 1119
+    },
+    {
+      "name": "endpoints: definitions path=proposal",
+      "tool": "archigraph_endpoints",
+      "runs": 5,
+      "median_ms": 1.231,
+      "p95_ms": 1.32,
+      "min_ms": 1.066,
+      "max_ms": 1.416,
+      "bytes_out": 4337
+    },
+    {
+      "name": "endpoints: definitions all",
+      "tool": "archigraph_endpoints",
+      "runs": 5,
+      "median_ms": 2.227,
+      "p95_ms": 2.361,
+      "min_ms": 2.158,
+      "max_ms": 5.494,
+      "bytes_out": 55256
+    },
+    {
+      "name": "stats: corpus",
+      "tool": "archigraph_stats",
+      "runs": 5,
+      "median_ms": 0.225,
+      "p95_ms": 0.659,
+      "min_ms": 0.202,
+      "max_ms": 1.33,
+      "bytes_out": 482
+    }
+  ]
+}

--- a/internal/mcp/compact_test.go
+++ b/internal/mcp/compact_test.go
@@ -1,0 +1,113 @@
+// compact_test.go — #1663 compact serializer tests.
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+// TestCompactJSON_Minified verifies the output has no indentation whitespace
+// and round-trips back to the same shape.
+func TestCompactJSON_Minified(t *testing.T) {
+	v := map[string]any{
+		"id":          "abc",
+		"source_file": "foo/bar.go",
+		"start_line":  42,
+		"nested":      map[string]any{"k": "v"},
+	}
+	got := compactJSON(v)
+	if strings.Contains(got, "  ") || strings.Contains(got, "\n") {
+		t.Errorf("compactJSON should not contain pretty whitespace: %q", got)
+	}
+	var back map[string]any
+	if err := json.Unmarshal([]byte(got), &back); err != nil {
+		t.Fatalf("round-trip failed: %v", err)
+	}
+	if back["id"] != "abc" || back["source_file"] != "foo/bar.go" {
+		t.Errorf("schema lost on round-trip: %v", back)
+	}
+}
+
+// TestJSONResult_NoIndent verifies the public helper now emits minified JSON.
+func TestJSONResult_NoIndent(t *testing.T) {
+	res := jsonResult(map[string]any{"foo": "bar", "baz": []int{1, 2, 3}})
+	if res == nil || len(res.Content) == 0 {
+		t.Fatal("nil result")
+	}
+	// Inspect the text content.
+	type texter interface{ GetText() string }
+	var text string
+	for _, c := range res.Content {
+		// mcpapi.TextContent has a Text field; rely on JSON-marshalling the
+		// content to read it portably here.
+		data, err := json.Marshal(c)
+		if err != nil {
+			continue
+		}
+		var obj map[string]any
+		if err := json.Unmarshal(data, &obj); err == nil {
+			if t, ok := obj["text"].(string); ok {
+				text = t
+				break
+			}
+		}
+	}
+	if text == "" {
+		t.Fatal("could not read text content")
+	}
+	if strings.Contains(text, "\n  ") {
+		t.Errorf("jsonResult emitted indented JSON: %q", text)
+	}
+}
+
+// TestTabularEncode_Shape verifies the schema/row format and escaping.
+func TestTabularEncode_Shape(t *testing.T) {
+	got := tabularEncode(
+		[]string{"id", "kind", "file", "line"},
+		[][]any{
+			{"abc", "View", "routers.py", 12},
+			{"def", "Method", "view.py", 40},
+			{"weird,name", "Class", "a\\b.py", 1},
+		},
+	)
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	if len(lines) != 4 {
+		t.Fatalf("want 4 lines (1 schema + 3 rows), got %d: %q", len(lines), got)
+	}
+	if lines[0] != "[!schema {id,kind,file,line}]" {
+		t.Errorf("schema line wrong: %q", lines[0])
+	}
+	if lines[1] != "{abc,View,routers.py,12}" {
+		t.Errorf("row 1 wrong: %q", lines[1])
+	}
+	// Escaped comma and backslash.
+	if !strings.Contains(lines[3], `weird\,name`) {
+		t.Errorf("comma should be escaped: %q", lines[3])
+	}
+	if !strings.Contains(lines[3], `a\\b.py`) {
+		t.Errorf("backslash should be escaped: %q", lines[3])
+	}
+}
+
+// TestTabularEncode_SavesTokensVsJSON spot-checks that for list-of-record
+// payloads, the tabular form is meaningfully shorter than the equivalent
+// minified JSON array.
+func TestTabularEncode_SavesTokensVsJSON(t *testing.T) {
+	rows := make([][]any, 50)
+	for i := range rows {
+		rows[i] = []any{"id_" + strings.Repeat("x", 4), "Method", "path/to/file.go", 100 + i}
+	}
+	tab := tabularEncode([]string{"id", "kind", "file", "line"}, rows)
+
+	// Equivalent JSON: array of objects.
+	arr := make([]map[string]any, len(rows))
+	for i, r := range rows {
+		arr[i] = map[string]any{"id": r[0], "kind": r[1], "file": r[2], "line": r[3]}
+	}
+	data, _ := json.Marshal(arr)
+	if len(tab) >= len(data) {
+		t.Errorf("tabular (%d) should be shorter than JSON array (%d) for list-of-record",
+			len(tab), len(data))
+	}
+}

--- a/internal/mcp/render.go
+++ b/internal/mcp/render.go
@@ -1,6 +1,7 @@
 package mcp
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -118,6 +119,109 @@ func renderCompact(r renderResult, tokenBudget int) string {
 	}
 	if r.TruncatedNote != "" {
 		b.WriteString("# " + r.TruncatedNote + "\n")
+	}
+	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// #1663 — compact serializers
+// ---------------------------------------------------------------------------
+
+// compactJSON serializes v to minified JSON (no indentation, no trailing
+// whitespace). Field names and shapes are unchanged. Returns "null" on error;
+// callers that need to detect marshal failure should use json.Marshal directly.
+//
+// This is the wire-format helper for MCP tool responses (#1663). The package
+// disk-bound writers (repair, candidates, docstate, memory notes) intentionally
+// keep MarshalIndent because those files are read by humans on disk.
+func compactJSON(v any) string {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return "null"
+	}
+	return string(data)
+}
+
+// tabularEncode serializes a slice of homogeneous records as a header-prefixed
+// row-major table. Format:
+//
+//	[!schema {f1,f2,f3}]
+//	{v1,v2,v3}
+//	{v1,v2,v3}
+//
+// Strings are escaped: backslash, comma, and brace are quoted. Numbers and
+// booleans are emitted bare. Nested objects/arrays are emitted as their
+// json.Marshal form (single-cell).
+//
+// Use only for true list-of-record payloads where the schema is fixed across
+// every row. For nested or heterogeneous shapes use compactJSON.
+//
+// NOTE: not wired to any production tool by default. The schema contract that
+// MCP callers depend on is plain JSON; opting a tool into tabularEncode is a
+// behavioural change that requires caller-side updates. The helper lives here
+// so future opt-in payloads can use it; see docs/verify2/mcp-payload-after.md
+// for projected savings.
+func tabularEncode(schema []string, rows [][]any) string {
+	var b strings.Builder
+	b.WriteString("[!schema {")
+	for i, f := range schema {
+		if i > 0 {
+			b.WriteByte(',')
+		}
+		b.WriteString(f)
+	}
+	b.WriteString("}]\n")
+	for _, row := range rows {
+		b.WriteByte('{')
+		for i, v := range row {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			b.WriteString(tabularCell(v))
+		}
+		b.WriteString("}\n")
+	}
+	return b.String()
+}
+
+// tabularCell renders one cell value. Strings need escaping for `,` `}` `\`.
+func tabularCell(v any) string {
+	switch x := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return tabularEscapeString(x)
+	case bool:
+		if x {
+			return "true"
+		}
+		return "false"
+	case int, int32, int64, float32, float64:
+		return fmt.Sprintf("%v", x)
+	default:
+		// Fallback: minified JSON for nested types.
+		data, err := json.Marshal(x)
+		if err != nil {
+			return ""
+		}
+		return tabularEscapeString(string(data))
+	}
+}
+
+func tabularEscapeString(s string) string {
+	if !strings.ContainsAny(s, `,}{\`) {
+		return s
+	}
+	var b strings.Builder
+	b.Grow(len(s) + 4)
+	for _, r := range s {
+		switch r {
+		case '\\', ',', '{', '}':
+			b.WriteByte('\\')
+			b.WriteRune(r)
+		default:
+			b.WriteRune(r)
+		}
 	}
 	return b.String()
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -485,7 +485,8 @@ func injectElapsedMS(res *mcpapi.CallToolResult, ms int64) *mcpapi.CallToolResul
 			var obj map[string]any
 			if err := json.Unmarshal([]byte(tc.Text), &obj); err == nil {
 				obj["elapsed_ms"] = ms
-				if data, err := json.MarshalIndent(obj, "", "  "); err == nil {
+				// #1663: minified JSON on the wire. Schema preserved.
+				if data, err := json.Marshal(obj); err == nil {
 					res.Content[i] = mcpapi.NewTextContent(string(data))
 					return res
 				}
@@ -498,7 +499,8 @@ func injectElapsedMS(res *mcpapi.CallToolResult, ms int64) *mcpapi.CallToolResul
 					"count":      len(arr),
 					"elapsed_ms": ms,
 				}
-				if data, err := json.MarshalIndent(env, "", "  "); err == nil {
+				// #1663: minified JSON on the wire. items/count envelope preserved.
+				if data, err := json.Marshal(env); err == nil {
 					res.Content[i] = mcpapi.NewTextContent(string(data))
 					return res
 				}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -338,10 +338,10 @@ func TestShortestPathCrossRepo(t *testing.T) {
 	}
 	res := callTool(t, srv, "archigraph_trace", map[string]any{"source": "rA::a1", "target": "rB::a4"})
 	txt := resultText(res)
-	if !strings.Contains(txt, "\"crosses_repos\": true") {
+	if !strings.Contains(txt, "\"crosses_repos\":true") {
 		t.Fatalf("expected crosses_repos=true, got: %s", txt)
 	}
-	if !strings.Contains(txt, "\"found\": true") {
+	if !strings.Contains(txt, "\"found\":true") {
 		t.Fatalf("expected found=true, got: %s", txt)
 	}
 }

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -138,8 +138,14 @@ func reposToConsider(lg *LoadedGroup, filter []string) []*LoadedRepo {
 
 // jsonResult is a small helper to produce JSON tool output with a structured
 // payload for agents that prefer machine-readable shapes.
+//
+// Wire format: MINIFIED JSON (no indentation, no trailing whitespace). Field
+// names and shapes are unchanged — callers still find `id`, `qualified_name`,
+// `source_file`, `start_line`, etc. See #1663: pretty-printing was costing
+// ~20-30% of MCP payload tokens for zero semantic value (callers all
+// `json.Unmarshal` the response).
 func jsonResult(v any) *mcpapi.CallToolResult {
-	data, err := json.MarshalIndent(v, "", "  ")
+	data, err := json.Marshal(v)
 	if err != nil {
 		return mcpapi.NewToolResultError("marshal: " + err.Error())
 	}

--- a/internal/mcp/traces_test.go
+++ b/internal/mcp/traces_test.go
@@ -90,7 +90,7 @@ func TestTraces_ListReturnsAllProcesses(t *testing.T) {
 	// have 3-step chains and the test asserts list completeness, not filtering.
 	res := callTool(t, srv, "archigraph_traces", map[string]any{"action": "list", "min_steps": 0})
 	txt := resultText(res)
-	if !strings.Contains(txt, "\"count\": 2") {
+	if !strings.Contains(txt, "\"count\":2") {
 		t.Errorf("expected count=2, got: %s", txt)
 	}
 	if !strings.Contains(txt, "handleSubmit") {
@@ -106,7 +106,7 @@ func TestTraces_ListCrossStackOnly(t *testing.T) {
 		"min_steps":        0,
 	})
 	txt := resultText(res)
-	if !strings.Contains(txt, "\"count\": 1") {
+	if !strings.Contains(txt, "\"count\":1") {
 		t.Errorf("expected count=1 cross-stack process, got: %s", txt)
 	}
 	if !strings.Contains(txt, "/api/orders") {
@@ -121,7 +121,7 @@ func TestTraces_GetReturnsFullChain(t *testing.T) {
 		"process_id": "p1",
 	})
 	txt := resultText(res)
-	if !strings.Contains(txt, "\"found\": true") {
+	if !strings.Contains(txt, "\"found\":true") {
 		t.Errorf("expected found=true, got: %s", txt)
 	}
 	if !strings.Contains(txt, "validateForm") || !strings.Contains(txt, "submitOrder") {


### PR DESCRIPTION
Fixes #1663

## What

`jsonResult` (used by 79 MCP tool handlers) and the `elapsed_ms` envelope
in `Server.wrap` were both emitting `json.MarshalIndent(v, "", "  ")` —
pretty-printed JSON with two-space indentation that every caller immediately
discards via `json.Unmarshal`. Switch both to `json.Marshal` (minified).
Schema, field names, and envelope keys (`items` / `count` / `elapsed_ms`)
are unchanged.

Also ships a `tabularEncode()` helper in `internal/mcp/render.go` for a
future TOON-style list-of-record opt-in, plus a `compactJSON()` helper for
new tool writers.

## Why

Owner directive 2026-05-23: MCP responses are token-heavy. Iter2 + the
field report flagged total tokens slightly above grep. Pretty whitespace
buys zero semantic value when every consumer is a programmatic JSON
parser.

## How

Two-line behavioural change in production code:

- `internal/mcp/tools.go::jsonResult` — `MarshalIndent` → `Marshal`
- `internal/mcp/server.go::wrap` (#1650 envelope) — `MarshalIndent` →
  `Marshal` on both `{` and `[` branches

Disk artefacts (`repair.json`, `candidates`, `docstate`, memory-note files,
admin telemetry text) deliberately KEEP `MarshalIndent` — those are read
by humans on disk, not transported on the wire.

## Measurements

`cmd/bench-mcp -group upvate -runs 5` against the live registry,
per-handler `bytes_out` from the last sample, chars/4 token estimate.
Full per-tool table + format decisions in
`docs/verify2/mcp-payload-after.md`; raw JSON in
`docs/verify2/mcp-payload-baseline.json` and `…-after.json`.

| Tool                        | Before     | After      | Δ %      |
|-----------------------------|-----------:|-----------:|---------:|
| `inspect`                   |        473 |        407 |   −14.0% |
| `find_callers` depth=2      |        354 |        317 |   −10.5% |
| `traces:list`               |     19,769 |     15,411 |   −22.0% |
| `traces:follow`             |      1,159 |        781 |   −32.6% |
| `expand` depth=2            |  1,326,608 |  1,006,391 |   −24.1% |
| `impact_radius` depth=2     |      1,119 |        877 |   −21.6% |
| `endpoints:definitions` all |     55,256 |     44,237 |   −19.9% |
| `stats`                     |        482 |        332 |   −31.1% |
| **Session TOTAL**           | **1,413,405** | **1,076,024** | **−23.9%** |

Target was 20-30%+; result is **−23.9% session-wide, ~84,000 tokens
saved**. `find` and `get_source` are flat because they return non-JSON
text (compact graph format / source body), not `jsonResult` payloads —
correct by design.

## Tests

- 4 new tests in `internal/mcp/compact_test.go`:
  - `TestCompactJSON_Minified` — no pretty whitespace, round-trips
  - `TestJSONResult_NoIndent` — guards regression
  - `TestTabularEncode_Shape` — schema/row format + `,` `}` `\` escaping
  - `TestTabularEncode_SavesTokensVsJSON` — tabular is shorter than minified
    JSON for homogeneous list-of-record payloads
- 4 string assertions updated in `traces_test.go` + `server_test.go`:
  `"count": 2` → `"count":2` (the pretty form was an accidental wire
  detail being asserted on; the minified form is now canonical).

`go test ./internal/mcp/...` — green (2.4 s).

Pre-existing failures elsewhere in the tree
(`TestDaemonMCPListTools_Returns14Canonical`,
`TestPass4Algorithms_AttributesPresent`, `fixtures/sources/go` build) all
reproduce on `origin/main` and are unrelated to this PR.

## Risk

Low. The wire-format change is a strict subset of the previous output
(same bytes, different whitespace). Any consumer that was depending on the
pretty form was already broken — JSON parsers don't care, and string
matches on `"key": value` (with the space) were trivially updateable, as
the 4 test changes here demonstrate. Live `:47274` is unaffected until a
human-initiated rebuild + restart; per task brief, daemon was NOT
restarted.

## Worktree

`/Users/jorgecajas/Documents/Projects/archigraph-worktrees/feat-compact-mcp`
on branch `feat/compact-mcp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
