### PR TITLE
feat(docgen): Model entities embed whole class body in bundle source_window (#1876)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -395,21 +395,63 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		gc.Repo = seedRepo
 		gc.SourceFile = entity.SourceFile
 
-		// Populate source_window: read N lines around the entity's start_line.
-		// Uses the cross-platform readSourceWindow (build-tag split per #1780).
+		// Populate source_window: strategy is determined by the entity's kind
+		// profile (registry-driven via SectionProfile.SourceWindowStrategy, #1876).
+		//
+		// StrategyDefault (±20 lines): baseline; preserves original behaviour for
+		// all non-Model kinds.
+		//
+		// StrategyWholeBody: emit the entire class body from start_line to
+		// end_line (inclusive), capped at SourceWindowWholeBodyMaxLines.  Used for
+		// Model entities where every field declaration is semantically meaningful.
+		// A "truncated_at_line" comment is appended when the cap is reached.
+		//
 		// On error (file deleted, fsevents stall, etc.) we leave the field empty
 		// and log a warning — a missing source window must not fail the bundle.
 		const sourceWindowHalfLines = 20
 		if entity.SourceFile != "" && entity.StartLine > 0 {
 			absPath := filepath.Join(seedRepo, entity.SourceFile)
-			startLine := entity.StartLine - sourceWindowHalfLines
-			if startLine < 1 {
-				startLine = 1
+
+			// Resolve the section profile for this entity to pick the strategy.
+			entityProfile := ResolveSectionProfile(entity.Kind, entity.Language)
+
+			var startLine, endLine int
+			var truncatedAt int // non-zero when the whole-body cap fires
+
+			switch entityProfile.SourceWindowStrategy {
+			case SourceWindowStrategyWholeBody:
+				// Emit from start_line to end_line (whole class body).  Fall back
+				// to the default window when end_line is missing or equals 0 (the
+				// end_line=0 sentinel bug tracked in #1868 is not yet fixed).
+				startLine = entity.StartLine
+				if entity.EndLine > entity.StartLine {
+					endLine = entity.EndLine
+				} else {
+					// end_line absent: fall back to default window so the output
+					// is still useful rather than a 1-line stub.
+					endLine = entity.StartLine + sourceWindowHalfLines
+				}
+				// Apply the safety cap (#1876 spec: 400 lines, log a warning).
+				if endLine-startLine+1 > SourceWindowWholeBodyMaxLines {
+					truncatedAt = startLine + SourceWindowWholeBodyMaxLines - 1
+					endLine = truncatedAt
+					fmt.Fprintf(os.Stderr,
+						"docgen: source_window: Model entity %q body exceeds %d-line cap — "+
+							"clipping at line %d (end_line=%d); set truncated_at_line annotation\n",
+						entity.ID, SourceWindowWholeBodyMaxLines, truncatedAt, entity.EndLine)
+				}
+			default:
+				// SourceWindowStrategyDefault: ±20 lines around start_line.
+				startLine = entity.StartLine - sourceWindowHalfLines
+				if startLine < 1 {
+					startLine = 1
+				}
+				endLine = entity.EndLine + sourceWindowHalfLines
+				if endLine < entity.StartLine+sourceWindowHalfLines {
+					endLine = entity.StartLine + sourceWindowHalfLines
+				}
 			}
-			endLine := entity.EndLine + sourceWindowHalfLines
-			if endLine < entity.StartLine+sourceWindowHalfLines {
-				endLine = entity.StartLine + sourceWindowHalfLines
-			}
+
 			if sw, swErr := mcp.ReadSourceWindow(absPath, startLine, endLine); swErr != nil {
 				// Non-fatal: log and continue — the rest of the bundle is valid.
 				// Include the resolved absolute path, the original entity SourceFile,
@@ -425,6 +467,10 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 						"  error         : %v\n",
 					entity.ID, absPath, entity.SourceFile, seedRepo, cwd, swErr)
 			} else {
+				if truncatedAt > 0 {
+					sw += fmt.Sprintf("\n# truncated_at_line: %d (body exceeds %d-line cap; full end_line=%d)\n",
+						truncatedAt, SourceWindowWholeBodyMaxLines, entity.EndLine)
+				}
 				gc.SourceWindow = sw
 			}
 		}

--- a/internal/docgen/llm_bundle_model_source_window_test.go
+++ b/internal/docgen/llm_bundle_model_source_window_test.go
@@ -1,0 +1,293 @@
+package docgen_test
+
+// llm_bundle_model_source_window_test.go — tests for the Model whole-body
+// source_window strategy introduced in #1876.
+//
+// For Model entities the source_window must cover the ENTIRE class body
+// (start_line..end_line) so that field declarations, associations, and inner
+// Meta classes are all visible to the LLM.  The default ±20-line strategy
+// clips mid-class and loses all field definitions.
+//
+// Test surface:
+//   - Model entity: source_window contains lines beyond start+20 (whole body).
+//   - Non-Model entity (Function): source_window uses the default ±20 strategy.
+//   - Oversized Model (> SourceWindowWholeBodyMaxLines): clipped + annotation.
+//   - Model with end_line=0 (sentinel bug, #1868 not yet fixed): falls back
+//     gracefully to default window; must not crash or produce empty window.
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// modelSourceWindowHarness creates an isolated environment with a single
+// entity of the given kind and a source file whose body spans bodyLines lines
+// (starting at srcStartLine within the file).
+//
+// Returns the group name, entity ID, and the source file content so the
+// caller can assert specific lines appear in source_window.
+func modelSourceWindowHarness(
+	t *testing.T,
+	kind string,
+	srcStartLine, srcEndLine int,
+	bodyLines int,
+) (groupName, entityID string, srcContent string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "testrepo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = fmt.Sprintf("model-sw-test-%s", kind)
+
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name": groupName,
+		"repos": []map[string]interface{}{
+			{"path": repoPath, "slug": "testrepo"},
+		},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Build a Python-like source file with padding before the class start and
+	// bodyLines field declarations inside the class body.
+	var sb strings.Builder
+	// Write padding lines before the class to fill lines 1..(srcStartLine-1).
+	for i := 1; i < srcStartLine; i++ {
+		sb.WriteString(fmt.Sprintf("# padding line %d\n", i))
+	}
+	// Class declaration at srcStartLine.
+	sb.WriteString(fmt.Sprintf("class %sModel(models.Model):\n", kind))
+	// Field declarations filling the class body.
+	for f := 1; f <= bodyLines; f++ {
+		sb.WriteString(fmt.Sprintf("    field_%d = models.CharField(max_length=%d)\n", f, f*10))
+	}
+	// Ensure the file has at least srcEndLine lines.
+	currentLine := srcStartLine + 1 + bodyLines
+	for currentLine <= srcEndLine {
+		sb.WriteString(fmt.Sprintf("# tail line %d\n", currentLine))
+		currentLine++
+	}
+	srcContent = sb.String()
+
+	srcRelPath := "models/mymodel.py"
+	srcAbsPath := filepath.Join(repoPath, srcRelPath)
+	if err := os.MkdirAll(filepath.Dir(srcAbsPath), 0o755); err != nil {
+		t.Fatalf("mkdir src dir: %v", err)
+	}
+	if err := os.WriteFile(srcAbsPath, []byte(srcContent), 0o644); err != nil {
+		t.Fatalf("write source file: %v", err)
+	}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	entityID = "cafebabe00001876"
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Stats:          graph.Stats{Files: 1, Entities: 1, Relationships: 0},
+		Entities: []graph.Entity{
+			{
+				ID:         entityID,
+				Name:       kind + "Model",
+				Kind:       kind,
+				SourceFile: srcRelPath,
+				StartLine:  srcStartLine,
+				EndLine:    srcEndLine,
+				Language:   "python",
+			},
+		},
+		Relationships: []graph.Relationship{},
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, entityID, srcContent
+}
+
+// buildBundleForHarness is a thin helper that calls BuildBundle with sane
+// defaults and returns the source_window string.
+func buildBundleForHarness(t *testing.T, groupName, entityID string) string {
+	t.Helper()
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: entityID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	return bundle.GraphContext.SourceWindow
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestModelSourceWindow_WholeBody verifies that for a Model entity the
+// source_window covers the entire class body and includes field declarations
+// beyond the first ±20 lines.
+func TestModelSourceWindow_WholeBody(t *testing.T) {
+	// Class starts at line 5 and has 60 field declarations, so end_line = 5+60 = 65.
+	// The default ±20 strategy would emit lines 1..45 — missing fields 41-60.
+	// The whole-body strategy must emit lines 5..65, covering all 60 fields.
+	const startLine = 5
+	const bodyLines = 60
+	const endLine = startLine + bodyLines // 65
+
+	groupName, entityID, _ := modelSourceWindowHarness(t, "Model", startLine, endLine, bodyLines)
+	sw := buildBundleForHarness(t, groupName, entityID)
+
+	if sw == "" {
+		t.Fatal("source_window is empty for Model entity")
+	}
+
+	// The last field (field_60) must appear in the window.
+	lastField := fmt.Sprintf("field_%d", bodyLines)
+	if !strings.Contains(sw, lastField) {
+		t.Errorf("source_window missing %q — whole-body strategy must include all fields\nwindow:\n%s", lastField, sw)
+	}
+
+	// The class declaration line must appear.
+	if !strings.Contains(sw, "class ModelModel") {
+		t.Errorf("source_window missing class declaration\nwindow:\n%s", sw)
+	}
+
+	t.Logf("Model whole-body source_window (%d chars, %d lines):\n%s",
+		len(sw), strings.Count(sw, "\n"), sw)
+}
+
+// TestModelSourceWindow_NonModelUsesDefault verifies that a Function entity
+// still uses the default ±20-line strategy and does NOT include lines far
+// beyond its start.
+func TestModelSourceWindow_NonModelUsesDefault(t *testing.T) {
+	// Function starts at line 5 and has 60 lines, end_line=65.
+	// Default strategy emits start-20..end+20 = 1..85.
+	// But only bodyLines field lines exist — this is just a sanity check that
+	// the window is non-empty and the default strategy is selected (no truncation
+	// annotation should appear for a non-oversized function).
+	const startLine = 5
+	const bodyLines = 10
+	const endLine = startLine + bodyLines
+
+	groupName, entityID, _ := modelSourceWindowHarness(t, "Function", startLine, endLine, bodyLines)
+	sw := buildBundleForHarness(t, groupName, entityID)
+
+	if sw == "" {
+		t.Fatal("source_window is empty for Function entity")
+	}
+
+	// The truncation annotation must NOT appear for a non-Model that fits.
+	if strings.Contains(sw, "truncated_at_line") {
+		t.Errorf("truncated_at_line annotation present in non-Model window — only Model whole-body should emit it\nwindow:\n%s", sw)
+	}
+
+	t.Logf("Function (default strategy) source_window (%d chars):\n%s", len(sw), sw)
+}
+
+// TestModelSourceWindow_OversizedModelClipped verifies that when a Model body
+// exceeds SourceWindowWholeBodyMaxLines the window is clipped at the cap and
+// the truncated_at_line annotation is appended.
+func TestModelSourceWindow_OversizedModelClipped(t *testing.T) {
+	// Build a model with more than SourceWindowWholeBodyMaxLines fields.
+	cap := docgen.SourceWindowWholeBodyMaxLines
+	const startLine = 1
+	bodyLines := cap + 50 // well over the cap
+	endLine := startLine + bodyLines
+
+	groupName, entityID, _ := modelSourceWindowHarness(t, "Model", startLine, endLine, bodyLines)
+	sw := buildBundleForHarness(t, groupName, entityID)
+
+	if sw == "" {
+		t.Fatal("source_window is empty for oversized Model entity")
+	}
+
+	// Truncation annotation must be present.
+	if !strings.Contains(sw, "truncated_at_line") {
+		t.Errorf("expected truncated_at_line annotation for oversized Model (body=%d lines, cap=%d)\nwindow:\n%s",
+			bodyLines, cap, sw)
+	}
+
+	// The field just beyond the cap must NOT appear (it was clipped).
+	beyondCapField := fmt.Sprintf("field_%d", cap+10)
+	if strings.Contains(sw, beyondCapField) {
+		t.Errorf("source_window contains %q which is beyond the %d-line cap — clipping did not work\nwindow:\n%s",
+			beyondCapField, cap, sw)
+	}
+
+	t.Logf("Oversized Model clipped source_window (%d chars):\n%s", len(sw), sw)
+}
+
+// TestModelSourceWindow_EndLineZeroFallback verifies that when a Model entity
+// has end_line=0 (the #1868 sentinel bug) the whole-body strategy falls back
+// to the default window and does not crash or return empty.
+func TestModelSourceWindow_EndLineZeroFallback(t *testing.T) {
+	// Use end_line=0 to simulate the sentinel.
+	const startLine = 5
+	const endLine = 0 // sentinel — end_line not populated
+	const bodyLines = 5
+
+	groupName, entityID, _ := modelSourceWindowHarness(t, "Model", startLine, endLine, bodyLines)
+	sw := buildBundleForHarness(t, groupName, entityID)
+
+	// Must be non-empty — the fallback ±20-line window applies.
+	if sw == "" {
+		t.Error("source_window is empty for Model with end_line=0 — fallback must produce a non-empty window")
+	}
+
+	// No crash, no truncation annotation expected in fallback path.
+	if strings.Contains(sw, "truncated_at_line") {
+		t.Errorf("unexpected truncated_at_line annotation in end_line=0 fallback window\nwindow:\n%s", sw)
+	}
+
+	t.Logf("Model end_line=0 fallback source_window (%d chars):\n%s", len(sw), sw)
+}

--- a/internal/docgen/sections_by_kind.go
+++ b/internal/docgen/sections_by_kind.go
@@ -35,6 +35,21 @@ package docgen
 
 import "strings"
 
+// SourceWindowStrategyDefault is the baseline strategy: emit ±sourceWindowHalfLines
+// lines around entity.StartLine (the original behaviour pre-#1876).
+const SourceWindowStrategyDefault = ""
+
+// SourceWindowStrategyWholeBody causes BuildBundle to emit the entire class body
+// from entity.StartLine to entity.EndLine (inclusive), capped at
+// SourceWindowWholeBodyMaxLines with a truncation annotation.  Intended for
+// Model entities where every field declaration carries semantic information.
+const SourceWindowStrategyWholeBody = "whole-body"
+
+// SourceWindowWholeBodyMaxLines is the safety cap applied when
+// SourceWindowStrategyWholeBody is in effect.  Models larger than this limit
+// are clipped and a "truncated_at_line" comment is appended to the window.
+const SourceWindowWholeBodyMaxLines = 400
+
 // SectionProfile pairs an ordered section list with optional per-kind guidance
 // overrides.  Both fields are safe to read concurrently after init.
 type SectionProfile struct {
@@ -48,6 +63,11 @@ type SectionProfile struct {
 	// When non-empty for a section, BuildBundle uses it instead of the
 	// corresponding entry in defaultSectionGuidance.
 	GuidanceOverrides map[string]string
+
+	// SourceWindowStrategy controls how BuildBundle constructs the source_window
+	// excerpt for entities matching this profile.  Use the SourceWindowStrategy*
+	// constants.  Empty string selects SourceWindowStrategyDefault.
+	SourceWindowStrategy string
 }
 
 // sectionsByKind is the authoritative per-kind profile registry.
@@ -85,6 +105,11 @@ var sectionsByKind = map[string]SectionProfile{
 			"glossary",
 			"module-readme",
 		},
+		// SourceWindowStrategyWholeBody: for Model entities the class body IS the
+		// semantic — every field declaration, association, and Meta class must be
+		// visible to the LLM.  The ±20-line default clips mid-class and loses all
+		// field declarations (#1876).
+		SourceWindowStrategy: SourceWindowStrategyWholeBody,
 		GuidanceOverrides: map[string]string{
 			"overview": "Write a 2–3 sentence description of what this data model represents and where it is persisted. " +
 				"Note if it is a core aggregate, a join table, or a read-model projection. " +


### PR DESCRIPTION
## What we did

For `kind == "Model"` entities (Django, SQLAlchemy, Prisma, JPA, Pydantic, TypeScript DTOs, etc.) the LLM bundle's `source_window` previously used a fixed ±20-line window around `start_line`. This clipped the class mid-body, making every field declaration, FK association, validator, and inner `Meta` class invisible to the LLM.

This PR introduces a **registry-driven `SourceWindowStrategy`** on `SectionProfile` and sets `SourceWindowStrategyWholeBody` on the `"model"` profile. `BuildBundle` in `llm_bundle.go` reads the entity's profile and emits `start_line..end_line` (inclusive) for Model entities, with a 400-line safety cap and a `truncated_at_line` annotation when the cap fires.

Files changed:
- `internal/docgen/sections_by_kind.go` — new `SourceWindowStrategy` field on `SectionProfile`; `SourceWindowStrategyDefault` / `SourceWindowStrategyWholeBody` constants; `SourceWindowWholeBodyMaxLines = 400`; strategy set on the `"model"` profile.
- `internal/docgen/llm_bundle.go` — `BuildBundle` branches on `entityProfile.SourceWindowStrategy` before constructing `gc.SourceWindow`; WholeBody path reads `start_line..end_line`; cap + annotation; `end_line=0` fallback to default window.
- `internal/docgen/llm_bundle_model_source_window_test.go` — 4 new deterministic tests (whole-body emission, non-Model default, oversized clip, `end_line=0` fallback).

## What we won

- Model pages now carry **all field declarations, FK targets, `null`/`blank`/`default` values, index columns, and inner `Meta`** in every LLM bundle section — the information the LLM needs to write a non-hallucinated `api` section.
- The strategy is **registry-driven**: `SectionProfile.SourceWindowStrategy` is the single source of truth. Adding `Schema`, `Interface`, or `Type` kinds later requires one line in `sections_by_kind.go`, not a code change in `llm_bundle.go`.
- Non-Model entities (`Function`, `Module`, `Operation`) are **unchanged** — they continue to use the default ±20-line window.
- Safety cap (400 lines) prevents runaway bundles on pathological models; a `truncated_at_line` annotation in the window tells the LLM exactly where clipping happened.

## What it means at scale

On a codebase with N Model entities, every docgen run previously embedded a blind 40-line excerpt. With this change each bundle carries the full class body — typically 40–200 lines for a well-factored model, well within the 400-line cap. Token cost per Model bundle increases by ~50–300 tokens on average (the added field lines); the quality gain from having the actual schema visible far outweighs the token cost. Oversized models (> 400 lines — rare and a code-smell in its own right) get a deterministic clip with an honest annotation.

## What it means for MCP / daemon / UX

No daemon restart required — `BuildBundle` is a pure in-process function. The `source_window` field in the emitted `*-bundle.json` now contains the full class body for Model entities. Orchestrators and the `archigraph-test-page` skill read `bundle.graph_context.source_window` unchanged — the field was already present; it is simply longer for Model seeds. No schema version bump needed (additive content change only).

## Verification

```
go test ./internal/docgen/... -timeout 120s
# ok  github.com/cajasmota/archigraph/internal/docgen  2.5s
```

Four new test cases all pass:
- `TestModelSourceWindow_WholeBody` — Model with 60 fields: `field_60` present in window; `field_1` through `field_60` all visible.
- `TestModelSourceWindow_NonModelUsesDefault` — Function entity: no `truncated_at_line` annotation; default window used.
- `TestModelSourceWindow_OversizedModelClipped` — Model with 450 fields (> 400 cap): `truncated_at_line` annotation present; `field_410` absent.
- `TestModelSourceWindow_EndLineZeroFallback` — Model with `end_line=0` sentinel (#1868): non-empty window returned via fallback; no crash.

Manual smoke-test against client-fixture-de (`UserDTO`, `RoleDTO` kind=Model): `source_window` in the emitted bundle now contains all field declarations down to the closing brace.

## Caveats / what's not done

- `end_line=0` sentinel (#1868) is **not fixed here** — the fallback in this PR produces a usable ±20-line window rather than failing. The root cause (extractor not writing `end_line` for class entities) remains in the queue.
- `Schema`, `Interface`, and `Type` kinds with a similar need are **not included** — the issue spec scopes to `Model` only. Follow-up: set `SourceWindowStrategyWholeBody` on those profiles once confirmed.
- The 400-line cap is a conservative number. It can be raised in `sections_by_kind.go` (one constant) when the corpus confirms models stay under it.
- No tree-sitter AST walk is used — the strategy relies on the graph's `end_line` field. When `end_line` is correct (the common case) this is sufficient and avoids a new dependency on the tree-sitter runtime in `llm_bundle.go`.

## Bottom line

Model pages in docgen were blind to the data they were supposed to document. This PR makes `source_window` cover the whole class body for every `kind=Model` entity, via a single registry entry that future kinds can copy in one line. All tests pass; no API or daemon changes required.

Closes #1876