### PR TITLE
test(axum-e2e): skip tests when local fixture path is absent (Fixes #1798)

### DIFF
--- a/cmd/archigraph/axum_e2e_test.go
+++ b/cmd/archigraph/axum_e2e_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"os"
 	"testing"
 )
 
@@ -13,6 +14,9 @@ import (
 // retains the canonical synthetic ID (e.g. "http:POST:/quote").
 func TestAxumE2E_PricingService(t *testing.T) {
 	const pricingPath = "/Users/jorgecajas/Documents/Projects/polyglot-platform/services/pricing"
+	if _, err := os.Stat(pricingPath); err != nil {
+		t.Skipf("requires local Axum fixture at %s: %v", pricingPath, err)
+	}
 	doc := runIndexerOn(t, pricingPath, "pricing", nil)
 
 	// Collect by Name (canonical ID) not by stamped hash ID.
@@ -68,6 +72,9 @@ func TestAxumE2E_PricingService(t *testing.T) {
 // verifies the POST /quote consumer-side call entity is present.
 func TestAxumE2E_OrdersCaller(t *testing.T) {
 	const ordersPath = "/Users/jorgecajas/Documents/Projects/polyglot-platform/services/orders"
+	if _, err := os.Stat(ordersPath); err != nil {
+		t.Skipf("requires local Axum fixture at %s: %v", ordersPath, err)
+	}
 	doc := runIndexerOn(t, ordersPath, "orders", nil)
 
 	// Collect by Name (canonical ID) not by stamped hash ID.


### PR DESCRIPTION
## What

Add an `os.Stat` skip guard to `TestAxumE2E_PricingService` and `TestAxumE2E_OrdersCaller` in `cmd/archigraph/axum_e2e_test.go`.

## Why

Both tests hard-code absolute paths under `/Users/jorgecajas/Documents/Projects/polyglot-platform/services/{pricing,orders}`. Without any guard, they unconditionally fail on CI runners (path never exists) and on any developer machine that isn't the fixture owner — turning a useful local regression test into a permanent red flag on every pipeline run.

## How

At the very top of each test body, before any indexer call:

```go
if _, err := os.Stat(<fixturePath>); err != nil {
    t.Skipf("requires local Axum fixture at %s: %v", <fixturePath>, err)
}
```

`os.Stat` is cross-platform and triggers on path-not-found without relying on `CI` env vars or build tags. When the fixture directory exists the test runs exactly as before; when it doesn't, the test reports `SKIP` instead of `FAIL`.

## Verification

- `go build ./cmd/archigraph/...` — clean
- `go vet ./cmd/archigraph/...` — clean
- `go test ./cmd/archigraph/... -v -run TestAxumE2E` on the owner machine (fixture present): both tests **PASS** (`ok github.com/cajasmota/archigraph/cmd/archigraph`)
- On any machine where `/Users/jorgecajas/Documents/Projects/polyglot-platform/services/{pricing,orders}` does not exist both tests will report `--- SKIP` and the package result will be `ok` not `FAIL`

## Scope

Single file changed (`cmd/archigraph/axum_e2e_test.go`): added `"os"` import + 3-line guard per test. Zero changes to test logic.

## References

Fixes #1798 — investigation traced back to #937.

🤖 Generated with [Claude Code](https://claude.com/claude-code)