### PR TITLE
feat(mcp/denoise): bucket SCOPE.Pattern entities as tier-8 noise

### DIFF
--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -2,15 +2,25 @@
 //
 // The graph carries many synthetic / structural entities that are useful for
 // traversal but pure noise in a ranked find/search result: file-and-module
-// CONTAINER components, inferred class-hierarchy shadows, raw Pattern nodes, and
-// Process nodes for array built-ins. Worse, because these often share the BM25
-// score of a real match (label substring), they frequently rank ABOVE the real
-// lined entity the agent actually wants.
+// CONTAINER components, inferred class-hierarchy shadows, raw SCOPE.Pattern nodes
+// (e.g. error_handling:try_catch:N), Schema field members, and Process nodes for
+// array built-ins. Worse, because these often share the BM25 score of a real
+// match (label substring), they frequently rank ABOVE the real lined entity the
+// agent actually wants.
 //
 // This file classifies entities into noise buckets and provides a stable
 // re-rank comparator so that real, lined, qualified entities sort first. It is
 // purely a serving-layer concern — no extraction state is touched (other grinds
 // own internal/extractors and internal/engine).
+//
+// Noise tiers (ascending = worse rank):
+//
+//	noiseNone (0)       — real entity; ranks by BM25 and start_line presence
+//	noiseShadow (4)     — inferred class-hierarchy / implicit-method shadow
+//	noiseContainer (5)  — file/module CONTAINER Component
+//	noiseProcess (6)    — array/string built-in Process node
+//	noiseSchemaField (7) — SCOPE.Schema subtype=field member (#1715)
+//	noisePattern (8)    — SCOPE.Pattern structural node (#1733)
 package mcp
 
 import (
@@ -83,7 +93,9 @@ func classifyNoise(e *graph.Entity) noiseKind {
 
 	// Raw structural Pattern nodes (NOT the agent-learned AgentPattern kind,
 	// which has no SCOPE. prefix and is surfaced deliberately).
-	if e.Kind == string(types.EntityKindPattern) {
+	// Match both the canonical "SCOPE.Pattern" kind and any bare "pattern"
+	// variant that extractors may emit without the scope prefix.
+	if e.Kind == string(types.EntityKindPattern) || bareKind == "pattern" {
 		return noisePattern
 	}
 
@@ -159,18 +171,31 @@ func isNoise(e *graph.Entity) bool { return classifyNoise(e) != noiseNone }
 // lineless (endpoints/resources) tier 2, and every noise bucket tier 3+. The
 // caller combines tier with BM25 score so that within a tier the BM25 order is
 // preserved, but a real entity always outranks a shadow/container/pattern.
+//
+// Tier map (ascending = worse rank):
+//
+//	0 — real lined entity (start_line > 0)
+//	1 — lineless but legitimate (endpoint/resource)
+//	4 — noiseShadow (inferred class-hierarchy / implicit-method shadow)
+//	5 — noiseContainer (file/module CONTAINER Component)
+//	6 — noiseProcess (array/string built-in Process node)
+//	7 — noiseSchemaField (SCOPE.Schema subtype=field member, #1712)
+//	8 — noisePattern (SCOPE.Pattern structural node, #1733)
 func rankTier(e *graph.Entity) int {
 	switch classifyNoise(e) {
 	case noiseContainer:
 		return 5
 	case noiseShadow:
 		return 4
-	case noisePattern:
-		return 6
 	case noiseProcess:
 		return 6
 	case noiseSchemaField:
 		return 7
+	case noisePattern:
+		// SCOPE.Pattern nodes (e.g. error_handling:try_catch:N) rank below all
+		// other noise tiers — they are structural enrichment signals, never
+		// direct answers to a user search query (#1733).
+		return 8
 	}
 	// Real entity. Lined entities (whether or not they carry a qualified_name)
 	// share the top tier so that BM25 relevance — not the mere presence of a

--- a/internal/mcp/denoise_test.go
+++ b/internal/mcp/denoise_test.go
@@ -159,6 +159,104 @@ func TestRankTierSchemaFieldBelowParent(t *testing.T) {
 	}
 }
 
+// TestClassifyNoiseScopePattern verifies that SCOPE.Pattern entities (structural
+// pattern nodes such as error_handling:try_catch:N) are classified as
+// noisePattern — tier 8, below all other noise tiers (#1733).
+func TestClassifyNoiseScopePattern(t *testing.T) {
+	cases := []struct {
+		name string
+		e    graph.Entity
+		want noiseKind
+	}{
+		{
+			name: "canonical SCOPE.Pattern kind",
+			e: graph.Entity{
+				Kind: "SCOPE.Pattern", Name: "error_handling:try_catch:19",
+				SourceFile: "src/api/handlers.go", StartLine: 42,
+			},
+			want: noisePattern,
+		},
+		{
+			name: "bare Pattern kind (no SCOPE. prefix)",
+			e: graph.Entity{
+				Kind: "Pattern", Name: "auth:jwt_verify:3",
+				SourceFile: "src/middleware/auth.go", StartLine: 7,
+			},
+			want: noisePattern,
+		},
+		{
+			name: "AgentPattern is NOT structural noise (agent-learned, ADR-0018)",
+			e: graph.Entity{
+				// AgentPattern entities are agent-learned (ADR-0018); they have a
+				// StartLine from their definition source and are real surfaceable
+				// results — not structural noise like SCOPE.Pattern.
+				Kind: "AgentPattern", Name: "use-retry-on-transient-errors",
+				QualifiedName: "patterns.use-retry-on-transient-errors", StartLine: 3,
+			},
+			want: noiseNone,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := classifyNoise(&c.e); got != c.want {
+				t.Fatalf("classifyNoise = %d, want %d", got, c.want)
+			}
+		})
+	}
+}
+
+// TestRankTierPatternBelowSchemaField verifies the tier-8 guarantee: SCOPE.Pattern
+// nodes must rank strictly below Schema field members (tier 7) and below all
+// other real entities (#1733).
+func TestRankTierPatternBelowSchemaField(t *testing.T) {
+	real := &graph.Entity{
+		Kind: "SCOPE.Operation", Name: "authenticateJWT",
+		QualifiedName: "middleware.authenticateJWT", StartLine: 12,
+	}
+	schemaField := &graph.Entity{
+		Kind: "SCOPE.Schema", Subtype: "field",
+		Name:       "TokenSerializer.expiry",
+		SourceFile: "core/serializers/token_serializer.py", StartLine: 5,
+	}
+	pattern := &graph.Entity{
+		Kind: "SCOPE.Pattern", Name: "error_handling:try_catch:19",
+		SourceFile: "src/api/handlers.go", StartLine: 42,
+	}
+
+	// Real entity should rank better than both schema field and pattern.
+	if rankTier(real) >= rankTier(schemaField) {
+		t.Fatalf("real entity tier (%d) should be lower (better) than schema field tier (%d)",
+			rankTier(real), rankTier(schemaField))
+	}
+	if rankTier(real) >= rankTier(pattern) {
+		t.Fatalf("real entity tier (%d) should be lower (better) than pattern tier (%d)",
+			rankTier(real), rankTier(pattern))
+	}
+	// Schema field (tier 7) should rank better than pattern (tier 8).
+	if rankTier(schemaField) >= rankTier(pattern) {
+		t.Fatalf("schema field tier (%d) should be lower (better) than pattern tier (%d)",
+			rankTier(schemaField), rankTier(pattern))
+	}
+}
+
+// TestRankTierPatternBelowProcess verifies that SCOPE.Pattern (tier 8) ranks
+// strictly below noiseProcess (tier 6) — process nodes are structural but at
+// least name a real call site, whereas pattern nodes are aggregated labels.
+func TestRankTierPatternBelowProcess(t *testing.T) {
+	process := &graph.Entity{
+		ID: "proc:aabbccdd11223344", Kind: "SCOPE.Process", Name: "Login → map",
+		SourceFile: "src/features/auth/login/index.tsx", StartLine: 0,
+	}
+	pattern := &graph.Entity{
+		Kind: "SCOPE.Pattern", Name: "error_handling:try_catch:7",
+		SourceFile: "src/api/users.ts", StartLine: 88,
+	}
+	if rankTier(process) >= rankTier(pattern) {
+		t.Fatalf("process tier (%d) should be lower (better) than pattern tier (%d)",
+			rankTier(process), rankTier(pattern))
+	}
+}
+
 func TestPageSlice(t *testing.T) {
 	s := []int{0, 1, 2, 3, 4}
 	if got := pageSlice(s, 0, 2); len(got) != 2 || got[0] != 0 {


### PR DESCRIPTION
## What

Extends the MCP serving-layer de-noise system to bucket `SCOPE.Pattern` structural entities (e.g. `error_handling:try_catch:N`) into a new **tier 8** — the lowest rank tier — so they no longer surface above real code entities in default `find`/`search_entities` results.

Fixes #1733

---

## Why

iter3 + iter4 calibrations flagged 1,156 `SCOPE.Pattern` nodes in upvate-core polluting default ranked results. These nodes are valuable as enrichment signals (the `archigraph_patterns` MCP uses them) but are not what agents want when searching for actual entities like auth middleware. Because they often carry a BM25-matching label substring (e.g. `error_handling:try_catch:19` matches a query for "error handling"), they ranked alongside or above real lined entities.

The de-noise layer already handles class shadows (tier 4), containers (tier 5), process builtins (tier 6), and schema field members (tier 7) from #1715. This PR adds tier 8 for `SCOPE.Pattern`.

---

## Changes

### `internal/mcp/denoise.go`
- `classifyNoise`: extended the pattern guard to match both `e.Kind == "SCOPE.Pattern"` (canonical) **and** `bareKind == "pattern"` (belt-and-suspenders for extractors that emit the kind without the `SCOPE.` prefix).
- `rankTier`: moved `noisePattern` from tier 6 (was shared with `noiseProcess`) to **tier 8** — new lowest tier, below `noiseSchemaField` at tier 7.
- Added a full tier-map comment to the `rankTier` docstring for future maintainability.
- Updated the file header to list all noise tiers including the new tier 8.

### `internal/mcp/denoise_test.go`
Three new test functions:
- `TestClassifyNoiseScopePattern` — three sub-cases: canonical `SCOPE.Pattern` kind, bare `Pattern` kind, and `AgentPattern` guard (agent-learned patterns must NOT be classified as structural noise).
- `TestRankTierPatternBelowSchemaField` — asserts tier-8 guarantee: real entity < schema field (tier 7) < pattern (tier 8).
- `TestRankTierPatternBelowProcess` — asserts that process nodes (tier 6) rank strictly better than pattern nodes (tier 8).

---

## Verification

- `go build ./...` — clean
- `go vet ./internal/mcp/...` — clean
- `go test ./internal/mcp/...` — all pass (2.4s)
- `go test ./...` — all pass except `TestModuleCoverage_AllEntitiesTagged` which is pre-existing on `main` (confirmed by running against `main` HEAD directly; not introduced by this PR)

### Spot-check: `archigraph_patterns` MCP surface unaffected

`patterns.go` routes `archigraph_patterns` calls to the `agentpatterns` JSON sidecar store (`handlePatternsQuery` → `agentpatterns.Load`). It does not call `classifyNoise` or `rankTier`. SCOPE.Pattern nodes in the graph entity index are unrelated to agent-learned patterns in the sidecar — no change needed, no de-noise bypass risk.

### In-flight PR compatibility

- #1727 (`dup-kind`) and #1731 (`migration-exclude`) do not touch `denoise.go` or `denoise_test.go` — no conflicts.

---

## Test plan

- [ ] `go test ./internal/mcp/ -run "TestClassifyNoise|TestRankTier" -v` — all subtests pass
- [ ] Search `authentication middleware` on upvate group — `error_handling:try_catch:N` entities should no longer appear in top results
- [ ] Search with `include_noise=true` — pattern entities reappear in results, confirming they are suppressed (not deleted)
- [ ] `archigraph_patterns action=query text="error handling"` — still returns AgentPattern results; SCOPE.Pattern nodes are not in the sidecar store and are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)