### PR TITLE
[python] Emit config_module entities for settings.py / urls.py / wsgi.py etc. (#1775)

### DIFF
--- a/internal/extractors/python/config_module.go
+++ b/internal/extractors/python/config_module.go
@@ -1,0 +1,252 @@
+// config_module.go — supplemental pass for Python configuration-module entities.
+//
+// Many Python projects carry files that have strong architectural signal but
+// zero extractable entities from the normal walkNode pass because they consist
+// entirely (or almost entirely) of module-level assignments:
+//
+//	settings.py   — Django / DRF / Flask application settings
+//	urls.py       — Django URL dispatcher
+//	routes.py     — Flask/FastAPI route registrations defined imperatively
+//	wsgi.py       — WSGI application entry point
+//	asgi.py       — ASGI application entry point
+//	conftest.py   — pytest shared fixtures
+//	setup.py      — legacy setuptools project manifest
+//	manage.py     — Django management script (typically has a main())
+//	celery.py     — Celery application and task-routing config
+//
+// Without these entities, bench Q1 ("Where is the Django settings class for
+// upvate-core?") returns WRONG because upvate_core/settings.py contains only
+// module-level assignments (no class, no def at all) and the extractor
+// previously emitted nothing but the file entity for it.
+//
+// Issue #1775 — add a SUPPLEMENTAL fallback pass that runs AFTER the base
+// walkNode walk. If the file satisfies either:
+//
+//  1. Filename match — basename is in the canonical config-filename set
+//     (case-sensitive; Python convention).
+//  2. Content heuristic — ≥80% of top-level non-blank non-comment statements
+//     are assignment / augmented-assignment nodes.
+//
+// …and the walk produced zero semantic entities (excluding the file entity
+// and import records), emit exactly one SCOPE.Config entity with
+// subtype="config_module" and a set of Properties that describe the config
+// type, the count of top-level assignments, and the collected symbol names.
+//
+// If the file already produced semantic entities (classes, functions, …) the
+// config_module entity is STILL emitted (supplemental, not replacing).  Only
+// pure-config files usually hit criterion 2; named-file files always hit
+// criterion 1 regardless of their content (e.g. a manage.py with a main()).
+//
+// The entity is wired into extractor.go by calling emitConfigModuleEntity
+// just before TagRelationshipsLanguage.
+
+package python
+
+import (
+	"fmt"
+	"strings"
+
+	sitter "github.com/smacker/go-tree-sitter"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// configFilenames is the canonical set of Python module basenames that always
+// deserve a config_module entity regardless of their content. Case-sensitive
+// per Python import convention.
+var configFilenames = map[string]string{
+	// basename → config_type
+	"settings.py": "django_settings",
+	"urls.py":     "django_urls",
+	"routes.py":   "generic_routes",
+	"wsgi.py":     "wsgi",
+	"asgi.py":     "asgi",
+	"conftest.py": "pytest_conftest",
+	"setup.py":    "setuptools",
+	"manage.py":   "django_manage",
+	"celery.py":   "celery",
+}
+
+// configAssignmentRatio is the fraction of top-level non-blank non-comment
+// statements that must be assignments for the content heuristic to fire.
+const configAssignmentRatio = 0.80
+
+// emitConfigModuleEntity is the supplemental pass wired into Extract.
+//
+// It inspects the file and, when either the filename-match or content
+// heuristic fires, appends a single SCOPE.Config/config_module entity to
+// *out. The pass is unconditional — it runs even when walkNode already
+// produced semantic entities (the entity is supplemental, not replacing).
+//
+// Parameters:
+//
+//	root — tree-sitter parse tree root (used for the content heuristic).
+//	file — source file input (Path + Content are consulted).
+//	out  — the entity accumulator; the file entity is always at index 0.
+//	       emitConfigModuleEntity appends to it in-place.
+//
+// Returns true when a config_module entity was appended, false otherwise.
+// Callers may use the boolean to increment an OTel attribute counter.
+func emitConfigModuleEntity(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) bool {
+	base := filepathBase(file.Path)
+
+	// --- criterion 1: filename match ---
+	configType, byName := configFilenames[base]
+
+	// --- criterion 2: content heuristic ---
+	var byContent bool
+	assignCount, totalCount := countTopLevelStatements(root, file.Content)
+	if !byName && totalCount > 0 {
+		ratio := float64(assignCount) / float64(totalCount)
+		if ratio >= configAssignmentRatio {
+			byContent = true
+			configType = "generic_config"
+		}
+	}
+
+	if !byName && !byContent {
+		return false
+	}
+
+	// Collect top-level symbol names for the properties bag.
+	symbolNames := collectTopLevelAssignmentNames(root, file.Content)
+
+	// Derive the short name (strip .py suffix from base).
+	shortName := strings.TrimSuffix(base, ".py")
+
+	// Qualified name: <module>.<shortName>
+	mod := filePathToModule(file.Path)
+	qualName := shortName
+	if mod != "" {
+		qualName = mod + "." + shortName
+	}
+
+	props := map[string]string{
+		"config_type":      configType,
+		"assignment_count": fmt.Sprintf("%d", assignCount),
+	}
+	if len(symbolNames) > 0 {
+		props["top_level_symbols"] = strings.Join(symbolNames, ",")
+	}
+
+	rec := types.EntityRecord{
+		Name:          shortName,
+		QualifiedName: qualName,
+		Kind:          string(types.EntityKindConfig),
+		Subtype:       "config_module",
+		Language:      "python",
+		SourceFile:    file.Path,
+		StartLine:     1,
+		EndLine:       1,
+		Signature:     "# " + base,
+		Properties:    props,
+	}
+
+	// Wire a CONTAINS edge from the file entity so the config_module is
+	// reachable from the file in graph traversals.
+	if len(*out) > 0 {
+		(*out)[0].Relationships = append((*out)[0].Relationships, types.RelationshipRecord{
+			ToID: "scope:config:config_module:python:" + file.Path + ":" + shortName,
+			Kind: string(types.RelationshipKindContains),
+		})
+	}
+
+	*out = append(*out, rec)
+	return true
+}
+
+// countTopLevelStatements walks the immediate children of the module root node
+// and returns (assignCount, totalCount) where:
+//   - totalCount is the number of non-blank, non-comment top-level statements.
+//   - assignCount is the subset of those that are expression_statement nodes
+//     wrapping an assignment or augmented_assignment — i.e. module-level
+//     variable / constant declarations.
+//
+// Only the direct children of the module root are examined (file-level
+// scope). Nested statements inside functions, classes, or if-blocks are
+// intentionally NOT counted — we want the file-level heuristic only.
+func countTopLevelStatements(root *sitter.Node, src []byte) (assignCount, totalCount int) {
+	if root == nil {
+		return 0, 0
+	}
+	for i := 0; i < int(root.ChildCount()); i++ {
+		child := root.Child(i)
+		if child == nil {
+			continue
+		}
+		switch child.Type() {
+		case "comment", "newline", "":
+			// skip blank lines and comments
+			continue
+		}
+		totalCount++
+		if child.Type() == "expression_statement" {
+			for j := 0; j < int(child.NamedChildCount()); j++ {
+				expr := child.NamedChild(j)
+				if expr == nil {
+					continue
+				}
+				if expr.Type() == "assignment" || expr.Type() == "augmented_assignment" {
+					assignCount++
+					break
+				}
+			}
+		}
+	}
+	return assignCount, totalCount
+}
+
+// collectTopLevelAssignmentNames returns the left-hand-side identifier names
+// of every simple module-level assignment (identifier = expr). At most 50
+// names are returned to keep the Property value bounded. Dunder names are
+// excluded.
+func collectTopLevelAssignmentNames(root *sitter.Node, src []byte) []string {
+	if root == nil {
+		return nil
+	}
+	const maxSymbols = 50
+	seen := make(map[string]bool)
+	var names []string
+	for i := 0; i < int(root.ChildCount()); i++ {
+		if len(names) >= maxSymbols {
+			break
+		}
+		child := root.Child(i)
+		if child == nil || child.Type() != "expression_statement" {
+			continue
+		}
+		for j := 0; j < int(child.NamedChildCount()); j++ {
+			expr := child.NamedChild(j)
+			if expr == nil {
+				continue
+			}
+			var lhs *sitter.Node
+			switch expr.Type() {
+			case "assignment":
+				lhs = expr.ChildByFieldName("left")
+			case "augmented_assignment":
+				lhs = expr.ChildByFieldName("left")
+			default:
+				continue
+			}
+			if lhs == nil || lhs.Type() != "identifier" {
+				continue
+			}
+			name := nodeText(lhs, src)
+			if name == "" || seen[name] {
+				continue
+			}
+			// skip dunder names — they are implementation internals
+			if strings.HasPrefix(name, "__") && strings.HasSuffix(name, "__") {
+				continue
+			}
+			seen[name] = true
+			names = append(names, name)
+			if len(names) >= maxSymbols {
+				break
+			}
+		}
+	}
+	return names
+}

--- a/internal/extractors/python/config_module.go
+++ b/internal/extractors/python/config_module.go
@@ -44,6 +44,7 @@ package python
 
 import (
 	"fmt"
+	"path/filepath"
 	"strings"
 
 	sitter "github.com/smacker/go-tree-sitter"
@@ -89,7 +90,7 @@ const configAssignmentRatio = 0.80
 // Returns true when a config_module entity was appended, false otherwise.
 // Callers may use the boolean to increment an OTel attribute counter.
 func emitConfigModuleEntity(root *sitter.Node, file extractor.FileInput, out *[]types.EntityRecord) bool {
-	base := filepathBase(file.Path)
+	base := filepath.Base(filepath.FromSlash(file.Path))
 
 	// --- criterion 1: filename match ---
 	configType, byName := configFilenames[base]

--- a/internal/extractors/python/config_module_test.go
+++ b/internal/extractors/python/config_module_test.go
@@ -1,0 +1,263 @@
+package python_test
+
+// config_module_test.go — fixture tests for issue #1775 config-module entity emission.
+//
+// Three cases:
+//  1. settings.py with only module-level assignments → emits exactly one
+//     SCOPE.Config/config_module entity with config_type="django_settings".
+//  2. manage.py with a def main() → emits BOTH the function entity AND the
+//     config_module entity (supplemental, not replacing).
+//  3. utils.py with mostly def/class (non-config filename) → no config_module
+//     entity emitted.
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// findConfigModule returns the first SCOPE.Config/config_module entity in
+// entities, or nil when none is present.
+func findConfigModule(entities []types.EntityRecord) *types.EntityRecord {
+	for i := range entities {
+		e := &entities[i]
+		if e.Kind == string(types.EntityKindConfig) && e.Subtype == "config_module" {
+			return e
+		}
+	}
+	return nil
+}
+
+// countSemanticEntities returns the count of entities that are NOT the
+// file-level SCOPE.Component(file) entity and NOT import placeholder entities
+// (SCOPE.Component/module). Only SCOPE.Operation, SCOPE.Component/class,
+// SCOPE.Schema, and SCOPE.Config are counted.
+func countSemanticEntities(entities []types.EntityRecord) int {
+	n := 0
+	for _, e := range entities {
+		switch {
+		case e.Kind == "SCOPE.Component" && e.Subtype == "file":
+			continue
+		case e.Kind == "SCOPE.Component" && e.Subtype == "module":
+			continue
+		}
+		n++
+	}
+	return n
+}
+
+// TestConfigModule_SettingsPy verifies that a settings.py file consisting only
+// of module-level assignments emits a single SCOPE.Config/config_module entity
+// with the correct config_type, name, and qualified_name.
+//
+// Issue #1775 — bench Q1 regression: settings.py was previously invisible.
+func TestConfigModule_SettingsPy(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("testdata", "settings_only_assignments.py.fixture"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	tree := parse(t, src)
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+
+	fi := extractor.FileInput{
+		Path:     "upvate_core/settings.py",
+		Content:  src,
+		Language: "python",
+		Tree:     tree,
+	}
+	entities, err := ext.Extract(context.Background(), fi)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// The fixture has no class or function definitions, so the only semantic
+	// entities after the base pass should be from the config-module pass.
+	cfgEnt := findConfigModule(entities)
+	if cfgEnt == nil {
+		t.Fatal("expected a SCOPE.Config/config_module entity but found none")
+	}
+
+	// Kind must be SCOPE.Config, subtype must be config_module.
+	if cfgEnt.Kind != string(types.EntityKindConfig) {
+		t.Errorf("config_module entity Kind = %q, want %q", cfgEnt.Kind, string(types.EntityKindConfig))
+	}
+	if cfgEnt.Subtype != "config_module" {
+		t.Errorf("config_module entity Subtype = %q, want config_module", cfgEnt.Subtype)
+	}
+
+	// config_type property must be "django_settings".
+	if got := cfgEnt.Properties["config_type"]; got != "django_settings" {
+		t.Errorf("config_type = %q, want django_settings", got)
+	}
+
+	// Name should be the basename without extension.
+	if cfgEnt.Name != "settings" {
+		t.Errorf("Name = %q, want settings", cfgEnt.Name)
+	}
+
+	// QualifiedName should be module-qualified.
+	// filePathToModule("upvate_core/settings.py") → "upvate_core.settings"
+	wantQN := "upvate_core.settings.settings"
+	if cfgEnt.QualifiedName != wantQN {
+		t.Errorf("QualifiedName = %q, want %q", cfgEnt.QualifiedName, wantQN)
+	}
+
+	// StartLine should be 1 (points to the top of the file).
+	if cfgEnt.StartLine != 1 {
+		t.Errorf("StartLine = %d, want 1", cfgEnt.StartLine)
+	}
+
+	// assignment_count property should be > 0.
+	if cfgEnt.Properties["assignment_count"] == "" || cfgEnt.Properties["assignment_count"] == "0" {
+		t.Errorf("assignment_count = %q, want a positive number", cfgEnt.Properties["assignment_count"])
+	}
+
+	// top_level_symbols should include at least one known setting name.
+	symbols := cfgEnt.Properties["top_level_symbols"]
+	if symbols == "" {
+		t.Error("expected top_level_symbols to be set")
+	}
+
+	// Verify the file entity carries a CONTAINS edge to the config_module.
+	var fileEnt *types.EntityRecord
+	for i := range entities {
+		if entities[i].Kind == "SCOPE.Component" && entities[i].Subtype == "file" {
+			fileEnt = &entities[i]
+			break
+		}
+	}
+	if fileEnt == nil {
+		t.Fatal("file entity not found")
+	}
+	found := false
+	for _, rel := range fileEnt.Relationships {
+		if rel.Kind == "CONTAINS" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("file entity has no CONTAINS relationship to config_module")
+	}
+}
+
+// TestConfigModule_ManageWithMain verifies that manage.py (which contains a
+// def main() function) emits BOTH the function entity AND the config_module
+// entity — the pass is supplemental and must not suppress function extraction.
+//
+// Issue #1775 — "don't double-skip just because there's a def".
+func TestConfigModule_ManageWithMain(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("testdata", "manage_with_main.py.fixture"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	tree := parse(t, src)
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+
+	fi := extractor.FileInput{
+		Path:     "manage.py",
+		Content:  src,
+		Language: "python",
+		Tree:     tree,
+	}
+	entities, err := ext.Extract(context.Background(), fi)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	// There must be a config_module entity.
+	cfgEnt := findConfigModule(entities)
+	if cfgEnt == nil {
+		t.Fatal("expected a SCOPE.Config/config_module entity for manage.py but found none")
+	}
+	if cfgEnt.Properties["config_type"] != "django_manage" {
+		t.Errorf("config_type = %q, want django_manage", cfgEnt.Properties["config_type"])
+	}
+
+	// There must also be the function entity for main().
+	found := false
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Operation" && e.Subtype == "function" && e.Name == "main" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("expected SCOPE.Operation/function entity named 'main' but did not find it")
+	}
+
+	// config_module name/qn for a root-level file.
+	if cfgEnt.Name != "manage" {
+		t.Errorf("Name = %q, want manage", cfgEnt.Name)
+	}
+	// filePathToModule("manage.py") → "manage"
+	wantQN := "manage.manage"
+	if cfgEnt.QualifiedName != wantQN {
+		t.Errorf("QualifiedName = %q, want %q", cfgEnt.QualifiedName, wantQN)
+	}
+}
+
+// TestConfigModule_UtilsNormal verifies that a non-config-named file (utils.py)
+// whose content is mostly def/class declarations does NOT receive a
+// config_module entity.
+//
+// Issue #1775 — "A normal utils.py with no recognized config name and mostly
+// def/class → no config_module entity emitted."
+func TestConfigModule_UtilsNormal(t *testing.T) {
+	src, err := os.ReadFile(filepath.Join("testdata", "utils_normal.py.fixture"))
+	if err != nil {
+		t.Fatalf("read fixture: %v", err)
+	}
+
+	tree := parse(t, src)
+	ext, ok := extractor.Get("python")
+	if !ok {
+		t.Fatal("python extractor not registered")
+	}
+
+	fi := extractor.FileInput{
+		Path:     "app/utils/utils.py",
+		Content:  src,
+		Language: "python",
+		Tree:     tree,
+	}
+	entities, err := ext.Extract(context.Background(), fi)
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+
+	cfgEnt := findConfigModule(entities)
+	if cfgEnt != nil {
+		t.Errorf("unexpected SCOPE.Config/config_module entity for utils.py: %+v", cfgEnt)
+	}
+
+	// Sanity: functions and class are still extracted.
+	hasFunction := false
+	hasClass := false
+	for _, e := range entities {
+		if e.Kind == "SCOPE.Operation" {
+			hasFunction = true
+		}
+		if e.Kind == "SCOPE.Component" && e.Subtype == "class" {
+			hasClass = true
+		}
+	}
+	if !hasFunction {
+		t.Error("expected function entities in utils.py but found none")
+	}
+	if !hasClass {
+		t.Error("expected class entity in utils.py but found none")
+	}
+}

--- a/internal/extractors/python/extractor.go
+++ b/internal/extractors/python/extractor.go
@@ -256,12 +256,22 @@ func (e *Extractor) Extract(ctx context.Context, file extractor.FileInput) ([]ty
 	// source_module / imported_name properties.
 	resolveImportToIDs(entities)
 
+	// Issue #1775 — supplemental config-module pass.
+	// Runs after all primary extraction passes so it can observe the full
+	// entity list and emit a SCOPE.Config/config_module entity for files
+	// that would otherwise surface no semantic entities (e.g. settings.py
+	// with only module-level assignments) OR are canonical config files by
+	// name (e.g. manage.py, celery.py) even when they do carry functions.
+	// The pass never removes or modifies existing entities.
+	configModuleEmitted := emitConfigModuleEntity(root, file, &entities)
+
 	span.SetAttributes(
 		attribute.Int("entity_count", len(entities)),
 		attribute.Int("function_count", functionCount),
 		attribute.Int("class_count", classCount),
 		attribute.Int("error_pattern_count", len(errorPatterns)),
 		attribute.Int("import_count", importCount),
+		attribute.Bool("config_module_emitted", configModuleEmitted),
 	)
 	// Issue #90 — stamp Properties["language"]="python" on every embedded
 	// relationship so the resolver's per-language dynamic-pattern dispatch

--- a/internal/extractors/python/testdata/manage_with_main.py.fixture
+++ b/internal/extractors/python/testdata/manage_with_main.py.fixture
@@ -1,0 +1,12 @@
+import os
+import sys
+
+
+def main():
+    os.environ.setdefault('DJANGO_SETTINGS_MODULE', 'myproject.settings')
+    from django.core.management import execute_from_command_line
+    execute_from_command_line(sys.argv)
+
+
+if __name__ == '__main__':
+    main()

--- a/internal/extractors/python/testdata/settings_only_assignments.py.fixture
+++ b/internal/extractors/python/testdata/settings_only_assignments.py.fixture
@@ -1,0 +1,23 @@
+DEBUG = True
+
+INSTALLED_APPS = [
+    'django.contrib.admin',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'myapp',
+]
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql',
+        'NAME': 'mydb',
+    }
+}
+
+SECRET_KEY = 'super-secret-key-here'
+
+ALLOWED_HOSTS = ['*']
+
+STATIC_URL = '/static/'
+
+MEDIA_ROOT = '/var/media/'

--- a/internal/extractors/python/testdata/utils_normal.py.fixture
+++ b/internal/extractors/python/testdata/utils_normal.py.fixture
@@ -1,0 +1,14 @@
+def parse_response(data):
+    return data.get('result', None)
+
+
+def format_date(dt):
+    return dt.strftime('%Y-%m-%d')
+
+
+class DateHelper:
+    def __init__(self):
+        self.fmt = '%Y-%m-%d'
+
+    def format(self, dt):
+        return dt.strftime(self.fmt)


### PR DESCRIPTION
## What

Adds a **supplemental pass** to the Python extractor that emits a `SCOPE.Config/config_module` entity for Python files that carry strong architectural signal but produce zero semantic entities from the base walkNode pass (because they consist entirely of module-level assignments).

## Why

Bench Q1 ("Where is the Django settings class for upvate-core?") returned **WRONG** because `upvate_core/settings.py` has only module-level assignments — no class, no def — so the extractor previously emitted nothing but the file entity. Same gap existed for `urls.py`, `routes.py`, `wsgi.py`, `asgi.py`, `conftest.py`, `setup.py`, `manage.py`, `celery.py`.

## How

New file `internal/extractors/python/config_module.go` implements `emitConfigModuleEntity`, called just before `TagRelationshipsLanguage` in `Extract`. The pass fires when either criterion is met:

1. **Filename match** — basename is in the canonical config-filename set (9 names). Case-sensitive. Unconditional — fires even when the file has other entities (e.g. `manage.py` + `def main()` → both the function entity AND the config_module entity are emitted).

2. **Content heuristic** — ≥80% of top-level non-blank non-comment statements are `assignment` / `augmented_assignment` nodes. Catches project-specific config modules not in the named set.

**Entity shape:**
| Field | Value |
|-------|-------|
| Kind | `SCOPE.Config` |
| Subtype | `config_module` |
| Name | basename without `.py` (e.g. `"settings"`) |
| QualifiedName | `<module>.<name>` (e.g. `"upvate_core.settings.settings"`) |
| Properties | `config_type`, `assignment_count`, `top_level_symbols` (first 50) |
| StartLine | `1` |
| Edge | file entity → `CONTAINS` → config_module |

**config_type values:** `django_settings`, `django_urls`, `generic_routes`, `wsgi`, `asgi`, `pytest_conftest`, `setuptools`, `django_manage`, `celery`, `generic_config` (heuristic).

## Changes

- `internal/extractors/python/config_module.go` — new supplemental pass (216 lines)
- `internal/extractors/python/extractor.go` — wire `emitConfigModuleEntity` + OTel attribute `config_module_emitted`
- `internal/extractors/python/config_module_test.go` — 3 fixture tests
- `internal/extractors/python/testdata/settings_only_assignments.py.fixture`
- `internal/extractors/python/testdata/manage_with_main.py.fixture`
- `internal/extractors/python/testdata/utils_normal.py.fixture`

## Tests

```
=== RUN   TestConfigModule_SettingsPy
--- PASS: TestConfigModule_SettingsPy (0.00s)
=== RUN   TestConfigModule_ManageWithMain
--- PASS: TestConfigModule_ManageWithMain (0.00s)
=== RUN   TestConfigModule_UtilsNormal
--- PASS: TestConfigModule_UtilsNormal (0.00s)
PASS
ok  github.com/cajasmota/archigraph/internal/extractors/python  0.528s
```

All existing Python extractor tests green. Full project (`go build ./...`) clean.

**Note:** Requires reindex to take effect on existing groups. Unit-test fixtures prove the extractor logic works. Reindex wedge bug #1763 is tracked separately.

Fixes #1775