### PR TITLE
feat(mcp): add entity_id filter to archigraph_test_coverage

### DIFF
--- a/internal/graph/coverage.go
+++ b/internal/graph/coverage.go
@@ -253,8 +253,123 @@ func pct(covered, total int) float64 {
 }
 
 // ─────────────────────────────────────────────────────────────────────────────
-// Core algorithm
+// Relationship kind constants (shared by all coverage functions)
 // ─────────────────────────────────────────────────────────────────────────────
+
+const kindTests = "TESTS"
+const kindCalls = "CALLS"
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Per-entity coverage lookup (#1774)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// EntityCoverageResult is the single-entity output of ComputeEntityCoverage.
+type EntityCoverageResult struct {
+	EntityID         string   `json:"entity_id"`
+	Name             string   `json:"name"`
+	Kind             string   `json:"kind"`
+	SourceFile       string   `json:"source_file"`
+	StartLine        int      `json:"start_line"`
+	Severity         string   `json:"severity"`
+	Tested           bool     `json:"tested"`
+	CoveringTests    []string `json:"covering_tests"`
+	CoverageFraction float64  `json:"coverage_fraction"`
+}
+
+// ComputeEntityCoverage returns coverage details for a single entity ID within
+// doc. It applies the same two-phase algorithm as ComputeCoverage (real TESTS
+// edges, then synthetic fallback via CALLS) but only for the requested entity,
+// so it avoids iterating the entire graph for the output rendering step.
+//
+// Returns (result, true) when the entity is found and is a production entity.
+// Returns (nil, false) when the entity ID is not present in the document.
+// Returns a result with Tested=false and empty CoveringTests when the entity
+// exists but is a test entity or out-of-scope kind.
+func ComputeEntityCoverage(doc *Document, entityID string) (*EntityCoverageResult, bool) {
+	// ── find entity ────────────────────────────────────────────────────────────
+	var target *Entity
+	for i := range doc.Entities {
+		if doc.Entities[i].ID == entityID {
+			target = &doc.Entities[i]
+			break
+		}
+	}
+	if target == nil {
+		return nil, false
+	}
+
+	// ── index all entities needed for the two-phase algorithm ─────────────────
+	prodIDs := make(map[string]bool)
+	testIDs := make(map[string]bool)
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		switch {
+		case isProductionEntity(e):
+			prodIDs[e.ID] = true
+		case isTestEntity(e):
+			testIDs[e.ID] = true
+		}
+	}
+
+	result := &EntityCoverageResult{
+		EntityID:   entityID,
+		Name:       target.Name,
+		Kind:       target.Kind,
+		SourceFile: target.SourceFile,
+		StartLine:  target.StartLine,
+		Severity:   entitySeverity(target),
+	}
+
+	if !prodIDs[entityID] {
+		// Entity exists but is not a production entity (test entity or out-of-scope).
+		// Report it as not applicable — Tested=false, empty covering tests.
+		return result, true
+	}
+
+	// ── phase 1: collect direct TESTS edges targeting entityID ────────────────
+	coveringSet := make(map[string]bool)
+	// testCallsTo: sets of production entity IDs each test entity calls.
+	testCallsToTarget := make(map[string]bool) // test entity IDs that CALL entityID
+
+	for i := range doc.Relationships {
+		rel := &doc.Relationships[i]
+		switch strings.ToUpper(rel.Kind) {
+		case kindTests:
+			if rel.ToID == entityID && testIDs[rel.FromID] {
+				coveringSet[rel.FromID] = true
+			}
+		case kindCalls:
+			if rel.ToID == entityID && testIDs[rel.FromID] {
+				testCallsToTarget[rel.FromID] = true
+			}
+		}
+	}
+
+	// ── phase 2: synthetic TESTS from CALLS (only when no direct TESTS exist) ──
+	if len(coveringSet) == 0 {
+		for testID := range testCallsToTarget {
+			coveringSet[testID] = true
+		}
+	}
+
+	// ── build sorted covering-tests slice ─────────────────────────────────────
+	coveringTests := make([]string, 0, len(coveringSet))
+	for id := range coveringSet {
+		coveringTests = append(coveringTests, id)
+	}
+	sort.Strings(coveringTests)
+
+	tested := len(coveringTests) > 0
+	fraction := 0.0
+	if tested {
+		fraction = 1.0
+	}
+
+	result.Tested = tested
+	result.CoveringTests = coveringTests
+	result.CoverageFraction = fraction
+	return result, true
+}
 
 // ComputeCoverage analyses doc and returns a CoverageReport.
 //
