### PR TITLE
[#1708] DB trigger + Debezium CDC chain edges

### DIFF
--- a/internal/classifier/classifier.go
+++ b/internal/classifier/classifier.go
@@ -589,6 +589,38 @@ func detectLanguage(norm string) string {
 		return "scala"
 	}
 
+	// Issue #1708 — narrow JSON routing for Debezium / Kafka-Connect
+	// connector files. Indexing every .json file would balloon scope
+	// (package.json, tsconfig.json, jest.config.json, lockfiles, etc.), so
+	// we opt-in path patterns whose only purpose in any reasonable repo is
+	// a CDC connector definition. The downstream extractor still content-
+	// sniffs for `io.debezium` / `connector.class` to confirm before
+	// emitting any entities, so a false positive is a harmless no-op.
+	//
+	// Path patterns accept either a directory anchor (e.g. cdc/, debezium/)
+	// OR a filename suffix (*-connector.json, *.connector.json). The
+	// directory check uses both "prefix/cdc/" AND "cdc/<something>" forms
+	// because when a monorepo subrepo is indexed with its sub-directory as
+	// the root (e.g. fleet entry root=services/cdc/), the file paths the
+	// classifier receives are relative to that root and won't contain
+	// "/cdc/" as a substring — they start with the filename instead.
+	if strings.HasSuffix(lower, ".json") {
+		dirAnchor := func(seg string) bool {
+			return strings.Contains(lower, "/"+seg+"/") ||
+				strings.HasPrefix(lower, seg+"/")
+		}
+		switch {
+		case dirAnchor("cdc"),
+			dirAnchor("debezium"),
+			dirAnchor("kafka-connect"),
+			dirAnchor("connectors"),
+			strings.HasSuffix(lower, "-connector.json"),
+			strings.HasSuffix(lower, ".connector.json"),
+			strings.HasSuffix(lower, "-debezium.json"):
+			return "json"
+		}
+	}
+
 	// Issue #497 — exact-basename check before the extension lookup so that
 	// files like "Package.swift" (which carry a recognised extension) can be
 	// assigned a more specific language key ("swift_package") instead of the

--- a/internal/classifier/classifier_test.go
+++ b/internal/classifier/classifier_test.go
@@ -1147,3 +1147,58 @@ func TestClassify_PackageSwift_IsSwiftPackage(t *testing.T) {
 		})
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1708 — narrow JSON routing for Debezium / Kafka-Connect connectors
+// ---------------------------------------------------------------------------
+// The classifier must route ONLY path-narrow JSON files (cdc/, debezium/,
+// kafka-connect/, *-connector.json, etc.) to language="json" so the
+// Debezium CDC engine pass sees them. Indexing all .json files would
+// balloon scope across package.json / tsconfig.json / lockfiles.
+
+func TestClassify_DebeziumConnectorJSON(t *testing.T) {
+	c := newTestClassifier(t)
+
+	cdcPaths := []string{
+		"services/cdc/orders-connector.json",
+		"services/cdc/users.json",
+		"infra/debezium/billing.json",
+		"infra/kafka-connect/inventory.json",
+		"infra/connectors/payments.json",
+		"connectors/orders-connector.json",
+		"connectors/orders.connector.json",
+		"deploy/orders-debezium.json",
+	}
+	for _, p := range cdcPaths {
+		t.Run(p, func(t *testing.T) {
+			r := c.Classify(context.Background(), p)
+			if r.Skip {
+				t.Errorf("%s should not be skipped: %q", p, r.SkipReason)
+			}
+			if r.Language != "json" {
+				t.Errorf("expected Language=json, got %q", r.Language)
+			}
+		})
+	}
+}
+
+func TestClassify_GenericJSONNotIndexed(t *testing.T) {
+	c := newTestClassifier(t)
+	// These must NOT be picked up — they would balloon indexing scope and
+	// the Debezium pass would no-op on them anyway via the content sniff.
+	noisyPaths := []string{
+		"package.json",
+		"tsconfig.json",
+		"jest.config.json",
+		"src/data/users.json",
+		"frontend/public/manifest.json",
+	}
+	for _, p := range noisyPaths {
+		t.Run(p, func(t *testing.T) {
+			r := c.Classify(context.Background(), p)
+			if r.Language != "" {
+				t.Errorf("%s should have empty Language to skip Pass1, got %q", p, r.Language)
+			}
+		})
+	}
+}

