### PR TITLE
ui(paths): RefLine path becomes clickable link, drop redundant kind/framework chips (#1934)

### DIFF
--- a/webui-v2/src/components/RefLine.tsx
+++ b/webui-v2/src/components/RefLine.tsx
@@ -4,15 +4,17 @@
    Issue #1910: unified format across Defined-in / Called-by /
    Downstream in the endpoint detail pane (and future detail pages).
 
+   Issue #1934: file path is a full clickable link with RTL
+   ellipsis on overflow; per-row kind/framework chips removed.
+
    Row layout:
-     [repo chip]  file:line (mono, dim)  entity name (regular)
+     [repo chip]  full/file/path:line (mono link, RTL trunc)  entity name (regular)
 
    Props:
      repo   — owning repository slug (shown as a small colored chip)
-     file   — source file path (basename:line shown in mono dim text)
+     file   — source file path (full relative path shown as a link)
      line   — source line number
      name   — entity / caller name (regular weight)
-     kind?  — optional kind label shown as a small tag after the name
    ============================================================ */
 
 import { cn } from "@/lib/utils";
@@ -22,10 +24,11 @@ export interface RefLineProps {
   file: string;
   line: number;
   name: string;
-  kind?: string;
   /** Accessibility: full title on hover (defaults to "repo · file:line  name") */
   title?: string;
   className?: string;
+  /** Called when the file path link is clicked. Receives "file:line" string. */
+  onFileClick?: (fileRef: string) => void;
 }
 
 /** Stable hash → pastel color index (1-9) for the repo chip. */
@@ -37,31 +40,29 @@ function repoColorIndex(repo: string): number {
   return (Math.abs(h) % 9) + 1;
 }
 
-/** Basename of a file path: "src/orders/order.service.ts" → "order.service.ts" */
-function basename(filePath: string): string {
-  const last = filePath.lastIndexOf("/");
-  return last >= 0 ? filePath.slice(last + 1) : filePath;
-}
-
 /**
  * RefLine — one-line entity reference used in Defined-in, Called-by, and
  * Downstream sections. Keeps all three sections visually consistent and
- * scannable: repo chip on the left, file:line in mono dim, name in regular
- * weight on the right.
+ * scannable: repo chip on the left, full file:line path as a clickable link
+ * (RTL ellipsis so filename+line stays visible on overflow), entity name on
+ * the right.
+ *
+ * Issue #1934: kind/framework per-row chips removed — they live in the
+ * endpoint header chip strip and are redundant at row level.
  */
 export function RefLine({
   repo,
   file,
   line,
   name,
-  kind,
   title,
   className,
+  onFileClick,
 }: RefLineProps) {
   const ci = repoColorIndex(repo);
-  const fileLabel = file ? `${basename(file)}:${line}` : line > 0 ? `:${line}` : "";
-  const derivedTitle =
-    title ?? `${repo} · ${file}:${line}  ${name}${kind ? ` (${kind})` : ""}`;
+  // Full path including line number — never trimmed to basename.
+  const fileLabel = file ? `${file}:${line}` : line > 0 ? `:${line}` : "";
+  const derivedTitle = title ?? `${repo} · ${file}:${line}  ${name}`;
 
   return (
     <div
@@ -78,7 +79,6 @@ export function RefLine({
           className={cn(
             "shrink-0 inline-flex items-center h-[18px] px-1.5 rounded",
             "text-[10px] font-semibold font-mono leading-none select-none",
-            // Use pastel CSS token for background, darker ink for text.
           )}
           style={{
             background: `var(--pastel-${ci})`,
@@ -90,14 +90,24 @@ export function RefLine({
         </span>
       )}
 
-      {/* file:line — mono, dimmed */}
+      {/* Full file:line path — clickable link with RTL overflow so filename+line
+          remains visible when the path is long and the container is narrow.
+          `direction: rtl` causes overflow to clip on the LEFT side; the
+          rightmost content (filename:line) is always fully visible. */}
       {fileLabel && (
-        <span
-          className="font-mono text-[11px] text-text-4 shrink-0 tabular-nums truncate max-w-[160px]"
-          title={file ? `${file}:${line}` : String(line)}
+        <button
+          type="button"
+          onClick={() => onFileClick?.(fileLabel)}
+          title={fileLabel}
+          className={cn(
+            "font-mono text-[11px] tabular-nums text-left",
+            "min-w-0 overflow-hidden whitespace-nowrap text-ellipsis",
+            "text-accent hover:underline cursor-pointer",
+          )}
+          style={{ direction: "rtl", unicodeBidi: "plaintext" as const }}
         >
           {fileLabel}
-        </span>
+        </button>
       )}
 
       {/* Entity name — regular weight, takes remaining space */}
@@ -107,13 +117,6 @@ export function RefLine({
       >
         {name}
       </span>
-
-      {/* Optional kind tag */}
-      {kind && (
-        <span className="shrink-0 text-[10px] text-text-4 font-mono px-1 rounded bg-surface-2">
-          {kind}
-        </span>
-      )}
     </div>
   );
 }

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -503,7 +503,8 @@ function SectionHeader({
   );
 }
 
-/** EntityRow — wraps RefLine for PathEntity values (Downstream, Side-effects, Tests). */
+/** EntityRow — wraps RefLine for PathEntity values (Downstream, Side-effects, Tests).
+ *  Issue #1934: kind chip dropped from row — redundant with header-level metadata. */
 function EntityRow({ entity }: { entity: PathEntity }) {
   return (
     <RefLine
@@ -511,13 +512,13 @@ function EntityRow({ entity }: { entity: PathEntity }) {
       file={entity.source_file ?? ""}
       line={entity.start_line ?? 0}
       name={entity.label ?? entity.qualified_name ?? ""}
-      kind={entity.kind}
     />
   );
 }
 
 /** HandlerRefLine — renders a handler detail using the canonical RefLine format.
- *  Issue #1910: Defined-in section collapses from verbose card to one-line ref. */
+ *  Issue #1910: Defined-in section collapses from verbose card to one-line ref.
+ *  Issue #1934: framework/kind chip removed from RefLine — shown in header strip. */
 function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
   return (
     <div className="flex items-start gap-2 py-1 px-4 hover:bg-surface-2 transition-colors">
@@ -526,7 +527,6 @@ function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
         file={handler.source_file ?? ""}
         line={handler.start_line ?? 0}
         name={handler.qualified_name ?? handler.verb}
-        kind={handler.framework || handler.language || undefined}
         className="flex-1 px-0 py-0"
       />
       <div className="flex items-center gap-1 shrink-0">


### PR DESCRIPTION
## What

Closes #1934

Two UX cleanups to the endpoint detail pane introduced in #1910:

1. **Full clickable file paths** — the file:line column in every RefLine row now shows the full relative path (e.g. `src/main/java/…/TransfersController.java:76`) instead of the truncated basename. The cell is a `<button>` styled as an accent-colored link with hover underline and pointer cursor. An `onFileClick` callback prop is exposed for future editor deep-linking (`vscode://` / `cursor://`).

2. **RTL overflow ellipsis** — `direction: rtl; unicode-bidi: plaintext` on the path button causes long paths to ellipsify on the **left**, so the filename and line number are always visible even in narrow columns. The path text still reads LTR (`unicodeBidi: plaintext`).

3. **Per-row kind/framework chips removed** — the `kind` prop is dropped from `RefLineProps`. Neither `EntityRow` nor `HandlerRefLine` pass a kind/framework chip anymore. Those labels are already present in the detail-panel header chip strip (`PUT [jaxrs] [client-fixture-d]`) and were visually noisy at row level.

## Files changed

| File | Change |
|------|--------|
| `webui-v2/src/components/RefLine.tsx` | Drop `kind` prop + chip render; drop `basename()` helper; file label = full path; `<span>` → `<button>` with RTL CSS; add `onFileClick` callback |
| `webui-v2/src/routes/paths.tsx` | `EntityRow`: remove `kind={entity.kind}`; `HandlerRefLine`: remove `kind={handler.framework\|language}` |

## Verify on client-fixture-de

- `/transfers/confirm/{transferId}` → Defined-in row shows `[client-fixture-d] src/main/java/com/…/TransfersController.java:76  TransfersController.confirmTransfer` with the path as a link, no `[jaxrs]` / `[PUT]` chip after.
- Called-by row shows `[client-fixture-e] src/store/inventory/inventory.service.js:56  confirmTransfer` — no `[Operation]` chip.
- Header chip strip at top still shows `PUT [jaxrs] [client-fixture-d]` — unchanged.
- Verify on polyglot-platform endpoint detail too.

## Build

`tsc -b && vite build` — zero errors, zero new warnings. ✓

## Notes

- The `onFileClick` prop is optional and currently no-ops (future hook for editor deep-links).
- Header chip strip and all other UI elements are untouched.
- No snapshot or unit test changes needed — RefLine has no dedicated test file; E2E covers endpoint detail rendering.