### PR TITLE
[#1694] Python cross-module `<alias>.<leaf>(...)` CALL-target resolution

### DIFF
--- a/internal/extractors/python/crossmodule_calls.go
+++ b/internal/extractors/python/crossmodule_calls.go
@@ -1,0 +1,291 @@
+// crossmodule_calls.go — cross-module CALL-target resolution for the Python
+// extractor (issue #1694).
+//
+// Background
+// ----------
+// The base extractor's extractCallRelationships emits one CALLS edge per
+// `call` node in a function body. For attribute calls (`recv.leaf(...)`) the
+// `callTarget` resolver only qualifies the target when the receiver can be
+// statically typed (`self`, `cls`, `ClassName()`, or PEP-8 PascalCase
+// identifiers). Every other shape — including the dominant cross-module
+// idioms:
+//
+//	import x;            x.fn(...)
+//	from x import y;     y.fn(...)
+//	from . import steps; steps.create_order(...)
+//
+// — collapses to the bare leaf name (`fn` / `create_order`) with the
+// `disposition_hint: ambiguous` property. The import-aware CALLS rewrite
+// (ResolveImports in internal/resolve/imports.go) can only bind a bare-name
+// CALLS target via its file-level import bucket; when the bucket has no
+// binding for the bare leaf (because the leaf is a *method on a module*,
+// not an imported symbol itself), the edge stays orphan.
+//
+// The orchestrator/saga pattern is the canonical failure case: a
+// `PlaceOrderSaga.run` method that calls `steps.create_order(...)` etc.
+// emits ZERO CALLS edges to the four step Operations, blocking every saga
+// / orchestrator question on polyglot fixtures.
+//
+// Fix
+// ---
+// 1. Pre-scan top-level imports into a per-file map from local_name to
+//    (source_module, imported_name). Relative imports (`from . import X`,
+//    `from ..foo import bar`) are resolved to their absolute dotted module
+//    form using the current file's path so the resolver's `(module, leaf)`
+//    reverse index can bind them.
+//
+// 2. When the call extractor sees `recv.leaf(...)` where `recv` is a bare
+//    identifier matching a local import binding, it stamps two Properties
+//    on the emitted CALLS edge:
+//
+//        import_alias  = "<recv>"      // the local name in this file
+//        call_leaf     = "<leaf>"      // the called member name
+//
+//    The ToID itself stays as the bare leaf name so the existing
+//    `ContainsAny(":.#")` skip in ResolveImports doesn't drop the edge
+//    before our new resolution path runs.
+//
+// 3. The resolver's ResolveCrossModuleCallTarget (this PR, imports.go)
+//    consumes those properties: it looks up the alias in the file's
+//    import bucket and tries the appropriate `(module, leaf)` tuple
+//    against `lookupModuleEntity`. For `import x` shape the module is
+//    `b.SourceModule`; for `from x import y` shape (where y is itself a
+//    submodule) the module is `b.SourceModule + "." + b.ImportedName`.
+//
+// Local-call behaviour (same-module function references like a top-level
+// `foo()` from inside another top-level function in the same file) is
+// untouched — those are bare-identifier calls with no `attribute` parent
+// and never enter this code path.
+
+package python
+
+import (
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+)
+
+// pythonImportBinding mirrors the (source_module, imported_name) pair the
+// resolver's ImportTable carries per local name. It is intentionally a
+// trimmed copy so the extractor package stays decoupled from
+// internal/resolve.
+type pythonImportBinding struct {
+	sourceModule string
+	importedName string
+	// plainModule is true when the binding came from `import x` rather than
+	// `from x import y`. Detected at build time so callers don't have to
+	// re-check `sourceModule == importedName`.
+	plainModule bool
+}
+
+// pythonImportMap is the per-file local_name → binding map consumed by
+// extractCallRelationships when qualifying attribute-call targets.
+type pythonImportMap map[string]pythonImportBinding
+
+// buildPythonImportMap walks the same top-level import_statement /
+// import_from_statement nodes that extractImports walks and produces a
+// local_name → binding lookup table. Wildcard imports and `*` shapes are
+// skipped — they bind no specific local name and the bare-name resolver's
+// wildcard branch already handles them.
+//
+// Relative source modules (`.`, `..foo`, `...x.y`) are resolved against
+// the current file's dotted module form so the resolver can bind them
+// without further normalisation.
+//
+// The map is intentionally small and per-file — it is rebuilt for every
+// extracted file and never escapes the Extract call frame.
+func buildPythonImportMap(root *sitter.Node, file extractor.FileInput) pythonImportMap {
+	if root == nil {
+		return nil
+	}
+	out := make(pythonImportMap)
+
+	// `import a, b.c [as alias]` — direct module imports. local_name is the
+	// alias when present, else the top-level package segment of the dotted
+	// path. source_module == imported_name (the full dotted path).
+	for _, n := range findAll(root, "import_statement") {
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			ch := n.NamedChild(i)
+			path, alias := dottedNameAndAlias(ch, file.Content)
+			if path == "" || path == "*" {
+				continue
+			}
+			localName := alias
+			if localName == "" {
+				if dot := strings.IndexByte(path, '.'); dot > 0 {
+					localName = path[:dot]
+				} else {
+					localName = path
+				}
+			}
+			if _, exists := out[localName]; exists {
+				continue // first-binding-wins, matches extractImports
+			}
+			out[localName] = pythonImportBinding{
+				sourceModule: path,
+				importedName: path,
+				plainModule:  true,
+			}
+		}
+	}
+
+	// `from x import a, b [as alias]` — symbol imports. Relative source
+	// modules are resolved against the current file's dotted form.
+	for _, n := range findAll(root, "import_from_statement") {
+		modNode := n.ChildByFieldName("module_name")
+		modPath := resolvePythonImportModule(modNode, file)
+		if modPath == "" {
+			continue
+		}
+		for i := 0; i < int(n.NamedChildCount()); i++ {
+			ch := n.NamedChild(i)
+			if ch == modNode {
+				continue
+			}
+			name, alias := dottedNameAndAlias(ch, file.Content)
+			if name == "" || name == "*" {
+				continue
+			}
+			localName := alias
+			if localName == "" {
+				localName = name
+			}
+			if _, exists := out[localName]; exists {
+				continue
+			}
+			out[localName] = pythonImportBinding{
+				sourceModule: modPath,
+				importedName: name,
+				plainModule:  false,
+			}
+		}
+	}
+
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// resolvePythonImportModule returns the dotted module path for an
+// import_from_statement's module_name field. For a non-relative
+// `from x.y import ...` it returns the literal "x.y". For a relative
+// import (`from . import ...` / `from ..foo import bar`) it climbs the
+// current file's module path by the count of leading dots and appends any
+// trailing dotted_name to produce an absolute dotted form.
+//
+// Returns "" when modNode is nil, when the parse cannot produce a path,
+// or when the relative climb would escape the file's package (more dots
+// than parent segments) — in which case the caller leaves the binding
+// out of the map rather than emit a malformed key.
+func resolvePythonImportModule(modNode *sitter.Node, file extractor.FileInput) string {
+	if modNode == nil {
+		return ""
+	}
+	if modNode.Type() != "relative_import" {
+		// `from x.y import ...` — already absolute, reuse the existing
+		// path-flattener so behaviour matches extractImports exactly.
+		return dottedNamePath(modNode, file.Content)
+	}
+
+	// Count the leading dots and capture any trailing dotted_name suffix.
+	dots := 0
+	var suffix string
+	for i := 0; i < int(modNode.ChildCount()); i++ {
+		ch := modNode.Child(i)
+		switch ch.Type() {
+		case "import_prefix":
+			// Each "." child is one level up.
+			for j := 0; j < int(ch.ChildCount()); j++ {
+				if ch.Child(j).Type() == "." {
+					dots++
+				}
+			}
+		case "dotted_name":
+			suffix = strings.TrimSpace(nodeText(ch, file.Content))
+		}
+	}
+	if dots == 0 {
+		// Defensive — relative_import without dots shouldn't happen.
+		if suffix != "" {
+			return suffix
+		}
+		return ""
+	}
+
+	// Convert the file's path to its dotted package form, then climb.
+	mod := filePathToModule(file.Path)
+	if mod == "" {
+		// File at repo root with no module — relative import has no
+		// meaningful absolute form. Leave the binding out.
+		return ""
+	}
+	parts := strings.Split(mod, ".")
+	// Python's "from ." semantics: one dot = same package = drop the
+	// current file's leaf module. Two dots = parent package = drop two
+	// leaves (current leaf + parent package boundary), and so on.
+	//
+	// Note: filePathToModule already collapses __init__.py to the parent
+	// directory, so `from . import x` inside a package's __init__ correctly
+	// refers to that package itself.
+	drop := dots
+	if drop > len(parts) {
+		// Escapes the file's known package — leave unresolved rather than
+		// guess. The existing bare-name resolver still has the option of
+		// binding via wildcard or alias fallbacks.
+		return ""
+	}
+	base := strings.Join(parts[:len(parts)-drop], ".")
+	if suffix == "" {
+		return base
+	}
+	if base == "" {
+		return suffix
+	}
+	return base + "." + suffix
+}
+
+// extractCallTargetImportAlias returns the (alias, leaf) tuple for an
+// attribute-shaped call whose receiver is a bare identifier present in
+// `imports`. Returns ("", "") for any shape that isn't `<alias>.<leaf>(...)`
+// or whose alias isn't a known import binding.
+//
+// This is a narrow, conservative check: chained attribute calls like
+// `a.b.c()`, subscript receivers, and method calls on non-identifier
+// receivers are deliberately not handled here — those are either already
+// covered by callTarget's receiver-typing branches or are syntactically
+// ambiguous (e.g. `a.b.c()` could be a class method on a submodule member
+// or a deeper attribute chain; emitting a guess risks binding edges to the
+// wrong entity).
+func extractCallTargetImportAlias(
+	call *sitter.Node,
+	src []byte,
+	imports pythonImportMap,
+) (alias, leaf string) {
+	if call == nil || imports == nil {
+		return "", ""
+	}
+	fn := call.ChildByFieldName("function")
+	if fn == nil || fn.Type() != "attribute" {
+		return "", ""
+	}
+	recv := fn.ChildByFieldName("object")
+	if recv == nil || recv.Type() != "identifier" {
+		return "", ""
+	}
+	attr := fn.ChildByFieldName("attribute")
+	if attr == nil {
+		return "", ""
+	}
+	recvName := nodeText(recv, src)
+	if _, ok := imports[recvName]; !ok {
+		return "", ""
+	}
+	leafName := nodeText(attr, src)
+	if leafName == "" {
+		return "", ""
+	}
+	return recvName, leafName
+}

--- a/internal/extractors/python/crossmodule_calls_test.go
+++ b/internal/extractors/python/crossmodule_calls_test.go
@@ -1,0 +1,247 @@
+// crossmodule_calls_test.go — issue #1694 coverage for Python cross-module
+// `<alias>.<leaf>(...)` CALL-target extraction.
+//
+// These tests exercise the extractor in isolation: they verify that the
+// emitted CALLS edges carry the `import_alias` / `call_leaf` property
+// hints the resolver needs. Resolver-side binding is covered separately
+// in internal/resolve/imports_test.go (issue #1694 resolver test).
+
+package python
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// extractEntities runs the Python extractor on the given file and returns
+// its entity records, failing the test on any error.
+func extractEntities(t *testing.T, path, content string) []types.EntityRecord {
+	t.Helper()
+	ents, err := (&Extractor{}).Extract(context.Background(), extractor.FileInput{
+		Path:    path,
+		Content: []byte(content),
+	})
+	if err != nil {
+		t.Fatalf("Extract(%q) returned error: %v", path, err)
+	}
+	return ents
+}
+
+// findCallsFrom returns every CALLS relationship emitted from the entity
+// whose Name == callerName in the given entity slice. Methods are looked
+// up under their dotted "Class.method" form.
+func findCallsFrom(ents []types.EntityRecord, callerName string) []types.RelationshipRecord {
+	for i := range ents {
+		if ents[i].Name != callerName {
+			continue
+		}
+		var out []types.RelationshipRecord
+		for _, r := range ents[i].Relationships {
+			if r.Kind == "CALLS" {
+				out = append(out, r)
+			}
+		}
+		return out
+	}
+	return nil
+}
+
+// TestCrossModuleCall_FromImportSubmodule covers the canonical PlaceOrderSaga
+// failure case: `from . import steps; steps.create_order(...)`. The extractor
+// must emit a CALLS edge with ToID="create_order" and Properties carrying
+// {import_alias: "steps", call_leaf: "create_order"} so the resolver can
+// bind the edge cross-file.
+func TestCrossModuleCall_FromImportSubmodule(t *testing.T) {
+	src := `from . import steps
+
+class PlaceOrderSaga:
+    def run(self):
+        steps.create_order()
+        steps.charge_payment()
+        steps.reserve_inventory()
+`
+	ents := extractEntities(t, "services/order_saga/orchestrator.py", src)
+	calls := findCallsFrom(ents, "PlaceOrderSaga.run")
+	if len(calls) != 3 {
+		t.Fatalf("want 3 CALLS edges from PlaceOrderSaga.run, got %d (%+v)", len(calls), calls)
+	}
+	wantLeaves := map[string]bool{
+		"create_order":       true,
+		"charge_payment":     true,
+		"reserve_inventory":  true,
+	}
+	for _, c := range calls {
+		if !wantLeaves[c.ToID] {
+			t.Errorf("unexpected CALLS ToID %q", c.ToID)
+		}
+		if c.Properties == nil {
+			t.Errorf("CALLS to %q missing Properties — expected import_alias hint", c.ToID)
+			continue
+		}
+		if got := c.Properties["import_alias"]; got != "steps" {
+			t.Errorf("CALLS to %q: import_alias = %q, want %q", c.ToID, got, "steps")
+		}
+		if got := c.Properties["call_leaf"]; got != c.ToID {
+			t.Errorf("CALLS to %q: call_leaf = %q, want %q", c.ToID, got, c.ToID)
+		}
+		// The disposition_hint should NOT be set when import_alias is — the
+		// alias hint disambiguates the call precisely.
+		if _, has := c.Properties["disposition_hint"]; has {
+			t.Errorf("CALLS to %q: disposition_hint set together with import_alias", c.ToID)
+		}
+	}
+}
+
+// TestCrossModuleCall_PlainImport covers the `import x; x.fn(...)` shape.
+// The extractor must stamp import_alias="x" with the bare leaf as ToID.
+func TestCrossModuleCall_PlainImport(t *testing.T) {
+	src := `import billing
+
+def checkout():
+    billing.charge_card()
+`
+	ents := extractEntities(t, "services/orders/checkout.py", src)
+	calls := findCallsFrom(ents, "checkout")
+	if len(calls) != 1 {
+		t.Fatalf("want 1 CALLS edge from checkout, got %d (%+v)", len(calls), calls)
+	}
+	c := calls[0]
+	if c.ToID != "charge_card" {
+		t.Errorf("CALLS ToID = %q, want %q", c.ToID, "charge_card")
+	}
+	if c.Properties["import_alias"] != "billing" {
+		t.Errorf("import_alias = %q, want %q", c.Properties["import_alias"], "billing")
+	}
+	if c.Properties["call_leaf"] != "charge_card" {
+		t.Errorf("call_leaf = %q, want %q", c.Properties["call_leaf"], "charge_card")
+	}
+}
+
+// TestCrossModuleCall_FromImportFunction covers the `from x import y; y(...)`
+// shape — a direct call (no attribute). This should bind via the existing
+// bare-name resolver path; no import_alias hint is needed and none must be
+// stamped (the alias would point the resolver away from the right target).
+func TestCrossModuleCall_FromImportFunction(t *testing.T) {
+	src := `from billing import charge_card
+
+def checkout():
+    charge_card()
+`
+	ents := extractEntities(t, "services/orders/checkout.py", src)
+	calls := findCallsFrom(ents, "checkout")
+	if len(calls) != 1 {
+		t.Fatalf("want 1 CALLS edge from checkout, got %d (%+v)", len(calls), calls)
+	}
+	c := calls[0]
+	if c.ToID != "charge_card" {
+		t.Errorf("CALLS ToID = %q, want %q", c.ToID, "charge_card")
+	}
+	// Direct bare-name call — no import_alias property should be stamped.
+	if c.Properties != nil {
+		if alias := c.Properties["import_alias"]; alias != "" {
+			t.Errorf("bare-name call must not carry import_alias (got %q)", alias)
+		}
+	}
+}
+
+// TestCrossModuleCall_SelfRecursionUnchanged confirms that bare-name
+// self-recursion (a function calling itself by name) is still dropped, even
+// when the alias-extraction path is active.
+func TestCrossModuleCall_SelfRecursionUnchanged(t *testing.T) {
+	src := `import sys
+
+def factorial(n):
+    if n <= 1:
+        return 1
+    return factorial(n - 1)
+`
+	ents := extractEntities(t, "math/factorial.py", src)
+	calls := findCallsFrom(ents, "factorial")
+	for _, c := range calls {
+		if c.ToID == "factorial" {
+			t.Errorf("self-recursion edge should have been dropped, got %+v", c)
+		}
+	}
+}
+
+// TestCrossModuleCall_NoImportNoAlias confirms that an attribute call whose
+// receiver is NOT an import binding (e.g. `obj.fn()` where `obj` is a local
+// variable) gets the prior ambiguous treatment: bare leaf as ToID, with the
+// disposition_hint="ambiguous" property, and no import_alias.
+func TestCrossModuleCall_NoImportNoAlias(t *testing.T) {
+	src := `def consume(queue):
+    queue.pop()
+`
+	ents := extractEntities(t, "workers/consumer.py", src)
+	calls := findCallsFrom(ents, "consume")
+	if len(calls) != 1 {
+		t.Fatalf("want 1 CALLS edge from consume, got %d (%+v)", len(calls), calls)
+	}
+	c := calls[0]
+	if c.ToID != "pop" {
+		t.Errorf("CALLS ToID = %q, want %q", c.ToID, "pop")
+	}
+	if c.Properties != nil {
+		if alias := c.Properties["import_alias"]; alias != "" {
+			t.Errorf("non-import receiver must not carry import_alias (got %q)", alias)
+		}
+		if c.Properties["disposition_hint"] != "ambiguous" {
+			t.Errorf("non-import receiver: disposition_hint = %q, want %q", c.Properties["disposition_hint"], "ambiguous")
+		}
+	} else {
+		t.Errorf("expected disposition_hint=ambiguous Property, got nil Properties")
+	}
+}
+
+// TestRelativeImport_AbsoluteSourceModule confirms that
+// `from . import steps` inside services/order_saga/app/orchestrator.py
+// produces an IMPORTS edge whose source_module is the absolute dotted form
+// (`services.order_saga.app`), not the literal "." text.
+func TestRelativeImport_AbsoluteSourceModule(t *testing.T) {
+	src := `from . import steps
+from ..shared import util
+`
+	ents := extractEntities(t, "services/order_saga/app/orchestrator.py", src)
+
+	// IMPORTS edges live on the file entity (entities[0]) after the
+	// attachImportRelationships lift.
+	if len(ents) == 0 {
+		t.Fatalf("no entities returned")
+	}
+	var imports []types.RelationshipRecord
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "IMPORTS" {
+				imports = append(imports, r)
+			}
+		}
+	}
+	if len(imports) == 0 {
+		t.Fatalf("no IMPORTS edges emitted")
+	}
+
+	want := map[string]string{
+		"steps": "services.order_saga.app",
+		"util":  "services.order_saga.shared",
+	}
+	got := map[string]string{}
+	for _, imp := range imports {
+		if imp.Properties == nil {
+			continue
+		}
+		local := imp.Properties["local_name"]
+		mod := imp.Properties["source_module"]
+		if local == "" {
+			continue
+		}
+		got[local] = mod
+	}
+	for local, wantMod := range want {
+		if got[local] != wantMod {
+			t.Errorf("import %q: source_module = %q, want %q", local, got[local], wantMod)
+		}
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -138,9 +138,19 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 		return entities, nil
 	}
 
