### PR TITLE
P0 [#1781 cross-platform recovery] split walk/gitignore.go into _unix.go/_windows.go (Windows vet was broken since #1729)

### DIFF
--- a/internal/daemon/walk/fsevents_hang_test.go
+++ b/internal/daemon/walk/fsevents_hang_test.go
@@ -1,3 +1,5 @@
+//go:build darwin || linux
+
 // fsevents_hang_test.go — #1721 regression coverage.
 //
 // We simulate the macOS fsevents kernel stall by pointing ParseIgnoreFile and
@@ -5,6 +7,9 @@
 // open(2) blocks until a writer connects — the writer never connects here, so
 // without the deadline fix both callers would block indefinitely. After the
 // fix they must return within the test's timeout budget.
+//
+// Build-constrained to darwin||linux: syscall.Mkfifo is a POSIX-only syscall
+// and does not exist on Windows.
 package walk
 
 import (

--- a/internal/daemon/walk/gitignore.go
+++ b/internal/daemon/walk/gitignore.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
-	"syscall"
 	"time"
 )
 
@@ -45,118 +44,6 @@ var ErrIgnoreFileTimeout = errors.New("walk: ParseIgnoreFile timed out (fsevents
 // but the vast majority complete in microseconds, so the semaphore is only
 // load-bearing when something is genuinely wedged. 64 is plenty.
 var openSlotSem = make(chan struct{}, 64)
-
-// openWithDeadline opens path and returns the file or an error.
-//
-// #1723: the previous version of this function spawned an unbounded worker
-// goroutine per call and "let it leak" on timeout. In real reindexes
-// (especially when the daemon is fsnotify-watching the same tree being
-// walked) thousands of workers accumulated, the kernel ran out of resources,
-// and the daemon became unresponsive. The new implementation:
-//
-//  1. lstats the path first — quick, non-blocking, and lets us bail out
-//     immediately if the path doesn't exist or isn't a regular file.
-//     Ignore files MUST be regular files; anything else (FIFO, socket,
-//     device) is treated as inaccessible (ErrIgnoreFileTimeout).
-//  2. uses O_NONBLOCK on the open(2) — POSIX guarantees this returns
-//     without blocking. On macOS fsevents kernel stalls (issue #1721) this
-//     is the actual fix: the open returns immediately instead of wedging.
-//  3. caps the total concurrent worker-goroutine count via a semaphore.
-//     If the semaphore is saturated (because earlier workers wedged on a
-//     non-O_NONBLOCK-honouring path) we surface ErrIgnoreFileTimeout
-//     immediately — no further leaks possible.
-//  4. still wraps the syscall in a deadline-bounded goroutine, but the
-//     bounded semaphore guarantees the leak count is at most
-//     cap(openSlotSem).
-//
-// The returned *os.File is ready for normal blocking reads (we clear
-// O_NONBLOCK after a successful open). Callers must Close it.
-func openWithDeadline(path string, timeout time.Duration) (*os.File, error) {
-	// Step 1: lstat. If the path doesn't exist or isn't a regular file
-	// we don't need to open it at all.
-	fi, err := os.Lstat(path)
-	if err != nil {
-		// Preserve os.IsNotExist semantics for callers.
-		return nil, err
-	}
-	if !fi.Mode().IsRegular() {
-		// Special files (FIFO, socket, device, symlink-to-nothing) cannot
-		// be ignore files. Treat as inaccessible — same as a kernel stall.
-		return nil, ErrIgnoreFileTimeout
-	}
-
-	// Step 2: try to acquire a worker slot without blocking. If we can't,
-	// the daemon is already saturated with leaked workers — bail rather
-	// than make it worse.
-	select {
-	case openSlotSem <- struct{}{}:
-	default:
-		return nil, ErrIgnoreFileTimeout
-	}
-
-	type result struct {
-		f   *os.File
-		err error
-	}
-	ch := make(chan result, 1)
-	go func() {
-		// Step 3: non-blocking open. POSIX guarantees open(2) with
-		// O_NONBLOCK returns without blocking — this is the actual leak
-		// fix for the macOS fsevents kernel-stall case.
-		fd, oerr := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
-		if oerr != nil {
-			// EWOULDBLOCK / EAGAIN means "would block" — treat as stall.
-			if errors.Is(oerr, syscall.EWOULDBLOCK) || errors.Is(oerr, syscall.EAGAIN) {
-				ch <- result{err: ErrIgnoreFileTimeout}
-				<-openSlotSem
-				return
-			}
-			ch <- result{err: &os.PathError{Op: "open", Path: path, Err: oerr}}
-			<-openSlotSem
-			return
-		}
-
-		// Clear O_NONBLOCK so subsequent Read(2) calls behave normally on
-		// the returned file. Failure here is non-fatal; regular files
-		// don't actually need this cleared but we do it for hygiene.
-		if flags, ferr := fcntlGetFl(fd); ferr == nil && (flags&syscall.O_NONBLOCK) != 0 {
-			_ = fcntlSetFl(fd, flags&^syscall.O_NONBLOCK)
-		}
-
-		f := os.NewFile(uintptr(fd), path)
-		ch <- result{f: f}
-		<-openSlotSem
-	}()
-
-	select {
-	case r := <-ch:
-		return r.f, r.err
-	case <-time.After(timeout):
-		// Defensive: open with O_NONBLOCK should never block, but if the
-		// platform/kernel doesn't honour it we still cap total leaks via
-		// the semaphore. The slot will be released by the worker when it
-		// eventually unblocks.
-		return nil, ErrIgnoreFileTimeout
-	}
-}
-
-// fcntlGetFl wraps fcntl(fd, F_GETFL).
-func fcntlGetFl(fd int) (int, error) {
-	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
-	if errno != 0 {
-		return 0, errno
-	}
-	return int(flags), nil
-}
-
-// fcntlSetFl wraps fcntl(fd, F_SETFL, flags).
-func fcntlSetFl(fd int, flags int) error {
-	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_SETFL), uintptr(flags))
-	if errno != 0 {
-		return errno
-	}
-	return nil
-}
 
 // parseIgnoreReader parses gitignore-syntax rules from r, anchored to dir
 // with the given source label. It is the I/O-free core of ParseIgnoreFile.

