### PR TITLE
[#1386] webui-v2: module-overview collapsed graph mode (closes epic #1380)

### DIFF
--- a/internal/dashboard/v2_modules.go
+++ b/internal/dashboard/v2_modules.go
@@ -27,7 +27,9 @@
 //	        "modules_in_cycle": N,
 //	        "top_pagerank": [...],
 //	        "top_betweenness": [...],
-//	        "sccs": [...]
+//	        "sccs": [...],
+//	        "modules": [...],   // full centrality list, one per module
+//	        "edges":   [...]    // full directed module→module aggregated edges
 //	      }, ...
 //	    ],
 //	    "count": N
@@ -97,6 +99,16 @@ func (s *Server) handleV2ModulesAnalysis(w http.ResponseWriter, r *http.Request)
 		MemberNames []string           `json:"member_names"`
 		Edges       []graph.ModuleEdge `json:"edges"`
 	}
+	type edgeOut struct {
+		FromModule string `json:"from_module"`
+		ToModule   string `json:"to_module"`
+		Weight     int    `json:"weight"`
+		// SCCInternal=true when both endpoints are in the same SCC (cycle
+		// edge). Lets the UI tint these edges as part of the cycle group.
+		SCCInternal bool `json:"scc_internal"`
+		// SCCID is the SCC ID when both endpoints share an SCC, otherwise -1.
+		SCCID int `json:"scc_id"`
+	}
 	type repoOut struct {
 		Repo           string    `json:"repo"`
 		NumModules     int       `json:"num_modules"`
@@ -107,6 +119,13 @@ func (s *Server) handleV2ModulesAnalysis(w http.ResponseWriter, r *http.Request)
 		TopPageRank    []centOut `json:"top_pagerank"`
 		TopBetweenness []centOut `json:"top_betweenness"`
 		SCCs           []sccOut  `json:"sccs"`
+		// Modules carries the FULL centrality list (one entry per module) so
+		// the webui-v2 module-overview surface (#1386) can render every node
+		// — not just the top-N hubs — sized by PageRank and tinted by SCC.
+		Modules []centOut `json:"modules"`
+		// Edges carries the FULL directed module→module aggregated edges so
+		// the overview can draw weighted inter-module arrows.
+		Edges []edgeOut `json:"edges"`
 	}
 
 	out := make([]repoOut, 0)
