### PR TITLE
[#1690] find_paths: walk cross_repo_link edges across repo-prefix aliases + reverse IMPLEMENTS

### DIFF
--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -12,6 +12,7 @@ package mcp
 
 import (
 	"context"
+	"path/filepath"
 	"sort"
 	"strings"
 
@@ -937,9 +938,91 @@ func (s *Server) handleGetSubgraph(_ context.Context, req mcpapi.CallToolRequest
 	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
 }
 
+// reverseTraversalEdgeKinds is the set of edge kinds where the BFS in
+// find_paths should ALSO follow the reverse direction. These are the
+// "interface-style" edges where (handler --IMPLEMENTS--> endpoint) is
+// emitted from the implementation side but a cross-repo link lands on
+// the contract/endpoint node — to reach the handler, BFS must walk the
+// IMPLEMENTS edge in reverse. (#1690)
+var reverseTraversalEdgeKinds = map[string]bool{
+	"IMPLEMENTS":      true,
+	"GRPC_IMPLEMENTS": true,
+	"HANDLES":         true,
+	"GRPC_HANDLES":    true,
+}
+
+// buildRepoAliasMap returns a map of every recognised repo-prefix to the
+// canonical *LoadedRepo. A loaded repo can be addressed by:
+//
+//   - its registry slug (the key in lg.Repos)
+//   - the `repo` field embedded in its graph document
+//
+// These can DIVERGE when the on-disk repo directory uses underscores but
+// the fleet config lists the slug with dashes (or vice versa). The
+// cross-repo links file is written with the graph-encoded repo name, but
+// MCP resolves IDs through the registry slug — so without aliasing,
+// link.Target points at a repo prefix that lg.Repos doesn't contain and
+// BFS expansion stops at the cross-repo hop. (#1690)
+func buildRepoAliasMap(lg *LoadedGroup) map[string]*LoadedRepo {
+	if lg == nil {
+		return nil
+	}
+	aliases := make(map[string]*LoadedRepo, len(lg.Repos)*4)
+	register := func(key string, r *LoadedRepo) {
+		if key == "" || r == nil {
+			return
+		}
+		if _, exists := aliases[key]; !exists {
+			aliases[key] = r
+		}
+	}
+	for slug, r := range lg.Repos {
+		register(slug, r)
+		if r != nil && r.Doc != nil && r.Doc.Repo != "" {
+			register(r.Doc.Repo, r)
+		}
+		// Path basename — the links generator has historically derived the
+		// `repo` field of cross-repo Source/Target prefixes from the on-disk
+		// directory name, which uses underscores where the fleet slug uses
+		// dashes (e.g. /Projects/UpVate/upvate_core vs slug upvate-core). When
+		// the links file was written under that older convention but the
+		// current graph.fb is tagged with the new slug, neither slug nor
+		// doc.Repo match the link's prefix. Register the directory basename
+		// AND its dash/underscore swap so the prefix still resolves. (#1690)
+		if r != nil && r.Path != "" {
+			base := filepath.Base(r.Path)
+			register(base, r)
+			register(strings.ReplaceAll(base, "_", "-"), r)
+			register(strings.ReplaceAll(base, "-", "_"), r)
+		}
+		// Defensive: also register the slug/doc.Repo with `_`↔`-` swapped.
+		register(strings.ReplaceAll(slug, "-", "_"), r)
+		register(strings.ReplaceAll(slug, "_", "-"), r)
+		if r != nil && r.Doc != nil && r.Doc.Repo != "" {
+			register(strings.ReplaceAll(r.Doc.Repo, "-", "_"), r)
+			register(strings.ReplaceAll(r.Doc.Repo, "_", "-"), r)
+		}
+	}
+	return aliases
+}
+
+// lookupRepo resolves a repo prefix (either the registry slug or the
+// graph-encoded `Doc.Repo` name) to its LoadedRepo. Returns the canonical
+// slug + repo, or ("", nil) when nothing matches. (#1690)
+func lookupRepo(aliases map[string]*LoadedRepo, prefix string) (string, *LoadedRepo) {
+	if r, ok := aliases[prefix]; ok && r != nil {
+		return r.Repo, r
+	}
+	return "", nil
+}
+
 // handleFindPaths finds the shortest path between two entities up to max_hops.
 // #1650: traverses cross-repo edges via lg.Links, so an id in repo A can reach
 // an id in repo B when a link connects the two graphs.
+// #1690: aliases path-derived and slug-derived repo prefixes so links written
+// as `<doc.Repo>::<id>` resolve to the registry-loaded repo even when the
+// fleet slug uses dashes vs underscores; also walks IMPLEMENTS-style edges
+// in reverse so an endpoint cross-repo target can reach its handler.
 func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	from, err := req.RequireString("from")
 	if err != nil {
@@ -961,10 +1044,33 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 		maxHops = 8
 	}
 
+	aliases := buildRepoAliasMap(lg)
+
+	// canonicalize normalises a "<repo>::<id>" prefix so its repo segment
+	// always matches a key in lg.Repos. Bare ids / labels fall through to
+	// normalizePrefixed.
+	canonicalize := func(s string) string {
+		if rPref, lid := splitPrefixed(s); rPref != "" {
+			if slug, r := lookupRepo(aliases, rPref); r != nil {
+				if _, ok := r.LabelIndex.ByID[lid]; ok {
+					return prefixedID(slug, lid)
+				}
+				// id may be a label/qname within this repo
+				if e := r.LabelIndex.Lookup(lid); e != nil {
+					return prefixedID(slug, e.ID)
+				}
+				return ""
+			}
+			return ""
+		}
+		return normalizePrefixed(lg, s)
+	}
+
 	// Resolve both endpoints to PREFIXED ids. Accept either a "<repo>::<id>"
-	// string or a bare local id / label that LabelIndex can resolve.
-	prefSrc := normalizePrefixed(lg, from)
-	prefDst := normalizePrefixed(lg, to)
+	// string (under either the registry slug or the graph-encoded repo name)
+	// or a bare local id / label that LabelIndex can resolve.
+	prefSrc := canonicalize(from)
+	prefDst := canonicalize(to)
 	if prefSrc == "" {
 		return jsonResult(map[string]any{
 			"from":  from,
@@ -989,29 +1095,76 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 		Repo     string `json:"repo"`
 	}
 
+	// canonicalRepoOf returns the canonical slug for a prefixed id, falling
+	// back to the literal prefix when no alias matches (so dijkstra still
+	// has stable node ids to compare).
+	canonicalRepoOf := func(node string) (string, string, *LoadedRepo) {
+		rPref, lid := splitPrefixed(node)
+		if rPref == "" {
+			return "", node, nil
+		}
+		slug, r := lookupRepo(aliases, rPref)
+		if r == nil {
+			return rPref, lid, nil
+		}
+		return slug, lid, r
+	}
+
 	// Expand function: intra-repo CALLS/IMPORTS/etc. + cross-repo overlay.
+	// The expansion also walks IMPLEMENTS-class edges in reverse so that a
+	// cross-repo link landing on an http_endpoint_definition can reach the
+	// implementing handler. (#1690)
 	expand := func(node string) []edge {
-		repo, local := splitPrefixed(node)
+		slug, local, r := canonicalRepoOf(node)
 		out := []edge{}
-		if r, ok := lg.Repos[repo]; ok && r.Doc != nil {
+		if r != nil && r.Doc != nil && r.Adjacency != nil {
 			a := r.Adjacency
 			for _, e := range a.out[local] {
 				out = append(out, edge{
-					target: prefixedID(repo, e.target),
+					target: prefixedID(slug, e.target),
 					kind:   e.kind,
 					weight: 1, // unit cost — we want shortest hop count
 				})
 			}
-		}
-		// Cross-repo overlay: source-side matches the current node.
-		for _, l := range lg.Links {
-			if l.Source == node {
+			// Reverse traversal for interface-style edges (#1690).
+			for _, e := range a.in[local] {
+				if !reverseTraversalEdgeKinds[e.kind] {
+					continue
+				}
 				out = append(out, edge{
-					target: l.Target,
-					kind:   l.EffectiveKind(),
+					target: prefixedID(slug, e.target),
+					kind:   e.kind + "_REVERSED",
 					weight: 1,
 				})
 			}
+		}
+		// Cross-repo overlay: a link's source-side matches the current node
+		// under either the registry slug or the graph-encoded repo prefix.
+		// Re-canonicalise the link Target so dijkstra sees the slug used in
+		// lg.Repos — without this, BFS would store the target under the
+		// graph-encoded prefix and fail to expand further. (#1690)
+		for _, l := range lg.Links {
+			lSrcSlug, lSrcID := splitPrefixed(l.Source)
+			if lSrcSlug == "" {
+				continue
+			}
+			cSrcSlug, _ := lookupRepo(aliases, lSrcSlug)
+			if cSrcSlug == "" {
+				cSrcSlug = lSrcSlug
+			}
+			if prefixedID(cSrcSlug, lSrcID) != node {
+				continue
+			}
+			lTgtSlug, lTgtID := splitPrefixed(l.Target)
+			cTgtSlug, _ := lookupRepo(aliases, lTgtSlug)
+			if cTgtSlug == "" {
+				cTgtSlug = lTgtSlug
+			}
+			out = append(out, edge{
+				target: prefixedID(cTgtSlug, lTgtID),
+				kind:   l.EffectiveKind(),
+				weight: 1,
+			})
 		}
 		return out
 	}
@@ -1031,12 +1184,12 @@ func (s *Server) handleFindPaths(_ context.Context, req mcpapi.CallToolRequest) 
 	crosses := false
 	firstRepo, _ := splitPrefixed(prefSrc)
 	for _, pid := range path {
-		repo, local := splitPrefixed(pid)
-		if repo != firstRepo {
+		slug, local, r := canonicalRepoOf(pid)
+		if slug != firstRepo {
 			crosses = true
 		}
-		st := step{EntityID: pid, Repo: repo}
-		if r, ok := lg.Repos[repo]; ok && r.Doc != nil {
+		st := step{EntityID: pid, Repo: slug}
+		if r != nil && r.Doc != nil {
 			if e := r.LabelIndex.ByID[local]; e != nil {
 				st.Name = e.Name
 				st.Kind = e.Kind

--- a/internal/mcp/find_paths_1690_test.go
+++ b/internal/mcp/find_paths_1690_test.go
@@ -1,0 +1,189 @@
+// find_paths_1690_test.go — regression tests for #1690.
+//
+// Covers two failure modes from the iter3 calibration:
+//
+//	(a) The cross-repo links file is written with a repo-prefix that does
+//	    not exactly match the registered fleet slug (the historical case
+//	    is "<dir-basename-with-underscores>" vs "<fleet-slug-with-dashes>"
+//	    — see iter3 #1690 add-rec #1). With the alias map in place,
+//	    find_paths must still walk the cross_repo_link edge.
+//
+//	(b) The cross-repo link's Target lands on an http_endpoint_definition
+//	    (not the handler function), and the handler is connected via an
+//	    out-of-direction IMPLEMENTS edge (handler → endpoint). find_paths
+//	    must walk IMPLEMENTS in reverse so the BFS can resolve the
+//	    handler from the endpoint.
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// scenario (a) — link's Target prefix uses the on-disk dir name with
+// underscores while the registered slug uses dashes. find_paths must
+// canonicalise both sides to the slug so BFS can continue.
+func TestFindPaths_1690_RepoPrefixAlias(t *testing.T) {
+	docMobile := &graph.Document{
+		Repo: "core-mobile",
+		Entities: []graph.Entity{
+			{ID: "caller_fn", Name: "createInspectionDeficiency", Kind: "Function", SourceFile: "api.ts"},
+			{ID: "ep_call", Name: "http:POST:/inspections", Kind: "http_endpoint_call", SourceFile: "api.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "caller_fn", ToID: "ep_call", Kind: "FETCHES"},
+		},
+	}
+	docCore := &graph.Document{
+		Repo: "upvate-core", // fleet slug
+		Entities: []graph.Entity{
+			{ID: "handler_fn", Name: "InspectionViewSet.create_deficiency", Kind: "Function", SourceFile: "views.py"},
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"core-mobile": docMobile,
+		"upvate-core": docCore,
+	})
+	lg := srv.State.Group("test")
+	// The links emitter wrote the upvate-core side as `upvate_core::handler_fn`
+	// (path-basename with underscores) — this MUST still resolve.
+	lg.Links = []CrossRepoLink{
+		{
+			Source:   prefixedID("core-mobile", "ep_call"),
+			Target:   "upvate_core::handler_fn",
+			Relation: "calls",
+			Method:   "http",
+		},
+	}
+
+	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
+		"group": "test",
+		"from":  prefixedID("core-mobile", "caller_fn"),
+		"to":    prefixedID("upvate-core", "handler_fn"),
+	})
+	if found, _ := res["found"].(bool); !found {
+		t.Fatalf("expected cross-repo path via underscore-prefixed link target, got: %v", res)
+	}
+	if crosses, _ := res["crosses_repos"].(bool); !crosses {
+		t.Errorf("expected crosses_repos=true, got %v", res["crosses_repos"])
+	}
+	// Path should be: caller_fn -- FETCHES --> ep_call -- calls (xrepo) --> handler_fn
+	if hop, _ := res["hop_count"].(float64); hop != 2 {
+		t.Errorf("expected 2 hops, got %v", hop)
+	}
+	// The xrepo edge kind ("calls" via http method) MUST appear in edge_kinds.
+	if !containsKind(res, "calls") {
+		t.Errorf("expected edge_kinds to include 'calls', got %v", res["edge_kinds"])
+	}
+}
+
+// scenario (b) — the cross-repo link lands on an http_endpoint_definition
+// in the producer repo (not the handler function). The handler is
+// connected via `handler --IMPLEMENTS--> http_endpoint_definition`, so
+// BFS must walk IMPLEMENTS in reverse.
+func TestFindPaths_1690_ReverseImplementsAcrossRepo(t *testing.T) {
+	docMobile := &graph.Document{
+		Repo: "core-mobile",
+		Entities: []graph.Entity{
+			{ID: "caller_fn", Name: "createInspectionDeficiency", Kind: "Function", SourceFile: "api.ts"},
+			{ID: "ep_call", Name: "http:POST:/inspections", Kind: "http_endpoint_call", SourceFile: "api.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "caller_fn", ToID: "ep_call", Kind: "FETCHES"},
+		},
+	}
+	docCore := &graph.Document{
+		Repo: "upvate-core",
+		Entities: []graph.Entity{
+			{ID: "handler_fn", Name: "InspectionViewSet.create_deficiency", Kind: "Function", SourceFile: "views.py"},
+			{ID: "ep_def", Name: "http:POST:/inspections", Kind: "http_endpoint_definition", SourceFile: "views.py"},
+		},
+		Relationships: []graph.Relationship{
+			// handler --IMPLEMENTS--> endpoint_definition  (so the BFS must
+			// walk this edge IN REVERSE to reach handler from endpoint).
+			{ID: "r2", FromID: "handler_fn", ToID: "ep_def", Kind: "IMPLEMENTS"},
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"core-mobile": docMobile,
+		"upvate-core": docCore,
+	})
+	lg := srv.State.Group("test")
+	lg.Links = []CrossRepoLink{
+		{
+			Source:   prefixedID("core-mobile", "ep_call"),
+			Target:   prefixedID("upvate-core", "ep_def"), // lands on the endpoint, NOT the handler
+			Relation: "calls",
+			Method:   "http",
+		},
+	}
+
+	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
+		"group": "test",
+		"from":  prefixedID("core-mobile", "caller_fn"),
+		"to":    prefixedID("upvate-core", "handler_fn"),
+	})
+	if found, _ := res["found"].(bool); !found {
+		t.Fatalf("expected find_paths to walk IMPLEMENTS in reverse, got: %v", res)
+	}
+	if crosses, _ := res["crosses_repos"].(bool); !crosses {
+		t.Errorf("expected crosses_repos=true")
+	}
+	// Hop chain: caller_fn → ep_call → ep_def → handler_fn = 3 hops.
+	if hop, _ := res["hop_count"].(float64); hop != 3 {
+		t.Errorf("expected 3 hops (caller→ep_call→ep_def→handler), got %v", hop)
+	}
+	if !containsKind(res, "IMPLEMENTS_REVERSED") {
+		t.Errorf("expected edge_kinds to include 'IMPLEMENTS_REVERSED', got %v", res["edge_kinds"])
+	}
+}
+
+// scenario (c) — when neither alias nor reverse-IMPLEMENTS applies the
+// handler returns the same "no path" shape as before. Guards against
+// regression where the new expansion accidentally invents paths.
+func TestFindPaths_1690_NoPathStillNoPath(t *testing.T) {
+	doc := &graph.Document{
+		Repo: "solo",
+		Entities: []graph.Entity{
+			{ID: "a", Name: "A", Kind: "Function"},
+			{ID: "b", Name: "B", Kind: "Function"}, // unconnected
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{"solo": doc})
+	res := callEndpointTool(t, srv.handleFindPaths, map[string]any{
+		"group": "test",
+		"from":  "solo::a",
+		"to":    "solo::b",
+	})
+	if found, _ := res["found"].(bool); found {
+		t.Errorf("expected found=false on unconnected nodes, got: %v", res)
+	}
+}
+
+// containsKind reports whether res["edge_kinds"] contains the literal kind.
+func containsKind(res map[string]any, want string) bool {
+	raw, _ := res["edge_kinds"]
+	// JSON path: []any of strings.
+	if arr, ok := raw.([]any); ok {
+		for _, k := range arr {
+			if s, ok := k.(string); ok && s == want {
+				return true
+			}
+		}
+	}
+	// Direct path when the handler is invoked without round-tripping JSON.
+	if arr, ok := raw.([]string); ok {
+		for _, k := range arr {
+			if k == want {
+				return true
+			}
+		}
+	}
+	// Fallback: stringify and substring-match.
+	b, _ := json.Marshal(raw)
+	return strings.Contains(string(b), want)
+}
+


### PR DESCRIPTION
Fixes #1690

## Problem

Iter3 (`~/private/benchmarks/mcp-quality-bench-2026-05-23-iter3.md`, add-rec #1) flagged `find_paths` as the highest-leverage cross-stack lever: 3/3 cross-repo probes (q04 / q14 / q15) returned `found:false` even though the `cross_repo_link` edges were present in the graph and surfaced by `endpoints action=calls` (40 of 44 mobile→backend calls annotated `matched_definition: cross_repo_link` after #1653). Every cross-stack end-to-end MCP win was blocked on this one handler.

## Root cause (two failure modes, both fixed)

### 1. Repo-prefix mismatch between links file and registry slug

The cross-repo links file is written by the link passes using the `repo` field embedded in each graph document. Historically that field tracked the on-disk directory basename (`upvate_core`), but the fleet config registers the repo under a slug (`upvate-core`). MCP loads `lg.Repos[\"upvate-core\"]` — so `lg.Repos[\"upvate_core\"]` is `nil`, and any `link.Target` written as `upvate_core::<id>` lands the BFS on a node with no further neighbors. Worse, `to=upvate_core::<id>` fails normalization outright (`'to' entity not found in any loaded repo`).

Live evidence on the upvate group at the time of writing: **every** `method=http` cross-repo link target uses the underscored prefix, none of which match any registered slug. Result: `find_paths` returned `found:false` for every cross-stack pair, exactly matching iter3's symptom.

### 2. Cross-repo link can land on `http_endpoint_definition`, not the handler

For the ~6 upvate-core targets that resolve to a synthetic definition node (not a handler function), the handler is connected via `handler --IMPLEMENTS--> http_endpoint_definition`. To reach the handler from the endpoint, BFS must walk IMPLEMENTS *in reverse* — and the previous expand only followed forward (out) edges.

## Fix (`internal/mcp/dashboard_tools.go::handleFindPaths`)

- **Repo-alias map** (`buildRepoAliasMap`): registers each loaded repo under every prefix that might appear in a links file — registry slug, `Doc.Repo`, on-disk path basename, and the `_`↔`-` swaps of all of those. `lookupRepo` resolves any of them back to the canonical `*LoadedRepo` + slug.
- **Canonicalisation pass** before dijkstra: both ends of every link, plus the user's `from`/`to`, are re-prefixed to the slug used in `lg.Repos` so dijkstra sees a fully connected graph.
- **Reverse traversal for interface-style edges**: the expand function now also walks `in[node]` for `IMPLEMENTS` / `GRPC_IMPLEMENTS` / `HANDLES` / `GRPC_HANDLES`, emitted as `<KIND>_REVERSED` in `edge_kinds` so callers can audit the traversal.

The forward case (link target directly equals the handler function ID, which is most of the http link targets in practice) keeps the existing 2-hop shape: `caller --FETCHES--> http_endpoint_call --calls--> handler`. The reverse case adds one extra hop through `http_endpoint_definition`.

## Files

- `internal/mcp/dashboard_tools.go` — `buildRepoAliasMap`, `lookupRepo`, `reverseTraversalEdgeKinds`, and the updated `handleFindPaths` with `canonicalize` / `canonicalRepoOf` / rewritten `expand`.
- `internal/mcp/find_paths_1690_test.go` — three new regression tests.

## Tests

- `TestFindPaths_1690_RepoPrefixAlias` — link target written as `upvate_core::handler_fn` (underscored) resolves through the alias map; `found:true`, `crosses_repos:true`, `hop_count:2`, edge kind `calls` present.
- `TestFindPaths_1690_ReverseImplementsAcrossRepo` — link lands on `http_endpoint_definition`; BFS walks IMPLEMENTS in reverse; `found:true`, `hop_count:3`, `IMPLEMENTS_REVERSED` present in `edge_kinds`.
- `TestFindPaths_1690_NoPathStillNoPath` — unconnected nodes still return `found:false` (no invented paths).
- Existing `TestUX1650_FindPathsCrossRepo`, `TestHandleFindPaths`, `TestHandleFindPaths_NoPath` still pass.
- `go build ./...` clean.
- `go vet ./...` clean.
- `go test ./internal/mcp/...` green (full mcp suite).

## Risk

- **Touch surface kept tight**: only `handleFindPaths` and its three helpers (`buildRepoAliasMap`, `lookupRepo`, `canonicalize`/`canonicalRepoOf`). No changes to `internal/mcp/server.go` or `internal/cli/mcp_bridge.go` per dispatch instructions; no changes to the link emitter or to `endpoint_tools.go`. The alias map is built per query and is `O(repos)` so the cost is negligible.
- **Reverse traversal is restricted** to four interface-style edge kinds. CALLS / FETCHES / IMPORTS / CONTAINS keep their existing forward-only semantics so the BFS can't fabricate paths through "any inbound edge".

## Follow-ups (out of scope for #1690)

Iter3 also flagged: (a) `per_repo.cross_repo_resolved` aggregate disagrees with per-call annotations on the frontend repo; (b) the links file in production still uses stale repo prefixes (underscores) — once the daemon re-indexes with the current slug convention, the alias map becomes belt-and-suspenders rather than load-bearing. Neither is a blocker for this fix; both should be tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)