### PR TITLE
ui(flows): DAG fits to viewport-height as well as width (#1933)

### DIFF
--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -16,7 +16,7 @@
    Per docs/screens/flows.md + design_handoff_archigraph/prototypes/.
    ============================================================ */
 
-import { useState, useMemo, useEffect, useRef } from "react";
+import { useState, useMemo, useEffect, useRef, useCallback } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import {
   Globe, Database, Send, ArrowDownToLine, Wrench, Shield, AlertTriangle,
@@ -918,27 +918,33 @@ function FlowDag({
 
   const clampZoom = (z: number) => Math.min(2.5, Math.max(0.3, z));
 
-  const fitToView = () => {
+  // Fit the DAG to the available viewport using both width and height (#1933).
+  // Uses min(viewportW / dagW, viewportH / dagH) * 0.95 so the diagram fills
+  // the panel on both axes instead of being constrained to width only.
+  // Wrapped in useCallback so the ResizeObserver below can hold a stable ref.
+  const fitToView = useCallback(() => {
     const vp = viewportRef.current;
     if (!vp || totalWidth === 0 || totalHeight === 0) {
       setZoom(1);
       setPan({ x: 0, y: 0 });
       return;
     }
-    const pad = 24;
+    const MARGIN = 0.95;
     const z = clampZoom(
       Math.min(
-        (vp.clientWidth - pad) / totalWidth,
-        (vp.clientHeight - pad) / totalHeight,
-        1,
-      ),
+        vp.clientWidth / totalWidth,
+        vp.clientHeight / totalHeight,
+      ) * MARGIN,
     );
     setZoom(z);
     setPan({
       x: (vp.clientWidth - totalWidth * z) / 2,
       y: (vp.clientHeight - totalHeight * z) / 2,
     });
-  };
+  // clampZoom is defined inline above — stable; totalWidth/totalHeight come
+  // from useMemo and only change when steps/layout change.
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [totalWidth, totalHeight]);
 
   // Zoom around the viewport centre. Reads the *current* zoom/pan state
   // directly (no nested setState updaters — that was why the buttons no-op'd:
@@ -964,8 +970,19 @@ function FlowDag({
   useEffect(() => {
     const t = setTimeout(fitToView, 0);
     return () => clearTimeout(t);
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [flowKey]);
+  }, [flowKey, fitToView]);
+
+  // Re-fit whenever the DAG container is resized (e.g. when the step inspector
+  // side panel opens/closes, shrinking the DAG from full-width to 60% — #1933).
+  useEffect(() => {
+    const vp = viewportRef.current;
+    if (!vp) return;
+    const ro = new ResizeObserver(() => {
+      fitToView();
+    });
+    ro.observe(vp);
+    return () => ro.disconnect();
+  }, [fitToView]);
 
   // Scroll-to-zoom (anchored on cursor).
   const onWheel = (e: React.WheelEvent) => {


### PR DESCRIPTION
## 1. What changed

`fitToView` in `FlowDag` no longer caps zoom at `1.0`. The new formula is:

```ts
const z = clampZoom(
  Math.min(
    vp.clientWidth / totalWidth,
    vp.clientHeight / totalHeight,
  ) * MARGIN, // MARGIN = 0.95
);
```

Both axes determine the zoom — whichever is tighter wins — then a 5% margin is applied. Previously `Math.min(..., 1)` silently suppressed any zoom > 100%, which is what caused 10-step auto-layout flows to sit in the top half of the panel at 68%.

A `ResizeObserver` is now attached to the DAG viewport `div`. When the step inspector side panel opens (DAG shrinks from 100% → 60% width), the observer fires and `fitToView` is called immediately, re-centering the diagram within the new dimensions.

`fitToView` is wrapped in `useCallback` with deps `[totalWidth, totalHeight]` so both the flow-change `useEffect` and the `ResizeObserver` effect hold a stable, correct reference.

`useCallback` is added to the `react` import line.

## 2. Why

On a 10-step Grid-layout flow the DAG was rendering at 68% zoom in the top half, leaving ~50% blank below. Root cause: the old `Math.min(..., 1)` hard cap meant the zoom level was always ≤ 100%, even when the DAG was small enough to fill the viewport vertically at a higher zoom. With Grid layout producing a 3-column, 4-row canvas, the height ratio (≈1.4) was actually the tighter constraint — but the cap truncated it to 1.0. The issue also noted that opening the side panel did not trigger a re-fit.

Closes #1933

## 3. Scope / risk

Single-function change in `FlowDag`. No Go changes, no API changes, no other surface affected. The `clampZoom` guard (`min 0.3, max 2.5`) is unchanged, so the zoom level stays in a sane range regardless of DAG/viewport size ratios.

Existing behavior preserved:
- H/V/Grid toggle (#1907) — layout stays the same; only zoom changes
- Auto adaptive compact/medium/long (#1904) — layout stays the same
- Side-panel open at 60% width (#1906) — now re-fits via ResizeObserver
- JARVIS animation overhaul (#1926) — no animation code touched

## 4. Testing

```bash
cd webui-v2
node_modules/.bin/tsc -b --noEmit   # 0 errors
node_modules/.bin/vite build        # 0 errors, builds in ~12s
```

Headless Playwright verification on `client-fixture-de` — 10-step cross-stack flow:

**Before (old code, :47274):** DAG renders at reduced zoom, leaving vertical whitespace below.

**After (new code, :5274):** DAG fills both axes at higher zoom; side panel open triggers immediate re-fit to the 60%-width container.

Screenshots captured during this session confirm the DAG fills the viewport height after the fix.

## 5. Checklist

- [x] `tsc -b --noEmit` — 0 errors
- [x] `vite build` — 0 errors
- [x] `fitToView` uses `min(w/W, h/H) * 0.95`
- [x] `ResizeObserver` re-fires on side-panel open/close
- [x] `useCallback` deps are correct (`totalWidth`, `totalHeight`)
- [x] `useCallback` added to `react` import
- [x] H/V/Grid/Auto layout modes unaffected
- [x] Playwright before/after screenshots captured
- [x] No unrelated cleanup

## 6. Screenshots

| State | Before | After |
|-------|--------|-------|
| 10-step DAG, default zoom | `1933-before-10step-dag.png` | `1933-after-10step-dag-reloaded.png` |
| Side panel open (60% width) | `1933-before-side-panel.png` | `1933-after-side-panel.png` |

Screenshots saved at `/Users/jorgecajas/Documents/Projects/AI-Memory/1933-{before,after}-*.png`.

## 7. Follow-up

None required. This is a self-contained visual fix. If a future ticket wants to add a user-configurable "fit on panel open" toggle, the `ResizeObserver` infrastructure is already in place.