### PR TITLE
ui(paths): Response shapes (N) counter matches rendered row count (#1960)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -749,8 +749,13 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
                     </tr>
                   </thead>
                   <tbody>
-                    {filteredShapes.flatMap((shape, shapeIdx) =>
-                      (shape.status_codes ?? []).map((statusCode) => {
+                    {filteredShapes.flatMap((shape, shapeIdx) => {
+                      // If no status_codes, render a single default row for this response shape
+                      const statusCodesToRender = (shape.status_codes ?? []).length > 0
+                        ? shape.status_codes
+                        : [undefined]; // undefined status code for empty status_codes case
+
+                      return statusCodesToRender.map((statusCode) => {
                         const hasBody = !shape.dynamic && shape.keys && shape.keys.length > 0;
                         const typeDisplay = shape.dynamic
                           ? "Dynamic"
@@ -766,7 +771,7 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
 
                         return (
                           <tr
-                            key={`${shapeIdx}-${statusCode}`}
+                            key={`${shapeIdx}-${statusCode ?? "default"}`}
                             className={cn(
                               "border-b border-border-soft last:border-0",
                               isMuted && "opacity-60",
@@ -786,21 +791,27 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
                               </span>
                             </td>
                             <td className="py-1.5 pr-3 font-mono text-text-3">
-                              <span className={cn(
-                                "text-xs font-mono font-semibold",
-                                statusCodeClass(statusCode),
-                              )}>
-                                {statusCode}
-                              </span>
-                              {typeDisplay !== "—" && (
-                                <span className="ml-2 text-text-3">{typeDisplay}</span>
+                              {statusCode !== undefined ? (
+                                <>
+                                  <span className={cn(
+                                    "text-xs font-mono font-semibold",
+                                    statusCodeClass(statusCode),
+                                  )}>
+                                    {statusCode}
+                                  </span>
+                                  {typeDisplay !== "—" && (
+                                    <span className="ml-2 text-text-3">{typeDisplay}</span>
+                                  )}
+                                </>
+                              ) : (
+                                <span className="text-text-3">{typeDisplay}</span>
                               )}
                             </td>
                             <td className="py-1.5 text-text-3 leading-snug">{description}</td>
                           </tr>
                         );
-                      }),
-                    )}
+                      });
+                    })}
                   </tbody>
                 </table>
               )}


### PR DESCRIPTION
## Summary
Response shapes section header counter showed (1) but zero rows rendered when response entries had empty status_codes arrays. The flatMap would produce 0 rows despite counter showing (1+), creating a contract violation.

## Changes
- When response_shapes entries have empty status_codes[], render a single default row instead of zero rows
- Updated key generation to use `statusCode ?? "default"` to handle undefined status codes
- Modified Type column rendering to gracefully handle undefined status codes (no status badge, just type display)

## Root cause
The `flatMap` + nested `map` pattern over status_codes would return empty array when status_codes was empty, collapsing rows while counter stayed at 1+.

## Verification
- TypeScript: `tsc -b` zero errors
- Build: `vite build` succeeds with no new warnings
- Behavior: Counter (N) now always equals rendered row count

## Test case
On client-fixture-de endpoint `PUT /transfers/confirm/{transferId}` (issue #131): Response shapes (1) → 1 visible row, not zero.

Closes #1960