### PR TITLE
[#1754] Fold get_subgraph + summarize_subgraph into unified archigraph_subgraph tool

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -117,13 +117,14 @@ Agents using these names will receive a "tool not found" error — update to the
 | ~~`archigraph_quality_orphans`~~ | Dropped — use `archigraph_find_dead_code`. |
 | [`archigraph_graph_patterns`](#archigraph_graph_patterns) | Indexer-extracted graph patterns (action: list\|get). |
 | [`archigraph_search_entities`](#archigraph_search_entities) | Full-text substring search across entity names. |
-| [`archigraph_get_subgraph`](#archigraph_get_subgraph) | All nodes and edges within N hops of an entity. |
+| [`archigraph_subgraph`](#archigraph_subgraph) | Nodes+edges (format=raw) or Markdown summary (format=markdown) within N hops. |
+| ~~`archigraph_get_subgraph`~~ | Deprecated — use `archigraph_subgraph(format=raw)`. |
 | [`archigraph_find_paths`](#archigraph_find_paths) | Shortest path between two entities. |
 | [`archigraph_endpoints`](#archigraph_endpoints) | HTTP endpoint surface (action: definitions\|calls\|stats). |
 | [`archigraph_find_callers`](#archigraph_find_callers) | Inbound call graph up to N hops. |
 | [`archigraph_find_callees`](#archigraph_find_callees) | Outbound call graph up to N hops. |
 | [`archigraph_impact_radius`](#archigraph_impact_radius) | Blast-radius analysis with per-entity risk score. |
-| [`archigraph_summarize_subgraph`](#archigraph_summarize_subgraph) | Markdown summary of entity call neighbourhood. |
+| ~~`archigraph_summarize_subgraph`~~ | Deprecated — use `archigraph_subgraph(format=markdown)`. |
 | [`archigraph_find_dead_code`](#archigraph_find_dead_code) | Entities with 0 inbound/outbound project edges. |
 | [`archigraph_auth_coverage`](#archigraph_auth_coverage) | Security audit: flag HTTP endpoints missing auth decorators/middleware. |
 | [`archigraph_secrets`](#archigraph_secrets) | Security scan: detect hardcoded API keys, passwords, JWT tokens, and other credentials in source files. |
@@ -1148,6 +1149,46 @@ When `migrated: false`, `note` contains a migration reminder.
 
 When `token_budget` is exceeded the response carries a `truncation_note` explaining
 how many items were omitted and how to get more. Use `limit=N` for simple pagination.
+
+---
+
+### `archigraph_subgraph`
+
+> Added in #1754. Folds `archigraph_get_subgraph` + `archigraph_summarize_subgraph`
+> into a single entry point discriminated by `format`.
+
+Return nodes+edges within N hops of an entity (`format="raw"`) or an LLM-friendly
+Markdown summary of the same neighbourhood (`format="markdown"`).
+
+**Inputs**
+
+| Name | Type | Required | Default | Description |
+|------|------|----------|---------|-------------|
+| `entity_id` | string | yes | — | Entity ID or prefixed cross-repo ID. |
+| `depth` | number | no | `2` | Hop depth. `raw`: clamped ≤5; `markdown`: clamped ≤4. |
+| `format` | string | no | `"raw"` | `"raw"` → JSON graph; `"markdown"` → Markdown summary. |
+| `group`, `cwd` | string | no | — | Common args. |
+
+**Output `format="raw"`** — JSON object:
+
+```json
+{
+  "root": "repo::abc123",
+  "repo": "my-service",
+  "depth": 2,
+  "node_count": 5,
+  "edge_count": 4,
+  "nodes": [
+    { "entity_id": "repo::abc123", "name": "processOrder", "kind": "Function", "source_file": "order.go", "start_line": 42, "depth": 0 }
+  ],
+  "edges": [
+    { "from_id": "repo::abc123", "to_id": "repo::def456", "kind": "CALLS" }
+  ]
+}
+```
+
+**Output `format="markdown"`** — plain Markdown text with `# EntityName`, `**Kind**`,
+`**Repo**`, `**File**`, `## Called by (N)`, and `## Calls (N)` sections.
 
 ---
 

--- a/internal/mcp/budget_test.go
+++ b/internal/mcp/budget_test.go
@@ -37,7 +37,11 @@ func TestMCPHandshakeBudget(t *testing.T) {
 		// 2026-05-23 (#1738): ceiling bumped to 3,300 to seat token_budget params on
 		// expand/traces/endpoints/find_callers/find_callees (5 params, +48 tokens).
 		// Measured: 3,248 tokens.
-		tokenCeiling  = 3300
+		// 2026-05-23 (#1754): ceiling bumped to 3,350 to seat archigraph_subgraph
+		// unified tool (format=raw|markdown discriminator folding get_subgraph +
+		// summarize_subgraph). Net: +1 schema entry with deprecated shims retained.
+		// Measured: 3,319 tokens. Full saving (~229B) lands when shims drop next release.
+		tokenCeiling  = 3350
 		charsPerToken = 4
 		envelopeBytes = 512 // initEnvelopeBytes constant from cmd/mcp-audit
 		maxDescLen    = 80

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -870,108 +870,17 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 
 // handleGetSubgraph returns all nodes and edges within `depth` hops of the
 // given entity_id — a local neighbourhood extract.
-func (s *Server) handleGetSubgraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	entityID, err := req.RequireString("entity_id")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
+//
+// Deprecated: use archigraph_subgraph with format="raw".
+func (s *Server) handleGetSubgraph(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	// Trampoline: delegate to unified handler with format="raw".
+	args := req.GetArguments()
+	if args == nil {
+		args = map[string]any{}
+		req.Params.Arguments = args
 	}
-	_, lg, errRes := s.resolveAndGroup(req)
-	if errRes != nil {
-		return errRes, nil
-	}
-	depth := argInt(req, "depth", 2)
-	if depth < 1 {
-		depth = 1
-	}
-	if depth > 5 {
-		depth = 5
-	}
-	repos := reposToConsider(lg, nil)
-	repoHint, local := splitPrefixed(entityID)
-	if repoHint != "" {
-		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
-			repos = []*LoadedRepo{r}
-		}
-	}
-
-	for _, r := range repos {
-		if r.Doc == nil {
-			continue
-		}
-		target := local
-		if target == "" {
-			target = entityID
-		}
-		byID := r.ByID
-		if _, ok := byID[target]; !ok {
-			continue
-		}
-		adj := r.Adjacency
-		visited := bfs(adj, target, depth, nil)
-		byID2 := r.ByID
-		type nodeOut struct {
-			EntityID   string `json:"entity_id"`
-			Name       string `json:"name"`
-			Kind       string `json:"kind"`
-			SourceFile string `json:"source_file,omitempty"`
-			StartLine  int    `json:"start_line,omitempty"`
-			Depth      int    `json:"depth"`
-		}
-		type edgeOut struct {
-			FromID string `json:"from_id"`
-			ToID   string `json:"to_id"`
-			Kind   string `json:"kind"`
-		}
-		var nodes []nodeOut
-		nodeSet := map[string]bool{}
-		for id, d := range visited {
-			if e := byID2[id]; e != nil {
-				nodes = append(nodes, nodeOut{
-					EntityID:   prefixedID(r.Repo, e.ID),
-					Name:       e.Name,
-					Kind:       e.Kind,
-					SourceFile: e.SourceFile,
-					StartLine:  e.StartLine,
-					Depth:      d,
-				})
-			}
-			nodeSet[id] = true
-		}
-		sort.Slice(nodes, func(i, j int) bool {
-			if nodes[i].Depth != nodes[j].Depth {
-				return nodes[i].Depth < nodes[j].Depth
-			}
-			return nodes[i].Name < nodes[j].Name
-		})
-		var edges []edgeOut
-		seen := map[string]bool{}
-		for i := range r.Doc.Relationships {
-			rel := &r.Doc.Relationships[i]
-			if !nodeSet[rel.FromID] || !nodeSet[rel.ToID] {
-				continue
-			}
-			key := rel.FromID + ">" + rel.ToID + ":" + rel.Kind
-			if seen[key] {
-				continue
-			}
-			seen[key] = true
-			edges = append(edges, edgeOut{
-				FromID: prefixedID(r.Repo, rel.FromID),
-				ToID:   prefixedID(r.Repo, rel.ToID),
-				Kind:   rel.Kind,
-			})
-		}
-		return jsonResult(map[string]any{
-			"root":       prefixedID(r.Repo, target),
-			"repo":       r.Repo,
-			"depth":      depth,
-			"nodes":      nodes,
-			"edges":      edges,
-			"node_count": len(nodes),
-			"edge_count": len(edges),
-		}), nil
-	}
-	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+	args["format"] = "raw"
+	return s.handleSubgraph(ctx, req)
 }
 
 // reverseTraversalEdgeKinds is the set of edge kinds where the BFS in

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -1,11 +1,12 @@
 // flow_tools.go — MCP handlers for flow-aware graph traversal tools (issue #1252).
 //
 // Implements:
-//   - archigraph_find_callers   — what calls this entity (inbound edges, N hops)
-//   - archigraph_find_callees   — what does this entity call (outbound edges, N hops)
-//   - archigraph_impact_radius  — entities affected if this one changes, with risk score
-//   - archigraph_summarize_subgraph — LLM-friendly markdown summary of entity neighbourhood
-//   - archigraph_find_dead_code — unreferenced public operations carrying a dead-code marker
+//   - archigraph_find_callers       — what calls this entity (inbound edges, N hops)
+//   - archigraph_find_callees       — what does this entity call (outbound edges, N hops)
+//   - archigraph_impact_radius      — entities affected if this one changes, with risk score
+//   - archigraph_subgraph           — unified subgraph tool (format=raw|markdown) (#1754)
+//   - archigraph_summarize_subgraph — deprecated alias for archigraph_subgraph(format=markdown)
+//   - archigraph_find_dead_code     — unreferenced public operations carrying a dead-code marker
 //
 // All handlers operate against the in-memory LoadedGroup data — no HTTP calls.
 package mcp
@@ -535,17 +536,134 @@ func buildRiskReason(e *graph.Entity, inDegree int) string {
 }
 
 // ---------------------------------------------------------------------------
-// archigraph_summarize_subgraph
+// archigraph_subgraph (unified, #1754)
 // ---------------------------------------------------------------------------
 
-// handleSummarizeSubgraph returns an LLM-friendly Markdown summary of an
-// entity's local neighbourhood. The summary can be pasted directly into a
-// doc or used as context for a follow-up agent prompt.
-func (s *Server) handleSummarizeSubgraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+// handleSubgraph is the unified handler for archigraph_subgraph.
+// format="raw"      → JSON graph (nodes + edges), identical output to old get_subgraph.
+// format="markdown" → LLM-friendly Markdown summary, identical output to old summarize_subgraph.
+// Both legacy tools delegate here as deprecated trampolines.
+func (s *Server) handleSubgraph(_ context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	entityID, err := req.RequireString("entity_id")
 	if err != nil {
 		return mcpapi.NewToolResultError(err.Error()), nil
 	}
+	format := argString(req, "format", "raw")
+	switch format {
+	case "raw":
+		return s.subgraphRaw(entityID, req)
+	case "markdown":
+		return s.subgraphMarkdown(entityID, req)
+	default:
+		return mcpapi.NewToolResultError("format must be \"raw\" or \"markdown\"; got: " + format), nil
+	}
+}
+
+// subgraphRaw returns all nodes and edges within depth hops of entity_id.
+// Extracted from the former handleGetSubgraph (dashboard_tools.go).
+func (s *Server) subgraphRaw(entityID string, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	_, lg, errRes := s.resolveAndGroup(req)
+	if errRes != nil {
+		return errRes, nil
+	}
+	depth := argInt(req, "depth", 2)
+	if depth < 1 {
+		depth = 1
+	}
+	if depth > 5 {
+		depth = 5
+	}
+	repos := reposToConsider(lg, nil)
+	repoHint, local := splitPrefixed(entityID)
+	if repoHint != "" {
+		if r, ok := lg.Repos[repoHint]; ok && r.Doc != nil {
+			repos = []*LoadedRepo{r}
+		}
+	}
+
+	for _, r := range repos {
+		if r.Doc == nil {
+			continue
+		}
+		target := local
+		if target == "" {
+			target = entityID
+		}
+		byID := r.ByID
+		if _, ok := byID[target]; !ok {
+			continue
+		}
+		adj := r.Adjacency
+		visited := bfs(adj, target, depth, nil)
+		byID2 := r.ByID
+		type nodeOut struct {
+			EntityID   string `json:"entity_id"`
+			Name       string `json:"name"`
+			Kind       string `json:"kind"`
+			SourceFile string `json:"source_file,omitempty"`
+			StartLine  int    `json:"start_line,omitempty"`
+			Depth      int    `json:"depth"`
+		}
+		type edgeOut struct {
+			FromID string `json:"from_id"`
+			ToID   string `json:"to_id"`
+			Kind   string `json:"kind"`
+		}
+		var nodes []nodeOut
+		nodeSet := map[string]bool{}
+		for id, d := range visited {
+			if e := byID2[id]; e != nil {
+				nodes = append(nodes, nodeOut{
+					EntityID:   prefixedID(r.Repo, e.ID),
+					Name:       e.Name,
+					Kind:       e.Kind,
+					SourceFile: e.SourceFile,
+					StartLine:  e.StartLine,
+					Depth:      d,
+				})
+			}
+			nodeSet[id] = true
+		}
+		sort.Slice(nodes, func(i, j int) bool {
+			if nodes[i].Depth != nodes[j].Depth {
+				return nodes[i].Depth < nodes[j].Depth
+			}
+			return nodes[i].Name < nodes[j].Name
+		})
+		var edges []edgeOut
+		seen := map[string]bool{}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if !nodeSet[rel.FromID] || !nodeSet[rel.ToID] {
+				continue
+			}
+			key := rel.FromID + ">" + rel.ToID + ":" + rel.Kind
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			edges = append(edges, edgeOut{
+				FromID: prefixedID(r.Repo, rel.FromID),
+				ToID:   prefixedID(r.Repo, rel.ToID),
+				Kind:   rel.Kind,
+			})
+		}
+		return jsonResult(map[string]any{
+			"root":       prefixedID(r.Repo, target),
+			"repo":       r.Repo,
+			"depth":      depth,
+			"nodes":      nodes,
+			"edges":      edges,
+			"node_count": len(nodes),
+			"edge_count": len(edges),
+		}), nil
+	}
+	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// subgraphMarkdown returns an LLM-friendly Markdown summary of entity_id's
+// local neighbourhood. Extracted from the former handleSummarizeSubgraph.
+func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
@@ -701,6 +819,26 @@ func (s *Server) handleSummarizeSubgraph(_ context.Context, req mcpapi.CallToolR
 		return mcpapi.NewToolResultText(b.String()), nil
 	}
 	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
+}
+
+// ---------------------------------------------------------------------------
+// archigraph_summarize_subgraph (deprecated — trampoline to archigraph_subgraph)
+// ---------------------------------------------------------------------------
+
+// handleSummarizeSubgraph returns an LLM-friendly Markdown summary of an
+// entity's local neighbourhood. The summary can be pasted directly into a
+// doc or used as context for a follow-up agent prompt.
+//
+// Deprecated: use archigraph_subgraph with format="markdown".
+func (s *Server) handleSummarizeSubgraph(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
+	// Trampoline: delegate to unified handler with format="markdown".
+	args := req.GetArguments()
+	if args == nil {
+		args = map[string]any{}
+		req.Params.Arguments = args
+	}
+	args["format"] = "markdown"
+	return s.handleSubgraph(ctx, req)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -421,6 +421,152 @@ func TestSummarizeSubgraph_RootNoCallers(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// TestSubgraph — unified archigraph_subgraph tool (#1754)
+// ---------------------------------------------------------------------------
+
+// TestSubgraph_FormatRaw_DefaultsToRaw verifies that omitting format= returns
+// JSON (raw) output identical to the old get_subgraph path.
+func TestSubgraph_FormatRaw_DefaultsToRaw(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "root", Name: "Root", Kind: "Function"},
+		{ID: "child", Name: "Child", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	// No format= → default is "raw".
+	out := callFlowTool(t, srv.handleSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(1),
+	})
+	if out == nil {
+		t.Fatal("expected JSON output for format=raw, got nil (markdown path?)")
+	}
+	nc, ok := out["node_count"].(float64)
+	if !ok {
+		t.Fatalf("node_count missing or wrong type in raw output: %v", out)
+	}
+	if int(nc) != 2 {
+		t.Errorf("expected node_count=2, got %d", int(nc))
+	}
+}
+
+// TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph verifies byte-identical
+// node_count + edge_count output for the same seed/depth between the unified
+// tool with format="raw" and the legacy handleGetSubgraph trampoline.
+func TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "root", Name: "Root", Kind: "Function"},
+		{ID: "child", Name: "Child", Kind: "Function"},
+		{ID: "grandchild", Name: "GrandChild", Kind: "Function"},
+	}
+	rels := []graph.Relationship{
+		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
+		{ID: "r2", FromID: "child", ToID: "grandchild", Kind: "CALLS"},
+	}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	args := map[string]any{"group": "test", "entity_id": "root", "depth": float64(2)}
+
+	// Legacy path via deprecated handleGetSubgraph trampoline.
+	legacyArgs := map[string]any{"group": "test", "entity_id": "root", "depth": float64(2)}
+	legacy := callDashboardTool(t, srv.handleGetSubgraph, legacyArgs)
+
+	// New unified path with explicit format="raw".
+	args["format"] = "raw"
+	unified := callFlowTool(t, srv.handleSubgraph, args)
+	if unified == nil {
+		t.Fatal("expected JSON output for format=raw")
+	}
+
+	if legacy["node_count"] != unified["node_count"] {
+		t.Errorf("node_count mismatch: legacy=%v unified=%v", legacy["node_count"], unified["node_count"])
+	}
+	if legacy["edge_count"] != unified["edge_count"] {
+		t.Errorf("edge_count mismatch: legacy=%v unified=%v", legacy["edge_count"], unified["edge_count"])
+	}
+}
+
+// TestSubgraph_FormatMarkdown_MatchesLegacySummarize verifies that
+// format="markdown" produces identical content to the legacy trampoline.
+func TestSubgraph_FormatMarkdown_MatchesLegacySummarize(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	unifiedText := callFlowToolText(t, srv.handleSubgraph, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+		"format":    "markdown",
+	})
+	legacyText := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+	})
+
+	if unifiedText != legacyText {
+		t.Errorf("format=markdown output differs from legacy summarize_subgraph:\nunified:\n%s\nlegacy:\n%s", unifiedText, legacyText)
+	}
+}
+
+// TestSubgraph_InvalidFormat verifies a helpful error is returned for unknown format.
+func TestSubgraph_InvalidFormat(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"entity_id": "ent-a",
+		"depth":     float64(1),
+		"format":    "xml",
+	}
+	res, err := srv.handleSubgraph(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !res.IsError {
+		t.Fatal("expected IsError=true for invalid format")
+	}
+}
+
+// TestSubgraph_LegacyGetSubgraph_TrampolineWorks ensures the deprecated
+// handleGetSubgraph still produces valid JSON output via the trampoline.
+func TestSubgraph_LegacyGetSubgraph_TrampolineWorks(t *testing.T) {
+	entities := []graph.Entity{
+		{ID: "a", Name: "A", Kind: "Function"},
+		{ID: "b", Name: "B", Kind: "Function"},
+	}
+	rels := []graph.Relationship{{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"}}
+	srv := newTestServerWithDoc(t, minDoc(entities, rels))
+
+	out := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "a",
+		"depth":     float64(1),
+	})
+	if int(out["node_count"].(float64)) != 2 {
+		t.Errorf("expected 2 nodes via legacy trampoline, got %v", out["node_count"])
+	}
+}
+
+// TestSubgraph_LegacySummarizeSubgraph_TrampolineWorks ensures the deprecated
+// handleSummarizeSubgraph still produces markdown output via the trampoline.
+func TestSubgraph_LegacySummarizeSubgraph_TrampolineWorks(t *testing.T) {
+	doc := buildChainDoc()
+	srv := newTestServerWithDoc(t, doc)
+
+	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+		"entity_id": "ent-b",
+		"depth":     float64(1),
+	})
+	if !strings.Contains(text, "FuncB") {
+		t.Errorf("legacy trampoline should still return FuncB in markdown:\n%s", text)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // TestFindDeadCode
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -332,8 +332,20 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_search_entities", s.handleSearchEntities))
 
+	// archigraph_subgraph — unified subgraph tool (#1754).
+	// Folds archigraph_get_subgraph + archigraph_summarize_subgraph into one
+	// entry point; discriminated by format="raw"|"markdown".
+	s.MCP.AddTool(mcpapi.NewTool("archigraph_subgraph",
+		mcpapi.WithDescription("Nodes+edges within N hops (format=raw) or Markdown summary (format=markdown)."),
+		mcpapi.WithString("entity_id", mcpapi.Required()),
+		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2)),
+		mcpapi.WithString("format", mcpapi.DefaultString("raw")),
+		mcpapi.WithAny("group"),
+		mcpapi.WithAny("cwd"),
+	), s.wrap("archigraph_subgraph", s.handleSubgraph))
+
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_subgraph",
-		mcpapi.WithDescription("All nodes and edges within N hops of an entity."),
+		mcpapi.WithDescription("Deprecated — use archigraph_subgraph(format=raw)."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2)),
 		mcpapi.WithAny("group"),
@@ -396,7 +408,7 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_impact_radius", s.handleImpactRadius))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_summarize_subgraph",
-		mcpapi.WithDescription("Markdown summary of callers + callees within N hops."),
+		mcpapi.WithDescription("Deprecated — use archigraph_subgraph(format=markdown)."),
 		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2)),
 		mcpapi.WithAny("group"),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -605,12 +605,13 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 30 (28 baseline + archigraph_module_analysis from #1384,
+	// Total count: 31 (28 baseline + archigraph_module_analysis from #1384,
 	// + archigraph_apply_docgen_repairs from #1659: docgen→graph repair feedback
 	// loop — emit repair candidates in generate-docs, apply high-confidence ones
-	// immediately as enrichment resolutions, queue low-confidence for review).
-	if got := len(srv.MCP.ListTools()); got != 30 {
-		t.Errorf("expected 30 registered tools, got %d", got)
+	// immediately as enrichment resolutions, queue low-confidence for review,
+	// + archigraph_subgraph unified tool from #1754).
+	if got := len(srv.MCP.ListTools()); got != 31 {
+		t.Errorf("expected 31 registered tools, got %d", got)
 	}
 }
 
@@ -2702,6 +2703,7 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_flows":               {"group": "g", "action": "dead_ends"},
 		"archigraph_graph_patterns":      {"group": "g", "action": "list"},
 		"archigraph_search_entities":     {"group": "g", "query": "Dashboard"},
+		"archigraph_subgraph":            {"group": "g", "entity_id": "r1::a1"},
 		"archigraph_get_subgraph":        {"group": "g", "entity_id": "r1::a1"},
 		"archigraph_find_paths":          {"group": "g", "from": "r1::a1", "to": "r1::a4"},
 		"archigraph_endpoints":           {"group": "g", "action": "definitions"},
@@ -2759,8 +2761,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 30 {
-		t.Errorf("expected 30 registered tools, got %d — update minimalArgs if new tools were added", len(tools))
+	if len(tools) != 31 {
+		t.Errorf("expected 31 registered tools, got %d — update minimalArgs if new tools were added", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## What

Introduces `archigraph_subgraph(entity_id, depth=2, format="raw"|"markdown")` — a single unified entry point that replaces the two zero-call tools `archigraph_get_subgraph` and `archigraph_summarize_subgraph` identified in Phase A research (#1742).

Both legacy tools are retained as deprecated backward-compat shims for one release. Each shim is a 2-line trampoline that injects `format="raw"` or `format="markdown"` into the args map before delegating to the shared handler.

## Why

Phase A evidence (#1742#issuecomment-4524503297): both tools had **0 calls** across two real benchmark sessions and have **identical input params** — the only difference was output rendering. This is the cleanest fold candidate of all identified pairs.

Estimated saving when shims drop next release: ~229 bytes / ~57 tokens off the MCP handshake. With shims retained (this PR): net +71 tokens (3248 → 3319), ceiling bumped to 3350.

## Changes

| File | Change |
|------|--------|
| `internal/mcp/flow_tools.go` | New `handleSubgraph` dispatcher + `subgraphRaw` + `subgraphMarkdown` helpers extracted from old handlers; `handleSummarizeSubgraph` → 2-line trampoline |
| `internal/mcp/dashboard_tools.go` | `handleGetSubgraph` → 2-line trampoline |
| `internal/mcp/server.go` | Register `archigraph_subgraph`; mark legacy descriptions as deprecated |
| `internal/mcp/flow_tools_test.go` | 6 new tests: default format, raw parity, markdown parity, invalid format, both trampoline paths |
| `internal/mcp/server_test.go` | Tool count 30→31; add `archigraph_subgraph` to `minimalArgs` |
| `internal/mcp/budget_test.go` | Ceiling bump 3300→3350 with measured token count comment |
| `internal/mcp/SCHEMA.md` | New `archigraph_subgraph` section; legacy entries marked deprecated in index |

## Verification

```
go build ./internal/mcp/...   # clean
go vet ./internal/mcp/...     # clean
go test ./internal/mcp/... -count=1  # PASS (all 9 subgraph tests + full suite)
```

Handshake measurement: **3,319 tokens** (31 tools, ceiling 3,350).

## Zero-behavior-change guarantee

- `handleGetSubgraph` delegates to `subgraphRaw` — same BFS, same JSON shape, same depth clamp (≤5)
- `handleSummarizeSubgraph` delegates to `subgraphMarkdown` — same in/out traversal, same Markdown rendering, same depth clamp (≤4)
- `TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph` asserts node_count/edge_count identity
- `TestSubgraph_FormatMarkdown_MatchesLegacySummarize` asserts full string equality

Fixes #1754