### PR TITLE
ui(paths): RefLine center-ellipsis path + repo chip right-anchored + drop verb chip on Defined-in (#1957)

### DIFF
--- a/webui-v2/src/components/RefLine.tsx
+++ b/webui-v2/src/components/RefLine.tsx
@@ -7,8 +7,15 @@
    Issue #1934: file path is a full clickable link with RTL
    ellipsis on overflow; per-row kind/framework chips removed.
 
+   Issue #1957: layout overhaul:
+     - 60/40 column split: path column (60%) | name column (40%)
+     - repo chip right-anchored (after name column)
+     - center-ellipsis on path overflow: head span LTR-truncates,
+       tail span (filename:line) never shrinks, ellipsis in between
+     - native `title` attr on row for full-path hover tooltip
+
    Row layout:
-     [repo chip]  full/file/path:line (mono link, RTL trunc)  entity name (regular)
+     [path-col 60% center-ellipsis]  [name-col 40%]  [repo chip]
 
    Props:
      repo   — owning repository slug (shown as a small colored chip)
@@ -41,14 +48,46 @@ function repoColorIndex(repo: string): number {
 }
 
 /**
+ * Split a file path into head and tail for center-ellipsis rendering.
+ *
+ * The tail always contains the filename (last segment) plus the line suffix.
+ * The head contains everything before the filename (directory prefix).
+ *
+ * Example: "src/main/java/com/example/TransfersController.java:48"
+ *   tail → "TransfersController.java:48"
+ *   head → "src/main/java/com/example/"
+ */
+function splitPathForEllipsis(
+  file: string,
+  line: number,
+): { head: string; tail: string } {
+  const fileLabel = file ? `${file}:${line}` : line > 0 ? `:${line}` : "";
+  if (!fileLabel) return { head: "", tail: "" };
+
+  const lastSlash = file.lastIndexOf("/");
+  if (lastSlash < 0) {
+    return { head: "", tail: fileLabel };
+  }
+
+  const head = file.slice(0, lastSlash + 1);
+  const filename = file.slice(lastSlash + 1);
+  const tail = `${filename}:${line}`;
+  return { head, tail };
+}
+
+/**
  * RefLine — one-line entity reference used in Defined-in, Called-by, and
  * Downstream sections. Keeps all three sections visually consistent and
- * scannable: repo chip on the left, full file:line path as a clickable link
- * (RTL ellipsis so filename+line stays visible on overflow), entity name on
- * the right.
+ * scannable.
  *
- * Issue #1934: kind/framework per-row chips removed — they live in the
- * endpoint header chip strip and are redundant at row level.
+ * Issue #1957 layout:
+ *   [path-col 60%] [name-col 40%] [repo chip right]
+ *
+ * The path column uses the two-span center-ellipsis trick: the head span
+ * (directory prefix) truncates on its right with LTR ellipsis; the tail span
+ * (filename:line) never shrinks so the important part is always visible.
+ *
+ * A native `title` attribute on the row gives the full path as a hover tooltip.
  */
 export function RefLine({
   repo,
@@ -60,9 +99,9 @@ export function RefLine({
   onFileClick,
 }: RefLineProps) {
   const ci = repoColorIndex(repo);
-  // Full path including line number — never trimmed to basename.
   const fileLabel = file ? `${file}:${line}` : line > 0 ? `:${line}` : "";
   const derivedTitle = title ?? `${repo} · ${file}:${line}  ${name}`;
+  const { head, tail } = splitPathForEllipsis(file, line);
 
   return (
     <div
@@ -73,11 +112,49 @@ export function RefLine({
       )}
       title={derivedTitle}
     >
-      {/* Repo chip — distinct color per repo slug for quick scanning */}
+      {/* Path column — 60% width, center-ellipsis via two-span trick.
+          Head (directory prefix) truncates LTR; tail (filename:line) shrink-0. */}
+      {fileLabel && (
+        <button
+          type="button"
+          onClick={() => onFileClick?.(fileLabel)}
+          title={fileLabel}
+          className={cn(
+            "flex items-center min-w-0 text-left",
+            "font-mono text-[11px] tabular-nums",
+            "text-accent hover:underline cursor-pointer",
+          )}
+          style={{ flexBasis: "60%", flexShrink: 1, flexGrow: 0, minWidth: 0 }}
+        >
+          {head ? (
+            <>
+              <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0 shrink">
+                {head}
+              </span>
+              <span className="shrink-0 whitespace-nowrap">{tail}</span>
+            </>
+          ) : (
+            <span className="overflow-hidden whitespace-nowrap text-ellipsis min-w-0">
+              {tail || fileLabel}
+            </span>
+          )}
+        </button>
+      )}
+
+      {/* Name column — 40% width, right-truncates on overflow */}
+      <span
+        className="text-xs text-text truncate font-mono min-w-0"
+        title={name}
+        style={{ flexBasis: "40%", flexShrink: 1, flexGrow: 0 }}
+      >
+        {name}
+      </span>
+
+      {/* Repo chip — right-anchored via ml-auto, never squished */}
       {repo && (
         <span
           className={cn(
-            "shrink-0 inline-flex items-center h-[18px] px-1.5 rounded",
+            "shrink-0 inline-flex items-center h-[18px] px-1.5 rounded ml-auto",
             "text-[10px] font-semibold font-mono leading-none select-none",
           )}
           style={{
@@ -89,34 +166,6 @@ export function RefLine({
           {repo}
         </span>
       )}
-
-      {/* Full file:line path — clickable link with RTL overflow so filename+line
-          remains visible when the path is long and the container is narrow.
-          `direction: rtl` causes overflow to clip on the LEFT side; the
-          rightmost content (filename:line) is always fully visible. */}
-      {fileLabel && (
-        <button
-          type="button"
-          onClick={() => onFileClick?.(fileLabel)}
-          title={fileLabel}
-          className={cn(
-            "font-mono text-[11px] tabular-nums text-left",
-            "min-w-0 overflow-hidden whitespace-nowrap text-ellipsis",
-            "text-accent hover:underline cursor-pointer",
-          )}
-          style={{ direction: "rtl", unicodeBidi: "plaintext" as const }}
-        >
-          {fileLabel}
-        </button>
-      )}
-
-      {/* Entity name — regular weight, takes remaining space */}
-      <span
-        className="text-xs text-text truncate flex-1 font-mono"
-        title={name}
-      >
-        {name}
-      </span>
     </div>
   );
 }

--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -480,10 +480,23 @@ function EntityRow({ entity }: { entity: PathEntity }) {
 
 /** HandlerRefLine — renders a handler detail using the canonical RefLine format.
  *  Issue #1910: Defined-in section collapses from verbose card to one-line ref.
- *  Issue #1934: framework/kind chip removed from RefLine — shown in header strip. */
+ *  Issue #1934: framework/kind chip removed from RefLine — shown in header strip.
+ *  Issue #1957: verb chip dropped from Defined-in rows — verb is already shown
+ *               in the panel header. Repo chip is now right-anchored inside RefLine. */
 function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
+  const hasBadges = handler.auth || handler.has_docs;
+  if (!hasBadges) {
+    return (
+      <RefLine
+        repo={handler.repo ?? ""}
+        file={handler.source_file ?? ""}
+        line={handler.start_line ?? 0}
+        name={handler.qualified_name ?? handler.verb}
+      />
+    );
+  }
   return (
-    <div className="flex items-start gap-2 py-1 px-4 hover:bg-surface-2 transition-colors">
+    <div className="flex items-center gap-2 py-1 px-4 hover:bg-surface-2 transition-colors">
       <RefLine
         repo={handler.repo ?? ""}
         file={handler.source_file ?? ""}
@@ -492,7 +505,6 @@ function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
         className="flex-1 px-0 py-0"
       />
       <div className="flex items-center gap-1 shrink-0">
-        <VerbChip verb={handler.verb} />
         {handler.auth && (
           <span className="inline-flex items-center gap-0.5 text-[10px] px-1 py-0.5 rounded bg-success-soft text-success">
             <Lock size={8} /> auth


### PR DESCRIPTION
## What

RefLine polish per #1957: four visual fixes to the Defined-in / Called-by / Downstream rows in the endpoint detail panel.

## Why

The row layout had three issues: the `[PUT]` verb chip was redundant (verb is already shown in the panel header), the repo chip was on the left making rows harder to scan vertically, and long Java/Python paths truncated on the right hiding the filename.

## Changes

**`webui-v2/src/components/RefLine.tsx`**
- New 60/40 flex-basis column split: path column takes 60%, entity name takes 40%
- Repo chip moved to the right side via `ml-auto` — predictable right edge for vertical scanning when 5+ rows are stacked
- Center-ellipsis via two-span trick: `head` span (directory prefix) LTR-truncates with `text-ellipsis`, `tail` span (filename:line) is `shrink-0` so it is always fully visible
- Native `title={derivedTitle}` on the row div gives a free hover tooltip with the full path (was already present, now confirmed on the outer row)
- Helper `splitPathForEllipsis()` splits `src/main/java/com/example/TransfersController.java` → `{ head: "src/main/java/com/example/", tail: "TransfersController.java:48" }`

**`webui-v2/src/routes/paths.tsx`**
- `HandlerRefLine`: removed `<VerbChip verb={handler.verb} />` — the verb chip is redundant on Defined-in rows since the selected verb is already shown in the panel header chip strip
- Auth/docs badges are preserved; simplified to a plain `<RefLine>` when neither badge is present

## Verification

- `tsc -b` zero errors
- `vite build` zero errors (chunk-size warnings are pre-existing)
- Daemon rebuilt and restarted on :47274 with new dist
- On client-fixture-de `PUT /transfers/confirm/{transferId}`:
  - Defined-in row: `src/main/java/com/.../TransfersController.java:48  TransfersController.confirmTransfer  [client-fixture-d]` — no [PUT] chip, repo chip on right
  - Narrow panel → directory prefix ellipsifies, `TransfersController.java:48` stays visible
  - Hover → native title tooltip shows full path

## Sections

1. **What**: four layout fixes (60/40 split, repo right, center-ellipsis, drop verb chip)
2. **Why**: verb chip redundant; left repo chip hard to scan; RTL truncation hid filename
3. **Files**: `RefLine.tsx`, `paths.tsx`
4. **Approach**: two-span center-ellipsis trick (no JS measurement, no ResizeObserver)
5. **Build**: `tsc -b` + `vite build` clean; daemon restarted
6. **Risk**: layout-only; no data model changes; auth/docs badges preserved
7. **Closes**: Closes #1957

Closes #1957