### PR TITLE
feat(mcp/denoise): fold Schema field members behind parent in default results

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -245,15 +245,15 @@ Previously named `archigraph_search` (renamed in #668).
 | `context_filter` | string[] | no | `[]` | Edge-kind filter (see [Relationship Types](#relationship-types)). |
 | `repo_filter` | string[] | no | `[]` | Repo names to scope. `["*"]` requests a full dump. |
 | `full` | boolean | no | `false` | Return raw JSON instead of compact text. |
-| `include_noise` | boolean | no | `false` | Keep synthetic nodes (file/module container components, inferred class-hierarchy shadows, raw `SCOPE.Pattern` nodes, built-in `Process` nodes). Excluded by default (#1614). |
+| `include_noise` | boolean | no | `false` | Keep synthetic nodes (file/module container components, inferred class-hierarchy shadows, raw `SCOPE.Pattern` nodes, built-in `Process` nodes, and Schema field members). Excluded by default (#1614, #1712). |
 | `group`, `cwd` | string | no | — | Common args. |
 
-By default results are **de-noised and re-ranked** (#1614): file/module container
-components, inferred class-hierarchy shadows, raw Pattern nodes and array-built-in
-Process nodes are dropped, and real **lined** entities (`start_line > 0`) rank above
-lineless route/resource entities — both above any retained synthetic node. The same
-filtering applies to the `full=true` JSON dump. Set `include_noise=true` to recover
-the unfiltered list.
+By default results are **de-noised and re-ranked** (#1614, #1712): file/module container
+components, inferred class-hierarchy shadows, raw Pattern nodes, array-built-in
+Process nodes, and `SCOPE.Schema/field` member entities are dropped. Real **lined**
+entities (`start_line > 0`) rank above lineless route/resource entities — both above
+any retained synthetic node. The same filtering applies to the `full=true` JSON dump.
+Set `include_noise=true` to recover the unfiltered list.
 
 **Output** — text (default) or JSON when `full=true`:
 

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -787,6 +787,7 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 	}
 	kindFilter := strings.ToLower(argString(req, "kind_filter", ""))
 	limit := argInt(req, "limit", 30)
+	includeNoise := argBool(req, "include_noise", false)
 	repos := reposToConsider(lg, argStringSlice(req, "repo_filter"))
 	ql := strings.ToLower(query)
 
@@ -810,6 +811,12 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 			// matchesKindFilter expands alias kinds (e.g. "http_endpoint" →
 			// [http_endpoint, http_endpoint_definition, http_endpoint_call]).
 			if !matchesKindFilter(e, kindFilter) {
+				continue
+			}
+			// De-noise (#1712): Schema field members (SCOPE.Schema/field entities)
+			// are suppressed from default results — ~25 fields per serializer
+			// class clutter ranked output. Pass include_noise:true to recover them.
+			if !includeNoise && classifyNoise(e) == noiseSchemaField {
 				continue
 			}
 			nameL := strings.ToLower(e.Name)

--- a/internal/mcp/dashboard_tools_test.go
+++ b/internal/mcp/dashboard_tools_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -296,6 +297,82 @@ func TestTopicDetail_RepoAliasRoundtrip(t *testing.T) {
 	})
 	if out2["found"] != true {
 		t.Fatalf("underscore-alias round-trip: expected found=true, got: %v", out2)
+	}
+}
+
+// TestSearchEntities_SchemaFieldFold verifies that SCOPE.Schema/field members
+// are suppressed from default search_entities results and restored when
+// include_noise:true is set (#1712).
+func TestSearchEntities_SchemaFieldFold(t *testing.T) {
+	// Serializer class + 3 field members, all matching the query "Deficiency".
+	entities := []graph.Entity{
+		{
+			ID:         "s1",
+			Name:       "DeficiencyCreateSerializer",
+			Kind:       "SCOPE.Schema",
+			SourceFile: "core/serializers/deficiency_serializer.py",
+			StartLine:  8,
+		},
+		{
+			ID:         "f1",
+			Name:       "DeficiencyCreateSerializer.amount",
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			SourceFile: "core/serializers/deficiency_serializer.py",
+			StartLine:  12,
+		},
+		{
+			ID:         "f2",
+			Name:       "DeficiencyCreateSerializer.created_at",
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			SourceFile: "core/serializers/deficiency_serializer.py",
+			StartLine:  13,
+		},
+		{
+			ID:         "f3",
+			Name:       "DeficiencyCreateSerializer.updated_at",
+			Kind:       "SCOPE.Schema",
+			Subtype:    "field",
+			SourceFile: "core/serializers/deficiency_serializer.py",
+			StartLine:  14,
+		},
+		// Unrelated real entity — must always be returned.
+		{
+			ID:        "op1",
+			Name:      "get_deficiency_list",
+			Kind:      "SCOPE.Operation",
+			StartLine: 40,
+		},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, nil))
+
+	// Default: only the parent class + the operation should appear; fields suppressed.
+	out := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
+		"group": "test",
+		"query": "deficiency",
+	})
+	results, _ := out["results"].([]any)
+	if len(results) != 2 {
+		t.Fatalf("default: expected 2 results (parent class + operation), got %d: %v", len(results), results)
+	}
+	for _, r := range results {
+		obj, _ := r.(map[string]any)
+		name, _ := obj["name"].(string)
+		if strings.HasPrefix(name, "DeficiencyCreateSerializer.") {
+			t.Errorf("default: schema field %q should be suppressed", name)
+		}
+	}
+
+	// include_noise:true — all 5 entities returned.
+	outNoise := callDashboardTool(t, srv.handleSearchEntities, map[string]any{
+		"group":         "test",
+		"query":         "deficiency",
+		"include_noise": true,
+	})
+	noiseResults, _ := outNoise["results"].([]any)
+	if len(noiseResults) != 5 {
+		t.Fatalf("include_noise:true: expected 5 results, got %d: %v", len(noiseResults), noiseResults)
 	}
 }
 

--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -43,6 +43,13 @@ const (
 	// "Login → map", "Foo → trim". Identified by the proc: ID prefix and/or
 	// the "X → builtin" label shape.
 	noiseProcess
+	// noiseSchemaField: a SCOPE.Schema entity with Subtype="field" — a
+	// single field/attribute belonging to a serializer or schema class (e.g.
+	// DeficiencyCreateSerializer.amount). These are member entities of their
+	// parent class and clutter default results when ~25 fields accompany every
+	// serializer. Suppressed by default (#1712); the parent class surfaces
+	// normally. Reachable via include_noise:true.
+	noiseSchemaField
 )
 
 // arrayBuiltins is the set of array/string built-in method names whose Process
@@ -105,6 +112,15 @@ func classifyNoise(e *graph.Entity) noiseKind {
 		}
 	}
 
