### PR TITLE
feat(engine): commit-coupling soft-edge layer (VCS-derived) — fixes #21

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -52,12 +52,13 @@ const (
 	PassEnrichment    = "enrichment"     // Pass 6: emit enrichment candidates
 	PassProcessFlow   = "process-flow"   // Pass 7: process-flow BFS over CALLS (#724)
 	PassModuleAgg     = "module-agg"     // Pass 8: module-level aggregation (#1383)
+	PassCommitCouple  = "commit-couple"  // Pass 8.5: VCS-derived COMMIT_COUPLED soft edges (#21)
 	PassEmbed         = "embed"          // Pass 9: semantic embeddings sidecar (#461 / ADR-0019)
 )
 
 // allPassNames is used to validate --skip-pass entries.
 var allPassNames = []string{
-	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassModuleAgg, PassEmbed,
+	PassExtract, PassFramework, PassCrossLang, PassGraphAlgo, PassBuildDocument, PassRenameDetect, PassEnrichment, PassProcessFlow, PassModuleAgg, PassCommitCouple, PassEmbed,
 }
 
 // fileTask carries one repo-relative path and its absolute counterpart
@@ -1139,6 +1140,29 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			fmt.Fprintf(os.Stderr,
 				"archigraph: module-agg modules=%d contains=%d depends_on=%d\n",
 				aggStats.ModuleNodes, aggStats.ContainsEdges, aggStats.DependsOnEdges)
+		}
+	}
+
+	// Pass 8.5 — commit-coupling soft edges (issue #21). Runs AFTER the main
+	// extraction + algorithm + module-agg passes. Mines `git log --name-only`
+	// to derive a co-change support count between file pairs and emits
+	// COMMIT_COUPLED edges between synthetic File entities for pairs that
+	// meet the minimum support threshold (default 5 commits). Pass 4 graph
+	// algorithms already ran above on the pre-coupling graph, so this layer
+	// does NOT influence community detection / centrality — it is a true
+	// soft-edge layer that opt-in consumers can read on demand. Skippable
+	// via --skip-pass=commit-couple.
+	if !i.skipPasses[PassCommitCouple] {
+		ccStats := engine.ApplyCommitCoupling(doc, absRepo, engine.DefaultCommitCouplingConfig())
+		if ccStats.Skipped {
+			if verbose() {
+				fmt.Fprintf(os.Stderr, "archigraph: commit-couple skipped (%s)\n", ccStats.SkipReason)
+			}
+		} else if verbose() || ccStats.CoupledEdges > 0 {
+			fmt.Fprintf(os.Stderr,
+				"archigraph: commit-couple commits=%d candidate_pairs=%d files=%d edges=%d oversize_skipped=%d\n",
+				ccStats.TotalCommits, ccStats.CandidatePairs, ccStats.FileEntities,
+				ccStats.CoupledEdges, ccStats.SkippedOversizeCommits)
 		}
 	}
 

