### PR TITLE
fix(links): canonicalise emitted repo prefix to fleet slug (Fixes #1701)

### DIFF
--- a/internal/links/links.go
+++ b/internal/links/links.go
@@ -390,16 +390,48 @@ func loadAllGraphs(graphsDir string) ([]repoGraph, error) {
 			return nil, fmt.Errorf("load graph in %s: %w", dir, err)
 		}
 
-		repoName := doc.Repo
+		// Prefer the staged directory name as the canonical slug.
+		// When called via stageGraphsDir, each graph file is at
+		// <tmp>/<fleet-slug>/graph.{fb,json} so filepath.Base(dir) is the
+		// exact fleet slug (dash form). doc.Repo, by contrast, is set from
+		// the repoTag written at index time — historically derived from the
+		// on-disk directory basename, which may use underscores where the
+		// fleet config uses dashes (e.g. "upvate_core" vs "upvate-core").
+		// Using the directory name here means the emitter writes the correct
+		// fleet slug into Link.Source / Link.Target, so downstream readers
+		// (MCP find_paths, dashboard graph merge) never need to alias-map
+		// the underscore form. Fixes #1701.
+		//
+		// Special case: when the graph file lives in a hidden subdirectory
+		// (e.g. <repo>/.archigraph/graph.json in test fixtures and legacy
+		// on-disk layouts), the immediate basename is ".archigraph" — not
+		// a useful slug. In that case fall up one level to the repo directory
+		// name, which agrees with doc.Repo. If that is also unhelpful, fall
+		// back to doc.Repo.
+		dirBase := filepath.Base(dir)
+		if strings.HasPrefix(dirBase, ".") {
+			// Hidden sub-dir (e.g. .archigraph): use parent directory name.
+			dirBase = filepath.Base(filepath.Dir(dir))
+		}
+		repoName := dirBase
+		if repoName == "" || repoName == "." {
+			repoName = doc.Repo
+		}
 		if repoName == "" {
-			// Fallback: derive from the slug sub-directory name (one level up
-			// from the staged dir, which has layout <tmp>/<slug>/graph.{fb,json}).
+			// Final fallback: use the symlink-resolved directory.
 			repoName = filepath.Base(realDir)
 		}
 		if seen[repoName] {
 			continue
 		}
 		seen[repoName] = true
+		// Also mark the graph-embedded repo name as seen so that if the same
+		// repo is encountered a second time (e.g. both graph.fb and graph.json
+		// present, or a symlink loop), the underscore variant won't be loaded
+		// as a separate repo.
+		if doc.Repo != "" && doc.Repo != repoName {
+			seen[doc.Repo] = true
+		}
 
 		rg := repoGraph{
 			Repo:     repoName,

--- a/internal/links/links_test.go
+++ b/internal/links/links_test.go
@@ -724,3 +724,154 @@ func TestLoadAllGraphs_MixedFBAndJSON(t *testing.T) {
 		t.Errorf("frontend (fb-only) not loaded; repos found: %v", slugs)
 	}
 }
+
+// TestLoadAllGraphs_SlugCanonicalisation verifies that when a staged
+// directory is named after the fleet slug (dash form) but the embedded
+// doc.Repo field uses the path-derived underscore form, loadAllGraphs
+// returns the dash-slug as repoGraph.Repo. This is the #1701 regression:
+// the links emitter was writing "upvate_core::<id>" targets instead of
+// "upvate-core::<id>", causing find_paths to need an alias map.
+func TestLoadAllGraphs_SlugCanonicalisation(t *testing.T) {
+	root := t.TempDir()
+
+	// Simulate the staged layout: <tmp>/<fleet-slug>/graph.fb
+	// doc.Repo is the underscore form (as historically written by the indexer).
+	writeRepoFB := func(dirSlug, docRepo string, doc *graph.Document) {
+		t.Helper()
+		dir := filepath.Join(root, dirSlug)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		doc.Repo = docRepo
+		if err := fbwriter.WriteAtomic(filepath.Join(dir, "graph.fb"), doc); err != nil {
+			t.Fatalf("write graph.fb for %s: %v", dirSlug, err)
+		}
+	}
+
+	// Fleet slug uses dashes; on-disk repo dir used underscores.
+	writeRepoFB("api-service", "api_service", &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "a1", Name: "UserHandler", Kind: "function", SourceFile: "handler.go"},
+		},
+	})
+	writeRepoFB("mobile-app", "mobile_app", &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "m1", Name: "fetchUser", Kind: "function", SourceFile: "api.ts"},
+		},
+	})
+
+	graphs, err := loadAllGraphs(root)
+	if err != nil {
+		t.Fatalf("loadAllGraphs: %v", err)
+	}
+	if len(graphs) != 2 {
+		t.Fatalf("expected 2 graphs, got %d", len(graphs))
+	}
+
+	byRepo := make(map[string]repoGraph, len(graphs))
+	for _, g := range graphs {
+		byRepo[g.Repo] = g
+	}
+
+	// The canonical slug (dash form from the dir name) must be used, NOT the
+	// underscore form from doc.Repo.
+	for _, want := range []string{"api-service", "mobile-app"} {
+		if _, ok := byRepo[want]; !ok {
+			t.Errorf("expected repo %q (dash slug), got repos: %v — emitter would write underscore prefix (Fixes #1701)", want, keys(byRepo))
+		}
+	}
+	for _, bad := range []string{"api_service", "mobile_app"} {
+		if _, ok := byRepo[bad]; ok {
+			t.Errorf("repo %q (underscore form) found in output — should have been canonicalised to dash form (Fixes #1701)", bad)
+		}
+	}
+}
+
+// TestRunAllPasses_SlugCanonicalisation verifies end-to-end that RunAllPasses
+// writes Link.Source / Link.Target using the fleet slug (dir-name, dash form)
+// when the staged directories use dash-form slugs but doc.Repo uses underscore.
+// This is the emitter-level fix for #1701.
+func TestRunAllPasses_SlugCanonicalisation(t *testing.T) {
+	root := t.TempDir()
+	home := filepath.Join(root, "ag-home")
+
+	// Write two repos in staged-layout (flat dir named after slug, no
+	// .archigraph subdir) with doc.Repo in the underscore form.
+	writeFlat := func(slug, docRepo string) {
+		t.Helper()
+		dir := filepath.Join(root, slug)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		raw := map[string]any{
+			"version": 1,
+			"repo":    docRepo, // underscore form — what the indexer historically wrote
+			"entities": []map[string]any{
+				{"id": slug + "1", "name": "Foo", "kind": "function", "source_file": "main.go"},
+				{"id": slug + "2", "name": "ext:" + strings.ReplaceAll(slug, "-", "_"), "kind": "class", "subtype": "package", "source_file": ""},
+			},
+			"relationships": []map[string]any{
+				{"from_id": slug + "1", "to_id": slug + "2", "kind": "imports"},
+			},
+		}
+		b, _ := json.Marshal(raw)
+		if err := os.WriteFile(filepath.Join(dir, "graph.json"), b, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// api-service (slug) / api_service (doc.Repo) imports mobile-app (slug) / mobile_app (doc.Repo).
+	writeFlat("api-service", "api_service")
+	writeFlat("mobile-app", "mobile_app")
+
+	// Write a graph for "mobile-app" that has an entity whose name matches the
+	// external import from "api-service" so import pass can link them.
+	mobileDir := filepath.Join(root, "mobile-app")
+	mobileDoc := map[string]any{
+		"version": 1,
+		"repo":    "mobile_app",
+		"entities": []map[string]any{
+			{"id": "mob1", "name": "MobileMain", "kind": "function", "source_file": "app.go"},
+		},
+		"relationships": []map[string]any{},
+	}
+	b, _ := json.Marshal(mobileDoc)
+	if err := os.WriteFile(filepath.Join(mobileDir, "graph.json"), b, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	_ = b
+
+	res, err := RunAllPasses("slug-test", root, home)
+	if err != nil {
+		t.Fatalf("RunAllPasses: %v", err)
+	}
+
+	doc, err := readDoc(res.OutLinks)
+	if err != nil {
+		t.Fatalf("readDoc: %v", err)
+	}
+
+	// Every Source and Target prefix must use the dash form, never the
+	// underscore form.
+	for _, l := range doc.Links {
+		for _, endpoint := range []string{l.Source, l.Target} {
+			if idx := strings.Index(endpoint, "::"); idx > 0 {
+				prefix := endpoint[:idx]
+				if strings.Contains(prefix, "_") {
+					// Reject underscore-prefixed targets (#1701).
+					t.Errorf("link %s→%s: endpoint %q uses underscore prefix (want dash slug, Fixes #1701)",
+						l.Source, l.Target, endpoint)
+				}
+			}
+		}
+	}
+}
+
+// keys returns the sorted key list of a map[string]repoGraph.
+func keys(m map[string]repoGraph) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	return out
+}


### PR DESCRIPTION
## What

The link emitter was writing `Link.Source` / `Link.Target` using the graph-embedded `doc.Repo` field (e.g. `upvate_core`) instead of the fleet-config slug (e.g. `upvate-core`). Downstream readers — MCP `find_paths` and the dashboard graph-merge path — had to carry alias maps to compensate.

## Why it happened

`loadAllGraphs` (in `internal/links/links.go`) used `doc.Repo` as the primary source for `repoGraph.Repo`. That field is set at index time from the on-disk directory basename, which historically used underscores. The calling code (`stageGraphsDir`) already creates the staged temporary directory named after `r.Slug` (the fleet slug, dash form), so `filepath.Base(dir)` is the canonical slug — but it was never consulted.

## Fix

In `loadAllGraphs`, prefer `filepath.Base(dir)` (the staged directory name = fleet slug) over `doc.Repo` for `repoName`. Special-case: when the graph file sits in a hidden subdirectory (`.archigraph/graph.json` in test fixtures / legacy layouts), the basename is `.archigraph` — walk up one level instead. Also mark `doc.Repo` as seen in the dedup set to prevent double-loading when both the dash and underscore forms are encountered.

## Backward compatibility

**Read path unchanged.** The `#1699` alias map in `find_paths` / `buildRepoAliasMap` continues to resolve legacy links files that still use the underscore prefix. No migration needed — fresh reindexes emit the dash form; old files keep working.

## Verification

- `TestLoadAllGraphs_SlugCanonicalisation`: staged dir named `api-service` + `doc.Repo = "api_service"` → `loadAllGraphs` returns `Repo = "api-service"` (dash).
- `TestRunAllPasses_SlugCanonicalisation`: end-to-end `RunAllPasses` with staged dirs; every `Link.Source` / `Link.Target` prefix uses dashes, never underscores.
- **Live reindex of upvate**: after running the fixed `links pass upvate`, `~/.archigraph/groups/upvate-links.json` prefixes changed from `['core-mobile', 'upvate-core-frontend', 'upvate_core']` → `['core-mobile', 'upvate-core', 'upvate-core-frontend']` — `upvate_core` gone.
- `TestFindPaths_1690_RepoPrefixAlias` still passes (legacy underscore target resolved via alias map).
- `go build ./...` + `go vet ./...` clean.
- `go test ./internal/links/... ./internal/cli/... ./internal/mcp/...` all green.

## Files changed

- `internal/links/links.go` — prefer dir-basename over `doc.Repo` in `loadAllGraphs`; also alias-dedup `doc.Repo`
- `internal/links/links_test.go` — two new tests: `TestLoadAllGraphs_SlugCanonicalisation` and `TestRunAllPasses_SlugCanonicalisation`

Fixes #1701

🤖 Generated with [Claude Code](https://claude.com/claude-code)