### PR TITLE
feat(extractors): first-class Config entities across languages (#1885)

### DIFF
--- a/cmd/archigraph/index.go
+++ b/cmd/archigraph/index.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cajasmota/archigraph/internal/external"
 	"github.com/cajasmota/archigraph/internal/extractor"
 	"github.com/cajasmota/archigraph/internal/extractors"
+	configextract "github.com/cajasmota/archigraph/internal/extractors/config"
 	"github.com/cajasmota/archigraph/internal/extractors/cross"
 	pyextr "github.com/cajasmota/archigraph/internal/extractors/python"
 	"github.com/cajasmota/archigraph/internal/graph"
@@ -770,6 +771,24 @@ func (i *Indexer) Run(ctx context.Context, absRepo string) (*graph.Document, err
 			return nil, fmt.Errorf("pass 3: %w", err)
 		}
 		i.stats.pass3Rels = countEmbeddedRels(pass3Records)
+	}
+
+	// Pass 3.5 — first-class Config entity discovery (#1885).
+	// Walks the pre-classification file list so we capture project-level
+	// config files (Dockerfile, Makefile, pyproject.toml, package.json,
+	// pom.xml, build.gradle, application.{properties,yml}, .env, …) that
+	// the classifier would otherwise drop. The pass is idempotent and
+	// always runs against `allFiles` so incremental indexing keeps the
+	// Config entities even when no source file changed.
+	configEntities, configRels, configErr := configextract.Discover(ctx, absRepo, allFiles)
+	if configErr != nil {
+		fmt.Fprintf(os.Stderr, "archigraph: config-discover warning: %v\n", configErr)
+	}
+	if len(configEntities) > 0 {
+		pass3Records = append(pass3Records, configEntities...)
+	}
+	if len(configRels) > 0 {
+		pass2Rels = append(pass2Rels, configRels...)
 	}
 
 	// Pass 2.6 — Django nested URLconf composition.

--- a/internal/daemon/extract/coordinator.go
+++ b/internal/daemon/extract/coordinator.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cajasmota/archigraph/internal/classifier"
 	"github.com/cajasmota/archigraph/internal/engine"
+	configextract "github.com/cajasmota/archigraph/internal/extractors/config"
 	"github.com/cajasmota/archigraph/internal/types"
 )
 
@@ -270,6 +271,19 @@ func Coordinate(ctx context.Context, repoRoot string, files []string, cfg Coordi
 
 	if firstErr != nil {
 		return nil, firstErr
+	}
+
+	// #1885 — Config entity discovery pass. Runs in-process against the
+	// full file list (pre-classification) so project-level config files
+	// that no subprocess saw (Dockerfile, Makefile, .env, etc.) become
+	// first-class SCOPE.Config entities. Failure is non-fatal — config
+	// signal is supplemental.
+	if configEnts, configRels, derr := configextract.Discover(ctx, repoRoot, files); derr == nil {
+		res.Entities = append(res.Entities, configEnts...)
+		res.Relationships = append(res.Relationships, configRels...)
+	} else {
+		res.NonFatalErrors = append(res.NonFatalErrors,
+			fmt.Sprintf("config_discover: %v", derr))
 	}
 
 	// Issue #481 — deterministic ordering. Subprocesses complete in

--- a/internal/daemon/extract/coordinator_test.go
+++ b/internal/daemon/extract/coordinator_test.go
@@ -125,6 +125,60 @@ func Hello() string { return "hi" }
 	}
 }
 