--- a/internal/daemon/walk/gitignore_unix.go
+++ b/internal/daemon/walk/gitignore_unix.go
@@ -1,0 +1,114 @@
+//go:build darwin || linux
+
+package walk
+
+// gitignore_unix.go — non-blocking open(2) implementation of openWithDeadline.
+//
+// #1729 introduced O_NONBLOCK + fcntl(F_GETFL/F_SETFL) to defend against
+// macOS fsevents kernel stalls. These syscalls are Unix-only; the Windows
+// counterpart lives in gitignore_windows.go and uses plain os.Open (Windows
+// has no fsevents stall problem).
+//
+// Ported to a platform split in response to #1781 (CI cross-platform gate):
+// the original single-file implementation broke `GOOS=windows go vet` because
+// syscall.SYS_FCNTL, syscall.F_GETFL, syscall.F_SETFL, and the Handle→int
+// conversion are undefined on Windows.
+
+import (
+	"errors"
+	"os"
+	"syscall"
+	"time"
+)
+
+// openWithDeadline opens path and returns the file or an error.
+//
+// See the full design commentary in gitignore.go (ParseIgnoreFile).
+// This implementation uses O_NONBLOCK + fcntl to defend against macOS
+// fsevents kernel stalls (#1721, #1723, #1729).
+func openWithDeadline(path string, timeout time.Duration) (*os.File, error) {
+	// Step 1: lstat. If the path doesn't exist or isn't a regular file
+	// we don't need to open it at all.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		// Preserve os.IsNotExist semantics for callers.
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		// Special files (FIFO, socket, device, symlink-to-nothing) cannot
+		// be ignore files. Treat as inaccessible — same as a kernel stall.
+		return nil, ErrIgnoreFileTimeout
+	}
+
+	// Step 2: try to acquire a worker slot without blocking. If we can't,
+	// the daemon is already saturated with leaked workers — bail rather
+	// than make it worse.
+	select {
+	case openSlotSem <- struct{}{}:
+	default:
+		return nil, ErrIgnoreFileTimeout
+	}
+
+	type result struct {
+		f   *os.File
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		// Step 3: non-blocking open. POSIX guarantees open(2) with
+		// O_NONBLOCK returns without blocking — this is the actual leak
+		// fix for the macOS fsevents kernel-stall case.
+		fd, oerr := syscall.Open(path, syscall.O_RDONLY|syscall.O_NONBLOCK|syscall.O_CLOEXEC, 0)
+		if oerr != nil {
+			// EWOULDBLOCK / EAGAIN means "would block" — treat as stall.
+			if errors.Is(oerr, syscall.EWOULDBLOCK) || errors.Is(oerr, syscall.EAGAIN) {
+				ch <- result{err: ErrIgnoreFileTimeout}
+				<-openSlotSem
+				return
+			}
+			ch <- result{err: &os.PathError{Op: "open", Path: path, Err: oerr}}
+			<-openSlotSem
+			return
+		}
+
+		// Clear O_NONBLOCK so subsequent Read(2) calls behave normally on
+		// the returned file. Failure here is non-fatal; regular files
+		// don't actually need this cleared but we do it for hygiene.
+		if flags, ferr := fcntlGetFl(int(fd)); ferr == nil && (flags&syscall.O_NONBLOCK) != 0 {
+			_ = fcntlSetFl(int(fd), flags&^syscall.O_NONBLOCK)
+		}
+
+		f := os.NewFile(uintptr(fd), path)
+		ch <- result{f: f}
+		<-openSlotSem
+	}()
+
+	select {
+	case r := <-ch:
+		return r.f, r.err
+	case <-time.After(timeout):
+		// Defensive: open with O_NONBLOCK should never block, but if the
+		// platform/kernel doesn't honour it we still cap total leaks via
+		// the semaphore. The slot will be released by the worker when it
+		// eventually unblocks.
+		return nil, ErrIgnoreFileTimeout
+	}
+}
+
+// fcntlGetFl wraps fcntl(fd, F_GETFL).
+func fcntlGetFl(fd int) (int, error) {
+	flags, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_GETFL), 0)
+	if errno != 0 {
+		return 0, errno
+	}
+	return int(flags), nil
+}
+
+// fcntlSetFl wraps fcntl(fd, F_SETFL, flags).
+func fcntlSetFl(fd int, flags int) error {
+	_, _, errno := syscall.Syscall(syscall.SYS_FCNTL, uintptr(fd), uintptr(syscall.F_SETFL), uintptr(flags))
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}

