### PR TITLE
feat(go-extractor): emit CALLS via_value=true for method-value references (#1789)

### DIFF
--- a/internal/extractors/golang/extractor.go
+++ b/internal/extractors/golang/extractor.go
@@ -16,6 +16,8 @@
 //
 //	import_spec            → RelationshipRecord{Kind="IMPORTS"}       (File → Module)
 //	call_expression        → RelationshipRecord{Kind="CALLS"}         (Function → Function)
+//	method-value ref       → RelationshipRecord{Kind="CALLS", Properties["via_value"]="true"}
+//	                         (Function → Method, when method used as value: s.M passed as arg)
 //	method receiver        → RelationshipRecord{Kind="DEPENDS_ON"}    (Method → Component)
 //	struct field type      → RelationshipRecord{Kind="DEPENDS_ON"}    (Component → Component)
 //	interface satisfaction → RelationshipRecord{Kind="IMPLEMENTS"}    (Component → Component)
@@ -1079,6 +1081,48 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVar
 				pushed = true
 			}
 		}
+		// Issue #1789 — method-value references.
+		// Detect selector_expression nodes that are NOT the function child of a
+		// call_expression — i.e. the method is used as a VALUE (passed as an
+		// argument, stored in a variable, etc.) rather than being invoked.
+		// For these cases the CALLS path never fires, so `find_callers` sees
+		// "no_incoming_edges". We emit a CALLS edge with via_value=true so the
+		// resolver binds it like any other CALLS edge, while the property lets
+		// consumers distinguish "invoked here" from "passed here".
+		//
+		// Supported shapes:
+		//   s.wrap("name", s.handler)       — method value as argument
+		//   var h = obj.Method               — method value in short/var decl
+		//   return obj.Method                — method value in return statement
+		//
+		// Not handled (v1): `m := obj.Method; m(arg)` — the through-a-local
+		// indirect call requires tracking local-var method aliases, which is a
+		// separate pass. The declaration site DOES emit via_value=true already.
+		if t == "selector_expression" && !isSelectorCalleeOf(n) {
+			mvTarget, mvRecvMatch, mvOperand := selectorMethodValue(n, src, recvVarName)
+			if mvTarget != "" && mvTarget != callerName {
+				// Deduplicate with suffix "?mv" to avoid merging with a direct
+				// CALLS edge to the same method (they carry different semantics).
+				mvKey := mvTarget + "?mv"
+				if !seen[mvKey] {
+					seen[mvKey] = true
+					mvRec := types.RelationshipRecord{
+						FromID: callerName,
+						ToID:   mvTarget,
+						Kind:   "CALLS",
+						Properties: map[string]string{"via_value": "true"},
+					}
+					if mvRecvMatch && recvType != "" {
+						mvRec.Properties["receiver_type"] = recvType
+					} else if mvOperand != "" {
+						if ty := lookup(mvOperand); ty != "" {
+							mvRec.Properties["receiver_type"] = ty
+						}
+					}
+					rels = append(rels, mvRec)
+				}
+			}
+		}
 		if t == "call_expression" {
 			target, isSelfReceiver, operand := callExpressionTargetWithOperand(n, src, recvVarName)
 			// Self-recursion suppression: drop a call only when target
@@ -1168,6 +1212,57 @@ func extractCallRelationships(body *sitter.Node, src []byte, callerName, recvVar
 	}
 	visit(body)
 	return rels
+}
+
+// isSelectorCalleeOf reports whether sel is the `function` child of its
+// parent `call_expression`. When true, CALLS already owns the edge and the
+// method-value path must NOT emit a duplicate via_value edge.
+func isSelectorCalleeOf(sel *sitter.Node) bool {
+	if sel == nil {
+		return false
+	}
+	parent := sel.Parent()
+	if parent == nil || parent.Type() != "call_expression" {
+		return false
+	}
+	return parent.ChildByFieldName("function") == sel
+}
+
+// selectorMethodValue extracts the method name from a selector_expression
+// that is being used as a value (not invoked). Returns:
+//   - methodName: the bare field name (e.g. "handleQueryGraph")
+//   - isSelfReceiver: true when the operand matches recvVarName
+//   - operandName: the operand identifier text (for type lookup)
+//
+// Returns ("", false, "") when the selector is not a simple `obj.Method`
+// shape, or when the operand is not an identifier (chained selectors,
+// index expressions, etc.).
+//
+// Issue #1789: drives CALLS via_value=true emission for patterns like
+//
+//	s.wrap("name", s.handleQueryGraph)   — operand == recvVarName
+//	var h = obj.Method                   — operand is a known variable
+//	register("foo", obj.Method)          — generic argument
+func selectorMethodValue(sel *sitter.Node, src []byte, recvVarName string) (string, bool, string) {
+	if sel == nil {
+		return "", false, ""
+	}
+	operand := sel.ChildByFieldName("operand")
+	field := sel.ChildByFieldName("field")
+	if operand == nil || field == nil {
+		return "", false, ""
+	}
+	if operand.Type() != "identifier" {
+		// Chained selector (e.g. a.b.c used as value) — not covered in v1.
+		return "", false, ""
+	}
+	opName := nodeText(operand, src)
+	methodName := nodeText(field, src)
+	if opName == "" || methodName == "" {
+		return "", false, ""
+	}
+	isSelf := recvVarName != "" && opName == recvVarName
+	return methodName, isSelf, opName
 }
 
 // callExpressionTarget resolves the callee name from a call_expression node.

