### PR TITLE
fix(mcp): archigraph_inspect accepts entity_id (compat alias for label_or_id) (#1888)

### DIFF
--- a/internal/mcp/param_rename_test.go
+++ b/internal/mcp/param_rename_test.go
@@ -2,11 +2,13 @@ package mcp
 
 // Tests for #1790: param-name standardization (query/entity_id) with compat aliases.
 //
-// Four cases:
+// Six cases:
 //   (a) new name "query"     works for archigraph_find
 //   (b) old name "question"  works for archigraph_find + deprecation log fires
 //   (c) new name "entity_id" works for archigraph_get_source
 //   (d) old name "node_id"   works for archigraph_get_source + deprecation log fires
+//   (e) new name "entity_id" works for archigraph_inspect
+//   (f) old name "label_or_id" works for archigraph_inspect + deprecation log fires
 
 import (
 	"bytes"
@@ -156,6 +158,61 @@ func TestGetSourceOldParamNodeID_DeprecationFires(t *testing.T) {
 		t.Errorf("expected deprecation warning on stderr for legacy param 'node_id', got: %q", stderr)
 	}
 	if !strings.Contains(stderr, "archigraph_get_source") {
+		t.Errorf("deprecation message should name the tool, got: %q", stderr)
+	}
+}
+
+// (e) new name "entity_id" works for archigraph_inspect — no deprecation warning.
+func TestInspectNewParamEntityID(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_inspect", map[string]any{
+			"entity_id": "DashboardScreen",
+			"group":     "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("new param 'entity_id' should be accepted, got missing-arg error")
+	}
+	if strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("new param 'entity_id' should NOT emit a deprecation warning, got stderr: %s", stderr)
+	}
+}
+
+// (f) old name "label_or_id" works for archigraph_inspect AND deprecation log fires.
+func TestInspectOldParamLabelOrID_DeprecationFires(t *testing.T) {
+	srv := newSmokeSrv(t)
+
+	var resultIsHardError bool
+	stderr := captureStderr(func() {
+		r := callTool(t, srv, "archigraph_inspect", map[string]any{
+			"label_or_id": "DashboardScreen",
+			"group":       "g",
+		})
+		if r.IsError {
+			text := resultText(r)
+			if strings.Contains(text, "missing required argument") {
+				resultIsHardError = true
+			}
+		}
+	})
+
+	if resultIsHardError {
+		t.Error("legacy param 'label_or_id' should still work (compat alias), got missing-arg error")
+	}
+	if !strings.Contains(stderr, "[archigraph deprecation]") {
+		t.Errorf("expected deprecation warning on stderr for legacy param 'label_or_id', got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "archigraph_inspect") {
 		t.Errorf("deprecation message should name the tool, got: %q", stderr)
 	}
 }

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -287,7 +287,7 @@ func (s *Server) registerTools() {
 
 	s.MCP.AddTool(mcpapi.NewTool("archigraph_inspect",
 		mcpapi.WithDescription("Look up entity by id/qname/label. verbose=true restores all fields."),
-		mcpapi.WithString("label_or_id", mcpapi.Required()),
+		mcpapi.WithString("entity_id", mcpapi.Required()),
 		// verbose=true (default false) read from request map to stay under token ceiling.
 		mcpapi.WithArray("repo_filter"),
 		mcpapi.WithAny("group"),

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -622,9 +622,16 @@ func renderPerRepoSummary(all []scored, lg *LoadedGroup) string {
 // ---------------------------------------------------------------------------
 
 func (s *Server) handleGetNode(ctx context.Context, req mcpapi.CallToolRequest) (*mcpapi.CallToolResult, error) {
-	key, err := req.RequireString("label_or_id")
-	if err != nil {
-		return mcpapi.NewToolResultError(err.Error()), nil
+	// canonical name is "entity_id"; accept legacy "label_or_id" with a deprecation log.
+	key := argString(req, "entity_id", "")
+	if key == "" {
+		key = argString(req, "label_or_id", "")
+		if key != "" {
+			fmt.Fprintln(os.Stderr, "[archigraph deprecation] archigraph_inspect: param 'label_or_id' is deprecated, use 'entity_id'")
+		}
+	}
+	if key == "" {
+		return mcpapi.NewToolResultError("missing required argument: entity_id"), nil
 	}
 	_, lg, errRes := s.resolveAndGroup(req)
 	if errRes != nil {


### PR DESCRIPTION
## Summary
Completes #1790 standardization. Renames `label_or_id` → `entity_id` for `archigraph_inspect` tool to match standardization across `find_callers`, `find_callees`, `expand`, `traces`, `subgraph`, `find_paths`, and `get_source`. Maintains backward compatibility with deprecation log on stderr.

## Design
- JSON-Schema: `archigraph_inspect` parameter now declared as `entity_id` (required)
- Handler logic: reads new name first, falls back to legacy `label_or_id` with `[archigraph deprecation]` stderr log
- Same deprecation pattern as prior #1790 work (query/question for archigraph_find, entity_id/node_id for archigraph_get_source)

## Tests
- TestInspectNewParamEntityID: new name works, no deprecation log
- TestInspectOldParamLabelOrID_DeprecationFires: old name works + emits deprecation warning to stderr with tool name

## Verification
- `go build ./internal/mcp/...` ✓
- `go vet ./internal/mcp/...` ✓
- Unit tests pass ✓
- Cross-platform safe (pure arg-parsing, no syscalls)

## Example
```bash
# New canonical form (no warning)
archigraph_inspect entity_id=upvate-core::abc123

# Legacy form (still works, emits deprecation log to stderr)
archigraph_inspect label_or_id=upvate-core::abc123
[archigraph deprecation] archigraph_inspect: param 'label_or_id' is deprecated, use 'entity_id'
```

Fixes #1888. Do NOT merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)