### PR TITLE
[#1672] TOON wire conversion: JSON→TOON last-step encoding for list-of-record MCP payloads

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -50,6 +50,7 @@ bump (and a deprecation warning lap in the prior minor).
 |----------|--------|
 | `ARCHIGRAPH_MCP_DEBUG` | `0` silent (default), `1` print per-tool summary on shutdown, `2` per-call telemetry. Read by `cmd/archigraph/mcp.go`. |
 | `ARCHIGRAPH_VERBOSE` | When `1`, the indexer (`archigraph index`) prints per-language relationship breakdowns. Indexer-side; the MCP server itself does not read this. |
+| `MCP_WIRE_FORMAT` | `toon` (default) or `json`. Controls whether list-of-record responses use TOON encoding or fall back to minified JSON arrays in the `items` field. See [Wire Format](#wire-format) below. |
 
 The registry path defaults to `~/.archigraph/registry.json` and can be
 overridden via the `--registry` CLI flag.
@@ -1301,6 +1302,72 @@ AUDIT_CEILING=4200 make mcp-audit          # stricter gate
 AUDIT_BASELINE=4219 make mcp-audit         # show delta from measured baseline
 go run ./cmd/mcp-audit -json               # machine-readable JSON report
 ```
+
+---
+
+---
+
+## Wire Format
+
+### TOON encoding (#1672)
+
+Since #1672 the MCP server applies a last-step JSON→TOON conversion for
+**list-of-record tool payloads** before bytes leave the daemon. Internal code
+stays JSON throughout; the conversion happens only in `Server.wrap` via
+`injectElapsedMS` → `recordsToTOON`.
+
+#### What changes
+
+| Response shape | Before #1672 | After #1672 (default) |
+|----------------|-------------|----------------------|
+| JSON array of homogeneous records | `{"items":[{...},{...}], "count":N, "elapsed_ms":M}` | `{"items":"[!schema {f1,f2}]\n{v1,v2}\n{v1,v2}\n", "count":N, "elapsed_ms":M}` |
+| JSON object (single entity) | unchanged | unchanged |
+| Non-JSON / compact-text payloads | unchanged | unchanged |
+
+#### TOON format
+
+A TOON-encoded block starts with a schema declaration followed by one row per
+record:
+
+```
+[!schema {field1,field2,field3}]
+{value1,value2,value3}
+{value1,value2,value3}
+```
+
+- Keys are **sorted alphabetically** for determinism.
+- Strings are escaped: `\`, `,`, `{`, `}` are preceded by a backslash.
+- Numbers and booleans are emitted bare.
+- Nested objects/arrays fall back to their minified JSON form (single cell,
+  escaped as a string).
+- An agent reading TOON treats each `{...}` line as a row and the schema line
+  as the column names.
+
+#### Detection rule
+
+`recordsToTOON` converts only when **every element** of the array is a
+`map[string]any` with **the same key set** (same count, same keys). Any
+mismatch — including missing keys, extra keys, or non-object elements — falls
+back to the minified JSON array in `items`.
+
+#### Opt-out
+
+Set `MCP_WIRE_FORMAT=json` to receive `items` as a raw JSON array (same
+shape as #1663 minified JSON). This env var is read at call time so it can be
+toggled without restarting the daemon.
+
+#### Token savings
+
+Measured on a representative 40-record endpoint payload (8 fields per row):
+
+| Format | Tokens (≈chars/4) | Savings vs JSON |
+|--------|-------------------|-----------------|
+| Minified JSON array | 2,270 | — |
+| TOON-encoded | 1,388 | **~39%** |
+
+For list-heavy tools (`archigraph_endpoints`, `archigraph_topology`,
+`archigraph_auth_coverage`, `archigraph_find_dead_code`, etc.) this is
+additive on top of the minification savings from #1663.
 
 ---
 

--- a/internal/mcp/compact_test.go
+++ b/internal/mcp/compact_test.go
@@ -1,4 +1,4 @@
-// compact_test.go — #1663 compact serializer tests.
+// compact_test.go — #1663 compact serializer tests; #1672 TOON wire helpers.
 package mcp
 
 import (
@@ -110,4 +110,111 @@ func TestTabularEncode_SavesTokensVsJSON(t *testing.T) {
 		t.Errorf("tabular (%d) should be shorter than JSON array (%d) for list-of-record",
 			len(tab), len(data))
 	}
+}
+
+// ---------------------------------------------------------------------------
+// #1672 — recordsToTOON helper tests
+// ---------------------------------------------------------------------------
+
+// TestRecordsToTOON_HomogeneousConverts verifies homogeneous record arrays are
+// converted to TOON with a sorted schema line and one row per record.
+func TestRecordsToTOON_HomogeneousConverts(t *testing.T) {
+	// Simulate what json.Unmarshal produces for []any of map[string]any.
+	input := []any{
+		map[string]any{"id": "e1", "name": "OrderService", "repo": "svc"},
+		map[string]any{"id": "e2", "name": "UserService", "repo": "svc"},
+	}
+	got, ok := recordsToTOON(input)
+	if !ok {
+		t.Fatal("expected recordsToTOON to return ok=true for homogeneous input")
+	}
+	lines := strings.Split(strings.TrimSpace(got), "\n")
+	// 1 schema line + 2 rows
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d: %q", len(lines), got)
+	}
+	// Keys sorted: id, name, repo
+	if lines[0] != "[!schema {id,name,repo}]" {
+		t.Errorf("schema line wrong: %q", lines[0])
+	}
+	// Both rows present (exact order is deterministic via sorted keys).
+	if !strings.Contains(got, "e1") || !strings.Contains(got, "OrderService") {
+		t.Errorf("missing row 1 data: %q", got)
+	}
+	if !strings.Contains(got, "e2") || !strings.Contains(got, "UserService") {
+		t.Errorf("missing row 2 data: %q", got)
+	}
+}
+
+// TestRecordsToTOON_HeterogeneousReturnsFalse verifies that arrays with
+// mismatched key sets across elements return ok=false.
+func TestRecordsToTOON_HeterogeneousReturnsFalse(t *testing.T) {
+	input := []any{
+		map[string]any{"id": "e1", "name": "fn1"},
+		map[string]any{"id": "e2", "name": "fn2", "extra": "x"},
+	}
+	_, ok := recordsToTOON(input)
+	if ok {
+		t.Error("expected recordsToTOON to return ok=false for heterogeneous schema")
+	}
+}
+
+// TestRecordsToTOON_EmptyReturnsFalse verifies empty slices return ok=false.
+func TestRecordsToTOON_EmptyReturnsFalse(t *testing.T) {
+	_, ok := recordsToTOON(nil)
+	if ok {
+		t.Error("expected ok=false for nil input")
+	}
+	_, ok2 := recordsToTOON([]any{})
+	if ok2 {
+		t.Error("expected ok=false for empty slice")
+	}
+}
+
+// TestRecordsToTOON_NonObjectElementReturnsFalse verifies that a slice
+// containing non-map elements is not TOON-encoded.
+func TestRecordsToTOON_NonObjectElementReturnsFalse(t *testing.T) {
+	input := []any{"just a string", "another"}
+	_, ok := recordsToTOON(input)
+	if ok {
+		t.Error("expected ok=false when elements are not map[string]any")
+	}
+}
+
+// TestRecordsToTOON_TokenSavings verifies that TOON text is shorter than the
+// minified JSON for the same data — confirming actual token savings on the wire.
+func TestRecordsToTOON_TokenSavings(t *testing.T) {
+	const n = 40
+	input := make([]any, n)
+	for i := range input {
+		input[i] = map[string]any{
+			"entity_id":   "repo1::abcdef1234567890",
+			"name":        "POST /api/v2/orders",
+			"kind":        "http_endpoint_definition",
+			"repo":        "orders-service",
+			"source_file": "internal/handlers/orders.go",
+			"start_line":  float64(42 + i),
+			"method":      "POST",
+			"path":        "/api/v2/orders",
+		}
+	}
+	toonText, ok := recordsToTOON(input)
+	if !ok {
+		t.Fatal("expected homogeneous input to convert")
+	}
+	jsonData, _ := json.Marshal(input)
+
+	toonTokens := estimateTokens(toonText)
+	jsonTokens := estimateTokens(string(jsonData))
+	savings := float64(jsonTokens-toonTokens) / float64(jsonTokens) * 100
+	if toonTokens >= jsonTokens {
+		t.Errorf("TOON (%d tokens) should be fewer than JSON (%d tokens)", toonTokens, jsonTokens)
+	}
+	// Expect at least 30% savings for this representative endpoint payload.
+	if savings < 30 {
+		t.Errorf("expected ≥30%% token savings, got %.1f%% (TOON=%d, JSON=%d)",
+			savings, toonTokens, jsonTokens)
+	}
+	t.Logf("Token savings: %.1f%% (TOON=%d vs JSON=%d for %d endpoint records)",
+		savings, toonTokens, jsonTokens, n)
 }

--- a/internal/mcp/render.go
+++ b/internal/mcp/render.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"encoding/json"
 	"fmt"
+	"os"
 	"sort"
 	"strings"
 
@@ -182,6 +183,71 @@ func tabularEncode(schema []string, rows [][]any) string {
 		b.WriteString("}\n")
 	}
 	return b.String()
+}
+
+// ---------------------------------------------------------------------------
+// #1672 — TOON wire conversion helpers
+// ---------------------------------------------------------------------------
+
+// toonWireEnabled returns true when the MCP_WIRE_FORMAT env var is unset or
+// set to "toon". Set MCP_WIRE_FORMAT=json to opt out of TOON encoding and
+// receive minified JSON on the wire instead.
+func toonWireEnabled() bool {
+	v := strings.ToLower(strings.TrimSpace(os.Getenv("MCP_WIRE_FORMAT")))
+	return v == "" || v == "toon"
+}
+
+// recordsToTOON detects whether arr is a homogeneous list of records (every
+// element is a map[string]any with the same key set) and, if so, returns the
+// TOON-encoded text. Returns ("", false) when the array is not suitable for
+// tabular encoding (empty, heterogeneous, non-object elements, etc.).
+//
+// Key ordering is sorted for determinism; the schema line mirrors the result.
+func recordsToTOON(arr []any) (string, bool) {
+	if len(arr) == 0 {
+		return "", false
+	}
+	// First pass: collect the canonical key set from the first element.
+	first, ok := arr[0].(map[string]any)
+	if !ok {
+		return "", false
+	}
+	keys := make([]string, 0, len(first))
+	for k := range first {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) == 0 {
+		return "", false
+	}
+
+	// Second pass: verify every element has exactly the same key set.
+	for _, item := range arr[1:] {
+		obj, ok := item.(map[string]any)
+		if !ok {
+			return "", false
+		}
+		if len(obj) != len(keys) {
+			return "", false
+		}
+		for _, k := range keys {
+			if _, has := obj[k]; !has {
+				return "", false
+			}
+		}
+	}
+
+	// Build the rows slice for tabularEncode.
+	rows := make([][]any, len(arr))
+	for i, item := range arr {
+		obj := item.(map[string]any)
+		row := make([]any, len(keys))
+		for j, k := range keys {
+			row[j] = obj[k]
+		}
+		rows[i] = row
+	}
+	return tabularEncode(keys, rows), true
 }
 
 // tabularCell renders one cell value. Strings need escaping for `,` `}` `\`.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -507,8 +507,19 @@ func injectElapsedMS(res *mcpapi.CallToolResult, ms int64) *mcpapi.CallToolResul
 		case '[':
 			var arr []any
 			if err := json.Unmarshal([]byte(tc.Text), &arr); err == nil {
+				// #1672: attempt TOON wire conversion for homogeneous record arrays.
+				// When MCP_WIRE_FORMAT=toon (default), replace the JSON array in
+				// "items" with a TOON-encoded text block. The envelope shape is
+				// preserved: {items:<TOON-text>, count:N, elapsed_ms:M}.
+				// Non-homogeneous arrays fall back to the minified-JSON items value.
+				var itemsVal any = arr
+				if toonWireEnabled() {
+					if toon, ok := recordsToTOON(arr); ok {
+						itemsVal = toon
+					}
+				}
 				env := map[string]any{
-					"items":      arr,
+					"items":      itemsVal,
 					"count":      len(arr),
 					"elapsed_ms": ms,
 				}

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2064,6 +2064,183 @@ func TestPatterns_ConcurrentRefineApply(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// #1672 — TOON wire conversion tests
+// ---------------------------------------------------------------------------
+
+// TestTOONWire_HomogeneousArrayGetsTOON verifies that when MCP_WIRE_FORMAT=toon
+// (default), a tool that returns a JSON array of homogeneous records will
+// produce an envelope with items=<TOON-text>, count=N, elapsed_ms.
+func TestTOONWire_HomogeneousArrayGetsTOON(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "toon")
+
+	// injectElapsedMS is the last step in wrap; exercise it directly with a
+	// synthetic homogeneous-record array payload.
+	arr := `[{"id":"e1","name":"POST /api/orders","repo":"svc"},{"id":"e2","name":"GET /api/orders","repo":"svc"}]`
+	res := &mcpapi.CallToolResult{
+		Content: []mcpapi.Content{mcpapi.NewTextContent(arr)},
+	}
+	out := injectElapsedMS(res, 42)
+	text := resultText(out)
+
+	// Envelope must be valid JSON.
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope not valid JSON: %v — got: %s", err, text)
+	}
+
+	// items must be a TOON-encoded string (not a JSON array).
+	items, ok := env["items"].(string)
+	if !ok {
+		t.Fatalf("expected items to be a string (TOON), got %T: %v", env["items"], env["items"])
+	}
+	if !strings.HasPrefix(items, "[!schema {") {
+		t.Errorf("expected TOON header '[!schema {', got: %s", items)
+	}
+	// Schema line must list the sorted keys.
+	if !strings.Contains(items, "id,name,repo") {
+		t.Errorf("expected schema keys id,name,repo in TOON header, got: %s", items)
+	}
+	// Row count must match.
+	if env["count"].(float64) != 2 {
+		t.Errorf("expected count=2, got %v", env["count"])
+	}
+	// elapsed_ms injected.
+	if env["elapsed_ms"].(float64) != 42 {
+		t.Errorf("expected elapsed_ms=42, got %v", env["elapsed_ms"])
+	}
+}
+
+// TestTOONWire_JSONOptOutKeepsArrayInItems verifies that MCP_WIRE_FORMAT=json
+// leaves items as a JSON array (backwards-compat opt-out).
+func TestTOONWire_JSONOptOutKeepsArrayInItems(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "json")
+
+	arr := `[{"id":"e1","name":"fn1"},{"id":"e2","name":"fn2"}]`
+	res := &mcpapi.CallToolResult{
+		Content: []mcpapi.Content{mcpapi.NewTextContent(arr)},
+	}
+	out := injectElapsedMS(res, 7)
+	text := resultText(out)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope not valid JSON: %v — got: %s", err, text)
+	}
+	// items must be a JSON array, not a string.
+	if _, isStr := env["items"].(string); isStr {
+		t.Errorf("expected items to be a JSON array with MCP_WIRE_FORMAT=json, got a string: %v", env["items"])
+	}
+	if _, isArr := env["items"].([]any); !isArr {
+		t.Errorf("expected items to be []any, got %T", env["items"])
+	}
+}
+
+// TestTOONWire_HeterogeneousArrayFallsBackToJSON verifies that a mixed-schema
+// array (different key sets per row) is NOT TOON-encoded — items stays as a
+// JSON array even when MCP_WIRE_FORMAT=toon.
+func TestTOONWire_HeterogeneousArrayFallsBackToJSON(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "toon")
+
+	// Second record has an extra key "extra" that the first doesn't.
+	arr := `[{"id":"e1","name":"fn1"},{"id":"e2","name":"fn2","extra":"oops"}]`
+	res := &mcpapi.CallToolResult{
+		Content: []mcpapi.Content{mcpapi.NewTextContent(arr)},
+	}
+	out := injectElapsedMS(res, 0)
+	text := resultText(out)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("envelope not valid JSON: %v — got: %s", err, text)
+	}
+	if _, isStr := env["items"].(string); isStr {
+		t.Errorf("heterogeneous array should not produce TOON string, got items=%v", env["items"])
+	}
+}
+
+// TestTOONWire_SingleEntityObjectUnchanged verifies that a plain JSON object
+// (single entity, not an array) passes through unchanged as minified JSON.
+func TestTOONWire_SingleEntityObjectUnchanged(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "toon")
+
+	obj := `{"id":"e1","name":"OrderViewSet","kind":"Component"}`
+	res := &mcpapi.CallToolResult{
+		Content: []mcpapi.Content{mcpapi.NewTextContent(obj)},
+	}
+	out := injectElapsedMS(res, 5)
+	text := resultText(out)
+
+	var env map[string]any
+	if err := json.Unmarshal([]byte(text), &env); err != nil {
+		t.Fatalf("expected valid JSON for single object, got: %s — %v", text, err)
+	}
+	// No "items" envelope for plain objects.
+	if _, hasItems := env["items"]; hasItems {
+		t.Errorf("single-entity object should not be wrapped in items envelope, got: %s", text)
+	}
+	if env["id"] != "e1" {
+		t.Errorf("expected id=e1 preserved, got: %s", text)
+	}
+	if env["elapsed_ms"].(float64) != 5 {
+		t.Errorf("expected elapsed_ms=5, got %v", env["elapsed_ms"])
+	}
+}
+
+// TestTOONWire_LiveEndpointsTool verifies end-to-end that archigraph_find_dead_code
+// (a list tool) returns TOON-encoded items in its response when MCP_WIRE_FORMAT=toon.
+// This exercises the full wrap → injectElapsedMS → TOON path with a real Server.
+func TestTOONWire_LiveEndpointsTool(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "toon")
+
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, fixtureDoc("r1"))
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"r1": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	res := callTool(t, srv, "archigraph_find_dead_code", map[string]any{
+		"limit": float64(10),
+	})
+	if res.IsError {
+		t.Fatalf("find_dead_code error: %s", resultText(res))
+	}
+	text := resultText(res)
+	// The outer response must be valid JSON.
+	var outer map[string]any
+	if err := json.Unmarshal([]byte(text), &outer); err != nil {
+		t.Fatalf("outer response not valid JSON: %v — got: %s", err, text)
+	}
+	// elapsed_ms must be present (injected by wrap).
+	if _, ok := outer["elapsed_ms"]; !ok {
+		t.Errorf("expected elapsed_ms in outer envelope, got: %s", text)
+	}
+	// When the tool returns any items, they must be TOON-encoded in items string.
+	// (dead_code on the fixture may or may not have entries; we just assert shape.)
+	if items, ok := outer["items"]; ok {
+		switch v := items.(type) {
+		case string:
+			// TOON path: expected. Verify schema line present.
+			if !strings.HasPrefix(v, "[!schema {") {
+				t.Errorf("items string is not TOON-encoded: %s", v)
+			}
+		case []any:
+			// JSON fallback is only valid when array is empty (0 dead-code nodes).
+			if len(v) != 0 {
+				t.Errorf("expected TOON string for non-empty items array, got []any len=%d", len(v))
+			}
+		default:
+			t.Errorf("unexpected items type %T: %v", items, items)
+		}
+	}
+}
+
 // writeGraphFB writes a graph.Document to <repoDir>/.archigraph/graph.fb
 // (FlatBuffers format). Used to verify fix for issue #1374 item #1.
 func writeGraphFB(t *testing.T, repoDir string, doc *graph.Document) string {


### PR DESCRIPTION
## Summary

- Wires `tabularEncode` (from #1669) as the last step in `Server.wrap` — after `injectElapsedMS` produces the `{items, count, elapsed_ms}` envelope, homogeneous record arrays in `items` are replaced with a TOON-encoded text block
- Adds `MCP_WIRE_FORMAT=json|toon` env toggle (default `toon`) for caller opt-out without restarting the daemon
- Internal code stays JSON throughout; only the wire bytes change; no internal callers need updates

## Changes

**`internal/mcp/render.go`**
- `toonWireEnabled()` — reads `MCP_WIRE_FORMAT`, returns true when unset or `toon`
- `recordsToTOON(arr []any) (string, bool)` — detects homogeneous arrays (same sorted key set across every element), delegates to `tabularEncode`; returns `false` for empty, non-object, or heterogeneous inputs

**`internal/mcp/server.go`**
- `injectElapsedMS` `[` branch: after unmarshalling the JSON array, calls `recordsToTOON`; on success puts TOON text string in `items`; on fallback puts the JSON array; envelope shape (`items`, `count`, `elapsed_ms`) is preserved in both cases

**`internal/mcp/compact_test.go`** — 5 unit tests:
- Homogeneous conversion produces correct TOON schema + rows
- Heterogeneous schema returns `ok=false`
- Empty / non-object inputs return `ok=false`
- Token savings ≥30% gate (measured 38.9% on 40-record endpoint payload)

**`internal/mcp/server_test.go`** — 5 integration tests:
- `TestTOONWire_HomogeneousArrayGetsTOON` — verifies items is a TOON string with `[!schema {` header, correct keys, count, elapsed_ms
- `TestTOONWire_JSONOptOutKeepsArrayInItems` — `MCP_WIRE_FORMAT=json` keeps items as `[]any`
- `TestTOONWire_HeterogeneousArrayFallsBackToJSON` — mixed-schema array stays as JSON array
- `TestTOONWire_SingleEntityObjectUnchanged` — plain JSON objects pass through with no `items` envelope
- `TestTOONWire_LiveEndpointsTool` — end-to-end via real Server + `archigraph_find_dead_code`

**`internal/mcp/SCHEMA.md`** — adds Wire Format section documenting TOON shape, detection rule, opt-out env var, and token-savings table

## Test plan

- [x] `go build ./internal/mcp/...` — clean
- [x] `go vet ./internal/mcp/...` — clean
- [x] `go test ./internal/mcp/... -count=1` — all pass (1.4s)
- [x] 5 new TOON wire tests all green
- [x] 5 new `recordsToTOON` unit tests all green, including ≥30% savings gate (measured 38.9%)
- [x] All existing `internal/mcp` tests unchanged and green
- [x] Daemon on :47274 NOT restarted

## Token savings

| Payload | Format | Tokens | Savings |
|---------|--------|--------|---------|
| 40-record endpoint list (8 fields/row) | minified JSON | 2,270 | — |
| 40-record endpoint list (8 fields/row) | TOON | 1,388 | **38.9%** |

Additive on top of #1663 minification for list-heavy tools (`archigraph_endpoints`, `archigraph_topology`, `archigraph_auth_coverage`, `archigraph_find_dead_code`, etc.).

Fixes #1672

🤖 Generated with [Claude Code](https://claude.com/claude-code)