### PR TITLE
[#1703] fix: topic_detail alias-aware lookup + topic kind_filter expansion

### DIFF
--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -211,9 +211,14 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 	}
 	repos := reposToConsider(lg, nil)
 
+	// #1703: use alias-aware repo resolution so slugs with dash/underscore
+	// variants (e.g. "upvate-core" vs "upvate_core") still narrow to the
+	// correct repo.  Fall back to all repos when the hint is unrecognised —
+	// the per-repo loop below will find the entity via LabelIndex.
 	repoHint, local := splitPrefixed(topicID)
 	if repoHint != "" {
-		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+		aliases := buildRepoAliasMap(lg)
+		if _, r := lookupRepo(aliases, repoHint); r != nil && r.Doc != nil {
 			repos = []*LoadedRepo{r}
 		}
 	}
@@ -230,21 +235,33 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 		if r.Doc == nil {
 			continue
 		}
-		target := local
-		if target == "" {
-			target = topicID
+		// Determine the lookup key within this repo.  Try in order:
+		//   1. local part of a "repo::id" prefixed input (exact hash ID)
+		//   2. the full topicID when no prefix was present
+		// Then fall back to LabelIndex for name/qualified-name inputs so that
+		// the id returned by search_entities (which matches by name) round-trips
+		// successfully. (#1703)
+		lookup := local
+		if lookup == "" {
+			lookup = topicID
 		}
 		byID := r.ByID
-		topicEnt, ok := byID[target]
+		topicEnt, ok := byID[lookup]
 		if !ok {
-			continue
+			// Fall back: resolve by entity name or qualified name.
+			topicEnt = r.LabelIndex.Lookup(lookup)
+			if topicEnt == nil {
+				continue
+			}
 		}
+		// Use the canonical entity ID for relationship matching.
+		canonID := topicEnt.ID
 		var publishers, subscribers []participant
 		for i := range r.Doc.Relationships {
 			rel := &r.Doc.Relationships[i]
 			switch rel.Kind {
 			case "PUBLISHES_TO":
-				if rel.ToID == target {
+				if rel.ToID == canonID {
 					if src, ok2 := byID[rel.FromID]; ok2 {
 						publishers = append(publishers, participant{
 							EntityID:   prefixedID(r.Repo, src.ID),
@@ -256,7 +273,7 @@ func (s *Server) handleTopologyTopicDetail(_ context.Context, req mcpapi.CallToo
 					}
 				}
 			case "SUBSCRIBES_TO":
-				if rel.ToID == target {
+				if rel.ToID == canonID {
 					if src, ok2 := byID[rel.FromID]; ok2 {
 						subscribers = append(subscribers, participant{
 							EntityID:   prefixedID(r.Repo, src.ID),

--- a/internal/mcp/dashboard_tools_test.go
+++ b/internal/mcp/dashboard_tools_test.go
@@ -191,6 +191,145 @@ func TestHandleTopologyTopicDetail_NotFound(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// #1703 — search_entities → topic_detail round-trip consistency
+// ---------------------------------------------------------------------------
+
+// TestTopicDetail_PrefixedIDRoundtrip verifies that the entity_id returned by
+// search_entities (a "repo::hash" prefixed form) is accepted by topic_detail.
+// This is the core tool-pair-consistency requirement from #1703.
+func TestTopicDetail_PrefixedIDRoundtrip(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "t1", Name: "payments.settled", Kind: "SCOPE.Queue"},
+		{ID: "pub", Name: "PaymentService", Kind: "Class"},
+		{ID: "sub", Name: "AuditService", Kind: "Class"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
+		{ID: "r2", FromID: "sub", ToID: "t1", Kind: "SUBSCRIBES_TO"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	// Simulate what search_entities returns: prefixedID(r.Repo, e.ID) = "repo1::t1".
+	prefixedTopicID := prefixedID("repo1", "t1")
+
+	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": prefixedTopicID,
+	})
+	if out["found"] != true {
+		t.Fatalf("prefixed id round-trip: expected found=true, got: %v", out)
+	}
+	if out["topic_name"] != "payments.settled" {
+		t.Errorf("expected topic_name=payments.settled, got %v", out["topic_name"])
+	}
+	pubs, _ := out["publishers"].([]any)
+	subs, _ := out["subscribers"].([]any)
+	if len(pubs) != 1 {
+		t.Errorf("expected 1 publisher, got %d", len(pubs))
+	}
+	if len(subs) != 1 {
+		t.Errorf("expected 1 subscriber, got %d", len(subs))
+	}
+}
+
+// TestTopicDetail_NameLookupRoundtrip verifies that topic_detail accepts the
+// topic entity's NAME as topic_id (not just the hash ID), so that an LLM that
+// copies the "name" field instead of "entity_id" from search_entities output
+// still gets a useful result. (#1703)
+func TestTopicDetail_NameLookupRoundtrip(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "t1", Name: "payments.settled", Kind: "SCOPE.Queue"},
+		{ID: "pub", Name: "PaymentService", Kind: "Class"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	// Pass the topic name directly — LabelIndex.Lookup must bridge the gap.
+	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": "payments.settled",
+	})
+	if out["found"] != true {
+		t.Fatalf("name-based lookup: expected found=true, got: %v", out)
+	}
+	if out["topic_name"] != "payments.settled" {
+		t.Errorf("expected topic_name=payments.settled, got %v", out["topic_name"])
+	}
+}
+
+// TestTopicDetail_RepoAliasRoundtrip verifies that topic_detail resolves the
+// repo prefix through the alias map when the slug uses dashes but the repo key
+// uses underscores (the slug/path-basename divergence from #1690). (#1703)
+func TestTopicDetail_RepoAliasRoundtrip(t *testing.T) {
+	docA := &graph.Document{
+		Repo: "payments-service", // fleet slug
+		Entities: []graph.Entity{
+			{ID: "t1", Name: "payments.settled", Kind: "SCOPE.Queue"},
+			{ID: "pub", Name: "PaymentService", Kind: "Class"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "pub", ToID: "t1", Kind: "PUBLISHES_TO"},
+		},
+	}
+	// Register under the slug key — repo1 path-basename is "payments_service"
+	// (underscore variant).  buildRepoAliasMap must alias both forms.
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"payments-service": docA,
+	})
+
+	// search_entities would emit "payments-service::t1" (canonical slug prefix).
+	// topic_detail must resolve this even if an internal alias is involved.
+	out := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": "payments-service::t1",
+	})
+	if out["found"] != true {
+		t.Fatalf("repo-alias round-trip: expected found=true, got: %v", out)
+	}
+
+	// Also accept the underscore variant prefix (underscore alias → same repo).
+	out2 := callDashboardTool(t, srv.handleTopologyTopicDetail, map[string]any{
+		"group":    "test",
+		"topic_id": "payments_service::t1",
+	})
+	if out2["found"] != true {
+		t.Fatalf("underscore-alias round-trip: expected found=true, got: %v", out2)
+	}
+}
+
+// TestSearchEntities_TopicKindAlias verifies that search_entities with
+// kind_filter="topic" matches SCOPE.Queue and SCOPE.Topic entities so that
+// the entity_ids it returns are always valid inputs for topic_detail. (#1703)
+func TestSearchEntities_TopicKindAlias(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "q1", Name: "payments.settled", Kind: "SCOPE.Queue"},
+		{ID: "q2", Name: "user.updated", Kind: "SCOPE.Topic"},
+		{ID: "q3", Name: "order.placed", Kind: "Topic"},
+		{ID: "x1", Name: "PaymentService", Kind: "Class"}, // must not match
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+
+	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
+		"group":       "test",
+		"query":       ".",    // matches the dot in all topic names
+		"kind_filter": "topic",
+	})
+	results, _ := out["results"].([]any)
+	if len(results) != 3 {
+		t.Errorf("expected 3 topic results (SCOPE.Queue + SCOPE.Topic + Topic), got %d: %v", len(results), results)
+	}
+	// Verify none of the results are the Class entity.
+	for _, r := range results {
+		obj, _ := r.(map[string]any)
+		if obj["name"] == "PaymentService" {
+			t.Errorf("Class entity should not match kind_filter=topic")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
 // archigraph_flow_dead_ends
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/endpoint_tools.go
+++ b/internal/mcp/endpoint_tools.go
@@ -93,6 +93,16 @@ var kindAliases = map[string][]string{
 		"http_endpoint_definition",
 		"http_endpoint_call",
 	},
+	// #1703: "topic" is a caller-facing umbrella that covers all messaging-channel
+	// kinds.  search_entities(kind_filter="topic") must match SCOPE.Queue,
+	// SCOPE.Topic, Queue, Topic, and their dot-suffixed variants so the returned
+	// entity_ids can be passed to topic_detail without "found:false".
+	"topic": {
+		"topic",
+		"scope.topic",
+		"queue",
+		"scope.queue",
+	},
 }
 
 // expandKindAlias returns the set of kind strings that a caller-supplied kind


### PR DESCRIPTION
## What

`archigraph_topology(action=topic_detail)` returned `found:false` for IDs that `archigraph_search_entities` accepts — flagged by polyglot iter3 as an asymmetric-lookup MCP-UX regression.

## Root causes

Three independent bugs caused the asymmetry:

**1. `lg.Repos[repoHint]` direct map lookup (same class as #1690)**
`handleTopologyTopicDetail` called `lg.Repos[repoHint]` instead of the alias-aware `lookupRepo(buildRepoAliasMap(lg), repoHint)`. When the prefixed ID's slug uses dashes and the registry key uses underscores (e.g. `payments-service` vs `payments_service`), the lookup fails silently and the handler falls through to `found:false`.

**2. No label/name fallback after `byID` miss**
When `byID[target]` missed (e.g. user/LLM passed the topic's `name` field like `"payments.settled"` instead of the hex hash `entity_id`), the handler skipped to the next repo and ultimately returned `found:false`. `search_entities` matches by name substring; `topic_detail` must accept the same name inputs.

**3. `kindAliases` missing `"topic"` umbrella entry**
`search_entities(kind_filter="topic")` only matched entities with kind literally equal to `"topic"`. Entities extracted as `SCOPE.Queue` or `SCOPE.Topic` (the majority in the polyglot fixture) were excluded from results entirely. An LLM using `kind_filter="topic"` got no results and had nothing to pass to `topic_detail`.

## Fix

- `handleTopologyTopicDetail`: replace `lg.Repos[repoHint]` with `lookupRepo(buildRepoAliasMap(lg), repoHint)` for alias-aware repo resolution.
- After a `byID` miss, fall back to `r.LabelIndex.Lookup(lookup)` (same pattern used by `get_source` / `inspect`) so entity names and qualified names resolve.
- Use `topicEnt.ID` (canonical hash) for relationship matching after a label-based resolution.
- `kindAliases` gains a `"topic"` entry expanding to `["topic", "scope.topic", "queue", "scope.queue"]`.

## Tests added

| Test | Scenario covered |
|------|-----------------|
| `TestTopicDetail_PrefixedIDRoundtrip` | exact `"repo::hash"` id from `search_entities` → `topic_detail` |
| `TestTopicDetail_NameLookupRoundtrip` | topic name as `topic_id` (LabelIndex fallback) |
| `TestTopicDetail_RepoAliasRoundtrip` | dash/underscore slug alias; both `payments-service::t1` and `payments_service::t1` accepted |
| `TestSearchEntities_TopicKindAlias` | `kind_filter="topic"` matches `SCOPE.Queue`, `SCOPE.Topic`, `Topic` |

## Verification

```
go build ./...   ✓
go vet ./...     ✓
go test ./internal/mcp/  ✓  (all pass, 2.1s)
```

Live daemon was intentionally stopped (see session checkpoint); correctness verified via unit tests. Intra-repo roundtrips confirmed working on polyglot-platform before daemon stop.

## Files changed

- `internal/mcp/dashboard_tools.go` — alias-aware repo lookup + LabelIndex fallback in `handleTopologyTopicDetail`
- `internal/mcp/endpoint_tools.go` — `"topic"` umbrella alias in `kindAliases`
- `internal/mcp/dashboard_tools_test.go` — 4 new regression tests

Fixes #1703