### PR TITLE
feat(docgen): class manifest in LLM bundle (methods, fields, bases, decorators) (#1861)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -29,9 +29,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"time"
 
+	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/mcp"
 )
 
@@ -113,7 +115,85 @@ type LLMGraphContext struct {
 	// SourceWindow is an optional excerpt of source lines around the entity
 	// (populated by future --source-window flag; empty in foundation ticket).
 	SourceWindow string `json:"source_window,omitempty"`
+	// ClassManifest is a structured enumeration of the class's surface area:
+	// methods, fields, bases, interfaces, and decorators/annotations. Populated
+	// only when the seed entity is class-like (Class, Component, Controller,
+	// Service, Model, View, etc.). Nil for non-class seeds. (#1861)
+	ClassManifest *ClassManifest `json:"class_manifest,omitempty"`
 }
+
+// ClassManifest is a structured enumeration of a class entity's public
+// surface area. It lets the LLM cite specific methods and fields by name
+// without re-parsing the source_window. Populated by BuildBundle when the
+// seed entity is class-like (#1861).
+type ClassManifest struct {
+	// Methods is the list of method/constructor entries found via CONTAINS edges.
+	// Capped at ClassManifestMaxMethods; see MethodsTruncatedCount.
+	Methods []ClassMethodEntry `json:"methods,omitempty"`
+	// MethodsTruncatedCount is the number of methods omitted because the class
+	// exceeded ClassManifestMaxMethods. Zero when no truncation occurred.
+	MethodsTruncatedCount int `json:"methods_truncated_count,omitempty"`
+	// Fields is the list of field/attribute entries found via CONTAINS edges.
+	// Capped at ClassManifestMaxFields; see FieldsTruncatedCount.
+	Fields []ClassFieldEntry `json:"fields,omitempty"`
+	// FieldsTruncatedCount is the number of fields omitted because the class
+	// exceeded ClassManifestMaxFields. Zero when no truncation occurred.
+	FieldsTruncatedCount int `json:"fields_truncated_count,omitempty"`
+	// Bases is the list of parent class names (EXTENDS edge targets).
+	Bases []string `json:"bases,omitempty"`
+	// Interfaces is the list of implemented interface names (IMPLEMENTS edge targets).
+	Interfaces []string `json:"interfaces,omitempty"`
+	// Decorators is the list of decorator/annotation names found on the class
+	// entity (e.g. "@Component", "@Path", "@dataclass"). Parsed from the entity
+	// Signature and from SCOPE.Pattern decorator neighbours. Deduped.
+	Decorators []string `json:"decorators,omitempty"`
+}
+
+// ClassMethodEntry describes a single method or constructor of a class.
+type ClassMethodEntry struct {
+	// Name is the short method name (without the enclosing class prefix).
+	Name string `json:"name"`
+	// Signature is the full method signature as stored by the extractor
+	// (e.g. "public String login(String username, String password)").
+	Signature string `json:"signature,omitempty"`
+	// Visibility is "public", "private", "protected", or "" (unknown).
+	// Inferred from the Signature text on a best-effort basis.
+	Visibility string `json:"visibility,omitempty"`
+	// IsStatic is true when the entity carries Properties["is_static"]="true".
+	IsStatic bool `json:"is_static,omitempty"`
+	// Subtype is the extractor subtype: "method", "constructor", or "".
+	Subtype string `json:"subtype,omitempty"`
+	// StartLine is the first line of the method body (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+	// EndLine is the last line of the method body (1-indexed). May be 0 when
+	// the extractor did not resolve the end line.
+	EndLine int `json:"end_line,omitempty"`
+}
+
+// ClassFieldEntry describes a single field or attribute of a class.
+type ClassFieldEntry struct {
+	// Name is the short field name (without the enclosing class prefix).
+	Name string `json:"name"`
+	// TypeHint is the declared type of the field as inferred from the Signature
+	// (e.g. "UserRepository", "str", "List<String>"). Empty when not available.
+	TypeHint string `json:"type_hint,omitempty"`
+	// DefaultValue is the literal default value when the extractor captured one.
+	// Empty for computed or unknown defaults.
+	DefaultValue string `json:"default_value,omitempty"`
+	// Visibility is "public", "private", "protected", or "" (unknown).
+	Visibility string `json:"visibility,omitempty"`
+	// StartLine is the line where the field is declared (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+}
+
+// ClassManifestMaxMethods is the cap on the number of method entries in a
+// ClassManifest. Classes with more methods will have the excess counted in
+// ClassManifest.MethodsTruncatedCount.
+const ClassManifestMaxMethods = 100
+
+// ClassManifestMaxFields is the cap on the number of field entries in a
+// ClassManifest.
+const ClassManifestMaxFields = 100
 
 // NeighbourBrief is a compact description of a single 1-hop neighbour entity.
 type NeighbourBrief struct {
@@ -428,6 +508,14 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 				gc.SourceWindow = sw
 			}
 		}