+	// Issue #1694 — pre-scan top-level imports BEFORE walkNode so the
+	// CALL-extraction pass can qualify `<alias>.<leaf>(...)` shapes by
+	// resolving the receiver alias against the file's import bindings.
+	// Built once per file and threaded through walkNode →
+	// extractCallRelationships. Wildcard imports and unresolvable relative
+	// imports return nil entries that the call extractor's range guards
+	// treat as "no binding" (i.e. the call falls back to bare-name
+	// resolution, preserving prior behaviour).
+	importMap := buildPythonImportMap(root, file)
+
 	// Walk top-level children.
 	walkBeforeCount := len(entities)
-	walkNode(root, file, "", &entities, &functionCount, &classCount)
+	walkNode(root, file, "", &entities, &functionCount, &classCount, importMap)
 
 	// Issue #699b — emit CONTAINS edges from the file entity to every
 	// top-level class (SCOPE.Component/class) and module-level function
@@ -297,6 +307,7 @@ func walkNode(
 	out *[]types.EntityRecord,
 	funcCount *int,
 	classCount *int,
+	imports pythonImportMap,
 ) {
 	if node == nil {
 		return
@@ -342,7 +353,7 @@ func walkNode(
 			if body != nil {
 				before := len(*out)
 				for i := range int(body.ChildCount()) {
-					walkNode(body.Child(i), file, childParent, out, funcCount, classCount)
+					walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports)
 				}
 				// Issue #526 — class-attribute assignments (DRF ViewSet
 				// `serializer_class = ...`, Django Model `title =
@@ -436,7 +447,7 @@ func walkNode(
 				selfName = nodeText(nameNode, file.Content)
 			}
 			rec.Relationships = append(rec.Relationships,
-				extractCallRelationships(node.ChildByFieldName("body"), file.Content, selfName, parentClass)...)
+				extractCallRelationships(node.ChildByFieldName("body"), file.Content, selfName, parentClass, imports)...)
 			*out = append(*out, rec)
 			*funcCount++
 		}
@@ -459,7 +470,7 @@ func walkNode(
 					selfName = nodeText(nameNode, file.Content)
 				}
 				rec.Relationships = append(rec.Relationships,
-					extractCallRelationships(inner.ChildByFieldName("body"), file.Content, selfName, parentClass)...)
+					extractCallRelationships(inner.ChildByFieldName("body"), file.Content, selfName, parentClass, imports)...)
 				*out = append(*out, rec)
 				*funcCount++
 			}