--- a/internal/engine/commit_coupling_edges.go
+++ b/internal/engine/commit_coupling_edges.go
@@ -1,0 +1,513 @@
+// Commit-coupling soft-edge layer — VCS-derived co-change signal (issue #21).
+//
+// # What
+//
+// At index time, mine the repo's git history (`git log --name-only`) to build a
+// co-change matrix: for every commit, every unordered pair of files that
+// appear together in that commit contributes +1 to a support counter. Pairs
+// whose support meets a minimum threshold are emitted as `COMMIT_COUPLED`
+// soft-edges between synthetic `File` entities, with
+// `Properties = {confidence, support}` where `confidence = support /
+// total_commits`.
+//
+// # Why
+//
+// Files that change together over time often share logical coupling that
+// static analysis misses — a handler and its test, an infra YAML and the
+// feature it follows, a JSON schema and its consumers. Surfacing this as a
+// soft edge lets downstream algorithms (impact-radius, community detection,
+// docs grouping) opt in to a richer view without changing default graph
+// topology.
+//
+// # Soft-edge contract
+//
+// COMMIT_COUPLED edges are **append-only** and live on synthetic File
+// entities (Kind="File", Properties["synthetic"]="true"). They do not
+// influence:
+//
+//   - Pass 4 graph algorithms (community/centrality/PageRank). Those run
+//     before this pass and operate on real CALLS/IMPORTS/etc. edges only.
+//   - Module aggregation. The module-agg pass has already produced
+//     DEPENDS_ON edges and does not see File entities.
+//   - The HTTP endpoint resolver, process-flow BFS, or enrichment emitters.
+//
+// Consumers that *want* the signal (e.g. an opt-in impact-radius mode, a
+// "what changes with me?" MCP tool) can filter by `Kind == "COMMIT_COUPLED"`.
+// Consumers that ignore it see the synthetic File nodes only as detached
+// containers — by convention they filter `entity.Kind != "File"` (mirroring
+// the `entity.Kind != "Module"` pattern used elsewhere).
+//
+// # Algorithm
+//
+//  1. Detect git availability: `git -C <repo> rev-parse --is-inside-work-tree`.
+//     If the repo is not a git working tree (or `git` is unavailable), the
+//     pass logs a single line and returns an empty result.
+//
+//  2. Stream `git log --no-merges --pretty=format:%H --name-only` and group
+//     lines into commits. Each commit is the set of files touched. Merge
+//     commits are skipped — they aggregate many unrelated file changes and
+//     would dominate the support count with spurious coupling.
+//
+//  3. For each commit, enumerate the unordered pairs (i<j) of its file set
+//     and accumulate `support[pair]++`.
+//
+//  4. Filter: keep only pairs with `support >= MinSupport` (default 5). For
+//     each kept pair, emit:
+//       - Two synthetic `File` entities (if not already emitted).
+//       - One `COMMIT_COUPLED` relationship between them, with
+//         `Properties["support"] = "<n>"`,
+//         `Properties["confidence"] = "<f>"` (formatted with 4 decimals).
+//
+// # Determinism
+//
+// The git log order is deterministic by commit hash, and we sort each commit's
+// file list before enumerating pairs. Output entities and edges are sorted
+// before append so the resulting graph.Document is byte-identical across runs
+// on the same repo state.
+//
+// # Performance
+//
+// `git log --name-only` over a large repo (>10k commits) produces a few MB of
+// stdout — we stream-parse it via bufio.Scanner so memory stays bounded. The
+// pair enumeration is O(sum k^2) where k is the file count per commit; merge
+// skipping bounds k in practice. For a repo with 10k non-merge commits at
+// average k=5, that is 250k pair updates — sub-second.
+//
+// # Refs
+//
+// Fixes #21 (v1.1 commit-coupling layer).
+package engine
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// KindCommitCoupled is the relationship kind emitted by this pass.
+const KindCommitCoupled = "COMMIT_COUPLED"
+
+// KindFile is the synthetic entity kind used as endpoints for commit-coupling
+// edges. We use "File" rather than reusing "Module" because module rollup is
+// coarser than per-file granularity, and the co-change signal is inherently
+// per-file.
+const KindFile = "File"
+
+// DefaultMinSupport is the default minimum number of commits a file pair
+// must co-occur in before a COMMIT_COUPLED edge is emitted.
+//
+// Set per spec (#21): 5 is high enough to filter noise from one-off refactor
+// commits that touch many files, and low enough to catch genuine recurring
+// coupling on younger repos.
+const DefaultMinSupport = 5
+
+// DefaultGitLogTimeout caps the git-log subprocess to avoid pathological hangs
+// on huge or wedged repos.
+const DefaultGitLogTimeout = 60 * time.Second
+
+// MaxFilesPerCommit is a guard against catastrophically large commits (vendor
+// drops, lockfile mass-updates) that would explode pair enumeration. Commits
+// touching more than this many files are skipped. 200 covers virtually all
+// real-world feature commits.
+const MaxFilesPerCommit = 200
+
+// CommitCouplingConfig tunes the pass. Zero values fall back to defaults so
+// callers can pass `CommitCouplingConfig{}` for stock behaviour.
+type CommitCouplingConfig struct {
+	// MinSupport is the minimum number of commits a pair must co-occur in
+	// before we emit an edge. Defaults to DefaultMinSupport.
+	MinSupport int
+
+	// GitLogTimeout caps the git-log subprocess. Defaults to
+	// DefaultGitLogTimeout.
+	GitLogTimeout time.Duration
+
+	// MaxFilesPerCommit skips commits touching more than this many files.
+	// Defaults to MaxFilesPerCommit.
+	MaxFilesPerCommit int
+}
+
+// DefaultCommitCouplingConfig returns the stock configuration.
+func DefaultCommitCouplingConfig() CommitCouplingConfig {
+	return CommitCouplingConfig{
+		MinSupport:        DefaultMinSupport,
+		GitLogTimeout:     DefaultGitLogTimeout,
+		MaxFilesPerCommit: MaxFilesPerCommit,
+	}
+}
+
+// CommitCouplingStats summarises a single Apply call.
+type CommitCouplingStats struct {
+	// TotalCommits is the number of commits scanned (post-filter:
+	// excludes merges and oversize commits).
+	TotalCommits int
+
+	// SkippedMergeCommits counts merge commits dropped during scan.
+	SkippedMergeCommits int
+
+	// SkippedOversizeCommits counts commits dropped for exceeding
+	// MaxFilesPerCommit.
+	SkippedOversizeCommits int
+
+	// CandidatePairs is the number of distinct file pairs observed at
+	// least once.
+	CandidatePairs int
+
+	// FileEntities is the number of synthetic File entities emitted.
+	FileEntities int
+
+	// CoupledEdges is the number of COMMIT_COUPLED edges emitted.
+	CoupledEdges int
+
+	// Skipped is true when the pass returned without scanning (non-git
+	// repo, git binary missing, or git error).
+	Skipped bool
+
+	// SkipReason records why the pass was skipped, when Skipped is true.
+	SkipReason string
+}
+
+// ApplyCommitCoupling runs the pass over doc, mining commit history from
+// repoPath. It appends synthetic File entities and COMMIT_COUPLED edges to
+// doc.Entities / doc.Relationships and updates doc.Stats.
+//
+// The pass is best-effort: any git failure is logged in stats.SkipReason and
+// the document is returned unchanged. Callers should treat a Skipped result
+// as a non-error outcome.
+func ApplyCommitCoupling(doc *graph.Document, repoPath string, cfg CommitCouplingConfig) CommitCouplingStats {
+	stats := CommitCouplingStats{}
+	if doc == nil {
+		stats.Skipped = true
+		stats.SkipReason = "nil document"
+		return stats
+	}
+
+	cfg = withDefaults(cfg)
+
+	// Detect git working tree. The check uses `git rev-parse` rather than
+	// stat-ing .git because submodules and git-worktrees use a .git file
+	// (pointing at the real gitdir) instead of a directory.
+	if !isGitWorkTree(repoPath) {
+		stats.Skipped = true
+		stats.SkipReason = "not a git working tree"
+		return stats
+	}
+
+	commits, scanStats, err := scanCommitHistory(repoPath, cfg)
+	stats.SkippedMergeCommits = scanStats.SkippedMergeCommits
+	stats.SkippedOversizeCommits = scanStats.SkippedOversizeCommits
+	if err != nil {
+		stats.Skipped = true
+		stats.SkipReason = fmt.Sprintf("git log failed: %v", err)
+		return stats
+	}
+	stats.TotalCommits = len(commits)
+	if stats.TotalCommits == 0 {
+		stats.Skipped = true
+		stats.SkipReason = "no commits scanned"
+		return stats
+	}
+
+	// Build the co-change support map.
+	support := buildSupport(commits)
+	stats.CandidatePairs = len(support)
+
+	// Filter to high-support pairs.
+	kept := filterPairs(support, cfg.MinSupport)
+	if len(kept) == 0 {
+		return stats
+	}
+
+	// Emit synthetic File entities for every endpoint touched by a kept
+	// pair, then emit COMMIT_COUPLED edges. Dedup against any entities/
+	// edges already in the document (idempotency).
+	existingEntities := make(map[string]bool, len(doc.Entities))
+	for k := range doc.Entities {
+		existingEntities[doc.Entities[k].ID] = true
+	}
+	existingRels := make(map[string]bool, len(doc.Relationships))
+	for k := range doc.Relationships {
+		existingRels[doc.Relationships[k].ID] = true
+	}
+
+	totalCommits := stats.TotalCommits
+
+	// Collect endpoint files in sorted order for deterministic emission.
+	fileSet := make(map[string]struct{})
+	for _, p := range kept {
+		fileSet[p.a] = struct{}{}
+		fileSet[p.b] = struct{}{}
+	}
+	sortedFiles := make([]string, 0, len(fileSet))
+	for f := range fileSet {
+		sortedFiles = append(sortedFiles, f)
+	}
+	sort.Strings(sortedFiles)
+
+	for _, f := range sortedFiles {
+		fid := fileEntityID(doc.Repo, f)
+		if existingEntities[fid] {
+			continue
+		}
+		existingEntities[fid] = true
+		doc.Entities = append(doc.Entities, graph.Entity{
+			ID:         fid,
+			Name:       f,
+			Kind:       KindFile,
+			SourceFile: f,
+			Properties: map[string]string{
+				"path":      f,
+				"repo":      doc.Repo,
+				"synthetic": "true",
+				"source":    "commit-coupling",
+			},
+		})
+		stats.FileEntities++
+	}
+
+	// Sort kept pairs for deterministic edge emission.
+	sort.Slice(kept, func(i, j int) bool {
+		if kept[i].a != kept[j].a {
+			return kept[i].a < kept[j].a
+		}
+		return kept[i].b < kept[j].b
+	})
+
+	for _, pair := range kept {
+		aID := fileEntityID(doc.Repo, pair.a)
+		bID := fileEntityID(doc.Repo, pair.b)
+		// Stable edge ID uses lexicographic ordering of endpoints so the
+		// undirected pair always hashes the same way regardless of how the
+		// `a`/`b` happen to be ordered upstream.
+		fromID, toID := aID, bID
+		if pair.b < pair.a {
+			fromID, toID = bID, aID
+		}
+		eid := graph.RelationshipID(fromID, toID, KindCommitCoupled)
+		if existingRels[eid] {
+			continue
+		}
+		existingRels[eid] = true
+		conf := float64(pair.support) / float64(totalCommits)
+		doc.Relationships = append(doc.Relationships, graph.Relationship{
+			ID:     eid,
+			FromID: fromID,
+			ToID:   toID,
+			Kind:   KindCommitCoupled,
+			Properties: map[string]string{
+				"support":    strconv.Itoa(pair.support),
+				"confidence": strconv.FormatFloat(conf, 'f', 4, 64),
+			},
+		})
+		stats.CoupledEdges++
+	}
+
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+	return stats
+}
+
+// withDefaults fills zero-valued fields with their package defaults.
+func withDefaults(cfg CommitCouplingConfig) CommitCouplingConfig {
+	if cfg.MinSupport <= 0 {
+		cfg.MinSupport = DefaultMinSupport
+	}
+	if cfg.GitLogTimeout <= 0 {
+		cfg.GitLogTimeout = DefaultGitLogTimeout
+	}
+	if cfg.MaxFilesPerCommit <= 0 {
+		cfg.MaxFilesPerCommit = MaxFilesPerCommit
+	}
+	return cfg
+}
+
+// isGitWorkTree reports whether repoPath is inside a git working tree.
+func isGitWorkTree(repoPath string) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "rev-parse", "--is-inside-work-tree")
+	out, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "true"
+}
+
+// commitRecord is one scanned commit's set of files.
+type commitRecord struct {
+	files []string // sorted, deduped, repo-relative
+}
+
+// scanCommitHistory runs `git log --no-merges --pretty=format:%H --name-only`
+// and returns one commitRecord per non-merge commit, skipping commits that
+// exceed cfg.MaxFilesPerCommit.
+func scanCommitHistory(repoPath string, cfg CommitCouplingConfig) ([]commitRecord, CommitCouplingStats, error) {
+	stats := CommitCouplingStats{}
+	ctx, cancel := context.WithTimeout(context.Background(), cfg.GitLogTimeout)
+	defer cancel()
+
+	// --no-merges already filters merge commits at the git level. We still
+	// surface a SkippedMergeCommits counter via a second cheap pass if we
+	// ever decide to include them; for now it stays 0 by construction.
+	cmd := exec.CommandContext(ctx, "git", "-C", repoPath, "log",
+		"--no-merges",
+		"--pretty=format:__archigraph_commit__:%H",
+		"--name-only",
+	)
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, stats, fmt.Errorf("stdout pipe: %w", err)
+	}
+	if err := cmd.Start(); err != nil {
+		return nil, stats, fmt.Errorf("start: %w", err)
+	}
+
+	commits, parseErr := parseGitLog(stdout, cfg.MaxFilesPerCommit, &stats)
+
+	// Drain remaining output if parse aborted early, then wait.
+	_, _ = io.Copy(io.Discard, stdout)
+	waitErr := cmd.Wait()
+	if parseErr != nil {
+		return nil, stats, parseErr
+	}
+	if waitErr != nil {
+		// Non-zero exit (e.g. empty repo) — surface stderr for debugging.
+		return nil, stats, fmt.Errorf("git log exit: %v: %s", waitErr, strings.TrimSpace(stderr.String()))
+	}
+	return commits, stats, nil
+}
+
+// parseGitLog streams a `git log --name-only` formatted stream and groups
+// lines into commitRecord values. The format is:
+//
+//	__archigraph_commit__:<HASH>
+//	path/one
+//	path/two
+//	<blank line>
+//	__archigraph_commit__:<NEXT-HASH>
+//	...
+//
+// Commits exceeding maxFiles are dropped and counted in stats.
+func parseGitLog(r io.Reader, maxFiles int, stats *CommitCouplingStats) ([]commitRecord, error) {
+	const marker = "__archigraph_commit__:"
+	sc := bufio.NewScanner(r)
+	// git log can produce long file lines and very long commit lists; raise
+	// the line buffer to 1 MiB so we never hit ErrTooLong on realistic repos.
+	buf := make([]byte, 0, 64*1024)
+	sc.Buffer(buf, 1024*1024)
+
+	var commits []commitRecord
+	var cur []string
+	inCommit := false
+
+	flush := func() {
+		if !inCommit {
+			return
+		}
+		if len(cur) == 0 {
+			// Commit with no file changes (e.g. an empty / git commit
+			// --allow-empty). Skip — contributes nothing to coupling.
+			return
+		}
+		if len(cur) > maxFiles {
+			stats.SkippedOversizeCommits++
+			return
+		}
+		// Dedup + sort for deterministic pair enumeration.
+		sort.Strings(cur)
+		deduped := cur[:0]
+		var last string
+		for i, p := range cur {
+			if i > 0 && p == last {
+				continue
+			}
+			deduped = append(deduped, p)
+			last = p
+		}
+		commits = append(commits, commitRecord{files: append([]string(nil), deduped...)})
+	}
+
+	for sc.Scan() {
+		line := sc.Text()
+		if strings.HasPrefix(line, marker) {
+			flush()
+			cur = cur[:0]
+			inCommit = true
+			continue
+		}
+		if !inCommit {
+			continue
+		}
+		if line == "" {
+			continue
+		}
+		cur = append(cur, line)
+	}
+	if err := sc.Err(); err != nil {
+		return nil, fmt.Errorf("scan: %w", err)
+	}
+	flush()
+	return commits, nil
+}
+
+// pairKey is an ordered (a < b) pair of file paths, used as a map key for the
+// support counter. Using a struct keeps allocations down vs string concat.
+type pairKey struct {
+	a string
+	b string
+}
+
+// keptPair carries a pair plus its support count out of the filter step.
+type keptPair struct {
+	a       string
+	b       string
+	support int
+}
+
+// buildSupport enumerates unordered pairs from every commit and returns the
+// support map.
+func buildSupport(commits []commitRecord) map[pairKey]int {
+	support := make(map[pairKey]int)
+	for _, c := range commits {
+		// files are already sorted+deduped by parseGitLog; iterate i<j to
+		// emit each unordered pair exactly once.
+		n := len(c.files)
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				key := pairKey{a: c.files[i], b: c.files[j]}
+				support[key]++
+			}
+		}
+	}
+	return support
+}
+
+// filterPairs returns the pairs whose support meets the threshold.
+func filterPairs(support map[pairKey]int, minSupport int) []keptPair {
+	kept := make([]keptPair, 0)
+	for k, n := range support {
+		if n >= minSupport {
+			kept = append(kept, keptPair{a: k.a, b: k.b, support: n})
+		}
+	}
+	return kept
+}
+
+// fileEntityID returns the stable 16-char hex ID used for synthetic File
+// entities. The path is used as both name and sourceFile, mirroring how
+// real Entity IDs encode source location.
+func fileEntityID(repo, path string) string {
+	return graph.EntityID(repo, KindFile, path, path)
+}
+

