### PR TITLE
fix(docgen): --seed-entity accepts both prefixed and raw hex forms (#1826)

### DIFF
--- a/internal/cli/docgen.go
+++ b/internal/cli/docgen.go
@@ -222,7 +222,9 @@ Available sections (--section, used by --tier=0 only):
 	cmd.Flags().StringVar(&group, "group", "",
 		"group name (defaults to sole registered group)")
 	cmd.Flags().StringVar(&seedEntity, "seed-entity", "",
-		"entity ID (or prefix) to render (required for all tiers)")
+		"entity ID to render (required for all tiers). Accepts both raw hex (e.g. 7a349f6cd77984c9) "+
+			"and the prefixed form returned by archigraph_find (e.g. archigraph::7a349f6cd77984c9 "+
+			"or upvate-core::7a349f6cd77984c9). The <group>:: prefix is stripped automatically.")
 	cmd.Flags().StringVar(&section, "section", "",
 		fmt.Sprintf("section type to render (required for --tier=0); one of: %s", strings.Join(docgen.KnownSections, ", ")))
 	cmd.Flags().StringVar(&pageID, "page-id", "",

--- a/internal/docgen/seed_entity_format_test.go
+++ b/internal/docgen/seed_entity_format_test.go
@@ -1,0 +1,171 @@
+// Package docgen_test — integration tests for #1826: --seed-entity accepts
+// both raw hex and prefixed (group::<hex>) forms.
+package docgen_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+)
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+// buildSeedEntityFixture creates a minimal ARCHIGRAPH_HOME + ARCHIGRAPH_DAEMON_ROOT
+// with a single group containing one repo with one entity whose ID is rawHex.
+// It returns the group name. The graph.json is placed at the path that
+// daemon.StateDirForRepo resolves to under ARCHIGRAPH_DAEMON_ROOT.
+func buildSeedEntityFixture(t *testing.T, rawHex string) (group string) {
+	t.Helper()
+	archHome := t.TempDir()
+	daemonRoot := t.TempDir()
+	group = "archigraph"
+
+	t.Setenv("ARCHIGRAPH_HOME", archHome)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	xdgConfigHome := filepath.Join(archHome, "xdg-config")
+	t.Setenv("XDG_CONFIG_HOME", xdgConfigHome)
+
+	cfgDir := filepath.Join(xdgConfigHome, "archigraph")
+	if err := os.MkdirAll(cfgDir, 0o755); err != nil {
+		t.Fatalf("mkdir cfgDir: %v", err)
+	}
+
+	// Use a simple unique repo path inside archHome so the hash is stable.
+	repoPath := filepath.Join(archHome, "fake-repo")
+	if err := os.MkdirAll(repoPath, 0o755); err != nil {
+		t.Fatalf("mkdir repoPath: %v", err)
+	}
+
+	// Write a minimal graph.json at the daemon.StateDirForRepo location.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir stateDir %s: %v", stateDir, err)
+	}
+
+	entity := map[string]interface{}{
+		"id":          rawHex,
+		"name":        "SeedFunc",
+		"kind":        "function",
+		"source_file": "pkg/seed.go",
+		"start_line":  1,
+		"end_line":    42,
+		"language":    "go",
+	}
+	graphDoc := map[string]interface{}{
+		"version":       1,
+		"repo":          repoPath,
+		"entities":      []interface{}{entity},
+		"relationships": []interface{}{},
+	}
+	graphBytes, err := json.Marshal(graphDoc)
+	if err != nil {
+		t.Fatalf("marshal graph: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), graphBytes, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	// Write the fleet config pointing at the repo.
+	groupCfg := map[string]interface{}{
+		"name": group,
+		"repos": []map[string]interface{}{
+			{"slug": "core", "path": repoPath},
+		},
+	}
+	cfgBytes, cfgErr := json.Marshal(groupCfg)
+	if cfgErr != nil {
+		t.Fatalf("marshal group config: %v", cfgErr)
+	}
+	if err := os.WriteFile(filepath.Join(cfgDir, group+".fleet.json"), cfgBytes, 0o644); err != nil {
+		t.Fatalf("write group config: %v", err)
+	}
+
+	return group
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests — full Run() path (#1826)
+// ---------------------------------------------------------------------------
+
+// TestSeedEntity_RawHex checks that a raw hex ID resolves correctly (regression escape).
+func TestSeedEntity_RawHex(t *testing.T) {
+	const rawHex = "7a349f6cd77984c9"
+	group := buildSeedEntityFixture(t, rawHex)
+
+	_, _, score, err := docgen.Run(docgen.RunOpts{
+		Group:        group,
+		SeedEntityID: rawHex, // raw hex — the form that always worked
+		Section:      "overview",
+		OutputDir:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run with raw hex: %v", err)
+	}
+	if !score.SeedEntityFound {
+		t.Errorf("seed_entity_found: want true (raw hex), got false")
+	}
+}
+
+// TestSeedEntity_ArchigraphPrefixed checks that "archigraph::<hex>" resolves —
+// this was the broken form before #1826.
+func TestSeedEntity_ArchigraphPrefixed(t *testing.T) {
+	const rawHex = "7a349f6cd77984c9"
+	group := buildSeedEntityFixture(t, rawHex)
+
+	_, _, score, err := docgen.Run(docgen.RunOpts{
+		Group:        group,
+		SeedEntityID: "archigraph::" + rawHex, // prefixed form from archigraph_find
+		Section:      "overview",
+		OutputDir:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run with prefixed archigraph:: form: %v", err)
+	}
+	if !score.SeedEntityFound {
+		t.Errorf("seed_entity_found: want true (archigraph:: prefix), got false — #1826 regression")
+	}
+}
+
+// TestSeedEntity_ArbitraryGroupPrefixed checks that "<group>::<hex>" resolves
+// for a repo-specific group name (e.g. upvate-core).
+func TestSeedEntity_ArbitraryGroupPrefixed(t *testing.T) {
+	const rawHex = "7a349f6cd77984c9"
+	group := buildSeedEntityFixture(t, rawHex)
+
+	_, _, score, err := docgen.Run(docgen.RunOpts{
+		Group:        group,
+		SeedEntityID: "upvate-core::" + rawHex, // any group:: prefix must work
+		Section:      "overview",
+		OutputDir:    t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run with prefixed upvate-core:: form: %v", err)
+	}
+	if !score.SeedEntityFound {
+		t.Errorf("seed_entity_found: want true (upvate-core:: prefix), got false")
+	}
+}
+
+// TestSeedEntity_InvalidPrefixedForm checks that "archigraph::" (empty RHS) returns
+// a clear error rather than silently producing found:false.
+func TestSeedEntity_InvalidPrefixedForm(t *testing.T) {
+	const rawHex = "7a349f6cd77984c9"
+	group := buildSeedEntityFixture(t, rawHex)
+
+	_, _, _, err := docgen.Run(docgen.RunOpts{
+		Group:        group,
+		SeedEntityID: "archigraph::", // empty RHS
+		Section:      "overview",
+		OutputDir:    t.TempDir(),
+	})
+	if err == nil {
+		t.Fatal("expected error for 'archigraph::', got nil")
+	}
+}

--- a/internal/docgen/tier0.go
+++ b/internal/docgen/tier0.go
@@ -230,10 +230,40 @@ func defaultOutDir(group string) (string, error) {
 	return filepath.Join(home, "docs", group, ".tier0-"+ts), nil
 }
 
+// NormalizeSeedEntityID strips an optional <group>:: or <repo>:: prefix from
+// a seed entity ID and returns the raw 16-char hex. This lets users pass the
+// prefixed form returned by archigraph_find (e.g. "archigraph::7a349f6cd77984c9"
+// or "upvate-core::7a349f6cd77984c9") directly to --seed-entity without having
+// to manually trim the prefix.
+//
+// Accepted forms (all resolve to the same raw hex):
+//   - "7a349f6cd77984c9"               — raw hex (unchanged)
+//   - "archigraph::7a349f6cd77984c9"   — group-prefixed
+//   - "upvate-core::7a349f6cd77984c9"  — repo-prefixed
+//
+// Returns an error when the input contains "::" but the RHS is empty.
+func NormalizeSeedEntityID(id string) (string, error) {
+	if !strings.Contains(id, "::") {
+		return id, nil
+	}
+	parts := strings.SplitN(id, "::", 2)
+	if len(parts) != 2 || parts[1] == "" {
+		return "", fmt.Errorf("invalid --seed-entity %q: prefixed form must be <group>::<hex> with a non-empty hex part", id)
+	}
+	return parts[1], nil
+}
+
+// normalizeSeedEntityID is the unexported alias used internally.
+func normalizeSeedEntityID(id string) (string, error) { return NormalizeSeedEntityID(id) }
+
 // loadEntityContext loads all graphs for the group, finds the seed entity,
 // and returns it along with its 1-hop neighbours and the repo root of the
 // seed entity (Document.Repo from the graph document that contains it).
 func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.Entity, neighbours []graph.Entity, seedRepo string, err error) {
+	seedID, err = normalizeSeedEntityID(seedID)
+	if err != nil {
+		return
+	}
 	repoGraphDirs, err := findGroupGraphDirs(group)
 	if err != nil {
 		return

--- a/internal/docgen/tier0_test.go
+++ b/internal/docgen/tier0_test.go
@@ -165,6 +165,74 @@ func TestRun_CreatesOutputDir(t *testing.T) {
 }
 
 // ---------------------------------------------------------------------------
+// NormalizeSeedEntityID — unit tests for #1826
+// ---------------------------------------------------------------------------
+
+func TestNormalizeSeedEntityID_RawHex(t *testing.T) {
+	// Raw hex passes through unchanged — regression escape.
+	got, err := docgen.NormalizeSeedEntityID("7a349f6cd77984c9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "7a349f6cd77984c9" {
+		t.Errorf("want %q, got %q", "7a349f6cd77984c9", got)
+	}
+}
+
+func TestNormalizeSeedEntityID_ArchigraphPrefix(t *testing.T) {
+	// archigraph::<hex> — was broken before this fix.
+	got, err := docgen.NormalizeSeedEntityID("archigraph::7a349f6cd77984c9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "7a349f6cd77984c9" {
+		t.Errorf("want %q, got %q", "7a349f6cd77984c9", got)
+	}
+}
+
+func TestNormalizeSeedEntityID_ArbitraryGroupPrefix(t *testing.T) {
+	// Any <group>:: prefix should be stripped — upvate-core form.
+	got, err := docgen.NormalizeSeedEntityID("upvate-core::7a349f6cd77984c9")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "7a349f6cd77984c9" {
+		t.Errorf("want %q, got %q", "7a349f6cd77984c9", got)
+	}
+}
+
+func TestNormalizeSeedEntityID_InvalidEmptyRHS(t *testing.T) {
+	// "group::" with empty RHS must return an error.
+	_, err := docgen.NormalizeSeedEntityID("archigraph::")
+	if err == nil {
+		t.Fatal("expected error for 'archigraph::', got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid --seed-entity") {
+		t.Errorf("expected 'invalid --seed-entity' in error, got: %v", err)
+	}
+}
+
+func TestNormalizeSeedEntityID_DoubleColonOnlyRHS(t *testing.T) {
+	// Just "::" with no prefix and no suffix — invalid.
+	_, err := docgen.NormalizeSeedEntityID("::")
+	if err == nil {
+		t.Fatal("expected error for '::', got nil")
+	}
+}
+
+func TestNormalizeSeedEntityID_NestedDoubleColon(t *testing.T) {
+	// "a::b::c" — only the FIRST "::" is split; RHS is "b::c", which is valid
+	// (we take everything after the first "::").
+	got, err := docgen.NormalizeSeedEntityID("a::b::c")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "b::c" {
+		t.Errorf("want %q, got %q", "b::c", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
 // KnownSections completeness
 // ---------------------------------------------------------------------------
 

--- a/internal/docgen/tier2.go
+++ b/internal/docgen/tier2.go
@@ -251,6 +251,11 @@ type entityRecord struct {
 // pickSliceEntities returns up to maxPages entity IDs for the slice:
 // the seed entity first, then the highest-priority dependents.
 func pickSliceEntities(group, seedID string, maxPages int) ([]string, error) {
+	// Normalise seedID so both raw hex and prefixed forms work.
+	if norm, err := normalizeSeedEntityID(seedID); err == nil {
+		seedID = norm
+	}
+
 	// Load all entities and relationships for the group.
 	repoGraphDirs, err := findGroupGraphDirs(group)
 	if err != nil {
@@ -336,7 +341,14 @@ func pickSliceEntities(group, seedID string, maxPages int) ([]string, error) {
 }
 
 // resolveEntity finds an entity by exact ID, then by prefix/suffix.
+// It normalises seedID via normalizeSeedEntityID so callers can pass either
+// the raw hex ("7a349f6cd77984c9") or the prefixed form returned by
+// archigraph_find ("archigraph::7a349f6cd77984c9", "upvate-core::7a349f6cd77984c9").
 func resolveEntity(byID map[string]*graph.Entity, seedID string) *graph.Entity {
+	// Strip optional <group>:: prefix — ignore error, fall through to raw lookup.
+	if norm, err := normalizeSeedEntityID(seedID); err == nil {
+		seedID = norm
+	}
 	if e, ok := byID[seedID]; ok {
 		return e
 	}


### PR DESCRIPTION
## 1. Problem

`archigraph_find` returns entity IDs in the `<group>::<hex>` form per ADR-0009 (#1750 interning, #1761 schema). When users copy that output directly into `--seed-entity=`, the lookup yields `found: false` and an empty `graph_context`.

**Evidence:**
```
--seed-entity=archigraph::7a349f6cd77984c9  → found: false, empty graph_context
--seed-entity=7a349f6cd77984c9              → found: true,  56 neighbours, source_file populated
```

The root cause: `loadEntityContext` indexed entities by their raw 16-char hex (`e.ID`), while `archigraph_find` output carries the `<group>::<hex>` prefix. The find → docgen chain was broken for any prefixed copy-paste.

## 2. Before / After

**Before** (prefixed form broken):
```
$ archigraph docgen --tier=1 --group=archigraph \
    --seed-entity=archigraph::7a349f6cd77984c9 --llm-mode=emit
tier1 complete

  entity:     archigraph::7a349f6cd77984c9
  found:      false          ← broken
  sections:   13
  ...
  "seed_entity_found": false
```

**After** (prefixed form normalised):
```
$ archigraph docgen --tier=1 --group=archigraph \
    --seed-entity=archigraph::7a349f6cd77984c9 --llm-mode=emit
tier1 complete

  entity:     archigraph::7a349f6cd77984c9
  found:      true           ← fixed
  sections:   13
  ...
  "seed_entity_found": true
```

## 3. Changes

| File | Change |
|------|--------|
| `internal/docgen/tier0.go` | Add `NormalizeSeedEntityID` (exported) + `normalizeSeedEntityID` alias; call it at the entry point of `loadEntityContext` (covers Tier 0, Tier 1, Bundle) |
| `internal/docgen/tier2.go` | Normalize in `pickSliceEntities` and `resolveEntity` (covers Tier 2 seed resolution) |
| `internal/cli/docgen.go` | Update `--seed-entity` flag help text to document both accepted forms |
| `internal/docgen/tier0_test.go` | Add 6 unit tests for `NormalizeSeedEntityID` |
| `internal/docgen/seed_entity_format_test.go` | Add 4 integration tests with a real in-memory graph fixture (raw hex, `archigraph::` prefix, `upvate-core::` prefix, invalid empty-RHS error) |

Tier 3 and Tier 4 enumerate entity IDs from the graph directly — no user-supplied `--seed-entity` — so they need no changes.

## 4. Normalization contract

`NormalizeSeedEntityID` (pure string parsing, no I/O, no syscalls per #1777):

| Input | Output |
|-------|--------|
| `7a349f6cd77984c9` | `7a349f6cd77984c9` (unchanged) |
| `archigraph::7a349f6cd77984c9` | `7a349f6cd77984c9` |
| `upvate-core::7a349f6cd77984c9` | `7a349f6cd77984c9` |
| `archigraph::` | error: `invalid --seed-entity` |
| `::` | error: `invalid --seed-entity` |

The `@N` interned form is out of scope — deferred to follow-up per spec.

## 5. Tests

```
go test ./internal/docgen/ -run "TestNormalizeSeedEntityID|TestSeedEntity" -v
```

All 10 new tests pass. Full docgen suite green (`ok 2.851s`). `go vet` clean.

## 6. Coordination

- Does NOT touch `archigraph_find` output format, MCP responses, or any other prefixed-ID consumer — only the docgen INPUT path is affected.
- No overlap with parallel #1848 (find output), #1834 (source_window), #1835 (Tier 4 investigation) — different files.

## 7. Checklist

- [x] `go build ./...` clean
- [x] `go vet ./internal/docgen/ ./internal/cli/` clean
- [x] All new tests pass
- [x] Full docgen test suite green
- [x] No changes to find output / MCP response format
- [x] Pure string parsing — no syscalls, cross-platform safe (#1777)

Fixes #1826

🤖 Generated with [Claude Code](https://claude.com/claude-code)