### PR TITLE
release: v0.1.0 prep — CHANGELOG, README banner, RELEASING doc, wire_version (#1845)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,97 @@
 # Changelog
 
-All notable changes are documented here. Entries are grouped by the session
-or release they landed in. PR numbers link to
-https://github.com/cajasmota/archigraph/pull/<N>.
+All notable changes are documented here. Entries follow
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/) conventions.
+PR numbers link to https://github.com/cajasmota/archigraph/pull/<N>.
+
+---
+
+## [0.1.0] — 2026-05-23 (Preview Release)
+
+archigraph's first pre-release. Active development; APIs, MCP tool names,
+and graph schema may change between minor versions.
+
+### Added
+
+- **5-tier docgen ladder** — Tier 0 single-section (#1809), Tier 1
+  single-page with contracts (#1812), Tier 2 5-page slice with cross-page
+  contracts (#1814), Tier 3 single-repo with repo-level contracts (#1817),
+  Tier 4 full multi-repo group (#1820).
+- **LLM-mode emit-and-orchestrate workflow** — schema (#1816),
+  `--llm-mode=emit` for Tier 0+1 (#1819), `--llm-mode=apply` (#1821),
+  section cache (#1823), `generate-docs` skill Pass 20 orchestrator (#1822),
+  user-facing docs (#1824).
+- **MCP handshake cwd-gate** with `archigraph_status` sentinel — tools list
+  goes from 2,319 tokens → ~80 bytes for sessions outside any indexed group
+  (#1769, #1783).
+- **`archigraph_stats --breakdown=unresolved_imports`** for import taxonomy
+  (#1839).
+- **Windows CGO experimental build workflow** (#1791) — produces
+  `archigraph.exe` artifact via MinGW on GitHub Actions.
+- **Python `config_module` entity** for `settings.py`/`urls.py`/etc. (#1778).
+- **Go extractor** — method-value references (#1789, #1792), intra-package
+  bare-function calls (#1806, #1810), struct field references via receiver
+  type chain (#1840, #1843).
+- **Resolver** — platform-variant merging for `_unix.go` + `_windows.go`
+  pairs (#1815).
+- **`archigraph_whoami` `wire_version` field** — returns `"0.1.0"`; bump per
+  minor release (#1845).
+
+### Changed
+
+- **MCP param renames with compat aliases** — `archigraph_find(query=)` was
+  `question`; `archigraph_get_source(entity_id=)` was `node_id` (#1790).
+- **`archigraph_stats.fidelity` scope narrowed to IMPORTS-only** matching
+  `health-history.bug_rate` — value jumped from 0.656 to 0.943 on archigraph
+  (prior dilution was hiding ~5,000 import rescues) (#1842, #1844).
+- **MCP positioning** embedded in handshake/CLAUDE.md/skills/docs: "pair MCP
+  + grep" is the canonical position (#1838).
+- **Default response limits shrunk**; token_budget enforcement extended;
+  per-tool field elision (#1738, #1739, #1749, #1751).
+- **`archigraph_find` returns TOON format** with `id` as first column (#1737,
+  #1743, #1761).
+- **Entity-ID interning** in MCP responses (#1740, #1750).
+- **Subgraph fold** — `get_subgraph` + `summarize_subgraph` →
+  `archigraph_subgraph(format=raw|markdown)` (#1754, #1764, #1768).
+- Posix-only test files now carry `//go:build !windows` tags for Windows
+  compatibility (#1787, #1804).
+
+### Fixed
+
+- **`archigraph_get_source` 5 s fsevents wedge on macOS** — now 48 ms via
+  `O_NONBLOCK` + `lstat` + semaphore (#1773, #1780).
+- **`gitignore.go` Windows build** via `_unix`/`_windows` split (#1787).
+- **`filepathBase` cross-platform path handling** (#1782).
+- **Tier 4 LLM emit propagation** through Tier 2/3/4 opts + integration test
+  (#1825, #1828, #1832).
+- **Section guidance `graph_context`** now populated with
+  `qualified_name`/`repo`/`source_window` (#1827, #1831).
+- **MSYS2 path resolution** on Windows GHA runners (#1805, #1808).
+- **archigraph daemon test deadline** 2 s → 4 s + `test.yml` `-timeout 5m`
+  (#1797, #1800).
+- **`mat: zero length` panic guard** in `RunAlgorithmsWithOptions` (#1795,
+  #1801).
+- **`TestAxumE2E` skip-on-CI guard** (#1798, #1799).
+- **166-file gofmt baseline** restored (#1786).
+- **Vendored go-tree-sitter** with `//go:build cgo` patch (#1796, #1802).
+
+### Known Limitations (roadmap for v0.2.0+)
+
+- Resolver platform-variant merging works in unit tests but does not fully
+  reflect in `find_callers` end-to-end (#1818 — separate bug class).
+- Token-ratio recovery: iter6 had token ratio 6.83× vs 0.7× target — quality
+  is strong, token economy needs work (#1807).
+- Docgen `source_window` cwd-relative path bug — affects `BuildBundle` when
+  called from a cwd outside the indexed repo root (#1834).
+- Tier 4 emit one-off bundle/page count mismatch: one page in N produces no
+  bundle (#1835).
+- Go struct field extraction v2: cross-file struct types, interfaces,
+  generics, embedded type promotion (#1840 — current v1 handles same-file
+  struct fields only).
+- `archigraph_stats.fidelity` is IMPORTS-only; CALLS and REFERENCES
+  improvements are not yet surfaced as metrics.
+- JS/TS/Python sibling sweeps for the receiver-chain pattern that #1843 fixed
+  in Go are queued for v0.2.0.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # archigraph
 
+> **Status: Preview (v0.x).** Active development. APIs, MCP tool names, and graph schema may change between minor versions. macOS is the primary supported platform; Linux is being tested; Windows works via MinGW build (#937). See [CHANGELOG.md](CHANGELOG.md) for breaking changes. See [CLAUDE.md](CLAUDE.md) for "When to use archigraph MCP vs grep" — these are paired tools, not a grep replacement.
+
 Multi-repo code knowledge graphs for AI agents.
 
 ## Status

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,78 @@
+# Releasing archigraph
+
+## Versioning policy
+
+archigraph follows [Semantic Versioning](https://semver.org/) under a
+`v0.MINOR.PATCH` scheme until v1.0.
+
+| Component | Rule |
+|-----------|------|
+| **MINOR** | May break MCP tool APIs, graph schema wire format, or CLI flags. Always documented in CHANGELOG.md under "Changed" or "Known Limitations". |
+| **PATCH** | Bug fixes and additive changes only. No breaking changes to public APIs, MCP tool signatures, or the `graph.fb` wire format. |
+
+## v1.0 ship criteria
+
+v1.0 ships when all of the following are true:
+
+1. **Schema stability commitment** — `graph.fb` wire format version has been
+   stable (no breaking field changes) for at least two consecutive MINOR
+   releases.
+2. **All 3 platforms verified end-to-end** — macOS, Linux, and Windows
+   binaries each pass the full integration test suite in CI.
+3. **MCP API stable for 3+ minor releases** — no tool renames, param renames,
+   or response-shape changes across the most recent three MINOR versions.
+4. **Documented migration path** — `docs/migration/v1.md` covers every
+   breaking change since v0.1.0 with before/after examples.
+
+Until v1.0, the "This is a pre-release" checkbox on every GitHub Release
+must be ticked.
+
+## Release process
+
+### 1. Prepare the release commit
+
+1. Update `CHANGELOG.md` — move entries from `[Unreleased]` to a new
+   `[X.Y.Z] — YYYY-MM-DD` section.
+2. Verify `go build ./...` and `go vet ./...` are clean.
+3. Open a PR titled `release: vX.Y.Z prep` and merge it.
+
+### 2. Tag
+
+```bash
+git checkout main
+git pull
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+### 3. GitHub Release
+
+1. Go to **Releases → Draft a new release**.
+2. Select the tag `vX.Y.Z`.
+3. Title: `vX.Y.Z`.
+4. Body: paste the CHANGELOG section for this version.
+5. Tick **"This is a pre-release"** for every release until v1.0.
+6. Attach platform binaries as release assets:
+   - `archigraph-darwin-arm64`
+   - `archigraph-darwin-amd64`
+   - `archigraph-linux-amd64`
+   - `archigraph-linux-arm64`
+   - `archigraph.exe` (Windows, CGO/MinGW build)
+
+### 4. Post-release
+
+- Update `wire_version` constant in `internal/mcp/tools.go` for the next
+  MINOR release.
+- Bump the `graph.fb` schema `version` field if any wire-format changes
+  landed (see [graph-format.md](graph-format.md)).
+
+## Graph schema versioning
+
+The on-disk `graph.fb` FlatBuffers schema carries a `version` integer field
+(currently `2`). See [graph-format.md](graph-format.md) for the full policy.
+
+## MCP wire_version
+
+`archigraph_whoami` returns a `wire_version` field (e.g. `"0.1.0"`). Agents
+can use this to detect incompatible daemon versions. The value is a constant
+in `internal/mcp/tools.go` and must be bumped on every MINOR release.

--- a/docs/graph-format.md
+++ b/docs/graph-format.md
@@ -1,0 +1,63 @@
+# archigraph graph format
+
+archigraph stores its code-knowledge graph on disk as a FlatBuffers binary
+(`graph.fb`) defined in
+[`internal/graph/schema/graph.fbs`](../internal/graph/schema/graph.fbs).
+The design rationale is in
+[ADR-0016](adrs/0016-binary-graph-format.md).
+
+## Schema version field
+
+The root `Graph` table carries a `version: int` field (currently `2`):
+
+```
+table Graph {
+  version: int = 2;
+  ...
+}
+```
+
+This integer is the **wire format version** — it is independent of the
+archigraph release version and of the MCP `wire_version` string.
+
+### Versioning rules
+
+| Scenario | Action |
+|----------|--------|
+| Additive field appended at the end of a table | No bump required — FlatBuffers default-fills missing fields on old readers. |
+| Existing field semantics change, or a field is removed / reordered | Bump `version` by 1. |
+| Breaking change incompatible with old readers | Bump `version` and add a migration path in `docs/migration/`. |
+
+### Reader behaviour
+
+When archigraph reads a `graph.fb` file it checks the `version` field:
+
+- **Current version** — file is read normally.
+- **Older version** — archigraph either migrates the data transparently (for
+  additive-only changes) or returns a clear error asking the user to run
+  `archigraph rebuild` to regenerate the graph.
+- **Newer version** — archigraph returns an error asking the user to upgrade
+  the binary.
+
+### Current schema version history
+
+| `version` | Introduced | Notes |
+|-----------|------------|-------|
+| 1 | v0.0.x | Initial FlatBuffers format (replaced legacy `graph.json`). |
+| 2 | v0.1.0 | Pass 4 graph-algorithm fields added: `community_id`, `pagerank`, `centrality`, `is_god_node`, `is_surprise_endpoint`, `is_articulation_point`, `communities`, aggregate counters (#1620). Old `version=1` files read back with these fields zero/empty. |
+
+## Field authorship rules
+
+- Do **not** reorder existing fields — FlatBuffers assigns IDs by ordinal
+  position.
+- To deprecate a field, mark it `(deprecated)` in the `.fbs` file; do not
+  remove it.
+- New fields must be **appended** to the end of the table.
+
+## Regenerating the Go bindings
+
+```bash
+flatc --go -o internal/graph/fbgraph internal/graph/schema/graph.fbs
+```
+
+Run this after any schema change and commit the updated `fbgraph/` files.

--- a/internal/mcp/docstate_test.go
+++ b/internal/mcp/docstate_test.go
@@ -381,6 +381,59 @@ func TestHandleWhoami_quietMode(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// wire_version field
+// ---------------------------------------------------------------------------
+
+// TestHandleWhoami_wireVersion asserts that archigraph_whoami always returns
+// a non-empty wire_version field, both in normal mode and in quiet mode.
+func TestHandleWhoami_wireVersion(t *testing.T) {
+	for _, quiet := range []string{"", "quiet"} {
+		quiet := quiet
+		name := "normal"
+		if quiet == "quiet" {
+			name = "quiet"
+		}
+		t.Run(name, func(t *testing.T) {
+			tmp := t.TempDir()
+			t.Setenv("HOME", tmp)
+			t.Setenv("ARCHIGRAPH_WHOAMI_NUDGE", quiet)
+
+			repoDir := filepath.Join(tmp, "repo-a")
+			doc := fixtureDoc("repo-a")
+			writeGraph(t, repoDir, doc)
+
+			regPath := makeRegistry(t, tmp, map[string]map[string]string{
+				"g": {"repo-a": repoDir},
+			})
+			srv, err := NewServer(Config{RegistryPath: regPath})
+			if err != nil {
+				t.Fatalf("NewServer: %v", err)
+			}
+
+			req := mcpapi.CallToolRequest{}
+			req.Params.Arguments = map[string]any{"group": "g"}
+			res, err := srv.handleWhoami(context.Background(), req)
+			if err != nil {
+				t.Fatalf("handleWhoami: %v", err)
+			}
+			if res.IsError {
+				t.Fatalf("tool error: %v", res.Content)
+			}
+
+			var out map[string]any
+			if err := json.Unmarshal([]byte(res.Content[0].(mcpapi.TextContent).Text), &out); err != nil {
+				t.Fatalf("unmarshal: %v", err)
+			}
+
+			wv, ok := out["wire_version"].(string)
+			if !ok || wv == "" {
+				t.Errorf("wire_version: missing or empty (got %T: %v)", out["wire_version"], out["wire_version"])
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -155,6 +155,11 @@ func jsonResult(v any) *mcpapi.CallToolResult {
 // whoami
 // ---------------------------------------------------------------------------
 
+// mcpWireVersion is the MCP API version advertised by archigraph_whoami.
+// Bump this on every MINOR release. Agents can use it to detect
+// incompatible daemon versions without inspecting the binary.
+const mcpWireVersion = "0.1.0"
+
 func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
 	cwd := s.inferCWD(req)
 	explicit := argString(req, "group", "")
@@ -165,6 +170,7 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 			"repo":          "",
 			"source":        "none",
 			"registry_path": s.State.registry.Path,
+			"wire_version":  mcpWireVersion,
 			"error":         err.Error(),
 		}), nil
 	}
@@ -176,6 +182,7 @@ func (s *Server) handleWhoami(ctx context.Context, req mcpapi.CallToolRequest) (
 		"repo":          repo,
 		"source":        source,
 		"registry_path": s.State.registry.Path,
+		"wire_version":  mcpWireVersion,
 	}
 
 	// Nudge suppression: ARCHIGRAPH_WHOAMI_NUDGE=quiet disables doc-state fields.


### PR DESCRIPTION
Fixes #1845.

## 1. What and why

Ship-paperwork for the v0.1.0 pre-release. The product is structurally v0.1.0-ready (cross-platform validated, fidelity strong: archigraph 0.943, upvate 0.967, polyglot 0.819 IMPORTS). This PR delivers the release-prep artifacts so the owner can do `git tag v0.1.0` + create the GitHub Release after merge.

## 2. Fidelity / experiment context

The v0.1.0 fidelity numbers are locked from the dogfood experiment:
- archigraph corpus: **0.943** IMPORTS fidelity (post-#1844 scope narrowing from 0.656 — the prior dilution was hiding ~5,000 import rescues)
- upvate corpus: **0.967** IMPORTS fidelity
- polyglot corpus: **0.819** IMPORTS fidelity

MCP positioning confirmed: "pair MCP + grep" is the right model — MCP alone used 3–6× more tokens than grep+read in benchmark (#1838).

## 3. Changes

| File | Change |
|------|--------|
| `CHANGELOG.md` | Prepend `[0.1.0]` section (Keep-a-Changelog format) with Added/Changed/Fixed/Known-Limitations, all PR citations from the #1738–#1845 wave. Existing Unreleased section preserved below. |
| `README.md` | Add Preview-status blockquote banner immediately after the `# archigraph` title. |
| `docs/RELEASING.md` | New: semver policy (v0.MINOR.PATCH until v1.0), v1.0 ship criteria (4 gates), step-by-step tag + GitHub-Release process, wire_version + schema bump reminders. |
| `docs/graph-format.md` | New: FlatBuffers `graph.fb` schema-version field doc, reader behaviour on old/new/current versions, version history table (v1 → v2), field authorship rules, codegen command. |
| `internal/mcp/tools.go` | Add `mcpWireVersion = "0.1.0"` constant; include `wire_version` in `archigraph_whoami` response on both success and error paths. |
| `internal/mcp/docstate_test.go` | `TestHandleWhoami_wireVersion`: asserts `wire_version` is present and non-empty in normal mode and quiet mode. |

## 4. Tests

```
=== RUN   TestHandleWhoami_wireVersion/normal   PASS
=== RUN   TestHandleWhoami_wireVersion/quiet    PASS
--- PASS: TestHandleWhoami_wireVersion (0.02s)

All prior TestHandleWhoami_* tests: PASS (no regressions)
go build ./...   clean (only pre-existing go-tree-sitter null-char warning)
go vet ./...     clean
```

## 5. Risks / rollback

No behaviour changes to existing MCP tools beyond the additive `wire_version` field in `archigraph_whoami`. All agents that already parse the whoami response will ignore the new field (it is additive). Rollback: revert `internal/mcp/tools.go` if needed; all docs files are standalone.

## 6. Deployment notes

- Daemon must be rebuilt after merge for `wire_version` to appear in live responses.
- No schema changes; `graph.fb` version field is unchanged.
- Owner: after merge, run `git tag v0.1.0 && git push origin v0.1.0`, create GitHub Release with "This is a pre-release" ticked, attach platform binaries.

## 7. v0.1.0 ship paperwork confirmation

This is the v0.1.0 ship paperwork PR. It does **not** contain the `git tag v0.1.0` (owner does that after merge). The PR itself is the gate: CHANGELOG, README, RELEASING policy, graph-format doc, and wire_version field are all present and verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)