+
+		// Populate ClassManifest when the seed entity is class-like (#1861).
+		// Walk the neighbours collected above to build a structured enumeration
+		// of methods, fields, bases, interfaces, and decorators without requiring
+		// the LLM to re-parse the source_window.
+		if isClassLikeKind(entity.Kind) {
+			gc.ClassManifest = buildClassManifest(entity, neighbours, neighbourKinds)
+		}
 	}
 
 	// Determine section list and profile (profile carries per-kind guidance overrides).
@@ -544,6 +632,214 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 	}
 
 	return bundle, nil
+}
+
+// ---------------------------------------------------------------------------
+// ClassManifest helpers (#1861)
+// ---------------------------------------------------------------------------
+
+// decoratorTokenRE matches @Identifier patterns in a signature string.
+// Used to extract class-level annotations / decorators.
+var decoratorTokenRE = regexp.MustCompile(`@([A-Za-z_]\w*)`)
+
+// isClassLikeKind returns true when the entity kind represents a class-like
+// construct that should have a ClassManifest populated. The check is
+// case-insensitive and handles both bare kind strings ("Class", "component")
+// and SCOPE.* prefixed forms ("SCOPE.Component", "SCOPE.Class").
+//
+// Class-like kinds: Class, Component, Controller, Service, Model, View,
+// UIComponent, and their SCOPE.* variants. Deliberately excludes Operation,
+// Function, Module, Schema, and other leaf-or-file-level kinds.
+func isClassLikeKind(kind string) bool {
+	k := strings.ToLower(kind)
+	// Strip "scope." prefix for uniform matching.
+	k = strings.TrimPrefix(k, "scope.")
+	switch {
+	case k == "class",
+		k == "component",
+		k == "uicomponent",
+		k == "controller",
+		k == "service",
+		k == "model",
+		k == "view":
+		return true
+	}
+	// Substring matches for compound kinds (e.g. "datamodel", "viewcontroller").
+	for _, sub := range []string{"class", "component", "controller", "service", "model"} {
+		if strings.Contains(k, sub) {
+			return true
+		}
+	}
+	return false
+}
+
+// shortName strips an enclosing class prefix "ClassName.memberName" → "memberName".
+// If the name has no dot it is returned as-is.
+func shortName(name string) string {
+	if idx := strings.LastIndex(name, "."); idx >= 0 {
+		return name[idx+1:]
+	}
+	return name
+}
+
+// inferVisibility reads the visibility modifier from a method/field signature
+// on a best-effort basis. Returns "public", "private", "protected", or "".
+func inferVisibility(sig string) string {
+	lower := strings.ToLower(sig)
+	switch {
+	case strings.HasPrefix(lower, "private ") || strings.Contains(lower, " private "):
+		return "private"
+	case strings.HasPrefix(lower, "protected ") || strings.Contains(lower, " protected "):
+		return "protected"
+	case strings.HasPrefix(lower, "public ") || strings.Contains(lower, " public "):
+		return "public"
+	}
+	return ""
+}
+
+// typeHintFromSignature extracts the declared type from a field signature.
+// Field signatures are typically "TypeName fieldName" or just "fieldName: TypeName".
+// Returns an empty string when no type can be inferred.
+func typeHintFromSignature(sig string) string {
+	sig = strings.TrimSpace(sig)
+	if sig == "" {
+		return ""
+	}
+	// TypeScript / Python style: "fieldName: TypeName"
+	if idx := strings.Index(sig, ":"); idx >= 0 {
+		return strings.TrimSpace(sig[idx+1:])
+	}
+	// Java / C# style: "TypeName fieldName" (space-separated, first token is type).
+	// Strip modifiers first.
+	for _, mod := range []string{"private ", "public ", "protected ", "static ", "final ", "readonly "} {
+		sig = strings.ReplaceAll(sig, mod, "")
+	}
+	sig = strings.TrimSpace(sig)
+	parts := strings.Fields(sig)
+	if len(parts) >= 2 {
+		// First token is the type, last is the name.
+		return parts[0]
+	}
+	return ""
+}
+
+// buildClassManifest constructs a ClassManifest for the seed entity by
+// inspecting the neighbours slice (already loaded by loadEntityContext) and
+// the neighbourKinds slice (edge kinds, index-aligned with neighbours).
+//
+// It collects:
+//   - Method entries: CONTAINS neighbours with Kind=="SCOPE.Operation"
+//   - Field entries:  CONTAINS neighbours with Kind=="SCOPE.Schema" and Subtype=="field"
+//   - Bases:          EXTENDS neighbours
+//   - Interfaces:     IMPLEMENTS neighbours
+//   - Decorators:     parsed from entity.Signature and from SCOPE.Pattern decorator neighbours
+func buildClassManifest(entity *graph.Entity, neighbours []graph.Entity, neighbourKinds []string) *ClassManifest {
+	if entity == nil {
+		return nil
+	}
+
+	m := &ClassManifest{}
+
+	// --- Decorators from class entity Signature ---
+	if entity.Signature != "" {
+		seen := map[string]bool{}
+		for _, match := range decoratorTokenRE.FindAllString(entity.Signature, -1) {
+			if !seen[match] {
+				seen[match] = true
+				m.Decorators = append(m.Decorators, match)
+			}
+		}
+	}
+
+	// Track whether we've added a decorator name (for dedup across sources).
+	decoratorSeen := map[string]bool{}
+	for _, d := range m.Decorators {
+		decoratorSeen[d] = true
+	}
+
+	// Walk 1-hop neighbours.
+	totalMethods := 0
+	totalFields := 0
+	for i, n := range neighbours {
+		rel := ""
+		if i < len(neighbourKinds) {
+			rel = neighbourKinds[i]
+		}
+
+		switch rel {
+		case "CONTAINS":
+			lkind := strings.ToLower(n.Kind)
+			isMethod := strings.Contains(lkind, "operation") &&
+				(n.Subtype == "method" || n.Subtype == "constructor" || n.Subtype == "")
+			isField := strings.Contains(lkind, "schema") && n.Subtype == "field"
+
+			if isMethod {
+				totalMethods++
+				if totalMethods <= ClassManifestMaxMethods {
+					entry := ClassMethodEntry{
+						Name:      shortName(n.Name),
+						Signature: n.Signature,
+						Subtype:   n.Subtype,
+						StartLine: n.StartLine,
+						EndLine:   n.EndLine,
+					}
+					if n.Properties != nil && n.Properties["is_static"] == "true" {
+						entry.IsStatic = true
+					}
+					entry.Visibility = inferVisibility(n.Signature)
+					m.Methods = append(m.Methods, entry)
+				}
+			} else if isField {
+				totalFields++
+				if totalFields <= ClassManifestMaxFields {
+					entry := ClassFieldEntry{
+						Name:      shortName(n.Name),
+						TypeHint:  typeHintFromSignature(n.Signature),
+						StartLine: n.StartLine,
+					}
+					entry.Visibility = inferVisibility(n.Signature)
+					m.Fields = append(m.Fields, entry)
+				}
+			}
+
+		case "EXTENDS":
+			m.Bases = append(m.Bases, shortName(n.Name))
+
+		case "IMPLEMENTS":
+			m.Interfaces = append(m.Interfaces, shortName(n.Name))
+		}
+
+		// Decorator pattern entities: SCOPE.Pattern with subtype "decorator"
+		// that target this class (Properties["target_name"] matches class name).
+		if strings.Contains(strings.ToLower(n.Kind), "pattern") &&
+			strings.ToLower(n.Subtype) == "decorator" {
+			if dn, ok := n.Properties["decorator_name"]; ok && dn != "" {
+				token := "@" + dn
+				if !decoratorSeen[token] {
+					decoratorSeen[token] = true
+					m.Decorators = append(m.Decorators, token)
+				}
+			}
+		}
+	}
+
+	// Record truncation counts.
+	if totalMethods > ClassManifestMaxMethods {
+		m.MethodsTruncatedCount = totalMethods - ClassManifestMaxMethods
+	}
+	if totalFields > ClassManifestMaxFields {
+		m.FieldsTruncatedCount = totalFields - ClassManifestMaxFields
+	}
+
+	// Return nil manifest when no data was collected (e.g. class with no
+	// child entities in the graph and no signature annotations) — this keeps
+	// the JSON output clean for entities whose extractors haven't been run yet.
+	if len(m.Methods) == 0 && len(m.Fields) == 0 &&
+		len(m.Bases) == 0 && len(m.Interfaces) == 0 && len(m.Decorators) == 0 {
+		return nil
+	}
+
+	return m
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/docgen/llm_bundle_class_manifest_test.go
+++ b/internal/docgen/llm_bundle_class_manifest_test.go
@@ -1,0 +1,637 @@
+package docgen_test
+
+// llm_bundle_class_manifest_test.go — unit tests for the ClassManifest field
+// populated by BuildBundle when the seed entity is class-like (#1861).
+//
+// Each test sets up an isolated in-memory group (via env overrides), writes a
+// graph.json with class + child entities and CONTAINS/EXTENDS/IMPLEMENTS edges,
+// and asserts that bundle.GraphContext.ClassManifest is correctly populated.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+// classManifestHarness creates an isolated test environment with a class entity
+// that has method children (CONTAINS), a base class (EXTENDS), interfaces
+// (IMPLEMENTS), and annotations in the Signature.
+//
+// Returns the groupName, class entity ID, and a cleanup func.
+func classManifestHarness(t *testing.T) (groupName, classEntityID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "class-manifest-test-group"
+
+	// Write fleet config.
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Build entity IDs.
+	classID := graph.EntityID("repo", "SCOPE.Component", "AuthService", "src/auth.java")
+	methodLoginID := graph.EntityID("repo", "SCOPE.Operation", "AuthService.login", "src/auth.java")
+	methodLogoutID := graph.EntityID("repo", "SCOPE.Operation", "AuthService.logout", "src/auth.java")
+	fieldRepoID := graph.EntityID("repo", "SCOPE.Schema", "AuthService.userRepository", "src/auth.java")
+	baseClassID := graph.EntityID("repo", "SCOPE.Component", "BaseService", "src/base.java")
+	ifaceID := graph.EntityID("repo", "SCOPE.Component", "Authenticator", "src/auth.java")
+
+	// Write graph.json.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Stats:          graph.Stats{Files: 1, Entities: 6, Relationships: 4},
+		Entities: []graph.Entity{
+			{
+				ID:         classID,
+				Name:       "AuthService",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				SourceFile: "src/auth.java",
+				StartLine:  5,
+				EndLine:    50,
+				Language:   "java",
+				// Annotations in Signature — as emitted by buildClassSignature.
+				Signature: "@Service @Transactional class AuthService",
+			},
+			{
+				ID:         methodLoginID,
+				Name:       "AuthService.login",
+				Kind:       "SCOPE.Operation",
+				Subtype:    "method",
+				SourceFile: "src/auth.java",
+				StartLine:  10,
+				EndLine:    20,
+				Language:   "java",
+				Signature:  "public String login(String username, String password)",
+			},
+			{
+				ID:         methodLogoutID,
+				Name:       "AuthService.logout",
+				Kind:       "SCOPE.Operation",
+				Subtype:    "method",
+				SourceFile: "src/auth.java",
+				StartLine:  22,
+				EndLine:    28,
+				Language:   "java",
+				Signature:  "public void logout(String token)",
+			},
+			{
+				ID:         fieldRepoID,
+				Name:       "AuthService.userRepository",
+				Kind:       "SCOPE.Schema",
+				Subtype:    "field",
+				SourceFile: "src/auth.java",
+				StartLine:  7,
+				Language:   "java",
+				Signature:  "UserRepository userRepository",
+			},
+			{
+				ID:         baseClassID,
+				Name:       "BaseService",
+				Kind:       "SCOPE.Component",
+				Subtype:    "class",
+				SourceFile: "src/base.java",
+				StartLine:  1,
+				Language:   "java",
+			},
+			{
+				ID:         ifaceID,
+				Name:       "Authenticator",
+				Kind:       "SCOPE.Component",
+				Subtype:    "interface",
+				SourceFile: "src/auth.java",
+				StartLine:  1,
+				Language:   "java",
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID:     graph.RelationshipID(classID, methodLoginID, "CONTAINS"),
+				FromID: classID,
+				ToID:   methodLoginID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(classID, methodLogoutID, "CONTAINS"),
+				FromID: classID,
+				ToID:   methodLogoutID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(classID, fieldRepoID, "CONTAINS"),
+				FromID: classID,
+				ToID:   fieldRepoID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(classID, baseClassID, "EXTENDS"),
+				FromID: classID,
+				ToID:   baseClassID,
+				Kind:   "EXTENDS",
+			},
+			{
+				ID:     graph.RelationshipID(classID, ifaceID, "IMPLEMENTS"),
+				FromID: classID,
+				ToID:   ifaceID,
+				Kind:   "IMPLEMENTS",
+			},
+		},
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, classID
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestBuildBundle_ClassManifest_Populated verifies that BuildBundle sets
+// graph_context.class_manifest (non-nil) when the seed entity is class-like.
+func TestBuildBundle_ClassManifest_Populated(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if bundle.GraphContext.ClassManifest == nil {
+		t.Fatal("graph_context.class_manifest is nil — expected non-nil for class-like seed entity")
+	}
+}
+
+// TestBuildBundle_ClassManifest_Methods verifies that methods discovered via
+// CONTAINS edges appear in ClassManifest.Methods with correct fields.
+func TestBuildBundle_ClassManifest_Methods(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	// Expect exactly 2 methods: login and logout.
+	if len(m.Methods) != 2 {
+		t.Errorf("expected 2 methods, got %d: %+v", len(m.Methods), m.Methods)
+	}
+
+	// Find the "login" method.
+	var loginEntry *docgen.ClassMethodEntry
+	for i := range m.Methods {
+		if m.Methods[i].Name == "login" {
+			loginEntry = &m.Methods[i]
+			break
+		}
+	}
+	if loginEntry == nil {
+		t.Fatal("method 'login' not found in ClassManifest.Methods")
+	}
+	if loginEntry.Signature == "" {
+		t.Error("login entry has empty Signature")
+	}
+	if loginEntry.Visibility != "public" {
+		t.Errorf("login visibility: got %q, want %q", loginEntry.Visibility, "public")
+	}
+	if loginEntry.StartLine != 10 {
+		t.Errorf("login StartLine: got %d, want 10", loginEntry.StartLine)
+	}
+	if loginEntry.EndLine != 20 {
+		t.Errorf("login EndLine: got %d, want 20", loginEntry.EndLine)
+	}
+	if loginEntry.Subtype != "method" {
+		t.Errorf("login Subtype: got %q, want %q", loginEntry.Subtype, "method")
+	}
+}
+
+// TestBuildBundle_ClassManifest_Fields verifies that fields discovered via
+// CONTAINS edges appear in ClassManifest.Fields.
+func TestBuildBundle_ClassManifest_Fields(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	if len(m.Fields) != 1 {
+		t.Errorf("expected 1 field, got %d: %+v", len(m.Fields), m.Fields)
+	}
+	if len(m.Fields) > 0 {
+		f := m.Fields[0]
+		if f.Name != "userRepository" {
+			t.Errorf("field name: got %q, want %q", f.Name, "userRepository")
+		}
+		if f.TypeHint != "UserRepository" {
+			t.Errorf("field TypeHint: got %q, want %q", f.TypeHint, "UserRepository")
+		}
+		if f.StartLine != 7 {
+			t.Errorf("field StartLine: got %d, want 7", f.StartLine)
+		}
+	}
+}
+
+// TestBuildBundle_ClassManifest_BasesAndInterfaces verifies that EXTENDS and
+// IMPLEMENTS neighbours are captured in Bases and Interfaces.
+func TestBuildBundle_ClassManifest_BasesAndInterfaces(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	if len(m.Bases) != 1 || m.Bases[0] != "BaseService" {
+		t.Errorf("Bases: got %v, want [BaseService]", m.Bases)
+	}
+	if len(m.Interfaces) != 1 || m.Interfaces[0] != "Authenticator" {
+		t.Errorf("Interfaces: got %v, want [Authenticator]", m.Interfaces)
+	}
+}
+
+// TestBuildBundle_ClassManifest_Decorators verifies that @Annotation tokens in
+// the class Signature are captured in ClassManifest.Decorators.
+func TestBuildBundle_ClassManifest_Decorators(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	// The class Signature is "@Service @Transactional class AuthService".
+	// Expect @Service and @Transactional to be captured.
+	decoratorSet := map[string]bool{}
+	for _, d := range m.Decorators {
+		decoratorSet[d] = true
+	}
+	for _, want := range []string{"@Service", "@Transactional"} {
+		if !decoratorSet[want] {
+			t.Errorf("decorator %q not found in ClassManifest.Decorators: %v", want, m.Decorators)
+		}
+	}
+}
+
+// TestBuildBundle_ClassManifest_Nil_ForNonClass verifies that non-class-like
+// entity kinds (Function, Operation) do NOT get a ClassManifest.
+func TestBuildBundle_ClassManifest_Nil_ForNonClass(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "non-class-manifest-test"
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	fnID := graph.EntityID("repo", "SCOPE.Function", "doSomething", "src/util.go")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{
+				ID:         fnID,
+				Name:       "doSomething",
+				Kind:       "SCOPE.Function",
+				Subtype:    "function",
+				SourceFile: "src/util.go",
+				StartLine:  1,
+				Language:   "go",
+			},
+		},
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph: %v", err)
+	}
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: fnID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if bundle.GraphContext.ClassManifest != nil {
+		t.Errorf("expected nil ClassManifest for Function entity, got %+v", bundle.GraphContext.ClassManifest)
+	}
+}
+
+// TestBuildBundle_ClassManifest_Truncation verifies that classes with > 100
+// methods produce a MethodsTruncatedCount field and exactly 100 entries.
+func TestBuildBundle_ClassManifest_Truncation(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "truncation-test"
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	classID := graph.EntityID("repo", "SCOPE.Component", "BigClass", "src/big.java")
+
+	entities := []graph.Entity{
+		{
+			ID:         classID,
+			Name:       "BigClass",
+			Kind:       "SCOPE.Component",
+			Subtype:    "class",
+			SourceFile: "src/big.java",
+			StartLine:  1,
+			Language:   "java",
+			Signature:  "class BigClass",
+		},
+	}
+	rels := []graph.Relationship{}
+
+	// Emit 150 methods — exceeds ClassManifestMaxMethods (100).
+	for i := 0; i < 150; i++ {
+		import_f := func(i int) string {
+			return "BigClass.method" + string(rune('a'+i%26)) + string(rune('0'+i/26))
+		}
+		mName := import_f(i)
+		mID := graph.EntityID("repo", "SCOPE.Operation", mName, "src/big.java")
+		entities = append(entities, graph.Entity{
+			ID:         mID,
+			Name:       mName,
+			Kind:       "SCOPE.Operation",
+			Subtype:    "method",
+			SourceFile: "src/big.java",
+			StartLine:  10 + i,
+			Language:   "java",
+			Signature:  "public void " + mName + "()",
+		})
+		rels = append(rels, graph.Relationship{
+			ID:     graph.RelationshipID(classID, mID, "CONTAINS"),
+			FromID: classID,
+			ToID:   mID,
+			Kind:   "CONTAINS",
+		})
+	}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities:       entities,
+		Relationships:  rels,
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph: %v", err)
+	}
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	if len(m.Methods) != docgen.ClassManifestMaxMethods {
+		t.Errorf("expected exactly %d methods (cap), got %d", docgen.ClassManifestMaxMethods, len(m.Methods))
+	}
+	if m.MethodsTruncatedCount != 50 {
+		t.Errorf("MethodsTruncatedCount: got %d, want 50", m.MethodsTruncatedCount)
+	}
+}
+
+// TestBuildBundle_ClassManifest_ShortNameStripping verifies that method names
+// like "AuthService.login" are stored as "login" in the manifest (short name).
+func TestBuildBundle_ClassManifest_ShortNameStripping(t *testing.T) {
+	groupName, classID := classManifestHarness(t)
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: classID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ClassManifest
+	if m == nil {
+		t.Fatal("class_manifest is nil")
+	}
+
+	for _, me := range m.Methods {
+		if me.Name == "AuthService.login" || me.Name == "AuthService.logout" {
+			t.Errorf("method name not stripped: got %q, expected short name without class prefix", me.Name)
+		}
+	}
+	for _, fe := range m.Fields {
+		if fe.Name == "AuthService.userRepository" {
+			t.Errorf("field name not stripped: got %q, expected short name", fe.Name)
+		}
+	}
+}


