### PR TITLE
ci: experimental Windows CGO build + smoke-test workflow (#1791)

### DIFF
--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -1,0 +1,84 @@
+name: Windows CGO Experiment
+
+on:
+  workflow_dispatch:
+  pull_request:
+    paths:
+      - "go.mod"
+      - "go.sum"
+      - ".github/workflows/windows-cgo-experiment.yml"
+      - "internal/extractors/**"
+      - "internal/daemon/**"
+      - "cmd/archigraph/**"
+
+jobs:
+  build:
+    runs-on: windows-latest
+    continue-on-error: true   # experimental until #937 closed
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: msys2/setup-msys2@v2
+        with:
+          msystem: MINGW64
+          update: true
+          install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkgconf
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: "1.22"
+          cache: true
+
+      - name: Configure CGO for MinGW
+        shell: powershell
+        run: |
+          echo "CGO_ENABLED=1"                                | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "C:\msys64\mingw64\bin"                        | Out-File -FilePath $env:GITHUB_PATH -Append
+          echo "CC=C:\msys64\mingw64\bin\gcc.exe"             | Out-File -FilePath $env:GITHUB_ENV -Append
+
+      - name: go mod download
+        run: go mod download
+
+      - name: go vet
+        run: go vet ./...
+        continue-on-error: true   # capture both vet + build signals independently
+
+      - name: go build daemon
+        run: go build -v -o archigraph.exe ./cmd/archigraph
+
+      - name: smoke test — start daemon, hit healthz, stop
+        shell: powershell
+        run: |
+          $env:ARCHIGRAPH_DAEMON_ROOT = "$env:RUNNER_TEMP\archigraph-test"
+          New-Item -ItemType Directory -Path $env:ARCHIGRAPH_DAEMON_ROOT -Force | Out-Null
+          $proc = Start-Process -FilePath ".\archigraph.exe" -ArgumentList "daemon" -PassThru -RedirectStandardOutput "daemon.log" -RedirectStandardError "daemon.err"
+          Start-Sleep -Seconds 5
+          $code = curl.exe -s -o NUL -w "%{http_code}" http://127.0.0.1:47274/healthz
+          Write-Host "healthz response code: $code"
+          if ($code -ne "200") {
+            Get-Content daemon.log -ErrorAction SilentlyContinue
+            Get-Content daemon.err -ErrorAction SilentlyContinue
+            Stop-Process -Id $proc.Id -ErrorAction SilentlyContinue
+            exit 1
+          }
+          Stop-Process -Id $proc.Id -Force
+
+      - name: Upload binary
+        if: success()
+        uses: actions/upload-artifact@v4
+        with:
+          name: archigraph-windows-amd64
+          path: archigraph.exe
+          retention-days: 7
+
+      - name: Upload daemon log on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: daemon-logs
+          path: |
+            daemon.log
+            daemon.err
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
## What

Add `.github/workflows/windows-cgo-experiment.yml` — a CI job that installs MinGW via `msys2/setup-msys2`, sets `CGO_ENABLED=1`, builds the archigraph daemon binary for Windows (`archigraph.exe`), and runs a `/healthz` smoke test against the running daemon process.

## Why

#937 was filed on anecdotal evidence: the `iter.go undefined: Node` error suggested tree-sitter might not compile on Windows at all. This workflow provides empirical data without speculation. Possible outcomes are documented in #1791:

- Build succeeds → tree-sitter works with MinGW; #937 was overstated
- Build fails on same `undefined: Node` → a build-tag fix suffices
- Build fails with C-compiler errors → tree-sitter C code has real Windows incompatibility — exact error exposed
- Build succeeds, smoke fails → something else (watchers, signals, paths) — error pinpointed

## How

1. `msys2/setup-msys2@v2` installs `mingw-w64-x86_64-gcc` and `pkgconf` on `windows-latest`
2. `Configure CGO for MinGW` step writes `CGO_ENABLED=1`, `CC=C:\msys64\mingw64\bin\gcc.exe`, and the MinGW bin dir to `GITHUB_ENV` / `GITHUB_PATH`
3. `go build -v -o archigraph.exe ./cmd/archigraph` is the critical gate
4. Smoke test: start daemon, `curl.exe` against `/healthz`, assert HTTP 200
5. Binary uploaded as artifact on success; daemon logs uploaded on failure

The job is `continue-on-error: true` — it never blocks PR merges; it only produces signal.

## Constraints

- **Zero source changes.** Only `.github/workflows/windows-cgo-experiment.yml` is added.
- No existing workflow is modified.
- Does not touch `internal/mcp`, `internal/extractors`, or any live grind (#1789, #1790).

## Verification — actual triggered-run outcome

> **Run triggered by this PR's `pull_request` event.**
> Results will appear in the Actions tab under **Windows CGO Experiment**.
> This section will be updated with the first run's outcome (build log excerpt or success confirmation) before owner review.
>
> To read the run once it completes:
> ```
> gh run list --workflow=windows-cgo-experiment.yml
> gh run view <run-id> --log
> ```

If the build succeeds: a follow-up ticket will be filed proposing to enable Windows in the main `test.yml` matrix.
If the build fails on `iter.go undefined: Node` specifically: that confirms a build-tag patch is the fix.

Fixes #1791