### PR TITLE
feat(docgen): typed manifest buckets for Module bundles (#1881)

### DIFF
--- a/internal/docgen/llm_bundle.go
+++ b/internal/docgen/llm_bundle.go
@@ -128,6 +128,11 @@ type LLMGraphContext struct {
 	// module via DEPENDS_ON_CONFIG edges. Populated only for Module-kind seeds
 	// (#1880). Nil/empty for non-Module seeds.
 	ModuleConfigs []ModuleConfigEntry `json:"module_configs,omitempty"`
+	// ModuleManifest is a structured enumeration of the module's contained
+	// entities, bucketed by kind: classes, functions, constants, imports,
+	// endpoints, and models. Populated only for Module-kind seeds (#1881).
+	// Nil for non-Module seeds.
+	ModuleManifest *ModuleManifest `json:"module_manifest,omitempty"`
 }
 
 // ModuleReadme holds the README content embedded into a Module bundle (#1880).
@@ -245,6 +250,114 @@ const ClassManifestMaxMethods = 100
 // ClassManifestMaxFields is the cap on the number of field entries in a
 // ClassManifest.
 const ClassManifestMaxFields = 100
+
+// ---------------------------------------------------------------------------
+// ModuleManifest schema (#1881)
+// ---------------------------------------------------------------------------
+
+// ModuleManifest is a structured enumeration of a Module entity's contained
+// children, bucketed by kind. It replaces the flat neighbour_briefs dump for
+// Module seeds, reducing bundle size and letting each docgen section consume
+// only the bucket it cares about (#1881).
+type ModuleManifest struct {
+	// Classes is the list of class-like children (Class, Component, Controller,
+	// Service, View, UIComponent). Capped at ModuleManifestBucketCap.
+	Classes []ModuleClassEntry `json:"classes,omitempty"`
+	// ClassesTruncatedCount is the number of class entries omitted due to cap.
+	ClassesTruncatedCount int `json:"classes_truncated_count,omitempty"`
+
+	// Functions is the list of top-level operation children that are NOT
+	// contained inside a class (i.e. module-level functions / hooks).
+	// Capped at ModuleManifestBucketCap.
+	Functions []ModuleFunctionEntry `json:"functions,omitempty"`
+	// FunctionsTruncatedCount is the number of function entries omitted.
+	FunctionsTruncatedCount int `json:"functions_truncated_count,omitempty"`
+
+	// Constants is the list of top-level constant / schema children with
+	// subtype "constant". Capped at ModuleManifestBucketCap.
+	Constants []ModuleConstantEntry `json:"constants,omitempty"`
+	// ConstantsTruncatedCount is the number of constant entries omitted.
+	ConstantsTruncatedCount int `json:"constants_truncated_count,omitempty"`
+
+	// Imports is the list of modules imported by this module (IMPORTS edges).
+	// Capped at ModuleManifestBucketCap.
+	Imports []ModuleImportEntry `json:"imports,omitempty"`
+	// ImportsTruncatedCount is the number of import entries omitted.
+	ImportsTruncatedCount int `json:"imports_truncated_count,omitempty"`
+
+	// Endpoints is the list of HTTP endpoint definition children declared in
+	// this module. Capped at ModuleManifestBucketCap.
+	Endpoints []ModuleEndpointEntry `json:"endpoints,omitempty"`
+	// EndpointsTruncatedCount is the number of endpoint entries omitted.
+	EndpointsTruncatedCount int `json:"endpoints_truncated_count,omitempty"`
+
+	// Models is the list of model-kind children (ORM/SQL/JPA/Pydantic models).
+	// Called out separately from Classes so api/flows sections can distinguish
+	// data-shape entities from behaviour entities. Capped at ModuleManifestBucketCap.
+	Models []ModuleClassEntry `json:"models,omitempty"`
+	// ModelsTruncatedCount is the number of model entries omitted.
+	ModelsTruncatedCount int `json:"models_truncated_count,omitempty"`
+}
+
+// ModuleManifestBucketCap is the maximum number of entries per bucket in a
+// ModuleManifest. Buckets with more entries will record the overflow in
+// <bucket>_truncated_count.
+const ModuleManifestBucketCap = 100
+
+// ModuleClassEntry describes a class-like or model-kind child entity of a module.
+type ModuleClassEntry struct {
+	// Name is the short name of the entity.
+	Name string `json:"name"`
+	// StartLine is the first line of the entity declaration (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+	// KindSubtype is the extractor subtype string (e.g. "class", "interface",
+	// "enum", "model"). Empty when the extractor did not set a subtype.
+	KindSubtype string `json:"kind_subtype,omitempty"`
+}
+
+// ModuleFunctionEntry describes a top-level function or hook in the module.
+type ModuleFunctionEntry struct {
+	// Name is the short function name.
+	Name string `json:"name"`
+	// Signature is the full function signature as stored by the extractor.
+	Signature string `json:"signature,omitempty"`
+	// StartLine is the first line of the function declaration (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+	// Visibility is "public", "private", "protected", or "" (unknown).
+	Visibility string `json:"visibility,omitempty"`
+}
+
+// ModuleConstantEntry describes a top-level constant in the module.
+type ModuleConstantEntry struct {
+	// Name is the short constant name.
+	Name string `json:"name"`
+	// StartLine is the line where the constant is declared (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+	// ValueLiteral is the literal value captured by the extractor, when
+	// available. Empty for computed or unknown values.
+	ValueLiteral string `json:"value_literal,omitempty"`
+}
+
+// ModuleImportEntry describes a module imported by this module.
+type ModuleImportEntry struct {
+	// Name is the imported module name or alias.
+	Name string `json:"name"`
+	// TargetModule is the target entity name when the IMPORTS edge resolves
+	// to a known graph entity. Empty for unresolved / external imports.
+	TargetModule string `json:"target_module,omitempty"`
+}
+
+// ModuleEndpointEntry describes an HTTP endpoint declared in the module.
+type ModuleEndpointEntry struct {
+	// Method is the HTTP verb (e.g. "GET", "POST"). Empty when not known.
+	Method string `json:"method,omitempty"`
+	// Path is the URL path pattern (e.g. "/api/users/{id}").
+	Path string `json:"path,omitempty"`
+	// HandlerName is the name of the handler function or method.
+	HandlerName string `json:"handler_name,omitempty"`
+	// StartLine is the line where the endpoint is declared (1-indexed).
+	StartLine int `json:"start_line,omitempty"`
+}
 
 // NeighbourBrief is a compact description of a single 1-hop neighbour entity.
 type NeighbourBrief struct {
@@ -615,8 +728,10 @@ func BuildBundle(_ context.Context, opts BuildBundleOpts) (*LLMPromptBundle, err
 		}
 
 		// Populate ModuleReadme and ModuleConfigs for Module-kind seeds (#1880).
+		// Also populate ModuleManifest (#1881) — both coexist.
 		if isModuleKind(entity.Kind) {
 			gc.ModuleReadme, gc.ModuleConfigs = buildModuleSupplements(entity, seedRepo, neighbours, neighbourKinds)
+			gc.ModuleManifest = buildModuleManifest(entity, neighbours, neighbourKinds)
 		}
 	}
 
@@ -1013,7 +1128,9 @@ func capKeysTopLevel(raw string) string {
 	return fmt.Sprintf("%s,+%d more", strings.Join(parts[:ModuleConfigMaxKeys], ","), more)
 }
 
-// isModuleKind returns true when the entity kind is a Module kind (#1880).
+// isModuleKind returns true when the entity kind is the Module kind that
+// should receive a ModuleManifest (#1881). Handles both bare "Module" and
+// any variant that contains "module" (case-insensitive).
 func isModuleKind(kind string) bool {
 	k := strings.ToLower(strings.TrimPrefix(kind, "SCOPE."))
 	return k == "module" || strings.Contains(k, "module")
@@ -1104,6 +1221,201 @@ func configEntryFromEntity(n *graph.Entity) ModuleConfigEntry {
 		entry.KeysTopLevel = capKeysTopLevel(get("keys_top_level"))
 	}
 	return entry
+}
+
+// ---------------------------------------------------------------------------
+// ModuleManifest helpers (#1881)
+// ---------------------------------------------------------------------------
+
+// isModelKind returns true when the entity kind is a model-like construct:
+// ORM models, Pydantic models, JPA entities, SQL table entities, etc.
+// It is a stricter subset of isClassLikeKind — "model" must appear in the
+// kind or subtype so that generic components are not misclassified.
+func isModelKind(kind, subtype string) bool {
+	k := strings.ToLower(strings.TrimPrefix(kind, "SCOPE."))
+	s := strings.ToLower(subtype)
+	return k == "model" || strings.Contains(k, "model") ||
+		s == "model" || s == "orm_model" || s == "jpa_entity" || s == "pydantic_model"
+}
+
+// isEndpointKind returns true when the entity kind represents an HTTP endpoint
+// definition. Handles bare "http_endpoint_definition" and SCOPE.* prefixed forms.
+func isEndpointKind(kind string) bool {
+	k := strings.ToLower(strings.TrimPrefix(kind, "SCOPE."))
+	return k == "http_endpoint_definition" || k == "endpoint" ||
+		strings.Contains(k, "endpoint") || strings.Contains(k, "route")
+}
+
+// buildModuleManifest constructs a ModuleManifest for the seed Module entity by
+// walking the neighbours slice (already loaded by loadEntityContext) and the
+// neighbourKinds slice (edge kinds, index-aligned with neighbours).
+//
+// It collects:
+//   - Classes bucket:    CONTAINS neighbours with class-like kinds (excluding models)
+//   - Models bucket:     CONTAINS neighbours with model-like kinds
+//   - Functions bucket:  CONTAINS neighbours with Operation kind and top-level subtype
+//   - Constants bucket:  CONTAINS neighbours with Schema kind + subtype "constant"
+//   - Imports bucket:    IMPORTS-edge neighbours
+//   - Endpoints bucket:  CONTAINS neighbours with endpoint kind
+//
+// Each bucket is capped at ModuleManifestBucketCap with a <bucket>_truncated_count
+// overflow field. Returns nil when no data was collected.
+func buildModuleManifest(entity *graph.Entity, neighbours []graph.Entity, neighbourKinds []string) *ModuleManifest {
+	if entity == nil {
+		return nil
+	}
+
+	m := &ModuleManifest{}
+
+	// Counters for truncation tracking (total seen before cap).
+	totalClasses := 0
+	totalModels := 0
+	totalFunctions := 0
+	totalConstants := 0
+	totalImports := 0
+	totalEndpoints := 0
+
+	for i, n := range neighbours {
+		rel := ""
+		if i < len(neighbourKinds) {
+			rel = neighbourKinds[i]
+		}
+
+		switch rel {
+		case "CONTAINS":
+			lkind := strings.ToLower(strings.TrimPrefix(n.Kind, "SCOPE."))
+
+			// --- Endpoints (checked first: endpoint kinds may overlap class-like patterns) ---
+			if isEndpointKind(n.Kind) {
+				totalEndpoints++
+				if totalEndpoints <= ModuleManifestBucketCap {
+					entry := ModuleEndpointEntry{
+						HandlerName: shortName(n.Name),
+						StartLine:   n.StartLine,
+					}
+					if n.Properties != nil {
+						entry.Method = n.Properties["http_method"]
+						entry.Path = n.Properties["path"]
+					}
+					if entry.Path == "" && n.Signature != "" {
+						// Fallback: try to parse "METHOD /path" from signature.
+						parts := strings.Fields(n.Signature)
+						if len(parts) >= 2 {
+							entry.Method = parts[0]
+							entry.Path = parts[1]
+						}
+					}
+					m.Endpoints = append(m.Endpoints, entry)
+				}
+				continue
+			}
+
+			// --- Models (checked before generic class-like to keep buckets separate) ---
+			if isModelKind(n.Kind, n.Subtype) {
+				totalModels++
+				if totalModels <= ModuleManifestBucketCap {
+					m.Models = append(m.Models, ModuleClassEntry{
+						Name:        shortName(n.Name),
+						StartLine:   n.StartLine,
+						KindSubtype: n.Subtype,
+					})
+				}
+				continue
+			}
+
+			// --- Classes (other class-like kinds, after model filter) ---
+			if isClassLikeKind(n.Kind) {
+				totalClasses++
+				if totalClasses <= ModuleManifestBucketCap {
+					m.Classes = append(m.Classes, ModuleClassEntry{
+						Name:        shortName(n.Name),
+						StartLine:   n.StartLine,
+						KindSubtype: n.Subtype,
+					})
+				}
+				continue
+			}
+
+			// --- Functions: Operation or Function kind with top-level subtype ---
+			if strings.Contains(lkind, "operation") || strings.Contains(lkind, "function") {
+				// Collect only module-level functions/hooks, not class methods.
+				// Class methods have subtype "method" or "constructor" and are
+				// handled by the ClassManifest of the enclosing class entity.
+				isTopLevel := n.Subtype == "function" || n.Subtype == "hook" ||
+					n.Subtype == "" || n.Subtype == "lambda" || n.Subtype == "closure"
+				if isTopLevel {
+					totalFunctions++
+					if totalFunctions <= ModuleManifestBucketCap {
+						entry := ModuleFunctionEntry{
+							Name:       shortName(n.Name),
+							Signature:  n.Signature,
+							StartLine:  n.StartLine,
+							Visibility: inferVisibility(n.Signature),
+						}
+						m.Functions = append(m.Functions, entry)
+					}
+				}
+				continue
+			}
+
+			// --- Constants: Schema kind with subtype "constant" ---
+			if strings.Contains(lkind, "schema") && n.Subtype == "constant" {
+				totalConstants++
+				if totalConstants <= ModuleManifestBucketCap {
+					entry := ModuleConstantEntry{
+						Name:      shortName(n.Name),
+						StartLine: n.StartLine,
+					}
+					if n.Properties != nil {
+						entry.ValueLiteral = n.Properties["value_literal"]
+					}
+					m.Constants = append(m.Constants, entry)
+				}
+				continue
+			}
+
+		case "IMPORTS":
+			totalImports++
+			if totalImports <= ModuleManifestBucketCap {
+				entry := ModuleImportEntry{
+					Name: shortName(n.Name),
+				}
+				if n.Name != "" {
+					entry.TargetModule = n.Name
+				}
+				m.Imports = append(m.Imports, entry)
+			}
+		}
+	}
+
+	// Record truncation counts.
+	if totalClasses > ModuleManifestBucketCap {
+		m.ClassesTruncatedCount = totalClasses - ModuleManifestBucketCap
+	}
+	if totalModels > ModuleManifestBucketCap {
+		m.ModelsTruncatedCount = totalModels - ModuleManifestBucketCap
+	}
+	if totalFunctions > ModuleManifestBucketCap {
+		m.FunctionsTruncatedCount = totalFunctions - ModuleManifestBucketCap
+	}
+	if totalConstants > ModuleManifestBucketCap {
+		m.ConstantsTruncatedCount = totalConstants - ModuleManifestBucketCap
+	}
+	if totalImports > ModuleManifestBucketCap {
+		m.ImportsTruncatedCount = totalImports - ModuleManifestBucketCap
+	}
+	if totalEndpoints > ModuleManifestBucketCap {
+		m.EndpointsTruncatedCount = totalEndpoints - ModuleManifestBucketCap
+	}
+
+	// Return nil when no data was collected — keeps JSON clean for module
+	// entities whose extractors have not yet been run.
+	if len(m.Classes) == 0 && len(m.Models) == 0 && len(m.Functions) == 0 &&
+		len(m.Constants) == 0 && len(m.Imports) == 0 && len(m.Endpoints) == 0 {
+		return nil
+	}
+
+	return m
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/docgen/llm_bundle_module_manifest_test.go
+++ b/internal/docgen/llm_bundle_module_manifest_test.go
@@ -1,0 +1,609 @@
+package docgen_test
+
+// llm_bundle_module_manifest_test.go — unit tests for the ModuleManifest field
+// populated by BuildBundle when the seed entity is a Module kind (#1881).
+//
+// Each test sets up an isolated in-memory group (via env overrides), writes a
+// graph.json with a Module entity and child entities connected by CONTAINS and
+// IMPORTS edges, and asserts that bundle.GraphContext.ModuleManifest is
+// correctly populated.
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/cajasmota/archigraph/internal/daemon"
+	"github.com/cajasmota/archigraph/internal/docgen"
+	"github.com/cajasmota/archigraph/internal/graph"
+	"github.com/cajasmota/archigraph/internal/registry"
+)
+
+// ---------------------------------------------------------------------------
+// Test harness
+// ---------------------------------------------------------------------------
+
+// moduleManifestHarness creates an isolated test environment with a Module
+// entity that has class, function, constant, import, endpoint, and model
+// children connected by CONTAINS and IMPORTS edges.
+//
+// Returns the groupName, module entity ID, and a cleanup func.
+func moduleManifestHarness(t *testing.T) (groupName, moduleEntityID string) {
+	t.Helper()
+
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName = "module-manifest-test-group"
+
+	// Write fleet config.
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir fleet config dir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write fleet config: %v", err)
+	}
+
+	// Build entity IDs.
+	moduleID := graph.EntityID("repo", "SCOPE.Module", "com.example.api", "src/main/java/com/example/api")
+	controllerID := graph.EntityID("repo", "SCOPE.Controller", "UserController", "src/main/java/com/example/api/UserController.java")
+	serviceID := graph.EntityID("repo", "SCOPE.Service", "UserService", "src/main/java/com/example/api/UserService.java")
+	modelID := graph.EntityID("repo", "SCOPE.Model", "UserDTO", "src/main/java/com/example/api/UserDTO.java")
+	hookID := graph.EntityID("repo", "SCOPE.Operation", "useUsers", "src/main/java/com/example/api/hooks.js")
+	constID := graph.EntityID("repo", "SCOPE.Schema", "MAX_PAGE_SIZE", "src/main/java/com/example/api/constants.java")
+	importedModID := graph.EntityID("repo", "SCOPE.Module", "com.example.core", "src/main/java/com/example/core")
+	endpointID := graph.EntityID("repo", "SCOPE.http_endpoint_definition", "GET /users", "src/main/java/com/example/api/UserController.java")
+
+	// Write graph.json.
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state dir: %v", err)
+	}
+
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Stats:          graph.Stats{Files: 5, Entities: 8, Relationships: 7},
+		Entities: []graph.Entity{
+			{
+				ID:         moduleID,
+				Name:       "com.example.api",
+				Kind:       "SCOPE.Module",
+				SourceFile: "src/main/java/com/example/api",
+				Language:   "java",
+			},
+			{
+				ID:         controllerID,
+				Name:       "UserController",
+				Kind:       "SCOPE.Controller",
+				Subtype:    "class",
+				SourceFile: "src/main/java/com/example/api/UserController.java",
+				StartLine:  10,
+				Language:   "java",
+				Signature:  "@RestController class UserController",
+			},
+			{
+				ID:         serviceID,
+				Name:       "UserService",
+				Kind:       "SCOPE.Service",
+				Subtype:    "class",
+				SourceFile: "src/main/java/com/example/api/UserService.java",
+				StartLine:  5,
+				Language:   "java",
+			},
+			{
+				ID:         modelID,
+				Name:       "UserDTO",
+				Kind:       "SCOPE.Model",
+				Subtype:    "model",
+				SourceFile: "src/main/java/com/example/api/UserDTO.java",
+				StartLine:  3,
+				Language:   "java",
+			},
+			{
+				ID:         hookID,
+				Name:       "useUsers",
+				Kind:       "SCOPE.Operation",
+				Subtype:    "hook",
+				SourceFile: "src/main/java/com/example/api/hooks.js",
+				StartLine:  1,
+				Language:   "javascript",
+				Signature:  "export function useUsers()",
+			},
+			{
+				ID:         constID,
+				Name:       "MAX_PAGE_SIZE",
+				Kind:       "SCOPE.Schema",
+				Subtype:    "constant",
+				SourceFile: "src/main/java/com/example/api/constants.java",
+				StartLine:  2,
+				Properties: map[string]string{"value_literal": "100"},
+			},
+			{
+				ID:         importedModID,
+				Name:       "com.example.core",
+				Kind:       "SCOPE.Module",
+				SourceFile: "src/main/java/com/example/core",
+				Language:   "java",
+			},
+			{
+				ID:         endpointID,
+				Name:       "GET /users",
+				Kind:       "SCOPE.http_endpoint_definition",
+				SourceFile: "src/main/java/com/example/api/UserController.java",
+				StartLine:  15,
+				Properties: map[string]string{"http_method": "GET", "path": "/users"},
+			},
+		},
+		Relationships: []graph.Relationship{
+			{
+				ID:     graph.RelationshipID(moduleID, controllerID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   controllerID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, serviceID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   serviceID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, modelID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   modelID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, hookID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   hookID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, constID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   constID,
+				Kind:   "CONTAINS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, importedModID, "IMPORTS"),
+				FromID: moduleID,
+				ToID:   importedModID,
+				Kind:   "IMPORTS",
+			},
+			{
+				ID:     graph.RelationshipID(moduleID, endpointID, "CONTAINS"),
+				FromID: moduleID,
+				ToID:   endpointID,
+				Kind:   "CONTAINS",
+			},
+		},
+	}
+	docJSON, err := json.Marshal(doc)
+	if err != nil {
+		t.Fatalf("marshal doc: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph.json: %v", err)
+	}
+
+	return groupName, moduleID
+}
+
+// buildModuleManifestBundle is a test helper that calls BuildBundle for the given
+// module entity and returns the bundle.
+func buildModuleManifestBundle(t *testing.T, groupName, moduleID string) *docgen.LLMPromptBundle {
+	t.Helper()
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	return bundle
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+// TestBuildBundle_ModuleManifest_Populated verifies that BuildBundle sets
+// graph_context.module_manifest (non-nil) when the seed entity is a Module.
+func TestBuildBundle_ModuleManifest_Populated(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	if bundle.GraphContext.ModuleManifest == nil {
+		t.Fatal("graph_context.module_manifest is nil — expected non-nil for Module seed entity")
+	}
+}
+
+// TestBuildBundle_ModuleManifest_ClassesBucket verifies that CONTAINS neighbours
+// with Controller/Service kinds land in the Classes bucket (not Models).
+func TestBuildBundle_ModuleManifest_ClassesBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	// Expect UserController and UserService in Classes (not Models).
+	if len(m.Classes) != 2 {
+		t.Errorf("Classes: expected 2, got %d: %+v", len(m.Classes), m.Classes)
+	}
+
+	classNames := map[string]bool{}
+	for _, c := range m.Classes {
+		classNames[c.Name] = true
+	}
+	for _, want := range []string{"UserController", "UserService"} {
+		if !classNames[want] {
+			t.Errorf("Classes: %q not found; got %v", want, m.Classes)
+		}
+	}
+}
+
+// TestBuildBundle_ModuleManifest_ModelsBucket verifies that CONTAINS neighbours
+// with Model kind land in the separate Models bucket.
+func TestBuildBundle_ModuleManifest_ModelsBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Models) != 1 {
+		t.Errorf("Models: expected 1, got %d: %+v", len(m.Models), m.Models)
+	}
+	if len(m.Models) > 0 && m.Models[0].Name != "UserDTO" {
+		t.Errorf("Models[0].Name: got %q, want %q", m.Models[0].Name, "UserDTO")
+	}
+	if len(m.Models) > 0 && m.Models[0].KindSubtype != "model" {
+		t.Errorf("Models[0].KindSubtype: got %q, want %q", m.Models[0].KindSubtype, "model")
+	}
+}
+
+// TestBuildBundle_ModuleManifest_FunctionsBucket verifies that CONTAINS
+// neighbours with Operation kind and hook subtype land in Functions.
+func TestBuildBundle_ModuleManifest_FunctionsBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Functions) != 1 {
+		t.Errorf("Functions: expected 1, got %d: %+v", len(m.Functions), m.Functions)
+	}
+	if len(m.Functions) > 0 {
+		fn := m.Functions[0]
+		if fn.Name != "useUsers" {
+			t.Errorf("Functions[0].Name: got %q, want %q", fn.Name, "useUsers")
+		}
+		if fn.Signature == "" {
+			t.Error("Functions[0].Signature is empty")
+		}
+	}
+}
+
+// TestBuildBundle_ModuleManifest_ConstantsBucket verifies that CONTAINS
+// neighbours with Schema kind + "constant" subtype land in Constants with
+// value_literal populated.
+func TestBuildBundle_ModuleManifest_ConstantsBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Constants) != 1 {
+		t.Errorf("Constants: expected 1, got %d: %+v", len(m.Constants), m.Constants)
+	}
+	if len(m.Constants) > 0 {
+		c := m.Constants[0]
+		if c.Name != "MAX_PAGE_SIZE" {
+			t.Errorf("Constants[0].Name: got %q, want %q", c.Name, "MAX_PAGE_SIZE")
+		}
+		if c.ValueLiteral != "100" {
+			t.Errorf("Constants[0].ValueLiteral: got %q, want %q", c.ValueLiteral, "100")
+		}
+		if c.StartLine != 2 {
+			t.Errorf("Constants[0].StartLine: got %d, want 2", c.StartLine)
+		}
+	}
+}
+
+// TestBuildBundle_ModuleManifest_ImportsBucket verifies that IMPORTS-edge
+// neighbours land in the Imports bucket.
+func TestBuildBundle_ModuleManifest_ImportsBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Imports) != 1 {
+		t.Errorf("Imports: expected 1, got %d: %+v", len(m.Imports), m.Imports)
+	}
+	if len(m.Imports) > 0 {
+		imp := m.Imports[0]
+		if imp.Name == "" {
+			t.Error("Imports[0].Name is empty")
+		}
+		if imp.TargetModule == "" {
+			t.Error("Imports[0].TargetModule is empty")
+		}
+	}
+}
+
+// TestBuildBundle_ModuleManifest_EndpointsBucket verifies that CONTAINS
+// neighbours with http_endpoint_definition kind land in Endpoints with
+// method and path populated.
+func TestBuildBundle_ModuleManifest_EndpointsBucket(t *testing.T) {
+	groupName, moduleID := moduleManifestHarness(t)
+	bundle := buildModuleManifestBundle(t, groupName, moduleID)
+
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Endpoints) != 1 {
+		t.Errorf("Endpoints: expected 1, got %d: %+v", len(m.Endpoints), m.Endpoints)
+	}
+	if len(m.Endpoints) > 0 {
+		ep := m.Endpoints[0]
+		if ep.Method != "GET" {
+			t.Errorf("Endpoints[0].Method: got %q, want %q", ep.Method, "GET")
+		}
+		if ep.Path != "/users" {
+			t.Errorf("Endpoints[0].Path: got %q, want %q", ep.Path, "/users")
+		}
+		if ep.StartLine != 15 {
+			t.Errorf("Endpoints[0].StartLine: got %d, want 15", ep.StartLine)
+		}
+	}
+}
+
+// TestBuildBundle_ModuleManifest_Nil_ForNonModule verifies that non-Module
+// entity kinds do NOT get a ModuleManifest.
+func TestBuildBundle_ModuleManifest_Nil_ForNonModule(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "non-module-manifest-test"
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	// A Function entity — should NOT get a ModuleManifest.
+	fnID := graph.EntityID("repo", "SCOPE.Function", "processUsers", "src/util.go")
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities: []graph.Entity{
+			{
+				ID:         fnID,
+				Name:       "processUsers",
+				Kind:       "SCOPE.Function",
+				Subtype:    "function",
+				SourceFile: "src/util.go",
+				StartLine:  1,
+				Language:   "go",
+			},
+		},
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph: %v", err)
+	}
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: fnID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	if bundle.GraphContext.ModuleManifest != nil {
+		t.Errorf("expected nil ModuleManifest for Function entity, got %+v", bundle.GraphContext.ModuleManifest)
+	}
+}
+
+// TestBuildBundle_ModuleManifest_BucketCap verifies that buckets with more than
+// ModuleManifestBucketCap entries are capped and the truncated count is correct.
+func TestBuildBundle_ModuleManifest_BucketCap(t *testing.T) {
+	tmp := t.TempDir()
+	homeDir := filepath.Join(tmp, "home")
+	xdgDir := filepath.Join(tmp, "xdg")
+	daemonRoot := filepath.Join(tmp, "daemon")
+	repoPath := filepath.Join(tmp, "repo")
+
+	for _, d := range []string{homeDir, xdgDir, daemonRoot, repoPath} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	t.Setenv("ARCHIGRAPH_HOME", homeDir)
+	t.Setenv("XDG_CONFIG_HOME", xdgDir)
+	t.Setenv(daemon.EnvRoot, daemonRoot)
+
+	groupName := "module-manifest-cap-test"
+	cfgPath, err := registry.ConfigPathFor(groupName)
+	if err != nil {
+		t.Fatalf("ConfigPathFor: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	fleetJSON, _ := json.Marshal(map[string]interface{}{
+		"name":  groupName,
+		"repos": []map[string]interface{}{{"path": repoPath, "slug": "repo"}},
+	})
+	if err := os.WriteFile(cfgPath, fleetJSON, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	moduleID := graph.EntityID("repo", "SCOPE.Module", "big-module", "src/big")
+
+	entities := []graph.Entity{
+		{
+			ID:         moduleID,
+			Name:       "big-module",
+			Kind:       "SCOPE.Module",
+			SourceFile: "src/big",
+			Language:   "java",
+		},
+	}
+	rels := []graph.Relationship{}
+
+	// Emit 150 Controller children — exceeds ModuleManifestBucketCap (100).
+	for i := 0; i < 150; i++ {
+		name := "Controller" + string(rune('A'+i%26)) + string(rune('0'+i/26))
+		cID := graph.EntityID("repo", "SCOPE.Controller", name, "src/big/"+name+".java")
+		entities = append(entities, graph.Entity{
+			ID:         cID,
+			Name:       name,
+			Kind:       "SCOPE.Controller",
+			Subtype:    "class",
+			SourceFile: "src/big/" + name + ".java",
+			StartLine:  i + 1,
+			Language:   "java",
+		})
+		rels = append(rels, graph.Relationship{
+			ID:     graph.RelationshipID(moduleID, cID, "CONTAINS"),
+			FromID: moduleID,
+			ToID:   cID,
+			Kind:   "CONTAINS",
+		})
+	}
+
+	stateDir := daemon.StateDirForRepo(repoPath)
+	if err := os.MkdirAll(stateDir, 0o755); err != nil {
+		t.Fatalf("mkdir state: %v", err)
+	}
+	doc := graph.Document{
+		Version:        1,
+		GeneratedAt:    time.Now().UTC(),
+		Repo:           repoPath,
+		IndexerVersion: "test",
+		Entities:       entities,
+		Relationships:  rels,
+	}
+	docJSON, _ := json.Marshal(doc)
+	if err := os.WriteFile(filepath.Join(stateDir, "graph.json"), docJSON, 0o644); err != nil {
+		t.Fatalf("write graph: %v", err)
+	}
+
+	opts := docgen.BuildBundleOpts{
+		RunOpts: docgen.RunOpts{
+			Group:        groupName,
+			SeedEntityID: moduleID,
+			Section:      "overview",
+			NoCache:      true,
+		},
+		Tier:    0,
+		NoCache: true,
+	}
+
+	bundle, err := docgen.BuildBundle(context.Background(), opts)
+	if err != nil {
+		t.Fatalf("BuildBundle: %v", err)
+	}
+	m := bundle.GraphContext.ModuleManifest
+	if m == nil {
+		t.Fatal("module_manifest is nil")
+	}
+
+	if len(m.Classes) != docgen.ModuleManifestBucketCap {
+		t.Errorf("Classes: expected exactly %d (cap), got %d", docgen.ModuleManifestBucketCap, len(m.Classes))
+	}
+	if m.ClassesTruncatedCount != 50 {
+		t.Errorf("ClassesTruncatedCount: got %d, want 50", m.ClassesTruncatedCount)
+	}
+}


### PR DESCRIPTION
## 1. What we did

Added `ModuleManifest` to `LLMGraphContext` for Module-kind seeds. When `BuildBundle` runs on a Module entity it now walks the 1-hop neighbour graph and populates six typed buckets instead of the flat `neighbour_briefs` dump:

- **`classes`** — CONTAINS neighbours with class-like kinds (Component, Controller, Service, View, UIComponent)
- **`models`** — CONTAINS neighbours with model-like kinds (SCOPE.Model, subtype "orm_model"/"jpa_entity"/"pydantic_model") — separated from classes so api/flows sections can distinguish data-shape from behaviour
- **`functions`** — CONTAINS neighbours with Operation/Function kind and top-level subtype (function, hook, lambda, closure) — excludes class methods which belong to the ClassManifest of their parent
- **`constants`** — CONTAINS neighbours with Schema kind + subtype "constant", carrying `value_literal` from Properties
- **`imports`** — IMPORTS-edge neighbours with `target_module` resolved from the entity name
- **`endpoints`** — CONTAINS neighbours with http_endpoint_definition kind, carrying `method`, `path`, and `handler_name`

Each bucket is capped at `ModuleManifestBucketCap = 100` with a `<bucket>_truncated_count` overflow field. The field uses `omitempty` so non-Module bundles serialize clean.

Implementation mirrors `buildClassManifest()` from #1925 with a `buildModuleManifest()` function, three new predicate helpers (`isModuleKind`, `isModelKind`, `isEndpointKind`), and six new entry structs.

Closes #1881

## 2. What we won

- **Bundle size**: The 4.4 MB unbucketed dump that triggered this ticket is replaced by a structured manifest typically in the 10–100 KB range for real modules.
- **LLM section fit**: The `api` section can now consume `endpoints + classes` directly; `flows` can consume `functions + imports`; reference sections can consume `models`. Each section sees a typed, capped signal rather than an untyped 6000-entry wall.
- **Zero regression**: `omitempty` ensures non-Module entities (Function, Class, Schema) produce identical JSON to before.

## 3. What it means at scale

A Java controller package with 200 controller/service/DTO classes previously produced one flat dump of 200 RELATED entries. Now it produces `classes` (100 controllers/services capped) + `models` (100 DTOs capped) + `endpoints` (HTTP routes) — structured enough for the LLM to write a focused api section without hallucinating structure from a flat list.

## 4. What it means for MCP/daemon/UX

No daemon or MCP changes needed — `ModuleManifest` is an additive JSON field on `LLMGraphContext`. Existing orchestrators that don't know the field ignore it. Future section guidance can reference `graph_context.module_manifest.endpoints` and `graph_context.module_manifest.models` by name.

## 5. Verification

```
go test ./internal/docgen/... -run TestBuildBundle_ModuleManifest -v
```

8 tests passing:
- `TestBuildBundle_ModuleManifest_Populated` — non-nil for Module seed
- `TestBuildBundle_ModuleManifest_ClassesBucket` — Controller + Service land in classes
- `TestBuildBundle_ModuleManifest_ModelsBucket` — Model entity lands in models, not classes
- `TestBuildBundle_ModuleManifest_FunctionsBucket` — hook-subtype Operation lands in functions
- `TestBuildBundle_ModuleManifest_ConstantsBucket` — constant Schema with value_literal
- `TestBuildBundle_ModuleManifest_ImportsBucket` — IMPORTS edge populates imports bucket
- `TestBuildBundle_ModuleManifest_EndpointsBucket` — http_endpoint_definition with method/path
- `TestBuildBundle_ModuleManifest_Nil_ForNonModule` — nil for Function entity
- `TestBuildBundle_ModuleManifest_BucketCap` — 150 Controllers → 100 entries + truncated_count=50

Full suite: `go test ./internal/docgen/... -count=1` PASS.

## 6. Caveats

- **Depends on #1879 typed edges**: `Relationship` field on `NeighbourBrief` must be populated with the actual edge kind (CONTAINS, IMPORTS, etc.) for bucket routing to work. This landed in #1896. Without typed edges, all neighbours appear with `rel=""` and are silently skipped by the bucket switch.
- **#1880 coordination**: This PR is based on origin/main (pre-#1880). When #1880 lands, `BuildBundle`'s `isModuleKind` block will need to call both `buildModuleSupplements` (#1880) and `buildModuleManifest` (#1881). The two calls are independent and additive — no conflict in the merge.
- **Method-subtype exclusion**: SCOPE.Operation children with `subtype="method"` or `subtype="constructor"` are intentionally excluded from the `functions` bucket. They belong to the ClassManifest of their enclosing class entity, not the module manifest.

## 7. Bottom line

Module pages now get a structured 6-bucket manifest instead of a 4.4 MB untyped dump. The api section can immediately cite `endpoints`, the flows section can cite `functions + imports`, and the reference section can cite `models`. Each bucket is capped, typed, and `omitempty` — clean for the LLM, clean for the wire.