--- a/internal/engine/debezium_cdc_edges.go
+++ b/internal/engine/debezium_cdc_edges.go
@@ -1,0 +1,380 @@
+// Debezium / Kafka-Connect CDC connector extraction — Issue #1708.
+//
+// Polyglot-platform iter3 calibration surfaced a stitch gap: the DB
+// trigger entity, the source table, the audit table, and the downstream
+// Kafka CDC topic all exist as nodes, but no edges connect them into a
+// single "CDC chain" subgraph. The trigger half is handled by the SQL
+// extractor (Issue #1414 — CREATE TRIGGER ... ON ... EXECUTE FUNCTION
+// emits FIRES + DEFINED_ON; the trigger function body emits WRITES_TO
+// for INSERT INTO order_status_audit). What's missing is the connector
+// half: the JSON file that says "Debezium captures `public.orders` and
+// `public.order_status_audit` and produces topics `cdc.public.orders`
+// and `cdc.public.order_status_audit`."
+//
+// This pass parses Debezium / Kafka-Connect connector JSON configs and
+// emits, for each connector it can statically recognise:
+//
+//   - a SCOPE.Component entity for the connector itself (Subtype="cdc_connector"),
+//     keyed by the JSON `name` field (e.g. "orders-postgres-cdc").
+//   - a SCOPE.Datastore "table" stub entity per element of
+//     `table.include.list` (or the `x-shipfast-cdc.captured-tables`
+//     escape hatch). Stub entities collapse onto the SQL extractor's
+//     real table entities via the existing same-name dedup path: the
+//     resolver's same-repo entity-name reconciliation (#1662 family)
+//     pins these to the canonical SCOPE.Datastore/table node when the
+//     migration SQL is in the same repo. Cross-repo (CDC in services/cdc/
+//     pointing at services/orders/migrations/) still binds via the
+//     cross-repo name linker that #534 uses for HTTP and #726 for Kafka.
+//   - a SCOPE.MessageTopic entity per produced Kafka topic, broker=kafka,
+//     using the canonical `kafka:<topic>` ID that the existing Kafka
+//     synthesizer uses (kafka_edges.go). This lets the CDC connector
+//     share topic nodes with downstream Kafka consumers in other repos.
+//   - edges:
+//       connector  CAPTURES       table              (per captured table)
+//       connector  PUBLISHES_TO   kafka:<topic>      (per produced topic)
+//
+//   CAPTURES is a new typed edge for the CDC chain — consumers of the
+//   topic produce SUBSCRIBES_TO edges from the regular Kafka synthesis
+//   pass (e.g. a Python consumer doing `KafkaConsumer("cdc.public.orders")`)
+//   so the resulting subgraph is:
+//
+//       trigger ─FIRES─▶ trigger_function
+//                         │
+//                         └─WRITES_TO─▶ audit_table
+//                                        │
+//                                        └◀─CAPTURES─ connector ─PUBLISHES_TO─▶ kafka:cdc.public.audit_table
+//                                                                                        │
+//                                                                                        └─SUBSCRIBES_TO─ consumer
+//
+// # Topic-name derivation
+//
+// Debezium PostgreSQL connector topic names follow the pattern
+// `<topic.prefix>.<schema>.<table>` — e.g. with `topic.prefix=cdc` and
+// `table.include.list=public.orders,public.order_status_audit` the
+// produced topics are `cdc.public.orders` and `cdc.public.order_status_audit`.
+// We derive both from the standard fields. As a calibration escape
+// hatch (and to match #1596 IaC-side x-shipfast-* convention), we also
+// honour an `x-*-cdc.produced-topics` array if present in the connector
+// document, which lets fixtures pin exact topic names without us having
+// to encode every variant of Debezium's topic-naming rules.
+//
+// # Scope guard
+//
+// Append-only — this pass never modifies or removes existing entities
+// or edges, so it cannot regress the surrounding pipeline's bug-rate.
+// Files that don't content-sniff as a connector are no-ops.
+//
+// Refs #1708.
+package engine
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// debeziumCDCSupportsLanguage gates applyDebeziumCDCEdges. The classifier
+// only routes path-narrow JSON files (cdc/, debezium/, kafka-connect/,
+// *-connector.json, …) to language="json" precisely so this pass receives
+// likely-connector files and nothing else.
+func debeziumCDCSupportsLanguage(lang string) bool {
+	return lang == "json"
+}
+
+// debeziumCDCSniff returns true if the raw content looks like a Debezium /
+// Kafka-Connect connector config. Cheap byte-substring checks first so
+// we don't pay JSON-decode cost on every JSON file the classifier may
+// route through.
+func debeziumCDCSniff(content []byte) bool {
+	if len(content) == 0 {
+		return false
+	}
+	s := string(content)
+	// Debezium connectors have connector.class=io.debezium.* and Kafka-
+	// Connect connectors carry connector.class. We sniff for the JSON-
+	// quoted form to avoid matching prose / Dockerfile snippets.
+	if strings.Contains(s, `"connector.class"`) {
+		return true
+	}
+	if strings.Contains(s, "io.debezium") {
+		return true
+	}
+	return false
+}
+
+// debeziumConnectorDoc is the subset of a Debezium / Kafka-Connect JSON
+// config we care about. The actual schema is far richer; we ignore the
+// rest. Both top-level shapes are supported:
+//
+//   - bare connector config: { "name": ..., "config": {...} }
+//   - the "config" object inline at top level
+//
+// We also pick up the calibration escape-hatch fields
+// `x-*-cdc.produced-topics` and `x-*-cdc.captured-tables` from the
+// top-level document (any property whose key starts with "x-" and ends
+// with "-cdc"), so fixture authors can pin exact topic / table names
+// without us having to reverse Debezium's topic-naming rules.
+type debeziumConnectorDoc struct {
+	Name   string                 `json:"name"`
+	Config map[string]interface{} `json:"config"`
+}
+
+// applyDebeziumCDCEdges parses one JSON file as a Debezium / Kafka-Connect
+// connector and APPENDS connector / table / topic entities and CAPTURES /
+// PUBLISHES_TO edges. Returns inputs untouched if the file is not a
+// connector or fails to parse.
+func applyDebeziumCDCEdges(
+	lang string,
+	path string,
+	content []byte,
+	entities []types.EntityRecord,
+	relationships []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord) {
+	if !debeziumCDCSupportsLanguage(lang) {
+		return entities, relationships
+	}
+	if !debeziumCDCSniff(content) {
+		return entities, relationships
+	}
+
+	// Use a raw map so we can pick up both the typed `name`/`config`
+	// fields and any `x-*-cdc` calibration overrides without a second
+	// pass.
+	var raw map[string]interface{}
+	if err := json.Unmarshal(content, &raw); err != nil {
+		return entities, relationships
+	}
+
+	connectorName, _ := raw["name"].(string)
+	cfg := flattenConfig(raw)
+
+	connectorClass, _ := cfg["connector.class"].(string)
+	tableList, _ := cfg["table.include.list"].(string)
+	topicPrefix, _ := cfg["topic.prefix"].(string)
+	dbName, _ := cfg["database.dbname"].(string)
+	dbServer, _ := cfg["database.server.name"].(string)
+
+	// Derive the connector name if missing.
+	if connectorName == "" {
+		if name, ok := cfg["name"].(string); ok {
+			connectorName = name
+		}
+	}
+	if connectorName == "" {
+		// Last resort: derive from filename. Strip directory + ".json".
+		connectorName = derefConnectorNameFromPath(path)
+	}
+	if connectorName == "" {
+		return entities, relationships
+	}
+
+	// Calibration escape hatches.
+	capturedFromExt := extractCDCExtList(raw, "captured-tables")
+	producedFromExt := extractCDCExtList(raw, "produced-topics")
+
+	tables := parseTableIncludeList(tableList)
+	for _, t := range capturedFromExt {
+		tables = appendUnique(tables, normaliseTableName(t))
+	}
+
+	topics := producedFromExt
+	if len(topics) == 0 {
+		topics = derivedDebeziumTopics(topicPrefix, dbServer, tables)
+	}
+
+	// Emit connector entity.
+	connectorEntity := types.EntityRecord{
+		Name:       connectorName,
+		Kind:       "SCOPE.Component",
+		Subtype:    "cdc_connector",
+		SourceFile: path,
+		Language:   lang,
+		Signature:  fmt.Sprintf("Debezium connector %s (class=%s db=%s)", connectorName, connectorClass, dbName),
+		Properties: map[string]string{
+			"connector_class":     connectorClass,
+			"database_dbname":     dbName,
+			"database_server":     dbServer,
+			"topic_prefix":        topicPrefix,
+			"table_include_list":  tableList,
+			"pattern_type":        "debezium_cdc",
+			"enrichment_pipeline": "debezium_cdc",
+		},
+		EnrichmentRequired: false,
+	}
+
+	// Build relationships from the connector outward.
+	for _, table := range tables {
+		// Bare table name (drop schema prefix) so the SQL extractor's
+		// SCOPE.Datastore/table entities (which are stored by bare name)
+		// collapse onto this same node via same-name dedup.
+		bare := bareTableName(table)
+		connectorEntity.Relationships = append(connectorEntity.Relationships, types.RelationshipRecord{
+			FromID:     connectorName,
+			ToID:       bare,
+			Kind:       "CAPTURES",
+			Properties: map[string]string{"cdc_source_table": table, "pattern_type": "debezium_cdc"},
+		})
+		// Emit a stub table entity so even if the SQL migration is in
+		// another repo (or not yet indexed) the captured table still
+		// renders as a graph node. The resolver collapses it onto the
+		// canonical table when both are present.
+		entities = append(entities, types.EntityRecord{
+			Name:               bare,
+			Kind:               "SCOPE.Datastore",
+			Subtype:            "table",
+			SourceFile:         "",
+			Language:           lang,
+			Signature:          fmt.Sprintf("Debezium-captured table %s", table),
+			Properties:         map[string]string{"pattern_type": "debezium_cdc", "schema_qualified": table},
+			EnrichmentRequired: false,
+		})
+	}
+
+	for _, topic := range topics {
+		topicID := "kafka:" + topic
+		connectorEntity.Relationships = append(connectorEntity.Relationships, types.RelationshipRecord{
+			FromID: connectorName,
+			ToID:   topicID,
+			Kind:   "PUBLISHES_TO",
+			Properties: map[string]string{
+				"broker":       "kafka",
+				"topic_name":   topic,
+				"pattern_type": "debezium_cdc",
+			},
+		})
+		// Emit the canonical MessageTopic node, matching the
+		// kafka_edges.go convention (SourceFile="" so cross-file +
+		// cross-repo emissions collapse onto the same stamped entity).
+		entities = append(entities, types.EntityRecord{
+			Name:       topicID,
+			Kind:       messageTopicKind,
+			SourceFile: "",
+			Language:   lang,
+			Properties: map[string]string{
+				"broker":       "kafka",
+				"topic_name":   topic,
+				"pattern_type": "debezium_cdc",
+			},
+			EnrichmentRequired: false,
+			EnrichmentStatus:   types.StatusPending,
+			QualityScore:       0.8,
+		})
+	}
+
+	entities = append(entities, connectorEntity)
+	return entities, relationships
+}
+
+// flattenConfig returns the "config" sub-object if present, otherwise the
+// raw doc itself (some Kafka-Connect bundles inline the config at the top
+// level rather than under a "config" key).
+func flattenConfig(raw map[string]interface{}) map[string]interface{} {
+	if c, ok := raw["config"].(map[string]interface{}); ok {
+		return c
+	}
+	return raw
+}
+
+// extractCDCExtList walks raw["x-*-cdc"] (any property whose key starts
+// with "x-" and ends with "-cdc") and returns the named string list.
+// Used for fixture-pinned captured-tables / produced-topics overrides.
+func extractCDCExtList(raw map[string]interface{}, field string) []string {
+	var out []string
+	for k, v := range raw {
+		if !strings.HasPrefix(k, "x-") || !strings.HasSuffix(k, "-cdc") {
+			continue
+		}
+		obj, ok := v.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		arr, ok := obj[field].([]interface{})
+		if !ok {
+			continue
+		}
+		for _, item := range arr {
+			if s, ok := item.(string); ok && s != "" {
+				out = append(out, s)
+			}
+		}
+	}
+	return out
+}
+
+// parseTableIncludeList splits a Debezium `table.include.list` value
+// (comma-separated schema.table tokens) and returns the trimmed,
+// non-empty entries.
+func parseTableIncludeList(s string) []string {
+	if s == "" {
+		return nil
+	}
+	parts := strings.Split(s, ",")
+	out := make([]string, 0, len(parts))
+	for _, p := range parts {
+		p = strings.TrimSpace(p)
+		if p != "" {
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// derivedDebeziumTopics computes the canonical Debezium topic names from
+// the prefix and table list. Modern Debezium uses `<topic.prefix>.<schema>.<table>`
+// (topic.prefix replaced server.name in Debezium 2.x but the topic
+// pattern is identical). Pre-2.x connectors that only set
+// `database.server.name` fall back to that as the prefix.
+func derivedDebeziumTopics(topicPrefix, dbServer string, tables []string) []string {
+	prefix := topicPrefix
+	if prefix == "" {
+		prefix = dbServer
+	}
+	if prefix == "" || len(tables) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(tables))
+	for _, t := range tables {
+		out = append(out, prefix+"."+strings.TrimSpace(t))
+	}
+	return out
+}
+
+// bareTableName strips an optional schema prefix from "schema.table",
+// returning just the table name so it matches the SQL extractor's
+// canonical entity name.
+func bareTableName(t string) string {
+	if i := strings.LastIndex(t, "."); i >= 0 {
+		return t[i+1:]
+	}
+	return t
+}
+
+// normaliseTableName trims whitespace from a captured table reference.
+func normaliseTableName(t string) string { return strings.TrimSpace(t) }
+
+// appendUnique appends s to xs only if not already present.
+func appendUnique(xs []string, s string) []string {
+	if s == "" {
+		return xs
+	}
+	for _, x := range xs {
+		if x == s {
+			return xs
+		}
+	}
+	return append(xs, s)
+}
+
+// derefConnectorNameFromPath returns the basename of path stripped of the
+// .json extension. Used only when the connector JSON has no `name`
+// field (some Kafka-Connect distributions ship the config without the
+// outer envelope, expecting the filename to provide the name).
+func derefConnectorNameFromPath(path string) string {
+	base := path
+	if i := strings.LastIndex(base, "/"); i >= 0 {
+		base = base[i+1:]
+	}
+	return strings.TrimSuffix(base, ".json")
+}

--- a/internal/engine/debezium_cdc_edges_test.go
+++ b/internal/engine/debezium_cdc_edges_test.go
@@ -1,0 +1,210 @@
+// Tests for the Debezium / Kafka-Connect CDC connector edges pass —
+// Issue #1708.
+//
+// Acceptance criteria:
+//   - The polyglot-platform `services/cdc/orders-connector.json`
+//     fixture emits one cdc_connector entity, two captured-table
+//     entities, two MessageTopic entities, and the expected
+//     CAPTURES / PUBLISHES_TO edges.
+//   - Topic IDs use the canonical "kafka:<topic>" form so they
+//     collapse onto the same node as the Kafka synthesis pass would
+//     emit for a downstream consumer.
+//   - Non-CDC JSON (package.json shape) is a no-op.
+//   - Non-JSON languages are a no-op.
+
+package engine
+
+import (
+	"strings"
+	"testing"
+)
+
+const debeziumPolyglotConnector = `{
+  "name": "orders-postgres-cdc",
+  "config": {
+    "connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+    "database.dbname": "orders",
+    "database.server.name": "shipfast",
+    "plugin.name": "pgoutput",
+    "table.include.list": "public.orders,public.order_status_audit",
+    "topic.prefix": "cdc"
+  },
+  "x-shipfast-cdc": {
+    "captured-tables": ["public.orders", "public.order_status_audit"],
+    "produced-topics": ["cdc.public.orders", "cdc.public.order_status_audit"]
+  }
+}`
+
+func TestDebeziumCDC_PolyglotFixture(t *testing.T) {
+	ents, _ := applyDebeziumCDCEdges("json",
+		"services/cdc/orders-connector.json",
+		[]byte(debeziumPolyglotConnector), nil, nil,
+	)
+
+	var connector *struct {
+		captures      map[string]bool
+		publishes     map[string]bool
+		connectorName string
+	}
+	connector = &struct {
+		captures      map[string]bool
+		publishes     map[string]bool
+		connectorName string
+	}{
+		captures:  map[string]bool{},
+		publishes: map[string]bool{},
+	}
+
+	var (
+		gotConnectorEntity bool
+		gotTables          = map[string]bool{}
+		gotTopics          = map[string]bool{}
+	)
+	for _, e := range ents {
+		switch {
+		case e.Kind == "SCOPE.Component" && e.Subtype == "cdc_connector":
+			gotConnectorEntity = true
+			connector.connectorName = e.Name
+			for _, r := range e.Relationships {
+				switch r.Kind {
+				case "CAPTURES":
+					connector.captures[r.ToID] = true
+				case "PUBLISHES_TO":
+					connector.publishes[r.ToID] = true
+				}
+			}
+		case e.Kind == "SCOPE.Datastore" && e.Subtype == "table":
+			gotTables[e.Name] = true
+		case e.Kind == messageTopicKind:
+			gotTopics[e.Name] = true
+		}
+	}
+
+	if !gotConnectorEntity {
+		t.Fatal("expected cdc_connector entity")
+	}
+	if connector.connectorName != "orders-postgres-cdc" {
+		t.Errorf("connector name = %q, want orders-postgres-cdc", connector.connectorName)
+	}
+
+	for _, want := range []string{"orders", "order_status_audit"} {
+		if !gotTables[want] {
+			t.Errorf("expected SCOPE.Datastore/table %q stub, got %v", want, gotTables)
+		}
+		if !connector.captures[want] {
+			t.Errorf("expected CAPTURES edge to %q, got %v", want, connector.captures)
+		}
+	}
+
+	for _, want := range []string{"kafka:cdc.public.orders", "kafka:cdc.public.order_status_audit"} {
+		if !gotTopics[want] {
+			t.Errorf("expected MessageTopic %q, got %v", want, gotTopics)
+		}
+		if !connector.publishes[want] {
+			t.Errorf("expected PUBLISHES_TO edge to %q, got %v", want, connector.publishes)
+		}
+	}
+}
+
+// Even without the x-*-cdc escape hatch, topics are derived from the
+// standard `topic.prefix` + `table.include.list` fields.
+func TestDebeziumCDC_DerivedTopics(t *testing.T) {
+	doc := `{
+		"name": "users-cdc",
+		"config": {
+			"connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+			"table.include.list": "public.users,public.sessions",
+			"topic.prefix": "cdc"
+		}
+	}`
+	ents, _ := applyDebeziumCDCEdges("json", "cdc/users.json", []byte(doc), nil, nil)
+	topics := map[string]bool{}
+	for _, e := range ents {
+		if e.Kind == messageTopicKind {
+			topics[e.Name] = true
+		}
+	}
+	for _, want := range []string{"kafka:cdc.public.users", "kafka:cdc.public.sessions"} {
+		if !topics[want] {
+			t.Errorf("expected derived topic %q, got %v", want, topics)
+		}
+	}
+}
+
+// Pre-2.x Debezium connectors only set database.server.name — that should
+// be used as the topic prefix when topic.prefix is missing.
+func TestDebeziumCDC_LegacyServerNameAsPrefix(t *testing.T) {
+	doc := `{
+		"name": "legacy-cdc",
+		"config": {
+			"connector.class": "io.debezium.connector.postgresql.PostgresConnector",
+			"database.server.name": "legacy",
+			"table.include.list": "public.orders"
+		}
+	}`
+	ents, _ := applyDebeziumCDCEdges("json", "debezium/legacy.json", []byte(doc), nil, nil)
+	got := false
+	for _, e := range ents {
+		if e.Kind == messageTopicKind && e.Name == "kafka:legacy.public.orders" {
+			got = true
+		}
+	}
+	if !got {
+		t.Error("expected kafka:legacy.public.orders derived from database.server.name")
+	}
+}
+
+func TestDebeziumCDC_NonJSONLanguageNoop(t *testing.T) {
+	ents, rels := applyDebeziumCDCEdges("python", "x.py", []byte(debeziumPolyglotConnector), nil, nil)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("expected no-op for non-json language, got %d entities, %d rels", len(ents), len(rels))
+	}
+}
+
+func TestDebeziumCDC_NonConnectorJSONNoop(t *testing.T) {
+	pkg := `{"name":"some-package","version":"1.0.0","dependencies":{"react":"^18"}}`
+	ents, rels := applyDebeziumCDCEdges("json", "package.json", []byte(pkg), nil, nil)
+	if len(ents) != 0 || len(rels) != 0 {
+		t.Errorf("expected no-op for non-connector JSON, got %d entities, %d rels", len(ents), len(rels))
+	}
+}
+
+// A connector JSON missing both `name` and content sniff anchors must
+// no-op (defensive guard against false positives from path heuristics).
+func TestDebeziumCDC_SniffGuardsOutNonDebezium(t *testing.T) {
+	// Has connector.class but it's not Debezium; we still accept any
+	// Kafka-Connect connector that declares connector.class.
+	doc := `{"name":"foo","config":{"connector.class":"com.example.Foo"}}`
+	ents, _ := applyDebeziumCDCEdges("json", "cdc/foo.json", []byte(doc), nil, nil)
+	got := false
+	for _, e := range ents {
+		if e.Kind == "SCOPE.Component" && e.Subtype == "cdc_connector" && e.Name == "foo" {
+			got = true
+		}
+	}
+	if !got {
+		t.Error("expected non-Debezium Kafka-Connect connector to still emit a cdc_connector entity")
+	}
+}
+
+func TestDebeziumCDC_BareTableNameStripsSchema(t *testing.T) {
+	// Edges should target the bare table name so they align with the SQL
+	// extractor's canonical SCOPE.Datastore/table entity names.
+	ents, _ := applyDebeziumCDCEdges("json",
+		"services/cdc/orders-connector.json",
+		[]byte(debeziumPolyglotConnector), nil, nil,
+	)
+	for _, e := range ents {
+		if e.Kind != "SCOPE.Component" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "CAPTURES" {
+				continue
+			}
+			if strings.Contains(r.ToID, ".") {
+				t.Errorf("CAPTURES ToID %q must be bare table name (no schema prefix)", r.ToID)
+			}
+		}
+	}
+}

