### PR TITLE
feat(mcp): archigraph_stats breakdown for unresolved-edge taxonomies (#1837)

### DIFF
--- a/internal/mcp/docgen_repair_tools.go
+++ b/internal/mcp/docgen_repair_tools.go
@@ -14,9 +14,11 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"strings"
 
 	"github.com/cajasmota/archigraph/internal/daemon"
 	"github.com/cajasmota/archigraph/internal/enrichment"
+	"github.com/cajasmota/archigraph/internal/graph"
 	mcpapi "github.com/mark3labs/mcp-go/mcp"
 )
 
@@ -200,4 +202,223 @@ func countEdgeRepairsFromCandidates(repairs []enrichment.DocgenRepairCandidate) 
 		}
 	}
 	return n
+}
+
+// ---------------------------------------------------------------------------
+// Unresolved-import breakdown (breakdown="unresolved_imports")
+// ---------------------------------------------------------------------------
+
+// UnresolvedBreakdown holds the three supplementary fields returned when
+// breakdown="unresolved_imports" is requested on archigraph_stats.
+type UnresolvedBreakdown struct {
+	ByDisposition map[string]int     `json:"unresolved_imports_by_disposition"`
+	ByLanguage    map[string]int     `json:"unresolved_imports_by_language"`
+	TopRoots      []importRootEntry  `json:"unresolved_imports_top_roots"`
+}
+
+// importRootEntry is one row in the top-N import roots table.
+type importRootEntry struct {
+	Root        string `json:"root"`
+	Count       int    `json:"count"`
+	Disposition string `json:"disposition"`
+}
+
+// unresolvedImportDisposition derives a human-readable disposition label for a
+// single unresolved edge using signals available in the serialised graph
+// document (ToID shape + Relationship.Properties). It does NOT reproduce the
+// full resolver Disposition enum; it maps to a coarser taxonomy that is useful
+// for triage:
+//
+//   - "proto_generated"        — source_module / ToID matches proto/grpc patterns.
+//   - "cross_repo"             — source_module contains a "/" (Go-style module
+//     path) or "." separated segments that look like an org/repo prefix, and
+//     the root is not a stdlib/well-known package.
+//   - "same_package_unqualified" — ToID is a bare unqualified name with no
+//     separator characters (no ".", "/", ":", "#", " ").
+//   - "external_unknown"       — dotted path / package that is not in-project
+//     but does not match the above categories.
+//   - "other"                  — catch-all.
+//
+// Limitation: without the resolver's per-import binding the cross_repo /
+// external_unknown boundary is heuristic. A dedicated per-edge disposition
+// property on the graph schema (tracked as a separate enhancement) would make
+// this exact. See discussion in #1837.
+func unresolvedImportDisposition(rel *graph.Relationship) string {
+	toID := rel.ToID
+	srcMod := ""
+	if rel.Properties != nil {
+		srcMod = rel.Properties["source_module"]
+	}
+
+	// Proto/gRPC generated code: proto package paths, protobuf imports,
+	// grpc stubs.
+	if matchesProto(toID) || matchesProto(srcMod) {
+		return "proto_generated"
+	}
+
+	// Cross-repo heuristic: a Go-style module path (contains "/") or a
+	// multi-segment dotted path whose root segment looks like an org prefix.
+	// We use source_module when available (IMPORTS edges) and fall back to
+	// ToID (CALLS/REFERENCES edges).
+	ref := srcMod
+	if ref == "" {
+		ref = toID
+	}
+	if strings.Contains(ref, "/") {
+		return "cross_repo"
+	}
+
+	// Same-package unqualified: ToID has no separator → bare symbol name.
+	if !strings.ContainsAny(toID, "./:# ") && toID != "" {
+		return "same_package_unqualified"
+	}
+
+	// Dotted paths without "/" are treated as external package references
+	// (Python, JS, etc.).
+	if strings.Contains(ref, ".") {
+		return "external_unknown"
+	}
+
+	return "other"
+}
+
+// matchesProto returns true when s looks like a proto/gRPC import path.
+func matchesProto(s string) bool {
+	if s == "" {
+		return false
+	}
+	sl := strings.ToLower(s)
+	return strings.Contains(sl, "proto") ||
+		strings.Contains(sl, "grpc") ||
+		strings.Contains(sl, ".pb.") ||
+		strings.HasSuffix(sl, "_pb") ||
+		strings.HasSuffix(sl, "_pb2") ||
+		strings.HasSuffix(sl, "_grpc")
+}
+
+// importRoot extracts the first path segment from an import reference.
+// For "opentelemetry.trace" → "opentelemetry".
+// For "github.com/org/repo/pkg" → "github.com" (full first slash-segment).
+// For a bare name like "myFunc" → "myFunc".
+func importRoot(rel *graph.Relationship) string {
+	ref := rel.ToID
+	if rel.Properties != nil {
+		if sm := rel.Properties["source_module"]; sm != "" {
+			ref = sm
+		}
+	}
+	if ref == "" {
+		return ""
+	}
+	// slash-first (Go module paths)
+	if idx := strings.Index(ref, "/"); idx > 0 {
+		return ref[:idx]
+	}
+	// dot-first (Python, TS, etc.)
+	if idx := strings.Index(ref, "."); idx > 0 {
+		return ref[:idx]
+	}
+	return ref
+}
+
+// computeUnresolvedBreakdown iterates the unresolved edges across all repos in
+// repos and builds the three breakdown maps. repos is the already-filtered
+// slice used by handleGraphStats.
+//
+// The top-roots list is capped at topN (default 10) entries, sorted by count
+// descending. Ties are broken alphabetically by root name for stable output.
+func computeUnresolvedBreakdown(repos []*LoadedRepo, topN int) UnresolvedBreakdown {
+	byDisp := map[string]int{}
+	byLang := map[string]int{}
+	// rootKey → (count, disposition of the majority)
+	type rootStat struct {
+		count       int
+		dispCounts  map[string]int
+	}
+	roots := map[string]*rootStat{}
+
+	for _, r := range repos {
+		if r == nil || r.Doc == nil {
+			continue
+		}
+		for i := range r.Doc.Relationships {
+			rel := &r.Doc.Relationships[i]
+			if rel.Kind != "CALLS" && rel.Kind != "IMPORTS" && rel.Kind != "REFERENCES" {
+				continue
+			}
+			if !isBugEdgeToID(rel.ToID) {
+				continue
+			}
+
+			disp := unresolvedImportDisposition(rel)
+			byDisp[disp]++
+
+			// Language: from the source entity when the ByID index is available,
+			// otherwise from rel.Properties["language"].
+			lang := ""
+			if r.ByID != nil {
+				if ent := r.ByID[rel.FromID]; ent != nil {
+					lang = strings.ToLower(ent.Language)
+				}
+			}
+			if lang == "" && rel.Properties != nil {
+				lang = strings.ToLower(rel.Properties["language"])
+			}
+			if lang == "" {
+				lang = "unknown"
+			}
+			byLang[lang]++
+
+			// Top roots.
+			root := importRoot(rel)
+			if root == "" {
+				root = "(empty)"
+			}
+			rs := roots[root]
+			if rs == nil {
+				rs = &rootStat{dispCounts: map[string]int{}}
+				roots[root] = rs
+			}
+			rs.count++
+			rs.dispCounts[disp]++
+		}
+	}
+
+	// Build sorted top-N list.
+	type kv struct {
+		root  string
+		count int
+		disp  string
+	}
+	flat := make([]kv, 0, len(roots))
+	for root, rs := range roots {
+		// Pick the dominant disposition for this root.
+		bestDisp, bestCount := "other", 0
+		for d, c := range rs.dispCounts {
+			if c > bestCount || (c == bestCount && d < bestDisp) {
+				bestDisp = d
+				bestCount = c
+			}
+		}
+		flat = append(flat, kv{root, rs.count, bestDisp})
+	}
+	sort.Slice(flat, func(i, j int) bool {
+		if flat[i].count != flat[j].count {
+			return flat[i].count > flat[j].count
+		}
+		return flat[i].root < flat[j].root
+	})
+	if len(flat) > topN {
+		flat = flat[:topN]
+	}
+	topRoots := make([]importRootEntry, len(flat))
+	for i, f := range flat {
+		topRoots[i] = importRootEntry{Root: f.root, Count: f.count, Disposition: f.disp}
+	}
+
+	return UnresolvedBreakdown{
+		ByDisposition: byDisp,
+		ByLanguage:    byLang,
+		TopRoots:      topRoots,
+	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -338,10 +338,11 @@ func (s *Server) registerTools() {
 	), s.wrap("archigraph_clusters", s.handleListCommunities))
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_stats",
-		mcpapi.WithDescription("Corpus-level metrics for the resolved group."),
+		mcpapi.WithDescription("Corpus-level metrics. breakdown=unresolved_imports adds edge taxonomy."),
 		mcpapi.WithAny("group"),
 		mcpapi.WithAny("cwd"),
 		mcpapi.WithArray("repo_filter"),
+		mcpapi.WithString("breakdown", mcpapi.Description("Taxonomy breakdown. Supported: \"unresolved_imports\".")),
 	), s.wrap("archigraph_stats", s.handleGraphStats))
 
 	// archigraph_enrichments — action: list|submit|reject.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -735,6 +735,199 @@ func TestGraphStatsRepoFilter(t *testing.T) {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// #1837 archigraph_stats breakdown="unresolved_imports"
