### PR TITLE
feat(docgen): surface typed NeighbourBrief edges instead of flat RELATED (#1879)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -123,10 +123,33 @@ type NeighbourBrief struct {
 	Name string `json:"name"`
 	// Kind is the entity kind.
 	Kind string `json:"kind"`
-	// Relationship is the edge type from the seed to this neighbour
-	// (e.g. "CALLS", "IMPORTS", "TESTS", "IMPLEMENTS").
+	// Relationship is the typed edge kind from the seed to this neighbour as
+	// stored on the graph relationship — see NeighbourRelationship* constants
+	// for the canonical set. The value is preserved verbatim from the graph
+	// (#1879) so docgen can answer questions like "upstream callers" or
+	// "downstream callees" without inference. Falls back to
+	// NeighbourRelationshipRelated only when the graph lacks an explicit kind.
 	Relationship string `json:"relationship"`
 }
+
+// Canonical NeighbourBrief.Relationship values. The graph may emit other
+// kinds — these constants name the well-known set that docgen section
+// templates rely on (#1879, #1881, #1877). Consumers should treat the field
+// as an open string and switch on these constants for known cases.
+const (
+	NeighbourRelationshipCalls      = "CALLS"
+	NeighbourRelationshipImports    = "IMPORTS"
+	NeighbourRelationshipReferences = "REFERENCES"
+	NeighbourRelationshipContains   = "CONTAINS"
+	NeighbourRelationshipDependsOn  = "DEPENDS_ON"
+	NeighbourRelationshipFKTo       = "FK_TO"
+	NeighbourRelationshipRenders    = "RENDERS"
+	NeighbourRelationshipTests      = "TESTS"
+	NeighbourRelationshipImplements = "IMPLEMENTS"
+	// NeighbourRelationshipRelated is the fallback used only when an edge has
+	// no explicit kind on the graph. Should be rare for a well-formed graph.
+	NeighbourRelationshipRelated = "RELATED"
+)
 
 // LLMSectionResult is the per-section output written by the external
 // orchestrator after calling an LLM. The daemon reads a slice of these (wrapped
@@ -325,7 +348,11 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 	}
 
 	// Load entity context — reuses tier0.go loadEntityContext.
-	_, entity, neighbours, seedRepo, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	// neighbourKinds carries the typed edge kind for each neighbour so that
+	// NeighbourBrief.Relationship surfaces the actual graph relationship
+	// (CALLS, IMPORTS, CONTAINS, REFERENCES, DEPENDS_ON, FK_TO, ...) instead
+	// of a flat "RELATED" placeholder (#1879).
+	_, entity, neighbours, neighbourKinds, seedRepo, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return nil, err
 	}
@@ -336,20 +363,24 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		resolvedID = entity.ID
 	}
 
-	// Collect neighbour IDs and build briefs.
+	// Collect neighbour IDs and build briefs. Relationship is sourced from
+	// the index-aligned neighbourKinds slice produced by loadEntityContext;
+	// when a kind is somehow missing (defensive: should not happen for a
+	// well-formed graph) we fall back to "RELATED" to preserve a valid
+	// non-empty enum-shaped value for downstream consumers (#1879).
 	var neighbourIDs []string
 	var briefs []NeighbourBrief
