### PR TITLE
[#1748] Hide non-addressable local const bindings from archigraph_find

### DIFF
--- a/internal/extractors/javascript/extractor.go
+++ b/internal/extractors/javascript/extractor.go
@@ -270,6 +270,12 @@ type extractor struct {
 	entities      []types.EntityRecord
 	relationships []types.RelationshipRecord
 
+	// funcDepth tracks how many function/method bodies deep the current
+	// walk is. Zero means module scope. Incremented before recursing into
+	// a function body, decremented on exit. Used by handleVariableDeclarator
+	// to suppress non-addressable local destructure bindings (#1748).
+	funcDepth int
+
 	// module — Issue #1616. The dotted module path derived from filePath
 	// (e.g. "src/stores/authReducer.js" → "src.stores.authReducer"). Set
 	// once in Extract before walk() runs. Used to populate every emitted
@@ -429,6 +435,21 @@ func (x *extractor) emitWithRels(name, kind string, n *sitter.Node, subtype stri
 	x.entities = append(x.entities, e)
 }
 
+// tagLocalScope stamps Properties["local_scope"]="true" on every entity
+// appended to x.entities at index >= from. Called after emitting entities that
+// were discovered inside a function/method body (funcDepth > 0) to mark them
+// as non-addressable locals. The serving layer (denoise.go) uses this flag to
+// hide these entities from archigraph_find results while still allowing the
+// resolver to use them for REFERENCES/CALLS binding (#1748).
+func (x *extractor) tagLocalScope(from int) {
+	for i := from; i < len(x.entities); i++ {
+		if x.entities[i].Properties == nil {
+			x.entities[i].Properties = map[string]string{}
+		}
+		x.entities[i].Properties["local_scope"] = "true"
+	}
+}
+
 // emitWithProps appends an entity to the extraction results using a caller-supplied
 // Properties map rather than the default {"kind": ..., "subtype": ...} map.
 // Used by handlers that need to store structured metadata (fields, generics, etc.).
@@ -552,8 +573,12 @@ func (x *extractor) handleFunctionDeclaration(n *sitter.Node, parentClass string
 	x.emitWithRels(name, "SCOPE.Operation", n, subtype, sig, rels)
 
 	// Recurse into the body for nested declarations.
+	// Increment funcDepth so handleVariableDeclarator suppresses non-addressable
+	// local destructure bindings discovered inside this body (#1748).
 	if body != nil {
+		x.funcDepth++
 		x.walkChildren(body, parentClass, cb)
+		x.funcDepth--
 	}
 }
 
@@ -713,8 +738,12 @@ func (x *extractor) handlePublicFieldDefinition(n *sitter.Node, parentClass stri
 	x.emitWithRels(name, "SCOPE.Operation", valueNode, "method", sig, rels)
 
 	// Recurse into the body for nested declarations.
+	// Increment funcDepth so nested const declarations inside this arrow
+	// class-field method are not emitted as addressable entities (#1748).
 	if body != nil {
+		x.funcDepth++
 		x.walkChildren(body, parentClass, cb)
+		x.funcDepth--
 	}
 }
 
@@ -1000,7 +1029,16 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		// "state_setter" so the resolver binds setX() calls to a real
 		// entity instead of landing in bug-extractor.
 		stateHook := nameNode.Type() == "array_pattern" && isStateHookCall(x, valueNode)
+		// Issue #1748 — inside a function body (funcDepth > 0) and not a
+		// hook-result binding, tag newly emitted entities as local_scope=true
+		// so the serving layer can filter them from archigraph_find results.
+		// We still emit the entities so the resolver can bind same-file
+		// REFERENCES/CALLS edges.
+		before := len(x.entities)
 		x.emitDestructuredEntities(nameNode, valueNode, opLift, stateHook, parentClass, cb)
+		if x.funcDepth > 0 && !opLift && !stateHook {
+			x.tagLocalScope(before)
+		}
 		if valueNode != nil {
 			x.walkChildren(valueNode, parentClass, cb)
 		}
@@ -1030,7 +1068,11 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = (...) =>", name), rels)
 		if body != nil {
+			// Increment funcDepth so nested const declarations inside this
+			// arrow body are not emitted as addressable entities (#1748).
+			x.funcDepth++
 			x.walkChildren(body, parentClass, cb)
+			x.funcDepth--
 		}
 
 	case "function", "function_expression":
@@ -1046,7 +1088,11 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 		rels = append(rels, x.extractJSXRendersRelationships(body, name)...)
 		x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = function", name), rels)
 		if body != nil {
+			// Increment funcDepth so nested const declarations inside this
+			// function-expression body are not emitted as addressable entities (#1748).
+			x.funcDepth++
 			x.walkChildren(body, parentClass, cb)
+			x.funcDepth--
 		}
 
 	default:
@@ -1084,7 +1130,13 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 			// properties), NOT a callable function. Emit as SCOPE.Component with
 			// subtype="context" so Provider/Consumer relationships can attach and
 			// the entity is not confused with a regular callable.
+			before := len(x.entities)
 			x.emit(name, "SCOPE.Component", valueNode, "context", fmt.Sprintf("const %s = createContext()", name))
+			// Issue #1748 — context factories inside function bodies are
+			// unusual/non-addressable; tag as local_scope so find hides them.
+			if x.funcDepth > 0 {
+				x.tagLocalScope(before)
+			}
 		} else if x.isFunctionWrapperCall(valueNode) {
 			subtype := "function"
 			if parentClass != "" {
@@ -1098,15 +1150,27 @@ func (x *extractor) handleVariableDeclarator(n *sitter.Node, parentClass string,
 			frame := x.functionParamFrame(nil, cb)
 			rels := x.extractCallRelationships(valueNode, name, frame)
 			_ = inner
+			before := len(x.entities)
 			x.emitWithRels(name, "SCOPE.Operation", valueNode, subtype, fmt.Sprintf("const %s = <wrapper>", name), rels)
+			// Issue #1748 — wrapper calls (forwardRef, memo, etc.) inside a
+			// function body are non-addressable; tag as local_scope.
+			if x.funcDepth > 0 {
+				x.tagLocalScope(before)
+			}
 		} else {
 			// Issue #709 — TS `const x: MyType = ...` has a type annotation.
 			// We need to emit it as an entity so type-position REFERENCES edges
 			// can be attributed to it. This applies only when there's an explicit
 			// type annotation on the declarator.
 			if n.ChildByFieldName("type") != nil {
+				before := len(x.entities)
 				// Has a type annotation; emit as SCOPE.Component
 				x.emit(name, "SCOPE.Component", valueNode, "const", fmt.Sprintf("const %s: Type", name))
+				// Issue #1748 — type-annotated locals inside function bodies are
+				// non-addressable; tag as local_scope.
+				if x.funcDepth > 0 {
+					x.tagLocalScope(before)
+				}
 			}
 		}
 		// Recurse so nested function/class declarations inside the value

--- a/internal/extractors/javascript/issue1748_hide_locals_test.go
+++ b/internal/extractors/javascript/issue1748_hide_locals_test.go
@@ -1,0 +1,190 @@
+// Package javascript — unit tests for issue #1748: non-addressable local
+// const bindings inside function/component bodies are tagged with
+// Properties["local_scope"]="true" so the serving layer (denoise.go) can
+// hide them from archigraph_find results while keeping them emitted for
+// resolver use (REFERENCES/CALLS binding still works).
+package javascript_test
+
+import (
+	"testing"
+)
+
+// --------------------------------------------------------------------------
+// Tests — local_scope tagging
+// --------------------------------------------------------------------------
+
+// TestLocalScope_PlainDestructureInFunction — `const { counts } = someData`
+// inside a component body must be tagged local_scope=true.
+func TestLocalScope_PlainDestructureInFunction(t *testing.T) {
+	src := []byte(`
+function ContractProposals() {
+  const { counts } = someData;
+  return counts;
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	// counts IS emitted (resolver may need it) but flagged as local_scope.
+	e := findByName(entities, "counts")
+	if e == nil {
+		t.Fatalf("counts entity not found; names: %v", entityNames(entities))
+	}
+	if e.Properties["local_scope"] != "true" {
+		t.Errorf("counts should have local_scope=true; got Properties=%v", e.Properties)
+	}
+
+	// The enclosing component must NOT be local_scope.
+	comp := findByName(entities, "ContractProposals")
+	if comp != nil && comp.Properties["local_scope"] == "true" {
+		t.Errorf("ContractProposals should NOT have local_scope=true")
+	}
+}
+
+// TestLocalScope_ArrayDestructureNonHook — `const [a, b] = arr` inside a
+// function (non-hook RHS) must be tagged local_scope=true.
+func TestLocalScope_ArrayDestructureNonHook(t *testing.T) {
+	src := []byte(`
+function Cmp() {
+  const [a, b] = arr;
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	for _, name := range []string{"a", "b"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("entity %q not found; names: %v", name, entityNames(entities))
+			continue
+		}
+		if e.Properties["local_scope"] != "true" {
+			t.Errorf("%q: want local_scope=true; got Properties=%v", name, e.Properties)
+		}
+	}
+}
+
+// TestLocalScope_HookDestructureKept — hook-result destructures (mutation
+// hooks, state hooks) inside a function body must NOT be tagged local_scope.
+// The resolver depends on these entities for CALLS binding.
+func TestLocalScope_HookDestructureKept(t *testing.T) {
+	src := []byte(`
+function Cmp() {
+  const [isOpen, setIsOpen] = useState(false);
+  const { mutate: createItem } = useCreateItem();
+  const { data, isLoading } = useQuery({ queryKey: ["x"] });
+}
+`)
+	tree := parseTS(t, src)
+	entities := extract(t, src, "typescript", tree)
+
+	// State hook results — kept without local_scope.
+	for _, name := range []string{"isOpen", "setIsOpen"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("hook entity %q not found", name)
+			continue
+		}
+		if e.Properties["local_scope"] == "true" {
+			t.Errorf("%q (state hook result): should NOT have local_scope=true", name)
+		}
+	}
+
+	// Mutation hook — kept.
+	e := findByName(entities, "createItem")
+	if e == nil {
+		t.Errorf("createItem (mutation hook) not found")
+	} else if e.Properties["local_scope"] == "true" {
+		t.Errorf("createItem (mutation hook): should NOT have local_scope=true")
+	}
+
+	// useQuery is in the mutation-style list — kept.
+	for _, name := range []string{"data", "isLoading"} {
+		e := findByName(entities, name)
+		if e == nil {
+			t.Errorf("query hook entity %q not found", name)
+			continue
+		}
+		if e.Properties["local_scope"] == "true" {
+			t.Errorf("%q (query hook): should NOT have local_scope=true", name)
+		}
+	}
+}
+
+// TestLocalScope_ModuleScopeNotTagged — destructures at module scope
+// (top-level) must NOT be tagged local_scope, regardless of whether the RHS
+// is a hook call.
+func TestLocalScope_ModuleScopeNotTagged(t *testing.T) {
+	src := []byte(`
+const { foo, bar } = somethingArbitrary();
+const [x, y] = arr;
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	for _, name := range []string{"foo", "bar", "x", "y"} {
+		e := findByName(entities, name)
+		if e == nil {
+			// Not emitted at all — fine (may be filtered by existing logic).
+			continue
+		}
+		if e.Properties["local_scope"] == "true" {
+			t.Errorf("%q at module scope: should NOT have local_scope=true", name)
+		}
+	}
+}
+
+// TestLocalScope_NestedArrowNotTagged — a nested arrow const inside a
+// component body (`const handleClick = () => {...}`) is a real callable
+// entity and must NOT be tagged local_scope.
+func TestLocalScope_NestedArrowNotTagged(t *testing.T) {
+	src := []byte(`
+function ContractProposals() {
+  const handleClick = () => {
+    doSomething();
+  };
+  return handleClick;
+}
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	e := findByName(entities, "handleClick")
+	if e == nil {
+		t.Fatalf("handleClick not found; names: %v", entityNames(entities))
+	}
+	if e.Properties["local_scope"] == "true" {
+		t.Errorf("handleClick (nested arrow const): should NOT have local_scope=true (it IS callable)")
+	}
+}
+
+// TestLocalScope_ArrowComponentTopLevel — a top-level arrow component must
+// NOT be tagged local_scope; but non-hook destructures inside its body must be.
+func TestLocalScope_ArrowComponentTopLevel(t *testing.T) {
+	src := []byte(`
+const MyComponent = () => {
+  const { counts } = someData;
+  return counts;
+};
+`)
+	tree := parseJS(t, src)
+	entities := extract(t, src, "javascript", tree)
+
+	// Top-level component — not local.
+	comp := findByName(entities, "MyComponent")
+	if comp == nil {
+		t.Fatalf("MyComponent not found; names: %v", entityNames(entities))
+	}
+	if comp.Properties["local_scope"] == "true" {
+		t.Errorf("MyComponent top-level arrow: should NOT have local_scope=true")
+	}
+
+	// counts INSIDE the arrow body — must be tagged.
+	e := findByName(entities, "counts")
+	if e == nil {
+		t.Fatalf("counts not found inside arrow body; names: %v", entityNames(entities))
+	}
+	if e.Properties["local_scope"] != "true" {
+		t.Errorf("counts inside arrow body: want local_scope=true; got Properties=%v", e.Properties)
+	}
+}

--- a/internal/mcp/denoise.go
+++ b/internal/mcp/denoise.go
@@ -21,6 +21,7 @@
 //	noiseProcess (6)    — array/string built-in Process node
 //	noiseSchemaField (7) — SCOPE.Schema subtype=field member (#1715)
 //	noisePattern (8)    — SCOPE.Pattern structural node (#1733)
+//	noiseLocalScope (9) — non-addressable function-body local binding (#1748)
 package mcp
 
 import (
@@ -60,6 +61,15 @@ const (
 	// serializer. Suppressed by default (#1712); the parent class surfaces
 	// normally. Reachable via include_noise:true.
 	noiseSchemaField
+	// noiseLocalScope: a non-addressable local binding emitted inside a
+	// function/method body (#1748). Examples: `const { counts } = someData`
+	// or `const [a, b] = arr` inside a React component. These are kept in
+	// the graph so the resolver can bind REFERENCES/CALLS edges, but they
+	// are never independently inspectable via archigraph_inspect (the name
+	// is not addressable as "Component.counts") so surfacing them in
+	// archigraph_find wastes tokens and violates "everything you see is
+	// queryable". Identified by Properties["local_scope"]=="true".
+	noiseLocalScope
 )
 
 // arrayBuiltins is the set of array/string built-in method names whose Process
@@ -131,6 +141,13 @@ func classifyNoise(e *graph.Entity) noiseKind {
 	// entity (same Kind, no "field" Subtype) surfaces normally.
 	if bareKind == "schema" && e.Subtype == "field" {
 		return noiseSchemaField
+	}
+
+	// Non-addressable function-body locals (#1748): emitted at extraction
+	// time for resolver use but not independently inspectable. The extractor
+	// stamps Properties["local_scope"]="true" on these entities.
+	if e.Properties["local_scope"] == "true" {
+		return noiseLocalScope
 	}
 
 	return noiseNone

--- a/internal/mcp/denoise_test.go
+++ b/internal/mcp/denoise_test.go
@@ -113,6 +113,43 @@ func TestClassifyNoise(t *testing.T) {
 			},
 			want: noiseNone,
 		},
+		// #1748: non-addressable function-body locals are noise.
+		{
+			name: "local_scope plain destructure binding",
+			e: graph.Entity{
+				Kind: "SCOPE.Component", Subtype: "const_destructure",
+				Name:       "counts",
+				SourceFile: "src/features/ContractProposals.jsx", StartLine: 48,
+				Properties: map[string]string{
+					"kind": "SCOPE.Component", "subtype": "const_destructure",
+					"local_scope": "true",
+				},
+			},
+			want: noiseLocalScope,
+		},
+		{
+			name: "local_scope array destructure binding",
+			e: graph.Entity{
+				Kind: "SCOPE.Component", Subtype: "const_destructure",
+				Name:       "a",
+				SourceFile: "src/features/Cmp.jsx", StartLine: 10,
+				Properties: map[string]string{
+					"kind": "SCOPE.Component", "subtype": "const_destructure",
+					"local_scope": "true",
+				},
+			},
+			want: noiseLocalScope,
+		},
+		{
+			name: "real top-level component (no local_scope) is NOT noise",
+			e: graph.Entity{
+				Kind: "SCOPE.Component", Subtype: "const_destructure",
+				Name:       "foo",
+				SourceFile: "src/features/Widget.jsx", StartLine: 3,
+				// No local_scope property — module-scope binding.
+			},
+			want: noiseNone,
+		},
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {


### PR DESCRIPTION
## What

Local `const` bindings declared inside function/component bodies appeared in `archigraph_find` results but could not be resolved via `archigraph_inspect` — breaking the "everything you see is queryable" contract and wasting tokens in multi-step investigations (field-reported: `counts  src/.../ContractProposals.jsx:48` surfaced in find, but `archigraph_inspect("ContractProposals.countsData")` returned not-found).

## Why

The JS/TS extractor's `walk()` recurses into function bodies to discover nested functions/components. When it encounters `lexical_declaration` / `variable_declaration` nodes inside those bodies, it calls `handleVariableDeclaration` → `handleVariableDeclarator`, which emits entities for destructure-pattern bindings (`const { counts } = someData`, `const [a, b] = arr`) unconditionally. These entities have no independently-addressable qualified name — `inspect("ContractProposals.counts")` can't find them — but they appeared in BM25-ranked `find` results.

## Approach: mark-at-extraction, filter-at-serve

**Why not suppress entirely?** Destructure bindings are emitted so the resolver can bind same-file `REFERENCES`/`CALLS` edges (e.g. `const { onConfirmLeave } = useReviewLeaveGuard()`). Removing the entities breaks `TestReferences_DestructureBinding_*` tests. The alt path (emit + mark + filter) preserves resolver correctness.

### Extractor changes (`internal/extractors/javascript/extractor.go`)

- Add `funcDepth int` field to `extractor` struct.
- Increment/decrement `funcDepth` around every `walkChildren(body, ...)` call in `handleFunctionDeclaration`, `handleVariableDeclarator` (arrow + function-expression cases), and `handlePublicFieldDefinition`.
- After emitting destructure-pattern entities at `funcDepth > 0` where `opLift=false && stateHook=false`, call `tagLocalScope(before)` which stamps `Properties["local_scope"]="true"` on newly-appended entities.
- Same guard applied to `isContextFactory`, `isFunctionWrapperCall`, and type-annotated const defaults inside function bodies.
- New `tagLocalScope(from int)` helper.

**What is NOT tagged (intentional anti-regressions):**
- Arrow/function-expression const inside function bodies → real callables, appear in call graphs
- Hook-result destructures (`opLift=true` or `stateHook=true`) → resolver needs them for CALLS binding
- Module-scope destructures (`funcDepth==0`) → never tagged
- Python, Go, Java extractors → already correct (Python explicitly returns out of function bodies; Go/Java don't emit local variable entities)

### Denoise changes (`internal/mcp/denoise.go`)

- Add `noiseLocalScope` tier (highest noise tier) to `noiseKind` enum.
- `classifyNoise()` returns `noiseLocalScope` for any entity with `Properties["local_scope"]=="true"`.
- `archigraph_find` hides these by default; `include_noise:true` still surfaces them.
- Header comment updated to document the new tier.

## Tests

- **6 new extractor tests** (`issue1748_hide_locals_test.go`): verify that plain destructures inside function bodies get `local_scope=true`, hook results don't, module-scope bindings don't, nested arrow consts don't, and inside top-level arrow components the inner destructures are tagged.
- **3 new denoise cases** in `TestClassifyNoise`: local_scope binding → `noiseLocalScope`; top-level binding without flag → `noiseNone`.
- All existing JS/TS extractor tests green (no golden baselines change).
- All existing MCP tests green.
- Pre-existing failure `TestModuleCoverage_AllEntitiesTagged` confirmed present on `origin/main` — not introduced by this PR.

## Verification checklist

- [x] `go build ./...` clean
- [x] `go vet ./internal/extractors/javascript/... ./internal/mcp/...` clean
- [x] `go test ./internal/extractors/javascript/...` — all pass
- [x] `go test ./internal/mcp/...` — all pass
- [x] No change to hook-result entity emission (mutation hooks, state hooks, useQuery)
- [x] Nested arrow const (`const handleClick = () => {}`) NOT tagged
- [x] Extractor side only — no conflict with in-flight grinds #1738/#1739/#1740

Fixes #1748

🤖 Generated with [Claude Code](https://claude.com/claude-code)