@@ -301,9 +416,6 @@ func ComputeCoverage(doc *Document) *CoverageReport {
 	covered := make(map[string]int, len(prodIDs))
 	// testCallsTo: per test-entity-ID, the set of CALLS target IDs.
 	testCallsTo := make(map[string][]string)
-
-	const kindTests = "TESTS"
-	const kindCalls = "CALLS"
 
 	for i := range doc.Relationships {
 		rel := &doc.Relationships[i]

--- a/internal/graph/coverage_test.go
+++ b/internal/graph/coverage_test.go
@@ -1,6 +1,7 @@
 package graph
 
 import (
+	"fmt"
 	"testing"
 )
 
@@ -306,6 +307,136 @@ func TestComputeCoverage_HTTPEndpointHighSeverity(t *testing.T) {
 	}
 	if report.UncoveredEntities[0].Severity != "high" {
 		t.Errorf("HTTP endpoint severity want high, got %s", report.UncoveredEntities[0].Severity)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// ComputeEntityCoverage tests (#1774)
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestComputeEntityCoverage_KnownTested verifies that a production entity with
+// a direct TESTS inbound edge is reported as tested with the covering test ID.
+func TestComputeEntityCoverage_KnownTested(t *testing.T) {
+	entities := []Entity{
+		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
+		{ID: "test1", Name: "TestHandleUser", Kind: "Function", SourceFile: "handler_test.go"},
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "test1", ToID: "prod1", Kind: "TESTS"},
+	}
+	result, found := ComputeEntityCoverage(makeDoc(entities, rels), "prod1")
+	if !found {
+		t.Fatal("want found=true, got false")
+	}
+	if !result.Tested {
+		t.Errorf("want Tested=true, got false")
+	}
+	if result.CoverageFraction != 1.0 {
+		t.Errorf("want CoverageFraction=1.0, got %f", result.CoverageFraction)
+	}
+	if len(result.CoveringTests) != 1 || result.CoveringTests[0] != "test1" {
+		t.Errorf("want CoveringTests=[test1], got %v", result.CoveringTests)
+	}
+}
+
+// TestComputeEntityCoverage_KnownUntested verifies that a production entity
+// with no inbound TESTS edges (and no CALLS fallback) is reported as untested.
+func TestComputeEntityCoverage_KnownUntested(t *testing.T) {
+	entities := []Entity{
+		{ID: "prod1", Name: "UntestedFn", Kind: "Function", SourceFile: "lib.go"},
+		{ID: "test1", Name: "TestOther", Kind: "Function", SourceFile: "other_test.go"},
+	}
+	// No TESTS or CALLS edges to prod1.
+	result, found := ComputeEntityCoverage(makeDoc(entities, nil), "prod1")
+	if !found {
+		t.Fatal("want found=true, got false")
+	}
+	if result.Tested {
+		t.Errorf("want Tested=false, got true")
+	}
+	if result.CoverageFraction != 0.0 {
+		t.Errorf("want CoverageFraction=0.0, got %f", result.CoverageFraction)
+	}
+	if len(result.CoveringTests) != 0 {
+		t.Errorf("want CoveringTests=[], got %v", result.CoveringTests)
+	}
+}
+
+// TestComputeEntityCoverage_Unknown verifies that an unknown entity_id returns
+// found=false (triggering "entity not found" in the MCP handler).
+func TestComputeEntityCoverage_Unknown(t *testing.T) {
+	entities := []Entity{
+		{ID: "prod1", Name: "HandleUser", Kind: "Function", SourceFile: "handler.go"},
+	}
+	result, found := ComputeEntityCoverage(makeDoc(entities, nil), "does-not-exist")
+	if found {
+		t.Errorf("want found=false for unknown entity, got result=%+v", result)
+	}
+	if result != nil {
+		t.Errorf("want nil result for unknown entity, got %+v", result)
+	}
+}
+
+// TestComputeEntityCoverage_SyntheticCALLS verifies that the synthetic CALLS
+// fallback also works for the per-entity path.
+func TestComputeEntityCoverage_SyntheticCALLS(t *testing.T) {
+	entities := []Entity{
+		{ID: "t1", Name: "TestFoo", Kind: "Function", SourceFile: "foo_test.go"},
+		{ID: "p1", Name: "Foo", Kind: "Function", SourceFile: "foo.go"},
+	}
+	// No TESTS edge — only CALLS from test to prod.
+	rels := []Relationship{
+		{ID: "c1", FromID: "t1", ToID: "p1", Kind: "CALLS"},
+	}
+	result, found := ComputeEntityCoverage(makeDoc(entities, rels), "p1")
+	if !found {
+		t.Fatal("want found=true, got false")
+	}
+	if !result.Tested {
+		t.Errorf("want Tested=true (synthetic CALLS fallback), got false")
+	}
+	if len(result.CoveringTests) != 1 || result.CoveringTests[0] != "t1" {
+		t.Errorf("want CoveringTests=[t1], got %v", result.CoveringTests)
+	}
+}
+
+// TestComputeEntityCoverage_OutputSize verifies that the result struct is
+// compact — the covering_tests slice alone is bounded by the actual test count,
+// not the whole entity list. (Token-budget guard from #1774 spec.)
+func TestComputeEntityCoverage_OutputSize(t *testing.T) {
+	// Build 100 test entities and 100 production entities; only one covers prod1.
+	entities := []Entity{
+		{ID: "prod1", Name: "TargetFn", Kind: "Function", SourceFile: "target.go"},
+	}
+	for i := 0; i < 100; i++ {
+		id := fmt.Sprintf("prod%d", i+2)
+		entities = append(entities, Entity{
+			ID: id, Name: "OtherFn", Kind: "Function", SourceFile: "other.go",
+		})
+	}
+	// One test covers prod1; 99 other tests cover nothing relevant.
+	entities = append(entities, Entity{
+		ID: "test1", Name: "TestTarget", Kind: "Function", SourceFile: "target_test.go",
+	})
+	for i := 0; i < 99; i++ {
+		entities = append(entities, Entity{
+			ID: fmt.Sprintf("testother%d", i), Name: "TestOther", Kind: "Function",
+			SourceFile: "other_test.go",
+		})
+	}
+	rels := []Relationship{
+		{ID: "r1", FromID: "test1", ToID: "prod1", Kind: "TESTS"},
+	}
+	result, found := ComputeEntityCoverage(makeDoc(entities, rels), "prod1")
+	if !found {
+		t.Fatal("want found=true")
+	}
+	if !result.Tested {
+		t.Errorf("want Tested=true")
+	}
+	// Only the one covering test should appear — not all 100.
+	if len(result.CoveringTests) != 1 {
+		t.Errorf("want 1 covering test, got %d: %v", len(result.CoveringTests), result.CoveringTests)
 	}
 }
 

--- a/internal/mcp/coverage_tools.go
+++ b/internal/mcp/coverage_tools.go
@@ -6,6 +6,9 @@
 //	resolved group. Identifies production entities that have no TESTS edge
 //	inbound (untested) and ranks them by severity.
 //
+// When entity_id is provided (#1774), returns a single-record focused answer:
+// "is THIS entity tested?" — skips the full dump-all path entirely.
+//
 // Severity rules:
 //
 //	high   — HTTP endpoint without tests (unprotected surface area)
@@ -27,6 +30,15 @@ func (s *Server) handleTestCoverage(ctx context.Context, req mcpapi.CallToolRequ
 	_, lg, toolErr := s.resolveAndGroup(req)
 	if toolErr != nil {
 		return toolErr, nil
+	}
+
+	// ── entity_id fast-path (#1774) ───────────────────────────────────────────
+	// When entity_id is provided, return a focused single-record answer instead
+	// of the full dump. This avoids the O(all-entities) output rendering and
+	// answers "is THIS entity tested?" in < 500 bytes.
+	entityID := argString(req, "entity_id", "")
+	if entityID != "" {
+		return s.handleTestCoverageEntity(lg, entityID)
 	}
 
 	repoFilter := argStringSlice(req, "repo_filter")
@@ -173,6 +185,69 @@ func (s *Server) handleTestCoverage(ctx context.Context, req mcpapi.CallToolRequ
 	}
 
 	return mcpapi.NewToolResultText(out), nil
+}
+
+// handleTestCoverageEntity is the entity_id fast-path for handleTestCoverage
+// (#1774). It searches all repos in the loaded group for the entity, runs the
+// two-phase coverage algorithm restricted to that single entity, and returns a
+// compact single-record result.
+func (s *Server) handleTestCoverageEntity(lg *LoadedGroup, entityID string) (*mcpapi.CallToolResult, error) {
+	// Search repos in sorted order for deterministic behaviour.
+	repoNames := make([]string, 0, len(lg.Repos))
+	for name := range lg.Repos {
+		repoNames = append(repoNames, name)
+	}
+	sort.Strings(repoNames)
+
+	for _, name := range repoNames {
+		rd := lg.Repos[name]
+		if rd == nil || rd.Doc == nil {
+			continue
+		}
+
+		result, found := graph.ComputeEntityCoverage(rd.Doc, entityID)
+		if !found {
+			continue
+		}
+
+		// Render compact single-record output.
+		testedStr := "no"
+		if result.Tested {
+			testedStr = "yes"
+		}
+		out := fmt.Sprintf(
+			"## Test Coverage — entity %q\n\n"+
+				"entity_id         : %s\n"+
+				"name              : %s\n"+
+				"kind              : %s\n"+
+				"source_file       : %s (line %d)\n"+
+				"severity          : %s\n"+
+				"tested            : %s\n"+
+				"coverage_fraction : %.2f\n"+
+				"covering_tests    : %d\n",
+			entityID,
+			result.EntityID,
+			result.Name,
+			result.Kind,
+			result.SourceFile, result.StartLine,
+			result.Severity,
+			testedStr,
+			result.CoverageFraction,
+			len(result.CoveringTests),
+		)
+		if len(result.CoveringTests) > 0 {
+			out += "\n### Covering test entity IDs\n\n"
+			for _, tid := range result.CoveringTests {
+				out += "- " + tid + "\n"
+			}
+		}
+		return mcpapi.NewToolResultText(out), nil
+	}
+
+	// Entity not found in any repo.
+	return mcpapi.NewToolResultText(
+		fmt.Sprintf("entity not found: %q — check the entity_id is correct and the group is fully loaded.", entityID),
+	), nil
 }
 
 // repoMatchesSlice returns true when slug matches any entry in filter.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -433,8 +433,10 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_auth_coverage", s.handleAuthCoverage))
 
 	// #1323: test-coverage graph — link Test entities to the code they exercise.
+	// #1774: entity_id param added for single-entity focused queries.
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_test_coverage",
 		mcpapi.WithDescription("Find production entities with no TESTS edge, ranked by severity."),
+		mcpapi.WithString("entity_id"),
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("severity"),
 		mcpapi.WithNumber("limit", mcpapi.DefaultNumber(100)),


### PR DESCRIPTION
## Why

`archigraph_test_coverage` dumped 100 untested entities to answer a single coverage question (Q7 in iter5 quality bench) → **18× token ratio vs grep**. Most callers want "is THIS entity tested?" not "list everything untested in the repo." This was the dominant driver of iter5's 3.72× overall token blowout.

## What

### 1 — `internal/graph/coverage.go`
- Added package-level `kindTests` / `kindCalls` constants (previously local inside `ComputeCoverage`).
- New `EntityCoverageResult` type: `{entity_id, name, kind, source_file, start_line, severity, tested, covering_tests, coverage_fraction}`.
- New `ComputeEntityCoverage(doc, entityID)` function: same two-phase algorithm as `ComputeCoverage` (real TESTS edges then synthetic CALLS fallback) but scoped to one entity. Returns `(nil, false)` when entity ID is not in the document, returns `(result, true)` otherwise.

### 2 — `internal/graph/coverage_test.go`
Five new unit tests:
- `TestComputeEntityCoverage_KnownTested` — entity with TESTS inbound → `Tested=true`, covering test ID returned
- `TestComputeEntityCoverage_KnownUntested` — entity with no TESTS/CALLS → `Tested=false`, empty slice
- `TestComputeEntityCoverage_Unknown` — unknown entity_id → `found=false, result=nil`
- `TestComputeEntityCoverage_SyntheticCALLS` — no TESTS edge but CALLS fallback covers the entity
- `TestComputeEntityCoverage_OutputSize` — 100 entities in doc, only 1 covering test returned (token-budget guard)

### 3 — `internal/mcp/coverage_tools.go`
- New `entity_id` fast-path at the top of `handleTestCoverage`: reads `entity_id`; when non-empty, delegates to `handleTestCoverageEntity` and returns immediately — skips the dump-all path entirely.
- New `handleTestCoverageEntity(lg, entityID)` helper: searches repos in sorted order, calls `ComputeEntityCoverage`, renders compact ≤ ~300-byte single-record output. Returns "entity not found: …" error string (not silent empty) when the ID is unknown across all repos.
- Default dump-all path (no `entity_id`) is **unchanged**.

### 4 — `internal/mcp/server.go`
- Declared `entity_id` (string) in the JSON-Schema for `archigraph_test_coverage`. This is a primary filter — agents need to see it in the handshake. The #1639 schema-shrink discipline applies only to optional details, not to feature-defining params.

## Token impact

| Call form | Output size |
|-----------|-------------|
| `test_coverage()` dump-all (100 entities) | ~10 KB+ |
| `test_coverage(entity_id="<id>")` | ~300 bytes |

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/graph/... ./internal/mcp/...` — clean
- [x] `go test ./internal/graph/... -run TestComputeEntityCoverage` — 5/5 pass
- [x] `go test ./internal/graph/... -run TestComputeCoverage` — 10/10 pass (regression check)
- [x] `go test ./internal/mcp/... -run TestElapsedMSCoverageAllTools` — pass (smoke, includes test_coverage without entity_id)
- [x] `go test ./internal/mcp/...` — full suite pass (1.585s)

## Constraints respected

- Dump-all path response shape unchanged — only new behaviour added under new param.
- `find_dead_code`, `impact_radius`, `quality_cycles` not touched.
- No overlap with #1773 (`tools.go` get_source).

Fixes #1774

🤖 Generated with [Claude Code](https://claude.com/claude-code)