### PR TITLE
[PLT-1648] Restore per-verb DRF endpoint defs for explicit-method + http_method_names ViewSets

### DIFF
--- a/internal/engine/django_drf_actions.go
+++ b/internal/engine/django_drf_actions.go
@@ -165,6 +165,30 @@ var drfExplicitMethodRe = regexp.MustCompile(
 	`\bdef\s+(list|create|retrieve|update|partial_update|destroy)\s*\(\s*self`,
 )
 
+// drfHTTPMethodNamesRe captures the `http_method_names = ['get', 'post', ...]`
+// class-attribute assignment that DRF View / ViewSet classes use to restrict
+// the set of HTTP verbs accepted by the dispatcher. When present, ONLY the
+// listed verbs are routed — every other CRUD method that maps to an
+// unlisted verb is silently dropped at request time. Mirroring this gate
+// here turns CRUD-method derived verbs that would never actually run into
+// no-ops, which is essential for ViewSets like `RefreshViewSet(viewsets.ViewSet,
+// TokenRefreshView)` with `http_method_names=['post']` + explicit `def create()`
+// — without this gate the verb stays ANY (#1648).
+var drfHTTPMethodNamesRe = regexp.MustCompile(
+	`http_method_names\s*=\s*[\[\(]([^\]\)]+)[\]\)]`,
+)
+
+// crudMethodToVerb maps a DRF CRUD method name to the HTTP verb DRF wires it
+// to. This is the canonical DRF dispatch table.
+var crudMethodToVerb = map[string]string{
+	"list":           "GET",
+	"create":         "POST",
+	"retrieve":       "GET",
+	"update":         "PUT",
+	"partial_update": "PATCH",
+	"destroy":        "DELETE",
+}
+
 // drfViewSetClass describes a ViewSet class located on disk and parsed for
 // its CRUD method support + @action endpoints + lookup_field override.
 type drfViewSetClass struct {
@@ -1323,6 +1347,62 @@ func parseViewSetClass(src, viewSetName string) drfViewSetClass {
 		if len(m) >= 2 {
 			out.explicitMethods[m[1]] = true
 		}
+	}
+
+	// Issue #1648 — merge explicitly-defined CRUD methods into crudMethods.
+	// A ViewSet whose base class doesn't include a CRUD mixin (e.g. bare
+	// `viewsets.ViewSet`) can still expose CRUD verbs by directly defining
+	// `def create(self, ...)` / `def list(self, ...)` etc. Previously these
+	// classes ended up with an empty crudMethods set, which caused
+	// emitOneCRUDFamily to skip every per-verb emission and fall through to
+	// the ANY catch-all — producing the verb-collapsed
+	// `http:ANY:/api/v1/auth/refresh` entries that defeat verb-aware call→def
+	// matching on the consumer side. Merging the explicit set restores the
+	// per-verb signal for these classes.
+	if out.crudMethods == nil {
+		out.crudMethods = map[string]bool{}
+	}
+	for name := range out.explicitMethods {
+		out.crudMethods[name] = true
+	}
+
+	// Issue #1648 — honour `http_method_names = [...]`. DRF treats this
+	// class-level attribute as an absolute filter: the dispatcher only
+	// routes requests whose verb appears in the list, regardless of which
+	// CRUD methods the class otherwise defines. Without applying this gate
+	// here we would emit phantom verbs (e.g. GET/PUT/PATCH/DELETE on a
+	// POST-only viewset) which dilutes the verb signal even though the
+	// emission is per-verb.
+	if m := drfHTTPMethodNamesRe.FindStringSubmatch(classBody); len(m) >= 2 {
+		allowed := parseHTTPMethodNames(m[1])
+		if len(allowed) > 0 {
+			filtered := map[string]bool{}
+			for name := range out.crudMethods {
+				if verb, ok := crudMethodToVerb[name]; ok && allowed[verb] {
+					filtered[name] = true
+				}
+			}
+			out.crudMethods = filtered
+		}
+	}
+
+	return out
+}
+
+// parseHTTPMethodNames parses the comma-separated argument list of
+// `http_method_names = [...]` into a set of UPPERCASE HTTP verbs. Single and
+// double-quoted entries are both accepted; whitespace and bare identifiers
+// are tolerated.
+func parseHTTPMethodNames(args string) map[string]bool {
+	out := map[string]bool{}
+	for _, raw := range strings.Split(args, ",") {
+		s := strings.TrimSpace(raw)
+		s = strings.Trim(s, "\"'")
+		s = strings.TrimSpace(s)
+		if s == "" {
+			continue
+		}
+		out[strings.ToUpper(s)] = true
 	}
 	return out
 }

--- a/internal/engine/django_drf_actions_test.go
+++ b/internal/engine/django_drf_actions_test.go
@@ -364,6 +364,117 @@ router.register(r"mystery", MysteryViewSet)
 	})
 }
 