--- a/internal/engine/commit_coupling_edges_test.go
+++ b/internal/engine/commit_coupling_edges_test.go
@@ -1,0 +1,388 @@
+// Tests for the commit-coupling soft-edge pass (#21).
+//
+// Two layers of coverage:
+//
+//  1. Pure helpers (parseGitLog / buildSupport / filterPairs) drive the
+//     algorithm without touching the filesystem — fast, deterministic.
+//
+//  2. End-to-end smoke against a temp git repo created via the real `git`
+//     binary. Skips when git is unavailable or the test is run on a host
+//     without a working PATH.
+package engine
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// ──────────────────────────────────────────────────────────────────────────
+// Unit tests — pure helpers
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestParseGitLog_ParsesMultipleCommits(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"__archigraph_commit__:abc",
+		"a.go",
+		"b.go",
+		"",
+		"__archigraph_commit__:def",
+		"a.go",
+		"c.go",
+		"",
+	}, "\n"))
+
+	stats := &CommitCouplingStats{}
+	commits, err := parseGitLog(input, 100, stats)
+	if err != nil {
+		t.Fatalf("parseGitLog: %v", err)
+	}
+	if len(commits) != 2 {
+		t.Fatalf("want 2 commits, got %d", len(commits))
+	}
+	// files must be sorted within each commit
+	if commits[0].files[0] != "a.go" || commits[0].files[1] != "b.go" {
+		t.Errorf("commit 0 files unsorted: %v", commits[0].files)
+	}
+	if commits[1].files[0] != "a.go" || commits[1].files[1] != "c.go" {
+		t.Errorf("commit 1 files: %v", commits[1].files)
+	}
+}
+
+func TestParseGitLog_DedupsFilesWithinCommit(t *testing.T) {
+	// A rename within a commit can produce the same path twice; we dedup
+	// so pair enumeration doesn't double-count.
+	input := strings.NewReader(strings.Join([]string{
+		"__archigraph_commit__:abc",
+		"a.go",
+		"a.go",
+		"b.go",
+		"",
+	}, "\n"))
+
+	stats := &CommitCouplingStats{}
+	commits, err := parseGitLog(input, 100, stats)
+	if err != nil {
+		t.Fatalf("parseGitLog: %v", err)
+	}
+	if len(commits) != 1 || len(commits[0].files) != 2 {
+		t.Fatalf("want 1 commit with 2 deduped files, got %+v", commits)
+	}
+}
+
+func TestParseGitLog_SkipsOversizeCommits(t *testing.T) {
+	// 3-file commit, then a 5-file commit, max=3 → second is dropped.
+	input := strings.NewReader(strings.Join([]string{
+		"__archigraph_commit__:abc",
+		"a", "b", "c",
+		"",
+		"__archigraph_commit__:def",
+		"a", "b", "c", "d", "e",
+		"",
+	}, "\n"))
+
+	stats := &CommitCouplingStats{}
+	commits, err := parseGitLog(input, 3, stats)
+	if err != nil {
+		t.Fatalf("parseGitLog: %v", err)
+	}
+	if len(commits) != 1 {
+		t.Errorf("want 1 surviving commit, got %d", len(commits))
+	}
+	if stats.SkippedOversizeCommits != 1 {
+		t.Errorf("want 1 oversize-skipped, got %d", stats.SkippedOversizeCommits)
+	}
+}
+
+func TestParseGitLog_SkipsEmptyCommit(t *testing.T) {
+	input := strings.NewReader(strings.Join([]string{
+		"__archigraph_commit__:abc",
+		"",
+		"__archigraph_commit__:def",
+		"a.go",
+		"",
+	}, "\n"))
+	stats := &CommitCouplingStats{}
+	commits, err := parseGitLog(input, 100, stats)
+	if err != nil {
+		t.Fatalf("parseGitLog: %v", err)
+	}
+	// Empty commit contributes nothing; single-file commit alone produces
+	// no pairs but is still recorded so total_commits is honest.
+	if len(commits) != 1 {
+		t.Fatalf("want 1 commit, got %d", len(commits))
+	}
+}
+
+func TestBuildSupport_CountsUnorderedPairsOnce(t *testing.T) {
+	commits := []commitRecord{
+		{files: []string{"a", "b", "c"}}, // pairs: (a,b), (a,c), (b,c)
+		{files: []string{"a", "b"}},      // pairs: (a,b)
+		{files: []string{"a", "c"}},      // pairs: (a,c)
+	}
+	support := buildSupport(commits)
+	if got, want := support[pairKey{"a", "b"}], 2; got != want {
+		t.Errorf("support(a,b) = %d, want %d", got, want)
+	}
+	if got, want := support[pairKey{"a", "c"}], 2; got != want {
+		t.Errorf("support(a,c) = %d, want %d", got, want)
+	}
+	if got, want := support[pairKey{"b", "c"}], 1; got != want {
+		t.Errorf("support(b,c) = %d, want %d", got, want)
+	}
+	if len(support) != 3 {
+		t.Errorf("want 3 distinct pairs, got %d", len(support))
+	}
+}
+
+func TestFilterPairs_AppliesThreshold(t *testing.T) {
+	support := map[pairKey]int{
+		{"a", "b"}: 5,
+		{"a", "c"}: 4,
+		{"a", "d"}: 10,
+	}
+	kept := filterPairs(support, 5)
+	if len(kept) != 2 {
+		t.Fatalf("want 2 kept pairs, got %d", len(kept))
+	}
+	// Order is map-iteration dependent — assert by set membership.
+	keys := map[string]int{}
+	for _, p := range kept {
+		keys[p.a+":"+p.b] = p.support
+	}
+	if keys["a:b"] != 5 || keys["a:d"] != 10 {
+		t.Errorf("unexpected kept set: %v", keys)
+	}
+	if _, present := keys["a:c"]; present {
+		t.Errorf("filtered pair leaked through")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// Apply — synthetic doc, no git involvement
+// ──────────────────────────────────────────────────────────────────────────
+
+func TestApplyCommitCoupling_SkipsNonGitRepo(t *testing.T) {
+	dir := t.TempDir()
+	doc := &graph.Document{Repo: "test"}
+	stats := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if !stats.Skipped {
+		t.Fatalf("want Skipped=true, got %+v", stats)
+	}
+	if stats.SkipReason == "" {
+		t.Errorf("want SkipReason populated")
+	}
+	if len(doc.Entities) != 0 || len(doc.Relationships) != 0 {
+		t.Errorf("non-git repo must not mutate document")
+	}
+}
+
+func TestApplyCommitCoupling_NilDoc(t *testing.T) {
+	stats := ApplyCommitCoupling(nil, t.TempDir(), DefaultCommitCouplingConfig())
+	if !stats.Skipped {
+		t.Errorf("nil doc must be skipped")
+	}
+}
+
+// ──────────────────────────────────────────────────────────────────────────
+// End-to-end smoke against a real git fixture
+// ──────────────────────────────────────────────────────────────────────────
+
+// gitAvailable reports whether `git` is on PATH. Tests that need git skip
+// when this returns false.
+func gitAvailable(t *testing.T) bool {
+	t.Helper()
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// makeFixtureRepo creates a git repo at dir and runs the supplied commits.
+// Each commit is described as (files-to-touch, message). Files are created
+// with deterministic content (the commit index) so each commit produces a
+// real diff.
+func makeFixtureRepo(t *testing.T, dir string, commits [][]string) {
+	t.Helper()
+	mustRun := func(args ...string) {
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		// Quiet env so the user's global gitconfig (commit-template, signing)
+		// doesn't break the test.
+		cmd.Env = append(cmd.Environ(),
+			"GIT_AUTHOR_NAME=t",
+			"GIT_AUTHOR_EMAIL=t@example.com",
+			"GIT_COMMITTER_NAME=t",
+			"GIT_COMMITTER_EMAIL=t@example.com",
+		)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v: %s", args, err, out)
+		}
+	}
+	mustRun("init", "-q", "-b", "main")
+	mustRun("config", "commit.gpgsign", "false")
+
+	for i, files := range commits {
+		for _, f := range files {
+			path := filepath.Join(dir, f)
+			if err := writeFile(path, []byte{byte('a' + (i % 26)), '\n'}); err != nil {
+				t.Fatalf("write %s: %v", path, err)
+			}
+			mustRun("add", f)
+		}
+		mustRun("commit", "-q", "-m", "c"+string(rune('0'+i)))
+	}
+}
+
+// writeFile creates path (and parent dirs) and writes content. The test
+// caller varies content per commit so each commit produces a real diff.
+func writeFile(path string, content []byte) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, content, 0o644)
+}
+
+func TestApplyCommitCoupling_EndToEnd(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	// 3 files always changed together in 5 commits → 3 pairs (3 choose 2)
+	// at support=5. One extra unrelated file appears in 2 commits only —
+	// must not produce any edges at MinSupport=5.
+	trio := []string{"a.go", "b.go", "c.go"}
+	commits := [][]string{
+		trio, trio, trio, trio, trio,
+		{"unrelated1.go"},
+		{"unrelated2.go"},
+	}
+
+	dir := t.TempDir()
+	makeFixtureRepo(t, dir, commits)
+
+	doc := &graph.Document{Repo: "fixture"}
+	stats := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if stats.Skipped {
+		t.Fatalf("e2e skipped: %s", stats.SkipReason)
+	}
+	if stats.TotalCommits != 7 {
+		t.Errorf("TotalCommits = %d, want 7", stats.TotalCommits)
+	}
+	if stats.CoupledEdges != 3 {
+		t.Errorf("CoupledEdges = %d, want 3 (3 choose 2 from the trio)", stats.CoupledEdges)
+	}
+	if stats.FileEntities != 3 {
+		t.Errorf("FileEntities = %d, want 3", stats.FileEntities)
+	}
+
+	// Verify edge properties: support should be 5 for each trio pair, and
+	// confidence = 5/7 (~0.7143).
+	fileCount := 0
+	edgeCount := 0
+	for _, e := range doc.Entities {
+		if e.Kind == KindFile {
+			fileCount++
+		}
+	}
+	for _, r := range doc.Relationships {
+		if r.Kind != KindCommitCoupled {
+			continue
+		}
+		edgeCount++
+		if r.Properties["support"] != "5" {
+			t.Errorf("edge %s support=%q, want 5", r.ID, r.Properties["support"])
+		}
+		conf := r.Properties["confidence"]
+		if !strings.HasPrefix(conf, "0.71") {
+			t.Errorf("edge %s confidence=%q, want ~0.7143", r.ID, conf)
+		}
+	}
+	if fileCount != 3 {
+		t.Errorf("File entities in doc = %d, want 3", fileCount)
+	}
+	if edgeCount != 3 {
+		t.Errorf("COMMIT_COUPLED edges in doc = %d, want 3", edgeCount)
+	}
+
+	// Verify the edges are between the right files.
+	want := map[string]bool{
+		"a.go|b.go": false,
+		"a.go|c.go": false,
+		"b.go|c.go": false,
+	}
+	idToName := map[string]string{}
+	for _, e := range doc.Entities {
+		if e.Kind == KindFile {
+			idToName[e.ID] = e.Name
+		}
+	}
+	for _, r := range doc.Relationships {
+		if r.Kind != KindCommitCoupled {
+			continue
+		}
+		a, b := idToName[r.FromID], idToName[r.ToID]
+		if a > b {
+			a, b = b, a
+		}
+		want[a+"|"+b] = true
+	}
+	for k, hit := range want {
+		if !hit {
+			t.Errorf("expected COMMIT_COUPLED edge for %s not emitted", k)
+		}
+	}
+}
+
+func TestApplyCommitCoupling_Idempotent(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	trio := []string{"x", "y", "z"}
+	dir := t.TempDir()
+	makeFixtureRepo(t, dir, [][]string{trio, trio, trio, trio, trio})
+
+	doc := &graph.Document{Repo: "fixture"}
+	first := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	entitiesAfterFirst := len(doc.Entities)
+	relsAfterFirst := len(doc.Relationships)
+
+	second := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if len(doc.Entities) != entitiesAfterFirst {
+		t.Errorf("entities changed on second apply: %d → %d", entitiesAfterFirst, len(doc.Entities))
+	}
+	if len(doc.Relationships) != relsAfterFirst {
+		t.Errorf("relationships changed on second apply: %d → %d", relsAfterFirst, len(doc.Relationships))
+	}
+	if second.CoupledEdges != 0 || second.FileEntities != 0 {
+		t.Errorf("second apply emitted new artifacts: %+v", second)
+	}
+	if first.CoupledEdges != 3 {
+		t.Errorf("first apply edges = %d, want 3", first.CoupledEdges)
+	}
+}
+
+func TestApplyCommitCoupling_RespectsMinSupport(t *testing.T) {
+	if !gitAvailable(t) {
+		t.Skip("git not available")
+	}
+	// Trio in 3 commits — below default MinSupport=5, above MinSupport=2.
+	trio := []string{"p", "q", "r"}
+	dir := t.TempDir()
+	makeFixtureRepo(t, dir, [][]string{trio, trio, trio})
+
+	doc := &graph.Document{Repo: "fixture"}
+	stats := ApplyCommitCoupling(doc, dir, DefaultCommitCouplingConfig())
+	if stats.CoupledEdges != 0 {
+		t.Errorf("MinSupport=5 with 3 co-changes must emit 0 edges, got %d", stats.CoupledEdges)
+	}
+
+	doc2 := &graph.Document{Repo: "fixture"}
+	cfg := DefaultCommitCouplingConfig()
+	cfg.MinSupport = 2
+	stats2 := ApplyCommitCoupling(doc2, dir, cfg)
+	if stats2.CoupledEdges != 3 {
+		t.Errorf("MinSupport=2 with 3 co-changes must emit 3 edges, got %d", stats2.CoupledEdges)
+	}
+}