+	// Schema field members (#1712): a SCOPE.Schema entity whose Subtype is
+	// "field" is a single attribute of a parent serializer/schema class
+	// (e.g. DeficiencyCreateSerializer.amount). ~25 of these accompany every
+	// serializer class and pollute default ranked results. The parent class
+	// entity (same Kind, no "field" Subtype) surfaces normally.
+	if bareKind == "schema" && e.Subtype == "field" {
+		return noiseSchemaField
+	}
+
 	return noiseNone
 }
 
@@ -153,6 +169,8 @@ func rankTier(e *graph.Entity) int {
 		return 6
 	case noiseProcess:
 		return 6
+	case noiseSchemaField:
+		return 7
 	}
 	// Real entity. Lined entities (whether or not they carry a qualified_name)
 	// share the top tier so that BM25 relevance — not the mere presence of a

--- a/internal/mcp/denoise_test.go
+++ b/internal/mcp/denoise_test.go
@@ -86,6 +86,33 @@ func TestClassifyNoise(t *testing.T) {
 			},
 			want: noiseNone,
 		},
+		// #1712: Schema field members are noise.
+		{
+			name: "schema field member (SCOPE.Schema subtype=field)",
+			e: graph.Entity{
+				Kind: "SCOPE.Schema", Subtype: "field",
+				Name:       "DeficiencyCreateSerializer.amount",
+				SourceFile: "core/serializers/deficiency_serializer.py", StartLine: 12,
+			},
+			want: noiseSchemaField,
+		},
+		{
+			name: "schema field member (no SCOPE. prefix)",
+			e: graph.Entity{
+				Kind: "Schema", Subtype: "field",
+				Name:       "DeficiencyCreateSerializer.created_at",
+				SourceFile: "core/serializers/deficiency_serializer.py", StartLine: 13,
+			},
+			want: noiseSchemaField,
+		},
+		{
+			name: "schema class itself (no subtype) is NOT noise",
+			e: graph.Entity{
+				Kind: "SCOPE.Schema", Name: "DeficiencyCreateSerializer",
+				SourceFile: "core/serializers/deficiency_serializer.py", StartLine: 8,
+			},
+			want: noiseNone,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -106,6 +133,29 @@ func TestRankTierOrdersRealAboveNoise(t *testing.T) {
 	}
 	if rankTier(shadow) >= rankTier(container) {
 		t.Fatalf("shadow (%d) should rank above container (%d)", rankTier(shadow), rankTier(container))
+	}
+}
+
+// TestRankTierSchemaFieldBelowParent verifies that a Schema field member ranks
+// strictly below the real parent Schema class entity (#1712).
+func TestRankTierSchemaFieldBelowParent(t *testing.T) {
+	parent := &graph.Entity{
+		Kind: "SCOPE.Schema", Name: "DeficiencyCreateSerializer",
+		SourceFile: "core/serializers/deficiency_serializer.py", StartLine: 8,
+	}
+	field := &graph.Entity{
+		Kind: "SCOPE.Schema", Subtype: "field",
+		Name:       "DeficiencyCreateSerializer.amount",
+		SourceFile: "core/serializers/deficiency_serializer.py", StartLine: 12,
+	}
+	if classifyNoise(parent) != noiseNone {
+		t.Fatalf("parent serializer should be noiseNone, got %d", classifyNoise(parent))
+	}
+	if classifyNoise(field) != noiseSchemaField {
+		t.Fatalf("schema field should be noiseSchemaField, got %d", classifyNoise(field))
+	}
+	if rankTier(parent) >= rankTier(field) {
+		t.Fatalf("parent tier (%d) should be lower (better) than field tier (%d)", rankTier(parent), rankTier(field))
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -311,6 +311,7 @@ func (s *Server) registerTools() {
 		mcpapi.WithString("query", mcpapi.Required()),
 		mcpapi.WithAny("kind_filter"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(30)),
+		mcpapi.WithBoolean("include_noise", mcpapi.DefaultBool(false)),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),


### PR DESCRIPTION
## What

Extends the MCP serving-layer de-noise layer (`internal/mcp/denoise.go`, #1614) with a new `noiseSchemaField` bucket. `SCOPE.Schema` entities whose `Subtype == "field"` (e.g. `DeficiencyCreateSerializer.amount`, `DeficiencyCreateSerializer.created_at`, …) are suppressed from default `archigraph_find` and `archigraph_search_entities` results. The parent serializer/class entity surfaces normally. `include_noise:true` restores all field members.

Fixes #1712.

## Why

Iter3 calibration on the upvate corpus (top prune rec #2): every DRF serializer class emits ~25 `SCOPE.Schema/field` entities that ranked alongside the parent class in `find` / `search_entities`, polluting default results with `amount`, `created_at`, `updated_at`, etc. The parent (`DeficiencyCreateSerializer`) is the entity agents actually want.

## How

**Detection** — `bareKind == "schema" && e.Subtype == "field"`:

- Python extractor emits `Kind="SCOPE.Schema", Subtype="field", Name="ParentClass.attr"` for all class-attribute assignments (refs `internal/extractors/python/extractor.go:1176`).
- Java and proto extractors use the same shape (`internal/extractors/java/java.go:974`, `internal/extractors/proto/proto.go:332`).
- Parent class/serializer: same `SCOPE.Schema` kind, no `"field"` subtype — continues to rank at tier 0.

**Changes**:
- `denoise.go`: new `noiseSchemaField` constant; `classifyNoise` adds a guard after the shadow check; `rankTier` returns 7 (below container=5, shadow=4, pattern/process=6).
- `dashboard_tools.go`: `handleSearchEntities` reads `include_noise` arg and skips `noiseSchemaField` entities by default.
- `server.go`: exposes `include_noise` boolean (default false) on `archigraph_search_entities` tool declaration.
- `SCHEMA.md`: updates `include_noise` description and de-noise prose for both tools.

**Tests**:
- `TestClassifyNoise`: 3 new cases — `SCOPE.Schema/field`, `Schema/field` (no scope prefix), schema class with no subtype (must be `noiseNone`).
- `TestRankTierSchemaFieldBelowParent`: asserts parent tier < field tier.
- `TestSearchEntities_SchemaFieldFold`: serializer fixture with 1 parent + 3 fields + 1 unrelated op; default returns 2, `include_noise:true` returns 5.

## MCP dogfood notes

Daemon was intentionally stopped (runaway drift loop, per session memory — resume after #1626). All investigation was via Read + grep.

| Tool call | Args | Result | Elapsed estimate | Replaced grep+Read? |
|---|---|---|---|---|
| `archigraph_search_entities` query="denoise" | group=upvate | Error: daemon not running | ~200ms | NO — daemon stopped; fell back to grep |
| `archigraph_search_entities` query="DeficiencyCreateSerializer" | group=upvate | Error: daemon not running | ~200ms | NO — daemon stopped; fell back to Read |

**Finding**: with daemon stopped, 0/2 MCP calls succeeded. Investigation completed via grep+Read in ~8 tool calls covering denoise.go, scoring.go, dashboard_tools.go, server.go, and extractor files. MCP would have been faster for the entity-shape lookups (confirming `Subtype="field"` in live indexed data) but was not available.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/mcp/...` — clean
- [x] `go test ./internal/mcp/ -run TestClassifyNoise` — 12 cases pass (3 new)
- [x] `go test ./internal/mcp/ -run TestRankTierSchemaFieldBelowParent` — pass
- [x] `go test ./internal/mcp/ -run TestSearchEntities_SchemaFieldFold` — pass
- [x] `go test ./internal/mcp/...` — full suite green (no regressions)
- [x] `go test ./internal/...` — all internal packages green

🤖 Generated with [Claude Code](https://claude.com/claude-code)