### PR TITLE
feat(extractor/golang): resolve struct field references via receiver type chain (#1840, biggest archigraph fidelity lever)

### DIFF
--- a/internal/extractors/golang/references.go
+++ b/internal/extractors/golang/references.go
@@ -141,6 +141,15 @@ type goFrame struct {
 	funcLeafName    string // bare leaf name of the enclosing operation
 	receiverType    string // "" outside a method; receiver type otherwise
 	receiverVar     string // bound name of the receiver parameter (e.g. "r" for `(r *Foo)`)
+	// varTypes is the per-function local-variable type table built by
+	// buildFunctionVarTypes in type_table.go (#1840). Maps a bound name
+	// (parameter, receiver, short-var-decl LHS, var-spec name) to its
+	// canonical type literal. handleGoSelector consults this when the
+	// selector's operand is a bare identifier that isn't the receiver
+	// var and isn't a PascalCase type/import — i.e. the dominant
+	// `<localVar>.<field>` shape that drove same_package_unqualified
+	// on the archigraph corpus.
+	varTypes goVarTypes
 }
 
 // emitReferences is the second-pass entry point invoked from Extract
@@ -271,7 +280,15 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 	type edgeKey struct{ from, to string }
 	seen := make(map[edgeKey]bool)
 
-	emit := func(fstack []goFrame, sym goSymbol) {
+	// emit appends a REFERENCES edge from the top-of-stack function to
+	// the resolved symbol. When viaReceiverType is non-empty, it's
+	// stamped on the edge's Properties as a diagnostic so #1840's
+	// "resolved via local-var type chain" cases are visible in
+	// audits (e.g. you can count how many edges the v1 lightweight
+	// scope rescued from same_package_unqualified). Empty
+	// viaReceiverType produces a property-less edge for parity with
+	// pre-#1840 receiver / PascalCase paths.
+	emit := func(fstack []goFrame, sym goSymbol, viaReceiverType string) {
 		if len(fstack) == 0 {
 			return
 		}
@@ -289,11 +306,14 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 			return
 		}
 		toID := buildGoReferenceTargetID(file.Path, sym)
-		(*entities)[idx].Relationships = append((*entities)[idx].Relationships,
-			types.RelationshipRecord{
-				ToID: toID,
-				Kind: "REFERENCES",
-			})
+		rec := types.RelationshipRecord{
+			ToID: toID,
+			Kind: "REFERENCES",
+		}
+		if viaReceiverType != "" {
+			rec.Properties = map[string]string{"via_receiver_type": viaReceiverType}
+		}
+		(*entities)[idx].Relationships = append((*entities)[idx].Relationships, rec)
 	}
 
 	var walk func(n *sitter.Node, fstack []goFrame)
@@ -326,11 +346,21 @@ func emitReferences(root *sitter.Node, file extractor.FileInput, entities *[]typ
 			if body == nil {
 				return
 			}
+			// #1840 — build the per-function var-type table so the
+			// selector handler can resolve `<localVar>.<field>`. Cost
+			// is one extra pass over the body's
+			// short_var_declaration / var_declaration nodes plus a
+			// scan of the parameter_list; both already done by the
+			// CALLS pass, so the absolute walk cost is small. When
+			// the function has no params and no typeable locals,
+			// buildFunctionVarTypes returns nil and the selector
+			// handler short-circuits via lookupVarType's nil check.
 			newFrame := goFrame{
 				funcEmittedName: emitted,
 				funcLeafName:    leaf,
 				receiverType:    recvType,
 				receiverVar:     recvVar,
+				varTypes:        buildFunctionVarTypes(n, file.Content),
 			}
 			newStack := fstack
 			if emitted != "" {
@@ -392,7 +422,7 @@ func handleGoIdentifier(
 	file extractor.FileInput,
 	fstack []goFrame,
 	bareSymbols map[string]goSymbol,
-	emit func([]goFrame, goSymbol),
+	emit func([]goFrame, goSymbol, string),
 ) {
 	name := nodeText(n, file.Content)
 	if name == "" {
@@ -422,7 +452,7 @@ func handleGoIdentifier(
 	if name == top.receiverVar && top.receiverVar != "" {
 		return
 	}
-	emit(fstack, sym)
+	emit(fstack, sym, "")
 }
 
 // handleGoSelector handles `obj.attr` (selector_expression) nodes:
@@ -441,7 +471,7 @@ func handleGoSelector(
 	fstack []goFrame,
 	bareSymbols map[string]goSymbol,
 	dottedSymbols map[string]goSymbol,
-	emit func([]goFrame, goSymbol),
+	emit func([]goFrame, goSymbol, string),
 ) {
 	// Skip if this selector IS the function child of a call_expression.
 	// The operand identifier is still picked up via the recursion (it's
@@ -479,7 +509,7 @@ func handleGoSelector(
 			if _, isReserved := goReservedNames[opName]; !isReserved {
 				if opName != top.funcLeafName && opName != top.receiverVar {
 					if sym, ok := bareSymbols[opName]; ok {
-						emit(fstack, sym)
+						emit(fstack, sym, "")
 					}
 				}
 			}
@@ -493,21 +523,60 @@ func handleGoSelector(
 		fieldName := nodeText(field, file.Content)
 		if fieldName != "" && opName != "" {
 			// Receiver-method `r.<field>` shape.
+			emittedViaPath := false
 			if top.receiverVar != "" && opName == top.receiverVar && top.receiverType != "" {
 				dotted := top.receiverType + "." + fieldName
 				if sym, ok := dottedSymbols[dotted]; ok {
 					if dotted != top.funcEmittedName {
-						emit(fstack, sym)
+						emit(fstack, sym, "")
+						emittedViaPath = true
 					}
 				}
 			}
 			// PascalCase receiver — `T.M` method expression or
 			// `T{Field: value}` composite literal field.
-			if isPascalCase(opName) {
+			if !emittedViaPath && isPascalCase(opName) {
 				dotted := opName + "." + fieldName
 				if sym, ok := dottedSymbols[dotted]; ok {
 					if dotted != top.funcEmittedName {
-						emit(fstack, sym)
+						emit(fstack, sym, "")
+						emittedViaPath = true
+					}
+				}
+			}
+			// #1840 — local-var type chain. When the operand is a
+			// bare identifier that didn't match the receiver-var
+			// path (above) and isn't a PascalCase type/import, try
+			// the per-function var-type table. This rescues the
+			// dominant same_package_unqualified bucket: parameters
+			// typed as a project struct, `:=`-declared composite
+			// literals, and `var x T` declarations where T is a
+			// same-file struct.
+			//
+			// Why guard on emittedViaPath: the receiver var is
+			// also present in varTypes (see buildFunctionVarTypes)
+			// so without the guard we'd double-emit the receiver
+			// `r.<field>` edge with two different code paths.
+			// PascalCase identifiers can also alias a local var
+			// (rare but legal), and again we'd double-emit; first-
+			// hit-wins is the right choice for a unique-edge
+			// invariant the seen-map already enforces, but the
+			// guard is cheaper than the second lookup + seen-check.
+			//
+			// Fallback semantics: a lookup miss (varTypes returns
+			// "" or the dotted lookup misses) leaves the selector
+			// unbound — the resolver downstream still routes it to
+			// the existing same_package_unqualified bucket. No
+			// regression risk vs. pre-#1840 behaviour.
+			if !emittedViaPath {
+				if opType := top.varTypes.lookupVarType(opName); opType != "" {
+					dotted := opType + "." + fieldName
+					if sym, ok := dottedSymbols[dotted]; ok {
+						if dotted != top.funcEmittedName {
+							// Stamp the resolved receiver type so audits
+							// can attribute rescued edges to this path.
+							emit(fstack, sym, opType)
+						}
 					}
 				}
 			}

--- a/internal/extractors/golang/type_table.go
+++ b/internal/extractors/golang/type_table.go
@@ -1,0 +1,129 @@
+// type_table.go — per-function local-variable type tracking for the
+// Go references pass (#1840).
+//
+// Background. Issue #1839's disposition breakdown on archigraph showed
+// `same_package_unqualified` is the dominant remaining bucket — 24,697
+// edges, 67% of all unresolved Go edges. The top-10 unresolved roots
+// (Relationships, ToID, Properties, Get, Subtype, ID, Contains, Name,
+// ...) are all struct *field names* referenced via a local variable
+// whose type the extractor never tracked. Example:
+//
+//	func (s *Server) handle(entry EntityRecord) {
+//	    fmt.Println(entry.ToID) // refs EntityRecord.ToID
+//	}
+//
+// `entry` is a parameter typed `EntityRecord`, and `entry.ToID` should
+// bind to the struct's ToID field. The existing references pass only
+// recognised two LHS shapes for `<expr>.<field>` selectors:
+//
+//  1. `r.<field>` where `r` is the enclosing method's receiver var.
+//  2. `T.<field>` where `T` is a PascalCase identifier (type / package).
+//
+// Anything else — a parameter, a `:=` short-var-decl, a `var x T` —
+// missed entirely. The infrastructure to type those names already
+// existed in extractor.go (`collectParamTypes`, `collectBodyVarTypes`,
+// `mergeVarTypes`) but was consumed only by extractCallRelationships
+// for CALLS edges. This file plumbs the same maps into the references
+// walk so REFERENCES selectors can resolve `<localVar>.<field>` against
+// dottedSymbols / structFields.
+//
+// Scope — v1 lightweight (per #1840 acceptance):
+//   - Function & method PARAMETERS with explicit types.
+//   - Method RECEIVER (`(s *Server)` → s is `Server`).
+//   - Short-var-decl whose RHS is a struct literal (`x := Foo{...}`,
+//     `x := &Foo{...}`).
+//   - `var x T` / `var x = Foo{...}`.
+//   - Short-var-decl from an allowlisted constructor (`r := chi.NewRouter()`).
+//
+// Out of scope (v2 ticket — TODO file separately if signal warrants):
+//   - Return-type chains across user-defined functions (`x := myFunc()` →
+//     resolve myFunc's declared return type). Requires a cross-function
+//     return-type table; deferred.
+//   - Interface dispatch / embedded type promotion.
+//   - Generic type inference.
+//   - Multi-LHS assignment (`a, b := f()`).
+//   - Closure capture beyond the immediate enclosing function.
+//
+// Why a separate file: keeps the references pass narrow (walk + emit)
+// and isolates the type-tracking concern so v2 can swap in a richer
+// implementation without touching emission logic.
+
+package golang
+
+import (
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// goVarTypes is a (varName → canonicalTypeName) map for a single
+// function/method scope. Canonical form strips a leading `*` and any
+// generic `[T]` suffix — the same form used by collectParamTypes /
+// collectBodyVarTypes so the maps are mergeable.
+//
+// The map is consumed during selector_expression resolution in
+// references.go. A miss leaves the selector unbound (graceful fallback
+// to same_package_unqualified, matching the pre-#1840 behaviour) — we
+// never crash and never emit a wrong edge.
+type goVarTypes map[string]string
+
+// buildFunctionVarTypes returns the var-type table for a function or
+// method body. Composes three sources, in lexical-scope order (outer
+// → inner), with mergeVarTypes' "drop on type conflict" semantics
+// preventing spurious bindings on shadowed names:
+//
+//  1. The receiver parameter, if this is a method_declaration. Bound to
+//     the receiver's value type (pointer stripped — pointer-vs-value
+//     receivers share their type's field set).
+//  2. Regular parameters from the function's parameter_list (via
+//     collectParamTypes). Already canonical.
+//  3. Local short-var-decls and var-decls inside the body (via
+//     collectBodyVarTypes). Already canonical, ambiguous names dropped.
+//
+// Returns nil when no name can be typed — callers can no-op cheaply.
+// All three sub-collectors are pre-existing infrastructure originally
+// added for CALLS-edge resolution (issue #364); this function is the
+// adapter that lets the references pass share them.
+//
+// Passing nil for funcOrMethodNode is safe and returns nil.
+func buildFunctionVarTypes(funcOrMethodNode *sitter.Node, src []byte) goVarTypes {
+	if funcOrMethodNode == nil {
+		return nil
+	}
+
+	var receiverMap map[string]string
+	if funcOrMethodNode.Type() == "method_declaration" {
+		recvNode := funcOrMethodNode.ChildByFieldName("receiver")
+		recvVar := receiverParamName(recvNode, src)
+		recvType := receiverTypeName(recvNode, src)
+		if recvVar != "" && recvType != "" {
+			receiverMap = map[string]string{recvVar: recvType}
+		}
+	}
+
+	paramsNode := funcOrMethodNode.ChildByFieldName("parameters")
+	paramMap := collectParamTypes(paramsNode, src)
+
+	bodyNode := funcOrMethodNode.ChildByFieldName("body")
+	bodyMap := collectBodyVarTypes(bodyNode, src)
+
+	// Merge in scope order: receiver → params → body. mergeVarTypes
+	// drops names with conflicting types (the conservative choice from
+	// #364 — better to miss than to mis-bind).
+	out := mergeVarTypes(receiverMap, paramMap)
+	out = mergeVarTypes(out, bodyMap)
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// lookupVarType returns the tracked type for varName, or "" when no
+// binding is recorded. Always safe on a nil receiver. The "" miss is
+// the graceful fallback path required by #1840 — callers proceed
+// without emitting an edge, leaving the selector as the existing
+// `same_package_unqualified` bucket.
+func (vt goVarTypes) lookupVarType(varName string) string {
+	if vt == nil || varName == "" {
+		return ""
+	}
+	return vt[varName]
+}

--- a/internal/extractors/golang/type_table_test.go
+++ b/internal/extractors/golang/type_table_test.go
@@ -1,0 +1,243 @@
+// type_table_test.go — coverage for the local-var type-chain
+// resolution path added in #1840.
+//
+// These tests assert that REFERENCES edges are emitted for selector
+// expressions whose LHS is a local-scope name typed as a project
+// struct, not just the receiver-method / PascalCase shapes the
+// references pass already handled. Each test exercises exactly one
+// of the three v1 lightweight scope cases enumerated in #1840:
+//
+//   - Parameter typed as a project struct.
+//   - Short-var-decl with composite literal RHS.
+//   - var-spec with explicit type.
+//
+// Cases NOT covered here (and intentionally so — they are v2):
+//   - Cross-file struct types (the symbol table is per-file).
+//   - Return-type chains across user-defined functions.
+//   - Interface dispatch and embedded type promotion.
+
+package golang
+
+import (
+	"testing"
+)
+
+// Parameter typed as a same-file struct. `entry.ToID` inside the
+// function body should resolve to the struct's ToID field via the
+// local-var type chain.
+func TestGoRefsStructFieldViaParameter(t *testing.T) {
+	src := `package demo
+
+type EntityRecord struct {
+	ToID string
+	Name string
+}
+
+func handle(entry EntityRecord) string {
+	return entry.ToID
+}
+`
+	ents := runGoExtract(t, src)
+	if !hasGoRef(ents, "handle", "EntityRecord") {
+		t.Fatalf("expected handle to REFERENCES EntityRecord (parameter type-chain); got %s",
+			goRelsSummary(ents))
+	}
+}
+
+// Method receiver typed as a same-file struct. `s.Name` inside the
+// method body should resolve via the receiver path (already worked
+// pre-#1840), but the receiver is also entered into varTypes, so the
+// local-var path should NOT double-emit. Verifies the dedup guard.
+func TestGoRefsReceiverPathStillResolves(t *testing.T) {
+	src := `package demo
+
+type Server struct {
+	Name string
+}
+
+func (s *Server) describe() string {
+	return s.Name
+}
+`
+	ents := runGoExtract(t, src)
+	if !hasGoRef(ents, "Server.describe", "Server") {
+		t.Fatalf("expected Server.describe to REFERENCES Server (receiver path); got %s",
+			goRelsSummary(ents))
+	}
+	// Count Server-receiver edges — must be exactly one (no double-emit).
+	count := 0
+	for _, e := range ents {
+		if e.Name != "Server.describe" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind == "REFERENCES" {
+				count++
+			}
+		}
+	}
+	if count != 1 {
+		t.Fatalf("expected exactly one REFERENCES edge on Server.describe, got %d (%s)",
+			count, goRelsSummary(ents))
+	}
+}
+
+// Short-var-decl with composite literal. `x := EntityRecord{}` types
+// x, and `x.ToID` resolves through the var-type table.
+func TestGoRefsStructFieldViaShortVarDecl(t *testing.T) {
+	src := `package demo
+
+type EntityRecord struct {
+	ToID string
+}
+
+func handle() string {
+	x := EntityRecord{ToID: "abc"}
+	return x.ToID
+}
+`
+	ents := runGoExtract(t, src)
+	if !hasGoRef(ents, "handle", "EntityRecord") {
+		t.Fatalf("expected handle to REFERENCES EntityRecord (short-var-decl chain); got %s",
+			goRelsSummary(ents))
+	}
+}
+
+// Short-var-decl with pointer composite literal. `x := &EntityRecord{}`
+// canonicalises to type `EntityRecord` (pointer stripped); same lookup
+// path works as the value-receiver case.
+func TestGoRefsStructFieldViaPointerShortVarDecl(t *testing.T) {
+	src := `package demo
+
+type EntityRecord struct {
+	ToID string
+}
+
+func handle() string {
+	x := &EntityRecord{ToID: "abc"}
+	return x.ToID
+}
+`
+	ents := runGoExtract(t, src)
+	if !hasGoRef(ents, "handle", "EntityRecord") {
+		t.Fatalf("expected handle to REFERENCES EntityRecord (pointer short-var-decl); got %s",
+			goRelsSummary(ents))
+	}
+}
+
+// var-spec with explicit type. `var x EntityRecord` types x via the
+// type field, and `x.ToID` resolves through the var-type table.
+func TestGoRefsStructFieldViaVarSpec(t *testing.T) {
+	src := `package demo
+
+type EntityRecord struct {
+	ToID string
+}
+
+func handle() string {
+	var x EntityRecord
+	return x.ToID
+}
+`
+	ents := runGoExtract(t, src)
+	if !hasGoRef(ents, "handle", "EntityRecord") {
+		t.Fatalf("expected handle to REFERENCES EntityRecord (var-spec); got %s",
+			goRelsSummary(ents))
+	}
+}
+
+// The via_receiver_type Properties stamp is emitted on edges resolved
+// through the local-var type chain. Lets audits attribute rescued
+// edges to this path vs. the older receiver / PascalCase paths.
+func TestGoRefsLocalVarChainStampsViaReceiverType(t *testing.T) {
+	src := `package demo
+
+type EntityRecord struct {
+	ToID string
+}
+
+func handle(entry EntityRecord) string {
+	return entry.ToID
+}
+`
+	ents := runGoExtract(t, src)
+	found := false
+	for _, e := range ents {
+		if e.Name != "handle" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			if r.Properties != nil && r.Properties["via_receiver_type"] == "EntityRecord" {
+				found = true
+				break
+			}
+		}
+	}
+	if !found {
+		t.Fatalf("expected handle REFERENCES edge with via_receiver_type=EntityRecord; got %s",
+			goRelsSummary(ents))
+	}
+}
+
+// Graceful fallback: an unknown LHS type produces no edge and no
+// crash. `entry` here is typed as an unrecognised type — the lookup
+// misses and emission is skipped silently.
+func TestGoRefsUnknownLHSTypeIsGraceful(t *testing.T) {
+	src := `package demo
+
+func handle(entry interface{}) {
+	_ = entry
+}
+`
+	ents := runGoExtract(t, src)
+	// No panic, no edge — just confirm we got entities back.
+	if len(ents) == 0 {
+		t.Fatalf("expected entities from runGoExtract even for unbindable type")
+	}
+}
+
+// Conflicting types on the same name across scopes are dropped by
+// mergeVarTypes, so neither lookup binds. Verifies the conservative
+// "drop on conflict" rule survives the wiring.
+func TestGoRefsAmbiguousNameDropsBinding(t *testing.T) {
+	src := `package demo
+
+type A struct {
+	F string
+}
+type B struct {
+	F string
+}
+
+func handle() {
+	x := A{}
+	_ = x
+	{
+		x := B{}
+		_ = x.F
+	}
+}
+`
+	ents := runGoExtract(t, src)
+	// We do not assert on absence of an A/B edge — collectBodyVarTypes
+	// flattens block scopes and drops the conflicting binding. What we
+	// assert is that extraction completes without crashing AND that we
+	// don't emit a mis-bound A.F edge (the inner reference is to B.F).
+	for _, e := range ents {
+		if e.Name != "handle" {
+			continue
+		}
+		for _, r := range e.Relationships {
+			if r.Kind != "REFERENCES" {
+				continue
+			}
+			if r.Properties != nil && r.Properties["via_receiver_type"] == "A" {
+				t.Fatalf("ambiguous binding produced A-typed edge (should have been dropped): %s",
+					goRelsSummary(ents))
+			}
+		}
+	}
+}


### PR DESCRIPTION
Fixes #1840.

## 1. Root cause

Issue #1839's disposition breakdown on the archigraph corpus pinned the dominant remaining Go-extractor fidelity gap: **`same_package_unqualified` = 24,697 edges, 67% of all unresolved Go edges**. The top-10 unresolved roots were not random — they were all struct *field names* referenced via a local variable whose type the extractor never tracked:

```
Relationships, ToID, Properties, Get, Subtype, ID, Contains, Name, ...
```

Concrete shape (taken straight from archigraph's own source):

```go
func (s *Server) handle(entry EntityRecord) {
    fmt.Println(entry.ToID) // should ref EntityRecord.ToID
}
```

`entry` is a parameter typed `EntityRecord`. `entry.ToID` should resolve to the struct's `ToID` field. The pre-existing `handleGoSelector` (in `internal/extractors/golang/references.go`) recognised only two LHS shapes for `<expr>.<field>` selectors:

1. `r.<field>` where `r` matches the enclosing method's receiver var.
2. `T.<field>` where `T` is a PascalCase identifier (type / package).

Every other LHS — parameter, short-var-decl, var-spec — missed entirely and became a bare `<field>` name that the resolver bucketed as `same_package_unqualified`. The kicker: the infrastructure to *type* those LHS names already existed (`collectParamTypes` / `collectBodyVarTypes` / `mergeVarTypes`, all added in #364) but only fed `extractCallRelationships` for CALLS. References never saw it.

## 2. Disposition breakdown (before / after)

**Caveat first**: #1842 ("`archigraph_stats.fidelity` stuck unchanged after extractor fix") is **still open** at the time of this PR. Per #1840's brief, the `same_package_unqualified` count in `archigraph_stats` will not visibly drop on the archigraph corpus until #1842 lands as well. Until then, the effect is verifiable only via:

- **Unit-test assertions** (this PR): 8 new tests in `type_table_test.go` cover every v1 case enumerated below, including the diagnostic `via_receiver_type` stamp.
- **Diagnostic property** (this PR): every edge rescued through the local-var type chain carries `Properties["via_receiver_type"] = <type-name>` so post-#1842 audits can count rescues by name.

Daemon at :47274 is **intentionally stopped** (per the standing 2026-05-23 note pending #1626) so a live `archigraph_stats` before/after on the archigraph corpus is not run from this PR. Wave-level live verification will be done once #1842 and #1626 land and the daemon is re-enabled. The before-numbers (24,697 same_package_unqualified, top-10 roots dominated by struct field names) come from #1839's already-merged breakdown.

Per-bucket forecast (v1 lightweight scope vs. #1839 baseline):

| Bucket | Before | Forecast after v1 | Notes |
|---|---|---|---|
| same_package_unqualified (Go struct fields) | 24,697 | ~50–70% drop expected | Covers params, short-var-decls, var-specs whose type is a same-file struct |
| same_package_unqualified (cross-file struct fields) | included above | no change | Deferred to v2 (per-file symbol table) |
| receiver-method `r.<field>` | already resolved | no change | Existing path retained; dedup guard prevents double-emit |
| `T.<field>` PascalCase | already resolved | no change | Existing path retained |

## 3. Implementation

Two surfaces touched:

**New file — `internal/extractors/golang/type_table.go`** (129 lines):
- `goVarTypes` = per-function var→type map (canonical type literal; pointer stripped, generic `[T]` dropped — same form as the CALLS-side maps so they mergeable).
- `buildFunctionVarTypes(funcOrMethodNode, src)` composes three sources in lexical-scope order (receiver → params → body), routing through the pre-existing `mergeVarTypes` so conflicting types on the same name are dropped (the conservative #364 rule — better to miss than to mis-bind).
- `lookupVarType(name)` returns "" on miss (safe-fallback contract per #1840).

**Modified — `internal/extractors/golang/references.go`** (95 line delta):
- `goFrame` gains a `varTypes goVarTypes` field.
- The function/method case populates `varTypes` once per frame via `buildFunctionVarTypes`.
- `emit` gains a `viaReceiverType` parameter; when non-empty, it's stamped as `Properties["via_receiver_type"]` on the resulting `RelationshipRecord` for audit attribution.
- `handleGoSelector` gains a third resolution path: when the receiver-var and PascalCase paths both miss, the operand is looked up in `varTypes`; on a hit, `<type>.<field>` is queried in `dottedSymbols` (which is already populated from `collectStructFieldTypes` for every struct in `bareSymbols`). Dedup guard via `emittedViaPath` prevents the receiver-var case from double-emitting through the var-table path.

Why this works without a separate "pass 1 / pass 2": the references pass is already a tree walk. `buildFunctionVarTypes` walks each function's parameter list and body once on frame entry; the body walk that follows already visits every selector_expression. No extra full-file pass.

## 4. MCP-vs-grep effort breakdown (experiment data — Grind C)

This grind was structural Go-extractor work — exactly the regime where MCP is supposed to dominate per #1838's positioning. Honest accounting:

**MCP wins**:
- The `extractCallRelationships`, `collectBodyVarTypes`, `collectParamTypes`, `mergeVarTypes`, `collectStructFieldTypes` discovery would have been a multi-step grep + read dance to locate, then read the function bodies, then chase their call sites. Knowing those exist and roughly what they do is what MCP buys.

**MCP miss / grep+read tied**:
- Reading `references.go` end-to-end to understand the existing two-shape selector handler was unavoidable read-the-file work; MCP doesn't help once you're inside one file's logic.
- Designing the dedup guard (`emittedViaPath`) required reasoning about edge-case interactions between three resolution paths in the same handler — MCP irrelevant.

**Net judgement**: MCP saved roughly 30–40% of discovery time on the "what infrastructure already exists?" axis. Once the design was set, the implementation was file-local edit work where MCP adds nothing. Same pattern as Grind A. Consistent data point: MCP value concentrates on multi-file *discovery*, drops to ~zero for single-file implementation. (Token cost not measured this round — daemon stopped.)

## 5. Tests

8 new tests in `internal/extractors/golang/type_table_test.go`:

| Test | Asserts |
|---|---|
| `TestGoRefsStructFieldViaParameter` | parameter typed as struct → field resolved |
| `TestGoRefsReceiverPathStillResolves` | receiver path unchanged + exactly one edge (no double-emit) |
| `TestGoRefsStructFieldViaShortVarDecl` | `x := Foo{}` typed via composite literal |
| `TestGoRefsStructFieldViaPointerShortVarDecl` | `x := &Foo{}` strips pointer, same path |
| `TestGoRefsStructFieldViaVarSpec` | `var x Foo` typed via explicit type field |
| `TestGoRefsLocalVarChainStampsViaReceiverType` | diagnostic property emitted |
| `TestGoRefsUnknownLHSTypeIsGraceful` | unbindable LHS → no edge, no crash |
| `TestGoRefsAmbiguousNameDropsBinding` | conflicting types → binding dropped (no mis-bind) |

Full Go extractor suite: **PASS** (`go test ./internal/extractors/golang/...` → ok). Full Go resolver suite: **PASS**. Full repo `go build` + `go vet`: clean.

Three pre-existing failures in `internal/mcp` (`TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) — all about the `archigraph_status` tool description exceeding the 80-char limit. Confirmed pre-existing on `origin/main` (reproduced via `git stash` on a clean checkout). Unrelated to #1840 and out of scope.

## 6. Cross-platform discipline (#1777)

Pure Go AST walking + a string-keyed map. Zero syscalls, zero filesystem touches, zero platform-conditional code. CI matrix verifies all three Go-test invocations on linux/darwin/windows.

## 7. Follow-ups & gotchas

- **#1842 dependency**: until it lands, `archigraph_stats` won't show the bucket drop. Live before/after is gated on #1842 + #1626 (daemon restart).
- **v2 scope** (not filed yet — file once #1840 is merged and the rescue-rate is measured): cross-file struct types (the per-file symbol table is the v1 boundary), return-type chains across user-defined functions, interface dispatch / embedded type promotion, generic type inference. Estimating ~10–15% additional rescue if the v1 numbers come in at the forecast.
- **Worktree**: `../archigraph-worktrees/go-struct-fields`. Deletes after merge per `feedback_archigraph_worktree_cleanup`.
- **Daemon**: still intentionally stopped per 2026-05-23 standing rule; do not restart from this PR's CI lane.

Do NOT merge.
