### PR TITLE
[#1700] Extend class-shadow fold to cover SCOPE.Service and all SCOPE.-prefixed class kinds

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2361,19 +2361,39 @@ type foldShadowStats struct {
 // node we fold AWAY into a framework-typed survivor (so a class with a View
 // resolves to ONE node), and it is itself the survivor only when no
 // framework-typed node exists (handled separately, never as a candidate here).
+//
+// Both bare kind names (emitted by Java/Django custom extractors) AND their
+// "SCOPE."-prefixed forms (emitted by Kotlin, TypeScript, proto, and pattern
+// extractors) must appear so that frameworkClassKindPriority[r.Kind] matches
+// regardless of which extractor emitted the survivor. Issue #1700.
 var frameworkClassKindPriority = map[string]int{
+	// Bare names (Java/Django/Spring-boot custom extractors)
 	"Model":          100,
 	"View":           100,
 	"Controller":     100,
 	"Service":        100,
 	"Middleware":     100,
 	"Repository":     100,
+	"Worker":         100,
+	"Job":            100,
+	"Topic":          100,
 	"TestClass":      90,
 	"Schema":         80,
 	"Plugin":         80,
 	"Implementation": 80,
 	"Interface":      80,
 	"Task":           70,
+
+	// SCOPE.-prefixed equivalents (Kotlin extractor, proto extractor, NestJS
+	// service_detector, and any other extractor that emits the canonical
+	// "SCOPE.<Kind>" form for a class-like entity). Priorities mirror the bare
+	// form so that the highest-fidelity named node always beats a generic shadow.
+	"SCOPE.Service":    100,
+	"SCOPE.View":       100,
+	"SCOPE.Model":      100,
+	"SCOPE.UIComponent": 100,
+	"SCOPE.GrpcService": 90,
+	"SCOPE.Schema":     80,
 }
 
 func isShadowRecord(r *types.EntityRecord) bool {
@@ -2382,9 +2402,20 @@ func isShadowRecord(r *types.EntityRecord) bool {
 
 // classLikeComponentSubtypes are the SCOPE.Component subtypes that denote a
 // class/type declaration (as opposed to subtype="file"/"import"/"module").
+// Language AST subtypes ("class", "struct", …) are the primary set. Framework-
+// injected subtypes from NestJS, Angular, Spring-boot, Quarkus, and similar
+// extractors are included so that an inferential SCOPE.Component(subtype="service")
+// node emitted alongside a real SCOPE.Service node for the same class symbol is
+// recognised as a fold source and collapsed into the typed survivor. Issue #1700.
 var classLikeComponentSubtypes = map[string]bool{
+	// Language AST subtypes
 	"class": true, "struct": true, "interface": true,
 	"protocol": true, "trait": true, "behaviour": true,
+	// Framework-injected subtypes (NestJS, Angular, Spring, Quarkus, …)
+	"service": true, "controller": true, "repository": true,
+	"guard": true, "interceptor": true, "pipe": true,
+	"middleware": true, "resolver": true, "gateway": true,
+	"worker": true, "job": true, "task": true,
 }
 
 // isFoldSource reports whether r is a class-representation node that should be

--- a/cmd/archigraph/nestjs_shadow_fold_test.go
+++ b/cmd/archigraph/nestjs_shadow_fold_test.go
@@ -1,0 +1,137 @@
+package main
+
+import (
+	"testing"
+)
+
+// TestClassShadowFold_ServiceKind_Kotlin asserts the #1700 fix for the Kotlin
+// Spring case: a class annotated @Service emits SCOPE.Service (Kotlin extractor)
+// while the hierarchy pass emits a companion SCOPE.Component/class shadow for
+// the same (source_file, name). The fold must absorb the shadow so that
+// ChannelRegistry resolves to exactly ONE node of kind SCOPE.Service.
+//
+// Before #1700 the fix only covered bare "Service" in frameworkClassKindPriority,
+// not the "SCOPE.Service" kind that the Kotlin extractor actually emits.
+func TestClassShadowFold_ServiceKind_Kotlin(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/spring_app", "spring_app", nil)
+
+	byName := map[string][]entitySummary{}
+	for _, e := range doc.Entities {
+		if e.Name == "" {
+			continue
+		}
+		byName[e.Name] = append(byName[e.Name], entitySummary{
+			Kind:    e.Kind,
+			Subtype: e.Subtype,
+			Line:    e.StartLine,
+		})
+	}
+
+	// ChannelRegistry is declared @Service in Kotlin. The Kotlin extractor
+	// emits SCOPE.Service; the hierarchy extractor additionally emits
+	// SCOPE.Component/class for the same symbol. After the fold exactly one
+	// class-declaration node must remain (the SCOPE.Service survivor).
+	nodes := byName["ChannelRegistry"]
+	var decls []entitySummary
+	for _, n := range nodes {
+		if n.Subtype == "file" || n.Subtype == "import" || n.Subtype == "module" {
+			continue
+		}
+		decls = append(decls, n)
+	}
+	if len(decls) != 1 {
+		t.Errorf("ChannelRegistry: expected 1 class-declaration node after fold, got %d: %v",
+			len(decls), decls)
+	} else if decls[0].Kind != "SCOPE.Service" {
+		t.Errorf("ChannelRegistry: surviving node should be SCOPE.Service, got kind=%s subtype=%s",
+			decls[0].Kind, decls[0].Subtype)
+	}
+
+	// No INFERRED_FROM_CLASS_HIERARCHY shadow must survive for any entity.
+	for _, e := range doc.Entities {
+		if e.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY" {
+			t.Errorf("surviving INFERRED_FROM_CLASS_HIERARCHY shadow: %s (%s/%s)",
+				e.Name, e.Kind, e.Subtype)
+		}
+	}
+}
+
+// TestClassShadowFold_ServiceKind_NestJS asserts that @Injectable NestJS
+// classes (which emit SCOPE.Component/service from the custom extractor and
+// SCOPE.Component/class from the AST extractor) collapse to a single node.
+func TestClassShadowFold_ServiceKind_NestJS(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/nestjs_app", "nestjs_app", nil)
+
+	if len(doc.Entities) == 0 {
+		t.Fatal("nestjs_app: no entities extracted")
+	}
+
+	byName := map[string][]entitySummary{}
+	for _, e := range doc.Entities {
+		if e.Name == "" {
+			continue
+		}
+		byName[e.Name] = append(byName[e.Name], entitySummary{
+			Kind:    e.Kind,
+			Subtype: e.Subtype,
+			Line:    e.StartLine,
+		})
+	}
+
+	for _, name := range []string{"ChannelRegistry", "NotificationService"} {
+		nodes, ok := byName[name]
+		if !ok {
+			t.Errorf("%s: no entity found after indexing", name)
+			continue
+		}
+		var decls []entitySummary
+		for _, n := range nodes {
+			if n.Subtype == "file" || n.Subtype == "import" || n.Subtype == "module" {
+				continue
+			}
+			decls = append(decls, n)
+		}
+		if len(decls) != 1 {
+			t.Errorf("%s: expected exactly 1 class-declaration node after fold, got %d: %v",
+				name, len(decls), decls)
+		}
+	}
+
+	for _, e := range doc.Entities {
+		if e.Properties["provenance"] == "INFERRED_FROM_CLASS_HIERARCHY" {
+			t.Errorf("surviving INFERRED_FROM_CLASS_HIERARCHY shadow: %s (%s/%s)",
+				e.Name, e.Kind, e.Subtype)
+		}
+	}
+}
+
+// TestClassShadowFold_ServiceKind_NoDanglingEdges asserts the fold does not
+// introduce new dangling hex-id edge endpoints in either fixture.
+func TestClassShadowFold_ServiceKind_NoDanglingEdges(t *testing.T) {
+	for _, tc := range []struct {
+		path string
+		tag  string
+	}{
+		{"testdata/spring_app", "spring_app"},
+		{"testdata/nestjs_app", "nestjs_app"},
+	} {
+		t.Run(tc.tag, func(t *testing.T) {
+			t.Setenv("ARCHIGRAPH_DISABLE_1613_FOLD", "1")
+			unfolded := runIndexerOn(t, tc.path, tc.tag, nil)
+			t.Setenv("ARCHIGRAPH_DISABLE_1613_FOLD", "")
+			folded := runIndexerOn(t, tc.path, tc.tag, nil)
+
+			if d := danglingHexEndpoints(folded); d > danglingHexEndpoints(unfolded) {
+				t.Errorf("fold introduced new dangling hex endpoints: folded=%d unfolded=%d",
+					d, danglingHexEndpoints(unfolded))
+			}
+		})
+	}
+}
+
+// entitySummary is a compact representation of an entity for test diagnostics.
+type entitySummary struct {
+	Kind    string
+	Subtype string
+	Line    int
+}

--- a/cmd/archigraph/testdata/nestjs_app/package.json
+++ b/cmd/archigraph/testdata/nestjs_app/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "nestjs-app",
+  "version": "1.0.0",
+  "dependencies": {
+    "@nestjs/common": "^10.0.0",
+    "@nestjs/core": "^10.0.0"
+  }
+}

--- a/cmd/archigraph/testdata/nestjs_app/src/channel-registry.service.ts
+++ b/cmd/archigraph/testdata/nestjs_app/src/channel-registry.service.ts
@@ -1,0 +1,25 @@
+import { Injectable } from '@nestjs/common';
+
+/**
+ * ChannelRegistry tracks all active WebSocket channels.
+ * Marked @Injectable so NestJS injects it into dependent modules.
+ */
+@Injectable()
+export class ChannelRegistry {
+  private readonly channels = new Map<string, Set<string>>();
+
+  register(channelId: string, clientId: string): void {
+    if (!this.channels.has(channelId)) {
+      this.channels.set(channelId, new Set());
+    }
+    this.channels.get(channelId)!.add(clientId);
+  }
+
+  unregister(channelId: string, clientId: string): void {
+    this.channels.get(channelId)?.delete(clientId);
+  }
+
+  getClients(channelId: string): string[] {
+    return Array.from(this.channels.get(channelId) ?? []);
+  }
+}

--- a/cmd/archigraph/testdata/nestjs_app/src/notification.service.ts
+++ b/cmd/archigraph/testdata/nestjs_app/src/notification.service.ts
@@ -1,0 +1,19 @@
+import { Injectable } from '@nestjs/common';
+import { ChannelRegistry } from './channel-registry.service';
+
+/**
+ * NotificationService sends messages to registered clients through the
+ * ChannelRegistry. Demonstrates a second @Injectable class so we can spot-
+ * check that the fold works for more than one service per fixture.
+ */
+@Injectable()
+export class NotificationService {
+  constructor(private readonly registry: ChannelRegistry) {}
+
+  broadcast(channelId: string, message: string): void {
+    const clients = this.registry.getClients(channelId);
+    clients.forEach(clientId => {
+      console.log(`[${channelId}] -> ${clientId}: ${message}`);
+    });
+  }
+}

--- a/cmd/archigraph/testdata/spring_app/src/main/kotlin/com/example/ChannelRegistry.kt
+++ b/cmd/archigraph/testdata/spring_app/src/main/kotlin/com/example/ChannelRegistry.kt
@@ -1,0 +1,26 @@
+package com.example
+
+import org.springframework.stereotype.Service
+
+/**
+ * ChannelRegistry tracks active WebSocket channels.
+ * The @Service annotation causes the Kotlin extractor to emit SCOPE.Service
+ * (with provenance="@Service"), while the hierarchy extractor simultaneously
+ * emits SCOPE.Component/class for the same symbol. Without the #1700 fix,
+ * both nodes survive: this class tests that SCOPE.Service absorbs the shadow.
+ */
+@Service
+class ChannelRegistry {
+    private val channels = mutableMapOf<String, MutableSet<String>>()
+
+    fun register(channelId: String, clientId: String) {
+        channels.getOrPut(channelId) { mutableSetOf() }.add(clientId)
+    }
+
+    fun unregister(channelId: String, clientId: String) {
+        channels[channelId]?.remove(clientId)
+    }
+
+    fun getClients(channelId: String): List<String> =
+        channels[channelId]?.toList() ?: emptyList()
+}


### PR DESCRIPTION
## What

Fixes the polyglot iter3 duplicate-node bug where `ChannelRegistry` (and any other Spring/Kotlin/NestJS class annotated with a framework stereotype) appeared as **two entities** at the same `source_file + line`:
- `SCOPE.Service` (from the Kotlin extractor, proto extractor, or service_detector)
- `SCOPE.Component` / subtype `class` (from the language AST extractor)

## Why it broke

`foldClassHierarchyShadows` (shipped in #1636) maintains a `frameworkClassKindPriority` map to identify fold **survivors** — the typed node that absorbs the generic shadow. The map only contained **bare** kind names (`"Service"`, `"Model"`, …) but several extractors emit the canonical **`SCOPE.`-prefixed** form:

| Extractor | Kind emitted |
|---|---|
| Kotlin (`@Service` / `@Repository` / `@Controller`) | `SCOPE.Service` |
| Proto extractor | `SCOPE.Service` |
| NestJS service_detector | `SCOPE.Service` |

`frameworkClassKindPriority["SCOPE.Service"]` returned `0` (map miss), so the fold skipped these nodes entirely and both the typed node and the shadow survived.

## Fix (3 changes in `cmd/archigraph/index.go`)

**1. Add `SCOPE.`-prefixed entries to `frameworkClassKindPriority`**

```go
"SCOPE.Service":    100,
"SCOPE.View":       100,
"SCOPE.Model":      100,
"SCOPE.UIComponent": 100,
"SCOPE.GrpcService": 90,
"SCOPE.Schema":     80,
```

Priorities mirror the bare equivalents. Any extractor that emits a namespaced kind for a class-like entity now participates in fold survivor election.

**2. Add missing bare kinds** (`Worker`, `Job`, `Topic`) that were absent from the original allowlist but are emitted by Celery / BullMQ / Kafka extractors.

**3. Extend `classLikeComponentSubtypes`** with framework-injected subtypes:

```go
"service", "controller", "repository",
"guard", "interceptor", "pipe",
"middleware", "resolver", "gateway",
"worker", "job", "task"
```

These subtypes are stamped by the NestJS, Angular, and Spring-boot custom extractors on `SCOPE.Component` nodes. Without them in this set, `isFoldSource` returned `false` for those nodes and they survived alongside the typed survivor.

## Test evidence

New fixture `testdata/spring_app/src/main/kotlin/com/example/ChannelRegistry.kt` — a Kotlin `@Service` class.

**Before fix:** two entities survive for `ChannelRegistry` (`SCOPE.Service` + `SCOPE.Component/class`), fold log shows `folded=0`.

**After fix:** exactly one entity (`SCOPE.Service`) survives, fold log shows `class-shadow-fold: folded=1 (edges_repointed=0)`.

New tests:
- `TestClassShadowFold_ServiceKind_Kotlin` — asserts `ChannelRegistry` resolves to 1 × `SCOPE.Service`
- `TestClassShadowFold_ServiceKind_NestJS` — asserts `@Injectable` NestJS classes collapse to 1 node
- `TestClassShadowFold_ServiceKind_NoDanglingEdges` — fold introduces no new dangling hex edges on either fixture

All existing `TestClassShadowFold_*` tests continue to pass. Only pre-existing failure (`TestModuleCoverage_AllEntitiesTagged`) unrelated to this change.

## Checklist
- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] All shadow fold tests green (`TestClassShadowFold_*`)
- [x] No new test failures vs `origin/main`
- [x] Rebased on latest main

Fixes #1700