### PR TITLE
[#1678] fix(mcp): bound get_source file I/O with a deadline; pre-dispatch RPC log

### DIFF
--- a/internal/daemon/mcp_rpc.go
+++ b/internal/daemon/mcp_rpc.go
@@ -157,16 +157,24 @@ func (s *Service) MCPToolCall(args *MCPToolCallArgs, reply *MCPToolCallReply) er
 		return nil
 	}
 
+	// #1678: emit a "received" log line BEFORE dispatching so a hung handler
+	// still leaves a trace in daemon.log. The original "elapsed=Xms" line only
+	// fired after mcpCallTool returned, which made hangs invisible (the call
+	// looked like it had never reached the dispatcher).
+	repoLabel := args.CWD
+	if repoLabel == "" {
+		repoLabel = "(cwd not provided)"
+	}
+	if s.logger != nil {
+		s.logger.Printf("[mcp-rpc] tool=%s received repo=%s", args.Name, repoLabel)
+	}
+
 	start := time.Now()
 	result, err := s.mcpCallTool(args.Name, args.Arguments, args.CWD)
 	elapsed := time.Since(start)
 
 	// Debug log: tool=name elapsed=Xms repo=Y (from CWD when available)
 	if s.logger != nil {
-		repoLabel := args.CWD
-		if repoLabel == "" {
-			repoLabel = "(cwd not provided)"
-		}
 		s.logger.Printf("[mcp-rpc] tool=%s elapsed=%dms repo=%s", args.Name, elapsed.Milliseconds(), repoLabel)
 	}
 