--- a/internal/engine/detector.go
+++ b/internal/engine/detector.go
@@ -344,6 +344,21 @@ func (d *Detector) Detect(ctx context.Context, file extractor.FileInput) (*Detec
 		file.Language, file.Path, file.Content, entities, relationships,
 	)
 
+	// Debezium / Kafka-Connect CDC connector edges (#1708). Parses the
+	// JSON config of a CDC connector and emits a SCOPE.Component
+	// (cdc_connector) plus CAPTURES → captured-table and PUBLISHES_TO →
+	// produced kafka:<topic> edges. Topic IDs use the same canonical
+	// "kafka:<topic>" form as the Kafka synthesis pass, so downstream
+	// SUBSCRIBES_TO edges from regular Kafka consumers attach to the same
+	// node without an explicit cross-pass handoff. Append-only — cannot
+	// regress the surrounding pipeline's bug-rate. Only fires for files
+	// whose path the classifier narrowed to language="json" (cdc/,
+	// debezium/, kafka-connect/, *-connector.json, …), then content-
+	// sniffed for `connector.class` / `io.debezium`.
+	entities, relationships = applyDebeziumCDCEdges(
+		file.Language, file.Path, file.Content, entities, relationships,
+	)
+
 	// Google Cloud Pub/Sub producer/consumer cross-repo edges (wave 3 of #726).
 	// Emits SCOPE.Queue entities + PUBLISHES_TO / SUBSCRIBES_TO edges for
 	// google-cloud-pubsub (Python/Node/Go/Java), Pub/Sub Lite, and

