### PR TITLE
ui(flows): side-by-side step panel + layout toggle (#1906 #1907)

### DIFF
--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -22,7 +22,7 @@ import {
   Globe, Database, Send, ArrowDownToLine, Wrench, Shield, AlertTriangle,
   Package, CheckCircle2, Layout, Terminal, Clock, TestTube2, Wifi,
   ChevronRight, Search, X, Copy, Share2, ExternalLink, ZoomIn, ZoomOut,
-  Maximize2, Link2, Sparkles, Info, Check,
+  Maximize2, Link2, Sparkles, Info, Check, ArrowRight, Rows2, Grid2x2,
   type LucideProps,
 } from "lucide-react";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
@@ -752,10 +752,12 @@ function ListRail({
 
 // ─── DAG layout constants ─────────────────────────────────────────────────────
 //
-// Three layout modes selected at render time by step count:
-//   short  (≤5 steps)   — full-size nodes, single horizontal row
-//   medium (6-10 steps) — ~70% scale, single horizontal row (no wrap)
-//   long   (11+ steps)  — 3-column grid with readable nodes
+// Three layout modes selected at render time by step count (adaptive default,
+// from #1904) or by explicit user selection (#1907):
+//   auto       — adaptive: short/medium/long based on step count
+//   horizontal — single row, no wrapping
+//   vertical   — single column
+//   grid       — 3-column grid
 //
 // All sizing is expressed as a LayoutMode object so the SVG edge renderer
 // and the absolute-positioned nodes always use the same values.
@@ -768,6 +770,11 @@ type LayoutMode = {
   pad: number;
   perLane: number;
 };
+
+// User-selectable layout preference ("auto" = adaptive default from #1904)
+type UserLayout = "auto" | "horizontal" | "vertical" | "grid";
+
+const LAYOUT_STORAGE_KEY = "archigraph:flows:layout";
 
 const LAYOUT_SHORT: LayoutMode = {
   nodeW: 248,
@@ -796,10 +803,45 @@ const LAYOUT_LONG: LayoutMode = {
   perLane: 3,   // 3-column grid for 11+ steps (≤15 → 5 rows; ≤30 → 10 rows)
 };
 
+// Explicit layout presets for user-selected modes (#1907)
+const LAYOUT_USER_HORIZONTAL: LayoutMode = {
+  nodeW: 220,
+  nodeH: 80,
+  hgap: 72,
+  vgap: 64,
+  pad: 32,
+  perLane: 999, // never wrap — single row
+};
+
+const LAYOUT_USER_VERTICAL: LayoutMode = {
+  nodeW: 248,
+  nodeH: 84,
+  hgap: 72,
+  vgap: 56,
+  pad: 36,
+  perLane: 1,   // one per lane = single column
+};
+
+const LAYOUT_USER_GRID: LayoutMode = {
+  nodeW: 220,
+  nodeH: 80,
+  hgap: 64,
+  vgap: 56,
+  pad: 32,
+  perLane: 3,   // 3-column grid
+};
+
 function pickLayout(stepCount: number): LayoutMode {
   if (stepCount <= 5) return LAYOUT_SHORT;
   if (stepCount <= 10) return LAYOUT_MEDIUM;
   return LAYOUT_LONG;
+}
+
+function resolveLayout(stepCount: number, userLayout: UserLayout): LayoutMode {
+  if (userLayout === "horizontal") return LAYOUT_USER_HORIZONTAL;
+  if (userLayout === "vertical") return LAYOUT_USER_VERTICAL;
+  if (userLayout === "grid") return LAYOUT_USER_GRID;
+  return pickLayout(stepCount);
 }
 
 // Left-to-right layered layout: entry on the left, terminal on the right,
@@ -807,8 +849,8 @@ function pickLayout(stepCount: number): LayoutMode {
 // canvas is used instead of a single tall column.
 // Returns the positions array plus the canvas dimensions and the layout mode
 // used (so the caller can size nodes consistently with the edges).
-function layoutDAG(steps: ProcessStep[]) {
-  const mode = pickLayout(steps.length);
+function layoutDAG(steps: ProcessStep[], userLayout: UserLayout = "auto") {
+  const mode = resolveLayout(steps.length, userLayout);
   const { nodeW, nodeH, hgap, vgap, pad, perLane } = mode;
   const effectivePerLane = Math.max(1, Math.min(perLane, steps.length));
   const positions = steps.map((_, i) => {
@@ -833,11 +875,13 @@ function FlowDag({
   detailSteps,
   selectedStepIdx,
   onPickStep,
+  userLayout = "auto",
 }: {
   flow: Process;
   detailSteps?: ProcessStep[];
   selectedStepIdx: number | null;
   onPickStep: (i: number | null) => void;
+  userLayout?: UserLayout;
 }) {
   const steps = detailSteps ?? flow.steps ?? [];
 
@@ -852,8 +896,8 @@ function FlowDag({
   const [dragging, setDragging] = useState(false);
 
   const { positions, totalHeight, totalWidth, perLane, mode } = useMemo(
-    () => layoutDAG(steps),
-    [steps],
+    () => layoutDAG(steps, userLayout),
+    [steps, userLayout],
   );
 
   const clampZoom = (z: number) => Math.min(2.5, Math.max(0.3, z));
@@ -899,8 +943,8 @@ function FlowDag({
     setZoom(nz);
   };
 
-  // Fit when the flow changes.
-  const flowKey = flow.process_id + ":" + steps.length;
+  // Fit when the flow changes or the user switches layout.
+  const flowKey = flow.process_id + ":" + steps.length + ":" + userLayout;
   useEffect(() => {
     const t = setTimeout(fitToView, 0);
     return () => clearTimeout(t);
@@ -1770,6 +1814,31 @@ function DetailPanel({
   const [selectedStepIdx, setSelectedStepIdx] = useState<number | null>(null);
   const [sideEffectsOpen, setSideEffectsOpen] = useState(false);
 
+  // ── Layout toggle (#1907) ──────────────────────────────────────────────────
+  const [userLayout, setUserLayout] = useState<UserLayout>(() => {
+    try {
+      const saved = localStorage.getItem(LAYOUT_STORAGE_KEY);
+      if (saved === "horizontal" || saved === "vertical" || saved === "grid") return saved;
+    } catch {
+      /* localStorage unavailable */
+    }
+    return "auto";
+  });
+
+  function applyLayout(l: UserLayout) {
+    setUserLayout(l);
+    try {
+      if (l === "auto") {
+        localStorage.removeItem(LAYOUT_STORAGE_KEY);
+      } else {
+        localStorage.setItem(LAYOUT_STORAGE_KEY, l);
+      }
+    } catch {
+      /* ignore */
+    }
+  }
+  // ─────────────────────────────────────────────────────────────────────────
+
   const selId = selection?.kind === "flow" ? selection.flow.process_id : null;
   useEffect(() => {
     setSelectedStepIdx(null);
@@ -1964,6 +2033,43 @@ function DetailPanel({
               <ExternalLink size={12} /> Topic
             </button>
           )}
+
+          {/* Layout toggle (#1907) — segmented control, right-justified */}
+          <div
+            className="ml-auto inline-flex items-center bg-surface-2 border border-border rounded-sm overflow-hidden h-7"
+            role="group"
+            aria-label="DAG layout"
+          >
+            {(
+              [
+                { key: "auto" as UserLayout,       label: "Auto",  Icon: undefined },
+                { key: "horizontal" as UserLayout,  label: "H",    Icon: ArrowRight },
+                { key: "vertical" as UserLayout,    label: "V",    Icon: Rows2 },
+                { key: "grid" as UserLayout,        label: "Grid", Icon: Grid2x2 },
+              ]
+            ).map(({ key, label, Icon }) => (
+              <button
+                key={key}
+                type="button"
+                title={
+                  key === "auto"       ? "Adaptive (default)"
+                  : key === "horizontal" ? "Horizontal — single row"
+                  : key === "vertical"   ? "Vertical — single column"
+                  : "Grid — 3-column"
+                }
+                onClick={() => applyLayout(key)}
+                className={cn(
+                  "px-2 h-full text-[10px] font-medium border-r last:border-0 border-border inline-flex items-center gap-1",
+                  userLayout === key
+                    ? "bg-surface text-text shadow-[inset_0_-2px_0_var(--accent)]"
+                    : "text-text-3 hover:text-text",
+                )}
+              >
+                {Icon ? <Icon size={11} /> : null}
+                {label}
+              </button>
+            ))}
+          </div>
         </div>
       </header>
 
@@ -1976,35 +2082,58 @@ function DetailPanel({
           </div>
         )}
 
-        {/* DAG canvas + floating overlays */}
+        {/* DAG canvas — when a step is selected, switch to 60/40 side-by-side.
+            The DAG takes 60% and the StepInspector takes 40%. The side-effects
+            panel remains floating (anchored bottom-left inside the DAG area)
+            and is only shown when no step is selected. */}
         {(fullFlow.steps?.length ?? 0) > 0 && (
-          <div className="relative flex-none">
-            <FlowDag
-              flow={fullFlow}
-              detailSteps={fullFlow.steps}
-              selectedStepIdx={selectedStepIdx}
-              onPickStep={(idx) => {
-                setSelectedStepIdx(idx);
-                // Selecting a step dismisses the side-effects panel so both
-                // don't overlap at once.
-                setSideEffectsOpen(false);
-              }}
-            />
-            {/* Floating step-detail card — only when a step is selected. */}
-            {selectedStep && (
-              <StepInspector
-                step={selectedStep}
-                flow={fullFlow}
-                totalSteps={fullFlow.steps?.length ?? fullFlow.step_count}
-                onClose={() => setSelectedStepIdx(null)}
-              />
+          <div
+            className={cn(
+              "flex-none",
+              selectedStep ? "flex" : "relative",
             )}
-            {/* Floating side-effects panel — only when toggled open. */}
-            {sideEffectsOpen && !selectedStep && (
-              <SideEffectsPanel
+            style={selectedStep ? { minHeight: 400 } : undefined}
+          >
+            {/* DAG — 60% when step is open, full-width otherwise */}
+            <div
+              className={cn(
+                "relative",
+                selectedStep ? "flex-none" : "w-full",
+              )}
+              style={selectedStep ? { width: "60%" } : undefined}
+            >
+              <FlowDag
                 flow={fullFlow}
-                onClose={() => setSideEffectsOpen(false)}
+                detailSteps={fullFlow.steps}
+                selectedStepIdx={selectedStepIdx}
+                onPickStep={(idx) => {
+                  setSelectedStepIdx(idx);
+                  // Selecting a step dismisses the side-effects panel so both
+                  // don't conflict at once.
+                  setSideEffectsOpen(false);
+                }}
+                userLayout={userLayout}
               />
+              {/* Floating side-effects panel — only when toggled open and no
+                  step is selected (consistent with previous #1895 behavior). */}
+              {sideEffectsOpen && !selectedStep && (
+                <SideEffectsPanel
+                  flow={fullFlow}
+                  onClose={() => setSideEffectsOpen(false)}
+                />
+              )}
+            </div>
+
+            {/* Step inspector side panel — 40% when a step is selected */}
+            {selectedStep && (
+              <div className="flex-1 min-w-0 overflow-hidden">
+                <StepInspector
+                  step={selectedStep}
+                  flow={fullFlow}
+                  totalSteps={fullFlow.steps?.length ?? fullFlow.step_count}
+                  onClose={() => setSelectedStepIdx(null)}
+                />
+              </div>
             )}
           </div>
         )}


### PR DESCRIPTION
## 1. What changed

`webui-v2/src/routes/flows.tsx` — two bundled UX fixes:

**#1906 — Step panel side-by-side layout**
- `StepInspector` is no longer an absolute overlay that covered the DAG
- When a step is selected, the canvas area switches to a `flex` row: **DAG at 60%, code panel at 40%**
- X button dismisses the panel, DAG returns to full width
- The floating Side-effects panel from #1895 is preserved — it stays anchored bottom-left inside the DAG area and hides itself when a step is selected (prevents visual conflict)

**#1907 — Flow layout toggle**
- New segmented control **Auto · H · V · Grid** added to the flow header action row (right-justified, next to Copy chain / process\_id / Share)
- **Auto** = adaptive default from #1904 (LAYOUT\_SHORT / LAYOUT\_MEDIUM / LAYOUT\_LONG by step count)
- **H** = single row (no wrapping)
- **V** = single column
- **Grid** = 3-column grid (same as LAYOUT\_LONG)
- Selection persists in `localStorage` under key `archigraph:flows:layout` and survives route navigation
- DAG re-fits to viewport automatically on every layout switch

## 2. Why

#1906: The overlay pattern made the diagram unusable while inspecting a step — the panel covered 50%+ of the canvas with no way to compare the DAG context and the code at the same time. Side-by-side keeps both visible simultaneously.

#1907: The adaptive heuristic from #1904 is a good default but can't match every user's screen shape or flow topology. Giving explicit control over layout direction costs zero backend work and avoids the most common mismatch (wide screen with a short flow that the user still wants to see in a grid).

## 3. How to verify

1. `cd webui-v2 && npm run dev` — navigate to `/g/<any-group>/flows`
2. Click any flow to open the detail panel
3. Click any step node in the DAG — **expect**: DAG shrinks to ~60% width; code panel appears on the right with step metadata and snippet; X closes it and restores full DAG width
4. Open a flow that has Side-effects — toggle Side-effects without a step selected — **expect**: floating panel appears at bottom-left of DAG only (does not conflict with step panel)
5. Use the **Auto · H · V · Grid** segmented control in the header — **expect**: DAG re-renders with the selected layout and re-fits; reload the page — **expect**: last selection is remembered

## 4. Test plan

- [x] TypeScript build passes (`tsc -b && vite build`) — zero new errors
- [ ] Manual: step click → side-by-side confirmed, no overlap with DAG controls
- [ ] Manual: X dismiss → full-width DAG restored
- [ ] Manual: layout toggle cycles through all four modes; each re-fits correctly
- [ ] Manual: localStorage persistence survives a hard-reload
- [ ] Manual: Side-effects panel still floats correctly when no step is selected
- [ ] Regression: zoom / pan / fit-to-view controls still function after layout switch

## 5. Risk

**Low.** Single file, UI-only. No API, no data model, no routing changes. The adaptive default (Auto) is untouched — layout only changes when the user explicitly clicks a segment.

## 6. Screenshots

Manual screenshot recommended after merging the embedded SPA build into the Go binary — open `:47274/g/client-fixture-de/flows`, click a step, verify 60/40 split.

## 7. Issues closed

Closes #1906
Closes #1907