### PR TITLE
ui(paths): unified columns + repo-only-chip across entity-ref + param/response sections (#1961)

### DIFF
--- a/webui-v2/src/routes/paths.tsx
+++ b/webui-v2/src/routes/paths.tsx
@@ -7,6 +7,14 @@
 
    Data: usePaths, usePathDetail, useOrphans via TanStack Query.
    All network calls go through lib/api.ts (never raw fetch).
+
+   Issue #1961: unified column layout rules:
+     - Entity-ref sections (Defined in / Called by / Downstream / Side effects):
+       all use RefLine with 60%/40% path/name split + repo chip right-anchored.
+       No verb/kind/framework chips on any row — only the repo chip.
+     - Param/response sections (Parameters / Response shapes):
+       both use table-fixed with identical <colgroup> widths:
+       Name 22% | In 12% | Type 28% | Description 38%.
    ============================================================ */
 
 import { useState, useMemo, useCallback, useRef, useEffect } from "react";
@@ -482,39 +490,17 @@ function EntityRow({ entity }: { entity: PathEntity }) {
  *  Issue #1910: Defined-in section collapses from verbose card to one-line ref.
  *  Issue #1934: framework/kind chip removed from RefLine — shown in header strip.
  *  Issue #1957: verb chip dropped from Defined-in rows — verb is already shown
- *               in the panel header. Repo chip is now right-anchored inside RefLine. */
+ *               in the panel header. Repo chip is now right-anchored inside RefLine.
+ *  Issue #1961: auth/docs trailing badges dropped — only repo chip allowed on row.
+ *               Auth is visible in the sticky header chip row above. */
 function HandlerRefLine({ handler }: { handler: HandlerDetail }) {
-  const hasBadges = handler.auth || handler.has_docs;
-  if (!hasBadges) {
-    return (
-      <RefLine
-        repo={handler.repo ?? ""}
-        file={handler.source_file ?? ""}
-        line={handler.start_line ?? 0}
-        name={handler.qualified_name ?? handler.verb}
-      />
-    );
-  }
   return (
-    <div className="flex items-center gap-2 py-1 px-4 hover:bg-surface-2 transition-colors">
-      <RefLine
-        repo={handler.repo ?? ""}
-        file={handler.source_file ?? ""}
-        line={handler.start_line ?? 0}
-        name={handler.qualified_name ?? handler.verb}
-        className="flex-1 px-0 py-0"
-      />
-      <div className="flex items-center gap-1 shrink-0">
-        {handler.auth && (
-          <span className="inline-flex items-center gap-0.5 text-[10px] px-1 py-0.5 rounded bg-success-soft text-success">
-            <Lock size={8} /> auth
-          </span>
-        )}
-        {handler.has_docs && (
-          <span className="text-[10px] text-text-4 italic">docs</span>
-        )}
-      </div>
-    </div>
+    <RefLine
+      repo={handler.repo ?? ""}
+      file={handler.source_file ?? ""}
+      line={handler.start_line ?? 0}
+      name={handler.qualified_name ?? handler.verb}
+    />
   );
 }
 
@@ -692,7 +678,13 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
               {filteredParams.length === 0 ? (
                 <p className="text-xs text-text-4 py-1">None</p>
               ) : (
-                <table className="w-full text-xs">
+                <table className="w-full text-xs table-fixed">
+                  <colgroup>
+                    <col style={{ width: "22%" }} />
+                    <col style={{ width: "12%" }} />
+                    <col style={{ width: "28%" }} />
+                    <col style={{ width: "38%" }} />
+                  </colgroup>
                   <thead>
                     <tr className="border-b border-border">
                       <th className="text-left py-1.5 text-text-4 font-medium pr-3">Name</th>
@@ -739,7 +731,13 @@ function DetailPane({ detail: rawDetail, initialVerb }: { detail: PathDetail; in
               {filteredShapes.length === 0 ? (
                 <p className="text-xs text-text-4 py-1">None</p>
               ) : (
-                <table className="w-full text-xs">
+                <table className="w-full text-xs table-fixed">
+                  <colgroup>
+                    <col style={{ width: "22%" }} />
+                    <col style={{ width: "12%" }} />
+                    <col style={{ width: "28%" }} />
+                    <col style={{ width: "38%" }} />
+                  </colgroup>
                   <thead>
                     <tr className="border-b border-border">
                       <th className="text-left py-1.5 text-text-4 font-medium pr-3">Name</th>


### PR DESCRIPTION
## What

Closes #1961

Enforces the two column-consistency rules across all endpoint detail pane sections.

## Changes

### 1 — Entity-ref sections: repo chip only (rule 1)

`HandlerRefLine` (Defined-in) previously rendered a second wrapper div with auth-lock and "docs" text badges alongside `RefLine` when `handler.auth || handler.has_docs`. Per #1961 rule 1 ("only chip allowed on any row is the repo chip"), those trailing badges are dropped. Auth information is already visible in the sticky header chip strip above the scrollable sections (`Auth · Bearer`), so no information is lost.

All four entity-ref sections now use `RefLine` exclusively:

| Section | Component | Widths |
|---|---|---|
| Defined in | `HandlerRefLine` → `RefLine` | 60% path / 40% name / repo chip |
| Called by | `EntityRow` → `RefLine` | same |
| Downstream | `EntityRow` → `RefLine` | same |
| Side effects | `EntityRow` → `RefLine` | same |

### 2 — Param/response sections: identical column widths (rule 3)

Both tables were already `Name | In | Type | Description` but used browser-natural widths (content-driven), so columns misaligned when scanning vertically across sections. Added `table-fixed` + identical `<colgroup>` to both:

```
Name 22% | In 12% | Type 28% | Description 38%
```

Applied identically to Parameters (section 2) and Response shapes (section 3).

## Verification

- `tsc -b`: zero errors
- `vite build`: zero errors, clean bundle
- On client-fixture-de PUT /transfers/confirm:
  - Defined-in row and Called-by row use identical 60/40 RefLine widths, repo chip only on right (no auth badge, no PUT chip)
  - Parameters table and Response shapes table have identical column widths

## Composes with

- #1957 — RefLine 60/40 split + repo chip (landed)
- #1958 — Response shapes as Name/In/Type/Description table (landed)

## No daemon restart needed

Frontend-only change. No Go code modified. No `go install` / `launchctl kickstart` / dist copies.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)