### PR TITLE
feat(dashboard+java): unified endpoint-detail refs + JAX-RS body extraction (#1908 #1909 #1910)

### DIFF
--- a/internal/dashboard/graphstate.go
+++ b/internal/dashboard/graphstate.go
@@ -525,9 +525,22 @@ func findEntity(g *DashGroup, key string) (*DashRepo, *graph.Entity) {
 	// Prefixed "<repo>::<local>".
 	if rp, local := dashSplitPrefixed(key); rp != "" {
 		if r, ok := g.Repos[rp]; ok && r.Doc != nil {
+			// First try exact ID match.
 			for i := range r.Doc.Entities {
 				if r.Doc.Entities[i].ID == local {
 					return r, &r.Doc.Entities[i]
+				}
+			}
+			// Synthetic IDs produced during JS/TS extraction have the form
+			// "Kind:Name" (e.g. "Function:confirmTransfer") — they never match
+			// hex entity IDs. Resolve by extracting the name portion and falling
+			// back to a name-based lookup within the same repo.
+			if idx := strings.LastIndex(local, ":"); idx >= 0 {
+				name := local[idx+1:]
+				for i := range r.Doc.Entities {
+					if r.Doc.Entities[i].Name == name {
+						return r, &r.Doc.Entities[i]
+					}
 				}
 			}
 		}

--- a/internal/dashboard/v2_paths.go
+++ b/internal/dashboard/v2_paths.go
@@ -17,6 +17,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cajasmota/archigraph/internal/graph"
 	"github.com/cajasmota/archigraph/internal/mcp"
 	"github.com/cajasmota/archigraph/internal/types"
 )
@@ -671,6 +672,10 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 		// Both are used to match inbound cross-repo links (#1891).
 		HandlerEntityIDs []string
 		DefEntityID      string
+		// Issue #1909 — JAX-RS / Spring request body type inferred from method
+		// parameter annotations (populated for POST/PUT/PATCH endpoints).
+		RequestBodyType      string
+		RequestBodyParamName string
 	}
 
 	var hits []matched
@@ -810,8 +815,11 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 				OutboundIDs:   classified.downstream,
 				SideEffectIDs: classified.sideEffects,
 				TestIDs:       classified.tests,
-				HandlerEntityIDs: prefixedHandlerIDs,
-				DefEntityID:      dashPrefixedID(repo.Slug, e.ID),
+				HandlerEntityIDs:     prefixedHandlerIDs,
+				DefEntityID:          dashPrefixedID(repo.Slug, e.ID),
+				// Issue #1909 — request body type from entity properties.
+				RequestBodyType:      e.Properties["request_body_type"],
+				RequestBodyParamName: e.Properties["request_body_param_name"],
 			})
 		}
 	}
@@ -917,6 +925,31 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	// Extract parameters from path segments (dynamic path params).
 	params := extractPathParameters(pathStr, verbs)
 
+	// Issue #1909 — append request body parameter when the Java extractor
+	// captured a JAX-RS / Spring request body type. Collect from all matched
+	// hits (may differ per verb); first non-empty wins per verb.
+	{
+		seenBodyVerbs := map[string]bool{}
+		for _, h := range hits {
+			if h.RequestBodyType == "" || seenBodyVerbs[h.Verb] {
+				continue
+			}
+			seenBodyVerbs[h.Verb] = true
+			paramName := h.RequestBodyParamName
+			if paramName == "" {
+				paramName = "body"
+			}
+			params = append(params, v2PathParameter{
+				Name:     paramName,
+				In:       "body",
+				Type:     h.RequestBodyType,
+				Required: true,
+				Desc:     "Request body — inferred from method parameter annotation.",
+				Verbs:    []string{h.Verb},
+			})
+		}
+	}
+
 	// Resolve entity IDs (#1646: all collected from the resolved handler).
 	calledByIDs := collectUniqueIDs(hits, func(h matched) []string { return h.CalledByIDs })
 	outboundIDs := collectUniqueIDs(hits, func(h matched) []string { return h.OutboundIDs })
@@ -963,7 +996,9 @@ func (s *Server) handleV2PathDetail(w http.ResponseWriter, r *http.Request) {
 	// Called-by: inbound callers resolved to this endpoint (frontend FETCHES
 	// retargeted to the definition + intra-repo CALLS into the handler, plus
 	// cross-repo http_endpoint_call sources from the links file).
-	inboundFetches := resolveEntitySlice(grp, calledByIDs, "CALLED_BY")
+	// Issue #1908 — use the specialized inbound resolver that unwraps
+	// http_endpoint_call entities to their actual calling code entity.
+	inboundFetches := resolveInboundFetches(grp, calledByIDs)
 	// Downstream: the handler's outbound CALLS (services, helpers, DB-access fns).
 	outboundAll := resolveEntitySlice(grp, outboundIDs, "CALLS")
 	// Side effects: DB writes / model mutation / pub-sub the handler performs.
@@ -1358,6 +1393,195 @@ func mergeUniqueStrings(base, extra []string) []string {
 		}
 	}
 	return base