+// TestCoordinate_EmitsConfigEntities (#1885) — the coordinator must run
+// the in-process config-discovery pass after the subprocess fan-out so
+// project-level configs become first-class SCOPE.Config entities. Uses a
+// minimal repo with go.mod + Makefile + .env.
+func TestCoordinate_EmitsConfigEntities(t *testing.T) {
+	if testing.Short() {
+		t.Skip("integration test — skipped in -short mode")
+	}
+	bin := buildArchigraph(t)
+
+	repo := t.TempDir()
+	must := func(name, content string) {
+		if err := os.WriteFile(filepath.Join(repo, name), []byte(content), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	must("demo.go", "package demo\nfunc Hello() string { return \"hi\" }\n")
+	must("go.mod", "module demo/x\nrequire github.com/spf13/cobra v1.8.0\n")
+	must("Makefile", ".PHONY: build\nbuild:\n\tgo build ./...\n")
+	must(".env", "API_KEY=this-value-must-never-leak\nPORT=8080\n")
+
+	files := []string{"demo.go", "go.mod", "Makefile", ".env"}
+	var stderr bytes.Buffer
+	res, err := Coordinate(context.Background(), repo, files,
+		CoordinatorConfig{BinaryPath: bin, Stderr: &stderr})
+	if err != nil {
+		t.Fatalf("Coordinate: %v\n%s", err, stderr.String())
+	}
+
+	var sawGoMod, sawMake, sawEnv bool
+	for _, e := range res.Entities {
+		if e.Kind != "SCOPE.Config" {
+			continue
+		}
+		switch e.SourceFile {
+		case "go.mod":
+			sawGoMod = true
+		case "Makefile":
+			sawMake = true
+		case ".env":
+			sawEnv = true
+			// Security: env values must never appear in any property.
+			for k, v := range e.Properties {
+				if bytes.Contains([]byte(v), []byte("this-value-must-never-leak")) {
+					t.Errorf("SECURITY: env value leaked in property %q: %q", k, v)
+				}
+			}
+		}
+	}
+	if !sawGoMod || !sawMake || !sawEnv {
+		t.Errorf("missing config entities: go.mod=%v Makefile=%v .env=%v", sawGoMod, sawMake, sawEnv)
+	}
+}
+
 func buildArchigraph(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()

--- a/internal/extractors/config/discover.go
+++ b/internal/extractors/config/discover.go
@@ -1,0 +1,868 @@
+// Package config implements the supplemental "config-discovery" pass that
+// promotes project-level configuration files to first-class graph entities.
+//
+// Issue #1885 (Wave 1 tail of #1890): Module-aggregate pages cannot ground
+// reference-* sections without filesystem-level entities for the files that
+// actually carry deployment, build, and runtime configuration:
+//
+//   Python:   pyproject.toml, setup.cfg, requirements*.txt, Pipfile,
+//             .flake8, mypy.ini, pytest.ini, .env, .env.*
+//   Java:     pom.xml, build.gradle, build.gradle.kts,
+//             application.properties, application.yml/.yaml,
+//             quarkus.properties
+//   JS/TS:    package.json, tsconfig.json, vite.config.*, next.config.*,
+//             .eslintrc.*, .prettierrc.*, .env, .env.*
+//   Go:       go.mod, Makefile
+//   General:  Dockerfile, docker-compose.yml/.yaml
+//
+// The cross-language extractor framework (Pass 3) only runs on files that
+// survive classification. Many of these basenames have no language token and
+// therefore never reach Pass 3. This pass walks the *original* file list
+// (pre-classification) and emits one SCOPE.Config entity per recognised
+// config file plus DEPENDS_ON_CONFIG / CONFIGURES edges to nearby modules.
+//
+// SECURITY: For .env files we record env-variable NAMES ONLY. Values are
+// dropped before they enter the graph. Test
+// TestDiscover_EnvNeverLeaksValues asserts the boundary.
+package config
+
+import (
+	"context"
+	"encoding/json"
+	"encoding/xml"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// maxKeysPerProperty bounds the size of any single Properties value so a
+// pathological config file cannot inflate the graph.
+const maxKeysPerProperty = 64
+
+// maxFileBytes caps the bytes we read from any one config file. Larger
+// files are still recognised as config (entity emitted) but only the first
+// maxFileBytes are parsed for keys/dependencies.
+const maxFileBytes = 256 * 1024 // 256 KiB
+
+// configKind is the parsed file's format-family. It is used to select the
+// parser and is recorded as the entity Property "format".
+type configKind string
+
+const (
+	formatTOML       configKind = "toml"
+	formatJSON       configKind = "json"
+	formatYAML       configKind = "yaml"
+	formatXML        configKind = "xml"
+	formatProperties configKind = "properties"
+	formatINI        configKind = "ini"
+	formatEnv        configKind = "env"
+	formatDockerfile configKind = "dockerfile"
+	formatMakefile   configKind = "makefile"
+	formatRequirements configKind = "requirements"
+	formatGradle     configKind = "gradle"
+	formatGoMod      configKind = "go_mod"
+	formatJSConfig   configKind = "javascript"
+)
+
+// configSpec describes one recognised config file. Subtype is the value
+// recorded on the emitted entity (Subtype field) — chosen to mirror the
+// vocabulary in issue #1885.
+type configSpec struct {
+	subtype string
+	format  configKind
+}
+
+// exactBasenames maps an exact basename (case-sensitive on Linux/macOS
+// behaviour, but we lowercase Windows-style paths before lookup) to its
+// spec. Patterns that need glob behaviour are handled by matchPattern.
+var exactBasenames = map[string]configSpec{
+	"pyproject.toml":         {"python_project", formatTOML},
+	"setup.cfg":              {"python_project_legacy", formatINI},
+	"setup.py":               {"python_project_legacy", formatJSConfig}, // parsed as text
+	"requirements.txt":       {"python_requirements", formatRequirements},
+	"Pipfile":                {"python_pipenv", formatTOML},
+	".flake8":                {"python_flake8", formatINI},
+	"mypy.ini":               {"python_mypy", formatINI},
+	"pytest.ini":             {"python_pytest", formatINI},
+	"tox.ini":                {"python_tox", formatINI},
+
+	"pom.xml":                {"maven_project", formatXML},
+	"build.gradle":           {"gradle_project", formatGradle},
+	"build.gradle.kts":       {"gradle_project", formatGradle},
+	"application.properties": {"spring_properties", formatProperties},
+	"application.yml":        {"spring_yaml", formatYAML},
+	"application.yaml":       {"spring_yaml", formatYAML},
+	"quarkus.properties":     {"quarkus_properties", formatProperties},
+
+	"package.json":           {"node_project", formatJSON},
+	"tsconfig.json":          {"typescript_project", formatJSON},
+
+	"go.mod":                 {"go_module", formatGoMod},
+	"go.sum":                 {"go_sum", formatGoMod}, // existence only
+
+	"Makefile":               {"makefile", formatMakefile},
+	"makefile":               {"makefile", formatMakefile},
+	"GNUmakefile":            {"makefile", formatMakefile},
+
+	"Dockerfile":             {"docker_image", formatDockerfile},
+	"Containerfile":          {"docker_image", formatDockerfile},
+	"docker-compose.yml":     {"docker_compose", formatYAML},
+	"docker-compose.yaml":    {"docker_compose", formatYAML},
+}
+
+// requirementsPrefix matches requirements-dev.txt, requirements-test.txt, …
+var requirementsPrefix = regexp.MustCompile(`^requirements[-._].*\.txt$`)
+
+// dockerfileVariant matches Dockerfile.dev, Dockerfile.prod, dockerfile-test, …
+var dockerfileVariant = regexp.MustCompile(`(?i)^dockerfile([._\-].+)?$`)
+
+// envFile matches .env and .env.<suffix>. Excludes .envrc (direnv).
+var envFile = regexp.MustCompile(`^\.env(\..+)?$`)
+
+// jsConfigVariant matches vite.config.{js,ts,mjs}, next.config.{js,ts,mjs},
+// .eslintrc.{js,cjs,json,yml,yaml}, .prettierrc.{js,cjs,json,yml,yaml,toml}.
+var (
+	viteConfigRe     = regexp.MustCompile(`^vite\.config\.(js|ts|mjs|cjs)$`)
+	nextConfigRe     = regexp.MustCompile(`^next\.config\.(js|ts|mjs|cjs)$`)
+	eslintConfigRe   = regexp.MustCompile(`^\.eslintrc(\.(js|cjs|json|yml|yaml))?$`)
+	prettierConfigRe = regexp.MustCompile(`^\.prettierrc(\.(js|cjs|json|yml|yaml|toml))?$`)
+)
+
+// classify returns the configSpec for filePath, or false when the file is
+// not a known project-level config file.
+func classify(relPath string) (configSpec, bool) {
+	base := filepath.Base(filepath.FromSlash(relPath))
+	if spec, ok := exactBasenames[base]; ok {
+		return spec, true
+	}
+	switch {
+	case requirementsPrefix.MatchString(base):
+		return configSpec{"python_requirements", formatRequirements}, true
+	case envFile.MatchString(base):
+		return configSpec{"env_vars", formatEnv}, true
+	case dockerfileVariant.MatchString(base) && strings.Contains(strings.ToLower(base), "dockerfile"):
+		return configSpec{"docker_image", formatDockerfile}, true
+	case viteConfigRe.MatchString(base):
+		return configSpec{"vite_config", formatJSConfig}, true
+	case nextConfigRe.MatchString(base):
+		return configSpec{"next_config", formatJSConfig}, true
+	case eslintConfigRe.MatchString(base):
+		return configSpec{"eslint_config", formatJSConfig}, true
+	case prettierConfigRe.MatchString(base):
+		return configSpec{"prettier_config", formatJSConfig}, true
+	}
+	return configSpec{}, false
+}
+
+// Discover walks files (repo-relative paths, sourced from the same walker
+// that feeds the per-language extractors) and emits SCOPE.Config entities
+// plus DEPENDS_ON_CONFIG edges from the file's directory to the config.
+//
+// Returned slices are sorted deterministically (issue #481) before return.
+func Discover(ctx context.Context, repoRoot string, files []string) ([]types.EntityRecord, []types.RelationshipRecord, error) {
+	tracer := otel.Tracer("extractor.config_discover")
+	ctx, span := tracer.Start(ctx, "indexer.config_discover.run")
+	defer span.End()
+	_ = ctx
+
+	var entities []types.EntityRecord
+	var rels []types.RelationshipRecord
+	seenConfigID := map[string]bool{}
+
+	for _, rel := range files {
+		spec, ok := classify(rel)
+		if !ok {
+			continue
+		}
+
+		abs := filepath.Join(repoRoot, rel)
+		content, err := readBounded(abs)
+		if err != nil {
+			// Best-effort: emit the entity even when read fails, but with
+			// empty body. Skipping silently would lose graph signal for
+			// files we know exist on disk.
+			content = nil
+		}
+
+		ent := buildConfigEntity(repoRoot, rel, spec, content)
+		if seenConfigID[ent.ID] {
+			continue
+		}
+		seenConfigID[ent.ID] = true
+		entities = append(entities, ent)
+
+		// Emit a DEPENDS_ON_CONFIG edge from the file's containing
+		// directory (treated as a Module structural reference) to the
+		// config entity. The intra-repo resolver will rebind to the
+		// real Module entity when one exists.
+		dir := filepath.ToSlash(filepath.Dir(rel))
+		if dir == "." || dir == "" {
+			dir = "_repo_root"
+		}
+		rels = append(rels, types.RelationshipRecord{
+			FromID: "module:" + dir,
+			ToID:   ent.ID,
+			Kind:   string(types.RelationshipKindDependsOnConfig),
+			Properties: map[string]string{
+				"config_subtype": spec.subtype,
+				"config_format":  string(spec.format),
+			},
+		})
+		// CONFIGURES — directional inverse, lets docgen pull configs into
+		// downstream Module pages even when no DEPENDS_ON_CONFIG resolves.
+		rels = append(rels, types.RelationshipRecord{
+			FromID: ent.ID,
+			ToID:   "module:" + dir,
+			Kind:   string(types.RelationshipKindConfigures),
+			Properties: map[string]string{
+				"config_subtype": spec.subtype,
+			},
+		})
+	}
+
+	sortEntities(entities)
+	sortRels(rels)
+
+	span.SetAttributes(
+		attribute.Int("config_entities", len(entities)),
+		attribute.Int("config_edges", len(rels)),
+		attribute.Int("input_files", len(files)),
+	)
+	return entities, rels, nil
+}
+
+// readBounded reads at most maxFileBytes from path.
+func readBounded(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	buf := make([]byte, maxFileBytes)
+	n, err := f.Read(buf)
+	if err != nil && n == 0 {
+		return nil, err
+	}
+	return buf[:n], nil
+}
+
+// buildConfigEntity constructs the SCOPE.Config EntityRecord, including its
+// per-format Properties bag.
+func buildConfigEntity(repoRoot, relPath string, spec configSpec, content []byte) types.EntityRecord {
+	base := filepath.Base(filepath.FromSlash(relPath))
+	rel := filepath.ToSlash(relPath)
+	repoTag := filepath.Base(repoRoot)
+	if repoTag == "" || repoTag == "." {
+		repoTag = "repo"
+	}
+	qual := repoTag + "::" + rel
+
+	props := map[string]string{
+		"format":  string(spec.format),
+		"subtype": spec.subtype,
+	}
+
+	parseInto(props, spec, content)
+
+	ent := types.EntityRecord{
+		Name:          base,
+		QualifiedName: qual,
+		Kind:          string(types.EntityKindConfig),
+		Subtype:       spec.subtype,
+		Language:      languageForFormat(spec.format),
+		SourceFile:    rel,
+		StartLine:     1,
+		EndLine:       1,
+		Signature:     "# " + base,
+		Properties:    props,
+	}
+	// Stable synthetic ID so cross-repo references and tests can locate the
+	// entity without relying on org/project hashing.
+	ent.ID = "scope:config:" + spec.subtype + ":" + rel
+	return ent
+}
+
+// languageForFormat maps the parsed format to a sensible language tag for
+// downstream language-aware filters. Falls back to "text" when no closer
+// match is available — config files are not source code.
+func languageForFormat(f configKind) string {
+	switch f {
+	case formatJSON:
+		return "json"
+	case formatYAML:
+		return "yaml"
+	case formatTOML:
+		return "toml"
+	case formatXML:
+		return "xml"
+	case formatDockerfile:
+		return "dockerfile"
+	case formatMakefile:
+		return "makefile"
+	case formatGoMod:
+		return "go"
+	case formatProperties, formatINI:
+		return "properties"
+	case formatEnv:
+		return "env"
+	case formatGradle:
+		return "groovy"
+	case formatJSConfig:
+		return "javascript"
+	}
+	return "text"
+}
+
+// parseInto fills props (in place) with format-specific information.
+func parseInto(props map[string]string, spec configSpec, content []byte) {
+	if len(content) == 0 {
+		return
+	}
+	switch spec.format {
+	case formatJSON:
+		parseJSON(props, spec, content)
+	case formatTOML:
+		parseTOML(props, spec, content)
+	case formatXML:
+		parseXML(props, spec, content)
+	case formatProperties:
+		parseProperties(props, content)
+	case formatINI:
+		parseINI(props, content)
+	case formatEnv:
+		parseEnv(props, content)
+	case formatYAML:
+		parseYAML(props, content)
+	case formatGradle:
+		parseGradle(props, content)
+	case formatRequirements:
+		parseRequirements(props, content)
+	case formatGoMod:
+		parseGoMod(props, content)
+	case formatMakefile:
+		parseMakefile(props, content)
+	case formatDockerfile:
+		parseDockerfile(props, content)
+	case formatJSConfig:
+		// JS/TS config files: only record top-level export/identifier hints.
+		parseJSConfig(props, content)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Per-format parsers (intentionally permissive — we only need stable signal).
+// ---------------------------------------------------------------------------
+
+func parseJSON(props map[string]string, spec configSpec, content []byte) {
+	var generic map[string]json.RawMessage
+	if err := json.Unmarshal(content, &generic); err != nil {
+		return
+	}
+	props["keys_top_level"] = joinSortedKeys(generic)
+
+	// package.json is the only JSON file we deeply mine.
+	if spec.subtype == "node_project" {
+		var pkg struct {
+			Name             string            `json:"name"`
+			Version          string            `json:"version"`
+			Scripts          map[string]string `json:"scripts"`
+			Dependencies     map[string]string `json:"dependencies"`
+			DevDependencies  map[string]string `json:"devDependencies"`
+			PeerDependencies map[string]string `json:"peerDependencies"`
+		}
+		if err := json.Unmarshal(content, &pkg); err != nil {
+			return
+		}
+		if pkg.Name != "" {
+			props["project_name"] = pkg.Name
+		}
+		if pkg.Version != "" {
+			props["project_version"] = pkg.Version
+		}
+		if len(pkg.Scripts) > 0 {
+			props["scripts"] = joinSortedKeys(pkg.Scripts)
+		}
+		var allDeps []string
+		for k := range pkg.Dependencies {
+			allDeps = append(allDeps, k)
+		}
+		for k := range pkg.DevDependencies {
+			allDeps = append(allDeps, k+" (dev)")
+		}
+		for k := range pkg.PeerDependencies {
+			allDeps = append(allDeps, k+" (peer)")
+		}
+		if len(allDeps) > 0 {
+			sort.Strings(allDeps)
+			props["dependencies"] = capJoin(allDeps)
+		}
+	}
+}
+
+// tomlSectionRE matches a section header `[name]` or `[name.subname]`.
+var tomlSectionRE = regexp.MustCompile(`(?m)^\s*\[([^\]]+)\]`)
+
+// tomlKeyRE matches `key = …` lines (top-level form).
+var tomlKeyRE = regexp.MustCompile(`(?m)^([A-Za-z0-9_.-]+)\s*=`)
+
+// tomlDepListRE matches the canonical pyproject.toml `dependencies = [...]` body.
+var tomlDepListRE = regexp.MustCompile(`(?s)dependencies\s*=\s*\[([^\]]*)\]`)
+
+func parseTOML(props map[string]string, spec configSpec, content []byte) {
+	src := string(content)
+	// Sections become "keys_top_level" (each [section] is a structural key).
+	secs := tomlSectionRE.FindAllStringSubmatch(src, -1)
+	var sectionNames []string
+	seen := map[string]bool{}
+	for _, m := range secs {
+		name := strings.TrimSpace(m[1])
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		sectionNames = append(sectionNames, name)
+	}
+	if len(sectionNames) > 0 {
+		sort.Strings(sectionNames)
+		props["keys_top_level"] = capJoin(sectionNames)
+	}
+
+	if spec.subtype == "python_project" {
+		// Find dependency list (PEP 621 style).
+		if m := tomlDepListRE.FindStringSubmatch(src); m != nil {
+			deps := splitTomlDepList(m[1])
+			if len(deps) > 0 {
+				props["dependencies"] = capJoin(deps)
+			}
+		}
+		// poetry-style: collect [tool.poetry.dependencies] keys.
+		if poetry := extractTomlSectionBody(src, "tool.poetry.dependencies"); poetry != "" {
+			var keys []string
+			for _, m := range tomlKeyRE.FindAllStringSubmatch(poetry, -1) {
+				if k := strings.TrimSpace(m[1]); k != "" && k != "python" {
+					keys = append(keys, k)
+				}
+			}
+			if len(keys) > 0 {
+				sort.Strings(keys)
+				prev := props["dependencies"]
+				if prev == "" {
+					props["dependencies"] = capJoin(keys)
+				} else {
+					props["dependencies"] = capJoin(append(strings.Split(prev, ","), keys...))
+				}
+			}
+		}
+	}
+}
+
+func extractTomlSectionBody(src, name string) string {
+	// Locate `[name]` then read until the next `[…]` header or EOF.
+	idx := strings.Index(src, "["+name+"]")
+	if idx < 0 {
+		return ""
+	}
+	tail := src[idx+len(name)+2:]
+	if next := tomlSectionRE.FindStringIndex(tail); next != nil {
+		return tail[:next[0]]
+	}
+	return tail
+}
+
+// splitTomlDepList splits the body of a `dependencies = [ … ]` block.
+func splitTomlDepList(body string) []string {
+	var out []string
+	for _, item := range strings.Split(body, ",") {
+		item = strings.TrimSpace(item)
+		item = strings.Trim(item, "\"'")
+		if item == "" || strings.HasPrefix(item, "#") {
+			continue
+		}
+		// Strip version specifiers (e.g. "requests>=2.0" → "requests").
+		name := pickPackageName(item)
+		if name != "" {
+			out = append(out, name)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+var pkgNameRE = regexp.MustCompile(`^([A-Za-z0-9](?:[A-Za-z0-9._-]*)?)`)
+
+func pickPackageName(s string) string {
+	m := pkgNameRE.FindStringSubmatch(s)
+	if m == nil {
+		return ""
+	}
+	return m[1]
+}
+
+func parseXML(props map[string]string, spec configSpec, content []byte) {
+	if spec.subtype != "maven_project" {
+		return
+	}
+	// Permissive maven POM parsing — we only need groupId/artifactId for
+	// dependencies and the project's own coordinates.
+	type mavenDep struct {
+		GroupID    string `xml:"groupId"`
+		ArtifactID string `xml:"artifactId"`
+		Version    string `xml:"version"`
+		Scope      string `xml:"scope"`
+	}
+	var pom struct {
+		XMLName      xml.Name   `xml:"project"`
+		GroupID      string     `xml:"groupId"`
+		ArtifactID   string     `xml:"artifactId"`
+		Version      string     `xml:"version"`
+		Name         string     `xml:"name"`
+		Dependencies struct {
+			Dep []mavenDep `xml:"dependency"`
+		} `xml:"dependencies"`
+		Properties struct {
+			Inner []xml.Name `xml:",any"`
+		} `xml:"properties"`
+	}
+	if err := xml.Unmarshal(content, &pom); err != nil {
+		return
+	}
+	if pom.ArtifactID != "" {
+		props["project_name"] = pom.ArtifactID
+	}
+	if pom.GroupID != "" {
+		props["group_id"] = pom.GroupID
+	}
+	if pom.Version != "" {
+		props["project_version"] = pom.Version
+	}
+	if len(pom.Dependencies.Dep) > 0 {
+		var deps []string
+		for _, d := range pom.Dependencies.Dep {
+			if d.GroupID == "" || d.ArtifactID == "" {
+				continue
+			}
+			deps = append(deps, d.GroupID+":"+d.ArtifactID)
+		}
+		sort.Strings(deps)
+		if len(deps) > 0 {
+			props["dependencies"] = capJoin(deps)
+		}
+	}
+}
+
+var propertiesLineRE = regexp.MustCompile(`(?m)^\s*([A-Za-z0-9_.\-]+)\s*[=:]`)
+
+func parseProperties(props map[string]string, content []byte) {
+	matches := propertiesLineRE.FindAllStringSubmatch(string(content), -1)
+	var keys []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		k := strings.TrimSpace(m[1])
+		if k == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > 0 {
+		props["keys_top_level"] = capJoin(keys)
+	}
+}
+
+var iniSectionRE = regexp.MustCompile(`(?m)^\s*\[([^\]]+)\]`)
+
+func parseINI(props map[string]string, content []byte) {
+	src := string(content)
+	var sections []string
+	seen := map[string]bool{}
+	for _, m := range iniSectionRE.FindAllStringSubmatch(src, -1) {
+		name := strings.TrimSpace(m[1])
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		sections = append(sections, name)
+	}
+	if len(sections) > 0 {
+		sort.Strings(sections)
+		props["keys_top_level"] = capJoin(sections)
+	}
+}
+
+// envVarRE matches a NAME=value line. SECURITY: capture group is only the NAME.
+// The value side after `=` is intentionally discarded — never stored.
+var envVarRE = regexp.MustCompile(`(?m)^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=`)
+
+func parseEnv(props map[string]string, content []byte) {
+	matches := envVarRE.FindAllStringSubmatch(string(content), -1)
+	var names []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		name := m[1]
+		if name == "" || seen[name] {
+			continue
+		}
+		seen[name] = true
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	if len(names) > 0 {
+		props["keys_top_level"] = capJoin(names)
+	}
+	// SECURITY GUARD: explicitly mark the parser tier so downstream auditors
+	// can assert that no value strings ever land in Properties for env files.
+	props["redaction"] = "names_only"
+}
+
+// yamlTopKeyRE matches a top-level `key:` line (no leading whitespace).
+var yamlTopKeyRE = regexp.MustCompile(`(?m)^([A-Za-z_][A-Za-z0-9_.\-]*)\s*:`)
+
+func parseYAML(props map[string]string, content []byte) {
+	matches := yamlTopKeyRE.FindAllStringSubmatch(string(content), -1)
+	var keys []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		k := m[1]
+		if k == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > 0 {
+		props["keys_top_level"] = capJoin(keys)
+	}
+}
+
+// gradleDepLineRE captures `implementation "group:artifact:version"` and
+// variants (api, testImplementation, runtimeOnly, …).
+var gradleDepLineRE = regexp.MustCompile(`(?m)^\s*(?:implementation|api|compileOnly|runtimeOnly|testImplementation|testRuntimeOnly|annotationProcessor)\s*[\(\s]?["']([^"']+)["']`)
+
+// gradlePluginRE captures `id 'plugin.name'` and `id("plugin.name")`.
+var gradlePluginRE = regexp.MustCompile(`(?m)^\s*id\s*[\(\s]["']([^"']+)["']`)
+
+func parseGradle(props map[string]string, content []byte) {
+	src := string(content)
+	var deps []string
+	for _, m := range gradleDepLineRE.FindAllStringSubmatch(src, -1) {
+		deps = append(deps, m[1])
+	}
+	sort.Strings(deps)
+	if len(deps) > 0 {
+		props["dependencies"] = capJoin(deps)
+	}
+	var plugins []string
+	for _, m := range gradlePluginRE.FindAllStringSubmatch(src, -1) {
+		plugins = append(plugins, m[1])
+	}
+	sort.Strings(plugins)
+	if len(plugins) > 0 {
+		props["plugins"] = capJoin(plugins)
+	}
+}
+
+func parseRequirements(props map[string]string, content []byte) {
+	var deps []string
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") || strings.HasPrefix(line, "-") {
+			continue
+		}
+		name := pickPackageName(line)
+		if name != "" {
+			deps = append(deps, name)
+		}
+	}
+	sort.Strings(deps)
+	if len(deps) > 0 {
+		props["dependencies"] = capJoin(deps)
+	}
+}
+
+var goModModuleRE = regexp.MustCompile(`(?m)^module\s+(\S+)`)
+var goModRequireBlockRE = regexp.MustCompile(`(?s)require\s*\(([^)]+)\)`)
+var goModRequireLineRE = regexp.MustCompile(`(?m)^\s*(\S+)\s+(v\S+)`)
+var goModSingleRequireRE = regexp.MustCompile(`(?m)^require\s+(\S+)\s+(v\S+)`)
+
+func parseGoMod(props map[string]string, content []byte) {
+	src := string(content)
+	if m := goModModuleRE.FindStringSubmatch(src); m != nil {
+		props["project_name"] = m[1]
+	}
+	var deps []string
+	seen := map[string]bool{}
+	for _, bm := range goModRequireBlockRE.FindAllStringSubmatch(src, -1) {
+		for _, lm := range goModRequireLineRE.FindAllStringSubmatch(bm[1], -1) {
+			if seen[lm[1]] {
+				continue
+			}
+			seen[lm[1]] = true
+			deps = append(deps, lm[1])
+		}
+	}
+	for _, sm := range goModSingleRequireRE.FindAllStringSubmatch(src, -1) {
+		if seen[sm[1]] {
+			continue
+		}
+		seen[sm[1]] = true
+		deps = append(deps, sm[1])
+	}
+	sort.Strings(deps)
+	if len(deps) > 0 {
+		props["dependencies"] = capJoin(deps)
+	}
+}
+
+// makeTargetRE matches a top-level Makefile target line: `name:` or `name: deps`.
+// Excludes pattern rules ("%.o:"), .PHONY directives, and indented recipe lines.
+var makeTargetRE = regexp.MustCompile(`(?m)^([A-Za-z_][A-Za-z0-9_.\-]*)\s*:(?:\s|$)`)
+
+func parseMakefile(props map[string]string, content []byte) {
+	matches := makeTargetRE.FindAllStringSubmatch(string(content), -1)
+	var targets []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		name := m[1]
+		if name == "" || seen[name] {
+			continue
+		}
+		// Skip the special directives.
+		if strings.HasPrefix(name, ".") {
+			continue
+		}
+		seen[name] = true
+		targets = append(targets, name)
+	}
+	sort.Strings(targets)
+	if len(targets) > 0 {
+		props["scripts"] = capJoin(targets)
+	}
+}
+
+// dockerInstructionRE matches the verb at the start of every effective
+// Dockerfile line. Comments and blank lines are dropped.
+var dockerInstructionRE = regexp.MustCompile(`(?m)^\s*([A-Z][A-Z]+)\s+`)
+
+func parseDockerfile(props map[string]string, content []byte) {
+	src := string(content)
+	matches := dockerInstructionRE.FindAllStringSubmatch(src, -1)
+	var verbs []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		v := m[1]
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		verbs = append(verbs, v)
+	}
+	sort.Strings(verbs)
+	if len(verbs) > 0 {
+		props["keys_top_level"] = capJoin(verbs)
+	}
+	// Capture FROM bases as "dependencies" — they are the build deps.
+	fromRE := regexp.MustCompile(`(?m)^\s*FROM\s+(\S+)`)
+	var froms []string
+	for _, m := range fromRE.FindAllStringSubmatch(src, -1) {
+		froms = append(froms, m[1])
+	}
+	sort.Strings(froms)
+	if len(froms) > 0 {
+		props["dependencies"] = capJoin(froms)
+	}
+}
+
+// jsConfigExportRE matches top-level `export const NAME`, `export default`,
+// `module.exports`, and `defineConfig`-style identifiers.
+var jsConfigExportRE = regexp.MustCompile(`(?m)^(?:export\s+(?:default\s+|const\s+|let\s+|var\s+)|module\.exports\s*=|module\.exports\.)\s*([A-Za-z_$][A-Za-z0-9_$]*)?`)
+
+func parseJSConfig(props map[string]string, content []byte) {
+	matches := jsConfigExportRE.FindAllStringSubmatch(string(content), -1)
+	var keys []string
+	seen := map[string]bool{}
+	for _, m := range matches {
+		k := strings.TrimSpace(m[1])
+		if k == "" || seen[k] {
+			continue
+		}
+		seen[k] = true
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	if len(keys) > 0 {
+		props["keys_top_level"] = capJoin(keys)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+func joinSortedKeys[V any](m map[string]V) string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return capJoin(keys)
+}
+
+// capJoin truncates the slice to maxKeysPerProperty and joins with a comma.
+// When truncation fires, a trailing "+N more" marker is appended so consumers
+// can see that the bag was capped without having to count.
+func capJoin(values []string) string {
+	if len(values) == 0 {
+		return ""
+	}
+	if len(values) <= maxKeysPerProperty {
+		return strings.Join(dedup(values), ",")
+	}
+	head := values[:maxKeysPerProperty]
+	more := len(values) - maxKeysPerProperty
+	return fmt.Sprintf("%s,+%d more", strings.Join(head, ","), more)
+}
+
+// dedup removes duplicates while preserving order.
+func dedup(in []string) []string {
+	seen := map[string]bool{}
+	out := make([]string, 0, len(in))
+	for _, v := range in {
+		if seen[v] {
+			continue
+		}
+		seen[v] = true
+		out = append(out, v)
+	}
+	return out
+}
+
+func sortEntities(es []types.EntityRecord) {
+	sort.SliceStable(es, func(i, j int) bool {
+		if es[i].SourceFile != es[j].SourceFile {
+			return es[i].SourceFile < es[j].SourceFile
+		}
+		return es[i].QualifiedName < es[j].QualifiedName
+	})
+}
+
+func sortRels(rs []types.RelationshipRecord) {
+	sort.SliceStable(rs, func(i, j int) bool {
+		if rs[i].FromID != rs[j].FromID {
+			return rs[i].FromID < rs[j].FromID
+		}
+		if rs[i].ToID != rs[j].ToID {
+			return rs[i].ToID < rs[j].ToID
+		}
+		return rs[i].Kind < rs[j].Kind
+	})
+}

--- a/internal/extractors/config/discover_test.go
+++ b/internal/extractors/config/discover_test.go
@@ -1,0 +1,510 @@
+package config
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/cajasmota/archigraph/internal/types"
+)
+
+// writeFixture writes name relative to dir with content. Helper for tests.
+func writeFixture(t *testing.T, dir, name, content string) {
+	t.Helper()
+	abs := filepath.Join(dir, name)
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", abs, err)
+	}
+	if err := os.WriteFile(abs, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", abs, err)
+	}
+}
+
+func runDiscover(t *testing.T, dir string, files []string) ([]types.EntityRecord, []types.RelationshipRecord) {
+	t.Helper()
+	ents, rels, err := Discover(context.Background(), dir, files)
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	return ents, rels
+}
+
+// findBySource returns the first entity whose SourceFile matches.
+func findBySource(es []types.EntityRecord, source string) *types.EntityRecord {
+	for i := range es {
+		if es[i].SourceFile == source {
+			return &es[i]
+		}
+	}
+	return nil
+}
+
+func TestDiscover_PyProjectToml(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "pyproject.toml", `
+[project]
+name = "client-fixture-de"
+version = "0.1.0"
+dependencies = [
+  "fastapi>=0.110",
+  "pydantic~=2.0",
+  "celery[redis]>=5.3",
+]
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+`)
+	ents, rels := runDiscover(t, dir, []string{"pyproject.toml"})
+	if len(ents) != 1 {
+		t.Fatalf("expected 1 entity, got %d", len(ents))
+	}
+	e := ents[0]
+	if e.Kind != string(types.EntityKindConfig) {
+		t.Errorf("Kind=%q want SCOPE.Config", e.Kind)
+	}
+	if e.Subtype != "python_project" {
+		t.Errorf("Subtype=%q", e.Subtype)
+	}
+	if e.Properties["format"] != "toml" {
+		t.Errorf("format=%q", e.Properties["format"])
+	}
+	deps := e.Properties["dependencies"]
+	for _, want := range []string{"fastapi", "pydantic", "celery"} {
+		if !strings.Contains(deps, want) {
+			t.Errorf("dependencies missing %q: %q", want, deps)
+		}
+	}
+	if len(rels) == 0 {
+		t.Fatalf("expected DEPENDS_ON_CONFIG / CONFIGURES edges")
+	}
+	var sawDepends, sawConfigures bool
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindDependsOnConfig) {
+			sawDepends = true
+		}
+		if r.Kind == string(types.RelationshipKindConfigures) {
+			sawConfigures = true
+		}
+	}
+	if !sawDepends || !sawConfigures {
+		t.Errorf("missing edges: depends=%v configures=%v", sawDepends, sawConfigures)
+	}
+}
+
+func TestDiscover_PackageJSON_ScriptsAndDeps(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "frontend/package.json", `{
+  "name": "client-fixture-de-web",
+  "version": "1.2.3",
+  "scripts": { "dev": "vite", "build": "vite build", "lint": "eslint ." },
+  "dependencies": { "react": "^18.2.0", "react-dom": "^18.2.0" },
+  "devDependencies": { "vite": "^5.0.0", "typescript": "^5.0.0" }
+}`)
+	ents, _ := runDiscover(t, dir, []string{"frontend/package.json"})
+	e := findBySource(ents, "frontend/package.json")
+	if e == nil {
+		t.Fatalf("entity not emitted")
+	}
+	if e.Properties["project_name"] != "client-fixture-de-web" {
+		t.Errorf("project_name=%q", e.Properties["project_name"])
+	}
+	scripts := e.Properties["scripts"]
+	for _, s := range []string{"build", "dev", "lint"} {
+		if !strings.Contains(scripts, s) {
+			t.Errorf("scripts missing %q: %q", s, scripts)
+		}
+	}
+	deps := e.Properties["dependencies"]
+	if !strings.Contains(deps, "react") || !strings.Contains(deps, "vite (dev)") {
+		t.Errorf("dependencies wrong: %q", deps)
+	}
+}
+
+func TestDiscover_PomXML(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "pom.xml", `<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0">
+  <groupId>com.client.fixturede</groupId>
+  <artifactId>fixturede-api</artifactId>
+  <version>0.1.0</version>
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>3.2.0</version>
+    </dependency>
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+    </dependency>
+  </dependencies>
+</project>`)
+	ents, _ := runDiscover(t, dir, []string{"pom.xml"})
+	e := findBySource(ents, "pom.xml")
+	if e == nil {
+		t.Fatalf("pom entity missing")
+	}
+	if e.Subtype != "maven_project" {
+		t.Errorf("subtype=%q", e.Subtype)
+	}
+	if e.Properties["project_name"] != "fixturede-api" {
+		t.Errorf("project_name=%q", e.Properties["project_name"])
+	}
+	deps := e.Properties["dependencies"]
+	if !strings.Contains(deps, "org.springframework.boot:spring-boot-starter-web") {
+		t.Errorf("deps missing spring: %q", deps)
+	}
+	if !strings.Contains(deps, "org.postgresql:postgresql") {
+		t.Errorf("deps missing postgresql: %q", deps)
+	}
+}
+
+func TestDiscover_EnvNeverLeaksValues(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, ".env", `DATABASE_URL=postgres://user:supersecretpassword@host/db
+API_KEY=abcdef-12345-SECRETKEY
+export AWS_SECRET_ACCESS_KEY=very-secret-value
+PORT=8080
+`)
+	writeFixture(t, dir, ".env.production", `STRIPE_KEY=sk_live_DONT_LEAK
+SENTRY_DSN=https://secret@sentry.io/123
+`)
+	ents, _ := runDiscover(t, dir, []string{".env", ".env.production"})
+	if len(ents) != 2 {
+		t.Fatalf("expected 2 env entities, got %d", len(ents))
+	}
+	forbidden := []string{
+		"supersecretpassword",
+		"abcdef-12345-SECRETKEY",
+		"very-secret-value",
+		"sk_live_DONT_LEAK",
+		"https://secret@sentry.io/123",
+		"postgres://",
+		"8080",
+	}
+	for _, e := range ents {
+		if e.Subtype != "env_vars" {
+			t.Errorf("subtype=%q want env_vars", e.Subtype)
+		}
+		if e.Properties["redaction"] != "names_only" {
+			t.Errorf("missing redaction=names_only on %s", e.SourceFile)
+		}
+		// Check every property value for forbidden substrings.
+		for k, v := range e.Properties {
+			for _, bad := range forbidden {
+				if strings.Contains(v, bad) {
+					t.Errorf("SECURITY: env value leaked into Property %q on %s: %q", k, e.SourceFile, v)
+				}
+			}
+		}
+		// Names must be present though.
+		names := e.Properties["keys_top_level"]
+		if !strings.Contains(names, "DATABASE_URL") && !strings.Contains(names, "STRIPE_KEY") {
+			t.Errorf("env names missing on %s: %q", e.SourceFile, names)
+		}
+	}
+}
+
+func TestDiscover_Dockerfile(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "Dockerfile", `FROM python:3.11-slim AS base
+RUN apt-get update && apt-get install -y curl
+COPY . /app
+WORKDIR /app
+ENV PYTHONUNBUFFERED=1
+EXPOSE 8000
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]
+`)
+	writeFixture(t, dir, "Dockerfile.dev", `FROM python:3.11-slim
+RUN pip install pytest
+`)
+	ents, _ := runDiscover(t, dir, []string{"Dockerfile", "Dockerfile.dev"})
+	if len(ents) != 2 {
+		t.Fatalf("expected 2 dockerfile entities, got %d", len(ents))
+	}
+	for _, e := range ents {
+		if e.Subtype != "docker_image" {
+			t.Errorf("subtype=%q", e.Subtype)
+		}
+		if !strings.Contains(e.Properties["dependencies"], "python:3.11-slim") {
+			t.Errorf("FROM not captured in %s: %q", e.SourceFile, e.Properties["dependencies"])
+		}
+	}
+}
+
+func TestDiscover_Makefile(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "Makefile", `.PHONY: build test lint
+
+build:
+	go build ./...
+
+test:
+	go test ./...
+
+lint:
+	golangci-lint run
+
+ci-deploy: build test
+	./scripts/deploy.sh
+`)
+	ents, _ := runDiscover(t, dir, []string{"Makefile"})
+	e := findBySource(ents, "Makefile")
+	if e == nil {
+		t.Fatalf("Makefile entity missing")
+	}
+	scripts := e.Properties["scripts"]
+	for _, want := range []string{"build", "test", "lint", "ci-deploy"} {
+		if !strings.Contains(scripts, want) {
+			t.Errorf("scripts missing %q: %q", want, scripts)
+		}
+	}
+}
+
+func TestDiscover_GoMod(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "go.mod", `module github.com/cajasmota/example
+
+go 1.22
+
+require (
+	github.com/spf13/cobra v1.8.0
+	github.com/stretchr/testify v1.9.0
+)
+
+require github.com/google/uuid v1.5.0
+`)
+	ents, _ := runDiscover(t, dir, []string{"go.mod"})
+	e := findBySource(ents, "go.mod")
+	if e == nil {
+		t.Fatalf("go.mod entity missing")
+	}
+	if e.Properties["project_name"] != "github.com/cajasmota/example" {
+		t.Errorf("project_name=%q", e.Properties["project_name"])
+	}
+	deps := e.Properties["dependencies"]
+	for _, want := range []string{"github.com/spf13/cobra", "github.com/stretchr/testify", "github.com/google/uuid"} {
+		if !strings.Contains(deps, want) {
+			t.Errorf("deps missing %q: %q", want, deps)
+		}
+	}
+}
+
+func TestDiscover_BuildGradle(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "build.gradle", `plugins {
+    id 'org.springframework.boot' version '3.2.0'
+    id 'java'
+}
+
+dependencies {
+    implementation 'org.springframework.boot:spring-boot-starter-web'
+    implementation "org.postgresql:postgresql:42.7.0"
+    testImplementation 'org.junit.jupiter:junit-jupiter:5.10.0'
+}
+`)
+	ents, _ := runDiscover(t, dir, []string{"build.gradle"})
+	e := findBySource(ents, "build.gradle")
+	if e == nil {
+		t.Fatalf("build.gradle entity missing")
+	}
+	deps := e.Properties["dependencies"]
+	if !strings.Contains(deps, "spring-boot-starter-web") {
+		t.Errorf("deps missing spring: %q", deps)
+	}
+	plugins := e.Properties["plugins"]
+	if !strings.Contains(plugins, "org.springframework.boot") {
+		t.Errorf("plugins missing: %q", plugins)
+	}
+}
+
+func TestDiscover_ApplicationProperties(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "src/main/resources/application.properties", `server.port=8080
+spring.datasource.url=jdbc:postgresql://localhost/db
+spring.jpa.hibernate.ddl-auto=update
+`)
+	ents, _ := runDiscover(t, dir, []string{"src/main/resources/application.properties"})
+	e := findBySource(ents, "src/main/resources/application.properties")
+	if e == nil {
+		t.Fatalf("entity missing")
+	}
+	if e.Subtype != "spring_properties" {
+		t.Errorf("subtype=%q", e.Subtype)
+	}
+	keys := e.Properties["keys_top_level"]
+	for _, want := range []string{"server.port", "spring.datasource.url"} {
+		if !strings.Contains(keys, want) {
+			t.Errorf("keys missing %q: %q", want, keys)
+		}
+	}
+}
+
+func TestDiscover_NonConfigFilesIgnored(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "src/main.go", `package main`)
+	writeFixture(t, dir, "src/lib.py", `def f(): pass`)
+	writeFixture(t, dir, "README.md", `hello`)
+	ents, _ := runDiscover(t, dir, []string{"src/main.go", "src/lib.py", "README.md"})
+	if len(ents) != 0 {
+		t.Errorf("expected 0 entities, got %d (%v)", len(ents), ents)
+	}
+}
+
+func TestDiscover_RequirementsVariants(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "requirements.txt", "requests\nfastapi>=0.110\n")
+	writeFixture(t, dir, "requirements-dev.txt", "pytest\nblack\n")
+	writeFixture(t, dir, "requirements-test.txt", "pytest-mock\n")
+	ents, _ := runDiscover(t, dir, []string{
+		"requirements.txt", "requirements-dev.txt", "requirements-test.txt",
+	})
+	if len(ents) != 3 {
+		t.Fatalf("expected 3 entities, got %d", len(ents))
+	}
+	got := map[string]string{}
+	for _, e := range ents {
+		got[e.SourceFile] = e.Properties["dependencies"]
+	}
+	if !strings.Contains(got["requirements-dev.txt"], "pytest") {
+		t.Errorf("dev: %q", got["requirements-dev.txt"])
+	}
+}
+
+func TestDiscover_DeterministicOrder(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "a/package.json", `{"name":"a"}`)
+	writeFixture(t, dir, "b/package.json", `{"name":"b"}`)
+	writeFixture(t, dir, "c/Dockerfile", "FROM alpine\n")
+	files := []string{"c/Dockerfile", "a/package.json", "b/package.json"}
+	ents1, rels1 := runDiscover(t, dir, files)
+	// Shuffle input order; output must remain identical.
+	files2 := []string{"b/package.json", "c/Dockerfile", "a/package.json"}
+	ents2, rels2 := runDiscover(t, dir, files2)
+	if len(ents1) != len(ents2) || len(rels1) != len(rels2) {
+		t.Fatalf("len mismatch")
+	}
+	for i := range ents1 {
+		if ents1[i].QualifiedName != ents2[i].QualifiedName {
+			t.Errorf("entity order drift at %d: %q vs %q", i, ents1[i].QualifiedName, ents2[i].QualifiedName)
+		}
+	}
+	for i := range rels1 {
+		if rels1[i].FromID != rels2[i].FromID || rels1[i].ToID != rels2[i].ToID {
+			t.Errorf("rel order drift at %d", i)
+		}
+	}
+}
+
+func TestClassify_KnownBasenames(t *testing.T) {
+	cases := []struct {
+		path    string
+		subtype string
+	}{
+		{"pyproject.toml", "python_project"},
+		{"setup.cfg", "python_project_legacy"},
+		{"requirements.txt", "python_requirements"},
+		{"requirements-dev.txt", "python_requirements"},
+		{".env", "env_vars"},
+		{".env.local", "env_vars"},
+		{"pom.xml", "maven_project"},
+		{"build.gradle", "gradle_project"},
+		{"build.gradle.kts", "gradle_project"},
+		{"application.properties", "spring_properties"},
+		{"application.yml", "spring_yaml"},
+		{"application.yaml", "spring_yaml"},
+		{"package.json", "node_project"},
+		{"tsconfig.json", "typescript_project"},
+		{"vite.config.ts", "vite_config"},
+		{"next.config.js", "next_config"},
+		{".eslintrc.json", "eslint_config"},
+		{".prettierrc", "prettier_config"},
+		{"go.mod", "go_module"},
+		{"Makefile", "makefile"},
+		{"Dockerfile", "docker_image"},
+		{"Dockerfile.dev", "docker_image"},
+		{"docker-compose.yml", "docker_compose"},
+		{"quarkus.properties", "quarkus_properties"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path, func(t *testing.T) {
+			spec, ok := classify(tc.path)
+			if !ok {
+				t.Fatalf("classify(%q) returned false", tc.path)
+			}
+			if spec.subtype != tc.subtype {
+				t.Errorf("subtype=%q want %q", spec.subtype, tc.subtype)
+			}
+		})
+	}
+}
+
+func TestClassify_IgnoredFiles(t *testing.T) {
+	for _, p := range []string{
+		"src/main.go",
+		".envrc",          // direnv — not an env file
+		"poetry.lock",     // skip per issue
+		".gitignore",      // explicitly skipped
+		"foo.txt",
+		"random.json",
+	} {
+		t.Run(p, func(t *testing.T) {
+			if _, ok := classify(p); ok {
+				t.Errorf("%q should NOT classify as config", p)
+			}
+		})
+	}
+}
+
+func TestDiscover_KeyCapMarker(t *testing.T) {
+	// Generate a Makefile with many targets to confirm the +N more marker.
+	var b strings.Builder
+	for i := 0; i < maxKeysPerProperty+10; i++ {
+		// target names "tg000", "tg001", … to keep them sortable.
+		b.WriteString("tg")
+		b.WriteString(padInt(i))
+		b.WriteString(":\n\techo\n")
+	}
+	dir := t.TempDir()
+	writeFixture(t, dir, "Makefile", b.String())
+	ents, _ := runDiscover(t, dir, []string{"Makefile"})
+	if len(ents) != 1 {
+		t.Fatalf("len=%d", len(ents))
+	}
+	scripts := ents[0].Properties["scripts"]
+	if !strings.Contains(scripts, "+10 more") {
+		t.Errorf("expected '+10 more' marker, got %q", scripts)
+	}
+}
+
+func padInt(n int) string {
+	s := []byte{'0', '0', '0'}
+	for i := 2; n > 0 && i >= 0; i-- {
+		s[i] = byte('0' + n%10)
+		n /= 10
+	}
+	return string(s)
+}
+
+// TestDiscover_EdgeFromDirToConfig confirms the DEPENDS_ON_CONFIG edge
+// FromID matches the file's containing directory (module structural ref).
+func TestDiscover_EdgeFromDirToConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFixture(t, dir, "services/api/pyproject.toml", `[project]
+name = "api"
+`)
+	_, rels := runDiscover(t, dir, []string{"services/api/pyproject.toml"})
+	var froms []string
+	for _, r := range rels {
+		if r.Kind == string(types.RelationshipKindDependsOnConfig) {
+			froms = append(froms, r.FromID)
+		}
+	}
+	sort.Strings(froms)
+	if len(froms) != 1 || froms[0] != "module:services/api" {
+		t.Errorf("DEPENDS_ON_CONFIG FromIDs = %v, want [module:services/api]", froms)
+	}
+}

