### PR TITLE
fix(engine): cross-repo flow bridge steps carry correct repo prefix + full metadata (#1905)

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -545,6 +545,36 @@ func findEntity(g *DashGroup, key string) (*DashRepo, *graph.Entity) {
 	return nil, nil
 }
 
+// groupEntityHit bundles an entity with its owning repo slug for group-wide lookups.
+type groupEntityHit struct {
+	repo   string
+	entity *graph.Entity
+}
+
+// buildGroupEntityIndex builds a group-wide map of entity ID → {repo, entity}.
+// When the same entity ID appears in multiple repos (should not happen given the
+// hash salting, but defensive), the first repo encountered (sorted) wins.
+// Used by handleFlowDetail to resolve bridge-step entity IDs that live in
+// companion repos (#1905).
+func buildGroupEntityIndex(g *DashGroup) map[string]groupEntityHit {
+	total := 0
+	for _, r := range g.Repos {
+		if r.Doc != nil {
+			total += len(r.Doc.Entities)
+		}
+	}
+	out := make(map[string]groupEntityHit, total)
+	for _, r := range sortedRepos(g) {
+		for i := range r.Doc.Entities {
+			e := &r.Doc.Entities[i]
+			if _, exists := out[e.ID]; !exists {
+				out[e.ID] = groupEntityHit{repo: r.Slug, entity: e}
+			}
+		}
+	}
+	return out
+}
+
 // serializeEntity converts a graph.Entity into the REST wire shape.
 func serializeEntity(repo string, e *graph.Entity) map[string]any {
 	out := map[string]any{

--- a/internal/dashboard/handlers_flows.go
+++ b/internal/dashboard/handlers_flows.go
@@ -470,6 +470,13 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 	// STEP_IN_PROCESS edges are emitted as FromID=processID → ToID=stepEntityID
 	// (see engine/process_flow.go). Collect all edges whose FromID matches the
 	// process entity, then resolve the step entity from ToID.
+	//
+	// #1905 — bridge steps in cross-repo flows carry entity IDs that belong to
+	// a companion repo, not the repo that holds the STEP_IN_PROCESS edge. We
+	// build a group-wide entity index (id → repo+entity) so bridge steps are
+	// resolved and enriched correctly instead of being silently dropped.
+	groupEntityIndex := buildGroupEntityIndex(grp)
+
 	var rawSteps []rawStep
 	for _, r := range sortedRepos(grp) {
 		for _, rel := range r.Doc.Relationships {
@@ -480,27 +487,22 @@ func (s *Server) handleFlowDetail(w http.ResponseWriter, r *http.Request) {
 			if rel.FromID != processEnt.ID && dashPrefixedID(r.Slug, rel.FromID) != processID {
 				continue
 			}
-			// ToID is the step entity.
+			// ToID is the step entity. Resolve from the group-wide index so
+			// bridge steps (entity lives in a companion repo) are enriched
+			// with the correct repo slug and metadata (#1905).
 			stepIDLocal := rel.ToID
-			stepRepo := r
-			// Find the step entity.
-			for i := range stepRepo.Doc.Entities {
-				e := &stepRepo.Doc.Entities[i]
-				if e.ID != stepIDLocal {
-					continue
-				}
-				idx, _ := strconv.Atoi(rel.Properties["step_index"])
+			idx, _ := strconv.Atoi(rel.Properties["step_index"])
+			if hit, ok := groupEntityIndex[stepIDLocal]; ok {
 				rawSteps = append(rawSteps, rawStep{
-					EntityID:   dashPrefixedID(stepRepo.Slug, e.ID),
-					Label:      e.Name,
-					SourceFile: e.SourceFile,
-					StartLine:  e.StartLine,
-					Repo:       stepRepo.Slug,
+					EntityID:   dashPrefixedID(hit.repo, hit.entity.ID),
+					Label:      hit.entity.Name,
+					SourceFile: hit.entity.SourceFile,
+					StartLine:  hit.entity.StartLine,
+					Repo:       hit.repo,
 					StepIndex:  idx,
 					EdgeKind:   rel.Kind,
-					EntityKind: e.Kind,
+					EntityKind: hit.entity.Kind,
 				})
-				break
 			}
 		}
 	}

--- a/internal/dashboard/handlers_flows_annotation_test.go
+++ b/internal/dashboard/handlers_flows_annotation_test.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
@@ -515,5 +516,130 @@ func TestFlowDetail_FlowSideEffectsEmptyForPureTransform(t *testing.T) {
 	}
 	if len(arr) != 0 {
 		t.Errorf("flow_side_effects: want empty for pure transform, got %v", arr)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #1905: bridge steps in cross-repo flows carry correct repo prefix + metadata
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestFlowDetail_BridgeStepMetadata_1905 verifies that GET /api/flows/{group}/{pid}
+// returns all steps for a cross-repo flow, with bridge steps carrying the companion
+// repo's slug in their entity_id and with name/file populated from that repo.
+func TestFlowDetail_BridgeStepMetadata_1905(t *testing.T) {
+	// Process lives in the frontend repo; its chain spans frontend + backend.
+	proc := graph.Entity{
+		ID:         "proc-xr",
+		Name:       "loadDashboard → getSummary",
+		Kind:       processEntityKind,
+		SourceFile: "dashboard.ts",
+		StartLine:  10,
+		Properties: map[string]string{
+			"entry_id":    "fe_entry",
+			"entry_name":  "loadDashboard",
+			"terminal_id": "be_handler",
+			"step_count":  "3",
+			"cross_stack": "true",
+			"chain":       "fe_entry,fe_caller,be_handler",
+		},
+	}
+	feEntry := graph.Entity{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "dashboard.ts", StartLine: 10}
+	feCaller := graph.Entity{ID: "fe_caller", Name: "fetchSummary", Kind: "SCOPE.Function", SourceFile: "dashboard.ts", StartLine: 20}
+
+	frontendDoc := &graph.Document{
+		Repo:     "frontend",
+		Entities: []graph.Entity{proc, feEntry, feCaller},
+		Relationships: []graph.Relationship{
+			// STEP_IN_PROCESS for the cross-repo chain.
+			{ID: "s0", FromID: "proc-xr", ToID: "fe_entry", Kind: stepInProcessEdge, Properties: map[string]string{"step_index": "0"}},
+			{ID: "s1", FromID: "proc-xr", ToID: "fe_caller", Kind: stepInProcessEdge, Properties: map[string]string{"step_index": "1"}},
+			// Bridge step: ToID lives in the backend doc.
+			{ID: "s2", FromID: "proc-xr", ToID: "be_handler", Kind: stepInProcessEdge, Properties: map[string]string{"step_index": "2"}},
+		},
+	}
+	beHandler := graph.Entity{
+		ID:         "be_handler",
+		Name:       "OrdersController.getSummary",
+		Kind:       "SCOPE.Operation",
+		SourceFile: "OrdersController.java",
+		StartLine:  42,
+	}
+	backendDoc := &graph.Document{
+		Repo:     "backend",
+		Entities: []graph.Entity{beHandler},
+	}
+
+	grp := &DashGroup{
+		Name: "testgrp",
+		Repos: map[string]*DashRepo{
+			"frontend": {Slug: "frontend", Path: "/tmp/frontend", Doc: frontendDoc},
+			"backend":  {Slug: "backend", Path: "/tmp/backend", Doc: backendDoc},
+		},
+	}
+	ts := newFlowDetailTestServer(t, grp)
+
+	resp, err := http.Get(ts.URL + "/api/flows/testgrp/frontend::proc-xr")
+	if err != nil {
+		t.Fatalf("GET: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		t.Fatalf("status: want 200, got %d — body: %s", resp.StatusCode, b)
+	}
+
+	b, _ := io.ReadAll(resp.Body)
+	var body struct {
+		Process struct {
+			Steps []struct {
+				EntityID  string `json:"entity_id"`
+				Label     string `json:"label"`
+				StepIndex int    `json:"step_index"`
+			} `json:"steps"`
+		} `json:"process"`
+	}
+	if err := json.Unmarshal(b, &body); err != nil {
+		t.Fatalf("decode: %v\nbody: %s", err, b)
+	}
+
+	// All 3 steps must be present.
+	if len(body.Process.Steps) != 3 {
+		t.Fatalf("steps: want 3, got %d\nbody: %s", len(body.Process.Steps), b)
+	}
+
+	// Find the bridge step (index 2).
+	var bridgeStep *struct {
+		EntityID  string `json:"entity_id"`
+		Label     string `json:"label"`
+		StepIndex int    `json:"step_index"`
+	}
+	for i := range body.Process.Steps {
+		if body.Process.Steps[i].StepIndex == 2 {
+			bridgeStep = &body.Process.Steps[i]
+			break
+		}
+	}
+	if bridgeStep == nil {
+		t.Fatalf("bridge step (step_index=2) missing\nbody: %s", b)
+	}
+
+	// entity_id must carry the backend:: prefix.
+	if !strings.HasPrefix(bridgeStep.EntityID, "backend::") {
+		t.Errorf("bridge step entity_id must carry backend:: prefix, got %q\nbody: %s", bridgeStep.EntityID, b)
+	}
+	// label (name) must be populated from the backend entity.
+	if bridgeStep.Label != "OrdersController.getSummary" {
+		t.Errorf("bridge step label want OrdersController.getSummary, got %q\nbody: %s", bridgeStep.Label, b)
+	}
+
+	// Seed-repo steps must carry the frontend:: prefix.
+	for _, s := range body.Process.Steps {
+		if s.StepIndex == 2 {
+			continue
+		}
+		if !strings.HasPrefix(s.EntityID, "frontend::") {
+			t.Errorf("seed step[%d] entity_id should carry frontend:: prefix, got %q", s.StepIndex, s.EntityID)
+		}
 	}
 }

--- a/internal/mcp/traces.go
+++ b/internal/mcp/traces.go
@@ -196,7 +196,12 @@ func (s *Server) handleTracesGet(_ context.Context, req mcpapi.CallToolRequest) 
 			if e.Kind != processEntityKind || e.ID != target {
 				continue
 			}
-			steps := buildProcessSteps(r.Doc, e, r.ByID, r.Repo, verbose)
+			// #1905 — bridge steps in cross-repo flows live in companion repos.
+			// Build a cross-repo lookup so bridge step entities are enriched with
+			// name/file/line/repo from the correct companion repo instead of being
+			// emitted as bare {id, node_id, step_index} stubs.
+			xrLookup := buildGroupCrossRepoLookup(lg, r.Repo)
+			steps := buildProcessStepsWithCrossRepo(r.Doc, e, r.ByID, r.Repo, xrLookup, verbose)
 			return jsonResult(map[string]any{
 				"process_id":  prefixedID(r.Repo, e.ID),
 				"repo":        r.Repo,
@@ -312,6 +317,43 @@ func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolReques
 	return mcpapi.NewToolResultError("entry_point_id not found in any loaded repo"), nil
 }
 
+// crossRepoLookup is a function that resolves an entity ID that may belong
+// to a companion repo. Returns the owning repo slug and entity pointer, or
+// ("", nil) when the entity is not found in any companion repo.
+// Passed to buildProcessSteps so bridge steps carry the correct repo prefix
+// and full metadata (#1905).
+type crossRepoLookup func(id string) (repoSlug string, e *graph.Entity)
+
+// buildGroupCrossRepoLookup constructs a crossRepoLookup from all repos in a
+// LoadedGroup, excluding the seed repo (seedRepo). Companion repos are searched
+// in deterministic order so the result is stable. Entities in the seed repo are
+// already covered by the byID map passed to buildProcessSteps; this lookup
+// handles bridge steps whose entities live elsewhere in the group.
+func buildGroupCrossRepoLookup(lg *LoadedGroup, seedRepo string) crossRepoLookup {
+	// Pre-collect companion repos in sorted order for determinism.
+	type companion struct {
+		slug string
+		byID map[string]*graph.Entity
+	}
+	var companions []companion
+	for slug, r := range lg.Repos {
+		if slug == seedRepo || r == nil || r.ByID == nil {
+			continue
+		}
+		companions = append(companions, companion{slug, r.ByID})
+	}
+	sort.Slice(companions, func(i, j int) bool { return companions[i].slug < companions[j].slug })
+
+	return func(id string) (string, *graph.Entity) {
+		for _, c := range companions {
+			if e, ok := c.byID[id]; ok {
+				return c.slug, e
+			}
+		}
+		return "", nil
+	}
+}
+
 // buildProcessSteps reconstructs the ordered step list for one Process
 // from its STEP_IN_PROCESS edges, falling back to the `chain` property
 // when the edges are missing.
@@ -323,7 +365,19 @@ func (s *Server) handleTracesFollow(_ context.Context, req mcpapi.CallToolReques
 // so callers can pass it directly to archigraph_get_source without a separate
 // archigraph_inspect round-trip (#1744). node_id (local ID) is preserved for
 // backward compatibility.
+//
+// crossRepo, when non-nil, is consulted for step entity IDs not found in byID.
+// This is the cross-repo companion lookup needed to enrich bridge steps in
+// flows that extend across repo boundaries (#1905). When crossRepo is nil the
+// function behaves identically to the single-repo path.
 func buildProcessSteps(doc *graph.Document, proc *graph.Entity, byID map[string]*graph.Entity, repo string, verbose ...bool) []map[string]any {
+	return buildProcessStepsWithCrossRepo(doc, proc, byID, repo, nil, verbose...)
+}
+
+// buildProcessStepsWithCrossRepo is the cross-repo-aware variant of
+// buildProcessSteps (#1905). Pass a non-nil crossRepo to resolve bridge step
+// entities that live in companion repos.
+func buildProcessStepsWithCrossRepo(doc *graph.Document, proc *graph.Entity, byID map[string]*graph.Entity, repo string, crossRepo crossRepoLookup, verbose ...bool) []map[string]any {
 	wantVerbose := len(verbose) > 0 && verbose[0]
 	if byID == nil {
 		// Defensive fallback: callers should always pass a cached map (#1656),
@@ -359,20 +413,38 @@ func buildProcessSteps(doc *graph.Document, proc *graph.Entity, byID map[string]
 	sort.Slice(ordered, func(i, j int) bool { return ordered[i].idx < ordered[j].idx })
 	out := make([]map[string]any, 0, len(ordered))
 	for _, o := range ordered {
+		// Determine which repo owns this step entity. Seed repo first (#1905):
+		// bridge steps carry IDs that live in companion repos and must use the
+		// companion's slug for the prefixed id field, not the seed repo slug.
+		stepRepo := repo
+		var ent *graph.Entity
+		if e, ok := byID[o.id]; ok {
+			ent = e
+		} else if crossRepo != nil {
+			// Not found in the seed repo — look across companion repos.
+			if slug, e := crossRepo(o.id); e != nil {
+				stepRepo = slug
+				ent = e
+			}
+		}
+
 		step := map[string]any{
-			"id":         prefixedID(repo, o.id),
+			"id":         prefixedID(stepRepo, o.id),
 			"step_index": o.idx,
 			"node_id":    o.id,
 		}
-		if e, ok := byID[o.id]; ok {
-			step["name"] = e.Name
-			step["file"] = e.SourceFile
-			if e.StartLine > 0 {
-				step["line"] = e.StartLine
+		if ent != nil {
+			step["name"] = ent.Name
+			step["file"] = ent.SourceFile
+			if ent.StartLine > 0 {
+				step["line"] = ent.StartLine
 			}
 			if wantVerbose {
-				step["kind"] = e.Kind
+				step["kind"] = ent.Kind
 			}
+			// Stamp the owning repo on every step so consumers can distinguish
+			// seed-repo steps from bridge steps without parsing the id prefix.
+			step["repo"] = stepRepo
 		}
 		out = append(out, step)
 	}

--- a/internal/mcp/traces_test.go
+++ b/internal/mcp/traces_test.go
@@ -244,3 +244,152 @@ func TestTracesList_TokenBudgetEnforced(t *testing.T) {
 		t.Errorf("expected truncation_note when token_budget is exceeded")
 	}
 }
+
+// ---------------------------------------------------------------------------
+// #1905: bridge steps in cross-repo flows carry correct repo prefix + metadata
+// ---------------------------------------------------------------------------
+
+// buildCrossRepoFlowFixture constructs a two-repo group where the seed repo
+// ("frontend") holds a Process entity whose STEP_IN_PROCESS edges reference
+// both frontend entities AND a backend entity from the "backend" companion
+// repo. This mirrors what RunProcessFlowWithCompanions emits for cross-repo
+// flows (#1893/#1905).
+//
+// Chain: fe_entry (frontend) → fe_caller (frontend) → be_handler (backend)
+//
+// All three STEP_IN_PROCESS edges live in the frontend doc (the seed repo),
+// but be_handler's entity lives in the backend doc.
+func buildCrossRepoFlowFixture() (frontend, backend *graph.Document) {
+	frontend = &graph.Document{
+		Repo: "frontend",
+		Entities: []graph.Entity{
+			{ID: "fe_entry", Name: "loadDashboard", Kind: "SCOPE.Function", SourceFile: "dashboard.ts", StartLine: 10},
+			{ID: "fe_caller", Name: "fetchSummary", Kind: "SCOPE.Function", SourceFile: "dashboard.ts", StartLine: 20},
+			// Process spanning frontend + backend via bridge at step 2.
+			{ID: "proc_xr", Name: "loadDashboard → getSummary", Kind: "SCOPE.Process",
+				SourceFile: "dashboard.ts", StartLine: 10,
+				Properties: map[string]string{
+					"entry_id":    "fe_entry",
+					"entry_name":  "loadDashboard",
+					"terminal_id": "be_handler",
+					"step_count":  "3",
+					"cross_stack": "true",
+					"chain":       "fe_entry,fe_caller,be_handler",
+				}},
+		},
+		Relationships: []graph.Relationship{
+			// STEP_IN_PROCESS edges for proc_xr: steps 0+1 are frontend, step 2
+			// is a bridge into the backend repo.
+			{ID: "s0", FromID: "proc_xr", ToID: "fe_entry", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "0"}},
+			{ID: "s1", FromID: "proc_xr", ToID: "fe_caller", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "1"}},
+			// Bridge step: ToID lives in the backend doc, not in this doc.
+			{ID: "s2", FromID: "proc_xr", ToID: "be_handler", Kind: "STEP_IN_PROCESS", Properties: map[string]string{"step_index": "2"}},
+		},
+	}
+	backend = &graph.Document{
+		Repo: "backend",
+		Entities: []graph.Entity{
+			{ID: "be_handler", Name: "OrdersController.getSummary", Kind: "SCOPE.Operation",
+				SourceFile: "OrdersController.java", StartLine: 42},
+		},
+	}
+	return frontend, backend
+}
+
+// TestTracesGet_BridgeStepMetadata_1905 asserts that when a cross-repo Process
+// is fetched via archigraph_traces action=get, the bridge step (whose entity
+// lives in the companion repo) is enriched with name, file, line, and repo,
+// and its id carries the companion repo prefix — not the seed repo prefix.
+func TestTracesGet_BridgeStepMetadata_1905(t *testing.T) {
+	frontend, backend := buildCrossRepoFlowFixture()
+	srv := newTestServerWithDocs(t, map[string]*graph.Document{
+		"frontend": frontend,
+		"backend":  backend,
+	})
+
+	req := mcpapi.CallToolRequest{}
+	req.Params.Arguments = map[string]any{
+		"action":     "get",
+		"process_id": "frontend::proc_xr",
+		"group":      "test",
+	}
+	res, err := srv.handleTraces(context.Background(), req)
+	if err != nil {
+		t.Fatalf("handler error: %v", err)
+	}
+	if res == nil || res.IsError {
+		t.Fatalf("unexpected error from traces get: %v", res)
+	}
+	txt := resultText(res)
+
+	var result map[string]any
+	if err := json.Unmarshal([]byte(txt), &result); err != nil {
+		t.Fatalf("invalid JSON response: %v\nraw: %s", err, txt)
+	}
+	if result["found"] != true {
+		t.Fatalf("process not found in response: %s", txt)
+	}
+
+	steps, ok := result["steps"].([]any)
+	if !ok {
+		t.Fatalf("steps not an array in response: %s", txt)
+	}
+	if len(steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d: %s", len(steps), txt)
+	}
+
+	// Verify the bridge step (index 2) carries backend metadata.
+	var bridgeStep map[string]any
+	for _, s := range steps {
+		m, _ := s.(map[string]any)
+		if idx, _ := m["step_index"].(float64); int(idx) == 2 {
+			bridgeStep = m
+			break
+		}
+	}
+	if bridgeStep == nil {
+		t.Fatalf("bridge step (step_index=2) missing from steps: %s", txt)
+	}
+
+	// The id prefix must be the backend repo, not the frontend repo.
+	id, _ := bridgeStep["id"].(string)
+	if !strings.HasPrefix(id, "backend::") {
+		t.Errorf("bridge step id must carry backend:: prefix, got %q", id)
+	}
+	if strings.HasPrefix(id, "frontend::") {
+		t.Errorf("bridge step id must NOT carry frontend:: prefix, got %q", id)
+	}
+
+	// name, file, line must all be populated for the bridge step.
+	name, _ := bridgeStep["name"].(string)
+	if name == "" {
+		t.Errorf("bridge step missing 'name' field: %v", bridgeStep)
+	}
+	if name != "OrdersController.getSummary" {
+		t.Errorf("bridge step name = %q, want OrdersController.getSummary", name)
+	}
+	file, _ := bridgeStep["file"].(string)
+	if file == "" {
+		t.Errorf("bridge step missing 'file' field: %v", bridgeStep)
+	}
+	line, hasLine := bridgeStep["line"]
+	if !hasLine {
+		t.Errorf("bridge step missing 'line' field (StartLine=42 in fixture): %v", bridgeStep)
+	}
+	if line.(float64) != 42 {
+		t.Errorf("bridge step line = %v, want 42", line)
+	}
+
+	// Seed-repo steps (index 0 and 1) must carry frontend:: prefix.
+	for _, s := range steps {
+		m, _ := s.(map[string]any)
+		idx, _ := m["step_index"].(float64)
+		if int(idx) == 2 {
+			continue
+		}
+		sid, _ := m["id"].(string)
+		if !strings.HasPrefix(sid, "frontend::") {
+			t.Errorf("seed step (index=%d) id should carry frontend:: prefix, got %q", int(idx), sid)
+		}
+	}
+}


### PR DESCRIPTION
## What

Fixes #1905. After #1902 (`RunProcessFlowWithCompanions`) cross-repo flows return the correct 10-step chain, but bridge steps (steps whose entities live in the companion/backend repo) arrive with only `{id, node_id, step_index}` — no `name`, `file`, `line`, or `repo`. Additionally all 10 step IDs carry the seed repo prefix (`client-fixture-e::`) even for bridge steps that belong to the backend repo (`client-fixture-d::`).

## Root Cause

Two independent serialisation paths shared the same bug:

1. **`internal/mcp/traces.go` — `buildProcessSteps`**: the function is called with `r.ByID` (the seed repo's entity map) and `r.Repo` (the seed repo slug). For bridge step IDs that live in a companion repo, `byID[id]` returns nil → no metadata. And `prefixedID(repo, id)` always stamps the seed repo's name → wrong prefix.

2. **`internal/dashboard/handlers_flows.go` — `handleFlowDetail`**: the inner entity-lookup loop iterated over the _same repo_ that holds the `STEP_IN_PROCESS` edge and searched only that repo's `Entities` slice. Bridge step entity IDs never exist there → steps silently dropped.

## Fix

**`mcp/traces.go`**
- Add `crossRepoLookup` function type and `buildGroupCrossRepoLookup(lg, seedRepo)` which pre-indexes all companion repos by entity ID.
- Add `buildProcessStepsWithCrossRepo` (the new enrichment path) that falls back to the cross-repo lookup for unresolved step IDs. Bridge steps get the companion slug as the `id` prefix and are enriched with name/file/line. A `repo` field is also stamped on every step.
- `buildProcessSteps` delegates to the new function with `nil` crossRepo (backward-compatible for single-repo paths).
- `handleTracesGet` builds the cross-repo lookup from the full `LoadedGroup` before calling the step builder.

**`dashboard/graphstate.go`**
- Add `groupEntityHit` + `buildGroupEntityIndex(grp)` which builds a group-wide `map[entityID]→{repoSlug, *Entity}` used by `handleFlowDetail`.

**`dashboard/handlers_flows.go`**
- Replace the per-repo entity-search loop with a single `groupEntityIndex[stepIDLocal]` lookup so bridge steps are found in their owning companion repo.

## Tests

- `mcp/traces_test.go` — `TestTracesGet_BridgeStepMetadata_1905`: two-repo fixture where a cross-repo Process has a bridge step (entity in companion "backend" repo). Asserts `id` carries `backend::` prefix, `name`/`file`/`line` are populated, and seed-repo steps still carry `frontend::`.
- `dashboard/handlers_flows_annotation_test.go` — `TestFlowDetail_BridgeStepMetadata_1905`: HTTP integration test hitting `GET /api/flows/{group}/{pid}` with the same two-repo fixture. Asserts all 3 steps returned, bridge step has `backend::` prefix and correct label.

## Verification checklist

- [ ] `archigraph rebuild client-fixture-de`
- [ ] `GET /api/flows/client-fixture-de?cross_stack_only=true` returns the `auth.service.js → AuthController.login` flow
- [ ] `GET /api/flows/client-fixture-de/{process_id}` returns 10 steps, each with `name` + `file` + `line`; steps 0–6 carry `client-fixture-e::` prefix, steps 7–9 carry `client-fixture-d::` prefix
- [ ] Dashboard flow detail renders all 10 steps without blank rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)