### PR TITLE
feat(extractor/python): close top unresolved-import pattern on polyglot corpus (bug-rate experiment)

### DIFF
--- a/internal/external/synth.go
+++ b/internal/external/synth.go
@@ -16218,6 +16218,18 @@ var knownExternalPackages = map[string]struct{}{
 	"cv2":       {}, // OpenCV
 	"pdf2image": {}, // PDF to image conversion
 	"coreapi":   {}, // Django REST coreapi client
+	// Polyglot-platform corpus additions (bug-rate experiment 2026-05-23).
+	// These packages appeared as unresolved IMPORTS on the polyglot-platform
+	// group (27.0% unresolved rate, 372/1377 edges) and were missing from the
+	// allowlist, causing the resolver to tag them ExternalUnknown / bug-extractor.
+	// Note: opentelemetry, grpc, and kafka already exist later in this map for
+	// Scala/Go uses — they are omitted here to avoid duplicate-key errors.
+	"airflow":               {}, // Apache Airflow: `from airflow import DAG`, etc.
+	"strawberry":            {}, // Strawberry GraphQL: `import strawberry`, etc.
+	"aio_pika":              {}, // Async AMQP/RabbitMQ: `import aio_pika`
+	"hvac":                  {}, // HashiCorp Vault client: `import hvac`
+	"pgvector":              {}, // pgvector Postgres extension: `from pgvector.psycopg import ...`
+	"sentence_transformers": {}, // Sentence Transformers ML: `from sentence_transformers import ...`
 	// Wave-7 third-party additions (Django/Channels/AWS/PDF/Excel
 	// stack from client-fixture-a residual).
 	"asgiref":                  {},

--- a/internal/extractors/python/imports.go
+++ b/internal/extractors/python/imports.go
@@ -172,6 +172,35 @@ var pythonKnownExternalRoots = map[string]struct{}{
 	"pdfplumber": {}, // PDF extraction
 	// Django REST (wave-8 fixture-a residual)
 	"coreapi": {}, // Django REST coreapi client
+	// Observability / tracing — polyglot-platform corpus gap
+	// `from opentelemetry import trace`, `from opentelemetry.sdk.trace import TracerProvider`, etc.
+	// All sub-packages share the `opentelemetry` root.
+	"opentelemetry": {},
+	// Workflow orchestration — polyglot-platform corpus gap
+	// Apache Airflow: `from airflow import DAG`, `from airflow.operators.python import PythonOperator`
+	"airflow": {},
+	// GraphQL (Strawberry) — polyglot-platform corpus gap
+	// `import strawberry`, `from strawberry.fastapi import GraphQLRouter`
+	"strawberry": {},
+	// gRPC — polyglot-platform corpus gap
+	// `import grpc`, generated stubs (`import inventory_pb2`, `import inventory_pb2_grpc`)
+	// use top-level `grpc` which is the canonical PyPI package name.
+	"grpc": {},
+	// Async messaging — polyglot-platform corpus gap
+	// `import aio_pika` (AMQP/RabbitMQ async client)
+	"aio_pika": {},
+	// Kafka pure-Python client — polyglot-platform corpus gap
+	// `from kafka import KafkaProducer, KafkaConsumer`
+	"kafka": {},
+	// HashiCorp Vault client — polyglot-platform corpus gap
+	// `import hvac`
+	"hvac": {},
+	// pgvector Postgres extension client — polyglot-platform corpus gap
+	// `from pgvector.psycopg import register_vector`
+	"pgvector": {},
+	// Sentence Transformers (ML) — polyglot-platform corpus gap
+	// `from sentence_transformers import SentenceTransformer`
+	"sentence_transformers": {},
 }
 
 // resolveImportToIDs walks every IMPORTS edge on every entity in

--- a/internal/extractors/python/imports_test.go
+++ b/internal/extractors/python/imports_test.go
@@ -86,6 +86,117 @@ func TestImportsLeavesUnknownAlone(t *testing.T) {
 	}
 }
 