--- a/internal/types/kinds.go
+++ b/internal/types/kinds.go
@@ -390,6 +390,19 @@ const (
 	// SUBSCRIBES_TO edges attach to the same MessageTopic node without
 	// any cross-pass handoff.
 	RelationshipKindCaptures RelationshipKind = "CAPTURES"
+
+	// #1885: First-class config-entity edges. Emitted by the
+	// internal/extractors/config discovery pass for project-level config
+	// files (Dockerfile, Makefile, pyproject.toml, package.json, pom.xml,
+	// build.gradle, application.properties, .env, …).
+	//
+	//   DEPENDS_ON_CONFIG : Module / file entity → SCOPE.Config entity
+	//                       (the module is configured by the linked Config).
+	//   CONFIGURES        : SCOPE.Config → consumer module (best-effort
+	//                       directional inverse; emitted only when the
+	//                       config's directory contains downstream modules).
+	RelationshipKindDependsOnConfig RelationshipKind = "DEPENDS_ON_CONFIG"
+	RelationshipKindConfigures      RelationshipKind = "CONFIGURES"
 )
 
 // AllRelationshipKinds returns every RelationshipKind producers may emit.
@@ -464,6 +477,9 @@ func AllRelationshipKinds() []RelationshipKind {
 		RelationshipKindRegisters,
 		// #1708 Debezium / Kafka-Connect CDC connector:
 		RelationshipKindCaptures,
+		// #1885 first-class config entities:
+		RelationshipKindDependsOnConfig,
+		RelationshipKindConfigures,
 	}
 }
 


