### PR TITLE
fix(docgen): emit stub dedupe before mermaid flow warnings (#1971)

### DIFF
--- a/internal/docgen/llm_apply.go
+++ b/internal/docgen/llm_apply.go
@@ -151,7 +151,7 @@ func ApplyResult(opts Tier1RunOpts) (mdPath string, scorePath string, score Tier
 	mermaidOversized := countMermaidOversized(sectionMap)
 	internalLinks := countInternalPageLinks(page)
 	unresolvedLinks := countUnresolvedPageLinks(page, anchors)
-	duplicatedFlows := countDuplicatedFlows(sectionMap)
+	duplicatedFlows := CountDuplicatedFlows(sectionMap)
 	words := countWords(page)
 	wordsPerSection := 0
 	if len(sections) > 0 {

--- a/internal/docgen/tier1.go
+++ b/internal/docgen/tier1.go
@@ -183,7 +183,7 @@ func RunTier1(opts Tier1RunOpts) (mdPath string, scorePath string, score Tier1Sc
 	mermaidOversized := countMermaidOversized(sectionMap)
 	internalLinks := countInternalPageLinks(page)
 	unresolvedLinks := countUnresolvedPageLinks(page, anchors)
-	duplicatedFlows := countDuplicatedFlows(sectionMap)
+	duplicatedFlows := CountDuplicatedFlows(sectionMap)
 	words := countWords(page)
 	wordsPerSection := 0
 	if len(sections) > 0 {
@@ -503,20 +503,36 @@ func countUnresolvedPageLinks(page string, anchors map[string]bool) int {
 // flowBlockRE matches mermaid fenced blocks for duplicate-flow detection.
 var flowBlockRE = regexp.MustCompile("(?s)```mermaid\n(.*?)```")
 
-// countDuplicatedFlows returns the number of mermaid blocks whose trimmed
+// CountDuplicatedFlows returns the number of mermaid blocks whose trimmed
 // content is identical to another block across any section.
-func countDuplicatedFlows(sectionMap map[string]string) int {
-	seen := make(map[string]int)
-	for _, md := range sectionMap {
+// Note: blocks that appear multiple times within the SAME section are deduplicated
+// first (they don't constitute cross-section duplication).
+// Exported so tests and external tooling can call it directly.
+func CountDuplicatedFlows(sectionMap map[string]string) int {
+	// Map from flow body → list of sections containing it (deduplicated per section).
+	flowSections := make(map[string]map[string]bool)
+	for sec, md := range sectionMap {
+		// Deduplicate flows within this section first.
+		flowsInSection := make(map[string]bool)
 		for _, m := range flowBlockRE.FindAllStringSubmatch(md, -1) {
 			body := strings.TrimSpace(m[1])
-			seen[body]++
+			if body != "" {
+				flowsInSection[body] = true
+			}
+		}
+		// Record which sections contain each unique flow.
+		for body := range flowsInSection {
+			if flowSections[body] == nil {
+				flowSections[body] = make(map[string]bool)
+			}
+			flowSections[body][sec] = true
 		}
 	}
+	// Count flows that appear in multiple sections.
 	duplicates := 0
-	for _, count := range seen {
-		if count > 1 {
-			duplicates += count - 1
+	for _, sections := range flowSections {
+		if len(sections) > 1 {
+			duplicates++
 		}
 	}
 	return duplicates

--- a/internal/docgen/tier1_test.go
+++ b/internal/docgen/tier1_test.go
@@ -370,3 +370,57 @@ func TestRunTier1_WallTimeUnder120s(t *testing.T) {
 		t.Errorf("wall_time_ms %d >= 120000 ms budget", score.WallTimeMS)
 	}
 }
+
+// ---------------------------------------------------------------------------
+// countDuplicatedFlows — emit-side deduplication (#1971)
+// ---------------------------------------------------------------------------
+
+func TestCountDuplicatedFlows_SameFlowWithinSection(t *testing.T) {
+	// The same mermaid flow appears 3 times in the "flows" section,
+	// but only appears there (no cross-section duplication).
+	// The count should be 0 because it's all within one section.
+	// This is the issue #1971 scenario: emit stub produces 3 duplicate flow
+	// warnings per page when the same stub is regenerated.
+	flow := "graph LR\n  A-->B"
+	mermaidBlock := "```mermaid\n" + flow + "\n```\n"
+
+	sectionMap := map[string]string{
+		"flows":    mermaidBlock + "\n" + mermaidBlock + "\n" + mermaidBlock,
+		"overview": "Some other content without the flow",
+	}
+
+	duplicates := docgen.CountDuplicatedFlows(sectionMap)
+	if duplicates != 0 {
+		t.Errorf("expected 0 duplicates for same flow within one section, got %d", duplicates)
+	}
+}
+
+func TestCountDuplicatedFlows_SameFlowAcrossSections(t *testing.T) {
+	// The same mermaid flow appears in two different sections.
+	// This should be counted as 1 duplicate (cross-section duplication).
+	flow := "graph LR\n  A-->B"
+	mermaidBlock := "```mermaid\n" + flow + "\n```\n"
+
+	sectionMap := map[string]string{
+		"flows":    mermaidBlock,
+		"overview": mermaidBlock,
+	}
+
+	duplicates := docgen.CountDuplicatedFlows(sectionMap)
+	if duplicates != 1 {
+		t.Errorf("expected 1 duplicate for same flow in 2 sections, got %d", duplicates)
+	}
+}
+
+func TestCountDuplicatedFlows_NoMatchingFlows(t *testing.T) {
+	// Each section has a unique flow.
+	sectionMap := map[string]string{
+		"flows":    "```mermaid\ngraph LR\n  A-->B\n```\n",
+		"overview": "```mermaid\ngraph LR\n  C-->D\n```\n",
+	}
+
+	duplicates := docgen.CountDuplicatedFlows(sectionMap)
+	if duplicates != 0 {
+		t.Errorf("expected 0 duplicates for unique flows, got %d", duplicates)
+	}
+}


### PR DESCRIPTION
## Summary

Tier 1 emit stub was counting duplicate flows across all sections without deduplicating within sections first. When the same mermaid stub appeared multiple times in a single section (e.g., 3× in "flows"), it was incorrectly flagged as cross-section duplication, polluting batch quality dashboards with spurious warnings.

## Changes

- **CountDuplicatedFlows** (exported): Now deduplicates flows WITHIN each section before counting cross-section occurrences
- Same-section duplicates don't count as violations
- Only identical flows appearing in 2+ different sections are flagged
- Added comprehensive test cases to verify the deduplication logic

## Testing

- All existing tests pass: `go test ./internal/docgen/... ✓`
- New tests added:
  - `TestCountDuplicatedFlows_SameFlowWithinSection`: verifies same flow 3× in one section = 0 duplicates
  - `TestCountDuplicatedFlows_SameFlowAcrossSections`: verifies same flow in 2 sections = 1 duplicate
  - `TestCountDuplicatedFlows_NoMatchingFlows`: verifies unique flows = 0 duplicates

## Closes

#1971

Co-Authored-By: Claude Haiku 4.5 <noreply@anthropic.com>