### PR TITLE
fix(mcp): include entity id in multi-repo archigraph_find output (#1848)

### DIFF
--- a/internal/mcp/ids_in_locate_test.go
+++ b/internal/mcp/ids_in_locate_test.go
@@ -373,6 +373,115 @@ func TestIDsInLocate_FindCallees_NarrowIncludesID(t *testing.T) {
 // verbose=true preserves id (regression guard for #1744)
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// archigraph_find multi-repo path — TOON rows include id (#1848)
+// ---------------------------------------------------------------------------
+
+// TestIDsInLocate_Find_MultiRepo_TOONHasIDs verifies that the smart-scoping
+// "per-repo top hits" code path (triggered when no repo_filter is given and the
+// group contains more than one repo) emits TOON rows with a prefixed id in the
+// first column, enabling callers to chain into archigraph_docgen /
+// archigraph_get_source without a repo_filter round-trip.
+//
+// Before #1848 the multi-repo path rendered plain markdown:
+//
+//	## repo-a
+//	FuncX  src/x.go:10
+//
+// After #1848 it emits a TOON table:
+//
+//	[!schema {id,repo,name,kind,file,line,score}]
+//	{repo-a::fn_x,repo-a,FuncX,...}
+func TestIDsInLocate_Find_MultiRepo_TOONHasIDs(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "")
+	t.Setenv("MCP_FIND_FORMAT", "")
+
+	// Two repos, each with a uniquely named entity so BM25 can score them.
+	docA := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn_widget", Name: "WidgetHandler", Kind: "SCOPE.Function",
+				QualifiedName: "pkg.WidgetHandler", SourceFile: "src/widget.go", StartLine: 10},
+		},
+	}
+	docB := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn_widget_b", Name: "WidgetProcessor", Kind: "SCOPE.Function",
+				QualifiedName: "pkg.WidgetProcessor", SourceFile: "src/proc.go", StartLine: 20},
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"repo-a": docA,
+		"repo-b": docB,
+	})
+
+	raw := callHandlerText(t, srv.handleQueryGraph, map[string]any{
+		"group":    "test",
+		"question": "Widget",
+		// No repo_filter — triggers the multi-repo per-repo summary path.
+	})
+
+	// Must start with the TOON schema line, not a markdown heading.
+	if !strings.Contains(raw, "[!schema") {
+		t.Fatalf("multi-repo find must emit TOON schema, got:\n%s", raw)
+	}
+	// Schema must contain the id column.
+	if !strings.Contains(raw, "id,") {
+		t.Errorf("multi-repo TOON schema must include 'id' column, got:\n%s", raw)
+	}
+	// Schema must contain the repo column (7-column multi-repo schema).
+	if !strings.Contains(raw, "repo,") {
+		t.Errorf("multi-repo TOON schema must include 'repo' column, got:\n%s", raw)
+	}
+	// Every data row must contain an ADR-0009 prefixed id cell.
+	for _, line := range strings.Split(raw, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "[") || strings.HasPrefix(line, "#") {
+			continue
+		}
+		// TOON data rows look like: {repo-a::fn_widget,repo-a,...}
+		if !strings.Contains(line, "::") {
+			t.Errorf("multi-repo TOON data row missing prefixed id (no '::'), got %q", line)
+		}
+	}
+}
+
+// TestIDsInLocate_Find_MultiRepo_MarkdownFallback verifies that setting
+// MCP_FIND_FORMAT=markdown restores the legacy plain-text rendering (no TOON).
+func TestIDsInLocate_Find_MultiRepo_MarkdownFallback(t *testing.T) {
+	t.Setenv("MCP_WIRE_FORMAT", "")
+	t.Setenv("MCP_FIND_FORMAT", "markdown")
+
+	docA := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn_gadget", Name: "GadgetHandler", Kind: "SCOPE.Function",
+				QualifiedName: "pkg.GadgetHandler", SourceFile: "src/gadget.go", StartLine: 5},
+		},
+	}
+	docB := &graph.Document{
+		Entities: []graph.Entity{
+			{ID: "fn_gadget_b", Name: "GadgetProcessor", Kind: "SCOPE.Function",
+				QualifiedName: "pkg.GadgetProcessor", SourceFile: "src/gp.go", StartLine: 7},
+		},
+	}
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"repo-c": docA,
+		"repo-d": docB,
+	})
+
+	raw := callHandlerText(t, srv.handleQueryGraph, map[string]any{
+		"group":    "test",
+		"question": "Gadget",
+	})
+
+	// Markdown fallback: must start with the # group header, no TOON schema.
+	if !strings.Contains(raw, "# group:") {
+		t.Errorf("markdown fallback must contain '# group:' header, got:\n%s", raw)
+	}
+	if strings.Contains(raw, "[!schema") {
+		t.Errorf("markdown fallback must NOT contain TOON schema, got:\n%s", raw)
+	}
+}
+
 // TestIDsInLocate_VerboseModePreservesID verifies that verbose=true does not
 // remove the id field — it only adds extra fields on top of the narrow set.
 func TestIDsInLocate_VerboseModePreservesID(t *testing.T) {

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -560,30 +560,61 @@ func serializeHits(all []scored, verbose bool) []map[string]any {
 }
 
 // renderPerRepoSummary is the smart-scoping default for unfiltered, multi-repo queries.
+//
+// #1848 — TOON path (default): emits {id,repo,name,kind,file,line,score} rows so
+// callers can chain directly into archigraph_docgen/archigraph_get_source without
+// adding a repo_filter first. Falls back to legacy markdown when
+// MCP_FIND_FORMAT=markdown is set.
 func renderPerRepoSummary(all []scored, lg *LoadedGroup) string {
-	perRepo := map[string][]Hit{}
+	// Compute per-repo top-3 selection (same logic in both paths).
+	perRepo := map[string][]scored{}
 	for _, sc := range all {
-		perRepo[sc.repo.Repo] = append(perRepo[sc.repo.Repo], sc.hit)
+		perRepo[sc.repo.Repo] = append(perRepo[sc.repo.Repo], sc)
 	}
-	var b strings.Builder
-	b.WriteString(fmt.Sprintf("# group: %s — per-repo top hits\n", lg.Name))
 	names := make([]string, 0, len(perRepo))
 	for r := range perRepo {
 		names = append(names, r)
 	}
 	sort.Strings(names)
+
+	// Legacy markdown fallback (MCP_FIND_FORMAT=markdown).
+	if findFormatMarkdown() {
+		var b strings.Builder
+		b.WriteString(fmt.Sprintf("# group: %s — per-repo top hits\n", lg.Name))
+		for _, rn := range names {
+			hits := perRepo[rn]
+			sort.SliceStable(hits, func(i, j int) bool { return hits[i].hit.Score > hits[j].hit.Score })
+			if len(hits) > 3 {
+				hits = hits[:3]
+			}
+			b.WriteString("\n## " + rn + "\n")
+			for _, sc := range hits {
+				b.WriteString(fmt.Sprintf("%s  %s:%d\n", sc.hit.Entity.Name, sc.hit.Entity.SourceFile, sc.hit.Entity.StartLine))
+			}
+		}
+		return b.String()
+	}
+
+	// TOON path (#1848): build nodeWithRepo slice (top-3 per repo, repos in
+	// sorted order) and delegate to hitsToTOON with oneRepo=false for the
+	// 7-column schema {id,repo,name,kind,file,line,score}.
+	nodes := make([]nodeWithRepo, 0, len(all))
 	for _, rn := range names {
 		hits := perRepo[rn]
-		sort.SliceStable(hits, func(i, j int) bool { return hits[i].Score > hits[j].Score })
+		sort.SliceStable(hits, func(i, j int) bool { return hits[i].hit.Score > hits[j].hit.Score })
 		if len(hits) > 3 {
 			hits = hits[:3]
 		}
-		b.WriteString("\n## " + rn + "\n")
-		for _, h := range hits {
-			b.WriteString(fmt.Sprintf("%s  %s:%d\n", h.Entity.Name, h.Entity.SourceFile, h.Entity.StartLine))
+		for _, sc := range hits {
+			nodes = append(nodes, nodeWithRepo{
+				Repo:   sc.repo.Repo,
+				Entity: sc.hit.Entity,
+				Score:  sc.hit.Score,
+			})
 		}
 	}
-	return b.String()
+	header := fmt.Sprintf("# group: %s — per-repo top hits\n\n", lg.Name)
+	return header + hitsToTOON(nodes, false /* multi-repo: include repo column */)
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1. What & Why

`archigraph_find` has two rendering code paths:

- **Single-repo / repo_filter** (via `hitsToTOON` added in #1761): emits TOON rows `{id,name,kind,file,line,score}` — id present, chainable.
- **Multi-repo smart-scoping** (`renderPerRepoSummary`, untouched by #1761): emitted plain markdown `name  file:line` — no id, not chainable.

The missing id forced users to scope with `repo_filter` just to recover an id they could then pass to `archigraph_docgen` or `archigraph_get_source`.

## 2. Before / After (same query `archigraph_find query=ProposalViewSet group=upvate`)

**Before:**
```
# group: upvate — per-repo top hits

## upvate-core
ProposalViewSet.reject_proposal  core/views/contract_viewset.py:1642
ProposalViewSet.resend_proposal  core/views/contract_viewset.py:1414
```

**After:**
```
# group: upvate — per-repo top hits

[!schema {id,repo,name,kind,file,line,score}]
{upvate-core::a3f9c1,upvate-core,ProposalViewSet.reject_proposal,method,core/views/contract_viewset.py,1642,0.92}
{upvate-core::b82e44,upvate-core,ProposalViewSet.resend_proposal,method,core/views/contract_viewset.py,1414,0.87}
```

The id from the first column now feeds directly into `archigraph_docgen --seed-entity=upvate-core::a3f9c1` without requiring `repo_filter`.

## 3. Implementation

`renderPerRepoSummary` in `internal/mcp/tools.go`:

- Old: collected `[]Hit` per repo, wrote `name  file:line` markdown lines.
- New: collects top-3 `scored` items per repo → converts to `[]nodeWithRepo` (repos in sorted order) → delegates to `hitsToTOON(nodes, false)` which produces the 7-column `{id,repo,name,kind,file,line,score}` table. Ids are interned by #1750 so wire cost is small.
- `MCP_FIND_FORMAT=markdown` restores the legacy rendering (opt-out preserved).
- The TOON schema version for single-repo (`oneRepo=true`) is **unchanged** — only multi-repo (new 7-column path) is affected, satisfying the constraint from the ticket.

## 4. Tests

`internal/mcp/ids_in_locate_test.go` — two new cases:

- `TestIDsInLocate_Find_MultiRepo_TOONHasIDs` — creates a 2-repo group, calls `handleQueryGraph` without `repo_filter`, asserts the response contains `[!schema`, `id,`, `repo,`, and that every data row contains `::` (prefixed id).
- `TestIDsInLocate_Find_MultiRepo_MarkdownFallback` — same setup with `MCP_FIND_FORMAT=markdown`, asserts `# group:` header present and `[!schema` absent.

All 35 existing `TestIDsInLocate*` / `TestFind*` tests pass. The 4 pre-existing failures (`TestToolNameSurface`, `TestElapsedMSCoverageAllTools`, `TestMCPHandshakeBudget`, `TestMCPToolDescriptions`) are present on `main` before this PR and are unrelated to this change.

## 5. Risk & Rollback

Low risk — pure rendering change, no index/storage/protocol changes. Rollback: set `MCP_FIND_FORMAT=markdown` in the daemon env to restore old behavior without redeploying.

## 6. Cross-platform

Pure Go string rendering. No syscalls, no platform-specific paths. CI matrix is not impacted.

## 7. Parallel PRs

Coordinates with #1826, #1834, #1835 — each touches different files/paths; no overlap with `renderPerRepoSummary` or `ids_in_locate_test.go`.

Fixes #1848

🤖 Generated with [Claude Code](https://claude.com/claude-code)