### PR TITLE
fix: add darwin||linux build tag to get_source_timeout_test.go (#1803 — unblocks Windows build)

### DIFF
--- a/internal/mcp/get_source_timeout_test.go
+++ b/internal/mcp/get_source_timeout_test.go
@@ -1,3 +1,5 @@
+//go:build darwin || linux
+
 // get_source_timeout_test.go — #1678 / #1773 regression coverage.
 //
 // Background: real MCP calls to archigraph_get_source against the live daemon


### PR DESCRIPTION
`internal/mcp/get_source_timeout_test.go` (added by #1780) calls `syscall.Mkfifo`, which does not exist on Windows. This caused `go build` to fail in the Windows CGO experiment (run 26329497541). The fix mirrors the `//go:build darwin || linux` tag already present on sibling files (`read_source_unix.go`, `fsevents_hang_test.go`, `openleak_test.go`, `gitignore_unix.go`).

Verified: `go build ./...` and `go vet ./...` green on macOS; `GOOS=windows GOARCH=amd64 go vet/build ./internal/mcp/...` both green (were failing before). Test still executes on macOS/Linux unchanged.

Fixes #1803