+// Polyglot-platform corpus additions: packages that were missing from
+// pythonKnownExternalRoots and caused unresolved IMPORTS on the
+// polyglot-platform group (bug-rate experiment 2026-05-23).
+//
+// Each sub-test checks that the top-level root is rewritten to ext:<root>
+// form so the resolver's external-disposition gate classifies the edge
+// as ExternalKnown rather than routing it to bug-extractor.
+func TestImportsRewritePolyglotExternals(t *testing.T) {
+	ex := &Extractor{}
+
+	cases := []struct {
+		name       string
+		src        string
+		sourcemod  string
+		wantPrefix string
+	}{
+		{
+			name:       "opentelemetry_trace",
+			src:        "from opentelemetry import trace\n",
+			sourcemod:  "opentelemetry",
+			wantPrefix: "ext:opentelemetry",
+		},
+		{
+			name:       "opentelemetry_sdk_submodule",
+			src:        "from opentelemetry.sdk.trace import TracerProvider\n",
+			sourcemod:  "opentelemetry.sdk.trace",
+			wantPrefix: "ext:opentelemetry",
+		},
+		{
+			name:       "airflow_dag",
+			src:        "from airflow import DAG\n",
+			sourcemod:  "airflow",
+			wantPrefix: "ext:airflow",
+		},
+		{
+			name:       "airflow_operators_python",
+			src:        "from airflow.operators.python import PythonOperator\n",
+			sourcemod:  "airflow.operators.python",
+			wantPrefix: "ext:airflow",
+		},
+		{
+			name:       "strawberry_import",
+			src:        "import strawberry\n",
+			sourcemod:  "strawberry",
+			wantPrefix: "ext:strawberry",
+		},
+		{
+			name:       "strawberry_fastapi",
+			src:        "from strawberry.fastapi import GraphQLRouter\n",
+			sourcemod:  "strawberry.fastapi",
+			wantPrefix: "ext:strawberry",
+		},
+		{
+			name:       "grpc_import",
+			src:        "import grpc\n",
+			sourcemod:  "grpc",
+			wantPrefix: "ext:grpc",
+		},
+		{
+			name:       "aio_pika",
+			src:        "import aio_pika\n",
+			sourcemod:  "aio_pika",
+			wantPrefix: "ext:aio_pika",
+		},
+		{
+			name:       "kafka",
+			src:        "from kafka import KafkaProducer, KafkaConsumer\n",
+			sourcemod:  "kafka",
+			wantPrefix: "ext:kafka",
+		},
+		{
+			name:       "hvac",
+			src:        "import hvac\n",
+			sourcemod:  "hvac",
+			wantPrefix: "ext:hvac",
+		},
+		{
+			name:       "pgvector",
+			src:        "from pgvector.psycopg import register_vector\n",
+			sourcemod:  "pgvector.psycopg",
+			wantPrefix: "ext:pgvector",
+		},
+		{
+			name:       "sentence_transformers",
+			src:        "from sentence_transformers import SentenceTransformer\n",
+			sourcemod:  "sentence_transformers",
+			wantPrefix: "ext:sentence_transformers",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			ents, err := ex.Extract(context.Background(), extractor.FileInput{
+				Path:     "app/main.py",
+				Language: "python",
+				Content:  []byte(tc.src),
+			})
+			if err != nil {
+				t.Fatalf("Extract: %v", err)
+			}
+			r := findImportEdge(ents, tc.sourcemod)
+			if r == nil {
+				t.Fatalf("missing IMPORTS edge for source_module=%q", tc.sourcemod)
+			}
+			if !strings.HasPrefix(r.ToID, tc.wantPrefix) {
+				t.Fatalf("ToID = %q, want prefix %q", r.ToID, tc.wantPrefix)
+			}
+		})
+	}
+}
+
 // Relative imports are never rewritten — `from .foo import bar` carries
 // a source_module starting with "." which is never an external package.
 //


### PR DESCRIPTION
## 1. What & Why