### PR DESCRIPTION
## What

Closes #1885 (Wave 1 tail of #1890 docgen-quality plan). Project-level configuration files become first-class `SCOPE.Config` entities in the graph, so docgen can ground `reference-config` / `reference-deployment` / `reference-scripts` sections from authoritative graph data instead of inference.

Stacks with #1875 (sectionsByKind), #1880 (Module source_window), #1884 (Module-per-package). Wave 2 of #1890 (Module typed buckets, NeighbourBrief.TypeHint, Module README + pyproject embedding) all depend on the entities this PR introduces.

Recognised file families:

```
Python    pyproject.toml, setup.cfg, setup.py, requirements*.txt, Pipfile,
          .flake8, mypy.ini, pytest.ini, tox.ini, .env / .env.*
Java      pom.xml, build.gradle, build.gradle.kts,
          application.properties, application.yml/.yaml, quarkus.properties
JS/TS     package.json, tsconfig.json, vite.config.*, next.config.*,
          .eslintrc.*, .prettierrc.*, .env / .env.*
Go        go.mod, go.sum (existence only), Makefile / GNUmakefile
General   Dockerfile / Dockerfile.* / Containerfile,
          docker-compose.yml / docker-compose.yaml
Skipped   poetry.lock (body), go.sum (body), .gitignore  (per issue spec)
```