+// ---------------------------------------------------------------------------
+
+// fixtureDocWithUnresolved builds a small graph that contains a mix of resolved
+// and unresolved IMPORTS/CALLS edges so breakdown assertions have something to
+// bite on.
+func fixtureDocWithUnresolved(repo string) *graph.Document {
+	return &graph.Document{
+		Version:     1,
+		GeneratedAt: time.Now(),
+		Repo:        repo,
+		Entities: []graph.Entity{
+			{ID: "e1", Name: "ServiceA", Kind: "class", SourceFile: "svc/a.py", Language: "python"},
+			{ID: "e2", Name: "ServiceB", Kind: "class", SourceFile: "svc/b.ts", Language: "typescript"},
+			{ID: "e3", Name: "ServiceC", Kind: "class", SourceFile: "svc/c.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			// Resolved: hex ToID
+			{ID: "r1", FromID: "e1", ToID: "e2", Kind: "CALLS"},
+			// Unresolved: external Python package (dotted, no slash)
+			{
+				ID: "r2", FromID: "e1", ToID: "opentelemetry.trace", Kind: "IMPORTS",
+				Properties: map[string]string{"source_module": "opentelemetry.trace"},
+			},
+			// Unresolved: bare name (same-package unqualified)
+			{ID: "r3", FromID: "e2", ToID: "MyHelper", Kind: "CALLS"},
+			// Unresolved: Go module path (cross-repo)
+			{
+				ID: "r4", FromID: "e3", ToID: "github.com/myorg/shared/pkg", Kind: "IMPORTS",
+				Properties: map[string]string{"source_module": "github.com/myorg/shared/pkg"},
+			},
+			// Unresolved: proto import
+			{
+				ID: "r5", FromID: "e1", ToID: "myservice_pb2", Kind: "IMPORTS",
+				Properties: map[string]string{"source_module": "myservice_pb2"},
+			},
+			// Unresolved: another external Python package
+			{
+				ID: "r6", FromID: "e1", ToID: "opentelemetry.sdk", Kind: "IMPORTS",
+				Properties: map[string]string{"source_module": "opentelemetry.sdk"},
+			},
+		},
+	}
+}
+
+// TestStatsBreakdownUnresolvedImports verifies that breakdown="unresolved_imports"
+// returns the three extra fields with sensible values and does not disturb the
+// base fields present without breakdown.
+func TestStatsBreakdownUnresolvedImports(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "rX")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeGraph(t, repo, fixtureDocWithUnresolved("rX"))
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"rX": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// --- 1. Without breakdown: behavior unchanged, no extra fields. ---
+	resBase := callTool(t, srv, "archigraph_stats", nil)
+	var base map[string]any
+	if err := json.Unmarshal([]byte(resultText(resBase)), &base); err != nil {
+		t.Fatalf("unmarshal base: %v", err)
+	}
+	if _, ok := base["unresolved_imports_by_disposition"]; ok {
+		t.Error("base response must NOT contain unresolved_imports_by_disposition")
+	}
+	if _, ok := base["unresolved_imports_by_language"]; ok {
+		t.Error("base response must NOT contain unresolved_imports_by_language")
+	}
+	if _, ok := base["unresolved_imports_top_roots"]; ok {
+		t.Error("base response must NOT contain unresolved_imports_top_roots")
+	}
+	// fidelity should be present (5 unresolved out of 6 import-class edges)
+	if _, ok := base["fidelity"]; !ok {
+		t.Error("base response must contain fidelity")
+	}
+
+	// --- 2. With breakdown="unresolved_imports": three extra fields present and non-empty. ---
+	resBD := callTool(t, srv, "archigraph_stats", map[string]any{"breakdown": "unresolved_imports"})
+	var bd struct {
+		Fidelity                     float64          `json:"fidelity"`
+		FidelityImportTotal          int              `json:"fidelity_import_total"`
+		FidelityImportBug            int              `json:"fidelity_import_bug"`
+		Entities                     int              `json:"entities"`
+		ByDisposition                map[string]int   `json:"unresolved_imports_by_disposition"`
+		ByLanguage                   map[string]int   `json:"unresolved_imports_by_language"`
+		TopRoots                     []map[string]any `json:"unresolved_imports_top_roots"`
+	}
+	if err := json.Unmarshal([]byte(resultText(resBD)), &bd); err != nil {
+		t.Fatalf("unmarshal breakdown: %v: %s", err, resultText(resBD))
+	}
+	// Core fields still present.
+	if bd.Entities != 3 {
+		t.Errorf("entities: want 3, got %d", bd.Entities)
+	}
+	if bd.FidelityImportBug == 0 {
+		t.Error("expected non-zero fidelity_import_bug")
+	}
+	// Breakdown fields non-empty.
+	if len(bd.ByDisposition) == 0 {
+		t.Error("unresolved_imports_by_disposition must not be empty")
+	}
+	if len(bd.ByLanguage) == 0 {
+		t.Error("unresolved_imports_by_language must not be empty")
+	}
+	if len(bd.TopRoots) == 0 {
+		t.Error("unresolved_imports_top_roots must not be empty")
+	}
+	// Check specific expected values.
+	if bd.ByDisposition["proto_generated"] == 0 {
+		t.Error("expected at least one proto_generated edge (myservice_pb2)")
+	}
+	if bd.ByDisposition["cross_repo"] == 0 {
+		t.Error("expected at least one cross_repo edge (github.com/myorg/shared/pkg)")
+	}
+	if bd.ByDisposition["same_package_unqualified"] == 0 {
+		t.Error("expected at least one same_package_unqualified edge (MyHelper)")
+	}
+	if bd.ByDisposition["external_unknown"] == 0 {
+		t.Error("expected at least one external_unknown edge (opentelemetry.*)")
+	}
+	// opentelemetry should be the top root (2 occurrences).
+	if len(bd.TopRoots) > 0 {
+		if topRoot, _ := bd.TopRoots[0]["root"].(string); topRoot != "opentelemetry" {
+			t.Errorf("expected top root to be \"opentelemetry\", got %q", topRoot)
+		}
+	}
+
+	// --- 3. breakdown="invalid_value": returns a clear error. ---
+	resErr := callTool(t, srv, "archigraph_stats", map[string]any{"breakdown": "invalid_value"})
+	txt := resultText(resErr)
+	if !strings.Contains(txt, "unsupported breakdown") {
+		t.Errorf("expected error message for invalid breakdown, got: %s", txt)
+	}
+	if resErr.IsError != true {
+		t.Error("expected IsError=true for invalid breakdown key")
+	}
+}
+
+// TestStatsBreakdownEmptyGroup ensures that breakdown="unresolved_imports" on a
+// group with no unresolved edges returns the three fields as empty collections
+// rather than null/absent.
+func TestStatsBreakdownEmptyUnresolved(t *testing.T) {
+	dir := t.TempDir()
+	repo := filepath.Join(dir, "rClean")
+	if err := os.MkdirAll(repo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// fixtureDoc has only resolved (hex-like short but within the test-valid
+	// range) edges — but actually the short IDs "a1"/"a2" ARE unresolved (not
+	// 16-hex chars), so build a truly resolved fixture.
+	cleanDoc := &graph.Document{
+		Version: 1, GeneratedAt: time.Now(), Repo: "rClean",
+		Entities: []graph.Entity{
+			{ID: "aabb112233445566", Name: "Alpha", Kind: "function", SourceFile: "a.go", Language: "go"},
+			{ID: "bbcc223344556677", Name: "Beta", Kind: "function", SourceFile: "b.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: "aabb112233445566", ToID: "bbcc223344556677", Kind: "CALLS"},
+		},
+	}
+	writeGraph(t, repo, cleanDoc)
+	regPath := makeRegistry(t, dir, map[string]map[string]string{"g": {"rClean": repo}})
+	srv, err := NewServer(Config{RegistryPath: regPath})
+	if err != nil {
+		t.Fatal(err)
+	}
+	res := callTool(t, srv, "archigraph_stats", map[string]any{"breakdown": "unresolved_imports"})
+	var out struct {
+		ByDisposition map[string]int   `json:"unresolved_imports_by_disposition"`
+		ByLanguage    map[string]int   `json:"unresolved_imports_by_language"`
+		TopRoots      []map[string]any `json:"unresolved_imports_top_roots"`
+	}
+	if err := json.Unmarshal([]byte(resultText(res)), &out); err != nil {
+		t.Fatalf("unmarshal clean: %v: %s", err, resultText(res))
+	}
+	// Empty maps/slices — not nil/absent.
+	if out.ByDisposition == nil {
+		t.Error("unresolved_imports_by_disposition should be an empty map, not nil")
+	}
+	if out.ByLanguage == nil {
+		t.Error("unresolved_imports_by_language should be an empty map, not nil")
+	}
+	if out.TopRoots == nil {
+		t.Error("unresolved_imports_top_roots should be an empty slice, not nil")
+	}
+}
+
 // ADR-0015 phase-1 (#549 + #550): archigraph_repairs action=list|submit round-trip.
 func TestRepairToolsRoundTrip(t *testing.T) {
 	dir := t.TempDir()

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -1478,6 +1478,17 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 	if errRes != nil {
 		return errRes, nil
 	}
+	// Optional breakdown selector. Currently only "unresolved_imports" is
+	// supported. Any other non-empty value returns an error so callers learn
+	// about the supported keys early rather than silently getting a partial
+	// response.
+	breakdown := argString(req, "breakdown", "")
+	if breakdown != "" && breakdown != "unresolved_imports" {
+		return mcpapi.NewToolResultError(fmt.Sprintf(
+			"unsupported breakdown value %q — supported values: \"unresolved_imports\"", breakdown,
+		)), nil
+	}
+
 	// Build the set of repo names to consider. Empty filter or ["*"]
 	// means "every loaded repo" (matching reposToConsider semantics).
 	filter := argStringSlice(req, "repo_filter")
@@ -1501,6 +1512,9 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 	}
 	sort.Strings(names)
 	totalImport, totalBug := 0, 0
+	// Collect the loaded repos so we can pass them to computeUnresolvedBreakdown
+	// without a second pass over the names slice.
+	var loadedRepos []*LoadedRepo
 	for _, name := range names {
 		r := lg.Repos[name]
 		if r == nil {
@@ -1521,6 +1535,7 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 			"relationships": len(r.Doc.Relationships),
 			"communities":   len(r.Doc.Communities),
 		})
+		loadedRepos = append(loadedRepos, r)
 	}
 	totals["entities"] = totalE
 	totals["relationships"] = totalR
@@ -1550,6 +1565,15 @@ func (s *Server) handleGraphStats(ctx context.Context, req mcpapi.CallToolReques
 	if len(unavailable) > 0 {
 		totals["unavailable"] = unavailable
 	}
+
+	// breakdown="unresolved_imports": add the three taxonomy fields.
+	if breakdown == "unresolved_imports" {
+		bd := computeUnresolvedBreakdown(loadedRepos, 10)
+		totals["unresolved_imports_by_disposition"] = bd.ByDisposition
+		totals["unresolved_imports_by_language"] = bd.ByLanguage
+		totals["unresolved_imports_top_roots"] = bd.TopRoots
+	}
+
 	return jsonResult(totals), nil
 }
 


### PR DESCRIPTION
Fixes #1837.

## 1 — What & Why

Adds an optional `breakdown=` parameter to `archigraph_stats`. When `breakdown="unresolved_imports"`, the response includes three additional fields that give a per-disposition, per-language, and top-root taxonomy of unresolved edges — all in a single MCP call.

**Motivation (Grind B / PR #1833 experiment):** The bug-rate experiment on polyglot-platform required 10+ minutes of grep enumeration to classify 372 unresolved Python imports by disposition. This feature reduces that to one call: `archigraph_stats(group=..., breakdown="unresolved_imports")`.

## 2 — Live call against polyglot-platform

```json
{
  "fidelity": 0.737,
  "fidelity_import_bug": 367,
  "fidelity_import_total": 1394,
  "unresolved_imports_by_disposition": {
    "cross_repo": 82,
    "external_unknown": 34,
    "other": 47,
    "same_package_unqualified": 204
  },
  "unresolved_imports_by_language": {
    "dockerfile": 28,
    "elixir": 24,
    "go": 34,
    "java": 6,
    "kotlin": 6,
    "php": 11,
    "python": 122,
    "rust": 9,
    "terraform": 2,
    "typescript": 110,
    "unknown": 15
  },
  "unresolved_imports_top_roots": [
    {"count": 31, "disposition": "cross_repo", "root": "scope:component:ref:typescript:src"},
    {"count": 28, "disposition": "cross_repo", "root": "scope:component:ref:typescript:handlers"},
    {"count": 17, "disposition": "same_package_unqualified", "root": "post"},
    {"count": 17, "disposition": "other", "root": "py_shared"},
    {"count": 10, "disposition": "same_package_unqualified", "root": "AsyncClient"},
    {"count": 8, "disposition": "cross_repo", "root": "scope:operation:method:terraform:multi-region"},
    {"count": 7, "disposition": "other", "root": "node:20-alpine"},
    {"count": 7, "disposition": "external_unknown", "root": "python:3"},
    {"count": 6, "disposition": "same_package_unqualified", "root": "consumer"},
    {"count": 6, "disposition": "cross_repo", "root": "scope:operation:method:go:internal"}
  ]
}
```

**Key findings from live data:**
- 204 of 367 unresolved edges are `same_package_unqualified` (bare names like `post`, `AsyncClient`) — the dominant category, not external packages
- 82 are cross-repo stubs (structured `scope:*` ToIDs from TS component refs + terraform module paths)
- Python (122) and TypeScript (110) account for 64% of all unresolved edges
- `py_shared` (17 occurrences) lands in `other` because the heuristic sees no separator — see heuristic note in §7

## 3 — Changes

**`internal/mcp/docgen_repair_tools.go`** (new functions at bottom):
- `UnresolvedBreakdown` struct — the three new response fields
- `unresolvedImportDisposition(rel)` — derives disposition label from ToID shape + `source_module` property; maps to `proto_generated`, `cross_repo`, `same_package_unqualified`, `external_unknown`, `other`
- `matchesProto(s)` — proto/gRPC pattern matcher
- `importRoot(rel)` — extracts first path segment for top-N aggregation
- `computeUnresolvedBreakdown(repos, topN)` — one pass over all relationships in the group, builds all three maps, caps top-N at 10

**`internal/mcp/tools.go`** (`handleGraphStats`):
- Read `breakdown` arg; return error for unsupported values
- Collect `loadedRepos` slice during the existing repo loop (no extra pass)
- After the existing stats, call `computeUnresolvedBreakdown` and merge the 3 fields into `totals`
- Default behavior (no `breakdown` arg) is fully unchanged

**`internal/mcp/server.go`**:
- Added `breakdown` string param to `archigraph_stats` tool schema (description within 80-char limit)

## 4 — How this closes the edge-property-question gap

Before this PR, answering "what are the main categories of unresolved imports in this group?" required:
1. `archigraph_list_residuals` (paginated, returns raw edges with no aggregation)
2. Multiple grep calls over source files to identify package origins
3. Manual tallying by disposition type and language

After this PR, it is one call: `archigraph_stats(breakdown="unresolved_imports")`. The three fields (by_disposition, by_language, top_roots) answer the triage questions that drove 10+ minutes of manual grep work in Grind B.

**Disposition derivation:** The graph document does not store a per-edge disposition property (the resolver's `Disposition` enum lives in memory during indexing and is not serialised to `graph.json`). Disposition is therefore derived at query time from signals in the serialised graph: `ToID` shape (hex = resolved, `ext:` = external, bare = unresolved), `source_module` property (Go module paths contain `/`; Python paths use `.`; proto/gRPC patterns matched by name). This is a heuristic, but accurately reflects the main categories for triage purposes. Adding a serialised `disposition` property to the graph schema would make this exact — tracked separately.

## 5 — Test plan

All tests pass (except the 4 pre-existing failures introduced by `archigraph_status` being added to origin/main after this branch was cut — `TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions` all fail on base `origin/main` too):

```
=== RUN   TestStatsBreakdownUnresolvedImports
--- PASS: TestStatsBreakdownUnresolvedImports (0.01s)
=== RUN   TestStatsBreakdownEmptyUnresolved
--- PASS: TestStatsBreakdownEmptyUnresolved (0.01s)
=== RUN   TestGraphStatsRepoFilter
--- PASS: TestGraphStatsRepoFilter (0.01s)
```

New tests cover:
- `breakdown="unresolved_imports"`: all 3 fields present, specific disposition categories verified (proto_generated, cross_repo, same_package_unqualified, external_unknown), top root is correct
- `breakdown=""` (absent): base behavior unchanged, no extra fields present
- `breakdown="invalid_value"`: returns `IsError=true` with "unsupported breakdown" in message
- Empty-unresolved group: returns empty maps/slices (not nil)

## 6 — Scope & isolation

Work is entirely in `internal/mcp/` — disjoint from in-flight Grind A (`internal/extractors/golang/`, `internal/resolve/`) and #1836 (positioning text). No daemon changes, no schema changes outside the tool registration.

Cross-platform: pure Go aggregation, no syscalls. CI matrix verifies.

## 7 — Known heuristic limitations

The disposition taxonomy is heuristic because the graph document does not store a serialised `disposition` property per edge. Two notable misclassifications visible in the live data:
- `scope:component:ref:typescript:src` — structured internal TS component stubs classified as `cross_repo` because the ToID contains `/`; these are actually unresolved internal stubs, not cross-repo imports
- `py_shared` — cross-module library reference classified as `other` because the bare identifier has no separator character; a per-edge `source_module` property would resolve this

A follow-on ticket to serialise the resolver's disposition to `graph.json` would make the breakdown exact. This PR is intentionally additive and does not invent categories — it maps the available signals to a triage-useful taxonomy.