### PR TITLE
fix(graph): JARVIS replay + audio cleanup on route unmount (#1954)

### DIFF
--- a/webui-v2/src/hooks/use-graph-jarvis-replay.ts
+++ b/webui-v2/src/hooks/use-graph-jarvis-replay.ts
@@ -31,7 +31,7 @@ import {
   useFlowAnim,
 } from "@/lib/flow-animation";
 import { usePrefersReducedMotion } from "@/lib/use-reduced-motion";
-import { playStepBlip, readGraphAudio, writeGraphAudio } from "@/lib/graph-audio";
+import { playStepBlip, readGraphAudio, suspendGraphAudio, writeGraphAudio } from "@/lib/graph-audio";
 import type { MCPActivityEvent } from "./use-mcp-activity";
 import type { JarvisStep } from "@/components/graph/graph-jarvis-overlay";
 
@@ -178,21 +178,27 @@ export function useGraphJarvisReplay(
 
   // Controller lifecycle (StrictMode-safe).
   // -----------------------------------------------------------------
-  // Earlier versions of this hook created the controller inside a
-  // useEffect and stopped it in the cleanup. Under React 18 StrictMode
-  // dev mode the cleanup runs between the double-invoked mount, which
-  // leaves the controller in state STOPPED — the user clicks Replay-all
-  // and the engine fires the first couple of arrivals before its still-
-  // pending interStepTimer gets cleared by the cleanup, then freezes.
-  //
   // We own the controller in a ref that we (re)build in the render phase
   // ONLY when the engine is idle (no replay in flight) AND the total step
   // count has shifted. This survives the StrictMode dev double-render
   // because the second render sees `controllerStepsRef.current === totalSteps`
-  // and skips the rebuild path. There's NO useEffect cleanup that could
-  // clobber a running engine.
+  // and skips the rebuild path.
+  //
+  // StrictMode cleanup problem (pre-#1954 fix): if we stopped the controller in
+  // a plain useEffect cleanup, React 18 StrictMode dev-mode would fire that
+  // cleanup between the double-mount, clobbering the running rAF and freezing
+  // the engine at step 2.
+  //
+  // Solution: track whether the component has completed its FIRST committed
+  // mount via `mountedRef`. On the StrictMode double-mount the cleanup runs
+  // before `mountedRef` is set to true; we therefore skip the stop(). On a
+  // REAL route unmount the cleanup runs after mount committed, so we stop().
+  // This gives correct teardown on navigation without breaking dev-mode replay.
   const controllerRef = useRef<FlowAnimController | null>(null);
   const controllerStepsRef = useRef<number>(-2);
+  // True after the first real commit (set in useEffect, which only runs after
+  // the browser has painted, not during StrictMode's synchronous cleanup).
+  const mountedRef = useRef(false);
 
   // Re-create the controller whenever totalSteps changes AND no replay is in
   // flight. Once a replay is running we leave the engine alone (the user can
@@ -236,13 +242,31 @@ export function useGraphJarvisReplay(
   }
   const controller = controllerRef.current;
 
-  // Note: we deliberately do NOT run a useEffect cleanup that calls
-  // controller.stop()/reset() on unmount. React 18 StrictMode dev mode
-  // would invoke that cleanup between the dev-mode double-mount, which
-  // would clear the controller's rAF + interStepTimer mid-replay and
-  // freeze the engine at step 2. The engine's only side-effects are
-  // timers; the engine is GC'd when the host route unmounts (no global
-  // listeners), so the route's natural unmount is sufficient cleanup.
+  // Route-unmount cleanup (#1954).
+  // We must stop the controller (rAF loop + scheduled blips) when the graph
+  // route unmounts for real. We cannot use a plain useEffect cleanup because
+  // React 18 StrictMode dev mode fires cleanups between the double-mount —
+  // that would stop a mid-replay engine before the user has done anything.
+  //
+  // Pattern: mark the component as "committed" in a useEffect (runs after
+  // paint, after StrictMode's synchronous cleanup). The cleanup below only
+  // calls stop() once mounted=true, which is never the case for the ephemeral
+  // StrictMode teardown, but IS true for every real route navigation.
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      if (!mountedRef.current) return; // StrictMode pre-commit teardown — skip.
+      mountedRef.current = false;
+      // Stop the rAF state machine. This prevents further onArrive callbacks
+      // (which is what schedules new audio blips). Already-enqueued 60ms blip
+      // nodes will play to completion — they're too short to matter.
+      controllerRef.current?.stop();
+      // Suspend the shared AudioContext so no residual oscillator output
+      // reaches the speakers even if a blip node was mid-play.
+      suspendGraphAudio();
+    };
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // empty deps: run once on mount, cleanup runs on real unmount.
 
   // Live-push speed updates without recreating the controller.
   useEffect(() => {

--- a/webui-v2/src/lib/flow-audio.ts
+++ b/webui-v2/src/lib/flow-audio.ts
@@ -51,6 +51,21 @@ function getCtx(): AudioContext | null {
 }
 
 /**
+ * Suspend the shared AudioContext so any residual oscillator nodes stop
+ * producing output immediately. Called on route unmount (#1954) to silence
+ * audio that may be mid-play when the user navigates away from the graph view.
+ * The context is resumed automatically by playStepBlip() on the next blip.
+ */
+export function suspendAudioCtx(): void {
+  if (!ctx || ctx.state === "suspended" || ctx.state === "closed") return;
+  try {
+    void ctx.suspend();
+  } catch {
+    /* best-effort */
+  }
+}
+
+/**
  * Play a short sine-wave blip. No-op on failure (unsupported, suspended,
  * etc.) — audio is strictly optional polish.
  */

--- a/webui-v2/src/lib/graph-audio.ts
+++ b/webui-v2/src/lib/graph-audio.ts
@@ -10,7 +10,7 @@
    Default OFF.
    ============================================================ */
 
-export { playStepBlip } from "./flow-audio";
+export { playStepBlip, suspendAudioCtx as suspendGraphAudio } from "./flow-audio";
 
 export const GRAPH_AUDIO_KEY = "archigraph:graph:audio";
 


### PR DESCRIPTION
## Summary

Closes #1954

JARVIS Replay-all with audio toggled ON was leaking animation frames and WebAudio blip nodes across the `/graph` → `/paths` route change. The rAF state machine kept ticking and scheduling new oscillator nodes even after the graph route unmounted.

## Root cause

PR #1948 moved the controller into a render-phase ref (not a `useEffect`) to survive React 18 StrictMode dev double-mount. That solved StrictMode, but eliminated the only place where `controller.stop()` could have been called on unmount. The comment in that code explicitly said no cleanup was needed because "no global listeners" — but the rAF loop itself IS the leak.

## Changes

### `webui-v2/src/hooks/use-graph-jarvis-replay.ts`
- Adds a `mountedRef` boolean (set to `true` in a `useEffect` after the first committed paint).
- The `useEffect` cleanup calls `controller.stop()` + `suspendGraphAudio()` **only when `mountedRef === true`** — which is never the case for the StrictMode pre-commit teardown, but is always the case for a real route navigation unmount.
- This cleanly distinguishes StrictMode from production without any timers or heuristics.

### `webui-v2/src/lib/flow-audio.ts`
- Adds `suspendAudioCtx()`: calls `AudioContext.suspend()` on the shared context so any oscillator nodes mid-play stop producing output immediately. The context auto-resumes on the next `playStepBlip()` call when the user returns to the graph.

### `webui-v2/src/lib/graph-audio.ts`
- Re-exports `suspendAudioCtx` as `suspendGraphAudio` for use by the hook.

### `webui-v2/src/components/graph/graph-jarvis-overlay.tsx`
- No change needed. The overlay's rAF loop already had a correct `useEffect` cleanup with `cancelAnimationFrame` and a `stopped` guard.

## Coordination with #1953

This fix is intentionally minimal and targets only the cleanup contract. #1953 (JARVIS two-phase rebalance) is refactoring `flow-animation.ts` and `graph-jarvis-overlay.tsx` extensively. Since this PR touches different surfaces (`use-graph-jarvis-replay.ts`, `flow-audio.ts`, `graph-audio.ts`), conflicts should be minimal. If #1953 lands first, rebasing this branch against main and re-verifying the cleanup paths in the rewritten code is the correct path.

## Verify

1. Open `/g/client-fixture-de/graph`, toggle audio ON, fire 8 MCP calls.
2. While Replay-all is mid-flight navigate to `/g/client-fixture-de/paths`.
3. Expected: animation stops immediately, NO further audio blips, devtools Performance shows no orphaned rAF tick.
4. Navigate back to `/graph`: state is clean — no auto-resume, audio only fires when Replay-all is explicitly triggered again.

## Build

`tsc -b && vite build` — zero errors, zero new TS warnings in changed files.

## Test plan

- [ ] Audio stops on `/graph` → `/paths` navigation (no blips after route change)
- [ ] rAF loop is cancelled (no orphaned animation frame in devtools Performance)
- [ ] Navigating back to `/graph` starts clean — no auto-play of animation
- [ ] StrictMode dev double-mount does NOT clobber a running replay (existing behaviour from #1948 preserved)
- [ ] `tsc -b && vite build` passes with zero errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)