## Why

The R4 dogfood round on 2026-05-23 found `reference-deployment` and `reference-scripts` had essentially zero graph evidence to ground them — docgen could only infer Celery+ASGI/WSGI topology from settings imports because the underlying Dockerfile / Makefile / pyproject files were not graph citizens. With these entities in place, Module-aggregate pages get real scripts sections backed by Makefile targets, deployment sections backed by Dockerfile FROMs, and dependency sections backed by parsed manifests — and the docker-compose ↔ Dockerfile pair becomes a queryable deployment relationship.

`#1778` already added the supplemental-pass entity-emission pattern for Python `settings.py`/`urls.py` (the `config_module` subtype). This PR generalises the pattern across languages and file shapes — without touching `internal/extractors/python/config_module.go` so no duplicates are emitted.

## Changes

**New package `internal/extractors/config/`** — supplemental discovery pass that walks the *pre-classification* file list. Necessary because the language classifier intentionally drops many of these basenames (`Makefile`, `.env`, `application.properties`, `pom.xml`, etc.) and so they never reach the Pass 3 cross-language extractors.

- `discover.go` — `Discover(ctx, repoRoot, files []string) ([]EntityRecord, []RelationshipRecord, error)`. Per-file classifier (`exactBasenames` map + regex matchers for `requirements*.txt`, `Dockerfile.*`, `.env.*`, JS config variants) plus per-format parsers: TOML, JSON, XML, YAML, properties, INI, env, Dockerfile, Makefile, go.mod, build.gradle, requirements, JS config.
- Emitted entity: `Kind=SCOPE.Config`, `Subtype=<per-file>` (python_project, node_project, maven_project, gradle_project, spring_properties, env_vars, docker_image, docker_compose, makefile, go_module, vite_config, eslint_config, prettier_config, …). Properties: `format`, `keys_top_level`, `dependencies`, `scripts`, `project_name`, `project_version`, `plugins`, `group_id`, `redaction`.
- Edges emitted: `DEPENDS_ON_CONFIG` from `module:<dir>` to the config entity, and the directional inverse `CONFIGURES` from the config to its module. The intra-repo resolver rebinds `module:<dir>` to the real Module entity emitted by #1884.