--- a/internal/engine/commit_coupling_fb_roundtrip_test.go
+++ b/internal/engine/commit_coupling_fb_roundtrip_test.go
@@ -1,0 +1,88 @@
+// Round-trip test for commit-coupling edges through graph.fb.
+//
+// The .fb schema treats Kind as an opaque string (see internal/graph/
+// fbwriter/writer.go: kindOff := b.CreateString(e.Kind) / r.Kind), so a new
+// edge kind needs no schema bump. This test verifies that empirically by
+// writing a Document containing File entities + COMMIT_COUPLED edges to .fb,
+// reading it back via the standard loader, and comparing counts + a sample
+// edge's properties.
+package engine_test
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/engine"
+	"github.com/cajasmota/archigraph/internal/graph"
+	fbwriter "github.com/cajasmota/archigraph/internal/graph/fbwriter"
+)
+
+func TestCommitCoupling_FlatBufferRoundTrip(t *testing.T) {
+	// Hand-build a tiny Document mimicking what ApplyCommitCoupling would
+	// produce — avoids needing a real git fixture in this test.
+	doc := &graph.Document{
+		Repo:    "fixture",
+		Version: graph.SchemaVersion,
+	}
+	aID := graph.EntityID("fixture", engine.KindFile, "a.go", "a.go")
+	bID := graph.EntityID("fixture", engine.KindFile, "b.go", "b.go")
+	doc.Entities = []graph.Entity{
+		{ID: aID, Name: "a.go", Kind: engine.KindFile, SourceFile: "a.go",
+			Properties: map[string]string{"synthetic": "true", "source": "commit-coupling"}},
+		{ID: bID, Name: "b.go", Kind: engine.KindFile, SourceFile: "b.go",
+			Properties: map[string]string{"synthetic": "true", "source": "commit-coupling"}},
+	}
+	relID := graph.RelationshipID(aID, bID, engine.KindCommitCoupled)
+	doc.Relationships = []graph.Relationship{
+		{
+			ID:     relID,
+			FromID: aID,
+			ToID:   bID,
+			Kind:   engine.KindCommitCoupled,
+			Properties: map[string]string{
+				"support":    "7",
+				"confidence": "0.7000",
+			},
+		},
+	}
+	doc.Stats.Entities = len(doc.Entities)
+	doc.Stats.Relationships = len(doc.Relationships)
+
+	dir := t.TempDir()
+	fbPath := filepath.Join(dir, "graph.fb")
+	if err := fbwriter.WriteAtomic(fbPath, doc); err != nil {
+		t.Fatalf("WriteAtomic: %v", err)
+	}
+
+	// LoadGraphFromDir picks graph.fb when present.
+	loaded, err := graph.LoadGraphFromDir(dir)
+	if err != nil {
+		t.Fatalf("LoadGraphFromDir: %v", err)
+	}
+	if len(loaded.Entities) != 2 {
+		t.Fatalf("entities round-tripped: got %d, want 2", len(loaded.Entities))
+	}
+	if len(loaded.Relationships) != 1 {
+		t.Fatalf("relationships round-tripped: got %d, want 1", len(loaded.Relationships))
+	}
+	r := loaded.Relationships[0]
+	if r.Kind != engine.KindCommitCoupled {
+		t.Errorf("kind round-trip: got %q, want %q", r.Kind, engine.KindCommitCoupled)
+	}
+	if r.Properties["support"] != "7" {
+		t.Errorf("support property lost: got %q", r.Properties["support"])
+	}
+	if r.Properties["confidence"] != "0.7000" {
+		t.Errorf("confidence property lost: got %q", r.Properties["confidence"])
+	}
+	// Entity kind round-trip.
+	foundFile := false
+	for _, e := range loaded.Entities {
+		if e.Kind == engine.KindFile {
+			foundFile = true
+		}
+	}
+	if !foundFile {
+		t.Errorf("File entity kind did not survive round-trip")
+	}
+}