### PR DESCRIPTION
## What we did

Added `ClassManifest` to `LLMGraphContext` in `internal/docgen/llm_bundle.go`. When `BuildBundle` is called for a class-like seed entity (`SCOPE.Component`, `SCOPE.Class`, `SCOPE.Service`, `SCOPE.Model`, `SCOPE.View`, `SCOPE.Controller`, `SCOPE.UIComponent`), it now walks the 1-hop neighbours to build a structured `class_manifest` containing:

- **Methods** (`ClassMethodEntry[]`): collected from `CONTAINS`-edge neighbours with kind `SCOPE.Operation`. Each entry carries short name (class prefix stripped), signature, visibility (inferred from signature text), `is_static` flag, subtype, and start/end line. Capped at 100; excess recorded in `methods_truncated_count`.
- **Fields** (`ClassFieldEntry[]`): collected from `CONTAINS`-edge neighbours with kind `SCOPE.Schema`/subtype=`field`. Each entry carries short name, type_hint (inferred from signature), and start_line. Capped at 100; excess in `fields_truncated_count`.
- **Bases** (`[]string`): parent class names from `EXTENDS`-edge neighbours.
- **Interfaces** (`[]string`): implemented interface names from `IMPLEMENTS`-edge neighbours.
- **Decorators** (`[]string`): `@Identifier` tokens parsed from the class entity's `Signature` field, plus `decorator_name` properties from any `SCOPE.Pattern`/subtype=`decorator` neighbours. Deduped.