--- a/internal/mcp/get_source_timeout_test.go
+++ b/internal/mcp/get_source_timeout_test.go
@@ -1,0 +1,193 @@
+// get_source_timeout_test.go — #1678 regression coverage.
+//
+// Background: real MCP calls to archigraph_get_source against the live daemon
+// were observed to hang indefinitely. SIGQUIT goroutine dumps showed multiple
+// in-flight calls all stuck inside os.Open at internal/mcp/tools.go (the
+// open(2) syscall blocked in kernel for source-file paths that opened fine
+// from a fresh process). Because the bridge (#1671/#1677) reuses a single
+// jsonrpc.Client across an MCP session, one hung Open serializes every
+// subsequent tool call too.
+//
+// Fix: the handler now performs file I/O on a worker goroutine and selects on
+// a context deadline (5s). A stuck Open surfaces as a tool error instead of
+// wedging the bridge.
+//
+// These tests exercise both the success path (verifies refactor preserves the
+// existing output shape — windowed snippet, hard-cap, formatted lines) and
+// the timeout path (verifies a slow-Open scenario returns a clean error
+// instead of hanging the test).
+package mcp
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// TestGetSource_ReturnsWindowedSnippet — happy path: an entity with a real
+// source file on disk gets a clamped, formatted window back.
+func TestGetSource_ReturnsWindowedSnippet(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "sample.go")
+	lines := []string{
+		"package sample",            // 1
+		"",                          // 2
+		"func Foo() {",              // 3
+		"\tprintln(\"in Foo\")",     // 4
+		"}",                         // 5
+		"",                          // 6
+		"func Bar() {",              // 7
+		"\tprintln(\"in Bar\")",     // 8
+		"}",                         // 9
+		"",                          // 10
+	}
+	if err := os.WriteFile(srcPath, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "foo", Name: "Foo", Kind: "Function", SourceFile: "sample.go", StartLine: 3, EndLine: 5},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	// Repoint the test repo at our temp dir.
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "node_id": "foo", "context_lines": 1}
+
+	res, err := srv.handleGetNodeSource(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	tc, ok := res.Content[0].(mcpapi.TextContent)
+	if !ok {
+		t.Fatalf("expected TextContent, got %T", res.Content[0])
+	}
+	// With context_lines=1, expect lines 2..6 (inclusive) — 5 numbered lines.
+	if !strings.Contains(tc.Text, "    3  func Foo()") {
+		t.Errorf("expected line 3 (Foo) in output, got:\n%s", tc.Text)
+	}
+	if strings.Contains(tc.Text, "    1  package sample") {
+		t.Errorf("did not expect line 1 in output (context_lines=1, start=3), got:\n%s", tc.Text)
+	}
+	if strings.Contains(tc.Text, "    7  func Bar()") {
+		t.Errorf("did not expect line 7 in output (context_lines=1, end=5), got:\n%s", tc.Text)
+	}
+}
+
+// TestGetSource_TimesOutOnStuckOpen — covers the #1678 hang fix end-to-end.
+// We point the entity at a POSIX FIFO whose writer never connects; os.Open on
+// the read side of a FIFO blocks indefinitely until a writer opens it. Before
+// the fix the handler would never return. After the fix the context deadline
+// fires (or, when the caller's own context cancels, that wins) and the
+// handler returns a clean tool-error result within a bounded interval.
+//
+// To keep CI fast we override the handler's internal 5s deadline by passing a
+// caller context that we cancel after 500ms — the handler's select picks up
+// whichever deadline fires first.
+func TestGetSource_TimesOutOnStuckOpen(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("FIFO test requires POSIX mkfifo; skipping on windows")
+	}
+	dir := t.TempDir()
+	fifoPath := filepath.Join(dir, "stuck.fifo")
+	if err := syscall.Mkfifo(fifoPath, 0o600); err != nil {
+		t.Fatalf("mkfifo: %v", err)
+	}
+
+	doc := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "stuck", Name: "Stuck", Kind: "Function", SourceFile: "stuck.fifo", StartLine: 1, EndLine: 1},
+		},
+	}
+	srv := newTestServerWithDoc(t, doc)
+	srv.State.groups["test"].Repos["repo1"].Path = dir
+
+	// Caller cancels at 500ms — well under the handler's 5s internal deadline.
+	// Whichever fires first, the handler MUST return promptly.
+	ctx, cancel := context.WithTimeout(context.Background(), 500*time.Millisecond)
+	defer cancel()
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{"group": "test", "node_id": "stuck"}
+
+	type out struct {
+		res *mcpapi.CallToolResult
+		err error
+	}
+	resCh := make(chan out, 1)
+	start := time.Now()
+	go func() {
+		res, err := srv.handleGetNodeSource(ctx, req)
+		resCh <- out{res: res, err: err}
+	}()
+
+	select {
+	case got := <-resCh:
+		elapsed := time.Since(start)
+		// The handler must return well before the FIFO ever unblocks (which
+		// would need a writer to connect — nothing does). Anything under
+		// ~5.5s is acceptable; in practice the caller-context cancel fires at
+		// ~500ms and we return shortly after.
+		if elapsed > 5500*time.Millisecond {
+			t.Fatalf("handler returned but took too long: %v", elapsed)
+		}
+		if got.err != nil {
+			t.Fatalf("handler returned go error: %v", got.err)
+		}
+		if got.res == nil || !got.res.IsError {
+			t.Fatalf("expected an isError result describing the timeout, got: %+v", got.res)
+		}
+		tc, _ := got.res.Content[0].(mcpapi.TextContent)
+		if !strings.Contains(tc.Text, "timed out") {
+			t.Errorf("expected 'timed out' in error message, got: %s", tc.Text)
+		}
+		t.Logf("handler returned timeout error after %v: %s", elapsed, tc.Text)
+	case <-time.After(7 * time.Second):
+		// Open never released the goroutine; the bug is back.
+		buf := make([]byte, 1<<14)
+		n := runtime.Stack(buf, true)
+		t.Fatalf("handler did not return within 7s — fix regression\nstacks:\n%s", buf[:n])
+	}
+}
+
+// TestReadSourceWindow_FormatsLines — direct unit test on the extracted
+// readSourceWindow helper. Locks down the line-number formatting and bounds.
+func TestReadSourceWindow_FormatsLines(t *testing.T) {
+	dir := t.TempDir()
+	srcPath := filepath.Join(dir, "tiny.go")
+	if err := os.WriteFile(srcPath, []byte("aaa\nbbb\nccc\nddd\neee\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	out, err := readSourceWindow(srcPath, 2, 4)
+	if err != nil {
+		t.Fatalf("readSourceWindow: %v", err)
+	}
+	want := "    2  bbb\n    3  ccc\n    4  ddd\n"
+	if out != want {
+		t.Errorf("readSourceWindow mismatch:\ngot:  %q\nwant: %q", out, want)
+	}
+}
+
+// TestReadSourceWindow_MissingFile — error path: a non-existent path returns
+// the os.Open error, not a panic. Important because the daemon stores
+// SourceFile strings that may be stale after a repo file is deleted.
+func TestReadSourceWindow_MissingFile(t *testing.T) {
+	_, err := readSourceWindow(filepath.Join(t.TempDir(), "no-such-file.go"), 1, 5)
+	if err == nil {
+		t.Fatal("expected error for missing file, got nil")
+	}
+}

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1063,13 +1063,6 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	if !filepath.IsAbs(abs) && lr.Path != "" {
 		abs = filepath.Join(lr.Path, e.SourceFile)
 	}
-	f, err := os.Open(abs)
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
-	}
-	defer f.Close()
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 64*1024*1024)
 
 	// Bound the requested span (#1614). Synthetic / shadow / route entities
 	// frequently carry end_line<=start_line or start_line==0, which previously
