### PR TITLE
fix(flow-extractor): extend cross-repo flows into backend handler via http_endpoint_call -> http_endpoint_definition bridge (#1893)

### DIFF
--- a/internal/cli/links.go
+++ b/internal/cli/links.go
@@ -275,8 +275,18 @@ func runPhantomEdgePass(group string, cfg *registry.GroupConfig, linksPath strin
 		// starts clean. Process entities have Kind=engine.EntityKindProcess.
 		doc.Entities, doc.Relationships = stripProcessEntities(doc)
 
-		// Re-run process flow.
-		_ = engine.RunProcessFlow(doc, engine.DefaultProcessFlowConfig())
+		// Re-run process flow. #1893 — pass the group's other docs as
+		// companions so flows extend past phantom cross-repo edges into the
+		// target repo's handler chain instead of dead-ending at the HTTP
+		// boundary. Companions are read-only; only `doc` is mutated.
+		companions := make([]*graph.Document, 0, len(docs)-1)
+		for cslug, cdoc := range docs {
+			if cslug == slug || cdoc == nil {
+				continue
+			}
+			companions = append(companions, cdoc)
+		}
+		_ = engine.RunProcessFlowWithCompanions(doc, companions, engine.DefaultProcessFlowConfig())
 
 		// Update stats.
 		doc.Stats.Entities = len(doc.Entities)

--- a/internal/engine/process_flow.go
+++ b/internal/engine/process_flow.go
@@ -107,16 +107,60 @@ type processStats struct {
 // the document in place. Returns a stats summary. Safe to call on a
 // document with no CALLS edges (returns an empty stats record).
 func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
+	return RunProcessFlowWithCompanions(doc, nil, cfg)
+}
+
+// RunProcessFlowWithCompanions is the cross-repo-aware variant of
+// RunProcessFlow (#1893). When companions is non-empty, the BFS extends past
+// phantom cross-repo CALLS edges into the target repo's handler chain by
+// unifying adjacency + entity index across all provided docs.
+//
+// Semantics:
+//   - Process entities + edges are still appended only to `doc` (the source
+//     repo). companions are read-only — never mutated.
+//   - The BFS traverses CALLS / FETCHES / phantom edges from `doc` AND from
+//     every companion. With phantom-edge targets indexed across docs, a chain
+//     that begins in the frontend and traverses
+//     caller → http_endpoint_call → http_endpoint_definition → backend handler
+//     → ... is one continuous walk rather than a frontend-only chain that
+//     dead-ends at the HTTP boundary.
+//   - chainCrossesRepoBoundary still uses the phantom edge as the
+//     authoritative cross-repo marker. The resulting Process is tagged
+//     cross_stack=true and gets a new `cross_stack_bridge_at_step` property
+//     recording the index of the first phantom step in the chain (useful for
+//     dashboards to highlight the boundary visually).
+//   - When companions is nil/empty the behavior is byte-identical to the
+//     pre-#1893 single-doc pass.
+func RunProcessFlowWithCompanions(doc *graph.Document, companions []*graph.Document, cfg ProcessFlowConfig) processStats {
 	if doc == nil {
 		return processStats{}
 	}
 	cfg = clampConfig(cfg)
 
-	// Index entities by ID for fast lookup of kind / source-file metadata.
-	byID := make(map[string]*graph.Entity, len(doc.Entities))
+	// Index entities by ID across doc + companions for fast lookup of kind /
+	// source-file metadata. Entity IDs include the repo as a hash salt (see
+	// graph.EntityID), so cross-doc collisions are impossible by construction.
+	totalEntities := len(doc.Entities)
+	for _, c := range companions {
+		if c != nil {
+			totalEntities += len(c.Entities)
+		}
+	}
+	byID := make(map[string]*graph.Entity, totalEntities)
 	for i := range doc.Entities {
 		e := &doc.Entities[i]
 		byID[e.ID] = e
+	}
+	for _, c := range companions {
+		if c == nil {
+			continue
+		}
+		for i := range c.Entities {
+			e := &c.Entities[i]
+			if _, exists := byID[e.ID]; !exists {
+				byID[e.ID] = e
+			}
+		}
 	}
 
 	// Build the same HTTP-boundary set used by entry ranking. Any chain
@@ -124,7 +168,7 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 	// makes the resulting Process cross-stack relevant even when the
 	// http_endpoint entity itself sits at the end of an IMPLEMENTS edge
 	// rather than the CALLS chain.
-	httpBoundary := buildHTTPBoundarySet(doc)
+	httpBoundary := buildHTTPBoundarySetMulti(doc, companions)
 
 	// #754 — file-level consumer endpoint index. Maps a source file path
 	// to whether it contains a CONSUMER-side synthetic http_endpoint.
@@ -139,9 +183,13 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 	// no-op overlay on top of the precise FETCHES-edge signal.
 	consumerEndpointFiles := buildConsumerEndpointFileSet(doc)
 
-	// Build CALLS adjacency. Edges with explicit `confidence < 0.5` are
-	// excluded so fuzzy global-fallback matches don't dominate traces.
-	adj := buildCallsAdjacency(doc)
+	// Build CALLS adjacency across doc + companions. Edges with explicit
+	// `confidence < 0.5` are excluded so fuzzy global-fallback matches don't
+	// dominate traces. Companion edges extend the adjacency past phantom
+	// cross-repo edge targets (#1893): the phantom edge in doc points at an
+	// entity that lives in a companion's Entities slice; without companion
+	// adjacency the BFS would dead-end there.
+	adj := buildCallsAdjacencyMulti(doc, companions)
 
 	// Score candidate entry points.
 	candidates := rankEntryPoints(doc, byID, adj, cfg)
@@ -330,6 +378,14 @@ func RunProcessFlow(doc *graph.Document, cfg ProcessFlowConfig) processStats {
 		if crossStack && crossReason != "" {
 			props["cross_stack_reason"] = crossReason
 		}
+		// #1893 — record the chain index of the first phantom cross-repo edge
+		// so dashboards / docs can visually mark the boundary step. -1 means no
+		// phantom edge was traversed (the chain may still be cross_stack via
+		// an unresolved consumer http_endpoint signal, in which case the
+		// boundary is the endpoint step itself; see chainCrossesRepoBoundary).
+		if bridgeIdx := firstPhantomStepIndex(chain, adj); bridgeIdx >= 0 {
+			props["cross_stack_bridge_at_step"] = strconv.Itoa(bridgeIdx)
+		}
 
 		doc.Entities = append(doc.Entities, graph.Entity{
 			ID:         processID,
@@ -419,14 +475,30 @@ type callsAdjacency struct {
 // edgeKey is a directed (from,to) edge identity.
 type edgeKey struct{ from, to string }
 
-// buildCallsAdjacency filters the document's edges down to CALLS + FETCHES
-// (#754) and produces a deterministic adjacency list. Edges with
-// confidence < 0.5 (as set by the resolver) are excluded — they're
-// typically global-fallback matches and inflate trace counts with false
-// branches. FETCHES edges are unconditionally included: they're emitted
-// at extraction/resolve time with no confidence property and represent
-// definite cross-repo fetch points, not fuzzy resolution candidates.
+// buildCallsAdjacency is the single-doc adjacency builder. Equivalent to
+// buildCallsAdjacencyMulti(doc, nil); preserved for tests that exercise the
+// single-doc shape directly.
 func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
+	return buildCallsAdjacencyMulti(doc, nil)
+}
+
+// buildCallsAdjacencyMulti filters CALLS + FETCHES edges (#754) across `doc`
+// AND every doc in `companions`, producing a single deterministic adjacency
+// list. The unified adjacency lets the BFS continue past phantom cross-repo
+// CALLS edges (whose target ID lives in a companion's Entities slice) into
+// the target repo's CALLS chain — the #1893 cross-repo flow extension.
+//
+// Edge filtering rules (per-relationship, identical across docs):
+//   - CALLS with confidence < 0.5 dropped (fuzzy global fallback noise).
+//   - FETCHES always kept (no confidence property; structural primitive).
+//   - Phantom CALLS (cross_repo="true") always kept; recorded in adj.phantom.
+//   - IMPLEMENTS edges to http_endpoint_definition reversed as handler-
+//     continuation edges (#1639). Reversal runs for every doc, so a frontend
+//     phantom edge can land on the backend's http_endpoint_definition and
+//     continue into the backend handler in one BFS step.
+//
+// Per-doc passes are merged into the same maps. Companion docs are read-only.
+func buildCallsAdjacencyMulti(doc *graph.Document, companions []*graph.Document) *callsAdjacency {
 	a := &callsAdjacency{
 		out:         make(map[string][]string),
 		in:          make(map[string]int),
@@ -435,6 +507,29 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		handlerCont: make(map[edgeKey]bool),
 	}
 	seen := make(map[string]map[string]bool)
+	docs := make([]*graph.Document, 0, 1+len(companions))
+	docs = append(docs, doc)
+	for _, c := range companions {
+		if c != nil {
+			docs = append(docs, c)
+		}
+	}
+	for _, d := range docs {
+		ingestCallsAdjacency(a, seen, d)
+	}
+	for k := range a.out {
+		sort.Strings(a.out[k])
+	}
+	return a
+}
+
+// ingestCallsAdjacency merges one document's edges into the shared adjacency.
+// Extracted so the multi-doc path can iterate without duplicating logic.
+// Sorting of out-lists is deferred to the caller.
+func ingestCallsAdjacency(a *callsAdjacency, seen map[string]map[string]bool, doc *graph.Document) {
+	if doc == nil {
+		return
+	}
 	for i := range doc.Relationships {
 		r := &doc.Relationships[i]
 		isFetches := r.Kind == RelationshipKindFetches
@@ -520,11 +615,6 @@ func buildCallsAdjacency(doc *graph.Document) *callsAdjacency {
 		a.in[to]++
 		a.handlerCont[edgeKey{from, to}] = true
 	}
-
-	for k := range a.out {
-		sort.Strings(a.out[k])
-	}
-	return a
 }
 
 // isPhantomCallsEdge reports whether a CALLS relationship is a phantom
@@ -686,14 +776,32 @@ func chainLabels(chain []string, byID map[string]*graph.Entity) []string {
 // Used by both rankEntryPoints (boost candidate score) and the cross-
 // stack detector (mark Process as cross_stack=true).
 func buildHTTPBoundarySet(doc *graph.Document) map[string]bool {
+	return buildHTTPBoundarySetMulti(doc, nil)
+}
+
+// buildHTTPBoundarySetMulti is the cross-repo-aware variant. Companion docs'
+// IMPLEMENTS / ROUTES_TO / SERVES endpoints (in particular the backend
+// handlers + http_endpoint_definition pairs) are included so cross-repo flow
+// extension can score backend handlers as legitimate entry-points / boundary
+// nodes (#1893).
+func buildHTTPBoundarySetMulti(doc *graph.Document, companions []*graph.Document) map[string]bool {
 	out := make(map[string]bool)
-	for i := range doc.Relationships {
-		r := &doc.Relationships[i]
-		switch r.Kind {
-		case "IMPLEMENTS", "ROUTES_TO", "SERVES":
-			out[r.FromID] = true
-			out[r.ToID] = true
+	add := func(d *graph.Document) {
+		if d == nil {
+			return
 		}
+		for i := range d.Relationships {
+			r := &d.Relationships[i]
+			switch r.Kind {
+			case "IMPLEMENTS", "ROUTES_TO", "SERVES":
+				out[r.FromID] = true
+				out[r.ToID] = true
+			}
+		}
+	}
+	add(doc)
+	for _, c := range companions {
+		add(c)
 	}
 	return out
 }
@@ -841,6 +949,23 @@ func phantomEdgeForStep(fromID, toID string, doc *graph.Document) *graph.Relatio
 		}
 	}
 	return nil
+}
+
+// firstPhantomStepIndex returns the (1-based-into-chain) index of the first
+// step reached via a phantom cross-repo CALLS edge, or -1 when no such edge
+// is traversed. The returned index points at the TARGET step of the phantom
+// edge — i.e. the first step that lives in the other repo. Used to stamp
+// cross_stack_bridge_at_step (#1893) so consumers can highlight the boundary.
+func firstPhantomStepIndex(chain []string, adj *callsAdjacency) int {
+	if adj == nil {
+		return -1
+	}
+	for i := 1; i < len(chain); i++ {
+		if adj.phantom[edgeKey{chain[i-1], chain[i]}] {
+			return i
+		}
+	}
+	return -1
 }
 
 // chainCrossesRepo is a convenience predicate that returns true iff any

--- a/internal/engine/process_flow_xrepo_1893_test.go
+++ b/internal/engine/process_flow_xrepo_1893_test.go
@@ -1,0 +1,195 @@
+// process_flow_xrepo_1893_test.go — Wave-1 fix for issue #1893.
+//
+// Owner observation: a cross-stack Process flow titled "frontendFunc →
+// repo-d:<cross-repo>" had ALL its steps in the frontend repo and ZERO
+// steps in the backend repo. The flow terminated at the HTTP CALL SITE
+// (a phantom cross-repo CALLS edge target) instead of continuing into
+// the backend handler that resolves the route.
+//
+// Why this happened: RunProcessFlow walked ONE document at a time. The
+// phantom edge target ID lives in the OTHER repo's Entities slice; with
+// no companion adjacency the BFS could not follow into the backend.
+//
+// Fix (#1893): RunProcessFlowWithCompanions unifies adjacency + entity
+// index across all provided docs. The BFS now traverses the phantom
+// edge AND continues into the backend handler's CALLS chain.
+//
+// Tests in this file assert the cross-repo extension by construction
+// (no live graph required):
+//
+//   - TestProcessFlow_1893_CrossRepoExtension_Extends: with companions,
+//     the flow extends past the phantom edge into the backend handler.
+//   - TestProcessFlow_1893_NoCompanions_StillTerminates: without
+//     companions, the flow still terminates at the phantom target
+//     (pre-#1893 behaviour preserved).
+//   - TestProcessFlow_1893_BridgeStepIndex: the
+//     cross_stack_bridge_at_step property is stamped with the chain
+//     index of the first phantom edge target.
+package engine
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/graph"
+)
+
+// makeXRepoFixture builds a two-repo fixture mirroring the #1893
+// evidence: a frontend chain that fetches a backend route, where the
+// backend has its own multi-step handler chain.
+//
+//	Frontend (repo "fe"):
+//	  fe_entry --CALLS--> fe_loadData --FETCHES--> http_call ...
+//	  http_call --CALLS(phantom, cross_repo)--> be_handler  (lives in "be")
+//
+//	Backend (repo "be"):
+//	  be_handler --IMPLEMENTS--> http_endpoint_definition
+//	  be_handler --CALLS--> be_service --CALLS--> be_repo
+//
+// After buildCallsAdjacencyMulti reverses the IMPLEMENTS edge, the
+// chain through fe_handler also flows definition → be_handler (the
+// #1639 handler-continuation reverse). Combined with the phantom edge
+// fe_loadData reaches be_handler via the phantom and continues into
+// the backend handler's own CALLS chain.
+func makeXRepoFixture() (fe, be *graph.Document) {
+	fe = &graph.Document{
+		Repo: "fe",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+			{ID: "fe_loadData", Name: "fetchSummary", Kind: "SCOPE.Function", Language: "ts", SourceFile: "dashboard.ts"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "fe_r1", FromID: "fe_entry", ToID: "fe_loadData", Kind: "CALLS"},
+			// Phantom cross-repo CALLS edge pointing at the backend
+			// handler. This is what links.PromoteToPhantomEdges injects.
+			{
+				ID: "fe_phantom", FromID: "fe_loadData", ToID: "be_handler", Kind: "CALLS",
+				Properties: map[string]string{
+					"cross_repo":  "true",
+					"target_repo": "be",
+					"link_method": "http",
+				},
+			},
+		},
+	}
+	be = &graph.Document{
+		Repo: "be",
+		Entities: []graph.Entity{
+			{ID: "be_handler", Name: "OrdersController.getSummary", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrdersController.java"},
+			{ID: "be_service", Name: "OrderService.summarize", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrderService.java"},
+			{ID: "be_repo", Name: "OrderRepository.fetchAll", Kind: "SCOPE.Operation", Language: "java", SourceFile: "OrderRepository.java"},
+		},
+		Relationships: []graph.Relationship{
+			{ID: "be_r1", FromID: "be_handler", ToID: "be_service", Kind: "CALLS"},
+			{ID: "be_r2", FromID: "be_service", ToID: "be_repo", Kind: "CALLS"},
+		},
+	}
+	return fe, be
+}
+
+// findProcessByEntry returns the first SCOPE.Process whose entry_id matches.
+func findProcessByEntry(doc *graph.Document, entryID string) *graph.Entity {
+	for i := range doc.Entities {
+		e := &doc.Entities[i]
+		if e.Kind != EntityKindProcess {
+			continue
+		}
+		if e.Properties["entry_id"] == entryID {
+			return e
+		}
+	}
+	return nil
+}
+
+func TestProcessFlow_1893_CrossRepoExtension_Extends(t *testing.T) {
+	fe, be := makeXRepoFixture()
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2 // allow short chains for the test fixture
+
+	stats := RunProcessFlowWithCompanions(fe, []*graph.Document{be}, cfg)
+	if stats.Processes == 0 {
+		t.Fatalf("expected ≥1 Process entity, got 0 (stats=%+v)", stats)
+	}
+
+	p := findProcessByEntry(fe, "fe_entry")
+	if p == nil {
+		t.Fatalf("no Process found with entry_id=fe_entry; got: %+v", fe.Entities)
+	}
+
+	chain := strings.Split(p.Properties["chain"], ",")
+	// Pre-#1893: chain would be [fe_entry, fe_loadData, be_handler] (3 steps,
+	// terminating at the phantom target with no continuation).
+	// Post-#1893: chain extends through be_service / be_repo.
+	if len(chain) < 4 {
+		t.Fatalf("expected chain to extend into backend (≥4 steps), got %d: %v", len(chain), chain)
+	}
+	// Assert backend handler + at least one of its downstream steps is in the chain.
+	have := map[string]bool{}
+	for _, id := range chain {
+		have[id] = true
+	}
+	if !have["be_handler"] {
+		t.Errorf("chain missing be_handler: %v", chain)
+	}
+	if !have["be_service"] && !have["be_repo"] {
+		t.Errorf("chain didn't continue past be_handler into backend CALLS chain: %v", chain)
+	}
+
+	if p.Properties["cross_stack"] != "true" {
+		t.Errorf("Process should be cross_stack=true, got %q", p.Properties["cross_stack"])
+	}
+}
+
+func TestProcessFlow_1893_NoCompanions_StillTerminates(t *testing.T) {
+	fe, _ := makeXRepoFixture()
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	// No companions — pre-#1893 behaviour: chain dead-ends at the phantom target.
+	RunProcessFlow(fe, cfg)
+	p := findProcessByEntry(fe, "fe_entry")
+	if p == nil {
+		t.Fatalf("no Process found with entry_id=fe_entry")
+	}
+	chain := strings.Split(p.Properties["chain"], ",")
+	// Without companions the chain must NOT continue into the backend.
+	for _, id := range chain {
+		if id == "be_service" || id == "be_repo" {
+			t.Errorf("single-doc flow leaked backend entity %q into chain %v", id, chain)
+		}
+	}
+	if chain[len(chain)-1] != "be_handler" {
+		t.Errorf("expected chain to terminate at be_handler (phantom target); got terminal=%q chain=%v",
+			chain[len(chain)-1], chain)
+	}
+	if p.Properties["cross_stack"] != "true" {
+		t.Errorf("Process should still be cross_stack=true via phantom edge; got %q",
+			p.Properties["cross_stack"])
+	}
+}
+
+func TestProcessFlow_1893_BridgeStepIndex(t *testing.T) {
+	fe, be := makeXRepoFixture()
+	cfg := DefaultProcessFlowConfig()
+	cfg.MinSteps = 2
+
+	RunProcessFlowWithCompanions(fe, []*graph.Document{be}, cfg)
+	p := findProcessByEntry(fe, "fe_entry")
+	if p == nil {
+		t.Fatalf("no Process found")
+	}
+	raw, ok := p.Properties["cross_stack_bridge_at_step"]
+	if !ok {
+		t.Fatalf("Process missing cross_stack_bridge_at_step property; props=%v", p.Properties)
+	}
+	idx, err := strconv.Atoi(raw)
+	if err != nil {
+		t.Fatalf("cross_stack_bridge_at_step not an integer: %q (%v)", raw, err)
+	}
+	// In the fixture the phantom edge target be_handler is the 3rd step
+	// (index 2: fe_entry[0] -> fe_loadData[1] -> be_handler[2]).
+	if idx != 2 {
+		t.Errorf("cross_stack_bridge_at_step = %d, want 2", idx)
+	}
+}


### PR DESCRIPTION
Fixes #1893.

## 1. What changed (one sentence)
The process-flow BFS now accepts companion documents and extends cross-repo flows past the HTTP boundary into the backend handler's own CALLS chain instead of dead-ending at the frontend's phantom edge target.

## 2. Before vs after (numbers)
Test fixture mirroring the #1893 evidence (frontend `loadDashboard → fetchSummary → <phantom HTTP> → backend OrdersController.getSummary → OrderService.summarize → OrderRepository.fetchAll`):

| | step count | last step in chain |
|---|---|---|
| Before (`RunProcessFlow`, single-doc) | **3** | `be_handler` (phantom target, frontend dead-end) |
| After (`RunProcessFlowWithCompanions`) | **5** | `be_repo` (backend handler's terminal call) |

The `cross_stack=true` label is now structurally honest — the chain physically contains backend entities — and a new `cross_stack_bridge_at_step` property records the chain index of the first phantom step (index 2 in the fixture) so dashboards can highlight the boundary.

## 3. How the fix works (mechanism)
- New `RunProcessFlowWithCompanions(doc, companions, cfg)` variant of the BFS entry point. `RunProcessFlow` delegates with `companions=nil`, preserving byte-identical single-doc behaviour for every existing caller / test.
- `buildCallsAdjacency` factored into `buildCallsAdjacencyMulti(doc, companions)` + a per-doc `ingestCallsAdjacency` helper. The shared adjacency now merges:
  - CALLS / FETCHES edges from `doc` and every companion (confidence-gated identically across docs).
  - Phantom cross-repo CALLS edges (`cross_repo="true"`) — already in `doc` from the phantom-edge pass (#769).
  - The #1639 handler-continuation reversal of `IMPLEMENTS handler → http_endpoint_definition` — now applied to every doc, so a phantom edge can land on the backend's `http_endpoint_definition` and continue into the handler in a single BFS step.
- `buildHTTPBoundarySet` similarly factored into `Multi` so the entry-ranking + cross-stack heuristic still classify backend handlers correctly when their IMPLEMENTS edges live in a companion.
- Entity IDs are globally unique (the `graph.EntityID` hash salts with `repo`), so unifying `byID` across docs has zero collision risk.
- `cli/links.go` (the single live caller — runs after `PromoteToPhantomEdges`) now passes every other group doc as a companion when re-running the flow on each affected source repo.

## 4. Architectural shift (why this matters)
Flows used to be a per-repo artefact: each doc's BFS could only see its own adjacency, so a cross-stack flow stopped at the boundary node by definition. With companion adjacency, flows are now group-scoped: a single Process can span multiple repos and the `cross_stack` label means "the chain physically traversed a repo boundary" rather than "the chain mentioned an HTTP synthetic". This unblocks meaningful end-to-end documentation of business processes that fan out across the frontend, backend, and downstream services.

## 5. Risk + blast radius
- `RunProcessFlow` signature unchanged. Every caller outside `cli/links.go` (re-index path, broker entry tests, MCP read-paths) goes through the no-companion delegation and gets identical output.
- Existing BFS bounds (`MaxDepth ≤ 10`, `BranchingFactor ≤ 4`, `MaxProcesses=300`) cap runaway extension — a 5-hop frontend chain joining a 5-hop backend chain still truncates at depth 10.
- Companion docs are read-only; only the source doc is mutated.
- Performance: companion adjacency adds O(sum of companion-edge counts) per source repo per re-link. Groups in practice have ≤10 repos with ≤10k edges each so the cost is negligible compared to the JSON write that already runs in the same loop.

## 6. Tests
New file `internal/engine/process_flow_xrepo_1893_test.go` adds three tests against a two-repo fixture that mirrors the #1893 evidence shape:
- `TestProcessFlow_1893_CrossRepoExtension_Extends` — with companions the chain reaches ≥4 steps and contains backend entities.
- `TestProcessFlow_1893_NoCompanions_StillTerminates` — without companions the chain stops at the phantom target (regression guard for the no-op delegation path).
- `TestProcessFlow_1893_BridgeStepIndex` — `cross_stack_bridge_at_step` is stamped with the correct chain index.

Existing suites untouched and green: `internal/engine`, `internal/engine/httproutes`, `internal/cli`, `internal/links`, `internal/mcp` (flow/trace subset).

## 7. Cross-platform discipline (#1777)
Pure Go. No new syscalls, paths, or platform-specific code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
