### PR TITLE
[#1756] Shrink archigraph_repairs schema: undeclare 10 submit-only params

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -624,7 +624,11 @@ Manage the residual-edge repair queue (ADR-0015) via a single action-dispatch
 interface. Combines the former `archigraph_list_residuals` and
 `archigraph_submit_repair` tools (bundled in #668).
 
-**Inputs**
+The 10 submit-only optional params below are **not declared in the JSON-Schema**
+(#1756 — #1639 pattern) to keep the handshake under its token ceiling. They are
+read from `args` by the handler exactly as before — no behavior change.
+
+**Inputs (declared in schema)**
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
@@ -632,18 +636,23 @@ interface. Combines the former `archigraph_list_residuals` and
 | `repo_filter` | string[] | no | `[]` | **(list)** Repos to scope. |
 | `limit` | number | no | `20` | **(list)** Max residuals returned. |
 | `offset` | number | no | `0` | **(list)** Pagination offset. |
-| `residual_id` | string | cond. | — | **(submit)** `er:<hex16>` identifier from `action=list`. |
-| `resolution` | string | cond. | — | **(submit)** `bind_to_entity` \| `reclassify_as_external` \| `reclassify_as_dynamic` \| `reclassify_as_resolved` \| `abandon` |
-| `target_entity_id` | string | no | — | **(submit)** Required when `resolution=bind_to_entity`. |
-| `module` | string | no | — | **(submit)** Required when `resolution=reclassify_as_external`. |
-| `new_target` | string | no | — | **(submit)** Required when `resolution=reclassify_as_resolved`. |
-| `dynamic_reason` | string | no | — | **(submit)** Reason for dynamic dispatch classification. |
-| `abandon_reason` | string | no | — | **(submit)** Reason for abandoning repair. |
-| `confidence` | number | no | `0.0` | **(submit)** Agent confidence in `[0,1]`. |
-| `reasoning` | string | no | — | **(submit)** Free-form agent reasoning. |
-| `source` | string | no | `mcp_submit_repair` | **(submit)** Audit source tag. |
-| `repo` | string | no | — | **(submit)** Optional repo override; defaults to repo that owns `residual_id`. |
 | `group`, `cwd` | string | no | — | Common args. |
+
+**Optional params for `action=submit` (pass in args, not declared in schema)**
+
+| Name | Type | Notes |
+|------|------|-------|
+| `residual_id` | string | `er:<hex16>` identifier from `action=list`. Required for submit. |
+| `resolution` | string | `bind_to_entity` \| `reclassify_as_external` \| `reclassify_as_dynamic` \| `reclassify_as_resolved` \| `abandon`. Required for submit. |
+| `target_entity_id` | string | Required when `resolution=bind_to_entity`. |
+| `module` | string | Required when `resolution=reclassify_as_external`. |
+| `new_target` | string | Required when `resolution=reclassify_as_resolved`. |
+| `dynamic_reason` | string | Reason for dynamic dispatch classification. |
+| `abandon_reason` | string | Reason for abandoning repair. |
+| `confidence` | number | Agent confidence in `[0,1]`; default `0.0`. |
+| `reasoning` | string | Free-form agent reasoning. |
+| `repo` | string | Override repo lookup when `residual_id` is ambiguous. |
+| `source` | string | Audit source tag; default `mcp_submit_repair`. |
 
 **Output (action=list)**
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -239,22 +239,20 @@ func (s *Server) registerTools() {
 	// archigraph_cross_links dropped (niche; agents rarely invoke; saves 164 tokens).
 
 	// archigraph_repairs — action: list|submit. ADR-0015 residual-edge repair.
+	// Submit-only optional args are read from request map but undeclared in
+	// schema to keep the handshake token budget under its ceiling (#1639 pattern,
+	// #1756): residual_id (string), resolution (string — bind_to_entity|
+	// reclassify_as_external|reclassify_as_dynamic|reclassify_as_resolved|
+	// abandon), target_entity_id (string), module (string), new_target (string),
+	// dynamic_reason (string), abandon_reason (string), confidence (number 0-1),
+	// reasoning (string), repo (string — override when residual_id is ambiguous),
+	// source (string — audit tag, default "mcp_submit_repair").
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_repairs",
 		mcpapi.WithDescription("Residual-edge repair queue: list=pending, submit=resolve."),
 		mcpapi.WithString("action", mcpapi.Required()),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(20)),
 		mcpapi.WithNumber("offset", mcpapi.DefaultNumber(0)),
-		mcpapi.WithAny("residual_id"),
-		mcpapi.WithAny("resolution"),
-		mcpapi.WithAny("target_entity_id"),
-		mcpapi.WithAny("module"),
-		mcpapi.WithAny("new_target"),
-		mcpapi.WithAny("dynamic_reason"),
-		mcpapi.WithAny("abandon_reason"),
-		mcpapi.WithNumber("confidence", mcpapi.DefaultNumber(0.0)),
-		mcpapi.WithAny("reasoning"),
-		mcpapi.WithAny("repo"),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_repairs", s.handleRepairs))

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -887,6 +887,98 @@ func TestRepairToolsRoundTrip(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// #1756: submit-only params are not declared in schema but still work in args.
+// ---------------------------------------------------------------------------
+
+// TestRepairsSubmitUndeclaredParamsStillWork is a regression guard for #1756.
+// It verifies that the 10 submit-only params removed from the JSON-Schema
+// (residual_id, resolution, target_entity_id, module, new_target, dynamic_reason,
+// abandon_reason, confidence, reasoning, repo) are still read from args by the
+// handler and produce the expected result — schema shrink must not break behavior.
+func TestRepairsSubmitUndeclaredParamsStillWork(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "rB")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, fixtureDoc("rB"))
+
+	// Seed a repair_edge candidate — same shape as TestRepairToolsRoundTrip.
+	cands := []map[string]any{
+		{
+			"id":         "ec:1756000000000001",
+			"kind":       "repair_edge",
+			"subject_id": "a1",
+			"context": map[string]any{
+				"edge_id":            "er:1756beef00000001",
+				"relation":           "CALLS",
+				"original_stub":      "doWork",
+				"disposition":        "DispositionBugResolver",
+				"disposition_reason": "duplicate_short_name",
+				"from_entity": map[string]any{
+					"id":   "a1",
+					"kind": "SCOPE.Component",
+					"name": "WorkerService",
+					"file": "src/WorkerService.go",
+					"line": 5,
+				},
+			},
+		},
+	}
+	candPath := filepath.Join(daemon.StateDirForRepo(repo), "enrichment-candidates.json")
+	if err := os.MkdirAll(filepath.Dir(candPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cd, _ := json.MarshalIndent(cands, "", "  ")
+	if err := os.WriteFile(candPath, cd, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"rB": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Verify none of the submit-only params appear in the declared schema.
+	byName := srv.MCP.ListTools()
+	st, ok := byName["archigraph_repairs"]
+	if !ok {
+		t.Fatal("archigraph_repairs not registered")
+	}
+	submitOnlyParams := []string{
+		"residual_id", "resolution", "target_entity_id", "module",
+		"new_target", "dynamic_reason", "abandon_reason", "confidence",
+		"reasoning", "repo",
+	}
+	props := st.Tool.InputSchema.Properties
+	for _, p := range submitOnlyParams {
+		if _, declared := props[p]; declared {
+			t.Errorf("param %q should not be declared in schema after #1756 shrink", p)
+		}
+	}
+
+	// Now verify the handler still reads residual_id, resolution, confidence,
+	// reasoning, and abandon_reason from args correctly despite them being
+	// undeclared in the schema.
+	res := callTool(t, srv, "archigraph_repairs", map[string]any{
+		"action":         "submit",
+		"residual_id":    "er:1756beef00000001", // undeclared in schema
+		"resolution":     "abandon",             // undeclared in schema
+		"abandon_reason": "test-1756 regression guard",
+		"confidence":     0.7,
+		"reasoning":      "undeclared params must still route through handler",
+	})
+	if res.IsError {
+		t.Fatalf("#1756: undeclared submit params not read by handler: %s", resultText(res))
+	}
+	text := resultText(res)
+	if !strings.Contains(text, "er:1756beef00000001") {
+		t.Fatalf("#1756: response missing residual_id: %s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Source-attribution tests (ADR-0015 #4/8 — issue #547)
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Removes 10 submit-only optional params from the `archigraph_repairs` JSON-Schema `InputSchema` declaration, following the #1639 pattern established by `archigraph_module_analysis`. The params are documented in a code comment and in the `SCHEMA.md` prose section. The handler reads them from `args` exactly as before.

**Params moved to prose (not removed from the handler):**
`residual_id`, `resolution`, `target_entity_id`, `module`, `new_target`, `dynamic_reason`, `abandon_reason`, `confidence`, `reasoning`, `repo`

## Why

Phase A research (#1742, comment #4524503297) identified `archigraph_repairs` as the single most expensive tool in the MCP handshake: **837 bytes / 8.7% of total**, driven by 16 declared input params despite 0 observed calls across both benchmark sessions. The 10 submit-only params are pure schema weight.

## Measurement

| | Tokens |
|---|---|
| Before | 3,248 |
| After | 3,209 |
| Delta | **−39 tokens / −157 bytes** |

> Note: Per-param byte savings are smaller than the issue estimate because `WithAny` params emit minimal JSON-Schema (just `{}`); the savings are real but bounded by the compact encoding.

## Verification

- `go build ./...` — clean
- `go vet ./internal/mcp/...` — clean
- `go test ./internal/mcp/...` — all pass (1.234s)
- `TestMCPHandshakeBudget` logs: `tools=30 chars=12835 tokens=3209 ceiling=3300`
- `TestRepairsSubmitUndeclaredParamsStillWork` (new) — asserts schema has no declared submit-only params AND handler still accepts them via args

## Test plan

- [ ] `go test ./internal/mcp/... -run TestRepairsSubmitUndeclaredParamsStillWork` passes
- [ ] `go test ./internal/mcp/... -run TestRepairToolsRoundTrip` passes (existing round-trip)
- [ ] `go test ./internal/mcp/... -run TestMCPHandshakeBudget` passes with `tokens=3209`
- [ ] Full suite: `go test ./internal/mcp/...` green

Fixes #1756.

🤖 Generated with [Claude Code](https://claude.com/claude-code)