### PR DESCRIPTION
## What

New index-time pass that mines `git log --no-merges --name-only` to derive co-change support between file pairs and emits `COMMIT_COUPLED` soft-edges between synthetic `File` entities. Catches logical coupling that static analysis misses (test ↔ module, serializer ↔ viewset, infra ↔ feature, etc.).

Fixes #21.

## Why

Files that change together in commits often share logical coupling that AST-only analysis cannot see. Adding this as an **opt-in soft-edge layer** lets downstream consumers (impact-radius, "what changes with me?" MCP, docs grouping, community detection) read a richer view without changing the default graph topology that Pass 4 algorithms already work on.

## How

- **New pass** at `internal/engine/commit_coupling_edges.go`. Skippable via `--skip-pass=commit-couple` (new `PassCommitCouple` constant).
- **Runs as "Pass 8.5"** — AFTER module-agg, BEFORE enrichment, and crucially AFTER Pass 4 graph algorithms so community/centrality/PageRank are computed on the pre-coupling graph. The new edges are a true soft-edge layer — they do not influence Pass 4 defaults.
- **Algorithm**
  1. Detect git via `git rev-parse --is-inside-work-tree` (handles worktrees + submodules via `.git` files, unlike a `stat .git` check). Non-git repo or missing binary → pass skipped, doc unchanged.
  2. Stream `git log --no-merges --pretty=format:%H --name-only` and group lines into commits. Merge commits skipped (they aggregate unrelated changes and would dominate the support count).
  3. For each commit, enumerate unordered pairs `(i<j)`; `support[pair]++`.
  4. Filter `support >= MinSupport` (default 5).
  5. Emit synthetic `File` entities (`Kind="File"`, `synthetic=true`, `source="commit-coupling"`) + `COMMIT_COUPLED` relationships with `Properties = {support, confidence}` where `confidence = support / total_commits`.