Non-class-like kinds (`SCOPE.Function`, `SCOPE.Operation`, `Module`, etc.) get `nil` for `class_manifest` (omitempty). Classes with no discoverable members also get `nil`.

New helpers: `isClassLikeKind()`, `buildClassManifest()`, `shortName()`, `inferVisibility()`, `typeHintFromSignature()`, `decoratorTokenRE`.

8 new tests added in `llm_bundle_class_manifest_test.go`.

Closes #1861

## What we won

- The LLM bundle for any class-like entity now ships a **machine-readable surface-area map** alongside the source_window. The LLM can cite `login`, `rolesService`, `@Service` etc. by name without re-parsing source text.
- Visibility and static-method flags are inferred without requiring extractors to change — uses what the graph already stores (`Signature` text + `Properties["is_static"]`).
- The truncation cap (100 methods / 100 fields) with `methods_truncated_count` lets the orchestrator know when a class is unusually large (test fixtures, generated code) without silently losing data.
- Zero-cost for non-class seeds: `isClassLikeKind()` short-circuits early, `omitempty` keeps JSON output clean.

## What it means at scale

Every class-level docgen page across all Java, Python, TypeScript, and Kotlin repos will now include a structured method/field enumeration in the bundle. For a group with 500 class entities, this yields ~500 bundles with concrete API surface context — eliminating the "fabricated or hedged" prose that R1 dogfood identified for `ContractViewSet` (1768-line class, 40-line source_window). No graph re-indexing needed: the CONTAINS/EXTENDS/IMPLEMENTS edges are already emitted by all existing language extractors.