--- a/internal/engine/http_endpoint_synthesis.go
+++ b/internal/engine/http_endpoint_synthesis.go
@@ -110,6 +110,13 @@ func synthesisSupportsLanguage(lang string) bool {
 	// with none of the recognised anchors are no-ops inside those passes.
 	case "terraform", "hcl", "yaml":
 		return true
+	// #1708: Debezium / Kafka-Connect connector configs are JSON. The
+	// classifier only routes path-narrow JSON files (cdc/, debezium/,
+	// kafka-connect/, *-connector.json, …) to language="json", so this
+	// case is reached only for likely-connector files. Files that don't
+	// content-sniff as a connector are no-ops in applyDebeziumCDCEdges.
+	case "json":
+		return true
 	default:
 		return false
 	}

--- a/internal/extractors/sql/sql.go
+++ b/internal/extractors/sql/sql.go
@@ -93,8 +93,16 @@ var (
 	// EXECUTE {FUNCTION|PROCEDURE} func_name
 	// Captures: (1) trigger_name, (2) event (BEFORE|AFTER|INSTEAD OF),
 	//           (3) table_name, (4) func_name
+	//
+	// Issue #1708: PostgreSQL supports an optional column list on UPDATE
+	// triggers — `UPDATE OF col[, col2]` — and column-list events may chain
+	// with `OR INSERT|DELETE`. The original DML segment only handled the
+	// `UPDATE [OR INSERT [OR DELETE]]` form (no `OF`). The .*? before `ON`
+	// now non-greedily skips ANY tokens between the event keyword and the
+	// `ON` clause, so column-list, FROM/REFERENCING, deferral, and WHEN
+	// clauses no longer prevent extraction.
 	triggerRE = regexp.MustCompile(
-		`(?is)CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\s+(\w+)\s+(?:(BEFORE|AFTER|INSTEAD\s+OF)\s+)?(?:\w+\s+(?:OR\s+\w+\s+)*)?ON\s+(?:\w+\.)?(\w+)\s+.*?EXECUTE\s+(?:FUNCTION|PROCEDURE)\s+(?:\w+\.)?(\w+)\s*\(`,
+		`(?is)CREATE\s+(?:CONSTRAINT\s+)?TRIGGER\s+(\w+)\s+(?:(BEFORE|AFTER|INSTEAD\s+OF)\s+)?.*?\bON\s+(?:\w+\.)?(\w+)\b.*?EXECUTE\s+(?:FUNCTION|PROCEDURE)\s+(?:\w+\.)?(\w+)\s*\(`,
 	)
 
 	// dbt Jinja patterns.

--- a/internal/extractors/sql/sql_1708_test.go
+++ b/internal/extractors/sql/sql_1708_test.go
@@ -1,0 +1,61 @@
+package sql_test
+
+// Issue #1708: PostgreSQL `CREATE TRIGGER ... AFTER UPDATE OF <col> ON <table>`
+// (column-list event form) was not matched by triggerRE, so the trigger
+// entity and the FIRES / DEFINED_ON edges were never emitted on real-world
+// fixtures (polyglot-platform-services-orders 002_views_procs_triggers.sql).
+//
+// The fixture migration_007_trigger_update_of.sql exercises both single-column
+// (`UPDATE OF status`) and multi-column (`UPDATE OF status, total_cents`)
+// forms. The fix relaxes the DML segment of triggerRE to skip ANY tokens
+// between the event keyword and the `ON` clause.
+
+import "testing"
+
+func loadFixture1708(t *testing.T) []byte {
+	t.Helper()
+	return loadFixture(t, "migration_007_trigger_update_of.sql")
+}
+
+func Test1708_TriggerColumnListExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1708(t), "migrations/007_trigger_update_of.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("expected TRIGGER trg_order_status_change (UPDATE OF col form)")
+	}
+	if e.Subtype != "trigger" {
+		t.Errorf("expected Subtype=trigger, got %q", e.Subtype)
+	}
+}
+
+func Test1708_TriggerMultiColumnListExtracted(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1708(t), "migrations/007_trigger_update_of.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_orders_multi_col")
+	if e == nil {
+		t.Fatal("expected TRIGGER trg_orders_multi_col (UPDATE OF col1, col2 form)")
+	}
+}
+
+func Test1708_TriggerFiresEdge(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1708(t), "migrations/007_trigger_update_of.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("trigger entity missing")
+	}
+	fires := collectEdges(e.Relationships, "FIRES")
+	if !fires["log_order_status_change"] {
+		t.Errorf("expected FIRES log_order_status_change, got %v", fires)
+	}
+}
+
+func Test1708_TriggerDefinedOnEdge(t *testing.T) {
+	entities := extractSQLBytes(t, loadFixture1708(t), "migrations/007_trigger_update_of.sql")
+	e := findEntity(entities, "SCOPE.Datastore", "trg_order_status_change")
+	if e == nil {
+		t.Fatal("trigger entity missing")
+	}
+	definedOn := collectEdges(e.Relationships, "DEFINED_ON")
+	if !definedOn["orders"] {
+		t.Errorf("expected DEFINED_ON orders, got %v", definedOn)
+	}
+}

