### PR TITLE
[#1689] Wire generate-docs writer passes to emit DocgenRepairCandidate entries

### DIFF
--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -638,7 +638,9 @@ Before any pass commits its output, the writer subagent runs the checks in `snip
 
 ## Docgen Repair Feedback Contract
 
-As each writer pass (Passes 3–6, 12, and 3a) reads source and reasons about the code it is describing, it may discover facts the static extractor missed. When a writer makes such a discovery it **MUST** emit a repair candidate so Fidelity climbs toward 100% over successive runs.
+As each writer pass (Passes 3, 3a, 4, 5, 6, 12, 13, 15, 16, 17, and 18) reads source and reasons about the code it is describing, it may discover facts the static extractor missed. When a writer makes such a discovery it **MUST** emit a repair candidate so Fidelity climbs toward 100% over successive runs.
+
+The full emission procedure — confidence bands, JSONL path, worked examples, and invariants — is in `snippets/docgen-repair-emission.md`. Refer to that snippet; the summary here is for orientation only.
 
 ### When to emit
 
@@ -696,6 +698,7 @@ After applying, `archigraph_stats` now includes `fidelity` (0–1 ratio), `fidel
 
 ## Related
 
+- `skills/generate-docs/snippets/docgen-repair-emission.md` - full emission procedure every writer pass follows; confidence bands, JSONL path, worked examples, and invariants.
 - `skills/extend-convention/SKILL.md` - companion skill for adding a new stack convention.
 - `skills/archigraph-repair/SKILL.md` - standalone repair flow for ad-hoc residual cleanup outside doc generation.
 - ADR-0015 (`docs/adrs/0015-residual-repair-agent-enrichment.md`) - residual repair foundation; powers Passes 1a, 1b, and 3a.

--- a/skills/generate-docs/prompts/03-overview.md
+++ b/skills/generate-docs/prompts/03-overview.md
@@ -52,7 +52,23 @@ Open `output-templates/overview.md`, fill every section, write the result to `~/
 
 Run `snippets/verification-checklist.md`. If any check fails, fix and re-run before moving on.
 
-### Step 6 — Save the result
+### Step 6 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. As you wrote
+the overview you read source files and reasoned about entities — collect any
+observations that qualify as repair candidates (resolved stubs, dynamic
+dispatch targets, mis-classified kinds, external library references). Append
+them to `~/.archigraph/groups/<group>/docgen-repairs.jsonl`, one JSON object
+per line, and record the emission summary line in your pass report.
+
+Common discoveries in this pass:
+- Entry-point files that import modules whose stubs are unresolved in the graph.
+- Cross-repo links whose direction or target is ambiguous in the graph but clear
+  from the source you just read.
+
+Use `source: "generate-docs/pass-3"` in every candidate emitted here.
+
+### Step 7 — Save the result
 
 Call:
 

--- a/skills/generate-docs/prompts/03a-generation-time-repair.md
+++ b/skills/generate-docs/prompts/03a-generation-time-repair.md
@@ -49,11 +49,37 @@ Phase 1 of #732 ships the synchronous in-prose hook. On a 5k-residual graph this
 - Skip the hook for entities whose `from_entity.id` does not appear in the cached residual set — most entities will have zero residuals.
 - Batch-submit is out of scope for Phase 1 (see ADR-0015 risks §3).
 
+## Repair candidate emission (DocgenRepairCandidate)
+
+The Pass 3a hook is also the primary site for **docgen repair emission** per
+`snippets/docgen-repair-emission.md`. The hook's repair submissions go through
+`archigraph_repairs(action=submit)` (the existing channel). But when the hook
+sees facts about an entity that are broader than the residual being acted on —
+for example, while resolving a residual for `OrderService` you notice that a
+_separate_ `UNRESOLVED` stub elsewhere in the subgraph resolves to a visible
+import — emit those broader facts as `DocgenRepairCandidate` entries appended to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+Use `source: "generate-docs/pass-3a"` in all candidates emitted from this hook.
+
+Confidence rules: same as `snippets/docgen-repair-emission.md`. The two
+channels complement each other:
+- `archigraph_repairs(action=submit)` — fixes the residual in the daemon
+  immediately (this pass always did this).
+- `docgen-repairs.jsonl` append — feeds the post-run `archigraph_apply_docgen_repairs`
+  batch for fidelity tracking and for repairs that touch entities outside the
+  current residual set (e.g. kind mis-classifications, external library labels).
+
+Do NOT double-count: if you already submitted a repair via
+`archigraph_repairs(action=submit)`, you MAY also emit the same observation to
+`docgen-repairs.jsonl` — the daemon deduplicates. This lets the fidelity delta
+capture every discovery regardless of which path applied it.
+
 ## Reporting
 
 Writer subagents append a line to their existing pass report:
 
-> `pass-3a hook: <N> entities scanned, <M> residuals seen, <A> auto-repaired, <D> documented as runtime-resolved.`
+> `pass-3a hook: <N> entities scanned, <M> residuals seen, <A> auto-repaired, <D> documented as runtime-resolved, <E> DocgenRepairCandidates emitted.`
 
 The orchestrator aggregates these into the final `repair-sweep.md` under a "Generation-time repairs" section.
 

--- a/skills/generate-docs/prompts/04-cluster.md
+++ b/skills/generate-docs/prompts/04-cluster.md
@@ -113,7 +113,24 @@ If your module references entities owned by another module, link to that module'
 
 Run every check in `snippets/verification-checklist.md`. The orchestrator will reject your output otherwise.
 
-### Step 7 — Save
+### Step 7 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. This pass is
+the richest source of repair candidates because it reads the deepest source
+context (Step 3 pulled source for many entities via `archigraph_get_source`).
+
+Collect every observation made during Steps 1–6:
+- Stubs in the module subgraph that resolved to imports you actually read.
+- Dynamic dispatch sites (event bus, string registries, dependency-injection
+  factories) whose callees you identified from source.
+- Entities in the module whose `kind` contradicts what you saw in source.
+- Outbound edges to well-known external libraries you recognised.
+- Two flows in the module that represent the same workflow under different names.
+
+Append candidates to `~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+Use `source: "generate-docs/pass-4"` in every candidate.
+
+### Step 8 — Save
 
 ```
 archigraph_save_finding(

--- a/skills/generate-docs/prompts/05-reference.md
+++ b/skills/generate-docs/prompts/05-reference.md
@@ -69,9 +69,55 @@ List direct dependencies only (no transitive). For each: name, version pin, purp
 
 Created only if the convention required it. Most repos won't have one.
 
-## Verification & save
+## Verification, repair emission, and save
 
-Run `snippets/verification-checklist.md` after each file. After all six are produced, save:
+Run `snippets/verification-checklist.md` after each file.
+
+After all six files are produced, run the emission step from
+`snippets/docgen-repair-emission.md`. Reference documentation is a strong
+source of the following discovery types:
+
+- **`label_external`** — dependency listing (`dependencies.md`) frequently
+  reveals external library stubs that the graph has not catalogued. For every
+  direct dependency whose stub appears `UNRESOLVED` in the graph, emit a
+  `label_external` candidate at confidence 0.92+ (you are reading the manifest
+  directly).
+
+  Example — from `dependencies.md` for a Node repo:
+
+  ```json
+  {
+    "type": "label_external",
+    "source_entity_id": "<entity id of the unresolved stub>",
+    "target": "ext:stripe",
+    "confidence": 0.93,
+    "evidence": "package.json@line 12: \"stripe\": \"^14.0.0\" — confirmed external SaaS payment library",
+    "source": "generate-docs/pass-5",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`resolve_ref`** — the route listing in `api.md` may name handler functions
+  whose UNRESOLVED stubs become resolvable once you know the file they live in.
+
+  Example — from `api.md` for a Django repo:
+
+  ```json
+  {
+    "type": "resolve_ref",
+    "source_entity_id": "<stub entity id>",
+    "target": "<OrderViewSet entity id>",
+    "confidence": 0.95,
+    "evidence": "urls.py@line 47: path('orders/', OrderViewSet.as_view()) — stub resolved to OrderViewSet in orders/views.py",
+    "source": "generate-docs/pass-5",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+Use `source: "generate-docs/pass-5"` in every candidate. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+Then save:
 
 ```
 archigraph_save_finding(

--- a/skills/generate-docs/prompts/06-cross-cutting.md
+++ b/skills/generate-docs/prompts/06-cross-cutting.md
@@ -78,7 +78,53 @@ directory links).
 
 After all per-repo files for the topic are written, write the group-level aggregator at `~/.archigraph/groups/<group>/cross-cutting/<topic>.md`. The aggregator is short — it points to each repo's page and calls out repo-to-repo divergence.
 
-### Step 6 — Verification
+### Step 6 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. Cross-cutting
+passes cover auth, logging, observability, and error handling — topics that
+routinely expose two discovery types:
+
+- **`resolve_ref` / `add_edge`** — auth middleware and logging utilities are
+  called from many modules; their dynamic-dispatch patterns (decorator
+  registration, middleware chaining, signal hooks) are often invisible to the
+  static extractor.
+
+  Example — from `auth.md` for a Django repo:
+
+  ```json
+  {
+    "type": "add_edge",
+    "source_entity_id": "<JWTAuthMiddleware entity id>",
+    "target": "TokenValidator",
+    "edge_kind": "CALLS",
+    "confidence": 0.85,
+    "evidence": "middleware.py@line 34: self._validator.validate(token) — TokenValidator instantiated in __init__, not visible at call site",
+    "source": "generate-docs/pass-6",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`label_external`** — logging and observability sections frequently name
+  external SDKs (Datadog, Sentry, OpenTelemetry) whose stubs are unresolved.
+
+  Example — from `observability.md`:
+
+  ```json
+  {
+    "type": "label_external",
+    "source_entity_id": "<stub entity id>",
+    "target": "ext:datadog-lambda",
+    "confidence": 0.91,
+    "evidence": "tracing.go@line 9: import \"github.com/datadog/datadog-lambda-go\" — Datadog Lambda tracer SDK",
+    "source": "generate-docs/pass-6",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+Append to `~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+Use `source: "generate-docs/pass-6"` in every candidate.
+
+### Step 7 — Verification
 
 Run `snippets/verification-checklist.md` for each file produced.
 

--- a/skills/generate-docs/prompts/12-pattern-prose.md
+++ b/skills/generate-docs/prompts/12-pattern-prose.md
@@ -83,6 +83,56 @@ For each approved pattern `p` (every pattern with `is_candidate=false`) that was
    - Writes to `<docs_root>/<category>/<id>.md` atomically.
 4. After writing, run `CheckBacktickConvention` on the produced markdown. If violations are reported, fail the pass with the exact heading line — do NOT silently re-write.
 
+## Repair candidate emission
+
+After all pattern docs for this run are written, run the emission step from
+`snippets/docgen-repair-emission.md`. Pattern documentation is a specialised
+source of repair candidates because exemplar resolution (Step 1 of the
+Procedure) reads source files and inspects entity neighborhoods — exactly the
+context that surfaces mis-classifications and unresolved stubs.
+
+Primary discovery types in this pass:
+
+- **`fix_kind`** — exemplar entities are often mis-classified. When you call
+  `archigraph_inspect` on an exemplar and see it is, say, a Kafka topic
+  struct catalogued as `Class`, emit a `fix_kind` candidate.
+
+  Example:
+
+  ```json
+  {
+    "type": "fix_kind",
+    "source_entity_id": "<UserEventTopic entity id>",
+    "new_kind": "MessageTopic",
+    "confidence": 0.90,
+    "evidence": "events/user_event_topic.go@line 3: var UserEventTopic = kafka.Topic{Name: \"user.events\"} — topic definition misclassified as Class",
+    "source": "generate-docs/pass-12",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`merge_flow`** — pattern detection sometimes surfaces two flow entities
+  that represent the same workflow (e.g. a canary variant and a stable variant
+  with the same business outcome). When you see this while building the
+  exemplar table, emit a `merge_flow` candidate.
+
+  Example:
+
+  ```json
+  {
+    "type": "merge_flow",
+    "source_entity_id": "<checkout_flow entity id>",
+    "target": "<checkout_legacy_flow entity id>",
+    "confidence": 0.80,
+    "evidence": "checkout_handler.go@line 71: A/B flag routes to checkout_flow or checkout_legacy_flow — same business outcome, different entry points",
+    "source": "generate-docs/pass-12",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+Use `source: "generate-docs/pass-12"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
 ## Constraints
 
 - DO NOT generate docs for `is_candidate=true` patterns. The renderer skips them; this is a hard invariant.

--- a/skills/generate-docs/prompts/13-enrichment.md
+++ b/skills/generate-docs/prompts/13-enrichment.md
@@ -219,7 +219,62 @@ verify:
 - [ ] For `message_topic`: `summary`, `schema`, `volume_estimate`, `typical_payload_size_bytes`, `expected_consumers`, and `gaps` are all present (needed for `filled_field_count` = 6).
 - [ ] The doc file path is registered in `docgen-state.json` `GeneratedPaths` so the backend can locate it.
 
-### Step 7 — Hand back
+### Step 7 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. Pass 13 reads
+`archigraph_expand` neighborhoods for every entity in the working list; this is
+rich signal for repair candidates.
+
+Primary discovery types in this pass:
+
+- **`fix_kind`** — the enrichment candidate list from `archigraph_enrichments`
+  may contain entities whose graph kind contradicts what you observe. For
+  example, a `process_flow` entity that is actually an `http_endpoint` (a
+  handler with route metadata), or a `message_topic` catalogued as `Class`.
+  Emit a `fix_kind` for each.
+
+  Example:
+
+  ```json
+  {
+    "type": "fix_kind",
+    "source_entity_id": "<entity id>",
+    "new_kind": "http_endpoint",
+    "confidence": 0.88,
+    "evidence": "orders/views.py@line 21: class OrderCreateView(APIView) — has @route decorator; listed as process_flow in graph but is an HTTP endpoint",
+    "source": "generate-docs/pass-13",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`merge_flow`** — Step 3b asks you to decide whether two near-duplicate
+  entities should be merged (`merged_into`). When you make that decision, also
+  emit a `merge_flow` candidate so the graph reflects the merge, not just the
+  enrichment YAML.
+
+  Example:
+
+  ```json
+  {
+    "type": "merge_flow",
+    "source_entity_id": "<redundant entity id>",
+    "target": "<canonical entity id>",
+    "confidence": 0.82,
+    "evidence": "payments/handlers.py@line 55 and line 88 — PaymentCreateView and LegacyPaymentCreateView handle identical POST /payments route; canonical is PaymentCreateView",
+    "source": "generate-docs/pass-13",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`label_external`** — `FETCHES` edges pointing at external URLs (third-party
+  APIs) are often unresolved in the graph. When you document these in
+  `http_endpoint` enrichments (the `caveats` or `examples` sections), emit a
+  `label_external` for the external target.
+
+Use `source: "generate-docs/pass-13"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+### Step 8 — Hand back
 
 Save a finding summarising enrichment coverage:
 

--- a/skills/generate-docs/prompts/15-business-domain.md
+++ b/skills/generate-docs/prompts/15-business-domain.md
@@ -71,7 +71,42 @@ Write headings first, then derive the `anchors:` frontmatter list per
 `snippets/anchor-contract.md`. Put any code/file references ONLY inside the
 collapsed `<details>` provenance block at the bottom.
 
-### Step 5 — Verify + save
+### Step 5 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`, but only for
+observations made while reading the graph — not from business-voice prose.
+
+This pass calls `archigraph_find` against the data model and reads entity
+neighborhoods. The expected repair type here is narrow but high-value:
+
+- **`fix_kind`** — while collapsing code entities into business terms (Step 2),
+  you may notice an entity that the graph catalogued as the wrong kind. For
+  example, a serializer class that is actually a domain model for business
+  purposes (though this is usually a legitimate plumbing entity to discard — use
+  your judgment; only emit if the kind in the graph is factually wrong).
+
+  Example:
+
+  ```json
+  {
+    "type": "fix_kind",
+    "source_entity_id": "<entity id>",
+    "new_kind": "Class",
+    "confidence": 0.85,
+    "evidence": "inspections/models.py@line 8: class Inspection(models.Model) — catalogued as Function in graph; is a Django ORM model class",
+    "source": "generate-docs/pass-15",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+Only emit when the evidence is concrete (you read the source or a graph property
+confirms it). Business-tier reasoning alone does not reach confidence 0.5; skip
+emission for glossary judgments that are purely interpretive.
+
+Use `source: "generate-docs/pass-15"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+### Step 6 — Verify + save
 
 Run `snippets/verification-checklist.md` (business-voice section applies).
 

--- a/skills/generate-docs/prompts/16-business-capabilities.md
+++ b/skills/generate-docs/prompts/16-business-capabilities.md
@@ -66,7 +66,43 @@ Pass 17). Plain language throughout.
 Headings first, then derive `anchors:` per `snippets/anchor-contract.md`. Code
 references only in the collapsed `<details>` block.
 
-### Step 5 — Verify + save
+### Step 5 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. This pass
+calls `archigraph_endpoints` and `archigraph_flows`, which surfaces concrete
+entity data. The expected repair types are:
+
+- **`merge_flow`** — Step 2's clustering often reveals two process-flow or
+  flow entities that represent the same capability. When you collapse multiple
+  flows into one capability, emit a `merge_flow` candidate for the redundant
+  flow entity pointing at the canonical one.
+
+  Example — two checkout flows collapsed into one "Conduct checkout" capability:
+
+  ```json
+  {
+    "type": "merge_flow",
+    "source_entity_id": "<checkout_legacy_flow entity id>",
+    "target": "<checkout_flow entity id>",
+    "confidence": 0.78,
+    "evidence": "archigraph_flows result: checkout_legacy_flow and checkout_flow both terminate at OrderConfirmed — same business outcome, merged into capability 'conduct-checkout'",
+    "source": "generate-docs/pass-16",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`fix_kind`** — `archigraph_endpoints` may return entities that are
+  catalogued as `Function` but are clearly HTTP endpoints (they have a route
+  path and method). Emit a `fix_kind` if you observe this.
+
+Only emit when `archigraph_endpoints` / `archigraph_flows` data or a direct
+`archigraph_expand` result provides concrete evidence. Business-layer
+clustering reasoning alone does not reach the 0.5 threshold.
+
+Use `source: "generate-docs/pass-16"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+### Step 6 — Verify + save
 
 Run `snippets/verification-checklist.md`. Then once, for the capability set:
 

--- a/skills/generate-docs/prompts/17-business-journeys.md
+++ b/skills/generate-docs/prompts/17-business-journeys.md
@@ -69,7 +69,40 @@ business-only labels. Otherwise omit. NEVER a `sequenceDiagram`.
 Headings first, derive `anchors:` per `snippets/anchor-contract.md`. Symbols and
 file paths ONLY in the collapsed `<details>` block.
 
-### Step 5 — Verify + save
+### Step 5 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. This pass
+calls `archigraph_flows`, `archigraph_traces`, and `archigraph_cross_links`.
+The expected repair types here are narrow:
+
+- **`merge_flow`** — Step 1 may reveal two flow entities returned by
+  `archigraph_flows` that represent legs of the same end-to-end journey (e.g.
+  `sync_to_office_flow` and `offline_sync_flow` are the same flow triggered
+  from two contexts). Emit a `merge_flow` only when the evidence from
+  `archigraph_traces` or `archigraph_cross_links` makes the identity
+  unambiguous (confidence ≥ 0.75).
+
+  Example:
+
+  ```json
+  {
+    "type": "merge_flow",
+    "source_entity_id": "<offline_sync_flow entity id>",
+    "target": "<sync_to_office_flow entity id>",
+    "confidence": 0.76,
+    "evidence": "archigraph_traces result: offline_sync_flow and sync_to_office_flow share identical call chain terminating at SyncService.commit — same business journey, different connectivity contexts",
+    "source": "generate-docs/pass-17",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+Do not emit candidates derived purely from business-narrative reasoning.
+Cross-link and trace data must back any emission.
+
+Use `source: "generate-docs/pass-17"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+### Step 6 — Verify + save
 
 Run `snippets/verification-checklist.md`. Then:
 

--- a/skills/generate-docs/prompts/18-business-rules.md
+++ b/skills/generate-docs/prompts/18-business-rules.md
@@ -66,7 +66,43 @@ Headings first, derive `anchors:` per `snippets/anchor-contract.md`. The
 capability pages forward-link to specific rule anchors, so name your rule
 headings clearly and stably. File/symbol references ONLY in `<details>`.
 
-### Step 4 — Verify + save
+### Step 4 — Emit repair candidates
+
+Run the emission step from `snippets/docgen-repair-emission.md`. This pass's
+`archigraph_find` queries on validation, permission checks, and state
+transitions produce graph data that may surface repair candidates — specifically:
+
+- **`add_edge`** — permission checks often call a shared auth/permission
+  utility whose edge to the validation logic is dynamic (decorator-based,
+  mixin-based). If you can identify the concrete callee from source context
+  while mining validation rules, emit an `add_edge`.
+
+  Example:
+
+  ```json
+  {
+    "type": "add_edge",
+    "source_entity_id": "<InspectionSubmitView entity id>",
+    "target": "IsInspectorPermission",
+    "edge_kind": "CALLS",
+    "confidence": 0.80,
+    "evidence": "inspections/views.py@line 14: permission_classes = [IsInspectorPermission] — decorator permission not captured as a CALLS edge in graph",
+    "source": "generate-docs/pass-18",
+    "emitted_at": "<ISO 8601 timestamp>"
+  }
+  ```
+
+- **`fix_kind`** — state-machine queries sometimes surface entities that are
+  mis-classified (e.g. a status enum catalogued as `Function`).
+
+Only emit when `archigraph_find` returned an entity that you then inspected
+closely enough to have concrete file-level evidence. Business rule translation
+itself is not evidence.
+
+Use `source: "generate-docs/pass-18"` in all candidates. Append to
+`~/.archigraph/groups/<group>/docgen-repairs.jsonl`.
+
+### Step 5 — Verify + save
 
 Run `snippets/verification-checklist.md`. Then:
 

--- a/skills/generate-docs/snippets/docgen-repair-emission.md
+++ b/skills/generate-docs/snippets/docgen-repair-emission.md
@@ -1,0 +1,215 @@
+# Docgen Repair Emission — shared writer contract
+
+Every writer pass (Passes 3, 4, 5, 6, 12, and 3a) MUST run this emission step
+after its main doc output is produced. Do not skip, even when no candidates are
+found — the zero-candidate case is the common case and costs nothing.
+
+## When to collect a candidate
+
+As you reason over source code and graph data to write the doc, note any of the
+following observations in a running candidate list:
+
+| Observation | Repair type |
+|-------------|-------------|
+| An `UNRESOLVED` stub that matches a real entity you just read (import, class definition, function) | `resolve_ref` |
+| A dynamic call site whose callee you can identify from context (string registry, event bus dispatch, factory pattern) | `add_edge` |
+| An entity whose `kind` is clearly wrong (e.g. a class catalogued as `Function`, a topic catalogued as `Class`) | `fix_kind` |
+| A stub that resolves to a well-known external library / SaaS API (e.g. `stripe`, `aws-sdk`, `sendgrid`) | `label_external` |
+| Two flow entities that represent the same business workflow with different entry points | `merge_flow` |
+
+## Confidence rules
+
+Use these levels — never fabricate certainty:
+
+| Confidence | Meaning |
+|------------|---------|
+| `0.9–1.0` | Agent READ the source file AND saw the literal target (e.g. import statement, function definition, explicit assignment). Only use this band when the evidence is unambiguous. |
+| `0.7–0.8` | Agent has strong contextual evidence (type signature, docstring, or call convention strongly implies the target) but did not see the literal binding. |
+| `0.5–0.7` | Pattern-matched or inferred from naming convention and structure. Plausible but not confirmed. |
+| Below 0.5 | Do not emit. Let the static extractor own it. |
+
+## Emission procedure
+
+After the doc is written (AFTER — do not interrupt prose generation):
+
+1. For each collected observation, produce one JSON object per line and append
+   to the JSONL file:
+
+   ```
+   ~/.archigraph/groups/<group>/docgen-repairs.jsonl
+   ```
+
+   To obtain the exact path, call `archigraph_apply_docgen_repairs` with no
+   parameters and read the `state_dir` field, or use the path recorded in
+   `docgen-state.json`.
+
+2. Record shape (all fields are described in SKILL.md § "Docgen Repair Feedback
+   Contract"; reproduce the exact schema below for reference):
+
+   ```json
+   {
+     "type": "resolve_ref | add_edge | fix_kind | label_external | merge_flow",
+     "source_entity_id": "<hex entity id>",
+     "target": "<target id, qualified name, or ext:<module>>",
+     "edge_kind": "CALLS",
+     "new_kind": "Service",
+     "confidence": 0.9,
+     "evidence": "<file.go>@line N: <one-line observation>",
+     "source": "generate-docs/pass-N",
+     "emitted_at": "<ISO 8601 timestamp>"
+   }
+   ```
+
+   Field rules:
+   - `type` — always required; one of the five types above.
+   - `source_entity_id` — always required; the entity the repair targets.
+   - `target` — required for all types except `fix_kind`; a resolved entity id,
+     qualified name, or `ext:<module>` for externals.
+   - `edge_kind` — required only for `add_edge`; e.g. `CALLS`, `IMPORTS`,
+     `SUBSCRIBES_TO`.
+   - `new_kind` — required only for `fix_kind`; the replacement Kind string.
+   - `confidence` — always required; float in [0.5, 1.0] (below 0.5 → don't
+     emit at all).
+   - `evidence` — always required; format: `"<file>@line N: <observation>"`.
+     One line only — no multi-line strings. Must be citable.
+   - `source` — optional but strongly recommended; set to the pass name so the
+     audit trail is readable (e.g. `"generate-docs/pass-3"`,
+     `"generate-docs/pass-4"`, `"generate-docs/pass-3a"`).
+   - `emitted_at` — ISO 8601 UTC timestamp of when the observation was made.
+
+3. If zero candidates were collected during this pass, skip the file append
+   entirely (do not write an empty line).
+
+4. At the end of the pass report, append one line:
+
+   > `repair-emission: <N> candidates emitted to docgen-repairs.jsonl (<M> resolve_ref, <K> add_edge, <J> fix_kind, <L> label_external, <O> merge_flow).`
+
+   If zero: `repair-emission: 0 candidates — no new discoveries this pass.`
+
+## Worked examples
+
+### Example A — resolve_ref (confidence 0.95)
+
+Writer is documenting `OrderService` in Pass 4. It calls
+`archigraph_get_source(node_id=<OrderService id>)` and reads:
+
+```go
+// order_service.go@line 8
+import "github.com/example/app/internal/billing"
+```
+
+The graph shows `OrderService` has an `UNRESOLVED` outbound edge to the stub
+`billing`. The writer recognises this is `BillingService` in the `billing`
+package (`entity_id = a3f9...`). Emission:
+
+```json
+{
+  "type": "resolve_ref",
+  "source_entity_id": "8b2c4d...",
+  "target": "a3f9...",
+  "confidence": 0.95,
+  "evidence": "order_service.go@line 8: import \"github.com/example/app/internal/billing\" — stub resolves to BillingService",
+  "source": "generate-docs/pass-4",
+  "emitted_at": "2026-05-23T14:00:00Z"
+}
+```
+
+### Example B — label_external (confidence 0.92)
+
+Writer is documenting `EmailNotifier` in Pass 6. Source shows:
+
+```python
+# notifier.py@line 14
+import sendgrid
+```
+
+The graph has an `UNRESOLVED` stub for `sendgrid`. Emission:
+
+```json
+{
+  "type": "label_external",
+  "source_entity_id": "c7d1e2...",
+  "target": "ext:sendgrid",
+  "confidence": 0.92,
+  "evidence": "notifier.py@line 14: import sendgrid — well-known external SaaS email API",
+  "source": "generate-docs/pass-6",
+  "emitted_at": "2026-05-23T14:00:00Z"
+}
+```
+
+### Example C — add_edge (confidence 0.75)
+
+Writer is documenting `TaskDispatcher` in Pass 4. Source shows a string-keyed
+registry dispatch:
+
+```python
+# dispatcher.py@line 42
+handler = self._registry.get(event.type)   # "payment.completed" → PaymentHandler
+```
+
+The graph has no edge from `TaskDispatcher` to `PaymentHandler`. The writer
+infers the mapping from a comment but did not read the registry initialiser.
+Confidence is 0.75 (contextual, not literal). Emission:
+
+```json
+{
+  "type": "add_edge",
+  "source_entity_id": "d4a9c0...",
+  "target": "PaymentHandler",
+  "edge_kind": "CALLS",
+  "confidence": 0.75,
+  "evidence": "dispatcher.py@line 42: string registry dispatch — comment names PaymentHandler as handler for payment.completed",
+  "source": "generate-docs/pass-4",
+  "emitted_at": "2026-05-23T14:01:00Z"
+}
+```
+
+### Example D — fix_kind (confidence 0.90)
+
+Writer is documenting `UserEventTopic` in Pass 12. The entity is catalogued as
+kind `Class` but the source file shows it is a Kafka topic config struct, not a
+class. Emission:
+
+```json
+{
+  "type": "fix_kind",
+  "source_entity_id": "f1b3a7...",
+  "new_kind": "MessageTopic",
+  "confidence": 0.90,
+  "evidence": "events/user_event_topic.go@line 3: var UserEventTopic = kafka.Topic{Name: \"user.events\"} — this is a Kafka topic definition, not a class",
+  "source": "generate-docs/pass-12",
+  "emitted_at": "2026-05-23T14:02:00Z"
+}
+```
+
+### Example E — merge_flow (confidence 0.80)
+
+Writer is documenting flows in Pass 4 and notices two process-flow entities
+`checkout_flow` and `checkout_legacy_flow` that both describe the same checkout
+business workflow, distinguished only by an A/B flag at entry. Emission:
+
+```json
+{
+  "type": "merge_flow",
+  "source_entity_id": "e9c2f5...",
+  "target": "a1b4d8...",
+  "confidence": 0.80,
+  "evidence": "checkout_handler.go@line 71: ab_flag routes to checkout_flow or checkout_legacy_flow — same business workflow, same terminal state",
+  "source": "generate-docs/pass-4",
+  "emitted_at": "2026-05-23T14:03:00Z"
+}
+```
+
+## Invariants
+
+- Only one candidate per distinct observation — do not emit the same
+  `(source_entity_id, type, target)` triple twice in one pass.
+- Never emit below confidence 0.5. If you are not sure, use the Pass 3a
+  "Runtime-resolved edge" callout in prose instead.
+- Emission is additive: if the same repair was already submitted by Pass 1a or
+  Pass 3a via `archigraph_repairs(action=submit)`, the daemon deduplicates; you
+  may still emit it here — the duplicate will be silently dropped.
+- The JSONL file may already contain entries from a prior pass or a prior run;
+  always append, never overwrite.
+- Evidence must be a single line. Multi-line evidence will fail
+  `DocgenRepairCandidate.Validate()`.


### PR DESCRIPTION
## Why

\#1682 shipped the `DocgenRepairCandidate` schema, the `docgen-repairs.jsonl` apply path, the `archigraph_apply_docgen_repairs` MCP tool, and fidelity tracking. The contract is documented in `SKILL.md § "Docgen Repair Feedback Contract"`. But the writer-pass prompts were never updated to actually emit candidates. Without that the feedback loop never closes: docgen produces docs and the graph never improves.

## What changed

**New shared snippet** — `skills/generate-docs/snippets/docgen-repair-emission.md`

The single source of truth for the emission procedure: confidence bands, the JSONL append step, the full record schema, five worked examples (one per repair type), and invariants. All writer passes reference this snippet rather than duplicating the contract.

**Updated writer passes** — all files in `skills/generate-docs/prompts/`

Each pass received an "Emit repair candidates" step inserted after the doc-writing step and before the save/hand-back step. The step is tailored to the discovery types realistic for that pass:

| Pass | Step added | Primary discovery types |
|------|-----------|------------------------|
| 03 overview | Step 6 | `resolve_ref`, cross-repo edge discoveries |
| 03a (hook) | New § "Repair candidate emission" | broader observations beyond the current residual; dual-channel with `archigraph_repairs(action=submit)` |
| 04 cluster | Step 7 | all five types — richest source pass |
| 05 reference | Added to "Verification & save" | `label_external` from deps manifest, `resolve_ref` from route listing |
| 06 cross-cutting | Step 6 | `add_edge` (middleware/decorator chains), `label_external` (observability SDKs) |
| 12 pattern prose | New § "Repair candidate emission" | `fix_kind` (exemplar mis-class), `merge_flow` |
| 13 enrichment | Step 7 | `fix_kind`, `merge_flow`, `label_external` |
| 15 business domain | Step 5 | `fix_kind` only — guarded; business reasoning alone ≠ confidence ≥ 0.5 |
| 16 capabilities | Step 5 | `merge_flow`, `fix_kind` from `archigraph_endpoints` |
| 17 journeys | Step 5 | `merge_flow` from trace/cross-link data |
| 18 business rules | Step 4 | `add_edge` (permission decorators), `fix_kind` |

Pass 19 (business overview) is intentionally excluded — it reads no source and does no entity inspection.

**SKILL.md** — updated the contract section header to list all 11 passes and pointer to the new snippet in `## Related`.

## Confidence rule (documented in the snippet, enforced per-pass)

| Band | Meaning |
|------|---------|
| 0.9–1.0 | Agent read source AND saw the literal target |
| 0.7–0.8 | Strong contextual evidence (type sig, docstring, convention) |
| 0.5–0.7 | Pattern-matched / inferred |
| Below 0.5 | Do not emit |

## Verify (design dry-walk)

For each updated prompt: a writer following it would produce at least one syntactically valid JSONL entry for a common discovery type. The worked examples in the snippet and in each per-pass emission section show the exact emission shape the `DocgenRepairCandidate.Validate()` contract requires.

No Go code was touched. No `internal/` files. Prompts only.

## Test plan

- [ ] Read `snippets/docgen-repair-emission.md` and confirm it matches the schema in `SKILL.md § "Docgen Repair Feedback Contract"`.
- [ ] For each updated prompt, follow the "Emit repair candidates" step and confirm a valid JSONL object would be produced for at least one example type.
- [ ] Confirm Pass 19 has no emission step (correct — it reads no source).
- [ ] Run `/generate-docs` on a test group; after the run call `archigraph_apply_docgen_repairs`; verify `fidelity_delta` is nonzero.

Fixes #1689

🤖 Generated with [Claude Code](https://claude.com/claude-code)