@@ -489,7 +500,7 @@ func walkNode(
 				if body != nil {
 					before := len(*out)
 					for i := range int(body.ChildCount()) {
-						walkNode(body.Child(i), file, childParent, out, funcCount, classCount)
+						walkNode(body.Child(i), file, childParent, out, funcCount, classCount, imports)
 					}
 					// Issue #526 — see the bare class_definition branch.
 					extractClassFields(body, file, childParent, out)
@@ -539,7 +550,7 @@ func walkNode(
 	default:
 		// Recurse into all other node types.
 		for i := range int(node.ChildCount()) {
-			walkNode(node.Child(i), file, parentClass, out, funcCount, classCount)
+			walkNode(node.Child(i), file, parentClass, out, funcCount, classCount, imports)
 		}
 	}
 }
@@ -660,7 +671,12 @@ func buildFunction(node *sitter.Node, file extractor.FileInput, parentClass stri
 // parentClass is the dotted enclosing class path of the caller ("" for
 // module-level functions). It is used to qualify `self.X` calls and to
 // detect when an inferred class-qualified target is in fact self-recursion.
-func extractCallRelationships(body *sitter.Node, src []byte, callerName, parentClass string) []types.RelationshipRecord {
+func extractCallRelationships(
+	body *sitter.Node,
+	src []byte,
+	callerName, parentClass string,
+	imports pythonImportMap,
+) []types.RelationshipRecord {
 	if body == nil || callerName == "" {
 		return nil
 	}
@@ -674,28 +690,65 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, parentC
 	if parentClass != "" {
 		selfQualified = parentClass + "." + callerName
 	}
-	seen := make(map[string]bool, len(calls))
+	// De-dup by (target, import_alias). A bare-name `foo()` and an attribute
+	// call `mod.foo()` whose leaf happens to also be `foo` are different
+	// callees in the cross-module case — they would resolve to different
+	// entities — so the alias is part of the dedup key.
+	type seenKey struct{ target, alias string }
+	seen := make(map[seenKey]bool, len(calls))
 	rels := make([]types.RelationshipRecord, 0, len(calls))
 	for _, call := range calls {
 		target, ambiguous := callTarget(call, src, parentClass)
 		if target == "" {
 			continue
 		}
+		// Issue #1694 — cross-module attribute call.
+		// Detect the `<import_alias>.<leaf>(...)` shape and stamp the
+		// resolver hint properties. callTarget returned the bare leaf with
+		// ambiguous=true for this shape; we keep the bare leaf as ToID
+		// (so ResolveImports' `ContainsAny(":.#")` skip doesn't drop the
+		// edge before the cross-module path runs) and add the alias hint
+		// so the resolver can look the binding up against the file's
+		// import bucket.
+		var importAlias string
+		if len(imports) > 0 {
+			if alias, leaf := extractCallTargetImportAlias(call, src, imports); alias != "" {
+				importAlias = alias
+				// Defensive: extractCallTargetImportAlias returned the
+				// same leaf callTarget surfaced, but if they ever diverge
+				// (grammar drift) prefer the import-aware leaf so the
+				// resolver tuple is always consistent.
+				target = leaf
+			}
+		}
 		// Drop self-recursion. The bare-name match preserves prior behavior
 		// for module-level recursion (parentClass == ""); the dotted match
-		// catches `self.foo()` inside the owning class.
-		if target == callerName || target == selfQualified {
+		// catches `self.foo()` inside the owning class. Self-recursion can't
+		// be a cross-module call, so this only fires when importAlias == "".
+		if importAlias == "" && (target == callerName || target == selfQualified) {
 			continue
 		}
-		if seen[target] {
+		key := seenKey{target, importAlias}
+		if seen[key] {
 			continue
 		}
-		seen[target] = true
+		seen[key] = true
 		r := types.RelationshipRecord{
 			ToID: target,
 			Kind: "CALLS",
 		}
-		if ambiguous {
+		switch {
+		case importAlias != "":
+			// Cross-module attribute call — the resolver's
+			// ResolveCrossModuleCallTarget consumes these properties to
+			// look up (source_module, leaf) against the file's import
+			// bucket. The ambiguous hint is dropped because the
+			// import_alias now disambiguates the call site precisely.
+			r.Properties = map[string]string{
+				"import_alias": importAlias,
+				"call_leaf":    target,
+			}
+		case ambiguous:
 			r.Properties = map[string]string{"disposition_hint": "ambiguous"}
 		}
 		rels = append(rels, r)
@@ -915,7 +968,14 @@ func extractImports(root *sitter.Node, file extractor.FileInput) []types.EntityR
 	}
 	for _, n := range findAll(root, "import_from_statement") {
 		modNode := n.ChildByFieldName("module_name")
-		modPath := dottedNamePath(modNode, file.Content)
+		// Issue #1694 — resolve relative imports (`from . import x`,
+		// `from ..pkg import y`) to their absolute dotted module form
+		// using the current file's path. Non-relative imports return
+		// the literal source text via dottedNamePath, matching prior
+		// behaviour exactly. This makes the resolver's `(module, leaf)`
+		// reverse index bind relative-import callsites without any
+		// extra resolution layer.
+		modPath := resolvePythonImportModule(modNode, file)
 		if modPath == "" {
 			continue
 		}

--- a/internal/resolve/imports.go
+++ b/internal/resolve/imports.go
@@ -1181,6 +1181,91 @@ func (t ImportTable) ResolveCrossFileReferenceTarget(callerFile, name string) (s
 	return "", false
 }
 
+// ResolveCrossModuleCallTarget resolves a Python attribute-call site of the
+// shape `<alias>.<leaf>(...)` where `alias` is a local name introduced by an
+// import in callerFile. Issue #1694.
+//
+// The Python extractor stamps two Properties on every CALLS edge that
+// originated from a `<alias>.<leaf>(...)` shape:
+//
+//	Properties["import_alias"] = "<alias>"
+//	Properties["call_leaf"]    = "<leaf>"
+//
+// The ToID is intentionally left as the bare leaf name so the
+// `ContainsAny(":.#")` skip in ResolveImports doesn't drop the edge before
+// this function runs. This function looks the alias up in the file's
+// import bucket and probes `lookupModuleEntity` with the correct
+// (module, name) tuple depending on which import shape introduced the
+// alias:
+//
+//	import x[.y]           → (alias=x, source_module=imported_name=x[.y])
+//	                          → lookup (x[.y], leaf)
+//	from x import y        → (alias=y, source_module=x, imported_name=y)
+//	                          → lookup (x.y, leaf)   — y is a submodule
+//	                          → lookup (x, leaf)     — y is a class/struct
+//	                            (rare: same-class chained call where the
+//	                            class lives in x and exposes a classmethod
+//	                            named `leaf`; the resolver's byMember path
+//	                            would otherwise miss because the receiver
+//	                            type is unknown at extraction time)
+//
+// The two-step probe for the `from x import y` shape is conservative — the
+// submodule lookup is tried first and only falls through to the
+// (x, leaf) shape when the submodule probe finds no match. This avoids
+// binding a true submodule call to a same-module same-named symbol.
+//
+// Returns ("", false) when:
+//   - leaf is empty
+//   - the alias is not in the file's import bucket
+//   - neither (module, leaf) tuple resolves unambiguously
+//
+// In those cases the caller leaves the original bare-name ToID in place
+// and the downstream bare-name resolver gets a turn.
+func (t ImportTable) ResolveCrossModuleCallTarget(callerFile, alias, leaf string) (string, bool) {
+	if alias == "" || leaf == "" {
+		return "", false
+	}
+	callerFile = normalizePath(callerFile)
+	bucket := t.byFile[callerFile]
+	if bucket == nil {
+		return "", false
+	}
+	b, ok := bucket[alias]
+	if !ok {
+		return "", false
+	}
+	if b.SourceModule == "" {
+		return "", false
+	}
+	// `import x` shape — alias IS the module name.
+	if b.ImportedName == b.SourceModule {
+		if id, ok := t.lookupModuleEntity(b.SourceModule, leaf); ok {
+			return id, true
+		}
+		return "", false
+	}
+	// `from x import y` shape — the alias may be a submodule of x or a
+	// symbol exposed by x. Try submodule first.
+	if b.ImportedName != "" {
+		submod := b.SourceModule + "." + b.ImportedName
+		if id, ok := t.lookupModuleEntity(submod, leaf); ok {
+			return id, true
+		}
+	}
+	// Same-class fallback: the alias is a class imported from module x,
+	// and `<alias>.<leaf>` is a classmethod call.
+	if id, ok := t.lookupModuleEntity(b.SourceModule, leaf); ok {
+		// Sanity guard — only accept this fallback when the class itself
+		// also lives in (source_module, imported_name). Otherwise we could
+		// bind to an unrelated function named `leaf` in module x.
+		if classID, classOk := t.lookupModuleEntity(b.SourceModule, b.ImportedName); classOk && classID != "" {
+			_ = classID // we only need to verify the class is in the module
+			return id, true
+		}
+	}
+	return "", false
+}
+
 // lookupModuleEntity returns (id, true) when (module, name) maps to
 // exactly one entity. Ambiguous tuples return ("", false); the caller
 // leaves the original CALLS stub alone.
@@ -1863,6 +1948,29 @@ func ResolveImports(records []types.EntityRecord, tbl ImportTable) ImportResolve
 					continue
 				}
 				stats.CallsConsidered++
+				// Issue #1694 — Python cross-module attribute call.
+				// The extractor stamps import_alias + call_leaf properties on
+				// CALLS edges that came from a `<alias>.<leaf>(...)` shape.
+				// Resolve those against the per-file import bucket BEFORE the
+				// generic bare-name path so a cross-module call doesn't
+				// silently bind to a same-named symbol via the wildcard or
+				// plain-import fallbacks. When the cross-module probe fails we
+				// fall through to ResolveBareCallTarget so the existing
+				// resolution surface still gets a turn (e.g. the leaf might be
+				// directly imported elsewhere in the file).
+				if rel.Properties != nil {
+					if alias := rel.Properties["import_alias"]; alias != "" {
+						leaf := rel.Properties["call_leaf"]
+						if leaf == "" {
+							leaf = to
+						}
+						if id, ok := tbl.ResolveCrossModuleCallTarget(callerFile, alias, leaf); ok {
+							rel.ToID = id
+							stats.CallsRewritten++
+							continue
+						}
+					}
+				}
 				id, ok := tbl.ResolveBareCallTarget(callerFile, to)
 				if !ok {
 					continue

--- a/internal/resolve/imports_test.go
+++ b/internal/resolve/imports_test.go
@@ -2099,3 +2099,107 @@ func TestResolveImports_ReferencesHexToIDUntouched(t *testing.T) {
 		t.Fatalf("expected hex REFERENCES ToID untouched, got %q", got)
 	}
 }
+
+// callerRecordWithProps builds a caller EntityRecord whose single CALLS
+// edge carries the given ToID + Properties. Used by the cross-module
+// CALL-target tests (issue #1694) to inject the `import_alias` /
+// `call_leaf` hints the Python extractor stamps for
+// `<alias>.<leaf>(...)` shapes.
+func callerRecordWithProps(name, file, target string, props map[string]string) types.EntityRecord {
+	return types.EntityRecord{
+		ID:         "0123456789abcdef",
+		Name:       name,
+		Kind:       "SCOPE.Operation",
+		Subtype:    "function",
+		SourceFile: file,
+		Language:   "python",
+		Relationships: []types.RelationshipRecord{{
+			ToID:       target,
+			Kind:       "CALLS",
+			Properties: props,
+		}},
+	}
+}
+
+// TestResolveImports_CrossModuleCall_FromImportSubmodule covers the
+// canonical PlaceOrderSaga case: `from . import steps;
+// steps.create_order()`. The extractor has resolved the relative import
+// to its absolute dotted form (`services.order_saga.app`) and stamped
+// import_alias="steps", call_leaf="create_order". The resolver must
+// probe (source_module + "." + imported_name, call_leaf) → bind to the
+// real `create_order` entity in services/order_saga/app/steps.py.
+func TestResolveImports_CrossModuleCall_FromImportSubmodule(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("services/order_saga/app/orchestrator.py", "services.order_saga.app.steps", map[string]string{
+			"local_name":    "steps",
+			"source_module": "services.order_saga.app",
+			"imported_name": "steps",
+		}),
+		targetRecord("create_order", "services/order_saga/app/steps.py", "abcdef0123456789"),
+		callerRecordWithProps("run", "services/order_saga/app/orchestrator.py", "create_order", map[string]string{
+			"import_alias": "steps",
+			"call_leaf":    "create_order",
+		}),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d (considered=%d)", stats.CallsRewritten, stats.CallsConsidered)
+	}
+	if got := records[2].Relationships[0].ToID; got != "abcdef0123456789" {
+		t.Fatalf("expected ToID rewritten to abcdef0123456789, got %q", got)
+	}
+}
+
+// TestResolveImports_CrossModuleCall_PlainImport covers `import billing;
+// billing.charge_card()`. import_alias="billing"; source_module ==
+// imported_name; the resolver probes (source_module, call_leaf) directly.
+func TestResolveImports_CrossModuleCall_PlainImport(t *testing.T) {
+	records := []types.EntityRecord{
+		importerRecord("services/orders/checkout.py", "billing", map[string]string{
+			"local_name":    "billing",
+			"source_module": "billing",
+			"imported_name": "billing",
+		}),
+		targetRecord("charge_card", "billing/__init__.py", "1111222233334444"),
+		callerRecordWithProps("checkout", "services/orders/checkout.py", "charge_card", map[string]string{
+			"import_alias": "billing",
+			"call_leaf":    "charge_card",
+		}),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 1 {
+		t.Fatalf("expected 1 rewrite, got %d", stats.CallsRewritten)
+	}
+	if got := records[2].Relationships[0].ToID; got != "1111222233334444" {
+		t.Fatalf("expected ToID 1111222233334444, got %q", got)
+	}
+}
+
+// TestResolveImports_CrossModuleCall_UnknownAliasUnchanged confirms that
+// when the import_alias hint references a name that is NOT in the file's
+// import bucket (e.g. the alias was shadowed by a local variable), the
+// resolver leaves the bare leaf ToID alone — it does not fall through to
+// the generic bare-name resolution that would otherwise bind the leaf
+// to a same-named symbol via wildcard / plain-import branches.
+func TestResolveImports_CrossModuleCall_UnknownAliasUnchanged(t *testing.T) {
+	// A target named `charge_card` exists in module `billing`, but the
+	// caller's file imports nothing — the cross-module probe must miss
+	// and the bare-name resolver must also miss (no binding).
+	records := []types.EntityRecord{
+		targetRecord("charge_card", "billing/__init__.py", "9999888877776666"),
+		callerRecordWithProps("checkout", "services/orders/checkout.py", "charge_card", map[string]string{
+			"import_alias": "billing", // alias not in bucket
+			"call_leaf":    "charge_card",
+		}),
+	}
+	tbl := BuildImportTable(records)
+	stats := ResolveImports(records, tbl)
+	if stats.CallsRewritten != 0 {
+		t.Fatalf("expected 0 rewrites (no import binding), got %d", stats.CallsRewritten)
+	}
+	if got := records[1].Relationships[0].ToID; got != "charge_card" {
+		t.Fatalf("expected bare ToID untouched, got %q", got)
+	}
+}


### PR DESCRIPTION
## Problem (#1694)

The Python extractor's `extractCallRelationships` collapses every attribute call (`recv.leaf(...)`) with a non-statically-typed receiver to the bare leaf name + `disposition_hint=ambiguous`. For the dominant cross-module idioms the bare-leaf ToID has no binding in the file's import bucket, so the import-aware resolver leaves the edge orphan:

- `import x; x.fn(...)` — module-attribute call
- `from x import y; y.fn(...)` — submodule attribute call
- `from . import steps; steps.create_order(...)` — relative-import + submodule attribute

This kills every saga / orchestrator pattern on the polyglot calibration corpus and traces back to the polyglot benchmark scoring 0.45 vs grep 0.92 on saga / orchestrator questions.

## Root cause

`callTarget` in `internal/extractors/python/extractor.go` infers a receiver class only for `self`, `cls`, `ClassName()`, and PEP-8 PascalCase identifiers. Every lowercase identifier receiver (the dominant cross-module shape) falls through to bare-leaf with the ambiguous hint. The downstream resolver's bare-name path can only bind to a leaf that was directly `from x import <leaf>`-ed, never to a member of an imported module.

## Fix

1. **Pre-scan top-level imports** into a per-file `local_name → binding` map BEFORE `walkNode` runs (`crossmodule_calls.go`). Relative source modules (`.`, `..foo`) are resolved to their absolute dotted form using the current file's path so the resolver's `(module, leaf)` reverse index can bind them.

2. **`extractCallRelationships`** now consults the map: when the shape is `<alias>.<leaf>(...)` and `alias` is a local import binding, it stamps `Properties{import_alias, call_leaf}` on the CALLS edge. The ToID stays as the bare leaf so the existing `ContainsAny(\":.#\")` skip in `ResolveImports` doesn't drop the edge before the new resolution path runs.

3. **`internal/resolve/imports.go`** adds `ResolveCrossModuleCallTarget` which probes `(source_module, leaf)` or `(source_module + \".\" + imported_name, leaf)` against the existing reverse index depending on the import shape (`import x` vs `from x import y`). `ResolveImports` dispatches to it BEFORE `ResolveBareCallTarget` so the alias hint wins over wildcard / plain-import fallbacks.

4. **`extractImports`** resolves relative module paths the same way so the IMPORTS edge itself binds in `BuildImportTable` — without that, the resolver wouldn't know about the binding at lookup time.

## Verification

- **5 new extractor tests** (`crossmodule_calls_test.go`): the canonical PlaceOrderSaga shape, plain `import x`, `from x import y` direct call (no alias property stamped — regression guard), self-recursion unchanged, non-import receiver still gets `disposition_hint=ambiguous`, relative-import absolute source_module.
- **3 new resolver tests** (`imports_test.go`): the from-import-submodule rewrite that fixes #1694, the plain-import rewrite, and an unknown-alias passthrough (must NOT rewrite when alias isn't in the bucket).
- **Existing python + resolve test packages** pass with no regressions (`go test ./internal/extractors/python/ ./internal/resolve/`).
- **Live polyglot reindex (ledger):** `balance` → `get_balance` CALLS edge now resolves end-to-end. This is the textbook `from . import projections; projections.get_balance(...)` pattern from `services/ledger/app/read_routes.py`. Pre-fix this edge was missing.

## Tradeoffs

- The fix is intentionally narrow: only `<bare-identifier>.<leaf>(...)` shapes are qualified. Chained attribute calls (`a.b.c()`), subscript receivers, and method calls on non-identifier receivers fall through to the existing `callTarget` paths — emitting a guess there would risk binding edges to the wrong entity.
- The `from x import y` shape has two-step resolution: `(source_module.imported_name, leaf)` is tried first (treating `y` as a submodule); falls through to `(source_module, leaf)` ONLY when the class `y` itself also lives in `source_module` (sanity-checked via a second `lookupModuleEntity`). This avoids binding a true submodule call to an unrelated same-named symbol.
- Local-call behaviour (same-module bare function references) is untouched — those never enter the new code path.

## Files touched

- `internal/extractors/python/crossmodule_calls.go` (new) — `pythonImportMap`, `buildPythonImportMap`, `resolvePythonImportModule`, `extractCallTargetImportAlias`
- `internal/extractors/python/crossmodule_calls_test.go` (new) — 5 extractor tests
- `internal/extractors/python/extractor.go` — thread `importMap` through `walkNode` + `extractCallRelationships`; emit `import_alias` / `call_leaf` properties; resolve relative imports in `extractImports`
- `internal/resolve/imports.go` — `ResolveCrossModuleCallTarget` + dispatch in `ResolveImports`
- `internal/resolve/imports_test.go` — 3 resolver tests

Fixes #1694

🤖 Generated with [Claude Code](https://claude.com/claude-code)