@@ -1098,6 +1091,57 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 	if end-start+1 > hardMaxLines {
 		end = start + hardMaxLines - 1
 	}
+
+	// #1678: bound the file I/O with a hard deadline. The daemon owns fsnotify
+	// watchers on every indexed source tree; under certain macOS conditions a
+	// raw open(2) on a watched-but-otherwise-normal file has been observed to
+	// block indefinitely inside the kernel — the original handler had no
+	// timeout, so a single stuck Open wedged the entire MCP session (the
+	// shared bridge jsonrpc.Client serializes calls per #1671/#1677). Running
+	// the read on a worker goroutine and select-ing on a context deadline lets
+	// the handler return a clean error instead of hanging the bridge.
+	//
+	// Budget: 5s is generous for any local file but short enough that a
+	// genuine kernel/FS stall surfaces as a real error the caller can retry
+	// or route around.
+	readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
+	defer readCancel()
+
+	type readOut struct {
+		text string
+		err  error
+	}
+	resCh := make(chan readOut, 1)
+	go func() {
+		text, rerr := readSourceWindow(abs, start, end)
+		resCh <- readOut{text: text, err: rerr}
+	}()
+
+	select {
+	case out := <-resCh:
+		if out.err != nil {
+			return mcpapi.NewToolResultError(out.err.Error()), nil
+		}
+		return mcpapi.NewToolResultText(out.text), nil
+	case <-readCtx.Done():
+		return mcpapi.NewToolResultError(fmt.Sprintf(
+			"get_source: read timed out after 5s on %s (file may be on a stalled filesystem or watched-path kernel stall); node_id=%s",
+			abs, nodeID,
+		)), nil
+	}
+}
+
+// readSourceWindow opens path, scans lines [start,end] (1-indexed inclusive),
+// and returns the formatted text. Split out so handleGetNodeSource can run
+// the call on a worker goroutine bounded by a context deadline (#1678).
+func readSourceWindow(path string, start, end int) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 64*1024*1024)
 	var b strings.Builder
 	line := 0
 	for scanner.Scan() {
@@ -1110,7 +1154,10 @@ func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolReq
 		}
 		b.WriteString(fmt.Sprintf("%5d  %s\n", line, scanner.Text()))
 	}
-	return mcpapi.NewToolResultText(b.String()), nil
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return b.String(), nil
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #1678

## 1. Context

`archigraph_get_source` is the agent-facing tool that returns a windowed
source snippet for an indexed entity. It is the **only** MCP tool that
performs synchronous filesystem I/O on a path read from the graph — every
other tool serves results from the in-memory document. The daemon also owns
fsnotify watchers on every indexed source tree (the `watcher: registered
repo=...` lines you see in `daemon.log`).

Real calls from Claude Code go through `archigraph mcp-bridge` → unix socket
→ `Daemon.MCPToolCall` RPC → `*mcp.Server` handler. Since #1671/#1677 the
bridge reuses a single `jsonrpc.Client` for the whole MCP session, so
`net/rpc` serializes every call on that client.

## 2. Problem

`archigraph_get_source` hangs indefinitely against the live daemon while
every other tool returns in single-digit milliseconds. Subsequent tool calls
from the same session pile up behind it (shared client) and the agent sees a
frozen MCP surface. The post-dispatch `[mcp-rpc] tool=X elapsed=Yms` log line
never fires for the hung call, so historically the call looked like it had
never reached the daemon.

## 3. Root cause

Both the live (~9 min old) daemon AND a freshly-restarted daemon were
SIGQUIT'd and the goroutine dumps showed multiple in-flight callers stuck in
the same place:

```
syscall.Open(...)                          /usr/local/go/.../syscall_darwin.go
os.openFileNolog → os.OpenFile → os.Open   /usr/local/go/.../os/file.go:390
mcp.(*Server).handleGetNodeSource          internal/mcp/tools.go:1066
mcp.(*Server).registerTools.wrap.func12    internal/mcp/server.go:469
main.daemonMCPCallTool                     cmd/archigraph/daemon_mcp_rpc.go:134
daemon.(*Service).MCPToolCall              internal/daemon/mcp_rpc.go:161
net/rpc.(*service).call                    net/rpc/server.go:383
```

The raw `open(2)` syscall on a normal local source file (e.g.
`users_auth/views.py`) **blocks indefinitely inside the kernel** when invoked
from the long-running daemon, even though a fresh process opens the same
path in ~0.5 ms. The most plausible cause is a macOS fsevents /
watched-path kernel-state issue with the daemon's own fsnotify watchers; the
specific trigger has been documented across multiple Go/macOS reports.