- **Guards** — `MaxFilesPerCommit=200` to skip vendor drops / lockfile mass-updates that would explode pair enumeration; `GitLogTimeout=60s` to cap the subprocess; bufio scanner buffer raised to 1 MiB for long commit lists; idempotent re-apply via ID-set dedup; deterministic ordering (sort within commits, sort kept pairs, lexicographic edge IDs).
- **Schema** — `graph.fb` stores `Kind` as opaque string (`kindOff = b.CreateString(r.Kind)` in `internal/graph/fbwriter/writer.go`) — no `.fb` schema bump required. Verified empirically by a FlatBuffer round-trip test.

## Verification

### Unit + integration tests (11 new, all passing)

```
ok  github.com/cajasmota/archigraph/internal/engine  3.5s
```

- `parseGitLog` — multi-commit / within-commit dedup / oversize-skip / empty-commit
- `buildSupport` — unordered pair counting (a,b),(a,c),(b,c) from one 3-file commit
- `filterPairs` — threshold respected
- `ApplyCommitCoupling` skip paths — nil doc, non-git repo
- **End-to-end** against a tmp git fixture: 3 files in 5 commits → exactly 3 `COMMIT_COUPLED` edges (3-choose-2) with `support=5` and `confidence ~= 0.7143` (5/7 total commits)
- Idempotency — second `ApplyCommitCoupling` on the same doc emits 0 new entities/edges
- `MinSupport` respected — 3 co-changes: 0 edges at default (5), 3 edges at `min=2`
- **FlatBuffer round-trip** — File entities + `COMMIT_COUPLED` edges + their properties (`support`, `confidence`) survive write + read back

