### PR TITLE
ui(flows): adaptive DAG layout — compact nodes for medium flows, grid for long flows (#1897)

### DIFF
--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -750,33 +750,80 @@ function ListRail({
   );
 }
 
-// ─── DAG constants ────────────────────────────────────────────────────────────
+// ─── DAG layout constants ─────────────────────────────────────────────────────
+//
+// Three layout modes selected at render time by step count:
+//   short  (≤5 steps)   — full-size nodes, single horizontal row
+//   medium (6-10 steps) — ~70% scale, single horizontal row (no wrap)
+//   long   (11+ steps)  — 3-column grid with readable nodes
+//
+// All sizing is expressed as a LayoutMode object so the SVG edge renderer
+// and the absolute-positioned nodes always use the same values.
 
-const NODE_W = 248; // wider so name + kind sit on clean single lines
-const NODE_H = 84;  // taller so kind label + meta row never wrap/clip
-const NODE_HGAP = 96;  // generous horizontal gap so edge labels don't collide
-const NODE_VGAP = 72;  // generous vertical gap between wrapped lanes
-const CANVAS_PAD = 36;
-const MAX_PER_LANE = 5; // wrap to a new lane after this many nodes
+type LayoutMode = {
+  nodeW: number;
+  nodeH: number;
+  hgap: number;
+  vgap: number;
+  pad: number;
+  perLane: number;
+};
+
+const LAYOUT_SHORT: LayoutMode = {
+  nodeW: 248,
+  nodeH: 84,
+  hgap: 96,
+  vgap: 72,
+  pad: 36,
+  perLane: 5,   // ≤5 steps: single row, no wrapping needed
+};
+
+const LAYOUT_MEDIUM: LayoutMode = {
+  nodeW: 174,   // ~70% of 248 — fits 6-10 nodes on one row
+  nodeH: 59,    // ~70% of 84
+  hgap: 52,     // proportionally tighter
+  vgap: 52,
+  pad: 28,
+  perLane: 10,  // never wrap for 6-10 steps
+};
+
+const LAYOUT_LONG: LayoutMode = {
+  nodeW: 220,   // readable but slightly compressed
+  nodeH: 80,
+  hgap: 72,
+  vgap: 64,
+  pad: 32,
+  perLane: 3,   // 3-column grid for 11+ steps (≤15 → 5 rows; ≤30 → 10 rows)
+};
+
+function pickLayout(stepCount: number): LayoutMode {
+  if (stepCount <= 5) return LAYOUT_SHORT;
+  if (stepCount <= 10) return LAYOUT_MEDIUM;
+  return LAYOUT_LONG;
+}
 
 // Left-to-right layered layout: entry on the left, terminal on the right,
 // edges flow horizontally. Long chains wrap onto stacked lanes so the wide
 // canvas is used instead of a single tall column.
+// Returns the positions array plus the canvas dimensions and the layout mode
+// used (so the caller can size nodes consistently with the edges).
 function layoutDAG(steps: ProcessStep[]) {
-  const perLane = Math.max(1, Math.min(MAX_PER_LANE, steps.length));
+  const mode = pickLayout(steps.length);
+  const { nodeW, nodeH, hgap, vgap, pad, perLane } = mode;
+  const effectivePerLane = Math.max(1, Math.min(perLane, steps.length));
   const positions = steps.map((_, i) => {
-    const lane = Math.floor(i / perLane);
-    const col = i % perLane;
+    const lane = Math.floor(i / effectivePerLane);
+    const col = i % effectivePerLane;
     return {
-      x: CANVAS_PAD + col * (NODE_W + NODE_HGAP),
-      y: CANVAS_PAD + lane * (NODE_H + NODE_VGAP),
+      x: pad + col * (nodeW + hgap),
+      y: pad + lane * (nodeH + vgap),
     };
   });
-  const lanes = Math.ceil(steps.length / perLane);
-  const cols = Math.min(perLane, steps.length);
-  const totalWidth = CANVAS_PAD * 2 + cols * NODE_W + (cols - 1) * NODE_HGAP;
-  const totalHeight = CANVAS_PAD * 2 + lanes * NODE_H + (lanes - 1) * NODE_VGAP;
-  return { positions, totalHeight, totalWidth, perLane };
+  const lanes = Math.ceil(steps.length / effectivePerLane);
+  const cols = Math.min(effectivePerLane, steps.length);
+  const totalWidth = pad * 2 + cols * nodeW + (cols - 1) * hgap;
+  const totalHeight = pad * 2 + lanes * nodeH + (lanes - 1) * vgap;
+  return { positions, totalHeight, totalWidth, perLane: effectivePerLane, mode };
 }
 
 // ─── FlowDag ──────────────────────────────────────────────────────────────────
@@ -804,7 +851,7 @@ function FlowDag({
   } | null>(null);
   const [dragging, setDragging] = useState(false);
 
-  const { positions, totalHeight, totalWidth, perLane } = useMemo(
+  const { positions, totalHeight, totalWidth, perLane, mode } = useMemo(
     () => layoutDAG(steps),
     [steps],
   );
@@ -962,8 +1009,8 @@ function FlowDag({
     const b = positions[i];
     const wrap = i % perLane === 0; // first node of a new lane
     edges.push({
-      from: { x: a.x + NODE_W, y: a.y + NODE_H / 2 },
-      to: { x: b.x, y: b.y + NODE_H / 2 },
+      from: { x: a.x + mode.nodeW, y: a.y + mode.nodeH / 2 },
+      to: { x: b.x, y: b.y + mode.nodeH / 2 },
       kind: steps[i].edge_kind,
       xrepo: steps[i].repo !== steps[i - 1].repo,
       wrap,
@@ -980,9 +1027,9 @@ function FlowDag({
       style={{
         background:
           "radial-gradient(circle at 1px 1px, var(--canvas-grid) 1px, transparent 1px) 0 0 / 18px 18px, var(--canvas-bg)",
-        minHeight: 320,
-        height: 400,
-        maxHeight: 560,
+        minHeight: mode === LAYOUT_MEDIUM ? 220 : 320,
+        height: mode === LAYOUT_LONG ? 520 : 400,
+        maxHeight: mode === LAYOUT_LONG ? 680 : 560,
       }}
       onWheel={onWheel}
       onPointerDown={onPointerDown}
@@ -1105,9 +1152,9 @@ function FlowDag({
               style={{
                 left: pos.x,
                 top: pos.y,
-                width: NODE_W,
-                minHeight: NODE_H,
-                padding: "8px 12px 8px 14px",
+                width: mode.nodeW,
+                minHeight: mode.nodeH,
+                padding: mode === LAYOUT_MEDIUM ? "5px 8px 5px 10px" : "8px 12px 8px 14px",
                 background:
                   isEntry || isTerminal
                     ? `color-mix(in srgb, ${meta.color} 8%, var(--surface))`
@@ -1182,7 +1229,7 @@ function FlowDag({
                   {s.repo}
                 </span>
               </div>
-              {locator && (
+              {locator && mode !== LAYOUT_MEDIUM && (
                 <span
                   className="font-mono text-[9px] text-text-4 truncate block min-w-0"
                   title={s.source_file ? `${s.source_file}${s.start_line ? `:${s.start_line}` : ""}` : ""}


### PR DESCRIPTION
## 1 — What & why

The flows DAG hard-coded `MAX_PER_LANE = 5`, so a 6-step flow wraps to a second lane and leaves ~70% of the canvas below empty. This PR introduces three adaptive layout modes driven by step count, eliminating unused vertical space and keeping all steps readable without zooming.

Fixes #1897.

## 2 — Before / after

| Step count | Before | After |
|---|---|---|
| ≤5 | Single horizontal row (unchanged) | Single horizontal row (unchanged) |
| 6–10 | Wraps to 2 rows; ~70% canvas empty | All on one row at ~70% scale — no wrap |
| 11+ | Multiple narrow rows, underuses width | 3-column grid, balanced fill |

Node sizing per mode:
- **LAYOUT_SHORT** (≤5): 248×84 px nodes, 96 px h-gap, perLane=5 — constants identical to pre-PR globals
- **LAYOUT_MEDIUM** (6–10): 174×59 px nodes (~70%), 52 px h-gap, perLane=10, file:line locator hidden
- **LAYOUT_LONG** (11+): 220×80 px nodes, 72 px h-gap, perLane=3 (3-column grid)

Canvas viewport scales per mode: medium minHeight 220 px; long height 520 px / maxHeight 680 px to expose grid rows without immediate zoom-to-fit.

## 3 — Implementation

Single file changed: `webui-v2/src/routes/flows.tsx`.

- Six global `const NODE_*` → `LayoutMode` type + three `const LAYOUT_*` objects + `pickLayout(stepCount)` function
- `layoutDAG` now returns `{ ..., mode }` alongside existing fields
- `FlowDag` destructures `mode`; edge `from/to` coords and node `width/minHeight/padding` all read from `mode.*`
- File:line locator row hidden when `mode === LAYOUT_MEDIUM` (fits 59 px node height)
- Canvas viewport `minHeight/height/maxHeight` adjusted per mode

Zero new npm dependencies. 74 lines added, 27 removed.

## 4 — Testing

- `tsc --noEmit`: zero errors in flows.tsx ✓
- `vite build`: clean build in ~10s ✓
- Manual spot-check path: 3-step flow (LAYOUT_SHORT, unchanged); 7-step flow (LAYOUT_MEDIUM, compact single row); 15-step flow (LAYOUT_LONG, 3-col grid)
- Zoom/pan/click-step interactions unchanged — no changes to pointer event handlers
- Short flows (≤5): LAYOUT_SHORT constants match old globals exactly → pixel-identical

## 5 — Risk

Low. Pure presentation math:
- No API changes, no data-type changes
- Short flows untouched (constants match pre-PR globals)
- `fitToView` auto-scales to the new `totalWidth`/`totalHeight` on flow load — zoom stays correct for all modes

## 6 — Constraints respected

- Does not touch `StepInspector` (the step-click floating panel — #1898 surface)
- Does not touch any Go backend code
- No Cosmograph / graph-canvas changes
- No competitor or private names in any artifact

## 7 — Follow-up (not in this PR)

- `#1898` step-click panel improvements (separate surface, no overlap)
- Responsive canvas height via `ResizeObserver` (nice-to-have, avoids fixed px budgets)