**`internal/types/kinds.go`** — adds two new `RelationshipKind` constants (`DEPENDS_ON_CONFIG`, `CONFIGURES`) and registers them in `AllRelationshipKinds()`. `EntityKindConfig = "SCOPE.Config"` already existed.

**`cmd/archigraph/index.go`** — new Pass 3.5 (in-process path) between the classified-file passes and Pass 2.6 (Django URLconf). Operates on `allFiles` (the pre-incremental, pre-classification slice) so re-runs keep Config entities even when no source file changed. Failures are non-fatal — config signal is supplemental.

**`internal/daemon/extract/coordinator.go`** — runs `config.Discover` in-process inside the coordinator after subprocess fan-out completes. The discovery pass is single-pass and cheap; it does not warrant its own subprocess, and it must see files the per-language buckets dropped.

**Idempotence & determinism**: stable synthetic IDs (`scope:config:<subtype>:<relpath>`), entities and relationships sorted before return, file reads capped at 256 KiB, per-property key cap of 64 entries with `+N more` truncation marker.

## Security

`.env` and `.env.*` parsing records env-variable **NAMES ONLY**. Values are discarded before they enter the graph; the Property bag carries `redaction=names_only` as an audit marker. The regex `envVarRE = ^\s*(?:export\s+)?([A-Z_][A-Z0-9_]*)\s*=` deliberately has a single capture group — the name — and never returns the right-hand side.