-	// Build a relationship-kind lookup from the neighbours slice.
-	// loadEntityContext does not return relationship kinds, so we use a generic
-	// "RELATED" placeholder here; the emit-mode ticket (B) will wire the actual
-	// relationship kinds by passing relationships through.
-	for _, n := range neighbours {
+	for i, n := range neighbours {
 		neighbourIDs = append(neighbourIDs, n.ID)
+		rel := "RELATED"
+		if i < len(neighbourKinds) && neighbourKinds[i] != "" {
+			rel = neighbourKinds[i]
+		}
 		briefs = append(briefs, NeighbourBrief{
 			EntityID:     n.ID,
 			Name:         n.Name,
 			Kind:         n.Kind,
-			Relationship: "RELATED",
+			Relationship: rel,
 		})
 	}
 

--- a/internal/docgen/llm_bundle_typed_edges_test.go
+++ b/internal/docgen/llm_bundle_typed_edges_test.go
@@ -1,0 +1,293 @@
+package docgen_test
+
+// llm_bundle_typed_edges_test.go — unit tests for typed NeighbourBrief
+// relationships (#1879).
+//
+// Before this fix, BuildBundle collapsed every 1-hop neighbour edge to the
+// literal "RELATED" string, even though the underlying graph already carried
+// typed edge kinds (CALLS, IMPORTS, CONTAINS, REFERENCES, DEPENDS_ON, FK_TO,
+// ...). These tests build a fixture graph with a seed entity connected to
+// distinct neighbours via different edge kinds and assert that each kind
+// surfaces verbatim in the corresponding NeighbourBrief.Relationship value.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// typedEdgesHarness sets up an isolated group containing a single repo with
+// one seed entity wired to several neighbours via DIFFERENT typed edge kinds.
+// Returns the group name and the seed entity ID.
+//
+// Fixture topology (seed at center):
+//
+//	seed --CALLS-->        callee
+//	seed --IMPORTS-->      importedPkg
+//	seed --CONTAINS-->     childFn
+//	seed --REFERENCES-->   refTarget
+//	seed --DEPENDS_ON-->   depTarget
+//	seed --FK_TO-->        fkTarget
+//	parentMod --CONTAINS--> seed   (inbound — kind should still surface)
+func typedEdgesHarness(t *testing.T) (groupName, seedID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "myrepo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "typed-edges-test-group"
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name": groupName,
+		"repos": []map[string]interface{}{
+			{"path": repoPath, "slug": "myrepo"},
+		},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Entity IDs — fixed hex so assertions can reference them by name.
+	seedID = "1111111111111111"
+	calleeID := "2222222222222222"
+	importedID := "3333333333333333"
+	childID := "4444444444444444"
+	refID := "5555555555555555"
+	depID := "6666666666666666"
+	fkID := "7777777777777777"
+	parentID := "8888888888888888"
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{ID: seedID, Name: "seedFn", Kind: "Function", SourceFile: "seed.go", Language: "go"},
+			{ID: calleeID, Name: "callee", Kind: "Function", SourceFile: "callee.go", Language: "go"},
+			{ID: importedID, Name: "fmt", Kind: "Module", SourceFile: "", Language: "go"},
+			{ID: childID, Name: "innerFn", Kind: "Function", SourceFile: "seed.go", Language: "go"},
+			{ID: refID, Name: "RefType", Kind: "Class", SourceFile: "ref.go", Language: "go"},
+			{ID: depID, Name: "depTarget", Kind: "Module", SourceFile: "", Language: "go"},
+			{ID: fkID, Name: "fkTable", Kind: "Table", SourceFile: "schema.sql", Language: "sql"},
+			{ID: parentID, Name: "ParentModule", Kind: "Module", SourceFile: "seed.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "r1", FromID: seedID, ToID: calleeID, Kind: "CALLS"},
+			{ID: "r2", FromID: seedID, ToID: importedID, Kind: "IMPORTS"},
+			{ID: "r3", FromID: seedID, ToID: childID, Kind: "CONTAINS"},
+			{ID: "r4", FromID: seedID, ToID: refID, Kind: "REFERENCES"},
+			{ID: "r5", FromID: seedID, ToID: depID, Kind: "DEPENDS_ON"},
+			{ID: "r6", FromID: seedID, ToID: fkID, Kind: "FK_TO"},
+			// Inbound edge: parent contains seed. The seed→parent neighbour
+			// should still surface the "CONTAINS" kind (preserved verbatim
+			// regardless of direction).
+			{ID: "r7", FromID: parentID, ToID: seedID, Kind: "CONTAINS"},
+		},
+	}
+	doc.Stats = graph.Stats{
+		Files:         3,
+		Entities:      len(doc.Entities),
+		Relationships: len(doc.Relationships),
+	}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal graph doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, seedID
+}
+
+// TestBuildBundle_NeighbourBrief_TypedRelationships asserts that each typed
+// edge in the fixture surfaces in NeighbourBrief.Relationship verbatim, and
+// that NO neighbour is reported with the legacy "RELATED" placeholder when
+// the graph has explicit kinds (#1879).
+func TestBuildBundle_NeighbourBrief_TypedRelationships(t *testing.T) {
+	groupName, seedID := typedEdgesHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: seedID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	briefs := bundle.GraphContext.NeighbourBriefs
+	if len(briefs) == 0 {
+		t.Fatalf("expected non-empty neighbour_briefs, got 0")
+	}
+
+	// Build a lookup: neighbour name → relationship kind.
+	byName := make(map[string]string, len(briefs))
+	for _, b := range briefs {
+		byName[b.Name] = b.Relationship
+	}
+
+	wantByName := map[string]string{
+		"callee":       docgen.NeighbourRelationshipCalls,
+		"fmt":          docgen.NeighbourRelationshipImports,
+		"innerFn":      docgen.NeighbourRelationshipContains,
+		"RefType":      docgen.NeighbourRelationshipReferences,
+		"depTarget":    docgen.NeighbourRelationshipDependsOn,
+		"fkTable":      docgen.NeighbourRelationshipFKTo,
+		"ParentModule": docgen.NeighbourRelationshipContains, // inbound CONTAINS edge
+	}
+
+	for name, wantKind := range wantByName {
+		got, ok := byName[name]
+		if !ok {
+			t.Errorf("neighbour %q missing from neighbour_briefs", name)
+			continue
+		}
+		if got != wantKind {
+			t.Errorf("neighbour %q: Relationship=%q want %q", name, got, wantKind)
+		}
+	}
+
+	// Defensive: nothing should be the legacy "RELATED" placeholder when the
+	// graph has explicit kinds for every edge.
+	for _, b := range briefs {
+		if b.Relationship == docgen.NeighbourRelationshipRelated {
+			t.Errorf("neighbour %q collapsed to RELATED — typed edge kind was not preserved", b.Name)
+		}
+	}
+}
+
+// TestBuildBundle_NeighbourBrief_FallbackToRELATED asserts that when the
+// graph stores an edge with an empty Kind, NeighbourBrief.Relationship falls
+// back to "RELATED" rather than emitting an empty string. This is the
+// defensive path documented on BuildBundle.
+func TestBuildBundle_NeighbourBrief_FallbackToRELATED(t *testing.T) {
+	tmp := t.TempDir()
+
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "myrepo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "typed-edges-fallback-group"
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name": groupName,
+		"repos": []map[string]interface{}{
+			{"path": repoPath, "slug": "myrepo"},
+		},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	seedID := "aaaaaaaaaaaaaaaa"
+	otherID := "bbbbbbbbbbbbbbbb"
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{ID: seedID, Name: "seedFn", Kind: "Function", SourceFile: "x.go", Language: "go"},
+			{ID: otherID, Name: "other", Kind: "Function", SourceFile: "y.go", Language: "go"},
+		},
+		Relationships: []graph.Relationship{
+			// Intentionally empty Kind.
+			{ID: "r1", FromID: seedID, ToID: otherID, Kind: ""},
+		},
+	}
+	doc.Stats = graph.Stats{Files: 2, Entities: 2, Relationships: 1}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: seedID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	})
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+
+	briefs := bundle.GraphContext.NeighbourBriefs
+	if len(briefs) != 1 {
+		t.Fatalf("expected 1 neighbour brief, got %d", len(briefs))
+	}
+	if briefs[0].Relationship != docgen.NeighbourRelationshipRelated {
+		t.Errorf("empty-kind edge: Relationship=%q want %q",
+			briefs[0].Relationship, docgen.NeighbourRelationshipRelated)
+	}
+}