+}
+
+// resolveInboundFetches resolves a list of caller entity IDs for the
+// "Called by" section. Issue #1908: when the resolved entity is an
+// http_endpoint_call (its name is an HTTP URL pattern like
+// "http:PUT:/transfers/..."), the useful information is NOT the URL template
+// but the ACTUAL calling code entity (the function/method that makes the call).
+//
+// Resolution strategy:
+//  1. Look up the entity by the prefixed ID.
+//  2. If the entity's kind contains "http_endpoint_call" OR its name starts
+//     with "http:" (the canonical http_endpoint_call naming convention), scan
+//     the owning repo's relationship list for an entity that has a FETCHES or
+//     CALLS edge TO this http_endpoint_call entity. Use that entity instead.
+//  3. Fall back to the http_endpoint_call entity itself when no caller is found
+//     (better than dropping the entry entirely).
+func resolveInboundFetches(grp *DashGroup, ids []string) []v2PathEntity {
+	out := make([]v2PathEntity, 0, len(ids))
+	for _, id := range ids {
+		repo, entity := findEntity(grp, id)
+		if entity == nil {
+			continue
+		}
+
+		// Determine if this entity is an http_endpoint_call that needs unwrapping.
+		// http_endpoint_call entities carry the URL pattern as their name
+		// (e.g. "http:PUT:/transfers/confirm/{transferId}") which is not useful
+		// as a "Called by" label. We unwrap these to the actual caller entity.
+		kind := dashStripScopePrefix(entity.Kind)
+		isCallEntity := strings.EqualFold(kind, "http_endpoint_call") ||
+			strings.EqualFold(entity.Kind, "http_endpoint_call") ||
+			strings.Contains(strings.ToLower(entity.Kind), "http_endpoint_call") ||
+			strings.HasPrefix(entity.Name, "http:")
+
+		if isCallEntity && repo != nil {
+			// Find the entity that FETCHES or CALLS this http_endpoint_call.
+			// Relationships are stored at the Doc level (not on Entity).
+			localID := entity.ID
+			// Build an entity-by-ID lookup for this repo so we can quickly look up
+			// the caller by its FromID.
+			entityByID := make(map[string]*graph.Entity, len(repo.Doc.Entities))
+			entityByName := make(map[string]*graph.Entity, len(repo.Doc.Entities))
+			for i := range repo.Doc.Entities {
+				e := &repo.Doc.Entities[i]
+				entityByID[e.ID] = e
+				entityByName[e.Name] = e
+			}
+			// resolveSyntheticFromID resolves synthetic "Kind:Name" IDs produced
+			// during JS/TS extraction (e.g. "Function:confirmTransfer"). These IDs
+			// don't match the real hex entity IDs, so we extract the name portion
+			// and fall back to an entity-by-name lookup in the same repo.
+			resolveSyntheticFromID := func(fromID string) *graph.Entity {
+				if e := entityByID[fromID]; e != nil {
+					return e
+				}
+				// Try "Kind:Name" synthetic id formats
+				if idx := strings.LastIndex(fromID, ":"); idx >= 0 {
+					name := fromID[idx+1:]
+					if e := entityByName[name]; e != nil {
+						return e
+					}
+				}
+				return nil
+			}
+			for i := range repo.Doc.Relationships {
+				rel := &repo.Doc.Relationships[i]
+				if rel.ToID == localID &&
+					(rel.Kind == "FETCHES" || rel.Kind == "CALLS") {
+					if caller := resolveSyntheticFromID(rel.FromID); caller != nil {
+						callerLabel := caller.Name
+						callerQN := caller.QualifiedName
+						if callerQN == "" {
+							callerQN = callerLabel
+						}
+						out = append(out, v2PathEntity{
+							Label:         callerLabel,
+							QualifiedName: callerQN,
+							Kind:          dashStripScopePrefix(caller.Kind),
+							Repo:          repo.Slug,
+							SourceFile:    caller.SourceFile,
+							StartLine:     caller.StartLine,
+							Edge:          "CALLED_BY",
+							Protocol:      caller.Properties["protocol"],
+						})
+						goto nextID
+					}
+				}
+			}
+			// No intra-repo caller relationship found — also scan all other repos in
+			// the group (cross-repo FETCHES edges from a consumer repo).
+			callerEntityLocalID := entity.ID
+			callerFound := false
+			for _, otherRepo := range sortedRepos(grp) {
+				if otherRepo.Slug == repo.Slug {
+					continue
+				}
+				otherEntityByID := make(map[string]*graph.Entity, len(otherRepo.Doc.Entities))
+				otherEntityByName := make(map[string]*graph.Entity, len(otherRepo.Doc.Entities))
+				for i := range otherRepo.Doc.Entities {
+					e := &otherRepo.Doc.Entities[i]
+					otherEntityByID[e.ID] = e
+					otherEntityByName[e.Name] = e
+				}
+				resolveOtherSyntheticID := func(fromID string) *graph.Entity {
+					if e := otherEntityByID[fromID]; e != nil {
+						return e
+					}
+					if idx := strings.LastIndex(fromID, ":"); idx >= 0 {
+						name := fromID[idx+1:]
+						if e := otherEntityByName[name]; e != nil {
+							return e
+						}
+					}
+					return nil
+				}
+				for i := range otherRepo.Doc.Relationships {
+					rel := &otherRepo.Doc.Relationships[i]
+					if rel.ToID == callerEntityLocalID &&
+						(rel.Kind == "FETCHES" || rel.Kind == "CALLS") {
+						if caller := resolveOtherSyntheticID(rel.FromID); caller != nil {
+							callerLabel := caller.Name
+							callerQN := caller.QualifiedName
+							if callerQN == "" {
+								callerQN = callerLabel
+							}
+							out = append(out, v2PathEntity{
+								Label:         callerLabel,
+								QualifiedName: callerQN,
+								Kind:          dashStripScopePrefix(caller.Kind),
+								Repo:          otherRepo.Slug,
+								SourceFile:    caller.SourceFile,
+								StartLine:     caller.StartLine,
+								Edge:          "CALLED_BY",
+								Protocol:      caller.Properties["protocol"],
+							})
+							callerFound = true
+							goto nextID
+						}
+					}
+				}
+			}
+			if !callerFound {
+				// Fallback: surface the http_endpoint_call entity as-is — the
+				// URL pattern is more informative than dropping the entry.
+				repoSlug := ""
+				if repo != nil {
+					repoSlug = repo.Slug
+				}
+				label := entity.Name
+				qn := entity.QualifiedName
+				if qn == "" {
+					qn = label
+				}
+				out = append(out, v2PathEntity{
+					Label:         label,
+					QualifiedName: qn,
+					Kind:          kind,
+					Repo:          repoSlug,
+					SourceFile:    entity.SourceFile,
+					StartLine:     entity.StartLine,
+					Edge:          "CALLED_BY",
+					Protocol:      entity.Properties["protocol"],
+				})
+			}
+		} else {
+			// Regular non-endpoint entity: use as-is.
+			label := entity.Name
+			qn := entity.QualifiedName
+			if qn == "" {
+				qn = label
+			}
+			repoSlug := ""
+			if repo != nil {
+				repoSlug = repo.Slug
+			}
+			out = append(out, v2PathEntity{
+				Label:         label,
+				QualifiedName: qn,
+				Kind:          kind,
+				Repo:          repoSlug,
+				SourceFile:    entity.SourceFile,
+				StartLine:     entity.StartLine,
+				Edge:          "CALLED_BY",
+				Protocol:      entity.Properties["protocol"],
+			})
+		}
+	nextID:
+	}
+	return out
 }
 
 // resolveEntitySlice resolves a list of prefixed entity IDs to v2PathEntity values.