### Real-corpus spot-check (upvate_core, 1957 non-merge commits)

Standalone driver (not committed) ran the pass in isolation — no daemon RPC, no `:47274` touched:

```
total_commits:         1957
candidate_pairs:       11455
oversize_skipped:      2
file_entities_emitted: 86
coupled_edges:         217   (MinSupport=5)

top 5 couplings:
  support=65 conf=0.0332  core/routers.py  <->  core/views/__init__.py
  support=37 conf=0.0189  core/serializers/contract_serializer.py  <->  core/views/contract_viewset.py
  support=28 conf=0.0143  core/views/group_viewset.py  <->  core/views/user_viewset.py
  support=28 conf=0.0143  core/serializers/inspection_serializer.py  <->  core/views/inspection_viewset.py
  support=28 conf=0.0143  core/serializers/group_serializer.py  <->  core/views/group_viewset.py
```

Couplings match intuition end-to-end:
- `routers.py` ↔ `views/__init__.py` (every router edit touches the view registry)
- DRF `<thing>_serializer.py` ↔ `<thing>_viewset.py` (textbook serializer/viewset co-evolution)
- `models/contract.py` ↔ `contract_serializer.py` (model change propagates to serializer)

These are exactly the "test files that always change with a module, infra files coupled to features" examples from the spec.