--- a/internal/docgen/tier0.go
+++ b/internal/docgen/tier0.go
@@ -146,7 +146,7 @@ func Run(opts RunOpts) (mdPath string, scoreFile string, score Score, err error)
 	}
 
 	// Load the group's graphs and locate the seed entity.
-	doc, entity, neighbours, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	doc, entity, neighbours, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return
 	}
@@ -261,7 +261,17 @@ func normalizeSeedEntityID(id string) (string, error) { return NormalizeSeedEnti
 // path of the seed entity. The returned seedRepo is always an absolute path
 // resolved from the fleet config — never a bare slug — so callers can safely
 // join it with entity.SourceFile regardless of the working directory.
-func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.Entity, neighbours []graph.Entity, seedRepo string, err error) {
+//
+// neighbourKinds is index-aligned with neighbours: neighbourKinds[i] is the
+// graph edge `kind` (e.g. "CALLS", "IMPORTS", "CONTAINS", "REFERENCES",
+// "DEPENDS_ON", "FK_TO") of the first relationship discovered between the seed
+// and neighbours[i]. The kind is preserved verbatim from the graph regardless
+// of edge direction so docgen can surface typed relationships in
+// NeighbourBrief.Relationship (#1879). When a neighbour is connected through
+// multiple relationships, the first edge encountered (in document iteration
+// order) wins; this is deterministic for a given graph state, which matches
+// the determinism guarantee already documented on this function.
+func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.Entity, neighbours []graph.Entity, neighbourKinds []string, seedRepo string, err error) {
 	seedID, err = normalizeSeedEntityID(seedID)
 	if err != nil {
 		return
@@ -329,7 +339,9 @@ func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.E
 		}
 	}
 
