### PR TITLE
[#1740] Token sprint Tier-2.1: entity-ID interning in MCP responses

### DIFF
--- a/internal/mcp/id_interning.go
+++ b/internal/mcp/id_interning.go
@@ -1,0 +1,186 @@
+package mcp
+
+// id_interning.go — #1740 Token sprint Tier-2.1: short-form entity-ID interning.
+//
+// Entity IDs on the wire look like "upvate-core::c84f9b9c0c3a7b18" (25–40 chars).
+// On graph-heavy responses (expand depth=2, find_callers depth=2, traces:follow)
+// the same id can appear 10+ times in a single response. By replacing every
+// occurrence with a compact handle (@1, @2, …) and emitting a _id_table field
+// that maps handles back to full IDs we save 15–30 % on response bytes with zero
+// information loss.
+//
+// Wire contract:
+//   - "_id_table" key is added to the top-level JSON object.
+//   - Every occurrence of a qualifying ID string is replaced by its handle.
+//   - Handles are assigned in order of first appearance.
+//   - Single-occurrence IDs are NOT interned (table overhead outweighs savings).
+//   - Opt-out: set MCP_NO_ID_INTERNING=1 to receive raw IDs.
+//
+// ID patterns recognised:
+//   - Prefixed:  <repo-slug>::<16-hex>   (ADR-0009 canonical form)
+//   - Bare 16-hex: [0-9a-f]{16}          (local ids before prefixing)
+//
+// The interning pass operates on the final marshaled JSON string so it is
+// encoding-agnostic and works identically for JSON objects, TOON envelopes,
+// and any future wire formats that embed IDs as strings.
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// idPattern matches the ADR-0009 canonical prefixed entity-ID form:
+//
+//	<repo-slug>::<16-hex>  e.g. "upvate-core::c84f9b9c0c3a7b18"
+//
+// Repo-slug characters: letters, digits, hyphens, underscores, dots (the first
+// char must be alphanumeric to avoid matching "::hex" or ":hex" fragments).
+// Only the fully-qualified prefixed form is interned. Bare 16-hex IDs are NOT
+// matched — they are local IDs that may appear as primary keys in responses
+// (e.g. pattern IDs, edge IDs) and round-trip directly as tool arguments;
+// interning them would break callers that pass the parsed ID back immediately.
+var idPattern = regexp.MustCompile(`[A-Za-z0-9][A-Za-z0-9\-_.]*::[0-9a-f]{16}`)
+
+// internIDs is the opt-out flag: if MCP_NO_ID_INTERNING=1 this pass is skipped.
+func internIDsEnabled() bool {
+	return strings.TrimSpace(os.Getenv("MCP_NO_ID_INTERNING")) != "1"
+}
+
+// applyIDInterning rewrites res in-place: it scans all TextContent items for
+// entity-ID strings, counts occurrences, interns IDs that appear ≥2 times, and
+// injects a "_id_table" field at the top level of the first JSON object found.
+//
+// Rules:
+//   - IDs that appear only once are NOT substituted (table overhead > savings).
+//   - Non-JSON payloads are returned unchanged.
+//   - If no ID appears ≥2 times the response is returned unchanged.
+//   - Opt-out: MCP_NO_ID_INTERNING=1 skips this function entirely.
+func applyIDInterning(res *mcpapi.CallToolResult) *mcpapi.CallToolResult {
+	if res == nil || len(res.Content) == 0 || !internIDsEnabled() {
+		return res
+	}
+
+	// Phase 1: collect all ID occurrences across all TextContent items.
+	// We build a joined "corpus" string so the regex only runs once, then
+	// re-run targeted replacement per item.
+	var corpus strings.Builder
+	for _, c := range res.Content {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok {
+			continue
+		}
+		corpus.WriteString(tc.Text)
+	}
+
+	counts := countIDOccurrences(corpus.String())
+
+	// Determine which IDs qualify for interning (appear ≥2 times).
+	// Build the table in first-appearance order by scanning corpus once more.
+	table := make(map[string]string) // full-id -> "@N"
+	var order []string               // first-appearance order
+
+	allMatches := idPattern.FindAllString(corpus.String(), -1)
+	for _, m := range allMatches {
+		if counts[m] < 2 {
+			continue
+		}
+		if _, already := table[m]; !already {
+			handle := fmt.Sprintf("@%d", len(order)+1)
+			table[m] = handle
+			order = append(order, m)
+		}
+	}
+
+	if len(order) == 0 {
+		// Nothing qualifies — return unchanged.
+		return res
+	}
+
+	// Build the _id_table payload (ordered map via key sequence).
+	idTableEntries := make(map[string]string, len(order))
+	for _, id := range order {
+		idTableEntries[table[id]] = id
+	}
+
+	// Phase 2: replace IDs in every TextContent item and inject the table.
+	// We inject into the first TextContent item that is a JSON object.
+	injected := false
+	newContent := make([]mcpapi.Content, len(res.Content))
+	copy(newContent, res.Content)
+
+	for i, c := range newContent {
+		tc, ok := c.(mcpapi.TextContent)
+		if !ok || tc.Text == "" {
+			continue
+		}
+
+		// Substitute all qualifying IDs.
+		substituted := substituteIDs(tc.Text, table)
+
+		// Inject _id_table into the first JSON object content.
+		if !injected {
+			var obj map[string]any
+			if err := json.Unmarshal([]byte(substituted), &obj); err == nil {
+				obj["_id_table"] = idTableEntries
+				if data, err := json.Marshal(obj); err == nil {
+					substituted = string(data)
+					injected = true
+				}
+			}
+		}
+
+		newContent[i] = mcpapi.NewTextContent(substituted)
+	}
+
+	// If we couldn't inject the table (all non-JSON payloads), still return the
+	// substituted content — callers can look for the table in subsequent items.
+	// For non-JSON payloads we append the table as a trailing comment.
+	if !injected && len(order) > 0 {
+		tableData, _ := json.Marshal(idTableEntries)
+		for i, c := range newContent {
+			tc, ok := c.(mcpapi.TextContent)
+			if !ok || tc.Text == "" {
+				continue
+			}
+			newContent[i] = mcpapi.NewTextContent(tc.Text + fmt.Sprintf("\n# _id_table=%s\n", string(tableData)))
+			break
+		}
+	}
+
+	out := *res
+	out.Content = newContent
+	return &out
+}
+
+// countIDOccurrences returns a map from each found ID string to the number of
+// times it appears in text.
+func countIDOccurrences(text string) map[string]int {
+	counts := make(map[string]int)
+	for _, m := range idPattern.FindAllString(text, -1) {
+		counts[m]++
+	}
+	return counts
+}
+
+// substituteIDs replaces every occurrence of a qualifying ID in text with its
+// handle from the table. Replacement is done with a single regex pass to avoid
+// partial-match issues (e.g. a bare hex ID appearing inside a prefixed one).
+//
+// We build a joint pattern that matches any qualifying ID and replaces via a
+// callback so each match is looked up in the table.
+func substituteIDs(text string, table map[string]string) string {
+	if len(table) == 0 || text == "" {
+		return text
+	}
+	return idPattern.ReplaceAllStringFunc(text, func(m string) string {
+		if h, ok := table[m]; ok {
+			return h
+		}
+		return m // not in table (appeared only once) — keep raw
+	})
+}

--- a/internal/mcp/id_interning_test.go
+++ b/internal/mcp/id_interning_test.go
@@ -1,0 +1,389 @@
+package mcp
+
+// id_interning_test.go — #1740 Token sprint Tier-2.1: entity-ID interning tests.
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	mcpapi "github.com/mark3labs/mcp-go/mcp"
+)
+
+// makeTextResult wraps a string in a CallToolResult with one TextContent.
+func makeTextResult(text string) *mcpapi.CallToolResult {
+	return &mcpapi.CallToolResult{
+		Content: []mcpapi.Content{mcpapi.NewTextContent(text)},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countIDOccurrences
+// ---------------------------------------------------------------------------
+
+func TestCountIDOccurrences_PrefixedOnly(t *testing.T) {
+	// Only the prefixed form <repo>::<hex> is interned; bare hex IDs are NOT.
+	text := `{"id":"upvate-core::c84f9b9c0c3a7b18","callers":[{"id":"upvate-core::c84f9b9c0c3a7b18"},{"id":"1234567890abcdef"},{"id":"1234567890abcdef"}]}`
+	counts := countIDOccurrences(text)
+
+	if counts["upvate-core::c84f9b9c0c3a7b18"] != 2 {
+		t.Errorf("expected 2 for prefixed id, got %d", counts["upvate-core::c84f9b9c0c3a7b18"])
+	}
+	// Bare hex IDs are intentionally NOT matched to avoid round-trip breakage.
+	if counts["1234567890abcdef"] != 0 {
+		t.Errorf("bare hex IDs should not be counted (only prefixed form is interned), got %d", counts["1234567890abcdef"])
+	}
+}
+
+func TestCountIDOccurrences_SingleOccurrence(t *testing.T) {
+	text := `{"id":"repo::aabbccddeeff0011"}`
+	counts := countIDOccurrences(text)
+	if counts["repo::aabbccddeeff0011"] != 1 {
+		t.Errorf("expected 1 occurrence, got %d", counts["repo::aabbccddeeff0011"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// substituteIDs
+// ---------------------------------------------------------------------------
+
+func TestSubstituteIDs_ReplacesQualifyingIDs(t *testing.T) {
+	table := map[string]string{
+		"repo-a::c84f9b9c0c3a7b18": "@1",
+		"repo-b::deadbeef01234567": "@2",
+	}
+	text := `{"from":"repo-a::c84f9b9c0c3a7b18","to":"repo-b::deadbeef01234567","also":"repo-a::c84f9b9c0c3a7b18"}`
+	got := substituteIDs(text, table)
+	if !strings.Contains(got, `"@1"`) {
+		t.Errorf("expected @1 in substituted text: %s", got)
+	}
+	if !strings.Contains(got, `"@2"`) {
+		t.Errorf("expected @2 in substituted text: %s", got)
+	}
+	if strings.Contains(got, "c84f9b9c0c3a7b18") {
+		t.Errorf("original ID should be replaced: %s", got)
+	}
+}
+
+func TestSubstituteIDs_LeavesNonQualifyingIDsAlone(t *testing.T) {
+	// singletonID appears only once so it is not in the table.
+	table := map[string]string{
+		"repo::c84f9b9c0c3a7b18": "@1",
+	}
+	text := `{"a":"repo::c84f9b9c0c3a7b18","b":"repo::aabbccddeeff0011"}`
+	got := substituteIDs(text, table)
+	if !strings.Contains(got, `"@1"`) {
+		t.Errorf("expected @1: %s", got)
+	}
+	if !strings.Contains(got, "aabbccddeeff0011") {
+		t.Errorf("singleton ID should remain unchanged: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — opt-out
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_OptOut(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "1")
+	payload := `{"id":"repo::c84f9b9c0c3a7b18","callers":[{"id":"repo::c84f9b9c0c3a7b18"},{"id":"repo::c84f9b9c0c3a7b18"}]}`
+	res := makeTextResult(payload)
+	out := applyIDInterning(res)
+	got := resultText(out)
+	if strings.Contains(got, "@1") {
+		t.Errorf("interning should be skipped when MCP_NO_ID_INTERNING=1, got: %s", got)
+	}
+	if !strings.Contains(got, "c84f9b9c0c3a7b18") {
+		t.Errorf("original IDs should be preserved on opt-out: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — single-occurrence pass-through
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_SingleOccurrence_NoTable(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "")
+	// Each ID appears exactly once — no interning should happen.
+	payload := `{"a":"repo::c84f9b9c0c3a7b18","b":"repo::deadbeef01234567"}`
+	res := makeTextResult(payload)
+	out := applyIDInterning(res)
+	got := resultText(out)
+	if strings.Contains(got, "_id_table") {
+		t.Errorf("no _id_table expected when no ID repeats: %s", got)
+	}
+	if strings.Contains(got, "@1") {
+		t.Errorf("no handles expected when no ID repeats: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — core: intern + inject table + reversible
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_InternAndTableInjected(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "")
+	id1 := "upvate-core::c84f9b9c0c3a7b18"
+	id2 := "upvate-core::deadbeef01234567"
+	payload := map[string]any{
+		"root": id1,
+		"callers": []any{
+			map[string]any{"id": id1, "name": "funcA"},
+			map[string]any{"id": id2, "name": "funcB"},
+			map[string]any{"id": id1, "name": "funcC"},
+			map[string]any{"id": id2, "name": "funcD"},
+		},
+		"elapsed_ms": 12,
+	}
+	data, _ := json.Marshal(payload)
+	res := makeTextResult(string(data))
+	out := applyIDInterning(res)
+	got := resultText(out)
+
+	// _id_table must be present.
+	if !strings.Contains(got, "_id_table") {
+		t.Fatalf("_id_table missing from interned response: %s", got)
+	}
+
+	// Full IDs must only appear inside _id_table, not in the body fields.
+	// Parse the object and check that body fields use handles, not raw IDs.
+	var checkObj map[string]any
+	if err := json.Unmarshal([]byte(got), &checkObj); err != nil {
+		t.Fatalf("unmarshal for body-field check: %v", err)
+	}
+	// "root" field should be a handle, not the raw id.
+	if checkObj["root"] == id1 {
+		t.Errorf("root field should be a handle, not raw id1: %s", got)
+	}
+	// callers items should use handles.
+	if callers, ok := checkObj["callers"].([]any); ok {
+		for _, c := range callers {
+			if obj, ok := c.(map[string]any); ok {
+				if obj["id"] == id1 || obj["id"] == id2 {
+					t.Errorf("caller id field should be a handle, not raw id: %v", obj)
+				}
+			}
+		}
+	}
+
+	// Handles @1 and @2 must appear in the output.
+	if !strings.Contains(got, `"@1"`) && !strings.Contains(got, `@1`) {
+		t.Errorf("handle @1 missing: %s", got)
+	}
+	if !strings.Contains(got, `"@2"`) && !strings.Contains(got, `@2`) {
+		t.Errorf("handle @2 missing: %s", got)
+	}
+
+	// Reversibility: parse the _id_table and resolve both handles back to full IDs.
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(got), &obj); err != nil {
+		t.Fatalf("unmarshal interned response: %v", err)
+	}
+	rawTable, ok := obj["_id_table"]
+	if !ok {
+		t.Fatal("_id_table key absent in parsed object")
+	}
+	tableMap, ok := rawTable.(map[string]any)
+	if !ok {
+		t.Fatalf("_id_table is not a map: %T", rawTable)
+	}
+
+	// Find which handle maps to id1 and id2.
+	var h1, h2 string
+	for handle, full := range tableMap {
+		switch full {
+		case id1:
+			h1 = handle
+		case id2:
+			h2 = handle
+		}
+	}
+	if h1 == "" {
+		t.Errorf("id1 not found in _id_table: %v", tableMap)
+	}
+	if h2 == "" {
+		t.Errorf("id2 not found in _id_table: %v", tableMap)
+	}
+
+	// Both handles must be resolvable (reversibility assertion).
+	if tableMap[h1] != id1 {
+		t.Errorf("handle %s does not resolve to %s: got %v", h1, id1, tableMap[h1])
+	}
+	if tableMap[h2] != id2 {
+		t.Errorf("handle %s does not resolve to %s: got %v", h2, id2, tableMap[h2])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — handles are assigned in first-appearance order
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_FirstAppearanceOrder(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "")
+	// id1 appears first, id2 second.
+	id1 := "svc-a::aaaa1111bbbb2222"
+	id2 := "svc-b::cccc3333dddd4444"
+	payload := `{"first":"` + id1 + `","second":"` + id2 + `","repeat_first":"` + id1 + `","repeat_second":"` + id2 + `"}`
+	res := makeTextResult(payload)
+	out := applyIDInterning(res)
+	got := resultText(out)
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(got), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	table, _ := obj["_id_table"].(map[string]any)
+	if table == nil {
+		t.Fatal("_id_table missing")
+	}
+	// @1 must resolve to id1 (first appearance), @2 to id2.
+	if table["@1"] != id1 {
+		t.Errorf("@1 should be %s, got %v", id1, table["@1"])
+	}
+	if table["@2"] != id2 {
+		t.Errorf("@2 should be %s, got %v", id2, table["@2"])
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — elapsed_ms field is preserved after interning
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_ElapsedMSPreserved(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "")
+	id1 := "repo::ffeeddccbbaa9988"
+	payload := map[string]any{
+		"id":         id1,
+		"callers":    []any{map[string]any{"id": id1}},
+		"elapsed_ms": int64(42),
+	}
+	data, _ := json.Marshal(payload)
+	res := makeTextResult(string(data))
+	out := applyIDInterning(res)
+	got := resultText(out)
+
+	var obj map[string]any
+	if err := json.Unmarshal([]byte(got), &obj); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if obj["elapsed_ms"] == nil {
+		t.Errorf("elapsed_ms should be preserved after interning: %s", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — nil / empty result safety
+// ---------------------------------------------------------------------------
+
+func TestApplyIDInterning_NilResult(t *testing.T) {
+	if applyIDInterning(nil) != nil {
+		t.Error("nil in, nil out")
+	}
+}
+
+func TestApplyIDInterning_EmptyContent(t *testing.T) {
+	res := &mcpapi.CallToolResult{}
+	out := applyIDInterning(res)
+	if out != res {
+		t.Error("empty content: should return same pointer")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// applyIDInterning — wire-bytes reduction smoke test
+// ---------------------------------------------------------------------------
+
+// TestApplyIDInterning_ByteReduction verifies that for a graph-heavy expand
+// response (many repeated IDs) the interned output is meaningfully shorter
+// than the original.
+func TestApplyIDInterning_ByteReduction(t *testing.T) {
+	t.Setenv("MCP_NO_ID_INTERNING", "")
+	const baseID = "upvate-core::c84f9b9c0c3a7b18"
+	const callerID = "upvate-core::deadbeef01234567"
+	const calleeID = "upvate-core::aabbccdd11223344"
+
+	// Simulate an expand depth=2 response: root node appears everywhere.
+	nodes := make([]any, 50)
+	for i := range nodes {
+		var callee string
+		if i%2 == 0 {
+			callee = callerID
+		} else {
+			callee = calleeID
+		}
+		nodes[i] = map[string]any{
+			"id":     baseID,
+			"caller": callerID,
+			"callee": callee,
+			"name":   "SomeFunction",
+		}
+	}
+	payload := map[string]any{
+		"root":       baseID,
+		"nodes":      nodes,
+		"elapsed_ms": 33,
+	}
+	data, _ := json.Marshal(payload)
+	before := len(data)
+
+	res := makeTextResult(string(data))
+	out := applyIDInterning(res)
+	after := len(resultText(out))
+
+	savingPct := float64(before-after) / float64(before) * 100
+	t.Logf("ID interning: before=%d bytes, after=%d bytes, saving=%.1f%%", before, after, savingPct)
+
+	if after >= before {
+		t.Errorf("expected interned response to be smaller: before=%d after=%d", before, after)
+	}
+	// For this graph-heavy fixture we expect ≥15% savings.
+	if savingPct < 15 {
+		t.Errorf("expected ≥15%% savings, got %.1f%%", savingPct)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// idPattern — regex correctness checks
+// ---------------------------------------------------------------------------
+
+func TestIDPattern_MatchesPrefixedForm(t *testing.T) {
+	cases := []struct {
+		input string
+		want  bool
+	}{
+		{`"upvate-core::c84f9b9c0c3a7b18"`, true},
+		{`"svc.name::aabbccddeeff0011"`, true},
+		{`"my-repo_v2::1234567890abcdef"`, true},
+		{`"notanid::ZZZZZZZZZZZZZZZZ"`, false}, // uppercase hex is not matched
+		{`"short::abc"`, false},                // too short
+	}
+	for _, c := range cases {
+		m := idPattern.FindString(c.input)
+		got := m != ""
+		if got != c.want {
+			t.Errorf("idPattern.Match(%q) = %v, want %v (matched: %q)", c.input, got, c.want, m)
+		}
+	}
+}
+
+// TestIDPattern_BareHexNotMatched verifies that bare 16-hex strings (without
+// the <repo>:: prefix) are NOT matched by idPattern. This is intentional:
+// bare hex IDs are local entity IDs used as primary keys in responses (e.g.
+// pattern IDs, edge IDs) and must not be substituted to preserve round-trips.
+func TestIDPattern_BareHexNotMatched(t *testing.T) {
+	cases := []string{
+		`"c84f9b9c0c3a7b18"`,
+		`"1234567890abcdef"`,
+		`"c84f9b9c0c3a7b1"`,
+		`"c84f9b9c0c3a7b189"`,
+	}
+	for _, input := range cases {
+		matches := idPattern.FindAllString(input, -1)
+		// None of the bare-hex strings should be matched.
+		for _, m := range matches {
+			if !strings.Contains(m, "::") {
+				t.Errorf("bare hex should NOT be matched: input=%q matched=%q", input, m)
+			}
+		}
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -476,6 +476,11 @@ func (s *Server) wrap(name string, fn func(ctx context.Context, req mcpapi.CallT
 		elapsed := time.Since(start).Milliseconds()
 		if res != nil {
 			res = injectElapsedMS(res, elapsed)
+			// #1740: intern repeated entity IDs to short handles (@1, @2, …).
+			// Runs after elapsed-ms injection so the _id_table lands in the
+			// same top-level JSON object that carries elapsed_ms.
+			// Opt-out: MCP_NO_ID_INTERNING=1.
+			res = applyIDInterning(res)
 		}
 		s.emitActivity(ctx, name, req, res, collector)
 		return res, err


### PR DESCRIPTION
## What

At the final render stage in `internal/mcp/server.go` (`wrap()`), after `injectElapsedMS`, scan every MCP tool response for repeated entity IDs and intern them to short handles (`@1`, `@2`, …), emitting a `_id_table` field for reversibility.

## Why

Entity IDs in the ADR-0009 canonical form (`<repo-slug>::<16-hex>`) are 25–40 chars. On graph-heavy responses (`archigraph_expand depth=2`, `archigraph_find_callers depth=2`, `archigraph_traces action=follow`) the same ID can appear 10+ times. Interning saves 15–54% on response wire bytes (54% measured on the expand-depth-2 fixture with 3 distinct IDs × 50 nodes).

## Changes

**`internal/mcp/id_interning.go`** (new)
- `idPattern`: regex matching only the prefixed form `[A-Za-z0-9][A-Za-z0-9\-_.]*::[0-9a-f]{16}`. Bare 16-hex local IDs (pattern IDs, edge IDs) are intentionally excluded — interning them breaks callers that parse an ID out of a response and pass it back as a tool argument immediately.
- `internIDsEnabled()`: opt-out check for `MCP_NO_ID_INTERNING=1`.
- `countIDOccurrences(text)`: single regex pass, returns frequency map.
- `substituteIDs(text, table)`: single regex pass replacement.
- `applyIDInterning(res)`: orchestrates the full pipeline — collect counts, assign handles in first-appearance order, substitute, inject `_id_table` into the first JSON object content item.

**`internal/mcp/server.go`**
- `wrap()`: calls `applyIDInterning(res)` immediately after `injectElapsedMS(res, elapsed)`.

**`internal/mcp/id_interning_test.go`** (new, 14 tests)
- Opt-out via `MCP_NO_ID_INTERNING=1`
- Single-occurrence IDs pass through without a table
- Core: intern + inject `_id_table` + reversibility (resolve `@N` → full ID)
- First-appearance handle ordering
- `elapsed_ms` field preserved after interning
- Nil / empty result safety
- Byte-reduction smoke test: ≥15% savings required, 54% measured
- `idPattern` regex correctness (prefixed form matched, bare hex not matched)

## Wire contract

```json
{
  "_id_table": { "@1": "upvate-core::c84f9b9c0c3a7b18", "@2": "upvate-core::deadbeef01234567" },
  "root": "@1",
  "callers": [{"id": "@1", "name": "funcA"}, {"id": "@2", "name": "funcB"}],
  "elapsed_ms": 33
}
```

## Test plan

- [x] `go build ./internal/mcp/...` — clean
- [x] `go vet ./internal/mcp/...` — clean
- [x] `go test ./internal/mcp/...` — all 14 new tests pass, full suite green
- [x] `go test ./...` — only pre-existing `TestModuleCoverage_AllEntitiesTagged` failure (present on `main` before this PR)
- [x] Bench result: 54.8% byte reduction on 50-node expand fixture (3 distinct prefixed IDs)
- [x] Confirmed interning skips single-occurrence IDs (no table overhead)
- [x] Confirmed opt-out `MCP_NO_ID_INTERNING=1` fully suppresses interning

Fixes #1740

🤖 Generated with [Claude Code](https://claude.com/claude-code)