### PR TITLE
ui(paths): rename misleading [No auth] to muted [Auth: unknown] (#1942 Phase 0)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -643,8 +643,8 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
               <Lock size={10} /> Auth · {detail.auth_scheme ?? "Bearer"}
             </span>
           ) : (
-            <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-warning-soft text-warning">
-              No auth
+            <span className="inline-flex items-center gap-1 text-xs px-2 py-0.5 rounded-full bg-surface-2 text-text-3">
+              Auth: unknown
             </span>
           )}
           {detail.handlers[0]?.framework && (


### PR DESCRIPTION
## Summary

Replace the misleading `[No auth]` label with `[Auth: unknown]` in muted color. Most real-world endpoints are auth-required by middleware/filter/config, not per-handler annotation. The current yellow chip incorrectly implies the endpoint is unprotected. `[Auth: unknown]` muted is accurate until the full auth policy resolver is built (Phases 1-5 of #1942).

## Changes

- Renamed label from `[No auth]` to `[Auth: unknown]` in endpoint detail header chip strip
- Changed color from yellow warning (bg-warning-soft/text-warning) to muted (bg-surface-2/text-text-3)
- Verified no other dashboard components render `[No auth]`
- Build checks: `tsc -b` ✓ zero errors, `vite build` ✓ zero errors

## How to test

1. Run the dashboard on client-fixture-de
2. Inspect an endpoint without explicit `@PermitAll` annotation
3. Verify the chip shows `[Auth: unknown]` in muted gray, not `[No auth]` in yellow

Refs #1942 (Phase 0)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>