-	// Collect 1-hop neighbours via relationships.
+	// Collect 1-hop neighbours via relationships. neighbourKinds is built in
+	// lockstep with neighbours so that downstream NeighbourBrief construction
+	// can surface the typed edge kind (#1879).
 	seen := make(map[string]bool)
 	if seed != nil {
 		for _, rel := range allRels {
@@ -348,6 +360,7 @@ func loadEntityContext(group, seedID string) (doc *graph.Document, seed *graph.E
 			seen[neighbourID] = true
 			if n, ok := byID[neighbourID]; ok {
 				neighbours = append(neighbours, *n)
+				neighbourKinds = append(neighbourKinds, rel.Kind)
 			}
 		}
 	}

--- a/internal/docgen/tier1.go
+++ b/internal/docgen/tier1.go
@@ -151,7 +151,7 @@ func RunTier1(opts Tier1RunOpts) (mdPath string, scorePath string, score Tier1Sc
 	}
 
 	// Load entity context — reuse tier0 machinery.
-	_, entity, neighbours, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
+	_, entity, neighbours, _, _, err := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if err != nil {
 		return
 	}

--- a/internal/docgen/tier2.go
+++ b/internal/docgen/tier2.go
@@ -159,7 +159,7 @@ func RunTier2(opts Tier2RunOpts) (outDir string, score Tier2Score, err error) {
 	}
 
 	// Load entity context for the seed.
-	_, seedEntity, _, _, loadErr := loadEntityContext(opts.Group, opts.SeedEntityID)
+	_, seedEntity, _, _, _, loadErr := loadEntityContext(opts.Group, opts.SeedEntityID)
 	if loadErr != nil {
 		err = fmt.Errorf("load seed entity: %w", loadErr)
 		return


### PR DESCRIPTION
Fixes #1879

## 1. What this PR does

Surfaces the **actual** graph edge `Kind` on `NeighbourBrief.Relationship` instead of collapsing every 1-hop neighbour to the literal string `"RELATED"`. `BuildBundle` now threads relationship kinds through from the underlying graph relationships (`CALLS`, `IMPORTS`, `CONTAINS`, `REFERENCES`, `DEPENDS_ON`, `FK_TO`, `EXTENDS`, …) so docgen sections like *flows*, *reference-dependencies*, and *patterns* can be grounded in real edges instead of inferred from neighbour names.

This is the Wave 1 foundation called out by R3/R4 dogfooding:

> "All 116 neighbours marked RELATED — the bundle's neighbour graph is undifferentiated."

## 2. Evidence — before/after on a real bundle

Live-emitted bundle for `upvate-core::28710b94eae3f980` (Contract Django Model) using the patched daemon binary, `--llm-mode=emit --no-cache --tier=1`.

**Before** (main, per #1879 evidence):
| Relationship | Count |
|---|---:|
| `RELATED` | 116 |

**After** (this PR):
| Relationship | Count |
|---|---:|
| `REFERENCES` | 68 |
| `CONTAINS` | 46 |
| `DEPENDS_ON` | 1 |
| `EXTENDS` | 1 |

Generated with:
```
archigraph docgen --group upvate --seed-entity upvate-core::28710b94eae3f980 \
  --tier 1 --llm-mode emit --no-cache --output-dir /tmp/typed-edges-verify
jq '.graph_context.neighbour_briefs | group_by(.relationship)
    | map({rel: .[0].relationship, count: length}) | sort_by(-.count)' \
  /tmp/typed-edges-verify/upvate-core--28710b94eae3f980-page-bundle.json
```

Note: `EXTENDS` is a real Django graph kind not in my canonical enum set. The fix preserves the kind verbatim, so future graph-emitted kinds surface immediately without enum churn.

## 3. Implementation

- `internal/docgen/tier0.go::loadEntityContext`
  - New return slot `neighbourKinds []string` index-aligned with `neighbours`. First relationship discovered between seed and neighbour wins (deterministic for a given graph state).
  - Direction-agnostic: edge kind is preserved verbatim whether the seed is `FromID` or `ToID`.
- `internal/docgen/llm_bundle.go::BuildBundle`
  - Uses `neighbourKinds[i]` to populate `NeighbourBrief.Relationship`.
  - Falls back to `"RELATED"` only when the graph kind is empty (defensive — should not happen for well-formed graphs).
- `internal/docgen/llm_bundle.go`
  - Added canonical `NeighbourRelationship*` constants (`CALLS`, `IMPORTS`, `REFERENCES`, `CONTAINS`, `DEPENDS_ON`, `FK_TO`, `RENDERS`, `TESTS`, `IMPLEMENTS`, `RELATED`). The `Relationship` field stays an open string so graph-emitted kinds outside this set still surface to downstream consumers.
- `internal/docgen/tier1.go`, `internal/docgen/tier2.go`
  - Caller signature update for the new return slot (discarded — neither file consumes kinds yet).
- `internal/docgen/llm_bundle_typed_edges_test.go` (new)
  - `TestBuildBundle_NeighbourBrief_TypedRelationships`: fixture graph wires seed to 6 outbound neighbours via distinct kinds plus an inbound `CONTAINS` edge; asserts each surfaces verbatim and no neighbour collapses to `RELATED`.
  - `TestBuildBundle_NeighbourBrief_FallbackToRELATED`: empty-kind edge asserts the defensive fallback.

## 4. What this unblocks (Wave 2)

The flat-`RELATED` problem was the choke point for all the typed-bucket and archetypal-mode work. With kinds preserved:

- **#1881 Module typed buckets** — can now group neighbours by `CONTAINS` / `IMPORTS` / `REFERENCES` directly from `NeighbourBrief.Relationship`. No more name-pattern guessing.
- **#1877 NeighbourBrief.TypeHint** — companion ticket can layer richer hints on top of an already-typed edge.
- **#1882 api catalog mode** — exported-surface enumeration filters by `CONTAINS` from the module seed.
- **#1883 module flows archetypal mode** — "largest typed sub-graph" picker can finally compare `CALLS` vs `REFERENCES` vs `DEPENDS_ON` clusters.
- **#1867 class-seed typed deps from method bodies** — reads `CALLS` and `REFERENCES` to build dependency lists.
- **General prose grounding** — *flows* section can write "upstream callers" / "downstream callees" by filtering `Relationship == "CALLS"`; *reference-dependencies* can list `DEPENDS_ON` and `IMPORTS` separately.

## 5. Verification

```
$ go vet ./...                       # clean
$ go build ./...                     # clean
$ go test ./internal/docgen/... -count=1
ok  github.com/cajasmota/archigraph/internal/docgen 2.224s
```

New tests pass:
```
=== RUN   TestBuildBundle_NeighbourBrief_TypedRelationships
--- PASS: TestBuildBundle_NeighbourBrief_TypedRelationships (0.02s)
=== RUN   TestBuildBundle_NeighbourBrief_FallbackToRELATED
--- PASS: TestBuildBundle_NeighbourBrief_FallbackToRELATED (0.02s)
```

Plus live verification on a real upvate-core entity (table above).

## 6. Cross-platform discipline (#1777)

Pure Go data plumbing through existing data structures. No new `os.*`, `syscall.*`, or filesystem code added. CI matrix coverage unchanged.

## 7. Coordination & scope

- **No** changes to `sectionsByKind` (separate grind #1875).
- **No** changes to section guidance text (separate grind).
- **No** changes to webui (#1891/#1892/#1893 are different code base).
- Parallel haiku grind #1888 (`inspect` param standardization) touches different files — no conflict.
- All-7-sections format per `feedback_archigraph_pr_and_cleanup` + owner 2026-05-23 lock.
- **Do NOT merge** — flagged for owner review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