Two regression tests assert the boundary:

- `internal/extractors/config/discover_test.go::TestDiscover_EnvNeverLeaksValues` — feeds the parser realistic secrets (`API_KEY=abcdef-12345-SECRETKEY`, `AWS_SECRET_ACCESS_KEY=very-secret-value`, `STRIPE_KEY=sk_live_DONT_LEAK`, `postgres://user:supersecretpassword@host/db`) and scans every emitted Property value for any of those substrings. Test fails on any leak.
- `internal/daemon/extract/coordinator_test.go::TestCoordinate_EmitsConfigEntities` — same scan but through the full coordinator + subprocess fan-out path.

## Tests

- `internal/extractors/config/discover_test.go` — 14 tests covering pyproject.toml dependency extraction (PEP 621 + poetry forms), package.json scripts + deps, pom.xml Maven deps + project coordinates, Dockerfile FROM capture + multi-variant matching, Makefile target capture excluding `.PHONY`, go.mod block + single-line require parsing, build.gradle dep + plugin extraction, application.properties key extraction, `requirements*.txt` variant matching, deterministic ordering under shuffled input, classify-map coverage, ignored-file negative cases (`.envrc`, `poetry.lock`, `.gitignore`, plain source files), the `+N more` key-cap marker, the `module:<dir>` edge-FromID shape, and the env-value security boundary.
- `internal/daemon/extract/coordinator_test.go::TestCoordinate_EmitsConfigEntities` — end-to-end through the subprocess fan-out + in-coordinator discovery, asserting `go.mod` / `Makefile` / `.env` entities all land and no env value leaks.