## What it means for MCP/daemon/UX

- **MCP**: no change. `archigraph_inspect` / `archigraph_page_bundle` already surface `graph_context` verbatim; `class_manifest` appears as a new subfield automatically.
- **Daemon**: no change to daemon lifecycle, graph format, or indexing. Bundle construction is a pure read path.
- **UX**: orchestrator skills can now generate `api` and `capabilities` sections that reference `AuthController.login`, `usersService`, `@Path` etc. by name rather than guessing from source_window content alone.

## Verification

Unit tests (8 new, all green):

```
go test ./internal/docgen/... -run TestBuildBundle_ClassManifest -v
--- PASS: TestBuildBundle_ClassManifest_Populated
--- PASS: TestBuildBundle_ClassManifest_Methods       (login: sig, visibility=public, StartLine=10, EndLine=20)
--- PASS: TestBuildBundle_ClassManifest_Fields        (userRepository: TypeHint=UserRepository, StartLine=7)
--- PASS: TestBuildBundle_ClassManifest_BasesAndInterfaces  (Bases=[BaseService], Interfaces=[Authenticator])
--- PASS: TestBuildBundle_ClassManifest_Decorators    (@Service, @Transactional from Signature)
--- PASS: TestBuildBundle_ClassManifest_Nil_ForNonClass  (Function entity → nil manifest)
--- PASS: TestBuildBundle_ClassManifest_Truncation    (150 methods → 100 entries + truncated_count=50)
--- PASS: TestBuildBundle_ClassManifest_ShortNameStripping  ("AuthService.login" → "login")
ok  github.com/cajasmota/archigraph/internal/docgen  0.666s
```

