### PR TITLE
[#1746] Infer MCP group from cwd — os.Getwd fallback + targeted ambiguous error

### DIFF
--- a/internal/mcp/routing.go
+++ b/internal/mcp/routing.go
@@ -9,14 +9,22 @@ import (
 	"strings"
 )
 
-// resolveGroup implements the ADR-0008 cascade:
+// resolveGroup implements the ADR-0008 cascade (#1746):
 //
 //  1. explicit `group` argument
-//  2. CWD inference (walk up looking for .archigraph/group.json)
-//  3. singleton-group fallback
+//  2. CWD inference via .archigraph/group.json marker (walk upward)
+//  3. Registry-based CWD inference: match cwd against registered repo paths
+//  4. Singleton-group fallback (only one group registered)
 //
-// Returns the chosen group name, the source ("explicit"/"cwd"/"singleton"),
-// or an error listing the registered groups when ambiguous.
+// Returns the chosen group name, the source ("explicit"/"cwd"/"cwd_registry"/
+// "singleton"), or an error when the group cannot be determined.
+//
+// Error cases:
+//   - cwd is inside repos registered to multiple groups → "ambiguous group"
+//     error listing only the matching candidate groups.
+//   - cwd is not inside any registered repo AND multiple groups exist →
+//     "ambiguous group" error listing all registered groups.
+//   - registry is empty → distinct error.
 func resolveGroup(s *State, explicit, cwd string) (string, string, error) {
 	if explicit != "" {
 		return explicit, "explicit", nil
@@ -27,12 +35,18 @@ func resolveGroup(s *State, explicit, cwd string) (string, string, error) {
 			return g, "cwd", nil
 		}
 	}
-	// Registry-based cwd inference (#1650): when no group.json marker is found,
-	// walk the registry and pick the group whose repo path is a prefix of cwd.
-	// If exactly one group matches we honor it as "cwd_registry"; multiple
-	// matches fall through to the ambiguous-group error.
-	if g := groupFromRegistry(s, cwd); g != "" {
+	// Registry-based cwd inference (#1650 / #1746): walk the registry and pick
+	// the group whose repo path is a prefix of cwd. groupFromRegistryWithCandidates
+	// returns the single matched group or "" + the distinct matching groups for the
+	// error message when multiple groups cover the cwd.
+	g, candidates := groupFromRegistryWithCandidates(s, cwd)
+	if g != "" {
 		return g, "cwd_registry", nil
+	}
+	if len(candidates) > 1 {
+		// cwd is under repos in multiple groups — genuinely ambiguous.
+		sort.Strings(candidates)
+		return "", "", errors.New("ambiguous group; pass `group=<name>`. candidate groups for your cwd: " + strings.Join(candidates, ", "))
 	}
 	if len(s.registry.Groups) == 1 {
 		for g := range s.registry.Groups {
@@ -52,13 +66,28 @@ func resolveGroup(s *State, explicit, cwd string) (string, string, error) {
 
 // groupFromRegistry returns the registered group whose repo path is an
 // ancestor of cwd. Returns "" when cwd is empty, no registered repo path
-// covers cwd, or multiple groups cover it (ambiguous). The match prefers the
-// longest path (most specific repo) when several repos under the SAME group
-// could cover cwd; when different groups each cover cwd, "" is returned and
-// the caller surfaces the standard ambiguous-group error.
+// covers cwd, or multiple groups cover it (ambiguous). See
+// groupFromRegistryWithCandidates for the richer variant that also returns
+// the matching candidate group names.
 func groupFromRegistry(s *State, cwd string) string {
+	g, _ := groupFromRegistryWithCandidates(s, cwd)
+	return g
+}
+
+// groupFromRegistryWithCandidates is the core registry-cwd matcher (#1746).
+// It walks the registry and collects all groups whose repo path is an ancestor
+// of cwd. Returns:
+//   - (group, nil) when exactly one group's repos cover cwd (unambiguous).
+//   - ("", candidates) when multiple distinct groups cover cwd; candidates
+//     lists those group names so the caller can surface a targeted error.
+//   - ("", nil) when cwd is empty, the registry is empty/nil, or no repo
+//     covers cwd.
+//
+// When multiple repos from the SAME group cover cwd, the longest (most
+// specific) repo path is preferred — that is unambiguous.
+func groupFromRegistryWithCandidates(s *State, cwd string) (string, []string) {
 	if cwd == "" || s == nil || s.registry == nil {
-		return ""
+		return "", nil
 	}
 	abs, err := filepath.Abs(cwd)
 	if err != nil {
@@ -82,16 +111,27 @@ func groupFromRegistry(s *State, cwd string) string {
 		}
 	}
 	if len(hits) == 0 {
-		return ""
+		return "", nil
 	}
-	// All hits same group → unambiguous; pick longest path (most specific).
-	first := hits[0].group
-	for _, h := range hits[1:] {
-		if h.group != first {
-			return "" // ambiguous across groups
+	// Collect distinct matched groups.
+	groupSet := make(map[string]string) // group → longest matching path
+	for _, h := range hits {
+		if prev, ok := groupSet[h.group]; !ok || len(h.path) > len(prev) {
+			groupSet[h.group] = h.path
 		}
 	}
-	return first
+	if len(groupSet) == 1 {
+		// Unambiguous: all hits belong to the same group.
+		for g := range groupSet {
+			return g, nil
+		}
+	}
+	// Multiple distinct groups cover cwd — return candidates for error reporting.
+	candidates := make([]string, 0, len(groupSet))
+	for g := range groupSet {
+		candidates = append(candidates, g)
+	}
+	return "", candidates
 }
 
 // pathContains reports whether ancestor is an ancestor (or equal to) child.

--- a/internal/mcp/routing_test.go
+++ b/internal/mcp/routing_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -53,6 +54,174 @@ func TestResolveGroup_CWDFromRegistry(t *testing.T) {
 	_, _, err = resolveGroup(st, "", filepath.Join(tmp, "nowhere"))
 	if err == nil {
 		t.Errorf("expected ambiguous-group error for cwd outside any repo")
+	}
+}
+
+// TestResolveGroup_InferFromCWD is the table-driven suite for #1746 CWD group
+// inference. It covers all four key cases described in the issue:
+//
+//  1. explicit group= is set → returns that group, no cwd lookup.
+//  2. cwd inside exactly one registered repo's group → inferred unambiguously.
+//  3. cwd inside repos registered to two different groups → error listing
+//     the candidate groups.
+//  4. cwd is under no registered repo (and multiple groups exist) → ambiguous
+//     error listing all registered groups.
+func TestResolveGroup_InferFromCWD(t *testing.T) {
+	tmp := t.TempDir()
+
+	repoA := filepath.Join(tmp, "repo_a") // group alpha
+	repoB := filepath.Join(tmp, "repo_b") // group beta
+	repoC := filepath.Join(tmp, "repo_c") // ALSO group beta (multi-repo group)
+	// shared sits inside both repoA AND repoB trees by having both as ancestors
+	// — achieved by making repoShared a subdir of repoA AND registering repoA
+	// under a second group (gamma) to force cross-group ambiguity.
+	repoAGamma := repoA // same physical path, second group (gamma)
+
+	for _, p := range []string{repoA, repoB, repoC} {
+		if err := mkdirp(p); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"alpha": {
+				Repos: map[string]RegistryRepo{
+					"repo-a": {Path: repoA},
+				},
+			},
+			"beta": {
+				Repos: map[string]RegistryRepo{
+					"repo-b": {Path: repoB},
+					"repo-c": {Path: repoC},
+				},
+			},
+			"gamma": {
+				// gamma also registers repoA → cwd inside repoA is ambiguous
+				// between alpha and gamma.
+				Repos: map[string]RegistryRepo{
+					"repo-a-mirror": {Path: repoAGamma},
+				},
+			},
+		},
+	}
+	st := NewState(reg)
+
+	subdirA := filepath.Join(repoA, "pkg", "handler")
+	subdirB := filepath.Join(repoB, "src")
+	nowhere := filepath.Join(tmp, "totally-unrelated")
+	for _, p := range []string{subdirA, subdirB} {
+		if err := mkdirp(p); err != nil {
+			t.Fatalf("mkdir %s: %v", p, err)
+		}
+	}
+
+	cases := []struct {
+		name         string
+		explicit     string
+		cwd          string
+		wantGroup    string
+		wantSource   string
+		wantErrFrag  string // non-empty → expect error containing this substring
+	}{
+		{
+			name:       "explicit group overrides cwd",
+			explicit:   "beta",
+			cwd:        subdirA, // would resolve alpha/gamma if not for explicit
+			wantGroup:  "beta",
+			wantSource: "explicit",
+		},
+		{
+			name:       "cwd inside single-group repo resolves unambiguously",
+			explicit:   "",
+			cwd:        subdirB,
+			wantGroup:  "beta",
+			wantSource: "cwd_registry",
+		},
+		{
+			name:        "cwd inside repo registered to two groups errors with candidates",
+			explicit:    "",
+			cwd:         subdirA,
+			wantErrFrag: "ambiguous group",
+		},
+		{
+			name:        "cwd under no registered repo errors with all groups",
+			explicit:    "",
+			cwd:         nowhere,
+			wantErrFrag: "ambiguous group",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			g, src, err := resolveGroup(st, tc.explicit, tc.cwd)
+			if tc.wantErrFrag != "" {
+				if err == nil {
+					t.Fatalf("want error containing %q, got nil (group=%q)", tc.wantErrFrag, g)
+				}
+				if !strings.Contains(err.Error(), tc.wantErrFrag) {
+					t.Fatalf("error %q does not contain %q", err.Error(), tc.wantErrFrag)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if g != tc.wantGroup {
+				t.Errorf("group: want %q, got %q", tc.wantGroup, g)
+			}
+			if src != tc.wantSource {
+				t.Errorf("source: want %q, got %q", tc.wantSource, src)
+			}
+		})
+	}
+}
+
+// TestResolveGroup_AmbiguousCWDIncludesCandidates verifies that when cwd is
+// inside repos registered to multiple groups, the error message names those
+// specific candidate groups (not all registered groups) (#1746).
+func TestResolveGroup_AmbiguousCWDIncludesCandidates(t *testing.T) {
+	tmp := t.TempDir()
+	sharedRepo := filepath.Join(tmp, "shared")
+	if err := mkdirp(sharedRepo); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	reg := &Registry{
+		Groups: map[string]RegistryGroup{
+			"groupA": {
+				Repos: map[string]RegistryRepo{"r": {Path: sharedRepo}},
+			},
+			"groupB": {
+				Repos: map[string]RegistryRepo{"r": {Path: sharedRepo}},
+			},
+			"unrelated": {
+				Repos: map[string]RegistryRepo{"other": {Path: filepath.Join(tmp, "other")}},
+			},
+		},
+	}
+	st := NewState(reg)
+
+	cwd := filepath.Join(sharedRepo, "sub")
+	if err := mkdirp(cwd); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	_, _, err := resolveGroup(st, "", cwd)
+	if err == nil {
+		t.Fatal("expected ambiguous-group error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "groupA") {
+		t.Errorf("error %q missing groupA", msg)
+	}
+	if !strings.Contains(msg, "groupB") {
+		t.Errorf("error %q missing groupB", msg)
+	}
+	// "unrelated" is NOT a candidate (its repo path doesn't cover cwd) — it
+	// must NOT appear in the targeted error message.
+	if strings.Contains(msg, "unrelated") {
+		t.Errorf("error %q unexpectedly lists unrelated group", msg)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -90,8 +90,13 @@ func (s *Server) reloadBeforeCall() {
 	s.Tel.MarkReload(n)
 }
 
-// inferCWD returns the caller-provided cwd from the request arguments if any,
-// falling back to the configured CWD on the server.
+// inferCWD returns the best available working-directory hint for a tool call.
+// Resolution order (ADR-0008 / #1746):
+//  1. "cwd" argument in the request (set by the bridge from _meta.cwd or bridge startup dir).
+//  2. CWD configured on the server at construction time (set by callers that
+//     know the cwd at build time, e.g. bench-mcp or tests).
+//  3. os.Getwd() of the daemon/server process — covers the stdio transport
+//     ("archigraph mcp serve" launched directly from the user's project dir).
 func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 	args := req.GetArguments()
 	if v, ok := args["cwd"]; ok {
@@ -99,7 +104,16 @@ func (s *Server) inferCWD(req mcpapi.CallToolRequest) string {
 			return str
 		}
 	}
-	return s.cfg.CWD
+	if s.cfg.CWD != "" {
+		return s.cfg.CWD
+	}
+	// Last resort: use the process working directory. On the stdio transport
+	// the daemon/server process inherits the cwd of the spawning CLI, so this
+	// is the user's project directory when they run `archigraph mcp serve`.
+	if wd, err := os.Getwd(); err == nil {
+		return wd
+	}
+	return ""
 }
 
 // registerTools registers every tool handler on the MCP server.


### PR DESCRIPTION
## What

Fixes the field-reported friction where `archigraph_whoami` and `archigraph_stats` both errored with `ambiguous group; pass group=<name>` on first call — even when the MCP session's cwd was inside a registered repo (`upvate_core` / group `upvate`).

## Root cause

`inferCWD` had two fallbacks for the working directory (request `cwd=` arg, then `cfg.CWD`), but **no final fallback to `os.Getwd()`**. On the **stdio transport** (`archigraph mcp serve` launched directly from a project directory), `cfg.CWD` is always empty (`mcp.Config{}`), so `resolveGroup` received an empty string, `groupFromRegistry` short-circuited, and the ambiguous-group error fired regardless of where the user launched from.

## Changes

### `internal/mcp/server.go` — `inferCWD`
Added `os.Getwd()` as a third fallback, covering the stdio transport case where the daemon/server process inherits the user's project directory as its working directory:

```
1. request args["cwd"]
2. s.cfg.CWD (set at construction time by callers that know cwd)
3. os.Getwd() — covers stdio transport (archigraph mcp serve)
```

### `internal/mcp/routing.go` — `groupFromRegistryWithCandidates`
Refactored `groupFromRegistry` into a richer variant that also returns the set of matching candidate groups when ambiguous. The ambiguous-group error message now names **only the groups whose repo paths actually cover the cwd** rather than all registered groups, making it immediately actionable:

- Before: `ambiguous group; pass group=<name>. registered groups: alpha, beta, gamma, unrelated`
- After: `ambiguous group; pass group=<name>. candidate groups for your cwd: alpha, gamma`

`groupFromRegistry` is retained as a thin shim (calls `groupFromRegistryWithCandidates`) so callers outside `resolveGroup` are unaffected.

### `internal/mcp/routing_test.go`
Three new tests:
- **`TestResolveGroup_InferFromCWD`** — table-driven, covers all four key cases: (1) explicit overrides cwd, (2) cwd inside single-group repo → unambiguous, (3) cwd inside multi-group repo → error with candidates, (4) cwd outside all repos → error with all groups.
- **`TestResolveGroup_AmbiguousCWDIncludesCandidates`** — asserts that the targeted error names only the matching groups (groupA, groupB) and NOT an unrelated group whose repo is elsewhere.

## Constraints honored
- **Zero behavior change** when `group=` is explicitly passed — `resolveGroup` returns `explicit` immediately.
- Ambiguous-cwd case still errors; error message is now more targeted.
- No conflict with #1738/#1739/#1740 — only touches `inferCWD` entry point and routing internals, not per-tool handler bodies or render envelope.

## Test results
```
--- PASS: TestResolveGroup_CWDFromRegistry (0.00s)
--- PASS: TestResolveGroup_InferFromCWD (0.01s)
    --- PASS: .../explicit_group_overrides_cwd
    --- PASS: .../cwd_inside_single-group_repo_resolves_unambiguously
    --- PASS: .../cwd_inside_repo_registered_to_two_groups_errors_with_candidates
    --- PASS: .../cwd_under_no_registered_repo_errors_with_all_groups
--- PASS: TestResolveGroup_AmbiguousCWDIncludesCandidates (0.00s)
ok  github.com/cajasmota/archigraph/internal/mcp  0.777s
```

Full `go test ./...` green except `TestModuleCoverage_AllEntitiesTagged` which is pre-existing on `main` (verified).

Fixes #1746

🤖 Generated with [Claude Code](https://claude.com/claude-code)