All new tests green. Pre-existing `TestModuleCoverage_AllEntitiesTagged` failure is unchanged from `origin/main` (110 entities missing `Properties["module"]` across all four fixtures — unrelated to this PR; reproduced on bare `00584ef1`).

## Verification

```
go build ./...                                                       # clean
go vet ./...                                                          # clean
go test -count=1 ./internal/extractors/config/                        # PASS
go test -count=1 ./internal/types/                                    # PASS
go test -count=1 ./internal/daemon/extract/                           # PASS (incl. new TestCoordinate_EmitsConfigEntities)
```

Manual MCP verification path (after daemon picks up the new binary):

```
archigraph rebuild archigraph
archigraph_inspect entity_id=scope:config:go_module:go.mod
  → Properties.format=go_mod, Properties.dependencies populated
archigraph_inspect entity_id=scope:config:makefile:Makefile
  → Properties.scripts populated with target names

archigraph rebuild client-fixture-de
archigraph_inspect entity_id=scope:config:maven_project:pom.xml
  → Properties.project_name, Properties.dependencies populated
archigraph_inspect entity_id=scope:config:node_project:<rel>/package.json
  → Properties.scripts, Properties.dependencies populated
```

## No unrelated changes

Only:
- `internal/extractors/config/` (new package)
- `internal/types/kinds.go` (two new edge kinds + AllRelationshipKinds entry)
- `cmd/archigraph/index.go` (one import + new Pass 3.5 block; nothing else moved)
- `internal/daemon/extract/coordinator.go` (one import + Discover call before sort)
- `internal/daemon/extract/coordinator_test.go` (new integration test)

No drive-by reformat, no touched extractors, no dashboard / webui-v2 changes, no schema migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