--- a/internal/daemon/walk/gitignore_windows.go
+++ b/internal/daemon/walk/gitignore_windows.go
@@ -1,0 +1,65 @@
+//go:build windows
+
+package walk
+
+// gitignore_windows.go — plain os.Open fallback for openWithDeadline on Windows.
+//
+// Windows does not have the fsevents / kqueue kernel-stall behaviour that
+// motivated the O_NONBLOCK + fcntl dance in gitignore_unix.go (#1729).
+// Plain os.Open is sufficient; the 5s context deadline in ParseIgnoreFile
+// remains the only safety net, which is fine on Windows.
+//
+// The 64-slot openSlotSem semaphore is still honoured here to bound the
+// maximum number of concurrently-outstanding open goroutines (callers of
+// ParseIgnoreFile expect the same concurrency-control contract regardless of
+// platform).
+
+import (
+	"os"
+	"time"
+)
+
+// openWithDeadline opens path and returns the file or an error.
+//
+// Windows implementation: plain os.Open inside a semaphore-bounded goroutine.
+// There is no O_NONBLOCK dance because Windows does not suffer the macOS
+// fsevents kernel-stall problem that motivated the Unix version.
+func openWithDeadline(path string, timeout time.Duration) (*os.File, error) {
+	// Step 1: lstat. Quick bail for non-existent or non-regular paths.
+	fi, err := os.Lstat(path)
+	if err != nil {
+		return nil, err
+	}
+	if !fi.Mode().IsRegular() {
+		return nil, ErrIgnoreFileTimeout
+	}
+
+	// Step 2: semaphore — bail early if already saturated.
+	select {
+	case openSlotSem <- struct{}{}:
+	default:
+		return nil, ErrIgnoreFileTimeout
+	}
+
+	type result struct {
+		f   *os.File
+		err error
+	}
+	ch := make(chan result, 1)
+	go func() {
+		f, oerr := os.Open(path)
+		if oerr != nil {
+			ch <- result{err: oerr}
+		} else {
+			ch <- result{f: f}
+		}
+		<-openSlotSem
+	}()
+
+	select {
+	case r := <-ch:
+		return r.f, r.err
+	case <-time.After(timeout):
+		return nil, ErrIgnoreFileTimeout
+	}
+}

--- a/internal/daemon/walk/openleak_test.go
+++ b/internal/daemon/walk/openleak_test.go
@@ -1,3 +1,5 @@
+//go:build darwin || linux
+
 // openleak_test.go — #1723 regression coverage.
 //
 // #1722 (cf113fd) fixed the *caller* hang by wrapping os.Open in a goroutine
@@ -8,6 +10,11 @@
 //
 // These tests force ParseIgnoreFile to hit the deadline path repeatedly and
 // confirm the goroutine count stays bounded — i.e. no leak per call.