--- a/internal/extractors/sql/testdata/migration_007_trigger_update_of.sql
+++ b/internal/extractors/sql/testdata/migration_007_trigger_update_of.sql
@@ -1,0 +1,37 @@
+-- Fixture for Issue #1708: PostgreSQL UPDATE OF column trigger form.
+-- Mirrors polyglot-platform/services/orders/migrations/002_views_procs_triggers.sql
+-- which uses `AFTER UPDATE OF status ON orders` — the original triggerRE
+-- failed to match the column-list form.
+
+CREATE TABLE orders (
+    id SERIAL PRIMARY KEY,
+    status TEXT
+);
+
+CREATE TABLE order_status_audit (
+    id BIGSERIAL PRIMARY KEY,
+    order_id TEXT NOT NULL,
+    old_status TEXT,
+    new_status TEXT
+);
+
+CREATE OR REPLACE FUNCTION log_order_status_change()
+RETURNS TRIGGER AS $$
+BEGIN
+    INSERT INTO order_status_audit(order_id, old_status, new_status)
+    VALUES (OLD.id, OLD.status, NEW.status);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- The column-list trigger form (`UPDATE OF status`) is what broke #1708.
+CREATE TRIGGER trg_order_status_change
+    AFTER UPDATE OF status ON orders
+    FOR EACH ROW
+    EXECUTE FUNCTION log_order_status_change();
+
+-- Multi-column list form, also covered.
+CREATE TRIGGER trg_orders_multi_col
+    AFTER UPDATE OF status, total_cents ON orders
+    FOR EACH ROW
+    EXECUTE FUNCTION log_order_status_change();

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -370,6 +370,15 @@ const (
 	// SCOPE.Component/class or SCOPE.Schema model entity without new linker code.
 	RelationshipKindHandlesSignal RelationshipKind = "HANDLES_SIGNAL"
 	RelationshipKindRegisters     RelationshipKind = "REGISTERS"
+
+	// #1708: Debezium / Kafka-Connect CDC connector edges.
+	//   CAPTURES : cdc_connector → source table (one per element of the
+	//              connector's table.include.list).
+	// PUBLISHES_TO is reused (RelationshipKindPublishesTo) for the
+	// connector → kafka:<topic> edge, so downstream Kafka consumers'
+	// SUBSCRIBES_TO edges attach to the same MessageTopic node without
+	// any cross-pass handoff.
+	RelationshipKindCaptures RelationshipKind = "CAPTURES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -442,6 +451,8 @@ func AllRelationshipKinds() []RelationshipKind {
 		// #1374 Django signal/admin connectivity:
 		RelationshipKindHandlesSignal,
 		RelationshipKindRegisters,
+		// #1708 Debezium / Kafka-Connect CDC connector:
+		RelationshipKindCaptures,
 	}
 }
 