The handler had **no timeout** on the I/O — `os.Open(abs)` directly, no
context, no goroutine, no deadline. There was no way for the bridge or the
agent to recover short of killing the daemon.

## 4. Fix

### 4a. Bound the file I/O — `internal/mcp/tools.go`

`handleGetNodeSource` now runs the file open + scan on a worker goroutine
and selects on a `context.WithTimeout(ctx, 5*time.Second)`. If the read does
not complete, the handler returns a structured `NewToolResultError`
describing the timeout and the offending path instead of blocking forever.

```go
readCtx, readCancel := context.WithTimeout(ctx, 5*time.Second)
defer readCancel()
resCh := make(chan readOut, 1)
go func() { ... resCh <- readOut{text, err} }()
select {
case out := <-resCh:        // happy path or open-error
    ...
case <-readCtx.Done():       // bounded: 5 s OR caller-context cancel
    return mcpapi.NewToolResultError("get_source: read timed out after 5s on " + abs + ...), nil
}
```

The existing window-clamping logic (#1614 fallback span, hardMaxLines cap,
context_lines budget) is preserved exactly; the only behavioural change is
the deadline. The read body is extracted to `readSourceWindow(path, start,
end)` so the worker goroutine has a clean entry point.

### 4b. Pre-dispatch RPC log — `internal/daemon/mcp_rpc.go`

`MCPToolCall` now logs the tool name **before** dispatching, in addition to
the existing post-dispatch `elapsed=Xms` line. The previous log fired only
after the handler returned, so a hung tool was invisible.

```
[mcp-rpc] tool=archigraph_get_source received repo=...
[mcp-rpc] tool=archigraph_get_source elapsed=4ms repo=...
```

A `received` without a matching `elapsed` is now an immediate signal that a
specific handler is stalled.

### 4c. Regression tests — `internal/mcp/get_source_timeout_test.go`

Four unit tests:

- `TestGetSource_ReturnsWindowedSnippet` — locks the formatted output for the
  happy path so the refactor cannot silently change the wire shape
  (line-number prefix, context_lines window, start/end bounds).
- `TestGetSource_TimesOutOnStuckOpen` — POSIX FIFO regression: points an
  entity at a FIFO with no writer (where `os.Open` blocks until a writer
  connects), calls `handleGetNodeSource` with a 500 ms caller context, and
  asserts the handler returns within 5.5 s with `isError=true` and a "timed
  out" message. **Without the fix this test would never return**; with the
  fix it passes in ~501 ms.
- `TestReadSourceWindow_FormatsLines` — direct test of the extracted helper.
- `TestReadSourceWindow_MissingFile` — error path: missing file surfaces the
  `os.Open` error without panicking. Important because the daemon's stored
  `SourceFile` can be stale after a repo file is deleted.

## 5. Verification

- `go test ./internal/mcp/... ./internal/daemon/... ./internal/cli/...` — all green.
- `go vet ./...` — clean.
- New `TestGetSource_TimesOutOnStuckOpen` passes in ~501 ms (FIFO would
  otherwise block forever).
- Local reproduction against an isolated daemon (`ARCHIGRAPH_DAEMON_ROOT`)
  with this fix returns `get_source` results — or a clean error — in
  <100 ms instead of hanging.
- The pre-existing `TestModuleCoverage_AllEntitiesTagged` test in
  `cmd/archigraph` fails on both `main` and this branch and is unrelated to
  this change (module-tagging coverage debt; documented in pre-existing
  test-failure list).

## 6. Risks

- **5 s is a hard wall on legitimate large reads.** The hard cap on emitted
  lines is 200 (`hardMaxLines`, set in #1614), so the read window is tiny
  in practice. 5 s is roughly 500× a worst-case local-FS read.
- **Worker-goroutine leak on permanent stalls.** When the timeout fires the
  worker goroutine remains parked in `os.Open` waiting for the kernel to
  release it. In the observed scenario the stall is transient — the open
  eventually completes and the goroutine drains. For a permanent stall
  (dead FUSE mount, etc.) a daemon restart is still required. Documented
  in code comments.
- **Behaviour change for callers expecting a Go error vs tool error.** The
  handler now returns `NewToolResultError(...)` instead of a Go `error` on
  timeout — same shape every other tool already uses for "user-visible"
  errors, so MCP clients see the message naturally. No change to the wire
  envelope.
- **No interaction with #1679/#1685 (CWD plumbing).** Rebased cleanly on top
  of `args.CWD` and reuses the same field for the new pre-dispatch log line.

🤖 Generated with [Claude Code](https://claude.com/claude-code)