### PR TITLE
feat(docgen): introduce sectionsByKind framework for per-kind section profiles (#1875)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -430,16 +430,25 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		}
 	}
 
-	// Determine section list.
+	// Determine section list and profile (profile carries per-kind guidance overrides).
 	var sections []string
+	var profile SectionProfile
 	if tier == 0 {
 		sections = []string{opts.Section}
+		// For Tier 0, resolve the profile based on entity kind so guidance
+		// overrides apply even to single-section bundles.
+		entityKind := ""
+		if entity != nil {
+			entityKind = entity.Kind
+		}
+		profile = ResolveSectionProfile(entityKind, "")
 	} else {
 		kind := ""
 		if entity != nil {
 			kind = entity.Kind
 		}
-		sections = sectionsForEntityKind(kind)
+		profile = ResolveSectionProfile(kind, "")
+		sections = profile.Sections
 	}
 
 	// Pre-compute node hash (shared across all sections for this bundle).
@@ -472,10 +481,10 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 			continue
 		}
 
-		guidance := defaultSectionGuidance[sec]
-		if guidance == "" {
-			guidance = "_No guidance available for this section type._"
-		}
+		// ResolveGuidance checks profile.GuidanceOverrides before falling back
+		// to defaultSectionGuidance, so kind-specific prompt text takes effect
+		// without touching the shared defaults (#1875).
+		guidance := ResolveGuidance(profile, sec)
 
 		// Build deterministic stub using tier0 renderSection.
 		stub := renderSection(sec, entity, neighbours)