## Files

- `internal/engine/commit_coupling_edges.go` — new pass (algorithm + git mining + emission)
- `internal/engine/commit_coupling_edges_test.go` — unit + end-to-end fixture tests
- `internal/engine/commit_coupling_fb_roundtrip_test.go` — `.fb` schema round-trip
- `cmd/archigraph/index.go` — wire the pass into the orchestrator (Pass 8.5), add `PassCommitCouple` constant + skip-flag entry, verbose log line

## Risk

- **Hot paths untouched** — does not modify the candidate-file walker (`cmd/archigraph/index.go#1629` is in flight elsewhere) or the engine HTTP route extractor area (recently touched by #1648 / #1673).
- **Soft-edge contract preserved** — Pass 4 graph algorithms run BEFORE this pass, so community/centrality/PageRank see the pre-coupling graph exactly as before. Existing consumers that filter `entity.Kind != "Module"` extend naturally to `entity.Kind != "File"` for the same purpose.
- **No `.fb` schema change** — `Kind` is opaque string in the writer; the round-trip test pins this guarantee.
- **Graceful degradation** — non-git repos, missing `git` binary, empty repos, and `git log` failures all return `Skipped=true` with a populated `SkipReason`. Document is never partially mutated.
- **Live `:47274` not restarted** — verification used a one-off driver against `upvate_core`; daemon untouched per standing rule.

🤖 Generated with [Claude Code](https://claude.com/claude-code)