### PR TITLE
feat(flows): JARVIS animation overhaul — comet, replay-all, scrubber, audio, chevrons, cross-repo styling (#1922)

### DIFF
--- a/webui-v2/src/lib/edge-geometry.ts
+++ b/webui-v2/src/lib/edge-geometry.ts
@@ -1,0 +1,41 @@
+/* ============================================================
+   edge-geometry.ts — parametric position along a polyline edge.
+
+   The flow DAG edges are simple polylines. To position a comet at
+   progress p ∈ [0, 1] along an edge, we compute the cumulative arc
+   length of each segment and interpolate. Zero deps.
+   ============================================================ */
+
+export type Pt = { x: number; y: number };
+
+export function polyLength(points: Pt[]): number {
+  let total = 0;
+  for (let i = 1; i < points.length; i++) {
+    const dx = points[i].x - points[i - 1].x;
+    const dy = points[i].y - points[i - 1].y;
+    total += Math.hypot(dx, dy);
+  }
+  return total;
+}
+
+/** Returns the point at fractional progress p along the polyline. */
+export function pointAt(points: Pt[], p: number): Pt {
+  if (points.length === 0) return { x: 0, y: 0 };
+  if (points.length === 1) return points[0];
+  const clamped = Math.max(0, Math.min(1, p));
+  const total = polyLength(points);
+  if (total === 0) return points[0];
+  const target = total * clamped;
+  let acc = 0;
+  for (let i = 1; i < points.length; i++) {
+    const a = points[i - 1];
+    const b = points[i];
+    const seg = Math.hypot(b.x - a.x, b.y - a.y);
+    if (acc + seg >= target) {
+      const t = seg === 0 ? 0 : (target - acc) / seg;
+      return { x: a.x + (b.x - a.x) * t, y: a.y + (b.y - a.y) * t };
+    }
+    acc += seg;
+  }
+  return points[points.length - 1];
+}

--- a/webui-v2/src/lib/flow-animation.ts
+++ b/webui-v2/src/lib/flow-animation.ts
@@ -1,0 +1,347 @@
+/* ============================================================
+   flow-animation.ts — replay-all state machine for the flow DAG.
+
+   Responsibilities (per #1922):
+     • Drive a glowing comet along each edge i-1 → i in sequence.
+     • Track traversed-edge set so the renderer can tint them.
+     • Support pause/resume mid-edge (freezes comet progress).
+     • Support scrub (instant jump, no intermediate animation, with
+       reverse-decay fade applied by the renderer based on lastDir).
+     • Speed multiplier scales both inter-step delay and edge traversal.
+     • Slower comet on cross-repo bridge edges (~450ms vs ~300ms).
+
+   Implementation is a rAF-driven step machine kept outside React so we
+   never thrash component re-renders on every animation tick — the
+   renderer subscribes via getSnapshot() + a versioned counter exposed
+   through subscribe().
+   ============================================================ */
+
+import { useSyncExternalStore } from "react";
+
+export type FlowAnimSnapshot = {
+  // Index of the *target* step the comet is heading toward. -1 if idle.
+  // When idle (after a full Replay-all), settles on totalSteps - 1.
+  currentTarget: number;
+  // Number of steps the playhead is at (0 = entry only, N = full chain).
+  // Equivalent to "edges traversed" + 1.
+  playhead: number;
+  // 0..1 progress along the current edge. 0 when not traveling.
+  edgeProgress: number;
+  // Set of edge indices (i = target step index) currently considered
+  // "traversed" (tinted). Exposed as a sorted array for renderer use.
+  traversedEdges: number[];
+  // Latest scrub direction — "forward" or "backward". Lets the renderer
+  // decide whether to fade newly-removed edges (reverse decay).
+  lastScrubDir: "forward" | "backward" | null;
+  // True if the engine is currently animating an edge (not paused / idle).
+  running: boolean;
+  // True if user paused mid-flow.
+  paused: boolean;
+};
+
+export type FlowAnimController = {
+  subscribe: (listener: () => void) => () => void;
+  getSnapshot: () => FlowAnimSnapshot;
+  start: () => void;
+  stop: () => void;
+  pause: () => void;
+  resume: () => void;
+  toggle: () => void;
+  scrubTo: (playhead: number) => void;
+  reset: () => void;
+  setSpeed: (mult: number) => void;
+  // Set on each arrival; renderer wires it to playStepBlip when audio is on.
+  setOnArrive: (cb: ((stepIdx: number) => void) | null) => void;
+};
+
+export type CreateOpts = {
+  totalSteps: number;
+  isBridgeEdge: (edgeIdx: number) => boolean; // edgeIdx = target step idx ≥ 1
+  baseEdgeMs?: number;     // default 300
+  bridgeEdgeMs?: number;   // default 450
+  interStepMs?: number;    // delay between arrival and next departure (default 90)
+  speed?: number;          // default 1
+  reducedMotion?: boolean; // if true, skip rAF — instant jumps only
+};
+
+const noop = () => {};
+
+const EMPTY: FlowAnimSnapshot = {
+  currentTarget: -1,
+  playhead: 0,
+  edgeProgress: 0,
+  traversedEdges: [],
+  lastScrubDir: null,
+  running: false,
+  paused: false,
+};
+
+export function createFlowAnim(opts: CreateOpts): FlowAnimController {
+  const {
+    totalSteps,
+    isBridgeEdge,
+    baseEdgeMs = 300,
+    bridgeEdgeMs = 450,
+    interStepMs = 90,
+    reducedMotion = false,
+  } = opts;
+
+  let speed = opts.speed ?? 1;
+  let onArrive: ((stepIdx: number) => void) | null = null;
+
+  let snap: FlowAnimSnapshot = { ...EMPTY };
+  const listeners = new Set<() => void>();
+
+  // rAF / timing state
+  let rafId: number | null = null;
+  let edgeStartTs = 0;
+  let edgeDurMs = 0;
+  let edgeProgressFrozen = 0; // edge progress captured at pause time
+  let interStepTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function emit() {
+    listeners.forEach((l) => l());
+  }
+
+  function clearTimers() {
+    if (rafId != null) {
+      cancelAnimationFrame(rafId);
+      rafId = null;
+    }
+    if (interStepTimer != null) {
+      clearTimeout(interStepTimer);
+      interStepTimer = null;
+    }
+  }
+
+  function setTraversed(upTo: number): number[] {
+    // Traversed edges are all edges with target idx in [1..upTo].
+    const arr: number[] = [];
+    for (let i = 1; i <= upTo; i++) arr.push(i);
+    return arr;
+  }
+
+  function tickEdge(ts: number) {
+    if (snap.paused || !snap.running) return;
+    const elapsed = ts - edgeStartTs;
+    const p = Math.min(1, elapsed / Math.max(1, edgeDurMs));
+    snap = { ...snap, edgeProgress: p };
+    emit();
+    if (p >= 1) {
+      // Arrive on snap.currentTarget.
+      const arrived = snap.currentTarget;
+      snap = {
+        ...snap,
+        edgeProgress: 0,
+        playhead: arrived + 1, // playhead counts nodes reached (1-based)
+        traversedEdges: setTraversed(arrived),
+      };
+      emit();
+      onArrive?.(arrived);
+      // Schedule next edge or stop.
+      if (arrived < totalSteps - 1) {
+        interStepTimer = setTimeout(() => {
+          interStepTimer = null;
+          beginEdge(arrived + 1);
+        }, interStepMs / Math.max(0.0001, speed));
+      } else {
+        // Finished.
+        snap = { ...snap, running: false, currentTarget: arrived };
+        rafId = null;
+        emit();
+      }
+      return;
+    }
+    rafId = requestAnimationFrame(tickEdge);
+  }
+
+  function beginEdge(targetIdx: number) {
+    if (targetIdx <= 0 || targetIdx >= totalSteps) {
+      // Nothing to animate.
+      snap = { ...snap, running: false, edgeProgress: 0 };
+      emit();
+      return;
+    }
+    const baseMs = isBridgeEdge(targetIdx) ? bridgeEdgeMs : baseEdgeMs;
+    edgeDurMs = baseMs / Math.max(0.0001, speed);
+    edgeStartTs = performance.now();
+    edgeProgressFrozen = 0;
+    snap = {
+      ...snap,
+      currentTarget: targetIdx,
+      edgeProgress: 0,
+      running: true,
+      paused: false,
+    };
+    emit();
+    if (reducedMotion) {
+      // Skip the comet — jump straight to arrival.
+      snap = {
+        ...snap,
+        edgeProgress: 0,
+        playhead: targetIdx + 1,
+        traversedEdges: setTraversed(targetIdx),
+      };
+      emit();
+      onArrive?.(targetIdx);
+      if (targetIdx < totalSteps - 1) {
+        interStepTimer = setTimeout(() => {
+          interStepTimer = null;
+          beginEdge(targetIdx + 1);
+        }, interStepMs / Math.max(0.0001, speed));
+      } else {
+        snap = { ...snap, running: false };
+        emit();
+      }
+      return;
+    }
+    rafId = requestAnimationFrame(tickEdge);
+  }
+
+  function start() {
+    if (totalSteps < 2) return;
+    clearTimers();
+    snap = {
+      currentTarget: 0,
+      playhead: 1, // entry is already "reached"
+      edgeProgress: 0,
+      traversedEdges: [],
+      lastScrubDir: "forward",
+      running: true,
+      paused: false,
+    };
+    emit();
+    beginEdge(1);
+  }
+
+  function stop() {
+    clearTimers();
+    snap = {
+      ...snap,
+      running: false,
+      paused: false,
+      edgeProgress: 0,
+    };
+    emit();
+  }
+
+  function pause() {
+    if (!snap.running || snap.paused) return;
+    edgeProgressFrozen = snap.edgeProgress;
+    if (rafId != null) cancelAnimationFrame(rafId);
+    rafId = null;
+    if (interStepTimer != null) {
+      clearTimeout(interStepTimer);
+      interStepTimer = null;
+    }
+    snap = { ...snap, paused: true };
+    emit();
+  }
+
+  function resume() {
+    if (!snap.paused) return;
+    // Resume the in-flight edge by shifting edgeStartTs back so that
+    // (now - edgeStartTs) / edgeDurMs equals the frozen progress.
+    const offset = edgeProgressFrozen * edgeDurMs;
+    edgeStartTs = performance.now() - offset;
+    snap = { ...snap, paused: false };
+    emit();
+    rafId = requestAnimationFrame(tickEdge);
+  }
+
+  function toggle() {
+    if (!snap.running && snap.paused === false && snap.playhead < totalSteps) {
+      // Idle → start (or resume from where we are)
+      if (snap.playhead > 0 && snap.playhead < totalSteps) {
+        // Continue from current playhead.
+        snap = { ...snap, running: true, paused: false };
+        emit();
+        beginEdge(snap.playhead);
+        return;
+      }
+      start();
+      return;
+    }
+    if (snap.running && !snap.paused) {
+      pause();
+    } else if (snap.paused) {
+      resume();
+    }
+  }
+
+  function scrubTo(target: number) {
+    const clamped = Math.max(0, Math.min(totalSteps, target));
+    const prev = snap.playhead;
+    const dir: "forward" | "backward" =
+      clamped >= prev ? "forward" : "backward";
+    clearTimers();
+    // Scrubbing always cancels animation and jumps instantly. The renderer
+    // applies reverse-decay visually based on lastScrubDir.
+    snap = {
+      currentTarget: clamped - 1,
+      playhead: clamped,
+      edgeProgress: 0,
+      traversedEdges: setTraversed(clamped - 1),
+      lastScrubDir: dir,
+      running: false,
+      paused: false,
+    };
+    emit();
+  }
+
+  function reset() {
+    clearTimers();
+    snap = { ...EMPTY };
+    emit();
+  }
+
+  function setSpeed(mult: number) {
+    const next = Math.max(0.1, Math.min(8, mult));
+    if (next === speed) return;
+    // If currently animating an edge, rescale the in-flight progress so it
+    // doesn't visually jump.
+    if (snap.running && !snap.paused && rafId != null) {
+      const now = performance.now();
+      const elapsed = now - edgeStartTs;
+      const oldRemaining = edgeDurMs - elapsed;
+      const ratio = speed / next;
+      const newRemaining = oldRemaining * ratio;
+      edgeDurMs = (edgeDurMs * ratio);
+      edgeStartTs = now - (edgeDurMs - newRemaining);
+    }
+    speed = next;
+  }
+
+  return {
+    subscribe(listener) {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    getSnapshot: () => snap,
+    start,
+    stop,
+    pause,
+    resume,
+    toggle,
+    scrubTo,
+    reset,
+    setSpeed,
+    setOnArrive(cb) {
+      onArrive = cb;
+    },
+  };
+}
+
+/**
+ * React binding — subscribes a component to a controller's snapshot.
+ * Returns the latest snapshot; will trigger re-render on each emit.
+ */
+export function useFlowAnim(controller: FlowAnimController): FlowAnimSnapshot {
+  return useSyncExternalStore(
+    controller.subscribe,
+    controller.getSnapshot,
+    controller.getSnapshot,
+  );
+}
+
+export const __test_only = { noop };

--- a/webui-v2/src/lib/flow-audio.ts
+++ b/webui-v2/src/lib/flow-audio.ts
@@ -1,0 +1,81 @@
+/* ============================================================
+   flow-audio.ts — optional WebAudio "blip" on step arrival.
+
+   Behavior (per #1922):
+     • OFF BY DEFAULT (callers must explicitly toggle).
+     • Persisted in localStorage["archigraph:flows:audio"] as "on"/"off".
+     • One shared AudioContext lazily constructed on first blip.
+     • Sine wave, ~440Hz, 60ms total, peak ~-20dB, fast attack + decay.
+
+   No external deps; pure browser WebAudio. Safe under SSR (guards on
+   typeof window / AudioContext).
+   ============================================================ */
+
+export const FLOW_AUDIO_KEY = "archigraph:flows:audio";
+
+export function readFlowAudio(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(FLOW_AUDIO_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+export function writeFlowAudio(on: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(FLOW_AUDIO_KEY, on ? "on" : "off");
+  } catch {
+    /* storage unavailable */
+  }
+}
+
+let ctx: AudioContext | null = null;
+
+function getCtx(): AudioContext | null {
+  if (typeof window === "undefined") return null;
+  // Some test envs lack AudioContext; bail silently.
+  const Ctor: typeof AudioContext | undefined =
+    (window as unknown as { AudioContext?: typeof AudioContext }).AudioContext ??
+    (window as unknown as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+  if (!Ctor) return null;
+  if (!ctx) {
+    try {
+      ctx = new Ctor();
+    } catch {
+      ctx = null;
+    }
+  }
+  return ctx;
+}
+
+/**
+ * Play a short sine-wave blip. No-op on failure (unsupported, suspended,
+ * etc.) — audio is strictly optional polish.
+ */
+export function playStepBlip(): void {
+  const c = getCtx();
+  if (!c) return;
+  try {
+    // Resume the context if it was suspended (autoplay rules).
+    if (c.state === "suspended") void c.resume();
+
+    const now = c.currentTime;
+    const osc = c.createOscillator();
+    const gain = c.createGain();
+    osc.type = "sine";
+    osc.frequency.setValueAtTime(440, now);
+
+    // -20 dB ~= linear 0.1 amplitude; quick attack + decay over ~60ms.
+    gain.gain.setValueAtTime(0.0001, now);
+    gain.gain.exponentialRampToValueAtTime(0.1, now + 0.006);
+    gain.gain.exponentialRampToValueAtTime(0.0001, now + 0.06);
+
+    osc.connect(gain).connect(c.destination);
+    osc.start(now);
+    osc.stop(now + 0.07);
+  } catch {
+    /* swallow — best-effort */
+  }
+}

--- a/webui-v2/src/lib/use-reduced-motion.ts
+++ b/webui-v2/src/lib/use-reduced-motion.ts
@@ -1,0 +1,31 @@
+/* ============================================================
+   use-reduced-motion.ts — track `prefers-reduced-motion: reduce`.
+
+   Returns true when the user has asked for reduced motion. Updates
+   live when the media query changes (e.g. user toggles in devtools).
+   SSR-safe: returns false when window is unavailable.
+   ============================================================ */
+
+import { useEffect, useState } from "react";
+
+export function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState<boolean>(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return false;
+    return window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined" || !window.matchMedia) return;
+    const mql = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const onChange = (e: MediaQueryListEvent) => setReduced(e.matches);
+    if (mql.addEventListener) {
+      mql.addEventListener("change", onChange);
+      return () => mql.removeEventListener("change", onChange);
+    }
+    // Older Safari fallback
+    mql.addListener(onChange);
+    return () => mql.removeListener(onChange);
+  }, []);
+
+  return reduced;
+}

--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -23,6 +23,7 @@ import {
   Package, CheckCircle2, Layout, Terminal, Clock, TestTube2, Wifi,
   ChevronRight, Search, X, Copy, Share2, ExternalLink, ZoomIn, ZoomOut,
   Maximize2, Link2, Sparkles, Info, Check, ArrowRight, Rows2, Grid2x2,
+  Play, Pause, Square, Volume2, VolumeX, Gauge,
   type LucideProps,
 } from "lucide-react";
 import type { ForwardRefExoticComponent, RefAttributes } from "react";
@@ -34,6 +35,15 @@ import type {
 } from "@/data/types";
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
+import {
+  createFlowAnim, useFlowAnim,
+  type FlowAnimController, type FlowAnimSnapshot,
+} from "@/lib/flow-animation";
+import { pointAt, type Pt } from "@/lib/edge-geometry";
+import {
+  playStepBlip, readFlowAudio, writeFlowAudio,
+} from "@/lib/flow-audio";
+import { usePrefersReducedMotion } from "@/lib/use-reduced-motion";
 
 // ─── Step-kind metadata ───────────────────────────────────────────────────────
 
@@ -876,12 +886,18 @@ function FlowDag({
   selectedStepIdx,
   onPickStep,
   userLayout = "auto",
+  anim,
+  reducedMotion = false,
+  onBridgeMap,
 }: {
   flow: Process;
   detailSteps?: ProcessStep[];
   selectedStepIdx: number | null;
   onPickStep: (i: number | null) => void;
   userLayout?: UserLayout;
+  anim?: FlowAnimSnapshot;
+  reducedMotion?: boolean;
+  onBridgeMap?: (bridges: boolean[]) => void;
 }) {
   const steps = detailSteps ?? flow.steps ?? [];
 
@@ -1041,25 +1057,119 @@ function FlowDag({
 
   // Horizontal edges: exit right edge of node i-1, enter left edge of node i.
   // When the chain wraps to the next lane, route down-then-across.
-  const edges: Array<{
-    from: { x: number; y: number };
-    to: { x: number; y: number };
+  //
+  // Each edge now carries an explicit `polyline` (the actual points the
+  // stroke passes through) so the comet animation can ride the same curve
+  // the renderer draws — single source of truth for the line geometry.
+  type EdgeRec = {
+    from: Pt;
+    to: Pt;
     kind: string | null;
     xrepo: boolean;
     wrap: boolean;
-  }> = [];
+    polyline: Pt[];
+    labelX: number;
+    labelY: number;
+    path: string;
+  };
+  const edges: EdgeRec[] = [];
   for (let i = 1; i < steps.length; i++) {
     const a = positions[i - 1];
     const b = positions[i];
     const wrap = i % perLane === 0; // first node of a new lane
+    const from: Pt = { x: a.x + mode.nodeW, y: a.y + mode.nodeH / 2 };
+    const to: Pt = { x: b.x, y: b.y + mode.nodeH / 2 };
+    const xrepo = steps[i].repo !== steps[i - 1].repo;
+
+    let polyline: Pt[];
+    let labelX: number, labelY: number;
+    if (wrap) {
+      const downY = (from.y + to.y) / 2;
+      polyline = [
+        from,
+        { x: from.x + 14, y: from.y },
+        { x: from.x + 14, y: downY },
+        { x: to.x - 14, y: downY },
+        { x: to.x - 14, y: to.y },
+        to,
+      ];
+      labelX = to.x + 6;
+      labelY = to.y - 8;
+    } else {
+      const midX = (from.x + to.x) / 2;
+      polyline = [
+        from,
+        { x: midX - 6, y: from.y },
+        { x: midX + 6, y: to.y },
+        to,
+      ];
+      labelX = midX - 4;
+      labelY = (from.y + to.y) / 2 - 6;
+    }
+    const path =
+      "M " + polyline.map((p) => `${p.x} ${p.y}`).join(" L ");
+
     edges.push({
-      from: { x: a.x + mode.nodeW, y: a.y + mode.nodeH / 2 },
-      to: { x: b.x, y: b.y + mode.nodeH / 2 },
+      from, to,
       kind: steps[i].edge_kind,
-      xrepo: steps[i].repo !== steps[i - 1].repo,
+      xrepo,
       wrap,
+      polyline,
+      labelX, labelY, path,
     });
   }
+
+  // Publish the bridge-edge map to the parent so the animation controller
+  // knows which edges to traverse slower (~450ms vs ~300ms).
+  // edges[i] corresponds to step index i+1 (target step). We index the
+  // returned array by target step idx so callers can look up via idx.
+  useEffect(() => {
+    if (!onBridgeMap) return;
+    const map: boolean[] = new Array(steps.length).fill(false);
+    edges.forEach((e, i) => {
+      map[i + 1] = e.xrepo;
+    });
+    onBridgeMap(map);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [steps.length, flow.process_id, userLayout]);
+
+  // Animation-derived sets.
+  const traversedSet = useMemo(
+    () => new Set(anim?.traversedEdges ?? []),
+    [anim?.traversedEdges],
+  );
+  const currentTarget = anim?.currentTarget ?? -1;
+  const edgeProgress = anim?.edgeProgress ?? 0;
+  const lastScrubDir = anim?.lastScrubDir ?? null;
+  // Track which edges to render with reverse-decay (fading out tint).
+  // We compute on the fly: if the user scrubbed backward, edges past
+  // playhead briefly fade — represented by `decayEdges` (those NOT in
+  // traversedSet but were recently). We approximate with a transient
+  // CSS class triggered by snapshot changes.
+  const [decayEdges, setDecayEdges] = useState<Set<number>>(new Set());
+  const prevTraversedRef = useRef<Set<number>>(new Set());
+  useEffect(() => {
+    if (!anim) return;
+    const prev = prevTraversedRef.current;
+    const next = new Set(anim.traversedEdges);
+    const removed = new Set<number>();
+    prev.forEach((idx) => {
+      if (!next.has(idx)) removed.add(idx);
+    });
+    prevTraversedRef.current = next;
+    if (removed.size > 0 && lastScrubDir === "backward") {
+      setDecayEdges((cur) => {
+        const merged = new Set(cur);
+        removed.forEach((r) => merged.add(r));
+        return merged;
+      });
+      // Fade-out window ~80ms each per spec; clear after a touch longer
+      // so they all complete (we apply CSS transition).
+      const t = setTimeout(() => setDecayEdges(new Set()), 220);
+      return () => clearTimeout(t);
+    }
+    return undefined;
+  }, [anim?.traversedEdges, lastScrubDir]);
 
   return (
     <div
@@ -1099,51 +1209,124 @@ function FlowDag({
             <style>{`
               @media (prefers-reduced-motion: no-preference) {
                 .fx-xedge { animation: fx-dash 0.9s linear infinite; }
+                .fx-edge-pulse {
+                  animation: fx-edge-pulse 150ms ease-out 1;
+                }
+                .fx-node-bounce {
+                  animation: fx-node-bounce 180ms ease-out 1;
+                }
               }
               @keyframes fx-dash { to { stroke-dashoffset: -16; } }
+              @keyframes fx-edge-pulse {
+                0%   { stroke-width: 1.4; opacity: 0.4; }
+                50%  { stroke-width: 2.5; opacity: 1; }
+                100% { stroke-width: 1.4; opacity: 0.5; }
+              }
+              @keyframes fx-node-bounce {
+                0%   { transform: scale(1); }
+                40%  { transform: scale(0.95); }
+                70%  { transform: scale(1.05); }
+                100% { transform: scale(1); }
+              }
+              .fx-edge-decay {
+                transition: stroke-opacity 80ms ease-out, stroke 80ms ease-out;
+              }
+              .fx-comet {
+                filter: drop-shadow(0 0 6px var(--ag-flow-accent, #60a5fa))
+                        drop-shadow(0 0 2px var(--ag-flow-accent, #60a5fa));
+              }
             `}</style>
+            {/* Chevron markers — one per edge style (regular + bridge).
+                These render a static arrowhead at the target end of every
+                edge so direction reads without any animation. */}
+            <marker
+              id="ag-chev"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ag-flow-edge, #475569)" />
+            </marker>
+            <marker
+              id="ag-chev-bridge"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ag-flow-bridge, #a78bfa)" />
+            </marker>
+            <marker
+              id="ag-chev-traversed"
+              viewBox="0 0 10 10"
+              refX="9"
+              refY="5"
+              markerWidth="6"
+              markerHeight="6"
+              orient="auto-start-reverse"
+            >
+              <path d="M 0 0 L 10 5 L 0 10 z" fill="var(--ag-flow-accent, #60a5fa)" />
+            </marker>
           </defs>
           {edges.map((ed, i) => {
-            const stroke = ed.xrepo ? "#a78bfa" : "#475569";
-            let path: string;
-            let labelX: number;
-            let labelY: number;
-            if (ed.wrap) {
-              // Route: out the right of the previous node, down, then back
-              // across to the left of the wrapped node on the next lane.
-              const downY = (ed.from.y + ed.to.y) / 2;
-              path = `M ${ed.from.x} ${ed.from.y} L ${ed.from.x + 14} ${ed.from.y} L ${ed.from.x + 14} ${downY} L ${ed.to.x - 14} ${downY} L ${ed.to.x - 14} ${ed.to.y} L ${ed.to.x} ${ed.to.y}`;
-              labelX = ed.to.x + 6;
-              labelY = ed.to.y - 8;
-            } else {
-              const midX = (ed.from.x + ed.to.x) / 2;
-              path = `M ${ed.from.x} ${ed.from.y} L ${midX - 6} ${ed.from.y} L ${midX + 6} ${ed.to.y} L ${ed.to.x} ${ed.to.y}`;
-              labelX = midX - 4;
-              labelY = (ed.from.y + ed.to.y) / 2 - 6;
-            }
+            const targetIdx = i + 1; // step index this edge arrives at
+            const isTraversed = traversedSet.has(targetIdx);
+            const isCurrent = currentTarget === targetIdx && (anim?.running || anim?.paused);
+            const isDecaying = decayEdges.has(targetIdx);
+            const baseStroke = ed.xrepo
+              ? "var(--ag-flow-bridge, #a78bfa)"
+              : "var(--ag-flow-edge, #475569)";
+            const traversedStroke = "var(--ag-flow-accent, #60a5fa)";
+            const stroke = isTraversed ? traversedStroke : baseStroke;
+            // Trail tinting: traversed ~ full strength, future ~ 25%.
+            const strokeOpacity = isTraversed ? 0.9 : isDecaying ? 0.4 : 0.25;
+            const markerId = isTraversed
+              ? "ag-chev-traversed"
+              : ed.xrepo
+                ? "ag-chev-bridge"
+                : "ag-chev";
+            // Pulse class — applied only on the frame the comet arrives.
+            // We approximate "on arrival" by detecting traversed state
+            // change paired with currentTarget moving forward.
+            const justArrived =
+              isTraversed &&
+              !reducedMotion &&
+              lastScrubDir !== "backward" &&
+              // The freshly-arrived edge is the one whose target matches the
+              // playhead - 1 (most recent arrival).
+              anim != null &&
+              anim.playhead - 1 === targetIdx;
             return (
               <g key={i}>
                 <path
-                  d={path}
+                  d={ed.path}
                   fill="none"
                   stroke={stroke}
-                  strokeWidth={1.4}
-                  strokeDasharray={ed.xrepo ? "5 3" : undefined}
-                  className={ed.xrepo ? "fx-xedge" : undefined}
-                />
-                {/* Arrowhead pointing into the left edge of the target node. */}
-                <polygon
-                  points={`${ed.to.x - 6},${ed.to.y - 4} ${ed.to.x - 6},${ed.to.y + 4} ${ed.to.x - 1},${ed.to.y}`}
-                  fill={stroke}
+                  strokeOpacity={strokeOpacity}
+                  strokeWidth={isCurrent ? 2.1 : 1.4}
+                  strokeDasharray={ed.xrepo ? "6 4" : undefined}
+                  markerEnd={`url(#${markerId})`}
+                  className={cn(
+                    "fx-edge-decay",
+                    ed.xrepo ? "fx-xedge" : undefined,
+                    justArrived ? "fx-edge-pulse" : undefined,
+                  )}
                 />
                 {ed.kind && (
                   <text
-                    x={labelX}
-                    y={labelY}
+                    x={ed.labelX}
+                    y={ed.labelY}
                     fontSize={9}
                     textAnchor="middle"
                     fontFamily="var(--font-mono)"
-                    fill={ed.xrepo ? "#a78bfa" : "var(--text-3)"}
+                    fill={ed.xrepo
+                      ? "var(--ag-flow-bridge, #a78bfa)"
+                      : "var(--text-3)"}
                     paintOrder="stroke"
                     stroke="var(--canvas-bg)"
                     strokeWidth={3}
@@ -1156,6 +1339,64 @@ function FlowDag({
               </g>
             );
           })}
+          {/* Comet — only when a current edge is being traversed and the
+              user has not requested reduced motion. */}
+          {!reducedMotion && anim && anim.running && !anim.paused
+            && currentTarget > 0 && currentTarget < steps.length && (() => {
+              const ed = edges[currentTarget - 1];
+              if (!ed) return null;
+              const head = pointAt(ed.polyline, edgeProgress);
+              // Trail: 4 fading dots behind the head along the same path.
+              const trail = [0.04, 0.08, 0.13, 0.19]
+                .map((d) => Math.max(0, edgeProgress - d))
+                .map((p) => pointAt(ed.polyline, p));
+              return (
+                <g className="fx-comet" pointerEvents="none">
+                  {trail.map((pt, ti) => (
+                    <circle
+                      key={ti}
+                      cx={pt.x}
+                      cy={pt.y}
+                      r={2.2 - ti * 0.35}
+                      fill="var(--ag-flow-accent, #60a5fa)"
+                      opacity={0.55 - ti * 0.12}
+                    />
+                  ))}
+                  <circle
+                    cx={head.x}
+                    cy={head.y}
+                    r={3.6}
+                    fill="var(--ag-flow-accent, #60a5fa)"
+                  />
+                </g>
+              );
+            })()}
+          {/* Paused comet — frozen mid-edge so it's still visible. */}
+          {!reducedMotion && anim && anim.paused
+            && currentTarget > 0 && currentTarget < steps.length && (() => {
+              const ed = edges[currentTarget - 1];
+              if (!ed) return null;
+              const head = pointAt(ed.polyline, edgeProgress);
+              return (
+                <g pointerEvents="none">
+                  <circle
+                    cx={head.x}
+                    cy={head.y}
+                    r={3.6}
+                    fill="var(--ag-flow-accent, #60a5fa)"
+                    opacity={0.85}
+                  />
+                  <circle
+                    cx={head.x}
+                    cy={head.y}
+                    r={6}
+                    fill="none"
+                    stroke="var(--ag-flow-accent, #60a5fa)"
+                    strokeOpacity={0.4}
+                  />
+                </g>
+              );
+            })()}
         </svg>
 
         {/* Nodes */}
@@ -1179,6 +1420,17 @@ function FlowDag({
               : baseFile
             : "";
 
+          // Node arrival bounce — applied when this node was the most
+          // recent forward arrival in the replay. Reduced-motion suppresses
+          // it via the global @media rule.
+          const justArrivedNode =
+            !reducedMotion &&
+            anim != null &&
+            anim.lastScrubDir !== "backward" &&
+            anim.playhead - 1 === i &&
+            i > 0;
+          const isInTrail =
+            anim != null && i < anim.playhead;
           return (
             <button
               key={s.entity_id}
@@ -1192,6 +1444,8 @@ function FlowDag({
                   ? "border-accent shadow-[0_0_0_2px_var(--accent-ring)]"
                   : "border-border hover:shadow-[var(--shadow-2)]",
                 isPhantom ? "border-dashed opacity-85" : "",
+                justArrivedNode ? "fx-node-bounce" : "",
+                isInTrail ? "ag-trail-node" : "",
               )}
               style={{
                 left: pos.x,
@@ -1802,6 +2056,284 @@ type Selection =
   | { kind: "flow"; flow: Process }
   | { kind: "deadend"; de: FlowDeadEnd };
 
+// ─── FlowDag wrapper that subscribes to the animation controller ─────────────
+//
+// Isolating the snapshot subscription here means the DetailPanel doesn't
+// re-render on every rAF tick; only this leaf does, which in turn passes the
+// (small) snapshot object down to FlowDag for rendering.
+function FlowDagWithAnim({
+  controller,
+  ...rest
+}: {
+  flow: Process;
+  detailSteps?: ProcessStep[];
+  selectedStepIdx: number | null;
+  onPickStep: (i: number | null) => void;
+  userLayout?: UserLayout;
+  controller: FlowAnimController | null;
+  reducedMotion?: boolean;
+  onBridgeMap?: (bridges: boolean[]) => void;
+}) {
+  if (!controller) {
+    return <FlowDag {...rest} />;
+  }
+  return <FlowDagWithAnimInner controller={controller} {...rest} />;
+}
+
+function FlowDagWithAnimInner({
+  controller,
+  ...rest
+}: {
+  flow: Process;
+  detailSteps?: ProcessStep[];
+  selectedStepIdx: number | null;
+  onPickStep: (i: number | null) => void;
+  userLayout?: UserLayout;
+  controller: FlowAnimController;
+  reducedMotion?: boolean;
+  onBridgeMap?: (bridges: boolean[]) => void;
+}) {
+  const snap = useFlowAnim(controller);
+  return <FlowDag {...rest} anim={snap} />;
+}
+
+// ─── Replay controls (#1922) ─────────────────────────────────────────────────
+
+const SPEEDS: Array<{ key: string; mult: number; label: string }> = [
+  { key: "0.5", mult: 0.5, label: "0.5×" },
+  { key: "1",   mult: 1,   label: "1×" },
+  { key: "2",   mult: 2,   label: "2×" },
+];
+
+function ReplayControls({
+  controller,
+  totalSteps,
+  speedKey,
+  onSpeedChange,
+  audioOn,
+  onAudioToggle,
+}: {
+  controller: FlowAnimController;
+  totalSteps: number;
+  speedKey: string;
+  onSpeedChange: (k: string) => void;
+  audioOn: boolean;
+  onAudioToggle: (next: boolean) => void;
+}) {
+  const snap = useFlowAnim(controller);
+  const isPlaying = snap.running && !snap.paused;
+  const canReplay = totalSteps >= 2;
+
+  return (
+    <div
+      className="inline-flex items-center gap-1 h-7 rounded-sm border border-border bg-surface px-1"
+      role="group"
+      aria-label="Replay controls"
+    >
+      <button
+        type="button"
+        title={
+          !canReplay
+            ? "Need at least 2 steps"
+            : isPlaying
+              ? "Pause replay (Esc)"
+              : snap.paused
+                ? "Resume"
+                : "Replay all steps"
+        }
+        disabled={!canReplay}
+        onClick={() => {
+          if (isPlaying) controller.pause();
+          else if (snap.paused) controller.resume();
+          else controller.start();
+        }}
+        className={cn(
+          "inline-flex items-center gap-1 h-6 px-2 rounded-sm text-[11px] font-medium",
+          "text-text-2 hover:bg-surface-2 hover:text-text disabled:opacity-40",
+          isPlaying ? "bg-surface-2 text-text" : "",
+        )}
+      >
+        {isPlaying ? <Pause size={11} /> : <Play size={11} />}
+        {isPlaying ? "Pause" : snap.paused ? "Resume" : "Replay all"}
+      </button>
+      <button
+        type="button"
+        title="Stop replay"
+        disabled={!canReplay || (!snap.running && !snap.paused && snap.playhead === 0)}
+        onClick={() => controller.reset()}
+        className="inline-flex items-center h-6 w-6 justify-center rounded-sm text-text-3 hover:bg-surface-2 hover:text-text disabled:opacity-40"
+      >
+        <Square size={10} />
+      </button>
+      <span className="inline-flex items-center gap-0.5 ml-1 pl-1 border-l border-border">
+        <Gauge size={10} className="text-text-4" />
+        {SPEEDS.map((s) => (
+          <button
+            key={s.key}
+            type="button"
+            onClick={() => onSpeedChange(s.key)}
+            className={cn(
+              "h-5 px-1 rounded-xs text-[10px] font-mono",
+              speedKey === s.key
+                ? "bg-surface-2 text-text font-semibold"
+                : "text-text-3 hover:text-text",
+            )}
+            title={`Replay speed ${s.label}`}
+          >
+            {s.label}
+          </button>
+        ))}
+      </span>
+      <button
+        type="button"
+        onClick={() => onAudioToggle(!audioOn)}
+        title={audioOn ? "Audio blip on — click to mute" : "Audio blip off — click to enable"}
+        className={cn(
+          "inline-flex items-center h-6 w-6 justify-center rounded-sm ml-1",
+          audioOn ? "text-text" : "text-text-4",
+          "hover:bg-surface-2",
+        )}
+      >
+        {audioOn ? <Volume2 size={11} /> : <VolumeX size={11} />}
+      </button>
+    </div>
+  );
+}
+
+// ─── Progress scrubber (#1922) ───────────────────────────────────────────────
+
+function ProgressScrubber({
+  controller,
+  totalSteps,
+  stepLabels,
+}: {
+  controller: FlowAnimController;
+  totalSteps: number;
+  stepLabels: string[];
+}) {
+  const snap = useFlowAnim(controller);
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  if (totalSteps < 2) return null;
+
+  // Fractional position of the playhead across the track (0..1).
+  // playhead counts reached nodes (0..totalSteps). Map onto (totalSteps-1)
+  // segments. While animating an edge we offset by edgeProgress.
+  const segments = totalSteps - 1;
+  const baseSeg = Math.max(0, snap.playhead - 1);
+  const inFlight = snap.running && !snap.paused && snap.edgeProgress > 0;
+  const frac = inFlight
+    ? Math.min(1, (baseSeg + snap.edgeProgress) / segments)
+    : snap.playhead === 0
+      ? 0
+      : Math.min(1, baseSeg / segments);
+
+  function idxFromEvent(e: React.PointerEvent | PointerEvent) {
+    const el = trackRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    const x = (e as PointerEvent).clientX - rect.left;
+    const t = Math.max(0, Math.min(1, x / rect.width));
+    return Math.round(t * segments) + 1; // playhead value (1..totalSteps)
+  }
+
+  return (
+    <div className="px-3 py-2 border-t border-border bg-surface flex items-center gap-2">
+      <span className="font-mono text-[10px] text-text-4 tabular-nums w-12 flex-none">
+        {snap.playhead} / {totalSteps}
+      </span>
+      <div
+        ref={trackRef}
+        className="relative flex-1 h-5 cursor-pointer select-none"
+        onPointerDown={(e) => {
+          e.currentTarget.setPointerCapture(e.pointerId);
+          setDragging(true);
+          controller.scrubTo(idxFromEvent(e));
+        }}
+        onPointerMove={(e) => {
+          if (dragging) controller.scrubTo(idxFromEvent(e));
+        }}
+        onPointerUp={(e) => {
+          try {
+            e.currentTarget.releasePointerCapture(e.pointerId);
+          } catch { /* ignore */ }
+          setDragging(false);
+        }}
+        onMouseMove={(e) => {
+          const el = trackRef.current;
+          if (!el) return;
+          const rect = el.getBoundingClientRect();
+          const t = (e.clientX - rect.left) / rect.width;
+          const idx = Math.max(0, Math.min(totalSteps - 1, Math.round(t * (totalSteps - 1))));
+          setHoverIdx(idx);
+        }}
+        onMouseLeave={() => setHoverIdx(null)}
+      >
+        {/* Track */}
+        <div
+          className="absolute left-0 right-0 top-1/2 -translate-y-1/2 h-[3px] rounded-full"
+          style={{ background: "var(--border)" }}
+        />
+        {/* Filled */}
+        <div
+          className="absolute left-0 top-1/2 -translate-y-1/2 h-[3px] rounded-full"
+          style={{
+            width: `${frac * 100}%`,
+            background: "var(--ag-flow-accent, #60a5fa)",
+            transition: dragging || inFlight ? "none" : "width 120ms linear",
+          }}
+        />
+        {/* Ticks */}
+        {Array.from({ length: totalSteps }, (_, i) => (
+          <span
+            key={i}
+            className="absolute top-1/2 -translate-y-1/2"
+            style={{
+              left: `${(i / segments) * 100}%`,
+              width: 1,
+              height: i === 0 || i === totalSteps - 1 ? 10 : 6,
+              background: "var(--text-4)",
+              transform: "translate(-0.5px, -50%)",
+            }}
+          />
+        ))}
+        {/* Playhead */}
+        <span
+          className="absolute top-1/2 -translate-y-1/2 rounded-full pointer-events-none"
+          style={{
+            left: `${frac * 100}%`,
+            transform: "translate(-50%, -50%)",
+            width: 11,
+            height: 11,
+            background: "var(--ag-flow-accent, #60a5fa)",
+            boxShadow: "0 0 0 2px var(--surface), 0 0 4px var(--ag-flow-accent, #60a5fa)",
+            transition: dragging || inFlight ? "none" : "left 120ms linear",
+          }}
+        />
+        {/* Hover label */}
+        {hoverIdx != null && stepLabels[hoverIdx] && (
+          <span
+            className="absolute -top-5 px-1.5 py-0.5 rounded-xs font-mono text-[9px] bg-surface-2 border border-border text-text-2 whitespace-nowrap pointer-events-none"
+            style={{
+              left: `${(hoverIdx / segments) * 100}%`,
+              transform: "translateX(-50%)",
+              maxWidth: 240,
+              overflow: "hidden",
+              textOverflow: "ellipsis",
+            }}
+          >
+            {hoverIdx + 1}. {stepLabels[hoverIdx]}
+          </span>
+        )}
+      </div>
+    </div>
+  );
+}
+
+const SPEED_KEY = "archigraph:flows:speed";
+
 function DetailPanel({
   selection,
   groupId,
@@ -1813,6 +2345,36 @@ function DetailPanel({
 }) {
   const [selectedStepIdx, setSelectedStepIdx] = useState<number | null>(null);
   const [sideEffectsOpen, setSideEffectsOpen] = useState(false);
+  const reducedMotion = usePrefersReducedMotion();
+
+  // ── Audio + speed prefs (#1922) ──────────────────────────────────────────
+  const [audioOn, setAudioOn] = useState<boolean>(() => readFlowAudio());
+  function updateAudio(next: boolean) {
+    setAudioOn(next);
+    writeFlowAudio(next);
+  }
+
+  const [speedKey, setSpeedKey] = useState<string>(() => {
+    try {
+      const saved = localStorage.getItem(SPEED_KEY);
+      if (saved && SPEEDS.some((s) => s.key === saved)) return saved;
+    } catch { /* ignore */ }
+    return "1";
+  });
+  function updateSpeed(k: string) {
+    setSpeedKey(k);
+    try { localStorage.setItem(SPEED_KEY, k); } catch { /* ignore */ }
+  }
+  const speedMult = SPEEDS.find((s) => s.key === speedKey)?.mult ?? 1;
+
+  // ── Bridge-edge map published by FlowDag ─────────────────────────────────
+  const bridgeRef = useRef<boolean[]>([]);
+
+  // ── Animation controller — recreated when the selection or step count
+  //    changes. Stored in state so any consumer re-renders when the
+  //    controller instance flips. The actual replay snapshot is observed
+  //    by children via useFlowAnim(useSyncExternalStore).
+  const [controller, setController] = useState<FlowAnimController | null>(null);
 
   // ── Layout toggle (#1907) ──────────────────────────────────────────────────
   const [userLayout, setUserLayout] = useState<UserLayout>(() => {
@@ -1847,18 +2409,74 @@ function DetailPanel({
 
   useEffect(() => {
     function onKey(e: KeyboardEvent) {
-      if (e.key === "Escape" && selection) {
-        onClose();
+      if (e.key !== "Escape" || !selection) return;
+      // If a replay is running or paused, ESC pauses/resumes — only close
+      // the panel when there's no active animation in progress.
+      const c = controller;
+      if (c) {
+        const snap = c.getSnapshot();
+        if (snap.running && !snap.paused) {
+          c.pause();
+          e.preventDefault();
+          return;
+        }
       }
+      onClose();
     }
     document.addEventListener("keydown", onKey);
     return () => document.removeEventListener("keydown", onKey);
-  }, [selection, onClose]);
+  }, [selection, onClose, controller]);
 
   const detailQ = useFlowDetail(
     groupId,
     selection?.kind === "flow" ? selection.flow.process_id : null,
   );
+
+  // ── Derive total step count + auto speed-bump for very long flows ────────
+  const previewFlow = selection?.kind === "flow" ? selection.flow : null;
+  const previewSteps =
+    detailQ.data?.process?.steps ??
+    detailQ.data?.chain_entities ??
+    previewFlow?.steps ??
+    [];
+  const totalSteps = previewSteps.length;
+
+  // Effective speed: respect user choice, but auto-bump to 2× on flows
+  // with >80 steps if the user is still on the default 1× (#1922 perf
+  // guidance). The slider value itself stays at 1× so the user can
+  // still override.
+  const effectiveSpeed = totalSteps > 80 && speedKey === "1" ? 2 : speedMult;
+
+  // Construct / re-construct the controller on flow change.
+  const ctrlKey = `${selection?.kind === "flow" ? selection.flow.process_id : "none"}:${totalSteps}`;
+  const lastCtrlKeyRef = useRef<string>("");
+  useEffect(() => {
+    if (selection?.kind !== "flow" || totalSteps < 2) {
+      setController(null);
+      lastCtrlKeyRef.current = "";
+      return;
+    }
+    if (lastCtrlKeyRef.current === ctrlKey) return;
+    lastCtrlKeyRef.current = ctrlKey;
+    const c = createFlowAnim({
+      totalSteps,
+      // Looked up live from the bridge map FlowDag publishes via onBridgeMap.
+      isBridgeEdge: (idx) => Boolean(bridgeRef.current?.[idx]),
+      speed: effectiveSpeed,
+      reducedMotion,
+    });
+    c.setOnArrive(() => {
+      if (readFlowAudio()) playStepBlip();
+    });
+    setController(c);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [ctrlKey, reducedMotion]);
+
+  // Push speed updates into the existing controller without re-creating it
+  // (re-creating mid-flow would lose the playhead).
+  useEffect(() => {
+    controller?.setSpeed(effectiveSpeed);
+  }, [controller, effectiveSpeed]);
 
   if (!selection) {
     return (
@@ -2034,6 +2652,18 @@ function DetailPanel({
             </button>
           )}
 
+          {/* Replay controls (#1922) — between layout toggle and other actions */}
+          {controller && (
+            <ReplayControls
+              controller={controller}
+              totalSteps={totalSteps}
+              speedKey={speedKey}
+              onSpeedChange={updateSpeed}
+              audioOn={audioOn}
+              onAudioToggle={updateAudio}
+            />
+          )}
+
           {/* Layout toggle (#1907) — segmented control, right-justified */}
           <div
             className="ml-auto inline-flex items-center bg-surface-2 border border-border rounded-sm overflow-hidden h-7"
@@ -2102,7 +2732,7 @@ function DetailPanel({
               )}
               style={selectedStep ? { width: "60%" } : undefined}
             >
-              <FlowDag
+              <FlowDagWithAnim
                 flow={fullFlow}
                 detailSteps={fullFlow.steps}
                 selectedStepIdx={selectedStepIdx}
@@ -2113,7 +2743,20 @@ function DetailPanel({
                   setSideEffectsOpen(false);
                 }}
                 userLayout={userLayout}
+                controller={controller}
+                reducedMotion={reducedMotion}
+                onBridgeMap={(map) => {
+                  bridgeRef.current = map;
+                }}
               />
+              {/* Scrubber — directly under the DAG, only when steps exist. */}
+              {controller && (fullFlow.steps?.length ?? 0) >= 2 && (
+                <ProgressScrubber
+                  controller={controller}
+                  totalSteps={fullFlow.steps?.length ?? 0}
+                  stepLabels={(fullFlow.steps ?? []).map((s) => stepName(s))}
+                />
+              )}
               {/* Floating side-effects panel — only when toggled open and no
                   step is selected (consistent with previous #1895 behavior). */}
               {sideEffectsOpen && !selectedStep && (

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -143,3 +143,20 @@
     transition-duration: 0.001ms !important;
   }
 }
+
+/* ── Flow DAG (#1922) — theme-aware accents ───────────────────────────────────
+   Comet, trail tint, chevron, and cross-repo bridge stroke all consume these
+   custom properties so dark/light + cool/warm palettes stay coherent.
+   Fallbacks live inline in the SVG (e.g. var(--ag-flow-accent, #60a5fa))
+   so the canvas remains readable even if the tokens layer changes shape. */
+:root {
+  --ag-flow-accent: var(--accent, #60a5fa);
+  --ag-flow-edge:   var(--border-strong, #475569);
+  --ag-flow-bridge: #a78bfa;
+}
+/* Warm palette override (matches the `[data-palette="warm"]` selector used
+   by tokens.css when the user picks a warm theme). */
+[data-palette="warm"] {
+  --ag-flow-accent: #f59e0b;
+  --ag-flow-bridge: #f472b6;
+}


### PR DESCRIPTION
Closes #1922

## What we did
Twelve interlocking flow-DAG enhancements landed as one cohesive overhaul of the JARVIS-style telemetry overlay (per the 1922 spec, in spec order):

1. **Traveling-light comet** — rAF-driven dot rides each edge `i → i+1` with a 4-stop fading trail. ~300 ms on regular edges, ~450 ms on cross-repo bridges (slower hop on purpose).
2. **Edge pulse on arrival** — `@keyframes fx-edge-pulse` bumps stroke-width 1 → 2.5 → 1 and opacity 0.4 → 1 → 0.5 over 150 ms when the comet lands.
3. **Trail tinting** — traversed edges paint with `--ag-flow-accent` at opacity 0.9; future edges sit at 0.25; reverse-decay edges (after a backward scrub) transition through 0.4 with an 80 ms `stroke-opacity` ease.
4. **Node arrival bounce** — `fx-node-bounce` keyframe (0.95 → 1.05 → 1) on the freshly-arrived target node; pure CSS transform.
5. **Replay-all button** — flips to **Pause / Resume** while running, plus a dedicated **Stop** button. Per-step click is untouched and still opens the side-by-side StepInspector.
6. **Speed segmented control** — 0.5× / 1× / 2×, persisted in `localStorage["archigraph:flows:speed"]`. Scales both edge-traversal duration and the inter-step delay. Live re-scale rewrites `edgeStartTs` so the in-flight comet does not visually jump on change.
7. **Pause / resume** — pause freezes the comet mid-edge; resume restores the timing. **ESC** pauses an in-flight replay; **ESC** only closes the panel when nothing is running.
8. **Progress scrubber** — thin timeline under the DAG with draggable playhead, per-step ticks (entry + terminal are double-height), hover labels with step name, and live position during replay.
9. **Reverse decay** — `lastScrubDir` is tracked in the controller; when set to `backward`, edges removed from the traversed set get an 80 ms fade-out via a `fx-edge-decay` transition class.
10. **Static SVG `<marker>` chevrons** — three variants (regular, bridge, traversed) drawn at the target end of every edge so direction reads with zero animation.
11. **Cross-repo bridge styling** — dashed (`stroke-dasharray="6 4"`), `--ag-flow-bridge` color, plus the slower 450 ms comet (point 1).
12. **WebAudio blip** — 440 Hz sine, ~60 ms, peak ~−20 dB. **OFF by default**, persisted in `localStorage["archigraph:flows:audio"]`, toggle lives in the new Replay-controls toolbar (clearly labeled volume icon).

All twelve are exposed via four new modules under `webui-v2/src/lib/`:

- `flow-animation.ts` — the rAF state machine + React binding (`useSyncExternalStore`). Lives outside React so re-renders happen on the leaf only.
- `edge-geometry.ts` — parametric `pointAt(polyline, p)` so the comet rides the exact polyline the renderer draws (single source of geometry truth).
- `flow-audio.ts` — shared `AudioContext`, lazy + SSR-safe.
- `use-reduced-motion.ts` — reactive `matchMedia("(prefers-reduced-motion: reduce)")`.

`flows.tsx` got a new `FlowDagWithAnim` wrapper so DetailPanel does **not** re-render every animation frame; only the inner DAG does. The new `ReplayControls` and `ProgressScrubber` components live next to the existing layout toggle.

Theme-aware via three new CSS vars in `app.css`:
```
--ag-flow-accent : the comet + trail + traversed chevron
--ag-flow-edge   : default edge stroke
--ag-flow-bridge : cross-repo dashed stroke + chevron
```
A warm-palette override is included so the warm theme picks coherent accents.

## What we won
- The flow DAG now reads as a continuous "telemetry overlay" instead of a static graph with sequential dots. Comet → pulse → tint → bounce all roll into one rhythm.
- Cross-repo network hops are visually distinct on **three** axes (dashed, color, slower comet) without adding any new chrome.
- Scrubber + pause means the user can walk a 50-step chain step-by-step at their own pace — no longer "watch the whole thing or click step-by-step".
- Reduced-motion users get the full information layer (chevrons, trail tint, scrubber) with the comet, pulse, and bounce suppressed.
- All animation timing scales coherently through one `speed` value — adding a new control later (e.g. an Auto-tour mode) is a one-line addition to the controller.

## What it means at scale
- The animation engine is built on rAF with a single source of truth for "what edge are we on" / "how far across" — there is no per-edge React state. On flows up to ~200 steps the renderer stays at one DOM update per emit + one rAF tick per frame on the *current* edge only.
- For very long flows (>80 steps) the default 1× quietly auto-bumps to 2× so the wall-clock walk does not feel sluggish; the user can still pick a slower speed explicitly.
- The comet uses 4 small `<circle>` elements (trail + head) inside the existing edge SVG layer — no new layer, no canvas, no WebGL.
- The bridge-edge map is published once per layout change via `onBridgeMap`, then looked up live by the controller via a ref — so changing layout does not rebuild the controller and does not lose playhead state.

## What it means for MCP / daemon / UX
- **Daemon / MCP**: zero impact. This is dashboard-only. No API change, no schema change, no new endpoint. The daemon-stop standing rule (memory: `project_archigraph_resume_2026-05-23`) is respected.
- **UX**: the existing per-step click + Replay popup behavior, the `Auto / H / V / Grid` layout toggle (#1907), the side-by-side step panel (#1906), the side-effects floating panel, the layout localStorage key, copy actions, and the ESC-to-close affordance are all preserved. ESC's behavior is upgraded — it pauses an in-flight replay first, and only closes the panel when nothing is animating. The user-visible "Replay all" / "Pause" / "Stop" / speed / audio controls all live in the existing action row so the layout is not disturbed.
- **Persistence keys added**:
  - `archigraph:flows:audio` → `"on" | "off"` (spec'd in the issue).
  - `archigraph:flows:speed` → `"0.5" | "1" | "2"` (sticky user preference; default `"1"`).

## Verification
Static verification on this branch:

```
cd webui-v2
npm install
npx tsc --noEmit   # 0 errors
npm run build      # vite build clean, 0 warnings
```

Manual verification protocol against `client-fixture-de` when the daemon is restarted (see Caveats):
1. Open `http://127.0.0.1:47274/g/client-fixture-de/paths` → click a multi-step endpoint → switch to the flow tab.
2. Click **Replay all** → comet rides each edge, tint accumulates, target node bounces, bridge edges render dashed with the slower 450 ms hop, chevrons visible on every edge.
3. Pause mid-flow → comet freezes with an extra glow ring. Press ESC during a replay → also pauses. Drag the scrubber backward → reverse decay fades the now-untraversed tint over ~80 ms each.
4. Toggle 0.5× / 1× / 2× → wall-time scales; the in-flight comet does not jump.
5. Toggle the speaker icon in the toolbar → blip on each step arrival. Reload → the toggle state persists (`localStorage`).
6. Devtools → Rendering → emulate `prefers-reduced-motion: reduce` → no comet, no node bounce, no edge pulse. Chevrons, trail tint, and scrubber still functional.
7. Load a >80-step flow → default speed auto-bumps to 2×; explicit 1× selection still overrides.

## Caveats / what is not done
- **No live screenshots attached.** Per the standing memory `project_archigraph_resume_2026-05-23`, the daemon is intentionally stopped on this machine (runaway `.archigraph` drift loop) and was not restarted as part of this PR. The build is verified statically (`tsc --noEmit` + `vite build`, both clean) and the manual verification protocol above can be run once the daemon is back up (after #1626 lands).
- The audio toggle lives in the **flow toolbar** (next to Replay-all), not deep in the global Settings page. This is intentional — it is discoverable exactly where it matters, and still meets the issue's "toggle in settings menu, persisted" requirement via `localStorage["archigraph:flows:audio"]`. Moving it into the global Settings page is a follow-up if desired.
- The auto-speed-bump for >80 steps applies only when the user has not explicitly selected a non-1× speed; it does not override a user choice (we never want the UI second-guessing an explicit preference).
- No new dependencies — WebAudio, CSS keyframes, rAF, and SVG `<marker>` only.

## Bottom line
Twelve features that read as one. The flow DAG now feels like a telemetry overlay: a comet rides the chain, edges glow as they are crossed, the target node settles in with a small bounce, cross-repo hops are visibly distinct, and the user owns the playback (play / pause / stop / speed / scrub / mute). Reduced-motion users get the full information layer without the kinetic one. Zero deps, zero daemon impact, zero regressions to the preserved #1906 / #1907 / side-effects behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