The polyglot-platform group had **fidelity 0.730** with **372/1,377 (27.0%) unresolved IMPORTS**. Investigation identified that 9 Python package roots used by the corpus were absent from `pythonKnownExternalRoots` (the extractor-side rewrite list in `imports.go`) and from `knownExternalPackages` (the resolver-side allowlist in `synth.go`). Without an `ext:<root>` prefix, these edges bypassed the external-disposition gate and landed in ExternalUnknown / bug-extractor.

Top offenders (28 unresolved edges total):
| Package | Imports | Role |
|---------|---------|------|
| `airflow` | 10 | Apache Airflow DAGs + operators |
| `opentelemetry` | 7 | OTel SDK tracing |
| `strawberry` | 3 | Strawberry GraphQL |
| `grpc` | 2 | gRPC (already in synth.go for Scala; added to imports.go) |
| `aio_pika` | 2 | Async AMQP/RabbitMQ |
| `kafka` | 1 | kafka-python |
| `hvac` | 1 | HashiCorp Vault client |
| `pgvector` | 1 | pgvector Postgres extension |
| `sentence_transformers` | 1 | ML sentence embeddings |

## 2. Before / After Fidelity

| Metric | Before | After |
|--------|--------|-------|
| Fidelity | 0.730 | **0.737** |
| Entities | 1,892 | 1,905 |
| Relationships | 4,956 | 4,971 |
| Unresolved imports | 372 / 1,377 (27.0%) | **367 / 1,394 (26.3%)** |

The total edge count grew slightly because the rebuild picks up more relationships; the absolute unresolved count dropped by 5 and the percentage dropped 0.7 pp.

## 3. Files Changed

- `internal/extractors/python/imports.go` — 9 new entries in `pythonKnownExternalRoots`
- `internal/external/synth.go` — 6 new entries in `knownExternalPackages` (3 already existed for Scala/Go: `opentelemetry`, `grpc`, `kafka`)
- `internal/extractors/python/imports_test.go` — 12 new sub-tests in `TestImportsRewritePolyglotExternals` covering all new package roots with real polyglot-corpus import shapes

## 4. MCP-vs-Grep Investigation Breakdown

| Tool | Time | Actions |
|------|------|---------|
| MCP (`archigraph_stats`, `archigraph_find`) | ~5 min | Baseline stats, language search, topology queries |
| Grep + file read | ~8 min | Corpus import count, per-package tallies, cross-check against existing allowlists |

**Reflection:** MCP was fast for the high-level fidelity baseline (single call to `archigraph_stats` gave exact unresolved counts and per-repo breakdown). However, MCP's `archigraph_find` returned limited signal for "which language has worst unresolved rate" because the query language is entity-name–oriented, not relationship-property–oriented. Grep on the actual corpus files was more efficient for the critical step of enumerating all external import package roots and comparing against the allowlist. MCP dogfood materially helped for baseline + orientation (saved ~15 min of manual corpus navigation); grep was necessary and faster for the gap-finding analysis step.

## 5. Test Plan

- [x] `go test ./internal/extractors/python/...` — all pass including 12 new sub-tests
- [x] `go test ./internal/external/...` — all pass
- [x] `go build ./...` — no errors
- [x] `archigraph rebuild polyglot-platform` — before/after metrics confirmed
- [ ] CI matrix verifies (Linux + Darwin, per #1777 cross-platform discipline)

## 6. Constraints Respected

- Only touched `internal/extractors/python/` and `internal/external/synth.go` — no `internal/resolve/` changes (Grind A domain)
- No Go extractor changes (Grind A domain)
- `filepath.Join` not used (no path construction); pure data additions
- Disjoint from #1827 + #1828 (those touch `internal/docgen/`)

## 7. Risks / Follow-ups

- Residual 26.3% unresolved is driven by cross-repo `py_shared` imports (in-tree package, not external) and proto-generated stubs (`inventory_pb2`, `inventory_pb2_grpc`) — requires cross-repo resolution improvement, not extractor allowlist changes
- `opentelemetry`, `grpc`, and `kafka` were already in synth.go for Scala/Go — only added to imports.go (extractor rewrite list)

🤖 Generated with [Claude Code](https://claude.com/claude-code)