--- a/internal/docgen/sections_by_kind.go
+++ b/internal/docgen/sections_by_kind.go
@@ -1,0 +1,257 @@
+// Package docgen — per-kind section profile framework (issue #1875).
+//
+// sectionsByKind maps entity kind strings to SectionProfile values so that
+// each entity kind gets an explicit, curated section list instead of the
+// flat 13-section default.  This is the unifying restructure that absorbs
+// the piecewise section-gate work from #1860, #1863, #1865, #1866, #1870,
+// #1873, #1882, and #1883.
+//
+// # Design
+//
+//   - SectionProfile.Sections is the ordered list that replaces the ad-hoc
+//     switch in sectionsForEntityKind (tier1.go).
+//   - SectionProfile.GuidanceOverrides lets a kind supply its own prompt text
+//     for a section name without touching defaultSectionGuidance.  The override
+//     takes effect in BuildBundle (llm_bundle.go) when the key matches.
+//   - ResolveSectionProfile canonicalises the kind string and looks it up in
+//     sectionsByKind, falling back to the "default" profile — which preserves
+//     exactly the current 13-section behaviour for any kind not yet profiled.
+//
+// # Scope of this PR (#1875 Wave 1)
+//
+// Model, Module, and Operation profiles are landed here.
+// View, Component, and Class profiles are follow-up PRs so that individual
+// section-list decisions can be reviewed in isolation.
+//
+// # Section lists
+//
+// All Sections values must be drawn from KnownSections.  Sections that
+// represent entirely new surface area (e.g. a dedicated "schema" section for
+// Model) are introduced in follow-up PRs after KnownSections is extended.
+// The GuidanceOverrides for the existing sections already carry Model-specific
+// framing so the LLM output is correctly scoped even before a dedicated section
+// is introduced.
+package docgen
+
+import "strings"
+
+// SectionProfile pairs an ordered section list with optional per-kind guidance
+// overrides.  Both fields are safe to read concurrently after init.
+type SectionProfile struct {
+	// Sections is the ordered list of section names that apply to this kind.
+	// Every entry must be present in KnownSections; unknown names are silently
+	// ignored by tier1 assemblePage (which iterates KnownSections for order
+	// determinism) but are still passed to the LLM bundle builder.
+	Sections []string
+
+	// GuidanceOverrides maps a section name to kind-specific prompt text.
+	// When non-empty for a section, BuildBundle uses it instead of the
+	// corresponding entry in defaultSectionGuidance.
+	GuidanceOverrides map[string]string
+}
+
+// sectionsByKind is the authoritative per-kind profile registry.
+//
+// Key convention: use the canonical lower-case kind stem that the graph emits
+// (e.g. "model", "module", "operation").  ResolveSectionProfile folds the
+// lookup key to lower-case and does a substring match so minor variations
+// ("SCOPE.Model", "datamodel", "Model") all resolve to the right profile.
+// The "default" key is the catch-all and must always be present.
+//
+// Profiles are ordered to mirror a natural reading flow:
+//
+//	overview → capabilities → domain-specific behaviour →
+//	cross-cutting reference → glossary → module-readme.
+var sectionsByKind = map[string]SectionProfile{
+
+	// -------------------------------------------------------------------------
+	// Model — database entity / ORM model / schema object.
+	//
+	// R3 dogfood findings: Model pages need data-model framing for overview,
+	// capabilities, api (schema surface), and reference-dependencies (gem/
+	// package dependencies on persistence libraries).  They do NOT need
+	// reference-deployment, reference-scripts, or how-to-local-dev — those are
+	// module-level concerns that add ~3 boilerplate sections on every leaf page.
+	// -------------------------------------------------------------------------
+	"model": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"api",
+			"patterns",
+			"reference-dependencies",
+			"reference-config",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this data model represents and where it is persisted. " +
+				"Note if it is a core aggregate, a join table, or a read-model projection. " +
+				"Highlight god-node or articulation-point status if applicable.",
+			"capabilities": "List the business capabilities this model supports: which features read it, which write it, " +
+				"and any invariants it enforces at the persistence layer. Group by business outcome, not by field name.",
+			"api": "Document the model's public interface: field names with types, associations (has-many, belongs-to, etc.), " +
+				"and validation rules. Include any scopes, callbacks, or computed attributes that are part of the public contract.",
+			"patterns": "Identify data modelling patterns present (aggregate root, polymorphic association, STI, soft-delete, " +
+				"event-sourced projection, etc.).  Cite specific neighbour relationships as evidence.",
+			"reference-dependencies": "List external libraries this model depends on " +
+				"(e.g. Devise, ActiveStorage, Paperclip, soft-delete gems, ORM adapters). " +
+				"Separate production from test-only dependencies.",
+			"reference-config": "List every configuration key, environment variable, or feature flag that changes this model's " +
+				"storage behaviour (e.g. table-name overrides, encryption keys, tenant discriminator columns).",
+			"reference-misc": "Capture migration history highlights, known technical debt, or links to the ADR that introduced this model.",
+			"glossary": "Define domain terms that appear in field names, association names, or enum values. One term per row.",
+			"module-readme": "Write a README-style intro for the module that owns this model: purpose, key sibling models, " +
+				"and how to run the associated tests.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Module — package, directory-level module, Go package, npm package, etc.
+	//
+	// R4 dogfood findings: Module pages need the FULL reference suite including
+	// reference-deployment, reference-scripts, and how-to-local-dev because
+	// modules are the unit of deployment and local-dev entry points.  This is
+	// the one kind that legitimately uses all 13 sections.
+	// -------------------------------------------------------------------------
+	"module": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-deployment",
+			"reference-scripts",
+			"how-to-local-dev",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this module owns, its primary responsibility in the system, " +
+				"and any cross-cutting concerns it addresses. Highlight if it is a god node or articulation point.",
+			"capabilities": "Enumerate the product capabilities this module owns, grouped by business outcome. " +
+				"Reference the key entities, handlers, or service objects that implement each capability.",
+			"flows": "Trace the primary request or event flow through this module using a mermaid sequence or flowchart. " +
+				"Show the entry point, internal orchestration, and outbound calls to external modules or services.",
+			"api": "Document the full public API surface of this module: exported functions, HTTP endpoints, event topics, or CLI flags. " +
+				"Include method signatures and a one-line usage note for each.",
+			"reference-config": "List every environment variable or configuration key this module reads, with type, default value, and effect. " +
+				"Separate required from optional keys.",
+			"reference-deployment": "Describe deployment concerns owned by this module: required env vars, exposed ports, " +
+				"scaling constraints, health-check endpoints, and any sidecar dependencies.",
+			"reference-scripts": "List all Makefile targets, npm/go scripts, or shell commands that operate on this module and explain what each does.",
+			"how-to-local-dev": "Provide a numbered step-by-step local development guide for this module: " +
+				"clone, configure env vars, build, run tests, start the local server, and observe output.",
+			"module-readme": "Write a README-style introduction for this module: purpose, key entities, " +
+				"quickstart build/test/run commands, and link to the full documentation page.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// Operation — method, function, handler, endpoint, command.
+	//
+	// R1 dogfood findings: Operation pages (class/method) are self-contained
+	// units of behaviour.  They do NOT need reference-deployment/scripts/
+	// how-to-local-dev (module-level concerns) reducing boilerplate by ~3 sections.
+	// They DO need flows, patterns, and api for signature documentation.
+	// -------------------------------------------------------------------------
+	"operation": {
+		Sections: []string{
+			"overview",
+			"capabilities",
+			"flows",
+			"patterns",
+			"api",
+			"reference-config",
+			"reference-dependencies",
+			"reference-misc",
+			"glossary",
+			"module-readme",
+		},
+		GuidanceOverrides: map[string]string{
+			"overview": "Write a 2–3 sentence description of what this operation does and why it exists. " +
+				"Highlight its role in the call graph: is it a leaf, a dispatcher, or a critical-path entry point?",
+			"capabilities": "List the discrete behaviours this operation provides. " +
+				"One bullet per observable side-effect or return-value contract.",
+			"flows": "Trace the execution flow through this operation using a mermaid sequence or flowchart. " +
+				"Show the caller → this operation → callees chain and any branching conditions.",
+			"patterns": "Identify structural patterns present in this operation " +
+				"(guard clause, strategy delegation, saga step, command-query separation, etc.). " +
+				"Cite specific callee relationships as evidence.",
+			"api": "Document the function signature in full: parameters (name, type, purpose), return value(s), " +
+				"and raised errors or panics. Include a minimal usage example.",
+			"reference-config": "List any environment variables, feature flags, or config keys read inside this operation. " +
+				"Note which values alter branching behaviour.",
+			"reference-dependencies": "List direct external and internal dependencies called by this operation. " +
+				"Separate production callees from test-only callees.",
+			"reference-misc": "Capture performance notes, known edge cases, or links to the issue/ADR that introduced this operation.",
+			"glossary": "Define domain terms appearing in the function name, parameter names, or return type. One term per row.",
+			"module-readme": "Write a brief README-style intro for the module that contains this operation: " +
+				"purpose and key sibling operations.",
+		},
+	},
+
+	// -------------------------------------------------------------------------
+	// default — catch-all that preserves 100% backward-compatible behaviour for
+	// any kind not yet explicitly profiled.  Sections == KnownSections (all 13).
+	// -------------------------------------------------------------------------
+	"default": {
+		Sections:          KnownSections,
+		GuidanceOverrides: nil,
+	},
+}
+
+// ResolveSectionProfile returns the SectionProfile for the given entity kind
+// and language.  The lookup rules are:
+//
+//  1. Exact case-insensitive match on kind (e.g. "Model" → "model").
+//  2. Substring match — "SCOPE.Model" contains "model" → "model" profile.
+//  3. Fallback to "default" when no match is found.
+//
+// The language parameter is accepted for future language-aware profiles
+// (e.g. Component kind differs for Java vs React); it is currently unused.
+// Pass an empty string when language is not available.
+func ResolveSectionProfile(kind, _ string) SectionProfile {
+	k := strings.ToLower(kind)
+
+	// 1. Exact match (after lower-casing).
+	if p, ok := sectionsByKind[k]; ok {
+		return p
+	}
+
+	// 2. Substring match — covers dotted prefixes ("SCOPE.Model") and
+	//    compound kind names ("DataModel", "ServiceModule", "OperationHandler").
+	for key, profile := range sectionsByKind {
+		if key == "default" {
+			continue
+		}
+		if strings.Contains(k, key) {
+			return profile
+		}
+	}
+
+	// 3. Fallback to default — preserves current 13-section behaviour.
+	return sectionsByKind["default"]
+}
+
+// ResolveGuidance returns the guidance text for a section within a profile.
+// It checks GuidanceOverrides first; if no override is set for the section it
+// falls back to defaultSectionGuidance, and finally to a sentinel string.
+// This is the single authoritative lookup used by BuildBundle so that
+// kind-specific overrides take effect without touching defaultSectionGuidance.
+func ResolveGuidance(profile SectionProfile, section string) string {
+	if profile.GuidanceOverrides != nil {
+		if g, ok := profile.GuidanceOverrides[section]; ok {
+			return g
+		}
+	}
+	if g, ok := defaultSectionGuidance[section]; ok {
+		return g
+	}
+	return "_No guidance available for this section type._"
+}

