### PR TITLE
feat(positioning): embed pair-MCP-with-grep philosophy across handshake, CLAUDE.md, skills, and docs (#1836)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,30 @@
+# When to use archigraph MCP vs grep
+
+archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches.
+Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph?
+Use grep for raw enumeration: every `if err != nil`, every import line, every TODO.
+Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet.
+
+## Three concrete examples
+
+**MCP-good — structural navigation:**
+"Which services call `OrderService.CreateOrder`?" → `archigraph_find` + `archigraph_callers` gives you
+the precise call graph with repo context, in one round-trip. grep would require you to know every
+caller file location across every repo in the group.
+
+**grep-good — raw enumeration:**
+"List every `if err != nil` block that is missing a `log.Error` call." → grep is the right tool.
+archigraph models control flow at the entity level, not at the statement level. Raw text search on
+the source files is faster and more complete for this class of pattern.
+
+**Paired — search space reduction then raw verify:**
+"Does any service leak the internal `User.PasswordHash` field in an HTTP response?" →
+1. MCP: `archigraph_find entity_type=http_endpoint_definition` + `archigraph_paths` to identify
+   every endpoint that touches `User`. Narrows a 500-file repo to 8 handlers.
+2. grep: search only those 8 handler files for `PasswordHash` to confirm whether it appears in any
+   serialisation path.
+
+---
+
+For archigraph developer workflow, architecture decisions, and contributing guidelines see
+[`docs/adrs/`](docs/adrs/) and [`AGENTS.md`](AGENTS.md).

--- a/README.md
+++ b/README.md
@@ -180,6 +180,8 @@ command recipes, section cache details, and troubleshooting reference.
 
 ## Usage
 
+> **Using archigraph MCP with an AI agent?** See [`CLAUDE.md`](CLAUDE.md#when-to-use-archigraph-mcp-vs-grep) for the MCP + grep pairing philosophy: when to use MCP for structural questions vs grep for raw enumeration, and how to combine them.
+
 archigraph is a CLI plus a unified daemon process that manages indexing,
 the MCP server, embedded dashboard, and file watchers. The common path:
 

--- a/docs/docgen-llm-mode.md
+++ b/docs/docgen-llm-mode.md
@@ -9,6 +9,21 @@ workflows.
 
 ---
 
+## MCP + grep, paired
+
+archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches.
+Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph?
+Use grep for raw enumeration: every `if err != nil`, every import line, every TODO.
+Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet.
+
+In the LLM-mode docgen loop specifically: the emit phase uses MCP tools to resolve the structural
+context that fills `graph_context` and `neighbour_briefs` in the bundle; the apply phase uses the
+already-resolved context rather than re-querying. If you need to verify an exact symbol spelling or
+confirm a source line number inside a section prompt, use grep on the source file — do not make an
+additional MCP round-trip for text-level detail that grep resolves in milliseconds.
+
+---
+
 ## 1. The 5-Tier Docgen Ladder
 
 Archigraph docgen is built around a progressive-validation ladder. Each tier

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -638,7 +638,15 @@ func (s *Server) handleStatus(ctx context.Context, req mcpapi.CallToolRequest) (
 		msg = fmt.Sprintf("Archigraph: cwd %q is not under any registered group (registered: %v). cd into a registered repo or run `archigraph install` here. Note: new groups registered mid-session are not reflected until restart (#1772).", cwd, known)
 	}
 
-	return mcpapi.NewToolResultText(msg), nil
+	// Append the MCP + grep pairing philosophy so agents onboarding via
+	// archigraph_status understand how to use MCP alongside grep (#1836).
+	const pairingPhilosophy = "\n\n" +
+		"Pairing philosophy — " +
+		"archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches. " +
+		"Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph? " +
+		"Use grep for raw enumeration: every `if err != nil`, every import line, every TODO. " +
+		"Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet."
+	return mcpapi.NewToolResultText(msg + pairingPhilosophy), nil
 }
 
 // wrap is the shared handler middleware: telemetry + lazy reload + panic guard

--- a/skills/archigraph-quality-check/SKILL.md
+++ b/skills/archigraph-quality-check/SKILL.md
@@ -20,6 +20,18 @@ Invoke when the user asks for any of:
 
 Do **not** invoke for one-off lookups, ad-hoc grep substitution, or to "test the daemon" - the daemon health-check is a separate concern.
 
+## MCP + grep, paired
+
+archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches.
+Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph?
+Use grep for raw enumeration: every `if err != nil`, every import line, every TODO.
+Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet.
+
+This benchmark exists precisely to measure whether archigraph MCP earns its place in that pairing:
+if it does not outperform grep+read on structural questions, the pair is unbalanced and docgen will
+burn tokens for no quality gain. Phases 2 and 3 operationalise the pairing by running each side
+independently then comparing outcomes.
+
 ## Why this skill exists
 
 A predecessor MCP tool ("Tool A") was empirically found to consume **3-6× more tokens than grep+read** on representative questions, while not improving answer quality. This skill is the gate that confirms archigraph does not have the same failure mode. It is the formal step between "we built archigraph" and "we have evidence archigraph helps."

--- a/skills/generate-docs/SKILL.md
+++ b/skills/generate-docs/SKILL.md
@@ -113,6 +113,19 @@ Do not invoke it for one-off docstrings, README touch-ups, or commit-message wri
 
 If the daemon is not running, the skill stops at Pass 0 and tells the user to run `archigraph start`. If a repo is not yet registered, the skill tells the user to run `archigraph register <repo-path>`. Do not invoke `archigraph index` directly — it is now a thin RPC client that delegates to the daemon.
 
+## MCP + grep, paired
+
+archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches.
+Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph?
+Use grep for raw enumeration: every `if err != nil`, every import line, every TODO.
+Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet.
+
+In the docgen pipeline this means: use MCP tools (`archigraph_find`, `archigraph_callers`,
+`archigraph_clusters`) to build the structural inventory and navigate entity relationships across
+passes; use grep/`rg` inside individual writer subagents to confirm exact symbol spellings, locate
+concrete source lines for code excerpts, or enumerate every occurrence of a pattern that MCP models
+at the entity level rather than the text level.
+
 ## Pass numbering (Pass 0 through Pass 13)
 
 The skill is a strict pipeline. Each pass has a dedicated prompt file under `prompts/`. A subagent reads the prompt and follows it; the orchestrator (this skill) tracks progress and gates each pass on the previous one's output.


### PR DESCRIPTION
Fixes #1836.

## 1. What this PR does

Embeds the canonical MCP + grep pairing philosophy verbatim across 6 surfaces so every agent onboarding path — MCP handshake, repo CLAUDE.md, skill docs, docgen reference — carries the same positioning text consistently.

## 2. Where the canonical text appears (all 6 surfaces)

| Surface | File | Placement |
|---------|------|-----------|
| MCP handshake sentinel | `internal/mcp/server.go` | Appended to every `handleStatus` response body — agents receive it when calling `archigraph_status` before a group is indexed |
| Repo Claude.md | `CLAUDE.md` (new file) | Top-level "When to use archigraph MCP vs grep" section with 3 concrete examples |
| generate-docs skill | `skills/generate-docs/SKILL.md` | New "MCP + grep, paired" section before the Pass numbering table |
| quality-check skill | `skills/archigraph-quality-check/SKILL.md` | New "MCP + grep, paired" section between "When to use" and "Why this skill exists" |
| Docgen LLM mode doc | `docs/docgen-llm-mode.md` | New "MCP + grep, paired" section between the intro and the 5-tier ladder |
| README | `README.md` | One-line callout in the Usage section linking to `CLAUDE.md#when-to-use-archigraph-mcp-vs-grep` |

The canonical four-line block appears verbatim in surfaces 1–5:
```
archigraph MCP gives you a navigable, accurate map of the code; grep gives you raw pattern matches.
Use MCP for structural questions: who calls X? what is the flow? where does Y live in the graph?
Use grep for raw enumeration: every `if err != nil`, every import line, every TODO.
Pair them: MCP narrows the search space; grep verifies edge-property questions MCP can't answer yet.
```

## 3. Constraints respected

- Zero code logic changes — pure text additions to Go string constants and markdown files.
- No paraphrasing of the canonical block; every surface uses it verbatim.
- Cross-platform per #1777: Go string constant + markdown only.
- `go build ./...` and `go vet ./internal/mcp/...` clean.
- The 4 pre-existing test failures (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) are present on `main` before this branch — confirmed by running them on a stash of this branch's changes. They are not introduced by this PR.

## 4. Agent-onboarding behavior change

Before this PR, an agent encountering `archigraph_status` (the sentinel — shown when no group covers the cwd) received only a navigation instruction ("run `archigraph install`"). After this PR, the same response body includes the pairing philosophy, so the agent immediately learns:
- MCP is for structural traversal, not text enumeration.
- grep is the complement, not the replacement.
- The two tools compose: MCP narrows scope, grep verifies text-level detail.

This changes the first-contact moment: agents that land in an unindexed directory and call `archigraph_status` to understand the tool will carry the pairing contract into subsequent calls, even before a group is registered. CLAUDE.md reinforces this for agents that read repo context at session start. The skills reinforce it at invocation time.

## 5. Testing

```sh
# Build clean
go build ./...
go vet ./internal/mcp/...

# Canonical text present on all 6 surfaces
grep -r "MCP narrows the search space" \
  internal/mcp/server.go CLAUDE.md \
  docs/docgen-llm-mode.md \
  skills/generate-docs/SKILL.md \
  skills/archigraph-quality-check/SKILL.md
# → 5 hits (README uses a link, not the full phrase — by design)

grep "CLAUDE.md" README.md
# → line 183: callout in Usage section
```

## 6. Pre-existing test failures (not introduced here)

`TestMCPHandshakeBudget` and `TestMCPToolDescriptions` fail on `main` because `archigraph_status` description is 197 chars (limit 80) and tool count is 30 vs expected 29. These are tracked separately and should be addressed in a follow-up that adjusts the budget ceiling or trims the sentinel description. This PR does not touch the sentinel description constant.

## 7. Rollout / merge notes

Pure text. No flag, no migration, no rollback concern. Safe to merge at any time after review. Do NOT merge until owner approves (2026-05-23 lock per task instructions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)