+// TestApplyDjangoDRFRoutes_ExplicitCreateOnBareViewSet verifies Issue #1648.
+// A ViewSet whose base class is just `viewsets.ViewSet` (no CRUD mixins) but
+// which explicitly defines `def create(self, ...)` must emit a per-verb POST
+// endpoint at the bare prefix, not collapse to a verb-less ANY entry. This is
+// the upvate RefreshViewSet shape — without the fix every consumer-side
+// `POST /api/v1/auth/refresh` call falls into the verb-agnostic ANY bucket
+// and the cross-repo matcher can't tell apart a real POST from an accidental
+// GET / DELETE caller.
+func TestApplyDjangoDRFRoutes_ExplicitCreateOnBareViewSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import RefreshViewSet
+
+router = routers.DefaultRouter()
+router.register(r"auth/refresh", RefreshViewSet)
+`,
+		"views.py": `
+from rest_framework import viewsets
+
+class RefreshViewSet(viewsets.ViewSet):
+    http_method_names = ['post']
+
+    def create(self, request):
+        return None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	// Must emit the per-verb POST at the bare prefix (driven by the explicit
+	// `def create` + `http_method_names=['post']`).
+	assertHasAllIDs(t, got, []string{
+		"http:POST:/auth/refresh",
+	})
+	// Must NOT emit phantom verbs filtered out by http_method_names=['post'].
+	// In particular GET/list and DELETE/destroy/PUT/PATCH are forbidden by
+	// the http_method_names gate, so they should never appear.
+	assertHasNoneIDs(t, got, []string{
+		"http:GET:/auth/refresh",
+		"http:GET:/auth/refresh/{pk}",
+		"http:DELETE:/auth/refresh/{pk}",
+		"http:PUT:/auth/refresh/{pk}",
+		"http:PATCH:/auth/refresh/{pk}",
+	})
+}
+
+// TestApplyDjangoDRFRoutes_HTTPMethodNamesFiltersModelViewSet verifies that
+// `http_method_names = ['post']` on a ModelViewSet correctly suppresses every
+// CRUD method whose verb is NOT in the list. Mirrors Django REST Framework's
+// dispatch behaviour: the verb gate runs BEFORE the method handler is
+// resolved, so verbs not listed are simply unreachable in production.
+func TestApplyDjangoDRFRoutes_HTTPMethodNamesFiltersModelViewSet(t *testing.T) {
+	files := fileMap{
+		"urls.py": `
+from rest_framework import routers
+from views import LoginViewSet
+
+router = routers.DefaultRouter()
+router.register(r"auth/login", LoginViewSet)
+`,
+		"views.py": `
+from rest_framework import viewsets
+
+class LoginViewSet(viewsets.ModelViewSet):
+    http_method_names = ['post']
+
+    def create(self, request, *args, **kwargs):
+        return None
+`,
+	}
+	got := ApplyDjangoDRFRoutes([]string{"urls.py", "views.py"}, files.reader)
+	assertHasAllIDs(t, got, []string{
+		"http:POST:/auth/login",
+	})
+	// ModelViewSet would normally emit GET/PUT/PATCH/DELETE at the detail
+	// path, but http_method_names=['post'] eliminates every non-POST verb.
+	assertHasNoneIDs(t, got, []string{
+		"http:GET:/auth/login",
+		"http:GET:/auth/login/{pk}",
+		"http:PUT:/auth/login/{pk}",
+		"http:PATCH:/auth/login/{pk}",
+		"http:DELETE:/auth/login/{pk}",
+	})
+}
+
+// TestParseHTTPMethodNames covers the small parser used by parseViewSetClass
+// when filtering CRUD methods through the http_method_names class attribute.
+func TestParseHTTPMethodNames(t *testing.T) {
+	tests := []struct {
+		in   string
+		want []string // sorted UPPERCASE verbs
+	}{
+		{`'post'`, []string{"POST"}},
+		{`"post"`, []string{"POST"}},
+		{`'get', 'post'`, []string{"GET", "POST"}},
+		{`"get", "post", "patch"`, []string{"GET", "PATCH", "POST"}},
+		{`  'post' ,  'put'  `, []string{"POST", "PUT"}},
+		{``, nil},
+	}
+	for _, tc := range tests {
+		got := parseHTTPMethodNames(tc.in)
+		gotKeys := make([]string, 0, len(got))
+		for k := range got {
+			gotKeys = append(gotKeys, k)
+		}
+		sort.Strings(gotKeys)
+		if !equalStringSlicesDRF(gotKeys, tc.want) {
+			t.Errorf("parseHTTPMethodNames(%q) = %v, want %v", tc.in, gotKeys, tc.want)
+		}
+	}
+}
+
 // TestParseActionArgs verifies the @action decorator argument parser.
 func TestParseActionArgs(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Problem

The iter2 quality benchmark Phase-6 calibration on upvate flagged a sizeable cluster of DRF endpoint definitions that were collapsing to `verb=ANY` instead of carrying the real HTTP verb. The root cause turned out to live in a single function — `parseViewSetClass` in `internal/engine/django_drf_actions.go` — which derived `crudMethods` *only* from the base-class list and ignored two routine DRF narrowing signals:

1. **Explicitly-defined CRUD methods** on a bare `viewsets.ViewSet`. Example from upvate-core `core/views/auth_viewset.py`:
   ```python
   class RefreshViewSet(viewsets.ViewSet, TokenRefreshView):
       http_method_names = ['post']
       def create(self, request): ...
   ```
   `classifyViewSetParent("viewsets.ViewSet, TokenRefreshView")` returns `{}` because `ViewSet` carries no CRUD mixin. The explicit `def create()` was being recorded into `explicitMethods` (for the SCOPE.Operation synthesizer from #699c) but never merged into `crudMethods`, so `emitOneCRUDFamily` skipped every per-verb emission and only the ANY catch-all survived → `http:ANY:/api/v1/auth/refresh`.

2. **`http_method_names = [...]`** — DRF's class-level dispatch filter. On `LoginViewSet(viewsets.ModelViewSet)` with `http_method_names=['post']`, the full ModelViewSet CRUD set was emitted (GET/POST/PUT/PATCH/DELETE) because the filter was never consulted, producing four phantom verbs that DRF would 405 at request time and that dilute the verb signal for the cross-repo call→def matcher (#1615).

## Fix

In `parseViewSetClass`, after the existing base-class classification:

1. Merge `explicitMethods` into `crudMethods`. A hand-written `def create(self, …)` on a bare ViewSet now contributes its verb to the per-verb emission, restoring `http:POST:/api/v1/auth/refresh` and similar.
2. Parse `http_method_names = ['…', '…']` via a new regex + small parser and use it as an absolute filter: every CRUD method whose canonical verb is **not** in the allowed set is dropped. Mapping uses the canonical DRF dispatch table (`list`/`retrieve`→`GET`, `create`→`POST`, `update`→`PUT`, `partial_update`→`PATCH`, `destroy`→`DELETE`).

The logic only **restricts** the verb set when a narrowing signal is present — never widens it — so existing ModelViewSet / ReadOnlyModelViewSet / mixin combinations behave unchanged.

## Tests

New:
- `TestApplyDjangoDRFRoutes_ExplicitCreateOnBareViewSet` — exactly reproduces the upvate RefreshViewSet shape (bare `viewsets.ViewSet` + explicit `def create()` + `http_method_names=['post']`). Asserts `http:POST:/auth/refresh` is emitted and `http:GET:/auth/refresh`, `http:GET|PUT|PATCH|DELETE:/auth/refresh/{pk}` are NOT.
- `TestApplyDjangoDRFRoutes_HTTPMethodNamesFiltersModelViewSet` — `ModelViewSet` + `http_method_names=['post']`. Asserts only POST is kept and every non-POST CRUD verb is suppressed at the detail path.
- `TestParseHTTPMethodNames` — small parser unit table (single/double quotes, whitespace, multi-verb).

Existing 16-test `TestApplyDjangoDRFRoutes_*` suite continues to pass (full ModelViewSet CRUD, ReadOnly, @action / @detail_route / @list_route, nested router chain, url_prefix property assertions, etc.).

## Verification

Engine-level on the real upvate corpus (raw filesystem walk, same input as the indexer's Python-file pass):

| Input | Before | After |
|---|---|---|
| `router.register("auth/refresh", RefreshViewSet)` (bare ViewSet + explicit `def create` + `http_method_names=['post']`) | `http:ANY:/auth/refresh` only | `http:POST:/auth/refresh` only |
| `router.register("auth/login", LoginViewSet)` (ModelViewSet + `http_method_names=['post']`) | full CRUD: GET/POST/PUT/PATCH/DELETE + ANY catch-all | `http:POST:/auth/login` only |

The Phase-2 verb-aware call→def matcher (#1615) is now usable on these endpoints: a `POST /auth/refresh` consumer call resolves to the new POST definition; a `DELETE` against the same path stays orphan (correct), where previously both fell into the ANY bucket.

A full live-daemon corpus comparison wasn't run because the existing daemon on :47274 must stay up (per the grind directive) and serves indexes through its own embedded binary; the engine-level verification above isolates the fix without disturbing the live socket.

## Files

- `internal/engine/django_drf_actions.go` — added `drfHTTPMethodNamesRe`, `crudMethodToVerb`, `parseHTTPMethodNames`; updated `parseViewSetClass` to merge explicit methods + apply the http_method_names filter
- `internal/engine/django_drf_actions_test.go` — three new tests

## Scope discipline

`internal/mcp/*` is untouched (the #1650 MCP-UX grind owns it). No other Django pass was modified — the change is intentionally surgical to `parseViewSetClass`, which is called from a single site (`ApplyDjangoDRFRoutes` line 419).

Fixes #1648

🤖 Generated with [Claude Code](https://claude.com/claude-code)