### PR TITLE
ci(windows): use path-type: inherit + drop hardcoded gcc path (#1805)

### DIFF
--- a/.github/workflows/windows-cgo-experiment.yml
+++ b/.github/workflows/windows-cgo-experiment.yml
@@ -24,6 +24,7 @@ jobs:
           msystem: MINGW64
           update: true
           install: mingw-w64-x86_64-gcc mingw-w64-x86_64-pkgconf
+          path-type: inherit
 
       - uses: actions/setup-go@v5
         with:
@@ -33,9 +34,8 @@ jobs:
       - name: Configure CGO for MinGW
         shell: powershell
         run: |
-          echo "CGO_ENABLED=1"                                | Out-File -FilePath $env:GITHUB_ENV -Append
-          echo "C:\msys64\mingw64\bin"                        | Out-File -FilePath $env:GITHUB_PATH -Append
-          echo "CC=C:\msys64\mingw64\bin\gcc.exe"             | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CGO_ENABLED=1" | Out-File -FilePath $env:GITHUB_ENV -Append
+          echo "CC=gcc.exe"    | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: go mod download
         run: go mod download


### PR DESCRIPTION
## 1 — Problem

Run [26329785006](https://github.com/cajasmota/archigraph/actions/runs/26329785006) (on `main`) failed with:

```
cgo: C compiler "C:\msys64\mingw64\bin\gcc.exe" not found:
exec: "C:\msys64\mingw64\bin\gcc.exe": file does not exist
```

`msys2/setup-msys2@v2` installs to the GHA runner tool-cache, **not** `C:\msys64`. The two broken lines in the "Configure CGO for MinGW" step:

- `echo "C:\msys64\mingw64\bin" | Out-File … $env:GITHUB_PATH` — appended the wrong directory to PATH.
- `echo "CC=C:\msys64\mingw64\bin\gcc.exe" | Out-File … $env:GITHUB_ENV` — set an absolute path that doesn't exist on the runner.

## 2 — Root Cause

`msys2/setup-msys2@v2` has a `path-type` option (default `msys2`). When `path-type: inherit` is set the action prepends the MINGW64 `bin` directory to the job's `PATH` automatically, regardless of where on the runner MSYS2 was installed. Without it the action manages its own sub-shell PATH and the MINGW64 tools are invisible to subsequent PowerShell / cmd steps.

## 3 — Change

Single file: `.github/workflows/windows-cgo-experiment.yml`

| Before | After |
|---|---|
| (no `path-type`) | `path-type: inherit` added to `msys2/setup-msys2@v2` `with:` block |
| `echo "C:\msys64\mingw64\bin" \| Out-File … $env:GITHUB_PATH` | **removed** |
| `echo "CC=C:\msys64\mingw64\bin\gcc.exe" \| Out-File … $env:GITHUB_ENV` | `echo "CC=gcc.exe" \| Out-File … $env:GITHUB_ENV` |

All other steps (smoke test, artifact upload, `go vet`, `go mod download`) are **unchanged**.

## 4 — Why This Is Safe

`path-type: inherit` is the documented pattern for using MSYS2-installed tools from non-MSYS2 shells in GHA. It only affects PATH within this job. No production code changes.

## 5 — Verification

Triggered via `gh workflow run windows-cgo-experiment.yml --ref fix/msys2-path-inherit`.

**Run [26329884847](https://github.com/cajasmota/archigraph/actions/runs/26329884847) — PASSED (3m 55s)**

All steps green:
- `Run msys2/setup-msys2@v2` ✓
- `Configure CGO for MinGW` ✓ (`CC=gcc.exe`, no hardcoded path)
- `go build daemon` ✓ — `archigraph.exe` compiled successfully with CGO
- `smoke test — start daemon, hit healthz, stop` ✓ — `/healthz` returned HTTP 200
- `Upload binary` ✓ — artifact `archigraph-windows-amd64` uploaded (retention 7 days)
- `Upload daemon log on failure` — skipped (no failure)

The C compiler "not found" error is gone. The fix resolves the root cause.

## 6 — Follow-up / Known Issues

- Node.js 20 deprecation warnings on `actions/checkout@v4`, `actions/setup-go@v5`, `actions/upload-artifact@v4` — separate concern, not introduced by this PR.
- `windows-latest` runner will redirect to `windows-2025-vs2026` by June 15 2026 — separate concern.

## 7 — Review Notes

Do **not** merge without owner review of the empirical run outcome linked in §5. This is an experimental workflow (`continue-on-error: true` until #937 is closed); the fix clears the blocker for gathering real CGO signal on Windows.

Fixes #1805

🤖 Generated with [Claude Code](https://claude.com/claude-code)