--- a/internal/engine/java_annotation_routes.go
+++ b/internal/engine/java_annotation_routes.go
@@ -106,7 +106,172 @@ var javaProducesRe = regexp.MustCompile(`@Produces\s*\(([^)]+)\)`)
 // line-by-line in the file walker; this regex matches one method-decl line.
 //
 // We accept: modifiers, generic return type, method-name, opening paren.
-var javaMethodDeclRe = regexp.MustCompile(`^\s*(?:public|protected|private|static|final|abstract|synchronized|default|\s)+[\w<>\[\],.\s?]+?\s+(\w+)\s*\(`)
+// Group 1 = method name; group 2 = rest of line after the opening paren
+// (the parameter fragment, may be partial for multi-line signatures).
+var javaMethodDeclRe = regexp.MustCompile(`^\s*(?:public|protected|private|static|final|abstract|synchronized|default|\s)+[\w<>\[\],.\s?]+?\s+(\w+)\s*\((.*)`)
+
+// jaxrsNonBodyAnnotations is the set of JAX-RS / Spring parameter annotations
+// whose presence means the parameter is NOT the request body.
+// Issue #1909: a JAX-RS method parameter that carries none of these is the
+// implicit request body (applies to POST/PUT/PATCH/DELETE).
+var jaxrsNonBodyAnnotations = []string{
+	"@PathParam", "@QueryParam", "@HeaderParam", "@FormParam",
+	"@CookieParam", "@Context", "@MatrixParam", "@BeanParam",
+	"@PathVariable", "@RequestParam", "@RequestHeader", // Spring equivalents
+}
+
+// jaxrsVerbsThatHaveBody is the set of HTTP verbs where a request body is
+// plausible. GET/HEAD/OPTIONS are excluded to avoid false positives.
+var jaxrsVerbsThatHaveBody = map[string]bool{
+	"POST": true, "PUT": true, "PATCH": true, "DELETE": true,
+}
+
+// inferRequestBodyParam parses the parameter fragment from a method declaration
+// and returns the (type, name) of the first parameter that carries no JAX-RS
+// binding annotation. Returns ("","") when no body param is found or when the
+// verb set does not include a body-eligible verb.
+//
+// paramFrag is everything after the opening '(' on the method declaration line
+// (may not include the closing ')' for multi-line signatures — single-line is
+// the dominant case for REST controllers).
+func inferRequestBodyParam(paramFrag string, verbs []string) (bodyType, bodyName string) {
+	hasBodyVerb := false
+	for _, v := range verbs {
+		if jaxrsVerbsThatHaveBody[strings.ToUpper(v)] {
+			hasBodyVerb = true
+			break
+		}
+	}
+	if !hasBodyVerb {
+		return "", ""
+	}
+	// Trim trailing ')' or '{' if present.
+	paramFrag = strings.TrimRight(strings.TrimSpace(paramFrag), "){")
+	params := splitTopLevelCommas(paramFrag)
+	for _, chunk := range params {
+		chunk = strings.TrimSpace(chunk)
+		if chunk == "" {
+			continue
+		}
+		// @RequestBody (Spring) is an EXPLICIT body marker — highest priority.
+		if strings.Contains(chunk, "@RequestBody") {
+			t, n := extractParamTypeAndName(chunk)
+			if t != "" {
+				return t, n
+			}
+		}
+		// Skip if any non-body annotation is present.
+		skip := false
+		for _, anno := range jaxrsNonBodyAnnotations {
+			if strings.Contains(chunk, anno) {
+				skip = true
+				break
+			}
+		}
+		if skip {
+			continue
+		}
+		// No binding annotation — this parameter is the implicit body.
+		t, n := extractParamTypeAndName(chunk)
+		if t != "" && !isJavaNoisyType(t) {
+			return t, n
+		}
+	}
+	return "", ""
+}
+
+// isJavaNoisyType returns true for type names that are framework/context
+// objects and should NOT be surfaced as request body types.
+func isJavaNoisyType(t string) bool {
+	switch t {
+	case "void", "Response", "UriInfo", "SecurityContext",
+		"HttpServletRequest", "HttpServletResponse",
+		"Principal", "AsyncResponse", "SSEEventSink":
+		return true
+	}
+	return false
+}
+
+// splitTopLevelCommas splits s on commas that are not nested inside < > or ( ).
+func splitTopLevelCommas(s string) []string {
+	var out []string
+	depth := 0
+	start := 0
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case '<', '(':
+			depth++
+		case '>', ')':
+			if depth > 0 {
+				depth--
+			}
+		case ',':
+			if depth == 0 {
+				out = append(out, s[start:i])
+				start = i + 1
+			}
+		}
+	}
+	out = append(out, s[start:])
+	return out
+}
+
+// extractParamTypeAndName strips annotations from a parameter fragment and
+// returns (type, name). Returns ("","") when the fragment cannot be parsed.
+func extractParamTypeAndName(p string) (typ, name string) {
+	// Remove annotation tokens: @Word or @Word(args).
+	var sb strings.Builder
+	i := 0
+	for i < len(p) {
+		if p[i] == '@' {
+			i++ // skip '@'
+			for i < len(p) && (p[i] == '_' || (p[i] >= 'A' && p[i] <= 'Z') ||
+				(p[i] >= 'a' && p[i] <= 'z') || (p[i] >= '0' && p[i] <= '9')) {
+				i++
+			}
+			// Skip optional (...)
+			if i < len(p) && p[i] == '(' {
+				depth := 1
+				i++
+				for i < len(p) && depth > 0 {
+					if p[i] == '(' {
+						depth++
+					} else if p[i] == ')' {
+						depth--
+					}
+					i++
+				}
+			}
+			sb.WriteByte(' ')
+			continue
+		}
+		sb.WriteByte(p[i])
+		i++
+	}
+	tokens := strings.Fields(sb.String())
+	if len(tokens) < 2 {
+		return "", ""
+	}
+	// Last token = variable name, everything before = type.
+	// Strip trailing ')' or '{' that may appear when the method param list was
+	// captured on the same line as the opening brace (e.g. "body) {").
+	name = strings.TrimRight(tokens[len(tokens)-1], "){;")
+	// Strip leading "final" modifier from type.
+	typeTokens := tokens[:len(tokens)-1]
+	if len(typeTokens) > 0 && typeTokens[0] == "final" {
+		typeTokens = typeTokens[1:]
+	}
+	if len(typeTokens) == 0 {
+		return "", ""
+	}
+	typ = strings.TrimSpace(strings.Join(typeTokens, " "))
+	// Reject bare modifiers that leaked through.
+	switch typ {
+	case "final", "synchronized", "volatile", "transient", "static":
+		return "", ""
+	}
+	return typ, name
+}
 
 // ApplyJavaAnnotationRoutes scans the supplied Java files for JAX-RS or
 // Spring MVC annotation patterns and returns a slice of synthetic