### PR DESCRIPTION
## 1. What changed

Polyglot iter3 calibration ([benchmark report](~/private/benchmarks/mcp-quality-bench-polyglot-2026-05-24.md), §11 q11) flagged the CDC chain as unstitchable: the DB trigger, source table, audit table, and Debezium connector all exist as nodes, but the **edges** between them are missing. This PR fixes both halves of the chain.

**Trigger half** — `internal/extractors/sql/sql.go` `triggerRE` did not match the PostgreSQL `UPDATE OF col[, col2]` column-list trigger form. The polyglot fixture `services/orders/migrations/002_views_procs_triggers.sql` uses exactly that form (`AFTER UPDATE OF status ON orders`), so the trigger entity and its `FIRES` + `DEFINED_ON` edges were silently absent on real-world fixtures. The existing #1414 fixture used the simpler `AFTER UPDATE ON` form which kept the tests green while the production codepath no-op'd.

Fix: relax the DML segment of `triggerRE` to non-greedily skip ANY tokens between the event keyword and the `ON` clause. Adds regression fixture `migration_007_trigger_update_of.sql` plus tests pinning extraction, `FIRES`, `DEFINED_ON`, and the multi-column form.

**Connector half** — Debezium / Kafka-Connect connector JSON files were never reaching the engine: the classifier's `extensionLanguageMap` has no `.json` entry, so every connector config was `Skipped` at Pass 1.

