### PR TITLE
[token-sprint] Drop subgraph deprecation shims (saves +180 net tokens, no real callers per #1742 research)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -118,13 +118,11 @@ Agents using these names will receive a "tool not found" error — update to the
 | [`archigraph_graph_patterns`](#archigraph_graph_patterns) | Indexer-extracted graph patterns (action: list\|get). |
 | [`archigraph_search_entities`](#archigraph_search_entities) | Full-text substring search across entity names. |
 | [`archigraph_subgraph`](#archigraph_subgraph) | Nodes+edges (format=raw) or Markdown summary (format=markdown) within N hops. |
-| ~~`archigraph_get_subgraph`~~ | Deprecated — use `archigraph_subgraph(format=raw)`. |
 | [`archigraph_find_paths`](#archigraph_find_paths) | Shortest path between two entities. |
 | [`archigraph_endpoints`](#archigraph_endpoints) | HTTP endpoint surface (action: definitions\|calls\|stats). |
 | [`archigraph_find_callers`](#archigraph_find_callers) | Inbound call graph up to N hops. |
 | [`archigraph_find_callees`](#archigraph_find_callees) | Outbound call graph up to N hops. |
 | [`archigraph_impact_radius`](#archigraph_impact_radius) | Blast-radius analysis with per-entity risk score. |
-| ~~`archigraph_summarize_subgraph`~~ | Deprecated — use `archigraph_subgraph(format=markdown)`. |
 | [`archigraph_find_dead_code`](#archigraph_find_dead_code) | Entities with 0 inbound/outbound project edges. |
 | [`archigraph_auth_coverage`](#archigraph_auth_coverage) | Security audit: flag HTTP endpoints missing auth decorators/middleware. |
 | [`archigraph_secrets`](#archigraph_secrets) | Security scan: detect hardcoded API keys, passwords, JWT tokens, and other credentials in source files. |

--- a/internal/mcp/budget_test.go
+++ b/internal/mcp/budget_test.go
@@ -38,10 +38,11 @@ func TestMCPHandshakeBudget(t *testing.T) {
 		// expand/traces/endpoints/find_callers/find_callees (5 params, +48 tokens).
 		// Measured: 3,248 tokens.
 		// 2026-05-23 (#1754): ceiling bumped to 3,350 to seat archigraph_subgraph
-		// unified tool (format=raw|markdown discriminator folding get_subgraph +
-		// summarize_subgraph). Net: +1 schema entry with deprecated shims retained.
-		// Measured: 3,319 tokens. Full saving (~229B) lands when shims drop next release.
-		tokenCeiling  = 3350
+		// unified tool. Pre-shim-drop measurement: 3,319 tokens (31 tools).
+		// feat/drop-subgraph-shims: drop archigraph_get_subgraph + archigraph_summarize_subgraph
+		// shims (0 real callers per #1742 research). Net saving: ~180 tokens.
+		// 29 tools, ceiling lowered to 3,200.
+		tokenCeiling  = 3200
 		charsPerToken = 4
 		envelopeBytes = 512 // initEnvelopeBytes constant from cmd/mcp-audit
 		maxDescLen    = 80

--- a/internal/mcp/dashboard_tools.go
+++ b/internal/mcp/dashboard_tools.go
@@ -783,7 +783,7 @@ func (s *Server) handlePatternsGetGraph(_ context.Context, req mcpapi.CallToolRe
 }
 
 // ---------------------------------------------------------------------------
-// Bonus tools: search_entities, get_subgraph, find_paths
+// Bonus tools: search_entities, find_paths
 // ---------------------------------------------------------------------------
 
 // handleSearchEntities performs a substring / prefix search across entity
@@ -866,21 +866,6 @@ func (s *Server) handleSearchEntities(_ context.Context, req mcpapi.CallToolRequ
 		"total":     total,
 		"truncated": total > len(out),
 	}), nil
-}
-
-// handleGetSubgraph returns all nodes and edges within `depth` hops of the
-// given entity_id — a local neighbourhood extract.
-//
-// Deprecated: use archigraph_subgraph with format="raw".
-func (s *Server) handleGetSubgraph(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	// Trampoline: delegate to unified handler with format="raw".
-	args := req.GetArguments()
-	if args == nil {
-		args = map[string]any{}
-		req.Params.Arguments = args
-	}
-	args["format"] = "raw"
-	return s.handleSubgraph(ctx, req)
 }
 
 // reverseTraversalEdgeKinds is the set of edge kinds where the BFS in

--- a/internal/mcp/dashboard_tools_test.go
+++ b/internal/mcp/dashboard_tools_test.go
@@ -585,47 +585,6 @@ func TestHandleSearchEntities_KindFilter(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// archigraph_get_subgraph
-// ---------------------------------------------------------------------------
-
-func TestHandleGetSubgraph(t *testing.T) {
-	entities := []graph.Entity{
-		{ID: "root", Name: "Root", Kind: "Function"},
-		{ID: "child", Name: "Child", Kind: "Function"},
-		{ID: "grandchild", Name: "GrandChild", Kind: "Function"},
-		{ID: "distant", Name: "Distant", Kind: "Function"},
-	}
-	rels := []graph.Relationship{
-		{ID: "r1", FromID: "root", ToID: "child", Kind: "CALLS"},
-		{ID: "r2", FromID: "child", ToID: "grandchild", Kind: "CALLS"},
-		{ID: "r3", FromID: "grandchild", ToID: "distant", Kind: "CALLS"},
-	}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
-
-	// depth=1: root + child
-	out := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
-		"group":     "test",
-		"entity_id": "root",
-		"depth":     float64(1),
-	})
-	nc := int(out["node_count"].(float64))
-	if nc != 2 {
-		t.Errorf("depth=1 expected 2 nodes, got %d", nc)
-	}
-
-	// depth=2: root + child + grandchild
-	out2 := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
-		"group":     "test",
-		"entity_id": "root",
-		"depth":     float64(2),
-	})
-	nc2 := int(out2["node_count"].(float64))
-	if nc2 != 3 {
-		t.Errorf("depth=2 expected 3 nodes, got %d", nc2)
-	}
-}
-
-// ---------------------------------------------------------------------------
 // archigraph_find_paths
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/flow_tools.go
+++ b/internal/mcp/flow_tools.go
@@ -5,7 +5,6 @@
 //   - archigraph_find_callees       — what does this entity call (outbound edges, N hops)
 //   - archigraph_impact_radius      — entities affected if this one changes, with risk score
 //   - archigraph_subgraph           — unified subgraph tool (format=raw|markdown) (#1754)
-//   - archigraph_summarize_subgraph — deprecated alias for archigraph_subgraph(format=markdown)
 //   - archigraph_find_dead_code     — unreferenced public operations carrying a dead-code marker
 //
 // All handlers operate against the in-memory LoadedGroup data — no HTTP calls.
@@ -819,26 +818,6 @@ func (s *Server) subgraphMarkdown(entityID string, req mcpapi.CallToolRequest) (
 		return mcpapi.NewToolResultText(b.String()), nil
 	}
 	return mcpapi.NewToolResultError("entity not found: " + entityID), nil
-}
-
-// ---------------------------------------------------------------------------
-// archigraph_summarize_subgraph (deprecated — trampoline to archigraph_subgraph)
-// ---------------------------------------------------------------------------
-
-// handleSummarizeSubgraph returns an LLM-friendly Markdown summary of an
-// entity's local neighbourhood. The summary can be pasted directly into a
-// doc or used as context for a follow-up agent prompt.
-//
-// Deprecated: use archigraph_subgraph with format="markdown".
-func (s *Server) handleSummarizeSubgraph(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	// Trampoline: delegate to unified handler with format="markdown".
-	args := req.GetArguments()
-	if args == nil {
-		args = map[string]any{}
-		req.Params.Arguments = args
-	}
-	args["format"] = "markdown"
-	return s.handleSubgraph(ctx, req)
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/mcp/flow_tools_test.go
+++ b/internal/mcp/flow_tools_test.go
@@ -384,16 +384,17 @@ func TestImpactRadius_RootHasNoUpstreamImpact(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
-// TestSummarizeSubgraph
+// TestSubgraph_FormatMarkdown (format=markdown path of the unified tool)
 // ---------------------------------------------------------------------------
 
-func TestSummarizeSubgraph_MarkdownContainsName(t *testing.T) {
+func TestSubgraph_FormatMarkdown_ContainsStructure(t *testing.T) {
 	doc := buildChainDoc()
 	srv := newTestServerWithDoc(t, doc)
 
-	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-b",
 		"depth":     float64(1),
+		"format":    "markdown",
 	})
 
 	if !strings.Contains(text, "FuncB") {
@@ -407,13 +408,14 @@ func TestSummarizeSubgraph_MarkdownContainsName(t *testing.T) {
 	}
 }
 
-func TestSummarizeSubgraph_RootNoCallers(t *testing.T) {
+func TestSubgraph_FormatMarkdown_RootNoCallers(t *testing.T) {
 	doc := buildChainDoc()
 	srv := newTestServerWithDoc(t, doc)
 
-	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
+	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-a",
 		"depth":     float64(1),
+		"format":    "markdown",
 	})
 	if !strings.Contains(text, "No callers") {
 		t.Errorf("FuncA has no callers; summary should say so:\n%s", text)
@@ -454,10 +456,9 @@ func TestSubgraph_FormatRaw_DefaultsToRaw(t *testing.T) {
 	}
 }
 
-// TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph verifies byte-identical
-// node_count + edge_count output for the same seed/depth between the unified
-// tool with format="raw" and the legacy handleGetSubgraph trampoline.
-func TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph(t *testing.T) {
+// TestSubgraph_FormatRaw_GraphCounts verifies node_count and edge_count for
+// a known fixture using format="raw" on the canonical archigraph_subgraph tool.
+func TestSubgraph_FormatRaw_GraphCounts(t *testing.T) {
 	entities := []graph.Entity{
 		{ID: "root", Name: "Root", Kind: "Function"},
 		{ID: "child", Name: "Child", Kind: "Function"},
@@ -469,45 +470,37 @@ func TestSubgraph_FormatRaw_MatchesLegacyGetSubgraph(t *testing.T) {
 	}
 	srv := newTestServerWithDoc(t, minDoc(entities, rels))
 
-	args := map[string]any{"group": "test", "entity_id": "root", "depth": float64(2)}
-
-	// Legacy path via deprecated handleGetSubgraph trampoline.
-	legacyArgs := map[string]any{"group": "test", "entity_id": "root", "depth": float64(2)}
-	legacy := callDashboardTool(t, srv.handleGetSubgraph, legacyArgs)
-
-	// New unified path with explicit format="raw".
-	args["format"] = "raw"
-	unified := callFlowTool(t, srv.handleSubgraph, args)
+	// depth=2 from root should reach root+child+grandchild (3 nodes, 2 edges).
+	unified := callFlowTool(t, srv.handleSubgraph, map[string]any{
+		"group":     "test",
+		"entity_id": "root",
+		"depth":     float64(2),
+		"format":    "raw",
+	})
 	if unified == nil {
 		t.Fatal("expected JSON output for format=raw")
 	}
-
-	if legacy["node_count"] != unified["node_count"] {
-		t.Errorf("node_count mismatch: legacy=%v unified=%v", legacy["node_count"], unified["node_count"])
+	if nc := int(unified["node_count"].(float64)); nc != 3 {
+		t.Errorf("expected node_count=3, got %d", nc)
 	}
-	if legacy["edge_count"] != unified["edge_count"] {
-		t.Errorf("edge_count mismatch: legacy=%v unified=%v", legacy["edge_count"], unified["edge_count"])
+	if ec := int(unified["edge_count"].(float64)); ec != 2 {
+		t.Errorf("expected edge_count=2, got %d", ec)
 	}
 }
 
-// TestSubgraph_FormatMarkdown_MatchesLegacySummarize verifies that
-// format="markdown" produces identical content to the legacy trampoline.
-func TestSubgraph_FormatMarkdown_MatchesLegacySummarize(t *testing.T) {
+// TestSubgraph_FormatMarkdown_ContainsEntityName verifies that format="markdown"
+// returns a summary containing the target entity name.
+func TestSubgraph_FormatMarkdown_ContainsEntityName(t *testing.T) {
 	doc := buildChainDoc()
 	srv := newTestServerWithDoc(t, doc)
 
-	unifiedText := callFlowToolText(t, srv.handleSubgraph, map[string]any{
+	text := callFlowToolText(t, srv.handleSubgraph, map[string]any{
 		"entity_id": "ent-b",
 		"depth":     float64(1),
 		"format":    "markdown",
 	})
-	legacyText := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
-		"entity_id": "ent-b",
-		"depth":     float64(1),
-	})
-
-	if unifiedText != legacyText {
-		t.Errorf("format=markdown output differs from legacy summarize_subgraph:\nunified:\n%s\nlegacy:\n%s", unifiedText, legacyText)
+	if !strings.Contains(text, "FuncB") {
+		t.Errorf("format=markdown should contain FuncB in output:\n%s", text)
 	}
 }
 
@@ -528,41 +521,6 @@ func TestSubgraph_InvalidFormat(t *testing.T) {
 	}
 	if !res.IsError {
 		t.Fatal("expected IsError=true for invalid format")
-	}
-}
-
-// TestSubgraph_LegacyGetSubgraph_TrampolineWorks ensures the deprecated
-// handleGetSubgraph still produces valid JSON output via the trampoline.
-func TestSubgraph_LegacyGetSubgraph_TrampolineWorks(t *testing.T) {
-	entities := []graph.Entity{
-		{ID: "a", Name: "A", Kind: "Function"},
-		{ID: "b", Name: "B", Kind: "Function"},
-	}
-	rels := []graph.Relationship{{ID: "r1", FromID: "a", ToID: "b", Kind: "CALLS"}}
-	srv := newTestServerWithDoc(t, minDoc(entities, rels))
-
-	out := callDashboardTool(t, srv.handleGetSubgraph, map[string]any{
-		"group":     "test",
-		"entity_id": "a",
-		"depth":     float64(1),
-	})
-	if int(out["node_count"].(float64)) != 2 {
-		t.Errorf("expected 2 nodes via legacy trampoline, got %v", out["node_count"])
-	}
-}
-
-// TestSubgraph_LegacySummarizeSubgraph_TrampolineWorks ensures the deprecated
-// handleSummarizeSubgraph still produces markdown output via the trampoline.
-func TestSubgraph_LegacySummarizeSubgraph_TrampolineWorks(t *testing.T) {
-	doc := buildChainDoc()
-	srv := newTestServerWithDoc(t, doc)
-
-	text := callFlowToolText(t, srv.handleSummarizeSubgraph, map[string]any{
-		"entity_id": "ent-b",
-		"depth":     float64(1),
-	})
-	if !strings.Contains(text, "FuncB") {
-		t.Errorf("legacy trampoline should still return FuncB in markdown:\n%s", text)
 	}
 }
 

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -344,14 +344,6 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_subgraph", s.handleSubgraph))
 
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_subgraph",
-		mcpapi.WithDescription("Deprecated — use archigraph_subgraph(format=raw)."),
-		mcpapi.WithString("entity_id", mcpapi.Required()),
-		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2)),
-		mcpapi.WithAny("group"),
-		mcpapi.WithAny("cwd"),
-	), s.wrap("archigraph_get_subgraph", s.handleGetSubgraph))
-
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_paths",
 		mcpapi.WithDescription("Shortest path between two entities with confidence."),
 		mcpapi.WithString("from", mcpapi.Required()),
@@ -407,14 +399,6 @@ func (s *Server) registerTools() {
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 	), s.wrap("archigraph_impact_radius", s.handleImpactRadius))
-
-	s.MCP.AddTool(mcpapi.NewTool("archigraph_summarize_subgraph",
-		mcpapi.WithDescription("Deprecated — use archigraph_subgraph(format=markdown)."),
-		mcpapi.WithString("entity_id", mcpapi.Required()),
-		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(2)),
-		mcpapi.WithAny("group"),
-		mcpapi.WithAny("cwd"),
-	), s.wrap("archigraph_summarize_subgraph", s.handleSummarizeSubgraph))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find_dead_code",
 		mcpapi.WithDescription("Entities with no project edges — dead code or extraction gap candidates."),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -541,7 +541,6 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_graph_patterns",
 		// #1202 bonus traversal
 		"archigraph_search_entities",
-		"archigraph_get_subgraph",
 		"archigraph_find_paths",
 		// #1281 consolidated HTTP endpoint tools (was 3 tools)
 		"archigraph_endpoints",
@@ -549,7 +548,6 @@ func TestToolNameSurface(t *testing.T) {
 		"archigraph_find_callers",
 		"archigraph_find_callees",
 		"archigraph_impact_radius",
-		"archigraph_summarize_subgraph",
 		"archigraph_find_dead_code",
 		"archigraph_auth_coverage",
 		// #1659 docgen→graph repair feedback loop
@@ -597,6 +595,9 @@ func TestToolNameSurface(t *testing.T) {
 		// agent-facing tools dropped in refactor/mcp-real-3k (≤3k budget)
 		"archigraph_recent_activity",
 		"archigraph_save_finding",
+		// deprecated shims dropped in feat/drop-subgraph-shims (no real callers per #1742)
+		"archigraph_get_subgraph",
+		"archigraph_summarize_subgraph",
 		"archigraph_list_findings",
 		"archigraph_cross_links",
 	}
@@ -605,13 +606,13 @@ func TestToolNameSurface(t *testing.T) {
 			t.Errorf("expected old tool %q to NOT be registered", n)
 		}
 	}
-	// Total count: 31 (28 baseline + archigraph_module_analysis from #1384,
-	// + archigraph_apply_docgen_repairs from #1659: docgen→graph repair feedback
-	// loop — emit repair candidates in generate-docs, apply high-confidence ones
-	// immediately as enrichment resolutions, queue low-confidence for review,
-	// + archigraph_subgraph unified tool from #1754).
-	if got := len(srv.MCP.ListTools()); got != 31 {
-		t.Errorf("expected 31 registered tools, got %d", got)
+	// Total count: 29 (28 baseline + archigraph_module_analysis from #1384,
+	// + archigraph_apply_docgen_repairs from #1659,
+	// + archigraph_subgraph from #1754,
+	// - archigraph_get_subgraph shim dropped (feat/drop-subgraph-shims),
+	// - archigraph_summarize_subgraph shim dropped (feat/drop-subgraph-shims)).
+	if got := len(srv.MCP.ListTools()); got != 29 {
+		t.Errorf("expected 29 registered tools, got %d — update this count if tools are added/removed", got)
 	}
 }
 
@@ -2704,13 +2705,11 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 		"archigraph_graph_patterns":      {"group": "g", "action": "list"},
 		"archigraph_search_entities":     {"group": "g", "query": "Dashboard"},
 		"archigraph_subgraph":            {"group": "g", "entity_id": "r1::a1"},
-		"archigraph_get_subgraph":        {"group": "g", "entity_id": "r1::a1"},
 		"archigraph_find_paths":          {"group": "g", "from": "r1::a1", "to": "r1::a4"},
 		"archigraph_endpoints":           {"group": "g", "action": "definitions"},
 		"archigraph_find_callers":        {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_find_callees":        {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_impact_radius":       {"group": "g", "entity_id": "r1::a2"},
-		"archigraph_summarize_subgraph":  {"group": "g", "entity_id": "r1::a2"},
 		"archigraph_find_dead_code":      {"group": "g"},
 		"archigraph_quality_cycles":      {"group": "g"},
 		"archigraph_auth_coverage":       {"group": "g"},
@@ -2761,8 +2760,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	}
 
 	tools := srv.MCP.ListTools()
-	if len(tools) != 31 {
-		t.Errorf("expected 31 registered tools, got %d — update minimalArgs if new tools were added", len(tools))
+	if len(tools) != 29 {
+		t.Errorf("expected 29 registered tools, got %d — update minimalArgs if tools are added/removed", len(tools))
 	}
 
 	for _, st := range tools {


### PR DESCRIPTION
## Summary

Drops the two deprecated shim tools that were retained for one release after #1764 folded `archigraph_get_subgraph` and `archigraph_summarize_subgraph` into the unified `archigraph_subgraph(format=raw|markdown)` entry point.

Per #1742 benchmark research: **0 calls** to either shim tool in any real benchmark session. No external callers exist — this is internal-controlled tooling. The "keep for one release" idiom is for libraries with external users; it does not apply here.

## BREAKING CHANGE

`archigraph_get_subgraph` and `archigraph_summarize_subgraph` are **removed**.

Callers must migrate:
- `archigraph_get_subgraph(entity_id=X, depth=N)` → `archigraph_subgraph(entity_id=X, depth=N, format=raw)`
- `archigraph_summarize_subgraph(entity_id=X, depth=N)` → `archigraph_subgraph(entity_id=X, depth=N, format=markdown)`

Per #1742 research: no real caller exists. This note is documentation hygiene only.

## Handshake measurement

| State | Tools | Tokens |
|---|---|---|
| Before #1764 (shims not yet added) | 30 | ~3,248 |
| After #1764 (shims added, unified tool added) | 31 | 3,319 |
| **This PR (shims dropped)** | **29** | **3,134** |

**Net saving: −185 tokens** (target was −180; slightly exceeded due to schema description cleanup). Ceiling lowered from 3,350 → 3,200 in `budget_test.go`.

## What changed

- `internal/mcp/server.go`: Remove `archigraph_get_subgraph` and `archigraph_summarize_subgraph` `AddTool` registrations
- `internal/mcp/dashboard_tools.go`: Delete `handleGetSubgraph` trampoline function
- `internal/mcp/flow_tools.go`: Delete `handleSummarizeSubgraph` trampoline function; update file-level doc comment
- `internal/mcp/dashboard_tools_test.go`: Remove `TestHandleGetSubgraph` (tested the deleted handler)
- `internal/mcp/flow_tools_test.go`: Remove `TestSubgraph_LegacyGetSubgraph_TrampolineWorks` and `TestSubgraph_LegacySummarizeSubgraph_TrampolineWorks`; rewrite trampoline-comparison tests to exercise `handleSubgraph` directly; update `TestSummarizeSubgraph_*` → `TestSubgraph_FormatMarkdown_*`
- `internal/mcp/server_test.go`: Tool count 31 → 29; remove shims from `wantPresent`; add shims to `wantAbsent`; remove from `minimalArgs`
- `internal/mcp/budget_test.go`: Lower ceiling to 3,200; update comment with measured token count
- `internal/mcp/SCHEMA.md`: Remove deprecated index rows for both shims

## Parent

#1764 (fold PR that added the unified tool + shims)

## Test plan

- [ ] `go build ./internal/mcp/...` — clean
- [ ] `go vet ./internal/mcp/...` — clean
- [ ] `go test ./internal/mcp/...` — all pass (verified locally: ok in 1.488s)
- [ ] `TestMCPHandshakeBudget` logs `tools=29  chars=12533  tokens=3134  ceiling=3200`
- [ ] `archigraph_get_subgraph` and `archigraph_summarize_subgraph` appear in `wantAbsent` and are confirmed absent
- [ ] `archigraph_subgraph(format=raw)` and `archigraph_subgraph(format=markdown)` still pass their format-based tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)