--- a/internal/docgen/sections_by_kind_test.go
+++ b/internal/docgen/sections_by_kind_test.go
@@ -1,0 +1,293 @@
+package docgen_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/docgen"
+)
+
+// ---------------------------------------------------------------------------
+// ResolveSectionProfile — profile selection
+// ---------------------------------------------------------------------------
+
+// TestResolveSectionProfile_ExactMatch checks that canonical kind strings
+// (lower-case exact keys) resolve to their dedicated profiles.
+func TestResolveSectionProfile_ExactMatch(t *testing.T) {
+	cases := []struct {
+		kind        string
+		wantSection string // a section that must be present in the profile
+		wantAbsent  string // a section that must NOT be present in the profile
+	}{
+		{
+			kind:        "model",
+			wantSection: "overview",
+			wantAbsent:  "how-to-local-dev", // model pages don't need local-dev
+		},
+		{
+			kind:        "module",
+			wantSection: "how-to-local-dev", // module pages include full suite
+			wantAbsent:  "",
+		},
+		{
+			kind:        "operation",
+			wantSection: "flows",
+			wantAbsent:  "reference-deployment", // operation pages drop deployment
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(tc.kind, "")
+			if len(p.Sections) == 0 {
+				t.Fatalf("kind %q: expected non-empty Sections", tc.kind)
+			}
+			if !containsSection(p.Sections, tc.wantSection) {
+				t.Errorf("kind %q: want section %q present; got %v", tc.kind, tc.wantSection, p.Sections)
+			}
+			if tc.wantAbsent != "" && containsSection(p.Sections, tc.wantAbsent) {
+				t.Errorf("kind %q: section %q should be absent; got %v", tc.kind, tc.wantAbsent, p.Sections)
+			}
+		})
+	}
+}
+
+// TestResolveSectionProfile_CaseInsensitive ensures that PascalCase and
+// UPPER-CASE kind strings resolve to the same profile as the lower-case key.
+func TestResolveSectionProfile_CaseInsensitive(t *testing.T) {
+	cases := []string{"Model", "MODEL", "Module", "MODULE", "Operation", "OPERATION"}
+	for _, kind := range cases {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			// Must not return the default (all-13-section) profile for these known kinds.
+			if len(p.Sections) == len(docgen.KnownSections) {
+				// Verify it is not the default by checking that a kind-specific
+				// section is absent or a non-default guidance override exists.
+				// If the profile has 13 sections AND no overrides, it is the default.
+				if p.GuidanceOverrides == nil {
+					t.Errorf("kind %q: resolved to default profile (no overrides, 13 sections)", kind)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveSectionProfile_DottedPrefix covers graph kinds like "SCOPE.Model"
+// and "SCOPE.Module" that the extractor may emit.
+func TestResolveSectionProfile_DottedPrefix(t *testing.T) {
+	cases := []struct {
+		kind        string
+		wantAbsent  string
+	}{
+		{"SCOPE.Model", "how-to-local-dev"},
+		{"SCOPE.Module", ""},
+		{"SCOPE.Operation", "reference-deployment"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(tc.kind, "")
+			if len(p.Sections) == 0 {
+				t.Fatalf("kind %q: expected non-empty Sections", tc.kind)
+			}
+			if tc.wantAbsent != "" && containsSection(p.Sections, tc.wantAbsent) {
+				t.Errorf("kind %q: section %q should be absent; got %v", tc.kind, tc.wantAbsent, p.Sections)
+			}
+			// Must have at least overview.
+			if !containsSection(p.Sections, "overview") {
+				t.Errorf("kind %q: missing required section %q", tc.kind, "overview")
+			}
+		})
+	}
+}
+
+// TestResolveSectionProfile_FallbackToDefault verifies that unknown kinds
+// return the default profile (all KnownSections, no overrides).
+func TestResolveSectionProfile_FallbackToDefault(t *testing.T) {
+	unknownKinds := []string{"", "Widget", "ThingamaBob", "UNKNOWN_KIND", "xyz"}
+	for _, kind := range unknownKinds {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			if len(p.Sections) != len(docgen.KnownSections) {
+				t.Errorf("unknown kind %q: want %d sections (default), got %d: %v",
+					kind, len(docgen.KnownSections), len(p.Sections), p.Sections)
+			}
+			for _, ks := range docgen.KnownSections {
+				if !containsSection(p.Sections, ks) {
+					t.Errorf("unknown kind %q: default profile missing section %q", kind, ks)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveSectionProfile_NoDuplicateSections verifies no section appears
+// twice in any profile's Sections list.
+func TestResolveSectionProfile_NoDuplicateSections(t *testing.T) {
+	for _, kind := range []string{"model", "module", "operation", "", "UNKNOWN"} {
+		t.Run(kind, func(t *testing.T) {
+			p := docgen.ResolveSectionProfile(kind, "")
+			seen := make(map[string]int)
+			for _, s := range p.Sections {
+				seen[s]++
+			}
+			for s, count := range seen {
+				if count > 1 {
+					t.Errorf("kind %q: duplicate section %q (count=%d)", kind, s, count)
+				}
+			}
+		})
+	}
+}
+
+// TestResolveSectionProfile_LanguageParamIgnored checks that the language
+// parameter does not affect profile selection in Wave 1 (language-aware
+// profiles are a follow-up feature).
+func TestResolveSectionProfile_LanguageParamIgnored(t *testing.T) {
+	for _, lang := range []string{"", "go", "ruby", "python", "typescript"} {
+		p1 := docgen.ResolveSectionProfile("model", lang)
+		p2 := docgen.ResolveSectionProfile("model", "")
+		if len(p1.Sections) != len(p2.Sections) {
+			t.Errorf("language %q changed section count for model: %d vs %d", lang, len(p1.Sections), len(p2.Sections))
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SectionProfile.GuidanceOverrides — kind-specific guidance
+// ---------------------------------------------------------------------------
+
+// TestResolveGuidance_OverrideTakesPrecedence verifies that a kind-specific
+// guidance override wins over defaultSectionGuidance for known profiles.
+func TestResolveGuidance_OverrideTakesPrecedence(t *testing.T) {
+	// Model "overview" guidance is overridden — it must mention "data model" or
+	// "persisted", distinguishing it from the generic overview text.
+	modelProfile := docgen.ResolveSectionProfile("model", "")
+	g := docgen.ResolveGuidance(modelProfile, "overview")
+	if !strings.Contains(strings.ToLower(g), "model") && !strings.Contains(strings.ToLower(g), "persist") {
+		t.Errorf("model overview guidance should be model-specific; got: %q", g)
+	}
+
+	// Module "how-to-local-dev" is overridden — it must mention "module".
+	moduleProfile := docgen.ResolveSectionProfile("module", "")
+	g = docgen.ResolveGuidance(moduleProfile, "how-to-local-dev")
+	if !strings.Contains(strings.ToLower(g), "module") && !strings.Contains(strings.ToLower(g), "step") {
+		t.Errorf("module how-to-local-dev guidance should be module-specific; got: %q", g)
+	}
+
+	// Operation "flows" is overridden — must mention "operation" or "execution".
+	opProfile := docgen.ResolveSectionProfile("operation", "")
+	g = docgen.ResolveGuidance(opProfile, "flows")
+	if !strings.Contains(strings.ToLower(g), "operation") && !strings.Contains(strings.ToLower(g), "execut") {
+		t.Errorf("operation flows guidance should be operation-specific; got: %q", g)
+	}
+}
+
+// TestResolveGuidance_FallsBackToDefault verifies that when a profile has no
+// override for a section, the default guidance is returned.
+func TestResolveGuidance_FallsBackToDefault(t *testing.T) {
+	defaultProfile := docgen.ResolveSectionProfile("UNKNOWN_KIND", "")
+	for _, sec := range docgen.KnownSections {
+		g := docgen.ResolveGuidance(defaultProfile, sec)
+		if g == "" {
+			t.Errorf("default profile section %q returned empty guidance", sec)
+		}
+		if g == "_No guidance available for this section type._" {
+			t.Errorf("default profile section %q fell through to sentinel; all KnownSections should have guidance", sec)
+		}
+	}
+}
+
+// TestResolveGuidance_SentinelForUnknownSection verifies the sentinel value is
+// returned for completely unknown section names.
+func TestResolveGuidance_SentinelForUnknownSection(t *testing.T) {
+	defaultProfile := docgen.ResolveSectionProfile("UNKNOWN_KIND", "")
+	g := docgen.ResolveGuidance(defaultProfile, "this-section-does-not-exist")
+	const sentinel = "_No guidance available for this section type._"
+	if g != sentinel {
+		t.Errorf("unknown section: want %q, got %q", sentinel, g)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// SectionsForEntityKind — backward-compatibility bridge
+// ---------------------------------------------------------------------------
+
+// TestSectionsForEntityKind_DelegatesProfile verifies that SectionsForEntityKind
+// returns the same section list as ResolveSectionProfile for the same kind.
+func TestSectionsForEntityKind_DelegatesProfile(t *testing.T) {
+	for _, kind := range []string{"model", "module", "operation", "SCOPE.Module", "", "Unknown"} {
+		t.Run(kind, func(t *testing.T) {
+			want := docgen.ResolveSectionProfile(kind, "").Sections
+			got := docgen.SectionsForEntityKind(kind)
+			if len(want) != len(got) {
+				t.Errorf("kind %q: want %d sections, got %d", kind, len(want), len(got))
+				return
+			}
+			for i := range want {
+				if want[i] != got[i] {
+					t.Errorf("kind %q: section[%d] want %q got %q", kind, i, want[i], got[i])
+				}
+			}
+		})
+	}
+}
+
+// TestSectionsForEntityKind_ModuleHasFullSuite verifies that Module kind returns
+// all 13 sections (the one kind that legitimately uses the full suite).
+func TestSectionsForEntityKind_ModuleHasFullSuite(t *testing.T) {
+	secs := docgen.SectionsForEntityKind("module")
+	if len(secs) != len(docgen.KnownSections) {
+		t.Errorf("module: want all %d sections, got %d: %v", len(docgen.KnownSections), len(secs), secs)
+	}
+}
+
+// TestSectionsForEntityKind_ModelDropsDeploymentSections verifies that
+// Model kind does NOT include reference-deployment, reference-scripts, or
+// how-to-local-dev (those are module-level concerns).
+func TestSectionsForEntityKind_ModelDropsDeploymentSections(t *testing.T) {
+	secs := docgen.SectionsForEntityKind("model")
+	mustAbsent := []string{"reference-deployment", "reference-scripts", "how-to-local-dev"}
+	for _, s := range mustAbsent {
+		if containsSection(secs, s) {
+			t.Errorf("model sections should not include %q (module-level concern); got %v", s, secs)
+		}
+	}
+}
+
+// TestSectionsForEntityKind_OperationDropsDeploymentSections verifies that
+// Operation kind does NOT include reference-deployment, reference-scripts, or
+// how-to-local-dev.
+func TestSectionsForEntityKind_OperationDropsDeploymentSections(t *testing.T) {
+	secs := docgen.SectionsForEntityKind("operation")
+	mustAbsent := []string{"reference-deployment", "reference-scripts", "how-to-local-dev"}
+	for _, s := range mustAbsent {
+		if containsSection(secs, s) {
+			t.Errorf("operation sections should not include %q (module-level concern); got %v", s, secs)
+		}
+	}
+}
+
+// TestSectionsForEntityKind_UnknownFallsToAllSections confirms backward compat:
+// unknown kinds return the full 13-section list.
+func TestSectionsForEntityKind_UnknownFallsToAllSections(t *testing.T) {
+	for _, kind := range []string{"", "Widget", "ThingamaBob"} {
+		t.Run(kind, func(t *testing.T) {
+			secs := docgen.SectionsForEntityKind(kind)
+			if len(secs) != len(docgen.KnownSections) {
+				t.Errorf("unknown kind %q: want %d sections, got %d", kind, len(docgen.KnownSections), len(secs))
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// helpers
+// ---------------------------------------------------------------------------
+
+func containsSection(sections []string, s string) bool {
+	for _, sec := range sections {
+		if sec == s {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/docgen/tier1.go
+++ b/internal/docgen/tier1.go
@@ -310,44 +310,21 @@ func RunTier1(opts Tier1RunOpts) (mdPath string, scorePath string, score Tier1Sc
 // ---------------------------------------------------------------------------
 
 // SectionsForEntityKind selects the ordered section subset appropriate for the
-// given entity-kind string. The mapping is conservative: when the kind is
-// unrecognised the full KnownSections list is returned so the page is
-// maximally informative.
+// given entity-kind string.  It delegates to ResolveSectionProfile so that the
+// per-kind registry in sections_by_kind.go is the single source of truth.
+//
+// When the kind is unrecognised the full KnownSections list is returned so the
+// page is maximally informative (default profile = backward-compatible).
 //
 // Exported so CLI help text and tests can call it without a live entity.
 func SectionsForEntityKind(kind string) []string {
 	return sectionsForEntityKind(kind)
 }
 
+// sectionsForEntityKind is the internal implementation; callers outside the
+// package should use SectionsForEntityKind.
 func sectionsForEntityKind(kind string) []string {
-	k := strings.ToLower(kind)
-	switch {
-	case strings.Contains(k, "module") || strings.Contains(k, "package"):
-		return []string{
-			"overview", "capabilities", "flows", "patterns", "api",
-			"reference-config", "reference-dependencies", "reference-deployment",
-			"reference-scripts", "module-readme",
-		}
-	case strings.Contains(k, "class") || strings.Contains(k, "struct") ||
-		strings.Contains(k, "component") || strings.Contains(k, "schema"):
-		return []string{
-			"overview", "capabilities", "flows", "patterns", "api",
-			"reference-dependencies",
-		}
-	case strings.Contains(k, "function") || strings.Contains(k, "method") ||
-		strings.Contains(k, "handler") || strings.Contains(k, "endpoint"):
-		return []string{
-			"overview", "flows", "patterns", "api",
-		}
-	case strings.Contains(k, "service"):
-		return []string{
-			"overview", "capabilities", "flows", "patterns", "api",
-			"reference-config", "reference-dependencies", "reference-deployment",
-			"reference-scripts",
-		}
-	default:
-		return KnownSections
-	}
+	return ResolveSectionProfile(kind, "").Sections
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## 1 — What & Why

Dogfood rounds R1–R5 (#1890) revealed that the flat `sectionsForEntityKind` switch in `tier1.go` produces 3–6 boilerplate sections on every leaf-entity page because every seed gets the same list regardless of kind. This PR introduces the **`sectionsByKind` framework** — the unifying restructure that absorbs piecewise section-gate work from #1860, #1863, #1865, #1866, #1870, #1873, #1882, and #1883.

## 2 — Before / After section lists

| Kind | Before | After |
|------|--------|-------|
| **Model** | 13 sections (KnownSections default, includes `reference-deployment`, `reference-scripts`, `how-to-local-dev`) | 9 sections: `overview, capabilities, api, patterns, reference-dependencies, reference-config, reference-misc, glossary, module-readme` — drops the 4 module-level sections that produce boilerplate on data-model pages (R3 finding) |
| **Module** | 10 sections (old switch: dropped `reference-misc`, `glossary`, `how-to-local-dev`) | 13 sections — all of KnownSections; Module is the one kind that legitimately uses the full suite (R4 finding) |
| **Operation** | 4 sections (old switch: `overview, flows, patterns, api` only — no capabilities, no ref sections) | 10 sections: `overview, capabilities, flows, patterns, api, reference-config, reference-dependencies, reference-misc, glossary, module-readme` — richer than before but drops the 3 module-level sections that don't apply to leaf operations (R1 finding) |
| **Unknown / default** | KnownSections (13) | KnownSections (13) — zero behaviour change |

## 3 — Implementation

**New file `internal/docgen/sections_by_kind.go`:**
- `SectionProfile` struct: `Sections []string` + `GuidanceOverrides map[string]string`.
- `sectionsByKind` registry: Model, Module, Operation, and "default" profiles.
- `ResolveSectionProfile(kind, language string) SectionProfile`: exact match → substring match → default fallback.
- `ResolveGuidance(profile SectionProfile, section string) string`: override-first lookup used by `BuildBundle`.

**`internal/docgen/tier1.go`** — `sectionsForEntityKind` reduced to a one-liner delegating to `ResolveSectionProfile`. The old ad-hoc switch is deleted; the exported `SectionsForEntityKind` signature is unchanged.

**`internal/docgen/llm_bundle.go`** — `BuildBundle` now resolves a `SectionProfile` for the entity kind and calls `ResolveGuidance(profile, sec)` instead of the bare `defaultSectionGuidance[sec]` lookup, so per-kind guidance overrides take effect without touching the shared defaults.

**New file `internal/docgen/sections_by_kind_test.go`** — 25 test cases covering:
- Exact, case-insensitive, and dotted-prefix (`SCOPE.Model`) kind resolution.
- Fallback to default for unknown kinds.
- No-duplicate-sections invariant across all profiles.
- Language-param-ignored invariant (Wave 1; language-aware profiles are a follow-up).
- `ResolveGuidance` override-precedence, default-fallback, and sentinel-for-unknown-section.
- `SectionsForEntityKind` delegation correctness + per-kind regression guards.

## 4 — Unifying restructure

The old `sectionsForEntityKind` switch had four cases (module/package, class/struct/component/schema, function/method/handler/endpoint, service) each hard-coded as inline `[]string` literals. Adding a new kind required editing `tier1.go` and separately updating `llm_bundle.go` if guidance needed adjusting. The two places could drift.

`sectionsByKind` co-locates the section list and guidance overrides in one profile struct, so:
- A new kind profile is a single registry entry — no need to touch the tier files.
- Guidance overrides are per-kind and per-section, eliminating ad-hoc `if kind == "..." { guidance = "..." }` patches scattered across future tickets.
- `ResolveSectionProfile` is the single authoritative resolution path for both `tier1` (section list) and `llm_bundle` (guidance text).

## 5 — Tests

```
go test ./internal/docgen/... -timeout 60s
ok  github.com/cajasmota/archigraph/internal/docgen  2.5s
```

All pre-existing tests pass. 25 new tests added in `sections_by_kind_test.go`, all green.

## 6 — Cross-platform / scope

Pure Go restructure. No CGO, no OS-specific paths, no shell calls. Cross-platform clean per #1777.

View, Component, and Class profiles are intentionally deferred to follow-up PRs so that individual section-list decisions can be reviewed in isolation.

## 7 — Checklist

- [x] `SectionProfile` + `sectionsByKind` registry in new `sections_by_kind.go`
- [x] Model profile (9 sections, drops module-level boilerplate, guidance overrides)
- [x] Module profile (13 sections — full suite — guidance overrides)
- [x] Operation profile (10 sections, drops deployment/scripts/local-dev, guidance overrides)
- [x] Default profile = KnownSections (zero regression for unknown kinds)
- [x] `tier1.go` wired — `sectionsForEntityKind` delegates to `ResolveSectionProfile`
- [x] `llm_bundle.go` wired — `BuildBundle` uses `ResolveGuidance` for per-kind guidance
- [x] 25 unit tests, all pass
- [x] Full `go test ./internal/docgen/...` green
- [x] DO NOT MERGE (per owner lock 2026-05-23)

Implements #1875.