Fix split across three layers:

1. `internal/classifier/classifier.go` — narrow JSON routing in `detectLanguage` that returns `"json"` ONLY for path-narrow files (`cdc/`, `debezium/`, `kafka-connect/`, `connectors/`, `*-connector.json`, `*.connector.json`, `*-debezium.json`). All other `.json` (package.json, tsconfig.json, lockfiles, frontend data) stays unindexed. A `dirAnchor` helper matches both `<root>/cdc/<file>` and `cdc/<file>` forms so the pattern survives monorepo subrepo rooting.

2. `internal/engine/debezium_cdc_edges.go` — new append-only engine pass `applyDebeziumCDCEdges` that parses Debezium / Kafka-Connect JSON config and emits:
   - `SCOPE.Component` / `cdc_connector` entity per connector.
   - `SCOPE.Datastore` / `table` stub per element of `table.include.list` (bare table name, so cross-repo same-name dedup collapses it onto the canonical SQL extractor table entity).
   - `SCOPE.MessageTopic` per produced topic, keyed by canonical `kafka:<topic>` ID matching the existing Kafka synthesis pass (so downstream consumer `SUBSCRIBES_TO` edges attach to the same node without any cross-pass handoff).
   - `CAPTURES` edge: connector → captured table.
   - `PUBLISHES_TO` edge: connector → `kafka:<topic>`.

   Topic names are derived from `<topic.prefix>.<schema>.<table>` (pre-2.x Debezium connectors that only set `database.server.name` fall back to that). As a calibration escape hatch (matches #1596 `x-shipfast-*` convention) the pass also honours any top-level `x-*-cdc` doc with `captured-tables` / `produced-topics` arrays. Content-sniff guard (`"connector.class"` / `io.debezium`) makes any non-CDC file a harmless no-op.

3. `internal/engine/detector.go` — wire `applyDebeziumCDCEdges` after `applyIaCSNSEdges` (mirrors #1596 placement). `internal/engine/http_endpoint_synthesis.go` — add `"json"` to `synthesisSupportsLanguage` so the file reaches the synthesis pass list. `internal/types/kinds.go` — register `RelationshipKindCaptures = "CAPTURES"` so the producer-kinds validator scan accepts the new edge.

## 2. Tests

- `internal/extractors/sql/sql_1708_test.go` — 4 new tests pin trigger extraction on the `UPDATE OF col` and `UPDATE OF col1, col2` forms plus the `FIRES` / `DEFINED_ON` edges. All existing #1414 tests still pass.
- `internal/engine/debezium_cdc_edges_test.go` — 6 tests cover the polyglot fixture, derived topic-name path, legacy `database.server.name` fallback, non-JSON no-op, non-connector JSON no-op (package.json shape), and the bare-table-name CAPTURES contract.
- `internal/classifier/classifier_test.go` — 2 new tests cover 8 CDC-path-narrow patterns + 5 noisy generic JSON paths to lock the narrow-routing contract.

`go vet ./...` clean. Full suite green except for a pre-existing `TestModuleCoverage_AllEntitiesTagged` failure on `origin/main` (verified by running the same test on a clean `/tmp/ag-main` worktree — same failures, unrelated to this PR).

## 3. Risks / scope guard

Append-only across every layer: every new entity and edge is added; no existing entity or edge is modified or removed. The Debezium pass also content-sniffs before emitting anything, so even if the classifier widens scope later, files that aren't connector configs stay silent.

The narrow JSON routing intentionally leaves every other `.json` file (lockfiles, frontend data, tsconfig, etc.) outside the indexer's reach, so this PR does not change indexing volume on any non-CDC corpus.

## 4. End-to-end verification (isolated reindex on polyglot-platform)

- **services/orders** rebuild: 174 entities, 575 rels — `trg_order_status_change` entity now present, `FIRES log_order_status_change` + `DEFINED_ON orders` edges emitted; `log_order_status_change WRITES_TO order_status_audit` preserved.
- **services/cdc** rebuild (after adding the subdir to the fleet, matching #1696 pattern for IaC subdirs): 15 entities, 23 rels — 1 `SCOPE.Component`/`cdc_connector`, 2 `SCOPE.Datastore`/`table` stubs, 2 `SCOPE.MessageTopic`, 2 `CAPTURES`, 2 `PUBLISHES_TO`.
- **Cross-repo linker**: 2 new `shared_label` links — `cdc::CAPTURES.target("orders")` ↔ `orders::SCOPE.Datastore.table("orders")` and similarly for `order_status_audit`. The chain stitches end-to-end:

  ```
  trg_order_status_change (orders)
    ─FIRES─▶ log_order_status_change ─WRITES_TO─▶ order_status_audit
                                                        ◀─CAPTURES─ orders-postgres-cdc (cdc)
                                                                     ─PUBLISHES_TO─▶ kafka:cdc.public.order_status_audit
  ```

## 5. Follow-ups

- The polyglot `services/cdc/` subdirectory is not in the fleet config; #1696 added the analogous `infra/*` subdirs. Filing a small follow-up PR to add `services/cdc` to the polyglot fleet so the orphan recovery + topology tests pick it up automatically.
- The Debezium pass uses bare table names on the `CAPTURES` ToID for cross-repo dedup. If the same table name exists in multiple repos in a group, the resolver's tie-break (#1662 family) determines which canonical node wins. For the polyglot fixture this is fine (only one `orders` table); for groups with shadowed names, the schema-qualified form is preserved as `Properties["cdc_source_table"]` so a future resolver pass can disambiguate without re-parsing.

## 6. MCP dogfood notes (Issue #1680)

Per #1680 instructions I tried to use the archigraph MCP throughout this investigation. **Friction blocker:** every MCP call returned `MCP error -32000: archigraph daemon is not running — run 'archigraph start' or 'archigraph install'`, despite the daemon being healthy (`status` reported `running pid=21442 uptime=1m+ rss=53MB`, socket present at `~/.archigraph/sockets/daemon.sock`, port 47274 LISTEN, and `mcp-activity.jsonl` showed another session's MCP bridge talking to the same daemon successfully). The Claude-Code MCP bridge process my session inherited (pid 8684, started Thursday) appears to have lost its connection to the daemon and never reconnected. Restarting the daemon from this terminal did not help — the bridge handle is per-Claude-session, not per-CLI-call.

| Tool call                              | Args                                                                | Result                                  | Elapsed | Replaces?                | Friction                                                                                            |
| -------------------------------------- | ------------------------------------------------------------------- | --------------------------------------- | ------- | ------------------------ | --------------------------------------------------------------------------------------------------- |
| `archigraph_whoami`                    | `cwd=/tmp/ag-idx`                                                   | error: daemon not running               | ~50ms   | none                     | bridge-vs-daemon disconnect; no path to recover from inside Claude session                          |
| `archigraph_whoami`                    | `group=polyglot-platform`                                           | error: daemon not running               | ~50ms   | none                     | same                                                                                                |
| `archigraph_stats`                     | `group=polyglot-platform cwd=…/polyglot-platform`                   | error: daemon not running               | ~50ms   | none                     | same                                                                                                |
| `archigraph_search_entities`           | `query=trg_order_status_change group=polyglot-platform`             | error: daemon not running               | ~50ms   | none                     | same                                                                                                |

**Investigation actually proceeded via** `python3` reads of `~/.archigraph/store/orders-d925d1cae0b28e3b/graph.json` (definitive for "what edges exist NOW", which `archigraph_inspect` would normally answer in one round-trip) + `grep -nE "CREATE TRIGGER"` over `internal/extractors/sql/` (which `archigraph_get_source` would have answered for the extractor regex itself, ~10ms typical).

**Estimated tool calls replaced if MCP had worked:**
- `archigraph_inspect(label_or_id="trg_order_status_change", group=polyglot-platform)` — 1 call vs ~30s of `python3` + jq across multiple graph.json files to discover the entity was missing from the orders graph entirely.
- `archigraph_find(question="how does the trigger function reach the audit table", group=polyglot-platform, depth=2)` — 1 call vs the entire `grep -rnE "WRITES_TO|trigger|audit"` walk I did across `internal/extractors/sql/` and `internal/engine/`.
- `archigraph_topology(action="topic_detail", topic_id="kafka:cdc.public.orders", group=polyglot-platform)` — would have proven the consumer side at the end without the cross-repo links JSON dive.

**Net verdict for this refactor:** would have benefited from MCP. The investigation surface (locate trigger emitter → confirm regex bug → trace function-body DML edges → confirm cross-repo dedup post-fix) is exactly the kind of "small targeted graph queries against an already-indexed group" that the MCP should crush. Every call I attempted was a candidate to replace grep+Read but the bridge failure forced me back to the slow path. This data feeds #1680's value-measurement: MCP value DEPENDS ON the bridge being reliable across Claude session lifetimes; that's the failure mode this run surfaces.

Fixes #1708

🤖 Generated with [Claude Code](https://claude.com/claude-code)