### PR TITLE
MCP: standardize param names — find/query, get_source/entity_id (compat aliases retained)

### DIFF
--- a/internal/mcp/SCHEMA.md
+++ b/internal/mcp/SCHEMA.md
@@ -37,6 +37,17 @@ for clients (Claude Code, Windsurf, etc.) and tracks the implementation in
 - **No backwards compat for old names:** ADR-0017 (no-backcompat guarantee).
   Agents using pre-#668 tool names will receive a clear "tool not found" error.
 
+### Deprecated parameter aliases
+
+The following parameter names were renamed for consistency (#1790). The old
+names are still accepted at runtime and print a `[archigraph deprecation]`
+message to `os.Stderr`; they will be removed in the next major version.
+
+| Tool | Old name (deprecated) | New canonical name |
+|------|-----------------------|--------------------|
+| `archigraph_find` | `question` | `query` |
+| `archigraph_get_source` | `node_id` | `entity_id` |
+
 ### Stability policy
 
 The tool surface evolves additively. New tools and new optional arguments may
@@ -237,7 +248,7 @@ Previously named `archigraph_search` (renamed in #668).
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `question` | string | yes | — | Natural-language query. |
+| `query` | string | yes | — | Natural-language query. |
 | `mode` | string | no | `bfs` | Traversal mode: `bfs` \| `dfs` \| `none`. |
 | `depth` | number | no | `3` | BFS depth from each match. |
 | `token_budget` | number | no | `800` | Max approximate tokens in compact output. |
@@ -763,7 +774,7 @@ what span the entity records.
 
 | Name | Type | Required | Default | Description |
 |------|------|----------|---------|-------------|
-| `node_id` | string | yes | — | Entity ID, prefixed ID, qname, or label. |
+| `entity_id` | string | yes | — | Entity ID, prefixed ID, qname, or label. |
 | `context_lines` | number | no | `20` | Lines of context above/below the entity. |
 | `group`, `cwd` | string | no | — | Common args. |
 

--- a/internal/mcp/param_rename_test.go
+++ b/internal/mcp/param_rename_test.go
@@ -1,0 +1,161 @@
+package mcp
+
+// Tests for #1790: param-name standardization (query/entity_id) with compat aliases.
+//
+// Four cases:
+//   (a) new name "query"     works for archigraph_find
+//   (b) old name "question"  works for archigraph_find + deprecation log fires
+//   (c) new name "entity_id" works for archigraph_get_source
+//   (d) old name "node_id"   works for archigraph_get_source + deprecation log fires
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// captureStderr redirects os.Stderr to a buffer for the duration of fn,
+// then restores it and returns whatever was written.
+func captureStderr(fn func()) string {
+	r, w, _ := os.Pipe()
+	orig := os.Stderr
+	os.Stderr = w
+
+	fn()
+
+	w.Close()
+	os.Stderr = orig
+
+	var buf bytes.Buffer
+	io.Copy(&buf, r) //nolint:errcheck
+	return buf.String()
+}
+
+func newSmokeSrv(t *testing.T) *Server {
+	t.Helper()
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "r1")
+	_ = os.MkdirAll(repo, 0o755)
+	writeGraph(t, repo, fixtureDoc("r1"))
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"r1": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return srv
+}
+
+// (a) new name "query" works for archigraph_find — no deprecation warning.
+func TestFindNewParamQuery(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var sawHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_find", map[string]any{
+			"query": "rareUniqueWidget",
+			"group": "g",
+		})
+		if r.IsError {
+			// response may be an error (node not found etc.) but should not be a
+			// "missing required argument" hard error.
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				sawHardError = true
+			}
+		}
+	})
+
+	if sawHardError {
+		t.Error("new param 'query' should be accepted, got missing-arg error")
+	}
+	if strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("new param 'query' should NOT emit a deprecation warning, got stderr: %s", stderr)
+	}
+}
+
+// (b) old name "question" works for archigraph_find AND deprecation log fires.
+func TestFindOldParamQuestion_DeprecationFires(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_find", map[string]any{
+			"question": "rareUniqueWidget",
+			"group":    "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("legacy param 'question' should still work (compat alias), got missing-arg error")
+	}
+	if !strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("expected deprecation warning on stderr for legacy param 'question', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "archigraph_find") {
+		t.Errorf("deprecation message should name the tool, got: %q", stderr)
+	}
+}
+
+// (c) new name "entity_id" works for archigraph_get_source — no deprecation warning.
+func TestGetSourceNewParamEntityID(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_get_source", map[string]any{
+			"entity_id": "DashboardScreen",
+			"group":     "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("new param 'entity_id' should be accepted, got missing-arg error")
+	}
+	if strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("new param 'entity_id' should NOT emit a deprecation warning, got stderr: %s", stderr)
+	}
+}
+
+// (d) old name "node_id" works for archigraph_get_source AND deprecation log fires.
+func TestGetSourceOldParamNodeID_DeprecationFires(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_get_source", map[string]any{
+			"node_id": "DashboardScreen",
+			"group":   "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("legacy param 'node_id' should still work (compat alias), got missing-arg error")
+	}
+	if !strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("expected deprecation warning on stderr for legacy param 'node_id', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "archigraph_get_source") {
+		t.Errorf("deprecation message should name the tool, got: %q", stderr)
+	}
+}

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -264,7 +264,7 @@ func (s *Server) registerTools() {
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_get_source",
 		mcpapi.WithDescription("Return source for a node; accepts id, qualified_name, or label."),
-		mcpapi.WithString("node_id", mcpapi.Required()),
+		mcpapi.WithString("entity_id", mcpapi.Required()),
 		mcpapi.WithNumber("context_lines", mcpapi.DefaultNumber(20)),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
@@ -272,7 +272,7 @@ func (s *Server) registerTools() {
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_find",
 		mcpapi.WithDescription("BM25 graph query, de-noised. verbose=true: wide. min_score=0.15 trims tail."),
-		mcpapi.WithString("question", mcpapi.Required()),
+		mcpapi.WithString("query", mcpapi.Required()),
 		mcpapi.WithString("mode", mcpapi.DefaultString("bfs")),
 		mcpapi.WithNumber("depth", mcpapi.DefaultNumber(3)),
 		mcpapi.WithNumber("token_budget", mcpapi.DefaultNumber(800)),

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -2689,8 +2689,8 @@ func TestElapsedMSCoverageAllTools(t *testing.T) {
 	// and IsError=true results, so this test validates both paths.
 	minimalArgs := map[string]map[string]any{
 		"archigraph_whoami":               {"group": "g"},
-		"archigraph_get_source":           {"group": "g", "node_id": "DashboardScreen"},
-		"archigraph_find":                 {"group": "g", "question": "DashboardScreen"},
+		"archigraph_get_source":           {"group": "g", "entity_id": "DashboardScreen"},
+		"archigraph_find":                 {"group": "g", "query": "DashboardScreen"},
 		"archigraph_inspect":              {"group": "g", "label_or_id": "DashboardScreen"},
 		"archigraph_expand":               {"group": "g", "node": "DashboardScreen"},
 		"archigraph_trace":                {"group": "g", "source": "r1::a1", "target": "r1::a4"},

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -281,10 +281,19 @@ type patternForCount struct {
 // ---------------------------------------------------------------------------
 
 func (s *Server) handleQueryGraph(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	question, err := req.RequireString("question")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
+	// canonical name is "query"; accept legacy "question" with a deprecation log.
+	question := argString(req, "query", "")
+	if question == "" {
+		question = argString(req, "question", "")
+		if question != "" {
+			fmt.Fprintln(os.Stderr, "[archigraph deprecation] archigraph_find: param 'question' is deprecated, use 'query'")
+		}
 	}
+	if question == "" {
+		return mcpapi.NewToolResultError("missing required argument: query"), nil
+	}
+	var err error
+	_ = err // retained for symmetry with other handlers
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {
 		return errRes, nil
@@ -1056,9 +1065,16 @@ func (s *Server) handleListFindings(ctx context.Context, req mcpapi.CallToolRequ
 // ---------------------------------------------------------------------------
 
 func (s *Server) handleGetNodeSource(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	nodeID, err := req.RequireString("node_id")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
+	// canonical name is "entity_id"; accept legacy "node_id" with a deprecation log.
+	nodeID := argString(req, "entity_id", "")
+	if nodeID == "" {
+		nodeID = argString(req, "node_id", "")
+		if nodeID != "" {
+			fmt.Fprintln(os.Stderr, "[archigraph deprecation] archigraph_get_source: param 'node_id' is deprecated, use 'entity_id'")
+		}
+	}
+	if nodeID == "" {
+		return mcpapi.NewToolResultError("missing required argument: entity_id"), nil
 	}
 	contextLines := argInt(req, "context_lines", 20)
 	_, lg, errRes := s.resolveAndGroup(req)


### PR DESCRIPTION
## Summary

- Renames `archigraph_find` param `question` → `query` (canonical) with `question` retained as a compat alias
- Renames `archigraph_get_source` param `node_id` → `entity_id` (canonical) with `node_id` retained as a compat alias
- All other entity-reference params (`label_or_id`, `node`, `source`/`target`, `process_id`, `entry_point_id`, `topic_id`, `from`/`to`) are intentionally left unchanged — each names its specific semantic role

## Why

Consistent param names let agents and clients predict the naming pattern (`query` for search, `entity_id` for entity lookups) without consulting the schema on every call. The `entity_id` name already appears on `archigraph_subgraph`, `archigraph_find_callers`, `archigraph_find_callees`, and `archigraph_impact_radius`; this PR aligns `get_source` to that established convention. The `query` name aligns `archigraph_find` with `archigraph_search_entities` (which already uses `query`).

## Implementation

- `internal/mcp/server.go` — JSON-Schema input declarations updated to new canonical names
- `internal/mcp/tools.go` — `handleQueryGraph` and `handleGetNodeSource` read new name first via `argString`; fall back to old name; emit `[archigraph deprecation]` to `os.Stderr` when old name fires
- `internal/mcp/SCHEMA.md` — param tables updated; new "Deprecated parameter aliases" table added
- `internal/mcp/server_test.go` — smoke map updated to new canonical names (compat alias coverage provided by pre-existing tests at lines 490 and 640 which still use the old names)
- `internal/mcp/param_rename_test.go` — 4 new tests: (a) new `query` accepted, (b) old `question` accepted + deprecation fires, (c) new `entity_id` accepted, (d) old `node_id` accepted + deprecation fires

## Verification

- `go build ./...` ✓
- `go vet ./...` ✓
- `go test ./internal/mcp/... -run "TestFindNewParamQuery|TestFindOldParamQuestion|TestGetSourceNewParam|TestGetSourceOldParam"` — all 4 new tests pass ✓
- Pre-existing tests using old names (`question`, `node_id`) still pass via compat aliases ✓
- 4 pre-existing failures (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) are confirmed pre-existing on `main` — unrelated to this PR (sentinel tool count issue)
- Handshake token count: 3244 before and after (net delta = 0 tokens; chars: 12975 → 12973, -2 chars)

## Cross-platform

Pure schema + handler arg-parsing change. No syscalls, no file paths. Cross-platform clean by construction (#1777).

Fixes #1790