### PR TITLE
ci: expand test matrix to ubuntu + macos + windows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,16 +8,33 @@ permissions:
 
 jobs:
   test:
-    runs-on: ubuntu-latest
+    # Windows is allowed to fail until tree-sitter CGO bindings are confirmed
+    # on windows-latest — tracked in #937. Remove continue-on-error once #937
+    # and its prerequisites (#926, #928) are resolved.
+    continue-on-error: ${{ matrix.os == 'windows-latest' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-go@v5
         with:
           go-version: '1.22'
           cache: true
+
       - run: go mod download
+
       - run: go vet ./...
+
+      # gofmt check — only enforce on Linux to avoid CRLF noise from Windows
+      # tooling. macOS and Linux share the same line endings in the repo so
+      # running on ubuntu-latest is sufficient.
       - name: gofmt
+        if: runner.os == 'Linux'
+        shell: bash
         run: |
           diff=$(gofmt -l . 2>&1)
           if [ -n "$diff" ]; then
@@ -25,5 +42,7 @@ jobs:
             echo "$diff"
             exit 1
           fi
+
       - run: go build ./...
+
       - run: go test -race -count=1 ./...


### PR DESCRIPTION
## What

Converts `test.yml` from a single `ubuntu-latest` runner to a 3-runner strategy matrix: `ubuntu-latest`, `macos-latest`, `windows-latest`. Closes #935.

## Why

The daemon has CGO dependencies (tree-sitter grammars) that behave differently across platforms. A matrix CI gate catches cross-platform regressions before they reach main, and was explicitly requested by the parent issue #856.

## How

- `strategy.matrix.os` drives `runs-on` — one job row per OS.
- `fail-fast: false` so macOS/Linux results are always surfaced even when Windows fails.
- `continue-on-error: ${{ matrix.os == 'windows-latest' }}` marks the Windows leg expected-red until tree-sitter CGO on `windows-latest` is confirmed (tracked in #937; full daemon coverage also needs #926 and #928).
- `gofmt` check is scoped to `runner.os == 'Linux'` to avoid false positives from Windows CRLF line endings. macOS shares Unix line endings so Linux is the canonical enforcement point.
- All steps use plain `go` commands — no `make` wrapper — so no MSYS2/make dependency is needed on Windows runners.

## Expected CI state after merge

| Runner | Expected result |
|---|---|
| `ubuntu-latest` | Green |
| `macos-latest` | Green |
| `windows-latest` | Red (continue-on-error — acceptable until #937 lands) |

## Out of scope

- Cross-compilation (each runner builds natively due to CGO — per #935 scope).
- Release / binary distribution (deferred per #856).
- Flipping `continue-on-error` off — that follows #937 + #926 + #928.

## Test plan

- [ ] Trigger `workflow_dispatch` on this branch and confirm ubuntu + macOS rows pass.
- [ ] Confirm Windows row is red-but-acceptable (job shown as `continue-on-error`).
- [ ] Confirm no regression vs the existing Linux-only run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)