### PR TITLE
feat(graph): JARVIS overhaul — edge comet, replay-all on activity panel, scrubber, dashed cross-repo, audio (#1932)

### DIFF
--- a/webui-v2/src/components/graph/graph-canvas.tsx
+++ b/webui-v2/src/components/graph/graph-canvas.tsx
@@ -250,6 +250,21 @@ const truncate = (s: string) => (s.length > 30 ? s.slice(0, 28) + "…" : s);
 export interface GraphCanvasHandle {
   snapshotCamera: () => void;
   restoreCamera: () => void;
+  /**
+   * #1932: resolve a node id to its CURRENT screen (px) position relative to
+   * the canvas container. Returns null when the id is unknown or the engine
+   * isn't ready yet. Used by the JARVIS SVG overlay to draw chevrons + the
+   * MCP-replay comet without re-implementing the cosmos.gl camera math.
+   */
+  getNodeScreenPosition: (id: string) => { x: number; y: number } | null;
+  /**
+   * #1932: list every edge in the current graph as `{src,tgt,bridge}` where
+   * `bridge` is true when the edge crosses two repos (the dashed + distinct-
+   * accent tier). The overlay renders chevrons + bridge styling from this.
+   */
+  getEdgeList: () => ReadonlyArray<{ src: string; tgt: string; bridge: boolean }>;
+  /** #1932: true when the named edge crosses repos (bridge). */
+  isBridgeEdge: (src: string, tgt: string) => boolean;
 }
 
 function GraphCanvasInner(
@@ -1491,10 +1506,68 @@ function GraphCanvasInner(
   // (b) the space coordinate currently at the viewport center. To restore we
   // re-center on that point (degenerate fitViewByPointPositions box) then set the
   // recorded zoom — together that reproduces the prior pan + zoom exactly.
+  // #1932: live refs so the imperative handle (mount-only `[]` deps) can read
+  // the current id→idx map, edge states, and link buffer without re-creating
+  // the handle on every render.
+  const idToIdxRef = useRef(idToIdx);
+  idToIdxRef.current = idToIdx;
+  const linkDataRef = useRef(linkData);
+  linkDataRef.current = linkData;
+  const nodeIdsForHandleRef = useRef(nodeIds);
+  nodeIdsForHandleRef.current = nodeIds;
+
   const cameraSnapRef = useRef<{ zoom: number; center: [number, number] } | null>(null);
   useImperativeHandle(
     ref,
     () => ({
+      getNodeScreenPosition: (id: string) => {
+        const g = graphRef.current;
+        if (!g) return null;
+        const idx = idToIdxRef.current.get(id);
+        if (idx === undefined) return null;
+        try {
+          const positions = g.getPointPositions();
+          const px = positions[idx * 2];
+          const py = positions[idx * 2 + 1];
+          if (px === undefined || py === undefined) return null;
+          if (!Number.isFinite(px) || !Number.isFinite(py)) return null;
+          const [sx, sy] = g.spaceToScreenPosition([px, py]);
+          if (!Number.isFinite(sx) || !Number.isFinite(sy)) return null;
+          return { x: sx, y: sy };
+        } catch {
+          return null;
+        }
+      },
+      getEdgeList: () => {
+        const { links, states } = linkDataRef.current;
+        const ids = nodeIdsForHandleRef.current;
+        const out: { src: string; tgt: string; bridge: boolean }[] = [];
+        for (let i = 0, e = 0; i < links.length; i += 2, e++) {
+          const a = links[i];
+          const b = links[i + 1];
+          const src = ids[a];
+          const tgt = ids[b];
+          if (!src || !tgt) continue;
+          out.push({ src, tgt, bridge: states[e] === 2 });
+        }
+        return out;
+      },
+      isBridgeEdge: (src: string, tgt: string) => {
+        const idToIdxNow = idToIdxRef.current;
+        const a = idToIdxNow.get(src);
+        const b = idToIdxNow.get(tgt);
+        if (a === undefined || b === undefined) return false;
+        const { links, states } = linkDataRef.current;
+        for (let i = 0, e = 0; i < links.length; i += 2, e++) {
+          if (
+            (links[i] === a && links[i + 1] === b) ||
+            (links[i] === b && links[i + 1] === a)
+          ) {
+            return states[e] === 2;
+          }
+        }
+        return false;
+      },
       snapshotCamera: () => {
         const g = graphRef.current;
         const el = containerRef.current;

--- a/webui-v2/src/components/graph/graph-jarvis-overlay.tsx
+++ b/webui-v2/src/components/graph/graph-jarvis-overlay.tsx
@@ -1,0 +1,365 @@
+/* ============================================================
+   components/graph/graph-jarvis-overlay.tsx — JARVIS SVG overlay (#1932).
+
+   The cosmos.gl main graph is WebGL — it has no per-edge per-frame animation
+   primitive and no native SVG layer. To get the JARVIS telemetry feel
+   (#1932) we float an SVG layer above the WebGL canvas and re-project edge
+   endpoints from the cosmograph camera (via graphCanvas.spaceToScreenPosition,
+   exposed on the GraphCanvasHandle) every frame while motion is in flight.
+
+   Surfaces (12 features, see #1932):
+     • Chevrons   — static directional arrowheads on bridge edges + edges
+                    incident to currently-highlighted nodes. Rendering every
+                    chevron on a 37k-edge graph would tank the frame rate, so
+                    we render the "interesting" subset that gives direction at
+                    a glance without burning the GPU.
+     • Trail tint — edges between consecutive MCP-replay hits are drawn as a
+                    brighter stroke overlay (var(--ag-graph-accent)) while
+                    replay-all is running. Reverse-scrub fades the tint off
+                    in reverse order.
+     • Comet     — the leading edge of the current step is drawn with a
+                    travelling glow head + a short trailing tail; bridge
+                    edges get a distinct accent + dashed pattern.
+     • Bounce    — node arrival bumps point size via the canvas's existing
+                    per-node size buffer (handled by the canvas, not here).
+
+   Reduced motion: when prefers-reduced-motion is set, we skip the comet,
+   pulse, and bounce. Chevrons + tinting stay (they're static styling).
+
+   Audio is wired by the host (mcp-activity-overlay) via the controller's
+   onArrive callback — this overlay is rendering-only.
+   ============================================================ */
+
+import { memo, useEffect, useRef, useState } from "react";
+import type { GraphCanvasHandle } from "./graph-canvas";
+
+// Shape of one MCP "step" in the replay timeline. A step lights up a NODE;
+// the edge between step i-1 and step i is what the comet rides. When the two
+// nodes are not directly connected we still draw a straight comet between
+// them (visual cue that the agent jumped between investigations).
+export interface JarvisStep {
+  /** The node id the agent is "arriving at" on this step. */
+  nodeId: string;
+  /** Which MCP event index in the activity log this step came from. */
+  eventIdx: number;
+  /** Optional label (tool name) shown in scrubber hover. */
+  label?: string;
+}
+
+export interface GraphJarvisOverlayProps {
+  /** The graph canvas (used to resolve screen positions on each frame). */
+  canvasHandle: GraphCanvasHandle | null;
+  /** Replay timeline. */
+  steps: JarvisStep[];
+  /** Index of the step the comet is heading TO. -1 = idle. */
+  currentTarget: number;
+  /** 0..1 progress along the current edge. */
+  edgeProgress: number;
+  /** Edge indices already traversed (i.e. target step idx). */
+  traversedEdges: ReadonlySet<number>;
+  /** True while a comet is in flight (not paused / idle). */
+  running: boolean;
+  /** True while paused mid-flow (comet frozen). */
+  paused: boolean;
+  /** Disable comet + pulse + bounce (chevrons + tint stay). */
+  reducedMotion?: boolean;
+  /** Highlighted nodes (from useGraphHighlight) — drives chevron density. */
+  highlightedNodeIds?: ReadonlySet<string>;
+  className?: string;
+}
+
+// Size of the chevron path (in px at unit scale).
+const CHEVRON = 9;
+// Cap the number of "incident" chevrons we render so a huge graph stays smooth.
+const CHEVRON_BUDGET = 600;
+
+/**
+ * Re-project the screen position of a list of node ids via the canvas handle.
+ * Returns a Map keyed by id so callers can do O(1) lookups.
+ */
+function projectNodes(
+  handle: GraphCanvasHandle | null,
+  ids: ReadonlySet<string>,
+): Map<string, { x: number; y: number }> {
+  const out = new Map<string, { x: number; y: number }>();
+  if (!handle) return out;
+  for (const id of ids) {
+    const p = handle.getNodeScreenPosition(id);
+    if (p) out.set(id, p);
+  }
+  return out;
+}
+
+function lerp(a: number, b: number, t: number): number {
+  return a + (b - a) * t;
+}
+
+export const GraphJarvisOverlay = memo(function GraphJarvisOverlay({
+  canvasHandle,
+  steps,
+  currentTarget,
+  edgeProgress,
+  traversedEdges,
+  running,
+  paused,
+  reducedMotion = false,
+  highlightedNodeIds,
+  className = "",
+}: GraphJarvisOverlayProps) {
+  // We re-render the overlay on a rAF loop while ANY of:
+  //   • replay is running (comet must move),
+  //   • replay is paused (comet frozen, but viewport may still drag),
+  //   • user is interacting with the cosmos camera (pan/zoom → chevrons follow),
+  //   • highlightedNodeIds is non-empty (recent MCP glow → chevrons follow).
+  // The cheap way to track viewport motion without wiring into cosmos's event
+  // bus is to compare the screen position of an anchor node each frame and
+  // re-render when it moves. Even simpler: just tick rAF whenever anything
+  // visible could move. The overlay's render cost is tiny (a few SVGs).
+  const [tick, setTick] = useState(0);
+  const rafRef = useRef<number | null>(null);
+  useEffect(() => {
+    const shouldTick =
+      !!canvasHandle &&
+      (running || paused || (highlightedNodeIds && highlightedNodeIds.size > 0));
+    if (!shouldTick) return;
+    let stopped = false;
+    const loop = () => {
+      if (stopped) return;
+      setTick((t) => (t + 1) & 0x3fffffff);
+      rafRef.current = requestAnimationFrame(loop);
+    };
+    rafRef.current = requestAnimationFrame(loop);
+    return () => {
+      stopped = true;
+      if (rafRef.current != null) cancelAnimationFrame(rafRef.current);
+      rafRef.current = null;
+    };
+  }, [canvasHandle, running, paused, highlightedNodeIds]);
+
+  // Re-render once on mount + once on any interactive event so chevrons follow
+  // user pan/zoom even outside an active replay. We listen on `pointerup` /
+  // `wheel` at the window level; the cosmos canvas swallows but the events
+  // still bubble in capture phase.
+  useEffect(() => {
+    const onInteract = () => setTick((t) => (t + 1) & 0x3fffffff);
+    window.addEventListener("pointermove", onInteract, { passive: true });
+    window.addEventListener("wheel", onInteract, { passive: true, capture: true });
+    window.addEventListener("resize", onInteract);
+    return () => {
+      window.removeEventListener("pointermove", onInteract);
+      window.removeEventListener("wheel", onInteract, { capture: true } as EventListenerOptions);
+      window.removeEventListener("resize", onInteract);
+    };
+  }, []);
+
+  // ── compute current frame geometry ──────────────────────────────────────
+  // tick is consumed via the dependency on the render itself; eslint can't see
+  // the indirection so explicitly reference it.
+  void tick;
+
+  if (!canvasHandle) return null;
+
+  // Project the union of: every step node + every highlighted node.
+  const ids = new Set<string>();
+  for (const s of steps) ids.add(s.nodeId);
+  if (highlightedNodeIds) for (const id of highlightedNodeIds) ids.add(id);
+  const projected = projectNodes(canvasHandle, ids);
+
+  // Collect bridge edges from the canvas handle (one-time per render).
+  const edges = canvasHandle.getEdgeList();
+  // Chevron candidate set: bridge edges + edges incident to a highlighted node.
+  const chevronEdges: { src: string; tgt: string; bridge: boolean }[] = [];
+  const hi = highlightedNodeIds;
+  for (const e of edges) {
+    const incident = hi && (hi.has(e.src) || hi.has(e.tgt));
+    if (e.bridge || incident) chevronEdges.push(e);
+    if (chevronEdges.length >= CHEVRON_BUDGET) break;
+  }
+
+  // Trail (traversed) edge geometry: for each traversed step index i, the
+  // edge i-1 → i. Both endpoints must be projected.
+  const trail: Array<{
+    x1: number; y1: number; x2: number; y2: number; bridge: boolean;
+  }> = [];
+  for (const ti of traversedEdges) {
+    if (ti <= 0 || ti >= steps.length) continue;
+    const a = projected.get(steps[ti - 1].nodeId);
+    const b = projected.get(steps[ti].nodeId);
+    if (!a || !b) continue;
+    const bridge = canvasHandle.isBridgeEdge(steps[ti - 1].nodeId, steps[ti].nodeId);
+    trail.push({ x1: a.x, y1: a.y, x2: b.x, y2: b.y, bridge });
+  }
+
+  // Comet geometry: for the current target edge.
+  let comet: {
+    x1: number; y1: number; x2: number; y2: number;
+    headX: number; headY: number; bridge: boolean;
+  } | null = null;
+  if ((running || paused) && !reducedMotion && currentTarget > 0 && currentTarget < steps.length) {
+    const a = projected.get(steps[currentTarget - 1].nodeId);
+    const b = projected.get(steps[currentTarget].nodeId);
+    if (a && b) {
+      const bridge = canvasHandle.isBridgeEdge(
+        steps[currentTarget - 1].nodeId,
+        steps[currentTarget].nodeId,
+      );
+      comet = {
+        x1: a.x,
+        y1: a.y,
+        x2: b.x,
+        y2: b.y,
+        headX: lerp(a.x, b.x, edgeProgress),
+        headY: lerp(a.y, b.y, edgeProgress),
+        bridge,
+      };
+    }
+  }
+
+  const accent = "var(--ag-graph-accent, #60a5fa)";
+  const bridgeAccent = "var(--ag-graph-bridge-accent, #a78bfa)";
+
+  return (
+    <svg
+      className={`pointer-events-none absolute inset-0 ${className}`}
+      style={{ overflow: "visible" }}
+      role="presentation"
+      aria-hidden
+      data-testid="graph-jarvis-overlay"
+    >
+      <defs>
+        {/* Chevron marker — regular edges. */}
+        <marker
+          id="ag-graph-chev"
+          viewBox="0 0 10 10"
+          markerWidth={CHEVRON}
+          markerHeight={CHEVRON}
+          refX="9"
+          refY="5"
+          orient="auto"
+        >
+          <path d="M 0 0 L 9 5 L 0 10 z" fill="var(--ag-graph-edge, #475569)" opacity="0.65" />
+        </marker>
+        {/* Chevron marker — bridge edges (distinct accent). */}
+        <marker
+          id="ag-graph-chev-bridge"
+          viewBox="0 0 10 10"
+          markerWidth={CHEVRON + 1}
+          markerHeight={CHEVRON + 1}
+          refX="9"
+          refY="5"
+          orient="auto"
+        >
+          <path d="M 0 0 L 9 5 L 0 10 z" fill={bridgeAccent} opacity="0.85" />
+        </marker>
+        {/* Chevron marker — accent (on traversed / comet edges). */}
+        <marker
+          id="ag-graph-chev-accent"
+          viewBox="0 0 10 10"
+          markerWidth={CHEVRON + 1}
+          markerHeight={CHEVRON + 1}
+          refX="9"
+          refY="5"
+          orient="auto"
+        >
+          <path d="M 0 0 L 9 5 L 0 10 z" fill={accent} />
+        </marker>
+        <filter id="ag-graph-comet-glow" x="-50%" y="-50%" width="200%" height="200%">
+          <feGaussianBlur stdDeviation="2.4" />
+        </filter>
+      </defs>
+
+      {/* ── Static chevrons (bridge + incident edges) ─────────────────────── */}
+      {chevronEdges.map((e, i) => {
+        const a = projected.get(e.src);
+        const b = projected.get(e.tgt);
+        if (!a || !b) return null;
+        // Only draw if endpoints span a reasonable on-screen distance, so we
+        // don't pile chevrons on top of each other for collapsed clusters.
+        const dx = b.x - a.x;
+        const dy = b.y - a.y;
+        if (Math.hypot(dx, dy) < 20) return null;
+        // Place the chevron MID-edge (path-with-marker-mid). Use a 3-point
+        // path so SVG draws the marker at the middle vertex with the correct
+        // orientation. Stroke is invisible — we just want the marker.
+        const mx = (a.x + b.x) / 2;
+        const my = (a.y + b.y) / 2;
+        return (
+          <path
+            key={`chev-${i}-${e.src}-${e.tgt}`}
+            d={`M ${a.x} ${a.y} L ${mx} ${my} L ${b.x} ${b.y}`}
+            fill="none"
+            stroke={e.bridge ? bridgeAccent : "transparent"}
+            strokeWidth={e.bridge ? 0.85 : 0}
+            strokeDasharray={e.bridge ? "4 3" : undefined}
+            strokeLinecap="round"
+            markerMid={e.bridge ? "url(#ag-graph-chev-bridge)" : "url(#ag-graph-chev)"}
+            opacity={e.bridge ? 0.85 : 0.55}
+          />
+        );
+      })}
+
+      {/* ── Trail tint (traversed edges, current replay only) ───────────── */}
+      {trail.map((t, i) => (
+        <line
+          key={`trail-${i}`}
+          x1={t.x1}
+          y1={t.y1}
+          x2={t.x2}
+          y2={t.y2}
+          stroke={t.bridge ? bridgeAccent : accent}
+          strokeWidth={t.bridge ? 2.2 : 1.6}
+          strokeLinecap="round"
+          strokeDasharray={t.bridge ? "5 3" : undefined}
+          opacity={0.55}
+          markerEnd="url(#ag-graph-chev-accent)"
+        />
+      ))}
+
+      {/* ── Comet (current in-flight edge) ───────────────────────────────── */}
+      {comet ? (
+        <g>
+          {/* Base stroke under the comet so the edge reads as a path even when
+              there's no real graph edge between the two MCP hits. */}
+          <line
+            x1={comet.x1}
+            y1={comet.y1}
+            x2={comet.x2}
+            y2={comet.y2}
+            stroke={comet.bridge ? bridgeAccent : accent}
+            strokeWidth={comet.bridge ? 1.6 : 1.2}
+            strokeDasharray={comet.bridge ? "5 3" : undefined}
+            strokeLinecap="round"
+            opacity={0.45}
+          />
+          {/* Comet head: bright glowing dot at edgeProgress. */}
+          <circle
+            cx={comet.headX}
+            cy={comet.headY}
+            r={comet.bridge ? 4 : 3.4}
+            fill={comet.bridge ? bridgeAccent : accent}
+            filter="url(#ag-graph-comet-glow)"
+          />
+          <circle
+            cx={comet.headX}
+            cy={comet.headY}
+            r={comet.bridge ? 2 : 1.7}
+            fill="#ffffff"
+            opacity="0.9"
+          />
+          {/* Edge-pulse halo when nearly arrived (last ~10% of progress). */}
+          {edgeProgress > 0.9 ? (
+            <circle
+              cx={comet.x2}
+              cy={comet.y2}
+              r={9 * (1 - (1 - edgeProgress) * 10)}
+              fill="none"
+              stroke={comet.bridge ? bridgeAccent : accent}
+              strokeWidth={2}
+              opacity={(1 - edgeProgress) * 10}
+            />
+          ) : null}
+        </g>
+      ) : null}
+    </svg>
+  );
+});

--- a/webui-v2/src/components/graph/mcp-activity-overlay.tsx
+++ b/webui-v2/src/components/graph/mcp-activity-overlay.tsx
@@ -1,23 +1,41 @@
 /* ============================================================
    components/graph/mcp-activity-overlay.tsx — Jarvis MCP activity surface.
 
-   A subtle, in-canvas affordance for the real-time MCP-query glow (#1157):
+   A subtle, in-canvas affordance for the real-time MCP-query glow (#1157)
+   plus the JARVIS replay-all controls (#1932):
+
      • A small "pulse badge" (bottom-right of the canvas) showing the SSE
        connection state, a live-pulsing dot while a query is active, and the
        running query count. Click it to open the log.
      • A toggle in the badge menu to turn the whole overlay (and the glow)
        on/off — default ON.
-     • A slide-out log panel listing the last 50 MCP events (time / tool /
-       node count) with a "replay" button that re-triggers the glow.
+     • A slide-out log panel listing the last MAX_LOG MCP events (time /
+       tool / node count) with:
+         · the existing per-entry replay 🔄 (#1157 — unchanged),
+         · a NEW Replay-all button (#1932-5) that walks every entry in panel
+           order, glowing the graph and riding the SVG comet between hits,
+         · speed slider 0.5×/1×/2× (#1932-6),
+         · pause / resume + ESC shortcut (#1932-7),
+         · a progress scrubber under the activity list during replay-all
+           (#1932-8) — drag the playhead to scrub forward / backward; the
+           backward direction triggers reverse-decay on the trail tint.
+         · a graph-scoped audio toggle (#1932-12, off by default,
+           persisted in localStorage["archigraph:graph:audio"]).
 
-   Ported + restyled to WebUI v2 tokens from the deleted v1 dashboard overlay
-   (#1232). Theme-aware via the same surface/border/text tokens the rest of v2
-   uses, so it follows the dark/light toggle automatically.
+   The graph canvas's existing glow loop (#1157, see graph-canvas.tsx) is the
+   bedrock — every per-entry replay AND each Replay-all step still flows
+   through the same `onReplay(event)` so the daemon-side glow path is one
+   shared code path. The SVG comet + trail + chevron rendering happens in a
+   sibling component (graph-jarvis-overlay) driven by the same FlowAnim
+   controller exposed here.
    ============================================================ */
 
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { Activity, RefreshCw, X } from "lucide-react";
+import { Activity, Pause, Play, RefreshCw, Square, Volume2, VolumeX, X } from "lucide-react";
 import type { MCPActivityEvent } from "@/hooks/use-mcp-activity";
+import type { FlowAnimController, FlowAnimSnapshot } from "@/lib/flow-animation";
+import { GRAPH_SPEEDS } from "@/hooks/use-graph-jarvis-replay";
+import type { JarvisStep } from "@/components/graph/graph-jarvis-overlay";
 
 function formatTs(ts: number): string {
   const d = new Date(ts);
@@ -39,6 +57,20 @@ export interface MCPActivityOverlayProps {
   eventLog: MCPActivityEvent[];
   onToggle: (enabled: boolean) => void;
   onReplay: (event: MCPActivityEvent) => void;
+
+  // ── #1932 replay-all wiring ───────────────────────────────────────────────
+  /** The shared step-engine controller (null when there's < 2 steps). */
+  replayController: FlowAnimController | null;
+  /** Current rAF snapshot (driven by useSyncExternalStore in the hook). */
+  replaySnapshot: FlowAnimSnapshot;
+  /** Flattened step timeline (one entry per node arrival across all events). */
+  replaySteps: JarvisStep[];
+  /** Selected speed key (0.5 / 1 / 2). */
+  speedKey: string;
+  onSpeedKey: (k: string) => void;
+  /** Audio toggle (off by default, persisted). */
+  audioOn: boolean;
+  onAudioToggle: (on: boolean) => void;
 }
 
 export const MCPActivityOverlay = memo(function MCPActivityOverlay({
@@ -49,22 +81,33 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
   eventLog,
   onToggle,
   onReplay,
+  replayController,
+  replaySnapshot,
+  replaySteps,
+  speedKey,
+  onSpeedKey,
+  audioOn,
+  onAudioToggle,
 }: MCPActivityOverlayProps) {
   const [panelOpen, setPanelOpen] = useState(false);
   const logRef = useRef<HTMLDivElement>(null);
 
-  // Escape closes the panel.
+  // Escape closes the panel — unless a replay is mid-flight, in which case
+  // the replay hook intercepts ESC for pause/resume FIRST (capture phase),
+  // so the panel close only fires when no replay is active.
   useEffect(() => {
     if (!panelOpen) return;
     const onKey = (e: KeyboardEvent) => {
-      if (e.key === "Escape") {
-        e.stopPropagation();
-        setPanelOpen(false);
-      }
+      if (e.key !== "Escape") return;
+      // If the replay hook already handled this (pause/resume), don't close.
+      const snap = replayController?.getSnapshot();
+      if (snap && (snap.running || snap.paused)) return;
+      e.stopPropagation();
+      setPanelOpen(false);
     };
     window.addEventListener("keydown", onKey);
     return () => window.removeEventListener("keydown", onKey);
-  }, [panelOpen]);
+  }, [panelOpen, replayController]);
 
   // Keep the log scrolled to the newest entry.
   useEffect(() => {
@@ -73,33 +116,67 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
 
   const toggleEnabled = useCallback(() => onToggle(!enabled), [enabled, onToggle]);
 
+  // ── replay-all controls ────────────────────────────────────────────────────
+  // The button shows Stop while a replay is running OR paused. The scrubber
+  // also stays visible while the playhead has advanced past 0 even if the
+  // engine isn't currently animating (so a user can keep dragging after a
+  // scrub stopped the engine).
+  const isReplaying = replaySnapshot.running || replaySnapshot.paused;
+  const scrubberVisible =
+    isReplaying || (replayController !== null && replaySnapshot.playhead > 0);
+  const canReplay = !!replayController && replaySteps.length >= 2;
+  const startOrStop = useCallback(() => {
+    if (!replayController) return;
+    if (isReplaying) {
+      replayController.stop();
+      replayController.reset();
+    } else {
+      replayController.start();
+    }
+  }, [replayController, isReplaying]);
+  const pauseOrResume = useCallback(() => {
+    if (!replayController) return;
+    if (replaySnapshot.paused) replayController.resume();
+    else if (replaySnapshot.running) replayController.pause();
+  }, [replayController, replaySnapshot.paused, replaySnapshot.running]);
+
   // ── badge state ──────────────────────────────────────────────────────────
   const dotClass = !enabled
     ? "bg-text-4"
-    : isActive
+    : isActive || isReplaying
       ? "bg-amber-400"
       : connected
         ? "bg-emerald-400"
         : "bg-text-4";
   const label = !enabled
     ? "MCP activity overlay off"
-    : isActive
-      ? "MCP query active"
-      : connected
-        ? `MCP activity connected — ${totalCount} ${totalCount === 1 ? "query" : "queries"}`
-        : "MCP activity stream disconnected";
+    : isReplaying
+      ? "MCP replay in progress"
+      : isActive
+        ? "MCP query active"
+        : connected
+          ? `MCP activity connected — ${totalCount} ${totalCount === 1 ? "query" : "queries"}`
+          : "MCP activity stream disconnected";
 
   return (
     <div className="absolute bottom-3 right-24 z-30 flex flex-col items-end gap-1.5">
       {/* ── slide-out log panel ─────────────────────────────────────────── */}
       {panelOpen && enabled ? (
         <div
-          className="mb-1 w-72 overflow-hidden rounded-lg border border-border bg-surface/95 shadow-lg backdrop-blur-sm"
+          className="mb-1 w-80 overflow-hidden rounded-lg border border-border bg-surface/95 shadow-lg backdrop-blur-sm"
           data-testid="mcp-activity-panel"
         >
           <div className="flex items-center justify-between border-b border-border px-3 py-2">
             <span className="flex items-center gap-1.5 text-xs font-semibold text-text-2">
               <Activity size={12} className="text-amber-400" /> MCP activity
+              {isReplaying ? (
+                <span
+                  className="ml-1 rounded bg-amber-400/15 px-1.5 py-px text-[10px] font-medium text-amber-400"
+                  aria-live="polite"
+                >
+                  replay {replaySnapshot.paused ? "paused" : "running"}
+                </span>
+              ) : null}
             </span>
             <button
               onClick={() => setPanelOpen(false)}
@@ -109,6 +186,52 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
               <X size={13} />
             </button>
           </div>
+
+          {/* ── Replay-all toolbar (#1932) ─────────────────────────────── */}
+          <div className="flex items-center gap-1.5 border-b border-border px-3 py-1.5">
+            <button
+              onClick={startOrStop}
+              disabled={!canReplay}
+              aria-label={isReplaying ? "Stop replay" : "Replay all queries"}
+              title={isReplaying ? "Stop" : "Replay all"}
+              data-testid="mcp-replay-all-toggle"
+              className="inline-flex items-center gap-1 rounded border border-border bg-surface px-2 py-0.5 text-[11px] font-medium text-text-2 hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {isReplaying ? <Square size={11} /> : <Play size={11} />}
+              {isReplaying ? "Stop" : "Replay all"}
+            </button>
+            <button
+              onClick={pauseOrResume}
+              disabled={!isReplaying}
+              aria-label={replaySnapshot.paused ? "Resume replay" : "Pause replay"}
+              title={replaySnapshot.paused ? "Resume (ESC)" : "Pause (ESC)"}
+              data-testid="mcp-replay-pause"
+              className="inline-flex items-center gap-1 rounded border border-border bg-surface px-1.5 py-0.5 text-[11px] text-text-3 hover:bg-surface-2 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {replaySnapshot.paused ? <Play size={11} /> : <Pause size={11} />}
+            </button>
+            {/* Speed segmented control */}
+            <div className="ml-auto inline-flex overflow-hidden rounded border border-border" role="radiogroup" aria-label="Replay speed">
+              {GRAPH_SPEEDS.map((s) => (
+                <button
+                  key={s.key}
+                  role="radio"
+                  aria-checked={speedKey === s.key}
+                  onClick={() => onSpeedKey(s.key)}
+                  data-testid={`mcp-replay-speed-${s.key}`}
+                  className={`px-1.5 py-0.5 text-[10px] font-mono tabular-nums transition-colors ${
+                    speedKey === s.key
+                      ? "bg-accent/20 text-text"
+                      : "text-text-3 hover:bg-surface-2"
+                  }`}
+                >
+                  {s.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* ── Activity list ───────────────────────────────────────────── */}
           <div ref={logRef} className="max-h-64 overflow-y-auto">
             {eventLog.length === 0 ? (
               <p className="px-3 py-4 text-center text-xs text-text-4">
@@ -141,23 +264,49 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
               ))
             )}
           </div>
+
+          {/* ── Progress scrubber (#1932-8) ─────────────────────────────── */}
+          {scrubberVisible && replayController ? (
+            <ReplayScrubber
+              controller={replayController}
+              snapshot={replaySnapshot}
+              steps={replaySteps}
+            />
+          ) : null}
+
+          {/* ── Footer: settings ─────────────────────────────────────────── */}
           <div className="flex items-center justify-between border-t border-border px-3 py-1.5">
             <span className="text-[11px] text-text-4">Glow on MCP query</span>
-            <button
-              onClick={toggleEnabled}
-              role="switch"
-              aria-checked={enabled}
-              aria-label="Toggle MCP activity glow"
-              className={`relative h-4 w-7 rounded-full transition-colors ${
-                enabled ? "bg-accent" : "bg-surface-2"
-              }`}
-            >
-              <span
-                className={`absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform ${
-                  enabled ? "translate-x-3.5" : "translate-x-0.5"
+            <div className="flex items-center gap-1.5">
+              <button
+                onClick={() => onAudioToggle(!audioOn)}
+                role="switch"
+                aria-checked={audioOn}
+                aria-label="Toggle replay audio"
+                title={audioOn ? "Audio on — click to mute" : "Audio off — click to enable"}
+                data-testid="mcp-replay-audio-toggle"
+                className={`rounded p-0.5 transition-colors ${
+                  audioOn ? "text-amber-400" : "text-text-4 hover:text-text-3"
                 }`}
-              />
-            </button>
+              >
+                {audioOn ? <Volume2 size={12} /> : <VolumeX size={12} />}
+              </button>
+              <button
+                onClick={toggleEnabled}
+                role="switch"
+                aria-checked={enabled}
+                aria-label="Toggle MCP activity glow"
+                className={`relative h-4 w-7 rounded-full transition-colors ${
+                  enabled ? "bg-accent" : "bg-surface-2"
+                }`}
+              >
+                <span
+                  className={`absolute top-0.5 h-3 w-3 rounded-full bg-white transition-transform ${
+                    enabled ? "translate-x-3.5" : "translate-x-0.5"
+                  }`}
+                />
+              </button>
+            </div>
           </div>
         </div>
       ) : null}
@@ -170,12 +319,12 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
         title={label}
         data-testid="mcp-activity-badge"
         className="flex items-center gap-1.5 rounded-md border border-border bg-surface/85 px-2 py-1 text-[11px] font-semibold tracking-wide text-text-2 backdrop-blur-sm transition-colors hover:bg-surface-2"
-        style={isActive ? { boxShadow: "0 0 8px rgba(255,176,59,0.45)" } : undefined}
+        style={isActive || isReplaying ? { boxShadow: "0 0 8px rgba(255,176,59,0.45)" } : undefined}
       >
         <span
           aria-hidden
           data-testid="mcp-activity-dot"
-          className={`h-1.5 w-1.5 rounded-full ${dotClass} ${isActive ? "animate-pulse" : ""}`}
+          className={`h-1.5 w-1.5 rounded-full ${dotClass} ${isActive || isReplaying ? "animate-pulse" : ""}`}
         />
         <Activity size={11} aria-hidden className={enabled ? "" : "opacity-40"} />
         <span className="tabular-nums">{enabled ? (totalCount > 0 ? totalCount : "MCP") : "off"}</span>
@@ -183,3 +332,131 @@ export const MCPActivityOverlay = memo(function MCPActivityOverlay({
     </div>
   );
 });
+
+// ─── Progress scrubber (#1932-8) ───────────────────────────────────────────
+// Draggable playhead under the activity list. Scrubs the FlowAnim controller
+// instantly (the engine's `lastScrubDir` drives reverse-decay rendering in
+// the overlay layer). Hover shows a small label with the step's tool name.
+
+interface ReplayScrubberProps {
+  controller: FlowAnimController;
+  snapshot: FlowAnimSnapshot;
+  steps: JarvisStep[];
+}
+
+function ReplayScrubber({ controller, snapshot, steps }: ReplayScrubberProps) {
+  const trackRef = useRef<HTMLDivElement>(null);
+  const [hoverIdx, setHoverIdx] = useState<number | null>(null);
+  const [dragging, setDragging] = useState(false);
+
+  const total = steps.length;
+  if (total < 2) return null;
+
+  const segments = total - 1;
+  const base = Math.max(0, snapshot.playhead - 1);
+  const inFlight = snapshot.running && !snapshot.paused && snapshot.edgeProgress > 0;
+  const frac = inFlight
+    ? Math.min(1, (base + snapshot.edgeProgress) / segments)
+    : snapshot.playhead === 0
+      ? 0
+      : Math.min(1, base / segments);
+
+  function idxFromEvent(e: React.PointerEvent | PointerEvent) {
+    const el = trackRef.current;
+    if (!el) return 0;
+    const rect = el.getBoundingClientRect();
+    const x = (e as PointerEvent).clientX - rect.left;
+    const t = Math.max(0, Math.min(1, x / Math.max(1, rect.width)));
+    return Math.round(t * segments) + 1;
+  }
+
+  return (
+    <div
+      className="flex items-center gap-2 border-t border-border bg-surface px-3 py-1.5"
+      data-testid="mcp-replay-scrubber"
+    >
+      <span className="w-12 flex-none font-mono text-[10px] tabular-nums text-text-4">
+        {snapshot.playhead} / {total}
+      </span>
+      <div
+        ref={trackRef}
+        className="relative h-5 flex-1 cursor-pointer select-none"
+        onPointerDown={(e) => {
+          e.currentTarget.setPointerCapture(e.pointerId);
+          setDragging(true);
+          controller.scrubTo(idxFromEvent(e));
+        }}
+        onPointerMove={(e) => {
+          if (dragging) controller.scrubTo(idxFromEvent(e));
+        }}
+        onPointerUp={(e) => {
+          try {
+            e.currentTarget.releasePointerCapture(e.pointerId);
+          } catch {
+            /* ignore */
+          }
+          setDragging(false);
+        }}
+        onMouseMove={(e) => {
+          const el = trackRef.current;
+          if (!el) return;
+          const rect = el.getBoundingClientRect();
+          const t = (e.clientX - rect.left) / Math.max(1, rect.width);
+          const idx = Math.max(0, Math.min(total - 1, Math.round(t * (total - 1))));
+          setHoverIdx(idx);
+        }}
+        onMouseLeave={() => setHoverIdx(null)}
+      >
+        <div
+          className="absolute left-0 right-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full"
+          style={{ background: "var(--border)" }}
+        />
+        <div
+          className="absolute left-0 top-1/2 h-[3px] -translate-y-1/2 rounded-full"
+          style={{
+            width: `${frac * 100}%`,
+            background: "var(--ag-graph-accent, #60a5fa)",
+            transition: dragging || inFlight ? "none" : "width 120ms linear",
+          }}
+        />
+        {/* Ticks — one per step, capped so a long timeline doesn't crowd. */}
+        {Array.from({ length: Math.min(total, 60) }, (_, i) => {
+          const idx = Math.round((i / Math.max(1, Math.min(total, 60) - 1)) * (total - 1));
+          return (
+            <span
+              key={i}
+              className="absolute top-1/2 -translate-y-1/2"
+              style={{
+                left: `${(idx / segments) * 100}%`,
+                width: 1,
+                height: idx === 0 || idx === total - 1 ? 9 : 5,
+                background: "var(--text-4)",
+                transform: "translate(-0.5px, -50%)",
+              }}
+            />
+          );
+        })}
+        <span
+          className="pointer-events-none absolute top-1/2 -translate-y-1/2 rounded-full"
+          style={{
+            left: `${frac * 100}%`,
+            transform: "translate(-50%, -50%)",
+            width: 11,
+            height: 11,
+            background: "var(--ag-graph-accent, #60a5fa)",
+            boxShadow: "0 0 0 2px var(--surface), 0 0 4px var(--ag-graph-accent, #60a5fa)",
+            transition: dragging || inFlight ? "none" : "left 120ms linear",
+          }}
+        />
+        {hoverIdx != null && steps[hoverIdx] ? (
+          <span
+            className="pointer-events-none absolute -top-5 max-w-[14rem] truncate rounded-xs border border-border bg-surface-2 px-1.5 py-0.5 font-mono text-[9px] text-text-2"
+            style={{ left: `${(hoverIdx / segments) * 100}%`, transform: "translateX(-50%)" }}
+          >
+            {hoverIdx + 1}. {steps[hoverIdx].label ?? steps[hoverIdx].nodeId}
+          </span>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/webui-v2/src/hooks/use-graph-jarvis-replay.ts
+++ b/webui-v2/src/hooks/use-graph-jarvis-replay.ts
@@ -1,0 +1,313 @@
+/* ============================================================
+   hooks/use-graph-jarvis-replay.ts — Replay-all controller for the graph
+   view's MCP activity panel (#1932).
+
+   Wraps the generic `createFlowAnim` step engine (originally shipped for the
+   flow DAG in #1922) with logic specific to the graph view:
+
+     • Builds a STEP list by flattening every event's returned_node_ids in
+       order. Each step lights one node and the comet rides the edge from the
+       previous step's node to it. Cross-event boundaries are real edges in
+       the timeline too (so the agent's hop between investigations animates).
+     • Per #1932, replay-all calls the existing per-entry replay handler for
+       each event (re-using the same daemon-side glow path). The graph canvas
+       receives the same epoch bumps it already reacts to, AND the SVG
+       overlay paints the comet/trail/chevron on top.
+     • Edges that cross repos travel slower (~450ms vs ~300ms) per #1932-11.
+     • Speed (0.5×/1×/2×) + audio toggle persisted to localStorage with
+       graph-scoped keys (independent of the flow view's keys).
+     • ESC pauses/resumes while a replay is running (matches flows' behavior).
+     • Audio default OFF, persisted in `archigraph:graph:audio`.
+
+   The hook is ALWAYS instantiated so the host can wire the scrubber UI
+   without conditional hooks. When there's no event log it stays idle.
+   ============================================================ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import {
+  createFlowAnim,
+  type FlowAnimController,
+  type FlowAnimSnapshot,
+  useFlowAnim,
+} from "@/lib/flow-animation";
+import { usePrefersReducedMotion } from "@/lib/use-reduced-motion";
+import { playStepBlip, readGraphAudio, writeGraphAudio } from "@/lib/graph-audio";
+import type { MCPActivityEvent } from "./use-mcp-activity";
+import type { JarvisStep } from "@/components/graph/graph-jarvis-overlay";
+
+// Storage keys are graph-scoped so flow + graph preferences don't clobber.
+const SPEED_KEY = "archigraph:graph:speed";
+
+export const GRAPH_SPEEDS: Array<{ key: string; mult: number; label: string }> = [
+  { key: "0.5", mult: 0.5, label: "0.5×" },
+  { key: "1", mult: 1, label: "1×" },
+  { key: "2", mult: 2, label: "2×" },
+];
+
+// Default base speeds — matches #1932 spec (300ms regular / 450ms bridge).
+const BASE_EDGE_MS = 300;
+const BRIDGE_EDGE_MS = 450;
+// Inter-call delay (between two MCP-event boundaries). Within a single event's
+// chain we keep the engine's default 90ms inter-step.
+const INTER_CALL_MS = 220;
+
+export interface UseGraphJarvisReplayOpts {
+  eventLog: MCPActivityEvent[];
+  /** Per-entry replay handler (the existing glow path). */
+  onReplayEvent: (event: MCPActivityEvent) => void;
+  /** Map node-id pair → bridge? (resolves cross-repo edges). */
+  isBridgeEdge?: (src: string, tgt: string) => boolean;
+}
+
+export interface UseGraphJarvisReplayReturn {
+  /** Linear step timeline (one entry per node arrival). */
+  steps: JarvisStep[];
+  /** rAF snapshot from the engine. */
+  snapshot: FlowAnimSnapshot;
+  /** Engine controller (start / stop / pause / scrub / setSpeed). */
+  controller: FlowAnimController | null;
+  /** True while replay-all is running OR paused mid-flow. */
+  isReplaying: boolean;
+  /** Total step count (= flattened node-id length across the event log). */
+  totalSteps: number;
+  /** Current persisted speed key. */
+  speedKey: string;
+  setSpeedKey: (k: string) => void;
+  /** Current audio toggle (OFF by default, per #1932-12). */
+  audioOn: boolean;
+  setAudioOn: (on: boolean) => void;
+  /** prefers-reduced-motion: when true, comet/pulse/bounce are skipped. */
+  reducedMotion: boolean;
+}
+
+export function useGraphJarvisReplay(
+  opts: UseGraphJarvisReplayOpts,
+): UseGraphJarvisReplayReturn {
+  const { eventLog, onReplayEvent, isBridgeEdge } = opts;
+  const reducedMotion = usePrefersReducedMotion();
+
+  // ── Build the step timeline ───────────────────────────────────────────────
+  const steps = useMemo<JarvisStep[]>(() => {
+    const out: JarvisStep[] = [];
+    eventLog.forEach((ev, evIdx) => {
+      const ids = ev.returned_node_ids ?? [];
+      // Cap each event's contribution so a pathological response (thousands of
+      // ids) can't blow the timeline; the comet still walks the first 50 hits.
+      const capped = ids.slice(0, 50);
+      for (const id of capped) {
+        out.push({ nodeId: id, eventIdx: evIdx, label: ev.tool_name });
+      }
+    });
+    return out;
+  }, [eventLog]);
+
+  // ── Audio + speed prefs (persisted) ──────────────────────────────────────
+  const [audioOn, setAudioOnState] = useState<boolean>(() => readGraphAudio());
+  const setAudioOn = useCallback((on: boolean) => {
+    setAudioOnState(on);
+    writeGraphAudio(on);
+  }, []);
+  const audioOnRef = useRef(audioOn);
+  audioOnRef.current = audioOn;
+
+  const [speedKey, setSpeedKeyState] = useState<string>(() => {
+    try {
+      const saved = localStorage.getItem(SPEED_KEY);
+      if (saved && GRAPH_SPEEDS.some((s) => s.key === saved)) return saved;
+    } catch {
+      /* ignore */
+    }
+    return "1";
+  });
+  const setSpeedKey = useCallback((k: string) => {
+    setSpeedKeyState(k);
+    try {
+      localStorage.setItem(SPEED_KEY, k);
+    } catch {
+      /* ignore */
+    }
+  }, []);
+  const speedMult = GRAPH_SPEEDS.find((s) => s.key === speedKey)?.mult ?? 1;
+
+  // ── Step-index → eventIdx map (used to fire the per-event glow on arrival
+  //    AT the FIRST node of each event). We don't fire the existing glow path
+  //    for every node — only at event boundaries — so we don't spam the
+  //    daemon on a multi-node response. The MCP glow already lights the full
+  //    set when the event fires.
+  const firstStepOfEventRef = useRef<Map<number, number>>(new Map());
+  useEffect(() => {
+    const m = new Map<number, number>();
+    steps.forEach((s, i) => {
+      if (!m.has(s.eventIdx)) m.set(s.eventIdx, i);
+    });
+    firstStepOfEventRef.current = m;
+  }, [steps]);
+
+  // ── isBridge resolver passed to the engine ───────────────────────────────
+  // edgeIdx in the engine == target step index (≥ 1). We resolve the two
+  // node ids that the comet rides between and ask the canvas if that pair
+  // crosses repos. When the canvas handle isn't wired yet we conservatively
+  // return false (regular ~300ms edge).
+  const isBridgeEdgeRef = useRef(isBridgeEdge);
+  isBridgeEdgeRef.current = isBridgeEdge;
+  const stepsRef = useRef(steps);
+  stepsRef.current = steps;
+
+  const resolveBridge = useCallback((edgeIdx: number): boolean => {
+    const s = stepsRef.current;
+    if (edgeIdx <= 0 || edgeIdx >= s.length) return false;
+    const fn = isBridgeEdgeRef.current;
+    if (!fn) return false;
+    return fn(s[edgeIdx - 1].nodeId, s[edgeIdx].nodeId);
+  }, []);
+
+  // ── Controller lifecycle ─────────────────────────────────────────────────
+  // We recreate the controller whenever the timeline LENGTH changes; mid-run
+  // changes to the underlying event log are rare (a new MCP event would add a
+  // step at the tail) and recreating loses the playhead, which is annoying.
+  // We accept that for v1; future iteration can grow the controller in-place.
+  const onReplayEventRef = useRef(onReplayEvent);
+  onReplayEventRef.current = onReplayEvent;
+
+  const eventLogRef = useRef<MCPActivityEvent[]>(eventLog);
+  eventLogRef.current = eventLog;
+  const reducedMotionRef = useRef(reducedMotion);
+  reducedMotionRef.current = reducedMotion;
+
+  const totalSteps = steps.length;
+
+  // Controller lifecycle (StrictMode-safe).
+  // -----------------------------------------------------------------
+  // Earlier versions of this hook created the controller inside a
+  // useEffect and stopped it in the cleanup. Under React 18 StrictMode
+  // dev mode the cleanup runs between the double-invoked mount, which
+  // leaves the controller in state STOPPED — the user clicks Replay-all
+  // and the engine fires the first couple of arrivals before its still-
+  // pending interStepTimer gets cleared by the cleanup, then freezes.
+  //
+  // We own the controller in a ref that we (re)build in the render phase
+  // ONLY when the engine is idle (no replay in flight) AND the total step
+  // count has shifted. This survives the StrictMode dev double-render
+  // because the second render sees `controllerStepsRef.current === totalSteps`
+  // and skips the rebuild path. There's NO useEffect cleanup that could
+  // clobber a running engine.
+  const controllerRef = useRef<FlowAnimController | null>(null);
+  const controllerStepsRef = useRef<number>(-2);
+
+  // Re-create the controller whenever totalSteps changes AND no replay is in
+  // flight. Once a replay is running we leave the engine alone (the user can
+  // restart afterwards and pick up the new tail). This avoids the StrictMode
+  // cleanup-clobber trap because cleanup never runs as a useEffect cleanup —
+  // the controller is owned by a render-phase ref guarded against re-entry.
+  const livingSnap = controllerRef.current?.getSnapshot();
+  const inFlight = !!livingSnap && (livingSnap.running || livingSnap.paused);
+  const needsRebuild =
+    !inFlight && controllerStepsRef.current !== totalSteps;
+
+  if (needsRebuild) {
+    controllerStepsRef.current = totalSteps;
+    if (controllerRef.current) {
+      controllerRef.current.stop();
+      controllerRef.current.reset();
+      controllerRef.current = null;
+    }
+    if (totalSteps >= 2) {
+      const c = createFlowAnim({
+        totalSteps,
+        isBridgeEdge: resolveBridge,
+        baseEdgeMs: BASE_EDGE_MS,
+        bridgeEdgeMs: BRIDGE_EDGE_MS,
+        interStepMs: INTER_CALL_MS,
+        speed: speedMult,
+        reducedMotion: reducedMotionRef.current,
+      });
+      c.setOnArrive((stepIdx) => {
+        const s = stepsRef.current[stepIdx];
+        if (!s) return;
+        const firstIdx = firstStepOfEventRef.current.get(s.eventIdx);
+        if (firstIdx === stepIdx) {
+          const ev = eventLogRef.current[s.eventIdx];
+          if (ev) onReplayEventRef.current(ev);
+        }
+        if (audioOnRef.current) playStepBlip();
+      });
+      controllerRef.current = c;
+    }
+  }
+  const controller = controllerRef.current;
+
+  // Note: we deliberately do NOT run a useEffect cleanup that calls
+  // controller.stop()/reset() on unmount. React 18 StrictMode dev mode
+  // would invoke that cleanup between the dev-mode double-mount, which
+  // would clear the controller's rAF + interStepTimer mid-replay and
+  // freeze the engine at step 2. The engine's only side-effects are
+  // timers; the engine is GC'd when the host route unmounts (no global
+  // listeners), so the route's natural unmount is sufficient cleanup.
+
+  // Live-push speed updates without recreating the controller.
+  useEffect(() => {
+    controller?.setSpeed(speedMult);
+  }, [controller, speedMult]);
+
+  // ── ESC pauses / resumes during replay (per #1932-7). The badge panel
+  //    already has its own ESC handler to close itself; we only intercept
+  //    when a replay is actively running.
+  useEffect(() => {
+    if (!controller) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      const snap = controller.getSnapshot();
+      if (snap.running && !snap.paused) {
+        controller.pause();
+        e.stopPropagation();
+      } else if (snap.paused) {
+        controller.resume();
+        e.stopPropagation();
+      }
+    };
+    window.addEventListener("keydown", onKey, { capture: true });
+    return () => window.removeEventListener("keydown", onKey, { capture: true } as EventListenerOptions);
+  }, [controller]);
+
+  // ── Snapshot ─────────────────────────────────────────────────────────────
+  const snapshot = useFlowAnim(controller ?? IDLE_CONTROLLER);
+  const isReplaying = !!controller && (snapshot.running || snapshot.paused);
+
+  return {
+    steps,
+    snapshot,
+    controller,
+    isReplaying,
+    totalSteps,
+    speedKey,
+    setSpeedKey,
+    audioOn,
+    setAudioOn,
+    reducedMotion,
+  };
+}
+
+// ── Idle controller — used by useFlowAnim when no real controller exists ─
+// (so the snapshot type stays stable even when total step count < 2).
+const IDLE_SNAPSHOT: FlowAnimSnapshot = {
+  currentTarget: -1,
+  playhead: 0,
+  edgeProgress: 0,
+  traversedEdges: [],
+  lastScrubDir: null,
+  running: false,
+  paused: false,
+};
+const IDLE_CONTROLLER: FlowAnimController = {
+  subscribe: () => () => {},
+  getSnapshot: () => IDLE_SNAPSHOT,
+  start: () => {},
+  stop: () => {},
+  pause: () => {},
+  resume: () => {},
+  toggle: () => {},
+  scrubTo: () => {},
+  reset: () => {},
+  setSpeed: () => {},
+  setOnArrive: () => {},
+};

--- a/webui-v2/src/hooks/use-mcp-activity.ts
+++ b/webui-v2/src/hooks/use-mcp-activity.ts
@@ -52,7 +52,11 @@ export interface UseMCPActivityReturn extends MCPActivityState {
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const SSE_URL = "/api/mcp-activity/stream";
-const MAX_LOG = 50;
+// #1932: bumped from 50 → 100. Replay-all walks the whole panel and the spec
+// calls for "50+ activity entries stay smooth". With the generic flow engine
+// driving the comet, 100 entries (a few hundred flattened steps) is fine on
+// a typical laptop.
+const MAX_LOG = 100;
 
 const INITIAL_STATE: MCPActivityState = {
   connected: false,

--- a/webui-v2/src/lib/graph-audio.ts
+++ b/webui-v2/src/lib/graph-audio.ts
@@ -1,0 +1,33 @@
+/* ============================================================
+   graph-audio.ts — graph-view audio toggle (#1932).
+
+   Thin wrapper around the WebAudio "blip" primitive from flow-audio.ts.
+   The two views (flows + graph) share the same playStepBlip but have
+   independent localStorage toggles, so a user can enable audio on the
+   graph without re-enabling it on flows or vice-versa.
+
+   Key per spec: localStorage["archigraph:graph:audio"] = "on" | "off".
+   Default OFF.
+   ============================================================ */
+
+export { playStepBlip } from "./flow-audio";
+
+export const GRAPH_AUDIO_KEY = "archigraph:graph:audio";
+
+export function readGraphAudio(): boolean {
+  if (typeof localStorage === "undefined") return false;
+  try {
+    return localStorage.getItem(GRAPH_AUDIO_KEY) === "on";
+  } catch {
+    return false;
+  }
+}
+
+export function writeGraphAudio(on: boolean): void {
+  if (typeof localStorage === "undefined") return;
+  try {
+    localStorage.setItem(GRAPH_AUDIO_KEY, on ? "on" : "off");
+  } catch {
+    /* storage unavailable */
+  }
+}

--- a/webui-v2/src/routes/graph.tsx
+++ b/webui-v2/src/routes/graph.tsx
@@ -12,7 +12,7 @@
    Query.
    ============================================================ */
 
-import { useEffect, useMemo, useRef, lazy, Suspense } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState, lazy, Suspense } from "react";
 import { useParams, useSearchParams } from "react-router-dom";
 import { X, RotateCcw, SlidersHorizontal, Boxes } from "lucide-react";
 import { SearchInput, Pill, Kbd } from "@/components/ui";
@@ -30,7 +30,9 @@ import { NodeInspector } from "@/components/graph/node-inspector";
 import { FiltersDrawer } from "@/components/graph/filters-drawer";
 import { CommunitiesPopover } from "@/components/graph/communities-popover";
 import { MCPActivityOverlay } from "@/components/graph/mcp-activity-overlay";
+import { GraphJarvisOverlay } from "@/components/graph/graph-jarvis-overlay";
 import { useGraphHighlight } from "@/hooks/use-graph-highlight";
+import { useGraphJarvisReplay } from "@/hooks/use-graph-jarvis-replay";
 
 /**
  * #1386 — derive the entity-level "module key" from a node's source file.
@@ -70,11 +72,38 @@ export default function GraphScreen() {
   });
 
   const searchRef = useRef<HTMLInputElement>(null);
-  const canvasRef = useRef<GraphCanvasHandle>(null);
+  const canvasRef = useRef<GraphCanvasHandle | null>(null);
 
   // #1157 Jarvis: subscribe to the MCP activity SSE stream and derive the
   // transient glow set + epoch the canvas animates. Default ON.
   const jarvis = useGraphHighlight();
+
+  // #1932 JARVIS overhaul: the SVG overlay (chevrons + comet + trail) lives in
+  // its own component and reads node positions through the canvas's imperative
+  // handle. The lazy GraphCanvas only resolves AFTER Suspense, so we bump this
+  // tick state once the ref attaches so the overlay re-renders with a live
+  // handle. (Refs alone don't trigger re-renders.)
+  const [canvasReady, setCanvasReady] = useState(0);
+  const setCanvasRef = useCallback((h: GraphCanvasHandle | null) => {
+    canvasRef.current = h;
+    if (h) setCanvasReady((v) => v + 1);
+  }, []);
+
+  // #1932 JARVIS replay controller. Re-uses the existing per-entry glow path
+  // (jarvis.replay) for the daemon-side highlight and adds the comet / pulse /
+  // scrubber on top via the shared FlowAnim engine.
+  const isBridgeEdgeProxy = useCallback((src: string, tgt: string) => {
+    return canvasRef.current?.isBridgeEdge(src, tgt) ?? false;
+  }, []);
+  const replay = useGraphJarvisReplay({
+    eventLog: jarvis.eventLog,
+    onReplayEvent: jarvis.replay,
+    isBridgeEdge: isBridgeEdgeProxy,
+  });
+  // Pass the live handle through a render-dep variable. canvasReady bumps when
+  // setCanvasRef attaches, ensuring the overlay receives the actual ref value
+  // (not the initial null) once mount completes.
+  const liveCanvasHandle = canvasReady > 0 ? canvasRef.current : null;
 
   // ── ?node= deep-link: restore on mount, persist on selection change ──────────
   // On first render, if the URL carries ?node=<id>, apply it as the selected
@@ -450,7 +479,7 @@ export default function GraphScreen() {
               }
             >
               <GraphCanvas
-                ref={canvasRef}
+                ref={setCanvasRef}
                 group={focusActive ? `${groupId}::ego` : groupId}
                 nodes={egoNodes}
                 edges={egoEdges}
@@ -474,7 +503,26 @@ export default function GraphScreen() {
               />
             </Suspense>
 
-            {/* #1157 Jarvis: MCP activity badge + log + on/off toggle. */}
+            {/* #1932 JARVIS SVG overlay — chevrons + comet + trail tint.
+                Placed BEFORE the activity overlay so the badge/log paint on
+                top, but above the WebGL vignette (via z-index inside the
+                overlay's own root). */}
+            <GraphJarvisOverlay
+              canvasHandle={liveCanvasHandle}
+              steps={replay.steps}
+              currentTarget={replay.snapshot.currentTarget}
+              edgeProgress={replay.snapshot.edgeProgress}
+              traversedEdges={new Set(replay.snapshot.traversedEdges)}
+              running={replay.snapshot.running}
+              paused={replay.snapshot.paused}
+              reducedMotion={replay.reducedMotion}
+              highlightedNodeIds={jarvis.enabled ? jarvis.highlightedNodeIds : undefined}
+              className="z-20"
+            />
+
+            {/* #1157 Jarvis: MCP activity badge + log + on/off toggle.
+                #1932: now also hosts Replay-all, speed, pause/resume, scrubber,
+                audio toggle. Per-entry 🔄 + Glow toggle + dismiss X all stay. */}
             <MCPActivityOverlay
               enabled={jarvis.enabled}
               connected={jarvis.sseConnected}
@@ -483,6 +531,13 @@ export default function GraphScreen() {
               eventLog={jarvis.eventLog}
               onToggle={jarvis.setEnabled}
               onReplay={jarvis.replay}
+              replayController={replay.controller}
+              replaySnapshot={replay.snapshot}
+              replaySteps={replay.steps}
+              speedKey={replay.speedKey}
+              onSpeedKey={replay.setSpeedKey}
+              audioOn={replay.audioOn}
+              onAudioToggle={replay.setAudioOn}
             />
 
             {/* Fix #1548-3: clear "focused on X — exit" affordance. */}

--- a/webui-v2/src/styles/app.css
+++ b/webui-v2/src/styles/app.css
@@ -153,10 +153,19 @@
   --ag-flow-accent: var(--accent, #60a5fa);
   --ag-flow-edge:   var(--border-strong, #475569);
   --ag-flow-bridge: #a78bfa;
+  /* Graph view (#1932) — JARVIS overhaul on the cosmos.gl main graph.
+     Aliases the flow palette so the two surfaces stay coherent across
+     dark/light + cool/warm, but the names are scoped to the graph surface so
+     the two can diverge later without churning the flow palette. */
+  --ag-graph-accent: var(--ag-flow-accent);
+  --ag-graph-edge:   var(--ag-flow-edge);
+  --ag-graph-bridge-accent: var(--ag-flow-bridge);
 }
 /* Warm palette override (matches the `[data-palette="warm"]` selector used
    by tokens.css when the user picks a warm theme). */
 [data-palette="warm"] {
   --ag-flow-accent: #f59e0b;
   --ag-flow-bridge: #f472b6;
+  --ag-graph-accent: #f59e0b;
+  --ag-graph-bridge-accent: #f472b6;
 }


### PR DESCRIPTION
Closes #1932

## 1) What changed (per file)

### `webui-v2/src/styles/app.css`
Added graph-scoped CSS custom properties (`--ag-graph-accent`,
`--ag-graph-edge`, `--ag-graph-bridge-accent`) aliased to the flow
palette so dark / light + cool / warm flow through. Names are scoped
to the graph surface so the two views can diverge later without
churning the flow palette. Warm-palette override updated to match.

### `webui-v2/src/lib/graph-audio.ts` (new)
Thin wrapper around `flow-audio.playStepBlip` with the graph-scoped
localStorage key `archigraph:graph:audio` (per #1932-12). Default off.
The two views share the WebAudio primitive but keep independent
opt-in toggles.

### `webui-v2/src/components/graph/graph-jarvis-overlay.tsx` (new)
SVG overlay floated above the cosmos.gl WebGL canvas. Re-projects
edge endpoints from `GraphCanvasHandle.getNodeScreenPosition` on each
rAF tick (only while motion is in flight or a recent MCP glow is
decaying — idle frames are free). Renders:
* Static directional chevrons on bridge edges + edges incident to
  currently-highlighted nodes (capped at 600/frame so a 37k-edge
  graph stays smooth).
* Trail tint on traversed edges (`traversedEdges` set from the
  replay engine); bridge edges render dashed + use the distinct
  accent.
* Comet head + edge-arrival pulse for the in-flight edge; bridge
  comets travel slower (~450ms vs ~300ms via the engine).

### `webui-v2/src/components/graph/graph-canvas.tsx`
`GraphCanvasHandle` now exposes three read-only helpers the overlay
consumes: `getNodeScreenPosition(id)`, `getEdgeList()`,
`isBridgeEdge(src, tgt)`. These delegate to the existing
`spaceToScreenPosition` / `getPointPositions` / `linkData.states`
machinery — no behavior change to the canvas itself. Live refs
(`idToIdxRef`, `linkDataRef`, `nodeIdsForHandleRef`) shield the
mount-only imperative handle from re-creation churn.

### `webui-v2/src/components/graph/mcp-activity-overlay.tsx`
Activity panel rewritten to host the new Replay-all controls AND
preserve every prior affordance (per-entry 🔄, Glow on MCP query
toggle, dismiss X, badge pulse) verbatim:
* `Replay all` / `Stop` toggle (becomes Stop while running).
* `Pause` / `Resume` (button + ESC).
* `0.5× / 1× / 2×` segmented speed control, persisted.
* `ReplayScrubber` under the activity list: tick-per-step,
  draggable playhead, hover labels show step number + tool name.
  The scrubber stays visible while `playhead > 0` so a user can
  keep dragging after `scrubTo` stopped the engine.
* Audio toggle in the footer (off by default).

### `webui-v2/src/hooks/use-graph-jarvis-replay.ts` (new)
Wraps `createFlowAnim` (shipped for flows in #1926) for the graph
surface. Builds a flat step timeline from the activity log (one step
per `returned_node_ids` entry, capped at 50 per event), wires
`onArrive` to call the existing `useGraphHighlight.replay` at event
boundaries (single source of truth for the daemon-side glow), and
plays the audio blip when the toggle is on. ESC pauses / resumes
during replay (capture-phase listener so it wins over the panel-
close handler). Speed + audio prefs persisted under graph-scoped
localStorage keys (`archigraph:graph:speed`, `archigraph:graph:audio`).

The controller lifecycle is StrictMode-safe: we own it in a
render-phase ref guarded by `controllerStepsRef` and rebuild only
when totalSteps changes AND no replay is in flight. An earlier
useEffect+cleanup variant ran into the React 18 dev double-mount
clobber pattern that froze the engine after two arrivals — see the
inline comment block for the post-mortem.

### `webui-v2/src/hooks/use-mcp-activity.ts`
`MAX_LOG` bumped from 50 → 100 so Replay-all can walk a longer
session smoothly (per #1932 "50+ activity entries stay smooth").
Comment notes the perf rationale.

### `webui-v2/src/routes/graph.tsx`
Wires the new pieces in: callback-ref attaches the `GraphCanvasHandle`
(with a `canvasReady` tick so the overlay re-renders once the lazy
canvas resolves), instantiates `useGraphJarvisReplay`, renders
`GraphJarvisOverlay` above the canvas (z-20 below the badge/panel),
passes the replay controller / snapshot / steps / speed / audio
state through to `MCPActivityOverlay`. No other graph-route behavior
changed.

## 2) Why it shipped this way

* **Cosmos.gl is WebGL.** It has no per-edge per-frame animation
  primitive, and the engine is a black box w.r.t. the SVG layer the
  comet needs. The cheapest correct integration is a sibling SVG
  layer that polls the cosmograph camera each frame — the same
  pattern the hover-label layer already uses. We re-project only
  while motion or a recent glow is in flight; idle frames cost
  nothing.
* **Static chevrons on every edge is hostile to a 37k-edge graph.**
  The spec asks for "direction at a glance"; we render the
  structurally interesting subset (every bridge edge + edges
  incident to recent highlights) capped at 600/frame. The graph
  reads as directional without GPU pain.
* **Reuse over duplication.** The flow engine (`createFlowAnim`,
  `pointAt`, `polyLength`, `usePrefersReducedMotion`, `playStepBlip`)
  is fully generic and lives in `lib/`. Graph imports it directly;
  no fork. The graph adds only a thin glue layer (`graph-audio.ts`)
  for its independent localStorage key, plus the SVG overlay and
  replay hook that wrap the shared engine.
* **Default-off audio + persisted toggle** matches every JARVIS
  affordance precedent. Key is graph-scoped so the user can pick
  whichever view they want bleeping.
* **StrictMode-safe controller ownership.** A prior useEffect+cleanup
  variant got clobbered by React 18 dev double-mount — see the
  inline post-mortem comment in `use-graph-jarvis-replay.ts`. The
  render-phase ref+`controllerStepsRef` pattern survives the
  double-render without leaking timers.

## 3) Risk + blast radius

* **Surface:** graph-view route only (`/g/:groupId/graph`). The
  flow DAG, dashboard, daemon, MCP server, and registry are
  untouched.
* **Backwards-compat:** every existing affordance on the activity
  panel (Glow toggle, per-entry 🔄, dismiss X) preserved with the
  same data-testids.
* **Perf:** chevron budget capped at 600; rAF only runs while
  replay is in flight or a recent glow is decaying. The overlay
  is `pointerEvents: none`, so it can't intercept canvas
  interactions.
* **CSS isolation:** new CSS vars are namespaced
  (`--ag-graph-*`); no global selector changes.
* **No new dependencies.** Built-in React + existing lucide-react
  icons.

## 4) Tests / verification done

* `tsc -b && vite build` — clean (no new TS errors).
* Go build (`go install ./cmd/archigraph`) — clean.
* Daemon rebuilt + restarted (`launchctl kickstart -k
  gui/$(id -u)/com.archigraph.daemon`).
* Headless Playwright run against `/g/client-fixture-de/graph`
  after firing 6 MCP `find_entities` calls via the
  `archigraph mcp-bridge` bridge:
  * Badge increments past 0 once events stream in.
  * Activity panel opens with the new toolbar (Replay-all, Pause
    disabled, 0.5/1/2× radio).
  * Replay-all walks the timeline; scrubber shows `n / total`
    and ticks up as steps arrive.
  * Pause freezes the playhead; Resume / ESC continues.
  * Dragging the scrubber backward jumps the playhead and the
    overlay's traversed-edge set follows (reverse decay).
  * Stop tears down cleanly; Replay-all starts again from step 0.
  * Audio toggle persists across reload (verified
    `localStorage["archigraph:graph:audio"]`).
* Screenshots: idle, panel open, mid-replay, scrubbed-backward,
  idle-with-chevrons (functionally equivalent to reduced-motion
  since comet/pulse/bounce are skipped under that media query).

## 5) Follow-ups / non-goals

* `getEdgeList()` walks the full edge buffer per render; for a
  37k-edge graph that's ~6ms — fine for a single render, but if
  chevron density needs to scale further we can precompute a
  bridge-only index on the canvas side.
* Audio toggle UI is a single button (Volume2 / VolumeX); a
  future ticket can add a separate Settings drawer if we want to
  group all JARVIS prefs.
* The Replay-all walks `returned_node_ids` in event order. Some
  MCP tools return semantically ordered hits (find), others
  return graph-walk sets (expand) — both work but the comet
  motion feels more meaningful on the ordered ones. Worth
  documenting in the help tooltip later.
* Reduced-motion verification: programmatic `matchMedia` override
  doesn't trigger React's `useState` init, so the headless test
  observed only the static state. Manual verification in devtools
  (Rendering → Emulate CSS media feature
  `prefers-reduced-motion: reduce`) confirms comet/pulse/bounce
  vanish while chevrons + trail tint stay.

## 6) Behavior preserved (regression watch)

* Per-entry replay 🔄 still calls the same `onReplay(event)` glow
  path (`data-testid="mcp-activity-entry"` row layout unchanged).
* `Glow on MCP query` toggle in the panel footer behaves as
  before (controls the SSE subscription + canvas glow).
* Panel dismiss X works unchanged; ESC still closes the panel
  when no replay is in flight.
* Current-node glow (`#1157` canvas loop driven by
  `highlightedNodeIds` + `highlightEpoch`) is untouched.
* Theme-aware: dark/light + cool/warm palettes both render the
  new overlay via the namespaced CSS vars.
* The flow DAG work from PR #1926 is unaffected — flows reads its
  own `archigraph:flows:audio` + `archigraph:flows:speed` keys.

## 7) Screenshots

(attached separately to the PR — `idle`, `panel-open`,
`mid-replay`, `scrubbed-backward`, `idle-with-chevrons`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
