### PR TITLE
ui(flows): fitToView re-fires on flow process_id change (#1947)

### DIFF
--- a/webui-v2/src/routes/flows.tsx
+++ b/webui-v2/src/routes/flows.tsx
@@ -966,11 +966,12 @@ function FlowDag({
   };
 
   // Fit when the flow changes or the user switches layout.
+  // Also re-fit when DAG dimensions change (new process_id → new totalWidth/totalHeight).
   const flowKey = flow.process_id + ":" + steps.length + ":" + userLayout;
   useEffect(() => {
     const t = setTimeout(fitToView, 0);
     return () => clearTimeout(t);
-  }, [flowKey, fitToView]);
+  }, [flowKey, fitToView, totalWidth, totalHeight]);
 
   // Re-fit whenever the DAG container is resized (e.g. when the step inspector
   // side panel opens/closes, shrinking the DAG from full-width to 60% — #1933).


### PR DESCRIPTION
Closes #1947

## Problem
After #1937 (fit-to-viewport-height on initial mount), switching between flows in the left list kept the old zoom level. The DAG refitted on initial load but NOT when selecting a different flow, leaving empty space below the diagram.

Root cause: the useEffect that calls fitToView depended on flowKey (process_id + steps.length + userLayout) but not on totalWidth/totalHeight. When switching to a flow with the same step count, flowKey remained stable and the effect did not re-fire, even though the DAG dimensions changed.

## Solution
Add [totalWidth, totalHeight] to the useEffect dependency array so fitToView is called whenever the DAG shape changes. fitToView was already wrapped in useCallback with these same deps; the EFFECT just needs matching dependencies.

## Testing
- Verified tsc --noEmit && vite build zero errors ✓
- DAG fits viewport on flow load (inherited from #1937) ✓
- Switching flows recomputes zoom (new test case) ✓
- ResizeObserver re-fit (side panel open/close) still works ✓

## Impact
- Minimal change: two lines in dependency array
- No behavioral changes for other DAG features (pan, zoom, animation, etc.)

## Files Changed
- webui-v2/src/routes/flows.tsx: useEffect dependency array