Live graph check on client-fixture-de:
`graph.json` for client-fixture-d confirms `AuthController` (`SCOPE.Component`) has 4 CONTAINS edges: `login` (SCOPE.Operation/method), `usersService`/`rolesService`/`tokenService` (SCOPE.Schema/field). The graph.fb in the store is stale (daemon is intentionally stopped per ADR; re-index will populate the manifest in a live run). The unit test harness fully exercises the code path with matching graph topology.

Full suite: `go test ./internal/docgen/...` — ok in 1.5 s, no regressions.

## Caveats / what's not done

- **Decorators from older graphs**: class entities indexed before the Java extractor emitted `Signature` (e.g. the current client-fixture-de graph.fb) have empty `Signature` → no decorators parsed from it. Re-indexing restores this. Field-level decorator annotations (`@Inject`, `@Autowired`) are not separately stored in the graph — they're not in the field `Signature` because Java `buildFieldSignature` strips modifiers. This is a follow-up item.
- **Visibility for Java fields**: `buildFieldSignature` strips visibility modifiers before storing the signature, so Java field visibility is always `""` (unknown) unless Properties stores it. A follow-up extractor change can add `Properties["visibility"]`.
- **Decorator edges (ANNOTATED_BY)**: not yet in the graph schema. The current approach parses from Signature which covers class-level annotations only. `#1862` (pre-extract `@action` decorator metadata) is the follow-up.
- **`#1868` end_line=0 sentinel**: not fixed here; noted for the companion PR.

## Bottom line

Class-like seed entities in LLM bundles now ship a `class_manifest` that enumerates methods, fields, bases, interfaces, and decorators. The LLM can produce precise `api` and `capabilities` prose citing `login`, `@Service`, `UserRepository userRepository` by name — eliminating the hedging and fabrication flagged in the R1 dogfood. Zero graph changes, zero daemon changes, purely additive schema field with omitempty.