### PR TITLE
fix(graph): guard RunAlgorithmsWithOptions against zero-entity panic

### DIFF
--- a/internal/graph/algorithms.go
+++ b/internal/graph/algorithms.go
@@ -830,6 +830,15 @@ func RunAlgorithms(entities []Entity, rels []Relationship) *AlgorithmResults {
 // per-entity attributes onto the on-disk Document and where to emit the corpus
 // aggregate.
 func RunAlgorithmsWithOptions(entities []Entity, rels []Relationship, opts CommunityOptions) *AlgorithmResults {
+	// Guard: gonum's PageRankSparse (via ComputeCentrality) calls
+	// mat.NewVecDense(0, ...) when the graph has zero nodes, which panics with
+	// "mat: zero length in matrix dimension" (gonum/mat vector.go:103).
+	// Return an empty-but-valid result immediately so callers get a safe no-op
+	// rather than a crash. Tracked in #937 / #1795.
+	if len(entities) == 0 {
+		return &AlgorithmResults{} //nolint:exhaustruct // zero-entity fast path; all fields intentionally zero
+	}
+
 	start := time.Now()
 
 	g, idx := BuildGraph(entities, rels)

--- a/internal/graph/algorithms_test.go
+++ b/internal/graph/algorithms_test.go
@@ -393,3 +393,37 @@ func TestDenoise_Determinism(t *testing.T) {
 		t.Errorf("DenoisedCommunities differs: %d vs %d", r1.Stats.DenoisedCommunities, r2.Stats.DenoisedCommunities)
 	}
 }
+
+// TestRunAlgorithmsWithOptions_EmptyDoc verifies that passing zero entities does
+// not panic (regression for #937/#1795: gonum's PageRankSparse → mat.NewVecDense(0)
+// panicked with "mat: zero length in matrix dimension") and returns an empty,
+// well-formed AlgorithmResults.
+func TestRunAlgorithmsWithOptions_EmptyDoc(t *testing.T) {
+	// Must not panic.
+	res := RunAlgorithmsWithOptions(nil, nil, DefaultCommunityOptions())
+
+	if res == nil {
+		t.Fatal("expected non-nil AlgorithmResults for empty doc, got nil")
+	}
+	if len(res.Communities) != 0 {
+		t.Errorf("expected 0 communities for empty doc, got %d", len(res.Communities))
+	}
+	if len(res.CommunityID) != 0 {
+		t.Errorf("expected empty CommunityID map for empty doc, got %d entries", len(res.CommunityID))
+	}
+	if len(res.GodNodes) != 0 {
+		t.Errorf("expected no god nodes for empty doc, got %d", len(res.GodNodes))
+	}
+	if len(res.ArticulationPoints) != 0 {
+		t.Errorf("expected no articulation points for empty doc, got %d", len(res.ArticulationPoints))
+	}
+	if len(res.SurpriseEdges) != 0 {
+		t.Errorf("expected no surprise edges for empty doc, got %d", len(res.SurpriseEdges))
+	}
+
+	// Also exercise the convenience wrapper.
+	res2 := RunAlgorithms(nil, nil)
+	if res2 == nil {
+		t.Fatal("RunAlgorithms: expected non-nil result for empty doc")
+	}
+}


### PR DESCRIPTION
## Summary

- **Root cause**: `RunAlgorithmsWithOptions` → `ComputeCentrality` → `network.PageRankSparse` calls `mat.NewVecDense(0, ...)` when the graph has zero nodes. gonum panics unconditionally on a zero-length vector dimension (gonum `mat/vector.go:103`). This crashed `TestAxumE2E_PricingService` and produced iter5 WRONG-class failures (tracked in #937).
- **Fix**: Early-return guard at the very top of `RunAlgorithmsWithOptions`: if `len(entities) == 0` return `&AlgorithmResults{}` immediately, before any graph construction or algorithm invocation.
- **Scope**: Pure Go logic, zero syscalls — cross-platform clean per #1777 discipline.

## Root cause

```
RunAlgorithmsWithOptions
  └─ ComputeCentrality(g, idx)
       └─ network.PageRankSparse(g, 0.85, 1e-6)
            └─ mat.NewVecDense(0, nil)   ← panic: "mat: zero length in matrix dimension"
```

A graph document with no entities produces an empty `simple.WeightedDirectedGraph`. gonum's PageRank implementation allocates an N-length dense vector up front; when N=0 gonum validates and panics before any computation.

## Fix

`internal/graph/algorithms.go` — 8 lines added before `BuildGraph`:

```go
if len(entities) == 0 {
    return &AlgorithmResults{} //nolint:exhaustruct // zero-entity fast path; all fields intentionally zero
}
```

Both `RunAlgorithmsWithOptions` and the convenience wrapper `RunAlgorithms` are covered by the same path.

## Files

| File | Change |
|------|--------|
| `internal/graph/algorithms.go` | +9 lines: guard + comment block |
| `internal/graph/algorithms_test.go` | +35 lines: `TestRunAlgorithmsWithOptions_EmptyDoc` |

## Verification

```
go build ./...          ✅ clean
go vet ./...            ✅ clean
go test ./internal/graph/... -run TestRunAlgorithmsWithOptions_EmptyDoc   ✅ PASS (0.00s)
go test ./internal/graph/... -timeout 120s   ✅ all packages PASS (no regressions)
```

## Risks / Follow-ups

- **No behaviour change for non-empty docs**: the guard exits before any existing code runs; all existing algorithm paths are unaffected.
- **Follow-up**: `ComputeCentrality` itself could defensively guard at its own entry point for belt-and-suspenders safety — deferred as a separate story since the call site guard is sufficient and safer to review in isolation.
- **Related**: `ComputeCommunities` with an empty graph likely has the same class of risk; worth auditing in a follow-up (#937 investigation continues).

Fixes #1795