+//
+// Build-constrained to darwin||linux: the FIFO-based leak simulation and the
+// syscall.Mkfifo / syscall.Write helpers are POSIX-only. Windows uses a
+// separate test (openleak_windows_test.go) that exercises the plain os.Open
+// fallback path.
 package walk
 
 import (

--- a/internal/daemon/walk/openleak_windows_test.go
+++ b/internal/daemon/walk/openleak_windows_test.go
@@ -1,0 +1,151 @@
+//go:build windows
+
+package walk
+
+// openleak_windows_test.go — goroutine-leak and concurrency tests for the
+// Windows os.Open fallback path in gitignore_windows.go.
+//
+// The Unix tests (openleak_test.go) use POSIX FIFOs to simulate a blocked
+// open(2). On Windows we can't do that, so we exercise the happy path and
+// the semaphore-under-concurrency path instead.
+//
+// The key invariant we test: concurrent calls to ParseIgnoreFile do NOT
+// accumulate goroutines. The 64-slot openSlotSem semaphore must ensure
+// that goroutine count stays bounded even under parallel load.
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+// TestOpenWithDeadline_Windows_RegularFileFastPath confirms that ParseIgnoreFile
+// correctly reads a regular .gitignore on Windows using the os.Open fallback.
+func TestOpenWithDeadline_Windows_RegularFileFastPath(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".gitignore")
+	body := "node_modules/\n*.log\n"
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	ig, err := ParseIgnoreFile("", p, ".gitignore")
+	if err != nil {
+		t.Fatalf("ParseIgnoreFile: %v", err)
+	}
+	if ig == nil || len(ig.patterns) != 2 {
+		t.Fatalf("expected 2 patterns, got %#v", ig)
+	}
+}
+
+// TestOpenWithDeadline_Windows_NoGoroutineLeak confirms that repeated
+// ParseIgnoreFile calls (on a real regular file) do not accumulate goroutines.
+// This mirrors TestOpenWithDeadline_NoGoroutineLeak from openleak_test.go but
+// uses a real file instead of a FIFO.
+func TestOpenWithDeadline_Windows_NoGoroutineLeak(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(p, []byte("dist/\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	const iterations = 200
+	for i := 0; i < iterations; i++ {
+		ig, err := ParseIgnoreFile("", p, ".gitignore")
+		if err != nil {
+			t.Fatalf("iter %d: unexpected error: %v", i, err)
+		}
+		if ig == nil {
+			t.Fatalf("iter %d: expected non-nil IgnoreFile", i)
+		}
+	}
+
+	runtime.GC()
+	time.Sleep(100 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	const slack = 5
+	if after > baseline+slack {
+		t.Fatalf("goroutine leak: baseline=%d after=%d iterations=%d slack=%d",
+			baseline, after, iterations, slack)
+	}
+	t.Logf("baseline=%d after=%d iterations=%d (no leak)", baseline, after, iterations)
+}
+
+// TestOpenWithDeadline_Windows_NoLeakUnderConcurrency hammers ParseIgnoreFile
+// from multiple goroutines simultaneously and verifies the goroutine count
+// does not grow without bound.
+func TestOpenWithDeadline_Windows_NoLeakUnderConcurrency(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(p, []byte("vendor/\n__pycache__/\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	runtime.GC()
+	time.Sleep(50 * time.Millisecond)
+	baseline := runtime.NumGoroutine()
+
+	const workers = 16
+	const perWorker = 50
+	var wg sync.WaitGroup
+	for w := 0; w < workers; w++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < perWorker; i++ {
+				_, _ = ParseIgnoreFile("", p, ".gitignore")
+			}
+		}()
+	}
+	wg.Wait()
+
+	runtime.GC()
+	time.Sleep(150 * time.Millisecond)
+	after := runtime.NumGoroutine()
+
+	const slack = 10
+	if after > baseline+slack {
+		t.Fatalf("goroutine leak under concurrency: baseline=%d after=%d total_calls=%d",
+			baseline, after, workers*perWorker)
+	}
+	t.Logf("baseline=%d after=%d total_calls=%d (no leak)", baseline, after, workers*perWorker)
+}
+
+// TestOpenWithDeadline_Windows_SemaphoreSaturation confirms that when all
+// semaphore slots are held, ParseIgnoreFile returns ErrIgnoreFileTimeout
+// immediately rather than blocking or leaking an additional goroutine.
+func TestOpenWithDeadline_Windows_SemaphoreSaturation(t *testing.T) {
+	dir := t.TempDir()
+	p := filepath.Join(dir, ".gitignore")
+	if err := os.WriteFile(p, []byte("dist/\n"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Saturate the semaphore manually.
+	for i := 0; i < cap(openSlotSem); i++ {
+		openSlotSem <- struct{}{}
+	}
+	defer func() {
+		// Drain the semaphore after the test.
+		for i := 0; i < cap(openSlotSem); i++ {
+			<-openSlotSem
+		}
+	}()
+
+	ig, err := ParseIgnoreFile("", p, ".gitignore")
+	if err != ErrIgnoreFileTimeout {
+		t.Fatalf("expected ErrIgnoreFileTimeout when semaphore saturated, got err=%v ig=%v", err, ig)
+	}
+	if ig == nil {
+		t.Fatal("expected non-nil IgnoreFile on semaphore saturation")
+	}
+	t.Log("semaphore saturation correctly returns ErrIgnoreFileTimeout")
+}


### PR DESCRIPTION
## Problem

`GOOS=windows GOARCH=amd64 go vet ./internal/daemon/walk/...` has been broken since #1729 landed. The fix in #1729 used `syscall.SYS_FCNTL`, `syscall.F_GETFL`, `syscall.F_SETFL`, and a `syscall.Handle`→`int` conversion — all of which are undefined on Windows. The file had no build tag so the Windows compiler tried to parse them and failed.

**Before this PR (`GOOS=windows go vet ./internal/daemon/walk/...`):**
```
# github.com/cajasmota/archigraph/internal/daemon/walk
vet: internal/daemon/walk/gitignore.go:122:32: cannot use fd (variable of uintptr type syscall.Handle) as int value in argument to fcntlGetFl
vet: internal/daemon/walk/gitignore.go:123:19: cannot use fd as int
vet: internal/daemon/walk/gitignore.go:145:45: undefined: syscall.SYS_FCNTL
vet: internal/daemon/walk/gitignore.go:145:85: undefined: syscall.F_GETFL
vet: internal/daemon/walk/gitignore.go:154:41: undefined: syscall.SYS_FCNTL
vet: internal/daemon/walk/gitignore.go:154:81: undefined: syscall.F_SETFL
```

**After this PR (`GOOS=windows go vet ./internal/daemon/walk/...`):**
```
(no output — GREEN)
```

The failure was hidden because CI's cross-platform gate was disabled until #1781 re-enabled it.

## Solution

Follows the exact pattern from #1780 (`internal/mcp/read_source_unix.go` + `read_source_windows.go`):

| File | Build tag | Content |
|------|-----------|---------|
| `gitignore.go` | _(none — all platforms)_ | Structs, `ParseIgnoreFile`, `IgnoreStack`, pattern matching helpers, `openSlotSem` semaphore, `ErrIgnoreFileTimeout` |
| `gitignore_unix.go` | `darwin \|\| linux` | `openWithDeadline` with O_NONBLOCK + `fcntlGetFl`/`fcntlSetFl` — the #1729 implementation, unchanged in behaviour |
| `gitignore_windows.go` | `windows` | `openWithDeadline` using plain `os.Open` inside the same 64-slot semaphore — Windows has no fsevents kernel-stall problem |

Two test files that use `syscall.Mkfifo` (POSIX-only) also needed build tags added:
- `fsevents_hang_test.go` → `//go:build darwin || linux`
- `openleak_test.go` → `//go:build darwin || linux`

A new `openleak_windows_test.go` provides Windows-specific goroutine-leak, concurrency, and semaphore-saturation coverage.

## Verification

```
# macOS
go build ./internal/daemon/walk/...                              GREEN
go vet  ./internal/daemon/walk/...                              GREEN
go test ./internal/daemon/walk/... (29 tests, all PASS)

# Cross-compile
GOOS=windows GOARCH=amd64 go build ./internal/daemon/walk/...  GREEN
GOOS=windows GOARCH=amd64 go vet  ./internal/daemon/walk/...  GREEN  ← was FAIL
GOOS=linux   GOARCH=amd64 go build ./internal/daemon/walk/...  GREEN
GOOS=linux   GOARCH=amd64 go vet  ./internal/daemon/walk/...  GREEN
```

Unix behaviour is **completely unchanged** — only the platform split is new.

## References

- #1729 — introduced the Unix-only syscalls (the root cause)
- #1780 — `read_source` platform split (the reference pattern used here)
- #1781 — CI cross-platform gate re-enabled (surfaced this failure)

🤖 Generated with [Claude Code](https://claude.com/claude-code)