--- a/internal/extractors/golang/method_value_refs_test.go
+++ b/internal/extractors/golang/method_value_refs_test.go
@@ -1,0 +1,304 @@
+// method_value_refs_test.go — fixture tests for issue #1789.
+//
+// Covers CALLS via_value=true emission for method-value references: the
+// `s.wrap("name", s.handler)` registration pattern and similar shapes where
+// a method is used as a VALUE (passed as an argument, stored in a variable,
+// etc.) rather than being directly invoked.
+//
+// These tests verify:
+//  1. s.wrap("name", s.Method) argument → CALLS via_value=true, receiver_type set.
+//  2. var h = obj.Method (var decl) → CALLS via_value=true.
+//  3. register("foo", obj.Method) generic arg → CALLS via_value=true.
+//  4. obj.Method() direct call → existing CALLS behaviour UNCHANGED (no via_value).
+//  5. Self-receiver method value does NOT produce a self-loop when target == caller.
+package golang
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/extractor"
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// runMethodValueExtract runs the Go extractor on src with the given path and
+// returns the entity slice.
+func runMethodValueExtract(t *testing.T, src, path string) []types.EntityRecord {
+	t.Helper()
+	ex := &GoExtractor{}
+	ents, err := ex.Extract(context.Background(), extractor.FileInput{
+		Path:     path,
+		Language: "go",
+		Content:  []byte(src),
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	return ents
+}
+
+// findCallsEdgeWithViaValue looks in e.Relationships for a CALLS edge whose
+// ToID contains toSubstr and whose Properties["via_value"] == "true".
+func findCallsEdgeWithViaValue(e *types.EntityRecord, toSubstr string) *types.RelationshipRecord {
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind != "CALLS" {
+			continue
+		}
+		if !strings.Contains(r.ToID, toSubstr) {
+			continue
+		}
+		if r.Properties["via_value"] == "true" {
+			return r
+		}
+	}
+	return nil
+}
+
+// findCallsEdge looks in e.Relationships for any CALLS edge whose ToID
+// contains toSubstr (ignoring via_value).
+func findCallsEdge(e *types.EntityRecord, toSubstr string) *types.RelationshipRecord {
+	if e == nil {
+		return nil
+	}
+	for i := range e.Relationships {
+		r := &e.Relationships[i]
+		if r.Kind == "CALLS" && strings.Contains(r.ToID, toSubstr) {
+			return r
+		}
+	}
+	return nil
+}
+
+// methodValueSummary returns a compact string of all CALLS edges on ents,
+// for use in test failure messages.
+func methodValueSummary(ents []types.EntityRecord) string {
+	var b strings.Builder
+	for _, e := range ents {
+		for _, r := range e.Relationships {
+			if r.Kind == "CALLS" {
+				b.WriteString(e.Name)
+				b.WriteString(" -[CALLS")
+				if r.Properties["via_value"] == "true" {
+					b.WriteString(",via_value")
+				}
+				if rt := r.Properties["receiver_type"]; rt != "" {
+					b.WriteString(",recv=")
+					b.WriteString(rt)
+				}
+				b.WriteString("]-> ")
+				b.WriteString(r.ToID)
+				b.WriteString("; ")
+			}
+		}
+	}
+	if b.Len() == 0 {
+		return "(no CALLS)"
+	}
+	return b.String()
+}
+
+// findEntityByName returns a pointer to the first entity matching name.
+func findEntityByName(ents []types.EntityRecord, name string) *types.EntityRecord {
+	for i := range ents {
+		if ents[i].Name == name {
+			return &ents[i]
+		}
+	}
+	return nil
+}
+
+// ---- Test 1: s.wrap("name", s.Method) registration pattern -----------------
+//
+// This is the concrete dogfood case from issue #1789:
+//   s.wrap("archigraph_find", s.handleQueryGraph)
+// The inner s.handleQueryGraph is a method-value reference; it should emit
+// a CALLS edge with via_value=true and receiver_type=Server so the resolver
+// can bind the bare name "handleQueryGraph" to the entity Server.handleQueryGraph.
+
+func TestMethodValueRef_RegistrationPattern(t *testing.T) {
+	src := `package demo
+
+type Server struct{}
+
+func (s *Server) handleQueryGraph() {}
+
+func (s *Server) wrap(name string, fn func()) {}
+
+func (s *Server) registerTools() {
+	s.wrap("archigraph_find", s.handleQueryGraph)
+}
+`
+	ents := runMethodValueExtract(t, src, "server.go")
+	caller := findEntityByName(ents, "Server.registerTools")
+	if caller == nil {
+		t.Fatal("Server.registerTools entity not found")
+	}
+	hit := findCallsEdgeWithViaValue(caller, "handleQueryGraph")
+	if hit == nil {
+		t.Fatalf("expected CALLS via_value=true from Server.registerTools -> handleQueryGraph; all edges: %s",
+			methodValueSummary(ents))
+	}
+	if hit.Properties["receiver_type"] != "Server" {
+		t.Errorf("expected receiver_type=Server on via_value CALLS edge, got %+v", hit.Properties)
+	}
+}
+
+// ---- Test 2: var handler = obj.Method (variable-bound method value) ---------
+//
+// `var h = obj.Method` in a function body. The method is stored as a
+// function value; emit CALLS via_value=true from the enclosing function.
+
+func TestMethodValueRef_VarDecl(t *testing.T) {
+	src := `package demo
+
+type Widget struct{}
+
+func (w *Widget) Process() {}
+
+func setup(obj *Widget) {
+	var h = obj.Process
+	_ = h
+}
+`
+	ents := runMethodValueExtract(t, src, "widget.go")
+	caller := findEntityByName(ents, "setup")
+	if caller == nil {
+		t.Fatal("setup function not found")
+	}
+	hit := findCallsEdgeWithViaValue(caller, "Process")
+	if hit == nil {
+		t.Fatalf("expected CALLS via_value=true from setup -> Process; all edges: %s",
+			methodValueSummary(ents))
+	}
+}
+
+// ---- Test 3: register("foo", obj.Method) generic argument ------------------
+//
+// `register("foo", obj.Method)` — the method is the second argument to a
+// plain function call (not a method call on the same receiver). Should emit
+// CALLS via_value=true from the enclosing function.
+
+func TestMethodValueRef_GenericFuncArg(t *testing.T) {
+	src := `package demo
+
+type Handler struct{}
+
+func (h *Handler) ServeHTTP() {}
+
+func register(name string, fn func()) {}
+
+func setupRoutes(h *Handler) {
+	register("foo", h.ServeHTTP)
+}
+`
+	ents := runMethodValueExtract(t, src, "routes.go")
+	caller := findEntityByName(ents, "setupRoutes")
+	if caller == nil {
+		t.Fatal("setupRoutes function not found")
+	}
+	hit := findCallsEdgeWithViaValue(caller, "ServeHTTP")
+	if hit == nil {
+		t.Fatalf("expected CALLS via_value=true from setupRoutes -> ServeHTTP; all edges: %s",
+			methodValueSummary(ents))
+	}
+}
+
+// ---- Test 4: obj.Method() direct invocation — NO via_value -----------------
+//
+// Existing CALLS behaviour must be UNCHANGED: `obj.Method()` emits a CALLS
+// edge WITHOUT via_value=true. This test confirms no regression.
+
+func TestMethodValueRef_DirectCallNoViaValue(t *testing.T) {
+	src := `package demo
+
+type Foo struct{}
+
+func (f *Foo) Bar() {}
+
+func driver(x *Foo) {
+	x.Bar()
+}
+`
+	ents := runMethodValueExtract(t, src, "foo.go")
+	caller := findEntityByName(ents, "driver")
+	if caller == nil {
+		t.Fatal("driver function not found")
+	}
+	// A normal CALLS edge must exist.
+	direct := findCallsEdge(caller, "Bar")
+	if direct == nil {
+		t.Fatalf("expected CALLS edge from driver -> Bar; all edges: %s",
+			methodValueSummary(ents))
+	}
+	// It must NOT carry via_value=true (the direct-invocation case).
+	if direct.Properties["via_value"] == "true" {
+		t.Errorf("direct invocation x.Bar() should NOT carry via_value=true, got %+v", direct.Properties)
+	}
+}
+
+// ---- Test 5: method value passed via self-receiver (same struct) -----------
+//
+// `s.wrap("name", s.handleQueryGraph)` — multiple method-value arguments in
+// the same call. All must produce separate CALLS via_value=true edges.
+
+func TestMethodValueRef_MultipleMethodValues(t *testing.T) {
+	src := `package demo
+
+type Server struct{}
+
+func (s *Server) handleA() {}
+func (s *Server) handleB() {}
+func (s *Server) wrap(name string, fn func()) {}
+
+func (s *Server) registerAll() {
+	s.wrap("a", s.handleA)
+	s.wrap("b", s.handleB)
+}
+`
+	ents := runMethodValueExtract(t, src, "srv.go")
+	caller := findEntityByName(ents, "Server.registerAll")
+	if caller == nil {
+		t.Fatal("Server.registerAll entity not found")
+	}
+	for _, want := range []string{"handleA", "handleB"} {
+		hit := findCallsEdgeWithViaValue(caller, want)
+		if hit == nil {
+			t.Errorf("expected CALLS via_value=true from Server.registerAll -> %s; all edges: %s",
+				want, methodValueSummary(ents))
+		}
+	}
+}
+
+// ---- Test 6: no self-loop when method value references enclosing method -----
+//
+// `func (s *Server) setup() { s.wrap("x", s.setup) }` — the method value
+// IS the enclosing method itself. Must NOT produce a via_value self-edge.
+
+func TestMethodValueRef_NoSelfLoop(t *testing.T) {
+	src := `package demo
+
+type Server struct{}
+
+func (s *Server) wrap(name string, fn func()) {}
+
+func (s *Server) setup() {
+	// Pathological: passing self as handler. Should not produce a self-loop.
+	s.wrap("self", s.setup)
+}
+`
+	ents := runMethodValueExtract(t, src, "srv.go")
+	caller := findEntityByName(ents, "Server.setup")
+	if caller == nil {
+		t.Fatal("Server.setup entity not found")
+	}
+	for _, r := range caller.Relationships {
+		if r.Kind == "CALLS" && strings.Contains(r.ToID, "setup") && r.Properties["via_value"] == "true" {
+			t.Errorf("self-loop via_value edge leaked: %+v", r)
+		}
+	}
+}


### PR DESCRIPTION
## 1. What & Why

Fixes #1789. The Go extractor only emitted CALLS edges for **invocation-site** `call_expression` nodes. When a method is used as a **value** — passed as a function argument, stored in a variable, returned — no edge was produced at all. The canonical failure case:

```go
// internal/mcp/server.go:286
), s.wrap("archigraph_find", s.handleQueryGraph))
```

`s.handleQueryGraph` here is a method-value reference, not an invocation. Before this PR `find_callers(Server.handleQueryGraph)` returned `no_incoming_edges` even though `grep -rn handleQueryGraph` finds 9 references. Every archigraph MCP tool registration follows this pattern, so the "who registers this tool?" question was broken across the board.

## 2. How

**`internal/extractors/golang/extractor.go`** — pure Go AST extension, no other extractors touched:

- `isSelectorCalleeOf(sel)` — returns true when a `selector_expression` is the `function` child of its parent `call_expression` (i.e. it IS the invocation target; CALLS already owns it).
- `selectorMethodValue(sel, src, recvVarName)` — extracts `(methodName, isSelfReceiver, operandName)` from a selector used as a value.
- In the `visit` loop inside `extractCallRelationships`, a new branch fires when `t == "selector_expression" && !isSelectorCalleeOf(n)`:
  - Emits `CALLS` with `Properties["via_value"]="true"` and optional `receiver_type` stamp.
  - Deduplicated with key `"name?mv"` to prevent merging with any direct-invocation edge to the same method.
  - Self-loop guard: `target == callerName` is suppressed as before.

The `via_value=true` property distinguishes "passed here" from "invoked here" so consumers can filter. The resolver treats the CALLS edge identically to any other selector-form CALLS edge (bare ToID resolves through byMember + receiver_type), so `find_callers` traversal picks it up immediately.

## 3. Covered patterns

| Pattern | Status |
|---|---|
| `s.wrap("name", s.handleQueryGraph)` — method value as argument | ✅ NEW |
| `var h = obj.Method` — variable-bound method value | ✅ NEW |
| `register("foo", obj.Method)` — generic function argument | ✅ NEW |
| `obj.Method()` — direct invocation | ✅ UNCHANGED (no via_value) |
| `var m = obj.Method; m(arg)` — through-a-local (v2 scope) | documented, deferred |

## 4. Tests

New file `internal/extractors/golang/method_value_refs_test.go` — 6 focused fixture tests:

1. `TestMethodValueRef_RegistrationPattern` — exact dogfood case: `s.wrap("name", s.handleQueryGraph)`
2. `TestMethodValueRef_VarDecl` — `var h = obj.Process`
3. `TestMethodValueRef_GenericFuncArg` — `register("foo", h.ServeHTTP)`
4. `TestMethodValueRef_DirectCallNoViaValue` — `x.Bar()` no via_value (regression guard)
5. `TestMethodValueRef_MultipleMethodValues` — two method values in same registration method
6. `TestMethodValueRef_NoSelfLoop` — `s.wrap("x", s.setup)` self-ref suppressed

All 6 pass. Full extractor suite (`./internal/extractors/...`) green. `go build/vet` clean.

## 5. Cross-platform

Pure Go AST walking — no syscalls, no file paths. Cross-platform clean by construction.

## 6. Dogfood expected result

After merge + reindex on the archigraph repo:

```
find_callers(Server.handleQueryGraph)
→ Server.registerTools  [server.go:286]  hop_count=1  via_value=true
```

Currently returns `no_incoming_edges`. The same fix applies to all 20+ MCP tool registrations in `server.go` that follow the `s.wrap(name, s.handlerXxx)` pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)