@@ -142,6 +161,30 @@ func (s *Server) handleV2ModulesAnalysis(w http.ResponseWriter, r *http.Request)
 		}
 		for _, c := range graph.TopByBetweenness(res.Centrality, topN) {
 			ro.TopBetweenness = append(ro.TopBetweenness, toCent(c))
+		}
+		// #1386 — full module list (every module gets a node in the overview).
+		ro.Modules = make([]centOut, 0, len(res.Centrality))
+		for _, c := range res.Centrality {
+			ro.Modules = append(ro.Modules, toCent(c))
+		}
+		// #1386 — full directed module→module edges, prefixed + SCC-tagged so
+		// the UI can color cycle edges as a group.
+		ro.Edges = make([]edgeOut, 0, len(res.Edges))
+		for _, e := range res.Edges {
+			fromSCC := res.SCCOf[e.FromModule]
+			toSCC := res.SCCOf[e.ToModule]
+			internal := fromSCC >= 0 && fromSCC == toSCC
+			sccID := -1
+			if internal {
+				sccID = fromSCC
+			}
+			ro.Edges = append(ro.Edges, edgeOut{
+				FromModule:  dashPrefixedID(repo.Slug, e.FromModule),
+				ToModule:    dashPrefixedID(repo.Slug, e.ToModule),
+				Weight:      e.Weight,
+				SCCInternal: internal,
+				SCCID:       sccID,
+			})
 		}
 		for _, c := range res.SCCs {
 			if c.Size < minSCC {

--- a/internal/dashboard/v2_modules_test.go
+++ b/internal/dashboard/v2_modules_test.go
@@ -1,0 +1,237 @@
+package dashboard
+
+// v2_modules_test.go — coverage for the GET /api/v2/groups/:group/modules/
+// analysis endpoint, focused on the FULL modules + edges arrays added in
+// #1386 to power the webui-v2 "Module overview" surface (closing epic
+// #1380 alongside #1384).
+//
+// The shape under test is the per-repo entry inside data.repos[]:
+//
+//   - modules:    ONE entry per module (NOT top-N) so the overview can
+//                 lay out every node — sized + tinted from the centrality
+//                 data.
+//   - edges:      ONE entry per directed module→module aggregated edge so
+//                 the overview can render every inter-module arrow with a
+//                 weight + scc_internal flag for cycle highlighting.
+//
+// The endpoint also keeps its pre-existing top_pagerank / top_betweenness /
+// sccs fields, so the test asserts those survived too.
+
+import (
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// buildModuleCycleFixture wires three modules into a directed dependency
+// cycle (a → b → c → a) plus one singleton "solo" so the SCC pass yields a
+// real, non-trivial SCC of size 3 and we can also exercise the non-cycle
+// edge tinting code path.
+func buildModuleCycleFixture() *DashGroup {
+	mkMod := func(name string) graph.Entity {
+		return graph.Entity{
+			ID:   "mod-" + name,
+			Kind: "Module",
+			Name: name,
+			Properties: map[string]string{
+				"module": name,
+				"repo":   "testrepo",
+			},
+		}
+	}
+	mkEnt := func(id, mod string) graph.Entity {
+		return graph.Entity{
+			ID:   id,
+			Kind: "function",
+			Name: id,
+			Properties: map[string]string{
+				"module": mod,
+				"repo":   "testrepo",
+			},
+		}
+	}
+
+	entities := []graph.Entity{
+		mkMod("a"), mkMod("b"), mkMod("c"), mkMod("solo"),
+		mkEnt("a1", "a"), mkEnt("a2", "a"),
+		mkEnt("b1", "b"), mkEnt("b2", "b"),
+		mkEnt("c1", "c"), mkEnt("c2", "c"),
+		mkEnt("s1", "solo"),
+	}
+	rels := []graph.Relationship{
+		{ID: "a1->b1", FromID: "a1", ToID: "b1", Kind: "CALLS"},
+		{ID: "a2->b2", FromID: "a2", ToID: "b2", Kind: "CALLS"},
+		{ID: "b1->c1", FromID: "b1", ToID: "c1", Kind: "CALLS"},
+		{ID: "c1->a1", FromID: "c1", ToID: "a1", Kind: "CALLS"},
+		{ID: "a1->s1", FromID: "a1", ToID: "s1", Kind: "CALLS"},
+	}
+	return makeGraphTestGroup(entities, rels)
+}
+
+func newV2ModulesTestServer(t *testing.T, grp *DashGroup) *httptest.Server {
+	t.Helper()
+	st := newFakeStore()
+	st.groups["testgrp"] = GroupSummary{
+		Name: "testgrp", ConfigPath: "/tmp/testgrp.json", Repos: []string{"testrepo"},
+	}
+	cfg := DefaultConfig()
+	srv, err := NewServer(cfg, st)
+	if err != nil {
+		t.Fatalf("NewServer: %v", err)
+	}
+	srv.graphs.mu.Lock()
+	srv.graphs.entries["testgrp"] = &cacheEntry{group: grp, loadedAt: time.Now()}
+	srv.graphs.mu.Unlock()
+	ts := httptest.NewServer(srv.routes())
+	t.Cleanup(ts.Close)
+	return ts
+}
+
+type v2ModulesEdge struct {
+	FromModule  string `json:"from_module"`
+	ToModule    string `json:"to_module"`
+	Weight      int    `json:"weight"`
+	SCCInternal bool   `json:"scc_internal"`
+	SCCID       int    `json:"scc_id"`
+}
+
+type v2ModulesCentrality struct {
+	ModuleID    string  `json:"module_id"`
+	ModuleName  string  `json:"module_name"`
+	PageRank    float64 `json:"pagerank"`
+	Betweenness float64 `json:"betweenness"`
+	InDegree    int     `json:"in_degree"`
+	OutDegree   int     `json:"out_degree"`
+	InCycle     bool    `json:"in_cycle"`
+}
+
+type v2ModulesRepo struct {
+	Repo           string                `json:"repo"`
+	NumModules     int                   `json:"num_modules"`
+	NumModuleEdges int                   `json:"num_module_edges"`
+	NumSCCs        int                   `json:"num_sccs"`
+	LargestSCCSize int                   `json:"largest_scc_size"`
+	ModulesInCycle int                   `json:"modules_in_cycle"`
+	TopPageRank    []v2ModulesCentrality `json:"top_pagerank"`
+	TopBetweenness []v2ModulesCentrality `json:"top_betweenness"`
+	SCCs           []struct {
+		ID      int      `json:"id"`
+		Size    int      `json:"size"`
+		Members []string `json:"members"`
+	} `json:"sccs"`
+	Modules []v2ModulesCentrality `json:"modules"`
+	Edges   []v2ModulesEdge       `json:"edges"`
+}
+
+type v2ModulesEnvelope struct {
+	Data struct {
+		Repos []v2ModulesRepo `json:"repos"`
+		Count int             `json:"count"`
+	} `json:"data"`
+}
+
+func fetchModuleAnalysis(t *testing.T, ts *httptest.Server) v2ModulesEnvelope {
+	t.Helper()
+	resp, err := http.Get(ts.URL + "/api/v2/groups/testgrp/modules/analysis")
+	if err != nil {
+		t.Fatalf("GET modules/analysis: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status %d", resp.StatusCode)
+	}
+	var env v2ModulesEnvelope
+	if err := json.NewDecoder(resp.Body).Decode(&env); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	return env
+}
+
+// TestV2ModulesAnalysis_FullModulesAndEdges asserts that the overview-
+// powering fields land on the wire: every module gets a `modules` entry
+// (not just the top-N) and every aggregated edge gets an `edges` entry
+// with weight + scc_internal correctly set.
+func TestV2ModulesAnalysis_FullModulesAndEdges(t *testing.T) {
+	ts := newV2ModulesTestServer(t, buildModuleCycleFixture())
+	env := fetchModuleAnalysis(t, ts)
+
+	if len(env.Data.Repos) != 1 {
+		t.Fatalf("want 1 repo, got %d", len(env.Data.Repos))
+	}
+	r := env.Data.Repos[0]
+
+	if r.NumModules < 3 {
+		t.Fatalf("want >=3 modules, got %d", r.NumModules)
+	}
+	// All four modules (a, b, c, solo) must appear in `modules`.
+	if got := len(r.Modules); got != r.NumModules {
+		t.Fatalf("modules array size %d != num_modules %d (overview needs every module)", got, r.NumModules)
+	}
+	names := map[string]v2ModulesCentrality{}
+	for _, m := range r.Modules {
+		names[m.ModuleName] = m
+		if !strings.HasPrefix(m.ModuleID, "testrepo::") {
+			t.Errorf("module ID %q lacks repo prefix", m.ModuleID)
+		}
+	}
+	for _, want := range []string{"a", "b", "c", "solo"} {
+		if _, ok := names[want]; !ok {
+			t.Errorf("module %q missing from `modules` array", want)
+		}
+	}
+
+	// in_cycle must be true for a/b/c (the SCC) and false for solo.
+	for _, n := range []string{"a", "b", "c"} {
+		if !names[n].InCycle {
+			t.Errorf("module %q expected in_cycle=true, got false", n)
+		}
+	}
+	if names["solo"].InCycle {
+		t.Errorf("solo module unexpectedly flagged in_cycle=true")
+	}
+
+	// `edges` must contain the cycle edges, with scc_internal=true on at least
+	// the cycle members, and the a→solo edge with scc_internal=false.
+	if len(r.Edges) == 0 {
+		t.Fatalf("edges array empty — overview cannot draw")
+	}
+	var sawCycle, sawNonCycle bool
+	for _, e := range r.Edges {
+		if !strings.HasPrefix(e.FromModule, "testrepo::") || !strings.HasPrefix(e.ToModule, "testrepo::") {
+			t.Errorf("edge %v lacks repo prefix on endpoints", e)
+		}
+		if e.Weight <= 0 {
+			t.Errorf("edge %v has non-positive weight %d", e, e.Weight)
+		}
+		if e.SCCInternal {
+			sawCycle = true
+			if e.SCCID < 0 {
+				t.Errorf("scc_internal=true but scc_id=%d on edge %v", e.SCCID, e)
+			}
+		} else {
+			sawNonCycle = true
+			if e.SCCID >= 0 {
+				t.Errorf("scc_internal=false but scc_id=%d on edge %v", e.SCCID, e)
+			}
+		}
+	}
+	if !sawCycle {
+		t.Errorf("expected at least one scc_internal=true edge from the a→b→c→a cycle")
+	}
+	if !sawNonCycle {
+		t.Errorf("expected at least one scc_internal=false edge (a→solo)")
+	}
+
+	// The pre-existing top-N and SCC fields must still be populated.
+	if len(r.TopPageRank) == 0 {
+		t.Errorf("top_pagerank unexpectedly empty")
+	}
+	if len(r.SCCs) == 0 || r.SCCs[0].Size < 3 {
+		t.Errorf("expected an SCC of size >=3, got %+v", r.SCCs)
+	}
+}

--- a/webui-v2/src/components/graph/module-overview.tsx
+++ b/webui-v2/src/components/graph/module-overview.tsx
@@ -1,0 +1,724 @@
+/* ============================================================
+   components/graph/module-overview.tsx — the COLLAPSED module-level
+   canvas (#1386, closes epic #1380 alongside #1384).
+
+   At module scope a corpus is small (12 modules on upvate, ~30 on
+   polyglot per repo) so we skip cosmos.gl entirely and lay the graph
+   out in SVG. The render is deterministic + screenshot-friendly:
+
+     • Force-directed simulation runs synchronously for ~200 ticks on
+       mount, then freezes — no rAF loop, no GPU pressure. The graph
+       is small enough that this finishes in <5 ms even on slow
+       machines, and the result is identical across reloads (we seed
+       node positions on a circle keyed by sorted module ID).
+     • Node radius scales with PageRank (sqrt of count-mass + a base).
+     • Node color tints SCC members so the "cycle group" reads at a
+       glance; non-cycle modules use a per-repo pastel.
+     • Edge width scales with aggregated weight; cycle-internal edges
+       (SCCInternal=true) are tinted with the SCC color.
+     • One click selects a module (shows the right-hand metrics card);
+       a second click on the SAME module expands it back into the
+       entity-level view, filtered to that module's entities.
+
+   This component is dependency-free apart from the v2 design tokens
+   (CSS vars on :root) and the existing graph color helpers, so it
+   stays light to maintain and easy to screenshot in E2E.
+   ============================================================ */
+
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import type {
+  ModuleAnalysisResponse,
+  ModuleAnalysisRepoWire,
+  ModuleCentralityWire,
+  ModuleEdgeWire,
+} from "@/data/types";
+
+/* ─────────────────────────────────────────────────────────────────
+   Internal node + layout types.
+   ───────────────────────────────────────────────────────────────── */
+
+interface OverviewNode {
+  /** Repo-prefixed module ID — globally unique. */
+  id: string;
+  repo: string;
+  /** Module display name (e.g. "core/views"). */
+  name: string;
+  pagerank: number;
+  betweenness: number;
+  inDegree: number;
+  outDegree: number;
+  inCycle: boolean;
+  /** SCC ID (≥0 when in a cycle, -1 otherwise). */
+  sccId: number;
+  /** Live simulation position (mutated in-place by the force loop). */
+  x: number;
+  y: number;
+  /** Velocity components for the simple Verlet step. */
+  vx: number;
+  vy: number;
+  /** Settled radius in viewbox units. */
+  radius: number;
+}
+
+interface OverviewEdge {
+  from: string;
+  to: string;
+  weight: number;
+  sccInternal: boolean;
+  sccId: number;
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Layout: synchronous force-directed simulation in SVG units.
+   ───────────────────────────────────────────────────────────────── */
+
+const VIEWBOX = 1000;
+const PADDING = 60;
+const SIM_TICKS = 220;
+
+/** Stable hash for ring-seeding so we never spawn nodes at the exact
+ *  same coordinate (which produces an Infinity force vector). */
+function seedHash(s: string): number {
+  let h = 2166136261;
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0) / 0x100000000;
+}
+
+/** Build sized nodes + edges from a single repo's analysis payload. */
+function buildOverview(
+  repo: ModuleAnalysisRepoWire,
+  pageRankBySCC: Map<number, number>,
+): { nodes: OverviewNode[]; edges: OverviewEdge[] } {
+  // Map module_id → centrality for fast O(1) lookup while building edges.
+  const cents = new Map<string, ModuleCentralityWire>();
+  for (const c of repo.modules) cents.set(c.module_id, c);
+
+  // PageRank-based radius: sqrt(pr * 4000) + 14, clamped to [14, 60].
+  const nodes: OverviewNode[] = repo.modules.map((c) => {
+    const seed = seedHash(c.module_id);
+    const ringR = 0.32 * VIEWBOX;
+    const cx = VIEWBOX / 2;
+    const cy = VIEWBOX / 2;
+    const idx = Array.from(cents.keys()).indexOf(c.module_id);
+    const total = repo.modules.length || 1;
+    const ang = (idx / total) * Math.PI * 2 + seed * 0.5;
+    const radius = Math.min(
+      60,
+      Math.max(14, Math.sqrt(Math.max(c.pagerank, 0.001) * 4000) + 14),
+    );
+    return {
+      id: c.module_id,
+      repo: repo.repo,
+      name: c.module_name,
+      pagerank: c.pagerank,
+      betweenness: c.betweenness,
+      inDegree: c.in_degree,
+      outDegree: c.out_degree,
+      inCycle: c.in_cycle,
+      sccId: c.in_cycle ? findSCC(repo, c.module_id) : -1,
+      x: cx + ringR * Math.cos(ang),
+      y: cy + ringR * Math.sin(ang),
+      vx: 0,
+      vy: 0,
+      radius,
+    };
+  });
+
+  const edges: OverviewEdge[] = repo.edges.map((e: ModuleEdgeWire) => ({
+    from: e.from_module,
+    to: e.to_module,
+    weight: e.weight,
+    sccInternal: e.scc_internal,
+    sccId: e.scc_id,
+  }));
+
+  // Use pageRankBySCC to surface the dominant SCC visually (no-op when
+  // there are no SCCs — present for symmetry with the legend code).
+  void pageRankBySCC;
+
+  return { nodes, edges };
+}
+
+/** Find which SCC a module belongs to by scanning the SCCs list. */
+function findSCC(repo: ModuleAnalysisRepoWire, moduleId: string): number {
+  // The daemon serializes empty slices as JSON `null` (Go zero-value), so
+  // defensively coalesce to [] before iterating — never trust the wire
+  // shape's "non-empty array" guarantee.
+  for (const s of repo.sccs ?? []) {
+    if (s.members.includes(moduleId)) return s.id;
+  }
+  return -1;
+}
+
+/** Run SIM_TICKS of a tiny force simulation in-place on `nodes`. */
+function runSimulation(nodes: OverviewNode[], edges: OverviewEdge[]) {
+  if (nodes.length === 0) return;
+  const cx = VIEWBOX / 2;
+  const cy = VIEWBOX / 2;
+  const byId = new Map(nodes.map((n) => [n.id, n] as const));
+
+  // Repulsion strength scales DOWN with node count so big graphs don't fly
+  // apart and small graphs (12 nodes) don't collapse into the center.
+  const k = Math.max(900, 14000 / Math.sqrt(nodes.length));
+  const springK = 0.012;
+  const damping = 0.82;
+  const centerPull = 0.0035;
+
+  for (let tick = 0; tick < SIM_TICKS; tick++) {
+    // O(n²) repulsion — fine at n≤80.
+    for (let i = 0; i < nodes.length; i++) {
+      const a = nodes[i];
+      for (let j = i + 1; j < nodes.length; j++) {
+        const b = nodes[j];
+        const dx = a.x - b.x;
+        const dy = a.y - b.y;
+        const distSq = Math.max(dx * dx + dy * dy, 25);
+        const force = k / distSq;
+        const inv = 1 / Math.sqrt(distSq);
+        const fx = dx * inv * force;
+        const fy = dy * inv * force;
+        a.vx += fx;
+        a.vy += fy;
+        b.vx -= fx;
+        b.vy -= fy;
+      }
+    }
+
+    // Spring along edges. Resting length scales gently with weight so heavy
+    // edges pull harder (but never collapse the two endpoints onto each other).
+    for (const e of edges) {
+      const a = byId.get(e.from);
+      const b = byId.get(e.to);
+      if (!a || !b) continue;
+      const rest = 120 + 40 / Math.max(e.weight, 1);
+      const dx = b.x - a.x;
+      const dy = b.y - a.y;
+      const dist = Math.sqrt(dx * dx + dy * dy) || 1;
+      const stretch = (dist - rest) * springK;
+      const fx = (dx / dist) * stretch;
+      const fy = (dy / dist) * stretch;
+      a.vx += fx;
+      a.vy += fy;
+      b.vx -= fx;
+      b.vy -= fy;
+    }
+
+    // Center pull + damping integration.
+    for (const n of nodes) {
+      n.vx += (cx - n.x) * centerPull;
+      n.vy += (cy - n.y) * centerPull;
+      n.vx *= damping;
+      n.vy *= damping;
+      n.x += n.vx;
+      n.y += n.vy;
+      // Soft viewbox clamp (keep nodes visible).
+      n.x = Math.max(PADDING, Math.min(VIEWBOX - PADDING, n.x));
+      n.y = Math.max(PADDING, Math.min(VIEWBOX - PADDING, n.y));
+    }
+  }
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Color palette for SCC groups — deterministic by sccId.
+   ───────────────────────────────────────────────────────────────── */
+
+const SCC_COLORS = [
+  "#f97316", // orange
+  "#ec4899", // pink
+  "#a855f7", // purple
+  "#3b82f6", // blue
+  "#10b981", // emerald
+  "#eab308", // yellow
+  "#ef4444", // red
+  "#06b6d4", // cyan
+];
+
+function sccColor(sccId: number): string {
+  if (sccId < 0) return "var(--color-accent, #38bdf8)";
+  return SCC_COLORS[sccId % SCC_COLORS.length];
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   The component.
+   ───────────────────────────────────────────────────────────────── */
+
+export interface ModuleOverviewProps {
+  /** Wire payload from useModuleAnalysis. */
+  data: ModuleAnalysisResponse;
+  /** Optional repo slug filter — when set, only this repo's modules render. */
+  activeRepo?: string | null;
+  /** When the user expands a module, the entity-level view should take over. */
+  onExpandModule: (m: { repo: string; moduleName: string }) => void;
+  /** Theme — affects label + edge colors. */
+  isDark: boolean;
+}
+
+interface SelectedModule {
+  repo: string;
+  node: OverviewNode;
+}
+
+export function ModuleOverview({
+  data,
+  activeRepo,
+  onExpandModule,
+  isDark,
+}: ModuleOverviewProps) {
+  // Pick which repo(s) to render. Default: the first one with modules. If the
+  // graph store has an activeRepo filter, honor it. Defensive `?? []` on the
+  // wire slices — the Go daemon serializes empty slices as JSON null.
+  const repos = useMemo(() => {
+    const withModules = (data.repos ?? [])
+      .map((r) => ({
+        ...r,
+        modules: r.modules ?? [],
+        edges: r.edges ?? [],
+        sccs: r.sccs ?? [],
+        top_pagerank: r.top_pagerank ?? [],
+        top_betweenness: r.top_betweenness ?? [],
+      }))
+      .filter((r) => r.modules.length > 0);
+    if (activeRepo) {
+      const m = withModules.find((r) => r.repo === activeRepo);
+      return m ? [m] : withModules;
+    }
+    return withModules;
+  }, [data, activeRepo]);
+
+  const [activeRepoSlug, setActiveRepoSlug] = useState<string | null>(
+    repos[0]?.repo ?? null,
+  );
+
+  // When the repos list changes (e.g. activeRepo prop), reset selection.
+  useEffect(() => {
+    if (!activeRepoSlug || !repos.find((r) => r.repo === activeRepoSlug)) {
+      setActiveRepoSlug(repos[0]?.repo ?? null);
+    }
+  }, [repos, activeRepoSlug]);
+
+  const repo = useMemo(
+    () => repos.find((r) => r.repo === activeRepoSlug) ?? repos[0] ?? null,
+    [repos, activeRepoSlug],
+  );
+
+  // Synchronous layout: build the node/edge sets + run the simulation once
+  // per repo change. Memoized so re-renders for hover/select don't re-layout.
+  const layout = useMemo(() => {
+    if (!repo) return { nodes: [], edges: [] };
+    const built = buildOverview(repo, new Map());
+    runSimulation(built.nodes, built.edges);
+    return built;
+  }, [repo]);
+
+  const [selected, setSelected] = useState<SelectedModule | null>(null);
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  // Reset selection when repo changes.
+  useEffect(() => {
+    setSelected(null);
+    setHovered(null);
+  }, [repo?.repo]);
+
+  const onNodeClick = useCallback(
+    (node: OverviewNode) => {
+      // First click = select (show side card). Second click on SAME node =
+      // expand back into the entity-level view filtered to this module.
+      if (selected?.node.id === node.id) {
+        onExpandModule({ repo: node.repo, moduleName: node.name });
+        return;
+      }
+      setSelected({ repo: node.repo, node });
+    },
+    [selected, onExpandModule],
+  );
+
+  // Click-on-background clears selection.
+  const svgRef = useRef<SVGSVGElement | null>(null);
+
+  if (!repo) {
+    return (
+      <div className="grid h-full place-items-center bg-bg">
+        <div className="text-center">
+          <p className="text-md text-text">No modules in this group.</p>
+          <p className="mt-1 text-sm text-text-3">
+            Module-level analysis requires Module entities (re-index the repo with
+            the module aggregator enabled).
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  // Build the edge-render order: cycle edges drawn LAST so they sit on top.
+  const sortedEdges = useMemo(() => {
+    return [...layout.edges].sort((a, b) =>
+      Number(a.sccInternal) - Number(b.sccInternal),
+    );
+  }, [layout.edges]);
+
+  // Min/max weight for edge stroke-width scaling.
+  const maxWeight = Math.max(1, ...layout.edges.map((e) => e.weight));
+
+  const nodeById = useMemo(
+    () => new Map(layout.nodes.map((n) => [n.id, n] as const)),
+    [layout.nodes],
+  );
+
+  const edgeColor = isDark ? "rgba(148, 163, 184, 0.45)" : "rgba(71, 85, 105, 0.45)";
+  const labelColor = isDark ? "#e2e8f0" : "#0f172a";
+
+  return (
+    <div className="relative flex h-full w-full">
+      {/* Repo tabs — when the group has more than one repo with modules. */}
+      {repos.length > 1 ? (
+        <div className="pointer-events-auto absolute left-3 top-3 z-20 flex gap-1 rounded-md border border-border bg-surface/85 p-1 backdrop-blur-sm">
+          {repos.map((r) => (
+            <button
+              key={r.repo}
+              onClick={() => setActiveRepoSlug(r.repo)}
+              aria-pressed={r.repo === repo.repo}
+              className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                r.repo === repo.repo
+                  ? "bg-accent-soft text-accent-strong"
+                  : "text-text-2 hover:bg-surface-2"
+              }`}
+            >
+              {r.repo}{" "}
+              <span className="text-text-4 tabular-nums">({r.num_modules})</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      {/* Top-right stats card — corpus-level summary from #1384. */}
+      <div className="pointer-events-none absolute right-3 top-3 z-20 rounded-md border border-border bg-surface/85 px-3 py-2 text-xs text-text-2 backdrop-blur-sm">
+        <div className="flex items-center gap-3 tabular-nums">
+          <Stat label="modules" value={repo.num_modules} />
+          <span className="h-3 w-px bg-border" />
+          <Stat label="edges" value={repo.num_module_edges} />
+          <span className="h-3 w-px bg-border" />
+          <Stat
+            label="cycles"
+            value={repo.num_sccs}
+            tone={repo.num_sccs > 0 ? "warn" : undefined}
+          />
+          {repo.largest_scc_size > 0 ? (
+            <>
+              <span className="h-3 w-px bg-border" />
+              <Stat label="largest SCC" value={repo.largest_scc_size} tone="warn" />
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      {/* The canvas. */}
+      <svg
+        ref={svgRef}
+        viewBox={`0 0 ${VIEWBOX} ${VIEWBOX}`}
+        preserveAspectRatio="xMidYMid meet"
+        className="h-full w-full"
+        onClick={(e) => {
+          if (e.target === svgRef.current) setSelected(null);
+        }}
+        role="img"
+        aria-label={`Module overview for ${repo.repo}: ${repo.num_modules} modules, ${repo.num_module_edges} edges, ${repo.num_sccs} cycles`}
+        data-testid="module-overview-svg"
+      >
+        <defs>
+          {/* Arrowhead per SCC color group + the default. */}
+          {SCC_COLORS.map((c, i) => (
+            <marker
+              key={i}
+              id={`mod-arrow-scc-${i}`}
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="5"
+              markerHeight="5"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill={c} />
+            </marker>
+          ))}
+          <marker
+            id="mod-arrow-default"
+            viewBox="0 0 10 10"
+            refX="9"
+            refY="5"
+            markerWidth="5"
+            markerHeight="5"
+            orient="auto-start-reverse"
+          >
+            <path d="M 0 0 L 10 5 L 0 10 z" fill={edgeColor} />
+          </marker>
+        </defs>
+
+        {/* Edges. */}
+        <g>
+          {sortedEdges.map((e) => {
+            const a = nodeById.get(e.from);
+            const b = nodeById.get(e.to);
+            if (!a || !b) return null;
+            const dx = b.x - a.x;
+            const dy = b.y - a.y;
+            const len = Math.sqrt(dx * dx + dy * dy) || 1;
+            // Trim the line endpoints to the circle radius so the arrowhead
+            // lands on the node edge, not inside it.
+            const ax = a.x + (dx / len) * a.radius;
+            const ay = a.y + (dy / len) * a.radius;
+            const bx = b.x - (dx / len) * (b.radius + 4);
+            const by = b.y - (dy / len) * (b.radius + 4);
+            const isCycle = e.sccInternal;
+            const stroke = isCycle ? sccColor(e.sccId) : edgeColor;
+            const width = 0.8 + (e.weight / maxWeight) * 3;
+            const opacity = isCycle ? 0.95 : 0.6;
+            const markerId = isCycle
+              ? `mod-arrow-scc-${e.sccId % SCC_COLORS.length}`
+              : "mod-arrow-default";
+            return (
+              <line
+                key={`${e.from}->${e.to}`}
+                x1={ax}
+                y1={ay}
+                x2={bx}
+                y2={by}
+                stroke={stroke}
+                strokeWidth={width}
+                strokeOpacity={opacity}
+                markerEnd={`url(#${markerId})`}
+              />
+            );
+          })}
+        </g>
+
+        {/* Nodes. */}
+        <g>
+          {layout.nodes.map((n) => {
+            const isSelected = selected?.node.id === n.id;
+            const isHovered = hovered === n.id;
+            const fill = sccColor(n.sccId);
+            const stroke = isSelected
+              ? "var(--color-accent, #38bdf8)"
+              : n.inCycle
+                ? fill
+                : isDark
+                  ? "#475569"
+                  : "#cbd5e1";
+            const strokeWidth = isSelected ? 3 : n.inCycle ? 2 : 1.2;
+            const opacity = isHovered || isSelected ? 1 : n.inCycle ? 0.95 : 0.78;
+            return (
+              <g
+                key={n.id}
+                transform={`translate(${n.x}, ${n.y})`}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onNodeClick(n);
+                }}
+                onMouseEnter={() => setHovered(n.id)}
+                onMouseLeave={() => setHovered((cur) => (cur === n.id ? null : cur))}
+                style={{ cursor: "pointer" }}
+                role="button"
+                aria-label={`Module ${n.name}, PageRank ${n.pagerank.toFixed(3)}${
+                  n.inCycle ? ", in cycle" : ""
+                }`}
+              >
+                <circle
+                  r={n.radius}
+                  fill={n.inCycle ? fill : isDark ? "#1e293b" : "#f1f5f9"}
+                  stroke={stroke}
+                  strokeWidth={strokeWidth}
+                  fillOpacity={n.inCycle ? 0.35 : 1}
+                  opacity={opacity}
+                />
+                {/* Label inside / below the node. */}
+                <text
+                  textAnchor="middle"
+                  dy={n.radius < 22 ? n.radius + 12 : 4}
+                  fill={labelColor}
+                  fontSize={n.radius < 22 ? 11 : 12}
+                  fontFamily="ui-sans-serif, system-ui, -apple-system, sans-serif"
+                  fontWeight={isSelected ? 600 : 500}
+                  style={{ pointerEvents: "none", userSelect: "none" }}
+                >
+                  {truncate(n.name, n.radius < 22 ? 18 : 14)}
+                </text>
+              </g>
+            );
+          })}
+        </g>
+      </svg>
+
+      {/* Side panel — module metrics + expand action. */}
+      {selected ? (
+        <ModuleDetailsCard
+          repo={selected.repo}
+          node={selected.node}
+          onClose={() => setSelected(null)}
+          onExpand={() =>
+            onExpandModule({
+              repo: selected.node.repo,
+              moduleName: selected.node.name,
+            })
+          }
+          sccs={repo.sccs}
+        />
+      ) : null}
+
+      {/* Legend — bottom-left, shows cycle groups + a render hint. */}
+      <div className="pointer-events-none absolute bottom-3 left-3 z-20 rounded-md border border-border bg-surface/85 px-3 py-2 text-xs text-text-3 backdrop-blur-sm">
+        <div className="flex items-center gap-3">
+          <span className="font-medium text-text-2">Module overview</span>
+          <span className="h-3 w-px bg-border" />
+          <span>{layout.nodes.length} modules</span>
+          {(repo.sccs ?? []).length > 0 ? (
+            <>
+              <span className="h-3 w-px bg-border" />
+              <span className="inline-flex items-center gap-1.5">
+                {(repo.sccs ?? []).slice(0, 4).map((s) => (
+                  <span
+                    key={s.id}
+                    className="inline-flex items-center gap-1"
+                    title={`SCC ${s.id} — ${s.size} modules`}
+                  >
+                    <span
+                      className="inline-block h-2 w-2 rounded-full"
+                      style={{ background: sccColor(s.id) }}
+                    />
+                    cycle ×{s.size}
+                  </span>
+                ))}
+              </span>
+            </>
+          ) : null}
+          <span className="h-3 w-px bg-border" />
+          <span className="text-text-4">click → expand a module</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/* ─────────────────────────────────────────────────────────────────
+   Side card — metric breakdown for the selected module.
+   ───────────────────────────────────────────────────────────────── */
+
+interface ModuleDetailsCardProps {
+  repo: string;
+  node: OverviewNode;
+  onClose: () => void;
+  onExpand: () => void;
+  sccs: ModuleAnalysisRepoWire["sccs"];
+}
+
+function ModuleDetailsCard({
+  repo,
+  node,
+  onClose,
+  onExpand,
+  sccs,
+}: ModuleDetailsCardProps) {
+  const scc = node.inCycle ? sccs.find((s) => s.members.includes(node.id)) : null;
+  return (
+    <aside
+      className="absolute right-3 bottom-3 top-16 z-30 flex w-80 flex-col overflow-hidden rounded-lg border border-border bg-surface shadow-lg"
+      data-testid="module-overview-card"
+    >
+      <header className="flex items-start justify-between gap-2 border-b border-border px-3 py-2">
+        <div className="min-w-0">
+          <div className="truncate text-sm font-semibold text-text" title={node.name}>
+            {node.name}
+          </div>
+          <div className="truncate text-xs text-text-3">{repo}</div>
+        </div>
+        <button
+          onClick={onClose}
+          aria-label="Close"
+          className="rounded p-1 text-text-3 hover:bg-surface-2"
+        >
+          ×
+        </button>
+      </header>
+      <div className="flex-1 overflow-y-auto px-3 py-2 text-sm">
+        <Row label="PageRank" value={node.pagerank.toFixed(4)} mono />
+        <Row label="Betweenness" value={node.betweenness.toFixed(4)} mono />
+        <Row label="In-degree" value={String(node.inDegree)} mono />
+        <Row label="Out-degree" value={String(node.outDegree)} mono />
+        {node.inCycle && scc ? (
+          <div className="mt-3 rounded border border-amber-500/30 bg-amber-500/10 px-2 py-1.5">
+            <div className="text-xs font-medium text-amber-700 dark:text-amber-300">
+              In dependency cycle · SCC #{scc.id}
+            </div>
+            <div className="mt-1 text-xs text-text-2">
+              {scc.size} modules · {scc.edges.length} internal edges
+            </div>
+            <ul className="mt-1.5 max-h-32 space-y-0.5 overflow-y-auto text-xs text-text-3">
+              {scc.member_names.map((m) => (
+                <li key={m} className="truncate" title={m}>
+                  · {m}
+                </li>
+              ))}
+            </ul>
+          </div>
+        ) : null}
+      </div>
+      <footer className="border-t border-border px-3 py-2">
+        <button
+          onClick={onExpand}
+          className="w-full rounded bg-accent px-3 py-1.5 text-sm font-medium text-white hover:bg-accent-strong"
+          data-testid="module-overview-expand"
+        >
+          Expand into entity view
+        </button>
+        <p className="mt-1 text-center text-[10px] text-text-4">
+          tip: double-click a module to expand
+        </p>
+      </footer>
+    </aside>
+  );
+}
+
+function Row({ label, value, mono }: { label: string; value: string; mono?: boolean }) {
+  return (
+    <div className="flex items-center justify-between py-0.5">
+      <span className="text-xs text-text-3">{label}</span>
+      <span
+        className={`text-xs text-text-2 ${mono ? "font-mono tabular-nums" : ""}`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function Stat({
+  label,
+  value,
+  tone,
+}: {
+  label: string;
+  value: number;
+  tone?: "warn";
+}) {
+  return (
+    <span className="inline-flex items-center gap-1">
+      <span
+        className={`font-semibold ${
+          tone === "warn"
+            ? "text-amber-600 dark:text-amber-400"
+            : "text-text"
+        }`}
+      >
+        {value.toLocaleString()}
+      </span>
+      <span className="text-text-3">{label}</span>
+    </span>
+  );
+}
+
+function truncate(s: string, n: number): string {
+  if (s.length <= n) return s;
+  return s.slice(0, Math.max(1, n - 1)) + "…";
+}

--- a/webui-v2/src/data/types.ts
+++ b/webui-v2/src/data/types.ts
@@ -1224,3 +1224,58 @@ export interface RecallReply {
   errors: string[];
   elapsed_ms: number;
 }
+
+/* ============================================================
+   Module overview (#1386 / #1380 / #1384)
+
+   Wire shape for GET /api/v2/groups/:group/modules/analysis — module-
+   level GDS (SCC + PageRank + betweenness on the aggregated module
+   graph). One repoOut per repo in the group. `modules` is the FULL
+   centrality list (one entry per module) and `edges` is the FULL set
+   of directed module→module aggregated edges, both used by the webui
+   to render the collapsed module-overview canvas.
+   ============================================================ */
+export interface ModuleCentralityWire {
+  module_id: string;
+  module_name: string;
+  pagerank: number;
+  betweenness: number;
+  in_degree: number;
+  out_degree: number;
+  in_cycle: boolean;
+}
+
+export interface ModuleEdgeWire {
+  from_module: string;
+  to_module: string;
+  weight: number;
+  scc_internal: boolean;
+  scc_id: number;
+}
+
+export interface ModuleSCCWire {
+  id: number;
+  size: number;
+  members: string[];
+  member_names: string[];
+  edges: { from_module: string; to_module: string; weight: number }[];
+}
+
+export interface ModuleAnalysisRepoWire {
+  repo: string;
+  num_modules: number;
+  num_module_edges: number;
+  num_sccs: number;
+  largest_scc_size: number;
+  modules_in_cycle: number;
+  top_pagerank: ModuleCentralityWire[];
+  top_betweenness: ModuleCentralityWire[];
+  sccs: ModuleSCCWire[];
+  modules: ModuleCentralityWire[];
+  edges: ModuleEdgeWire[];
+}
+
+export interface ModuleAnalysisResponse {
+  repos: ModuleAnalysisRepoWire[];
+  count: number;
+}

--- a/webui-v2/src/hooks/use-module-analysis.ts
+++ b/webui-v2/src/hooks/use-module-analysis.ts
@@ -1,0 +1,44 @@
+/* ============================================================
+   hooks/use-module-analysis.ts — module-level GDS for the Graph
+   screen's "Module overview" mode (#1386, closes #1380 alongside
+   #1384 which shipped the algorithms + endpoint).
+
+   Thin TanStack Query wrapper around api.getModuleAnalysis. The
+   payload is small (12 modules on upvate, ~30 on polyglot per repo)
+   so we keep it warm for the session and let the UI re-derive
+   normalized shapes from the wire response.
+   ============================================================ */
+
+import { useQuery } from "@tanstack/react-query";
+import { api } from "@/lib/api";
+import type { ModuleAnalysisResponse } from "@/data/types";
+
+export const moduleAnalysisQueryKey = (
+  groupId: string,
+  topN?: number,
+  repoFilter?: string[],
+) =>
+  [
+    "module-analysis",
+    groupId,
+    topN ?? 10,
+    repoFilter?.slice().sort().join(",") ?? "",
+  ] as const;
+
+export function useModuleAnalysis(
+  groupId: string,
+  opts?: { topN?: number; repoFilter?: string[]; enabled?: boolean },
+) {
+  return useQuery<ModuleAnalysisResponse>({
+    queryKey: moduleAnalysisQueryKey(groupId, opts?.topN, opts?.repoFilter),
+    queryFn: () =>
+      api.getModuleAnalysis(groupId, {
+        topN: opts?.topN ?? 10,
+        repoFilter: opts?.repoFilter,
+      }),
+    // Module-level GDS is deterministic given the indexed graph; we keep it
+    // warm across mode-toggles within a session.
+    staleTime: 5 * 60 * 1000,
+    enabled: opts?.enabled ?? true,
+  });
+}

--- a/webui-v2/src/lib/api.ts
+++ b/webui-v2/src/lib/api.ts
@@ -49,6 +49,7 @@ import type {
   ScanInspectReply,
   WizardRepo,
   FsListReply,
+  ModuleAnalysisResponse,
 } from "@/data/types";
 
 const BASE = import.meta.env.VITE_AG_API_BASE ?? "/api";
@@ -264,6 +265,31 @@ export const api = {
     if (params?.lod) qs.set("lod", params.lod);
     const suffix = qs.toString() ? `?${qs.toString()}` : "";
     return requestV2<GraphPayloadWire>(`/graph/${encodeURIComponent(groupId)}${suffix}`);
+  },
+
+  /**
+   * GET /api/v2/groups/:group/modules/analysis — module-level GDS (SCC,
+   * PageRank, betweenness over the aggregated module graph). Powers the
+   * "Module overview" mode on the Graph screen (#1386, closes epic #1380
+   * alongside #1384 which shipped the algorithms + endpoint).
+   *
+   * `topN` defaults to 10 (top hubs lists); `minSccSize` to 2; the full
+   * `modules` + `edges` arrays are returned regardless of `topN` so the
+   * UI can lay out every module-level node.
+   */
+  getModuleAnalysis: (
+    groupId: string,
+    params?: { topN?: number; minSccSize?: number; repoFilter?: string[] },
+  ) => {
+    const qs = new URLSearchParams();
+    if (params?.topN) qs.set("top_n", String(params.topN));
+    if (params?.minSccSize) qs.set("min_scc_size", String(params.minSccSize));
+    if (params?.repoFilter && params.repoFilter.length > 0)
+      qs.set("repo_filter", params.repoFilter.join(","));
+    const suffix = qs.toString() ? `?${qs.toString()}` : "";
+    return requestV2<ModuleAnalysisResponse>(
+      `/groups/${encodeURIComponent(groupId)}/modules/analysis${suffix}`,
+    );
   },
 
   // --- Topology screen (#1440, epic #1432) ---

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -14,12 +14,14 @@
 
 import { useEffect, useMemo, useRef, lazy, Suspense } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
-import { X, RotateCcw, SlidersHorizontal } from "lucide-react";
+import { X, RotateCcw, SlidersHorizontal, Boxes } from "lucide-react";
 import { SearchInput, Pill, Kbd } from "@/components/ui";
 import { useGraph } from "@/hooks/use-graph";
+import { useModuleAnalysis } from "@/hooks/use-module-analysis";
 import { useGraphStore, type ColorMode } from "@/store/use-graph-store";
 import { useAppStore } from "@/store/use-app-store";
 import type { EdgeKind, GraphNode } from "@/data/types";
+import { ModuleOverview } from "@/components/graph/module-overview";
 const GraphCanvas = lazy(() =>
   import("@/components/graph/graph-canvas").then((m) => ({ default: m.GraphCanvas })),
 );
@@ -29,6 +31,20 @@ import { FiltersDrawer } from "@/components/graph/filters-drawer";
 import { CommunitiesPopover } from "@/components/graph/communities-popover";
 import { MCPActivityOverlay } from "@/components/graph/mcp-activity-overlay";
 import { useGraphHighlight } from "@/hooks/use-graph-highlight";
+
+/**
+ * #1386 — derive the entity-level "module key" from a node's source file.
+ *
+ * Mirrors `moduleKey` in graph-canvas.tsx (last 2 path segments minus the
+ * file part). Kept here in addition to (not instead of) the canvas copy so
+ * the route can filter the entity set when a user expands a module from
+ * the overview, without reaching into the canvas internals.
+ */
+function moduleKeyOf(sourceFile: string): string {
+  if (!sourceFile) return "";
+  const parts = sourceFile.replace(/\\/g, "/").split("/");
+  return parts.slice(0, -1).slice(-2).join("/");
+}
 
 const COLOR_MODES: { id: ColorMode; label: string }[] = [
   { id: "repo", label: "Repo" },
@@ -45,6 +61,13 @@ export default function GraphScreen() {
   const s = useGraphStore();
   const [searchParams, setSearchParams] = useSearchParams();
   const { data, isLoading, isError } = useGraph(groupId, { lod: s.lod });
+
+  // #1386 — module-level GDS for the "Module overview" mode. Lazy: only
+  // fetched while the overview toggle is ON, so the default graph route has
+  // zero extra network cost.
+  const moduleAnalysis = useModuleAnalysis(groupId, {
+    enabled: s.moduleOverviewMode,
+  });
 
   const searchRef = useRef<HTMLInputElement>(null);
   const canvasRef = useRef<GraphCanvasHandle>(null);
@@ -98,6 +121,8 @@ export default function GraphScreen() {
         else if (s.focusNodeIds) exitFocus();
         else if (s.selectedNodeId) s.setSelectedNode(null);
         else if (s.focusedCommunityId != null) s.setFocusedCommunity(null);
+        // #1386 — last-resort Escape: exit Module overview mode.
+        else if (s.moduleOverviewMode) s.setModuleOverviewMode(false);
       }
     };
     window.addEventListener("keydown", onKey);
@@ -185,6 +210,43 @@ export default function GraphScreen() {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [s.egoHops, s.focusRootId, adjacency]);
 
+  // #1386 — when the user expands a module from the overview, build a focus
+  // set covering all entities in that (repo, module) pair and pop back into
+  // the entity-level view. We piggy-back on the existing focus machinery so
+  // the rendered ego sub-graph, exit affordance, camera snapshot etc. all
+  // just work — no parallel "module focus" branch.
+  useEffect(() => {
+    if (!s.expandedModule || !data) return;
+    const { repo: targetRepo, moduleName } = s.expandedModule;
+    const ids = new Set<string>();
+    for (const n of nodes) {
+      if (n.repo !== targetRepo) continue;
+      if (moduleKeyOf(n.sourceFile) !== moduleName) continue;
+      ids.add(n.id);
+    }
+    if (ids.size === 0) {
+      // Fallback: the module identity from the daemon (Module entity Name)
+      // doesn't always line up with the entity-graph's path-derived module
+      // key — synthetic top-level modules carry the repo slug as their name,
+      // for example. Fall back to filtering by repo so the user STILL gets a
+      // meaningful expanded sub-graph (the repo's entities) rather than a
+      // silent no-op.
+      for (const n of nodes) {
+        if (n.repo === targetRepo) ids.add(n.id);
+      }
+    }
+    if (ids.size === 0) {
+      s.setExpandedModule(null);
+      return;
+    }
+    canvasRef.current?.snapshotCamera();
+    s.setModuleOverviewMode(false); // exit overview into entity view…
+    s.setExpandedModule(null);
+    s.setFocusRoot(null); // …with a module-scoped focus instead of a single root.
+    s.setFocusNodes(ids);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [s.expandedModule, data]);
+
   // Once data arrives, if a node was deep-linked, focus its ego-graph.
   useEffect(() => {
     if (data && s.selectedNodeId && !s.focusNodeIds) {
@@ -268,6 +330,23 @@ export default function GraphScreen() {
         ) : null}
 
         <div className="ml-auto flex items-center gap-2">
+          {/* #1386 — Module overview toggle. Off by default; ON collapses the
+              graph to module-level nodes (one node per module) so users can
+              see the SCC/PageRank/betweenness from #1384 at a glance. */}
+          <button
+            onClick={() => s.setModuleOverviewMode(!s.moduleOverviewMode)}
+            aria-pressed={s.moduleOverviewMode}
+            data-testid="module-overview-toggle"
+            className={`inline-flex h-7 items-center gap-1.5 rounded-md border px-2.5 text-sm transition-colors ${
+              s.moduleOverviewMode
+                ? "border-accent bg-accent-soft text-accent-strong"
+                : "border-border bg-surface text-text-2 hover:bg-surface-2"
+            }`}
+            title="Collapse graph to module-level overview"
+          >
+            <Boxes size={13} /> Module overview
+          </button>
+
           <div className="flex overflow-hidden rounded-md border border-border">
             {COLOR_MODES.map((m) => (
               <button
@@ -310,7 +389,40 @@ export default function GraphScreen() {
 
       {/* Canvas + overlays */}
       <div className="relative min-h-0 flex-1">
-        {isLoading ? (
+        {s.moduleOverviewMode ? (
+          /* #1386 — module-level collapsed view. Renders OVER the entity
+             graph route's data plumbing; closing it (toggle off OR Reset)
+             returns to the canonical entity-level canvas below. */
+          moduleAnalysis.isLoading ? (
+            <div className="grid h-full place-items-center bg-bg">
+              <div className="flex flex-col items-center gap-3 text-text-3">
+                <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />
+                <span className="text-sm">Computing module analysis…</span>
+              </div>
+            </div>
+          ) : moduleAnalysis.isError ? (
+            <div className="grid h-full place-items-center bg-bg">
+              <div className="text-center">
+                <p className="text-md text-text">Module analysis unavailable.</p>
+                <p className="mt-1 text-sm text-text-3">
+                  The daemon endpoint /api/v2/groups/{groupId}/modules/analysis
+                  returned an error.
+                </p>
+              </div>
+            </div>
+          ) : moduleAnalysis.data ? (
+            <ModuleOverview
+              data={moduleAnalysis.data}
+              activeRepo={
+                s.activeRepos && s.activeRepos.size === 1
+                  ? Array.from(s.activeRepos)[0]
+                  : null
+              }
+              isDark={isDark}
+              onExpandModule={(m) => s.setExpandedModule(m)}
+            />
+          ) : null
+        ) : isLoading ? (
           <div className="grid h-full place-items-center bg-bg">
             <div className="flex flex-col items-center gap-3 text-text-3">
               <div className="h-8 w-8 animate-spin rounded-full border-2 border-border border-t-accent" />

--- a/webui-v2/src/store/use-graph-store.ts
+++ b/webui-v2/src/store/use-graph-store.ts
@@ -283,6 +283,20 @@ interface GraphState {
   nodeSizing: NodeSizingConfig;
   render: RenderConfig;
 
+  // #1386 — Module overview mode (closes epic #1380 alongside #1384).
+  // When ON, the Graph screen renders a COLLAPSED view: one node per
+  // module (sized by entity count / PageRank), edges = weighted
+  // module→module aggregates, cycles (SCCs) highlighted as a group.
+  // Clicking a module sets `expandedModule` and pops back into the
+  // entity-level view filtered to that module's entities. Default OFF —
+  // this is a separate mode, NOT a replacement for the Repo/Module/
+  // Community/Degree color modes (which apply to the entity-level view).
+  moduleOverviewMode: boolean;
+  /** When non-null, the entity-level view is filtered to the entities of
+   *  this `${repo}::${moduleName}` pair (the user "expanded" a module).
+   *  Cleared by exiting via the focus banner. */
+  expandedModule: { repo: string; moduleName: string } | null;
+
   // Re-layout request flag (flips true to force a fresh settle)
   relayoutNonce: number;
 
@@ -315,6 +329,10 @@ interface GraphState {
   requestRelayout: () => void;
   clearAllFilters: () => void;
   resetView: () => void;
+
+  // #1386 — Module overview actions.
+  setModuleOverviewMode: (on: boolean) => void;
+  setExpandedModule: (m: { repo: string; moduleName: string } | null) => void;
 }
 
 // Fix #1567-4: run the migration ONCE at module init (before the store reads any
@@ -352,6 +370,10 @@ export const useGraphStore = create<GraphState>((set) => ({
   simulation: persistedJSON("ag.v2.graph.sim", DEFAULT_SIMULATION, STORED_DEFAULTS_VERSION),
   nodeSizing: persistedJSON("ag.v2.graph.sizing", DEFAULT_NODE_SIZING, STORED_DEFAULTS_VERSION),
   render: persistedJSON("ag.v2.graph.render", DEFAULT_RENDER, STORED_DEFAULTS_VERSION),
+
+  // #1386 — module-overview defaults OFF; expandedModule null.
+  moduleOverviewMode: false,
+  expandedModule: null,
 
   relayoutNonce: 0,
 
@@ -433,5 +455,21 @@ export const useGraphStore = create<GraphState>((set) => ({
       focusedCommunityId: null,
       focusNodeIds: null,
       focusRootId: null,
+      // #1386 — Reset also exits the module-overview / expanded-module state so
+      // the user lands back on the canonical full entity graph.
+      moduleOverviewMode: false,
+      expandedModule: null,
     }),
+
+  // #1386 — toggling the overview mode clears any in-flight focus state so the
+  // module-collapsed canvas renders cleanly; exiting also clears any expansion.
+  setModuleOverviewMode: (moduleOverviewMode) =>
+    set({
+      moduleOverviewMode,
+      expandedModule: null,
+      selectedNodeId: null,
+      focusNodeIds: null,
+      focusRootId: null,
+    }),
+  setExpandedModule: (expandedModule) => set({ expandedModule }),
 }));


### PR DESCRIPTION
## What

Closes the #1380 epic by adding the webui surface for #1384's module-level GDS. New "Module overview" toggle on the Graph route renders a COLLAPSED canvas (one node per module, sized by PageRank, cycles tinted by SCC group, weighted directed edges). Clicking a module opens a metrics card; Expand pops back into the entity-level view filtered to that module's entities. Default OFF.

## Why

#1384 landed the algorithms + `archigraph_module_analysis` MCP tool + dashboard endpoint, but the data wasn't yet visible in the UI. #1386 (the last open ticket of epic #1380) wires the dashboard surface so users SEE the SCC/PageRank/betweenness signal without reading JSON. Combined with #1384 this closes epic #1380.

## How

### Backend (`internal/dashboard/v2_modules.go`)
Two new fields per repo on `GET /api/v2/groups/:group/modules/analysis`:
- `modules` — FULL centrality list (one entry per module, not just top-N) so the overview can lay out every node.
- `edges` — FULL directed module→module aggregated edges, each tagged with `scc_internal` + `scc_id` so the UI can tint cycle edges as a group.

Pre-existing `top_pagerank` / `top_betweenness` / `sccs` / `stats` fields are unchanged. New `v2_modules_test.go` drives the endpoint with a 3-module cycle fixture and asserts wire shape, SCC tagging, weight, and repo prefixing.

### Frontend (`webui-v2/`)
- `src/components/graph/module-overview.tsx` — new dependency-free SVG canvas. Synchronous force-directed layout (~220 ticks, O(n²) at n≤80 finishes in <5 ms), PageRank-scaled radii, SCC-group colors, weighted arrowheads. Per-repo tabs when the group has more than one repo with modules. Side card shows PageRank / Betweenness / in/out-degree + SCC roster.
- `src/hooks/use-module-analysis.ts` — TanStack Query wrapper; only fetches while the overview toggle is ON (zero extra network cost in default flow).
- `src/store/use-graph-store.ts` — `moduleOverviewMode` + `expandedModule` state; toggle clears focus, Reset + Escape exit cleanly.
- `src/routes/graph.tsx` — new "Module overview" toolbar toggle next to the color-mode group; conditional render of `<ModuleOverview/>`; an effect that converts an `expandedModule` into a `focusNodes` set on the entity-level canvas (with a repo-fallback for the synthetic-module edge case where `Module.Name` is a repo slug that doesn't match any `sourceFile` module-key).
- `src/data/types.ts` + `src/lib/api.ts` — wire types + typed `api.getModuleAnalysis`.

The overview is performant by design — module-level corpora are small (12-30 nodes per repo on real groups). Cosmos.gl would be overkill at this scale, so we render SVG with a tiny synchronous simulation: deterministic across reloads (seeded by sorted module ID), no rAF loop, screenshot-friendly.

## Risk

LOW.
- New mode is fully gated behind a toggle that defaults OFF. The existing Repo/Module/Community/Degree color modes and the entity-level canvas are untouched.
- Backend change is purely additive (two new JSON fields per repo). No existing field renamed or removed; no schema migrations.
- New hook is lazy (`enabled: s.moduleOverviewMode`) so the default Graph route has zero extra network cost.
- Module-overview canvas is dependency-free (pure React + SVG) so it cannot regress the cosmos.gl pipeline.
- Defensive `?? []` guards on every wire-shape slice access — Go nil-slice JSON `null` won't crash the component.

## Verification

- `cd webui-v2 && npm run build` — clean (3821 modules, no TS errors).
- `go test ./internal/dashboard -run TestV2ModulesAnalysis -count=1` — PASS (covers full modules + edges arrays, SCC tagging, repo prefixing, non-cycle edge edge tagging).
- Drove a worktree-local `archigraph dashboard serve --port 47275` (NEVER touched the live :47274 daemon — confirmed alive both before and after with the same version + groups). Vite dev on :47282 with `AG_API_TARGET=http://localhost:47275`. Verified on both upvate and polyglot-platform across light + dark themes:
  - Toggle ON renders the SVG overview with repo tabs + stats card.
  - Selecting a module opens the metrics card with PageRank/Betweenness/degree.
  - Expand button transitions back to the entity-level canvas with focus on the module's entities.
  - Toggle OFF restores the cosmos canvas cleanly.
  - Escape exits the overview as last-resort.

Screenshots locally: `1386-01..1386-09` (also in `/tmp/1386-screenshots/`).

### Note on live-data SCC visibility
The indexed corpus on this machine has sparse Module entities (1-5 modules per repo, zero SCCs) so the dramatic "Django tangle of 6" mentioned in the grind isn't visible without a re-index. The component handles the zero-SCC, sparse-module path defensively, and the backend test covers the cycle-rich path with a synthetic 3-module SCC.

## Tested

- Unit: `TestV2ModulesAnalysis_FullModulesAndEdges` — PASS.
- E2E (Playwright, local against worktree daemon on :47275): toggle on/off, module select, expand, both themes, both groups — all green.
- Build: `npm run build` + `go build ./...` — both clean.

## Follow-ups

None required. The "Django tangle" demo requires a re-indexed corpus with rich per-package Module entities; that's a data-quality concern tracked separately and the surface here handles both the rich-data and sparse-data cases gracefully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)