### PR TITLE
[#1727] Extend class-shadow fold to cover View+Component and File+Component duplicate-kind pairs

### DIFF
--- a/cmd/archigraph/dupkind_fold_test.go
+++ b/cmd/archigraph/dupkind_fold_test.go
@@ -1,0 +1,423 @@
+package main
+
+import (
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// makeTestID computes the same hex entity-ID the indexer would stamp.
+func makeTestID(kind, name, sourceFile string) string {
+	return graph.EntityID("test_repo", kind, name, sourceFile)
+}
+
+// dupkindIndexer returns a minimal Indexer sufficient for fold method calls.
+func dupkindIndexer() *Indexer {
+	return &Indexer{repoTag: "test_repo"}
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 1: View + Component fold
+// ---------------------------------------------------------------------------
+
+// TestDupKindFold_ViewComponent_ScopeView verifies that a SCOPE.View entity
+// is preferred over a sibling SCOPE.Component/class entity (with role="class")
+// sharing the same (source_file, name). After the fold exactly ONE node must
+// remain and it must be SCOPE.View. Issue #1727.
+func TestDupKindFold_ViewComponent_ScopeView(t *testing.T) {
+	const (
+		srcFile = "src/views/UserListView.ts"
+		name    = "UserListView"
+	)
+
+	viewID := makeTestID("SCOPE.View", name, srcFile)
+	compID := makeTestID("SCOPE.Component", name, srcFile)
+
+	records := []types.EntityRecord{
+		{
+			ID:         viewID,
+			Kind:       "SCOPE.View",
+			Name:       name,
+			SourceFile: srcFile,
+			StartLine:  5,
+			Properties: map[string]string{"framework": "some_framework"},
+		},
+		{
+			// SCOPE.Component with role="class" — hierarchy pass annotation
+			// or similar extractor that sets the role but not yet in
+			// classLikeComponentSubtypes. isFoldSource must return true.
+			ID:         compID,
+			Kind:       "SCOPE.Component",
+			Name:       name,
+			SourceFile: srcFile,
+			StartLine:  5,
+			Subtype:    "", // empty subtype — would NOT match classLikeComponentSubtypes alone
+			Properties: map[string]string{"role": "class"},
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldClassHierarchyShadows(records, nil)
+
+	if stats.ShadowsFolded != 1 {
+		t.Errorf("expected 1 fold, got %d; records=%+v", stats.ShadowsFolded, out)
+	}
+
+	// Exactly ONE entity with name=UserListView must survive.
+	var survivors []types.EntityRecord
+	for _, r := range out {
+		if r.Name == name {
+			survivors = append(survivors, r)
+		}
+	}
+	if len(survivors) != 1 {
+		t.Fatalf("expected 1 surviving node for %q, got %d: %+v", name, len(survivors), survivors)
+	}
+	if survivors[0].Kind != "SCOPE.View" {
+		t.Errorf("surviving node should be SCOPE.View, got kind=%s", survivors[0].Kind)
+	}
+}
+
+// TestDupKindFold_ViewComponent_BareView verifies that the bare "View" kind
+// (emitted by Django YAML rules) absorbs a sibling SCOPE.Component/class
+// entity for the same (source_file, name). Issue #1727 — regression guard.
+func TestDupKindFold_ViewComponent_BareView(t *testing.T) {
+	const (
+		srcFile = "users/views.py"
+		name    = "UserDetailView"
+	)
+
+	viewID := makeTestID("View", name, srcFile)
+	compID := makeTestID("SCOPE.Component", name, srcFile)
+
+	records := []types.EntityRecord{
+		{
+			ID:         viewID,
+			Kind:       "View",
+			Name:       name,
+			SourceFile: srcFile,
+			StartLine:  10,
+			Properties: map[string]string{"framework": "django"},
+		},
+		{
+			// SCOPE.Component/class emitted by the Python AST extractor
+			ID:         compID,
+			Kind:       "SCOPE.Component",
+			Name:       name,
+			SourceFile: srcFile,
+			Subtype:    "class",
+			StartLine:  10,
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldClassHierarchyShadows(records, nil)
+
+	if stats.ShadowsFolded != 1 {
+		t.Errorf("expected 1 fold (bare View absorbs SCOPE.Component/class), got %d", stats.ShadowsFolded)
+	}
+
+	var survivors []types.EntityRecord
+	for _, r := range out {
+		if r.Name == name {
+			survivors = append(survivors, r)
+		}
+	}
+	if len(survivors) != 1 {
+		t.Fatalf("expected 1 surviving node for %q, got %d: %+v", name, len(survivors), survivors)
+	}
+	if survivors[0].Kind != "View" {
+		t.Errorf("surviving node should be View, got kind=%s", survivors[0].Kind)
+	}
+}
+
+// TestDupKindFold_ViewComponent_NoOverFold verifies that two DIFFERENT classes
+// in the same file (with different names) are NOT folded together. Issue #1727.
+func TestDupKindFold_ViewComponent_NoOverFold(t *testing.T) {
+	const srcFile = "users/views.py"
+
+	records := []types.EntityRecord{
+		{
+			ID:         makeTestID("View", "UserListView", srcFile),
+			Kind:       "View",
+			Name:       "UserListView",
+			SourceFile: srcFile,
+			StartLine:  5,
+		},
+		{
+			ID:         makeTestID("SCOPE.Component", "UserListView", srcFile),
+			Kind:       "SCOPE.Component",
+			Name:       "UserListView",
+			SourceFile: srcFile,
+			Subtype:    "class",
+			StartLine:  5,
+		},
+		{
+			// This class has a DIFFERENT name — must NOT be absorbed.
+			ID:         makeTestID("SCOPE.Component", "HelperMixin", srcFile),
+			Kind:       "SCOPE.Component",
+			Name:       "HelperMixin",
+			SourceFile: srcFile,
+			Subtype:    "class",
+			StartLine:  20,
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldClassHierarchyShadows(records, nil)
+
+	// Only the UserListView SCOPE.Component should be absorbed.
+	if stats.ShadowsFolded != 1 {
+		t.Errorf("expected exactly 1 fold (UserListView only), got %d", stats.ShadowsFolded)
+	}
+
+	// HelperMixin must still be present.
+	var helperNodes int
+	for _, r := range out {
+		if r.Name == "HelperMixin" {
+			helperNodes++
+		}
+	}
+	if helperNodes != 1 {
+		t.Errorf("HelperMixin should survive the fold unchanged, got %d nodes", helperNodes)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2: File + Component fold
+// ---------------------------------------------------------------------------
+
+// TestDupKindFold_FileComponent_BasicFold verifies that a SCOPE.Component/class
+// entity whose name matches the file stem is absorbed into the co-located
+// SCOPE.Component(subtype="file") entity. Issue #1727.
+func TestDupKindFold_FileComponent_BasicFold(t *testing.T) {
+	const (
+		srcFile  = "src/components/LoginPage.tsx"
+		fileID   = "ffff000000000001" // pre-computed sentinel for test
+		classID  = "cccc000000000001"
+		className = "LoginPage" // matches stem of "LoginPage.tsx"
+	)
+
+	records := []types.EntityRecord{
+		{
+			// File entity: name == source_file path.
+			ID:         fileID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "file",
+			Name:       srcFile,
+			SourceFile: srcFile,
+			StartLine:  0,
+		},
+		{
+			// Class entity: name matches file stem "loginpage".
+			ID:         classID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			Name:       className,
+			SourceFile: srcFile,
+			StartLine:  3,
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldFileComponentDuplicates(records, nil)
+
+	if stats.Folded != 1 {
+		t.Errorf("expected 1 file-component fold, got %d; remaining=%+v", stats.Folded, out)
+	}
+
+	// The file entity must be the sole survivor.
+	var fileEnts, classEnts int
+	for _, r := range out {
+		if r.Subtype == "file" {
+			fileEnts++
+		}
+		if r.Subtype == "class" {
+			classEnts++
+		}
+	}
+	if fileEnts != 1 {
+		t.Errorf("expected 1 file entity survivor, got %d", fileEnts)
+	}
+	if classEnts != 0 {
+		t.Errorf("expected 0 class entity survivors (absorbed), got %d", classEnts)
+	}
+}
+
+// TestDupKindFold_FileComponent_NoOverFold_DifferentName verifies that a class
+// with a name that does NOT match the file stem is NOT absorbed. Issue #1727.
+func TestDupKindFold_FileComponent_NoOverFold_DifferentName(t *testing.T) {
+	const (
+		srcFile   = "src/components/LoginPage.tsx"
+		fileID    = "ffff000000000002"
+		classID1  = "cccc000000000002"
+		classID2  = "cccc000000000003"
+		className = "FormValidator" // does NOT match "loginpage"
+	)
+
+	records := []types.EntityRecord{
+		{
+			ID:         fileID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "file",
+			Name:       srcFile,
+			SourceFile: srcFile,
+			StartLine:  0,
+		},
+		{
+			// LoginPage matches stem — should be absorbed.
+			ID:         classID1,
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			Name:       "LoginPage",
+			SourceFile: srcFile,
+			StartLine:  3,
+		},
+		{
+			// FormValidator does NOT match stem — must NOT be absorbed.
+			ID:         classID2,
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			Name:       className,
+			SourceFile: srcFile,
+			StartLine:  40,
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldFileComponentDuplicates(records, nil)
+
+	// Only LoginPage should be folded; FormValidator must survive.
+	if stats.Folded != 1 {
+		t.Errorf("expected exactly 1 fold (LoginPage only), got %d", stats.Folded)
+	}
+
+	var formEnts int
+	for _, r := range out {
+		if r.Name == className {
+			formEnts++
+		}
+	}
+	if formEnts != 1 {
+		t.Errorf("FormValidator should survive unchanged, got %d entities", formEnts)
+	}
+}
+
+// TestDupKindFold_FileComponent_EdgeRepoint verifies that edges pointing to the
+// absorbed class entity are re-pointed to the file entity survivor. Issue #1727.
+func TestDupKindFold_FileComponent_EdgeRepoint(t *testing.T) {
+	const (
+		srcFile   = "src/components/Button.tsx"
+		fileID    = "ffff000000000010"
+		classID   = "cccc000000000010"
+		callerID  = "eeee000000000010"
+		className = "Button"
+	)
+
+	records := []types.EntityRecord{
+		{
+			ID:         fileID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "file",
+			Name:       srcFile,
+			SourceFile: srcFile,
+			StartLine:  0,
+		},
+		{
+			ID:         classID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			Name:       className,
+			SourceFile: srcFile,
+			StartLine:  1,
+		},
+		{
+			// A caller that IMPORTS or RENDERS the Button class.
+			ID:         callerID,
+			Kind:       "SCOPE.Component",
+			Subtype:    "file",
+			Name:       "src/pages/Home.tsx",
+			SourceFile: "src/pages/Home.tsx",
+			Relationships: []types.RelationshipRecord{
+				{Kind: "IMPORTS", ToID: classID},
+			},
+		},
+	}
+
+	idx := dupkindIndexer()
+	out, _, stats := idx.foldFileComponentDuplicates(records, nil)
+
+	if stats.Folded != 1 {
+		t.Errorf("expected 1 fold, got %d", stats.Folded)
+	}
+	if stats.EdgesRepointed == 0 {
+		t.Errorf("expected at least 1 edge repointed, got 0")
+	}
+
+	// The IMPORTS edge on Home.tsx must now point to the file entity.
+	for _, r := range out {
+		if r.ID == callerID {
+			for _, rel := range r.Relationships {
+				if rel.Kind == "IMPORTS" && rel.ToID != fileID {
+					t.Errorf("IMPORTS edge ToID should be re-pointed to fileID=%s, got %s",
+						fileID, rel.ToID)
+				}
+			}
+		}
+	}
+}
+
+// TestDupKindFold_FileComponent_NoDanglingEdges verifies the file+component
+// fold does not introduce new dangling hex-id endpoints relative to the
+// unfolded graph. Issue #1727.
+func TestDupKindFold_FileComponent_NoDanglingEdges(t *testing.T) {
+	t.Setenv("ARCHIGRAPH_DISABLE_1727_FILE_FOLD", "1")
+	unfolded := runIndexerOn(t, "testdata/django_cbv_app", "django_cbv_app", nil)
+	t.Setenv("ARCHIGRAPH_DISABLE_1727_FILE_FOLD", "")
+	folded := runIndexerOn(t, "testdata/django_cbv_app", "django_cbv_app", nil)
+
+	if d := danglingHexEndpoints(folded); d > danglingHexEndpoints(unfolded) {
+		t.Errorf("file-component fold introduced new dangling hex endpoints: folded=%d unfolded=%d",
+			d, danglingHexEndpoints(unfolded))
+	}
+}
+
+// TestDupKindFold_ViewComponent_RoleClass_Integration verifies the View+Component
+// fold via a full-indexer run on the django_cbv_app fixture. After the fold, no
+// (name, source_file) pair should yield BOTH a View kind entity AND a
+// SCOPE.Component entity (except intentional pairs like orm_model_sentinel+Model).
+// Issue #1727.
+func TestDupKindFold_ViewComponent_Integration(t *testing.T) {
+	doc := runIndexerOn(t, "testdata/django_cbv_app", "django_cbv_app", nil)
+
+	type key struct{ name, src string }
+	byKey := map[key][]string{}
+	for _, e := range doc.Entities {
+		if e.Name == "" {
+			continue
+		}
+		k := key{e.Name, e.SourceFile}
+		byKey[k] = append(byKey[k], e.Kind)
+	}
+
+	// For CBV view classes (UserListView, UserDetailView), verify no View+Component pair.
+	viewNames := []string{"UserListView", "UserDetailView"}
+	for _, name := range viewNames {
+		k := key{name, "users/views.py"}
+		kinds := byKey[k]
+		hasView := false
+		hasComponent := false
+		for _, kd := range kinds {
+			if kd == "View" || kd == "SCOPE.View" {
+				hasView = true
+			}
+			if kd == "SCOPE.Component" {
+				hasComponent = true
+			}
+		}
+		if hasView && hasComponent {
+			t.Errorf("%s: View+Component duplicate-kind pair still present after fold; kinds=%v", name, kinds)
+		}
+	}
+}

--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -2411,8 +2411,9 @@ var frameworkClassKindPriority = map[string]int{
 	// service_detector, and any other extractor that emits the canonical
 	// "SCOPE.<Kind>" form for a class-like entity). Priorities mirror the bare
 	// form so that the highest-fidelity named node always beats a generic shadow.
+	// Issue #1700.
 	"SCOPE.Service":    100,
-	"SCOPE.View":       100,
+	"SCOPE.View":       100, // #1727: View+Component fold (SCOPE-prefixed form)
 	"SCOPE.Model":      100,
 	"SCOPE.UIComponent": 100,
 	"SCOPE.GrpcService": 90,
@@ -2430,6 +2431,10 @@ func isShadowRecord(r *types.EntityRecord) bool {
 // extractors are included so that an inferential SCOPE.Component(subtype="service")
 // node emitted alongside a real SCOPE.Service node for the same class symbol is
 // recognised as a fold source and collapsed into the typed survivor. Issue #1700.
+//
+// "view" is included so that SCOPE.Component(subtype="view") nodes emitted
+// alongside a real SCOPE.View (or bare "View") node for the same class symbol
+// are recognised as fold sources. Issue #1727.
 var classLikeComponentSubtypes = map[string]bool{
 	// Language AST subtypes
 	"class": true, "struct": true, "interface": true,
@@ -2439,13 +2444,19 @@ var classLikeComponentSubtypes = map[string]bool{
 	"guard": true, "interceptor": true, "pipe": true,
 	"middleware": true, "resolver": true, "gateway": true,
 	"worker": true, "job": true, "task": true,
+	// View-type subtypes (Django CBV, MVC view layers, …) — #1727
+	"view": true,
 }
 
 // isFoldSource reports whether r is a class-representation node that should be
 // folded into a framework-typed node when one exists for the same symbol:
 //   - the INFERRED_FROM_CLASS_HIERARCHY shadow emitted by the hierarchy pass, OR
 //   - the generic SCOPE.Component class node emitted by the per-language AST
-//     extractor (these two share an EntityID and pre-merge at assembly).
+//     extractor (these two share an EntityID and pre-merge at assembly), OR
+//   - a SCOPE.Component carrying Properties["role"]="class" (hierarchy pass
+//     annotations on nodes where the language AST subtype is not yet in
+//     classLikeComponentSubtypes — e.g. TypeScript/React class components
+//     with a framework-injected role tag). Issue #1727.
 //
 // When NO framework-typed node exists, a fold source is kept as the single
 // node for that class (it already carries a real line from its extractor).
@@ -2456,7 +2467,17 @@ func isFoldSource(r *types.EntityRecord) bool {
 	if isShadowRecord(r) {
 		return true
 	}
-	return r.Kind == "SCOPE.Component" && classLikeComponentSubtypes[r.Subtype]
+	if r.Kind != "SCOPE.Component" {
+		return false
+	}
+	// Subtype-based recognition: language AST and framework-injected subtypes.
+	if classLikeComponentSubtypes[r.Subtype] {
+		return true
+	}
+	// Role-property recognition: hierarchy pass sets role="class" on SCOPE.Component
+	// nodes whose subtype is not yet in the allowlist (e.g. component, vue_component,
+	// empty subtype from certain extractors). Issue #1727.
+	return r.Properties["role"] == "class"
 }
 
 // foldClassHierarchyShadows folds line-less / generic class nodes into the real
@@ -2675,6 +2696,198 @@ func (i *Indexer) foldClassHierarchyShadows(
 	return out, pass2Rels, stats
 }
 
+// foldFileComponentStats reports the result of foldFileComponentDuplicates.
+type foldFileComponentStats struct {
+	// Folded is the number of SCOPE.Component class-like nodes collapsed into
+	// their co-located SCOPE.Component(subtype="file") sibling.
+	Folded int
+	// EdgesRepointed is the number of edge endpoints rewritten from a folded
+	// class-like component ID to its file-entity survivor ID.
+	EdgesRepointed int
+}
+
+// filePathStem returns the base filename without extension, lower-cased.
+// E.g. "src/components/LoginPage.tsx" → "loginpage".
+func filePathStem(path string) string {
+	base := filepath.Base(path)
+	ext := filepath.Ext(base)
+	stem := base[:len(base)-len(ext)]
+	return strings.ToLower(stem)
+}
+
+// foldFileComponentDuplicates collapses SCOPE.Component class-like nodes into
+// their co-located SCOPE.Component(subtype="file") sibling when the class
+// entity's name matches the file stem and there is no other distinguishing
+// structural reason to keep them separate.
+//
+// This targets the "File + Component" duplicate-kind pattern reported by iter4
+// calibration (Issue #1727): frontend repos with one-class-per-file conventions
+// (React/Vue/Svelte components, Angular services, etc.) accumulate 297+ pairs
+// where a file-level entity and a same-named class entity share source_file.
+//
+// Fold rules:
+//  1. The survivor must be a SCOPE.Component with subtype="file" (emitted by
+//     extractor.FileEntity) carrying Name == SourceFile.
+//  2. The fold source must be a SCOPE.Component with a class-like subtype (see
+//     classLikeComponentSubtypes) or role="class" property, whose Name
+//     case-insensitively matches the file stem of the survivor's SourceFile,
+//     AND whose SourceFile matches the survivor's SourceFile.
+//  3. Anti-over-fold guard: if the class entity's name does NOT match the file
+//     stem — meaning it's a *different* class inside the same file — keep both.
+//
+// Runs AFTER foldClassHierarchyShadows (so shadows are already resolved) and
+// AFTER stampEntityIDs (so r.ID is populated).
+func (i *Indexer) foldFileComponentDuplicates(
+	merged []types.EntityRecord,
+	pass2Rels []types.RelationshipRecord,
+) ([]types.EntityRecord, []types.RelationshipRecord, foldFileComponentStats) {
+	var stats foldFileComponentStats
+
+	// Index all SCOPE.Component(subtype="file") survivors by SourceFile.
+	// These are the canonical per-file module entities emitted by FileEntity().
+	type fileEnt struct {
+		idx  int
+		id   string
+		stem string // lower-cased filename without extension
+	}
+	fileBySourceFile := make(map[string]fileEnt)
+	for k := range merged {
+		r := &merged[k]
+		if r.Kind == "SCOPE.Component" && r.Subtype == "file" && r.ID != "" {
+			fileBySourceFile[r.SourceFile] = fileEnt{
+				idx:  k,
+				id:   r.ID,
+				stem: filePathStem(r.SourceFile),
+			}
+		}
+	}
+
+	if len(fileBySourceFile) == 0 {
+		return merged, pass2Rels, stats
+	}
+
+	// remap: folded class entity ID -> file entity ID.
+	remap := make(map[string]string)
+	drop := make(map[int]bool)
+
+	for k := range merged {
+		r := &merged[k]
+		// Must be a SCOPE.Component with a class-like subtype or role="class".
+		if r.Kind != "SCOPE.Component" || r.Subtype == "file" {
+			continue
+		}
+		if !classLikeComponentSubtypes[r.Subtype] && r.Properties["role"] != "class" {
+			continue
+		}
+		if r.Name == "" || r.ID == "" {
+			continue
+		}
+		fe, ok := fileBySourceFile[r.SourceFile]
+		if !ok {
+			continue
+		}
+		// Anti-over-fold: only absorb if the class entity's name matches
+		// the file stem (case-insensitive). This ensures a class named
+		// "LoginPage" in "LoginPage.tsx" is folded, but a helper class
+		// "FormValidator" in the same file is NOT absorbed.
+		if strings.ToLower(r.Name) != fe.stem {
+			continue
+		}
+		if fe.id == r.ID {
+			// Degenerate: same ID — already the same entity.
+			continue
+		}
+		drop[k] = true
+		remap[r.ID] = fe.id
+		stats.Folded++
+
+		// Copy useful properties from the class entity to the file entity
+		// (e.g. start_line, qualified_name, language) when the file entity
+		// lacks them.
+		sv := &merged[fe.idx]
+		if sv.Properties == nil {
+			sv.Properties = map[string]string{}
+		}
+		for pk, pv := range r.Properties {
+			if pk == "provenance" || pk == "ref" || pk == "kind" || pk == "subtype" {
+				continue
+			}
+			if _, exists := sv.Properties[pk]; !exists {
+				sv.Properties[pk] = pv
+			}
+		}
+		// Promote real line numbers to the file entity if it has none.
+		if sv.StartLine == 0 && r.StartLine > 0 {
+			sv.StartLine = r.StartLine
+		}
+		if sv.EndLine == 0 && r.EndLine > 0 {
+			sv.EndLine = r.EndLine
+		}
+		if sv.QualifiedName == "" && r.QualifiedName != "" {
+			sv.QualifiedName = r.QualifiedName
+		}
+		// Re-home edges the class entity owns onto the file entity.
+		for ri := range r.Relationships {
+			rel := r.Relationships[ri]
+			if rel.FromID == "" || rel.FromID == r.ID {
+				rel.FromID = fe.id
+			}
+			sv.Relationships = append(sv.Relationships, rel)
+		}
+		r.Relationships = nil
+	}
+
+	if len(remap) == 0 {
+		return merged, pass2Rels, stats
+	}
+
+	// Re-point every edge endpoint that targets a folded class entity.
+	rewrite := func(id string) (string, bool) {
+		if nv, ok := remap[id]; ok {
+			return nv, true
+		}
+		return id, false
+	}
+	for k := range merged {
+		if drop[k] {
+			continue
+		}
+		r := &merged[k]
+		for ri := range r.Relationships {
+			rel := &r.Relationships[ri]
+			if nv, ok := rewrite(rel.FromID); ok {
+				rel.FromID = nv
+				stats.EdgesRepointed++
+			}
+			if nv, ok := rewrite(rel.ToID); ok {
+				rel.ToID = nv
+				stats.EdgesRepointed++
+			}
+		}
+	}
+	for ri := range pass2Rels {
+		rel := &pass2Rels[ri]
+		if nv, ok := rewrite(rel.FromID); ok {
+			rel.FromID = nv
+			stats.EdgesRepointed++
+		}
+		if nv, ok := rewrite(rel.ToID); ok {
+			rel.ToID = nv
+			stats.EdgesRepointed++
+		}
+	}
+
+	// Compact: drop the folded class entity records.
+	out := merged[:0]
+	for k := range merged {
+		if drop[k] {
+			continue
+		}
+		out = append(out, merged[k])
+	}
+	return out, pass2Rels, stats
+}
+
 // buildDocument merges entity records from every pass, dedupes by stable
 // graph-entity ID, resolves cross-file CALLS edges, then assembles the
 // final on-disk document.
@@ -2878,6 +3091,22 @@ func (i *Indexer) buildDocument(pass1, pass2 []types.EntityRecord, pass2Rels []t
 			"class-shadow-fold: folded=%d (edges_repointed=%d) survived_with_real_lines=%d still_line0=%d\n",
 			foldStats.ShadowsFolded, foldStats.EdgesRepointed,
 			foldStats.ShadowsBackfilled, foldStats.ShadowsStillLine0)
+	}
+
+	// #1727 — fold File+Component duplicate-kind pairs: SCOPE.Component class-like
+	// nodes whose name matches the file stem of a co-located SCOPE.Component(subtype="file")
+	// entity are collapsed into the file entity. This deduplicates the 297+
+	// File+Component pairs reported by iter4 calibration on one-class-per-file
+	// front-end repos (React/Vue/Svelte components).
+	// ARCHIGRAPH_DISABLE_1727_FILE_FOLD is the verification escape hatch.
+	if os.Getenv("ARCHIGRAPH_DISABLE_1727_FILE_FOLD") == "" {
+		var fileStats foldFileComponentStats
+		merged, pass2Rels, fileStats = i.foldFileComponentDuplicates(merged, pass2Rels)
+		if fileStats.Folded > 0 {
+			fmt.Fprintf(os.Stderr,
+				"file-component-fold: folded=%d (edges_repointed=%d)\n",
+				fileStats.Folded, fileStats.EdgesRepointed)
+		}
 	}
 
 	entities := make([]graph.Entity, 0, len(merged))

--- a/cmd/archigraph/testdata/django_cbv_app/manage.py
+++ b/cmd/archigraph/testdata/django_cbv_app/manage.py
@@ -1,0 +1,11 @@
+#!/usr/bin/env python
+import os
+import sys
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myproject.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+if __name__ == '__main__':
+    main()

--- a/cmd/archigraph/testdata/django_cbv_app/users/models.py
+++ b/cmd/archigraph/testdata/django_cbv_app/users/models.py
@@ -1,0 +1,5 @@
+from django.db import models
+
+class User(models.Model):
+    email = models.EmailField()
+    name = models.CharField(max_length=100)

--- a/cmd/archigraph/testdata/django_cbv_app/users/views.py
+++ b/cmd/archigraph/testdata/django_cbv_app/users/views.py
@@ -1,0 +1,11 @@
+from django.views import View
+from django.http import JsonResponse
+from .models import User
+
+class UserListView(View):
+    def get(self, request):
+        return JsonResponse({"users": []})
+
+class UserDetailView(View):
+    def get(self, request, pk):
+        return JsonResponse({"id": pk})


### PR DESCRIPTION
## What & Why

iter4 calibration on the upvate corpus found two duplicate-kind patterns that survived the #1636/#1710 fold passes:

- **152 `(View, Component)` pairs in upvate-core**: A `View`/`SCOPE.View` entity and a sibling `SCOPE.Component` share `(source_file, name)` but the fold missed `SCOPE.Component` nodes carrying `Properties["role"]=="class"` without a subtype that was in `classLikeComponentSubtypes`.
- **297 `(File, Component)` pairs in frontend**: A `SCOPE.Component(subtype="file")` file-entity coexists with a `SCOPE.Component` class-entity whose name matches the file stem (e.g. `LoginPage` in `LoginPage.tsx`). No prior fold addressed this at-source-file level.

## Changes

### 1. `isFoldSource` extension (View + Component)

- Added `"view"` to `classLikeComponentSubtypes` so `SCOPE.Component(subtype="view")` nodes are recognised as fold sources alongside `SCOPE.View`/`View` survivors.
- Extended `isFoldSource` with a `Properties["role"]=="class"` branch: any `SCOPE.Component` that the hierarchy pass (or a future extractor) annotates with `role=class` is now eligible to be folded, even if its `Subtype` isn't in the static allowlist.

### 2. `foldFileComponentDuplicates` (File + Component)

New fold pass running immediately after `foldClassHierarchyShadows`:

- Indexes all `SCOPE.Component(subtype="file")` entities (the canonical per-file module entities emitted by `extractor.FileEntity()`).
- For each co-located `SCOPE.Component` with a class-like subtype or `role="class"`, checks: does the class entity's `Name` case-insensitively match the file stem (e.g. `"loginpage"` == stem of `"src/components/LoginPage.tsx"`)?
- **Anti-over-fold guard**: if the name does NOT match the stem, both entities survive. Classes inside a file that aren't named after the file (e.g. `FormValidator` in `LoginPage.tsx`) are never absorbed.
- Promotes real `StartLine`/`EndLine`/`QualifiedName` from the class entity to the file entity when the file entity lacks them.
- Re-homes edges owned by the absorbed class entity and re-points all referencing edges.
- Controlled by `ARCHIGRAPH_DISABLE_1727_FILE_FOLD` escape hatch (mirrors the existing `ARCHIGRAPH_DISABLE_1613_FOLD` pattern).

### 3. `django_cbv_app` fixture

New `testdata/django_cbv_app/` with Django Class-Based Views (`UserListView`, `UserDetailView`) to exercise the View+Component integration path in CI (`TestDupKindFold_ViewComponent_Integration`).

## Tests

- `TestDupKindFold_ViewComponent_ScopeView`: unit — `SCOPE.View` survives, `SCOPE.Component(role="class")` absorbed.
- `TestDupKindFold_ViewComponent_BareView`: unit — bare `View` kind absorbs `SCOPE.Component/class`.
- `TestDupKindFold_ViewComponent_NoOverFold`: unit — different-named classes in the same file are never over-folded.
- `TestDupKindFold_FileComponent_BasicFold`: unit — file entity absorbs stem-matching class entity.
- `TestDupKindFold_FileComponent_NoOverFold_DifferentName`: unit — non-stem-matching class survives.
- `TestDupKindFold_FileComponent_EdgeRepoint`: unit — IMPORTS edge re-pointed from absorbed class to file entity.
- `TestDupKindFold_FileComponent_NoDanglingEdges`: integration — fold introduces no new dangling hex endpoints.
- `TestDupKindFold_ViewComponent_Integration`: integration — CBV views have no View+Component pair after fold.

All 13 fold tests + all pre-existing `TestClassShadowFold_*` tests pass green.

## Verification

```
go build ./cmd/archigraph/...   # clean
go vet ./cmd/archigraph/...     # clean
go test ./cmd/archigraph/... -run "TestDupKindFold|TestClassShadow"   # 13 PASS
```

The pre-existing `TestModuleCoverage_AllEntitiesTagged` failure is unchanged (present on `main` before this PR).

Fixes #1727

🤖 Generated with [Claude Code](https://claude.com/claude-code)