@@ -249,13 +414,19 @@ func extractJavaEndpoints(src, relPath string) []types.EntityRecord {
 		// Method declaration?
 		if m := javaMethodDeclRe.FindStringSubmatch(line); m != nil {
 			methodName := m[1]
+			// m[2] is the rest of the line after the opening '(' — used for
+			// request body inference (#1909). May be empty for multi-line sigs.
+			paramFrag := ""
+			if len(m) > 2 {
+				paramFrag = m[2]
+			}
 			methodAnnos := flushAnnoBuf()
 			if cur.name == "" {
 				// Method declared before any class header (shouldn't happen
 				// in valid Java but harmless to skip).
 				continue
 			}
-			eps := buildMethodEndpoints(cur, methodName, methodAnnos, relPath)
+			eps := buildMethodEndpoints(cur, methodName, paramFrag, methodAnnos, relPath)
 			out = append(out, eps...)
 			continue
 		}
@@ -317,7 +488,10 @@ func buildClassFrame(className string, annos []string) classFrame {
 // (not a regex-windowed slice), it correctly handles annotation stacks of
 // any depth. @Path will be found regardless of how many @PermitAll,
 // @Consumes, @Operation, @RateLimited, etc. annotations precede it.
-func buildMethodEndpoints(cf classFrame, methodName string, annos []string, relPath string) []types.EntityRecord {
+//
+// Issue #1909: paramFrag is the rest of the method declaration line after the
+// opening '(' — used to infer the JAX-RS request body parameter type.
+func buildMethodEndpoints(cf classFrame, methodName, paramFrag string, annos []string, relPath string) []types.EntityRecord {
 	joined := strings.Join(annos, "\n")
 
 	// Collect method-level paths (may be empty).
@@ -404,6 +578,10 @@ func buildMethodEndpoints(cf classFrame, methodName string, annos []string, relP
 		uniqueVerbs = append(uniqueVerbs, v)
 	}
 
+	// Issue #1909 — infer request body type from the method parameter fragment.
+	// inferRequestBodyParam needs the full verb list to decide eligibility.
+	bodyType, bodyParamName := inferRequestBodyParam(paramFrag, uniqueVerbs)
+
 	var out []types.EntityRecord
 	for _, verb := range uniqueVerbs {
 		id := httproutes.SyntheticID(verb, canonical)
@@ -421,6 +599,14 @@ func buildMethodEndpoints(cf classFrame, methodName string, annos []string, relP
 		}
 		if methodProduces != "" {
 			props["produces"] = methodProduces
+		}
+		// Issue #1909 — emit request_body_type and request_body_param_name when
+		// the method carries an inferred or explicit JAX-RS / Spring request body.
+		if bodyType != "" && jaxrsVerbsThatHaveBody[strings.ToUpper(verb)] {
+			props["request_body_type"] = bodyType
+			if bodyParamName != "" {
+				props["request_body_param_name"] = bodyParamName
+			}
 		}
 
 		out = append(out, types.EntityRecord{

--- a/internal/engine/java_annotation_routes_test.go
+++ b/internal/engine/java_annotation_routes_test.go
@@ -401,6 +401,118 @@ public class AuthController {
 	}
 }
 
+// ---------------------------------------------------------------------------
+// Tests for #1909 — JAX-RS request body inference
+// ---------------------------------------------------------------------------
+
+// TestApplyJavaAnnotationRoutes_Issue1909_JAXRSImplicitBody verifies that a
+// JAX-RS PUT method whose only non-annotated parameter is treated as the
+// request body emits request_body_type correctly.
+//
+// Fixture is a client-fixture-X style transfer confirmation endpoint:
+//
+//	@PUT
+//	@Path("/transfers/confirm/{transferId}")
+//	public Response confirm(@PathParam("transferId") String id, ConfirmRequest body) { ... }
+//
+// Expected: request_body_type = "ConfirmRequest", request_body_param_name = "body"
+func TestApplyJavaAnnotationRoutes_Issue1909_JAXRSImplicitBody(t *testing.T) {
+	src := `package com.example.banking;
+import jakarta.ws.rs.*;
+import jakarta.ws.rs.core.Response;
+
+@Path("/transfers")
+public class TransferResource {
+
+    @PUT
+    @Path("/confirm/{transferId}")
+    public Response confirm(@PathParam("transferId") String id, ConfirmRequest body) {
+        return Response.ok().build();
+    }
+
+    @GET
+    @Path("/{id}")
+    public Response getTransfer(@PathParam("id") String id) {
+        return Response.ok().build();
+    }
+}
+`
+	got := collect(t, map[string]string{"TransferResource.java": src})
+	// Find the PUT endpoint.
+	var putEP *recordLike
+	for i := range got {
+		if got[i].ID == "http:PUT:/transfers/confirm/{transferId}" {
+			putEP = &got[i]
+			break
+		}
+	}
+	if putEP == nil {
+		ids := endpointIDs(got)
+		t.Fatalf("[#1909] PUT endpoint not found; got IDs: %v", ids)
+	}
+	if putEP.Props["request_body_type"] != "ConfirmRequest" {
+		t.Errorf("[#1909] PUT: want request_body_type=ConfirmRequest, got %q", putEP.Props["request_body_type"])
+	}
+	if putEP.Props["request_body_param_name"] != "body" {
+		t.Errorf("[#1909] PUT: want request_body_param_name=body, got %q", putEP.Props["request_body_param_name"])
+	}
+	// GET endpoint must NOT have request_body_type set.
+	for _, r := range got {
+		if r.ID == "http:GET:/transfers/{id}" && r.Props["request_body_type"] != "" {
+			t.Errorf("[#1909] GET endpoint should not have request_body_type, got %q", r.Props["request_body_type"])
+		}
+	}
+}
+
+// TestApplyJavaAnnotationRoutes_Issue1909_SpringExplicitRequestBody verifies
+// that a Spring controller with @RequestBody emits request_body_type correctly.
+func TestApplyJavaAnnotationRoutes_Issue1909_SpringExplicitRequestBody(t *testing.T) {
+	src := `package com.example.api;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    @PostMapping
+    public OrderResponse create(@RequestBody CreateOrderRequest req) {
+        return new OrderResponse();
+    }
+
+    @PutMapping("/{id}")
+    public OrderResponse update(@PathVariable Long id, @RequestBody UpdateOrderRequest req) {
+        return new OrderResponse();
+    }
+}
+`
+	got := collect(t, map[string]string{"OrderController.java": src})
+	// POST endpoint.
+	var postEP *recordLike
+	var putEP *recordLike
+	for i := range got {
+		if got[i].ID == "http:POST:/api/orders" {
+			postEP = &got[i]
+		}
+		if got[i].ID == "http:PUT:/api/orders/{id}" {
+			putEP = &got[i]
+		}
+	}
+	if postEP == nil {
+		ids := endpointIDs(got)
+		t.Fatalf("[#1909] POST endpoint not found; got IDs: %v", ids)
+	}
+	if postEP.Props["request_body_type"] != "CreateOrderRequest" {
+		t.Errorf("[#1909] POST: want request_body_type=CreateOrderRequest, got %q", postEP.Props["request_body_type"])
+	}
+	if putEP == nil {
+		ids := endpointIDs(got)
+		t.Fatalf("[#1909] PUT endpoint not found; got IDs: %v", ids)
+	}
+	if putEP.Props["request_body_type"] != "UpdateOrderRequest" {
+		t.Errorf("[#1909] PUT: want request_body_type=UpdateOrderRequest, got %q", putEP.Props["request_body_type"])
+	}
+}
+
 // TestApplyJavaAnnotationRoutes_Issue683_QuarkusDeepAnnotationStack verifies
 // that a realistic Quarkus annotation stack with 5+ annotations between
 // @GET and @Path is handled correctly. Covers @RateLimited, @Produces,

--- a/webui-v2/src/components/RefLine.tsx
+++ b/webui-v2/src/components/RefLine.tsx
@@ -1,0 +1,119 @@
+/* ============================================================
+   RefLine.tsx — canonical single-line entity reference row.
+
+   Issue #1910: unified format across Defined-in / Called-by /
+   Downstream in the endpoint detail pane (and future detail pages).
+
+   Row layout:
+     [repo chip]  file:line (mono, dim)  entity name (regular)
+
+   Props:
+     repo   — owning repository slug (shown as a small colored chip)
+     file   — source file path (basename:line shown in mono dim text)
+     line   — source line number
+     name   — entity / caller name (regular weight)
+     kind?  — optional kind label shown as a small tag after the name
+   ============================================================ */
+
+import { cn } from "@/lib/utils";
+
+export interface RefLineProps {
+  repo: string;
+  file: string;
+  line: number;
+  name: string;
+  kind?: string;
+  /** Accessibility: full title on hover (defaults to "repo · file:line  name") */
+  title?: string;
+  className?: string;
+}
+
+/** Stable hash → pastel color index (1-9) for the repo chip. */
+function repoColorIndex(repo: string): number {
+  let h = 0;
+  for (let i = 0; i < repo.length; i++) {
+    h = (h * 31 + repo.charCodeAt(i)) & 0xffffffff;
+  }
+  return (Math.abs(h) % 9) + 1;
+}
+
+/** Basename of a file path: "src/orders/order.service.ts" → "order.service.ts" */
+function basename(filePath: string): string {
+  const last = filePath.lastIndexOf("/");
+  return last >= 0 ? filePath.slice(last + 1) : filePath;
+}
+
+/**
+ * RefLine — one-line entity reference used in Defined-in, Called-by, and
+ * Downstream sections. Keeps all three sections visually consistent and
+ * scannable: repo chip on the left, file:line in mono dim, name in regular
+ * weight on the right.
+ */
+export function RefLine({
+  repo,
+  file,
+  line,
+  name,
+  kind,
+  title,
+  className,
+}: RefLineProps) {
+  const ci = repoColorIndex(repo);
+  const fileLabel = file ? `${basename(file)}:${line}` : line > 0 ? `:${line}` : "";
+  const derivedTitle =
+    title ?? `${repo} · ${file}:${line}  ${name}${kind ? ` (${kind})` : ""}`;
+
+  return (
+    <div
+      className={cn(
+        "flex items-center gap-2 py-1 px-4 min-w-0",
+        "hover:bg-surface-2 transition-colors duration-75",
+        className,
+      )}
+      title={derivedTitle}
+    >
+      {/* Repo chip — distinct color per repo slug for quick scanning */}
+      {repo && (
+        <span
+          className={cn(
+            "shrink-0 inline-flex items-center h-[18px] px-1.5 rounded",
+            "text-[10px] font-semibold font-mono leading-none select-none",
+            // Use pastel CSS token for background, darker ink for text.
+          )}
+          style={{
+            background: `var(--pastel-${ci})`,
+            color: `var(--pastel-${ci}-ink)`,
+          }}
+          title={repo}
+        >
+          {repo}
+        </span>
+      )}
+
+      {/* file:line — mono, dimmed */}
+      {fileLabel && (
+        <span
+          className="font-mono text-[11px] text-text-4 shrink-0 tabular-nums truncate max-w-[160px]"
+          title={file ? `${file}:${line}` : String(line)}
+        >
+          {fileLabel}
+        </span>
+      )}
+
+      {/* Entity name — regular weight, takes remaining space */}
+      <span
+        className="text-xs text-text truncate flex-1 font-mono"
+        title={name}
+      >
+        {name}
+      </span>
+
+      {/* Optional kind tag */}
+      {kind && (
+        <span className="shrink-0 text-[10px] text-text-4 font-mono px-1 rounded bg-surface-2">
+          {kind}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -13,15 +13,16 @@ import { useState, useMemo, useCallback, useRef, useEffect } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
   Search, X, ChevronRight, ChevronLeft, Lock, ExternalLink, Copy,
-  Database, Zap, Globe, FlaskConical, TestTube, Server,
+  Database, Zap, Globe, TestTube, Server,
   Layers, Box, List, Maximize2, FolderTree, Boxes, AlertTriangle,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { Badge, Tabs, TabsList, TabsTrigger, TabsContent, Skeleton } from "@/components/ui";
+import { RefLine } from "@/components/RefLine";
 import { usePaths, usePathDetail, useOrphans } from "@/hooks/use-paths";
 import type {
   PathBackend, ControllerGroupShape, PathRoute, PathDetail,
-  OrphanCaller, HttpVerb, OrphanReason, PathEntity,
+  OrphanCaller, HttpVerb, OrphanReason, PathEntity, HandlerDetail,
 } from "@/data/types";
 
 /* ============================================================
@@ -116,21 +117,6 @@ function statusCodeClass(code: number): string {
   if (c === 2) return "text-success";
   if (c === 3) return "text-warning";
   return "text-danger";
-}
-
-function kindIcon(kind: string): React.ReactNode {
-  switch ((kind ?? "").toLowerCase()) {
-    case "component": return <Box size={12} />;
-    case "datastore":
-    case "db":        return <Database size={12} />;
-    case "event":     return <Zap size={12} />;
-    case "queue":     return <Layers size={12} />;
-    case "service":   return <Server size={12} />;
-    case "externalapi": return <Globe size={12} />;
-    case "function":  return <FlaskConical size={12} />;
-    case "test":      return <TestTube size={12} />;
-    default:          return <Box size={12} />;
-  }
 }
 
 /* ============================================================
@@ -478,23 +464,43 @@ function SectionHeader({
   );
 }
 
+/** EntityRow — wraps RefLine for PathEntity values (Downstream, Side-effects, Tests). */
 function EntityRow({ entity }: { entity: PathEntity }) {
   return (
-    <div className="flex items-center gap-2 py-1.5 px-4 hover:bg-surface-2 rounded group">
-      <span className="text-text-4 shrink-0">{kindIcon(entity.kind)}</span>
-      <span
-        className="font-mono text-xs text-text truncate flex-1"
-        title={entity.qualified_name}
-      >
-        {entity.label}
-      </span>
-      {entity.edge && (
-        <span className="text-[10px] text-text-4 font-mono shrink-0">{entity.edge}</span>
-      )}
-      <span className="text-[10px] text-text-4 font-mono shrink-0 truncate max-w-[140px]">
-        {entity.source_file}:{entity.start_line}
-      </span>
-      <span className="text-[10px] text-text-3 font-mono shrink-0">{entity.repo}</span>
+    <RefLine
+      repo={entity.repo ?? ""}
+      file={entity.source_file ?? ""}
+      line={entity.start_line ?? 0}
+      name={entity.label ?? entity.qualified_name ?? ""}
+      kind={entity.kind}
+    />
+  );
+}
+
+/** HandlerRefLine — renders a handler detail using the canonical RefLine format.
+ *  Issue #1910: Defined-in section collapses from verbose card to one-line ref. */
+function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
+  return (
+    <div className="flex items-start gap-2 py-1 px-4 hover:bg-surface-2 transition-colors">
+      <RefLine
+        repo={handler.repo ?? ""}
+        file={handler.source_file ?? ""}
+        line={handler.start_line ?? 0}
+        name={handler.qualified_name ?? handler.verb}
+        kind={handler.framework || handler.language || undefined}
+        className="flex-1 px-0 py-0"
+      />
+      <div className="flex items-center gap-1 shrink-0">
+        <VerbChip verb={handler.verb} />
+        {handler.auth && (
+          <span className="inline-flex items-center gap-0.5 text-[10px] px-1 py-0.5 rounded bg-success-soft text-success">
+            <Lock size={8} /> auth
+          </span>
+        )}
+        {handler.has_docs && (
+          <span className="text-[10px] text-text-4 italic">docs</span>
+        )}
+      </div>
     </div>
   );
 }
@@ -795,71 +801,17 @@ function DetailPane({ detail: rawDetail }: { detail: PathDetail }) {
             open={openSections.defined}
             onToggle={() => toggleSection("defined")}
           />
+          {/* Issue #1910: Defined-in uses canonical RefLine row format. */}
           {openSections.defined && (
-            <div className="px-4 py-2 space-y-2">
+            <div className="py-1">
               {filteredHandlers.length === 0 ? (
-                <div className="rounded-md border border-warning bg-warning-soft/50 px-3 py-2 text-sm text-warning">
+                <div className="mx-4 my-2 rounded-md border border-warning bg-warning-soft/50 px-3 py-2 text-sm text-warning">
                   Orphan call — no backend handler found. Check the Orphan callers tab.
                 </div>
               ) : (
-                filteredHandlers.map((h, i) => {
-                  const verbBorderColor =
-                    h.verb === "GET" ? "var(--pastel-1-ink)"
-                    : h.verb === "POST" ? "var(--pastel-2-ink)"
-                    : h.verb === "DELETE" ? "var(--pastel-4-ink)"
-                    : h.verb === "GRPC" ? "var(--pastel-9-ink)"
-                    : "var(--pastel-6-ink)";
-
-                  return (
-                    <div
-                      key={i}
-                      className="rounded-md border border-border overflow-hidden"
-                      style={{ borderLeftWidth: "3px", borderLeftColor: verbBorderColor }}
-                    >
-                      <div className="flex items-center gap-2 px-3 py-2 bg-bg-soft border-b border-border">
-                        <VerbChip verb={h.verb} />
-                        <span className="font-mono text-xs text-text truncate flex-1" title={h.qualified_name}>
-                          {h.qualified_name}
-                        </span>
-                        <span
-                          className="text-[10px] font-mono text-text-4 shrink-0"
-                          title={`${h.source_file}:${h.start_line}`}
-                        >
-                          {(h.source_file ?? "").split("/").slice(-1)[0]}:{h.start_line}
-                        </span>
-                      </div>
-                      <div className="px-3 py-2">
-                        {h.has_docs && h.docs_summary ? (
-                          <p className="text-xs text-text-2 leading-relaxed">{h.docs_summary}</p>
-                        ) : (
-                          <p className="text-xs text-text-4 italic">No handler docs yet.</p>
-                        )}
-                        <div className="mt-1.5 flex flex-wrap gap-1">
-                          {h.framework && (
-                            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-2 text-text-3">
-                              {h.framework}
-                            </span>
-                          )}
-                          {h.language && (
-                            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-2 text-text-3">
-                              {h.language}
-                            </span>
-                          )}
-                          {h.repo && (
-                            <span className="text-[10px] font-mono px-1.5 py-0.5 rounded bg-surface-2 text-text-3">
-                              {h.repo}
-                            </span>
-                          )}
-                          {h.auth && (
-                            <span className="inline-flex items-center gap-1 text-[10px] px-1.5 py-0.5 rounded bg-success-soft text-success">
-                              <Lock size={8} /> {h.auth}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                  );
-                })
+                filteredHandlers.map((h, i) => (
+                  <HandlerRefLine key={i} handler={h} />
+                ))
               )}
             </div>
           )}


### PR DESCRIPTION
Closes #1908
Closes #1909
Closes #1910

---

## What

Three coordinated fixes to the endpoint-detail surface — all verified against client-fixture-de (Java/Quarkus backend + React frontend).

---

## Why

### #1909 — JAX-RS / Spring request body extraction

The Parameters section of the endpoint-detail pane showed only path/query segments; it never surfaced the request body type. JAX-RS uses an **implicit convention**: the method parameter that carries no binding annotation (`@PathParam`, `@QueryParam`, etc.) IS the request body. Spring's `@RequestBody` is explicit. Neither was handled.

### #1908 — Called-by real name resolution

The "Called by" section was rendering raw URL pattern labels like `http:PUT:/transfers/confirm/{transferId}` instead of the function name + file + line of the actual caller. The root cause was two-part:
1. `http_endpoint_call` entities were detected only when `SourceFile == ""` — but they always have a source file.
2. The FETCHES relationship `from_id` in JS/TS graphs is a synthetic `Kind:Name` string (e.g. `Function:confirmTransfer`) that never matched any hex entity ID in the lookup map.

### #1910 — RefLine component

Defined-in, Called-by, and Downstream sections each had divergent inline rendering. A unified `RefLine` component creates consistent scannable rows: `[repo chip] file:line  entity name  [kind tag]`.

---

## How

### #1909 — Go (internal/engine/java_annotation_routes.go)

- Extended `javaMethodDeclRe` to capture parameter fragment as group 2.
- `inferRequestBodyParam(paramFrag, verbs)`: splits params at top-level commas; skips params with any JAX-RS/Spring binding annotation; treats `@RequestBody` as an explicit body marker; returns `(type, name)` for the first unannotated param on POST/PUT/PATCH/DELETE.
- `splitTopLevelCommas`, `extractParamTypeAndName`, `isJavaNoisyType` helpers.
- `buildMethodEndpoints` emits `request_body_type` + `request_body_param_name` on the generated `http_endpoint` entity.
- `v2_paths.go`: reads those properties → appends `v2PathParameter{in:"body"}` to the `Parameters` field.
- **2 new tests**: JAX-RS implicit body (PUT with `@PathParam` + bare DTO); Spring `@RequestBody` explicit.

### #1908 — Go (internal/dashboard/v2_paths.go + graphstate.go)

- `isCallEntity` check: removed `SourceFile == ""` condition; now detects purely by kind (`http_endpoint_call`).
- `resolveInboundFetches()`: scans `repo.Doc.Relationships` for FETCHES/CALLS edges → resolves `FromID` via `resolveSyntheticFromID()` which extracts the name fragment from `Kind:Name` synthetic IDs and falls back to entity-by-name lookup.
- `findEntity()` in `graphstate.go`: when repo-prefixed local part looks like a synthetic ID (contains `:`), falls back to name-based lookup within the repo — makes the resolution work end-to-end.
- Cross-repo scan uses the same synthetic-ID resolution pattern.

### #1910 — TypeScript (webui-v2/src/components/RefLine.tsx + routes/paths.tsx)

- New `RefLine` component: `{repo, file, line, name, kind?}` props; stable hash → pastel CSS token (`--pastel-N`) for repo chip; `basename(file):line` in mono dim; name in regular weight.
- `paths.tsx`: `EntityRow` delegates to `RefLine`; new `HandlerRefLine` uses `RefLine`; Defined-in section renders `HandlerRefLine`; unused `kindIcon()` helper removed.

---

## Verified

Against client-fixture-de (Java/Quarkus + React SPA), endpoint `PUT /transfers/confirm/{transferId}`:

- **Parameters**: `[{name:"transferId", in:"path"}, {name:"request", in:"body", type:"TransferRequest"}]` ✅
- **Called by**: `{label:"confirmTransfer", source_file:"src/store/inventory/inventory.service.js", start_line:56}` ✅ (was `http:PUT:/transfers/confirm/{transferId}`)
- All 15 Go tests pass (13 pre-existing + 2 new for #1909) ✅
- All dashboard package tests pass ✅
- Full Go build clean ✅
- Pre-existing mcp budget failures on `main` (unrelated) — not introduced by this PR ✅

---

## Checklist

- [x] Go tests pass (`go test ./internal/dashboard/... ./internal/engine/...`)
- [x] 2 new test cases for #1909 body extraction
- [x] Verified against client-fixture-de live daemon
- [x] No competitor/client names leaked in code or comments
- [x] RefLine component uses CSS design tokens (no hardcoded colours)
- [x] TypeScript compiles (no new type errors in touched files)